### PR TITLE
Add `QualifiedName` usage to Function/Type/Window expression, and add hash / equality

### DIFF
--- a/.github/patches/extensions/fts/0002-qualified-name-accessors.patch
+++ b/.github/patches/extensions/fts/0002-qualified-name-accessors.patch
@@ -1,0 +1,89 @@
+diff --git a/extension/fts/fts_indexing.cpp b/extension/fts/fts_indexing.cpp
+index a63ed4e..061864b 100644
+--- a/extension/fts/fts_indexing.cpp
++++ b/extension/fts/fts_indexing.cpp
+@@ -12,15 +12,15 @@ namespace duckdb {
+ 
+ static QualifiedName GetQualifiedName(ClientContext &context, const string &qname_str) {
+ 	auto qname = QualifiedName::Parse(qname_str);
+-	if (qname.schema == INVALID_SCHEMA) {
+-		qname.schema = Identifier(ClientData::Get(context).catalog_search_path->GetDefaultSchema(qname.catalog));
++	if (qname.Schema() == INVALID_SCHEMA) {
++		qname.SchemaMutable() = Identifier(ClientData::Get(context).catalog_search_path->GetDefaultSchema(qname.Catalog()));
+ 	}
+ 	return qname;
+ }
+ 
+ static string GetFTSSchema(QualifiedName &qname) {
+-	auto result = qname.catalog == INVALID_CATALOG ? "" : StringUtil::Format("%s.", qname.catalog.GetIdentifierName());
+-	result += StringUtil::Format("fts_%s_%s", qname.schema.GetIdentifierName(), qname.name.GetIdentifierName());
++	auto result = qname.Catalog() == INVALID_CATALOG ? "" : StringUtil::Format("%s.", qname.Catalog().GetIdentifierName());
++	result += StringUtil::Format("fts_%s_%s", qname.Schema().GetIdentifierName(), qname.Name().GetIdentifierName());
+ 	return result;
+ }
+ 
+@@ -28,10 +28,10 @@ string FTSIndexing::DropFTSIndexQuery(ClientContext &context, const FunctionPara
+ 	auto qname = GetQualifiedName(context, StringValue::Get(parameters.values[0]));
+ 	string fts_schema = GetFTSSchema(qname);
+ 
+-	if (!Catalog::GetSchema(context, qname.catalog, Identifier(fts_schema), OnEntryNotFound::RETURN_NULL)) {
++	if (!Catalog::GetSchema(context, qname.Catalog(), Identifier(fts_schema), OnEntryNotFound::RETURN_NULL)) {
+ 		throw CatalogException(
+ 		    "a FTS index does not exist on table '%s.%s'. Create one with 'PRAGMA create_fts_index()'.",
+-		    qname.schema.GetIdentifierName(), qname.name.GetIdentifierName());
++		    qname.Schema().GetIdentifierName(), qname.Name().GetIdentifierName());
+ 	}
+ 
+ 	return StringUtil::Format("DROP SCHEMA %s CASCADE;", fts_schema);
+@@ -232,8 +232,9 @@ static string IndexingScript(ClientContext &context, QualifiedName &qname, const
+ 	result = StringUtil::Replace(result, "%union_fields_query%", StringUtil::Join(tokenize_fields, " UNION ALL "));
+ 
+ 	string fts_schema = GetFTSSchema(qname);
+-	string input_table = qname.catalog == INVALID_CATALOG ? "" : StringUtil::Format("%s.", qname.catalog.GetIdentifierName());
+-	input_table += StringUtil::Format("%s.%s", qname.schema.GetIdentifierName(), qname.name.GetIdentifierName());
++	string input_table =
++	    qname.Catalog() == INVALID_CATALOG ? "" : StringUtil::Format("%s.", qname.Catalog().GetIdentifierName());
++	input_table += StringUtil::Format("%s.%s", qname.Schema().GetIdentifierName(), qname.Name().GetIdentifierName());
+ 
+ 	// fill in variables (inefficiently, but keeps SQL script readable)
+ 	result = StringUtil::Replace(result, "%fts_schema%", fts_schema);
+@@ -245,7 +246,7 @@ static string IndexingScript(ClientContext &context, QualifiedName &qname, const
+ }
+ 
+ static void CheckIfTableExists(ClientContext &context, QualifiedName &qname) {
+-	Catalog::GetEntry<TableCatalogEntry>(context, qname.catalog, qname.schema, qname.name);
++	Catalog::GetEntry<TableCatalogEntry>(context, qname.Catalog(), qname.Schema(), qname.Name());
+ }
+ 
+ string FTSIndexing::CreateFTSIndexQuery(ClientContext &context, const FunctionParameters &parameters) {
+@@ -295,16 +296,16 @@ string FTSIndexing::CreateFTSIndexQuery(ClientContext &context, const FunctionPa
+ 
+ 	// throw error if an index already exists on this table
+ 	const string fts_schema = GetFTSSchema(qname);
+-	if (Catalog::GetSchema(context, qname.catalog, Identifier(fts_schema), OnEntryNotFound::RETURN_NULL) && !overwrite) {
++	if (Catalog::GetSchema(context, qname.Catalog(), Identifier(fts_schema), OnEntryNotFound::RETURN_NULL) && !overwrite) {
+ 		throw CatalogException("a FTS index already exists on table '%s.%s'. Supply 'overwrite=1' to overwrite, or "
+ 		                       "drop the existing index with 'PRAGMA drop_fts_index()' before creating a new one.",
+-		                       qname.schema.GetIdentifierName(), qname.name.GetIdentifierName());
++		                       qname.Schema().GetIdentifierName(), qname.Name().GetIdentifierName());
+ 	}
+ 
+ 	// positional parameters
+ 	auto doc_id = StringValue::Get(parameters.values[1]);
+ 	// check all specified columns
+-	auto &table = Catalog::GetEntry<TableCatalogEntry>(context, qname.catalog, qname.schema, qname.name);
++	auto &table = Catalog::GetEntry<TableCatalogEntry>(context, qname.Catalog(), qname.Schema(), qname.Name());
+ 	vector<string> doc_values;
+ 	for (idx_t i = 2; i < parameters.values.size(); i++) {
+ 		string col_name = StringValue::Get(parameters.values[i]);
+@@ -320,8 +321,8 @@ string FTSIndexing::CreateFTSIndexQuery(ClientContext &context, const FunctionPa
+ 		}
+ 		if (!table.ColumnExists(Identifier(col_name))) {
+ 			// we check this here because else we we end up with an error halfway the indexing script
+-			throw CatalogException("Table '%s.%s' does not have a column named '%s'!", qname.schema.GetIdentifierName(),
+-			                       qname.name.GetIdentifierName(),
++			throw CatalogException("Table '%s.%s' does not have a column named '%s'!", qname.Schema().GetIdentifierName(),
++			                       qname.Name().GetIdentifierName(),
+ 			                       col_name);
+ 		}
+ 		doc_values.push_back(col_name);

--- a/.github/patches/extensions/spatial/0021-qualified-name-accessors.patch
+++ b/.github/patches/extensions/spatial/0021-qualified-name-accessors.patch
@@ -1,0 +1,18 @@
+diff --git a/src/spatial/index/rtree/rtree_index_pragmas.cpp b/src/spatial/index/rtree/rtree_index_pragmas.cpp
+index d21bec8..24f99b7 100644
+--- a/src/spatial/index/rtree/rtree_index_pragmas.cpp
++++ b/src/spatial/index/rtree/rtree_index_pragmas.cpp
+@@ -110,10 +110,10 @@ static optional_ptr<RTreeIndex> TryGetIndex(ClientContext &context, const string
+ 	auto qname = QualifiedName::Parse(index_name);
+ 
+ 	// look up the index name in the catalog
+-	Binder::BindSchemaOrCatalog(context, qname.catalog, qname.schema);
+-	auto &index_entry = Catalog::GetEntry(context, CatalogType::INDEX_ENTRY, qname.catalog, qname.schema, qname.name)
++	Binder::BindSchemaOrCatalog(context, qname.CatalogMutable(), qname.SchemaMutable());
++	auto &index_entry = Catalog::GetEntry(context, CatalogType::INDEX_ENTRY, qname.Catalog(), qname.Schema(), qname.Name())
+ 	                        .Cast<IndexCatalogEntry>();
+-	auto &table_entry = Catalog::GetEntry(context, CatalogType::TABLE_ENTRY, qname.catalog,
++	auto &table_entry = Catalog::GetEntry(context, CatalogType::TABLE_ENTRY, qname.Catalog(),
+ 	                                      index_entry.GetSchemaName(),
+ 	                                      index_entry.GetTableName())
+ 	                        .Cast<TableCatalogEntry>();

--- a/.github/patches/extensions/unity_catalog/0004-qualified-name-accessors.patch
+++ b/.github/patches/extensions/unity_catalog/0004-qualified-name-accessors.patch
@@ -1,0 +1,19 @@
+diff --git a/src/functions/uc_checkpoint.cpp b/src/functions/uc_checkpoint.cpp
+index 88ae3e7..7fbc218 100644
+--- a/src/functions/uc_checkpoint.cpp
++++ b/src/functions/uc_checkpoint.cpp
+@@ -28,9 +28,11 @@ static CheckpointTableBindData ResolveTableName(ClientContext &context, const st
+ 	auto &search_path = ClientData::Get(context).catalog_search_path->GetDefault();
+ 
+ 	CheckpointTableBindData result;
+-	result.catalog_name = qname.catalog.empty() ? search_path.catalog.GetIdentifierName() : qname.catalog.GetIdentifierName();
+-	result.schema_name = qname.schema.empty() ? search_path.schema.GetIdentifierName() : qname.schema.GetIdentifierName();
+-	result.table_name = qname.name.GetIdentifierName();
++	result.catalog_name =
++	    qname.Catalog().empty() ? search_path.catalog.GetIdentifierName() : qname.Catalog().GetIdentifierName();
++	result.schema_name =
++	    qname.Schema().empty() ? search_path.schema.GetIdentifierName() : qname.Schema().GetIdentifierName();
++	result.table_name = qname.Name().GetIdentifierName();
+ 
+ 	if (result.catalog_name.empty()) {
+ 		throw InvalidInputException(

--- a/.github/patches/extensions/vss/0006-qualified-name-accessors.patch
+++ b/.github/patches/extensions/vss/0006-qualified-name-accessors.patch
@@ -1,0 +1,18 @@
+diff --git a/src/hnsw/hnsw_index_pragmas.cpp b/src/hnsw/hnsw_index_pragmas.cpp
+index 166ef68..eb6ca01 100644
+--- a/src/hnsw/hnsw_index_pragmas.cpp
++++ b/src/hnsw/hnsw_index_pragmas.cpp
+@@ -188,10 +188,10 @@ static void CompactIndexPragma(ClientContext &context, const FunctionParameters
+ 	auto qname = QualifiedName::Parse(index_name);
+ 
+ 	// look up the index name in the catalog
+-	Binder::BindSchemaOrCatalog(context, qname.catalog, qname.schema);
+-	auto &index_entry = Catalog::GetEntry(context, CatalogType::INDEX_ENTRY, qname.catalog, qname.schema, qname.name)
++	Binder::BindSchemaOrCatalog(context, qname.CatalogMutable(), qname.SchemaMutable());
++	auto &index_entry = Catalog::GetEntry(context, CatalogType::INDEX_ENTRY, qname.Catalog(), qname.Schema(), qname.Name())
+ 	                        .Cast<IndexCatalogEntry>();
+-	auto &table_entry = Catalog::GetEntry(context, CatalogType::TABLE_ENTRY, qname.catalog,
++	auto &table_entry = Catalog::GetEntry(context, CatalogType::TABLE_ENTRY, qname.Catalog(),
+ 	                                      index_entry.GetSchemaName(),
+ 	                                      index_entry.GetTableName())
+ 	                        .Cast<TableCatalogEntry>();

--- a/extension/core_functions/scalar/generic/type_functions.cpp
+++ b/extension/core_functions/scalar/generic/type_functions.cpp
@@ -111,8 +111,8 @@ static unique_ptr<Expression> BindMakeTypeFunctionExpression(FunctionBindExpress
 	auto type_name = args.front().second.GetValue<string>();
 	auto qualified_name = QualifiedName::Parse(type_name);
 
-	auto unbound_type = LogicalType::UNBOUND(make_uniq<TypeExpression>(qualified_name.catalog, qualified_name.schema,
-	                                                                   qualified_name.name, std::move(type_args)));
+	auto unbound_type = LogicalType::UNBOUND(make_uniq<TypeExpression>(
+	    qualified_name.Catalog(), qualified_name.Schema(), qualified_name.Name(), std::move(type_args)));
 
 	// Bind the unbound type
 	auto binder = Binder::CreateBinder(input.context);

--- a/scripts/generate_serialization.py
+++ b/scripts/generate_serialization.py
@@ -320,6 +320,8 @@ supported_member_entries = [
     # equality/hash generation annotations (used by generate_util.py)
     'equals_skip',
     'hash_skip',
+    # skip (de)serialization entirely (member only exists for equals/hash/copy generation)
+    'serialize_skip',
     # accessor annotations (used by generate_util.py for Children/ChildrenMutable generation)
     'accessor_mut',
     'accessor',
@@ -360,7 +362,8 @@ def normalize_json_type(type_str):
 
 class MemberVariable:
     def __init__(self, entry):
-        self.id = entry['id']
+        # serialize_skip members are not (de)serialized, so they need no field id
+        self.id = entry.get('id', -1)
         self.name = entry['name']
         self.type = normalize_json_type(entry['type'])
         self.base = None
@@ -398,6 +401,9 @@ class MemberVariable:
             self.has_default = True
         if 'base' in entry:
             self.base = entry['base']
+        # Members marked serialize_skip are not (de)serialized; they only exist for the
+        # equals/hash/copy generation (e.g. an aggregate field serialized as its components).
+        self.serialize_skip = entry.get('serialize_skip', False)
         for key in entry.keys():
             if key not in supported_member_entries:
                 print(
@@ -802,12 +808,16 @@ def generate_class_code(class_entry: SerializableClass):
         class_serialize += BASE_SERIALIZE_FORMAT.format(base_class_name=class_entry.base)
     for entry_idx in range(last_constructor_index + 1):
         entry = class_entry.members[entry_idx]
+        if entry.serialize_skip:
+            continue
         class_deserialize += class_entry.get_deserialize_element(entry, base=entry.base, pointer_type='unique_ptr')
 
     class_deserialize += class_entry.generate_constructor(constructor_parameters)
     if class_entry.members is None:
         return None
     for entry_idx, entry in enumerate(class_entry.members):
+        if entry.serialize_skip:
+            continue
         write_property_name = entry.serialize_property
         deserialize_template_str = DESERIALIZE_ELEMENT_CLASS_FORMAT
         if entry.base:

--- a/scripts/generate_util.py
+++ b/scripts/generate_util.py
@@ -437,6 +437,8 @@ def generate_member_hash(member, indent='\t'):
         return [f'{indent}hash = CombineHash(hash, {field_name}.Hash());']
     if type_str == 'LogicalType':
         return [f'{indent}hash = CombineHash(hash, {field_name}.Hash());']
+    if type_str == 'QualifiedName':
+        return [f'{indent}hash = CombineHash(hash, {field_name}.Hash());']
     if type_str == 'bool':
         return [f'{indent}hash = CombineHash(hash, duckdb::Hash<bool>({field_name}));']
     if type_str == 'idx_t':

--- a/src/common/util/util_parsed_expression.cpp
+++ b/src/common/util/util_parsed_expression.cpp
@@ -581,10 +581,7 @@ bool FunctionExpression::Equals(const ParsedExpression &other) const {
 		return false;
 	}
 	auto &other_p = other.Cast<FunctionExpression>();
-	if (function_name != other_p.function_name) {
-		return false;
-	}
-	if (schema != other_p.schema) {
+	if (qualified_name != other_p.qualified_name) {
 		return false;
 	}
 	if (!ParsedExpression::Equals(filter, other_p.filter)) {
@@ -597,9 +594,6 @@ bool FunctionExpression::Equals(const ParsedExpression &other) const {
 		return false;
 	}
 	if (export_state != other_p.export_state) {
-		return false;
-	}
-	if (catalog != other_p.catalog) {
 		return false;
 	}
 	if (arguments.size() != other_p.arguments.size()) {
@@ -615,25 +609,21 @@ bool FunctionExpression::Equals(const ParsedExpression &other) const {
 
 hash_t FunctionExpression::Hash() const {
 	hash_t hash = ParsedExpression::Hash();
-	hash = CombineHash(hash, function_name.Hash());
-	hash = CombineHash(hash, schema.Hash());
+	hash = CombineHash(hash, qualified_name.Hash());
 	hash = CombineHash(hash, duckdb::Hash<bool>(distinct));
 	hash = CombineHash(hash, duckdb::Hash<bool>(export_state));
-	hash = CombineHash(hash, catalog.Hash());
 	return hash;
 }
 
 unique_ptr<ParsedExpression> FunctionExpression::Copy() const {
 	auto copy = duckdb::unique_ptr<FunctionExpression>(new FunctionExpression());
 	copy->is_legacy_function_call = is_legacy_function_call;
-	copy->function_name = function_name;
-	copy->schema = schema;
+	copy->qualified_name = qualified_name;
 	copy->filter = filter ? filter->Copy() : nullptr;
 	copy->order_bys = order_bys ? unique_ptr_cast<ResultModifier, OrderModifier>(order_bys->Copy()) : nullptr;
 	copy->distinct = distinct;
 	copy->is_operator = is_operator;
 	copy->export_state = export_state;
-	copy->catalog = catalog;
 	for (auto &arg : arguments) {
 		copy->arguments.emplace_back(arg.Copy());
 	}
@@ -832,13 +822,7 @@ bool WindowExpression::Equals(const ParsedExpression &other) const {
 		return false;
 	}
 	auto &other_p = other.Cast<WindowExpression>();
-	if (function_name != other_p.function_name) {
-		return false;
-	}
-	if (schema != other_p.schema) {
-		return false;
-	}
-	if (catalog != other_p.catalog) {
+	if (qualified_name != other_p.qualified_name) {
 		return false;
 	}
 	if (!ParsedExpression::ListEquals(partitions, other_p.partitions)) {
@@ -912,9 +896,7 @@ bool WindowExpression::Equals(const ParsedExpression &other) const {
 
 hash_t WindowExpression::Hash() const {
 	hash_t hash = ParsedExpression::Hash();
-	hash = CombineHash(hash, function_name.Hash());
-	hash = CombineHash(hash, schema.Hash());
-	hash = CombineHash(hash, catalog.Hash());
+	hash = CombineHash(hash, qualified_name.Hash());
 	for (idx_t i = 0; i < orders.size(); i++) {
 		hash = CombineHash(hash, duckdb::Hash<uint32_t>(static_cast<uint32_t>(orders[i].type)));
 		hash = CombineHash(hash, duckdb::Hash<uint32_t>(static_cast<uint32_t>(orders[i].null_order)));
@@ -935,9 +917,7 @@ hash_t WindowExpression::Hash() const {
 unique_ptr<ParsedExpression> WindowExpression::Copy() const {
 	auto copy = duckdb::unique_ptr<WindowExpression>(new WindowExpression());
 	copy->is_legacy_function_call = is_legacy_function_call;
-	copy->function_name = function_name;
-	copy->schema = schema;
-	copy->catalog = catalog;
+	copy->qualified_name = qualified_name;
 	for (auto &child : partitions) {
 		copy->partitions.push_back(child->Copy());
 	}
@@ -968,13 +948,7 @@ bool TypeExpression::Equals(const ParsedExpression &other) const {
 		return false;
 	}
 	auto &other_p = other.Cast<TypeExpression>();
-	if (catalog != other_p.catalog) {
-		return false;
-	}
-	if (schema != other_p.schema) {
-		return false;
-	}
-	if (type_name != other_p.type_name) {
+	if (qualified_name != other_p.qualified_name) {
 		return false;
 	}
 	if (!ParsedExpression::ListEquals(children, other_p.children)) {
@@ -985,17 +959,13 @@ bool TypeExpression::Equals(const ParsedExpression &other) const {
 
 hash_t TypeExpression::Hash() const {
 	hash_t hash = ParsedExpression::Hash();
-	hash = CombineHash(hash, catalog.Hash());
-	hash = CombineHash(hash, schema.Hash());
-	hash = CombineHash(hash, type_name.Hash());
+	hash = CombineHash(hash, qualified_name.Hash());
 	return hash;
 }
 
 unique_ptr<ParsedExpression> TypeExpression::Copy() const {
 	auto copy = duckdb::unique_ptr<TypeExpression>(new TypeExpression());
-	copy->catalog = catalog;
-	copy->schema = schema;
-	copy->type_name = type_name;
+	copy->qualified_name = qualified_name;
 	for (auto &child : children) {
 		copy->children.push_back(child->Copy());
 	}

--- a/src/function/scalar/sequence/nextval.cpp
+++ b/src/function/scalar/sequence/nextval.cpp
@@ -46,7 +46,7 @@ SequenceCatalogEntry &BindSequenceFromContext(ClientContext &context, Identifier
 
 SequenceCatalogEntry &BindSequence(Binder &binder, const Identifier &name) {
 	auto qname = QualifiedName::Parse(name.GetIdentifierName());
-	return BindSequence(binder, qname.catalog, qname.schema, qname.name);
+	return BindSequence(binder, qname.Catalog(), qname.Schema(), qname.Name());
 }
 
 struct NextValLocalState : public FunctionLocalState {

--- a/src/function/scalar/sequence/nextval.cpp
+++ b/src/function/scalar/sequence/nextval.cpp
@@ -46,7 +46,7 @@ SequenceCatalogEntry &BindSequenceFromContext(ClientContext &context, Identifier
 
 SequenceCatalogEntry &BindSequence(Binder &binder, const Identifier &name) {
 	auto qname = QualifiedName::Parse(name.GetIdentifierName());
-	return BindSequence(binder, qname.Catalog(), qname.Schema(), qname.Name());
+	return BindSequence(binder, qname.CatalogMutable(), qname.SchemaMutable(), qname.NameMutable());
 }
 
 struct NextValLocalState : public FunctionLocalState {

--- a/src/function/table/system/pragma_storage_info.cpp
+++ b/src/function/table/system/pragma_storage_info.cpp
@@ -111,7 +111,7 @@ static unique_ptr<FunctionData> PragmaStorageInfoBind(ClientContext &context, Ta
 	auto qname = QualifiedName::Parse(input.inputs[0].GetValue<string>());
 
 	// look up the table name in the catalog
-	Binder::BindSchemaOrCatalog(context, qname.Catalog(), qname.Schema());
+	Binder::BindSchemaOrCatalog(context, qname.CatalogMutable(), qname.SchemaMutable());
 	auto &table_entry = Catalog::GetEntry<TableCatalogEntry>(context, qname.Catalog(), qname.Schema(), qname.Name());
 	return make_uniq<PragmaStorageFunctionData>(table_entry, options);
 }

--- a/src/function/table/system/pragma_storage_info.cpp
+++ b/src/function/table/system/pragma_storage_info.cpp
@@ -111,8 +111,8 @@ static unique_ptr<FunctionData> PragmaStorageInfoBind(ClientContext &context, Ta
 	auto qname = QualifiedName::Parse(input.inputs[0].GetValue<string>());
 
 	// look up the table name in the catalog
-	Binder::BindSchemaOrCatalog(context, qname.catalog, qname.schema);
-	auto &table_entry = Catalog::GetEntry<TableCatalogEntry>(context, qname.catalog, qname.schema, qname.name);
+	Binder::BindSchemaOrCatalog(context, qname.Catalog(), qname.Schema());
+	auto &table_entry = Catalog::GetEntry<TableCatalogEntry>(context, qname.Catalog(), qname.Schema(), qname.Name());
 	return make_uniq<PragmaStorageFunctionData>(table_entry, options);
 }
 

--- a/src/function/table/system/pragma_table_info.cpp
+++ b/src/function/table/system/pragma_table_info.cpp
@@ -170,8 +170,8 @@ static unique_ptr<FunctionData> PragmaTableInfoBind(ClientContext &context, Tabl
 	auto qname = QualifiedName::Parse(input.inputs[0].GetValue<string>());
 
 	// look up the table name in the catalog
-	Binder::BindSchemaOrCatalog(context, qname.catalog, qname.schema);
-	auto &entry = Catalog::GetEntry(context, CatalogType::TABLE_ENTRY, qname.catalog, qname.schema, qname.name);
+	Binder::BindSchemaOrCatalog(context, qname.Catalog(), qname.Schema());
+	auto &entry = Catalog::GetEntry(context, CatalogType::TABLE_ENTRY, qname.Catalog(), qname.Schema(), qname.Name());
 	return make_uniq<PragmaTableFunctionData>(entry, IS_PRAGMA_TABLE_INFO);
 }
 

--- a/src/function/table/system/pragma_table_info.cpp
+++ b/src/function/table/system/pragma_table_info.cpp
@@ -170,7 +170,7 @@ static unique_ptr<FunctionData> PragmaTableInfoBind(ClientContext &context, Tabl
 	auto qname = QualifiedName::Parse(input.inputs[0].GetValue<string>());
 
 	// look up the table name in the catalog
-	Binder::BindSchemaOrCatalog(context, qname.Catalog(), qname.Schema());
+	Binder::BindSchemaOrCatalog(context, qname.CatalogMutable(), qname.SchemaMutable());
 	auto &entry = Catalog::GetEntry(context, CatalogType::TABLE_ENTRY, qname.Catalog(), qname.Schema(), qname.Name());
 	return make_uniq<PragmaTableFunctionData>(entry, IS_PRAGMA_TABLE_INFO);
 }

--- a/src/function/table/system/pragma_table_sample.cpp
+++ b/src/function/table/system/pragma_table_sample.cpp
@@ -34,9 +34,9 @@ static unique_ptr<FunctionData> DuckDBTableSampleBind(ClientContext &context, Ta
                                                       vector<LogicalType> &return_types, vector<string> &names) {
 	// look up the table name in the catalog
 	auto qname = QualifiedName::Parse(input.inputs[0].GetValue<string>());
-	Binder::BindSchemaOrCatalog(context, qname.catalog, qname.schema);
+	Binder::BindSchemaOrCatalog(context, qname.Catalog(), qname.Schema());
 
-	auto &entry = Catalog::GetEntry<TableCatalogEntry>(context, qname.catalog, qname.schema, qname.name);
+	auto &entry = Catalog::GetEntry<TableCatalogEntry>(context, qname.Catalog(), qname.Schema(), qname.Name());
 	if (entry.type != CatalogType::TABLE_ENTRY) {
 		throw NotImplementedException("Invalid Catalog type passed to table_sample()");
 	}

--- a/src/function/table/system/pragma_table_sample.cpp
+++ b/src/function/table/system/pragma_table_sample.cpp
@@ -34,7 +34,7 @@ static unique_ptr<FunctionData> DuckDBTableSampleBind(ClientContext &context, Ta
                                                       vector<LogicalType> &return_types, vector<string> &names) {
 	// look up the table name in the catalog
 	auto qname = QualifiedName::Parse(input.inputs[0].GetValue<string>());
-	Binder::BindSchemaOrCatalog(context, qname.Catalog(), qname.Schema());
+	Binder::BindSchemaOrCatalog(context, qname.CatalogMutable(), qname.SchemaMutable());
 
 	auto &entry = Catalog::GetEntry<TableCatalogEntry>(context, qname.Catalog(), qname.Schema(), qname.Name());
 	if (entry.type != CatalogType::TABLE_ENTRY) {

--- a/src/include/duckdb/parser/expression/function_expression.hpp
+++ b/src/include/duckdb/parser/expression/function_expression.hpp
@@ -11,6 +11,7 @@
 #include "duckdb/common/identifier.hpp"
 #include "duckdb/common/vector.hpp"
 #include "duckdb/parser/parsed_expression.hpp"
+#include "duckdb/parser/qualified_name.hpp"
 #include "duckdb/parser/result_modifier.hpp"
 #include "duckdb/parser/keyword_helper.hpp"
 
@@ -99,26 +100,32 @@ public:
 	                              bool is_operator = false, bool export_state = false);
 
 public:
+	const QualifiedName &GetQualifiedName() const {
+		return qualified_name;
+	}
+	QualifiedName &GetQualifiedNameMutable() {
+		return qualified_name;
+	}
 	const Identifier &Catalog() const {
-		return catalog;
+		return qualified_name.Catalog();
 	}
 	Identifier &CatalogMutable() {
-		return catalog;
+		return qualified_name.Catalog();
 	}
 	const Identifier &Schema() const {
-		return schema;
+		return qualified_name.Schema();
 	}
 	Identifier &SchemaMutable() {
-		return schema;
+		return qualified_name.Schema();
 	}
 	const Identifier &FunctionName() const {
-		return function_name;
+		return qualified_name.Name();
 	}
 	Identifier &FunctionNameMutable() {
-		return function_name;
+		return qualified_name.Name();
 	}
 	void SetFunctionName(string function_name_p) {
-		function_name = Identifier(std::move(function_name_p));
+		qualified_name.Name() = Identifier(std::move(function_name_p));
 	}
 	bool IsOperator() const {
 		return is_operator;
@@ -178,12 +185,8 @@ public:
 	}
 
 private:
-	//! Catalog of the function
-	Identifier catalog;
-	//! Schema of the function
-	Identifier schema;
-	//! Function name
-	Identifier function_name;
+	//! Qualified name of the function (catalog.schema.name)
+	QualifiedName qualified_name;
 	//! Whether or not the function is an operator, only used for rendering
 	bool is_operator;
 	//! List of arguments to the function

--- a/src/include/duckdb/parser/expression/function_expression.hpp
+++ b/src/include/duckdb/parser/expression/function_expression.hpp
@@ -110,22 +110,22 @@ public:
 		return qualified_name.Catalog();
 	}
 	Identifier &CatalogMutable() {
-		return qualified_name.Catalog();
+		return qualified_name.CatalogMutable();
 	}
 	const Identifier &Schema() const {
 		return qualified_name.Schema();
 	}
 	Identifier &SchemaMutable() {
-		return qualified_name.Schema();
+		return qualified_name.SchemaMutable();
 	}
 	const Identifier &FunctionName() const {
 		return qualified_name.Name();
 	}
 	Identifier &FunctionNameMutable() {
-		return qualified_name.Name();
+		return qualified_name.NameMutable();
 	}
 	void SetFunctionName(string function_name_p) {
-		qualified_name.Name() = Identifier(std::move(function_name_p));
+		qualified_name.NameMutable() = Identifier(std::move(function_name_p));
 	}
 	bool IsOperator() const {
 		return is_operator;

--- a/src/include/duckdb/parser/expression/type_expression.hpp
+++ b/src/include/duckdb/parser/expression/type_expression.hpp
@@ -11,6 +11,7 @@
 #include "duckdb/common/identifier.hpp"
 #include "duckdb/common/vector.hpp"
 #include "duckdb/parser/parsed_expression.hpp"
+#include "duckdb/parser/qualified_name.hpp"
 #include "duckdb/parser/keyword_helper.hpp"
 
 namespace duckdb {
@@ -25,20 +26,26 @@ public:
 	TypeExpression(const string &type_name, vector<unique_ptr<ParsedExpression>> children);
 
 public:
+	const QualifiedName &GetQualifiedName() const {
+		return qualified_name;
+	}
+	QualifiedName &GetQualifiedNameMutable() {
+		return qualified_name;
+	}
 	const Identifier &GetTypeName() const {
-		return type_name;
+		return qualified_name.Name();
 	}
 	const Identifier &GetSchema() const {
-		return schema;
+		return qualified_name.Schema();
 	}
 	void SetSchema(Identifier new_schema) {
-		schema = std::move(new_schema);
+		qualified_name.Schema() = std::move(new_schema);
 	}
 	const Identifier &GetCatalog() const {
-		return catalog;
+		return qualified_name.Catalog();
 	}
 	void SetCatalog(Identifier new_catalog) {
-		catalog = std::move(new_catalog);
+		qualified_name.Catalog() = std::move(new_catalog);
 	}
 	const vector<unique_ptr<ParsedExpression>> &GetChildren() const {
 		return children;
@@ -63,10 +70,8 @@ public:
 private:
 	TypeExpression();
 
-	//! Qualified name parts
-	Identifier catalog;
-	Identifier schema;
-	Identifier type_name;
+	//! Qualified name of the type (catalog.schema.name)
+	QualifiedName qualified_name;
 
 	//! Children of the type expression (e.g. type parameters)
 	vector<unique_ptr<ParsedExpression>> children;

--- a/src/include/duckdb/parser/expression/type_expression.hpp
+++ b/src/include/duckdb/parser/expression/type_expression.hpp
@@ -39,13 +39,13 @@ public:
 		return qualified_name.Schema();
 	}
 	void SetSchema(Identifier new_schema) {
-		qualified_name.Schema() = std::move(new_schema);
+		qualified_name.SchemaMutable() = std::move(new_schema);
 	}
 	const Identifier &GetCatalog() const {
 		return qualified_name.Catalog();
 	}
 	void SetCatalog(Identifier new_catalog) {
-		qualified_name.Catalog() = std::move(new_catalog);
+		qualified_name.CatalogMutable() = std::move(new_catalog);
 	}
 	const vector<unique_ptr<ParsedExpression>> &GetChildren() const {
 		return children;

--- a/src/include/duckdb/parser/expression/window_expression.hpp
+++ b/src/include/duckdb/parser/expression/window_expression.hpp
@@ -67,23 +67,29 @@ public:
 	static ExpressionType WindowToExpressionType(const string &fun_name);
 
 public:
+	const QualifiedName &GetQualifiedName() const {
+		return qualified_name;
+	}
+	QualifiedName &GetQualifiedNameMutable() {
+		return qualified_name;
+	}
 	const Identifier &Catalog() const {
-		return catalog;
+		return qualified_name.Catalog();
 	}
 	Identifier &CatalogMutable() {
-		return catalog;
+		return qualified_name.Catalog();
 	}
 	const Identifier &Schema() const {
-		return schema;
+		return qualified_name.Schema();
 	}
 	Identifier &SchemaMutable() {
-		return schema;
+		return qualified_name.Schema();
 	}
 	const Identifier &FunctionName() const {
-		return function_name;
+		return qualified_name.Name();
 	}
 	Identifier &FunctionNameMutable() {
-		return function_name;
+		return qualified_name.Name();
 	}
 	const vector<unique_ptr<ParsedExpression>> &Partitions() const {
 		return partitions;
@@ -374,12 +380,8 @@ public:
 	}
 
 private:
-	//! Catalog of the aggregate function
-	Identifier catalog;
-	//! Schema of the aggregate function
-	Identifier schema;
-	//! Name of the aggregate function
-	Identifier function_name;
+	//! Qualified name of the aggregate function (catalog.schema.name)
+	QualifiedName qualified_name;
 	//! The child expression of the main window function
 	vector<FunctionArgument> arguments;
 	//! The set of expressions to partition by

--- a/src/include/duckdb/parser/expression/window_expression.hpp
+++ b/src/include/duckdb/parser/expression/window_expression.hpp
@@ -77,19 +77,19 @@ public:
 		return qualified_name.Catalog();
 	}
 	Identifier &CatalogMutable() {
-		return qualified_name.Catalog();
+		return qualified_name.CatalogMutable();
 	}
 	const Identifier &Schema() const {
 		return qualified_name.Schema();
 	}
 	Identifier &SchemaMutable() {
-		return qualified_name.Schema();
+		return qualified_name.SchemaMutable();
 	}
 	const Identifier &FunctionName() const {
 		return qualified_name.Name();
 	}
 	Identifier &FunctionNameMutable() {
-		return qualified_name.Name();
+		return qualified_name.NameMutable();
 	}
 	const vector<unique_ptr<ParsedExpression>> &Partitions() const {
 		return partitions;

--- a/src/include/duckdb/parser/qualified_name.hpp
+++ b/src/include/duckdb/parser/qualified_name.hpp
@@ -23,19 +23,19 @@ struct QualifiedName {
 	const Identifier &Catalog() const {
 		return catalog;
 	}
-	Identifier &Catalog() {
+	Identifier &CatalogMutable() {
 		return catalog;
 	}
 	const Identifier &Schema() const {
 		return schema;
 	}
-	Identifier &Schema() {
+	Identifier &SchemaMutable() {
 		return schema;
 	}
 	const Identifier &Name() const {
 		return name;
 	}
-	Identifier &Name() {
+	Identifier &NameMutable() {
 		return name;
 	}
 

--- a/src/include/duckdb/parser/qualified_name.hpp
+++ b/src/include/duckdb/parser/qualified_name.hpp
@@ -15,15 +15,44 @@
 namespace duckdb {
 
 struct QualifiedName {
-	Identifier catalog;
-	Identifier schema;
-	Identifier name;
+	QualifiedName() = default;
+	QualifiedName(Identifier catalog_p, Identifier schema_p, Identifier name_p)
+	    : catalog(std::move(catalog_p)), schema(std::move(schema_p)), name(std::move(name_p)) {
+	}
+
+	const Identifier &Catalog() const {
+		return catalog;
+	}
+	Identifier &Catalog() {
+		return catalog;
+	}
+	const Identifier &Schema() const {
+		return schema;
+	}
+	Identifier &Schema() {
+		return schema;
+	}
+	const Identifier &Name() const {
+		return name;
+	}
+	Identifier &Name() {
+		return name;
+	}
 
 	//! Parse the (optional) schema and a name from a string in the format of e.g. "schema"."table"; if there is no dot
 	//! the schema will be set to INVALID_SCHEMA
 	static QualifiedName Parse(const string &input);
 	static vector<Identifier> ParseComponents(const string &input);
 	string ToString() const;
+
+	hash_t Hash() const;
+	bool operator==(const QualifiedName &rhs) const;
+	bool operator!=(const QualifiedName &rhs) const;
+
+private:
+	Identifier catalog;
+	Identifier schema;
+	Identifier name;
 };
 
 struct QualifiedColumnName {

--- a/src/include/duckdb/storage/serialization/parsed_expression.json
+++ b/src/include/duckdb/storage/serialization/parsed_expression.json
@@ -586,8 +586,8 @@
       {
         "id": 200,
         "name": "catalog",
-        "property": "qualified_name.Catalog()",
         "serialize_property": "qualified_name.Catalog()",
+        "deserialize_property": "qualified_name.CatalogMutable()",
         "type": "Identifier",
         "equals_skip": true,
         "hash_skip": true
@@ -595,8 +595,8 @@
       {
         "id": 201,
         "name": "schema",
-        "property": "qualified_name.Schema()",
         "serialize_property": "qualified_name.Schema()",
+        "deserialize_property": "qualified_name.SchemaMutable()",
         "type": "Identifier",
         "equals_skip": true,
         "hash_skip": true
@@ -604,8 +604,8 @@
       {
         "id": 202,
         "name": "type_name",
-        "property": "qualified_name.Name()",
         "serialize_property": "qualified_name.Name()",
+        "deserialize_property": "qualified_name.NameMutable()",
         "type": "Identifier",
         "equals_skip": true,
         "hash_skip": true

--- a/src/include/duckdb/storage/serialization/parsed_expression.json
+++ b/src/include/duckdb/storage/serialization/parsed_expression.json
@@ -232,17 +232,8 @@
     "members": [
       {
         "id": 200,
-        "name": "function_name",
-        "type": "Identifier",
-        "accessor_mut": "FunctionNameMutable()",
-        "accessor": "FunctionName()"
-      },
-      {
-        "id": 201,
-        "name": "schema",
-        "type": "Identifier",
-        "accessor_mut": "SchemaMutable()",
-        "accessor": "Schema()"
+        "name": "qualified_name",
+        "type": "QualifiedName"
       },
       {
         "id": 202,
@@ -289,13 +280,6 @@
         "type": "bool",
         "accessor_mut": "ExportStateMutable()",
         "accessor": "ExportState()"
-      },
-      {
-        "id": 208,
-        "name": "catalog",
-        "type": "Identifier",
-        "accessor_mut": "CatalogMutable()",
-        "accessor": "Catalog()"
       },
       {
         "id": 209,
@@ -478,18 +462,8 @@
     "members": [
       {
         "id": 200,
-        "name": "function_name",
-        "type": "Identifier"
-      },
-      {
-        "id": 201,
-        "name": "schema",
-        "type": "Identifier"
-      },
-      {
-        "id": 202,
-        "name": "catalog",
-        "type": "Identifier"
+        "name": "qualified_name",
+        "type": "QualifiedName"
       },
       {
         "id": 203,
@@ -605,19 +579,36 @@
     "enum": "TYPE",
     "members": [
       {
+        "name": "qualified_name",
+        "type": "QualifiedName",
+        "serialize_skip": true
+      },
+      {
         "id": 200,
         "name": "catalog",
-        "type": "Identifier"
+        "property": "qualified_name.Catalog()",
+        "serialize_property": "qualified_name.Catalog()",
+        "type": "Identifier",
+        "equals_skip": true,
+        "hash_skip": true
       },
       {
         "id": 201,
         "name": "schema",
-        "type": "Identifier"
+        "property": "qualified_name.Schema()",
+        "serialize_property": "qualified_name.Schema()",
+        "type": "Identifier",
+        "equals_skip": true,
+        "hash_skip": true
       },
       {
         "id": 202,
         "name": "type_name",
-        "type": "Identifier"
+        "property": "qualified_name.Name()",
+        "serialize_property": "qualified_name.Name()",
+        "type": "Identifier",
+        "equals_skip": true,
+        "hash_skip": true
       },
       {
         "id": 203,

--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -132,8 +132,8 @@ shared_ptr<AttachedDatabase> DatabaseManager::AttachDatabase(ClientContext &cont
 				throw BinderException("Database \"%s\" is already attached in %s mode, cannot re-attach in %s mode",
 				                      info.name, existing_mode_str, attached_mode);
 			}
-			if (!options.default_table.name.empty()) {
-				existing_db->GetCatalog().SetDefaultTable(options.default_table.schema, options.default_table.name);
+			if (!options.default_table.Name().empty()) {
+				existing_db->GetCatalog().SetDefaultTable(options.default_table.Schema(), options.default_table.Name());
 			}
 			if (info.on_conflict == OnCreateConflict::REPLACE_ON_CONFLICT) {
 				// we require the vacuuming threshold for indexed tables to be the same as the already attached db
@@ -214,8 +214,8 @@ shared_ptr<AttachedDatabase> DatabaseManager::AttachDatabase(ClientContext &cont
 		attached_db->Initialize(context);
 	} else {
 		attached_db->Initialize(context);
-		if (!options.default_table.name.empty()) {
-			attached_db->GetCatalog().SetDefaultTable(options.default_table.schema, options.default_table.name);
+		if (!options.default_table.Name().empty()) {
+			attached_db->GetCatalog().SetDefaultTable(options.default_table.Schema(), options.default_table.Name());
 		}
 		attached_db->FinalizeLoad(context);
 	}

--- a/src/parser/expression/function_expression.cpp
+++ b/src/parser/expression/function_expression.cpp
@@ -167,8 +167,8 @@ void FunctionExpression::Serialize(Serializer &serializer) const {
 
 unique_ptr<ParsedExpression> FunctionExpression::Deserialize(Deserializer &deserializer) {
 	auto result = duckdb::unique_ptr<FunctionExpression>(new FunctionExpression());
-	deserializer.ReadPropertyWithDefault<Identifier>(200, "function_name", result->qualified_name.Name());
-	deserializer.ReadPropertyWithDefault<Identifier>(201, "schema", result->qualified_name.Schema());
+	deserializer.ReadPropertyWithDefault<Identifier>(200, "function_name", result->qualified_name.NameMutable());
+	deserializer.ReadPropertyWithDefault<Identifier>(201, "schema", result->qualified_name.SchemaMutable());
 
 	// Legacy children deserialization
 	vector<unique_ptr<ParsedExpression>> children;
@@ -190,7 +190,7 @@ unique_ptr<ParsedExpression> FunctionExpression::Deserialize(Deserializer &deser
 	deserializer.ReadPropertyWithDefault<bool>(205, "distinct", result->distinct);
 	deserializer.ReadPropertyWithDefault<bool>(206, "is_operator", result->is_operator);
 	deserializer.ReadPropertyWithDefault<bool>(207, "export_state", result->export_state);
-	deserializer.ReadPropertyWithDefault<Identifier>(208, "catalog", result->qualified_name.Catalog());
+	deserializer.ReadPropertyWithDefault<Identifier>(208, "catalog", result->qualified_name.CatalogMutable());
 
 	// New children deserialization
 	if (children.empty()) {

--- a/src/parser/expression/function_expression.cpp
+++ b/src/parser/expression/function_expression.cpp
@@ -16,8 +16,9 @@ FunctionExpression::FunctionExpression(Identifier catalog, Identifier schema, co
                                        vector<unique_ptr<ParsedExpression>> children_p,
                                        unique_ptr<ParsedExpression> filter, unique_ptr<OrderModifier> order_bys_p,
                                        bool distinct, bool is_operator, bool export_state_p)
-    : ParsedExpression(ExpressionType::FUNCTION, ExpressionClass::FUNCTION), catalog(std::move(catalog)),
-      schema(std::move(schema)), function_name(StringUtil::Lower(function_name.GetIdentifierName())),
+    : ParsedExpression(ExpressionType::FUNCTION, ExpressionClass::FUNCTION),
+      qualified_name {std::move(catalog), std::move(schema),
+                      Identifier(StringUtil::Lower(function_name.GetIdentifierName()))},
       is_operator(is_operator), distinct(distinct), filter(std::move(filter)), order_bys(std::move(order_bys_p)),
       export_state(export_state_p) {
 	arguments.reserve(children_p.size());
@@ -42,8 +43,9 @@ FunctionExpression::FunctionExpression(Identifier catalog_name, Identifier schem
                                        vector<FunctionArgument> children, unique_ptr<ParsedExpression> filter,
                                        unique_ptr<OrderModifier> order_bys_p, bool distinct, bool is_operator,
                                        bool export_state)
-    : ParsedExpression(ExpressionType::FUNCTION, ExpressionClass::FUNCTION), catalog(std::move(catalog_name)),
-      schema(std::move(schema_name)), function_name(StringUtil::Lower(function_name.GetIdentifierName())),
+    : ParsedExpression(ExpressionType::FUNCTION, ExpressionClass::FUNCTION),
+      qualified_name {std::move(catalog_name), std::move(schema_name),
+                      Identifier(StringUtil::Lower(function_name.GetIdentifierName()))},
       is_operator(is_operator), arguments(std::move(children)), distinct(distinct), filter(std::move(filter)),
       order_bys(std::move(order_bys_p)), export_state(export_state) {
 	D_ASSERT(!function_name.empty());
@@ -64,26 +66,26 @@ string FunctionExpression::ToString() const {
 		// built-in operator
 		D_ASSERT(!distinct);
 		if (arguments.size() == 1) {
-			if (StringUtil::Contains(function_name.GetIdentifierName(), "__postfix")) {
+			if (StringUtil::Contains(qualified_name.Name().GetIdentifierName(), "__postfix")) {
 				return "((" + arguments[0].ToString() + ")" +
-				       StringUtil::Replace(function_name.GetIdentifierName(), "__postfix", "") + ")";
+				       StringUtil::Replace(qualified_name.Name().GetIdentifierName(), "__postfix", "") + ")";
 			}
-			return function_name.GetIdentifierName() + "(" + arguments[0].ToString() + ")";
+			return qualified_name.Name().GetIdentifierName() + "(" + arguments[0].ToString() + ")";
 		}
 		if (arguments.size() == 2) {
-			return StringUtil::Format("(%s %s %s)", arguments[0].ToString(), function_name.GetIdentifierName(),
+			return StringUtil::Format("(%s %s %s)", arguments[0].ToString(), qualified_name.Name().GetIdentifierName(),
 			                          arguments[1].ToString());
 		}
 	}
 	// standard function call
 	string result;
-	if (!catalog.empty()) {
-		result += SQLIdentifier(catalog) + ".";
+	if (!qualified_name.Catalog().empty()) {
+		result += SQLIdentifier(qualified_name.Catalog()) + ".";
 	}
-	if (!schema.empty()) {
-		result += SQLIdentifier(schema) + ".";
+	if (!qualified_name.Schema().empty()) {
+		result += SQLIdentifier(qualified_name.Schema()) + ".";
 	}
-	result += SQLIdentifier(function_name);
+	result += SQLIdentifier(qualified_name.Name());
 	result += "(";
 	if (distinct) {
 		result += "DISTINCT ";
@@ -118,12 +120,12 @@ string FunctionExpression::ToString() const {
 }
 
 void FunctionExpression::Verify() const {
-	D_ASSERT(!function_name.empty());
+	D_ASSERT(!qualified_name.Name().empty());
 }
 
 optional_ptr<ParsedExpression> FunctionExpression::IsLambdaFunction() {
 	// Ignore the ->> operator (JSON extension).
-	if (function_name == "->>") {
+	if (qualified_name.Name() == "->>") {
 		return nullptr;
 	}
 	// Check the children for lambda expressions.
@@ -137,8 +139,8 @@ optional_ptr<ParsedExpression> FunctionExpression::IsLambdaFunction() {
 
 void FunctionExpression::Serialize(Serializer &serializer) const {
 	ParsedExpression::Serialize(serializer);
-	serializer.WritePropertyWithDefault<Identifier>(200, "function_name", function_name);
-	serializer.WritePropertyWithDefault<Identifier>(201, "schema", schema);
+	serializer.WritePropertyWithDefault<Identifier>(200, "function_name", qualified_name.Name());
+	serializer.WritePropertyWithDefault<Identifier>(201, "schema", qualified_name.Schema());
 
 	if (!serializer.ShouldSerialize(StorageVersion::V2_0_0)) {
 		// Legacy serialization.
@@ -156,7 +158,7 @@ void FunctionExpression::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<bool>(205, "distinct", distinct);
 	serializer.WritePropertyWithDefault<bool>(206, "is_operator", is_operator);
 	serializer.WritePropertyWithDefault<bool>(207, "export_state", export_state);
-	serializer.WritePropertyWithDefault<Identifier>(208, "catalog", catalog);
+	serializer.WritePropertyWithDefault<Identifier>(208, "catalog", qualified_name.Catalog());
 
 	if (serializer.ShouldSerialize(StorageVersion::V2_0_0)) {
 		serializer.WritePropertyWithDefault<vector<FunctionArgument>>(209, "arguments", arguments);
@@ -165,8 +167,8 @@ void FunctionExpression::Serialize(Serializer &serializer) const {
 
 unique_ptr<ParsedExpression> FunctionExpression::Deserialize(Deserializer &deserializer) {
 	auto result = duckdb::unique_ptr<FunctionExpression>(new FunctionExpression());
-	deserializer.ReadPropertyWithDefault<Identifier>(200, "function_name", result->function_name);
-	deserializer.ReadPropertyWithDefault<Identifier>(201, "schema", result->schema);
+	deserializer.ReadPropertyWithDefault<Identifier>(200, "function_name", result->qualified_name.Name());
+	deserializer.ReadPropertyWithDefault<Identifier>(201, "schema", result->qualified_name.Schema());
 
 	// Legacy children deserialization
 	vector<unique_ptr<ParsedExpression>> children;
@@ -188,7 +190,7 @@ unique_ptr<ParsedExpression> FunctionExpression::Deserialize(Deserializer &deser
 	deserializer.ReadPropertyWithDefault<bool>(205, "distinct", result->distinct);
 	deserializer.ReadPropertyWithDefault<bool>(206, "is_operator", result->is_operator);
 	deserializer.ReadPropertyWithDefault<bool>(207, "export_state", result->export_state);
-	deserializer.ReadPropertyWithDefault<Identifier>(208, "catalog", result->catalog);
+	deserializer.ReadPropertyWithDefault<Identifier>(208, "catalog", result->qualified_name.Catalog());
 
 	// New children deserialization
 	if (children.empty()) {

--- a/src/parser/expression/type_expression.cpp
+++ b/src/parser/expression/type_expression.cpp
@@ -9,9 +9,11 @@ namespace duckdb {
 
 TypeExpression::TypeExpression(Identifier catalog, Identifier schema, Identifier type_name,
                                vector<unique_ptr<ParsedExpression>> children_p)
-    : ParsedExpression(ExpressionType::TYPE, ExpressionClass::TYPE), catalog(std::move(catalog)),
-      schema(std::move(schema)), type_name(std::move(type_name)), children(std::move(children_p)) {
-	D_ASSERT(!this->type_name.empty());
+    : ParsedExpression(ExpressionType::TYPE, ExpressionClass::TYPE), qualified_name {std::move(catalog),
+                                                                                     std::move(schema),
+                                                                                     std::move(type_name)},
+      children(std::move(children_p)) {
+	D_ASSERT(!qualified_name.Name().empty());
 }
 
 TypeExpression::TypeExpression(Identifier type_name, vector<unique_ptr<ParsedExpression>> children)
@@ -28,11 +30,12 @@ TypeExpression::TypeExpression() : ParsedExpression(ExpressionType::TYPE, Expres
 
 string TypeExpression::ToString() const {
 	string result;
-	if (!catalog.empty()) {
-		result += SQLIdentifier(catalog) + ".";
+	auto &type_name = qualified_name.Name();
+	if (!qualified_name.Catalog().empty()) {
+		result += SQLIdentifier(qualified_name.Catalog()) + ".";
 	}
-	if (!schema.empty()) {
-		result += SQLIdentifier(schema) + ".";
+	if (!qualified_name.Schema().empty()) {
+		result += SQLIdentifier(qualified_name.Schema()) + ".";
 	}
 
 	auto &params = children;
@@ -115,7 +118,7 @@ string TypeExpression::ToString() const {
 }
 
 void TypeExpression::Verify() const {
-	D_ASSERT(!type_name.empty());
+	D_ASSERT(!qualified_name.Name().empty());
 }
 
 } // namespace duckdb

--- a/src/parser/expression/window_expression.cpp
+++ b/src/parser/expression/window_expression.cpp
@@ -89,7 +89,7 @@ string WindowExpression::ExpressionTypeToWindow(ExpressionType expression_type) 
 }
 
 void WindowExpression::SetFunctionName(const string &function_name_p) {
-	qualified_name.Name() = Identifier(function_name_p);
+	qualified_name.NameMutable() = Identifier(function_name_p);
 	type = WindowToExpressionType(qualified_name.Name().GetIdentifierName());
 }
 
@@ -167,9 +167,9 @@ void WindowExpression::Serialize(Serializer &serializer) const {
 
 unique_ptr<ParsedExpression> WindowExpression::Deserialize(Deserializer &deserializer) {
 	auto result = duckdb::unique_ptr<WindowExpression>(new WindowExpression());
-	deserializer.ReadPropertyWithDefault<Identifier>(200, "function_name", result->qualified_name.Name());
-	deserializer.ReadPropertyWithDefault<Identifier>(201, "schema", result->qualified_name.Schema());
-	deserializer.ReadPropertyWithDefault<Identifier>(202, "catalog", result->qualified_name.Catalog());
+	deserializer.ReadPropertyWithDefault<Identifier>(200, "function_name", result->qualified_name.NameMutable());
+	deserializer.ReadPropertyWithDefault<Identifier>(201, "schema", result->qualified_name.SchemaMutable());
+	deserializer.ReadPropertyWithDefault<Identifier>(202, "catalog", result->qualified_name.CatalogMutable());
 
 	// Legacy children deserialization
 	vector<unique_ptr<ParsedExpression>> children;

--- a/src/parser/expression/window_expression.cpp
+++ b/src/parser/expression/window_expression.cpp
@@ -10,7 +10,8 @@ WindowExpression::WindowExpression() : ParsedExpression(ExpressionType::INVALID,
 vector<unique_ptr<ParsedExpression>> WindowExpression::SerializedChildren(Serializer &serializer) const {
 	vector<unique_ptr<ParsedExpression>> result;
 	idx_t nargs = arguments.size();
-	if (!serializer.ShouldSerialize(StorageVersion::V2_0_0) && (function_name == "lead" || function_name == "lag")) {
+	if (!serializer.ShouldSerialize(StorageVersion::V2_0_0) &&
+	    (qualified_name.Name() == "lead" || qualified_name.Name() == "lag")) {
 		nargs = 1;
 	}
 
@@ -23,7 +24,7 @@ vector<unique_ptr<ParsedExpression>> WindowExpression::SerializedChildren(Serial
 
 unique_ptr<ParsedExpression> WindowExpression::SerializedOffset(Serializer &serializer) const {
 	if (!serializer.ShouldSerialize(StorageVersion::V2_0_0) && arguments.size() > 1 &&
-	    (function_name == "lead" || function_name == "lag")) {
+	    (qualified_name.Name() == "lead" || qualified_name.Name() == "lag")) {
 		return arguments[1].GetExpression().Copy();
 	}
 
@@ -32,7 +33,7 @@ unique_ptr<ParsedExpression> WindowExpression::SerializedOffset(Serializer &seri
 
 unique_ptr<ParsedExpression> WindowExpression::SerializedDefault(Serializer &serializer) const {
 	if (!serializer.ShouldSerialize(StorageVersion::V2_0_0) && arguments.size() > 2 &&
-	    (function_name == "lead" || function_name == "lag")) {
+	    (qualified_name.Name() == "lead" || qualified_name.Name() == "lag")) {
 		return arguments[2].GetExpression().Copy();
 	}
 
@@ -40,8 +41,9 @@ unique_ptr<ParsedExpression> WindowExpression::SerializedDefault(Serializer &ser
 }
 
 WindowExpression::WindowExpression(const string &catalog_name, const string &schema, const string &function_name)
-    : ParsedExpression(WindowToExpressionType(function_name), ExpressionClass::WINDOW), catalog(catalog_name),
-      schema(schema), function_name(StringUtil::Lower(function_name)), ignore_nulls(false), distinct(false) {
+    : ParsedExpression(WindowToExpressionType(function_name), ExpressionClass::WINDOW),
+      qualified_name {Identifier(catalog_name), Identifier(schema), Identifier(StringUtil::Lower(function_name))},
+      ignore_nulls(false), distinct(false) {
 }
 
 struct WindowFunctionDefinition {
@@ -87,13 +89,13 @@ string WindowExpression::ExpressionTypeToWindow(ExpressionType expression_type) 
 }
 
 void WindowExpression::SetFunctionName(const string &function_name_p) {
-	function_name = Identifier(function_name_p);
-	type = WindowToExpressionType(function_name.GetIdentifierName());
+	qualified_name.Name() = Identifier(function_name_p);
+	type = WindowToExpressionType(qualified_name.Name().GetIdentifierName());
 }
 
 string WindowExpression::ToString() const {
-	return ToString<WindowExpression, ParsedExpression, OrderByNode>(*this, schema.GetIdentifierName(),
-	                                                                 function_name.GetIdentifierName());
+	return ToString<WindowExpression, ParsedExpression, OrderByNode>(*this, qualified_name.Schema().GetIdentifierName(),
+	                                                                 qualified_name.Name().GetIdentifierName());
 }
 
 bool WindowExpression::HasBoundedParts() const {
@@ -124,9 +126,9 @@ bool WindowExpression::HasBoundedParts() const {
 
 void WindowExpression::Serialize(Serializer &serializer) const {
 	ParsedExpression::Serialize(serializer);
-	serializer.WritePropertyWithDefault<Identifier>(200, "function_name", function_name);
-	serializer.WritePropertyWithDefault<Identifier>(201, "schema", schema);
-	serializer.WritePropertyWithDefault<Identifier>(202, "catalog", catalog);
+	serializer.WritePropertyWithDefault<Identifier>(200, "function_name", qualified_name.Name());
+	serializer.WritePropertyWithDefault<Identifier>(201, "schema", qualified_name.Schema());
+	serializer.WritePropertyWithDefault<Identifier>(202, "catalog", qualified_name.Catalog());
 
 	if (!serializer.ShouldSerialize(StorageVersion::V2_0_0)) {
 		// Legacy serialization.
@@ -165,9 +167,9 @@ void WindowExpression::Serialize(Serializer &serializer) const {
 
 unique_ptr<ParsedExpression> WindowExpression::Deserialize(Deserializer &deserializer) {
 	auto result = duckdb::unique_ptr<WindowExpression>(new WindowExpression());
-	deserializer.ReadPropertyWithDefault<Identifier>(200, "function_name", result->function_name);
-	deserializer.ReadPropertyWithDefault<Identifier>(201, "schema", result->schema);
-	deserializer.ReadPropertyWithDefault<Identifier>(202, "catalog", result->catalog);
+	deserializer.ReadPropertyWithDefault<Identifier>(200, "function_name", result->qualified_name.Name());
+	deserializer.ReadPropertyWithDefault<Identifier>(201, "schema", result->qualified_name.Schema());
+	deserializer.ReadPropertyWithDefault<Identifier>(202, "catalog", result->qualified_name.Catalog());
 
 	// Legacy children deserialization
 	vector<unique_ptr<ParsedExpression>> children;

--- a/src/parser/peg/transformer/peg_transformer_factory.cpp
+++ b/src/parser/peg/transformer/peg_transformer_factory.cpp
@@ -225,17 +225,17 @@ QualifiedName PEGTransformerFactory::StringToQualifiedName(vector<string> input)
 		throw InternalException("QualifiedName cannot be made with an empty input.");
 	}
 	if (input.size() == 1) {
-		result.catalog = Identifier::InvalidCatalog();
-		result.schema = Identifier::InvalidSchema();
-		result.name = Identifier(input[0]);
+		result.Catalog() = Identifier::InvalidCatalog();
+		result.Schema() = Identifier::InvalidSchema();
+		result.Name() = Identifier(input[0]);
 	} else if (input.size() == 2) {
-		result.catalog = Identifier::InvalidCatalog();
-		result.schema = Identifier(input[0]);
-		result.name = Identifier(input[1]);
+		result.Catalog() = Identifier::InvalidCatalog();
+		result.Schema() = Identifier(input[0]);
+		result.Name() = Identifier(input[1]);
 	} else if (input.size() == 3) {
-		result.catalog = Identifier(input[0]);
-		result.schema = Identifier(input[1]);
-		result.name = Identifier(input[2]);
+		result.Catalog() = Identifier(input[0]);
+		result.Schema() = Identifier(input[1]);
+		result.Name() = Identifier(input[2]);
 	} else {
 		throw ParserException("Too many qualifications found - expected [catalog.schema.name] or [schema.name]");
 	}

--- a/src/parser/peg/transformer/peg_transformer_factory.cpp
+++ b/src/parser/peg/transformer/peg_transformer_factory.cpp
@@ -225,17 +225,17 @@ QualifiedName PEGTransformerFactory::StringToQualifiedName(vector<string> input)
 		throw InternalException("QualifiedName cannot be made with an empty input.");
 	}
 	if (input.size() == 1) {
-		result.Catalog() = Identifier::InvalidCatalog();
-		result.Schema() = Identifier::InvalidSchema();
-		result.Name() = Identifier(input[0]);
+		result.CatalogMutable() = Identifier::InvalidCatalog();
+		result.SchemaMutable() = Identifier::InvalidSchema();
+		result.NameMutable() = Identifier(input[0]);
 	} else if (input.size() == 2) {
-		result.Catalog() = Identifier::InvalidCatalog();
-		result.Schema() = Identifier(input[0]);
-		result.Name() = Identifier(input[1]);
+		result.CatalogMutable() = Identifier::InvalidCatalog();
+		result.SchemaMutable() = Identifier(input[0]);
+		result.NameMutable() = Identifier(input[1]);
 	} else if (input.size() == 3) {
-		result.Catalog() = Identifier(input[0]);
-		result.Schema() = Identifier(input[1]);
-		result.Name() = Identifier(input[2]);
+		result.CatalogMutable() = Identifier(input[0]);
+		result.SchemaMutable() = Identifier(input[1]);
+		result.NameMutable() = Identifier(input[2]);
 	} else {
 		throw ParserException("Too many qualifications found - expected [catalog.schema.name] or [schema.name]");
 	}

--- a/src/parser/peg/transformer/transform_alter.cpp
+++ b/src/parser/peg/transformer/transform_alter.cpp
@@ -90,13 +90,13 @@ unique_ptr<AlterInfo> PEGTransformerFactory::TransformAlterSequenceStmt(PEGTrans
                                                                         const optional<bool> &if_exists,
                                                                         const QualifiedName &qualified_sequence_name,
                                                                         unique_ptr<AlterInfo> alter_sequence_options) {
-	if (qualified_sequence_name.schema.empty()) {
-		alter_sequence_options->schema = qualified_sequence_name.catalog;
+	if (qualified_sequence_name.Schema().empty()) {
+		alter_sequence_options->schema = qualified_sequence_name.Catalog();
 	} else {
-		alter_sequence_options->catalog = qualified_sequence_name.catalog;
-		alter_sequence_options->schema = qualified_sequence_name.schema;
+		alter_sequence_options->catalog = qualified_sequence_name.Catalog();
+		alter_sequence_options->schema = qualified_sequence_name.Schema();
 	}
-	alter_sequence_options->name = qualified_sequence_name.name;
+	alter_sequence_options->name = qualified_sequence_name.Name();
 	alter_sequence_options->if_not_found = if_exists ? OnEntryNotFound::RETURN_NULL : OnEntryNotFound::THROW_EXCEPTION;
 	return alter_sequence_options;
 }
@@ -106,9 +106,9 @@ QualifiedName PEGTransformerFactory::TransformQualifiedSequenceName(PEGTransform
                                                                     const optional<Identifier> &schema_qualification,
                                                                     const Identifier &sequence_name) {
 	QualifiedName result;
-	result.catalog = catalog_qualification ? *catalog_qualification : INVALID_CATALOG;
-	result.schema = schema_qualification ? *schema_qualification : INVALID_SCHEMA;
-	result.name = sequence_name;
+	result.Catalog() = catalog_qualification ? *catalog_qualification : INVALID_CATALOG;
+	result.Schema() = schema_qualification ? *schema_qualification : INVALID_SCHEMA;
+	result.Name() = sequence_name;
 	return result;
 }
 
@@ -132,11 +132,11 @@ PEGTransformerFactory::TransformSetSequenceOption(PEGTransformer &transformer,
 			}
 			has_owned = true;
 			auto owned_by = unique_ptr_cast<SequenceOption, QualifiedSequenceOption>(std::move(seq_option.second));
-			auto schema =
-			    owned_by->qualified_name.schema.empty() ? Identifier::DefaultSchema() : owned_by->qualified_name.schema;
+			auto schema = owned_by->qualified_name.Schema().empty() ? Identifier::DefaultSchema()
+			                                                        : owned_by->qualified_name.Schema();
 			owned_info =
 			    make_uniq<ChangeOwnershipInfo>(CatalogType::SEQUENCE_ENTRY, "", "", "", schema,
-			                                   owned_by->qualified_name.name, OnEntryNotFound::THROW_EXCEPTION);
+			                                   owned_by->qualified_name.Name(), OnEntryNotFound::THROW_EXCEPTION);
 		}
 	}
 	if (owned_info) {

--- a/src/parser/peg/transformer/transform_alter.cpp
+++ b/src/parser/peg/transformer/transform_alter.cpp
@@ -106,9 +106,9 @@ QualifiedName PEGTransformerFactory::TransformQualifiedSequenceName(PEGTransform
                                                                     const optional<Identifier> &schema_qualification,
                                                                     const Identifier &sequence_name) {
 	QualifiedName result;
-	result.Catalog() = catalog_qualification ? *catalog_qualification : INVALID_CATALOG;
-	result.Schema() = schema_qualification ? *schema_qualification : INVALID_SCHEMA;
-	result.Name() = sequence_name;
+	result.CatalogMutable() = catalog_qualification ? *catalog_qualification : INVALID_CATALOG;
+	result.SchemaMutable() = schema_qualification ? *schema_qualification : INVALID_SCHEMA;
+	result.NameMutable() = sequence_name;
 	return result;
 }
 

--- a/src/parser/peg/transformer/transform_call.cpp
+++ b/src/parser/peg/transformer/transform_call.cpp
@@ -11,8 +11,8 @@ PEGTransformerFactory::TransformCallStatement(PEGTransformer &transformer,
                                               vector<FunctionArgument> table_function_arguments) {
 	auto result = make_uniq<CallStatement>();
 	auto function_expression =
-	    make_uniq<FunctionExpression>(qualified_table_function.catalog, qualified_table_function.schema,
-	                                  qualified_table_function.name, std::move(table_function_arguments));
+	    make_uniq<FunctionExpression>(qualified_table_function.Catalog(), qualified_table_function.Schema(),
+	                                  qualified_table_function.Name(), std::move(table_function_arguments));
 	result->function = std::move(function_expression);
 	return std::move(result);
 }

--- a/src/parser/peg/transformer/transform_comment.cpp
+++ b/src/parser/peg/transformer/transform_comment.cpp
@@ -21,7 +21,7 @@ unique_ptr<SQLStatement> PEGTransformerFactory::TransformCommentStatement(PEGTra
 			throw ParserException("Invalid column reference: '%s'", column_name.GetIdentifierName());
 		}
 		auto qualified_name = StringToQualifiedName(identifier);
-		info = make_uniq<SetColumnCommentInfo>(qualified_name.catalog, qualified_name.schema, qualified_name.name,
+		info = make_uniq<SetColumnCommentInfo>(qualified_name.Catalog(), qualified_name.Schema(), qualified_name.Name(),
 		                                       column_name, comment_value, OnEntryNotFound::THROW_EXCEPTION);
 	} else if (comment_on_type == CatalogType::DATABASE_ENTRY) {
 		throw NotImplementedException("Adding comments to databases is not implemented");
@@ -29,8 +29,8 @@ unique_ptr<SQLStatement> PEGTransformerFactory::TransformCommentStatement(PEGTra
 		throw NotImplementedException("Adding comments to schemas is not implemented");
 	} else {
 		auto qualified_name = StringToQualifiedName(dotted_identifier);
-		info = make_uniq<SetCommentInfo>(comment_on_type, qualified_name.catalog, qualified_name.schema,
-		                                 qualified_name.name, comment_value, OnEntryNotFound::THROW_EXCEPTION);
+		info = make_uniq<SetCommentInfo>(comment_on_type, qualified_name.Catalog(), qualified_name.Schema(),
+		                                 qualified_name.Name(), comment_value, OnEntryNotFound::THROW_EXCEPTION);
 	}
 	if (!info) {
 		throw NotImplementedException("Cannot comment on this type");

--- a/src/parser/peg/transformer/transform_common.cpp
+++ b/src/parser/peg/transformer/transform_common.cpp
@@ -267,8 +267,8 @@ PEGTransformerFactory::TransformQualifiedSimpleType(PEGTransformer &transformer,
                                                     optional<vector<unique_ptr<ParsedExpression>>> type_modifiers) {
 	auto result = qualified_type_name;
 	if (result.Schema().empty()) {
-		result.Schema() = result.Catalog();
-		result.Catalog() = INVALID_CATALOG;
+		result.SchemaMutable() = result.Catalog();
+		result.CatalogMutable() = INVALID_CATALOG;
 	}
 	vector<unique_ptr<ParsedExpression>> modifiers;
 	if (type_modifiers) {
@@ -280,9 +280,9 @@ PEGTransformerFactory::TransformQualifiedSimpleType(PEGTransformer &transformer,
 QualifiedName PEGTransformerFactory::TransformTypeNameAsQualifiedName(PEGTransformer &transformer,
                                                                       const Identifier &type_name) {
 	QualifiedName result;
-	result.Catalog() = INVALID_CATALOG;
-	result.Schema() = INVALID_SCHEMA;
-	result.Name() = type_name;
+	result.CatalogMutable() = INVALID_CATALOG;
+	result.SchemaMutable() = INVALID_SCHEMA;
+	result.NameMutable() = type_name;
 	return result;
 }
 
@@ -290,9 +290,9 @@ QualifiedName PEGTransformerFactory::TransformSchemaReservedTypeName(PEGTransfor
                                                                      const Identifier &schema_qualification,
                                                                      const Identifier &reserved_type_name) {
 	QualifiedName result;
-	result.Catalog() = INVALID_CATALOG;
-	result.Schema() = schema_qualification;
-	result.Name() = reserved_type_name;
+	result.CatalogMutable() = INVALID_CATALOG;
+	result.SchemaMutable() = schema_qualification;
+	result.NameMutable() = reserved_type_name;
 	return result;
 }
 
@@ -300,9 +300,9 @@ QualifiedName PEGTransformerFactory::TransformCatalogReservedSchemaTypeName(
     PEGTransformer &transformer, const Identifier &catalog_qualification,
     const Identifier &reserved_schema_qualification, const Identifier &reserved_type_name) {
 	QualifiedName result;
-	result.Catalog() = catalog_qualification;
-	result.Schema() = reserved_schema_qualification;
-	result.Name() = reserved_type_name;
+	result.CatalogMutable() = catalog_qualification;
+	result.SchemaMutable() = reserved_schema_qualification;
+	result.NameMutable() = reserved_type_name;
 	return result;
 }
 

--- a/src/parser/peg/transformer/transform_common.cpp
+++ b/src/parser/peg/transformer/transform_common.cpp
@@ -266,23 +266,23 @@ PEGTransformerFactory::TransformQualifiedSimpleType(PEGTransformer &transformer,
                                                     const QualifiedName &qualified_type_name,
                                                     optional<vector<unique_ptr<ParsedExpression>>> type_modifiers) {
 	auto result = qualified_type_name;
-	if (result.schema.empty()) {
-		result.schema = result.catalog;
-		result.catalog = INVALID_CATALOG;
+	if (result.Schema().empty()) {
+		result.Schema() = result.Catalog();
+		result.Catalog() = INVALID_CATALOG;
 	}
 	vector<unique_ptr<ParsedExpression>> modifiers;
 	if (type_modifiers) {
 		modifiers = std::move(*type_modifiers);
 	}
-	return make_uniq<TypeExpression>(result.catalog, result.schema, result.name, std::move(modifiers));
+	return make_uniq<TypeExpression>(result.Catalog(), result.Schema(), result.Name(), std::move(modifiers));
 }
 
 QualifiedName PEGTransformerFactory::TransformTypeNameAsQualifiedName(PEGTransformer &transformer,
                                                                       const Identifier &type_name) {
 	QualifiedName result;
-	result.catalog = INVALID_CATALOG;
-	result.schema = INVALID_SCHEMA;
-	result.name = type_name;
+	result.Catalog() = INVALID_CATALOG;
+	result.Schema() = INVALID_SCHEMA;
+	result.Name() = type_name;
 	return result;
 }
 
@@ -290,9 +290,9 @@ QualifiedName PEGTransformerFactory::TransformSchemaReservedTypeName(PEGTransfor
                                                                      const Identifier &schema_qualification,
                                                                      const Identifier &reserved_type_name) {
 	QualifiedName result;
-	result.catalog = INVALID_CATALOG;
-	result.schema = schema_qualification;
-	result.name = reserved_type_name;
+	result.Catalog() = INVALID_CATALOG;
+	result.Schema() = schema_qualification;
+	result.Name() = reserved_type_name;
 	return result;
 }
 
@@ -300,9 +300,9 @@ QualifiedName PEGTransformerFactory::TransformCatalogReservedSchemaTypeName(
     PEGTransformer &transformer, const Identifier &catalog_qualification,
     const Identifier &reserved_schema_qualification, const Identifier &reserved_type_name) {
 	QualifiedName result;
-	result.catalog = catalog_qualification;
-	result.schema = reserved_schema_qualification;
-	result.name = reserved_type_name;
+	result.Catalog() = catalog_qualification;
+	result.Schema() = reserved_schema_qualification;
+	result.Name() = reserved_type_name;
 	return result;
 }
 

--- a/src/parser/peg/transformer/transform_create_macro.cpp
+++ b/src/parser/peg/transformer/transform_create_macro.cpp
@@ -11,13 +11,13 @@ unique_ptr<CreateStatement> PEGTransformerFactory::TransformCreateMacroStmt(
 	auto result = make_uniq<CreateStatement>();
 	auto info = make_uniq<CreateMacroInfo>(CatalogType::MACRO_ENTRY);
 
-	if (qualified_name.schema.empty()) {
-		info->schema = qualified_name.catalog;
+	if (qualified_name.Schema().empty()) {
+		info->schema = qualified_name.Catalog();
 	} else {
-		info->catalog = qualified_name.catalog;
-		info->schema = qualified_name.schema;
+		info->catalog = qualified_name.Catalog();
+		info->schema = qualified_name.Schema();
 	}
-	info->name = qualified_name.name;
+	info->name = qualified_name.Name();
 
 	info->on_conflict = if_not_exists ? OnCreateConflict::IGNORE_ON_CONFLICT : OnCreateConflict::ERROR_ON_CONFLICT;
 	for (auto &macro_function : macro_definition) {

--- a/src/parser/peg/transformer/transform_create_schema.cpp
+++ b/src/parser/peg/transformer/transform_create_schema.cpp
@@ -5,14 +5,14 @@ namespace duckdb {
 unique_ptr<CreateStatement> PEGTransformerFactory::TransformCreateSchemaStmt(PEGTransformer &transformer,
                                                                              const optional<bool> &if_not_exists,
                                                                              const QualifiedName &qualified_name) {
-	if (!qualified_name.catalog.empty()) {
+	if (!qualified_name.Catalog().empty()) {
 		throw ParserException("CREATE SCHEMA too many dots: expected \"catalog.schema\" or \"schema\"");
 	}
 	auto result = make_uniq<CreateStatement>();
 	auto info = make_uniq<CreateSchemaInfo>();
 	info->on_conflict = if_not_exists ? OnCreateConflict::IGNORE_ON_CONFLICT : OnCreateConflict::ERROR_ON_CONFLICT;
-	info->catalog = qualified_name.schema;
-	info->schema = qualified_name.name;
+	info->catalog = qualified_name.Schema();
+	info->schema = qualified_name.Name();
 
 	result->info = std::move(info);
 	return result;

--- a/src/parser/peg/transformer/transform_create_sequence.cpp
+++ b/src/parser/peg/transformer/transform_create_sequence.cpp
@@ -9,9 +9,9 @@ unique_ptr<CreateStatement> PEGTransformerFactory::TransformCreateSequenceStmt(
     optional<vector<pair<string, unique_ptr<SequenceOption>>>> sequence_option) {
 	auto result = make_uniq<CreateStatement>();
 	auto info = make_uniq<CreateSequenceInfo>();
-	info->catalog = qualified_name.catalog;
-	info->schema = qualified_name.schema;
-	info->name = qualified_name.name;
+	info->catalog = qualified_name.Catalog();
+	info->schema = qualified_name.Schema();
+	info->name = qualified_name.Name();
 	info->on_conflict = if_not_exists ? OnCreateConflict::IGNORE_ON_CONFLICT : OnCreateConflict::ERROR_ON_CONFLICT;
 	case_insensitive_map_t<unique_ptr<SequenceOption>> sequence_options;
 	if (sequence_option) {

--- a/src/parser/peg/transformer/transform_create_table.cpp
+++ b/src/parser/peg/transformer/transform_create_table.cpp
@@ -186,9 +186,9 @@ PEGTransformerFactory::TransformCreateTableConstraint(PEGTransformer &transforme
 QualifiedName PEGTransformerFactory::TransformIdentifierOrStringLiteral(PEGTransformer &transformer,
                                                                         const string &child) {
 	QualifiedName result;
-	result.Catalog() = INVALID_CATALOG;
-	result.Schema() = INVALID_SCHEMA;
-	result.Name() = Identifier(child);
+	result.CatalogMutable() = INVALID_CATALOG;
+	result.SchemaMutable() = INVALID_SCHEMA;
+	result.NameMutable() = Identifier(child);
 	return result;
 }
 

--- a/src/parser/peg/transformer/transform_create_table.cpp
+++ b/src/parser/peg/transformer/transform_create_table.cpp
@@ -57,11 +57,11 @@ unique_ptr<CreateStatement> PEGTransformerFactory::TransformCreateTableStmt(
     PEGTransformer &transformer, const optional<bool> &if_not_exists, const QualifiedName &qualified_name,
     CreateTableDefinition create_table_definition, const optional<bool> &commit_action) {
 	auto result = make_uniq<CreateStatement>();
-	if (qualified_name.name.empty()) {
+	if (qualified_name.Name().empty()) {
 		throw ParserException("Empty table name not supported");
 	}
 	// Use appropriate constructor
-	auto info = make_uniq<CreateTableInfo>(qualified_name.catalog, qualified_name.schema, qualified_name.name);
+	auto info = make_uniq<CreateTableInfo>(qualified_name.Catalog(), qualified_name.Schema(), qualified_name.Name());
 
 	info->on_conflict = if_not_exists ? OnCreateConflict::IGNORE_ON_CONFLICT : OnCreateConflict::ERROR_ON_CONFLICT;
 	info->query = std::move(create_table_definition.select_statement);
@@ -186,9 +186,9 @@ PEGTransformerFactory::TransformCreateTableConstraint(PEGTransformer &transforme
 QualifiedName PEGTransformerFactory::TransformIdentifierOrStringLiteral(PEGTransformer &transformer,
                                                                         const string &child) {
 	QualifiedName result;
-	result.catalog = INVALID_CATALOG;
-	result.schema = INVALID_SCHEMA;
-	result.name = Identifier(child);
+	result.Catalog() = INVALID_CATALOG;
+	result.Schema() = INVALID_SCHEMA;
+	result.Name() = Identifier(child);
 	return result;
 }
 
@@ -257,7 +257,7 @@ ConstraintColumnDefinition PEGTransformerFactory::TransformColumnDefinition(
 				}
 			} else if (cc_entry.constraint_name == "ForeignKeyConstraint") {
 				auto &fk_constraint = cc_entry.constraint->Cast<ForeignKeyConstraint>();
-				fk_constraint.fk_columns.push_back(qualified_name.name);
+				fk_constraint.fk_columns.push_back(qualified_name.Name());
 				accumulated_constraints.constraints.push_back(std::move(cc_entry.constraint));
 			} else if (cc_entry.constraint_name == "ColumnCollation") {
 				if (has_generated) {
@@ -291,17 +291,17 @@ ConstraintColumnDefinition PEGTransformerFactory::TransformColumnDefinition(
 		auto generated = std::move(*generated_column);
 		if (generated.expr->HasSubquery()) {
 			throw ParserException("Expression of generated column \"%s\" contains a subquery, which isn't allowed",
-			                      qualified_name.name);
+			                      qualified_name.Name());
 		}
 		if (column_type != LogicalType::ANY) {
 			generated.expr = make_uniq<CastExpression>(column_type, std::move(generated.expr));
 		}
 		if (generated.expr->HasSubquery()) {
 			throw ParserException("Expression of generated column \"%s\" contains a subquery, which isn't allowed",
-			                      qualified_name.name);
+			                      qualified_name.Name());
 		}
 
-		ColumnDefinition col(qualified_name.name, column_type, std::move(generated.expr), TableColumnType::GENERATED);
+		ColumnDefinition col(qualified_name.Name(), column_type, std::move(generated.expr), TableColumnType::GENERATED);
 		col.SetCompressionType(compression_type);
 		if (accumulated_constraints.default_value) {
 			throw ParserException("Not allowed to set default on a generated column");
@@ -311,7 +311,7 @@ ConstraintColumnDefinition PEGTransformerFactory::TransformColumnDefinition(
 		return result;
 	}
 
-	ColumnDefinition col(qualified_name.name, column_type);
+	ColumnDefinition col(qualified_name.Name(), column_type);
 
 	if (accumulated_constraints.default_value) {
 		col.SetDefaultValue(std::move(accumulated_constraints.default_value));

--- a/src/parser/peg/transformer/transform_create_type.cpp
+++ b/src/parser/peg/transformer/transform_create_type.cpp
@@ -10,9 +10,9 @@ unique_ptr<CreateStatement> PEGTransformerFactory::TransformCreateTypeStmt(PEGTr
                                                                            const QualifiedName &qualified_name,
                                                                            unique_ptr<CreateTypeInfo> create_type) {
 	auto result = make_uniq<CreateStatement>();
-	create_type->catalog = qualified_name.catalog;
-	create_type->schema = qualified_name.schema;
-	create_type->name = qualified_name.name;
+	create_type->catalog = qualified_name.Catalog();
+	create_type->schema = qualified_name.Schema();
+	create_type->name = qualified_name.Name();
 	create_type->on_conflict =
 	    if_not_exists ? OnCreateConflict::IGNORE_ON_CONFLICT : OnCreateConflict::ERROR_ON_CONFLICT;
 	result->info = std::move(create_type);

--- a/src/parser/peg/transformer/transform_create_view.cpp
+++ b/src/parser/peg/transformer/transform_create_view.cpp
@@ -95,9 +95,9 @@ PEGTransformerFactory::TransformCreateViewStmt(PEGTransformer &transformer, cons
 	auto result = make_uniq<CreateStatement>();
 	auto info = make_uniq<CreateViewInfo>();
 	info->on_conflict = if_not_exists ? OnCreateConflict::IGNORE_ON_CONFLICT : OnCreateConflict::ERROR_ON_CONFLICT;
-	info->catalog = qualified_name.catalog;
-	info->schema = qualified_name.schema;
-	info->view_name = qualified_name.name;
+	info->catalog = qualified_name.Catalog();
+	info->schema = qualified_name.Schema();
+	info->view_name = qualified_name.Name();
 	if (insert_column_list) {
 		info->aliases = StringsToIdentifiers(*insert_column_list);
 	}

--- a/src/parser/peg/transformer/transform_describe.cpp
+++ b/src/parser/peg/transformer/transform_describe.cpp
@@ -27,15 +27,15 @@ unique_ptr<QueryNode> PEGTransformerFactory::TransformShowTables(PEGTransformer 
                                                                  const QualifiedName &qualified_name) {
 	auto showref = make_uniq<ShowRef>();
 	showref->show_type = ShowType::SHOW_FROM;
-	if (!IsInvalidCatalog(qualified_name.catalog)) {
+	if (!IsInvalidCatalog(qualified_name.Catalog())) {
 		throw ParserException("Expected \"SHOW TABLES FROM database\", \"SHOW TABLES FROM schema\", or "
 		                      "\"SHOW TABLES FROM database.schema\"");
 	}
-	if (IsInvalidSchema(qualified_name.schema)) {
-		showref->schema_name = qualified_name.name;
+	if (IsInvalidSchema(qualified_name.Schema())) {
+		showref->schema_name = qualified_name.Name();
 	} else {
-		showref->catalog_name = qualified_name.schema;
-		showref->schema_name = qualified_name.name;
+		showref->catalog_name = qualified_name.Schema();
+		showref->schema_name = qualified_name.Name();
 	}
 	auto select_node = make_uniq<SelectNode>();
 	select_node->select_list.push_back(make_uniq<StarExpression>());

--- a/src/parser/peg/transformer/transform_drop.cpp
+++ b/src/parser/peg/transformer/transform_drop.cpp
@@ -102,8 +102,8 @@ PEGTransformerFactory::TransformDropSchema(PEGTransformer &transformer, const op
 QualifiedName PEGTransformerFactory::TransformQualifiedSchemaNameString(PEGTransformer &transformer,
                                                                         const Identifier &schema_name) {
 	QualifiedName result;
-	result.Catalog() = INVALID_CATALOG;
-	result.Schema() = schema_name;
+	result.CatalogMutable() = INVALID_CATALOG;
+	result.SchemaMutable() = schema_name;
 	return result;
 }
 
@@ -111,8 +111,8 @@ QualifiedName PEGTransformerFactory::TransformCatalogReservedSchema(PEGTransform
                                                                     const Identifier &catalog_qualification,
                                                                     const Identifier &reserved_schema_name) {
 	QualifiedName result;
-	result.Catalog() = catalog_qualification;
-	result.Schema() = reserved_schema_name;
+	result.CatalogMutable() = catalog_qualification;
+	result.SchemaMutable() = reserved_schema_name;
 	return result;
 }
 
@@ -137,9 +137,9 @@ unique_ptr<DropStatement> PEGTransformerFactory::TransformDropIndex(PEGTransform
 QualifiedName PEGTransformerFactory::TransformQualifiedIndexNameString(PEGTransformer &transformer,
                                                                        const Identifier &index_name) {
 	QualifiedName result;
-	result.Catalog() = INVALID_CATALOG;
-	result.Schema() = INVALID_SCHEMA;
-	result.Name() = index_name;
+	result.CatalogMutable() = INVALID_CATALOG;
+	result.SchemaMutable() = INVALID_SCHEMA;
+	result.NameMutable() = index_name;
 	return result;
 }
 
@@ -147,9 +147,9 @@ QualifiedName PEGTransformerFactory::TransformSchemaReservedIndex(PEGTransformer
                                                                   const Identifier &schema_qualification,
                                                                   const Identifier &reserved_index_name) {
 	QualifiedName result;
-	result.Catalog() = INVALID_CATALOG;
-	result.Schema() = schema_qualification;
-	result.Name() = reserved_index_name;
+	result.CatalogMutable() = INVALID_CATALOG;
+	result.SchemaMutable() = schema_qualification;
+	result.NameMutable() = reserved_index_name;
 	return result;
 }
 
@@ -157,9 +157,9 @@ QualifiedName PEGTransformerFactory::TransformCatalogReservedSchemaIndex(
     PEGTransformer &transformer, const Identifier &catalog_qualification,
     const Identifier &reserved_schema_qualification, const Identifier &reserved_index_name) {
 	QualifiedName result;
-	result.Catalog() = catalog_qualification;
-	result.Schema() = reserved_schema_qualification;
-	result.Name() = reserved_index_name;
+	result.CatalogMutable() = catalog_qualification;
+	result.SchemaMutable() = reserved_schema_qualification;
+	result.NameMutable() = reserved_index_name;
 	return result;
 }
 

--- a/src/parser/peg/transformer/transform_drop.cpp
+++ b/src/parser/peg/transformer/transform_drop.cpp
@@ -73,9 +73,9 @@ PEGTransformerFactory::TransformDropFunction(PEGTransformer &transformer, const 
 		throw NotImplementedException("Can only drop one object at a time");
 	}
 	const auto &function = function_identifier[0];
-	info->catalog = function.catalog.empty() ? INVALID_CATALOG : function.catalog;
-	info->schema = function.schema;
-	info->name = function.name;
+	info->catalog = function.Catalog().empty() ? INVALID_CATALOG : function.Catalog();
+	info->schema = function.Schema();
+	info->name = function.Name();
 	info->if_not_found = if_exists ? OnEntryNotFound::RETURN_NULL : OnEntryNotFound::THROW_EXCEPTION;
 	info->type = catalog_type;
 	result->info = std::move(info);
@@ -91,8 +91,8 @@ PEGTransformerFactory::TransformDropSchema(PEGTransformer &transformer, const op
 		throw NotImplementedException("Can only drop one object at a time");
 	}
 	const auto &schema = qualified_schema_name[0];
-	info->catalog = schema.catalog;
-	info->name = schema.schema;
+	info->catalog = schema.Catalog();
+	info->name = schema.Schema();
 	info->if_not_found = if_exists ? OnEntryNotFound::RETURN_NULL : OnEntryNotFound::THROW_EXCEPTION;
 	info->type = CatalogType::SCHEMA_ENTRY;
 	result->info = std::move(info);
@@ -102,8 +102,8 @@ PEGTransformerFactory::TransformDropSchema(PEGTransformer &transformer, const op
 QualifiedName PEGTransformerFactory::TransformQualifiedSchemaNameString(PEGTransformer &transformer,
                                                                         const Identifier &schema_name) {
 	QualifiedName result;
-	result.catalog = INVALID_CATALOG;
-	result.schema = schema_name;
+	result.Catalog() = INVALID_CATALOG;
+	result.Schema() = schema_name;
 	return result;
 }
 
@@ -111,8 +111,8 @@ QualifiedName PEGTransformerFactory::TransformCatalogReservedSchema(PEGTransform
                                                                     const Identifier &catalog_qualification,
                                                                     const Identifier &reserved_schema_name) {
 	QualifiedName result;
-	result.catalog = catalog_qualification;
-	result.schema = reserved_schema_name;
+	result.Catalog() = catalog_qualification;
+	result.Schema() = reserved_schema_name;
 	return result;
 }
 
@@ -125,9 +125,9 @@ unique_ptr<DropStatement> PEGTransformerFactory::TransformDropIndex(PEGTransform
 		throw NotImplementedException("Can only drop one object at a time");
 	}
 	const auto &index = qualified_index_name[0];
-	info->catalog = index.catalog;
-	info->schema = index.schema;
-	info->name = index.name;
+	info->catalog = index.Catalog();
+	info->schema = index.Schema();
+	info->name = index.Name();
 	info->type = CatalogType::INDEX_ENTRY;
 	info->if_not_found = if_exists ? OnEntryNotFound::RETURN_NULL : OnEntryNotFound::THROW_EXCEPTION;
 	result->info = std::move(info);
@@ -137,9 +137,9 @@ unique_ptr<DropStatement> PEGTransformerFactory::TransformDropIndex(PEGTransform
 QualifiedName PEGTransformerFactory::TransformQualifiedIndexNameString(PEGTransformer &transformer,
                                                                        const Identifier &index_name) {
 	QualifiedName result;
-	result.catalog = INVALID_CATALOG;
-	result.schema = INVALID_SCHEMA;
-	result.name = index_name;
+	result.Catalog() = INVALID_CATALOG;
+	result.Schema() = INVALID_SCHEMA;
+	result.Name() = index_name;
 	return result;
 }
 
@@ -147,9 +147,9 @@ QualifiedName PEGTransformerFactory::TransformSchemaReservedIndex(PEGTransformer
                                                                   const Identifier &schema_qualification,
                                                                   const Identifier &reserved_index_name) {
 	QualifiedName result;
-	result.catalog = INVALID_CATALOG;
-	result.schema = schema_qualification;
-	result.name = reserved_index_name;
+	result.Catalog() = INVALID_CATALOG;
+	result.Schema() = schema_qualification;
+	result.Name() = reserved_index_name;
 	return result;
 }
 
@@ -157,9 +157,9 @@ QualifiedName PEGTransformerFactory::TransformCatalogReservedSchemaIndex(
     PEGTransformer &transformer, const Identifier &catalog_qualification,
     const Identifier &reserved_schema_qualification, const Identifier &reserved_index_name) {
 	QualifiedName result;
-	result.catalog = catalog_qualification;
-	result.schema = reserved_schema_qualification;
-	result.name = reserved_index_name;
+	result.Catalog() = catalog_qualification;
+	result.Schema() = reserved_schema_qualification;
+	result.Name() = reserved_index_name;
 	return result;
 }
 
@@ -172,13 +172,13 @@ PEGTransformerFactory::TransformDropSequence(PEGTransformer &transformer, const 
 		throw NotImplementedException("Can only drop one object at a time");
 	}
 	const auto &sequence = qualified_sequence_name[0];
-	if (sequence.schema.empty()) {
-		info->schema = sequence.catalog;
+	if (sequence.Schema().empty()) {
+		info->schema = sequence.Catalog();
 	} else {
-		info->catalog = sequence.catalog;
-		info->schema = sequence.schema;
+		info->catalog = sequence.Catalog();
+		info->schema = sequence.Schema();
 	}
-	info->name = sequence.name;
+	info->name = sequence.Name();
 	info->if_not_found = if_exists ? OnEntryNotFound::RETURN_NULL : OnEntryNotFound::THROW_EXCEPTION;
 	info->type = CatalogType::SEQUENCE_ENTRY;
 	result->info = std::move(info);
@@ -219,13 +219,13 @@ unique_ptr<DropStatement> PEGTransformerFactory::TransformDropType(PEGTransforme
 		throw NotImplementedException("Can only drop one object at a time");
 	}
 	const auto &type = qualified_type_name[0];
-	if (type.schema.empty()) {
-		info->schema = type.catalog;
+	if (type.Schema().empty()) {
+		info->schema = type.Catalog();
 	} else {
-		info->catalog = type.catalog;
-		info->schema = type.schema;
+		info->catalog = type.Catalog();
+		info->schema = type.Schema();
 	}
-	info->name = type.name;
+	info->name = type.Name();
 	info->if_not_found = if_exists ? OnEntryNotFound::RETURN_NULL : OnEntryNotFound::THROW_EXCEPTION;
 	info->type = CatalogType::TYPE_ENTRY;
 	result->info = std::move(info);

--- a/src/parser/peg/transformer/transform_expression.cpp
+++ b/src/parser/peg/transformer/transform_expression.cpp
@@ -174,7 +174,7 @@ unique_ptr<ParsedExpression> PEGTransformerFactory::TransformFunctionExpression(
 		// COUNT(*) gets converted into COUNT()
 		function_children.clear();
 	}
-	auto lowercase_name = StringUtil::Lower(qualified_function.name.GetIdentifierName());
+	auto lowercase_name = StringUtil::Lower(qualified_function.Name().GetIdentifierName());
 
 	if (over_clause) {
 		if (transformer.in_window_definition) {
@@ -192,8 +192,8 @@ unique_ptr<ParsedExpression> PEGTransformerFactory::TransformFunctionExpression(
 
 		transformer.in_window_definition = true;
 		auto expr = std::move(*over_clause);
-		expr->CatalogMutable() = qualified_function.catalog;
-		expr->SchemaMutable() = qualified_function.schema;
+		expr->CatalogMutable() = qualified_function.Catalog();
+		expr->SchemaMutable() = qualified_function.Schema();
 		expr->SetFunctionName(lowercase_name);
 
 		for (auto &arg : function_children) {
@@ -323,12 +323,13 @@ unique_ptr<ParsedExpression> PEGTransformerFactory::TransformFunctionExpression(
 			}
 			lowercase_name = "mode";
 		} else {
-			throw ParserException("Unknown ordered aggregate \"%s\".", qualified_function.name);
+			throw ParserException("Unknown ordered aggregate \"%s\".", qualified_function.Name());
 		}
 	}
-	auto result = make_uniq<FunctionExpression>(
-	    qualified_function.catalog, qualified_function.schema, Identifier(lowercase_name), std::move(function_children),
-	    std::move(filter_expr), std::move(order_modifier), distinct, false, export_clause);
+	auto result =
+	    make_uniq<FunctionExpression>(qualified_function.Catalog(), qualified_function.Schema(),
+	                                  Identifier(lowercase_name), std::move(function_children), std::move(filter_expr),
+	                                  std::move(order_modifier), distinct, false, export_clause);
 
 	return std::move(result);
 }
@@ -371,9 +372,9 @@ QualifiedName PEGTransformerFactory::TransformFunctionIdentifier(PEGTransformer 
                                                                  ParseResult &choice_result) {
 	if (choice_result.type == ParseResultType::IDENTIFIER) {
 		QualifiedName result;
-		result.catalog = INVALID_CATALOG;
-		result.schema = INVALID_SCHEMA;
-		result.name = choice_result.Cast<IdentifierParseResult>().identifier;
+		result.Catalog() = INVALID_CATALOG;
+		result.Schema() = INVALID_SCHEMA;
+		result.Name() = choice_result.Cast<IdentifierParseResult>().identifier;
 		return result;
 	}
 	return transformer.Transform<QualifiedName>(choice_result);
@@ -383,9 +384,9 @@ QualifiedName PEGTransformerFactory::TransformSchemaReservedFunctionName(PEGTran
                                                                          const Identifier &schema_qualification,
                                                                          const Identifier &reserved_function_name) {
 	QualifiedName result;
-	result.catalog = INVALID_CATALOG;
-	result.schema = schema_qualification;
-	result.name = reserved_function_name;
+	result.Catalog() = INVALID_CATALOG;
+	result.Schema() = schema_qualification;
+	result.Name() = reserved_function_name;
 	return result;
 }
 
@@ -394,13 +395,13 @@ QualifiedName PEGTransformerFactory::TransformCatalogReservedSchemaFunctionName(
     const optional<Identifier> &reserved_schema_qualification, const Identifier &reserved_function_name) {
 	QualifiedName result;
 	if (reserved_schema_qualification) {
-		result.catalog = catalog_qualification;
-		result.schema = *reserved_schema_qualification;
+		result.Catalog() = catalog_qualification;
+		result.Schema() = *reserved_schema_qualification;
 	} else {
-		result.catalog = INVALID_CATALOG;
-		result.schema = catalog_qualification;
+		result.Catalog() = INVALID_CATALOG;
+		result.Schema() = catalog_qualification;
 	}
-	result.name = reserved_function_name;
+	result.Name() = reserved_function_name;
 	return result;
 }
 

--- a/src/parser/peg/transformer/transform_expression.cpp
+++ b/src/parser/peg/transformer/transform_expression.cpp
@@ -372,9 +372,9 @@ QualifiedName PEGTransformerFactory::TransformFunctionIdentifier(PEGTransformer 
                                                                  ParseResult &choice_result) {
 	if (choice_result.type == ParseResultType::IDENTIFIER) {
 		QualifiedName result;
-		result.Catalog() = INVALID_CATALOG;
-		result.Schema() = INVALID_SCHEMA;
-		result.Name() = choice_result.Cast<IdentifierParseResult>().identifier;
+		result.CatalogMutable() = INVALID_CATALOG;
+		result.SchemaMutable() = INVALID_SCHEMA;
+		result.NameMutable() = choice_result.Cast<IdentifierParseResult>().identifier;
 		return result;
 	}
 	return transformer.Transform<QualifiedName>(choice_result);
@@ -384,9 +384,9 @@ QualifiedName PEGTransformerFactory::TransformSchemaReservedFunctionName(PEGTran
                                                                          const Identifier &schema_qualification,
                                                                          const Identifier &reserved_function_name) {
 	QualifiedName result;
-	result.Catalog() = INVALID_CATALOG;
-	result.Schema() = schema_qualification;
-	result.Name() = reserved_function_name;
+	result.CatalogMutable() = INVALID_CATALOG;
+	result.SchemaMutable() = schema_qualification;
+	result.NameMutable() = reserved_function_name;
 	return result;
 }
 
@@ -395,13 +395,13 @@ QualifiedName PEGTransformerFactory::TransformCatalogReservedSchemaFunctionName(
     const optional<Identifier> &reserved_schema_qualification, const Identifier &reserved_function_name) {
 	QualifiedName result;
 	if (reserved_schema_qualification) {
-		result.Catalog() = catalog_qualification;
-		result.Schema() = *reserved_schema_qualification;
+		result.CatalogMutable() = catalog_qualification;
+		result.SchemaMutable() = *reserved_schema_qualification;
 	} else {
-		result.Catalog() = INVALID_CATALOG;
-		result.Schema() = catalog_qualification;
+		result.CatalogMutable() = INVALID_CATALOG;
+		result.SchemaMutable() = catalog_qualification;
 	}
-	result.Name() = reserved_function_name;
+	result.NameMutable() = reserved_function_name;
 	return result;
 }
 

--- a/src/parser/peg/transformer/transform_load.cpp
+++ b/src/parser/peg/transformer/transform_load.cpp
@@ -33,7 +33,7 @@ unique_ptr<SQLStatement> PEGTransformerFactory::TransformInstallStatement(
 	auto result = make_uniq<LoadStatement>();
 	auto info = make_uniq<LoadInfo>();
 	info->load_type = LoadType::INSTALL;
-	info->filename = identifier_or_string_literal.name.GetIdentifierName();
+	info->filename = identifier_or_string_literal.Name().GetIdentifierName();
 	info->repo_is_alias = false;
 	if (from_source) {
 		info->repository = from_source->name.GetIdentifierName();
@@ -76,7 +76,7 @@ PEGTransformerFactory::TransformUpdateExtensionsStatement(PEGTransformer &transf
 
 string PEGTransformerFactory::TransformVersionNumber(PEGTransformer &transformer,
                                                      const QualifiedName &identifier_or_string_literal) {
-	return identifier_or_string_literal.name.GetIdentifierName();
+	return identifier_or_string_literal.Name().GetIdentifierName();
 }
 
 } // namespace duckdb

--- a/src/parser/peg/transformer/transform_select.cpp
+++ b/src/parser/peg/transformer/transform_select.cpp
@@ -256,9 +256,9 @@ QualifiedName PEGTransformerFactory::TransformCatalogReservedSchemaIdentifier(
     PEGTransformer &transformer, const Identifier &catalog_qualification,
     const Identifier &reserved_schema_qualification, const Identifier &reserved_identifier_or_string_literal) {
 	QualifiedName result;
-	result.catalog = catalog_qualification;
-	result.schema = reserved_schema_qualification;
-	result.name = reserved_identifier_or_string_literal;
+	result.Catalog() = catalog_qualification;
+	result.Schema() = reserved_schema_qualification;
+	result.Name() = reserved_identifier_or_string_literal;
 	return result;
 }
 
@@ -266,9 +266,9 @@ QualifiedName PEGTransformerFactory::TransformSchemaReservedIdentifierOrStringLi
     PEGTransformer &transformer, const Identifier &schema_qualification,
     const Identifier &reserved_identifier_or_string_literal) {
 	QualifiedName result;
-	result.catalog = INVALID_CATALOG;
-	result.schema = schema_qualification;
-	result.name = reserved_identifier_or_string_literal;
+	result.Catalog() = INVALID_CATALOG;
+	result.Schema() = schema_qualification;
+	result.Name() = reserved_identifier_or_string_literal;
 	return result;
 }
 
@@ -587,8 +587,8 @@ unique_ptr<TableRef> PEGTransformerFactory::TransformTableFunctionLateralOpt(
 	result->with_ordinality =
 	    with_ordinality.value_or(false) ? OrdinalityType::WITH_ORDINALITY : OrdinalityType::WITHOUT_ORDINALITY;
 	result->function =
-	    make_uniq<FunctionExpression>(qualified_table_function.catalog, qualified_table_function.schema,
-	                                  qualified_table_function.name, std::move(table_function_arguments));
+	    make_uniq<FunctionExpression>(qualified_table_function.Catalog(), qualified_table_function.Schema(),
+	                                  qualified_table_function.Name(), std::move(table_function_arguments));
 	if (table_alias) {
 		result->alias = table_alias->name;
 		result->column_name_alias = table_alias->column_name_alias;
@@ -604,8 +604,8 @@ unique_ptr<TableRef> PEGTransformerFactory::TransformTableFunctionAliasColon(
 	result->with_ordinality =
 	    with_ordinality.value_or(false) ? OrdinalityType::WITH_ORDINALITY : OrdinalityType::WITHOUT_ORDINALITY;
 	result->function =
-	    make_uniq<FunctionExpression>(qualified_table_function.catalog, qualified_table_function.schema,
-	                                  qualified_table_function.name, std::move(table_function_arguments));
+	    make_uniq<FunctionExpression>(qualified_table_function.Catalog(), qualified_table_function.Schema(),
+	                                  qualified_table_function.Name(), std::move(table_function_arguments));
 	result->alias = table_alias_colon;
 	if (sample_clause) {
 		result->sample = std::move(*sample_clause);
@@ -1277,13 +1277,13 @@ QualifiedName PEGTransformerFactory::TransformQualifiedTableFunction(PEGTransfor
                                                                      const optional<Identifier> &schema_qualification,
                                                                      const Identifier &table_function_name) {
 	QualifiedName result;
-	result.catalog = catalog_qualification ? *catalog_qualification : INVALID_CATALOG;
-	result.schema = schema_qualification ? *schema_qualification : INVALID_SCHEMA;
-	if (!result.catalog.empty() && result.schema.empty()) {
-		result.schema = result.catalog;
-		result.catalog = INVALID_CATALOG;
+	result.Catalog() = catalog_qualification ? *catalog_qualification : INVALID_CATALOG;
+	result.Schema() = schema_qualification ? *schema_qualification : INVALID_SCHEMA;
+	if (!result.Catalog().empty() && result.Schema().empty()) {
+		result.Schema() = result.Catalog();
+		result.Catalog() = INVALID_CATALOG;
 	}
-	result.name = table_function_name;
+	result.Name() = table_function_name;
 	return result;
 }
 
@@ -1300,7 +1300,7 @@ TableAlias PEGTransformerFactory::TransformTableAliasAs(PEGTransformer &transfor
                                                         const QualifiedName &identifier_or_string_literal,
                                                         const optional<vector<string>> &column_aliases) {
 	TableAlias result;
-	result.name = identifier_or_string_literal.name;
+	result.name = identifier_or_string_literal.Name();
 	if (column_aliases) {
 		result.column_name_alias = StringsToIdentifiers(*column_aliases);
 	}

--- a/src/parser/peg/transformer/transform_select.cpp
+++ b/src/parser/peg/transformer/transform_select.cpp
@@ -256,9 +256,9 @@ QualifiedName PEGTransformerFactory::TransformCatalogReservedSchemaIdentifier(
     PEGTransformer &transformer, const Identifier &catalog_qualification,
     const Identifier &reserved_schema_qualification, const Identifier &reserved_identifier_or_string_literal) {
 	QualifiedName result;
-	result.Catalog() = catalog_qualification;
-	result.Schema() = reserved_schema_qualification;
-	result.Name() = reserved_identifier_or_string_literal;
+	result.CatalogMutable() = catalog_qualification;
+	result.SchemaMutable() = reserved_schema_qualification;
+	result.NameMutable() = reserved_identifier_or_string_literal;
 	return result;
 }
 
@@ -266,9 +266,9 @@ QualifiedName PEGTransformerFactory::TransformSchemaReservedIdentifierOrStringLi
     PEGTransformer &transformer, const Identifier &schema_qualification,
     const Identifier &reserved_identifier_or_string_literal) {
 	QualifiedName result;
-	result.Catalog() = INVALID_CATALOG;
-	result.Schema() = schema_qualification;
-	result.Name() = reserved_identifier_or_string_literal;
+	result.CatalogMutable() = INVALID_CATALOG;
+	result.SchemaMutable() = schema_qualification;
+	result.NameMutable() = reserved_identifier_or_string_literal;
 	return result;
 }
 
@@ -1277,13 +1277,13 @@ QualifiedName PEGTransformerFactory::TransformQualifiedTableFunction(PEGTransfor
                                                                      const optional<Identifier> &schema_qualification,
                                                                      const Identifier &table_function_name) {
 	QualifiedName result;
-	result.Catalog() = catalog_qualification ? *catalog_qualification : INVALID_CATALOG;
-	result.Schema() = schema_qualification ? *schema_qualification : INVALID_SCHEMA;
+	result.CatalogMutable() = catalog_qualification ? *catalog_qualification : INVALID_CATALOG;
+	result.SchemaMutable() = schema_qualification ? *schema_qualification : INVALID_SCHEMA;
 	if (!result.Catalog().empty() && result.Schema().empty()) {
-		result.Schema() = result.Catalog();
-		result.Catalog() = INVALID_CATALOG;
+		result.SchemaMutable() = result.Catalog();
+		result.CatalogMutable() = INVALID_CATALOG;
 	}
-	result.Name() = table_function_name;
+	result.NameMutable() = table_function_name;
 	return result;
 }
 

--- a/src/parser/peg/transformer/transform_use.cpp
+++ b/src/parser/peg/transformer/transform_use.cpp
@@ -7,10 +7,10 @@ namespace duckdb {
 unique_ptr<SQLStatement> PEGTransformerFactory::TransformUseStatement(PEGTransformer &transformer,
                                                                       const QualifiedName &use_target) {
 	string value_str;
-	if (IsInvalidSchema(use_target.schema)) {
-		value_str = SQLIdentifier::ToString(use_target.name.GetIdentifierName());
+	if (IsInvalidSchema(use_target.Schema())) {
+		value_str = SQLIdentifier::ToString(use_target.Name().GetIdentifierName());
 	} else {
-		value_str = SQLIdentifier(use_target.schema) + "." + SQLIdentifier(use_target.name);
+		value_str = SQLIdentifier(use_target.Schema()) + "." + SQLIdentifier(use_target.Name());
 	}
 
 	auto value_expr = make_uniq<ConstantExpression>(Value(value_str));
@@ -21,14 +21,14 @@ unique_ptr<SQLStatement> PEGTransformerFactory::TransformUseStatement(PEGTransfo
 QualifiedName PEGTransformerFactory::TransformSchemaNameAsUseTarget(PEGTransformer &transformer,
                                                                     const Identifier &schema_name) {
 	QualifiedName result;
-	result.name = schema_name;
+	result.Name() = schema_name;
 	return result;
 }
 
 QualifiedName PEGTransformerFactory::TransformCatalogNameAsUseTarget(PEGTransformer &transformer,
                                                                      const Identifier &catalog_name) {
 	QualifiedName result;
-	result.name = catalog_name;
+	result.Name() = catalog_name;
 	return result;
 }
 
@@ -41,9 +41,9 @@ PEGTransformerFactory::TransformUseTargetCatalogSchema(PEGTransformer &transform
 		throw ParserException("Expected \"USE database\" or \"USE database.schema\"");
 	}
 	QualifiedName result;
-	result.catalog = Identifier::InvalidCatalog();
-	result.schema = catalog_name;
-	result.name = reserved_schema_name;
+	result.Catalog() = Identifier::InvalidCatalog();
+	result.Schema() = catalog_name;
+	result.Name() = reserved_schema_name;
 	return result;
 }
 

--- a/src/parser/peg/transformer/transform_use.cpp
+++ b/src/parser/peg/transformer/transform_use.cpp
@@ -21,14 +21,14 @@ unique_ptr<SQLStatement> PEGTransformerFactory::TransformUseStatement(PEGTransfo
 QualifiedName PEGTransformerFactory::TransformSchemaNameAsUseTarget(PEGTransformer &transformer,
                                                                     const Identifier &schema_name) {
 	QualifiedName result;
-	result.Name() = schema_name;
+	result.NameMutable() = schema_name;
 	return result;
 }
 
 QualifiedName PEGTransformerFactory::TransformCatalogNameAsUseTarget(PEGTransformer &transformer,
                                                                      const Identifier &catalog_name) {
 	QualifiedName result;
-	result.Name() = catalog_name;
+	result.NameMutable() = catalog_name;
 	return result;
 }
 
@@ -41,9 +41,9 @@ PEGTransformerFactory::TransformUseTargetCatalogSchema(PEGTransformer &transform
 		throw ParserException("Expected \"USE database\" or \"USE database.schema\"");
 	}
 	QualifiedName result;
-	result.Catalog() = Identifier::InvalidCatalog();
-	result.Schema() = catalog_name;
-	result.Name() = reserved_schema_name;
+	result.CatalogMutable() = Identifier::InvalidCatalog();
+	result.SchemaMutable() = catalog_name;
+	result.NameMutable() = reserved_schema_name;
 	return result;
 }
 

--- a/src/parser/qualified_name.cpp
+++ b/src/parser/qualified_name.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/parser/qualified_name.hpp"
 #include "duckdb/parser/parsed_data/parse_info.hpp"
 #include "duckdb/common/exception/parser_exception.hpp"
+#include "duckdb/common/types/hash.hpp"
 
 namespace duckdb {
 
@@ -46,6 +47,21 @@ end:
 		result.push_back(Identifier(entry));
 	}
 	return result;
+}
+
+hash_t QualifiedName::Hash() const {
+	hash_t result = catalog.Hash();
+	result = CombineHash(result, schema.Hash());
+	result = CombineHash(result, name.Hash());
+	return result;
+}
+
+bool QualifiedName::operator==(const QualifiedName &rhs) const {
+	return catalog == rhs.catalog && schema == rhs.schema && name == rhs.name;
+}
+
+bool QualifiedName::operator!=(const QualifiedName &rhs) const {
+	return !(*this == rhs);
 }
 
 QualifiedName QualifiedName::Parse(const string &input) {

--- a/src/planner/binder/statement/bind_summarize.cpp
+++ b/src/planner/binder/statement/bind_summarize.cpp
@@ -86,9 +86,9 @@ BoundStatement Binder::BindSummarize(ShowRef &ref) {
 		auto node = make_uniq<SelectNode>();
 		node->select_list.push_back(make_uniq<StarExpression>());
 		auto basetableref = make_uniq<BaseTableRef>();
-		basetableref->catalog_name = table_name.catalog;
-		basetableref->schema_name = table_name.schema;
-		basetableref->table_name = table_name.name;
+		basetableref->catalog_name = table_name.Catalog();
+		basetableref->schema_name = table_name.Schema();
+		basetableref->table_name = table_name.Name();
 		node->from_table = std::move(basetableref);
 		query = std::move(node);
 	}

--- a/src/storage/serialization/serialize_parsed_expression.cpp
+++ b/src/storage/serialization/serialize_parsed_expression.cpp
@@ -320,9 +320,9 @@ void TypeExpression::Serialize(Serializer &serializer) const {
 
 unique_ptr<ParsedExpression> TypeExpression::Deserialize(Deserializer &deserializer) {
 	auto result = duckdb::unique_ptr<TypeExpression>(new TypeExpression());
-	deserializer.ReadPropertyWithDefault<Identifier>(200, "catalog", result->qualified_name.Catalog());
-	deserializer.ReadPropertyWithDefault<Identifier>(201, "schema", result->qualified_name.Schema());
-	deserializer.ReadPropertyWithDefault<Identifier>(202, "type_name", result->qualified_name.Name());
+	deserializer.ReadPropertyWithDefault<Identifier>(200, "catalog", result->qualified_name.CatalogMutable());
+	deserializer.ReadPropertyWithDefault<Identifier>(201, "schema", result->qualified_name.SchemaMutable());
+	deserializer.ReadPropertyWithDefault<Identifier>(202, "type_name", result->qualified_name.NameMutable());
 	deserializer.ReadPropertyWithDefault<vector<unique_ptr<ParsedExpression>>>(203, "children", result->children);
 	return std::move(result);
 }

--- a/src/storage/serialization/serialize_parsed_expression.cpp
+++ b/src/storage/serialization/serialize_parsed_expression.cpp
@@ -312,17 +312,17 @@ unique_ptr<ParsedExpression> SubqueryExpression::Deserialize(Deserializer &deser
 
 void TypeExpression::Serialize(Serializer &serializer) const {
 	ParsedExpression::Serialize(serializer);
-	serializer.WritePropertyWithDefault<Identifier>(200, "catalog", catalog);
-	serializer.WritePropertyWithDefault<Identifier>(201, "schema", schema);
-	serializer.WritePropertyWithDefault<Identifier>(202, "type_name", type_name);
+	serializer.WritePropertyWithDefault<Identifier>(200, "catalog", qualified_name.Catalog());
+	serializer.WritePropertyWithDefault<Identifier>(201, "schema", qualified_name.Schema());
+	serializer.WritePropertyWithDefault<Identifier>(202, "type_name", qualified_name.Name());
 	serializer.WritePropertyWithDefault<vector<unique_ptr<ParsedExpression>>>(203, "children", children);
 }
 
 unique_ptr<ParsedExpression> TypeExpression::Deserialize(Deserializer &deserializer) {
 	auto result = duckdb::unique_ptr<TypeExpression>(new TypeExpression());
-	deserializer.ReadPropertyWithDefault<Identifier>(200, "catalog", result->catalog);
-	deserializer.ReadPropertyWithDefault<Identifier>(201, "schema", result->schema);
-	deserializer.ReadPropertyWithDefault<Identifier>(202, "type_name", result->type_name);
+	deserializer.ReadPropertyWithDefault<Identifier>(200, "catalog", result->qualified_name.Catalog());
+	deserializer.ReadPropertyWithDefault<Identifier>(201, "schema", result->qualified_name.Schema());
+	deserializer.ReadPropertyWithDefault<Identifier>(202, "type_name", result->qualified_name.Name());
 	deserializer.ReadPropertyWithDefault<vector<unique_ptr<ParsedExpression>>>(203, "children", result->children);
 	return std::move(result);
 }


### PR DESCRIPTION
Currently many places in our code have a group of several identifiers - generally `catalog`, `schema`, `name`. We already have a grouping for this - `QualifiedName`. If we ever want to change the way we handle this (e.g. for adding support for nested schemas perhaps, hmm) we currently need to change many different places in the code.

This PR makes an initial step in that direction by using `QualifiedName` in various parsed expressions (`FunctionExpression`, `WindowExpression`, `TypeExpression`).