### PR TITLE
bound multi-byte reads in UTF8ToCodepoint

### DIFF
--- a/extension/core_functions/scalar/string/ascii.cpp
+++ b/extension/core_functions/scalar/string/ascii.cpp
@@ -12,7 +12,7 @@ struct AsciiOperator {
 			return str[0];
 		}
 		int utf8_bytes = 4;
-		return Utf8Proc::UTF8ToCodepoint(str, utf8_bytes);
+		return Utf8Proc::UTF8ToCodepoint(str, utf8_bytes, input.GetSize());
 	}
 };
 

--- a/extension/core_functions/scalar/string/translate.cpp
+++ b/extension/core_functions/scalar/string/translate.cpp
@@ -35,10 +35,10 @@ static string_t TranslateScalarFunction(const string_t &haystack, const string_t
 	// Character to be replaced
 	unordered_map<int32_t, int32_t> to_replace;
 	while (i < size_needle && j < size_thread) {
-		auto codepoint_needle = Utf8Proc::UTF8ToCodepoint(input_needle, sz);
+		auto codepoint_needle = Utf8Proc::UTF8ToCodepoint(input_needle, sz, size_needle - i);
 		input_needle += sz;
 		i += UnsafeNumericCast<idx_t>(sz);
-		auto codepoint_thread = Utf8Proc::UTF8ToCodepoint(input_thread, sz);
+		auto codepoint_thread = Utf8Proc::UTF8ToCodepoint(input_thread, sz, size_thread - j);
 		input_thread += sz;
 		j += UnsafeNumericCast<idx_t>(sz);
 		// Ignore unicode character that is existed in to_replace
@@ -50,7 +50,7 @@ static string_t TranslateScalarFunction(const string_t &haystack, const string_t
 	// Character to be deleted
 	unordered_set<int32_t> to_delete;
 	while (i < size_needle) {
-		auto codepoint_needle = Utf8Proc::UTF8ToCodepoint(input_needle, sz);
+		auto codepoint_needle = Utf8Proc::UTF8ToCodepoint(input_needle, sz, size_needle - i);
 		input_needle += sz;
 		i += UnsafeNumericCast<idx_t>(sz);
 		// Add unicode character that will be deleted
@@ -61,7 +61,7 @@ static string_t TranslateScalarFunction(const string_t &haystack, const string_t
 
 	char c[5] = {'\0', '\0', '\0', '\0', '\0'};
 	for (i = 0; i < size_haystack; i += UnsafeNumericCast<idx_t>(sz)) {
-		auto codepoint_haystack = Utf8Proc::UTF8ToCodepoint(input_haystack, sz);
+		auto codepoint_haystack = Utf8Proc::UTF8ToCodepoint(input_haystack, sz, size_haystack - i);
 		if (to_replace.count(codepoint_haystack) != 0) {
 			Utf8Proc::CodepointToUtf8(to_replace[codepoint_haystack], c_sz, c);
 			result.insert(result.end(), c, c + c_sz);

--- a/src/function/scalar/string/caseconvert.cpp
+++ b/src/function/scalar/string/caseconvert.cpp
@@ -39,7 +39,7 @@ static idx_t GetResultLength(const char *input_data, idx_t input_length) {
 
 		// UTF-8.
 		int sz = 0;
-		auto codepoint = Utf8Proc::UTF8ToCodepoint(input_data + i, sz);
+		auto codepoint = Utf8Proc::UTF8ToCodepoint(input_data + i, sz, input_length - i);
 		auto converted = IS_UPPER ? Utf8Proc::CodepointToUpper(codepoint) : Utf8Proc::CodepointToLower(codepoint);
 		auto new_sz = Utf8Proc::CodepointLength(converted);
 		output_length += UnsafeNumericCast<idx_t>(new_sz);
@@ -55,7 +55,7 @@ static void CaseConvert(const char *input_data, idx_t input_length, char *result
 		if (input_data[i] & 0x80) {
 			// non-ascii character
 			int sz = 0, new_sz = 0;
-			auto codepoint = Utf8Proc::UTF8ToCodepoint(input_data + i, sz);
+			auto codepoint = Utf8Proc::UTF8ToCodepoint(input_data + i, sz, input_length - i);
 			auto converted_codepoint =
 			    IS_UPPER ? Utf8Proc::CodepointToUpper(codepoint) : Utf8Proc::CodepointToLower(codepoint);
 			auto success = Utf8Proc::CodepointToUtf8(converted_codepoint, new_sz, result_data);

--- a/test/common/CMakeLists.txt
+++ b/test/common/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library_unity(
   test_strftime.cpp
   test_string_util.cpp
   test_substring_oob.cpp
+  test_utf8_codepoint_oob.cpp
   test_temporary_memory_manager.cpp
   test_value_to_sql_string.cpp)
 

--- a/test/common/test_utf8_codepoint_oob.cpp
+++ b/test/common/test_utf8_codepoint_oob.cpp
@@ -1,0 +1,29 @@
+#include "catch.hpp"
+#include "duckdb/common/helper.hpp"
+#include "duckdb/function/scalar/string_common.hpp"
+
+#include <cstring>
+
+using namespace duckdb;
+
+// upper()/lower() decode each non-ascii character with Utf8Proc::UTF8ToCodepoint, which reads up
+// to 4 bytes based on the leading byte. When a heap-backed (> 12 byte, not null-terminated) string
+// ends in a truncated multi-byte sequence the decoder walks past the end of the buffer. Passing the
+// remaining byte count lets it reject the truncated sequence instead of reading out of bounds.
+TEST_CASE("lower on truncated trailing utf8 sequence stays in bounds", "[utf8]") {
+	for (auto lead : {'\xc2', '\xe0', '\xf0'}) {
+		auto buffer = make_unsafe_uniq_array<char>(20);
+		memset(buffer.get(), 'A', 20);
+		buffer[19] = lead; // multi-byte lead byte with no continuation bytes left in the buffer
+		REQUIRE_THROWS(LowerLength(buffer.get(), 20));
+	}
+}
+
+TEST_CASE("lower on complete trailing utf8 sequence is unchanged", "[utf8]") {
+	// 18 ascii bytes followed by a full 2-byte 'Ä' (U+00C4) at the end of a heap-backed string
+	auto buffer = make_unsafe_uniq_array<char>(20);
+	memset(buffer.get(), 'A', 20);
+	buffer[18] = '\xc3';
+	buffer[19] = '\x84';
+	REQUIRE(LowerLength(buffer.get(), 20) == 20);
+}

--- a/test/common/test_utf8_codepoint_oob.cpp
+++ b/test/common/test_utf8_codepoint_oob.cpp
@@ -1,6 +1,7 @@
 #include "catch.hpp"
 #include "duckdb/common/helper.hpp"
 #include "duckdb/function/scalar/string_common.hpp"
+#include "utf8proc_wrapper.hpp"
 
 #include <cstring>
 
@@ -9,13 +10,15 @@ using namespace duckdb;
 // upper()/lower() decode each non-ascii character with Utf8Proc::UTF8ToCodepoint, which reads up
 // to 4 bytes based on the leading byte. When a heap-backed (> 12 byte, not null-terminated) string
 // ends in a truncated multi-byte sequence the decoder walks past the end of the buffer. Passing the
-// remaining byte count lets it reject the truncated sequence instead of reading out of bounds.
+// remaining byte count lets it reject the truncated sequence instead of reading out of bounds. The
+// same path is reached by the grapheme iterator behind reverse()/length_grapheme().
 TEST_CASE("lower on truncated trailing utf8 sequence stays in bounds", "[utf8]") {
 	for (auto lead : {'\xc2', '\xe0', '\xf0'}) {
 		auto buffer = make_unsafe_uniq_array<char>(20);
 		memset(buffer.get(), 'A', 20);
 		buffer[19] = lead; // multi-byte lead byte with no continuation bytes left in the buffer
 		REQUIRE_THROWS(LowerLength(buffer.get(), 20));
+		REQUIRE_THROWS(Utf8Proc::GraphemeCount(buffer.get(), 20));
 	}
 }
 

--- a/third_party/utf8proc/include/utf8proc_wrapper.hpp
+++ b/third_party/utf8proc/include/utf8proc_wrapper.hpp
@@ -55,7 +55,8 @@ public:
 	//! Returns the codepoint length in bytes when encoded in UTF8
 	static int CodepointLength(int cp);
 	//! Transform a UTF8 string to a codepoint; returns the codepoint and writes the length of the codepoint (in UTF8) to sz
-	static int32_t UTF8ToCodepoint(const char *c, int &sz);
+	//! length is the number of bytes available at c, used to reject truncated multi-byte sequences
+	static int32_t UTF8ToCodepoint(const char *c, int &sz, size_t length);
 	//! Returns the render width of a single character in a string
 	static size_t RenderWidth(const char *s, size_t len, size_t pos);
 	static size_t RenderWidth(const std::string &str);

--- a/third_party/utf8proc/utf8proc_wrapper.cpp
+++ b/third_party/utf8proc/utf8proc_wrapper.cpp
@@ -203,14 +203,14 @@ std::string Utf8Proc::RemoveInvalid(const char *s, size_t len) {
 
 size_t Utf8Proc::NextGraphemeCluster(const char *s, size_t len, size_t cpos) {
 	int sz;
-	auto prev_codepoint = Utf8Proc::UTF8ToCodepoint(s + cpos, sz);
+	auto prev_codepoint = Utf8Proc::UTF8ToCodepoint(s + cpos, sz, len - cpos);
 	utf8proc_int32_t state = 0;
 	while (true) {
 		cpos += sz;
 		if (cpos >= len) {
 			return cpos;
 		}
-		auto next_codepoint = Utf8Proc::UTF8ToCodepoint(s + cpos, sz);
+		auto next_codepoint = Utf8Proc::UTF8ToCodepoint(s + cpos, sz, len - cpos);
 		if (utf8proc_grapheme_break_stateful(prev_codepoint, next_codepoint, &state)) {
 			// found a grapheme break here
 			return cpos;
@@ -358,13 +358,16 @@ int Utf8Proc::CodepointLength(int cp) {
 	throw InternalException("invalid code point detected in Utf8Proc::CodepointLength, likely due to invalid UTF-8");
 }
 
-int32_t Utf8Proc::UTF8ToCodepoint(const char *u_input, int &sz) {
+int32_t Utf8Proc::UTF8ToCodepoint(const char *u_input, int &sz, const size_t length) {
 	// from http://www.zedwood.com/article/cpp-utf8-char-to-codepoint
 	auto u = reinterpret_cast<const unsigned char *>(u_input);
 	unsigned char u0 = u[0];
 	if (u0 <= 127) {
 		sz = 1;
 		return u0;
+	}
+	if (length < 2) {
+		throw InternalException("truncated UTF-8 sequence detected in Utf8Proc::UTF8ToCodepoint");
 	}
 	unsigned char u1 = u[1];
 	if (u0 >= 192 && u0 <= 223) {
@@ -374,10 +377,16 @@ int32_t Utf8Proc::UTF8ToCodepoint(const char *u_input, int &sz) {
 	if (u[0] == 0xed && (u[1] & 0xa0) == 0xa0) {
 		throw InternalException("invalid code point detected in Utf8Proc::UTF8ToCodepoint (0xd800 to 0xdfff), likely due to invalid UTF-8");
 	}
+	if (length < 3) {
+		throw InternalException("truncated UTF-8 sequence detected in Utf8Proc::UTF8ToCodepoint");
+	}
 	unsigned char u2 = u[2];
 	if (u0 >= 224 && u0 <= 239) {
 		sz = 3;
 		return (u0 - 224) * 4096 + (u1 - 128) * 64 + (u2 - 128);
+	}
+	if (length < 4) {
+		throw InternalException("truncated UTF-8 sequence detected in Utf8Proc::UTF8ToCodepoint");
 	}
 	unsigned char u3 = u[3];
 	if (u0 >= 240 && u0 <= 247) {
@@ -389,7 +398,7 @@ int32_t Utf8Proc::UTF8ToCodepoint(const char *u_input, int &sz) {
 
 size_t Utf8Proc::RenderWidth(const char *s, size_t len, size_t pos) {
 	int sz;
-	auto codepoint = Utf8Proc::UTF8ToCodepoint(s + pos, sz);
+	auto codepoint = Utf8Proc::UTF8ToCodepoint(s + pos, sz, len - pos);
 	auto properties = duckdb::utf8proc_get_property(codepoint);
 	return properties->charwidth;
 }
@@ -482,7 +491,9 @@ bool Utf8Proc::FindNextLegalUTF8(string &str) {
 			return true;
 		}
 		int codepoint_size;
-		auto codepoint = Utf8Proc::UTF8ToCodepoint(str.c_str() + last_codepoint_start, codepoint_size) + 1;
+		auto codepoint =
+		    Utf8Proc::UTF8ToCodepoint(str.c_str() + last_codepoint_start, codepoint_size, str.size() - last_codepoint_start) +
+		    1;
 		if (codepoint >= 0xD800 && codepoint <= 0xDFFF) {
 			// incremented codepoint falls within surrogate range; skip to next valid character
 			codepoint = 0xE000;

--- a/third_party/utf8proc/utf8proc_wrapper.cpp
+++ b/third_party/utf8proc/utf8proc_wrapper.cpp
@@ -366,34 +366,37 @@ int32_t Utf8Proc::UTF8ToCodepoint(const char *u_input, int &sz, const size_t len
 		sz = 1;
 		return u0;
 	}
-	if (length < 2) {
-		throw InternalException("truncated UTF-8 sequence detected in Utf8Proc::UTF8ToCodepoint");
+	// work out the sequence length from the lead byte and make sure the continuation bytes are present before
+	// reading them, otherwise a truncated trailing sequence reads past the end of the buffer
+	size_t needed;
+	if (u0 >= 240 && u0 <= 247) {
+		needed = 4;
+	} else if (u0 >= 224 && u0 <= 239) {
+		needed = 3;
+	} else if (u0 >= 192 && u0 <= 223) {
+		needed = 2;
+	} else {
+		throw InvalidInputException("invalid lead byte detected in Utf8Proc::UTF8ToCodepoint, likely due to invalid UTF-8");
+	}
+	if (length < needed) {
+		throw InvalidInputException("truncated UTF-8 sequence detected in Utf8Proc::UTF8ToCodepoint");
 	}
 	unsigned char u1 = u[1];
-	if (u0 >= 192 && u0 <= 223) {
+	if (needed == 2) {
 		sz = 2;
 		return (u0 - 192) * 64 + (u1 - 128);
 	}
-	if (u[0] == 0xed && (u[1] & 0xa0) == 0xa0) {
-		throw InternalException("invalid code point detected in Utf8Proc::UTF8ToCodepoint (0xd800 to 0xdfff), likely due to invalid UTF-8");
-	}
-	if (length < 3) {
-		throw InternalException("truncated UTF-8 sequence detected in Utf8Proc::UTF8ToCodepoint");
+	if (u0 == 0xed && (u1 & 0xa0) == 0xa0) {
+		throw InvalidInputException("invalid code point detected in Utf8Proc::UTF8ToCodepoint (0xd800 to 0xdfff), likely due to invalid UTF-8");
 	}
 	unsigned char u2 = u[2];
-	if (u0 >= 224 && u0 <= 239) {
+	if (needed == 3) {
 		sz = 3;
 		return (u0 - 224) * 4096 + (u1 - 128) * 64 + (u2 - 128);
 	}
-	if (length < 4) {
-		throw InternalException("truncated UTF-8 sequence detected in Utf8Proc::UTF8ToCodepoint");
-	}
 	unsigned char u3 = u[3];
-	if (u0 >= 240 && u0 <= 247) {
-		sz = 4;
-		return (u0 - 240) * 262144 + (u1 - 128) * 4096 + (u2 - 128) * 64 + (u3 - 128);
-	}
-	throw InternalException("invalid code point detected in Utf8Proc::UTF8ToCodepoint, likely due to invalid UTF-8");
+	sz = 4;
+	return (u0 - 240) * 262144 + (u1 - 128) * 4096 + (u2 - 128) * 64 + (u3 - 128);
 }
 
 size_t Utf8Proc::RenderWidth(const char *s, size_t len, size_t pos) {

--- a/tools/shell/linenoise/linenoise.cpp
+++ b/tools/shell/linenoise/linenoise.cpp
@@ -346,7 +346,7 @@ size_t Linenoise::ComputeRenderWidth(const char *buf, size_t len) {
 		}
 
 		// --- 4. Handle UTF-8 grapheme clusters ---
-		int codepoint = duckdb::Utf8Proc::UTF8ToCodepoint(buf + cpos, sz);
+		int codepoint = duckdb::Utf8Proc::UTF8ToCodepoint(buf + cpos, sz, len - cpos);
 		if (codepoint < 0) {
 			// invalid byte, treat as width 1
 			cpos++;
@@ -407,7 +407,7 @@ void Linenoise::NextPosition(const char *buf, size_t len, size_t &cpos, int &row
 	}
 	int sz;
 	int char_render_width;
-	if (duckdb::Utf8Proc::UTF8ToCodepoint(buf + cpos, sz) < 0) {
+	if (duckdb::Utf8Proc::UTF8ToCodepoint(buf + cpos, sz, len - cpos) < 0) {
 		char_render_width = 1;
 		cpos++;
 	} else {


### PR DESCRIPTION
UTF8ToCodepoint reads up to 4 bytes off the leading byte but took no length, so a string ending in a truncated multi-byte sequence reads past the buffer:
- reachable on untrusted varchar via upper/lower, translate, ascii, and the grapheme helpers behind length_grapheme/substring
- a heap-backed (> 12 byte, non-terminated) string ending in a lead byte with missing continuation bytes is a heap-buffer-overflow read (ASan, size 1)
- added a length arg that rejects truncated sequences, passing the remaining byte count at every call site
regression test under test/common reads out of bounds on the unpatched tree under ASan