### PR TITLE
Add a fast path for reading all-NULL columns in Parquet

### DIFF
--- a/benchmark/micro/parquet/read_null_column.benchmark
+++ b/benchmark/micro/parquet/read_null_column.benchmark
@@ -1,0 +1,18 @@
+# name: benchmark/micro/parquet/read_null_column.benchmark
+# description: Read a Parquet column that is entirely NULL (served from statistics as a constant NULL vector)
+# group: [parquet]
+
+name Read NULL Column
+group micro
+subgroup parquet
+
+require parquet
+
+load
+COPY (SELECT range AS i, NULL::BIGINT AS n FROM range(50000000)) TO '${BENCHMARK_DIR}/read_null_column.parquet';
+
+run
+SELECT count(n) FROM '${BENCHMARK_DIR}/read_null_column.parquet';
+
+result I
+0

--- a/extension/parquet/column_reader.cpp
+++ b/extension/parquet/column_reader.cpp
@@ -1,6 +1,7 @@
 #include "column_reader.hpp"
 
 #include "duckdb/common/vector/flat_vector.hpp"
+#include "duckdb/common/vector/constant_vector.hpp"
 
 #include <algorithm>
 #include <memory>
@@ -204,6 +205,19 @@ idx_t ColumnReader::FileOffset() const {
 
 idx_t ColumnReader::GroupRowsAvailable() {
 	return group_rows_available;
+}
+
+bool ColumnReader::AllValuesAreNull() const {
+	// for repeated columns the null_count/num_values statistics do not reliably indicate that every value is NULL
+	// (num_values counts leaf slots, not rows), so we only trust this for non-repeated columns
+	if (MaxRepeat() != 0 || !chunk || !chunk->__isset.meta_data) {
+		return false;
+	}
+	auto &chunk_meta = chunk->meta_data;
+	if (!chunk_meta.__isset.statistics || !chunk_meta.statistics.__isset.null_count) {
+		return false;
+	}
+	return chunk_meta.statistics.null_count == chunk_meta.num_values;
 }
 
 void ColumnReader::PlainSkip(ByteBuffer &plain_data, uint8_t *defines, idx_t num_values) {
@@ -731,6 +745,20 @@ void ColumnReader::ReadData(idx_t read_now, data_ptr_t define_out, data_ptr_t re
 	}
 	// read the defines/repeats
 	const auto all_valid = PrepareRead(read_now, define_out, repeat_out, result_offset);
+	if (!IsRoot() && AllValuesAreNull()) {
+		// every value is NULL: the parent still needs the define/repeat levels we just read, but there are no
+		// values to decode - set the result to NULL and skip the encoding read
+		if (result_offset == 0) {
+			// we own the entire vector - emit a constant NULL
+			ConstantVector::SetNull(result, count_t(read_now));
+		} else {
+			for (idx_t i = 0; i < read_now; i++) {
+				FlatVector::SetNull(result, result_offset + i, true);
+			}
+		}
+		page_rows_available -= read_now;
+		return;
+	}
 	// read the data according to the encoder
 	const auto define_ptr = all_valid ? nullptr : static_cast<uint8_t *>(define_out);
 	switch (encoding) {
@@ -790,6 +818,12 @@ idx_t ColumnReader::ReadInternal(ColumnReaderInput &input, Vector &result) {
 }
 
 idx_t ColumnReader::Read(ColumnReaderInput &input, Vector &result) {
+	if (IsRoot() && AllValuesAreNull()) {
+		// a top-level column that is entirely NULL - emit a constant NULL vector without reading anything.
+		// (nested columns are handled in ReadData: they still need to emit their define/repeat levels)
+		ConstantVector::SetNull(result, count_t(input.num_values));
+		return input.num_values;
+	}
 	BeginRead(input.define_out, input.repeat_out);
 	return ReadInternal(input, result);
 }
@@ -797,7 +831,7 @@ idx_t ColumnReader::Read(ColumnReaderInput &input, Vector &result) {
 void ColumnReader::Select(ColumnReaderInput &input, Vector &result, const SelectionVector &sel,
                           idx_t approved_tuple_count) {
 	auto &num_values = input.num_values;
-	if (SupportsDirectSelect() && approved_tuple_count < num_values) {
+	if (SupportsDirectSelect() && approved_tuple_count < num_values && !(IsRoot() && AllValuesAreNull())) {
 		DirectSelect(input, result, sel, approved_tuple_count);
 		return;
 	}
@@ -834,7 +868,7 @@ void ColumnReader::Filter(ColumnReaderInput &input, Vector &result, const TableF
                           TableFilterState &filter_state, SelectionVector &sel, idx_t &approved_tuple_count,
                           bool is_first_filter) {
 	auto &num_values = input.num_values;
-	if (SupportsDirectFilter() && is_first_filter) {
+	if (SupportsDirectFilter() && is_first_filter && !(IsRoot() && AllValuesAreNull())) {
 		DirectFilter(input, result, filter, filter_state, sel, approved_tuple_count);
 		return;
 	}

--- a/extension/parquet/include/column_reader.hpp
+++ b/extension/parquet/include/column_reader.hpp
@@ -140,6 +140,16 @@ public:
 	inline bool IsSkipped() const {
 		return !chunk;
 	}
+	//! Set the parent reader (the composite reader this reader is a child of). Top-level readers have no parent.
+	void SetParent(ColumnReader &parent_p) {
+		parent = parent_p;
+	}
+	//! Whether this is a top-level reader (i.e. it has no parent reader)
+	bool IsRoot() const {
+		return !parent;
+	}
+	//! Whether every value in the current row group's column chunk is NULL (according to its statistics)
+	bool AllValuesAreNull() const;
 
 	void InitializeCryptoMetadata(const duckdb_parquet::EncryptionAlgorithm &encryption_algorithm,
 	                              idx_t row_group_ordinal_p) {
@@ -364,6 +374,8 @@ private:
 	void DecompressInternal(CompressionCodec::type codec, const_data_ptr_t src, idx_t src_size, data_ptr_t dst,
 	                        idx_t dst_size);
 	const ColumnChunk *chunk = nullptr;
+	//! The composite reader this reader is a child of (struct/list/variant/expression). Null for top-level readers.
+	optional_ptr<ColumnReader> parent;
 
 	TProtocol *protocol;
 	idx_t page_rows_available;

--- a/extension/parquet/reader/expression_column_reader.cpp
+++ b/extension/parquet/reader/expression_column_reader.cpp
@@ -30,6 +30,11 @@ ExpressionColumnReader::ExpressionColumnReader(ClientContext &context, vector<un
 	if (child_readers.empty()) {
 		throw InternalException("Can't instantiate an ExpressionColumnReader with 0 children");
 	}
+	for (auto &child : child_readers) {
+		if (child) {
+			child->SetParent(*this);
+		}
+	}
 	InitializeChunk();
 }
 
@@ -40,6 +45,11 @@ ExpressionColumnReader::ExpressionColumnReader(ClientContext &context, vector<un
       expr(std::move(expr_p)), executor(context, expr.get()), owned_schema(std::move(owned_schema_p)) {
 	if (child_readers.empty()) {
 		throw InternalException("Can't instantiate an ExpressionColumnReader with 0 children");
+	}
+	for (auto &child : child_readers) {
+		if (child) {
+			child->SetParent(*this);
+		}
 	}
 	InitializeChunk();
 }

--- a/extension/parquet/reader/list_column_reader.cpp
+++ b/extension/parquet/reader/list_column_reader.cpp
@@ -200,6 +200,9 @@ ListColumnReader::ListColumnReader(const ParquetReader &reader, const ParquetCol
 	child_repeats.resize(reader.allocator, STANDARD_VECTOR_SIZE);
 	child_defines_ptr = (uint8_t *)child_defines.ptr;
 	child_repeats_ptr = (uint8_t *)child_repeats.ptr;
+	if (child_column_reader) {
+		child_column_reader->SetParent(*this);
+	}
 }
 
 void ListColumnReader::ApplyPendingSkips(data_ptr_t define_out, data_ptr_t repeat_out) {

--- a/extension/parquet/reader/struct_column_reader.cpp
+++ b/extension/parquet/reader/struct_column_reader.cpp
@@ -42,6 +42,11 @@ StructColumnReader::StructColumnReader(const ParquetReader &reader, const Parque
                                        vector<unique_ptr<ColumnReader>> child_readers_p)
     : ColumnReader(reader, schema), child_readers(std::move(child_readers_p)) {
 	D_ASSERT(Type().InternalType() == PhysicalType::STRUCT);
+	for (auto &child : child_readers) {
+		if (child) {
+			child->SetParent(*this);
+		}
+	}
 }
 
 ColumnReader &StructColumnReader::GetChildReader(idx_t child_idx) {

--- a/extension/parquet/reader/variant_column_reader.cpp
+++ b/extension/parquet/reader/variant_column_reader.cpp
@@ -45,6 +45,12 @@ VariantColumnReader::VariantColumnReader(ClientContext &context, const ParquetRe
     : ColumnReader(reader, schema), context(context), child_readers(std::move(child_readers_p)) {
 	D_ASSERT(Type().InternalType() == PhysicalType::STRUCT);
 
+	for (auto &child : child_readers) {
+		if (child) {
+			child->SetParent(*this);
+		}
+	}
+
 	if (child_readers[0]->Schema().name == "metadata" && child_readers[1]->Schema().name == "value") {
 		metadata_reader_idx = 0;
 		value_reader_idx = 1;

--- a/test/sql/copy/parquet/parquet_all_null_column.test
+++ b/test/sql/copy/parquet/parquet_all_null_column.test
@@ -1,0 +1,116 @@
+# name: test/sql/copy/parquet/parquet_all_null_column.test
+# description: Read Parquet columns that are entirely NULL (served as constant NULL from statistics)
+# group: [parquet]
+
+require parquet
+
+# a file with a fully-NULL typed column "n" next to a non-null column "i", spread over multiple row groups
+statement ok
+COPY (SELECT range AS i, NULL::BIGINT AS n FROM range(10000)) TO '{TEST_DIR}/all_null.parquet' (FORMAT PARQUET, ROW_GROUP_SIZE 2048);
+
+# plain projection of the NULL column
+query I
+SELECT count(n) FROM '{TEST_DIR}/all_null.parquet';
+----
+0
+
+query I
+SELECT count(*) FROM '{TEST_DIR}/all_null.parquet' WHERE n IS NULL;
+----
+10000
+
+query I
+SELECT count(*) FROM '{TEST_DIR}/all_null.parquet' WHERE n IS NOT NULL;
+----
+0
+
+# filter directly on the all-NULL column - comparisons against NULL never pass
+query I
+SELECT count(*) FROM '{TEST_DIR}/all_null.parquet' WHERE n > 5;
+----
+0
+
+# the NULL column read alongside a filter on another column (goes through the Select path)
+query II
+SELECT i, n FROM '{TEST_DIR}/all_null.parquet' WHERE i IN (0, 5000, 9999) ORDER BY i;
+----
+0	NULL
+5000	NULL
+9999	NULL
+
+# every value really is NULL
+query I
+SELECT n FROM '{TEST_DIR}/all_null.parquet' WHERE i = 1234;
+----
+NULL
+
+# combining the NULL column with the live column in an expression
+query I
+SELECT count(*) FROM '{TEST_DIR}/all_null.parquet' WHERE coalesce(n, i) = i;
+----
+10000
+
+# different types are all handled
+statement ok
+COPY (SELECT range AS i, NULL::VARCHAR AS s, NULL::DOUBLE AS d, NULL::DATE AS dt FROM range(5000)) TO '{TEST_DIR}/all_null_types.parquet' (FORMAT PARQUET);
+
+query IIII
+SELECT count(i), count(s), count(d), count(dt) FROM '{TEST_DIR}/all_null_types.parquet';
+----
+5000	0	0	0
+
+query III
+SELECT s, d, dt FROM '{TEST_DIR}/all_null_types.parquet' WHERE i = 42;
+----
+NULL	NULL	NULL
+
+# nested: a struct with an all-NULL field must NOT be mis-served (struct validity must be preserved).
+# Here the struct itself is sometimes NULL while its field is always NULL.
+statement ok
+COPY (SELECT i, CASE WHEN i % 2 = 0 THEN {'a': NULL::INTEGER} ELSE NULL END AS s FROM range(10) t(i)) TO '{TEST_DIR}/nested_null.parquet' (FORMAT PARQUET);
+
+query II
+SELECT i, s FROM '{TEST_DIR}/nested_null.parquet' ORDER BY i;
+----
+0	{'a': NULL}
+1	NULL
+2	{'a': NULL}
+3	NULL
+4	{'a': NULL}
+5	NULL
+6	{'a': NULL}
+7	NULL
+8	{'a': NULL}
+9	NULL
+
+# the struct column is NULL for exactly the odd rows, even though field 'a' is always NULL
+query I
+SELECT count(*) FROM '{TEST_DIR}/nested_null.parquet' WHERE s IS NULL;
+----
+5
+
+# a list with all-NULL elements keeps its list structure (lengths) intact
+statement ok
+COPY (SELECT i, [NULL, NULL]::INTEGER[] AS l FROM range(5) t(i)) TO '{TEST_DIR}/list_null.parquet' (FORMAT PARQUET);
+
+query II
+SELECT i, l FROM '{TEST_DIR}/list_null.parquet' ORDER BY i;
+----
+0	[NULL, NULL]
+1	[NULL, NULL]
+2	[NULL, NULL]
+3	[NULL, NULL]
+4	[NULL, NULL]
+
+# regression: a struct field inside a list (a repeated leaf) must NOT be collapsed to NULL. Its
+# null_count == num_values statistic can be true even when non-NULL values are present, because for
+# repeated columns num_values counts leaf slots rather than rows.
+statement ok
+COPY (SELECT i, [{'a': NULL}, {'a': i}, NULL]::STRUCT(a INTEGER)[] AS los FROM range(3) t(i)) TO '{TEST_DIR}/list_of_structs.parquet' (FORMAT PARQUET);
+
+query II
+SELECT i, los FROM '{TEST_DIR}/list_of_structs.parquet' ORDER BY i;
+----
+0	[{'a': NULL}, {'a': 0}, NULL]
+1	[{'a': NULL}, {'a': 1}, NULL]
+2	[{'a': NULL}, {'a': 2}, NULL]


### PR DESCRIPTION
When the stats indicate that a column only contains `NULL` values, we can speed up the reading:

* For root columns we don't need to read defines, we can immediately emit a constant `NULL`
* For non-root columns we still need to read defines, as they are used by their parent, but we can skip actually doing the decoding of the defines as we know all values are `NULL`

This popped up on the profiler when working on variant, since fully shredded variants include a bunch of columns that are fully `NULL`. 
