### PR TITLE
Improve hamming function test coverage

### DIFF
--- a/extension/core_functions/scalar/string/functions.json
+++ b/extension/core_functions/scalar/string/functions.json
@@ -97,7 +97,7 @@
     {
         "name": "hamming",
         "parameters": "s1,s2",
-        "description": "The Hamming distance between to strings, i.e., the number of positions with different characters for two strings of equal length. Strings must be of equal length. Characters of different cases (e.g., `a` and `A`) are considered different.",
+        "description": "The Hamming distance between two strings, i.e., the number of positions with different characters for two strings of equal length. Strings must be of equal length. Characters of different cases (e.g., `a` and `A`) are considered different.",
         "example": "hamming('duck', 'luck')",
         "categories": ["text_similarity"],
         "type": "scalar_function",

--- a/test/sql/function/string/test_mismatches.test
+++ b/test/sql/function/string/test_mismatches.test
@@ -80,6 +80,7 @@ NULL
 statement error
 SELECT mismatches('', '')
 ----
+Invalid Input Error: Mismatch Function: Strings must be of length > 0!
 
 query I
 SELECT mismatches(NULL, s) FROM strings ORDER BY s
@@ -107,26 +108,32 @@ NULL
 statement error
 SELECT mismatches('hoi', 'hallo')
 ----
+Invalid Input Error: Mismatch Function: Strings must be of equal length!
 
 statement error
 SELECT mismatches('hallo', 'hoi')
 ----
+Invalid Input Error: Mismatch Function: Strings must be of equal length!
 
 statement error
 SELECT mismatches('', 'hallo')
 ----
+Invalid Input Error: Mismatch Function: Strings must be of equal length!
 
 statement error
 SELECT mismatches('hi', '')
 ----
+Invalid Input Error: Mismatch Function: Strings must be of equal length!
 
 statement error
 SELECT mismatches('', s) FROM strings ORDER BY s
 ----
+Invalid Input Error: Mismatch Function: Strings must be of equal length!
 
 statement error
 SELECT mismatches(s, '') FROM strings ORDER BY s
 ----
+Invalid Input Error: Mismatch Function: Strings must be of equal length!
 
 
 statement ok
@@ -144,10 +151,12 @@ INSERT INTO strings VALUES ('hello'), ('halo'), (NULL)
 statement error
 SELECT mismatches(s, 'hallo') FROM strings
 ----
+Invalid Input Error: Mismatch Function: Strings must be of equal length!
 
 statement error
 SELECT mismatches('hallo', s) FROM strings
 ----
+Invalid Input Error: Mismatch Function: Strings must be of equal length!
 
 
 
@@ -183,7 +192,9 @@ INSERT INTO strings VALUES ('hello', 'world'), ('hallo', 'ola'), ('hello', ''), 
 statement error
 SELECT s, t, hamming(s, t) hd FROM strings WHERE length(s) = length(t)
 ----
+Invalid Input Error: Mismatch Function: Strings must be of length > 0!
 
 statement error
 SELECT hamming(s, t)  FROM strings
 ----
+Invalid Input Error: Mismatch Function: Strings must be of equal length!


### PR DESCRIPTION
## Description

This pr tightens the sqllogictest coverage for `mismatches`/`hamming` error cases.

The existing test cases checked that invalid inputs errored, but left the expected error output blank. This updates those cases to assert the current `Invalid Input Error` messages thrown by the implementation:
- unequal input lengths
- empty string inputs
It also fixes a small typo in the `hamming` function description: “between to strings” -> “between two strings”.

No behavior changes.

## Tests

- [x] `git diff --check`
- [ ] `build/debug/test/run test/sql/function/string/test_mismatches.test`

I could not run the focused sqllogictest locally because this checkout is missing `build/debug/test/unittest`; the checked-in test runner delegates to that binary.