### PR TITLE
Make profiling printers pluggable through a `ProfilerExtension`, and use this in the CLI to add syntax highlighting to `EXPLAIN (ANALYZE)` output

### DIFF
--- a/src/common/box_renderer.cpp
+++ b/src/common/box_renderer.cpp
@@ -103,6 +103,33 @@ const string &StringResultRenderer::str() {
 	return result;
 }
 
+PrinterResultRenderer::PrinterResultRenderer(OutputStream stream) : stream(stream) {
+}
+
+void PrinterResultRenderer::RenderLayout(const string &text) {
+	Printer::RawPrint(stream, text);
+}
+
+void PrinterResultRenderer::RenderColumnName(const string &text) {
+	Printer::RawPrint(stream, text);
+}
+
+void PrinterResultRenderer::RenderType(const string &text) {
+	Printer::RawPrint(stream, text);
+}
+
+void PrinterResultRenderer::RenderValue(const string &text, const LogicalType &type) {
+	Printer::RawPrint(stream, text);
+}
+
+void PrinterResultRenderer::RenderNull(const string &text, const LogicalType &type) {
+	Printer::RawPrint(stream, text);
+}
+
+void PrinterResultRenderer::RenderFooter(const string &text) {
+	Printer::RawPrint(stream, text);
+}
+
 //===--------------------------------------------------------------------===//
 // Box Renderer Implementation
 //===--------------------------------------------------------------------===//

--- a/src/common/tree_renderer.cpp
+++ b/src/common/tree_renderer.cpp
@@ -9,6 +9,8 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/main/query_profiler.hpp"
+#include "duckdb/main/client_config.hpp"
+#include "duckdb/main/profiler_extension.hpp"
 
 namespace duckdb {
 
@@ -73,17 +75,29 @@ static const ProfilerPrintFormatEntry &LookupProfilerPrintFormat(const string &n
 	                            StringUtil::Join(options, ", "));
 }
 
-ProfilerPrintFormat ProfilerPrintFormat::FromString(const string &name) {
-	// return the canonical (lowercase) name for the matched entry
-	return ProfilerPrintFormat(LookupProfilerPrintFormat(name).name);
-}
-
 unique_ptr<TreeRenderer> TreeRenderer::CreateRenderer(const string &name) {
 	return LookupProfilerPrintFormat(name).create_renderer();
 }
 
 unique_ptr<TreeRenderer> TreeRenderer::CreateRenderer(const ProfilerPrintFormat &format) {
 	return CreateRenderer(format.ToString());
+}
+
+unique_ptr<TreeRenderer> TreeRenderer::CreateRenderer(ClientContext &context, const string &name) {
+	// registered renderers take precedence over the built-in formats
+	auto extension = ProfilerExtension::Find(context, name);
+	if (extension && extension->create_renderer) {
+		return extension->create_renderer(context);
+	}
+	auto renderer = CreateRenderer(name);
+	if (renderer) {
+		renderer->Configure(ClientConfig::GetConfig(context).profiling_renderer_settings);
+	}
+	return renderer;
+}
+
+unique_ptr<TreeRenderer> TreeRenderer::CreateRenderer(ClientContext &context, const ProfilerPrintFormat &format) {
+	return CreateRenderer(context, format.ToString());
 }
 
 } // namespace duckdb

--- a/src/common/tree_renderer.cpp
+++ b/src/common/tree_renderer.cpp
@@ -11,15 +11,20 @@
 #include "duckdb/main/query_profiler.hpp"
 #include "duckdb/main/client_config.hpp"
 #include "duckdb/main/profiler_extension.hpp"
+#include "duckdb/common/box_renderer.hpp"
 
 namespace duckdb {
 
 //===--------------------------------------------------------------------===//
 // Profiler output (base implementations)
 //===--------------------------------------------------------------------===//
-string TreeRenderer::RenderProfiler(const QueryProfiler &profiler) {
+void TreeRenderer::RenderProfiler(const QueryProfiler &profiler, BaseResultRenderer &ss) {
 	// by default, render the profiling node tree using this renderer (covers HTML/GraphViz/Mermaid)
-	return profiler.RenderProfilingNodeTree(*this);
+	profiler.RenderProfilingNodeTree(*this, ss);
+}
+
+unique_ptr<BaseResultRenderer> TreeRenderer::GetPrintRenderer() {
+	return make_uniq<PrinterResultRenderer>();
 }
 
 string TreeRenderer::RenderProfilerDisabled() {

--- a/src/common/tree_renderer/graphviz_tree_renderer.cpp
+++ b/src/common/tree_renderer/graphviz_tree_renderer.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/common/tree_renderer/graphviz_tree_renderer.hpp"
 
+#include "duckdb/common/box_renderer.hpp"
 #include "duckdb/common/pair.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/execution/operator/aggregate/physical_hash_aggregate.hpp"
@@ -59,7 +60,7 @@ void GRAPHVIZTreeRenderer::Render(const Pipeline &op, std::ostream &ss) {
 	ToStream(*tree, ss);
 }
 
-void GRAPHVIZTreeRenderer::ToStreamInternal(RenderTree &root, std::ostream &ss) {
+void GRAPHVIZTreeRenderer::ToStreamInternal(RenderTree &root, BaseResultRenderer &ss) {
 	const string digraph_format = R"(
 digraph G {
     node [shape=box, style=rounded, fontname="Courier New", fontsize=10];

--- a/src/common/tree_renderer/graphviz_tree_renderer.cpp
+++ b/src/common/tree_renderer/graphviz_tree_renderer.cpp
@@ -17,45 +17,45 @@
 namespace duckdb {
 
 string GRAPHVIZTreeRenderer::ToString(const LogicalOperator &op) {
-	duckdb::stringstream ss;
+	StringResultRenderer ss;
 	Render(op, ss);
 	return ss.str();
 }
 
 string GRAPHVIZTreeRenderer::ToString(const PhysicalOperator &op) {
-	duckdb::stringstream ss;
+	StringResultRenderer ss;
 	Render(op, ss);
 	return ss.str();
 }
 
 string GRAPHVIZTreeRenderer::ToString(const ProfilingNode &op) {
-	duckdb::stringstream ss;
+	StringResultRenderer ss;
 	Render(op, ss);
 	return ss.str();
 }
 
 string GRAPHVIZTreeRenderer::ToString(const Pipeline &op) {
-	duckdb::stringstream ss;
+	StringResultRenderer ss;
 	Render(op, ss);
 	return ss.str();
 }
 
-void GRAPHVIZTreeRenderer::Render(const LogicalOperator &op, std::ostream &ss) {
+void GRAPHVIZTreeRenderer::Render(const LogicalOperator &op, BaseResultRenderer &ss) {
 	auto tree = RenderTree::CreateRenderTree(op);
 	ToStream(*tree, ss);
 }
 
-void GRAPHVIZTreeRenderer::Render(const PhysicalOperator &op, std::ostream &ss) {
+void GRAPHVIZTreeRenderer::Render(const PhysicalOperator &op, BaseResultRenderer &ss) {
 	auto tree = RenderTree::CreateRenderTree(op);
 	ToStream(*tree, ss);
 }
 
-void GRAPHVIZTreeRenderer::Render(const ProfilingNode &op, std::ostream &ss) {
+void GRAPHVIZTreeRenderer::Render(const ProfilingNode &op, BaseResultRenderer &ss) {
 	auto tree = RenderTree::CreateRenderTree(op);
 	ToStream(*tree, ss);
 }
 
-void GRAPHVIZTreeRenderer::Render(const Pipeline &op, std::ostream &ss) {
+void GRAPHVIZTreeRenderer::Render(const Pipeline &op, BaseResultRenderer &ss) {
 	auto tree = RenderTree::CreateRenderTree(op);
 	ToStream(*tree, ss);
 }

--- a/src/common/tree_renderer/html_tree_renderer.cpp
+++ b/src/common/tree_renderer/html_tree_renderer.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/common/tree_renderer/html_tree_renderer.hpp"
 
+#include "duckdb/common/box_renderer.hpp"
 #include "duckdb/common/pair.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/execution/operator/aggregate/physical_hash_aggregate.hpp"
@@ -257,7 +258,7 @@ function toggleDisplay(button) {
 	return StringUtil::Format(body_section, CreateTreeRecursive(root, 0, 0));
 }
 
-void HTMLTreeRenderer::ToStreamInternal(RenderTree &root, std::ostream &ss) {
+void HTMLTreeRenderer::ToStreamInternal(RenderTree &root, BaseResultRenderer &ss) {
 	string result;
 	result += CreateHeadSection(root);
 	result += CreateBodySection(root);

--- a/src/common/tree_renderer/html_tree_renderer.cpp
+++ b/src/common/tree_renderer/html_tree_renderer.cpp
@@ -16,45 +16,45 @@
 namespace duckdb {
 
 string HTMLTreeRenderer::ToString(const LogicalOperator &op) {
-	duckdb::stringstream ss;
+	StringResultRenderer ss;
 	Render(op, ss);
 	return ss.str();
 }
 
 string HTMLTreeRenderer::ToString(const PhysicalOperator &op) {
-	duckdb::stringstream ss;
+	StringResultRenderer ss;
 	Render(op, ss);
 	return ss.str();
 }
 
 string HTMLTreeRenderer::ToString(const ProfilingNode &op) {
-	duckdb::stringstream ss;
+	StringResultRenderer ss;
 	Render(op, ss);
 	return ss.str();
 }
 
 string HTMLTreeRenderer::ToString(const Pipeline &op) {
-	duckdb::stringstream ss;
+	StringResultRenderer ss;
 	Render(op, ss);
 	return ss.str();
 }
 
-void HTMLTreeRenderer::Render(const LogicalOperator &op, std::ostream &ss) {
+void HTMLTreeRenderer::Render(const LogicalOperator &op, BaseResultRenderer &ss) {
 	auto tree = RenderTree::CreateRenderTree(op);
 	ToStream(*tree, ss);
 }
 
-void HTMLTreeRenderer::Render(const PhysicalOperator &op, std::ostream &ss) {
+void HTMLTreeRenderer::Render(const PhysicalOperator &op, BaseResultRenderer &ss) {
 	auto tree = RenderTree::CreateRenderTree(op);
 	ToStream(*tree, ss);
 }
 
-void HTMLTreeRenderer::Render(const ProfilingNode &op, std::ostream &ss) {
+void HTMLTreeRenderer::Render(const ProfilingNode &op, BaseResultRenderer &ss) {
 	auto tree = RenderTree::CreateRenderTree(op);
 	ToStream(*tree, ss);
 }
 
-void HTMLTreeRenderer::Render(const Pipeline &op, std::ostream &ss) {
+void HTMLTreeRenderer::Render(const Pipeline &op, BaseResultRenderer &ss) {
 	auto tree = RenderTree::CreateRenderTree(op);
 	ToStream(*tree, ss);
 }

--- a/src/common/tree_renderer/json_tree_renderer.cpp
+++ b/src/common/tree_renderer/json_tree_renderer.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/common/tree_renderer/json_tree_renderer.hpp"
 
+#include "duckdb/common/box_renderer.hpp"
 #include "duckdb/common/pair.hpp"
 #include "duckdb/main/query_profiler.hpp"
 #include "duckdb/common/string_util.hpp"
@@ -95,7 +96,7 @@ static yyjson_mut_val *RenderRecursive(yyjson_mut_doc *doc, RenderTree &tree, id
 	return object;
 }
 
-void JSONTreeRenderer::ToStreamInternal(RenderTree &root, std::ostream &ss) {
+void JSONTreeRenderer::ToStreamInternal(RenderTree &root, BaseResultRenderer &ss) {
 	auto doc = yyjson_mut_doc_new(nullptr);
 	auto result_obj = yyjson_mut_arr(doc);
 	yyjson_mut_doc_set_root(doc, result_obj);

--- a/src/common/tree_renderer/json_tree_renderer.cpp
+++ b/src/common/tree_renderer/json_tree_renderer.cpp
@@ -115,9 +115,9 @@ void JSONTreeRenderer::ToStreamInternal(RenderTree &root, BaseResultRenderer &ss
 	yyjson_mut_doc_free(doc);
 }
 
-string JSONTreeRenderer::RenderProfiler(const QueryProfiler &profiler) {
+void JSONTreeRenderer::RenderProfiler(const QueryProfiler &profiler, BaseResultRenderer &ss) {
 	// the JSON profiler output is the full query profile result tree (including query-level metrics)
-	return profiler.ToJSON();
+	ss << profiler.ToJSON();
 }
 
 string JSONTreeRenderer::RenderProfilerDisabled() {

--- a/src/common/tree_renderer/json_tree_renderer.cpp
+++ b/src/common/tree_renderer/json_tree_renderer.cpp
@@ -21,45 +21,45 @@ using namespace duckdb_yyjson; // NOLINT
 namespace duckdb {
 
 string JSONTreeRenderer::ToString(const LogicalOperator &op) {
-	duckdb::stringstream ss;
+	StringResultRenderer ss;
 	Render(op, ss);
 	return ss.str();
 }
 
 string JSONTreeRenderer::ToString(const PhysicalOperator &op) {
-	duckdb::stringstream ss;
+	StringResultRenderer ss;
 	Render(op, ss);
 	return ss.str();
 }
 
 string JSONTreeRenderer::ToString(const ProfilingNode &op) {
-	duckdb::stringstream ss;
+	StringResultRenderer ss;
 	Render(op, ss);
 	return ss.str();
 }
 
 string JSONTreeRenderer::ToString(const Pipeline &op) {
-	duckdb::stringstream ss;
+	StringResultRenderer ss;
 	Render(op, ss);
 	return ss.str();
 }
 
-void JSONTreeRenderer::Render(const LogicalOperator &op, std::ostream &ss) {
+void JSONTreeRenderer::Render(const LogicalOperator &op, BaseResultRenderer &ss) {
 	auto tree = RenderTree::CreateRenderTree(op);
 	ToStream(*tree, ss);
 }
 
-void JSONTreeRenderer::Render(const PhysicalOperator &op, std::ostream &ss) {
+void JSONTreeRenderer::Render(const PhysicalOperator &op, BaseResultRenderer &ss) {
 	auto tree = RenderTree::CreateRenderTree(op);
 	ToStream(*tree, ss);
 }
 
-void JSONTreeRenderer::Render(const ProfilingNode &op, std::ostream &ss) {
+void JSONTreeRenderer::Render(const ProfilingNode &op, BaseResultRenderer &ss) {
 	auto tree = RenderTree::CreateRenderTree(op);
 	ToStream(*tree, ss);
 }
 
-void JSONTreeRenderer::Render(const Pipeline &op, std::ostream &ss) {
+void JSONTreeRenderer::Render(const Pipeline &op, BaseResultRenderer &ss) {
 	auto tree = RenderTree::CreateRenderTree(op);
 	ToStream(*tree, ss);
 }

--- a/src/common/tree_renderer/mermaid_tree_renderer.cpp
+++ b/src/common/tree_renderer/mermaid_tree_renderer.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/common/tree_renderer/mermaid_tree_renderer.hpp"
 
+#include "duckdb/common/box_renderer.hpp"
 #include "duckdb/common/pair.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/execution/operator/aggregate/physical_hash_aggregate.hpp"
@@ -80,7 +81,7 @@ static string SanitizeMermaidLabel(const string &text) {
 	return result;
 }
 
-void MermaidTreeRenderer::ToStreamInternal(RenderTree &root, std::ostream &ss) {
+void MermaidTreeRenderer::ToStreamInternal(RenderTree &root, BaseResultRenderer &ss) {
 	vector<string> nodes;
 	vector<string> edges;
 

--- a/src/common/tree_renderer/mermaid_tree_renderer.cpp
+++ b/src/common/tree_renderer/mermaid_tree_renderer.cpp
@@ -17,45 +17,45 @@
 namespace duckdb {
 
 string MermaidTreeRenderer::ToString(const LogicalOperator &op) {
-	duckdb::stringstream ss;
+	StringResultRenderer ss;
 	Render(op, ss);
 	return ss.str();
 }
 
 string MermaidTreeRenderer::ToString(const PhysicalOperator &op) {
-	duckdb::stringstream ss;
+	StringResultRenderer ss;
 	Render(op, ss);
 	return ss.str();
 }
 
 string MermaidTreeRenderer::ToString(const ProfilingNode &op) {
-	duckdb::stringstream ss;
+	StringResultRenderer ss;
 	Render(op, ss);
 	return ss.str();
 }
 
 string MermaidTreeRenderer::ToString(const Pipeline &op) {
-	duckdb::stringstream ss;
+	StringResultRenderer ss;
 	Render(op, ss);
 	return ss.str();
 }
 
-void MermaidTreeRenderer::Render(const LogicalOperator &op, std::ostream &ss) {
+void MermaidTreeRenderer::Render(const LogicalOperator &op, BaseResultRenderer &ss) {
 	auto tree = RenderTree::CreateRenderTree(op);
 	ToStream(*tree, ss);
 }
 
-void MermaidTreeRenderer::Render(const PhysicalOperator &op, std::ostream &ss) {
+void MermaidTreeRenderer::Render(const PhysicalOperator &op, BaseResultRenderer &ss) {
 	auto tree = RenderTree::CreateRenderTree(op);
 	ToStream(*tree, ss);
 }
 
-void MermaidTreeRenderer::Render(const ProfilingNode &op, std::ostream &ss) {
+void MermaidTreeRenderer::Render(const ProfilingNode &op, BaseResultRenderer &ss) {
 	auto tree = RenderTree::CreateRenderTree(op);
 	ToStream(*tree, ss);
 }
 
-void MermaidTreeRenderer::Render(const Pipeline &op, std::ostream &ss) {
+void MermaidTreeRenderer::Render(const Pipeline &op, BaseResultRenderer &ss) {
 	auto tree = RenderTree::CreateRenderTree(op);
 	ToStream(*tree, ss);
 }

--- a/src/common/tree_renderer/text_tree_renderer.cpp
+++ b/src/common/tree_renderer/text_tree_renderer.cpp
@@ -554,9 +554,9 @@ string TextTreeRenderer::ExtraInfoSeparator() {
 	return StringUtil::Repeat(string(config.HORIZONTAL), (config.node_render_width - 9));
 }
 
-string TextTreeRenderer::RenderProfiler(const QueryProfiler &profiler) {
+void TextTreeRenderer::RenderProfiler(const QueryProfiler &profiler, BaseResultRenderer &ss) {
 	// the text profiler output is the framed query tree (header, total time, phase timings, operator tree)
-	return profiler.QueryTreeToString();
+	profiler.RenderQueryTree(ss);
 }
 
 } // namespace duckdb

--- a/src/common/tree_renderer/text_tree_renderer.cpp
+++ b/src/common/tree_renderer/text_tree_renderer.cpp
@@ -330,9 +330,35 @@ void TextTreeRenderer::RenderBoxContent(RenderTree &root, BaseResultRenderer &ss
 						}
 					}
 				}
+				// determine the type of this cell: the box title (render_y 0) is the operator name, the
+				// separator line between the title and the extra info is layout, everything else is a value
+				ResultRenderType content_type;
+				if (render_y == 0) {
+					content_type = ResultRenderType::COLUMN_NAME;
+				} else if (render_text == ExtraInfoSeparator()) {
+					content_type = ResultRenderType::LAYOUT;
+				} else {
+					content_type = ResultRenderType::VALUE;
+				}
+				// center the text in the box, rendering the surrounding padding as layout and the text with its type
 				render_text = AdjustTextForRendering(render_text, config.node_render_width - 2);
-				// the box title (operator name) is a column name; the rest of the box is value content
-				ss.Render(render_y == 0 ? ResultRenderType::COLUMN_NAME : ResultRenderType::VALUE, render_text);
+				idx_t content_start = 0;
+				while (content_start < render_text.size() && render_text[content_start] == ' ') {
+					content_start++;
+				}
+				idx_t content_end = render_text.size();
+				while (content_end > content_start && render_text[content_end - 1] == ' ') {
+					content_end--;
+				}
+				if (content_start > 0) {
+					ss << render_text.substr(0, content_start);
+				}
+				if (content_end > content_start) {
+					ss.Render(content_type, render_text.substr(content_start, content_end - content_start));
+				}
+				if (content_end < render_text.size()) {
+					ss << render_text.substr(content_end);
+				}
 
 				if (render_y == halfway_point && NodeHasMultipleChildren(*node)) {
 					ss << config.LMIDDLE;

--- a/src/common/tree_renderer/text_tree_renderer.cpp
+++ b/src/common/tree_renderer/text_tree_renderer.cpp
@@ -346,45 +346,45 @@ void TextTreeRenderer::RenderBoxContent(RenderTree &root, BaseResultRenderer &ss
 }
 
 string TextTreeRenderer::ToString(const LogicalOperator &op) {
-	duckdb::stringstream ss;
+	StringResultRenderer ss;
 	Render(op, ss);
 	return ss.str();
 }
 
 string TextTreeRenderer::ToString(const PhysicalOperator &op) {
-	duckdb::stringstream ss;
+	StringResultRenderer ss;
 	Render(op, ss);
 	return ss.str();
 }
 
 string TextTreeRenderer::ToString(const ProfilingNode &op) {
-	duckdb::stringstream ss;
+	StringResultRenderer ss;
 	Render(op, ss);
 	return ss.str();
 }
 
 string TextTreeRenderer::ToString(const Pipeline &op) {
-	duckdb::stringstream ss;
+	StringResultRenderer ss;
 	Render(op, ss);
 	return ss.str();
 }
 
-void TextTreeRenderer::Render(const LogicalOperator &op, std::ostream &ss) {
+void TextTreeRenderer::Render(const LogicalOperator &op, BaseResultRenderer &ss) {
 	auto tree = RenderTree::CreateRenderTree(op);
 	ToStream(*tree, ss);
 }
 
-void TextTreeRenderer::Render(const PhysicalOperator &op, std::ostream &ss) {
+void TextTreeRenderer::Render(const PhysicalOperator &op, BaseResultRenderer &ss) {
 	auto tree = RenderTree::CreateRenderTree(op);
 	ToStream(*tree, ss);
 }
 
-void TextTreeRenderer::Render(const ProfilingNode &op, std::ostream &ss) {
+void TextTreeRenderer::Render(const ProfilingNode &op, BaseResultRenderer &ss) {
 	auto tree = RenderTree::CreateRenderTree(op);
 	ToStream(*tree, ss);
 }
 
-void TextTreeRenderer::Render(const Pipeline &op, std::ostream &ss) {
+void TextTreeRenderer::Render(const Pipeline &op, BaseResultRenderer &ss) {
 	auto tree = RenderTree::CreateRenderTree(op);
 	ToStream(*tree, ss);
 }

--- a/src/common/tree_renderer/text_tree_renderer.cpp
+++ b/src/common/tree_renderer/text_tree_renderer.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/common/tree_renderer/text_tree_renderer.hpp"
 
+#include "duckdb/common/box_renderer.hpp"
 #include "duckdb/common/pair.hpp"
 #include "duckdb/main/query_profiler.hpp"
 #include "duckdb/common/string_util.hpp"
@@ -50,7 +51,7 @@ void TextTreeRenderer::Configure(const unordered_map<string, Value> &settings) {
 	}
 }
 
-void TextTreeRenderer::RenderTopLayer(RenderTree &root, std::ostream &ss, idx_t y) {
+void TextTreeRenderer::RenderTopLayer(RenderTree &root, BaseResultRenderer &ss, idx_t y) {
 	for (idx_t x = 0; x < root.width; x++) {
 		if (x * config.node_render_width >= config.maximum_render_width) {
 			break;
@@ -110,7 +111,7 @@ static bool ShouldRenderWhitespace(RenderTree &root, idx_t x, idx_t y) {
 	return false;
 }
 
-void TextTreeRenderer::RenderBottomLayer(RenderTree &root, std::ostream &ss, idx_t y) {
+void TextTreeRenderer::RenderBottomLayer(RenderTree &root, BaseResultRenderer &ss, idx_t y) {
 	for (idx_t x = 0; x <= root.width; x++) {
 		if (x * config.node_render_width >= config.maximum_render_width) {
 			break;
@@ -219,7 +220,7 @@ string TextTreeRenderer::FormatNumber(const string &input) {
 	return result;
 }
 
-void TextTreeRenderer::RenderBoxContent(RenderTree &root, std::ostream &ss, idx_t y) {
+void TextTreeRenderer::RenderBoxContent(RenderTree &root, BaseResultRenderer &ss, idx_t y) {
 	// we first need to figure out how high our boxes are going to be
 	vector<vector<string>> extra_info;
 	idx_t extra_height = 0;
@@ -330,7 +331,8 @@ void TextTreeRenderer::RenderBoxContent(RenderTree &root, std::ostream &ss, idx_
 					}
 				}
 				render_text = AdjustTextForRendering(render_text, config.node_render_width - 2);
-				ss << render_text;
+				// the box title (operator name) is a column name; the rest of the box is value content
+				ss.Render(render_y == 0 ? ResultRenderType::COLUMN_NAME : ResultRenderType::VALUE, render_text);
 
 				if (render_y == halfway_point && NodeHasMultipleChildren(*node)) {
 					ss << config.LMIDDLE;
@@ -387,7 +389,7 @@ void TextTreeRenderer::Render(const Pipeline &op, std::ostream &ss) {
 	ToStream(*tree, ss);
 }
 
-void TextTreeRenderer::ToStreamInternal(RenderTree &root, std::ostream &ss) {
+void TextTreeRenderer::ToStreamInternal(RenderTree &root, BaseResultRenderer &ss) {
 	while (root.width * config.node_render_width > config.maximum_render_width) {
 		if (config.node_render_width - 2 < config.minimum_render_width) {
 			break;

--- a/src/common/tree_renderer/tree_renderer.cpp
+++ b/src/common/tree_renderer/tree_renderer.cpp
@@ -10,11 +10,4 @@ void TreeRenderer::ToStream(RenderTree &root, BaseResultRenderer &ss) {
 	ToStreamInternal(root, ss);
 }
 
-void TreeRenderer::ToStream(RenderTree &root, std::ostream &ss) {
-	// bridge for plain-text consumers: render into a string sink and emit the result
-	StringResultRenderer renderer;
-	ToStream(root, renderer);
-	ss << renderer.str();
-}
-
 } // namespace duckdb

--- a/src/common/tree_renderer/tree_renderer.cpp
+++ b/src/common/tree_renderer/tree_renderer.cpp
@@ -1,12 +1,20 @@
 #include "duckdb/common/tree_renderer.hpp"
+#include "duckdb/common/box_renderer.hpp"
 
 namespace duckdb {
 
-void TreeRenderer::ToStream(RenderTree &root, std::ostream &ss) {
+void TreeRenderer::ToStream(RenderTree &root, BaseResultRenderer &ss) {
 	if (!UsesRawKeyNames()) {
 		root.SanitizeKeyNames();
 	}
-	return ToStreamInternal(root, ss);
+	ToStreamInternal(root, ss);
+}
+
+void TreeRenderer::ToStream(RenderTree &root, std::ostream &ss) {
+	// bridge for plain-text consumers: render into a string sink and emit the result
+	StringResultRenderer renderer;
+	ToStream(root, renderer);
+	ss << renderer.str();
 }
 
 } // namespace duckdb

--- a/src/common/tree_renderer/yaml_tree_renderer.cpp
+++ b/src/common/tree_renderer/yaml_tree_renderer.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/common/tree_renderer/yaml_tree_renderer.hpp"
 
+#include "duckdb/common/box_renderer.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/typedefs.hpp"
 #include "duckdb/execution/physical_operator.hpp"
@@ -56,8 +57,11 @@ void YAMLTreeRenderer::Render(const Pipeline &op, std::ostream &ss) {
 	ToStream(*tree, ss);
 }
 
-void YAMLTreeRenderer::ToStreamInternal(RenderTree &root, std::ostream &ss) {
-	RenderRecursive(root, ss, 0, 0, 0);
+void YAMLTreeRenderer::ToStreamInternal(RenderTree &root, BaseResultRenderer &ss) {
+	// the YAML output is built with an ostream (using the EscapedString operator) and emitted as layout text
+	duckdb::stringstream result;
+	RenderRecursive(root, result, 0, 0, 0);
+	ss << result.str();
 }
 
 struct EscapedString {

--- a/src/common/tree_renderer/yaml_tree_renderer.cpp
+++ b/src/common/tree_renderer/yaml_tree_renderer.cpp
@@ -8,109 +8,95 @@
 #include "duckdb/planner/logical_operator.hpp"
 #include "fmt/printf.h"
 
-#include <ostream>
-#include <sstream>
-
 namespace duckdb {
 
 string YAMLTreeRenderer::ToString(const LogicalOperator &op) {
-	std::stringstream ss;
+	StringResultRenderer ss;
 	Render(op, ss);
 	return ss.str();
 }
 
 string YAMLTreeRenderer::ToString(const PhysicalOperator &op) {
-	std::stringstream ss;
+	StringResultRenderer ss;
 	Render(op, ss);
 	return ss.str();
 }
 
 string YAMLTreeRenderer::ToString(const ProfilingNode &op) {
-	std::stringstream ss;
+	StringResultRenderer ss;
 	Render(op, ss);
 	return ss.str();
 }
 
 string YAMLTreeRenderer::ToString(const Pipeline &op) {
-	std::stringstream ss;
+	StringResultRenderer ss;
 	Render(op, ss);
 	return ss.str();
 }
 
-void YAMLTreeRenderer::Render(const LogicalOperator &op, std::ostream &ss) {
+void YAMLTreeRenderer::Render(const LogicalOperator &op, BaseResultRenderer &ss) {
 	auto tree = RenderTree::CreateRenderTree(op);
 	ToStream(*tree, ss);
 }
 
-void YAMLTreeRenderer::Render(const PhysicalOperator &op, std::ostream &ss) {
+void YAMLTreeRenderer::Render(const PhysicalOperator &op, BaseResultRenderer &ss) {
 	auto tree = RenderTree::CreateRenderTree(op);
 	ToStream(*tree, ss);
 }
 
-void YAMLTreeRenderer::Render(const ProfilingNode &op, std::ostream &ss) {
+void YAMLTreeRenderer::Render(const ProfilingNode &op, BaseResultRenderer &ss) {
 	auto tree = RenderTree::CreateRenderTree(op);
 	ToStream(*tree, ss);
 }
 
-void YAMLTreeRenderer::Render(const Pipeline &op, std::ostream &ss) {
+void YAMLTreeRenderer::Render(const Pipeline &op, BaseResultRenderer &ss) {
 	auto tree = RenderTree::CreateRenderTree(op);
 	ToStream(*tree, ss);
 }
 
 void YAMLTreeRenderer::ToStreamInternal(RenderTree &root, BaseResultRenderer &ss) {
-	// the YAML output is built with an ostream (using the EscapedString operator) and emitted as layout text
-	duckdb::stringstream result;
-	RenderRecursive(root, result, 0, 0, 0);
-	ss << result.str();
+	RenderRecursive(root, ss, 0, 0, 0);
 }
 
-struct EscapedString {
-	explicit EscapedString(const string &str) : str(str) {};
-	const string &str;
-};
-
-std::ostream &operator<<(std::ostream &out, const EscapedString &es) {
-	out << '"';
-
-	// escape
-	for (auto &ch : es.str) {
+static string EscapedString(const string &str) {
+	string out = "\"";
+	for (auto &ch : str) {
 		switch (ch) {
 		case '\b':
-			out << "\\b";
+			out += "\\b";
 			break;
 		case '\f':
-			out << "\\f";
+			out += "\\f";
 			break;
 		case '\n':
-			out << "\\n";
+			out += "\\n";
 			break;
 		case '\r':
-			out << "\\r";
+			out += "\\r";
 			break;
 		case '\t':
-			out << "\\t";
+			out += "\\t";
 			break;
 		case '"':
-			out << "\\\"";
+			out += "\\\"";
 			break;
 		case '\\':
-			out << "\\\\";
+			out += "\\\\";
 			break;
 		default:
 			if ((unsigned char)ch < ' ') {
-				out << duckdb_fmt::sprintf("\\u%04x", (int)ch);
+				out += duckdb_fmt::sprintf("\\u%04x", (int)ch);
 			} else {
-				out << ch;
+				out += ch;
 			}
 			break;
 		}
 	}
-
-	out << '"';
+	out += "\"";
 	return out;
 }
 
-void YAMLTreeRenderer::RenderRecursive(RenderTree &node, std::ostream &ss, idx_t indent, idx_t x, idx_t y) {
+void YAMLTreeRenderer::RenderRecursive(RenderTree &node, BaseResultRenderer &ss, idx_t indent, idx_t x, idx_t y) {
 	auto node_p = node.GetNode(x, y);
 	D_ASSERT(node_p);
 	auto &current_node = *node_p;

--- a/src/execution/physical_operator.cpp
+++ b/src/execution/physical_operator.cpp
@@ -29,8 +29,8 @@ string PhysicalOperator::GetName() const {
 	return PhysicalOperatorToString(type);
 }
 
-string PhysicalOperator::ToString(const ProfilerPrintFormat &format) const {
-	auto renderer = TreeRenderer::CreateRenderer(format);
+string PhysicalOperator::ToString(optional_ptr<ClientContext> context, const ProfilerPrintFormat &format) const {
+	auto renderer = context ? TreeRenderer::CreateRenderer(*context, format) : TreeRenderer::CreateRenderer(format);
 	if (!renderer) {
 		// formats without output (e.g. "no_output") render nothing
 		return string();

--- a/src/execution/physical_operator.cpp
+++ b/src/execution/physical_operator.cpp
@@ -3,6 +3,7 @@
 #include "duckdb/function/table_function.hpp"
 
 #include "duckdb/common/printer.hpp"
+#include "duckdb/common/box_renderer.hpp"
 #include "duckdb/common/render_tree.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/tree_renderer.hpp"
@@ -35,7 +36,7 @@ string PhysicalOperator::ToString(optional_ptr<ClientContext> context, const Pro
 		// formats without output (e.g. "no_output") render nothing
 		return string();
 	}
-	stringstream ss;
+	StringResultRenderer ss;
 	auto tree = RenderTree::CreateRenderTree(*this);
 	renderer->ToStream(*tree, ss);
 	return ss.str();

--- a/src/execution/physical_plan/plan_explain.cpp
+++ b/src/execution/physical_plan/plan_explain.cpp
@@ -10,7 +10,7 @@ namespace duckdb {
 
 PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalExplain &op) {
 	D_ASSERT(op.children.size() == 1);
-	auto logical_plan_opt = op.children[0]->ToString(op.format);
+	auto logical_plan_opt = op.children[0]->ToString(context, op.format);
 	auto &plan = CreatePlan(*op.children[0]);
 	if (op.explain_type == ExplainType::EXPLAIN_ANALYZE) {
 		auto &explain = Make<PhysicalExplainAnalyze>(op.types, op.format);
@@ -19,7 +19,7 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalExplain &op) {
 	}
 
 	// Format the plan and set the output of the EXPLAIN.
-	op.physical_plan = plan.ToString(op.format);
+	op.physical_plan = plan.ToString(context, op.format);
 	vector<string> keys, values;
 	switch (Settings::Get<ExplainOutputSetting>(context)) {
 	case ExplainOutputType::OPTIMIZED_ONLY:

--- a/src/include/duckdb/common/box_renderer.hpp
+++ b/src/include/duckdb/common/box_renderer.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb/common/constants.hpp"
 #include "duckdb/common/vector.hpp"
+#include "duckdb/common/printer.hpp"
 #include "duckdb/main/query_profiler.hpp"
 #include "duckdb/common/list.hpp"
 #include "duckdb/common/column_data_collection_render_interface.hpp"
@@ -67,6 +68,22 @@ public:
 
 private:
 	string result;
+};
+
+//! A result renderer that prints directly to an output stream (stdout/stderr) as it renders.
+class PrinterResultRenderer : public BaseResultRenderer {
+public:
+	explicit PrinterResultRenderer(OutputStream stream = OutputStream::STREAM_STDERR);
+
+	void RenderLayout(const string &text) override;
+	void RenderColumnName(const string &text) override;
+	void RenderType(const string &text) override;
+	void RenderValue(const string &text, const LogicalType &type) override;
+	void RenderNull(const string &text, const LogicalType &type) override;
+	void RenderFooter(const string &text) override;
+
+private:
+	OutputStream stream;
 };
 
 enum class LargeNumberRendering {

--- a/src/include/duckdb/common/tree_renderer.hpp
+++ b/src/include/duckdb/common/tree_renderer.hpp
@@ -35,6 +35,11 @@ public:
 	//! Render the tree into a BaseResultRenderer (e.g. a StringResultRenderer, or a highlighting-aware sink)
 	void ToStream(RenderTree &root, BaseResultRenderer &ss);
 	virtual void ToStreamInternal(RenderTree &root, BaseResultRenderer &ss) = 0;
+
+	//! Returns the sink to render into when printing this format's output directly. Only invoked when we are about
+	//! to print (the default renderer writes straight to the output stream), so it is never created for the
+	//! string-producing paths. Formats can override this to provide a highlighting-aware sink.
+	virtual unique_ptr<BaseResultRenderer> GetPrintRenderer();
 	//! Create a renderer for the given format, consulting the pluggable registry and configuring built-ins from the
 	//! client's "profiling_renderer_settings". Matched case-insensitively; throws if unknown, nullptr for "no_output".
 	static unique_ptr<TreeRenderer> CreateRenderer(ClientContext &context, const string &name);
@@ -56,9 +61,9 @@ public:
 	virtual void Render(const ProfilingNode &op, BaseResultRenderer &ss) {
 	}
 
-	//! Render the profiler's output in this format. Only called when profiling is enabled. The base implementation
-	//! renders the profiling node tree; formats with richer output (text, JSON) override this.
-	virtual string RenderProfiler(const QueryProfiler &profiler);
+	//! Render the profiler's output into the given sink. Only called when profiling is enabled. The base
+	//! implementation renders the profiling node tree; formats with richer output (text, JSON) override this.
+	virtual void RenderProfiler(const QueryProfiler &profiler, BaseResultRenderer &ss);
 	//! The message shown (in this format) when profiling is disabled.
 	virtual string RenderProfilerDisabled();
 };

--- a/src/include/duckdb/common/tree_renderer.hpp
+++ b/src/include/duckdb/common/tree_renderer.hpp
@@ -32,10 +32,8 @@ public:
 	}
 
 public:
-	//! Render the tree into a BaseResultRenderer - the primary sink, enabling highlighting-aware output
+	//! Render the tree into a BaseResultRenderer (e.g. a StringResultRenderer, or a highlighting-aware sink)
 	void ToStream(RenderTree &root, BaseResultRenderer &ss);
-	//! Render the tree into a plain ostream (bridges to the BaseResultRenderer path via a StringResultRenderer)
-	void ToStream(RenderTree &root, std::ostream &ss);
 	virtual void ToStreamInternal(RenderTree &root, BaseResultRenderer &ss) = 0;
 	//! Create a renderer for the given format, consulting the pluggable registry and configuring built-ins from the
 	//! client's "profiling_renderer_settings". Matched case-insensitively; throws if unknown, nullptr for "no_output".
@@ -55,7 +53,7 @@ public:
 	virtual bool UsesRawKeyNames() {
 		return false;
 	}
-	virtual void Render(const ProfilingNode &op, std::ostream &ss) {
+	virtual void Render(const ProfilingNode &op, BaseResultRenderer &ss) {
 	}
 
 	//! Render the profiler's output in this format. Only called when profiling is enabled. The base implementation

--- a/src/include/duckdb/common/tree_renderer.hpp
+++ b/src/include/duckdb/common/tree_renderer.hpp
@@ -17,6 +17,7 @@
 
 namespace duckdb {
 
+class BaseResultRenderer;
 class ClientContext;
 class QueryProfiler;
 
@@ -31,8 +32,11 @@ public:
 	}
 
 public:
+	//! Render the tree into a BaseResultRenderer - the primary sink, enabling highlighting-aware output
+	void ToStream(RenderTree &root, BaseResultRenderer &ss);
+	//! Render the tree into a plain ostream (bridges to the BaseResultRenderer path via a StringResultRenderer)
 	void ToStream(RenderTree &root, std::ostream &ss);
-	virtual void ToStreamInternal(RenderTree &root, std::ostream &ss) = 0;
+	virtual void ToStreamInternal(RenderTree &root, BaseResultRenderer &ss) = 0;
 	//! Create a renderer for the given format, consulting the pluggable registry and configuring built-ins from the
 	//! client's "profiling_renderer_settings". Matched case-insensitively; throws if unknown, nullptr for "no_output".
 	static unique_ptr<TreeRenderer> CreateRenderer(ClientContext &context, const string &name);

--- a/src/include/duckdb/common/tree_renderer.hpp
+++ b/src/include/duckdb/common/tree_renderer.hpp
@@ -17,6 +17,7 @@
 
 namespace duckdb {
 
+class ClientContext;
 class QueryProfiler;
 
 //! TreeRenderer renders a plan/operator tree (for EXPLAIN) or a query profiler's output in a particular format.
@@ -32,11 +33,13 @@ public:
 public:
 	void ToStream(RenderTree &root, std::ostream &ss);
 	virtual void ToStreamInternal(RenderTree &root, std::ostream &ss) = 0;
-	//! Create a TreeRenderer for the given format name (e.g. "json", "text"). The name is matched case-insensitively
-	//! and throws if it is not recognized. Returns nullptr for formats that render no output (i.e. "no_output").
-	//! This is the primary, name-based factory; new render formats are added here.
+	//! Create a renderer for the given format, consulting the pluggable registry and configuring built-ins from the
+	//! client's "profiling_renderer_settings". Matched case-insensitively; throws if unknown, nullptr for "no_output".
+	static unique_ptr<TreeRenderer> CreateRenderer(ClientContext &context, const string &name);
+	static unique_ptr<TreeRenderer> CreateRenderer(ClientContext &context, const ProfilerPrintFormat &format);
+
+	//! Create a built-in renderer without configuring it or consulting the registry (no ClientContext available)
 	static unique_ptr<TreeRenderer> CreateRenderer(const string &name);
-	//! Create a TreeRenderer for the given ProfilerPrintFormat (thin wrapper over the name-based factory).
 	static unique_ptr<TreeRenderer> CreateRenderer(const ProfilerPrintFormat &format);
 
 	//! Generic configuration of the renderer: passes renderer settings (e.g. from the "profiling_renderer_settings"

--- a/src/include/duckdb/common/tree_renderer/graphviz_tree_renderer.hpp
+++ b/src/include/duckdb/common/tree_renderer/graphviz_tree_renderer.hpp
@@ -38,7 +38,7 @@ public:
 	void Render(const ProfilingNode &op, std::ostream &ss) override;
 	void Render(const Pipeline &op, std::ostream &ss);
 
-	void ToStreamInternal(RenderTree &root, std::ostream &ss) override;
+	void ToStreamInternal(RenderTree &root, BaseResultRenderer &ss) override;
 
 	string RenderProfilerDisabled() override;
 };

--- a/src/include/duckdb/common/tree_renderer/graphviz_tree_renderer.hpp
+++ b/src/include/duckdb/common/tree_renderer/graphviz_tree_renderer.hpp
@@ -33,10 +33,10 @@ public:
 	string ToString(const ProfilingNode &op);
 	string ToString(const Pipeline &op);
 
-	void Render(const LogicalOperator &op, std::ostream &ss);
-	void Render(const PhysicalOperator &op, std::ostream &ss);
-	void Render(const ProfilingNode &op, std::ostream &ss) override;
-	void Render(const Pipeline &op, std::ostream &ss);
+	void Render(const LogicalOperator &op, BaseResultRenderer &ss);
+	void Render(const PhysicalOperator &op, BaseResultRenderer &ss);
+	void Render(const ProfilingNode &op, BaseResultRenderer &ss) override;
+	void Render(const Pipeline &op, BaseResultRenderer &ss);
 
 	void ToStreamInternal(RenderTree &root, BaseResultRenderer &ss) override;
 

--- a/src/include/duckdb/common/tree_renderer/html_tree_renderer.hpp
+++ b/src/include/duckdb/common/tree_renderer/html_tree_renderer.hpp
@@ -38,7 +38,7 @@ public:
 	void Render(const ProfilingNode &op, std::ostream &ss) override;
 	void Render(const Pipeline &op, std::ostream &ss);
 
-	void ToStreamInternal(RenderTree &root, std::ostream &ss) override;
+	void ToStreamInternal(RenderTree &root, BaseResultRenderer &ss) override;
 
 	string RenderProfilerDisabled() override;
 };

--- a/src/include/duckdb/common/tree_renderer/html_tree_renderer.hpp
+++ b/src/include/duckdb/common/tree_renderer/html_tree_renderer.hpp
@@ -33,10 +33,10 @@ public:
 	string ToString(const ProfilingNode &op);
 	string ToString(const Pipeline &op);
 
-	void Render(const LogicalOperator &op, std::ostream &ss);
-	void Render(const PhysicalOperator &op, std::ostream &ss);
-	void Render(const ProfilingNode &op, std::ostream &ss) override;
-	void Render(const Pipeline &op, std::ostream &ss);
+	void Render(const LogicalOperator &op, BaseResultRenderer &ss);
+	void Render(const PhysicalOperator &op, BaseResultRenderer &ss);
+	void Render(const ProfilingNode &op, BaseResultRenderer &ss) override;
+	void Render(const Pipeline &op, BaseResultRenderer &ss);
 
 	void ToStreamInternal(RenderTree &root, BaseResultRenderer &ss) override;
 

--- a/src/include/duckdb/common/tree_renderer/json_tree_renderer.hpp
+++ b/src/include/duckdb/common/tree_renderer/json_tree_renderer.hpp
@@ -38,7 +38,7 @@ public:
 	void Render(const ProfilingNode &op, std::ostream &ss) override;
 	void Render(const Pipeline &op, std::ostream &ss);
 
-	void ToStreamInternal(RenderTree &root, std::ostream &ss) override;
+	void ToStreamInternal(RenderTree &root, BaseResultRenderer &ss) override;
 
 	//! Profiler JSON output: the full query profile result tree (with query-level metrics)
 	string RenderProfiler(const QueryProfiler &profiler) override;

--- a/src/include/duckdb/common/tree_renderer/json_tree_renderer.hpp
+++ b/src/include/duckdb/common/tree_renderer/json_tree_renderer.hpp
@@ -33,10 +33,10 @@ public:
 	string ToString(const ProfilingNode &op);
 	string ToString(const Pipeline &op);
 
-	void Render(const LogicalOperator &op, std::ostream &ss);
-	void Render(const PhysicalOperator &op, std::ostream &ss);
-	void Render(const ProfilingNode &op, std::ostream &ss) override;
-	void Render(const Pipeline &op, std::ostream &ss);
+	void Render(const LogicalOperator &op, BaseResultRenderer &ss);
+	void Render(const PhysicalOperator &op, BaseResultRenderer &ss);
+	void Render(const ProfilingNode &op, BaseResultRenderer &ss) override;
+	void Render(const Pipeline &op, BaseResultRenderer &ss);
 
 	void ToStreamInternal(RenderTree &root, BaseResultRenderer &ss) override;
 

--- a/src/include/duckdb/common/tree_renderer/json_tree_renderer.hpp
+++ b/src/include/duckdb/common/tree_renderer/json_tree_renderer.hpp
@@ -41,7 +41,7 @@ public:
 	void ToStreamInternal(RenderTree &root, BaseResultRenderer &ss) override;
 
 	//! Profiler JSON output: the full query profile result tree (with query-level metrics)
-	string RenderProfiler(const QueryProfiler &profiler) override;
+	void RenderProfiler(const QueryProfiler &profiler, BaseResultRenderer &ss) override;
 	string RenderProfilerDisabled() override;
 };
 

--- a/src/include/duckdb/common/tree_renderer/mermaid_tree_renderer.hpp
+++ b/src/include/duckdb/common/tree_renderer/mermaid_tree_renderer.hpp
@@ -38,7 +38,7 @@ public:
 	void Render(const ProfilingNode &op, std::ostream &ss) override;
 	void Render(const Pipeline &op, std::ostream &ss);
 
-	void ToStreamInternal(RenderTree &root, std::ostream &ss) override;
+	void ToStreamInternal(RenderTree &root, BaseResultRenderer &ss) override;
 
 	string RenderProfilerDisabled() override;
 };

--- a/src/include/duckdb/common/tree_renderer/mermaid_tree_renderer.hpp
+++ b/src/include/duckdb/common/tree_renderer/mermaid_tree_renderer.hpp
@@ -33,10 +33,10 @@ public:
 	string ToString(const ProfilingNode &op);
 	string ToString(const Pipeline &op);
 
-	void Render(const LogicalOperator &op, std::ostream &ss);
-	void Render(const PhysicalOperator &op, std::ostream &ss);
-	void Render(const ProfilingNode &op, std::ostream &ss) override;
-	void Render(const Pipeline &op, std::ostream &ss);
+	void Render(const LogicalOperator &op, BaseResultRenderer &ss);
+	void Render(const PhysicalOperator &op, BaseResultRenderer &ss);
+	void Render(const ProfilingNode &op, BaseResultRenderer &ss) override;
+	void Render(const Pipeline &op, BaseResultRenderer &ss);
 
 	void ToStreamInternal(RenderTree &root, BaseResultRenderer &ss) override;
 

--- a/src/include/duckdb/common/tree_renderer/text_tree_renderer.hpp
+++ b/src/include/duckdb/common/tree_renderer/text_tree_renderer.hpp
@@ -80,7 +80,7 @@ public:
 	void Render(const ProfilingNode &op, std::ostream &ss) override;
 	void Render(const Pipeline &op, std::ostream &ss);
 
-	void ToStreamInternal(RenderTree &root, std::ostream &ss) override;
+	void ToStreamInternal(RenderTree &root, BaseResultRenderer &ss) override;
 
 	//! Profiler text output: the framed query tree (with phase timings, total time, etc.)
 	string RenderProfiler(const QueryProfiler &profiler) override;
@@ -97,9 +97,9 @@ private:
 
 private:
 	string ExtraInfoSeparator();
-	void RenderTopLayer(RenderTree &root, std::ostream &ss, idx_t y);
-	void RenderBoxContent(RenderTree &root, std::ostream &ss, idx_t y);
-	void RenderBottomLayer(RenderTree &root, std::ostream &ss, idx_t y);
+	void RenderTopLayer(RenderTree &root, BaseResultRenderer &ss, idx_t y);
+	void RenderBoxContent(RenderTree &root, BaseResultRenderer &ss, idx_t y);
+	void RenderBottomLayer(RenderTree &root, BaseResultRenderer &ss, idx_t y);
 
 	bool CanSplitOnThisChar(char l);
 	bool IsPadding(char l);

--- a/src/include/duckdb/common/tree_renderer/text_tree_renderer.hpp
+++ b/src/include/duckdb/common/tree_renderer/text_tree_renderer.hpp
@@ -83,7 +83,7 @@ public:
 	void ToStreamInternal(RenderTree &root, BaseResultRenderer &ss) override;
 
 	//! Profiler text output: the framed query tree (with phase timings, total time, etc.)
-	string RenderProfiler(const QueryProfiler &profiler) override;
+	void RenderProfiler(const QueryProfiler &profiler, BaseResultRenderer &ss) override;
 
 	void Configure(const unordered_map<string, Value> &settings) override;
 

--- a/src/include/duckdb/common/tree_renderer/text_tree_renderer.hpp
+++ b/src/include/duckdb/common/tree_renderer/text_tree_renderer.hpp
@@ -75,10 +75,10 @@ public:
 	string ToString(const ProfilingNode &op);
 	string ToString(const Pipeline &op);
 
-	void Render(const LogicalOperator &op, std::ostream &ss);
-	void Render(const PhysicalOperator &op, std::ostream &ss);
-	void Render(const ProfilingNode &op, std::ostream &ss) override;
-	void Render(const Pipeline &op, std::ostream &ss);
+	void Render(const LogicalOperator &op, BaseResultRenderer &ss);
+	void Render(const PhysicalOperator &op, BaseResultRenderer &ss);
+	void Render(const ProfilingNode &op, BaseResultRenderer &ss) override;
+	void Render(const Pipeline &op, BaseResultRenderer &ss);
 
 	void ToStreamInternal(RenderTree &root, BaseResultRenderer &ss) override;
 

--- a/src/include/duckdb/common/tree_renderer/yaml_tree_renderer.hpp
+++ b/src/include/duckdb/common/tree_renderer/yaml_tree_renderer.hpp
@@ -28,7 +28,7 @@ public:
 	void Render(const ProfilingNode &op, std::ostream &ss) override;
 	void Render(const Pipeline &op, std::ostream &ss);
 
-	void ToStreamInternal(RenderTree &root, std::ostream &ss) override;
+	void ToStreamInternal(RenderTree &root, BaseResultRenderer &ss) override;
 	bool UsesRawKeyNames() override {
 		return false;
 	}

--- a/src/include/duckdb/common/tree_renderer/yaml_tree_renderer.hpp
+++ b/src/include/duckdb/common/tree_renderer/yaml_tree_renderer.hpp
@@ -23,10 +23,10 @@ public:
 	string ToString(const ProfilingNode &op);
 	string ToString(const Pipeline &op);
 
-	void Render(const LogicalOperator &op, std::ostream &ss);
-	void Render(const PhysicalOperator &op, std::ostream &ss);
-	void Render(const ProfilingNode &op, std::ostream &ss) override;
-	void Render(const Pipeline &op, std::ostream &ss);
+	void Render(const LogicalOperator &op, BaseResultRenderer &ss);
+	void Render(const PhysicalOperator &op, BaseResultRenderer &ss);
+	void Render(const ProfilingNode &op, BaseResultRenderer &ss) override;
+	void Render(const Pipeline &op, BaseResultRenderer &ss);
 
 	void ToStreamInternal(RenderTree &root, BaseResultRenderer &ss) override;
 	bool UsesRawKeyNames() override {
@@ -34,7 +34,7 @@ public:
 	}
 
 private:
-	void RenderRecursive(RenderTree &node, std::ostream &ss, idx_t depth, idx_t x, idx_t y);
+	void RenderRecursive(RenderTree &node, BaseResultRenderer &ss, idx_t depth, idx_t x, idx_t y);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/execution/physical_operator.hpp
+++ b/src/include/duckdb/execution/physical_operator.hpp
@@ -75,7 +75,8 @@ public:
 		return InsertionOrderPreservingMap<string>();
 	}
 	static void SetEstimatedCardinality(InsertionOrderPreservingMap<string> &result, idx_t estimated_cardinality);
-	virtual string ToString(const ProfilerPrintFormat &format = ProfilerPrintFormat::Default()) const;
+	virtual string ToString(optional_ptr<ClientContext> context = nullptr,
+	                        const ProfilerPrintFormat &format = ProfilerPrintFormat::Default()) const;
 	void Print() const;
 	virtual vector<const_reference<PhysicalOperator>> GetChildren() const;
 

--- a/src/include/duckdb/main/extension_callback_manager.hpp
+++ b/src/include/duckdb/main/extension_callback_manager.hpp
@@ -22,6 +22,7 @@ class OperatorExtension;
 class OptimizerExtension;
 class ParserExtension;
 class PlannerExtension;
+class ProfilerExtension;
 class StorageExtension;
 struct ExtensionCallbackRegistry;
 
@@ -46,6 +47,7 @@ public:
 	void Register(shared_ptr<OperatorExtension> extension);
 	void Register(const string &name, shared_ptr<StorageExtension> extension);
 	void Register(shared_ptr<ExtensionCallback> extension);
+	void Register(const string &name, shared_ptr<ProfilerExtension> extension);
 
 	ExtensionCallbackIteratorHelper<shared_ptr<OperatorExtension>> OperatorExtensions() const;
 	ExtensionCallbackIteratorHelper<OptimizerExtension> OptimizerExtensions() const;
@@ -53,6 +55,7 @@ public:
 	ExtensionCallbackIteratorHelper<PlannerExtension> PlannerExtensions() const;
 	ExtensionCallbackIteratorHelper<shared_ptr<ExtensionCallback>> ExtensionCallbacks() const;
 	optional_ptr<StorageExtension> FindStorageExtension(const string &name) const;
+	optional_ptr<ProfilerExtension> FindProfilerExtension(const string &name) const;
 	bool HasParserExtensions() const;
 
 private:

--- a/src/include/duckdb/main/profiler/profiler_print_format.hpp
+++ b/src/include/duckdb/main/profiler/profiler_print_format.hpp
@@ -42,10 +42,6 @@ struct ProfilerPrintFormat {
 		return ProfilerPrintFormat("mermaid");
 	}
 
-	//! Resolve a (case-insensitive) format name against the registry, returning its canonical form. Throws
-	//! InvalidInputException listing the valid format names when the name is not recognized.
-	static ProfilerPrintFormat FromString(const string &name);
-
 	bool operator==(const ProfilerPrintFormat &other) const {
 		return format == other.format;
 	}

--- a/src/include/duckdb/main/profiler_extension.hpp
+++ b/src/include/duckdb/main/profiler_extension.hpp
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/main/profiler_extension.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/common.hpp"
+#include "duckdb/main/extension_callback_manager.hpp"
+
+#include <functional>
+
+namespace duckdb {
+struct DBConfig;
+class ClientContext;
+class TreeRenderer;
+
+//! Factory that creates and configures a TreeRenderer for a given client context
+using create_tree_renderer_t = std::function<unique_ptr<TreeRenderer>(ClientContext &context)>;
+
+//! A ProfilerExtension registers a pluggable tree renderer for a profiler / EXPLAIN output format
+class ProfilerExtension {
+public:
+	//! Creates the renderer for the registered format name
+	create_tree_renderer_t create_renderer = nullptr;
+
+	static void Register(DBConfig &config, const string &format_name, shared_ptr<ProfilerExtension> extension);
+	static optional_ptr<ProfilerExtension> Find(const ClientContext &context, const string &format_name);
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/main/query_profiler.hpp
+++ b/src/include/duckdb/main/query_profiler.hpp
@@ -29,6 +29,7 @@
 
 namespace duckdb {
 
+class BaseResultRenderer;
 class ClientContext;
 class ExpressionExecutor;
 class ProfilingNode;
@@ -166,7 +167,7 @@ public:
 
 private:
 	unique_ptr<ProfilingNode> CreateTree(const PhysicalOperator &root, const idx_t depth = 0);
-	void Render(const ProfilingNode &node, std::ostream &str) const;
+	void Render(const ProfilingNode &node, BaseResultRenderer &str) const;
 	//! Render the profiler output via the given renderer (nullptr renders nothing), handling the disabled case.
 	string RenderProfilerOutput(optional_ptr<TreeRenderer> renderer) const;
 

--- a/src/include/duckdb/main/query_profiler.hpp
+++ b/src/include/duckdb/main/query_profiler.hpp
@@ -138,6 +138,8 @@ public:
 
 	DUCKDB_API string QueryTreeToString() const;
 	DUCKDB_API void QueryTreeToStream(std::ostream &str) const;
+	//! Render the framed query tree (header, total time, phase timings, operator tree) into the given sink.
+	DUCKDB_API void RenderQueryTree(BaseResultRenderer &ss) const;
 	DUCKDB_API void Print();
 
 	//! Render the profiler output as a string, formatted based on the given ProfilerPrintFormat (or the configured
@@ -146,9 +148,9 @@ public:
 	//! Render the profiler output for the given profiler format name (e.g. "json", "query_tree"), handling the
 	//! profiling-disabled and no-output cases.
 	DUCKDB_API string ToString(const string &profiler_format_name) const;
-	//! Render the profiling node tree using the given renderer. Returns an empty string when there is no tree to
-	//! render. Called by TreeRenderer::RenderProfiler for the formats that render the node tree directly.
-	DUCKDB_API string RenderProfilingNodeTree(TreeRenderer &renderer) const;
+	//! Render the profiling node tree using the given renderer into the sink (renders nothing when there is no tree).
+	//! Called by TreeRenderer::RenderProfiler for the formats that render the node tree directly.
+	DUCKDB_API void RenderProfilingNodeTree(TreeRenderer &renderer, BaseResultRenderer &ss) const;
 
 	// Sanitize a Value::MAP
 	static Value JSONSanitize(const Value &input);
@@ -168,8 +170,12 @@ public:
 private:
 	unique_ptr<ProfilingNode> CreateTree(const PhysicalOperator &root, const idx_t depth = 0);
 	void Render(const ProfilingNode &node, BaseResultRenderer &str) const;
-	//! Render the profiler output via the given renderer (nullptr renders nothing), handling the disabled case.
+	//! Render the profiler output to a string via the given renderer (nullptr renders nothing), handling the disabled
+	//! case. Used for the programmatic / string paths.
 	string RenderProfilerOutput(optional_ptr<TreeRenderer> renderer) const;
+	//! Print the profiler output directly via the renderer's print sink (nullptr prints nothing), handling the
+	//! disabled case. Only used on the terminal-print paths.
+	void PrintProfilerOutput(optional_ptr<TreeRenderer> renderer) const;
 
 private:
 	ClientContext &context;

--- a/src/include/duckdb/planner/logical_operator.hpp
+++ b/src/include/duckdb/planner/logical_operator.hpp
@@ -64,7 +64,8 @@ public:
 
 	virtual string GetName() const;
 	virtual InsertionOrderPreservingMap<string> ParamsToString() const;
-	virtual string ToString(const ProfilerPrintFormat &format = ProfilerPrintFormat::Default()) const;
+	virtual string ToString(optional_ptr<ClientContext> context = nullptr,
+	                        const ProfilerPrintFormat &format = ProfilerPrintFormat::Default()) const;
 	DUCKDB_API void Print();
 	//! Debug method: verify that the integrity of expressions & child nodes are maintained
 	virtual void Verify(ClientContext &context);

--- a/src/main/extension_callback_manager.cpp
+++ b/src/main/extension_callback_manager.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/planner/planner_extension.hpp"
 #include "duckdb/storage/storage_extension.hpp"
 #include "duckdb/planner/extension_callback.hpp"
+#include "duckdb/main/profiler_extension.hpp"
 
 namespace duckdb {
 
@@ -21,6 +22,8 @@ struct ExtensionCallbackRegistry {
 	case_insensitive_map_t<shared_ptr<StorageExtension>> storage_extensions;
 	//! Set of callbacks that can be installed by extensions
 	vector<shared_ptr<ExtensionCallback>> extension_callbacks;
+	//! Pluggable profiler / EXPLAIN tree renderers, keyed by format name
+	case_insensitive_map_t<shared_ptr<ProfilerExtension>> profiler_extensions;
 };
 
 ExtensionCallbackManager &ExtensionCallbackManager::Get(ClientContext &context) {
@@ -90,6 +93,13 @@ void ExtensionCallbackManager::Register(shared_ptr<ExtensionCallback> extension)
 	callback_registry.atomic_store(new_registry);
 }
 
+void ExtensionCallbackManager::Register(const string &name, shared_ptr<ProfilerExtension> extension) {
+	lock_guard<mutex> guard(registry_lock);
+	auto new_registry = make_shared_ptr<ExtensionCallbackRegistry>(*callback_registry);
+	new_registry->profiler_extensions[name] = std::move(extension);
+	callback_registry.atomic_store(new_registry);
+}
+
 template <class T>
 ExtensionCallbackIteratorHelper<T>::ExtensionCallbackIteratorHelper(
     const vector<T> &vec, shared_ptr<ExtensionCallbackRegistry> callback_registry)
@@ -139,6 +149,15 @@ optional_ptr<StorageExtension> ExtensionCallbackManager::FindStorageExtension(co
 	return entry->second.get();
 }
 
+optional_ptr<ProfilerExtension> ExtensionCallbackManager::FindProfilerExtension(const string &name) const {
+	auto registry = callback_registry.atomic_load();
+	auto entry = registry->profiler_extensions.find(name);
+	if (entry == registry->profiler_extensions.end()) {
+		return nullptr;
+	}
+	return entry->second.get();
+}
+
 bool ExtensionCallbackManager::HasParserExtensions() const {
 	auto registry = callback_registry.atomic_load();
 	return !registry->parser_extensions.empty();
@@ -171,6 +190,14 @@ void ExtensionCallback::Register(DBConfig &config, shared_ptr<ExtensionCallback>
 void StorageExtension::Register(DBConfig &config, const string &extension_name,
                                 shared_ptr<StorageExtension> extension) {
 	config.GetCallbackManager().Register(extension_name, std::move(extension));
+}
+
+void ProfilerExtension::Register(DBConfig &config, const string &format_name, shared_ptr<ProfilerExtension> extension) {
+	config.GetCallbackManager().Register(format_name, std::move(extension));
+}
+
+optional_ptr<ProfilerExtension> ProfilerExtension::Find(const ClientContext &context, const string &format_name) {
+	return ExtensionCallbackManager::Get(context).FindProfilerExtension(format_name);
 }
 
 template class ExtensionCallbackIteratorHelper<shared_ptr<ExtensionCallback>>;

--- a/src/main/query_profiler.cpp
+++ b/src/main/query_profiler.cpp
@@ -546,23 +546,49 @@ string QueryProfiler::QueryTreeToString() const {
 	return ss.str();
 }
 
-void RenderPhaseTimings(std::ostream &ss, const pair<string, double> &head, map<string, double> &timings, idx_t width) {
+// renders a centered line: the surrounding box-drawing and padding is layout, the text itself is a value
+static void RenderPaddedValue(BaseResultRenderer &ss, const string &border_left, const string &padded,
+                              const string &border_right) {
+	idx_t start = 0;
+	while (start < padded.size() && padded[start] == ' ') {
+		start++;
+	}
+	idx_t end = padded.size();
+	while (end > start && padded[end - 1] == ' ') {
+		end--;
+	}
+	ss << border_left;
+	if (start > 0) {
+		ss << padded.substr(0, start);
+	}
+	if (end > start) {
+		ss.Render(ResultRenderType::VALUE, padded.substr(start, end - start));
+	}
+	if (end < padded.size()) {
+		ss << padded.substr(end);
+	}
+	ss << border_right;
+}
+
+void RenderPhaseTimings(BaseResultRenderer &ss, const pair<string, double> &head, map<string, double> &timings,
+                        idx_t width) {
 	ss << "┌────────────────────────────────────────────────┐\n";
-	ss << "│" + QueryProfiler::DrawPadded(RenderTitleCase(head.first) + ": " + RenderTiming(head.second), width - 2) +
-	          "│\n";
+	RenderPaddedValue(
+	    ss, "│", QueryProfiler::DrawPadded(RenderTitleCase(head.first) + ": " + RenderTiming(head.second), width - 2),
+	    "│\n");
 	ss << "│┌──────────────────────────────────────────────┐│\n";
 
 	for (const auto &entry : timings) {
-		ss << "││" +
-		          QueryProfiler::DrawPadded(RenderTitleCase(entry.first) + ": " + RenderTiming(entry.second),
-		                                    width - 4) +
-		          "││\n";
+		RenderPaddedValue(
+		    ss, "││",
+		    QueryProfiler::DrawPadded(RenderTitleCase(entry.first) + ": " + RenderTiming(entry.second), width - 4),
+		    "││\n");
 	}
 	ss << "│└──────────────────────────────────────────────┘│\n";
 	ss << "└────────────────────────────────────────────────┘\n";
 }
 
-void PrintPhaseTimingsToStream(std::ostream &ss, const GatheredMetrics &info, idx_t width) {
+void PrintPhaseTimingsToStream(BaseResultRenderer &ss, const GatheredMetrics &info, idx_t width) {
 	map<string, double> optimizer_timings;
 	map<string, double> planner_timings;
 	map<string, double> parser_timings;
@@ -625,10 +651,13 @@ void QueryProfiler::RenderQueryTree(BaseResultRenderer &ss) const {
 	}
 	ss << "┌─────────────────────────────────────┐\n";
 	ss << "│┌───────────────────────────────────┐│\n";
-	ss << "││    Query Profiling Information    ││\n";
+	RenderPaddedValue(ss, "││", "    Query Profiling Information    ", "││\n");
 	ss << "│└───────────────────────────────────┘│\n";
 	ss << "└─────────────────────────────────────┘\n";
-	ss << (show_query_name ? StringUtil::Replace(query_metrics.query_sql, "\n", " ") : "") + "\n";
+	if (show_query_name) {
+		ss.Render(ResultRenderType::VALUE, StringUtil::Replace(query_metrics.query_sql, "\n", " "));
+	}
+	ss << "\n";
 
 	// checking the tree to ensure the query is really empty
 	// the query string is empty when a logical plan is deserialized
@@ -647,16 +676,14 @@ void QueryProfiler::RenderQueryTree(BaseResultRenderer &ss) const {
 	ss << "┌────────────────────────────────────────────────┐\n";
 	ss << "│┌──────────────────────────────────────────────┐│\n";
 	string total_time = "Total Time: " + RenderTiming(query_metrics.GetStringMetricInSeconds("query.total_time"));
-	ss << "││" + DrawPadded(total_time, TOTAL_BOX_WIDTH - 4) + "││\n";
+	RenderPaddedValue(ss, "││", DrawPadded(total_time, TOTAL_BOX_WIDTH - 4), "││\n");
 	ss << "│└──────────────────────────────────────────────┘│\n";
 	ss << "└────────────────────────────────────────────────┘\n";
 	// render the main operator tree
 	if (root) {
 		// print phase timings
 		if (PrintOptimizerOutput()) {
-			duckdb::stringstream phase_timings;
-			PrintPhaseTimingsToStream(phase_timings, *metrics, TOTAL_BOX_WIDTH);
-			ss << phase_timings.str();
+			PrintPhaseTimingsToStream(ss, *metrics, TOTAL_BOX_WIDTH);
 		}
 		Render(*root, ss);
 	}

--- a/src/main/query_profiler.cpp
+++ b/src/main/query_profiler.cpp
@@ -82,13 +82,7 @@ bool QueryProfiler::IsEnabled() const {
 }
 
 unique_ptr<TreeRenderer> QueryProfiler::CreateProfiler(const string &name) const {
-	// formats are resolved through the renderer registry, which matches case-insensitively and throws on
-	// unrecognized formats - "no_output" has no renderer, for which CreateRenderer returns nullptr
-	auto renderer = TreeRenderer::CreateRenderer(name);
-	if (renderer) {
-		renderer->Configure(ClientConfig::GetConfig(context).profiling_renderer_settings);
-	}
-	return renderer;
+	return TreeRenderer::CreateRenderer(context, name);
 }
 
 unique_ptr<TreeRenderer> QueryProfiler::GetRenderer(const ProfilerPrintFormat &format) const {

--- a/src/main/query_profiler.cpp
+++ b/src/main/query_profiler.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/common/numeric_utils.hpp"
 #include "duckdb/common/optional_idx.hpp"
 #include "duckdb/common/printer.hpp"
+#include "duckdb/common/box_renderer.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/tree_renderer.hpp"
 #include "duckdb/common/tree_renderer/text_tree_renderer.hpp"
@@ -319,7 +320,7 @@ string QueryProfiler::RenderProfilingNodeTree(TreeRenderer &renderer) const {
 	if (query_metrics.query_sql.empty() || !root) {
 		return "";
 	}
-	stringstream str;
+	StringResultRenderer str;
 	renderer.Render(*root, str);
 	return str.str();
 }
@@ -631,7 +632,9 @@ void QueryProfiler::QueryTreeToStream(std::ostream &ss) const {
 		if (PrintOptimizerOutput()) {
 			PrintPhaseTimingsToStream(ss, *metrics, TOTAL_BOX_WIDTH);
 		}
-		Render(*root, ss);
+		StringResultRenderer result;
+		Render(*root, result);
+		ss << result.str();
 	}
 }
 
@@ -1033,7 +1036,7 @@ void QueryProfiler::Initialize(const PhysicalOperator &root_op) {
 	}
 }
 
-void QueryProfiler::Render(const ProfilingNode &node, std::ostream &ss) const {
+void QueryProfiler::Render(const ProfilingNode &node, BaseResultRenderer &ss) const {
 	TextTreeRenderer renderer;
 	renderer.Configure(ClientConfig::GetConfig(context).profiling_renderer_settings);
 	renderer.Render(node, ss);

--- a/src/main/query_profiler.cpp
+++ b/src/main/query_profiler.cpp
@@ -231,13 +231,14 @@ void QueryProfiler::EndQuery() {
 	guard.unlock();
 
 	if (emit_output) {
-		string tree = ToString();
 		auto save_location = GetSaveLocation();
-
 		if (save_location.empty()) {
-			Printer::Print(tree);
+			// print directly through the renderer's print sink
+			auto renderer = GetRenderer();
+			PrintProfilerOutput(renderer.get());
 			Printer::Print("\n");
 		} else {
+			string tree = ToString();
 			WriteToFile(save_location.c_str(), tree);
 		}
 	}
@@ -310,19 +311,33 @@ string QueryProfiler::RenderProfilerOutput(optional_ptr<TreeRenderer> renderer) 
 	if (!IsEnabled()) {
 		return renderer->RenderProfilerDisabled();
 	}
-	return renderer->RenderProfiler(*this);
+	StringResultRenderer ss;
+	renderer->RenderProfiler(*this, ss);
+	return ss.str();
 }
 
-string QueryProfiler::RenderProfilingNodeTree(TreeRenderer &renderer) const {
+void QueryProfiler::PrintProfilerOutput(optional_ptr<TreeRenderer> renderer) const {
+	if (!renderer) {
+		// "no_output" format: nothing is rendered, enabled or not
+		return;
+	}
+	// only created now that we are actually printing
+	auto sink = renderer->GetPrintRenderer();
+	if (!IsEnabled()) {
+		*sink << renderer->RenderProfilerDisabled();
+		return;
+	}
+	renderer->RenderProfiler(*this, *sink);
+}
+
+void QueryProfiler::RenderProfilingNodeTree(TreeRenderer &renderer, BaseResultRenderer &ss) const {
 	lock_guard<std::mutex> guard(lock);
 	// checking the tree to ensure the query is really empty
 	// the query string is empty when a logical plan is deserialized
 	if (query_metrics.query_sql.empty() || !root) {
-		return "";
+		return;
 	}
-	StringResultRenderer str;
-	renderer.Render(*root, str);
-	return str.str();
+	renderer.Render(*root, ss);
 }
 
 OperatorProfiler::OperatorProfiler(ClientContext &context) : context(context) {
@@ -526,9 +541,9 @@ static string RenderTiming(double timing) {
 }
 
 string QueryProfiler::QueryTreeToString() const {
-	duckdb::stringstream str;
-	QueryTreeToStream(str);
-	return str.str();
+	StringResultRenderer ss;
+	RenderQueryTree(ss);
+	return ss.str();
 }
 
 void RenderPhaseTimings(std::ostream &ss, const pair<string, double> &head, map<string, double> &timings, idx_t width) {
@@ -595,6 +610,12 @@ void PrintPhaseTimingsToStream(std::ostream &ss, const GatheredMetrics &info, id
 }
 
 void QueryProfiler::QueryTreeToStream(std::ostream &ss) const {
+	StringResultRenderer renderer;
+	RenderQueryTree(renderer);
+	ss << renderer.str();
+}
+
+void QueryProfiler::RenderQueryTree(BaseResultRenderer &ss) const {
 	lock_guard<std::mutex> guard(lock);
 
 	bool show_query_name = false;
@@ -615,9 +636,12 @@ void QueryProfiler::QueryTreeToStream(std::ostream &ss) const {
 		return;
 	}
 
+	// the registered states write profiling info through an ostream - capture it and emit as layout text
+	duckdb::stringstream state_info;
 	for (auto &state : context.registered_state->States()) {
-		state->WriteProfilingInformation(ss);
+		state->WriteProfilingInformation(state_info);
 	}
+	ss << state_info.str();
 
 	constexpr idx_t TOTAL_BOX_WIDTH = 50;
 	ss << "┌────────────────────────────────────────────────┐\n";
@@ -630,11 +654,11 @@ void QueryProfiler::QueryTreeToStream(std::ostream &ss) const {
 	if (root) {
 		// print phase timings
 		if (PrintOptimizerOutput()) {
-			PrintPhaseTimingsToStream(ss, *metrics, TOTAL_BOX_WIDTH);
+			duckdb::stringstream phase_timings;
+			PrintPhaseTimingsToStream(phase_timings, *metrics, TOTAL_BOX_WIDTH);
+			ss << phase_timings.str();
 		}
-		StringResultRenderer result;
-		Render(*root, result);
-		ss << result.str();
+		Render(*root, ss);
 	}
 }
 
@@ -1043,7 +1067,9 @@ void QueryProfiler::Render(const ProfilingNode &node, BaseResultRenderer &ss) co
 }
 
 void QueryProfiler::Print() {
-	Printer::Print(QueryTreeToString());
+	// print the framed text query tree directly through the renderer's print sink
+	auto renderer = CreateProfiler("query_tree");
+	PrintProfilerOutput(renderer.get());
 }
 
 static void MergeOperatorMeasurements(ProfilingNode &root, OperatorMetrics &result) {

--- a/src/parser/peg/transformer/transform_explain.cpp
+++ b/src/parser/peg/transformer/transform_explain.cpp
@@ -9,8 +9,8 @@ ProfilerPrintFormat ParseProfilerPrintFormat(const Value &val) {
 	if (val.type().id() != LogicalTypeId::VARCHAR) {
 		throw InvalidInputException("Expected a string as argument to FORMAT");
 	}
-	// resolve the format name through the shared explain format registry (see main/profiler/profiler_print_format.hpp)
-	return ProfilerPrintFormat::FromString(val.GetValue<string>());
+	// the format name is validated when the renderer is created (needs a ClientContext); only normalize it here
+	return ProfilerPrintFormat(StringUtil::Lower(val.GetValue<string>()));
 }
 
 unique_ptr<SQLStatement>

--- a/src/planner/binder/statement/bind_explain.cpp
+++ b/src/planner/binder/statement/bind_explain.cpp
@@ -10,7 +10,7 @@ BoundStatement Binder::Bind(ExplainStatement &stmt) {
 	// bind the underlying statement
 	auto plan = Bind(*stmt.stmt);
 	// get the unoptimized logical plan, and create the explain statement
-	auto logical_plan_unopt = plan.plan->ToString(stmt.format);
+	auto logical_plan_unopt = plan.plan->ToString(context, stmt.format);
 	auto explain = make_uniq<LogicalExplain>(std::move(plan.plan), stmt.explain_type, stmt.format);
 	explain->logical_plan_unopt = logical_plan_unopt;
 

--- a/src/planner/logical_operator.cpp
+++ b/src/planner/logical_operator.cpp
@@ -7,6 +7,7 @@
 #include "duckdb/common/serializer/binary_serializer.hpp"
 #include "duckdb/common/serializer/memory_stream.hpp"
 #include "duckdb/common/string_util.hpp"
+#include "duckdb/common/box_renderer.hpp"
 #include "duckdb/common/tree_renderer.hpp"
 #include "duckdb/parser/parser.hpp"
 #include "duckdb/planner/operator/list.hpp"
@@ -162,7 +163,7 @@ string LogicalOperator::ToString(optional_ptr<ClientContext> context, const Prof
 		// formats without output (e.g. "no_output") render nothing
 		return string();
 	}
-	duckdb::stringstream ss;
+	StringResultRenderer ss;
 	auto tree = RenderTree::CreateRenderTree(*this);
 	renderer->ToStream(*tree, ss);
 	return ss.str();

--- a/src/planner/logical_operator.cpp
+++ b/src/planner/logical_operator.cpp
@@ -156,8 +156,8 @@ vector<ColumnBinding> LogicalOperator::MapBindings(const vector<ColumnBinding> &
 	}
 }
 
-string LogicalOperator::ToString(const ProfilerPrintFormat &format) const {
-	auto renderer = TreeRenderer::CreateRenderer(format);
+string LogicalOperator::ToString(optional_ptr<ClientContext> context, const ProfilerPrintFormat &format) const {
+	auto renderer = context ? TreeRenderer::CreateRenderer(*context, format) : TreeRenderer::CreateRenderer(format);
 	if (!renderer) {
 		// formats without output (e.g. "no_output") render nothing
 		return string();

--- a/tools/shell/CMakeLists.txt
+++ b/tools/shell/CMakeLists.txt
@@ -18,6 +18,7 @@ set(SHELL_SOURCES
     shell_prompt.cpp
     shell_renderer.cpp
     shell_highlight.cpp
+    shell_profiler_renderer.cpp
     shell_progress_bar.cpp
     shell_render_table_metadata.cpp
     shell_windows.cpp)

--- a/tools/shell/include/shell_highlight.hpp
+++ b/tools/shell/include/shell_highlight.hpp
@@ -61,6 +61,9 @@ enum class HighlightElementType : uint32_t {
 	NONE
 };
 
+//! Registers a ProfilerExtension that highlights the CLI "query_tree" profiler output
+void RegisterProfilerHighlighting(duckdb::DBConfig &config);
+
 struct HighlightColorInfo {
 	const char *color_name;
 	uint8_t code;

--- a/tools/shell/include/shell_state.hpp
+++ b/tools/shell/include/shell_state.hpp
@@ -341,6 +341,8 @@ public:
 	vector<string> TableColumnList(const char *zTab);
 	SuccessState ExecuteStatement(unique_ptr<duckdb::SQLStatement> statement);
 	static bool UseDescribeRenderMode(const duckdb::SQLStatement &stmt, string &describe_table_name);
+	//! Route EXPLAIN ANALYZE output through the shell's direct-printing renderer when on an interactive console
+	void SetupPrettyExplain(duckdb::SQLStatement &statement);
 	void RenderTableMetadata(vector<ShellTableInfo> &result);
 
 	void PrintDatabaseError(const string &zErr);

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -51,6 +51,7 @@
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/parser/qualified_name.hpp"
 #include "duckdb/parser/parser.hpp"
+#include "duckdb/parser/statement/explain_statement.hpp"
 #include "duckdb/common/local_file_system.hpp"
 #include "shell_progress_bar.hpp"
 #include "shell_prompt.hpp"
@@ -987,6 +988,27 @@ SuccessState ShellState::ExecuteStatement(unique_ptr<duckdb::SQLStatement> state
 ** any result rows/columns depending on the current mode
 ** set via the supplied callback.
 */
+void ShellState::SetupPrettyExplain(duckdb::SQLStatement &statement) {
+	if (!stdout_is_console) {
+		// only pretty-print to an interactive console - redirected output keeps the plain plan as a result value
+		return;
+	}
+	auto &explain = statement.Cast<duckdb::ExplainStatement>();
+	if (explain.format != duckdb::ProfilerPrintFormat::Default()) {
+		// the user explicitly requested an output format (e.g. EXPLAIN (FORMAT json))
+		return;
+	}
+	if (explain.explain_type == duckdb::ExplainType::EXPLAIN_ANALYZE) {
+		auto &profiler_format = duckdb::ClientConfig::GetConfig(*conn->context).profiler_print_format;
+		if (profiler_format != "query_tree" && profiler_format != "no_output") {
+			// a custom profiler output format is configured - respect it
+			return;
+		}
+	}
+	// render the plan as a highlighted string (see RegisterProfilerHighlighting)
+	explain.format = duckdb::ProfilerPrintFormat("shell_explain_printer");
+}
+
 SuccessState ShellState::ExecuteSQL(const string &zSql) {
 	auto &con = *conn;
 	try {
@@ -1008,6 +1030,7 @@ SuccessState ShellState::ExecuteSQL(const string &zSql) {
 			cMode = mode;
 			if (statement->type == duckdb::StatementType::EXPLAIN_STATEMENT) {
 				cMode = RenderMode::EXPLAIN;
+				SetupPrettyExplain(*statement);
 			}
 			if (mode == RenderMode::DUCKBOX && UseDescribeRenderMode(*statement, describe_table_name)) {
 				cMode = RenderMode::DESCRIBE;

--- a/tools/shell/shell_extension.cpp
+++ b/tools/shell/shell_extension.cpp
@@ -131,6 +131,9 @@ void ShellExtension::Load(ExtensionLoader &loader) {
 	PlannerExtension planner_ext;
 	planner_ext.post_bind_function = duckdb::ShellPostBind;
 	PlannerExtension::Register(config, planner_ext);
+
+	// highlight the CLI profiler "query_tree" output
+	duckdb_shell::RegisterProfilerHighlighting(config);
 }
 
 std::string ShellExtension::Name() {

--- a/tools/shell/shell_profiler_renderer.cpp
+++ b/tools/shell/shell_profiler_renderer.cpp
@@ -1,0 +1,143 @@
+#include "shell_highlight.hpp"
+#include "shell_state.hpp"
+
+#include "duckdb/common/box_renderer.hpp"
+#include "duckdb/common/tree_renderer.hpp"
+#include "duckdb/common/tree_renderer/text_tree_renderer.hpp"
+#include "duckdb/main/client_config.hpp"
+#include "duckdb/main/config.hpp"
+#include "duckdb/main/profiler_extension.hpp"
+#include "duckdb/main/query_profiler.hpp"
+
+namespace duckdb_shell {
+
+namespace {
+
+//! Base sink that maps the tree renderer's typed segments onto the shell's highlight elements. Subclasses decide
+//! whether the highlighted text is printed to the terminal or accumulated into a string.
+class CLIHighlightRenderer : public duckdb::BaseResultRenderer {
+public:
+	void RenderLayout(const string &text) override {
+		Emit(text, HighlightElementType::LAYOUT);
+	}
+	void RenderColumnName(const string &text) override {
+		Emit(text, HighlightElementType::COLUMN_NAME);
+	}
+	void RenderType(const string &text) override {
+		Emit(text, HighlightElementType::COLUMN_TYPE);
+	}
+	void RenderValue(const string &text, const duckdb::LogicalType &type) override {
+		Emit(text, HighlightElementType::NUMERIC_VALUE);
+	}
+	void RenderNull(const string &text, const duckdb::LogicalType &type) override {
+		Emit(text, HighlightElementType::NULL_VALUE);
+	}
+	void RenderFooter(const string &text) override {
+		Emit(text, HighlightElementType::FOOTER);
+	}
+
+protected:
+	virtual void Emit(const string &text, HighlightElementType type) = 0;
+};
+
+//! Prints the highlighted profiler tree directly to an output stream (used by PRAGMA enable_profiling).
+class CLIResultRenderer : public CLIHighlightRenderer {
+public:
+	explicit CLIResultRenderer(PrintOutput output = PrintOutput::STDERR)
+	    : highlight(ShellState::Get()), output(output) {
+	}
+
+protected:
+	void Emit(const string &text, HighlightElementType type) override {
+		auto &state = highlight.state;
+		bool is_console = output == PrintOutput::STDOUT ? state.stdout_is_console : state.stderr_is_console;
+		if (is_console) {
+			// PrintText additionally honors the ".highlight" toggle
+			highlight.PrintText(text, output, type);
+		} else {
+			// not a console - emit plain text so redirected output has no escape codes
+			state.Print(output, text);
+		}
+	}
+
+private:
+	ShellHighlight highlight;
+	PrintOutput output;
+};
+
+//! Accumulates the highlighted tree into a string (used for EXPLAIN, whose plan flows back as a result value).
+class HighlightStringRenderer : public CLIHighlightRenderer {
+public:
+	const string &str() {
+		return result;
+	}
+
+protected:
+	void Emit(const string &text, HighlightElementType type) override {
+		auto &element = ShellHighlight::GetHighlightElement(type);
+		if (!ShellHighlight::IsEnabled() ||
+		    (element.color == PrintColor::STANDARD && element.intensity == PrintIntensity::STANDARD)) {
+			result += text;
+			return;
+		}
+		result += ShellHighlight::TerminalCode(element.color, element.intensity);
+		result += text;
+		result += ShellHighlight::ResetTerminalCode();
+	}
+
+private:
+	string result;
+};
+
+//! A text tree renderer whose print sink highlights the profiler output for the CLI (PRAGMA enable_profiling).
+class CLITreeRenderer : public duckdb::TextTreeRenderer {
+public:
+	duckdb::unique_ptr<duckdb::BaseResultRenderer> GetPrintRenderer() override {
+		return duckdb::make_uniq<CLIResultRenderer>(PrintOutput::STDERR);
+	}
+};
+
+//! Renderer used for EXPLAIN / EXPLAIN ANALYZE in the CLI. The plan is rendered into a highlighted string that flows
+//! back as the EXPLAIN result value and is printed by ModeExplainRenderer (which drops the section header).
+class ShellExplainPrinter : public duckdb::TextTreeRenderer {
+public:
+	// plain EXPLAIN: the logical/physical operator tree
+	void ToStreamInternal(duckdb::RenderTree &root, duckdb::BaseResultRenderer &ss) override {
+		HighlightStringRenderer highlighted;
+		duckdb::TextTreeRenderer::ToStreamInternal(root, highlighted);
+		ss << highlighted.str();
+	}
+
+	// EXPLAIN ANALYZE: the framed query profiling tree
+	void RenderProfiler(const duckdb::QueryProfiler &profiler, duckdb::BaseResultRenderer &ss) override {
+		HighlightStringRenderer highlighted;
+		profiler.RenderQueryTree(highlighted);
+		ss << highlighted.str();
+	}
+};
+
+} // namespace
+
+void RegisterProfilerHighlighting(duckdb::DBConfig &config) {
+	// PRAGMA enable_profiling output (printed directly to stderr)
+	auto profiler_extension = duckdb::make_shared_ptr<duckdb::ProfilerExtension>();
+	profiler_extension->create_renderer =
+	    [](duckdb::ClientContext &context) -> duckdb::unique_ptr<duckdb::TreeRenderer> {
+		auto renderer = duckdb::make_uniq<CLITreeRenderer>();
+		renderer->Configure(duckdb::ClientConfig::GetConfig(context).profiling_renderer_settings);
+		return std::move(renderer);
+	};
+	duckdb::ProfilerExtension::Register(config, "query_tree", std::move(profiler_extension));
+
+	// EXPLAIN / EXPLAIN ANALYZE output (highlighted string, see ShellState::SetupPrettyExplain)
+	auto explain_extension = duckdb::make_shared_ptr<duckdb::ProfilerExtension>();
+	explain_extension->create_renderer =
+	    [](duckdb::ClientContext &context) -> duckdb::unique_ptr<duckdb::TreeRenderer> {
+		auto renderer = duckdb::make_uniq<ShellExplainPrinter>();
+		renderer->Configure(duckdb::ClientConfig::GetConfig(context).profiling_renderer_settings);
+		return std::move(renderer);
+	};
+	duckdb::ProfilerExtension::Register(config, "shell_explain_printer", std::move(explain_extension));
+}
+
+} // namespace duckdb_shell

--- a/tools/shell/shell_renderer.cpp
+++ b/tools/shell/shell_renderer.cpp
@@ -904,20 +904,6 @@ public:
 		if (data.size() != 2) {
 			return;
 		}
-		if (duckdb::StringUtil::Equals(data[0], "logical_plan") || duckdb::StringUtil::Equals(data[0], "logical_opt") ||
-		    duckdb::StringUtil::Equals(data[0], "physical_plan")) {
-			out.Print("\n┌─────────────────────────────┐\n");
-			out.Print("│┌───────────────────────────┐│\n");
-			if (duckdb::StringUtil::Equals(data[0], "logical_plan")) {
-				out.Print("││ Unoptimized Logical Plan  ││\n");
-			} else if (duckdb::StringUtil::Equals(data[0], "logical_opt")) {
-				out.Print("││  Optimized Logical Plan   ││\n");
-			} else if (duckdb::StringUtil::Equals(data[0], "physical_plan")) {
-				out.Print("││       Physical Plan       ││\n");
-			}
-			out.Print("│└───────────────────────────┘│\n");
-			out.Print("└─────────────────────────────┘\n");
-		}
 		out.Print(data[1]);
 	}
 


### PR DESCRIPTION
This PR adds the `ProfilerExtension` that allows profiler formats to be plugged in:

```cpp
using create_tree_renderer_t = std::function<unique_ptr<TreeRenderer>(ClientContext &context)>;

class ProfilerExtension {
public:
	create_tree_renderer_t create_renderer = nullptr;
};
```

This allows new profiler formats to be defined, which can then be invoked using `EXPLAIN [ANALYZE] (FORMAT my_format)`. This also allows existing formats to be overridden.

In this PR we then use this behavior to override the default profiler printers in the CLI with a profile printer that highlights the layout / text. For now this only does simple highlighting of the layout, pending future work :)

