### PR TITLE
[ASYNC I/O] Refactor Multifile Scan for Read Ahead

### DIFF
--- a/.github/patches/extensions/iceberg/0008-multi-file-reader.patch
+++ b/.github/patches/extensions/iceberg/0008-multi-file-reader.patch
@@ -1,5 +1,5 @@
 diff --git a/src/include/planning/iceberg_multi_file_reader.hpp b/src/include/planning/iceberg_multi_file_reader.hpp
-index 983239df..35caaefc 100644
+index 679128c..eb79aae 100644
 --- a/src/include/planning/iceberg_multi_file_reader.hpp
 +++ b/src/include/planning/iceberg_multi_file_reader.hpp
 @@ -75,11 +75,10 @@ public:
@@ -17,8 +17,21 @@ index 983239df..35caaefc 100644
  
  public:
  	shared_ptr<TableFunctionInfo> function_info;
+diff --git a/src/planning/iceberg_multi_file_list.cpp b/src/planning/iceberg_multi_file_list.cpp
+index 9af1973..4f95470 100644
+--- a/src/planning/iceberg_multi_file_list.cpp
++++ b/src/planning/iceberg_multi_file_list.cpp
+@@ -1315,7 +1315,7 @@ void IcebergMultiFileList::ScanDeleteFile(const BoundIcebergManifestEntry &bound
+ 			result.Reset();
+ 			delete_scan_function.function(context, function_input, result);
+ 			result.Flatten();
+-			ScanEqualityDeleteFile(bound_manifest_entry, result, multi_file_local_state.reader->columns, global_columns,
++			ScanEqualityDeleteFile(bound_manifest_entry, result, multi_file_local_state.job.reader->columns, global_columns,
+ 			                       global_column_ids, projection_ids);
+ 		} while (result.size() != 0);
+ 	}
 diff --git a/src/planning/iceberg_multi_file_reader.cpp b/src/planning/iceberg_multi_file_reader.cpp
-index 3ac91158..5b2faae0 100644
+index f21ca88..9a3b33c 100644
 --- a/src/planning/iceberg_multi_file_reader.cpp
 +++ b/src/planning/iceberg_multi_file_reader.cpp
 @@ -511,10 +511,9 @@ static unique_ptr<Expression> ConstructVirtualRowIdExpression(ClientContext &con
@@ -122,7 +135,7 @@ index 3ac91158..5b2faae0 100644
  
  vector<PartitionStatistics> IcebergMultiFileReader::IcebergGetPartitionStats(ClientContext &context,
 diff --git a/src/planning/metadata_io/manifest_list/iceberg_manifest_list_reader.cpp b/src/planning/metadata_io/manifest_list/iceberg_manifest_list_reader.cpp
-index 3c6ef640..f057805a 100644
+index 3c6ef64..f057805 100644
 --- a/src/planning/metadata_io/manifest_list/iceberg_manifest_list_reader.cpp
 +++ b/src/planning/metadata_io/manifest_list/iceberg_manifest_list_reader.cpp
 @@ -175,9 +175,9 @@ void ManifestListReader::ReadChunk(DataChunk &chunk, idx_t iceberg_version, vect
@@ -139,7 +152,7 @@ index 3c6ef640..f057805a 100644
  			}
  		}
 diff --git a/test/sql/local/catalog_test_config_setup/catalog_agnostic/alter/table_properties/test_upgrade_format_version_2_to_3.test b/test/sql/local/catalog_test_config_setup/catalog_agnostic/alter/table_properties/test_upgrade_format_version_2_to_3.test
-index 3ce08b8b..1a22d863 100644
+index 3ce08b8..1a22d86 100644
 --- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/alter/table_properties/test_upgrade_format_version_2_to_3.test
 +++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/alter/table_properties/test_upgrade_format_version_2_to_3.test
 @@ -22,14 +22,20 @@ DROP TABLE IF EXISTS my_datalake.default.v2_to_v3_upgrade;
@@ -192,7 +205,7 @@ index 3ce08b8b..1a22d863 100644
  # 10 rows total: 5 pre-upgrade + 5 post-upgrade
  query II
 diff --git a/test/sql/local/catalog_test_config_setup/catalog_agnostic/test_row_lineage_read_from_upgraded.test b/test/sql/local/catalog_test_config_setup/catalog_agnostic/test_row_lineage_read_from_upgraded.test
-index f5c7d910..c648d64a 100644
+index f5c7d91..c648d64 100644
 --- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/test_row_lineage_read_from_upgraded.test
 +++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/test_row_lineage_read_from_upgraded.test
 @@ -2,9 +2,6 @@

--- a/extension/parquet/parquet_multi_file_info.cpp
+++ b/extension/parquet/parquet_multi_file_info.cpp
@@ -334,10 +334,10 @@ static void ParquetScanGetMetrics(TableFunctionGetMetricsInput &input) {
 		return;
 	}
 	auto &local = input.local_state->Cast<MultiFileLocalState>();
-	if (!local.local_state) {
+	if (!local.job.reader_scan_state) {
 		return;
 	}
-	auto &scan_state = local.local_state->Cast<ParquetReadLocalState>().scan_state;
+	auto &scan_state = local.job.reader_scan_state->Cast<ParquetReadLocalState>().scan_state;
 	input.operator_metrics.row_groups_scanned = scan_state.row_groups_read;
 	input.operator_metrics.total_row_groups_to_scan = scan_state.row_groups_read + scan_state.row_groups_skipped;
 }

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -3480,6 +3480,25 @@ MultiFileColumnMappingMode EnumUtil::FromString<MultiFileColumnMappingMode>(cons
 	return static_cast<MultiFileColumnMappingMode>(StringUtil::StringToEnum(GetMultiFileColumnMappingModeValues(), 2, "MultiFileColumnMappingMode", value));
 }
 
+const StringUtil::EnumStringLiteral *GetMultiFileDecodeResultValues() {
+	static constexpr StringUtil::EnumStringLiteral values[] {
+		{ static_cast<uint32_t>(MultiFileDecodeResult::CONTINUE), "CONTINUE" },
+		{ static_cast<uint32_t>(MultiFileDecodeResult::RETURN_TO_CALLER), "RETURN_TO_CALLER" },
+		{ static_cast<uint32_t>(MultiFileDecodeResult::JOB_FINISHED), "JOB_FINISHED" }
+	};
+	return values;
+}
+
+template<>
+const char* EnumUtil::ToChars<MultiFileDecodeResult>(MultiFileDecodeResult value) {
+	return StringUtil::EnumToString(GetMultiFileDecodeResultValues(), 3, "MultiFileDecodeResult", static_cast<uint32_t>(value));
+}
+
+template<>
+MultiFileDecodeResult EnumUtil::FromString<MultiFileDecodeResult>(const char *value) {
+	return static_cast<MultiFileDecodeResult>(StringUtil::StringToEnum(GetMultiFileDecodeResultValues(), 3, "MultiFileDecodeResult", value));
+}
+
 const StringUtil::EnumStringLiteral *GetMultiFileFileStateValues() {
 	static constexpr StringUtil::EnumStringLiteral values[] {
 		{ static_cast<uint32_t>(MultiFileFileState::UNOPENED), "UNOPENED" },

--- a/src/include/duckdb/common/enum_util.hpp
+++ b/src/include/duckdb/common/enum_util.hpp
@@ -320,6 +320,8 @@ enum class Monotonicity : uint8_t;
 
 enum class MultiFileColumnMappingMode : uint8_t;
 
+enum class MultiFileDecodeResult : uint8_t;
+
 enum class MultiFileFileState : uint8_t;
 
 enum class MultiFileScanPhase : uint8_t;
@@ -996,6 +998,9 @@ const char* EnumUtil::ToChars<Monotonicity>(Monotonicity value);
 
 template<>
 const char* EnumUtil::ToChars<MultiFileColumnMappingMode>(MultiFileColumnMappingMode value);
+
+template<>
+const char* EnumUtil::ToChars<MultiFileDecodeResult>(MultiFileDecodeResult value);
 
 template<>
 const char* EnumUtil::ToChars<MultiFileFileState>(MultiFileFileState value);
@@ -1795,6 +1800,9 @@ Monotonicity EnumUtil::FromString<Monotonicity>(const char *value);
 
 template<>
 MultiFileColumnMappingMode EnumUtil::FromString<MultiFileColumnMappingMode>(const char *value);
+
+template<>
+MultiFileDecodeResult EnumUtil::FromString<MultiFileDecodeResult>(const char *value);
 
 template<>
 MultiFileFileState EnumUtil::FromString<MultiFileFileState>(const char *value);

--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -289,8 +289,7 @@ public:
 
 	//! Helper function that try to start opening a next file. Parallel lock should be locked when calling.
 	static bool TryOpenNextFile(ClientContext &context, const MultiFileBindData &bind_data,
-	                            MultiFileLocalState &scan_data, MultiFileGlobalState &global_state,
-	                            unique_lock<mutex> &parallel_lock) {
+	                            MultiFileGlobalState &global_state, unique_lock<mutex> &parallel_lock) {
 		if (!parallel_lock.owns_lock()) {
 			throw InternalException("parallel_lock is not held in TryOpenNextFile, this should not happen");
 		}
@@ -398,14 +397,15 @@ public:
 		}
 	}
 
-	static void InitializeFileScanState(ClientContext &context, MultiFileReaderData &reader_data,
-	                                    MultiFileLocalState &lstate, vector<idx_t> &projection_ids) {
-		lstate.job.reader_data = reader_data;
+	//! (Re)initialize the per-thread decode scratch (scan_chunk + executor) for the file of the current job. Only needs
+	//! to run when this thread decodes a job from a different file than the one the scratch is currently built for.
+	static void InitializeDecodeChunk(ClientContext &context, MultiFileLocalState &lstate, vector<idx_t> &projection_ids) {
 		auto &reader = *lstate.job.reader;
+		auto &reader_data = *lstate.job.reader_data;
 		//! Initialize the intermediate chunk to be used by the underlying reader before being finalized
 		vector<LogicalType> intermediate_chunk_types;
 		auto &local_column_ids = reader.column_indexes;
-		auto &local_columns = lstate.job.reader->GetColumns();
+		auto &local_columns = reader.GetColumns();
 		for (idx_t i = 0; i < local_column_ids.size(); i++) {
 			auto &local_id = local_column_ids[i];
 
@@ -444,12 +444,16 @@ public:
 				executor.AddExpression(*expr);
 			}
 		}
+		lstate.scan_chunk_file_index = lstate.job.file_index;
 	}
 
-	// This function looks for the next available row group. If not available, it will open files from bind_data.files
-	// until there is a row group available for scanning or the files runs out
-	static bool TryInitializeNextBatch(ClientContext &context, const MultiFileBindData &bind_data,
-	                                   MultiFileLocalState &scan_data, MultiFileGlobalState &gstate) {
+	// Claims the next available batch (e.g. a row group) into 'job', opening files as needed until a batch is available
+	// or the files run out. The batch is claimed under the global lock (assigning its batch_index in scan order) and then
+	// prepared off-lock. Returns true if a job was claimed, false if the scan is exhausted. 'job.reader_scan_state' must
+	// already be allocated. This is the lock-bounded scheduling primitive: it never touches per-thread decode scratch, so
+	// it can be called repeatedly to claim several jobs ahead of decoding.
+	static bool ClaimNextJob(ClientContext &context, const MultiFileBindData &bind_data, MultiFileGlobalState &gstate,
+	                         MultiFileScanJob &job) {
 		unique_lock<mutex> parallel_lock(gstate.lock);
 
 		while (true) {
@@ -459,29 +463,25 @@ public:
 
 			//! If we don't have a file to read, and the MultiFileList has no new file for us - end the scan
 			if (!HasFilesToRead(gstate, parallel_lock) && !TryGetNextFile(gstate, parallel_lock)) {
-				bind_data.interface->FinishReading(context, *gstate.global_state, *scan_data.job.reader_scan_state);
+				bind_data.interface->FinishReading(context, *gstate.global_state, *job.reader_scan_state);
 				return false;
 			}
 
 			auto &current_reader_data = *gstate.readers[gstate.file_index];
 			if (current_reader_data.file_state == MultiFileFileState::OPEN) {
-				if (current_reader_data.reader->TryInitializeScan(context, *gstate.global_state,
-				                                                  *scan_data.job.reader_scan_state)) {
-					scan_data.job.reader = current_reader_data.reader;
-					if (!scan_data.job.reader) {
+				if (current_reader_data.reader->TryInitializeScan(context, *gstate.global_state, *job.reader_scan_state)) {
+					job.reader = current_reader_data.reader;
+					if (!job.reader) {
 						throw InternalException("MultiFileReader was moved");
 					}
 					// The current reader has data left to be scanned
-					scan_data.job.batch_index = gstate.batch_index++;
-					auto old_file_index = scan_data.job.file_index;
-					scan_data.job.file_index = gstate.file_index;
+					job.reader_data = current_reader_data;
+					job.batch_index = gstate.batch_index++;
+					job.file_index = gstate.file_index;
 					parallel_lock.unlock();
-					scan_data.job.reader->PrepareScan(context, *gstate.global_state, *scan_data.job.reader_scan_state);
-					if (old_file_index != scan_data.job.file_index) {
-						InitializeFileScanState(context, current_reader_data, scan_data, gstate.projection_ids);
-					}
-					// Initializing a batch is always a schedule phase
-					scan_data.job.phase = MultiFileScanPhase::SCHEDULE;
+					job.reader->PrepareScan(context, *gstate.global_state, *job.reader_scan_state);
+					// A freshly claimed job always starts in the schedule phase
+					job.phase = MultiFileScanPhase::SCHEDULE;
 					return true;
 				} else {
 					// Set state to the next file
@@ -503,7 +503,7 @@ public:
 				continue;
 			}
 
-			if (TryOpenNextFile(context, bind_data, scan_data, gstate, parallel_lock)) {
+			if (TryOpenNextFile(context, bind_data, gstate, parallel_lock)) {
 				continue;
 			}
 
@@ -528,7 +528,7 @@ public:
 		result->job.batch_index = 0;
 		result->job.reader_scan_state = bind_data.interface->InitializeLocalState(context, *gstate.global_state);
 
-		if (!TryInitializeNextBatch(context.client, bind_data, *result, gstate)) {
+		if (!ClaimNextJob(context.client, bind_data, gstate, result->job)) {
 			return nullptr;
 		}
 		return std::move(result);
@@ -703,6 +703,10 @@ public:
 
 	static bool DecodePhase(ClientContext &context, TableFunctionInput &data_p, MultiFileLocalState &data,
 	                        MultiFileGlobalState &gstate, MultiFileBindData &bind_data, DataChunk &output) {
+		// (Re)build the decode scratch if this thread moved to a job from a different file
+		if (data.scan_chunk_file_index != data.job.file_index) {
+			InitializeDecodeChunk(context, data, gstate.projection_ids);
+		}
 		auto &scan_chunk = data.scan_chunk;
 		if (!data.resuming_blocked_scan) {
 			// A BLOCKED scan leaves partial data in the chunk (e.g. filter prefetch from parquet) that the resume must
@@ -735,7 +739,7 @@ public:
 		}
 
 		// We are done with this batch
-		if (!TryInitializeNextBatch(context, bind_data, data, gstate)) {
+		if (!ClaimNextJob(context, bind_data, gstate, data.job)) {
 			if (output.size() > 0 && data_p.results_execution_mode == AsyncResultsExecutionMode::SYNCHRONOUS) {
 				gstate.finished = true;
 				data_p.async_result = SourceResultType::HAVE_MORE_OUTPUT;

--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -397,7 +397,8 @@ public:
 		}
 	}
 
-static void InitializeDecodeChunk(ClientContext &context, MultiFileLocalState &lstate, vector<idx_t> &projection_ids) {
+	static void InitializeDecodeChunk(ClientContext &context, MultiFileLocalState &lstate,
+	                                  vector<idx_t> &projection_ids) {
 		auto &reader = *lstate.job.reader;
 		auto &reader_data = *lstate.job.reader_data;
 		//! Initialize the intermediate chunk to be used by the underlying reader before being finalized
@@ -462,7 +463,8 @@ static void InitializeDecodeChunk(ClientContext &context, MultiFileLocalState &l
 
 			auto &current_reader_data = *gstate.readers[gstate.file_index];
 			if (current_reader_data.file_state == MultiFileFileState::OPEN) {
-				if (current_reader_data.reader->TryInitializeScan(context, *gstate.global_state, *job.reader_scan_state)) {
+				if (current_reader_data.reader->TryInitializeScan(context, *gstate.global_state,
+				                                                  *job.reader_scan_state)) {
 					job.reader = current_reader_data.reader;
 					if (!job.reader) {
 						throw InternalException("MultiFileReader was moved");
@@ -710,19 +712,22 @@ static void InitializeDecodeChunk(ClientContext &context, MultiFileLocalState &l
 
 		data.resuming_blocked_scan = res.GetResultType() == AsyncResultType::BLOCKED;
 		if (res.GetResultType() == AsyncResultType::BLOCKED) {
-			return HandleBlocked(data_p, res) ? MultiFileDecodeResult::PARKED : MultiFileDecodeResult::CONTINUE;
+			return HandleBlocked(data_p, res) ? MultiFileDecodeResult::RETURN_TO_CALLER
+			                                  : MultiFileDecodeResult::CONTINUE;
 		}
 
 		output.SetChildCardinality(scan_chunk.size());
 		if (scan_chunk.size() > 0) {
 			data.rows_scanned += scan_chunk.size();
 			bind_data.multi_file_reader->FinalizeChunk(context, bind_data, *data.job.reader, *data.job.reader_data,
-			                                           scan_chunk, output, data.executor, gstate.multi_file_reader_state);
+			                                           scan_chunk, output, data.executor,
+			                                           gstate.multi_file_reader_state);
 			output.SetChildCardinality(output.size());
 		}
 		if (res.GetResultType() == AsyncResultType::HAVE_MORE_OUTPUT) {
 			// More chunks left on this batch, lets keep going
-			return EmitOutput(data_p, output) ? MultiFileDecodeResult::EMITTED_RETURN : MultiFileDecodeResult::CONTINUE;
+			return EmitOutput(data_p, output) ? MultiFileDecodeResult::RETURN_TO_CALLER
+			                                  : MultiFileDecodeResult::CONTINUE;
 		}
 		if (res.GetResultType() != AsyncResultType::FINISHED) {
 			throw InternalException("Unexpected result in MultiFileScan, must be FINISHED, is %s",
@@ -757,8 +762,7 @@ static void InitializeDecodeChunk(ClientContext &context, MultiFileLocalState &l
 				switch (DecodeCurrentJob(context, data_p, data, gstate, bind_data, output)) {
 				case MultiFileDecodeResult::CONTINUE:
 					break;
-				case MultiFileDecodeResult::EMITTED_RETURN:
-				case MultiFileDecodeResult::PARKED:
+				case MultiFileDecodeResult::RETURN_TO_CALLER:
 					return;
 				case MultiFileDecodeResult::JOB_FINISHED:
 					// done with this job, gotta claim the next one

--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -733,7 +733,6 @@ public:
 			throw InternalException("Unexpected result in MultiFileScan, must be FINISHED, is %s",
 			                        EnumUtil::ToChars(res.GetResultType()));
 		}
-		// this batch is fully decoded - the caller claims the next one
 		return MultiFileDecodeResult::JOB_FINISHED;
 	}
 

--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -397,9 +397,7 @@ public:
 		}
 	}
 
-	//! (Re)initialize the per-thread decode scratch (scan_chunk + executor) for the file of the current job. Only needs
-	//! to run when this thread decodes a job from a different file than the one the scratch is currently built for.
-	static void InitializeDecodeChunk(ClientContext &context, MultiFileLocalState &lstate, vector<idx_t> &projection_ids) {
+static void InitializeDecodeChunk(ClientContext &context, MultiFileLocalState &lstate, vector<idx_t> &projection_ids) {
 		auto &reader = *lstate.job.reader;
 		auto &reader_data = *lstate.job.reader_data;
 		//! Initialize the intermediate chunk to be used by the underlying reader before being finalized
@@ -447,11 +445,6 @@ public:
 		lstate.scan_chunk_file_index = lstate.job.file_index;
 	}
 
-	// Claims the next available batch (e.g. a row group) into 'job', opening files as needed until a batch is available
-	// or the files run out. The batch is claimed under the global lock (assigning its batch_index in scan order) and then
-	// prepared off-lock. Returns true if a job was claimed, false if the scan is exhausted. 'job.reader_scan_state' must
-	// already be allocated. This is the lock-bounded scheduling primitive: it never touches per-thread decode scratch, so
-	// it can be called repeatedly to claim several jobs ahead of decoding.
 	static bool ClaimNextJob(ClientContext &context, const MultiFileBindData &bind_data, MultiFileGlobalState &gstate,
 	                         MultiFileScanJob &job) {
 		unique_lock<mutex> parallel_lock(gstate.lock);
@@ -703,8 +696,8 @@ public:
 
 	static bool DecodePhase(ClientContext &context, TableFunctionInput &data_p, MultiFileLocalState &data,
 	                        MultiFileGlobalState &gstate, MultiFileBindData &bind_data, DataChunk &output) {
-		// (Re)build the decode scratch if this thread moved to a job from a different file
 		if (data.scan_chunk_file_index != data.job.file_index) {
+			// if the file changes we need to initialize the chunk again
 			InitializeDecodeChunk(context, data, gstate.projection_ids);
 		}
 		auto &scan_chunk = data.scan_chunk;

--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -400,12 +400,12 @@ public:
 
 	static void InitializeFileScanState(ClientContext &context, MultiFileReaderData &reader_data,
 	                                    MultiFileLocalState &lstate, vector<idx_t> &projection_ids) {
-		lstate.reader_data = reader_data;
-		auto &reader = *lstate.reader;
+		lstate.job.reader_data = reader_data;
+		auto &reader = *lstate.job.reader;
 		//! Initialize the intermediate chunk to be used by the underlying reader before being finalized
 		vector<LogicalType> intermediate_chunk_types;
 		auto &local_column_ids = reader.column_indexes;
-		auto &local_columns = lstate.reader->GetColumns();
+		auto &local_columns = lstate.job.reader->GetColumns();
 		for (idx_t i = 0; i < local_column_ids.size(); i++) {
 			auto &local_id = local_column_ids[i];
 
@@ -459,29 +459,29 @@ public:
 
 			//! If we don't have a file to read, and the MultiFileList has no new file for us - end the scan
 			if (!HasFilesToRead(gstate, parallel_lock) && !TryGetNextFile(gstate, parallel_lock)) {
-				bind_data.interface->FinishReading(context, *gstate.global_state, *scan_data.local_state);
+				bind_data.interface->FinishReading(context, *gstate.global_state, *scan_data.job.reader_scan_state);
 				return false;
 			}
 
 			auto &current_reader_data = *gstate.readers[gstate.file_index];
 			if (current_reader_data.file_state == MultiFileFileState::OPEN) {
 				if (current_reader_data.reader->TryInitializeScan(context, *gstate.global_state,
-				                                                  *scan_data.local_state)) {
-					scan_data.reader = current_reader_data.reader;
-					if (!scan_data.reader) {
+				                                                  *scan_data.job.reader_scan_state)) {
+					scan_data.job.reader = current_reader_data.reader;
+					if (!scan_data.job.reader) {
 						throw InternalException("MultiFileReader was moved");
 					}
 					// The current reader has data left to be scanned
-					scan_data.batch_index = gstate.batch_index++;
-					auto old_file_index = scan_data.file_index;
-					scan_data.file_index = gstate.file_index;
+					scan_data.job.batch_index = gstate.batch_index++;
+					auto old_file_index = scan_data.job.file_index;
+					scan_data.job.file_index = gstate.file_index;
 					parallel_lock.unlock();
-					scan_data.reader->PrepareScan(context, *gstate.global_state, *scan_data.local_state);
-					if (old_file_index != scan_data.file_index) {
+					scan_data.job.reader->PrepareScan(context, *gstate.global_state, *scan_data.job.reader_scan_state);
+					if (old_file_index != scan_data.job.file_index) {
 						InitializeFileScanState(context, current_reader_data, scan_data, gstate.projection_ids);
 					}
 					// Initializing a batch is always a schedule phase
-					scan_data.phase = MultiFileScanPhase::SCHEDULE;
+					scan_data.job.phase = MultiFileScanPhase::SCHEDULE;
 					return true;
 				} else {
 					// Set state to the next file
@@ -525,8 +525,8 @@ public:
 
 		auto result = make_uniq<MultiFileLocalState>(context.client);
 		result->is_parallel = true;
-		result->batch_index = 0;
-		result->local_state = bind_data.interface->InitializeLocalState(context, *gstate.global_state);
+		result->job.batch_index = 0;
+		result->job.reader_scan_state = bind_data.interface->InitializeLocalState(context, *gstate.global_state);
 
 		if (!TryInitializeNextBatch(context.client, bind_data, *result, gstate)) {
 			return nullptr;
@@ -657,8 +657,8 @@ public:
 		auto &bind_data = input.bind_data->CastNoConst<MultiFileBindData>();
 		auto &data = input.local_state->Cast<MultiFileLocalState>();
 		auto &gstate = input.global_state->Cast<MultiFileGlobalState>();
-		OperatorPartitionData partition_data(data.batch_index);
-		bind_data.multi_file_reader->GetPartitionData(context, bind_data.reader_bind, *data.reader_data,
+		OperatorPartitionData partition_data(data.job.batch_index);
+		bind_data.multi_file_reader->GetPartitionData(context, bind_data.reader_bind, *data.job.reader_data,
 		                                              gstate.multi_file_reader_state, input.partition_info,
 		                                              partition_data);
 		return partition_data;
@@ -693,8 +693,8 @@ public:
 
 	static bool SchedulePhase(ClientContext &context, TableFunctionInput &data_p, MultiFileLocalState &data,
 	                          MultiFileGlobalState &gstate) {
-		auto scheduled = data.reader->ScheduleIO(context, *gstate.global_state, *data.local_state);
-		data.phase = MultiFileScanPhase::DECODE;
+		auto scheduled = data.job.reader->ScheduleIO(context, *gstate.global_state, *data.job.reader_scan_state);
+		data.job.phase = MultiFileScanPhase::DECODE;
 		if (scheduled.GetResultType() == AsyncResultType::BLOCKED) {
 			return HandleBlocked(data_p, scheduled);
 		}
@@ -709,7 +709,7 @@ public:
 			// keep. Hence, we only reset if we are not resuming from a blocked scan.
 			scan_chunk.Reset();
 		}
-		auto res = data.reader->Scan(context, *gstate.global_state, *data.local_state, scan_chunk);
+		auto res = data.job.reader->Scan(context, *gstate.global_state, *data.job.reader_scan_state, scan_chunk);
 
 		data.resuming_blocked_scan = res.GetResultType() == AsyncResultType::BLOCKED;
 		if (res.GetResultType() == AsyncResultType::BLOCKED) {
@@ -720,8 +720,8 @@ public:
 
 		if (scan_chunk.size() > 0) {
 			data.rows_scanned += scan_chunk.size();
-			bind_data.multi_file_reader->FinalizeChunk(context, bind_data, *data.reader, *data.reader_data, scan_chunk,
-			                                           output, data.executor, gstate.multi_file_reader_state);
+			bind_data.multi_file_reader->FinalizeChunk(context, bind_data, *data.job.reader, *data.job.reader_data,
+			                                           scan_chunk, output, data.executor, gstate.multi_file_reader_state);
 			output.SetChildCardinality(output.size());
 		}
 		if (res.GetResultType() == AsyncResultType::HAVE_MORE_OUTPUT) {
@@ -762,7 +762,7 @@ public:
 		}
 
 		do {
-			switch (data.phase) {
+			switch (data.job.phase) {
 			case MultiFileScanPhase::SCHEDULE:
 				if (SchedulePhase(context, data_p, data, gstate)) {
 					return;

--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -517,7 +517,6 @@ static void InitializeDecodeChunk(ClientContext &context, MultiFileLocalState &l
 		}
 
 		auto result = make_uniq<MultiFileLocalState>(context.client);
-		result->is_parallel = true;
 		result->job.batch_index = 0;
 		result->job.reader_scan_state = bind_data.interface->InitializeLocalState(context, *gstate.global_state);
 
@@ -694,8 +693,11 @@ static void InitializeDecodeChunk(ClientContext &context, MultiFileLocalState &l
 		return false;
 	}
 
-	static bool DecodePhase(ClientContext &context, TableFunctionInput &data_p, MultiFileLocalState &data,
-	                        MultiFileGlobalState &gstate, MultiFileBindData &bind_data, DataChunk &output) {
+	//! Decode the current job in place: scan a chunk and finalize it into 'output'. Never advances or finishes the job
+	//! - the caller claims the next one. Returns what the scan loop should do next.
+	static MultiFileDecodeResult DecodeCurrentJob(ClientContext &context, TableFunctionInput &data_p,
+	                                              MultiFileLocalState &data, MultiFileGlobalState &gstate,
+	                                              MultiFileBindData &bind_data, DataChunk &output) {
 		if (data.scan_chunk_file_index != data.job.file_index) {
 			// if the file changes we need to initialize the chunk again
 			InitializeDecodeChunk(context, data, gstate.projection_ids);
@@ -710,11 +712,10 @@ static void InitializeDecodeChunk(ClientContext &context, MultiFileLocalState &l
 
 		data.resuming_blocked_scan = res.GetResultType() == AsyncResultType::BLOCKED;
 		if (res.GetResultType() == AsyncResultType::BLOCKED) {
-			return HandleBlocked(data_p, res);
+			return HandleBlocked(data_p, res) ? MultiFileDecodeResult::PARKED : MultiFileDecodeResult::CONTINUE;
 		}
 
 		output.SetChildCardinality(scan_chunk.size());
-
 		if (scan_chunk.size() > 0) {
 			data.rows_scanned += scan_chunk.size();
 			bind_data.multi_file_reader->FinalizeChunk(context, bind_data, *data.job.reader, *data.job.reader_data,
@@ -723,25 +724,14 @@ static void InitializeDecodeChunk(ClientContext &context, MultiFileLocalState &l
 		}
 		if (res.GetResultType() == AsyncResultType::HAVE_MORE_OUTPUT) {
 			// More chunks left on this batch, lets keep going
-			return EmitOutput(data_p, output);
+			return EmitOutput(data_p, output) ? MultiFileDecodeResult::EMITTED_RETURN : MultiFileDecodeResult::CONTINUE;
 		}
-
 		if (res.GetResultType() != AsyncResultType::FINISHED) {
 			throw InternalException("Unexpected result in MultiFileScan, must be FINISHED, is %s",
 			                        EnumUtil::ToChars(res.GetResultType()));
 		}
-
-		// We are done with this batch
-		if (!ClaimNextJob(context, bind_data, gstate, data.job)) {
-			if (output.size() > 0 && data_p.results_execution_mode == AsyncResultsExecutionMode::SYNCHRONOUS) {
-				gstate.finished = true;
-				data_p.async_result = SourceResultType::HAVE_MORE_OUTPUT;
-			} else {
-				data_p.async_result = SourceResultType::FINISHED;
-			}
-			return true;
-		}
-		return EmitOutput(data_p, output);
+		// this batch is fully decoded - the caller claims the next one
+		return MultiFileDecodeResult::JOB_FINISHED;
 	}
 
 	static void MultiFileScan(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
@@ -766,8 +756,28 @@ static void InitializeDecodeChunk(ClientContext &context, MultiFileLocalState &l
 				}
 				break;
 			case MultiFileScanPhase::DECODE:
-				if (DecodePhase(context, data_p, data, gstate, bind_data, output)) {
+				switch (DecodeCurrentJob(context, data_p, data, gstate, bind_data, output)) {
+				case MultiFileDecodeResult::CONTINUE:
+					break;
+				case MultiFileDecodeResult::EMITTED_RETURN:
+				case MultiFileDecodeResult::PARKED:
 					return;
+				case MultiFileDecodeResult::JOB_FINISHED:
+					// we are done with this batch - claim the next one (a fresh job starts in the schedule phase)
+					if (!ClaimNextJob(context, bind_data, gstate, data.job)) {
+						if (output.size() > 0 &&
+						    data_p.results_execution_mode == AsyncResultsExecutionMode::SYNCHRONOUS) {
+							gstate.finished = true;
+							data_p.async_result = SourceResultType::HAVE_MORE_OUTPUT;
+						} else {
+							data_p.async_result = SourceResultType::FINISHED;
+						}
+						return;
+					}
+					if (EmitOutput(data_p, output)) {
+						return;
+					}
+					break;
 				}
 				break;
 			default:

--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -693,8 +693,6 @@ static void InitializeDecodeChunk(ClientContext &context, MultiFileLocalState &l
 		return false;
 	}
 
-	//! Decode the current job in place: scan a chunk and finalize it into 'output'. Never advances or finishes the job
-	//! - the caller claims the next one. Returns what the scan loop should do next.
 	static MultiFileDecodeResult DecodeCurrentJob(ClientContext &context, TableFunctionInput &data_p,
 	                                              MultiFileLocalState &data, MultiFileGlobalState &gstate,
 	                                              MultiFileBindData &bind_data, DataChunk &output) {
@@ -763,7 +761,7 @@ static void InitializeDecodeChunk(ClientContext &context, MultiFileLocalState &l
 				case MultiFileDecodeResult::PARKED:
 					return;
 				case MultiFileDecodeResult::JOB_FINISHED:
-					// we are done with this batch - claim the next one (a fresh job starts in the schedule phase)
+					// done with this job, gotta claim the next one
 					if (!ClaimNextJob(context, bind_data, gstate, data.job)) {
 						if (output.size() > 0 &&
 						    data_p.results_execution_mode == AsyncResultsExecutionMode::SYNCHRONOUS) {

--- a/src/include/duckdb/common/multi_file/multi_file_states.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_states.hpp
@@ -189,10 +189,9 @@ enum class MultiFileScanPhase : uint8_t { SCHEDULE, DECODE };
 
 //! Outcome of decoding the current scan job (see MultiFileFunction::DecodeCurrentJob)
 enum class MultiFileDecodeResult : uint8_t {
-	CONTINUE,       //! keep looping (BLOCKED ran inline, or an empty chunk was suppressed)
-	EMITTED_RETURN, //! a chunk was emitted to the caller - return from the scan
-	JOB_FINISHED,   //! the job is fully decoded - the caller claims the next one
-	PARKED          //! the operator parked on async I/O - return from the scan
+	CONTINUE,         //! keep looping
+	RETURN_TO_CALLER, //! return from the scan (a chunk was emitted, or the operator parked on async I/O)
+	JOB_FINISHED      //! job is done
 };
 
 //! A single, independently schedulable unit of scan work (e.g. one Parquet row group of one file)

--- a/src/include/duckdb/common/multi_file/multi_file_states.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_states.hpp
@@ -187,6 +187,14 @@ struct MultiFileGlobalState : public GlobalTableFunctionState {
 //! Phase of a scan job: we are either scheduling its I/O or decoding it
 enum class MultiFileScanPhase : uint8_t { SCHEDULE, DECODE };
 
+//! Outcome of decoding the current scan job (see MultiFileFunction::DecodeCurrentJob)
+enum class MultiFileDecodeResult : uint8_t {
+	CONTINUE,       //! keep looping (BLOCKED ran inline, or an empty chunk was suppressed)
+	EMITTED_RETURN, //! a chunk was emitted to the caller - return from the scan
+	JOB_FINISHED,   //! the job is fully decoded - the caller claims the next one
+	PARKED          //! the operator parked on async I/O - return from the scan
+};
+
 //! A single, independently schedulable unit of scan work (e.g. one Parquet row group of one file)
 struct MultiFileScanJob {
 	//! The reader producing this job (kept alive for the job's lifetime)
@@ -211,7 +219,6 @@ public:
 public:
 	//! The job currently being scanned by this thread
 	MultiFileScanJob job;
-	bool is_parallel;
 	//! The chunk written to by the reader, handed to FinalizeChunk to transform to the global schema
 	DataChunk scan_chunk;
 	//! Set when the previous Scan() returned BLOCKED, so the next Scan() preserves the partial chunk

--- a/src/include/duckdb/common/multi_file/multi_file_states.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_states.hpp
@@ -216,7 +216,7 @@ public:
 	DataChunk scan_chunk;
 	//! Set when the previous Scan() returned BLOCKED, so the next Scan() preserves the partial chunk
 	bool resuming_blocked_scan = false;
-	//! The file index that scan_chunk + executor are currently initialized for.
+	//! The file index that scan_chunk is initialized for.
 	idx_t scan_chunk_file_index = DConstants::INVALID_INDEX;
 	//! The executor to transform scan_chunk into the final result with FinalizeChunk
 	ExpressionExecutor executor;

--- a/src/include/duckdb/common/multi_file/multi_file_states.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_states.hpp
@@ -216,6 +216,8 @@ public:
 	DataChunk scan_chunk;
 	//! Set when the previous Scan() returned BLOCKED, so the next Scan() preserves the partial chunk
 	bool resuming_blocked_scan = false;
+	//! The file index that scan_chunk + executor are currently initialized for.
+	idx_t scan_chunk_file_index = DConstants::INVALID_INDEX;
 	//! The executor to transform scan_chunk into the final result with FinalizeChunk
 	ExpressionExecutor executor;
 	//! Number of rows scanned by this thread (for profiling)

--- a/src/include/duckdb/common/multi_file/multi_file_states.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_states.hpp
@@ -184,8 +184,24 @@ struct MultiFileGlobalState : public GlobalTableFunctionState {
 	}
 };
 
-//! Phase of the per-thread multi-file scan: we are either scheduling or decoding
+//! Phase of a scan job: we are either scheduling its I/O or decoding it
 enum class MultiFileScanPhase : uint8_t { SCHEDULE, DECODE };
+
+//! A single, independently schedulable unit of scan work (e.g. one Parquet row group of one file)
+struct MultiFileScanJob {
+	//! The reader producing this job (kept alive for the job's lifetime)
+	shared_ptr<BaseFileReader> reader;
+	//! Per-file data for the reader (constants/expressions used by FinalizeChunk)
+	optional_ptr<MultiFileReaderData> reader_data;
+	//! The reader-specific scan state that ScheduleIO/Scan operate on
+	unique_ptr<LocalTableFunctionState> reader_scan_state;
+	//! Batch index of this job (assigned in scan order under the global lock)
+	idx_t batch_index = 0;
+	//! Index of the file this job belongs to
+	idx_t file_index = DConstants::INVALID_INDEX;
+	//! Whether this job still needs its I/O scheduled or is ready to decode
+	MultiFileScanPhase phase = MultiFileScanPhase::SCHEDULE;
+};
 
 struct MultiFileLocalState : public LocalTableFunctionState {
 public:
@@ -193,18 +209,13 @@ public:
 	}
 
 public:
-	shared_ptr<BaseFileReader> reader;
-	optional_ptr<MultiFileReaderData> reader_data;
+	//! The job currently being scanned by this thread
+	MultiFileScanJob job;
 	bool is_parallel;
-	idx_t batch_index;
-	idx_t file_index = DConstants::INVALID_INDEX;
-	unique_ptr<LocalTableFunctionState> local_state;
 	//! The chunk written to by the reader, handed to FinalizeChunk to transform to the global schema
 	DataChunk scan_chunk;
 	//! Set when the previous Scan() returned BLOCKED, so the next Scan() preserves the partial chunk
 	bool resuming_blocked_scan = false;
-	//! Whether the current batch still needs its I/O scheduled or is ready to decode
-	MultiFileScanPhase phase = MultiFileScanPhase::SCHEDULE;
 	//! The executor to transform scan_chunk into the final result with FinalizeChunk
 	ExpressionExecutor executor;
 	//! Number of rows scanned by this thread (for profiling)

--- a/src/include/duckdb/common/multi_file/multi_file_states.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_states.hpp
@@ -196,13 +196,13 @@ enum class MultiFileDecodeResult : uint8_t {
 
 //! A single, independently schedulable unit of scan work (e.g. one Parquet row group of one file)
 struct MultiFileScanJob {
-	//! The reader producing this job (kept alive for the job's lifetime)
+	//! The reader producing this job
 	shared_ptr<BaseFileReader> reader;
-	//! Per-file data for the reader (constants/expressions used by FinalizeChunk)
+	//! Per-file data for the reader
 	optional_ptr<MultiFileReaderData> reader_data;
 	//! The reader-specific scan state that ScheduleIO/Scan operate on
 	unique_ptr<LocalTableFunctionState> reader_scan_state;
-	//! Batch index of this job (assigned in scan order under the global lock)
+	//! Batch index of this job
 	idx_t batch_index = 0;
 	//! Index of the file this job belongs to
 	idx_t file_index = DConstants::INVALID_INDEX;


### PR DESCRIPTION
This PR refactors the multi-file scan further, so we will be able to support the upcoming async-I/O read-ahead. 
The main idea is that the scan now has jobs that can be decoupled from the decoding thread.