### PR TITLE
Finalize hash groups early in `PartitionedCopy`

### DIFF
--- a/src/execution/operator/persistent/physical_copy_to_file.cpp
+++ b/src/execution/operator/persistent/physical_copy_to_file.cpp
@@ -539,6 +539,7 @@ public:
 //===--------------------------------------------------------------------===//
 enum class PartitionedCopyStage : uint8_t { SORT, MATERIALIZE, MASK, BATCH, PREPARE, FLUSH, DONE };
 enum class FileCreationReason : uint8_t { NORMAL, SORTED_RUN_BOUNDARY, ROTATION };
+enum class PartitionedCopyFinalizeTrigger : uint8_t { PARTITION_RUN_DONE, FINAL_PARTITION_DRAIN_DONE };
 
 struct PartitionedCopyTask {
 	PartitionedCopyStage stage = PartitionedCopyStage::DONE;
@@ -613,6 +614,9 @@ private:
 };
 
 class PartitionWriteManager {
+	using ActiveWrites = vector_of_value_map_t<unique_ptr<PartitionWriteInfo>>;
+	using ActiveWriteIterator = ActiveWrites::iterator;
+
 public:
 	class ReservationLock {
 	public:
@@ -639,16 +643,18 @@ public:
 	ReservationLock LockForReservation() DUCKDB_EXCLUDES(lock);
 	PartitionFileStateReservation ReserveFileState(ReservationLock &reservation_lock, const vector<Value> &values,
 	                                               FileCreationReason reason) DUCKDB_NO_THREAD_SAFETY_ANALYSIS;
+	FileStateHandle TryTakeInactiveFileState(const vector<Value> &values) DUCKDB_EXCLUDES(lock);
 	vector<FileStateHandle> TakeOpenFileStates() DUCKDB_EXCLUDES(lock);
 
 private:
+	FileStateHandle TakeInactiveFileStateLocked(ActiveWriteIterator entry) DUCKDB_REQUIRES(lock);
 	void Release(PartitionWriteInfo &write_info) DUCKDB_EXCLUDES(lock);
 
 private:
 	const PhysicalCopyToFile &op;
 	ClientContext &context;
 	mutable annotated_mutex lock;
-	vector_of_value_map_t<unique_ptr<PartitionWriteInfo>> active_writes DUCKDB_GUARDED_BY(lock);
+	ActiveWrites active_writes DUCKDB_GUARDED_BY(lock);
 	vector_of_value_map_t<idx_t> previous_partitions DUCKDB_GUARDED_BY(lock);
 	idx_t global_offset DUCKDB_GUARDED_BY(lock) = 0;
 
@@ -1224,7 +1230,7 @@ public:
 	bool HasCompleted() const;
 	optional<PartitionedCopyTask> TryAssignTask();
 	void ExecuteTask(ExecutionContext &execution_context, const PartitionedCopyTask &task, InterruptState &interrupt);
-	void FinishTask(const PartitionedCopyTask &task);
+	vector<vector<Value>> FinishTask(const PartitionedCopyTask &task);
 
 public:
 	//! The PartitionedCopy that this state belongs to
@@ -1303,6 +1309,8 @@ public:
 	                              DelayedPartitionFlush flush);
 	void RequestPartitionFileState(FileStateHandle &file_state, const vector<Value> &values,
 	                               FileCreationReason reason = FileCreationReason::NORMAL)
+	    DUCKDB_EXCLUDES(copy_gstate.lock);
+	void TryFinalizePartitionWrite(const vector<Value> &values, PartitionedCopyFinalizeTrigger trigger)
 	    DUCKDB_EXCLUDES(copy_gstate.lock);
 	void FinalizeActiveWrites() DUCKDB_EXCLUDES(copy_gstate.lock);
 	void FinalizeFileStates(vector<FileStateHandle> files_to_finalize) DUCKDB_EXCLUDES(copy_gstate.lock);
@@ -1753,9 +1761,7 @@ PartitionWriteManager::ReserveFileState(ReservationLock &reservation_lock, const
 	if (active_writes.size() >= Settings::Get<PartitionedWriteMaxOpenFilesSetting>(context)) {
 		for (auto it = active_writes.begin(); it != active_writes.end(); ++it) {
 			if (it->second->active_writes == 0) {
-				reservation.files_to_finalize.push_back(std::move(it->second->file_state));
-				++previous_partitions[it->first];
-				active_writes.erase(it);
+				reservation.files_to_finalize.push_back(TakeInactiveFileStateLocked(it));
 				break;
 			}
 		}
@@ -1787,6 +1793,27 @@ vector<FileStateHandle> PartitionWriteManager::TakeOpenFileStates() {
 		active_writes.clear();
 	}
 	return files_to_finalize;
+}
+
+FileStateHandle PartitionWriteManager::TakeInactiveFileStateLocked(ActiveWriteIterator entry) {
+	D_ASSERT(entry != active_writes.end());
+	D_ASSERT(entry->second->active_writes == 0);
+
+	auto file_state = std::move(entry->second->file_state);
+	if (op.hive_file_pattern) {
+		++previous_partitions[entry->first];
+	}
+	active_writes.erase(entry);
+	return file_state;
+}
+
+FileStateHandle PartitionWriteManager::TryTakeInactiveFileState(const vector<Value> &values) {
+	annotated_lock_guard<annotated_mutex> guard(lock);
+	auto entry = active_writes.find(values);
+	if (entry == active_writes.end() || entry->second->active_writes > 0) {
+		return FileStateHandle();
+	}
+	return TakeInactiveFileStateLocked(entry);
 }
 
 void PartitionWriteManager::Release(PartitionWriteInfo &write_info) {
@@ -2278,6 +2305,8 @@ void PartitionedCopyHashGroup::Flush(ExecutionContext &execution_context, Interr
 	D_ASSERT(flush_action.write_lease);
 	partitioned_copy.FlushPreparedPartitionRun(flush_action.values, *flush_action.write_lease,
 	                                           std::move(flush_action.batches));
+	flush_action.write_lease.Reset();
+	partitioned_copy.TryFinalizePartitionWrite(flush_action.values, PartitionedCopyFinalizeTrigger::PARTITION_RUN_DONE);
 }
 
 //===--------------------------------------------------------------------===//
@@ -2427,17 +2456,28 @@ void PartitionedCopyState::ExecuteTask(ExecutionContext &execution_context, cons
 	default:
 		throw InternalException("Invalid PartitionedCopyStage in PartitionedCopyState::ExecuteTask");
 	}
-	FinishTask(task);
+	auto partitions_to_finalize = FinishTask(task);
+	for (const auto &values : partitions_to_finalize) {
+		partitioned_copy.TryFinalizePartitionWrite(values, PartitionedCopyFinalizeTrigger::FINAL_PARTITION_DRAIN_DONE);
+	}
 }
 
-void PartitionedCopyState::FinishTask(const PartitionedCopyTask &task) {
+vector<vector<Value>> PartitionedCopyState::FinishTask(const PartitionedCopyTask &task) {
 	const auto group_idx = task.group_idx;
 	auto &finished_hash_group = hash_groups[group_idx];
+	vector<vector<Value>> partitions_to_finalize;
 
 	bool hash_group_completed = false;
 	if (task.stage == PartitionedCopyStage::FLUSH) {
 		annotated_lock_guard<annotated_mutex> group_guard(finished_hash_group->lock);
 		hash_group_completed = ++finished_hash_group->flushed == finished_hash_group->batch_states.size();
+		if (hash_group_completed) {
+			partitions_to_finalize.reserve(finished_hash_group->batch_states.size());
+			for (const auto &batch_state : finished_hash_group->batch_states) {
+				D_ASSERT(batch_state);
+				partitions_to_finalize.push_back(batch_state->Values());
+			}
+		}
 	}
 
 	if (hash_group_completed) {
@@ -2446,6 +2486,7 @@ void PartitionedCopyState::FinishTask(const PartitionedCopyTask &task) {
 		v.erase(std::remove(v.begin(), v.end(), group_idx), v.end());
 		finished_hash_group.reset();
 	}
+	return partitions_to_finalize;
 }
 
 //===--------------------------------------------------------------------===//
@@ -3043,10 +3084,12 @@ void PartitionedCopy::FlushPartitionCollection(ExecutionContext &execution_conte
 
 			auto write_lease = partition_writes.Acquire(flush.values);
 			FlushDelayedPartitionRun(flush.values, *write_lease, *flush.data.collection);
+			write_lease.Reset();
 		}
 
 		auto next = delayed_guard.Complete();
 		if (!next) {
+			TryFinalizePartitionWrite(flush.values, PartitionedCopyFinalizeTrigger::FINAL_PARTITION_DRAIN_DONE);
 			return;
 		}
 		flush = std::move(*next);
@@ -3145,6 +3188,29 @@ void PartitionedCopy::EnsureFreshPartitionFile(PartitionWriteInfo &write_info, c
 	}
 
 	copy_gstate.FinalizeFileState(std::move(old_file_state));
+}
+
+void PartitionedCopy::TryFinalizePartitionWrite(const vector<Value> &values, PartitionedCopyFinalizeTrigger trigger) {
+	if (!finalized.load(std::memory_order_relaxed)) {
+		return;
+	}
+	if (trigger == PartitionedCopyFinalizeTrigger::PARTITION_RUN_DONE && RequiresSerializedPartitionWrites()) {
+		return;
+	}
+	{
+		annotated_lock_guard<annotated_mutex> guard(lock);
+		if (sinking_state) {
+			return;
+		}
+	}
+	if (HasDelayedPartition(values)) {
+		return;
+	}
+
+	auto file_state = partition_writes.TryTakeInactiveFileState(values);
+	if (file_state) {
+		copy_gstate.FinalizeFileState(std::move(file_state));
+	}
 }
 
 void PartitionedCopy::FinalizeActiveWrites() {

--- a/src/execution/operator/persistent/physical_copy_to_file.cpp
+++ b/src/execution/operator/persistent/physical_copy_to_file.cpp
@@ -539,7 +539,6 @@ public:
 //===--------------------------------------------------------------------===//
 enum class PartitionedCopyStage : uint8_t { SORT, MATERIALIZE, MASK, BATCH, PREPARE, FLUSH, DONE };
 enum class FileCreationReason : uint8_t { NORMAL, SORTED_RUN_BOUNDARY, ROTATION };
-enum class PartitionedCopyFinalizeTrigger : uint8_t { PARTITION_RUN_DONE, FINAL_PARTITION_DRAIN_DONE };
 
 struct PartitionedCopyTask {
 	PartitionedCopyStage stage = PartitionedCopyStage::DONE;
@@ -1310,8 +1309,7 @@ public:
 	void RequestPartitionFileState(FileStateHandle &file_state, const vector<Value> &values,
 	                               FileCreationReason reason = FileCreationReason::NORMAL)
 	    DUCKDB_EXCLUDES(copy_gstate.lock);
-	void TryFinalizePartitionWrite(const vector<Value> &values, PartitionedCopyFinalizeTrigger trigger)
-	    DUCKDB_EXCLUDES(copy_gstate.lock);
+	void TryFinalizePartitionWrite(const vector<Value> &values) DUCKDB_EXCLUDES(copy_gstate.lock);
 	void FinalizeActiveWrites() DUCKDB_EXCLUDES(copy_gstate.lock);
 	void FinalizeFileStates(vector<FileStateHandle> files_to_finalize) DUCKDB_EXCLUDES(copy_gstate.lock);
 
@@ -2306,7 +2304,7 @@ void PartitionedCopyHashGroup::Flush(ExecutionContext &execution_context, Interr
 	partitioned_copy.FlushPreparedPartitionRun(flush_action.values, *flush_action.write_lease,
 	                                           std::move(flush_action.batches));
 	flush_action.write_lease.Reset();
-	partitioned_copy.TryFinalizePartitionWrite(flush_action.values, PartitionedCopyFinalizeTrigger::PARTITION_RUN_DONE);
+	partitioned_copy.TryFinalizePartitionWrite(flush_action.values);
 }
 
 //===--------------------------------------------------------------------===//
@@ -2458,7 +2456,7 @@ void PartitionedCopyState::ExecuteTask(ExecutionContext &execution_context, cons
 	}
 	auto partitions_to_finalize = FinishTask(task);
 	for (const auto &values : partitions_to_finalize) {
-		partitioned_copy.TryFinalizePartitionWrite(values, PartitionedCopyFinalizeTrigger::FINAL_PARTITION_DRAIN_DONE);
+		partitioned_copy.TryFinalizePartitionWrite(values);
 	}
 }
 
@@ -3089,7 +3087,7 @@ void PartitionedCopy::FlushPartitionCollection(ExecutionContext &execution_conte
 
 		auto next = delayed_guard.Complete();
 		if (!next) {
-			TryFinalizePartitionWrite(flush.values, PartitionedCopyFinalizeTrigger::FINAL_PARTITION_DRAIN_DONE);
+			TryFinalizePartitionWrite(flush.values);
 			return;
 		}
 		flush = std::move(*next);
@@ -3190,11 +3188,8 @@ void PartitionedCopy::EnsureFreshPartitionFile(PartitionWriteInfo &write_info, c
 	copy_gstate.FinalizeFileState(std::move(old_file_state));
 }
 
-void PartitionedCopy::TryFinalizePartitionWrite(const vector<Value> &values, PartitionedCopyFinalizeTrigger trigger) {
+void PartitionedCopy::TryFinalizePartitionWrite(const vector<Value> &values) {
 	if (!finalized.load(std::memory_order_relaxed)) {
-		return;
-	}
-	if (trigger == PartitionedCopyFinalizeTrigger::PARTITION_RUN_DONE && RequiresSerializedPartitionWrites()) {
 		return;
 	}
 	{

--- a/test/sql/copy/partitioned/partitioned_early_finalize.test
+++ b/test/sql/copy/partitioned/partitioned_early_finalize.test
@@ -1,0 +1,157 @@
+# name: test/sql/copy/partitioned/partitioned_early_finalize.test
+# description: exercise final-drain partition finalization for partitioned COPY
+# group: [partitioned]
+
+require parquet
+
+statement ok
+PRAGMA threads=4;
+
+statement ok
+SET partitioned_write_max_open_files=1024;
+
+statement ok
+SET partitioned_write_flush_threshold=64;
+
+statement ok
+CREATE TABLE partitioned_early_finalize_source AS
+SELECT
+	(i % 32)::INTEGER AS p,
+	i::INTEGER AS v,
+	repeat('payload-', 4) || i::VARCHAR AS payload
+FROM range(0, 8192) tbl(i);
+
+statement ok
+COPY partitioned_early_finalize_source
+TO '{TEST_DIR}/partitioned_early_finalize'
+(FORMAT PARQUET, PARTITION_BY (p), ROW_GROUP_SIZE 64);
+
+query II
+SELECT count(*), sum(v)
+FROM read_parquet('{TEST_DIR}/partitioned_early_finalize/**/*.parquet', hive_partitioning = true);
+----
+8192	33550336
+
+query I
+WITH files AS (
+	SELECT p, count(DISTINCT filename) AS file_count
+	FROM read_parquet(
+		'{TEST_DIR}/partitioned_early_finalize/**/*.parquet',
+		filename = true,
+		hive_partitioning = true
+	)
+	GROUP BY p
+)
+SELECT max(file_count)
+FROM files;
+----
+1
+
+statement ok
+SET partitioned_write_flush_threshold=128;
+
+statement ok
+CREATE TABLE partitioned_early_finalize_delayed AS
+SELECT
+	CASE WHEN i % 13 = 0 THEN ((i / 13) % 16) + 1 ELSE 0 END::INTEGER AS p,
+	i::INTEGER AS v
+FROM range(0, 12288) tbl(i);
+
+statement ok
+COPY partitioned_early_finalize_delayed
+TO '{TEST_DIR}/partitioned_early_finalize_delayed'
+(FORMAT PARQUET, PARTITION_BY (p), ROW_GROUP_SIZE 64);
+
+query II
+SELECT count(*), count(DISTINCT p)
+FROM read_parquet('{TEST_DIR}/partitioned_early_finalize_delayed/**/*.parquet', hive_partitioning = true);
+----
+12288	17
+
+query I
+WITH files AS (
+	SELECT p, count(DISTINCT filename) AS file_count
+	FROM read_parquet(
+		'{TEST_DIR}/partitioned_early_finalize_delayed/**/*.parquet',
+		filename = true,
+		hive_partitioning = true
+	)
+	GROUP BY p
+)
+SELECT max(file_count)
+FROM files
+WHERE p <> 0;
+----
+1
+
+statement ok
+CREATE TABLE partitioned_early_finalize_serialized AS
+SELECT
+	(i % 8)::INTEGER AS p,
+	((i * 131) % 4096)::INTEGER AS v,
+	i::INTEGER AS payload
+FROM range(0, 4096) tbl(i);
+
+statement ok
+COPY (SELECT p, v, payload FROM partitioned_early_finalize_serialized ORDER BY v DESC, p DESC)
+TO '{TEST_DIR}/partitioned_early_finalize_ordered'
+(FORMAT PARQUET, PARTITION_BY (p), ORDER_BY (v), ROW_GROUP_SIZE 64);
+
+query II
+SELECT count(*), count(DISTINCT p)
+FROM read_parquet('{TEST_DIR}/partitioned_early_finalize_ordered/**/*.parquet', hive_partitioning = true);
+----
+4096	8
+
+query I
+WITH per_file AS (
+	SELECT
+		filename,
+		v,
+		lag(v) OVER (PARTITION BY filename ORDER BY file_row_number) AS prev_v
+	FROM read_parquet(
+		'{TEST_DIR}/partitioned_early_finalize_ordered/**/*.parquet',
+		filename = true,
+		file_row_number = true,
+		hive_partitioning = true
+	)
+)
+SELECT count(*)
+FROM per_file
+WHERE prev_v IS NOT NULL AND prev_v > v;
+----
+0
+
+statement ok
+CREATE TABLE partitioned_early_finalize_rotation_source AS
+SELECT
+	(i % 4)::INTEGER AS p,
+	((i * 17) % 32768)::INTEGER AS v,
+	hash(i)::DOUBLE AS payload
+FROM range(0, 32768) tbl(i);
+
+statement ok
+COPY partitioned_early_finalize_rotation_source
+TO '{TEST_DIR}/partitioned_early_finalize_rotation'
+(FORMAT PARQUET, PARTITION_BY (p), ROW_GROUP_SIZE 1024, ROW_GROUPS_PER_FILE 1);
+
+query I
+SELECT count(*)
+FROM read_parquet('{TEST_DIR}/partitioned_early_finalize_rotation/**/*.parquet', hive_partitioning = true);
+----
+32768
+
+query I
+WITH files AS (
+	SELECT p, count(DISTINCT filename) AS file_count
+	FROM read_parquet(
+		'{TEST_DIR}/partitioned_early_finalize_rotation/**/*.parquet',
+		filename = true,
+		hive_partitioning = true
+	)
+	GROUP BY p
+)
+SELECT min(file_count) > 1
+FROM files;
+----
+true


### PR DESCRIPTION
At the very end we would finalize all the hash groups, but finalizing them as early as possible (and importantly, while overlapping with CPU work) is better at saturating IO bandwidth.