### PR TITLE
Enabled `ALP` and `ALP_RD` for storage version v1.5.0 and up when using smaller block sizes

### DIFF
--- a/src/include/duckdb/storage/compression/alp/alp_analyze.hpp
+++ b/src/include/duckdb/storage/compression/alp/alp_analyze.hpp
@@ -66,9 +66,19 @@ public:
 
 template <class T>
 unique_ptr<AnalyzeState> AlpInitAnalyze(ColumnData &col_data, PhysicalType type) {
-	CompressionInfo info(col_data.GetBlockManager());
+	auto &storage_manager = col_data.GetStorageManager();
+	auto &block_manager = storage_manager.GetBlockManager();
+
+	if (block_manager.GetBlockSize() + block_manager.GetBlockHeaderSize() < DEFAULT_BLOCK_ALLOC_SIZE) {
+		if (storage_manager.GetStorageVersion() < 7) {
+			// Before v1.5.0, blocks cannot use uncompressed-vector fallback
+			return nullptr;
+		}
+	}
+
+	CompressionInfo info(block_manager);
 	auto state = make_uniq<AlpAnalyzeState<T>>(info);
-	state->storage_version = col_data.GetStorageManager().GetStorageVersion();
+	state->storage_version = storage_manager.GetStorageVersion();
 	return unique_ptr<AnalyzeState>(std::move(state));
 }
 
@@ -77,10 +87,6 @@ unique_ptr<AnalyzeState> AlpInitAnalyze(ColumnData &col_data, PhysicalType type)
  */
 template <class T>
 bool AlpAnalyze(AnalyzeState &state, Vector &input, idx_t count) {
-	if (state.info.GetBlockSize() + state.info.GetBlockHeaderSize() < DEFAULT_BLOCK_ALLOC_SIZE) {
-		return false;
-	}
-
 	auto &analyze_state = state.Cast<AlpAnalyzeState<T>>();
 
 	bool must_skip_current_vector = alp::AlpUtils::MustSkipSamplingFromCurrentVector(
@@ -146,7 +152,7 @@ bool AlpAnalyze(AnalyzeState &state, Vector &input, idx_t count) {
  */
 template <class T>
 idx_t AlpFinalAnalyze(AnalyzeState &state) {
-	auto &analyze_state = (AlpAnalyzeState<T> &)state;
+	auto &analyze_state = state.Cast<AlpAnalyzeState<T>>();
 
 	// Finding the Top K combinations of Exponent and Factor
 	alp::AlpCompression<T, true>::FindTopKCombinations(analyze_state.rowgroup_sample, analyze_state.compression_data);

--- a/src/include/duckdb/storage/compression/alp/alp_analyze.hpp
+++ b/src/include/duckdb/storage/compression/alp/alp_analyze.hpp
@@ -16,8 +16,6 @@
 #include "duckdb/storage/compression/patas/patas.hpp"
 #include "duckdb/storage/table/column_data.hpp"
 
-#include <cmath>
-
 namespace duckdb {
 
 template <class T>

--- a/src/include/duckdb/storage/compression/alprd/alprd_analyze.hpp
+++ b/src/include/duckdb/storage/compression/alprd/alprd_analyze.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb/common/numeric_utils.hpp"
 #include "duckdb/function/compression_function.hpp"
+#include "duckdb/storage/storage_manager.hpp"
 #include "duckdb/storage/compression/alp/alp_constants.hpp"
 #include "duckdb/storage/compression/alp/alp_utils.hpp"
 #include "duckdb/storage/compression/alprd/algorithm/alprd.hpp"

--- a/src/include/duckdb/storage/compression/alprd/alprd_analyze.hpp
+++ b/src/include/duckdb/storage/compression/alprd/alprd_analyze.hpp
@@ -38,7 +38,17 @@ public:
 
 template <class T>
 unique_ptr<AnalyzeState> AlpRDInitAnalyze(ColumnData &col_data, PhysicalType type) {
-	CompressionInfo info(col_data.GetBlockManager());
+	auto &storage_manager = col_data.GetStorageManager();
+	auto &block_manager = storage_manager.GetBlockManager();
+
+	if (block_manager.GetBlockSize() + block_manager.GetBlockHeaderSize() < DEFAULT_BLOCK_ALLOC_SIZE) {
+		if (storage_manager.GetStorageVersion() < 7) {
+			// Before v1.5.0, blocks cannot use uncompressed-vector fallback
+			return nullptr;
+		}
+	}
+
+	CompressionInfo info(block_manager);
 	return make_uniq<AlpRDAnalyzeState<T>>(info);
 }
 
@@ -47,10 +57,6 @@ unique_ptr<AnalyzeState> AlpRDInitAnalyze(ColumnData &col_data, PhysicalType typ
  */
 template <class T>
 bool AlpRDAnalyze(AnalyzeState &state, Vector &input, idx_t count) {
-	if (state.info.GetBlockSize() + state.info.GetBlockHeaderSize() < DEFAULT_BLOCK_ALLOC_SIZE) {
-		return false;
-	}
-
 	using EXACT_TYPE = typename FloatingToExact<T>::TYPE;
 	auto &analyze_state = state.Cast<AlpRDAnalyzeState<T>>();
 

--- a/test/configs/block_size_16kB.json
+++ b/test/configs/block_size_16kB.json
@@ -18,14 +18,9 @@
       ]
     },
     {
-      "reason": "ALP and ALPRD are disabled for non-default block sizes.",
+      "reason": "Before storage version v1.5.0 ALP and ALPRD are disabled for non-default block sizes.",
       "paths": [
-        "test/sql/storage/compression/alp/alp_min_max.test",
-        "test/sql/storage/compression/alprd/alprd_min_max.test",
-        "test/sql/storage/compression/alp/alp_uncompressed_mode_v1_4_0.test_slow",
-        "test/sql/storage/compression/alp/alp_uncompressed_mode_v1_5_0.test_slow",
-        "test/sql/storage/compression/alprd/alprd_tpcds.test_slow",
-        "test/sql/storage/compression/alp/alp_tpcds.test_slow"
+        "test/sql/storage/compression/alp/alp_uncompressed_mode_v1_4_0.test_slow"
       ]
     }
   ]

--- a/test/sql/storage/compression/alp/alp_min_max.test
+++ b/test/sql/storage/compression/alp/alp_min_max.test
@@ -1,7 +1,7 @@
 # name: test/sql/storage/compression/alp/alp_min_max.test
 # group: [alp]
 
-load __TEST_DIR__/alp_min_max.db
+load __TEST_DIR__/alp_min_max.db readwrite v1.5.0
 
 statement ok
 PRAGMA enable_verification

--- a/test/sql/storage/compression/alp/alp_storage_version.test
+++ b/test/sql/storage/compression/alp/alp_storage_version.test
@@ -1,0 +1,53 @@
+# name: test/sql/storage/compression/alp/alp_storage_version.test
+# group: [alp]
+
+statement ok
+ATTACH '{TEST_DIR}/alp-v1_4_0-16k.db' AS alp_v1_4_0 (STORAGE_VERSION 'v1.4.0', BLOCK_SIZE 16384);
+
+statement ok
+ATTACH '{TEST_DIR}/alp-v1_4_0-default.db' AS alp_v1_4_0_default (STORAGE_VERSION 'v1.4.0', BLOCK_SIZE 262144);
+
+statement ok
+ATTACH '{TEST_DIR}/alp-v1_5_0-16k.db' AS alp_v1_5_0 (STORAGE_VERSION 'v1.5.0', BLOCK_SIZE 16384);
+
+statement ok
+SET force_compression='alp';
+
+statement ok
+CREATE TABLE alp_v1_4_0.t AS SELECT round(i * 0.001, 6)::DOUBLE AS x FROM range(10000) t(i);
+
+statement ok
+CREATE TABLE alp_v1_4_0_default.t AS SELECT round(i * 0.001, 6)::DOUBLE AS x FROM range(10000) t(i);
+
+statement ok
+CREATE TABLE alp_v1_5_0.t AS SELECT round(i * 0.001, 6)::DOUBLE AS x FROM range(10000) t(i);
+
+statement ok
+CHECKPOINT alp_v1_4_0;
+
+statement ok
+CHECKPOINT alp_v1_4_0_default;
+
+statement ok
+CHECKPOINT alp_v1_5_0;
+
+# Before storage version v1.5.0 should disable ALP with block sizes smaller than the default
+
+query I
+SELECT compression FROM pragma_storage_info('alp_v1_4_0.t') WHERE segment_type = 'DOUBLE' ORDER BY compression LIMIT 1;
+----
+Uncompressed
+
+# Before storage version v1.5.0 should use ALP with block sizes equal to or larger than the default
+
+query I
+SELECT compression FROM pragma_storage_info('alp_v1_4_0_default.t') WHERE segment_type = 'DOUBLE' ORDER BY compression LIMIT 1;
+----
+ALP
+
+# From storage version v1.5.0 should use ALP for any block sizes
+
+query I
+SELECT compression FROM pragma_storage_info('alp_v1_5_0.t') WHERE segment_type = 'DOUBLE' ORDER BY compression LIMIT 1;
+----
+ALP

--- a/test/sql/storage/compression/alp/alp_tpcds.test_slow
+++ b/test/sql/storage/compression/alp/alp_tpcds.test_slow
@@ -4,7 +4,7 @@
 require tpcds
 
 # load the DB from disk
-load __TEST_DIR__/test_alp.db
+load __TEST_DIR__/test_alp.db readwrite v1.5.0
 
 #statement ok
 #pragma threads=1

--- a/test/sql/storage/compression/alprd/alprd_min_max.test
+++ b/test/sql/storage/compression/alprd/alprd_min_max.test
@@ -1,7 +1,7 @@
 # name: test/sql/storage/compression/alprd/alprd_min_max.test
 # group: [alprd]
 
-load __TEST_DIR__/alprd_min_max.db
+load __TEST_DIR__/alprd_min_max.db readwrite v1.5.0
 
 statement ok
 PRAGMA enable_verification

--- a/test/sql/storage/compression/alprd/alprd_storage_version.test
+++ b/test/sql/storage/compression/alprd/alprd_storage_version.test
@@ -1,0 +1,53 @@
+# name: test/sql/storage/compression/alprd/alprd_storage_version.test
+# group: [alprd]
+
+statement ok
+ATTACH '{TEST_DIR}/alprd-v1_4_0-16k.db' AS alprd_v1_4_0 (STORAGE_VERSION 'v1.4.0', BLOCK_SIZE 16384);
+
+statement ok
+ATTACH '{TEST_DIR}/alprd-v1_4_0-default.db' AS alprd_v1_4_0_default (STORAGE_VERSION 'v1.4.0', BLOCK_SIZE 262144);
+
+statement ok
+ATTACH '{TEST_DIR}/alprd-v1_5_0-16k.db' AS alprd_v1_5_0 (STORAGE_VERSION 'v1.5.0', BLOCK_SIZE 16384);
+
+statement ok
+SET force_compression='alprd';
+
+statement ok
+CREATE TABLE alprd_v1_4_0.t AS SELECT round(i * 0.001, 6)::DOUBLE AS x FROM range(10000) t(i);
+
+statement ok
+CREATE TABLE alprd_v1_4_0_default.t AS SELECT round(i * 0.001, 6)::DOUBLE AS x FROM range(10000) t(i);
+
+statement ok
+CREATE TABLE alprd_v1_5_0.t AS SELECT round(i * 0.001, 6)::DOUBLE AS x FROM range(10000) t(i);
+
+statement ok
+CHECKPOINT alprd_v1_4_0;
+
+statement ok
+CHECKPOINT alprd_v1_4_0_default;
+
+statement ok
+CHECKPOINT alprd_v1_5_0;
+
+# Before storage version v1.5.0 should disable ALP_RD with block sizes smaller than the default
+
+query I
+SELECT compression FROM pragma_storage_info('alprd_v1_4_0.t') WHERE segment_type = 'DOUBLE' ORDER BY compression LIMIT 1;
+----
+Uncompressed
+
+# Before storage version v1.5.0 should use ALP_RD with block sizes equal to or larger than the default
+
+query I
+SELECT compression FROM pragma_storage_info('alprd_v1_4_0_default.t') WHERE segment_type = 'DOUBLE' ORDER BY compression LIMIT 1;
+----
+ALPRD
+
+# From storage version v1.5.0 should use ALP_RD for any block sizes
+
+query I
+SELECT compression FROM pragma_storage_info('alprd_v1_5_0.t') WHERE segment_type = 'DOUBLE' ORDER BY compression LIMIT 1;
+----
+ALPRD

--- a/test/sql/storage/compression/alprd/alprd_tpcds.test_slow
+++ b/test/sql/storage/compression/alprd/alprd_tpcds.test_slow
@@ -4,7 +4,7 @@
 require tpcds
 
 # load the DB from disk
-load __TEST_DIR__/test_alprd.db
+load __TEST_DIR__/test_alprd.db readwrite v1.5.0
 
 #statement ok
 #pragma threads=1


### PR DESCRIPTION
Resolves https://github.com/duckdblabs/duckdb-internal/issues/9727. 

In addition we moved the eligibility check to the `InitAnalyze` phase since the result is based on the database configuration and not on the incoming data.