### PR TITLE
Fix partial join filter pushdown through projections

### DIFF
--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -1279,8 +1279,8 @@ bool JoinFilterPushdownInfo::CanUseInFilter(const ClientContext &context, option
 	return ht && ht->Count() > 1 && ht->Count() <= dynamic_or_filter_threshold && cmp == ExpressionType::COMPARE_EQUAL;
 }
 
-bool JoinFilterPushdownInfo::PushInFilter(const JoinFilterPushdownFilter &info, JoinHashTable &ht,
-                                          const PhysicalOperator &op, idx_t filter_idx,
+bool JoinFilterPushdownInfo::PushInFilter(const JoinFilterPushdownFilter &info, const JoinFilterPushdownColumn &column,
+                                          JoinHashTable &ht, const PhysicalOperator &op, idx_t filter_idx,
                                           ProjectionIndex filter_col_idx) const {
 	// generate a "OR" filter (i.e. x=1 OR x=535 OR x=997)
 	// first scan the entire vector at the probe side
@@ -1297,8 +1297,7 @@ bool JoinFilterPushdownInfo::PushInFilter(const JoinFilterPushdownFilter &info, 
 	for (idx_t k = 0; k < key_count; k++) {
 		// Cast to storage type, only insert if it succeeds
 		auto value = build_vector.GetValue(k);
-		if (info.columns[filter_idx].storage_type.IsValid() &&
-		    !value.DefaultTryCastAs(info.columns[filter_idx].storage_type)) {
+		if (column.storage_type.IsValid() && !value.DefaultTryCastAs(column.storage_type)) {
 			return false; // it's all or nothing sadly
 		}
 		unique_ht_values.insert(value);
@@ -1315,9 +1314,8 @@ bool JoinFilterPushdownInfo::PushInFilter(const JoinFilterPushdownFilter &info, 
 	// we push the OR filter as an OptionalFilter so that we can use it for zonemap pruning only
 	// the IN-list is expensive to execute otherwise
 	auto in_expr = ExpressionFilter::CreateInExpression(
-	    make_uniq<BoundReferenceExpression>(info.columns[filter_idx].storage_type, idx_t(0)), std::move(in_list));
-	auto filter = make_uniq<ExpressionFilter>(
-	    CreateOptionalFilterExpression(std::move(in_expr), info.columns[filter_idx].storage_type));
+	    make_uniq<BoundReferenceExpression>(column.storage_type, idx_t(0)), std::move(in_list));
+	auto filter = make_uniq<ExpressionFilter>(CreateOptionalFilterExpression(std::move(in_expr), column.storage_type));
 	info.dynamic_filters->PushFilter(op, filter_col_idx, std::move(filter));
 	return true;
 }
@@ -1408,36 +1406,37 @@ static unique_ptr<Expression> CreateRuntimeFilterInputExpression(ClientContext &
 }
 
 void JoinFilterPushdownInfo::PushBloomFilter(ClientContext &context, const PhysicalOperator &op, JoinHashTable &ht,
-                                             const JoinFilterPushdownFilter &info, idx_t filter_idx,
+                                             const JoinFilterPushdownFilter &info,
+                                             const JoinFilterPushdownColumn &column,
                                              ProjectionIndex filter_col_idx) const {
 	// If the nulls are equal, we let nulls pass. If not, we filter them
 	auto filters_null_values = !ht.NullValuesAreEqual(0);
 	const auto key_name = ht.conditions[0].GetRHS().ToString();
 	const auto key_type = ht.conditions[0].GetLHS().GetReturnType();
-	auto filter_input_type = GetRuntimeFilterInputType(info.columns[filter_idx], key_type);
+	auto filter_input_type = GetRuntimeFilterInputType(column, key_type);
 	ht.SetBuildBloomFilter(true);
 	float selectivity_threshold;
 	idx_t n_vectors_to_check;
 	GetThresholdAndVectorsToCheck(SelectivityOptionalFilterType::BF, selectivity_threshold, n_vectors_to_check);
 	vector<unique_ptr<Expression>> children;
-	children.push_back(CreateRuntimeFilterInputExpression(context, info.columns[filter_idx], key_type));
+	children.push_back(CreateRuntimeFilterInputExpression(context, column, key_type));
 	auto filter_expr = make_uniq<BoundFunctionExpression>(
 	    BoundScalarFunction(BloomFilterScalarFun::GetFunction(filter_input_type)), std::move(children),
 	    make_uniq<BloomFilterFunctionData>(ht.GetBloomFilter(), filters_null_values, key_name, key_type,
 	                                       selectivity_threshold, n_vectors_to_check));
 	info.dynamic_filters->PushFilter(op, filter_col_idx,
 	                                 CreateSelectivityOptionalExpressionFilter(std::move(filter_expr),
-	                                                                           info.columns[filter_idx].storage_type,
+	                                                                           column.storage_type,
 	                                                                           SelectivityOptionalFilterType::BF));
 }
 
 bool JoinFilterPushdownInfo::TryRegisterPrefixRangeFilter(const JoinFilterPushdownFilter &info, ClientContext &context,
                                                           JoinHashTable &ht, const PhysicalOperator &op,
-                                                          idx_t filter_idx, ProjectionIndex filter_col_idx,
-                                                          const Value &min_val, const Value &max_val,
-                                                          idx_t max_bits) const {
+                                                          const JoinFilterPushdownColumn &column,
+                                                          ProjectionIndex filter_col_idx, const Value &min_val,
+                                                          const Value &max_val, idx_t max_bits) const {
 	const auto key_type = ht.conditions[0].GetLHS().GetReturnType();
-	auto filter_input_type = GetRuntimeFilterInputType(info.columns[filter_idx], key_type);
+	auto filter_input_type = GetRuntimeFilterInputType(column, key_type);
 	if (!ht.GetPrefixRangeFilter()) {
 		auto prefix_filter = PrefixRangeFilter::CreatePrefixRangeFilter(key_type);
 		prefix_filter->Initialize(context, ht.Count(), min_val, max_val, max_bits);
@@ -1450,14 +1449,14 @@ bool JoinFilterPushdownInfo::TryRegisterPrefixRangeFilter(const JoinFilterPushdo
 	idx_t n_vectors_to_check;
 	GetThresholdAndVectorsToCheck(SelectivityOptionalFilterType::PRF, selectivity_threshold, n_vectors_to_check);
 	vector<unique_ptr<Expression>> children;
-	children.push_back(CreateRuntimeFilterInputExpression(context, info.columns[filter_idx], key_type));
+	children.push_back(CreateRuntimeFilterInputExpression(context, column, key_type));
 	auto filter_expr = make_uniq<BoundFunctionExpression>(
 	    BoundScalarFunction(PrefixRangeScalarFun::GetFunction(filter_input_type)), std::move(children),
 	    make_uniq<PrefixRangeFunctionData>(ht.GetPrefixRangeFilter(), key_name, key_type, selectivity_threshold,
 	                                       n_vectors_to_check));
 	info.dynamic_filters->PushFilter(op, filter_col_idx,
 	                                 CreateSelectivityOptionalExpressionFilter(std::move(filter_expr),
-	                                                                           info.columns[filter_idx].storage_type,
+	                                                                           column.storage_type,
 	                                                                           SelectivityOptionalFilterType::PRF));
 	return true;
 }
@@ -1576,11 +1575,13 @@ unique_ptr<DataChunk> JoinFilterPushdownInfo::FinalizeFilters(ClientContext &con
 		return final_min_max; // There are no table sources in which we can push down filters
 	}
 
-	// create a filter for each of the aggregates
-	for (idx_t filter_idx = 0; filter_idx < join_condition.size(); filter_idx++) {
-		const auto cmp = op.conditions[join_condition[filter_idx]].GetComparisonType();
-		for (auto &info : probe_info) {
-			const auto &pushdown_column = info.columns[filter_idx];
+	// create a filter for each column that reached a table scan
+	for (auto &info : probe_info) {
+		for (auto &pushdown_column : info.columns) {
+			auto filter_idx = pushdown_column.join_filter_idx;
+			D_ASSERT(filter_idx != DConstants::INVALID_INDEX);
+			D_ASSERT(filter_idx < join_condition.size());
+			const auto cmp = op.conditions[join_condition[filter_idx]].GetComparisonType();
 			auto &filter_col_idx = pushdown_column.probe_column_index.column_index;
 			auto min_idx = filter_idx * 2;
 			auto max_idx = min_idx + 1;
@@ -1645,12 +1646,12 @@ unique_ptr<DataChunk> JoinFilterPushdownInfo::FinalizeFilters(ClientContext &con
 
 				bool pushed_in_filter = false;
 				if (CanUseInFilter(context, ht, cmp)) {
-					pushed_in_filter = PushInFilter(info, *ht, op, filter_idx, filter_col_idx);
+					pushed_in_filter = PushInFilter(info, pushdown_column, *ht, op, filter_idx, filter_col_idx);
 				}
 
 				static constexpr idx_t SMALL_EXACT_PRF_BITS = 1ULL << 26;
 				if (can_emit_prf && span < SMALL_EXACT_PRF_BITS &&
-				    TryRegisterPrefixRangeFilter(info, context, *ht, op, filter_idx, filter_col_idx,
+				    TryRegisterPrefixRangeFilter(info, context, *ht, op, pushdown_column, filter_col_idx,
 				                                 min_val_before_cast, max_val_before_cast, SMALL_EXACT_PRF_BITS)) {
 					continue;
 				}
@@ -1662,7 +1663,7 @@ unique_ptr<DataChunk> JoinFilterPushdownInfo::FinalizeFilters(ClientContext &con
 					}
 					const auto bloom_filter_bits = BloomFilterBitBudget(build_count);
 					if (span <= bloom_filter_bits &&
-					    TryRegisterPrefixRangeFilter(info, context, *ht, op, filter_idx, filter_col_idx,
+					    TryRegisterPrefixRangeFilter(info, context, *ht, op, pushdown_column, filter_col_idx,
 					                                 min_val_before_cast, max_val_before_cast, bloom_filter_bits)) {
 						continue;
 					}
@@ -1673,7 +1674,7 @@ unique_ptr<DataChunk> JoinFilterPushdownInfo::FinalizeFilters(ClientContext &con
 					                           max_val, condition_type, reconstruct_filter_expression, false);
 				}
 				if (allow_bloom_filters && can_emit_runtime_filters && ht && CanUseBloomFilter(context, op, cmp, ht)) {
-					PushBloomFilter(context, op, *ht, info, filter_idx, filter_col_idx);
+					PushBloomFilter(context, op, *ht, info, pushdown_column, filter_col_idx);
 				}
 			}
 		}

--- a/src/include/duckdb/execution/operator/join/join_filter_pushdown.hpp
+++ b/src/include/duckdb/execution/operator/join/join_filter_pushdown.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "duckdb/common/constants.hpp"
 #include "duckdb/common/enums/join_type.hpp"
 #include "duckdb/common/projection_index.hpp"
 #include "duckdb/main/client_context.hpp"
@@ -32,6 +33,8 @@ enum class JoinFilterPushdownMode : uint8_t {
 };
 
 struct JoinFilterPushdownColumn {
+	//! Index into JoinFilterPushdownInfo::join_condition for this pushed column
+	idx_t join_filter_idx = DConstants::INVALID_INDEX;
 	//! The probe column index to which this filter should be applied
 	ColumnBinding probe_column_index;
 	//! The type of the value in storage (LogicalGet)
@@ -104,14 +107,16 @@ public:
 	                                      bool allow_prefix_range_filters = true) const;
 
 private:
-	bool PushInFilter(const JoinFilterPushdownFilter &info, JoinHashTable &ht, const PhysicalOperator &op,
-	                  idx_t filter_idx, ProjectionIndex filter_col_idx) const;
+	bool PushInFilter(const JoinFilterPushdownFilter &info, const JoinFilterPushdownColumn &column, JoinHashTable &ht,
+	                  const PhysicalOperator &op, idx_t filter_idx, ProjectionIndex filter_col_idx) const;
 
 	void PushBloomFilter(ClientContext &context, const PhysicalOperator &op, JoinHashTable &ht,
-	                     const JoinFilterPushdownFilter &info, idx_t filter_idx, ProjectionIndex filter_col_idx) const;
+	                     const JoinFilterPushdownFilter &info, const JoinFilterPushdownColumn &column,
+	                     ProjectionIndex filter_col_idx) const;
 	bool TryRegisterPrefixRangeFilter(const JoinFilterPushdownFilter &info, ClientContext &context, JoinHashTable &ht,
-	                                  const PhysicalOperator &op, idx_t filter_idx, ProjectionIndex filter_col_idx,
-	                                  const Value &min_val, const Value &max_val, idx_t max_bits) const;
+	                                  const PhysicalOperator &op, const JoinFilterPushdownColumn &column,
+	                                  ProjectionIndex filter_col_idx, const Value &min_val, const Value &max_val,
+	                                  idx_t max_bits) const;
 
 	bool CanUseInFilter(const ClientContext &context, optional_ptr<JoinHashTable> ht, const ExpressionType &cmp) const;
 	bool CanUseBloomFilter(const ClientContext &context, const PhysicalComparisonJoin &op, const ExpressionType &cmp,

--- a/src/optimizer/join_filter_pushdown_optimizer.cpp
+++ b/src/optimizer/join_filter_pushdown_optimizer.cpp
@@ -125,6 +125,21 @@ bool JoinFilterPushdownUtil::JoinTypeIsSupported(JoinType join_type) {
 	}
 }
 
+static void PushdownProjectionColumns(LogicalProjection &proj, const vector<JoinFilterPushdownColumn> &columns,
+                                      vector<JoinFilterPushdownColumn> &projected_columns) {
+	for (auto &filter : columns) {
+		if (filter.probe_column_index.table_index != proj.table_index) {
+			continue;
+		}
+		auto candidate = filter;
+		auto &expr = proj.GetExpression(candidate.probe_column_index);
+		if (!JoinFilterPushdownUtil::PushdownJoinFilterExpression(expr, candidate)) {
+			continue;
+		}
+		projected_columns.push_back(std::move(candidate));
+	}
+}
+
 void JoinFilterPushdownOptimizer::GetPushdownFilterTargets(LogicalOperator &op,
                                                            vector<JoinFilterPushdownColumn> columns,
                                                            vector<PushdownFilterTarget> &targets) {
@@ -160,23 +175,24 @@ void JoinFilterPushdownOptimizer::GetPushdownFilterTargets(LogicalOperator &op,
 	case LogicalOperatorType::LOGICAL_INTERSECT:
 	case LogicalOperatorType::LOGICAL_UNION: {
 		auto &setop = probe_child.Cast<LogicalSetOperation>();
-		// union
-		// check if the filters apply to this table index
-		for (auto &filter : columns) {
-			if (filter.probe_column_index.table_index != setop.table_index) {
-				// the filter does not apply to the union - bail-out
-				return;
-			}
-		}
 		for (auto &child : probe_child.children) {
 			// rewrite the filters for each of the children of the union
 			vector<JoinFilterPushdownColumn> child_columns;
 			auto child_bindings = child->GetColumnBindings();
 			child_columns.reserve(columns.size());
 			for (auto &child_column : columns) {
+				if (child_column.probe_column_index.table_index != setop.table_index) {
+					continue;
+				}
 				auto new_col = child_column;
 				new_col.probe_column_index = child_bindings[child_column.probe_column_index.column_index];
 				child_columns.push_back(new_col);
+			}
+			if (child_columns.empty()) {
+				if (probe_child.type == LogicalOperatorType::LOGICAL_EXCEPT) {
+					break;
+				}
+				continue;
 			}
 			// then recurse into the child
 			GetPushdownFilterTargets(*child, std::move(child_columns), targets);
@@ -220,20 +236,14 @@ void JoinFilterPushdownOptimizer::GetPushdownFilterTargets(LogicalOperator &op,
 		break;
 	}
 	case LogicalOperatorType::LOGICAL_PROJECTION: {
-		// projection - check if we all of the expressions are only column references
 		auto &proj = probe_child.Cast<LogicalProjection>();
-		for (auto &filter : columns) {
-			if (filter.probe_column_index.table_index != proj.table_index) {
-				// index does not belong to this projection - bail-out
-				return;
-			}
-			auto &expr = proj.GetExpression(filter.probe_column_index);
-			if (!JoinFilterPushdownUtil::PushdownJoinFilterExpression(expr, filter)) {
-				// cannot push through this expression - bail-out
-				return;
-			}
+		vector<JoinFilterPushdownColumn> projected_columns;
+		projected_columns.reserve(columns.size());
+		PushdownProjectionColumns(proj, columns, projected_columns);
+		if (projected_columns.empty()) {
+			return;
 		}
-		GetPushdownFilterTargets(*probe_child.children[0], std::move(columns), targets);
+		GetPushdownFilterTargets(*probe_child.children[0], std::move(projected_columns), targets);
 		break;
 	}
 	case LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY: {
@@ -314,6 +324,7 @@ void JoinFilterPushdownOptimizer::GenerateJoinFilters(LogicalComparisonJoin &joi
 			continue;
 		}
 
+		pushdown_col.join_filter_idx = pushdown_info->join_condition.size();
 		pushdown_columns.push_back(pushdown_col);
 		pushdown_info->join_condition.push_back(cond_idx);
 	}

--- a/test/optimizer/pushdown/join_filter_pushdown.test
+++ b/test/optimizer/pushdown/join_filter_pushdown.test
@@ -1,5 +1,5 @@
 # name: test/optimizer/pushdown/join_filter_pushdown.test
-# description: Test sampling of larger relations
+# description: Test join filter pushdown
 # group: [pushdown]
 
 statement ok
@@ -19,3 +19,128 @@ statement ok
 SELECT t1.s
 FROM t1
 LEFT JOIN t2 ON t1.i = t2.v;
+
+# Join filters should push the join keys that can reach a scan, even when
+# another join key is a projection expression such as a constant UNION label.
+statement ok
+CREATE TABLE jfpp_post AS SELECT i::BIGINT AS messageid FROM range(1, 1001) t(i);
+
+statement ok
+CREATE TABLE jfpp_comment AS SELECT (i + 1000)::BIGINT AS messageid FROM range(1, 1001) t(i);
+
+query II
+EXPLAIN ANALYZE
+WITH limited(label, messageid) AS MATERIALIZED (
+	VALUES ('Post', 11::BIGINT), ('Post', 101::BIGINT), ('Comment', 1503::BIGINT), ('Comment', 1907::BIGINT)
+)
+SELECT COUNT(*)
+FROM limited l
+JOIN (
+	SELECT 'Post' AS label, messageid FROM jfpp_post
+	UNION ALL
+	SELECT 'Comment' AS label, messageid FROM jfpp_comment
+) x ON x.label = l.label AND x.messageid = l.messageid;
+----
+analyzed_plan	<REGEX>:.*Dynamic Filters:.*messageid IN.*
+
+query I
+WITH limited(label, messageid) AS MATERIALIZED (
+	VALUES ('Post', 11::BIGINT), ('Post', 101::BIGINT), ('Comment', 1503::BIGINT), ('Comment', 1907::BIGINT)
+)
+SELECT COUNT(*)
+FROM limited l
+JOIN (
+	SELECT 'Post' AS label, messageid FROM jfpp_post
+	UNION ALL
+	SELECT 'Comment' AS label, messageid FROM jfpp_comment
+) x ON x.label = l.label AND x.messageid = l.messageid;
+----
+4
+
+# One pushable join key should still be pushed when multiple other join keys
+# are projection expressions that cannot be pushed through the UNION branches.
+query II
+EXPLAIN ANALYZE
+WITH limited(label, source, messageid) AS MATERIALIZED (
+	VALUES ('Post', 'Forum', 11::BIGINT), ('Post', 'Forum', 101::BIGINT),
+	       ('Comment', 'Forum', 1503::BIGINT), ('Comment', 'Forum', 1907::BIGINT)
+)
+SELECT COUNT(*)
+FROM limited l
+JOIN (
+	SELECT 'Post' AS label, 'Forum' AS source, messageid FROM jfpp_post
+	UNION ALL
+	SELECT 'Comment' AS label, 'Forum' AS source, messageid FROM jfpp_comment
+) x ON x.label = l.label AND x.source = l.source AND x.messageid = l.messageid;
+----
+analyzed_plan	<REGEX>:.*Dynamic Filters:.*messageid IN.*
+
+query I
+WITH limited(label, source, messageid) AS MATERIALIZED (
+	VALUES ('Post', 'Forum', 11::BIGINT), ('Post', 'Forum', 101::BIGINT),
+	       ('Comment', 'Forum', 1503::BIGINT), ('Comment', 'Forum', 1907::BIGINT)
+)
+SELECT COUNT(*)
+FROM limited l
+JOIN (
+	SELECT 'Post' AS label, 'Forum' AS source, messageid FROM jfpp_post
+	UNION ALL
+	SELECT 'Comment' AS label, 'Forum' AS source, messageid FROM jfpp_comment
+) x ON x.label = l.label AND x.source = l.source AND x.messageid = l.messageid;
+----
+4
+
+statement ok
+CREATE TABLE jfpp_multi_post AS SELECT i::BIGINT AS messageid, (i % 97)::BIGINT AS creatorid FROM range(1, 1001) t(i);
+
+statement ok
+CREATE TABLE jfpp_multi_comment AS SELECT (i + 1000)::BIGINT AS messageid, (i % 89)::BIGINT AS creatorid FROM range(1, 1001) t(i);
+
+# Multiple pushable join keys should be pushed independently when multiple
+# other join keys cannot be pushed through the UNION branch projections.
+query II
+EXPLAIN ANALYZE
+WITH limited(label, source, messageid, creatorid) AS MATERIALIZED (
+	VALUES ('Post', 'Forum', 11::BIGINT, 11::BIGINT), ('Post', 'Forum', 101::BIGINT, 4::BIGINT),
+	       ('Comment', 'Forum', 1503::BIGINT, 58::BIGINT), ('Comment', 'Forum', 1907::BIGINT, 17::BIGINT)
+)
+SELECT COUNT(*)
+FROM limited l
+JOIN (
+	SELECT 'Post' AS label, 'Forum' AS source, messageid, creatorid FROM jfpp_multi_post
+	UNION ALL
+	SELECT 'Comment' AS label, 'Forum' AS source, messageid, creatorid FROM jfpp_multi_comment
+) x ON x.label = l.label AND x.source = l.source AND x.messageid = l.messageid AND x.creatorid = l.creatorid;
+----
+analyzed_plan	<REGEX>:.*Dynamic Filters:.*messageid IN.*
+
+query II
+EXPLAIN ANALYZE
+WITH limited(label, source, messageid, creatorid) AS MATERIALIZED (
+	VALUES ('Post', 'Forum', 11::BIGINT, 11::BIGINT), ('Post', 'Forum', 101::BIGINT, 4::BIGINT),
+	       ('Comment', 'Forum', 1503::BIGINT, 58::BIGINT), ('Comment', 'Forum', 1907::BIGINT, 17::BIGINT)
+)
+SELECT COUNT(*)
+FROM limited l
+JOIN (
+	SELECT 'Post' AS label, 'Forum' AS source, messageid, creatorid FROM jfpp_multi_post
+	UNION ALL
+	SELECT 'Comment' AS label, 'Forum' AS source, messageid, creatorid FROM jfpp_multi_comment
+) x ON x.label = l.label AND x.source = l.source AND x.messageid = l.messageid AND x.creatorid = l.creatorid;
+----
+analyzed_plan	<REGEX>:.*Dynamic Filters:.*creatorid IN.*
+
+query I
+WITH limited(label, source, messageid, creatorid) AS MATERIALIZED (
+	VALUES ('Post', 'Forum', 11::BIGINT, 11::BIGINT), ('Post', 'Forum', 101::BIGINT, 4::BIGINT),
+	       ('Comment', 'Forum', 1503::BIGINT, 58::BIGINT), ('Comment', 'Forum', 1907::BIGINT, 17::BIGINT)
+)
+SELECT COUNT(*)
+FROM limited l
+JOIN (
+	SELECT 'Post' AS label, 'Forum' AS source, messageid, creatorid FROM jfpp_multi_post
+	UNION ALL
+	SELECT 'Comment' AS label, 'Forum' AS source, messageid, creatorid FROM jfpp_multi_comment
+) x ON x.label = l.label AND x.source = l.source AND x.messageid = l.messageid AND x.creatorid = l.creatorid;
+----
+4


### PR DESCRIPTION
## Summary
Fix join filter pushdown so projection and set operation paths can push down the join keys that remain valid, instead of abandoning the whole target when another join key cannot be rewritten.

This allows queries such as joins against `UNION ALL` branches with constant label columns plus real key columns to still push dynamic filters on the real keys.

## Changes
- Allow partial join filter pushdown through projections and set operations.
- Track each pushed column’s original join condition index with `join_filter_idx`.
- Update hash join filter finalization to use the tracked join condition index instead of assuming pushed columns are positionally aligned with `join_condition`.
- Add regression coverage for:
  - one pushable key plus one unpushable projected key;
  - one pushable key plus multiple unpushable projected keys;
  - multiple pushable keys plus multiple unpushable projected keys.

## Testing
- `cmake --build /Users/mac/Documents/CLionProjects/duckdb/build/codex_release --target unittest -j10`
- `./build/codex_release/test/unittest test/optimizer/pushdown/join_filter_pushdown.test`
- `./build/codex_release/test/unittest`