### PR TITLE
Optimize flat contiguous string appends to `ColumnDataCollection`

### DIFF
--- a/src/common/sort/partition_key_tracker.cpp
+++ b/src/common/sort/partition_key_tracker.cpp
@@ -6,6 +6,9 @@
 
 namespace duckdb {
 
+static constexpr idx_t PARTITION_KEY_TRACKER_CAPACITY =
+    RadixPartitioning::NumberOfPartitions(RadixPartitioning::MAX_RADIX_BITS);
+
 template <bool USE_PARTITION_SEL>
 static idx_t GetPartitionRowIndex(PartitionedTupleDataAppendState &append_state, idx_t idx) {
 	if constexpr (USE_PARTITION_SEL) {
@@ -17,16 +20,16 @@ static idx_t GetPartitionRowIndex(PartitionedTupleDataAppendState &append_state,
 PartitionKeyTracker::PartitionKeyTracker(Allocator &allocator_p, const vector<LogicalType> &key_types_p)
     : key_count(key_types_p.size()) {
 	single_value_sel.Initialize();
-	candidate_input_sel.Initialize();
-	candidate_rep_sel.Initialize();
-	mismatch_sel.Initialize();
-	representatives.Initialize(allocator_p, key_types_p, 4096);
+	candidate_input_sel.Initialize(PARTITION_KEY_TRACKER_CAPACITY);
+	candidate_rep_sel.Initialize(PARTITION_KEY_TRACKER_CAPACITY);
+	mismatch_sel.Initialize(PARTITION_KEY_TRACKER_CAPACITY);
+	representatives.Initialize(allocator_p, key_types_p, PARTITION_KEY_TRACKER_CAPACITY);
 }
 
 void PartitionKeyTracker::Reset(idx_t radix_bits_p) {
 	radix_bits = radix_bits_p;
 	const auto partition_count = RadixPartitioning::NumberOfPartitions(radix_bits);
-	D_ASSERT(partition_count <= STANDARD_VECTOR_SIZE);
+	D_ASSERT(partition_count <= PARTITION_KEY_TRACKER_CAPACITY);
 	states.clear();
 	states.resize(partition_count, PartitionKeyTrackerState::EMPTY);
 	hashes.clear();
@@ -76,7 +79,7 @@ void PartitionKeyTracker::Combine(const PartitionKeyTracker &other) {
 	}
 	D_ASSERT(radix_bits == other.radix_bits);
 	D_ASSERT(states.size() == other.states.size());
-	D_ASSERT(states.size() <= STANDARD_VECTOR_SIZE);
+	D_ASSERT(states.size() <= PARTITION_KEY_TRACKER_CAPACITY);
 
 	idx_t candidate_count = 0;
 	for (idx_t bin_idx = 0; bin_idx < states.size(); bin_idx++) {
@@ -221,7 +224,7 @@ idx_t PartitionKeyTracker::CompactTrackerCandidates(idx_t candidate_count) {
 }
 
 void PartitionKeyTracker::CompareTrackerCandidates(const PartitionKeyTracker &source, idx_t candidate_count) {
-	D_ASSERT(candidate_count <= STANDARD_VECTOR_SIZE);
+	D_ASSERT(candidate_count <= PARTITION_KEY_TRACKER_CAPACITY);
 	for (idx_t col_idx = 0; col_idx < key_count && candidate_count; col_idx++) {
 		Vector target_slice(representatives.data[col_idx], candidate_input_sel, candidate_count);
 		Vector source_slice(source.representatives.data[col_idx], candidate_rep_sel, candidate_count);

--- a/src/common/types/column/column_data_collection.cpp
+++ b/src/common/types/column/column_data_collection.cpp
@@ -615,6 +615,89 @@ bool ColumnDataCopyCompressedStrings(ColumnDataMetaData &meta_data, const Vector
 	return true;
 }
 
+struct ColumnDataStringAppendInfo {
+	idx_t append_count = 0;
+	idx_t heap_size = 0;
+	const char *contiguous_source_ptr = nullptr;
+	bool source_bytes_are_contiguous = true;
+};
+
+static inline void AnalyzeColumnDataStringEntry(ColumnDataStringAppendInfo &result, const string_t &entry,
+                                                const idx_t block_size, bool &appending,
+                                                bool &has_contiguous_source_ptr, uintptr_t &expected_next_ptr) {
+	const auto entry_size = entry.GetSize();
+	const idx_t heap_size = entry_size * idx_t(entry_size > string_t::INLINE_LENGTH);
+	const auto next_heap_size = result.heap_size + heap_size;
+	const bool append_entry = appending & (next_heap_size <= block_size);
+	const bool copy_bytes = append_entry & (heap_size != 0);
+	const auto source_ptr = entry.GetData();
+	const auto source_ptr_value = reinterpret_cast<uintptr_t>(source_ptr);
+	const bool source_matches = !has_contiguous_source_ptr | (source_ptr_value == expected_next_ptr);
+
+	result.append_count += idx_t(append_entry);
+	result.heap_size += idx_t(append_entry) * heap_size;
+	result.source_bytes_are_contiguous &= !copy_bytes | source_matches;
+	result.contiguous_source_ptr =
+	    (!has_contiguous_source_ptr & copy_bytes) ? source_ptr : result.contiguous_source_ptr;
+	expected_next_ptr = copy_bytes ? source_ptr_value + heap_size : expected_next_ptr;
+	has_contiguous_source_ptr |= copy_bytes;
+	appending &= append_entry;
+}
+
+template <bool HAS_SELECTION, bool ALL_VALID>
+static ColumnDataStringAppendInfo
+AnalyzeColumnDataStringAppendInternal(const UnifiedVectorFormat &source_data, const idx_t offset,
+                                      const idx_t vector_remaining, const idx_t block_size) {
+	ColumnDataStringAppendInfo result;
+	const auto source_entries = UnifiedVectorFormat::GetData<string_t>(source_data);
+	bool appending = true;
+	bool has_contiguous_source_ptr = false;
+	uintptr_t expected_next_ptr = 0;
+
+	for (idx_t i = 0; i < vector_remaining; i++) {
+		const auto source_idx = HAS_SELECTION ? source_data.sel->get_index_unsafe(offset + i) : offset + i;
+		if constexpr (!ALL_VALID) {
+			if (!source_data.validity.RowIsValidUnsafe(source_idx)) {
+				result.append_count += static_cast<idx_t>(appending);
+				continue;
+			}
+		}
+		AnalyzeColumnDataStringEntry(result, source_entries[source_idx], block_size, appending,
+		                             has_contiguous_source_ptr, expected_next_ptr);
+	}
+
+	if (vector_remaining != 0 && result.append_count == 0) {
+		// The string exceeds Storage::DEFAULT_BLOCK_SIZE, so we allocate one block at a time for long strings.
+		auto source_idx = HAS_SELECTION ? source_data.sel->get_index_unsafe(offset) : offset;
+		if constexpr (!ALL_VALID) {
+			D_ASSERT(source_data.validity.RowIsValidUnsafe(source_idx));
+		}
+		D_ASSERT(!source_entries[source_idx].IsInlined());
+		D_ASSERT(source_entries[source_idx].GetSize() > block_size);
+		result.contiguous_source_ptr = source_entries[source_idx].GetData();
+		result.heap_size += source_entries[source_idx].GetSize();
+		result.append_count++;
+	}
+
+	return result;
+}
+
+static ColumnDataStringAppendInfo AnalyzeColumnDataStringAppend(const UnifiedVectorFormat &source_data,
+                                                                const idx_t offset, const idx_t vector_remaining,
+                                                                const idx_t block_size) {
+	const auto has_selection = source_data.sel->IsSet();
+	const auto all_valid = source_data.validity.CannotHaveNull();
+	if (has_selection) {
+		return all_valid ? AnalyzeColumnDataStringAppendInternal<true, true>(source_data, offset, vector_remaining,
+		                                                                     block_size)
+		                 : AnalyzeColumnDataStringAppendInternal<true, false>(source_data, offset, vector_remaining,
+		                                                                      block_size);
+	}
+	return all_valid
+	           ? AnalyzeColumnDataStringAppendInternal<false, true>(source_data, offset, vector_remaining, block_size)
+	           : AnalyzeColumnDataStringAppendInternal<false, false>(source_data, offset, vector_remaining, block_size);
+}
+
 template <>
 void ColumnDataCopy<string_t>(ColumnDataMetaData &meta_data, const UnifiedVectorFormat &source_data, Vector &source,
                               idx_t offset, idx_t copy_count) {
@@ -655,31 +738,10 @@ void ColumnDataCopy<string_t>(ColumnDataMetaData &meta_data, const UnifiedVector
 		if (!ColumnDataCopyCompressedStrings(meta_data, current_index, child_index, source_data, source, offset,
 		                                     vector_remaining, append_count, heap_size, base_heap_ptr)) {
 			// 'append_count' is less if we cannot fit that amount of non-inlined strings on one buffer-managed block
+			const auto append_info = AnalyzeColumnDataStringAppend(source_data, offset, vector_remaining, block_size);
+			append_count = append_info.append_count;
+			heap_size = append_info.heap_size;
 			const auto source_entries = UnifiedVectorFormat::GetData<string_t>(source_data);
-			for (; append_count < vector_remaining; append_count++) {
-				auto source_idx = source_data.sel->get_index(offset + append_count);
-				if (!source_data.validity.RowIsValid(source_idx)) {
-					continue;
-				}
-				const auto &entry = source_entries[source_idx];
-				if (entry.IsInlined()) {
-					continue;
-				}
-				if (heap_size + entry.GetSize() > block_size) {
-					break;
-				}
-				heap_size += entry.GetSize();
-			}
-
-			if (vector_remaining != 0 && append_count == 0) {
-				// The string exceeds Storage::DEFAULT_BLOCK_SIZE, so we allocate one block at a time for long strings.
-				auto source_idx = source_data.sel->get_index(offset + append_count);
-				D_ASSERT(source_data.validity.RowIsValid(source_idx));
-				D_ASSERT(!source_entries[source_idx].IsInlined());
-				D_ASSERT(source_entries[source_idx].GetSize() > block_size);
-				heap_size += source_entries[source_idx].GetSize();
-				append_count++;
-			}
 
 			// allocate string heap for the next 'append_count' strings
 			if (heap_size != 0) {
@@ -690,6 +752,9 @@ void ColumnDataCopy<string_t>(ColumnDataMetaData &meta_data, const UnifiedVector
 				const auto &child_segment = segment.GetVectorData(child_index);
 				base_heap_ptr = segment.allocator->GetDataPointer(append_state.current_chunk_state,
 				                                                  child_segment.block_id, child_segment.offset);
+				if (append_info.source_bytes_are_contiguous) {
+					memcpy(base_heap_ptr, append_info.contiguous_source_ptr, heap_size);
+				}
 			}
 
 			// We get a reference to the "current_segment" only after allocating the string heap above,
@@ -707,7 +772,7 @@ void ColumnDataCopy<string_t>(ColumnDataMetaData &meta_data, const UnifiedVector
 			}
 
 			auto target_entries = reinterpret_cast<string_t *>(base_ptr);
-			data_ptr_t heap_ptr = base_heap_ptr;
+			idx_t heap_offset = 0;
 			for (idx_t i = 0; i < append_count; i++) {
 				auto source_idx = source_data.sel->get_index(offset + i);
 				auto target_idx = current_segment.count + i;
@@ -721,10 +786,13 @@ void ColumnDataCopy<string_t>(ColumnDataMetaData &meta_data, const UnifiedVector
 					target_entry = source_entry;
 				} else {
 					D_ASSERT(base_heap_ptr != nullptr);
-					memcpy(heap_ptr, source_entry.GetData(), source_entry.GetSize());
-					target_entry =
-					    string_t(const_char_ptr_cast(heap_ptr), UnsafeNumericCast<uint32_t>(source_entry.GetSize()));
-					heap_ptr += source_entry.GetSize();
+					auto target_ptr = base_heap_ptr + heap_offset;
+					if (!append_info.source_bytes_are_contiguous) {
+						memcpy(target_ptr, source_entry.GetData(), source_entry.GetSize());
+					}
+					target_entry = source_entry;
+					target_entry.SetPointer(char_ptr_cast(target_ptr));
+					heap_offset += source_entry.GetSize();
 				}
 			}
 		}


### PR DESCRIPTION
Coalesces a vector worth of `memcpy`'s into a single `memcpy` if possible.

Also fixes a spurious issue seen in https://github.com/duckdb/duckdb/actions/runs/28234263611/job/83646238736?pr=23465#step:7:100