### PR TITLE
Make `QualifiedName` immutable and instead override the entire qualified name when modified

### DIFF
--- a/.github/patches/extensions/ducklake/zzzzzzzz-immutable-qualified-name.patch
+++ b/.github/patches/extensions/ducklake/zzzzzzzz-immutable-qualified-name.patch
@@ -1,0 +1,26 @@
+diff --git a/src/storage/ducklake_catalog.cpp b/src/storage/ducklake_catalog.cpp
+index 6df47ed..c9f0ef9 100644
+--- a/src/storage/ducklake_catalog.cpp
++++ b/src/storage/ducklake_catalog.cpp
+@@ -140,7 +140,7 @@ optional_ptr<CatalogEntry> DuckLakeCatalog::CreateSchema(CatalogTransaction tran
+ 		// drop the existing entry
+ 		DropInfo drop_info;
+ 		drop_info.type = CatalogType::SCHEMA_ENTRY;
+-		drop_info.NameMutable() = info.GetQualifiedName().Schema();
++		drop_info.SetName(info.GetQualifiedName().Schema());
+ 		DropSchema(transaction.GetContext(), drop_info);
+ 	}
+ 	auto &duck_transaction = transaction.transaction->Cast<DuckLakeTransaction>();
+diff --git a/src/storage/ducklake_schema_entry.cpp b/src/storage/ducklake_schema_entry.cpp
+index 7a828ff..69379a0 100644
+--- a/src/storage/ducklake_schema_entry.cpp
++++ b/src/storage/ducklake_schema_entry.cpp
+@@ -51,7 +51,7 @@ bool DuckLakeSchemaEntry::HandleCreateConflict(CatalogTransaction transaction, C
+ 		// try to drop the entry prior to creating
+ 		DropInfo info;
+ 		info.type = catalog_type;
+-		info.NameMutable() = Identifier(entry_name);
++		info.SetName(Identifier(entry_name));
+ 		DropEntry(transaction.GetContext(), info);
+ 		break;
+ 	}

--- a/.github/patches/extensions/fts/zzzzzzzz-immutable-qualified-name.patch
+++ b/.github/patches/extensions/fts/zzzzzzzz-immutable-qualified-name.patch
@@ -1,0 +1,13 @@
+diff --git a/extension/fts/fts_indexing.cpp b/extension/fts/fts_indexing.cpp
+index b8f9bc3..6701ce7 100644
+--- a/extension/fts/fts_indexing.cpp
++++ b/extension/fts/fts_indexing.cpp
+@@ -13,7 +13,7 @@ namespace duckdb {
+ static QualifiedName GetQualifiedName(ClientContext &context, const string &qname_str) {
+ 	auto qname = QualifiedName::Parse(qname_str);
+ 	if (qname.Schema() == INVALID_SCHEMA) {
+-		qname.SchemaMutable() = Identifier(ClientData::Get(context).catalog_search_path->GetDefaultSchema(qname.Catalog()));
++		qname = QualifiedName(qname.Catalog(), Identifier(ClientData::Get(context).catalog_search_path->GetDefaultSchema(qname.Catalog())), qname.Name());
+ 	}
+ 	return qname;
+ }

--- a/.github/patches/extensions/iceberg/zzzzzzzz-immutable-qualified-name.patch
+++ b/.github/patches/extensions/iceberg/zzzzzzzz-immutable-qualified-name.patch
@@ -1,0 +1,22 @@
+diff --git a/src/catalog/rest/transaction/iceberg_transaction.cpp b/src/catalog/rest/transaction/iceberg_transaction.cpp
+index f3ee57b..95f2cad 100644
+--- a/src/catalog/rest/transaction/iceberg_transaction.cpp
++++ b/src/catalog/rest/transaction/iceberg_transaction.cpp
+@@ -527,7 +527,7 @@ void IcebergTransaction::DoTableRename(IcebergTransactionRenameUpdate &rename_up
+ 	IRCAPI::CommitTableRename(context, catalog, transaction_json);
+ 
+ 	DropInfo drop_info;
+-	drop_info.NameMutable() = Identifier(table_name);
++	drop_info.SetName(Identifier(table_name));
+ 	drop_info.if_not_found = OnEntryNotFound::THROW_EXCEPTION;
+ 	schema.DropEntry(context, drop_info, true);
+ 
+@@ -551,7 +551,7 @@ void IcebergTransaction::DoTableDeletes(IcebergTransactionDeleteUpdate &delete_u
+ 	// remove the table entry from the catalog
+ 	auto &schema_entry = ic_catalog.schemas.GetEntry(schema_key.GetIdentifierName()).Cast<IcebergSchemaEntry>();
+ 	DropInfo drop_info;
+-	drop_info.NameMutable() = Identifier(table_name);
++	drop_info.SetName(Identifier(table_name));
+ 	drop_info.if_not_found = OnEntryNotFound::RETURN_NULL;
+ 	schema_entry.DropEntry(context, drop_info, true);
+ }

--- a/.github/patches/extensions/mysql_scanner/zzzzzzzz-immutable-qualified-name.patch
+++ b/.github/patches/extensions/mysql_scanner/zzzzzzzz-immutable-qualified-name.patch
@@ -1,0 +1,26 @@
+diff --git a/src/storage/mysql_catalog.cpp b/src/storage/mysql_catalog.cpp
+index 662ebd5..3402213 100644
+--- a/src/storage/mysql_catalog.cpp
++++ b/src/storage/mysql_catalog.cpp
+@@ -460,7 +460,7 @@ optional_ptr<CatalogEntry> MySQLCatalog::CreateSchema(CatalogTransaction transac
+ 	if (info.on_conflict == OnCreateConflict::REPLACE_ON_CONFLICT) {
+ 		DropInfo try_drop;
+ 		try_drop.type = CatalogType::SCHEMA_ENTRY;
+-		try_drop.NameMutable() = info.GetQualifiedName().Schema();
++		try_drop.SetName(info.GetQualifiedName().Schema());
+ 		try_drop.if_not_found = OnEntryNotFound::RETURN_NULL;
+ 		try_drop.cascade = false;
+ 		schemas.DropEntry(transaction.GetContext(), try_drop);
+diff --git a/src/storage/mysql_schema_entry.cpp b/src/storage/mysql_schema_entry.cpp
+index 460b1d9..195a439 100644
+--- a/src/storage/mysql_schema_entry.cpp
++++ b/src/storage/mysql_schema_entry.cpp
+@@ -28,7 +28,7 @@ MySQLTransaction &GetMySQLTransaction(CatalogTransaction transaction) {
+ void MySQLSchemaEntry::TryDropEntry(ClientContext &context, CatalogType catalog_type, const string &name) {
+ 	DropInfo info;
+ 	info.type = catalog_type;
+-	info.NameMutable() = Identifier(name);
++	info.SetName(Identifier(name));
+ 	info.cascade = false;
+ 	info.if_not_found = OnEntryNotFound::RETURN_NULL;
+ 	DropEntry(context, info);

--- a/.github/patches/extensions/postgres_scanner/zzzzzzzz-immutable-qualified-name.patch
+++ b/.github/patches/extensions/postgres_scanner/zzzzzzzz-immutable-qualified-name.patch
@@ -1,0 +1,39 @@
+diff --git a/src/storage/postgres_catalog.cpp b/src/storage/postgres_catalog.cpp
+index 160ad2e..deb8f6d 100644
+--- a/src/storage/postgres_catalog.cpp
++++ b/src/storage/postgres_catalog.cpp
+@@ -181,7 +181,7 @@ optional_ptr<CatalogEntry> PostgresCatalog::CreateSchema(CatalogTransaction tran
+ 		case OnCreateConflict::REPLACE_ON_CONFLICT: {
+ 			DropInfo try_drop;
+ 			try_drop.type = CatalogType::SCHEMA_ENTRY;
+-			try_drop.NameMutable() = info.GetQualifiedName().Schema();
++			try_drop.SetName(info.GetQualifiedName().Schema());
+ 			try_drop.if_not_found = OnEntryNotFound::RETURN_NULL;
+ 			try_drop.cascade = false;
+ 			schemas.DropEntry(postgres_transaction, try_drop);
+diff --git a/src/storage/postgres_index.cpp b/src/storage/postgres_index.cpp
+index 90e17db..7acbb23 100644
+--- a/src/storage/postgres_index.cpp
++++ b/src/storage/postgres_index.cpp
+@@ -39,7 +39,7 @@ SourceResultType PostgresCreateIndex::GetDataInternal(ExecutionContext &context,
+ 			drop_info.SetQualifiedName(QualifiedName(drop_info.GetQualifiedName().Catalog(),
+ 			                                         info->GetQualifiedName().Schema(),
+ 			                                         drop_info.GetQualifiedName().Name()));
+-			drop_info.NameMutable() = info->GetIndexName();
++			drop_info.SetName(info->GetIndexName());
+ 			schema.DropEntry(context.client, drop_info);
+ 			break;
+ 		}
+diff --git a/src/storage/postgres_schema_entry.cpp b/src/storage/postgres_schema_entry.cpp
+index 5a4f104..d2a19e0 100644
+--- a/src/storage/postgres_schema_entry.cpp
++++ b/src/storage/postgres_schema_entry.cpp
+@@ -42,7 +42,7 @@ PostgresTransaction &GetPostgresTransaction(CatalogTransaction transaction) {
+ void PostgresSchemaEntry::TryDropEntry(ClientContext &context, CatalogType catalog_type, const string &name) {
+ 	DropInfo info;
+ 	info.type = catalog_type;
+-	info.NameMutable() = Identifier(name);
++	info.SetName(Identifier(name));
+ 	info.cascade = false;
+ 	info.if_not_found = OnEntryNotFound::RETURN_NULL;
+ 	DropEntry(context, info);

--- a/.github/patches/extensions/spatial/zzzzzzzz-immutable-qualified-name.patch
+++ b/.github/patches/extensions/spatial/zzzzzzzz-immutable-qualified-name.patch
@@ -1,0 +1,13 @@
+diff --git a/src/spatial/index/rtree/rtree_index_pragmas.cpp b/src/spatial/index/rtree/rtree_index_pragmas.cpp
+index 1e2867a..a086365 100644
+--- a/src/spatial/index/rtree/rtree_index_pragmas.cpp
++++ b/src/spatial/index/rtree/rtree_index_pragmas.cpp
+@@ -111,7 +111,7 @@ static optional_ptr<RTreeIndex> TryGetIndex(ClientContext &context, const string
+ 	auto qname = QualifiedName::Parse(index_name);
+ 
+ 	// look up the index name in the catalog
+-	Binder::BindSchemaOrCatalog(context, qname.CatalogMutable(), qname.SchemaMutable());
++	Binder::BindSchemaOrCatalog(context, qname);
+ 	auto &index_entry =
+ 	    Catalog::GetEntry(context, CatalogType::INDEX_ENTRY, qname.Catalog(), qname.Schema(), qname.Name())
+ 	        .Cast<IndexCatalogEntry>();

--- a/.github/patches/extensions/sqlite_scanner/zzzzzzzz-immutable-qualified-name.patch
+++ b/.github/patches/extensions/sqlite_scanner/zzzzzzzz-immutable-qualified-name.patch
@@ -1,0 +1,13 @@
+diff --git a/src/storage/sqlite_schema_entry.cpp b/src/storage/sqlite_schema_entry.cpp
+index 7b04417..f266753 100644
+--- a/src/storage/sqlite_schema_entry.cpp
++++ b/src/storage/sqlite_schema_entry.cpp
+@@ -46,7 +46,7 @@ string GetCreateTableSQL(CreateTableInfo &info) {
+ void SQLiteSchemaEntry::TryDropEntry(ClientContext &context, CatalogType catalog_type, const string &name) {
+ 	DropInfo info;
+ 	info.type = catalog_type;
+-	info.NameMutable() = Identifier(name);
++	info.SetName(Identifier(name));
+ 	info.cascade = false;
+ 	info.if_not_found = OnEntryNotFound::RETURN_NULL;
+ 	DropEntry(context, info);

--- a/.github/patches/extensions/sqlsmith/zzzzzzzz-immutable-qualified-name.patch
+++ b/.github/patches/extensions/sqlsmith/zzzzzzzz-immutable-qualified-name.patch
@@ -1,0 +1,40 @@
+diff --git a/src/statement_generator.cpp b/src/statement_generator.cpp
+index 856d762..8a975db 100644
+--- a/src/statement_generator.cpp
++++ b/src/statement_generator.cpp
+@@ -189,7 +189,7 @@ unique_ptr<DeleteStatement> StatementGenerator::GenerateDelete() {
+ 		auto &entry = entry_ref.get();
+ 		if (entry.type == CatalogType::TABLE_ENTRY) {
+ 			auto result = make_uniq<BaseTableRef>();
+-			result->TableMutable() = entry.name;
++			result->SetTable(entry.name);
+ 			delete_statement->node->table = std::move(result);
+ 		} else {
+ 			delete_statement->node->table = GenerateTableRef();
+@@ -486,7 +486,7 @@ unique_ptr<TableRef> StatementGenerator::GenerateBaseTableRef() {
+ 		result->column_name_alias.emplace_back(GenerateIdentifier());
+ 	}
+ 	result->alias = Identifier(GenerateTableIdentifier());
+-	result->TableMutable() = entry.name;
++	result->SetTable(entry.name);
+ 	return std::move(result);
+ }
+ 
+@@ -1310,7 +1310,7 @@ string StatementGenerator::GenerateTestAllTypes(SimpleFunction &base_function) {
+ 		children.push_back(std::move(argument));
+ 	}
+ 	auto from_clause = make_uniq<BaseTableRef>();
+-	from_clause->TableMutable() = "all_types";
++	from_clause->SetTable("all_types");
+ 	node->from_table = std::move(from_clause);
+ 
+ 	auto function_expr = make_uniq<FunctionExpression>(base_function.GetName(), std::move(children));
+@@ -1362,7 +1362,7 @@ string StatementGenerator::GenerateCast(const LogicalType &target, const string
+ 	auto node = make_uniq<SelectNode>();
+ 
+ 	auto from_clause = make_uniq<BaseTableRef>();
+-	from_clause->TableMutable() = "all_types";
++	from_clause->SetTable("all_types");
+ 	node->from_table = std::move(from_clause);
+ 
+ 	unique_ptr<ParsedExpression> source;

--- a/.github/patches/extensions/unity_catalog/zzzzzzzz-immutable-qualified-name.patch
+++ b/.github/patches/extensions/unity_catalog/zzzzzzzz-immutable-qualified-name.patch
@@ -1,0 +1,13 @@
+diff --git a/src/storage/unity_catalog.cpp b/src/storage/unity_catalog.cpp
+index d13f376..1bbe814 100644
+--- a/src/storage/unity_catalog.cpp
++++ b/src/storage/unity_catalog.cpp
+@@ -28,7 +28,7 @@ optional_ptr<CatalogEntry> UnityCatalog::CreateSchema(CatalogTransaction transac
+ 	if (info.on_conflict == OnCreateConflict::REPLACE_ON_CONFLICT) {
+ 		DropInfo try_drop;
+ 		try_drop.type = CatalogType::SCHEMA_ENTRY;
+-		try_drop.NameMutable() = info.GetQualifiedName().Schema();
++		try_drop.SetName(info.GetQualifiedName().Schema());
+ 		try_drop.if_not_found = OnEntryNotFound::RETURN_NULL;
+ 		try_drop.cascade = false;
+ 		schemas.DropEntry(transaction.GetContext(), try_drop);

--- a/.github/patches/extensions/vss/zzzzzzzz-immutable-qualified-name.patch
+++ b/.github/patches/extensions/vss/zzzzzzzz-immutable-qualified-name.patch
@@ -1,0 +1,13 @@
+diff --git a/src/hnsw/hnsw_index_pragmas.cpp b/src/hnsw/hnsw_index_pragmas.cpp
+index 0354fab..683baab 100644
+--- a/src/hnsw/hnsw_index_pragmas.cpp
++++ b/src/hnsw/hnsw_index_pragmas.cpp
+@@ -188,7 +188,7 @@ static void CompactIndexPragma(ClientContext &context, const FunctionParameters
+ 	auto qname = QualifiedName::Parse(index_name);
+ 
+ 	// look up the index name in the catalog
+-	Binder::BindSchemaOrCatalog(context, qname.CatalogMutable(), qname.SchemaMutable());
++	Binder::BindSchemaOrCatalog(context, qname);
+ 	auto &index_entry =
+ 	    Catalog::GetEntry(context, CatalogType::INDEX_ENTRY, qname.Catalog(), qname.Schema(), qname.Name())
+ 	        .Cast<IndexCatalogEntry>();

--- a/scripts/generate_serialization.py
+++ b/scripts/generate_serialization.py
@@ -7,9 +7,9 @@ from enum import Enum
 
 from typing import Dict, Optional, Tuple, List
 
-parser = argparse.ArgumentParser(description='Generate serialization code')
-parser.add_argument('--source', type=str, help='Source directory')
-parser.add_argument('--target', type=str, help='Target directory')
+parser = argparse.ArgumentParser(description="Generate serialization code")
+parser.add_argument("--source", type=str, help="Source directory")
+parser.add_argument("--target", type=str, help="Target directory")
 
 args = parser.parse_args()
 
@@ -26,42 +26,45 @@ class MemberVariableStatus(Enum):
 def get_file_list():
     if args.source is None:
         targets = [
-            {'source': 'src/include/duckdb/storage/serialization', 'target': 'src/storage/serialization'},
-            {'source': 'extension/parquet/include/', 'target': 'extension/parquet'},
-            {'source': 'extension/json/include/', 'target': 'extension/json'},
+            {
+                "source": "src/include/duckdb/storage/serialization",
+                "target": "src/storage/serialization",
+            },
+            {"source": "extension/parquet/include/", "target": "extension/parquet"},
+            {"source": "extension/json/include/", "target": "extension/json"},
         ]
     else:
         targets = [
-            {'source': args.source, 'target': args.target},
+            {"source": args.source, "target": args.target},
         ]
 
     file_list = []
     for target in targets:
-        source_base = os.path.sep.join(target['source'].split('/'))
-        target_base = os.path.sep.join(target['target'].split('/'))
+        source_base = os.path.sep.join(target["source"].split("/"))
+        target_base = os.path.sep.join(target["target"].split("/"))
         for fname in os.listdir(source_base):
-            if '.json' not in fname:
+            if ".json" not in fname:
                 continue
-            if '_enums.json' in fname:
+            if "_enums.json" in fname:
                 continue
             file_list.append(
                 {
-                    'source': os.path.join(source_base, fname),
-                    'target': os.path.join(target_base, 'serialize_' + fname.replace('.json', '.cpp')),
+                    "source": os.path.join(source_base, fname),
+                    "target": os.path.join(target_base, "serialize_" + fname.replace(".json", ".cpp")),
                 }
             )
     return file_list
 
 
 scripts_dir = os.path.dirname(os.path.abspath(__file__))
-version_map_path = os.path.join(scripts_dir, '..', 'src', 'storage', 'version_map.json')
+version_map_path = os.path.join(scripts_dir, "..", "src", "storage", "version_map.json")
 version_map_file = file = open(version_map_path)
 version_map = json.load(version_map_file)
 
 
 def verify_serialization_versions(version_map):
-    serialization = version_map['serialization']['values']
-    if list(serialization.keys())[-1] != 'latest':
+    serialization = version_map["serialization"]["values"]
+    if list(serialization.keys())[-1] != "latest":
         print(f"The version map ({version_map_path}) for serialization versions must end in 'latest'!")
         exit(1)
 
@@ -75,7 +78,7 @@ def lookup_serialization_version(version: str):
             f"'latest' is not an allowed 'version' to use in serialization JSON files, please provide a duckdb version"
         )
 
-    versions = version_map['serialization']['values']
+    versions = version_map["serialization"]["values"]
     if version not in versions:
         from packaging.version import Version
 
@@ -91,85 +94,85 @@ def lookup_serialization_version(version: str):
                 f"Specified version ({current_version}) could not be found in the version_map.json, and it is lower than the last defined version ({last_registered_version})!"
             )
             exit(1)
-        if hasattr(versions, 'latest'):
+        if hasattr(versions, "latest"):
             # We have already mapped a version to 'latest', check that the versions match
-            latest_version = getattr(versions, 'latest')
+            latest_version = getattr(versions, "latest")
             if current_version != latest_version:
                 print(
                     f"Found more than one version that is not present in the version_map.json!: Current: {current_version}, Latest: {latest_version}"
                 )
                 exit(1)
         else:
-            setattr(lookup_serialization_version, 'latest', current_version)
-        return versions['latest']
+            setattr(lookup_serialization_version, "latest", current_version)
+        return versions["latest"]
     return versions[version]
 
 
 def version_string_to_storage_version_enum(version: str) -> str:
     """Convert a version string like 'v0.10.3' to 'StorageVersion::V0_10_3'."""
-    versions = version_map['serialization']['values']
+    versions = version_map["serialization"]["values"]
     if version not in versions:
-        return 'StorageVersion::LATEST'
+        return "StorageVersion::LATEST"
     # "v0.10.3" -> "V0_10_3"
-    enum_name = 'V' + version[1:].replace('.', '_')
-    return f'StorageVersion::{enum_name}'
+    enum_name = "V" + version[1:].replace(".", "_")
+    return f"StorageVersion::{enum_name}"
 
 
 INCLUDE_FORMAT = '#include "{filename}"\n'
 
-HEADER = '''//===----------------------------------------------------------------------===//
+HEADER = """//===----------------------------------------------------------------------===//
 // This file is automatically generated by scripts/generate_serialization.py
 // Do not edit this file manually, your changes will be overwritten
 //===----------------------------------------------------------------------===//
 
 {include_list}
 namespace duckdb {{
-'''
+"""
 
-FOOTER = '''
+FOOTER = """
 } // namespace duckdb
-'''
+"""
 
-TEMPLATED_BASE_FORMAT = '''
-template <typename {template_name}>'''
+TEMPLATED_BASE_FORMAT = """
+template <typename {template_name}>"""
 
-SERIALIZE_BASE_FORMAT = '''
+SERIALIZE_BASE_FORMAT = """
 void {class_name}::Serialize(Serializer &serializer) const {{
 {members}}}
-'''
+"""
 
 SERIALIZE_ELEMENT_FORMAT = (
     '\tserializer.WriteProperty<{property_type}>({property_id}, "{property_key}", {property_name}{property_default});\n'
 )
 
-BASE_SERIALIZE_FORMAT = '\t{base_class_name}::Serialize(serializer);\n'
+BASE_SERIALIZE_FORMAT = "\t{base_class_name}::Serialize(serializer);\n"
 
-POINTER_RETURN_FORMAT = '{pointer}<{class_name}>'
+POINTER_RETURN_FORMAT = "{pointer}<{class_name}>"
 
-DESERIALIZE_BASE_FORMAT = '''
+DESERIALIZE_BASE_FORMAT = """
 {deserialize_return} {class_name}::Deserialize(Deserializer &deserializer) {{
 {members}
 }}
-'''
+"""
 
-SWITCH_CODE_FORMAT = '''\tswitch ({switch_variable}) {{
+SWITCH_CODE_FORMAT = """\tswitch ({switch_variable}) {{
 {case_statements}\tdefault:
 \t\tthrow SerializationException("Unsupported type for deserialization of {base_class}!");
 \t}}
-'''
+"""
 
-SET_DESERIALIZE_PARAMETER_FORMAT = '\tdeserializer.Set<{property_type}>({property_name});\n'
-UNSET_DESERIALIZE_PARAMETER_FORMAT = '\tdeserializer.Unset<{property_type}>();\n'
-GET_DESERIALIZE_PARAMETER_FORMAT = 'deserializer.Get<{property_type}>()'
-TRY_GET_DESERIALIZE_PARAMETER_FORMAT = 'deserializer.TryGet<{property_type}>()'
+SET_DESERIALIZE_PARAMETER_FORMAT = "\tdeserializer.Set<{property_type}>({property_name});\n"
+UNSET_DESERIALIZE_PARAMETER_FORMAT = "\tdeserializer.Unset<{property_type}>();\n"
+GET_DESERIALIZE_PARAMETER_FORMAT = "deserializer.Get<{property_type}>()"
+TRY_GET_DESERIALIZE_PARAMETER_FORMAT = "deserializer.TryGet<{property_type}>()"
 
-SWITCH_HEADER_FORMAT = '\tcase {enum_type}::{enum_value}:\n'
+SWITCH_HEADER_FORMAT = "\tcase {enum_type}::{enum_value}:\n"
 
 SWITCH_STATEMENT_FORMAT = (
     SWITCH_HEADER_FORMAT
-    + '''\t\tresult = {class_deserialize}::Deserialize(deserializer);
+    + """\t\tresult = {class_deserialize}::Deserialize(deserializer);
 \t\tbreak;
-'''
+"""
 )
 
 DESERIALIZE_ELEMENT_FORMAT = '\tauto {property_name} = deserializer.ReadProperty<{property_type}>({property_id}, "{property_key}"{property_default});\n'
@@ -178,43 +181,43 @@ DESERIALIZE_ELEMENT_CLASS_FORMAT = '\tdeserializer.ReadProperty<{property_type}>
 DESERIALIZE_ELEMENT_CLASS_BASE_FORMAT = '\tauto {property_name} = deserializer.ReadProperty<unique_ptr<{base_property}>>({property_id}, "{property_key}"{property_default});\n\tresult{assignment}{property_name} = unique_ptr_cast<{base_property}, {derived_property}>(std::move({property_name}));\n'
 
 MOVE_LIST = [
-    'string',
-    'Identifier',
-    'ParsedExpression*',
-    'CommonTableExpressionMap',
-    'LogicalType',
-    'ColumnDefinition',
-    'BaseStatistics',
-    'BoundLimitNode',
+    "string",
+    "Identifier",
+    "ParsedExpression*",
+    "CommonTableExpressionMap",
+    "LogicalType",
+    "ColumnDefinition",
+    "BaseStatistics",
+    "BoundLimitNode",
 ]
 
-REFERENCE_LIST = ['ClientContext', 'bound_parameter_map_t', 'Catalog']
+REFERENCE_LIST = ["ClientContext", "bound_parameter_map_t", "Catalog"]
 
 
 def is_container(type):
-    return '<' in type and 'CSVOption' not in type
+    return "<" in type and "CSVOption" not in type
 
 
 def is_pointer(type):
-    return type.endswith('*') or type.startswith('shared_ptr<')
+    return type.endswith("*") or type.startswith("shared_ptr<")
 
 
 def is_zeroable(type):
     return type in [
-        'bool',
-        'int8_t',
-        'int16_t',
-        'int32_t',
-        'int64_t',
-        'uint8_t',
-        'uint16_t',
-        'uint32_t',
-        'uint64_t',
-        'idx_t',
-        'size_t',
-        'int',
-        'TableIndex',
-        'ProjectionIndex',
+        "bool",
+        "int8_t",
+        "int16_t",
+        "int32_t",
+        "int64_t",
+        "uint8_t",
+        "uint16_t",
+        "uint32_t",
+        "uint64_t",
+        "idx_t",
+        "size_t",
+        "int",
+        "TableIndex",
+        "ProjectionIndex",
     ]
 
 
@@ -223,11 +226,11 @@ def requires_move(type):
 
 
 def replace_pointer(type):
-    return re.sub('([a-zA-Z0-9]+)[*]', 'unique_ptr<\\1>', type)
+    return re.sub("([a-zA-Z0-9]+)[*]", "unique_ptr<\\1>", type)
 
 
 def get_default_argument(default_value):
-    return f'{default_value}'.lower() if type(default_value) == bool else f'{default_value}'
+    return f"{default_value}".lower() if type(default_value) == bool else f"{default_value}"
 
 
 def get_deserialize_element_template(
@@ -246,16 +249,16 @@ def get_deserialize_element_template(
         exit(1)
 
     # read_method = 'ReadProperty'
-    assignment = '.' if pointer_type == 'none' else '->'
-    default_argument = '' if default_value is None else f', {get_default_argument(default_value)}'
+    assignment = "." if pointer_type == "none" else "->"
+    default_argument = "" if default_value is None else f", {get_default_argument(default_value)}"
     if status == MemberVariableStatus.DELETED:
-        template = template.replace(', result{assignment}{property_name}', '').replace(
-            'ReadProperty', 'ReadDeletedProperty'
+        template = template.replace(", result{assignment}{property_name}", "").replace(
+            "ReadProperty", "ReadDeletedProperty"
         )
     elif has_default and default_value is None:
-        template = template.replace('ReadProperty', 'ReadPropertyWithDefault')
+        template = template.replace("ReadProperty", "ReadPropertyWithDefault")
     elif has_default and default_value is not None:
-        template = template.replace('ReadProperty', 'ReadPropertyWithExplicitDefault')
+        template = template.replace("ReadProperty", "ReadPropertyWithExplicitDefault")
     template = template.format(
         property_name=property_name,
         property_key=property_key,
@@ -265,7 +268,7 @@ def get_deserialize_element_template(
         assignment=assignment,
     )
     if status == MemberVariableStatus.DELETED:
-        template = template.replace(f'auto {property_name} = ', '')
+        template = template.replace(f"auto {property_name} = ", "")
     return template
 
 
@@ -273,42 +276,62 @@ def deserialize_local_name(entry):
     # Name of the local variable a member is read into (base-class / constructor deserialize).
     # Accessor-call deserialize properties (containing '(') are not valid identifiers, so fall back
     # to the member name.
-    if '(' in entry.deserialize_property:
+    if "(" in entry.deserialize_property:
         return entry.name
-    return entry.deserialize_property.replace('.', '_')
+    return entry.deserialize_property.replace(".", "_")
 
 
 def get_deserialize_assignment(property_name, property_type, pointer_type, local_name=None):
-    assignment = '.' if pointer_type == 'none' else '->'
+    assignment = "." if pointer_type == "none" else "->"
     # local_name is the variable the property was read into; accessor-call properties (containing '(')
     # are not valid identifiers, so callers pass the member name instead.
-    property = local_name if local_name is not None else property_name.replace('.', '_')
+    property = local_name if local_name is not None else property_name.replace(".", "_")
     if requires_move(property_type):
-        property = f'std::move({property})'
-    return f'\tresult{assignment}{property_name} = {property};\n'
+        property = f"std::move({property})"
+    return f"\tresult{assignment}{property_name} = {property};\n"
+
+
+def get_deserialize_method_calls(class_entry, members, pointer_type):
+    # Emit "result->Method(arg1, arg2, ...)" calls for each entry in the class' "methods" object. The arguments
+    # are members that were read into local variables (see is_method_arg) rather than assigned to result directly.
+    assignment = "." if pointer_type == "none" else "->"
+    member_by_name = {m.name: m for m in members} if members else {}
+    code = ""
+    for method_name, arg_names in class_entry.methods.items():
+        args = []
+        for arg_name in arg_names:
+            member = member_by_name.get(arg_name)
+            if member is not None and (
+                member.type in MOVE_LIST or is_container(member.type) or is_pointer(member.type)
+            ):
+                args.append(f"std::move({arg_name})")
+            else:
+                args.append(arg_name)
+        code += f'\tresult{assignment}{method_name}({", ".join(args)});\n'
+    return code
 
 
 def get_return_value(pointer_type, class_name):
-    if pointer_type == 'none':
+    if pointer_type == "none":
         return class_name
     return POINTER_RETURN_FORMAT.format(pointer=pointer_type, class_name=class_name)
 
 
 def generate_return(class_entry):
     if class_entry.base is None or class_entry.constructor_method is not None:
-        return '\treturn result;'
+        return "\treturn result;"
     else:
-        return '\treturn std::move(result);'
+        return "\treturn std::move(result);"
 
 
 def parse_status(status: str):
-    if status == 'deleted':
+    if status == "deleted":
         return MemberVariableStatus.DELETED
-    if status == 'read_only':
+    if status == "read_only":
         return MemberVariableStatus.READ_ONLY
-    if status == 'existing':
+    if status == "existing":
         return MemberVariableStatus.EXISTING
-    valid_options = ['deleted', 'read_only', 'existing']
+    valid_options = ["deleted", "read_only", "existing"]
     valid_options_string = ", ".join(valid_options)
     print(f"Invalid 'status' ('{status}') encountered, valid options are: {valid_options_string}")
     exit(1)
@@ -317,44 +340,44 @@ def parse_status(status: str):
 # FIXME: python has __slots__ for this, so it's enforced by Python itself
 # see: https://wiki.python.org/moin/UsingSlots
 supported_member_entries = [
-    'id',
-    'name',
-    'type',
-    'property',
-    'serialize_property',
-    'deserialize_property',
-    'base',
-    'default',
-    'status',
-    'version',
-    'required_until',
+    "id",
+    "name",
+    "type",
+    "property",
+    "serialize_property",
+    "deserialize_property",
+    "base",
+    "default",
+    "status",
+    "version",
+    "required_until",
     # equality/hash generation annotations (used by generate_util.py)
-    'equals_skip',
-    'hash_skip',
+    "equals_skip",
+    "hash_skip",
     # skip (de)serialization entirely (member only exists for equals/hash/copy generation)
-    'serialize_skip',
+    "serialize_skip",
     # accessor annotations (used by generate_util.py for Children/ChildrenMutable generation)
-    'accessor_mut',
-    'accessor',
+    "accessor_mut",
+    "accessor",
     # nullable annotation (used by generate_util.py)
-    'nullable',
+    "nullable",
 ]
 
 
 def has_default_by_default(type):
     if is_pointer(type):
         return True
-    if type == 'identifier_set_t':
+    if type == "identifier_set_t":
         return True
     if is_container(type):
-        if 'IndexVector' in type:
+        if "IndexVector" in type:
             return False
-        if 'CSVOption' in type:
+        if "CSVOption" in type:
             return False
         return True
-    if type == 'string':
+    if type == "string":
         return True
-    if type in ('Identifier', 'duckdb::Identifier'):
+    if type in ("Identifier", "duckdb::Identifier"):
         # Identifier behaves like string: the empty identifier is its default
         return True
     if is_zeroable(type):
@@ -374,73 +397,74 @@ def normalize_json_type(type_str):
 class MemberVariable:
     def __init__(self, entry):
         # serialize_skip members are not (de)serialized, so they need no field id
-        self.id = entry.get('id', -1)
-        self.name = entry['name']
-        self.type = normalize_json_type(entry['type'])
+        self.id = entry.get("id", -1)
+        self.name = entry["name"]
+        self.type = normalize_json_type(entry["type"])
         self.base = None
         self.has_default = False
         self.default = None
         self.status: MemberVariableStatus = MemberVariableStatus.EXISTING
-        self.version: str = 'v0.10.2'
+        self.version: str = "v0.10.2"
         self.required_until = None
-        if 'property' in entry:
-            self.serialize_property = entry['property']
-            self.deserialize_property = entry['property']
+        if "property" in entry:
+            self.serialize_property = entry["property"]
+            self.deserialize_property = entry["property"]
         else:
             self.serialize_property = self.name
             self.deserialize_property = self.name
-        if 'version' in entry:
-            self.version = entry['version']
-        if 'serialize_property' in entry:
-            self.serialize_property = entry['serialize_property']
-        if 'deserialize_property' in entry:
-            self.deserialize_property = entry['deserialize_property']
-        if 'default' in entry:
+        if "version" in entry:
+            self.version = entry["version"]
+        if "serialize_property" in entry:
+            self.serialize_property = entry["serialize_property"]
+        if "deserialize_property" in entry:
+            self.deserialize_property = entry["deserialize_property"]
+        if "default" in entry:
             self.has_default = True
-            self.default = entry['default']
-        if 'status' in entry:
-            self.status = parse_status(entry['status'])
+            self.default = entry["default"]
+        if "status" in entry:
+            self.status = parse_status(entry["status"])
         if self.default is None:
             # default default
             self.has_default = has_default_by_default(self.type)
-        if 'required_until' in entry:
+        if "required_until" in entry:
             # The field must be written (as a required property) for storage versions older than this version, so
             # that older DuckDB releases - which read it as a required property - can still open the database. From
             # this version onwards it is written as an optional property (skipped when default). Reads always tolerate
             # absence, so a default is required.
-            self.required_until = entry['required_until']
+            self.required_until = entry["required_until"]
             self.has_default = True
-        if 'base' in entry:
-            self.base = entry['base']
+        if "base" in entry:
+            self.base = entry["base"]
         # Members marked serialize_skip are not (de)serialized; they only exist for the
         # equals/hash/copy generation (e.g. an aggregate field serialized as its components).
-        self.serialize_skip = entry.get('serialize_skip', False)
+        self.serialize_skip = entry.get("serialize_skip", False)
         for key in entry.keys():
             if key not in supported_member_entries:
                 print(
-                    f"Unsupported key \"{key}\" in member variable, key should be in set {str(supported_member_entries)}"
+                    f'Unsupported key "{key}" in member variable, key should be in set {str(supported_member_entries)}'
                 )
                 exit(1)
 
 
 supported_serialize_entries = [
-    'class',
-    'class_type',
-    'pointer_type',
-    'base',
-    'enum',
-    'constructor',
-    'constructor_method',
-    'custom_implementation',
-    'custom_switch_code',
-    'members',
-    'return_type',
-    'set_parameters',
-    'includes',
-    'finalize_deserialization',
-    'ignore_clang_tidy_rules',
-    'functions',
-    'use_legacy_serialization',
+    "class",
+    "class_type",
+    "pointer_type",
+    "base",
+    "enum",
+    "constructor",
+    "constructor_method",
+    "custom_implementation",
+    "custom_switch_code",
+    "members",
+    "return_type",
+    "set_parameters",
+    "includes",
+    "finalize_deserialization",
+    "ignore_clang_tidy_rules",
+    "functions",
+    "use_legacy_serialization",
+    "methods",
 ]
 
 
@@ -450,27 +474,27 @@ class ClangTidyIgnoreRule:
     reason: str
 
     @classmethod
-    def from_dict(cls, entry: dict) -> 'ClangTidyIgnoreRule':
-        if 'name' not in entry or 'reason' not in entry:
+    def from_dict(cls, entry: dict) -> "ClangTidyIgnoreRule":
+        if "name" not in entry or "reason" not in entry:
             raise ValueError("Each entry in 'ignore_clang_tidy_rules' must have both 'name' and 'reason' fields")
-        return cls(name=entry['name'], reason=entry['reason'])
+        return cls(name=entry["name"], reason=entry["reason"])
 
     @classmethod
-    def from_entries(cls, entries: List[dict]) -> List['ClangTidyIgnoreRule']:
+    def from_entries(cls, entries: List[dict]) -> List["ClangTidyIgnoreRule"]:
         return [cls.from_dict(entry) for entry in entries]
 
 
 class SerializableClass:
     def __init__(self, entry):
-        self.name = entry['class']
-        self.is_base_class = 'class_type' in entry
+        self.name = entry["class"]
+        self.is_base_class = "class_type" in entry
         self.base = None
         self.base_object = None
         self.enum_value = None
         self.enum_entries = []
         self.set_parameter_names = []
         self.set_parameters = []
-        self.pointer_type = 'unique_ptr'
+        self.pointer_type = "unique_ptr"
         self.constructor: Optional[List[str]] = None
         self.constructor_method = None
         self.members: Optional[List[MemberVariable]] = None
@@ -481,41 +505,50 @@ class SerializableClass:
         self.return_class = self.name
         self.finalize_deserialization = None
         self.use_legacy_serialization = None
+        # methods to invoke on the result after deserialization, built from member values read into locals.
+        # maps a method name to the list of member names passed as arguments, e.g.
+        # {"SetQualifiedName": ["catalog", "schema", "name"]} -> result->SetQualifiedName(catalog, schema, name)
+        self.methods: Dict[str, List[str]] = {}
+        self.method_arg_names = set()
         self.ignore_clang_tidy_rules: List[ClangTidyIgnoreRule] = []
-        if 'use_legacy_serialization' in entry:
-            self.use_legacy_serialization = entry['use_legacy_serialization']
-        if 'ignore_clang_tidy_rules' in entry:
-            self.ignore_clang_tidy_rules = ClangTidyIgnoreRule.from_entries(entry['ignore_clang_tidy_rules'])
-        if 'finalize_deserialization' in entry:
-            self.finalize_deserialization = entry['finalize_deserialization']
+        if "use_legacy_serialization" in entry:
+            self.use_legacy_serialization = entry["use_legacy_serialization"]
+        if "ignore_clang_tidy_rules" in entry:
+            self.ignore_clang_tidy_rules = ClangTidyIgnoreRule.from_entries(entry["ignore_clang_tidy_rules"])
+        if "finalize_deserialization" in entry:
+            self.finalize_deserialization = entry["finalize_deserialization"]
         if self.is_base_class:
-            self.enum_value = entry['class_type']
-        if 'pointer_type' in entry:
-            self.pointer_type = entry['pointer_type']
-        if 'base' in entry:
-            self.base = entry['base']
-            self.enum_entries = entry['enum']
+            self.enum_value = entry["class_type"]
+        if "pointer_type" in entry:
+            self.pointer_type = entry["pointer_type"]
+        if "base" in entry:
+            self.base = entry["base"]
+            self.enum_entries = entry["enum"]
             if type(self.enum_entries) is str:
                 self.enum_entries = [self.enum_entries]
             self.return_type = self.base
-        if 'constructor' in entry:
-            self.constructor = entry['constructor']
+        if "constructor" in entry:
+            self.constructor = entry["constructor"]
             if not isinstance(self.constructor, list):
                 print(f"constructor for {self.name}, must be of type [], but is of type {str(type(self.constructor))}")
                 exit(1)
-        if 'constructor_method' in entry:
-            self.constructor_method = entry['constructor_method']
-        if 'custom_implementation' in entry and entry['custom_implementation']:
+        if "constructor_method" in entry:
+            self.constructor_method = entry["constructor_method"]
+        if "custom_implementation" in entry and entry["custom_implementation"]:
             self.custom_implementation = True
-        if 'custom_switch_code' in entry:
-            self.custom_switch_code = entry['custom_switch_code']
-        if 'members' in entry:
-            self.members = [MemberVariable(x) for x in entry['members']]
-        if 'return_type' in entry:
-            self.return_type = entry['return_type']
+        if "custom_switch_code" in entry:
+            self.custom_switch_code = entry["custom_switch_code"]
+        if "members" in entry:
+            self.members = [MemberVariable(x) for x in entry["members"]]
+        if "methods" in entry:
+            self.methods = entry["methods"]
+            for arg_names in self.methods.values():
+                self.method_arg_names.update(arg_names)
+        if "return_type" in entry:
+            self.return_type = entry["return_type"]
             self.return_class = self.return_type
-        if 'set_parameters' in entry:
-            self.set_parameter_names = entry['set_parameters']
+        if "set_parameters" in entry:
+            self.set_parameter_names = entry["set_parameters"]
             for set_parameter_name in self.set_parameter_names:
                 found = False
                 assert self.members is not None
@@ -525,11 +558,11 @@ class SerializableClass:
                         found = True
                         break
                 if not found:
-                    raise Exception(f'Set parameter {set_parameter_name} not found in member list')
+                    raise Exception(f"Set parameter {set_parameter_name} not found in member list")
         for key in entry.keys():
             if key not in supported_serialize_entries:
                 print(
-                    f"Unsupported key \"{key}\" in member variable, key should be in set {str(supported_serialize_entries)}"
+                    f'Unsupported key "{key}" in member variable, key should be in set {str(supported_serialize_entries)}'
                 )
                 exit(1)
 
@@ -538,7 +571,11 @@ class SerializableClass:
         self.pointer_type = base_class.pointer_type
 
     def get_deserialize_element(
-        self, entry: MemberVariable, *, base: Optional[str] = None, pointer_type: Optional[str] = None
+        self,
+        entry: MemberVariable,
+        *,
+        base: Optional[str] = None,
+        pointer_type: Optional[str] = None,
     ):
         property_name = entry.deserialize_property
         property_id = entry.id
@@ -553,7 +590,7 @@ class SerializableClass:
         property_name = deserialize_local_name(entry)
         template = DESERIALIZE_ELEMENT_FORMAT
         if base:
-            template = DESERIALIZE_ELEMENT_BASE_FORMAT.replace('{base_property}', base.replace('*', ''))
+            template = DESERIALIZE_ELEMENT_BASE_FORMAT.replace("{base_property}", base.replace("*", ""))
 
         return get_deserialize_element_template(
             template,
@@ -574,16 +611,16 @@ class SerializableClass:
         property_type = replace_pointer(entry.type)
         default_value = entry.default
 
-        assignment = '.' if self.pointer_type == 'none' else '->'
-        default_argument = '' if default_value is None else f', {get_default_argument(default_value)}'
+        assignment = "." if self.pointer_type == "none" else "->"
+        default_argument = "" if default_value is None else f", {get_default_argument(default_value)}"
         storage_version = lookup_serialization_version(entry.version)
         conditional_serialization = storage_version != 1
         storage_version_enum = version_string_to_storage_version_enum(entry.version)
         template = SERIALIZE_ELEMENT_FORMAT
         if entry.status != MemberVariableStatus.EXISTING and not conditional_serialization:
-            template = "\t/* [Deleted] ({property_type}) \"{property_name}\" */\n"
+            template = '\t/* [Deleted] ({property_type}) "{property_name}" */\n'
         elif entry.has_default:
-            template = template.replace('WriteProperty', 'WritePropertyWithDefault')
+            template = template.replace("WriteProperty", "WritePropertyWithDefault")
         serialization_code = template.format(
             property_name=property_name,
             property_type=property_type,
@@ -602,28 +639,28 @@ class SerializableClass:
                 property_type=property_type,
                 property_id=str(property_id),
                 property_key=property_key,
-                property_default='',
+                property_default="",
                 assignment=assignment,
             )
             return (
-                f'\tif (serializer.ShouldSerialize({required_until_enum})) {{\n'
-                f'\t{serialization_code}'
-                f'\t}} else {{\n'
-                f'\t{required_code}'
-                f'\t}}\n'
+                f"\tif (serializer.ShouldSerialize({required_until_enum})) {{\n"
+                f"\t{serialization_code}"
+                f"\t}} else {{\n"
+                f"\t{required_code}"
+                f"\t}}\n"
             )
 
         if conditional_serialization:
             code = []
             if entry.status != MemberVariableStatus.EXISTING:
                 # conditional delete
-                code.append(f'\tif (!serializer.ShouldSerialize({storage_version_enum})) {{')
+                code.append(f"\tif (!serializer.ShouldSerialize({storage_version_enum})) {{")
             else:
                 # conditional serialization
-                code.append(f'\tif (serializer.ShouldSerialize({storage_version_enum})) {{')
-            code.append('\t' + serialization_code)
+                code.append(f"\tif (serializer.ShouldSerialize({storage_version_enum})) {{")
+            code.append("\t" + serialization_code)
 
-            result = '\n'.join(code) + '\t}\n'
+            result = "\n".join(code) + "\t}\n"
             return result
         return serialization_code
 
@@ -631,20 +668,20 @@ class SerializableClass:
         parameters = ", ".join(constructor_parameters)
 
         if self.constructor_method is not None:
-            return f'\tauto result = {self.constructor_method}({parameters});\n'
-        if self.pointer_type == 'none':
-            if parameters != '':
-                parameters = f'({parameters})'
-            return f'\t{self.return_class} result{parameters};\n'
-        return f'\tauto result = duckdb::{self.pointer_type}<{self.return_class}>(new {self.return_class}({parameters}));\n'
+            return f"\tauto result = {self.constructor_method}({parameters});\n"
+        if self.pointer_type == "none":
+            if parameters != "":
+                parameters = f"({parameters})"
+            return f"\t{self.return_class} result{parameters};\n"
+        return f"\tauto result = duckdb::{self.pointer_type}<{self.return_class}>(new {self.return_class}({parameters}));\n"
 
 
 def generate_base_class_code(base_class: SerializableClass):
-    base_class_serialize = ''
-    base_class_deserialize = ''
+    base_class_serialize = ""
+    base_class_deserialize = ""
 
     # properties
-    enum_type = ''
+    enum_type = ""
     for entry in base_class.members:
         if entry.serialize_property == base_class.enum_value:
             enum_type = entry.type
@@ -661,22 +698,26 @@ def generate_base_class_code(base_class: SerializableClass):
             property_type=entry.type, property_name=entry.name
         )
 
-    base_class_deserialize += f'\t{base_class.pointer_type}<{base_class.name}> result;\n'
-    switch_cases = ''
+    base_class_deserialize += f"\t{base_class.pointer_type}<{base_class.name}> result;\n"
+    switch_cases = ""
     for expr in expressions:
         enum_value = expr[0]
         child_data = expr[1]
         if child_data.custom_switch_code is not None:
             switch_cases += SWITCH_HEADER_FORMAT.format(
-                enum_type=enum_type, enum_value=enum_value, class_deserialize=child_data.name
+                enum_type=enum_type,
+                enum_value=enum_value,
+                class_deserialize=child_data.name,
             )
-            switch_cases += '\n'.join(
-                ['\t\t' + x for x in child_data.custom_switch_code.replace('\\n', '\n').split('\n')]
+            switch_cases += "\n".join(
+                ["\t\t" + x for x in child_data.custom_switch_code.replace("\\n", "\n").split("\n")]
             )
-            switch_cases += '\n'
+            switch_cases += "\n"
             continue
         switch_cases += SWITCH_STATEMENT_FORMAT.format(
-            enum_type=enum_type, enum_value=enum_value, class_deserialize=child_data.name
+            enum_type=enum_type,
+            enum_value=enum_value,
+            class_deserialize=child_data.name,
         )
 
     assign_entries = []
@@ -693,7 +734,9 @@ def generate_base_class_code(base_class: SerializableClass):
 
     # class switch statement
     base_class_deserialize += SWITCH_CODE_FORMAT.format(
-        switch_variable=base_class.enum_value, case_statements=switch_cases, base_class=base_class.name
+        switch_variable=base_class.enum_value,
+        case_statements=switch_cases,
+        base_class=base_class.name,
     )
 
     deserialize_return = get_return_value(base_class.pointer_type, base_class.return_type)
@@ -704,27 +747,33 @@ def generate_base_class_code(base_class: SerializableClass):
     for entry in assign_entries:
         if entry.status != MemberVariableStatus.EXISTING:
             continue
+        if entry.name in base_class.method_arg_names:
+            # value is consumed by a method call below instead of being assigned to a member
+            continue
         local = deserialize_local_name(entry)
         move = False
         if entry.type in MOVE_LIST or is_container(entry.type) or is_pointer(entry.type):
             move = True
         if move:
-            base_class_deserialize += f'\tresult->{entry.deserialize_property} = std::move({local});\n'
+            base_class_deserialize += f"\tresult->{entry.deserialize_property} = std::move({local});\n"
         else:
-            base_class_deserialize += f'\tresult->{entry.deserialize_property} = {local};\n'
+            base_class_deserialize += f"\tresult->{entry.deserialize_property} = {local};\n"
+    base_class_deserialize += get_deserialize_method_calls(base_class, base_class.members, base_class.pointer_type)
     if base_class.finalize_deserialization is not None:
         for line in base_class.finalize_deserialization:
             base_class_deserialize += "\t" + line + "\n"
     base_class_deserialize += generate_return(base_class)
-    base_class_generation = ''
-    serialization = ''
+    base_class_generation = ""
+    serialization = ""
     if base_class.base is not None:
         serialization += BASE_SERIALIZE_FORMAT.format(base_class_name=base_class.base)
     base_class_generation += SERIALIZE_BASE_FORMAT.format(
         class_name=base_class.name, members=serialization + base_class_serialize
     )
     base_class_generation += DESERIALIZE_BASE_FORMAT.format(
-        deserialize_return=deserialize_return, class_name=base_class.name, members=base_class_deserialize
+        deserialize_return=deserialize_return,
+        class_name=base_class.name,
+        members=base_class_deserialize,
     )
     return base_class_generation
 
@@ -745,22 +794,24 @@ def wrap_with_clang_tidy_ignore(code: str, rules: List[ClangTidyIgnoreRule]) -> 
         return code
     rule_names_to_inject = ", ".join([rule.name for rule in rules])
     return "// NOLINTBEGIN({rule_names})\n// reasons: {reasons}\n{code}\n// NOLINTEND({rule_names})\n".format(
-        code=code, rule_names=rule_names_to_inject, reasons=", ".join([rule.reason for rule in rules])
+        code=code,
+        rule_names=rule_names_to_inject,
+        reasons=", ".join([rule.reason for rule in rules]),
     )
 
 
 def generate_class_code(class_entry: SerializableClass):
     if class_entry.custom_implementation:
         return None
-    class_serialize = ''
-    class_deserialize = ''
+    class_serialize = ""
+    class_deserialize = ""
 
     constructor_parameters: List[str] = []
     constructor_entries = set()
     last_constructor_index = -1
     if class_entry.constructor is not None:
         for constructor_entry_ in class_entry.constructor:
-            if constructor_entry_.endswith('&'):
+            if constructor_entry_.endswith("&"):
                 constructor_entry = constructor_entry_[:-1]
                 is_reference = True
             else:
@@ -773,24 +824,24 @@ def generate_class_code(class_entry: SerializableClass):
                     if entry_idx > last_constructor_index:
                         last_constructor_index = entry_idx
                     type_name = replace_pointer(entry.type)
-                    entry.deserialize_property = entry.deserialize_property.replace('.', '_')
+                    entry.deserialize_property = entry.deserialize_property.replace(".", "_")
                     if requires_move(type_name) and not is_reference:
-                        constructor_parameters.append(f'std::move({entry.deserialize_property})')
+                        constructor_parameters.append(f"std::move({entry.deserialize_property})")
                     else:
                         constructor_parameters.append(entry.deserialize_property)
                     found = True
                     break
 
-            if constructor_entry.startswith('$') or constructor_entry.startswith('?'):
-                is_optional = constructor_entry.startswith('?')
+            if constructor_entry.startswith("$") or constructor_entry.startswith("?"):
+                is_optional = constructor_entry.startswith("?")
                 if is_optional:
-                    param_type = constructor_entry.replace('?', '')
+                    param_type = constructor_entry.replace("?", "")
                     get_format = TRY_GET_DESERIALIZE_PARAMETER_FORMAT
                 else:
-                    param_type = constructor_entry.replace('$', '')
+                    param_type = constructor_entry.replace("$", "")
                     get_format = GET_DESERIALIZE_PARAMETER_FORMAT
                     if param_type in REFERENCE_LIST:
-                        param_type += ' &'
+                        param_type += " &"
                 constructor_parameters.append(get_format.format(property_type=param_type))
                 found = True
 
@@ -801,7 +852,7 @@ def generate_class_code(class_entry: SerializableClass):
                         found = True
                         break
             if not found:
-                print(f"Constructor member \"{constructor_entry}\" was not found in members list")
+                print(f'Constructor member "{constructor_entry}" was not found in members list')
                 exit(1)
     elif class_entry.constructor_method is not None:
         for entry_idx, entry in enumerate(class_entry.members):
@@ -811,9 +862,9 @@ def generate_class_code(class_entry: SerializableClass):
                 continue
             constructor_entries.add(entry.name)
             type_name = replace_pointer(entry.type)
-            entry.deserialize_property = entry.deserialize_property.replace('.', '_')
+            entry.deserialize_property = entry.deserialize_property.replace(".", "_")
             if requires_move(type_name):
-                constructor_parameters.append(f'std::move({entry.deserialize_property})')
+                constructor_parameters.append(f"std::move({entry.deserialize_property})")
             else:
                 constructor_parameters.append(entry.deserialize_property)
 
@@ -823,7 +874,7 @@ def generate_class_code(class_entry: SerializableClass):
         entry = class_entry.members[entry_idx]
         if entry.serialize_skip:
             continue
-        class_deserialize += class_entry.get_deserialize_element(entry, base=entry.base, pointer_type='unique_ptr')
+        class_deserialize += class_entry.get_deserialize_element(entry, base=entry.base, pointer_type="unique_ptr")
 
     class_deserialize += class_entry.generate_constructor(constructor_parameters)
     if class_entry.members is None:
@@ -835,33 +886,46 @@ def generate_class_code(class_entry: SerializableClass):
         deserialize_template_str = DESERIALIZE_ELEMENT_CLASS_FORMAT
         if entry.base:
             deserialize_template_str = DESERIALIZE_ELEMENT_CLASS_BASE_FORMAT.replace(
-                '{base_property}', entry.base.replace('*', '')
-            ).replace('{derived_property}', entry.type.replace('*', ''))
+                "{base_property}", entry.base.replace("*", "")
+            ).replace("{derived_property}", entry.type.replace("*", ""))
 
         class_serialize += class_entry.get_serialize_element(entry)
 
         type_name = replace_pointer(entry.type)
+        is_method_arg = entry.name in class_entry.method_arg_names
         if entry_idx > last_constructor_index:
-            class_deserialize += get_deserialize_element_template(
-                deserialize_template_str,
-                entry.deserialize_property,
-                entry.name,
-                entry.id,
-                type_name,
-                entry.has_default,
-                entry.default,
-                entry.status,
-                class_entry.pointer_type,
-            )
-        elif entry.name not in constructor_entries and entry.status == MemberVariableStatus.EXISTING:
+            if is_method_arg:
+                # read into a local variable; the value is passed to a method call after deserialization
+                class_deserialize += class_entry.get_deserialize_element(entry)
+            else:
+                class_deserialize += get_deserialize_element_template(
+                    deserialize_template_str,
+                    entry.deserialize_property,
+                    entry.name,
+                    entry.id,
+                    type_name,
+                    entry.has_default,
+                    entry.default,
+                    entry.status,
+                    class_entry.pointer_type,
+                )
+        elif (
+            not is_method_arg
+            and entry.name not in constructor_entries
+            and entry.status == MemberVariableStatus.EXISTING
+        ):
             class_deserialize += get_deserialize_assignment(
-                entry.deserialize_property, entry.type, class_entry.pointer_type, deserialize_local_name(entry)
+                entry.deserialize_property,
+                entry.type,
+                class_entry.pointer_type,
+                deserialize_local_name(entry),
             )
         if entry.name in class_entry.set_parameter_names and entry.status == MemberVariableStatus.EXISTING:
             class_deserialize += SET_DESERIALIZE_PARAMETER_FORMAT.format(
                 property_type=entry.type, property_name=entry.name
             )
 
+    class_deserialize += get_deserialize_method_calls(class_entry, class_entry.members, class_entry.pointer_type)
     for entry in class_entry.set_parameters:
         class_deserialize += UNSET_DESERIALIZE_PARAMETER_FORMAT.format(
             property_type=entry.type, property_name=entry.name
@@ -874,23 +938,23 @@ def generate_class_code(class_entry: SerializableClass):
     class_deserialize += generate_return(class_entry)
     deserialize_return = get_return_value(class_entry.pointer_type, class_entry.return_type)
 
-    class_generation = ''
-    pattern = re.compile(r'<\w+>')
-    templated_type = ''
+    class_generation = ""
+    pattern = re.compile(r"<\w+>")
+    templated_type = ""
 
     # Check if is a templated class
     is_templated = pattern.search(class_entry.name)
     if is_templated:
         templated_type = TEMPLATED_BASE_FORMAT.format(template_name=is_templated.group()[1:-1])
 
-    legacy_serialize_preamble = ''
+    legacy_serialize_preamble = ""
     if class_entry.use_legacy_serialization is not None:
         storage_version_enum = version_string_to_storage_version_enum(class_entry.use_legacy_serialization)
         legacy_serialize_preamble = (
-            f'\tif (!serializer.ShouldSerialize({storage_version_enum}) && UseLegacySerialization()) {{\n'
-            f'\t\tLegacySerialize(serializer);\n'
-            f'\t\treturn;\n'
-            f'\t}}\n'
+            f"\tif (!serializer.ShouldSerialize({storage_version_enum}) && UseLegacySerialization()) {{\n"
+            f"\t\tLegacySerialize(serializer);\n"
+            f"\t\treturn;\n"
+            f"\t}}\n"
         )
 
     class_generation += templated_type + SERIALIZE_BASE_FORMAT.format(
@@ -929,9 +993,9 @@ def check_children_for_duplicate_members(node: SerializableClass, parents: list,
 file_list = get_file_list()
 
 for entry in file_list:
-    source_path = entry['source']
-    target_path = entry['target']
-    with open(source_path, 'r') as f:
+    source_path = entry["source"]
+    target_path = entry["target"]
+    with open(source_path, "r") as f:
         try:
             json_data = json.load(f)
         except Exception as e:
@@ -939,26 +1003,26 @@ for entry in file_list:
             exit(1)
 
     include_list = [
-        'duckdb/common/serializer/serializer.hpp',
-        'duckdb/common/serializer/deserializer.hpp',
+        "duckdb/common/serializer/serializer.hpp",
+        "duckdb/common/serializer/deserializer.hpp",
     ]
     base_classes: List[SerializableClass] = []
     classes: List[SerializableClass] = []
     base_class_data: Dict[str, SerializableClass] = {}
 
     for entry in json_data:
-        if 'includes' in entry:
-            if type(entry['includes']) != type([]):
+        if "includes" in entry:
+            if type(entry["includes"]) != type([]):
                 print(f"Include list must be a list, found {type(entry['includes'])} (in {str(entry)})")
                 exit(1)
-            for include_entry in entry['includes']:
+            for include_entry in entry["includes"]:
                 if include_entry not in include_list:
                     include_list.append(include_entry)
         new_class = SerializableClass(entry)
         if new_class.is_base_class:
             # this class is a base class itself - construct the base class list
             if new_class.name in base_class_data:
-                raise Exception(f"Duplicate base class \"{new_class.name}\"")
+                raise Exception(f'Duplicate base class "{new_class.name}"')
             base_class_data[new_class.name] = new_class
             base_classes.append(new_class)
         else:
@@ -966,12 +1030,12 @@ for entry in file_list:
         if new_class.base is not None:
             # this class inherits from a base class - add the enum value
             if new_class.base not in base_class_data:
-                raise Exception(f"Unknown base class \"{new_class.base}\" for entry \"{new_class.name}\"")
+                raise Exception(f'Unknown base class "{new_class.base}" for entry "{new_class.name}"')
             base_class_object = base_class_data[new_class.base]
             new_class.inherit(base_class_object)
             for enum_entry in new_class.enum_entries:
                 if enum_entry in base_class_object.children:
-                    raise Exception(f"Duplicate enum entry \"{enum_entry}\"")
+                    raise Exception(f'Duplicate enum entry "{enum_entry}"')
                 base_class_object.children[enum_entry] = new_class
 
     # Ensure that there are no duplicate names in the inheritance tree
@@ -980,8 +1044,8 @@ for entry in file_list:
             # Root base class, now traverse the children
             check_children_for_duplicate_members(base_class, [], set(), set())
 
-    with open(target_path, 'w+') as f:
-        include_list = ''.join([INCLUDE_FORMAT.format(filename=x) for x in include_list])
+    with open(target_path, "w+") as f:
+        include_list = "".join([INCLUDE_FORMAT.format(filename=x) for x in include_list])
         header = HEADER.format(include_list=include_list)
         f.write(header)
 

--- a/src/include/duckdb/parser/expression/function_expression.hpp
+++ b/src/include/duckdb/parser/expression/function_expression.hpp
@@ -108,14 +108,14 @@ public:
 	void SetQualifiedName(QualifiedName name) {
 		qualified_name = std::move(name);
 	}
+	void SetQualifiedName(Identifier catalog, Identifier schema, Identifier name) {
+		qualified_name = QualifiedName(std::move(catalog), std::move(schema), std::move(name));
+	}
 	const Identifier &FunctionName() const {
 		return qualified_name.Name();
 	}
-	Identifier &FunctionNameMutable() {
-		return qualified_name.NameMutable();
-	}
 	void SetFunctionName(string function_name_p) {
-		qualified_name.NameMutable() = Identifier(std::move(function_name_p));
+		qualified_name = qualified_name.WithName(Identifier(std::move(function_name_p)));
 	}
 	bool IsOperator() const {
 		return is_operator;

--- a/src/include/duckdb/parser/expression/type_expression.hpp
+++ b/src/include/duckdb/parser/expression/type_expression.hpp
@@ -34,6 +34,9 @@ public:
 	void SetQualifiedName(QualifiedName name) {
 		qualified_name = std::move(name);
 	}
+	void SetQualifiedName(Identifier catalog, Identifier schema, Identifier name) {
+		qualified_name = QualifiedName(std::move(catalog), std::move(schema), std::move(name));
+	}
 	const Identifier &GetTypeName() const {
 		return qualified_name.Name();
 	}
@@ -41,13 +44,13 @@ public:
 		return qualified_name.Schema();
 	}
 	void SetSchema(Identifier new_schema) {
-		qualified_name.SchemaMutable() = std::move(new_schema);
+		qualified_name = QualifiedName(qualified_name.Catalog(), std::move(new_schema), qualified_name.Name());
 	}
 	const Identifier &GetCatalog() const {
 		return qualified_name.Catalog();
 	}
 	void SetCatalog(Identifier new_catalog) {
-		qualified_name.CatalogMutable() = std::move(new_catalog);
+		qualified_name = QualifiedName(std::move(new_catalog), qualified_name.Schema(), qualified_name.Name());
 	}
 	const vector<unique_ptr<ParsedExpression>> &GetChildren() const {
 		return children;

--- a/src/include/duckdb/parser/expression/window_expression.hpp
+++ b/src/include/duckdb/parser/expression/window_expression.hpp
@@ -76,11 +76,11 @@ public:
 	void SetQualifiedName(QualifiedName name) {
 		qualified_name = std::move(name);
 	}
+	void SetQualifiedName(Identifier catalog, Identifier schema, Identifier name) {
+		qualified_name = QualifiedName(std::move(catalog), std::move(schema), std::move(name));
+	}
 	const Identifier &FunctionName() const {
 		return qualified_name.Name();
-	}
-	Identifier &FunctionNameMutable() {
-		return qualified_name.NameMutable();
 	}
 	const vector<unique_ptr<ParsedExpression>> &Partitions() const {
 		return partitions;

--- a/src/include/duckdb/parser/parsed_data/alter_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/alter_info.hpp
@@ -75,8 +75,11 @@ public:
 	void SetQualifiedName(QualifiedName name) {
 		qualified_name = std::move(name);
 	}
-	Identifier &NameMutable() {
-		return qualified_name.NameMutable();
+	void SetQualifiedName(Identifier catalog, Identifier schema, Identifier name) {
+		qualified_name = QualifiedName(std::move(catalog), std::move(schema), std::move(name));
+	}
+	void SetName(Identifier name) {
+		qualified_name = qualified_name.WithName(std::move(name));
 	}
 
 public:

--- a/src/include/duckdb/parser/parsed_data/copy_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/copy_info.hpp
@@ -57,11 +57,14 @@ public:
 	void SetQualifiedName(QualifiedName name) {
 		qualified_name = std::move(name);
 	}
+	void SetQualifiedName(Identifier catalog, Identifier schema, Identifier name) {
+		qualified_name = QualifiedName(std::move(catalog), std::move(schema), std::move(name));
+	}
 	const Identifier &Table() const {
 		return qualified_name.Name();
 	}
-	Identifier &TableMutable() {
-		return qualified_name.NameMutable();
+	void SetTable(Identifier table) {
+		qualified_name = qualified_name.WithName(std::move(table));
 	}
 
 public:

--- a/src/include/duckdb/parser/parsed_data/create_collation_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_collation_info.hpp
@@ -23,7 +23,7 @@ struct CreateCollationInfo : public CreateInfo {
 		return qualified_name.Name();
 	}
 	void SetCollationName(Identifier name) {
-		qualified_name.NameMutable() = std::move(name);
+		qualified_name = qualified_name.WithName(std::move(name));
 	}
 	//! The collation function to push in case collation is required
 	ScalarFunction function;

--- a/src/include/duckdb/parser/parsed_data/create_coordinate_system_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_coordinate_system_info.hpp
@@ -23,7 +23,7 @@ struct CreateCoordinateSystemInfo : public CreateInfo {
 		return qualified_name.Name();
 	}
 	void SetCoordinateSystemName(Identifier name) {
-		qualified_name.NameMutable() = std::move(name);
+		qualified_name = qualified_name.WithName(std::move(name));
 	}
 
 	//! The authority identifier of the coordinate system (e.g. "EPSG")

--- a/src/include/duckdb/parser/parsed_data/create_copy_function_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_copy_function_info.hpp
@@ -22,7 +22,7 @@ struct CreateCopyFunctionInfo : public CreateInfo {
 		return qualified_name.Name();
 	}
 	void SetCopyFunctionName(Identifier name) {
-		qualified_name.NameMutable() = std::move(name);
+		qualified_name = qualified_name.WithName(std::move(name));
 	}
 	//! The table function
 	CopyFunction function;

--- a/src/include/duckdb/parser/parsed_data/create_function_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_function_info.hpp
@@ -38,7 +38,7 @@ struct CreateFunctionInfo : public CreateInfo {
 		return qualified_name.Name();
 	}
 	void SetFunctionName(Identifier name) {
-		qualified_name.NameMutable() = std::move(name);
+		qualified_name = qualified_name.WithName(std::move(name));
 	}
 
 	DUCKDB_API void CopyFunctionProperties(CreateFunctionInfo &other) const;

--- a/src/include/duckdb/parser/parsed_data/create_index_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_index_info.hpp
@@ -29,7 +29,7 @@ struct CreateIndexInfo : public CreateInfo {
 		return qualified_name.Name();
 	}
 	void SetIndexName(Identifier name) {
-		qualified_name.NameMutable() = std::move(name);
+		qualified_name = qualified_name.WithName(std::move(name));
 	}
 
 	//! Options values (WITH ...)

--- a/src/include/duckdb/parser/parsed_data/create_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_info.hpp
@@ -62,6 +62,14 @@ public:
 	void SetQualifiedName(QualifiedName name) {
 		qualified_name = std::move(name);
 	}
+	//! Set the name, keeping the catalog/schema qualification
+	void SetName(Identifier name) {
+		qualified_name = qualified_name.WithName(std::move(name));
+	}
+	//! Set the catalog/schema qualification, keeping the name
+	void SetQualification(Identifier catalog, Identifier schema) {
+		qualified_name = QualifiedName(std::move(catalog), std::move(schema), qualified_name.Name());
+	}
 	//! Renders the qualified name for ToString - the catalog is omitted for temporary entries and the default schema is
 	//! hidden
 	DUCKDB_API string QualifiedNameToString() const;

--- a/src/include/duckdb/parser/parsed_data/create_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_info.hpp
@@ -70,6 +70,14 @@ public:
 	void SetQualification(Identifier catalog, Identifier schema) {
 		qualified_name = QualifiedName(std::move(catalog), std::move(schema), qualified_name.Name());
 	}
+	//! Set the schema, keeping the catalog and name
+	void SetSchema(Identifier schema) {
+		qualified_name = QualifiedName(qualified_name.Catalog(), std::move(schema), qualified_name.Name());
+	}
+	//! Set the catalog, keeping the schema and name
+	void SetCatalog(Identifier catalog) {
+		qualified_name = QualifiedName(std::move(catalog), qualified_name.Schema(), qualified_name.Name());
+	}
 	//! Renders the qualified name for ToString - the catalog is omitted for temporary entries and the default schema is
 	//! hidden
 	DUCKDB_API string QualifiedNameToString() const;

--- a/src/include/duckdb/parser/parsed_data/create_secret_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_secret_info.hpp
@@ -37,7 +37,7 @@ public:
 		return qualified_name.Name();
 	}
 	void SetSecretName(Identifier name) {
-		qualified_name.NameMutable() = std::move(name);
+		qualified_name = qualified_name.WithName(std::move(name));
 	}
 	//! (optionally) the scope of the secret
 	unique_ptr<ParsedExpression> scope;

--- a/src/include/duckdb/parser/parsed_data/create_sequence_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_sequence_info.hpp
@@ -37,7 +37,7 @@ struct CreateSequenceInfo : public CreateInfo {
 		return qualified_name.Name();
 	}
 	void SetSequenceName(Identifier name) {
-		qualified_name.NameMutable() = std::move(name);
+		qualified_name = qualified_name.WithName(std::move(name));
 	}
 	//! Usage count of the sequence
 	uint64_t usage_count;

--- a/src/include/duckdb/parser/parsed_data/create_table_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_table_info.hpp
@@ -27,7 +27,7 @@ struct CreateTableInfo : public CreateInfo {
 		return qualified_name.Name();
 	}
 	void SetTableName(Identifier name) {
-		qualified_name.NameMutable() = std::move(name);
+		qualified_name = qualified_name.WithName(std::move(name));
 	}
 	//! List of columns of the table
 	ColumnList columns;

--- a/src/include/duckdb/parser/parsed_data/create_trigger_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_trigger_info.hpp
@@ -24,7 +24,7 @@ struct CreateTriggerInfo : public CreateInfo {
 		return qualified_name.Name();
 	}
 	void SetTriggerName(Identifier name) {
-		qualified_name.NameMutable() = std::move(name);
+		qualified_name = qualified_name.WithName(std::move(name));
 	}
 	//! The table the trigger is on
 	unique_ptr<BaseTableRef> base_table;

--- a/src/include/duckdb/parser/parsed_data/create_type_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_type_info.hpp
@@ -60,7 +60,7 @@ struct CreateTypeInfo : public CreateInfo {
 		return qualified_name.Name();
 	}
 	void SetTypeName(Identifier name) {
-		qualified_name.NameMutable() = std::move(name);
+		qualified_name = qualified_name.WithName(std::move(name));
 	}
 	//! Logical Type
 	LogicalType type;

--- a/src/include/duckdb/parser/parsed_data/create_view_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_view_info.hpp
@@ -29,7 +29,7 @@ public:
 		return qualified_name.Name();
 	}
 	void SetViewName(Identifier name) {
-		qualified_name.NameMutable() = std::move(name);
+		qualified_name = qualified_name.WithName(std::move(name));
 	}
 	//! Aliases of the view
 	vector<Identifier> aliases;

--- a/src/include/duckdb/parser/parsed_data/drop_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/drop_info.hpp
@@ -48,8 +48,11 @@ public:
 	void SetQualifiedName(QualifiedName name) {
 		qualified_name = std::move(name);
 	}
-	Identifier &NameMutable() {
-		return qualified_name.NameMutable();
+	void SetQualifiedName(Identifier catalog, Identifier schema, Identifier name) {
+		qualified_name = QualifiedName(std::move(catalog), std::move(schema), std::move(name));
+	}
+	void SetName(Identifier name) {
+		qualified_name = qualified_name.WithName(std::move(name));
 	}
 
 public:

--- a/src/include/duckdb/parser/parsed_data/drop_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/drop_info.hpp
@@ -54,6 +54,12 @@ public:
 	void SetName(Identifier name) {
 		qualified_name = qualified_name.WithName(std::move(name));
 	}
+	void SetSchema(Identifier schema) {
+		qualified_name = QualifiedName(qualified_name.Catalog(), std::move(schema), qualified_name.Name());
+	}
+	void SetCatalog(Identifier catalog) {
+		qualified_name = QualifiedName(std::move(catalog), qualified_name.Schema(), qualified_name.Name());
+	}
 
 public:
 	virtual unique_ptr<DropInfo> Copy() const;

--- a/src/include/duckdb/parser/parsed_data/exported_table_data.hpp
+++ b/src/include/duckdb/parser/parsed_data/exported_table_data.hpp
@@ -20,6 +20,10 @@ struct ExportedTableData {
 	//! The qualified name of the exported table (database = catalog, schema, table = name)
 	QualifiedName qualified_name;
 
+	void SetQualifiedName(Identifier catalog, Identifier schema, Identifier name) {
+		qualified_name = QualifiedName(std::move(catalog), std::move(schema), std::move(name));
+	}
+
 	//! Path to be exported
 	string file_path;
 	//! Not Null columns, if any

--- a/src/include/duckdb/parser/qualified_name.hpp
+++ b/src/include/duckdb/parser/qualified_name.hpp
@@ -29,55 +29,47 @@ struct QualifiedName {
 	QualifiedName() = default;
 	//! Construct an unqualified name (no catalog/schema). Implicit so that an Identifier can be passed wherever an
 	//! unqualified QualifiedName lookup is expected (also preserves backwards-compatibility for extensions).
-	QualifiedName(Identifier name_p) : name(std::move(name_p)) { // NOLINT: allow implicit conversion
+	QualifiedName(Identifier name_p) { // NOLINT: allow implicit conversion
+		path.push_back(std::move(name_p));
 	}
-	QualifiedName(Identifier catalog_p, Identifier schema_p, Identifier name_p) : name(std::move(name_p)) {
-		// store the catalog/schema as a schema path - in preparation for multi-level schema support
-		// for now we only support a single schema level, so the path is at most [catalog, schema]
+	QualifiedName(Identifier catalog_p, Identifier schema_p, Identifier name_p) {
+		// store the catalog/schema/name as a single path - in preparation for multi-level schema support
+		// for now we only support a single schema level, so the path is at most [catalog, schema, name]
 		if (!catalog_p.empty()) {
-			schema_path.push_back(std::move(catalog_p));
-			schema_path.push_back(std::move(schema_p));
+			path.push_back(std::move(catalog_p));
+			path.push_back(std::move(schema_p));
 		} else if (!schema_p.empty()) {
-			schema_path.push_back(std::move(schema_p));
+			path.push_back(std::move(schema_p));
 		}
+		path.push_back(std::move(name_p));
 	}
 	//! Construct from an explicit schema path (the catalog/schema components actually present) and a name. Use this to
 	//! avoid passing INVALID_CATALOG/INVALID_SCHEMA placeholders for components that are not set.
-	QualifiedName(vector<Identifier> schema_path_p, Identifier name_p)
-	    : schema_path(std::move(schema_path_p)), name(std::move(name_p)) {
+	QualifiedName(vector<Identifier> schema_path_p, Identifier name_p) : path(std::move(schema_path_p)) {
+		path.push_back(std::move(name_p));
 	}
 
-	//! The catalog is the first element of the schema path, but only when the path is fully qualified (size 2)
+	//! The catalog is the first element of the path, but only when the path is fully qualified ([catalog, schema,
+	//! name])
 	const Identifier &Catalog() const {
-		return schema_path.size() == 2 ? schema_path[0] : empty;
+		return path.size() == 3 ? path[0] : empty;
 	}
-	Identifier &CatalogMutable() {
-		EnsureQualified();
-		return schema_path[0];
-	}
-	//! The schema is the last element of the schema path (or empty if there is no schema)
+	//! The schema is the element directly before the name (or empty if there is no schema)
 	const Identifier &Schema() const {
-		if (schema_path.size() == 1) {
-			return schema_path[0];
-		}
-		if (schema_path.size() == 2) {
-			return schema_path[1];
-		}
-		return empty;
+		return path.size() >= 2 ? path[path.size() - 2] : empty;
 	}
-	Identifier &SchemaMutable() {
-		EnsureQualified();
-		return schema_path[1];
-	}
+	//! The name is the last element of the path
 	const Identifier &Name() const {
-		return name;
+		return path.empty() ? empty : path.back();
 	}
-	Identifier &NameMutable() {
-		return name;
+
+	//! Return a copy of this name with the name replaced, keeping the catalog/schema qualification
+	QualifiedName WithName(Identifier name) const {
+		return QualifiedName(Catalog(), Schema(), std::move(name));
 	}
-	//! The full schema path of the qualified name (catalog/schema components)
-	const vector<Identifier> &SchemaPath() const {
-		return schema_path;
+	//! Return a copy of this name with the catalog/schema qualification replaced by the given path, keeping the name
+	QualifiedName WithQualification(vector<Identifier> schema_path) const {
+		return QualifiedName(std::move(schema_path), Name());
 	}
 
 	//! Parse the (optional) schema and a name from a string in the format of e.g. "schema"."table"; if there is no dot
@@ -91,22 +83,10 @@ struct QualifiedName {
 	bool operator!=(const QualifiedName &rhs) const;
 
 private:
-	//! Normalize the schema path to be fully qualified ([catalog, schema]) so that CatalogMutable()/SchemaMutable()
-	//! return stable references - the catalog lives at [0] and the schema at [1]
-	void EnsureQualified() {
-		if (schema_path.empty()) {
-			schema_path.resize(2);
-		} else if (schema_path.size() == 1) {
-			schema_path.insert(schema_path.begin(), Identifier());
-		}
-	}
-
-private:
-	//! The schema path (catalog/schema). For now at most [catalog, schema] (single schema level).
-	vector<Identifier> schema_path;
-	//! The name of the entry
-	Identifier name;
-	//! Always-empty identifier, returned by the accessors when a catalog/schema component is absent
+	//! The full path (catalog/schema/name). The name is always the last element; the catalog/schema components that
+	//! are actually present precede it. For now at most [catalog, schema, name] (single schema level).
+	vector<Identifier> path;
+	//! Always-empty identifier, returned by the accessors when a catalog/schema/name component is absent
 	Identifier empty;
 };
 

--- a/src/include/duckdb/parser/query_node/insert_query_node.hpp
+++ b/src/include/duckdb/parser/query_node/insert_query_node.hpp
@@ -40,6 +40,10 @@ public:
 	//! The qualified name of the table to insert to (catalog/schema/name)
 	QualifiedName qualified_name;
 
+	void SetQualifiedName(Identifier catalog, Identifier schema, Identifier name) {
+		qualified_name = QualifiedName(std::move(catalog), std::move(schema), std::move(name));
+	}
+
 	//! keep track of optional returningList if statement contains a RETURNING keyword
 	vector<unique_ptr<ParsedExpression>> returning_list;
 

--- a/src/include/duckdb/parser/tableref/basetableref.hpp
+++ b/src/include/duckdb/parser/tableref/basetableref.hpp
@@ -42,11 +42,14 @@ public:
 	void SetQualifiedName(QualifiedName name) {
 		qualified_name = std::move(name);
 	}
+	void SetQualifiedName(Identifier catalog, Identifier schema, Identifier name) {
+		qualified_name = QualifiedName(std::move(catalog), std::move(schema), std::move(name));
+	}
 	const Identifier &Table() const {
 		return qualified_name.Name();
 	}
-	Identifier &TableMutable() {
-		return qualified_name.NameMutable();
+	void SetTable(Identifier table) {
+		qualified_name = qualified_name.WithName(std::move(table));
 	}
 
 public:

--- a/src/include/duckdb/parser/tableref/showref.hpp
+++ b/src/include/duckdb/parser/tableref/showref.hpp
@@ -34,26 +34,29 @@ public:
 	ShowType show_type;
 
 public:
+	void SetQualifiedName(Identifier catalog, Identifier schema, Identifier name) {
+		qualified_name = QualifiedName(std::move(catalog), std::move(schema), std::move(name));
+	}
 	//! The table name (if any)
 	const Identifier &GetTableName() const {
 		return qualified_name.Name();
 	}
 	void SetTableName(Identifier table_name) {
-		qualified_name.NameMutable() = std::move(table_name);
+		qualified_name = qualified_name.WithName(std::move(table_name));
 	}
 	//! The catalog name (if any)
 	const Identifier &GetCatalogName() const {
 		return qualified_name.Catalog();
 	}
 	void SetCatalogName(Identifier catalog_name) {
-		qualified_name.CatalogMutable() = std::move(catalog_name);
+		qualified_name = QualifiedName(std::move(catalog_name), qualified_name.Schema(), qualified_name.Name());
 	}
 	//! The schema name (if any)
 	const Identifier &GetSchemaName() const {
 		return qualified_name.Schema();
 	}
 	void SetSchemaName(Identifier schema_name) {
-		qualified_name.SchemaMutable() = std::move(schema_name);
+		qualified_name = QualifiedName(qualified_name.Catalog(), std::move(schema_name), qualified_name.Name());
 	}
 
 public:

--- a/src/include/duckdb/storage/serialization/create_info.json
+++ b/src/include/duckdb/storage/serialization/create_info.json
@@ -18,14 +18,12 @@
         "id": 101,
         "name": "catalog",
         "serialize_property": "qualified_name.Catalog()",
-        "deserialize_property": "qualified_name.CatalogMutable()",
         "type": "Identifier"
       },
       {
         "id": 102,
         "name": "schema",
         "serialize_property": "qualified_name.Schema()",
-        "deserialize_property": "qualified_name.SchemaMutable()",
         "type": "Identifier"
       },
       {
@@ -54,7 +52,7 @@
         "type": "Value",
         "default": "Value()"
       },
-	  {
+      {
         "id": 108,
         "name": "tags",
         "type": "InsertionOrderPreservingMap<string>",
@@ -66,13 +64,19 @@
         "type": "LogicalDependencyList",
         "default": "LogicalDependencyList()",
         "version": "v0.10.3"
-	  },
+      },
       {
         "id": 110,
         "name": "extension_name",
         "type": "Identifier"
       }
-    ]
+    ],
+    "methods": {
+      "SetQualification": [
+        "catalog",
+        "schema"
+      ]
+    }
   },
   {
     "class": "CreateIndexInfo",
@@ -86,7 +90,6 @@
         "id": 200,
         "name": "name",
         "serialize_property": "qualified_name.Name()",
-        "deserialize_property": "qualified_name.NameMutable()",
         "type": "Identifier"
       },
       {
@@ -136,7 +139,12 @@
         "type": "string",
         "property": "index_type"
       }
-    ]
+    ],
+    "methods": {
+      "SetName": [
+        "name"
+      ]
+    }
   },
   {
     "class": "CreateTableInfo",
@@ -150,7 +158,6 @@
         "id": 200,
         "name": "table",
         "serialize_property": "qualified_name.Name()",
-        "deserialize_property": "qualified_name.NameMutable()",
         "type": "Identifier"
       },
       {
@@ -183,7 +190,12 @@
         "name": "options",
         "type": "case_insensitive_map_t<ParsedExpression*>"
       }
-    ]
+    ],
+    "methods": {
+      "SetName": [
+        "table"
+      ]
+    }
   },
   {
     "class": "CreateSchemaInfo",
@@ -192,8 +204,7 @@
     "includes": [
       "duckdb/parser/parsed_data/create_schema_info.hpp"
     ],
-    "members": [
-    ]
+    "members": []
   },
   {
     "class": "CreateViewInfo",
@@ -207,7 +218,6 @@
         "id": 200,
         "name": "view_name",
         "serialize_property": "qualified_name.Name()",
-        "deserialize_property": "qualified_name.NameMutable()",
         "type": "Identifier"
       },
       {
@@ -246,7 +256,16 @@
         "version": "v1.5.0"
       }
     ],
-    "constructor": ["names", "column_comments", "column_comments_map"]
+    "constructor": [
+      "names",
+      "column_comments",
+      "column_comments_map"
+    ],
+    "methods": {
+      "SetName": [
+        "view_name"
+      ]
+    }
   },
   {
     "class": "CreateTypeInfo",
@@ -260,7 +279,6 @@
         "id": 200,
         "name": "name",
         "serialize_property": "qualified_name.Name()",
-        "deserialize_property": "qualified_name.NameMutable()",
         "type": "Identifier"
       },
       {
@@ -269,12 +287,20 @@
         "property": "type",
         "type": "LogicalType"
       }
-    ]
+    ],
+    "methods": {
+      "SetName": [
+        "name"
+      ]
+    }
   },
   {
     "class": "CreateMacroInfo",
     "base": "CreateInfo",
-    "enum": ["MACRO_ENTRY", "TABLE_MACRO_ENTRY"],
+    "enum": [
+      "MACRO_ENTRY",
+      "TABLE_MACRO_ENTRY"
+    ],
     "includes": [
       "duckdb/parser/parsed_data/create_macro_info.hpp"
     ],
@@ -283,7 +309,6 @@
         "id": 200,
         "name": "name",
         "serialize_property": "qualified_name.Name()",
-        "deserialize_property": "qualified_name.NameMutable()",
         "type": "Identifier"
       },
       {
@@ -299,7 +324,16 @@
         "serialize_property": "GetAllButFirstFunction()"
       }
     ],
-    "constructor": ["$CatalogType", "function", "extra_functions"]
+    "constructor": [
+      "$CatalogType",
+      "function",
+      "extra_functions"
+    ],
+    "methods": {
+      "SetName": [
+        "name"
+      ]
+    }
   },
   {
     "class": "CreateSequenceInfo",
@@ -313,7 +347,6 @@
         "id": 200,
         "name": "name",
         "serialize_property": "qualified_name.Name()",
-        "deserialize_property": "qualified_name.NameMutable()",
         "type": "Identifier"
       },
       {
@@ -352,7 +385,12 @@
         "type": "optional<int64_t>",
         "version": "v2.0.0"
       }
-    ]
+    ],
+    "methods": {
+      "SetName": [
+        "name"
+      ]
+    }
   },
   {
     "class": "CreateTriggerInfo",
@@ -366,7 +404,6 @@
         "id": 200,
         "name": "trigger_name",
         "serialize_property": "qualified_name.Name()",
-        "deserialize_property": "qualified_name.NameMutable()",
         "type": "Identifier"
       },
       {
@@ -410,6 +447,11 @@
         "name": "referencing_old_table",
         "type": "Identifier"
       }
-    ]
+    ],
+    "methods": {
+      "SetName": [
+        "trigger_name"
+      ]
+    }
   }
 ]

--- a/src/include/duckdb/storage/serialization/nodes.json
+++ b/src/include/duckdb/storage/serialization/nodes.json
@@ -1179,22 +1179,19 @@
         "id": 1,
         "name": "table_name",
         "type": "Identifier",
-        "serialize_property": "qualified_name.Name()",
-        "deserialize_property": "qualified_name.NameMutable()"
+        "serialize_property": "qualified_name.Name()"
       },
       {
         "id": 2,
         "name": "schema_name",
         "type": "Identifier",
-        "serialize_property": "qualified_name.Schema()",
-        "deserialize_property": "qualified_name.SchemaMutable()"
+        "serialize_property": "qualified_name.Schema()"
       },
       {
         "id": 3,
         "name": "database_name",
         "type": "Identifier",
-        "serialize_property": "qualified_name.Catalog()",
-        "deserialize_property": "qualified_name.CatalogMutable()"
+        "serialize_property": "qualified_name.Catalog()"
       },
       {
         "id": 4,
@@ -1207,7 +1204,14 @@
         "type": "vector<Identifier>"
       }
     ],
-    "pointer_type": "none"
+    "pointer_type": "none",
+    "methods": {
+      "SetQualifiedName": [
+        "database_name",
+        "schema_name",
+        "table_name"
+      ]
+    }
   },
   {
     "class": "ColumnIndex",

--- a/src/include/duckdb/storage/serialization/parse_info.json
+++ b/src/include/duckdb/storage/serialization/parse_info.json
@@ -31,21 +31,18 @@
         "id": 201,
         "name": "catalog",
         "serialize_property": "qualified_name.Catalog()",
-        "deserialize_property": "qualified_name.CatalogMutable()",
         "type": "Identifier"
       },
       {
         "id": 202,
         "name": "schema",
         "serialize_property": "qualified_name.Schema()",
-        "deserialize_property": "qualified_name.SchemaMutable()",
         "type": "Identifier"
       },
       {
         "id": 203,
         "name": "name",
         "serialize_property": "qualified_name.Name()",
-        "deserialize_property": "qualified_name.NameMutable()",
         "type": "Identifier"
       },
       {
@@ -58,7 +55,14 @@
         "name": "allow_internal",
         "type": "bool"
       }
-    ]
+    ],
+    "methods": {
+      "SetQualifiedName": [
+        "catalog",
+        "schema",
+        "name"
+      ]
+    }
   },
   {
     "class": "AlterTableInfo",
@@ -492,21 +496,18 @@
         "id": 200,
         "name": "catalog",
         "serialize_property": "qualified_name.Catalog()",
-        "deserialize_property": "qualified_name.CatalogMutable()",
         "type": "Identifier"
       },
       {
         "id": 201,
         "name": "schema",
         "serialize_property": "qualified_name.Schema()",
-        "deserialize_property": "qualified_name.SchemaMutable()",
         "type": "Identifier"
       },
       {
         "id": 202,
         "name": "table",
         "serialize_property": "qualified_name.Name()",
-        "deserialize_property": "qualified_name.NameMutable()",
         "type": "Identifier"
       },
       {
@@ -544,7 +545,14 @@
         "name": "is_format_auto_detected",
         "type": "bool"
       }
-    ]
+    ],
+    "methods": {
+      "SetQualifiedName": [
+        "catalog",
+        "schema",
+        "table"
+      ]
+    }
   },
   {
     "class": "DetachInfo",
@@ -617,21 +625,18 @@
         "id": 201,
         "name": "catalog",
         "serialize_property": "qualified_name.Catalog()",
-        "deserialize_property": "qualified_name.CatalogMutable()",
         "type": "Identifier"
       },
       {
         "id": 202,
         "name": "schema",
         "serialize_property": "qualified_name.Schema()",
-        "deserialize_property": "qualified_name.SchemaMutable()",
         "type": "Identifier"
       },
       {
         "id": 203,
         "name": "name",
         "serialize_property": "qualified_name.Name()",
-        "deserialize_property": "qualified_name.NameMutable()",
         "type": "Identifier"
       },
       {
@@ -654,7 +659,14 @@
         "name": "extra_drop_info",
         "type": "unique_ptr<ExtraDropInfo>"
       }
-    ]
+    ],
+    "methods": {
+      "SetQualifiedName": [
+        "catalog",
+        "schema",
+        "name"
+      ]
+    }
   },
   {
     "class": "LoadInfo",

--- a/src/include/duckdb/storage/serialization/parsed_expression.json
+++ b/src/include/duckdb/storage/serialization/parsed_expression.json
@@ -587,7 +587,6 @@
         "id": 200,
         "name": "catalog",
         "serialize_property": "qualified_name.Catalog()",
-        "deserialize_property": "qualified_name.CatalogMutable()",
         "type": "Identifier",
         "equals_skip": true,
         "hash_skip": true
@@ -596,7 +595,6 @@
         "id": 201,
         "name": "schema",
         "serialize_property": "qualified_name.Schema()",
-        "deserialize_property": "qualified_name.SchemaMutable()",
         "type": "Identifier",
         "equals_skip": true,
         "hash_skip": true
@@ -605,7 +603,6 @@
         "id": 202,
         "name": "type_name",
         "serialize_property": "qualified_name.Name()",
-        "deserialize_property": "qualified_name.NameMutable()",
         "type": "Identifier",
         "equals_skip": true,
         "hash_skip": true
@@ -616,6 +613,13 @@
         "type": "vector<unique_ptr<ParsedExpression>>",
         "accessor_mut": "GetChildren()"
       }
-    ]
+    ],
+    "methods": {
+      "SetQualifiedName": [
+        "catalog",
+        "schema",
+        "type_name"
+      ]
+    }
   }
 ]

--- a/src/include/duckdb/storage/serialization/query_node.json
+++ b/src/include/duckdb/storage/serialization/query_node.json
@@ -288,22 +288,19 @@
         "id": 202,
         "name": "table",
         "type": "Identifier",
-        "serialize_property": "qualified_name.Name()",
-        "deserialize_property": "qualified_name.NameMutable()"
+        "serialize_property": "qualified_name.Name()"
       },
       {
         "id": 203,
         "name": "schema",
         "type": "Identifier",
-        "serialize_property": "qualified_name.Schema()",
-        "deserialize_property": "qualified_name.SchemaMutable()"
+        "serialize_property": "qualified_name.Schema()"
       },
       {
         "id": 204,
         "name": "catalog",
         "type": "Identifier",
-        "serialize_property": "qualified_name.Catalog()",
-        "deserialize_property": "qualified_name.CatalogMutable()"
+        "serialize_property": "qualified_name.Catalog()"
       },
       {
         "id": 205,
@@ -332,7 +329,14 @@
         "type": "InsertColumnOrder",
         "default": "InsertColumnOrder::INSERT_BY_POSITION"
       }
-    ]
+    ],
+    "methods": {
+      "SetQualifiedName": [
+        "catalog",
+        "schema",
+        "table"
+      ]
+    }
   },
   {
     "class": "MergeQueryNode",

--- a/src/include/duckdb/storage/serialization/tableref.json
+++ b/src/include/duckdb/storage/serialization/tableref.json
@@ -38,14 +38,12 @@
         "id": 200,
         "name": "schema_name",
         "serialize_property": "qualified_name.Schema()",
-        "deserialize_property": "qualified_name.SchemaMutable()",
         "type": "Identifier"
       },
       {
         "id": 201,
         "name": "table_name",
         "serialize_property": "qualified_name.Name()",
-        "deserialize_property": "qualified_name.NameMutable()",
         "type": "Identifier"
       },
       {
@@ -57,7 +55,6 @@
         "id": 203,
         "name": "catalog_name",
         "serialize_property": "qualified_name.Catalog()",
-        "deserialize_property": "qualified_name.CatalogMutable()",
         "type": "Identifier"
       },
       {
@@ -65,7 +62,14 @@
         "name": "at_clause",
         "type": "AtClause*"
       }
-    ]
+    ],
+    "methods": {
+      "SetQualifiedName": [
+        "catalog_name",
+        "schema_name",
+        "table_name"
+      ]
+    }
   },
   {
     "class": "JoinRef",
@@ -166,8 +170,7 @@
     "class": "EmptyTableRef",
     "base": "TableRef",
     "enum": "EMPTY_FROM",
-    "members": [
-    ]
+    "members": []
   },
   {
     "class": "ExpressionListRef",
@@ -207,7 +210,10 @@
         "type": "optionally_owned_ptr<ColumnDataCollection>"
       }
     ],
-    "constructor": ["collection", "expected_names"]
+    "constructor": [
+      "collection",
+      "expected_names"
+    ]
   },
   {
     "class": "PivotRef",
@@ -260,7 +266,6 @@
         "id": 200,
         "name": "table_name",
         "serialize_property": "qualified_name.Name()",
-        "deserialize_property": "qualified_name.NameMutable()",
         "type": "Identifier"
       },
       {
@@ -277,17 +282,22 @@
         "id": 203,
         "name": "catalog_name",
         "serialize_property": "qualified_name.Catalog()",
-        "deserialize_property": "qualified_name.CatalogMutable()",
         "type": "Identifier"
       },
       {
         "id": 204,
         "name": "schema_name",
         "serialize_property": "qualified_name.Schema()",
-        "deserialize_property": "qualified_name.SchemaMutable()",
         "type": "Identifier"
       }
-    ]
+    ],
+    "methods": {
+      "SetQualifiedName": [
+        "catalog_name",
+        "schema_name",
+        "table_name"
+      ]
+    }
   },
   {
     "class": "AtClause",
@@ -306,6 +316,9 @@
         "type": "ParsedExpression*"
       }
     ],
-    "constructor": ["unit", "expr"]
+    "constructor": [
+      "unit",
+      "expr"
+    ]
   }
 ]

--- a/src/parser/expression/function_expression.cpp
+++ b/src/parser/expression/function_expression.cpp
@@ -165,8 +165,8 @@ void FunctionExpression::Serialize(Serializer &serializer) const {
 
 unique_ptr<ParsedExpression> FunctionExpression::Deserialize(Deserializer &deserializer) {
 	auto result = duckdb::unique_ptr<FunctionExpression>(new FunctionExpression());
-	deserializer.ReadPropertyWithDefault<Identifier>(200, "function_name", result->qualified_name.NameMutable());
-	deserializer.ReadPropertyWithDefault<Identifier>(201, "schema", result->qualified_name.SchemaMutable());
+	auto function_name = deserializer.ReadPropertyWithDefault<Identifier>(200, "function_name");
+	auto schema = deserializer.ReadPropertyWithDefault<Identifier>(201, "schema");
 
 	// Legacy children deserialization
 	vector<unique_ptr<ParsedExpression>> children;
@@ -188,7 +188,8 @@ unique_ptr<ParsedExpression> FunctionExpression::Deserialize(Deserializer &deser
 	deserializer.ReadPropertyWithDefault<bool>(205, "distinct", result->distinct);
 	deserializer.ReadPropertyWithDefault<bool>(206, "is_operator", result->is_operator);
 	deserializer.ReadPropertyWithDefault<bool>(207, "export_state", result->export_state);
-	deserializer.ReadPropertyWithDefault<Identifier>(208, "catalog", result->qualified_name.CatalogMutable());
+	auto catalog = deserializer.ReadPropertyWithDefault<Identifier>(208, "catalog");
+	result->SetQualifiedName(std::move(catalog), std::move(schema), std::move(function_name));
 
 	// New children deserialization
 	if (children.empty()) {

--- a/src/parser/expression/window_expression.cpp
+++ b/src/parser/expression/window_expression.cpp
@@ -89,7 +89,7 @@ string WindowExpression::ExpressionTypeToWindow(ExpressionType expression_type) 
 }
 
 void WindowExpression::SetFunctionName(const string &function_name_p) {
-	qualified_name.NameMutable() = Identifier(function_name_p);
+	qualified_name = qualified_name.WithName(Identifier(function_name_p));
 	type = WindowToExpressionType(qualified_name.Name().GetIdentifierName());
 }
 
@@ -167,9 +167,10 @@ void WindowExpression::Serialize(Serializer &serializer) const {
 
 unique_ptr<ParsedExpression> WindowExpression::Deserialize(Deserializer &deserializer) {
 	auto result = duckdb::unique_ptr<WindowExpression>(new WindowExpression());
-	deserializer.ReadPropertyWithDefault<Identifier>(200, "function_name", result->qualified_name.NameMutable());
-	deserializer.ReadPropertyWithDefault<Identifier>(201, "schema", result->qualified_name.SchemaMutable());
-	deserializer.ReadPropertyWithDefault<Identifier>(202, "catalog", result->qualified_name.CatalogMutable());
+	auto function_name = deserializer.ReadPropertyWithDefault<Identifier>(200, "function_name");
+	auto schema = deserializer.ReadPropertyWithDefault<Identifier>(201, "schema");
+	auto catalog = deserializer.ReadPropertyWithDefault<Identifier>(202, "catalog");
+	result->SetQualifiedName(std::move(catalog), std::move(schema), std::move(function_name));
 
 	// Legacy children deserialization
 	vector<unique_ptr<ParsedExpression>> children;

--- a/src/parser/peg/transformer/transform_deallocate.cpp
+++ b/src/parser/peg/transformer/transform_deallocate.cpp
@@ -8,7 +8,7 @@ unique_ptr<SQLStatement> PEGTransformerFactory::TransformDeallocateStatement(PEG
                                                                              const Identifier &identifier) {
 	auto result = make_uniq<DropStatement>();
 	result->info->type = CatalogType::PREPARED_STATEMENT;
-	result->info->NameMutable() = identifier;
+	result->info->SetName(identifier);
 	return std::move(result);
 }
 

--- a/src/parser/peg/transformer/transform_describe.cpp
+++ b/src/parser/peg/transformer/transform_describe.cpp
@@ -97,7 +97,7 @@ unique_ptr<QueryNode> PEGTransformerFactory::TransformShowQualifiedName(PEGTrans
 			if (target.is_table_name) {
 				// Case: SHOW 'something' or DESCRIBE 'something'
 				auto table_ref = make_uniq<BaseTableRef>();
-				table_ref->TableMutable() = target.table_name;
+				table_ref->SetTable(target.table_name);
 				show_select_node->from_table = std::move(table_ref);
 			} else {
 				// Case: A relation/table reference

--- a/src/parser/peg/transformer/transform_drop.cpp
+++ b/src/parser/peg/transformer/transform_drop.cpp
@@ -221,7 +221,7 @@ unique_ptr<DropStatement> PEGTransformerFactory::TransformDropSecret(PEGTransfor
 	}
 
 	info->if_not_found = if_exists ? OnEntryNotFound::RETURN_NULL : OnEntryNotFound::THROW_EXCEPTION;
-	info->NameMutable() = secret_name;
+	info->SetName(secret_name);
 	if (drop_secret_storage) {
 		extra_drop_info->secret_storage = drop_secret_storage->GetIdentifierName();
 	}
@@ -244,7 +244,7 @@ unique_ptr<DropStatement> PEGTransformerFactory::TransformDropTrigger(PEGTransfo
 	info->type = CatalogType::TRIGGER_ENTRY;
 	info->if_not_found = if_exists ? OnEntryNotFound::RETURN_NULL : OnEntryNotFound::THROW_EXCEPTION;
 
-	info->NameMutable() = trigger_name;
+	info->SetName(trigger_name);
 
 	auto extra_info = make_uniq<ExtraDropTriggerInfo>();
 	extra_info->base_table = std::move(base_table_name);

--- a/src/parser/peg/transformer/transform_expression.cpp
+++ b/src/parser/peg/transformer/transform_expression.cpp
@@ -58,7 +58,7 @@ PEGTransformerFactory::TransformExpressionStatement(PEGTransformer &transformer,
 			}
 		} else {
 			auto base_table = make_uniq<BaseTableRef>();
-			base_table->TableMutable() = col_expr.GetColumnName();
+			base_table->SetTable(col_expr.GetColumnName());
 			select_node->from_table = std::move(base_table);
 		}
 		select_node->select_list.push_back(make_uniq<StarExpression>());
@@ -942,11 +942,14 @@ PEGTransformerFactory::TransformBetweenInLikeExpression(PEGTransformer &transfor
 		} else {
 			func_expr->GetArgumentsMutable().insert(func_expr->GetArgumentsMutable().begin(), std::move(expr));
 		}
-		auto regex_operator_negated = TryRemoveRegexOperatorNegation(func_expr->FunctionNameMutable());
+		auto function_name = func_expr->FunctionName();
+		auto regex_operator_negated = TryRemoveRegexOperatorNegation(function_name);
+		bool negated_like = has_not && !regex_operator_negated && TryNegateLikeFunction(function_name);
+		func_expr->SetQualifiedName(func_expr->GetQualifiedName().WithName(std::move(function_name)));
 		if (has_not) {
 			if (regex_operator_negated) {
 				expr = std::move(func_expr);
-			} else if (!TryNegateLikeFunction(func_expr->FunctionNameMutable())) {
+			} else if (!negated_like) {
 				// If it wasn't a special "Like" function, wrap it in a standard NOT operator
 				expr = make_uniq<OperatorExpression>(ExpressionType::OPERATOR_NOT, std::move(func_expr));
 			} else {

--- a/src/parser/peg/transformer/transform_use.cpp
+++ b/src/parser/peg/transformer/transform_use.cpp
@@ -21,14 +21,14 @@ unique_ptr<SQLStatement> PEGTransformerFactory::TransformUseStatement(PEGTransfo
 QualifiedName PEGTransformerFactory::TransformSchemaNameAsUseTarget(PEGTransformer &transformer,
                                                                     const Identifier &schema_name) {
 	QualifiedName result;
-	result.NameMutable() = schema_name;
+	result = QualifiedName(schema_name);
 	return result;
 }
 
 QualifiedName PEGTransformerFactory::TransformCatalogNameAsUseTarget(PEGTransformer &transformer,
                                                                      const Identifier &catalog_name) {
 	QualifiedName result;
-	result.NameMutable() = catalog_name;
+	result = QualifiedName(catalog_name);
 	return result;
 }
 

--- a/src/parser/qualified_name.cpp
+++ b/src/parser/qualified_name.cpp
@@ -19,7 +19,7 @@ string QualifiedName::ToString(QualifiedNameToStringMode mode) const {
 	           !(mode == QualifiedNameToStringMode::HIDE_DEFAULT_SCHEMA && schema == DEFAULT_SCHEMA)) {
 		result += SQLIdentifier(schema) + ".";
 	}
-	result += SQLIdentifier(name);
+	result += SQLIdentifier(Name());
 	return result;
 }
 

--- a/src/planner/binder/query_node/bind_trigger_expansion.cpp
+++ b/src/planner/binder/query_node/bind_trigger_expansion.cpp
@@ -115,7 +115,7 @@ static unique_ptr<CommonTableExpressionInfo> MakeTransitionTableAliasCTE(const I
 	}
 	alias_select->select_list.push_back(std::move(star));
 	auto alias_ref = make_uniq<BaseTableRef>();
-	alias_ref->TableMutable() = base_cte_name;
+	alias_ref->SetTable(base_cte_name);
 	alias_select->from_table = std::move(alias_ref);
 	alias_cte->query_node = std::move(alias_select);
 	alias_cte->materialized = CTEMaterialize::CTE_MATERIALIZE_DEFAULT;
@@ -264,7 +264,7 @@ static unique_ptr<SelectNode> BuildTriggerChain(const QueryNode &node, const Tab
 		    make_uniq<FunctionExpression>("count_star", vector<unique_ptr<ParsedExpression>>()));
 	}
 	auto from_ref = make_uniq<BaseTableRef>();
-	from_ref->TableMutable() = base_cte_name;
+	from_ref->SetTable(base_cte_name);
 	from_ref->alias = GetTableAlias(node, table.name);
 	outer->from_table = std::move(from_ref);
 
@@ -498,7 +498,7 @@ BoundStatement Binder::ExpandRowTriggers(QueryNode &node, vector<unique_ptr<Pars
 	auto outer = make_uniq<SelectNode>();
 	outer->select_list.push_back(make_uniq<FunctionExpression>("count_star", vector<unique_ptr<ParsedExpression>>()));
 	auto from_ref = make_uniq<BaseTableRef>();
-	from_ref->TableMutable() = base_cte_name;
+	from_ref->SetTable(base_cte_name);
 	outer->from_table = std::move(from_ref);
 	outer->cte_map.map[base_cte_name] = std::move(base_cte);
 

--- a/src/storage/serialization/serialize_create_info.cpp
+++ b/src/storage/serialization/serialize_create_info.cpp
@@ -79,8 +79,6 @@ unique_ptr<CreateInfo> CreateInfo::Deserialize(Deserializer &deserializer) {
 		throw SerializationException("Unsupported type for deserialization of CreateInfo!");
 	}
 	deserializer.Unset<CatalogType>();
-	result->qualified_name.CatalogMutable() = std::move(catalog);
-	result->qualified_name.SchemaMutable() = std::move(schema);
 	result->temporary = temporary;
 	result->internal = internal;
 	result->on_conflict = on_conflict;
@@ -89,6 +87,7 @@ unique_ptr<CreateInfo> CreateInfo::Deserialize(Deserializer &deserializer) {
 	result->tags = std::move(tags);
 	result->dependencies = dependencies;
 	result->extension_name = std::move(extension_name);
+	result->SetQualification(std::move(catalog), std::move(schema));
 	return result;
 }
 
@@ -108,7 +107,7 @@ void CreateIndexInfo::Serialize(Serializer &serializer) const {
 
 unique_ptr<CreateInfo> CreateIndexInfo::Deserialize(Deserializer &deserializer) {
 	auto result = duckdb::unique_ptr<CreateIndexInfo>(new CreateIndexInfo());
-	deserializer.ReadPropertyWithDefault<Identifier>(200, "name", result->qualified_name.NameMutable());
+	auto name = deserializer.ReadPropertyWithDefault<Identifier>(200, "name");
 	deserializer.ReadPropertyWithDefault<Identifier>(201, "table", result->table);
 	deserializer.ReadDeletedProperty<DeprecatedIndexType>(202, "index_type");
 	deserializer.ReadProperty<IndexConstraintType>(203, "constraint_type", result->constraint_type);
@@ -118,6 +117,7 @@ unique_ptr<CreateInfo> CreateIndexInfo::Deserialize(Deserializer &deserializer) 
 	deserializer.ReadPropertyWithDefault<vector<column_t>>(207, "column_ids", result->column_ids);
 	deserializer.ReadPropertyWithDefault<case_insensitive_map_t<Value>>(208, "options", result->options);
 	deserializer.ReadPropertyWithDefault<string>(209, "index_type_name", result->index_type);
+	result->SetName(std::move(name));
 	return std::move(result);
 }
 
@@ -133,7 +133,7 @@ unique_ptr<CreateInfo> CreateMacroInfo::Deserialize(Deserializer &deserializer) 
 	auto function = deserializer.ReadPropertyWithDefault<unique_ptr<MacroFunction>>(201, "function");
 	auto extra_functions = deserializer.ReadPropertyWithDefault<vector<unique_ptr<MacroFunction>>>(202, "extra_functions");
 	auto result = duckdb::unique_ptr<CreateMacroInfo>(new CreateMacroInfo(deserializer.Get<CatalogType>(), std::move(function), std::move(extra_functions)));
-	result->qualified_name.NameMutable() = std::move(name);
+	result->SetName(std::move(name));
 	return std::move(result);
 }
 
@@ -162,7 +162,7 @@ void CreateSequenceInfo::Serialize(Serializer &serializer) const {
 
 unique_ptr<CreateInfo> CreateSequenceInfo::Deserialize(Deserializer &deserializer) {
 	auto result = duckdb::unique_ptr<CreateSequenceInfo>(new CreateSequenceInfo());
-	deserializer.ReadPropertyWithDefault<Identifier>(200, "name", result->qualified_name.NameMutable());
+	auto name = deserializer.ReadPropertyWithDefault<Identifier>(200, "name");
 	deserializer.ReadPropertyWithDefault<uint64_t>(201, "usage_count", result->usage_count);
 	deserializer.ReadPropertyWithDefault<int64_t>(202, "increment", result->increment);
 	deserializer.ReadPropertyWithDefault<int64_t>(203, "min_value", result->min_value);
@@ -170,6 +170,7 @@ unique_ptr<CreateInfo> CreateSequenceInfo::Deserialize(Deserializer &deserialize
 	deserializer.ReadPropertyWithDefault<int64_t>(205, "start_value", result->start_value);
 	deserializer.ReadPropertyWithDefault<bool>(206, "cycle", result->cycle);
 	deserializer.ReadPropertyWithDefault<optional<int64_t>>(207, "last_value", result->last_value);
+	result->SetName(std::move(name));
 	return std::move(result);
 }
 
@@ -186,13 +187,14 @@ void CreateTableInfo::Serialize(Serializer &serializer) const {
 
 unique_ptr<CreateInfo> CreateTableInfo::Deserialize(Deserializer &deserializer) {
 	auto result = duckdb::unique_ptr<CreateTableInfo>(new CreateTableInfo());
-	deserializer.ReadPropertyWithDefault<Identifier>(200, "table", result->qualified_name.NameMutable());
+	auto table = deserializer.ReadPropertyWithDefault<Identifier>(200, "table");
 	deserializer.ReadProperty<ColumnList>(201, "columns", result->columns);
 	deserializer.ReadPropertyWithDefault<vector<unique_ptr<Constraint>>>(202, "constraints", result->constraints);
 	deserializer.ReadPropertyWithDefault<unique_ptr<SelectStatement>>(203, "query", result->query);
 	deserializer.ReadPropertyWithDefault<vector<unique_ptr<ParsedExpression>>>(204, "partition_keys", result->partition_keys);
 	deserializer.ReadPropertyWithDefault<vector<unique_ptr<ParsedExpression>>>(205, "sort_keys", result->sort_keys);
 	deserializer.ReadPropertyWithDefault<case_insensitive_map_t<unique_ptr<ParsedExpression>>>(206, "options", result->options);
+	result->SetName(std::move(table));
 	return std::move(result);
 }
 
@@ -211,7 +213,7 @@ void CreateTriggerInfo::Serialize(Serializer &serializer) const {
 
 unique_ptr<CreateInfo> CreateTriggerInfo::Deserialize(Deserializer &deserializer) {
 	auto result = duckdb::unique_ptr<CreateTriggerInfo>(new CreateTriggerInfo());
-	deserializer.ReadPropertyWithDefault<Identifier>(200, "trigger_name", result->qualified_name.NameMutable());
+	auto trigger_name = deserializer.ReadPropertyWithDefault<Identifier>(200, "trigger_name");
 	auto base_table = deserializer.ReadPropertyWithDefault<unique_ptr<TableRef>>(201, "base_table");
 	result->base_table = unique_ptr_cast<TableRef, BaseTableRef>(std::move(base_table));
 	deserializer.ReadProperty<TriggerTiming>(204, "timing", result->timing);
@@ -221,6 +223,7 @@ unique_ptr<CreateInfo> CreateTriggerInfo::Deserialize(Deserializer &deserializer
 	deserializer.ReadPropertyWithDefault<unique_ptr<QueryNode>>(208, "trigger_action", result->trigger_action);
 	deserializer.ReadPropertyWithDefault<Identifier>(209, "referencing_new_table", result->referencing_new_table);
 	deserializer.ReadPropertyWithDefault<Identifier>(210, "referencing_old_table", result->referencing_old_table);
+	result->SetName(std::move(trigger_name));
 	return std::move(result);
 }
 
@@ -232,8 +235,9 @@ void CreateTypeInfo::Serialize(Serializer &serializer) const {
 
 unique_ptr<CreateInfo> CreateTypeInfo::Deserialize(Deserializer &deserializer) {
 	auto result = duckdb::unique_ptr<CreateTypeInfo>(new CreateTypeInfo());
-	deserializer.ReadPropertyWithDefault<Identifier>(200, "name", result->qualified_name.NameMutable());
+	auto name = deserializer.ReadPropertyWithDefault<Identifier>(200, "name");
 	deserializer.ReadProperty<LogicalType>(201, "logical_type", result->type);
+	result->SetName(std::move(name));
 	return std::move(result);
 }
 
@@ -261,10 +265,10 @@ unique_ptr<CreateInfo> CreateViewInfo::Deserialize(Deserializer &deserializer) {
 	auto column_comments = deserializer.ReadPropertyWithDefault<vector<Value>>(205, "column_comments");
 	auto column_comments_map = deserializer.ReadPropertyWithExplicitDefault<identifier_map_t<Value>>(206, "column_comments_map", identifier_map_t<Value>());
 	auto result = duckdb::unique_ptr<CreateViewInfo>(new CreateViewInfo(std::move(names), std::move(column_comments), std::move(column_comments_map)));
-	result->qualified_name.NameMutable() = std::move(view_name);
 	result->aliases = std::move(aliases);
 	result->types = std::move(types);
 	result->query = std::move(query);
+	result->SetName(std::move(view_name));
 	return std::move(result);
 }
 

--- a/src/storage/serialization/serialize_nodes.cpp
+++ b/src/storage/serialization/serialize_nodes.cpp
@@ -307,11 +307,12 @@ void ExportedTableData::Serialize(Serializer &serializer) const {
 
 ExportedTableData ExportedTableData::Deserialize(Deserializer &deserializer) {
 	ExportedTableData result;
-	deserializer.ReadPropertyWithDefault<Identifier>(1, "table_name", result.qualified_name.NameMutable());
-	deserializer.ReadPropertyWithDefault<Identifier>(2, "schema_name", result.qualified_name.SchemaMutable());
-	deserializer.ReadPropertyWithDefault<Identifier>(3, "database_name", result.qualified_name.CatalogMutable());
+	auto table_name = deserializer.ReadPropertyWithDefault<Identifier>(1, "table_name");
+	auto schema_name = deserializer.ReadPropertyWithDefault<Identifier>(2, "schema_name");
+	auto database_name = deserializer.ReadPropertyWithDefault<Identifier>(3, "database_name");
 	deserializer.ReadPropertyWithDefault<string>(4, "file_path", result.file_path);
 	deserializer.ReadPropertyWithDefault<vector<Identifier>>(5, "not_null_columns", result.not_null_columns);
+	result.SetQualifiedName(std::move(database_name), std::move(schema_name), std::move(table_name));
 	return result;
 }
 

--- a/src/storage/serialization/serialize_parse_info.cpp
+++ b/src/storage/serialization/serialize_parse_info.cpp
@@ -122,11 +122,9 @@ unique_ptr<ParseInfo> AlterInfo::Deserialize(Deserializer &deserializer) {
 	default:
 		throw SerializationException("Unsupported type for deserialization of AlterInfo!");
 	}
-	result->qualified_name.CatalogMutable() = std::move(catalog);
-	result->qualified_name.SchemaMutable() = std::move(schema);
-	result->qualified_name.NameMutable() = std::move(name);
 	result->if_not_found = if_not_found;
 	result->allow_internal = allow_internal;
+	result->SetQualifiedName(std::move(catalog), std::move(schema), std::move(name));
 	return std::move(result);
 }
 
@@ -394,9 +392,9 @@ void CopyInfo::Serialize(Serializer &serializer) const {
 
 unique_ptr<ParseInfo> CopyInfo::Deserialize(Deserializer &deserializer) {
 	auto result = duckdb::unique_ptr<CopyInfo>(new CopyInfo());
-	deserializer.ReadPropertyWithDefault<Identifier>(200, "catalog", result->qualified_name.CatalogMutable());
-	deserializer.ReadPropertyWithDefault<Identifier>(201, "schema", result->qualified_name.SchemaMutable());
-	deserializer.ReadPropertyWithDefault<Identifier>(202, "table", result->qualified_name.NameMutable());
+	auto catalog = deserializer.ReadPropertyWithDefault<Identifier>(200, "catalog");
+	auto schema = deserializer.ReadPropertyWithDefault<Identifier>(201, "schema");
+	auto table = deserializer.ReadPropertyWithDefault<Identifier>(202, "table");
 	deserializer.ReadPropertyWithDefault<vector<Identifier>>(203, "select_list", result->select_list);
 	deserializer.ReadPropertyWithDefault<bool>(204, "is_from", result->is_from);
 	deserializer.ReadPropertyWithDefault<string>(205, "format", result->format);
@@ -404,6 +402,7 @@ unique_ptr<ParseInfo> CopyInfo::Deserialize(Deserializer &deserializer) {
 	deserializer.ReadPropertyWithDefault<case_insensitive_map_t<vector<Value>>>(207, "options", result->options);
 	deserializer.ReadPropertyWithDefault<unique_ptr<QueryNode>>(208, "select_statement", result->select_statement);
 	deserializer.ReadPropertyWithDefault<bool>(209, "is_format_auto_detected", result->is_format_auto_detected);
+	result->SetQualifiedName(std::move(catalog), std::move(schema), std::move(table));
 	return std::move(result);
 }
 
@@ -444,13 +443,14 @@ void DropInfo::Serialize(Serializer &serializer) const {
 unique_ptr<ParseInfo> DropInfo::Deserialize(Deserializer &deserializer) {
 	auto result = duckdb::unique_ptr<DropInfo>(new DropInfo());
 	deserializer.ReadProperty<CatalogType>(200, "type", result->type);
-	deserializer.ReadPropertyWithDefault<Identifier>(201, "catalog", result->qualified_name.CatalogMutable());
-	deserializer.ReadPropertyWithDefault<Identifier>(202, "schema", result->qualified_name.SchemaMutable());
-	deserializer.ReadPropertyWithDefault<Identifier>(203, "name", result->qualified_name.NameMutable());
+	auto catalog = deserializer.ReadPropertyWithDefault<Identifier>(201, "catalog");
+	auto schema = deserializer.ReadPropertyWithDefault<Identifier>(202, "schema");
+	auto name = deserializer.ReadPropertyWithDefault<Identifier>(203, "name");
 	deserializer.ReadProperty<OnEntryNotFound>(204, "if_not_found", result->if_not_found);
 	deserializer.ReadPropertyWithDefault<bool>(205, "cascade", result->cascade);
 	deserializer.ReadPropertyWithDefault<bool>(206, "allow_drop_internal", result->allow_drop_internal);
 	deserializer.ReadPropertyWithDefault<unique_ptr<ExtraDropInfo>>(207, "extra_drop_info", result->extra_drop_info);
+	result->SetQualifiedName(std::move(catalog), std::move(schema), std::move(name));
 	return std::move(result);
 }
 

--- a/src/storage/serialization/serialize_parsed_expression.cpp
+++ b/src/storage/serialization/serialize_parsed_expression.cpp
@@ -320,10 +320,11 @@ void TypeExpression::Serialize(Serializer &serializer) const {
 
 unique_ptr<ParsedExpression> TypeExpression::Deserialize(Deserializer &deserializer) {
 	auto result = duckdb::unique_ptr<TypeExpression>(new TypeExpression());
-	deserializer.ReadPropertyWithDefault<Identifier>(200, "catalog", result->qualified_name.CatalogMutable());
-	deserializer.ReadPropertyWithDefault<Identifier>(201, "schema", result->qualified_name.SchemaMutable());
-	deserializer.ReadPropertyWithDefault<Identifier>(202, "type_name", result->qualified_name.NameMutable());
+	auto catalog = deserializer.ReadPropertyWithDefault<Identifier>(200, "catalog");
+	auto schema = deserializer.ReadPropertyWithDefault<Identifier>(201, "schema");
+	auto type_name = deserializer.ReadPropertyWithDefault<Identifier>(202, "type_name");
 	deserializer.ReadPropertyWithDefault<vector<unique_ptr<ParsedExpression>>>(203, "children", result->children);
+	result->SetQualifiedName(std::move(catalog), std::move(schema), std::move(type_name));
 	return std::move(result);
 }
 

--- a/src/storage/serialization/serialize_query_node.cpp
+++ b/src/storage/serialization/serialize_query_node.cpp
@@ -117,14 +117,15 @@ unique_ptr<QueryNode> InsertQueryNode::Deserialize(Deserializer &deserializer) {
 	auto result = duckdb::unique_ptr<InsertQueryNode>(new InsertQueryNode());
 	deserializer.ReadPropertyWithDefault<unique_ptr<SelectStatement>>(200, "select_statement", result->select_statement);
 	deserializer.ReadPropertyWithDefault<vector<Identifier>>(201, "columns", result->columns);
-	deserializer.ReadPropertyWithDefault<Identifier>(202, "table", result->qualified_name.NameMutable());
-	deserializer.ReadPropertyWithDefault<Identifier>(203, "schema", result->qualified_name.SchemaMutable());
-	deserializer.ReadPropertyWithDefault<Identifier>(204, "catalog", result->qualified_name.CatalogMutable());
+	auto table = deserializer.ReadPropertyWithDefault<Identifier>(202, "table");
+	auto schema = deserializer.ReadPropertyWithDefault<Identifier>(203, "schema");
+	auto catalog = deserializer.ReadPropertyWithDefault<Identifier>(204, "catalog");
 	deserializer.ReadPropertyWithDefault<vector<unique_ptr<ParsedExpression>>>(205, "returning_list", result->returning_list);
 	deserializer.ReadPropertyWithDefault<unique_ptr<OnConflictInfo>>(206, "on_conflict_info", result->on_conflict_info);
 	deserializer.ReadPropertyWithDefault<unique_ptr<TableRef>>(207, "table_ref", result->table_ref);
 	deserializer.ReadPropertyWithExplicitDefault<bool>(208, "default_values", result->default_values, false);
 	deserializer.ReadPropertyWithExplicitDefault<InsertColumnOrder>(209, "column_order", result->column_order, InsertColumnOrder::INSERT_BY_POSITION);
+	result->SetQualifiedName(std::move(catalog), std::move(schema), std::move(table));
 	return std::move(result);
 }
 

--- a/src/storage/serialization/serialize_tableref.cpp
+++ b/src/storage/serialization/serialize_tableref.cpp
@@ -83,11 +83,12 @@ void BaseTableRef::Serialize(Serializer &serializer) const {
 
 unique_ptr<TableRef> BaseTableRef::Deserialize(Deserializer &deserializer) {
 	auto result = duckdb::unique_ptr<BaseTableRef>(new BaseTableRef());
-	deserializer.ReadPropertyWithDefault<Identifier>(200, "schema_name", result->qualified_name.SchemaMutable());
-	deserializer.ReadPropertyWithDefault<Identifier>(201, "table_name", result->qualified_name.NameMutable());
+	auto schema_name = deserializer.ReadPropertyWithDefault<Identifier>(200, "schema_name");
+	auto table_name = deserializer.ReadPropertyWithDefault<Identifier>(201, "table_name");
 	deserializer.ReadPropertyWithDefault<vector<Identifier>>(202, "column_name_alias", result->column_name_alias);
-	deserializer.ReadPropertyWithDefault<Identifier>(203, "catalog_name", result->qualified_name.CatalogMutable());
+	auto catalog_name = deserializer.ReadPropertyWithDefault<Identifier>(203, "catalog_name");
 	deserializer.ReadPropertyWithDefault<unique_ptr<AtClause>>(204, "at_clause", result->at_clause);
+	result->SetQualifiedName(std::move(catalog_name), std::move(schema_name), std::move(table_name));
 	return std::move(result);
 }
 
@@ -191,11 +192,12 @@ void ShowRef::Serialize(Serializer &serializer) const {
 
 unique_ptr<TableRef> ShowRef::Deserialize(Deserializer &deserializer) {
 	auto result = duckdb::unique_ptr<ShowRef>(new ShowRef());
-	deserializer.ReadPropertyWithDefault<Identifier>(200, "table_name", result->qualified_name.NameMutable());
+	auto table_name = deserializer.ReadPropertyWithDefault<Identifier>(200, "table_name");
 	deserializer.ReadPropertyWithDefault<unique_ptr<QueryNode>>(201, "query", result->query);
 	deserializer.ReadProperty<ShowType>(202, "show_type", result->show_type);
-	deserializer.ReadPropertyWithDefault<Identifier>(203, "catalog_name", result->qualified_name.CatalogMutable());
-	deserializer.ReadPropertyWithDefault<Identifier>(204, "schema_name", result->qualified_name.SchemaMutable());
+	auto catalog_name = deserializer.ReadPropertyWithDefault<Identifier>(203, "catalog_name");
+	auto schema_name = deserializer.ReadPropertyWithDefault<Identifier>(204, "schema_name");
+	result->SetQualifiedName(std::move(catalog_name), std::move(schema_name), std::move(table_name));
 	return std::move(result);
 }
 

--- a/src/storage/wal_replay.cpp
+++ b/src/storage/wal_replay.cpp
@@ -899,7 +899,7 @@ void WriteAheadLogDeserializer::ReplayDropSchema() {
 	DropInfo info;
 
 	info.type = CatalogType::SCHEMA_ENTRY;
-	info.NameMutable() = Identifier(deserializer.ReadProperty<string>(101, "schema"));
+	info.SetName(Identifier(deserializer.ReadProperty<string>(101, "schema")));
 	if (DeserializeOnly()) {
 		return;
 	}


### PR DESCRIPTION
Currently we do a lot of in-place modification of the `QualifiedName` - this PR moves away from that and instead just generates a new `QualifiedName` when doing these modifications, e.g. by calling `QualifiedName::WithName` or `QualifiedName::WithQualification`. 

In general we should move away as much as possible from setting individual components of the `QualifiedName`, but this at least cleans this up a bit and makes it less error-prone / messy. 