### PR TITLE
Fix DISTINCT window aggregate ordering

### DIFF
--- a/src/function/window/window_aggregate_function.cpp
+++ b/src/function/window/window_aggregate_function.cpp
@@ -39,7 +39,7 @@ static BoundWindowExpression &SimplifyWindowedAggregate(BoundWindowExpression &w
 		}
 		if (aggr->GetOrderDependent() != AggregateOrderDependent::ORDER_DEPENDENT) {
 			arg_orders.clear();
-		} else {
+		} else if (!wexpr.Distinct()) {
 			//	If the argument order is prefix of the partition ordering,
 			//	then we can just use the partition ordering.
 			if (BoundWindowExpression::GetSharedOrders(wexpr.OrderBy(), arg_orders) == arg_orders.size()) {

--- a/test/sql/window/test_window_distinct.test
+++ b/test/sql/window/test_window_distinct.test
@@ -7,6 +7,22 @@ SELECT COUNT(DISTINCT 42) OVER ()
 ----
 1
 
+# DISTINCT with an aggregate-local ORDER BY keeps that ordering even when it
+# matches the window ORDER BY.
+query I
+WITH src(c) AS (
+	SELECT range % 2
+	FROM range(33)
+)
+SELECT LIST(DISTINCT c ORDER BY c) OVER (
+	ORDER BY c
+	ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+) AS window_list
+FROM src
+LIMIT 1
+----
+[0, 1]
+
 query IIII
 WITH t AS (
 	SELECT col0 AS a, col1 AS b 


### PR DESCRIPTION
Fixes #23448.

This keeps aggregate-local ordering for DISTINCT window aggregates instead of treating a matching window ORDER BY as a replacement. That prevents the distinct window aggregate path from dropping the ordering needed by ordered aggregates such as LIST.

Adds a regression test for LIST(DISTINCT c ORDER BY c) OVER (ORDER BY c) returning [0, 1].

Tests:
- make debug
- ./build/debug/test/unittest test/sql/window/test_window_distinct.test