### PR TITLE
Parquet Variant: only set metadata `sorted_strings` when the dictionary is sorted

### DIFF
--- a/extension/parquet/writer/variant/convert_variant.cpp
+++ b/extension/parquet/writer/variant/convert_variant.cpp
@@ -65,14 +65,14 @@ static idx_t CalculateByteLength(idx_t value) {
 	return sizeof(idx_t) - irrelevant_bytes;
 }
 
-static uint8_t EncodeMetadataHeader(idx_t byte_length) {
+static uint8_t EncodeMetadataHeader(idx_t byte_length, bool sorted_strings) {
 	D_ASSERT(byte_length <= 4);
 
 	uint8_t header_byte = 0;
 	//! Set 'version' to 1
 	header_byte |= static_cast<uint8_t>(1);
-	//! Set 'sorted_strings' to 1
-	header_byte |= static_cast<uint8_t>(1) << 4;
+	//! Set 'sorted_strings' only when the dictionary is sorted + unique
+	header_byte |= static_cast<uint8_t>(sorted_strings ? 1 : 0) << 4;
 	//! Set 'offset_size_minus_one' to byte_length-1
 	header_byte |= (static_cast<uint8_t>(byte_length) - 1) << 6;
 
@@ -94,9 +94,14 @@ static void CreateMetadata(UnifiedVariantVectorData &variant, Vector &metadata, 
 			dictionary_count = variant.GetKeysCount(row);
 		}
 		idx_t dictionary_size = 0;
+		//! 'sorted_strings' is only valid if the keys are strictly ascending (sorted + unique)
+		bool sorted_strings = true;
 		for (idx_t i = 0; i < dictionary_count; i++) {
 			auto &key = variant.GetKey(row, i);
 			dictionary_size += key.GetSize();
+			if (i && !(variant.GetKey(row, i - 1) < key)) {
+				sorted_strings = false;
+			}
 		}
 		if (dictionary_size >= NumericLimits<uint32_t>::Maximum()) {
 			throw InvalidInputException("The total length of the dictionary exceeds a 4 byte value (uint32_t), failed "
@@ -110,7 +115,7 @@ static void CreateMetadata(UnifiedVariantVectorData &variant, Vector &metadata, 
 		auto &metadata_blob = metadata_data[row];
 		auto metadata_blob_data = metadata_blob.GetDataWriteable();
 
-		metadata_blob_data[0] = static_cast<char>(EncodeMetadataHeader(byte_length));
+		metadata_blob_data[0] = static_cast<char>(EncodeMetadataHeader(byte_length, sorted_strings));
 		memcpy(metadata_blob_data + 1, const_data_ptr_cast(&dictionary_count), byte_length);
 
 		auto offset_ptr = metadata_blob_data + 1 + byte_length;

--- a/test/parquet/variant/variant_metadata_sorted_strings.test
+++ b/test/parquet/variant/variant_metadata_sorted_strings.test
@@ -1,0 +1,24 @@
+# name: test/parquet/variant/variant_metadata_sorted_strings.test
+# group: [variant]
+
+require parquet
+
+require json
+
+# sorted_strings in the Variant metadata header may only be set when the
+# dictionary keys are unique and sorted by their UTF-8 bytes:
+# https://github.com/apache/parquet-format/blob/master/VariantEncoding.md#metadata-encoding
+# The writer serializes the dictionary in its existing order, so the flag must
+# reflect that order rather than be set unconditionally.
+
+# Sorted dictionary -> flag set (header byte 0x11).
+query I
+select (variant_to_parquet_variant('{"a": 1, "b": 2}'::JSON::VARIANT)::STRUCT(metadata BLOB, value BLOB)).metadata;
+----
+\x11\x02\x00\x01\x02ab
+
+# Unsorted dictionary -> flag cleared (header byte 0x01).
+query I
+select (variant_to_parquet_variant('{"b": 1, "a": 2}'::JSON::VARIANT)::STRUCT(metadata BLOB, value BLOB)).metadata;
+----
+\x01\x02\x00\x01\x02ba


### PR DESCRIPTION
## Problem

`EncodeMetadataHeader` (`extension/parquet/writer/variant/convert_variant.cpp`) sets the Variant metadata `sorted_strings` bit unconditionally:

```cpp
//! Set 'sorted_strings' to 1
header_byte |= static_cast<uint8_t>(1) << 4;
```

Per the [Parquet Variant encoding spec](https://github.com/apache/parquet-format/blob/master/VariantEncoding.md#metadata-encoding), `sorted_strings = 1` means the dictionary strings are **unique and sorted by their UTF-8 bytes** — a guarantee readers may rely on (e.g. binary-searching a field), and a strict reader rejects a file that sets the bit over an out-of-order dictionary.

The metadata builder serializes the dictionary in its existing order and never sorts it, so the flag is set even when the keys aren't sorted. A cast of an object whose keys aren't already in byte order reaches the writer directly:

```sql
SELECT (variant_to_parquet_variant('{"b": 1, "a": 2}'::JSON::VARIANT)::STRUCT(metadata BLOB, value BLOB)).metadata;
-- before this PR: \x11\x02\x00\x01\x02ba   header 0x11 (sorted_strings=1) over dictionary ["b","a"]
```

Any Variant whose keys aren't already byte-sorted hits this (an object literal, a value read back from Parquet, etc.).

## Fix

Track whether the dictionary is strictly ascending during the key pass `CreateMetadata` already makes (same `string_t` byte comparison the rest of the writer uses) and set the flag from it:

```cpp
if (i && !(variant.GetKey(row, i - 1) < key)) {
    sorted_strings = false;
}
...
EncodeMetadataHeader(byte_length, sorted_strings);
```

The keys are still serialized in the same order — only the header flag changes, so there's no value-section remapping and no read regression for already-sorted dictionaries (they keep `sorted_strings = 1`).

## Test

`test/parquet/variant/variant_metadata_sorted_strings.test` — a sorted dictionary keeps the flag (`\x11…`), an unsorted one clears it (`\x01…`).
