### PR TITLE
[v1.5] Quickfix `ALTER TABLE ADD COLUMN IF NOT EXISTS ... DEFAULT` regression

### DIFF
--- a/src/parser/transform/statement/transform_alter_table.cpp
+++ b/src/parser/transform/statement/transform_alter_table.cpp
@@ -127,19 +127,26 @@ unique_ptr<SQLStatement> Transformer::TransformAlter(duckdb_libpgquery::PGAlterT
 			}
 			column_entry.SetName(column_names.back());
 			if (column_names.size() == 1) {
-				// ADD COLUMN
-				if (!column_entry.HasDefaultValue() ||
-				    column_entry.DefaultValue().GetExpressionClass() == ExpressionClass::CONSTANT) {
+				if (command->missing_ok) {
+					// SQL query has `IF NOT EXISTS`, so we fall back to the old path to avoid a regression due to the
+					// multistatement rewrite.
+					// This is just a v1.5-variegata quickfix. We can tackle this properly later on for v2.0.
 					result->info =
 					    make_uniq<AddColumnInfo>(std::move(data), std::move(column_entry), command->missing_ok);
-					break;
+				} else {
+					// ADD COLUMN
+					if (!column_entry.HasDefaultValue() ||
+					    column_entry.DefaultValue().GetExpressionClass() == ExpressionClass::CONSTANT) {
+						result->info =
+						    make_uniq<AddColumnInfo>(std::move(data), std::move(column_entry), command->missing_ok);
+						break;
+					}
+					auto null_column = column_entry.Copy();
+					null_column.SetDefaultValue(make_uniq<ConstantExpression>(ConstantExpression(Value(nullptr))));
+					return unique_ptr<SQLStatement>(std::move(TransformAndMaterializeAlter(
+					    stmt, data, make_uniq<AddColumnInfo>(data, std::move(null_column), command->missing_ok),
+					    column_entry.GetName(), column_entry.DefaultValue().Copy())));
 				}
-				auto null_column = column_entry.Copy();
-				null_column.SetDefaultValue(make_uniq<ConstantExpression>(ConstantExpression(Value(nullptr))));
-				return unique_ptr<SQLStatement>(std::move(TransformAndMaterializeAlter(
-				    stmt, data, make_uniq<AddColumnInfo>(data, std::move(null_column), command->missing_ok),
-				    column_entry.GetName(), column_entry.DefaultValue().Copy())));
-
 			} else {
 				// ADD FIELD
 				column_names.pop_back();

--- a/test/sql/alter/add_col/test_add_col_if_not_exists_default.test
+++ b/test/sql/alter/add_col/test_add_col_if_not_exists_default.test
@@ -1,0 +1,29 @@
+# name: test/sql/alter/add_col/test_add_col_if_not_exists_default.test
+# group: [add_col]
+
+statement ok
+CREATE TABLE t (i INTEGER)
+
+statement ok
+INSERT INTO t VALUES (1), (2)
+
+statement ok
+ALTER TABLE t ADD COLUMN IF NOT EXISTS b BOOLEAN DEFAULT false
+
+statement ok
+UPDATE t SET b = true
+
+query I
+SELECT b FROM t
+----
+true
+true
+
+statement ok
+ALTER TABLE t ADD COLUMN IF NOT EXISTS b BOOLEAN DEFAULT false
+
+query I
+SELECT b FROM t
+----
+true
+true


### PR DESCRIPTION
https://github.com/duckdblabs/duckdb-internal/issues/9721
## The problem
When ADD COLUMN IF NOT EXISTS targets a column that already exists and the clause carries a DEFAULT, DuckDB 1.5.x does not treat the statement as a no-op: it re-applies the default expression to every existing row, silently destroying the column's current data.
## The fix
Don't do the 3 multi-statement rewrite workaround from https://github.com/duckdb/duckdb/pull/20224 when there is a `IF NOT EXISTS`
This is just a v1.5-variegata quickfix. We can tackle this properly later on for v2.0. 