### PR TITLE
Add error handling around `export` option

### DIFF
--- a/src/parser/peg/transformer/transform_export.cpp
+++ b/src/parser/peg/transformer/transform_export.cpp
@@ -17,9 +17,12 @@ PEGTransformerFactory::TransformExportStatement(PEGTransformer &transformer, con
 	if (generic_copy_option_list) {
 		for (const auto &option : *generic_copy_option_list) {
 			if (option.name == "format") {
-				if (option.expression || option.children.empty()) {
+				if (option.expression) {
 					throw ParserException(
 					    "Unsupported parameter type for FORMAT: expected e.g. FORMAT 'csv', 'parquet'");
+				}
+				if (option.children.empty()) {
+					throw ParserException("FORMAT requires a parameter, e.g. FORMAT 'csv' or FORMAT 'parquet'");
 				}
 				info->format = option.children[0].GetValue<string>();
 				info->is_format_auto_detected = false;

--- a/src/parser/peg/transformer/transform_export.cpp
+++ b/src/parser/peg/transformer/transform_export.cpp
@@ -17,6 +17,10 @@ PEGTransformerFactory::TransformExportStatement(PEGTransformer &transformer, con
 	if (generic_copy_option_list) {
 		for (const auto &option : *generic_copy_option_list) {
 			if (option.name == "format") {
+				if (option.expression || option.children.empty()) {
+					throw ParserException(
+					    "Unsupported parameter type for FORMAT: expected e.g. FORMAT 'csv', 'parquet'");
+				}
 				info->format = option.children[0].GetValue<string>();
 				info->is_format_auto_detected = false;
 			} else if (option.expression) {

--- a/test/sql/export/export_database.test
+++ b/test/sql/export/export_database.test
@@ -8,6 +8,16 @@ SET default_null_order='nulls_first';
 statement ok
 SET default_transaction_invalidation_policy='SYNTACTIC_ERRORS_DO_NOT_INVALIDATE';
 
+statement error
+EXPORT DATABASE '' (FORMAT X!);
+----
+Unsupported parameter type for FORMAT: expected e.g. FORMAT 'csv', 'parquet'
+
+statement error
+EXPORT DATABASE '' (FORMAT lower('csv'));
+----
+Unsupported parameter type for FORMAT: expected e.g. FORMAT 'csv', 'parquet'
+
 # create a bunch of tables with data and views
 
 statement ok

--- a/test/sql/export/export_database.test
+++ b/test/sql/export/export_database.test
@@ -14,6 +14,16 @@ EXPORT DATABASE '' (FORMAT X!);
 Unsupported parameter type for FORMAT: expected e.g. FORMAT 'csv', 'parquet'
 
 statement error
+EXPORT DATABASE '' (FORMAT x);
+----
+Copy Function with name x does not exist!
+
+statement error
+EXPORT DATABASE '' (FORMAT);
+----
+FORMAT requires a parameter, e.g. FORMAT 'csv' or FORMAT 'parquet'
+
+statement error
 EXPORT DATABASE '' (FORMAT lower('csv'));
 ----
 Unsupported parameter type for FORMAT: expected e.g. FORMAT 'csv', 'parquet'


### PR DESCRIPTION
Fix https://github.com/duckdb/duckdb-fuzzer/issues/4537

(Second attempt at this)

Adding some error handling around options for `EXPORT` and improve error messages:

```sql
EXPORT DATABASE '' (FORMAT X!);
Unsupported parameter type for FORMAT: expected e.g. FORMAT 'csv', 'parquet'
```

```sql
EXPORT DATABASE '' (FORMAT);
FORMAT requires a parameter, e.g. FORMAT 'csv' or FORMAT 'parquet'
```
