### PR TITLE
Upload codecov as github artifacts

### DIFF
--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -509,6 +509,59 @@ jobs:
         zip -j libduckdb-src.zip src/include/duckdb.h src/include/duckdb_extension.h
         ./scripts/upload-assets-to-staging.sh github_release libduckdb-src.zip
 
+ codecov:
+    name: Code Coverage
+    if: ${{ contains(fromJson(needs.prepare.outputs.enabled_jobs), 'codecov') }}
+    needs:
+      - prepare
+      - linux-release
+    runs-on: ${{ needs.prepare.outputs.runner_linux_x64 }}
+    env:
+      CC: clang-20
+      CXX: clang++-20
+      GEN: ninja
+
+    steps:
+    - name: "Checkout"
+      uses: duckdb/duckdb-ci/.github/actions/checkout@main
+      with:
+        runner_provider: ${{ needs.prepare.outputs.runner_provider }}
+        fetch_depth: 0
+        ref: ${{ needs.prepare.outputs.git_sha }}
+
+    - name: Install tools
+      timeout-minutes: 10
+      run: |
+        python3 scripts/ci/retry.py -- make toolsci
+        python3 scripts/ci/retry.py -- sudo apt-get update -y -qq
+        python3 scripts/ci/retry.py -- sudo apt-get install -y -qq lcov
+
+    - uses: ./.github/actions/ccache-action
+      with:
+        key: codecov
+        save: ${{ fromJson(needs.prepare.outputs.save_cache) }}
+
+    - name: Build DuckDB
+      uses: duckdb/duckdb-ci/build-duckdb@main
+      env:
+        CORE_EXTENSIONS: "icu;tpch;tpcds;fts;json;inet;parquet;autocomplete;test-utils;httpfs"
+      with:
+        build-type: codecov
+        build: python3 scripts/ci/retry.py -- make codecov
+        vcpkg-commit: 84bab45d415d22042bd0b9081aea57f362da3f35
+        cache-suffix: codecov
+        save-cache: ${{ fromJson(needs.prepare.outputs.save_cache) }}
+
+    - name: Generate coverage report
+      run: build/codecov/test/run --coverage-report coverage/linux-release-default-tests
+
+    - name: Upload coverage report
+      uses: actions/upload-artifact@v7
+      with:
+        name: coverage-linux-release-default-tests
+        path: coverage/linux-release-default-tests
+        if-no-files-found: error
+
  linux-release-tests:
     name: Linux Release Tests
     if: ${{ contains(fromJson(needs.prepare.outputs.enabled_jobs), 'linux-release-tests') }}
@@ -1298,6 +1351,7 @@ jobs:
       - extensions
       - wasm-eh
       - linux-release
+      - codecov
       - linux-release-tests
       - linux-release-cli
       - linux-musl-release-cli

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -534,7 +534,8 @@ jobs:
       run: |
         python3 scripts/ci/retry.py -- make toolsci
         python3 scripts/ci/retry.py -- sudo apt-get update -y -qq
-        python3 scripts/ci/retry.py -- sudo apt-get install -y -qq lcov
+        python3 scripts/ci/retry.py -- sudo apt-get install -y -qq lcov llvm-20
+        echo "/usr/lib/llvm-20/bin" >> "$GITHUB_PATH"
 
     - uses: ./.github/actions/ccache-action
       with:

--- a/scripts/ci/job_stages.py
+++ b/scripts/ci/job_stages.py
@@ -15,7 +15,6 @@ COMMON_JOBS = [
     "extensions",
     "wasm-eh",
     "linux-release",
-    "codecov",
     "linux-release-tests",
     "linux-release-cli",
     "linux-musl-release-cli",
@@ -38,6 +37,7 @@ NIGHTLY_ONLY_JOBS = [
     "main_julia",
     "static-libs-osx",
     "static-libs-windows-mingw",
+    "codecov",
 ]
 
 NIGHTLY_JOBS = COMMON_JOBS + NIGHTLY_ONLY_JOBS
@@ -62,7 +62,6 @@ SKIP_TESTS_JOBS = {
     "swift",
     "linux-configs",
     "linux-release-tests",
-    "codecov",
 }
 
 PREPARE_JOBS = [

--- a/scripts/ci/job_stages.py
+++ b/scripts/ci/job_stages.py
@@ -15,6 +15,7 @@ COMMON_JOBS = [
     "extensions",
     "wasm-eh",
     "linux-release",
+    "codecov",
     "linux-release-tests",
     "linux-release-cli",
     "linux-musl-release-cli",
@@ -61,6 +62,7 @@ SKIP_TESTS_JOBS = {
     "swift",
     "linux-configs",
     "linux-release-tests",
+    "codecov",
 }
 
 PREPARE_JOBS = [


### PR DESCRIPTION
Follow up of #23486 to gather and publish codecov results.

Code coverage reports are created on the main branch. The reports are currently only stored as a github artifact and thus not directly "viewable".

### Coverage report viewer (out of scope)

We can view those coverage reports with a custom HTML file that internally fetches the artifact zip file using https://artifacts.duckdb.org/.

An idea could be to let github pages (like https://duckdb-ci.github.io/coverage/) serve the initial HTML file.