### PR TITLE
Fuzzer pivot issue with `ConstructConstantFromExpression`

### DIFF
--- a/src/parser/peg/transformer/peg_transformer_factory.cpp
+++ b/src/parser/peg/transformer/peg_transformer_factory.cpp
@@ -371,12 +371,7 @@ bool PEGTransformerFactory::ConstructConstantFromExpression(const ParsedExpressi
 			return false;
 		}
 
-		LogicalType cast_type;
-		try {
-			cast_type = UnboundType::TryDefaultBind(cast.TargetType());
-		} catch (...) {
-			return false;
-		}
+		auto cast_type = UnboundType::TryDefaultBind(cast.TargetType());
 		if (cast_type == LogicalType::INVALID || cast_type == LogicalTypeId::UNBOUND) {
 			return false;
 		}

--- a/src/parser/peg/transformer/peg_transformer_factory.cpp
+++ b/src/parser/peg/transformer/peg_transformer_factory.cpp
@@ -371,10 +371,20 @@ bool PEGTransformerFactory::ConstructConstantFromExpression(const ParsedExpressi
 			return false;
 		}
 
+		LogicalType cast_type;
+		try {
+			cast_type = UnboundType::TryDefaultBind(cast.TargetType());
+		} catch (...) {
+			return false;
+		}
+		if (cast_type == LogicalType::INVALID || cast_type == LogicalTypeId::UNBOUND) {
+			return false;
+		}
+
 		string error_message;
-		if (!dummy_value.DefaultTryCastAs(cast.TargetType(), value, &error_message)) {
+		if (!dummy_value.DefaultTryCastAs(cast_type, value, &error_message)) {
 			throw ConversionException("Unable to cast %s to %s", dummy_value.ToString(),
-			                          EnumUtil::ToString(cast.TargetType().id()));
+			                          EnumUtil::ToString(cast_type.id()));
 		}
 		return true;
 	}

--- a/test/sql/pivot/test_multi_pivot.test
+++ b/test/sql/pivot/test_multi_pivot.test
@@ -69,6 +69,16 @@ SELECT (SELECT * FROM (SELECT 1 a, 2 b, 3 c) PIVOT (min(a) FOR (b, c) IN ((NULL,
 ----
 NULL
 
+query I
+SELECT * FROM (VALUES (1)) PIVOT (count(col0) FOR col0 IN (1::INT));
+----
+1
+
+query I
+FROM (SELECT 1 a, 2 b) PIVOT (sum(a) FOR b IN ('2022-01-01'::DATE));
+----
+NULL
+
 statement ok
 SET pivot_limit=10000
 


### PR DESCRIPTION
Fix: https://github.com/duckdb/duckdb-fuzzer/issues/4538 and https://github.com/duckdb/duckdb-fuzzer/issues/4490

Fixes a parser-time internal error when folding casted constants in `PIVOT ... IN (...)` lists.

`ConstructConstantFromExpression previously` passed the raw cast expression directly to `Value::DefaultTryCastAs`. For cases such as `1::INT` or `'2022-01-01'::DATE`, that target can still be an unbound type, which could trigger `Trying to create buffer for zero-length type.`

Also fixes this case where a malformed query could be interpreted as a TypeLiteral cast and fail (see `Q3', $Q4'` missing a `'`: 
```sql
 SELECT * FROM (VALUES ('Q1')) t(quarter) PIVOT (count(*) FOR quarter IN ('Q1', Q3', $Q4'));
```