### PR TITLE
Expose limit hints to C++ table functions

### DIFF
--- a/src/execution/operator/scan/physical_table_scan.cpp
+++ b/src/execution/operator/scan/physical_table_scan.cpp
@@ -19,13 +19,14 @@ PhysicalTableScan::PhysicalTableScan(PhysicalPlan &physical_plan, vector<Logical
                                      vector<ColumnIndex> column_ids_p, vector<idx_t> projection_ids_p,
                                      vector<string> names_p, unique_ptr<TableFilterSet> table_filters_p,
                                      idx_t estimated_cardinality, ExtraOperatorInfo extra_info,
-                                     vector<Value> parameters_p, virtual_column_map_t virtual_columns_p)
+                                     vector<Value> parameters_p, virtual_column_map_t virtual_columns_p,
+                                     optional_idx limit_p)
     : PhysicalOperator(physical_plan, PhysicalOperatorType::TABLE_SCAN, std::move(types), estimated_cardinality),
 
       function(std::move(function_p)), bind_data(std::move(bind_data_p)), returned_types(std::move(returned_types_p)),
       column_ids(std::move(column_ids_p)), projection_ids(std::move(projection_ids_p)), names(std::move(names_p)),
       table_filters(std::move(table_filters_p)), extra_info(std::move(extra_info)), parameters(std::move(parameters_p)),
-      virtual_columns(std::move(virtual_columns_p)) {
+      virtual_columns(std::move(virtual_columns_p)), limit(limit_p) {
 }
 
 class TableScanGlobalSourceState : public GlobalSourceState {
@@ -40,7 +41,7 @@ public:
 		if (op.function.init_global) {
 			auto filters = table_filters ? *table_filters : GetTableFilters(op);
 			TableFunctionInitInput input(op.bind_data.get(), op.column_ids, op.projection_ids, filters,
-			                             op.extra_info.sample_options, &op);
+			                             op.extra_info.sample_options, &op, op.limit);
 
 			global_state = op.function.init_global(context, input);
 			if (global_state) {
@@ -84,7 +85,7 @@ public:
 	                          const PhysicalTableScan &op) {
 		if (op.function.init_local) {
 			TableFunctionInitInput input(op.bind_data.get(), op.column_ids, op.projection_ids,
-			                             gstate.GetTableFilters(op), op.extra_info.sample_options, &op);
+			                             gstate.GetTableFilters(op), op.extra_info.sample_options, &op, op.limit);
 			local_state = op.function.init_local(context, input, gstate.global_state.get());
 		}
 	}
@@ -400,6 +401,9 @@ bool PhysicalTableScan::Equals(const PhysicalOperator &other_p) const {
 		return false;
 	}
 	if (!FunctionData::Equals(bind_data.get(), other.bind_data.get())) {
+		return false;
+	}
+	if (limit != other.limit) {
 		return false;
 	}
 	return true;

--- a/src/execution/physical_plan/plan_get.cpp
+++ b/src/execution/physical_plan/plan_get.cpp
@@ -150,7 +150,7 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalGet &op) {
 		auto &table_scan = Make<PhysicalTableScan>(
 		    op.returned_types, op.function, std::move(op.bind_data), op.returned_types, column_ids, vector<column_t>(),
 		    IdentifiersToStrings(op.names), std::move(table_filters), op.estimated_cardinality,
-		    std::move(op.extra_info), std::move(op.parameters), std::move(op.virtual_columns));
+		    std::move(op.extra_info), std::move(op.parameters), std::move(op.virtual_columns), op.limit);
 		// first check if an additional projection is necessary
 		if (column_ids.size() == op.returned_types.size()) {
 			bool projection_necessary = false;
@@ -200,7 +200,7 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalGet &op) {
 	auto &table_scan = Make<PhysicalTableScan>(
 	    op.types, op.function, std::move(op.bind_data), op.returned_types, column_ids, std::move(projection_indices),
 	    IdentifiersToStrings(op.names), std::move(table_filters), op.estimated_cardinality, std::move(op.extra_info),
-	    std::move(op.parameters), std::move(op.virtual_columns));
+	    std::move(op.parameters), std::move(op.virtual_columns), op.limit);
 	auto &cast_table_scan = table_scan.Cast<PhysicalTableScan>();
 	cast_table_scan.dynamic_filters = op.dynamic_filters;
 	if (filter) {

--- a/src/include/duckdb/execution/operator/scan/physical_table_scan.hpp
+++ b/src/include/duckdb/execution/operator/scan/physical_table_scan.hpp
@@ -32,7 +32,8 @@ public:
 	                  unique_ptr<FunctionData> bind_data, vector<LogicalType> returned_types,
 	                  vector<ColumnIndex> column_ids, vector<idx_t> projection_ids, vector<string> names,
 	                  unique_ptr<TableFilterSet> table_filters, idx_t estimated_cardinality,
-	                  ExtraOperatorInfo extra_info, vector<Value> parameters, virtual_column_map_t virtual_columns);
+	                  ExtraOperatorInfo extra_info, vector<Value> parameters, virtual_column_map_t virtual_columns,
+	                  optional_idx limit = optional_idx());
 
 	//! The table function
 	TableFunction function;
@@ -57,6 +58,8 @@ public:
 	shared_ptr<DynamicTableFilterSet> dynamic_filters;
 	//! Virtual columns
 	virtual_column_map_t virtual_columns;
+	//! Optional upper bound on rows needed from this scan.
+	optional_idx limit;
 
 public:
 	string GetName() const override;

--- a/src/include/duckdb/function/table_function.hpp
+++ b/src/include/duckdb/function/table_function.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "duckdb/common/enums/operator_result_type.hpp"
+#include "duckdb/common/optional_idx.hpp"
 #include "duckdb/common/optional_ptr.hpp"
 #include "duckdb/execution/execution_context.hpp"
 #include "duckdb/execution/physical_operator_states.hpp"
@@ -130,9 +131,9 @@ struct TableFunctionInitInput {
 	TableFunctionInitInput(optional_ptr<const FunctionData> bind_data_p, vector<column_t> column_ids_p,
 	                       const vector<idx_t> &projection_ids_p, optional_ptr<TableFilterSet> filters_p,
 	                       optional_ptr<SampleOptions> sample_options_p = nullptr,
-	                       optional_ptr<const PhysicalOperator> op_p = nullptr)
+	                       optional_ptr<const PhysicalOperator> op_p = nullptr, optional_idx limit_p = optional_idx())
 	    : bind_data(bind_data_p), column_ids(std::move(column_ids_p)), projection_ids(projection_ids_p),
-	      filters(filters_p), sample_options(sample_options_p), op(op_p) {
+	      filters(filters_p), sample_options(sample_options_p), op(op_p), limit(limit_p) {
 		for (auto &col_id : column_ids) {
 			column_indexes.emplace_back(col_id);
 		}
@@ -141,9 +142,9 @@ struct TableFunctionInitInput {
 	TableFunctionInitInput(optional_ptr<const FunctionData> bind_data_p, vector<ColumnIndex> column_indexes_p,
 	                       const vector<idx_t> &projection_ids_p, optional_ptr<TableFilterSet> filters_p,
 	                       optional_ptr<SampleOptions> sample_options_p = nullptr,
-	                       optional_ptr<const PhysicalOperator> op_p = nullptr)
+	                       optional_ptr<const PhysicalOperator> op_p = nullptr, optional_idx limit_p = optional_idx())
 	    : bind_data(bind_data_p), column_indexes(std::move(column_indexes_p)), projection_ids(projection_ids_p),
-	      filters(filters_p), sample_options(sample_options_p), op(op_p) {
+	      filters(filters_p), sample_options(sample_options_p), op(op_p), limit(limit_p) {
 		for (auto &col_id : column_indexes) {
 			column_ids.emplace_back(col_id.GetPrimaryIndex());
 		}
@@ -156,6 +157,8 @@ struct TableFunctionInitInput {
 	optional_ptr<TableFilterSet> filters;
 	optional_ptr<SampleOptions> sample_options;
 	optional_ptr<const PhysicalOperator> op;
+	//! Optional upper bound on rows needed from this scan. This is a hint; LIMIT remains enforced above the scan.
+	optional_idx limit;
 
 	bool CanRemoveFilterColumns() const {
 		if (projection_ids.empty()) {

--- a/src/include/duckdb/planner/operator/logical_get.hpp
+++ b/src/include/duckdb/planner/operator/logical_get.hpp
@@ -64,6 +64,8 @@ public:
 	unique_ptr<RowGroupOrderOptions> row_group_order_options;
 	//! Partition indices to scan, empty means scan all
 	vector<idx_t> scan_partition_indices;
+	//! Optional upper bound on rows needed from this scan.
+	optional_idx limit;
 
 	string GetName() const override;
 	InsertionOrderPreservingMap<string> ParamsToString() const override;

--- a/src/optimizer/limit_pushdown.cpp
+++ b/src/optimizer/limit_pushdown.cpp
@@ -1,9 +1,75 @@
 #include "duckdb/optimizer/limit_pushdown.hpp"
 
+#include "duckdb/common/limits.hpp"
+#include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/planner/operator/logical_limit.hpp"
 #include "duckdb/planner/operator/logical_projection.hpp"
 
 namespace duckdb {
+
+namespace {
+
+optional_idx GetLimitPushdownValue(const LogicalLimit &limit) {
+	if (limit.limit_val.Type() != LimitNodeType::CONSTANT_VALUE) {
+		return optional_idx();
+	}
+	idx_t offset_value = 0;
+	switch (limit.offset_val.Type()) {
+	case LimitNodeType::UNSET:
+		break;
+	case LimitNodeType::CONSTANT_VALUE:
+		offset_value = limit.offset_val.GetConstantValue();
+		break;
+	default:
+		return optional_idx();
+	}
+
+	auto limit_value = limit.limit_val.GetConstantValue();
+	if (offset_value > NumericLimits<idx_t>::Maximum() - limit_value) {
+		return optional_idx();
+	}
+	return limit_value + offset_value;
+}
+
+bool CanPushdownIntoGet(LogicalGet &get) {
+	return get.children.empty() && get.input_table_types.empty() && get.input_table_names.empty() &&
+	       get.projected_input.empty() && !get.table_filters.HasFilters();
+}
+
+void PushdownLimitIntoScan(LogicalOperator &op, optional_idx limit_value) {
+	if (!limit_value.IsValid()) {
+		return;
+	}
+
+	if (op.type == LogicalOperatorType::LOGICAL_PROJECTION) {
+		if (op.children.size() != 1) {
+			return;
+		}
+		PushdownLimitIntoScan(*op.children[0], limit_value);
+		return;
+	}
+
+	if (op.type != LogicalOperatorType::LOGICAL_GET) {
+		return;
+	}
+
+	auto &get = op.Cast<LogicalGet>();
+	if (!CanPushdownIntoGet(get)) {
+		return;
+	}
+	if (!get.limit.IsValid() || limit_value.GetIndex() < get.limit.GetIndex()) {
+		get.limit = limit_value;
+	}
+}
+
+void PushdownLimitIntoScan(LogicalLimit &limit) {
+	if (limit.children.empty()) {
+		return;
+	}
+	PushdownLimitIntoScan(*limit.children[0], GetLimitPushdownValue(limit));
+}
+
+} // namespace
 
 bool LimitPushdown::CanOptimize(duckdb::LogicalOperator &op) {
 	if (op.type == LogicalOperatorType::LOGICAL_LIMIT &&
@@ -33,6 +99,9 @@ unique_ptr<LogicalOperator> LimitPushdown::Optimize(unique_ptr<LogicalOperator> 
 		projection->SetEstimatedCardinality(op->estimated_cardinality);
 		projection->children[0] = std::move(op);
 		swap(projection, op);
+	}
+	if (op->type == LogicalOperatorType::LOGICAL_LIMIT) {
+		PushdownLimitIntoScan(op->Cast<LogicalLimit>());
 	}
 	for (auto &child : op->children) {
 		child = Optimize(std::move(child));

--- a/src/planner/operator/logical_get.cpp
+++ b/src/planner/operator/logical_get.cpp
@@ -328,6 +328,7 @@ void LogicalGet::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<unique_ptr<RowGroupOrderOptions>>(214, "row_group_order_options",
 	                                                                      row_group_order_options);
 	serializer.WritePropertyWithDefault(215, "scan_partition_indices", scan_partition_indices, vector<idx_t>());
+	serializer.WritePropertyWithDefault<optional_idx>(216, "limit", limit);
 }
 
 unique_ptr<LogicalOperator> LogicalGet::Deserialize(Deserializer &deserializer) {
@@ -362,6 +363,7 @@ unique_ptr<LogicalOperator> LogicalGet::Deserialize(Deserializer &deserializer) 
 	    deserializer.ReadPropertyWithDefault<unique_ptr<RowGroupOrderOptions>>(214, "row_group_order_options");
 	auto scan_partition_indices =
 	    deserializer.ReadPropertyWithExplicitDefault<vector<idx_t>>(215, "scan_partition_indices", vector<idx_t>());
+	deserializer.ReadPropertyWithDefault<optional_idx>(216, "limit", result->limit);
 	if (!legacy_column_ids.empty()) {
 		if (!result->column_ids.empty()) {
 			throw SerializationException(

--- a/test/sql/function/table/CMakeLists.txt
+++ b/test/sql/function/table/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library_unity(test_table_function OBJECT table_in_out.cpp
-                  table_bind_replace.cpp)
+                  table_bind_replace.cpp table_function_limit_hint.cpp)
 set(UNITTEST_OBJECT_FILES
     ${UNITTEST_OBJECT_FILES} $<TARGET_OBJECTS:test_table_function>
     PARENT_SCOPE)

--- a/test/sql/function/table/table_function_limit_hint.cpp
+++ b/test/sql/function/table/table_function_limit_hint.cpp
@@ -1,0 +1,174 @@
+#include "catch.hpp"
+#include "test_helpers.hpp"
+
+#include "duckdb/execution/operator/scan/physical_table_scan.hpp"
+#include "duckdb/main/prepared_statement_data.hpp"
+#include "duckdb/parser/parsed_data/create_table_function_info.hpp"
+
+using namespace duckdb;
+
+struct LimitHintProbe {
+	struct BindData : public TableFunctionData {
+		idx_t max_rows = 0;
+	};
+
+	struct GlobalState : public GlobalTableFunctionState {
+		optional_idx limit;
+
+		idx_t MaxThreads() const override {
+			return 8;
+		}
+	};
+
+	struct LocalState : public LocalTableFunctionState {
+		optional_idx limit;
+		idx_t row_idx = 0;
+	};
+
+	static duckdb::unique_ptr<FunctionData> Bind(ClientContext &context, TableFunctionBindInput &input,
+	                                             duckdb::vector<LogicalType> &return_types,
+	                                             duckdb::vector<duckdb::string> &names) {
+		auto result = make_uniq<BindData>();
+		result->max_rows = NumericCast<idx_t>(input.inputs[0].GetValue<int64_t>());
+
+		return_types.emplace_back(LogicalType::BIGINT);
+		names.emplace_back("row_idx");
+		return_types.emplace_back(LogicalType::BIGINT);
+		names.emplace_back("global_limit");
+		return_types.emplace_back(LogicalType::BIGINT);
+		names.emplace_back("local_limit");
+
+		return std::move(result);
+	}
+
+	static duckdb::unique_ptr<GlobalTableFunctionState> InitGlobal(ClientContext &context,
+	                                                               TableFunctionInitInput &input) {
+		auto result = make_uniq<GlobalState>();
+		result->limit = input.limit;
+		return std::move(result);
+	}
+
+	static duckdb::unique_ptr<LocalTableFunctionState>
+	InitLocal(ExecutionContext &context, TableFunctionInitInput &input, GlobalTableFunctionState *global_state) {
+		auto result = make_uniq<LocalState>();
+		result->limit = input.limit;
+		return std::move(result);
+	}
+
+	static void SetLimitValue(Vector &result, idx_t row_idx, optional_idx limit) {
+		if (limit.IsValid()) {
+			result.SetValue(row_idx, Value::BIGINT(NumericCast<int64_t>(limit.GetIndex())));
+		} else {
+			result.SetValue(row_idx, Value(LogicalType::BIGINT));
+		}
+	}
+
+	static void Function(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+		auto &bind = data_p.bind_data->Cast<BindData>();
+		auto &global_state = data_p.global_state->Cast<GlobalState>();
+		auto &local_state = data_p.local_state->Cast<LocalState>();
+
+		if (local_state.row_idx >= bind.max_rows) {
+			return;
+		}
+
+		auto count = MinValue<idx_t>(STANDARD_VECTOR_SIZE, bind.max_rows - local_state.row_idx);
+		output.SetChildCardinality(count);
+		for (idx_t idx = 0; idx < count; idx++) {
+			output.data[0].SetValue(idx, Value::BIGINT(NumericCast<int64_t>(local_state.row_idx + idx)));
+			SetLimitValue(output.data[1], idx, global_state.limit);
+			SetLimitValue(output.data[2], idx, local_state.limit);
+		}
+		local_state.row_idx += count;
+	}
+
+	static void Register(Connection &con) {
+		con.BeginTransaction();
+		auto &catalog = Catalog::GetSystemCatalog(*con.context);
+		TableFunction function("limit_hint_probe", {LogicalType::BIGINT}, LimitHintProbe::Function,
+		                       LimitHintProbe::Bind, LimitHintProbe::InitGlobal, LimitHintProbe::InitLocal);
+		CreateTableFunctionInfo info(function);
+		catalog.CreateTableFunction(*con.context, info);
+		con.Commit();
+	}
+};
+
+static const PhysicalTableScan *FindTableScan(const PhysicalOperator &op) {
+	if (op.type == PhysicalOperatorType::TABLE_SCAN) {
+		return &op.Cast<PhysicalTableScan>();
+	}
+	for (auto &child : op.GetChildren()) {
+		auto result = FindTableScan(child.get());
+		if (result) {
+			return result;
+		}
+	}
+	return nullptr;
+}
+
+TEST_CASE("Table function limit pushdown", "[table_function]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	LimitHintProbe::Register(con);
+
+	auto no_limit = con.Query("SELECT global_limit IS NULL, local_limit IS NULL FROM limit_hint_probe(1)");
+	REQUIRE_NO_FAIL(*no_limit);
+	REQUIRE(CHECK_COLUMN(no_limit, 0, {true}));
+	REQUIRE(CHECK_COLUMN(no_limit, 1, {true}));
+
+	auto simple_limit = con.Query("SELECT global_limit, local_limit FROM limit_hint_probe(10) LIMIT 3");
+	REQUIRE_NO_FAIL(*simple_limit);
+	REQUIRE(CHECK_COLUMN(simple_limit, 0, {3, 3, 3}));
+	REQUIRE(CHECK_COLUMN(simple_limit, 1, {3, 3, 3}));
+
+	auto offset_limit =
+	    con.Query("SELECT row_idx, global_limit, local_limit FROM limit_hint_probe(10) LIMIT 3 OFFSET 2");
+	REQUIRE_NO_FAIL(*offset_limit);
+	REQUIRE(CHECK_COLUMN(offset_limit, 0, {2, 3, 4}));
+	REQUIRE(CHECK_COLUMN(offset_limit, 1, {5, 5, 5}));
+	REQUIRE(CHECK_COLUMN(offset_limit, 2, {5, 5, 5}));
+
+	auto projection = con.Query("SELECT global_limit + 0, local_limit + 0 FROM limit_hint_probe(10) LIMIT 3");
+	REQUIRE_NO_FAIL(*projection);
+	REQUIRE(CHECK_COLUMN(projection, 0, {3, 3, 3}));
+	REQUIRE(CHECK_COLUMN(projection, 1, {3, 3, 3}));
+
+	auto filter = con.Query(
+	    "SELECT global_limit IS NULL, local_limit IS NULL FROM limit_hint_probe(10) WHERE row_idx > 0 LIMIT 3");
+	REQUIRE_NO_FAIL(*filter);
+	REQUIRE(CHECK_COLUMN(filter, 0, {true, true, true}));
+	REQUIRE(CHECK_COLUMN(filter, 1, {true, true, true}));
+
+	auto order = con.Query(
+	    "SELECT global_limit IS NULL, local_limit IS NULL FROM limit_hint_probe(10) ORDER BY row_idx LIMIT 3");
+	REQUIRE_NO_FAIL(*order);
+	REQUIRE(CHECK_COLUMN(order, 0, {true, true, true}));
+	REQUIRE(CHECK_COLUMN(order, 1, {true, true, true}));
+
+	auto threshold = con.Query("SELECT bool_and(global_limit = 8192), bool_and(local_limit = 8192), count(*) "
+	                           "FROM (SELECT global_limit, local_limit FROM limit_hint_probe(9000) LIMIT 8192)");
+	REQUIRE_NO_FAIL(*threshold);
+	REQUIRE(CHECK_COLUMN(threshold, 0, {true}));
+	REQUIRE(CHECK_COLUMN(threshold, 1, {true}));
+	REQUIRE(CHECK_COLUMN(threshold, 2, {8192}));
+
+	auto large_projection = con.Query("SELECT bool_and(global_limit = 9000), bool_and(local_limit = 9000), count(*) "
+	                                  "FROM (SELECT global_limit + 0 AS global_limit, local_limit + 0 AS local_limit "
+	                                  "FROM limit_hint_probe(10000) LIMIT 9000)");
+	REQUIRE_NO_FAIL(*large_projection);
+	REQUIRE(CHECK_COLUMN(large_projection, 0, {true}));
+	REQUIRE(CHECK_COLUMN(large_projection, 1, {true}));
+	REQUIRE(CHECK_COLUMN(large_projection, 2, {9000}));
+
+	auto limited = con.Prepare("SELECT row_idx FROM limit_hint_probe(10) LIMIT 3");
+	REQUIRE(!limited->HasError());
+	auto limited_scan = FindTableScan(limited->data->physical_plan->Root());
+	REQUIRE(limited_scan);
+	REQUIRE(limited_scan->ParallelSource());
+
+	auto unlimited = con.Prepare("SELECT row_idx FROM limit_hint_probe(10)");
+	REQUIRE(!unlimited->HasError());
+	auto unlimited_scan = FindTableScan(unlimited->data->physical_plan->Root());
+	REQUIRE(unlimited_scan);
+	REQUIRE(unlimited_scan->ParallelSource());
+}


### PR DESCRIPTION
## Background

DuckDB table functions already receive several scan-level properties during initialization, such as projected columns and filters. This lets table functions avoid unnecessary work when the optimizer can prove that only part of the source needs to be read.

There is currently no equivalent way for a C++ table function to observe a query-level `LIMIT` at scan initialization time. This matters for extensions that read from external systems, remote APIs, lakehouse metadata, or paginated sources, where knowing a conservative upper bound can avoid opening extra files, planning extra splits, or issuing extra remote requests.

I noticed that similar needs have come up in a few DuckDB repositories. In the main DuckDB repository, [duckdb/duckdb#5065](https://github.com/duckdb/duckdb/issues/5065) asks about pushing offset/limit down to the data access layer for an Arrow scanner. In the Postgres extension, [duckdb/duckdb-postgres#233](https://github.com/duckdb/duckdb-postgres/issues/233) reported that `LIMIT` was not pushed down and caused the entire table to be copied, which was later addressed by [duckdb/duckdb-postgres#313](https://github.com/duckdb/duckdb-postgres/pull/313). In the Iceberg extension, [duckdb/duckdb-iceberg#55](https://github.com/duckdb/duckdb-iceberg/issues/55) also contains user reports around `LIMIT` not being pushed into `iceberg_scan`.

Those implementations are necessarily extension-specific today. This PR adds a small core-level hint so C++ table functions can observe a conservative limit bound during scan initialization, while DuckDB still keeps the real limit operator in the plan.

## Changes

- Add an advisory `limit` field to the C++ `TableFunctionInitInput`; the C table function API is unchanged.
- Propagate constant `LIMIT` and `LIMIT/OFFSET` bounds into simple table scans, including projection-above-scan cases.
- Keep the existing limit operators in the plan; the hint is for scan planning only and does not change correctness semantics.
- Keep propagation conservative: no filters, order/top-n, joins, aggregates, windows, table-in-out input, overflowed bounds, or other row-changing operators.
- Keep this separate from the existing small-limit projection rewrite, so larger limits can still be exposed as scan hints.

## Testing

Added a C++ table-function test that records the observed limit during global and local initialization, covering limited and unlimited scans plus conservative non-propagation cases.
