### PR TITLE
Allow more expressions in PositionExpression

### DIFF
--- a/src/include/duckdb/parser/peg/inlined_grammar.gram
+++ b/src/include/duckdb/parser/peg/inlined_grammar.gram
@@ -1039,7 +1039,7 @@ LambdaExpression <- 'LAMBDA' List(ColIdOrString) ':' Expression
 NullIfExpression <- 'NULLIF' Parens(NullIfArguments)
 NullIfArguments <- Expression ',' Expression
 PositionExpression <- 'POSITION' Parens(PositionArguments)
-PositionArguments <- SingleExpression 'IN' SingleExpression
+PositionArguments <- OtherOperatorExpression 'IN' Expression
 RowExpression <- 'ROW' Parens(List(Expression)?)
 SubstringExpression <- 'SUBSTRING' Parens(SubstringArguments)
 SubstringArguments <- SubstringParameters / SubstringExpressionList

--- a/src/include/duckdb/parser/peg/inlined_grammar.hpp
+++ b/src/include/duckdb/parser/peg/inlined_grammar.hpp
@@ -1005,7 +1005,7 @@ const char INLINED_PEG_GRAMMAR[] = {
 	"NullIfExpression <- 'NULLIF' Parens(NullIfArguments)\n"
 	"NullIfArguments <- Expression ',' Expression\n"
 	"PositionExpression <- 'POSITION' Parens(PositionArguments)\n"
-	"PositionArguments <- SingleExpression 'IN' SingleExpression\n"
+	"PositionArguments <- OtherOperatorExpression 'IN' Expression\n"
 	"RowExpression <- 'ROW' Parens(List(Expression)?)\n"
 	"SubstringExpression <- 'SUBSTRING' Parens(SubstringArguments)\n"
 	"SubstringArguments <- SubstringParameters / SubstringExpressionList\n"

--- a/src/include/duckdb/parser/peg/transformer/peg_transformer.hpp
+++ b/src/include/duckdb/parser/peg/transformer/peg_transformer.hpp
@@ -2797,8 +2797,8 @@ public:
 	static unique_ptr<TransformResultValue> TransformPositionArgumentsInternal(PEGTransformer &transformer,
 	                                                                           ParseResult &parse_result);
 	static vector<unique_ptr<ParsedExpression>>
-	TransformPositionArguments(PEGTransformer &transformer, unique_ptr<ParsedExpression> single_expression,
-	                           unique_ptr<ParsedExpression> single_expression_1);
+	TransformPositionArguments(PEGTransformer &transformer, unique_ptr<ParsedExpression> other_operator_expression,
+	                           unique_ptr<ParsedExpression> expression);
 	static unique_ptr<TransformResultValue> TransformRowExpressionInternal(PEGTransformer &transformer,
 	                                                                       ParseResult &parse_result);
 	static unique_ptr<ParsedExpression>

--- a/src/parser/peg/grammar/statements/expression.gram
+++ b/src/parser/peg/grammar/statements/expression.gram
@@ -301,7 +301,7 @@ LambdaExpression <- 'LAMBDA' List(ColIdOrString) ':' Expression
 NullIfExpression <- 'NULLIF' Parens(NullIfArguments)
 NullIfArguments <- Expression ',' Expression
 PositionExpression <- 'POSITION' Parens(PositionArguments)
-PositionArguments <- SingleExpression 'IN' SingleExpression
+PositionArguments <- OtherOperatorExpression 'IN' Expression
 RowExpression <- 'ROW' Parens(List(Expression)?)
 SubstringExpression <- 'SUBSTRING' Parens(SubstringArguments)
 SubstringArguments <- SubstringParameters / SubstringExpressionList

--- a/src/parser/peg/transformer/transform_expression.cpp
+++ b/src/parser/peg/transformer/transform_expression.cpp
@@ -2397,11 +2397,11 @@ PEGTransformerFactory::TransformPositionExpression(PEGTransformer &transformer,
 
 vector<unique_ptr<ParsedExpression>>
 PEGTransformerFactory::TransformPositionArguments(PEGTransformer &transformer,
-                                                  unique_ptr<ParsedExpression> single_expression,
-                                                  unique_ptr<ParsedExpression> single_expression_1) {
+                                                  unique_ptr<ParsedExpression> other_operator_expression,
+                                                  unique_ptr<ParsedExpression> expression) {
 	vector<unique_ptr<ParsedExpression>> result;
-	result.push_back(std::move(single_expression_1));
-	result.push_back(std::move(single_expression));
+	result.push_back(std::move(expression));
+	result.push_back(std::move(other_operator_expression));
 	return result;
 }
 

--- a/src/parser/peg/transformer/transform_generated.cpp
+++ b/src/parser/peg/transformer/transform_generated.cpp
@@ -6651,9 +6651,9 @@ unique_ptr<TransformResultValue> PEGTransformerFactory::TransformPositionExpress
 unique_ptr<TransformResultValue> PEGTransformerFactory::TransformPositionArgumentsInternal(PEGTransformer &transformer,
                                                                                            ParseResult &parse_result) {
 	auto &list_pr = parse_result.Cast<ListParseResult>();
-	auto single_expression = transformer.Transform<unique_ptr<ParsedExpression>>(list_pr.GetChild(0));
-	auto single_expression_1 = transformer.Transform<unique_ptr<ParsedExpression>>(list_pr.GetChild(2));
-	auto result = TransformPositionArguments(transformer, std::move(single_expression), std::move(single_expression_1));
+	auto other_operator_expression = transformer.Transform<unique_ptr<ParsedExpression>>(list_pr.GetChild(0));
+	auto expression = transformer.Transform<unique_ptr<ParsedExpression>>(list_pr.GetChild(2));
+	auto result = TransformPositionArguments(transformer, std::move(other_operator_expression), std::move(expression));
 	return make_uniq<TypedTransformResult<vector<unique_ptr<ParsedExpression>>>>(std::move(result));
 }
 

--- a/test/sql/peg_parser/parser/position.test
+++ b/test/sql/peg_parser/parser/position.test
@@ -1,0 +1,17 @@
+# name: test/sql/peg_parser/parser/position.test
+# description: Test POSITION syntax in peg parser
+# group: [parser]
+
+require autocomplete
+
+statement ok
+CALL check_peg_parser($TEST_PEG_PARSER$SELECT POSITION('a' || 'b' IN 'xab')$TEST_PEG_PARSER$);
+
+statement ok
+CALL check_peg_parser($TEST_PEG_PARSER$SELECT POSITION('a' IN 'x' || 'ab')$TEST_PEG_PARSER$);
+
+statement ok
+CALL check_peg_parser($TEST_PEG_PARSER$SELECT POSITION(lower('A') IN 'xab')$TEST_PEG_PARSER$);
+
+statement ok
+CALL check_peg_parser($TEST_PEG_PARSER$SELECT POSITION(lower('A') || 'b' IN 'xab')$TEST_PEG_PARSER$);


### PR DESCRIPTION
Part of: https://github.com/duckdblabs/duckdb-internal/issues/9093

Fixes the regression in the `POSITION` expression introduced by the PEG Parser: 
```
query I
SELECT POSITION('a' || 'b' IN 'xab')
----
2

query I
SELECT POSITION('a' IN 'x' || 'ab')
----
2
```

Previously it was restricted by `SingleExpression`, but we can be more lenient. 