### PR TITLE
Fix FORCE INSTALL being ignored by new PEG parser

### DIFF
--- a/src/parser/peg/transformer/transform_load.cpp
+++ b/src/parser/peg/transformer/transform_load.cpp
@@ -32,7 +32,7 @@ unique_ptr<SQLStatement> PEGTransformerFactory::TransformInstallStatement(
     const optional<ExtensionRepositoryInfo> &from_source, const optional<string> &version_number) {
 	auto result = make_uniq<LoadStatement>();
 	auto info = make_uniq<LoadInfo>();
-	info->load_type = LoadType::INSTALL;
+	info->load_type = has_result ? LoadType::FORCE_INSTALL : LoadType::INSTALL;
 	info->filename = identifier_or_string_literal.Name().GetIdentifierName();
 	info->repo_is_alias = false;
 	if (from_source) {

--- a/test/common/CMakeLists.txt
+++ b/test/common/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library_unity(
   test_lru_cache.cpp
   test_numeric_cast.cpp
   test_parse_expression.cpp
+  test_parse_load_statement.cpp
   test_parse_logical_type.cpp
   test_utf.cpp
   test_allocator_debug_info.cpp

--- a/test/common/test_parse_load_statement.cpp
+++ b/test/common/test_parse_load_statement.cpp
@@ -1,0 +1,25 @@
+#include "catch.hpp"
+#include "duckdb/parser/parser.hpp"
+#include "duckdb/parser/statement/load_statement.hpp"
+#include "test_helpers.hpp"
+
+using namespace duckdb;
+
+static duckdb::unique_ptr<LoadInfo> ParseLoad(const string &query) {
+	Parser parser;
+	parser.ParseQuery(query);
+	REQUIRE(parser.statements.size() == 1);
+	REQUIRE(parser.statements[0]->type == StatementType::LOAD_STATEMENT);
+	return parser.statements[0]->Cast<LoadStatement>().info->Copy();
+}
+
+TEST_CASE("Parse INSTALL / FORCE INSTALL statements", "[parse_load]") {
+	REQUIRE(ParseLoad("INSTALL x")->load_type == LoadType::INSTALL);
+	REQUIRE(ParseLoad("FORCE INSTALL x")->load_type == LoadType::FORCE_INSTALL);
+
+	auto from_repo = ParseLoad("FORCE INSTALL x FROM 'some_repo'");
+	REQUIRE(from_repo->load_type == LoadType::FORCE_INSTALL);
+	REQUIRE(from_repo->repository == "some_repo");
+
+	REQUIRE(ParseLoad("LOAD x")->load_type == LoadType::LOAD);
+}


### PR DESCRIPTION
The new SQL parser dropped the `FORCE` keyword when parsing `FORCE INSTALL`, so it was treated like a plain `INSTALL`. As a result, force-installing an extension that was already installed from a different source failed with a confusing error telling the user to rerun with `FORCE INSTALL`.

Keep the `FORCE` keyword and add a parser test.

Fixes https://github.com/duckdblabs/duckdb-internal/issues/9782

Not a problem in v1.5-variegata, which still uses the old PEG parser.