### PR TITLE
make unittest cli/config parsing lenient with lists

### DIFF
--- a/test/helpers/test_config.cpp
+++ b/test/helpers/test_config.cpp
@@ -226,7 +226,20 @@ bool TestConfiguration::TryParseOption(const string &name, const Value &value) {
 		return false;
 	}
 	auto &test_config = test_config_options[config_index.GetIndex()];
-	auto parameter = value.DefaultCastAs(test_config.type);
+	// Config values arrive as strings, parsed as SQL types. Lists in particular are
+	// user-unfriendly, requiring [] wrappers instead of just-plain-commas.
+	// Help out here, and add [] for list params. This intentionally also
+	// allows a meaningful '' empty arg to work for list-type params,
+	// eg --skip-error-messages '' -> [], and 'HTTP' -> [HTTP]
+	Value to_cast = value;
+	if (test_config.type.id() == LogicalTypeId::LIST && value.type().id() == LogicalTypeId::VARCHAR &&
+	    !value.IsNull()) {
+		auto str = value.GetValue<string>();
+		if (str.empty() || str[0] != '[') {
+			to_cast = Value("[" + str + "]");
+		}
+	}
+	auto parameter = to_cast.DefaultCastAs(test_config.type);
 	if (test_config.on_set_option) {
 		test_config.on_set_option(parameter);
 	}


### PR DESCRIPTION
Simple tweak for dev friendliness: when a list-of-strings does not begin with a '[', add the [] wrapper to it.

That gives you by example:
- `--skip-error-messages ''` — was a hard crash, now → [] (empty set).
- `--skip-error-messages 'HTTP'` — was a crash, now → [HTTP].
- `--skip-error-messages 'X,Y'` — was a crash, now → [X,Y].
- `--skip-error-messages '[]'` — worked before, still works, also with any valid items in the brackets.