### PR TITLE
Add 'connection' secret storage, for connection scoped contexts

### DIFF
--- a/src/include/duckdb/main/secret/secret_manager.hpp
+++ b/src/include/duckdb/main/secret/secret_manager.hpp
@@ -99,6 +99,8 @@ public:
 	static constexpr const char *TEMPORARY_STORAGE_NAME = "memory";
 	static constexpr const char *LOCAL_FILE_STORAGE_NAME = "local_file";
 	static constexpr const char *TRANSACTION_STORAGE_NAME = "transaction";
+	//! Connection-scoped storage: secrets live only for the creating connection and are reaped when it closes.
+	static constexpr const char *CONNECTION_STORAGE_NAME = "connection";
 
 	//! Static Helper Functions
 	DUCKDB_API static SecretManager &Get(ClientContext &context);

--- a/src/include/duckdb/main/secret/secret_storage.hpp
+++ b/src/include/duckdb/main/secret/secret_storage.hpp
@@ -37,8 +37,10 @@ public:
 	    : storage_name(name), tie_break_offset(tie_break_offset), persistent(false) {};
 	virtual ~SecretStorage() = default;
 
-	//! Default storage backend offsets
+	//! Default storage backend offsets. Lower offsets win tie-breaks (equal path-match score), so the connection-scoped
+	//! storage is preferred over the global ones when a connection secret and a global secret match equally well.
 	static const int64_t TRANSACTION_STORAGE_OFFSET = 0;
+	static const int64_t CONNECTION_STORAGE_OFFSET = 5;
 	static const int64_t TEMPORARY_STORAGE_OFFSET = 10;
 	static const int64_t LOCAL_FILE_STORAGE_OFFSET = 20;
 
@@ -181,6 +183,30 @@ protected:
 	identifier_set_t persistent_secrets;
 	//! Path that is searched for secrets;
 	string secret_path;
+};
+
+//! A secret storage whose secrets are scoped to the calling connection. It is registered once on the SecretManager but
+//! presents a per-ClientContext view: every operation reads the connection out of the passed CatalogTransaction and
+//! works only on that connection's secrets, which live in a state object on the connection's RegisteredStateManager.
+//! That gives automatic, crash-robust cleanup (the secrets die with the ClientContext) and full isolation between
+//! connections. A context-less lookup (e.g. a system/background call) simply returns no match, so it never leaks
+//! across connections and never resolves where there is no connection to attribute the request to.
+class ConnectionSecretStorage : public SecretStorage {
+public:
+	explicit ConnectionSecretStorage(const string &name_p) : SecretStorage(name_p, CONNECTION_STORAGE_OFFSET) {
+		// persistent stays false (base default): these secrets are connection-lifetime only.
+	}
+
+public:
+	unique_ptr<SecretEntry> StoreSecret(unique_ptr<const BaseSecret> secret, OnCreateConflict on_conflict,
+	                                    optional_ptr<CatalogTransaction> transaction = nullptr) override;
+	vector<SecretEntry> AllSecrets(optional_ptr<CatalogTransaction> transaction = nullptr) override;
+	void DropSecretByName(const Identifier &name, OnEntryNotFound on_entry_not_found,
+	                      optional_ptr<CatalogTransaction> transaction = nullptr) override;
+	SecretMatch LookupSecret(const string &path, const string &type,
+	                         optional_ptr<CatalogTransaction> transaction = nullptr) override;
+	unique_ptr<SecretEntry> GetSecretByName(const string &name,
+	                                        optional_ptr<CatalogTransaction> transaction = nullptr) override;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/main/secret/secret_storage.hpp
+++ b/src/include/duckdb/main/secret/secret_storage.hpp
@@ -191,6 +191,8 @@ protected:
 //! That gives automatic, crash-robust cleanup (the secrets die with the ClientContext) and full isolation between
 //! connections. A context-less lookup (e.g. a system/background call) simply returns no match, so it never leaks
 //! across connections and never resolves where there is no connection to attribute the request to.
+//! The per-connection container is a CatalogSet, so these secrets get the same MVCC visibility and rollback behaviour
+//! as the global storages: a CREATE or DROP inside an aborted transaction is undone.
 class ConnectionSecretStorage : public SecretStorage {
 public:
 	explicit ConnectionSecretStorage(const string &name_p) : SecretStorage(name_p, CONNECTION_STORAGE_OFFSET) {

--- a/src/include/duckdb/main/secret/secret_storage.hpp
+++ b/src/include/duckdb/main/secret/secret_storage.hpp
@@ -191,8 +191,8 @@ protected:
 //! That gives automatic, crash-robust cleanup (the secrets die with the ClientContext) and full isolation between
 //! connections. A context-less lookup (e.g. a system/background call) simply returns no match, so it never leaks
 //! across connections and never resolves where there is no connection to attribute the request to.
-//! The per-connection container is a CatalogSet, so these secrets get the same MVCC visibility and rollback behaviour
-//! as the global storages: a CREATE or DROP inside an aborted transaction is undone.
+//! The container keeps the pre-image of every secret the active transaction touched, so a CREATE or DROP inside an
+//! aborted transaction is undone, like in the global storages.
 class ConnectionSecretStorage : public SecretStorage {
 public:
 	explicit ConnectionSecretStorage(const string &name_p) : SecretStorage(name_p, CONNECTION_STORAGE_OFFSET) {

--- a/src/main/secret/secret_manager.cpp
+++ b/src/main/secret/secret_manager.cpp
@@ -173,10 +173,12 @@ unique_ptr<SecretEntry> SecretManager::RegisterSecretInternal(CatalogTransaction
 	if (persist_type == SecretPersistType::DEFAULT) {
 		if (storage.empty()) {
 			persist_type = config.default_persist_type;
-		} else if (storage == TEMPORARY_STORAGE_NAME) {
-			persist_type = SecretPersistType::TEMPORARY;
 		} else {
-			persist_type = SecretPersistType::PERSISTENT;
+			// Derive the persist type from the named storage's own flag, so that *any* registered temporary storage
+			// (not only "memory") accepts a default `CREATE SECRET ... IN <storage>` without the TEMPORARY keyword.
+			auto storage_backend = GetSecretStorage(storage);
+			persist_type = (storage_backend && !storage_backend->Persistent()) ? SecretPersistType::TEMPORARY
+			                                                                   : SecretPersistType::PERSISTENT;
 		}
 	}
 
@@ -619,6 +621,10 @@ void SecretManager::InitializeSecrets(CatalogTransaction transaction) {
 
 		// load the tmp storage
 		LoadSecretStorageInternal(make_uniq<TemporarySecretStorage>(TEMPORARY_STORAGE_NAME, *transaction.db));
+
+		// load the connection-scoped storage: secrets created `IN connection_storage` are visible only to the
+		// connection that created them, and are dropped automatically when that connection closes.
+		LoadSecretStorageInternal(make_uniq<ConnectionSecretStorage>(CONNECTION_STORAGE_NAME));
 
 		if (config.allow_persistent_secrets) {
 			// load the persistent storage if enabled

--- a/src/main/secret/secret_manager.cpp
+++ b/src/main/secret/secret_manager.cpp
@@ -171,10 +171,12 @@ unique_ptr<SecretEntry> SecretManager::RegisterSecretInternal(CatalogTransaction
 	if (persist_type == SecretPersistType::DEFAULT) {
 		if (storage.empty()) {
 			persist_type = config.default_persist_type;
-		} else if (storage == TEMPORARY_STORAGE_NAME) {
-			persist_type = SecretPersistType::TEMPORARY;
 		} else {
-			persist_type = SecretPersistType::PERSISTENT;
+			// Derive the persist type from the named storage's own flag, so that *any* registered temporary storage
+			// (not only "memory") accepts a default `CREATE SECRET ... IN <storage>` without the TEMPORARY keyword.
+			auto storage_backend = GetSecretStorage(storage);
+			persist_type = (storage_backend && !storage_backend->Persistent()) ? SecretPersistType::TEMPORARY
+			                                                                   : SecretPersistType::PERSISTENT;
 		}
 	}
 
@@ -617,6 +619,10 @@ void SecretManager::InitializeSecrets(CatalogTransaction transaction) {
 
 		// load the tmp storage
 		LoadSecretStorageInternal(make_uniq<TemporarySecretStorage>(TEMPORARY_STORAGE_NAME, *transaction.db));
+
+		// load the connection-scoped storage: secrets created `IN connection_storage` are visible only to the
+		// connection that created them, and are dropped automatically when that connection closes.
+		LoadSecretStorageInternal(make_uniq<ConnectionSecretStorage>(CONNECTION_STORAGE_NAME));
 
 		if (config.allow_persistent_secrets) {
 			// load the persistent storage if enabled

--- a/src/main/secret/secret_storage.cpp
+++ b/src/main/secret/secret_storage.cpp
@@ -336,9 +336,13 @@ constexpr const char *CONNECTION_SECRET_STATE_KEY = "connection_secret_storage";
 
 //! Per-connection secret container. Lives on the ClientContext's RegisteredStateManager, so it is destroyed exactly
 //! when the connection (its ClientContext) goes away - giving automatic, crash-robust cleanup with no cooperation.
+//! The secrets are held in a CatalogSet so that they follow the transaction they were created in: an aborted
+//! transaction undoes the CREATE/DROP, exactly like the global storages. No mutex is needed, CatalogSet locks itself.
 struct ConnectionSecretState : public ClientContextState {
-	mutex lock;
-	identifier_map_t<unique_ptr<SecretEntry>> secrets;
+	explicit ConnectionSecretState(Catalog &catalog) : secrets(make_uniq<CatalogSet>(catalog)) {
+	}
+
+	unique_ptr<CatalogSet> secrets;
 };
 
 //! Fetch the calling connection's secret container. With create=false returns nullptr when there is no context or no
@@ -349,7 +353,8 @@ optional_ptr<ConnectionSecretState> GetConnectionState(optional_ptr<CatalogTrans
 	}
 	auto &context = transaction->GetContext();
 	if (create) {
-		return context.registered_state->GetOrCreate<ConnectionSecretState>(CONNECTION_SECRET_STATE_KEY).get();
+		auto &catalog = Catalog::GetSystemCatalog(*context.db);
+		return context.registered_state->GetOrCreate<ConnectionSecretState>(CONNECTION_SECRET_STATE_KEY, catalog).get();
 	}
 	return context.registered_state->Get<ConnectionSecretState>(CONNECTION_SECRET_STATE_KEY).get();
 }
@@ -363,29 +368,33 @@ unique_ptr<SecretEntry> ConnectionSecretStorage::StoreSecret(unique_ptr<const Ba
 	if (!state) {
 		throw InvalidInputException("Cannot create a connection-scoped secret without an active client context");
 	}
-	lock_guard<mutex> guard(state->lock);
-	// Copy the name: we std::move(secret) below, after which a reference into it would dangle and the entry would be
-	// inserted under a garbage key (breaking later name-keyed lookups like DROP / GetSecretByName).
+	auto &secrets = *state->secrets;
+	// Copy the name: we std::move(secret) below, after which a reference into it would dangle.
 	auto name = secret->GetName();
 
-	auto existing = state->secrets.find(name);
-	if (existing != state->secrets.end()) {
+	if (secrets.GetEntry(*transaction, name)) {
 		switch (on_conflict) {
 		case OnCreateConflict::ERROR_ON_CONFLICT:
 			throw InvalidInputException("Connection secret with name '%s' already exists", name.GetIdentifierName());
 		case OnCreateConflict::IGNORE_ON_CONFLICT:
-			return make_uniq<SecretEntry>(*existing->second);
-		default: // REPLACE_ON_CONFLICT
+			return nullptr;
+		case OnCreateConflict::REPLACE_ON_CONFLICT:
+			secrets.DropEntry(*transaction, name, true, true);
 			break;
+		default:
+			throw InternalException("unknown OnCreateConflict found while registering connection secret");
 		}
 	}
 
-	auto entry = make_uniq<SecretEntry>(std::move(secret));
-	entry->persist_type = SecretPersistType::TEMPORARY;
-	entry->storage_mode = storage_name;
-	auto result = make_uniq<SecretEntry>(*entry);
-	state->secrets[name] = std::move(entry);
-	return result;
+	auto secret_entry = make_uniq<SecretCatalogEntry>(std::move(secret), Catalog::GetSystemCatalog(*transaction->db));
+	secret_entry->temporary = true;
+	secret_entry->secret->storage_mode = storage_name;
+	secret_entry->secret->persist_type = SecretPersistType::TEMPORARY;
+	LogicalDependencyList dependencies;
+	secrets.CreateEntry(*transaction, name, std::move(secret_entry), dependencies);
+
+	auto &stored = secrets.GetEntry(*transaction, name)->Cast<SecretCatalogEntry>();
+	return make_uniq<SecretEntry>(*stored.secret);
 }
 
 SecretMatch ConnectionSecretStorage::LookupSecret(const string &path, const string &type,
@@ -395,13 +404,14 @@ SecretMatch ConnectionSecretStorage::LookupSecret(const string &path, const stri
 		// No connection context (or nothing stored yet) - decline, so the global storages serve this lookup.
 		return SecretMatch();
 	}
-	lock_guard<mutex> guard(state->lock);
 	auto best_match = SecretMatch();
-	for (auto &entry : state->secrets) {
-		if (entry.second->secret->GetType() == type) {
-			best_match = SelectBestMatch(*entry.second, path, tie_break_offset, best_match);
+	const std::function<void(CatalogEntry &)> callback = [&](CatalogEntry &entry) {
+		auto &cast_entry = entry.Cast<SecretCatalogEntry>();
+		if (cast_entry.secret->secret->GetType() == type) {
+			best_match = SelectBestMatch(*cast_entry.secret, path, tie_break_offset, best_match);
 		}
-	}
+	};
+	state->secrets->Scan(*transaction, callback);
 	return best_match;
 }
 
@@ -411,23 +421,21 @@ unique_ptr<SecretEntry> ConnectionSecretStorage::GetSecretByName(const string &n
 	if (!state) {
 		return nullptr;
 	}
-	lock_guard<mutex> guard(state->lock);
-	auto entry = state->secrets.find(Identifier(name));
-	if (entry == state->secrets.end()) {
+	auto entry = state->secrets->GetEntry(*transaction, Identifier(name));
+	if (!entry) {
 		return nullptr;
 	}
-	return make_uniq<SecretEntry>(*entry->second);
+	return make_uniq<SecretEntry>(*entry->Cast<SecretCatalogEntry>().secret);
 }
 
 void ConnectionSecretStorage::DropSecretByName(const Identifier &name, OnEntryNotFound on_entry_not_found,
                                                optional_ptr<CatalogTransaction> transaction) {
 	auto state = GetConnectionState(transaction, false);
-	idx_t erased = 0;
-	if (state) {
-		lock_guard<mutex> guard(state->lock);
-		erased = state->secrets.erase(name);
+	if (state && state->secrets->GetEntry(*transaction, name)) {
+		state->secrets->DropEntry(*transaction, name, true, true);
+		return;
 	}
-	if (erased == 0 && on_entry_not_found == OnEntryNotFound::THROW_EXCEPTION) {
+	if (on_entry_not_found == OnEntryNotFound::THROW_EXCEPTION) {
 		throw InvalidInputException("Connection secret with name '%s' not found", name.GetIdentifierName());
 	}
 }
@@ -438,10 +446,10 @@ vector<SecretEntry> ConnectionSecretStorage::AllSecrets(optional_ptr<CatalogTran
 	if (!state) {
 		return result;
 	}
-	lock_guard<mutex> guard(state->lock);
-	for (auto &entry : state->secrets) {
-		result.push_back(*entry.second);
-	}
+	const std::function<void(CatalogEntry &)> callback = [&](CatalogEntry &entry) {
+		result.push_back(*entry.Cast<SecretCatalogEntry>().secret);
+	};
+	state->secrets->Scan(*transaction, callback);
 	return result;
 }
 

--- a/src/main/secret/secret_storage.cpp
+++ b/src/main/secret/secret_storage.cpp
@@ -12,6 +12,12 @@
 #include "duckdb/main/secret/secret_manager.hpp"
 #include "duckdb/parser/parsed_data/create_secret_info.hpp"
 #include "duckdb/parser/statement/create_statement.hpp"
+#include "duckdb/catalog/catalog_transaction.hpp"
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/main/client_context_state.hpp"
+#include "duckdb/main/secret/secret.hpp"
 
 namespace duckdb {
 
@@ -319,6 +325,124 @@ void LocalFileSecretStorage::RemoveSecret(const string &secret, OnEntryNotFound 
 		}
 		throw;
 	}
+}
+
+//===--------------------------------------------------------------------===//
+// ConnectionSecretStorage
+//===--------------------------------------------------------------------===//
+namespace {
+
+constexpr const char *CONNECTION_SECRET_STATE_KEY = "connection_secret_storage";
+
+//! Per-connection secret container. Lives on the ClientContext's RegisteredStateManager, so it is destroyed exactly
+//! when the connection (its ClientContext) goes away - giving automatic, crash-robust cleanup with no cooperation.
+struct ConnectionSecretState : public ClientContextState {
+	mutex lock;
+	identifier_map_t<unique_ptr<SecretEntry>> secrets;
+};
+
+//! Fetch the calling connection's secret container. With create=false returns nullptr when there is no context or no
+//! container yet; with create=true it allocates the container on the context (used by StoreSecret).
+optional_ptr<ConnectionSecretState> GetConnectionState(optional_ptr<CatalogTransaction> transaction, bool create) {
+	if (!transaction || !transaction->HasContext()) {
+		return nullptr;
+	}
+	auto &context = transaction->GetContext();
+	if (create) {
+		return context.registered_state->GetOrCreate<ConnectionSecretState>(CONNECTION_SECRET_STATE_KEY).get();
+	}
+	return context.registered_state->Get<ConnectionSecretState>(CONNECTION_SECRET_STATE_KEY).get();
+}
+
+} // namespace
+
+unique_ptr<SecretEntry> ConnectionSecretStorage::StoreSecret(unique_ptr<const BaseSecret> secret,
+                                                             OnCreateConflict on_conflict,
+                                                             optional_ptr<CatalogTransaction> transaction) {
+	auto state = GetConnectionState(transaction, true);
+	if (!state) {
+		throw InvalidInputException("Cannot create a connection-scoped secret without an active client context");
+	}
+	lock_guard<mutex> guard(state->lock);
+	// Copy the name: we std::move(secret) below, after which a reference into it would dangle and the entry would be
+	// inserted under a garbage key (breaking later name-keyed lookups like DROP / GetSecretByName).
+	auto name = secret->GetName();
+
+	auto existing = state->secrets.find(name);
+	if (existing != state->secrets.end()) {
+		switch (on_conflict) {
+		case OnCreateConflict::ERROR_ON_CONFLICT:
+			throw InvalidInputException("Connection secret with name '%s' already exists", name.GetIdentifierName());
+		case OnCreateConflict::IGNORE_ON_CONFLICT:
+			return make_uniq<SecretEntry>(*existing->second);
+		default: // REPLACE_ON_CONFLICT
+			break;
+		}
+	}
+
+	auto entry = make_uniq<SecretEntry>(std::move(secret));
+	entry->persist_type = SecretPersistType::TEMPORARY;
+	entry->storage_mode = storage_name;
+	auto result = make_uniq<SecretEntry>(*entry);
+	state->secrets[name] = std::move(entry);
+	return result;
+}
+
+SecretMatch ConnectionSecretStorage::LookupSecret(const string &path, const string &type,
+                                                  optional_ptr<CatalogTransaction> transaction) {
+	auto state = GetConnectionState(transaction, false);
+	if (!state) {
+		// No connection context (or nothing stored yet) - decline, so the global storages serve this lookup.
+		return SecretMatch();
+	}
+	lock_guard<mutex> guard(state->lock);
+	auto best_match = SecretMatch();
+	for (auto &entry : state->secrets) {
+		if (entry.second->secret->GetType() == type) {
+			best_match = SelectBestMatch(*entry.second, path, tie_break_offset, best_match);
+		}
+	}
+	return best_match;
+}
+
+unique_ptr<SecretEntry> ConnectionSecretStorage::GetSecretByName(const string &name,
+                                                                 optional_ptr<CatalogTransaction> transaction) {
+	auto state = GetConnectionState(transaction, false);
+	if (!state) {
+		return nullptr;
+	}
+	lock_guard<mutex> guard(state->lock);
+	auto entry = state->secrets.find(Identifier(name));
+	if (entry == state->secrets.end()) {
+		return nullptr;
+	}
+	return make_uniq<SecretEntry>(*entry->second);
+}
+
+void ConnectionSecretStorage::DropSecretByName(const Identifier &name, OnEntryNotFound on_entry_not_found,
+                                               optional_ptr<CatalogTransaction> transaction) {
+	auto state = GetConnectionState(transaction, false);
+	idx_t erased = 0;
+	if (state) {
+		lock_guard<mutex> guard(state->lock);
+		erased = state->secrets.erase(name);
+	}
+	if (erased == 0 && on_entry_not_found == OnEntryNotFound::THROW_EXCEPTION) {
+		throw InvalidInputException("Connection secret with name '%s' not found", name.GetIdentifierName());
+	}
+}
+
+vector<SecretEntry> ConnectionSecretStorage::AllSecrets(optional_ptr<CatalogTransaction> transaction) {
+	vector<SecretEntry> result;
+	auto state = GetConnectionState(transaction, false);
+	if (!state) {
+		return result;
+	}
+	lock_guard<mutex> guard(state->lock);
+	for (auto &entry : state->secrets) {
+		result.push_back(*entry.second);
+	}
+	return result;
 }
 
 } // namespace duckdb

--- a/src/main/secret/secret_storage.cpp
+++ b/src/main/secret/secret_storage.cpp
@@ -419,7 +419,7 @@ unique_ptr<SecretEntry> ConnectionSecretStorage::StoreSecret(unique_ptr<const Ba
 		case OnCreateConflict::ERROR_ON_CONFLICT:
 			throw InvalidInputException("Connection secret with name '%s' already exists", name.GetIdentifierName());
 		case OnCreateConflict::IGNORE_ON_CONFLICT:
-			return make_uniq<SecretEntry>(*existing->second);
+			return nullptr;
 		default: // REPLACE_ON_CONFLICT
 			break;
 		}

--- a/src/main/secret/secret_storage.cpp
+++ b/src/main/secret/secret_storage.cpp
@@ -18,6 +18,7 @@
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/client_context_state.hpp"
 #include "duckdb/main/secret/secret.hpp"
+#include "duckdb/transaction/meta_transaction.hpp"
 
 namespace duckdb {
 
@@ -336,13 +337,53 @@ constexpr const char *CONNECTION_SECRET_STATE_KEY = "connection_secret_storage";
 
 //! Per-connection secret container. Lives on the ClientContext's RegisteredStateManager, so it is destroyed exactly
 //! when the connection (its ClientContext) goes away - giving automatic, crash-robust cleanup with no cooperation.
-//! The secrets are held in a CatalogSet so that they follow the transaction they were created in: an aborted
-//! transaction undoes the CREATE/DROP, exactly like the global storages. No mutex is needed, CatalogSet locks itself.
+//! Rollback is implemented here rather than by storing the secrets in a CatalogSet: the container is private to a
+//! single connection, and a connection runs one transaction at a time, so there is never a second snapshot to serve.
+//! All that is needed is undo - the pre-image of every secret the active transaction touched, replayed if it aborts.
 struct ConnectionSecretState : public ClientContextState {
-	explicit ConnectionSecretState(Catalog &catalog) : secrets(make_uniq<CatalogSet>(catalog)) {
+	mutex lock;
+	//! The secrets of this connection: the last committed state, plus the changes of the active transaction
+	identifier_map_t<unique_ptr<SecretEntry>> secrets;
+
+	//! Records the pre-image of `name` before the active transaction modifies it, so that a rollback can restore it.
+	//! Only the first change per name is recorded, making the undo replay order-independent.
+	void StageChange(MetaTransaction &transaction, const Identifier &name) {
+		if (undo_transaction_id != transaction.global_transaction_id) {
+			// First change of a new transaction: any leftover pre-images belong to a transaction that already ended
+			undo_log.clear();
+			undo_transaction_id = transaction.global_transaction_id;
+		}
+		if (undo_log.find(name) != undo_log.end()) {
+			return;
+		}
+		auto entry = secrets.find(name);
+		auto pre_image = entry == secrets.end() ? nullptr : make_uniq<SecretEntry>(*entry->second);
+		undo_log.emplace(name, std::move(pre_image));
 	}
 
-	unique_ptr<CatalogSet> secrets;
+	void TransactionCommit(MetaTransaction &transaction, ClientContext &context) override {
+		lock_guard<mutex> guard(lock);
+		undo_log.clear();
+	}
+
+	void TransactionRollback(MetaTransaction &transaction, ClientContext &context) override {
+		lock_guard<mutex> guard(lock);
+		for (auto &entry : undo_log) {
+			if (entry.second) {
+				secrets[entry.first] = std::move(entry.second);
+			} else {
+				// The secret did not exist before the transaction
+				secrets.erase(entry.first);
+			}
+		}
+		undo_log.clear();
+	}
+
+private:
+	//! Pre-images of the secrets modified by the active transaction, a null entry meaning "did not exist"
+	identifier_map_t<unique_ptr<SecretEntry>> undo_log;
+	//! The transaction the pre-images belong to
+	transaction_t undo_transaction_id = 0;
 };
 
 //! Fetch the calling connection's secret container. With create=false returns nullptr when there is no context or no
@@ -353,8 +394,7 @@ optional_ptr<ConnectionSecretState> GetConnectionState(optional_ptr<CatalogTrans
 	}
 	auto &context = transaction->GetContext();
 	if (create) {
-		auto &catalog = Catalog::GetSystemCatalog(*context.db);
-		return context.registered_state->GetOrCreate<ConnectionSecretState>(CONNECTION_SECRET_STATE_KEY, catalog).get();
+		return context.registered_state->GetOrCreate<ConnectionSecretState>(CONNECTION_SECRET_STATE_KEY).get();
 	}
 	return context.registered_state->Get<ConnectionSecretState>(CONNECTION_SECRET_STATE_KEY).get();
 }
@@ -368,33 +408,30 @@ unique_ptr<SecretEntry> ConnectionSecretStorage::StoreSecret(unique_ptr<const Ba
 	if (!state) {
 		throw InvalidInputException("Cannot create a connection-scoped secret without an active client context");
 	}
-	auto &secrets = *state->secrets;
-	// Copy the name: we std::move(secret) below, after which a reference into it would dangle.
+	lock_guard<mutex> guard(state->lock);
+	// Copy the name: we std::move(secret) below, after which a reference into it would dangle and the entry would be
+	// inserted under a garbage key (breaking later name-keyed lookups like DROP / GetSecretByName).
 	auto name = secret->GetName();
 
-	if (secrets.GetEntry(*transaction, name)) {
+	auto existing = state->secrets.find(name);
+	if (existing != state->secrets.end()) {
 		switch (on_conflict) {
 		case OnCreateConflict::ERROR_ON_CONFLICT:
 			throw InvalidInputException("Connection secret with name '%s' already exists", name.GetIdentifierName());
 		case OnCreateConflict::IGNORE_ON_CONFLICT:
-			return nullptr;
-		case OnCreateConflict::REPLACE_ON_CONFLICT:
-			secrets.DropEntry(*transaction, name, true, true);
+			return make_uniq<SecretEntry>(*existing->second);
+		default: // REPLACE_ON_CONFLICT
 			break;
-		default:
-			throw InternalException("unknown OnCreateConflict found while registering connection secret");
 		}
 	}
 
-	auto secret_entry = make_uniq<SecretCatalogEntry>(std::move(secret), Catalog::GetSystemCatalog(*transaction->db));
-	secret_entry->temporary = true;
-	secret_entry->secret->storage_mode = storage_name;
-	secret_entry->secret->persist_type = SecretPersistType::TEMPORARY;
-	LogicalDependencyList dependencies;
-	secrets.CreateEntry(*transaction, name, std::move(secret_entry), dependencies);
-
-	auto &stored = secrets.GetEntry(*transaction, name)->Cast<SecretCatalogEntry>();
-	return make_uniq<SecretEntry>(*stored.secret);
+	auto entry = make_uniq<SecretEntry>(std::move(secret));
+	entry->persist_type = SecretPersistType::TEMPORARY;
+	entry->storage_mode = storage_name;
+	auto result = make_uniq<SecretEntry>(*entry);
+	state->StageChange(MetaTransaction::Get(transaction->GetContext()), name);
+	state->secrets[name] = std::move(entry);
+	return result;
 }
 
 SecretMatch ConnectionSecretStorage::LookupSecret(const string &path, const string &type,
@@ -404,14 +441,13 @@ SecretMatch ConnectionSecretStorage::LookupSecret(const string &path, const stri
 		// No connection context (or nothing stored yet) - decline, so the global storages serve this lookup.
 		return SecretMatch();
 	}
+	lock_guard<mutex> guard(state->lock);
 	auto best_match = SecretMatch();
-	const std::function<void(CatalogEntry &)> callback = [&](CatalogEntry &entry) {
-		auto &cast_entry = entry.Cast<SecretCatalogEntry>();
-		if (cast_entry.secret->secret->GetType() == type) {
-			best_match = SelectBestMatch(*cast_entry.secret, path, tie_break_offset, best_match);
+	for (auto &entry : state->secrets) {
+		if (entry.second->secret->GetType() == type) {
+			best_match = SelectBestMatch(*entry.second, path, tie_break_offset, best_match);
 		}
-	};
-	state->secrets->Scan(*transaction, callback);
+	}
 	return best_match;
 }
 
@@ -421,21 +457,26 @@ unique_ptr<SecretEntry> ConnectionSecretStorage::GetSecretByName(const string &n
 	if (!state) {
 		return nullptr;
 	}
-	auto entry = state->secrets->GetEntry(*transaction, Identifier(name));
-	if (!entry) {
+	lock_guard<mutex> guard(state->lock);
+	auto entry = state->secrets.find(Identifier(name));
+	if (entry == state->secrets.end()) {
 		return nullptr;
 	}
-	return make_uniq<SecretEntry>(*entry->Cast<SecretCatalogEntry>().secret);
+	return make_uniq<SecretEntry>(*entry->second);
 }
 
 void ConnectionSecretStorage::DropSecretByName(const Identifier &name, OnEntryNotFound on_entry_not_found,
                                                optional_ptr<CatalogTransaction> transaction) {
 	auto state = GetConnectionState(transaction, false);
-	if (state && state->secrets->GetEntry(*transaction, name)) {
-		state->secrets->DropEntry(*transaction, name, true, true);
-		return;
+	idx_t erased = 0;
+	if (state) {
+		lock_guard<mutex> guard(state->lock);
+		if (state->secrets.find(name) != state->secrets.end()) {
+			state->StageChange(MetaTransaction::Get(transaction->GetContext()), name);
+			erased = state->secrets.erase(name);
+		}
 	}
-	if (on_entry_not_found == OnEntryNotFound::THROW_EXCEPTION) {
+	if (erased == 0 && on_entry_not_found == OnEntryNotFound::THROW_EXCEPTION) {
 		throw InvalidInputException("Connection secret with name '%s' not found", name.GetIdentifierName());
 	}
 }
@@ -446,10 +487,10 @@ vector<SecretEntry> ConnectionSecretStorage::AllSecrets(optional_ptr<CatalogTran
 	if (!state) {
 		return result;
 	}
-	const std::function<void(CatalogEntry &)> callback = [&](CatalogEntry &entry) {
-		result.push_back(*entry.Cast<SecretCatalogEntry>().secret);
-	};
-	state->secrets->Scan(*transaction, callback);
+	lock_guard<mutex> guard(state->lock);
+	for (auto &entry : state->secrets) {
+		result.push_back(*entry.second);
+	}
 	return result;
 }
 

--- a/src/parser/parsed_data/drop_info.cpp
+++ b/src/parser/parsed_data/drop_info.cpp
@@ -38,6 +38,13 @@ string DropInfo::ToString() const {
 				result += trigger_info.base_table->Cast<BaseTableRef>().ToString();
 			}
 		}
+		if (type == CatalogType::SECRET_ENTRY && extra_drop_info) {
+			// Preserve the `FROM <storage>` storage specifier so `DROP SECRET <name> FROM <storage>` round-trips.
+			auto &secret_info = extra_drop_info->Cast<ExtraDropSecretInfo>();
+			if (!secret_info.secret_storage.empty()) {
+				result += " FROM " + SQLIdentifier(secret_info.secret_storage);
+			}
+		}
 		if (cascade) {
 			result += " CASCADE";
 		}

--- a/test/api/CMakeLists.txt
+++ b/test/api/CMakeLists.txt
@@ -14,6 +14,7 @@ set(TEST_API_OBJECTS
     test_scalar_function_decimal_return.cpp
     test_aggregate_state_bind_data.cpp
     test_config.cpp
+    test_connection_secrets.cpp
     test_custom_allocator.cpp
     test_extension_setting_autoload.cpp
     test_instance_cache.cpp

--- a/test/api/test_connection_secrets.cpp
+++ b/test/api/test_connection_secrets.cpp
@@ -1,0 +1,61 @@
+#include "catch.hpp"
+#include "duckdb/main/connection.hpp"
+#include "duckdb/main/database.hpp"
+#include "test_helpers.hpp"
+
+using namespace duckdb;
+
+static idx_t ConnectionSecretCount(Connection &con) {
+	auto result = con.Query("SELECT count(*) FROM duckdb_secrets() WHERE storage = 'connection'");
+	REQUIRE_NO_FAIL(*result);
+	return static_cast<idx_t>(result->GetValue(0, 0).GetValue<int64_t>());
+}
+
+TEST_CASE("Test closing a connection that created connection secrets", "[api]") {
+	DuckDB database(nullptr);
+
+	// An older connection holds an open transaction, which keeps the transaction that creates the secret from being
+	// cleaned up when it commits
+	Connection older(database);
+	REQUIRE_NO_FAIL(older.Query("BEGIN"));
+	REQUIRE(ConnectionSecretCount(older) == 0);
+
+	{
+		Connection creator(database);
+		REQUIRE_NO_FAIL(creator.Query("CREATE SECRET s IN connection (TYPE http)"));
+		REQUIRE(ConnectionSecretCount(creator) == 1);
+	}
+
+	// The secrets of the closed connection are gone, and are never visible to another connection
+	REQUIRE(ConnectionSecretCount(older) == 0);
+	REQUIRE_NO_FAIL(older.Query("COMMIT"));
+	REQUIRE(ConnectionSecretCount(older) == 0);
+}
+
+TEST_CASE("Test rolling back connection secrets", "[api]") {
+	DuckDB database(nullptr);
+	Connection con(database);
+
+	REQUIRE_NO_FAIL(con.Query("CREATE SECRET s IN connection (TYPE http, SCOPE 'http://committed')"));
+
+	// A rolled-back replace restores the original secret, not just its name
+	REQUIRE_NO_FAIL(con.Query("BEGIN"));
+	REQUIRE_NO_FAIL(con.Query("CREATE OR REPLACE SECRET s IN connection (TYPE http, SCOPE 'http://replaced')"));
+	auto result = con.Query("SELECT scope[1] FROM duckdb_secrets() WHERE name = 's'");
+	REQUIRE(CHECK_COLUMN(result, 0, {Value("http://replaced")}));
+	REQUIRE_NO_FAIL(con.Query("ROLLBACK"));
+	result = con.Query("SELECT scope[1] FROM duckdb_secrets() WHERE name = 's'");
+	REQUIRE(CHECK_COLUMN(result, 0, {Value("http://committed")}));
+
+	// A secret created and dropped within the same aborted transaction does not come back
+	REQUIRE_NO_FAIL(con.Query("BEGIN"));
+	REQUIRE_NO_FAIL(con.Query("CREATE SECRET tmp IN connection (TYPE http)"));
+	REQUIRE_NO_FAIL(con.Query("DROP SECRET tmp FROM connection"));
+	REQUIRE_NO_FAIL(con.Query("ROLLBACK"));
+	REQUIRE(ConnectionSecretCount(con) == 1);
+
+	// A failing statement rolls back its own implicit transaction
+	REQUIRE_FAIL(con.Query("CREATE SECRET s IN connection (TYPE http)"));
+	result = con.Query("SELECT scope[1] FROM duckdb_secrets() WHERE name = 's'");
+	REQUIRE(CHECK_COLUMN(result, 0, {Value("http://committed")}));
+}

--- a/test/sql/secrets/connection_secret_storage.test
+++ b/test/sql/secrets/connection_secret_storage.test
@@ -82,3 +82,59 @@ statement error con1
 CREATE PERSISTENT SECRET s3 IN connection (TYPE http)
 ----
 Cannot create persistent secrets in a temporary secret storage
+
+# TRANSACTIONS: a rolled-back CREATE leaves no secret behind
+statement ok con1
+BEGIN
+
+statement ok con1
+CREATE SECRET txn_conn IN connection (TYPE http, SCOPE 'https://txn.example.com')
+
+# visible inside the transaction that created it
+query I con1
+SELECT count(*) FROM duckdb_secrets() WHERE name = 'txn_conn' AND storage = 'connection'
+----
+1
+
+statement ok con1
+ROLLBACK
+
+query I con1
+SELECT count(*) FROM duckdb_secrets() WHERE name = 'txn_conn' AND storage = 'connection'
+----
+0
+
+# and a committed one survives
+statement ok con1
+BEGIN
+
+statement ok con1
+CREATE SECRET txn_conn IN connection (TYPE http, SCOPE 'https://txn.example.com')
+
+statement ok con1
+COMMIT
+
+query I con1
+SELECT count(*) FROM duckdb_secrets() WHERE name = 'txn_conn' AND storage = 'connection'
+----
+1
+
+# a rolled-back DROP brings the secret back
+statement ok con1
+BEGIN
+
+statement ok con1
+DROP SECRET txn_conn FROM connection
+
+query I con1
+SELECT count(*) FROM duckdb_secrets() WHERE name = 'txn_conn' AND storage = 'connection'
+----
+0
+
+statement ok con1
+ROLLBACK
+
+query I con1
+SELECT count(*) FROM duckdb_secrets() WHERE name = 'txn_conn' AND storage = 'connection'
+----
+1

--- a/test/sql/secrets/connection_secret_storage.test
+++ b/test/sql/secrets/connection_secret_storage.test
@@ -1,0 +1,84 @@
+# name: test/sql/secrets/connection_secret_storage.test
+# description: connection-scoped secret storage - secrets created `IN connection` are isolated per connection
+# group: [secrets]
+
+require noforcestorage
+
+# Part 1: a named *temporary* storage accepts a default CREATE SECRET (no TEMPORARY keyword required).
+statement ok con1
+CREATE SECRET s1 IN connection (TYPE http, SCOPE 'https://a.example.com')
+
+# visible to the creating connection, in the connection storage
+query I con1
+SELECT count(*) FROM duckdb_secrets() WHERE name = 's1' AND storage = 'connection'
+----
+1
+
+# ISOLATION: a different connection does not see it
+query I con2
+SELECT count(*) FROM duckdb_secrets() WHERE name = 's1'
+----
+0
+
+# con2 can create its own, independent secret of the same name in its own connection storage
+statement ok con2
+CREATE SECRET s1 IN connection (TYPE http, SCOPE 'https://b.example.com')
+
+# each connection sees only its own scope
+query I con1
+SELECT scope = ['https://a.example.com'] FROM duckdb_secrets() WHERE name = 's1' AND storage = 'connection'
+----
+true
+
+query I con2
+SELECT scope = ['https://b.example.com'] FROM duckdb_secrets() WHERE name = 's1' AND storage = 'connection'
+----
+true
+
+# CREATE OR REPLACE updates within the connection
+statement ok con1
+CREATE OR REPLACE SECRET s1 IN connection (TYPE http, SCOPE 'https://a2.example.com')
+
+query I con1
+SELECT scope = ['https://a2.example.com'] FROM duckdb_secrets() WHERE name = 's1' AND storage = 'connection'
+----
+true
+
+# DROP ... FROM connection removes only the calling connection's secret
+statement ok con1
+DROP SECRET s1 FROM connection
+
+query I con1
+SELECT count(*) FROM duckdb_secrets() WHERE name = 's1' AND storage = 'connection'
+----
+0
+
+# con2's secret is untouched
+query I con2
+SELECT count(*) FROM duckdb_secrets() WHERE name = 's1' AND storage = 'connection'
+----
+1
+
+# dropping a non-existent connection secret errors (THROW), IF EXISTS does not
+statement error con1
+DROP SECRET nope FROM connection
+----
+not found
+
+statement ok con1
+DROP SECRET IF EXISTS nope FROM connection
+
+# explicit TEMPORARY keyword is also accepted (storage is temporary)
+statement ok con1
+CREATE TEMPORARY SECRET s2 IN connection (TYPE http, SCOPE 'https://c.example.com')
+
+query I con1
+SELECT count(*) FROM duckdb_secrets() WHERE name = 's2' AND storage = 'connection'
+----
+1
+
+# but a PERSISTENT secret cannot go into the temporary connection storage
+statement error con1
+CREATE PERSISTENT SECRET s3 IN connection (TYPE http)
+----
+Cannot create persistent secrets in a temporary secret storage


### PR DESCRIPTION
This is a by-product of https://github.com/duckdb/duckdb-quack/pull/187, where I tried to figure out how secrets could be passed onto quack, and this is the duckdb-side change that would make possible to store client-scoped secrets in a quack server (since 1 client = 1 Connection). I think this could be of some general usage, together with current default secret storage that are instance-wide.

Allows
```sql
CREATE SECRET <name> IN connection (...);
```
to be stored in a `Connection`-level secret storage, and be used only by query on the same Connection. This allows some degree of isolation between connections, given secrets that normally would clash and resolve all together can be scoped down to single connection.
`Connection` secret storage stores only `TEMPORARY` secrets.

Initial use case was connected to `quack`, and this can be implemented purely extension side (give secret manager is extensible), but this is general it's (in my view) worth landing in `duckdb/duckdb`.