### PR TITLE
Push down scalar functions to file readers

### DIFF
--- a/extension/parquet/include/column_reader.hpp
+++ b/extension/parquet/include/column_reader.hpp
@@ -172,7 +172,7 @@ public:
 	// register the range this reader will touch for prefetching
 	virtual void RegisterPrefetch(ThriftFileTransport &transport, bool allow_merge);
 
-	unique_ptr<BaseStatistics> Stats(idx_t row_group_idx_p, const vector<ColumnChunk> &columns);
+	virtual unique_ptr<BaseStatistics> Stats(idx_t row_group_idx_p, const vector<ColumnChunk> &columns);
 
 	template <class VALUE_TYPE, class CONVERSION, bool HAS_DEFINES>
 	void PlainTemplatedDefines(ByteBuffer &plain_data, const uint8_t *defines, uint64_t num_values, idx_t result_offset,

--- a/extension/parquet/include/parquet.json
+++ b/extension/parquet/include/parquet.json
@@ -35,6 +35,25 @@
     "pointer_type": "none"
   },
   {
+    "class": "ParquetReaderProjectionExpression",
+    "includes": [
+      "parquet_reader.hpp"
+    ],
+    "members": [
+      {
+        "id": 100,
+        "name": "type",
+        "type": "ParquetReaderProjectionExpressionType"
+      },
+      {
+        "id": 101,
+        "name": "return_type",
+        "type": "LogicalType"
+      }
+    ],
+    "pointer_type": "none"
+  },
+  {
     "class": "ParquetEncryptionConfig",
     "includes": [
       "parquet_crypto.hpp"

--- a/extension/parquet/include/parquet_column_schema.hpp
+++ b/extension/parquet/include/parquet_column_schema.hpp
@@ -12,6 +12,7 @@
 
 #include "duckdb.hpp"
 #include "parquet_types.h"
+#include "duckdb/common/column_index.hpp"
 #include "duckdb/common/optional_idx.hpp"
 #include "duckdb/common/string.hpp"
 #include "duckdb/common/typedefs.hpp"
@@ -80,6 +81,7 @@ public:
 
 public:
 	void SetSchemaIndex(idx_t schema_idx);
+	ParquetColumnSchema &ResolveExtractedChild(const ColumnIndex &column_id);
 
 public:
 	string name;

--- a/extension/parquet/include/parquet_column_schema.hpp
+++ b/extension/parquet/include/parquet_column_schema.hpp
@@ -12,7 +12,6 @@
 
 #include "duckdb.hpp"
 #include "parquet_types.h"
-#include "duckdb/common/column_index.hpp"
 #include "duckdb/common/optional_idx.hpp"
 #include "duckdb/common/string.hpp"
 #include "duckdb/common/typedefs.hpp"
@@ -81,7 +80,6 @@ public:
 
 public:
 	void SetSchemaIndex(idx_t schema_idx);
-	ParquetColumnSchema &ResolveExtractedChild(const ColumnIndex &column_id);
 
 public:
 	string name;

--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -296,6 +296,24 @@ struct ParquetUnionData : public BaseUnionData {
 	unique_ptr<ParquetColumnSchema> root_schema;
 };
 
+enum class ParquetReaderProjectionExpressionType : uint8_t {
+	BYTE_LENGTH,
+};
+
+template <>
+const char *EnumUtil::ToChars<ParquetReaderProjectionExpressionType>(ParquetReaderProjectionExpressionType value);
+
+template <>
+ParquetReaderProjectionExpressionType EnumUtil::FromString<ParquetReaderProjectionExpressionType>(const char *value);
+
+struct ParquetReaderProjectionExpression {
+	ParquetReaderProjectionExpressionType type;
+	LogicalType return_type;
+
+	void Serialize(Serializer &serializer) const;
+	static ParquetReaderProjectionExpression Deserialize(Deserializer &deserializer);
+};
+
 class ParquetReader : public BaseFileReader {
 public:
 	//! Virtual column identifier for the "file_row_group_number" column (the file-relative row group index of each row)
@@ -303,7 +321,8 @@ public:
 
 public:
 	ParquetReader(ClientContext &context, OpenFileInfo file, ParquetOptions parquet_options,
-	              shared_ptr<ParquetFileMetadataCache> metadata = nullptr);
+	              shared_ptr<ParquetFileMetadataCache> metadata = nullptr,
+	              unordered_map<idx_t, ParquetReaderProjectionExpression> projection_expressions = {});
 	~ParquetReader() override;
 
 	mutable CachingFileSystem fs;
@@ -314,6 +333,8 @@ public:
 	shared_ptr<EncryptionUtil> encryption_util;
 	//! How many rows have been read from this file
 	atomic<idx_t> rows_read;
+	//! Storage indices of columns where expressions like strlen/octet_length are pushed down
+	unordered_map<idx_t, ParquetReaderProjectionExpression> projection_expressions;
 
 public:
 	string GetReaderType() const override {

--- a/extension/parquet/include/reader/byte_array_length_column_reader.hpp
+++ b/extension/parquet/include/reader/byte_array_length_column_reader.hpp
@@ -1,0 +1,79 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// reader/byte_array_length_column_reader.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <stdint.h>
+
+#include "column_reader.hpp"
+#include "duckdb/common/constants.hpp"
+#include "duckdb/common/typedefs.hpp"
+#include "duckdb/common/types.hpp"
+#include "duckdb/common/shared_ptr_ipp.hpp"
+#include "resizable_buffer.hpp"
+
+namespace duckdb {
+class Vector;
+struct SelectionVector;
+struct ParquetColumnSchema;
+class ParquetReader;
+
+// Column reader that writes byte length of each value into a BIGINT vector.
+class ByteArrayLengthColumnReader : public ColumnReader {
+public:
+	static constexpr const PhysicalType TYPE = PhysicalType::INT64;
+
+	ByteArrayLengthColumnReader(const ParquetReader &reader, const ParquetColumnSchema &schema);
+
+	idx_t fixed_width_string_length;
+
+protected:
+	void Plain(ByteBuffer &plain_data, uint8_t *defines, idx_t num_values, idx_t result_offset,
+	           Vector &result) override {
+		throw NotImplementedException("ByteArrayLengthColumnReader requires shared-buffer Plain overload");
+	}
+	void Plain(shared_ptr<ResizeableBuffer> &plain_data, uint8_t *defines, idx_t num_values, idx_t result_offset,
+	           Vector &result) override;
+	void PlainSkip(ByteBuffer &plain_data, uint8_t *defines, idx_t num_values) override;
+	void PlainSelect(shared_ptr<ResizeableBuffer> &plain_data, uint8_t *defines, idx_t num_values, Vector &result,
+	                 const SelectionVector &sel, idx_t count) override;
+
+	bool SupportsDirectFilter() const override {
+		return true;
+	}
+	bool SupportsDirectSelect() const override {
+		return true;
+	}
+};
+
+struct ByteArrayLengthValueConversion {
+	template <bool CHECKED>
+	static int64_t PlainRead(ByteBuffer &plain_data, ColumnReader &reader) {
+		auto &r = reader.Cast<ByteArrayLengthColumnReader>();
+		const uint32_t len = r.fixed_width_string_length == DConstants::INVALID_INDEX ? plain_data.read<uint32_t>()
+		                                                                              : r.fixed_width_string_length;
+		plain_data.available(len);
+		plain_data.inc(len);
+		return static_cast<int64_t>(len);
+	}
+	template <bool CHECKED>
+	static void PlainSkip(ByteBuffer &plain_data, ColumnReader &reader) {
+		auto &r = reader.Cast<ByteArrayLengthColumnReader>();
+		const uint32_t len = r.fixed_width_string_length == DConstants::INVALID_INDEX ? plain_data.read<uint32_t>()
+		                                                                              : r.fixed_width_string_length;
+		plain_data.inc(len);
+	}
+	static bool PlainAvailable(const ByteBuffer &, const idx_t) {
+		return false;
+	}
+	static idx_t PlainConstantSize() {
+		return 0;
+	}
+};
+
+} // namespace duckdb

--- a/extension/parquet/include/reader/byte_array_length_column_reader.hpp
+++ b/extension/parquet/include/reader/byte_array_length_column_reader.hpp
@@ -32,6 +32,10 @@ public:
 
 	idx_t fixed_width_string_length;
 
+	unique_ptr<BaseStatistics> Stats(idx_t, const vector<ColumnChunk> &) override {
+		return {};
+	}
+
 protected:
 	void Plain(ByteBuffer &plain_data, uint8_t *defines, idx_t num_values, idx_t result_offset,
 	           Vector &result) override {

--- a/extension/parquet/parquet_column_schema.cpp
+++ b/extension/parquet/parquet_column_schema.cpp
@@ -17,6 +17,14 @@ void ParquetColumnSchema::SetSchemaIndex(idx_t schema_idx) {
 	schema_index = schema_idx;
 }
 
+ParquetColumnSchema &ParquetColumnSchema::ResolveExtractedChild(const ColumnIndex &column_id) {
+	if (!column_id.HasChildren()) {
+		return *this;
+	}
+	auto &child = column_id.GetChildIndex(0);
+	return children[child.GetPrimaryIndex()].ResolveExtractedChild(child);
+}
+
 //! Writer constructors
 
 ParquetColumnSchema ParquetColumnSchema::FromLogicalType(const Identifier &name, const LogicalType &type,

--- a/extension/parquet/parquet_column_schema.cpp
+++ b/extension/parquet/parquet_column_schema.cpp
@@ -17,14 +17,6 @@ void ParquetColumnSchema::SetSchemaIndex(idx_t schema_idx) {
 	schema_index = schema_idx;
 }
 
-ParquetColumnSchema &ParquetColumnSchema::ResolveExtractedChild(const ColumnIndex &column_id) {
-	if (!column_id.HasChildren()) {
-		return *this;
-	}
-	auto &child = column_id.GetChildIndex(0);
-	return children[child.GetPrimaryIndex()].ResolveExtractedChild(child);
-}
-
 //! Writer constructors
 
 ParquetColumnSchema ParquetColumnSchema::FromLogicalType(const Identifier &name, const LogicalType &type,

--- a/extension/parquet/parquet_extension.cpp
+++ b/extension/parquet/parquet_extension.cpp
@@ -591,6 +591,24 @@ ParquetPrefetchStrategyOption EnumUtil::FromString<ParquetPrefetchStrategyOption
 }
 
 template <>
+const char *EnumUtil::ToChars<ParquetReaderProjectionExpressionType>(ParquetReaderProjectionExpressionType value) {
+	switch (value) {
+	case ParquetReaderProjectionExpressionType::BYTE_LENGTH:
+		return "BYTE_LENGTH";
+	default:
+		throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	}
+}
+
+template <>
+ParquetReaderProjectionExpressionType EnumUtil::FromString<ParquetReaderProjectionExpressionType>(const char *value) {
+	if (StringUtil::Equals(value, "BYTE_LENGTH")) {
+		return ParquetReaderProjectionExpressionType::BYTE_LENGTH;
+	}
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+}
+
+template <>
 const char *EnumUtil::ToChars<GeoParquetVersion>(GeoParquetVersion value) {
 	switch (value) {
 	case GeoParquetVersion::NONE:

--- a/extension/parquet/parquet_multi_file_info.cpp
+++ b/extension/parquet/parquet_multi_file_info.cpp
@@ -336,20 +336,27 @@ static unique_ptr<FunctionData> ParquetScanDeserialize(Deserializer &deserialize
 	parquet_bind_data.projection_expressions = std::move(projection_expressions);
 
 	for (const auto &[idx, expr] : parquet_bind_data.projection_expressions) {
-		if (idx < inner_bind_data.columns.size()) {
-			inner_bind_data.columns[idx].type = expr.return_type;
-		}
-		if (idx < inner_bind_data.types.size()) {
-			inner_bind_data.types[idx] = expr.return_type;
-		}
-		if (auto &schema = inner_bind_data.reader_bind.schema; !schema.empty() && idx < schema.size()) {
-			schema[idx].type = expr.return_type;
+		const bool is_nested =
+		    idx < inner_bind_data.columns.size() && inner_bind_data.columns[idx].type.id() == LogicalTypeId::STRUCT;
+		if (!is_nested) {
+			if (idx < inner_bind_data.columns.size()) {
+				inner_bind_data.columns[idx].type = expr.return_type;
+			}
+			if (idx < inner_bind_data.types.size()) {
+				inner_bind_data.types[idx] = expr.return_type;
+			}
+			if (auto &schema = inner_bind_data.reader_bind.schema; !schema.empty() && idx < schema.size()) {
+				schema[idx].type = expr.return_type;
+			}
 		}
 		if (!inner_bind_data.initial_reader) {
 			continue;
 		}
 		auto &reader = inner_bind_data.initial_reader->Cast<ParquetReader>();
 		reader.projection_expressions[idx] = expr;
+		if (is_nested) {
+			continue;
+		}
 		if (idx < reader.columns.size()) {
 			reader.columns[idx].type = expr.return_type;
 		}

--- a/extension/parquet/parquet_multi_file_info.cpp
+++ b/extension/parquet/parquet_multi_file_info.cpp
@@ -299,6 +299,8 @@ static void ParquetScanSerialize(Serializer &serializer, const optional_ptr<Func
 	}
 	if (serializer.ShouldSerialize(StorageVersion::V2_0_0)) {
 		serializer.WriteProperty(105, "projection_expressions", parquet_data.projection_expressions);
+	} else if (!parquet_data.projection_expressions.empty()) {
+		throw SerializationException("Version too old to serialize projection_expressions but they are non-empty");
 	}
 }
 
@@ -441,11 +443,12 @@ static bool ParquetProjectionExpressionPushdown(ClientContext &context,
 
 	auto &reader = bind_data.initial_reader->Cast<ParquetReader>();
 	auto &children = reader.root_schema->children;
+	if (idx >= children.size()) {
+		return false;
+	}
 	for (const auto &group : reader.GetFileMetadata()->row_groups) {
-		if (idx >= children.size()) {
-			continue;
-		}
 		const idx_t column_flat_idx = children[idx].column_index;
+		D_ASSERT(column_flat_idx < group.columns.size());
 		for (const Encoding::type type : group.columns[column_flat_idx].meta_data.encodings) {
 			if (type == duckdb_parquet::Encoding::DELTA_LENGTH_BYTE_ARRAY) {
 				return false;
@@ -454,9 +457,6 @@ static bool ParquetProjectionExpressionPushdown(ClientContext &context,
 	}
 
 	const LogicalType type = LogicalType::BIGINT;
-	if (auto &schema = bind_data.reader_bind.schema; !schema.empty()) {
-		schema[idx].type = type;
-	}
 	bind_data.types[idx] = type;
 	bind_data.columns[idx].type = type;
 

--- a/extension/parquet/parquet_multi_file_info.cpp
+++ b/extension/parquet/parquet_multi_file_info.cpp
@@ -2,13 +2,13 @@
 #include "duckdb/main/client_context.hpp"
 
 #include <stdint.h>
-#include <atomic>
 #include <unordered_map>
-#include <vector>
 
 #include "duckdb/common/multi_file/multi_file_function.hpp"
 #include "duckdb/common/serializer/serializer.hpp"
 #include "duckdb/common/serializer/deserializer.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "duckdb/planner/table_filter.hpp"
 #include "parquet_crypto.hpp"
 #include "duckdb/function/table_function.hpp"
 #include "duckdb/common/assert.hpp"
@@ -30,6 +30,7 @@
 #include "duckdb/parser/parsed_expression.hpp"
 #include "parquet_column_schema.hpp"
 #include "parquet_file_metadata_cache.hpp"
+#include "parquet_reader.hpp"
 #include "parquet_types.h"
 
 namespace duckdb {
@@ -58,6 +59,7 @@ struct ParquetReadBindData : public TableFunctionData {
 	idx_t initial_file_data_size = 0;
 	idx_t explicit_cardinality = 0; // can be set to inject exterior cardinality knowledge (e.g. from a data lake)
 	unique_ptr<ParquetFileReaderOptions> options;
+	unordered_map<idx_t, ParquetReaderProjectionExpression> projection_expressions;
 
 	ParquetOptions &GetParquetOptions() {
 		return options->options;
@@ -74,6 +76,7 @@ struct ParquetReadBindData : public TableFunctionData {
 		result->initial_file_data_size = initial_file_data_size;
 		result->explicit_cardinality = explicit_cardinality;
 		result->options = make_uniq<ParquetFileReaderOptions>(options->options);
+		result->projection_expressions = projection_expressions;
 		return std::move(result);
 	}
 
@@ -294,6 +297,7 @@ static void ParquetScanSerialize(Serializer &serializer, const optional_ptr<Func
 	if (serializer.ShouldSerialize(StorageVersion::V1_2_0)) {
 		serializer.WriteProperty(104, "table_columns", bind_data.table_columns);
 	}
+	serializer.WriteProperty(105, "projection_expressions", parquet_data.projection_expressions);
 }
 
 static unique_ptr<FunctionData> ParquetScanDeserialize(Deserializer &deserializer, TableFunction &function) {
@@ -304,6 +308,9 @@ static unique_ptr<FunctionData> ParquetScanDeserialize(Deserializer &deserialize
 	auto serialization = deserializer.ReadProperty<ParquetOptionsSerialization>(103, "parquet_options");
 	auto table_columns =
 	    deserializer.ReadPropertyWithExplicitDefault<vector<string>>(104, "table_columns", vector<string> {});
+	auto projection_expressions =
+	    deserializer.ReadPropertyWithExplicitDefault<unordered_map<idx_t, ParquetReaderProjectionExpression>>(
+	        105, "projection_expressions", unordered_map<idx_t, ParquetReaderProjectionExpression> {});
 
 	vector<Value> file_path;
 	for (auto &path : files) {
@@ -319,7 +326,33 @@ static unique_ptr<FunctionData> ParquetScanDeserialize(Deserializer &deserialize
 	auto bind_data = MultiFileFunction<ParquetMultiFileInfo>::MultiFileBindInternal(
 	    context, std::move(multi_file_reader), std::move(file_list), types, names,
 	    std::move(serialization.file_options), std::move(parquet_options), std::move(interface));
-	bind_data->Cast<MultiFileBindData>().table_columns = std::move(table_columns);
+	auto &inner_bind_data = bind_data->Cast<MultiFileBindData>();
+	inner_bind_data.table_columns = std::move(table_columns);
+	auto &parquet_bind_data = inner_bind_data.bind_data->Cast<ParquetReadBindData>();
+	parquet_bind_data.projection_expressions = std::move(projection_expressions);
+
+	for (const auto &[idx, expr] : parquet_bind_data.projection_expressions) {
+		if (idx < inner_bind_data.columns.size()) {
+			inner_bind_data.columns[idx].type = expr.return_type;
+		}
+		if (idx < inner_bind_data.types.size()) {
+			inner_bind_data.types[idx] = expr.return_type;
+		}
+		if (auto &schema = inner_bind_data.reader_bind.schema; !schema.empty() && idx < schema.size()) {
+			schema[idx].type = expr.return_type;
+		}
+		if (!inner_bind_data.initial_reader) {
+			continue;
+		}
+		auto &reader = inner_bind_data.initial_reader->Cast<ParquetReader>();
+		reader.projection_expressions[idx] = expr;
+		if (idx < reader.columns.size()) {
+			reader.columns[idx].type = expr.return_type;
+		}
+		if (idx < reader.root_schema->children.size()) {
+			reader.root_schema->children[idx].type = expr.return_type;
+		}
+	}
 	return bind_data;
 }
 
@@ -344,6 +377,77 @@ static void ParquetScanGetMetrics(TableFunctionGetMetricsInput &input) {
 	// each local state drains the not-yet-reported count
 	input.operator_metrics.row_groups_scanned = parquet_gstate.row_groups_scanned_unreported.exchange(0);
 	input.operator_metrics.total_row_groups_to_scan = parquet_gstate.total_row_groups_to_scan.load();
+}
+
+static bool ParquetProjectionExpressionPushdown(ClientContext &context,
+                                                const TableFunctionProjectionExpressionInput &input) {
+	if (input.expr.GetExpressionClass() != ExpressionClass::BOUND_FUNCTION) {
+		return false;
+	}
+	const auto &fn = input.expr.Cast<BoundFunctionExpression>();
+	if (const Identifier &name = fn.Function().GetName(); name != "strlen" && name != "octet_length") {
+		return false;
+	}
+
+	auto &bind_data = input.get.bind_data->Cast<MultiFileBindData>();
+	// Don't do pushdown on custom schema users like Ducklake
+	if (!bind_data.reader_bind.schema.empty()) {
+		return false;
+	}
+
+	const idx_t idx = input.proj_index;
+	// We run this optimizer after FILTER_PUSHDOWN. If there was a filter
+	// pushed into get.table_filters, we don't see it here and can't
+	// proceed with pushdown
+	const auto &col_ids = input.get.GetColumnIds();
+	for (idx_t proj_idx = 0; proj_idx < col_ids.size(); proj_idx++) {
+		if (col_ids[proj_idx].GetPrimaryIndex() != idx) {
+			continue;
+		}
+		if (input.get.table_filters.HasFilter(ProjectionIndex(proj_idx))) {
+			return false;
+		}
+		break;
+	}
+
+	if (bind_data.initial_reader) {
+		const FileMetaData *metadata = bind_data.initial_reader->Cast<ParquetReader>().GetFileMetadata();
+		for (const auto &group : metadata->row_groups) {
+			if (idx >= group.columns.size()) {
+				continue;
+			}
+			for (const Encoding::type type : group.columns[idx].meta_data.encodings) {
+				if (type == duckdb_parquet::Encoding::DELTA_LENGTH_BYTE_ARRAY) {
+					return false;
+				}
+			}
+		}
+	}
+
+	if (auto &schema = bind_data.reader_bind.schema; !schema.empty()) {
+		schema[idx].type = LogicalType::BIGINT;
+	}
+	bind_data.types[idx] = LogicalType::BIGINT;
+	bind_data.columns[idx].type = LogicalType::BIGINT;
+
+	auto &parquet_bind_data = bind_data.bind_data->Cast<ParquetReadBindData>();
+	parquet_bind_data.projection_expressions[idx] = {ParquetReaderProjectionExpressionType::BYTE_LENGTH,
+	                                                 LogicalType::BIGINT};
+
+	if (!bind_data.initial_reader) {
+		return true;
+	}
+
+	// initial_reader was created before this optimizer pass, update its types.
+	auto &reader = bind_data.initial_reader->Cast<ParquetReader>();
+	reader.projection_expressions[idx] = {ParquetReaderProjectionExpressionType::BYTE_LENGTH, LogicalType::BIGINT};
+	if (idx < reader.columns.size()) {
+		reader.columns[idx].type = LogicalType::BIGINT;
+	}
+	if (idx < reader.root_schema->children.size()) {
+		reader.root_schema->children[idx].type = LogicalType::BIGINT;
+	}
+	return true;
 }
 
 ParquetMetadataCacheEntry::ParquetMetadataCacheEntry(shared_ptr<ParquetFileMetadataCache> metadata_p,
@@ -443,6 +547,7 @@ TableFunctionSet ParquetScanFunction::GetFunctionSet() {
 	table_function.named_parameters["prefetch_strategy"] = LogicalType::VARCHAR;
 	table_function.statistics_extended = MultiFileFunction<ParquetMultiFileInfo>::MultiFileScanStatsExtended;
 	table_function.get_metrics = ParquetScanGetMetrics;
+	table_function.projection_expression_pushdown = ParquetProjectionExpressionPushdown;
 	table_function.supports_pushdown_extract = ParquetScanSupportPushdownExtract;
 	table_function.serialize = ParquetScanSerialize;
 	table_function.deserialize = ParquetScanDeserialize;
@@ -716,7 +821,8 @@ shared_ptr<BaseFileReader> ParquetMultiFileInfo::CreateReader(ClientContext &con
                                                               const OpenFileInfo &file, idx_t file_idx,
                                                               const MultiFileBindData &multi_bind_data) {
 	auto &bind_data = multi_bind_data.bind_data->Cast<ParquetReadBindData>();
-	return make_shared_ptr<ParquetReader>(context, file, bind_data.GetParquetOptions());
+	return make_shared_ptr<ParquetReader>(context, file, bind_data.GetParquetOptions(), nullptr,
+	                                      bind_data.projection_expressions);
 }
 
 shared_ptr<BaseFileReader> ParquetMultiFileInfo::CreateReader(ClientContext &context, const OpenFileInfo &file,

--- a/extension/parquet/parquet_multi_file_info.cpp
+++ b/extension/parquet/parquet_multi_file_info.cpp
@@ -379,6 +379,20 @@ static void ParquetScanGetMetrics(TableFunctionGetMetricsInput &input) {
 	input.operator_metrics.total_row_groups_to_scan = parquet_gstate.total_row_groups_to_scan.load();
 }
 
+static bool ParquetEncodingSupportsBytelengthPushdown(const FileMetaData &metadata, idx_t idx) {
+	for (const auto &group : metadata.row_groups) {
+		if (idx >= group.columns.size()) {
+			continue;
+		}
+		for (const Encoding::type type : group.columns[idx].meta_data.encodings) {
+			if (type == duckdb_parquet::Encoding::DELTA_LENGTH_BYTE_ARRAY) {
+				return false;
+			}
+		}
+	}
+	return true;
+}
+
 static bool ParquetProjectionExpressionPushdown(ClientContext &context,
                                                 const TableFunctionProjectionExpressionInput &input) {
 	if (input.expr.GetExpressionClass() != ExpressionClass::BOUND_FUNCTION) {
@@ -390,13 +404,14 @@ static bool ParquetProjectionExpressionPushdown(ClientContext &context,
 	}
 
 	auto &bind_data = input.get.bind_data->Cast<MultiFileBindData>();
-	// Don't do pushdown on custom schema users like Ducklake
-	if (!bind_data.reader_bind.schema.empty()) {
+	// Don't do pushdown on custom schema users like Ducklake.
+	// We may support it and UNION readers in the future
+	if (!bind_data.reader_bind.schema.empty() || !bind_data.union_readers.empty()) {
 		return false;
 	}
 
 	const idx_t idx = input.proj_index;
-	// We run this optimizer after FILTER_PUSHDOWN. If there was a filter
+	// We run this optimizer after FILTER_PUSHDOWN. If a filter was
 	// pushed into get.table_filters, we don't see it here and can't
 	// proceed with pushdown
 	const auto &col_ids = input.get.GetColumnIds();
@@ -410,42 +425,48 @@ static bool ParquetProjectionExpressionPushdown(ClientContext &context,
 		break;
 	}
 
-	if (bind_data.initial_reader) {
-		const FileMetaData *metadata = bind_data.initial_reader->Cast<ParquetReader>().GetFileMetadata();
-		for (const auto &group : metadata->row_groups) {
-			if (idx >= group.columns.size()) {
-				continue;
-			}
-			for (const Encoding::type type : group.columns[idx].meta_data.encodings) {
-				if (type == duckdb_parquet::Encoding::DELTA_LENGTH_BYTE_ARRAY) {
-					return false;
-				}
+	auto &parquet_bind_data = bind_data.bind_data->Cast<ParquetReadBindData>();
+	if (bind_data.file_list->GetExpandResult() == FileExpandResult::SINGLE_FILE) {
+		if (bind_data.initial_reader && !ParquetEncodingSupportsBytelengthPushdown(
+		                                    *bind_data.initial_reader->Cast<ParquetReader>().GetFileMetadata(), idx)) {
+			return false;
+		}
+	} else {
+		const auto &caches = parquet_bind_data.TryLoadCaches(bind_data, context);
+		if (caches.empty()) {
+			return false;
+		}
+		for (const auto &cache : caches) {
+			if (!ParquetEncodingSupportsBytelengthPushdown(*cache.metadata->metadata, idx)) {
+				return false;
 			}
 		}
 	}
 
-	if (auto &schema = bind_data.reader_bind.schema; !schema.empty()) {
-		schema[idx].type = LogicalType::BIGINT;
-	}
-	bind_data.types[idx] = LogicalType::BIGINT;
-	bind_data.columns[idx].type = LogicalType::BIGINT;
+	const LogicalType type = LogicalType::BIGINT;
 
-	auto &parquet_bind_data = bind_data.bind_data->Cast<ParquetReadBindData>();
-	parquet_bind_data.projection_expressions[idx] = {ParquetReaderProjectionExpressionType::BYTE_LENGTH,
-	                                                 LogicalType::BIGINT};
+	if (auto &schema = bind_data.reader_bind.schema; !schema.empty()) {
+		schema[idx].type = type;
+	}
+	bind_data.types[idx] = type;
+	bind_data.columns[idx].type = type;
+
+	const ParquetReaderProjectionExpression expression {ParquetReaderProjectionExpressionType::BYTE_LENGTH, type};
+
+	parquet_bind_data.projection_expressions[idx] = expression;
 
 	if (!bind_data.initial_reader) {
 		return true;
 	}
 
-	// initial_reader was created before this optimizer pass, update its types.
+	// initial reader was created before scalar function pushdown optimizer pass, update its types.
 	auto &reader = bind_data.initial_reader->Cast<ParquetReader>();
-	reader.projection_expressions[idx] = {ParquetReaderProjectionExpressionType::BYTE_LENGTH, LogicalType::BIGINT};
+	reader.projection_expressions[idx] = expression;
 	if (idx < reader.columns.size()) {
-		reader.columns[idx].type = LogicalType::BIGINT;
+		reader.columns[idx].type = type;
 	}
 	if (idx < reader.root_schema->children.size()) {
-		reader.root_schema->children[idx].type = LogicalType::BIGINT;
+		reader.root_schema->children[idx].type = type;
 	}
 	return true;
 }

--- a/extension/parquet/parquet_multi_file_info.cpp
+++ b/extension/parquet/parquet_multi_file_info.cpp
@@ -417,6 +417,7 @@ static bool ParquetProjectionExpressionPushdown(ClientContext &context,
 	// pushed into get.table_filters, we don't see it here and can't
 	// proceed with pushdown
 	const auto &col_ids = input.get.GetColumnIds();
+	optional_ptr<const ColumnIndex> column_id;
 	for (idx_t proj_idx = 0; proj_idx < col_ids.size(); proj_idx++) {
 		if (col_ids[proj_idx].GetPrimaryIndex() != idx) {
 			continue;
@@ -424,7 +425,11 @@ static bool ParquetProjectionExpressionPushdown(ClientContext &context,
 		if (input.get.table_filters.HasFilter(ProjectionIndex(proj_idx))) {
 			return false;
 		}
+		column_id = col_ids[proj_idx];
 		break;
+	}
+	if (!column_id) {
+		return false;
 	}
 
 	auto &parquet_bind_data = bind_data.bind_data->Cast<ParquetReadBindData>();
@@ -446,8 +451,10 @@ static bool ParquetProjectionExpressionPushdown(ClientContext &context,
 	if (idx >= children.size()) {
 		return false;
 	}
+
+	ParquetColumnSchema &schema = children[idx].ResolveExtractedChild(*column_id);
+	const idx_t column_flat_idx = schema.column_index;
 	for (const auto &group : reader.GetFileMetadata()->row_groups) {
-		const idx_t column_flat_idx = children[idx].column_index;
 		D_ASSERT(column_flat_idx < group.columns.size());
 		for (const Encoding::type type : group.columns[column_flat_idx].meta_data.encodings) {
 			if (type == duckdb_parquet::Encoding::DELTA_LENGTH_BYTE_ARRAY) {
@@ -457,8 +464,10 @@ static bool ParquetProjectionExpressionPushdown(ClientContext &context,
 	}
 
 	const LogicalType type = LogicalType::BIGINT;
-	bind_data.types[idx] = type;
-	bind_data.columns[idx].type = type;
+	if (!column_id->IsPushdownExtract()) {
+		bind_data.types[idx] = type;
+		bind_data.columns[idx].type = type;
+	}
 
 	const ParquetReaderProjectionExpression expression {ParquetReaderProjectionExpressionType::BYTE_LENGTH, type};
 
@@ -466,12 +475,10 @@ static bool ParquetProjectionExpressionPushdown(ClientContext &context,
 
 	// initial reader was created before scalar function pushdown optimizer pass, update its types.
 	reader.projection_expressions[idx] = expression;
-	if (idx < reader.columns.size()) {
+	if (!column_id->IsPushdownExtract() && idx < reader.columns.size()) {
 		reader.columns[idx].type = type;
 	}
-	if (idx < reader.root_schema->children.size()) {
-		reader.root_schema->children[idx].type = type;
-	}
+	schema.type = type;
 	return true;
 }
 

--- a/extension/parquet/parquet_multi_file_info.cpp
+++ b/extension/parquet/parquet_multi_file_info.cpp
@@ -297,9 +297,9 @@ static void ParquetScanSerialize(Serializer &serializer, const optional_ptr<Func
 	if (serializer.ShouldSerialize(StorageVersion::V1_2_0)) {
 		serializer.WriteProperty(104, "table_columns", bind_data.table_columns);
 	}
-    // Old clients won't be able to read the plan even if we
-    // don't push this field. If projection expression worked,
-    // it modified "types" which we serialize ultimately
+	// Old clients won't be able to read the plan even if we
+	// don't push this field. If projection expression worked,
+	// it modified "types" which we serialize ultimately
 	serializer.WriteProperty(105, "projection_expressions", parquet_data.projection_expressions);
 }
 

--- a/extension/parquet/parquet_multi_file_info.cpp
+++ b/extension/parquet/parquet_multi_file_info.cpp
@@ -336,27 +336,20 @@ static unique_ptr<FunctionData> ParquetScanDeserialize(Deserializer &deserialize
 	parquet_bind_data.projection_expressions = std::move(projection_expressions);
 
 	for (const auto &[idx, expr] : parquet_bind_data.projection_expressions) {
-		const bool is_nested =
-		    idx < inner_bind_data.columns.size() && inner_bind_data.columns[idx].type.id() == LogicalTypeId::STRUCT;
-		if (!is_nested) {
-			if (idx < inner_bind_data.columns.size()) {
-				inner_bind_data.columns[idx].type = expr.return_type;
-			}
-			if (idx < inner_bind_data.types.size()) {
-				inner_bind_data.types[idx] = expr.return_type;
-			}
-			if (auto &schema = inner_bind_data.reader_bind.schema; !schema.empty() && idx < schema.size()) {
-				schema[idx].type = expr.return_type;
-			}
+		if (idx < inner_bind_data.columns.size()) {
+			inner_bind_data.columns[idx].type = expr.return_type;
+		}
+		if (idx < inner_bind_data.types.size()) {
+			inner_bind_data.types[idx] = expr.return_type;
+		}
+		if (auto &schema = inner_bind_data.reader_bind.schema; !schema.empty() && idx < schema.size()) {
+			schema[idx].type = expr.return_type;
 		}
 		if (!inner_bind_data.initial_reader) {
 			continue;
 		}
 		auto &reader = inner_bind_data.initial_reader->Cast<ParquetReader>();
 		reader.projection_expressions[idx] = expr;
-		if (is_nested) {
-			continue;
-		}
 		if (idx < reader.columns.size()) {
 			reader.columns[idx].type = expr.return_type;
 		}
@@ -407,35 +400,28 @@ static bool ParquetProjectionExpressionPushdown(ClientContext &context,
 		return false;
 	}
 
+	const auto &column_id = input.get.GetColumnIds()[input.column_index];
+	// Pushdown extract columns i.e. SELECT x.y.z have a complex nested type update
+	if (column_id.IsPushdownExtract()) {
+		return false;
+	}
+	const idx_t idx = column_id.GetPrimaryIndex();
+
 	// Don't do pushdown of strlen to hive and filename columns.
 	// See src/function/table/read_csv.cpp : PushdownProjectionExpression
 	for (const auto &partition : bind_data.reader_bind.hive_partitioning_indexes) {
-		if (partition.index == input.proj_index) {
+		if (partition.index == idx) {
 			return false;
 		}
 	}
-	if (bind_data.reader_bind.filename_idx.IsValid() &&
-	    bind_data.reader_bind.filename_idx.GetIndex() == input.proj_index) {
+	if (bind_data.reader_bind.filename_idx.IsValid() && bind_data.reader_bind.filename_idx.GetIndex() == idx) {
 		return false;
 	}
 
-	const idx_t idx = input.proj_index;
 	// We run scalar function pushdown after filter pushdown. If a filter was
 	// pushed into get.table_filters, we don't see it here and can't
 	// proceed with pushdown
-	const auto &col_ids = input.get.GetColumnIds();
-	optional_ptr<const ColumnIndex> column_id;
-	for (idx_t proj_idx = 0; proj_idx < col_ids.size(); proj_idx++) {
-		if (col_ids[proj_idx].GetPrimaryIndex() != idx) {
-			continue;
-		}
-		if (input.get.table_filters.HasFilter(ProjectionIndex(proj_idx))) {
-			return false;
-		}
-		column_id = col_ids[proj_idx];
-		break;
-	}
-	if (!column_id) {
+	if (input.get.table_filters.HasFilter(input.column_index)) {
 		return false;
 	}
 
@@ -459,8 +445,7 @@ static bool ParquetProjectionExpressionPushdown(ClientContext &context,
 		return false;
 	}
 
-	ParquetColumnSchema &schema = children[idx].ResolveExtractedChild(*column_id);
-	const idx_t column_flat_idx = schema.column_index;
+	const idx_t column_flat_idx = children[idx].column_index;
 	for (const auto &group : reader.GetFileMetadata()->row_groups) {
 		D_ASSERT(column_flat_idx < group.columns.size());
 		for (const Encoding::type type : group.columns[column_flat_idx].meta_data.encodings) {
@@ -471,10 +456,8 @@ static bool ParquetProjectionExpressionPushdown(ClientContext &context,
 	}
 
 	const LogicalType type = LogicalType::BIGINT;
-	if (!column_id->IsPushdownExtract()) {
-		bind_data.types[idx] = type;
-		bind_data.columns[idx].type = type;
-	}
+	bind_data.types[idx] = type;
+	bind_data.columns[idx].type = type;
 
 	const ParquetReaderProjectionExpression expression {ParquetReaderProjectionExpressionType::BYTE_LENGTH, type};
 
@@ -482,10 +465,10 @@ static bool ParquetProjectionExpressionPushdown(ClientContext &context,
 
 	// initial reader was created before scalar function pushdown optimizer pass, update its types.
 	reader.projection_expressions[idx] = expression;
-	if (!column_id->IsPushdownExtract() && idx < reader.columns.size()) {
+	if (idx < reader.columns.size()) {
 		reader.columns[idx].type = type;
 	}
-	schema.type = type;
+	children[idx].type = type;
 	return true;
 }
 

--- a/extension/parquet/parquet_multi_file_info.cpp
+++ b/extension/parquet/parquet_multi_file_info.cpp
@@ -435,23 +435,25 @@ static bool ParquetProjectionExpressionPushdown(ClientContext &context,
 	if (bind_data.file_list->GetExpandResult() == FileExpandResult::MULTIPLE_FILES) {
 		return false;
 	}
+	if (!bind_data.initial_reader) {
+		return false;
+	}
 
-	if (bind_data.initial_reader) {
-		const FileMetaData &metadata = *bind_data.initial_reader->Cast<ParquetReader>().GetFileMetadata();
-		for (const auto &group : metadata.row_groups) {
-			if (idx >= group.columns.size()) {
-				continue;
-			}
-			for (const Encoding::type type : group.columns[idx].meta_data.encodings) {
-				if (type == duckdb_parquet::Encoding::DELTA_LENGTH_BYTE_ARRAY) {
-					return false;
-				}
+	auto &reader = bind_data.initial_reader->Cast<ParquetReader>();
+	auto &children = reader.root_schema->children;
+	for (const auto &group : reader.GetFileMetadata()->row_groups) {
+		if (idx >= children.size()) {
+			continue;
+		}
+		const idx_t column_flat_idx = children[idx].column_index;
+		for (const Encoding::type type : group.columns[column_flat_idx].meta_data.encodings) {
+			if (type == duckdb_parquet::Encoding::DELTA_LENGTH_BYTE_ARRAY) {
+				return false;
 			}
 		}
 	}
 
 	const LogicalType type = LogicalType::BIGINT;
-
 	if (auto &schema = bind_data.reader_bind.schema; !schema.empty()) {
 		schema[idx].type = type;
 	}
@@ -462,12 +464,7 @@ static bool ParquetProjectionExpressionPushdown(ClientContext &context,
 
 	parquet_bind_data.projection_expressions[idx] = expression;
 
-	if (!bind_data.initial_reader) {
-		return true;
-	}
-
 	// initial reader was created before scalar function pushdown optimizer pass, update its types.
-	auto &reader = bind_data.initial_reader->Cast<ParquetReader>();
 	reader.projection_expressions[idx] = expression;
 	if (idx < reader.columns.size()) {
 		reader.columns[idx].type = type;

--- a/extension/parquet/parquet_multi_file_info.cpp
+++ b/extension/parquet/parquet_multi_file_info.cpp
@@ -297,11 +297,10 @@ static void ParquetScanSerialize(Serializer &serializer, const optional_ptr<Func
 	if (serializer.ShouldSerialize(StorageVersion::V1_2_0)) {
 		serializer.WriteProperty(104, "table_columns", bind_data.table_columns);
 	}
-	if (serializer.ShouldSerialize(StorageVersion::V2_0_0)) {
-		serializer.WriteProperty(105, "projection_expressions", parquet_data.projection_expressions);
-	} else if (!parquet_data.projection_expressions.empty()) {
-		throw SerializationException("Version too old to serialize projection_expressions but they are non-empty");
-	}
+    // Old clients won't be able to read the plan even if we
+    // don't push this field. If projection expression worked,
+    // it modified "types" which we serialize ultimately
+	serializer.WriteProperty(105, "projection_expressions", parquet_data.projection_expressions);
 }
 
 static unique_ptr<FunctionData> ParquetScanDeserialize(Deserializer &deserializer, TableFunction &function) {

--- a/extension/parquet/parquet_multi_file_info.cpp
+++ b/extension/parquet/parquet_multi_file_info.cpp
@@ -297,7 +297,9 @@ static void ParquetScanSerialize(Serializer &serializer, const optional_ptr<Func
 	if (serializer.ShouldSerialize(StorageVersion::V1_2_0)) {
 		serializer.WriteProperty(104, "table_columns", bind_data.table_columns);
 	}
-	serializer.WriteProperty(105, "projection_expressions", parquet_data.projection_expressions);
+	if (serializer.ShouldSerialize(StorageVersion::V2_0_0)) {
+		serializer.WriteProperty(105, "projection_expressions", parquet_data.projection_expressions);
+	}
 }
 
 static unique_ptr<FunctionData> ParquetScanDeserialize(Deserializer &deserializer, TableFunction &function) {
@@ -379,20 +381,6 @@ static void ParquetScanGetMetrics(TableFunctionGetMetricsInput &input) {
 	input.operator_metrics.total_row_groups_to_scan = parquet_gstate.total_row_groups_to_scan.load();
 }
 
-static bool ParquetEncodingSupportsBytelengthPushdown(const FileMetaData &metadata, idx_t idx) {
-	for (const auto &group : metadata.row_groups) {
-		if (idx >= group.columns.size()) {
-			continue;
-		}
-		for (const Encoding::type type : group.columns[idx].meta_data.encodings) {
-			if (type == duckdb_parquet::Encoding::DELTA_LENGTH_BYTE_ARRAY) {
-				return false;
-			}
-		}
-	}
-	return true;
-}
-
 static bool ParquetProjectionExpressionPushdown(ClientContext &context,
                                                 const TableFunctionProjectionExpressionInput &input) {
 	if (input.expr.GetExpressionClass() != ExpressionClass::BOUND_FUNCTION) {
@@ -410,8 +398,20 @@ static bool ParquetProjectionExpressionPushdown(ClientContext &context,
 		return false;
 	}
 
+	// Don't do pushdown of strlen to hive and filename columns.
+	// See src/function/table/read_csv.cpp : PushdownProjectionExpression
+	for (const auto &partition : bind_data.reader_bind.hive_partitioning_indexes) {
+		if (partition.index == input.proj_index) {
+			return false;
+		}
+	}
+	if (bind_data.reader_bind.filename_idx.IsValid() &&
+	    bind_data.reader_bind.filename_idx.GetIndex() == input.proj_index) {
+		return false;
+	}
+
 	const idx_t idx = input.proj_index;
-	// We run this optimizer after FILTER_PUSHDOWN. If a filter was
+	// We run scalar function pushdown after filter pushdown. If a filter was
 	// pushed into get.table_filters, we don't see it here and can't
 	// proceed with pushdown
 	const auto &col_ids = input.get.GetColumnIds();
@@ -426,19 +426,26 @@ static bool ParquetProjectionExpressionPushdown(ClientContext &context,
 	}
 
 	auto &parquet_bind_data = bind_data.bind_data->Cast<ParquetReadBindData>();
-	if (bind_data.file_list->GetExpandResult() == FileExpandResult::SINGLE_FILE) {
-		if (bind_data.initial_reader && !ParquetEncodingSupportsBytelengthPushdown(
-		                                    *bind_data.initial_reader->Cast<ParquetReader>().GetFileMetadata(), idx)) {
-			return false;
-		}
-	} else {
-		const auto &caches = parquet_bind_data.TryLoadCaches(bind_data, context);
-		if (caches.empty()) {
-			return false;
-		}
-		for (const auto &cache : caches) {
-			if (!ParquetEncodingSupportsBytelengthPushdown(*cache.metadata->metadata, idx)) {
-				return false;
+	// Don't do pushdown with multiple files. As metadata for all but first file is not
+	// available upfront, we need to TryLoadCaches and check cache validity which complicates
+	// things. Another complication is that different files may have separate schemas:
+	// if we're reading file 1 (int, str) and file 2 (str, int) and trying to push down
+	// strlen for column 2, query will fail on file 2 as it compares column indices and
+	// not names
+	if (bind_data.file_list->GetExpandResult() == FileExpandResult::MULTIPLE_FILES) {
+		return false;
+	}
+
+	if (bind_data.initial_reader) {
+		const FileMetaData &metadata = *bind_data.initial_reader->Cast<ParquetReader>().GetFileMetadata();
+		for (const auto &group : metadata.row_groups) {
+			if (idx >= group.columns.size()) {
+				continue;
+			}
+			for (const Encoding::type type : group.columns[idx].meta_data.encodings) {
+				if (type == duckdb_parquet::Encoding::DELTA_LENGTH_BYTE_ARRAY) {
+					return false;
+				}
 			}
 		}
 	}

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -9,6 +9,7 @@
 #include "duckdb/function/partition_stats.hpp"
 #include "parquet_types.h"
 #include "column_reader.hpp"
+#include "reader/byte_array_length_column_reader.hpp"
 #include "reader/expression_column_reader.hpp"
 #include "parquet_geometry.hpp"
 #include "reader/list_column_reader.hpp"
@@ -1060,9 +1061,11 @@ ParquetColumnDefinition ParquetColumnDefinition::FromSchemaValue(ClientContext &
 }
 
 ParquetReader::ParquetReader(ClientContext &context_p, OpenFileInfo file_p, ParquetOptions parquet_options_p,
-                             shared_ptr<ParquetFileMetadataCache> metadata_p)
+                             shared_ptr<ParquetFileMetadataCache> metadata_p,
+                             unordered_map<idx_t, ParquetReaderProjectionExpression> projection_expressions_p)
     : BaseFileReader(std::move(file_p)), fs(CachingFileSystem::Get(context_p)),
-      allocator(BufferAllocator::Get(context_p)), parquet_options(std::move(parquet_options_p)) {
+      allocator(BufferAllocator::Get(context_p)), parquet_options(std::move(parquet_options_p)),
+      projection_expressions(std::move(projection_expressions_p)) {
 	file_handle = fs.OpenFile(context_p, file, FileFlags::FILE_FLAGS_READ);
 	if (!file_handle->CanSeek()) {
 		throw NotImplementedException(
@@ -1106,6 +1109,15 @@ ParquetReader::ParquetReader(ClientContext &context_p, OpenFileInfo file_p, Parq
 		}
 	}
 	InitializeSchema(context_p);
+	// Length-pushdown rewrites these columns to BIGINT, update the local schema
+	for (const auto &[idx, expr] : projection_expressions) {
+		if (idx < columns.size()) {
+			columns[idx].type = expr.return_type;
+		}
+		if (idx < root_schema->children.size()) {
+			root_schema->children[idx].type = expr.return_type;
+		}
+	}
 }
 
 bool ParquetReader::MetadataCacheEnabled(ClientContext &context) {
@@ -1507,6 +1519,13 @@ void ParquetReader::InitializeScan(ClientContext &context, ParquetReaderScanStat
 	for (idx_t i = 0; i < column_indexes.size(); i++) {
 		auto &index = column_indexes[i];
 		auto column_id = index.GetPrimaryIndex();
+		if (auto it = projection_expressions.find(column_id);
+		    it != projection_expressions.end() &&
+		    it->second.type == ParquetReaderProjectionExpressionType::BYTE_LENGTH) {
+			auto &schema = root_schema->children[column_id];
+			state.column_readers[i] = make_uniq<ByteArrayLengthColumnReader>(*this, schema);
+			continue;
+		}
 		auto it = expression_map.find(column_id);
 		if (it != expression_map.end()) {
 			auto &expression_data = it->second;

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1523,6 +1523,7 @@ void ParquetReader::InitializeScan(ClientContext &context, ParquetReaderScanStat
 		    it != projection_expressions.end() &&
 		    it->second.type == ParquetReaderProjectionExpressionType::BYTE_LENGTH) {
 			auto &schema = root_schema->children[column_id].ResolveExtractedChild(index);
+			schema.type = it->second.return_type;
 			state.column_readers[i] = make_uniq<ByteArrayLengthColumnReader>(*this, schema);
 			continue;
 		}

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1522,8 +1522,7 @@ void ParquetReader::InitializeScan(ClientContext &context, ParquetReaderScanStat
 		if (auto it = projection_expressions.find(column_id);
 		    it != projection_expressions.end() &&
 		    it->second.type == ParquetReaderProjectionExpressionType::BYTE_LENGTH) {
-			auto &schema = root_schema->children[column_id].ResolveExtractedChild(index);
-			schema.type = it->second.return_type;
+			auto &schema = root_schema->children[column_id];
 			state.column_readers[i] = make_uniq<ByteArrayLengthColumnReader>(*this, schema);
 			continue;
 		}

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1522,7 +1522,7 @@ void ParquetReader::InitializeScan(ClientContext &context, ParquetReaderScanStat
 		if (auto it = projection_expressions.find(column_id);
 		    it != projection_expressions.end() &&
 		    it->second.type == ParquetReaderProjectionExpressionType::BYTE_LENGTH) {
-			auto &schema = root_schema->children[column_id];
+			auto &schema = root_schema->children[column_id].ResolveExtractedChild(index);
 			state.column_readers[i] = make_uniq<ByteArrayLengthColumnReader>(*this, schema);
 			continue;
 		}

--- a/extension/parquet/reader/CMakeLists.txt
+++ b/extension/parquet/reader/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library_unity(
   duckdb_parquet_readers
   OBJECT
+  byte_array_length_column_reader.cpp
   decimal_column_reader.cpp
   expression_column_reader.cpp
   list_column_reader.cpp

--- a/extension/parquet/reader/byte_array_length_column_reader.cpp
+++ b/extension/parquet/reader/byte_array_length_column_reader.cpp
@@ -1,0 +1,29 @@
+#include "reader/byte_array_length_column_reader.hpp"
+
+#include "parquet_column_schema.hpp"
+
+namespace duckdb {
+
+ByteArrayLengthColumnReader::ByteArrayLengthColumnReader(const ParquetReader &reader, const ParquetColumnSchema &schema)
+    : ColumnReader(reader, schema), fixed_width_string_length(DConstants::INVALID_INDEX) {
+	if (schema.parquet_type == Type::FIXED_LEN_BYTE_ARRAY) {
+		fixed_width_string_length = schema.type_length;
+	}
+}
+
+void ByteArrayLengthColumnReader::Plain(shared_ptr<ResizeableBuffer> &plain_data, uint8_t *defines, idx_t num_values,
+                                        idx_t result_offset, Vector &result) {
+	PlainTemplated<int64_t, ByteArrayLengthValueConversion>(*plain_data, defines, num_values, result_offset, result);
+}
+
+void ByteArrayLengthColumnReader::PlainSkip(ByteBuffer &plain_data, uint8_t *defines, idx_t num_values) {
+	PlainSkipTemplated<ByteArrayLengthValueConversion>(plain_data, defines, num_values);
+}
+
+void ByteArrayLengthColumnReader::PlainSelect(shared_ptr<ResizeableBuffer> &plain_data, uint8_t *defines,
+                                              idx_t num_values, Vector &result, const SelectionVector &sel,
+                                              idx_t count) {
+	PlainSelectTemplated<int64_t, ByteArrayLengthValueConversion>(*plain_data, defines, num_values, result, sel, count);
+}
+
+} // namespace duckdb

--- a/extension/parquet/serialize_parquet.cpp
+++ b/extension/parquet/serialize_parquet.cpp
@@ -102,6 +102,18 @@ ParquetOptionsSerialization ParquetOptionsSerialization::Deserialize(Deserialize
 	return result;
 }
 
+void ParquetReaderProjectionExpression::Serialize(Serializer &serializer) const {
+	serializer.WriteProperty<ParquetReaderProjectionExpressionType>(100, "type", type);
+	serializer.WriteProperty<LogicalType>(101, "return_type", return_type);
+}
+
+ParquetReaderProjectionExpression ParquetReaderProjectionExpression::Deserialize(Deserializer &deserializer) {
+	ParquetReaderProjectionExpression result;
+	deserializer.ReadProperty<ParquetReaderProjectionExpressionType>(100, "type", result.type);
+	deserializer.ReadProperty<LogicalType>(101, "return_type", result.return_type);
+	return result;
+}
+
 void ShreddingType::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<bool>(100, "set", set);
 	serializer.WriteProperty<LogicalType>(101, "type", type);

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -3823,19 +3823,20 @@ const StringUtil::EnumStringLiteral *GetOptimizerTypeValues() {
 		{ static_cast<uint32_t>(OptimizerType::PARTIAL_AGGREGATE_PUSHDOWN), "PARTIAL_AGGREGATE_PUSHDOWN" },
 		{ static_cast<uint32_t>(OptimizerType::REMOTE_PUSHDOWN), "REMOTE_PUSHDOWN" },
 		{ static_cast<uint32_t>(OptimizerType::GROUPING_SETS), "GROUPING_SETS" },
-		{ static_cast<uint32_t>(OptimizerType::TYPE_PUSHDOWN), "TYPE_PUSHDOWN" }
+		{ static_cast<uint32_t>(OptimizerType::TYPE_PUSHDOWN), "TYPE_PUSHDOWN" },
+		{ static_cast<uint32_t>(OptimizerType::SCALAR_FN_PUSHDOWN), "SCALAR_FN_PUSHDOWN" }
 	};
 	return values;
 }
 
 template<>
 const char* EnumUtil::ToChars<OptimizerType>(OptimizerType value) {
-	return StringUtil::EnumToString(GetOptimizerTypeValues(), 42, "OptimizerType", static_cast<uint32_t>(value));
+	return StringUtil::EnumToString(GetOptimizerTypeValues(), 43, "OptimizerType", static_cast<uint32_t>(value));
 }
 
 template<>
 OptimizerType EnumUtil::FromString<OptimizerType>(const char *value) {
-	return static_cast<OptimizerType>(StringUtil::StringToEnum(GetOptimizerTypeValues(), 42, "OptimizerType", value));
+	return static_cast<OptimizerType>(StringUtil::StringToEnum(GetOptimizerTypeValues(), 43, "OptimizerType", value));
 }
 
 const StringUtil::EnumStringLiteral *GetOrderByColumnTypeValues() {

--- a/src/common/enums/optimizer_type.cpp
+++ b/src/common/enums/optimizer_type.cpp
@@ -54,6 +54,7 @@ static const DefaultOptimizerType internal_optimizer_types[] = {
     {"remote_pushdown", OptimizerType::REMOTE_PUSHDOWN},
     {"grouping_sets", OptimizerType::GROUPING_SETS},
     {"type_pushdown", OptimizerType::TYPE_PUSHDOWN},
+    {"scalar_fn_pushdown", OptimizerType::SCALAR_FN_PUSHDOWN},
     {nullptr, OptimizerType::INVALID}};
 
 string OptimizerTypeToString(OptimizerType type) {

--- a/src/function/table/read_csv.cpp
+++ b/src/function/table/read_csv.cpp
@@ -148,21 +148,21 @@ static bool PushdownProjectionExpression(ClientContext &context, const TableFunc
 	const auto &cast = input.expr.Cast<BoundCastExpression>();
 	const auto &target_type = cast.GetReturnType();
 	auto &bind_data = input.get.bind_data->Cast<MultiFileBindData>();
+	const idx_t idx = input.get.GetColumnIds()[input.column_index].GetPrimaryIndex();
 	// Hive-partition and filename columns are produced from the file path by
 	// separate finalize expressions, not parsed from the file. Retyping them
 	// here would desync those expressions, so leave the cast in place.
 	// See test/sql/copy/csv/csv_hive.test
 	for (const auto &partition : bind_data.reader_bind.hive_partitioning_indexes) {
-		if (partition.index == input.proj_index) {
+		if (partition.index == idx) {
 			return false;
 		}
 	}
-	if (bind_data.reader_bind.filename_idx.IsValid() &&
-	    bind_data.reader_bind.filename_idx.GetIndex() == input.proj_index) {
+	if (bind_data.reader_bind.filename_idx.IsValid() && bind_data.reader_bind.filename_idx.GetIndex() == idx) {
 		return false;
 	}
-	bind_data.types[input.proj_index] = target_type;
-	bind_data.columns[input.proj_index].type = target_type;
+	bind_data.types[idx] = target_type;
+	bind_data.columns[idx].type = target_type;
 	return true;
 }
 

--- a/src/include/duckdb/common/enums/optimizer_type.hpp
+++ b/src/include/duckdb/common/enums/optimizer_type.hpp
@@ -56,6 +56,7 @@ enum class OptimizerType : uint32_t {
 	REMOTE_PUSHDOWN = 39,
 	GROUPING_SETS = 40,
 	TYPE_PUSHDOWN = 41,
+	SCALAR_FN_PUSHDOWN = 42,
 };
 
 string OptimizerTypeToString(OptimizerType type);

--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -1114,17 +1114,6 @@ public:
 		}
 	}
 
-	static bool PushdownProjectionExpression(ClientContext &context, TableFunctionProjectionExpressionInput &input) {
-		if (input.expr.GetExpressionClass() != ExpressionClass::BOUND_CAST) {
-			return false;
-		}
-		auto &bind_data = input.get.bind_data->Cast<MultiFileBindData>();
-		const auto &cast = input.expr.Cast<BoundCastExpression>();
-		bind_data.types[input.proj_index] = cast.GetReturnType();
-		bind_data.columns[input.proj_index].type = cast.GetReturnType();
-		return true;
-	}
-
 private:
 	static bool HasFilesToRead(MultiFileGlobalState &gstate, unique_lock<mutex> &parallel_lock) {
 		D_ASSERT(parallel_lock.owns_lock());

--- a/src/include/duckdb/function/table_function.hpp
+++ b/src/include/duckdb/function/table_function.hpp
@@ -15,6 +15,7 @@
 #include "duckdb/function/function.hpp"
 #include "duckdb/storage/statistics/node_statistics.hpp"
 #include "duckdb/common/column_index.hpp"
+#include "duckdb/common/projection_index.hpp"
 #include "duckdb/common/table_column.hpp"
 #include "duckdb/parallel/async_result.hpp"
 #include "duckdb/common/exception/binder_exception.hpp"
@@ -202,7 +203,8 @@ struct TableFunctionPartitionInput {
 struct TableFunctionProjectionExpressionInput {
 	const LogicalGet &get;
 	const Expression &expr;
-	idx_t proj_index;
+	//! Position of pushed down column within get, usage: get.GetColumnIds()[column_index]
+	ProjectionIndex column_index;
 };
 
 struct TableFunctionToStringInput {

--- a/src/include/duckdb/optimizer/scalar_fn_pushdown.hpp
+++ b/src/include/duckdb/optimizer/scalar_fn_pushdown.hpp
@@ -1,0 +1,54 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/optimizer/scalar_fn_pushdown.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+#include "duckdb/optimizer/type_pushdown.hpp"
+
+namespace duckdb {
+
+/**
+ * Collect fn(col) expressions i.e. expressions where a single function (not
+ * a function chain) wraps a single bound column. If "col" is used without
+ * function application in "plan", record in "analyses.conflicts"
+ */
+struct ScalarFnCollect final : LogicalOperatorVisitor {
+	Analyses &analyses;
+	const Projections &projections;
+
+	ScalarFnCollect(Analyses &analyses, const Projections &projections);
+	void VisitOperator(LogicalOperator &op) override;
+	unique_ptr<Expression> VisitReplace(BoundColumnRefExpression &expr, unique_ptr<Expression> *ptr) override;
+	unique_ptr<Expression> VisitReplace(BoundFunctionExpression &expr, unique_ptr<Expression> *ptr) override;
+};
+
+/*
+ * For "col" in columns collected by ScalarFnCollect, replace fn(col) to "col"
+ * if "col" doesn't have conflicting usage. Update return types for bound
+ * columns and logical projections referencing this column.
+ */
+struct ScalarFnReplace final : LogicalOperatorVisitor {
+	Analyses &analyses;
+	const Projections &projections;
+
+	ScalarFnReplace(Analyses &analyses, const Projections &aliases);
+	unique_ptr<Expression> VisitReplace(BoundColumnRefExpression &expr, unique_ptr<Expression> *ptr) override;
+	unique_ptr<Expression> VisitReplace(BoundFunctionExpression &expr, unique_ptr<Expression> *ptr) override;
+};
+
+class ScalarFnPushdown {
+public:
+	explicit inline ScalarFnPushdown(ClientContext &context) : context(context) {
+	}
+	unique_ptr<LogicalOperator> Optimize(unique_ptr<LogicalOperator> op) {
+		return PushdownOptimize<ScalarFnCollect, ScalarFnReplace>(context, std::move(op));
+	}
+
+private:
+	ClientContext &context;
+};
+} // namespace duckdb

--- a/src/include/duckdb/optimizer/type_pushdown.hpp
+++ b/src/include/duckdb/optimizer/type_pushdown.hpp
@@ -28,6 +28,13 @@ struct GetAnalysis {
 	unordered_map<ProjectionIndex, const Expression *> col_to_expr;
 
 	idx_t StorageIndex(ProjectionIndex idx) const;
+
+	/**
+	 * Type returned from a pushed down expression.
+	 * Special case is PushdownExtract column, this function returns the base
+	 * struct type.
+	 */
+	LogicalType GetPushdownType(ProjectionIndex idx) const;
 };
 
 using Analyses = unordered_map<TableIndex, GetAnalysis>;
@@ -121,9 +128,18 @@ unique_ptr<LogicalOperator> PushdownOptimize(ClientContext &context, unique_ptr<
 			}
 			const idx_t storage_index = analysis.StorageIndex(column_index);
 			TableFunctionProjectionExpressionInput input {analysis.get, *expr, storage_index};
+			const LogicalType return_type = expr->GetReturnType();
+
 			if (analysis.get.function.projection_expression_pushdown(context, input)) {
-				// LOGICAL_GET doesn't initialize .types of LogicalOperator
-				analysis.get.returned_types[storage_index] = expr->GetReturnType();
+				auto &column_id = analysis.get.GetMutableColumnIds()[column_index];
+				if (column_id.IsPushdownExtract()) {
+					column_id.SetPushdownExtractType(analysis.get.returned_types[storage_index], &return_type);
+				} else {
+					analysis.get.returned_types[storage_index] = return_type;
+					if (column_index < analysis.get.types.size()) {
+						analysis.get.types[column_index] = return_type;
+					}
+				}
 				any_pushed = true;
 			} else { // failed to push down expression, can't replace it
 				expr = nullptr;

--- a/src/include/duckdb/optimizer/type_pushdown.hpp
+++ b/src/include/duckdb/optimizer/type_pushdown.hpp
@@ -7,14 +7,13 @@
 //===----------------------------------------------------------------------===//
 
 #pragma once
+#include "duckdb/common/optional.hpp"
 #include "duckdb/common/projection_index.hpp"
 #include "duckdb/common/unique_ptr.hpp"
 #include "duckdb/common/unordered_set.hpp"
 #include "duckdb/planner/expression.hpp"
 #include "duckdb/planner/logical_operator.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
-
-#include <optional>
 
 namespace duckdb {
 class ClientContext;
@@ -99,7 +98,7 @@ struct GetBinding {
  * Returns nullopt for virtual columns and columns which are neither part of
  * GET nor part of PROJECTION wrapping a GET.
  */
-std::optional<GetBinding> Resolve(ColumnBinding binding, Analyses &analyses, const Projections &projections);
+optional<GetBinding> Resolve(ColumnBinding binding, Analyses &analyses, const Projections &projections);
 
 template <class Collect, class Replace>
 unique_ptr<LogicalOperator> PushdownOptimize(ClientContext &context, unique_ptr<LogicalOperator> op) {

--- a/src/include/duckdb/optimizer/type_pushdown.hpp
+++ b/src/include/duckdb/optimizer/type_pushdown.hpp
@@ -14,6 +14,8 @@
 #include "duckdb/planner/logical_operator.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
 
+#include <optional>
+
 namespace duckdb {
 class ClientContext;
 

--- a/src/include/duckdb/optimizer/type_pushdown.hpp
+++ b/src/include/duckdb/optimizer/type_pushdown.hpp
@@ -7,32 +7,26 @@
 //===----------------------------------------------------------------------===//
 
 #pragma once
-#include "duckdb/common/optional.hpp"
+#include "duckdb/common/projection_index.hpp"
 #include "duckdb/common/unique_ptr.hpp"
 #include "duckdb/common/unordered_set.hpp"
 #include "duckdb/planner/expression.hpp"
 #include "duckdb/planner/logical_operator.hpp"
+#include "duckdb/planner/operator/logical_get.hpp"
 
 namespace duckdb {
 class ClientContext;
 
-class TypePushdown {
-public:
-	explicit TypePushdown(ClientContext &ctx);
-	unique_ptr<LogicalOperator> Optimize(unique_ptr<LogicalOperator> op);
-
-private:
-	ClientContext &context;
-};
-
 struct GetAnalysis {
 	LogicalGet &get;
 	/**
-	 * for CAST(col), mapping of "col scan index" -> "CAST expression".
-	 * "CAST expression" is nullptr iff column is used with a different function
-	 * or without function application in the query plan.
+	 * for CAST(col), mapping of "col scan index" -> "expression".
+	 * "expression" is nullptr iff column is used with a different expression
+	 * or without expression in the query plan.
 	 */
-	unordered_map<ProjectionIndex, const BoundCastExpression *> col_to_cast;
+	unordered_map<ProjectionIndex, const Expression *> col_to_expr;
+
+	idx_t StorageIndex(ProjectionIndex idx) const;
 };
 
 using Analyses = unordered_map<TableIndex, GetAnalysis>;
@@ -104,4 +98,55 @@ struct GetBinding {
  * GET nor part of PROJECTION wrapping a GET.
  */
 std::optional<GetBinding> Resolve(ColumnBinding binding, Analyses &analyses, const Projections &projections);
+
+template <class Collect, class Replace>
+unique_ptr<LogicalOperator> PushdownOptimize(ClientContext &context, unique_ptr<LogicalOperator> op) {
+	Analyses analyses;
+	Projections projections;
+	FindGetsAndProjections(*op, analyses, projections);
+	if (analyses.empty()) {
+		return op;
+	}
+	Collect(analyses, projections).VisitOperator(*op);
+
+	bool any_pushed = false;
+	for (auto &[_, analysis] : analyses) {
+		for (auto &[column_index, expr] : analysis.col_to_expr) {
+			if (expr == nullptr) { // Conflict for column
+				continue;
+			}
+			if (analysis.get.GetColumnIds()[column_index].IsVirtualColumn()) {
+				continue;
+			}
+			const idx_t storage_index = analysis.StorageIndex(column_index);
+			TableFunctionProjectionExpressionInput input {analysis.get, *expr, storage_index};
+			if (analysis.get.function.projection_expression_pushdown(context, input)) {
+				// LOGICAL_GET doesn't initialize .types of LogicalOperator
+				analysis.get.returned_types[storage_index] = expr->GetReturnType();
+				any_pushed = true;
+			} else { // failed to push down expression, can't replace it
+				expr = nullptr;
+			}
+		}
+	}
+
+	if (any_pushed) {
+		Replace(analyses, projections).VisitOperator(*op);
+	}
+	return op;
+}
+
+class TypePushdown {
+public:
+	explicit inline TypePushdown(ClientContext &context) : context(context) {
+	}
+	inline unique_ptr<LogicalOperator> Optimize(unique_ptr<LogicalOperator> op) {
+		return PushdownOptimize<CastCollect, CastReplace>(context, std::move(op));
+	}
+
+private:
+	ClientContext &context;
+};
+
+bool CanPushdownColumn(const GetAnalysis &analysis, ProjectionIndex idx);
 } // namespace duckdb

--- a/src/include/duckdb/optimizer/type_pushdown.hpp
+++ b/src/include/duckdb/optimizer/type_pushdown.hpp
@@ -28,13 +28,6 @@ struct GetAnalysis {
 	unordered_map<ProjectionIndex, const Expression *> col_to_expr;
 
 	idx_t StorageIndex(ProjectionIndex idx) const;
-
-	/**
-	 * Type returned from a pushed down expression.
-	 * Special case is PushdownExtract column, this function returns the base
-	 * struct type.
-	 */
-	LogicalType GetPushdownType(ProjectionIndex idx) const;
 };
 
 using Analyses = unordered_map<TableIndex, GetAnalysis>;
@@ -126,19 +119,11 @@ unique_ptr<LogicalOperator> PushdownOptimize(ClientContext &context, unique_ptr<
 			if (analysis.get.GetColumnIds()[column_index].IsVirtualColumn()) {
 				continue;
 			}
-			const idx_t storage_index = analysis.StorageIndex(column_index);
-			TableFunctionProjectionExpressionInput input {analysis.get, *expr, storage_index};
-			const LogicalType return_type = expr->GetReturnType();
-
+			TableFunctionProjectionExpressionInput input {analysis.get, *expr, column_index};
 			if (analysis.get.function.projection_expression_pushdown(context, input)) {
-				auto &column_id = analysis.get.GetMutableColumnIds()[column_index];
-				if (column_id.IsPushdownExtract()) {
-					column_id.SetPushdownExtractType(analysis.get.returned_types[storage_index], &return_type);
-				} else {
-					analysis.get.returned_types[storage_index] = return_type;
-					if (column_index < analysis.get.types.size()) {
-						analysis.get.types[column_index] = return_type;
-					}
+				analysis.get.returned_types[analysis.StorageIndex(column_index)] = expr->GetReturnType();
+				if (!analysis.get.types.empty()) {
+					analysis.get.ResolveOperatorTypes();
 				}
 				any_pushed = true;
 			} else { // failed to push down expression, can't replace it

--- a/src/optimizer/CMakeLists.txt
+++ b/src/optimizer/CMakeLists.txt
@@ -49,6 +49,7 @@ add_library_unity(
   row_number_rewriter.cpp
   sampling_pushdown.cpp
   type_pushdown.cpp
+  scalar_fn_pushdown.cpp
   projection_pullup.cpp
   remote_pushdown_optimizer.cpp)
 set(ALL_OBJECT_FILES

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -436,7 +436,7 @@ void Optimizer::RunBuiltInOptimizers() {
 	RunOptimizer(OptimizerType::TYPE_PUSHDOWN, [&] {
 		TypePushdown type_pushdown(context);
 		plan = type_pushdown.Optimize(std::move(plan));
-    });
+	});
 
 	// Pushdown scalar functions in SELECT like SELECT strlen(str) to readers
 	RunOptimizer(OptimizerType::SCALAR_FN_PUSHDOWN, [&] {

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -33,6 +33,7 @@
 #include "duckdb/optimizer/rule/join_dependent_filter.hpp"
 #include "duckdb/optimizer/rule/list.hpp"
 #include "duckdb/optimizer/sampling_pushdown.hpp"
+#include "duckdb/optimizer/scalar_fn_pushdown.hpp"
 #include "duckdb/optimizer/statistics_propagator.hpp"
 #include "duckdb/optimizer/aggregate_function_rewriter.hpp"
 #include "duckdb/optimizer/topn_optimizer.hpp"
@@ -435,6 +436,12 @@ void Optimizer::RunBuiltInOptimizers() {
 	RunOptimizer(OptimizerType::TYPE_PUSHDOWN, [&] {
 		TypePushdown type_pushdown(context);
 		plan = type_pushdown.Optimize(std::move(plan));
+    });
+
+	// Pushdown scalar functions in SELECT like SELECT strlen(str) to readers
+	RunOptimizer(OptimizerType::SCALAR_FN_PUSHDOWN, [&] {
+		ScalarFnPushdown fn_pushdown(context);
+		plan = fn_pushdown.Optimize(std::move(plan));
 	});
 }
 

--- a/src/optimizer/scalar_fn_pushdown.cpp
+++ b/src/optimizer/scalar_fn_pushdown.cpp
@@ -67,7 +67,7 @@ unique_ptr<Expression> ScalarFnReplace::VisitReplace(BoundColumnRefExpression &e
 
 	const auto &[analysis, column_index, projection] = *binding;
 	if (CanPushdownColumn(analysis, column_index)) {
-		const LogicalType return_type = analysis.GetPushdownType(column_index);
+		const LogicalType return_type = analysis.get.returned_types[analysis.StorageIndex(column_index)];
 		expr.SetReturnType(return_type);
 		if (projection != nullptr && !projection->types.empty()) {
 			projection->types[column_index] = return_type;
@@ -94,7 +94,7 @@ unique_ptr<Expression> ScalarFnReplace::VisitReplace(BoundFunctionExpression &ex
 		return std::move(*ptr);
 	}
 
-	const LogicalType return_type = analysis.GetPushdownType(column_index);
+	const LogicalType return_type = analysis.get.returned_types[analysis.StorageIndex(column_index)];
 	bound_col_base->SetReturnType(return_type);
 	if (projection != nullptr && !projection->types.empty()) {
 		projection->types[column_index] = return_type;

--- a/src/optimizer/scalar_fn_pushdown.cpp
+++ b/src/optimizer/scalar_fn_pushdown.cpp
@@ -1,0 +1,114 @@
+#include "duckdb/optimizer/scalar_fn_pushdown.hpp"
+#include "duckdb/common/types.hpp"
+#include "duckdb/planner/expression/bound_columnref_expression.hpp"
+#include "duckdb/planner/operator/logical_get.hpp"
+#include "duckdb/planner/operator/logical_projection.hpp"
+
+namespace duckdb {
+void ScalarFnCollect::VisitOperator(LogicalOperator &op) {
+	/*
+	 * Logical projection expressions are columns which reference underlying
+	 * GETs. Don't process them, as they would add conflicts for every column
+	 * used in projection. Example: PROJECTION(col) -> GET(col). We don't want
+	 * to visit BoundColumnRefExpression in PROJECTION to avoid registering a
+	 * non-existent conflict.
+	 *
+	 * However, ScalarFnReplace will visit them because we need to update their
+	 * types if pushdown succeeded.
+	 */
+	if (op.type == LogicalOperatorType::LOGICAL_PROJECTION &&
+	    projections.count(op.Cast<LogicalProjection>().table_index)) {
+		VisitOperatorChildren(op);
+		return;
+	}
+	LogicalOperatorVisitor::VisitOperator(op);
+}
+
+unique_ptr<Expression> ScalarFnCollect::VisitReplace(BoundColumnRefExpression &expr, unique_ptr<Expression> *ptr) {
+	if (const auto binding = Resolve(expr.Binding(), analyses, projections)) {
+		// Column is used without function applied to it, register a conflict.
+		// Not emplace() as we need to update the value if it was present
+		binding->analysis.col_to_expr[binding->column_index] = nullptr;
+	}
+	return std::move(*ptr);
+}
+
+unique_ptr<Expression> ScalarFnCollect::VisitReplace(BoundFunctionExpression &expr, unique_ptr<Expression> *ptr) {
+	if (expr.GetChildren().size() != 1 ||
+	    expr.GetChildren()[0]->GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
+		// Descend into children so e.g. fn(col, other) still sees "col" and
+		// registers a conflict
+		return nullptr;
+	}
+	const auto &bound_col = expr.GetChildren()[0]->Cast<BoundColumnRefExpression>();
+	const auto binding = Resolve(bound_col.Binding(), analyses, projections);
+	if (!binding) {
+		return nullptr;
+	}
+	auto &col_to_expr = binding->analysis.col_to_expr;
+
+	if (auto it = col_to_expr.find(binding->column_index); it == col_to_expr.end()) {
+		// This is the first time we see the column used by a single function.
+		col_to_expr.emplace(binding->column_index, &expr);
+	} else if (it->second == nullptr || !it->second->Equals(expr)) {
+		// Either column is used with different function in "expr" or
+		// there already is a conflict.
+		it->second = nullptr;
+	}
+
+	return std::move(*ptr);
+}
+
+unique_ptr<Expression> ScalarFnReplace::VisitReplace(BoundColumnRefExpression &expr, unique_ptr<Expression> *ptr) {
+	const auto binding = Resolve(expr.Binding(), analyses, projections);
+	if (!binding) {
+		return std::move(*ptr);
+	}
+
+	const auto &[analysis, column_index, projection] = *binding;
+	if (CanPushdownColumn(analysis, column_index)) {
+		const idx_t storage_index = analysis.StorageIndex(column_index);
+		const LogicalType return_type = analysis.get.returned_types[storage_index];
+		expr.SetReturnType(return_type);
+		if (projection != nullptr && !projection->types.empty()) {
+			projection->types[column_index] = return_type;
+		}
+	}
+
+	return std::move(*ptr);
+}
+
+unique_ptr<Expression> ScalarFnReplace::VisitReplace(BoundFunctionExpression &expr, unique_ptr<Expression> *ptr) {
+	if (expr.GetChildren().size() != 1 ||
+	    expr.GetChildren()[0]->GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
+		return nullptr; // Same as in ScalarFnCollect::VisitReplace
+	}
+	unique_ptr<Expression> &bound_col_base = expr.GetChildrenMutable()[0];
+	const auto &bound_col = bound_col_base->Cast<BoundColumnRefExpression>();
+	const auto binding = Resolve(bound_col.Binding(), analyses, projections);
+	if (!binding) {
+		return nullptr;
+	}
+
+	const auto &[analysis, column_index, projection] = *binding;
+	if (!CanPushdownColumn(analysis, column_index)) {
+		return std::move(*ptr);
+	}
+
+	const idx_t storage_index = analysis.StorageIndex(column_index);
+	const LogicalType return_type = analysis.get.returned_types[storage_index];
+	bound_col_base->SetReturnType(return_type);
+	if (projection != nullptr && !projection->types.empty()) {
+		projection->types[column_index] = return_type;
+	}
+	return std::move(bound_col_base);
+}
+
+ScalarFnCollect::ScalarFnCollect(Analyses &analyses, const Projections &projections)
+    : analyses(analyses), projections(projections) {
+}
+
+ScalarFnReplace::ScalarFnReplace(Analyses &analyses, const Projections &projections)
+    : analyses(analyses), projections(projections) {
+}
+} // namespace duckdb

--- a/src/optimizer/scalar_fn_pushdown.cpp
+++ b/src/optimizer/scalar_fn_pushdown.cpp
@@ -2,7 +2,6 @@
 #include "duckdb/common/types.hpp"
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
-#include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/planner/operator/logical_projection.hpp"
 
 namespace duckdb {
@@ -68,8 +67,7 @@ unique_ptr<Expression> ScalarFnReplace::VisitReplace(BoundColumnRefExpression &e
 
 	const auto &[analysis, column_index, projection] = *binding;
 	if (CanPushdownColumn(analysis, column_index)) {
-		const idx_t storage_index = analysis.StorageIndex(column_index);
-		const LogicalType return_type = analysis.get.returned_types[storage_index];
+		const LogicalType return_type = analysis.GetPushdownType(column_index);
 		expr.SetReturnType(return_type);
 		if (projection != nullptr && !projection->types.empty()) {
 			projection->types[column_index] = return_type;
@@ -96,8 +94,7 @@ unique_ptr<Expression> ScalarFnReplace::VisitReplace(BoundFunctionExpression &ex
 		return std::move(*ptr);
 	}
 
-	const idx_t storage_index = analysis.StorageIndex(column_index);
-	const LogicalType return_type = analysis.get.returned_types[storage_index];
+	const LogicalType return_type = analysis.GetPushdownType(column_index);
 	bound_col_base->SetReturnType(return_type);
 	if (projection != nullptr && !projection->types.empty()) {
 		projection->types[column_index] = return_type;

--- a/src/optimizer/scalar_fn_pushdown.cpp
+++ b/src/optimizer/scalar_fn_pushdown.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/optimizer/scalar_fn_pushdown.hpp"
 #include "duckdb/common/types.hpp"
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/planner/operator/logical_projection.hpp"
 

--- a/src/optimizer/type_pushdown.cpp
+++ b/src/optimizer/type_pushdown.cpp
@@ -221,8 +221,7 @@ unique_ptr<Expression> CastReplace::VisitReplace(BoundColumnRefExpression &expr,
 
 	const auto &[analysis, column_index, projection] = *binding;
 	if (CanPushdownColumn(analysis, column_index)) {
-		const idx_t storage_index = analysis.StorageIndex(column_index);
-		const LogicalType return_type = analysis.get.returned_types[storage_index];
+		const LogicalType return_type = analysis.GetPushdownType(column_index);
 		expr.SetReturnType(return_type);
 		// LogicalProjection types are resolved by calling
 		// LogicalProjection::ResolveTypes, so we need to check whether types in
@@ -251,8 +250,7 @@ unique_ptr<Expression> CastReplace::VisitReplace(BoundCastExpression &expr, uniq
 		return std::move(*ptr);
 	}
 
-	const idx_t storage_index = analysis.StorageIndex(column_index);
-	const LogicalType return_type = analysis.get.returned_types[storage_index];
+	const LogicalType return_type = analysis.GetPushdownType(column_index);
 	bound_col_base->SetReturnType(return_type);
 	// Same as in CastReplace::VisitReplace(BoundColumnRefExpression)
 	if (projection != nullptr && !projection->types.empty()) {
@@ -276,5 +274,13 @@ bool CanPushdownColumn(const GetAnalysis &analysis, ProjectionIndex idx) {
 
 idx_t GetAnalysis::StorageIndex(ProjectionIndex idx) const {
 	return get.GetColumnIds()[idx].GetPrimaryIndex();
+}
+
+LogicalType GetAnalysis::GetPushdownType(ProjectionIndex idx) const {
+	const auto &column_id = get.GetColumnIds()[idx];
+	if (column_id.IsPushdownExtract()) {
+		return column_id.GetScanType();
+	}
+	return get.returned_types[StorageIndex(idx)];
 }
 } // namespace duckdb

--- a/src/optimizer/type_pushdown.cpp
+++ b/src/optimizer/type_pushdown.cpp
@@ -29,9 +29,6 @@
 
 namespace duckdb {
 
-TypePushdown::TypePushdown(ClientContext &context) : context(context) {
-}
-
 // A passthrough projection only forwards its child columns, e.g. a VIEW's
 // "SELECT col".
 static bool IsPassthrough(const LogicalProjection &projection) {
@@ -182,7 +179,7 @@ unique_ptr<Expression> CastCollect::VisitReplace(BoundColumnRefExpression &expr,
 	if (const auto binding = Resolve(expr.Binding(), analyses, projections)) {
 		// Column is used without cast applied to it, register a conflict.
 		// Not emplace() as we need to update the value if it was present
-		binding->analysis.col_to_cast[binding->column_index] = nullptr;
+		binding->analysis.col_to_expr[binding->column_index] = nullptr;
 	}
 	return std::move(*ptr);
 }
@@ -198,7 +195,7 @@ unique_ptr<Expression> CastCollect::VisitReplace(BoundCastExpression &expr, uniq
 	if (!binding) {
 		return nullptr;
 	}
-	auto &col_to_cast = binding->analysis.col_to_cast;
+	auto &col_to_cast = binding->analysis.col_to_expr;
 
 	if (auto it = col_to_cast.find(binding->column_index); it == col_to_cast.end()) {
 		// Only a top-level projection cast starts a candidate.
@@ -216,11 +213,6 @@ unique_ptr<Expression> CastCollect::VisitReplace(BoundCastExpression &expr, uniq
 	return std::move(*ptr);
 }
 
-static bool can_pushdown_column(const GetAnalysis &analysis, ProjectionIndex idx) {
-	const auto it = analysis.col_to_cast.find(idx);
-	return it != analysis.col_to_cast.end() && it->second != nullptr;
-}
-
 unique_ptr<Expression> CastReplace::VisitReplace(BoundColumnRefExpression &expr, unique_ptr<Expression> *ptr) {
 	const auto binding = Resolve(expr.Binding(), analyses, projections);
 	if (!binding) {
@@ -228,8 +220,8 @@ unique_ptr<Expression> CastReplace::VisitReplace(BoundColumnRefExpression &expr,
 	}
 
 	const auto &[analysis, column_index, projection] = *binding;
-	if (can_pushdown_column(analysis, column_index)) {
-		const idx_t storage_index = analysis.get.GetColumnIds()[column_index].GetPrimaryIndex();
+	if (CanPushdownColumn(analysis, column_index)) {
+		const idx_t storage_index = analysis.StorageIndex(column_index);
 		const LogicalType return_type = analysis.get.returned_types[storage_index];
 		expr.SetReturnType(return_type);
 		// LogicalProjection types are resolved by calling
@@ -255,11 +247,11 @@ unique_ptr<Expression> CastReplace::VisitReplace(BoundCastExpression &expr, uniq
 	}
 
 	const auto &[analysis, column_index, projection] = *binding;
-	if (!can_pushdown_column(analysis, column_index)) {
+	if (!CanPushdownColumn(analysis, column_index)) {
 		return std::move(*ptr);
 	}
 
-	const idx_t storage_index = analysis.get.GetColumnIds()[column_index].GetPrimaryIndex();
+	const idx_t storage_index = analysis.StorageIndex(column_index);
 	const LogicalType return_type = analysis.get.returned_types[storage_index];
 	bound_col_base->SetReturnType(return_type);
 	// Same as in CastReplace::VisitReplace(BoundColumnRefExpression)
@@ -277,36 +269,12 @@ CastReplace::CastReplace(Analyses &analyses, const Projections &projections)
     : analyses(analyses), projections(projections) {
 }
 
-unique_ptr<LogicalOperator> TypePushdown::Optimize(unique_ptr<LogicalOperator> op) {
-	Analyses analyses;
-	Projections projections;
-	FindGetsAndProjections(*op, analyses, projections);
-	if (analyses.empty()) {
-		return op;
-	}
-	CastCollect(analyses, projections).VisitOperator(*op);
+bool CanPushdownColumn(const GetAnalysis &analysis, ProjectionIndex idx) {
+	const auto it = analysis.col_to_expr.find(idx);
+	return it != analysis.col_to_expr.end() && it->second != nullptr;
+}
 
-	bool any_pushed = false;
-	for (auto &[_, analysis] : analyses) {
-		for (auto &[column_index, expr] : analysis.col_to_cast) {
-			if (expr == nullptr) { // Conflict for column
-				continue;
-			}
-			const idx_t storage_index = analysis.get.GetColumnIds()[column_index].GetPrimaryIndex();
-			TableFunctionProjectionExpressionInput input {analysis.get, *expr, storage_index};
-			if (analysis.get.function.projection_expression_pushdown(context, input)) {
-				// LOGICAL_GET doesn't initialize .types of LogicalOperator
-				analysis.get.returned_types[storage_index] = expr->GetReturnType();
-				any_pushed = true;
-			} else { // failed to push down expression, can't replace it
-				expr = nullptr;
-			}
-		}
-	}
-
-	if (any_pushed) {
-		CastReplace(analyses, projections).VisitOperator(*op);
-	}
-	return op;
+idx_t GetAnalysis::StorageIndex(ProjectionIndex idx) const {
+	return get.GetColumnIds()[idx].GetPrimaryIndex();
 }
 } // namespace duckdb

--- a/src/optimizer/type_pushdown.cpp
+++ b/src/optimizer/type_pushdown.cpp
@@ -72,9 +72,9 @@ void FindGetsAndProjections(LogicalOperator &op, Analyses &analyses, Projections
 	}
 }
 
-std::optional<GetBinding> Resolve(ColumnBinding binding, Analyses &analyses, const Projections &projections) {
+optional<GetBinding> Resolve(ColumnBinding binding, Analyses &analyses, const Projections &projections) {
 	if (IsVirtualColumn(binding.column_index)) {
-		return std::nullopt;
+		return nullopt;
 	}
 	if (const auto it = analyses.find(binding.table_index); it != analyses.end()) {
 		return {{it->second, binding.column_index, nullptr}};
@@ -82,22 +82,22 @@ std::optional<GetBinding> Resolve(ColumnBinding binding, Analyses &analyses, con
 
 	const auto projection_it = projections.find(binding.table_index);
 	if (projection_it == projections.end()) {
-		return std::nullopt;
+		return nullopt;
 	}
 
 	LogicalProjection &projection = projection_it->second;
 	const auto &inner = projection.expressions[binding.column_index];
 	if (inner->GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
-		return std::nullopt;
+		return nullopt;
 	}
 	const ColumnBinding get_binding = inner->Cast<BoundColumnRefExpression>().Binding();
 	if (IsVirtualColumn(get_binding.column_index)) {
-		return std::nullopt;
+		return nullopt;
 	}
 	if (const auto it = analyses.find(get_binding.table_index); it != analyses.end()) {
 		return {{it->second, get_binding.column_index, &projection}};
 	}
-	return std::nullopt;
+	return nullopt;
 }
 
 /**

--- a/src/optimizer/type_pushdown.cpp
+++ b/src/optimizer/type_pushdown.cpp
@@ -221,7 +221,7 @@ unique_ptr<Expression> CastReplace::VisitReplace(BoundColumnRefExpression &expr,
 
 	const auto &[analysis, column_index, projection] = *binding;
 	if (CanPushdownColumn(analysis, column_index)) {
-		const LogicalType return_type = analysis.GetPushdownType(column_index);
+		const LogicalType return_type = analysis.get.returned_types[analysis.StorageIndex(column_index)];
 		expr.SetReturnType(return_type);
 		// LogicalProjection types are resolved by calling
 		// LogicalProjection::ResolveTypes, so we need to check whether types in
@@ -250,7 +250,7 @@ unique_ptr<Expression> CastReplace::VisitReplace(BoundCastExpression &expr, uniq
 		return std::move(*ptr);
 	}
 
-	const LogicalType return_type = analysis.GetPushdownType(column_index);
+	const LogicalType return_type = analysis.get.returned_types[analysis.StorageIndex(column_index)];
 	bound_col_base->SetReturnType(return_type);
 	// Same as in CastReplace::VisitReplace(BoundColumnRefExpression)
 	if (projection != nullptr && !projection->types.empty()) {
@@ -274,13 +274,5 @@ bool CanPushdownColumn(const GetAnalysis &analysis, ProjectionIndex idx) {
 
 idx_t GetAnalysis::StorageIndex(ProjectionIndex idx) const {
 	return get.GetColumnIds()[idx].GetPrimaryIndex();
-}
-
-LogicalType GetAnalysis::GetPushdownType(ProjectionIndex idx) const {
-	const auto &column_id = get.GetColumnIds()[idx];
-	if (column_id.IsPushdownExtract()) {
-		return column_id.GetScanType();
-	}
-	return get.returned_types[StorageIndex(idx)];
 }
 } // namespace duckdb

--- a/test/configs/disable_optimizer.json
+++ b/test/configs/disable_optimizer.json
@@ -97,9 +97,10 @@
       ]
     },
     {
-      "reason": "Type pushdown optimizer changes output types",
+      "reason": "Type and function pushdown optimizers changes output types",
       "paths": [
         "test/optimizer/pushdown/csv_type_pushdown.test",
+        "test/optimizer/pushdown/scalar_function_pushdown.test",
         "test/sql/copy/csv/test_insert_into_types.test",
         "test/sql/copy/csv/test_csv_error_message_type.test",
         "test/sql/copy/csv/test_timestamptz_12926.test"

--- a/test/configs/verification_projection.json
+++ b/test/configs/verification_projection.json
@@ -4,9 +4,10 @@
   "skip_compiled": "true",
   "skip_tests": [
     {
-      "reason": "Type pushdown optimizer collapses projections and checks for that",
+      "reason": "Type and function pushdown optimizers collapses projections and check for that",
       "paths": [
-        "test/optimizer/pushdown/csv_type_pushdown.test"
+        "test/optimizer/pushdown/csv_type_pushdown.test",
+        "test/optimizer/pushdown/scalar_function_pushdown.test"
       ]
     }
   ]

--- a/test/optimizer/pushdown/scalar_function_pushdown.test
+++ b/test/optimizer/pushdown/scalar_function_pushdown.test
@@ -479,10 +479,29 @@ FROM '{TEST_DIR}/scalar-pushdown-nested.parquet'
 physical_plan	<REGEX>:.*PROJECTION.*
 
 statement ok
+COPY (SELECT {'x': 'a', 'y': 'b'} s, 'hello' v)
+TO '{TEST_DIR}/scalar-pushdown-nested-2.parquet' (FORMAT PARQUET, PARQUET_VERSION v1);
+
+query I
+SELECT strlen(s.x)
+FROM '{TEST_DIR}/scalar-pushdown-nested-2.parquet';
+----
+1
+
+statement ok
+COPY (SELECT {'x': 'a', 'y': {'z': 'aa'}} s, 'hello' v)
+TO '{TEST_DIR}/scalar-pushdown-nested-3.parquet' (FORMAT PARQUET, PARQUET_VERSION v1);
+
+query I
+SELECT strlen(s.y.z)
+FROM '{TEST_DIR}/scalar-pushdown-nested-3.parquet';
+----
+2
+
+statement ok
 COPY (SELECT 'hello world ' || r AS s, r FROM range(3) t(r)) TO '{TEST_DIR}/scalar-pushdown-filter.parquet';
 
 query I
 SELECT strlen(s) FROM '{TEST_DIR}/scalar-pushdown-filter.parquet' WHERE r = 2;
 ----
 13
-

--- a/test/optimizer/pushdown/scalar_function_pushdown.test
+++ b/test/optimizer/pushdown/scalar_function_pushdown.test
@@ -477,3 +477,12 @@ EXPLAIN SELECT strlen(v)
 FROM '{TEST_DIR}/scalar-pushdown-nested.parquet'
 ----
 physical_plan	<REGEX>:.*PROJECTION.*
+
+statement ok
+COPY (SELECT 'hello world ' || r AS s, r FROM range(3) t(r)) TO '{TEST_DIR}/scalar-pushdown-filter.parquet';
+
+query I
+SELECT strlen(s) FROM '{TEST_DIR}/scalar-pushdown-filter.parquet' WHERE r = 2;
+----
+13
+

--- a/test/optimizer/pushdown/scalar_function_pushdown.test
+++ b/test/optimizer/pushdown/scalar_function_pushdown.test
@@ -482,6 +482,13 @@ statement ok
 COPY (SELECT {'x': 'a', 'y': 'b'} s, 'hello' v)
 TO '{TEST_DIR}/scalar-pushdown-nested-2.parquet' (FORMAT PARQUET, PARQUET_VERSION v1);
 
+# pushdown-extract columns e.g s.x are not pushed down
+query II
+EXPLAIN SELECT strlen(s.x)
+FROM '{TEST_DIR}/scalar-pushdown-nested-2.parquet'
+----
+physical_plan	<REGEX>:.*PROJECTION.*
+
 query I
 SELECT strlen(s.x)
 FROM '{TEST_DIR}/scalar-pushdown-nested-2.parquet';
@@ -491,6 +498,12 @@ FROM '{TEST_DIR}/scalar-pushdown-nested-2.parquet';
 statement ok
 COPY (SELECT {'x': 'a', 'y': {'z': 'aa'}} s, 'hello' v)
 TO '{TEST_DIR}/scalar-pushdown-nested-3.parquet' (FORMAT PARQUET, PARQUET_VERSION v1);
+
+query II
+EXPLAIN SELECT strlen(s.y.z)
+FROM '{TEST_DIR}/scalar-pushdown-nested-3.parquet'
+----
+physical_plan	<REGEX>:.*PROJECTION.*
 
 query I
 SELECT strlen(s.y.z)

--- a/test/optimizer/pushdown/scalar_function_pushdown.test
+++ b/test/optimizer/pushdown/scalar_function_pushdown.test
@@ -457,45 +457,23 @@ ORDER BY ALL;
 1
 2
 
-statement ok
-COPY (SELECT 'bb'::VARCHAR AS s)
-TO '{TEST_DIR}/01_scalar_fn_plain2.parquet' (FORMAT PARQUET, PARQUET_VERSION v1);
-
-# Metadata isn't present in caches so we can't determine the encoding, reject pushdown
 query II
 EXPLAIN SELECT strlen(s)
-FROM read_parquet(['{TEST_DIR}/00_scalar_fn_plain.parquet', '{TEST_DIR}/01_scalar_fn_plain2.parquet']);
+FROM read_parquet(['{TEST_DIR}/00_scalar_fn_plain.parquet', '{TEST_DIR}/99_scalar_fn_delta.parquet']);
 ----
 physical_plan	<REGEX>:.*PROJECTION.*
 
 statement ok
-SET parquet_metadata_cache = true;
-
-# Populate cache
-statement ok
-SELECT s FROM read_parquet(['{TEST_DIR}/00_scalar_fn_plain.parquet', '{TEST_DIR}/01_scalar_fn_plain2.parquet']);
-
-# Now we have all caches, pushdown succeeds
-query II
-EXPLAIN SELECT strlen(s)
-FROM read_parquet(['{TEST_DIR}/00_scalar_fn_plain.parquet', '{TEST_DIR}/01_scalar_fn_plain2.parquet']);
-----
-physical_plan	<!REGEX>:.*PROJECTION.*
+COPY (SELECT {'x':0,'y':0} s, 'hello' v) TO '{TEST_DIR}/scalar-pushdown-nested.parquet' (PARQUET_VERSION V2);
 
 query I
-SELECT strlen(s)
-FROM read_parquet(['{TEST_DIR}/00_scalar_fn_plain.parquet', '{TEST_DIR}/01_scalar_fn_plain2.parquet'])
-ORDER BY ALL;
+SELECT strlen(v)
+FROM '{TEST_DIR}/scalar-pushdown-nested.parquet'
 ----
 1
-2
 
-statement ok
-SELECT s FROM read_parquet(['{TEST_DIR}/00_scalar_fn_plain.parquet', '{TEST_DIR}/99_scalar_fn_delta.parquet']);
-
-# Pushdown rejected because second file's encoding is unsupported
 query II
-EXPLAIN SELECT strlen(s)
-FROM read_parquet(['{TEST_DIR}/00_scalar_fn_plain.parquet', '{TEST_DIR}/99_scalar_fn_delta.parquet']);
+EXPLAIN SELECT strlen(v)
+FROM '{TEST_DIR}/scalar-pushdown-nested.parquet'
 ----
 physical_plan	<REGEX>:.*PROJECTION.*

--- a/test/optimizer/pushdown/scalar_function_pushdown.test
+++ b/test/optimizer/pushdown/scalar_function_pushdown.test
@@ -431,3 +431,71 @@ query II
 EXPLAIN SELECT data, octet_length(data) FROM '{TEST_DIR}/pe-blob.parquet';
 ----
 physical_plan	<REGEX>:.*PROJECTION.*
+
+# Test unsupported encoding rejects pushdown in any of files
+
+statement ok
+COPY (SELECT 'a'::VARCHAR AS s)
+TO '{TEST_DIR}/00_scalar_fn_plain.parquet' (FORMAT PARQUET, PARQUET_VERSION v1);
+
+statement ok
+COPY (SELECT range::VARCHAR AS s FROM range(30))
+TO '{TEST_DIR}/99_scalar_fn_delta.parquet' (FORMAT PARQUET, PARQUET_VERSION v2, DICTIONARY_SIZE_LIMIT 1);
+
+query I
+SELECT strlen(s)
+FROM '{TEST_DIR}/00_scalar_fn_plain.parquet'
+ORDER BY ALL;
+----
+1
+
+query I
+SELECT DISTINCT strlen(s)
+FROM read_parquet(['{TEST_DIR}/00_scalar_fn_plain.parquet', '{TEST_DIR}/99_scalar_fn_delta.parquet'])
+ORDER BY ALL;
+----
+1
+2
+
+statement ok
+COPY (SELECT 'bb'::VARCHAR AS s)
+TO '{TEST_DIR}/01_scalar_fn_plain2.parquet' (FORMAT PARQUET, PARQUET_VERSION v1);
+
+# Metadata isn't present in caches so we can't determine the encoding, reject pushdown
+query II
+EXPLAIN SELECT strlen(s)
+FROM read_parquet(['{TEST_DIR}/00_scalar_fn_plain.parquet', '{TEST_DIR}/01_scalar_fn_plain2.parquet']);
+----
+physical_plan	<REGEX>:.*PROJECTION.*
+
+statement ok
+SET parquet_metadata_cache = true;
+
+# Populate cache
+statement ok
+SELECT s FROM read_parquet(['{TEST_DIR}/00_scalar_fn_plain.parquet', '{TEST_DIR}/01_scalar_fn_plain2.parquet']);
+
+# Now we have all caches, pushdown succeeds
+query II
+EXPLAIN SELECT strlen(s)
+FROM read_parquet(['{TEST_DIR}/00_scalar_fn_plain.parquet', '{TEST_DIR}/01_scalar_fn_plain2.parquet']);
+----
+physical_plan	<!REGEX>:.*PROJECTION.*
+
+query I
+SELECT strlen(s)
+FROM read_parquet(['{TEST_DIR}/00_scalar_fn_plain.parquet', '{TEST_DIR}/01_scalar_fn_plain2.parquet'])
+ORDER BY ALL;
+----
+1
+2
+
+statement ok
+SELECT s FROM read_parquet(['{TEST_DIR}/00_scalar_fn_plain.parquet', '{TEST_DIR}/99_scalar_fn_delta.parquet']);
+
+# Pushdown rejected because second file's encoding is unsupported
+query II
+EXPLAIN SELECT strlen(s)
+FROM read_parquet(['{TEST_DIR}/00_scalar_fn_plain.parquet', '{TEST_DIR}/99_scalar_fn_delta.parquet']);
+----
+physical_plan	<REGEX>:.*PROJECTION.*

--- a/test/optimizer/pushdown/scalar_function_pushdown.test
+++ b/test/optimizer/pushdown/scalar_function_pushdown.test
@@ -1,0 +1,433 @@
+# name: test/optimizer/pushdown/scalar_function_pushdown.test
+# description: Test Parquet With Pushing Down Scalar Functions
+# group: [pushdown]
+
+require parquet
+
+statement ok
+SET profiling_renderer_settings = MAP {'operator_casing': 'upper'};
+
+# str has storage_index=1. This tests cases where column_index (i.e. 0 in
+# SELECT strlen(str)) is different from storage_index.
+statement ok
+CREATE TABLE pep_test (before INTEGER, str VARCHAR, after INTEGER);
+
+statement ok
+INSERT INTO pep_test VALUES (0, 'Hello', 0), (1, 'Hi', 1), (2, 'Hey', 2);
+
+statement ok
+COPY (SELECT * FROM pep_test) TO '{TEST_DIR}/pe-pushdown.parquet';
+
+query T
+SELECT str FROM '{TEST_DIR}/pe-pushdown.parquet' ORDER BY str;
+----
+Hello
+Hey
+Hi
+
+# strlen is pushed down
+query II
+EXPLAIN SELECT strlen(str) FROM '{TEST_DIR}/pe-pushdown.parquet';
+----
+physical_plan	<!REGEX>:.*PROJECTION.*
+
+# we need "order by" for test output to be deterministic
+query I
+SELECT strlen(str) FROM '{TEST_DIR}/pe-pushdown.parquet' ORDER BY strlen(str);
+----
+2
+3
+5
+
+# explain: same for aliased columns
+query II
+EXPLAIN SELECT strlen(str) AS l FROM '{TEST_DIR}/pe-pushdown.parquet';
+----
+physical_plan	<!REGEX>:.*PROJECTION.*
+
+query I
+SELECT strlen(str) AS l FROM '{TEST_DIR}/pe-pushdown.parquet' ORDER BY strlen(str);
+----
+2
+3
+5
+
+# explain: any filter on the column blocks length pushdown
+query II
+EXPLAIN SELECT strlen(str) FROM '{TEST_DIR}/pe-pushdown.parquet'
+WHERE strlen(str) > 2;
+----
+physical_plan	<REGEX>:.*PROJECTION.*
+
+query I
+SELECT strlen(str) AS l FROM '{TEST_DIR}/pe-pushdown.parquet'
+WHERE strlen(str) > 2
+ORDER BY strlen(str);
+----
+3
+5
+
+# Same, but filter expression has multiple children
+query I
+SELECT strlen(str) AS l FROM '{TEST_DIR}/pe-pushdown.parquet'
+WHERE strlen(str) * 2 > 4
+ORDER BY strlen(str);
+----
+3
+5
+
+query I
+SELECT strlen(str) AS l FROM '{TEST_DIR}/pe-pushdown.parquet'
+WHERE len(str) * 2 > 4
+ORDER BY strlen(str);
+----
+3
+5
+
+# strlen with filter using len, no pushdown
+query I
+SELECT strlen(str) FROM '{TEST_DIR}/pe-pushdown.parquet'
+WHERE len(str) > 2
+ORDER BY strlen(str);
+----
+3
+5
+
+# explain: len() in WHERE conflicts with strlen() in SELECT, no pushdown
+query II
+EXPLAIN SELECT strlen(str) FROM '{TEST_DIR}/pe-pushdown.parquet' WHERE len(str) > 2;
+----
+physical_plan	<REGEX>:.*PROJECTION.*
+
+# strlen with bare str: no pushdown
+query TI
+SELECT str, strlen(str) AS l FROM '{TEST_DIR}/pe-pushdown.parquet'
+WHERE strlen(str) > 3 ORDER BY str;
+----
+Hello	5
+
+# explain: bare str in SELECT conflicts with strlen(), no pushdown
+query II
+EXPLAIN SELECT str, strlen(str) FROM '{TEST_DIR}/pe-pushdown.parquet';
+----
+physical_plan	<REGEX>:.*PROJECTION.*
+
+# pushdown of prefix() not supported
+query T
+SELECT prefix(str, 'H') FROM '{TEST_DIR}/pe-pushdown.parquet' ORDER BY str;
+----
+true
+true
+true
+
+# conflict on str, no pushdown.
+query TI
+SELECT str, strlen(str) AS l FROM '{TEST_DIR}/pe-pushdown.parquet'
+WHERE strlen(str) > 3 ORDER BY str;
+----
+Hello	5
+
+# conflict in SELECT, no pushdown
+query TI
+SELECT str, strlen(str) AS l FROM '{TEST_DIR}/pe-pushdown.parquet' ORDER BY str;
+----
+Hello	5
+Hey	3
+Hi	2
+
+# same with aliased strlen()
+query IT
+SELECT strlen(str) AS l, str FROM '{TEST_DIR}/pe-pushdown.parquet' ORDER BY str;
+----
+5	Hello
+3	Hey
+2	Hi
+
+# str as part of multi-arg ||, conflict
+query IT
+SELECT strlen(str) AS l, str || '!' AS s FROM '{TEST_DIR}/pe-pushdown.parquet'
+ORDER BY l;
+----
+2	Hi!
+3	Hey!
+5	Hello!
+
+query II
+EXPLAIN SELECT strlen(str), str || '!' FROM '{TEST_DIR}/pe-pushdown.parquet';
+----
+physical_plan	<REGEX>:.*PROJECTION.*
+
+# strlen() and a different multi-arg use of str (substr): no pushdown
+query IT
+SELECT strlen(str) AS l, substr(str, 1, 1) AS c FROM '{TEST_DIR}/pe-pushdown.parquet'
+ORDER BY l;
+----
+2	H
+3	H
+5	H
+
+# fn -> cte
+query I
+SELECT strlen(str) FROM (SELECT str FROM '{TEST_DIR}/pe-pushdown.parquet' ORDER BY str);
+----
+5
+3
+2
+
+# fn -> cte -> cte
+query I
+WITH cte1 AS (SELECT str FROM '{TEST_DIR}/pe-pushdown.parquet' ORDER BY str),
+     cte2 AS (SELECT str from cte1)
+SELECT strlen(str) FROM cte2;
+----
+5
+3
+2
+
+# cte -> fn -> cte
+query TI
+WITH cte1 AS (SELECT str FROM '{TEST_DIR}/pe-pushdown.parquet' ORDER BY str),
+     cte2 AS (SELECT str, strlen(str) as l from cte1)
+SELECT str, l FROM cte2;
+----
+Hello	5
+Hey	3
+Hi	2
+
+statement ok
+CREATE VIEW pe1 AS SELECT str FROM '{TEST_DIR}/pe-pushdown.parquet';
+
+query T
+SELECT str FROM pe1 ORDER BY str;
+----
+Hello
+Hey
+Hi
+
+query I
+SELECT strlen(str) FROM pe1 ORDER BY strlen(str);
+----
+2
+3
+5
+
+query II
+EXPLAIN SELECT strlen(str) FROM pe1;
+----
+physical_plan	<!REGEX>:.*PROJECTION.*
+
+# nested view
+statement ok
+CREATE VIEW pe2 AS SELECT str FROM pe1;
+
+query T
+SELECT str FROM pe2 ORDER BY str;
+----
+Hello
+Hey
+Hi
+
+query I
+SELECT strlen(str) FROM pe2 ORDER BY strlen(str);
+----
+2
+3
+5
+
+query TI
+SELECT str, strlen(str) FROM pe2 ORDER BY str;
+----
+Hello	5
+Hey	3
+Hi	2
+
+# fn -> cte with fn -> cte
+query I
+WITH cte1 AS (SELECT str FROM '{TEST_DIR}/pe-pushdown.parquet' ORDER BY str),
+     cte2 AS (SELECT str, strlen(str) as l from cte1)
+SELECT strlen(str) FROM cte2;
+----
+5
+3
+2
+
+query II
+SELECT before, strlen(str) AS l FROM '{TEST_DIR}/pe-pushdown.parquet' ORDER BY before;
+----
+0	5
+1	2
+2	3
+
+query II
+SELECT strlen(str) AS l, after FROM '{TEST_DIR}/pe-pushdown.parquet' ORDER BY after;
+----
+5	0
+2	1
+3	2
+
+# virtual columns don't block pushdown
+query II
+SELECT strlen(str) AS l, file_row_number FROM read_parquet('{TEST_DIR}/pe-pushdown.parquet', file_row_number=true) ORDER BY l DESC;
+----
+5	0
+3	2
+2	1
+
+query I
+SELECT strlen(str) AS l FROM pe2 ORDER BY l DESC;
+----
+5
+3
+2
+
+# no pushdown (two levels of indirection)
+query TI
+SELECT str, strlen(str) AS l FROM pe2 ORDER BY str;
+----
+Hello	5
+Hey	3
+Hi	2
+
+# explain: two levels of indirection, no pushdown
+query II
+EXPLAIN SELECT strlen(str) FROM pe2;
+----
+physical_plan	<REGEX>:.*PROJECTION.*
+
+# cte -> view -> pe2
+query I
+WITH cte AS (SELECT str FROM pe2)
+SELECT strlen(str) FROM cte ORDER BY str;
+----
+5
+3
+2
+
+# strlen(str) * 2 must be visited correctly in replace visitor
+query II
+SELECT strlen(str) AS a, strlen(str) * 2 AS b FROM pe1 ORDER BY a;
+----
+2	4
+3	6
+5	10
+
+# conflict in SELECT, no pushdown
+query II
+SELECT strlen(str) AS a, len(str) * 2 AS b FROM pe1 ORDER BY a;
+----
+2	4
+3	6
+5	10
+
+# constant comparison is pushed down as a complex filter so WHERE disappears.
+# This is only usage of str in SELECT so we push it down
+query II
+EXPLAIN SELECT strlen(str) FROM '{TEST_DIR}/pe-pushdown.parquet'
+WHERE str != '';
+----
+physical_plan	<!REGEX>:.*PROJECTION.*
+
+query I
+SELECT strlen(str) FROM '{TEST_DIR}/pe-pushdown.parquet'
+WHERE str != ''
+ORDER BY strlen(str);
+----
+2
+3
+5
+
+# prefix isn't pushed down as a complex filter so WHERE is not pushed down
+# although this is only usage of str in SELECT, we can't push strlen down
+# as there is usage in WHERE.
+# This also tests functions with multiple arguments using "str" inside
+query I
+SELECT strlen(str) FROM '{TEST_DIR}/pe-pushdown.parquet'
+WHERE prefix("str", 'H') > 0
+ORDER BY strlen(str);
+----
+2
+3
+5
+
+query I
+SELECT strlen(str) FROM '{TEST_DIR}/pe-pushdown.parquet'
+WHERE suffix(concat("str", 'y'), 'y') > 0
+ORDER BY strlen(str);
+----
+2
+3
+5
+
+# explain: prefix()/suffix() in WHERE are multi-arg uses of str, no pushdown
+query II
+EXPLAIN SELECT strlen(str) FROM '{TEST_DIR}/pe-pushdown.parquet' WHERE prefix("str", 'H') > 0;
+----
+physical_plan	<REGEX>:.*PROJECTION.*
+
+# conflict with concat(), no pushdown
+query I
+SELECT strlen(str) FROM '{TEST_DIR}/pe-pushdown.parquet'
+WHERE concat(str, str) = 'HelloHello'
+ORDER BY strlen(str);
+----
+5
+
+# both strlen()s are replaced correctly.
+query II
+SELECT strlen(str), strlen(str) * 2 FROM '{TEST_DIR}/pe-pushdown.parquet'
+ORDER BY strlen(str);
+----
+2	4
+3	6
+5	10
+
+query I
+SELECT strlen(str) FROM '{TEST_DIR}/pe-pushdown.parquet'
+WHERE str = 'Hello' ORDER BY strlen(str);
+----
+5
+
+# ConstantFilter on "str" blocks pushdown
+query II
+EXPLAIN SELECT strlen(str) FROM '{TEST_DIR}/pe-pushdown.parquet' WHERE str = 'Hello';
+----
+physical_plan	<REGEX>:.*PROJECTION.*
+
+# function application conflict
+query II
+EXPLAIN SELECT strlen(str) FROM '{TEST_DIR}/pe-pushdown.parquet' WHERE prefix(str, 'H');
+----
+physical_plan	<REGEX>:.*PROJECTION.*
+
+statement ok
+CREATE TABLE pep_blob (before INTEGER, data BLOB, after INTEGER);
+
+statement ok
+INSERT INTO pep_blob VALUES (0, 'Hello'::BLOB, 0), (1, 'Hi'::BLOB, 1), (2, 'Hey'::BLOB, 2);
+
+statement ok
+COPY (SELECT * FROM pep_blob) TO '{TEST_DIR}/pe-blob.parquet';
+
+query II
+EXPLAIN SELECT octet_length(data) FROM '{TEST_DIR}/pe-blob.parquet';
+----
+physical_plan	<!REGEX>:.*PROJECTION.*
+
+query I
+SELECT octet_length(data) FROM '{TEST_DIR}/pe-blob.parquet' ORDER BY 1;
+----
+2
+3
+5
+
+query I
+SELECT octet_length(data) AS l FROM '{TEST_DIR}/pe-blob.parquet'
+WHERE octet_length(data) > 2 ORDER BY l;
+----
+3
+5
+
+query II
+EXPLAIN SELECT data, octet_length(data) FROM '{TEST_DIR}/pe-blob.parquet';
+----
+physical_plan	<REGEX>:.*PROJECTION.*

--- a/test/optimizer/pushdown/scalar_function_pushdown.test
+++ b/test/optimizer/pushdown/scalar_function_pushdown.test
@@ -470,7 +470,7 @@ query I
 SELECT strlen(v)
 FROM '{TEST_DIR}/scalar-pushdown-nested.parquet'
 ----
-1
+5
 
 query II
 EXPLAIN SELECT strlen(v)


### PR DESCRIPTION
This PR supports pushing down single-argument scalar functions in SELECT expression of form SELECT fn(T) into file readers.
Changes:

- New optimizer pass reusing most code from type pushdown
- Parquet support for pushdown: pushes octet_length() and strlen() to file reader. Both are not pushed for pushdown-extract columns, for multiple files, and for custom schema readers like Ducklake.
- projection_expression_pushdown now takes a column index in LOGICAL_GET instead of projection index. This allows getting a full ColumnIndex which in turn would allow supporting pushdown-extract columns in the future.