### PR TITLE
Configurable approximate join order threshold

### DIFF
--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -115,6 +115,13 @@
         "custom_implementation": true
     },
     {
+        "name": "approximate_join_order_threshold",
+        "description": "The minimum number of tables in a join to determine the optimal join order approximately instead of exactly.",
+        "type": "UBIGINT",
+        "default_scope": "local",
+        "default_value": "12"
+    },
+    {
         "name": "arrow_large_buffer_size",
         "description": "Whether Arrow buffers for strings, blobs, uuids and bits should be exported using large buffers",
         "type": "BOOLEAN",

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -258,6 +258,17 @@ struct AllowedPathsSetting {
 	static Value GetSetting(const ClientContext &context);
 };
 
+struct ApproximateJoinOrderThresholdSetting {
+	using RETURN_TYPE = idx_t;
+	static constexpr const char *Name = "approximate_join_order_threshold";
+	static constexpr const char *Description =
+	    "The minimum number of tables in a join to determine the optimal join order approximately instead of exactly.";
+	static constexpr const char *InputType = "UBIGINT";
+	static constexpr const char *DefaultValue = "12";
+	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
+	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+};
+
 struct ArrowLargeBufferSizeSetting {
 	using RETURN_TYPE = bool;
 	static constexpr const char *Name = "arrow_large_buffer_size";

--- a/src/include/duckdb/optimizer/join_order/plan_enumerator.hpp
+++ b/src/include/duckdb/optimizer/join_order/plan_enumerator.hpp
@@ -28,8 +28,6 @@ class QueryGraphManager;
 
 class PlanEnumerator {
 public:
-	static constexpr idx_t THRESHOLD_TO_SWAP_TO_APPROXIMATE = 12;
-
 	explicit PlanEnumerator(QueryGraphManager &query_graph_manager, CostModel &cost_model,
 	                        const QueryGraphEdges &query_graph);
 

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -80,6 +80,7 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_GLOBAL(AllowedConfigsSetting),
     DUCKDB_GLOBAL(AllowedDirectoriesSetting),
     DUCKDB_GLOBAL(AllowedPathsSetting),
+    DUCKDB_SETTING(ApproximateJoinOrderThresholdSetting),
     DUCKDB_SETTING(ArrowLargeBufferSizeSetting),
     DUCKDB_SETTING(ArrowLosslessConversionSetting),
     DUCKDB_SETTING(ArrowOutputListViewSetting),
@@ -246,14 +247,14 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_SETTING(ZstdMinStringLengthSetting),
     FINAL_SETTING};
 
-static const ConfigurationAlias setting_aliases[] = {DUCKDB_SETTING_ALIAS("configure_metrics", 29),
-                                                     DUCKDB_SETTING_ALIAS("custom_profiling_settings", 29),
-                                                     DUCKDB_SETTING_ALIAS("memory_limit", 128),
-                                                     DUCKDB_SETTING_ALIAS("null_order", 61),
-                                                     DUCKDB_SETTING_ALIAS("profile_output", 151),
-                                                     DUCKDB_SETTING_ALIAS("user", 169),
-                                                     DUCKDB_SETTING_ALIAS("wal_autocheckpoint", 28),
-                                                     DUCKDB_SETTING_ALIAS("worker_threads", 167),
+static const ConfigurationAlias setting_aliases[] = {DUCKDB_SETTING_ALIAS("configure_metrics", 30),
+                                                     DUCKDB_SETTING_ALIAS("custom_profiling_settings", 30),
+                                                     DUCKDB_SETTING_ALIAS("memory_limit", 129),
+                                                     DUCKDB_SETTING_ALIAS("null_order", 62),
+                                                     DUCKDB_SETTING_ALIAS("profile_output", 152),
+                                                     DUCKDB_SETTING_ALIAS("user", 170),
+                                                     DUCKDB_SETTING_ALIAS("wal_autocheckpoint", 29),
+                                                     DUCKDB_SETTING_ALIAS("worker_threads", 168),
                                                      FINAL_ALIAS};
 
 vector<ConfigurationOption> DBConfig::GetOptions() {

--- a/src/optimizer/join_order/plan_enumerator.cpp
+++ b/src/optimizer/join_order/plan_enumerator.cpp
@@ -531,8 +531,11 @@ void PlanEnumerator::InitLeafPlans() {
 // https://db.in.tum.de/teaching/ws1415/queryopt/chapter3.pdf?lang=de
 void PlanEnumerator::SolveJoinOrder() {
 	bool force_no_cross_product = Settings::Get<DebugForceNoCrossProductSetting>(query_graph_manager.context);
+	auto swap_to_approximate_threshold =
+	    Settings::Get<ApproximateJoinOrderThresholdSetting>(query_graph_manager.context);
+
 	// first try to solve the join order exactly
-	if (query_graph_manager.relation_manager.NumRelations() >= THRESHOLD_TO_SWAP_TO_APPROXIMATE) {
+	if (query_graph_manager.relation_manager.NumRelations() >= swap_to_approximate_threshold) {
 		SolveJoinOrderApproximately();
 	} else if (!SolveJoinOrderExactly()) {
 		// otherwise, if that times out we resort to a greedy algorithm

--- a/test/optimizer/joins/order_optimizer_bindings.test
+++ b/test/optimizer/joins/order_optimizer_bindings.test
@@ -7,5 +7,14 @@ foreach threshold 0 30
 statement ok
 PRAGMA approximate_join_order_threshold = {threshold};
 
-statement ok
+query IIII
 SELECT * FROM summary((select 5)) tbl1(i) JOIN summary((select 5)) tbl2(i) ON tbl1.i=tbl2.i;
+----
+[5]	5	[5]	5
+
+endloop
+
+statement error
+PRAGMA approximate_join_order_threshold = -1;
+----
+Invalid Input Error: Failed to cast value: Type INT32 with value -1 can't be cast because the value is out of range for the destination type UINT64

--- a/test/optimizer/joins/order_optimizer_bindings.test
+++ b/test/optimizer/joins/order_optimizer_bindings.test
@@ -2,5 +2,10 @@
 # description: In the join order optimizer queries need to have the correct bindings
 # group: [joins]
 
+foreach threshold 0 30
+
+statement ok
+PRAGMA approximate_join_order_threshold = {threshold};
+
 statement ok
 SELECT * FROM summary((select 5)) tbl1(i) JOIN summary((select 5)) tbl2(i) ON tbl1.i=tbl2.i;

--- a/test/optimizer/joins/order_optimizer_bindings.test
+++ b/test/optimizer/joins/order_optimizer_bindings.test
@@ -13,8 +13,3 @@ SELECT * FROM summary((select 5)) tbl1(i) JOIN summary((select 5)) tbl2(i) ON tb
 [5]	5	[5]	5
 
 endloop
-
-statement error
-PRAGMA approximate_join_order_threshold = -1;
-----
-Invalid Input Error: Failed to cast value: Type INT32 with value -1 can't be cast because the value is out of range for the destination type UINT64


### PR DESCRIPTION
### Hello
I am a computer science student of the university of Tübingen and have just started working on my masters thesis supervised by @Teggy  and @timfi. Over the course of my masters thesis, I will take a closer look at the optimizer and try to find and implement some improvements. This PR is the first (tiny) contribution.

## Changes
Introduces a new setting `approximate_join_order_threshold`. This setting lets users configure the maximum number of tables for which the optimizer computes the join order using the exact algorithm, instead of it being fixed to 12 join partners.

## Benchmark
From the [join-order-benchmark](https://github.com/gregrahn/join-order-benchmark), some queries profit from changing the threshold. For example, query `7c` which has 8 join partners speeds up a lot with the approximate algorithm. The measurements presented were made on my laptop, the trend is the same on the universities server though.

Using `.timer on` :
|threshold | query execution time|
|-----------|------------------------|
|8 (approximate)|Run Time (s): real 0.208 user 0.643378 sys 0.470962|
|9 (exact)| Run Time (s): real 1.772 user 2.194499 sys 4.251899|

Using detailed profiling with `PRAGMA enable_profiling;`
|threshold| join_order_optimizer time| sum of all join `operator_timing`s|
|----------|-----------------------------|------------------------------------------|
|8|0.00023|0.4561|
|9|0.00088|20.6082|

The fact that actually doing the joins takes that much longer with the exact algorithm is not what I expected. 

## Testing
Extended an existing unit test to verify that the newly introduced setting doesn't break anything.