### PR TITLE
Fix arrow type extension bugs

### DIFF
--- a/src/common/arrow/arrow_converter.cpp
+++ b/src/common/arrow/arrow_converter.cpp
@@ -175,17 +175,11 @@ void SetArrowFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, co
 	case LogicalTypeId::UUID: {
 		if (options.arrow_lossless_conversion) {
 			SetArrowExtension(root_holder, child, type, context);
+		} else if (options.arrow_offset_size == ArrowOffsetSize::LARGE) {
+			// UUID is cast to a regular (non-view) string by the appender, so never declare "vu".
+			child.format = "U";
 		} else {
-			if (options.produce_arrow_string_view && options.arrow_output_version >= ArrowFormatVersion::V1_4) {
-				// List views are only introduced in arrow format v1.4
-				child.format = "vu";
-			} else {
-				if (options.arrow_offset_size == ArrowOffsetSize::LARGE) {
-					child.format = "U";
-				} else {
-					child.format = "u";
-				}
-			}
+			child.format = "u";
 		}
 		break;
 	}
@@ -400,6 +394,7 @@ void SetArrowFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, co
 		root_holder.nested_children_ptr.back().push_back(&root_holder.nested_children.back()[0]);
 		InitializeChild(root_holder.nested_children.back()[0], root_holder);
 		child.dictionary = root_holder.nested_children_ptr.back()[0];
+		// dict values are always written in the regular int32 layout (see ArrowEnumData).
 		child.dictionary->format = "u";
 		break;
 	}

--- a/src/common/arrow/arrow_type_extension.cpp
+++ b/src/common/arrow/arrow_type_extension.cpp
@@ -281,7 +281,8 @@ struct ArrowJson {
 		root_holder.metadata_info.emplace_back(schema_metadata.SerializeMetadata());
 		schema.metadata = root_holder.metadata_info.back().get();
 		const auto options = context.GetClientProperties();
-		if (options.produce_arrow_string_view) {
+		// view layout only when string_view + >= 1.4; declare it to match.
+		if (options.produce_arrow_string_view && options.arrow_output_version >= ArrowFormatVersion::V1_4) {
 			schema.format = "vu";
 		} else {
 			if (options.arrow_offset_size == ArrowOffsetSize::LARGE) {
@@ -302,6 +303,8 @@ struct ArrowBit {
 		} else if (format == "Z") {
 			return make_uniq<ArrowType>(LogicalType::BIT,
 			                            make_uniq<ArrowStringInfo>(ArrowVariableSizeType::SUPER_SIZE));
+		} else if (format == "vz") {
+			return make_uniq<ArrowType>(LogicalType::BIT, make_uniq<ArrowStringInfo>(ArrowVariableSizeType::VIEW));
 		}
 		throw InvalidInputException("Arrow extension type \"%s\" not supported for BIT type", format.c_str());
 	}
@@ -313,7 +316,10 @@ struct ArrowBit {
 		root_holder.metadata_info.emplace_back(schema_metadata.SerializeMetadata());
 		schema.metadata = root_holder.metadata_info.back().get();
 		const auto options = context.GetClientProperties();
-		if (options.arrow_offset_size == ArrowOffsetSize::LARGE) {
+		if (options.arrow_output_version >= ArrowFormatVersion::V1_4) {
+			// >= 1.4 appends the binary view (4-buffer) layout; declare it to match.
+			schema.format = "vz";
+		} else if (options.arrow_offset_size == ArrowOffsetSize::LARGE) {
 			schema.format = "Z";
 		} else {
 			schema.format = "z";
@@ -330,6 +336,8 @@ struct ArrowBignum {
 		} else if (format == "Z") {
 			return make_uniq<ArrowType>(LogicalType::BIGNUM,
 			                            make_uniq<ArrowStringInfo>(ArrowVariableSizeType::SUPER_SIZE));
+		} else if (format == "vz") {
+			return make_uniq<ArrowType>(LogicalType::BIGNUM, make_uniq<ArrowStringInfo>(ArrowVariableSizeType::VIEW));
 		}
 		throw InvalidInputException("Arrow extension type \"%s\" not supported for Bignum", format.c_str());
 	}
@@ -341,7 +349,10 @@ struct ArrowBignum {
 		root_holder.metadata_info.emplace_back(schema_metadata.SerializeMetadata());
 		schema.metadata = root_holder.metadata_info.back().get();
 		const auto options = context.GetClientProperties();
-		if (options.arrow_offset_size == ArrowOffsetSize::LARGE) {
+		if (options.arrow_output_version >= ArrowFormatVersion::V1_4) {
+			// >= 1.4 appends the binary view (4-buffer) layout; declare it to match.
+			schema.format = "vz";
+		} else if (options.arrow_offset_size == ArrowOffsetSize::LARGE) {
 			schema.format = "Z";
 		} else {
 			schema.format = "z";
@@ -539,7 +550,10 @@ struct ArrowGeometry {
 		schema.metadata = root_holder.metadata_info.back().get();
 
 		const auto options = context.GetClientProperties();
-		if (options.arrow_offset_size == ArrowOffsetSize::LARGE) {
+		if (options.arrow_output_version >= ArrowFormatVersion::V1_4) {
+			// >= 1.4 appends the binary view (4-buffer) layout; declare it to match.
+			schema.format = "vz";
+		} else if (options.arrow_offset_size == ArrowOffsetSize::LARGE) {
 			schema.format = "Z";
 		} else {
 			schema.format = "z";

--- a/src/include/duckdb/common/arrow/appender/enum_data.hpp
+++ b/src/include/duckdb/common/arrow/appender/enum_data.hpp
@@ -68,8 +68,15 @@ struct ArrowEnumData : public ArrowScalarBaseData<TGT> {
 
 	static void Initialize(ArrowAppendData &result, const LogicalType &type, idx_t capacity) {
 		result.GetMainBuffer().reserve(capacity * sizeof(TGT));
-		// construct the enum child data
-		auto enum_data = ArrowAppender::InitializeChild(LogicalType::VARCHAR, EnumType::GetSize(type), result.options);
+		// EnumAppendVector always writes the dictionary in the regular int32-offset string
+		// layout, so force a non-view, regular-offset child regardless of the connection's
+		// produce_arrow_string_view / arrow_large_buffer_size settings. Otherwise the child
+		// would be finalized as a view (4-buffer) or large (int64-offset) array over int32
+		// data, producing a malformed dictionary that consumers read as garbage.
+		ClientProperties dict_options = result.options;
+		dict_options.produce_arrow_string_view = false;
+		dict_options.arrow_offset_size = ArrowOffsetSize::REGULAR;
+		auto enum_data = ArrowAppender::InitializeChild(LogicalType::VARCHAR, EnumType::GetSize(type), dict_options);
 		EnumAppendVector(*enum_data, EnumType::GetValuesInsertOrder(type), EnumType::GetSize(type));
 		result.child_data.push_back(std::move(enum_data));
 	}

--- a/test/arrow/CMakeLists.txt
+++ b/test/arrow/CMakeLists.txt
@@ -1,6 +1,11 @@
 add_library_unity(
-  test_arrow_roundtrip OBJECT arrow_test_helper.cpp arrow_roundtrip.cpp
-  arrow_move_children.cpp arrow_filter_pushdown.cpp)
+  test_arrow_roundtrip
+  OBJECT
+  arrow_test_helper.cpp
+  arrow_roundtrip.cpp
+  arrow_move_children.cpp
+  arrow_filter_pushdown.cpp
+  arrow_output_version_buffers.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:test_arrow_roundtrip>
     PARENT_SCOPE)

--- a/test/arrow/arrow_output_version_buffers.cpp
+++ b/test/arrow/arrow_output_version_buffers.cpp
@@ -1,0 +1,209 @@
+#include "catch.hpp"
+
+#include "arrow/arrow_test_helper.hpp"
+#include "duckdb/common/arrow/arrow_appender.hpp"
+#include "duckdb/common/arrow/arrow_converter.hpp"
+#include "duckdb/common/arrow/arrow_type_extension.hpp"
+#include "duckdb/common/unordered_map.hpp"
+
+using namespace duckdb;
+
+namespace {
+
+// At arrow_output_version >= 1.4 some string/blob-backed types are appended with
+// the 4-buffer view layout while their schema still declares the non-view 3-buffer
+// format, so an Arrow C Data importer (e.g. pyarrow) rejects them. These tests
+// export schema+array and assert the two stay consistent.
+
+// Fixed buffer count implied by a leaf format string, or -1 if not fixed.
+int64_t ExpectedFixedBufferCount(const string &format) {
+	if (format == "z" || format == "Z" || format == "u" || format == "U") {
+		return 3;
+	}
+	return -1;
+}
+
+// Recursively assert each field's buffer count matches its declared format.
+void ValidateField(const ArrowSchema &schema, const ArrowArray &array, const string &path) {
+	REQUIRE(schema.format != nullptr);
+	const string format = schema.format;
+
+	const int64_t expected = ExpectedFixedBufferCount(format);
+	if (expected >= 0) {
+		INFO("Field '" << path << "': Expected " << expected << " buffers for imported type '" << format
+		               << "', ArrowArray struct has " << array.n_buffers);
+		REQUIRE(array.n_buffers == expected);
+	} else if (format == "vz" || format == "vu") {
+		INFO("Field '" << path << "': view type '" << format << "' must use the variadic-buffer layout");
+		REQUIRE(array.n_buffers >= 3);
+	}
+
+	if (schema.dictionary) {
+		REQUIRE(array.dictionary != nullptr);
+		ValidateField(*schema.dictionary, *array.dictionary, path + ".dict");
+	}
+	REQUIRE(schema.n_children == array.n_children);
+	for (int64_t i = 0; i < schema.n_children; i++) {
+		ValidateField(*schema.children[i], *array.children[i], path + ".child[" + to_string(i) + "]");
+	}
+}
+
+// Export `query` to a schema + one combined array using the connection's current
+// client properties, then validate every column.
+void ExportAndValidateBuffers(Connection &con, const string &query) {
+	auto props = con.context->GetClientProperties();
+
+	auto result = con.Query(query);
+	REQUIRE_NO_FAIL(*result);
+	auto types = result->types;
+	auto names = result->names;
+
+	ArrowSchema schema;
+	ArrowConverter::ToArrowSchema(&schema, types, names, props);
+
+	unordered_map<idx_t, const shared_ptr<ArrowTypeExtensionData>> extension_type_cast;
+	ArrowAppender appender(types, STANDARD_VECTOR_SIZE, props, extension_type_cast);
+	idx_t count = 0;
+	while (true) {
+		auto chunk = result->Fetch();
+		if (!chunk || chunk->size() == 0) {
+			break;
+		}
+		count += chunk->size();
+		appender.Append(*chunk, 0, chunk->size(), chunk->size());
+	}
+	REQUIRE(count > 0);
+	ArrowArray array = appender.Finalize();
+
+	REQUIRE(schema.n_children == array.n_children);
+	for (int64_t i = 0; i < schema.n_children; i++) {
+		ValidateField(*schema.children[i], *array.children[i], "col[" + to_string(i) + "]");
+	}
+
+	if (array.release) {
+		array.release(&array);
+	}
+	if (schema.release) {
+		schema.release(&schema);
+	}
+}
+
+// Export `query` (under `setup`) to Arrow, re-import it via arrow_scan, and assert
+// the data survives. Buffer-count consistency alone does not catch a schema that
+// declares a view/large layout over data written in a different layout: such an
+// array passes the count check but a real consumer reads garbage. The roundtrip
+// catches that.
+void ExpectArrowRoundtrip(const vector<string> &setup, const string &query) {
+	DuckDB db;
+	Connection con(db);
+	for (auto &s : setup) {
+		REQUIRE_NO_FAIL(con.Query(s));
+	}
+	INFO("roundtrip: " << query);
+	REQUIRE(ArrowTestHelper::RunArrowComparison(con, query, false));
+	REQUIRE(ArrowTestHelper::RunArrowComparison(con, query, true));
+}
+
+} // namespace
+
+//===--------------------------------------------------------------------===//
+// Export schema/buffer-count consistency
+//===--------------------------------------------------------------------===//
+
+// VARINT/BIGNUM: arrow.opaque over binary, views at aov >= 1.4.
+TEST_CASE("VARINT arrow_output_version buffer consistency", "[arrow]") {
+	DuckDB db;
+	Connection con(db);
+	REQUIRE_NO_FAIL(con.Query("SET arrow_output_version='1.4'"));
+	ExportAndValidateBuffers(con, "SELECT (2**100)::VARINT AS v");
+}
+
+// ENUM dictionary values are a VARCHAR child: must match the layout they are written in.
+TEST_CASE("ENUM string_view arrow_output_version buffer consistency", "[arrow]") {
+	DuckDB db;
+	Connection con(db);
+	REQUIRE_NO_FAIL(con.Query("SET produce_arrow_string_view=true"));
+	REQUIRE_NO_FAIL(con.Query("SET arrow_output_version='1.5'"));
+	ExportAndValidateBuffers(con, "SELECT 'happy'::ENUM('happy', 'sad') AS v");
+}
+
+// GEOMETRY (built-in, WKB/binary storage): views at aov >= 1.4.
+TEST_CASE("GEOMETRY arrow_output_version buffer consistency", "[arrow]") {
+	DuckDB db;
+	Connection con(db);
+	REQUIRE_NO_FAIL(con.Query("SET arrow_output_version='1.5'"));
+	ExportAndValidateBuffers(con, "SELECT 'POINT(1 2)'::GEOMETRY AS g");
+}
+
+// BIT (lossless) shares the extension-schema path with GEOMETRY/VARINT.
+TEST_CASE("BIT lossless arrow_output_version buffer consistency", "[arrow]") {
+	DuckDB db;
+	Connection con(db);
+	REQUIRE_NO_FAIL(con.Query("SET arrow_lossless_conversion=true"));
+	REQUIRE_NO_FAIL(con.Query("SET arrow_output_version='1.4'"));
+	ExportAndValidateBuffers(con, "SELECT '101'::BIT AS v");
+}
+
+//===--------------------------------------------------------------------===//
+// Data roundtrip: export at arrow_output_version >= 1.4, re-import, compare.
+// Buffer-count consistency is necessary but not sufficient — these assert the
+// declared layout actually matches the bytes written.
+//===--------------------------------------------------------------------===//
+
+TEST_CASE("VARINT arrow_output_version roundtrip", "[arrow]") {
+	ExpectArrowRoundtrip({"SET arrow_output_version='1.4'"}, "SELECT (2**100 + i)::VARINT AS v FROM range(5) t(i)");
+}
+
+TEST_CASE("BIT lossless arrow_output_version roundtrip", "[arrow]") {
+	ExpectArrowRoundtrip({"SET arrow_lossless_conversion=true", "SET arrow_output_version='1.4'"},
+	                     "SELECT x::BIT AS v FROM (VALUES ('1010'), ('111'), ('0'), ('110011')) t(x)");
+}
+
+TEST_CASE("GEOMETRY arrow_output_version roundtrip", "[arrow]") {
+	ExpectArrowRoundtrip({"SET arrow_output_version='1.5'"},
+	                     "SELECT ('POINT(' || i || ' ' || (i + 1) || ')')::GEOMETRY AS g FROM range(5) t(i)");
+}
+
+TEST_CASE("ENUM string_view arrow_output_version roundtrip", "[arrow]") {
+	ExpectArrowRoundtrip({"SET produce_arrow_string_view=true", "SET arrow_output_version='1.5'"},
+	                     "SELECT x::ENUM('happy', 'sad', 'angry') AS v "
+	                     "FROM (VALUES ('happy'), ('sad'), ('angry'), ('happy')) t(x)");
+}
+
+// Same enum, but exercising the large-offset path instead of string view.
+TEST_CASE("ENUM large_buffer arrow_output_version roundtrip", "[arrow]") {
+	ExpectArrowRoundtrip({"SET arrow_large_buffer_size=true"},
+	                     "SELECT x::ENUM('happy', 'sad', 'angry') AS v "
+	                     "FROM (VALUES ('happy'), ('sad'), ('angry'), ('happy')) t(x)");
+}
+
+// UUID has no string-view appender (it is cast to a regular string), so even with
+// produce_arrow_string_view the schema must declare a regular string "u" — never a
+// view "vu" whose 4-buffer layout the appender never produces. (A non-lossless UUID
+// exports as a string, so this is checked at the schema/buffer level rather than via
+// a type-preserving roundtrip.)
+TEST_CASE("UUID string_view arrow_output_version export is regular string", "[arrow]") {
+	DuckDB db;
+	Connection con(db);
+	REQUIRE_NO_FAIL(con.Query("SET produce_arrow_string_view=true"));
+	REQUIRE_NO_FAIL(con.Query("SET arrow_output_version='1.4'"));
+	const string query = "SELECT '550e8400-e29b-41d4-a716-446655440000'::UUID AS v";
+
+	auto props = con.context->GetClientProperties();
+	auto result = con.Query(query);
+	REQUIRE_NO_FAIL(*result);
+	ArrowSchema schema;
+	ArrowConverter::ToArrowSchema(&schema, result->types, result->names, props);
+	REQUIRE(string(schema.children[0]->format) == "u");
+	if (schema.release) {
+		schema.release(&schema);
+	}
+
+	// The appended array must agree with that declaration (3 buffers).
+	ExportAndValidateBuffers(con, query);
+}
+
+// Control: plain BLOB already exports/imports the view layout correctly.
+TEST_CASE("BLOB arrow_output_version roundtrip", "[arrow]") {
+	ExpectArrowRoundtrip({"SET arrow_output_version='1.4'"}, "SELECT ('blob_' || i)::BLOB AS v FROM range(5) t(i)");
+}


### PR DESCRIPTION
Fixes duckdb/duckdb-python#517

This is a patch for the reported issue. The underlying issue is that we don't have a central, authoritative source of truth for the encoding we need to produce, and if the ArrowAppender and type extensions disagree then we can get a schema that does not fit the output.

We should fix this properly in main.

Python regression tests are up in https://github.com/duckdb/duckdb-python/pull/520, I'll land that together with a submodule bump after this lands.