### PR TITLE
Don't push down CAST if there's a TRY_CAST

### DIFF
--- a/src/optimizer/type_pushdown.cpp
+++ b/src/optimizer/type_pushdown.cpp
@@ -202,10 +202,11 @@ unique_ptr<Expression> CastCollect::VisitReplace(BoundCastExpression &expr, uniq
 		if (top_level_casts.count(&expr)) {
 			col_to_cast.emplace(binding->column_index, &expr);
 		}
-	} else if (it->second == nullptr || it->second->GetReturnType() != expr.GetReturnType()) {
+	} else if (it->second == nullptr || it->second->GetReturnType() != expr.GetReturnType() ||
+	           it->second->Cast<BoundCastExpression>().IsTryCast() != expr.IsTryCast()) {
 		// Different target type, or already a conflict.
-		// TODO(myrrc): CAST and TRY_CAST to the same type don't conflict
-		// but what if reader can push down TRY_CAST but not CAST?
+		// If reader can push CAST but not TRY_CAST or vice versa, we can't
+		// pretend thery are the same
 		it->second = nullptr;
 	}
 

--- a/test/optimizer/pushdown/csv_type_pushdown.test
+++ b/test/optimizer/pushdown/csv_type_pushdown.test
@@ -223,13 +223,12 @@ WHERE TRY_CAST(column00 AS UTINYINT) > 0 ORDER BY 1;
 3
 3
 
-# CAST and TRY_CAST of the same target type: no conflict, both pushed down;
-# PROJECTION remains only to duplicate the column, no cast expressions in the plan
+# CAST and TRY_CAST conflict in NULL-semantics. Not pushed down
 query II
 EXPLAIN SELECT column00::UTINYINT, TRY_CAST(column00 AS UTINYINT)
 FROM read_csv('{DATA_DIR}/csv/real/lineitem_sample.csv', delim='|');
 ----
-physical_plan	<!REGEX>:.*CAST.*
+physical_plan	<REGEX>:.*CAST.*
 
 query II
 SELECT column00::UTINYINT, TRY_CAST(column00 AS UTINYINT)


### PR DESCRIPTION
This a fix for https://github.com/duckdb/duckdb/pull/22788.
Previously, we allowed to push CAST and TRY_CAST at once if type for column was the same.

It doesn't work for readers like Vortex which have cast() but not try_cast(). After this PR, CAST+TRY_CAST is registered as a conflict