### PR TITLE
add --emit-on-skip flag -- emits SKIP_TEST to stderr, skip

### DIFF
--- a/test/helpers/test_helpers.cpp
+++ b/test/helpers/test_helpers.cpp
@@ -23,6 +23,7 @@ namespace duckdb {
 static string custom_test_directory;
 static case_insensitive_set_t required_requires;
 static bool delete_test_path = true;
+static bool emit_on_skip = false; // --emit-on-skip opt-in: emit a [SKIP_TEST] marker per skipped test
 
 bool NO_FAIL(QueryResult &result) {
 	if (result.HasError()) {
@@ -82,6 +83,14 @@ string TestJoinPath(string path1, string path2) {
 
 void SetTestDirectory(string path) {
 	custom_test_directory = path;
+}
+
+void SetEmitOnSkip(bool emit) {
+	emit_on_skip = emit;
+}
+
+bool EmitOnSkipEnabled() {
+	return emit_on_skip;
 }
 
 void AddRequire(string require) {

--- a/test/include/test_helpers.hpp
+++ b/test/include/test_helpers.hpp
@@ -51,6 +51,8 @@ string TestCreatePath(string suffix);
 unique_ptr<DBConfig> GetTestConfig();
 bool TestIsInternalError(unordered_set<string> &internal_error_messages, const string &error);
 void SetTestDirectory(string path);
+void SetEmitOnSkip(bool emit);
+bool EmitOnSkipEnabled();
 void SetDebugInitialize(int value);
 void AddRequire(string require);
 bool IsRequired(string require);

--- a/test/sqlite/result_helper.cpp
+++ b/test/sqlite/result_helper.cpp
@@ -12,6 +12,15 @@
 
 #include <thread>
 
+// PROTOTYPE: shadow Catch's SKIP_TEST to also emit the parseable skip marker.
+// Skip sites here live in TestResultHelper, which holds a `runner` reference.
+#undef SKIP_TEST
+#define SKIP_TEST(reason)                                                                                              \
+	do {                                                                                                               \
+		duckdb::SQLLogicTestLogger::PrintSkip(runner.file_name, (reason));                                             \
+		Catch::getResultCapture().skipTestDuringRun(reason);                                                           \
+	} while (0)
+
 namespace duckdb {
 
 void TestResultHelper::SortQueryResult(SortStyle sort_style, vector<string> &result, idx_t ncols) {

--- a/test/sqlite/sqllogic_test_logger.cpp
+++ b/test/sqlite/sqllogic_test_logger.cpp
@@ -37,6 +37,17 @@ void SQLLogicTestLogger::LogFailureAnnotation(const string &log_message) {
 	Log(prefix, log_message);
 }
 
+void SQLLogicTestLogger::PrintSkip(const string &file_name, const string &reason) {
+	// Opt-in via --emit-on-skip (SetEmitOnSkip): off by default so normal runs stay quiet.
+	if (!EmitOnSkipEnabled()) {
+		return;
+	}
+	// Stable, uncolored marker consumable by e.g. pytest collector. Emitted to std::cerr
+	// (which survives subprocess capture) per skipped test, so skips are attributable
+	// even inside a batched invocation.
+	std::cerr << "[SKIP_TEST] " << file_name << " :: " << reason << "\n";
+}
+
 void SQLLogicTestLogger::PrintSummaryHeader(const std::string &file_name, idx_t query_line) {
 	auto failures_count = to_string(FailureSummary::GetSummaryCounter());
 	if (std::getenv("NO_DUPLICATING_HEADERS") == 0) {

--- a/test/sqlite/sqllogic_test_logger.cpp
+++ b/test/sqlite/sqllogic_test_logger.cpp
@@ -37,15 +37,17 @@ void SQLLogicTestLogger::LogFailureAnnotation(const string &log_message) {
 	Log(prefix, log_message);
 }
 
-void SQLLogicTestLogger::PrintSkip(const string &file_name, const string &reason) {
+void SQLLogicTestLogger::PrintSkip(const string &file_name, const string &reason, bool partial) {
 	// Opt-in via --emit-on-skip (SetEmitOnSkip): off by default so normal runs stay quiet.
 	if (!EmitOnSkipEnabled()) {
 		return;
 	}
-	// Stable, uncolored marker consumable by e.g. pytest collector. Emitted to std::cerr
-	// (which survives subprocess capture) per skipped test, so skips are attributable
-	// even inside a batched invocation.
-	std::cerr << "[SKIP_TEST] " << file_name << " :: " << reason << "\n";
+	// Stable, uncolored marker consumable by e.g. pytest collector. Emitted to std::cerr (which
+	// survives subprocess capture) per skipped test, so skips are attributable even inside a
+	// batched invocation. Two kinds: [SKIP_TEST] = the whole test was skipped (Catch aborts the
+	// run, e.g. require-env); [SKIP_TEST_PARTIAL] = a region was skipped but the test kept running
+	// (mode skip) — so a consumer can tell "skipped" from "passed with skips".
+	std::cerr << (partial ? "[SKIP_TEST_PARTIAL] " : "[SKIP_TEST] ") << file_name << " :: " << reason << "\n";
 }
 
 void SQLLogicTestLogger::PrintSummaryHeader(const std::string &file_name, idx_t query_line) {

--- a/test/sqlite/sqllogic_test_logger.hpp
+++ b/test/sqlite/sqllogic_test_logger.hpp
@@ -23,7 +23,7 @@ public:
 	~SQLLogicTestLogger();
 
 	static void Log(const string &annotation, const string &str);
-	static void PrintSkip(const string &file_name, const string &reason);
+	static void PrintSkip(const string &file_name, const string &reason, bool partial = false);
 	void PrintExpectedResult(const vector<string> &values, idx_t columns, bool row_wise);
 	static void PrintLineSep();
 	static void PrintHeader(string header);

--- a/test/sqlite/sqllogic_test_logger.hpp
+++ b/test/sqlite/sqllogic_test_logger.hpp
@@ -23,6 +23,7 @@ public:
 	~SQLLogicTestLogger();
 
 	static void Log(const string &annotation, const string &str);
+	static void PrintSkip(const string &file_name, const string &reason);
 	void PrintExpectedResult(const vector<string> &values, idx_t columns, bool row_wise);
 	static void PrintLineSep();
 	static void PrintHeader(string header);

--- a/test/sqlite/sqllogic_test_runner.cpp
+++ b/test/sqlite/sqllogic_test_runner.cpp
@@ -18,6 +18,16 @@
 #include DUCKDB_EXTENSION_HEADER
 #endif
 
+// PROTOTYPE: shadow Catch's SKIP_TEST so every skip also emits a stable, parseable
+// marker (consumed by the pytest collector) before recording the skip with Catch.
+// `file_name` is the runner's member, in scope at all skip sites in this TU.
+#undef SKIP_TEST
+#define SKIP_TEST(reason)                                                                                              \
+	do {                                                                                                               \
+		duckdb::SQLLogicTestLogger::PrintSkip(file_name, (reason));                                                    \
+		Catch::getResultCapture().skipTestDuringRun(reason);                                                           \
+	} while (0)
+
 namespace duckdb {
 
 mutex SQLLogicTestRunner::skip_reason_lock;

--- a/test/sqlite/sqllogic_test_runner.cpp
+++ b/test/sqlite/sqllogic_test_runner.cpp
@@ -953,7 +953,13 @@ void SQLLogicTestRunner::ExecuteInternal(SQLLogicParser &parser, const string &s
 						reason += " " + token.parameters[i];
 					}
 				}
-				AddSkipReason("mode skip " + reason);
+				auto skip_reason = "mode skip " + reason;
+				AddSkipReason(skip_reason);
+				// Also emit the parseable marker (gated on --emit-on-skip inside PrintSkip), tagged
+				// partial: unlike SkipTest() this does NOT abort via Catch — `mode skip` is a region
+				// skip (skip_level), so the test keeps running (and may `mode unskip`), hence
+				// [SKIP_TEST_PARTIAL] rather than the whole-test [SKIP_TEST].
+				SQLLogicTestLogger::PrintSkip(file_name, skip_reason, /* partial */ true);
 				skip_level++;
 			} else if (parameter == "unskip") {
 				skip_level--;

--- a/test/unittest.cpp
+++ b/test/unittest.cpp
@@ -38,6 +38,8 @@ int main(int argc_in, char *argv[]) {
 			SetTestDirectory(test_dir);
 		} else if (argument == "--require") {
 			AddRequire(string(argv[++i]));
+		} else if (argument == "--emit-on-skip") {
+			SetEmitOnSkip(true);
 		} else if (argument == "--keep-home") {
 			keep_home = true;
 		} else if (argument == "--stdin") {


### PR DESCRIPTION
Useful for external tooling (eg pytest) to get per-test attribution of skips. (Previously this is only aggregated by Catch/unittest.)