### PR TITLE
Fix typo in UNNEST error message (#23532) "at lease" → "at least"

### DIFF
--- a/src/planner/binder/expression/bind_unnest_expression.cpp
+++ b/src/planner/binder/expression/bind_unnest_expression.cpp
@@ -69,7 +69,7 @@ BindResult SelectBinder::BindUnnest(FunctionExpression &function, idx_t depth, b
 
 	ErrorData error;
 	if (function.GetArguments().empty()) {
-		return BindResult(BinderException(function, "UNNEST() requires at lease one argument"));
+		return BindResult(BinderException(function, "UNNEST() requires at least one argument"));
 	}
 	if (inside_window || inside_aggregate || inside_try) {
 		return BindResult(BinderException(function, UnsupportedUnnestMessage()));

--- a/test/sql/types/list/recursive_unnest.test
+++ b/test/sql/types/list/recursive_unnest.test
@@ -108,7 +108,7 @@ Nested UNNEST calls are not supported
 statement error
 SELECT UNNEST();
 ----
-requires at lease one argument
+requires at least one argument
 
 statement error
 SELECT UNNEST([1, 2, 3], 'hello');

--- a/test/sql/types/nested/list/test_nested_list.test
+++ b/test/sql/types/nested/list/test_nested_list.test
@@ -274,7 +274,7 @@ SELECT g, UNNEST(g) u FROM (SELECT g, LIST(e) l FROM list_data GROUP BY g) u1
 statement error
 SELECT g, UNNEST() u FROM (SELECT g, LIST(e) l FROM list_data GROUP BY g) u1
 ----
-<REGEX>:.*Binder Error.*requires at lease one argument.*
+<REGEX>:.*Binder Error.*requires at least one argument.*
 
 statement error
 SELECT UNNEST(42)
@@ -284,7 +284,7 @@ SELECT UNNEST(42)
 statement error
 SELECT UNNEST()
 ----
-<REGEX>:.*Binder Error.*requires at lease one argument.*
+<REGEX>:.*Binder Error.*requires at least one argument.*
 
 statement error
 SELECT UNNEST(42) from list_data
@@ -294,7 +294,7 @@ SELECT UNNEST(42) from list_data
 statement error
 SELECT UNNEST() from list_data
 ----
-<REGEX>:.*Binder Error.*requires at lease one argument.*
+<REGEX>:.*Binder Error.*requires at least one argument.*
 
 statement error
 SELECT g FROM (SELECT g, LIST(e) l FROM list_data GROUP BY g) u1 where UNNEST(l) > 42


### PR DESCRIPTION
Fixes #23532

Changed "at lease" → "at least" in the `UNNEST()` binder error message and updated corresponding test expectations.