### PR TITLE
Dont special-case geometry stats pruning, pass child stats to filter callback

### DIFF
--- a/src/function/scalar/geometry/geometry_functions.cpp
+++ b/src/function/scalar/geometry/geometry_functions.cpp
@@ -4,6 +4,8 @@
 #include "duckdb/common/vector_operations/binary_executor.hpp"
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "duckdb/storage/statistics/base_statistics.hpp"
 #include "duckdb/storage/statistics/geometry_stats.hpp"
 #include "duckdb/storage/statistics/string_stats.hpp"
 
@@ -136,9 +138,61 @@ static void IntersectsExtentFunction(DataChunk &input, ExpressionState &state, V
 	    });
 }
 
+// Prune row groups for `geom1 && geom2` (a.k.a. ST_Intersects_Extent), which is true iff the two bounding
+// boxes intersect. One argument must be a constant geometry; the other is the column we prune against. Both
+// operands' statistics are derived for us (the constant's geometry stats already carry its bounding box, and
+// the column's look through any CRS-only cast), so this works regardless of which side the constant is on.
+static FilterPropagateResult IntersectsExtentFilterPrune(const FunctionStatisticsPruneInput &input) {
+	auto &children = input.function.GetChildren();
+	if (children.size() != 2) {
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+
+	// Constants are folded by the time we get here, so the constant operand is a plain BoundConstantExpression.
+	const auto lhs_is_const = children[0]->GetExpressionType() == ExpressionType::VALUE_CONSTANT;
+	const auto rhs_is_const = children[1]->GetExpressionType() == ExpressionType::VALUE_CONSTANT;
+	if (lhs_is_const == rhs_is_const) {
+		// Need exactly one constant operand and one column operand.
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+	const idx_t constant_idx = lhs_is_const ? 0 : 1;
+
+	auto column_stats = input.ChildStats(1 - constant_idx);
+	auto constant_stats = input.ChildStats(constant_idx);
+	if (!column_stats || column_stats->GetStatsType() != StatisticsType::GEOMETRY_STATS || !constant_stats ||
+	    constant_stats->GetStatsType() != StatisticsType::GEOMETRY_STATS) {
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+	if (!column_stats->CanHaveNoNull()) {
+		// no non-null values are possible: always false
+		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
+	}
+	const auto &col_extent = GeometryStats::GetExtent(*column_stats);
+	if (!col_extent.CanPruneXY()) {
+		// If neither axis is set (the extent is empty or fully unknown), we cannot prune.
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+
+	const auto &const_extent = GeometryStats::GetExtent(*constant_stats);
+	if (!const_extent.CanPruneXY()) {
+		// An empty constant geometry never intersects anything.
+		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
+	}
+	if (!const_extent.IntersectsXY(col_extent)) {
+		// The column zonemap does not intersect the constant: no row can match.
+		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
+	}
+	if (const_extent.ContainsXY(col_extent)) {
+		// The constant fully covers the column zonemap, so every non-null row's bbox intersects it.
+		return FilterPropagateResult::FILTER_ALWAYS_TRUE;
+	}
+	return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+}
+
 ScalarFunction StIntersectsExtentFun::GetFunction() {
 	ScalarFunction function({LogicalType::GEOMETRY(), LogicalType::GEOMETRY()}, LogicalType::BOOLEAN,
 	                        IntersectsExtentFunction);
+	function.SetFilterPruneCallback(IntersectsExtentFilterPrune);
 	return function;
 }
 

--- a/src/include/duckdb/function/scalar_function.hpp
+++ b/src/include/duckdb/function/scalar_function.hpp
@@ -59,12 +59,22 @@ class ScalarFunctionCatalogEntry;
 struct StatementProperties;
 
 struct FunctionStatisticsPruneInput {
-	FunctionStatisticsPruneInput(optional_ptr<FunctionData> bind_data_p, const BaseStatistics &stats_p)
-	    : bind_data(bind_data_p), stats(stats_p) {
+	FunctionStatisticsPruneInput(const BoundFunctionExpression &function_p, optional_ptr<FunctionData> bind_data_p,
+	                             const vector<optional_ptr<const BaseStatistics>> &child_stats_p)
+	    : function(function_p), bind_data(bind_data_p), child_stats(child_stats_p) {
 	}
 
+	//! The bound function expression being checked (gives access to the argument expressions)
+	const BoundFunctionExpression &function;
 	optional_ptr<FunctionData> bind_data;
-	const BaseStatistics &stats;
+
+	//! Statistics for each function argument (an entry is null if it could not be derived for that argument)
+	const vector<optional_ptr<const BaseStatistics>> &child_stats;
+
+	//! Convenience accessor: statistics of the i-th argument, or null if absent / not derivable
+	optional_ptr<const BaseStatistics> ChildStats(idx_t i) const {
+		return i < child_stats.size() ? child_stats[i] : optional_ptr<const BaseStatistics>();
+	}
 };
 
 struct FunctionStatisticsInput {

--- a/src/include/duckdb/storage/statistics/geometry_stats.hpp
+++ b/src/include/duckdb/storage/statistics/geometry_stats.hpp
@@ -341,10 +341,6 @@ struct GeometryStats {
 	DUCKDB_API static void Verify(const BaseStatistics &stats, const Vector &vector, const SelectionVector &sel,
 	                              idx_t count);
 
-	//! Check if a spatial predicate check with a constant could possibly be satisfied by rows given the statistics
-	DUCKDB_API static FilterPropagateResult CheckZonemap(const BaseStatistics &stats,
-	                                                     const unique_ptr<Expression> &expr);
-
 	DUCKDB_API static GeometryExtent &GetExtent(BaseStatistics &stats);
 	DUCKDB_API static const GeometryExtent &GetExtent(const BaseStatistics &stats);
 	DUCKDB_API static GeometryTypeSet &GetTypes(BaseStatistics &stats);

--- a/src/optimizer/statistics/expression/propagate_cast.cpp
+++ b/src/optimizer/statistics/expression/propagate_cast.cpp
@@ -228,6 +228,11 @@ unique_ptr<BaseStatistics> StatisticsPropagator::TryPropagateCast(const BaseStat
 		// the cast shreds every value into a single bucket - mirror the (possibly nested) source as typed stats
 		return VariantStats::StatisticsPropagateToVariant(source, stats);
 	}
+	if (source.id() == LogicalTypeId::GEOMETRY && target.id() == LogicalTypeId::GEOMETRY) {
+		// A geometry -> geometry cast only changes CRS metadata, not coordinates, so the bounding box,
+		// type set and null-ness are unchanged: propagate the statistics as-is.
+		return stats.Copy().ToUnique();
+	}
 	if (!CanPropagateCast(source, target)) {
 		return nullptr;
 	}

--- a/src/planner/filter/expression_filter.cpp
+++ b/src/planner/filter/expression_filter.cpp
@@ -164,18 +164,10 @@ bool ExpressionFilter::EvaluateWithConstant(ExpressionExecutor &executor, const 
 }
 
 FilterPropagateResult ExpressionFilter::CheckStatistics(const BaseStatistics &stats) const {
-	if (stats.GetStatsType() == StatisticsType::GEOMETRY_STATS) {
-		// Delegate to GeometryStats for geometry types
-		return GeometryStats::CheckZonemap(stats, expr);
-	}
 	return CheckExpressionStatistics(*expr, stats);
 }
 
 FilterPropagateResult ExpressionFilter::CheckStatistics(ClientContext &context, const BaseStatistics &stats) const {
-	if (stats.GetStatsType() == StatisticsType::GEOMETRY_STATS) {
-		// Delegate to GeometryStats for geometry types
-		return GeometryStats::CheckZonemap(stats, expr);
-	}
 	return CheckExpressionStatistics(&context, *expr, stats);
 }
 
@@ -395,16 +387,16 @@ static FilterPropagateResult CheckFunctionStatistics(optional_ptr<ClientContext>
 	if (!func_expr.Function().HasFilterPruneCallback()) {
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 	}
+	// Derive the statistics of each argument. This lets a callback prune regardless of which argument is the column and
+	// which is the constant (e.g. `foo(col, const)` vs `foo(const, col`).
+	// Entries are null when an argument's stats can't be derived.
 	vector<unique_ptr<BaseStatistics>> owned_stats;
-	auto filter_stats = &stats;
-	if (!func_expr.GetChildren().empty()) {
-		auto child_stats = TryGetFilterStats(context_p, *func_expr.GetChildren()[0], stats, owned_stats);
-		if (!child_stats) {
-			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
-		}
-		filter_stats = child_stats.get();
+	vector<optional_ptr<const BaseStatistics>> child_stats;
+	child_stats.reserve(func_expr.GetChildren().size());
+	for (auto &child : func_expr.GetChildren()) {
+		child_stats.push_back(TryGetFilterStats(context_p, *child, stats, owned_stats));
 	}
-	FunctionStatisticsPruneInput input(func_expr.BindInfo().get(), *filter_stats);
+	FunctionStatisticsPruneInput input(func_expr, func_expr.BindInfo().get(), child_stats);
 	return func_expr.Function().GetFilterPruneCallback()(input);
 }
 

--- a/src/planner/filter/table_filter_bloom_function.cpp
+++ b/src/planner/filter/table_filter_bloom_function.cpp
@@ -260,28 +260,33 @@ FilterPropagateResult BloomFilterScalarFun::FilterPrune(const FunctionStatistics
 	if (!data.filter || !data.filter->IsInitialized()) {
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 	}
+	auto column_stats = input.ChildStats(0);
+	if (!column_stats) {
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+	auto &stats = *column_stats;
 
 	switch (data.key_type.InternalType()) {
 	case PhysicalType::UINT8:
-		return TemplatedBloomFilterPrune<uint8_t>(*data.filter, input.stats);
+		return TemplatedBloomFilterPrune<uint8_t>(*data.filter, stats);
 	case PhysicalType::UINT16:
-		return TemplatedBloomFilterPrune<uint16_t>(*data.filter, input.stats);
+		return TemplatedBloomFilterPrune<uint16_t>(*data.filter, stats);
 	case PhysicalType::UINT32:
-		return TemplatedBloomFilterPrune<uint32_t>(*data.filter, input.stats);
+		return TemplatedBloomFilterPrune<uint32_t>(*data.filter, stats);
 	case PhysicalType::UINT64:
-		return TemplatedBloomFilterPrune<uint64_t>(*data.filter, input.stats);
+		return TemplatedBloomFilterPrune<uint64_t>(*data.filter, stats);
 	case PhysicalType::UINT128:
-		return TemplatedBloomFilterPrune<uhugeint_t>(*data.filter, input.stats);
+		return TemplatedBloomFilterPrune<uhugeint_t>(*data.filter, stats);
 	case PhysicalType::INT8:
-		return TemplatedBloomFilterPrune<int8_t>(*data.filter, input.stats);
+		return TemplatedBloomFilterPrune<int8_t>(*data.filter, stats);
 	case PhysicalType::INT16:
-		return TemplatedBloomFilterPrune<int16_t>(*data.filter, input.stats);
+		return TemplatedBloomFilterPrune<int16_t>(*data.filter, stats);
 	case PhysicalType::INT32:
-		return TemplatedBloomFilterPrune<int32_t>(*data.filter, input.stats);
+		return TemplatedBloomFilterPrune<int32_t>(*data.filter, stats);
 	case PhysicalType::INT64:
-		return TemplatedBloomFilterPrune<int64_t>(*data.filter, input.stats);
+		return TemplatedBloomFilterPrune<int64_t>(*data.filter, stats);
 	case PhysicalType::INT128:
-		return TemplatedBloomFilterPrune<hugeint_t>(*data.filter, input.stats);
+		return TemplatedBloomFilterPrune<hugeint_t>(*data.filter, stats);
 	default:
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 	}

--- a/src/planner/filter/table_filter_dynamic_function.cpp
+++ b/src/planner/filter/table_filter_dynamic_function.cpp
@@ -146,7 +146,11 @@ FilterPropagateResult DynamicFilterScalarFun::FilterPrune(const FunctionStatisti
 	if (!data.filter_data->initialized) {
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 	}
-	return DynamicFilterData::CheckStatistics(input.stats, data.filter_data->comparison_type,
+	auto column_stats = input.ChildStats(0);
+	if (!column_stats) {
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+	return DynamicFilterData::CheckStatistics(*column_stats, data.filter_data->comparison_type,
 	                                          data.filter_data->constant);
 }
 

--- a/src/planner/filter/table_filter_optional_function.cpp
+++ b/src/planner/filter/table_filter_optional_function.cpp
@@ -73,7 +73,11 @@ FilterPropagateResult OptionalFilterScalarFun::FilterPrune(const FunctionStatist
 	if (!data.child_filter_expr) {
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 	}
-	return ExpressionFilter::CheckExpressionStatistics(*data.child_filter_expr, input.stats);
+	auto column_stats = input.ChildStats(0);
+	if (!column_stats) {
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+	return ExpressionFilter::CheckExpressionStatistics(*data.child_filter_expr, *column_stats);
 }
 
 string OptionalFilterScalarFun::ToString(const string &child_filter_string) {

--- a/src/planner/filter/table_filter_prefix_range_function.cpp
+++ b/src/planner/filter/table_filter_prefix_range_function.cpp
@@ -547,26 +547,31 @@ FilterPropagateResult PrefixRangeScalarFun::FilterPrune(const FunctionStatistics
 	if (!data.filter || !data.filter->IsInitialized()) {
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 	}
-	switch (input.stats.GetStatsType()) {
+	auto column_stats = input.ChildStats(0);
+	if (!column_stats) {
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+	auto &stats = *column_stats;
+	switch (stats.GetStatsType()) {
 	case StatisticsType::NUMERIC_STATS: {
-		if (!NumericStats::HasMinMax(input.stats)) {
+		if (!NumericStats::HasMinMax(stats)) {
 			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 		}
-		const auto min = NumericStats::Min(input.stats);
-		const auto max = NumericStats::Max(input.stats);
+		const auto min = NumericStats::Min(stats);
+		const auto max = NumericStats::Max(stats);
 		if (min > max) {
 			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 		}
 		return data.filter->LookupRange(min, max);
 	}
 	case StatisticsType::STRING_STATS: {
-		if (!StringStats::HasMinMax(input.stats)) {
+		if (!StringStats::HasMinMax(stats)) {
 			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 		}
 		// String stats may contain raw parquet bytes that are not valid UTF-8. Reconstruct them as BLOBs so the
 		// prefix-range comparable logic can inspect the raw bytes without value-construction validation.
-		return data.filter->LookupRange(Value::BLOB_RAW(StringStats::Min(input.stats)),
-		                                Value::BLOB_RAW(StringStats::Max(input.stats)));
+		return data.filter->LookupRange(Value::BLOB_RAW(StringStats::Min(stats)),
+		                                Value::BLOB_RAW(StringStats::Max(stats)));
 	}
 	default:
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;

--- a/src/planner/filter/table_filter_selectivity_optional_function.cpp
+++ b/src/planner/filter/table_filter_selectivity_optional_function.cpp
@@ -172,7 +172,11 @@ FilterPropagateResult SelectivityOptionalFilterScalarFun::FilterPrune(const Func
 	if (!data.child_filter_expr) {
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 	}
-	return ExpressionFilter::CheckExpressionStatistics(*data.child_filter_expr, input.stats);
+	auto column_stats = input.ChildStats(0);
+	if (!column_stats) {
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+	return ExpressionFilter::CheckExpressionStatistics(*data.child_filter_expr, *column_stats);
 }
 
 string SelectivityOptionalFilterScalarFun::ToString(const string &child_filter_string) {

--- a/src/storage/statistics/geometry_stats.cpp
+++ b/src/storage/statistics/geometry_stats.cpp
@@ -4,9 +4,6 @@
 #include "duckdb/common/types/vector.hpp"
 #include "duckdb/common/serializer/serializer.hpp"
 #include "duckdb/common/serializer/deserializer.hpp"
-#include "duckdb/planner/expression/bound_cast_expression.hpp"
-#include "duckdb/planner/expression/bound_constant_expression.hpp"
-#include "duckdb/planner/expression/bound_function_expression.hpp"
 
 namespace duckdb {
 
@@ -234,114 +231,5 @@ const GeometryStatsFlags &GeometryStats::GetFlags(const BaseStatistics &stats) {
 	return GetDataUnsafe(stats).flags;
 }
 
-// Expression comparison pruning
-static FilterPropagateResult CheckIntersectionFilter(const GeometryStatsData &data, const Value &constant) {
-	if (constant.IsNull() || constant.type().id() != LogicalTypeId::GEOMETRY) {
-		// Cannot prune against NULL
-		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
-	}
-
-	// This has been checked before and needs to be true for the checks below to be valid.
-	// Note: only one axis needs to be set; an unknown axis is an infinite range that
-	// intersects everything, so the IntersectsXY/ContainsXY math below stays valid.
-	D_ASSERT(data.extent.CanPruneXY());
-
-	const auto &geom = StringValue::Get(constant);
-	auto extent = GeometryExtent::Empty();
-	if (Geometry::GetExtent(string_t(geom), extent) == 0) {
-		// If the geometry is empty, the predicate will never match
-		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
-	}
-
-	// Check if the bounding boxes intersect
-	// If the bounding boxes do not intersect, the predicate will never match
-	if (!extent.IntersectsXY(data.extent)) {
-		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
-	}
-
-	// If the column is completely inside the bounds, the predicate will always match
-	if (extent.ContainsXY(data.extent)) {
-		return FilterPropagateResult::FILTER_ALWAYS_TRUE;
-	}
-
-	// We cannot prune, as this column may contain geometries that intersect
-	return FilterPropagateResult::NO_PRUNING_POSSIBLE;
-}
-
-FilterPropagateResult GeometryStats::CheckZonemap(const BaseStatistics &stats, const unique_ptr<Expression> &expr) {
-	if (expr->GetExpressionClass() != ExpressionClass::BOUND_FUNCTION) {
-		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
-	}
-	if (expr->GetReturnType() != LogicalType::BOOLEAN) {
-		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
-	}
-	const auto &func = expr->Cast<BoundFunctionExpression>();
-	if (func.GetChildren().size() != 2) {
-		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
-	}
-
-	if (func.GetChildren()[0]->GetReturnType().id() != LogicalTypeId::GEOMETRY ||
-	    func.GetChildren()[1]->GetReturnType().id() != LogicalTypeId::GEOMETRY) {
-		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
-	}
-
-	// The set of geometry predicates that can be optimized using the bounding box
-	static constexpr const char *geometry_predicates[2] = {"&&", "st_intersects_extent"};
-
-	auto found = false;
-	for (const auto &name : geometry_predicates) {
-		if (func.Function().GetName() == name) {
-			found = true;
-			break;
-		}
-	}
-	if (!found) {
-		// Not a geometry predicate we can optimize
-		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
-	}
-
-	// The column reference may be wrapped in a GEOMETRY -> GEOMETRY cast (e.g. a CRS-erasing cast inserted to match
-	// the predicate's argument type). Such casts only change CRS metadata, not coordinates, so the bounding box
-	// remains valid. Look through them when classifying the operands.
-	auto strip_geometry_cast = [](const Expression &child) -> const Expression * {
-		if (child.GetExpressionType() == ExpressionType::OPERATOR_CAST) {
-			auto &cast = child.Cast<BoundCastExpression>();
-			if (cast.Child().GetReturnType().id() == LogicalTypeId::GEOMETRY) {
-				return &cast.Child();
-			}
-		}
-		return &child;
-	};
-
-	const auto &lhs = *strip_geometry_cast(*func.GetChildren()[0]);
-	const auto &rhs = *strip_geometry_cast(*func.GetChildren()[1]);
-	const auto lhs_kind = lhs.GetExpressionType();
-	const auto rhs_kind = rhs.GetExpressionType();
-	const auto lhs_is_const = lhs_kind == ExpressionType::VALUE_CONSTANT && rhs_kind == ExpressionType::BOUND_REF;
-	const auto rhs_is_const = rhs_kind == ExpressionType::VALUE_CONSTANT && lhs_kind == ExpressionType::BOUND_REF;
-
-	if (!stats.CanHaveNoNull()) {
-		// no non-null values are possible: always false
-		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
-	}
-
-	auto &data = GetDataUnsafe(stats);
-
-	if (!data.extent.CanPruneXY()) {
-		// If neither axis is set (the extent is empty or fully unknown), we cannot prune.
-		// A single known axis is enough: the unknown axis is an infinite range that
-		// intersects everything, so pruning degrades to the known axis.
-		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
-	}
-
-	if (lhs_is_const) {
-		return CheckIntersectionFilter(data, lhs.Cast<BoundConstantExpression>().GetValue());
-	}
-	if (rhs_is_const) {
-		return CheckIntersectionFilter(data, rhs.Cast<BoundConstantExpression>().GetValue());
-	}
-	// Else, no constant argument
-	return FilterPropagateResult::NO_PRUNING_POSSIBLE;
-}
 
 } // namespace duckdb

--- a/src/storage/statistics/geometry_stats.cpp
+++ b/src/storage/statistics/geometry_stats.cpp
@@ -231,5 +231,4 @@ const GeometryStatsFlags &GeometryStats::GetFlags(const BaseStatistics &stats) {
 	return GetDataUnsafe(stats).flags;
 }
 
-
 } // namespace duckdb

--- a/test/extension/loadable_extension_demo.cpp
+++ b/test/extension/loadable_extension_demo.cpp
@@ -825,7 +825,11 @@ static void RowIdFilterFunction(DataChunk &args, ExpressionState &state, Vector 
 
 static FilterPropagateResult RowIdFilterPropagate(const FunctionStatisticsPruneInput &input) {
 	auto &allowed = input.bind_data->Cast<RowIdFilterBindData>().allowed_ids;
-	auto &stats = input.stats;
+	auto column_stats = input.ChildStats(0);
+	if (!column_stats) {
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+	auto &stats = *column_stats;
 
 	if (!NumericStats::HasMinMax(stats)) {
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;


### PR DESCRIPTION
This PR turns the geometry "&&" stats pruning into a "filter_prune" scalar function callback, instead of having a special case in the expression filter evaluation.

Geometry stats are now also propagated across geometry CRS casts automatically.

Additionally the function filter_prune input now contains the bound function expression, as well as the stats of all child arguments, not just the first child. I've updated the existing join-filter-pushdown functions to adapt to this change.

