### PR TITLE
Add windows_undefs to a multi-file reader header

### DIFF
--- a/src/include/duckdb/common/multi_file/multi_file_states.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_states.hpp
@@ -12,6 +12,7 @@
 #include "duckdb/common/multi_file/multi_file_options.hpp"
 #include "duckdb/common/multi_file/base_file_reader.hpp"
 #include "duckdb/common/multi_file/multi_file_list.hpp"
+#include "duckdb/common/windows_undefs.hpp"
 #include "duckdb/execution/expression_executor.hpp"
 
 namespace duckdb {


### PR DESCRIPTION
On Window with MSVC the `interface` is defined as a macro:

```c++
#define interface struct
```

We have the [undef header](https://github.com/duckdb/duckdb/blob/3cb65aa794b4c985a98493f188fb58db79a370f8/src/include/duckdb/common/windows_undefs.hpp#L46-L48) for that, but it is not applied everywhere.

In unity builds after some recent inclusion changes in `ub_src_common.cpp` the build started failing on Windows with:

```
multi_file_states.hpp(69): error C2236: unexpected token 'struct'. Did you forget a ';'?
```

This PR adds the under header to `multi_file_states.hpp` that fixes the problem.