### PR TITLE
Fold empty list contains filters to EMPTY_RESULT

### DIFF
--- a/src/optimizer/rule/contains_to_in_clause.cpp
+++ b/src/optimizer/rule/contains_to_in_clause.cpp
@@ -9,7 +9,8 @@ namespace duckdb {
 
 ContainsToInClauseRule::ContainsToInClauseRule(ExpressionRewriter &rewriter) : Rule(rewriter) {
 	auto func = make_uniq<FunctionExpressionMatcher>();
-	func->function = make_uniq<SpecificFunctionMatcher>("contains");
+	identifier_set_t functions = {"contains", "list_contains", "list_has", "array_contains", "array_has"};
+	func->function = make_uniq<ManyFunctionMatcher>(functions);
 	func->matchers.push_back(make_uniq<FoldableConstantMatcher>());
 	func->matchers.push_back(make_uniq<ExpressionMatcher>());
 	func->policy = SetMatcher::Policy::ORDERED;
@@ -22,15 +23,27 @@ unique_ptr<Expression> ContainsToInClauseRule::Apply(LogicalOperator &op, vector
 	auto &list_arg = expr.GetChildren()[0];
 	auto &probe_arg = expr.GetChildren()[1];
 
-	if (probe_arg->IsFoldable()) {
-		return nullptr;
-	}
-
 	Value list_val;
 	if (!ExpressionExecutor::TryEvaluateScalar(GetContext(), *list_arg, list_val)) {
 		return nullptr;
 	}
-	if (list_val.IsNull() || list_val.type().id() != LogicalTypeId::LIST || ListValue::GetChildren(list_val).empty()) {
+	// Null list: result is always NULL regardless of the probe value.
+	if (list_val.IsNull()) {
+		changes_made = true;
+		return make_uniq<BoundConstantExpression>(Value(LogicalType::BOOLEAN));
+	}
+	// For other types (i.e., string/map/struct) leave them alone.
+	if (list_val.type().id() != LogicalTypeId::LIST) {
+		return nullptr;
+	}
+	// Empty list: never contains a non-NULL value.
+	if (ListValue::GetChildren(list_val).empty()) {
+		changes_made = true;
+		return ExpressionRewriter::ConstantOrNull(probe_arg->Copy(), Value::BOOLEAN(false));
+	}
+
+	// Fully constant probe: let constant folding handle it.
+	if (probe_arg->IsFoldable()) {
 		return nullptr;
 	}
 

--- a/src/optimizer/rule/contains_to_in_clause.cpp
+++ b/src/optimizer/rule/contains_to_in_clause.cpp
@@ -27,17 +27,29 @@ unique_ptr<Expression> ContainsToInClauseRule::Apply(LogicalOperator &op, vector
 	if (!ExpressionExecutor::TryEvaluateScalar(GetContext(), *list_arg, list_val)) {
 		return nullptr;
 	}
+
 	// Null list: result is always NULL regardless of the probe value.
 	if (list_val.IsNull()) {
 		changes_made = true;
 		return make_uniq<BoundConstantExpression>(Value(LogicalType::BOOLEAN));
 	}
+
 	// For other types (i.e., string/map/struct) leave them alone.
 	if (list_val.type().id() != LogicalTypeId::LIST) {
 		return nullptr;
 	}
-	// Empty list: never contains a non-NULL value.
-	if (ListValue::GetChildren(list_val).empty()) {
+
+	// Collect non-NULL elements from the list.
+	const auto &child_type = ListType::GetChildType(list_val.type());
+	vector<Value> non_null_elements;
+	for (const auto &elem : ListValue::GetChildren(list_val)) {
+		if (!elem.IsNull()) {
+			non_null_elements.emplace_back(elem.DefaultCastAs(child_type));
+		}
+	}
+
+	// No non-NULL elements: never contains any value.
+	if (non_null_elements.empty()) {
 		changes_made = true;
 		return ExpressionRewriter::ConstantOrNull(probe_arg->Copy(), Value::BOOLEAN(false));
 	}
@@ -49,9 +61,7 @@ unique_ptr<Expression> ContainsToInClauseRule::Apply(LogicalOperator &op, vector
 
 	auto in_expr = make_uniq<BoundOperatorExpression>(ExpressionType::COMPARE_IN, LogicalType::BOOLEAN);
 	in_expr->GetChildrenMutable().push_back(probe_arg->Copy());
-	const auto &child_type = ListType::GetChildType(list_val.type());
-	for (const auto &elem : ListValue::GetChildren(list_val)) {
-		Value v = elem.DefaultCastAs(child_type);
+	for (auto &v : non_null_elements) {
 		in_expr->GetChildrenMutable().push_back(make_uniq<BoundConstantExpression>(std::move(v)));
 	}
 	changes_made = true;

--- a/test/optimizer/contains_to_in_clause.test
+++ b/test/optimizer/contains_to_in_clause.test
@@ -1,5 +1,5 @@
 # name: test/optimizer/contains_to_in_clause.test
-# description: Test that col IN [large_list] is rewritten to a hash join
+# description: Test contains/list_contains on a constant list (rewrite to IN, join vs scan, null/empty semantics)
 # group: [optimizer]
 
 statement ok
@@ -34,3 +34,40 @@ query II
 EXPLAIN FROM the_table WHERE the_id NOT IN [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20]
 ----
 logical_opt	<!REGEX>:.*COMPARISON_JOIN.*
+
+statement ok
+CREATE TABLE t AS SELECT * FROM (VALUES (1), (2), (NULL::INTEGER)) v(a);
+
+# FILTER on empty / null list becomes EMPTY_RESULT
+statement ok
+SET explain_output='physical_only';
+
+query II
+EXPLAIN SELECT * FROM t WHERE list_contains([], a)
+----
+physical_plan	<REGEX>:.*EMPTY_RESULT.*
+
+query II
+EXPLAIN SELECT * FROM t WHERE list_has([], a)
+----
+physical_plan	<REGEX>:.*EMPTY_RESULT.*
+
+query II
+EXPLAIN SELECT * FROM t WHERE array_contains([], a)
+----
+physical_plan	<REGEX>:.*EMPTY_RESULT.*
+
+query II
+EXPLAIN SELECT * FROM t WHERE array_has([], a)
+----
+physical_plan	<REGEX>:.*EMPTY_RESULT.*
+
+query II
+EXPLAIN SELECT * FROM t WHERE contains([], a)
+----
+physical_plan	<REGEX>:.*EMPTY_RESULT.*
+
+query II
+EXPLAIN SELECT * FROM t WHERE list_contains(NULL::INTEGER[], a)
+----
+physical_plan	<REGEX>:.*EMPTY_RESULT.*

--- a/test/optimizer/contains_to_in_clause.test
+++ b/test/optimizer/contains_to_in_clause.test
@@ -71,3 +71,20 @@ query II
 EXPLAIN SELECT * FROM t WHERE list_contains(NULL::INTEGER[], a)
 ----
 physical_plan	<REGEX>:.*EMPTY_RESULT.*
+
+# NULL-only list: list_contains([NULL], a) should return false, not NULL
+query I
+SELECT list_contains([NULL], a) FROM (VALUES (1)) t(a);
+----
+false
+
+query II
+EXPLAIN SELECT * FROM t WHERE list_contains([NULL], a)
+----
+physical_plan	<REGEX>:.*EMPTY_RESULT.*
+
+# Mixed list with NULLs: NULLs are stripped, non-NULL elements remain
+query II
+EXPLAIN SELECT * FROM t WHERE list_contains([1, NULL, 2], a)
+----
+physical_plan	<!REGEX>:.*EMPTY_RESULT.*


### PR DESCRIPTION
Closes https://github.com/duckdb/duckdb/issues/23542

This PR handles empty list in the contains optimizer to emit empty result directly, so we don't do sequential scan, as it's described in the issue.