### PR TITLE
Address test warning

### DIFF
--- a/test/sql/copy/csv/test_copy_gzip_large_block.test_slow
+++ b/test/sql/copy/csv/test_copy_gzip_large_block.test_slow
@@ -3,12 +3,12 @@
 # group: [csv]
 
 statement ok
-COPY (SELECT repeat('x', 2100000) AS doc FROM range(2048)) TO '__TEST_DIR__/large_gzip_block.csv.gz' (FORMAT CSV, HEADER false);
+COPY (SELECT repeat('x', 2100000) AS doc FROM range(2048)) TO '{TEST_DIR}/large_gzip_block.csv.gz' (FORMAT CSV, HEADER false);
 
 # Round-trip read-back ensures the gzip stream produced across multiple deflate chunks is
 # valid and decompresses to exactly the original data (2048 rows of 2100000 'x' characters).
 query II
 SELECT count(*), sum(length(doc))::BIGINT
-FROM read_csv('__TEST_DIR__/large_gzip_block.csv.gz', columns={'doc': 'VARCHAR'}, header=false, max_line_size=20000000);
+FROM read_csv('{TEST_DIR}/large_gzip_block.csv.gz', columns={'doc': 'VARCHAR'}, header=false, max_line_size=20000000);
 ----
 2048	4300800000

--- a/test/sql/copy/parquet/parquet_expression_filter_pruning.test
+++ b/test/sql/copy/parquet/parquet_expression_filter_pruning.test
@@ -9,13 +9,13 @@ require parquet
 
 # 10 row groups of 10240 rows (multiple of vector size -> deterministic boundaries)
 statement ok
-COPY (SELECT range AS a FROM range(102400)) TO '__TEST_DIR__/expr_prune_int.parquet' (ROW_GROUP_SIZE 10240)
+COPY (SELECT range AS a FROM range(102400)) TO '{TEST_DIR}/expr_prune_int.parquet' (ROW_GROUP_SIZE 10240)
 
 statement ok
-COPY (SELECT range::DOUBLE AS d FROM range(102400)) TO '__TEST_DIR__/expr_prune_double.parquet' (ROW_GROUP_SIZE 10240)
+COPY (SELECT range::DOUBLE AS d FROM range(102400)) TO '{TEST_DIR}/expr_prune_double.parquet' (ROW_GROUP_SIZE 10240)
 
 statement ok
-COPY (SELECT CASE WHEN range = 95000 THEN 'nan'::DOUBLE ELSE range::DOUBLE END AS d FROM range(102400)) TO '__TEST_DIR__/expr_prune_nan.parquet' (ROW_GROUP_SIZE 10240)
+COPY (SELECT CASE WHEN range = 95000 THEN 'nan'::DOUBLE ELSE range::DOUBLE END AS d FROM range(102400)) TO '{TEST_DIR}/expr_prune_nan.parquet' (ROW_GROUP_SIZE 10240)
 
 # constants are not divisible by the multiplier, so the optimizer keeps the expression filter
 # instead of folding it into a plain comparison
@@ -25,7 +25,7 @@ statement ok
 CALL enable_logging('PhysicalOperator')
 
 query I
-SELECT count(*) FROM '__TEST_DIR__/expr_prune_int.parquet' WHERE a * 4 + 4 > 327681
+SELECT count(*) FROM '{TEST_DIR}/expr_prune_int.parquet' WHERE a * 4 + 4 > 327681
 ----
 20480
 
@@ -46,7 +46,7 @@ statement ok
 CALL enable_logging('PhysicalOperator')
 
 query I
-SELECT count(*) FROM '__TEST_DIR__/expr_prune_int.parquet' WHERE a * 4 - 4 < 40961
+SELECT count(*) FROM '{TEST_DIR}/expr_prune_int.parquet' WHERE a * 4 - 4 < 40961
 ----
 10242
 
@@ -64,7 +64,7 @@ CALL truncate_duckdb_logs()
 
 # false for the whole file -> optimizer folds to EMPTY_RESULT from file-level stats
 query II
-EXPLAIN SELECT count(*) FROM '__TEST_DIR__/expr_prune_int.parquet' WHERE a * 4 + 4 > 409601
+EXPLAIN SELECT count(*) FROM '{TEST_DIR}/expr_prune_int.parquet' WHERE a * 4 + 4 > 409601
 ----
 physical_plan	<REGEX>:.*EMPTY_RESULT.*
 
@@ -73,7 +73,7 @@ statement ok
 CALL enable_logging('PhysicalOperator')
 
 query I
-SELECT count(*) FROM '__TEST_DIR__/expr_prune_double.parquet' WHERE d + d < 20479.5e0
+SELECT count(*) FROM '{TEST_DIR}/expr_prune_double.parquet' WHERE d + d < 20479.5e0
 ----
 10240
 
@@ -94,7 +94,7 @@ statement ok
 CALL enable_logging('PhysicalOperator')
 
 query I
-SELECT count(*) FROM '__TEST_DIR__/expr_prune_nan.parquet' WHERE d + d > 184318.5e0
+SELECT count(*) FROM '{TEST_DIR}/expr_prune_nan.parquet' WHERE d + d > 184318.5e0
 ----
 10240
 
@@ -116,7 +116,7 @@ statement ok
 CALL enable_logging('PhysicalOperator')
 
 query III
-SELECT count(*), min(d), max(d) FROM read_parquet('__TEST_DIR__/expr_prune_nan.parquet', can_have_nan=true) WHERE d + d > 184318.5e0
+SELECT count(*), min(d), max(d) FROM read_parquet('{TEST_DIR}/expr_prune_nan.parquet', can_have_nan=true) WHERE d + d > 184318.5e0
 ----
 10240	92160.0	nan
 

--- a/test/sql/logging/enable_logging_file_no_path.test
+++ b/test/sql/logging/enable_logging_file_no_path.test
@@ -30,7 +30,7 @@ memory
 # 2) ...and it must not have poisoned the storage: the same call WITH a path now succeeds.
 #    Before the fix this also failed with "path wasn't set", and DuckDB aborted on exit.
 statement ok
-CALL enable_logging('QueryLog', storage=file, storage_path='__TEST_DIR__/issue9144.csv')
+CALL enable_logging('QueryLog', storage=file, storage_path='{TEST_DIR}/issue9144.csv')
 
 query I
 SELECT value FROM duckdb_settings() WHERE name = 'logging_storage';

--- a/test/sql/parallelism/interquery/concurrent_drop_schema_macro_table.test_slow
+++ b/test/sql/parallelism/interquery/concurrent_drop_schema_macro_table.test_slow
@@ -2,7 +2,7 @@
 # description: Concurrent DROP SCHEMA CASCADE while recreating a dependent macro and table
 # group: [interquery]
 
-load __TEST_DIR__/concurrent_drop_schema_macro_table.db
+load {TEST_DIR}/concurrent_drop_schema_macro_table.db
 
 concurrentloop threadid 0 12
 

--- a/test/sql/storage/compression/alp/alp_corrupted_file.test
+++ b/test/sql/storage/compression/alp/alp_corrupted_file.test
@@ -3,10 +3,10 @@
 
 require vector_size 2048
 
-unzip data/storage/alp_corrupted.db.gz __TEST_DIR__/alp_corrupted.db
+unzip data/storage/alp_corrupted.db.gz {TEST_DIR}/alp_corrupted.db
 
 statement ok
-ATTACH '__TEST_DIR__/alp_corrupted.db' AS db2
+ATTACH '{TEST_DIR}/alp_corrupted.db' AS db2
 
 statement ok
 USE db2;

--- a/test/sql/storage/compression/alp/alp_corrupted_offsets.test
+++ b/test/sql/storage/compression/alp/alp_corrupted_offsets.test
@@ -3,10 +3,10 @@
 
 require vector_size 2048
 
-unzip data/storage/alp_corrupted_offsets.db.gz __TEST_DIR__/alp_corrupted_offsets.db
+unzip data/storage/alp_corrupted_offsets.db.gz {TEST_DIR}/alp_corrupted_offsets.db
 
 statement ok
-ATTACH '__TEST_DIR__/alp_corrupted_offsets.db' AS db2
+ATTACH '{TEST_DIR}/alp_corrupted_offsets.db' AS db2
 
 statement ok
 USE db2;

--- a/test/sql/storage/compression/alp/alp_corrupted_vector_size.test
+++ b/test/sql/storage/compression/alp/alp_corrupted_vector_size.test
@@ -3,10 +3,10 @@
 
 require vector_size 2048
 
-unzip data/storage/alp_corrupt_vector_size.db.gz __TEST_DIR__/alp_corrupt_vector_size.db
+unzip data/storage/alp_corrupt_vector_size.db.gz {TEST_DIR}/alp_corrupt_vector_size.db
 
 statement ok
-ATTACH '__TEST_DIR__/alp_corrupt_vector_size.db' AS db2
+ATTACH '{TEST_DIR}/alp_corrupt_vector_size.db' AS db2
 
 statement ok
 USE db2;

--- a/test/sql/storage/compression/alprd/alprd_corrupted_dict_size.test
+++ b/test/sql/storage/compression/alprd/alprd_corrupted_dict_size.test
@@ -3,10 +3,10 @@
 
 require vector_size 2048
 
-unzip data/storage/alprd_corrupted_dict_size.db.gz __TEST_DIR__/alprd_corrupted_dict_size.db
+unzip data/storage/alprd_corrupted_dict_size.db.gz {TEST_DIR}/alprd_corrupted_dict_size.db
 
 statement ok
-ATTACH '__TEST_DIR__/alprd_corrupted_dict_size.db' AS db2
+ATTACH '{TEST_DIR}/alprd_corrupted_dict_size.db' AS db2
 
 statement ok
 USE db2;

--- a/test/sql/storage/types/variant/variant_case_sensitive_fields_shredded.test
+++ b/test/sql/storage/types/variant/variant_case_sensitive_fields_shredded.test
@@ -1,7 +1,7 @@
 # name: test/sql/storage/types/variant/variant_case_sensitive_fields_shredded.test
 # group: [variant]
 
-load __TEST_DIR__/variant_checkpoint_issue.db readwrite v1.5.3
+load {TEST_DIR}/variant_checkpoint_issue.db readwrite v1.5.3
 
 statement ok
 set variant_minimum_shredding_size = 0;

--- a/test/sql/storage/types/variant/variant_parquet_shredding_bug.test_slow
+++ b/test/sql/storage/types/variant/variant_parquet_shredding_bug.test_slow
@@ -16,9 +16,9 @@ CREATE TABLE t AS
 FROM range(300000) tbl(i) ORDER BY i;
 
 statement ok
-COPY (from t) TO '__TEST_DIR__/variant.parquet' (file_size_bytes '2mb')
+COPY (from t) TO '{TEST_DIR}/variant.parquet' (file_size_bytes '2mb')
 
 query I
-SELECT count(*) FROM read_parquet('__TEST_DIR__/variant.parquet')
+SELECT count(*) FROM read_parquet('{TEST_DIR}/variant.parquet')
 ----
 300000

--- a/test/sql/storage/vacuum/vacuum_rebuild_indexes_attach.test_slow
+++ b/test/sql/storage/vacuum/vacuum_rebuild_indexes_attach.test_slow
@@ -4,7 +4,7 @@
 
 # set threshold at 5 X rowgroup size
 statement ok
-ATTACH '__TEST_DIR__/attach_vacuum_indexed.db' AS db1 (vacuum_rebuild_indexes 614400)
+ATTACH '{TEST_DIR}/attach_vacuum_indexed.db' AS db1 (vacuum_rebuild_indexes 614400)
 
 statement ok
 CREATE TABLE db1.t(i INTEGER);
@@ -62,17 +62,17 @@ SELECT COUNT(*) FROM db1.t
 
 # ATTACH OR REPLACE with a different vacuum_rebuild_indexes value fails
 statement error
-ATTACH OR REPLACE '__TEST_DIR__/attach_vacuum_indexed.db' AS db1 (vacuum_rebuild_indexes 0)
+ATTACH OR REPLACE '{TEST_DIR}/attach_vacuum_indexed.db' AS db1 (vacuum_rebuild_indexes 0)
 ----
 Cannot re-attach with a different vacuum_rebuild_indexes setting
 
 # ATTACH OR REPLACE with the same value is a no-op
 statement ok
-ATTACH OR REPLACE '__TEST_DIR__/attach_vacuum_indexed.db' AS db1 (vacuum_rebuild_indexes 614400)
+ATTACH OR REPLACE '{TEST_DIR}/attach_vacuum_indexed.db' AS db1 (vacuum_rebuild_indexes 614400)
 
 # ATTACH IF NOT EXISTS ignores the supplied options; the existing threshold (614400) remains in effect
 statement ok
-ATTACH IF NOT EXISTS '__TEST_DIR__/attach_vacuum_indexed.db' AS db1 (vacuum_rebuild_indexes 0)
+ATTACH IF NOT EXISTS '{TEST_DIR}/attach_vacuum_indexed.db' AS db1 (vacuum_rebuild_indexes 0)
 
 # delete all rows in the (now) first row group
 statement ok

--- a/test/sql/storage/vacuum/vacuum_rebuild_indexes_attach_overrides_global.test_slow
+++ b/test/sql/storage/vacuum/vacuum_rebuild_indexes_attach_overrides_global.test_slow
@@ -6,7 +6,7 @@ require vacuum_rebuild_indexes
 
 # set threshold at 0
 statement ok
-ATTACH '__TEST_DIR__/attach_vacuum_indexed.db' AS db1 (vacuum_rebuild_indexes 0)
+ATTACH '{TEST_DIR}/attach_vacuum_indexed.db' AS db1 (vacuum_rebuild_indexes 0)
 
 statement ok
 CREATE TABLE db1.t(i INTEGER);

--- a/test/sql/types/geo/geometry_shred_deletes.test
+++ b/test/sql/types/geo/geometry_shred_deletes.test
@@ -1,7 +1,7 @@
 # name: test/sql/types/geo/geometry_shred_deletes.test
 # group: [geo]
 
-load __TEST_DIR__/geo_crash.db readwrite v1.5.0
+load {TEST_DIR}/geo_crash.db readwrite v1.5.0
 
 statement ok
 set checkpoint_threshold='10gb'

--- a/test/sql/types/geo/geometry_shred_more.test
+++ b/test/sql/types/geo/geometry_shred_more.test
@@ -10,7 +10,7 @@ foreach storage_version v1.0.0 v1.5.0
 foreach rgsize 2048 8192
 
 statement ok
-ATTACH '__TEST_DIR__/geocp_${storage_version}_${rgsize}.db' AS db (ROW_GROUP_SIZE ${rgsize}, STORAGE_VERSION '${storage_version}');
+ATTACH '{TEST_DIR}/geocp_${storage_version}_${rgsize}.db' AS db (ROW_GROUP_SIZE ${rgsize}, STORAGE_VERSION '${storage_version}');
 
 statement ok
 USE db;
@@ -140,7 +140,7 @@ statement ok
 DETACH db;
 
 statement ok
-ATTACH '__TEST_DIR__/geocp_${storage_version}_${rgsize}.db' AS db;
+ATTACH '{TEST_DIR}/geocp_${storage_version}_${rgsize}.db' AS db;
 
 statement ok
 USE db;

--- a/test/sql/types/struct/test_tuple.test
+++ b/test/sql/types/struct/test_tuple.test
@@ -154,7 +154,7 @@ SELECT struct_extract(c, 1), struct_extract(c, 2) FROM t WHERE c IS NOT NULL ORD
 
 # storage: a recent (v2.0.0+) database stores the TUPLE id directly - empty and non-empty round-trip as TUPLE
 statement ok
-ATTACH '__TEST_DIR__/tuple_v2.db' AS v2 (STORAGE_VERSION 'v2.0.0');
+ATTACH '{TEST_DIR}/tuple_v2.db' AS v2 (STORAGE_VERSION 'v2.0.0');
 
 statement ok
 CREATE TABLE v2.tup AS SELECT row() AS e, row(1) AS one, row(2, 'b') AS two;
@@ -163,7 +163,7 @@ statement ok
 DETACH v2;
 
 statement ok
-ATTACH '__TEST_DIR__/tuple_v2.db' AS v2 (READ_ONLY);
+ATTACH '{TEST_DIR}/tuple_v2.db' AS v2 (READ_ONLY);
 
 query TTTTTT
 SELECT e, typeof(e), one, typeof(one), two, typeof(two) FROM v2.tup;
@@ -175,7 +175,7 @@ DETACH v2;
 
 # storage: TUPLE columns are not storable in older formats (older engines reject the unnamed STRUCT on disk)
 statement ok
-ATTACH '__TEST_DIR__/tuple_v15.db' AS v15 (STORAGE_VERSION 'v1.5.0');
+ATTACH '{TEST_DIR}/tuple_v15.db' AS v15 (STORAGE_VERSION 'v1.5.0');
 
 statement error
 CREATE TABLE v15.tup AS SELECT row(2, 'b') AS two;


### PR DESCRIPTION
I get a few warning messages on tests, so I asked agents to update them all.
```sh
[65/193] (33%): ...l/copy/parquet/tpch_parquet_copy_cast.test_slow took 0.009sReplacing deprecated string __TEST_DIR__ in path "COPY (SELECT range AS a FROM range(102400)) TO '__TEST_DIR__/expr_prune_int.parquet' (ROW_GROUP_SIZE 10240)" - please replace with {TEST_DIR}
Replacing deprecated string __TEST_DIR__ in path "COPY (SELECT range::DOUBLE AS d FROM range(102400)) TO '__TEST_DIR__/expr_prune_double.parquet' (ROW_GROUP_SIZE 10240)" - please replace with {TEST_DIR}
```