### PR TITLE
Rename columns to original names before passing to reader if they were aliased

### DIFF
--- a/src/optimizer/pushdown/pushdown_get.cpp
+++ b/src/optimizer/pushdown/pushdown_get.cpp
@@ -4,14 +4,46 @@
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
 #include "duckdb/planner/expression/bound_operator_expression.hpp"
 #include "duckdb/planner/expression/bound_parameter_expression.hpp"
-#include "duckdb/planner/operator/logical_filter.hpp"
+#include "duckdb/planner/expression_iterator.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/planner/operator/logical_empty_result.hpp"
 
 namespace duckdb {
+
+/**
+ * When a BoundColumnRefExpression that's part of expr (a filter) arrives here, its
+ * name will be set to the projection name i.e. "other" for SELECT col as other.
+ * If CTE inlining optimizer collapses the CTE in
+ * WITH cte AS (SELECT col AS other FROM reader()) SELECT * WHERE other > 0 FROM cte,
+ * reader() will get a complex filter with "other" which doesn't exist.
+ * Rename the columns back to their original names
+ */
+static void NormalizeColumnRefAliases(unique_ptr<Expression> &expr, const LogicalGet &get) {
+	const vector<ColumnIndex> &column_ids = get.GetColumnIds();
+	ExpressionIterator::VisitExpressionMutable<BoundColumnRefExpression>(expr, [&](auto &ref, auto &) {
+		const ColumnBinding &binding = ref.Binding();
+		if (binding.table_index != get.table_index || binding.column_index >= column_ids.size()) {
+			return;
+		}
+		const ColumnIndex &col_idx = column_ids[binding.column_index];
+		const idx_t primary = col_idx.GetPrimaryIndex();
+		if (col_idx.IsVirtualColumn()) {
+			if (const auto it = get.virtual_columns.find(primary); it != get.virtual_columns.end()) {
+				ref.SetAlias(Identifier(it->second.name.GetIdentifierName()));
+			}
+		} else if (primary < get.names.size()) {
+			ref.SetAlias(Identifier(col_idx.GetName(get.names[primary].GetIdentifierName())));
+		}
+	});
+}
+
 unique_ptr<LogicalOperator> FilterPushdown::PushdownGet(unique_ptr<LogicalOperator> op) {
 	D_ASSERT(op->type == LogicalOperatorType::LOGICAL_GET);
 	auto &get = op->Cast<LogicalGet>();
+
+	for (auto &filter : filters) {
+		NormalizeColumnRefAliases(filter->filter, get);
+	}
 
 	if (get.function.pushdown_complex_filter || get.function.filter_pushdown) {
 		// this scan supports some form of filter push-down

--- a/test/optimizer/CMakeLists.txt
+++ b/test/optimizer/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library_unity(test_optimizer OBJECT common_subplan_nonserializable.cpp
-                  union_alls.cpp)
+                  filter_pushdown_alias.cpp union_alls.cpp)
 
 set(UNITTEST_OBJECT_FILES
     ${UNITTEST_OBJECT_FILES} $<TARGET_OBJECTS:test_optimizer>

--- a/test/optimizer/filter_pushdown_alias.cpp
+++ b/test/optimizer/filter_pushdown_alias.cpp
@@ -1,7 +1,5 @@
 #include "catch.hpp"
 #include "duckdb/common/string_util.hpp"
-#include "duckdb/common/unique_ptr.hpp"
-#include "duckdb/function/function.hpp"
 #include "duckdb/function/table_function.hpp"
 #include "duckdb/main/database.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
@@ -17,88 +15,58 @@ namespace {
 struct BindData : public TableFunctionData {
 	mutable string alias;
 	unique_ptr<FunctionData> Copy() const override {
-		auto result = make_uniq<BindData>();
-		result->alias = alias;
-		return std::move(result);
+		auto out = make_uniq<BindData>();
+		out->alias = alias;
+		return std::move(out);
 	}
 };
 
-void PushdownComplexFilter(ClientContext &, LogicalGet &get, FunctionData *bind_data_p,
-                           vector<unique_ptr<Expression>> &filters) {
-	auto &bind_data = bind_data_p->Cast<BindData>();
-	for (auto &expr : filters) {
-		ExpressionIterator::VisitExpressionMutable<BoundColumnRefExpression>(expr, [&](auto &ref, auto &) {
-			if (ref.Binding().table_index == get.table_index && bind_data.alias.empty()) {
-				bind_data.alias = ref.GetAlias().GetIdentifierName();
-			}
-		});
-	}
-}
+} // namespace
 
-void RegisterAliasInspect(DuckDB &db) {
-	auto function = [](auto &, auto &, auto &output) {
-		output.SetChildCardinality(0);
-	};
-	auto init = [](auto &, auto &) -> unique_ptr<GlobalTableFunctionState> {
-		return {};
-	};
-	auto bind = [](auto &, auto &, auto &types, auto &names) -> unique_ptr<FunctionData> {
-		types.emplace_back(LogicalType::INTEGER);
-		names.emplace_back("col");
-		return make_uniq<BindData>();
-	};
+TEST_CASE("Filter pushdown rewrites BoundColumnRef alias to the scan column name", "[optimizer][filter_pushdown]") {
+	DuckDB db(nullptr);
+	Connection con(db);
 
-	TableFunction tf("alias_inspect", {}, function, bind, init);
+	TableFunction tf(
+	    "alias_inspect", {}, [](auto &, auto &, auto &out) { out.SetChildCardinality(0); },
+	    [](auto &, auto &, auto &types, auto &names) -> unique_ptr<FunctionData> {
+		    types.emplace_back(LogicalType::INTEGER);
+		    names.emplace_back("col");
+		    return make_uniq<BindData>();
+	    },
+	    [](auto &, auto &) -> unique_ptr<GlobalTableFunctionState> { return {}; });
 
-	tf.pushdown_complex_filter = PushdownComplexFilter;
+	tf.pushdown_complex_filter = [](auto &, auto &get, auto *bind_data_p, auto &filters) {
+		auto &data = bind_data_p->template Cast<BindData>();
+		for (auto &expr : filters) {
+			ExpressionIterator::VisitExpressionMutable<BoundColumnRefExpression>(expr, [&](auto &ref, auto &) {
+				if (ref.Binding().table_index == get.table_index && data.alias.empty()) {
+					data.alias = ref.GetAlias().GetIdentifierName();
+				}
+			});
+		}
+	};
 	tf.to_string = [](auto &input) {
 		InsertionOrderPreservingMap<string> result;
-		if (auto bind_data = input.bind_data.get(); bind_data) {
-			auto &data = bind_data->template Cast<BindData>();
-			result["FilterAlias"] = data.alias.empty() ? "<none>" : data.alias;
-		}
+		result["FilterAlias"] = input.bind_data->template Cast<BindData>().alias;
 		return result;
 	};
 
-	ExtensionInfo extension_info {};
-	ExtensionActiveLoad load_info {*db.instance, extension_info, "test_extension", ""};
+	ExtensionInfo ext_info {};
+	ExtensionActiveLoad load_info {*db.instance, ext_info, "test_extension", ""};
 	ExtensionLoader loader {load_info};
 	loader.RegisterFunction(tf);
-}
 
-string GetExplain(Connection &con, const string &query) {
-	auto result = con.Query("EXPLAIN " + query);
+	REQUIRE_NO_FAIL(con.Query("PRAGMA explain_output='optimized_only'"));
+	auto result =
+	    con.Query("EXPLAIN SELECT * FROM (SELECT col AS other FROM alias_inspect()) sub WHERE other IS NOT NULL");
 	REQUIRE_NO_FAIL(*result);
+
 	string explain;
 	for (idx_t row = 0; row < result->RowCount(); row++) {
 		for (idx_t col = 0; col < result->ColumnCount(); col++) {
 			explain += result->GetValue(col, row).ToString();
-			explain += "\n";
 		}
 	}
-	return explain;
-}
-
-} // namespace
-
-TEST_CASE("Filter pushdown normalizes BoundColumnRef alias to scan column name", "[optimizer][filter_pushdown]") {
-	DuckDB db(nullptr);
-	Connection con(db);
-	RegisterAliasInspect(db);
-
-	REQUIRE_NO_FAIL(con.Query("PRAGMA explain_output='optimized_only'"));
-
-	SECTION("subquery with column rename") {
-		const auto explain =
-		    GetExplain(con, "SELECT * FROM (SELECT col AS other FROM alias_inspect()) sub WHERE other IS NOT NULL");
-		REQUIRE(StringUtil::Contains(explain, "FilterAlias: col"));
-		REQUIRE_FALSE(StringUtil::Contains(explain, "FilterAlias: other"));
-	}
-
-	SECTION("CTE with column rename") {
-		const auto explain = GetExplain(con, "WITH cte AS (SELECT col AS other FROM alias_inspect()) "
-		                                     "SELECT * FROM cte WHERE other IS NOT NULL ORDER BY other");
-		REQUIRE(StringUtil::Contains(explain, "FilterAlias: col"));
-		REQUIRE_FALSE(StringUtil::Contains(explain, "FilterAlias: other"));
-	}
+	REQUIRE(StringUtil::Contains(explain, "FilterAlias: col"));
 }

--- a/test/optimizer/filter_pushdown_alias.cpp
+++ b/test/optimizer/filter_pushdown_alias.cpp
@@ -1,0 +1,104 @@
+#include "catch.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/common/unique_ptr.hpp"
+#include "duckdb/function/function.hpp"
+#include "duckdb/function/table_function.hpp"
+#include "duckdb/main/database.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/planner/expression/bound_columnref_expression.hpp"
+#include "duckdb/planner/expression_iterator.hpp"
+#include "duckdb/planner/operator/logical_get.hpp"
+#include "test_helpers.hpp"
+
+using namespace duckdb;
+
+namespace {
+
+struct BindData : public TableFunctionData {
+	mutable string alias;
+	unique_ptr<FunctionData> Copy() const override {
+		auto result = make_uniq<BindData>();
+		result->alias = alias;
+		return std::move(result);
+	}
+};
+
+void PushdownComplexFilter(ClientContext &, LogicalGet &get, FunctionData *bind_data_p,
+                           vector<unique_ptr<Expression>> &filters) {
+	auto &bind_data = bind_data_p->Cast<BindData>();
+	for (auto &expr : filters) {
+		ExpressionIterator::VisitExpressionMutable<BoundColumnRefExpression>(expr, [&](auto &ref, auto &) {
+			if (ref.Binding().table_index == get.table_index && bind_data.alias.empty()) {
+				bind_data.alias = ref.GetAlias().GetIdentifierName();
+			}
+		});
+	}
+}
+
+void RegisterAliasInspect(DuckDB &db) {
+	auto function = [](auto &, auto &, auto &output) {
+		output.SetChildCardinality(0);
+	};
+	auto init = [](auto &, auto &) -> unique_ptr<GlobalTableFunctionState> {
+		return {};
+	};
+	auto bind = [](auto &, auto &, auto &types, auto &names) -> unique_ptr<FunctionData> {
+		types.emplace_back(LogicalType::INTEGER);
+		names.emplace_back("col");
+		return make_uniq<BindData>();
+	};
+
+	TableFunction tf("alias_inspect", {}, function, bind, init);
+
+	tf.pushdown_complex_filter = PushdownComplexFilter;
+	tf.to_string = [](auto &input) {
+		InsertionOrderPreservingMap<string> result;
+		if (auto bind_data = input.bind_data.get(); bind_data) {
+			auto &data = bind_data->template Cast<BindData>();
+			result["FilterAlias"] = data.alias.empty() ? "<none>" : data.alias;
+		}
+		return result;
+	};
+
+	ExtensionInfo extension_info {};
+	ExtensionActiveLoad load_info {*db.instance, extension_info, "test_extension", ""};
+	ExtensionLoader loader {load_info};
+	loader.RegisterFunction(tf);
+}
+
+string GetExplain(Connection &con, const string &query) {
+	auto result = con.Query("EXPLAIN " + query);
+	REQUIRE_NO_FAIL(*result);
+	string explain;
+	for (idx_t row = 0; row < result->RowCount(); row++) {
+		for (idx_t col = 0; col < result->ColumnCount(); col++) {
+			explain += result->GetValue(col, row).ToString();
+			explain += "\n";
+		}
+	}
+	return explain;
+}
+
+} // namespace
+
+TEST_CASE("Filter pushdown normalizes BoundColumnRef alias to scan column name", "[optimizer][filter_pushdown]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	RegisterAliasInspect(db);
+
+	REQUIRE_NO_FAIL(con.Query("PRAGMA explain_output='optimized_only'"));
+
+	SECTION("subquery with column rename") {
+		const auto explain =
+		    GetExplain(con, "SELECT * FROM (SELECT col AS other FROM alias_inspect()) sub WHERE other IS NOT NULL");
+		REQUIRE(StringUtil::Contains(explain, "FilterAlias: col"));
+		REQUIRE_FALSE(StringUtil::Contains(explain, "FilterAlias: other"));
+	}
+
+	SECTION("CTE with column rename") {
+		const auto explain = GetExplain(con, "WITH cte AS (SELECT col AS other FROM alias_inspect()) "
+		                                     "SELECT * FROM cte WHERE other IS NOT NULL ORDER BY other");
+		REQUIRE(StringUtil::Contains(explain, "FilterAlias: col"));
+		REQUIRE_FALSE(StringUtil::Contains(explain, "FilterAlias: other"));
+	}
+}


### PR DESCRIPTION
In the following query

WITH cte AS (SELECT col AS other FROM '1.vortex') SELECT * WHERE other > 0 FROM cte,

Vortex reader fails because a complex filter pushed ("WHERE other > 0") contains a column "other" not present in the file. This happens because BoundColumnRefExpression contains the aliased name, not the original one.

When CTE inline optimizer collapses the CTE, the aliased column name is not changed.
This PR renames columns back to their unaliased names before passing to the reader.