### PR TITLE
Rewrite `LEFT` to `ANTI` if there is a `IS NULL` filter on the null-extended side 

### DIFF
--- a/src/include/duckdb/optimizer/outer_join_simplification.hpp
+++ b/src/include/duckdb/optimizer/outer_join_simplification.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "duckdb/common/enums/expression_type.hpp"
 #include "duckdb/planner/column_binding_map.hpp"
 #include "duckdb/planner/logical_operator_visitor.hpp"
 

--- a/src/include/duckdb/optimizer/outer_join_simplification.hpp
+++ b/src/include/duckdb/optimizer/outer_join_simplification.hpp
@@ -13,7 +13,17 @@
 
 namespace duckdb {
 
-//! Simplifies FULL OUTER -> LEFT/RIGHT OUTER -> INNER if NULLs are filtered anyway
+class Expression;
+struct JoinCondition;
+class LogicalAggregate;
+class LogicalComparisonJoin;
+class LogicalFilter;
+class LogicalJoin;
+class LogicalOrder;
+class LogicalProjection;
+class LogicalTopN;
+
+//! Simplifies outer joins if NULL-extended rows are filtered in a way that changes the join semantics
 class OuterJoinSimplification : public LogicalOperatorVisitor {
 public:
 	OuterJoinSimplification();
@@ -22,11 +32,53 @@ public:
 	void VisitOperator(LogicalOperator &op) override;
 
 private:
+	explicit OuterJoinSimplification(column_binding_set_t required_columns);
+
+	//! Extract and propagate column references through expressions and join conditions
+	void AddColumnReferences(const Expression &expr, column_binding_set_t &bindings);
+	void AddRequiredColumns(const Expression &expr);
+	void AddRequiredColumns(const JoinCondition &condition);
+	void AddRequiredColumns(const vector<JoinCondition> &conditions);
+	bool GetColumnBinding(const Expression &expr, ColumnBinding &binding);
+	bool GetNullPreservingColumnBinding(const Expression &expr, ColumnBinding &binding);
+
+	//! Track predicates that require columns to be NULL or reject NULL values
 	void HandleExpression(const Expression &expr);
+	void HandleFilterExpression(const Expression &expr);
+	bool HandleIsNullExpression(const Expression &expr);
+	bool IsNullFilter(const Expression &expr, ColumnBinding &binding);
+	void InitializeRequiredColumns(LogicalOperator &op);
+	bool FiltersNulls(ExpressionType comparison_type);
+
+	//! Rewrite joins based on the NULL constraints collected from operators above them
+	bool TryConvertLeftToAntiJoin(LogicalComparisonJoin &join);
+	bool HasNullRequiredColumns(const vector<ColumnBinding> &bindings);
+	bool HasRequiredColumns(const vector<ColumnBinding> &bindings);
+	void MarkEliminatedNullColumns(const vector<ColumnBinding> &bindings);
+	vector<ColumnBinding> GetRightBindings(LogicalJoin &join);
+	void SimplifyOuterJoinType(LogicalComparisonJoin &join);
+
+	//! Visit operators while preserving only the constraints that can safely pass through each operator type
+	void VisitComparisonJoin(LogicalComparisonJoin &join, LogicalOperator &op);
+	void VisitInnerOrSemiJoin(LogicalComparisonJoin &join, LogicalOperator &op);
+	void VisitOuterJoin(LogicalComparisonJoin &join, LogicalOperator &op);
+	void VisitProjection(LogicalProjection &projection, LogicalOperator &op);
+	void VisitFilter(LogicalFilter &filter, LogicalOperator &op);
+	void VisitOrder(LogicalOrder &order, LogicalOperator &op);
+	void VisitTopN(LogicalTopN &top_n, LogicalOperator &op);
+	void VisitAggregate(LogicalAggregate &aggregate, LogicalOperator &op);
+	void VisitUnsupportedOperator(LogicalOperator &op);
 
 private:
 	//! Columns that have their NULL values filtered
 	column_binding_set_t null_filtered_columns;
+	//! Columns that are required to be NULL
+	column_binding_set_t null_required_columns;
+	//! Columns that are known to be NULL after rewriting a LEFT join to an ANTI join
+	column_binding_set_t eliminated_null_columns;
+	//! Columns that must remain available to operators above the current point in the plan
+	column_binding_set_t required_columns;
+	bool initialized_required_columns = false;
 };
 
 } // namespace duckdb

--- a/src/optimizer/outer_join_simplification.cpp
+++ b/src/optimizer/outer_join_simplification.cpp
@@ -1,126 +1,441 @@
 #include "duckdb/optimizer/outer_join_simplification.hpp"
 
 #include "duckdb/planner/operator/list.hpp"
+#include "duckdb/planner/expression/bound_cast_expression.hpp"
+#include "duckdb/planner/expression/bound_columnref_expression.hpp"
 #include "duckdb/planner/expression/bound_comparison_expression.hpp"
+#include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression/bound_operator_expression.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "duckdb/planner/expression_iterator.hpp"
 
 namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// Setup
+//===--------------------------------------------------------------------===//
 
 OuterJoinSimplification::OuterJoinSimplification() {
 }
 
-void OuterJoinSimplification::HandleExpression(const Expression &expr) {
-	// TODO: could unwrap casts or basic arithmetic
+OuterJoinSimplification::OuterJoinSimplification(column_binding_set_t required_columns_p)
+    : required_columns(std::move(required_columns_p)), initialized_required_columns(true) {
+}
+
+//===--------------------------------------------------------------------===//
+// Column Binding Helpers
+//===--------------------------------------------------------------------===//
+
+void OuterJoinSimplification::AddColumnReferences(const Expression &expr, column_binding_set_t &bindings) {
+	ExpressionIterator::VisitExpression<BoundColumnRefExpression>(expr, [&](const BoundColumnRefExpression &colref) {
+		if (colref.Depth() == 0) {
+			bindings.insert(colref.Binding());
+		}
+	});
+}
+
+void OuterJoinSimplification::AddRequiredColumns(const Expression &expr) {
+	AddColumnReferences(expr, required_columns);
+}
+
+void OuterJoinSimplification::AddRequiredColumns(const JoinCondition &condition) {
+	if (condition.IsComparison()) {
+		AddRequiredColumns(condition.GetLHS());
+		AddRequiredColumns(condition.GetRHS());
+	} else {
+		AddRequiredColumns(condition.GetJoinExpression());
+	}
+}
+
+void OuterJoinSimplification::AddRequiredColumns(const vector<JoinCondition> &conditions) {
+	for (const auto &condition : conditions) {
+		AddRequiredColumns(condition);
+	}
+}
+
+bool OuterJoinSimplification::GetColumnBinding(const Expression &expr, ColumnBinding &binding) {
 	if (expr.GetExpressionClass() != ExpressionClass::BOUND_COLUMN_REF) {
-		return;
+		if (expr.GetExpressionClass() != ExpressionClass::BOUND_CAST) {
+			return false;
+		}
+		auto &cast = expr.Cast<BoundCastExpression>();
+		return GetColumnBinding(cast.Child(), binding);
 	}
 	auto &colref = expr.Cast<BoundColumnRefExpression>();
-	null_filtered_columns.insert(colref.Binding());
+	binding = colref.Binding();
+	return true;
+}
+
+bool OuterJoinSimplification::GetNullPreservingColumnBinding(const Expression &expr, ColumnBinding &binding) {
+	if (expr.GetExpressionClass() != ExpressionClass::BOUND_COLUMN_REF) {
+		if (expr.GetExpressionClass() != ExpressionClass::BOUND_CAST) {
+			return false;
+		}
+		auto &cast = expr.Cast<BoundCastExpression>();
+		if (cast.IsTryCast() || !BoundCastExpression::CastIsInvertible(cast.source_type(), cast.GetReturnType())) {
+			return false;
+		}
+		return GetNullPreservingColumnBinding(cast.Child(), binding);
+	}
+	auto &colref = expr.Cast<BoundColumnRefExpression>();
+	binding = colref.Binding();
+	return true;
+}
+
+//===--------------------------------------------------------------------===//
+// NULL Constraint Tracking
+//===--------------------------------------------------------------------===//
+
+void OuterJoinSimplification::HandleExpression(const Expression &expr) {
+	ColumnBinding binding;
+	if (GetColumnBinding(expr, binding)) {
+		null_filtered_columns.insert(binding);
+	}
+}
+
+void OuterJoinSimplification::HandleFilterExpression(const Expression &expr) {
+	if (expr.GetExpressionClass() == ExpressionClass::BOUND_OPERATOR &&
+	    expr.GetExpressionType() == ExpressionType::OPERATOR_IS_NOT_NULL) {
+		const auto &is_not_null = expr.Cast<BoundOperatorExpression>();
+		HandleExpression(*is_not_null.GetChildren()[0]);
+		AddRequiredColumns(expr);
+		return;
+	}
+
+	if (expr.GetExpressionClass() == ExpressionClass::BOUND_OPERATOR &&
+	    expr.GetExpressionType() == ExpressionType::OPERATOR_IS_NULL) {
+		const auto &is_null = expr.Cast<BoundOperatorExpression>();
+		if (!HandleIsNullExpression(*is_null.GetChildren()[0])) {
+			AddRequiredColumns(expr);
+		}
+		return;
+	}
+
+	if (!BoundComparisonExpression::IsComparison(expr)) {
+		AddRequiredColumns(expr);
+		return;
+	}
+
+	AddRequiredColumns(expr);
+	if (!FiltersNulls(expr.GetExpressionType())) {
+		return;
+	}
+	const auto &comparison = expr.Cast<BoundFunctionExpression>();
+	HandleExpression(BoundComparisonExpression::Left(comparison));
+	HandleExpression(BoundComparisonExpression::Right(comparison));
+}
+
+bool OuterJoinSimplification::HandleIsNullExpression(const Expression &expr) {
+	ColumnBinding binding;
+	if (GetNullPreservingColumnBinding(expr, binding)) {
+		null_required_columns.insert(binding);
+		return true;
+	}
+	return false;
+}
+
+bool OuterJoinSimplification::IsNullFilter(const Expression &expr, ColumnBinding &binding) {
+	if (expr.GetExpressionClass() != ExpressionClass::BOUND_OPERATOR ||
+	    expr.GetExpressionType() != ExpressionType::OPERATOR_IS_NULL) {
+		return false;
+	}
+	auto &is_null = expr.Cast<BoundOperatorExpression>();
+	auto &child = *is_null.GetChildren()[0];
+	return GetNullPreservingColumnBinding(child, binding);
+}
+
+void OuterJoinSimplification::InitializeRequiredColumns(LogicalOperator &op) {
+	if (initialized_required_columns) {
+		return;
+	}
+	for (const auto &binding : op.GetColumnBindings()) {
+		required_columns.insert(binding);
+	}
+	initialized_required_columns = true;
+}
+
+bool OuterJoinSimplification::FiltersNulls(ExpressionType comparison_type) {
+	return comparison_type != ExpressionType::COMPARE_DISTINCT_FROM &&
+	       comparison_type != ExpressionType::COMPARE_NOT_DISTINCT_FROM;
+}
+
+//===--------------------------------------------------------------------===//
+// Join Rewrite Helpers
+//===--------------------------------------------------------------------===//
+
+vector<ColumnBinding> OuterJoinSimplification::GetRightBindings(LogicalJoin &join) {
+	return LogicalOperator::MapBindings(join.children[1]->GetColumnBindings(), join.right_projection_map);
+}
+
+bool OuterJoinSimplification::HasNullRequiredColumns(const vector<ColumnBinding> &bindings) {
+	for (const auto &binding : bindings) {
+		if (null_required_columns.find(binding) != null_required_columns.end()) {
+			return true;
+		}
+	}
+	return false;
+}
+
+bool OuterJoinSimplification::HasRequiredColumns(const vector<ColumnBinding> &bindings) {
+	for (const auto &binding : bindings) {
+		if (required_columns.find(binding) != required_columns.end()) {
+			return true;
+		}
+	}
+	return false;
+}
+
+void OuterJoinSimplification::MarkEliminatedNullColumns(const vector<ColumnBinding> &bindings) {
+	for (const auto &binding : bindings) {
+		eliminated_null_columns.insert(binding);
+	}
+}
+
+bool OuterJoinSimplification::TryConvertLeftToAntiJoin(LogicalComparisonJoin &join) {
+	if (join.join_type != JoinType::LEFT) {
+		return false;
+	}
+
+	auto right_bindings = GetRightBindings(join);
+	if (!HasNullRequiredColumns(right_bindings) || HasRequiredColumns(right_bindings)) {
+		return false;
+	}
+
+	column_binding_set_t match_non_null_rhs;
+	for (const auto &condition : join.conditions) {
+		if (!condition.IsComparison() || !FiltersNulls(condition.GetComparisonType())) {
+			continue;
+		}
+		ColumnBinding rhs_binding;
+		if (!GetColumnBinding(condition.GetRHS(), rhs_binding)) {
+			continue;
+		}
+		match_non_null_rhs.insert(rhs_binding);
+	}
+
+	for (const auto &binding : right_bindings) {
+		if (null_required_columns.find(binding) == null_required_columns.end()) {
+			continue;
+		}
+		if (match_non_null_rhs.find(binding) == match_non_null_rhs.end()) {
+			continue;
+		}
+		join.join_type = JoinType::ANTI;
+		MarkEliminatedNullColumns(right_bindings);
+		return true;
+	}
+	return false;
+}
+
+void OuterJoinSimplification::SimplifyOuterJoinType(LogicalComparisonJoin &join) {
+	bool preserves_null_extended_rows[2] = {join.join_type == JoinType::LEFT || join.join_type == JoinType::OUTER,
+	                                        join.join_type == JoinType::RIGHT || join.join_type == JoinType::OUTER};
+	for (idx_t child_idx = 0; child_idx < 2; child_idx++) {
+		for (const auto &binding : join.children[child_idx]->GetColumnBindings()) {
+			if (null_filtered_columns.find(binding) != null_filtered_columns.end()) {
+				// Rejecting NULLs in one child removes preservation of NULL extended rows for the other child.
+				preserves_null_extended_rows[1 - child_idx] = false;
+				break;
+			}
+		}
+	}
+
+	if (!preserves_null_extended_rows[0] && !preserves_null_extended_rows[1]) {
+		join.join_type = JoinType::INNER;
+		return;
+	}
+
+	if (preserves_null_extended_rows[0] && !preserves_null_extended_rows[1]) {
+		D_ASSERT(join.join_type == JoinType::LEFT || join.join_type == JoinType::OUTER);
+		join.join_type = JoinType::LEFT;
+	} else if (!preserves_null_extended_rows[0] && preserves_null_extended_rows[1]) {
+		D_ASSERT(join.join_type == JoinType::RIGHT || join.join_type == JoinType::OUTER);
+		join.join_type = JoinType::RIGHT;
+	} else {
+		D_ASSERT(join.join_type == JoinType::OUTER);
+		join.join_type = JoinType::OUTER;
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Operator Visitors
+//===--------------------------------------------------------------------===//
+
+void OuterJoinSimplification::VisitComparisonJoin(LogicalComparisonJoin &join, LogicalOperator &op) {
+	switch (join.join_type) {
+	case JoinType::INNER:
+	case JoinType::SEMI:
+		VisitInnerOrSemiJoin(join, op);
+		return;
+	case JoinType::LEFT:
+	case JoinType::RIGHT:
+	case JoinType::OUTER:
+		VisitOuterJoin(join, op);
+		return;
+	default:
+		break;
+	}
+	VisitUnsupportedOperator(op);
+}
+
+void OuterJoinSimplification::VisitInnerOrSemiJoin(LogicalComparisonJoin &join, LogicalOperator &op) {
+	for (const auto &condition : join.conditions) {
+		if (!condition.IsComparison()) {
+			continue;
+		}
+		AddRequiredColumns(condition);
+		if (!FiltersNulls(condition.GetComparisonType())) {
+			continue;
+		}
+		HandleExpression(condition.GetLHS());
+		HandleExpression(condition.GetRHS());
+	}
+	VisitOperatorChildren(op);
+}
+
+void OuterJoinSimplification::VisitOuterJoin(LogicalComparisonJoin &join, LogicalOperator &op) {
+	if (TryConvertLeftToAntiJoin(join)) {
+		AddRequiredColumns(join.conditions);
+		VisitOperatorChildren(op);
+		return;
+	}
+
+	SimplifyOuterJoinType(join);
+	if (join.join_type == JoinType::INNER) {
+		VisitOperator(op);
+		return;
+	}
+
+	AddRequiredColumns(join.conditions);
+	VisitOperatorChildren(op);
+}
+
+void OuterJoinSimplification::VisitProjection(LogicalProjection &projection, LogicalOperator &op) {
+	vector<pair<idx_t, ColumnBinding>> direct_projection_map;
+	for (idx_t col_idx = 0; col_idx < projection.expressions.size(); col_idx++) {
+		auto &expr = *projection.expressions[col_idx];
+		const ColumnBinding binding(projection.table_index, ProjectionIndex(col_idx));
+		if (expr.GetExpressionClass() != ExpressionClass::BOUND_COLUMN_REF) {
+			AddRequiredColumns(expr);
+			continue;
+		}
+
+		auto input_binding = expr.Cast<BoundColumnRefExpression>().Binding();
+		direct_projection_map.emplace_back(col_idx, input_binding);
+		if (null_filtered_columns.find(binding) != null_filtered_columns.end()) {
+			null_filtered_columns.insert(input_binding);
+		}
+		if (null_required_columns.find(binding) != null_required_columns.end()) {
+			null_required_columns.insert(input_binding);
+		}
+	}
+	VisitOperatorChildren(op);
+
+	for (const auto &entry : direct_projection_map) {
+		auto col_idx = entry.first;
+		auto input_binding = entry.second;
+		if (eliminated_null_columns.find(input_binding) == eliminated_null_columns.end()) {
+			continue;
+		}
+		const ColumnBinding output_binding(projection.table_index, ProjectionIndex(col_idx));
+		auto type = projection.expressions[col_idx]->GetReturnType();
+		projection.expressions[col_idx] = make_uniq<BoundConstantExpression>(Value(type));
+		eliminated_null_columns.insert(output_binding);
+	}
+}
+
+void OuterJoinSimplification::VisitFilter(LogicalFilter &filter, LogicalOperator &op) {
+	filter.SplitPredicates(filter.expressions);
+	for (const auto &expr : filter.expressions) {
+		HandleFilterExpression(*expr);
+	}
+	VisitOperatorChildren(op);
+
+	for (idx_t i = 0; i < filter.expressions.size(); i++) {
+		ColumnBinding binding;
+		if (!IsNullFilter(*filter.expressions[i], binding)) {
+			continue;
+		}
+		if (eliminated_null_columns.find(binding) == eliminated_null_columns.end()) {
+			continue;
+		}
+		filter.expressions.erase_at(i);
+		i--;
+	}
+}
+
+void OuterJoinSimplification::VisitOrder(LogicalOrder &order, LogicalOperator &op) {
+	for (const auto &order_node : order.orders) {
+		AddRequiredColumns(*order_node.expression);
+	}
+	VisitOperatorChildren(op);
+}
+
+void OuterJoinSimplification::VisitTopN(LogicalTopN &top_n, LogicalOperator &op) {
+	for (const auto &order_node : top_n.orders) {
+		AddRequiredColumns(*order_node.expression);
+	}
+	VisitOperatorChildren(op);
+}
+
+void OuterJoinSimplification::VisitAggregate(LogicalAggregate &aggregate, LogicalOperator &op) {
+	column_binding_set_t child_required_columns;
+	for (const auto &expr : aggregate.groups) {
+		AddColumnReferences(*expr, child_required_columns);
+	}
+	for (const auto &expr : aggregate.expressions) {
+		AddColumnReferences(*expr, child_required_columns);
+	}
+	OuterJoinSimplification child_simplification(std::move(child_required_columns));
+	child_simplification.VisitOperator(*op.children[0]);
+}
+
+void OuterJoinSimplification::VisitUnsupportedOperator(LogicalOperator &op) {
+	for (auto &child : op.children) {
+		column_binding_set_t child_required_columns;
+		for (const auto &binding : child->GetColumnBindings()) {
+			child_required_columns.insert(binding);
+		}
+		OuterJoinSimplification outer_join_simplification(std::move(child_required_columns));
+		outer_join_simplification.VisitOperator(*child);
+	}
 }
 
 void OuterJoinSimplification::VisitOperator(LogicalOperator &op) {
+	InitializeRequiredColumns(op);
+
 	switch (op.type) {
 	case LogicalOperatorType::LOGICAL_COMPARISON_JOIN: {
 		auto &join = op.Cast<LogicalComparisonJoin>();
-		switch (join.join_type) {
-		case JoinType::INNER:
-		case JoinType::SEMI: {
-			// Derive bindings that cannot be NULL
-			for (const auto &condition : join.conditions) {
-				if (!condition.IsComparison()) {
-					continue; // Non-comparison predicate, bail
-				}
-				if (condition.GetComparisonType() == ExpressionType::COMPARE_DISTINCT_FROM ||
-				    condition.GetComparisonType() == ExpressionType::COMPARE_NOT_DISTINCT_FROM) {
-					continue; // Predicate does not filter NULL values
-				}
-				HandleExpression(condition.GetLHS());
-				HandleExpression(condition.GetRHS());
-			}
-			VisitOperatorChildren(op);
-			return;
-		}
-		case JoinType::LEFT:
-		case JoinType::RIGHT:
-		case JoinType::OUTER: {
-			// Try to simplify joins
-			bool preserves_null_extended_rows[2] = {
-			    join.join_type == JoinType::LEFT || join.join_type == JoinType::OUTER,
-			    join.join_type == JoinType::RIGHT || join.join_type == JoinType::OUTER};
-			for (idx_t child_idx = 0; child_idx < 2; child_idx++) {
-				for (const auto &binding : join.children[child_idx]->GetColumnBindings()) {
-					if (null_filtered_columns.find(binding) != null_filtered_columns.end()) {
-						// Rejecting NULLS in one child removes preservation of NULL extended rows for the other child
-						preserves_null_extended_rows[1 - child_idx] = false;
-						break;
-					}
-				}
-			}
-
-			if (!preserves_null_extended_rows[0] && !preserves_null_extended_rows[1]) {
-				join.join_type = JoinType::INNER;
-				VisitOperator(op); // Re-enter because we just created another (NULL-filtering!) INNER join
-				return;
-			}
-
-			if (preserves_null_extended_rows[0] && !preserves_null_extended_rows[1]) {
-				D_ASSERT(join.join_type == JoinType::LEFT || join.join_type == JoinType::OUTER);
-				join.join_type = JoinType::LEFT;
-			} else if (!preserves_null_extended_rows[0] && preserves_null_extended_rows[1]) {
-				D_ASSERT(join.join_type == JoinType::RIGHT || join.join_type == JoinType::OUTER);
-				join.join_type = JoinType::RIGHT;
-			} else {
-				D_ASSERT(join.join_type == JoinType::OUTER);
-				join.join_type = JoinType::OUTER;
-			}
-
-			VisitOperatorChildren(op);
-			return;
-		}
-		default:
-			// Passthrough not supported.
-			break;
-		}
-		break;
+		VisitComparisonJoin(join, op);
+		return;
 	}
 	case LogicalOperatorType::LOGICAL_PROJECTION: {
-		// Passthrough supported. Add input bindings
 		auto &projection = op.Cast<LogicalProjection>();
-		for (idx_t col_idx = 0; col_idx < projection.expressions.size(); col_idx++) {
-			auto &expr = *projection.expressions[col_idx];
-			if (expr.GetExpressionClass() != ExpressionClass::BOUND_COLUMN_REF) {
-				continue;
-			}
-			const ColumnBinding binding(projection.table_index, ProjectionIndex(col_idx));
-			if (null_filtered_columns.find(binding) == null_filtered_columns.end()) {
-				continue;
-			}
-			null_filtered_columns.insert(expr.Cast<BoundColumnRefExpression>().Binding());
-		}
-		VisitOperatorChildren(op);
+		VisitProjection(projection, op);
 		return;
 	}
 	case LogicalOperatorType::LOGICAL_FILTER: {
-		// Passthrough supported. Handle expressions that filter NULLs
 		auto &filter = op.Cast<LogicalFilter>();
-		filter.SplitPredicates(filter.expressions);
-		for (const auto &expr : filter.expressions) {
-			if (expr->GetExpressionClass() == ExpressionClass::BOUND_OPERATOR &&
-			    expr->GetExpressionType() == ExpressionType::OPERATOR_IS_NOT_NULL) {
-				const auto &is_not_null = expr->Cast<BoundOperatorExpression>();
-				HandleExpression(*is_not_null.GetChildren()[0]);
-			} else if (BoundComparisonExpression::IsComparison(*expr)) {
-				if (expr->GetExpressionType() == ExpressionType::COMPARE_DISTINCT_FROM ||
-				    expr->GetExpressionType() == ExpressionType::COMPARE_NOT_DISTINCT_FROM) {
-					continue;
-				}
-				const auto &comparison = expr->Cast<BoundFunctionExpression>();
-				HandleExpression(BoundComparisonExpression::Left(comparison));
-				HandleExpression(BoundComparisonExpression::Right(comparison));
-			}
-		}
+		VisitFilter(filter, op);
+		return;
+	}
+	case LogicalOperatorType::LOGICAL_ORDER_BY: {
+		auto &order = op.Cast<LogicalOrder>();
+		VisitOrder(order, op);
+		return;
+	}
+	case LogicalOperatorType::LOGICAL_TOP_N: {
+		auto &top_n = op.Cast<LogicalTopN>();
+		VisitTopN(top_n, op);
+		return;
+	}
+	case LogicalOperatorType::LOGICAL_LIMIT:
 		VisitOperatorChildren(op);
+		return;
+	case LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY: {
+		auto &aggregate = op.Cast<LogicalAggregate>();
+		VisitAggregate(aggregate, op);
 		return;
 	}
 	default:
@@ -128,11 +443,7 @@ void OuterJoinSimplification::VisitOperator(LogicalOperator &op) {
 		break;
 	}
 
-	// Recurse with a new optimizer for each child
-	for (auto &child : op.children) {
-		OuterJoinSimplification outer_join_simplification;
-		outer_join_simplification.VisitOperator(*child);
-	}
+	VisitUnsupportedOperator(op);
 }
 
 } // namespace duckdb

--- a/test/optimizer/outer_join_simplification.test
+++ b/test/optimizer/outer_join_simplification.test
@@ -53,6 +53,114 @@ ORDER BY 1;
 ----
 logical_opt	<!REGEX>:.*LEFT.*
 
+query II
+EXPLAIN SELECT l.i
+FROM range(3) l(i)
+LEFT JOIN range(2) r(i) ON l.i = r.i
+WHERE r.i IS NULL
+ORDER BY 1;
+----
+logical_opt	<REGEX>:.*ANTI.*
+
+query II
+EXPLAIN SELECT li
+FROM (
+    SELECT l.i AS li, r.i AS ri
+    FROM range(3) l(i)
+    LEFT JOIN range(2) r(i) ON l.i = r.i
+) t
+WHERE ri IS NULL
+ORDER BY 1;
+----
+logical_opt	<REGEX>:.*ANTI.*
+
+query II
+EXPLAIN SELECT l.i, r.i
+FROM range(3) l(i)
+LEFT JOIN range(2) r(i) ON l.i = r.i
+WHERE r.i IS NULL
+ORDER BY 1;
+----
+logical_opt	<REGEX>:.*ANTI.*
+
+query II
+EXPLAIN SELECT l.i, r.v
+FROM (VALUES (1), (2), (3)) l(i)
+LEFT JOIN (VALUES (1, 10), (2, 20)) r(i, v) ON l.i = r.i
+WHERE r.i IS NULL
+ORDER BY 1;
+----
+logical_opt	<REGEX>:.*ANTI.*
+
+query II
+EXPLAIN SELECT l.i
+FROM (VALUES (1), (2), (3)) l(i)
+LEFT JOIN (VALUES (1), (2)) r(i) ON l.i = r.i
+WHERE CAST(r.i AS BIGINT) IS NULL
+ORDER BY 1;
+----
+logical_opt	<REGEX>:.*ANTI.*
+
+query II
+EXPLAIN SELECT l.i
+FROM (VALUES (1), (2), (3)) l(i)
+LEFT JOIN (VALUES (1), (2)) r(i) ON l.i = CAST(r.i AS BIGINT)
+WHERE CAST(r.i AS BIGINT) IS NULL
+ORDER BY 1;
+----
+logical_opt	<REGEX>:.*ANTI.*
+
+query II
+EXPLAIN SELECT l.s
+FROM (VALUES ('x'), ('2'), ('3')) l(s)
+LEFT JOIN (VALUES ('x'), ('2')) r(s) ON l.s = r.s
+WHERE TRY_CAST(r.s AS INTEGER) IS NULL
+ORDER BY 1;
+----
+logical_opt	<REGEX>:.*LEFT.*
+
+query II
+EXPLAIN SELECT l.s
+FROM (VALUES ('x'), ('2'), ('3')) l(s)
+LEFT JOIN (VALUES ('x'), ('2')) r(s) ON l.s = r.s
+WHERE CAST(r.s AS INTEGER) IS NULL
+ORDER BY 1;
+----
+logical_opt	<REGEX>:.*LEFT.*
+
+query II
+EXPLAIN SELECT l.i
+FROM (VALUES (1), (2), (3)) l(i)
+LEFT JOIN (VALUES (1, NULL), (2, 5)) r(i, v) ON l.i = r.i
+WHERE r.v IS NULL
+ORDER BY 1;
+----
+logical_opt	<REGEX>:.*LEFT.*
+
+query II
+EXPLAIN SELECT l.i
+FROM (VALUES (NULL), (1), (2)) l(i)
+LEFT JOIN (VALUES (NULL), (1)) r(i) ON l.i IS NOT DISTINCT FROM r.i
+WHERE r.i IS NULL
+ORDER BY 1 NULLS FIRST;
+----
+logical_opt	<REGEX>:.*LEFT.*
+
+query II
+EXPLAIN WITH sales AS (
+    SELECT y, l.i, sum(q) AS total_q
+    FROM (VALUES (2000, 1, 10), (2000, 2, 20), (2001, 3, 30)) l(y, i, q)
+    LEFT JOIN (VALUES (1), (3)) r(i) ON l.i = r.i
+    WHERE r.i IS NULL
+    GROUP BY y, l.i
+)
+SELECT *
+FROM sales
+WHERE y = 2000
+ORDER BY i;
+----
+logical_opt	<REGEX>:.*ANTI.*
+
 # Then a bunch of correct result checks
 query II
 SELECT l.i, r.i
@@ -84,6 +192,104 @@ ORDER BY 1;
 0	0
 1	1
 2	2
+
+query I
+SELECT l.i
+FROM (VALUES (NULL), (1), (2), (3)) l(i)
+LEFT JOIN (VALUES (NULL), (1), (1)) r(i) ON l.i = r.i
+WHERE r.i IS NULL
+ORDER BY 1 NULLS FIRST;
+----
+NULL
+2
+3
+
+query I
+SELECT li
+FROM (
+    SELECT l.i AS li, r.i AS ri
+    FROM range(3) l(i)
+    LEFT JOIN range(2) r(i) ON l.i = r.i
+) t
+WHERE ri IS NULL
+ORDER BY 1;
+----
+2
+
+query II
+SELECT l.i, r.i
+FROM range(3) l(i)
+LEFT JOIN range(2) r(i) ON l.i = r.i
+WHERE r.i IS NULL
+ORDER BY 1;
+----
+2	NULL
+
+query II
+SELECT l.i, r.v
+FROM (VALUES (1), (2), (3)) l(i)
+LEFT JOIN (VALUES (1, 10), (2, 20)) r(i, v) ON l.i = r.i
+WHERE r.i IS NULL
+ORDER BY 1;
+----
+3	NULL
+
+query I
+SELECT l.i
+FROM (VALUES (1), (2), (3)) l(i)
+LEFT JOIN (VALUES (1), (2)) r(i) ON l.i = r.i
+WHERE CAST(r.i AS BIGINT) IS NULL
+ORDER BY 1;
+----
+3
+
+query I
+SELECT l.i
+FROM (VALUES (1), (2), (3)) l(i)
+LEFT JOIN (VALUES (1), (2)) r(i) ON l.i = CAST(r.i AS BIGINT)
+WHERE CAST(r.i AS BIGINT) IS NULL
+ORDER BY 1;
+----
+3
+
+query I
+SELECT l.s
+FROM (VALUES ('x'), ('2'), ('3')) l(s)
+LEFT JOIN (VALUES ('x'), ('2')) r(s) ON l.s = r.s
+WHERE TRY_CAST(r.s AS INTEGER) IS NULL
+ORDER BY 1;
+----
+3
+x
+
+statement error
+SELECT l.s
+FROM (VALUES ('x'), ('2'), ('3')) l(s)
+LEFT JOIN (VALUES ('x'), ('2')) r(s) ON l.s = r.s
+WHERE CAST(r.s AS INTEGER) IS NULL
+ORDER BY 1;
+----
+<REGEX>:.*Could not convert string 'x' to INT32.*
+
+query I
+SELECT l.i
+FROM (VALUES (1), (2), (3)) l(i)
+LEFT JOIN (VALUES (1, NULL), (2, 5)) r(i, v) ON l.i = r.i
+WHERE r.v IS NULL
+ORDER BY 1;
+----
+1
+3
+
+query I
+SELECT l.i
+FROM (VALUES (NULL), (1), (2)) l(i)
+LEFT JOIN (VALUES (NULL), (1)) r(i) ON l.i IS NOT DISTINCT FROM r.i
+WHERE r.i IS NULL
+ORDER BY 1 NULLS FIRST;
+----
+NULL
+2
 
 query II
 SELECT l.i, r.i
@@ -136,3 +342,29 @@ ORDER BY sumsales NULLS FIRST,
 LIMIT 100;
 ----
 logical_opt	<!REGEX>:.*(LEFT|RIGHT).*
+
+# TPC-DS Q78
+query II
+EXPLAIN WITH ws AS
+  (SELECT d_year AS ws_sold_year,
+          ws_item_sk,
+          ws_bill_customer_sk ws_customer_sk,
+          sum(ws_quantity) ws_qty,
+          sum(ws_wholesale_cost) ws_wc,
+          sum(ws_sales_price) ws_sp
+   FROM web_sales
+   LEFT JOIN web_returns ON wr_order_number=ws_order_number
+   AND ws_item_sk=wr_item_sk
+   JOIN date_dim ON ws_sold_date_sk = d_date_sk
+   WHERE wr_order_number IS NULL
+   GROUP BY d_year,
+            ws_item_sk,
+            ws_bill_customer_sk )
+SELECT *
+FROM ws
+ORDER BY ws_sold_year,
+         ws_item_sk,
+         ws_customer_sk
+LIMIT 100;
+----
+logical_opt	<REGEX>:.*ANTI.*


### PR DESCRIPTION
Classic rewrite, implemented in the `OuterJoinSimplifcation` optimizer.