### PR TITLE
Don't allow empty identifiers

### DIFF
--- a/src/include/duckdb/parser/peg/tokenizer/parser_tokenizer.hpp
+++ b/src/include/duckdb/parser/peg/tokenizer/parser_tokenizer.hpp
@@ -9,6 +9,7 @@ public:
 	ParserTokenizer(const string &sql, vector<MatcherToken> &tokens);
 	~ParserTokenizer() override = default;
 
+	void PushToken(idx_t start, idx_t end, TokenType type, bool unterminated = false) override;
 	void OnStatementEnd(idx_t pos) override;
 	void OnLastToken(TokenizeState state, string last_word, idx_t last_pos) override;
 };

--- a/src/parser/peg/tokenizer/parser_tokenizer.cpp
+++ b/src/parser/peg/tokenizer/parser_tokenizer.cpp
@@ -3,7 +3,18 @@
 
 namespace duckdb {
 
+static bool IsEmptyQuotedIdentifier(const string &sql, idx_t start, idx_t end, TokenType type) {
+	return type == TokenType::IDENTIFIER && end == start + 2 && sql.substr(start, 2) == "\"\"";
+}
+
 ParserTokenizer::ParserTokenizer(const string &sql, vector<MatcherToken> &tokens) : BaseTokenizer(sql, tokens) {
+}
+
+void ParserTokenizer::PushToken(idx_t start, idx_t end, TokenType type, bool unterminated) {
+	if (IsEmptyQuotedIdentifier(sql, start, end, type)) {
+		throw ParserException::SyntaxError(sql, "zero-length delimited identifier", optional_idx(start));
+	}
+	BaseTokenizer::PushToken(start, end, type, unterminated);
 }
 
 void ParserTokenizer::OnStatementEnd(idx_t pos) {

--- a/test/sql/create/create_table_empty_name.test
+++ b/test/sql/create/create_table_empty_name.test
@@ -12,4 +12,4 @@ create schema s1;
 statement error
 CREATE TABLE s1.""(i INTEGER);
 ----
-<REGEX>:(Parser Error.*zero-length delimited identifier at or near """".*|Parser Error: Empty table name not supported.*)
+Parser Error: zero-length delimited identifier

--- a/test/sql/join/inner/test_using_join.test
+++ b/test/sql/join/inner/test_using_join.test
@@ -61,7 +61,7 @@ Parser Error: syntax error at or near "+"
 statement error
 SELECT t2.a, t2.b, t2.c FROM t1 JOIN t2 USING("")
 ----
-<REGEX>:(.*Parser Error.*zero-length delimited identifier at or near """".*|Parser Error: Column identifier cannot be empty.*)
+Parser Error: zero-length delimited identifier
 
 statement error
 SELECT t2.a, t2.b, t2.c FROM t1 JOIN t2 USING(d)

--- a/test/sql/parser/empty_quoted_identifier.test
+++ b/test/sql/parser/empty_quoted_identifier.test
@@ -1,0 +1,18 @@
+# name: test/sql/parser/empty_quoted_identifier.test
+# description: Empty quoted identifiers should fail during parsing
+# group: [parser]
+
+statement error
+SELECT a."";
+----
+Parser Error: zero-length delimited identifier
+
+statement error
+SELECT "";
+----
+Parser Error: zero-length delimited identifier
+
+statement error
+CREATE TABLE t("");
+----
+Parser Error: zero-length delimited identifier


### PR DESCRIPTION
Fix: https://github.com/duckdb/duckdb-fuzzer/issues/4554

We no longer allow empty identifiers, same as the old parser. 