### PR TITLE
Implement `CONNECT '<uri>' [(OPTS...)]` as ephemeral attach

### DIFF
--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -366,7 +366,15 @@ bool Catalog::SupportsPushdown(const QueryNode &node) {
 }
 
 string Catalog::GetConnectDisplay() {
-	return GetAttached().GetName().GetIdentifierName();
+	auto &attached = GetAttached();
+	// Ephemeral catalogs (from `CONNECT '<uri>'`) carry a generated internal name; show the URI instead.
+	if (attached.IsEphemeral()) {
+		auto path = attached.StoredPath();
+		if (!path.empty()) {
+			return path;
+		}
+	}
+	return attached.GetName().GetIdentifierName();
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/execution/operator/helper/physical_connect.cpp
+++ b/src/execution/operator/helper/physical_connect.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/execution/operator/helper/physical_connect.hpp"
 #include "duckdb/catalog/catalog.hpp"
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/types/uuid.hpp"
 #include "duckdb/main/attached_database.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/config.hpp"
@@ -34,11 +35,12 @@ SourceResultType PhysicalConnect::GetDataInternal(ExecutionContext &context, Dat
 
 	auto &db_manager = DatabaseManager::Get(client);
 	if (info->name_is_string_literal) {
-		// `CONNECT '<uri>'`: attach the connection string under a hidden, ephemeral alias and bind to
-		// it in one shot. The alias is scoped to this connection (single-binding guarantees at most one
-		// active at a time) and is detached again by DISCONNECT (see PhysicalDisconnect).
+		// `CONNECT '<uri>'`: attach the connection string under an internal, hidden, ephemeral alias and
+		// bind to it in one shot. The name is a random UUID (like __pivot_enum_<uuid>): unique, ASCII
+		// (backend-safe), and unguessable, so it is not referenceable in SQL. It is owned by this
+		// connection and detached again by DISCONNECT (see PhysicalDisconnect).
 		AttachInfo attach_info;
-		attach_info.name = Identifier("__connect_" + to_string(client.GetConnectionId()));
+		attach_info.name = Identifier("__connect_" + UUID::ToString(UUID::GenerateRandomUUID()));
 		attach_info.path = info->name.GetIdentifierName();
 		attach_info.options = info->options;
 

--- a/src/execution/operator/helper/physical_connect.cpp
+++ b/src/execution/operator/helper/physical_connect.cpp
@@ -1,25 +1,25 @@
 #include "duckdb/execution/operator/helper/physical_connect.hpp"
+#include "duckdb/catalog/catalog.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/main/attached_database.hpp"
 #include "duckdb/main/client_context.hpp"
+#include "duckdb/main/config.hpp"
 #include "duckdb/main/database_manager.hpp"
+#include "duckdb/main/database_path_and_type.hpp"
+#include "duckdb/parser/parsed_data/attach_info.hpp"
 #include "duckdb/storage/storage_extension.hpp"
 
 namespace duckdb {
 
 SourceResultType PhysicalConnect::GetDataInternal(ExecutionContext &context, DataChunk &chunk,
                                                   OperatorSourceInput &input) const {
-	// The 4 grammar forms are accepted at parse time. This commit implements only
-	// `CONNECT <name>` (attached-db identifier); the other forms stay as per-form
-	// NotImplementedException placeholders and get swapped in by follow-up PRs.
+	// The 4 grammar forms are accepted at parse time. `CONNECT LOCAL` and bare `CONNECT` stay as
+	// per-form NotImplementedException placeholders and get swapped in by follow-up PRs.
 	if (info->target_is_local) {
 		throw NotImplementedException("CONNECT LOCAL is not yet implemented");
 	}
 	if (info->name.empty()) {
 		throw NotImplementedException("CONNECT with no target is not yet implemented");
-	}
-	if (info->name_is_string_literal) {
-		throw NotImplementedException("CONNECT '<connection_string>' is not yet implemented");
 	}
 
 	auto &client = context.client;
@@ -32,7 +32,35 @@ SourceResultType PhysicalConnect::GetDataInternal(ExecutionContext &context, Dat
 		                            current ? current->GetName().GetIdentifierName() : "<detached>");
 	}
 
-	auto target = DatabaseManager::Get(client).GetDatabase(info->name);
+	auto &db_manager = DatabaseManager::Get(client);
+	if (info->name_is_string_literal) {
+		// `CONNECT '<uri>'`: attach the connection string under a hidden, ephemeral alias and bind to
+		// it in one shot. The alias is scoped to this connection (single-binding guarantees at most one
+		// active at a time) and is detached again by DISCONNECT (see PhysicalDisconnect).
+		AttachInfo attach_info;
+		attach_info.name = Identifier("__connect_" + to_string(client.GetConnectionId()));
+		attach_info.path = info->name.GetIdentifierName();
+
+		auto &config = DBConfig::GetConfig(client);
+		AttachOptions options(attach_info.options, config.options.access_mode);
+		options.visibility = AttachVisibility::HIDDEN;
+		options.ephemeral = true;
+		if (options.db_type.empty()) {
+			DBPathAndType::ExtractExtensionPrefix(attach_info.path, options.db_type);
+		}
+		auto target = db_manager.AttachDatabase(client, attach_info, options);
+		if (!target->GetCatalog().Supports(RemoteCapability::CONNECT)) {
+			// No CONNECT capability: roll back the implicit attach so it does not leak.
+			db_manager.DetachDatabase(client, attach_info.name, OnEntryNotFound::RETURN_NULL);
+			throw InvalidInputException("CONNECT '%s': the attached database does not support CONNECT",
+			                            attach_info.path);
+		}
+		// Capability confirmed above, so ConnectToCatalog's own support check will not fire.
+		client.ConnectToCatalog(target);
+		return SourceResultType::FINISHED;
+	}
+
+	auto target = db_manager.GetDatabase(info->name);
 	if (!target) {
 		throw InvalidInputException("Database \"%s\" is not attached", info->name);
 	}

--- a/src/execution/operator/helper/physical_connect.cpp
+++ b/src/execution/operator/helper/physical_connect.cpp
@@ -40,6 +40,7 @@ SourceResultType PhysicalConnect::GetDataInternal(ExecutionContext &context, Dat
 		AttachInfo attach_info;
 		attach_info.name = Identifier("__connect_" + to_string(client.GetConnectionId()));
 		attach_info.path = info->name.GetIdentifierName();
+		attach_info.options = info->options;
 
 		auto &config = DBConfig::GetConfig(client);
 		AttachOptions options(attach_info.options, config.options.access_mode);

--- a/src/execution/operator/helper/physical_disconnect.cpp
+++ b/src/execution/operator/helper/physical_disconnect.cpp
@@ -1,6 +1,8 @@
 #include "duckdb/execution/operator/helper/physical_disconnect.hpp"
 #include "duckdb/common/exception.hpp"
+#include "duckdb/main/attached_database.hpp"
 #include "duckdb/main/client_context.hpp"
+#include "duckdb/main/database_manager.hpp"
 
 namespace duckdb {
 
@@ -11,7 +13,13 @@ SourceResultType PhysicalDisconnect::GetDataInternal(ExecutionContext &context, 
 	if (!client.IsConnected()) {
 		throw InvalidInputException("DISCONNECT: no active CONNECT (already on LOCAL)");
 	}
+	// Capture the target before clearing the binding so we can reap an ephemeral attachment.
+	auto target = client.TryGetConnectedCatalog();
 	client.DisconnectFromCatalog();
+	if (target && target->IsEphemeral()) {
+		// `CONNECT '<uri>'` attached this hidden catalog implicitly; detach it now.
+		DatabaseManager::Get(client).DetachDatabase(client, target->GetName(), OnEntryNotFound::RETURN_NULL);
+	}
 	return SourceResultType::FINISHED;
 }
 

--- a/src/include/duckdb/main/attached_database.hpp
+++ b/src/include/duckdb/main/attached_database.hpp
@@ -79,6 +79,9 @@ struct AttachOptions {
 	bool is_main_database = false;
 	//! The visibility of the attached database
 	AttachVisibility visibility = AttachVisibility::SHOWN;
+	//! Whether this attachment is ephemeral: created implicitly by `CONNECT '<uri>'` and detached
+	//! again on DISCONNECT. Not settable via SQL; only the connection-string CONNECT path sets it.
+	bool ephemeral = false;
 	//! The stored database path (in the path manager)
 	unique_ptr<StoredDatabasePath> stored_database_path;
 	//! Per-database override of vacuum_rebuild_indexes. If not set, the global setting value is used.
@@ -141,6 +144,10 @@ public:
 	AttachVisibility GetVisibility() const {
 		return visibility;
 	}
+	//! True for attachments created implicitly by `CONNECT '<uri>'`; DISCONNECT detaches them.
+	bool IsEphemeral() const {
+		return ephemeral;
+	}
 	//! vacuum_rebuild_indexes threshold for this attached database.
 	//! Falls back to the global VacuumRebuildIndexesSetting if not overridden.
 	idx_t GetVacuumRebuildIndexThreshold() const;
@@ -166,6 +173,7 @@ private:
 	optional_ptr<StorageExtension> storage_extension;
 	RecoveryMode recovery_mode = RecoveryMode::DEFAULT;
 	AttachVisibility visibility = AttachVisibility::SHOWN;
+	bool ephemeral = false;
 	bool is_initial_database = false;
 	bool is_closed = false;
 	shared_ptr<mutex> close_lock;

--- a/src/include/duckdb/parser/parsed_data/connect_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/connect_info.hpp
@@ -9,7 +9,11 @@
 #pragma once
 
 #include "duckdb/common/identifier.hpp"
+#include "duckdb/common/case_insensitive_map.hpp"
+#include "duckdb/common/types/value.hpp"
+#include "duckdb/common/unordered_map.hpp"
 #include "duckdb/parser/parsed_data/parse_info.hpp"
+#include "duckdb/parser/parsed_expression.hpp"
 
 namespace duckdb {
 
@@ -32,6 +36,11 @@ public:
 	//! (connection-string form) from `CONNECT foo` (attached-db identifier) at the AST level,
 	//! so ToString roundtrips the source form and downstream impl can dispatch correctly.
 	bool name_is_string_literal = false;
+	//! Set of parsed (key, value) options — only for the connection-string form. Bound in
+	//! bind_connect and passed through to the implicit ATTACH performed by `CONNECT '<uri>'`.
+	case_insensitive_map_t<unique_ptr<ParsedExpression>> parsed_options;
+	//! Set of bound (key, value) options forwarded to the implicit ATTACH.
+	unordered_map<string, Value> options;
 
 public:
 	unique_ptr<ConnectInfo> Copy() const;

--- a/src/include/duckdb/parser/peg/inlined_grammar.gram
+++ b/src/include/duckdb/parser/peg/inlined_grammar.gram
@@ -1592,7 +1592,7 @@ ConnectStatement <- 'CONNECT' SessionTarget?
 DisconnectStatement <- 'DISCONNECT'
 SessionTarget <- LocalSessionTarget / StringSessionTarget / CatalogSessionTarget
 LocalSessionTarget <- 'LOCAL'
-StringSessionTarget <- StringLiteral
+StringSessionTarget <- StringLiteral GenericCopyOptionList?
 CatalogSessionTarget <- CatalogName
 
 CreateTypeStmt <- 'TYPE' IfNotExists? QualifiedName 'AS' CreateType

--- a/src/include/duckdb/parser/peg/inlined_grammar.hpp
+++ b/src/include/duckdb/parser/peg/inlined_grammar.hpp
@@ -1473,7 +1473,7 @@ const char INLINED_PEG_GRAMMAR[] = {
 	"DisconnectStatement <- 'DISCONNECT'\n"
 	"SessionTarget <- LocalSessionTarget / StringSessionTarget / CatalogSessionTarget\n"
 	"LocalSessionTarget <- 'LOCAL'\n"
-	"StringSessionTarget <- StringLiteral\n"
+	"StringSessionTarget <- StringLiteral GenericCopyOptionList?\n"
 	"CatalogSessionTarget <- CatalogName\n"
 	"CreateTypeStmt <- 'TYPE' IfNotExists? QualifiedName 'AS' CreateType\n"
 	"CreateType <- EnumSelectType / EnumStringLiteralList / CreateTypeFromType\n"

--- a/src/include/duckdb/parser/peg/transformer/peg_transformer.hpp
+++ b/src/include/duckdb/parser/peg/transformer/peg_transformer.hpp
@@ -688,6 +688,11 @@ public:
 	                                                                       ParseResult &parse_result);
 	static vector<GenericCopyOption> TransformAttachOptions(PEGTransformer &transformer,
 	                                                        const vector<GenericCopyOption> &generic_copy_option_list);
+	//! Split a generic option list into bound (key, value) options and parsed (key, expression) options.
+	//! Shared by ATTACH and CONNECT; `statement_name` labels the NULL-option error message.
+	static void SplitGenericOptions(const vector<GenericCopyOption> &options_in,
+	                                case_insensitive_map_t<unique_ptr<ParsedExpression>> &parsed_options,
+	                                unordered_map<string, Value> &options, const char *statement_name);
 	static unique_ptr<TransformResultValue> TransformCallStatementInternal(PEGTransformer &transformer,
 	                                                                       ParseResult &parse_result);
 	static unique_ptr<SQLStatement> TransformCallStatement(PEGTransformer &transformer,

--- a/src/include/duckdb/parser/peg/transformer/peg_transformer.hpp
+++ b/src/include/duckdb/parser/peg/transformer/peg_transformer.hpp
@@ -1011,8 +1011,9 @@ public:
 	static unique_ptr<ConnectInfo> TransformLocalSessionTarget(PEGTransformer &transformer);
 	static unique_ptr<TransformResultValue> TransformStringSessionTargetInternal(PEGTransformer &transformer,
 	                                                                             ParseResult &parse_result);
-	static unique_ptr<ConnectInfo> TransformStringSessionTarget(PEGTransformer &transformer,
-	                                                            const string &string_literal);
+	static unique_ptr<ConnectInfo>
+	TransformStringSessionTarget(PEGTransformer &transformer, const string &string_literal,
+	                             const optional<vector<GenericCopyOption>> &generic_copy_option_list);
 	static unique_ptr<TransformResultValue> TransformCatalogSessionTargetInternal(PEGTransformer &transformer,
 	                                                                              ParseResult &parse_result);
 	static unique_ptr<ConnectInfo> TransformCatalogSessionTarget(PEGTransformer &transformer,

--- a/src/include/duckdb/storage/serialization/parse_info.json
+++ b/src/include/duckdb/storage/serialization/parse_info.json
@@ -596,6 +596,11 @@
         "id": 202,
         "name": "target_is_local",
         "type": "bool"
+      },
+      {
+        "id": 203,
+        "name": "options",
+        "type": "unordered_map<string, Value>"
       }
     ]
   },

--- a/src/main/attached_database.cpp
+++ b/src/main/attached_database.cpp
@@ -144,6 +144,7 @@ AttachedDatabase::AttachedDatabase(DatabaseInstance &db, Catalog &catalog_p, Ide
 	}
 	recovery_mode = options.recovery_mode;
 	visibility = options.visibility;
+	ephemeral = options.ephemeral;
 	vacuum_rebuild_threshold = options.vacuum_rebuild_indexes_threshold;
 
 	// We create the storage after the catalog to guarantee we allow extensions to instantiate the DuckCatalog.
@@ -166,6 +167,7 @@ AttachedDatabase::AttachedDatabase(DatabaseInstance &db, Catalog &catalog_p, Sto
 	}
 	recovery_mode = options.recovery_mode;
 	visibility = options.visibility;
+	ephemeral = options.ephemeral;
 	vacuum_rebuild_threshold = options.vacuum_rebuild_indexes_threshold;
 
 	optional_ptr<StorageExtensionInfo> storage_info = storage_extension->storage_info.get();

--- a/src/parser/parsed_data/connect_info.cpp
+++ b/src/parser/parsed_data/connect_info.cpp
@@ -1,5 +1,7 @@
 #include "duckdb/parser/parsed_data/connect_info.hpp"
 
+#include "duckdb/common/string_util.hpp"
+
 namespace duckdb {
 
 unique_ptr<ConnectInfo> ConnectInfo::Copy() const {
@@ -7,6 +9,10 @@ unique_ptr<ConnectInfo> ConnectInfo::Copy() const {
 	result->name = name;
 	result->target_is_local = target_is_local;
 	result->name_is_string_literal = name_is_string_literal;
+	for (auto &entry : parsed_options) {
+		result->parsed_options[entry.first] = entry.second->Copy();
+	}
+	result->options = options;
 	return result;
 }
 
@@ -22,6 +28,16 @@ string ConnectInfo::ToString() const {
 		result += SQLString(name.GetIdentifierName());
 	} else {
 		result += SQLIdentifier(name);
+	}
+	if (!parsed_options.empty() || !options.empty()) {
+		vector<string> stringified;
+		for (auto &opt : parsed_options) {
+			stringified.push_back(StringUtil::Format("%s %s", opt.first, opt.second->ToString()));
+		}
+		for (auto &opt : options) {
+			stringified.push_back(StringUtil::Format("%s %s", opt.first, opt.second.ToSQLString()));
+		}
+		result += " (" + StringUtil::Join(stringified, ", ") + ")";
 	}
 	result += ";";
 	return result;

--- a/src/parser/peg/grammar/statements/connect.gram
+++ b/src/parser/peg/grammar/statements/connect.gram
@@ -2,5 +2,5 @@ ConnectStatement <- 'CONNECT' SessionTarget?
 DisconnectStatement <- 'DISCONNECT'
 SessionTarget <- LocalSessionTarget / StringSessionTarget / CatalogSessionTarget
 LocalSessionTarget <- 'LOCAL'
-StringSessionTarget <- StringLiteral
+StringSessionTarget <- StringLiteral GenericCopyOptionList?
 CatalogSessionTarget <- CatalogName

--- a/src/parser/peg/transformer/transform_attach.cpp
+++ b/src/parser/peg/transformer/transform_attach.cpp
@@ -33,24 +33,7 @@ unique_ptr<SQLStatement> PEGTransformerFactory::TransformAttachStatement(
 	}
 
 	auto &attach_info = *result->info;
-	for (const auto &attach_option : *attach_options) {
-		if (attach_option.expression) {
-			attach_info.parsed_options[attach_option.name.GetIdentifierName()] = attach_option.expression->Copy();
-			continue;
-		}
-		if (attach_option.children.empty()) {
-			attach_info.options[attach_option.name.GetIdentifierName()] = Value(true);
-		} else if (attach_option.children.size() == 1) {
-			auto val = attach_option.children[0];
-			if (val.IsNull()) {
-				throw BinderException("NULL is not supported as a valid option for ATTACH option \"%s\"",
-				                      attach_option.name);
-			}
-			attach_info.options[attach_option.name.GetIdentifierName()] = attach_option.children[0];
-		} else {
-			throw ParserException("Option %s can only have one argument", attach_option.name);
-		}
-	}
+	SplitGenericOptions(*attach_options, attach_info.parsed_options, attach_info.options, "ATTACH");
 	return std::move(result);
 }
 

--- a/src/parser/peg/transformer/transform_connect.cpp
+++ b/src/parser/peg/transformer/transform_connect.cpp
@@ -11,9 +11,9 @@ unique_ptr<ConnectInfo> PEGTransformerFactory::TransformLocalSessionTarget(PEGTr
 	return result;
 }
 
-unique_ptr<ConnectInfo>
-PEGTransformerFactory::TransformStringSessionTarget(PEGTransformer &transformer, const string &string_literal,
-                                                    const optional<vector<GenericCopyOption>> &generic_copy_option_list) {
+unique_ptr<ConnectInfo> PEGTransformerFactory::TransformStringSessionTarget(
+    PEGTransformer &transformer, const string &string_literal,
+    const optional<vector<GenericCopyOption>> &generic_copy_option_list) {
 	auto result = make_uniq<ConnectInfo>();
 	result->name = Identifier(string_literal);
 	result->name_is_string_literal = true;
@@ -30,8 +30,7 @@ PEGTransformerFactory::TransformStringSessionTarget(PEGTransformer &transformer,
 			result->options[option.name.GetIdentifierName()] = Value(true);
 		} else if (option.children.size() == 1) {
 			if (option.children[0].IsNull()) {
-				throw BinderException("NULL is not supported as a valid option for CONNECT option \"%s\"",
-				                      option.name);
+				throw BinderException("NULL is not supported as a valid option for CONNECT option \"%s\"", option.name);
 			}
 			result->options[option.name.GetIdentifierName()] = option.children[0];
 		} else {

--- a/src/parser/peg/transformer/transform_connect.cpp
+++ b/src/parser/peg/transformer/transform_connect.cpp
@@ -1,3 +1,4 @@
+#include "duckdb/parser/peg/ast/generic_copy_option.hpp"
 #include "duckdb/parser/peg/transformer/peg_transformer.hpp"
 #include "duckdb/parser/statement/connect_statement.hpp"
 #include "duckdb/parser/statement/disconnect_statement.hpp"
@@ -10,11 +11,33 @@ unique_ptr<ConnectInfo> PEGTransformerFactory::TransformLocalSessionTarget(PEGTr
 	return result;
 }
 
-unique_ptr<ConnectInfo> PEGTransformerFactory::TransformStringSessionTarget(PEGTransformer &transformer,
-                                                                            const string &string_literal) {
+unique_ptr<ConnectInfo>
+PEGTransformerFactory::TransformStringSessionTarget(PEGTransformer &transformer, const string &string_literal,
+                                                    const optional<vector<GenericCopyOption>> &generic_copy_option_list) {
 	auto result = make_uniq<ConnectInfo>();
 	result->name = Identifier(string_literal);
 	result->name_is_string_literal = true;
+	if (!generic_copy_option_list) {
+		return result;
+	}
+	// NOTE: mirrors the option split in TransformAttachStatement; candidate for a shared helper.
+	for (const auto &option : *generic_copy_option_list) {
+		if (option.expression) {
+			result->parsed_options[option.name.GetIdentifierName()] = option.expression->Copy();
+			continue;
+		}
+		if (option.children.empty()) {
+			result->options[option.name.GetIdentifierName()] = Value(true);
+		} else if (option.children.size() == 1) {
+			if (option.children[0].IsNull()) {
+				throw BinderException("NULL is not supported as a valid option for CONNECT option \"%s\"",
+				                      option.name);
+			}
+			result->options[option.name.GetIdentifierName()] = option.children[0];
+		} else {
+			throw ParserException("Option %s can only have one argument", option.name);
+		}
+	}
 	return result;
 }
 

--- a/src/parser/peg/transformer/transform_connect.cpp
+++ b/src/parser/peg/transformer/transform_connect.cpp
@@ -20,23 +20,7 @@ unique_ptr<ConnectInfo> PEGTransformerFactory::TransformStringSessionTarget(
 	if (!generic_copy_option_list) {
 		return result;
 	}
-	// NOTE: mirrors the option split in TransformAttachStatement; candidate for a shared helper.
-	for (const auto &option : *generic_copy_option_list) {
-		if (option.expression) {
-			result->parsed_options[option.name.GetIdentifierName()] = option.expression->Copy();
-			continue;
-		}
-		if (option.children.empty()) {
-			result->options[option.name.GetIdentifierName()] = Value(true);
-		} else if (option.children.size() == 1) {
-			if (option.children[0].IsNull()) {
-				throw BinderException("NULL is not supported as a valid option for CONNECT option \"%s\"", option.name);
-			}
-			result->options[option.name.GetIdentifierName()] = option.children[0];
-		} else {
-			throw ParserException("Option %s can only have one argument", option.name);
-		}
-	}
+	SplitGenericOptions(*generic_copy_option_list, result->parsed_options, result->options, "CONNECT");
 	return result;
 }
 

--- a/src/parser/peg/transformer/transform_generated.cpp
+++ b/src/parser/peg/transformer/transform_generated.cpp
@@ -1404,7 +1404,14 @@ unique_ptr<TransformResultValue>
 PEGTransformerFactory::TransformStringSessionTargetInternal(PEGTransformer &transformer, ParseResult &parse_result) {
 	auto &list_pr = parse_result.Cast<ListParseResult>();
 	auto string_literal = transformer.Transform<string>(list_pr.GetChild(0));
-	auto result = TransformStringSessionTarget(transformer, string_literal);
+	optional<vector<GenericCopyOption>> generic_copy_option_list {};
+	auto &generic_copy_option_list_opt = list_pr.GetChild(1).Cast<OptionalParseResult>();
+	if (generic_copy_option_list_opt.HasResult()) {
+		auto generic_copy_option_list_value =
+		    transformer.Transform<vector<GenericCopyOption>>(generic_copy_option_list_opt.GetResult());
+		generic_copy_option_list = generic_copy_option_list_value;
+	}
+	auto result = TransformStringSessionTarget(transformer, string_literal, generic_copy_option_list);
 	return make_uniq<TypedTransformResult<unique_ptr<ConnectInfo>>>(std::move(result));
 }
 

--- a/src/parser/peg/transformer/transform_generic_copy_option.cpp
+++ b/src/parser/peg/transformer/transform_generic_copy_option.cpp
@@ -134,4 +134,26 @@ vector<OrderByNode> PEGTransformerFactory::TransformGenericCopyOptionParenthesiz
 	return order_by_expression_list;
 }
 
+void PEGTransformerFactory::SplitGenericOptions(const vector<GenericCopyOption> &options_in,
+                                                case_insensitive_map_t<unique_ptr<ParsedExpression>> &parsed_options,
+                                                unordered_map<string, Value> &options, const char *statement_name) {
+	for (const auto &option : options_in) {
+		if (option.expression) {
+			parsed_options[option.name.GetIdentifierName()] = option.expression->Copy();
+			continue;
+		}
+		if (option.children.empty()) {
+			options[option.name.GetIdentifierName()] = Value(true);
+		} else if (option.children.size() == 1) {
+			if (option.children[0].IsNull()) {
+				throw BinderException("NULL is not supported as a valid option for %s option \"%s\"", statement_name,
+				                      option.name);
+			}
+			options[option.name.GetIdentifierName()] = option.children[0];
+		} else {
+			throw ParserException("Option %s can only have one argument", option.name);
+		}
+	}
+}
+
 } // namespace duckdb

--- a/src/planner/binder/statement/bind_connect.cpp
+++ b/src/planner/binder/statement/bind_connect.cpp
@@ -2,6 +2,8 @@
 #include "duckdb/parser/statement/disconnect_statement.hpp"
 #include "duckdb/planner/binder.hpp"
 #include "duckdb/planner/operator/logical_simple.hpp"
+#include "duckdb/planner/expression_binder/table_function_binder.hpp"
+#include "duckdb/execution/expression_executor.hpp"
 
 namespace duckdb {
 
@@ -9,6 +11,22 @@ BoundStatement Binder::Bind(ConnectStatement &stmt) {
 	BoundStatement result;
 	result.types = {LogicalType::BOOLEAN};
 	result.names = {"Success"};
+
+	// Bind the connection-string options (if any) and fold them into the bound options map.
+	// NOTE: mirrors the option binding in bind_attach; candidate for a shared Binder helper.
+	if (!stmt.info->parsed_options.empty()) {
+		TableFunctionBinder option_binder(*this, context, "Connect", "Connect parameter");
+		for (auto &entry : stmt.info->parsed_options) {
+			auto bound_expr = option_binder.Bind(entry.second);
+			auto val = ExpressionExecutor::EvaluateScalar(context, *bound_expr);
+			if (val.IsNull()) {
+				throw BinderException("NULL is not supported as a valid option for CONNECT option \"" + entry.first +
+				                      "\"");
+			}
+			stmt.info->options[entry.first] = std::move(val);
+		}
+		stmt.info->parsed_options.clear();
+	}
 
 	result.plan = make_uniq<LogicalSimple>(LogicalOperatorType::LOGICAL_CONNECT, std::move(stmt.info));
 

--- a/src/storage/serialization/serialize_parse_info.cpp
+++ b/src/storage/serialization/serialize_parse_info.cpp
@@ -353,6 +353,7 @@ void ConnectInfo::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<Identifier>(200, "name", name);
 	serializer.WritePropertyWithDefault<bool>(201, "name_is_string_literal", name_is_string_literal);
 	serializer.WritePropertyWithDefault<bool>(202, "target_is_local", target_is_local);
+	serializer.WritePropertyWithDefault<unordered_map<string, Value>>(203, "options", options);
 }
 
 unique_ptr<ParseInfo> ConnectInfo::Deserialize(Deserializer &deserializer) {
@@ -360,6 +361,7 @@ unique_ptr<ParseInfo> ConnectInfo::Deserialize(Deserializer &deserializer) {
 	deserializer.ReadPropertyWithDefault<Identifier>(200, "name", result->name);
 	deserializer.ReadPropertyWithDefault<bool>(201, "name_is_string_literal", result->name_is_string_literal);
 	deserializer.ReadPropertyWithDefault<bool>(202, "target_is_local", result->target_is_local);
+	deserializer.ReadPropertyWithDefault<unordered_map<string, Value>>(203, "options", result->options);
 	return std::move(result);
 }
 

--- a/test/sql/connect/connect_quack.test
+++ b/test/sql/connect/connect_quack.test
@@ -153,3 +153,39 @@ SELECT getvariable('v');
 
 statement ok
 DISCONNECT;
+
+# ============================================================================
+# Connection-string form with options: CONNECT '<uri>' (opts) attaches an
+# ephemeral, hidden catalog with those options and binds to it in one shot;
+# DISCONNECT detaches it again.
+# ============================================================================
+
+statement ok
+CONNECT 'quack:localhost' (TOKEN 'test_token');
+
+# Query routes through the ephemeral binding to the quack backend.
+query I
+SELECT 42;
+----
+42
+
+statement ok
+DISCONNECT;
+
+# After DISCONNECT the ephemeral attachment is reaped — nothing leaks.
+query I
+SELECT count(*) FROM pragma_database_list WHERE name LIKE '__connect%';
+----
+0
+
+# Wrong option value is surfaced from the backend at attach time (and rolled back).
+statement error
+CONNECT 'quack:localhost' (TOKEN 'wrong_token');
+----
+<REGEX>:.*(token|auth|Authentication|Unauthorized).*
+
+# The failed attempt did not leave a binding or a leaked attachment.
+statement error
+DISCONNECT;
+----
+<REGEX>:.*no active CONNECT.*

--- a/test/sql/connect/connect_string_ephemeral.test
+++ b/test/sql/connect/connect_string_ephemeral.test
@@ -1,0 +1,22 @@
+# name: test/sql/connect/connect_string_ephemeral.test
+# description: CONNECT '<uri>' attaches an ephemeral, hidden catalog and binds to it; unsupported backends roll back.
+# group: [connect]
+
+# A plain DuckDB database does not support CONNECT. The implicit attach performed by the
+# connection-string form is rolled back, and the statement errors with the offending URI.
+statement error
+CONNECT ':memory:';
+----
+<REGEX>:.*Invalid Input Error.*CONNECT ':memory:'.*does not support CONNECT.*
+
+# The rolled-back ephemeral attachment must not leak into the catalog.
+query I
+SELECT count(*) FROM pragma_database_list WHERE name LIKE '__connect%';
+----
+0
+
+# CONNECT never bound (the attach was rolled back), so we are still on LOCAL: DISCONNECT errors.
+statement error
+DISCONNECT;
+----
+<REGEX>:.*no active CONNECT.*

--- a/test/sql/connect/connect_syntax.test
+++ b/test/sql/connect/connect_syntax.test
@@ -35,11 +35,13 @@ CONNECT plain_duckdb;
 statement ok
 DETACH plain_duckdb;
 
-# CONNECT '<connection_string>'; — string-literal form, not yet implemented.
+# CONNECT '<connection_string>'; — string-literal form. Attaches the URI under an ephemeral,
+# hidden alias and binds to it. A plain DuckDB target does not support CONNECT, so the implicit
+# attach is rolled back and the statement errors.
 statement error
-CONNECT 'connection_string_form';
+CONNECT ':memory:';
 ----
-Not implemented Error: CONNECT '<connection_string>' is not yet implemented
+<REGEX>:Invalid Input Error:.*does not support CONNECT.*
 
 # ========================= DISCONNECT =========================
 

--- a/tools/shell/shell_prompt.cpp
+++ b/tools/shell/shell_prompt.cpp
@@ -281,7 +281,12 @@ string Prompt::HandleSetting(ShellState &state, const PromptComponent &component
 		if (component.literal == "connect_name_prefix") {
 			auto connected = context.TryGetConnectedCatalog();
 			if (connected) {
-				return connected->GetCatalog().GetAttached().GetName() + " ";
+				auto &catalog = connected->GetCatalog();
+				// Ephemeral connections (CONNECT '<uri>') have no user-facing name; show the display (URI).
+				if (catalog.GetAttached().IsEphemeral()) {
+					return catalog.GetConnectDisplay() + " ";
+				}
+				return catalog.GetAttached().GetName() + " ";
 			}
 			return string();
 		}


### PR DESCRIPTION
After this PR:
```sql
CONNECT 'quack:localhost' (TOKEN 'qwerty');
## some SQL
DISCONNECT;
```
is equivalent to:
```sql
ATTACH 'quack:localhost' as q (TOKEN 'qwerty');
CONNECT q;
## some SQL
DISCONNECT;   # performs also DETACH q;
```
allowing this to just work in a single statement (at the moment for `quack` and `postgres`)
```
memory D CONNECT 'quack:localhost' (TOKEN 'qwerty');
quack:localhost memory D
quack:localhost memory D

memory D
```