### PR TITLE
Optimizer: use UTF-8 successor for LIKE prefix pushdown

### DIFF
--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -501,15 +501,16 @@ FilterPushdownResult FilterCombiner::TryPushdownLikeFilter(TableFilterSet &table
 		return FilterPushdownResult::PUSHED_DOWN_FULLY;
 	}
 
-	//! We have a prefix - we can push down the prefix using a bound (x >= PREFIX AND x <= prefix + 1)
+	//! We have a prefix - we can push down the prefix using a bound (x >= PREFIX AND x < next_prefix)
 	// Note that we still need to execute the LIKE filter
 	auto lower_bound =
 	    CreateComparisonExpression(*func.GetChildren()[0], ExpressionType::COMPARE_GREATERTHANOREQUALTO, Value(prefix));
-	prefix[prefix.size() - 1]++;
-	auto upper_bound =
-	    CreateComparisonExpression(*func.GetChildren()[0], ExpressionType::COMPARE_LESSTHAN, Value(prefix));
 	table_filters.PushFilter(proj_index, make_uniq<ExpressionFilter>(std::move(lower_bound)));
-	table_filters.PushFilter(proj_index, make_uniq<ExpressionFilter>(std::move(upper_bound)));
+	if (Utf8Proc::FindNextLegalUTF8(prefix)) {
+		auto upper_bound =
+		    CreateComparisonExpression(*func.GetChildren()[0], ExpressionType::COMPARE_LESSTHAN, Value(prefix));
+		table_filters.PushFilter(proj_index, make_uniq<ExpressionFilter>(std::move(upper_bound)));
+	}
 	return FilterPushdownResult::PUSHED_DOWN_PARTIALLY;
 }
 

--- a/test/optimizer/filter_pushdown/like_prefix_boundary.test
+++ b/test/optimizer/filter_pushdown/like_prefix_boundary.test
@@ -1,0 +1,25 @@
+# name: test/optimizer/filter_pushdown/like_prefix_boundary.test
+# description: Test LIKE filter pushdown with boundary UTF-8 prefixes
+# group: [filter_pushdown]
+
+statement ok
+CREATE TABLE strings(s VARCHAR);
+
+statement ok
+INSERT INTO strings VALUES (chr(127)), (chr(127) || 'abc'), (chr(128)), ('abc');
+
+query I
+SELECT encode(s) FROM strings WHERE s LIKE chr(127) || '%' || 'c' ORDER BY 1
+----
+\x7Fabc
+
+statement ok
+DELETE FROM strings;
+
+statement ok
+INSERT INTO strings VALUES (chr(2047)), (chr(2047) || 'abc'), (chr(2048)), ('abc');
+
+query I
+SELECT encode(s) FROM strings WHERE s LIKE chr(2047) || '%' || 'c' ORDER BY 1
+----
+\xDF\xBFabc


### PR DESCRIPTION
LIKE table filter pushdown derives a range filter from the constant prefix of a LIKE pattern.

The upper bound was previously built by incrementing the last byte of the prefix directly. Prefix filter pushdown already uses Utf8Proc::FindNextLegalUTF8 for this, which avoids constructing invalid UTF-8 boundaries and handles boundary prefixes consistently.

This changes LIKE prefix range pushdown to use the same UTF-8 successor helper. If no successor exists, the pushdown keeps the safe lower bound and leaves the original LIKE predicate in place.

A sqllogictest covers boundary UTF-8 prefixes through the LIKE table filter pushdown path.
