### PR TITLE
Fold unsatisfiable NOT(comparison) filters to empty result

### DIFF
--- a/src/include/duckdb/optimizer/rule/list.hpp
+++ b/src/include/duckdb/optimizer/rule/list.hpp
@@ -11,6 +11,7 @@
 #include "duckdb/optimizer/rule/like_optimizations.hpp"
 #include "duckdb/optimizer/rule/list_comprehension_rewrite.hpp"
 #include "duckdb/optimizer/rule/move_constants.hpp"
+#include "duckdb/optimizer/rule/not_comparison_simplification.hpp"
 #include "duckdb/optimizer/rule/enum_comparison.hpp"
 #include "duckdb/optimizer/rule/regex_optimizations.hpp"
 #include "duckdb/optimizer/rule/ordered_aggregate_optimizer.hpp"

--- a/src/include/duckdb/optimizer/rule/not_comparison_simplification.hpp
+++ b/src/include/duckdb/optimizer/rule/not_comparison_simplification.hpp
@@ -1,0 +1,24 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/optimizer/rule/not_comparison_simplification.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/optimizer/rule.hpp"
+
+namespace duckdb {
+
+// Rewrites NOT(comparison) into the negated comparison: NOT(a > b) → a <= b
+class NotComparisonSimplificationRule : public Rule {
+public:
+	explicit NotComparisonSimplificationRule(ExpressionRewriter &rewriter);
+
+	unique_ptr<Expression> Apply(LogicalOperator &op, vector<reference<Expression>> &bindings, bool &changes_made,
+	                             bool is_root) override;
+};
+
+} // namespace duckdb

--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -1447,7 +1447,12 @@ ValueComparisonResult CompareValueInformation(ExpressionValueInformation &left, 
 		// (1) prune nothing or
 		// (2) return UNSATISFIABLE
 		// the SMALLER THAN constant has to be greater than the BIGGER THAN constant
-		if (left.constant >= right.constant) {
+		if (left.constant > right.constant) {
+			return ValueComparisonResult::PRUNE_NOTHING;
+		} else if (left.constant == right.constant &&
+		           left.comparison_type == ExpressionType::COMPARE_LESSTHANOREQUALTO &&
+		           right.comparison_type == ExpressionType::COMPARE_GREATERTHANOREQUALTO) {
+			// a <= C AND a >= C is satisfiable (a = C)
 			return ValueComparisonResult::PRUNE_NOTHING;
 		} else {
 			return ValueComparisonResult::UNSATISFIABLE_CONDITION;

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -85,6 +85,7 @@ Optimizer::Optimizer(Binder &binder, ClientContext &context) : context(context),
 	rewriter.rules.push_back(make_uniq<PredicateFactoringRule>(rewriter));
 	rewriter.rules.push_back(make_uniq<ListComprehensionRewriteRule>(rewriter));
 	rewriter.rules.push_back(make_uniq<ContainsToInClauseRule>(rewriter));
+	rewriter.rules.push_back(make_uniq<NotComparisonSimplificationRule>(rewriter));
 
 #ifdef DEBUG
 	for (auto &rule : rewriter.rules) {

--- a/src/optimizer/rule/CMakeLists.txt
+++ b/src/optimizer/rule/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library_unity(
   like_optimizations.cpp
   list_comprehension_rewrite.cpp
   move_constants.cpp
+  not_comparison_simplification.cpp
   ordered_aggregate_optimizer.cpp
   predicate_factoring.cpp
   regex_optimizations.cpp

--- a/src/optimizer/rule/not_comparison_simplification.cpp
+++ b/src/optimizer/rule/not_comparison_simplification.cpp
@@ -1,0 +1,41 @@
+#include "duckdb/optimizer/rule/not_comparison_simplification.hpp"
+#include "duckdb/planner/expression/bound_operator_expression.hpp"
+#include "duckdb/planner/expression/bound_comparison_expression.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "duckdb/common/enums/expression_type.hpp"
+
+namespace duckdb {
+
+NotComparisonSimplificationRule::NotComparisonSimplificationRule(ExpressionRewriter &rewriter) : Rule(rewriter) {
+	// match BOUND_OPERATOR with type OPERATOR_NOT
+	auto op = make_uniq<ExpressionMatcher>(ExpressionClass::BOUND_OPERATOR);
+	op->expr_type = make_uniq<SpecificExpressionTypeMatcher>(ExpressionType::OPERATOR_NOT);
+	root = std::move(op);
+}
+
+unique_ptr<Expression> NotComparisonSimplificationRule::Apply(LogicalOperator &op,
+                                                              vector<reference<Expression>> &bindings,
+                                                              bool &changes_made, bool is_root) {
+	auto &not_expr = bindings[0].get().Cast<BoundOperatorExpression>();
+	D_ASSERT(not_expr.GetExpressionType() == ExpressionType::OPERATOR_NOT);
+	D_ASSERT(not_expr.GetChildren().size() == 1);
+
+	auto &child = not_expr.GetChildrenMutable()[0];
+
+	// check if the child is a comparison expression
+	if (!BoundComparisonExpression::IsComparison(*child)) {
+		return nullptr;
+	}
+
+	auto &comparison = child->Cast<BoundFunctionExpression>();
+	auto negated_type = NegateComparisonExpression(comparison.GetExpressionType());
+
+	// set the negated comparison type (updates both expression type and bind data)
+	BoundComparisonExpression::SetType(comparison, negated_type);
+	changes_made = true;
+
+	// return the child comparison directly, removing the NOT wrapper
+	return std::move(child);
+}
+
+} // namespace duckdb

--- a/src/storage/external_file_cache/caching_file_system_wrapper.cpp
+++ b/src/storage/external_file_cache/caching_file_system_wrapper.cpp
@@ -253,7 +253,7 @@ bool CachingFileSystemWrapper::ListFilesExtended(const string &directory,
 }
 
 bool CachingFileSystemWrapper::SupportsListFilesExtended() const {
-	// Cannot delegate to internal filesystem's invocaton since it's `protected`.
+	// Cannot delegate to internal filesystem's invocation since it's `protected`.
 	return true;
 }
 

--- a/test/sql/optimizer/test_not_comparison_simplification.test
+++ b/test/sql/optimizer/test_not_comparison_simplification.test
@@ -1,0 +1,41 @@
+# name: test/sql/optimizer/test_not_comparison_simplification.test
+# description: Test NOT(comparison) simplification and pruning
+# group: [optimizer]
+
+statement ok
+CREATE TABLE t AS SELECT * FROM (VALUES (1),(2),(3)) v(a);
+
+# Contradiction with NOT should be pruned to empty result
+query I
+SELECT * FROM t WHERE a > 1 AND NOT (a > 1)
+----
+
+# Other comparison types
+query I
+SELECT * FROM t WHERE a >= 2 AND NOT (a >= 2)
+----
+
+query I
+SELECT * FROM t WHERE a < 2 AND NOT (a < 2)
+----
+
+query I
+SELECT * FROM t WHERE a <= 2 AND NOT (a <= 2)
+----
+
+query I
+SELECT * FROM t WHERE a = 2 AND NOT (a = 2)
+----
+
+# NOT(comparison) without contradiction should still return correct results
+query I
+SELECT * FROM t WHERE NOT (a > 2) ORDER BY a
+----
+1
+2
+
+query I
+SELECT * FROM t WHERE NOT (a = 1) ORDER BY a
+----
+2
+3


### PR DESCRIPTION
Fixes #23545

## Problem

Predicates like `a > 1 AND NOT(a > 1)` are always false, but the optimizer
did not fold them to `EMPTY_RESULT`. A similar contradiction without `NOT`
(e.g. `a = 2 AND a != 2`) was already pruned correctly.

`FilterCombiner` only understands direct comparisons, so `NOT(comparison)`
was left unprocessed and the scan was kept.

## Solution

- Add `NotComparisonSimplificationRule` to rewrite `NOT(comparison)` into
  the negated comparison (e.g. `NOT(a > 1)` → `a <= 1`) before filter pushdown.
- Fix a boundary case in `CompareValueInformation` so `a <= C AND a >= C`
  is treated as satisfiable (`a = C`), while `a > C AND a <= C` remains
  unsatisfiable.

## Before / After

<img width="510" height="164" alt="Screenshot 2026-07-02 at 12 39 55 AM" src="https://github.com/user-attachments/assets/5915ec19-3939-4893-96ca-ffc3208efaac" />


Before: `EXPLAIN SELECT * FROM t WHERE a > 1 AND NOT (a > 1)` → Seq Scan  
After:  `EXPLAIN SELECT * FROM t WHERE a > 1 AND NOT (a > 1)` → Empty Result

## Test plan

- [x] Added `test/sql/optimizer/test_not_comparison_simplification.test`
- [x] Covers contradictions for `>`, `>=`, `<`, `<=`, `=`
- [x] Covers non-contradictory `NOT(comparison)` still returning correct rows
- [x] `make format-fix`
- [x] `build/reldebug/test/unittest test/sql/optimizer/test_not_comparison_simplification.test`
- [ ] `make unit` (or full CI on fork)