### PR TITLE
Fix filter combiner not pruning unsatisfiable bounds

### DIFF
--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -1204,10 +1204,19 @@ ValueComparisonResult CompareValueInformation(ExpressionValueInformation &left, 
 		// (1) prune nothing or
 		// (2) return UNSATISFIABLE
 		// the SMALLER THAN constant has to be greater than the BIGGER THAN constant
-		if (left.constant >= right.constant) {
+		if (left.constant > right.constant) {
 			return ValueComparisonResult::PRUNE_NOTHING;
-		} else {
+		} else if (left.constant < right.constant) {
 			return ValueComparisonResult::UNSATISFIABLE_CONDITION;
+		} else {
+			// the constants are equal
+			// This is only satisfiable if both bounds are inclusive
+			if (left.comparison_type == ExpressionType::COMPARE_LESSTHANOREQUALTO &&
+			    right.comparison_type == ExpressionType::COMPARE_GREATERTHANOREQUALTO) {
+				return ValueComparisonResult::PRUNE_NOTHING;
+			} else {
+				return ValueComparisonResult::UNSATISFIABLE_CONDITION;
+			}
 		}
 	} else {
 		// left is [>] and right is [<] or [!=]

--- a/test/optimizer/transitive_filters.test
+++ b/test/optimizer/transitive_filters.test
@@ -137,6 +137,27 @@ EXPLAIN SELECT * FROM (VALUES(5,5)) tbl(col0, col1) WHERE col1 < col0 AND col0<=
 ----
 logical_opt	<REGEX>:.*\(col1 < 5\).*
 
+# Check unsatisfiable pruning
+query II
+EXPLAIN SELECT * FROM (VALUES(1),(2),(3)) tbl(a) WHERE a > 1 AND NOT (a > 1);
+----
+logical_opt	<REGEX>:.*EMPTY_RESULT.*
+
+query II
+EXPLAIN SELECT * FROM (VALUES(1),(2),(3)) tbl(a) WHERE a > 1 AND a <= 1;
+----
+logical_opt	<REGEX>:.*EMPTY_RESULT.*
+
+query II
+EXPLAIN SELECT * FROM (VALUES(1),(2),(3)) tbl(a) WHERE a >= 2 AND a < 2;
+----
+logical_opt	<REGEX>:.*EMPTY_RESULT.*
+
+query II
+EXPLAIN SELECT * FROM (VALUES(1),(2),(3)) tbl(a) WHERE a <= 2 AND a >= 2;
+----
+logical_opt	<!REGEX>:.*EMPTY_RESULT.*
+
 
 # FIXME - disabled because of bugs in the filter combiner
 mode skip

--- a/test/sql/copy/parquet/parquet_hive.test
+++ b/test/sql/copy/parquet/parquet_hive.test
@@ -189,8 +189,8 @@ EXPLAIN select a from parquet_scan('{TEMP_DIR}/hive_filters/*/*.parquet', HIVE_P
 ----
 physical_plan	<REGEX>:.*PARQUET_SCAN.*Filters:.*a<4.*File Filters:.*\(CAST\(c AS.*INTEGER\) = 500\).*
 
-# unsatisfiable file filters also show up
+# unsatisfiable filters are pruned to an empty result
 query II
 EXPLAIN select a from parquet_scan('{TEMP_DIR}/hive_filters_2/*/*/*.parquet', HIVE_PARTITIONING=1, HIVE_TYPES_AUTOCAST=0) where c::INT > 500 and c::INT < 500;
 ----
-physical_plan	<REGEX>:.*PARQUET_SCAN.*File Filters:.*\(CAST\(c AS.*INTEGER\).*BETWEEN.*500 AND 500\).*
+physical_plan	<REGEX>:.*EMPTY_RESULT.*


### PR DESCRIPTION
Fixes: https://github.com/duckdb/duckdb/issues/23545

Prune unsatisfiable filters where an upper and lower bound meet at the same constant. Split out the equal-constant case: when the two constants are equal, the range is satisfiable only if both bounds are inclusive, otherwise it's unsatisfiable.