### PR TITLE
Fix/capi scalar bind subquery crash

### DIFF
--- a/src/main/capi/scalar_function-c.cpp
+++ b/src/main/capi/scalar_function-c.cpp
@@ -354,11 +354,13 @@ duckdb_expression duckdb_scalar_function_bind_get_argument(duckdb_bind_info info
 		return nullptr;
 	}
 	auto &bind_info = GetCScalarFunctionBindInfo(info);
+	ExpressionWrapper *wrapper = nullptr;
 	try {
-		auto wrapper = new ExpressionWrapper();
+		wrapper = new ExpressionWrapper();
 		wrapper->expr = bind_info.arguments[index]->Copy();
 		return reinterpret_cast<duckdb_expression>(wrapper);
 	} catch (std::exception &e) {
+		delete wrapper;
 		duckdb_scalar_function_bind_set_error(info, e.what());
 		return nullptr;
 	}

--- a/src/main/capi/scalar_function-c.cpp
+++ b/src/main/capi/scalar_function-c.cpp
@@ -354,9 +354,14 @@ duckdb_expression duckdb_scalar_function_bind_get_argument(duckdb_bind_info info
 		return nullptr;
 	}
 	auto &bind_info = GetCScalarFunctionBindInfo(info);
-	auto wrapper = new ExpressionWrapper();
-	wrapper->expr = bind_info.arguments[index]->Copy();
-	return reinterpret_cast<duckdb_expression>(wrapper);
+	try {
+		auto wrapper = new ExpressionWrapper();
+		wrapper->expr = bind_info.arguments[index]->Copy();
+		return reinterpret_cast<duckdb_expression>(wrapper);
+	} catch (std::exception &e) {
+		duckdb_scalar_function_bind_set_error(info, e.what());
+		return nullptr;
+	}
 }
 
 void duckdb_scalar_function_set_extra_info(duckdb_scalar_function function, void *extra_info,

--- a/src/main/capi/scalar_function-c.cpp
+++ b/src/main/capi/scalar_function-c.cpp
@@ -354,13 +354,11 @@ duckdb_expression duckdb_scalar_function_bind_get_argument(duckdb_bind_info info
 		return nullptr;
 	}
 	auto &bind_info = GetCScalarFunctionBindInfo(info);
-	ExpressionWrapper *wrapper = nullptr;
 	try {
-		wrapper = new ExpressionWrapper();
+		auto wrapper = duckdb::make_uniq<ExpressionWrapper>();
 		wrapper->expr = bind_info.arguments[index]->Copy();
-		return reinterpret_cast<duckdb_expression>(wrapper);
+		return reinterpret_cast<duckdb_expression>(wrapper.release());
 	} catch (std::exception &e) {
-		delete wrapper;
 		duckdb_scalar_function_bind_set_error(info, e.what());
 		return nullptr;
 	}

--- a/test/api/capi/capi_scalar_functions.cpp
+++ b/test/api/capi/capi_scalar_functions.cpp
@@ -563,8 +563,7 @@ TEST_CASE("Test Scalar Function with Bind Info", "[capi]") {
 	// Before the fix, this exception escaped the C API boundary and called std::terminate() because
 	// Go's CGo frames (and plain C callers) have no C++ unwind tables. The fix catches at the C
 	// boundary and surfaces it as a normal query error.
-	result = tester.Query(
-	    "SELECT get_connection_id((SELECT 42::UBIGINT)) FROM (VALUES(1)) t(x)");
+	result = tester.Query("SELECT get_connection_id((SELECT 42::UBIGINT)) FROM (VALUES(1)) t(x)");
 	REQUIRE_FAIL(result);
 }
 

--- a/test/api/capi/capi_scalar_functions.cpp
+++ b/test/api/capi/capi_scalar_functions.cpp
@@ -558,6 +558,14 @@ TEST_CASE("Test Scalar Function with Bind Info", "[capi]") {
 	result = tester.Query("SELECT get_connection_id(200::UTINYINT + 200::UTINYINT)");
 	REQUIRE_FAIL(result);
 	REQUIRE(StringUtil::Contains(result->ErrorMessage(), "Overflow in addition of"));
+
+	// Correlated subquery as argument: BoundSubqueryExpression::Copy() throws SerializationException.
+	// Before the fix, this exception escaped the C API boundary and called std::terminate() because
+	// Go's CGo frames (and plain C callers) have no C++ unwind tables. The fix catches at the C
+	// boundary and surfaces it as a normal query error.
+	result = tester.Query(
+	    "SELECT get_connection_id((SELECT 42::UBIGINT)) FROM (VALUES(1)) t(x)");
+	REQUIRE_FAIL(result);
 }
 
 TEST_CASE("Test volatile scalar function with bind in WHERE clause", "[capi]") {


### PR DESCRIPTION
## Summary

- `BoundSubqueryExpression::Copy()` throws `SerializationException` when a scalar UDF with a `ScalarBinder` receives a correlated subquery as an argument
- The exception escaped the C API boundary, passed through CGo/C frames with no C++ unwind tables, and called `std::terminate()` → `abort()` — uncatchable from Go
- Fix wraps the `Copy()` call in a `try/catch` inside `duckdb_scalar_function_bind_get_argument` (`src/main/capi/scalar_function-c.cpp`), sets the error via `duckdb_scalar_function_bind_set_error`, and returns `nullptr` — surfacing it as a normal query error
- Regression test added in `test/api/capi/capi_scalar_functions.cpp` verifies the query fails gracefully instead of aborting the process

## Test plan

- [ ] `test/api/capi/capi_scalar_functions.cpp` — new case in `Test Scalar Function with Bind Info`: passes a correlated subquery to `get_connection_id` (which uses a `ScalarBinder`) and asserts `REQUIRE_FAIL` instead of process abort
- [ ] All existing scalar function bind tests continue to pass