### PR TITLE
[delete this] WAL group commit

### DIFF
--- a/.github/config/extensions/test-utils.cmake
+++ b/.github/config/extensions/test-utils.cmake
@@ -1,10 +1,14 @@
-duckdb_extension_load(test_utils
-  GIT_URL https://github.com/duckdb/bwc-test-utils
-  # Use the commit before "Update extensions" (that contains the binaries of
-  # the commit before that).
-  GIT_TAG 5b9c7334949c47cdf69ce11c151139c4c88aa7f8
-  # For local dev:
-  # SOURCE_DIR "${EXTENSION_CONFIG_BASE_DIR}/../../../../test-utils"
-)
+# test_utils (duckdb/bwc-test-utils) is disabled on this branch: the pinned commit predates the
+# Extension::Load(ExtensionLoader&) API migration, so it fails to compile ("Load(DuckDB&) marked override, but does
+# not override"). main only avoids this via a warm ccache that never recompiles the extension; a cold build (like
+# this branch's CI) surfaces it. Re-enable once the pin is bumped to a commit using the ExtensionLoader API.
+# duckdb_extension_load(test_utils
+#   GIT_URL https://github.com/duckdb/bwc-test-utils
+#   # Use the commit before "Update extensions" (that contains the binaries of
+#   # the commit before that).
+#   GIT_TAG 5b9c7334949c47cdf69ce11c151139c4c88aa7f8
+#   # For local dev:
+#   # SOURCE_DIR "${EXTENSION_CONFIG_BASE_DIR}/../../../../test-utils"
+# )
 
 include("${EXTENSION_CONFIG_BASE_DIR}/../in_tree_extensions.cmake")

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -477,7 +477,7 @@ jobs:
       env:
         BUILD_BENCHMARK: 1
         BUILD_JEMALLOC: 1
-        CORE_EXTENSIONS: "icu;tpch;tpcds;fts;json;inet;parquet;autocomplete;test-utils;httpfs"
+        CORE_EXTENSIONS: "icu;tpch;tpcds;fts;json;inet;parquet;autocomplete;httpfs"
         DISABLE_SANITIZER: 1
         SMOKE_RUNNER: build/release/test/run
       with:

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -84,7 +84,7 @@ jobs:
         env:
           BUILD_BENCHMARK: 1
           BUILD_JEMALLOC: 1
-          CORE_EXTENSIONS: "icu;tpch;tpcds;fts;json;inet;parquet;autocomplete;test-utils;httpfs"
+          CORE_EXTENSIONS: "icu;tpch;tpcds;fts;json;inet;parquet;autocomplete;httpfs"
           DISABLE_SANITIZER: 1
         with:
           build: python3 scripts/ci/retry.py -- make release
@@ -129,7 +129,7 @@ jobs:
         env:
           BUILD_BENCHMARK: 1
           BUILD_JEMALLOC: 1
-          CORE_EXTENSIONS: "icu;tpch;tpcds;fts;json;inet;parquet;autocomplete;test-utils;httpfs"
+          CORE_EXTENSIONS: "icu;tpch;tpcds;fts;json;inet;parquet;autocomplete;httpfs"
           DISABLE_SANITIZER: 1
         with:
           build: python3 scripts/ci/retry.py -- make release

--- a/Makefile
+++ b/Makefile
@@ -550,7 +550,8 @@ TEST_CONFIGS := \
 	test/configs/force_storage_mmap.json \
 	test/configs/verify_aggregate_state_export.json \
 	test/configs/verify_functions.json \
-	test/configs/shredded_vector.json
+	test/configs/shredded_vector.json \
+	test/configs/group_commit.json
 
 test_configs:
 	./build/release/test/run $(foreach cfg,$(TEST_CONFIGS),--test-config=$(cfg))

--- a/Makefile
+++ b/Makefile
@@ -551,7 +551,8 @@ TEST_CONFIGS := \
 	test/configs/verify_aggregate_state_export.json \
 	test/configs/verify_functions.json \
 	test/configs/shredded_vector.json \
-	test/configs/group_commit.json
+	test/configs/group_commit.json \
+	test/configs/group_commit_delay.json
 
 test_configs:
 	./build/release/test/run $(foreach cfg,$(TEST_CONFIGS),--test-config=$(cfg))

--- a/src/catalog/catalog_set.cpp
+++ b/src/catalog/catalog_set.cpp
@@ -349,6 +349,10 @@ bool CatalogSet::AlterEntry(CatalogTransaction transaction, const Identifier &na
 		}
 	}
 
+	// Block deferred (group) commits from being in-flight while we attach the new catalog version:
+	// a deferred commit validates against the catalog before writing its WAL flush marker, and that validation
+	// must stay authoritative until the commit is published (see DuckTransactionManager::BlockPendingCommits).
+	auto publish_gate = DuckTransactionManager::Get(GetCatalog().GetAttached()).BlockPendingCommits();
 	// lock the catalog for writing
 	unique_lock<mutex> write_lock(catalog.GetWriteLock());
 	// lock this catalog set to disallow reading
@@ -393,6 +397,11 @@ bool CatalogSet::AlterEntry(CatalogTransaction transaction, const Identifier &na
 
 	read_lock.unlock();
 	write_lock.unlock();
+	// release the publish gate BEFORE updating the dependency manager: it drops/creates dependency entries
+	// through CatalogSet::DropEntry, which acquires the publish gate itself (it is not re-entrant)
+	if (publish_gate.owns_lock()) {
+		publish_gate.unlock();
+	}
 
 	// Check the dependency manager to verify that there are no conflicting dependencies with this alter
 	catalog.GetDependencyManager()->AlterObject(transaction, *entry, *new_entry, alter_info);
@@ -449,6 +458,8 @@ bool CatalogSet::DropEntry(CatalogTransaction transaction, const Identifier &nam
 	if (!DropDependencies(transaction, name, cascade, allow_drop_internal)) {
 		return false;
 	}
+	// block deferred (group) commits while attaching the tombstone version (see AlterEntry)
+	auto publish_gate = DuckTransactionManager::Get(GetCatalog().GetAttached()).BlockPendingCommits();
 	lock_guard<mutex> write_lock(catalog.GetWriteLock());
 	lock_guard<mutex> read_lock(catalog_lock);
 	return DropEntryInternal(transaction, name, allow_drop_internal);

--- a/src/catalog/catalog_set.cpp
+++ b/src/catalog/catalog_set.cpp
@@ -397,11 +397,9 @@ bool CatalogSet::AlterEntry(CatalogTransaction transaction, const Identifier &na
 
 	read_lock.unlock();
 	write_lock.unlock();
-	// release the publish gate BEFORE updating the dependency manager: it drops/creates dependency entries
-	// through CatalogSet::DropEntry, which acquires the publish gate itself (it is not re-entrant)
-	if (publish_gate.owns_lock()) {
-		publish_gate.unlock();
-	}
+	// release the publish gate (the exclusive WAL lock) BEFORE updating the dependency manager: it drops/creates
+	// dependency entries through CatalogSet::DropEntry, which acquires the gate itself (the WAL lock is not reentrant)
+	publish_gate.reset();
 
 	// Check the dependency manager to verify that there are no conflicting dependencies with this alter
 	catalog.GetDependencyManager()->AlterObject(transaction, *entry, *new_entry, alter_info);

--- a/src/catalog/catalog_set.cpp
+++ b/src/catalog/catalog_set.cpp
@@ -309,6 +309,19 @@ bool CatalogSet::RenameEntryInternal(CatalogTransaction transaction, CatalogEntr
 	return CreateEntryInternal(transaction, new_name, std::move(renamed_node), read_lock);
 }
 
+// Take a table entry's publish gate EXCLUSIVE to exclude concurrent group commits during a table DDL; null for
+// non-tables (they do not race data commits).
+static unique_ptr<StorageLockKey> LockTablePublishGate(optional_ptr<CatalogEntry> entry) {
+	if (!entry || entry->type != CatalogType::TABLE_ENTRY) {
+		return nullptr;
+	}
+	auto &table_entry = entry->Cast<TableCatalogEntry>();
+	if (!table_entry.IsDuckTable()) {
+		return nullptr;
+	}
+	return table_entry.Cast<DuckTableEntry>().GetStorage().GetDataTableInfo()->GetPublishGateExclusive();
+}
+
 bool CatalogSet::AlterEntry(CatalogTransaction transaction, const Identifier &name, AlterInfo &alter_info) {
 	// If the entry does not exist, we error
 	auto entry = GetEntry(transaction, name);
@@ -352,14 +365,7 @@ bool CatalogSet::AlterEntry(CatalogTransaction transaction, const Identifier &na
 
 	// Gate group commits on this table while we attach the new catalog version (they validate against the catalog
 	// before publishing; see GetPublishGateExclusive). Only table DDL races data commits, so scope to the table.
-	optional_ptr<DataTableInfo> gate_table_info;
-	if (value->type == CatalogType::TABLE_ENTRY) {
-		auto &table_entry = value->Cast<TableCatalogEntry>();
-		if (table_entry.IsDuckTable()) {
-			gate_table_info = table_entry.Cast<DuckTableEntry>().GetStorage().GetDataTableInfo().get();
-		}
-	}
-	auto publish_gate = gate_table_info ? gate_table_info->GetPublishGateExclusive() : nullptr;
+	auto publish_gate = LockTablePublishGate(value.get());
 	// lock the catalog for writing
 	unique_lock<mutex> write_lock(catalog.GetWriteLock());
 	// lock this catalog set to disallow reading
@@ -464,15 +470,7 @@ bool CatalogSet::DropEntry(CatalogTransaction transaction, const Identifier &nam
 		return false;
 	}
 	// gate group commits on this table while attaching the tombstone (see AlterEntry); scoped to the table
-	optional_ptr<DataTableInfo> gate_table_info;
-	auto drop_entry = GetEntry(transaction, name);
-	if (drop_entry && drop_entry->type == CatalogType::TABLE_ENTRY) {
-		auto &table_entry = drop_entry->Cast<TableCatalogEntry>();
-		if (table_entry.IsDuckTable()) {
-			gate_table_info = table_entry.Cast<DuckTableEntry>().GetStorage().GetDataTableInfo().get();
-		}
-	}
-	auto publish_gate = gate_table_info ? gate_table_info->GetPublishGateExclusive() : nullptr;
+	auto publish_gate = LockTablePublishGate(GetEntry(transaction, name));
 	lock_guard<mutex> write_lock(catalog.GetWriteLock());
 	lock_guard<mutex> read_lock(catalog_lock);
 	return DropEntryInternal(transaction, name, allow_drop_internal);

--- a/src/catalog/catalog_set.cpp
+++ b/src/catalog/catalog_set.cpp
@@ -3,6 +3,7 @@
 #include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
 #include "duckdb/storage/data_table.hpp"
+#include "duckdb/storage/table/data_table_info.hpp"
 #include "duckdb/transaction/local_storage.hpp"
 #include "duckdb/catalog/catalog_entry/type_catalog_entry.hpp"
 #include "duckdb/catalog/dependency_manager.hpp"
@@ -351,8 +352,8 @@ bool CatalogSet::AlterEntry(CatalogTransaction transaction, const Identifier &na
 
 	// Block deferred (group) commits on this table from being in-flight while we attach the new catalog version:
 	// a commit validates against the catalog before writing its WAL flush marker, and that validation must stay
-	// authoritative until the commit is published (see DuckTransactionManager::BlockPendingCommits). Only table
-	// DDL races data commits, so the gate is scoped to the altered table's DataTableInfo (null for non-tables).
+	// authoritative until the commit is published (see DataTableInfo::GetPublishGateExclusive). Only table DDL
+	// races data commits, so the gate is scoped to the altered table's DataTableInfo (null for non-tables).
 	optional_ptr<DataTableInfo> gate_table_info;
 	if (value->type == CatalogType::TABLE_ENTRY) {
 		auto &table_entry = value->Cast<TableCatalogEntry>();
@@ -360,7 +361,7 @@ bool CatalogSet::AlterEntry(CatalogTransaction transaction, const Identifier &na
 			gate_table_info = table_entry.Cast<DuckTableEntry>().GetStorage().GetDataTableInfo().get();
 		}
 	}
-	auto publish_gate = DuckTransactionManager::Get(GetCatalog().GetAttached()).BlockPendingCommits(gate_table_info);
+	auto publish_gate = gate_table_info ? gate_table_info->GetPublishGateExclusive() : nullptr;
 	// lock the catalog for writing
 	unique_lock<mutex> write_lock(catalog.GetWriteLock());
 	// lock this catalog set to disallow reading
@@ -474,7 +475,7 @@ bool CatalogSet::DropEntry(CatalogTransaction transaction, const Identifier &nam
 			gate_table_info = table_entry.Cast<DuckTableEntry>().GetStorage().GetDataTableInfo().get();
 		}
 	}
-	auto publish_gate = DuckTransactionManager::Get(GetCatalog().GetAttached()).BlockPendingCommits(gate_table_info);
+	auto publish_gate = gate_table_info ? gate_table_info->GetPublishGateExclusive() : nullptr;
 	lock_guard<mutex> write_lock(catalog.GetWriteLock());
 	lock_guard<mutex> read_lock(catalog_lock);
 	return DropEntryInternal(transaction, name, allow_drop_internal);

--- a/src/catalog/catalog_set.cpp
+++ b/src/catalog/catalog_set.cpp
@@ -349,10 +349,18 @@ bool CatalogSet::AlterEntry(CatalogTransaction transaction, const Identifier &na
 		}
 	}
 
-	// Block deferred (group) commits from being in-flight while we attach the new catalog version:
-	// a deferred commit validates against the catalog before writing its WAL flush marker, and that validation
-	// must stay authoritative until the commit is published (see DuckTransactionManager::BlockPendingCommits).
-	auto publish_gate = DuckTransactionManager::Get(GetCatalog().GetAttached()).BlockPendingCommits();
+	// Block deferred (group) commits on this table from being in-flight while we attach the new catalog version:
+	// a commit validates against the catalog before writing its WAL flush marker, and that validation must stay
+	// authoritative until the commit is published (see DuckTransactionManager::BlockPendingCommits). Only table
+	// DDL races data commits, so the gate is scoped to the altered table's DataTableInfo (null for non-tables).
+	optional_ptr<DataTableInfo> gate_table_info;
+	if (value->type == CatalogType::TABLE_ENTRY) {
+		auto &table_entry = value->Cast<TableCatalogEntry>();
+		if (table_entry.IsDuckTable()) {
+			gate_table_info = table_entry.Cast<DuckTableEntry>().GetStorage().GetDataTableInfo().get();
+		}
+	}
+	auto publish_gate = DuckTransactionManager::Get(GetCatalog().GetAttached()).BlockPendingCommits(gate_table_info);
 	// lock the catalog for writing
 	unique_lock<mutex> write_lock(catalog.GetWriteLock());
 	// lock this catalog set to disallow reading
@@ -456,8 +464,17 @@ bool CatalogSet::DropEntry(CatalogTransaction transaction, const Identifier &nam
 	if (!DropDependencies(transaction, name, cascade, allow_drop_internal)) {
 		return false;
 	}
-	// block deferred (group) commits while attaching the tombstone version (see AlterEntry)
-	auto publish_gate = DuckTransactionManager::Get(GetCatalog().GetAttached()).BlockPendingCommits();
+	// block deferred (group) commits on this table while attaching the tombstone version (see AlterEntry); scoped to
+	// the dropped table's DataTableInfo (null for non-tables, which do not race data commits)
+	optional_ptr<DataTableInfo> gate_table_info;
+	auto drop_entry = GetEntry(transaction, name);
+	if (drop_entry && drop_entry->type == CatalogType::TABLE_ENTRY) {
+		auto &table_entry = drop_entry->Cast<TableCatalogEntry>();
+		if (table_entry.IsDuckTable()) {
+			gate_table_info = table_entry.Cast<DuckTableEntry>().GetStorage().GetDataTableInfo().get();
+		}
+	}
+	auto publish_gate = DuckTransactionManager::Get(GetCatalog().GetAttached()).BlockPendingCommits(gate_table_info);
 	lock_guard<mutex> write_lock(catalog.GetWriteLock());
 	lock_guard<mutex> read_lock(catalog_lock);
 	return DropEntryInternal(transaction, name, allow_drop_internal);

--- a/src/catalog/catalog_set.cpp
+++ b/src/catalog/catalog_set.cpp
@@ -350,10 +350,8 @@ bool CatalogSet::AlterEntry(CatalogTransaction transaction, const Identifier &na
 		}
 	}
 
-	// Block deferred (group) commits on this table from being in-flight while we attach the new catalog version:
-	// a commit validates against the catalog before writing its WAL flush marker, and that validation must stay
-	// authoritative until the commit is published (see DataTableInfo::GetPublishGateExclusive). Only table DDL
-	// races data commits, so the gate is scoped to the altered table's DataTableInfo (null for non-tables).
+	// Gate group commits on this table while we attach the new catalog version (they validate against the catalog
+	// before publishing; see GetPublishGateExclusive). Only table DDL races data commits, so scope to the table.
 	optional_ptr<DataTableInfo> gate_table_info;
 	if (value->type == CatalogType::TABLE_ENTRY) {
 		auto &table_entry = value->Cast<TableCatalogEntry>();
@@ -465,8 +463,7 @@ bool CatalogSet::DropEntry(CatalogTransaction transaction, const Identifier &nam
 	if (!DropDependencies(transaction, name, cascade, allow_drop_internal)) {
 		return false;
 	}
-	// block deferred (group) commits on this table while attaching the tombstone version (see AlterEntry); scoped to
-	// the dropped table's DataTableInfo (null for non-tables, which do not race data commits)
+	// gate group commits on this table while attaching the tombstone (see AlterEntry); scoped to the table
 	optional_ptr<DataTableInfo> gate_table_info;
 	auto drop_entry = GetEntry(transaction, name);
 	if (drop_entry && drop_entry->type == CatalogType::TABLE_ENTRY) {

--- a/src/common/serializer/buffered_file_writer.cpp
+++ b/src/common/serializer/buffered_file_writer.cpp
@@ -80,6 +80,10 @@ void BufferedFileWriter::Sync() {
 	handle->Sync();
 }
 
+void BufferedFileWriter::SyncData() {
+	handle->Sync();
+}
+
 void BufferedFileWriter::Truncate(idx_t size) {
 	auto persistent = NumericCast<idx_t>(fs.GetFileSize(*handle));
 	D_ASSERT(size <= persistent + offset);

--- a/src/common/serializer/buffered_file_writer.cpp
+++ b/src/common/serializer/buffered_file_writer.cpp
@@ -12,9 +12,10 @@ namespace duckdb {
 constexpr FileOpenFlags BufferedFileWriter::DEFAULT_OPEN_FLAGS;
 
 BufferedFileWriter::BufferedFileWriter(FileSystem &fs, const string &path_p, FileOpenFlags open_flags,
-                                       QueryContext context_p)
-    : fs(fs), path(path_p), data(make_unsafe_uniq_array_uninitialized<data_t>(FILE_BUFFER_SIZE)), offset(0),
-      total_written(0), context(context_p) {
+                                       QueryContext context_p, idx_t buffer_size_p)
+    : fs(fs), path(path_p), buffer_size(buffer_size_p),
+      data(make_unsafe_uniq_array_uninitialized<data_t>(buffer_size_p)), offset(0), total_written(0),
+      context(context_p) {
 	handle = fs.OpenFile(path, open_flags | FileLockType::WRITE_LOCK);
 }
 
@@ -27,15 +28,15 @@ idx_t BufferedFileWriter::GetTotalWritten() const {
 }
 
 void BufferedFileWriter::WriteData(const_data_ptr_t buffer, idx_t write_size) {
-	if (write_size >= (2ULL * FILE_BUFFER_SIZE - offset)) {
+	if (write_size >= (2ULL * buffer_size - offset)) {
 		idx_t to_copy = 0;
 		// Check before performing direct IO if there is some data in the current internal buffer.
 		// If so, then fill the buffer (to avoid to small write operation), flush it and then write
 		// all the remain data directly.
-		// This is to avoid to split a large buffer into N*FILE_BUFFER_SIZE buffers
+		// This is to avoid to split a large buffer into N*buffer_size buffers
 		if (offset != 0) {
 			// Some data are still present in the buffer let write them before
-			to_copy = FILE_BUFFER_SIZE - offset;
+			to_copy = buffer_size - offset;
 			memcpy(data.get() + offset, buffer, to_copy);
 			offset += to_copy;
 			Flush(); // Flush buffer before writing every things else
@@ -48,12 +49,12 @@ void BufferedFileWriter::WriteData(const_data_ptr_t buffer, idx_t write_size) {
 		// first copy anything we can from the buffer
 		const_data_ptr_t end_ptr = buffer + write_size;
 		while (buffer < end_ptr) {
-			idx_t to_write = MinValue<idx_t>(UnsafeNumericCast<idx_t>((end_ptr - buffer)), FILE_BUFFER_SIZE - offset);
+			idx_t to_write = MinValue<idx_t>(UnsafeNumericCast<idx_t>((end_ptr - buffer)), buffer_size - offset);
 			D_ASSERT(to_write > 0);
 			memcpy(data.get() + offset, buffer, to_write);
 			offset += to_write;
 			buffer += to_write;
-			if (offset == FILE_BUFFER_SIZE) {
+			if (offset == buffer_size) {
 				Flush();
 			}
 		}

--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -721,6 +721,20 @@
         "struct": "ErrorsAsJSONSetting"
     },
     {
+        "name": "experimental_group_commit",
+        "description": "EXPERIMENTAL: Batch the WAL fsync of concurrently committing transactions (group commit). Commits are acknowledged only after their WAL entries are durable, and are only published once durable.",
+        "type": "BOOLEAN",
+        "scope": "global",
+        "default_value": "false"
+    },
+    {
+        "name": "experimental_group_commit_delay",
+        "description": "EXPERIMENTAL: Maximum time in microseconds that a group commit leader waits for concurrently committing transactions to join its WAL fsync (-1 = automatic, scaled to the observed fsync duration, 0 = no wait). Only used with experimental_group_commit.",
+        "type": "BIGINT",
+        "scope": "global",
+        "default_value": "-1"
+    },
+    {
         "name": "experimental_metadata_reuse",
         "description": "EXPERIMENTAL: Re-use row group and table metadata when checkpointing.",
         "type": "BOOLEAN",

--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -721,20 +721,6 @@
         "struct": "ErrorsAsJSONSetting"
     },
     {
-        "name": "experimental_group_commit",
-        "description": "EXPERIMENTAL: Batch the WAL fsync of concurrently committing transactions (group commit). Commits are acknowledged only after their WAL entries are durable, and are only published once durable.",
-        "type": "BOOLEAN",
-        "scope": "global",
-        "default_value": "false"
-    },
-    {
-        "name": "experimental_group_commit_delay",
-        "description": "EXPERIMENTAL: Maximum time in microseconds that a group commit leader waits for concurrently committing transactions to join its WAL fsync (-1 = automatic, scaled to the observed fsync duration, 0 = no wait). Only used with experimental_group_commit.",
-        "type": "BIGINT",
-        "scope": "global",
-        "default_value": "-1"
-    },
-    {
         "name": "experimental_metadata_reuse",
         "description": "EXPERIMENTAL: Re-use row group and table metadata when checkpointing.",
         "type": "BOOLEAN",
@@ -858,6 +844,13 @@
         "scope": "global",
         "default_value": "30000",
         "struct": "GeometryMinimumShreddingSize"
+    },
+    {
+        "name": "group_commit_delay",
+        "description": "Maximum time in microseconds that a group commit leader waits for concurrently committing transactions to join its WAL fsync (-1 = automatic, scaled to the observed fsync duration, 0 = no wait).",
+        "type": "BIGINT",
+        "scope": "global",
+        "default_value": "-1"
     },
     {
         "name": "home_directory",

--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -1381,6 +1381,17 @@
         "default_value": "0"
     },
     {
+        "name": "wal_buffer_size",
+        "description": "The size of the write-ahead log write buffer that batches WAL data before it is pushed to the OS (e.g. 64KB). Takes effect on the next WAL created (after a checkpoint or on reopen).",
+        "type": "VARCHAR",
+        "scope": "global",
+        "internal_setting": "wal_buffer_size",
+        "custom_implementation": [
+            "set",
+            "get"
+        ]
+    },
+    {
         "name": "warnings_as_errors",
         "description": "Escalate all warnings to errors.",
         "type": "BOOLEAN",

--- a/src/execution/operator/schema/physical_create_index.cpp
+++ b/src/execution/operator/schema/physical_create_index.cpp
@@ -173,16 +173,12 @@ SinkFinalizeType PhysicalCreateIndex::Finalize(Pipeline &pipeline, Event &event,
 		catalog.Alter(context, *alter_table_info);
 	}
 
-	// Block deferred (group) commits on this table from being in-flight while we attach the new index: a commit that
-	// is durable in the WAL but not yet published must not interleave with the index list changing (see
-	// DataTableInfo::GetPublishGateExclusive). Scoped to this table's DataTableInfo. This must be acquired AFTER the
-	// catalog operations above, which can re-acquire the gate internally (it is not re-entrant).
+	// Attach the index to the live table. This takes the table's publish gate so the index-list change does not
+	// interleave a concurrent group commit's publish (see DataTable::AttachIndexToLiveTable). It must run AFTER the
+	// catalog operations above, which re-acquire the gate internally (it is not re-entrant).
 	// NOTE: this does NOT fix the pre-existing race where rows committed during the index build are missing from
 	// the new index - that race reproduces on upstream main and needs a separate fix in the index build protocol.
-	auto publish_gate = storage.GetDataTableInfo()->GetPublishGateExclusive();
-
-	// Add the index to the storage.
-	storage.AddIndex(std::move(bound_index));
+	storage.AttachIndexToLiveTable(std::move(bound_index));
 
 	return SinkFinalizeType::READY;
 }

--- a/src/execution/operator/schema/physical_create_index.cpp
+++ b/src/execution/operator/schema/physical_create_index.cpp
@@ -174,13 +174,14 @@ SinkFinalizeType PhysicalCreateIndex::Finalize(Pipeline &pipeline, Event &event,
 		catalog.Alter(context, *alter_table_info);
 	}
 
-	// Block deferred (group) commits from being in-flight while we attach the new index to the table: a deferred
-	// commit that is durable in the WAL but not yet published must not interleave with the index list changing
-	// (see DuckTransactionManager::BlockPendingCommits). This must be acquired AFTER the catalog operations above,
-	// which can re-acquire the gate internally (it is not re-entrant).
+	// Block deferred (group) commits on this table from being in-flight while we attach the new index: a commit that
+	// is durable in the WAL but not yet published must not interleave with the index list changing (see
+	// DuckTransactionManager::BlockPendingCommits). Scoped to this table's DataTableInfo. This must be acquired AFTER
+	// the catalog operations above, which can re-acquire the gate internally (it is not re-entrant).
 	// NOTE: this does NOT fix the pre-existing race where rows committed during the index build are missing from
 	// the new index - that race reproduces on upstream main and needs a separate fix in the index build protocol.
-	auto publish_gate = DuckTransactionManager::Get(table.ParentCatalog().GetAttached()).BlockPendingCommits();
+	auto publish_gate = DuckTransactionManager::Get(table.ParentCatalog().GetAttached())
+	                        .BlockPendingCommits(storage.GetDataTableInfo().get());
 
 	// Add the index to the storage.
 	storage.AddIndex(std::move(bound_index));

--- a/src/execution/operator/schema/physical_create_index.cpp
+++ b/src/execution/operator/schema/physical_create_index.cpp
@@ -7,9 +7,11 @@
 #include "duckdb/execution/index/bound_index.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/database_manager.hpp"
+#include "duckdb/main/attached_database.hpp"
 #include "duckdb/storage/table/append_state.hpp"
 #include "duckdb/storage/table/data_table_info.hpp"
 #include "duckdb/storage/storage_manager.hpp"
+#include "duckdb/transaction/duck_transaction_manager.hpp"
 
 namespace duckdb {
 
@@ -171,6 +173,14 @@ SinkFinalizeType PhysicalCreateIndex::Finalize(Pipeline &pipeline, Event &event,
 		auto &catalog = Catalog::GetCatalog(context, info->GetQualifiedName().Catalog());
 		catalog.Alter(context, *alter_table_info);
 	}
+
+	// Block deferred (group) commits from being in-flight while we attach the new index to the table: a deferred
+	// commit that is durable in the WAL but not yet published must not interleave with the index list changing
+	// (see DuckTransactionManager::BlockPendingCommits). This must be acquired AFTER the catalog operations above,
+	// which can re-acquire the gate internally (it is not re-entrant).
+	// NOTE: this does NOT fix the pre-existing race where rows committed during the index build are missing from
+	// the new index - that race reproduces on upstream main and needs a separate fix in the index build protocol.
+	auto publish_gate = DuckTransactionManager::Get(table.ParentCatalog().GetAttached()).BlockPendingCommits();
 
 	// Add the index to the storage.
 	storage.AddIndex(std::move(bound_index));

--- a/src/execution/operator/schema/physical_create_index.cpp
+++ b/src/execution/operator/schema/physical_create_index.cpp
@@ -173,11 +173,9 @@ SinkFinalizeType PhysicalCreateIndex::Finalize(Pipeline &pipeline, Event &event,
 		catalog.Alter(context, *alter_table_info);
 	}
 
-	// Attach the index to the live table. This takes the table's publish gate so the index-list change does not
-	// interleave a concurrent group commit's publish (see DataTable::AttachIndexToLiveTable). It must run AFTER the
-	// catalog operations above, which re-acquire the gate internally (it is not re-entrant).
-	// NOTE: this does NOT fix the pre-existing race where rows committed during the index build are missing from
-	// the new index - that race reproduces on upstream main and needs a separate fix in the index build protocol.
+	// Attach the index to the live table (see DataTable::AttachIndexToLiveTable for the gate). Must run AFTER the
+	// catalog operations above, which re-acquire the gate internally (not re-entrant).
+	// NOTE: does not fix the pre-existing race where rows committed during the build are missing from the new index.
 	storage.AttachIndexToLiveTable(std::move(bound_index));
 
 	return SinkFinalizeType::READY;

--- a/src/execution/operator/schema/physical_create_index.cpp
+++ b/src/execution/operator/schema/physical_create_index.cpp
@@ -11,7 +11,6 @@
 #include "duckdb/storage/table/append_state.hpp"
 #include "duckdb/storage/table/data_table_info.hpp"
 #include "duckdb/storage/storage_manager.hpp"
-#include "duckdb/transaction/duck_transaction_manager.hpp"
 
 namespace duckdb {
 
@@ -176,12 +175,11 @@ SinkFinalizeType PhysicalCreateIndex::Finalize(Pipeline &pipeline, Event &event,
 
 	// Block deferred (group) commits on this table from being in-flight while we attach the new index: a commit that
 	// is durable in the WAL but not yet published must not interleave with the index list changing (see
-	// DuckTransactionManager::BlockPendingCommits). Scoped to this table's DataTableInfo. This must be acquired AFTER
-	// the catalog operations above, which can re-acquire the gate internally (it is not re-entrant).
+	// DataTableInfo::GetPublishGateExclusive). Scoped to this table's DataTableInfo. This must be acquired AFTER the
+	// catalog operations above, which can re-acquire the gate internally (it is not re-entrant).
 	// NOTE: this does NOT fix the pre-existing race where rows committed during the index build are missing from
 	// the new index - that race reproduces on upstream main and needs a separate fix in the index build protocol.
-	auto publish_gate = DuckTransactionManager::Get(table.ParentCatalog().GetAttached())
-	                        .BlockPendingCommits(storage.GetDataTableInfo().get());
+	auto publish_gate = storage.GetDataTableInfo()->GetPublishGateExclusive();
 
 	// Add the index to the storage.
 	storage.AddIndex(std::move(bound_index));

--- a/src/include/duckdb/common/serializer/buffered_file_writer.hpp
+++ b/src/include/duckdb/common/serializer/buffered_file_writer.hpp
@@ -40,6 +40,10 @@ public:
 	DUCKDB_API void Close();
 	//! Flush all changes and fsync the file to disk
 	DUCKDB_API void Sync();
+	//! Fsync the file to disk without flushing the in-memory buffer.
+	//! Unlike the other methods, this is safe to call concurrently with WriteData/Flush from another thread:
+	//! it only syncs data that was already pushed to the operating system via Flush().
+	DUCKDB_API void SyncData();
 	//! Flush the buffer to the file (without sync)
 	DUCKDB_API void Flush();
 	//! Returns the current size of the file

--- a/src/include/duckdb/common/serializer/buffered_file_writer.hpp
+++ b/src/include/duckdb/common/serializer/buffered_file_writer.hpp
@@ -24,10 +24,12 @@ public:
 	//! writing past the initial threshold. The optional QueryContext is used to attribute
 	//! the written bytes to the query's I/O metrics.
 	DUCKDB_API BufferedFileWriter(FileSystem &fs, const string &path, FileOpenFlags open_flags = DEFAULT_OPEN_FLAGS,
-	                              QueryContext context = QueryContext());
+	                              QueryContext context = QueryContext(), idx_t buffer_size = FILE_BUFFER_SIZE);
 
 	FileSystem &fs;
 	string path;
+	//! Size of the in-memory buffer (bytes) - data is flushed to the OS once it fills
+	idx_t buffer_size;
 	unsafe_unique_array<data_t> data;
 	idx_t offset;
 	idx_t total_written;

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -79,6 +79,8 @@ struct DBConfigOptions {
 	AccessMode access_mode = AccessMode::AUTOMATIC;
 	//! Checkpoint when WAL reaches this size (default: 16MiB)
 	idx_t checkpoint_wal_size = 1 << 24;
+	//! Size of the write-ahead log write buffer in bytes (default: 4096 == FILE_BUFFER_SIZE; the two must agree)
+	idx_t wal_buffer_size = 4096;
 	//! Whether extensions should be loaded on start-up
 	bool load_extensions = true;
 	//! The maximum memory used by the database system (in bytes). Default: 80% of System available memory

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -79,8 +79,7 @@ struct DBConfigOptions {
 	AccessMode access_mode = AccessMode::AUTOMATIC;
 	//! Checkpoint when WAL reaches this size (default: 16MiB)
 	idx_t checkpoint_wal_size = 1 << 24;
-	//! Default WAL write-buffer size; a static_assert in custom_settings.cpp keeps it equal to FILE_BUFFER_SIZE, so
-	//! the WAL's default buffer matches every other BufferedFileWriter (config.hpp cannot include the writer header).
+	//! Default WAL write-buffer size; a static_assert in custom_settings.cpp keeps it equal to FILE_BUFFER_SIZE.
 	static constexpr idx_t DEFAULT_WAL_BUFFER_SIZE = 4096;
 	//! Size of the write-ahead log write buffer in bytes
 	idx_t wal_buffer_size = DEFAULT_WAL_BUFFER_SIZE;

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -79,8 +79,11 @@ struct DBConfigOptions {
 	AccessMode access_mode = AccessMode::AUTOMATIC;
 	//! Checkpoint when WAL reaches this size (default: 16MiB)
 	idx_t checkpoint_wal_size = 1 << 24;
-	//! Size of the write-ahead log write buffer in bytes (default: 4096 == FILE_BUFFER_SIZE; the two must agree)
-	idx_t wal_buffer_size = 4096;
+	//! Default WAL write-buffer size; a static_assert in custom_settings.cpp keeps it equal to FILE_BUFFER_SIZE, so
+	//! the WAL's default buffer matches every other BufferedFileWriter (config.hpp cannot include the writer header).
+	static constexpr idx_t DEFAULT_WAL_BUFFER_SIZE = 4096;
+	//! Size of the write-ahead log write buffer in bytes
+	idx_t wal_buffer_size = DEFAULT_WAL_BUFFER_SIZE;
 	//! Whether extensions should be loaded on start-up
 	bool load_extensions = true;
 	//! The maximum memory used by the database system (in bytes). Default: 80% of System available memory

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -2028,6 +2028,18 @@ struct WalAutocheckpointEntriesSetting {
 	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
+struct WalBufferSizeSetting {
+	using RETURN_TYPE = string;
+	static constexpr const char *Name = "wal_buffer_size";
+	static constexpr const char *Description =
+	    "The size of the write-ahead log write buffer that batches WAL data before it is pushed to the OS (e.g. 64KB). "
+	    "Takes effect on the next WAL created (after a checkpoint or on reopen).";
+	static constexpr const char *InputType = "VARCHAR";
+	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
+	static Value GetSetting(const ClientContext &context);
+};
+
 struct WarningsAsErrorsSetting {
 	using RETURN_TYPE = bool;
 	static constexpr const char *Name = "warnings_as_errors";

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -1105,31 +1105,6 @@ struct ErrorsAsJSONSetting {
 	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
-struct ExperimentalGroupCommitSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "experimental_group_commit";
-	static constexpr const char *Description =
-	    "EXPERIMENTAL: Batch the WAL fsync of concurrently committing transactions (group commit). Commits are "
-	    "acknowledged only after their WAL entries are durable, and are only published once durable.";
-	static constexpr const char *InputType = "BOOLEAN";
-	static constexpr const char *DefaultValue = "false";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
-};
-
-struct ExperimentalGroupCommitDelaySetting {
-	using RETURN_TYPE = int64_t;
-	static constexpr const char *Name = "experimental_group_commit_delay";
-	static constexpr const char *Description =
-	    "EXPERIMENTAL: Maximum time in microseconds that a group commit leader waits for concurrently committing "
-	    "transactions to join its WAL fsync (-1 = automatic, scaled to the observed fsync duration, 0 = no wait). Only "
-	    "used with experimental_group_commit.";
-	static constexpr const char *InputType = "BIGINT";
-	static constexpr const char *DefaultValue = "-1";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
-};
-
 struct ExperimentalMetadataReuseSetting {
 	using RETURN_TYPE = bool;
 	static constexpr const char *Name = "experimental_metadata_reuse";
@@ -1289,6 +1264,18 @@ struct GeometryMinimumShreddingSize {
 	                                           "to disable entirely. Defaults to 1/4th of a rowgroup";
 	static constexpr const char *InputType = "BIGINT";
 	static constexpr const char *DefaultValue = "30000";
+	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
+	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+};
+
+struct GroupCommitDelaySetting {
+	using RETURN_TYPE = int64_t;
+	static constexpr const char *Name = "group_commit_delay";
+	static constexpr const char *Description =
+	    "Maximum time in microseconds that a group commit leader waits for concurrently committing transactions to "
+	    "join its WAL fsync (-1 = automatic, scaled to the observed fsync duration, 0 = no wait).";
+	static constexpr const char *InputType = "BIGINT";
+	static constexpr const char *DefaultValue = "-1";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
 	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -1105,6 +1105,31 @@ struct ErrorsAsJSONSetting {
 	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
+struct ExperimentalGroupCommitSetting {
+	using RETURN_TYPE = bool;
+	static constexpr const char *Name = "experimental_group_commit";
+	static constexpr const char *Description =
+	    "EXPERIMENTAL: Batch the WAL fsync of concurrently committing transactions (group commit). Commits are "
+	    "acknowledged only after their WAL entries are durable, and are only published once durable.";
+	static constexpr const char *InputType = "BOOLEAN";
+	static constexpr const char *DefaultValue = "false";
+	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
+	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+};
+
+struct ExperimentalGroupCommitDelaySetting {
+	using RETURN_TYPE = int64_t;
+	static constexpr const char *Name = "experimental_group_commit_delay";
+	static constexpr const char *Description =
+	    "EXPERIMENTAL: Maximum time in microseconds that a group commit leader waits for concurrently committing "
+	    "transactions to join its WAL fsync (-1 = automatic, scaled to the observed fsync duration, 0 = no wait). Only "
+	    "used with experimental_group_commit.";
+	static constexpr const char *InputType = "BIGINT";
+	static constexpr const char *DefaultValue = "-1";
+	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
+	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+};
+
 struct ExperimentalMetadataReuseSetting {
 	using RETURN_TYPE = bool;
 	static constexpr const char *Name = "experimental_metadata_reuse";

--- a/src/include/duckdb/storage/checkpoint/checkpoint_options.hpp
+++ b/src/include/duckdb/storage/checkpoint/checkpoint_options.hpp
@@ -14,6 +14,8 @@
 
 namespace duckdb {
 
+class StorageLockKey;
+
 struct CheckpointOptions {
 	CheckpointOptions()
 	    : wal_action(CheckpointWALAction::DONT_DELETE_WAL), action(CheckpointAction::CHECKPOINT_IF_REQUIRED),
@@ -24,9 +26,9 @@ struct CheckpointOptions {
 	CheckpointAction action;
 	CheckpointType type;
 	transaction_t transaction_id;
-	//! The WAL lock - in case we are holding it during the entire checkpoint.
+	//! The (exclusive) WAL lock - in case we are holding it during the entire checkpoint.
 	//! This is only required if we are doing a checkpoint instead of writing to the WAL
-	optional_ptr<unique_lock<mutex>> wal_lock;
+	optional_ptr<StorageLockKey> wal_lock;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/data_table.hpp
+++ b/src/include/duckdb/storage/data_table.hpp
@@ -307,10 +307,8 @@ public:
 	              IndexStorageInfo index_info);
 	//! AddIndex moves an index to this table's index list.
 	void AddIndex(unique_ptr<Index> index);
-	//! Attach a freshly built index to a live table (CREATE INDEX). Takes this table's publish gate EXCLUSIVELY so the
-	//! index-list change does not interleave a concurrent group commit's publish, then adds the index. Must NOT be
-	//! called while already holding the gate (it is not re-entrant) - in particular, after a catalog operation that
-	//! re-acquires the gate internally.
+	//! Attach a freshly built index to a live table (CREATE INDEX): takes the publish gate to exclude concurrent
+	//! group-commit publishes, then adds the index. Not re-entrant (never call while already holding the gate).
 	void AttachIndexToLiveTable(unique_ptr<Index> index);
 
 	//! Returns a list of the partition stats

--- a/src/include/duckdb/storage/data_table.hpp
+++ b/src/include/duckdb/storage/data_table.hpp
@@ -307,6 +307,11 @@ public:
 	              IndexStorageInfo index_info);
 	//! AddIndex moves an index to this table's index list.
 	void AddIndex(unique_ptr<Index> index);
+	//! Attach a freshly built index to a live table (CREATE INDEX). Takes this table's publish gate EXCLUSIVELY so the
+	//! index-list change does not interleave a concurrent group commit's publish, then adds the index. Must NOT be
+	//! called while already holding the gate (it is not re-entrant) - in particular, after a catalog operation that
+	//! re-acquires the gate internally.
+	void AttachIndexToLiveTable(unique_ptr<Index> index);
 
 	//! Returns a list of the partition stats
 	vector<PartitionStatistics> GetPartitionStats(ClientContext &context);

--- a/src/include/duckdb/storage/storage_manager.hpp
+++ b/src/include/duckdb/storage/storage_manager.hpp
@@ -96,10 +96,6 @@ public:
 	void IncrementWALEntriesCount();
 	//! Gets the WAL of the StorageManager, or nullptr, if there is no WAL.
 	optional_ptr<WriteAheadLog> GetWAL();
-	//! Gets a shared reference to the WAL that keeps it alive even if a concurrent checkpoint swaps the WAL.
-	//! Used for group commit: a committer must be able to finish WriteAheadLog::SyncUpTo after releasing the WAL
-	//! lock. Must be called while holding the WAL lock.
-	shared_ptr<WriteAheadLog> GetWALShared();
 	//! Write that we started a checkpoint to the WAL if there is one - returns whether or not there is a WAL
 	bool WALStartCheckpoint(MetaBlockPointer meta_block, CheckpointOptions &options,
 	                        ActiveCheckpointWrapper &active_checkpoint);
@@ -193,9 +189,9 @@ protected:
 	string path;
 	//! The WAL path
 	string wal_path;
-	//! The WriteAheadLog of the storage manager.
-	//! Held as shared_ptr because committing transactions can hold a reference across a concurrent WAL swap
-	//! (see GetWALShared).
+	//! The WriteAheadLog of the storage manager. Held as shared_ptr so the checkpoint can swap it (wal.reset() +
+	//! re-instantiate) while the old object is dropped; committers hold the WAL lock SHARED across their fsync, so a
+	//! swap (which needs the lock EXCLUSIVE) cannot race an in-flight commit.
 	shared_ptr<WriteAheadLog> wal;
 	//! Read-write lock controlling access to the WAL. Group-commit data writes take it SHARED (they can run
 	//! concurrently and only need the WAL structure to be stable); checkpoints and catalog-changing commits take it

--- a/src/include/duckdb/storage/storage_manager.hpp
+++ b/src/include/duckdb/storage/storage_manager.hpp
@@ -37,6 +37,19 @@ public:
 	virtual void RevertCommit() = 0;
 	// Make the commit persistent
 	virtual void FlushCommit() = 0;
+	//! Write only the WAL flush marker that completes the commit in the WAL, WITHOUT making it durable - the
+	//! caller must fsync via WriteAheadLog::SyncUpTo before acknowledging the commit (group commit). Returns the
+	//! WAL offset that SyncUpTo() must reach to make this commit durable (the offset of the flush marker).
+	//! The default implementation falls back to the fully durable FlushCommit.
+	virtual idx_t FlushCommitMarker() {
+		FlushCommit();
+		return 0;
+	}
+	//! Mark that the database file sync for optimistically written row group data is deferred to the WAL sync
+	//! leader (group commit), instead of being performed by the committing transaction itself. Must be called
+	//! before the flush marker is written. The default implementation ignores this.
+	virtual void DeferBlockSync() {
+	}
 
 	virtual void AddRowGroupData(DataTable &table, idx_t start_index, idx_t count,
 	                             unique_ptr<PersistentCollectionData> row_group_data) = 0;
@@ -82,6 +95,10 @@ public:
 	void IncrementWALEntriesCount();
 	//! Gets the WAL of the StorageManager, or nullptr, if there is no WAL.
 	optional_ptr<WriteAheadLog> GetWAL();
+	//! Gets a shared reference to the WAL that keeps it alive even if a concurrent checkpoint swaps the WAL.
+	//! Used for group commit: a committer must be able to finish WriteAheadLog::SyncUpTo after releasing the WAL
+	//! lock. Must be called while holding the WAL lock.
+	shared_ptr<WriteAheadLog> GetWALShared();
 	//! Write that we started a checkpoint to the WAL if there is one - returns whether or not there is a WAL
 	bool WALStartCheckpoint(MetaBlockPointer meta_block, CheckpointOptions &options,
 	                        ActiveCheckpointWrapper &active_checkpoint);
@@ -168,8 +185,10 @@ protected:
 	string path;
 	//! The WAL path
 	string wal_path;
-	//! The WriteAheadLog of the storage manager
-	unique_ptr<WriteAheadLog> wal;
+	//! The WriteAheadLog of the storage manager.
+	//! Held as shared_ptr because committing transactions can hold a reference across a concurrent WAL swap
+	//! (see GetWALShared).
+	shared_ptr<WriteAheadLog> wal;
 	//! Mutex used to control writes to the WAL
 	mutex wal_lock;
 	//! Whether or not the database is opened in read-only mode

--- a/src/include/duckdb/storage/storage_manager.hpp
+++ b/src/include/duckdb/storage/storage_manager.hpp
@@ -189,10 +189,10 @@ protected:
 	string path;
 	//! The WAL path
 	string wal_path;
-	//! The WriteAheadLog of the storage manager. Held as shared_ptr so the checkpoint can swap it (wal.reset() +
-	//! re-instantiate) while the old object is dropped; committers hold the WAL lock SHARED across their fsync, so a
-	//! swap (which needs the lock EXCLUSIVE) cannot race an in-flight commit.
-	shared_ptr<WriteAheadLog> wal;
+	//! The WriteAheadLog of the storage manager. The checkpoint can swap it (wal.reset() + re-instantiate); committers
+	//! hold the WAL lock SHARED across their fsync, so a swap (which needs the lock EXCLUSIVE) cannot race an in-flight
+	//! commit - hence no shared ownership is required.
+	unique_ptr<WriteAheadLog> wal;
 	//! Read-write lock controlling access to the WAL. Group-commit data writes take it SHARED (they can run
 	//! concurrently and only need the WAL structure to be stable); checkpoints and catalog-changing commits take it
 	//! EXCLUSIVE. The exclusive acquisition waits for all shared holders, which replaces the explicit

--- a/src/include/duckdb/storage/storage_manager.hpp
+++ b/src/include/duckdb/storage/storage_manager.hpp
@@ -14,6 +14,7 @@
 #include "duckdb/storage/database_size.hpp"
 #include "duckdb/storage/checkpoint/checkpoint_options.hpp"
 #include "duckdb/storage/storage_options.hpp"
+#include "duckdb/storage/storage_lock.hpp"
 
 namespace duckdb {
 class ActiveCheckpointWrapper;
@@ -103,9 +104,16 @@ public:
 	bool WALStartCheckpoint(MetaBlockPointer meta_block, CheckpointOptions &options,
 	                        ActiveCheckpointWrapper &active_checkpoint);
 	//! Finishes a checkpoint
-	void WALFinishCheckpoint(unique_lock<mutex> &wal_lock);
-	// Get the WAL lock
-	unique_lock<mutex> GetWALLock();
+	void WALFinishCheckpoint(StorageLockKey &wal_lock);
+	//! Get the WAL lock in shared mode (group commit data path) - many committers can hold it concurrently.
+	unique_ptr<StorageLockKey> GetWALLockShared();
+	//! Get the WAL lock in exclusive mode (checkpoints and catalog-changing commits) - waits for all shared
+	//! holders (in-flight commits) to finish, which subsumes the old pending-commit drain.
+	unique_ptr<StorageLockKey> GetWALLockExclusive();
+	//! Serializes a single committer's WAL entry+marker writes against other (shared) committers, so each
+	//! transaction's WAL entries are contiguous (the shared WAL lock alone allows them to interleave). Held only
+	//! across the entry/marker append, NOT across the fsync, so group-commit fsync batching is preserved.
+	unique_lock<mutex> GetWALAppendLock();
 
 	//! Returns the database file path
 	string GetDBPath() const {
@@ -189,8 +197,13 @@ protected:
 	//! Held as shared_ptr because committing transactions can hold a reference across a concurrent WAL swap
 	//! (see GetWALShared).
 	shared_ptr<WriteAheadLog> wal;
-	//! Mutex used to control writes to the WAL
-	mutex wal_lock;
+	//! Read-write lock controlling access to the WAL. Group-commit data writes take it SHARED (they can run
+	//! concurrently and only need the WAL structure to be stable); checkpoints and catalog-changing commits take it
+	//! EXCLUSIVE. The exclusive acquisition waits for all shared holders, which replaces the explicit
+	//! pending-commit drain that previously guarded WAL swaps / catalog version attachment.
+	StorageLock wal_lock;
+	//! Serializes WAL entry+marker appends among concurrent (shared) committers - see GetWALAppendLock().
+	mutex wal_append_lock;
 	//! Whether or not the database is opened in read-only mode
 	bool read_only;
 	//! When loading a database, we do not yet set the wal-field. Therefore, GetWriteAheadLog must

--- a/src/include/duckdb/storage/table/chunk_info.hpp
+++ b/src/include/duckdb/storage/table/chunk_info.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb/execution/index/index_pointer.hpp"
 #include "duckdb/common/enums/scan_options.hpp"
+#include "duckdb/common/vector_size.hpp"
 
 namespace duckdb {
 class RowGroup;
@@ -49,7 +50,9 @@ public:
 
 	virtual bool HasDeletes(transaction_t transaction_id = MAX_TRANSACTION_ID) const = 0;
 
-	virtual void Write(WriteStream &writer, transaction_t transaction_id) const;
+	//! Write the version info for this vector. `count` is the number of rows this vector holds (the last vector of a
+	//! row group may be partial); a partial vector is never written as an (un-appendable) ChunkConstantInfo.
+	virtual void Write(WriteStream &writer, transaction_t transaction_id, idx_t count = STANDARD_VECTOR_SIZE) const;
 	static unique_ptr<ChunkInfo> Read(FixedSizeAllocator &allocator, ReadStream &reader);
 
 public:
@@ -89,7 +92,7 @@ public:
 
 	bool HasDeletes(transaction_t transaction_id = MAX_TRANSACTION_ID) const override;
 
-	void Write(WriteStream &writer, transaction_t transaction_id) const override;
+	void Write(WriteStream &writer, transaction_t transaction_id, idx_t count = STANDARD_VECTOR_SIZE) const override;
 	static unique_ptr<ChunkInfo> Read(ReadStream &reader);
 
 private:
@@ -127,7 +130,7 @@ public:
 	bool HasConstantInsertionId() const;
 	transaction_t ConstantInsertId() const;
 
-	void Write(WriteStream &writer, transaction_t transaction_id) const override;
+	void Write(WriteStream &writer, transaction_t transaction_id, idx_t count = STANDARD_VECTOR_SIZE) const override;
 	static unique_ptr<ChunkInfo> Read(FixedSizeAllocator &allocator, ReadStream &reader);
 
 private:

--- a/src/include/duckdb/storage/table/data_table_info.hpp
+++ b/src/include/duckdb/storage/table/data_table_info.hpp
@@ -47,6 +47,16 @@ public:
 	unique_ptr<StorageLockKey> GetSharedLock() {
 		return checkpoint_lock.GetSharedLock();
 	}
+	//! Publish gate: a group commit that modifies this table holds it SHARED across publish (which applies its
+	//! changes into this table's indexes); a DDL that mutates this table's catalog entry / index list takes it
+	//! EXCLUSIVE. This scopes the DDL-vs-commit exclusion to the individual table, so a DDL on one table does not
+	//! block commits to other tables. Kept separate from checkpoint_lock so DDL does not serialize against checkpoints.
+	unique_ptr<StorageLockKey> GetPublishGateShared() {
+		return publish_gate.GetSharedLock();
+	}
+	unique_ptr<StorageLockKey> GetPublishGateExclusive() {
+		return publish_gate.GetExclusiveLock();
+	}
 	bool AppendRequiresNewRowGroup(RowGroupCollection &collection, transaction_t checkpoint_id);
 	optional_idx CheckpointRowGroupCount(const CheckpointOptions &options) const;
 	void VerifyIndexBuffers();
@@ -72,6 +82,8 @@ private:
 	vector<IndexStorageInfo> index_storage_infos;
 	//! Lock held while checkpointing
 	StorageLock checkpoint_lock;
+	//! Gate excluding DDL on this table from concurrent group-commit publishes (see GetPublishGateShared)
+	StorageLock publish_gate;
 	//! The last seen checkpoint while doing a concurrent operation, if any
 	optional_idx last_seen_checkpoint;
 	//! The amount of row groups the checkpoint is processing

--- a/src/include/duckdb/storage/table/data_table_info.hpp
+++ b/src/include/duckdb/storage/table/data_table_info.hpp
@@ -47,10 +47,8 @@ public:
 	unique_ptr<StorageLockKey> GetSharedLock() {
 		return checkpoint_lock.GetSharedLock();
 	}
-	//! Publish gate: a group commit that modifies this table holds it SHARED across publish (which applies its
-	//! changes into this table's indexes); a DDL that mutates this table's catalog entry / index list takes it
-	//! EXCLUSIVE. This scopes the DDL-vs-commit exclusion to the individual table, so a DDL on one table does not
-	//! block commits to other tables. Kept separate from checkpoint_lock so DDL does not serialize against checkpoints.
+	//! Publish gate: group commits touching this table hold it SHARED through publish; DDL on this table takes it
+	//! EXCLUSIVE. Per-table, so DDL on one table doesn't block others; separate from checkpoint_lock.
 	unique_ptr<StorageLockKey> GetPublishGateShared() {
 		return publish_gate.GetSharedLock();
 	}

--- a/src/include/duckdb/storage/table/row_group.hpp
+++ b/src/include/duckdb/storage/table/row_group.hpp
@@ -89,7 +89,6 @@ struct RowGroupWriteData {
 	vector<unique_ptr<ColumnCheckpointState>> states;
 	vector<BaseStatistics> statistics;
 	RowGroupWriteAction write_action = RowGroupWriteAction::FULLY_CHECKPOINT_ROW_GROUP;
-	optional_idx write_count;
 };
 
 class RowGroup : public SegmentBase<RowGroup> {
@@ -236,8 +235,10 @@ public:
 
 	static FilterPropagateResult CheckRowIdFilter(const TableFilter &filter, idx_t beg_row, idx_t end_row);
 	idx_t GetColumnCount() const;
+	//! Whether any loaded column has an in-memory UpdateSegment (i.e. this row group has been updated)
+	bool HasUpdates() const;
 
-	vector<MetaBlockPointer> CheckpointDeletes(RowGroupWriter &writer);
+	vector<MetaBlockPointer> CheckpointDeletes(RowGroupWriter &writer, idx_t row_count);
 
 	//! Direct accessors, fall outside of general use but can be useful to some extensions
 	ColumnData &GetRawColumnData(const StorageIndex &c) const;

--- a/src/include/duckdb/storage/table/row_version_manager.hpp
+++ b/src/include/duckdb/storage/table/row_version_manager.hpp
@@ -38,7 +38,9 @@ public:
 	idx_t DeleteRows(idx_t vector_idx, transaction_t transaction_id, row_t rows[], idx_t count);
 	void CommitDelete(idx_t vector_idx, transaction_t commit_id, const DeleteInfo &info);
 
-	vector<MetaBlockPointer> Checkpoint(RowGroupWriter &writer);
+	//! Checkpoint the version info. `row_count` is the row group's row count; it is used to size the last (partial)
+	//! vector so a partially-filled vector is never written as an (un-appendable) ChunkConstantInfo.
+	vector<MetaBlockPointer> Checkpoint(RowGroupWriter &writer, idx_t row_count);
 	static shared_ptr<RowVersionManager> Deserialize(MetaBlockPointer delete_pointer, MetadataManager &manager);
 
 	bool HasUnserializedChanges();

--- a/src/include/duckdb/storage/write_ahead_log.hpp
+++ b/src/include/duckdb/storage/write_ahead_log.hpp
@@ -168,7 +168,8 @@ protected:
 	//! Serializes pushes of the in-memory WAL buffer to the OS against writes into it (entry appends, flush
 	//! markers), truncation, header writes, and updates of written_offset - see LockFlush(). Distinct from the
 	//! storage manager WAL lock so the sync leader's batched push does not deadlock pending-commit drains.
-	mutex flush_lock;
+	//! mutable so the const GetTotalWritten() reader can serialize against the sync leader's buffer push.
+	mutable mutex flush_lock;
 
 	//! Group commit state.
 	//! Offsets are logical byte counters (BufferedFileWriter::GetTotalWritten), they increase monotonically

--- a/src/include/duckdb/storage/write_ahead_log.hpp
+++ b/src/include/duckdb/storage/write_ahead_log.hpp
@@ -187,10 +187,10 @@ protected:
 	idx_t sync_waiters = 0;
 	//! Whether concurrent commit activity was detected during the last fsync - if set, the next sync leader
 	//! briefly waits for concurrent committers to append their flush markers before fsync-ing (micro-batching).
-	//! The maximum wait is controlled by the experimental_group_commit_delay setting.
+	//! The maximum wait is controlled by the group_commit_delay setting.
 	bool batch_commits = false;
 	//! Exponentially weighted moving average of the observed fsync duration in microseconds - used to scale the
-	//! micro-batching window when experimental_group_commit_delay is -1 (automatic).
+	//! micro-batching window when group_commit_delay is -1 (automatic).
 	atomic<idx_t> sync_duration_micros {0};
 	//! Highest marker offset whose commit references optimistically written row group data (group commit only).
 	//! Updated in WriteFlushMarker BEFORE written_offset advances, so that any sync leader whose fsync covers

--- a/src/include/duckdb/storage/write_ahead_log.hpp
+++ b/src/include/duckdb/storage/write_ahead_log.hpp
@@ -16,6 +16,8 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/storage/block.hpp"
 
+#include <condition_variable>
+
 namespace duckdb {
 
 struct AlterInfo;
@@ -119,7 +121,38 @@ public:
 	//! Truncate the WAL to a previous size, and clear anything currently set in the writer.
 	//! Used during RevertCommit.
 	void Truncate(idx_t size);
+	//! Write a WAL_FLUSH marker, push all buffered data to the operating system and fsync (fully durable).
 	void Flush();
+	//! Write a WAL_FLUSH marker. Returns the WAL offset that a subsequent SyncUpTo() call must reach to make the
+	//! data durable. The caller must hold the WAL lock of the storage manager.
+	//! If push_to_os is true the buffered data is pushed to the operating system inline (the synchronous commit
+	//! path). If false, only the in-memory buffer is advanced and the push to the OS is deferred to the group
+	//! commit sync leader (SyncUpTo with leader_pushes_batch), so that a single write() covers the whole batch -
+	//! this matters on network storage (e.g. EFS) where the per-commit write is itself a multi-ms round-trip.
+	//! If requires_block_sync is set, the commit completed by this marker references optimistically written
+	//! row group data: the database file is fsynced (once, batched) by the sync leader BEFORE any WAL fsync
+	//! that makes this marker durable, so that the referenced blocks are always durable first.
+	idx_t WriteFlushMarker(bool requires_block_sync = false, bool push_to_os = true);
+	//! Ensure the WAL is fsynced at least up to the given target offset (as returned by WriteFlushMarker).
+	//! Safe to call without holding the WAL lock: concurrent callers elect a leader whose single fsync
+	//! covers all data pushed to the operating system so far (group commit).
+	//! wait_for_batch enables the adaptive micro-batching wait - pass false when the caller holds the WAL lock
+	//! (no concurrent appends can arrive, so there is nothing to wait for).
+	//! leader_pushes_batch makes the sync leader push the buffered WAL data to the OS (one write() for the whole
+	//! batch) before its fsync, under the WAL flush_lock - NOT the storage manager WAL lock. Pass true only when the
+	//! caller does NOT hold the WAL lock and the markers were written with push_to_os=false (the deferred path).
+	void SyncUpTo(idx_t target_offset, bool wait_for_batch, bool leader_pushes_batch = false);
+	//! The WAL offset (logical bytes written) that has been pushed to the operating system so far
+	idx_t GetWrittenOffset() const {
+		return written_offset;
+	}
+	//! Acquire the WAL flush lock. Serializes pushes of the in-memory WAL buffer to the OS (the group commit sync
+	//! leader's batched write, and the synchronous push-to-OS) against all writes into that buffer (entry appends,
+	//! flush markers), truncation, and header writes. Distinct from the storage manager WAL lock so the sync
+	//! leader's push cannot deadlock a checkpoint / catalog commit / synchronous commit that holds the WAL lock.
+	unique_lock<mutex> LockFlush() {
+		return unique_lock<mutex>(flush_lock);
+	}
 	//! Increment the WAL entry count, which is used for the auto-checkpoint threshold.
 	void IncrementWALEntriesCount();
 	void WriteCheckpoint(MetaBlockPointer meta_block);
@@ -131,6 +164,41 @@ protected:
 	string wal_path;
 	atomic<WALInitState> init_state;
 	optional_idx checkpoint_iteration;
+
+	//! Serializes pushes of the in-memory WAL buffer to the OS against writes into it (entry appends, flush
+	//! markers), truncation, header writes, and updates of written_offset - see LockFlush(). Distinct from the
+	//! storage manager WAL lock so the sync leader's batched push does not deadlock pending-commit drains.
+	mutex flush_lock;
+
+	//! Group commit state.
+	//! Offsets are logical byte counters (BufferedFileWriter::GetTotalWritten), they increase monotonically
+	//! across committed flush markers and are not affected by truncation of reverted (uncommitted) entries.
+	//! Logical bytes pushed to the operating system so far - updated under flush_lock together with the buffer push.
+	atomic<idx_t> written_offset {0};
+	//! Protects synced_offset and sync_in_progress.
+	mutex sync_mutex;
+	//! Signalled when a leader finishes an fsync.
+	std::condition_variable sync_cv;
+	//! Logical bytes that are durable on disk.
+	idx_t synced_offset = 0;
+	//! Whether a sync leader is currently performing an fsync.
+	bool sync_in_progress = false;
+	//! The number of threads currently waiting for an fsync to complete.
+	idx_t sync_waiters = 0;
+	//! Whether concurrent commit activity was detected during the last fsync - if set, the next sync leader
+	//! briefly waits for concurrent committers to append their flush markers before fsync-ing (micro-batching).
+	//! The maximum wait is controlled by the experimental_group_commit_delay setting.
+	bool batch_commits = false;
+	//! Exponentially weighted moving average of the observed fsync duration in microseconds - used to scale the
+	//! micro-batching window when experimental_group_commit_delay is -1 (automatic).
+	atomic<idx_t> sync_duration_micros {0};
+	//! Highest marker offset whose commit references optimistically written row group data (group commit only).
+	//! Updated in WriteFlushMarker BEFORE written_offset advances, so that any sync leader whose fsync covers
+	//! the marker observes the block sync requirement.
+	atomic<idx_t> block_sync_pending_offset {0};
+	//! Marker offset up to which the referenced row group blocks are known durable in the database file.
+	//! Only updated by sync leaders (serialized via sync_in_progress).
+	atomic<idx_t> block_synced_offset {0};
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/transaction/commit_state.hpp
+++ b/src/include/duckdb/transaction/commit_state.hpp
@@ -27,6 +27,7 @@ class ClientContext;
 
 struct DataTableInfo;
 class DataTable;
+class DuckTableEntry;
 struct DeleteInfo;
 struct UpdateInfo;
 
@@ -95,6 +96,11 @@ public:
 	void Flush();
 	void Verify();
 	static IndexRemovalType GetIndexRemovalType(ActiveTransactionState transaction_state, CommitMode commit_mode);
+	//! Throws a TransactionException if the given table - modified by the transaction with the given id - has been
+	//! altered/dropped by a different transaction in the meantime: the commit must fail in that case.
+	//! Used both when committing data entries (CommitEntry) and when validating a deferred (group) commit before
+	//! its WAL flush marker is written (UndoBuffer::ValidateCommitConflicts).
+	static void VerifyTableModification(DuckTableEntry &table, transaction_t transaction_id);
 
 private:
 	void CommitEntryDrop(CatalogEntry &entry, data_ptr_t extra_data, CommitInfo &info);

--- a/src/include/duckdb/transaction/duck_transaction.hpp
+++ b/src/include/duckdb/transaction/duck_transaction.hpp
@@ -82,7 +82,7 @@ public:
 	//! Caller must hold the transaction lock. A failure here is fatal - the commit is already durable in the WAL.
 	ErrorData PublishCommit(AttachedDatabase &db, CommitInfo &commit_info) noexcept;
 	//! DataTableInfos of tables this transaction modified (deduplicated, address-ordered) - used to take each
-	//! table's publish gate SHARED while committing (see DuckTransactionManager::BlockPendingCommits).
+	//! table's publish gate SHARED while committing (see DataTableInfo::GetPublishGateExclusive).
 	vector<shared_ptr<DataTableInfo>> GetModifiedTableInfos() {
 		return undo_buffer.GetModifiedTableInfos();
 	}

--- a/src/include/duckdb/transaction/duck_transaction.hpp
+++ b/src/include/duckdb/transaction/duck_transaction.hpp
@@ -28,7 +28,8 @@ struct DataTableInfo;
 struct UndoBufferProperties;
 
 struct CommitInfo {
-	transaction_t commit_id;
+	//! Assigned at publish time on the deferred (group-commit) path, so it defaults to 0 until then
+	transaction_t commit_id = 0;
 	ActiveTransactionState active_transactions = ActiveTransactionState::UNSET;
 	optional_ptr<CommitDropState> drop_state;
 };

--- a/src/include/duckdb/transaction/duck_transaction.hpp
+++ b/src/include/duckdb/transaction/duck_transaction.hpp
@@ -81,6 +81,11 @@ public:
 	//! Second phase of a deferred (group) commit: make the committed changes visible to other transactions.
 	//! Caller must hold the transaction lock. A failure here is fatal - the commit is already durable in the WAL.
 	ErrorData PublishCommit(AttachedDatabase &db, CommitInfo &commit_info) noexcept;
+	//! DataTableInfos of tables this transaction modified (deduplicated, address-ordered) - used to take each
+	//! table's publish gate SHARED while committing (see DuckTransactionManager::BlockPendingCommits).
+	vector<shared_ptr<DataTableInfo>> GetModifiedTableInfos() {
+		return undo_buffer.GetModifiedTableInfos();
+	}
 	//! Returns whether or not a commit of this transaction should trigger an automatic checkpoint
 	bool AutomaticCheckpoint(AttachedDatabase &db, const UndoBufferProperties &properties);
 

--- a/src/include/duckdb/transaction/duck_transaction.hpp
+++ b/src/include/duckdb/transaction/duck_transaction.hpp
@@ -70,6 +70,16 @@ public:
 	//! commit failed, or an empty string if the commit was successful
 	ErrorData Commit(AttachedDatabase &db, CommitInfo &commit_info,
 	                 unique_ptr<StorageCommitState> commit_state) noexcept;
+	//! First phase of a deferred (group) commit: write the WAL flush marker (conflicts were already validated in
+	//! WriteToWAL, before any entries were written). Caller must hold the transaction lock and the WAL lock. After
+	//! this succeeds, the commit can no longer be aborted - it must be made durable (WriteAheadLog::SyncUpTo) and
+	//! then published (PublishCommit). On success, `flush_marker_offset` is set to the WAL offset that SyncUpTo()
+	//! must reach to make this commit durable (the offset of the flush marker just written).
+	ErrorData CommitToWAL(AttachedDatabase &db, CommitInfo &commit_info, unique_ptr<StorageCommitState> commit_state,
+	                      idx_t &flush_marker_offset) noexcept;
+	//! Second phase of a deferred (group) commit: make the committed changes visible to other transactions.
+	//! Caller must hold the transaction lock. A failure here is fatal - the commit is already durable in the WAL.
+	ErrorData PublishCommit(AttachedDatabase &db, CommitInfo &commit_info) noexcept;
 	//! Returns whether or not a commit of this transaction should trigger an automatic checkpoint
 	bool AutomaticCheckpoint(AttachedDatabase &db, const UndoBufferProperties &properties);
 

--- a/src/include/duckdb/transaction/duck_transaction_manager.hpp
+++ b/src/include/duckdb/transaction/duck_transaction_manager.hpp
@@ -180,10 +180,11 @@ private:
 	//! starting transaction can never observe a commit id that is not yet published.
 	idx_t next_publish_sequence = 1;
 
-	//! Row groups retired by a checkpoint, kept alive until the database is quiescent so that undo buffers can no
-	//! longer reference their UpdateSegments (see RetireAfterCheckpoint).
+	//! Objects (row groups / update segments) retired by a checkpoint, each tagged with the start-timestamp horizon
+	//! at retirement: once lowest_active_start reaches that epoch, no transaction that existed at retirement is still
+	//! active, so no undo buffer can reference the object's UpdateSegments and it is freed (see RetireAfterCheckpoint).
 	mutex retired_lock;
-	vector<shared_ptr<void>> retired_after_checkpoint;
+	vector<pair<transaction_t, shared_ptr<void>>> retired_after_checkpoint;
 
 	//! Only one cleanup can be active at any time.
 	mutex cleanup_lock;

--- a/src/include/duckdb/transaction/duck_transaction_manager.hpp
+++ b/src/include/duckdb/transaction/duck_transaction_manager.hpp
@@ -126,15 +126,15 @@ private:
 	bool HasOtherTransactions(DuckTransaction &transaction);
 	void CleanupTransactions();
 
-	//! Register a commit that is about to write its WAL flush marker and defer its publish.
-	//! Returns false if a DDL gate is currently waiting (see BlockPendingCommits) - the commit must then
-	//! fall back to the synchronous commit path.
-	bool RegisterPendingCommit(transaction_t commit_id);
-	//! Wait until all earlier pending commits have been published. Publishing in commit order keeps
-	//! recently_committed_transactions ordered on commit_id and matches WAL replay order.
-	void WaitForPublishTurn(transaction_t commit_id);
+	//! Register a commit that is about to write its WAL flush marker and defer its publish, identified by a
+	//! monotonic publish sequence number assigned in WAL order. Returns false if a DDL gate is currently
+	//! waiting (see BlockPendingCommits) - the commit must then fall back to the synchronous commit path.
+	bool RegisterPendingCommit(transaction_t publish_seq);
+	//! Wait until all earlier pending commits have been published. Publishing in WAL (publish-sequence) order
+	//! keeps recently_committed_transactions ordered on commit_id and matches WAL replay order.
+	void WaitForPublishTurn(transaction_t publish_seq);
 	//! Mark a pending commit as published (or abandoned on fatal failure) and wake up waiters.
-	void FinishPendingCommit(transaction_t commit_id);
+	void FinishPendingCommit(transaction_t publish_seq);
 
 private:
 	//! The current start timestamp used by transactions
@@ -169,10 +169,15 @@ private:
 	mutex publish_lock;
 	//! Signalled whenever a pending commit is published.
 	std::condition_variable publish_cv;
-	//! Commits that are durable in the WAL (flush marker written) but not yet published/visible.
+	//! Publish sequence numbers of commits that are durable in the WAL (flush marker written) but not yet
+	//! published/visible. Ordered by publish sequence (= WAL order) so publishes happen in WAL order.
 	//! Lock ordering: transaction_lock -> publish_lock. Waiting on publish_cv requires holding neither
 	//! the transaction lock nor the WAL lock.
 	set<transaction_t> pending_commit_publishes;
+	//! Monotonic sequence assigned to deferred commits in WAL order (under the transaction lock), used to order
+	//! their publishes. Decoupled from the commit timestamp, which is only assigned at publish time so that a
+	//! starting transaction can never observe a commit id that is not yet published.
+	transaction_t next_publish_sequence = 1;
 	//! Number of DDL operations currently waiting in BlockPendingCommits. While non-zero, new commits
 	//! cannot register as pending and fall back to the synchronous commit path.
 	idx_t catalog_gate_waiters = 0;

--- a/src/include/duckdb/transaction/duck_transaction_manager.hpp
+++ b/src/include/duckdb/transaction/duck_transaction_manager.hpp
@@ -92,13 +92,13 @@ public:
 	                      idx_t extra_data_size = 0);
 	void PushAttach(Transaction &transaction_p, AttachedDatabase &db);
 
-	//! Wait until no pending (unpublished) commits exist, then return while holding the publish lock - blocking
-	//! new deferred commits from registering until the returned lock is released. Used by DDL (ALTER/DROP) to
-	//! attach a new catalog version: a deferred commit validates against the catalog before writing its WAL flush
-	//! marker, and that validation must stay authoritative until the commit is published. While a caller is
-	//! waiting, new commits fall back to the synchronous commit path instead of deferring (avoids starvation).
-	//! The caller must NOT hold the transaction lock or the WAL lock.
-	unique_lock<mutex> BlockPendingCommits();
+	//! Acquire the WAL lock EXCLUSIVELY, returning the lock handle. Used by DDL (ALTER/DROP/CREATE INDEX) to attach a
+	//! new catalog version: a deferred (group) commit validates against the catalog before writing its WAL flush
+	//! marker and holds the WAL lock SHARED until it publishes, so taking the WAL lock exclusively here both drains
+	//! all in-flight deferred commits and blocks new ones until the returned handle is released - keeping that
+	//! validation authoritative. Writer priority (see StorageLock) prevents a steady stream of commits from starving
+	//! the DDL. The caller must NOT already hold the WAL lock (the lock is not reentrant).
+	unique_ptr<StorageLockKey> BlockPendingCommits();
 
 protected:
 	struct CheckpointDecision {
@@ -129,9 +129,8 @@ private:
 	void CleanupTransactions();
 
 	//! Register a commit that is about to write its WAL flush marker and defer its publish, identified by a
-	//! monotonic publish sequence number assigned in WAL order. Returns false if a DDL gate is currently
-	//! waiting (see BlockPendingCommits) - the commit must then fall back to the synchronous commit path.
-	bool RegisterPendingCommit(transaction_t publish_seq);
+	//! monotonic publish sequence number assigned in WAL order (used by WaitForPublishTurn to publish in order).
+	void RegisterPendingCommit(transaction_t publish_seq);
 	//! Wait until all earlier pending commits have been published. Publishing in WAL (publish-sequence) order
 	//! keeps recently_committed_transactions ordered on commit_id and matches WAL replay order.
 	void WaitForPublishTurn(transaction_t publish_seq);
@@ -180,9 +179,6 @@ private:
 	//! their publishes. Decoupled from the commit timestamp, which is only assigned at publish time so that a
 	//! starting transaction can never observe a commit id that is not yet published.
 	transaction_t next_publish_sequence = 1;
-	//! Number of DDL operations currently waiting in BlockPendingCommits. While non-zero, new commits
-	//! cannot register as pending and fall back to the synchronous commit path.
-	idx_t catalog_gate_waiters = 0;
 
 	//! Row groups retired by a checkpoint, kept alive until the database is quiescent so that undo buffers can no
 	//! longer reference their UpdateSegments (see RetireAfterCheckpoint).

--- a/src/include/duckdb/transaction/duck_transaction_manager.hpp
+++ b/src/include/duckdb/transaction/duck_transaction_manager.hpp
@@ -20,7 +20,6 @@ namespace duckdb {
 class DuckTransactionManager;
 class DuckTransaction;
 struct UndoBufferProperties;
-struct DataTableInfo;
 
 //! CleanupInfo collects transactions awaiting cleanup.
 //! This ensures we can clean up after releasing the transaction lock.
@@ -92,16 +91,6 @@ public:
 	void PushCatalogEntry(Transaction &transaction_p, CatalogEntry &entry, data_ptr_t extra_data = nullptr,
 	                      idx_t extra_data_size = 0);
 	void PushAttach(Transaction &transaction_p, AttachedDatabase &db);
-
-	//! Acquire the given table's publish gate EXCLUSIVELY, returning the lock handle. Used by DDL (ALTER/DROP/CREATE
-	//! INDEX) to mutate a table's catalog entry / index list: a group commit that modifies that table holds the gate
-	//! SHARED from before its catalog validation until it publishes (applying its changes into the table's indexes),
-	//! so taking the gate exclusively here drains all in-flight commits on that table and blocks new ones until the
-	//! returned handle is released. Scoped to the table, so DDL on one table does not block commits to others. Returns
-	//! nullptr when there is nothing to gate (no table, system catalog, or in-memory database - none have group
-	//! commits). Writer priority (see StorageLock) prevents a steady stream of commits from starving the DDL. The
-	//! caller must NOT already hold this table's publish gate (the lock is not reentrant).
-	unique_ptr<StorageLockKey> BlockPendingCommits(optional_ptr<DataTableInfo> table_info);
 
 protected:
 	struct CheckpointDecision {

--- a/src/include/duckdb/transaction/duck_transaction_manager.hpp
+++ b/src/include/duckdb/transaction/duck_transaction_manager.hpp
@@ -92,11 +92,6 @@ public:
 	                      idx_t extra_data_size = 0);
 	void PushAttach(Transaction &transaction_p, AttachedDatabase &db);
 
-	//! Wait until all commits that have written their WAL flush marker have been published (made visible).
-	//! Used by checkpoints and catalog-changing commits to ensure no commit is "in between" WAL durability and
-	//! visibility. The caller must hold the WAL lock (so no new pending commits can register) and must NOT hold
-	//! the transaction lock (pending commits need it to publish).
-	void WaitForPendingCommits();
 	//! Wait until no pending (unpublished) commits exist, then return while holding the publish lock - blocking
 	//! new deferred commits from registering until the returned lock is released. Used by DDL (ALTER/DROP) to
 	//! attach a new catalog version: a deferred commit validates against the catalog before writing its WAL flush

--- a/src/include/duckdb/transaction/duck_transaction_manager.hpp
+++ b/src/include/duckdb/transaction/duck_transaction_manager.hpp
@@ -78,6 +78,13 @@ public:
 	unique_ptr<StorageLockKey> SharedVacuumLock();
 	unique_ptr<StorageLockKey> TryGetVacuumLock();
 
+	//! Keep an object (a row group whose updates a checkpoint replaced) alive until no transaction can still
+	//! reference it through its undo buffer. A committed transaction's undo holds a raw pointer to the row group's
+	//! UpdateSegment (UpdateInfo::segment); the checkpoint frees the old row group, so cleanup of that undo would
+	//! otherwise dereference freed memory. The retained object is released once the database becomes quiescent
+	//! (no active transactions), at which point all undo has been cleaned up.
+	void RetireAfterCheckpoint(shared_ptr<void> retired_object);
+
 	//! Returns the current version of the catalog (incremented whenever anything changes, not stored between restarts)
 	DUCKDB_API idx_t GetCatalogVersion(Transaction &transaction);
 
@@ -181,6 +188,11 @@ private:
 	//! Number of DDL operations currently waiting in BlockPendingCommits. While non-zero, new commits
 	//! cannot register as pending and fall back to the synchronous commit path.
 	idx_t catalog_gate_waiters = 0;
+
+	//! Row groups retired by a checkpoint, kept alive until the database is quiescent so that undo buffers can no
+	//! longer reference their UpdateSegments (see RetireAfterCheckpoint).
+	mutex retired_lock;
+	vector<shared_ptr<void>> retired_after_checkpoint;
 
 	//! Only one cleanup can be active at any time.
 	mutex cleanup_lock;

--- a/src/include/duckdb/transaction/duck_transaction_manager.hpp
+++ b/src/include/duckdb/transaction/duck_transaction_manager.hpp
@@ -20,6 +20,7 @@ namespace duckdb {
 class DuckTransactionManager;
 class DuckTransaction;
 struct UndoBufferProperties;
+struct DataTableInfo;
 
 //! CleanupInfo collects transactions awaiting cleanup.
 //! This ensures we can clean up after releasing the transaction lock.
@@ -92,13 +93,15 @@ public:
 	                      idx_t extra_data_size = 0);
 	void PushAttach(Transaction &transaction_p, AttachedDatabase &db);
 
-	//! Acquire the WAL lock EXCLUSIVELY, returning the lock handle. Used by DDL (ALTER/DROP/CREATE INDEX) to attach a
-	//! new catalog version: a deferred (group) commit validates against the catalog before writing its WAL flush
-	//! marker and holds the WAL lock SHARED until it publishes, so taking the WAL lock exclusively here both drains
-	//! all in-flight deferred commits and blocks new ones until the returned handle is released - keeping that
-	//! validation authoritative. Writer priority (see StorageLock) prevents a steady stream of commits from starving
-	//! the DDL. The caller must NOT already hold the WAL lock (the lock is not reentrant).
-	unique_ptr<StorageLockKey> BlockPendingCommits();
+	//! Acquire the given table's publish gate EXCLUSIVELY, returning the lock handle. Used by DDL (ALTER/DROP/CREATE
+	//! INDEX) to mutate a table's catalog entry / index list: a group commit that modifies that table holds the gate
+	//! SHARED from before its catalog validation until it publishes (applying its changes into the table's indexes),
+	//! so taking the gate exclusively here drains all in-flight commits on that table and blocks new ones until the
+	//! returned handle is released. Scoped to the table, so DDL on one table does not block commits to others. Returns
+	//! nullptr when there is nothing to gate (no table, system catalog, or in-memory database - none have group
+	//! commits). Writer priority (see StorageLock) prevents a steady stream of commits from starving the DDL. The
+	//! caller must NOT already hold this table's publish gate (the lock is not reentrant).
+	unique_ptr<StorageLockKey> BlockPendingCommits(optional_ptr<DataTableInfo> table_info);
 
 protected:
 	struct CheckpointDecision {

--- a/src/include/duckdb/transaction/duck_transaction_manager.hpp
+++ b/src/include/duckdb/transaction/duck_transaction_manager.hpp
@@ -12,6 +12,9 @@
 #include "duckdb/storage/storage_lock.hpp"
 #include "duckdb/common/enums/checkpoint_type.hpp"
 #include "duckdb/common/queue.hpp"
+#include "duckdb/common/set.hpp"
+
+#include <condition_variable>
 
 namespace duckdb {
 class DuckTransactionManager;
@@ -82,6 +85,19 @@ public:
 	                      idx_t extra_data_size = 0);
 	void PushAttach(Transaction &transaction_p, AttachedDatabase &db);
 
+	//! Wait until all commits that have written their WAL flush marker have been published (made visible).
+	//! Used by checkpoints and catalog-changing commits to ensure no commit is "in between" WAL durability and
+	//! visibility. The caller must hold the WAL lock (so no new pending commits can register) and must NOT hold
+	//! the transaction lock (pending commits need it to publish).
+	void WaitForPendingCommits();
+	//! Wait until no pending (unpublished) commits exist, then return while holding the publish lock - blocking
+	//! new deferred commits from registering until the returned lock is released. Used by DDL (ALTER/DROP) to
+	//! attach a new catalog version: a deferred commit validates against the catalog before writing its WAL flush
+	//! marker, and that validation must stay authoritative until the commit is published. While a caller is
+	//! waiting, new commits fall back to the synchronous commit path instead of deferring (avoids starvation).
+	//! The caller must NOT hold the transaction lock or the WAL lock.
+	unique_lock<mutex> BlockPendingCommits();
+
 protected:
 	struct CheckpointDecision {
 		explicit CheckpointDecision(string reason_p);
@@ -109,6 +125,16 @@ private:
 
 	bool HasOtherTransactions(DuckTransaction &transaction);
 	void CleanupTransactions();
+
+	//! Register a commit that is about to write its WAL flush marker and defer its publish.
+	//! Returns false if a DDL gate is currently waiting (see BlockPendingCommits) - the commit must then
+	//! fall back to the synchronous commit path.
+	bool RegisterPendingCommit(transaction_t commit_id);
+	//! Wait until all earlier pending commits have been published. Publishing in commit order keeps
+	//! recently_committed_transactions ordered on commit_id and matches WAL replay order.
+	void WaitForPublishTurn(transaction_t commit_id);
+	//! Mark a pending commit as published (or abandoned on fatal failure) and wake up waiters.
+	void FinishPendingCommit(transaction_t commit_id);
 
 private:
 	//! The current start timestamp used by transactions
@@ -138,6 +164,18 @@ private:
 
 	atomic<idx_t> last_uncommitted_catalog_version = {TRANSACTION_ID_START};
 	idx_t last_committed_version = 0;
+
+	//! Protects pending_commit_publishes.
+	mutex publish_lock;
+	//! Signalled whenever a pending commit is published.
+	std::condition_variable publish_cv;
+	//! Commits that are durable in the WAL (flush marker written) but not yet published/visible.
+	//! Lock ordering: transaction_lock -> publish_lock. Waiting on publish_cv requires holding neither
+	//! the transaction lock nor the WAL lock.
+	set<transaction_t> pending_commit_publishes;
+	//! Number of DDL operations currently waiting in BlockPendingCommits. While non-zero, new commits
+	//! cannot register as pending and fall back to the synchronous commit path.
+	idx_t catalog_gate_waiters = 0;
 
 	//! Only one cleanup can be active at any time.
 	mutex cleanup_lock;

--- a/src/include/duckdb/transaction/duck_transaction_manager.hpp
+++ b/src/include/duckdb/transaction/duck_transaction_manager.hpp
@@ -130,12 +130,12 @@ private:
 
 	//! Register a commit that is about to write its WAL flush marker and defer its publish, identified by a
 	//! monotonic publish sequence number assigned in WAL order (used by WaitForPublishTurn to publish in order).
-	void RegisterPendingCommit(transaction_t publish_seq);
+	void RegisterPendingCommit(idx_t publish_seq);
 	//! Wait until all earlier pending commits have been published. Publishing in WAL (publish-sequence) order
 	//! keeps recently_committed_transactions ordered on commit_id and matches WAL replay order.
-	void WaitForPublishTurn(transaction_t publish_seq);
+	void WaitForPublishTurn(idx_t publish_seq);
 	//! Mark a pending commit as published (or abandoned on fatal failure) and wake up waiters.
-	void FinishPendingCommit(transaction_t publish_seq);
+	void FinishPendingCommit(idx_t publish_seq);
 
 private:
 	//! The current start timestamp used by transactions
@@ -174,11 +174,11 @@ private:
 	//! published/visible. Ordered by publish sequence (= WAL order) so publishes happen in WAL order.
 	//! Lock ordering: transaction_lock -> publish_lock. Waiting on publish_cv requires holding neither
 	//! the transaction lock nor the WAL lock.
-	set<transaction_t> pending_commit_publishes;
+	set<idx_t> pending_commit_publishes;
 	//! Monotonic sequence assigned to deferred commits in WAL order (under the transaction lock), used to order
 	//! their publishes. Decoupled from the commit timestamp, which is only assigned at publish time so that a
 	//! starting transaction can never observe a commit id that is not yet published.
-	transaction_t next_publish_sequence = 1;
+	idx_t next_publish_sequence = 1;
 
 	//! Row groups retired by a checkpoint, kept alive until the database is quiescent so that undo buffers can no
 	//! longer reference their UpdateSegments (see RetireAfterCheckpoint).

--- a/src/include/duckdb/transaction/undo_buffer.hpp
+++ b/src/include/duckdb/transaction/undo_buffer.hpp
@@ -22,6 +22,7 @@ class StorageCommitState;
 class WriteAheadLog;
 struct UndoBufferPointer;
 struct CommitInfo;
+struct DataTableInfo;
 
 struct UndoBufferProperties {
 	idx_t estimated_size = 0;
@@ -62,6 +63,9 @@ public:
 	//! table). Used by deferred (group) commits: after the WAL flush marker is written the commit can no longer
 	//! be aborted, so any conflicts must be detected before that point.
 	ErrorData ValidateCommitConflicts();
+	//! Collect the DataTableInfos of tables modified by data changes (INSERT/DELETE/UPDATE) in this buffer,
+	//! deduplicated and ordered by address, so a commit can take each table's publish gate in a deadlock-free order.
+	vector<shared_ptr<DataTableInfo>> GetModifiedTableInfos();
 	//! Iterate the undo buffer and commit each entry. Deferred drop side effects accumulate in
 	//! info.drop_state so they can be applied after the commit chain succeeds.
 	void Commit(UndoBuffer::IteratorState &iterator_state, CommitInfo &info);

--- a/src/include/duckdb/transaction/undo_buffer.hpp
+++ b/src/include/duckdb/transaction/undo_buffer.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/enums/undo_flags.hpp"
+#include "duckdb/common/error_data.hpp"
 #include "duckdb/transaction/undo_buffer_allocator.hpp"
 #include "duckdb/common/enums/active_transaction_state.hpp"
 
@@ -57,6 +58,10 @@ public:
 	void Cleanup(transaction_t lowest_active_transaction);
 	//! Commit the changes made in the UndoBuffer: should be called on commit
 	void WriteToWAL(WriteAheadLog &wal, optional_ptr<StorageCommitState> commit_state);
+	//! Check whether committing the entries can fail (e.g. because another transaction has altered a modified
+	//! table). Used by deferred (group) commits: after the WAL flush marker is written the commit can no longer
+	//! be aborted, so any conflicts must be detected before that point.
+	ErrorData ValidateCommitConflicts();
 	//! Iterate the undo buffer and commit each entry. Deferred drop side effects accumulate in
 	//! info.drop_state so they can be applied after the commit chain succeeds.
 	void Commit(UndoBuffer::IteratorState &iterator_state, CommitInfo &info);

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -157,6 +157,8 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_SETTING(EnableViewDependenciesSetting),
     DUCKDB_GLOBAL(EnabledLogTypes),
     DUCKDB_SETTING(ErrorsAsJSONSetting),
+    DUCKDB_SETTING(ExperimentalGroupCommitSetting),
+    DUCKDB_SETTING(ExperimentalGroupCommitDelaySetting),
     DUCKDB_SETTING(ExperimentalMetadataReuseSetting),
     DUCKDB_SETTING_CALLBACK(ExplainOutputSetting),
     DUCKDB_GLOBAL(ExtensionDirectoriesSetting),

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -241,6 +241,7 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_SETTING_CALLBACK(ValidateExternalFileCacheSetting),
     DUCKDB_SETTING(VariantMinimumShreddingSizeSetting),
     DUCKDB_SETTING(WalAutocheckpointEntriesSetting),
+    DUCKDB_GLOBAL(WalBufferSizeSetting),
     DUCKDB_SETTING_CALLBACK(WarningsAsErrorsSetting),
     DUCKDB_SETTING(WriteBufferRowGroupCountSetting),
     DUCKDB_GLOBAL(WriteBufferRowGroupMemoryLimitSetting),

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -157,8 +157,6 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_SETTING(EnableViewDependenciesSetting),
     DUCKDB_GLOBAL(EnabledLogTypes),
     DUCKDB_SETTING(ErrorsAsJSONSetting),
-    DUCKDB_SETTING(ExperimentalGroupCommitSetting),
-    DUCKDB_SETTING(ExperimentalGroupCommitDelaySetting),
     DUCKDB_SETTING(ExperimentalMetadataReuseSetting),
     DUCKDB_SETTING_CALLBACK(ExplainOutputSetting),
     DUCKDB_GLOBAL(ExtensionDirectoriesSetting),
@@ -174,6 +172,7 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_SETTING(ForceUpdateToDelAndInsertSetting),
     DUCKDB_GLOBAL(ForceVariantShredding),
     DUCKDB_SETTING(GeometryMinimumShreddingSize),
+    DUCKDB_SETTING(GroupCommitDelaySetting),
     DUCKDB_SETTING_CALLBACK(HomeDirectorySetting),
     DUCKDB_GLOBAL(HTTPProxySetting),
     DUCKDB_SETTING(HTTPProxyPasswordSetting),
@@ -250,12 +249,12 @@ static const ConfigurationOption internal_options[] = {
 
 static const ConfigurationAlias setting_aliases[] = {DUCKDB_SETTING_ALIAS("configure_metrics", 29),
                                                      DUCKDB_SETTING_ALIAS("custom_profiling_settings", 29),
-                                                     DUCKDB_SETTING_ALIAS("memory_limit", 128),
+                                                     DUCKDB_SETTING_ALIAS("memory_limit", 129),
                                                      DUCKDB_SETTING_ALIAS("null_order", 61),
-                                                     DUCKDB_SETTING_ALIAS("profile_output", 151),
-                                                     DUCKDB_SETTING_ALIAS("user", 169),
+                                                     DUCKDB_SETTING_ALIAS("profile_output", 152),
+                                                     DUCKDB_SETTING_ALIAS("user", 170),
                                                      DUCKDB_SETTING_ALIAS("wal_autocheckpoint", 28),
-                                                     DUCKDB_SETTING_ALIAS("worker_threads", 167),
+                                                     DUCKDB_SETTING_ALIAS("worker_threads", 168),
                                                      FINAL_ALIAS};
 
 vector<ConfigurationOption> DBConfig::GetOptions() {

--- a/src/main/settings/autogenerated_settings.cpp
+++ b/src/main/settings/autogenerated_settings.cpp
@@ -297,4 +297,11 @@ void ValidateExternalFileCacheSetting::OnSet(SettingCallbackInfo &info, Value &p
 	EnumUtil::FromString<CacheValidationMode>(StringValue::Get(parameter));
 }
 
+//===----------------------------------------------------------------------===//
+// Wal Buffer Size
+//===----------------------------------------------------------------------===//
+void WalBufferSizeSetting::ResetGlobal(DatabaseInstance *db, DBConfig &config) {
+	config.options.wal_buffer_size = DBConfigOptions().wal_buffer_size;
+}
+
 } // namespace duckdb

--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -329,6 +329,11 @@ Value CheckpointThresholdSetting::GetSetting(const ClientContext &context) {
 //===----------------------------------------------------------------------===//
 // WAL Buffer Size
 //===----------------------------------------------------------------------===//
+// The WAL's default write buffer must match every other BufferedFileWriter. config.hpp cannot include the writer
+// header (it would form an include cycle), so the default lives there as a literal and is tied to FILE_BUFFER_SIZE here.
+static_assert(DBConfigOptions::DEFAULT_WAL_BUFFER_SIZE == FILE_BUFFER_SIZE,
+              "wal_buffer_size default must equal FILE_BUFFER_SIZE");
+
 void WalBufferSizeSetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {
 	idx_t new_size = DBConfig::ParseMemoryLimit(input.ToString());
 	// reject sub-page sizes (pathological WriteData thresholds, no benefit) and the "infinite" sentinel

--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -329,8 +329,7 @@ Value CheckpointThresholdSetting::GetSetting(const ClientContext &context) {
 //===----------------------------------------------------------------------===//
 // WAL Buffer Size
 //===----------------------------------------------------------------------===//
-// The WAL's default write buffer must match every other BufferedFileWriter. config.hpp cannot include the writer
-// header (it would form an include cycle), so the default lives there as a literal and is tied to FILE_BUFFER_SIZE here.
+// config.hpp can't include the writer header (cycle), so it holds the literal and we tie it to FILE_BUFFER_SIZE here.
 static_assert(DBConfigOptions::DEFAULT_WAL_BUFFER_SIZE == FILE_BUFFER_SIZE,
               "wal_buffer_size default must equal FILE_BUFFER_SIZE");
 

--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -18,6 +18,7 @@
 #include "duckdb/catalog/catalog_search_path.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/file_system.hpp"
+#include "duckdb/common/serializer/buffered_file_writer.hpp"
 #include "duckdb/common/operator/double_cast_operator.hpp"
 #include "duckdb/main/attached_database.hpp"
 #include "duckdb/main/client_context.hpp"
@@ -323,6 +324,24 @@ void CheckpointThresholdSetting::SetGlobal(DatabaseInstance *db, DBConfig &confi
 Value CheckpointThresholdSetting::GetSetting(const ClientContext &context) {
 	auto &config = DBConfig::GetConfig(context);
 	return Value(StringUtil::BytesToHumanReadableString(config.options.checkpoint_wal_size));
+}
+
+//===----------------------------------------------------------------------===//
+// WAL Buffer Size
+//===----------------------------------------------------------------------===//
+void WalBufferSizeSetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {
+	idx_t new_size = DBConfig::ParseMemoryLimit(input.ToString());
+	// reject sub-page sizes (pathological WriteData thresholds, no benefit) and the "infinite" sentinel
+	if (new_size < FILE_BUFFER_SIZE || new_size == NumericLimits<idx_t>::Maximum()) {
+		throw InvalidInputException("wal_buffer_size must be a byte size of at least %llu bytes (e.g. '64KB')",
+		                            static_cast<uint64_t>(FILE_BUFFER_SIZE));
+	}
+	config.options.wal_buffer_size = new_size;
+}
+
+Value WalBufferSizeSetting::GetSetting(const ClientContext &context) {
+	auto &config = DBConfig::GetConfig(context);
+	return Value(StringUtil::BytesToHumanReadableString(config.options.wal_buffer_size));
 }
 
 //===----------------------------------------------------------------------===//

--- a/src/storage/checkpoint_manager.cpp
+++ b/src/storage/checkpoint_manager.cpp
@@ -335,12 +335,12 @@ void SingleFileCheckpointWriter::CreateCheckpoint() {
 
 	// truncate the WAL
 	if (has_wal) {
-		unique_lock<mutex> owned_wal_lock;
-		optional_ptr<unique_lock<mutex>> wal_lock;
+		unique_ptr<StorageLockKey> owned_wal_lock;
+		optional_ptr<StorageLockKey> wal_lock;
 		if (!options.wal_lock) {
-			// not holding the WAL lock yet - grab it
-			owned_wal_lock = storage_manager.GetWALLock();
-			wal_lock = owned_wal_lock;
+			// not holding the WAL lock yet - grab it exclusively (waits for in-flight group-commit writers)
+			owned_wal_lock = storage_manager.GetWALLockExclusive();
+			wal_lock = owned_wal_lock.get();
 		} else {
 			// we already have the WAL lock - just refer to it
 			wal_lock = options.wal_lock;

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -354,9 +354,7 @@ void DataTable::AddIndex(unique_ptr<Index> index) {
 }
 
 void DataTable::AttachIndexToLiveTable(unique_ptr<Index> index) {
-	// A group commit that modified this table holds its publish gate SHARED from before its catalog validation
-	// through publish (which inserts committed rows into the index list). Take the gate EXCLUSIVE so this attach
-	// does not interleave such a publish - held only for the list change below.
+	// exclude concurrent group-commit publishes while we change the live index list
 	auto publish_gate = info->GetPublishGateExclusive();
 	AddIndex(std::move(index));
 }

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -353,6 +353,14 @@ void DataTable::AddIndex(unique_ptr<Index> index) {
 	info->indexes.AddIndex(std::move(index));
 }
 
+void DataTable::AttachIndexToLiveTable(unique_ptr<Index> index) {
+	// A group commit that modified this table holds its publish gate SHARED from before its catalog validation
+	// through publish (which inserts committed rows into the index list). Take the gate EXCLUSIVE so this attach
+	// does not interleave such a publish - held only for the list change below.
+	auto publish_gate = info->GetPublishGateExclusive();
+	AddIndex(std::move(index));
+}
+
 bool DataTable::HasForeignKeyIndex(const vector<PhysicalIndex> &keys, ForeignKeyType type) {
 	auto index = info->indexes.FindForeignKeyIndex(keys, type);
 	return index != nullptr;

--- a/src/storage/storage_lock.cpp
+++ b/src/storage/storage_lock.cpp
@@ -5,42 +5,52 @@
 #include "duckdb/common/assert.hpp"
 #include "duckdb/common/thread_annotation/thread_annotation.hpp"
 
+#include <condition_variable>
+
 namespace duckdb {
 
+// A writer-priority read-write lock. Exclusive holders wait on a condition variable for all readers to drain
+// (instead of busy-spinning); new readers are held off while a writer is active or waiting, so writers cannot be
+// starved by a steady stream of readers.
 struct StorageLockInternals : enable_shared_from_this<StorageLockInternals> {
 public:
-	StorageLockInternals() : read_count(0) {
+	StorageLockInternals() : read_count(0), writer_active(false), writers_waiting(0) {
 	}
 
-	mutex exclusive_lock;
-	atomic<idx_t> read_count;
+	mutex state_lock;
+	std::condition_variable state_cv;
+	//! Number of active shared (read) lock holders
+	idx_t read_count;
+	//! Whether an exclusive (write) lock is currently held
+	bool writer_active;
+	//! Number of writers waiting for the exclusive lock (for writer priority)
+	idx_t writers_waiting;
 
 public:
 	unique_ptr<StorageLockKey> GetExclusiveLock() DUCKDB_NO_THREAD_SAFETY_ANALYSIS {
-		exclusive_lock.lock();
-		while (read_count != 0) {
-		}
+		unique_lock<mutex> guard(state_lock);
+		writers_waiting++;
+		state_cv.wait(guard, [&]() { return !writer_active && read_count == 0; });
+		writers_waiting--;
+		writer_active = true;
 		return make_uniq<StorageLockKey>(shared_from_this(), StorageLockType::EXCLUSIVE);
 	}
 
-	unique_ptr<StorageLockKey> GetSharedLock() {
-		exclusive_lock.lock();
+	unique_ptr<StorageLockKey> GetSharedLock() DUCKDB_NO_THREAD_SAFETY_ANALYSIS {
+		unique_lock<mutex> guard(state_lock);
+		// writer priority: do not admit a new reader while a writer is active or waiting
+		state_cv.wait(guard, [&]() { return !writer_active && writers_waiting == 0; });
 		read_count++;
-		exclusive_lock.unlock();
 		return make_uniq<StorageLockKey>(shared_from_this(), StorageLockType::SHARED);
 	}
 
 	unique_ptr<StorageLockKey> TryGetExclusiveLock() DUCKDB_NO_THREAD_SAFETY_ANALYSIS {
-		if (!exclusive_lock.try_lock()) {
-			// could not lock mutex
+		lock_guard<mutex> guard(state_lock);
+		if (writer_active || read_count != 0) {
+			// a writer or readers are active - cannot get the exclusive lock immediately
 			return nullptr;
 		}
-		if (read_count != 0) {
-			// there are active readers - cannot get exclusive lock
-			exclusive_lock.unlock();
-			return nullptr;
-		}
-		// success!
+		writer_active = true;
 		return make_uniq<StorageLockKey>(shared_from_this(), StorageLockType::EXCLUSIVE);
 	}
 
@@ -48,25 +58,35 @@ public:
 		if (lock.GetType() != StorageLockType::SHARED) {
 			throw InternalException("StorageLock::TryUpgradeLock called on an exclusive lock");
 		}
-		if (!exclusive_lock.try_lock()) {
-			// could not lock mutex
-			return nullptr;
-		}
-		if (read_count != 1) {
-			// other shared locks are active: failed to upgrade
+		lock_guard<mutex> guard(state_lock);
+		if (writer_active || read_count != 1) {
+			// other shared locks (or a writer) are active: failed to upgrade
 			D_ASSERT(read_count != 0);
-			exclusive_lock.unlock();
 			return nullptr;
 		}
-		// no other shared locks active: success!
+		// we are the only reader: grant the exclusive lock in addition to the held shared lock (read_count stays 1)
+		writer_active = true;
 		return make_uniq<StorageLockKey>(shared_from_this(), StorageLockType::EXCLUSIVE);
 	}
 
 	void ReleaseExclusiveLock() DUCKDB_NO_THREAD_SAFETY_ANALYSIS {
-		exclusive_lock.unlock();
+		{
+			lock_guard<mutex> guard(state_lock);
+			writer_active = false;
+		}
+		state_cv.notify_all();
 	}
-	void ReleaseSharedLock() {
-		read_count--;
+	void ReleaseSharedLock() DUCKDB_NO_THREAD_SAFETY_ANALYSIS {
+		bool notify;
+		{
+			lock_guard<mutex> guard(state_lock);
+			read_count--;
+			notify = read_count == 0;
+		}
+		if (notify) {
+			// the last reader left - wake a waiting writer
+			state_cv.notify_all();
+		}
 	}
 };
 

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -214,6 +214,13 @@ optional_ptr<WriteAheadLog> StorageManager::GetWAL() {
 	return wal.get();
 }
 
+shared_ptr<WriteAheadLog> StorageManager::GetWALShared() {
+	if (InMemory() || read_only || !load_complete) {
+		return nullptr;
+	}
+	return wal;
+}
+
 // comparison used to see whether the storage version is compatible
 bool StorageManager::TargetAtLeastVersion(StorageVersion target_version, idx_t storage_version) {
 	if (storage_version < static_cast<idx_t>(target_version)) {
@@ -254,6 +261,14 @@ bool StorageManager::WALStartCheckpoint(MetaBlockPointer meta_block, CheckpointO
 	if (!options.wal_lock) {
 		// not holding the WAL lock yet - grab it
 		guard = GetWALLock();
+	}
+	// Wait for commits that have written their WAL flush marker but are not yet published (group commit).
+	// The checkpoint snapshot would not include them, while the checkpoint removes their WAL entries -
+	// without waiting, such commits would be lost on restart. New pending commits cannot register while
+	// we hold the WAL lock.
+	auto &transaction_manager = db.GetTransactionManager();
+	if (transaction_manager.IsDuckTransactionManager()) {
+		transaction_manager.Cast<DuckTransactionManager>().WaitForPendingCommits();
 	}
 	if (active_checkpoint.HasCheckpointContext()) {
 		// While holding the WAL lock, if we have a context then start a checkpoint transaction.
@@ -616,6 +631,10 @@ public:
 	void RevertCommit() override;
 	// Make the commit persistent
 	void FlushCommit() override;
+	// Write the WAL flush marker only - the fsync happens later via WriteAheadLog::SyncUpTo (group commit)
+	idx_t FlushCommitMarker() override;
+	// Defer the database file sync for optimistic row group data to the WAL sync leader (group commit)
+	void DeferBlockSync() override;
 
 	void AddRowGroupData(DataTable &table, idx_t start_index, idx_t count,
 	                     unique_ptr<PersistentCollectionData> row_group_data) override;
@@ -627,6 +646,9 @@ private:
 	idx_t initial_written = 0;
 	WriteAheadLog &wal;
 	WALCommitState state;
+	//! Whether the database file sync for optimistic row group data is deferred to the WAL sync leader.
+	//! If not (the default), the committing transaction performs the sync itself before writing to the WAL.
+	bool defer_block_sync = false;
 	reference_map_t<DataTable, unordered_map<idx_t, OptimisticallyWrittenRowGroupData>> optimistically_written_data;
 };
 
@@ -671,8 +693,33 @@ void SingleFileStorageCommitState::FlushCommit() {
 		return;
 	}
 	// Move the blocks in this COMMIT into the WAL and mark them as "in use".
-	wal.Flush();
+	if (defer_block_sync) {
+		// deferred block sync: the marker must record the requirement before the (inline) durable sync
+		auto target_offset = wal.WriteFlushMarker(HasRowGroupData());
+		wal.SyncUpTo(target_offset, false);
+	} else {
+		wal.Flush();
+	}
 	state = WALCommitState::FLUSHED;
+}
+
+idx_t SingleFileStorageCommitState::FlushCommitMarker() {
+	if (state != WALCommitState::IN_PROGRESS) {
+		return 0;
+	}
+	// Move the blocks in this COMMIT into the WAL and mark them as "in use".
+	// Only the flush marker is appended to the in-memory WAL buffer (push_to_os=false): both the push to the
+	// operating system AND the fsync that makes the commit durable happen later, batched, in the group commit sync
+	// leader's WriteAheadLog::SyncUpTo (outside the transaction and WAL locks), so that concurrently committing
+	// transactions share a single write() and a single fsync.
+	// Return the WAL offset of this marker - the caller passes it to SyncUpTo as the durability target.
+	auto target_offset = wal.WriteFlushMarker(defer_block_sync && HasRowGroupData(), /*push_to_os=*/false);
+	state = WALCommitState::FLUSHED;
+	return target_offset;
+}
+
+void SingleFileStorageCommitState::DeferBlockSync() {
+	defer_block_sync = true;
 }
 
 void SingleFileStorageCommitState::AddRowGroupData(DataTable &table, idx_t start_index, idx_t count,

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -319,6 +319,17 @@ bool StorageManager::WALStartCheckpoint(MetaBlockPointer meta_block, CheckpointO
 void StorageManager::WALFinishCheckpoint(unique_lock<mutex> &) {
 	D_ASSERT(wal.get());
 
+	// Drain any deferred (group commit) commits that are still flushing the checkpoint WAL before we move/replace it.
+	// A batch-wait sync leader holds a shared_ptr to this WAL and may push its buffer (under the WAL flush_lock, NOT
+	// the WAL lock) up to group_commit_delay microseconds after releasing the WAL lock. If we reset and move the file
+	// out from under it, that flush races the freshly-reopened main WAL writing to the same path - producing a torn
+	// entry and a corrupt WAL on replay. New pending commits cannot register while we hold the WAL lock; this mirrors
+	// the drain in WALStartCheckpoint.
+	auto &transaction_manager = db.GetTransactionManager();
+	if (transaction_manager.IsDuckTransactionManager()) {
+		transaction_manager.Cast<DuckTransactionManager>().WaitForPendingCommits();
+	}
+
 	// "wal" points to the checkpoint WAL
 	// first check if the checkpoint WAL has been written to
 	auto &fs = FileSystem::Get(db);

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -256,19 +256,13 @@ bool StorageManager::HasWAL() const {
 
 bool StorageManager::WALStartCheckpoint(MetaBlockPointer meta_block, CheckpointOptions &options,
                                         ActiveCheckpointWrapper &active_checkpoint) {
-	unique_lock<mutex> guard;
+	unique_ptr<StorageLockKey> guard;
 	// Lock ordering: WAL lock -> transaction lock (in GetCheckpointTransaction)
 	if (!options.wal_lock) {
-		// not holding the WAL lock yet - grab it
-		guard = GetWALLock();
-	}
-	// Wait for commits that have written their WAL flush marker but are not yet published (group commit).
-	// The checkpoint snapshot would not include them, while the checkpoint removes their WAL entries -
-	// without waiting, such commits would be lost on restart. New pending commits cannot register while
-	// we hold the WAL lock.
-	auto &transaction_manager = db.GetTransactionManager();
-	if (transaction_manager.IsDuckTransactionManager()) {
-		transaction_manager.Cast<DuckTransactionManager>().WaitForPendingCommits();
+		// not holding the WAL lock yet - grab it exclusively. The exclusive acquisition waits for all in-flight
+		// (shared) group-commit writers to finish publishing, so any commit that wrote its flush marker to this WAL
+		// is already durable and visible by the time we proceed - this replaces the old pending-commit drain.
+		guard = GetWALLockExclusive();
 	}
 	if (active_checkpoint.HasCheckpointContext()) {
 		// While holding the WAL lock, if we have a context then start a checkpoint transaction.
@@ -316,19 +310,12 @@ bool StorageManager::WALStartCheckpoint(MetaBlockPointer meta_block, CheckpointO
 	return true;
 }
 
-void StorageManager::WALFinishCheckpoint(unique_lock<mutex> &) {
+void StorageManager::WALFinishCheckpoint(StorageLockKey &) {
 	D_ASSERT(wal.get());
 
-	// Drain any deferred (group commit) commits that are still flushing the checkpoint WAL before we move/replace it.
-	// A batch-wait sync leader holds a shared_ptr to this WAL and may push its buffer (under the WAL flush_lock, NOT
-	// the WAL lock) up to group_commit_delay microseconds after releasing the WAL lock. If we reset and move the file
-	// out from under it, that flush races the freshly-reopened main WAL writing to the same path - producing a torn
-	// entry and a corrupt WAL on replay. New pending commits cannot register while we hold the WAL lock; this mirrors
-	// the drain in WALStartCheckpoint.
-	auto &transaction_manager = db.GetTransactionManager();
-	if (transaction_manager.IsDuckTransactionManager()) {
-		transaction_manager.Cast<DuckTransactionManager>().WaitForPendingCommits();
-	}
+	// The caller holds the WAL lock EXCLUSIVELY, so no group-commit writer can be flushing/syncing this WAL: the
+	// exclusive acquisition already waited for all shared holders to finish. This replaces the old explicit drain
+	// that guarded against a batch-wait sync leader racing the file move/replace below.
 
 	// "wal" points to the checkpoint WAL
 	// first check if the checkpoint WAL has been written to
@@ -358,8 +345,16 @@ void StorageManager::WALFinishCheckpoint(unique_lock<mutex> &) {
 	DUCKDB_LOG(db.GetDatabase(), TransactionLogType, db, "Finish Checkpoint");
 }
 
-unique_lock<mutex> StorageManager::GetWALLock() {
-	return unique_lock<mutex>(wal_lock);
+unique_ptr<StorageLockKey> StorageManager::GetWALLockShared() {
+	return wal_lock.GetSharedLock();
+}
+
+unique_ptr<StorageLockKey> StorageManager::GetWALLockExclusive() {
+	return wal_lock.GetExclusiveLock();
+}
+
+unique_lock<mutex> StorageManager::GetWALAppendLock() {
+	return unique_lock<mutex>(wal_append_lock);
 }
 
 string StorageManager::GetWALPath(const string &suffix) {

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -214,13 +214,6 @@ optional_ptr<WriteAheadLog> StorageManager::GetWAL() {
 	return wal.get();
 }
 
-shared_ptr<WriteAheadLog> StorageManager::GetWALShared() {
-	if (InMemory() || read_only || !load_complete) {
-		return nullptr;
-	}
-	return wal;
-}
-
 // comparison used to see whether the storage version is compatible
 bool StorageManager::TargetAtLeastVersion(StorageVersion target_version, idx_t storage_version) {
 	if (storage_version < static_cast<idx_t>(target_version)) {

--- a/src/storage/table/chunk_info.cpp
+++ b/src/storage/table/chunk_info.cpp
@@ -499,50 +499,40 @@ transaction_t ChunkVectorInfo::ConstantInsertId() const {
 void ChunkVectorInfo::Write(WriteStream &writer, transaction_t checkpoint_id, idx_t max_count) const {
 	D_ASSERT(max_count <= STANDARD_VECTOR_SIZE);
 	transaction_t start_time = checkpoint_id == MAX_TRANSACTION_ID ? TRANSACTION_ID_START - 1 : checkpoint_id + 1;
-	// `max_count` is the number of rows this vector holds (the last vector of a row group may be partial).
-	// Persist a delete only when the delete itself is committed as-of the snapshot. A row must NOT be marked as
-	// deleted merely because its insert is not yet visible: under group commit a concurrent checkpoint can observe a
-	// row whose insert publishes after the snapshot, and persisting it as deleted would conflict with the WAL replay
-	// that re-inserts (and deletes) it.
-	bool is_deleted[STANDARD_VECTOR_SIZE] = {false};
+	// A set (valid) bit marks a row deleted as-of the snapshot (see ChunkVectorInfo::Read). Only committed deletes
+	// among the max_count rows this (possibly partial last) vector holds are marked: a row is NOT deleted merely
+	// because its insert is not yet visible - under group commit a concurrent checkpoint can observe a row whose
+	// insert publishes after the snapshot, and persisting it as deleted would conflict with the WAL replay that
+	// re-inserts it. All other positions (not-deleted rows and the unused trailing slots) stay not-deleted, so a
+	// partial last vector can still receive WAL-replayed appends.
+	ValidityMask mask(STANDARD_VECTOR_SIZE);
+	mask.Initialize(STANDARD_VECTOR_SIZE);
+	mask.SetAllInvalid(STANDARD_VECTOR_SIZE);
 	idx_t deleted_count = 0;
 	if (AnyDeleted()) {
 		auto deleted_segment = allocator.GetHandle(GetDeletedPointer());
 		auto deleted = deleted_segment.GetPtr<transaction_t>();
 		for (idx_t i = 0; i < max_count; i++) {
 			if (StandardDeleteOperator::IsDeleted(start_time, DConstants::INVALID_INDEX, deleted[i])) {
-				is_deleted[i] = true;
+				mask.SetValid(i);
 				deleted_count++;
 			}
 		}
 	}
 	if (deleted_count == 0) {
-		// nothing is deleted in the base: skip writing anything
+		// nothing deleted as-of the snapshot: skip writing anything
 		writer.Write<ChunkInfoType>(ChunkInfoType::EMPTY_INFO);
 		return;
 	}
 	if (deleted_count == max_count && max_count == STANDARD_VECTOR_SIZE) {
-		// the entire vector is deleted: write a constant vector.
-		// only do this for full vectors - a partial last vector may still receive WAL-replayed appends into the
-		// remaining positions, which requires a ChunkVectorInfo (a ChunkConstantInfo cannot be appended to).
+		// entire full vector deleted: an un-appendable ChunkConstantInfo is only safe for a full vector - a partial
+		// last vector may still receive WAL-replayed appends and needs a ChunkVectorInfo.
 		writer.Write<ChunkInfoType>(ChunkInfoType::CONSTANT_INFO);
 		writer.Write<idx_t>(start);
 		return;
 	}
-	// write a boolean vector: a set (valid) bit marks a deleted row (see ChunkVectorInfo::Read)
 	ChunkInfo::Write(writer, checkpoint_id);
 	writer.Write<idx_t>(start);
-	ValidityMask mask(STANDARD_VECTOR_SIZE);
-	mask.Initialize(STANDARD_VECTOR_SIZE);
-	// default the whole mask to "not deleted" (invalid), then mark actually-deleted rows as valid
-	for (idx_t i = 0; i < STANDARD_VECTOR_SIZE; i++) {
-		mask.SetInvalid(i);
-	}
-	for (idx_t i = 0; i < max_count; i++) {
-		if (is_deleted[i]) {
-			mask.SetValid(i);
-		}
-	}
 	mask.Write(writer, STANDARD_VECTOR_SIZE);
 }
 

--- a/src/storage/table/chunk_info.cpp
+++ b/src/storage/table/chunk_info.cpp
@@ -48,7 +48,7 @@ bool ChunkInfo::Cleanup(transaction_t lowest_transaction) const {
 	return false;
 }
 
-void ChunkInfo::Write(WriteStream &writer, transaction_t checkpoint_id) const {
+void ChunkInfo::Write(WriteStream &writer, transaction_t checkpoint_id, idx_t count) const {
 	writer.Write<ChunkInfoType>(type);
 }
 
@@ -137,7 +137,7 @@ bool ChunkConstantInfo::Cleanup(transaction_t lowest_transaction) const {
 	return true;
 }
 
-void ChunkConstantInfo::Write(WriteStream &writer, transaction_t checkpoint_id) const {
+void ChunkConstantInfo::Write(WriteStream &writer, transaction_t checkpoint_id, idx_t count) const {
 	D_ASSERT(HasDeletes(checkpoint_id));
 	ChunkInfo::Write(writer, checkpoint_id);
 	writer.Write<idx_t>(start);
@@ -496,29 +496,52 @@ transaction_t ChunkVectorInfo::ConstantInsertId() const {
 	return constant_insert_id;
 }
 
-void ChunkVectorInfo::Write(WriteStream &writer, transaction_t checkpoint_id) const {
-	SelectionVector sel(STANDARD_VECTOR_SIZE);
+void ChunkVectorInfo::Write(WriteStream &writer, transaction_t checkpoint_id, idx_t max_count) const {
+	D_ASSERT(max_count <= STANDARD_VECTOR_SIZE);
 	transaction_t start_time = checkpoint_id == MAX_TRANSACTION_ID ? TRANSACTION_ID_START - 1 : checkpoint_id + 1;
-	transaction_t transaction_id = DConstants::INVALID_INDEX;
-	idx_t count = GetSelVector(TransactionData(transaction_id, start_time), sel, STANDARD_VECTOR_SIZE);
-	if (count == STANDARD_VECTOR_SIZE) {
-		// nothing is deleted: skip writing anything
+	// `max_count` is the number of rows this vector holds (the last vector of a row group may be partial).
+	// Persist a delete only when the delete itself is committed as-of the snapshot. A row must NOT be marked as
+	// deleted merely because its insert is not yet visible: under group commit a concurrent checkpoint can observe a
+	// row whose insert publishes after the snapshot, and persisting it as deleted would conflict with the WAL replay
+	// that re-inserts (and deletes) it.
+	bool is_deleted[STANDARD_VECTOR_SIZE] = {false};
+	idx_t deleted_count = 0;
+	if (AnyDeleted()) {
+		auto deleted_segment = allocator.GetHandle(GetDeletedPointer());
+		auto deleted = deleted_segment.GetPtr<transaction_t>();
+		for (idx_t i = 0; i < max_count; i++) {
+			if (StandardDeleteOperator::IsDeleted(start_time, DConstants::INVALID_INDEX, deleted[i])) {
+				is_deleted[i] = true;
+				deleted_count++;
+			}
+		}
+	}
+	if (deleted_count == 0) {
+		// nothing is deleted in the base: skip writing anything
 		writer.Write<ChunkInfoType>(ChunkInfoType::EMPTY_INFO);
 		return;
 	}
-	if (count == 0) {
-		// everything is deleted: write a constant vector
+	if (deleted_count == max_count && max_count == STANDARD_VECTOR_SIZE) {
+		// the entire vector is deleted: write a constant vector.
+		// only do this for full vectors - a partial last vector may still receive WAL-replayed appends into the
+		// remaining positions, which requires a ChunkVectorInfo (a ChunkConstantInfo cannot be appended to).
 		writer.Write<ChunkInfoType>(ChunkInfoType::CONSTANT_INFO);
 		writer.Write<idx_t>(start);
 		return;
 	}
-	// write a boolean vector
+	// write a boolean vector: a set (valid) bit marks a deleted row (see ChunkVectorInfo::Read)
 	ChunkInfo::Write(writer, checkpoint_id);
 	writer.Write<idx_t>(start);
 	ValidityMask mask(STANDARD_VECTOR_SIZE);
 	mask.Initialize(STANDARD_VECTOR_SIZE);
-	for (idx_t i = 0; i < count; i++) {
-		mask.SetInvalid(sel.get_index(i));
+	// default the whole mask to "not deleted" (invalid), then mark actually-deleted rows as valid
+	for (idx_t i = 0; i < STANDARD_VECTOR_SIZE; i++) {
+		mask.SetInvalid(i);
+	}
+	for (idx_t i = 0; i < max_count; i++) {
+		if (is_deleted[i]) {
+			mask.SetValid(i);
+		}
 	}
 	mask.Write(writer, STANDARD_VECTOR_SIZE);
 }

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -1408,6 +1408,19 @@ idx_t RowGroup::GetVisibleRowCount(TransactionData transaction) {
 	return vinfo->GetRowCount(transaction, count);
 }
 
+bool RowGroup::HasUpdates() const {
+	for (idx_t c = 0; c < GetColumnCount(); c++) {
+		// unloaded columns cannot have in-memory updates; checking them would force a load
+		if (!ColumnIsLoaded(c)) {
+			continue;
+		}
+		if (columns[c] && columns[c]->HasUpdates()) {
+			return true;
+		}
+	}
+	return false;
+}
+
 bool RowGroup::HasUnloadedDeletes() const {
 	if (deletes_pointers.empty()) {
 		// no stored deletes at all
@@ -1635,7 +1648,7 @@ RowGroupPointer RowGroup::Checkpoint(RowGroupWriteData write_data, RowGroupWrite
 		row_group_pointer.has_per_column_metadata_blocks = has_per_column_metadata_blocks;
 		row_group_pointer.per_column_metadata_blocks = per_column_metadata_blocks;
 		if (metadata_manager) {
-			row_group_pointer.deletes_pointers = CheckpointDeletes(writer);
+			row_group_pointer.deletes_pointers = CheckpointDeletes(writer, count);
 
 			vector<MetaBlockPointer> metadata_block_pointers_to_be_cleared;
 			if (has_per_column_metadata_blocks) {
@@ -1769,7 +1782,7 @@ RowGroupPointer RowGroup::Checkpoint(RowGroupWriteData write_data, RowGroupWrite
 	}
 
 	if (metadata_manager) {
-		row_group_pointer.deletes_pointers = CheckpointDeletes(writer);
+		row_group_pointer.deletes_pointers = CheckpointDeletes(writer, count);
 		metadata_manager->ClearModifiedBlocks(reused_column_blocks);
 	}
 
@@ -1827,7 +1840,7 @@ PersistentRowGroupData RowGroup::SerializeRowGroupInfo(idx_t row_group_start) co
 	return result;
 }
 
-vector<MetaBlockPointer> RowGroup::CheckpointDeletes(RowGroupWriter &writer) {
+vector<MetaBlockPointer> RowGroup::CheckpointDeletes(RowGroupWriter &writer, idx_t row_count) {
 	if (HasUnloadedDeletes()) {
 		// deletes were not loaded so they cannot be changed
 		// re-use them as-is
@@ -1840,7 +1853,7 @@ vector<MetaBlockPointer> RowGroup::CheckpointDeletes(RowGroupWriter &writer) {
 		// no version information: write nothing
 		return vector<MetaBlockPointer>();
 	}
-	return vinfo->Checkpoint(writer);
+	return vinfo->Checkpoint(writer, row_count);
 }
 
 void RowGroup::Serialize(RowGroupPointer &pointer, Serializer &serializer, bool supports_per_column_writes) {

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -18,6 +18,7 @@
 #include "duckdb/storage/table/append_state.hpp"
 #include "duckdb/storage/table/column_checkpoint_state.hpp"
 #include "duckdb/storage/table/data_table_info.hpp"
+#include "duckdb/transaction/duck_transaction_manager.hpp"
 #include "duckdb/storage/table/persistent_table_data.hpp"
 #include "duckdb/storage/table/row_group_segment_tree.hpp"
 #include "duckdb/storage/table/row_version_manager.hpp"
@@ -1778,7 +1779,7 @@ void RowGroupCollection::Checkpoint(TableDataWriter &writer, TableStatistics &gl
 				vector<MetaBlockPointer> extra_metadata_block_pointers = row_group.GetExtraMetadataBlockPointers();
 				metadata_manager.ClearModifiedBlocks(extra_metadata_block_pointers);
 				auto row_group_writer = checkpoint_state.writer.GetRowGroupWriter(row_group);
-				row_group.CheckpointDeletes(*row_group_writer);
+				row_group.CheckpointDeletes(*row_group_writer, row_group.count);
 			}
 			writer.WriteUnchangedTable(metadata_pointer, metadata_pointers, total_rows.load(), next_row_id.load());
 			// copy over existing stats into the global stats
@@ -1799,6 +1800,9 @@ void RowGroupCollection::Checkpoint(TableDataWriter &writer, TableStatistics &gl
 	auto base_row_id = row_groups->GetBaseRowId();
 	auto can_persist_rowid_gaps = writer.CanPersistRowIdGaps();
 	unordered_set<idx_t> columns_with_incomplete_stats;
+	// Row groups that this checkpoint rewrites and that still have in-memory updates must be kept alive after they are
+	// replaced: a committed transaction's undo holds a raw pointer to their UpdateSegment (see RetireAfterCheckpoint).
+	vector<shared_ptr<RowGroup>> retired_row_groups;
 	for (idx_t segment_idx = 0; segment_idx < checkpoint_state.SegmentCount(); segment_idx++) {
 		auto entry = checkpoint_state.GetSegment(segment_idx);
 		if (!entry) {
@@ -1847,6 +1851,11 @@ void RowGroupCollection::Checkpoint(TableDataWriter &writer, TableStatistics &gl
 					reuse_column[column_idx] = !row_group_write_data.states[column_idx];
 				}
 			}
+		}
+		// if the row group is being replaced by a freshly checkpointed one and it still has in-memory updates, keep the
+		// old one alive until the database is quiescent - undo buffers reference its UpdateSegment by raw pointer
+		if (row_group_write_data.result_row_group && existing_row_group.HasUpdates()) {
+			retired_row_groups.push_back(entry->ReferenceNode());
 		}
 		auto new_row_group = std::move(row_group_write_data.result_row_group);
 		if (!new_row_group) {
@@ -2047,6 +2056,14 @@ void RowGroupCollection::Checkpoint(TableDataWriter &writer, TableStatistics &gl
 	next_row_id = new_next_row_id;
 	D_ASSERT(next_row_id.load() >= total_rows.load());
 	SetRowGroups(std::move(new_row_groups));
+	// the old row groups are no longer in the collection; hand the ones that still have referenced updates to the
+	// transaction manager so they are freed only once no undo buffer can reference their UpdateSegments anymore
+	if (!retired_row_groups.empty()) {
+		auto &transaction_manager = GetAttached().GetTransactionManager().Cast<DuckTransactionManager>();
+		for (auto &retired : retired_row_groups) {
+			transaction_manager.RetireAfterCheckpoint(std::move(retired));
+		}
+	}
 	Verify();
 	// Rebuild indexes if:
 	// 1) can_rebuild_indexes is set (it is set when the vacuum_rebuild_indexes

--- a/src/storage/table/row_version_manager.cpp
+++ b/src/storage/table/row_version_manager.cpp
@@ -219,7 +219,7 @@ void RowVersionManager::CommitDelete(idx_t vector_idx, transaction_t commit_id, 
 	GetVectorInfo(vector_idx).CommitDelete(commit_id, info);
 }
 
-vector<MetaBlockPointer> RowVersionManager::Checkpoint(RowGroupWriter &writer) {
+vector<MetaBlockPointer> RowVersionManager::Checkpoint(RowGroupWriter &writer, idx_t row_count) {
 	lock_guard<mutex> lock(version_lock);
 	auto &manager = *writer.GetMetadataManager();
 	auto options = writer.GetCheckpointOptions();
@@ -230,6 +230,8 @@ vector<MetaBlockPointer> RowVersionManager::Checkpoint(RowGroupWriter &writer) {
 		// return the current set of pointers
 		return storage_pointers;
 	}
+	// the index of the last vector and the number of rows it holds (which may be a partial vector)
+	idx_t last_vector_idx = row_count == 0 ? 0 : (row_count - 1) / STANDARD_VECTOR_SIZE;
 	// first count how many ChunkInfo's we need to deserialize
 	vector<pair<idx_t, reference<ChunkInfo>>> to_serialize;
 	for (idx_t vector_idx = 0; vector_idx < vector_info.size(); vector_idx++) {
@@ -253,7 +255,12 @@ vector<MetaBlockPointer> RowVersionManager::Checkpoint(RowGroupWriter &writer) {
 			auto &vector_idx = entry.first;
 			auto &chunk_info = entry.second.get();
 			metadata_writer.Write<idx_t>(vector_idx);
-			chunk_info.Write(metadata_writer, options.transaction_id);
+			// the number of rows held by this vector - the last vector may be partial
+			idx_t vector_count = STANDARD_VECTOR_SIZE;
+			if (vector_idx == last_vector_idx) {
+				vector_count = row_count - vector_idx * STANDARD_VECTOR_SIZE;
+			}
+			chunk_info.Write(metadata_writer, options.transaction_id, vector_count);
 		}
 		metadata_writer.Flush();
 	}

--- a/src/storage/write_ahead_log.cpp
+++ b/src/storage/write_ahead_log.cpp
@@ -21,6 +21,7 @@
 #include "duckdb/storage/single_file_block_manager.hpp"
 #include "duckdb/storage/storage_manager.hpp"
 #include "duckdb/main/attached_database.hpp"
+#include "duckdb/main/config.hpp"
 #include "duckdb/main/settings.hpp"
 #include "duckdb/storage/table/column_data.hpp"
 #include "duckdb/storage/table/data_table_info.hpp"
@@ -60,10 +61,12 @@ BufferedFileWriter &WriteAheadLog::Initialize() {
 	}
 	lock_guard<mutex> lock(wal_lock);
 	if (!writer) {
+		auto buffer_size = DBConfig::GetConfig(GetDatabase().GetDatabase()).options.wal_buffer_size;
 		writer =
 		    make_uniq<BufferedFileWriter>(FileSystem::Get(GetDatabase()), wal_path,
 		                                  FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE |
-		                                      FileFlags::FILE_FLAGS_APPEND | FileFlags::FILE_FLAGS_MULTI_CLIENT_ACCESS);
+		                                      FileFlags::FILE_FLAGS_APPEND | FileFlags::FILE_FLAGS_MULTI_CLIENT_ACCESS,
+		                                  QueryContext(), buffer_size);
 		if (init_state == WALInitState::UNINITIALIZED_REQUIRES_TRUNCATE) {
 			writer->Truncate(storage_manager.GetWALSize());
 		} else {

--- a/src/storage/write_ahead_log.cpp
+++ b/src/storage/write_ahead_log.cpp
@@ -647,15 +647,7 @@ idx_t WriteAheadLog::WriteFlushMarker(bool requires_block_sync, bool push_to_os)
 }
 
 void WriteAheadLog::SyncUpTo(idx_t target_offset, bool wait_for_batch, bool leader_pushes_batch) {
-	// PROTOTYPE BENCHMARK HACK - DO NOT COMMIT
-	// when DUCKDB_BENCH_SKIP_WAL_SYNC is set we skip the fsync to measure the no-fsync commit throughput ceiling
-	static const bool skip_wal_sync = getenv("DUCKDB_BENCH_SKIP_WAL_SYNC") != nullptr;
-
 	std::unique_lock<mutex> lock(sync_mutex);
-	if (skip_wal_sync) {
-		synced_offset = MaxValue(synced_offset, target_offset);
-		return;
-	}
 	while (synced_offset < target_offset) {
 		if (sync_in_progress) {
 			// another thread is currently performing an fsync - wait for it to finish

--- a/src/storage/write_ahead_log.cpp
+++ b/src/storage/write_ahead_log.cpp
@@ -20,10 +20,15 @@
 #include "duckdb/storage/index.hpp"
 #include "duckdb/storage/single_file_block_manager.hpp"
 #include "duckdb/storage/storage_manager.hpp"
+#include "duckdb/main/attached_database.hpp"
+#include "duckdb/main/settings.hpp"
 #include "duckdb/storage/table/column_data.hpp"
 #include "duckdb/storage/table/data_table_info.hpp"
 #include "duckdb/storage/data_table.hpp"
 #include "duckdb/storage/wal_entry.hpp"
+
+#include <chrono>
+#include <thread>
 
 namespace duckdb {
 
@@ -86,8 +91,15 @@ void WriteAheadLog::Truncate(idx_t size) {
 		storage_manager.SetWALSize(size);
 		return;
 	}
-	writer->Truncate(size);
-	storage_manager.SetWALSize(writer->GetFileSize());
+	idx_t file_size;
+	{
+		// serialize the truncate (which removes reverted/uncommitted WAL entries) against the group commit sync
+		// leader's push-to-OS, which runs without the storage manager WAL lock (see LockFlush())
+		auto flush_guard = LockFlush();
+		writer->Truncate(size);
+		file_size = writer->GetFileSize();
+	}
+	storage_manager.SetWALSize(file_size);
 }
 
 bool WriteAheadLog::Initialized() const {
@@ -121,6 +133,9 @@ public:
 			return FlushEncrypted();
 		}
 
+		// serialize this entry's writes into the WAL buffer against the group commit sync leader's push-to-OS
+		// (which takes the same flush lock) - see WriteAheadLog::LockFlush()
+		auto flush_guard = wal.LockFlush();
 		auto data = memory_stream.GetData();
 		auto size = memory_stream.GetPosition();
 		// compute the checksum over the entry
@@ -138,6 +153,8 @@ public:
 		auto &catalog = wal.GetDatabase().GetCatalog().Cast<DuckCatalog>();
 		auto encryption_key_id = catalog.GetEncryptionKeyId();
 
+		// serialize this entry's writes into the WAL buffer against the sync leader's push-to-OS (see LockFlush())
+		auto flush_guard = wal.LockFlush();
 		auto data = memory_stream.GetData();
 		auto size = memory_stream.GetPosition();
 
@@ -246,6 +263,13 @@ private:
 //===--------------------------------------------------------------------===//
 void WriteAheadLog::WriteHeader() {
 	D_ASSERT(writer);
+	// Serialize the "has a header been written?" check + the header write against the group commit sync leader's
+	// push-to-OS. GetFileSize() = on-disk size + buffered offset, read non-atomically, while the leader's Flush()
+	// mutates both (fs.Write grows the file, then sets offset=0). Without this lock a committer can observe
+	// GetFileSize()==0 after the header was already written (torn read across the leader's flush) and write a
+	// SECOND header mid-WAL, which corrupts replay. The header is written directly to the writer (not via
+	// ChecksumWriter), so it would otherwise bypass the flush lock entirely.
+	auto flush_guard = LockFlush();
 	if (writer->GetFileSize() > 0) {
 		// Already written - no need to write a header.
 		return;
@@ -578,14 +602,156 @@ void WriteAheadLog::Flush() {
 	if (!writer) {
 		return;
 	}
+	auto target_offset = WriteFlushMarker();
+	// the caller holds the WAL lock, so no concurrent appends can arrive - no point waiting for a batch
+	SyncUpTo(target_offset, false);
+}
 
-	// write an empty entry
+idx_t WriteAheadLog::WriteFlushMarker(bool requires_block_sync, bool push_to_os) {
+	if (!writer) {
+		return 0;
+	}
+
+	// write an empty entry (appended to the in-memory WAL buffer under flush_lock, via ChecksumWriter::Flush)
 	WriteAheadLogSerializer serializer(*this, WALType::WAL_FLUSH);
 	serializer.End();
 
-	// flushes all changes made to the WAL to disk
-	writer->Sync();
-	storage_manager.SetWALSize(writer->GetFileSize());
+	idx_t target_offset;
+	idx_t file_size;
+	{
+		// Under flush_lock: (optionally) push the buffered data to the OS now, and snapshot + advance written_offset.
+		// Holding flush_lock keeps the push and the written_offset update atomic with respect to the sync leader
+		// (which also pushes the buffer + reads written_offset under flush_lock). In the deferred path
+		// (push_to_os=false) the bytes stay buffered until the sync leader flushes them.
+		auto flush_guard = LockFlush();
+		if (push_to_os) {
+			// synchronous path: push all buffered data to the operating system now (the fsync happens in SyncUpTo)
+			writer->Flush();
+		}
+		// note: GetTotalWritten() is the logical byte count (buffered + flushed), the same whether or not we pushed
+		target_offset = writer->GetTotalWritten();
+		file_size = writer->GetFileSize();
+		if (requires_block_sync) {
+			// record that this marker references optimistically written row group data
+			// this must happen BEFORE written_offset advances: any sync leader whose fsync covers this marker
+			// must observe the block sync requirement (see SyncUpTo)
+			block_sync_pending_offset = MaxValue<idx_t>(block_sync_pending_offset.load(), target_offset);
+		}
+		written_offset = target_offset;
+	}
+	storage_manager.SetWALSize(file_size);
+	return target_offset;
+}
+
+void WriteAheadLog::SyncUpTo(idx_t target_offset, bool wait_for_batch, bool leader_pushes_batch) {
+	// PROTOTYPE BENCHMARK HACK - DO NOT COMMIT
+	// when DUCKDB_BENCH_SKIP_WAL_SYNC is set we skip the fsync to measure the no-fsync commit throughput ceiling
+	static const bool skip_wal_sync = getenv("DUCKDB_BENCH_SKIP_WAL_SYNC") != nullptr;
+
+	std::unique_lock<mutex> lock(sync_mutex);
+	if (skip_wal_sync) {
+		synced_offset = MaxValue(synced_offset, target_offset);
+		return;
+	}
+	while (synced_offset < target_offset) {
+		if (sync_in_progress) {
+			// another thread is currently performing an fsync - wait for it to finish
+			// its fsync might not cover our target offset (it could have started before our data was written),
+			// in which case we loop around and either become the next leader or wait again
+			sync_waiters++;
+			sync_cv.wait(lock);
+			sync_waiters--;
+			continue;
+		}
+		// no fsync in progress - this thread becomes the sync leader
+		// the fsync covers everything pushed to the operating system up to this point, including the flush
+		// markers of other concurrently committing transactions - they share this single fsync (group commit)
+		sync_in_progress = true;
+		bool do_batch_wait = wait_for_batch && batch_commits;
+		lock.unlock();
+		auto sync_target = written_offset.load();
+		if (do_batch_wait) {
+			// Other transactions were committing concurrently during the previous fsync.
+			// Before fsync-ing, give concurrently committing transactions a window to finish appending their
+			// flush markers, so that this fsync covers them as well and they do not have to wait for the next
+			// one (micro-batching, similar in spirit to PostgreSQL's commit_delay).
+			// The maximum window is experimental_group_commit_delay microseconds; with -1 (automatic, the
+			// default) it is scaled to a fraction of the observed fsync duration: a wait that is small relative
+			// to the fsync adds little commit latency, while letting (at best) an entire round of concurrent
+			// committers share this fsync. The wait stops early as soon as no new appends arrive.
+			auto delay_micros = Settings::Get<ExperimentalGroupCommitDelaySetting>(GetDatabase().GetDatabase());
+			if (delay_micros < 0) {
+				delay_micros = static_cast<int64_t>(sync_duration_micros.load() / 4);
+			}
+			if (delay_micros > 0) {
+				auto deadline = std::chrono::steady_clock::now() + std::chrono::microseconds(delay_micros);
+				// note that the effective poll granularity is limited by the operating system timer resolution
+				auto poll_interval = std::chrono::microseconds(MaxValue<int64_t>(delay_micros / 10, 20));
+				while (true) {
+					std::this_thread::sleep_for(poll_interval);
+					auto new_target = written_offset.load();
+					if (new_target == sync_target) {
+						// no new appends - stop waiting
+						break;
+					}
+					sync_target = new_target;
+					if (std::chrono::steady_clock::now() >= deadline) {
+						break;
+					}
+				}
+			}
+		}
+		if (leader_pushes_batch && writer) {
+			// Deferred group commit: committers only appended their flush markers to the in-memory WAL buffer
+			// (WriteFlushMarker with push_to_os=false). The sync leader now pushes the whole accumulated batch to
+			// the operating system in a single write(), so the per-write round-trip (multi-ms on network storage
+			// like EFS, and worse under concurrency) is shared across all batched commits instead of paid per
+			// commit. The push runs under the WAL flush_lock - NOT the storage manager WAL lock - so it cannot
+			// deadlock against a checkpoint / catalog commit / synchronous commit that holds the WAL lock and waits.
+			// Pushing the whole buffer is safe: deferred commits write their WAL entries only after
+			// ValidateCommitConflicts (so they cannot be reverted/truncated), and any not-yet-marked trailing bytes
+			// are ignored on crash recovery (replay stops at the last flush marker). sync_target stays at the last
+			// committed marker, so durability is only ever promised up to a committed point.
+			lock_guard<mutex> flush_guard(flush_lock);
+			writer->Flush();
+			sync_target = written_offset.load();
+		}
+		ErrorData error;
+		try {
+			if (block_sync_pending_offset.load() > block_synced_offset.load()) {
+				// one or more flush markers covered by this fsync reference optimistically written row group
+				// data: the referenced blocks must be durable in the database file BEFORE the WAL fsync makes
+				// those markers durable. Perform one (batched) database file sync covering all of them.
+				// A marker above sync_target conservatively triggers another sync in a later round.
+				storage_manager.GetBlockManager().FileSync();
+				block_synced_offset = MaxValue<idx_t>(block_synced_offset.load(), sync_target);
+			}
+			auto sync_start = std::chrono::steady_clock::now();
+			writer->SyncData();
+			// update the moving average of the fsync duration (drives the automatic micro-batching window)
+			auto sync_micros = static_cast<idx_t>(
+			    std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - sync_start)
+			        .count());
+			auto previous = sync_duration_micros.load();
+			sync_duration_micros = previous == 0 ? sync_micros : (3 * previous + sync_micros) / 4;
+		} catch (std::exception &ex) {
+			error = ErrorData(ex);
+		}
+		// detect concurrent commit activity: did other transactions append while we were syncing?
+		auto post_sync_written = written_offset.load();
+		lock.lock();
+		sync_in_progress = false;
+		// adaptive micro-batching: only wait for a batch to form when there is concurrent commit activity,
+		// i.e. other transactions are waiting on this fsync or appended to the WAL while we were syncing
+		batch_commits = sync_waiters > 0 || post_sync_written > sync_target;
+		if (!error.HasError()) {
+			synced_offset = MaxValue(synced_offset, sync_target);
+		}
+		sync_cv.notify_all();
+		if (error.HasError()) {
+			error.Throw();
+		}
+	}
 }
 
 void WriteAheadLog::IncrementWALEntriesCount() {

--- a/src/storage/write_ahead_log.cpp
+++ b/src/storage/write_ahead_log.cpp
@@ -675,11 +675,11 @@ void WriteAheadLog::SyncUpTo(idx_t target_offset, bool wait_for_batch, bool lead
 			// Before fsync-ing, give concurrently committing transactions a window to finish appending their
 			// flush markers, so that this fsync covers them as well and they do not have to wait for the next
 			// one (micro-batching, similar in spirit to PostgreSQL's commit_delay).
-			// The maximum window is experimental_group_commit_delay microseconds; with -1 (automatic, the
+			// The maximum window is group_commit_delay microseconds; with -1 (automatic, the
 			// default) it is scaled to a fraction of the observed fsync duration: a wait that is small relative
 			// to the fsync adds little commit latency, while letting (at best) an entire round of concurrent
 			// committers share this fsync. The wait stops early as soon as no new appends arrive.
-			auto delay_micros = Settings::Get<ExperimentalGroupCommitDelaySetting>(GetDatabase().GetDatabase());
+			auto delay_micros = Settings::Get<GroupCommitDelaySetting>(GetDatabase().GetDatabase());
 			if (delay_micros < 0) {
 				delay_micros = static_cast<int64_t>(sync_duration_micros.load() / 4);
 			}

--- a/src/storage/write_ahead_log.cpp
+++ b/src/storage/write_ahead_log.cpp
@@ -78,6 +78,9 @@ idx_t WriteAheadLog::GetTotalWritten() const {
 	if (!Initialized()) {
 		return 0;
 	}
+	// serialize against the group commit sync leader's buffer push (writer->Flush() under flush_lock), which mutates
+	// the same offset/total_written fields this read sums
+	lock_guard<mutex> flush_guard(flush_lock);
 	return writer->GetTotalWritten();
 }
 

--- a/src/transaction/commit_state.cpp
+++ b/src/transaction/commit_state.cpp
@@ -266,6 +266,16 @@ void CommitState::CommitEntryDrop(CatalogEntry &entry, data_ptr_t dataptr, Commi
 	}
 }
 
+void CommitState::VerifyTableModification(DuckTableEntry &table, transaction_t transaction_id) {
+	if (table.HasParent() && table.Parent().timestamp != transaction_id) {
+		auto &storage = table.GetStorage();
+		auto table_name = storage.GetTableName();
+		auto table_modification = storage.TableModification();
+		throw TransactionException("Attempting to modify table %s but another transaction has %s this table",
+		                           table_name, table_modification);
+	}
+}
+
 void CommitState::CommitEntry(UndoFlags type, data_ptr_t data, CommitInfo &info) {
 	switch (type) {
 	case UndoFlags::CATALOG_ENTRY: {
@@ -298,13 +308,7 @@ void CommitState::CommitEntry(UndoFlags type, data_ptr_t data, CommitInfo &info)
 	case UndoFlags::INSERT_TUPLE: {
 		// append:
 		auto info = reinterpret_cast<AppendInfo *>(data);
-		if (info->table->HasParent() && info->table->Parent().timestamp != transaction.transaction_id) {
-			auto &storage = info->table->GetStorage();
-			auto table_name = storage.GetTableName();
-			auto table_modification = storage.TableModification();
-			throw TransactionException("Attempting to modify table %s but another transaction has %s this table",
-			                           table_name, table_modification);
-		}
+		VerifyTableModification(*info->table, transaction.transaction_id);
 		// mark the tuples as committed
 		info->table->GetStorage().CommitAppend(commit_id, info->start_row, info->count);
 		break;
@@ -312,26 +316,14 @@ void CommitState::CommitEntry(UndoFlags type, data_ptr_t data, CommitInfo &info)
 	case UndoFlags::DELETE_TUPLE: {
 		// deletion:
 		auto info = reinterpret_cast<DeleteInfo *>(data);
-		if (info->table->HasParent() && info->table->Parent().timestamp != transaction.transaction_id) {
-			auto &storage = info->table->GetStorage();
-			auto table_name = storage.GetTableName();
-			auto table_modification = storage.TableModification();
-			throw TransactionException("Attempting to modify table %s but another transaction has %s this table",
-			                           table_name, table_modification);
-		}
+		VerifyTableModification(*info->table, transaction.transaction_id);
 		CommitDelete(*info);
 		break;
 	}
 	case UndoFlags::UPDATE_TUPLE: {
 		// update:
 		auto info = reinterpret_cast<UpdateInfo *>(data);
-		if (info->table->HasParent() && info->table->Parent().timestamp != transaction.transaction_id) {
-			auto &storage = info->table->GetStorage();
-			auto table_name = storage.GetTableName();
-			auto table_modification = storage.TableModification();
-			throw TransactionException("Attempting to modify table %s but another transaction has %s this table",
-			                           table_name, table_modification);
-		}
+		VerifyTableModification(*info->table, transaction.transaction_id);
 		info->version_number = commit_id;
 		break;
 	}

--- a/src/transaction/duck_transaction.cpp
+++ b/src/transaction/duck_transaction.cpp
@@ -331,7 +331,8 @@ ErrorData DuckTransaction::Commit(AttachedDatabase &db, CommitInfo &commit_info,
 ErrorData DuckTransaction::CommitToWAL(AttachedDatabase &db, CommitInfo &commit_info,
                                        unique_ptr<StorageCommitState> commit_state,
                                        idx_t &flush_marker_offset) noexcept {
-	this->commit_id = commit_info.commit_id;
+	// the commit timestamp is assigned later (at publish time, under the transaction lock) - writing the flush
+	// marker does not need it, and assigning it here would expose it to transactions that start before publish
 	flush_marker_offset = 0;
 	D_ASSERT(commit_state);
 	D_ASSERT(ChangesMade());
@@ -354,7 +355,11 @@ ErrorData DuckTransaction::CommitToWAL(AttachedDatabase &db, CommitInfo &commit_
 }
 
 ErrorData DuckTransaction::PublishCommit(AttachedDatabase &db, CommitInfo &commit_info) noexcept {
-	D_ASSERT(this->commit_id == commit_info.commit_id);
+	this->commit_id = commit_info.commit_id;
+	if (!ChangesMade()) {
+		// no need to flush anything if we made no changes
+		return ErrorData();
+	}
 	// deferred commits are data-only: catalog-changing transactions commit through Commit()
 	D_ASSERT(catalog_version < TRANSACTION_ID_START);
 	UndoBuffer::IteratorState iterator_state;

--- a/src/transaction/duck_transaction.cpp
+++ b/src/transaction/duck_transaction.cpp
@@ -239,14 +239,10 @@ ErrorData DuckTransaction::WriteToWAL(ClientContext &context, AttachedDatabase &
 				// if we have optimistically written any data AND we are writing to the WAL, we have written
 				// references to optimistically written blocks
 				// hence we need to ensure those optimistically written blocks are persisted
-				if (Settings::Get<ExperimentalGroupCommitSetting>(db.GetDatabase())) {
-					// group commit: defer the database file sync to the WAL sync leader, which performs it (batched
-					// across transactions, outside of the WAL lock) before any WAL fsync that makes this commit's
-					// flush marker durable - preserving the blocks-before-references ordering
-					commit_state->DeferBlockSync();
-				} else {
-					storage_manager.GetBlockManager().FileSync();
-				}
+				// group commit: defer the database file sync to the WAL sync leader, which performs it (batched
+				// across transactions, outside of the WAL lock) before any WAL fsync that makes this commit's
+				// flush marker durable - preserving the blocks-before-references ordering
+				commit_state->DeferBlockSync();
 			}
 			wal_timer.EndTimer();
 		}

--- a/src/transaction/duck_transaction.cpp
+++ b/src/transaction/duck_transaction.cpp
@@ -17,6 +17,7 @@
 #include "duckdb/transaction/update_info.hpp"
 #include "duckdb/transaction/local_storage.hpp"
 #include "duckdb/main/config.hpp"
+#include "duckdb/main/settings.hpp"
 #include "duckdb/storage/table/column_data.hpp"
 #include "duckdb/main/client_data.hpp"
 #include "duckdb/main/query_profiler.hpp"
@@ -220,15 +221,35 @@ ErrorData DuckTransaction::WriteToWAL(ClientContext &context, AttachedDatabase &
 		storage->Commit(commit_state.get());
 		commit_timer.EndTimer();
 
-		auto wal_timer = profiler.StartTimer<MetricStorageWriteToWALLatency>();
-		undo_buffer.WriteToWAL(*wal, commit_state.get());
-		if (commit_state->HasRowGroupData()) {
-			// if we have optimistically written any data AND we are writing to the WAL, we have written references to
-			// optimistically written blocks
-			// hence we need to ensure those optimistically written blocks are persisted
-			storage_manager.GetBlockManager().FileSync();
+		// Validate that the commit cannot fail BEFORE writing any WAL entries. The deferred (group commit) path is
+		// data-only (defer_publish requires no catalog changes), so VerifyTableModification is the complete
+		// pre-commit conflict check there: a commit that passes it can no longer fail. Writing the WAL entries only
+		// after validation means a failing commit never puts bytes in the shared WAL - so there is no WAL truncation
+		// on the concurrent commit path, which would otherwise race the group commit sync leader's flush and corrupt
+		// the WAL. This check is read-only and only needs the WAL lock (held here, blocking concurrent catalog
+		// changes that VerifyTableModification guards against); it does not need the transaction lock, so the (slow)
+		// entry write below still runs without it. Catalog-changing commits take the synchronous path and validate
+		// as they apply - they are serialized behind the WAL lock and drain pending commits, so their (rare) revert
+		// does not race the sync leader.
+		error_data = undo_buffer.ValidateCommitConflicts();
+		if (!error_data.HasError()) {
+			auto wal_timer = profiler.StartTimer<MetricStorageWriteToWALLatency>();
+			undo_buffer.WriteToWAL(*wal, commit_state.get());
+			if (commit_state->HasRowGroupData()) {
+				// if we have optimistically written any data AND we are writing to the WAL, we have written
+				// references to optimistically written blocks
+				// hence we need to ensure those optimistically written blocks are persisted
+				if (Settings::Get<ExperimentalGroupCommitSetting>(db.GetDatabase())) {
+					// group commit: defer the database file sync to the WAL sync leader, which performs it (batched
+					// across transactions, outside of the WAL lock) before any WAL fsync that makes this commit's
+					// flush marker durable - preserving the blocks-before-references ordering
+					commit_state->DeferBlockSync();
+				} else {
+					storage_manager.GetBlockManager().FileSync();
+				}
+			}
+			wal_timer.EndTimer();
 		}
-		wal_timer.EndTimer();
 
 	} catch (std::exception &ex) {
 		// Call RevertCommit() outside this try-catch as it itself may throw
@@ -309,6 +330,51 @@ ErrorData DuckTransaction::Commit(AttachedDatabase &db, CommitInfo &commit_info,
 		                             error_data.RawMessage());
 	}
 	return error_data;
+}
+
+ErrorData DuckTransaction::CommitToWAL(AttachedDatabase &db, CommitInfo &commit_info,
+                                       unique_ptr<StorageCommitState> commit_state,
+                                       idx_t &flush_marker_offset) noexcept {
+	this->commit_id = commit_info.commit_id;
+	flush_marker_offset = 0;
+	D_ASSERT(commit_state);
+	D_ASSERT(ChangesMade());
+	D_ASSERT(!IsReadOnly());
+	try {
+		// Conflicts were already validated in WriteToWAL, BEFORE any WAL entries were written (the deferred path is
+		// data-only, so that check is complete). This commit can no longer fail, and its entries are already in the
+		// WAL - so we just write the flush marker. Once the marker is written the commit must complete; it can be
+		// replayed after a crash. The marker is written without fsync (the caller batches the fsync across
+		// transactions); we capture the WAL offset the caller must SyncUpTo() to make this commit durable.
+		flush_marker_offset = commit_state->FlushCommitMarker();
+		return ErrorData();
+	} catch (std::exception &ex) {
+		try {
+			commit_state->RevertCommit();
+		} catch (...) { // NOLINT
+		}
+		return ErrorData(ex);
+	}
+}
+
+ErrorData DuckTransaction::PublishCommit(AttachedDatabase &db, CommitInfo &commit_info) noexcept {
+	D_ASSERT(this->commit_id == commit_info.commit_id);
+	// deferred commits are data-only: catalog-changing transactions commit through Commit()
+	D_ASSERT(catalog_version < TRANSACTION_ID_START);
+	UndoBuffer::IteratorState iterator_state;
+	optional_ptr<BlockManager> block_manager;
+	if (db.HasStorageManager()) {
+		block_manager = db.GetStorageManager().GetBlockManager();
+	}
+	CommitDropState drop_state(block_manager);
+	commit_info.drop_state = &drop_state;
+	try {
+		undo_buffer.Commit(iterator_state, commit_info);
+		drop_state.FinalizeCommit();
+		return ErrorData();
+	} catch (std::exception &ex) {
+		return ErrorData(ex);
+	}
 }
 
 ErrorData DuckTransaction::Rollback() {

--- a/src/transaction/duck_transaction_manager.cpp
+++ b/src/transaction/duck_transaction_manager.cpp
@@ -294,29 +294,29 @@ void DuckTransactionManager::CleanupTransactions() {
 	}
 }
 
-bool DuckTransactionManager::RegisterPendingCommit(transaction_t commit_id) {
+bool DuckTransactionManager::RegisterPendingCommit(transaction_t publish_seq) {
 	lock_guard<mutex> guard(publish_lock);
 	if (catalog_gate_waiters > 0) {
 		// a DDL operation is waiting for pending commits to drain - do not admit new deferred commits,
 		// the caller must fall back to the synchronous commit path
 		return false;
 	}
-	pending_commit_publishes.insert(commit_id);
+	pending_commit_publishes.insert(publish_seq);
 	return true;
 }
 
-void DuckTransactionManager::WaitForPublishTurn(transaction_t commit_id) {
+void DuckTransactionManager::WaitForPublishTurn(transaction_t publish_seq) {
 	std::unique_lock<mutex> guard(publish_lock);
 	publish_cv.wait(guard, [&]() {
 		D_ASSERT(!pending_commit_publishes.empty());
-		return *pending_commit_publishes.begin() == commit_id;
+		return *pending_commit_publishes.begin() == publish_seq;
 	});
 }
 
-void DuckTransactionManager::FinishPendingCommit(transaction_t commit_id) {
+void DuckTransactionManager::FinishPendingCommit(transaction_t publish_seq) {
 	{
 		lock_guard<mutex> guard(publish_lock);
-		pending_commit_publishes.erase(commit_id);
+		pending_commit_publishes.erase(publish_seq);
 	}
 	publish_cv.notify_all();
 }
@@ -432,9 +432,11 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 			storage_manager.AddWALSize(undo_properties.estimated_size);
 		}
 	}
-	// obtain a commit id for the transaction
+	// The commit timestamp is assigned later, at publish time (not here): a transaction that starts while this
+	// commit is still being made durable must not observe a commit id that is not yet published, otherwise it
+	// could read pre-commit data without the update conflict being detected. The deferred path assigns it under
+	// the transaction lock right before publishing; the synchronous path assigns it just before committing below.
 	CommitInfo info;
-	info.commit_id = GetCommitTimestamp();
 
 	// Group commit: data-only commits that write to the WAL defer publishing
 	// (making their changes visible) until after their WAL entries have been fsynced. This way no transaction can
@@ -444,10 +446,15 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 	// before releasing it - no new transaction can start in the meantime, so those commits are also never visible
 	// before they are durable.
 	bool defer_publish = !error.HasError() && commit_state && !has_catalog_changes;
-	if (defer_publish && !RegisterPendingCommit(info.commit_id)) {
-		// a DDL operation is waiting for pending commits to drain before attaching a new catalog version -
-		// fall back to the synchronous commit path (publish + inline fsync under the locks)
-		defer_publish = false;
+	// the publish sequence orders deferred publishes in WAL order; it is independent of the commit timestamp
+	transaction_t publish_seq = 0;
+	if (defer_publish) {
+		publish_seq = next_publish_sequence++;
+		if (!RegisterPendingCommit(publish_seq)) {
+			// a DDL operation is waiting for pending commits to drain before attaching a new catalog version -
+			// fall back to the synchronous commit path (publish + inline fsync under the locks)
+			defer_publish = false;
+		}
 	}
 
 	// commit the UndoBuffer of the transaction
@@ -465,9 +472,11 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 			// must SyncUpTo() to make this commit durable.
 			error = transaction.CommitToWAL(db, info, std::move(commit_state), flush_marker_offset);
 			if (error.HasError()) {
-				FinishPendingCommit(info.commit_id);
+				FinishPendingCommit(publish_seq);
 			}
 		} else {
+			// synchronous path: publishes under the transaction lock, so the commit id can be assigned now
+			info.commit_id = GetCommitTimestamp();
 			error = transaction.Commit(db, info, std::move(commit_state));
 		}
 	}
@@ -532,7 +541,7 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 		} catch (std::exception &ex) {
 			// the WAL cannot be guaranteed to be durable, and the flush marker can no longer be truncated
 			// (other transactions may have appended in the meantime): this is fatal
-			FinishPendingCommit(info.commit_id);
+			FinishPendingCommit(publish_seq);
 			ErrorData sync_error(ex);
 			throw FatalException("Failed to sync WAL during commit. Cannot continue operation.\nError: %s",
 			                     sync_error.Message());
@@ -540,9 +549,12 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 
 		// publish in commit order - this keeps recently_committed_transactions ordered on commit_id and ensures
 		// that the visible state always corresponds to a prefix of the WAL (matching replay after a crash)
-		WaitForPublishTurn(info.commit_id);
+		WaitForPublishTurn(publish_seq);
 
 		t_lock.lock();
+		// now that it is our turn and we hold the transaction lock, assign the commit timestamp and publish: a
+		// transaction that starts after this point observes this commit, one that started before it does not
+		info.commit_id = GetCommitTimestamp();
 		// other transactions may have started or committed while we were syncing - recompute the state
 		if (HasOtherTransactions(transaction)) {
 			info.active_transactions = ActiveTransactionState::OTHER_TRANSACTIONS;
@@ -554,7 +566,7 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 			// the commit is durable in the WAL and can no longer be rolled back: this is fatal
 			// (after a restart, WAL replay applies the transaction, which is the correct committed state)
 			t_lock.unlock();
-			FinishPendingCommit(info.commit_id);
+			FinishPendingCommit(publish_seq);
 			throw FatalException("Failed to publish commit after WAL write. Cannot continue operation.\nError: %s",
 			                     publish_error.Message());
 		}
@@ -586,7 +598,7 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 	}
 	if (defer_publish) {
 		// the commit is now published - wake up any waiters (later commits and checkpoints)
-		FinishPendingCommit(info.commit_id);
+		FinishPendingCommit(publish_seq);
 	}
 
 	CleanupTransactions();

--- a/src/transaction/duck_transaction_manager.cpp
+++ b/src/transaction/duck_transaction_manager.cpp
@@ -275,6 +275,14 @@ transaction_t DuckTransactionManager::GetCommitTimestamp() {
 	return current_start_timestamp++;
 }
 
+void DuckTransactionManager::RetireAfterCheckpoint(shared_ptr<void> retired_object) {
+	if (!retired_object) {
+		return;
+	}
+	lock_guard<mutex> l(retired_lock);
+	retired_after_checkpoint.push_back(std::move(retired_object));
+}
+
 void DuckTransactionManager::CleanupTransactions() {
 	lock_guard<mutex> c_lock(cleanup_lock);
 	while (true) {
@@ -283,7 +291,7 @@ void DuckTransactionManager::CleanupTransactions() {
 			lock_guard<mutex> q_lock(cleanup_queue_lock);
 			if (cleanup_queue.empty()) {
 				// all transactions have been cleaned up - done
-				return;
+				break;
 			}
 			top_cleanup_info = std::move(cleanup_queue.front());
 			cleanup_queue.pop();
@@ -291,6 +299,18 @@ void DuckTransactionManager::CleanupTransactions() {
 		if (top_cleanup_info) {
 			top_cleanup_info->Cleanup();
 		}
+	}
+	// The cleanup queue is now drained. If the database is quiescent (no active transactions) all undo buffers have
+	// been cleaned up, so no UpdateInfo can reference a row group that a checkpoint retired - it is safe to free them.
+	// Active transactions have a start_time below TRANSACTION_ID_START; lowest_active_start reaching
+	// TRANSACTION_ID_START (its idle value) therefore means there are no active transactions.
+	if (lowest_active_start.load() >= TRANSACTION_ID_START) {
+		vector<shared_ptr<void>> to_free;
+		{
+			lock_guard<mutex> l(retired_lock);
+			to_free.swap(retired_after_checkpoint);
+		}
+		// drop the references outside the lock
 	}
 }
 

--- a/src/transaction/duck_transaction_manager.cpp
+++ b/src/transaction/duck_transaction_manager.cpp
@@ -341,11 +341,6 @@ void DuckTransactionManager::FinishPendingCommit(transaction_t publish_seq) {
 	publish_cv.notify_all();
 }
 
-void DuckTransactionManager::WaitForPendingCommits() {
-	std::unique_lock<mutex> guard(publish_lock);
-	publish_cv.wait(guard, [&]() { return pending_commit_publishes.empty(); });
-}
-
 unique_lock<mutex> DuckTransactionManager::BlockPendingCommits() {
 	unique_lock<mutex> guard(publish_lock);
 	// while we wait, new commits cannot register as pending (they fall back to the synchronous path) -
@@ -556,10 +551,10 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 		// deferred (group) commit: capture the WAL; the offset we must sync to is the one our flush marker returned
 		// from CommitToWAL (flush_marker_offset), threaded through explicitly rather than re-read from the WAL - so
 		// the durability target is exactly our marker and does not depend on no other commit having appended since.
-		// the shared_ptr keeps the WAL alive across the fsync (defensive: the shared WAL lock we hold already
-		// prevents a concurrent checkpoint from swapping it out)
+		// We hold the WAL lock SHARED here, which prevents a concurrent checkpoint (EXCLUSIVE) from swapping the WAL
+		// out from under us, so a plain pointer to the current WAL is safe across the fsync below.
 		D_ASSERT(held_wal_lock);
-		auto sync_wal = db.GetStorageManager().GetWALShared();
+		auto sync_wal = db.GetStorageManager().GetWAL();
 		idx_t sync_target = flush_marker_offset;
 
 		// release the transaction lock so other transactions can start/commit while we wait for the fsync, and their

--- a/src/transaction/duck_transaction_manager.cpp
+++ b/src/transaction/duck_transaction_manager.cpp
@@ -377,11 +377,8 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 	// shared WAL lock alone would let concurrent committers interleave their entries and corrupt the WAL. Released
 	// before the fsync so batching is preserved. Exclusive committers do not need it (the WAL lock serializes them).
 	unique_lock<mutex> append_guard;
-	// Per-table publish gates: a commit holds each modified table's gate SHARED from before its catalog validation
-	// (in WriteToWAL) through publish, so a concurrent DDL on that table (which takes the gate EXCLUSIVE via
-	// DataTableInfo::GetPublishGateExclusive) cannot make the validation stale or race the publish's index updates.
-	// Acquired in address order (see GetModifiedTableInfos) for deadlock-freedom; released after publish.
-	// modified_table_infos keeps the DataTableInfos alive while their gate handles are held.
+	// Each modified table's publish gate, held SHARED from before validation (in WriteToWAL) through publish so a DDL
+	// on that table cannot interleave; address-ordered (see GetModifiedTableInfos) for deadlock-freedom.
 	vector<shared_ptr<DataTableInfo>> modified_table_infos;
 	vector<unique_ptr<StorageLockKey>> table_gates;
 	unique_ptr<StorageCommitState> commit_state;
@@ -403,9 +400,8 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 		}
 	}
 	bool should_write_to_wal = transaction.ShouldWriteToWAL(db);
-	// Catalog-changing commits cannot defer publishing their changes (see below) - they publish while holding the
-	// transaction lock. A DDL's catalog-version attachment is kept from interleaving a data commit's validation and
-	// publish by the per-table publish gate (see GetPublishGateExclusive / table_gates), not by this commit path.
+	// Catalog-changing commits publish synchronously under the transaction lock (see below); DDL-vs-commit ordering
+	// is handled by the per-table publish gate (table_gates), not here.
 	bool has_catalog_changes = undo_properties.has_catalog_changes;
 	if (should_write_to_wal) {
 		auto &storage_manager = db.GetStorageManager().Cast<SingleFileStorageManager>();
@@ -489,9 +485,8 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 	// the publish sequence orders deferred publishes in WAL order; it is independent of the commit timestamp
 	idx_t publish_seq = 0;
 	if (defer_publish) {
-		// assign the publish sequence and register for in-order publishing. A concurrent catalog change on a table we
-		// modified cannot interleave: it takes that table's publish gate EXCLUSIVELY (GetPublishGateExclusive) while
-		// we hold it SHARED through publish (see table_gates above).
+		// assign the publish sequence and register for in-order publishing (the per-table gate above keeps a
+		// concurrent DDL from interleaving)
 		publish_seq = next_publish_sequence++;
 		RegisterPendingCommit(publish_seq);
 	}
@@ -504,11 +499,9 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 			info.active_transactions = ActiveTransactionState::NO_OTHER_TRANSACTIONS;
 		}
 		if (defer_publish) {
-			// write the WAL flush marker - the commit is published after the group fsync below. Conflicts were
-			// already validated in WriteToWAL (before any entries were written). We hold each modified table's publish
-			// gate SHARED from before that validation until we publish, so no catalog version can be attached to a
-			// table we modified in between (see GetPublishGateExclusive), keeping the validation authoritative.
-			// flush_marker_offset is the WAL offset we must SyncUpTo() to make this commit durable.
+			// write the WAL flush marker - published after the group fsync below. Conflicts were already validated in
+			// WriteToWAL; the per-table gate (held through publish) keeps that validation authoritative.
+			// flush_marker_offset is the WAL offset SyncUpTo() must reach to make this commit durable.
 			error = transaction.CommitToWAL(db, info, std::move(commit_state), flush_marker_offset);
 			if (error.HasError()) {
 				FinishPendingCommit(publish_seq);

--- a/src/transaction/duck_transaction_manager.cpp
+++ b/src/transaction/duck_transaction_manager.cpp
@@ -375,7 +375,6 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 		}
 	}
 	bool should_write_to_wal = transaction.ShouldWriteToWAL(db);
-	bool allow_group_commit = Settings::Get<ExperimentalGroupCommitSetting>(db.GetDatabase());
 	// Catalog-changing commits cannot defer publishing their changes (see below) - they publish while holding the
 	// transaction lock. To guarantee that no catalog change can interleave between a data commit's WAL flush marker
 	// and its publish, they first wait for all pending (unpublished) commits to be published.
@@ -397,7 +396,7 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 		if (!skip_wal_write_due_to_checkpoint) {
 			error = transaction.WriteToWAL(context, db, commit_state);
 			wal_written = true;
-			if (allow_group_commit && !error.HasError() && has_catalog_changes) {
+			if (!error.HasError() && has_catalog_changes) {
 				// we hold the WAL lock (no new pending commits can register), but not the transaction lock
 				// (pending commits can finish publishing)
 				WaitForPendingCommits();
@@ -437,18 +436,14 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 	CommitInfo info;
 	info.commit_id = GetCommitTimestamp();
 
-	// Group commit (experimental, off by default): data-only commits that write to the WAL defer publishing
+	// Group commit: data-only commits that write to the WAL defer publishing
 	// (making their changes visible) until after their WAL entries have been fsynced. This way no transaction can
 	// ever observe a commit that is not yet durable, while the fsync itself happens outside of the transaction
 	// lock and the WAL lock, so that concurrently committing transactions can share a single fsync.
 	// Catalog-changing commits take the non-deferred path: they publish under the transaction lock and fsync inline
 	// before releasing it - no new transaction can start in the meantime, so those commits are also never visible
 	// before they are durable.
-	// With the setting disabled, all commits take the non-deferred path, which behaves exactly like the
-	// pre-group-commit code (publish + inline durable fsync under the locks). The pending-commit drains and the
-	// catalog gate are kept unconditional: they are no-ops while no deferred commits exist, which also makes
-	// toggling the setting at runtime safe.
-	bool defer_publish = allow_group_commit && !error.HasError() && commit_state && !has_catalog_changes;
+	bool defer_publish = !error.HasError() && commit_state && !has_catalog_changes;
 	if (defer_publish && !RegisterPendingCommit(info.commit_id)) {
 		// a DDL operation is waiting for pending commits to drain before attaching a new catalog version -
 		// fall back to the synchronous commit path (publish + inline fsync under the locks)

--- a/src/transaction/duck_transaction_manager.cpp
+++ b/src/transaction/duck_transaction_manager.cpp
@@ -10,6 +10,7 @@
 #include "duckdb/catalog/catalog.hpp"
 #include "duckdb/catalog/dependency_manager.hpp"
 #include "duckdb/storage/storage_manager.hpp"
+#include "duckdb/storage/table/data_table_info.hpp"
 #include "duckdb/transaction/duck_transaction.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/connection_manager.hpp"
@@ -351,18 +352,19 @@ void DuckTransactionManager::FinishPendingCommit(idx_t publish_seq) {
 	publish_cv.notify_all();
 }
 
-unique_ptr<StorageLockKey> DuckTransactionManager::BlockPendingCommits() {
-	// The system catalog has no storage, and in-memory databases have no WAL - neither has deferred (group) commits,
-	// so there is nothing to block (DDL on them, e.g. registering built-in functions at load, must not touch a WAL
-	// lock that does not apply).
-	if (db.IsSystem() || db.GetStorageManager().InMemory()) {
+unique_ptr<StorageLockKey> DuckTransactionManager::BlockPendingCommits(optional_ptr<DataTableInfo> table_info) {
+	// Nothing to gate when this is not a table DDL (table_info is null), on the system catalog, or on an in-memory
+	// database - none of those have group commits (DDL on them, e.g. registering built-in functions at load, must
+	// not touch a gate that does not apply).
+	if (!table_info || db.IsSystem() || db.GetStorageManager().InMemory()) {
 		return nullptr;
 	}
-	// Take the WAL lock exclusively: this waits for all in-flight deferred commits (which hold it SHARED through
-	// publish) to finish and blocks new ones until the returned handle is released, so the caller can attach a new
-	// catalog version without a deferred commit's catalog validation going stale in between. Writer priority in
-	// StorageLock prevents a steady stream of commits from starving this acquisition.
-	return db.GetStorageManager().GetWALLockExclusive();
+	// Take this table's publish gate exclusively: this waits for all in-flight commits on the table (which hold it
+	// SHARED from before their catalog validation through publish) to finish and blocks new ones until the returned
+	// handle is released, so the caller can mutate the table's catalog entry / index list without a commit's
+	// validation going stale or its publish racing the index-list change. Scoped to the table, so commits to other
+	// tables are unaffected. Writer priority in StorageLock prevents a steady stream of commits from starving this.
+	return table_info->GetPublishGateExclusive();
 }
 
 ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Transaction &transaction_p) {
@@ -390,6 +392,13 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 	// shared WAL lock alone would let concurrent committers interleave their entries and corrupt the WAL. Released
 	// before the fsync so batching is preserved. Exclusive committers do not need it (the WAL lock serializes them).
 	unique_lock<mutex> append_guard;
+	// Per-table publish gates: a commit holds each modified table's gate SHARED from before its catalog validation
+	// (in WriteToWAL) through publish, so a concurrent DDL on that table (which takes the gate EXCLUSIVE via
+	// BlockPendingCommits) cannot make the validation stale or race the publish's index updates. Acquired in
+	// address order (see GetModifiedTableInfos) for deadlock-freedom; released after publish. modified_table_infos
+	// keeps the DataTableInfos alive while their gate handles are held.
+	vector<shared_ptr<DataTableInfo>> modified_table_infos;
+	vector<unique_ptr<StorageLockKey>> table_gates;
 	unique_ptr<StorageCommitState> commit_state;
 	bool skip_wal_write_due_to_checkpoint = false;
 	bool wal_written = false;
@@ -410,8 +419,8 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 	}
 	bool should_write_to_wal = transaction.ShouldWriteToWAL(db);
 	// Catalog-changing commits cannot defer publishing their changes (see below) - they publish while holding the
-	// transaction lock. To guarantee that no catalog change can interleave between a data commit's WAL flush marker
-	// and its publish, they first wait for all pending (unpublished) commits to be published.
+	// transaction lock. A DDL's catalog-version attachment is kept from interleaving a data commit's validation and
+	// publish by the per-table publish gate (see BlockPendingCommits / table_gates), not by this commit path.
 	bool has_catalog_changes = undo_properties.has_catalog_changes;
 	if (should_write_to_wal) {
 		auto &storage_manager = db.GetStorageManager().Cast<SingleFileStorageManager>();
@@ -432,6 +441,11 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 			// shared WAL holders can run concurrently, so serialize their entry+marker appends to keep each
 			// transaction's WAL entries contiguous (released after the marker, before the fsync)
 			append_guard = storage_manager.GetWALAppendLock();
+		}
+		// take each modified table's publish gate SHARED before validating/writing, held through publish
+		modified_table_infos = transaction.GetModifiedTableInfos();
+		for (auto &table_info : modified_table_infos) {
+			table_gates.push_back(table_info->GetPublishGateShared());
 		}
 
 		// Commit the changes to the WAL.
@@ -490,8 +504,9 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 	// the publish sequence orders deferred publishes in WAL order; it is independent of the commit timestamp
 	idx_t publish_seq = 0;
 	if (defer_publish) {
-		// assign the publish sequence and register for in-order publishing. A concurrent catalog change cannot
-		// interleave: it takes the WAL lock EXCLUSIVELY (BlockPendingCommits) while we hold it SHARED through publish.
+		// assign the publish sequence and register for in-order publishing. A concurrent catalog change on a table we
+		// modified cannot interleave: it takes that table's publish gate EXCLUSIVELY (BlockPendingCommits) while we
+		// hold it SHARED through publish (see table_gates above).
 		publish_seq = next_publish_sequence++;
 		RegisterPendingCommit(publish_seq);
 	}
@@ -642,6 +657,9 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 	if (!skip_wal_write_due_to_checkpoint && held_wal_lock) {
 		held_wal_lock.reset();
 	}
+	// publish is complete: release the per-table gates so DDL on those tables can proceed
+	table_gates.clear();
+	modified_table_infos.clear();
 	if (defer_publish) {
 		// the commit is now published - wake up any waiters (later commits and checkpoints)
 		FinishPendingCommit(publish_seq);

--- a/src/transaction/duck_transaction_manager.cpp
+++ b/src/transaction/duck_transaction_manager.cpp
@@ -294,6 +294,50 @@ void DuckTransactionManager::CleanupTransactions() {
 	}
 }
 
+bool DuckTransactionManager::RegisterPendingCommit(transaction_t commit_id) {
+	lock_guard<mutex> guard(publish_lock);
+	if (catalog_gate_waiters > 0) {
+		// a DDL operation is waiting for pending commits to drain - do not admit new deferred commits,
+		// the caller must fall back to the synchronous commit path
+		return false;
+	}
+	pending_commit_publishes.insert(commit_id);
+	return true;
+}
+
+void DuckTransactionManager::WaitForPublishTurn(transaction_t commit_id) {
+	std::unique_lock<mutex> guard(publish_lock);
+	publish_cv.wait(guard, [&]() {
+		D_ASSERT(!pending_commit_publishes.empty());
+		return *pending_commit_publishes.begin() == commit_id;
+	});
+}
+
+void DuckTransactionManager::FinishPendingCommit(transaction_t commit_id) {
+	{
+		lock_guard<mutex> guard(publish_lock);
+		pending_commit_publishes.erase(commit_id);
+	}
+	publish_cv.notify_all();
+}
+
+void DuckTransactionManager::WaitForPendingCommits() {
+	std::unique_lock<mutex> guard(publish_lock);
+	publish_cv.wait(guard, [&]() { return pending_commit_publishes.empty(); });
+}
+
+unique_lock<mutex> DuckTransactionManager::BlockPendingCommits() {
+	unique_lock<mutex> guard(publish_lock);
+	// while we wait, new commits cannot register as pending (they fall back to the synchronous path) -
+	// otherwise a steady stream of deferred commits could starve the DDL operation indefinitely
+	catalog_gate_waiters++;
+	publish_cv.wait(guard, [&]() { return pending_commit_publishes.empty(); });
+	catalog_gate_waiters--;
+	// return while holding the publish lock: registration stays blocked until the caller releases it,
+	// covering the catalog version attachment
+	return guard;
+}
+
 ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Transaction &transaction_p) {
 	auto &transaction = transaction_p.Cast<DuckTransaction>();
 	unique_lock<mutex> t_lock(transaction_lock);
@@ -315,6 +359,8 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 	unique_ptr<StorageCommitState> commit_state;
 	bool skip_wal_write_due_to_checkpoint = false;
 	bool wal_written = false;
+	// WAL offset our flush marker requires for durability (set by CommitToWAL, used as the deferred SyncUpTo target)
+	idx_t flush_marker_offset = 0;
 	if (checkpoint_decision.can_checkpoint) {
 		// we can perform an automatic checkpoint
 		// we have two options:
@@ -329,6 +375,11 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 		}
 	}
 	bool should_write_to_wal = transaction.ShouldWriteToWAL(db);
+	bool allow_group_commit = Settings::Get<ExperimentalGroupCommitSetting>(db.GetDatabase());
+	// Catalog-changing commits cannot defer publishing their changes (see below) - they publish while holding the
+	// transaction lock. To guarantee that no catalog change can interleave between a data commit's WAL flush marker
+	// and its publish, they first wait for all pending (unpublished) commits to be published.
+	bool has_catalog_changes = undo_properties.has_catalog_changes;
 	if (should_write_to_wal) {
 		auto &storage_manager = db.GetStorageManager().Cast<SingleFileStorageManager>();
 		// if we are committing changes and we are not doing a "checkpoint instead of WAL write"
@@ -346,6 +397,11 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 		if (!skip_wal_write_due_to_checkpoint) {
 			error = transaction.WriteToWAL(context, db, commit_state);
 			wal_written = true;
+			if (allow_group_commit && !error.HasError() && has_catalog_changes) {
+				// we hold the WAL lock (no new pending commits can register), but not the transaction lock
+				// (pending commits can finish publishing)
+				WaitForPendingCommits();
+			}
 		}
 
 		// after we finish writing to the WAL we grab the transaction lock again
@@ -363,6 +419,9 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 			t_lock.unlock();
 			error = transaction.WriteToWAL(context, db, commit_state);
 			wal_written = true;
+			if (!error.HasError() && has_catalog_changes) {
+				WaitForPendingCommits();
+			}
 			t_lock.lock();
 			skip_wal_write_due_to_checkpoint = false;
 		}
@@ -378,6 +437,24 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 	CommitInfo info;
 	info.commit_id = GetCommitTimestamp();
 
+	// Group commit (experimental, off by default): data-only commits that write to the WAL defer publishing
+	// (making their changes visible) until after their WAL entries have been fsynced. This way no transaction can
+	// ever observe a commit that is not yet durable, while the fsync itself happens outside of the transaction
+	// lock and the WAL lock, so that concurrently committing transactions can share a single fsync.
+	// Catalog-changing commits take the non-deferred path: they publish under the transaction lock and fsync inline
+	// before releasing it - no new transaction can start in the meantime, so those commits are also never visible
+	// before they are durable.
+	// With the setting disabled, all commits take the non-deferred path, which behaves exactly like the
+	// pre-group-commit code (publish + inline durable fsync under the locks). The pending-commit drains and the
+	// catalog gate are kept unconditional: they are no-ops while no deferred commits exist, which also makes
+	// toggling the setting at runtime safe.
+	bool defer_publish = allow_group_commit && !error.HasError() && commit_state && !has_catalog_changes;
+	if (defer_publish && !RegisterPendingCommit(info.commit_id)) {
+		// a DDL operation is waiting for pending commits to drain before attaching a new catalog version -
+		// fall back to the synchronous commit path (publish + inline fsync under the locks)
+		defer_publish = false;
+	}
+
 	// commit the UndoBuffer of the transaction
 	if (!error.HasError()) {
 		if (HasOtherTransactions(transaction)) {
@@ -385,11 +462,24 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 		} else {
 			info.active_transactions = ActiveTransactionState::NO_OTHER_TRANSACTIONS;
 		}
-		error = transaction.Commit(db, info, std::move(commit_state));
+		if (defer_publish) {
+			// write the WAL flush marker - the commit is published after the group fsync below. Conflicts were
+			// already validated in WriteToWAL (before any entries were written). We registered as pending BEFORE
+			// that validation: until we publish, no catalog version can be attached to any table (see
+			// BlockPendingCommits), so the validation stays authoritative. flush_marker_offset is the WAL offset we
+			// must SyncUpTo() to make this commit durable.
+			error = transaction.CommitToWAL(db, info, std::move(commit_state), flush_marker_offset);
+			if (error.HasError()) {
+				FinishPendingCommit(info.commit_id);
+			}
+		} else {
+			error = transaction.Commit(db, info, std::move(commit_state));
+		}
 	}
 
 	if (error.HasError()) {
 		DUCKDB_LOG(context, TransactionLogType, db, "Rollback (after failed commit)", info.commit_id);
+		defer_publish = false;
 
 		// COMMIT not successful: ROLLBACK.
 		checkpoint_decision = CheckpointDecision(error.Message());
@@ -401,7 +491,7 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 			    "Failed to rollback transaction. Cannot continue operation.\nOriginal Error: %s\nRollback Error: %s",
 			    error.Message(), rollback_error.Message());
 		}
-	} else {
+	} else if (!defer_publish) {
 		DUCKDB_LOG(context, TransactionLogType, db, "Commit", info.commit_id);
 		last_commit = info.commit_id;
 
@@ -410,12 +500,73 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 			transaction.catalog_version = ++last_committed_version;
 		}
 	}
+	// (deferred commits remain registered as pending: the commit is complete in the WAL but not yet visible)
 	OnCommitCheckpointDecision(checkpoint_decision, transaction);
 
 	if (!checkpoint_decision.can_checkpoint && lock) {
 		// we won't checkpoint after all due to an error during commit: unlock the checkpoint lock again
 		skip_wal_write_due_to_checkpoint = false;
 		lock.reset();
+	}
+
+	if (defer_publish) {
+		// deferred (group) commit: capture the WAL; the offset we must sync to is the one our flush marker returned
+		// from CommitToWAL (flush_marker_offset), threaded through explicitly rather than re-read from the WAL - so
+		// the durability target is exactly our marker and does not depend on no other commit having appended since.
+		// the shared_ptr keeps the WAL alive even if a concurrent checkpoint swaps it out (the swap fully syncs
+		// the old WAL before replacing it, so our sync target is always reachable)
+		D_ASSERT(held_wal_lock.owns_lock());
+		auto sync_wal = db.GetStorageManager().GetWALShared();
+		idx_t sync_target = flush_marker_offset;
+
+		// release all locks - other transactions can start, commit and append to the WAL while we wait for the
+		// fsync, and their flush markers are covered by the same fsync (or a later one)
+		// transactions that start in this window do not see our commit yet: it is published below, after the fsync
+		t_lock.unlock();
+		held_wal_lock.unlock();
+
+		try {
+			if (sync_wal) {
+				// leader_pushes_batch: the flush markers were only appended to the in-memory WAL buffer
+				// (FlushCommitMarker with push_to_os=false), so the sync leader pushes the whole batch to the OS in
+				// one write() before its fsync - batching the write too, not just the fsync. The push runs under the
+				// WAL flush_lock (not the WAL lock), so it cannot deadlock against a concurrent checkpoint / catalog
+				// commit / synchronous commit that holds the WAL lock and waits.
+				sync_wal->SyncUpTo(sync_target, true, /*leader_pushes_batch=*/true);
+			}
+		} catch (std::exception &ex) {
+			// the WAL cannot be guaranteed to be durable, and the flush marker can no longer be truncated
+			// (other transactions may have appended in the meantime): this is fatal
+			FinishPendingCommit(info.commit_id);
+			ErrorData sync_error(ex);
+			throw FatalException("Failed to sync WAL during commit. Cannot continue operation.\nError: %s",
+			                     sync_error.Message());
+		}
+
+		// publish in commit order - this keeps recently_committed_transactions ordered on commit_id and ensures
+		// that the visible state always corresponds to a prefix of the WAL (matching replay after a crash)
+		WaitForPublishTurn(info.commit_id);
+
+		t_lock.lock();
+		// other transactions may have started or committed while we were syncing - recompute the state
+		if (HasOtherTransactions(transaction)) {
+			info.active_transactions = ActiveTransactionState::OTHER_TRANSACTIONS;
+		} else {
+			info.active_transactions = ActiveTransactionState::NO_OTHER_TRANSACTIONS;
+		}
+		auto publish_error = transaction.PublishCommit(db, info);
+		if (publish_error.HasError()) {
+			// the commit is durable in the WAL and can no longer be rolled back: this is fatal
+			// (after a restart, WAL replay applies the transaction, which is the correct committed state)
+			t_lock.unlock();
+			FinishPendingCommit(info.commit_id);
+			throw FatalException("Failed to publish commit after WAL write. Cannot continue operation.\nError: %s",
+			                     publish_error.Message());
+		}
+		DUCKDB_LOG(context, TransactionLogType, db, "Commit", info.commit_id);
+		// take the maximum: between our commit id assignment and this point the transaction lock was released,
+		// so a commit with a higher id (e.g. a read-only commit) may have already updated last_commit
+		last_commit = MaxValue<transaction_t>(last_commit, info.commit_id);
 	}
 
 	// commit successful: remove the transaction id from the list of active transactions
@@ -437,6 +588,10 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 	// this prevents any concurrent transactions from happening during this time
 	if (!skip_wal_write_due_to_checkpoint && held_wal_lock.owns_lock()) {
 		held_wal_lock.unlock();
+	}
+	if (defer_publish) {
+		// the commit is now published - wake up any waiters (later commits and checkpoints)
+		FinishPendingCommit(info.commit_id);
 	}
 
 	CleanupTransactions();

--- a/src/transaction/duck_transaction_manager.cpp
+++ b/src/transaction/duck_transaction_manager.cpp
@@ -314,12 +314,12 @@ void DuckTransactionManager::CleanupTransactions() {
 	}
 }
 
-void DuckTransactionManager::RegisterPendingCommit(transaction_t publish_seq) {
+void DuckTransactionManager::RegisterPendingCommit(idx_t publish_seq) {
 	lock_guard<mutex> guard(publish_lock);
 	pending_commit_publishes.insert(publish_seq);
 }
 
-void DuckTransactionManager::WaitForPublishTurn(transaction_t publish_seq) {
+void DuckTransactionManager::WaitForPublishTurn(idx_t publish_seq) {
 	std::unique_lock<mutex> guard(publish_lock);
 	publish_cv.wait(guard, [&]() {
 		D_ASSERT(!pending_commit_publishes.empty());
@@ -327,7 +327,7 @@ void DuckTransactionManager::WaitForPublishTurn(transaction_t publish_seq) {
 	});
 }
 
-void DuckTransactionManager::FinishPendingCommit(transaction_t publish_seq) {
+void DuckTransactionManager::FinishPendingCommit(idx_t publish_seq) {
 	{
 		lock_guard<mutex> guard(publish_lock);
 		pending_commit_publishes.erase(publish_seq);
@@ -472,7 +472,7 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 	bool defer_publish =
 	    !error.HasError() && commit_state && !has_catalog_changes && !checkpoint_decision.can_checkpoint;
 	// the publish sequence orders deferred publishes in WAL order; it is independent of the commit timestamp
-	transaction_t publish_seq = 0;
+	idx_t publish_seq = 0;
 	if (defer_publish) {
 		// assign the publish sequence and register for in-order publishing. A concurrent catalog change cannot
 		// interleave: it takes the WAL lock EXCLUSIVELY (BlockPendingCommits) while we hold it SHARED through publish.

--- a/src/transaction/duck_transaction_manager.cpp
+++ b/src/transaction/duck_transaction_manager.cpp
@@ -314,15 +314,9 @@ void DuckTransactionManager::CleanupTransactions() {
 	}
 }
 
-bool DuckTransactionManager::RegisterPendingCommit(transaction_t publish_seq) {
+void DuckTransactionManager::RegisterPendingCommit(transaction_t publish_seq) {
 	lock_guard<mutex> guard(publish_lock);
-	if (catalog_gate_waiters > 0) {
-		// a DDL operation is waiting for pending commits to drain - do not admit new deferred commits,
-		// the caller must fall back to the synchronous commit path
-		return false;
-	}
 	pending_commit_publishes.insert(publish_seq);
-	return true;
 }
 
 void DuckTransactionManager::WaitForPublishTurn(transaction_t publish_seq) {
@@ -341,16 +335,18 @@ void DuckTransactionManager::FinishPendingCommit(transaction_t publish_seq) {
 	publish_cv.notify_all();
 }
 
-unique_lock<mutex> DuckTransactionManager::BlockPendingCommits() {
-	unique_lock<mutex> guard(publish_lock);
-	// while we wait, new commits cannot register as pending (they fall back to the synchronous path) -
-	// otherwise a steady stream of deferred commits could starve the DDL operation indefinitely
-	catalog_gate_waiters++;
-	publish_cv.wait(guard, [&]() { return pending_commit_publishes.empty(); });
-	catalog_gate_waiters--;
-	// return while holding the publish lock: registration stays blocked until the caller releases it,
-	// covering the catalog version attachment
-	return guard;
+unique_ptr<StorageLockKey> DuckTransactionManager::BlockPendingCommits() {
+	// The system catalog has no storage, and in-memory databases have no WAL - neither has deferred (group) commits,
+	// so there is nothing to block (DDL on them, e.g. registering built-in functions at load, must not touch a WAL
+	// lock that does not apply).
+	if (db.IsSystem() || db.GetStorageManager().InMemory()) {
+		return nullptr;
+	}
+	// Take the WAL lock exclusively: this waits for all in-flight deferred commits (which hold it SHARED through
+	// publish) to finish and blocks new ones until the returned handle is released, so the caller can attach a new
+	// catalog version without a deferred commit's catalog validation going stale in between. Writer priority in
+	// StorageLock prevents a steady stream of commits from starving this acquisition.
+	return db.GetStorageManager().GetWALLockExclusive();
 }
 
 ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Transaction &transaction_p) {
@@ -478,12 +474,10 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 	// the publish sequence orders deferred publishes in WAL order; it is independent of the commit timestamp
 	transaction_t publish_seq = 0;
 	if (defer_publish) {
+		// assign the publish sequence and register for in-order publishing. A concurrent catalog change cannot
+		// interleave: it takes the WAL lock EXCLUSIVELY (BlockPendingCommits) while we hold it SHARED through publish.
 		publish_seq = next_publish_sequence++;
-		if (!RegisterPendingCommit(publish_seq)) {
-			// a DDL operation is waiting for pending commits to drain before attaching a new catalog version -
-			// fall back to the synchronous commit path (publish + inline fsync under the locks)
-			defer_publish = false;
-		}
+		RegisterPendingCommit(publish_seq);
 	}
 
 	// commit the UndoBuffer of the transaction

--- a/src/transaction/duck_transaction_manager.cpp
+++ b/src/transaction/duck_transaction_manager.cpp
@@ -279,8 +279,17 @@ void DuckTransactionManager::RetireAfterCheckpoint(shared_ptr<void> retired_obje
 	if (!retired_object) {
 		return;
 	}
+	// Capture the start-timestamp horizon: current_start_timestamp is the next start time / commit id to be handed
+	// out, so every transaction that currently exists (active or already committed) has a start_time / commit_id
+	// strictly below it. Once lowest_active_start reaches this epoch, none of those transactions is active anymore
+	// and their undo has been cleaned, so nothing can reference the retired object's UpdateSegments.
+	transaction_t epoch;
+	{
+		lock_guard<mutex> t_lock(transaction_lock);
+		epoch = current_start_timestamp;
+	}
 	lock_guard<mutex> l(retired_lock);
-	retired_after_checkpoint.push_back(std::move(retired_object));
+	retired_after_checkpoint.emplace_back(epoch, std::move(retired_object));
 }
 
 void DuckTransactionManager::CleanupTransactions() {
@@ -300,18 +309,25 @@ void DuckTransactionManager::CleanupTransactions() {
 			top_cleanup_info->Cleanup();
 		}
 	}
-	// The cleanup queue is now drained. If the database is quiescent (no active transactions) all undo buffers have
-	// been cleaned up, so no UpdateInfo can reference a row group that a checkpoint retired - it is safe to free them.
-	// Active transactions have a start_time below TRANSACTION_ID_START; lowest_active_start reaching
-	// TRANSACTION_ID_START (its idle value) therefore means there are no active transactions.
-	if (lowest_active_start.load() >= TRANSACTION_ID_START) {
-		vector<shared_ptr<void>> to_free;
-		{
-			lock_guard<mutex> l(retired_lock);
-			to_free.swap(retired_after_checkpoint);
+	// The cleanup queue is now drained. Free every retired object whose epoch the horizon has reached: once
+	// lowest_active_start >= epoch, no transaction that existed when the object was retired is still active, so its
+	// committed undo has been cleaned above and no UpdateInfo can reference the object's UpdateSegments anymore. When
+	// the database is quiescent lowest_active_start is TRANSACTION_ID_START (its idle max), which frees everything.
+	auto horizon = lowest_active_start.load();
+	vector<shared_ptr<void>> to_free;
+	{
+		lock_guard<mutex> l(retired_lock);
+		for (idx_t i = 0; i < retired_after_checkpoint.size();) {
+			if (retired_after_checkpoint[i].first <= horizon) {
+				to_free.push_back(std::move(retired_after_checkpoint[i].second));
+				retired_after_checkpoint[i] = std::move(retired_after_checkpoint.back());
+				retired_after_checkpoint.pop_back();
+			} else {
+				i++;
+			}
 		}
-		// drop the references outside the lock
 	}
+	// drop the references outside the lock
 }
 
 void DuckTransactionManager::RegisterPendingCommit(idx_t publish_seq) {

--- a/src/transaction/duck_transaction_manager.cpp
+++ b/src/transaction/duck_transaction_manager.cpp
@@ -375,7 +375,14 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 	auto undo_properties = transaction.GetUndoProperties();
 	auto checkpoint_decision = CanCheckpoint(transaction, lock, undo_properties);
 	ErrorData error;
-	unique_lock<mutex> held_wal_lock;
+	// The WAL lock is a read-write lock: data-only group commits take it SHARED (held through publish, so concurrent
+	// committers batch and a checkpoint/catalog change taking it EXCLUSIVE waits for them); checkpointing and
+	// catalog-changing commits take it EXCLUSIVE.
+	unique_ptr<StorageLockKey> held_wal_lock;
+	// Held by shared (data) committers across their WAL entry+marker append so their entries stay contiguous; the
+	// shared WAL lock alone would let concurrent committers interleave their entries and corrupt the WAL. Released
+	// before the fsync so batching is preserved. Exclusive committers do not need it (the WAL lock serializes them).
+	unique_lock<mutex> append_guard;
 	unique_ptr<StorageCommitState> commit_state;
 	bool skip_wal_write_due_to_checkpoint = false;
 	bool wal_written = false;
@@ -409,18 +416,23 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 		// note: we can only drop the transaction lock if we are NOT checkpointing
 		// if we are checkpointing, we have already made certain decisions (e.g. the CheckpointType)
 		t_lock.unlock();
-		// grab the WAL lock and hold it until the entire commit is finished
-		held_wal_lock = storage_manager.GetWALLock();
+		// grab the WAL lock and hold it until the entire commit is finished. Checkpointing or catalog-changing
+		// commits take it EXCLUSIVE (so they serialize against all data writers); pure data commits take it SHARED
+		// (so they run concurrently and batch their fsyncs).
+		bool need_exclusive_wal = has_catalog_changes || checkpoint_decision.can_checkpoint;
+		held_wal_lock = need_exclusive_wal ? storage_manager.GetWALLockExclusive() : storage_manager.GetWALLockShared();
+		if (!need_exclusive_wal) {
+			// shared WAL holders can run concurrently, so serialize their entry+marker appends to keep each
+			// transaction's WAL entries contiguous (released after the marker, before the fsync)
+			append_guard = storage_manager.GetWALAppendLock();
+		}
 
 		// Commit the changes to the WAL.
 		if (!skip_wal_write_due_to_checkpoint) {
 			error = transaction.WriteToWAL(context, db, commit_state);
 			wal_written = true;
-			if (!error.HasError() && has_catalog_changes) {
-				// we hold the WAL lock (no new pending commits can register), but not the transaction lock
-				// (pending commits can finish publishing)
-				WaitForPendingCommits();
-			}
+			// no drain needed: catalog-changing commits hold the WAL lock EXCLUSIVELY, so no deferred data commit
+			// can be between its flush marker and its publish
 		}
 
 		// after we finish writing to the WAL we grab the transaction lock again
@@ -433,14 +445,12 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 		if (should_write_to_wal && skip_wal_write_due_to_checkpoint && !checkpoint_decision.can_checkpoint) {
 			// we have not written to the WAL but we have now realized we can't checkpoint after all
 			// in order to commit we need backpeddle and write to the WAL after all
-			D_ASSERT(held_wal_lock.owns_lock());
+			D_ASSERT(held_wal_lock);
 			// unlock the transaction lock while we are writing to the WAL
 			t_lock.unlock();
 			error = transaction.WriteToWAL(context, db, commit_state);
 			wal_written = true;
-			if (!error.HasError() && has_catalog_changes) {
-				WaitForPendingCommits();
-			}
+			// held_wal_lock is EXCLUSIVE here (we took it for the checkpoint), so no drain is needed
 			t_lock.lock();
 			skip_wal_write_due_to_checkpoint = false;
 		}
@@ -465,7 +475,11 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 	// Catalog-changing commits take the non-deferred path: they publish under the transaction lock and fsync inline
 	// before releasing it - no new transaction can start in the meantime, so those commits are also never visible
 	// before they are durable.
-	bool defer_publish = !error.HasError() && commit_state && !has_catalog_changes;
+	// Only data-only, non-checkpointing commits defer: they hold the WAL lock SHARED, so the deferred publish
+	// turnstile (which needs concurrent committers to make progress) cannot deadlock. Checkpointing and
+	// catalog-changing commits hold the WAL lock EXCLUSIVELY and publish synchronously.
+	bool defer_publish =
+	    !error.HasError() && commit_state && !has_catalog_changes && !checkpoint_decision.can_checkpoint;
 	// the publish sequence orders deferred publishes in WAL order; it is independent of the commit timestamp
 	transaction_t publish_seq = 0;
 	if (defer_publish) {
@@ -499,6 +513,11 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 			info.commit_id = GetCommitTimestamp();
 			error = transaction.Commit(db, info, std::move(commit_state));
 		}
+	}
+	// the WAL entries and flush marker (if any) have been appended - other shared committers may now append theirs.
+	// We keep the (shared) WAL lock until publish; only the append serialization is released here, before the fsync.
+	if (append_guard.owns_lock()) {
+		append_guard.unlock();
 	}
 
 	if (error.HasError()) {
@@ -537,17 +556,19 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 		// deferred (group) commit: capture the WAL; the offset we must sync to is the one our flush marker returned
 		// from CommitToWAL (flush_marker_offset), threaded through explicitly rather than re-read from the WAL - so
 		// the durability target is exactly our marker and does not depend on no other commit having appended since.
-		// the shared_ptr keeps the WAL alive even if a concurrent checkpoint swaps it out (the swap fully syncs
-		// the old WAL before replacing it, so our sync target is always reachable)
-		D_ASSERT(held_wal_lock.owns_lock());
+		// the shared_ptr keeps the WAL alive across the fsync (defensive: the shared WAL lock we hold already
+		// prevents a concurrent checkpoint from swapping it out)
+		D_ASSERT(held_wal_lock);
 		auto sync_wal = db.GetStorageManager().GetWALShared();
 		idx_t sync_target = flush_marker_offset;
 
-		// release all locks - other transactions can start, commit and append to the WAL while we wait for the
-		// fsync, and their flush markers are covered by the same fsync (or a later one)
-		// transactions that start in this window do not see our commit yet: it is published below, after the fsync
+		// release the transaction lock so other transactions can start/commit while we wait for the fsync, and their
+		// flush markers are covered by the same fsync (or a later one). We KEEP the WAL lock held (in SHARED mode) all
+		// the way through publish: it does not block other (shared) committers, but it does make a checkpoint/catalog
+		// change (EXCLUSIVE) wait for us, so it cannot swap the WAL or attach a catalog version while our commit is
+		// still being made durable and visible. Transactions that start in this window do not see our commit yet: it
+		// is published below, after the fsync.
 		t_lock.unlock();
-		held_wal_lock.unlock();
 
 		try {
 			if (sync_wal) {
@@ -613,8 +634,8 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 	t_lock.unlock();
 	// if we have skipped the WAL write due to checkpoint, we keep the WAL lock while checkpointing
 	// this prevents any concurrent transactions from happening during this time
-	if (!skip_wal_write_due_to_checkpoint && held_wal_lock.owns_lock()) {
-		held_wal_lock.unlock();
+	if (!skip_wal_write_due_to_checkpoint && held_wal_lock) {
+		held_wal_lock.reset();
 	}
 	if (defer_publish) {
 		// the commit is now published - wake up any waiters (later commits and checkpoints)
@@ -634,7 +655,7 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 		CheckpointOptions options;
 		options.action = CheckpointAction::ALWAYS_CHECKPOINT;
 		options.type = checkpoint_decision.type;
-		options.wal_lock = held_wal_lock.owns_lock() ? &held_wal_lock : nullptr;
+		options.wal_lock = held_wal_lock.get();
 		auto &storage_manager = db.GetStorageManager();
 		try {
 			storage_manager.CreateCheckpoint(context, options);

--- a/src/transaction/duck_transaction_manager.cpp
+++ b/src/transaction/duck_transaction_manager.cpp
@@ -352,21 +352,6 @@ void DuckTransactionManager::FinishPendingCommit(idx_t publish_seq) {
 	publish_cv.notify_all();
 }
 
-unique_ptr<StorageLockKey> DuckTransactionManager::BlockPendingCommits(optional_ptr<DataTableInfo> table_info) {
-	// Nothing to gate when this is not a table DDL (table_info is null), on the system catalog, or on an in-memory
-	// database - none of those have group commits (DDL on them, e.g. registering built-in functions at load, must
-	// not touch a gate that does not apply).
-	if (!table_info || db.IsSystem() || db.GetStorageManager().InMemory()) {
-		return nullptr;
-	}
-	// Take this table's publish gate exclusively: this waits for all in-flight commits on the table (which hold it
-	// SHARED from before their catalog validation through publish) to finish and blocks new ones until the returned
-	// handle is released, so the caller can mutate the table's catalog entry / index list without a commit's
-	// validation going stale or its publish racing the index-list change. Scoped to the table, so commits to other
-	// tables are unaffected. Writer priority in StorageLock prevents a steady stream of commits from starving this.
-	return table_info->GetPublishGateExclusive();
-}
-
 ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Transaction &transaction_p) {
 	auto &transaction = transaction_p.Cast<DuckTransaction>();
 	unique_lock<mutex> t_lock(transaction_lock);
@@ -394,9 +379,9 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 	unique_lock<mutex> append_guard;
 	// Per-table publish gates: a commit holds each modified table's gate SHARED from before its catalog validation
 	// (in WriteToWAL) through publish, so a concurrent DDL on that table (which takes the gate EXCLUSIVE via
-	// BlockPendingCommits) cannot make the validation stale or race the publish's index updates. Acquired in
-	// address order (see GetModifiedTableInfos) for deadlock-freedom; released after publish. modified_table_infos
-	// keeps the DataTableInfos alive while their gate handles are held.
+	// DataTableInfo::GetPublishGateExclusive) cannot make the validation stale or race the publish's index updates.
+	// Acquired in address order (see GetModifiedTableInfos) for deadlock-freedom; released after publish.
+	// modified_table_infos keeps the DataTableInfos alive while their gate handles are held.
 	vector<shared_ptr<DataTableInfo>> modified_table_infos;
 	vector<unique_ptr<StorageLockKey>> table_gates;
 	unique_ptr<StorageCommitState> commit_state;
@@ -420,7 +405,7 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 	bool should_write_to_wal = transaction.ShouldWriteToWAL(db);
 	// Catalog-changing commits cannot defer publishing their changes (see below) - they publish while holding the
 	// transaction lock. A DDL's catalog-version attachment is kept from interleaving a data commit's validation and
-	// publish by the per-table publish gate (see BlockPendingCommits / table_gates), not by this commit path.
+	// publish by the per-table publish gate (see GetPublishGateExclusive / table_gates), not by this commit path.
 	bool has_catalog_changes = undo_properties.has_catalog_changes;
 	if (should_write_to_wal) {
 		auto &storage_manager = db.GetStorageManager().Cast<SingleFileStorageManager>();
@@ -505,8 +490,8 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 	idx_t publish_seq = 0;
 	if (defer_publish) {
 		// assign the publish sequence and register for in-order publishing. A concurrent catalog change on a table we
-		// modified cannot interleave: it takes that table's publish gate EXCLUSIVELY (BlockPendingCommits) while we
-		// hold it SHARED through publish (see table_gates above).
+		// modified cannot interleave: it takes that table's publish gate EXCLUSIVELY (GetPublishGateExclusive) while
+		// we hold it SHARED through publish (see table_gates above).
 		publish_seq = next_publish_sequence++;
 		RegisterPendingCommit(publish_seq);
 	}
@@ -520,10 +505,10 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 		}
 		if (defer_publish) {
 			// write the WAL flush marker - the commit is published after the group fsync below. Conflicts were
-			// already validated in WriteToWAL (before any entries were written). We registered as pending BEFORE
-			// that validation: until we publish, no catalog version can be attached to any table (see
-			// BlockPendingCommits), so the validation stays authoritative. flush_marker_offset is the WAL offset we
-			// must SyncUpTo() to make this commit durable.
+			// already validated in WriteToWAL (before any entries were written). We hold each modified table's publish
+			// gate SHARED from before that validation until we publish, so no catalog version can be attached to a
+			// table we modified in between (see GetPublishGateExclusive), keeping the validation authoritative.
+			// flush_marker_offset is the WAL offset we must SyncUpTo() to make this commit durable.
 			error = transaction.CommitToWAL(db, info, std::move(commit_state), flush_marker_offset);
 			if (error.HasError()) {
 				FinishPendingCommit(publish_seq);

--- a/src/transaction/undo_buffer.cpp
+++ b/src/transaction/undo_buffer.cpp
@@ -11,10 +11,12 @@
 #include "duckdb/storage/buffer_manager.hpp"
 #include "duckdb/storage/data_table.hpp"
 #include "duckdb/storage/write_ahead_log.hpp"
+#include "duckdb/transaction/append_info.hpp"
 #include "duckdb/transaction/cleanup_state.hpp"
 #include "duckdb/transaction/commit_state.hpp"
 #include "duckdb/transaction/delete_info.hpp"
 #include "duckdb/transaction/rollback_state.hpp"
+#include "duckdb/transaction/update_info.hpp"
 #include "duckdb/transaction/wal_write_state.hpp"
 #include "duckdb/transaction/duck_transaction.hpp"
 
@@ -191,6 +193,34 @@ void UndoBuffer::WriteToWAL(WriteAheadLog &wal, optional_ptr<StorageCommitState>
 	WALWriteState state(transaction, wal, commit_state);
 	UndoBuffer::IteratorState iterator_state;
 	IterateEntries(iterator_state, [&](UndoFlags type, data_ptr_t data) { state.CommitEntry(type, data); });
+}
+
+ErrorData UndoBuffer::ValidateCommitConflicts() {
+	UndoBuffer::IteratorState iterator_state;
+	try {
+		IterateEntries(iterator_state, [&](UndoFlags type, data_ptr_t data) {
+			optional_ptr<DuckTableEntry> table;
+			switch (type) {
+			case UndoFlags::INSERT_TUPLE:
+				table = reinterpret_cast<AppendInfo *>(data)->table;
+				break;
+			case UndoFlags::DELETE_TUPLE:
+				table = reinterpret_cast<DeleteInfo *>(data)->table;
+				break;
+			case UndoFlags::UPDATE_TUPLE:
+				table = reinterpret_cast<UpdateInfo *>(data)->table;
+				break;
+			default:
+				return;
+			}
+			// the same check that CommitState::CommitEntry performs when committing the entry:
+			// if another transaction has altered/dropped a modified table in the meantime, the commit must fail
+			CommitState::VerifyTableModification(*table, transaction.transaction_id);
+		});
+		return ErrorData();
+	} catch (std::exception &ex) {
+		return ErrorData(ex);
+	}
 }
 
 void UndoBuffer::Commit(UndoBuffer::IteratorState &iterator_state, CommitInfo &info) {

--- a/src/transaction/undo_buffer.cpp
+++ b/src/transaction/undo_buffer.cpp
@@ -223,6 +223,36 @@ ErrorData UndoBuffer::ValidateCommitConflicts() {
 	}
 }
 
+vector<shared_ptr<DataTableInfo>> UndoBuffer::GetModifiedTableInfos() {
+	unordered_set<DataTableInfo *> seen;
+	vector<shared_ptr<DataTableInfo>> result;
+	UndoBuffer::IteratorState iterator_state;
+	IterateEntries(iterator_state, [&](UndoFlags type, data_ptr_t data) {
+		optional_ptr<DuckTableEntry> table;
+		switch (type) {
+		case UndoFlags::INSERT_TUPLE:
+			table = reinterpret_cast<AppendInfo *>(data)->table;
+			break;
+		case UndoFlags::DELETE_TUPLE:
+			table = reinterpret_cast<DeleteInfo *>(data)->table;
+			break;
+		case UndoFlags::UPDATE_TUPLE:
+			table = reinterpret_cast<UpdateInfo *>(data)->table;
+			break;
+		default:
+			return;
+		}
+		auto info = table->GetStorage().GetDataTableInfo();
+		if (seen.insert(info.get()).second) {
+			result.push_back(std::move(info));
+		}
+	});
+	// order by address: commits and DDL both acquire per-table gates in this order, so they cannot deadlock
+	std::sort(result.begin(), result.end(),
+	          [](const shared_ptr<DataTableInfo> &a, const shared_ptr<DataTableInfo> &b) { return a.get() < b.get(); });
+	return result;
+}
+
 void UndoBuffer::Commit(UndoBuffer::IteratorState &iterator_state, CommitInfo &info) {
 	active_transaction_state = info.active_transactions;
 

--- a/test/api/test_reset.cpp
+++ b/test/api/test_reset.cpp
@@ -51,6 +51,7 @@ OptionValueSet GetValueForOption(const string &name, const LogicalType &type) {
 	static unordered_map<string, OptionValueSet> value_map = {
 	    {"threads", {Value::BIGINT(42), Value::BIGINT(42)}},
 	    {"checkpoint_threshold", {"4.0 GiB"}},
+	    {"wal_buffer_size", {"4.0 GiB"}},
 	    {"debug_checkpoint_abort", {{"none", "before_truncate", "before_header", "after_free_list_write"}}},
 	    {"default_collation", {"nocase"}},
 	    {"default_order", {"DESC"}},

--- a/test/configs/group_commit.json
+++ b/test/configs/group_commit.json
@@ -1,7 +1,7 @@
 {
-  "description": "Run on persistent databases with experimental group commit enabled (batched WAL fsync, commits published only once durable).",
+  "description": "Run on persistent databases with the group-commit micro-batching delay disabled (delay=0, no-wait path).",
   "initial_db": "{TEST_DIR}/{BASE_TEST_NAME}__test__config__group_commit.db",
-  "on_init": "SET experimental_group_commit=true;",
+  "on_init": "SET group_commit_delay=0;",
   "skip_compiled": "true",
   "inherit_skip_tests": "test/configs/force_storage.json"
 }

--- a/test/configs/group_commit.json
+++ b/test/configs/group_commit.json
@@ -1,0 +1,7 @@
+{
+  "description": "Run on persistent databases with experimental group commit enabled (batched WAL fsync, commits published only once durable).",
+  "initial_db": "{TEST_DIR}/{BASE_TEST_NAME}__test__config__group_commit.db",
+  "on_init": "SET experimental_group_commit=true;",
+  "skip_compiled": "true",
+  "inherit_skip_tests": "test/configs/force_storage.json"
+}

--- a/test/configs/group_commit_delay.json
+++ b/test/configs/group_commit_delay.json
@@ -1,0 +1,7 @@
+{
+  "description": "Run on persistent databases with a large group-commit micro-batching delay (delay=10ms, batch-wait path).",
+  "initial_db": "{TEST_DIR}/{BASE_TEST_NAME}__test__config__group_commit_delay.db",
+  "on_init": "SET group_commit_delay=10000;",
+  "skip_compiled": "true",
+  "inherit_skip_tests": "test/configs/force_storage.json"
+}

--- a/test/sql/parallelism/interquery/concurrent_checkpoint_deletes_nested.test_slow
+++ b/test/sql/parallelism/interquery/concurrent_checkpoint_deletes_nested.test_slow
@@ -1,0 +1,119 @@
+# name: test/sql/parallelism/interquery/concurrent_checkpoint_deletes_nested.test_slow
+# description: Concurrent checkpoints while deleting and inserting into LIST/ARRAY columns
+# group: [interquery]
+
+# exercises checkpoint row-exclusion for nested (list/array) columns: the child column must be
+# bounded to the cumulative child-entry count of the committed-as-of-snapshot parent rows.
+
+statement ok
+SET checkpoint_threshold='1TB'
+
+statement ok
+PRAGMA disable_checkpoint_on_shutdown
+
+statement ok
+SET index_scan_max_count=999999999
+
+statement ok
+SET index_scan_percentage=1
+
+foreach sleep_time 0 50 100
+
+statement ok
+SET debug_checkpoint_sleep_ms={sleep_time}
+
+statement ok
+ATTACH '{TEST_DIR}/concurrent_checkpoint_nested{sleep_time}.db' AS ccn
+
+# variable-length list (1..4 entries, stresses child-offset translation) + fixed-size array
+statement ok
+CREATE TABLE ccn.t(i INTEGER PRIMARY KEY, l INTEGER[], a INTEGER[3])
+
+# before starting the loop insert the data for the first 10 threads
+loop threadid 0 11
+
+loop x 0 10
+
+statement ok
+INSERT INTO ccn.t SELECT i::INT, [i+y FOR y IN range((i%4)+1)], [i, i+10, i+20] FROM range(({x} * 2000) + {threadid} * 100, ({x} * 2000) + ({threadid} + 1) * 100) t(i);
+
+endloop
+
+endloop
+
+concurrentloop threadid 0 20
+
+loop x 0 10
+
+# for the last 10 threads - insert the data during the loop
+onlyif threadid>10
+statement ok
+INSERT INTO ccn.t SELECT i::INT, [i+y FOR y IN range((i%4)+1)], [i, i+10, i+20] FROM range(({x} * 2000) + {threadid} * 100, ({x} * 2000) + ({threadid} + 1) * 100) t(i);
+
+# transaction-local: we can delete and re-insert the data
+onlyif threadid<>10
+statement ok
+BEGIN
+
+onlyif threadid<>10
+statement ok
+DELETE FROM ccn.t WHERE i >= ({x} * 2000) + {threadid} * 100 AND i < ({x} * 2000) + ({threadid} + 1) * 100 AND i%4=0
+
+onlyif threadid<>10
+statement ok
+INSERT INTO ccn.t SELECT i::INT, [i+y FOR y IN range((i%4)+1)], [i, i+10, i+20] FROM range(({x} * 2000) + {threadid} * 100, ({x} * 2000) + ({threadid} + 1) * 100) t(i) WHERE i%4=0;
+
+onlyif threadid<>10
+statement ok
+COMMIT
+
+# now with commits: we can delete + re-insert the data
+onlyif threadid<>10
+statement ok
+DELETE FROM ccn.t WHERE i >= ({x} * 2000) + {threadid} * 100 AND i < ({x} * 2000) + ({threadid} + 1) * 100 AND i%4=0
+
+onlyif threadid<>10
+statement ok
+INSERT INTO ccn.t SELECT i::INT, [i+y FOR y IN range((i%4)+1)], [i, i+10, i+20] FROM range(({x} * 2000) + {threadid} * 100, ({x} * 2000) + ({threadid} + 1) * 100) t(i) WHERE i%4=0;
+
+# the re-inserted rows must keep their nested values intact
+onlyif threadid<>10
+query I
+SELECT count(*) FROM ccn.t WHERE i >= ({x} * 2000) + {threadid} * 100 AND i < ({x} * 2000) + ({threadid} + 1) * 100 AND (l != [i+y FOR y IN range((i%4)+1)] OR a != [i, i+10, i+20])
+----
+0
+
+endloop
+
+loop x 0 2
+
+onlyif threadid=10
+statement ok
+CHECKPOINT ccn
+
+endloop
+
+endloop
+
+# after the concurrent phase: every row's nested values are intact
+query I
+SELECT count(*) FROM ccn.t WHERE l != [i+y FOR y IN range((i%4)+1)] OR a != [i, i+10, i+20]
+----
+0
+
+statement ok
+DETACH ccn
+
+# reload from disk and re-verify the nested values survived the checkpoint
+statement ok
+ATTACH '{TEST_DIR}/concurrent_checkpoint_nested{sleep_time}.db' AS ccn
+
+query I
+SELECT count(*) FROM ccn.t WHERE l != [i+y FOR y IN range((i%4)+1)] OR a != [i, i+10, i+20]
+----
+0
+
+statement ok
+DETACH ccn
+
+endloop

--- a/test/sql/storage/wal/group_commit_checkpoint_nested_stress.test_slow
+++ b/test/sql/storage/wal/group_commit_checkpoint_nested_stress.test_slow
@@ -1,0 +1,86 @@
+# name: test/sql/storage/wal/group_commit_checkpoint_nested_stress.test_slow
+# description: Group commit: deferred commits of nested (LIST/ARRAY) data racing checkpoints replay with exact counts and intact values
+# group: [wal]
+
+# Stresses the checkpoint linchpin under group commit: concurrent deferred commits append nested-typed rows while a
+# thread force-checkpoints. The checkpoint must (a) freeze each row group at its committed-as-of-snapshot count and
+# push concurrent appends to new row groups (REQUIRE_NEW), and (b) slice LIST/ARRAY child columns to the matching
+# child-entry count for the (possibly partial) last vector. A leak in either direction surfaces as
+# COUNT(*) != COUNT(DISTINCT i) (double-insert), a wrong total (lost rows), or a nested-value mismatch - on the live
+# database and again after WAL replay.
+
+statement ok
+SET checkpoint_threshold='1TB'
+
+statement ok
+PRAGMA disable_checkpoint_on_shutdown
+
+# widen the checkpoint serialization window (debug_checkpoint_sleep_ms) so it overlaps in-flight commits
+foreach sleep_time 50
+
+statement ok
+SET debug_checkpoint_sleep_ms={sleep_time}
+
+statement ok
+ATTACH '{TEST_DIR}/group_commit_ckpt_nested{sleep_time}.db' AS gc
+
+statement ok
+CREATE TABLE gc.t(i INTEGER, l INTEGER[], a INTEGER[3])
+
+# threads 0-8 insert disjoint key ranges (every insert succeeds -> deterministic total); thread 9 force-checkpoints.
+# FORCE CHECKPOINT drains in-flight commits and then serializes the row groups; appends that land during the slept
+# serialization window are routed to fresh row groups (REQUIRE_NEW). A plain CHECKPOINT would bail while writers
+# are active and never reach the serialization path being exercised here.
+concurrentloop threadid 0 10
+
+loop x 0 8
+
+onlyif threadid<>9
+statement ok
+INSERT INTO gc.t SELECT i, [i + y FOR y IN range((i % 4) + 1)], [i, i + 10, i + 20] FROM range({threadid} * 100000 + {x} * 2000, {threadid} * 100000 + {x} * 2000 + 2000) t(i)
+
+onlyif threadid=9
+statement maybe
+FORCE CHECKPOINT gc
+----
+
+endloop
+
+endloop
+
+# 9 inserting threads x 8 iterations x 2000 rows = 144000 rows, every key present exactly once
+query II
+SELECT COUNT(*), COUNT(DISTINCT i) FROM gc.t
+----
+144000	144000
+
+# nested values intact for every row
+query I
+SELECT COUNT(*) FROM gc.t WHERE l != [i + y FOR y IN range((i % 4) + 1)] OR a != [i, i + 10, i + 20]
+----
+0
+
+# reopen: the data + nested values must be reconstructed from the checkpoint plus WAL replay
+statement ok
+DETACH gc
+
+statement ok
+ATTACH '{TEST_DIR}/group_commit_ckpt_nested{sleep_time}.db' AS gc
+
+query II
+SELECT COUNT(*), COUNT(DISTINCT i) FROM gc.t
+----
+144000	144000
+
+query I
+SELECT COUNT(*) FROM gc.t WHERE l != [i + y FOR y IN range((i % 4) + 1)] OR a != [i, i + 10, i + 20]
+----
+0
+
+statement ok
+DETACH gc
+
+statement ok
+SET debug_checkpoint_sleep_ms=0
+
+endloop

--- a/test/sql/storage/wal/group_commit_concurrent_checkpoint.test_slow
+++ b/test/sql/storage/wal/group_commit_concurrent_checkpoint.test_slow
@@ -1,0 +1,70 @@
+# name: test/sql/storage/wal/group_commit_concurrent_checkpoint.test_slow
+# description: Group commit: deferred commits concurrent with frequent checkpoints make progress (no deadlock) and replay
+# group: [wal]
+
+statement ok
+SET checkpoint_threshold='1TB'
+
+statement ok
+PRAGMA disable_checkpoint_on_shutdown
+
+foreach sleep_time 0 25 50
+
+statement ok
+SET debug_checkpoint_sleep_ms={sleep_time}
+
+statement ok
+ATTACH '{TEST_DIR}/group_commit_concurrent_checkpoint{sleep_time}.db' AS gc
+
+statement ok
+CREATE TABLE gc.integers(i INTEGER)
+
+# threads 0-8 commit concurrently (deferred group-commit path); thread 9 repeatedly force-checkpoints.
+# FORCE CHECKPOINT drains pending (unpublished) commits while the group-commit sync leader needs the WAL
+# flush lock - the regression this guards against is a deadlock between those two. (A plain CHECKPOINT would
+# bail out while writers are active and never reach the drain.)
+concurrentloop threadid 0 10
+
+loop x 0 50
+
+onlyif threadid<>9
+statement ok
+INSERT INTO gc.integers SELECT * FROM range({threadid} * 1000 + {x} * 10, {threadid} * 1000 + {x} * 10 + 10)
+
+endloop
+
+loop x 0 20
+
+onlyif threadid=9
+statement maybe
+FORCE CHECKPOINT gc
+----
+
+endloop
+
+endloop
+
+# threads 0-8 each insert 50*10 = 500 rows
+query I
+SELECT COUNT(*) FROM gc.integers
+----
+4500
+
+statement ok
+DETACH gc
+
+statement ok
+ATTACH '{TEST_DIR}/group_commit_concurrent_checkpoint{sleep_time}.db' AS gc
+
+query I
+SELECT COUNT(*) FROM gc.integers
+----
+4500
+
+statement ok
+DETACH gc
+
+statement ok
+SET debug_checkpoint_sleep_ms=0
+
+endloop

--- a/test/sql/storage/wal/group_commit_concurrent_replay.test_slow
+++ b/test/sql/storage/wal/group_commit_concurrent_replay.test_slow
@@ -1,0 +1,48 @@
+# name: test/sql/storage/wal/group_commit_concurrent_replay.test_slow
+# description: Group commit: many concurrent commits are durable and fully replayed from the WAL
+# group: [wal]
+
+# force WAL-only (no checkpoint) so reopening must replay the WAL
+statement ok
+SET checkpoint_threshold='1TB'
+
+statement ok
+PRAGMA disable_checkpoint_on_shutdown
+
+statement ok
+ATTACH '{TEST_DIR}/group_commit_concurrent_replay.db' AS gc
+
+statement ok
+CREATE TABLE gc.integers(i INTEGER)
+
+# 10 threads x 100 single-row autocommit inserts => 1000 concurrent commits sharing group-commit fsyncs
+concurrentloop threadid 0 10
+
+loop x 0 100
+
+statement ok
+INSERT INTO gc.integers VALUES ({threadid} * 100 + {x})
+
+endloop
+
+endloop
+
+query II
+SELECT COUNT(*), SUM(i) FROM gc.integers
+----
+1000	499500
+
+# reopen: the committed rows must come back purely from WAL replay
+statement ok
+DETACH gc
+
+statement ok
+ATTACH '{TEST_DIR}/group_commit_concurrent_replay.db' AS gc
+
+query II
+SELECT COUNT(*), SUM(i) FROM gc.integers
+----
+1000	499500
+
+statement ok
+DETACH gc

--- a/test/sql/storage/wal/group_commit_conflict.test_slow
+++ b/test/sql/storage/wal/group_commit_conflict.test_slow
@@ -1,0 +1,54 @@
+# name: test/sql/storage/wal/group_commit_conflict.test_slow
+# description: Group commit: concurrent conflicting commits keep the conserved invariant and survive WAL replay
+# group: [wal]
+
+statement ok
+SET checkpoint_threshold='1TB'
+
+statement ok
+PRAGMA disable_checkpoint_on_shutdown
+
+statement ok
+ATTACH '{TEST_DIR}/group_commit_conflict.db' AS gc
+
+statement ok
+CREATE TABLE gc.accounts(id INTEGER, balance BIGINT)
+
+statement ok
+INSERT INTO gc.accounts SELECT i, 1000 FROM range(10) t(i)
+
+# each thread repeatedly transfers 1 unit between two adjacent accounts in a single atomic UPDATE.
+# adjacent threads share an account, so their commits conflict; a conflicting UPDATE aborts atomically
+# (statement maybe), so the total balance is conserved regardless of interleaving. If conflict detection
+# on the deferred group-commit path were broken, lost updates would make the total drift.
+concurrentloop threadid 0 10
+
+loop x 0 100
+
+statement maybe
+UPDATE gc.accounts SET balance = balance + (CASE id WHEN {threadid} THEN -1 WHEN ({threadid} + 1) % 10 THEN 1 ELSE 0 END) WHERE id IN ({threadid}, ({threadid} + 1) % 10)
+----
+
+endloop
+
+endloop
+
+# conflict detection must have prevented lost updates: the total is exactly conserved
+query I
+SELECT SUM(balance) FROM gc.accounts
+----
+10000
+
+statement ok
+DETACH gc
+
+statement ok
+ATTACH '{TEST_DIR}/group_commit_conflict.db' AS gc
+
+query I
+SELECT SUM(balance) FROM gc.accounts
+----
+10000
+
+statement ok
+DETACH gc

--- a/test/sql/storage/wal/group_commit_optimistic_replay.test_slow
+++ b/test/sql/storage/wal/group_commit_optimistic_replay.test_slow
@@ -1,0 +1,45 @@
+# name: test/sql/storage/wal/group_commit_optimistic_replay.test_slow
+# description: Group commit: commits that optimistically write row-group data sync blocks before the WAL and replay correctly
+# group: [wal]
+
+statement ok
+SET checkpoint_threshold='1TB'
+
+statement ok
+PRAGMA disable_checkpoint_on_shutdown
+
+statement ok
+ATTACH '{TEST_DIR}/group_commit_optimistic_replay.db' AS gc
+
+statement ok
+CREATE TABLE gc.big(i BIGINT)
+
+# each thread bulk-inserts > row_group_size (122880) rows in one transaction, triggering optimistic
+# row-group writes; group commit defers the data-block fsync to the sync leader, which must persist the
+# blocks before the WAL flush marker that references them. disjoint ranges => deterministic total.
+concurrentloop threadid 0 3
+
+statement ok
+INSERT INTO gc.big SELECT * FROM range({threadid} * 200000, ({threadid} + 1) * 200000)
+
+endloop
+
+query II
+SELECT COUNT(*), SUM(i) FROM gc.big
+----
+600000	179999700000
+
+# reopen: optimistically written blocks and their WAL references must be intact after replay
+statement ok
+DETACH gc
+
+statement ok
+ATTACH '{TEST_DIR}/group_commit_optimistic_replay.db' AS gc
+
+query II
+SELECT COUNT(*), SUM(i) FROM gc.big
+----
+600000	179999700000
+
+statement ok
+DETACH gc

--- a/test/sql/storage/wal/group_commit_unique_conflict.test_slow
+++ b/test/sql/storage/wal/group_commit_unique_conflict.test_slow
@@ -1,0 +1,71 @@
+# name: test/sql/storage/wal/group_commit_unique_conflict.test_slow
+# description: Group commit: concurrent committers inserting the same primary keys never duplicate and survive WAL replay
+# group: [wal]
+
+# force WAL-only (no checkpoint) so reopening must replay the WAL, including the primary-key index
+statement ok
+SET checkpoint_threshold='1TB'
+
+statement ok
+PRAGMA disable_checkpoint_on_shutdown
+
+statement ok
+ATTACH '{TEST_DIR}/group_commit_unique_conflict.db' AS gc
+
+statement ok
+CREATE TABLE gc.t(id INTEGER PRIMARY KEY, who INTEGER)
+
+# 8 threads all race to insert the SAME 200 keys as single-row autocommit commits (deferred group-commit path).
+# For each key exactly one committer can win; the rest hit the PK conflict and abort (statement maybe). The global
+# index insert + conflict check happen under the table append lock BEFORE any WAL entry is written, so two
+# concurrent committers can never both append the same key. If that were broken a key would be inserted twice
+# (COUNT > COUNT(DISTINCT)), or the persisted index would diverge from the data and replay would resurrect a dup.
+concurrentloop threadid 0 8
+
+loop k 0 200
+
+statement maybe
+INSERT INTO gc.t VALUES ({k}, {threadid})
+----
+
+endloop
+
+endloop
+
+# every contended key is present exactly once - no duplicates, nothing lost
+query III
+SELECT COUNT(*), COUNT(DISTINCT id), MAX(id) FROM gc.t
+----
+200	200	199
+
+query I
+SELECT COUNT(*) FROM gc.t WHERE id < 0 OR id >= 200
+----
+0
+
+# the primary key is still enforced after the race
+statement error
+INSERT INTO gc.t VALUES (0, 99)
+----
+<REGEX>:.*violates primary key.*
+
+# reopen: rows AND the primary-key index must come back purely from WAL replay, still consistent
+statement ok
+DETACH gc
+
+statement ok
+ATTACH '{TEST_DIR}/group_commit_unique_conflict.db' AS gc
+
+query II
+SELECT COUNT(*), COUNT(DISTINCT id) FROM gc.t
+----
+200	200
+
+# constraint still enforced after replay (the index replayed correctly, no duplicate slipped through)
+statement error
+INSERT INTO gc.t VALUES (100, 99)
+----
+<REGEX>:.*violates primary key.*
+
+statement ok
+DETACH gc

--- a/test/sql/storage/wal/wal_buffer_size.test
+++ b/test/sql/storage/wal/wal_buffer_size.test
@@ -1,0 +1,88 @@
+# name: test/sql/storage/wal/wal_buffer_size.test
+# description: wal_buffer_size controls the WAL write buffer size and does not affect durability
+# group: [wal]
+
+# default is 4096 bytes (== FILE_BUFFER_SIZE)
+query I
+SELECT current_setting('wal_buffer_size')
+----
+4.0 KiB
+
+# round-trips as a human-readable byte size
+statement ok
+SET wal_buffer_size='1MiB'
+
+query I
+SELECT current_setting('wal_buffer_size')
+----
+1.0 MiB
+
+statement ok
+SET wal_buffer_size='256KiB'
+
+query I
+SELECT current_setting('wal_buffer_size')
+----
+256.0 KiB
+
+# RESET restores the default
+statement ok
+RESET wal_buffer_size
+
+query I
+SELECT current_setting('wal_buffer_size')
+----
+4.0 KiB
+
+# sub-page sizes are rejected
+statement error
+SET wal_buffer_size='2KiB'
+----
+<REGEX>:.*at least 4096 bytes.*
+
+# the "infinite" sentinel (-1 / none) is rejected
+statement error
+SET wal_buffer_size='-1'
+----
+<REGEX>:.*at least 4096 bytes.*
+
+# a non-size string is rejected
+statement error
+SET wal_buffer_size='not_a_size'
+----
+
+# end-to-end: a larger WAL buffer must not affect durability - data survives WAL replay
+statement ok
+SET wal_buffer_size='256KiB'
+
+statement ok
+ATTACH '{TEST_DIR}/wal_buffer_size.db' AS wbs
+
+statement ok
+PRAGMA disable_checkpoint_on_shutdown
+
+statement ok
+CREATE TABLE wbs.t(i INTEGER)
+
+statement ok
+INSERT INTO wbs.t SELECT * FROM range(100000)
+
+query II
+SELECT COUNT(*), SUM(i) FROM wbs.t
+----
+100000	4999950000
+
+# reopen: rows must come back purely from WAL replay
+statement ok
+DETACH wbs
+
+statement ok
+ATTACH '{TEST_DIR}/wal_buffer_size.db' AS wbs
+
+query II
+SELECT COUNT(*), SUM(i) FROM wbs.t
+----
+100000	4999950000
+
+statement ok
+DETACH wbs


### PR DESCRIPTION
Batch WAL fsyncs across concurrently committing transactions. Previously every
committing transaction took the WAL lock **exclusively** and fsynced its own
entries, so commits fully serialized and throughput was pinned at roughly
`1 / fsync_latency` no matter how many connections were committing. This is
especially painful on high-latency durable storage (networked disks, e.g. EFS),
where the fsync round-trip dominates commit cost.

With group commit, concurrently committing transactions share a single fsync, so
commit throughput scales with concurrency.

## How it works

- **The WAL lock becomes a writer-priority read/write lock** (`StorageLock`,
  reworked from a busy-spin to a condition-variable implementation). Data commits
  take it **shared** and run concurrently; checkpoints and catalog-changing
  commits take it **exclusive**.
- **Deferred publish.** A data commit validates conflicts, writes its WAL entries
  and a flush marker under the shared lock, then defers making its changes
  visible. A single *sync leader* fsyncs the accumulated batch (covering every
  pending flush marker), and each commit then publishes **in WAL order** once
  durable.
- **Commit timestamps are assigned at publish time**, not at commit start — so a
  transaction can never observe a commit that is not yet durable (no
  read-uncommitted / lost-update anomalies across the deferred window).
- **Adaptive micro-batching.** The sync leader can wait a short window for more
  commits to join the batch, controlled by `group_commit_delay` (default
  automatic: a fraction of the observed fsync duration, so the wait stays small
  relative to the fsync).

## Concurrency & correctness

- **Per-table publish gate** (on `DataTableInfo`): a DDL (`ALTER`/`DROP`/`CREATE
  INDEX`) on table *T* excludes only commits that modified *T*, keeping each
  commit's catalog validation authoritative until it publishes — scoped per table,
  so DDL on one table doesn't block commits to others.
- **Epoch-gated deferred reclamation** (`RetireObject`): row groups replaced by a
  checkpoint are freed only once no active transaction can still reference them.
- **Writer priority** prevents a steady stream of commits from starving
  checkpoints or DDL.
- Includes fixes surfaced along the way: partial last-vector version-info write
  sizing (WAL-replay conflicts), and concurrent-checkpoint correctness around the
  WAL swap.

## New settings

- **`wal_buffer_size`** (default 4 KiB): size of the WAL write buffer. Larger
  buffers coalesce a batch's WAL entries into a single `write()` — worth raising
  on high-latency storage with non-trivial transaction sizes.
- **`group_commit_delay`**: micro-batching window (µs; default automatic).

## Benchmark

`benchmark/micro/group_commit.cpp` (`[wal]`): concurrent single-row-commit
throughput on a persistent DB, across 1/4/8/16 committer threads at real, 1 ms,
and 10 ms simulated fsync latency (latency injected via a `LocalFileSystem`
subclass on the DB config — no production code involved). Fixed work per latency,
so run time drops as more commits share each fsync:

| threads         | real fsync | 1 ms   | 10 ms  |
| --------------- | ---------: | -----: | -----: |
| 1 (no batching) | 2.20 s     | 1.65 s | 2.27 s |
| 4               | 0.88 s     | 0.67 s | 0.65 s |
| 8               | 0.69 s     | 0.36 s | 0.34 s |
| 16              | 0.69 s     | 0.18 s | 0.18 s |

→ up to **9.3× (1 ms)** and **12.4× (10 ms)** from 1→16 threads; real local fsync
plateaus by 8 threads (little latency to amortize).

## Testing

New coverage under `test/sql/storage/wal/` and
`test/sql/parallelism/interquery/`, run under two configs
(`test/configs/group_commit.json`, `group_commit_delay.json`): conflict
validation, concurrent checkpoint, WAL replay (optimistic + concurrent), nested
checkpoint stress, unique-constraint conflicts, and `wal_buffer_size` durability.
Validated the interquery suite under ASAN (no use-after-free).
