### PR TITLE
Fix named window inheriting from an earlier window in the same WINDOW clause

### DIFF
--- a/src/parser/peg/transformer/transform_select.cpp
+++ b/src/parser/peg/transformer/transform_select.cpp
@@ -247,19 +247,7 @@ unique_ptr<SelectStatement> PEGTransformerFactory::TransformSimpleSelect(PEGTran
 	auto &list_pr = parse_result.Cast<ListParseResult>();
 	auto &opt_window_clause = list_pr.Child<OptionalParseResult>(4);
 	if (opt_window_clause.HasResult()) {
-		auto window_functions =
-		    transformer.Transform<vector<unique_ptr<ParsedExpression>>>(opt_window_clause.GetResult());
-		for (auto &window_func : window_functions) {
-			D_ASSERT(!window_func->GetAlias().empty());
-			auto window_name = window_func->GetAlias();
-			window_func->ClearAlias();
-			auto it = transformer.window_clauses.find(window_name);
-			if (it != transformer.window_clauses.end()) {
-				throw ParserException("window \"%s\" is already defined", window_name.GetIdentifierName());
-			}
-			auto window_function = unique_ptr_cast<ParsedExpression, WindowExpression>(std::move(window_func));
-			transformer.window_clauses[window_name] = std::move(window_function);
-		}
+		transformer.Transform<vector<unique_ptr<ParsedExpression>>>(opt_window_clause.GetResult());
 	}
 	auto select_node = transformer.Transform<unique_ptr<SelectNode>>(list_pr.Child<ListParseResult>(0));
 	transformer.TransformOptional<unique_ptr<ParsedExpression>>(list_pr, 1, select_node->where_clause);
@@ -282,18 +270,14 @@ unique_ptr<SelectStatement> PEGTransformerFactory::TransformSimpleSelect(PEGTran
 	return select_statement;
 }
 
-static void RegisterWindowClauses(PEGTransformer &transformer, vector<unique_ptr<ParsedExpression>> window_functions) {
-	for (auto &window_func : window_functions) {
-		D_ASSERT(!window_func->GetAlias().empty());
-		auto window_name = window_func->GetAlias();
-		window_func->ClearAlias();
-		auto it = transformer.window_clauses.find(window_name);
-		if (it != transformer.window_clauses.end()) {
-			throw ParserException("window \"%s\" is already defined", window_name.GetIdentifierName());
-		}
-		auto window_function = unique_ptr_cast<ParsedExpression, WindowExpression>(std::move(window_func));
-		transformer.window_clauses[window_name] = std::move(window_function);
+static void RegisterWindowClause(PEGTransformer &transformer, const Identifier &window_name,
+                                 WindowExpression &window_function) {
+	auto it = transformer.window_clauses.find(window_name);
+	if (it != transformer.window_clauses.end()) {
+		throw ParserException("window \"%s\" is already defined", window_name.GetIdentifierName());
 	}
+	transformer.window_clauses[window_name] =
+	    unique_ptr_cast<ParsedExpression, WindowExpression>(window_function.Copy());
 }
 
 static void PushSimpleSelectRemainder(TransformStack &stack, TransformStackFrame &frame) {
@@ -346,8 +330,7 @@ unique_ptr<TransformResultValue> PEGTransformerFactory::FinalizeSimpleSelectTram
                                                                                        TransformStack &stack,
                                                                                        TransformStackFrame &frame) {
 	if (frame.manual_state == 0) {
-		auto window_functions = frame.TakeResult<vector<unique_ptr<ParsedExpression>>>(4);
-		RegisterWindowClauses(transformer, std::move(window_functions));
+		frame.TakeResult<vector<unique_ptr<ParsedExpression>>>(4);
 		frame.manual_state = 1;
 		PushSimpleSelectRemainder(stack, frame);
 		return nullptr;
@@ -1214,7 +1197,8 @@ unique_ptr<ParsedExpression> PEGTransformerFactory::TransformWindowDefinition(PE
 	transformer.in_window_definition = true;
 	auto window_function = transformer.Transform<unique_ptr<WindowExpression>>(list_pr.Child<ListParseResult>(2));
 	transformer.in_window_definition = false;
-	window_function->SetAlias(list_pr.Child<IdentifierParseResult>(0).identifier);
+	auto window_name = list_pr.Child<IdentifierParseResult>(0).identifier;
+	RegisterWindowClause(transformer, window_name, *window_function);
 	return std::move(window_function);
 }
 
@@ -1233,7 +1217,8 @@ unique_ptr<TransformResultValue> PEGTransformerFactory::FinalizeWindowDefinition
 	auto &list_pr = frame.parse_result.Cast<ListParseResult>();
 	auto window_function = frame.TakeResult<unique_ptr<WindowExpression>>(0);
 	transformer.in_window_definition = false;
-	window_function->SetAlias(list_pr.Child<IdentifierParseResult>(0).identifier);
+	auto window_name = list_pr.Child<IdentifierParseResult>(0).identifier;
+	RegisterWindowClause(transformer, window_name, *window_function);
 	unique_ptr<ParsedExpression> result = std::move(window_function);
 	return make_uniq<TypedTransformResult<unique_ptr<ParsedExpression>>>(std::move(result));
 }

--- a/test/sql/window/test_window_clause.test
+++ b/test/sql/window/test_window_clause.test
@@ -79,3 +79,54 @@ statement ok
 SELECT sum(i) over cumulativeSum 
 FROM integers 
 WINDOW cumulativeSum AS ();
+
+# A named window can inherit from an earlier named window in the same WINDOW clause
+query I
+SELECT count(*) OVER w AS x
+FROM (VALUES (1), (2)) AS t(a)
+WINDOW base AS (ORDER BY a), w AS (base ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)
+ORDER BY a;
+----
+2
+1
+
+query I
+SELECT count(*) OVER w AS x
+FROM (VALUES (1), (2)) AS t(a)
+WINDOW base AS (ORDER BY a), w AS (base)
+ORDER BY a;
+----
+1
+2
+
+query I
+SELECT count(*) OVER w AS x
+FROM (VALUES (1), (2)) AS t(a)
+WINDOW base AS (ORDER BY a), w AS (base RANGE BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)
+ORDER BY a;
+----
+2
+1
+
+query I
+SELECT count(*) OVER w AS x
+FROM (VALUES (1), (2)) AS t(a)
+WINDOW base AS (ORDER BY a), w AS (base GROUPS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)
+ORDER BY a;
+----
+2
+1
+
+statement error
+SELECT count(*) OVER w
+FROM (VALUES (1), (2)) AS t(a)
+WINDOW w AS (base), base AS (ORDER BY a);
+----
+does not exist
+
+statement error
+SELECT count(*) OVER w
+FROM (VALUES (1), (2)) AS t(a)
+WINDOW w AS (w);
+----
+does not exist


### PR DESCRIPTION
Fixes #23443.

### Problem

On `main`, a named window that inherits from an *earlier* named window in the same `WINDOW` clause fails to parse — a regression from v1.5.4:

```sql
SELECT count(*) OVER w
FROM (VALUES (1), (2)) AS t(a)
WINDOW base AS (ORDER BY a), w AS (base ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING);
-- Parser Error: window "base" does not exist
```

The equivalent inline window works, and so does inheriting a named window in an `OVER (w ...)` clause — only inheritance *within* the `WINDOW` clause is affected.

### Cause

`TransformSimpleSelect` transformed the entire `WINDOW` list via `Transform<vector<...>>` and only registered each window into `window_clauses` afterwards. So while transforming `w AS (base ...)`, `GetWindowClause("base")` ran before `base` had been inserted. (Thanks to @Yibo-Dong for pinpointing this in the issue.)

### Fix

Register each named window into `window_clauses` as soon as it is transformed, in `TransformWindowDefinition`, so a later definition in the same clause can resolve an earlier one. `GetWindowClause` already returns a `Copy()`, so ownership is unchanged, and the duplicate-name check moves alongside the registration.

Forward references (`w AS (base), base AS (...)`) and self-references (`w AS (w)`) still error, consistent with SQL semantics where a window may only reference a preceding one.

### Tests

Added cases to `test/sql/window/test_window_clause.test` covering inheritance via `base`, `base ROWS/RANGE/GROUPS ...`, plus the forward-reference and self-reference error paths. The full window suite passes locally (96k assertions).
