### PR TITLE
[MultiFileReader] Add virtual `GetMetadata` function

### DIFF
--- a/src/common/multi_file/base_file_reader.cpp
+++ b/src/common/multi_file/base_file_reader.cpp
@@ -24,6 +24,10 @@ double BaseFileReader::GetProgressInFile(ClientContext &context) {
 	return 0;
 }
 
+InsertionOrderPreservingMap<Value> BaseFileReader::GetMetadata() const {
+	return {};
+}
+
 unique_ptr<BaseStatistics> BaseUnionData::GetStatistics(ClientContext &context, const Identifier &name) {
 	return nullptr;
 }

--- a/src/include/duckdb/common/multi_file/base_file_reader.hpp
+++ b/src/include/duckdb/common/multi_file/base_file_reader.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "duckdb/common/common.hpp"
+#include "duckdb/common/insertion_order_preserving_map.hpp"
 #include "duckdb/common/types/value.hpp"
 #include "duckdb/common/column_index.hpp"
 #include "duckdb/planner/table_filter_set.hpp"
@@ -102,6 +103,8 @@ public:
 	DUCKDB_API virtual void FinishFile(ClientContext &context, GlobalTableFunctionState &gstate);
 	//! Get progress within a given file
 	DUCKDB_API virtual double GetProgressInFile(ClientContext &context);
+	//! Get reader metadata, if available
+	DUCKDB_API virtual InsertionOrderPreservingMap<Value> GetMetadata() const;
 
 	virtual string GetReaderType() const = 0;
 


### PR DESCRIPTION
This gives readers that carry file-level metadata (such as parquet or avro) a way to expose this, to be consumed in `MultiFileReader::InitializeReader` implementations for example.