### PR TITLE
unittest: emit event w/ stats for harnesses (pytest)

### DIFF
--- a/test/helpers/test_helpers.cpp
+++ b/test/helpers/test_helpers.cpp
@@ -127,6 +127,16 @@ bool DeleteTestPath() {
 	return delete_test_path;
 }
 
+static bool emit_test_events = false;
+
+void SetEmitTestEvents(bool emit) {
+	emit_test_events = emit;
+}
+
+bool EmitTestEventsEnabled() {
+	return emit_test_events;
+}
+
 void ClearTestDirectory() {
 	if (!DeleteTestPath()) {
 		return;

--- a/test/include/test_helpers.hpp
+++ b/test/include/test_helpers.hpp
@@ -44,6 +44,8 @@ void TestChangeDirectory(string path);
 
 void SetDeleteTestPath(bool delete_path);
 bool DeleteTestPath();
+void SetEmitTestEvents(bool emit);
+bool EmitTestEventsEnabled();
 void ClearTestDirectory();
 string TestGetCurrentDirectory();
 string TestDirectoryPath();

--- a/test/sqlite/sqllogic_command.cpp
+++ b/test/sqlite/sqllogic_command.cpp
@@ -311,18 +311,39 @@ void Command::Execute(ExecuteContext &context) const {
 		return;
 	}
 	if (!CheckLoopCondition(context, conditions)) {
-		// condition excludes this file
+		// a loop-variable onlyif/skipif excludes this statement — a per-execution skip, counted like
+		// a mode-skip so the tally accounts for it instead of dropping it
+		if (IsCountableStatement()) {
+			runner.CountSkipMode();
+		}
 		return;
 	}
 	if (context.running_loops.empty()) {
 		context.sql_query = base_sql_query;
+	} else {
+		// perform the string replacement
+		context.sql_query = runner.LoopReplacement(base_sql_query, context.running_loops);
+	}
+	// Per-statement outcome events (--emit-test-events): count + emit pass/fail for the countable
+	// command kinds (statement/query); infrastructure commands run untracked. A failing statement
+	// throws (Catch FAIL) — record the fail, then rethrow so the failure still propagates.
+	if (!IsCountableStatement()) {
 		ExecuteInternal(context);
 		return;
 	}
-	// perform the string replacement
-	context.sql_query = runner.LoopReplacement(base_sql_query, context.running_loops);
-	// execute the iterated statement
-	ExecuteInternal(context);
+	// In parallel (concurrentloop) execution a failing statement does NOT throw — the worker records
+	// the failure into the context (error_file) and unwinds normally, to be re-raised after join. So
+	// besides the throwing (serial) path, treat a newly-set error_file as a fail; otherwise a
+	// concurrent failure is miscounted as a pass.
+	const bool had_error = !context.error_file.empty();
+	try {
+		ExecuteInternal(context);
+	} catch (...) {
+		runner.CountStatement(false);
+		throw;
+	}
+	const bool newly_failed = !had_error && !context.error_file.empty();
+	runner.CountStatement(!newly_failed);
 }
 
 Statement::Statement(SQLLogicTestRunner &runner) : Command(runner) {
@@ -666,6 +687,10 @@ void LoopCommand::ExecuteInternal(ExecuteContext &context) const {
 		}
 		for (auto &execute_context : contexts) {
 			if (!execute_context.success) {
+				// error_file/error_line hold the failing command's location on both the thrown and the
+				// error_file paths — same source as the serial fail sites, so the locator is consistent
+				runner.test_failure_locator =
+				    StringUtil::Format("%s:%d", execute_context.error_file, execute_context.error_line);
 				if (!execute_context.error_message.empty()) {
 					FAIL(execute_context.error_message);
 				} else {
@@ -741,6 +766,7 @@ void Query::ExecuteInternal(ExecuteContext &context) const {
 			context.error_file = file_name;
 			context.error_line = query_line;
 		} else {
+			runner.test_failure_locator = StringUtil::Format("%s:%d", file_name, query_line);
 			FAIL_LINE(file_name, query_line, 0);
 		}
 	}
@@ -855,6 +881,7 @@ void Statement::ExecuteInternal(ExecuteContext &context) const {
 			context.error_file = file_name;
 			context.error_line = query_line;
 		} else {
+			runner.test_failure_locator = StringUtil::Format("%s:%d", file_name, query_line);
 			FAIL_LINE(file_name, query_line, 0);
 		}
 	}

--- a/test/sqlite/sqllogic_command.hpp
+++ b/test/sqlite/sqllogic_command.hpp
@@ -74,6 +74,12 @@ public:
 		return false;
 	}
 
+	//! Whether this command is a countable test assertion (statement/query) for per-test outcome
+	//! stats (--emit-test-events). Infrastructure commands (mode/loop/load/...) return false.
+	virtual bool IsCountableStatement() const {
+		return false;
+	}
+
 private:
 	void RestartDatabase(ExecuteContext &context, reference<Connection> &connection, const string &sql_query) const;
 };
@@ -89,6 +95,9 @@ public:
 	void ExecuteInternal(ExecuteContext &context) const override;
 
 	bool SupportsConcurrent() const override {
+		return true;
+	}
+	bool IsCountableStatement() const override {
 		return true;
 	}
 };
@@ -122,6 +131,9 @@ public:
 	void ExecuteInternal(ExecuteContext &context) const override;
 
 	bool SupportsConcurrent() const override {
+		return true;
+	}
+	bool IsCountableStatement() const override {
 		return true;
 	}
 };

--- a/test/sqlite/sqllogic_test_logger.cpp
+++ b/test/sqlite/sqllogic_test_logger.cpp
@@ -26,6 +26,13 @@ void SQLLogicTestLogger::AppendFailure(const string &log_message) {
 	FailureSummary::Log(log_message);
 }
 
+void SQLLogicTestLogger::EmitTestEvent(const string &json_payload) {
+	// The "[TEST_EVENT] " flare marks a line as a machine-readable event; the payload is a JSON
+	// object (begin / end). Callers gate on EmitTestEventsEnabled() and pass a serialized object.
+	// Build the whole line first so it reaches cerr as a single insertion — no interleaving.
+	std::cerr << "[TEST_EVENT] " + json_payload + "\n";
+}
+
 void SQLLogicTestLogger::LogFailure(const string &log_message) {
 	Log("", log_message);
 }

--- a/test/sqlite/sqllogic_test_logger.hpp
+++ b/test/sqlite/sqllogic_test_logger.hpp
@@ -54,6 +54,8 @@ public:
 	void ExpectedErrorMismatch(const string &expected_error, MaterializedQueryResult &result);
 	void InternalException(MaterializedQueryResult &result);
 	static void LoadDatabaseFail(const string &file_name, const string &dbpath, const string &message);
+	//! Write a machine-readable event line: "[TEST_EVENT] <json>" (--emit-test-events). Caller gates.
+	static void EmitTestEvent(const string &json_payload);
 
 	static void AppendFailure(const string &log_message);
 	static void LogFailure(const string &log_message);

--- a/test/sqlite/sqllogic_test_runner.cpp
+++ b/test/sqlite/sqllogic_test_runner.cpp
@@ -3,6 +3,7 @@
 
 #include "catch.hpp"
 #include "duckdb/common/file_open_flags.hpp"
+#include "duckdb/common/json_document.hpp"
 #include "duckdb/common/virtual_file_system.hpp"
 #include "duckdb/main/extension/generated_extension_loader.hpp"
 #include "duckdb/common/types/uuid.hpp"
@@ -94,6 +95,10 @@ void SQLLogicTestRunner::AddSkipReason(const string &reason) {
 
 void SQLLogicTestRunner::SkipTest(const string &reason) {
 	AddSkipReason(reason);
+	// A whole-test skip is a terminal disposition, not a mid-stream event: record it and let the
+	// Catch wrapper emit the single end {status:"skip-requirement"} terminal.
+	test_skipped_requirement = true;
+	test_skip_reason = reason;
 	SKIP_TEST(reason);
 }
 
@@ -107,6 +112,57 @@ string SQLLogicTestRunner::GetSkipReasonSummary() {
 		oss << entry.first << ": " << entry.second << "\n";
 	}
 	return oss.str();
+}
+
+void SQLLogicTestRunner::CountStatement(bool passed) {
+	if (!EmitTestEventsEnabled()) {
+		return; // feature off: no counting on the normal path
+	}
+	if (passed) {
+		test_stat_passes++;
+	} else {
+		test_stat_fails++;
+	}
+}
+
+void SQLLogicTestRunner::CountSkipMode() {
+	if (!EmitTestEventsEnabled()) {
+		return;
+	}
+	test_stat_skip_mode++;
+}
+
+void SQLLogicTestRunner::EmitBegin(const string &test_name) {
+	if (!EmitTestEventsEnabled()) {
+		return;
+	}
+	JSONWriter writer;
+	auto obj = writer.CreateObject();
+	obj.AddString("event", "begin");
+	obj.AddString("name", test_name);
+	writer.SetRoot(obj);
+	SQLLogicTestLogger::EmitTestEvent(writer.ToString());
+}
+
+void SQLLogicTestRunner::EmitEnd(const string &test_name, const string &status, const string &data) {
+	if (!EmitTestEventsEnabled()) {
+		return;
+	}
+	// One terminal per test: status in {ok, error, skip-requirement}, the statement tallies, and
+	// optional free-form data (skip reason / error text — multi-line safe via JSON escaping).
+	JSONWriter writer;
+	auto obj = writer.CreateObject();
+	obj.AddString("event", "end");
+	obj.AddString("name", test_name);
+	obj.AddString("status", status);
+	obj.Add("passes", writer.CreateUnsignedInteger(test_stat_passes.load()));
+	obj.Add("fails", writer.CreateUnsignedInteger(test_stat_fails.load()));
+	obj.Add("skip-mode", writer.CreateUnsignedInteger(test_stat_skip_mode.load()));
+	if (!data.empty()) {
+		obj.AddString("data", data);
+	}
+	writer.SetRoot(obj);
+	SQLLogicTestLogger::EmitTestEvent(writer.ToString());
 }
 
 void SQLLogicTestRunner::ExecuteCommand(duckdb::unique_ptr<Command> command) {
@@ -706,13 +762,13 @@ void SQLLogicTestRunner::ExecuteStream(std::istream &input, const string &source
 }
 
 void SQLLogicTestRunner::ExecuteInternal(SQLLogicParser &parser, const string &script) {
+	file_name = script;
 	auto &test_config = TestConfiguration::Get();
 	if (test_config.ShouldSkipTest(script)) {
 		SkipTest("config skip_tests");
 		return;
 	}
 
-	file_name = script;
 	idx_t skip_level = 0;
 	bool test_expr_executed = false;
 	bool file_tags_expr_seen = false;
@@ -813,6 +869,10 @@ void SQLLogicTestRunner::ExecuteInternal(SQLLogicParser &parser, const string &s
 			continue;
 		}
 		if (skip_level > 0 && token.type != SQLLogicTokenType::SQLLOGIC_MODE) {
+			if (token.type == SQLLogicTokenType::SQLLOGIC_STATEMENT ||
+			    token.type == SQLLogicTokenType::SQLLOGIC_QUERY) {
+				CountSkipMode();
+			}
 			continue;
 		}
 		if (token.type == SQLLogicTokenType::SQLLOGIC_STATEMENT) {

--- a/test/sqlite/sqllogic_test_runner.hpp
+++ b/test/sqlite/sqllogic_test_runner.hpp
@@ -88,6 +88,20 @@ public:
 	HashLabelMap hash_label_map;
 	mutex log_lock;
 
+	//! Per-test statement tallies for --emit-test-events. Atomic: concurrent loops run the countable
+	//! commands on multiple threads; the begin/end events are emitted single-threaded at boundaries.
+	atomic<idx_t> test_stat_passes {0};
+	atomic<idx_t> test_stat_fails {0};
+	atomic<idx_t> test_stat_skip_mode {0};
+	//! Whole-test skip disposition (require/require-env/config/tag), recorded by SkipTest and read at
+	//! the terminal to emit end{status:"skip-requirement"}.
+	bool test_skipped_requirement = false;
+	string test_skip_reason;
+	//! Locator for the failing command (file:line), stashed at the throw site for --emit-test-events.
+	//! A Catch FAIL carries no message; consumers get this anchor to correlate with captured output.
+	//! Written single-threaded: serial fails throw directly; concurrent fails are re-raised post-join.
+	string test_failure_locator;
+
 public:
 	void ExecuteFile(string script);
 	void ExecuteStream(std::istream &input, const string &source_name);
@@ -107,6 +121,11 @@ public:
 	static ExtensionLoadResult LoadExtension(DuckDB &db, const std::string &extension);
 	void SkipTest(const string &reason);
 	static string GetSkipReasonSummary();
+	//! --emit-test-events: statement tallies (counted, not emitted) + the begin/end JSON events.
+	void CountStatement(bool passed);
+	void CountSkipMode();
+	void EmitBegin(const string &test_name);
+	void EmitEnd(const string &test_name, const string &status, const string &data);
 	NewDatabaseConnection CreateDatabase(const string &db_path, bool load_database);
 	unique_ptr<Connection> ConnectToDatabase(DuckDB &db_ref);
 	bool IsVariableReplacement(const string &token_name);

--- a/test/sqlite/test_sqllogictest.cpp
+++ b/test/sqlite/test_sqllogictest.cpp
@@ -92,6 +92,8 @@ static void RunSQLLogicTest(const string &name, optional_ptr<std::istream> input
 	runner.environment_variables["TEST_NAME"] = name;
 	runner.environment_variables["TEST_NAME__NO_SLASH"] = StringUtil::Replace(name, "/", "_");
 
+	runner.EmitBegin(name);
+
 	ErrorData error;
 	try {
 		if (input) {
@@ -101,6 +103,12 @@ static void RunSQLLogicTest(const string &name, optional_ptr<std::istream> input
 		}
 	} catch (std::exception &ex) {
 		error = ErrorData(ex);
+	} catch (...) {
+		// Catch's own assertion-failure control exception (not std::exception): the test aborted
+		// mid-run. Catch carries no message; emit the locator stashed at the throw site (file:line —
+		// the full diff is in the captured output), then rethrow so Catch still records the verdict.
+		runner.EmitEnd(name, "error", runner.test_failure_locator);
+		throw;
 	}
 
 	if (!input && AUTO_SWITCH_TEST_DIR) {
@@ -120,8 +128,12 @@ static void RunSQLLogicTest(const string &name, optional_ptr<std::istream> input
 			}
 		} catch (std::exception &ex) {
 			string cleanup_failure = "Error while running clean-up routine:\n";
-			ErrorData error(ex);
-			cleanup_failure += error.Message();
+			ErrorData cleanup_error(ex);
+			cleanup_failure += cleanup_error.Message();
+			// FAIL throws, unwinding past the unified terminal-event emit below. Emit the end event
+			// here first so a cleanup failure still yields one — preserving the one-begin/one-end
+			// invariant that --emit-test-events consumers rely on.
+			runner.EmitEnd(name, "error", cleanup_failure);
 			FAIL(cleanup_failure);
 		}
 	}
@@ -129,6 +141,16 @@ static void RunSQLLogicTest(const string &name, optional_ptr<std::istream> input
 	// clear test directory after running tests
 	ClearTestDirectory();
 
+	// Single terminal event (--emit-test-events): status = skip-requirement (whole-test skip) /
+	// error (a std::exception escaped: LoadDatabase / cleanup / unexpected) / ok. Catch-thrown
+	// statement failures are handled by the catch(...) above.
+	if (runner.test_skipped_requirement) {
+		runner.EmitEnd(name, "skip-requirement", runner.test_skip_reason);
+	} else if (error.HasError()) {
+		runner.EmitEnd(name, "error", error.Message());
+	} else {
+		runner.EmitEnd(name, "ok", "");
+	}
 	if (error.HasError()) {
 		FAIL(error.Message());
 	}

--- a/test/unittest.cpp
+++ b/test/unittest.cpp
@@ -42,6 +42,8 @@ int main(int argc_in, char *argv[]) {
 			keep_home = true;
 		} else if (argument == "--stdin") {
 			use_stdin = true;
+		} else if (argument == "--emit-test-events") {
+			SetEmitTestEvents(true);
 		} else {
 			try {
 				if (!test_config.ParseArgument(argument, argc, argv, i)) {


### PR DESCRIPTION
- emits (stderr) "[TEST_EVENT] {...}" tiny json event with name counts and message
- opt-in via --emit-test-stats
- allows pytest harness to recognize and count tests/fails/skips correctly

This could eventually be superseded by a structured reporter, e.g. custom json via Catch.