### PR TITLE
Fix ART iterator crash on empty table close range scan (#23064)

### DIFF
--- a/src/execution/index/art/art.cpp
+++ b/src/execution/index/art/art.cpp
@@ -748,6 +748,10 @@ bool ART::SearchLess(ARTKey &upper_bound, bool equal, idx_t max_count, set<row_t
 
 bool ART::SearchCloseRange(ARTKey &lower_bound, ARTKey &upper_bound, bool left_equal, bool right_equal, idx_t max_count,
                            set<row_t> &row_ids) {
+	if (!tree.HasMetadata()) {
+		return true;
+	}
+
 	// Find the first node that satisfies the left predicate.
 	Iterator it(*this);
 

--- a/test/sql/index/art/test_art_empty_close_range.test
+++ b/test/sql/index/art/test_art_empty_close_range.test
@@ -1,0 +1,11 @@
+# name: test/sql/index/art/test_art_empty_close_range.test
+# description: Test close range index scan on an empty ART (Issue 23064)
+# group: [art]
+
+statement ok
+CREATE TABLE t0(c0 DOUBLE UNIQUE);
+
+query I
+SELECT c0 FROM t0 WHERE (c0 - 0 BETWEEN 0 AND 0) AND (c0 - 0 = c0);
+----
+


### PR DESCRIPTION

Fixes #23064.
When executing a `BETWEEN` query on an empty table with a `UNIQUE` index, the ART index executes a `SearchCloseRange` operation. This function was missing a check to ensure the tree root node was initialized (which `SearchGreater` and `SearchLess` already handle). This caused `Iterator::LowerBound` to crash with `INTERNAL Error: ART Iterator::LowerBound: Reached node without metadata`.
This PR adds the missing `!tree.HasMetadata()` guard to `ART::SearchCloseRange` and includes a sqllogictest using the exact reproducer from the issue.
