### PR TITLE
Improve connect integration

### DIFF
--- a/.github/patches/extensions/postgres_scanner/zzzzzzzz-zz-connect-return-type.patch
+++ b/.github/patches/extensions/postgres_scanner/zzzzzzzz-zz-connect-return-type.patch
@@ -1,0 +1,15 @@
+diff --git a/src/postgres_query.cpp b/src/postgres_query.cpp
+index 8096f14..4f31936 100644
+--- a/src/postgres_query.cpp
++++ b/src/postgres_query.cpp
+@@ -85,6 +85,10 @@ static unique_ptr<FunctionData> PGQueryBind(ClientContext &context, TableFunctio
+ 		// the prepare/describe just done — no extra round-trip — and defer execution to
+ 		// InitGlobalState (execution time, not bind, so EXPLAIN does not run it).
+ 		result->command_only = true;
++		// This invocation wraps a command with no result set (DDL, or DML without RETURNING). Tell the
++		// binder via the return-type modifier so that when this is routed through CONNECT the outer
++		// statement is reported as NOTHING and displays like a native command (no spurious result table).
++		input.table_function.call_return_type = StatementReturnType::NOTHING;
+ 		return_types.emplace_back(LogicalType::BOOLEAN);
+ 		names.emplace_back("Success");
+ 		result->SetCatalog(pg_catalog);

--- a/.github/patches/extensions/postgres_scanner/zzzzzzzz-zz-connect-return-type.patch
+++ b/.github/patches/extensions/postgres_scanner/zzzzzzzz-zz-connect-return-type.patch
@@ -2,13 +2,12 @@ diff --git a/src/postgres_query.cpp b/src/postgres_query.cpp
 index 8096f14..4f31936 100644
 --- a/src/postgres_query.cpp
 +++ b/src/postgres_query.cpp
-@@ -85,6 +85,10 @@ static unique_ptr<FunctionData> PGQueryBind(ClientContext &context, TableFunctio
+@@ -85,6 +85,9 @@ static unique_ptr<FunctionData> PGQueryBind(ClientContext &context, TableFunctio
  		// the prepare/describe just done — no extra round-trip — and defer execution to
  		// InitGlobalState (execution time, not bind, so EXPLAIN does not run it).
  		result->command_only = true;
-+		// This invocation wraps a command with no result set (DDL, or DML without RETURNING). Tell the
-+		// binder via the return-type modifier so that when this is routed through CONNECT the outer
-+		// statement is reported as NOTHING and displays like a native command (no spurious result table).
++		// No result set (DDL, or DML without RETURNING): flag the return type so a CONNECT-routed
++		// statement reports as NOTHING instead of a spurious result table.
 +		input.table_function.call_return_type = StatementReturnType::NOTHING;
  		return_types.emplace_back(LogicalType::BOOLEAN);
  		names.emplace_back("Success");

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -242,10 +242,8 @@ public:
 	static unique_ptr<BoundCreateTableInfo> BindCreateTableCheckpoint(unique_ptr<CreateInfo> info,
 	                                                                  SchemaCatalogEntry &schema);
 
-	//! If `op` is a pass-through of a single table function - a chain of projections over exactly one
-	//! LOGICAL_GET and nothing else that produces rows - returns that get; otherwise nullptr. Used to
-	//! propagate a table function's call_return_type to the statement return type for the `CALL func()`
-	//! and `SELECT * FROM func()` (CONNECT chokepoint) forms.
+	//! The lone LOGICAL_GET reached through identity projections, or nullptr if `op` is not a bare
+	//! table-function passthrough.
 	static optional_ptr<LogicalGet> GetPassthroughTableFunctionGet(LogicalOperator &op);
 
 	static vector<unique_ptr<BoundConstraint>> BindConstraints(ClientContext &context,

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -51,6 +51,7 @@ class ViewCatalogEntry;
 class TableMacroCatalogEntry;
 class UpdateSetInfo;
 class LogicalProjection;
+class LogicalGet;
 class LogicalVacuum;
 
 class ColumnList;
@@ -240,6 +241,12 @@ public:
 	                                                     AlterBindMode bind_mode = AlterBindMode::BIND_ON_ALTER);
 	static unique_ptr<BoundCreateTableInfo> BindCreateTableCheckpoint(unique_ptr<CreateInfo> info,
 	                                                                  SchemaCatalogEntry &schema);
+
+	//! If `op` is a pass-through of a single table function - a chain of projections over exactly one
+	//! LOGICAL_GET and nothing else that produces rows - returns that get; otherwise nullptr. Used to
+	//! propagate a table function's call_return_type to the statement return type for the `CALL func()`
+	//! and `SELECT * FROM func()` (CONNECT chokepoint) forms.
+	static optional_ptr<LogicalGet> GetPassthroughTableFunctionGet(LogicalOperator &op);
 
 	static vector<unique_ptr<BoundConstraint>> BindConstraints(ClientContext &context,
 	                                                           const vector<unique_ptr<Constraint>> &constraints,

--- a/src/planner/binder.cpp
+++ b/src/planner/binder.cpp
@@ -234,9 +234,7 @@ StatementProperties &Binder::GetStatementProperties() {
 }
 
 optional_ptr<LogicalGet> Binder::GetPassthroughTableFunctionGet(LogicalOperator &op) {
-	// Descend through single-child projections (the identity projection above a `SELECT * FROM func()`);
-	// return the get iff we reach exactly one LOGICAL_GET. Any other operator (aggregate, filter, join,
-	// order, limit, ...) or a branch means the statement is not a bare table-function passthrough.
+	// Follow single-child projections down to a lone LOGICAL_GET; anything else is not a passthrough.
 	auto *current = &op;
 	while (true) {
 		if (current->type == LogicalOperatorType::LOGICAL_GET) {

--- a/src/planner/binder.cpp
+++ b/src/planner/binder.cpp
@@ -233,6 +233,22 @@ StatementProperties &Binder::GetStatementProperties() {
 	return global_binder_state->prop;
 }
 
+optional_ptr<LogicalGet> Binder::GetPassthroughTableFunctionGet(LogicalOperator &op) {
+	// Descend through single-child projections (the identity projection above a `SELECT * FROM func()`);
+	// return the get iff we reach exactly one LOGICAL_GET. Any other operator (aggregate, filter, join,
+	// order, limit, ...) or a branch means the statement is not a bare table-function passthrough.
+	auto *current = &op;
+	while (true) {
+		if (current->type == LogicalOperatorType::LOGICAL_GET) {
+			return current->Cast<LogicalGet>();
+		}
+		if (current->type != LogicalOperatorType::LOGICAL_PROJECTION || current->children.size() != 1) {
+			return nullptr;
+		}
+		current = current->children[0].get();
+	}
+}
+
 optional_ptr<BoundParameterMap> Binder::GetParameters() {
 	return global_binder_state->parameters;
 }

--- a/src/planner/binder/statement/bind_call.cpp
+++ b/src/planner/binder/statement/bind_call.cpp
@@ -15,9 +15,7 @@ BoundStatement Binder::Bind(CallStatement &stmt) {
 	select_node->from_table = std::move(table_function);
 	select_statement.node = std::move(select_node);
 
-	// Bind as `SELECT * FROM func()` - which already propagates the table function's call_return_type
-	// into the statement return type (see Binder::Bind(SelectStatement)) - then force materialization,
-	// the extra behavior CALL requires on top of the shared passthrough handling.
+	// CALL is `SELECT * FROM func()` (which already propagates call_return_type) forced to materialize.
 	auto result = Bind(select_statement);
 	GetStatementProperties().output_type = QueryResultOutputType::FORCE_MATERIALIZED;
 	return result;

--- a/src/planner/binder/statement/bind_call.cpp
+++ b/src/planner/binder/statement/bind_call.cpp
@@ -3,22 +3,8 @@
 #include "duckdb/planner/binder.hpp"
 #include "duckdb/parser/query_node/select_node.hpp"
 #include "duckdb/parser/expression/star_expression.hpp"
-#include "duckdb/planner/operator/logical_get.hpp"
 
 namespace duckdb {
-
-static optional_ptr<LogicalGet> FindTableFunctionGet(LogicalOperator &op) {
-	if (op.type == LogicalOperatorType::LOGICAL_GET) {
-		return op.Cast<LogicalGet>();
-	}
-	for (auto &child : op.children) {
-		auto get = FindTableFunctionGet(*child);
-		if (get) {
-			return get;
-		}
-	}
-	return nullptr;
-}
 
 BoundStatement Binder::Bind(CallStatement &stmt) {
 	SelectStatement select_statement;
@@ -29,16 +15,11 @@ BoundStatement Binder::Bind(CallStatement &stmt) {
 	select_node->from_table = std::move(table_function);
 	select_statement.node = std::move(select_node);
 
+	// Bind as `SELECT * FROM func()` - which already propagates the table function's call_return_type
+	// into the statement return type (see Binder::Bind(SelectStatement)) - then force materialization,
+	// the extra behavior CALL requires on top of the shared passthrough handling.
 	auto result = Bind(select_statement);
-	auto &properties = GetStatementProperties();
-	properties.output_type = QueryResultOutputType::FORCE_MATERIALIZED;
-	// use the return type of the table function (if any) instead of the default query result
-	if (result.plan) {
-		auto get = FindTableFunctionGet(*result.plan);
-		if (get) {
-			properties.return_type = get->function.call_return_type;
-		}
-	}
+	GetStatementProperties().output_type = QueryResultOutputType::FORCE_MATERIALIZED;
 	return result;
 }
 

--- a/src/planner/binder/statement/bind_select.cpp
+++ b/src/planner/binder/statement/bind_select.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/parser/statement/select_statement.hpp"
 #include "duckdb/planner/binder.hpp"
 #include "duckdb/planner/bound_query_node.hpp"
+#include "duckdb/planner/operator/logical_get.hpp"
 
 namespace duckdb {
 
@@ -8,7 +9,19 @@ BoundStatement Binder::Bind(SelectStatement &stmt) {
 	auto &properties = GetStatementProperties();
 	properties.output_type = QueryResultOutputType::ALLOW_STREAMING;
 	properties.return_type = StatementReturnType::QUERY_RESULT;
-	return Bind(*stmt.node);
+	auto result = Bind(*stmt.node);
+	// Generalize #23358 from CALL to the bare `SELECT * FROM func()` / `FROM func()` form: when the
+	// statement is just a table-function passthrough, honor the function's call_return_type so a
+	// CONNECT-routed statement with no result set (DDL/SET) is reported as its true return type and
+	// displays like a native statement. Only overrides when the function opts in (non-default modifier),
+	// so normal queries are unaffected.
+	if (result.plan) {
+		auto get = GetPassthroughTableFunctionGet(*result.plan);
+		if (get && get->function.call_return_type != StatementReturnType::QUERY_RESULT) {
+			properties.return_type = get->function.call_return_type;
+		}
+	}
+	return result;
 }
 
 } // namespace duckdb

--- a/src/planner/binder/statement/bind_select.cpp
+++ b/src/planner/binder/statement/bind_select.cpp
@@ -10,11 +10,8 @@ BoundStatement Binder::Bind(SelectStatement &stmt) {
 	properties.output_type = QueryResultOutputType::ALLOW_STREAMING;
 	properties.return_type = StatementReturnType::QUERY_RESULT;
 	auto result = Bind(*stmt.node);
-	// Generalize #23358 from CALL to the bare `SELECT * FROM func()` / `FROM func()` form: when the
-	// statement is just a table-function passthrough, honor the function's call_return_type so a
-	// CONNECT-routed statement with no result set (DDL/SET) is reported as its true return type and
-	// displays like a native statement. Only overrides when the function opts in (non-default modifier),
-	// so normal queries are unaffected.
+	// A bare table-function passthrough honors the function's call_return_type (e.g. a CONNECT-routed
+	// DDL/SET reports as NOTHING), but only when the function opts in via a non-default modifier.
 	if (result.plan) {
 		auto get = GetPassthroughTableFunctionGet(*result.plan);
 		if (get && get->function.call_return_type != StatementReturnType::QUERY_RESULT) {


### PR DESCRIPTION
Building on the work at https://github.com/duckdb/duckdb/pull/23358, this improves `CONNECT` support to be closer to regular local attached databases.
Fixed the general path, AND opted-in for `postgres_scanner` via patch, `quack` still to tackle (requires changes to protocol).

After this PR:
```sql
memory D ATTACH 'dbname=testdb user=duckdb host=localhost port=5432' AS pg (TYPE postgres);
memory D CONNECT pg;
pg testdb.public D CREATE TABLE demo(i int);
pg testdb.public D SELECT * FROM demo;
┌────────┐
│   i    │
│ int32  │
└────────┘
  0 rows
```
Before:
```sql
memory D ATTACH 'dbname=testdb user=duckdb host=localhost port=5432' AS pg (TYPE postgres);
memory D CONNECT pg;
pg testdb.public D CREATE TABLE demo(i int);
┌─────────┐
│ Success │
│ boolean │
├─────────┤
│ true    │
└─────────┘
pg testdb.public D SELECT * FROM demo;
┌────────┐
│   i    │
│ int32  │
└────────┘
  0 rows
```