### PR TITLE
Install bundled fmt headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1026,7 +1026,7 @@ set(CMAKE_CONFIG_VERSION_TEMPLATE
 if(EXISTS ${CMAKE_CONFIG_TEMPLATE} AND EXISTS ${CMAKE_CONFIG_VERSION_TEMPLATE})
 
   # Configure cmake package config for the build tree
-  set(CONF_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/src/include")
+  set(CONF_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/src/include;${PROJECT_SOURCE_DIR}/third_party/fmt/include")
   configure_file(${CMAKE_CONFIG_TEMPLATE}
                  "${PROJECT_BINARY_DIR}/DuckDBConfig.cmake" @ONLY)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -141,6 +141,11 @@ install(
   FILES_MATCHING
   PATTERN "*.hpp"
   PATTERN "*.ipp")
+install(
+  DIRECTORY "${PROJECT_SOURCE_DIR}/third_party/fmt/include/fmt"
+  DESTINATION "${INSTALL_INCLUDE_DIR}"
+  FILES_MATCHING
+  PATTERN "*.h")
 install(FILES "${PROJECT_SOURCE_DIR}/src/include/duckdb.hpp"
               "${PROJECT_SOURCE_DIR}/src/include/duckdb.h"
         DESTINATION "${INSTALL_INCLUDE_DIR}")


### PR DESCRIPTION
Fixes #23256.

DuckDB public headers include bundled fmt headers, but the CMake install rules only installed DuckDB's own public headers. This meant consumers using an installed DuckDB SDK could fail to compile with missing fmt headers.

This change installs the bundled fmt headers alongside the DuckDB headers and includes the fmt include directory in the build-tree CMake package config.

Validation:
- git diff --check
- Configured DuckDB with CMake/Ninja
- Compiled a minimal #include "duckdb.hpp" smoke test against a simulated installed include tree