### PR TITLE
[Parquet][Variant] Don't produce VARIANT metadata with `sorted_strings` set

### DIFF
--- a/extension/parquet/writer/variant/convert_variant.cpp
+++ b/extension/parquet/writer/variant/convert_variant.cpp
@@ -29,8 +29,7 @@ static uint8_t EncodeMetadataHeader(idx_t byte_length) {
 	uint8_t header_byte = 0;
 	//! Set 'version' to 1
 	header_byte |= static_cast<uint8_t>(1);
-	//! Set 'sorted_strings' to 1
-	header_byte |= static_cast<uint8_t>(1) << 4;
+	//! NOTE: keep 'sorted_strings' at 0, we don't always sort the key strings
 	//! Set 'offset_size_minus_one' to byte_length-1
 	header_byte |= (static_cast<uint8_t>(byte_length) - 1) << 6;
 

--- a/test/parquet/variant/variant_to_parquet_variant.test
+++ b/test/parquet/variant/variant_to_parquet_variant.test
@@ -6,7 +6,7 @@ require parquet
 query I
 select variant_to_parquet_variant(NULL)
 ----
-{'metadata': \x11\x00\x00, 'value': \x00}
+{'metadata': \x01\x00\x00, 'value': \x00}
 
 # We don't expose the overload with a shredded type, only internally will we use that
 statement error


### PR DESCRIPTION
This PR fixes https://github.com/duckdblabs/duckdb-internal/issues/9814

Not all VARIANT production logic produces sorted strings