### PR TITLE
[Backport] Fixed unsafe iteration when parent is `NULL` in string cast

### DIFF
--- a/src/function/cast/string_cast.cpp
+++ b/src/function/cast/string_cast.cpp
@@ -180,6 +180,9 @@ bool VectorStringToList::StringToNestedTypeCastLoop(const string_t *source_data,
 		varchar_vector.ToUnifiedFormat(total_list_size, parse_column_data);
 		// Something went wrong in the conversion, we need to nullify the parent
 		for (idx_t i = 0; i < count; i++) {
+			if (!result_mask.RowIsValid(i)) {
+				continue;
+			}
 			for (idx_t j = list_data[i].offset; j < list_data[i].offset + list_data[i].length; j++) {
 				if (!inserted_column_data.validity.RowIsValid(j) && parse_column_data.validity.RowIsValid(j)) {
 					result_mask.SetInvalid(i);

--- a/test/sql/cast/string_to_list_cast.test
+++ b/test/sql/cast/string_to_list_cast.test
@@ -493,6 +493,21 @@ SELECT * FROM assorted_lists;
 ----
 [8, 7, 6]	[hello, 'Duck\'DB']	[2022-12-02, 1929-01-25]
 
+# Issue 23373: a failed child cast should not inspect list entries for NULL parent rows
+statement ok
+COPY (
+	SELECT *
+	FROM (VALUES
+		(1, '[["a0974028-d682-4796-b142-b96580b1c103","2afb4b62-0eeb-4f1a-b351-1464a79d6db2"],["205ffd21-db5c-463d-9575-f7cbf6d73746","2b6705fd-2154-4815-a418-d86cb381efa9"]]'),
+		(2, NULL)
+	) tbl(id, v)
+) TO '__TEST_DIR__/issue_23373_uuid_list.csv' (HEADER true, NULLSTR '\N');
+
+statement error
+SELECT id, v FROM read_csv('__TEST_DIR__/issue_23373_uuid_list.csv', columns={'id':'BIGINT','v':'UUID[]'}, header=true, delim=',', quote='"', escape='"', nullstr='\N');
+----
+Could not convert string
+
 #              Escape tests
 #---------------------------------------------------
 


### PR DESCRIPTION
This PR is the backport equivalent of https://github.com/duckdb/duckdb/pull/23593. Resolves https://github.com/duckdblabs/duckdb-internal/issues/9768. 

As suggested in the original issue we should check if the resulting row is valid (non-`NULL`) before trying to nullify the parent on a failed cast, as a `NULL` row does not have meaningful references to data which should be nullified.