### PR TITLE
Add parquet as ducklake dep

### DIFF
--- a/scripts/generate_extensions_function.py
+++ b/scripts/generate_extensions_function.py
@@ -47,10 +47,13 @@ DUCKDB_PATH = os.path.join(*args.shell.split('/'))
 HEADER_PATH = os.path.join("src", "include", "duckdb", "main", "extension_entries.hpp")
 
 EXTENSION_DEPENDENCIES = {
+    'ducklake': [
+        'parquet',
+    ],
     'iceberg': [
         'avro',
         'parquet',
-    ]
+    ],
 }
 
 from enum import Enum


### PR DESCRIPTION
At the end of CI, we check `extension_entries.hpp` using:
```
python3 scripts/generate_extensions_function.py
  Located extension: tpcds in path: 'build/release/repository/a81547b43c/linux_amd64/tpcds.duckdb_extension'
  Located extension: quack in path: 'build/release/repository/a81547b43c/linux_amd64/quack.duckdb_extension'
  Located extension: fts in path: 'build/release/repository/a81547b43c/linux_amd64/fts.duckdb_extension'
  Located extension: delta in path: 'build/release/repository/a81547b43c/linux_amd64/delta.duckdb_extension'
  Located extension: azure in path: 'build/release/repository/a81547b43c/linux_amd64/azure.duckdb_extension'
  Located extension: inet in path: 'build/release/repository/a81547b43c/linux_amd64/inet.duckdb_extension'
  Located extension: ducklake in path: 'build/release/repository/a81547b43c/linux_amd64/ducklake.duckdb_extension'
...
  Located extension: core_functions in path: 'build/release/repository/a81547b43c/linux_amd64/core_functions.duckdb_extension'
  Located extension: spatial in path: 'build/release/repository/a81547b43c/linux_amd64/spatial.duckdb_extension'
  Located extension: httpfs in path: 'build/release/repository/a81547b43c/linux_amd64/httpfs.duckdb_extension'

.cache/format-venv/bin/python scripts/format.py src/include/duckdb/main/extension_entries.hpp --fix --noconfirm
```

Some functions are attributed to `ducklake` instead of `parquet`:
```
diff --git a/src/include/duckdb/main/extension_entries.hpp b/src/include/duckdb/main/extension_entries.hpp
index 7fb80c0ffc..81638d3382 100644
--- a/src/include/duckdb/main/extension_entries.hpp
+++ b/src/include/duckdb/main/extension_entries.hpp
@@ -1103,10 +1146,10 @@ static constexpr ExtensionEntry EXTENSION_SETTINGS[] = {
     {"azure_read_transfer_concurrency", "azure"},
     {"azure_storage_connection_string", "azure"},
     {"azure_transport_option_type", "azure"},
-    {"binary_as_string", "parquet"},
+    {"binary_as_string", "ducklake"},
     {"ca_cert_file", "httpfs"},
     {"calendar", "icu"},
-    {"disable_parquet_prefetching", "parquet"},
+    {"disable_parquet_prefetching", "ducklake"},
     {"ducklake_default_data_inlining_row_limit", "ducklake"},
     {"ducklake_default_version", "ducklake"},
     {"ducklake_max_retry_count", "ducklake"},
@@ -1114,7 +1157,7 @@ static constexpr ExtensionEntry EXTENSION_SETTINGS[] = {
     {"ducklake_retry_wait_ms", "ducklake"},
     {"ducklake_write_deletion_vectors", "ducklake"},
     {"enable_curl_server_cert_verification", "httpfs"},
-    {"enable_geoparquet_conversion", "parquet"},
+    {"enable_geoparquet_conversion", "ducklake"},
     {"enable_global_s3_configuration", "httpfs"},
     {"enable_server_cert_verification", "httpfs"},
     {"force_download", "httpfs"},
...
```

This PR adds `ducklake` to the static dependency list.

Fixes https://github.com/duckdblabs/duckdb-internal/issues/9194

### Future work

I'll look into generating this dependency list (at runtime) another time. See https://github.com/duckdblabs/duckdb-internal/issues/9274
