### PR TITLE
Fix missing traversal for (correlated) subqueries in non-inner join conditions

### DIFF
--- a/src/include/duckdb/planner/subquery/recursive_dependent_join_planner.hpp
+++ b/src/include/duckdb/planner/subquery/recursive_dependent_join_planner.hpp
@@ -14,6 +14,7 @@
 namespace duckdb {
 
 class Binder;
+class LogicalJoin;
 
 /*
  * Recursively plan subqueries and flatten dependent joins from outermost to innermost (like peeling an onion).
@@ -21,11 +22,15 @@ class Binder;
 class RecursiveDependentJoinPlanner : public LogicalOperatorVisitor {
 public:
 	static void Plan(Binder &binder, LogicalOperator &op);
+	static void PlanJoinConditionSubqueries(Binder &binder, LogicalOperator &op);
 
 private:
 	explicit RecursiveDependentJoinPlanner(Binder &binder) : binder(binder) {
 	}
 	void VisitOperator(LogicalOperator &op) override;
+	void PlanJoinChildFilters(LogicalOperator &op);
+	void PlanJoinExpressions(LogicalOperator &op);
+	void PlanJoinSubqueries(LogicalJoin &join, unique_ptr<Expression> &expr);
 	unique_ptr<Expression> VisitReplace(BoundSubqueryExpression &expr, unique_ptr<Expression> *expr_ptr) override;
 
 	unique_ptr<LogicalOperator> root;

--- a/src/planner/binder/query_node/plan_subquery.cpp
+++ b/src/planner/binder/query_node/plan_subquery.cpp
@@ -12,7 +12,11 @@
 #include "duckdb/planner/expression/bound_window_expression.hpp"
 #include "duckdb/planner/expression_iterator.hpp"
 #include "duckdb/planner/operator/list.hpp"
+#include "duckdb/planner/operator/logical_any_join.hpp"
+#include "duckdb/planner/operator/logical_comparison_join.hpp"
+#include "duckdb/planner/operator/logical_filter.hpp"
 #include "duckdb/planner/operator/logical_window.hpp"
+#include "duckdb/planner/joinside.hpp"
 #include "duckdb/function/function_binder.hpp"
 #include "duckdb/planner/subquery/flatten_dependent_join.hpp"
 #include "duckdb/common/enums/logical_operator_type.hpp"
@@ -402,6 +406,144 @@ static unique_ptr<Expression> PlanCorrelatedSubquery(Binder &binder, BoundSubque
 	}
 }
 
+static JoinSide GetCurrentJoinSide(TableIndex table_binding, const unordered_set<TableIndex> &left_bindings,
+                                   const unordered_set<TableIndex> &right_bindings) {
+	if (left_bindings.find(table_binding) != left_bindings.end()) {
+		D_ASSERT(right_bindings.find(table_binding) == right_bindings.end());
+		return JoinSide::LEFT;
+	}
+	if (right_bindings.find(table_binding) != right_bindings.end()) {
+		return JoinSide::RIGHT;
+	}
+	return JoinSide::NONE;
+}
+
+static JoinSide GetCurrentJoinSide(const Expression &expr, const unordered_set<TableIndex> &left_bindings,
+                                   const unordered_set<TableIndex> &right_bindings) {
+	if (expr.GetExpressionType() == ExpressionType::BOUND_COLUMN_REF) {
+		auto &colref = expr.Cast<BoundColumnRefExpression>();
+		if (colref.Depth() > 0) {
+			return JoinSide::NONE;
+		}
+		return GetCurrentJoinSide(colref.Binding().table_index, left_bindings, right_bindings);
+	}
+	if (expr.GetExpressionClass() == ExpressionClass::BOUND_SUBQUERY) {
+		auto &subquery = expr.Cast<BoundSubqueryExpression>();
+		JoinSide side = JoinSide::NONE;
+		for (auto &child : subquery.GetChildren()) {
+			auto child_side = GetCurrentJoinSide(*child, left_bindings, right_bindings);
+			side = JoinSide::CombineJoinSide(side, child_side);
+		}
+		for (auto &corr : subquery.GetBinder()->correlated_columns) {
+			if (corr.depth > 1) {
+				continue;
+			}
+			auto corr_side = GetCurrentJoinSide(corr.binding.table_index, left_bindings, right_bindings);
+			side = JoinSide::CombineJoinSide(side, corr_side);
+		}
+		return side;
+	}
+
+	JoinSide join_side = JoinSide::NONE;
+	ExpressionIterator::EnumerateChildren(expr, [&](const Expression &child) {
+		auto child_side = GetCurrentJoinSide(child, left_bindings, right_bindings);
+		join_side = JoinSide::CombineJoinSide(join_side, child_side);
+	});
+	return join_side;
+}
+
+static JoinSide GetCurrentJoinSide(LogicalJoin &join, const Expression &expr) {
+	unordered_set<TableIndex> left_bindings;
+	unordered_set<TableIndex> right_bindings;
+	LogicalJoin::GetTableReferences(*join.children[0], left_bindings);
+	LogicalJoin::GetTableReferences(*join.children[1], right_bindings);
+	return GetCurrentJoinSide(expr, left_bindings, right_bindings);
+}
+
+static unique_ptr<LogicalOperator> &GetJoinSideRoot(LogicalJoin &join, JoinSide side) {
+	if (side == JoinSide::LEFT || side == JoinSide::NONE) {
+		return join.children[0];
+	}
+	if (side == JoinSide::RIGHT) {
+		return join.children[1];
+	}
+	throw NotImplementedException("Correlated subquery in a non-inner join condition cannot reference both sides of "
+	                              "the join");
+}
+
+static bool HasJoinConditionExpressions(LogicalOperatorType type) {
+	switch (type) {
+	case LogicalOperatorType::LOGICAL_ASOF_JOIN:
+	case LogicalOperatorType::LOGICAL_COMPARISON_JOIN:
+	case LogicalOperatorType::LOGICAL_ANY_JOIN:
+		return true;
+	default:
+		return false;
+	}
+}
+
+void RecursiveDependentJoinPlanner::PlanJoinSubqueries(LogicalJoin &join, unique_ptr<Expression> &expr) {
+	if (!expr) {
+		return;
+	}
+	ExpressionIterator::EnumerateChildren(*expr,
+	                                      [&](unique_ptr<Expression> &child) { PlanJoinSubqueries(join, child); });
+	if (expr->GetExpressionClass() != ExpressionClass::BOUND_SUBQUERY) {
+		return;
+	}
+
+	auto side = GetCurrentJoinSide(join, *expr);
+	auto &root = GetJoinSideRoot(join, side);
+	auto &subquery = expr->Cast<BoundSubqueryExpression>();
+	expr = binder.PlanSubquery(subquery, root);
+}
+
+void RecursiveDependentJoinPlanner::PlanJoinExpressions(LogicalOperator &op) {
+	if (!HasJoinConditionExpressions(op.type)) {
+		return;
+	}
+	switch (op.type) {
+	case LogicalOperatorType::LOGICAL_ASOF_JOIN:
+	case LogicalOperatorType::LOGICAL_COMPARISON_JOIN: {
+		auto &join = op.Cast<LogicalComparisonJoin>();
+		for (auto &cond : join.conditions) {
+			if (cond.IsComparison()) {
+				PlanJoinSubqueries(join, cond.LeftReference());
+				PlanJoinSubqueries(join, cond.RightReference());
+			} else {
+				PlanJoinSubqueries(join, cond.JoinExpressionReference());
+			}
+		}
+		break;
+	}
+	case LogicalOperatorType::LOGICAL_ANY_JOIN: {
+		auto &join = op.Cast<LogicalAnyJoin>();
+		PlanJoinSubqueries(join, join.condition);
+		break;
+	}
+	default:
+		break;
+	}
+}
+
+void RecursiveDependentJoinPlanner::PlanJoinChildFilters(LogicalOperator &op) {
+	if (!HasJoinConditionExpressions(op.type)) {
+		return;
+	}
+
+	auto &join = op.Cast<LogicalJoin>();
+	for (auto &child : join.children) {
+		if (child->type != LogicalOperatorType::LOGICAL_FILTER) {
+			continue;
+		}
+		auto &filter = child->Cast<LogicalFilter>();
+		D_ASSERT(filter.children.size() == 1);
+		for (auto &expr : filter.expressions) {
+			binder.PlanSubqueries(expr, filter.children[0]);
+		}
+	}
+}
+
 void RecursiveDependentJoinPlanner::VisitOperator(LogicalOperator &op) {
 	if (!op.children.empty()) {
 		// Collect all recursive CTEs during recursive descend
@@ -410,11 +552,15 @@ void RecursiveDependentJoinPlanner::VisitOperator(LogicalOperator &op) {
 			auto &rec_cte = op.Cast<LogicalCTE>();
 			binder.recursive_ctes[rec_cte.table_index] = &op;
 		}
-		for (idx_t i = 0; i < op.children.size(); i++) {
-			root = std::move(op.children[i]);
-			D_ASSERT(root);
-			VisitOperatorExpressions(op);
-			op.children[i] = std::move(root);
+		if (HasJoinConditionExpressions(op.type)) {
+			PlanJoinExpressions(op);
+		} else {
+			for (idx_t i = 0; i < op.children.size(); i++) {
+				root = std::move(op.children[i]);
+				D_ASSERT(root);
+				VisitOperatorExpressions(op);
+				op.children[i] = std::move(root);
+			}
 		}
 
 		for (idx_t i = 0; i < op.children.size(); i++) {
@@ -427,6 +573,12 @@ void RecursiveDependentJoinPlanner::VisitOperator(LogicalOperator &op) {
 void RecursiveDependentJoinPlanner::Plan(Binder &binder, LogicalOperator &op) {
 	RecursiveDependentJoinPlanner planner(binder);
 	planner.VisitOperator(op);
+}
+
+void RecursiveDependentJoinPlanner::PlanJoinConditionSubqueries(Binder &binder, LogicalOperator &op) {
+	RecursiveDependentJoinPlanner planner(binder);
+	planner.PlanJoinChildFilters(op);
+	planner.PlanJoinExpressions(op);
 }
 
 unique_ptr<Expression> RecursiveDependentJoinPlanner::VisitReplace(BoundSubqueryExpression &expr,

--- a/src/planner/binder/tableref/plan_joinref.cpp
+++ b/src/planner/binder/tableref/plan_joinref.cpp
@@ -428,40 +428,7 @@ unique_ptr<LogicalOperator> Binder::CreatePlan(BoundJoinRef &ref) {
 	if (ref.type == JoinType::MARK) {
 		join->Cast<LogicalJoin>().mark_index = ref.mark_index;
 	}
-	for (auto &child : join->children) {
-		if (child->type == LogicalOperatorType::LOGICAL_FILTER) {
-			auto &filter = child->Cast<LogicalFilter>();
-			for (auto &expr : filter.expressions) {
-				PlanSubqueries(expr, filter.children[0]);
-			}
-		}
-	}
-
-	// we visit the expressions depending on the type of join
-	switch (join->type) {
-	case LogicalOperatorType::LOGICAL_ASOF_JOIN:
-	case LogicalOperatorType::LOGICAL_COMPARISON_JOIN: {
-		auto &comp_join = join->Cast<LogicalComparisonJoin>();
-		for (idx_t i = 0; i < comp_join.conditions.size(); i++) {
-			auto &cond = comp_join.conditions[i];
-			if (cond.IsComparison()) {
-				PlanSubqueries(cond.LeftReference(), comp_join.children[0]);
-				PlanSubqueries(cond.RightReference(), comp_join.children[1]);
-			}
-		}
-		break;
-	}
-	case LogicalOperatorType::LOGICAL_ANY_JOIN: {
-		auto &any_join = join->Cast<LogicalAnyJoin>();
-		// for the any join we just visit the condition
-		if (any_join.condition->HasSubquery()) {
-			throw NotImplementedException("Cannot perform non-inner join on subquery!");
-		}
-		break;
-	}
-	default:
-		break;
-	}
+	RecursiveDependentJoinPlanner::PlanJoinConditionSubqueries(*this, *join);
 	if (!ref.duplicate_eliminated_columns.empty()) {
 		auto &comp_join = join->Cast<LogicalComparisonJoin>();
 		comp_join.type = LogicalOperatorType::LOGICAL_DELIM_JOIN;

--- a/test/sql/subquery/complex/nested_correlated_list.test_slow
+++ b/test/sql/subquery/complex/nested_correlated_list.test_slow
@@ -110,13 +110,21 @@ NULL	NULL
 [3]	3.000000
 
 # left outer join on correlated subquery within subquery
-# not supported yet: left outer join on JoinSide::BOTH
-statement error
-SELECT l, (SELECT SUM(s1.l[1]) FROM lists s1 LEFT OUTER JOIN lists s2 ON (SELECT i1.l[1]+s1.l[1])=(SELECT i1.l[1]+s2.l[1])) AS j FROM lists i1 ORDER BY l;
+# supported because each side of the comparison only references one current join side
+query IR
+SELECT l,
+	(SELECT SUM(s1.l[1])
+	 FROM lists s1
+	 LEFT OUTER JOIN lists s2
+	   ON (SELECT i1.l[1]+s1.l[1])=(SELECT i1.l[1]+s2.l[1])) AS j
+FROM lists i1
+ORDER BY l;
 ----
+NULL	6
+[1]	6
+[2]	6
+[3]	6
 
-# REQUIRE(CHECK_COLUMN(result, 0, {Value(), 1, 2, 3}));
-# REQUIRE(CHECK_COLUMN(result, 1, {6, 6, 6, 6}));
 query IR
 SELECT l, (SELECT SUM(ss1.l[1])+SUM(ss2.l[1]) FROM (SELECT l FROM lists s1 WHERE l>ANY(SELECT l FROM lists WHERE l<>s1.l)) ss1 LEFT OUTER JOIN (SELECT l FROM lists s1 WHERE l=ANY(SELECT l FROM lists WHERE l=s1.l)) ss2 ON ss1.l=ss2.l) AS j FROM lists i1 ORDER BY l;
 ----
@@ -327,4 +335,3 @@ SELECT (SELECT (SELECT COVAR_POP(i2.l[1], i3.l[1]) FROM lists i3) FROM lists i2 
 0.000000
 0.000000
 0.000000
-

--- a/test/sql/subquery/exists/test_correlated_exists.test
+++ b/test/sql/subquery/exists/test_correlated_exists.test
@@ -51,6 +51,80 @@ SELECT i FROM integers i1 WHERE EXISTS(SELECT i FROM integers WHERE i=i1.i) ORDE
 2
 3
 
+# left join with correlated EXISTS in the ON clause
+statement ok
+CREATE TEMP VIEW x(x1, x2) AS VALUES
+	(2, 1),
+	(1, 1),
+	(3, 4);
+
+statement ok
+CREATE TEMP VIEW y(y1, y2) AS VALUES
+	(0, 2),
+	(1, 4),
+	(4, 11);
+
+statement ok
+CREATE TEMP VIEW z(z1, z2) AS VALUES
+	(4, 2),
+	(3, 3),
+	(8, 1);
+
+query IIII
+SELECT *
+FROM x
+LEFT JOIN y ON x1 = y1 AND EXISTS (SELECT * FROM z WHERE z2 = x2)
+ORDER BY x1, x2, y1, y2;
+----
+1	1	1	4
+2	1	NULL	NULL
+3	4	NULL	NULL
+
+query IIII
+SELECT *
+FROM x
+LEFT JOIN y ON EXISTS (SELECT * FROM z WHERE z2 = x2)
+ORDER BY x1, x2, y1, y2;
+----
+1	1	0	2
+1	1	1	4
+1	1	4	11
+2	1	0	2
+2	1	1	4
+2	1	4	11
+3	4	NULL	NULL
+
+query IIII
+SELECT *
+FROM x
+LEFT JOIN y ON y1 IN (SELECT z1 FROM z)
+ORDER BY x1, x2, y1, y2;
+----
+1	1	4	11
+2	1	4	11
+3	4	4	11
+
+query IIII
+SELECT *
+FROM x
+LEFT JOIN y ON x1 IN (SELECT z1 FROM z)
+ORDER BY x1, x2, y1, y2;
+----
+1	1	NULL	NULL
+2	1	NULL	NULL
+3	4	0	2
+3	4	1	4
+3	4	4	11
+
+statement ok
+DROP VIEW x;
+
+statement ok
+DROP VIEW y;
+
+statement ok
+DROP VIEW z;
+
 # correlated EXISTS with aggregations
 query T
 SELECT EXISTS(SELECT i FROM integers WHERE i>MIN(i1.i)) FROM integers i1;
@@ -123,4 +197,3 @@ query R
 SELECT (SELECT COVAR_POP(i1.i, i1.i) FROM integers i2 LIMIT 1) FROM integers i1 ORDER BY 1;
 ----
 0.666667
-

--- a/test/sql/subquery/exists/test_correlated_exists.test
+++ b/test/sql/subquery/exists/test_correlated_exists.test
@@ -116,15 +116,6 @@ ORDER BY x1, x2, y1, y2;
 3	4	1	4
 3	4	4	11
 
-statement ok
-DROP VIEW x;
-
-statement ok
-DROP VIEW y;
-
-statement ok
-DROP VIEW z;
-
 # correlated EXISTS with aggregations
 query T
 SELECT EXISTS(SELECT i FROM integers WHERE i>MIN(i1.i)) FROM integers i1;

--- a/test/sql/subquery/scalar/test_complex_correlated_subquery.test
+++ b/test/sql/subquery/scalar/test_complex_correlated_subquery.test
@@ -81,6 +81,7 @@ NULL	NULL
 statement error
 SELECT * FROM integers s1 LEFT OUTER JOIN integers s2 ON (SELECT CASE WHEN s1.i+s2.i>10 THEN TRUE ELSE FALSE END) ORDER BY s1.i;
 ----
+<REGEX>:.*Correlated subquery in a non-inner join condition cannot reference both sides of the join.*
 
 # left outer join on subquery only involving RHS works
 query TT
@@ -91,10 +92,33 @@ NULL	NULL
 2	NULL
 3	3
 
-# left outer join on subquery only involving LHS is not supported
-statement error
-SELECT * FROM integers s1 LEFT OUTER JOIN integers s2 ON s1.i=s2.i AND (SELECT CASE WHEN s1.i>2 THEN TRUE ELSE FALSE END) ORDER BY s1.i;
+# left outer join on subquery only involving LHS works
+query TT
+SELECT *
+FROM integers s1
+LEFT OUTER JOIN integers s2
+	ON s1.i=s2.i AND (SELECT CASE WHEN s1.i>2 THEN TRUE ELSE FALSE END)
+ORDER BY s1.i;
 ----
+NULL	NULL
+1	NULL
+2	NULL
+3	3
+
+# left outer join on subquery only involving outer query works
+query II
+SELECT i,
+	(SELECT SUM(s2.i)
+	 FROM integers s1
+	 LEFT OUTER JOIN integers s2
+	   ON s1.i=s2.i AND EXISTS(SELECT 1 WHERE i1.i > 1)) AS j
+FROM integers i1
+ORDER BY i;
+----
+NULL	NULL
+1	NULL
+2	6
+3	6
 
 # left outer join in correlated expression
 query II
@@ -163,4 +187,3 @@ NULL	NULL
 1	49.000000
 2	50.000000
 3	51.000000
-

--- a/test/sql/subquery/scalar/test_nested_correlated_subquery.test_slow
+++ b/test/sql/subquery/scalar/test_nested_correlated_subquery.test_slow
@@ -110,13 +110,21 @@ NULL	NULL
 3	3.000000
 
 # left outer join on correlated subquery within subquery
-# not supported yet: left outer join on JoinSide::BOTH
-statement error
-SELECT i, (SELECT SUM(s1.i) FROM integers s1 LEFT OUTER JOIN integers s2 ON (SELECT i1.i+s1.i)=(SELECT i1.i+s2.i)) AS j FROM integers i1 ORDER BY i;
+# supported because each side of the comparison only references one current join side
+query II
+SELECT i,
+	(SELECT SUM(s1.i)
+	 FROM integers s1
+	 LEFT OUTER JOIN integers s2
+	   ON (SELECT i1.i+s1.i)=(SELECT i1.i+s2.i)) AS j
+FROM integers i1
+ORDER BY i;
 ----
+NULL	6
+1	6
+2	6
+3	6
 
-# REQUIRE(CHECK_COLUMN(result, 0, {Value(), 1, 2, 3}));
-# REQUIRE(CHECK_COLUMN(result, 1, {6, 6, 6, 6}));
 query IR
 SELECT i, (SELECT SUM(ss1.i)+SUM(ss2.i) FROM (SELECT i FROM integers s1 WHERE i>ANY(SELECT i FROM integers WHERE i<>s1.i)) ss1 LEFT OUTER JOIN (SELECT i FROM integers s1 WHERE i=ANY(SELECT i FROM integers WHERE i=s1.i)) ss2 ON ss1.i=ss2.i) AS j FROM integers i1 ORDER BY i;
 ----
@@ -327,4 +335,3 @@ SELECT (SELECT (SELECT COVAR_POP(i2.i, i3.i) FROM integers i3) FROM integers i2 
 0.000000
 0.000000
 0.000000
-


### PR DESCRIPTION
Non-inner join planning could leave BoundSubqueryExpression nodes in ON conditions, which later failed during plan copying. Plan these subqueries through RecursiveDependentJoinPlanner using a narrow join-condition entry point after join condition extraction.

Classify subqueries by the side of the current join they reference, while treating outer-query-only correlations as not belonging to either current side. Keep pushed child filters covered, and reject subqueries that depend on both current join sides with a clearer error.

Add regressions for LEFT JOIN ON EXISTS/IN conditions, LHS/RHS/outer-only correlations, and a nested correlated comparison case that is now supported.

fix: https://github.com/duckdblabs/duckdb-internal/issues/9857