### PR TITLE
Disable function coverage in report to remove 5k HTML pages

### DIFF
--- a/scripts/ci/run_tests.py
+++ b/scripts/ci/run_tests.py
@@ -1365,6 +1365,7 @@ def generate_coverage_report(source_root: Path, unittest_bin: str, profile_dir: 
             os.fspath(coverage_css_file),
             "--quiet",
             "--hierarchical",
+            "--no-function-coverage",
             "--filter",
             "region",
             "--ignore-errors",


### PR DESCRIPTION
The code coverage viewer (https://duckdb.github.io/duckdb-ci/coverage/) downloads a zip file from the last workflow run on main.

That zip file is currently ~30 MB and consists of ~8000 HTML files.

The viewer extracts the zip in memory into HTML files using [fflate](https://www.npmjs.com/package/fflate), but it's still slow because there are many files.

The three operations take ~15 sec together:
- download zip (~5 sec).
- decompress 30 MB zip (~4 sec).
- extract 8000k files (~5 sec).

By removing the ~5000k "function coverage pages", we lower that to a few seconds.

Later, we can decide if function-level coverage is useful, but currently it's broken because it mismatches some of the functions and drops their hit count. I'll look into why that mismatch happens, but it's out of scope for this PR.