### PR TITLE
guard negative utf8proc_iterate return in string functions

### DIFF
--- a/extension/core_functions/scalar/string/instr.cpp
+++ b/extension/core_functions/scalar/string/instr.cpp
@@ -4,7 +4,7 @@
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/function/scalar/string_common.hpp"
-#include "utf8proc.hpp"
+#include "utf8proc_wrapper.hpp"
 
 namespace duckdb {
 
@@ -15,14 +15,12 @@ struct InstrOperator {
 
 		auto location = FindStrInStr(haystack, needle);
 		if (location != DConstants::INVALID_INDEX) {
-			auto len = (utf8proc_ssize_t)location;
-			auto str = reinterpret_cast<const utf8proc_uint8_t *>(haystack.GetData());
-			D_ASSERT(len <= (utf8proc_ssize_t)haystack.GetSize());
-			for (++string_position; len > 0; ++string_position) {
-				utf8proc_int32_t codepoint;
-				auto bytes = utf8proc_iterate(str, len, &codepoint);
-				str += bytes;
-				len -= bytes;
+			auto str = haystack.GetData();
+			D_ASSERT(location <= haystack.GetSize());
+			idx_t pos = 0;
+			for (++string_position; pos < location; ++string_position) {
+				int32_t codepoint;
+				pos += Utf8Proc::DecodeCharacter(str + pos, location - pos, codepoint);
 			}
 		}
 		return string_position;

--- a/extension/core_functions/scalar/string/pad.cpp
+++ b/extension/core_functions/scalar/string/pad.cpp
@@ -6,20 +6,17 @@
 #include "duckdb/common/vector_operations/ternary_executor.hpp"
 #include "duckdb/common/pair.hpp"
 
-#include "utf8proc.hpp"
+#include "utf8proc_wrapper.hpp"
 
 namespace duckdb {
 
 static pair<idx_t, idx_t> PadCountChars(const idx_t len, const char *data, const idx_t size) {
 	//  Count how much of str will fit in the output
-	auto str = reinterpret_cast<const utf8proc_uint8_t *>(data);
 	idx_t nbytes = 0;
 	idx_t nchars = 0;
 	for (; nchars < len && nbytes < size; ++nchars) {
-		utf8proc_int32_t codepoint;
-		auto bytes = utf8proc_iterate(str + nbytes, UnsafeNumericCast<utf8proc_ssize_t>(size - nbytes), &codepoint);
-		D_ASSERT(bytes > 0);
-		nbytes += UnsafeNumericCast<idx_t>(bytes);
+		int32_t codepoint;
+		nbytes += Utf8Proc::DecodeCharacter(data + nbytes, size - nbytes, codepoint);
 	}
 
 	return pair<idx_t, idx_t>(nbytes, nchars);
@@ -36,7 +33,6 @@ static bool InsertPadding(const idx_t len, const string_t &pad, vector<char> &re
 	}
 
 	//  Insert characters until we have all we need.
-	auto str = reinterpret_cast<const utf8proc_uint8_t *>(data);
 	idx_t nbytes = 0;
 	for (idx_t nchars = 0; nchars < len; ++nchars) {
 		//  If we are at the end of the pad, flush all of it and loop back
@@ -46,10 +42,8 @@ static bool InsertPadding(const idx_t len, const string_t &pad, vector<char> &re
 		}
 
 		//  Write the next character
-		utf8proc_int32_t codepoint;
-		auto bytes = utf8proc_iterate(str + nbytes, UnsafeNumericCast<utf8proc_ssize_t>(size - nbytes), &codepoint);
-		D_ASSERT(bytes > 0);
-		nbytes += UnsafeNumericCast<idx_t>(bytes);
+		int32_t codepoint;
+		nbytes += Utf8Proc::DecodeCharacter(data + nbytes, size - nbytes, codepoint);
 	}
 
 	//  Flush the remaining pad

--- a/extension/core_functions/scalar/string/trim.cpp
+++ b/extension/core_functions/scalar/string/trim.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/common/vector_operations/unary_executor.hpp"
 #include "utf8proc.hpp"
+#include "utf8proc_wrapper.hpp"
 
 #include <string.h>
 
@@ -16,20 +17,17 @@ struct TrimOperator {
 		auto data = input.GetData();
 		auto size = input.GetSize();
 
-		utf8proc_int32_t codepoint;
-		auto str = reinterpret_cast<const utf8proc_uint8_t *>(data);
+		int32_t codepoint;
 
 		// Find the first character that is not left trimmed
 		idx_t begin = 0;
 		if (LTRIM) {
 			while (begin < size) {
-				auto bytes =
-				    utf8proc_iterate(str + begin, UnsafeNumericCast<utf8proc_ssize_t>(size - begin), &codepoint);
-				D_ASSERT(bytes > 0);
+				auto bytes = Utf8Proc::DecodeCharacter(data + begin, size - begin, codepoint);
 				if (utf8proc_category(codepoint) != UTF8PROC_CATEGORY_ZS) {
 					break;
 				}
-				begin += UnsafeNumericCast<idx_t>(bytes);
+				begin += bytes;
 			}
 		}
 
@@ -38,9 +36,8 @@ struct TrimOperator {
 		if (RTRIM) {
 			end = begin;
 			for (auto next = begin; next < size;) {
-				auto bytes = utf8proc_iterate(str + next, UnsafeNumericCast<utf8proc_ssize_t>(size - next), &codepoint);
-				D_ASSERT(bytes > 0);
-				next += UnsafeNumericCast<idx_t>(bytes);
+				auto bytes = Utf8Proc::DecodeCharacter(data + next, size - next, codepoint);
+				next += bytes;
 				if (utf8proc_category(codepoint) != UTF8PROC_CATEGORY_ZS) {
 					end = next;
 				}
@@ -65,13 +62,12 @@ static void UnaryTrimFunction(DataChunk &args, ExpressionState &state, Vector &r
 }
 
 static void GetIgnoredCodepoints(string_t ignored, unordered_set<utf8proc_int32_t> &ignored_codepoints) {
-	auto dataptr = reinterpret_cast<const utf8proc_uint8_t *>(ignored.GetData());
+	auto data = ignored.GetData();
 	auto size = ignored.GetSize();
 	idx_t pos = 0;
 	while (pos < size) {
-		utf8proc_int32_t codepoint;
-		pos += UnsafeNumericCast<idx_t>(
-		    utf8proc_iterate(dataptr + pos, UnsafeNumericCast<utf8proc_ssize_t>(size - pos), &codepoint));
+		int32_t codepoint;
+		pos += Utf8Proc::DecodeCharacter(data + pos, size - pos, codepoint);
 		ignored_codepoints.insert(codepoint);
 	}
 }
@@ -86,19 +82,17 @@ static void BinaryTrimFunction(DataChunk &input, ExpressionState &state, Vector 
 		    unordered_set<utf8proc_int32_t> ignored_codepoints;
 		    GetIgnoredCodepoints(ignored, ignored_codepoints);
 
-		    utf8proc_int32_t codepoint;
-		    auto str = reinterpret_cast<const utf8proc_uint8_t *>(data);
+		    int32_t codepoint;
 
 		    // Find the first character that is not left trimmed
 		    idx_t begin = 0;
 		    if (LTRIM) {
 			    while (begin < size) {
-				    auto bytes =
-				        utf8proc_iterate(str + begin, UnsafeNumericCast<utf8proc_ssize_t>(size - begin), &codepoint);
+				    auto bytes = Utf8Proc::DecodeCharacter(data + begin, size - begin, codepoint);
 				    if (ignored_codepoints.find(codepoint) == ignored_codepoints.end()) {
 					    break;
 				    }
-				    begin += UnsafeNumericCast<idx_t>(bytes);
+				    begin += bytes;
 			    }
 		    }
 
@@ -107,10 +101,8 @@ static void BinaryTrimFunction(DataChunk &input, ExpressionState &state, Vector 
 		    if (RTRIM) {
 			    end = begin;
 			    for (auto next = begin; next < size;) {
-				    auto bytes =
-				        utf8proc_iterate(str + next, UnsafeNumericCast<utf8proc_ssize_t>(size - next), &codepoint);
-				    D_ASSERT(bytes > 0);
-				    next += UnsafeNumericCast<idx_t>(bytes);
+				    auto bytes = Utf8Proc::DecodeCharacter(data + next, size - next, codepoint);
+				    next += bytes;
 				    if (ignored_codepoints.find(codepoint) == ignored_codepoints.end()) {
 					    end = next;
 				    }

--- a/src/execution/operator/csv_scanner/sniffer/header_detection.cpp
+++ b/src/execution/operator/csv_scanner/sniffer/header_detection.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/parser/simplified_token.hpp"
 
 #include "utf8proc.hpp"
+#include "utf8proc_wrapper.hpp"
 
 namespace duckdb {
 // Helper function to generate column names
@@ -18,26 +19,24 @@ static string GenerateColumnName(const idx_t total_cols, const idx_t col_number,
 
 // Helper function for UTF-8 aware space trimming
 static string TrimWhitespace(const string &col_name) {
-	utf8proc_int32_t codepoint;
-	const auto str = reinterpret_cast<const utf8proc_uint8_t *>(col_name.c_str());
+	int32_t codepoint;
+	const auto str = col_name.c_str();
 	const idx_t size = col_name.size();
 	// Find the first character that is not left trimmed
 	idx_t begin = 0;
 	while (begin < size) {
-		auto bytes = utf8proc_iterate(str + begin, NumericCast<utf8proc_ssize_t>(size - begin), &codepoint);
-		D_ASSERT(bytes > 0);
+		auto bytes = Utf8Proc::DecodeCharacter(str + begin, size - begin, codepoint);
 		if (utf8proc_category(codepoint) != UTF8PROC_CATEGORY_ZS) {
 			break;
 		}
-		begin += NumericCast<idx_t>(bytes);
+		begin += bytes;
 	}
 
 	// Find the last character that is not right trimmed
 	idx_t end = begin;
-	for (auto next = begin; next < col_name.size();) {
-		auto bytes = utf8proc_iterate(str + next, NumericCast<utf8proc_ssize_t>(size - next), &codepoint);
-		D_ASSERT(bytes > 0);
-		next += NumericCast<idx_t>(bytes);
+	for (auto next = begin; next < size;) {
+		auto bytes = Utf8Proc::DecodeCharacter(str + next, size - next, codepoint);
+		next += bytes;
 		if (utf8proc_category(codepoint) != UTF8PROC_CATEGORY_ZS) {
 			end = next;
 		}

--- a/test/common/CMakeLists.txt
+++ b/test/common/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library_unity(
   test_parse_expression.cpp
   test_parse_logical_type.cpp
   test_utf.cpp
+  test_utf8_string_functions_oob.cpp
   test_allocator_debug_info.cpp
   test_storage_fuzz.cpp
   test_strftime.cpp

--- a/test/common/test_utf8_string_functions_oob.cpp
+++ b/test/common/test_utf8_string_functions_oob.cpp
@@ -1,0 +1,54 @@
+#include "catch.hpp"
+#include "duckdb/common/helper.hpp"
+#include "utf8proc_wrapper.hpp"
+
+#include <cstring>
+
+using namespace duckdb;
+
+// utf8proc_iterate returns a negative error code on invalid or truncated UTF-8. Callers that add
+// the raw return value to a byte index (rtrim/ltrim/trim, lpad/rpad, strpos and the CSV header
+// trimmer) underflow the index and read out of bounds. Utf8Proc::DecodeCharacter guards the return
+// value so that iterating over invalid input always advances by at least one byte and stays in bounds.
+TEST_CASE("Utf8Proc::DecodeCharacter guards invalid utf8", "[utf8]") {
+	int32_t codepoint;
+
+	// truncated multi-byte lead bytes with no continuation bytes: consume a single byte
+	for (auto lead : {"\xc2", "\xe0", "\xf0"}) {
+		codepoint = 0;
+		REQUIRE(Utf8Proc::DecodeCharacter(lead, 1, codepoint) == 1);
+		REQUIRE(codepoint == -1);
+	}
+
+	// a lone continuation byte is also invalid
+	codepoint = 0;
+	REQUIRE(Utf8Proc::DecodeCharacter("\x80", 1, codepoint) == 1);
+	REQUIRE(codepoint == -1);
+
+	// valid ascii and multi-byte characters are decoded as before
+	codepoint = 0;
+	REQUIRE(Utf8Proc::DecodeCharacter("A", 1, codepoint) == 1);
+	REQUIRE(codepoint == 'A');
+	codepoint = 0;
+	REQUIRE(Utf8Proc::DecodeCharacter("\xc3\x84", 2, codepoint) == 2); // U+00C4
+	REQUIRE(codepoint == 0xC4);
+}
+
+// walking a heap-backed buffer that ends in a truncated multi-byte sequence must stay within the
+// buffer and terminate; before the fix the negative return underflowed the byte index
+TEST_CASE("Iterating truncated trailing utf8 stays in bounds", "[utf8]") {
+	for (auto lead : {'\xc2', '\xe0', '\xf0'}) {
+		auto buffer = make_unsafe_uniq_array<char>(20);
+		memset(buffer.get(), 'A', 20);
+		buffer[19] = lead; // multi-byte lead byte with no continuation bytes left in the buffer
+		idx_t pos = 0;
+		idx_t chars = 0;
+		while (pos < 20) {
+			int32_t codepoint;
+			pos += Utf8Proc::DecodeCharacter(buffer.get() + pos, 20 - pos, codepoint);
+			chars++;
+		}
+		REQUIRE(pos == 20);
+		REQUIRE(chars == 20);
+	}
+}

--- a/third_party/utf8proc/include/utf8proc_wrapper.hpp
+++ b/third_party/utf8proc/include/utf8proc_wrapper.hpp
@@ -22,9 +22,10 @@ enum class UnicodeInvalidReason { BYTE_MISMATCH, INVALID_UNICODE };
 class Utf8Proc {
 public:
 	//! Distinguishes ASCII, Valid UTF8 and Invalid UTF8 strings
-	static UnicodeType Analyze(const char *s, size_t len, UnicodeInvalidReason *invalid_reason = nullptr, size_t *invalid_pos = nullptr);
+	static UnicodeType Analyze(const char *s, size_t len, UnicodeInvalidReason *invalid_reason = nullptr,
+	                           size_t *invalid_pos = nullptr);
 	//! Performs UTF NFC normalization of string, return value needs to be free'd
-	static char* Normalize(const char* s, size_t len);
+	static char *Normalize(const char *s, size_t len);
 	//! Returns whether or not the UTF8 string is valid
 	static bool IsValid(const char *s, size_t len);
 	//! Makes Invalid Unicode valid by replacing invalid parts with a given character
@@ -40,8 +41,13 @@ public:
 	static bool CodepointToUtf8(int cp, int &sz, char *c);
 	//! Returns the codepoint length in bytes when encoded in UTF8
 	static int CodepointLength(int cp);
-	//! Transform a UTF8 string to a codepoint; returns the codepoint and writes the length of the codepoint (in UTF8) to sz
+	//! Transform a UTF8 string to a codepoint; returns the codepoint and writes the length of the codepoint (in UTF8)
+	//! to sz
 	static int32_t UTF8ToCodepoint(const char *c, int &sz);
+	//! Decodes the character at "s" (of at most "len" bytes) and writes its codepoint to "codepoint" (-1 when the
+	//! sequence is invalid or truncated). Returns the number of bytes consumed, which is always >= 1 so that iterating
+	//! over invalid input still advances and stays in bounds.
+	static size_t DecodeCharacter(const char *s, size_t len, int32_t &codepoint);
 	//! Returns the render width of a single character in a string
 	static size_t RenderWidth(const char *s, size_t len, size_t pos);
 	static size_t RenderWidth(const std::string &str);
@@ -54,8 +60,6 @@ public:
 
 	//! Returns the number of grapheme clusters in a string
 	static size_t GraphemeCount(const char *s, size_t len);
-
-
 };
 
 struct GraphemeCluster {
@@ -99,5 +103,4 @@ public:
 	}
 };
 
-
-}
+} // namespace duckdb

--- a/third_party/utf8proc/utf8proc_wrapper.cpp
+++ b/third_party/utf8proc/utf8proc_wrapper.cpp
@@ -344,16 +344,17 @@ int Utf8Proc::CodepointLength(int cp) {
 	if (cp <= 0x7F) {
 		return 1;
 	}
-	 if (cp <= 0x7FF) {
+	if (cp <= 0x7FF) {
 		return 2;
 	}
-	 if (0xd800 <= cp && cp <= 0xdfff) {
-	 	throw InternalException("invalid code point detected in Utf8Proc::CodepointLength (0xd800 to 0xdfff), likely due to invalid UTF-8");
+	if (0xd800 <= cp && cp <= 0xdfff) {
+		throw InternalException(
+		    "invalid code point detected in Utf8Proc::CodepointLength (0xd800 to 0xdfff), likely due to invalid UTF-8");
 	}
-	 if (cp <= 0xFFFF) {
+	if (cp <= 0xFFFF) {
 		return 3;
 	}
-	 if (cp <= 0x10FFFF) {
+	if (cp <= 0x10FFFF) {
 		return 4;
 	}
 	throw InternalException("invalid code point detected in Utf8Proc::CodepointLength, likely due to invalid UTF-8");
@@ -373,7 +374,8 @@ int32_t Utf8Proc::UTF8ToCodepoint(const char *u_input, int &sz) {
 		return (u0 - 192) * 64 + (u1 - 128);
 	}
 	if (u[0] == 0xed && (u[1] & 0xa0) == 0xa0) {
-		throw InternalException("invalid code point detected in Utf8Proc::UTF8ToCodepoint (0xd800 to 0xdfff), likely due to invalid UTF-8");
+		throw InternalException(
+		    "invalid code point detected in Utf8Proc::UTF8ToCodepoint (0xd800 to 0xdfff), likely due to invalid UTF-8");
 	}
 	unsigned char u2 = u[2];
 	if (u0 >= 224 && u0 <= 239) {
@@ -386,6 +388,18 @@ int32_t Utf8Proc::UTF8ToCodepoint(const char *u_input, int &sz) {
 		return (u0 - 240) * 262144 + (u1 - 128) * 4096 + (u2 - 128) * 64 + (u3 - 128);
 	}
 	throw InternalException("invalid code point detected in Utf8Proc::UTF8ToCodepoint, likely due to invalid UTF-8");
+}
+
+size_t Utf8Proc::DecodeCharacter(const char *s, size_t len, int32_t &codepoint) {
+	utf8proc_int32_t cp;
+	auto bytes = utf8proc_iterate(reinterpret_cast<const utf8proc_uint8_t *>(s), (utf8proc_ssize_t)len, &cp);
+	if (bytes < 1) {
+		// invalid or truncated UTF8: treat the byte as a single character
+		codepoint = -1;
+		return 1;
+	}
+	codepoint = cp;
+	return (size_t)bytes;
 }
 
 size_t Utf8Proc::RenderWidth(const char *s, size_t len, size_t pos) {


### PR DESCRIPTION
utf8proc_iterate returns a negative error code on invalid or truncated utf8, but several callers add it straight to a byte index:
- rtrim/trim advance the copy `end` past the input, and lpad/rpad size the output from the same underflowed count
- strpos rewinds the read pointer before the buffer (asan: heap-buffer-overflow read of size 1 in utf8proc_iterate)
- the csv header trimmer walks column names with the same loop

Invalid utf8 reaches these through the appender / C API, which don't validate it. Added Utf8Proc::DecodeCharacter, which always advances at least one byte, and routed the callers through it.
