### PR TITLE
Monotone stats pruning

### DIFF
--- a/benchmark/micro/monotone/scan_between_pruning.benchmark
+++ b/benchmark/micro/monotone/scan_between_pruning.benchmark
@@ -1,0 +1,15 @@
+# name: benchmark/micro/monotone/scan_between_pruning.benchmark
+# description: Row-group skipping for a monotone-function range filter f(col) BETWEEN a AND b (confined to a single row group in the middle of the table)
+# group: [monotone]
+
+name MonotoneScanBetweenPruning
+group micro
+
+load
+CREATE TABLE ints AS SELECT range::INTEGER AS x FROM range(50000000);
+
+run
+SELECT count(*) FROM ints WHERE floor(x::DOUBLE) BETWEEN 25000000 AND 25001000;
+
+result I
+1001

--- a/benchmark/micro/monotone/scan_filter_pruning.benchmark
+++ b/benchmark/micro/monotone/scan_filter_pruning.benchmark
@@ -1,0 +1,15 @@
+# name: benchmark/micro/monotone/scan_filter_pruning.benchmark
+# description: Row-group skipping for a monotone-function filter f(col) OP const (floor is not rewritten, so this exercises the scan-time CheckStatistics pruning path)
+# group: [monotone]
+
+name MonotoneScanFilterPruning
+group micro
+
+load
+CREATE TABLE ints AS SELECT range::INTEGER AS x FROM range(50000000);
+
+run
+SELECT count(*) FROM ints WHERE floor(x::DOUBLE) > 49999000;
+
+result I
+999

--- a/extension/core_functions/scalar/math/numeric.cpp
+++ b/extension/core_functions/scalar/math/numeric.cpp
@@ -1027,6 +1027,7 @@ ScalarFunction SqrtFun::GetFunction() {
 	ScalarFunction function({LogicalType::DOUBLE}, LogicalType::DOUBLE, nullptr,
 	                        BindIEEEFloatingUnary<SqrtOperator, IEEESqrtOperator>);
 	function.SetFallible();
+	function.SetUnaryArgProperties(ArgProperties().StrictlyIncreasing());
 	return function;
 }
 
@@ -1081,6 +1082,7 @@ ScalarFunction LnFun::GetFunction() {
 	ScalarFunction function({LogicalType::DOUBLE}, LogicalType::DOUBLE, nullptr,
 	                        BindIEEEFloatingUnary<LnOperator, IEEELnOperator>);
 	function.SetFallible();
+	function.SetUnaryArgProperties(ArgProperties().StrictlyIncreasing());
 	return function;
 }
 
@@ -1115,6 +1117,7 @@ ScalarFunction Log10Fun::GetFunction() {
 	ScalarFunction function({LogicalType::DOUBLE}, LogicalType::DOUBLE, nullptr,
 	                        BindIEEEFloatingUnary<Log10Operator, IEEELog10Operator>);
 	function.SetFallible();
+	function.SetUnaryArgProperties(ArgProperties().StrictlyIncreasing());
 	return function;
 }
 
@@ -1145,8 +1148,12 @@ struct IEEELogBaseOperator {
 
 ScalarFunctionSet LogFun::GetFunctions() {
 	ScalarFunctionSet funcs;
-	funcs.AddFunction(ScalarFunction({LogicalType::DOUBLE}, LogicalType::DOUBLE, nullptr,
-	                                 BindIEEEFloatingUnary<Log10Operator, IEEELog10Operator>));
+	ScalarFunction log10({LogicalType::DOUBLE}, LogicalType::DOUBLE, nullptr,
+	                     BindIEEEFloatingUnary<Log10Operator, IEEELog10Operator>);
+	// single-argument log is base-10: strictly increasing. the two-arg log(base, x) is only
+	// monotone in x for a fixed base, and decreasing for base < 1, so it is left unannotated.
+	log10.SetUnaryArgProperties(ArgProperties().StrictlyIncreasing());
+	funcs.AddFunction(std::move(log10));
 	funcs.AddFunction(ScalarFunction({LogicalType::DOUBLE, LogicalType::DOUBLE}, LogicalType::DOUBLE, nullptr,
 	                                 BindIEEEFloatingBinary<LogBaseOperator, IEEELogBaseOperator>));
 	for (auto &function : funcs.functions) {
@@ -1184,6 +1191,7 @@ ScalarFunction Log2Fun::GetFunction() {
 	ScalarFunction function({LogicalType::DOUBLE}, LogicalType::DOUBLE, nullptr,
 	                        BindIEEEFloatingUnary<Log2Operator, IEEELog2Operator>);
 	function.SetFallible();
+	function.SetUnaryArgProperties(ArgProperties().StrictlyIncreasing());
 	return function;
 }
 
@@ -1213,8 +1221,10 @@ struct DegreesOperator {
 } // namespace
 
 ScalarFunction DegreesFun::GetFunction() {
-	return ScalarFunction({LogicalType::DOUBLE}, LogicalType::DOUBLE,
-	                      ScalarFunction::UnaryFunction<double, double, DegreesOperator>);
+	ScalarFunction func({LogicalType::DOUBLE}, LogicalType::DOUBLE,
+	                    ScalarFunction::UnaryFunction<double, double, DegreesOperator>);
+	func.SetUnaryArgProperties(ArgProperties().StrictlyIncreasing());
+	return func;
 }
 
 //===--------------------------------------------------------------------===//
@@ -1230,8 +1240,10 @@ struct RadiansOperator {
 } // namespace
 
 ScalarFunction RadiansFun::GetFunction() {
-	return ScalarFunction({LogicalType::DOUBLE}, LogicalType::DOUBLE,
-	                      ScalarFunction::UnaryFunction<double, double, RadiansOperator>);
+	ScalarFunction func({LogicalType::DOUBLE}, LogicalType::DOUBLE,
+	                    ScalarFunction::UnaryFunction<double, double, RadiansOperator>);
+	func.SetUnaryArgProperties(ArgProperties().StrictlyIncreasing());
+	return func;
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/include/duckdb/optimizer/statistics_propagator.hpp
+++ b/src/include/duckdb/optimizer/statistics_propagator.hpp
@@ -39,6 +39,11 @@ public:
 	static bool CanPropagateCast(const LogicalType &source, const LogicalType &target);
 	static unique_ptr<BaseStatistics> TryPropagateCast(const BaseStatistics &stats, const LogicalType &source,
 	                                                   const LogicalType &target);
+	//! Derive output statistics of a monotone function by evaluating it at the corners of its
+	//! argument ranges (see ArgProperties). Returns nullptr when the bounds cannot be derived.
+	static unique_ptr<BaseStatistics> PropagateMonotoneBounds(ClientContext &context,
+	                                                          const BoundFunctionExpression &func,
+	                                                          const vector<BaseStatistics> &child_stats);
 
 private:
 	//! Propagate statistics through an operator

--- a/src/optimizer/statistics/expression/propagate_function.cpp
+++ b/src/optimizer/statistics/expression/propagate_function.cpp
@@ -23,8 +23,9 @@ static bool TryEvaluateAtConstants(ClientContext &context, const BoundFunctionEx
 
 //! Evaluate `func` at the lo/hi corner of each child's value range to derive output min/max.
 //! Decreasing args are swapped so f(lo_args) and f(hi_args) bracket the output range.
-static unique_ptr<BaseStatistics> TryPropagateMonotoneBounds(ClientContext &context, BoundFunctionExpression &func,
-                                                             const vector<BaseStatistics> &child_stats) {
+unique_ptr<BaseStatistics> StatisticsPropagator::PropagateMonotoneBounds(ClientContext &context,
+                                                                         const BoundFunctionExpression &func,
+                                                                         const vector<BaseStatistics> &child_stats) {
 	if (!func.Function().HasArgProperties() || func.GetChildren().empty()) {
 		return nullptr;
 	}
@@ -147,7 +148,7 @@ unique_ptr<BaseStatistics> StatisticsPropagator::PropagateExpression(BoundFuncti
 		FunctionStatisticsInput input(func, func.BindInfo().get(), stats, &expr_ptr);
 		return func.Function().GetStatisticsCallback()(context, input);
 	}
-	return TryPropagateMonotoneBounds(context, func, stats);
+	return PropagateMonotoneBounds(context, func, stats);
 }
 
 } // namespace duckdb

--- a/src/planner/filter/expression_filter.cpp
+++ b/src/planner/filter/expression_filter.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/function/scalar_function.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/planner/expression_iterator.hpp"
+#include "duckdb/planner/expression/bound_between_expression.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/planner/expression/bound_comparison_expression.hpp"
 #include "duckdb/planner/expression/bound_conjunction_expression.hpp"
@@ -240,28 +241,47 @@ static optional_ptr<const BaseStatistics> TryGetFilterStats(optional_ptr<ClientC
 				owned_stats.push_back(StructStats::GetChildStats(*child_stats, child_idx).ToUnique());
 				return owned_stats.back().get();
 			}
-		}
-
-		if (!context_p || !func.Function().HasStatisticsCallback()) {
 			return nullptr;
 		}
 
-		vector<BaseStatistics> child_stats;
-		child_stats.reserve(func.GetChildren().size());
-		for (auto &child_expr : func.GetChildren()) {
-			auto child_stat = TryGetFilterStats(context_p, *child_expr, stats, owned_stats);
-			if (!child_stat) {
-				return nullptr;
+		if (func.Function().HasStatisticsCallback()) {
+			vector<BaseStatistics> child_stats;
+			child_stats.reserve(func.GetChildren().size());
+			for (auto &child_expr : func.GetChildren()) {
+				auto child_stat = TryGetFilterStats(context_p, *child_expr, stats, owned_stats);
+				if (!child_stat) {
+					return nullptr;
+				}
+				child_stats.push_back(child_stat->Copy());
 			}
-			child_stats.push_back(child_stat->Copy());
+
+			// Use copy to avoid expression rewritten
+			auto expr_copy = func.Copy();
+			auto &func_copy = expr_copy->Cast<BoundFunctionExpression>();
+			FunctionStatisticsInput input(func_copy, func_copy.BindInfo(), child_stats, &expr_copy);
+			owned_stats.push_back(func.Function().GetStatisticsCallback()(*context_p, input));
+			return owned_stats.back().get();
 		}
 
-		// Use copy to avoid expression rewritten
-		auto expr_copy = func.Copy();
-		auto &func_copy = expr_copy->Cast<BoundFunctionExpression>();
-		FunctionStatisticsInput input(func_copy, func_copy.BindInfo(), child_stats, &expr_copy);
-		owned_stats.push_back(func.Function().GetStatisticsCallback()(*context_p, input));
-		return owned_stats.back().get();
+		// No custom callback: fall back to the declared monotonicity (ArgProperties) and derive output
+		// bounds by evaluating the function at the corners of each argument's range. This lets a
+		// f(col) OP const filter prune row groups via the zonemap of the base column.
+		if (func.Function().HasArgProperties()) {
+			vector<BaseStatistics> child_stats;
+			child_stats.reserve(func.GetChildren().size());
+			for (auto &child_expr : func.GetChildren()) {
+				auto child_stat = TryGetFilterStats(context_p, *child_expr, stats, owned_stats);
+				child_stats.push_back(child_stat ? child_stat->Copy()
+				                                 : BaseStatistics::CreateUnknown(child_expr->GetReturnType()));
+			}
+			auto derived = StatisticsPropagator::PropagateMonotoneBounds(*context_p, func, child_stats);
+			if (derived) {
+				owned_stats.push_back(std::move(derived));
+				return owned_stats.back().get();
+			}
+		}
+
+		return nullptr;
 	}
 	default:
 		return nullptr;
@@ -378,9 +398,55 @@ static FilterPropagateResult CheckComparisonStatistics(optional_ptr<ClientContex
 	return result;
 }
 
+//! `input BETWEEN lower AND upper` prunes when the input's derived range is entirely outside
+//! [lower, upper] (always-false) or entirely inside it (always-true). Mirrors the null-handling of
+//! CheckComparisonStatistics. `input` may itself be a monotone function whose stats are derived.
+static FilterPropagateResult CheckBetweenStatistics(optional_ptr<ClientContext> context_p,
+                                                    const BoundFunctionExpression &between,
+                                                    const BaseStatistics &stats) {
+	auto &lower = BoundBetweenExpression::LowerBound(between);
+	auto &upper = BoundBetweenExpression::UpperBound(between);
+	if (lower.GetExpressionType() != ExpressionType::VALUE_CONSTANT ||
+	    upper.GetExpressionType() != ExpressionType::VALUE_CONSTANT) {
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+	auto &lower_val = lower.Cast<BoundConstantExpression>().GetValue();
+	auto &upper_val = upper.Cast<BoundConstantExpression>().GetValue();
+	if (lower_val.IsNull() || upper_val.IsNull()) {
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+	vector<unique_ptr<BaseStatistics>> owned_stats;
+	auto input_stats = TryGetFilterStats(context_p, BoundBetweenExpression::Input(between), stats, owned_stats);
+	if (!input_stats || input_stats->GetType().id() == LogicalTypeId::VARIANT) {
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+	if (!input_stats->CanHaveNoNull()) {
+		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
+	}
+	auto lower_res = CheckZonemapAgainstConstants(*input_stats, BoundBetweenExpression::LowerComparisonType(between),
+	                                              array_ptr<const Value>(&lower_val, 1));
+	auto upper_res = CheckZonemapAgainstConstants(*input_stats, BoundBetweenExpression::UpperComparisonType(between),
+	                                              array_ptr<const Value>(&upper_val, 1));
+	if (input_stats->CanHaveNull()) {
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+	if (lower_res == FilterPropagateResult::FILTER_ALWAYS_FALSE ||
+	    upper_res == FilterPropagateResult::FILTER_ALWAYS_FALSE) {
+		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
+	}
+	if (lower_res == FilterPropagateResult::FILTER_ALWAYS_TRUE &&
+	    upper_res == FilterPropagateResult::FILTER_ALWAYS_TRUE) {
+		return FilterPropagateResult::FILTER_ALWAYS_TRUE;
+	}
+	return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+}
+
 static FilterPropagateResult CheckFunctionStatistics(optional_ptr<ClientContext> context_p,
                                                      const BoundFunctionExpression &func_expr,
                                                      const BaseStatistics &stats) {
+	if (func_expr.GetExpressionType() == ExpressionType::COMPARE_BETWEEN) {
+		return CheckBetweenStatistics(context_p, func_expr, stats);
+	}
 	if (BoundComparisonExpression::IsComparison(func_expr.GetExpressionType())) {
 		return CheckComparisonStatistics(context_p, func_expr, stats);
 	}

--- a/test/optimizer/statistics/statistics_numeric.test
+++ b/test/optimizer/statistics/statistics_numeric.test
@@ -179,3 +179,70 @@ query II
 SELECT s.min, s.max FROM (SELECT STATS(exp(x)) s FROM mixed LIMIT 1)
 ----
 1.0	2.718281828459045
+
+# sqrt is strictly increasing: perfect squares round exactly, so bounds are exact
+statement ok
+CREATE TABLE squares(x DOUBLE);
+
+statement ok
+INSERT INTO squares VALUES (4.0), (16.0);
+
+query II
+SELECT s.min, s.max FROM (SELECT STATS(sqrt(x)) s FROM squares LIMIT 1)
+----
+2.0	4.0
+
+# sqrt of a negative corner throws/NaN: propagator bails, no derived bounds
+statement ok
+CREATE TABLE maybe_negative(x DOUBLE);
+
+statement ok
+INSERT INTO maybe_negative VALUES (-5.0), (10.0);
+
+query II
+SELECT s.min, s.max FROM (SELECT STATS(sqrt(x)) s FROM maybe_negative LIMIT 1)
+----
+NULL	NULL
+
+# ln of a negative corner throws/NaN: propagator bails
+query II
+SELECT s.min, s.max FROM (SELECT STATS(ln(x)) s FROM maybe_negative LIMIT 1)
+----
+NULL	NULL
+
+# monotone logs: derived output range prunes impossible filters
+statement ok
+CREATE TABLE positives(x DOUBLE);
+
+statement ok
+INSERT INTO positives VALUES (1.0), (100.0);
+
+# ln(x) for x in [1, 100] is in [0, ln(100)]: ln(x) < -1 is impossible
+query II
+EXPLAIN SELECT count(*) FROM positives WHERE ln(x) < -1;
+----
+logical_opt	<REGEX>:.*EMPTY_RESULT.*
+
+# log10(x) for x in [1, 100] is in [0, 2]: log10(x) > 3 is impossible
+query II
+EXPLAIN SELECT count(*) FROM positives WHERE log10(x) > 3;
+----
+logical_opt	<REGEX>:.*EMPTY_RESULT.*
+
+# log2(x) for x in [1, 100] is in [0, log2(100)]: log2(x) > 7 is impossible
+query II
+EXPLAIN SELECT count(*) FROM positives WHERE log2(x) > 7;
+----
+logical_opt	<REGEX>:.*EMPTY_RESULT.*
+
+# degrees is strictly increasing: degrees(x) for x in [1, 100] < 50 is impossible (degrees(1) ~= 57.3)
+query II
+EXPLAIN SELECT count(*) FROM positives WHERE degrees(x) < 50;
+----
+logical_opt	<REGEX>:.*EMPTY_RESULT.*
+
+# radians is strictly increasing: radians(x) for x in [1, 100] > 2 is impossible (radians(100) ~= 1.75)
+query II
+EXPLAIN SELECT count(*) FROM positives WHERE radians(x) > 2;
+----
+logical_opt	<REGEX>:.*EMPTY_RESULT.*

--- a/test/sql/optimizer/monotone_function_zonemap_pruning.test
+++ b/test/sql/optimizer/monotone_function_zonemap_pruning.test
@@ -1,0 +1,84 @@
+# name: test/sql/optimizer/monotone_function_zonemap_pruning.test
+# description: Monotone functions (ArgProperties) prune row groups via the base column zonemap
+# group: [optimizer]
+
+# 500k rows -> 5 row groups (122880 rows each). x increases with the row id, so each row
+# group covers a contiguous, disjoint range of x.
+statement ok
+CREATE TABLE t AS SELECT range::INTEGER AS x FROM range(500000);
+
+# floor() carries ArgProperties (non-decreasing) but has no dedicated statistics callback, so
+# these prune purely through the monotone corner-eval wired into scan-time filter pruning.
+
+# tail: floor(x) > 495000 -> only the last row group can contain matches
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM t WHERE floor(x::DOUBLE) > 495000;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 5.*
+
+query I
+SELECT count(*) FROM t WHERE floor(x::DOUBLE) > 495000;
+----
+4999
+
+# head: floor(x) < 5000 -> only the first row group
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM t WHERE floor(x::DOUBLE) < 5000;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 5.*
+
+query I
+SELECT count(*) FROM t WHERE floor(x::DOUBLE) < 5000;
+----
+5000
+
+# a >= filter prunes the row groups strictly below the threshold. sum(x), not
+# count(*), so the retained groups are actually scanned instead of answered from
+# row-group metadata -- the exact stats on persistent storage make the count a
+# metadata-only lookup (0 scans) when the threshold is row-group aligned.
+query II
+EXPLAIN ANALYZE SELECT sum(x) FROM t WHERE floor(x::DOUBLE) >= 245760;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 3 / 5.*
+
+# range query (BETWEEN) confined to a single middle row group prunes the other four
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM t WHERE floor(x::DOUBLE) BETWEEN 245760 AND 249999;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 5.*
+
+query I
+SELECT count(*) FROM t WHERE floor(x::DOUBLE) BETWEEN 245760 AND 249999;
+----
+4240
+
+# impossible range folds away entirely (no matching row group)
+query I
+SELECT count(*) FROM t WHERE floor(x::DOUBLE) BETWEEN 600000 AND 700000;
+----
+0
+
+# year() maps DATE -> INT and is non-decreasing: prunes on the date zonemap
+statement ok
+CREATE TABLE d AS SELECT (DATE '1970-01-01' + INTERVAL (range) DAY)::DATE AS dt FROM range(500000);
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM d WHERE year(dt) < 1971;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 5.*
+
+query I
+SELECT count(*) FROM d WHERE year(dt) < 1971;
+----
+365
+
+# correctness: derived pruning never drops matching rows (full-table equivalence)
+query I
+SELECT count(*) FROM t WHERE floor(x::DOUBLE) > 495000;
+----
+4999
+
+query I
+SELECT count(*) FROM d WHERE year(dt) BETWEEN 1975 AND 1976;
+----
+731


### PR DESCRIPTION
Follow up from the conversation at https://github.com/duckdb/duckdb/pull/22286#issuecomment-4327498159, that ended up in monotonicity being propagated (via different PR eventually, see for example @J-Meyers's https://github.com/duckdb/duckdb/pull/22384).

This PR builds on the available infrastructure, allowing zone map pruning or index scans in cases like:
```sql
SELECT count(*) FROM ints WHERE floor(x::DOUBLE) > 49999000;
```
or
```sql
SELECT count(*) FROM ints WHERE floor(x::DOUBLE) BETWEEN 25000000 AND 25001000;
```

Benchmarks improvements can be from significant from very significant if constructed correctly, although `SQL` rewrite was already possible (so it doesn't show up in any benchmark).

Fixes https://github.com/duckdb/duckdb/issues/23602