### PR TITLE
Allow partial aggregate precompute with inexact row group stats

### DIFF
--- a/src/include/duckdb/optimizer/statistics_propagator.hpp
+++ b/src/include/duckdb/optimizer/statistics_propagator.hpp
@@ -112,6 +112,11 @@ private:
 
 	//! Try to execute aggregates using only the statistics if possible
 	void TryExecuteAggregates(LogicalAggregate &op, unique_ptr<LogicalOperator> &node_ptr);
+	void ReplaceWithPartialPrecompute(LogicalAggregate &aggr, LogicalGet &get,
+	                                  vector<unique_ptr<Expression>> aggr_results, vector<idx_t> scan_partition_indices,
+	                                  unique_ptr<LogicalOperator> &node_ptr);
+	void ReplaceWithFullPrecompute(LogicalAggregate &aggr, vector<unique_ptr<Expression>> aggr_results,
+	                               unique_ptr<LogicalOperator> &node_ptr);
 	void ReplaceWithEmptyResult(unique_ptr<LogicalOperator> &node);
 
 	bool ExpressionIsConstant(Expression &expr, const Value &val);

--- a/src/optimizer/statistics/operator/propagate_aggregate.cpp
+++ b/src/optimizer/statistics/operator/propagate_aggregate.cpp
@@ -1,12 +1,16 @@
 #include "duckdb/common/assert.hpp"
 #include "duckdb/common/column_index.hpp"
 #include "duckdb/common/enums/expression_type.hpp"
+#include "duckdb/common/enums/filter_propagate_result.hpp"
 #include "duckdb/common/helper.hpp"
 #include "duckdb/common/numeric_utils.hpp"
+#include "duckdb/common/optional_ptr.hpp"
+#include "duckdb/common/typedefs.hpp"
 #include "duckdb/common/types.hpp"
 #include "duckdb/common/types/value.hpp"
 #include "duckdb/common/unique_ptr.hpp"
 #include "duckdb/common/vector.hpp"
+#include "duckdb/function/aggregate_state.hpp"
 #include "duckdb/function/function_binder.hpp"
 #include "duckdb/function/partition_stats.hpp"
 #include "duckdb/function/aggregate/distributive_functions.hpp"
@@ -15,6 +19,7 @@
 #include "duckdb/planner/binder.hpp"
 #include "duckdb/optimizer/statistics_propagator.hpp"
 #include "duckdb/planner/filter/expression_filter.hpp"
+#include "duckdb/planner/logical_operator.hpp"
 #include "duckdb/planner/operator/logical_aggregate.hpp"
 #include "duckdb/planner/operator/logical_dummy_scan.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
@@ -24,10 +29,13 @@
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression/bound_operator_expression.hpp"
+#include "duckdb/planner/table_filter.hpp"
 #include "duckdb/storage/statistics/base_statistics.hpp"
 #include "duckdb/storage/statistics/string_stats.hpp"
 #include "duckdb/storage/storage_index.hpp"
 #include "duckdb/optimizer/matcher/expression_matcher.hpp"
+#include <cstdint>
+#include <utility>
 
 namespace duckdb {
 
@@ -122,63 +130,82 @@ bool GroupingSetCanIntroduceNull(const LogicalAggregate &aggr, idx_t group_idx) 
 	return false;
 }
 
-} // namespace
+enum class PartitionAction : uint8_t { PRECOMPUTE, SCAN, PRUNE };
 
-void StatisticsPropagator::TryExecuteAggregates(LogicalAggregate &aggr, unique_ptr<LogicalOperator> &node_ptr) {
-	if (!aggr.groups.empty()) {
-		// not possible with groups
-		return;
-	}
-	// check if all aggregates are COUNT(*), MIN or MAX
-	vector<idx_t> count_star_idxs;
-	vector<ColumnBinding> min_max_bindings;
+struct PartitionAggregateRequirements {
+	//! filter column -> table filter (empty if the scan has no filters)
+	map<StorageIndex, reference<TableFilter>> filters;
+	//! columns that need an exact min/max, parallel to comparators
+	vector<StorageIndex> min_max_columns;
 	vector<unique_ptr<ValueComparator>> comparators;
+	//! the query contains count(*)
+	bool needs_exact_count = false;
+};
 
-	for (idx_t i = 0; i < aggr.expressions.size(); i++) {
-		auto &aggr_ref = aggr.expressions[i];
-		if (aggr_ref->GetExpressionClass() != ExpressionClass::BOUND_AGGREGATE) {
-			// not an aggregate
-			return;
+struct PartitionAggregateInfo {
+	optional_ptr<LogicalGet> get;
+	PartitionAggregateRequirements requirements;
+	//! positions of the aggregates in aggr.expressions
+	vector<idx_t> count_star_idxs;
+	vector<idx_t> min_max_idxs;
+	//! return types of the min/max aggregates, parallel to min_max_idxs
+	vector<LogicalType> min_max_types;
+};
+
+//! Values extracted from one partition, only valid when the action is PRECOMPUTE
+struct AggregateValues {
+	//! extracted min/max per column, parallel to requirements.min_max_columns
+	vector<Value> min_max_values;
+	idx_t count = 0;
+};
+
+bool TryGetPartitionAggregateInfo(LogicalAggregate &aggr, PartitionAggregateInfo &info) {
+	if (!aggr.groups.empty()) {
+		return false;
+	}
+
+	// every aggregate must be count_star, or min/max over a plain column
+	vector<ColumnBinding> min_max_bindings;
+	for (idx_t i = 0; i < aggr.expressions.size(); ++i) {
+		auto &expr = aggr.expressions[i];
+		if (expr->GetExpressionClass() != ExpressionClass::BOUND_AGGREGATE) {
+			return false;
 		}
-		auto &aggr_expr = aggr_ref->Cast<BoundAggregateExpression>();
-		if (aggr_expr.GetFilter()) {
-			// aggregate has a filter - bail
-			return;
+		auto &aggr_expr = expr->Cast<BoundAggregateExpression>();
+		if (aggr_expr.GetFilter() || aggr_expr.StateExportMode() == AggregateStateExportMode::STATE_EXPORT) {
+			return false;
 		}
-		if (aggr_expr.StateExportMode() == AggregateStateExportMode::STATE_EXPORT) {
-			// aggregate is in state export mode - cannot replace with a constant
-			return;
-		}
-		auto &fun_name = aggr_expr.Function().GetName();
-		if (fun_name == "min" || fun_name == "max") {
+		auto &func_name = aggr_expr.Function().GetName();
+		if (func_name == "min" || func_name == "max") {
 			if (aggr_expr.GetChildren().size() != 1 ||
 			    aggr_expr.GetChildren()[0]->GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
-				return;
+				return false;
 			}
-			const auto &col_ref = aggr_expr.GetChildren()[0]->Cast<BoundColumnRefExpression>();
-			min_max_bindings.push_back(col_ref.Binding());
-			auto comparator = GetComparator(fun_name, col_ref.GetReturnType());
+			auto &col_ref = aggr_expr.GetChildren()[0]->Cast<BoundColumnRefExpression>();
+			auto comparator = GetComparator(func_name, col_ref.GetReturnType());
 			if (!comparator) {
 				// Type has no min max statistics
-				return;
+				return false;
 			}
-			comparators.push_back(std::move(comparator));
-		} else if (fun_name == "count_star") {
-			count_star_idxs.push_back(i);
+			min_max_bindings.push_back(col_ref.Binding());
+			info.requirements.comparators.push_back(std::move(comparator));
+			info.min_max_idxs.push_back(i);
+			info.min_max_types.push_back(col_ref.GetReturnType());
+		} else if (func_name == "count_star") {
+			info.count_star_idxs.push_back(i);
+			info.requirements.needs_exact_count = true;
 		} else {
-			// aggregate is not count star, min or max - bail
-			return;
+			return false;
 		}
 	}
 
-	// skip any projections
 	reference<LogicalOperator> child_ref = *aggr.children[0];
 	while (child_ref.get().type == LogicalOperatorType::LOGICAL_PROJECTION) {
+		auto &proj = child_ref.get().Cast<LogicalProjection>();
 		for (auto &binding : min_max_bindings) {
-			auto &proj = child_ref.get().Cast<LogicalProjection>();
 			auto &expr = proj.GetExpression(binding);
 			if (expr.GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
-				return;
+				return false;
 			}
 			binding = expr.Cast<BoundColumnRefExpression>().Binding();
 		}
@@ -187,215 +214,233 @@ void StatisticsPropagator::TryExecuteAggregates(LogicalAggregate &aggr, unique_p
 
 	if (child_ref.get().type != LogicalOperatorType::LOGICAL_GET) {
 		// child must be a LOGICAL_GET
-		return;
+		return false;
 	}
+
 	auto &get = child_ref.get().Cast<LogicalGet>();
 	if (!get.function.get_partition_stats) {
 		// GET does not support getting the partition stats
-		return;
+		return false;
 	}
 	if (get.extra_info.sample_options) {
 		// only use row group statistics if we query the whole table
-		return;
+		return false;
 	}
 
-	// we can do the rewrite! get the stats
-	GetPartitionStatsInput input(get.function, get.bind_data.get());
-	auto partition_stats = get.function.get_partition_stats(context, input);
-	if (partition_stats.empty()) {
-		// no partition stats found
-		return;
-	}
-
-	vector<StorageIndex> min_max_storage_indexes(min_max_bindings.size());
-	for (idx_t i = 0; i < min_max_bindings.size(); i++) {
-		auto &binding = min_max_bindings[i];
-		auto &column_index = get.GetColumnIndex(binding);
-		if (!get.TryGetStorageIndex(column_index, min_max_storage_indexes[i])) {
-			//! Can't get a storage index for this column, so it doesn't have stats we can use
-			//! This happens when we're dealing with a generated column for example
-			return;
+	auto &min_max_columns = info.requirements.min_max_columns;
+	min_max_columns.resize(min_max_bindings.size());
+	for (idx_t i = 0; i < min_max_bindings.size(); ++i) {
+		auto &column_index = get.GetColumnIndex(min_max_bindings[i]);
+		if (!get.TryGetStorageIndex(column_index, min_max_columns[i])) {
+			// Can't get a storage index for this column, so it doesn't have stats we can use
+			// This happens when we're dealing with a generated column for example
+			return false;
 		}
 	}
 
+	auto &filters = info.requirements.filters;
+	for (auto &entry : get.table_filters) {
+		auto &column_index = get.GetColumnIndex(entry.GetIndex());
+		StorageIndex storage_index;
+		if (!get.TryGetStorageIndex(column_index, storage_index)) {
+			return false;
+		}
+		filters.emplace(storage_index, entry.Filter());
+	}
+
+	info.get = &get;
+
+	return true;
+}
+
+PartitionAction ClassifyPartition(ClientContext &context, const PartitionStatistics &stats,
+                                  const PartitionAggregateRequirements &requirements, AggregateValues &result) {
+	auto &row_group = stats.partition_row_group;
+	// filters can only be verified against per-partition column statistics;
+	// without them the count/min-max checks below decide on their own
+	if (!requirements.filters.empty() && !row_group) {
+		return PartitionAction::SCAN;
+	}
+	// filters: trust ALWAYS_TRUE / ALWAYS_FALSE only when the filter column's
+	// statistics are exact; a single trusted ALWAYS_FALSE prunes the partition
+	bool partial_match = false;
+	for (auto &[storage_index, filter] : requirements.filters) {
+		auto column_stats = row_group->GetColumnStatistics(storage_index);
+		if (!column_stats || !row_group->MinMaxIsExact(*column_stats, storage_index)) {
+			partial_match = true;
+			continue;
+		}
+		auto &expr_filter = ExpressionFilter::GetExpressionFilter(filter.get(), "ClassifyPartition");
+		switch (expr_filter.CheckStatistics(context, *column_stats)) {
+		case FilterPropagateResult::FILTER_ALWAYS_FALSE:
+			return PartitionAction::PRUNE;
+		case FilterPropagateResult::FILTER_ALWAYS_TRUE:
+			break;
+		default:
+			partial_match = true;
+			break;
+		}
+	}
+
+	if (partial_match) {
+		return PartitionAction::SCAN;
+	}
+
+	if (requirements.needs_exact_count) {
+		if (stats.count_type != CountType::COUNT_EXACT) {
+			return PartitionAction::SCAN;
+		}
+		result.count = stats.count;
+	}
+
+	auto &min_max_columns = requirements.min_max_columns;
+	auto &comparators = requirements.comparators;
+	D_ASSERT(min_max_columns.size() == comparators.size());
+	for (idx_t i = 0; i < min_max_columns.size(); ++i) {
+		Value value;
+		if (!TryGetValueFromStats(stats, min_max_columns[i], *comparators[i], value)) {
+			return PartitionAction::SCAN;
+		}
+		result.min_max_values.push_back(std::move(value));
+	}
+	return PartitionAction::PRECOMPUTE;
+}
+
+} // namespace
+
+void StatisticsPropagator::ReplaceWithPartialPrecompute(LogicalAggregate &aggr, LogicalGet &get,
+                                                        vector<unique_ptr<Expression>> aggr_results,
+                                                        vector<idx_t> scan_partition_indices,
+                                                        unique_ptr<LogicalOperator> &node_ptr) {
+	// merge each precomputed constant with the aggregate over the scanned partitions
+	auto proj_index = optimizer.binder.GenerateTableIndex();
+	vector<unique_ptr<Expression>> proj_expressions;
+	auto &aggr_expressions = aggr.expressions;
+	for (idx_t i = 0; i < aggr_expressions.size(); ++i) {
+		auto &aggr_expr = aggr_expressions[i]->Cast<BoundAggregateExpression>();
+		auto &func_name = aggr_expr.Function().GetName();
+		auto aggr_col_ref = make_uniq<BoundColumnRefExpression>(
+		    aggr_expr.GetReturnType(), ColumnBinding(aggr.aggregate_index, ProjectionIndex(i)));
+
+		if (func_name == "count_star") {
+			// pre_count + count_star_from_scan
+			auto &pre_count_expr = aggr_results[i];
+			auto add_expr = optimizer.BindScalarFunction("+", pre_count_expr->Copy(), std::move(aggr_col_ref));
+			add_expr->SetAlias(aggr.expressions[i]->GetAlias());
+			proj_expressions.push_back(std::move(add_expr));
+		} else {
+			// For min: COALESCE(least(pre_min, agg_min), pre_min)
+			// For max: COALESCE(greatest(pre_max, agg_max), pre_max)
+			auto &pre_val_expr = aggr_results[i];
+			Identifier merge_func((func_name == "min") ? "least" : "greatest");
+			auto merged = optimizer.BindScalarFunction(merge_func, pre_val_expr->Copy(), std::move(aggr_col_ref));
+			auto coalesce =
+			    make_uniq<BoundOperatorExpression>(ExpressionType::OPERATOR_COALESCE, aggr_expr.GetReturnType());
+			coalesce->GetChildrenMutable().push_back(std::move(merged));
+			coalesce->GetChildrenMutable().push_back(pre_val_expr->Copy());
+			coalesce->SetAlias(aggr.expressions[i]->GetAlias());
+			proj_expressions.push_back(std::move(coalesce));
+		}
+	}
+
+	get.SetPartitionsToScan(std::move(scan_partition_indices));
+
+	auto projection = make_uniq<LogicalProjection>(proj_index, std::move(proj_expressions));
+	projection->children.push_back(std::move(node_ptr));
+	ColumnBindingReplacer replacer;
+	for (idx_t i = 0; i < aggr.expressions.size(); i++) {
+		replacer.replacement_bindings.emplace_back(ColumnBinding(aggr.aggregate_index, ProjectionIndex(i)),
+		                                           ColumnBinding(proj_index, ProjectionIndex(i)));
+	}
+	replacer.stop_operator = projection.get();
+	node_ptr = std::move(projection);
+	replacer.VisitOperator(*root);
+}
+
+void StatisticsPropagator::ReplaceWithFullPrecompute(LogicalAggregate &aggr,
+                                                     vector<unique_ptr<Expression>> aggr_results,
+                                                     unique_ptr<LogicalOperator> &node_ptr) {
+	D_ASSERT(aggr_results.size() == aggr.expressions.size());
 	vector<LogicalType> types;
-	vector<unique_ptr<Expression>> agg_results;
-	bool need_to_scan = false;
-	vector<idx_t> scan_partition_indices;
-	// we can keep execute eager aggregate if all partitions could be either filtered entirely or remained entirely
-	if (get.table_filters.HasFilters()) {
-		map<StorageIndex, reference<TableFilter>> filter_storage_index_map;
-		for (auto &entry : get.table_filters) {
-			auto filter_idx = entry.GetIndex();
-			auto &filter = entry.Filter();
-			auto &column_index = get.GetColumnIndex(filter_idx);
-			StorageIndex storage_index;
-			if (!get.TryGetStorageIndex(column_index, storage_index)) {
-				return;
-			}
-			filter_storage_index_map.emplace(storage_index, filter);
-		}
-		vector<PartitionStatistics> precomputed_partition_stats;
-		for (idx_t partition_idx = 0; partition_idx < partition_stats.size(); partition_idx++) {
-			auto &stats = partition_stats[partition_idx];
-			if (!stats.partition_row_group) {
-				return;
-			}
-			auto filter_result = FilterPropagateResult::FILTER_ALWAYS_TRUE;
-			for (auto &entry : filter_storage_index_map) {
-				auto &storage_index = entry.first;
-				auto &filter = entry.second;
-				auto prg = stats.partition_row_group;
-				if (!prg) {
-					return;
-				}
-				auto column_stats = prg->GetColumnStatistics(storage_index);
-				if (!column_stats) {
-					return;
-				}
-				auto &expr_filter =
-				    ExpressionFilter::GetExpressionFilter(filter.get(), "AggregateStats::CheckPartitionFilters");
-				auto col_filter_result = expr_filter.CheckStatistics(context, *column_stats);
-				if (col_filter_result == FilterPropagateResult::FILTER_ALWAYS_FALSE) {
-					// all data in this partition is filtered out, remove this partition entirely
-					filter_result = FilterPropagateResult::FILTER_ALWAYS_FALSE;
-					break;
-				}
-				if (col_filter_result != FilterPropagateResult::FILTER_ALWAYS_TRUE) {
-					filter_result = col_filter_result;
-				}
-			}
-			switch (filter_result) {
-			case FilterPropagateResult::FILTER_ALWAYS_TRUE:
-				precomputed_partition_stats.push_back(std::move(stats));
-				break;
-			case FilterPropagateResult::FILTER_ALWAYS_FALSE:
-				break;
-			default:
-				need_to_scan = true;
-				scan_partition_indices.push_back(partition_idx);
-				break;
-			}
-		}
-		if (precomputed_partition_stats.empty()) {
-			// no partitions can be pre-computed
-			return;
-		}
-		partition_stats = std::move(precomputed_partition_stats);
+	for (idx_t i = 0; i < aggr_results.size(); i++) {
+		aggr_results[i]->SetAlias(aggr.expressions[i]->GetAlias());
+		types.push_back(aggr_results[i]->GetReturnType());
 	}
-
-	if (!min_max_bindings.empty()) {
-		// Execute min/max aggregates on partition statistics
-		for (idx_t agg_idx = 0; agg_idx < min_max_storage_indexes.size(); agg_idx++) {
-			const auto &storage_index = min_max_storage_indexes[agg_idx];
-			auto &comparator = comparators[agg_idx];
-
-			Value agg_result;
-			if (!TryGetValueFromStats(partition_stats[0], storage_index, *comparator, agg_result)) {
-				return;
-			}
-			for (idx_t partition_idx = 1; partition_idx < partition_stats.size(); partition_idx++) {
-				Value rhs;
-				if (!TryGetValueFromStats(partition_stats[partition_idx], storage_index, *comparator, rhs)) {
-					return;
-				}
-				if (!comparator->Compare(agg_result, rhs)) {
-					agg_result = rhs;
-				}
-			}
-			types.push_back(agg_result.GetTypeMutable());
-			auto expr = make_uniq<BoundConstantExpression>(agg_result);
-			agg_results.push_back(std::move(expr));
-		}
-	}
-	if (!count_star_idxs.empty()) {
-		// Execute count_star aggregates on partition statistics
-		idx_t count = 0;
-		for (const auto &stats : partition_stats) {
-			if (stats.count_type == CountType::COUNT_APPROXIMATE) {
-				// we cannot get an exact count
-				return;
-			}
-			count += stats.count;
-		}
-		for (const auto count_star_idx : count_star_idxs) {
-			auto count_result = make_uniq<BoundConstantExpression>(Value::BIGINT(NumericCast<int64_t>(count)));
-			agg_results.emplace(agg_results.begin() + NumericCast<int64_t>(count_star_idx), std::move(count_result));
-			types.insert(types.begin() + NumericCast<int64_t>(count_star_idx), LogicalType::BIGINT);
-		}
-	}
-
-	if (need_to_scan) {
-		// Partial precomputation: some partitions need scanning
-		// Insert a LogicalProjection above the aggregate that combines pre-computed constants with scan results
-		if (!get.function.set_partitions_to_scan) {
-			// scan does not support partition filtering - bail out
-			return;
-		}
-
-		// Build projection expressions that merge pre-computed values with aggregate results
-		auto proj_index = optimizer.binder.GenerateTableIndex();
-		vector<unique_ptr<Expression>> proj_expressions;
-		for (idx_t i = 0; i < aggr.expressions.size(); i++) {
-			auto &aggr_expr = aggr.expressions[i]->Cast<BoundAggregateExpression>();
-			auto &fun_name = aggr_expr.Function().GetName();
-
-			// Reference to the aggregate output column
-			auto agg_col_ref = make_uniq<BoundColumnRefExpression>(
-			    aggr_expr.GetReturnType(), ColumnBinding(aggr.aggregate_index, ProjectionIndex(i)));
-
-			if (fun_name == "count_star") {
-				// pre_count + count_star_from_scan
-				auto &pre_count_expr = agg_results[i];
-				auto add_expr = optimizer.BindScalarFunction("+", pre_count_expr->Copy(), std::move(agg_col_ref));
-				add_expr->SetAlias(aggr.expressions[i]->GetAlias());
-				proj_expressions.push_back(std::move(add_expr));
-			} else if (fun_name == "min" || fun_name == "max") {
-				// For min: COALESCE(least(pre_min, agg_min), pre_min)
-				// For max: COALESCE(greatest(pre_max, agg_max), pre_max)
-				auto &pre_val_expr = agg_results[i];
-				Identifier merge_func((fun_name == "min") ? "least" : "greatest");
-				auto merged = optimizer.BindScalarFunction(merge_func, pre_val_expr->Copy(), std::move(agg_col_ref));
-				auto coalesce =
-				    make_uniq<BoundOperatorExpression>(ExpressionType::OPERATOR_COALESCE, aggr_expr.GetReturnType());
-				coalesce->GetChildrenMutable().push_back(std::move(merged));
-				coalesce->GetChildrenMutable().push_back(pre_val_expr->Copy());
-				coalesce->SetAlias(aggr.expressions[i]->GetAlias());
-				proj_expressions.push_back(std::move(coalesce));
-			}
-		}
-
-		// Tell the scan to only scan partitions whose aggregates were NOT pre-computed
-		get.SetPartitionsToScan(std::move(scan_partition_indices));
-
-		// Create LogicalProjection above the aggregate
-		auto projection = make_uniq<LogicalProjection>(proj_index, std::move(proj_expressions));
-		projection->children.push_back(std::move(node_ptr));
-
-		ColumnBindingReplacer replacer;
-		for (idx_t i = 0; i < aggr.expressions.size(); i++) {
-			auto old_binding = ColumnBinding(aggr.aggregate_index, ProjectionIndex(i));
-			auto new_binding = ColumnBinding(proj_index, ProjectionIndex(i));
-			replacer.replacement_bindings.emplace_back(old_binding, new_binding);
-		}
-
-		replacer.stop_operator = projection.get();
-		node_ptr = std::move(projection);
-		replacer.VisitOperator(*root);
-		return;
-	}
-
-	// Set column names
-	for (idx_t expr_idx = 0; expr_idx < agg_results.size(); expr_idx++) {
-		agg_results[expr_idx]->SetAlias(aggr.expressions[expr_idx]->GetAlias());
-	}
-
 	vector<vector<unique_ptr<Expression>>> expressions;
-	expressions.push_back(std::move(agg_results));
+	expressions.push_back(std::move(aggr_results));
 	auto expression_get =
 	    make_uniq<LogicalExpressionGet>(aggr.aggregate_index, std::move(types), std::move(expressions));
 	expression_get->children.push_back(make_uniq<LogicalDummyScan>(aggr.group_index));
 	node_ptr = std::move(expression_get);
+}
+
+void StatisticsPropagator::TryExecuteAggregates(LogicalAggregate &aggr, unique_ptr<LogicalOperator> &node_ptr) {
+	PartitionAggregateInfo info;
+	if (!TryGetPartitionAggregateInfo(aggr, info)) {
+		return;
+	}
+	auto &get = *info.get;
+	GetPartitionStatsInput input(get.function, get.bind_data.get());
+	auto partition_stats = get.function.get_partition_stats(context, input);
+	if (partition_stats.empty()) {
+		return;
+	}
+
+	// classify every partition, folding the precomputable ones as we go
+	auto &reqs = info.requirements;
+	idx_t precompute_count = 0;
+	idx_t total_count = 0;
+	vector<Value> min_max_values;
+	for (auto &type : info.min_max_types) {
+		min_max_values.emplace_back(type);
+	}
+	vector<idx_t> scan_partition_indices;
+
+	for (idx_t partition_idx = 0; partition_idx < partition_stats.size(); partition_idx++) {
+		AggregateValues values;
+		switch (ClassifyPartition(context, partition_stats[partition_idx], reqs, values)) {
+		case PartitionAction::PRECOMPUTE:
+			precompute_count++;
+			total_count += values.count;
+			for (idx_t i = 0; i < min_max_values.size(); i++) {
+				if (min_max_values[i].IsNull() ||
+				    !reqs.comparators[i]->Compare(min_max_values[i], values.min_max_values[i])) {
+					min_max_values[i] = values.min_max_values[i];
+				}
+			}
+			break;
+		case PartitionAction::SCAN:
+			scan_partition_indices.push_back(partition_idx);
+			break;
+		case PartitionAction::PRUNE:
+			break;
+		}
+	}
+
+	if (precompute_count == 0) {
+		return;
+	}
+	const bool need_to_scan = !scan_partition_indices.empty();
+	if (need_to_scan && !get.function.set_partitions_to_scan) {
+		return;
+	}
+
+	// build one constant per aggregate, in expression order
+	vector<unique_ptr<Expression>> aggr_results(aggr.expressions.size());
+	for (idx_t i = 0; i < info.min_max_idxs.size(); i++) {
+		aggr_results[info.min_max_idxs[i]] = make_uniq<BoundConstantExpression>(min_max_values[i]);
+	}
+	for (const auto count_idx : info.count_star_idxs) {
+		aggr_results[count_idx] = make_uniq<BoundConstantExpression>(Value::BIGINT(NumericCast<int64_t>(total_count)));
+	}
+
+	if (need_to_scan) {
+		ReplaceWithPartialPrecompute(aggr, get, std::move(aggr_results), std::move(scan_partition_indices), node_ptr);
+		return;
+	}
+
+	// full precompute: replace the aggregate subtree with the constants
+	ReplaceWithFullPrecompute(aggr, std::move(aggr_results), node_ptr);
 }
 
 unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalAggregate &aggr,

--- a/test/optimizer/partial_aggregate_precomputation.test
+++ b/test/optimizer/partial_aggregate_precomputation.test
@@ -130,3 +130,190 @@ query II
 EXPLAIN SELECT count(*), min(i), max(i) FROM t WHERE i >= 2048 AND j > 5000 GROUP BY i % 10
 ----
 physical_plan	<REGEX>:.*HASH_GROUP_BY.*
+
+# Inexact statistics: updated/deleted row groups fall back to scanning, exact ones still precompute
+statement ok
+CREATE TABLE t2 AS (SELECT * FROM range(8192) _(i), LATERAL (SELECT (i * 2) AS j));
+
+# Reopen to clear version info so all row group stats start exact
+statement ok
+ATTACH '{TEST_DIR}/tmp_partial2.duckdb' AS tmp2
+
+statement ok
+USE tmp2
+
+statement ok
+DETACH db
+
+statement ok
+ATTACH '{TEST_DIR}/partial_agg.duckdb' AS db (ROW_GROUP_SIZE 2048)
+
+statement ok
+USE db
+
+statement ok
+DETACH tmp2
+
+# Prevent automatic checkpoints: a checkpoint rewrites the row group and re-tightens its statistics
+statement ok
+SET checkpoint_threshold = '1TB'
+
+# An update marks row group 0 as changed: its min/max become inexact, its count stays exact
+statement ok
+UPDATE t2 SET j = 4000 WHERE i = 100
+
+# count(*) alone is still fully precomputed - updates do not change row counts
+query II
+EXPLAIN SELECT count(*) FROM t2
+----
+physical_plan	<!REGEX>:.*UNGROUPED_AGGREGATE.*
+
+query I
+SELECT count(*) FROM t2
+----
+8192
+
+# min/max must scan the updated row group - partial precompute without any filter
+query II
+EXPLAIN SELECT min(j), max(j) FROM t2
+----
+physical_plan	<REGEX>:.*COALESCE.*least.*UNGROUPED_AGGREGATE.*
+
+query II
+SELECT min(j), max(j) FROM t2
+----
+0	16382
+
+# combined with max, count is scanned along with it and merged back
+query II
+EXPLAIN SELECT count(*), max(j) FROM t2
+----
+physical_plan	<REGEX>:.*UNGROUPED_AGGREGATE.*
+
+query II
+SELECT count(*), max(j) FROM t2
+----
+8192	16382
+
+# Filter + inexact min/max: the updated row group cannot be trusted for the filter
+# verdict at plan time, so it stays in the scan set; the scan-time zonemap then
+# skips it anyway, so no row group is actually read
+query II
+EXPLAIN ANALYZE SELECT min(j), max(j) FROM t2 WHERE i >= 2048
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 0 / 4.*
+
+query II
+SELECT min(j), max(j) FROM t2 WHERE i >= 2048
+----
+4096	16382
+
+# A delete creates version info: the count of row group 0 becomes approximate as well
+statement ok
+DELETE FROM t2 WHERE i = 100
+
+# partial precompute: the 3 clean row groups fold into the constant 6144
+query II
+EXPLAIN SELECT count(*) FROM t2
+----
+physical_plan	<REGEX>:.*6144.*UNGROUPED_AGGREGATE.*
+
+# only the deleted row group is scanned
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM t2
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 4.*
+
+query III
+SELECT count(*), min(j), max(j) FROM t2
+----
+8191	0	16382
+
+# Filter + approximate count: the deleted row group stays in the scan set at plan
+# time, the scan-time zonemap skips it, and the count comes from the constant alone
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM t2 WHERE i >= 2048
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 0 / 4.*
+
+query I
+SELECT count(*) FROM t2 WHERE i >= 2048
+----
+6144
+
+# All actions at once: row group 0 scanned (inexact stats), row group 2 scanned
+# (partial filter match), row group 3 pruned, row group 1 precomputed
+query II
+EXPLAIN ANALYZE SELECT count(*), min(j), max(j) FROM t2 WHERE i < 5000
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 2 / 4.*
+
+query III
+SELECT count(*), min(j), max(j) FROM t2 WHERE i < 5000
+----
+4999	0	9998
+
+# Update and delete hitting different row groups
+statement ok
+CREATE TABLE t3 AS (SELECT * FROM range(8192) _(i), LATERAL (SELECT (i * 2) AS j));
+
+# Reopen to clear version info
+statement ok
+ATTACH '{TEST_DIR}/tmp_partial3.duckdb' AS tmp3
+
+statement ok
+USE tmp3
+
+statement ok
+DETACH db
+
+statement ok
+ATTACH '{TEST_DIR}/partial_agg.duckdb' AS db (ROW_GROUP_SIZE 2048)
+
+statement ok
+USE db
+
+statement ok
+DETACH tmp3
+
+# row group 0: update only; row group 1: delete only
+statement ok
+UPDATE t3 SET j = 4000 WHERE i = 100
+
+statement ok
+DELETE FROM t3 WHERE i = 3000
+
+# count scans only the deleted row group - the updated one still precomputes its count
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM t3
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 4.*
+
+query I
+SELECT count(*) FROM t3
+----
+8191
+
+# min/max must scan both changed row groups
+query II
+EXPLAIN ANALYZE SELECT min(j), max(j) FROM t3
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 2 / 4.*
+
+query II
+SELECT min(j), max(j) FROM t3
+----
+0	16382
+
+# all three aggregates with a filter partially matching yet another row group:
+# row groups 0 (update) and 1 (delete) are scanned as untrusted, row group 3 is a
+# partial filter match, row group 2 precomputes
+query II
+EXPLAIN ANALYZE SELECT count(*), min(j), max(j) FROM t3 WHERE i < 7000
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 3 / 4.*
+
+query III
+SELECT count(*), min(j), max(j) FROM t3 WHERE i < 7000
+----
+6999	0	13998


### PR DESCRIPTION
Similar to  what we did in `StatisticsPropagator::TryExecuteAggregates`, we can also specify the specific partitions with  inexact stats for scanning instead of bailing out the optimization entirely. This PR also tries to make the code more readable since the `StatisticsPropagator::TryExecuteAggregates` is very long and not easy to be maintained.