### PR TITLE
Skip compression detection when specified

### DIFF
--- a/src/storage/table/column_data_checkpointer.cpp
+++ b/src/storage/table/column_data_checkpointer.cpp
@@ -191,25 +191,31 @@ vector<CheckpointAnalyzeResult> ColumnDataCheckpointer::DetectBestCompressionMet
 
 	InitAnalyze();
 
-	// scan over all the segments and run the analyze step
-	ScanSegments([&](Vector &scan_vector) {
-		for (idx_t i = 0; i < checkpoint_states.size(); i++) {
-			auto &functions = compression_functions[i];
-			auto &states = analyze_states[i];
-			for (idx_t j = 0; j < functions.size(); j++) {
-				auto &state = states[j];
-				auto &func = functions[j];
+	// If the compression type was explicitly specified at column definition time,
+	// the decision is already made — skip the entire analyze scan.
+	const bool skip_scan = (compression_type != CompressionType::COMPRESSION_AUTO);
 
-				if (!state) {
-					continue;
-				}
-				if (!func->analyze(*state, scan_vector)) {
-					state = nullptr;
-					func = nullptr;
+	if (!skip_scan) {
+		// scan over all the segments and run the analyze step
+		ScanSegments([&](Vector &scan_vector) {
+			for (idx_t i = 0; i < checkpoint_states.size(); i++) {
+				auto &functions = compression_functions[i];
+				auto &states = analyze_states[i];
+				for (idx_t j = 0; j < functions.size(); j++) {
+					auto &state = states[j];
+					auto &func = functions[j];
+
+					if (!state) {
+						continue;
+					}
+					if (!func->analyze(*state, scan_vector)) {
+						state = nullptr;
+						func = nullptr;
+					}
 				}
 			}
-		}
-	});
+		});
+	}
 
 	vector<CheckpointAnalyzeResult> result;
 	result.resize(checkpoint_states.size());


### PR DESCRIPTION
DuckDB by default auto detects the best compression algorithm to apply for column data when ingestion (i.e., `USING COMPRESSION BITPACKING`); it's useful for storage and query performance (because of less data to read).

In the current implementation, I found even when column is specified certain compression type, there's still analyze function eating up CPU; this PR skips the scan phase when specified.

I wrote a [benchmark](https://github.com/dentiny/duckdb/blob/cf3f6978ca35c06541087d65180f198e2f1a526e/benchmark/micro/appender_lineitem.cpp) to ingest 1M lineitem rows. The latency below is the wall-clock time spent on ingesting 1M rows in total.

| Case | Median | p10 | p90 | vs baseline |
|------|-------:|----:|----:|------------:|
| (1) Auto detection — baseline | 0.668s | 0.661s | 0.676s | — |
| (2) USING COMPRESSION — main branch DuckDB | 0.587s | 0.583s | 0.593s | −12.2% |
| (3) USING COMPRESSION + skip scan | 0.549s | 0.544s | 0.555s | −17.8% |