### PR TITLE
Prefetch DuckDB header on attach to cut redundant reads

### DIFF
--- a/src/common/file_buffer.cpp
+++ b/src/common/file_buffer.cpp
@@ -116,6 +116,11 @@ void FileBuffer::Read(QueryContext context, FileHandle &handle, uint64_t locatio
 	handle.Read(context, internal_buffer, internal_size, location);
 }
 
+void FileBuffer::ReadFromMemory(const_data_ptr_t source, uint64_t location) {
+	D_ASSERT(type != FileBufferType::TINY_BUFFER);
+	memcpy(internal_buffer, source + location, internal_size);
+}
+
 void FileBuffer::Read(QueryContext context, MemoryMappedFile &handle, uint64_t location) {
 	D_ASSERT(type != FileBufferType::TINY_BUFFER);
 	// Zero-copy: adopt a pointer into the mapping.

--- a/src/include/duckdb/common/file_buffer.hpp
+++ b/src/include/duckdb/common/file_buffer.hpp
@@ -42,8 +42,7 @@ public:
 	void Read(QueryContext context, FileHandle &handle, uint64_t location);
 	//! Read into the FileBuffer from a memory-mapped file at the location.
 	void Read(QueryContext context, MemoryMappedFile &handle, uint64_t location);
-	//! Read into the FileBuffer from an in-memory source at the location. The source must hold at least
-	//! location + AllocSize() bytes; callers verify coverage before calling.
+	//! Read into the FileBuffer from an in-memory source; the source must cover location + AllocSize() bytes.
 	void ReadFromMemory(const_data_ptr_t source, uint64_t location);
 	//! Write the FileBuffer to the location.
 	void Write(QueryContext context, FileHandle &handle, const uint64_t location);

--- a/src/include/duckdb/common/file_buffer.hpp
+++ b/src/include/duckdb/common/file_buffer.hpp
@@ -42,6 +42,9 @@ public:
 	void Read(QueryContext context, FileHandle &handle, uint64_t location);
 	//! Read into the FileBuffer from a memory-mapped file at the location.
 	void Read(QueryContext context, MemoryMappedFile &handle, uint64_t location);
+	//! Read into the FileBuffer from an in-memory source at the location. The source must hold at least
+	//! location + AllocSize() bytes; callers verify coverage before calling.
+	void ReadFromMemory(const_data_ptr_t source, uint64_t location);
 	//! Write the FileBuffer to the location.
 	void Write(QueryContext context, FileHandle &handle, const uint64_t location);
 	//! Write the FileBuffer to the location in a memory-mapped file.

--- a/src/include/duckdb/common/prefetched_file_data.hpp
+++ b/src/include/duckdb/common/prefetched_file_data.hpp
@@ -13,15 +13,10 @@
 
 namespace duckdb {
 
-//! A prefetched header prefix, read once while detecting the file type (magic bytes) and reused when the
-//! database is opened so the header reads are served from memory instead of issuing more reads. This mostly
-//! benefits remote files, where each read is a separate network request.
-//! Only the bytes are carried, not an open handle: the actual database handle is opened later (see
-//! DatabaseHandle::Open), so we never hold a handle to a file that may turn out to redirect elsewhere.
-//! The bytes are shared (read-only after capture) so the struct can ride along copyable option structs.
+//! Header bytes read once during file-type detection and reused when opening the database, so the header
+//! reads hit memory instead of re-reading (mainly helps remote files). Bytes only, no open handle.
 struct PrefetchedFileData {
-	//! Bytes prefetched from offset 0 (covers the MainHeader and both DatabaseHeaders). May be shorter than
-	//! requested for a small file.
+	//! Bytes prefetched from offset 0 (MainHeader + both DatabaseHeaders); may be shorter for a small file.
 	shared_ptr<const string> header;
 
 	//! Whether a usable prefetched header prefix is present.

--- a/src/include/duckdb/common/prefetched_file_data.hpp
+++ b/src/include/duckdb/common/prefetched_file_data.hpp
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/prefetched_file_data.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/shared_ptr.hpp"
+#include "duckdb/common/string.hpp"
+
+namespace duckdb {
+
+//! A prefetched header prefix, read once while detecting the file type (magic bytes) and reused when the
+//! database is opened so the header reads are served from memory instead of issuing more reads. This mostly
+//! benefits remote files, where each read is a separate network request.
+//! Only the bytes are carried, not an open handle: the actual database handle is opened later (see
+//! DatabaseHandle::Open), so we never hold a handle to a file that may turn out to redirect elsewhere.
+//! The bytes are shared (read-only after capture) so the struct can ride along copyable option structs.
+struct PrefetchedFileData {
+	//! Bytes prefetched from offset 0 (covers the MainHeader and both DatabaseHeaders). May be shorter than
+	//! requested for a small file.
+	shared_ptr<const string> header;
+
+	//! Whether a usable prefetched header prefix is present.
+	bool HasHeader() const {
+		return header && !header->empty();
+	}
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/main/attached_database.hpp
+++ b/src/include/duckdb/main/attached_database.hpp
@@ -87,8 +87,7 @@ struct AttachOptions {
 	unique_ptr<StoredDatabasePath> stored_database_path;
 	//! Per-database override of vacuum_rebuild_indexes. If not set, the global setting value is used.
 	optional_idx vacuum_rebuild_indexes_threshold;
-	//! Header bytes prefetched during file-type detection, reused when opening the database file so the header
-	//! reads hit memory instead of re-reading (mainly relevant for remote files). Empty for non-DuckDB files.
+	//! Header prefetched during file-type detection, reused when opening the file. Empty for non-DuckDB files.
 	PrefetchedFileData prefetched;
 };
 

--- a/src/include/duckdb/main/attached_database.hpp
+++ b/src/include/duckdb/main/attached_database.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "duckdb/common/prefetched_file_data.hpp"
 #include "duckdb/main/config.hpp"
 #include "duckdb/catalog/catalog_entry.hpp"
 #include "duckdb/main/valid_checker.hpp"
@@ -86,6 +87,9 @@ struct AttachOptions {
 	unique_ptr<StoredDatabasePath> stored_database_path;
 	//! Per-database override of vacuum_rebuild_indexes. If not set, the global setting value is used.
 	optional_idx vacuum_rebuild_indexes_threshold;
+	//! Header bytes prefetched during file-type detection, reused when opening the database file so the header
+	//! reads hit memory instead of re-reading (mainly relevant for remote files). Empty for non-DuckDB files.
+	PrefetchedFileData prefetched;
 };
 
 //! The AttachedDatabase represents an attached database instance.

--- a/src/include/duckdb/main/database_path_and_type.hpp
+++ b/src/include/duckdb/main/database_path_and_type.hpp
@@ -9,19 +9,24 @@
 #pragma once
 
 #include <string>
+#include "duckdb/common/optional_ptr.hpp"
 #include "duckdb/main/config.hpp"
 
 namespace duckdb {
 
 class QueryContext;
+struct PrefetchedFileData;
 
 struct DBPathAndType {
 	//! Parse database extension type and rest of path from combined form (type:path)
 	static void ExtractExtensionPrefix(string &path, string &db_type);
-	//! Check the magic bytes of a file and set the database type based on that
-	static void CheckMagicBytes(QueryContext context, FileSystem &fs, string &path, string &db_type);
+	//! Check the magic bytes of a file and set the database type based on that. If `out_prefetch` is set and
+	//! the file is a DuckDB database, the opened handle and prefetched header are returned through it.
+	static void CheckMagicBytes(QueryContext context, FileSystem &fs, string &path, string &db_type,
+	                            optional_ptr<PrefetchedFileData> out_prefetch = nullptr);
 
-	//! Run ExtractExtensionPrefix followed by CheckMagicBytes
-	static void ResolveDatabaseType(FileSystem &fs, string &path, string &db_type);
+	//! Run ExtractExtensionPrefix followed by CheckMagicBytes. Same `out_prefetch` semantics as CheckMagicBytes.
+	static void ResolveDatabaseType(FileSystem &fs, string &path, string &db_type,
+	                                optional_ptr<PrefetchedFileData> out_prefetch = nullptr);
 };
 } // namespace duckdb

--- a/src/include/duckdb/main/database_path_and_type.hpp
+++ b/src/include/duckdb/main/database_path_and_type.hpp
@@ -20,8 +20,8 @@ struct PrefetchedFileData;
 struct DBPathAndType {
 	//! Parse database extension type and rest of path from combined form (type:path)
 	static void ExtractExtensionPrefix(string &path, string &db_type);
-	//! Check the magic bytes of a file and set the database type based on that. If `out_prefetch` is set and
-	//! the file is a DuckDB database, the opened handle and prefetched header are returned through it.
+	//! Check the magic bytes of a file and set the database type. For a DuckDB file, the prefetched header is
+	//! returned through `out_prefetch` when set.
 	static void CheckMagicBytes(QueryContext context, FileSystem &fs, string &path, string &db_type,
 	                            optional_ptr<PrefetchedFileData> out_prefetch = nullptr);
 

--- a/src/include/duckdb/storage/database_handle.hpp
+++ b/src/include/duckdb/storage/database_handle.hpp
@@ -22,9 +22,8 @@ struct DatabaseHandle {
 	explicit DatabaseHandle(unique_ptr<FileHandle> handle);
 	explicit DatabaseHandle(unique_ptr<MemoryMappedFile> mmap_handle);
 
-	//! Open a fresh handle for the database file. If `options.prefetched` carries a header prefix read earlier
-	//! during file-type detection, it is adopted to serve the initial header reads from memory instead of
-	//! re-reading them from the (possibly remote) file.
+	//! Open a fresh handle for the database file. A header prefix in `options.prefetched` (from file-type
+	//! detection) is adopted to serve the initial header reads from memory.
 	static unique_ptr<DatabaseHandle> Open(AttachedDatabase &db, const string &path,
 	                                       const StorageManagerOptions &options, DatabaseOpenMode open_mode);
 	bool OnDiskFile() const;
@@ -53,8 +52,7 @@ private:
 	unique_ptr<FileHandle> handle;
 	//! Memory-mapped view of the file in MAP mode. Mutually exclusive with `handle`.
 	unique_ptr<MemoryMappedFile> mmap_handle;
-	//! Bytes prefetched from offset 0 during file-type detection. Reads fully covered by it are served from
-	//! memory (only the initial header reads qualify); everything else goes to `handle`.
+	//! Bytes prefetched from offset 0; reads fully covered by it are served from memory, the rest go to `handle`.
 	shared_ptr<const string> prefetched_header;
 };
 

--- a/src/include/duckdb/storage/database_handle.hpp
+++ b/src/include/duckdb/storage/database_handle.hpp
@@ -22,6 +22,9 @@ struct DatabaseHandle {
 	explicit DatabaseHandle(unique_ptr<FileHandle> handle);
 	explicit DatabaseHandle(unique_ptr<MemoryMappedFile> mmap_handle);
 
+	//! Open a fresh handle for the database file. If `options.prefetched` carries a header prefix read earlier
+	//! during file-type detection, it is adopted to serve the initial header reads from memory instead of
+	//! re-reading them from the (possibly remote) file.
 	static unique_ptr<DatabaseHandle> Open(AttachedDatabase &db, const string &path,
 	                                       const StorageManagerOptions &options, DatabaseOpenMode open_mode);
 	bool OnDiskFile() const;
@@ -50,6 +53,9 @@ private:
 	unique_ptr<FileHandle> handle;
 	//! Memory-mapped view of the file in MAP mode. Mutually exclusive with `handle`.
 	unique_ptr<MemoryMappedFile> mmap_handle;
+	//! Bytes prefetched from offset 0 during file-type detection. Reads fully covered by it are served from
+	//! memory (only the initial header reads qualify); everything else goes to `handle`.
+	shared_ptr<const string> prefetched_header;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/magic_bytes.hpp
+++ b/src/include/duckdb/storage/magic_bytes.hpp
@@ -9,10 +9,12 @@
 #pragma once
 
 #include "duckdb/common/common.hpp"
+#include "duckdb/common/optional_ptr.hpp"
 
 namespace duckdb {
 class FileSystem;
 class QueryContext;
+struct PrefetchedFileData;
 
 enum class DataFileType : uint8_t {
 	FILE_DOES_NOT_EXIST, // file does not exist
@@ -24,7 +26,11 @@ enum class DataFileType : uint8_t {
 
 class MagicBytes {
 public:
-	static DataFileType CheckMagicBytes(QueryContext context, FileSystem &fs, const string &path);
+	//! Detect the file type at `path` by reading its magic bytes. When `out_prefetch` is set and the file is a
+	//! DuckDB database, the opened handle and a prefetched header prefix are returned through it, so a later
+	//! storage open can reuse them instead of issuing a second open and re-reading the header.
+	static DataFileType CheckMagicBytes(QueryContext context, FileSystem &fs, const string &path,
+	                                    optional_ptr<PrefetchedFileData> out_prefetch = nullptr);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/magic_bytes.hpp
+++ b/src/include/duckdb/storage/magic_bytes.hpp
@@ -26,9 +26,8 @@ enum class DataFileType : uint8_t {
 
 class MagicBytes {
 public:
-	//! Detect the file type at `path` by reading its magic bytes. When `out_prefetch` is set and the file is a
-	//! DuckDB database, the opened handle and a prefetched header prefix are returned through it, so a later
-	//! storage open can reuse them instead of issuing a second open and re-reading the header.
+	//! Detect the file type at `path` from its magic bytes. For a DuckDB file, a prefetched header prefix is
+	//! returned through `out_prefetch` (when set) so a later storage open reuses it instead of re-reading.
 	static DataFileType CheckMagicBytes(QueryContext context, FileSystem &fs, const string &path,
 	                                    optional_ptr<PrefetchedFileData> out_prefetch = nullptr);
 };

--- a/src/include/duckdb/storage/single_file_block_manager.hpp
+++ b/src/include/duckdb/storage/single_file_block_manager.hpp
@@ -59,8 +59,7 @@ struct StorageManagerOptions {
 	//! Unique database identifier and optional encryption salt.
 	data_t db_identifier[MainHeader::DB_IDENTIFIER_LEN];
 	EncryptionOptions encryption_options;
-	//! Header bytes prefetched during file-type detection. When set, DatabaseHandle::Open reuses them to serve
-	//! the initial header reads from memory instead of re-reading. Empty unless opened via ATTACH.
+	//! Header prefetched during file-type detection; DatabaseHandle::Open reuses it. Empty unless opened via ATTACH.
 	PrefetchedFileData prefetched;
 };
 

--- a/src/include/duckdb/storage/single_file_block_manager.hpp
+++ b/src/include/duckdb/storage/single_file_block_manager.hpp
@@ -12,6 +12,7 @@
 #include "duckdb/storage/block.hpp"
 #include "duckdb/storage/storage_options.hpp"
 #include "duckdb/common/file_system.hpp"
+#include "duckdb/common/prefetched_file_data.hpp"
 #include "duckdb/common/memory_mapped_file.hpp"
 #include "duckdb/common/unordered_set.hpp"
 #include "duckdb/common/set.hpp"
@@ -58,6 +59,9 @@ struct StorageManagerOptions {
 	//! Unique database identifier and optional encryption salt.
 	data_t db_identifier[MainHeader::DB_IDENTIFIER_LEN];
 	EncryptionOptions encryption_options;
+	//! Header bytes prefetched during file-type detection. When set, DatabaseHandle::Open reuses them to serve
+	//! the initial header reads from memory instead of re-reading. Empty unless opened via ATTACH.
+	PrefetchedFileData prefetched;
 };
 
 //! SingleFileBlockManager is an implementation for a BlockManager which manages blocks in a single file

--- a/src/include/duckdb/storage/storage_manager.hpp
+++ b/src/include/duckdb/storage/storage_manager.hpp
@@ -186,8 +186,7 @@ protected:
 	atomic<idx_t> wal_entries_count;
 	//! Storage options passed in through configuration
 	StorageOptions storage_options;
-	//! Header bytes prefetched during file-type detection, consumed by LoadDatabase so the header reads hit
-	//! memory instead of re-reading. Empty unless this is a DuckDB file opened via ATTACH.
+	//! Header prefetched during file-type detection, consumed by LoadDatabase. Empty unless a DuckDB file via ATTACH.
 	PrefetchedFileData prefetched_file;
 
 public:

--- a/src/include/duckdb/storage/storage_manager.hpp
+++ b/src/include/duckdb/storage/storage_manager.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "duckdb/common/prefetched_file_data.hpp"
 #include "duckdb/common/helper.hpp"
 #include "duckdb/storage/table_io_manager.hpp"
 #include "duckdb/storage/write_ahead_log.hpp"
@@ -185,6 +186,9 @@ protected:
 	atomic<idx_t> wal_entries_count;
 	//! Storage options passed in through configuration
 	StorageOptions storage_options;
+	//! Header bytes prefetched during file-type detection, consumed by LoadDatabase so the header reads hit
+	//! memory instead of re-reading. Empty unless this is a DuckDB file opened via ATTACH.
+	PrefetchedFileData prefetched_file;
 
 public:
 	template <class TARGET>

--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -387,7 +387,8 @@ void DatabaseManager::GetDatabaseType(ClientContext &context, AttachInfo &info, 
 	// Try to extract the database type from the path.
 	if (options.db_type.empty()) {
 		auto &fs = FileSystem::GetFileSystem(context);
-		DBPathAndType::CheckMagicBytes(context, fs, info.path, options.db_type);
+		// Prefetch the header for a DuckDB file, reused when opening it (see AttachOptions::prefetched).
+		DBPathAndType::CheckMagicBytes(context, fs, info.path, options.db_type, &options.prefetched);
 	}
 
 	if (options.db_type.empty()) {

--- a/src/main/database_path_and_type.cpp
+++ b/src/main/database_path_and_type.cpp
@@ -19,9 +19,10 @@ void DBPathAndType::ExtractExtensionPrefix(string &path, string &db_type) {
 	}
 }
 
-void DBPathAndType::CheckMagicBytes(QueryContext context, FileSystem &fs, string &path, string &db_type) {
+void DBPathAndType::CheckMagicBytes(QueryContext context, FileSystem &fs, string &path, string &db_type,
+                                    optional_ptr<PrefetchedFileData> out_prefetch) {
 	// if there isn't - check the magic bytes of the file (if any)
-	auto file_type = MagicBytes::CheckMagicBytes(context, fs, path);
+	auto file_type = MagicBytes::CheckMagicBytes(context, fs, path, out_prefetch);
 	db_type = string();
 	switch (file_type) {
 	case DataFileType::SQLITE_FILE:
@@ -42,7 +43,8 @@ void DBPathAndType::CheckMagicBytes(QueryContext context, FileSystem &fs, string
 	}
 }
 
-void DBPathAndType::ResolveDatabaseType(FileSystem &fs, string &path, string &db_type) {
+void DBPathAndType::ResolveDatabaseType(FileSystem &fs, string &path, string &db_type,
+                                        optional_ptr<PrefetchedFileData> out_prefetch) {
 	if (!db_type.empty()) {
 		// database type specified explicitly - no need to check
 		return;
@@ -54,7 +56,7 @@ void DBPathAndType::ResolveDatabaseType(FileSystem &fs, string &path, string &db
 		return;
 	}
 	// check database type by reading the magic bytes of a file
-	DBPathAndType::CheckMagicBytes(QueryContext(), fs, path, db_type);
+	DBPathAndType::CheckMagicBytes(QueryContext(), fs, path, db_type, out_prefetch);
 }
 
 } // namespace duckdb

--- a/src/storage/database_handle.cpp
+++ b/src/storage/database_handle.cpp
@@ -1,6 +1,8 @@
 #include "duckdb/storage/database_handle.hpp"
 #include "duckdb/storage/single_file_block_manager.hpp"
 
+#include <cstring>
+
 namespace duckdb {
 
 DatabaseHandle::DatabaseHandle(unique_ptr<FileHandle> handle_p) : handle(std::move(handle_p)) {
@@ -11,6 +13,7 @@ DatabaseHandle::DatabaseHandle(unique_ptr<MemoryMappedFile> mmap_handle_p) : mma
 unique_ptr<DatabaseHandle> DatabaseHandle::Open(AttachedDatabase &db, const string &path,
                                                 const StorageManagerOptions &options, DatabaseOpenMode open_mode) {
 	if (options.io_mode == FileIOMode::MMAP) {
+		// mmap reads are zero-copy from the mapping, so the prefetched header is not needed here.
 		return OpenMemoryMap(db, path, options, open_mode);
 	} else {
 		return OpenFile(db, path, options, open_mode);
@@ -42,7 +45,13 @@ unique_ptr<DatabaseHandle> DatabaseHandle::OpenFile(AttachedDatabase &db, const 
 		// this can only happen in read-only mode - as that is when we set FILE_FLAGS_NULL_IF_NOT_EXISTS
 		throw IOException("Cannot open database \"%s\" in read-only mode: database does not exist", path);
 	}
-	return make_uniq<DatabaseHandle>(std::move(file_handle));
+
+	auto result = make_uniq<DatabaseHandle>(std::move(file_handle));
+	// Adopt the prefetched header bytes (if any) to serve the initial header reads from memory.
+	if (options.prefetched.HasHeader()) {
+		result->prefetched_header = options.prefetched.header;
+	}
+	return result;
 }
 
 unique_ptr<DatabaseHandle> DatabaseHandle::OpenMemoryMap(AttachedDatabase &db, const string &path,
@@ -86,17 +95,31 @@ bool DatabaseHandle::OnDiskFile() const {
 void DatabaseHandle::CheckMagicBytes(QueryContext context) {
 	if (mmap_handle) {
 		MainHeader::CheckMagicBytes(*mmap_handle);
-	} else {
-		MainHeader::CheckMagicBytes(context, *handle);
+		return;
 	}
+	// Verify against the prefetched header when it covers the magic-byte range.
+	const idx_t magic_end = MainHeader::MAGIC_BYTE_OFFSET + MainHeader::MAGIC_BYTE_SIZE;
+	if (prefetched_header && prefetched_header->size() >= magic_end) {
+		if (memcmp(prefetched_header->data() + MainHeader::MAGIC_BYTE_OFFSET, MainHeader::MAGIC_BYTES,
+		           MainHeader::MAGIC_BYTE_SIZE) != 0) {
+			throw IOException("The file \"%s\" exists, but it is not a valid DuckDB database file!", handle->GetPath());
+		}
+		return;
+	}
+	MainHeader::CheckMagicBytes(context, *handle);
 }
 
 void DatabaseHandle::Read(QueryContext context, FileBuffer &block, uint64_t location) const {
 	if (mmap_handle) {
 		block.Read(context, *mmap_handle, location);
-	} else {
-		block.Read(context, *handle, location);
+		return;
 	}
+	// Serve fully-covered reads from the prefetched header (only the first few header reads qualify).
+	if (prefetched_header && location + block.AllocSize() <= prefetched_header->size()) {
+		block.ReadFromMemory(const_data_ptr_cast(prefetched_header->data()), location);
+		return;
+	}
+	block.Read(context, *handle, location);
 }
 
 void DatabaseHandle::Write(QueryContext context, FileBuffer &buffer, uint64_t location) {

--- a/src/storage/magic_bytes.cpp
+++ b/src/storage/magic_bytes.cpp
@@ -10,8 +10,7 @@
 namespace duckdb {
 
 static constexpr idx_t MAGIC_BYTES_READ_SIZE = 16;
-//! MainHeader + 2 DatabaseHeaders (3 x FILE_HEADER_SIZE). Prefetched so a later storage open can serve the
-//! header reads from memory instead of issuing more requests.
+//! MainHeader + 2 DatabaseHeaders; prefetched so a later storage open serves the header reads from memory.
 static constexpr idx_t HEADER_PREFETCH_SIZE = 3 * Storage::FILE_HEADER_SIZE;
 
 static DataFileType ClassifyMagicBytes(const char *buffer) {
@@ -33,10 +32,8 @@ DataFileType MagicBytes::CheckMagicBytes(QueryContext context, FileSystem &fs, c
 		return DataFileType::DUCKDB_FILE;
 	}
 
-	// The handle is only used to read the header here and is closed on return: we deliberately do not keep it
-	// open, so the actual database handle is opened later (allowing a DuckDB file to eventually redirect to a
-	// different database). When a prefetch is requested we read the whole header region in one go instead of
-	// just the magic bytes, so the later open can serve the header reads from these bytes.
+	// The handle only reads the header and is closed on return; the database handle is opened later. On prefetch
+	// we read the whole header region at once so the later open can serve the header reads from these bytes.
 	auto handle = fs.OpenFile(path, FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS);
 	if (!handle) {
 		return DataFileType::FILE_DOES_NOT_EXIST;
@@ -53,8 +50,7 @@ DataFileType MagicBytes::CheckMagicBytes(QueryContext context, FileSystem &fs, c
 
 	auto file_type = ClassifyMagicBytes(buffer.get());
 
-	// Hand the prefetched header (bytes only, not the handle) to the caller for actual DuckDB files. Only the
-	// `to_read` valid bytes are kept, so a small file does not report zero-padded coverage to the reader.
+	// Hand the prefetched header bytes to the caller for DuckDB files. Only the `to_read` valid bytes are kept.
 	if (out_prefetch && file_type == DataFileType::DUCKDB_FILE) {
 		out_prefetch->header = make_shared_ptr<const string>(buffer.get(), to_read);
 	}

--- a/src/storage/magic_bytes.cpp
+++ b/src/storage/magic_bytes.cpp
@@ -1,23 +1,20 @@
 #include "duckdb/storage/magic_bytes.hpp"
+#include "duckdb/common/file_system.hpp"
+#include "duckdb/common/helper.hpp"
+#include "duckdb/common/prefetched_file_data.hpp"
 #include "duckdb/main/client_context.hpp"
-#include "duckdb/common/local_file_system.hpp"
 #include "duckdb/storage/storage_info.hpp"
+
+#include <cstring>
 
 namespace duckdb {
 
-DataFileType MagicBytes::CheckMagicBytes(QueryContext context, FileSystem &fs, const string &path) {
-	if (path.empty() || path == IN_MEMORY_PATH) {
-		return DataFileType::DUCKDB_FILE;
-	}
-	auto handle = fs.OpenFile(path, FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS);
-	if (!handle) {
-		return DataFileType::FILE_DOES_NOT_EXIST;
-	}
+static constexpr idx_t MAGIC_BYTES_READ_SIZE = 16;
+//! MainHeader + 2 DatabaseHeaders (3 x FILE_HEADER_SIZE). Prefetched so a later storage open can serve the
+//! header reads from memory instead of issuing more requests.
+static constexpr idx_t HEADER_PREFETCH_SIZE = 3 * Storage::FILE_HEADER_SIZE;
 
-	constexpr const idx_t MAGIC_BYTES_READ_SIZE = 16;
-	char buffer[MAGIC_BYTES_READ_SIZE] = {};
-
-	handle->Read(context, buffer, MAGIC_BYTES_READ_SIZE);
+static DataFileType ClassifyMagicBytes(const char *buffer) {
 	if (memcmp(buffer, "SQLite format 3\0", 16) == 0) {
 		return DataFileType::SQLITE_FILE;
 	}
@@ -28,6 +25,40 @@ DataFileType MagicBytes::CheckMagicBytes(QueryContext context, FileSystem &fs, c
 		return DataFileType::DUCKDB_FILE;
 	}
 	return DataFileType::UNKNOWN_FILE;
+}
+
+DataFileType MagicBytes::CheckMagicBytes(QueryContext context, FileSystem &fs, const string &path,
+                                         optional_ptr<PrefetchedFileData> out_prefetch) {
+	if (path.empty() || path == IN_MEMORY_PATH) {
+		return DataFileType::DUCKDB_FILE;
+	}
+
+	// The handle is only used to read the header here and is closed on return: we deliberately do not keep it
+	// open, so the actual database handle is opened later (allowing a DuckDB file to eventually redirect to a
+	// different database). When a prefetch is requested we read the whole header region in one go instead of
+	// just the magic bytes, so the later open can serve the header reads from these bytes.
+	auto handle = fs.OpenFile(path, FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS);
+	if (!handle) {
+		return DataFileType::FILE_DOES_NOT_EXIST;
+	}
+
+	// Zero-initialized so a short read at EOF still yields a well-defined (non-matching) classification.
+	const idx_t read_size = out_prefetch ? HEADER_PREFETCH_SIZE : MAGIC_BYTES_READ_SIZE;
+	auto buffer = make_unsafe_uniq_array<char>(read_size);
+	memset(buffer.get(), 0, read_size);
+	const idx_t to_read = MinValue<idx_t>(read_size, handle->GetFileSize());
+	if (to_read > 0) {
+		handle->Read(context, buffer.get(), to_read, 0);
+	}
+
+	auto file_type = ClassifyMagicBytes(buffer.get());
+
+	// Hand the prefetched header (bytes only, not the handle) to the caller for actual DuckDB files. Only the
+	// `to_read` valid bytes are kept, so a small file does not report zero-padded coverage to the reader.
+	if (out_prefetch && file_type == DataFileType::DUCKDB_FILE) {
+		out_prefetch->header = make_shared_ptr<const string>(buffer.get(), to_read);
+	}
+	return file_type;
 }
 
 } // namespace duckdb

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -524,8 +524,7 @@ void SingleFileStorageManager::LoadDatabase(QueryContext context) {
 			options.block_header_size = config.options.default_block_header_size;
 		}
 
-		// Carry the header prefetched during file-type detection into the block manager options, so the initial
-		// header reads are served from memory instead of re-reading them from the (possibly remote) file.
+		// Carry the prefetched header into the block manager options so the initial header reads hit memory.
 		options.prefetched = std::move(prefetched_file);
 
 		// Initialize the block manager while loading the database file.

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -154,7 +154,8 @@ void StorageOptions::Initialize(unordered_map<string, Value> &options) {
 }
 
 StorageManager::StorageManager(AttachedDatabase &db, string path_p, AttachOptions &options)
-    : db(db), path(std::move(path_p)), read_only(options.access_mode == AccessMode::READ_ONLY), wal_size(0) {
+    : db(db), path(std::move(path_p)), read_only(options.access_mode == AccessMode::READ_ONLY), wal_size(0),
+      prefetched_file(std::move(options.prefetched)) {
 	if (path.empty()) {
 		path = IN_MEMORY_PATH;
 		return;
@@ -522,6 +523,10 @@ void SingleFileStorageManager::LoadDatabase(QueryContext context) {
 			// No explicit option provided: use the default option.
 			options.block_header_size = config.options.default_block_header_size;
 		}
+
+		// Carry the header prefetched during file-type detection into the block manager options, so the initial
+		// header reads are served from memory instead of re-reading them from the (possibly remote) file.
+		options.prefetched = std::move(prefetched_file);
 
 		// Initialize the block manager while loading the database file.
 		// We'll construct the SingleFileBlockManager with the default block allocation size,

--- a/test/sql/attach/attach_prefetch_header.test
+++ b/test/sql/attach/attach_prefetch_header.test
@@ -1,0 +1,72 @@
+# name: test/sql/attach/attach_prefetch_header.test
+# description: Attaching a DuckDB file serves the initial header reads from bytes prefetched during file-type detection
+# group: [attach]
+
+# Populate a database file, then detach so it is closed on disk.
+statement ok
+ATTACH '{TEST_DIR}/attach_prefetch_header.db' AS db1
+
+statement ok
+CREATE TABLE db1.integers AS SELECT range AS i FROM range(10000);
+
+statement ok
+CREATE TABLE db1.strings AS SELECT 'v' || range::VARCHAR AS s FROM range(1000);
+
+statement ok
+DETACH db1
+
+# Re-attach read-only: the header prefetched during the magic-byte check serves the initial header reads;
+# the database handle itself is opened fresh (late), so no handle is carried over from type detection.
+statement ok
+ATTACH '{TEST_DIR}/attach_prefetch_header.db' AS db1 (READ_ONLY)
+
+query I
+SELECT COUNT(*) FROM db1.integers
+----
+10000
+
+query I
+SELECT SUM(i) FROM db1.integers
+----
+49995000
+
+query I
+SELECT COUNT(*) FROM db1.strings
+----
+1000
+
+statement ok
+DETACH db1
+
+# Re-attach read-write: a fresh read-write handle is opened, and the prefetched header bytes still serve the
+# initial header reads. Verify the data is intact and the database remains writable.
+statement ok
+ATTACH '{TEST_DIR}/attach_prefetch_header.db' AS db1 (READ_WRITE)
+
+query I
+SELECT COUNT(*) FROM db1.integers
+----
+10000
+
+statement ok
+INSERT INTO db1.integers VALUES (10000)
+
+query I
+SELECT COUNT(*) FROM db1.integers
+----
+10001
+
+statement ok
+DETACH db1
+
+# Attaching a non-DuckDB file must still work (prefetch is not populated for these).
+statement ok
+COPY (SELECT 42 AS a) TO '{TEST_DIR}/attach_prefetch_header.csv' (FORMAT CSV, HEADER)
+
+statement ok
+ATTACH '{TEST_DIR}/attach_prefetch_header.csv' AS c
+
+query I
+SELECT a FROM c.file
+----
+42


### PR DESCRIPTION
This reimplements #22359.

When attaching a DuckDB database, the file was opened once to detect its type (magic bytes) and then re-opened to read the header, issuing several separate reads. For remote files each read is a network request, so this adds avoidable round-trips.

While detecting the file type, read the whole header region in one go (MainHeader + both DatabaseHeaders, 3 x 4 KiB) and carry those bytes on AttachOptions. When the storage layer later opens the database, the initial header reads are served from the prefetched bytes instead of re-reading.

Only the bytes are kept, not the open handle: the actual database handle is opened later, so we never hold a handle to a file during type detection. 

```sql
 ATTACH 'http://127.0.0.1:8080/empty.db';
```
we (that is, duckdb `main` branch) currently performs:
```
HeadRequest         https://blobs.duckdb.org/data/tpch-sf1.db
GetRangeRequest 	https://blobs.duckdb.org/data/tpch-sf1.db       (start=0, len=12288)
HeadRequest         https://blobs.duckdb.org/data/tpch-sf1.db
GetRangeRequest 	https://blobs.duckdb.org/data/tpch-sf1.db	    8	4
GetRangeRequest 	https://blobs.duckdb.org/data/tpch-sf1.db	    0	4096
GetRangeRequest 	https://blobs.duckdb.org/data/tpch-sf1.db	    4096	4096
GetRangeRequest 	https://blobs.duckdb.org/data/tpch-sf1.db	    8192	4096
HeadRequest         https://blobs.duckdb.org/data/tpch-sf1.db.wal
```

After this PR, 4 range requests are removed, to:
```
HeadRequest         https://blobs.duckdb.org/data/tpch-sf1.db
GetRangeRequest 	https://blobs.duckdb.org/data/tpch-sf1.db	    (start=0, len= 12288)
HeadRequest         https://blobs.duckdb.org/data/tpch-sf1.db
HeadRequest         https://blobs.duckdb.org/data/tpch-sf1.db.wal
```
There is a way to cut also 1st and 3rd request, so moving 8 -> 4 -> 2 requests.