### PR TITLE
Fix string length stats propagation

### DIFF
--- a/src/function/scalar/string/length.cpp
+++ b/src/function/scalar/string/length.cpp
@@ -1,6 +1,10 @@
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/numeric_utils.hpp"
 #include "duckdb/common/types/bit.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
+#include "duckdb/storage/statistics/base_statistics.hpp"
+#include "duckdb/storage/statistics/numeric_stats.hpp"
+#include "duckdb/storage/statistics/string_stats.hpp"
 #include "duckdb/function/scalar/string_common.hpp"
 #include "duckdb/function/scalar/string_functions.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
@@ -61,11 +65,32 @@ unique_ptr<BaseStatistics> LengthPropagateStats(ClientContext &context, Function
 	auto &child_stats = input.child_stats;
 	auto &expr = input.expr;
 	D_ASSERT(child_stats.size() == 1);
-	// can only propagate stats if the children have stats
-	if (!StringStats::CanContainUnicode(child_stats[0])) {
+	const bool can_contain_unicode = StringStats::CanContainUnicode(child_stats[0]);
+	if (!can_contain_unicode) {
 		expr.FunctionMutable().SetFunctionCallback(ScalarFunction::UnaryFunction<string_t, int64_t, StrLenOperator>);
 	}
-	return nullptr;
+	if (!StringStats::HasMaxStringLength(child_stats[0])) {
+		return nullptr;
+	}
+
+	// String stats are stored as byte length, so we need to convert to character length
+	const auto max_length = NumericCast<int64_t>(StringStats::MaxStringLength(child_stats[0]));
+	int64_t min_length = 0;
+	auto min_string_length = StringStats::MinStringLength(child_stats[0]);
+	if (min_string_length.IsValid()) {
+		if (!can_contain_unicode) {
+			// ASCII-only: the character count is exactly the byte count
+			min_length = NumericCast<int64_t>(min_string_length.GetIndex());
+		} else if (min_string_length.GetIndex() > 0) {
+			// non-empty strings contain at least one character
+			min_length = 1;
+		}
+	}
+	auto result = NumericStats::CreateEmpty(expr.GetReturnType());
+	NumericStats::SetMin(result, Value::BIGINT(min_length));
+	NumericStats::SetMax(result, Value::BIGINT(max_length));
+	result.CopyValidity(child_stats[0]);
+	return result.ToUnique();
 }
 
 //------------------------------------------------------------------

--- a/test/optimizer/statistics/statistics_string_length.test
+++ b/test/optimizer/statistics/statistics_string_length.test
@@ -1,0 +1,14 @@
+# name: test/optimizer/statistics/statistics_string_length.test
+# description: Statistics propagation for the length function based on string length statistics
+# group: [statistics]
+
+statement ok
+CREATE TABLE strings AS
+SELECT 'user_' || lpad(i::VARCHAR, 10, '0') AS v
+FROM range(0, 100000) tbl(i);
+
+# every string is exactly 15 characters - length(v) > 30 can be pruned entirely
+query II
+EXPLAIN SELECT count(*) FROM strings WHERE length(v) > 30;
+----
+physical_plan	<REGEX>:.*Empty Result.*


### PR DESCRIPTION
Closes https://github.com/duckdb/duckdb/issues/23614

Current implementation returns NULL directly, which means stats gets ignored.