### PR TITLE
Clamp derived decimal width in Variant shredding analysis

### DIFF
--- a/extension/parquet/writer/variant/analyze_variant.cpp
+++ b/extension/parquet/writer/variant/analyze_variant.cpp
@@ -11,6 +11,7 @@
 #include "duckdb/common/helper.hpp"
 #include "duckdb/common/typedefs.hpp"
 #include "duckdb/common/types.hpp"
+#include "duckdb/common/types/decimal.hpp"
 #include "duckdb/common/types/string_type.hpp"
 #include "duckdb/common/types/variant.hpp"
 #include "duckdb/common/types/vector.hpp"
@@ -122,8 +123,22 @@ static void CheckPrimitive(const VariantAnalyzeData &state, ShredAnalysisState &
 		if (!state.decimal_consistent) {
 			return;
 		}
+		//! The Variant encoding does not store a precision, so the analyzed width is derived from the
+		//! values and can be invalid for Parquet: a zero value derives a width of 0, and a width below
+		//! the scale is invalid as well. Clamp it up; if the clamped width exceeds the decimal range,
+		//! don't shred as decimal.
+		auto width = state.decimal_width;
+		if (width < 1) {
+			width = 1;
+		}
+		if (width < state.decimal_scale) {
+			width = state.decimal_scale;
+		}
+		if (width > Decimal::MAX_WIDTH_DECIMAL) {
+			return;
+		}
 		result.highest_count = count;
-		result.type = LogicalType::DECIMAL(state.decimal_width, state.decimal_scale);
+		result.type = LogicalType::DECIMAL(static_cast<uint8_t>(width), static_cast<uint8_t>(state.decimal_scale));
 	} else {
 		result.highest_count = count;
 		result.type = SHREDDED_TYPE;

--- a/test/sql/copy/parquet/shredded_variant_decimal_width.test
+++ b/test/sql/copy/parquet/shredded_variant_decimal_width.test
@@ -1,0 +1,34 @@
+# name: test/sql/copy/parquet/shredded_variant_decimal_width.test
+# group: [parquet]
+
+require parquet
+
+# The Variant encoding does not store a decimal precision - the shredding analysis derives it
+# from the values. Zero-valued decimals derive a width of 0, which used to produce an invalid
+# Parquet DECIMAL annotation (precision must be >= 1 and >= scale) that strict readers reject.
+# Round-trip through the binary Variant encoding to force the derived-width path: the mixed
+# types keep the decimals unshredded in the 'value' blob on the first write.
+
+statement ok
+COPY (
+    SELECT CASE WHEN i % 3 = 0 THEN 0.00::DECIMAL(4,2)::VARIANT ELSE ('x' || i)::VARIANT END AS col
+    FROM range(9) t(i)
+) TO '{TEST_DIR}/canonical_zero_decimals.parquet'
+
+# The all-decimal rewrite shreds them as a typed decimal column; the derived width of the
+# zero values must be clamped to a valid precision (>= max(1, scale)).
+statement ok
+COPY (
+    SELECT col FROM '{TEST_DIR}/canonical_zero_decimals.parquet'
+    WHERE variant_typeof(col) LIKE 'DECIMAL%'
+) TO '{TEST_DIR}/shredded_zero_decimals.parquet'
+
+query II
+SELECT precision, scale FROM parquet_schema('{TEST_DIR}/shredded_zero_decimals.parquet') WHERE precision IS NOT NULL
+----
+2	2
+
+query I
+SELECT count(*) FROM '{TEST_DIR}/shredded_zero_decimals.parquet' WHERE col = 0.00::DECIMAL(4,2)::VARIANT
+----
+3


### PR DESCRIPTION
## Variant shredding: clamp the derived decimal width to a valid Parquet precision

The Variant binary encoding doesn't store a decimal precision, so the shredding analysis derives one from the values (`floor(log10(v)) + 1`). Two ways this can produce an invalid Parquet `DECIMAL` annotation:

- an all-zero decimal field with scale >= 2: a zero value derives one digit of width, so the analysis builds `DECIMAL(1, 2)` — scale exceeding precision, which the Parquet spec disallows and which trips `D_ASSERT(width >= scale)` in `LogicalType::DECIMAL` on debug builds;
- re-writing a file whose schema already carries an invalid precision (older writers could stamp `precision = 0` for zero-valued decimals): the shredded read path takes the width from the file schema, so the invalid annotation is reproduced on every rewrite.

DuckDB itself tolerates these files, but strict Parquet readers refuse to open them at footer parse — pyarrow with `Precision must be greater than or equal to 1 for Decimal logical type`, parquet-rs with `Invalid DECIMAL precision: 0`.

This PR clamps the analyzed width to `max(width, scale, 1)` before constructing the shredded type, and skips shredding as decimal if the clamped width exceeds `Decimal::MAX_WIDTH_DECIMAL`. Clamping only ever widens the container, so the stored values are unaffected. Includes a round-trip regression test with zero-valued decimals that fails without the clamp.
