### PR TITLE
Address test warning

### DIFF
--- a/test/sql/function/date/date_diff_extreme_dates.test
+++ b/test/sql/function/date/date_diff_extreme_dates.test
@@ -2,9 +2,6 @@
 # description: Test datediff with extreme date ranges that previously overflowed
 # group: [date]
 
-statement ok
-PRAGMA enable_verification
-
 # Bug fix: datediff('week') used int32 subtraction of date.days which overflowed
 # for dates spanning the full int32 range, producing 0 instead of ~613 million
 query I

--- a/test/sql/function/date/date_part_stats.test
+++ b/test/sql/function/date/date_part_stats.test
@@ -135,7 +135,7 @@ endloop
 foreach type DATE TIMESTAMP TIMESTAMP_S TIMESTAMP_MS TIMESTAMP_NS
 
 statement ok
-CREATE TABLE t0(c0 ${type});
+CREATE TABLE t0(c0 {type});
 
 statement ok
 INSERT INTO t0(c0) VALUES ('-infinity'), ('infinity');

--- a/test/sql/function/string/test_ilike_constant_pattern.test
+++ b/test/sql/function/string/test_ilike_constant_pattern.test
@@ -2,9 +2,6 @@
 # description: ILIKE / NOT ILIKE with a constant (CONSTANT_VECTOR) pattern over many rows - exercises the case-folded matcher fast path
 # group: [string]
 
-statement ok
-PRAGMA enable_verification
-
 # Unicode-possible data so the constant-pattern ILIKE takes the case-folding path
 # (the ASCII-only fast path is taken when stats prove the column cannot contain unicode).
 statement ok

--- a/test/sql/function/string/test_ilike_escape_constant_pattern.test
+++ b/test/sql/function/string/test_ilike_escape_constant_pattern.test
@@ -2,9 +2,6 @@
 # description: ILIKE / NOT ILIKE ... ESCAPE with a constant pattern over many rows - exercises the case-folded matcher fast path (escape no-op) and the escape-aware fallback
 # group: [string]
 
-statement ok
-PRAGMA enable_verification
-
 # Unicode-possible data so the constant-pattern ILIKE ... ESCAPE takes the case-folding path.
 statement ok
 CREATE TABLE t(id INTEGER, s VARCHAR);

--- a/test/sql/function/time/test_time_bucket_time.test
+++ b/test/sql/function/time/test_time_bucket_time.test
@@ -3,9 +3,6 @@
 # group: [time]
 
 statement ok
-PRAGMA enable_verification
-
-statement ok
 CREATE TABLE times(w INTERVAL, t TIME, shift INTERVAL, origin TIME);
 
 statement ok

--- a/test/sql/sample/test_system_rows.test
+++ b/test/sql/sample/test_system_rows.test
@@ -5,9 +5,6 @@
 statement ok
 SET profiling_renderer_settings = MAP {'operator_casing': 'upper'};
 
-statement ok
-PRAGMA enable_verification;
-
 # Create test table with 10000 rows
 statement ok
 CREATE TABLE test_table AS SELECT i FROM range(10000) tbl(i);
@@ -167,6 +164,3 @@ query I
 SELECT COUNT(*) FROM (SELECT * FROM test_table WHERE i % 2 = 0) tbl(i) USING SAMPLE 200 ROWS (system);
 ----
 100
-
-statement ok
-PRAGMA enable_verification;

--- a/test/sql/sample/test_system_rows_pushdown.test
+++ b/test/sql/sample/test_system_rows_pushdown.test
@@ -6,9 +6,6 @@ statement ok
 SET profiling_renderer_settings = MAP {'operator_casing': 'upper'};
 
 statement ok
-PRAGMA enable_verification;
-
-statement ok
 CREATE TABLE pushdown_test AS SELECT i FROM range(1000000) tbl(i);
 
 # Test with filter: STREAMING_SAMPLE sees only rows that pass the filter

--- a/test/sql/types/geo/geometry_shred_more.test
+++ b/test/sql/types/geo/geometry_shred_more.test
@@ -10,7 +10,7 @@ foreach storage_version v1.0.0 v1.5.0
 foreach rgsize 2048 8192
 
 statement ok
-ATTACH '{TEST_DIR}/geocp_${storage_version}_${rgsize}.db' AS db (ROW_GROUP_SIZE ${rgsize}, STORAGE_VERSION '${storage_version}');
+ATTACH '{TEST_DIR}/geocp_{storage_version}_{rgsize}.db' AS db (ROW_GROUP_SIZE {rgsize}, STORAGE_VERSION '{storage_version}');
 
 statement ok
 USE db;
@@ -140,7 +140,7 @@ statement ok
 DETACH db;
 
 statement ok
-ATTACH '{TEST_DIR}/geocp_${storage_version}_${rgsize}.db' AS db;
+ATTACH '{TEST_DIR}/geocp_{storage_version}_{rgsize}.db' AS db;
 
 statement ok
 USE db;

--- a/test/sql/types/struct/remap_struct_list_source_name.test
+++ b/test/sql/types/struct/remap_struct_list_source_name.test
@@ -8,9 +8,6 @@
 # and "bag" for Spark legacy. Such a non-"list" source name must still remap (the mapping is
 # unambiguous for a LIST) rather than throwing "Source value <name> not found".
 
-statement ok
-PRAGMA enable_verification
-
 # Control: the canonical "list" source name keeps working.
 query I
 SELECT remap_struct(

--- a/test/sql/variables/test_variable_syntax.test
+++ b/test/sql/variables/test_variable_syntax.test
@@ -3,9 +3,6 @@
 # group: [variables]
 
 statement ok
-PRAGMA enable_verification
-
-statement ok
 SET VARIABLE animal = 'duck'
 
 query I

--- a/test/sql/window/test_window_aggregate_macro.test
+++ b/test/sql/window/test_window_aggregate_macro.test
@@ -3,9 +3,6 @@
 # group: [window]
 
 statement ok
-PRAGMA enable_verification
-
-statement ok
 CREATE MACRO tinyint_min(a) as cast(min(a) as tinyint);
 
 statement ok


### PR DESCRIPTION
Resolve warnings like
```sh
1576/4979] (31%): test/sql/types/geo/geometry_crs.test took 0.011s                                        Replacing deprecated loop iterator ${storage_version} in test "test/sql/types/geo/geometry_shred_more.test" - please use the new loop iterator {storage_version}
Replacing deprecated loop iterator ${rgsize} in test "test/sql/types/geo/geometry_shred_more.test" - please use the new loop iterator {rgsize}
Replacing deprecated loop iterator ${rgsize} in test "test/sql/types/geo/geometry_shred_more.test" - please use the new loop iterator {rgsize}
[1614/4979] (32%): test/sql/types/struct/unnest_struct_mix.test took 0.037s                                PRAGMA enable_verification has been deprecated - there is no need to set this anymore
Replacing deprecated loop iterator ${type} in test "test/sql/function/date/date_part_stats.test" - please use the new loop iterator {type}
[3073/4979] (61%): test/sql/function/string/test_ilike_escape_constant_pattern.test took 0.095s            PRAGMA enable_verification has been deprecated - there is no need to set this anymore
```