### PR TITLE
Fix stats collection for dictionary encoding

### DIFF
--- a/src/include/duckdb/storage/compression/dictionary/analyze.hpp
+++ b/src/include/duckdb/storage/compression/dictionary/analyze.hpp
@@ -16,7 +16,7 @@ public:
 public:
 	bool LookupString(string_t str);
 	void AddNewString(string_t str);
-	void AddLastLookup();
+	void AddLastLookup(string_t str);
 	void AddNull();
 	bool CalculateSpaceRequirements(bool new_string, idx_t string_size);
 	void Flush(bool final = false);

--- a/src/include/duckdb/storage/compression/dictionary/common.hpp
+++ b/src/include/duckdb/storage/compression/dictionary/common.hpp
@@ -65,7 +65,7 @@ public:
 			} else if (new_string) {
 				state.AddNewString(entry.GetValue());
 			} else {
-				state.AddLastLookup();
+				state.AddLastLookup(entry.GetValue());
 			}
 
 			state.Verify();

--- a/src/include/duckdb/storage/compression/dictionary/compression.hpp
+++ b/src/include/duckdb/storage/compression/dictionary/compression.hpp
@@ -33,7 +33,7 @@ public:
 	bool LookupString(string_t str);
 	void AddNewString(string_t str);
 	void AddNull();
-	void AddLastLookup();
+	void AddLastLookup(string_t str);
 	bool CalculateSpaceRequirements(bool new_string, idx_t string_size);
 	void Flush(bool final = false);
 	idx_t Finalize();

--- a/src/include/duckdb/storage/statistics/stats_writer.hpp
+++ b/src/include/duckdb/storage/statistics/stats_writer.hpp
@@ -176,6 +176,16 @@ struct StatsWriter<string_t> : public BaseStatsWriter {
 		}
 	}
 
+	//! Update stats for a value that was already passed to Update - only additive stats need to be re-counted
+	inline void UpdateRepeated(const string_t &value) {
+		if (is_geometry) {
+			Update(value);
+			return;
+		}
+		SetHasValid();
+		total_string_length += value.GetSize();
+	}
+
 	void Merge(BaseStatistics &other) const {
 		MergeBase(other);
 		if (is_geometry) {

--- a/src/storage/compression/dictionary/analyze.cpp
+++ b/src/storage/compression/dictionary/analyze.cpp
@@ -19,7 +19,7 @@ void DictionaryAnalyzeState::AddNewString(string_t str) {
 	current_width = next_width;
 }
 
-void DictionaryAnalyzeState::AddLastLookup() {
+void DictionaryAnalyzeState::AddLastLookup(string_t str) {
 	current_tuple_count++;
 }
 

--- a/src/storage/compression/dictionary/compression.cpp
+++ b/src/storage/compression/dictionary/compression.cpp
@@ -85,7 +85,9 @@ void DictionaryCompressionCompressState::AddNull() {
 	current_segment->count++;
 }
 
-void DictionaryCompressionCompressState::AddLastLookup() {
+void DictionaryCompressionCompressState::AddLastLookup(string_t str) {
+	// the string is already in the dictionary - only additive stats (total_string_length) need updating
+	stats_writer.UpdateRepeated(str);
 	selection_buffer.push_back(latest_lookup_result);
 	current_segment->count++;
 }

--- a/test/configs/force_storage_restart.json
+++ b/test/configs/force_storage_restart.json
@@ -83,6 +83,7 @@
       "reason": "total_string_length requires exact per-row-group stats; force_restart causes persistent row groups with unloaded columns where only bound-expansion is possible, making the stat unknown.",
       "paths": [
         "test/sql/storage/total_string_length_repeated_insert.test",
+        "test/sql/storage/compression/dictionary/total_string_length_dictionary.test",
         "test/sql/storage/extended_string_stats.test"
       ]
     },

--- a/test/configs/stats_dependent_tests.json
+++ b/test/configs/stats_dependent_tests.json
@@ -33,6 +33,7 @@
         "test/sql/storage/extended_string_stats.test",
         "test/sql/storage/min_string_length_too_large.test_slow",
         "test/sql/storage/total_string_length_repeated_insert.test",
+        "test/sql/storage/compression/dictionary/total_string_length_dictionary.test",
         "test/sql/types/geo/geometry_from_wkb_stats.test",
         "test/parquet/variant/variant_stats_propagation.test",
         "test/sql/types/geo/geometry_stats.test",

--- a/test/sql/storage/compression/dictionary/total_string_length_dictionary.test
+++ b/test/sql/storage/compression/dictionary/total_string_length_dictionary.test
@@ -1,0 +1,32 @@
+# name: test/sql/storage/compression/dictionary/total_string_length_dictionary.test
+# description: Test that total_string_length counts repeated strings when checkpointing with dictionary compression
+# group: [dictionary]
+
+require no_latest_storage
+
+require vector_size 2048
+
+load {TEST_DIR}/total_string_length_dictionary.db readwrite v1.0.0
+
+statement ok
+PRAGMA force_compression='dictionary'
+
+statement ok
+CREATE TABLE t (s VARCHAR);
+
+statement ok
+INSERT INTO t SELECT 'hello' FROM range(10000);
+
+statement ok
+CHECKPOINT
+
+query I
+SELECT compression FROM pragma_storage_info('t') WHERE segment_type ILIKE 'VARCHAR' LIMIT 1
+----
+Dictionary
+
+# total_string_length must count every row, not just the unique dictionary entries
+query I
+select s.total_string_length from (select stats(s) s from t limit 1)
+----
+50000


### PR DESCRIPTION
Closes https://github.com/duckdb/duckdb/issues/23633

The root cause is: on a dictionary hit, `AddLastLookup` only wrote the index and incremented the segment count, but it never updated column stats.