### PR TITLE
Fix rows_scanned metric to report pre-filter row counts

### DIFF
--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -226,6 +226,9 @@ public:
 	//! (optional) pointer to the PhysicalOperator for logging
 	optional_ptr<const PhysicalOperator> op;
 
+	//! Per-thread rows scanned counter (incremented before filters in Scan)
+	idx_t rows_scanned = 0;
+
 	//! Per-thread counters for row groups whose data was read / skipped, incremented as row groups are processed.
 	//! Read in ParquetScanGetMetrics and surfaced as the standard row_groups_scanned / total_row_groups_to_scan
 	//! profiling metrics (the profiler sums them across threads).
@@ -333,6 +336,7 @@ public:
 	                 LocalTableFunctionState &local_state, DataChunk &chunk) override;
 	void FinishFile(ClientContext &context, GlobalTableFunctionState &gstate_p) override;
 	double GetProgressInFile(ClientContext &context) override;
+	idx_t GetLocalRowsScanned(LocalTableFunctionState &lstate) const override;
 
 public:
 	void InitializeScan(ClientContext &context, ParquetReaderScanState &state, idx_t group_to_read) const;

--- a/extension/parquet/parquet_multi_file_info.cpp
+++ b/extension/parquet/parquet_multi_file_info.cpp
@@ -799,6 +799,11 @@ AsyncResult ParquetReader::Scan(ClientContext &context, GlobalTableFunctionState
 	return Process(context, local_state.scan_state, chunk);
 }
 
+idx_t ParquetReader::GetLocalRowsScanned(LocalTableFunctionState &lstate) const {
+	auto &local_state = lstate.Cast<ParquetReadLocalState>();
+	return local_state.scan_state.rows_scanned;
+}
+
 unique_ptr<MultiFileReaderInterface> ParquetMultiFileInfo::Copy() {
 	return make_uniq<ParquetMultiFileInfo>();
 }

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -2006,6 +2006,7 @@ AsyncResult ParquetReader::Process(ClientContext &context, ParquetReaderScanStat
 
 	result.SetChildCardinality(result.size());
 	rows_read += scan_count;
+	state.rows_scanned += scan_count;
 	state.offset_in_group += scan_count;
 	state.resuming_payload = false;
 	return SourceResultType::HAVE_MORE_OUTPUT;

--- a/src/include/duckdb/common/multi_file/base_file_reader.hpp
+++ b/src/include/duckdb/common/multi_file/base_file_reader.hpp
@@ -108,6 +108,10 @@ public:
 	DUCKDB_API virtual double GetProgressInFile(ClientContext &context);
 	//! Get reader metadata, if available
 	DUCKDB_API virtual InsertionOrderPreservingMap<Value> GetMetadata() const;
+	//! Get the number of rows scanned by a specific thread (pre-filter, thread-safe).
+	virtual idx_t GetLocalRowsScanned(LocalTableFunctionState &lstate) const {
+		return 0;
+	}
 
 	virtual string GetReaderType() const = 0;
 

--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -720,7 +720,8 @@ public:
 
 		output.SetChildCardinality(scan_chunk.size());
 		if (scan_chunk.size() > 0) {
-			data.rows_scanned += scan_chunk.size();
+			auto local_scanned = data.job.reader->GetLocalRowsScanned(*data.job.reader_scan_state);
+			data.rows_scanned = local_scanned > 0 ? local_scanned : (data.rows_scanned + scan_chunk.size());
 			bind_data.multi_file_reader->FinalizeChunk(context, bind_data, *data.job.reader, *data.job.reader_data,
 			                                           scan_chunk, output, data.executor,
 			                                           gstate.multi_file_reader_state);

--- a/test/sql/pragma/profiling/test_custom_profiling_rows_scanned_parquet_prefilter.test
+++ b/test/sql/pragma/profiling/test_custom_profiling_rows_scanned_parquet_prefilter.test
@@ -1,0 +1,102 @@
+# name: test/sql/pragma/profiling/test_custom_profiling_rows_scanned_parquet_prefilter.test
+# description: Test that ROWS_SCANNED reports pre-filter row counts for parquet scans
+# group: [profiling]
+
+require json
+
+require parquet
+
+# Create a parquet file with 10000 rows, where only 10% pass the filter
+statement ok
+COPY (SELECT i, i % 10 AS grp FROM range(0, 10000) t(i)) TO '{TEST_DIR}/prefilter_test.parquet' (FORMAT 'parquet');
+
+statement ok
+PRAGMA enable_profiling = 'json';
+
+statement ok
+PRAGMA profiling_output = '{TEST_DIR}/profiling_output.json';
+
+statement ok
+SET tracked_metrics = ['operator.intermediate_rows', 'operator.rows_scanned', 'query.total_rows_scanned'];
+
+# Query with a selective filter: only 1000 out of 10000 rows pass
+statement ok
+SELECT * FROM '{TEST_DIR}/prefilter_test.parquet' WHERE grp = 5;
+
+statement ok
+PRAGMA disable_profiling;
+
+statement ok
+CREATE OR REPLACE TABLE metrics_output AS SELECT * FROM '{TEST_DIR}/profiling_output.json';
+
+# total_rows_scanned should be 10000 (all rows read pre-filter), not 1000 (post-filter)
+query I
+SELECT
+	CASE WHEN query.total_rows_scanned = 10000 THEN 'correct'
+	ELSE 'wrong: ' || COALESCE(query.total_rows_scanned::VARCHAR, 'NULL') END
+FROM metrics_output;
+----
+correct
+
+# Verify with count(*) and a very selective filter to ensure rows_scanned >> output rows
+statement ok
+PRAGMA enable_profiling = 'json';
+
+statement ok
+PRAGMA profiling_output = '{TEST_DIR}/profiling_output.json';
+
+statement ok
+SET tracked_metrics = ['operator.rows_scanned', 'query.total_rows_scanned'];
+
+statement ok
+SELECT count(*) FROM '{TEST_DIR}/prefilter_test.parquet' WHERE grp = 0;
+
+statement ok
+PRAGMA disable_profiling;
+
+statement ok
+CREATE OR REPLACE TABLE metrics_output AS SELECT * FROM '{TEST_DIR}/profiling_output.json';
+
+# rows_scanned should still be 10000 (pre-filter), even though only 1000 rows match
+query I
+SELECT
+	CASE WHEN query.total_rows_scanned = 10000 THEN 'correct'
+	ELSE 'wrong: ' || COALESCE(query.total_rows_scanned::VARCHAR, 'NULL') END
+FROM metrics_output;
+----
+correct
+
+# Test with multiple parquet files to ensure accumulation works across files
+statement ok
+COPY (SELECT i, i % 5 AS grp FROM range(0, 5000) t(i)) TO '{TEST_DIR}/prefilter_multi1.parquet' (FORMAT 'parquet');
+
+statement ok
+COPY (SELECT i, i % 5 AS grp FROM range(5000, 10000) t(i)) TO '{TEST_DIR}/prefilter_multi2.parquet' (FORMAT 'parquet');
+
+statement ok
+PRAGMA enable_profiling = 'json';
+
+statement ok
+PRAGMA profiling_output = '{TEST_DIR}/profiling_output.json';
+
+statement ok
+SET tracked_metrics = ['operator.rows_scanned', 'query.total_rows_scanned'];
+
+# Query across two files with a selective filter (20% pass rate)
+statement ok
+SELECT * FROM read_parquet(['{TEST_DIR}/prefilter_multi1.parquet', '{TEST_DIR}/prefilter_multi2.parquet']) WHERE grp = 2;
+
+statement ok
+PRAGMA disable_profiling;
+
+statement ok
+CREATE OR REPLACE TABLE metrics_output AS SELECT * FROM '{TEST_DIR}/profiling_output.json';
+
+# rows_scanned should be 10000 total (5000 from each file, pre-filter)
+query I
+SELECT
+	CASE WHEN query.total_rows_scanned = 10000 THEN 'correct'
+	ELSE 'wrong: ' || COALESCE(query.total_rows_scanned::VARCHAR, 'NULL') END
+FROM metrics_output;
+----
+correct


### PR DESCRIPTION
## Summary
The rows_scanned profiling metric was reporting post-filter row counts,
making it identical to output rows. This fix changes it to report
pre-filter counts (total rows read from parquet before filtering).

## Changes
- Add per-thread rows_scanned counter to ParquetReaderScanState
- Expose via virtual GetLocalRowsScanned() on BaseFileReader
- Multi-file scan layer uses this instead of post-filter chunk size
- Counter accumulates across row groups and files naturally

## Testing
- Added test: test_custom_profiling_rows_scanned_parquet_prefilter.test
- Covers single-file and multi-file scenarios with selective filters
- Verified: rows_scanned=10000 when only 1000 rows pass filter

## Before/After
| Metric | Before | After |
|--------|--------|-------|
| rows_scanned (10% selectivity) | 1000 (post-filter) | 10000 (pre-filter) |