### PR TITLE
fix negative count over reversed window frames

### DIFF
--- a/src/function/window/window_value_function.cpp
+++ b/src/function/window/window_value_function.cpp
@@ -646,7 +646,7 @@ void WindowLeadLagExecutor::GetData(ExecutionContext &context, DataChunk &eval_c
 			}
 
 			// (1) compute the ROW_NUMBER of the own row
-			frame = FrameBounds(frame_begin[i], frame_end[i]);
+			frame = FrameBounds(frame_begin[i], MaxValue(frame_end[i], frame_begin[i]));
 			const auto own_row = glstate.row_tree->Rank(frame.start, frame.end, row_idx) - 1;
 			// (2) adjust the row number by adding or subtracting an offset
 			auto val_idx = NumericCast<int64_t>(own_row);

--- a/src/include/duckdb/function/window/window_aggregator.hpp
+++ b/src/include/duckdb/function/window/window_aggregator.hpp
@@ -57,7 +57,7 @@ public:
 
 				//	WindowExcludePart::LEFT
 				const auto frame_begin = begins[i];
-				const auto frame_end = ends[i];
+				const auto frame_end = MaxValue(ends[i], frame_begin);
 				auto begin = frame_begin;
 				auto end = (exclude_mode == WindowExcludeMode::CURRENT_ROW) ? cur_row : peer_begin[i];
 				end = MinValue(end, frame_end);

--- a/src/include/duckdb/function/window/window_aggregator.hpp
+++ b/src/include/duckdb/function/window/window_aggregator.hpp
@@ -33,7 +33,7 @@ public:
 			idx_t nframes = 0;
 			if (exclude_mode == WindowExcludeMode::NO_OTHER) {
 				auto begin = begins[i];
-				auto end = ends[i];
+				auto end = MaxValue(ends[i], begin);
 				frames[nframes++] = FrameBounds(begin, end);
 			} else {
 				//	The frame_exclusion option allows rows around the current row to be excluded from the frame,

--- a/test/sql/window/test_empty_frames.test
+++ b/test/sql/window/test_empty_frames.test
@@ -31,7 +31,17 @@ NULL	0
 
 endloop
 
-#
+#  Reversed frames are empty, so COUNT must be 0 (not negative)
+foreach agg count(*) count_star()
+
+query I
+SELECT {agg} OVER (ROWS BETWEEN 1 FOLLOWING AND 1 PRECEDING) AS actual
+FROM range(1);
+----
+0
+
+endloop
+
 # All zeroes
 #
 foreach agg approx_count_distinct count entropy

--- a/test/sql/window/test_empty_frames.test
+++ b/test/sql/window/test_empty_frames.test
@@ -42,6 +42,15 @@ FROM range(1);
 
 endloop
 
+query II
+SELECT id, count(*) OVER (PARTITION BY ch ORDER BY id ROWS BETWEEN 3 FOLLOWING AND 1 FOLLOWING)
+FROM t1
+ORDER BY 1;
+----
+1	0
+2	0
+NULL	0
+
 # All zeroes
 #
 foreach agg approx_count_distinct count entropy

--- a/test/sql/window/test_empty_frames.test
+++ b/test/sql/window/test_empty_frames.test
@@ -51,6 +51,37 @@ ORDER BY 1;
 2	0
 NULL	0
 
+foreach agg count(*) count_star()
+
+# Check aggregates
+query I
+SELECT {agg} OVER (ROWS BETWEEN 1 FOLLOWING AND 1 PRECEDING EXCLUDE TIES) AS actual
+FROM range(1);
+----
+0
+
+endloop
+
+# Check value functions
+query II
+SELECT id, lead(id ORDER BY id) OVER (ORDER BY ch ROWS BETWEEN 3 FOLLOWING AND 1 FOLLOWING)
+FROM t1
+ORDER BY 1;
+----
+1	NULL
+2	NULL
+NULL	NULL
+
+# Check ranking functions
+query II
+SELECT id, rank() OVER (ORDER BY id ROWS BETWEEN 3 FOLLOWING AND 1 FOLLOWING)
+FROM t1
+ORDER BY 1;
+----
+1	1
+2	2
+NULL	3
+
 # All zeroes
 #
 foreach agg approx_count_distinct count entropy


### PR DESCRIPTION
Fixes: https://github.com/duckdb/duckdb/issues/23589

This PR fixes the case where a window aggregate over reversed `ROWS` gives negative`COUNT(*)`.