### PR TITLE
Use all hardware threads during benchmarks

### DIFF
--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -274,7 +274,6 @@ jobs:
             --new build/current/release/benchmark/benchmark_runner \
             --benchmarks ${{ matrix.benchmarks }} \
             --verbose \
-            --threads 2 \
             --clear-benchmark-cache \
             --disable-timeout \
             --max-timeout 3600

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -276,7 +276,8 @@ jobs:
             --verbose \
             --clear-benchmark-cache \
             --disable-timeout \
-            --max-timeout 3600
+            --max-timeout 3600 \
+            --timed-runs 20
 
   regression-bench-fivetran:
     name: Bench Fivetran

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -13,7 +13,7 @@ BUILD_BENCHMARK=1 BUILD_TPCH=1 make
 #### Run a single benchmark
 `build/release/benchmark/benchmark_runner benchmark/micro/nulls/no_nulls_addition.benchmark`
 
-The output will be printed to `stdout` in CSV format, in the following format:
+The output will be printed to `stderr` in CSV format, in the following format:
 
 ```
 name	run	timing
@@ -22,6 +22,12 @@ benchmark/micro/nulls/no_nulls_addition.benchmark	2	0.121702
 benchmark/micro/nulls/no_nulls_addition.benchmark	3	0.122948
 benchmark/micro/nulls/no_nulls_addition.benchmark	4	0.122534
 benchmark/micro/nulls/no_nulls_addition.benchmark	5	0.124102
+```
+
+By default, every benchmark emits five timed runs after one warmup run. You can override this using `--timed-runs n`:
+
+```
+build/release/benchmark/benchmark_runner benchmark/micro/nulls/no_nulls_addition.benchmark --timed-runs 20
 ```
 
 You can also specify an output file using the `--out` flag. This will write only the timings (delimited by newlines) to that file.
@@ -103,6 +109,5 @@ SELECT MIN(i + 1) FROM integers
 │          (0.08s)          │
 └───────────────────────────┘      
 ```
-
 
 

--- a/benchmark/benchmark_runner.cpp
+++ b/benchmark/benchmark_runner.cpp
@@ -139,7 +139,7 @@ void BenchmarkRunner::RunBenchmark(Benchmark *benchmark) {
 		LogLine(error_data.Message());
 		return;
 	}
-	auto nruns = benchmark->NRuns();
+	auto nruns = BenchmarkRunner::GetInstance().timed_runs;
 	for (size_t i = 0; i < nruns + 1; i++) {
 		bool hotrun = i > 0;
 		if (hotrun) {
@@ -208,6 +208,7 @@ void print_help() {
 	fprintf(stderr, "              --detailed-profile     Prints detailed query profile information\n");
 	fprintf(stderr, "              --threads=n            Sets the amount of threads to use during execution (default: "
 	                "hardware concurrency)\n");
+	fprintf(stderr, "              --timed-runs n         Sets the amount of timed runs per benchmark (default: 5)\n");
 	fprintf(stderr, "              --memory_limit=n       Sets the memory limit to use during execution (default: 0.8 "
 	                "* system memory)\n");
 	fprintf(stderr, "              --out=[file]           Move benchmark output to file\n");
@@ -329,6 +330,24 @@ void parse_arguments(const int arg_counter, char const *const *arg_values) {
 			}
 			instance.configuration.name_pattern = arg;
 		}
+	}
+	auto timed_runs_entry = instance.custom_arguments.find("timed-runs");
+	if (timed_runs_entry != instance.custom_arguments.end()) {
+		uint32_t timed_runs;
+		try {
+			timed_runs = Value(timed_runs_entry->second).DefaultCastAs(LogicalType::UINTEGER).GetValue<uint32_t>();
+		} catch (std::exception &) {
+			fprintf(stderr, "Invalid value for benchmark argument timed-runs: %s\n", timed_runs_entry->second.c_str());
+			print_help();
+			exit(1);
+		}
+		if (timed_runs == 0) {
+			fprintf(stderr, "Benchmark argument timed-runs must be greater than 0\n");
+			print_help();
+			exit(1);
+		}
+		instance.timed_runs = timed_runs;
+		instance.custom_arguments.erase(timed_runs_entry);
 	}
 }
 

--- a/benchmark/include/benchmark_runner.hpp
+++ b/benchmark/include/benchmark_runner.hpp
@@ -51,6 +51,7 @@ public:
 	ofstream out_file;
 	ofstream log_file;
 	uint32_t threads = MaxValue<uint32_t>(std::thread::hardware_concurrency(), 1u);
+	uint32_t timed_runs = 5;
 	string memory_limit;
 	unordered_map<string, string> custom_arguments;
 };

--- a/scripts/regression/benchmark.py
+++ b/scripts/regression/benchmark.py
@@ -37,6 +37,7 @@ class BenchmarkRunnerConfig:
     max_timeout: int = MAX_TIMEOUT
     root_dir: str = ""
     no_summary: bool = False
+    timed_runs: Optional[int] = None
 
     @classmethod
     def from_params(cls, benchmark_runner, benchmark_file, **kwargs) -> "BenchmarkRunnerConfig":
@@ -47,6 +48,7 @@ class BenchmarkRunnerConfig:
         max_timeout = kwargs.get("max_timeout", MAX_TIMEOUT)
         root_dir = kwargs.get("root_dir", "")
         no_summary = kwargs.get("no_summary", False)
+        timed_runs = kwargs.get("timed_runs", None)
 
         config = cls(
             benchmark_runner=benchmark_runner,
@@ -58,6 +60,7 @@ class BenchmarkRunnerConfig:
             max_timeout=max_timeout,
             root_dir=root_dir,
             no_summary=no_summary,
+            timed_runs=timed_runs,
         )
         return config
 
@@ -79,6 +82,7 @@ class BenchmarkRunnerConfig:
         parser.add_argument(
             "--no-summary", type=str, default=False, help="No failures summary is outputted when passing this flag."
         )
+        parser.add_argument("--timed-runs", type=int, help="Number of timed runs per benchmark.")
 
         # Parse arguments
         parsed_args = parser.parse_args()
@@ -94,6 +98,7 @@ class BenchmarkRunnerConfig:
             max_timeout=parsed_args.max_timeout,
             root_dir=parsed_args.root_dir,
             no_summary=parsed_args.no_summary,
+            timed_runs=parsed_args.timed_runs,
         )
         return config
 
@@ -105,6 +110,23 @@ class BenchmarkRunner:
         self.benchmark_list: List[str] = []
         with open(self.config.benchmark_file, 'r') as f:
             self.benchmark_list = [x.strip() for x in f.read().split('\n') if len(x) > 0]
+        self.supports_timed_runs = self.detect_timed_runs_support()
+
+    def detect_timed_runs_support(self):
+        if self.config.timed_runs is None:
+            return False
+        benchmark_args = [self.config.benchmark_runner]
+        if self.config.root_dir:
+            benchmark_args.extend(['--root-dir', self.config.root_dir])
+        benchmark_args.extend(["--help"])
+        try:
+            proc = subprocess.run(
+                benchmark_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=DEFAULT_TIMEOUT
+            )
+            output = proc.stdout.decode('utf8') + proc.stderr.decode('utf8')
+            return "--timed-runs" in output
+        except:
+            return False
 
     def construct_args(self, benchmark_path):
         benchmark_args = []
@@ -119,9 +141,11 @@ class BenchmarkRunner:
             benchmark_args.extend(["--disable-timeout"])
         if self.config.no_summary:
             benchmark_args.extend(["--no-summary"])
+        if self.config.timed_runs is not None and self.supports_timed_runs:
+            benchmark_args.extend(["--timed-runs", str(self.config.timed_runs)])
         return benchmark_args
 
-    def run_benchmark(self, benchmark) -> Tuple[Union[float, str], Optional[str]]:
+    def run_benchmark_once(self, benchmark) -> Tuple[Optional[List[float]], Optional[str]]:
         benchmark_args = self.construct_args(benchmark)
         timeout_seconds = DEFAULT_TIMEOUT
         if self.config.disable_timeout:
@@ -137,10 +161,7 @@ class BenchmarkRunner:
         except subprocess.TimeoutExpired:
             print("Failed to run benchmark " + benchmark)
             print(f"Aborted due to exceeding the limit of {timeout_seconds} seconds")
-            return (
-                'Failed to run benchmark ' + benchmark,
-                f"Aborted due to exceeding the limit of {timeout_seconds} seconds",
-            )
+            return None, f"Aborted due to exceeding the limit of {timeout_seconds} seconds"
         if returncode != 0:
             print("Failed to run benchmark " + benchmark)
             print(STDERR_HEADER)
@@ -150,7 +171,7 @@ class BenchmarkRunner:
             if 'HTTP' in err:
                 print("Ignoring HTTP error and terminating the running of the regression tests")
                 exit(0)
-            return 'Failed to run benchmark ' + benchmark, err
+            return None, err
         if self.config.verbose:
             print(err)
         # read the input CSV
@@ -165,13 +186,27 @@ class BenchmarkRunner:
                 if header:
                     header = False
                 else:
-                    timings.append(row[2])
-                    self.complete_timings.append(row[2])
-            return float(statistics.median(timings)), None
+                    timings.append(float(row[2]))
+            return timings, None
         except:
             print("Failed to run benchmark " + benchmark)
             print(err)
-            return 'Failed to run benchmark ' + benchmark, err
+            return None, err
+
+    def run_benchmark(self, benchmark) -> Tuple[Union[float, str], Optional[str]]:
+        requested_runs = self.config.timed_runs if self.config.timed_runs is not None else 0
+        timings = []
+        while True:
+            run_timings, failure_message = self.run_benchmark_once(benchmark)
+            if failure_message:
+                return 'Failed to run benchmark ' + benchmark, failure_message
+            if not run_timings:
+                return 'Failed to run benchmark ' + benchmark, "Benchmark did not produce any timings"
+            timings.extend(run_timings)
+            if self.supports_timed_runs or len(timings) >= requested_runs:
+                break
+        self.complete_timings.extend(timings)
+        return float(statistics.median(timings)), None
 
     def run_benchmarks(self, benchmark_list: List[str]):
         results = {}
@@ -186,7 +221,7 @@ class BenchmarkRunner:
 def main():
     config = BenchmarkRunnerConfig.from_args()
     runner = BenchmarkRunner(config)
-    runner.run_benchmarks()
+    runner.run_benchmarks(runner.benchmark_list)
 
 
 if __name__ == "__main__":

--- a/scripts/regression/test_runner.py
+++ b/scripts/regression/test_runner.py
@@ -46,6 +46,7 @@ parser.add_argument("--disable-timeout", action="store_true", help="Disable time
 parser.add_argument("--max-timeout", type=int, default=3600, help="Set maximum timeout in seconds (default: 3600).")
 parser.add_argument("--root-dir", type=str, default="", help="Root directory.")
 parser.add_argument("--no-summary", type=str, default=False, help="No summary in the end.")
+parser.add_argument("--timed-runs", type=int, help="Number of timed runs per benchmark.")
 parser.add_argument(
     "--clear-benchmark-cache", action="store_true", help="Clear benchmark caches prior to running", default=False
 )


### PR DESCRIPTION
Remove `--threads` to use all CPU cores on namespace CI runners (16 vCPU, 32 GB RAM).

Increase timed runs from 5 to 20 for tpc-h/tpc-ds queries to help stabilize the benchmark results.