### PR TITLE
Allow `UNNEST` in `GROUP BY`

### DIFF
--- a/src/include/duckdb/planner/expression_binder/group_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/group_binder.hpp
@@ -12,6 +12,7 @@
 #include "duckdb/planner/expression_binder.hpp"
 
 namespace duckdb {
+class BoundSelectNode;
 class ConstantExpression;
 class ColumnRefExpression;
 struct SelectBindState;
@@ -19,7 +20,7 @@ struct SelectBindState;
 //! The GROUP binder is responsible for binding expressions in the GROUP BY clause
 class GroupBinder : public ExpressionBinder {
 public:
-	GroupBinder(Binder &binder, ClientContext &context, TableIndex group_index, SelectBindState &bind_state);
+	GroupBinder(Binder &binder, ClientContext &context, BoundSelectNode &node, SelectBindState &bind_state);
 
 public:
 	static void ReplaceSelectRef(SelectNode &node, SelectBindState &bind_state, ProjectionIndex index,
@@ -27,6 +28,8 @@ public:
 
 protected:
 	BindResult BindExpression(unique_ptr<ParsedExpression> &expr_ptr, idx_t depth, bool root_expression) override;
+	BindResult BindUnnest(FunctionExpression &function, idx_t depth, bool root_expression) override;
+	void ThrowIfUnnestInLambda(const ColumnBinding &column_binding) override;
 
 	string UnsupportedAggregateMessage() override;
 
@@ -34,9 +37,9 @@ protected:
 	                              unique_ptr<ParsedExpression> &expr_ptr) override;
 
 private:
+	BoundSelectNode &node;
 	SelectBindState &bind_state;
-
-	TableIndex group_index;
+	idx_t unnest_level = 0;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/planner/query_node/bound_select_node.hpp
+++ b/src/include/duckdb/planner/query_node/bound_select_node.hpp
@@ -33,6 +33,28 @@ struct BoundUnnestNode {
 	vector<unique_ptr<Expression>> expressions;
 };
 
+using BoundUnnestMap = unordered_map<idx_t, BoundUnnestNode>;
+
+class BoundUnnestCollection {
+public:
+	BoundUnnestMap &SelectList() {
+		return select_list;
+	}
+	const BoundUnnestMap &SelectList() const {
+		return select_list;
+	}
+	BoundUnnestMap &GroupBy() {
+		return group_by;
+	}
+	const BoundUnnestMap &GroupBy() const {
+		return group_by;
+	}
+
+private:
+	BoundUnnestMap select_list;
+	BoundUnnestMap group_by;
+};
+
 //! Bound equivalent of SelectNode
 class BoundSelectNode : public BoundQueryNode {
 public:
@@ -79,8 +101,8 @@ public:
 	//! Window functions to compute (only used if HasWindow is true)
 	vector<unique_ptr<Expression>> windows;
 
-	//! Unnest expression
-	unordered_map<idx_t, BoundUnnestNode> unnests;
+	//! UNNEST expressions, split by SELECT-list and GROUP BY binding context
+	BoundUnnestCollection unnests;
 
 	//! Index of pruned node
 	TableIndex prune_index;

--- a/src/planner/binder/expression/bind_unnest_expression.cpp
+++ b/src/planner/binder/expression/bind_unnest_expression.cpp
@@ -7,6 +7,7 @@
 #include "duckdb/planner/expression/bound_expanded_expression.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/planner/expression/bound_parameter_expression.hpp"
+#include "duckdb/planner/expression_binder/group_binder.hpp"
 #include "duckdb/planner/expression_binder/select_binder.hpp"
 #include "duckdb/planner/query_node/bound_select_node.hpp"
 #include "duckdb/planner/expression/bound_unnest_expression.hpp"
@@ -50,18 +51,73 @@ static unique_ptr<Expression> CreateBoundStructExtractIndex(ClientContext &conte
 
 void SelectBinder::ThrowIfUnnestInLambda(const ColumnBinding &column_binding) {
 	// Extract the unnests and check if any match the column index.
-	for (auto &node_pair : node.unnests) {
-		auto &unnest_node = node_pair.second;
+	auto check_unnests = [&](const BoundUnnestMap &unnests) {
+		for (auto &node_pair : unnests) {
+			auto &unnest_node = node_pair.second;
 
-		if (unnest_node.index == column_binding.table_index) {
-			if (column_binding.column_index < unnest_node.expressions.size()) {
-				throw BinderException("UNNEST in lambda expressions is not supported");
+			if (unnest_node.index == column_binding.table_index) {
+				if (column_binding.column_index < unnest_node.expressions.size()) {
+					throw BinderException("UNNEST in lambda expressions is not supported");
+				}
 			}
 		}
+	};
+	check_unnests(node.unnests.SelectList());
+	check_unnests(node.unnests.GroupBy());
+}
+
+static void AddUnnestExpression(Binder &binder, BoundUnnestMap &unnests, idx_t current_level,
+                                unique_ptr<BoundUnnestExpression> result, TableIndex &unnest_table_index,
+                                ProjectionIndex &unnest_column_index) {
+	auto entry = unnests.find(current_level);
+	if (entry == unnests.end()) {
+		BoundUnnestNode unnest_node;
+		unnest_node.index = binder.GenerateTableIndex();
+		unnest_table_index = unnest_node.index;
+		unnest_column_index = ColumnBinding::PushExpression(unnest_node.expressions, std::move(result));
+		unnests.insert(make_pair(current_level, std::move(unnest_node)));
+	} else {
+		unnest_table_index = entry->second.index;
+		unnest_column_index = ColumnBinding::PushExpression(entry->second.expressions, std::move(result));
 	}
 }
 
-BindResult SelectBinder::BindUnnest(FunctionExpression &function, idx_t depth, bool root_expression) {
+enum class StructUnnestHandling : uint8_t { ALLOW_ROOT, REJECT };
+
+class UnnestLevelGuard {
+public:
+	explicit UnnestLevelGuard(idx_t &unnest_level) : unnest_level(unnest_level) {
+		unnest_level++;
+	}
+	~UnnestLevelGuard() {
+		unnest_level--;
+	}
+
+private:
+	idx_t &unnest_level;
+};
+
+class UnnestBinder {
+public:
+	UnnestBinder(ExpressionBinder &expression_binder, Binder &binder, ClientContext &context, BoundUnnestMap &unnests,
+	             idx_t &unnest_level, StructUnnestHandling struct_handling, string struct_error)
+	    : expression_binder(expression_binder), binder(binder), context(context), unnests(unnests),
+	      unnest_level(unnest_level), struct_handling(struct_handling), struct_error(std::move(struct_error)) {
+	}
+
+	BindResult Bind(FunctionExpression &function, idx_t depth, bool root_expression);
+
+private:
+	ExpressionBinder &expression_binder;
+	Binder &binder;
+	ClientContext &context;
+	BoundUnnestMap &unnests;
+	idx_t &unnest_level;
+	StructUnnestHandling struct_handling;
+	string struct_error;
+};
+
+BindResult UnnestBinder::Bind(FunctionExpression &function, idx_t depth, bool root_expression) {
 	// bind the children of the function expression
 	if (depth > 0) {
 		return BindResult(BinderException(function, "UNNEST() for correlated expressions is not supported yet"));
@@ -70,9 +126,6 @@ BindResult SelectBinder::BindUnnest(FunctionExpression &function, idx_t depth, b
 	ErrorData error;
 	if (function.GetArguments().empty()) {
 		return BindResult(BinderException(function, "UNNEST() requires at least one argument"));
-	}
-	if (inside_window || inside_aggregate || inside_try) {
-		return BindResult(BinderException(function, UnsupportedUnnestMessage()));
 	}
 
 	if (function.Distinct() || function.Filter() || !function.OrderBy()->orders.empty()) {
@@ -94,7 +147,7 @@ BindResult SelectBinder::BindUnnest(FunctionExpression &function, idx_t depth, b
 				break;
 			}
 			auto alias = args[i].GetExpression().GetAlias();
-			BindChild(args[i].GetExpressionMutable(), depth, error);
+			expression_binder.BindChild(args[i].GetExpressionMutable(), depth, error);
 			if (error.HasError()) {
 				return BindResult(std::move(error));
 			}
@@ -125,24 +178,24 @@ BindResult SelectBinder::BindUnnest(FunctionExpression &function, idx_t depth, b
 			              "recursive := [true/false], max_depth := # or keep_parent_names := [true/false]"));
 		}
 	}
-	unnest_level++;
-	BindChild(args[0].GetExpressionMutable(), depth, error);
+	auto outer_unnest_level = unnest_level;
+	UnnestLevelGuard unnest_level_guard(unnest_level);
+	expression_binder.BindChild(args[0].GetExpressionMutable(), depth, error);
 	if (error.HasError()) {
 		// failed to bind
 		// try to bind correlated columns manually
-		auto result = BindCorrelatedColumns(args[0].GetExpressionMutable(), error);
+		auto result = expression_binder.BindCorrelatedColumns(args[0].GetExpressionMutable(), error);
 		if (result.HasError()) {
 			return BindResult(result.error);
 		}
 		auto &bound_expr = BoundExpression::GetExpression(*args[0].GetExpressionMutable());
-		ExtractCorrelatedExpressions(binder, *bound_expr);
+		ExpressionBinder::ExtractCorrelatedExpressions(binder, *bound_expr);
 	}
 	auto &child = BoundExpression::GetExpression(*args[0].GetExpressionMutable());
 	child = BoundCastExpression::AddArrayCastToList(context, std::move(child));
 	auto &child_type = child->GetReturnType();
-	unnest_level--;
 
-	if (unnest_level > 0) {
+	if (outer_unnest_level > 0) {
 		throw BinderException(
 		    function,
 		    "Nested UNNEST calls are not supported - use UNNEST(x, recursive := true) to unnest multiple levels");
@@ -187,6 +240,10 @@ BindResult SelectBinder::BindUnnest(FunctionExpression &function, idx_t depth, b
 			struct_unnests = max_depth - list_unnests;
 		}
 	}
+	if (struct_unnests > 0 && struct_handling == StructUnnestHandling::REJECT) {
+		child = std::move(unnest_expr);
+		return BindResult(BinderException(function, struct_error));
+	}
 	if (struct_unnests > 0 && !root_expression) {
 		child = std::move(unnest_expr);
 		return BindResult(BinderException(
@@ -209,20 +266,10 @@ BindResult SelectBinder::BindUnnest(FunctionExpression &function, idx_t depth, b
 		result->ChildMutable() = std::move(unnest_expr);
 		Identifier alias = function.GetAlias().empty() ? Identifier(result->ToString()) : function.GetAlias();
 
-		auto current_level = unnest_level + list_unnests - current_depth - 1;
-		auto entry = node.unnests.find(current_level);
+		auto current_level = outer_unnest_level + list_unnests - current_depth - 1;
 		TableIndex unnest_table_index;
 		ProjectionIndex unnest_column_index;
-		if (entry == node.unnests.end()) {
-			BoundUnnestNode unnest_node;
-			unnest_node.index = binder.GenerateTableIndex();
-			unnest_table_index = unnest_node.index;
-			unnest_column_index = ColumnBinding::PushExpression(unnest_node.expressions, std::move(result));
-			node.unnests.insert(make_pair(current_level, std::move(unnest_node)));
-		} else {
-			unnest_table_index = entry->second.index;
-			unnest_column_index = ColumnBinding::PushExpression(entry->second.expressions, std::move(result));
-		}
+		AddUnnestExpression(binder, unnests, current_level, std::move(result), unnest_table_index, unnest_column_index);
 		// now create a column reference referring to the unnest
 		unnest_expr = make_uniq<BoundColumnRefExpression>(
 		    std::move(alias), return_type, ColumnBinding(unnest_table_index, unnest_column_index), depth);
@@ -270,6 +317,24 @@ BindResult SelectBinder::BindUnnest(FunctionExpression &function, idx_t depth, b
 		unnest_expr = make_uniq<BoundExpandedExpression>(std::move(struct_expressions));
 	}
 	return BindResult(std::move(unnest_expr));
+}
+
+BindResult SelectBinder::BindUnnest(FunctionExpression &function, idx_t depth, bool root_expression) {
+	if (inside_window || inside_aggregate || inside_try) {
+		return BindResult(BinderException(function, UnsupportedUnnestMessage()));
+	}
+	UnnestBinder unnest_binder(*this, binder, context, node.unnests.SelectList(), unnest_level,
+	                           StructUnnestHandling::ALLOW_ROOT, "UNNEST of struct cannot be used in GROUP BY clause");
+	return unnest_binder.Bind(function, depth, root_expression);
+}
+
+BindResult GroupBinder::BindUnnest(FunctionExpression &function, idx_t depth, bool root_expression) {
+	if (inside_try) {
+		return BindResult(BinderException(function, UnsupportedUnnestMessage()));
+	}
+	UnnestBinder unnest_binder(*this, binder, context, node.unnests.GroupBy(), unnest_level,
+	                           StructUnnestHandling::REJECT, "UNNEST of struct cannot be used in GROUP BY clause");
+	return unnest_binder.Bind(function, depth, root_expression);
 }
 
 } // namespace duckdb

--- a/src/planner/binder/query_node/bind_select_node.cpp
+++ b/src/planner/binder/query_node/bind_select_node.cpp
@@ -548,7 +548,7 @@ BoundStatement Binder::BindSelectNode(SelectNode &statement, BoundStatement from
 
 	if (!group_expressions.empty()) {
 		// the statement has a GROUP BY clause, bind it
-		GroupBinder group_binder(*this, context, result.group_index, bind_state);
+		GroupBinder group_binder(*this, context, result, bind_state);
 		// Allow NULL constants in GROUP BY to maintain their SQLNULL type
 		auto prev_can_contain_nulls = CanContainNulls();
 		SetCanContainNulls(true);
@@ -556,6 +556,9 @@ BoundStatement Binder::BindSelectNode(SelectNode &statement, BoundStatement from
 			// bind the groups
 			LogicalType group_type;
 			auto bound_expr = group_binder.Bind(group_expressions[i], &group_type);
+			if (bound_expr->GetExpressionType() == ExpressionType::BOUND_EXPANDED) {
+				throw BinderException("UNNEST of struct cannot be used in GROUP BY clause");
+			}
 			D_ASSERT(bound_expr->GetReturnType().id() != LogicalTypeId::INVALID);
 
 			// find out whether the expression contains a subquery, it can't be copied if so
@@ -620,7 +623,7 @@ BoundStatement Binder::BindSelectNode(SelectNode &statement, BoundStatement from
 
 	for (idx_t i = 0; i < statement.select_list.size(); i++) {
 		bool is_window = statement.select_list[i]->IsWindow();
-		idx_t unnest_count = result.unnests.size();
+		idx_t unnest_count = result.unnests.SelectList().size();
 		LogicalType result_type;
 		auto expr = select_binder.Bind(statement.select_list[i], &result_type, true);
 		bool is_original_column = i < result.column_count;
@@ -660,15 +663,15 @@ BoundStatement Binder::BindSelectNode(SelectNode &statement, BoundStatement from
 		}
 		bind_state.AddRegularColumn();
 
+		if (can_group_by_all && is_window) {
+			throw BinderException("Cannot group on a window clause");
+		}
+		if (can_group_by_all && result.unnests.SelectList().size() > unnest_count) {
+			throw BinderException("Cannot group on an UNNEST or UNLIST clause");
+		}
 		if (can_group_by_all && select_binder.HasBoundColumns()) {
 			if (select_binder.BoundAggregates()) {
 				throw BinderException("Cannot mix aggregates with non-aggregated columns!");
-			}
-			if (is_window) {
-				throw BinderException("Cannot group on a window clause");
-			}
-			if (result.unnests.size() > unnest_count) {
-				throw BinderException("Cannot group on an UNNEST or UNLIST clause");
 			}
 			// we are forcing aggregates, and the node has columns bound
 			// this entry becomes a group

--- a/src/planner/binder/query_node/plan_select_node.cpp
+++ b/src/planner/binder/query_node/plan_select_node.cpp
@@ -130,6 +130,29 @@ unique_ptr<LogicalOperator> Binder::CreatePlan(BoundSelectNode &statement) {
 	D_ASSERT(statement.from_table.plan);
 	auto root = std::move(statement.from_table.plan);
 
+	auto plan_unnests = [&](BoundUnnestMap &unnests) {
+		for (idx_t i = unnests.size(); i > 0; i--) {
+			auto unnest_depth = i - 1;
+			auto entry = unnests.find(unnest_depth);
+			if (entry == unnests.end()) {
+				throw InternalException("unnests specified at level %d but none were found", unnest_depth);
+			}
+			auto &unnest_node = entry->second;
+			auto unnest = make_uniq<LogicalUnnest>(unnest_node.index);
+			unnest->expressions = std::move(unnest_node.expressions);
+			// visit the unnest expressions
+			for (auto &expr : unnest->expressions) {
+				PlanSubqueries(expr, root);
+			}
+			D_ASSERT(!unnest->expressions.empty());
+			unnest->AddChild(std::move(root));
+			root = std::move(unnest);
+		}
+	};
+
+	// GROUP BY expressions containing UNNEST must expand rows before aggregation.
+	plan_unnests(statement.unnests.GroupBy());
+
 	if (!statement.aggregates.empty() || !statement.groups.group_expressions.empty() || statement.having) {
 		if (!statement.groups.group_expressions.empty()) {
 			// visit the groups
@@ -188,23 +211,7 @@ unique_ptr<LogicalOperator> Binder::CreatePlan(BoundSelectNode &statement) {
 		root = std::move(qualify);
 	}
 
-	for (idx_t i = statement.unnests.size(); i > 0; i--) {
-		auto unnest_level = i - 1;
-		auto entry = statement.unnests.find(unnest_level);
-		if (entry == statement.unnests.end()) {
-			throw InternalException("unnests specified at level %d but none were found", unnest_level);
-		}
-		auto &unnest_node = entry->second;
-		auto unnest = make_uniq<LogicalUnnest>(unnest_node.index);
-		unnest->expressions = std::move(unnest_node.expressions);
-		// visit the unnest expressions
-		for (auto &expr : unnest->expressions) {
-			PlanSubqueries(expr, root);
-		}
-		D_ASSERT(!unnest->expressions.empty());
-		unnest->AddChild(std::move(root));
-		root = std::move(unnest);
-	}
+	plan_unnests(statement.unnests.SelectList());
 
 	for (auto &expr : statement.select_list) {
 		PlanSubqueries(expr, root);

--- a/src/planner/expression_binder/group_binder.cpp
+++ b/src/planner/expression_binder/group_binder.cpp
@@ -5,13 +5,14 @@
 #include "duckdb/parser/query_node/select_node.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression_binder/select_bind_state.hpp"
+#include "duckdb/planner/query_node/bound_select_node.hpp"
 #include "duckdb/common/to_string.hpp"
 #include "duckdb/common/string_util.hpp"
 
 namespace duckdb {
 
-GroupBinder::GroupBinder(Binder &binder, ClientContext &context, TableIndex group_index, SelectBindState &bind_state)
-    : ExpressionBinder(binder, context), bind_state(bind_state), group_index(group_index) {
+GroupBinder::GroupBinder(Binder &binder, ClientContext &context, BoundSelectNode &node, SelectBindState &bind_state)
+    : ExpressionBinder(binder, context), node(node), bind_state(bind_state) {
 }
 
 BindResult GroupBinder::BindExpression(unique_ptr<ParsedExpression> &expr_ptr, idx_t depth, bool root_expression) {
@@ -22,12 +23,22 @@ BindResult GroupBinder::BindExpression(unique_ptr<ParsedExpression> &expr_ptr, i
 	case ExpressionClass::WINDOW:
 		return BindUnsupportedExpression(expr, depth, "GROUP BY clause cannot contain window functions!");
 	default:
-		return ExpressionBinder::BindExpression(expr_ptr, depth);
+		return ExpressionBinder::BindExpression(expr_ptr, depth, root_expression);
 	}
 }
 
 string GroupBinder::UnsupportedAggregateMessage() {
 	return "GROUP BY clause cannot contain aggregates!";
+}
+
+void GroupBinder::ThrowIfUnnestInLambda(const ColumnBinding &column_binding) {
+	for (auto &node_pair : node.unnests.GroupBy()) {
+		auto &unnest_node = node_pair.second;
+		if (unnest_node.index == column_binding.table_index &&
+		    column_binding.column_index < unnest_node.expressions.size()) {
+			throw BinderException("UNNEST in lambda expressions is not supported");
+		}
+	}
 }
 
 void GroupBinder::ReplaceSelectRef(SelectNode &node, SelectBindState &bind_state, ProjectionIndex group_index,

--- a/src/planner/expression_binder/select_binder.cpp
+++ b/src/planner/expression_binder/select_binder.cpp
@@ -1,6 +1,5 @@
 #include "duckdb/planner/expression_binder/select_binder.hpp"
 #include "duckdb/parser/expression/columnref_expression.hpp"
-#include "duckdb/parser/expression/function_expression.hpp"
 #include "duckdb/planner/query_node/bound_select_node.hpp"
 
 namespace duckdb {

--- a/src/storage/external_file_cache/caching_file_system_wrapper.cpp
+++ b/src/storage/external_file_cache/caching_file_system_wrapper.cpp
@@ -253,7 +253,7 @@ bool CachingFileSystemWrapper::ListFilesExtended(const string &directory,
 }
 
 bool CachingFileSystemWrapper::SupportsListFilesExtended() const {
-	// Cannot delegate to internal filesystem's invocaton since it's `protected`.
+	// Cannot delegate to internal filesystem's invocation since it's `protected`.
 	return true;
 }
 

--- a/test/issues/general/test_5660.test
+++ b/test/issues/general/test_5660.test
@@ -5,10 +5,12 @@
 statement ok
 CREATE TABLE foo AS SELECT 'a, b, c' AS "x", '1' AS y;
 
-statement error
-SELECT y, UNLIST(string_split("x", ', ')) alias, COUNT(*) FROM foo GROUP BY y, alias;
+query TTI
+SELECT y, UNLIST(string_split("x", ', ')) alias, COUNT(*) FROM foo GROUP BY y, alias ORDER BY alias;
 ----
-Binder Error
+1	a	1
+1	b	1
+1	c	1
 
 statement ok
 select * from foo

--- a/test/sql/types/list/unnest_group_by.test
+++ b/test/sql/types/list/unnest_group_by.test
@@ -1,0 +1,187 @@
+# name: test/sql/types/list/unnest_group_by.test
+# description: Test grouping by SELECT-list UNNEST expressions
+# group: [list]
+
+query TI
+SELECT unnest(['a', 'b']) AS tag, count(*) FROM range(1) GROUP BY tag ORDER BY tag
+----
+a	1
+b	1
+
+query TI
+SELECT unnest(['a', 'b']) AS tag, count(*) FROM range(1) GROUP BY 1 ORDER BY 1
+----
+a	1
+b	1
+
+query T
+SELECT trim(unnest([' a ', 'b '])) AS tag ORDER BY tag
+----
+a
+b
+
+statement ok
+CREATE TABLE grouped_unnest_strings(tags VARCHAR);
+
+statement ok
+INSERT INTO grouped_unnest_strings VALUES ('a>b'), ('a>c'), ('b');
+
+query TI
+SELECT unnest(string_split(tags, '>')) AS tag, count(*)
+FROM grouped_unnest_strings
+GROUP BY tag
+ORDER BY tag
+----
+a	2
+b	2
+c	1
+
+query TI
+SELECT unnest(string_split(tags, '>')) AS tag, count(*)
+FROM grouped_unnest_strings
+GROUP BY unnest(string_split(tags, '>'))
+ORDER BY tag
+----
+a	2
+b	2
+c	1
+
+query TI
+SELECT trim(unnest(string_split(tags, '>'))) AS tag, count(*)
+FROM grouped_unnest_strings
+GROUP BY tag
+ORDER BY tag
+----
+a	2
+b	2
+c	1
+
+query TI
+SELECT upper(unnest(string_split(tags, '>'))) AS tag, count(*)
+FROM grouped_unnest_strings
+GROUP BY upper(unnest(string_split(tags, '>')))
+ORDER BY tag
+----
+A	2
+B	2
+C	1
+
+query II
+SELECT nullif(unnest([1, 2]), 0) AS tag, count(*)
+FROM range(1)
+GROUP BY tag
+ORDER BY tag
+----
+1	1
+2	1
+
+query II
+SELECT nullif(unnest([1, 2]), 0) AS tag, count(*)
+FROM range(1)
+GROUP BY nullif(unnest([1, 2]), 0)
+ORDER BY tag
+----
+1	1
+2	1
+
+query III
+SELECT unnest([1, 2]) AS a, unnest([10, 20]) AS b, count(*)
+FROM range(1)
+GROUP BY a, b
+ORDER BY a, b
+----
+1	10	1
+2	20	1
+
+query III
+SELECT unnest([1, 2]) AS g, unnest([10, 20]) AS s, count(*)
+FROM range(1)
+GROUP BY g
+ORDER BY g, s
+----
+1	10	1
+1	20	1
+2	10	1
+2	20	1
+
+statement error
+SELECT unnest(['a', 'b']) AS tag, count(*) FROM range(1) GROUP BY ALL;
+----
+Cannot group on an UNNEST or UNLIST clause
+
+statement error
+SELECT count(*) FROM range(3) t(i) GROUP BY unnest([sum(i)]);
+----
+GROUP BY clause cannot contain aggregates
+
+statement error
+SELECT count(*) FROM range(3) t(i) GROUP BY unnest([row_number() OVER ()]);
+----
+GROUP BY clause cannot contain window functions
+
+statement error
+SELECT count(*) FROM range(1) GROUP BY unnest({'a': 1, 'b': 2});
+----
+UNNEST of struct cannot be used in GROUP BY clause
+
+statement error
+SELECT count(*) FROM range(1) GROUP BY lower(unnest({'a': 'x'}));
+----
+UNNEST of struct cannot be used in GROUP BY clause
+
+query II
+SELECT coalesce(unnest([1, 2]), 0) AS tag, count(*)
+FROM range(1)
+GROUP BY tag
+ORDER BY tag
+----
+1	1
+2	1
+
+query II
+SELECT coalesce(unnest([1, 2]), 0) AS tag, count(*)
+FROM range(1)
+GROUP BY coalesce(unnest([1, 2]), 0)
+ORDER BY tag
+----
+1	1
+2	1
+
+query II
+SELECT abs(coalesce(unnest([-1, -2]), 0)) AS tag, count(*)
+FROM range(1)
+GROUP BY tag
+ORDER BY tag
+----
+1	1
+2	1
+
+query II
+SELECT CASE WHEN true THEN unnest([1, 2]) ELSE 0 END AS tag, count(*)
+FROM range(1)
+GROUP BY tag
+ORDER BY tag
+----
+1	1
+2	1
+
+query II
+SELECT CASE WHEN true THEN unnest([1, 2]) ELSE 0 END AS tag, count(*)
+FROM range(1)
+GROUP BY CASE WHEN true THEN unnest([1, 2]) ELSE 0 END
+ORDER BY tag
+----
+1	1
+2	1
+
+query II
+SELECT abs(CASE WHEN true THEN unnest([-1, -2]) ELSE 0 END) AS tag, count(*)
+FROM range(1)
+GROUP BY tag
+ORDER BY tag
+----
+1	1
+2	1
+
+statement ok
+DROP TABLE grouped_unnest_strings;


### PR DESCRIPTION
This PR makes `UNNEST` usable in `GROUP BY` expressions for list/array inputs.

The binder only had a select-list `UNNEST` path, where the unnest is planned after aggregation/window/qualify and before the final projection. That does not work for grouped `UNNEST` keys: those rows have to be expanded before the aggregate is planned.

The actual `UNNEST` binding logic is shared, so scalar wrappers around list unnests work naturally. This includes aliases, positional references, explicit grouped expressions, `NULLIF`, `COALESCE`, and `CASE`.

This intentionally still does not support `GROUP BY UNNEST(struct_expr)`. Struct `UNNEST` expands to multiple expressions rather than a single grouping key, so that needs a separate multi-key grouping change.