### PR TITLE
WAL group commit: pipelined fsyncs from declared sync semantics

### DIFF
--- a/benchmark/micro/CMakeLists.txt
+++ b/benchmark/micro/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(
   append_mix.cpp
   bulkupdate.cpp
   cast.cpp
+  group_commit.cpp
   in.cpp
   storage.cpp
   string_serialize.cpp)

--- a/benchmark/micro/group_commit.cpp
+++ b/benchmark/micro/group_commit.cpp
@@ -1,0 +1,197 @@
+#include "benchmark_runner.hpp"
+#include "duckdb_benchmark_macro.hpp"
+#include "duckdb/common/local_file_system.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/common/virtual_file_system.hpp"
+
+#include <chrono>
+#include <thread>
+#include <vector>
+
+using namespace duckdb;
+
+// A LocalFileSystem that makes each WAL fsync cost a fixed delay, emulating
+// high-latency durable storage (e.g. networked disks like EFS). With delay 0 the
+// real fsync is performed. This exposes the WAL group-commit benefit, which grows
+// as the fsync gets slower and more concurrent commits batch into each one.
+class DelayFsyncFileSystem : public LocalFileSystem {
+public:
+	explicit DelayFsyncFileSystem(int64_t delay_us_p) : delay_us(delay_us_p) {
+	}
+	void FileSync(FileHandle &handle) override {
+		if (delay_us > 0 && StringUtil::EndsWith(handle.GetPath(), ".wal")) {
+			std::this_thread::sleep_for(std::chrono::microseconds(delay_us));
+			return;
+		}
+		LocalFileSystem::FileSync(handle);
+	}
+	FileSyncParallelism SyncParallelism(FileHandle &handle) override {
+		if (delay_us > 0 && StringUtil::EndsWith(handle.GetPath(), ".wal")) {
+			// the simulated latency stands in for a network round trip, which overlaps
+			return FileSyncParallelism::PARALLEL;
+		}
+		return LocalFileSystem::SyncParallelism(handle);
+	}
+
+private:
+	int64_t delay_us;
+};
+
+// Owns a persistent database whose WAL fsync latency is simulated. The base
+// DuckDBBenchmarkState db/conn (in-memory) are unused; all work runs on gc_db.
+struct GroupCommitState : public DuckDBBenchmarkState {
+	duckdb::unique_ptr<DuckDB> gc_db;
+
+	explicit GroupCommitState(int64_t delay_us) : DuckDBBenchmarkState(string()) {
+		DBConfig config;
+		config.file_system = make_uniq<VirtualFileSystem>(make_uniq<DelayFsyncFileSystem>(delay_us));
+		string path = "duckdb_group_commit_bench.db";
+		DeleteDatabase(path);
+		gc_db = make_uniq<DuckDB>(path, &config);
+		Connection con(*gc_db);
+		// keep the whole run on the WAL path - do not checkpoint mid-run
+		con.Query("SET checkpoint_threshold='1TB'");
+	}
+};
+
+// NUM_THREADS connections each commit COMMITS_PER_THREAD single-row INSERT
+// transactions. Every auto-commit INSERT is its own transaction, so this exercises
+// the group-commit path where concurrent committers batch their WAL fsyncs.
+#define GROUP_COMMIT_BENCHMARK(NUM_THREADS, COMMITS_PER_THREAD, DELAY_US)                                              \
+	duckdb::unique_ptr<DuckDBBenchmarkState> CreateBenchmarkState() override {                                         \
+		return make_uniq<GroupCommitState>(DELAY_US);                                                                  \
+	}                                                                                                                  \
+	void Load(DuckDBBenchmarkState *state_p) override {                                                                \
+		auto state = (GroupCommitState *)state_p;                                                                      \
+		Connection con(*state->gc_db);                                                                                 \
+		con.Query("CREATE TABLE integers(i INTEGER, t INTEGER)");                                                      \
+	}                                                                                                                  \
+	void RunBenchmark(DuckDBBenchmarkState *state_p) override {                                                        \
+		auto state = (GroupCommitState *)state_p;                                                                      \
+		std::vector<std::thread> threads;                                                                              \
+		for (int64_t t = 0; t < NUM_THREADS; t++) {                                                                    \
+			threads.emplace_back([state, t]() {                                                                        \
+				Connection con(*state->gc_db);                                                                         \
+				for (int64_t i = 0; i < COMMITS_PER_THREAD; i++) {                                                     \
+					con.Query("INSERT INTO integers VALUES (" + std::to_string(i) + ", " + std::to_string(t) + ")");   \
+				}                                                                                                      \
+			});                                                                                                        \
+		}                                                                                                              \
+		for (auto &thread : threads) {                                                                                 \
+			thread.join();                                                                                             \
+		}                                                                                                              \
+	}                                                                                                                  \
+	void Cleanup(DuckDBBenchmarkState *state_p) override {                                                             \
+		auto state = (GroupCommitState *)state_p;                                                                      \
+		Connection con(*state->gc_db);                                                                                 \
+		con.Query("DROP TABLE integers");                                                                              \
+		con.Query("CREATE TABLE integers(i INTEGER, t INTEGER)");                                                      \
+	}                                                                                                                  \
+	string VerifyResult(QueryResult *result) override {                                                                \
+		return string();                                                                                               \
+	}                                                                                                                  \
+	string BenchmarkInfo() override {                                                                                  \
+		return std::to_string((int64_t)NUM_THREADS) + " threads commit " +                                             \
+		       std::to_string((int64_t)(NUM_THREADS * COMMITS_PER_THREAD)) + " INSERT transactions, " +                \
+		       std::to_string((int64_t)DELAY_US) + "us simulated WAL fsync latency (group commit)";                    \
+	}
+
+// real local fsync (fixed 16000 total commits)
+DUCKDB_BENCHMARK(GroupCommit1Thread, "[wal]")
+GROUP_COMMIT_BENCHMARK(1, 16000, 0)
+FINISH_BENCHMARK(GroupCommit1Thread)
+
+DUCKDB_BENCHMARK(GroupCommit2Threads, "[wal]")
+GROUP_COMMIT_BENCHMARK(2, 8000, 0)
+FINISH_BENCHMARK(GroupCommit2Threads)
+
+DUCKDB_BENCHMARK(GroupCommit4Threads, "[wal]")
+GROUP_COMMIT_BENCHMARK(4, 4000, 0)
+FINISH_BENCHMARK(GroupCommit4Threads)
+
+DUCKDB_BENCHMARK(GroupCommit8Threads, "[wal]")
+GROUP_COMMIT_BENCHMARK(8, 2000, 0)
+FINISH_BENCHMARK(GroupCommit8Threads)
+
+DUCKDB_BENCHMARK(GroupCommit16Threads, "[wal]")
+GROUP_COMMIT_BENCHMARK(16, 1000, 0)
+FINISH_BENCHMARK(GroupCommit16Threads)
+
+DUCKDB_BENCHMARK(GroupCommit32Threads, "[wal]")
+GROUP_COMMIT_BENCHMARK(32, 500, 0)
+FINISH_BENCHMARK(GroupCommit32Threads)
+
+// 1ms simulated fsync latency (fixed 800 total commits)
+DUCKDB_BENCHMARK(GroupCommit1Thread1ms, "[wal]")
+GROUP_COMMIT_BENCHMARK(1, 800, 1000)
+FINISH_BENCHMARK(GroupCommit1Thread1ms)
+
+DUCKDB_BENCHMARK(GroupCommit2Threads1ms, "[wal]")
+GROUP_COMMIT_BENCHMARK(2, 400, 1000)
+FINISH_BENCHMARK(GroupCommit2Threads1ms)
+
+DUCKDB_BENCHMARK(GroupCommit4Threads1ms, "[wal]")
+GROUP_COMMIT_BENCHMARK(4, 200, 1000)
+FINISH_BENCHMARK(GroupCommit4Threads1ms)
+
+DUCKDB_BENCHMARK(GroupCommit8Threads1ms, "[wal]")
+GROUP_COMMIT_BENCHMARK(8, 100, 1000)
+FINISH_BENCHMARK(GroupCommit8Threads1ms)
+
+DUCKDB_BENCHMARK(GroupCommit16Threads1ms, "[wal]")
+GROUP_COMMIT_BENCHMARK(16, 50, 1000)
+FINISH_BENCHMARK(GroupCommit16Threads1ms)
+
+DUCKDB_BENCHMARK(GroupCommit32Threads1ms, "[wal]")
+GROUP_COMMIT_BENCHMARK(32, 25, 1000)
+FINISH_BENCHMARK(GroupCommit32Threads1ms)
+
+// 10ms simulated fsync latency (fixed 160 total commits)
+DUCKDB_BENCHMARK(GroupCommit1Thread10ms, "[wal]")
+GROUP_COMMIT_BENCHMARK(1, 160, 10000)
+FINISH_BENCHMARK(GroupCommit1Thread10ms)
+
+DUCKDB_BENCHMARK(GroupCommit2Threads10ms, "[wal]")
+GROUP_COMMIT_BENCHMARK(2, 80, 10000)
+FINISH_BENCHMARK(GroupCommit2Threads10ms)
+
+DUCKDB_BENCHMARK(GroupCommit4Threads10ms, "[wal]")
+GROUP_COMMIT_BENCHMARK(4, 40, 10000)
+FINISH_BENCHMARK(GroupCommit4Threads10ms)
+
+DUCKDB_BENCHMARK(GroupCommit8Threads10ms, "[wal]")
+GROUP_COMMIT_BENCHMARK(8, 20, 10000)
+FINISH_BENCHMARK(GroupCommit8Threads10ms)
+
+DUCKDB_BENCHMARK(GroupCommit16Threads10ms, "[wal]")
+GROUP_COMMIT_BENCHMARK(16, 10, 10000)
+FINISH_BENCHMARK(GroupCommit16Threads10ms)
+
+DUCKDB_BENCHMARK(GroupCommit32Threads10ms, "[wal]")
+GROUP_COMMIT_BENCHMARK(32, 5, 10000)
+FINISH_BENCHMARK(GroupCommit32Threads10ms)
+
+// 100ms simulated fsync latency (fixed 64 total commits)
+DUCKDB_BENCHMARK(GroupCommit1Thread100ms, "[wal]")
+GROUP_COMMIT_BENCHMARK(1, 64, 100000)
+FINISH_BENCHMARK(GroupCommit1Thread100ms)
+
+DUCKDB_BENCHMARK(GroupCommit2Threads100ms, "[wal]")
+GROUP_COMMIT_BENCHMARK(2, 32, 100000)
+FINISH_BENCHMARK(GroupCommit2Threads100ms)
+
+DUCKDB_BENCHMARK(GroupCommit4Threads100ms, "[wal]")
+GROUP_COMMIT_BENCHMARK(4, 16, 100000)
+FINISH_BENCHMARK(GroupCommit4Threads100ms)
+
+DUCKDB_BENCHMARK(GroupCommit8Threads100ms, "[wal]")
+GROUP_COMMIT_BENCHMARK(8, 8, 100000)
+FINISH_BENCHMARK(GroupCommit8Threads100ms)
+
+DUCKDB_BENCHMARK(GroupCommit16Threads100ms, "[wal]")
+GROUP_COMMIT_BENCHMARK(16, 4, 100000)
+FINISH_BENCHMARK(GroupCommit16Threads100ms)
+
+DUCKDB_BENCHMARK(GroupCommit32Threads100ms, "[wal]")
+GROUP_COMMIT_BENCHMARK(32, 2, 100000)
+FINISH_BENCHMARK(GroupCommit32Threads100ms)

--- a/src/catalog/catalog_set.cpp
+++ b/src/catalog/catalog_set.cpp
@@ -513,8 +513,13 @@ bool CatalogSet::CreatedByOtherActiveTransaction(CatalogTransaction transaction,
 }
 
 bool CatalogSet::CommittedAfterStarting(CatalogTransaction transaction, transaction_t timestamp) {
-	// The entry has been committed after this transaction started, this is not our source of truth.
-	return (timestamp < TRANSACTION_ID_START && timestamp > transaction.start_time);
+	// The entry has been committed at or after this transaction's snapshot, this is not our source of truth.
+	// At-or-after: a snapshot bounded at the durable horizon can be equal to a commit id, and that commit
+	// is invisible to the snapshot just like any later one. A fresh snapshot never equals a commit id; the
+	// one legitimate equality is the system transaction (start time 1) reading bootstrap entries committed
+	// at timestamp 1, which the transaction id check exempts as its own work.
+	return (timestamp < TRANSACTION_ID_START && timestamp >= transaction.start_time &&
+	        timestamp != transaction.transaction_id);
 }
 
 bool CatalogSet::HasConflict(CatalogTransaction transaction, transaction_t timestamp) {

--- a/src/catalog/dependency_manager.cpp
+++ b/src/catalog/dependency_manager.cpp
@@ -537,7 +537,7 @@ void DependencyManager::VerifyCommitDrop(CatalogTransaction transaction, transac
 	auto info = GetLookupProperties(object);
 	ScanDependents(transaction, info, [&](DependencyEntry &dep) {
 		auto dep_committed_at = dep.timestamp.load();
-		if (dep_committed_at > start_time) {
+		if (dep_committed_at >= start_time) {
 			// In the event of a CASCADE, the dependency drop has not committed yet
 			// so we would be halted by the existence of a dependency we are already dropping unless we check the
 			// timestamp
@@ -555,7 +555,7 @@ void DependencyManager::VerifyCommitDrop(CatalogTransaction transaction, transac
 			return;
 		}
 		D_ASSERT(dep.Subject().flags.IsOwnership());
-		if (dep_committed_at > start_time) {
+		if (dep_committed_at >= start_time) {
 			// Same as above, objects that are owned by the object that is being dropped will be dropped as part of this
 			// transaction. Only objects that were introduced by other transactions, that this transaction could not
 			// see, should cause this error:

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -89,6 +89,7 @@
 #include "duckdb/common/extra_type_info.hpp"
 #include "duckdb/common/file_buffer.hpp"
 #include "duckdb/common/file_open_flags.hpp"
+#include "duckdb/common/file_system.hpp"
 #include "duckdb/common/filename_pattern.hpp"
 #include "duckdb/common/http_util.hpp"
 #include "duckdb/common/multi_file/multi_file_data.hpp"
@@ -2482,6 +2483,24 @@ const char* EnumUtil::ToChars<FileNameSegmentType>(FileNameSegmentType value) {
 template<>
 FileNameSegmentType EnumUtil::FromString<FileNameSegmentType>(const char *value) {
 	return static_cast<FileNameSegmentType>(StringUtil::StringToEnum(GetFileNameSegmentTypeValues(), 4, "FileNameSegmentType", value));
+}
+
+const StringUtil::EnumStringLiteral *GetFileSyncParallelismValues() {
+	static constexpr StringUtil::EnumStringLiteral values[] {
+		{ static_cast<uint32_t>(FileSyncParallelism::SERIAL), "SERIAL" },
+		{ static_cast<uint32_t>(FileSyncParallelism::PARALLEL), "PARALLEL" }
+	};
+	return values;
+}
+
+template<>
+const char* EnumUtil::ToChars<FileSyncParallelism>(FileSyncParallelism value) {
+	return StringUtil::EnumToString(GetFileSyncParallelismValues(), 2, "FileSyncParallelism", static_cast<uint32_t>(value));
+}
+
+template<>
+FileSyncParallelism EnumUtil::FromString<FileSyncParallelism>(const char *value) {
+	return static_cast<FileSyncParallelism>(StringUtil::StringToEnum(GetFileSyncParallelismValues(), 2, "FileSyncParallelism", value));
 }
 
 const StringUtil::EnumStringLiteral *GetFilterPropagateResultValues() {

--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -609,6 +609,10 @@ void FileSystem::FileSync(FileHandle &handle) {
 	throw NotImplementedException("%s: FileSync is not implemented!", GetName());
 }
 
+FileSyncParallelism FileSystem::SyncParallelism(FileHandle &handle) {
+	return FileSyncParallelism::SERIAL;
+}
+
 bool FileSystem::HasGlob(const string &str) {
 	for (idx_t i = 0; i < str.size(); i++) {
 		switch (str[i]) {

--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -26,6 +26,12 @@
 #include <sys/mman.h>
 #include <sys/types.h>
 #include <unistd.h>
+#if defined(__linux__)
+#include <sys/vfs.h>
+#elif defined(__APPLE__)
+#include <sys/param.h>
+#include <sys/mount.h>
+#endif
 #else
 #include "duckdb/common/windows_util.hpp"
 
@@ -861,6 +867,50 @@ void LocalFileSystem::FileSync(FileHandle &handle) {
 	throw IOException("Could not fsync file \"%s\": %s", handle.GetPath(), strerror(errno));
 }
 
+FileSyncParallelism LocalFileSystem::SyncParallelism(FileHandle &handle) {
+#if defined(__linux__)
+	struct statfs fs_info;
+	if (fstatfs(handle.Cast<UnixFileHandle>().fd, &fs_info) != 0) {
+		return FileSyncParallelism::SERIAL;
+	}
+	switch (static_cast<uint64_t>(fs_info.f_type)) {
+	case 0x6969:     // NFS
+	case 0xFF534D42: // CIFS
+	case 0xFE534D42: // SMB2
+	case 0x517B:     // SMB
+	case 0x65735546: // FUSE (includes virtiofs and most userspace network file systems)
+	case 0x01021997: // 9P
+	case 0x73757245: // Coda
+	case 0x5346414F: // AFS
+	case 0x0BD00BD0: // Lustre
+	case 0x00C36400: // Ceph
+	case 0x013111A8: // iBRIX
+	case 0x61756673: // ACFS
+	case 0x0062656C: // BeeGFS
+	case 0xA501FCF5: // VxFS (clustered)
+		// a sync of these is a round trip to a server: concurrent syncs overlap and hide latency
+		return FileSyncParallelism::PARALLEL;
+	default:
+		// local (journaled) file systems: a sync commits the shared journal, concurrent syncs serialize
+		return FileSyncParallelism::SERIAL;
+	}
+#elif defined(__APPLE__)
+	struct statfs fs_info;
+	if (fstatfs(handle.Cast<UnixFileHandle>().fd, &fs_info) != 0) {
+		return FileSyncParallelism::SERIAL;
+	}
+	const char *fs_name = fs_info.f_fstypename;
+	if (strcmp(fs_name, "nfs") == 0 || strcmp(fs_name, "smbfs") == 0 || strcmp(fs_name, "afpfs") == 0 ||
+	    strcmp(fs_name, "webdav") == 0 || strncmp(fs_name, "fuse", 4) == 0 || strcmp(fs_name, "macfuse") == 0 ||
+	    strcmp(fs_name, "osxfuse") == 0) {
+		return FileSyncParallelism::PARALLEL;
+	}
+	return FileSyncParallelism::SERIAL;
+#else
+	return FileSyncParallelism::SERIAL;
+#endif
+}
+
 void LocalFileSystem::MoveFile(const string &source, const string &target, optional_ptr<FileOpener> opener) {
 	auto normalized_source = ExpandPath(source, opener);
 	auto normalized_target = ExpandPath(target, opener);
@@ -1580,14 +1630,71 @@ void LocalFileSystem::FileSync(FileHandle &handle) {
 	}
 }
 
+FileSyncParallelism LocalFileSystem::SyncParallelism(FileHandle &handle) {
+	auto path = handle.GetPath();
+	if (path.size() >= 2 && path[0] == '\\' && path[1] == '\\') {
+		// UNC path: a network share, where a sync is a round trip
+		return FileSyncParallelism::PARALLEL;
+	}
+	if (path.size() >= 2 && path[1] == ':') {
+		wchar_t root[4] = {static_cast<wchar_t>(path[0]), L':', L'\\', L'\0'};
+		if (GetDriveTypeW(root) == DRIVE_REMOTE) {
+			return FileSyncParallelism::PARALLEL;
+		}
+	}
+	return FileSyncParallelism::SERIAL;
+}
+
+#ifndef FILE_RENAME_FLAG_REPLACE_IF_EXISTS
+#define FILE_RENAME_FLAG_REPLACE_IF_EXISTS 0x00000001
+#endif
+#ifndef FILE_RENAME_FLAG_POSIX_SEMANTICS
+#define FILE_RENAME_FLAG_POSIX_SEMANTICS 0x00000002
+#endif
+
 void LocalFileSystem::MoveFile(const string &source, const string &target, optional_ptr<FileOpener> opener) {
 	auto source_unicode = NormalizePathAndConvertToUnicode(*this, source, opener);
 	auto target_unicode = NormalizePathAndConvertToUnicode(*this, target, opener);
 	DWORD flags = MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH;
 
-	if (!MoveFileExW(source_unicode.c_str(), target_unicode.c_str(), flags)) {
+	if (MoveFileExW(source_unicode.c_str(), target_unicode.c_str(), flags)) {
+		return;
+	}
+	DWORD move_error = GetLastError();
+	if (move_error != ERROR_ACCESS_DENIED) {
+		SetLastError(move_error);
 		throw IOException("Could not move file: %s", GetLastErrorAsString());
 	}
+	// MoveFileEx returns ACCESS_DENIED when the target (or source) still has an open handle -- FILE_SHARE_DELETE only
+	// marks it delete-pending and does not free its name until the last handle closes -- or when the target is
+	// read-only. Retry with a POSIX-semantics rename: it replaces an open target atomically and leaves existing
+	// handles valid on the orphaned file, exactly like Unix rename(2). Needs Windows 10 1607+/Server 2016+ on
+	// NTFS/ReFS and the open handles to share FILE_SHARE_DELETE (always set by this file system); where unsupported
+	// it fails and we surface the original error. Mirrors the fallback in Rust std (library/std/src/sys/fs/windows.rs).
+	HANDLE handle = CreateFileW(source_unicode.c_str(), DELETE, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+	                            NULL, OPEN_EXISTING, FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS, NULL);
+	if (handle == INVALID_HANDLE_VALUE) {
+		SetLastError(move_error);
+		throw IOException("Could not move file: %s", GetLastErrorAsString());
+	}
+	// FILE_RENAME_INFO is variable-length: reserve FileName plus its trailing NUL past FileNameLength (which excludes
+	// the NUL), and back it with vector<FILE_RENAME_INFO> so the buffer carries the struct's alignment.
+	const size_t name_bytes = target_unicode.size() * sizeof(wchar_t);
+	const size_t info_bytes = offsetof(FILE_RENAME_INFO, FileName) + name_bytes + sizeof(wchar_t);
+	duckdb::vector<FILE_RENAME_INFO> storage((info_bytes + sizeof(FILE_RENAME_INFO) - 1) / sizeof(FILE_RENAME_INFO));
+	auto &rename_info = storage.front();
+	rename_info.Flags = FILE_RENAME_FLAG_REPLACE_IF_EXISTS | FILE_RENAME_FLAG_POSIX_SEMANTICS;
+	rename_info.RootDirectory = NULL;
+	rename_info.FileNameLength = static_cast<DWORD>(name_bytes);
+	memcpy(rename_info.FileName, target_unicode.c_str(), name_bytes + sizeof(wchar_t));
+	bool renamed = SetFileInformationByHandle(handle, FileRenameInfoEx, &rename_info, static_cast<DWORD>(info_bytes));
+	const DWORD rename_error = renamed ? ERROR_SUCCESS : GetLastError();
+	CloseHandle(handle);
+	if (renamed) {
+		return;
+	}
+	SetLastError(rename_error == ERROR_DIR_NOT_EMPTY ? ERROR_DIR_NOT_EMPTY : move_error);
+	throw IOException("Could not move file: %s", GetLastErrorAsString());
 }
 
 FileType LocalFileSystem::GetFileType(FileHandle &handle) {

--- a/src/include/duckdb/common/enum_util.hpp
+++ b/src/include/duckdb/common/enum_util.hpp
@@ -240,6 +240,8 @@ enum class FileLockType : uint8_t;
 
 enum class FileNameSegmentType : uint8_t;
 
+enum class FileSyncParallelism : uint8_t;
+
 enum class FilterPropagateResult : uint8_t;
 
 enum class ForeignKeyType : uint8_t;
@@ -886,6 +888,9 @@ const char* EnumUtil::ToChars<FileLockType>(FileLockType value);
 
 template<>
 const char* EnumUtil::ToChars<FileNameSegmentType>(FileNameSegmentType value);
+
+template<>
+const char* EnumUtil::ToChars<FileSyncParallelism>(FileSyncParallelism value);
 
 template<>
 const char* EnumUtil::ToChars<FilterPropagateResult>(FilterPropagateResult value);
@@ -1700,6 +1705,9 @@ FileLockType EnumUtil::FromString<FileLockType>(const char *value);
 
 template<>
 FileNameSegmentType EnumUtil::FromString<FileNameSegmentType>(const char *value);
+
+template<>
+FileSyncParallelism EnumUtil::FromString<FileSyncParallelism>(const char *value);
 
 template<>
 FilterPropagateResult EnumUtil::FromString<FilterPropagateResult>(const char *value);

--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -62,6 +62,9 @@ enum class FileType {
 	FILE_TYPE_INVALID,
 };
 
+//! See FileSystem::SyncParallelism
+enum class FileSyncParallelism : uint8_t { SERIAL, PARALLEL };
+
 struct FileMetadata {
 	int64_t file_size = -1;
 	timestamp_t last_modification_time = timestamp_t::ninfinity();
@@ -237,6 +240,12 @@ public:
 	DUCKDB_API virtual void RemoveFiles(const vector<string> &filenames, optional_ptr<FileOpener> opener = nullptr);
 	//! Sync a file handle to disk
 	DUCKDB_API virtual void FileSync(FileHandle &handle);
+	//! What a sync of this file physically is, which determines whether concurrent syncs of one file are useful:
+	//! SERIAL means a sync commits a shared structure (a local file system's journal), so concurrent syncs serialize
+	//! and only add cost; PARALLEL means a sync is a per-call round trip (network file systems), so concurrent syncs
+	//! overlap and hide latency. Defaults to SERIAL, the conservative choice; file systems with round-trip sync
+	//! semantics should override.
+	DUCKDB_API virtual FileSyncParallelism SyncParallelism(FileHandle &handle);
 	//! Sets the working directory
 	DUCKDB_API static void SetWorkingDirectory(const string &path);
 	//! Gets the working directory

--- a/src/include/duckdb/common/local_file_system.hpp
+++ b/src/include/duckdb/common/local_file_system.hpp
@@ -71,6 +71,7 @@ public:
 	void RemoveFile(const string &filename, optional_ptr<FileOpener> opener = nullptr) override;
 	//! Sync a file handle to disk
 	void FileSync(FileHandle &handle) override;
+	FileSyncParallelism SyncParallelism(FileHandle &handle) override;
 
 	//! Checks if path is is an absolute path
 	bool IsPathAbsolute(const string &path) override;

--- a/src/include/duckdb/storage/storage_manager.hpp
+++ b/src/include/duckdb/storage/storage_manager.hpp
@@ -38,6 +38,11 @@ public:
 	virtual void RevertCommit() = 0;
 	// Make the commit persistent
 	virtual void FlushCommit() = 0;
+	//! The WAL byte offset covering this commit's entries after FlushCommit, or 0 if no WAL bytes were written. The
+	//! transaction manager passes this to WriteAheadLog::GroupSync to make the bytes durable before acknowledging.
+	virtual idx_t GetFlushOffset() const {
+		return 0;
+	}
 
 	virtual void AddRowGroupData(DataTable &table, idx_t start_index, idx_t count,
 	                             unique_ptr<PersistentCollectionData> row_group_data) = 0;
@@ -83,6 +88,9 @@ public:
 	void IncrementWALEntriesCount();
 	//! Gets the WAL of the StorageManager, or nullptr, if there is no WAL.
 	optional_ptr<WriteAheadLog> GetWAL();
+	//! Gets a shared owning reference to the WAL. Must be called while holding the WAL lock. Lets a committer pin the
+	//! WAL object across an unlocked GroupSync so a concurrent checkpoint's wal.reset() cannot free it mid-fsync.
+	shared_ptr<WriteAheadLog> GetWALShared();
 	//! Write that we started a checkpoint to the WAL if there is one - returns whether or not there is a WAL
 	bool WALStartCheckpoint(MetaBlockPointer meta_block, CheckpointOptions &options,
 	                        ActiveCheckpointWrapper &active_checkpoint);
@@ -169,8 +177,9 @@ protected:
 	string path;
 	//! The WAL path
 	string wal_path;
-	//! The WriteAheadLog of the storage manager
-	unique_ptr<WriteAheadLog> wal;
+	//! The WriteAheadLog of the storage manager. shared_ptr (not unique) so a committer can pin it across an unlocked
+	//! GroupSync; a checkpoint that resets/recreates the WAL only drops this reference, not the in-flight object.
+	shared_ptr<WriteAheadLog> wal;
 	//! Mutex used to control writes to the WAL
 	mutex wal_lock;
 	//! Whether or not the database is opened in read-only mode

--- a/src/include/duckdb/storage/write_ahead_log.hpp
+++ b/src/include/duckdb/storage/write_ahead_log.hpp
@@ -16,6 +16,9 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/storage/block.hpp"
 
+#include <condition_variable>
+#include <mutex>
+
 namespace duckdb {
 
 struct AlterInfo;
@@ -120,6 +123,15 @@ public:
 	//! Used during RevertCommit.
 	void Truncate(idx_t size);
 	void Flush();
+	//! Append the WAL_FLUSH marker for this commit and push the buffered bytes into the page cache, WITHOUT issuing an
+	//! fsync. Must be called while the WAL lock (StorageManager::wal_lock) is held so the append stays totally ordered.
+	//! Returns the WAL byte offset that covers this commit's entries; the caller must subsequently call GroupSync with
+	//! this offset to make the bytes durable before acknowledging the commit.
+	idx_t FlushAppendNoSync();
+	//! Group commit: make every WAL byte up to (at least) my_offset durable. Called with the WAL lock NOT held, so
+	//! concurrent committers overlap their fsyncs or coalesce onto in-flight ones. A committer returns from this call
+	//! only once durable_offset >= my_offset, i.e. its WAL_FLUSH marker is on stable storage.
+	void GroupSync(idx_t my_offset);
 	//! Increment the WAL entry count, which is used for the auto-checkpoint threshold.
 	void IncrementWALEntriesCount();
 	void WriteCheckpoint(MetaBlockPointer meta_block);
@@ -131,6 +143,43 @@ protected:
 	string wal_path;
 	atomic<WALInitState> init_state;
 	optional_idx checkpoint_iteration;
+
+private:
+	//! Park until sync_epoch differs from current (slow path only; fast paths never touch the mutex).
+	void WaitSyncEpochChange(uint64_t current);
+	//! Bump sync_epoch and wake every parked committer (called after durable_offset advances or the WAL is poisoned).
+	void BumpSyncEpochNotify();
+	//! Maximum number of concurrent fsyncs worth issuing on this WAL's storage, set at initialization from the file
+	//! system's declared sync semantics (FileSystem::SyncParallelism): unbounded where a sync is a per-call round
+	//! trip that overlaps (network file systems), 1 where a sync commits a shared journal and concurrent syncs only
+	//! add cost (local file systems) -- there the single stream's late-snapped targets batch naturally.
+	idx_t sync_lane_cap = 1;
+
+	//! Number of fsyncs currently in flight (bounded by sync_lane_cap).
+	atomic<idx_t> active_syncs = 0;
+	//! Raise-only maximum target of any in-flight (or completed) fsync: a committer whose bytes are already covered
+	//! by an in-flight fsync parks instead of claiming a lane for a redundant fsync.
+	atomic<idx_t> syncing_target = 0;
+	//! Bumped by Truncate (under the WAL lock, after draining lanes): a sync lane whose fsync raced a truncate
+	//! discards its durable_offset raise, since its snapshotted target may lie beyond the truncation point.
+	atomic<uint64_t> truncate_gen = 0;
+	//! Parking word for committers waiting on durability: bumped on every durable_offset advance and on failure.
+	atomic<uint64_t> sync_epoch = 0;
+	//! Terminal poison flag: after a failed fsync the OS may have dropped the failed dirty pages as clean, so a
+	//! retried fsync could falsely report success for bytes that never reached disk -- durability can no longer be
+	//! promised for any pending offset.
+	atomic<bool> sync_failed = false;
+	//! Guards only the parking of sync waiters; committers that are covered by a completed fsync, and committers
+	//! issuing their own fsync, never take it.
+	std::mutex sync_wait_mutex;
+	std::condition_variable sync_wait_cv;
+	//! Highest WAL byte offset known durable. Raise-only; stored by an fsyncer strictly AFTER its Sync() returns,
+	//! acquire-loaded as the sole durable-before-ack predicate.
+	atomic<idx_t> durable_offset = 0;
+	//! Highest WAL byte offset pushed to the page cache (writer->Flush()). Release-stored under the WAL lock by
+	//! FlushAppendNoSync (so it is monotonic and needs no sync coordination), acquire-loaded by fsyncers as their
+	//! target, and clamped down by Truncate.
+	atomic<idx_t> flushed_offset = 0;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/transaction/duck_transaction.hpp
+++ b/src/include/duckdb/transaction/duck_transaction.hpp
@@ -31,6 +31,10 @@ struct CommitInfo {
 	transaction_t commit_id;
 	ActiveTransactionState active_transactions = ActiveTransactionState::UNSET;
 	optional_ptr<CommitDropState> drop_state;
+	//! WAL byte offset covering this commit's entries after FlushCommit appended+flushed (without fsync), or 0 if no
+	//! WAL bytes were written. The transaction manager passes this to WriteAheadLog::GroupSync to make the bytes
+	//! durable.
+	idx_t wal_flush_offset = 0;
 };
 
 class DuckTransaction : public Transaction {

--- a/src/include/duckdb/transaction/duck_transaction_manager.hpp
+++ b/src/include/duckdb/transaction/duck_transaction_manager.hpp
@@ -13,9 +13,12 @@
 #include "duckdb/common/enums/checkpoint_type.hpp"
 #include "duckdb/common/queue.hpp"
 
+#include <thread>
+
 namespace duckdb {
 class DuckTransactionManager;
 class DuckTransaction;
+class WriteAheadLog;
 struct UndoBufferProperties;
 
 //! CleanupInfo collects transactions awaiting cleanup.
@@ -62,6 +65,10 @@ public:
 	}
 	void SetActiveCheckpoint(transaction_t checkpoint_id);
 	void ResetActiveCheckpoint();
+	//! Move a checkpoint transaction's snapshot up to a fresh timestamp: the checkpoint persists every committed
+	//! transaction and truncates the WAL, so it must also see commits whose group fsync is still pending -- a
+	//! durability-bounded snapshot would silently drop them from the checkpoint
+	void RefreshCheckpointSnapshot(DuckTransaction &transaction);
 
 	bool IsDuckTransactionManager() override {
 		return true;
@@ -96,19 +103,32 @@ protected:
 private:
 	//! Generates a new commit timestamp
 	transaction_t GetCommitTimestamp();
+	//! The snapshot bound for a transaction starting now: normally the passed fresh timestamp, but while commits are
+	//! awaiting their group fsync, just above the last durable commit instead -- the new snapshot then excludes
+	//! exactly the non-durable suffix, so no transaction can ever observe a commit that a crash could still lose,
+	//! and starting a transaction never waits. Must be called with transaction_lock held.
+	transaction_t DurableSnapshotBound(transaction_t fresh_start_time);
 	//! Remove the given transaction from the list of active transactions
 	unique_ptr<DuckCleanupInfo> RemoveTransaction(DuckTransaction &transaction) noexcept;
 	//! Remove the given transaction from the list of active transactions
 	unique_ptr<DuckCleanupInfo> RemoveTransaction(DuckTransaction &transaction, bool store_transaction) noexcept;
 
-	//! Whether or not we can checkpoint
+	//! Whether or not we can checkpoint. For a WAL-skipping commit (take_start_gate), start_gate tries to acquire
+	//! start_transaction_lock before the exclusive checkpoint lock, in the same order as Checkpoint()
 	CheckpointDecision CanCheckpoint(DuckTransaction &transaction, unique_ptr<StorageLockKey> &checkpoint_lock,
-	                                 const UndoBufferProperties &properties);
+	                                 const UndoBufferProperties &properties, unique_lock<mutex> &start_gate,
+	                                 bool take_start_gate);
 	//! Get the checkpoint type of an automatic checkpoint
 	CheckpointDecision GetCheckpointType(DuckTransaction &transaction, const UndoBufferProperties &undo_properties);
 
 	bool HasOtherTransactions(DuckTransaction &transaction);
 	void CleanupTransactions();
+	//! Promote every eligible recently-committed transaction to cleanup and process the queue, keeping commits the
+	//! durable horizon still bounds unless include_non_durable (a WAL-skipping checkpoint cleaning its own commit,
+	//! under the start gate).
+	void DrainCleanups(bool include_non_durable);
+	//! Wait until the group fsyncs of all published commits have completed and raised the durable horizon
+	void WaitForInFlightCommits();
 
 private:
 	//! The current start timestamp used by transactions
@@ -135,6 +155,16 @@ private:
 	StorageLock vacuum_lock;
 	//! Lock necessary to start transactions only - used by FORCE CHECKPOINT to prevent new transactions from starting
 	mutex start_transaction_lock;
+	//! Thread holding start_transaction_lock across an in-commit checkpoint. Transactions the checkpoint itself
+	//! starts (e.g. binding replay-buffered indexes) must not re-acquire the gate and deadlock on it.
+	atomic<std::thread::id> start_gate_holder;
+	//! Highest commit id that wrote WAL bytes, stored under transaction_lock in the same critical section that
+	//! publishes the commit (so it is monotonic). Durability follows commit order (commit order = WAL order = fsync
+	//! coverage order), so together with last_durable_commit it bounds new snapshots at the durable horizon.
+	atomic<transaction_t> last_pending_commit = 0;
+	//! Highest commit id whose WAL bytes are known durable. Raised (raise-only CAS) by each committer once its group
+	//! fsync covers its flush marker; acknowledgements can race out of commit order, hence the max.
+	atomic<transaction_t> last_durable_commit = 0;
 
 	atomic<idx_t> last_uncommitted_catalog_version = {TRANSACTION_ID_START};
 	idx_t last_committed_version = 0;

--- a/src/include/duckdb/transaction/update_info.hpp
+++ b/src/include/duckdb/transaction/update_info.hpp
@@ -58,13 +58,13 @@ struct UpdateInfo {
 	}
 
 	bool AppliesToTransaction(transaction_t start_time, transaction_t transaction_id) {
-		// these tuples were either committed AFTER this transaction started or are not committed yet, use
-		// tuples stored in this version
+		// these tuples were either committed at or after this transaction's snapshot or are not committed yet,
+		// use tuples stored in this version
 		if (version_number == TRANSACTION_ID_START - 1) {
 			// dummy transaction number for the root element - should always match
 			return true;
 		}
-		return version_number > start_time && version_number != transaction_id;
+		return version_number >= start_time && version_number != transaction_id;
 	}
 
 	//! Loop over the update chain and execute the specified callback on all UpdateInfo's that are relevant for that

--- a/src/storage/checkpoint_manager.cpp
+++ b/src/storage/checkpoint_manager.cpp
@@ -65,6 +65,7 @@ void ActiveCheckpointWrapper::GetCheckpointTransaction(CheckpointOptions &option
 	checkpoint_context->transaction.SetReadOnly();
 	auto &transaction = DuckTransaction::Get(*checkpoint_context, db);
 	transaction.SetIsCheckpointTransaction();
+	transaction_manager.RefreshCheckpointSnapshot(transaction);
 	checkpoint_transaction = &transaction;
 	options.transaction_id = transaction.start_time;
 	transaction_manager.SetActiveCheckpoint(transaction.start_time);

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -215,6 +215,10 @@ optional_ptr<WriteAheadLog> StorageManager::GetWAL() {
 	return wal.get();
 }
 
+shared_ptr<WriteAheadLog> StorageManager::GetWALShared() {
+	return wal;
+}
+
 // comparison used to see whether the storage version is compatible
 bool StorageManager::TargetAtLeastVersion(StorageVersion target_version, idx_t storage_version) {
 	if (storage_version < static_cast<idx_t>(target_version)) {
@@ -298,7 +302,8 @@ bool StorageManager::WALStartCheckpoint(MetaBlockPointer meta_block, CheckpointO
 	// as such override the checkpoint iteration number to the next one
 	auto &single_file_block_manager = GetBlockManager().Cast<SingleFileBlockManager>();
 	auto next_checkpoint_iteration = single_file_block_manager.GetCheckpointIteration() + 1;
-	wal = make_uniq<WriteAheadLog>(*this, checkpoint_wal_path, 0ULL, WALInitState::NO_WAL, next_checkpoint_iteration);
+	wal = make_shared_ptr<WriteAheadLog>(*this, checkpoint_wal_path, 0ULL, WALInitState::NO_WAL,
+	                                     next_checkpoint_iteration);
 	return true;
 }
 
@@ -314,7 +319,7 @@ void StorageManager::WALFinishCheckpoint(unique_lock<mutex> &) {
 		// in this case we can just remove the main WAL and re-instantiate it to empty
 		fs.TryRemoveFile(wal_path);
 		ResetWALEntriesCount();
-		wal = make_uniq<WriteAheadLog>(*this, wal_path);
+		wal = make_shared_ptr<WriteAheadLog>(*this, wal_path);
 		return;
 	}
 
@@ -327,7 +332,7 @@ void StorageManager::WALFinishCheckpoint(unique_lock<mutex> &) {
 	fs.MoveFile(checkpoint_wal_path, wal_path);
 
 	// open what is now the main WAL again
-	wal = make_uniq<WriteAheadLog>(*this, wal_path);
+	wal = make_shared_ptr<WriteAheadLog>(*this, wal_path);
 	wal->Initialize();
 
 	DUCKDB_LOG(db.GetDatabase(), TransactionLogType, db, "Finish Checkpoint");
@@ -503,7 +508,7 @@ void SingleFileStorageManager::LoadDatabase(QueryContext context) {
 		sf_block_manager->CreateNewDatabase(context);
 		block_manager = std::move(sf_block_manager);
 		table_io_manager = make_uniq<SingleFileTableIOManager>(*block_manager, row_group_size);
-		wal = make_uniq<WriteAheadLog>(*this, wal_path);
+		wal = make_shared_ptr<WriteAheadLog>(*this, wal_path);
 
 	} else {
 		// Either the file exists, or we are in read-only mode, so we
@@ -620,6 +625,9 @@ public:
 	void RevertCommit() override;
 	// Make the commit persistent
 	void FlushCommit() override;
+	idx_t GetFlushOffset() const override {
+		return flush_offset;
+	}
 
 	void AddRowGroupData(DataTable &table, idx_t start_index, idx_t count,
 	                     unique_ptr<PersistentCollectionData> row_group_data) override;
@@ -629,6 +637,10 @@ public:
 private:
 	idx_t initial_wal_size = 0;
 	idx_t initial_written = 0;
+	//! WAL byte offset covering this commit after the buffered append+marker flush (set by FlushCommit). The fsync is
+	//! deferred to WriteAheadLog::GroupSync, which the transaction manager calls once both the transaction and WAL
+	//! locks are released, so fsyncs overlap or coalesce across concurrent committers.
+	idx_t flush_offset = 0;
 	WriteAheadLog &wal;
 	WALCommitState state;
 	reference_map_t<DataTable, unordered_map<idx_t, OptimisticallyWrittenRowGroupData>> optimistically_written_data;
@@ -674,8 +686,11 @@ void SingleFileStorageCommitState::FlushCommit() {
 	if (state != WALCommitState::IN_PROGRESS) {
 		return;
 	}
-	// Move the blocks in this COMMIT into the WAL and mark them as "in use".
-	wal.Flush();
+	// Append the WAL_FLUSH marker and push this commit's bytes into the page cache, but defer the fsync: the
+	// transaction manager issues WriteAheadLog::GroupSync(flush_offset) after dropping the transaction and WAL locks,
+	// so concurrent committers overlap or share fsyncs while durability is still guaranteed before the commit is
+	// acknowledged.
+	flush_offset = wal.FlushAppendNoSync();
 	state = WALCommitState::FLUSHED;
 }
 

--- a/src/storage/table/update_segment.cpp
+++ b/src/storage/table/update_segment.cpp
@@ -673,7 +673,7 @@ static void CheckForConflicts(UndoBufferPointer next_ptr, TransactionData transa
 		if (info.version_number == transaction.transaction_id) {
 			// this UpdateInfo belongs to the current transaction, set it in the node
 			node_ref = std::move(pin);
-		} else if (info.version_number > transaction.start_time) {
+		} else if (info.version_number >= transaction.start_time) {
 			// potential conflict, check that tuple ids do not conflict
 			// as both ids and info->tuples are sorted, this is similar to a merge join
 			idx_t i = 0, j = 0;

--- a/src/storage/write_ahead_log.cpp
+++ b/src/storage/write_ahead_log.cpp
@@ -11,6 +11,8 @@
 #include "duckdb/catalog/duck_catalog.hpp"
 #include "duckdb/common/checksum.hpp"
 #include "duckdb/common/encryption_functions.hpp"
+#include "duckdb/common/error_data.hpp"
+
 #include "duckdb/common/encryption_key_manager.hpp"
 #include "duckdb/common/serializer/binary_serializer.hpp"
 #include "duckdb/common/serializer/memory_stream.hpp"
@@ -66,6 +68,9 @@ BufferedFileWriter &WriteAheadLog::Initialize() {
 		} else {
 			storage_manager.SetWALSize(writer->GetFileSize());
 		}
+		sync_lane_cap = writer->handle->file_system.SyncParallelism(*writer->handle) == FileSyncParallelism::PARALLEL
+		                    ? NumericLimits<idx_t>::Maximum()
+		                    : 1;
 		init_state = WALInitState::INITIALIZED;
 	}
 	return *writer;
@@ -89,7 +94,28 @@ void WriteAheadLog::Truncate(idx_t size) {
 		return;
 	}
 	writer->Truncate(size);
-	storage_manager.SetWALSize(writer->GetFileSize());
+	idx_t truncated = writer->GetFileSize();
+	storage_manager.SetWALSize(truncated);
+	// Truncate runs under the WAL lock (the same lock that serializes the FlushAppendNoSync publish), so lower the
+	// published page-cache offset too -- otherwise a later fsync could snapshot a target beyond the file. The order
+	// below is load-bearing: after the flushed clamp, the generation bump makes the clamped offset visible to every
+	// fsync that starts afterwards (its acquire-load of the generation precedes its target snapshot); an fsync from
+	// before the bump discards its durable_offset raise on the generation mismatch; and the drain guarantees no raise
+	// can land after the final durable clamp.
+	if (truncated < flushed_offset.load(std::memory_order_acquire)) {
+		flushed_offset.store(truncated, std::memory_order_release);
+	}
+	truncate_gen.fetch_add(1, std::memory_order_acq_rel);
+	while (active_syncs.load(std::memory_order_acquire) > 0) {
+		uint64_t epoch = sync_epoch.load(std::memory_order_acquire);
+		if (active_syncs.load(std::memory_order_acquire) == 0) {
+			break;
+		}
+		WaitSyncEpochChange(epoch);
+	}
+	if (truncated < durable_offset.load(std::memory_order_acquire)) {
+		durable_offset.store(truncated, std::memory_order_release);
+	}
 }
 
 bool WriteAheadLog::Initialized() const {
@@ -588,6 +614,108 @@ void WriteAheadLog::Flush() {
 	// flushes all changes made to the WAL to disk
 	writer->Sync();
 	storage_manager.SetWALSize(writer->GetFileSize());
+}
+
+idx_t WriteAheadLog::FlushAppendNoSync() {
+	if (!writer) {
+		return 0;
+	}
+
+	// write an empty entry, marking the end of this commit in the WAL byte stream
+	WriteAheadLogSerializer serializer(*this, WALType::WAL_FLUSH);
+	serializer.End();
+
+	// push the buffered bytes into the OS page cache, but do NOT fsync yet -- the grouped fsync in GroupSync makes
+	// them durable. Appends are serialized under the WAL lock, so the returned offset covers exactly this commit's
+	// entries (and every earlier commit's), and the publish below is monotonic with a plain release store.
+	writer->Flush();
+	auto offset = writer->GetFileSize();
+	storage_manager.SetWALSize(offset);
+	flushed_offset.store(offset, std::memory_order_release);
+	return offset;
+}
+
+void WriteAheadLog::BumpSyncEpochNotify() {
+	{
+		// the epoch advances under the same mutex that guards the waiters' predicate check, so a waiter either sees
+		// the new epoch and does not park, or is parked and receives the notify; notifying after the unlock keeps
+		// woken waiters from immediately colliding with a held mutex
+		std::lock_guard<std::mutex> guard(sync_wait_mutex);
+		sync_epoch.fetch_add(1, std::memory_order_acq_rel);
+	}
+	sync_wait_cv.notify_all();
+}
+
+void WriteAheadLog::WaitSyncEpochChange(uint64_t current) {
+	std::unique_lock<std::mutex> guard(sync_wait_mutex);
+	sync_wait_cv.wait(guard, [&]() { return sync_epoch.load(std::memory_order_acquire) != current; });
+}
+
+void WriteAheadLog::GroupSync(idx_t my_offset) {
+	if (!writer || my_offset == 0) {
+		return;
+	}
+	for (;;) {
+		// the epoch must be read BEFORE the durable/failed checks: a bump between those checks and the park then
+		// makes the park return immediately instead of missing the update
+		uint64_t epoch = sync_epoch.load(std::memory_order_acquire);
+		if (durable_offset.load(std::memory_order_acquire) >= my_offset) {
+			return;
+		}
+		if (sync_failed.load(std::memory_order_acquire)) {
+			throw FatalException("Failed to sync WAL during commit: an earlier WAL sync failed, durability can no "
+			                     "longer be guaranteed");
+		}
+		// A committer fsyncs itself -- overlapping with any fsyncs already in flight, up to the file system's declared
+		// sync parallelism -- unless an in-flight fsync's target already covers its bytes, in which case
+		// it parks until durability advances. Overlapping fsyncs pipeline the device/network round trips (a commit
+		// arriving mid-fsync does not wait out someone else's round trip); committers beyond the cap park, and the
+		// next fsync's late-snapped target covers them (group commit, no delay).
+		idx_t lanes = active_syncs.load(std::memory_order_acquire);
+		if (lanes > 0 && syncing_target.load(std::memory_order_acquire) >= my_offset) {
+			// if the covering fsync completes between the two loads, its epoch bump makes this park return immediately
+			WaitSyncEpochChange(epoch);
+			continue;
+		}
+		if (lanes >= sync_lane_cap || !active_syncs.compare_exchange_strong(lanes, lanes + 1, std::memory_order_acq_rel,
+		                                                                    std::memory_order_acquire)) {
+			WaitSyncEpochChange(epoch);
+			continue;
+		}
+		// cover every byte flushed (under the WAL lock) up to now -- includes our own bytes
+		uint64_t gen = truncate_gen.load(std::memory_order_acquire);
+		idx_t target = flushed_offset.load(std::memory_order_acquire);
+		idx_t prev_syncing = syncing_target.load(std::memory_order_relaxed);
+		while (prev_syncing < target &&
+		       !syncing_target.compare_exchange_weak(prev_syncing, target, std::memory_order_release,
+		                                             std::memory_order_relaxed)) {
+		}
+		try {
+			writer->handle->Sync();
+		} catch (const std::exception &ex) {
+			// A failed fsync is unrecoverable: the OS may have dropped the failed dirty pages as clean, so a
+			// retried fsync could falsely report success for bytes that never reached disk. Poison the WAL so
+			// every pending and future committer fails, and escalate to a fatal error so the database is
+			// invalidated and recovers from the durable WAL prefix on reopen.
+			sync_failed.store(true, std::memory_order_release);
+			active_syncs.fetch_sub(1, std::memory_order_acq_rel);
+			BumpSyncEpochNotify();
+			ErrorData error(ex);
+			throw FatalException("Failed to sync WAL during commit. Cannot continue operation.\nError: %s",
+			                     error.Message());
+		}
+		// raise durable_offset to (at least) this fsync's target; concurrent fsyncs may race, take the max.
+		// If a truncate intervened, the snapshotted target may exceed the truncation point -- discard the raise
+		// and loop; our own marker (if still valid) is covered by a fresh fsync with a fresh target.
+		if (truncate_gen.load(std::memory_order_acquire) == gen) {
+			idx_t durable = durable_offset.load(std::memory_order_relaxed);
+			while (durable < target && !durable_offset.compare_exchange_weak(durable, target, std::memory_order_release,
+			                                                                 std::memory_order_relaxed)) {
+			}
+		}
+		active_syncs.fetch_sub(1, std::memory_order_acq_rel);
+		BumpSyncEpochNotify();
+	}
 }
 
 void WriteAheadLog::IncrementWALEntriesCount() {

--- a/src/transaction/duck_transaction.cpp
+++ b/src/transaction/duck_transaction.cpp
@@ -273,7 +273,10 @@ ErrorData DuckTransaction::Commit(AttachedDatabase &db, CommitInfo &commit_info,
 		}
 		if (commit_state) {
 			// if we have written to the WAL - flush after the commit has been successful
+			// this appends the WAL_FLUSH marker and pushes the bytes into the page cache, but defers the fsync; the
+			// transaction manager issues GroupSync once the locks are dropped
 			commit_state->FlushCommit();
+			commit_info.wal_flush_offset = commit_state->GetFlushOffset();
 		}
 		drop_state.FinalizeCommit();
 		return ErrorData();

--- a/src/transaction/duck_transaction_manager.cpp
+++ b/src/transaction/duck_transaction_manager.cpp
@@ -21,6 +21,8 @@
 #include "duckdb/storage/checkpoint/checkpoint_options.hpp"
 #include "duckdb/common/string_util.hpp"
 
+#include <thread>
+
 namespace duckdb {
 
 static ErrorData BuildAutocheckpointError(AttachedDatabase &db, const std::exception &ex) {
@@ -31,6 +33,28 @@ static ErrorData BuildAutocheckpointError(AttachedDatabase &db, const std::excep
 	                                recovery, original.RawMessage());
 	return ErrorData(original.Type(), msg);
 }
+
+//! Publishes the identity of the thread holding the start-transaction gate across an in-commit checkpoint, so
+//! transactions the checkpoint itself starts can recognize the gate as their own. Clears and unlocks together,
+//! also on unwinding, so the marker can never outlive the gate.
+struct StartGateHolder {
+	StartGateHolder(atomic<std::thread::id> &holder_p, unique_lock<mutex> &gate_p) : holder(holder_p), gate(gate_p) {
+		if (gate.owns_lock()) {
+			holder.store(std::this_thread::get_id(), std::memory_order_release);
+		}
+	}
+	~StartGateHolder() {
+		Release();
+	}
+	void Release() {
+		if (gate.owns_lock()) {
+			holder.store(std::thread::id(), std::memory_order_release);
+			gate.unlock();
+		}
+	}
+	atomic<std::thread::id> &holder;
+	unique_lock<mutex> &gate;
+};
 
 void DuckCleanupInfo::Cleanup() {
 	for (auto &transaction : transactions) {
@@ -76,7 +100,8 @@ Transaction &DuckTransactionManager::StartTransaction(ClientContext &context) {
 	// obtain the transaction lock during this function
 	auto &meta_transaction = MetaTransaction::Get(context);
 	unique_lock<mutex> start_lock(start_transaction_lock, std::defer_lock);
-	if (!meta_transaction.IsReadOnly()) {
+	if (!meta_transaction.IsReadOnly() &&
+	    start_gate_holder.load(std::memory_order_acquire) != std::this_thread::get_id()) {
 		start_lock.lock();
 	}
 	lock_guard<mutex> lock(transaction_lock);
@@ -86,7 +111,7 @@ Transaction &DuckTransactionManager::StartTransaction(ClientContext &context) {
 	} // LCOV_EXCL_STOP
 
 	// obtain the start time and transaction ID of this transaction
-	transaction_t start_time = current_start_timestamp++;
+	transaction_t start_time = DurableSnapshotBound(current_start_timestamp++);
 	transaction_t transaction_id = current_transaction_id++;
 	if (active_transactions.empty()) {
 		lowest_active_start = start_time;
@@ -100,6 +125,28 @@ Transaction &DuckTransactionManager::StartTransaction(ClientContext &context) {
 	// store it in the set of active transactions
 	active_transactions.push_back(std::move(transaction));
 	return transaction_ref;
+}
+
+transaction_t DuckTransactionManager::DurableSnapshotBound(transaction_t fresh_start_time) {
+	// caller must hold transaction_lock: commits store last_pending_commit in the same critical section that makes
+	// them visible, so a snapshot bounded here either misses a commit entirely or sees its durability recorded
+	transaction_t durable = last_durable_commit.load(std::memory_order_acquire);
+	if (durable >= last_pending_commit.load(std::memory_order_acquire)) {
+		return fresh_start_time;
+	}
+	// commit order equals WAL order equals durability order, so the non-durable commits are exactly the suffix
+	// above last_durable_commit: a snapshot just above it sees every durable commit and no non-durable one.
+	// Floor at the lowest fresh timestamp: bootstrap catalog entries are committed at timestamp 1 by the system
+	// transaction and recreated deterministically on every database open, so they must stay visible even before
+	// the first commit is durable, while every real commit id is at least 2 and stays correctly excluded
+	return MaxValue<transaction_t>(durable + 1, 2);
+}
+
+void DuckTransactionManager::RefreshCheckpointSnapshot(DuckTransaction &transaction) {
+	// under transaction_lock every commit at a lower timestamp is fully applied, and the recomputation of
+	// lowest_active_start on transaction removal scans the live start times, so raising this one is consistent
+	lock_guard<mutex> lock(transaction_lock);
+	transaction.start_time = current_start_timestamp++;
 }
 
 void DuckTransactionManager::SetActiveCheckpoint(transaction_t checkpoint_id) {
@@ -131,7 +178,8 @@ bool DuckTransactionManager::HasOtherTransactions(DuckTransaction &transaction) 
 
 DuckTransactionManager::CheckpointDecision
 DuckTransactionManager::CanCheckpoint(DuckTransaction &transaction, unique_ptr<StorageLockKey> &lock,
-                                      const UndoBufferProperties &undo_properties) {
+                                      const UndoBufferProperties &undo_properties, unique_lock<mutex> &start_gate,
+                                      bool take_start_gate) {
 	if (db.IsSystem()) {
 		return CheckpointDecision("system transaction");
 	}
@@ -148,13 +196,38 @@ DuckTransactionManager::CanCheckpoint(DuckTransaction &transaction, unique_ptr<S
 	if (Settings::Get<DebugSkipCheckpointOnCommitSetting>(db.GetDatabase())) {
 		return CheckpointDecision("checkpointing on commit disabled through configuration");
 	}
+	if (take_start_gate) {
+		// a WAL-skipping commit stays non-durable for its whole checkpoint, so block new transactions meanwhile --
+		// else a snapshot could be bounded below it and need versions the checkpoint vacuums. Try-only, taken before
+		// the exclusive checkpoint lock (same order as Checkpoint(), so no deadlock); on failure the commit falls
+		// back to a normal WAL write. WAL-writing commits are durable before their checkpoint and skip the gate
+		(void)start_gate.try_lock();
+	}
+	// let the in-flight group fsyncs land and run the cleanups the durable horizon held back: committed but
+	// not-yet-cleaned transactions keep their shared checkpoint lock, and would otherwise starve the exclusive
+	// acquisition below when no later transaction re-evaluates the cleanup threshold
+	WaitForInFlightCommits();
+	DrainCleanups(false);
 	// try to lock the checkpoint lock
 	lock = transaction.TryGetCheckpointLock();
 	if (!lock) {
+		if (start_gate.owns_lock()) {
+			start_gate.unlock();
+		}
 		return CheckpointDecision("Failed to obtain checkpoint lock - another thread is writing/checkpointing or "
 		                          "another read transaction relies on data that is not yet committed");
 	}
 	return CheckpointDecision(CheckpointType::FULL_CHECKPOINT);
+}
+
+void DuckTransactionManager::WaitForInFlightCommits() {
+	// group fsyncs of already-published commits complete on their committers' threads without needing any lock
+	// held here, and every published commit raises the durable horizon on its durability path. The target is
+	// snapped once, so the wait is bounded by the fsyncs in flight now, not by later commits
+	transaction_t target = last_pending_commit.load(std::memory_order_acquire);
+	while (last_durable_commit.load(std::memory_order_acquire) < target) {
+		std::this_thread::yield();
+	}
 }
 
 DuckTransactionManager::CheckpointDecision
@@ -223,6 +296,10 @@ void DuckTransactionManager::Checkpoint(ClientContext &context, bool force) {
 	}
 
 	unique_ptr<StorageLockKey> lock;
+	// let the in-flight group fsyncs land and run the cleanups the durable horizon held back: committed but
+	// not-yet-cleaned transactions keep their shared checkpoint lock and would block the exclusive acquisition
+	WaitForInFlightCommits();
+	DrainCleanups(false);
 	if (!force) {
 		// not a force checkpoint
 		// try to get the checkpoint lock
@@ -240,9 +317,14 @@ void DuckTransactionManager::Checkpoint(ClientContext &context, bool force) {
 		// wait until any active transactions are finished
 		while (!lock) {
 			context.InterruptCheck();
+			WaitForInFlightCommits();
+			DrainCleanups(false);
 			lock = checkpoint_lock.TryGetExclusiveLock();
 		}
 	}
+	// a full checkpoint (chosen below when no active snapshot needs old data) is safe without blocking new
+	// transactions: after the drain the durable horizon covers every pending commit and the exclusive checkpoint
+	// lock keeps new write commits out, so a snapshot taken during the checkpoint is fresh
 	CheckpointOptions options;
 	if (GetLastCommit() > LowestActiveStart()) {
 		// we cannot do a full checkpoint if any transaction needs to read old data
@@ -276,6 +358,45 @@ transaction_t DuckTransactionManager::GetCommitTimestamp() {
 	return current_start_timestamp++;
 }
 
+void DuckTransactionManager::DrainCleanups(bool include_non_durable) {
+	// promote up to the minimum live start time, clamped at the durable horizon (like RemoveTransaction), so a commit
+	// whose fsync is still in flight keeps the versions a bounded snapshot may still see. Only a checkpoint carrying
+	// its own commit (include_non_durable) promotes past the horizon -- its start gate blocks such snapshots
+	auto cleanup_info = make_uniq<DuckCleanupInfo>();
+	{
+		lock_guard<mutex> lock(transaction_lock);
+		auto lowest_start_time = TRANSACTION_ID_START;
+		for (auto &active_transaction : active_transactions) {
+			lowest_start_time = MinValue(lowest_start_time, active_transaction->start_time);
+		}
+		// refresh the cached lower bound: it may still carry the durable-horizon clamp of an earlier
+		// RemoveTransaction, and a stale-low value silently downgrades full checkpoints to concurrent ones
+		lowest_active_start = MinValue(lowest_start_time, DurableSnapshotBound(TRANSACTION_ID_START));
+		if (!include_non_durable) {
+			lowest_start_time = MinValue(lowest_start_time, DurableSnapshotBound(TRANSACTION_ID_START));
+		}
+		cleanup_info->lowest_start_time = lowest_start_time;
+		idx_t i = 0;
+		for (; i < recently_committed_transactions.size(); i++) {
+			if (recently_committed_transactions[i]->commit_id >= lowest_start_time) {
+				break;
+			}
+			recently_committed_transactions[i]->awaiting_cleanup = true;
+			cleanup_info->transactions.push_back(std::move(recently_committed_transactions[i]));
+		}
+		if (i > 0) {
+			auto start = recently_committed_transactions.begin();
+			auto end = recently_committed_transactions.begin() + static_cast<int64_t>(i);
+			recently_committed_transactions.erase(start, end);
+		}
+	}
+	if (cleanup_info->ScheduleCleanup()) {
+		lock_guard<mutex> q_lock(cleanup_queue_lock);
+		cleanup_queue.emplace(std::move(cleanup_info));
+	}
+	CleanupTransactions();
+}
+
 void DuckTransactionManager::CleanupTransactions() {
 	lock_guard<mutex> c_lock(cleanup_lock);
 	while (true) {
@@ -297,6 +418,16 @@ void DuckTransactionManager::CleanupTransactions() {
 
 ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Transaction &transaction_p) {
 	auto &transaction = transaction_p.Cast<DuckTransaction>();
+	// check if we can checkpoint, before taking the transaction lock: for a WAL-skipping commit this acquires
+	// start_transaction_lock, which is ordered before transaction_lock (see StartTransaction)
+	unique_ptr<StorageLockKey> lock;
+	auto undo_properties = transaction.GetUndoProperties();
+	const bool wants_skip_wal =
+	    undo_properties.estimated_size >= Settings::Get<AutoCheckpointSkipWalThresholdSetting>(context);
+	unique_lock<mutex> start_gate(start_transaction_lock, std::defer_lock);
+	auto checkpoint_decision = CanCheckpoint(transaction, lock, undo_properties, start_gate, wants_skip_wal);
+	StartGateHolder gate_holder(start_gate_holder, start_gate);
+
 	unique_lock<mutex> t_lock(transaction_lock);
 	if (!db.IsSystem() && !db.IsTemporary()) {
 		if (transaction.ChangesMade()) {
@@ -306,16 +437,15 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 			}
 		}
 	}
-
-	// check if we can checkpoint
-	unique_ptr<StorageLockKey> lock;
-	auto undo_properties = transaction.GetUndoProperties();
-	auto checkpoint_decision = CanCheckpoint(transaction, lock, undo_properties);
 	ErrorData error;
 	unique_lock<mutex> held_wal_lock;
+	// pin the WAL object (captured below while holding the WAL lock) so a concurrent checkpoint that resets it cannot
+	// free the object out from under our GroupSync fsync, which runs with the WAL lock released
+	shared_ptr<WriteAheadLog> wal_ref;
 	unique_ptr<StorageCommitState> commit_state;
 	bool skip_wal_write_due_to_checkpoint = false;
 	bool wal_written = false;
+	transaction_t prior_pending = 0;
 	if (checkpoint_decision.can_checkpoint) {
 		// we can perform an automatic checkpoint
 		// we have two options:
@@ -324,8 +454,10 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 		// the reason for this is that if we don't write this transactions' changes to the WAL
 		// any failure during checkpoint will cause this transactions' changes to be lost,
 		// while later concurrent commits will not be
-		// this can cause undefined state, as those commits were made assuming this one was already committed
-		if (undo_properties.estimated_size >= Settings::Get<AutoCheckpointSkipWalThresholdSetting>(context)) {
+		// this can cause undefined state, as those commits were made assuming this one was already committed.
+		// skipping the WAL additionally requires the start gate (see CanCheckpoint): without it the commit falls
+		// back to a normal WAL write, so it is durable before the checkpoint runs
+		if (wants_skip_wal && start_gate.owns_lock()) {
 			skip_wal_write_due_to_checkpoint = true;
 		}
 	}
@@ -342,6 +474,7 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 		t_lock.unlock();
 		// grab the WAL lock and hold it until the entire commit is finished
 		held_wal_lock = storage_manager.GetWALLock();
+		wal_ref = storage_manager.GetWALShared();
 
 		// Commit the changes to the WAL.
 		if (!skip_wal_write_due_to_checkpoint) {
@@ -410,6 +543,15 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 		if (transaction.catalog_version >= TRANSACTION_ID_START) {
 			transaction.catalog_version = ++last_committed_version;
 		}
+		if (transaction.ChangesMade() &&
+		    (info.wal_flush_offset > 0 || (skip_wal_write_due_to_checkpoint && checkpoint_decision.can_checkpoint))) {
+			// visible now but not yet durable (WAL commits fsync in GroupSync below; checkpoint-instead-of-WAL commits
+			// become durable when their checkpoint completes). Record it under the transaction+WAL locks (monotonic
+			// store) so new snapshots stay bounded below it until the durability point raises last_durable_commit.
+			// In-memory/temporary commits are durable at publish, so they are not recorded and never defer snapshots
+			prior_pending = last_pending_commit.load(std::memory_order_relaxed);
+			last_pending_commit.store(info.commit_id, std::memory_order_release);
+		}
 	}
 	OnCommitCheckpointDecision(checkpoint_decision, transaction);
 
@@ -417,6 +559,7 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 		// we won't checkpoint after all due to an error during commit: unlock the checkpoint lock again
 		skip_wal_write_due_to_checkpoint = false;
 		lock.reset();
+		gate_holder.Release();
 	}
 
 	// commit successful: remove the transaction id from the list of active transactions
@@ -440,6 +583,24 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 		held_wal_lock.unlock();
 	}
 
+	// raise the durable horizon to this commit so new snapshots include it. Acknowledgements can race out of
+	// commit order (a later commit's fsync may cover an earlier one still parked), hence the raise-only max
+	auto raise_durable_horizon = [&]() {
+		transaction_t durable = last_durable_commit.load(std::memory_order_relaxed);
+		while (durable < info.commit_id &&
+		       !last_durable_commit.compare_exchange_weak(durable, info.commit_id, std::memory_order_release,
+		                                                  std::memory_order_relaxed)) {
+		}
+	};
+	// group commit: the entries + WAL_FLUSH marker are already in the page cache (deferred fsync); issue the grouped
+	// fsync here with no lock held, so concurrent committers overlap or share fsyncs, and block until it covers this
+	// commit's bytes -- durable before acknowledged. WAL append order equals commit order, so a later committer's
+	// fsync also covers this one, preserving prefix-consistent replay
+	if (!error.HasError() && info.wal_flush_offset > 0) {
+		wal_ref->GroupSync(info.wal_flush_offset);
+		raise_durable_horizon();
+	}
+
 	CleanupTransactions();
 
 	// now perform a checkpoint if (1) we are able to checkpoint, and (2) the WAL has reached sufficient size to
@@ -455,13 +616,39 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 		options.type = checkpoint_decision.type;
 		options.wal_lock = held_wal_lock.owns_lock() ? &held_wal_lock : nullptr;
 		auto &storage_manager = db.GetStorageManager();
+		if (options.type != CheckpointType::CONCURRENT_CHECKPOINT) {
+			// a vacuuming checkpoint frees segments not-yet-cleaned undo still references, so wait for earlier
+			// commits' fsyncs and run the held-back cleanups (including this commit's own). Safe: a WAL-skipping
+			// commit holds the start gate, so no snapshot bounded below its still-pending undo exists or can start
+			while (last_durable_commit.load(std::memory_order_acquire) < prior_pending) {
+				std::this_thread::yield();
+			}
+			DrainCleanups(start_gate.owns_lock());
+			if (options.type == CheckpointType::FULL_CHECKPOINT && !start_gate.owns_lock() &&
+			    GetLastCommit() > LowestActiveStart()) {
+				// a snapshot that started during this commit's fsync window is bounded below it and still needs
+				// the versions a full checkpoint would vacuum: fall back to a concurrent checkpoint, the same rule
+				// Checkpoint() applies. Race-free: the exclusive checkpoint lock blocks new write commits, so no
+				// new bounded snapshot can appear after this check
+				options.type = CheckpointType::CONCURRENT_CHECKPOINT;
+			}
+		}
 		try {
 			storage_manager.CreateCheckpoint(context, options);
+			// a checkpoint-instead-of-WAL commit is durable once its checkpoint completes: raise the horizon so new
+			// snapshots include it (no-op for WAL-written commits, whose GroupSync above already raised it)
+			if (!error.HasError()) {
+				raise_durable_horizon();
+			}
 		} catch (std::exception &ex) {
 			if (wal_written) {
 				context.transaction.SetAutocheckpointError(BuildAutocheckpointError(db, ex));
 			} else {
 				error.Merge(ErrorData(ex));
+				// the checkpoint that was to carry this commit failed: the changes were not persisted and the
+				// commit is reported as failed, but they remain visible in memory (as upstream leaves them).
+				// Raise the horizon so this commit cannot jam the pending window and durability waits forever
+				raise_durable_horizon();
 			}
 		}
 	}
@@ -516,6 +703,9 @@ unique_ptr<DuckCleanupInfo> DuckTransactionManager::RemoveTransaction(DuckTransa
 		lowest_start_time = MinValue(lowest_start_time, active_transactions[i]->start_time);
 		lowest_transaction_id = MinValue(lowest_transaction_id, active_transactions[i]->transaction_id);
 	}
+	// while commits are awaiting their group fsync, a future snapshot can be bounded down to just above the durable
+	// horizon: clamp the cleanup threshold there, so versions such a snapshot must still see are not destroyed
+	lowest_start_time = MinValue(lowest_start_time, DurableSnapshotBound(TRANSACTION_ID_START));
 	lowest_active_start = lowest_start_time;
 	lowest_active_id = lowest_transaction_id;
 	D_ASSERT(t_index != active_transactions.size());


### PR DESCRIPTION
This is an alternative take on WAL group commit, related to #23631. Same goal: stop serializing commits behind each other's WAL fsyncs, so commit throughput scales with concurrency instead of being pinned at `1 / fsync_latency`. The approach is different enough that it seemed more useful to open it as its own PR than as review comments there.

## How it works

A committing transaction appends its WAL entries and flush marker to the OS page cache under the WAL lock (no fsync there), publishes the resulting byte offset, and releases the lock. It then makes its bytes durable before acknowledging the commit:

- if an fsync currently in flight already covers its offset, it parks until the durable offset advances;
- otherwise it issues its own fsync, concurrently with those already running, up to the file system's declared sync parallelism.

That declaration is a new `FileSystem::SyncParallelism`: on network file systems a sync is a per-call round trip, so concurrent syncs overlap and hide latency, and the WAL pipelines them freely. On local journaled file systems a sync commits the shared journal, so concurrent syncs only add cost, and the WAL uses a single fsync stream whose late-snapped targets batch every commit that arrived during the previous fsync. `LocalFileSystem` classifies from the file system type (`fstatfs` on Linux/macOS, drive type on Windows); other `FileSystem` implementations can override. There are no settings, no delay windows and no runtime timing: the policy follows from what an fsync physically is on the storage, and durability is prefix-ordered either way since every fsync covers all bytes flushed before it.

Commit timestamps are assigned at commit time, as on main. To keep a not-yet-durable commit from being observed, snapshot acquisition is bounded at the durable horizon instead: while commits are waiting for their fsync, a new transaction gets a snapshot just below the oldest non-durable commit. Two raise-only atomics on the transaction manager, and starting a transaction never blocks. So no transaction can ever observe a commit that a crash could lose, commits are acknowledged only once durable, and recovery replays a WAL prefix that is always consistent with everything that was ever visible.

One behavioral note, which applies equally to #23631: since a commit stays invisible until durable, a write-write conflict on a hot row can occur somewhat more often than on main for update-heavy workloads on high-latency storage (the conflict window extends from "until committed" to "until durable"). It is the same error class applications already handle, at a rate proportional to fsync latency and row contention.

fsync failure is terminal: the OS may drop failed dirty pages as clean, so a retried fsync could report success for data that never reached disk. A failed WAL fsync poisons the log and escalates to a fatal error; the database recovers from the durable WAL prefix on reopen. Same handling as #23631, which got this right.

## Benchmark

`benchmark/micro/group_commit.cpp` is taken from #23631 (thanks, it is a good benchmark), extended with 2/32-thread and 100 ms latency variants. Concurrent single-row-commit throughput on a persistent database, fixed total work per latency tier, medians on a 32-core Linux box with a consumer NVMe. The real-fsync rows for this PR and #23631 were measured interleaved per run in one session, since fsync latency on consumer SSDs drifts with drive state; the simulated tiers are insensitive to that.

| fsync latency | threads | main | this PR | #23631 |
|---|---:|---:|---:|---:|
| real fsync | 1 | 14.49 s | 14.24 s | 14.32 s |
| real fsync | 2 | 12.44 s | 10.58 s | 11.87 s |
| real fsync | 4 | 11.41 s | 5.31 s | 5.95 s |
| real fsync | 8 | 11.56 s | 2.68 s | 3.00 s |
| real fsync | 16 | 11.62 s | 1.38 s | 1.54 s |
| real fsync | 32 | 11.61 s | 0.83 s | 0.87 s |
| 1 ms | 1 | 1.03 s | 1.02 s | 1.16 s |
| 1 ms | 2 | 0.93 s | 0.51 s | 0.93 s |
| 1 ms | 4 | 0.88 s | 0.26 s | 0.49 s |
| 1 ms | 8 | 0.89 s | 0.13 s | 0.30 s |
| 1 ms | 16 | 0.89 s | 0.07 s | 0.20 s |
| 1 ms | 32 | 0.89 s | 0.04 s | 0.18 s |
| 10 ms | 1 | 1.67 s | 1.79 s | 1.74 s |
| 10 ms | 2 | 1.64 s | 0.89 s | 1.36 s |
| 10 ms | 4 | 1.62 s | 0.44 s | 0.71 s |
| 10 ms | 8 | 1.62 s | 0.21 s | 0.40 s |
| 10 ms | 16 | 1.62 s | 0.11 s | 0.21 s |
| 10 ms | 32 | 1.63 s | 0.05 s | 0.11 s |
| 100 ms | 1 | 6.43 s | 6.47 s | 6.48 s |
| 100 ms | 2 | 6.42 s | 3.24 s | 3.51 s |
| 100 ms | 4 | 6.41 s | 1.62 s | 1.80 s |
| 100 ms | 8 | 6.41 s | 0.81 s | 0.96 s |
| 100 ms | 16 | 6.41 s | 0.40 s | 0.54 s |
| 100 ms | 32 | 6.41 s | 0.20 s | 0.32 s |

Compared to #23631 on the same machine this measures equal or faster in every cell, with an identical single-connection cost of one plain fsync per commit. The diff is also considerably smaller (~550 lines including the benchmark), since commit publication order never changes: no publish sequencing, no per-table gates, and the WAL lock stays a plain mutex.
