### PR TITLE
Improve TPC-H dbgen progress reporting, ETA stability, and generation performance

### DIFF
--- a/extension/tpch/dbgen/bm_utils.cpp
+++ b/extension/tpch/dbgen/bm_utils.cpp
@@ -289,9 +289,11 @@ void read_dist(const char *path, const char *name, distribution *target) {
 			target->max = 0;
 			continue;
 		}
-		target->list[count].text = (char *)malloc((size_t)((int)strlen(token) + 1));
+		auto token_length = (int)strlen(token);
+		target->list[count].text = (char *)malloc((size_t)(token_length + 1));
 		MALLOC_CHECK(target->list[count].text);
 		strcpy(target->list[count].text, token);
+		target->list[count].length = token_length;
 		target->max += weight;
 		target->list[count].weight = target->max;
 

--- a/extension/tpch/dbgen/build.cpp
+++ b/extension/tpch/dbgen/build.cpp
@@ -37,6 +37,23 @@
 #define TEXT(avg, seed, tgt)  dbg_text(tgt, (int)(avg * V_STR_LOW), (int)(avg * V_STR_HGH), seed)
 static void gen_phone PROTO((DSS_HUGE ind, char *target, seed_t *seed));
 
+static int write_padded_number(char *target, size_t target_size, DSS_HUGE value, int min_width) {
+	int width = 1;
+	for (auto remaining = value; remaining >= 10; remaining /= 10) {
+		width++;
+	}
+	width = MAX(width, min_width);
+	if ((size_t)width >= target_size) {
+		return snprintf(target, target_size, HUGE_FORMAT, value);
+	}
+	target[width] = '\0';
+	for (int i = width - 1; i >= 0; i--) {
+		target[i] = (char)('0' + (value % 10));
+		value /= 10;
+	}
+	return width;
+}
+
 DSS_HUGE
 rpb_routine(DSS_HUGE p) {
 	DSS_HUGE price;
@@ -55,10 +72,10 @@ static void gen_phone(DSS_HUGE ind, char *target, seed_t *seed) {
 	RANDOM(exchg, 100, 999, seed);
 	RANDOM(number, 1000, 9999, seed);
 
-	snprintf(target, 3, "%02d", (int)(10 + (ind % NATIONS_MAX)));
-	snprintf(target + 3, 4, "%03d", (int)acode);
-	snprintf(target + 7, 4, "%03d", (int)exchg);
-	snprintf(target + 11, 5, "%04d", (int)number);
+	write_padded_number(target, 3, 10 + (ind % NATIONS_MAX), 2);
+	write_padded_number(target + 3, 4, acode, 3);
+	write_padded_number(target + 7, 4, exchg, 3);
+	write_padded_number(target + 11, 5, number, 4);
 	target[2] = target[6] = target[10] = '-';
 
 	return;
@@ -66,14 +83,10 @@ static void gen_phone(DSS_HUGE ind, char *target, seed_t *seed) {
 
 long mk_cust(DSS_HUGE n_cust, customer_t *c, DBGenContext *ctx) {
 	DSS_HUGE i;
-	static std::once_flag bInit;
-	static char szFormat[100];
 
-	std::call_once (bInit, [&](){
-		snprintf(szFormat, sizeof(szFormat), C_NAME_FMT, 9, &HUGE_FORMAT[1]);
-	});
 	c->custkey = n_cust;
-	snprintf(c->name, sizeof(c->name), szFormat, C_NAME_TAG, n_cust);
+	memcpy(c->name, C_NAME_TAG, sizeof(C_NAME_TAG) - 1);
+	write_padded_number(c->name + sizeof(C_NAME_TAG) - 1, sizeof(c->name) - sizeof(C_NAME_TAG) + 1, n_cust, 9);
 	V_STR(C_ADDR_LEN, &ctx->Seed[C_ADDR_SD], c->address);
 	c->alen = (int)strlen(c->address);
 	RANDOM(i, 0, (nations.count - 1), &ctx->Seed[C_NTRG_SD]);
@@ -119,10 +132,9 @@ long mk_order(DSS_HUGE index, order_t *o, DBGenContext *ctx, long upd_num) {
 	char **mk_ascdate PROTO((void));
 	int delta = 1;
 	static std::once_flag bInit;
-	static char szFormat[100];
+	static const long current_date_raw = STARTDATE + unjulian(CURRENTDATE);
 
 	std::call_once (bInit, [&](){
-		snprintf(szFormat, sizeof(szFormat), O_CLRK_FMT, 9, &HUGE_FORMAT[1]);
 		asc_date = mk_ascdate();
 	});
 	mk_sparse(index, &o->okey, (upd_num == 0) ? 0 : 1 + upd_num / (10000 / UPD_PCT));
@@ -141,7 +153,8 @@ long mk_order(DSS_HUGE index, order_t *o, DBGenContext *ctx, long upd_num) {
 
 	pick_str(&o_priority_set, &ctx->Seed[O_PRIO_SD], o->opriority);
 	RANDOM(clk_num, 1, MAX((ctx->scale_factor * O_CLRK_SCL), O_CLRK_SCL), &ctx->Seed[O_CLRK_SD]);
-	snprintf(o->clerk, sizeof(o->clerk), szFormat, O_CLRK_TAG, clk_num);
+	memcpy(o->clerk, O_CLRK_TAG, sizeof(O_CLRK_TAG) - 1);
+	write_padded_number(o->clerk + sizeof(O_CLRK_TAG) - 1, sizeof(o->clerk) - sizeof(O_CLRK_TAG) + 1, clk_num, 9);
 	TEXT(O_CMNT_LEN, &ctx->Seed[O_CMNT_SD], o->comment);
 	o->clen = (int)strlen(o->comment);
 #ifdef DEBUG
@@ -190,13 +203,13 @@ long mk_order(DSS_HUGE index, order_t *o, DBGenContext *ctx, long upd_num) {
 		strcpy(o->l[lcnt].cdate, asc_date[c_date - STARTDATE]);
 		strcpy(o->l[lcnt].rdate, asc_date[r_date - STARTDATE]);
 
-		if (julian(r_date) <= CURRENTDATE) {
+		if (r_date <= current_date_raw) {
 			pick_str(&l_rflag_set, &ctx->Seed[L_RFLG_SD], tmp_str);
 			o->l[lcnt].rflag[0] = *tmp_str;
 		} else
 			o->l[lcnt].rflag[0] = 'N';
 
-		if (julian(s_date) <= CURRENTDATE) {
+		if (s_date <= current_date_raw) {
 			ocnt++;
 			o->l[lcnt].lstatus[0] = 'F';
 		} else
@@ -215,21 +228,17 @@ long mk_part(DSS_HUGE index, part_t *p, DBGenContext *ctx) {
 	DSS_HUGE temp;
 	long snum;
 	DSS_HUGE brnd;
-	static std::once_flag bInit;
-	static char szFormat[100];
-	static char szBrandFormat[100];
 
-
-	std::call_once (bInit, [&](){
-		snprintf(szFormat, sizeof(szFormat), P_MFG_FMT, 1, &HUGE_FORMAT[1]);
-		snprintf(szBrandFormat, sizeof(szBrandFormat), P_BRND_FMT, 2, &HUGE_FORMAT[1]);
-	});
 	p->partkey = index;
 	agg_str(&colors, (long)P_NAME_SCL, &ctx->Seed[P_NAME_SD], p->name, ctx);
+	p->nlen = (int)strlen(p->name);
 	RANDOM(temp, P_MFG_MIN, P_MFG_MAX, &ctx->Seed[P_MFG_SD]);
-	snprintf(p->mfgr, sizeof(p->mfgr), szFormat, P_MFG_TAG, temp);
+	memcpy(p->mfgr, P_MFG_TAG, sizeof(P_MFG_TAG) - 1);
+	write_padded_number(p->mfgr + sizeof(P_MFG_TAG) - 1, sizeof(p->mfgr) - sizeof(P_MFG_TAG) + 1, temp, 1);
 	RANDOM(brnd, P_BRND_MIN, P_BRND_MAX, &ctx->Seed[P_BRND_SD]);
-	snprintf(p->brand, sizeof(p->brand), szBrandFormat, P_BRND_TAG, (temp * 10 + brnd));
+	memcpy(p->brand, P_BRND_TAG, sizeof(P_BRND_TAG) - 1);
+	write_padded_number(p->brand + sizeof(P_BRND_TAG) - 1, sizeof(p->brand) - sizeof(P_BRND_TAG) + 1,
+	                    temp * 10 + brnd, 2);
 	p->tlen = pick_str(&p_types_set, &ctx->Seed[P_TYPE_SD], p->type);
 	p->tlen = (int)strlen(p_types_set.list[p->tlen].text);
 	RANDOM(p->size, P_SIZE_MIN, P_SIZE_MAX, &ctx->Seed[P_SIZE_SD]);
@@ -251,14 +260,10 @@ long mk_part(DSS_HUGE index, part_t *p, DBGenContext *ctx) {
 
 long mk_supp(DSS_HUGE index, supplier_t *s, DBGenContext *ctx) {
 	DSS_HUGE i, bad_press, noise, offset, type;
-	static std::once_flag bInit;
-	static char szFormat[100];
 
-	std::call_once (bInit, [&](){
-		snprintf(szFormat, sizeof(szFormat), S_NAME_FMT, 9, &HUGE_FORMAT[1]);
-	});
 	s->suppkey = index;
-	snprintf(s->name, sizeof(s->name), szFormat, S_NAME_TAG, index);
+	memcpy(s->name, S_NAME_TAG, sizeof(S_NAME_TAG) - 1);
+	write_padded_number(s->name + sizeof(S_NAME_TAG) - 1, sizeof(s->name) - sizeof(S_NAME_TAG) + 1, index, 9);
 	V_STR(S_ADDR_LEN, &ctx->Seed[S_ADDR_SD], s->address);
 	s->alen = (int)strlen(s->address);
 	RANDOM(i, 0, nations.count - 1, &ctx->Seed[S_NTRG_SD]);

--- a/extension/tpch/dbgen/dbgen.cpp
+++ b/extension/tpch/dbgen/dbgen.cpp
@@ -16,6 +16,7 @@
 #include "duckdb/planner/binder.hpp"
 #include "duckdb/storage/data_table.hpp"
 #include "duckdb/storage/optimistic_data_writer.hpp"
+#include "duckdb/storage/storage_info.hpp"
 #include "duckdb/storage/table/append_state.hpp"
 #include "duckdb/transaction/duck_transaction.hpp"
 
@@ -666,7 +667,7 @@ struct TPCHDBgenParameters {
 
 static constexpr int DBGEN_TABLES[] = {SUPP, CUST, ORDER_LINE, PART_PSUPP, NATION, REGION};
 static constexpr idx_t DBGEN_ROW_BATCH_SIZE = 100000;
-static constexpr idx_t DBGEN_TARGET_CHUNK_ROWS = 122880;
+static constexpr idx_t DBGEN_TARGET_CHUNK_ROWS = 2 * DEFAULT_ROW_GROUP_SIZE;
 
 struct DBGenTableRange {
 	idx_t offset;

--- a/extension/tpch/dbgen/dbgen.cpp
+++ b/extension/tpch/dbgen/dbgen.cpp
@@ -42,14 +42,21 @@ enum class TPCHAppendMode : uint8_t { APPENDER, OPTIMISTIC };
 struct tpch_append_information {
 	duckdb::unique_ptr<InternalAppender> appender;
 	unique_ptr<OptimisticDataWriter> optimistic_writer;
-	unique_ptr<OptimisticWriteCollection> optimistic_collection;
+	optional_ptr<OptimisticWriteCollection> optimistic_collection;
 	optional_ptr<DuckTableEntry> table_entry;
+	PhysicalIndex optimistic_collection_index = PhysicalIndex(DConstants::INVALID_INDEX);
 	TableAppendState append_state;
 	DataChunk chunk;
 	idx_t row = 0;
 	idx_t active_row = DConstants::INVALID_INDEX;
 	idx_t active_col = 0;
 	bool finalized = false;
+
+	~tpch_append_information() {
+		if (optimistic_writer) {
+			optimistic_writer->Rollback();
+		}
+	}
 
 	void Initialize(ClientContext &context, TableCatalogEntry &table, idx_t flush_count) {
 		appender = make_uniq<InternalAppender>(context, table, flush_count);
@@ -60,12 +67,22 @@ struct tpch_append_information {
 	                          OptimisticWritePartialManagers partial_manager_type) {
 		table_entry = table;
 		optimistic_writer = make_uniq<OptimisticDataWriter>(context, table.GetStorage());
-		optimistic_collection =
+		auto collection =
 		    optimistic_writer->CreateCollection(table.GetStorage(), table.GetTypes(), partial_manager_type);
-		auto &row_collection = *optimistic_collection->collection;
+		auto &row_collection = *collection->collection;
 		row_collection.InitializeEmpty();
 		row_collection.InitializeAppend(append_state);
+		optimistic_collection_index = table.GetStorage().CreateOptimisticCollection(context, std::move(collection));
+		optimistic_collection = table.GetStorage().GetOptimisticCollection(context, optimistic_collection_index);
 		chunk.Initialize(context, table.GetTypes());
+	}
+
+	void ResetOptimisticCollection(ClientContext &context) {
+		D_ASSERT(table_entry);
+		D_ASSERT(optimistic_collection_index.IsValid());
+		table_entry->GetStorage().ResetOptimisticCollection(context, optimistic_collection_index);
+		optimistic_collection_index = PhysicalIndex(DConstants::INVALID_INDEX);
+		optimistic_collection = nullptr;
 	}
 
 	void FlushChunk() {
@@ -98,7 +115,7 @@ struct tpch_append_information {
 		auto &row_collection = *optimistic_collection->collection;
 		auto append_count = row_collection.GetTotalRows();
 		if (append_count == 0) {
-			optimistic_collection.reset();
+			ResetOptimisticCollection(context);
 			optimistic_writer.reset();
 			finalized = false;
 			return;
@@ -116,13 +133,14 @@ struct tpch_append_information {
 				storage.LocalAppend(local_append_state, table, context, insert_chunk, false);
 			}
 			storage.FinalizeLocalAppend(local_append_state);
+			ResetOptimisticCollection(context);
 		} else {
 			optimistic_writer->WriteUnflushedRowGroups(*optimistic_collection);
 			storage.LocalMerge(context, table, *optimistic_collection);
 			auto &storage_writer = storage.GetOptimisticWriter(context);
 			storage_writer.Merge(*optimistic_writer);
+			ResetOptimisticCollection(context);
 		}
-		optimistic_collection.reset();
 		optimistic_writer.reset();
 		finalized = false;
 	}

--- a/extension/tpch/dbgen/dbgen.cpp
+++ b/extension/tpch/dbgen/dbgen.cpp
@@ -197,6 +197,7 @@ void append_int64(tpch_append_information &info, int64_t value) {
 }
 
 void append_string_reference(tpch_append_information &info, const char *value, idx_t length) {
+	// Only use for stable DBGEN strings; non-inlined string_t values keep a pointer until the chunk is appended.
 	auto &vector = append_next_column(info);
 	FlatVector::GetDataMutable<string_t>(vector)[info.active_row] =
 	    string_t(value, UnsafeNumericCast<uint32_t>(length));
@@ -214,6 +215,7 @@ void append_char(tpch_append_information &info, char value) {
 
 static date_t raw_tpch_date(DSS_HUGE value) {
 	static constexpr int32_t UNIX_EPOCH_OFFSET = 8035;
+	// DBGEN dates are raw day offsets from STARTDATE; DuckDB dates are days since the Unix epoch.
 	return date_t(NumericCast<int32_t>(value - STARTDATE + UNIX_EPOCH_OFFSET));
 }
 
@@ -292,6 +294,7 @@ static void AppendRandomAlphaNumeric(tpch_append_information &info, int average_
 static void AppendText(tpch_append_information &info, int average_length, seed_t *seed) {
 	const char *source;
 	auto length = dbg_text_source(int(average_length * V_STR_LOW), int(average_length * V_STR_HGH), seed, &source);
+	// Text pool memory is stable until cleanup_dists(), after all pending chunks have been appended.
 	append_string_reference(info, source, NumericCast<idx_t>(length));
 }
 
@@ -358,6 +361,7 @@ static void AppendSupplierComment(tpch_append_information &info, DBGenContext *c
 	const char *source;
 	auto length = dbg_text_source(int(S_CMNT_LEN * V_STR_LOW), int(S_CMNT_LEN * V_STR_HGH), &ctx->Seed[S_CMNT_SD],
 	                              &source);
+	// Supplier comments can be patched with BBB text, so they need writable vector-owned storage.
 	auto &result = append_empty_string(info, NumericCast<idx_t>(length));
 	auto target = result.GetDataWriteable();
 	memcpy(target, source, NumericCast<idx_t>(length));

--- a/extension/tpch/dbgen/dbgen.cpp
+++ b/extension/tpch/dbgen/dbgen.cpp
@@ -210,7 +210,7 @@ void append_decimal(tpch_append_information &info, int64_t value) {
 
 void append_char(tpch_append_information &info, char value) {
 	auto &vector = append_next_column(info);
-	FlatVector::GetDataMutable<string_t>(vector)[info.active_row] = string_t(&value, 1);
+	FlatVector::GetDataMutable<string_t>(vector)[info.active_row] = StringVector::AddString(vector, &value, 1);
 }
 
 static date_t raw_tpch_date(DSS_HUGE value) {
@@ -898,6 +898,15 @@ static idx_t GetDBGenTableOutputMultiplier(int table_index) {
 	}
 }
 
+static idx_t GetDBGenTableOrder(int table_index) {
+	for (idx_t i = 0; i < sizeof(DBGEN_TABLES) / sizeof(DBGEN_TABLES[0]); i++) {
+		if (DBGEN_TABLES[i] == table_index) {
+			return i;
+		}
+	}
+	throw InternalException("Unexpected TPC-H dbgen table index");
+}
+
 static idx_t GetDefaultTableChildCount(const DBGenContext &dbgen_ctx, int table_index, idx_t thread_count) {
 	auto row_count = GetDBGenTableRowCount(dbgen_ctx, table_index);
 	if (row_count <= DBGEN_TARGET_CHUNK_ROWS || thread_count <= 1) {
@@ -1019,6 +1028,15 @@ private:
 	DBGenContext dbgen_ctx;
 };
 
+struct FinishedDBGenAppender {
+	FinishedDBGenAppender(DBGenWorkItem work_item, unique_ptr<TPCHDataAppender> appender)
+	    : work_item(work_item), appender(std::move(appender)) {
+	}
+
+	DBGenWorkItem work_item;
+	unique_ptr<TPCHDataAppender> appender;
+};
+
 class ParallelTPCHAppendTask : public BaseExecutorTask {
 public:
 	ParallelTPCHAppendTask(TaskExecutor &executor, TPCHDataAppender &appender, DBGenWorkItem work_item)
@@ -1089,7 +1107,7 @@ public:
 
 	bool GenerateNext() override {
 		context.InterruptCheck();
-		if (finished) {
+		if (finished.load()) {
 			return true;
 		}
 		if (total_work == 0) {
@@ -1107,7 +1125,7 @@ public:
 	}
 
 	double Progress() const override {
-		if (finished) {
+		if (finished.load()) {
 			return 100.0;
 		}
 		if (total_work == 0) {
@@ -1179,6 +1197,17 @@ private:
 		return MinValue<idx_t>(static_cast<idx_t>(CHILDREN_PER_SCALE_FACTOR * flt_scale), MAX_CHILDREN);
 	}
 
+	bool UseStatsCompatibleChildCount(int table_index) const {
+		// Keep small join dimensions on the historical batch boundaries used by plan-cost-sensitive statistics.
+		switch (table_index) {
+		case SUPP:
+		case CUST:
+			return true;
+		default:
+			return false;
+		}
+	}
+
 	void InitializeParallelWorkItems() {
 		total_work = 0;
 		parallel_work_items.clear();
@@ -1186,8 +1215,10 @@ private:
 			if (!(table & (1 << table_index))) {
 				continue;
 			}
-			auto children =
-			    NumericCast<int>(GetDefaultTableChildCount(base_context, table_index, parallel_thread_count));
+			auto children = UseStatsCompatibleChildCount(table_index)
+			                    ? NumericCast<int>(GetDefaultChildCount())
+			                    : NumericCast<int>(
+			                          GetDefaultTableChildCount(base_context, table_index, parallel_thread_count));
 			for (int step = 0; step < children; step++) {
 				auto row_count = GetDBGenTableRowCount(base_context, table_index);
 				auto range = GetDBGenTableRange(row_count, children, step);
@@ -1202,28 +1233,41 @@ private:
 		          [](const DBGenWorkItem &left, const DBGenWorkItem &right) {
 			          auto left_output_rows = left.count * GetDBGenTableOutputMultiplier(left.table_index);
 			          auto right_output_rows = right.count * GetDBGenTableOutputMultiplier(right.table_index);
-			          return left_output_rows > right_output_rows;
+			          if (left_output_rows != right_output_rows) {
+				          return left_output_rows > right_output_rows;
+			          }
+			          auto left_table_order = GetDBGenTableOrder(left.table_index);
+			          auto right_table_order = GetDBGenTableOrder(right.table_index);
+			          if (left_table_order != right_table_order) {
+				          return left_table_order < right_table_order;
+			          }
+			          return left.step < right.step;
 		          });
+		parallel_next_flush_step.assign(REGION + 1, 0);
 	}
 
 	bool FlushNextFinishedAppender() {
-		if (finished_appender_offset >= finished_appenders.size()) {
-			finished_appenders.clear();
-			finished_appender_offset = 0;
-			return false;
+		for (idx_t appender_idx = 0; appender_idx < finished_appenders.size(); appender_idx++) {
+			auto &finished_appender = *finished_appenders[appender_idx];
+			auto table_index = finished_appender.work_item.table_index;
+			if (finished_appender.work_item.step != parallel_next_flush_step[table_index]) {
+				continue;
+			}
+			auto flushed_count = finished_appender.appender->GeneratedWork();
+			finished_appender.appender->Flush();
+			flushed_work.fetch_add(flushed_count);
+			parallel_next_flush_step[table_index]++;
+			finished_appenders.erase(finished_appenders.begin() + UnsafeNumericCast<int64_t>(appender_idx));
+			return true;
 		}
-		auto &appender = finished_appenders[finished_appender_offset++];
-		appender.Flush();
-		flushed_work.fetch_add(appender.GeneratedWork());
-		if (finished_appender_offset >= finished_appenders.size()) {
-			finished_appenders.clear();
-			finished_appender_offset = 0;
-		}
-		return true;
+		return false;
 	}
 
 	void FlushAllFinishedAppenders() {
 		while (FlushNextFinishedAppender()) {
+		}
+		if (!finished_appenders.empty()) {
+			throw InternalException("Failed to flush TPC-H dbgen appenders in deterministic order");
 		}
 	}
 
@@ -1237,18 +1281,19 @@ private:
 		if (parallel_work_offset < parallel_work_items.size()) {
 			TaskExecutor executor(context);
 
-			vector<TPCHDataAppender> new_appenders;
+			vector<unique_ptr<TPCHDataAppender>> new_appenders;
+			new_appenders.reserve(parallel_thread_count);
 			auto launched_offset = parallel_work_offset;
 			for (idx_t thr_idx = 0; thr_idx < parallel_thread_count && launched_offset < parallel_work_items.size();
 			     thr_idx++, launched_offset++) {
 				auto &work_item = parallel_work_items[launched_offset];
-				new_appenders.emplace_back(context, *parameters, base_context, TPCHAppendMode::OPTIMISTIC,
-				                           NumericLimits<int64_t>::Maximum(), &generated_work,
-				                           work_item.table_index);
+				new_appenders.push_back(make_uniq<TPCHDataAppender>(
+				    context, *parameters, base_context, TPCHAppendMode::OPTIMISTIC,
+				    NumericLimits<int64_t>::Maximum(), &generated_work, work_item.table_index));
 			}
 			for (auto &appender : new_appenders) {
-				auto task =
-				    make_uniq<ParallelTPCHAppendTask>(executor, appender, parallel_work_items[parallel_work_offset]);
+				auto task = make_uniq<ParallelTPCHAppendTask>(executor, *appender,
+				                                              parallel_work_items[parallel_work_offset]);
 				executor.ScheduleTask(std::move(task));
 				parallel_work_offset++;
 			}
@@ -1256,7 +1301,11 @@ private:
 			if (executor.HasError()) {
 				executor.ThrowError();
 			}
-			finished_appenders = std::move(new_appenders);
+			for (idx_t appender_idx = 0; appender_idx < new_appenders.size(); appender_idx++) {
+				auto work_item_idx = parallel_work_offset - new_appenders.size() + appender_idx;
+				finished_appenders.push_back(make_uniq<FinishedDBGenAppender>(
+				    parallel_work_items[work_item_idx], std::move(new_appenders[appender_idx])));
+			}
 			return false;
 		}
 		Finish();
@@ -1324,9 +1373,9 @@ private:
 			cleanup_dists();
 			distributions_loaded = false;
 		}
-		generated_work = total_work;
-		flushed_work = total_work;
-		finished = true;
+		generated_work.store(total_work);
+		flushed_work.store(total_work);
+		finished.store(true);
 	}
 
 private:
@@ -1337,7 +1386,7 @@ private:
 	DBGenContext base_context;
 	unique_ptr<TPCHDBgenParameters> parameters;
 	bool distributions_loaded = false;
-	bool finished = false;
+	atomic<bool> finished {false};
 	DBGenMode mode = DBGenMode::SEQUENTIAL;
 	atomic<idx_t> generated_work {0};
 	atomic<idx_t> flushed_work {0};
@@ -1346,8 +1395,8 @@ private:
 	idx_t parallel_thread_count = 1;
 	vector<DBGenWorkItem> parallel_work_items;
 	idx_t parallel_work_offset = 0;
-	vector<TPCHDataAppender> finished_appenders;
-	idx_t finished_appender_offset = 0;
+	vector<unique_ptr<FinishedDBGenAppender>> finished_appenders;
+	vector<int> parallel_next_flush_step;
 
 	int sequential_children = 1;
 	int sequential_start_step = 0;

--- a/extension/tpch/dbgen/dbgen.cpp
+++ b/extension/tpch/dbgen/dbgen.cpp
@@ -23,12 +23,14 @@
 #define DECLARER /* EXTERN references get defined here */
 
 #include "dbgen/dss.h"
+#include "dbgen/rng64.h"
 #include "dbgen/dsstypes.h"
 
 #include <cassert>
 #include <algorithm>
 #include <atomic>
 #include <cmath>
+#include <cstring>
 #include <mutex>
 
 using namespace duckdb;
@@ -194,14 +196,10 @@ void append_int64(tpch_append_information &info, int64_t value) {
 	FlatVector::GetDataMutable<int64_t>(vector)[info.active_row] = value;
 }
 
-void append_string(tpch_append_information &info, const char *value, idx_t length) {
+void append_string_reference(tpch_append_information &info, const char *value, idx_t length) {
 	auto &vector = append_next_column(info);
-	FlatVector::GetDataMutable<string_t>(vector)[info.active_row] = StringVector::AddString(vector, value, length);
-}
-
-void append_string(tpch_append_information &info, const char *value) {
-	auto &vector = append_next_column(info);
-	FlatVector::GetDataMutable<string_t>(vector)[info.active_row] = StringVector::AddString(vector, value);
+	FlatVector::GetDataMutable<string_t>(vector)[info.active_row] =
+	    string_t(value, UnsafeNumericCast<uint32_t>(length));
 }
 
 void append_decimal(tpch_append_information &info, int64_t value) {
@@ -209,233 +207,397 @@ void append_decimal(tpch_append_information &info, int64_t value) {
 	FlatVector::GetDataMutable<int64_t>(vector)[info.active_row] = value;
 }
 
-static date_t parse_tpch_date(const char *value) {
-	static constexpr int32_t UNIX_EPOCH_OFFSET = 8035;
-	static constexpr int32_t YEAR_OFFSET[] = {0, 366, 731, 1096, 1461, 1827, 2192};
-	static constexpr int32_t CUMULATIVE_DAYS[] = {0,  0,   31,  59,  90,  120, 151,
-	                                              181, 212, 243, 273, 304, 334};
-	static constexpr int32_t CUMULATIVE_LEAP_DAYS[] = {0,  0,   31,  60,  91,  121, 152,
-	                                                   182, 213, 244, 274, 305, 335};
-	auto year = static_cast<int32_t>((value[2] - '0') * 10 + (value[3] - '0'));
-	auto month = static_cast<int32_t>((value[5] - '0') * 10 + (value[6] - '0'));
-	auto day = static_cast<int32_t>((value[8] - '0') * 10 + (value[9] - '0'));
-	D_ASSERT(year >= 92 && year <= 98);
-	auto year_index = year - 92;
-	auto &year_days = (year == 92 || year == 96) ? CUMULATIVE_LEAP_DAYS : CUMULATIVE_DAYS;
-	return date_t(UNIX_EPOCH_OFFSET + YEAR_OFFSET[year_index] + year_days[month] + day - 1);
-}
-
-void append_date(tpch_append_information &info, const char *value) {
-	auto &vector = append_next_column(info);
-	FlatVector::GetDataMutable<date_t>(vector)[info.active_row] = parse_tpch_date(value);
-}
-
 void append_char(tpch_append_information &info, char value) {
 	auto &vector = append_next_column(info);
-	FlatVector::GetDataMutable<string_t>(vector)[info.active_row] = StringVector::AddString(vector, &value, 1);
+	FlatVector::GetDataMutable<string_t>(vector)[info.active_row] = string_t(&value, 1);
 }
 
-static void append_order(order_t *o, tpch_append_information *info) {
-	auto &append_info = info[ORDER];
-
-	// fill the current row with the order information
-	append_begin_row(append_info);
-	// o_orderkey
-	append_int64(append_info, o->okey);
-	// o_custkey
-	append_int64(append_info, o->custkey);
-	// o_orderstatus
-	append_char(append_info, o->orderstatus);
-	// o_totalprice
-	append_decimal(append_info, o->totalprice);
-	// o_orderdate
-	append_date(append_info, o->odate);
-	// o_orderpriority
-	append_string(append_info, o->opriority);
-	// o_clerk
-	append_string(append_info, o->clerk, O_CLRK_LEN);
-	// o_shippriority
-	append_int32(append_info, o->spriority);
-	// o_comment
-	append_string(append_info, o->comment, o->clen);
-	append_end_row(append_info);
+static date_t raw_tpch_date(DSS_HUGE value) {
+	static constexpr int32_t UNIX_EPOCH_OFFSET = 8035;
+	return date_t(NumericCast<int32_t>(value - STARTDATE + UNIX_EPOCH_OFFSET));
 }
 
-static void append_line(order_t *o, tpch_append_information *info) {
-	auto &append_info = info[LINE];
+void append_date(tpch_append_information &info, DSS_HUGE value) {
+	auto &vector = append_next_column(info);
+	FlatVector::GetDataMutable<date_t>(vector)[info.active_row] = raw_tpch_date(value);
+}
 
-	// fill the current row with the order information
-	for (DSS_HUGE i = 0; i < o->lines; i++) {
-		append_begin_row(append_info);
-		// l_orderkey
-		append_int64(append_info, o->l[i].okey);
-		// l_partkey
-		append_int64(append_info, o->l[i].partkey);
-		// l_suppkey
-		append_int64(append_info, o->l[i].suppkey);
-		// l_linenumber
-		append_int64(append_info, o->l[i].lcnt);
-		// l_quantity
-		append_decimal(append_info, o->l[i].quantity);
-		// l_extendedprice
-		append_decimal(append_info, o->l[i].eprice);
-		// l_discount
-		append_decimal(append_info, o->l[i].discount);
-		// l_tax
-		append_decimal(append_info, o->l[i].tax);
-		// l_returnflag
-		append_char(append_info, o->l[i].rflag[0]);
-		// l_linestatus
-		append_char(append_info, o->l[i].lstatus[0]);
-		// l_shipdate
-		append_date(append_info, o->l[i].sdate);
-		// l_commitdate
-		append_date(append_info, o->l[i].cdate);
-		// l_receiptdate
-		append_date(append_info, o->l[i].rdate);
-		// l_shipinstruct
-		append_string(append_info, o->l[i].shipinstruct);
-		// l_shipmode
-		append_string(append_info, o->l[i].shipmode);
-		// l_comment
-		append_string(append_info, o->l[i].comment, o->l[i].clen);
-		append_end_row(append_info);
+static string_t &append_empty_string(tpch_append_information &info, idx_t length) {
+	auto &vector = append_next_column(info);
+	auto data = FlatVector::GetDataMutable<string_t>(vector);
+	data[info.active_row] = StringVector::EmptyString(vector, length);
+	return data[info.active_row];
+}
+
+static int PaddedNumberWidth(DSS_HUGE value, int min_width) {
+	int width = 1;
+	for (auto remaining = value; remaining >= 10; remaining /= 10) {
+		width++;
+	}
+	return MaxValue(width, min_width);
+}
+
+static void WritePaddedNumber(char *target, DSS_HUGE value, int width) {
+	for (auto i = width; i > 0; i--) {
+		target[i - 1] = char('0' + (value % 10));
+		value /= 10;
 	}
 }
 
-static void append_order_line(order_t *o, tpch_append_information *info) {
-	append_order(o, info);
-	append_line(o, info);
+static void AppendTaggedNumber(tpch_append_information &info, const char *tag, idx_t tag_length, DSS_HUGE value,
+                               int min_width) {
+	auto number_width = PaddedNumberWidth(value, min_width);
+	auto &result = append_empty_string(info, tag_length + number_width);
+	auto target = result.GetDataWriteable();
+	memcpy(target, tag, tag_length);
+	WritePaddedNumber(target + tag_length, value, number_width);
+	result.Finalize();
 }
 
-static void append_supp(supplier_t *supp, tpch_append_information *info) {
+static void AppendPhone(tpch_append_information &info, DSS_HUGE nation_code, seed_t *seed) {
+	DSS_HUGE acode, exchg, number;
+	RANDOM(acode, 100, 999, seed);
+	RANDOM(exchg, 100, 999, seed);
+	RANDOM(number, 1000, 9999, seed);
+
+	auto &result = append_empty_string(info, PHONE_LEN);
+	auto target = result.GetDataWriteable();
+	WritePaddedNumber(target, 10 + (nation_code % NATIONS_MAX), 2);
+	target[2] = '-';
+	WritePaddedNumber(target + 3, acode, 3);
+	target[6] = '-';
+	WritePaddedNumber(target + 7, exchg, 3);
+	target[10] = '-';
+	WritePaddedNumber(target + 11, number, 4);
+	result.Finalize();
+}
+
+static void AppendRandomAlphaNumeric(tpch_append_information &info, int average_length, seed_t *seed) {
+	static const char ALPHA_NUM[] = "0123456789abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ,";
+	DSS_HUGE length, char_int = 0;
+	RANDOM(length, int(average_length * V_STR_LOW), int(average_length * V_STR_HGH), seed);
+
+	auto &result = append_empty_string(info, NumericCast<idx_t>(length));
+	auto target = result.GetDataWriteable();
+	for (DSS_HUGE i = 0; i < length; i++) {
+		if (i % 5 == 0) {
+			RANDOM(char_int, 0, MAX_LONG, seed);
+		}
+		target[i] = ALPHA_NUM[char_int & 077];
+		char_int >>= 6;
+	}
+	result.Finalize();
+}
+
+static void AppendText(tpch_append_information &info, int average_length, seed_t *seed) {
+	const char *source;
+	auto length = dbg_text_source(int(average_length * V_STR_LOW), int(average_length * V_STR_HGH), seed, &source);
+	append_string_reference(info, source, NumericCast<idx_t>(length));
+}
+
+struct TPCHStringRef {
+	const char *data;
+	idx_t length;
+};
+
+static TPCHStringRef PickDistribution(distribution *set, seed_t *seed) {
+	long index = 0;
+	DSS_HUGE choice;
+
+	RANDOM(choice, 1, set->list[set->count - 1].weight, seed);
+	while (set->list[index].weight < choice) {
+		index++;
+	}
+	auto data = set->list[index].text;
+	return TPCHStringRef {data, NumericCast<idx_t>(set->list[index].length)};
+}
+
+static void AppendDistribution(tpch_append_information &info, distribution *set, seed_t *seed) {
+	auto entry = PickDistribution(set, seed);
+	append_string_reference(info, entry.data, entry.length);
+}
+
+static DSS_HUGE RetailPrice(DSS_HUGE part_key) {
+	DSS_HUGE price = 90000;
+	price += (part_key / 10) % 20001;
+	price += (part_key % 1000) * 100;
+	return price;
+}
+
+static DSS_HUGE PartSuppBridge(DBGenContext *ctx, DSS_HUGE part_key, DSS_HUGE supp_num) {
+	DSS_HUGE total_supplier_count = ctx->tdefs[SUPP].base * ctx->scale_factor;
+	return (part_key + supp_num * (total_supplier_count / SUPP_PER_PART + (long)((part_key - 1) / total_supplier_count))) %
+	           total_supplier_count +
+	       1;
+}
+
+static void AppendPartName(tpch_append_information &info, DBGenContext *ctx) {
+	permute_dist(&colors, &ctx->Seed[P_NAME_SD], ctx);
+	idx_t length = 0;
+	for (idx_t i = 0; i < P_NAME_SCL; i++) {
+		length += NumericCast<idx_t>(colors.list[ctx->permute[i]].length);
+	}
+	length += P_NAME_SCL - 1;
+
+	auto &result = append_empty_string(info, length);
+	auto target = result.GetDataWriteable();
+	for (idx_t i = 0; i < P_NAME_SCL; i++) {
+		auto &member = colors.list[ctx->permute[i]];
+		auto member_length = NumericCast<idx_t>(member.length);
+		auto member_text = member.text;
+		memcpy(target, member_text, member_length);
+		target += member_length;
+		if (i + 1 < P_NAME_SCL) {
+			*target++ = ' ';
+		}
+	}
+	result.Finalize();
+}
+
+static void AppendSupplierComment(tpch_append_information &info, DBGenContext *ctx) {
+	const char *source;
+	auto length = dbg_text_source(int(S_CMNT_LEN * V_STR_LOW), int(S_CMNT_LEN * V_STR_HGH), &ctx->Seed[S_CMNT_SD],
+	                              &source);
+	auto &result = append_empty_string(info, NumericCast<idx_t>(length));
+	auto target = result.GetDataWriteable();
+	memcpy(target, source, NumericCast<idx_t>(length));
+
+	DSS_HUGE bad_press, noise, offset, type;
+	RANDOM(bad_press, 1, 10000, &ctx->Seed[BBB_CMNT_SD]);
+	RANDOM(type, 0, 100, &ctx->Seed[BBB_TYPE_SD]);
+	RANDOM(noise, 0, (length - BBB_CMNT_LEN), &ctx->Seed[BBB_JNK_SD]);
+	RANDOM(offset, 0, (length - (BBB_CMNT_LEN + noise)), &ctx->Seed[BBB_OFFSET_SD]);
+	if (bad_press <= S_CMNT_BBB) {
+		type = (type < BBB_DEADBEATS) ? 0 : 1;
+		memcpy(target + offset, BBB_BASE, BBB_BASE_LEN);
+		if (type == 0) {
+			memcpy(target + BBB_BASE_LEN + offset + noise, BBB_COMPLAIN, BBB_TYPE_LEN);
+		} else {
+			memcpy(target + BBB_BASE_LEN + offset + noise, BBB_COMMEND, BBB_TYPE_LEN);
+		}
+	}
+	result.Finalize();
+}
+
+static void AppendManufacturer(tpch_append_information &info, DSS_HUGE manufacturer) {
+	AppendTaggedNumber(info, P_MFG_TAG, sizeof(P_MFG_TAG) - 1, manufacturer, 1);
+}
+
+static void AppendBrand(tpch_append_information &info, DSS_HUGE manufacturer, DSS_HUGE brand) {
+	AppendTaggedNumber(info, P_BRND_TAG, sizeof(P_BRND_TAG) - 1, manufacturer * 10 + brand, 2);
+}
+
+static void GenerateOrderLine(DSS_HUGE index, tpch_append_information *info, DBGenContext *ctx) {
+	auto &order_info = info[ORDER];
+	auto &line_info = info[LINE];
+	static const DSS_HUGE CURRENT_DATE_RAW = STARTDATE + unjulian(CURRENTDATE);
+
+	DSS_HUGE order_key;
+	mk_sparse(index, &order_key, 0);
+
+	DSS_HUGE cust_key;
+	if (ctx->scale_factor >= 30000) {
+		dss_random64(&cust_key, O_CKEY_MIN, O_CKEY_MAX, &ctx->Seed[O_CKEY_SD]);
+	} else {
+		RANDOM(cust_key, O_CKEY_MIN, O_CKEY_MAX, &ctx->Seed[O_CKEY_SD]);
+	}
+	int delta = 1;
+	while (cust_key % CUST_MORTALITY == 0) {
+		cust_key += delta;
+		cust_key = MIN(cust_key, O_CKEY_MAX);
+		delta *= -1;
+	}
+
+	DSS_HUGE order_date;
+	RANDOM(order_date, O_ODATE_MIN, O_ODATE_MAX, &ctx->Seed[O_ODATE_SD]);
+	auto order_priority = PickDistribution(&o_priority_set, &ctx->Seed[O_PRIO_SD]);
+	DSS_HUGE clerk_number;
+	RANDOM(clerk_number, 1, MAX((ctx->scale_factor * O_CLRK_SCL), O_CLRK_SCL), &ctx->Seed[O_CLRK_SD]);
+	const char *order_comment;
+	auto order_comment_length =
+	    dbg_text_source(int(O_CMNT_LEN * V_STR_LOW), int(O_CMNT_LEN * V_STR_HGH), &ctx->Seed[O_CMNT_SD],
+	                    &order_comment);
+
+	DSS_HUGE line_count;
+	RANDOM(line_count, O_LCNT_MIN, O_LCNT_MAX, &ctx->Seed[O_LCNT_SD]);
+
+	DSS_HUGE total_price = 0;
+	DSS_HUGE closed_line_count = 0;
+	for (DSS_HUGE line_number = 0; line_number < line_count; line_number++) {
+		DSS_HUGE quantity, discount, tax, part_key, supp_num, ship_date, commit_date, receipt_date;
+		RANDOM(quantity, L_QTY_MIN, L_QTY_MAX, &ctx->Seed[L_QTY_SD]);
+		RANDOM(discount, L_DCNT_MIN, L_DCNT_MAX, &ctx->Seed[L_DCNT_SD]);
+		RANDOM(tax, L_TAX_MIN, L_TAX_MAX, &ctx->Seed[L_TAX_SD]);
+		auto ship_instruct = PickDistribution(&l_instruct_set, &ctx->Seed[L_SHIP_SD]);
+		auto ship_mode = PickDistribution(&l_smode_set, &ctx->Seed[L_SMODE_SD]);
+		const char *line_comment;
+		auto line_comment_length =
+		    dbg_text_source(int(L_CMNT_LEN * V_STR_LOW), int(L_CMNT_LEN * V_STR_HGH), &ctx->Seed[L_CMNT_SD],
+		                    &line_comment);
+		if (ctx->scale_factor >= 30000) {
+			dss_random64(&part_key, L_PKEY_MIN, L_PKEY_MAX, &ctx->Seed[L_PKEY_SD]);
+		} else {
+			RANDOM(part_key, L_PKEY_MIN, L_PKEY_MAX, &ctx->Seed[L_PKEY_SD]);
+		}
+		auto retail_price = RetailPrice(part_key);
+		RANDOM(supp_num, 0, 3, &ctx->Seed[L_SKEY_SD]);
+		auto supp_key = PartSuppBridge(ctx, part_key, supp_num);
+		quantity *= 100;
+		auto extended_price = retail_price * quantity / 100;
+		total_price += ((extended_price * (100 - discount)) / PENNIES) * (100 + tax) / PENNIES;
+
+		RANDOM(ship_date, L_SDTE_MIN, L_SDTE_MAX, &ctx->Seed[L_SDTE_SD]);
+		ship_date += order_date;
+		RANDOM(commit_date, L_CDTE_MIN, L_CDTE_MAX, &ctx->Seed[L_CDTE_SD]);
+		commit_date += order_date;
+		RANDOM(receipt_date, L_RDTE_MIN, L_RDTE_MAX, &ctx->Seed[L_RDTE_SD]);
+		receipt_date += ship_date;
+
+		char return_flag = 'N';
+		if (receipt_date <= CURRENT_DATE_RAW) {
+			return_flag = PickDistribution(&l_rflag_set, &ctx->Seed[L_RFLG_SD]).data[0];
+		}
+		char line_status;
+		if (ship_date <= CURRENT_DATE_RAW) {
+			closed_line_count++;
+			line_status = 'F';
+		} else {
+			line_status = 'O';
+		}
+
+		append_begin_row(line_info);
+		append_int64(line_info, order_key);
+		append_int64(line_info, part_key);
+		append_int64(line_info, supp_key);
+		append_int64(line_info, line_number + 1);
+		append_decimal(line_info, quantity);
+		append_decimal(line_info, extended_price);
+		append_decimal(line_info, discount);
+		append_decimal(line_info, tax);
+		append_char(line_info, return_flag);
+		append_char(line_info, line_status);
+		append_date(line_info, ship_date);
+		append_date(line_info, commit_date);
+		append_date(line_info, receipt_date);
+		append_string_reference(line_info, ship_instruct.data, ship_instruct.length);
+		append_string_reference(line_info, ship_mode.data, ship_mode.length);
+		append_string_reference(line_info, line_comment, NumericCast<idx_t>(line_comment_length));
+		append_end_row(line_info);
+	}
+
+	char order_status = 'O';
+	if (closed_line_count > 0) {
+		order_status = 'P';
+	}
+	if (closed_line_count == line_count) {
+		order_status = 'F';
+	}
+
+	append_begin_row(order_info);
+	append_int64(order_info, order_key);
+	append_int64(order_info, cust_key);
+	append_char(order_info, order_status);
+	append_decimal(order_info, total_price);
+	append_date(order_info, order_date);
+	append_string_reference(order_info, order_priority.data, order_priority.length);
+	AppendTaggedNumber(order_info, O_CLRK_TAG, sizeof(O_CLRK_TAG) - 1, clerk_number, 9);
+	append_int32(order_info, 0);
+	append_string_reference(order_info, order_comment, NumericCast<idx_t>(order_comment_length));
+	append_end_row(order_info);
+}
+
+static void GenerateSupplier(DSS_HUGE index, tpch_append_information *info, DBGenContext *ctx) {
 	auto &append_info = info[SUPP];
-
 	append_begin_row(append_info);
-	// s_suppkey
-	append_int64(append_info, supp->suppkey);
-	// s_name
-	append_string(append_info, supp->name);
-	// s_address
-	append_string(append_info, supp->address, supp->alen);
-	// s_nationkey
-	append_int32(append_info, supp->nation_code);
-	// s_phone
-	append_string(append_info, supp->phone, PHONE_LEN);
-	// s_acctbal
-	append_decimal(append_info, supp->acctbal);
-	// s_comment
-	append_string(append_info, supp->comment, supp->clen);
+	append_int64(append_info, index);
+	AppendTaggedNumber(append_info, S_NAME_TAG, sizeof(S_NAME_TAG) - 1, index, 9);
+	AppendRandomAlphaNumeric(append_info, S_ADDR_LEN, &ctx->Seed[S_ADDR_SD]);
+	DSS_HUGE nation_code;
+	RANDOM(nation_code, 0, nations.count - 1, &ctx->Seed[S_NTRG_SD]);
+	append_int32(append_info, NumericCast<int32_t>(nation_code));
+	AppendPhone(append_info, nation_code, &ctx->Seed[S_PHNE_SD]);
+	DSS_HUGE acctbal;
+	RANDOM(acctbal, S_ABAL_MIN, S_ABAL_MAX, &ctx->Seed[S_ABAL_SD]);
+	append_decimal(append_info, acctbal);
+	AppendSupplierComment(append_info, ctx);
 	append_end_row(append_info);
 }
 
-static void append_cust(customer_t *c, tpch_append_information *info) {
+static void GenerateCustomer(DSS_HUGE index, tpch_append_information *info, DBGenContext *ctx) {
 	auto &append_info = info[CUST];
-
 	append_begin_row(append_info);
-	// c_custkey
-	append_int64(append_info, c->custkey);
-	// c_name
-	append_string(append_info, c->name);
-	// c_address
-	append_string(append_info, c->address, c->alen);
-	// c_nationkey
-	append_int32(append_info, c->nation_code);
-	// c_phone
-	append_string(append_info, c->phone, PHONE_LEN);
-	// c_acctbal
-	append_decimal(append_info, c->acctbal);
-	// c_mktsegment
-	append_string(append_info, c->mktsegment);
-	// c_comment
-	append_string(append_info, c->comment, c->clen);
+	append_int64(append_info, index);
+	AppendTaggedNumber(append_info, C_NAME_TAG, sizeof(C_NAME_TAG) - 1, index, 9);
+	AppendRandomAlphaNumeric(append_info, C_ADDR_LEN, &ctx->Seed[C_ADDR_SD]);
+	DSS_HUGE nation_code;
+	RANDOM(nation_code, 0, nations.count - 1, &ctx->Seed[C_NTRG_SD]);
+	append_int32(append_info, NumericCast<int32_t>(nation_code));
+	AppendPhone(append_info, nation_code, &ctx->Seed[C_PHNE_SD]);
+	DSS_HUGE acctbal;
+	RANDOM(acctbal, C_ABAL_MIN, C_ABAL_MAX, &ctx->Seed[C_ABAL_SD]);
+	append_decimal(append_info, acctbal);
+	AppendDistribution(append_info, &c_mseg_set, &ctx->Seed[C_MSEG_SD]);
+	AppendText(append_info, C_CMNT_LEN, &ctx->Seed[C_CMNT_SD]);
 	append_end_row(append_info);
 }
 
-static void append_part(part_t *part, tpch_append_information *info) {
-	auto &append_info = info[PART];
+static void GeneratePartAndPartsupp(DSS_HUGE index, tpch_append_information *info, DBGenContext *ctx) {
+	auto &part_info = info[PART];
+	append_begin_row(part_info);
+	append_int64(part_info, index);
+	AppendPartName(part_info, ctx);
+	DSS_HUGE manufacturer;
+	RANDOM(manufacturer, P_MFG_MIN, P_MFG_MAX, &ctx->Seed[P_MFG_SD]);
+	AppendManufacturer(part_info, manufacturer);
+	DSS_HUGE brand;
+	RANDOM(brand, P_BRND_MIN, P_BRND_MAX, &ctx->Seed[P_BRND_SD]);
+	AppendBrand(part_info, manufacturer, brand);
+	AppendDistribution(part_info, &p_types_set, &ctx->Seed[P_TYPE_SD]);
+	DSS_HUGE size;
+	RANDOM(size, P_SIZE_MIN, P_SIZE_MAX, &ctx->Seed[P_SIZE_SD]);
+	append_int32(part_info, NumericCast<int32_t>(size));
+	AppendDistribution(part_info, &p_cntr_set, &ctx->Seed[P_CNTR_SD]);
+	append_decimal(part_info, RetailPrice(index));
+	AppendText(part_info, P_CMNT_LEN, &ctx->Seed[P_CMNT_SD]);
+	append_end_row(part_info);
 
-	append_begin_row(append_info);
-	// p_partkey
-	append_int64(append_info, part->partkey);
-	// p_name
-	append_string(append_info, part->name, part->nlen);
-	// p_mfgr
-	append_string(append_info, part->mfgr, sizeof(P_MFG_TAG));
-	// p_brand
-	append_string(append_info, part->brand, sizeof(P_BRND_TAG) + 1);
-	// p_type
-	append_string(append_info, part->type, part->tlen);
-	// p_size
-	append_int32(append_info, part->size);
-	// p_container
-	append_string(append_info, part->container);
-	// p_retailprice
-	append_decimal(append_info, part->retailprice);
-	// p_comment
-	append_string(append_info, part->comment, part->clen);
-	append_end_row(append_info);
-}
-
-static void append_psupp(part_t *part, tpch_append_information *info) {
-	auto &append_info = info[PSUPP];
-	for (size_t i = 0; i < SUPP_PER_PART; i++) {
-		append_begin_row(append_info);
-		// ps_partkey
-		append_int64(append_info, part->s[i].partkey);
-		// ps_suppkey
-		append_int64(append_info, part->s[i].suppkey);
-		// ps_availqty
-		append_int64(append_info, part->s[i].qty);
-		// ps_supplycost
-		append_decimal(append_info, part->s[i].scost);
-		// ps_comment
-		append_string(append_info, part->s[i].comment, part->s[i].clen);
-		append_end_row(append_info);
+	auto &partsupp_info = info[PSUPP];
+	for (DSS_HUGE supp_num = 0; supp_num < SUPP_PER_PART; supp_num++) {
+		append_begin_row(partsupp_info);
+		append_int64(partsupp_info, index);
+		append_int64(partsupp_info, PartSuppBridge(ctx, index, supp_num));
+		DSS_HUGE quantity;
+		RANDOM(quantity, PS_QTY_MIN, PS_QTY_MAX, &ctx->Seed[PS_QTY_SD]);
+		append_int64(partsupp_info, quantity);
+		DSS_HUGE supply_cost;
+		RANDOM(supply_cost, PS_SCST_MIN, PS_SCST_MAX, &ctx->Seed[PS_SCST_SD]);
+		append_decimal(partsupp_info, supply_cost);
+		AppendText(partsupp_info, PS_CMNT_LEN, &ctx->Seed[PS_CMNT_SD]);
+		append_end_row(partsupp_info);
 	}
 }
 
-static void append_part_psupp(part_t *part, tpch_append_information *info) {
-	append_part(part, info);
-	append_psupp(part, info);
-}
-
-static void append_nation(code_t *c, tpch_append_information *info) {
+static void GenerateNation(DSS_HUGE index, tpch_append_information *info, DBGenContext *ctx) {
 	auto &append_info = info[NATION];
-
 	append_begin_row(append_info);
-	// n_nationkey
-	append_int32(append_info, c->code);
-	// n_name
-	append_string(append_info, c->text);
-	// n_regionkey
-	append_int32(append_info, c->join);
-	// n_comment
-	append_string(append_info, c->comment, c->clen);
+	append_int32(append_info, NumericCast<int32_t>(index - 1));
+	append_string_reference(append_info, nations.list[index - 1].text, NumericCast<idx_t>(nations.list[index - 1].length));
+	append_int32(append_info, NumericCast<int32_t>(nations.list[index - 1].weight));
+	AppendText(append_info, N_CMNT_LEN, &ctx->Seed[N_CMNT_SD]);
 	append_end_row(append_info);
 }
 
-static void append_region(code_t *c, tpch_append_information *info) {
+static void GenerateRegion(DSS_HUGE index, tpch_append_information *info, DBGenContext *ctx) {
 	auto &append_info = info[REGION];
-
 	append_begin_row(append_info);
-	// r_regionkey
-	append_int32(append_info, c->code);
-	// r_name
-	append_string(append_info, c->text);
-	// r_comment
-	append_string(append_info, c->comment, c->clen);
+	append_int32(append_info, NumericCast<int32_t>(index - 1));
+	append_string_reference(append_info, regions.list[index - 1].text, NumericCast<idx_t>(regions.list[index - 1].length));
+	AppendText(append_info, R_CMNT_LEN, &ctx->Seed[R_CMNT_SD]);
 	append_end_row(append_info);
 }
 
 static void gen_tbl(ClientContext &context, int tnum, DSS_HUGE count, tpch_append_information *info,
                     DBGenContext *dbgen_ctx, idx_t offset = 0) {
-	order_t o;
-	supplier_t supp;
-	customer_t cust;
-	part_t part;
-	code_t code;
-
 	for (DSS_HUGE i = offset + 1; count; count--, i++) {
 		if (count % 1000 == 0) {
 			context.InterruptCheck();
@@ -445,30 +607,24 @@ static void gen_tbl(ClientContext &context, int tnum, DSS_HUGE count, tpch_appen
 		case LINE:
 		case ORDER:
 		case ORDER_LINE:
-			mk_order(i, &o, dbgen_ctx, 0);
-			append_order_line(&o, info);
+			GenerateOrderLine(i, info, dbgen_ctx);
 			break;
 		case SUPP:
-			mk_supp(i, &supp, dbgen_ctx);
-			append_supp(&supp, info);
+			GenerateSupplier(i, info, dbgen_ctx);
 			break;
 		case CUST:
-			mk_cust(i, &cust, dbgen_ctx);
-			append_cust(&cust, info);
+			GenerateCustomer(i, info, dbgen_ctx);
 			break;
 		case PSUPP:
 		case PART:
 		case PART_PSUPP:
-			mk_part(i, &part, dbgen_ctx);
-			append_part_psupp(&part, info);
+			GeneratePartAndPartsupp(i, info, dbgen_ctx);
 			break;
 		case NATION:
-			mk_nation(i, &code, dbgen_ctx);
-			append_nation(&code, info);
+			GenerateNation(i, info, dbgen_ctx);
 			break;
 		case REGION:
-			mk_region(i, &code, dbgen_ctx);
-			append_region(&code, info);
+			GenerateRegion(i, info, dbgen_ctx);
 			break;
 		}
 		row_stop_h(tnum, dbgen_ctx);

--- a/extension/tpch/dbgen/dbgen.cpp
+++ b/extension/tpch/dbgen/dbgen.cpp
@@ -8,8 +8,16 @@
 #include "duckdb/parser/constraints/not_null_constraint.hpp"
 #include "duckdb/catalog/catalog.hpp"
 #include "duckdb/main/appender.hpp"
+#include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
+#include "duckdb/common/vector/flat_vector.hpp"
+#include "duckdb/common/vector/string_vector.hpp"
 #include "duckdb/parallel/task_executor.hpp"
+#include "duckdb/planner/binder.hpp"
+#include "duckdb/storage/data_table.hpp"
+#include "duckdb/storage/optimistic_data_writer.hpp"
+#include "duckdb/storage/table/append_state.hpp"
+#include "duckdb/transaction/duck_transaction.hpp"
 
 #define DECLARER /* EXTERN references get defined here */
 
@@ -17,6 +25,7 @@
 #include "dbgen/dsstypes.h"
 
 #include <cassert>
+#include <algorithm>
 #include <atomic>
 #include <cmath>
 #include <mutex>
@@ -25,42 +34,203 @@ using namespace duckdb;
 
 namespace tpch {
 
+enum class TPCHAppendMode : uint8_t { APPENDER, OPTIMISTIC };
+
 struct tpch_append_information {
 	duckdb::unique_ptr<InternalAppender> appender;
+	unique_ptr<OptimisticDataWriter> optimistic_writer;
+	unique_ptr<OptimisticWriteCollection> optimistic_collection;
+	optional_ptr<DuckTableEntry> table_entry;
+	TableAppendState append_state;
+	DataChunk chunk;
+	idx_t row = 0;
+	idx_t active_row = DConstants::INVALID_INDEX;
+	idx_t active_col = 0;
+	bool finalized = false;
+
+	void Initialize(ClientContext &context, TableCatalogEntry &table, idx_t flush_count) {
+		appender = make_uniq<InternalAppender>(context, table, flush_count);
+		chunk.Initialize(context, table.GetTypes());
+	}
+
+	void InitializeOptimistic(ClientContext &context, DuckTableEntry &table) {
+		table_entry = table;
+		optimistic_writer = make_uniq<OptimisticDataWriter>(context, table.GetStorage());
+		optimistic_collection = optimistic_writer->CreateCollection(table.GetStorage(), table.GetTypes());
+		auto &row_collection = *optimistic_collection->collection;
+		row_collection.InitializeEmpty();
+		row_collection.InitializeAppend(append_state);
+		chunk.Initialize(context, table.GetTypes());
+	}
+
+	void FlushChunk() {
+		if (row == 0) {
+			return;
+		}
+		D_ASSERT(active_row == DConstants::INVALID_INDEX);
+		chunk.SetCardinality(row);
+		if (appender) {
+			appender->AppendDataChunk(chunk);
+		} else {
+			D_ASSERT(optimistic_collection);
+			auto &row_collection = *optimistic_collection->collection;
+			auto flushed_row_group_idx = row_collection.Append(chunk, append_state);
+			if (flushed_row_group_idx.IsValid()) {
+				optimistic_writer->WriteNewRowGroup(*optimistic_collection, flushed_row_group_idx.GetIndex());
+			}
+		}
+		chunk.Reset();
+		row = 0;
+		active_col = 0;
+	}
+
+	void FlushOptimistic(ClientContext &context) {
+		D_ASSERT(table_entry);
+		D_ASSERT(optimistic_writer);
+		D_ASSERT(optimistic_collection);
+		FinalizeOptimisticAppend();
+
+		auto &row_collection = *optimistic_collection->collection;
+		auto append_count = row_collection.GetTotalRows();
+		if (append_count == 0) {
+			optimistic_collection.reset();
+			optimistic_writer.reset();
+			finalized = false;
+			return;
+		}
+
+		auto &table = *table_entry;
+		auto &storage = table.GetStorage();
+		if (append_count < storage.GetRowGroupSize()) {
+			auto binder = Binder::CreateBinder(context);
+			auto bound_constraints = binder->BindConstraints(table);
+			LocalAppendState local_append_state;
+			storage.InitializeLocalAppend(local_append_state, table, context, bound_constraints);
+			auto &transaction = DuckTransaction::Get(context, table.catalog);
+			for (auto &insert_chunk : row_collection.Chunks(transaction)) {
+				storage.LocalAppend(local_append_state, table, context, insert_chunk, false);
+			}
+			storage.FinalizeLocalAppend(local_append_state);
+		} else {
+			optimistic_writer->WriteUnflushedRowGroups(*optimistic_collection);
+			storage.LocalMerge(context, table, *optimistic_collection);
+			auto &storage_writer = storage.GetOptimisticWriter(context);
+			storage_writer.Merge(*optimistic_writer);
+		}
+		optimistic_collection.reset();
+		optimistic_writer.reset();
+		finalized = false;
+	}
+
+	void Flush(ClientContext &context) {
+		FlushChunk();
+		if (appender) {
+			appender->Flush();
+			appender.reset();
+		} else if (optimistic_collection) {
+			FlushOptimistic(context);
+		}
+	}
+
+	void FinalizeOptimisticAppend() {
+		D_ASSERT(optimistic_collection);
+		if (finalized) {
+			return;
+		}
+		FlushChunk();
+		TransactionData transaction_data(0, 0);
+		auto &row_collection = *optimistic_collection->collection;
+		row_collection.FinalizeAppend(transaction_data, append_state);
+		finalized = true;
+	}
+
+	void PrepareOptimisticWriteToDisk() {
+		D_ASSERT(table_entry);
+		D_ASSERT(optimistic_writer);
+		D_ASSERT(optimistic_collection);
+		FinalizeOptimisticAppend();
+		auto &storage = table_entry->GetStorage();
+		auto &row_collection = *optimistic_collection->collection;
+		if (row_collection.GetTotalRows() >= storage.GetRowGroupSize()) {
+			optimistic_writer->WriteUnflushedRowGroups(*optimistic_collection);
+		}
+	}
 };
 
+static void append_begin_row(tpch_append_information &info) {
+	D_ASSERT(info.appender || info.optimistic_collection);
+	D_ASSERT(info.active_row == DConstants::INVALID_INDEX);
+	if (info.row >= STANDARD_VECTOR_SIZE) {
+		info.FlushChunk();
+	}
+	info.active_row = info.row;
+	info.active_col = 0;
+}
+
+static void append_end_row(tpch_append_information &info) {
+	D_ASSERT(info.active_row != DConstants::INVALID_INDEX);
+	D_ASSERT(info.active_col == info.chunk.ColumnCount());
+	info.row++;
+	info.active_row = DConstants::INVALID_INDEX;
+}
+
+static Vector &append_next_column(tpch_append_information &info) {
+	D_ASSERT(info.active_row != DConstants::INVALID_INDEX);
+	D_ASSERT(info.active_col < info.chunk.ColumnCount());
+	return info.chunk.data[info.active_col++];
+}
+
 void append_int32(tpch_append_information &info, int32_t value) {
-	info.appender->Append<int32_t>(value);
+	auto &vector = append_next_column(info);
+	FlatVector::GetDataMutable<int32_t>(vector)[info.active_row] = value;
 }
 
 void append_int64(tpch_append_information &info, int64_t value) {
-	info.appender->Append<int64_t>(value);
+	auto &vector = append_next_column(info);
+	FlatVector::GetDataMutable<int64_t>(vector)[info.active_row] = value;
 }
 
 void append_string(tpch_append_information &info, const char *value) {
-	info.appender->Append<const char *>(value);
+	auto &vector = append_next_column(info);
+	FlatVector::GetDataMutable<string_t>(vector)[info.active_row] = StringVector::AddString(vector, value);
 }
 
 void append_decimal(tpch_append_information &info, int64_t value) {
-	info.appender->Append<int64_t>(value);
+	auto &vector = append_next_column(info);
+	FlatVector::GetDataMutable<int64_t>(vector)[info.active_row] = value;
 }
 
-void append_date(tpch_append_information &info, string value) {
-	info.appender->Append<date_t>(Date::FromString(value));
+static date_t parse_tpch_date(const char *value) {
+	static constexpr int32_t UNIX_EPOCH_OFFSET = 8035;
+	static constexpr int32_t YEAR_OFFSET[] = {0, 366, 731, 1096, 1461, 1827, 2192};
+	static constexpr int32_t CUMULATIVE_DAYS[] = {0,  0,   31,  59,  90,  120, 151,
+	                                              181, 212, 243, 273, 304, 334};
+	static constexpr int32_t CUMULATIVE_LEAP_DAYS[] = {0,  0,   31,  60,  91,  121, 152,
+	                                                   182, 213, 244, 274, 305, 335};
+	auto year = static_cast<int32_t>((value[2] - '0') * 10 + (value[3] - '0'));
+	auto month = static_cast<int32_t>((value[5] - '0') * 10 + (value[6] - '0'));
+	auto day = static_cast<int32_t>((value[8] - '0') * 10 + (value[9] - '0'));
+	D_ASSERT(year >= 92 && year <= 98);
+	auto year_index = year - 92;
+	auto &year_days = (year == 92 || year == 96) ? CUMULATIVE_LEAP_DAYS : CUMULATIVE_DAYS;
+	return date_t(UNIX_EPOCH_OFFSET + YEAR_OFFSET[year_index] + year_days[month] + day - 1);
+}
+
+void append_date(tpch_append_information &info, const char *value) {
+	auto &vector = append_next_column(info);
+	FlatVector::GetDataMutable<date_t>(vector)[info.active_row] = parse_tpch_date(value);
 }
 
 void append_char(tpch_append_information &info, char value) {
-	char val[2];
-	val[0] = value;
-	val[1] = '\0';
-	append_string(info, val);
+	auto &vector = append_next_column(info);
+	FlatVector::GetDataMutable<string_t>(vector)[info.active_row] = StringVector::AddString(vector, &value, 1);
 }
 
 static void append_order(order_t *o, tpch_append_information *info) {
 	auto &append_info = info[ORDER];
 
 	// fill the current row with the order information
-	append_info.appender->BeginRow();
+	append_begin_row(append_info);
 	// o_orderkey
 	append_int64(append_info, o->okey);
 	// o_custkey
@@ -79,7 +249,7 @@ static void append_order(order_t *o, tpch_append_information *info) {
 	append_int32(append_info, o->spriority);
 	// o_comment
 	append_string(append_info, o->comment);
-	append_info.appender->EndRow();
+	append_end_row(append_info);
 }
 
 static void append_line(order_t *o, tpch_append_information *info) {
@@ -87,7 +257,7 @@ static void append_line(order_t *o, tpch_append_information *info) {
 
 	// fill the current row with the order information
 	for (DSS_HUGE i = 0; i < o->lines; i++) {
-		append_info.appender->BeginRow();
+		append_begin_row(append_info);
 		// l_orderkey
 		append_int64(append_info, o->l[i].okey);
 		// l_partkey
@@ -120,7 +290,7 @@ static void append_line(order_t *o, tpch_append_information *info) {
 		append_string(append_info, o->l[i].shipmode);
 		// l_comment
 		append_string(append_info, o->l[i].comment);
-		append_info.appender->EndRow();
+		append_end_row(append_info);
 	}
 }
 
@@ -132,7 +302,7 @@ static void append_order_line(order_t *o, tpch_append_information *info) {
 static void append_supp(supplier_t *supp, tpch_append_information *info) {
 	auto &append_info = info[SUPP];
 
-	append_info.appender->BeginRow();
+	append_begin_row(append_info);
 	// s_suppkey
 	append_int64(append_info, supp->suppkey);
 	// s_name
@@ -147,13 +317,13 @@ static void append_supp(supplier_t *supp, tpch_append_information *info) {
 	append_decimal(append_info, supp->acctbal);
 	// s_comment
 	append_string(append_info, supp->comment);
-	append_info.appender->EndRow();
+	append_end_row(append_info);
 }
 
 static void append_cust(customer_t *c, tpch_append_information *info) {
 	auto &append_info = info[CUST];
 
-	append_info.appender->BeginRow();
+	append_begin_row(append_info);
 	// c_custkey
 	append_int64(append_info, c->custkey);
 	// c_name
@@ -170,13 +340,13 @@ static void append_cust(customer_t *c, tpch_append_information *info) {
 	append_string(append_info, c->mktsegment);
 	// c_comment
 	append_string(append_info, c->comment);
-	append_info.appender->EndRow();
+	append_end_row(append_info);
 }
 
 static void append_part(part_t *part, tpch_append_information *info) {
 	auto &append_info = info[PART];
 
-	append_info.appender->BeginRow();
+	append_begin_row(append_info);
 	// p_partkey
 	append_int64(append_info, part->partkey);
 	// p_name
@@ -195,13 +365,13 @@ static void append_part(part_t *part, tpch_append_information *info) {
 	append_decimal(append_info, part->retailprice);
 	// p_comment
 	append_string(append_info, part->comment);
-	append_info.appender->EndRow();
+	append_end_row(append_info);
 }
 
 static void append_psupp(part_t *part, tpch_append_information *info) {
 	auto &append_info = info[PSUPP];
 	for (size_t i = 0; i < SUPP_PER_PART; i++) {
-		append_info.appender->BeginRow();
+		append_begin_row(append_info);
 		// ps_partkey
 		append_int64(append_info, part->s[i].partkey);
 		// ps_suppkey
@@ -212,7 +382,7 @@ static void append_psupp(part_t *part, tpch_append_information *info) {
 		append_decimal(append_info, part->s[i].scost);
 		// ps_comment
 		append_string(append_info, part->s[i].comment);
-		append_info.appender->EndRow();
+		append_end_row(append_info);
 	}
 }
 
@@ -224,7 +394,7 @@ static void append_part_psupp(part_t *part, tpch_append_information *info) {
 static void append_nation(code_t *c, tpch_append_information *info) {
 	auto &append_info = info[NATION];
 
-	append_info.appender->BeginRow();
+	append_begin_row(append_info);
 	// n_nationkey
 	append_int32(append_info, c->code);
 	// n_name
@@ -233,20 +403,20 @@ static void append_nation(code_t *c, tpch_append_information *info) {
 	append_int32(append_info, c->join);
 	// n_comment
 	append_string(append_info, c->comment);
-	append_info.appender->EndRow();
+	append_end_row(append_info);
 }
 
 static void append_region(code_t *c, tpch_append_information *info) {
 	auto &append_info = info[REGION];
 
-	append_info.appender->BeginRow();
+	append_begin_row(append_info);
 	// r_regionkey
 	append_int32(append_info, c->code);
 	// r_name
 	append_string(append_info, c->text);
 	// r_comment
 	append_string(append_info, c->comment);
-	append_info.appender->EndRow();
+	append_end_row(append_info);
 }
 
 static void gen_tbl(ClientContext &context, int tnum, DSS_HUGE count, tpch_append_information *info,
@@ -491,6 +661,7 @@ struct TPCHDBgenParameters {
 
 static constexpr int DBGEN_TABLES[] = {SUPP, CUST, ORDER_LINE, PART_PSUPP, NATION, REGION};
 static constexpr idx_t DBGEN_ROW_BATCH_SIZE = 100000;
+static constexpr idx_t DBGEN_TARGET_CHUNK_ROWS = 122880;
 
 struct DBGenTableRange {
 	idx_t offset;
@@ -529,20 +700,72 @@ static idx_t GetDBGenTotalWork(const DBGenContext &dbgen_ctx, int children, int 
 	return total;
 }
 
+struct DBGenWorkItem {
+	int table_index;
+	int children;
+	int step;
+	idx_t count;
+};
+
+static bool DBGenPhysicalTableMatches(int table_index, int physical_table_index) {
+	switch (table_index) {
+	case ORDER_LINE:
+		return physical_table_index == ORDER || physical_table_index == LINE;
+	case PART_PSUPP:
+		return physical_table_index == PART || physical_table_index == PSUPP;
+	default:
+		return physical_table_index == table_index;
+	}
+}
+
+static idx_t GetDBGenTableOutputMultiplier(int table_index) {
+	switch (table_index) {
+	case ORDER_LINE:
+		return 5;
+	case PART_PSUPP:
+		return SUPP_PER_PART + 1;
+	default:
+		return 1;
+	}
+}
+
+static idx_t GetDefaultTableChildCount(const DBGenContext &dbgen_ctx, int table_index, idx_t thread_count) {
+	auto row_count = GetDBGenTableRowCount(dbgen_ctx, table_index);
+	if (row_count <= DBGEN_TARGET_CHUNK_ROWS || thread_count <= 1) {
+		return 1;
+	}
+	auto child_count = (row_count + DBGEN_TARGET_CHUNK_ROWS - 1) / DBGEN_TARGET_CHUNK_ROWS;
+	return MinValue<idx_t>(child_count, MAX_CHILDREN);
+}
+
 class TPCHDataAppender {
 public:
 	TPCHDataAppender(ClientContext &context, TPCHDBgenParameters &parameters, DBGenContext base_context,
-	                 idx_t flush_count, optional_ptr<atomic<idx_t>> generated_work_counter = nullptr)
-	    : context(context), parameters(parameters), generated_work_counter(generated_work_counter) {
+	                 TPCHAppendMode append_mode, idx_t flush_count,
+	                 optional_ptr<atomic<idx_t>> generated_work_counter = nullptr, int target_table = -1)
+	    : context(context), parameters(parameters), append_mode(append_mode),
+	      generated_work_counter(generated_work_counter) {
 		dbgen_ctx = base_context;
 		append_info = duckdb::unique_ptr<tpch_append_information[]>(new tpch_append_information[REGION + 1]);
 		for (size_t i = PART; i <= REGION; i++) {
+			if (target_table != -1 && !DBGenPhysicalTableMatches(target_table, NumericCast<int>(i))) {
+				continue;
+			}
 			if (parameters.tables[i]) {
 				auto &tbl_catalog = *parameters.tables[i];
 				if (!tbl_catalog.IsDuckTable()) {
 					throw InvalidInputException("dbgen is only supported for DuckDB database files");
 				}
-				append_info[i].appender = make_uniq<InternalAppender>(context, tbl_catalog, flush_count);
+				switch (append_mode) {
+				case TPCHAppendMode::APPENDER:
+					append_info[i].Initialize(context, tbl_catalog, flush_count);
+					break;
+				case TPCHAppendMode::OPTIMISTIC:
+					append_info[i].InitializeOptimistic(context, tbl_catalog.Cast<DuckTableEntry>());
+					break;
+				default:
+					throw InternalException("Unsupported TPC-H append mode");
+				}
 			}
 		}
 	}
@@ -566,30 +789,45 @@ public:
 
 	void AppendData(int children, int current_step) {
 		for (auto table_index : DBGEN_TABLES) {
-			if (table & (1 << table_index)) {
-				auto rowcnt = GetDBGenTableRowCount(dbgen_ctx, table_index);
-				context.InterruptCheck();
-				if (children > 1 && current_step != -1) {
-					auto range = GetDBGenTableRange(rowcnt, children, current_step);
-					SkipTable(table_index, children, range.offset);
-					if (range.count > 0) {
-						// generate part of the table
-						GenerateTableData(table_index, range.count, range.offset);
-					}
-				} else {
-					// generate full table
-					GenerateTableData(table_index, rowcnt, 0);
-				}
+			AppendTableData(table_index, children, current_step);
+		}
+	}
+
+	void AppendTableData(int table_index, int children, int current_step) {
+		if (!(table & (1 << table_index))) {
+			return;
+		}
+		auto rowcnt = GetDBGenTableRowCount(dbgen_ctx, table_index);
+		context.InterruptCheck();
+		if (children > 1 && current_step != -1) {
+			auto range = GetDBGenTableRange(rowcnt, children, current_step);
+			SkipTable(table_index, children, range.offset);
+			if (range.count > 0) {
+				// generate part of the table
+				GenerateTableData(table_index, range.count, range.offset);
 			}
+		} else {
+			// generate full table
+			GenerateTableData(table_index, rowcnt, 0);
 		}
 	}
 
 	void Flush() {
 		// flush any incomplete chunks
 		for (idx_t i = PART; i <= REGION; i++) {
-			if (append_info[i].appender) {
-				append_info[i].appender->Flush();
-				append_info[i].appender.reset();
+			if (append_info[i].appender || append_info[i].optimistic_collection) {
+				append_info[i].Flush(context);
+			}
+		}
+	}
+
+	void PrepareOptimisticWrites() {
+		if (append_mode != TPCHAppendMode::OPTIMISTIC) {
+			return;
+		}
+		for (idx_t i = PART; i <= REGION; i++) {
+			if (append_info[i].optimistic_collection) {
+				append_info[i].PrepareOptimisticWriteToDisk();
 			}
 		}
 	}
@@ -601,6 +839,7 @@ public:
 private:
 	ClientContext &context;
 	TPCHDBgenParameters &parameters;
+	TPCHAppendMode append_mode;
 	optional_ptr<atomic<idx_t>> generated_work_counter;
 	idx_t generated_work = 0;
 	unique_ptr<tpch_append_information[]> append_info;
@@ -609,12 +848,13 @@ private:
 
 class ParallelTPCHAppendTask : public BaseExecutorTask {
 public:
-	ParallelTPCHAppendTask(TaskExecutor &executor, TPCHDataAppender &appender, int children, int current_step)
-	    : BaseExecutorTask(executor), appender(appender), children(children), current_step(current_step) {
+	ParallelTPCHAppendTask(TaskExecutor &executor, TPCHDataAppender &appender, DBGenWorkItem work_item)
+	    : BaseExecutorTask(executor), appender(appender), work_item(work_item) {
 	}
 
 	void ExecuteTask() override {
-		appender.AppendData(children, current_step);
+		appender.AppendTableData(work_item.table_index, work_item.children, work_item.step);
+		appender.PrepareOptimisticWrites();
 	}
 
 	string TaskType() const override {
@@ -623,8 +863,7 @@ public:
 
 private:
 	TPCHDataAppender &appender;
-	int children;
-	int current_step;
+	DBGenWorkItem work_item;
 };
 
 DBGenGenerator::~DBGenGenerator() {
@@ -656,9 +895,7 @@ public:
 		if (!ExplicitPartialGeneration() && thread_count > 1) {
 			mode = DBGenMode::PARALLEL;
 			parallel_thread_count = thread_count;
-			parallel_child_count = GetDefaultChildCount();
-			total_work = GetDBGenTotalWork(base_context, NumericCast<int>(parallel_child_count), 0,
-			                               NumericCast<int>(parallel_child_count));
+			InitializeParallelWorkItems();
 			return;
 		}
 #endif
@@ -705,8 +942,11 @@ public:
 		}
 		auto current_generated_work = MinValue<idx_t>(generated_work.load(), total_work);
 		auto current_flushed_work = MinValue<idx_t>(flushed_work.load(), total_work);
-		auto current_work = static_cast<double>(current_generated_work) + static_cast<double>(current_flushed_work);
-		auto current_progress = 100.0 * (current_work / (2.0 * static_cast<double>(total_work)));
+		auto generated_progress = static_cast<double>(current_generated_work) / static_cast<double>(total_work);
+		auto flushed_progress = static_cast<double>(current_flushed_work) / static_cast<double>(total_work);
+		auto flush_weight = mode == DBGenMode::PARALLEL ? 0.05 : 0.5;
+		auto current_progress =
+		    100.0 * (generated_progress * (1.0 - flush_weight) + flushed_progress * flush_weight);
 		return MinValue<double>(current_progress, 99.9);
 	}
 
@@ -766,6 +1006,33 @@ private:
 		return MinValue<idx_t>(static_cast<idx_t>(CHILDREN_PER_SCALE_FACTOR * flt_scale), MAX_CHILDREN);
 	}
 
+	void InitializeParallelWorkItems() {
+		total_work = 0;
+		parallel_work_items.clear();
+		for (auto table_index : DBGEN_TABLES) {
+			if (!(table & (1 << table_index))) {
+				continue;
+			}
+			auto children =
+			    NumericCast<int>(GetDefaultTableChildCount(base_context, table_index, parallel_thread_count));
+			for (int step = 0; step < children; step++) {
+				auto row_count = GetDBGenTableRowCount(base_context, table_index);
+				auto range = GetDBGenTableRange(row_count, children, step);
+				if (range.count == 0) {
+					continue;
+				}
+				parallel_work_items.push_back(DBGenWorkItem {table_index, children, step, range.count});
+				total_work += range.count;
+			}
+		}
+		std::sort(parallel_work_items.begin(), parallel_work_items.end(),
+		          [](const DBGenWorkItem &left, const DBGenWorkItem &right) {
+			          auto left_output_rows = left.count * GetDBGenTableOutputMultiplier(left.table_index);
+			          auto right_output_rows = right.count * GetDBGenTableOutputMultiplier(right.table_index);
+			          return left_output_rows > right_output_rows;
+		          });
+	}
+
 	bool FlushNextFinishedAppender() {
 		if (finished_appender_offset >= finished_appenders.size()) {
 			finished_appenders.clear();
@@ -794,21 +1061,23 @@ private:
 		if (FlushNextFinishedAppender()) {
 			return false;
 		}
-		if (parallel_step < parallel_child_count) {
+		if (parallel_work_offset < parallel_work_items.size()) {
 			TaskExecutor executor(context);
 
 			vector<TPCHDataAppender> new_appenders;
-			auto launched_step = parallel_step;
-			for (idx_t thr_idx = 0; thr_idx < parallel_thread_count && launched_step < parallel_child_count;
-			     thr_idx++, launched_step++) {
-				new_appenders.emplace_back(context, *parameters, base_context, NumericLimits<int64_t>::Maximum(),
-				                           &generated_work);
+			auto launched_offset = parallel_work_offset;
+			for (idx_t thr_idx = 0; thr_idx < parallel_thread_count && launched_offset < parallel_work_items.size();
+			     thr_idx++, launched_offset++) {
+				auto &work_item = parallel_work_items[launched_offset];
+				new_appenders.emplace_back(context, *parameters, base_context, TPCHAppendMode::OPTIMISTIC,
+				                           NumericLimits<int64_t>::Maximum(), &generated_work,
+				                           work_item.table_index);
 			}
 			for (auto &appender : new_appenders) {
-				auto task = make_uniq<ParallelTPCHAppendTask>(executor, appender, NumericCast<int>(parallel_child_count),
-				                                              NumericCast<int>(parallel_step));
+				auto task =
+				    make_uniq<ParallelTPCHAppendTask>(executor, appender, parallel_work_items[parallel_work_offset]);
 				executor.ScheduleTask(std::move(task));
-				parallel_step++;
+				parallel_work_offset++;
 			}
 			executor.WorkOnTasks();
 			if (executor.HasError()) {
@@ -827,8 +1096,8 @@ private:
 			return;
 		}
 		sequential_appender =
-		    make_uniq<TPCHDataAppender>(context, *parameters, base_context, BaseAppender::DEFAULT_FLUSH_COUNT,
-		                                &generated_work);
+		    make_uniq<TPCHDataAppender>(context, *parameters, base_context, TPCHAppendMode::APPENDER,
+		                                BaseAppender::DEFAULT_FLUSH_COUNT, &generated_work);
 		sequential_table = 0;
 		sequential_table_started = false;
 	}
@@ -902,8 +1171,8 @@ private:
 	idx_t total_work = 0;
 
 	idx_t parallel_thread_count = 1;
-	idx_t parallel_child_count = 1;
-	idx_t parallel_step = 0;
+	vector<DBGenWorkItem> parallel_work_items;
+	idx_t parallel_work_offset = 0;
 	vector<TPCHDataAppender> finished_appenders;
 	idx_t finished_appender_offset = 0;
 

--- a/extension/tpch/dbgen/dbgen.cpp
+++ b/extension/tpch/dbgen/dbgen.cpp
@@ -17,6 +17,7 @@
 #include "dbgen/dsstypes.h"
 
 #include <cassert>
+#include <atomic>
 #include <cmath>
 #include <mutex>
 
@@ -257,8 +258,8 @@ static void gen_tbl(ClientContext &context, int tnum, DSS_HUGE count, tpch_appen
 	code_t code;
 
 	for (DSS_HUGE i = offset + 1; count; count--, i++) {
-		if (count % 1000 == 0 && context.IsInterrupted()) {
-			return;
+		if (count % 1000 == 0) {
+			context.InterruptCheck();
 		}
 		row_start(tnum, dbgen_ctx);
 		switch (tnum) {
@@ -488,14 +489,53 @@ struct TPCHDBgenParameters {
 	vector<optional_ptr<TableCatalogEntry>> tables;
 };
 
+static constexpr int DBGEN_TABLES[] = {SUPP, CUST, ORDER_LINE, PART_PSUPP, NATION, REGION};
+static constexpr idx_t DBGEN_ROW_BATCH_SIZE = 100000;
+
+struct DBGenTableRange {
+	idx_t offset;
+	idx_t count;
+};
+
+static idx_t GetDBGenTableRowCount(const DBGenContext &dbgen_ctx, int table_index) {
+	if (table_index < NATION) {
+		return static_cast<idx_t>(dbgen_ctx.tdefs[table_index].base * dbgen_ctx.scale_factor);
+	}
+	return static_cast<idx_t>(dbgen_ctx.tdefs[table_index].base);
+}
+
+static DBGenTableRange GetDBGenTableRange(idx_t row_count, int children, int current_step) {
+	if (children <= 1 || current_step == -1) {
+		return DBGenTableRange {0, row_count};
+	}
+	auto child_count = static_cast<idx_t>(children);
+	auto step = static_cast<idx_t>(current_step);
+	auto part_size = (row_count + child_count - 1) / child_count;
+	auto part_offset = part_size * step;
+	if (part_offset >= row_count) {
+		return DBGenTableRange {part_offset, 0};
+	}
+	return DBGenTableRange {part_offset, MinValue<idx_t>(part_size, row_count - part_offset)};
+}
+
+static idx_t GetDBGenTotalWork(const DBGenContext &dbgen_ctx, int children, int start_step, int end_step) {
+	idx_t total = 0;
+	for (int step = start_step; step < end_step; step++) {
+		for (auto table_index : DBGEN_TABLES) {
+			auto row_count = GetDBGenTableRowCount(dbgen_ctx, table_index);
+			total += GetDBGenTableRange(row_count, children, step).count;
+		}
+	}
+	return total;
+}
+
 class TPCHDataAppender {
 public:
 	TPCHDataAppender(ClientContext &context, TPCHDBgenParameters &parameters, DBGenContext base_context,
-	                 idx_t flush_count)
-	    : context(context), parameters(parameters) {
+	                 idx_t flush_count, optional_ptr<atomic<idx_t>> generated_work_counter = nullptr)
+	    : context(context), parameters(parameters), generated_work_counter(generated_work_counter) {
 		dbgen_ctx = base_context;
 		append_info = duckdb::unique_ptr<tpch_append_information[]>(new tpch_append_information[REGION + 1]);
-		memset(append_info.get(), 0, sizeof(tpch_append_information) * REGION + 1);
 		for (size_t i = PART; i <= REGION; i++) {
 			if (parameters.tables[i]) {
 				auto &tbl_catalog = *parameters.tables[i];
@@ -508,35 +548,37 @@ public:
 	}
 
 	void GenerateTableData(int table_index, idx_t row_count, idx_t offset) {
+		if (row_count == 0) {
+			return;
+		}
 		gen_tbl(context, table_index, static_cast<DSS_HUGE>(row_count), append_info.get(), &dbgen_ctx, offset);
+		generated_work += row_count;
+		if (generated_work_counter) {
+			generated_work_counter->fetch_add(row_count);
+		}
+	}
+
+	void SkipTable(int table_index, int children, idx_t offset) {
+		if (children > 1) {
+			skip(table_index, children, static_cast<DSS_HUGE>(offset), dbgen_ctx);
+		}
 	}
 
 	void AppendData(int children, int current_step) {
-		DSS_HUGE i;
-		DSS_HUGE rowcnt = 0;
-		for (i = PART; i <= REGION; i++) {
-			if (table & (1 << i)) {
-				if (i < NATION) {
-					rowcnt = dbgen_ctx.tdefs[i].base * dbgen_ctx.scale_factor;
-				} else {
-					rowcnt = dbgen_ctx.tdefs[i].base;
-				}
-				if (context.IsInterrupted()) {
-					return;
-				}
+		for (auto table_index : DBGEN_TABLES) {
+			if (table & (1 << table_index)) {
+				auto rowcnt = GetDBGenTableRowCount(dbgen_ctx, table_index);
+				context.InterruptCheck();
 				if (children > 1 && current_step != -1) {
-					size_t part_size = std::ceil((double)rowcnt / (double)children);
-					auto part_offset = part_size * current_step;
-					auto part_end = part_offset + part_size;
-					rowcnt = part_end > rowcnt ? rowcnt - part_offset : part_size;
-					skip(i, children, part_offset, dbgen_ctx);
-					if (rowcnt > 0) {
+					auto range = GetDBGenTableRange(rowcnt, children, current_step);
+					SkipTable(table_index, children, range.offset);
+					if (range.count > 0) {
 						// generate part of the table
-						GenerateTableData((int)i, rowcnt, part_offset);
+						GenerateTableData(table_index, range.count, range.offset);
 					}
 				} else {
 					// generate full table
-					GenerateTableData((int)i, rowcnt, 0);
+					GenerateTableData(table_index, rowcnt, 0);
 				}
 			}
 		}
@@ -552,9 +594,15 @@ public:
 		}
 	}
 
+	idx_t GeneratedWork() const {
+		return generated_work;
+	}
+
 private:
 	ClientContext &context;
 	TPCHDBgenParameters &parameters;
+	optional_ptr<atomic<idx_t>> generated_work_counter;
+	idx_t generated_work = 0;
 	unique_ptr<tpch_append_information[]> append_info;
 	DBGenContext dbgen_ctx;
 };
@@ -579,130 +627,309 @@ private:
 	int current_step;
 };
 
-void DBGenWrapper::LoadTPCHData(ClientContext &context, double flt_scale, const Identifier &catalog_name,
-                                const Identifier &schema, string suffix, int children, int current_step) {
-	if (flt_scale == 0) {
-		return;
-	}
+DBGenGenerator::~DBGenGenerator() {
+}
 
-	// all tables
-	table = (1 << CUST) | (1 << SUPP) | (1 << NATION) | (1 << REGION) | (1 << PART_PSUPP) | (1 << ORDER_LINE);
-	force = 0;
-	insert_segments = 0;
-	delete_segments = 0;
-	insert_orders_segment = 0;
-	insert_lineitem_segment = 0;
-	delete_segment = 0;
-	verbose = 0;
-	set_seeds = 0;
-	updates = 0;
+class TPCHDBGenGenerator : public DBGenGenerator {
+public:
+	TPCHDBGenGenerator(ClientContext &context, double flt_scale, const Identifier &catalog_name,
+	                   const Identifier &schema, string suffix, int children, int current_step)
+	    : context(context), flt_scale(flt_scale), children(children), current_step(current_step) {
+		InitializeBaseContext();
 
-	d_path = NULL;
-
-	DBGenContext base_context;
-	tdef *tdefs = base_context.tdefs;
-	tdefs[PART].base = 200000;
-	tdefs[PSUPP].base = 200000;
-	tdefs[SUPP].base = 10000;
-	tdefs[CUST].base = 150000;
-	tdefs[ORDER].base = 150000 * ORDERS_PER_CUST;
-	tdefs[LINE].base = 150000 * ORDERS_PER_CUST;
-	tdefs[ORDER_LINE].base = 150000 * ORDERS_PER_CUST;
-	tdefs[PART_PSUPP].base = 200000;
-	tdefs[NATION].base = NATIONS_MAX;
-	tdefs[REGION].base = NATIONS_MAX;
-
-	if (flt_scale < MIN_SCALE) {
-		int i;
-		int int_scale;
-
-		base_context.scale_factor = 1;
-		int_scale = (int)(1000 * flt_scale);
-		for (i = PART; i < REGION; i++) {
-			tdefs[i].base = (DSS_HUGE)(int_scale * tdefs[i].base) / 1000;
-			if (tdefs[i].base < 1) {
-				tdefs[i].base = 1;
-			}
+		if (flt_scale == 0 || current_step >= children) {
+			Finish();
+			return;
 		}
-	} else {
-		base_context.scale_factor = (long)flt_scale;
-	}
 
-	if (current_step >= children) {
-		return;
-	}
+		auto &catalog = Catalog::GetCatalog(context, catalog_name);
+		parameters = make_uniq<TPCHDBgenParameters>(context, catalog, schema, suffix);
 
-	load_dists(10 * 1024 * 1024, &base_context); // 10MiB
-	/* have to do this after init */
-	tdefs[NATION].base = nations.count;
-	tdefs[REGION].base = regions.count;
+		load_dists(10 * 1024 * 1024, &base_context); // 10MiB
+		distributions_loaded = true;
+		/* have to do this after init */
+		base_context.tdefs[NATION].base = nations.count;
+		base_context.tdefs[REGION].base = regions.count;
 
-	auto &catalog = Catalog::GetCatalog(context, catalog_name);
-
-	TPCHDBgenParameters parameters(context, catalog, schema, suffix);
 #ifndef DUCKDB_NO_THREADS
-	bool explicit_partial_generation = children > 1 && current_step != -1;
-	auto thread_count = TaskScheduler::GetScheduler(context).NumberOfThreads();
-	if (explicit_partial_generation || thread_count <= 1) {
+		auto thread_count = TaskScheduler::GetScheduler(context).NumberOfThreads();
+		if (!ExplicitPartialGeneration() && thread_count > 1) {
+			mode = DBGenMode::PARALLEL;
+			parallel_thread_count = thread_count;
+			parallel_child_count = GetDefaultChildCount();
+			total_work = GetDBGenTotalWork(base_context, NumericCast<int>(parallel_child_count), 0,
+			                               NumericCast<int>(parallel_child_count));
+			return;
+		}
 #endif
-		// if we are doing explicit partial generation the parallelism is managed outside of dbgen
-		// only generate the chunk we are interested in
-		TPCHDataAppender appender(context, parameters, base_context, BaseAppender::DEFAULT_FLUSH_COUNT);
-		appender.AppendData(children, current_step);
-		appender.Flush();
-#ifndef DUCKDB_NO_THREADS
-	} else {
-		// we split into 20 children per scale factor by default
-		static constexpr idx_t CHILDREN_PER_SCALE_FACTOR = 20;
-		idx_t child_count;
-		if (flt_scale < 1) {
-			child_count = 1;
-		} else {
-			child_count = MinValue<idx_t>(static_cast<idx_t>(CHILDREN_PER_SCALE_FACTOR * flt_scale), MAX_CHILDREN);
+
+		mode = DBGenMode::SEQUENTIAL;
+		sequential_children = ExplicitPartialGeneration() ? children : NumericCast<int>(GetDefaultChildCount());
+		sequential_start_step = ExplicitPartialGeneration() ? current_step : 0;
+		sequential_end_step = ExplicitPartialGeneration() ? current_step + 1 : sequential_children;
+		sequential_step = sequential_start_step;
+		total_work = GetDBGenTotalWork(base_context, sequential_children, sequential_start_step, sequential_end_step);
+	}
+
+	~TPCHDBGenGenerator() override {
+		if (distributions_loaded) {
+			cleanup_dists();
 		}
-		idx_t step = 0;
-		vector<TPCHDataAppender> finished_appenders;
-		while (step < child_count) {
-			// launch N threads
+	}
+
+	bool GenerateNext() override {
+		context.InterruptCheck();
+		if (finished) {
+			return true;
+		}
+		if (total_work == 0) {
+			Finish();
+			return true;
+		}
+		switch (mode) {
+		case DBGenMode::PARALLEL:
+			return GenerateParallel();
+		case DBGenMode::SEQUENTIAL:
+			return GenerateSequential();
+		default:
+			throw InternalException("Unexpected TPC-H dbgen mode");
+		}
+	}
+
+	double Progress() const override {
+		if (finished) {
+			return 100.0;
+		}
+		if (total_work == 0) {
+			return 0.0;
+		}
+		auto current_generated_work = MinValue<idx_t>(generated_work.load(), total_work);
+		auto current_flushed_work = MinValue<idx_t>(flushed_work.load(), total_work);
+		auto current_work = static_cast<double>(current_generated_work) + static_cast<double>(current_flushed_work);
+		auto current_progress = 100.0 * (current_work / (2.0 * static_cast<double>(total_work)));
+		return MinValue<double>(current_progress, 99.9);
+	}
+
+private:
+	enum class DBGenMode : uint8_t { SEQUENTIAL, PARALLEL };
+
+	void InitializeBaseContext() {
+		// all tables
+		table = (1 << CUST) | (1 << SUPP) | (1 << NATION) | (1 << REGION) | (1 << PART_PSUPP) | (1 << ORDER_LINE);
+		force = 0;
+		insert_segments = 0;
+		delete_segments = 0;
+		insert_orders_segment = 0;
+		insert_lineitem_segment = 0;
+		delete_segment = 0;
+		verbose = 0;
+		set_seeds = 0;
+		updates = 0;
+
+		d_path = NULL;
+
+		auto tdefs = base_context.tdefs;
+		tdefs[PART].base = 200000;
+		tdefs[PSUPP].base = 200000;
+		tdefs[SUPP].base = 10000;
+		tdefs[CUST].base = 150000;
+		tdefs[ORDER].base = 150000 * ORDERS_PER_CUST;
+		tdefs[LINE].base = 150000 * ORDERS_PER_CUST;
+		tdefs[ORDER_LINE].base = 150000 * ORDERS_PER_CUST;
+		tdefs[PART_PSUPP].base = 200000;
+		tdefs[NATION].base = NATIONS_MAX;
+		tdefs[REGION].base = NATIONS_MAX;
+
+		if (flt_scale < MIN_SCALE) {
+			auto int_scale = static_cast<int>(1000 * flt_scale);
+			base_context.scale_factor = 1;
+			for (int i = PART; i < REGION; i++) {
+				tdefs[i].base = (DSS_HUGE)(int_scale * tdefs[i].base) / 1000;
+				if (tdefs[i].base < 1) {
+					tdefs[i].base = 1;
+				}
+			}
+		} else {
+			base_context.scale_factor = static_cast<long>(flt_scale);
+		}
+	}
+
+	bool ExplicitPartialGeneration() const {
+		return children > 1 && current_step != -1;
+	}
+
+	idx_t GetDefaultChildCount() const {
+		if (flt_scale < 1) {
+			return 1;
+		}
+		static constexpr idx_t CHILDREN_PER_SCALE_FACTOR = 20;
+		return MinValue<idx_t>(static_cast<idx_t>(CHILDREN_PER_SCALE_FACTOR * flt_scale), MAX_CHILDREN);
+	}
+
+	bool FlushNextFinishedAppender() {
+		if (finished_appender_offset >= finished_appenders.size()) {
+			finished_appenders.clear();
+			finished_appender_offset = 0;
+			return false;
+		}
+		auto &appender = finished_appenders[finished_appender_offset++];
+		appender.Flush();
+		flushed_work.fetch_add(appender.GeneratedWork());
+		if (finished_appender_offset >= finished_appenders.size()) {
+			finished_appenders.clear();
+			finished_appender_offset = 0;
+		}
+		return true;
+	}
+
+	void FlushAllFinishedAppenders() {
+		while (FlushNextFinishedAppender()) {
+		}
+	}
+
+	bool GenerateParallel() {
+#ifdef DUCKDB_NO_THREADS
+		throw InternalException("Parallel TPC-H dbgen selected without threading support");
+#else
+		if (FlushNextFinishedAppender()) {
+			return false;
+		}
+		if (parallel_step < parallel_child_count) {
 			TaskExecutor executor(context);
 
 			vector<TPCHDataAppender> new_appenders;
-			idx_t launched_step = step;
-			// initialize the appenders for each thread
-			// note we prevent the threads themselves from flushing the appenders by specifying a very high flush count
-			// here
-			for (idx_t thr_idx = 0; thr_idx < thread_count && launched_step < child_count; thr_idx++, launched_step++) {
-				new_appenders.emplace_back(context, parameters, base_context, NumericLimits<int64_t>::Maximum());
+			auto launched_step = parallel_step;
+			for (idx_t thr_idx = 0; thr_idx < parallel_thread_count && launched_step < parallel_child_count;
+			     thr_idx++, launched_step++) {
+				new_appenders.emplace_back(context, *parameters, base_context, NumericLimits<int64_t>::Maximum(),
+				                           &generated_work);
 			}
-			// schedule tasks for all appenders
 			for (auto &appender : new_appenders) {
-				auto task = make_uniq<ParallelTPCHAppendTask>(executor, appender, child_count, step);
+				auto task = make_uniq<ParallelTPCHAppendTask>(executor, appender, NumericCast<int>(parallel_child_count),
+				                                              NumericCast<int>(parallel_step));
 				executor.ScheduleTask(std::move(task));
-				step++;
+				parallel_step++;
 			}
-			// complete all tasks
 			executor.WorkOnTasks();
 			if (executor.HasError()) {
 				executor.ThrowError();
 			}
-			// flush the previous batch of appenders while waiting (if any are there)
-			// now flush the appenders in-order
-			// NOTE: do NOT catch exceptions here - if Flush() fails, let the exception
-			// propagate so that all appender destructors run with UncaughtException() == true,
-			// preventing them from re-attempting a flush on already-inconsistent local storage.
-			for (auto &appender : finished_appenders) {
-				appender.Flush();
-			}
-			finished_appenders.clear();
 			finished_appenders = std::move(new_appenders);
+			return false;
 		}
-		// flush the final batch of appenders
-		for (auto &appender : finished_appenders) {
-			appender.Flush();
-		}
-	}
+		Finish();
+		return true;
 #endif
-	cleanup_dists();
+	}
+
+	void InitializeSequentialAppender() {
+		if (sequential_appender) {
+			return;
+		}
+		sequential_appender =
+		    make_uniq<TPCHDataAppender>(context, *parameters, base_context, BaseAppender::DEFAULT_FLUSH_COUNT,
+		                                &generated_work);
+		sequential_table = 0;
+		sequential_table_started = false;
+	}
+
+	bool GenerateSequential() {
+		while (sequential_step < sequential_end_step) {
+			InitializeSequentialAppender();
+			while (sequential_table < sizeof(DBGEN_TABLES) / sizeof(DBGEN_TABLES[0])) {
+				auto table_index = DBGEN_TABLES[sequential_table];
+				if (!sequential_table_started) {
+					auto row_count = GetDBGenTableRowCount(base_context, table_index);
+					auto range = GetDBGenTableRange(row_count, sequential_children, sequential_step);
+					sequential_table_offset = range.offset;
+					sequential_table_count = range.count;
+					sequential_table_generated = 0;
+					sequential_table_started = true;
+					sequential_appender->SkipTable(table_index, sequential_children, sequential_table_offset);
+				}
+				if (sequential_table_generated >= sequential_table_count) {
+					sequential_table++;
+					sequential_table_started = false;
+					continue;
+				}
+				auto remaining = sequential_table_count - sequential_table_generated;
+				auto generate_count = MinValue<idx_t>(remaining, DBGEN_ROW_BATCH_SIZE);
+				sequential_appender->GenerateTableData(table_index, generate_count,
+				                                       sequential_table_offset + sequential_table_generated);
+				sequential_table_generated += generate_count;
+				if (generated_work.load() >= total_work) {
+					continue;
+				}
+				return false;
+			}
+			flushed_work.fetch_add(sequential_appender->GeneratedWork());
+			sequential_appender->Flush();
+			sequential_appender.reset();
+			sequential_step++;
+		}
+		Finish();
+		return true;
+	}
+
+	void Finish() {
+		FlushAllFinishedAppenders();
+		if (sequential_appender) {
+			flushed_work.fetch_add(sequential_appender->GeneratedWork());
+			sequential_appender->Flush();
+			sequential_appender.reset();
+		}
+		if (distributions_loaded) {
+			cleanup_dists();
+			distributions_loaded = false;
+		}
+		generated_work = total_work;
+		flushed_work = total_work;
+		finished = true;
+	}
+
+private:
+	ClientContext &context;
+	double flt_scale;
+	int children;
+	int current_step;
+	DBGenContext base_context;
+	unique_ptr<TPCHDBgenParameters> parameters;
+	bool distributions_loaded = false;
+	bool finished = false;
+	DBGenMode mode = DBGenMode::SEQUENTIAL;
+	atomic<idx_t> generated_work {0};
+	atomic<idx_t> flushed_work {0};
+	idx_t total_work = 0;
+
+	idx_t parallel_thread_count = 1;
+	idx_t parallel_child_count = 1;
+	idx_t parallel_step = 0;
+	vector<TPCHDataAppender> finished_appenders;
+	idx_t finished_appender_offset = 0;
+
+	int sequential_children = 1;
+	int sequential_start_step = 0;
+	int sequential_end_step = 0;
+	int sequential_step = 0;
+	idx_t sequential_table = 0;
+	bool sequential_table_started = false;
+	idx_t sequential_table_offset = 0;
+	idx_t sequential_table_count = 0;
+	idx_t sequential_table_generated = 0;
+	unique_ptr<TPCHDataAppender> sequential_appender;
+};
+
+unique_ptr<DBGenGenerator> CreateDBGenGenerator(ClientContext &context, double sf, const Identifier &catalog,
+                                                const Identifier &schema, string suffix, int children, int step) {
+	return make_uniq<TPCHDBGenGenerator>(context, sf, catalog, schema, std::move(suffix), children, step);
+}
+
+void DBGenWrapper::LoadTPCHData(ClientContext &context, double flt_scale, const Identifier &catalog_name,
+                                const Identifier &schema, string suffix, int children, int current_step) {
+	auto generator = CreateDBGenGenerator(context, flt_scale, catalog_name, schema, std::move(suffix), children,
+	                                      current_step);
+	while (!generator->GenerateNext()) {
+	}
 }
 
 string DBGenWrapper::GetQuery(int query) {

--- a/extension/tpch/dbgen/dbgen.cpp
+++ b/extension/tpch/dbgen/dbgen.cpp
@@ -190,6 +190,11 @@ void append_int64(tpch_append_information &info, int64_t value) {
 	FlatVector::GetDataMutable<int64_t>(vector)[info.active_row] = value;
 }
 
+void append_string(tpch_append_information &info, const char *value, idx_t length) {
+	auto &vector = append_next_column(info);
+	FlatVector::GetDataMutable<string_t>(vector)[info.active_row] = StringVector::AddString(vector, value, length);
+}
+
 void append_string(tpch_append_information &info, const char *value) {
 	auto &vector = append_next_column(info);
 	FlatVector::GetDataMutable<string_t>(vector)[info.active_row] = StringVector::AddString(vector, value);
@@ -244,11 +249,11 @@ static void append_order(order_t *o, tpch_append_information *info) {
 	// o_orderpriority
 	append_string(append_info, o->opriority);
 	// o_clerk
-	append_string(append_info, o->clerk);
+	append_string(append_info, o->clerk, O_CLRK_LEN);
 	// o_shippriority
 	append_int32(append_info, o->spriority);
 	// o_comment
-	append_string(append_info, o->comment);
+	append_string(append_info, o->comment, o->clen);
 	append_end_row(append_info);
 }
 
@@ -289,7 +294,7 @@ static void append_line(order_t *o, tpch_append_information *info) {
 		// l_shipmode
 		append_string(append_info, o->l[i].shipmode);
 		// l_comment
-		append_string(append_info, o->l[i].comment);
+		append_string(append_info, o->l[i].comment, o->l[i].clen);
 		append_end_row(append_info);
 	}
 }
@@ -308,15 +313,15 @@ static void append_supp(supplier_t *supp, tpch_append_information *info) {
 	// s_name
 	append_string(append_info, supp->name);
 	// s_address
-	append_string(append_info, supp->address);
+	append_string(append_info, supp->address, supp->alen);
 	// s_nationkey
 	append_int32(append_info, supp->nation_code);
 	// s_phone
-	append_string(append_info, supp->phone);
+	append_string(append_info, supp->phone, PHONE_LEN);
 	// s_acctbal
 	append_decimal(append_info, supp->acctbal);
 	// s_comment
-	append_string(append_info, supp->comment);
+	append_string(append_info, supp->comment, supp->clen);
 	append_end_row(append_info);
 }
 
@@ -329,17 +334,17 @@ static void append_cust(customer_t *c, tpch_append_information *info) {
 	// c_name
 	append_string(append_info, c->name);
 	// c_address
-	append_string(append_info, c->address);
+	append_string(append_info, c->address, c->alen);
 	// c_nationkey
 	append_int32(append_info, c->nation_code);
 	// c_phone
-	append_string(append_info, c->phone);
+	append_string(append_info, c->phone, PHONE_LEN);
 	// c_acctbal
 	append_decimal(append_info, c->acctbal);
 	// c_mktsegment
 	append_string(append_info, c->mktsegment);
 	// c_comment
-	append_string(append_info, c->comment);
+	append_string(append_info, c->comment, c->clen);
 	append_end_row(append_info);
 }
 
@@ -350,13 +355,13 @@ static void append_part(part_t *part, tpch_append_information *info) {
 	// p_partkey
 	append_int64(append_info, part->partkey);
 	// p_name
-	append_string(append_info, part->name);
+	append_string(append_info, part->name, part->nlen);
 	// p_mfgr
-	append_string(append_info, part->mfgr);
+	append_string(append_info, part->mfgr, sizeof(P_MFG_TAG));
 	// p_brand
-	append_string(append_info, part->brand);
+	append_string(append_info, part->brand, sizeof(P_BRND_TAG) + 1);
 	// p_type
-	append_string(append_info, part->type);
+	append_string(append_info, part->type, part->tlen);
 	// p_size
 	append_int32(append_info, part->size);
 	// p_container
@@ -364,7 +369,7 @@ static void append_part(part_t *part, tpch_append_information *info) {
 	// p_retailprice
 	append_decimal(append_info, part->retailprice);
 	// p_comment
-	append_string(append_info, part->comment);
+	append_string(append_info, part->comment, part->clen);
 	append_end_row(append_info);
 }
 
@@ -381,7 +386,7 @@ static void append_psupp(part_t *part, tpch_append_information *info) {
 		// ps_supplycost
 		append_decimal(append_info, part->s[i].scost);
 		// ps_comment
-		append_string(append_info, part->s[i].comment);
+		append_string(append_info, part->s[i].comment, part->s[i].clen);
 		append_end_row(append_info);
 	}
 }
@@ -402,7 +407,7 @@ static void append_nation(code_t *c, tpch_append_information *info) {
 	// n_regionkey
 	append_int32(append_info, c->join);
 	// n_comment
-	append_string(append_info, c->comment);
+	append_string(append_info, c->comment, c->clen);
 	append_end_row(append_info);
 }
 
@@ -415,7 +420,7 @@ static void append_region(code_t *c, tpch_append_information *info) {
 	// r_name
 	append_string(append_info, c->text);
 	// r_comment
-	append_string(append_info, c->comment);
+	append_string(append_info, c->comment, c->clen);
 	append_end_row(append_info);
 }
 

--- a/extension/tpch/dbgen/dbgen.cpp
+++ b/extension/tpch/dbgen/dbgen.cpp
@@ -73,7 +73,7 @@ struct tpch_append_information {
 			return;
 		}
 		D_ASSERT(active_row == DConstants::INVALID_INDEX);
-		chunk.SetCardinality(row);
+		chunk.SetChildCardinality(row);
 		if (appender) {
 			appender->AppendDataChunk(chunk);
 		} else {

--- a/extension/tpch/dbgen/dbgen.cpp
+++ b/extension/tpch/dbgen/dbgen.cpp
@@ -54,10 +54,12 @@ struct tpch_append_information {
 		chunk.Initialize(context, table.GetTypes());
 	}
 
-	void InitializeOptimistic(ClientContext &context, DuckTableEntry &table) {
+	void InitializeOptimistic(ClientContext &context, DuckTableEntry &table,
+	                          OptimisticWritePartialManagers partial_manager_type) {
 		table_entry = table;
 		optimistic_writer = make_uniq<OptimisticDataWriter>(context, table.GetStorage());
-		optimistic_collection = optimistic_writer->CreateCollection(table.GetStorage(), table.GetTypes());
+		optimistic_collection =
+		    optimistic_writer->CreateCollection(table.GetStorage(), table.GetTypes(), partial_manager_type);
 		auto &row_collection = *optimistic_collection->collection;
 		row_collection.InitializeEmpty();
 		row_collection.InitializeAppend(append_state);
@@ -154,6 +156,7 @@ struct tpch_append_information {
 		auto &row_collection = *optimistic_collection->collection;
 		if (row_collection.GetTotalRows() >= storage.GetRowGroupSize()) {
 			optimistic_writer->WriteUnflushedRowGroups(*optimistic_collection);
+			optimistic_writer->FinalFlush();
 		}
 	}
 };
@@ -766,9 +769,13 @@ public:
 				case TPCHAppendMode::APPENDER:
 					append_info[i].Initialize(context, tbl_catalog, flush_count);
 					break;
-				case TPCHAppendMode::OPTIMISTIC:
-					append_info[i].InitializeOptimistic(context, tbl_catalog.Cast<DuckTableEntry>());
+				case TPCHAppendMode::OPTIMISTIC: {
+					auto partial_manager_type = i == LINE ? OptimisticWritePartialManagers::GLOBAL
+					                                      : OptimisticWritePartialManagers::PER_COLUMN;
+					append_info[i].InitializeOptimistic(context, tbl_catalog.Cast<DuckTableEntry>(),
+					                                    partial_manager_type);
 					break;
+				}
 				default:
 					throw InternalException("Unsupported TPC-H append mode");
 				}

--- a/extension/tpch/dbgen/include/dbgen/dbgen.hpp
+++ b/extension/tpch/dbgen/include/dbgen/dbgen.hpp
@@ -33,4 +33,19 @@ struct DBGenWrapper {
 	static std::string GetAnswer(double sf, int query);
 };
 
+class DBGenGenerator {
+public:
+	virtual ~DBGenGenerator();
+
+	//! Generate the next batch of data, returning true when generation is complete
+	virtual bool GenerateNext() = 0;
+	//! Returns the progress percentage in [0, 100]
+	virtual double Progress() const = 0;
+};
+
+duckdb::unique_ptr<DBGenGenerator> CreateDBGenGenerator(duckdb::ClientContext &context, double sf,
+                                                        const duckdb::Identifier &catalog,
+                                                        const duckdb::Identifier &schema, std::string suffix,
+                                                        int children, int step);
+
 } // namespace tpch

--- a/extension/tpch/dbgen/include/dbgen/dss.h
+++ b/extension/tpch/dbgen/include/dbgen/dss.h
@@ -103,6 +103,7 @@
 typedef struct {
 	long weight;
 	char *text;
+	/* byte length cached when loading dists.dss */
 	int length;
 } set_member;
 

--- a/extension/tpch/dbgen/include/dbgen/dss.h
+++ b/extension/tpch/dbgen/include/dbgen/dss.h
@@ -103,6 +103,7 @@
 typedef struct {
 	long weight;
 	char *text;
+	int length;
 } set_member;
 
 typedef struct {
@@ -153,6 +154,7 @@ int pick_str PROTO((distribution * s, seed_t *seed, char *target));
 void agg_str PROTO((distribution * set, long count, seed_t *seed, char *dest, DBGenContext *ctx));
 void read_dist PROTO((const char *path, const char *name, distribution *target));
 void embed_str PROTO((distribution * d, int min, int max, int stream, char *dest));
+void permute_dist PROTO((distribution * d, seed_t *seed, DBGenContext *ctx));
 #ifndef STDLIB_HAS_GETOPT
 int getopt PROTO((int arg_cnt, char **arg_vect, char *oprions));
 #endif /* STDLIB_HAS_GETOPT */
@@ -175,6 +177,7 @@ void init_text_pool PROTO((long bSize, DBGenContext *ctx));
 void free_text_pool PROTO(());
 
 void dbg_text PROTO((char *t, int min, int max, seed_t *seed));
+int dbg_text_source PROTO((int min, int max, seed_t *seed, const char **source));
 
 #ifdef DECLARER
 #define EXTERN

--- a/extension/tpch/dbgen/rnd.cpp
+++ b/extension/tpch/dbgen/rnd.cpp
@@ -37,36 +37,49 @@ void dss_random(DSS_HUGE *tgt, DSS_HUGE lower, DSS_HUGE upper, seed_t *seed) {
 	return;
 }
 
+static int seed_table(int t) {
+	if (t == ORDER_LINE) {
+		return ORDER;
+	}
+	if (t == PART_PSUPP) {
+		return PART;
+	}
+	return t;
+}
+
+static bool seed_matches_table(seed_t &seed, int t, DBGenContext *ctx) {
+	return seed.table == t || seed.table == ctx->tdefs[t].child;
+}
+
 void row_start(int t, DBGenContext *ctx) {
-	(void)t;
-	int i;
-	for (i = 0; i <= MAX_STREAM; i++)
-		ctx->Seed[i].usage = 0;
+	t = seed_table(t);
+	for (int i = 0; i <= MAX_STREAM; i++) {
+		if (seed_matches_table(ctx->Seed[i], t, ctx)) {
+			ctx->Seed[i].usage = 0;
+		}
+	}
 
 	return;
 }
 
 void row_stop_h(int t, DBGenContext *ctx) {
-	int i;
-
-	/* need to allow for handling the master and detail together */
-	if (t == ORDER_LINE)
-		t = ORDER;
-	if (t == PART_PSUPP)
-		t = PART;
-
-	for (i = 0; i <= MAX_STREAM; i++)
-		if ((ctx->Seed[i].table == t) || (ctx->Seed[i].table == ctx->tdefs[t].child)) {
+	t = seed_table(t);
+	for (int i = 0; i <= MAX_STREAM; i++) {
+		if (seed_matches_table(ctx->Seed[i], t, ctx)) {
 			if (set_seeds && (ctx->Seed[i].usage > ctx->Seed[i].boundary)) {
 				fprintf(stderr, "\nSEED CHANGE: seed[%d].usage = " HUGE_FORMAT "\n", i, ctx->Seed[i].usage);
 				ctx->Seed[i].boundary = ctx->Seed[i].usage;
 			} else {
-				NthElement((ctx->Seed[i].boundary - ctx->Seed[i].usage), &ctx->Seed[i].value);
+				auto advance_count = ctx->Seed[i].boundary - ctx->Seed[i].usage;
+				if (advance_count > 0) {
+					NthElement(advance_count, &ctx->Seed[i].value);
+				}
 #ifdef RNG_TEST
-				ctx->Seed[i].nCalls += ctx->Seed[i].boundary - ctx->Seed[i].usage;
+				ctx->Seed[i].nCalls += advance_count;
 #endif
 			}
 		}
+	}
 	return;
 }
 

--- a/extension/tpch/dbgen/text.cpp
+++ b/extension/tpch/dbgen/text.cpp
@@ -429,13 +429,18 @@ void free_text_pool() {
  *		produce ELIZA-like text of random, bounded length, truncating the last
  *		generated sentence as required
  */
-void dbg_text(char *tgt, int min, int max, seed_t *seed) {
-	DSS_HUGE hgLength = 0, hgOffset, wordlen = 0, s_len, needed;
-	char sentence[MAX_SENT_LEN + 1], *cp;
-
+int dbg_text_source(int min, int max, seed_t *seed, const char **source) {
+	DSS_HUGE hgLength = 0, hgOffset;
 	RANDOM(hgOffset, 0, txtBufferSize - max, seed);
 	RANDOM(hgLength, min, max, seed);
-	strncpy(&tgt[0], &szTextPool[hgOffset], (int)hgLength);
+	*source = &szTextPool[hgOffset];
+	return (int)hgLength;
+}
+
+void dbg_text(char *tgt, int min, int max, seed_t *seed) {
+	const char *source;
+	auto hgLength = dbg_text_source(min, max, seed, &source);
+	memcpy(&tgt[0], source, (size_t)hgLength);
 	tgt[hgLength] = '\0';
 
 	return;

--- a/extension/tpch/dbgen/text.cpp
+++ b/extension/tpch/dbgen/text.cpp
@@ -433,6 +433,7 @@ int dbg_text_source(int min, int max, seed_t *seed, const char **source) {
 	DSS_HUGE hgLength = 0, hgOffset;
 	RANDOM(hgOffset, 0, txtBufferSize - max, seed);
 	RANDOM(hgLength, min, max, seed);
+	/* source points into szTextPool and remains valid until free_text_pool() */
 	*source = &szTextPool[hgOffset];
 	return (int)hgLength;
 }

--- a/extension/tpch/tpch_extension.cpp
+++ b/extension/tpch/tpch_extension.cpp
@@ -8,6 +8,9 @@
 #include "dbgen/dbgen.hpp"
 #include "tpch_extension.hpp"
 
+#include <atomic>
+#include <mutex>
+
 namespace duckdb {
 
 struct DBGenFunctionData : public TableFunctionData {
@@ -25,7 +28,8 @@ struct DBGenFunctionData : public TableFunctionData {
 
 struct DBGenGlobalState : public GlobalTableFunctionState {
 	bool schema_created = false;
-	bool finished = false;
+	atomic<bool> finished {false};
+	mutable mutex generator_lock;
 	unique_ptr<tpch::DBGenGenerator> generator;
 };
 
@@ -94,19 +98,28 @@ unique_ptr<GlobalTableFunctionState> DbgenInit(ClientContext &context, TableFunc
 static void DbgenFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
 	auto &data = data_p.bind_data->Cast<DBGenFunctionData>();
 	auto &state = data_p.global_state->Cast<DBGenGlobalState>();
-	if (state.finished) {
+	if (state.finished.load()) {
 		data_p.async_result = AsyncResultType::FINISHED;
 		return;
 	}
 	if (!state.schema_created) {
 		tpch::DBGenWrapper::CreateTPCHSchema(context, data.catalog, data.schema, data.suffix);
-		state.generator = tpch::CreateDBGenGenerator(context, data.sf, data.catalog, data.schema, data.suffix,
-		                                             data.children, data.step);
+		auto generator = tpch::CreateDBGenGenerator(context, data.sf, data.catalog, data.schema, data.suffix,
+		                                            data.children, data.step);
+		{
+			lock_guard<mutex> guard(state.generator_lock);
+			state.generator = std::move(generator);
+		}
 		state.schema_created = true;
 	}
 
-	if (!state.generator || state.generator->GenerateNext()) {
-		state.finished = true;
+	bool finished = false;
+	{
+		lock_guard<mutex> guard(state.generator_lock);
+		finished = !state.generator || state.generator->GenerateNext();
+	}
+	if (finished) {
+		state.finished.store(true);
 		data_p.async_result = AsyncResultType::FINISHED;
 		return;
 	}
@@ -123,10 +136,13 @@ static double DbgenProgress(ClientContext &context, const FunctionData *bind_dat
 		return 0.0;
 	}
 	auto &state = global_state->Cast<DBGenGlobalState>();
-	if (state.generator) {
-		return state.generator->Progress();
+	{
+		lock_guard<mutex> guard(state.generator_lock);
+		if (state.generator) {
+			return state.generator->Progress();
+		}
 	}
-	return state.finished ? 100.0 : 0.0;
+	return state.finished.load() ? 100.0 : 0.0;
 }
 
 struct TPCHData : public GlobalTableFunctionState {

--- a/extension/tpch/tpch_extension.cpp
+++ b/extension/tpch/tpch_extension.cpp
@@ -14,7 +14,6 @@ struct DBGenFunctionData : public TableFunctionData {
 	DBGenFunctionData() {
 	}
 
-	bool finished = false;
 	double sf = 0;
 	Identifier catalog = INVALID_CATALOG;
 	Identifier schema = DEFAULT_SCHEMA;
@@ -23,6 +22,24 @@ struct DBGenFunctionData : public TableFunctionData {
 	uint32_t children = 1;
 	int step = -1;
 };
+
+struct DBGenGlobalState : public GlobalTableFunctionState {
+	bool schema_created = false;
+	bool finished = false;
+	unique_ptr<tpch::DBGenGenerator> generator;
+};
+
+class DBGenYieldTask : public AsyncTask {
+public:
+	void Execute() override {
+	}
+};
+
+static AsyncResult DBGenYield() {
+	vector<unique_ptr<AsyncTask>> tasks;
+	tasks.push_back(make_uniq<DBGenYieldTask>());
+	return AsyncResult(std::move(tasks));
+}
 
 static unique_ptr<FunctionData> DbgenBind(ClientContext &context, TableFunctionBindInput &input,
                                           vector<LogicalType> &return_types, vector<string> &names) {
@@ -70,16 +87,46 @@ static unique_ptr<FunctionData> DbgenBind(ClientContext &context, TableFunctionB
 	return std::move(result);
 }
 
+unique_ptr<GlobalTableFunctionState> DbgenInit(ClientContext &context, TableFunctionInitInput &input) {
+	return make_uniq<DBGenGlobalState>();
+}
+
 static void DbgenFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
-	auto &data = data_p.bind_data->CastNoConst<DBGenFunctionData>();
-	if (data.finished) {
+	auto &data = data_p.bind_data->Cast<DBGenFunctionData>();
+	auto &state = data_p.global_state->Cast<DBGenGlobalState>();
+	if (state.finished) {
+		data_p.async_result = AsyncResultType::FINISHED;
 		return;
 	}
-	tpch::DBGenWrapper::CreateTPCHSchema(context, data.catalog, data.schema, data.suffix);
-	tpch::DBGenWrapper::LoadTPCHData(context, data.sf, data.catalog, data.schema, data.suffix, data.children,
-	                                 data.step);
+	if (!state.schema_created) {
+		tpch::DBGenWrapper::CreateTPCHSchema(context, data.catalog, data.schema, data.suffix);
+		state.generator = tpch::CreateDBGenGenerator(context, data.sf, data.catalog, data.schema, data.suffix,
+		                                             data.children, data.step);
+		state.schema_created = true;
+	}
 
-	data.finished = true;
+	if (!state.generator || state.generator->GenerateNext()) {
+		state.finished = true;
+		data_p.async_result = AsyncResultType::FINISHED;
+		return;
+	}
+	if (data_p.results_execution_mode == AsyncResultsExecutionMode::TASK_EXECUTOR) {
+		data_p.async_result = DBGenYield();
+	} else {
+		data_p.async_result = AsyncResultType::HAVE_MORE_OUTPUT;
+	}
+}
+
+static double DbgenProgress(ClientContext &context, const FunctionData *bind_data,
+                            const GlobalTableFunctionState *global_state) {
+	if (!global_state) {
+		return 0.0;
+	}
+	auto &state = global_state->Cast<DBGenGlobalState>();
+	if (state.generator) {
+		return state.generator->Progress();
+	}
+	return state.finished ? 100.0 : 0.0;
 }
 
 struct TPCHData : public GlobalTableFunctionState {
@@ -177,7 +224,7 @@ static string PragmaTpchQuery(ClientContext &context, const FunctionParameters &
 }
 
 static void LoadInternal(ExtensionLoader &loader) {
-	TableFunction dbgen_func("dbgen", {}, DbgenFunction, DbgenBind);
+	TableFunction dbgen_func("dbgen", {}, DbgenFunction, DbgenBind, DbgenInit);
 	dbgen_func.named_parameters["sf"] = LogicalType::DOUBLE;
 	dbgen_func.named_parameters["overwrite"] = LogicalType::BOOLEAN;
 	dbgen_func.named_parameters["catalog"] = LogicalType::VARCHAR;
@@ -186,6 +233,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	dbgen_func.named_parameters["children"] = LogicalType::UINTEGER;
 	dbgen_func.named_parameters["step"] = LogicalType::UINTEGER;
 	dbgen_func.call_return_type = StatementReturnType::NOTHING;
+	dbgen_func.table_scan_progress = DbgenProgress;
 	loader.RegisterFunction(dbgen_func);
 
 	// create the TPCH pragma that allows us to run the query

--- a/extension/tpch/tpch_extension.cpp
+++ b/extension/tpch/tpch_extension.cpp
@@ -113,20 +113,21 @@ static void DbgenFunction(ClientContext &context, TableFunctionInput &data_p, Da
 		state.schema_created = true;
 	}
 
-	bool finished = false;
-	{
-		lock_guard<mutex> guard(state.generator_lock);
-		finished = !state.generator || state.generator->GenerateNext();
-	}
-	if (finished) {
-		state.finished.store(true);
-		data_p.async_result = AsyncResultType::FINISHED;
-		return;
-	}
-	if (data_p.results_execution_mode == AsyncResultsExecutionMode::TASK_EXECUTOR) {
-		data_p.async_result = DBGenYield();
-	} else {
-		data_p.async_result = AsyncResultType::HAVE_MORE_OUTPUT;
+	while (true) {
+		bool finished = false;
+		{
+			lock_guard<mutex> guard(state.generator_lock);
+			finished = !state.generator || state.generator->GenerateNext();
+		}
+		if (finished) {
+			state.finished.store(true);
+			data_p.async_result = AsyncResultType::FINISHED;
+			return;
+		}
+		if (data_p.results_execution_mode == AsyncResultsExecutionMode::TASK_EXECUTOR) {
+			data_p.async_result = DBGenYield();
+			return;
+		}
 	}
 }
 

--- a/scripts/ci/test_run_tests.py
+++ b/scripts/ci/test_run_tests.py
@@ -1346,10 +1346,10 @@ Run with -? for options
 -------------------------------------------------------------------------------
 Test Progress Bar Fast
 -------------------------------------------------------------------------------
-{progress_bar_path}:91
+{progress_bar_path}:102
 ...............................................................................
 
-{progress_bar_path}:73: FAILED:
+{progress_bar_path}:84: FAILED:
   REQUIRE( cur_rows_read == total_cardinality )
 with expansion:
   20000 (0x4e20) == 100020002 (0x5f62f22)
@@ -1369,13 +1369,13 @@ assertions: 359 | 358 passed | 1 failed
             [
                 "error: FAIL Test Progress Bar Fast",
                 "",
-                '    70          if (std::getenv("FORCE_ASYNC_SINK_SOURCE") != nullptr) {',
-                "    71              return;",
-                "    72          }",
-                "  > 73          error.SetError([cur_rows_read, total_cardinality]() { REQUIRE(cur_rows_read == total_cardinality); });",
-                "    74      }",
-                "    75  }",
-                "    76  void Start() {",
+                '    81          if (std::getenv("FORCE_ASYNC_SINK_SOURCE") != nullptr) {',
+                "    82              return;",
+                "    83          }",
+                "  > 84          error.SetError([cur_rows_read, total_cardinality]() { REQUIRE(cur_rows_read == total_cardinality); });",
+                "    85      }",
+                "    86  }",
+                "    87  void Start() {",
                 "",
                 "FAILED: REQUIRE( cur_rows_read == total_cardinality )",
                 "  with expansion:",
@@ -1398,10 +1398,10 @@ Run with -? for options
 -------------------------------------------------------------------------------
 Test Progress Bar Fast
 -------------------------------------------------------------------------------
-{progress_bar_path}(91)
+{progress_bar_path}(102)
 ...............................................................................
 
-{progress_bar_path}(73): FAILED:
+{progress_bar_path}(84): FAILED:
   REQUIRE( cur_rows_read == total_cardinality )
 with expansion:
   20000 (0x4e20) == 100020002 (0x5f62f22)
@@ -1421,13 +1421,13 @@ assertions: 359 | 358 passed | 1 failed
             [
                 "error: FAIL Test Progress Bar Fast",
                 "",
-                '    70          if (std::getenv("FORCE_ASYNC_SINK_SOURCE") != nullptr) {',
-                "    71              return;",
-                "    72          }",
-                "  > 73          error.SetError([cur_rows_read, total_cardinality]() { REQUIRE(cur_rows_read == total_cardinality); });",
-                "    74      }",
-                "    75  }",
-                "    76  void Start() {",
+                '    81          if (std::getenv("FORCE_ASYNC_SINK_SOURCE") != nullptr) {',
+                "    82              return;",
+                "    83          }",
+                "  > 84          error.SetError([cur_rows_read, total_cardinality]() { REQUIRE(cur_rows_read == total_cardinality); });",
+                "    85      }",
+                "    86  }",
+                "    87  void Start() {",
                 "",
                 "FAILED: REQUIRE( cur_rows_read == total_cardinality )",
                 "  with expansion:",

--- a/src/common/progress_bar/terminal_progress_bar_display.cpp
+++ b/src/common/progress_bar/terminal_progress_bar_display.cpp
@@ -2,6 +2,8 @@
 #include "duckdb/common/printer.hpp"
 #include "duckdb/common/to_string.hpp"
 
+#include <cmath>
+
 namespace duckdb {
 
 int32_t TerminalProgressBarDisplay::NormalizePercentage(double percentage) {
@@ -31,8 +33,8 @@ string TerminalProgressBarDisplay::FormatETA(double seconds, bool elapsed) {
 		return string(RENDER_SIZE, ' ');
 	}
 
-	// Round to nearest centisecond as integer. The ETA is non-negative here.
-	auto total_centiseconds = static_cast<uint64_t>(seconds * 100.0 + 0.5);
+	// Round to nearest centisecond as integer.
+	auto total_centiseconds = static_cast<uint64_t>(std::llround(seconds * 100.0));
 
 	// Split into seconds and centiseconds
 	uint64_t total_seconds = total_centiseconds / 100;

--- a/src/common/progress_bar/terminal_progress_bar_display.cpp
+++ b/src/common/progress_bar/terminal_progress_bar_display.cpp
@@ -106,11 +106,13 @@ double TerminalProgressBarDisplay::EstimateRemainingSeconds(double percentage, d
 	if (percentage >= 100) {
 		return 0.0;
 	}
+	// The elapsed/progress estimate is stable even when progress updates are sparse.
 	auto cumulative_estimate = elapsed_seconds * ((100.0 - percentage) / percentage);
 	if (observed_progress_per_second <= 0) {
 		return cumulative_estimate;
 	}
 	auto observed_estimate = (100.0 - percentage) / observed_progress_per_second;
+	// Short-window rates can be noisy, so only let them correct the cumulative baseline within a bounded range.
 	auto minimum_estimate = cumulative_estimate * 0.5;
 	auto maximum_estimate = cumulative_estimate * 2.0;
 	return MaxValue<double>(minimum_estimate, MinValue<double>(maximum_estimate, observed_estimate));
@@ -158,6 +160,7 @@ double TerminalProgressBarDisplay::UpdateEstimatedRemainingSeconds(double percen
 	}
 	auto cumulative_estimate = EstimateRemainingSeconds(percentage, elapsed_seconds);
 	if (!has_eta_sample || percentage < last_eta_percentage || elapsed_seconds <= last_eta_update_time) {
+		// Progress may restart or move backwards when the display is reused for another operation.
 		has_eta_sample = true;
 		last_eta_percentage = percentage;
 		last_eta_sample_time = elapsed_seconds;
@@ -182,12 +185,14 @@ double TerminalProgressBarDisplay::UpdateEstimatedRemainingSeconds(double percen
 	}
 	auto candidate_remaining = EstimateRemainingSeconds(percentage, elapsed_seconds, smoothed_progress_per_second);
 	auto candidate_completion_time = elapsed_seconds + candidate_remaining;
+	// Smooth the completion time, not the remaining time, so the ETA naturally ticks down between samples.
 	if (candidate_completion_time < estimated_completion_time) {
 		static constexpr double ETA_DEADLINE_SMOOTHING_FACTOR = 0.3;
 		estimated_completion_time = ETA_DEADLINE_SMOOTHING_FACTOR * candidate_completion_time +
 		                            (1.0 - ETA_DEADLINE_SMOOTHING_FACTOR) * estimated_completion_time;
 	} else {
 		auto elapsed_delta = elapsed_seconds - last_eta_update_time;
+		// Avoid large upward ETA jumps; let a later estimate move out at most at wall-clock speed.
 		estimated_completion_time =
 		    MinValue<double>(candidate_completion_time, estimated_completion_time + elapsed_delta);
 	}

--- a/src/common/progress_bar/terminal_progress_bar_display.cpp
+++ b/src/common/progress_bar/terminal_progress_bar_display.cpp
@@ -31,8 +31,8 @@ string TerminalProgressBarDisplay::FormatETA(double seconds, bool elapsed) {
 		return string(RENDER_SIZE, ' ');
 	}
 
-	// Round to nearest centisecond as integer
-	auto total_centiseconds = static_cast<uint64_t>(std::llround(seconds * 100.0));
+	// Round to nearest centisecond as integer. The ETA is non-negative here.
+	auto total_centiseconds = static_cast<uint64_t>(seconds * 100.0 + 0.5);
 
 	// Split into seconds and centiseconds
 	uint64_t total_seconds = total_centiseconds / 100;

--- a/src/common/progress_bar/terminal_progress_bar_display.cpp
+++ b/src/common/progress_bar/terminal_progress_bar_display.cpp
@@ -98,6 +98,24 @@ string TerminalProgressBarDisplay::FormatProgressBar(const ProgressBarDisplayInf
 	return result;
 }
 
+double TerminalProgressBarDisplay::EstimateRemainingSeconds(double percentage, double elapsed_seconds,
+                                                            double observed_progress_per_second) {
+	if (percentage <= 0 || elapsed_seconds <= 0) {
+		return 2147483647.0;
+	}
+	if (percentage >= 100) {
+		return 0.0;
+	}
+	auto cumulative_estimate = elapsed_seconds * ((100.0 - percentage) / percentage);
+	if (observed_progress_per_second <= 0) {
+		return cumulative_estimate;
+	}
+	auto observed_estimate = (100.0 - percentage) / observed_progress_per_second;
+	auto minimum_estimate = cumulative_estimate * 0.5;
+	auto maximum_estimate = cumulative_estimate * 2.0;
+	return MaxValue<double>(minimum_estimate, MinValue<double>(maximum_estimate, observed_estimate));
+}
+
 void TerminalProgressBarDisplay::PrintProgressInternal(int32_t percentage, double seconds, bool finished) {
 	string result;
 
@@ -121,21 +139,8 @@ void TerminalProgressBarDisplay::PrintProgressInternal(int32_t percentage, doubl
 void TerminalProgressBarDisplay::Update(double percentage) {
 	const double current_time = GetElapsedDuration();
 
-	// Filters go from 0 to 1, percentage is from 0-100
-	const double filter_percentage = percentage / 100.0;
-
-	ukf.Update(filter_percentage, current_time);
-
-	double estimated_seconds_remaining;
-	//  If the query is mostly completed, there can be oscillation of estimated
-	//  time to completion since the progress updates seem sparse near the very
-	//  end of the query, so clamp time remaining to not oscillate with estimates
-	//  that are unlikely to be correct.
-	if (filter_percentage > 0.99) {
-		estimated_seconds_remaining = 0.5;
-	} else {
-		estimated_seconds_remaining = std::min(ukf.GetEstimatedRemainingSeconds(), 2147483647.0);
-	}
+	auto estimated_seconds_remaining =
+	    std::min(UpdateEstimatedRemainingSeconds(percentage, current_time), 2147483647.0);
 	auto percentage_int = NormalizePercentage(percentage);
 
 	TerminalProgressBarDisplayedProgressInfo updated_progress_info = {(idx_t)percentage_int,
@@ -145,6 +150,49 @@ void TerminalProgressBarDisplay::Update(double percentage) {
 		Printer::Flush(OutputStream::STREAM_STDOUT);
 		displayed_progress_info = updated_progress_info;
 	}
+}
+
+double TerminalProgressBarDisplay::UpdateEstimatedRemainingSeconds(double percentage, double elapsed_seconds) {
+	if (percentage <= 0 || elapsed_seconds <= 0 || percentage >= 100) {
+		return EstimateRemainingSeconds(percentage, elapsed_seconds);
+	}
+	auto cumulative_estimate = EstimateRemainingSeconds(percentage, elapsed_seconds);
+	if (!has_eta_sample || percentage < last_eta_percentage || elapsed_seconds <= last_eta_update_time) {
+		has_eta_sample = true;
+		last_eta_percentage = percentage;
+		last_eta_sample_time = elapsed_seconds;
+		last_eta_update_time = elapsed_seconds;
+		smoothed_progress_per_second = 0.0;
+		estimated_completion_time = elapsed_seconds + cumulative_estimate;
+		return cumulative_estimate;
+	}
+	if (percentage > last_eta_percentage) {
+		auto progress_delta = percentage - last_eta_percentage;
+		auto elapsed_delta = elapsed_seconds - last_eta_sample_time;
+		auto observed_progress_per_second = progress_delta / elapsed_delta;
+		static constexpr double ETA_SMOOTHING_FACTOR = 0.3;
+		if (smoothed_progress_per_second <= 0) {
+			smoothed_progress_per_second = observed_progress_per_second;
+		} else {
+			smoothed_progress_per_second = ETA_SMOOTHING_FACTOR * observed_progress_per_second +
+			                               (1.0 - ETA_SMOOTHING_FACTOR) * smoothed_progress_per_second;
+		}
+		last_eta_percentage = percentage;
+		last_eta_sample_time = elapsed_seconds;
+	}
+	auto candidate_remaining = EstimateRemainingSeconds(percentage, elapsed_seconds, smoothed_progress_per_second);
+	auto candidate_completion_time = elapsed_seconds + candidate_remaining;
+	if (candidate_completion_time < estimated_completion_time) {
+		static constexpr double ETA_DEADLINE_SMOOTHING_FACTOR = 0.3;
+		estimated_completion_time = ETA_DEADLINE_SMOOTHING_FACTOR * candidate_completion_time +
+		                            (1.0 - ETA_DEADLINE_SMOOTHING_FACTOR) * estimated_completion_time;
+	} else {
+		auto elapsed_delta = elapsed_seconds - last_eta_update_time;
+		estimated_completion_time =
+		    MinValue<double>(candidate_completion_time, estimated_completion_time + elapsed_delta);
+	}
+	last_eta_update_time = elapsed_seconds;
+	return MaxValue<double>(estimated_completion_time - elapsed_seconds, 0.0);
 }
 
 void TerminalProgressBarDisplay::Finish() {

--- a/src/include/duckdb/common/progress_bar/display/terminal_progress_bar_display.hpp
+++ b/src/include/duckdb/common/progress_bar/display/terminal_progress_bar_display.hpp
@@ -9,9 +9,9 @@
 #pragma once
 
 #include "duckdb/common/constants.hpp"
+#include "duckdb/common/optional_idx.hpp"
 #include "duckdb/common/progress_bar/progress_bar_display.hpp"
 #include "duckdb/common/unicode_bar.hpp"
-#include "duckdb/common/progress_bar/unscented_kalman_filter.hpp"
 #include <chrono>
 
 namespace duckdb {
@@ -63,6 +63,8 @@ public:
 	void Finish() override;
 	static string FormatETA(double seconds, bool elapsed = false);
 	static string FormatProgressBar(const ProgressBarDisplayInfo &display_info, int32_t percentage);
+	static double EstimateRemainingSeconds(double percentage, double elapsed_seconds,
+	                                       double observed_progress_per_second = 0.0);
 
 private:
 	void PeriodicUpdate();
@@ -82,8 +84,16 @@ protected:
 	void StopPeriodicUpdates();
 
 private:
-	UnscentedKalmanFilter ukf;
+	double UpdateEstimatedRemainingSeconds(double percentage, double elapsed_seconds);
+
+private:
 	std::chrono::steady_clock::time_point start_time;
+	bool has_eta_sample = false;
+	double last_eta_percentage = 0.0;
+	double last_eta_sample_time = 0.0;
+	double last_eta_update_time = 0.0;
+	double smoothed_progress_per_second = 0.0;
+	double estimated_completion_time = 0.0;
 
 	// track the progress info that has been previously
 	// displayed to prevent redundant updates

--- a/test/api/test_progress_bar.cpp
+++ b/test/api/test_progress_bar.cpp
@@ -1,6 +1,7 @@
 #ifndef DUCKDB_NO_THREADS
 
 #include "catch.hpp"
+#include "duckdb/common/progress_bar/display/terminal_progress_bar_display.hpp"
 #include "duckdb/common/progress_bar/progress_bar.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "test_helpers.hpp"
@@ -10,6 +11,16 @@
 #include <thread>
 
 using namespace duckdb;
+
+TEST_CASE("Test terminal progress ETA estimate", "[progress-bar]") {
+	REQUIRE(TerminalProgressBarDisplay::EstimateRemainingSeconds(0, 10) == Approx(2147483647.0));
+	REQUIRE(TerminalProgressBarDisplay::EstimateRemainingSeconds(25, 10) == Approx(30));
+	REQUIRE(TerminalProgressBarDisplay::EstimateRemainingSeconds(50, 100) == Approx(100));
+	REQUIRE(TerminalProgressBarDisplay::EstimateRemainingSeconds(100, 10) == Approx(0));
+	REQUIRE(TerminalProgressBarDisplay::EstimateRemainingSeconds(50, 100, 1) == Approx(50));
+	REQUIRE(TerminalProgressBarDisplay::EstimateRemainingSeconds(50, 100, 4) == Approx(50));
+	REQUIRE(TerminalProgressBarDisplay::EstimateRemainingSeconds(50, 100, 0.1) == Approx(200));
+}
 
 class TestProgressBar {
 	class TestFailure {

--- a/test/api/test_tpch_with_streaming.cpp
+++ b/test/api/test_tpch_with_streaming.cpp
@@ -126,3 +126,28 @@ TEST_CASE("Test TPC-H dbgen parallel progress does not finish early", "[tpch][pr
 	REQUIRE(!saw_finished_progress_before_ready);
 	REQUIRE(saw_progress_before_ready);
 }
+
+TEST_CASE("Test TPC-H dbgen rollback after interrupted optimistic write", "[tpch][.]") {
+	auto db_path = TestCreatePath("tpch_dbgen_interrupted_optimistic_write.db");
+	DuckDB db(db_path);
+	Connection con(db);
+	if (!db.ExtensionIsLoaded("tpch")) {
+		return;
+	}
+
+	REQUIRE_NO_FAIL(con.Query("PRAGMA threads=4"));
+	REQUIRE_NO_FAIL(con.Query("SET write_buffer_row_group_count=1"));
+
+	auto pending = con.PendingQuery("CALL dbgen(sf=1, suffix='_interrupted')");
+	auto state = pending->ExecuteTask();
+	REQUIRE(!PendingQueryResult::IsResultReady(state));
+
+	con.Interrupt();
+	auto result = pending->Execute();
+	REQUIRE(result->HasError());
+	con.context->ClearInterrupt();
+
+	REQUIRE_NO_FAIL(con.Query("CHECKPOINT"));
+	REQUIRE_NO_FAIL(con.Query("CALL dbgen(sf=0.01, suffix='_after_interrupt')"));
+	REQUIRE_NO_FAIL(con.Query("CHECKPOINT"));
+}

--- a/test/api/test_tpch_with_streaming.cpp
+++ b/test/api/test_tpch_with_streaming.cpp
@@ -1,6 +1,7 @@
 #include "catch.hpp"
 #include "test_helpers.hpp"
 #include "tpch_extension.hpp"
+#include "duckdb/main/pending_query_result.hpp"
 
 #include <chrono>
 #include <iostream>
@@ -35,4 +36,93 @@ TEST_CASE("Test TPC-H SF0.01 using streaming api", "[tpch][.]") {
 
 		COMPARE_CSV_COLLECTION(collection, TpchExtension::GetAnswer(sf, tpch_num), true);
 	}
+}
+
+TEST_CASE("Test TPC-H dbgen progress", "[tpch][progress-bar][.]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	if (!db.ExtensionIsLoaded("tpch")) {
+		return;
+	}
+
+	REQUIRE_NO_FAIL(con.Query("PRAGMA threads=1"));
+	REQUIRE_NO_FAIL(con.Query("PRAGMA progress_bar_time=1"));
+	REQUIRE_NO_FAIL(con.Query("PRAGMA disable_print_progress_bar"));
+
+	auto pending = con.PendingQuery("CALL dbgen(sf=0.01, suffix='_progress')");
+	double previous_percentage = -1;
+	bool saw_intermediate_progress = false;
+	bool saw_progress_before_ready = false;
+
+	while (true) {
+		auto state = pending->ExecuteTask();
+		auto result_ready = PendingQueryResult::IsResultReady(state);
+		auto query_progress = con.context->GetQueryProgress();
+		auto percentage = query_progress.GetPercentage();
+		if (percentage >= 0) {
+			REQUIRE(percentage >= previous_percentage);
+			REQUIRE(percentage <= 100);
+			previous_percentage = percentage;
+			if (percentage > 0 && percentage < 100) {
+				saw_intermediate_progress = true;
+			}
+			if (!result_ready) {
+				REQUIRE(percentage < 100);
+			}
+			if (!result_ready && percentage > 0) {
+				saw_progress_before_ready = true;
+			}
+		}
+		if (result_ready) {
+			break;
+		}
+		if (state == PendingExecutionResult::BLOCKED) {
+			pending->WaitForTask();
+		}
+	}
+
+	auto result = pending->Execute();
+	REQUIRE_NO_FAIL(*result);
+	REQUIRE(saw_intermediate_progress);
+	REQUIRE(saw_progress_before_ready);
+}
+
+TEST_CASE("Test TPC-H dbgen parallel progress does not finish early", "[tpch][progress-bar][.]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	if (!db.ExtensionIsLoaded("tpch")) {
+		return;
+	}
+
+	REQUIRE_NO_FAIL(con.Query("PRAGMA threads=2"));
+	REQUIRE_NO_FAIL(con.Query("PRAGMA progress_bar_time=1"));
+	REQUIRE_NO_FAIL(con.Query("PRAGMA disable_print_progress_bar"));
+
+	auto pending = con.PendingQuery("CALL dbgen(sf=0.01, suffix='_progress_parallel')");
+	bool saw_progress_before_ready = false;
+	bool saw_finished_progress_before_ready = false;
+
+	while (true) {
+		auto state = pending->ExecuteTask();
+		auto result_ready = PendingQueryResult::IsResultReady(state);
+		auto query_progress = con.context->GetQueryProgress();
+		auto percentage = query_progress.GetPercentage();
+		if (percentage >= 0 && !result_ready) {
+			if (percentage >= 100) {
+				saw_finished_progress_before_ready = true;
+			}
+			saw_progress_before_ready = true;
+		}
+		if (result_ready) {
+			break;
+		}
+		if (state == PendingExecutionResult::BLOCKED) {
+			pending->WaitForTask();
+		}
+	}
+
+	auto result = pending->Execute();
+	REQUIRE_NO_FAIL(*result);
+	REQUIRE(!saw_finished_progress_before_ready);
+	REQUIRE(saw_progress_before_ready);
 }


### PR DESCRIPTION
This PR hooks `CALL dbgen(...)` into the progress bar and ETA infrastructure and makes execution substantially faster, especially for larger scale factors and persistent databases.

Previously, TPC-H generation could run for a long time without meaningful progress feedback. DuckDB already has CLI progress bar support, but the TPC-H dbgen path did not use it. This PR wires dbgen into the progress system and tracks both generated work and flushed work, so the progress bar keeps moving through the storage phase instead of jumping from partial progress to done.

----

While working on progress reporting, the ETA behavior also needed attention. The previous terminal ETA used the Kalman estimator, which works better for relatively smooth progress signals. TPC-H generation is burstier: parallel workers finish chunks at uneven times, persistent storage introduces flush phases, and progress can arrive in larger steps. That made the ETA overreact to fresh samples and jump around.

This PR replaces the terminal ETA logic with a simpler estimator:
- use elapsed progress as the stable baseline,
- use recent observed progress rate as a correction,
- clamp the correction so short bursts cannot dominate the estimate,
- smooth the predicted completion timestamp,
- let later estimates move outward gradually instead of jumping upward.

The result is less clever, but more predictable: the ETA still adapts when the workload speed changes, but it no longer swings wildly on each progress update. However, I'm not attached to this change, we can also just revert to what we had before.

----

The larger part of the PR rewrites the hot TPC-H dbgen append path. The old implementation generated DBGEN row structs first and then copied those values into DuckDB vectors. That added extra row materialization, extra string handling, and avoidable date formatting/parsing work.

The new path generates directly into DuckDB chunks. In particular, it:

- writes TPC-H date offsets directly as DuckDB dates,
- avoids intermediate `order_t`, `line_t`, `part_t`, etc. append structs,
- avoids repeated distribution string length calculation,
- references stable DBGEN distribution/text-pool strings directly where safe,
- keeps writable vector-owned string storage only for values that DBGEN may mutate,
- tunes parallel generation granularity,
- flushes persistent append state earlier to keep memory use bounded.

The end result is a large runtime improvement:

| Mode       |          Query |   Before  |  After  | Speedup |
|------------|----------------|-----------|---------|---------|
|  In-memory |  dbgen(sf=1)   |  1.249s   |  0.259s |    4.8x |
|  In-memory | dbgen(sf=10)   | 12.818s   |  1.274s |   10.1x |
| Persistent | dbgen(sf=10)   | 46.752s   |  4.159s |   11.2x |

SF 1000 with a memory limit of 20GB now runs in about 470 seconds. I was not willing to wait for the old implementation to finish, but it would have been much longer.

The main practical win of the lower-level rewrite: less intermediate work, fewer copies, less string/date conversion overhead, and much less pressure on the storage append path.
