### PR TITLE
Fix ROW_NUMBER() OVER () over read_duckdb returning file-local row numbers

### DIFF
--- a/src/optimizer/row_number_rewriter.cpp
+++ b/src/optimizer/row_number_rewriter.cpp
@@ -37,6 +37,15 @@ bool RowNumberRewriter::CanOptimize(LogicalOperator &op) {
 		return false;
 	}
 
+	// only rewrite for a base-table scan: its virtual row_number column has SQL
+	// window semantics (dense, over the visible rows of this scan). Table
+	// functions such as read_duckdb also expose a row_number virtual column, but
+	// with different (e.g. file-local) semantics, so mapping ROW_NUMBER() OVER ()
+	// onto it would return the wrong values (issue #23586).
+	if (!get.GetTable()) {
+		return false;
+	}
+
 	// cannot rewrite if there are table filters pushed into the scan
 	// the virtual row_number column counts absolute row positions in storage,
 	// which does not match row_number() over() when rows are filtered out

--- a/test/optimizer/row_number_virtual_column.test
+++ b/test/optimizer/row_number_virtual_column.test
@@ -218,3 +218,28 @@ query II
 EXPLAIN SELECT row_number + 1 FROM (SELECT row_number() OVER () AS row_number FROM tbl);
 ----
 physical_plan	<!REGEX>:.*WINDOW.*
+
+# read_duckdb also exposes a row_number virtual column, but with file-local
+# semantics rather than SQL window semantics, so the rewrite must not fire for
+# it: ROW_NUMBER() OVER () must still be computed and return 1-based values, not
+# the scan's 0-based file-local row number. See issue #23586.
+statement ok
+ATTACH '{TEST_DIR}/row_number_read_duckdb.db' AS rd
+
+statement ok
+CREATE TABLE rd.t AS SELECT * FROM (VALUES (10), (20)) v(x)
+
+statement ok
+DETACH rd
+
+query II
+SELECT x, ROW_NUMBER() OVER () AS rn FROM read_duckdb('{TEST_DIR}/row_number_read_duckdb.db', table_name='t') ORDER BY x
+----
+10	1
+20	2
+
+# the window must be kept (not eliminated) for a table function scan
+query II
+EXPLAIN SELECT x, ROW_NUMBER() OVER () FROM read_duckdb('{TEST_DIR}/row_number_read_duckdb.db', table_name='t')
+----
+physical_plan	<REGEX>:.*WINDOW.*


### PR DESCRIPTION
Fixes #23586.

The `RowNumberRewriter` rewrites a bare `ROW_NUMBER() OVER ()` by mapping it onto the child `LogicalGet`'s virtual `row_number` column. That column only has SQL window semantics — dense and 1-based over the visible rows of the scan — for **base-table scans** (backed by `RowNumberColumnData`).

Table functions such as `read_duckdb` also expose a `row_number` virtual column, but with file-local semantics. So `ROW_NUMBER() OVER ()` over `read_duckdb(...)` returned the scan's 0-based file-local numbers (`0, 1`) instead of `1, 2`. (`SET disabled_optimizers='window_rewriter'` avoided it, confirming the rewriter as the cause.)

This restricts the rewrite to base-table scans via `LogicalGet::GetTable()` (non-null only for a real catalog table); table-function scans keep the window operator and compute correct SQL row numbers.

Verified the base-table rewrite still fires (existing `test/optimizer/row_number_virtual_column.test` cases pass) and added a `read_duckdb` case asserting the correct `1, 2` result and that the window is retained. The `read_duckdb` and full `optimizer` test groups pass with no regressions.



The separate case of a `read_duckdb` scan that projects no real columns (e.g. bare `SELECT ROW_NUMBER() OVER ()`), which trips an assertion in assert-enabled builds, is tracked in #23670.
