### PR TITLE
Support partial MIN/MAX precompute when some partitions lack exact stats

### DIFF
--- a/src/optimizer/statistics/operator/propagate_aggregate.cpp
+++ b/src/optimizer/statistics/operator/propagate_aggregate.cpp
@@ -222,7 +222,8 @@ void StatisticsPropagator::TryExecuteAggregates(LogicalAggregate &aggr, unique_p
 	vector<unique_ptr<Expression>> agg_results;
 	bool need_to_scan = false;
 	vector<idx_t> scan_partition_indices;
-	// we can keep execute eager aggregate if all partitions could be either filtered entirely or remained entirely
+	// With a WHERE clause, classify each partition using manifest bounds on filtered columns:
+	// drop partitions proven empty, precompute on partitions proven fully included, scan the rest.
 	if (get.table_filters.HasFilters()) {
 		map<StorageIndex, reference<TableFilter>> filter_storage_index_map;
 		for (auto &entry : get.table_filters) {
@@ -282,6 +283,35 @@ void StatisticsPropagator::TryExecuteAggregates(LogicalAggregate &aggr, unique_p
 			return;
 		}
 		partition_stats = std::move(precomputed_partition_stats);
+	}
+
+	// Without filters, split partitions by whether every MIN/MAX column has exact stats on that file.
+	// Files missing bounds for an aggregated column are scanned and merged via COALESCE below.
+	if (!min_max_bindings.empty() && !get.table_filters.HasFilters()) {
+		vector<PartitionStatistics> precomputed;
+		for (idx_t partition_idx = 0; partition_idx < partition_stats.size(); partition_idx++) {
+			auto &stats = partition_stats[partition_idx];
+			bool can_precompute = true;
+			for (idx_t agg_idx = 0; agg_idx < min_max_storage_indexes.size(); agg_idx++) {
+				Value dummy;
+				if (!TryGetValueFromStats(stats, min_max_storage_indexes[agg_idx], *comparators[agg_idx], dummy)) {
+					can_precompute = false;
+					break;
+				}
+			}
+			if (can_precompute) {
+				precomputed.push_back(stats);
+			} else {
+				need_to_scan = true;
+				scan_partition_indices.push_back(partition_idx);
+			}
+		}
+		if (need_to_scan) {
+			if (precomputed.empty()) {
+				return;
+			}
+			partition_stats = std::move(precomputed);
+		}
 	}
 
 	if (!min_max_bindings.empty()) {
@@ -353,6 +383,7 @@ void StatisticsPropagator::TryExecuteAggregates(LogicalAggregate &aggr, unique_p
 			} else if (fun_name == "min" || fun_name == "max") {
 				// For min: COALESCE(least(pre_min, agg_min), pre_min)
 				// For max: COALESCE(greatest(pre_max, agg_max), pre_max)
+				// COALESCE handles scanned partitions where agg_* is NULL (e.g. all-null column in that file).
 				auto &pre_val_expr = agg_results[i];
 				Identifier merge_func((fun_name == "min") ? "least" : "greatest");
 				auto merged = optimizer.BindScalarFunction(merge_func, pre_val_expr->Copy(), std::move(agg_col_ref));

--- a/test/optimizer/partial_aggregate_precomputation.test
+++ b/test/optimizer/partial_aggregate_precomputation.test
@@ -130,3 +130,79 @@ query II
 EXPLAIN SELECT count(*), min(i), max(i) FROM t WHERE i >= 2048 AND j > 5000 GROUP BY i % 10
 ----
 physical_plan	<REGEX>:.*HASH_GROUP_BY.*
+
+# Bare aggregate partition split: some row groups lack min/max stats for a column (all-null).
+statement ok
+ATTACH '{TEST_DIR}/partial_agg_sparse.duckdb' AS sparse (ROW_GROUP_SIZE 2048)
+
+statement ok
+USE sparse
+
+statement ok
+CREATE TABLE t_sparse AS SELECT i, CASE WHEN i < 4096 THEN NULL::BIGINT ELSE i * 2 END AS j FROM range(8192) _(i)
+
+statement ok
+ATTACH '{TEST_DIR}/tmp_partial_sparse.duckdb' AS tmp_sparse
+
+statement ok
+USE tmp_sparse
+
+statement ok
+DETACH sparse
+
+statement ok
+ATTACH '{TEST_DIR}/partial_agg_sparse.duckdb' AS sparse (ROW_GROUP_SIZE 2048)
+
+statement ok
+USE sparse
+
+statement ok
+DETACH tmp_sparse
+
+# Columns with stats on every row group still fully fold without a scan.
+query II
+EXPLAIN SELECT max(i) FROM t_sparse
+----
+physical_plan	<REGEX>:.*COLUMN_DATA_SCAN.*
+
+# Partial split without filters: COALESCE merges manifest-precomputed extrema with a subset scan.
+query II
+EXPLAIN SELECT max(j) FROM t_sparse
+----
+physical_plan	<REGEX>:.*COALESCE.*greatest.*UNGROUPED_AGGREGATE.*
+
+query II
+EXPLAIN SELECT min(j) FROM t_sparse
+----
+physical_plan	<REGEX>:.*COALESCE.*least.*UNGROUPED_AGGREGATE.*
+
+query I
+SELECT max(j) FROM t_sparse
+----
+16382
+
+query I
+SELECT min(j) FROM t_sparse
+----
+8192
+
+query II
+EXPLAIN ANALYZE SELECT max(j) FROM t_sparse
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 2 / 4.*
+
+statement ok
+SET disabled_optimizers='statistics_propagation'
+
+query I
+SELECT max(j) FROM t_sparse
+----
+16382
+
+query I
+SELECT min(j) FROM t_sparse
+----
+8192
+
+statement ok
+RESET disabled_optimizers


### PR DESCRIPTION
## Summary
Extend partial MIN/MAX precompute to bare aggregates when some partitions (row groups) lack exact min/max stats. Partitions with usable stats are folded from `get_partition_stats`; the rest are scanned via `set_partitions_to_scan` and merged with `COALESCE`/`least`/`greatest`.

Previously this path only triggered with table filters. Native tables hit it when a column is all-null in some row groups; table functions with per-file partition stats (e.g. Iceberg) are another consumer ([PR for `duckdb-iceberg` ](https://github.com/The-Alchemist/duckdb-iceberg/pull/5)will be ready once this is merged).

## Tests
- Extended `test/optimizer/partial_aggregate_precomputation.test` — bare aggregate partition split (`Row Groups Scanned: 2 / 4`, no `WHERE`)

## Test plan
- [x] `test/optimizer/partial_aggregate_precomputation.test`

## Feedback welcome!

Do we need more tests?

🙇‍♂️ 