### PR TITLE
Honor the comment option when quoting CSV output

### DIFF
--- a/src/common/csv_writer.cpp
+++ b/src/common/csv_writer.cpp
@@ -30,17 +30,28 @@ CSVWriterState::~CSVWriterState() {
 	}
 }
 
-CSVWriterOptions::CSVWriterOptions(const string &delim, const char &quote, const string &write_newline) {
+CSVWriterOptions::CSVWriterOptions(const string &delim, const char &quote, const string &write_newline,
+                                   char comment_char) {
 	requires_quotes = vector<bool>(256, false);
 	requires_quotes['\n'] = true;
 	requires_quotes['\r'] = true;
-	requires_quotes['#'] = true;
+	// quote values containing the comment char so they are not read back as comments (see #17744)
+	if (comment_char != '\0') {
+		requires_quotes[NumericCast<idx_t>(comment_char)] = true;
+	}
 	requires_quotes[NumericCast<idx_t>(delim[0])] = true;
 	requires_quotes[NumericCast<idx_t>(quote)] = true;
 
 	if (!write_newline.empty()) {
 		newline = TransformNewLine(write_newline);
 	}
+}
+
+// The comment char to protect on write. Defaults to '#' when unset, since the sniffer detects '#'
+// comments by default; an explicit comment (including the empty '\0' from `comment ''`) is honored.
+static char GetWriteCommentChar(CSVReaderOptions &options) {
+	auto &comment = options.dialect_options.state_machine_options.comment;
+	return comment.IsSetByUser() ? comment.GetValue() : '#';
 }
 
 CSVWriterOptions::CSVWriterOptions(CSVReaderOptions &options)
@@ -63,9 +74,9 @@ CSVWriter::CSVWriter(WriteStream &stream, vector<string> name_list, bool shared)
 
 CSVWriter::CSVWriter(CSVReaderOptions &options_p, FileSystem &fs, const string &file_path,
                      FileCompressionType compression, QueryContext context, bool shared)
-    : options(options_p),
-      writer_options(options.dialect_options.state_machine_options.delimiter.GetValue(),
-                     options.dialect_options.state_machine_options.quote.GetValue(), options.write_newline),
+    : options(options_p), writer_options(options.dialect_options.state_machine_options.delimiter.GetValue(),
+                                         options.dialect_options.state_machine_options.quote.GetValue(),
+                                         options.write_newline, GetWriteCommentChar(options)),
       file_writer(make_uniq<BufferedFileWriter>(fs, file_path,
                                                 FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE_NEW |
                                                     FileLockType::WRITE_LOCK | compression,

--- a/src/include/duckdb/common/csv_writer.hpp
+++ b/src/include/duckdb/common/csv_writer.hpp
@@ -26,7 +26,7 @@ enum class CSVNewLineMode {
 };
 
 struct CSVWriterOptions {
-	CSVWriterOptions(const string &delim, const char &quote, const string &write_newline);
+	CSVWriterOptions(const string &delim, const char &quote, const string &write_newline, char comment_char = '#');
 	explicit CSVWriterOptions(CSVReaderOptions &options);
 
 	//! The newline string to write

--- a/test/sql/copy/csv/comment_quoting.test
+++ b/test/sql/copy/csv/comment_quoting.test
@@ -1,0 +1,53 @@
+# name: test/sql/copy/csv/comment_quoting.test
+# description: CSV writer quotes the comment character, honoring the comment option (#17744, #20095)
+# group: [csv]
+
+# by default '#' is quoted so the values are not read back as comments (#17744)
+statement ok
+COPY (SELECT 'a#b' AS x, 'p!q' AS y, 'plain' AS z)
+TO '{TEST_DIR}/comment_default.csv' (FORMAT CSV, HEADER false);
+
+query I
+SELECT rtrim(content, chr(10)) FROM read_text('{TEST_DIR}/comment_default.csv');
+----
+"a#b",p!q,plain
+
+# comment '' gives RFC 4180 minimal quoting: '#' is no longer special (#20095)
+statement ok
+COPY (SELECT 'a#b' AS x, 'p!q' AS y, 'plain' AS z)
+TO '{TEST_DIR}/comment_none.csv' (FORMAT CSV, HEADER false, comment '');
+
+query I
+SELECT rtrim(content, chr(10)) FROM read_text('{TEST_DIR}/comment_none.csv');
+----
+a#b,p!q,plain
+
+# an explicit comment character is the one that gets quoted (not a hardcoded '#')
+statement ok
+COPY (SELECT 'a#b' AS x, 'p!q' AS y, 'plain' AS z)
+TO '{TEST_DIR}/comment_bang.csv' (FORMAT CSV, HEADER false, comment '!');
+
+query I
+SELECT rtrim(content, chr(10)) FROM read_text('{TEST_DIR}/comment_bang.csv');
+----
+a#b,"p!q",plain
+
+# delimiter, quote and newline still trigger quoting with comment ''
+statement ok
+COPY (SELECT 'a,b' AS x, 'c"d' AS y)
+TO '{TEST_DIR}/comment_special.csv' (FORMAT CSV, HEADER false, comment '');
+
+query I
+SELECT rtrim(content, chr(10)) FROM read_text('{TEST_DIR}/comment_special.csv');
+----
+"a,b","c""d"
+
+# '#' values written with comment '' are still read back intact
+statement ok
+COPY (SELECT '#hash' AS x, 1 AS y UNION ALL SELECT 'ok', 2 UNION ALL SELECT 'end #', 3)
+TO '{TEST_DIR}/comment_roundtrip.csv' (FORMAT CSV, HEADER 1, comment '');
+
+query I
+SELECT count(*) FROM read_csv('{TEST_DIR}/comment_roundtrip.csv');
+----
+3


### PR DESCRIPTION
The CSV writer unconditionally quoted fields containing '#'. Per my understanding, this was meant to keep '#' values from being read back as comments (the sniffer treats '#' as a default comment candidate), but it was applied regardless of the actual comment option: '#' was quoted even for `comment ''`, `comment '!'` quoted '#' while leaving '!' unquoted, and the output diverged from RFC 4180 minimal quoting.

Thread the comment character into CSVWriterOptions and quote it only when set, defaulting to '#' when the user specifies no comment for backwards compatibility. Default output is unchanged; `comment ''` now produces RFC 4180 minimal quoting and an explicit comment character is the one that gets quoted.