### PR TITLE
Bind default schema path correctly across catalogs

### DIFF
--- a/src/planner/binder/tableref/bind_basetableref.cpp
+++ b/src/planner/binder/tableref/bind_basetableref.cpp
@@ -106,8 +106,9 @@ vector<CatalogSearchEntry> Binder::GetSearchPath(Catalog &catalog, const string 
 	if (!schema_name.empty()) {
 		view_search_path.emplace_back(catalog_name, schema_name);
 	}
+	// always fall back to the default schema of the catalog, unless it was already added above
 	auto default_schema = catalog.GetDefaultSchema();
-	if (schema_name.empty() && schema_name != default_schema) {
+	if (schema_name != default_schema && !default_schema.empty()) {
 		view_search_path.emplace_back(catalog_name, default_schema);
 	}
 	//! Signal that this catalog should be checked, regardless of the schema in the reference

--- a/test/sql/attach/attach_view_search_path.test
+++ b/test/sql/attach/attach_view_search_path.test
@@ -76,3 +76,35 @@ query I
 FROM view_search_path.my_schema.my_view
 ----
 84
+
+# a view in a non-main schema can reference entries in the catalog's main schema
+# with an unqualified name, even when queried from another catalog
+# the view's own schema still takes priority: my_tbl resolves to my_schema.my_tbl (84)
+
+statement ok
+USE view_search_path
+
+statement ok
+CREATE MACRO my_macro(a) AS a + 1
+
+statement ok
+CREATE VIEW my_schema.macro_view AS SELECT my_macro(i) AS t FROM my_tbl
+
+statement ok
+USE view_search_path_other
+
+query I
+FROM view_search_path.my_schema.macro_view
+----
+85
+
+statement ok
+DETACH view_search_path
+
+statement ok
+ATTACH DATABASE '__TEST_DIR__/view_search_path.db' AS view_search_path;
+
+query I
+FROM view_search_path.my_schema.macro_view
+----
+85


### PR DESCRIPTION
Prior to https://github.com/duckdb/duckdb/pull/16059, the search path logic in bind basetableref looked like this:

```
  view_search_path.emplace_back(catalog_name, schema_name);
  if (schema_name != DEFAULT_SCHEMA) {
      view_search_path.emplace_back(catalog_name, DEFAULT_SCHEMA);
  }
  ```
Meaning, we always added the default schema (`main`) to the search path, _if_ it wasn't already added.

This condition was then changed to `schema_name.empty() && schema_name != default_schema`, which inverts the meaning to "only add the default schema when no schema was given". But this silently dropped the `main` fallback for views in named schemas, and was basically dead code as `default_schema` is almost never empty.

This PR changes the condition to `schema_name != default_schema && !default_schema.empty()`, preserving the original "own schema first, then the default (`main`), deduplicated" semantics.

