### PR TITLE
Fix `median` for INTERVAL type

### DIFF
--- a/extension/core_functions/aggregate/holistic/quantile.cpp
+++ b/extension/core_functions/aggregate/holistic/quantile.cpp
@@ -537,6 +537,8 @@ AggregateFunction GetContinuousQuantileTemplated(const LogicalType &type) {
 	case LogicalTypeId::TIME:
 	case LogicalTypeId::TIME_TZ:
 		return OP::template GetFunction<dtime_t, dtime_t>(type, type);
+	case LogicalTypeId::INTERVAL:
+		return OP::template GetFunction<interval_t, interval_t>(type, type);
 	default:
 		throw NotImplementedException("Unimplemented continuous quantile aggregate");
 	}
@@ -669,6 +671,7 @@ static bool CanInterpolate(const LogicalType &type) {
 	case LogicalTypeId::TIMESTAMP_NS:
 	case LogicalTypeId::TIME:
 	case LogicalTypeId::TIME_TZ:
+	case LogicalTypeId::INTERVAL:
 		return true;
 	default:
 		return false;

--- a/test/sql/aggregate/aggregates/test_median.test
+++ b/test/sql/aggregate/aggregates/test_median.test
@@ -154,6 +154,15 @@ FROM (VALUES
 ----
 00:00:00-04:30
 
+query I
+SELECT MEDIAN(x)
+FROM (VALUES
+	(INTERVAL '1 day'),
+	(INTERVAL '10 days')
+) v(x);
+----
+5 days 12:00:00
+
 # Floored
 foreach type varchar
 


### PR DESCRIPTION
Closes https://github.com/duckdb/duckdb/issues/23700

The issue is, when interpolation not supported for certain, we use [discrete quantile](https://github.com/duckdb/duckdb/blob/d5a681ff2dd3035012551d1965bd3052d0c75f52/extension/core_functions/aggregate/holistic/quantile.cpp#L680) instead of continuous quantile; for discrete quantile, when medium functions take two arguments the lower one will be picked.

I confirmed this PR's behavior conforms with postgres (percentile 50%): https://onecompiler.com/postgresql/44ukubcbm
