### PR TITLE
Fix top-n window elimination for inner joins

### DIFF
--- a/src/optimizer/topn_window_elimination.cpp
+++ b/src/optimizer/topn_window_elimination.cpp
@@ -953,8 +953,11 @@ bool TopNWindowElimination::CanUseLateMaterialization(const LogicalWindow &windo
 		}
 		case LogicalOperatorType::LOGICAL_COMPARISON_JOIN: {
 			auto &join = op.get().Cast<LogicalComparisonJoin>();
-			if (join.join_type != JoinType::INNER && join.join_type != JoinType::SEMI &&
-			    join.join_type != JoinType::ANTI) {
+			if (join.join_type == JoinType::INNER) {
+				// An inner join can produce multiple joined rows with the same base-table rowid.
+				return false;
+			}
+			if (join.join_type != JoinType::SEMI && join.join_type != JoinType::ANTI) {
 				return false;
 			}
 

--- a/test/sql/optimizer/topn_window_elimination_late_materialization.test
+++ b/test/sql/optimizer/topn_window_elimination_late_materialization.test
@@ -104,6 +104,33 @@ ORDER BY gp
 5	1	ee
 3	2	cc
 
+# Issue #23588: late materialization through a join must preserve duplicate
+# payload rows that share the same base-table rowid.
+statement ok
+CREATE TABLE l_topn_dup(id INTEGER, k INTEGER, p VARCHAR)
+
+statement ok
+CREATE TABLE r_topn_dup(k INTEGER, s INTEGER)
+
+statement ok
+INSERT INTO l_topn_dup VALUES (1, 1, 'x')
+
+statement ok
+INSERT INTO r_topn_dup VALUES (1, 20), (1, 10)
+
+query II
+SELECT id, p
+FROM (
+	SELECT l_topn_dup.id, l_topn_dup.p, r_topn_dup.s
+	FROM l_topn_dup
+	JOIN r_topn_dup ON l_topn_dup.k = r_topn_dup.k
+) AS src
+QUALIFY ROW_NUMBER() OVER (ORDER BY s DESC NULLS LAST) <= 2
+ORDER BY ALL
+----
+1	x
+1	x
+
 # top-2 (limit > 1) with a function payload
 query II
 SELECT id, uv FROM (SELECT *, upper(v) AS uv FROM t)


### PR DESCRIPTION
Summary:
- Fixes #23588 by avoiding rowid-based late materialization for inner joins in top_n_window_elimination.
- Adds a sqllogictest regression that preserves duplicate projected rows produced by a join.

Validation:
- PATH=/tmp/duckdb-build-tools-venv/bin:$PATH GEN=ninja CMAKE_BUILD_PARALLEL_LEVEL=4 make reldebug — passed
- build/reldebug/test/unittest test/sql/optimizer/topn_window_elimination_late_materialization.test — passed, 97 assertions
- build/reldebug/test/unittest test/sql/optimizer/topn_window_set_elimination.test — passed, 8 assertions
- git diff --check — passed
