### PR TITLE
Fix/lambda interrupt check

### DIFF
--- a/extension/core_functions/lambda_functions.cpp
+++ b/extension/core_functions/lambda_functions.cpp
@@ -314,6 +314,7 @@ static void ExecuteLambda(DataChunk &args, ExpressionState &state, Vector &resul
 		for (idx_t child_idx = 0; child_idx < list_entry.length; child_idx++) {
 			// reached STANDARD_VECTOR_SIZE elements
 			if (elem_cnt == STANDARD_VECTOR_SIZE) {
+				state.GetContext().InterruptCheck();
 				execute_info.lambda_chunk.Reset();
 				ExecuteExpression(elem_cnt, child_info, info.column_infos, index_vector, execute_info);
 				auto &lambda_vector = execute_info.lambda_chunk.data[0];

--- a/extension/core_functions/scalar/list/list_reduce.cpp
+++ b/extension/core_functions/scalar/list/list_reduce.cpp
@@ -1,6 +1,7 @@
 #include "core_functions/scalar/list_functions.hpp"
 
 #include "duckdb/function/lambda_functions.hpp"
+#include "duckdb/main/client_context.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/planner/expression/bound_lambda_expression.hpp"
 

--- a/extension/core_functions/scalar/list/list_reduce.cpp
+++ b/extension/core_functions/scalar/list/list_reduce.cpp
@@ -310,6 +310,7 @@ void LambdaFunctions::ListReduceFunction(DataChunk &args, ExpressionState &state
 	idx_t loops = 0;
 	bool end = false;
 	while (!end) {
+		state.GetContext().InterruptCheck();
 		auto &result_chunk = loops % 2 ? odd_result_chunk : even_result_chunk;
 		auto &spare_result_chunk = loops % 2 ? even_result_chunk : odd_result_chunk;
 

--- a/test/sql/function/list/lambdas/interrupt.test_slow
+++ b/test/sql/function/list/lambdas/interrupt.test_slow
@@ -10,7 +10,7 @@ statement ok
 SET max_execution_time=50
 
 statement error
-SELECT list_transform(list(i), x -> x * 2 + (x % 3))
+SELECT list_transform(list(i), lambda x: x * 2 + (x % 3))
 FROM range(1000000) t(i)
 ----
 Query exceeded maximum execution time
@@ -24,7 +24,7 @@ statement ok
 SET max_execution_time=50
 
 statement error
-SELECT list_filter(list(i), x -> x % 7 <> 0)
+SELECT list_filter(list(i), lambda x: x % 7 <> 0)
 FROM range(1000000) t(i)
 ----
 Query exceeded maximum execution time
@@ -38,7 +38,7 @@ statement ok
 SET max_execution_time=50
 
 statement error
-SELECT list_reduce(list(i), (a, b) -> a + b + (b % 3))
+SELECT list_reduce(list(i), lambda a, b: a + b + (b % 3))
 FROM range(1000000) t(i)
 ----
 Query exceeded maximum execution time
@@ -49,4 +49,4 @@ RESET max_execution_time
 # Sanity check: a short list completes without error after reset.
 
 statement ok
-SELECT list_transform(range(100), x -> x * 2)
+SELECT list_transform(range(100), lambda x: x * 2)

--- a/test/sql/function/list/lambdas/interrupt.test_slow
+++ b/test/sql/function/list/lambdas/interrupt.test_slow
@@ -1,0 +1,52 @@
+# name: test/sql/function/list/lambdas/interrupt.test_slow
+# description: Test that lambda functions respect query interruption via max_execution_time
+# group: [lambdas]
+
+# list_transform on 1M-element list must be interruptible.
+# Before the fix, ExecuteLambda had no InterruptCheck() calls, so the timeout
+# fired but was not observed until the entire lambda loop finished (~700ms).
+
+statement ok
+SET max_execution_time=50
+
+statement error
+SELECT list_transform(list(i), x -> x * 2 + (x % 3))
+FROM range(1000000) t(i)
+----
+Query exceeded maximum execution time
+
+statement ok
+RESET max_execution_time
+
+# list_filter on a large list must also be interruptible (same ExecuteLambda path).
+
+statement ok
+SET max_execution_time=50
+
+statement error
+SELECT list_filter(list(i), x -> x % 7 <> 0)
+FROM range(1000000) t(i)
+----
+Query exceeded maximum execution time
+
+statement ok
+RESET max_execution_time
+
+# list_reduce has a separate loop (list_reduce.cpp); verify it is also interruptible.
+
+statement ok
+SET max_execution_time=50
+
+statement error
+SELECT list_reduce(list(i), (a, b) -> a + b + (b % 3))
+FROM range(1000000) t(i)
+----
+Query exceeded maximum execution time
+
+statement ok
+RESET max_execution_time
+
+# Sanity check: a short list completes without error after reset.
+
+statement ok
+SELECT list_transform(range(100), x -> x * 2)

--- a/test/sql/function/list/lambdas/interrupt.test_slow
+++ b/test/sql/function/list/lambdas/interrupt.test_slow
@@ -2,44 +2,55 @@
 # description: Test that lambda functions respect query interruption via max_execution_time
 # group: [lambdas]
 
-# list_transform on 1M-element list must be interruptible.
-# Before the fix, ExecuteLambda had no InterruptCheck() calls, so the timeout
-# fired but was not observed until the entire lambda loop finished (~700ms).
+# Pre-build the 1M-element list once, outside any timeout window.
+# Each interrupt test then only times the lambda execution phase itself.
+# Building the list under max_execution_time would make timing hardware-dependent:
+# the aggregation could be interrupted before the lambda even starts on slow runners,
+# or the whole query (aggregation + simple arithmetic) could finish in <50ms on fast ones.
+
+statement ok
+CREATE TABLE interrupt_list AS SELECT list(i) AS l FROM range(1000000) t(i)
+
+# list_transform — uses string formatting (printf) to ensure the per-element cost
+# is high enough (~250ms for 1M elements) that a 50ms deadline reliably fires.
+# Before the fix, ExecuteLambda had no InterruptCheck() calls so the interrupt flag
+# set at the deadline was never read until the entire loop finished.
 
 statement ok
 SET max_execution_time=50
 
 statement error
-SELECT list_transform(list(i), lambda x: x * 2 + (x % 3))
-FROM range(1000000) t(i)
+SELECT list_transform(l, lambda x: printf('%09d-%09d-%09d', x, x * 2 + 1, x * 3 + 2))
+FROM interrupt_list
 ----
 Query exceeded maximum execution time
 
 statement ok
 RESET max_execution_time
 
-# list_filter on a large list must also be interruptible (same ExecuteLambda path).
+# list_filter — same ExecuteLambda code path.
 
 statement ok
 SET max_execution_time=50
 
 statement error
-SELECT list_filter(list(i), lambda x: x % 7 <> 0)
-FROM range(1000000) t(i)
+SELECT list_filter(l, lambda x: printf('%09d-%09d-%09d', x, x * 2 + 1, x * 3 + 2) LIKE '%999%')
+FROM interrupt_list
 ----
 Query exceeded maximum execution time
 
 statement ok
 RESET max_execution_time
 
-# list_reduce has a separate loop (list_reduce.cpp); verify it is also interruptible.
+# list_reduce — separate fold-left loop in list_reduce.cpp.
+# Sequential by nature (~1s for 1M elements), reliably interrupted by 50ms deadline.
 
 statement ok
 SET max_execution_time=50
 
 statement error
-SELECT list_reduce(list(i), lambda a, b: a + b + (b % 3))
-FROM range(1000000) t(i)
+SELECT list_reduce(l, lambda a, b: a + b + (b % 3))
+FROM interrupt_list
 ----
 Query exceeded maximum execution time
 
@@ -50,3 +61,6 @@ RESET max_execution_time
 
 statement ok
 SELECT list_transform(range(100), lambda x: x * 2)
+
+statement ok
+DROP TABLE interrupt_list


### PR DESCRIPTION
## Problem

`list_transform`, `list_filter`, and `list_reduce` did not respect query interruption (from `max_execution_time` or a cancelled client context) while their inner loops were running.

- **`list_transform` / `list_filter`** share `ExecuteLambda` in `lambda_functions.cpp`. This function processes list elements in batches of `STANDARD_VECTOR_SIZE` (2048). The batch loop had no `InterruptCheck()` calls, so a pending interrupt was never observed until the entire loop finished.
- **`list_reduce`** has a separate fold-left `while (!end)` loop in `list_reduce.cpp` that runs once per list element. It had the same problem.

**Symptoms:** on a 1 M-element list, a 50 ms `max_execution_time` was consistently ignored and the query ran for ~700 ms before returning.

## Fix

Call `state.GetContext().InterruptCheck()` at the top of each processing cycle in both loops. `InterruptCheck()` throws `InterruptException` as soon as `interrupt_state == INTERRUPTED` (set by `duckdb_interrupt()` or when the `query_deadline` is exceeded), allowing the query to abort promptly.

```cpp
// lambda_functions.cpp — ExecuteLambda batch loop
if (elem_cnt == STANDARD_VECTOR_SIZE) {
+   state.GetContext().InterruptCheck();
    execute_info.lambda_chunk.Reset();
    ...
}

// list_reduce.cpp — fold-left loop
while (!end) {
+   state.GetContext().InterruptCheck();
    auto &result_chunk = ...;
    ...
}
```

## Test

`test/sql/function/list/lambdas/interrupt.test_slow` — runs all three functions with `SET max_execution_time=50` against a 1 M-element list and expects `Query exceeded maximum execution time`.

## Checklist

- [x] All three lambda functions interrupted promptly with `max_execution_time`
- [x] SQL regression test added
- [x] No functional change when no interrupt is pending