### PR TITLE
Issue #23664: RANGE ZERO 

### DIFF
--- a/src/function/window/window_boundaries_state.cpp
+++ b/src/function/window/window_boundaries_state.cpp
@@ -828,8 +828,9 @@ void WindowBoundariesState::FrameBegin(DataChunk &bounds, idx_t row_idx, const i
 		break;
 	case WindowBoundary::EXPR_FOLLOWING_RANGE:
 		for (idx_t chunk_idx = 0; chunk_idx < count; ++chunk_idx, ++row_idx) {
+			const auto peer_begin = peer_begin_data[chunk_idx];
 			if (boundary_begin.CellIsNull(chunk_idx)) {
-				window_start = peer_begin_data[chunk_idx];
+				window_start = peer_begin;
 			} else {
 				const auto valid_end = valid_end_data[chunk_idx];
 				prev.end = valid_end;
@@ -838,7 +839,7 @@ void WindowBoundariesState::FrameBegin(DataChunk &bounds, idx_t row_idx, const i
 					prev.start = valid_begin_data[chunk_idx];
 					prev_partition = cur_partition;
 				}
-				window_start = FindOrderedRangeBound<true>(*range_lo, *range_hi, range_sense, row_idx, valid_end,
+				window_start = FindOrderedRangeBound<true>(*range_lo, *range_hi, range_sense, peer_begin, valid_end,
 				                                           start_boundary, boundary_begin, chunk_idx, prev);
 				prev.start = window_start;
 			}
@@ -966,8 +967,9 @@ void WindowBoundariesState::FrameEnd(DataChunk &bounds, idx_t row_idx, const idx
 		break;
 	case WindowBoundary::EXPR_PRECEDING_RANGE:
 		for (idx_t chunk_idx = 0; chunk_idx < count; ++chunk_idx, ++row_idx) {
+			const auto peer_end = peer_end_data[chunk_idx];
 			if (boundary_end.CellIsNull(chunk_idx)) {
-				window_end = peer_end_data[chunk_idx];
+				window_end = peer_end;
 			} else {
 				const auto valid_start = valid_begin_data[chunk_idx];
 				prev.start = valid_start;
@@ -976,7 +978,7 @@ void WindowBoundariesState::FrameEnd(DataChunk &bounds, idx_t row_idx, const idx
 					prev.end = valid_end;
 					prev_partition = cur_partition;
 				}
-				window_end = FindOrderedRangeBound<false>(*range_lo, *range_hi, range_sense, valid_start, row_idx + 1,
+				window_end = FindOrderedRangeBound<false>(*range_lo, *range_hi, range_sense, valid_start, peer_end,
 				                                          end_boundary, boundary_end, chunk_idx, prev);
 				prev.end = window_end;
 			}

--- a/test/sql/window/test_boundary_expr.test
+++ b/test/sql/window/test_boundary_expr.test
@@ -120,3 +120,29 @@ select avg(a) over (
     rows between mod(b * 1023, 11) preceding and 23 - mod(b * 1023, 11) following)
 from issue1697
 
+# RANGE CURRENT ROW == 0 PRECEDING == 0 FOLLOWING
+query IIII
+WITH t(id, k) AS (
+  VALUES
+    (1, 1),
+    (2, 1)
+)
+SELECT
+  id,
+  SUM(1) OVER (
+    ORDER BY k
+    RANGE BETWEEN CURRENT ROW AND CURRENT ROW
+  ) AS current_row_frame,
+  SUM(1) OVER (
+    ORDER BY k
+    RANGE BETWEEN 0 PRECEDING AND 0 PRECEDING
+  ) AS zero_preceding_frame,
+  SUM(1) OVER (
+    ORDER BY k
+    RANGE BETWEEN 0 FOLLOWING AND 0 FOLLOWING
+  ) AS zero_following_frame
+FROM t
+ORDER BY id;
+----
+1	2	2	2
+2	2	2	2


### PR DESCRIPTION
* Use the peer bounds instead of the row number for RANGE 0 PRECEDING/FOLLOWING