### PR TITLE
Rebind cached SQL PREPARE plans that read tables so EXECUTE sees new rows

### DIFF
--- a/src/planner/binder/statement/bind_prepare.cpp
+++ b/src/planner/binder/statement/bind_prepare.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/planner/binder.hpp"
+#include "duckdb/main/prepared_statement.hpp"
 #include "duckdb/parser/statement/prepare_statement.hpp"
 #include "duckdb/planner/planner.hpp"
 #include "duckdb/planner/operator/logical_prepare.hpp"
@@ -10,7 +11,10 @@ BoundStatement Binder::Bind(PrepareStatement &stmt) {
 	auto prepared_data = prepared_planner.PrepareSQLStatement(std::move(stmt.statement));
 	global_binder_state->bound_tables = prepared_planner.binder->global_binder_state->bound_tables;
 
-	if (prepared_planner.properties.always_require_rebind) {
+	if (prepared_planner.plan && !PreparedStatement::CanCachePlan(*prepared_planner.plan)) {
+		prepared_data->properties.always_require_rebind = true;
+	}
+	if (prepared_data->properties.always_require_rebind) {
 		// we always need to rebind - don't keep the plan around
 		prepared_planner.plan.reset();
 	}

--- a/test/sql/prepared/test_prepare_insert_visibility.test
+++ b/test/sql/prepared/test_prepare_insert_visibility.test
@@ -1,0 +1,30 @@
+# name: test/sql/prepared/test_prepare_insert_visibility.test
+# description: Prepared SELECT sees rows inserted after PREPARE
+# group: [prepared]
+
+statement ok
+CREATE TABLE t(i INT)
+
+statement ok
+INSERT INTO t SELECT range FROM range(100)
+
+statement ok
+PREPARE q AS SELECT count() FROM t WHERE i = 200
+
+statement ok
+INSERT INTO t VALUES (200)
+
+query I
+EXECUTE q
+----
+1
+
+query I
+EXECUTE q
+----
+1
+
+query I
+SELECT count() FROM t WHERE i = 200
+----
+1


### PR DESCRIPTION
Rebind cached SQL PREPARE plans that read tables so EXECUTE sees new rows

## Bug

A SQL-level `PREPARE`d statement returns stale results after an `INSERT`:

```sql
CREATE TABLE t(i INT);
INSERT INTO t SELECT range FROM range(100);
PREPARE q AS SELECT count() FROM t WHERE i = 200;
INSERT INTO t VALUES (200);
EXECUTE q;   -- returns 0, should return 1
```

`EXECUTE q` reuses a physical plan that was built and cached against the table state at PREPARE time, so rows inserted afterward are not seen.

## Root cause

`Binder::Bind(PrepareStatement&)` keeps the cached physical plan whenever `always_require_rebind` is false. For a plan that reads a table (`LOGICAL_GET`), the cached physical plan encodes the data state at prepare time and must not be reused across a mutation. The API-level prepared-statement path already guards this: it calls `PreparedStatement::CanCachePlan`, which returns false when the plan contains a `LOGICAL_GET`. The SQL `PREPARE` binder did not apply that same guard, so table-reading SQL prepares kept a stale plan.

## Fix

In `Binder::Bind(PrepareStatement&)`, apply the same cacheability predicate the API path uses: if the plan is present and `PreparedStatement::CanCachePlan(plan)` is false, set `always_require_rebind = true`. The existing branch then drops the cached plan, forcing a replan at `EXECUTE` against current data.

This reuses the exact predicate already used at the API layer (`client_context.cpp`), so it is consistent rather than a new rule. Prepares that do not read tables (for example `PREPARE c AS SELECT 40 + 2`) still cache their plan.

## Tests

Added `test/sql/prepared/test_prepare_insert_visibility.test`: a SQL prepare over a table, an insert of a matching row after prepare, then two `EXECUTE`s that must both observe the new row.

```
build/release/test/unittest "test/sql/prepared/test_prepare_insert_visibility.test"   # passes with fix
build/release/test/unittest "*prepared*"                                              # 76 test cases pass
```

Reverting only the source change makes the new test fail with `EXECUTE q` returning the stale `0` instead of `1`, so the test has teeth. Constant prepares still cache, and parameterized table-read prepares stay correct per parameter and observe newly inserted rows on re-execute.

Fixes #23704
