### PR TITLE
Fix DROP COLUMN corrupting per-column metadata block bookkeeping

### DIFF
--- a/src/include/duckdb/storage/table/per_column_metadata_blocks.hpp
+++ b/src/include/duckdb/storage/table/per_column_metadata_blocks.hpp
@@ -32,7 +32,11 @@ public:
 
 	//! Add a column entry with its block IDs
 	void AddColumn(idx_t col_idx, const vector<idx_t> &blocks);
-	//! Remove a column entry and all its block IDs (linear scan)
+	//! Clear a column's entry and all its block IDs in place, leaving the indices of the other
+	//! columns untouched (linear scan), for use when the column is rewritten (e.g. ALTER TYPE)
+	void ClearColumn(idx_t col_idx);
+	//! Remove a column's entry and shift down the indices of all subsequent columns,
+	//! for use when the column is positionally removed (e.g. DROP COLUMN)
 	void RemoveColumn(idx_t col_idx);
 	//! Merge two PerColumnMetadataBlocks sorted by column index with disjoint column sets
 	static PerColumnMetadataBlocks Merge(const PerColumnMetadataBlocks &a, const PerColumnMetadataBlocks &b);

--- a/src/storage/table/per_column_metadata_blocks.cpp
+++ b/src/storage/table/per_column_metadata_blocks.cpp
@@ -100,7 +100,7 @@ PerColumnMetadataBlocks PerColumnMetadataBlocks::Merge(const PerColumnMetadataBl
 	return result;
 }
 
-void PerColumnMetadataBlocks::RemoveColumn(idx_t col_idx) {
+void PerColumnMetadataBlocks::ClearColumn(idx_t col_idx) {
 	idx_t start = data.size();
 	idx_t end = data.size();
 	for (idx_t i = 0; i < data.size(); i++) {
@@ -119,6 +119,15 @@ void PerColumnMetadataBlocks::RemoveColumn(idx_t col_idx) {
 	}
 	if (start < data.size()) {
 		data.erase(data.begin() + NumericCast<int64_t>(start), data.begin() + NumericCast<int64_t>(end));
+	}
+}
+
+void PerColumnMetadataBlocks::RemoveColumn(idx_t col_idx) {
+	ClearColumn(col_idx);
+	for (auto &entry : data) {
+		if (entry.is_column_index && entry.index > col_idx) {
+			entry.index--;
+		}
 	}
 }
 

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -463,7 +463,7 @@ unique_ptr<RowGroup> RowGroup::AlterType(RowGroupCollection &new_collection, con
 	}
 	if (has_per_column_metadata_blocks) {
 		row_group->per_column_metadata_blocks = per_column_metadata_blocks;
-		row_group->per_column_metadata_blocks.RemoveColumn(changed_idx);
+		row_group->per_column_metadata_blocks.ClearColumn(changed_idx);
 	}
 	lock.unlock();
 	row_group->Verify();
@@ -552,6 +552,8 @@ unique_ptr<RowGroup> RowGroup::RemoveColumn(RowGroupCollection &new_collection, 
 	}
 	if (has_per_column_metadata_blocks) {
 		row_group->per_column_metadata_blocks = per_column_metadata_blocks;
+		// the columns after the removed one shift down by one position, so their
+		// metadata block entries (keyed by column index) must shift down as well
 		row_group->per_column_metadata_blocks.RemoveColumn(removed_column);
 	}
 	lock.unlock();

--- a/test/sql/storage/metadata/partial_column_metadata_reuse_drop_column.test
+++ b/test/sql/storage/metadata/partial_column_metadata_reuse_drop_column.test
@@ -1,0 +1,86 @@
+# name: test/sql/storage/metadata/partial_column_metadata_reuse_drop_column.test
+# description: Regression test for DROP COLUMN not shifting per_column_metadata_blocks indices.
+# group: [metadata]
+
+#              Columns after the dropped one shift down a position, but their metadata block entries
+#              kept the old index, so the next partial-reuse checkpoint attributed extra metadata
+#              blocks to the wrong columns and persisted the bad bookkeeping (surfacing later as
+#              "field id mismatch" corruption).
+
+# small block size shrinks the metadata block size (block_size / 64), so per-row-group
+# column metadata easily spills past one metadata block and reused columns end up with extras
+statement ok
+ATTACH '__TEST_DIR__/partial_reuse_drop_column.db' AS db1 (BLOCK_SIZE 16384, STORAGE_VERSION 'latest')
+
+statement ok
+SET debug_skip_checkpoint_on_commit=true
+
+statement ok
+SET force_column_metadata_reuse=true
+
+statement ok
+SET debug_verify_blocks=true
+
+# incompressible varchar payloads so every column's metadata spills into extra metadata blocks
+statement ok
+CREATE TABLE db1.wide_tbl AS SELECT
+    i AS id,
+    md5(i::VARCHAR || 'c0') AS c0,
+    md5(i::VARCHAR || 'c1') AS c1,
+    md5(i::VARCHAR || 'c2') AS c2,
+    md5(i::VARCHAR || 'c3') AS c3,
+    md5(i::VARCHAR || 'c4') AS c4,
+    md5(i::VARCHAR || 'c5') AS c5
+FROM range(50000) t(i)
+
+# initial checkpoint persists all column metadata, including per-column extra metadata blocks
+statement ok
+CHECKPOINT db1
+
+# drop a middle column: c2..c5 shift down one position
+statement ok
+ALTER TABLE db1.wide_tbl DROP COLUMN c1
+
+# modify one of the shifted columns so the next checkpoint partially reuses the others
+statement ok
+UPDATE db1.wide_tbl SET c4 = md5((id * 7)::VARCHAR) WHERE id BETWEEN 100 AND 600
+
+# without the fix this fails with "per_column_metadata_blocks mismatch"
+statement ok
+CHECKPOINT db1
+
+# verify every remaining column still holds its own payload (not a neighbor's)
+query I
+SELECT count(*) FROM db1.wide_tbl
+WHERE c0 != md5(id::VARCHAR || 'c0')
+   OR c2 != md5(id::VARCHAR || 'c2')
+   OR c3 != md5(id::VARCHAR || 'c3')
+   OR c4 != CASE WHEN id BETWEEN 100 AND 600 THEN md5((id * 7)::VARCHAR) ELSE md5(id::VARCHAR || 'c4') END
+   OR c5 != md5(id::VARCHAR || 'c5')
+----
+0
+
+# second round: drop another middle column so the already-shifted entries shift again
+statement ok
+ALTER TABLE db1.wide_tbl DROP COLUMN c3
+
+statement ok
+UPDATE db1.wide_tbl SET c5 = md5((id * 13)::VARCHAR) WHERE id BETWEEN 1000 AND 1500
+
+statement ok
+CHECKPOINT db1
+
+restart
+
+# re-attach and verify the persisted state deserializes correctly from disk
+statement ok
+ATTACH '__TEST_DIR__/partial_reuse_drop_column.db' AS db1
+
+query I
+SELECT count(*) FROM db1.wide_tbl
+WHERE c0 != md5(id::VARCHAR || 'c0')
+   OR c2 != md5(id::VARCHAR || 'c2')
+   OR c4 != CASE WHEN id BETWEEN 100 AND 600 THEN md5((id * 7)::VARCHAR) ELSE md5(id::VARCHAR || 'c4') END
+   OR c5 != CASE WHEN id BETWEEN 1000 AND 1500 THEN md5((id * 13)::VARCHAR) ELSE md5(id::VARCHAR || 'c5') END
+----
+0


### PR DESCRIPTION
RowGroup::RemoveColumn copied per_column_metadata_blocks and erased the dropped column's entry, but left the entries of all subsequent columns keyed by their old (pre-drop) indices while the columns themselves shift down a position. The next partial-reuse checkpoint (force_column_metadata_reuse) then looked up reused columns by their new indices and attributed extra metadata blocks to the wrong columns. The wrong block list was persisted, still-referenced metadata blocks were freed and reused, and a later scan deserialized garbage, surfacing as "field id mismatch".

Fix: shift the entry indices of all columns after the dropped one down by one. PerColumnMetadataBlocks::RemoveColumn now does exactly that; the old shift-less behavior is renamed to ClearColumn and kept for the ALTER TYPE path, where the column is rewritten in place and positions don't shift.

The regression test fails without the fix at the first checkpoint after the drop with "per_column_metadata_blocks mismatch" (debug_verify_blocks tripwire); the small BLOCK_SIZE and varchar payloads make each column's metadata spill into extra blocks, which is a precondition for the bug.