### PR TITLE
make extension-patch-check

### DIFF
--- a/.github/config/extensions/vortex.cmake
+++ b/.github/config/extensions/vortex.cmake
@@ -1,5 +1,8 @@
 # FIXME: disabled for now while CopyFunction undergoes heavy changes
-if (FALSE AND NOT WIN32 AND NOT ${WASM_ENABLED} AND NOT ${MUSL_ENABLED})
+if (NOT DEFINED VORTEX_ENABLED)
+    set(VORTEX_ENABLED OFF)
+endif()
+if (VORTEX_ENABLED AND NOT WIN32 AND NOT ${WASM_ENABLED} AND NOT ${MUSL_ENABLED})
     duckdb_extension_load(vortex
             GIT_URL https://github.com/vortex-data/duckdb-vortex
             GIT_TAG 6ea8bd77fe8e6e814bde11b6981f934fa82ab961

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -239,7 +239,7 @@ jobs:
 
       - name: Check format
         run: |
-          make format-check-silent enum-integrity-check -j -Otarget
+          make format-check-silent enum-integrity-check extension-patch-check -j -Otarget
           echo "::group::Check generated files"
           make generate-files
           git diff --exit-code

--- a/Makefile
+++ b/Makefile
@@ -711,6 +711,10 @@ spell_tools:
 enum-integrity-check:
 	$(PYTHON) scripts/verify_enum_integrity.py src/include/duckdb.h
 
+.PHONY: extension-patch-check
+extension-patch-check:
+	cmake -DCONFIG_DIR=.github/config -DPATCH_DIR=.github/patches/extensions -P scripts/check_extension_patches.cmake
+
 .PHONY: format_venv
 format_venv:
 	@if [ ! -x "$(FORMAT_PYTHON)" ]; then \

--- a/scripts/check_extension_patches.cmake
+++ b/scripts/check_extension_patches.cmake
@@ -1,0 +1,103 @@
+# Verifies that every extension with patches also passes APPLY_PATCHES.
+#
+# Patches under .github/patches/extensions/<name> are only used when the matching
+# duckdb_extension_load() call passes APPLY_PATCHES. Without it the patches are
+# silently ignored, which is how the mysql_scanner, postgres_scanner,
+# sqlite_scanner and sqlsmith patches went unapplied after their GIT_TAGs were
+# bumped.
+#
+# Run with:
+#   cmake -DCONFIG_DIR=.github/config -DPATCH_DIR=.github/patches/extensions \
+#         -P scripts/check_extension_patches.cmake
+
+cmake_minimum_required(VERSION 3.14...3.29)
+
+if(NOT CONFIG_DIR OR NOT PATCH_DIR)
+    message(FATAL_ERROR "CONFIG_DIR and PATCH_DIR must be set")
+endif()
+
+# Reach the maximal set of duckdb_extension_load() calls: guards such as
+# if (NOT MINGW AND NOT ${WASM_ENABLED}) would otherwise hide an extension whose
+# patch directory exists unconditionally.
+set(WASM_ENABLED 0)
+set(MUSL_ENABLED 0)
+set(MINGW OFF)
+set(WIN32 OFF)
+set(BUILD_COMPLETE_EXTENSION_SET 1)
+set(VORTEX_ENABLED ON)
+
+set(EXTENSION_CONFIG_BASE_DIR "${CONFIG_DIR}/extensions")
+
+# Record the extensions that ask for their patches to be applied.
+set(APPLYING "")
+macro(duckdb_extension_load NAME)
+    cmake_parse_arguments(EXT "APPLY_PATCHES;DONT_LINK;DONT_BUILD;LOAD_TESTS" "GIT_URL;GIT_TAG" "" ${ARGN})
+    if(EXT_APPLY_PATCHES)
+        list(APPEND APPLYING "${NAME}")
+    endif()
+endmacro()
+
+# test-utils.cmake sits in extensions/ but is a top-level config itself: it
+# includes ../in_tree_extensions.cmake.
+foreach(config
+        "${CONFIG_DIR}/bundled_extensions.cmake"
+        "${CONFIG_DIR}/external_extensions.cmake"
+        "${CONFIG_DIR}/in_tree_extensions.cmake"
+        "${CONFIG_DIR}/out_of_tree_extensions.cmake"
+        "${CONFIG_DIR}/rust_based_extensions.cmake"
+        "${EXTENSION_CONFIG_BASE_DIR}/test-utils.cmake")
+    include("${config}")
+endforeach()
+list(REMOVE_DUPLICATES APPLYING)
+list(SORT APPLYING)
+
+# Collect the extensions that actually have patches on disk.
+set(HAVING "")
+file(GLOB entries "${PATCH_DIR}/*")
+foreach(entry ${entries})
+    if(IS_DIRECTORY "${entry}")
+        file(GLOB patches "${entry}/*.patch")
+        if(patches)
+            get_filename_component(name "${entry}" NAME)
+            list(APPEND HAVING "${name}")
+            set(PATCHES_${name} "")
+            foreach(patch ${patches})
+                get_filename_component(patch_name "${patch}" NAME)
+                list(APPEND PATCHES_${name} "${patch_name}")
+            endforeach()
+            list(SORT PATCHES_${name})
+        endif()
+    endif()
+endforeach()
+list(SORT HAVING)
+
+set(ERRORS "")
+foreach(name ${HAVING})
+    if(NOT "${name}" IN_LIST APPLYING)
+        list(LENGTH PATCHES_${name} count)
+        if(count EQUAL 1)
+            set(text "${name}: 1 patch exists, no APPLY_PATCHES")
+        else()
+            set(text "${name}: ${count} patches exist, no APPLY_PATCHES")
+        endif()
+        foreach(patch ${PATCHES_${name}})
+            string(APPEND text "\n  ${patch}")
+        endforeach()
+        list(APPEND ERRORS "${text}")
+    endif()
+endforeach()
+foreach(name ${APPLYING})
+    if(NOT "${name}" IN_LIST HAVING)
+        list(APPEND ERRORS "${name}: no patches, APPLY_PATCHES is present")
+    endif()
+endforeach()
+
+if(ERRORS)
+    foreach(error ${ERRORS})
+        message(NOTICE "${error}")
+    endforeach()
+    message(FATAL_ERROR "extension patch check failed, see .github/patches/extensions/README.md")
+endif()
+
+list(LENGTH APPLYING count)
+message(STATUS "ok: ${count} extensions apply patches, all accounted for")


### PR DESCRIPTION
This is expected to fail on current `main`, proving it works in catching mismatches between `APPLY_PATCHES` and presence of patches.

Either for local development or CI:
```
make extension-patch-check
```
must pass or it will point to mistakes like:
```
mysql_scanner: 2 patches exist, no APPLY_PATCHES
  0014-freeloaded-includes.patch
  0015-bound-expression-includes.patch
postgres_scanner: 4 patches exist, no APPLY_PATCHES
  0014-freeloaded-includes.patch
  0015-logging-includes.patch
  0016-log-macro-manager.patch
  0017-log-manager-include.patch
sqlite_scanner: 1 patch exists, no APPLY_PATCHES
  0007-header-includes-column-list-attach-options.patch
sqlsmith: 1 patch exists, no APPLY_PATCHES
  0010-function-catalog-entry-includes.patch
CMake Error at scripts/check_extension_patches.cmake:99 (message):
  extension patch check failed, see .github/patches/extensions/README.md

```