### PR TITLE
Keep non-updatable row-groups non-updatable after adding a new segment

### DIFF
--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -184,7 +184,11 @@ void RowGroupCollection::AppendRowGroup(SegmentLock &l, idx_t start_row) {
 	auto new_row_group = make_uniq<RowGroup>(*this, 0U);
 	new_row_group->InitializeEmpty(types, GetColumnDataType(start_row));
 	owned_row_groups->AppendSegment(l, std::move(new_row_group), start_row);
-	row_group_append_mode = RowGroupAppendMode::APPEND_TO_EXISTING;
+
+	// Do not downgrade from REQUIRE_NEW
+	if (row_group_append_mode <= RowGroupAppendMode::SUGGEST_NEW) {
+		row_group_append_mode = RowGroupAppendMode::APPEND_TO_EXISTING;
+	}
 }
 
 optional_ptr<RowGroup> RowGroupCollection::GetRowGroup(int64_t index) {

--- a/test/sql/types/geo/geometry_shred_pk_append.test
+++ b/test/sql/types/geo/geometry_shred_pk_append.test
@@ -1,0 +1,35 @@
+# name: test/sql/types/geo/geometry_shred_pk_append.test
+# description: Append into a re-shredded rowgroup through the index append path
+# group: [geo]
+
+# Ensure that when appending to a rowgroup, the presence and state of an index does not impact the decision wether
+# a new row segment is created or not. If the row group has a non-updateable type (like GEOMETRY), new segments should
+# be created regardless, and the rowgroup should not be marked as updateable.
+
+load __TEST_DIR__/geometry_shred_pk_append.db readwrite v1.5.0
+
+statement ok
+SET geometry_minimum_shredding_size = 0;
+
+statement ok
+CREATE TABLE t(id UUID PRIMARY KEY, g GEOMETRY);
+
+statement ok
+INSERT INTO t VALUES (uuidv7(), 'POINT (0 1)'::GEOMETRY);
+
+statement ok
+CHECKPOINT
+
+statement ok
+INSERT INTO t VALUES (uuidv7(), 'POINT (0 1)'::GEOMETRY);
+
+statement ok
+CHECKPOINT
+
+statement ok
+INSERT INTO t VALUES (uuidv7(), 'POINT (0 1)'::GEOMETRY);
+
+query I
+SELECT COUNT(*) FROM t WHERE g::VARCHAR = 'POINT (0 1)';
+----
+3


### PR DESCRIPTION
`GEOMETRY` (and `VARIANT`?) column row groups need to keep their  `RowGroupAppendMode::REQUIRE_NEW` even after a new child row group is created. Otherwise, when we go through the index append path (`LocalTableStorage::AppendToTable`) we will initialize a regular in-place append and try to append regular chunks into a potentially shredded column data.

Follow up from https://github.com/duckdb/duckdb/pull/22060
Should fix https://github.com/duckdb/duckdb-spatial/issues/828