### PR TITLE
Move type pushdown after filter pushdown, don't push it filter is present

### DIFF
--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -214,16 +214,6 @@ void Optimizer::RunBuiltInOptimizers() {
 		plan = filter_pullup.Rewrite(std::move(plan));
 	});
 
-	/* Push down type casts in SELECT e.g. SELECT num::UHUGEINT to file readers.
-	 * This pass must run before FILTER_PUSHDOWN. After filter pushdown
-	 * get.table_filters are populated because WHERE clauses may have been
-	 * pushed. This makes type pushdown much more complex.
-	 */
-	RunOptimizer(OptimizerType::TYPE_PUSHDOWN, [&] {
-		TypePushdown type_pushdown(context);
-		plan = type_pushdown.Optimize(std::move(plan));
-	});
-
 	// perform filter pushdown
 	RunOptimizer(OptimizerType::FILTER_PUSHDOWN, [&]() {
 		FilterPushdown filter_pushdown(*this);
@@ -439,6 +429,12 @@ void Optimizer::RunBuiltInOptimizers() {
 	RunOptimizer(OptimizerType::ROW_NUMBER_REWRITER, [&]() {
 		RowNumberRewriter window_rewriter;
 		plan = window_rewriter.Optimize(std::move(plan));
+	});
+
+	// Push down type casts in SELECT e.g. SELECT num::UHUGEINT to file readers.
+	RunOptimizer(OptimizerType::TYPE_PUSHDOWN, [&] {
+		TypePushdown type_pushdown(context);
+		plan = type_pushdown.Optimize(std::move(plan));
 	});
 }
 

--- a/src/optimizer/type_pushdown.cpp
+++ b/src/optimizer/type_pushdown.cpp
@@ -25,10 +25,6 @@
  *
  * Example: SELECT ts::TIMESTAMP FROM file_reader();
  * We can push TIMESTAMP as ts's output type to file_reader();
- *
- * This pass runs before FILTER_PUSHDOWN so that WHERE conditions are still
- * visible as LOGICAL_FILTER nodes. That makes uncasted column usage detectable
- * by CollectFromOp without need to inspect table_filters.
  */
 
 namespace duckdb {
@@ -107,9 +103,17 @@ std::optional<GetBinding> Resolve(ColumnBinding binding, Analyses &analyses, con
 	return std::nullopt;
 }
 
-// A GET reachable through a single-child chain of filters/projections. A join
-// (or any other multi-child operator) breaks the chain.
-// See test/sql/copy/csv/test_insert_into_types.test (cast not pushed past a join)
+/**
+ * A GET reachable through a single-child chain of projections. A join or any
+ * other multi-child operator breaks the chain.
+ *
+ * LOGICAL_FILTER also breaks the chain. In SELECT CAST/TRY_CAST(x) WHERE g(x)
+ * we can't push down cast if g(x) isn't pushed. If g(x) filters some rows
+ * on which cast would fail, the query passed by default but fails if cast is pushed
+ * and runs before g(x).
+ *
+ * See test/sql/copy/csv/test_insert_into_types.test in duckdb (cast not pushed past a join)
+ */
 static bool ReachesPushdownGet(const LogicalOperator &op) {
 	const LogicalOperator *cur = &op;
 	while (cur->children.size() == 1) {
@@ -117,7 +121,6 @@ static bool ReachesPushdownGet(const LogicalOperator &op) {
 		switch (cur->type) {
 		case LogicalOperatorType::LOGICAL_GET:
 			return cur->Cast<LogicalGet>().function.projection_expression_pushdown != nullptr;
-		case LogicalOperatorType::LOGICAL_FILTER:
 		case LogicalOperatorType::LOGICAL_PROJECTION:
 			continue;
 		default:

--- a/test/optimizer/pushdown/csv_type_pushdown.test
+++ b/test/optimizer/pushdown/csv_type_pushdown.test
@@ -199,13 +199,14 @@ WHERE TRY_CAST(column00 AS UTINYINT) > 0 ORDER BY 1;
 3
 3
 
-# TRY_CAST: same try_cast in SELECT and WHERE; type pushed down so filter uses column index
+# CSV reader doesn't push down filters. We can't reorder filter after
+# projection because this may break correctness
 query II
 EXPLAIN SELECT TRY_CAST(column00 AS UTINYINT)
 FROM read_csv('{DATA_DIR}/csv/real/lineitem_sample.csv', delim='|')
 WHERE TRY_CAST(column00 AS UTINYINT) > 0;
 ----
-physical_plan	<!REGEX>:.*CAST.*
+physical_plan	<REGEX>:.*CAST.*
 
 query I
 SELECT TRY_CAST(column00 AS UTINYINT)
@@ -265,4 +266,112 @@ FROM read_csv('{DATA_DIR}/csv/real/lineitem_sample.csv', delim='|') ORDER BY 1, 
 2	2
 3	3
 3	3
+3	3
+
+# cast -> cte
+query I
+SELECT DISTINCT column00::UTINYINT FROM (
+    SELECT column00 FROM read_csv('{DATA_DIR}/csv/real/lineitem_sample.csv', delim='|')
+) ORDER BY column00;
+----
+1
+2
+3
+
+# cast -> cte -> cte
+query I
+WITH cte1 AS (SELECT column00 FROM read_csv('{DATA_DIR}/csv/real/lineitem_sample.csv', delim='|')),
+     cte2 AS (SELECT column00 FROM cte1)
+SELECT DISTINCT column00::UTINYINT FROM cte2 ORDER BY 1;
+----
+1
+2
+3
+
+# cte -> cast -> cte
+query II
+WITH cte1 AS (SELECT column00 FROM read_csv('{DATA_DIR}/csv/real/lineitem_sample.csv', delim='|') ORDER BY column00),
+     cte2 AS (SELECT column00, column00::UTINYINT AS c FROM cte1)
+SELECT column00, c FROM cte2 ORDER BY column00;
+----
+1	1
+1	1
+1	1
+1	1
+1	1
+1	1
+2	2
+3	3
+3	3
+3	3
+
+statement ok
+CREATE VIEW pv1 AS SELECT column00 FROM read_csv('{DATA_DIR}/csv/real/lineitem_sample.csv', delim='|');
+
+# cast pushed through a passthrough VIEW
+query II
+EXPLAIN SELECT column00::UTINYINT FROM pv1;
+----
+physical_plan	<!REGEX>:.*PROJECTION.*
+
+query I
+SELECT column00::UTINYINT FROM pv1 ORDER BY column00::UTINYINT;
+----
+1
+1
+1
+1
+1
+1
+2
+3
+3
+3
+
+# nested VIEW: two levels of indirection, no pushdown
+statement ok
+CREATE VIEW pv2 AS SELECT column00 FROM pv1;
+
+query II
+EXPLAIN SELECT column00::UTINYINT FROM pv2;
+----
+physical_plan	<REGEX>:.*PROJECTION.*
+
+query I
+SELECT column00::UTINYINT FROM pv2 ORDER BY column00::UTINYINT;
+----
+1
+1
+1
+1
+1
+1
+2
+3
+3
+3
+
+# cte -> view -> pv2
+query I
+WITH cte AS (SELECT column00 FROM pv2)
+SELECT column00::UTINYINT FROM cte ORDER BY column00;
+----
+1
+1
+1
+1
+1
+1
+2
+3
+3
+3
+
+statement ok
+CREATE VIEW pv3 AS SELECT column00 AS x, column00 AS y
+FROM read_csv('{DATA_DIR}/csv/real/lineitem_sample.csv', delim='|');
+
+query II
+SELECT x::UTINYINT, y::UTINYINT FROM pv3 ORDER BY x DESC LIMIT 1;
+----
 3	3


### PR DESCRIPTION
There is currently a correctness bug in type pushdown optimizer: in
SELECT col::T where condition(), if condition is not pushed, it is reodered over GET. However, if condition() doesn't contain "col", col::T may be pushed to GET so that chain is FILTER -> GET [-> CAST inside]. if condition() filtered out rows on which CAST errors i.e.

SELECT col::UTINYINT where this_filters_col_eq_257(), pushdown turns a working query into an erroring one.

Thus we disallow cast pushdown if after filter pushdown any filter survived.