### PR TITLE
Fix crash when appending to indexed table with shredded columns

### DIFF
--- a/src/include/duckdb/storage/table/array_column_data.hpp
+++ b/src/include/duckdb/storage/table/array_column_data.hpp
@@ -56,6 +56,7 @@ public:
 	                                             const BaseStatistics &old_stats) override;
 
 	bool IsPersistent() override;
+	bool IsAppendable() const override;
 	bool HasAnyChanges() const override;
 	PersistentColumnData Serialize() override;
 	void InitializeColumn(PersistentColumnData &column_data, BaseStatistics &target_stats) override;

--- a/src/include/duckdb/storage/table/column_data.hpp
+++ b/src/include/duckdb/storage/table/column_data.hpp
@@ -187,6 +187,8 @@ public:
 	virtual void CheckpointScan(ColumnSegment &segment, ColumnScanState &state, idx_t count, Vector &scan_vector) const;
 
 	virtual bool IsPersistent();
+	//! Whether new rows can be appended to this column, e.g. shredded GEOMETRY columns no longer accept appends
+	virtual bool IsAppendable() const;
 	vector<DataPointer> GetDataPointers();
 
 	virtual PersistentColumnData Serialize();

--- a/src/include/duckdb/storage/table/geo_column_data.hpp
+++ b/src/include/duckdb/storage/table/geo_column_data.hpp
@@ -60,6 +60,7 @@ public:
 	                                             const BaseStatistics &old_stats) override;
 
 	bool IsPersistent() override;
+	bool IsAppendable() const override;
 	bool HasAnyChanges() const override;
 	PersistentColumnData Serialize() override;
 	void InitializeColumn(PersistentColumnData &column_data, BaseStatistics &target_stats) override;

--- a/src/include/duckdb/storage/table/list_column_data.hpp
+++ b/src/include/duckdb/storage/table/list_column_data.hpp
@@ -54,6 +54,7 @@ public:
 	                                             const BaseStatistics &old_stats) override;
 
 	bool IsPersistent() override;
+	bool IsAppendable() const override;
 	bool HasAnyChanges() const override;
 	PersistentColumnData Serialize() override;
 	void InitializeColumn(PersistentColumnData &column_data, BaseStatistics &target_stats) override;

--- a/src/include/duckdb/storage/table/row_group.hpp
+++ b/src/include/duckdb/storage/table/row_group.hpp
@@ -182,6 +182,8 @@ public:
 	RowGroupPointer Checkpoint(RowGroupWriteData write_data, RowGroupWriter &writer, TableStatistics &global_stats,
 	                           idx_t row_group_start);
 	bool IsPersistent() const;
+	//! Whether new rows can be appended to this row group
+	bool IsAppendable() const;
 	PersistentRowGroupData SerializeRowGroupInfo(idx_t row_group_start) const;
 
 	void InitializeAppend(RowGroupAppendState &append_state);

--- a/src/include/duckdb/storage/table/struct_column_data.hpp
+++ b/src/include/duckdb/storage/table/struct_column_data.hpp
@@ -70,6 +70,7 @@ public:
 	                                             const BaseStatistics &old_stats) override;
 
 	bool IsPersistent() override;
+	bool IsAppendable() const override;
 	bool HasAnyChanges() const override;
 	PersistentColumnData Serialize() override;
 	void InitializeColumn(PersistentColumnData &column_data, BaseStatistics &target_stats) override;

--- a/src/include/duckdb/storage/table/variant_column_data.hpp
+++ b/src/include/duckdb/storage/table/variant_column_data.hpp
@@ -65,6 +65,7 @@ public:
 	                                             const BaseStatistics &old_stats) override;
 
 	bool IsPersistent() override;
+	bool IsAppendable() const override;
 	bool HasAnyChanges() const override;
 	PersistentColumnData Serialize() override;
 	void InitializeColumn(PersistentColumnData &column_data, BaseStatistics &target_stats) override;

--- a/src/storage/table/array_column_data.cpp
+++ b/src/storage/table/array_column_data.cpp
@@ -355,6 +355,10 @@ bool ArrayColumnData::IsPersistent() {
 	return validity->IsPersistent() && child_column->IsPersistent();
 }
 
+bool ArrayColumnData::IsAppendable() const {
+	return child_column->IsAppendable();
+}
+
 bool ArrayColumnData::HasAnyChanges() const {
 	return child_column->HasAnyChanges() || validity->HasAnyChanges();
 }

--- a/src/storage/table/column_data.cpp
+++ b/src/storage/table/column_data.cpp
@@ -744,6 +744,10 @@ bool ColumnData::IsPersistent() {
 	return true;
 }
 
+bool ColumnData::IsAppendable() const {
+	return true;
+}
+
 vector<DataPointer> ColumnData::GetDataPointers() {
 	vector<DataPointer> pointers;
 	idx_t row_start = 0;

--- a/src/storage/table/geo_column_data.cpp
+++ b/src/storage/table/geo_column_data.cpp
@@ -517,6 +517,12 @@ bool GeoColumnData::IsPersistent() {
 	return base_column->IsPersistent();
 }
 
+bool GeoColumnData::IsAppendable() const {
+	// Once this column has been checkpointed into a specialized layout (or holds the legacy spatial format),
+	// the base column no longer matches the GEOMETRY binary format and cannot accept appends.
+	return storage_type == GeometryStorageType::WKB;
+}
+
 bool GeoColumnData::HasAnyChanges() const {
 	return base_column->HasAnyChanges();
 }

--- a/src/storage/table/list_column_data.cpp
+++ b/src/storage/table/list_column_data.cpp
@@ -414,6 +414,10 @@ bool ListColumnData::IsPersistent() {
 	return ColumnData::IsPersistent() && validity->IsPersistent() && child_column->IsPersistent();
 }
 
+bool ListColumnData::IsAppendable() const {
+	return child_column->IsAppendable();
+}
+
 bool ListColumnData::HasAnyChanges() const {
 	return ColumnData::HasAnyChanges() || validity->HasAnyChanges() || child_column->HasAnyChanges();
 }

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -1631,6 +1631,16 @@ bool RowGroup::IsPersistent() const {
 	return true;
 }
 
+bool RowGroup::IsAppendable() const {
+	for (idx_t c = 0; c < columns.size(); c++) {
+		// GetColumn loads the column if it is not loaded yet - appending would load it regardless
+		if (!GetColumn(c).IsAppendable()) {
+			return false;
+		}
+	}
+	return true;
+}
+
 PersistentRowGroupData RowGroup::SerializeRowGroupInfo(idx_t row_group_start) const {
 	// all columns are persistent - serialize
 	PersistentRowGroupData result;

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -185,10 +185,7 @@ void RowGroupCollection::AppendRowGroup(SegmentLock &l, idx_t start_row) {
 	new_row_group->InitializeEmpty(types, GetColumnDataType(start_row));
 	owned_row_groups->AppendSegment(l, std::move(new_row_group), start_row);
 
-	// Do not downgrade from REQUIRE_NEW
-	if (row_group_append_mode <= RowGroupAppendMode::SUGGEST_NEW) {
-		row_group_append_mode = RowGroupAppendMode::APPEND_TO_EXISTING;
-	}
+	row_group_append_mode = RowGroupAppendMode::APPEND_TO_EXISTING;
 }
 
 optional_ptr<RowGroup> RowGroupCollection::GetRowGroup(int64_t index) {
@@ -514,6 +511,11 @@ void RowGroupCollection::InitializeAppend(TransactionData transaction, TableAppe
 			// unless the last row group is full already.
 			needs_new_row_group = row_group_size < state.row_groups->GetLastSegment(l)->GetNode().count;
 		}
+	}
+	if (!needs_new_row_group) {
+		// Some column layouts cannot be appended to once they have been checkpointed (e.g. shredded GEOMETRY).
+		// Ff the last row group contains such a column we always need a new row group, regardless of the append mode
+		needs_new_row_group = !state.row_groups->GetLastSegment(l)->GetNode().IsAppendable();
 	}
 	if (needs_new_row_group) {
 		AppendRowGroup(l, state.row_groups->GetBaseRowId() + total_rows);

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -184,7 +184,11 @@ void RowGroupCollection::AppendRowGroup(SegmentLock &l, idx_t start_row) {
 	auto new_row_group = make_uniq<RowGroup>(*this, 0U);
 	new_row_group->InitializeEmpty(types, GetColumnDataType(start_row));
 	owned_row_groups->AppendSegment(l, std::move(new_row_group), start_row);
-	row_group_append_mode = RowGroupAppendMode::APPEND_TO_EXISTING;
+
+	// Do not downgrade from REQUIRE_NEW
+	if (row_group_append_mode <= RowGroupAppendMode::SUGGEST_NEW) {
+		row_group_append_mode = RowGroupAppendMode::APPEND_TO_EXISTING;
+	}
 }
 
 optional_ptr<RowGroup> RowGroupCollection::GetRowGroup(int64_t index) {

--- a/src/storage/table/struct_column_data.cpp
+++ b/src/storage/table/struct_column_data.cpp
@@ -471,6 +471,15 @@ bool StructColumnData::IsPersistent() {
 	return true;
 }
 
+bool StructColumnData::IsAppendable() const {
+	for (auto &child_col : sub_columns) {
+		if (!child_col->IsAppendable()) {
+			return false;
+		}
+	}
+	return true;
+}
+
 bool StructColumnData::HasAnyChanges() const {
 	if (validity->HasAnyChanges()) {
 		return true;

--- a/src/storage/table/variant_column_data.cpp
+++ b/src/storage/table/variant_column_data.cpp
@@ -757,6 +757,11 @@ bool VariantColumnData::IsPersistent() {
 	return true;
 }
 
+bool VariantColumnData::IsAppendable() const {
+	// Once shredded, the variant column can no longer accept appends (see the guard in Append)
+	return !IsShredded();
+}
+
 bool VariantColumnData::HasAnyChanges() const {
 	if (validity->HasAnyChanges()) {
 		return true;

--- a/test/sql/storage/types/variant/variant_shred_geometry_pk_append.test
+++ b/test/sql/storage/types/variant/variant_shred_geometry_pk_append.test
@@ -1,0 +1,42 @@
+# name: test/sql/storage/types/variant/variant_shred_geometry_pk_append.test
+# description: Append into a re-shredded VARIANT rowgroup through the index append path
+# group: [variant]
+
+# Same shape as test/sql/types/geo/geometry_shred_pk_append.test: the PRIMARY KEY makes
+# LocalStorage::Flush append into the existing rowgroup, which must not land in a column
+# that has been checkpoint-shredded. Shredding the variant on GEOMETRY also covers the
+# nested case of a shredded GEOMETRY column inside a shredded VARIANT column.
+
+load __TEST_DIR__/variant_shred_geometry_pk_append.db readwrite v1.5.0
+
+statement ok
+SET variant_minimum_shredding_size = 0;
+
+statement ok
+SET geometry_minimum_shredding_size = 0;
+
+statement ok
+SET force_variant_shredding = 'GEOMETRY';
+
+statement ok
+CREATE TABLE t(id UUID PRIMARY KEY, v VARIANT);
+
+statement ok
+INSERT INTO t VALUES (uuidv7(), 'POINT (0 1)'::GEOMETRY::VARIANT);
+
+statement ok
+CHECKPOINT
+
+statement ok
+INSERT INTO t VALUES (uuidv7(), 'POINT (0 1)'::GEOMETRY::VARIANT);
+
+statement ok
+CHECKPOINT
+
+statement ok
+INSERT INTO t VALUES (uuidv7(), 'POINT (0 1)'::GEOMETRY::VARIANT);
+
+query I
+SELECT COUNT(*) FROM t WHERE v::GEOMETRY::VARCHAR = 'POINT (0 1)';
+----
+3

--- a/test/sql/storage/types/variant/variant_shredded_pk.test
+++ b/test/sql/storage/types/variant/variant_shredded_pk.test
@@ -1,0 +1,34 @@
+# name: test/sql/storage/types/variant/variant_shredded_pk.test
+# description: Append into a re-shredded rowgroup through the index append path
+# group: [variant]
+
+# Ensure that when appending to a rowgroup, the presence and state of an index does not impact the decision wether
+# a new row segment is created or not.
+
+load __TEST_DIR__/variant_shred_pk_append.db readwrite v1.5.0
+
+statement ok
+SET variant_minimum_shredding_size = 0;
+
+statement ok
+CREATE TABLE t(id UUID PRIMARY KEY, g VARIANT);
+
+statement ok
+INSERT INTO t VALUES (uuidv7(), 'POINT (0 1)'::VARIANT);
+
+statement ok
+CHECKPOINT
+
+statement ok
+INSERT INTO t VALUES (uuidv7(), 'POINT (0 1)'::VARIANT);
+
+statement ok
+CHECKPOINT
+
+statement ok
+INSERT INTO t VALUES (uuidv7(), 'POINT (0 1)'::VARIANT);
+
+query I
+SELECT COUNT(*) FROM t WHERE g::VARCHAR = 'POINT (0 1)';
+----
+3

--- a/test/sql/types/geo/geometry_shred_pk_append.test
+++ b/test/sql/types/geo/geometry_shred_pk_append.test
@@ -1,0 +1,35 @@
+# name: test/sql/types/geo/geometry_shred_pk_append.test
+# description: Append into a re-shredded rowgroup through the index append path
+# group: [geo]
+
+# Ensure that when appending to a rowgroup, the presence and state of an index does not impact the decision wether
+# a new row segment is created or not. If the row group has a non-updateable type (like GEOMETRY), new segments should
+# be created regardless, and the rowgroup should not be marked as updateable.
+
+load __TEST_DIR__/geometry_shred_pk_append.db readwrite v1.5.0
+
+statement ok
+SET geometry_minimum_shredding_size = 0;
+
+statement ok
+CREATE TABLE t(id UUID PRIMARY KEY, g GEOMETRY);
+
+statement ok
+INSERT INTO t VALUES (uuidv7(), 'POINT (0 1)'::GEOMETRY);
+
+statement ok
+CHECKPOINT
+
+statement ok
+INSERT INTO t VALUES (uuidv7(), 'POINT (0 1)'::GEOMETRY);
+
+statement ok
+CHECKPOINT
+
+statement ok
+INSERT INTO t VALUES (uuidv7(), 'POINT (0 1)'::GEOMETRY);
+
+query I
+SELECT COUNT(*) FROM t WHERE g::VARCHAR = 'POINT (0 1)';
+----
+3


### PR DESCRIPTION
This is an alternative to https://github.com/duckdb/duckdb/pull/23719

I still think the other PR is a more elegant solution, but it does not work with `VARIANT` columns, and the expectations they have around the state of a row group. To recap:

- Shredded `GEOMETRY` segments can not be appended to. Appended data lands unshredded in a new row group segment which only gets shredded back on checkpoint. In this sense, geometry shredding is "all or nothing".
- `VARIANT` columns do not generally have this limitation. They store both shredded and "unshredded" data simultaneously in the same row group. They only disallow appends when _fully shredded_. (and therefore in this case also runs into the same issue as geometry columns). But they still _need_ to be able to support appends in the mixed case, we can't just always create new segments or we mess up e.g. the stats when there are multiple mixed variant row groups.
- The `RowGroupCollection` sets `RowGroupAppendMode::REQUIRE_NEW` for tables containing geometry or variant, but `AppendRowGroup` unconditionally resets the mode to `APPEND_TO_EXISTING` the after a new rowgroup is created. That downgrade is correct for the original purpose which was to signal that "the tail rowgroup was just flushed to disk mid-transaction, don't touch it once" to the `OptimisticDataWriter`, or every append splits into separate row groups, for all types. (this is what messes up the variant stats in #23719, vacuum/merging these splintered groups).
- Checkpoint/load/merge storage resets this flag to an advisory `SUGGEST_NEW`, but indexed tables always ignore this suggestion. Because we can't yet vacuum and reorder indexed row groups (row ids need to be stable), we really want to avoid fragmenting if possible, so indexed tables always append to the last row group (unless its full).

So the full failure path is:

1. `INSERT` into an empty table, `LocalStorage::Flush` takes the `MergeStorage` path instead of `AppendRowGroup` and the transaction local rowgroup (1) is moved entirely into the collection - the `RowGroupAppendMode::REQUIRE_NEW` set in the constructor stays armed (as we never got into AppendRowGroup)
2. `CHECKPOINT` shreds the row group, the append mode is set to `RowGroupAppendMode::SUGGEST_NEW`, but we dont downgrade, so it stays `REQUIRE_NEW`.
3. `INSERT` again, this time the table is not empty so we go through `AppendToTable`. `REQUIRE_NEW` forces a fresh row group (2) but after calling `AppendRowGroup` the append mode is changed to `APPEND_TO_EXISTING`.
4. `CHECKPOINT` again, vacuum-merge row groups (1)+(2), re-shred, and set the append mode to `SUGGEST_NEW`.
5. `INSERT` for the third time. Now `SUGGEST_NEW` would have saved us, but because the table has an index (primary key), this suggestion is ignored and we append to the tail row group, which is shredded, but our input is not -> crash!

Essentially, the `RowGroupAppendMode` is used transiently to "debounce" row-group creation, but can _not_ be relied on to uphold the geometry/variant column data persistence invariants.

This PR works around this by letting the `ColumnData` itself (who has a much better idea of the current state of the segment and the invariants that need to hold) to tell the row group wether it can be appended to or not. In the case of `GEOMETRY` and `VARIANT`, this is of course dependent on if it's shredded or not.



