### PR TITLE
Make DataChunk::size() and optional_idx accessors inlineable

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -65,6 +65,7 @@ add_library_unity(
   memory_mapped_file.cpp
   error_data.cpp
   opener_file_system.cpp
+  optional_idx.cpp
   printer.cpp
   radix_partitioning.cpp
   re2_regex.cpp

--- a/src/common/optional_idx.cpp
+++ b/src/common/optional_idx.cpp
@@ -1,0 +1,13 @@
+#include "duckdb/common/optional_idx.hpp"
+
+namespace duckdb {
+
+void optional_idx::ThrowInvalidInitialization() {
+	throw InternalException("optional_idx cannot be initialized with an invalid index");
+}
+
+void optional_idx::ThrowNotSet() {
+	throw InternalException("Attempting to get the index of an optional_idx that is not set");
+}
+
+} // namespace duckdb

--- a/src/common/types/data_chunk.cpp
+++ b/src/common/types/data_chunk.cpp
@@ -74,6 +74,20 @@ void DataChunk::Initialize(Allocator &allocator, const vector<LogicalType> &type
 	}
 }
 
+idx_t DataChunk::DeriveSize() const {
+	for (const auto &v : data) {
+		if (v.GetBufferRef()) {
+			return v.size();
+		}
+	}
+	if (data.empty()) {
+		// a column-less chunk has nothing to derive a cardinality from; without an explicit count it is empty
+		return 0;
+	}
+	throw InternalException(
+	    "DataChunk::size() called but neither count was set, nor any vectors with valid counts were set");
+}
+
 idx_t DataChunk::GetDataSize() const {
 	idx_t total_size = 0;
 	for (auto &vec : data) {

--- a/src/include/duckdb/common/optional_idx.hpp
+++ b/src/include/duckdb/common/optional_idx.hpp
@@ -20,7 +20,7 @@ public:
 	}
 	optional_idx(idx_t index) : index(index) { // NOLINT: allow implicit conversion from idx_t
 		if (index == INVALID_INDEX) {
-			throw InternalException("optional_idx cannot be initialized with an invalid index");
+			ThrowInvalidInitialization();
 		}
 	}
 
@@ -38,7 +38,7 @@ public:
 
 	idx_t GetIndex() const {
 		if (index == INVALID_INDEX) {
-			throw InternalException("Attempting to get the index of an optional_idx that is not set");
+			ThrowNotSet();
 		}
 		return index;
 	}
@@ -50,6 +50,11 @@ public:
 	inline bool operator!=(const optional_idx &rhs) const {
 		return index != rhs.index;
 	}
+
+private:
+	//! Kept out-of-line so that the throwing paths do not block inlining of the accessors
+	[[noreturn]] DUCKDB_API static void ThrowInvalidInitialization();
+	[[noreturn]] DUCKDB_API static void ThrowNotSet();
 
 private:
 	idx_t index;

--- a/src/include/duckdb/common/types/data_chunk.hpp
+++ b/src/include/duckdb/common/types/data_chunk.hpp
@@ -55,17 +55,7 @@ public:
 		if (count.IsValid()) {
 			return count.GetIndex();
 		}
-		for (const auto &v : data) {
-			if (v.GetBufferRef()) {
-				return v.size();
-			}
-		}
-		if (data.empty()) {
-			// a column-less chunk has nothing to derive a cardinality from; without an explicit count it is empty
-			return 0;
-		}
-		throw InternalException(
-		    "DataChunk::size() called but neither count was set, nor any vectors with valid counts were set");
+		return DeriveSize();
 	}
 	inline idx_t ColumnCount() const {
 		return data.size();
@@ -200,5 +190,8 @@ private:
 
 private:
 	void VerifyInternal(DebugVerificationMode mode, optional_ptr<DatabaseInstance> db);
+	//! Derives the cardinality from the child vectors when no explicit count is set.
+	//! Kept out-of-line so that ::size() inlines down to a load and a branch.
+	DUCKDB_API idx_t DeriveSize() const;
 };
 } // namespace duckdb


### PR DESCRIPTION
Since count became an optional_idx, DataChunk::size() has carried a loop over the child vectors and a throw. Its fast path also calls optional_idx::GetIndex(), which throws too. Constructing an InternalException (exception allocation, std::string, ctor) is charged by clang's inline cost model even on a cold path, so neither function was inlined: libduckdb.dylib contained 1251 out-of-line calls to DataChunk::size(), each one two nested calls and a stack frame. Inside a loop the call also acts as an optimization barrier.

Move the throwing paths out of line behind [[noreturn]] helpers, and move size()'s vector-scan fallback into DataChunk::DeriveSize(). size() now compiles to a load and a branch, and all 1251 call sites inline away.

This should "just" move around code, and might make micro optimizations such as https://github.com/duckdb/duckdb/pull/23730 (thanks @gropaul for asking the right question) handled automatically by the compiler.


Edit CI result are in, for example: TPCDS SF3
```
Old timing geometric mean: 0.025611740414803262
New timing geometric mean: 0.022280849083911647, roughly 13% faster
```
(other benchmarks are neutral, but might be worth a review)