### PR TITLE
Implement stats propagation callback for `prefix`

### DIFF
--- a/src/function/scalar/string/prefix.cpp
+++ b/src/function/scalar/string/prefix.cpp
@@ -1,11 +1,10 @@
 #include "duckdb/function/scalar/string_functions.hpp"
+#include "duckdb/common/exception.hpp"
 #include "duckdb/common/types/string_type.hpp"
 #include "duckdb/common/types/value.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/storage/statistics/base_statistics.hpp"
 #include "duckdb/storage/statistics/string_stats.hpp"
-
-#include "duckdb/common/exception.hpp"
 
 namespace duckdb {
 
@@ -63,15 +62,16 @@ struct PrefixOperator {
 	}
 };
 
-// Find the next prefix of the given string
+// Update the prefix to be the next string of the given one, which is with less or equal length to the given prefix
 bool FindNextPrefix(string &prefix) {
 	for (idx_t idx = prefix.size(); idx > 0; idx--) {
 		auto c = static_cast<uint8_t>(prefix[idx - 1]);
-		if (c < 0xFF) {
-			prefix[idx - 1] = static_cast<char>(c + 1);
-			prefix.resize(idx);
-			return true;
+		if (c == 0xFF) {
+			continue;
 		}
+		prefix[idx - 1] = static_cast<char>(c + 1);
+		prefix.resize(idx);
+		return true;
 	}
 	return false;
 }
@@ -88,15 +88,16 @@ FilterPropagateResult PrefixFilterPrune(const FunctionStatisticsPruneInput &inpu
 	if (!column_stats || column_stats->GetStatsType() != StatisticsType::STRING_STATS) {
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 	}
+	// If all rows are null, always false
 	if (!column_stats->CanHaveNoNull()) {
 		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
 	}
-
+	// If the constant is null, always false
 	auto &constant = children[1]->Cast<BoundConstantExpression>().GetValue();
 	if (constant.IsNull()) {
 		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
 	}
-
+	// Handle empty prefix
 	auto prefix = StringValue::Get(constant);
 	if (prefix.empty()) {
 		return column_stats->CanHaveNull() ? FilterPropagateResult::NO_PRUNING_POSSIBLE
@@ -115,8 +116,8 @@ FilterPropagateResult PrefixFilterPrune(const FunctionStatisticsPruneInput &inpu
 	const auto max = StringStats::Max(*column_stats);
 
 	// prefix > max, always false
-	if (StringStats::Compare(string_t(prefix.c_str(), prefix.size()), string_t(max.c_str(), max.size()),
-	                         StringStats::GetMaxType(*column_stats)) > 0) {
+	if (StringStats::CompareStringStats(string_t(prefix.c_str(), prefix.size()), string_t(max.c_str(), max.size()),
+	                                    StringStats::GetMaxType(*column_stats)) > 0) {
 		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
 	}
 
@@ -124,8 +125,8 @@ FilterPropagateResult PrefixFilterPrune(const FunctionStatisticsPruneInput &inpu
 	auto upper_bound = prefix;
 	if (FindNextPrefix(upper_bound)) {
 		const auto min_compare =
-		    StringStats::Compare(string_t(upper_bound.c_str(), upper_bound.size()), string_t(min.c_str(), min.size()),
-		                         StringStats::GetMinType(*column_stats));
+		    StringStats::CompareStringStats(string_t(upper_bound.c_str(), upper_bound.size()),
+		                                    string_t(min.c_str(), min.size()), StringStats::GetMinType(*column_stats));
 		if (min_compare < 0) {
 			return FilterPropagateResult::FILTER_ALWAYS_FALSE;
 		}

--- a/src/function/scalar/string/prefix.cpp
+++ b/src/function/scalar/string/prefix.cpp
@@ -1,5 +1,4 @@
 #include "duckdb/function/scalar/string_functions.hpp"
-#include "duckdb/common/operator/comparison_operators.hpp"
 #include "duckdb/common/types/string_type.hpp"
 #include "duckdb/common/types/value.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
@@ -64,13 +63,6 @@ struct PrefixOperator {
 	}
 };
 
-int8_t CompareStringStats(string_t input, string_t stats, StringStatsType type) {
-	if (type == StringStatsType::TRUNCATED_STATS && input.GetSize() > stats.GetSize()) {
-		return Comparator::Operation(string_t(input.GetData(), static_cast<uint32_t>(stats.GetSize())), stats);
-	}
-	return Comparator::Operation(input, stats);
-}
-
 // Find the next prefix of the given string
 bool FindNextPrefix(string &prefix) {
 	for (idx_t idx = prefix.size(); idx > 0; idx--) {
@@ -119,21 +111,21 @@ FilterPropagateResult PrefixFilterPrune(const FunctionStatisticsPruneInput &inpu
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 	}
 
-	auto min = StringStats::Min(*column_stats);
-	auto max = StringStats::Max(*column_stats);
+	const auto min = StringStats::Min(*column_stats);
+	const auto max = StringStats::Max(*column_stats);
 
 	// prefix > max, always false
-	if (CompareStringStats(string_t(prefix.c_str(), prefix.size()), string_t(max.c_str(), max.size()),
-	                       StringStats::GetMaxType(*column_stats)) > 0) {
+	if (StringStats::Compare(string_t(prefix.c_str(), prefix.size()), string_t(max.c_str(), max.size()),
+	                         StringStats::GetMaxType(*column_stats)) > 0) {
 		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
 	}
 
 	// next(prefix) <= min, always false
 	auto upper_bound = prefix;
 	if (FindNextPrefix(upper_bound)) {
-		auto min_compare =
-		    CompareStringStats(string_t(upper_bound.c_str(), upper_bound.size()), string_t(min.c_str(), min.size()),
-		                       StringStats::GetMinType(*column_stats));
+		const auto min_compare =
+		    StringStats::Compare(string_t(upper_bound.c_str(), upper_bound.size()), string_t(min.c_str(), min.size()),
+		                         StringStats::GetMinType(*column_stats));
 		if (min_compare < 0) {
 			return FilterPropagateResult::FILTER_ALWAYS_FALSE;
 		}

--- a/src/function/scalar/string/prefix.cpp
+++ b/src/function/scalar/string/prefix.cpp
@@ -112,8 +112,7 @@ FilterPropagateResult PrefixFilterPrune(const FunctionStatisticsPruneInput &inpu
 	}
 
 	// Then check row group pruning with string stats min/max.
-	if (StringStats::HasMaxStringLength(*column_stats) &&
-	    StringStats::MaxStringLength(*column_stats) < prefix.size()) {
+	if (StringStats::HasMaxStringLength(*column_stats) && StringStats::MaxStringLength(*column_stats) < prefix.size()) {
 		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
 	}
 	if (!StringStats::HasMinMax(*column_stats)) {

--- a/src/function/scalar/string/prefix.cpp
+++ b/src/function/scalar/string/prefix.cpp
@@ -7,7 +7,6 @@
 #include "duckdb/storage/statistics/string_stats.hpp"
 
 #include "duckdb/common/exception.hpp"
-#include "utf8proc_wrapper.hpp"
 
 namespace duckdb {
 
@@ -65,15 +64,30 @@ struct PrefixOperator {
 	}
 };
 
-static int8_t CompareStringStats(string_t input, string_t stats, StringStatsType type) {
+int8_t CompareStringStats(string_t input, string_t stats, StringStatsType type) {
 	if (type == StringStatsType::TRUNCATED_STATS && input.GetSize() > stats.GetSize()) {
 		return Comparator::Operation(string_t(input.GetData(), static_cast<uint32_t>(stats.GetSize())), stats);
 	}
 	return Comparator::Operation(input, stats);
 }
 
-static FilterPropagateResult PrefixFilterPrune(const FunctionStatisticsPruneInput &input) {
+// Find the next prefix of the given string
+bool FindNextPrefix(string &prefix) {
+	for (idx_t idx = prefix.size(); idx > 0; idx--) {
+		auto c = static_cast<uint8_t>(prefix[idx - 1]);
+		if (c < 0xFF) {
+			prefix[idx - 1] = static_cast<char>(c + 1);
+			prefix.resize(idx);
+			return true;
+		}
+	}
+	return false;
+}
+
+FilterPropagateResult PrefixFilterPrune(const FunctionStatisticsPruneInput &input) {
 	auto &children = input.function.GetChildren();
+
+	// First check whether it's possible to prune completely.
 	if (children.size() != 2 || children[1]->GetExpressionType() != ExpressionType::VALUE_CONSTANT) {
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 	}
@@ -96,6 +110,8 @@ static FilterPropagateResult PrefixFilterPrune(const FunctionStatisticsPruneInpu
 		return column_stats->CanHaveNull() ? FilterPropagateResult::NO_PRUNING_POSSIBLE
 		                                   : FilterPropagateResult::FILTER_ALWAYS_TRUE;
 	}
+
+	// Then check row group pruning with string stats min/max.
 	if (StringStats::HasMaxStringLength(*column_stats) &&
 	    StringStats::MaxStringLength(*column_stats) < prefix.size()) {
 		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
@@ -106,18 +122,23 @@ static FilterPropagateResult PrefixFilterPrune(const FunctionStatisticsPruneInpu
 
 	auto min = StringStats::Min(*column_stats);
 	auto max = StringStats::Max(*column_stats);
+
+	// prefix > max, always false
 	if (CompareStringStats(string_t(prefix.c_str(), prefix.size()), string_t(max.c_str(), max.size()),
 	                       StringStats::GetMaxType(*column_stats)) > 0) {
 		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
 	}
 
+	// next(prefix) <= min, always false
 	auto upper_bound = prefix;
-	if (Utf8Proc::FindNextLegalUTF8(upper_bound)) {
+	if (FindNextPrefix(upper_bound)) {
 		auto min_compare =
 		    CompareStringStats(string_t(upper_bound.c_str(), upper_bound.size()), string_t(min.c_str(), min.size()),
 		                       StringStats::GetMinType(*column_stats));
-		if (min_compare < 0 ||
-		    (min_compare == 0 && StringStats::GetMinType(*column_stats) == StringStatsType::EXACT_STATS)) {
+		if (min_compare < 0) {
+			return FilterPropagateResult::FILTER_ALWAYS_FALSE;
+		}
+		if (min_compare == 0 && StringStats::GetMinType(*column_stats) == StringStatsType::EXACT_STATS) {
 			return FilterPropagateResult::FILTER_ALWAYS_FALSE;
 		}
 	}

--- a/src/function/scalar/string/prefix.cpp
+++ b/src/function/scalar/string/prefix.cpp
@@ -3,6 +3,7 @@
 #include "duckdb/common/types/string_type.hpp"
 #include "duckdb/common/types/value.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/storage/statistics/base_statistics.hpp"
 #include "duckdb/storage/statistics/string_stats.hpp"
 

--- a/src/function/scalar/string/prefix.cpp
+++ b/src/function/scalar/string/prefix.cpp
@@ -1,7 +1,13 @@
 #include "duckdb/function/scalar/string_functions.hpp"
+#include "duckdb/common/operator/comparison_operators.hpp"
 #include "duckdb/common/types/string_type.hpp"
+#include "duckdb/common/types/value.hpp"
+#include "duckdb/planner/expression/bound_constant_expression.hpp"
+#include "duckdb/storage/statistics/base_statistics.hpp"
+#include "duckdb/storage/statistics/string_stats.hpp"
 
 #include "duckdb/common/exception.hpp"
+#include "utf8proc_wrapper.hpp"
 
 namespace duckdb {
 
@@ -59,13 +65,74 @@ struct PrefixOperator {
 	}
 };
 
+static int8_t CompareStringStats(string_t input, string_t stats, StringStatsType type) {
+	if (type == StringStatsType::TRUNCATED_STATS && input.GetSize() > stats.GetSize()) {
+		return Comparator::Operation(string_t(input.GetData(), static_cast<uint32_t>(stats.GetSize())), stats);
+	}
+	return Comparator::Operation(input, stats);
+}
+
+static FilterPropagateResult PrefixFilterPrune(const FunctionStatisticsPruneInput &input) {
+	auto &children = input.function.GetChildren();
+	if (children.size() != 2 || children[1]->GetExpressionType() != ExpressionType::VALUE_CONSTANT) {
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+
+	auto column_stats = input.ChildStats(0);
+	if (!column_stats || column_stats->GetStatsType() != StatisticsType::STRING_STATS) {
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+	if (!column_stats->CanHaveNoNull()) {
+		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
+	}
+
+	auto &constant = children[1]->Cast<BoundConstantExpression>().GetValue();
+	if (constant.IsNull()) {
+		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
+	}
+
+	auto prefix = StringValue::Get(constant);
+	if (prefix.empty()) {
+		return column_stats->CanHaveNull() ? FilterPropagateResult::NO_PRUNING_POSSIBLE
+		                                   : FilterPropagateResult::FILTER_ALWAYS_TRUE;
+	}
+	if (StringStats::HasMaxStringLength(*column_stats) &&
+	    StringStats::MaxStringLength(*column_stats) < prefix.size()) {
+		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
+	}
+	if (!StringStats::HasMinMax(*column_stats)) {
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+
+	auto min = StringStats::Min(*column_stats);
+	auto max = StringStats::Max(*column_stats);
+	if (CompareStringStats(string_t(prefix.c_str(), prefix.size()), string_t(max.c_str(), max.size()),
+	                       StringStats::GetMaxType(*column_stats)) > 0) {
+		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
+	}
+
+	auto upper_bound = prefix;
+	if (Utf8Proc::FindNextLegalUTF8(upper_bound)) {
+		auto min_compare =
+		    CompareStringStats(string_t(upper_bound.c_str(), upper_bound.size()), string_t(min.c_str(), min.size()),
+		                       StringStats::GetMinType(*column_stats));
+		if (min_compare < 0 ||
+		    (min_compare == 0 && StringStats::GetMinType(*column_stats) == StringStatsType::EXACT_STATS)) {
+			return FilterPropagateResult::FILTER_ALWAYS_FALSE;
+		}
+	}
+	return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+}
+
 } // namespace
 
 ScalarFunction PrefixFun::GetFunction() {
-	return ScalarFunction("prefix",                                     // name of the function
-	                      {LogicalType::VARCHAR, LogicalType::VARCHAR}, // argument list
-	                      LogicalType::BOOLEAN,                         // return type
-	                      ScalarFunction::BinaryFunction<string_t, string_t, bool, PrefixOperator>);
+	ScalarFunction function("prefix",                                     // name of the function
+	                        {LogicalType::VARCHAR, LogicalType::VARCHAR}, // argument list
+	                        LogicalType::BOOLEAN,                         // return type
+	                        ScalarFunction::BinaryFunction<string_t, string_t, bool, PrefixOperator>);
+	function.SetFilterPruneCallback(PrefixFilterPrune);
+	return function;
 }
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/statistics/string_stats.hpp
+++ b/src/include/duckdb/storage/statistics/string_stats.hpp
@@ -116,6 +116,7 @@ struct StringStats {
 
 	DUCKDB_API static FilterPropagateResult CheckZonemap(const BaseStatistics &stats, ExpressionType comparison_type,
 	                                                     array_ptr<const Value> constants);
+	DUCKDB_API static int8_t Compare(string_t input, string_t stats, StringStatsType type);
 	DUCKDB_API static FilterPropagateResult CheckZonemap(string_t min, StringStatsType min_type, string_t max,
 	                                                     StringStatsType max_type, ExpressionType comparison_type,
 	                                                     string_t constant);

--- a/src/include/duckdb/storage/statistics/string_stats.hpp
+++ b/src/include/duckdb/storage/statistics/string_stats.hpp
@@ -116,7 +116,7 @@ struct StringStats {
 
 	DUCKDB_API static FilterPropagateResult CheckZonemap(const BaseStatistics &stats, ExpressionType comparison_type,
 	                                                     array_ptr<const Value> constants);
-	DUCKDB_API static int8_t Compare(string_t input, string_t stats, StringStatsType type);
+	DUCKDB_API static int8_t CompareStringStats(string_t input, string_t stats, StringStatsType type);
 	DUCKDB_API static FilterPropagateResult CheckZonemap(string_t min, StringStatsType min_type, string_t max,
 	                                                     StringStatsType max_type, ExpressionType comparison_type,
 	                                                     string_t constant);

--- a/src/storage/statistics/string_stats.cpp
+++ b/src/storage/statistics/string_stats.cpp
@@ -719,7 +719,7 @@ FilterPropagateResult StringStats::CheckZonemap(const BaseStatistics &stats, Exp
 	return FilterPropagateResult::FILTER_ALWAYS_FALSE;
 }
 
-int8_t CompareStringStats(string_t input, string_t stats, StringStatsType type) {
+int8_t StringStats::Compare(string_t input, string_t stats, StringStatsType type) {
 	if (type == StringStatsType::TRUNCATED_STATS && input.GetSize() > stats.GetSize()) {
 		// if the stats are truncated we can only compare at most the bytes as are present in the stats
 		return Comparator::Operation(string_t(input.GetData(), static_cast<uint32_t>(stats.GetSize())), stats);
@@ -730,8 +730,8 @@ int8_t CompareStringStats(string_t input, string_t stats, StringStatsType type) 
 FilterPropagateResult StringStats::CheckZonemap(string_t min, StringStatsType min_type, string_t max,
                                                 StringStatsType max_type, ExpressionType comparison_type,
                                                 string_t constant) {
-	auto min_comp = CompareStringStats(constant, min, min_type);
-	auto max_comp = CompareStringStats(constant, max, max_type);
+	auto min_comp = Compare(constant, min, min_type);
+	auto max_comp = Compare(constant, max, max_type);
 	switch (comparison_type) {
 	case ExpressionType::COMPARE_EQUAL:
 	case ExpressionType::COMPARE_NOT_DISTINCT_FROM:
@@ -821,14 +821,14 @@ void StringStats::Verify(const BaseStatistics &stats, const Vector &vector, cons
 			}
 		}
 		if (StatsIsSet(string_data.min_type)) {
-			auto min_cmp = CompareStringStats(value, string_data.min, string_data.min_type);
+			auto min_cmp = Compare(value, string_data.min, string_data.min_type);
 			if (min_cmp < 0) {
 				throw InternalException("Statistics mismatch: value is smaller than min.\nStatistics: %s\nVector: %s",
 				                        stats.ToString(), vector.ToString());
 			}
 		}
 		if (StatsIsSet(string_data.max_type)) {
-			auto max_cmp = CompareStringStats(value, string_data.max, string_data.max_type);
+			auto max_cmp = Compare(value, string_data.max, string_data.max_type);
 			if (max_cmp > 0) {
 				throw InternalException("Statistics mismatch: value is bigger than max.\nStatistics: %s\nVector: %s",
 				                        stats.ToString(), vector.ToString());

--- a/src/storage/statistics/string_stats.cpp
+++ b/src/storage/statistics/string_stats.cpp
@@ -719,7 +719,7 @@ FilterPropagateResult StringStats::CheckZonemap(const BaseStatistics &stats, Exp
 	return FilterPropagateResult::FILTER_ALWAYS_FALSE;
 }
 
-int8_t StringStats::Compare(string_t input, string_t stats, StringStatsType type) {
+int8_t StringStats::CompareStringStats(string_t input, string_t stats, StringStatsType type) {
 	if (type == StringStatsType::TRUNCATED_STATS && input.GetSize() > stats.GetSize()) {
 		// if the stats are truncated we can only compare at most the bytes as are present in the stats
 		return Comparator::Operation(string_t(input.GetData(), static_cast<uint32_t>(stats.GetSize())), stats);
@@ -730,8 +730,8 @@ int8_t StringStats::Compare(string_t input, string_t stats, StringStatsType type
 FilterPropagateResult StringStats::CheckZonemap(string_t min, StringStatsType min_type, string_t max,
                                                 StringStatsType max_type, ExpressionType comparison_type,
                                                 string_t constant) {
-	auto min_comp = Compare(constant, min, min_type);
-	auto max_comp = Compare(constant, max, max_type);
+	auto min_comp = CompareStringStats(constant, min, min_type);
+	auto max_comp = CompareStringStats(constant, max, max_type);
 	switch (comparison_type) {
 	case ExpressionType::COMPARE_EQUAL:
 	case ExpressionType::COMPARE_NOT_DISTINCT_FROM:
@@ -821,14 +821,14 @@ void StringStats::Verify(const BaseStatistics &stats, const Vector &vector, cons
 			}
 		}
 		if (StatsIsSet(string_data.min_type)) {
-			auto min_cmp = Compare(value, string_data.min, string_data.min_type);
+			auto min_cmp = CompareStringStats(value, string_data.min, string_data.min_type);
 			if (min_cmp < 0) {
 				throw InternalException("Statistics mismatch: value is smaller than min.\nStatistics: %s\nVector: %s",
 				                        stats.ToString(), vector.ToString());
 			}
 		}
 		if (StatsIsSet(string_data.max_type)) {
-			auto max_cmp = Compare(value, string_data.max, string_data.max_type);
+			auto max_cmp = CompareStringStats(value, string_data.max, string_data.max_type);
 			if (max_cmp > 0) {
 				throw InternalException("Statistics mismatch: value is bigger than max.\nStatistics: %s\nVector: %s",
 				                        stats.ToString(), vector.ToString());

--- a/test/sql/copy/parquet/parquet_expression_filter_pruning.test
+++ b/test/sql/copy/parquet/parquet_expression_filter_pruning.test
@@ -257,35 +257,6 @@ ReadRowGroup	4
 statement ok
 CALL truncate_duckdb_logs()
 
-# When exact min equals next_prefix(prefix), no string can match the prefix filter
-statement ok
-COPY (
-	SELECT 'aab'::VARCHAR AS s
-	UNION ALL SELECT 'aac'
-	UNION ALL SELECT 'aba'
-) TO '{TEST_DIR}/expr_prune_prefix_exact_min.parquet' (FORMAT PARQUET, ROW_GROUP_SIZE 100)
-
-statement ok
-CALL enable_logging('PhysicalOperator')
-
-query I
-SELECT count(*)
-FROM '{TEST_DIR}/expr_prune_prefix_exact_min.parquet'
-WHERE prefix(s, 'aaa')
-----
-0
-
-statement ok
-CALL disable_logging()
-
-query II
-SELECT event, count(*) FROM duckdb_logs_parsed('PhysicalOperator') WHERE class='ParquetReader' GROUP BY event ORDER BY event
-----
-SkipRowGroup	1
-
-statement ok
-CALL truncate_duckdb_logs()
-
 # Byte-wise prefix successor should prune across a UTF-8 byte boundary
 statement ok
 COPY (

--- a/test/sql/copy/parquet/parquet_expression_filter_pruning.test
+++ b/test/sql/copy/parquet/parquet_expression_filter_pruning.test
@@ -138,9 +138,6 @@ COPY (
 	FROM range(8192)
 ) TO '{TEST_DIR}/expr_prune_prefix_or.parquet' (FORMAT PARQUET, ROW_GROUP_SIZE 2048)
 
-statement ok
-CALL enable_logging('PhysicalOperator')
-
 query II
 SELECT count(*), sum(x)
 FROM '{TEST_DIR}/expr_prune_prefix_or.parquet'
@@ -148,21 +145,16 @@ WHERE s LIKE 'p0000%' OR s LIKE 'p0050%'
 ----
 200	509900
 
-statement ok
-CALL disable_logging()
-
 query II
-SELECT event, count(*) FROM duckdb_logs_parsed('PhysicalOperator') WHERE class='ParquetReader' GROUP BY event ORDER BY event
+EXPLAIN ANALYZE SELECT count(*), sum(x)
+FROM '{TEST_DIR}/expr_prune_prefix_or.parquet'
+WHERE s LIKE 'p0000%' OR s LIKE 'p0050%'
 ----
-ReadRowGroup	2
-SkipRowGroup	2
-
-statement ok
-CALL truncate_duckdb_logs()
+analyzed_plan	<REGEX>:(?s).*Row Groups Scanned: 2 / 4.*
 
 # Prefix pruning corner cases: NULL-only row groups, empty prefixes, NULL prefixes, and non-constant prefixes
 statement ok
-COPY (
+CREATE TABLE expr_prune_prefix_corner AS
 	SELECT range::INTEGER AS x,
 		CASE
 			WHEN range < 2048 THEN NULL
@@ -172,11 +164,9 @@ COPY (
 		END AS s,
 		CASE WHEN range % 2 = 0 THEN 'a' ELSE 'b' END AS p
 	FROM range(8192)
-) TO '{TEST_DIR}/expr_prune_prefix_corner.parquet' (FORMAT PARQUET, ROW_GROUP_SIZE 2048)
 
-# NULL-only, lower, and upper row groups are skipped
 statement ok
-CALL enable_logging('PhysicalOperator')
+COPY expr_prune_prefix_corner TO '{TEST_DIR}/expr_prune_prefix_corner.parquet' (FORMAT PARQUET, ROW_GROUP_SIZE 2048)
 
 query I
 SELECT count(*)
@@ -185,22 +175,24 @@ WHERE prefix(s, 'b')
 ----
 2048
 
-statement ok
-CALL disable_logging()
-
 query II
-SELECT event, count(*) FROM duckdb_logs_parsed('PhysicalOperator') WHERE class='ParquetReader' GROUP BY event ORDER BY event
+EXPLAIN ANALYZE SELECT count(*)
+FROM '{TEST_DIR}/expr_prune_prefix_corner.parquet'
+WHERE prefix(s, 'b')
 ----
-ReadRowGroup	1
-SkipRowGroup	3
-
-statement ok
-CALL truncate_duckdb_logs()
+analyzed_plan	<REGEX>:(?s).*Row Groups Scanned: 1 / 4.*
 
 # Empty prefixes match all non-NULL strings but not NULL strings
+query II
+EXPLAIN ANALYZE SELECT count(*)
+FROM expr_prune_prefix_corner
+WHERE prefix(s, '')
+----
+analyzed_plan	<REGEX>:(?s).*Sequential Scan.*6,144 rows.*
+
 query I
 SELECT count(*)
-FROM '{TEST_DIR}/expr_prune_prefix_corner.parquet'
+FROM expr_prune_prefix_corner
 WHERE prefix(s, '')
 ----
 6144
@@ -214,9 +206,6 @@ WHERE prefix(s, NULL::VARCHAR)
 physical_plan	<REGEX>:.*EMPTY_RESULT.*
 
 # Prefixes longer than the maximum string length can never match
-statement ok
-CALL enable_logging('PhysicalOperator')
-
 query I
 SELECT count(*)
 FROM '{TEST_DIR}/expr_prune_prefix_corner.parquet'
@@ -224,21 +213,14 @@ WHERE prefix(s, 'bbbbbbbb')
 ----
 0
 
-statement ok
-CALL disable_logging()
-
 query II
-SELECT event, count(*) FROM duckdb_logs_parsed('PhysicalOperator') WHERE class='ParquetReader' GROUP BY event ORDER BY event
+EXPLAIN ANALYZE SELECT count(*)
+FROM '{TEST_DIR}/expr_prune_prefix_corner.parquet'
+WHERE prefix(s, 'bbbbbbbb')
 ----
-SkipRowGroup	4
-
-statement ok
-CALL truncate_duckdb_logs()
+analyzed_plan	<REGEX>:(?s).*Row Groups Scanned: 0 / 4.*
 
 # Non-constant prefixes are not pruned using constant-prefix statistics
-statement ok
-CALL enable_logging('PhysicalOperator')
-
 query I
 SELECT count(*)
 FROM '{TEST_DIR}/expr_prune_prefix_corner.parquet'
@@ -246,16 +228,12 @@ WHERE prefix(s, p)
 ----
 2048
 
-statement ok
-CALL disable_logging()
-
 query II
-SELECT event, count(*) FROM duckdb_logs_parsed('PhysicalOperator') WHERE class='ParquetReader' GROUP BY event ORDER BY event
+EXPLAIN ANALYZE SELECT count(*)
+FROM '{TEST_DIR}/expr_prune_prefix_corner.parquet'
+WHERE prefix(s, p)
 ----
-ReadRowGroup	4
-
-statement ok
-CALL truncate_duckdb_logs()
+analyzed_plan	<REGEX>:(?s).*Row Groups Scanned: 4 / 4.*
 
 # Byte-wise prefix successor should prune across a UTF-8 byte boundary
 statement ok
@@ -264,9 +242,6 @@ COPY (
 	FROM range(4096)
 ) TO '{TEST_DIR}/expr_prune_prefix_utf8_boundary.parquet' (FORMAT PARQUET, ROW_GROUP_SIZE 2048)
 
-statement ok
-CALL enable_logging('PhysicalOperator')
-
 query I
 SELECT count(*)
 FROM '{TEST_DIR}/expr_prune_prefix_utf8_boundary.parquet'
@@ -274,14 +249,9 @@ WHERE prefix(s, chr(255))
 ----
 2048
 
-statement ok
-CALL disable_logging()
-
 query II
-SELECT event, count(*) FROM duckdb_logs_parsed('PhysicalOperator') WHERE class='ParquetReader' GROUP BY event ORDER BY event
+EXPLAIN ANALYZE SELECT count(*)
+FROM '{TEST_DIR}/expr_prune_prefix_utf8_boundary.parquet'
+WHERE prefix(s, chr(255))
 ----
-ReadRowGroup	1
-SkipRowGroup	1
-
-statement ok
-CALL truncate_duckdb_logs()
+analyzed_plan	<REGEX>:(?s).*Row Groups Scanned: 1 / 2.*

--- a/test/sql/copy/parquet/parquet_expression_filter_pruning.test
+++ b/test/sql/copy/parquet/parquet_expression_filter_pruning.test
@@ -130,3 +130,32 @@ ReadRowGroup	10
 
 statement ok
 CALL truncate_duckdb_logs()
+
+# OR of prefix predicates should still prune row groups that cannot match any branch
+statement ok
+COPY (
+	SELECT range::INTEGER AS x, 'p' || lpad(range::VARCHAR, 6, '0') AS s
+	FROM range(8192)
+) TO '{TEST_DIR}/expr_prune_prefix_or.parquet' (FORMAT PARQUET, ROW_GROUP_SIZE 2048)
+
+statement ok
+CALL enable_logging('PhysicalOperator')
+
+query II
+SELECT count(*), sum(x)
+FROM '{TEST_DIR}/expr_prune_prefix_or.parquet'
+WHERE s LIKE 'p0000%' OR s LIKE 'p0050%'
+----
+200	509900
+
+statement ok
+CALL disable_logging()
+
+query II
+SELECT event, count(*) FROM duckdb_logs_parsed('PhysicalOperator') WHERE class='ParquetReader' GROUP BY event ORDER BY event
+----
+ReadRowGroup	2
+SkipRowGroup	2
+
+statement ok
+CALL truncate_duckdb_logs()

--- a/test/sql/copy/parquet/parquet_expression_filter_pruning.test
+++ b/test/sql/copy/parquet/parquet_expression_filter_pruning.test
@@ -141,14 +141,14 @@ COPY (
 query II
 SELECT count(*), sum(x)
 FROM '{TEST_DIR}/expr_prune_prefix_or.parquet'
-WHERE s LIKE 'p0000%' OR s LIKE 'p0050%'
+WHERE prefix(s, 'p0000') OR prefix(s, 'p0050')
 ----
 200	509900
 
 query II
 EXPLAIN ANALYZE SELECT count(*), sum(x)
 FROM '{TEST_DIR}/expr_prune_prefix_or.parquet'
-WHERE s LIKE 'p0000%' OR s LIKE 'p0050%'
+WHERE prefix(s, 'p0000') OR prefix(s, 'p0050')
 ----
 analyzed_plan	<REGEX>:(?s).*Row Groups Scanned: 2 / 4.*
 
@@ -171,52 +171,44 @@ COPY expr_prune_prefix_corner TO '{TEST_DIR}/expr_prune_prefix_corner.parquet' (
 query I
 SELECT count(*)
 FROM '{TEST_DIR}/expr_prune_prefix_corner.parquet'
-WHERE prefix(s, 'b')
+WHERE prefix(s, 'b') OR prefix(s, 'd')
 ----
 2048
 
 query II
 EXPLAIN ANALYZE SELECT count(*)
 FROM '{TEST_DIR}/expr_prune_prefix_corner.parquet'
-WHERE prefix(s, 'b')
+WHERE prefix(s, 'b') OR prefix(s, 'd')
 ----
 analyzed_plan	<REGEX>:(?s).*Row Groups Scanned: 1 / 4.*
 
 # Empty prefixes match all non-NULL strings but not NULL strings
 query II
 EXPLAIN ANALYZE SELECT count(*)
-FROM expr_prune_prefix_corner
-WHERE prefix(s, '')
+FROM '{TEST_DIR}/expr_prune_prefix_corner.parquet'
+WHERE prefix(s, '') OR prefix(s, 'zz')
 ----
-analyzed_plan	<REGEX>:(?s).*Sequential Scan.*6,144 rows.*
+analyzed_plan	<REGEX>:(?s).*Row Groups Scanned: 4 / 4.*
 
 query I
 SELECT count(*)
-FROM expr_prune_prefix_corner
-WHERE prefix(s, '')
+FROM '{TEST_DIR}/expr_prune_prefix_corner.parquet'
+WHERE prefix(s, '') OR prefix(s, 'zz')
 ----
 6144
-
-# A NULL prefix can never pass a WHERE filter
-query II
-EXPLAIN SELECT count(*)
-FROM '{TEST_DIR}/expr_prune_prefix_corner.parquet'
-WHERE prefix(s, NULL::VARCHAR)
-----
-physical_plan	<REGEX>:.*EMPTY_RESULT.*
 
 # Prefixes longer than the maximum string length can never match
 query I
 SELECT count(*)
 FROM '{TEST_DIR}/expr_prune_prefix_corner.parquet'
-WHERE prefix(s, 'bbbbbbbb')
+WHERE prefix(s, 'bbbbbbbb') OR prefix(s, 'dddddddd')
 ----
 0
 
 query II
 EXPLAIN ANALYZE SELECT count(*)
 FROM '{TEST_DIR}/expr_prune_prefix_corner.parquet'
-WHERE prefix(s, 'bbbbbbbb')
+WHERE prefix(s, 'bbbbbbbb') OR prefix(s, 'dddddddd')
 ----
 analyzed_plan	<REGEX>:(?s).*Row Groups Scanned: 0 / 4.*
 
@@ -224,14 +216,14 @@ analyzed_plan	<REGEX>:(?s).*Row Groups Scanned: 0 / 4.*
 query I
 SELECT count(*)
 FROM '{TEST_DIR}/expr_prune_prefix_corner.parquet'
-WHERE prefix(s, p)
+WHERE prefix(s, p) OR prefix(s, 'd')
 ----
 2048
 
 query II
 EXPLAIN ANALYZE SELECT count(*)
 FROM '{TEST_DIR}/expr_prune_prefix_corner.parquet'
-WHERE prefix(s, p)
+WHERE prefix(s, p) OR prefix(s, 'd')
 ----
 analyzed_plan	<REGEX>:(?s).*Row Groups Scanned: 4 / 4.*
 
@@ -245,13 +237,13 @@ COPY (
 query I
 SELECT count(*)
 FROM '{TEST_DIR}/expr_prune_prefix_utf8_boundary.parquet'
-WHERE prefix(s, chr(255))
+WHERE prefix(s, chr(255)) OR prefix(s, 'zz')
 ----
 2048
 
 query II
 EXPLAIN ANALYZE SELECT count(*)
 FROM '{TEST_DIR}/expr_prune_prefix_utf8_boundary.parquet'
-WHERE prefix(s, chr(255))
+WHERE prefix(s, chr(255)) OR prefix(s, 'zz')
 ----
 analyzed_plan	<REGEX>:(?s).*Row Groups Scanned: 1 / 2.*

--- a/test/sql/copy/parquet/parquet_expression_filter_pruning.test
+++ b/test/sql/copy/parquet/parquet_expression_filter_pruning.test
@@ -159,3 +159,158 @@ SkipRowGroup	2
 
 statement ok
 CALL truncate_duckdb_logs()
+
+# Prefix pruning corner cases: NULL-only row groups, empty prefixes, NULL prefixes, and non-constant prefixes
+statement ok
+COPY (
+	SELECT range::INTEGER AS x,
+		CASE
+			WHEN range < 2048 THEN NULL
+			WHEN range < 4096 THEN 'a' || lpad((range - 2048)::VARCHAR, 4, '0')
+			WHEN range < 6144 THEN 'b' || lpad((range - 4096)::VARCHAR, 4, '0')
+			ELSE 'c' || lpad((range - 6144)::VARCHAR, 4, '0')
+		END AS s,
+		CASE WHEN range % 2 = 0 THEN 'a' ELSE 'b' END AS p
+	FROM range(8192)
+) TO '{TEST_DIR}/expr_prune_prefix_corner.parquet' (FORMAT PARQUET, ROW_GROUP_SIZE 2048)
+
+# NULL-only, lower, and upper row groups are skipped
+statement ok
+CALL enable_logging('PhysicalOperator')
+
+query I
+SELECT count(*)
+FROM '{TEST_DIR}/expr_prune_prefix_corner.parquet'
+WHERE prefix(s, 'b')
+----
+2048
+
+statement ok
+CALL disable_logging()
+
+query II
+SELECT event, count(*) FROM duckdb_logs_parsed('PhysicalOperator') WHERE class='ParquetReader' GROUP BY event ORDER BY event
+----
+ReadRowGroup	1
+SkipRowGroup	3
+
+statement ok
+CALL truncate_duckdb_logs()
+
+# Empty prefixes match all non-NULL strings but not NULL strings
+query I
+SELECT count(*)
+FROM '{TEST_DIR}/expr_prune_prefix_corner.parquet'
+WHERE prefix(s, '')
+----
+6144
+
+# A NULL prefix can never pass a WHERE filter
+query II
+EXPLAIN SELECT count(*)
+FROM '{TEST_DIR}/expr_prune_prefix_corner.parquet'
+WHERE prefix(s, NULL::VARCHAR)
+----
+physical_plan	<REGEX>:.*EMPTY_RESULT.*
+
+# Prefixes longer than the maximum string length can never match
+statement ok
+CALL enable_logging('PhysicalOperator')
+
+query I
+SELECT count(*)
+FROM '{TEST_DIR}/expr_prune_prefix_corner.parquet'
+WHERE prefix(s, 'bbbbbbbb')
+----
+0
+
+statement ok
+CALL disable_logging()
+
+query II
+SELECT event, count(*) FROM duckdb_logs_parsed('PhysicalOperator') WHERE class='ParquetReader' GROUP BY event ORDER BY event
+----
+SkipRowGroup	4
+
+statement ok
+CALL truncate_duckdb_logs()
+
+# Non-constant prefixes are not pruned using constant-prefix statistics
+statement ok
+CALL enable_logging('PhysicalOperator')
+
+query I
+SELECT count(*)
+FROM '{TEST_DIR}/expr_prune_prefix_corner.parquet'
+WHERE prefix(s, p)
+----
+2048
+
+statement ok
+CALL disable_logging()
+
+query II
+SELECT event, count(*) FROM duckdb_logs_parsed('PhysicalOperator') WHERE class='ParquetReader' GROUP BY event ORDER BY event
+----
+ReadRowGroup	4
+
+statement ok
+CALL truncate_duckdb_logs()
+
+# When exact min equals next_prefix(prefix), no string can match the prefix filter
+statement ok
+COPY (
+	SELECT 'aab'::VARCHAR AS s
+	UNION ALL SELECT 'aac'
+	UNION ALL SELECT 'aba'
+) TO '{TEST_DIR}/expr_prune_prefix_exact_min.parquet' (FORMAT PARQUET, ROW_GROUP_SIZE 100)
+
+statement ok
+CALL enable_logging('PhysicalOperator')
+
+query I
+SELECT count(*)
+FROM '{TEST_DIR}/expr_prune_prefix_exact_min.parquet'
+WHERE prefix(s, 'aaa')
+----
+0
+
+statement ok
+CALL disable_logging()
+
+query II
+SELECT event, count(*) FROM duckdb_logs_parsed('PhysicalOperator') WHERE class='ParquetReader' GROUP BY event ORDER BY event
+----
+SkipRowGroup	1
+
+statement ok
+CALL truncate_duckdb_logs()
+
+# Byte-wise prefix successor should prune across a UTF-8 byte boundary
+statement ok
+COPY (
+	SELECT CASE WHEN range < 2048 THEN chr(255) || 'a' ELSE chr(256) || 'a' END AS s
+	FROM range(4096)
+) TO '{TEST_DIR}/expr_prune_prefix_utf8_boundary.parquet' (FORMAT PARQUET, ROW_GROUP_SIZE 2048)
+
+statement ok
+CALL enable_logging('PhysicalOperator')
+
+query I
+SELECT count(*)
+FROM '{TEST_DIR}/expr_prune_prefix_utf8_boundary.parquet'
+WHERE prefix(s, chr(255))
+----
+2048
+
+statement ok
+CALL disable_logging()
+
+query II
+SELECT event, count(*) FROM duckdb_logs_parsed('PhysicalOperator') WHERE class='ParquetReader' GROUP BY event ORDER BY event
+----
+ReadRowGroup	1
+SkipRowGroup	1
+
+statement ok
+CALL truncate_duckdb_logs()


### PR DESCRIPTION
Closes https://github.com/duckdb/duckdb/issues/23748

The root cause for missing prune for OR is, it [iterates all children expressions](https://github.com/duckdb/duckdb/blob/3ea25ffc3ca8e3d3d5f0c2eb177f3d5038ad04dc/src/planner/filter/expression_filter.cpp#L565-L576) to see if there're any stats to leverage and prune, which in turns invokes stats propagation callback for `prefix` function, currently it's not implemented.

A few questions:
- How does other prefix matching function work?
  + `LIKE`/`LEFT` is rewritten to `prefix`, so the callback added applies elsewhere
- What's the optimization difference w/ vs w/o OR operator?
  + For the query mentioned in the issue, prefix query w/o OR is rewritten into range queries (say, x > 'b' OR x > 'a'), instead of relying on `prefix` function