### PR TITLE
Internal #9890: ENUM::VARCHAR Compare Constant

### DIFF
--- a/src/include/duckdb/optimizer/matcher/expression_matcher.hpp
+++ b/src/include/duckdb/optimizer/matcher/expression_matcher.hpp
@@ -101,8 +101,7 @@ public:
 
 class InUniformExpressionMatcher : public ExpressionMatcher {
 public:
-	InUniformExpressionMatcher() : ExpressionMatcher(ExpressionClass::BOUND_OPERATOR) {
-	}
+	InUniformExpressionMatcher();
 
 	//! The matchers for the probe and child expressions
 	unique_ptr<ExpressionMatcher> probe_matcher;

--- a/src/include/duckdb/optimizer/matcher/type_matcher.hpp
+++ b/src/include/duckdb/optimizer/matcher/type_matcher.hpp
@@ -53,20 +53,6 @@ private:
 	vector<LogicalType> types;
 };
 
-//! The SpecificTypeIdMatcher class matches only a single specified LogicalTypeId
-class SpecificTypeIdMatcher : public TypeMatcher {
-public:
-	explicit SpecificTypeIdMatcher(LogicalTypeId id_p) : id(id_p) {
-	}
-
-	bool Match(const LogicalType &type_p) override {
-		return type_p.id() == this->id;
-	}
-
-private:
-	LogicalTypeId id;
-};
-
 //! The NumericTypeMatcher class matches any numeric type (DECIMAL, INTEGER, etc...)
 class NumericTypeMatcher : public TypeMatcher {
 public:

--- a/src/include/duckdb/optimizer/rule/in_clause_simplification.hpp
+++ b/src/include/duckdb/optimizer/rule/in_clause_simplification.hpp
@@ -30,4 +30,13 @@ public:
 	                             bool is_root) override;
 };
 
+// The enum equals simplification rule rewrites cases where a left enum::VARCHAR is compared a right string literal
+class EnumCompareSimplificationRule : public Rule {
+public:
+	explicit EnumCompareSimplificationRule(ExpressionRewriter &rewriter);
+
+	unique_ptr<Expression> Apply(LogicalOperator &op, vector<reference<Expression>> &bindings, bool &changes_made,
+	                             bool is_root) override;
+};
+
 } // namespace duckdb

--- a/src/optimizer/matcher/expression_matcher.cpp
+++ b/src/optimizer/matcher/expression_matcher.cpp
@@ -68,15 +68,18 @@ bool InClauseExpressionMatcher::Match(Expression &expr_p, vector<reference<Expre
 	return SetMatcher::Match(matchers, expr.GetChildrenMutable(), bindings, policy);
 }
 
+InUniformExpressionMatcher::InUniformExpressionMatcher() : ExpressionMatcher(ExpressionClass::BOUND_OPERATOR) {
+	vector<ExpressionType> types;
+	types.emplace_back(ExpressionType::COMPARE_IN);
+	types.emplace_back(ExpressionType::COMPARE_NOT_IN);
+	expr_type = make_uniq<ManyExpressionTypeMatcher>(types);
+}
+
 bool InUniformExpressionMatcher::Match(Expression &expr_p, vector<reference<Expression>> &bindings) {
 	if (!ExpressionMatcher::Match(expr_p, bindings)) {
 		return false;
 	}
 	auto &expr = expr_p.Cast<BoundOperatorExpression>();
-	if (expr.GetExpressionType() != ExpressionType::COMPARE_IN ||
-	    expr.GetExpressionType() == ExpressionType::COMPARE_NOT_IN) {
-		return false;
-	}
 
 	auto &entries = expr.GetChildrenMutable();
 	if (entries.size() < 2) {

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -70,6 +70,7 @@ Optimizer::Optimizer(Binder &binder, ClientContext &context) : context(context),
 	rewriter.rules.push_back(make_uniq<ComparisonSimplificationRule>(rewriter));
 	rewriter.rules.push_back(make_uniq<InClauseSimplificationRule>(rewriter));
 	rewriter.rules.push_back(make_uniq<InEnumSimplificationRule>(rewriter));
+	rewriter.rules.push_back(make_uniq<EnumCompareSimplificationRule>(rewriter));
 	rewriter.rules.push_back(make_uniq<EqualOrNullSimplification>(rewriter));
 	rewriter.rules.push_back(make_uniq<MoveConstantsRule>(rewriter));
 	rewriter.rules.push_back(make_uniq<LikeOptimizationRule>(rewriter));

--- a/src/optimizer/rule/in_clause_simplification_rule.cpp
+++ b/src/optimizer/rule/in_clause_simplification_rule.cpp
@@ -2,6 +2,7 @@
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/optimizer/expression_rewriter.hpp"
 #include "duckdb/optimizer/rule/in_clause_simplification.hpp"
+#include "duckdb/optimizer/matcher/type_matcher_id.hpp"
 #include "duckdb/planner/expression/list.hpp"
 #include "duckdb/planner/expression/bound_operator_expression.hpp"
 #include "duckdb/common/string_map_set.hpp"
@@ -71,15 +72,11 @@ InEnumSimplificationRule::InEnumSimplificationRule(ExpressionRewriter &rewriter)
 	auto cast_matcher = make_uniq<CastExpressionMatcher>();
 	cast_matcher->type = make_uniq<SpecificTypeMatcher>(LogicalType::VARCHAR);
 	auto enum_matcher = make_uniq<ExpressionMatcher>();
-	enum_matcher->type = make_uniq<SpecificTypeIdMatcher>(LogicalTypeId::ENUM);
+	enum_matcher->type = make_uniq<TypeMatcherId>(LogicalTypeId::ENUM);
 	cast_matcher->matcher = std::move(enum_matcher);
 	op->probe_matcher = std::move(cast_matcher);
 
 	//	Children must be constant strings
-	vector<LogicalTypeId> ids;
-	ids.emplace_back(LogicalTypeId::VARCHAR);
-	ids.emplace_back(LogicalTypeId::STRING_LITERAL);
-	ids.emplace_back(LogicalTypeId::SQLNULL);
 	op->child_matcher = make_uniq<ExpressionMatcher>(ExpressionClass::BOUND_CONSTANT);
 	op->child_matcher->type = make_uniq<SpecificTypeMatcher>(LogicalType::VARCHAR);
 
@@ -130,6 +127,100 @@ unique_ptr<Expression> InEnumSimplificationRule::Apply(LogicalOperator &op, vect
 		// constant_or_null(not_in, child[0])
 		const bool not_in = (expr.GetExpressionType() == ExpressionType::COMPARE_NOT_IN);
 		return rewriter.ConstantOrNull(in_children[0]->Copy(), Value::BOOLEAN(not_in));
+	}
+
+	return nullptr;
+}
+
+EnumCompareSimplificationRule::EnumCompareSimplificationRule(ExpressionRewriter &rewriter) : Rule(rewriter) {
+	// match enum::VARCHAR = string literal
+	auto op = make_uniq<ComparisonExpressionMatcher>();
+	vector<ExpressionType> types;
+	types.emplace_back(ExpressionType::COMPARE_EQUAL);
+	types.emplace_back(ExpressionType::COMPARE_NOTEQUAL);
+	types.emplace_back(ExpressionType::COMPARE_DISTINCT_FROM);
+	types.emplace_back(ExpressionType::COMPARE_NOT_DISTINCT_FROM);
+	op->expr_type = make_uniq<ManyExpressionTypeMatcher>(types);
+
+	//	One side must be enum::VARCHAR
+	auto cast_matcher = make_uniq<CastExpressionMatcher>();
+	cast_matcher->type = make_uniq<SpecificTypeMatcher>(LogicalType::VARCHAR);
+	auto enum_matcher = make_uniq<ExpressionMatcher>();
+	enum_matcher->type = make_uniq<TypeMatcherId>(LogicalTypeId::ENUM);
+	cast_matcher->matcher = std::move(enum_matcher);
+	op->matchers.emplace_back(std::move(cast_matcher));
+
+	//	The other must must be a constant string
+	auto const_matcher = make_uniq<ExpressionMatcher>(ExpressionClass::BOUND_CONSTANT);
+	const_matcher->type = make_uniq<SpecificTypeMatcher>(LogicalType::VARCHAR);
+	op->matchers.emplace_back(std::move(const_matcher));
+
+	op->policy = SetMatcher::Policy::UNORDERED;
+
+	root = std::move(op);
+}
+
+unique_ptr<Expression> EnumCompareSimplificationRule::Apply(LogicalOperator &op,
+                                                            vector<reference<Expression>> &bindings, bool &changes_made,
+                                                            bool is_root) {
+	auto &expr = bindings[0].get().Cast<BoundFunctionExpression>();
+
+	optional_ptr<BoundCastExpression> cast_expr;
+	optional_ptr<BoundConstantExpression> const_expr;
+	idx_t cast_idx = 0;
+	if (BoundComparisonExpression::Left(expr).GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
+		cast_expr = BoundComparisonExpression::RightMutable(expr)->Cast<BoundCastExpression>();
+		const_expr = BoundComparisonExpression::LeftMutable(expr)->Cast<BoundConstantExpression>();
+		cast_idx = 1;
+	} else {
+		cast_expr = BoundComparisonExpression::LeftMutable(expr)->Cast<BoundCastExpression>();
+		const_expr = BoundComparisonExpression::RightMutable(expr)->Cast<BoundConstantExpression>();
+	}
+
+	auto &enum_expr = cast_expr->Child();
+	auto &enum_type = enum_expr.GetReturnType();
+
+	vector<unique_ptr<Expression>> cmp_children;
+	cmp_children.emplace_back(enum_expr.Copy());
+
+	auto &v = const_expr->GetValue();
+	if (v.IsNull()) {
+		//	Keep NULLs
+		cmp_children.emplace_back(make_uniq<BoundConstantExpression>(Value(enum_type)));
+	} else {
+		// Look up the string in the domain for the original ENUM
+		string_t s = v.ToString();
+		auto strings = FlatVector::GetData<string_t>(EnumType::GetValuesInsertOrder(enum_type));
+		for (uint64_t i = 0; i < EnumType::GetSize(enum_type); ++i) {
+			if (s == strings[i]) {
+				//	The literal is in the ENUM domain, so translate it
+				cmp_children.emplace_back(make_uniq<BoundConstantExpression>(Value::ENUM(i, enum_type)));
+				if (cast_idx) {
+					std::swap(cmp_children[0], cmp_children[1]);
+				}
+				break;
+			}
+		}
+	}
+
+	if (cmp_children.size() == 2) {
+		//	In the domain, so rewrite as enum = constant
+		BoundComparisonExpression::LeftMutable(expr) = std::move(cmp_children[0]);
+		BoundComparisonExpression::RightMutable(expr) = std::move(cmp_children[1]);
+	} else {
+		//	Not in the domain, so rewrite as ConstantOrNull(enum, ne)
+		switch (expr.GetExpressionType()) {
+		case ExpressionType::COMPARE_EQUAL:
+			return rewriter.ConstantOrNull(std::move(cmp_children[0]), Value::BOOLEAN(false));
+		case ExpressionType::COMPARE_NOT_DISTINCT_FROM:
+			return make_uniq<BoundConstantExpression>(Value::BOOLEAN(false));
+		case ExpressionType::COMPARE_NOTEQUAL:
+			return rewriter.ConstantOrNull(std::move(cmp_children[0]), Value::BOOLEAN(true));
+		case ExpressionType::COMPARE_DISTINCT_FROM:
+			return make_uniq<BoundConstantExpression>(Value::BOOLEAN(true));
+		default:
+			break;
+		}
 	}
 
 	return nullptr;

--- a/src/optimizer/rule/in_clause_simplification_rule.cpp
+++ b/src/optimizer/rule/in_clause_simplification_rule.cpp
@@ -189,13 +189,14 @@ unique_ptr<Expression> EnumCompareSimplificationRule::Apply(LogicalOperator &op,
 		cmp_children.emplace_back(make_uniq<BoundConstantExpression>(Value(enum_type)));
 	} else {
 		// Look up the string in the domain for the original ENUM
-		string_t s = v.ToString();
+		const auto s = v.ToString();
 		auto strings = FlatVector::GetData<string_t>(EnumType::GetValuesInsertOrder(enum_type));
 		for (uint64_t i = 0; i < EnumType::GetSize(enum_type); ++i) {
-			if (s == strings[i]) {
+			if (strings[i] == s) {
 				//	The literal is in the ENUM domain, so translate it
 				cmp_children.emplace_back(make_uniq<BoundConstantExpression>(Value::ENUM(i, enum_type)));
 				if (cast_idx) {
+					// Restore the original orientation
 					std::swap(cmp_children[0], cmp_children[1]);
 				}
 				break;

--- a/test/sql/optimizer/expression/test_enum_in_simplification.test
+++ b/test/sql/optimizer/expression/test_enum_in_simplification.test
@@ -1,5 +1,5 @@
 # name: test/sql/optimizer/expression/test_enum_in_simplification.test
-# description: Convert enum::VARCHAR IN (VARCHAR constants...) to enum IN (enums...)
+# description: Convert enum::VARCHAR op VARCHAR constant(s) to enum op enum(s)
 # group: [expression]
 
 statement ok
@@ -92,6 +92,37 @@ SELECT sym,
     CORR(asize, bsize) AS corSize 
 FROM quote
 WHERE sym NOT IN (
+	NULL,
+	'0',
+	'1',
+	'2',
+	'3',
+	'4',
+	'5',
+	'6',
+	'7',
+	'8',
+	'9',
+	'10',
+	'11',
+	'12',
+)
+GROUP BY sym 
+ORDER BY sym;
+----
+physical_plan	<!REGEX>:.*AS VARCHAR.*
+
+query II
+explain
+SELECT sym, 
+    SUM(asize * ask) AS wsumAsk, 
+    SUM(bid * bsize) AS wsumBid, 
+    STDDEV(asize) AS sdevasksize, 
+    STDDEV(bid) AS sdevbid, 
+    CORR(ask, bid) AS corPrice, 
+    CORR(asize, bsize) AS corSize 
+FROM quote
+WHERE sym NOT IN (
 	'10',
 	'11',
 	'12',
@@ -150,3 +181,61 @@ FROM (
 ) tbl;
 ----
 100	true
+
+# Test comparisons
+query II
+EXPLAIN
+FROM quote
+WHERE sym = '0';
+----
+physical_plan	<!REGEX>:.*AS VARCHAR.*
+
+query II
+EXPLAIN
+FROM quote
+WHERE sym = '100';
+----
+physical_plan	<REGEX>:.*EMPTY_RESULT.*
+
+query II
+EXPLAIN
+FROM quote
+WHERE sym <> '0';
+----
+physical_plan	<!REGEX>:.*AS VARCHAR.*
+
+query II
+EXPLAIN
+FROM quote
+WHERE sym <> '100';
+----
+physical_plan	<REGEX>:.*IS NOT NULL.*
+
+query II
+EXPLAIN
+FROM quote
+WHERE sym IS NOT DISTINCT FROM '0';
+----
+physical_plan	<!REGEX>:.*AS VARCHAR.*
+
+query II
+EXPLAIN
+FROM quote
+WHERE sym IS NOT DISTINCT FROM '100';
+----
+physical_plan	<REGEX>:.*EMPTY_RESULT.*
+
+query II
+EXPLAIN
+FROM quote
+WHERE sym IS DISTINCT FROM '0';
+----
+physical_plan	<!REGEX>:.*AS VARCHAR.*
+
+query II
+EXPLAIN
+FROM quote
+WHERE sym IS DISTINCT FROM '100';
+----
+physical_plan	<!REGEX>:.*AS VARCHAR.*
+


### PR DESCRIPTION
* Add EnumCompareSimplificationRule convert ENUM::VARCHAR cmp constant VARCHAR to ENUM cmp constant ENUM
* Remove redundant SpecificTypeIdMatcher
* Fix InUniformExpressionMatcher type test
* Remove dead code
* Fix obscure memory lifetime issue?
