### PR TITLE
Include extension header in libduckdb archives

### DIFF
--- a/.github/workflows/Android.yml
+++ b/.github/workflows/Android.yml
@@ -93,7 +93,7 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.S3_DUCKDB_STAGING_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DUCKDB_STAGING_KEY }}
       run: |
-        zip -j libduckdb-android_${{matrix.arch}}.zip build/release/src/libduckdb*.*  src/include/duckdb.h
+        zip -j libduckdb-android_${{matrix.arch}}.zip build/release/src/libduckdb*.* src/include/duckdb.h src/include/duckdb_extension.h
         ./scripts/upload-assets-to-staging.sh github_release libduckdb-android_${{matrix.arch}}.zip
 
     - uses: actions/upload-artifact@v4

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -128,7 +128,7 @@ jobs:
         python3 scripts/amalgamation.py
         zip -j duckdb_cli-linux-${{ matrix.config.arch }}.zip build/release/duckdb
         gzip -9 -k -n -c build/release/duckdb > duckdb_cli-linux-${{ matrix.config.arch }}.gz
-        zip -j libduckdb-linux-${{ matrix.config.arch }}.zip build/release/src/libduckdb*.* src/amalgamation/duckdb.hpp src/include/duckdb.h
+        zip -j libduckdb-linux-${{ matrix.config.arch }}.zip build/release/src/libduckdb*.* src/amalgamation/duckdb.hpp src/include/duckdb.h src/include/duckdb_extension.h
         ./scripts/upload-assets-to-staging.sh github_release libduckdb-linux-${{ matrix.config.arch }}.zip duckdb_cli-linux-${{ matrix.config.arch }}.zip duckdb_cli-linux-${{ matrix.config.arch }}.gz
 
     - uses: actions/upload-artifact@v4
@@ -222,7 +222,7 @@ jobs:
         python3 scripts/amalgamation.py
         zip -j duckdb_cli-linux-${{ matrix.config.arch }}-musl.zip build/release/duckdb
         gzip -9 -k -n -c build/release/duckdb > duckdb_cli-linux-${{ matrix.config.arch }}-musl.gz
-        zip -j libduckdb-linux-${{ matrix.config.arch }}-musl.zip build/release/src/libduckdb*.* src/amalgamation/duckdb.hpp src/include/duckdb.h
+        zip -j libduckdb-linux-${{ matrix.config.arch }}-musl.zip build/release/src/libduckdb*.* src/amalgamation/duckdb.hpp src/include/duckdb.h src/include/duckdb_extension.h
         ./scripts/upload-assets-to-staging.sh github_release libduckdb-linux-${{ matrix.config.arch }}-musl.zip duckdb_cli-linux-${{ matrix.config.arch }}-musl.zip duckdb_cli-linux-${{ matrix.config.arch }}-musl.gz
 
     - uses: actions/upload-artifact@v4

--- a/.github/workflows/OSX.yml
+++ b/.github/workflows/OSX.yml
@@ -172,7 +172,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DUCKDB_STAGING_KEY }}
         run: |
           python scripts/amalgamation.py
-          zip -j -y libduckdb-osx-universal.zip build/release/src/libduckdb*.dylib src/amalgamation/duckdb.hpp src/include/duckdb.h
+          zip -j -y libduckdb-osx-universal.zip build/release/src/libduckdb*.dylib src/amalgamation/duckdb.hpp src/include/duckdb.h src/include/duckdb_extension.h
 
           mkdir build/release_arm64 build/release_amd64
           lipo -extract arm64 -output build/release_arm64/duckdb build/release/duckdb

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -152,7 +152,7 @@ jobs:
         python scripts/amalgamation.py
         /c/msys64/usr/bin/bash.exe -lc "pacman -Sy --noconfirm zip"
         /c/msys64/usr/bin/zip.exe -j duckdb_cli-windows-amd64.zip Release/duckdb.exe
-        /c/msys64/usr/bin/zip.exe -j libduckdb-windows-amd64.zip src/Release/duckdb.dll src/Release/duckdb.lib src/amalgamation/duckdb.hpp src/include/duckdb.h
+        /c/msys64/usr/bin/zip.exe -j libduckdb-windows-amd64.zip src/Release/duckdb.dll src/Release/duckdb.lib src/amalgamation/duckdb.hpp src/include/duckdb.h src/include/duckdb_extension.h
         ./scripts/upload-assets-to-staging.sh github_release libduckdb-windows-amd64.zip duckdb_cli-windows-amd64.zip
 
     - uses: actions/upload-artifact@v4
@@ -257,7 +257,7 @@ jobs:
          python scripts/amalgamation.py
          /c/msys64/usr/bin/bash.exe -lc "pacman -Sy --noconfirm zip"
          /c/msys64/usr/bin/zip.exe -j duckdb_cli-windows-arm64.zip Release/duckdb.exe
-         /c/msys64/usr/bin/zip.exe -j libduckdb-windows-arm64.zip src/Release/duckdb.dll src/Release/duckdb.lib src/amalgamation/duckdb.hpp src/include/duckdb.h
+         /c/msys64/usr/bin/zip.exe -j libduckdb-windows-arm64.zip src/Release/duckdb.dll src/Release/duckdb.lib src/amalgamation/duckdb.hpp src/include/duckdb.h src/include/duckdb_extension.h
          ./scripts/upload-assets-to-staging.sh github_release libduckdb-windows-arm64.zip duckdb_cli-windows-arm64.zip
 
      - uses: actions/upload-artifact@v4

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -143,9 +143,11 @@ install(
   FILES_MATCHING
   PATTERN "*.hpp"
   PATTERN "*.ipp")
-install(FILES "${PROJECT_SOURCE_DIR}/src/include/duckdb.hpp"
-              "${PROJECT_SOURCE_DIR}/src/include/duckdb.h"
-        DESTINATION "${INSTALL_INCLUDE_DIR}")
+install(
+  FILES "${PROJECT_SOURCE_DIR}/src/include/duckdb.hpp"
+        "${PROJECT_SOURCE_DIR}/src/include/duckdb.h"
+        "${PROJECT_SOURCE_DIR}/src/include/duckdb_extension.h"
+  DESTINATION "${INSTALL_INCLUDE_DIR}")
 
 install(
   TARGETS duckdb duckdb_static


### PR DESCRIPTION
The platform libduckdb archives already ship `duckdb.h` and `duckdb.hpp` for consumers linking against the binary library, so they are development archives rather than only runtime artifacts.

Consumers such as [duckdb-rs need duckdb_extension.h](https://github.com/duckdb/duckdb-rs/pull/814) from the matching DuckDB release when building loadable-extension bindings. Before this change, that header was only published in `libduckdb-src.zip`, even though the platform archives otherwise carry the public headers needed to link against libduckdb.

## Open questions

1. Is there a specific reason why `duckdb_extension.h` is missing from the archives?
2. Should we add `duckdb_extension.h` to `static-libs-*` archives too?
3. Should this rather target `main` for v2?