### PR TITLE
Preserve NULL semantics in CTE deliminator

### DIFF
--- a/extension/tpcds/dsdgen/answers/sf3/16.csv
+++ b/extension/tpcds/dsdgen/answers/sf3/16.csv
@@ -1,2 +1,2 @@
 order count|total shipping cost|total net profit
-691|3264282.42|-407678.69
+691|3264157.47|-407644.04

--- a/src/planner/subquery/delim_join_cte_rewriter.cpp
+++ b/src/planner/subquery/delim_join_cte_rewriter.cpp
@@ -8,6 +8,7 @@
 
 #include "duckdb/planner/subquery/delim_join_cte_rewriter.hpp"
 
+#include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
 #include "duckdb/common/enums/optimizer_type.hpp"
 #include "duckdb/main/config.hpp"
 #include "duckdb/main/query_profiler.hpp"
@@ -16,11 +17,13 @@
 #include "duckdb/planner/column_binding_map.hpp"
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
 #include "duckdb/planner/expression/bound_comparison_expression.hpp"
+#include "duckdb/planner/expression/bound_conjunction_expression.hpp"
 #include "duckdb/planner/expression/bound_operator_expression.hpp"
 #include "duckdb/planner/expression_iterator.hpp"
 #include "duckdb/planner/filter/expression_filter.hpp"
 #include "duckdb/planner/logical_operator_visitor.hpp"
 #include "duckdb/planner/operator/list.hpp"
+#include "duckdb/storage/statistics/base_statistics.hpp"
 
 #include <algorithm>
 
@@ -543,6 +546,174 @@ static bool GetBoundColumnRefBinding(const Expression &expr, ColumnBinding &bind
 	return true;
 }
 
+static bool FilterNullRejectsExpression(const Expression &filter, const Expression &expr) {
+	if (filter.GetExpressionType() == ExpressionType::CONJUNCTION_AND) {
+		auto &conjunction = filter.Cast<BoundConjunctionExpression>();
+		for (auto &child : conjunction.GetChildren()) {
+			if (FilterNullRejectsExpression(*child, expr)) {
+				return true;
+			}
+		}
+		return false;
+	}
+	if (filter.GetExpressionType() == ExpressionType::CONJUNCTION_OR) {
+		auto &conjunction = filter.Cast<BoundConjunctionExpression>();
+		if (conjunction.GetChildren().empty()) {
+			return false;
+		}
+		for (auto &child : conjunction.GetChildren()) {
+			if (!FilterNullRejectsExpression(*child, expr)) {
+				return false;
+			}
+		}
+		return true;
+	}
+	if (filter.GetExpressionType() == ExpressionType::OPERATOR_IS_NOT_NULL) {
+		auto &op = filter.Cast<BoundOperatorExpression>();
+		return !op.GetChildren().empty() && Expression::Equals(*op.GetChildren()[0], expr);
+	}
+	if (!BoundComparisonExpression::IsComparison(filter)) {
+		return false;
+	}
+	if (filter.GetExpressionType() == ExpressionType::COMPARE_DISTINCT_FROM ||
+	    filter.GetExpressionType() == ExpressionType::COMPARE_NOT_DISTINCT_FROM) {
+		return false;
+	}
+	auto &comparison = filter.Cast<BoundFunctionExpression>();
+	return Expression::Equals(BoundComparisonExpression::Left(comparison), expr) ||
+	       Expression::Equals(BoundComparisonExpression::Right(comparison), expr);
+}
+
+static optional_ptr<LogicalCTE> FindCTE(LogicalOperator &op, TableIndex cte_index) {
+	if ((op.type == LogicalOperatorType::LOGICAL_MATERIALIZED_CTE ||
+	     op.type == LogicalOperatorType::LOGICAL_RECURSIVE_CTE) &&
+	    op.Cast<LogicalCTE>().table_index == cte_index) {
+		return op.Cast<LogicalCTE>();
+	}
+	for (auto &child : op.children) {
+		auto result = FindCTE(*child, cte_index);
+		if (result) {
+			return result;
+		}
+	}
+	return nullptr;
+}
+
+static bool ExpressionIsNotNull(ClientContext &context, LogicalOperator &op, const Expression &expr,
+                                LogicalOperator &rewrite_root, vector<TableIndex> &seen_ctes) {
+	switch (op.type) {
+	case LogicalOperatorType::LOGICAL_PROJECTION: {
+		auto &projection = op.Cast<LogicalProjection>();
+		if (projection.children.size() != 1) {
+			return false;
+		}
+		ColumnBinding binding;
+		if (!GetBoundColumnRefBinding(expr, binding)) {
+			return false;
+		}
+		auto projection_bindings = projection.GetColumnBindings();
+		for (idx_t idx = 0; idx < projection_bindings.size(); idx++) {
+			if (projection_bindings[idx] == binding) {
+				return ExpressionIsNotNull(context, *projection.children[0], *projection.expressions[idx], rewrite_root,
+				                           seen_ctes);
+			}
+		}
+		return false;
+	}
+	case LogicalOperatorType::LOGICAL_FILTER: {
+		auto &filter = op.Cast<LogicalFilter>();
+		for (auto &filter_expr : filter.expressions) {
+			if (FilterNullRejectsExpression(*filter_expr, expr)) {
+				return true;
+			}
+		}
+		return filter.children.size() == 1 &&
+		       ExpressionIsNotNull(context, *filter.children[0], expr, rewrite_root, seen_ctes);
+	}
+	case LogicalOperatorType::LOGICAL_COMPARISON_JOIN: {
+		ColumnBinding binding;
+		if (!GetBoundColumnRefBinding(expr, binding)) {
+			return false;
+		}
+		optional_ptr<LogicalOperator> binding_child;
+		for (auto &child : op.children) {
+			auto child_bindings = child->GetColumnBindings();
+			if (std::find(child_bindings.begin(), child_bindings.end(), binding) == child_bindings.end()) {
+				continue;
+			}
+			if (binding_child) {
+				return false;
+			}
+			binding_child = *child;
+		}
+		return binding_child && ExpressionIsNotNull(context, *binding_child, expr, rewrite_root, seen_ctes);
+	}
+	case LogicalOperatorType::LOGICAL_GET: {
+		ColumnBinding binding;
+		if (!GetBoundColumnRefBinding(expr, binding)) {
+			return false;
+		}
+		auto &get = op.Cast<LogicalGet>();
+		if (binding.table_index != get.table_index) {
+			return false;
+		}
+		if (get.table_filters.HasFilter(binding.column_index)) {
+			auto column_expr = make_uniq<BoundColumnRefExpression>(expr.GetReturnType(), binding);
+			auto filter_expr =
+			    get.table_filters.GetFilterByColumnIndex(binding.column_index).ToExpression(*column_expr);
+			if (FilterNullRejectsExpression(*filter_expr, expr)) {
+				return true;
+			}
+		}
+		auto table = get.GetTable();
+		if (!table) {
+			return false;
+		}
+		auto &column_index = get.GetColumnIndex(binding);
+		if (!column_index.HasPrimaryIndex() || column_index.HasChildren() ||
+		    column_index.GetPrimaryIndex() == DConstants::INVALID_INDEX) {
+			return false;
+		}
+		auto stats = table->GetStatistics(context, column_index.GetPrimaryIndex());
+		return stats && !stats->CanHaveNull();
+	}
+	case LogicalOperatorType::LOGICAL_CTE_REF: {
+		ColumnBinding binding;
+		if (!GetBoundColumnRefBinding(expr, binding)) {
+			return false;
+		}
+		auto &cte_ref = op.Cast<LogicalCTERef>();
+		if (binding.table_index != cte_ref.table_index ||
+		    std::find(seen_ctes.begin(), seen_ctes.end(), cte_ref.cte_index) != seen_ctes.end()) {
+			return false;
+		}
+		auto cte = FindCTE(rewrite_root, cte_ref.cte_index);
+		if (!cte || cte->children.empty()) {
+			return false;
+		}
+		auto column_index = binding.column_index.GetIndex();
+		auto &cte_source = *cte->children[0];
+		auto source_bindings = cte_source.GetColumnBindings();
+		if (column_index >= source_bindings.size() || column_index >= cte_source.types.size()) {
+			return false;
+		}
+		seen_ctes.push_back(cte_ref.cte_index);
+		auto source_expr = BoundColumnRefExpression(cte_source.types[column_index], source_bindings[column_index]);
+		auto result = ExpressionIsNotNull(context, cte_source, source_expr, rewrite_root, seen_ctes);
+		seen_ctes.pop_back();
+		return result;
+	}
+	default:
+		return false;
+	}
+}
+
+static bool ExpressionIsNotNull(ClientContext &context, LogicalOperator &op, const Expression &expr,
+                                LogicalOperator &rewrite_root) {
+	vector<TableIndex> seen_ctes;
+	return ExpressionIsNotNull(context, op, expr, rewrite_root, seen_ctes);
+}
+
 static bool ExpressionReferencesBinding(Expression &expr, const vector<ColumnBinding> &bindings) {
 	bool found = false;
 	ExpressionIterator::VisitExpression<BoundColumnRefExpression>(expr, [&](const BoundColumnRefExpression &colref) {
@@ -606,8 +777,8 @@ static void ReplaceOperatorBindings(LogicalOperator &op, const vector<ColumnBind
 
 class GeneratedDedupRefEliminator {
 public:
-	GeneratedDedupRefEliminator(LogicalComparisonJoin &delim_join, TableIndex dedup_cte_index, idx_t dedup_ref_count,
-	                            LogicalOperator &rewrite_root, bool preserve_evidence_side);
+	GeneratedDedupRefEliminator(ClientContext &context, LogicalComparisonJoin &delim_join, TableIndex dedup_cte_index,
+	                            idx_t dedup_ref_count, LogicalOperator &rewrite_root, bool preserve_evidence_side);
 
 	idx_t Remove();
 
@@ -635,6 +806,7 @@ private:
 	bool RemoveFilterCrossProduct(unique_ptr<LogicalOperator> &filter_op);
 
 private:
+	ClientContext &context;
 	LogicalComparisonJoin &delim_join;
 	TableIndex dedup_cte_index;
 	idx_t dedup_ref_count;
@@ -642,10 +814,10 @@ private:
 	bool preserve_evidence_side;
 };
 
-GeneratedDedupRefEliminator::GeneratedDedupRefEliminator(LogicalComparisonJoin &delim_join, TableIndex dedup_cte_index,
-                                                         idx_t dedup_ref_count, LogicalOperator &rewrite_root,
-                                                         bool preserve_evidence_side)
-    : delim_join(delim_join), dedup_cte_index(dedup_cte_index), dedup_ref_count(dedup_ref_count),
+GeneratedDedupRefEliminator::GeneratedDedupRefEliminator(ClientContext &context, LogicalComparisonJoin &delim_join,
+                                                         TableIndex dedup_cte_index, idx_t dedup_ref_count,
+                                                         LogicalOperator &rewrite_root, bool preserve_evidence_side)
+    : context(context), delim_join(delim_join), dedup_cte_index(dedup_cte_index), dedup_ref_count(dedup_ref_count),
       rewrite_root(rewrite_root), preserve_evidence_side(preserve_evidence_side) {
 }
 
@@ -926,6 +1098,12 @@ bool GeneratedDedupRefEliminator::RemoveInequalityJoinConditions(LogicalOperator
 			if (colref.Binding() == traced_binding) {
 				auto join_comparison = join_condition.GetComparisonType();
 				auto original_join_comparison = join_condition.GetComparisonType();
+				// DISTINCT FROM changes regular inequality semantics when the MARK probe key can be NULL.
+				if (delim_join.join_type == JoinType::MARK &&
+				    original_join_comparison == ExpressionType::COMPARE_NOTEQUAL &&
+				    !ExpressionIsNotNull(context, *delim_join.children[0], delim_condition.GetLHS(), rewrite_root)) {
+					return false;
+				}
 				if (delim_condition.GetComparisonType() == ExpressionType::COMPARE_DISTINCT_FROM ||
 				    delim_condition.GetComparisonType() == ExpressionType::COMPARE_NOT_DISTINCT_FROM) {
 					if (join_comparison == ExpressionType::COMPARE_EQUAL) {
@@ -2174,7 +2352,7 @@ void DelimJoinCTERewriter::MaterializeDelimJoinAsCTE(unique_ptr<LogicalOperator>
 	if (cte_deliminator_enabled) {
 		auto cte_deliminator_timer =
 		    QueryProfiler::Get(binder.context).StartTimerInternal(CTE_DELIMINATOR_PROFILER_KEY);
-		GeneratedDedupRefEliminator eliminator(join, dedup_cte_index, dedup_ref_count, rewrite_root,
+		GeneratedDedupRefEliminator eliminator(binder.context, join, dedup_cte_index, dedup_ref_count, rewrite_root,
 		                                       preserve_evidence_side);
 		dedup_ref_count = eliminator.Remove();
 		if (SingleJoinRHSIsDeduplicated(join)) {

--- a/test/sql/subquery/exists/test_correlated_exists.test
+++ b/test/sql/subquery/exists/test_correlated_exists.test
@@ -188,3 +188,49 @@ query R
 SELECT (SELECT COVAR_POP(i1.i, i1.i) FROM integers i2 LIMIT 1) FROM integers i1 ORDER BY 1;
 ----
 0.666667
+
+# The CTE deliminator must preserve regular NULL semantics for correlated inequality predicates.
+statement ok
+CREATE TABLE exists_sales(o INTEGER, ship_date INTEGER, wh INTEGER);
+
+statement ok
+INSERT INTO exists_sales VALUES
+	(1, 1, NULL), (1, 0, 1), (1, 0, 2),
+	(2, 1, 2), (2, 0, 2),
+	(3, 1, 3), (3, 0, 4);
+
+statement ok
+SET delim_join_as_cte=false;
+
+query IIT
+SELECT o, wh, EXISTS(
+	SELECT 1
+	FROM exists_sales s2
+	WHERE s1.o=s2.o
+		AND s1.wh<>s2.wh
+) AS ex
+FROM exists_sales s1
+WHERE ship_date=1
+ORDER BY o;
+----
+1	NULL	0
+2	2	0
+3	3	1
+
+statement ok
+SET delim_join_as_cte=true;
+
+query IIT
+SELECT o, wh, EXISTS(
+	SELECT 1
+	FROM exists_sales s2
+	WHERE s1.o=s2.o
+		AND s1.wh<>s2.wh
+) AS ex
+FROM exists_sales s1
+WHERE ship_date=1
+ORDER BY o;
+----
+1	NULL	0
+2	2	0
+3	3	1

--- a/test/sql/subquery/exists/test_correlated_exists.test
+++ b/test/sql/subquery/exists/test_correlated_exists.test
@@ -191,6 +191,9 @@ SELECT (SELECT COVAR_POP(i1.i, i1.i) FROM integers i2 LIMIT 1) FROM integers i1 
 
 # The CTE deliminator must preserve regular NULL semantics for correlated inequality predicates.
 statement ok
+SET delim_join_as_cte=true;
+
+statement ok
 CREATE TABLE exists_sales(o INTEGER, ship_date INTEGER, wh INTEGER);
 
 statement ok
@@ -198,27 +201,6 @@ INSERT INTO exists_sales VALUES
 	(1, 1, NULL), (1, 0, 1), (1, 0, 2),
 	(2, 1, 2), (2, 0, 2),
 	(3, 1, 3), (3, 0, 4);
-
-statement ok
-SET delim_join_as_cte=false;
-
-query IIT
-SELECT o, wh, EXISTS(
-	SELECT 1
-	FROM exists_sales s2
-	WHERE s1.o=s2.o
-		AND s1.wh<>s2.wh
-) AS ex
-FROM exists_sales s1
-WHERE ship_date=1
-ORDER BY o;
-----
-1	NULL	0
-2	2	0
-3	3	1
-
-statement ok
-SET delim_join_as_cte=true;
 
 query IIT
 SELECT o, wh, EXISTS(


### PR DESCRIPTION
TPC-DS Q16 returned incorrect results for generated datasets, initially observed at SF100. The issue was caused a pre-existing bug in the CTE Deliminator.

When decorrelating the query’s EXISTS subquery, the CTE Deliminator removed an evidence join and folded its regular `<>` predicate into a `MARK` join as `IS DISTINCT FROM`. This changes `NULL` semantics: a nullable probe key that should produce `UNKNOWN` for `NULL <> value` was instead treated as a successful inequality match. As a result, Q16 counted an additional order and included its net profit in the aggregate.

The rewrite is now only applied when the probe expression can be proven non-null. The check follows the expression through projections, filters, joins, scans, and CTE references. If nullability cannot be ruled out, the evidence join is retained and regular SQL `NULL` semantics are preserved. Non-null cases, including TPC-H Q21, continue to use the optimized plan.