### PR TITLE
Partial revert of #23649, this can still be triggered explicitly

### DIFF
--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -118,9 +118,6 @@ jobs:
         shell: bash
         run: |
           effective_git_describe="${{ github.event_name == 'workflow_dispatch' && inputs.override_git_describe || '' }}"
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" && -z "${{ inputs.git_ref }}" && -z "$effective_git_describe" ]]; then
-            effective_git_describe="v2.0.0-alpha${{ github.run_number }}"
-          fi
           echo "effective_git_describe=$effective_git_describe" >> "$GITHUB_OUTPUT"
           echo "Using effective_git_describe=$effective_git_describe"
 


### PR DESCRIPTION
Triggered CI was not functional after the merge of https://github.com/duckdb/duckdb/pull/23649, let's revert the automatic enroll part, to be reviewed on a side, first restoring functional CI.