### PR TITLE
Fix segfault in external hash aggregate when radix bits grow after going external

### DIFF
--- a/.github/config/extensions/lance.cmake
+++ b/.github/config/extensions/lance.cmake
@@ -3,6 +3,7 @@ if (NOT MINGW AND NOT ${WASM_ENABLED})
             GIT_URL https://github.com/lance-format/lance-duckdb
             GIT_TAG cd592bc76dfeac28bc7d6344a5bf85c4d4c31405
             SUBMODULES extension-ci-tools
+            APPLY_PATCHES
             LOAD_TESTS
             DONT_LINK
     )

--- a/.github/patches/extensions/lance/0001-bump-ethnum-to-1.5.3-for-rust-1.97.patch
+++ b/.github/patches/extensions/lance/0001-bump-ethnum-to-1.5.3-for-rust-1.97.patch
@@ -1,0 +1,16 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index 34d7760..56ffb8d 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -2096,9 +2096,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "ethnum"
+-version = "1.5.2"
++version = "1.5.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
++checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
+ 
+ [[package]]
+ name = "event-listener"

--- a/src/common/types/row/partitioned_tuple_data.cpp
+++ b/src/common/types/row/partitioned_tuple_data.cpp
@@ -277,6 +277,13 @@ void PartitionedTupleData::Repartition(ClientContext &context, PartitionedTupleD
 		return;
 	}
 
+	// Repartitioning only ever goes to more partitions - fewer would underflow the partition math and index
+	// out of bounds, so throw instead of corrupting memory.
+	if (partitions.size() > new_partitioned_data.partitions.size()) {
+		throw InternalException("PartitionedTupleData::Repartition into fewer partitions (%llu -> %llu)",
+		                        partitions.size(), new_partitioned_data.partitions.size());
+	}
+
 	PartitionedTupleDataAppendState append_state;
 	new_partitioned_data.InitializeAppendState(append_state);
 

--- a/src/execution/radix_partitioned_hashtable.cpp
+++ b/src/execution/radix_partitioned_hashtable.cpp
@@ -461,6 +461,21 @@ void DecideAdaptation(RadixHTGlobalSinkState &gstate, RadixHTLocalSinkState &lst
 	}
 }
 
+// Grow abandoned_data (frozen at the radix bits of when we first went external) up to the current radix bits, so it
+// never has fewer partitions than the data merged into it - Repartition/Combine only handle new >= old.
+void GrowAbandonedDataToRadixBits(ClientContext &context, RadixHTGlobalSinkState &gstate, RadixHTLocalSinkState &lstate,
+                                  const idx_t radix_bits) {
+	if (!lstate.abandoned_data ||
+	    lstate.abandoned_data->PartitionCount() >= RadixPartitioning::NumberOfPartitions(radix_bits)) {
+		return;
+	}
+	auto new_abandoned_data = make_uniq<RadixPartitionedTupleData>(
+	    BufferManager::GetBufferManager(context), gstate.radix_ht.GetLayoutPtr(), MemoryTag::HASH_TABLE, radix_bits,
+	    gstate.radix_ht.GetLayout().ColumnCount() - 1);
+	lstate.abandoned_data->Repartition(context, *new_abandoned_data);
+	lstate.abandoned_data = std::move(new_abandoned_data);
+}
+
 void MaybeRepartition(ClientContext &context, RadixHTGlobalSinkState &gstate, RadixHTLocalSinkState &lstate,
                       const bool combine) {
 	auto &config = gstate.config;
@@ -490,12 +505,15 @@ void MaybeRepartition(ClientContext &context, RadixHTGlobalSinkState &gstate, Ra
 	if (total_size > gstate.GetThreadLimit()) {
 		if (gstate.config.SetRadixBitsToExternal()) {
 			// We're approaching the memory limit, unpin the data
+			const auto external_radix_bits = config.GetRadixBits();
 			if (!lstate.abandoned_data) {
 				lstate.abandoned_data = make_uniq<RadixPartitionedTupleData>(
 				    BufferManager::GetBufferManager(context), gstate.radix_ht.GetLayoutPtr(), MemoryTag::HASH_TABLE,
-				    config.GetRadixBits(), gstate.radix_ht.GetLayout().ColumnCount() - 1);
+				    external_radix_bits, gstate.radix_ht.GetLayout().ColumnCount() - 1);
+			} else {
+				GrowAbandonedDataToRadixBits(context, gstate, lstate, external_radix_bits);
 			}
-			ht.SetRadixBits(gstate.config.GetRadixBits());
+			ht.SetRadixBits(external_radix_bits);
 			ht.AcquirePartitionedData()->Repartition(context, *lstate.abandoned_data);
 		}
 	}
@@ -600,6 +618,8 @@ void RadixPartitionedHashTable::Combine(ExecutionContext &context, GlobalSinkSta
 	auto lstate_data = ht.AcquirePartitionedData();
 	if (lstate.abandoned_data) {
 		D_ASSERT(gstate.external);
+		// The global radix bits may have grown after we last sized abandoned_data - grow it to match before combining
+		GrowAbandonedDataToRadixBits(context.client, gstate, lstate, gstate.config.GetRadixBits());
 		D_ASSERT(lstate.abandoned_data->PartitionCount() == lstate.ht->GetPartitionedData().PartitionCount());
 		D_ASSERT(lstate.abandoned_data->PartitionCount() ==
 		         RadixPartitioning::NumberOfPartitions(gstate.config.GetRadixBits()));

--- a/test/sql/aggregate/external/external_repartition_radix_grow.test_slow
+++ b/test/sql/aggregate/external/external_repartition_radix_grow.test_slow
@@ -1,0 +1,48 @@
+# name: test/sql/aggregate/external/external_repartition_radix_grow.test_slow
+# description: External hash aggregate must not crash when the global radix bits grow after going external
+# group: [external]
+
+# Stress guard for a segfault in TupleDataCollection::FinalizePinState, reached via
+# RadixPartitionedTupleData::RepartitionFinalizeStates <- PartitionedTupleData::Repartition <- MaybeRepartition.
+# A thread's abandoned_data is frozen at the radix bits of the moment it first goes external, but the global radix
+# bits can keep growing afterwards and the local HT data grows with them. Repartitioning the (now larger) HT data
+# into the (smaller, stale) abandoned_data made new_radix_bits - old_radix_bits underflow, indexing partitions[]
+# out of bounds. Triggering the exact interleaving depends on inter-operator memory dynamics and is not
+# deterministic, so this exercises the external hash-aggregate repartition path hard (many distinct wide groups +
+# tight memory limit + many threads) and asserts the result stays correct.
+
+load __TEST_DIR__/external_repartition_radix_grow.db
+
+# many threads: the repartition path is only taken above the grow-strategy thread threshold
+statement ok
+set threads=8
+
+# don't compress the materialized rows, otherwise the size estimates don't reflect what we want to test
+statement ok
+set disabled_optimizers to 'compressed_materialization'
+
+statement ok
+create table t as
+select (i % 3000000) as g,
+       concat((i % 3000000)::VARCHAR, repeat('x', 60)) as g_wide,
+       i as v
+from range(24000000) t(i)
+
+# go external at a low radix bit count, then let the many wide groups keep growing the radix bits
+statement ok
+pragma memory_limit='300MB'
+
+# sum(cnt) counts every input row exactly once  -> equals the number of rows (24000000)
+# sum(vsum) sums v over all groups              -> equals sum(i) for i in [0, 24000000)
+query II
+WITH cte AS (
+    SELECT g, g_wide, count(*) AS cnt, sum(v) AS vsum
+    FROM t
+    GROUP BY g, g_wide
+)
+SELECT sum(cnt), sum(vsum) FROM cte
+----
+24000000	287999988000000
+
+statement ok
+reset memory_limit


### PR DESCRIPTION
A thread's `abandoned_data` (the external-spill target) is sized once at the global radix bits of when it first went external and then frozen, but the global radix bits can keep growing afterwards along with the thread's own HT data. Merging the larger HT data into the smaller, stale `abandoned_data` makes `RepartitionFinalizeStates` compute `NumberOfPartitions(new_radix_bits - old_radix_bits)` with unsigned arithmetic: new < old underflows to a huge multiplier, indexing the partition and pin-state vectors out of bounds leading to segfault.

Fix: `GrowAbandonedDataToRadixBits` repartitions `abandoned_data` up to the current global radix bits (the supported new >= old direction) before merging into it, called in both the sink-phase external repartition and before the combine-phase Combine. As defense-in-depth, PartitionedTupleData::Repartition now throws instead of underflowing when asked to go to fewer partitions.