### PR TITLE
Preserve verbatim ATTACH path via AttachedDatabase::GetOriginalPath()

### DIFF
--- a/src/execution/operator/schema/physical_attach.cpp
+++ b/src/execution/operator/schema/physical_attach.cpp
@@ -23,6 +23,8 @@ SourceResultType PhysicalAttach::GetDataInternal(ExecutionContext &context, Data
 	// get the name and path of the database
 	auto &name = info->name;
 	auto &path = info->path;
+	// preserve the verbatim path before extension-prefix stripping
+	options.original_path = path;
 	if (options.db_type.empty()) {
 		DBPathAndType::ExtractExtensionPrefix(path, options.db_type);
 	}

--- a/src/include/duckdb/main/attached_database.hpp
+++ b/src/include/duckdb/main/attached_database.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "duckdb/common/optional.hpp"
 #include "duckdb/common/prefetched_file_data.hpp"
 #include "duckdb/main/config.hpp"
 #include "duckdb/catalog/catalog_entry.hpp"
@@ -72,6 +73,8 @@ struct AttachOptions {
 	RecoveryMode recovery_mode = RecoveryMode::DEFAULT;
 	//! The file format type. The default type is a duckdb database file, but other file formats are possible.
 	string db_type;
+	//! The verbatim path before extension-prefix stripping. Unset if not from an ATTACH statement.
+	optional<string> original_path;
 	//! Set of remaining (key, value) options
 	unordered_map<string, Value> options;
 	//! (optionally) a catalog can be provided with a default table
@@ -158,6 +161,10 @@ public:
 		return attach_options;
 	}
 	string StoredPath() const;
+	//! The verbatim ATTACH path before extension-prefix stripping. Unset if not from an ATTACH statement.
+	const optional<string> &GetOriginalPath() const {
+		return original_path;
+	}
 	static bool NameIsReserved(const Identifier &name);
 	static Identifier ExtractDatabaseName(const string &dbpath, FileSystem &fs);
 	// Invoke Close() on an attached database, if its use count is 1.
@@ -182,6 +189,7 @@ private:
 	shared_ptr<mutex> close_lock;
 	optional_idx vacuum_rebuild_threshold;
 	unordered_map<string, Value> attach_options;
+	optional<string> original_path;
 
 private:
 	//! Clean any (shared) resources held by the database.

--- a/src/main/attached_database.cpp
+++ b/src/main/attached_database.cpp
@@ -147,6 +147,7 @@ AttachedDatabase::AttachedDatabase(DatabaseInstance &db, Catalog &catalog_p, Ide
 	visibility = options.visibility;
 	ephemeral = options.ephemeral;
 	vacuum_rebuild_threshold = options.vacuum_rebuild_indexes_threshold;
+	original_path = options.original_path;
 
 	// We create the storage after the catalog to guarantee we allow extensions to instantiate the DuckCatalog.
 	catalog = make_uniq<DuckCatalog>(*this);
@@ -170,6 +171,7 @@ AttachedDatabase::AttachedDatabase(DatabaseInstance &db, Catalog &catalog_p, Sto
 	visibility = options.visibility;
 	ephemeral = options.ephemeral;
 	vacuum_rebuild_threshold = options.vacuum_rebuild_indexes_threshold;
+	original_path = options.original_path;
 
 	optional_ptr<StorageExtensionInfo> storage_info = storage_extension->storage_info.get();
 	catalog = storage_extension->attach(storage_info, context, *this, name.GetIdentifierName(), info, options);


### PR DESCRIPTION
Capture the user-supplied ATTACH path before extension-prefix stripping, so storage extensions (and introspection) can access it. Stored as an optional<string> on AttachOptions and AttachedDatabase and exposed via `GetOriginalPath()`; unset for databases not attached from an ATTACH statement.