### PR TITLE
Support CTAs for GetTableNames API

### DIFF
--- a/src/planner/binder/statement/bind_create.cpp
+++ b/src/planner/binder/statement/bind_create.cpp
@@ -795,6 +795,21 @@ BoundStatement Binder::Bind(CreateStatement &stmt) {
 		break;
 	}
 	case CatalogType::TABLE_ENTRY: {
+		// Skip real catalog/schema resolution in EXTRACT_NAMES or EXTRACT_QUALIFIED_NAMES mode
+		if (GetBindingMode() == BindingMode::EXTRACT_NAMES ||
+		    GetBindingMode() == BindingMode::EXTRACT_QUALIFIED_NAMES) {
+			auto &create_info = stmt.info->Cast<CreateTableInfo>();
+			if (GetBindingMode() == BindingMode::EXTRACT_QUALIFIED_NAMES) {
+				AddTableName(create_info.GetQualifiedName().ToString());
+			} else {
+				AddTableName(create_info.GetQualifiedName().Name().GetIdentifierName());
+			}
+			if (create_info.query) {
+				auto query_obj = Bind(*create_info.query);
+				result.plan = std::move(query_obj.plan);
+			}
+			break;
+		}
 		auto bound_info = BindCreateTableInfo(std::move(stmt.info));
 		auto root = std::move(bound_info->query);
 

--- a/test/api/test_get_table_names.cpp
+++ b/test/api/test_get_table_names.cpp
@@ -118,6 +118,31 @@ TEST_CASE("Test GetTableNames", "[api]") {
 	                                "TIMESTAMP '2001-04-11', INTERVAL 1 HOUR)) select * from series_generator");
 	REQUIRE(table_names.empty());
 
+	// table CTA
+	table_names = con.GetTableNames("CREATE TABLE some_cataloag.some_schema.some_table (a INT)");
+	REQUIRE(table_names.size() == 1);
+	REQUIRE(table_names.count("some_table"));
+
+	table_names = con.GetTableNames("CREATE TABLE some_cataloag.some_schema.some_table (a INT)", true);
+	REQUIRE(table_names.size() == 1);
+	REQUIRE(table_names.count("some_cataloag.some_schema.some_table"));
+
+	table_names = con.GetTableNames("CREATE TABLE some_cataloag.some_schema.some_table AS SELECT * FROM my_table");
+	REQUIRE(table_names.size() == 2);
+	REQUIRE(table_names.count("some_table"));
+	REQUIRE(table_names.count("my_table"));
+
+	table_names = con.GetTableNames("CREATE TEMP TABLE new_temp_table AS SELECT * FROM my_table");
+	REQUIRE(table_names.size() == 2);
+	REQUIRE(table_names.count("new_temp_table"));
+	REQUIRE(table_names.count("my_table"));
+
+	// CREATE TABLE IF NOT EXISTS
+	table_names = con.GetTableNames("CREATE TABLE IF NOT EXISTS my_schema.new_table4 AS SELECT * FROM my_table");
+	REQUIRE(table_names.size() == 2);
+	REQUIRE(table_names.count("new_table4"));
+	REQUIRE(table_names.count("my_table"));
+
 	if (!db.ExtensionIsLoaded("tpch")) {
 		return;
 	}


### PR DESCRIPTION
Hi folks, first time contributor here trying to fix #23762  I just filed 

I work for fivetran/dbt and I am leveraging your C++ client to inspect your logical plan/parsed tree. I noticed  [GetTableNames](https://github.com/duckdb/duckdb/blob/dfd87550849406b1823812222ef92525724780d3/src/main/connection.cpp#L328)  has what I need to extract referenced table names from SQL without needing to resolve the schema of the tables.

However, it doesn't work for `CREATE TABLE ... AS SELECT ...` (CTAS)): binding the write target tries to resolve its schema for real, which throws a binder error.

 This PR adds `EXTRACT_NAMES`/`EXTRACT_QUALIFIED_NAMES` support for `CREATE TABLE`

