### PR TITLE
Fixup some bugs in recent dsdgen parallelization work

### DIFF
--- a/extension/tpcds/dsdgen/dsdgen-c/scd.cpp
+++ b/extension/tpcds/dsdgen/dsdgen-c/scd.cpp
@@ -50,7 +50,7 @@
 #include "permute.h"
 
 /* an array of the most recent business key for each table */
-char arBKeys[MAX_TABLE][17];
+thread_local char arBKeys[MAX_TABLE][17];
 
 /*
  * Routine: setSCDKey

--- a/extension/tpcds/dsdgen/dsdgen-c/w_catalog_sales.cpp
+++ b/extension/tpcds/dsdgen/dsdgen-c/w_catalog_sales.cpp
@@ -65,6 +65,7 @@ static thread_local ds_key_t jDate;
 static thread_local int nTicketItemBase = 1;
 static thread_local int *pItemPermutation;
 static thread_local int nItemCount;
+static thread_local int nItemPermutationSize;
 
 /*
  * the validation process requires generating a single lineitem
@@ -84,7 +85,14 @@ static void mk_master(void *info_arr, ds_key_t index) {
 		strtodec(&dOne, "1.00");
 		strtodec(&dOneHalf, "0.50");
 		jDate = skipDays(CATALOG_SALES, &kNewDateIndex);
-		pItemPermutation = makePermutation(pItemPermutation, (nItemCount = (int)getIDCount(ITEM)), CS_PERMUTE);
+		nItemCount = (int)getIDCount(ITEM);
+		// A cached permutation is only reusable if it is at least as large as the
+		// current scale requires; otherwise re-allocate to avoid overflowing it.
+		if (nItemCount > nItemPermutationSize) {
+			pItemPermutation = NULL;
+			nItemPermutationSize = nItemCount;
+		}
+		pItemPermutation = makePermutation(pItemPermutation, nItemCount, CS_PERMUTE);
 
 		InitConstants::mk_master_catalog_sales_init = 1;
 	}

--- a/extension/tpcds/dsdgen/dsdgen-c/w_store_sales.cpp
+++ b/extension/tpcds/dsdgen/dsdgen-c/w_store_sales.cpp
@@ -59,6 +59,7 @@ extern thread_local rng_t Streams[];
 thread_local struct W_STORE_SALES_TBL g_w_store_sales;
 ds_key_t skipDays(int nTable, ds_key_t *pRemainder);
 static thread_local int *pItemPermutation, nItemCount, nItemIndex;
+static thread_local int nItemPermutationSize;
 static thread_local ds_key_t jDate, kNewDateIndex;
 
 /*
@@ -77,7 +78,14 @@ static void mk_master(void *info_arr, ds_key_t index) {
 		strtodec(&dMax, "100000.00");
 		nMaxItemCount = 20;
 		jDate = skipDays(STORE_SALES, &kNewDateIndex);
-		pItemPermutation = makePermutation(pItemPermutation, nItemCount = (int)getIDCount(ITEM), SS_PERMUTATION);
+		nItemCount = (int)getIDCount(ITEM);
+		// A cached permutation is only reusable if it is at least as large as the
+		// current scale requires; otherwise re-allocate to avoid overflowing it.
+		if (nItemCount > nItemPermutationSize) {
+			pItemPermutation = NULL;
+			nItemPermutationSize = nItemCount;
+		}
+		pItemPermutation = makePermutation(pItemPermutation, nItemCount, SS_PERMUTATION);
 
 		InitConstants::mk_master_store_sales_init = 1;
 	}

--- a/extension/tpcds/dsdgen/dsdgen-c/w_web_sales.cpp
+++ b/extension/tpcds/dsdgen/dsdgen-c/w_web_sales.cpp
@@ -125,6 +125,7 @@ static void mk_master(void *info_arr, ds_key_t index) {
 
 static void mk_detail(void *info_arr, int bPrint) {
 	static thread_local int *pItemPermutation, nItemCount;
+	static thread_local int nItemPermutationSize;
 	struct W_WEB_SALES_TBL *r;
 	int nShipLag, nTemp;
 	struct W_WEB_RETURNS_TBL w_web_returns;
@@ -132,7 +133,14 @@ static void mk_detail(void *info_arr, int bPrint) {
 
 	if (!InitConstants::mk_detail_init) {
 		jDate = skipDays(WEB_SALES, &kNewDateIndex);
-		pItemPermutation = makePermutation(pItemPermutation, nItemCount = (int)getIDCount(ITEM), WS_PERMUTATION);
+		nItemCount = (int)getIDCount(ITEM);
+		// A cached permutation is only reusable if it is at least as large as the
+		// current scale requires; otherwise re-allocate to avoid overflowing it.
+		if (nItemCount > nItemPermutationSize) {
+			pItemPermutation = NULL;
+			nItemPermutationSize = nItemCount;
+		}
+		pItemPermutation = makePermutation(pItemPermutation, nItemCount, WS_PERMUTATION);
 
 		InitConstants::mk_detail_init = 1;
 	}

--- a/extension/tpcds/dsdgen/include/dsdgen-c/scd.h
+++ b/extension/tpcds/dsdgen/include/dsdgen-c/scd.h
@@ -39,7 +39,7 @@
 #include "decimal.h"
 #include "tables.h"
 
-extern char arBKeys[MAX_TABLE][17];
+extern thread_local char arBKeys[MAX_TABLE][17];
 int setSCDKeys(int nTableID, ds_key_t hgIndex, char *szBKey, ds_key_t *hgBeginDateKey, ds_key_t *hgEndDateKey);
 ds_key_t scd_join(int tbl, int col, ds_key_t jDate);
 ds_key_t matchSCDSK(ds_key_t kUnique, ds_key_t jDate, int nTable);


### PR DESCRIPTION
Trigger was seeing failures in CI like:
```
config: patterns=['*'], workers=1, retry=2, max_retries=4, batch_size=10, batch_timeout_seconds=600, fail_require_skip=False
.................................................. [ 50%]
..............................
retrying failed test test/sql/tpcds/tpcds_reentrant.test_slow (attempt 1/2, retry 1/4)
retrying failed test test/sql/tpcds/tpcds_reentrant.test_slow (attempt 2/2, retry 2/4)
================================================================
error: FAIL test/sql/tpcds/tpcds_reentrant.test_slow

SIGTRAP - Trace/BPT trap: 5

reproduce:
build/release/test/unittest test/sql/tpcds/tpcds_reentrant.test_slow
```
Most likely introduced in parallelization rework at https://github.com/duckdb/duckdb/pull/23696

Failure reproduced with ASAN, can't repro anymore after the 2 commits of this PR, so that would point it's improving the situation.