### PR TITLE
Fix CLI JSON rendering for nested VARIANT

### DIFF
--- a/extension/json/json_functions/json_create.cpp
+++ b/extension/json/json_functions/json_create.cpp
@@ -933,6 +933,12 @@ static void CreateValues(const StructNames &names, yyjson_mut_doc *doc, yyjson_m
 		CreateRawValues(doc, vals, string_vector, count);
 		break;
 	}
+	case LogicalTypeId::VARIANT: {
+		Vector json_vector(LogicalType::JSON(), count);
+		VectorOperations::DefaultCast(value_v, json_vector, count);
+		TemplatedCreateValues<string_t, string_t>(doc, vals, json_vector, count);
+		break;
+	}
 	case LogicalTypeId::DECIMAL: {
 		if (DecimalType::GetWidth(type) > 15) {
 			Vector string_vector(LogicalTypeId::VARCHAR, count);
@@ -951,7 +957,6 @@ static void CreateValues(const StructNames &names, yyjson_mut_doc *doc, yyjson_m
 	case LogicalTypeId::TEMPLATE:
 	case LogicalTypeId::UNBOUND:
 	case LogicalTypeId::TYPE:
-	case LogicalTypeId::VARIANT:
 	case LogicalTypeId::CHAR:
 	case LogicalTypeId::STRING_LITERAL:
 	case LogicalTypeId::INTEGER_LITERAL:

--- a/test/sql/json/scalar/test_json_create.test
+++ b/test/sql/json/scalar/test_json_create.test
@@ -37,6 +37,11 @@ select json_object('x', 42::VARIANT)
 ----
 {"x":42}
 
+query T
+select [{'a': 1, 'b': [1]}::VARIANT]::JSON
+----
+[{"a":1,"b":[1]}]
+
 statement error
 select to_json({n: 42}, {extra: 'argument'})
 ----

--- a/tools/shell/tests/test_shell_rendering.py
+++ b/tools/shell/tests/test_shell_rendering.py
@@ -100,6 +100,18 @@ def test_mode_json_escapes(shell):
     result = test.run()
     result.check_stdout('{"name":"test","a":[4,5,6],"s":{"key":7}}')
 
+
+def test_mode_json_nested_variant(shell):
+    test = (
+        ShellTest(shell)
+        .statement(".mode json")
+        .statement("SELECT [{'a': 1, 'b': [1]}::VARIANT] AS v;")
+    )
+
+    result = test.run()
+    result.check_stdout('{"v":[{"a":1,"b":[1]}]}')
+
+
 def test_mode_json_empty_result(shell):
     test = (
         ShellTest(shell)


### PR DESCRIPTION
## Summary

- serialize `VARIANT` values encountered during recursive JSON creation through DuckDB's canonical `VARIANT` to `JSON` cast
- add SQL and CLI regression coverage for nested `VARIANT` values

## Root cause

The CLI JSON renderer casts nested result vectors directly to `JSON`. The JSON creation visitor recursed through lists and structs but treated a nested `VARIANT` as unsupported, even though normal scalar-function binding inserts a `VARIANT` to `JSON` cast for top-level values.

## Impact

Nested `VARIANT` values now render correctly in the CLI's `json` and `jsonlines` modes instead of raising an internal error.

## Validation

- built the DuckDB library and shell with the JSON extension using MSVC
- ran `python -m pytest tools/shell/tests/test_shell_rendering.py --shell-binary <duckdb.exe> -q` (`14 passed`)
- verified `SELECT [{'a': 1, 'b': [1]}::VARIANT] AS v;` in both `json` and `jsonlines` modes
- ran DuckDB's formatter and typo checker

Fixes #23745
