### PR TITLE
Convert TIMETZ to UTC on parquet write

### DIFF
--- a/extension/parquet/include/writer/parquet_write_operators.hpp
+++ b/extension/parquet/include/writer/parquet_write_operators.hpp
@@ -11,6 +11,7 @@
 #include "writer/parquet_write_stats.hpp"
 #include "parquet_timestamp.hpp"
 #include "zstd/common/xxhash.hpp"
+#include "duckdb/common/types/time.hpp"
 #include "duckdb/common/types/uhugeint.hpp"
 #include "duckdb/common/types/uuid.hpp"
 
@@ -317,7 +318,7 @@ struct ParquetUUIDOperator : public BaseParquetOperator {
 struct ParquetTimeTZOperator : public BaseParquetOperator {
 	template <class SRC, class TGT>
 	static TGT Operation(SRC input) {
-		return input.time().value;
+		return Time::NormalizeTimeTZ(input).value;
 	}
 
 	template <class SRC, class TGT>

--- a/test/sql/copy/parquet/writer/parquet_test_all_types.test
+++ b/test/sql/copy/parquet/writer/parquet_test_all_types.test
@@ -17,12 +17,12 @@ COPY all_types TO "{TEST_DIR}/all_types.parquet" (FORMAT PARQUET);
 
 # we have to make some replacements to get result equivalence
 # hugeint/uhugeint is stored as double -> we have to cast
-# TIME WITH TIME ZONE loses the offset
+# TIME WITH TIME ZONE is stored as a UTC-adjusted Parquet TIME
 query I nosort alltypes
 SELECT * REPLACE (
 	hugeint::DOUBLE AS hugeint,
 	uhugeint::DOUBLE AS uhugeint,
-	time_tz::TIME::TIMETZ AS time_tz
+	timezone(interval '0 seconds', time_tz) AS time_tz
 )
 FROM all_types
 ----

--- a/test/sql/copy/parquet/writer/parquet_timetz_roundtrip.test
+++ b/test/sql/copy/parquet/writer/parquet_timetz_roundtrip.test
@@ -1,0 +1,24 @@
+# name: test/sql/copy/parquet/writer/parquet_timetz_roundtrip.test
+# description: TIME WITH TIME ZONE is written as UTC-adjusted Parquet TIME
+# group: [writer]
+
+require parquet
+
+statement ok
+COPY (
+	SELECT *
+	FROM (VALUES
+		(TIMETZ '12:34:56+02'),
+		(TIMETZ '01:00:00+02'),
+		(TIMETZ '23:30:00-02')
+	) tbl(x)
+) TO '{TEST_DIR}/timetz_roundtrip.parquet' (FORMAT PARQUET)
+
+query II
+SELECT x::VARCHAR, typeof(x)
+FROM read_parquet('{TEST_DIR}/timetz_roundtrip.parquet')
+ORDER BY 1
+----
+01:30:00+00	TIME WITH TIME ZONE
+10:34:56+00	TIME WITH TIME ZONE
+23:00:00+00	TIME WITH TIME ZONE


### PR DESCRIPTION
Closes https://github.com/duckdb/duckdb/issues/23766

The root cause is, on parquet write, we mark it as [converted to UTC timezone](https://github.com/duckdb/duckdb/blob/2009475939c7b5ada2e55cc74843339bd9be79e3/extension/parquet/parquet_writer.cpp#L270), but on write it's getting the [microseconds for `dtime_tz_t`](https://github.com/duckdb/duckdb/blob/2009475939c7b5ada2e55cc74843339bd9be79e3/extension/parquet/include/writer/parquet_write_operators.hpp#L319-L321) at [local timezone](https://github.com/duckdb/duckdb/blob/2009475939c7b5ada2e55cc74843339bd9be79e3/src/include/duckdb/common/types/datetime.hpp#L149-L151) without considering offsets. In one word, we loss the offset information on write.

On read, we're constructing with [UTC timezone](https://github.com/duckdb/duckdb/blob/2009475939c7b5ada2e55cc74843339bd9be79e3/extension/parquet/parquet_timestamp.cpp#L149-L152); so the fix in this PR is to store in UTC timezone directly.