### PR TITLE
Patch postgres_scanner: report NOTHING for CONNECT-routed commands

### DIFF
--- a/.github/patches/extensions/postgres_scanner/zzzzzzzz-zz-connect-return-type.patch
+++ b/.github/patches/extensions/postgres_scanner/zzzzzzzz-zz-connect-return-type.patch
@@ -1,0 +1,15 @@
+diff --git a/src/postgres_query.cpp b/src/postgres_query.cpp
+index 8096f14..4f31936 100644
+--- a/src/postgres_query.cpp
++++ b/src/postgres_query.cpp
+@@ -85,6 +85,10 @@ static unique_ptr<FunctionData> PGQueryBind(ClientContext &context, TableFunctio
+ 		// the prepare/describe just done — no extra round-trip — and defer execution to
+ 		// InitGlobalState (execution time, not bind, so EXPLAIN does not run it).
+ 		result->command_only = true;
++		// This invocation wraps a command with no result set (DDL, or DML without RETURNING). Tell the
++		// binder via the return-type modifier so that when this is routed through CONNECT the outer
++		// statement is reported as NOTHING and displays like a native command (no spurious result table).
++		input.table_function.call_return_type = StatementReturnType::NOTHING;
+ 		return_types.emplace_back(LogicalType::BOOLEAN);
+ 		names.emplace_back("Success");
+ 		result->SetCatalog(pg_catalog);


### PR DESCRIPTION
When postgres_query prepares a statement that returns no result columns (DDL, or DML without RETURNING) it takes the command_only path. Set the table function's call_return_type to NOTHING there so that, combined with the core `SELECT * FROM func()` propagation, a command routed through CONNECT to a postgres database displays like a native command instead of a "Success" table.

Carried as an extension patch against the pinned postgres_scanner; the permanent change belongs in duckdb/duckdb-postgres.


This commit was somehow lost in history, like merged and then the patch deleted but not applied. Let's bring this back.