### PR TITLE
Fix lance build on Rust 1.97: patch its Cargo.lock to ethnum 1.5.3

### DIFF
--- a/.github/config/extensions/lance.cmake
+++ b/.github/config/extensions/lance.cmake
@@ -3,6 +3,7 @@ if (NOT MINGW AND NOT ${WASM_ENABLED})
             GIT_URL https://github.com/lance-format/lance-duckdb
             GIT_TAG cd592bc76dfeac28bc7d6344a5bf85c4d4c31405
             SUBMODULES extension-ci-tools
+            APPLY_PATCHES
             LOAD_TESTS
             DONT_LINK
     )

--- a/.github/patches/extensions/lance/0001-bump-ethnum-to-1.5.3-for-rust-1.97.patch
+++ b/.github/patches/extensions/lance/0001-bump-ethnum-to-1.5.3-for-rust-1.97.patch
@@ -1,0 +1,16 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index 34d7760..56ffb8d 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -2096,9 +2096,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "ethnum"
+-version = "1.5.2"
++version = "1.5.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
++checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
+ 
+ [[package]]
+ name = "event-listener"


### PR DESCRIPTION
lance-duckdb's committed Cargo.lock pins ethnum 1.5.2, whose error.rs fabricates a `core::num::TryFromIntError` via `mem::transmute(())`. That assumed the type was zero-sized; it is now 8 bits, so on Rust >= 1.97 the build fails with E0512. Rust 1.97 went stable on 2026-07-07, which is what turned this into a CI failure here.

ethnum 1.5.3 replaces the transmutes with safe constructors. jsonb (the crate that pulls ethnum in, via lance-arrow) requires `ethnum ^1.5.2`, so 1.5.3 already satisfies it: the fix is purely a lockfile refresh, a two-line diff with no manifest change and no other dependency moving.

Carry that refresh as an extension patch so the build is unblocked without waiting on upstream. The patch context is generated against the pinned GIT_TAG cd592bc, so the tag and the patch must be bumped together.

The durable fix belongs upstream in lance-format/lance-duckdb, which has not refreshed its lockfile; the sibling lance-format/lance repo already has.