### PR TITLE
Accumulate probe match count thread-locally

### DIFF
--- a/src/execution/join_hashtable.cpp
+++ b/src/execution/join_hashtable.cpp
@@ -1446,6 +1446,10 @@ void ScanStructure::Next(DataChunk &keys, DataChunk &probe_data, DataChunk &resu
 	default:
 		throw InternalException("Unhandled join type in JoinHashTable");
 	}
+
+	if (PointersExhausted()) {
+		FlushProbeMatches();
+	}
 }
 
 bool ScanStructure::PointersExhausted() const {
@@ -1484,10 +1488,18 @@ idx_t ScanStructure::ResolvePredicates(DataChunk &keys, DataChunk &probe_data, S
 		result_count = ApplyResidualPredicate(probe_data, match_sel, result_count, no_match_sel, no_match_count);
 	}
 
-	// Update total probe match count
-	ht.total_probe_matches.fetch_add(result_count, std::memory_order_relaxed);
-
+	// accumulate matches locally, will be flushed globally if PointersExhausted is true and we
+	// finished walking the chains
+	local_probe_matches += result_count;
 	return result_count;
+}
+
+void ScanStructure::FlushProbeMatches() {
+	if (local_probe_matches == 0) {
+		return;
+	}
+	ht.total_probe_matches.fetch_add(local_probe_matches, std::memory_order_relaxed);
+	local_probe_matches = 0;
 }
 
 idx_t ScanStructure::ApplyResidualPredicate(DataChunk &probe_data, SelectionVector &match_sel, idx_t match_count,

--- a/src/include/duckdb/execution/join_hashtable.hpp
+++ b/src/include/duckdb/execution/join_hashtable.hpp
@@ -123,12 +123,17 @@ public:
 		idx_t last_match_count;
 		SelectionVector last_sel_vector;
 
+		// thread-local probe match count, flushed to ht.total_probe_matches once per thread to avoid contention
+		idx_t local_probe_matches = 0;
+
 		explicit ScanStructure(JoinHashTable &ht, TupleDataChunkState &key_state);
 		void Reset();
 		//! Get the next batch of data from the scan structure
 		void Next(DataChunk &keys, DataChunk &probe_data, DataChunk &result);
 		//! Are pointer chains all pointing to NULL?
 		bool PointersExhausted() const;
+		//! Flush the thread-local probe match count into the global counter (idempotent)
+		void FlushProbeMatches();
 
 	private:
 		//! Next operator for the inner join


### PR DESCRIPTION
https://github.com/duckdb/duckdb/pull/19683 introduced logging for the number of probe matches, which can cause a performance regression in specific cases:

With the very selective n:m joins of the JOB benchmark, it can happen (often) that in a join only a few tuples of an incoming chunk find a match, and that these tuples produce many outputs, as there are many duplicates in the RHS, and therefore `AdvancePointer` / `ResolvePredicates` is called many, many times with only a few tuples. 

In these scenarios, `ht.total_probe_matches.fetch_add` in `ResolvePredicates` became a bottleneck when running JOB with many threads. I have now added a local aggregate for this scenario that is then flushed to the global state once all chains have been exhausted.

A more structural but complicated way could be to do something like https://github.com/duckdb/duckdb/pull/14956 to compact the vectors by asking for more input rows for selective probes before calling `ScanStructure::Next`. This way, `ResolvePredicates` would never be hit with fewer than N tuples. 

I did run experiments on my MacBook Pro M4 with 12 threads. For this setting, JOB 16b is now down from 192ms to 95ms.

Here is a profiler comparison of the whole JOB/IMDB benchmark. Before the PR, Next Inner Join accounted for 18% of the total runtime; now it is at 3.7%.
<img width="2166" height="1268" alt="flamegraph_join_atomic" src="https://github.com/user-attachments/assets/2a720672-9344-40cd-a1b0-1d2cb4982930" />


 

