### PR TITLE
Fix narrow cast invertibility

### DIFF
--- a/src/optimizer/rule/comparison_simplification.cpp
+++ b/src/optimizer/rule/comparison_simplification.cpp
@@ -117,6 +117,11 @@ unique_ptr<Expression> ComparisonSimplificationRule::Apply(LogicalOperator &op, 
 		//! invertible in practice.
 		auto &cast_expression = column_ref_expr.Cast<BoundCastExpression>();
 		auto target_type = cast_expression.source_type();
+		if (cast_expression.IsTryCast() && target_type.IsIntegral() && cast_expression.GetReturnType().IsIntegral() &&
+		    LogicalType::DefaultForceMaxLogicalType(target_type, cast_expression.GetReturnType()) !=
+		        cast_expression.GetReturnType()) {
+			return nullptr;
+		}
 		if (!BoundCastExpression::CastIsInvertible(target_type, cast_expression.GetReturnType())) {
 			return nullptr;
 		}

--- a/src/planner/expression/bound_cast_expression.cpp
+++ b/src/planner/expression/bound_cast_expression.cpp
@@ -154,6 +154,9 @@ bool BoundCastExpression::CastIsInvertible(const LogicalType &source_type, const
 		}
 		return true;
 	}
+	if (source_type.IsIntegral() && target_type.IsIntegral()) {
+		return LogicalType::DefaultForceMaxLogicalType(source_type, target_type) == target_type;
+	}
 	switch (source_type.id()) {
 	case LogicalTypeId::TIMESTAMP:
 	case LogicalTypeId::TIMESTAMP_TZ:
@@ -207,9 +210,6 @@ bool BoundCastExpression::CastIsInvertible(const LogicalType &source_type, const
 		default:
 			return false;
 		}
-	}
-	if (source_type.IsSigned() && target_type.IsUnsigned()) {
-		return false;
 	}
 	return true;
 }

--- a/src/planner/expression/bound_cast_expression.cpp
+++ b/src/planner/expression/bound_cast_expression.cpp
@@ -154,9 +154,6 @@ bool BoundCastExpression::CastIsInvertible(const LogicalType &source_type, const
 		}
 		return true;
 	}
-	if (source_type.IsIntegral() && target_type.IsIntegral()) {
-		return LogicalType::DefaultForceMaxLogicalType(source_type, target_type) == target_type;
-	}
 	switch (source_type.id()) {
 	case LogicalTypeId::TIMESTAMP:
 	case LogicalTypeId::TIMESTAMP_TZ:
@@ -210,6 +207,9 @@ bool BoundCastExpression::CastIsInvertible(const LogicalType &source_type, const
 		default:
 			return false;
 		}
+	}
+	if (source_type.IsSigned() && target_type.IsUnsigned()) {
+		return false;
 	}
 	return true;
 }

--- a/test/sql/optimizer/expression/test_comparison_simplification.test
+++ b/test/sql/optimizer/expression/test_comparison_simplification.test
@@ -35,7 +35,7 @@ ORDER BY 1
 2016-02-15 10:04:25
 2016-02-16 10:04:25
 
-# Narrowing casts are not invertible
+# Narrowing TRY_CAST expressions are not invertible
 statement ok
 CREATE TABLE issue23687 (a INTEGER);
 
@@ -46,8 +46,3 @@ query I
 SELECT list(a ORDER BY a) FROM issue23687 WHERE TRY_CAST(a AS TINYINT) > 50;
 ----
 [51, 127]
-
-statement error
-SELECT a FROM issue23687 WHERE CAST(a AS TINYINT) > 50;
-----
-<REGEX>:Conversion Error:.*out of range.*

--- a/test/sql/optimizer/expression/test_comparison_simplification.test
+++ b/test/sql/optimizer/expression/test_comparison_simplification.test
@@ -34,3 +34,20 @@ ORDER BY 1
 ----
 2016-02-15 10:04:25
 2016-02-16 10:04:25
+
+# Narrowing casts are not invertible
+statement ok
+CREATE TABLE issue23687 (a INTEGER);
+
+statement ok
+INSERT INTO issue23687 VALUES (51), (127), (128), (200), (300), (-200);
+
+query I
+SELECT list(a ORDER BY a) FROM issue23687 WHERE TRY_CAST(a AS TINYINT) > 50;
+----
+[51, 127]
+
+statement error
+SELECT a FROM issue23687 WHERE CAST(a AS TINYINT) > 50;
+----
+<REGEX>:Conversion Error:.*out of range.*


### PR DESCRIPTION
Fixes #23687.

### Summary
`BoundCastExpression::CastIsInvertible` incorrectly treated narrowing integral casts as invertible. This allowed the comparison simplification optimizer to remove casts such as `TRY_CAST(INTEGER AS TINYINT)`, resulting in incorrect behaviour for values outside the target type's range.
This change ensures that an integral cast is considered invertible only when the target type can represent all values of the source type.

Regression tests have also been added to cover:
- Correct results for `TRY_CAST`
- Error preservation for regular `CAST`

### Tests
- `make reldebug`
- `build/reldebug/test/unittest test/sql/optimizer/expression/test_comparison_simplification.test`
- Related IN-clause and filter-pushdown optimizer tests