### PR TITLE
Fix list slice to array casts

### DIFF
--- a/src/function/cast/list_casts.cpp
+++ b/src/function/cast/list_casts.cpp
@@ -225,16 +225,14 @@ static bool ListToArrayCast(Vector &source, Vector &result, idx_t count, CastPar
 		// We can just cast the child vector directly
 		// Note: Its worth doing a CheckAllValid here, the slow path is significantly more expensive
 		if (FlatVector::ValidityMutable(result).CheckAllValid(count)) {
-			Vector payload_vector(result_cc.GetType(), child_count);
+			Vector payload_vector(source_cc.GetType(), child_count);
+			VectorOperations::Copy(source_cc, payload_vector, child_sel, child_count, 0, 0);
 
-			bool ok = cast_data.child_cast_info.Cast(source_cc, payload_vector, child_count, child_parameters);
+			bool ok = cast_data.child_cast_info.Cast(payload_vector, result_cc, child_count, child_parameters);
 			if (all_ok && !ok) {
 				all_ok = false;
 				HandleCastError::AssignError(*child_parameters.error_message, parameters);
 			}
-			// Now do the actual copy onto the result vector, making sure to slice properly in case the lists are out of
-			// order
-			VectorOperations::Copy(payload_vector, result_cc, child_sel, child_count, 0, 0);
 			return all_ok;
 		}
 

--- a/src/function/cast/list_casts.cpp
+++ b/src/function/cast/list_casts.cpp
@@ -225,14 +225,16 @@ static bool ListToArrayCast(Vector &source, Vector &result, idx_t count, CastPar
 		// We can just cast the child vector directly
 		// Note: Its worth doing a CheckAllValid here, the slow path is significantly more expensive
 		if (FlatVector::ValidityMutable(result).CheckAllValid(count)) {
-			Vector payload_vector(source_cc.GetType(), child_count);
-			VectorOperations::Copy(source_cc, payload_vector, child_sel, child_count, 0, 0);
+			Vector source_payload(source_cc.GetType(), child_count);
+			VectorOperations::Copy(source_cc, source_payload, child_sel, child_count, 0, 0);
+			Vector result_payload(result_cc.GetType(), child_count);
 
-			bool ok = cast_data.child_cast_info.Cast(payload_vector, result_cc, child_count, child_parameters);
+			bool ok = cast_data.child_cast_info.Cast(source_payload, result_payload, child_count, child_parameters);
 			if (all_ok && !ok) {
 				all_ok = false;
 				HandleCastError::AssignError(*child_parameters.error_message, parameters);
 			}
+			VectorOperations::Copy(result_payload, result_cc, child_count, 0, 0);
 			return all_ok;
 		}
 

--- a/test/sql/types/nested/array/array_try_cast.test
+++ b/test/sql/types/nested/array/array_try_cast.test
@@ -6,6 +6,14 @@ SELECT TRY_CAST(array_value(1,2) as INTEGER[3]);
 ----
 NULL
 
+# List child values can be non-contiguous
+query II
+WITH t(l) AS (VALUES (['bad','1','2']), (['bad','3','4']))
+SELECT CAST(list_slice(l, 2, 3) AS INTEGER[2]), TRY_CAST(list_slice(l, 2, 3) AS INTEGER[2]) FROM t;
+----
+[1, 2]	[1, 2]
+[3, 4]	[3, 4]
+
 statement error
 SELECT CAST(array_value(1,2) as INTEGER[3]);
 ----


### PR DESCRIPTION
 Fixes #23716.
  The non-constant list-to-array cast path cast the full child vector before applying the list child selection. For sliced lists, the child offsets could therefore refer to the wrong positions in the cast result, producing incorrect values.
  This change gathers the selected child values into a contiguous source vector before casting them into the result array.

  A regression test covers both `CAST` and `TRY_CAST` with sliced lists containing different child offsets.

  Tested with:

  ```text
  build/reldebug/test/unittest test/sql/types/nested/array/array_try_cast.test