### PR TITLE
Fix INTERNAL error casting pre-epoch TIMESTAMP_NS to TIME_NS

### DIFF
--- a/src/common/types/timestamp.cpp
+++ b/src/common/types/timestamp.cpp
@@ -380,7 +380,7 @@ dtime_ns_t Timestamp::GetTimeNs(timestamp_ns_t input) {
 	if (!input.IsFinite()) {
 		throw ConversionException("Can't get TIME_NS of infinite TIMESTAMP");
 	}
-	date_t date = Timestamp::GetDate(Timestamp::FromEpochNanoSeconds(input.value));
+	date_t date = Timestamp::GetDateNS(input);
 	int64_t nanos;
 	if (!TryMultiplyOperator::Operation<int64_t, int64_t, int64_t>(date.days, Interval::NANOS_PER_DAY, nanos)) {
 		throw ConversionException("Overflow extracting TIME_NS of TIMESTAMP");

--- a/test/sql/types/time/test_time_ns.test
+++ b/test/sql/types/time/test_time_ns.test
@@ -344,3 +344,25 @@ query I
 SELECT '1962-05-20 15:30:00.123456789'::TIMESTAMP_NS::TIME_NS t;
 ----
 15:30:00.123456789
+
+# pre-epoch timestamps within a microsecond of midnight: the time-of-day is the
+# wall-clock time, not a negative value carried over from the truncated date
+query I
+SELECT (TIMESTAMP_NS '1969-12-31 23:59:59.999999999'::TIME_NS)::VARCHAR t;
+----
+23:59:59.999999999
+
+query I
+SELECT '1969-12-31 23:59:59.999999'::TIMESTAMP_NS::TIME_NS t;
+----
+23:59:59.999999
+
+query I
+SELECT '1969-12-31 23:59:59.000000001'::TIMESTAMP_NS::TIME_NS t;
+----
+23:59:59.000000001
+
+query I
+SELECT '1969-06-15 08:30:15.123456789'::TIMESTAMP_NS::TIME_NS t;
+----
+08:30:15.123456789


### PR DESCRIPTION
Casting a `TIMESTAMP_NS` from the last microsecond before the epoch to `TIME_NS` throws an INTERNAL error:

```
SELECT (TIMESTAMP_NS '1969-12-31 23:59:59.999999999'::TIME_NS)::VARCHAR;
-- INTERNAL Error: Information loss on integer cast: value -952 outside of target range [-128, 127]
```

`GetTimeNs` gets the date by truncating the nanoseconds to microseconds first, so -1 ns lands on the epoch instead of 1969-12-31 and the time-of-day goes negative, which is what overflows the formatter. Switching to `GetDateNS` (already nanosecond-accurate) fixes it, and only pre-epoch values right on midnight change.

`::DATE` and `::TIME` are off on the same input too, but through a different path, so I left those alone. Added tests in `test/sql/types/time/test_time_ns.test` for the crash and a few midnight boundary cases.

Closes #23722
