### PR TITLE
Fix percentile_cont/disc(0) with descending order

### DIFF
--- a/extension/core_functions/aggregate/holistic/quantile.cpp
+++ b/extension/core_functions/aggregate/holistic/quantile.cpp
@@ -14,7 +14,15 @@
 #include "duckdb/function/aggregate/list_aggregate.hpp"
 #include "duckdb/function/create_sort_key.hpp"
 
+#include <cmath>
+
 namespace duckdb {
+
+// Descending order is encoded as a negative quantile parameter. A zero fraction
+// is stored as negative zero, so use the sign bit to detect that case as well.
+static bool QuantileDescending(const Value &q) {
+	return std::signbit(q.GetValue<double>());
+}
 
 template <class INPUT_TYPE>
 struct IndirectLess {
@@ -66,7 +74,7 @@ QuantileBindData::QuantileBindData() {
 }
 
 QuantileBindData::QuantileBindData(const Value &quantile_p)
-    : quantiles(1, QuantileValue(QuantileAbs(quantile_p))), order(1, 0), desc(quantile_p < 0) {
+    : quantiles(1, QuantileValue(QuantileAbs(quantile_p))), order(1, 0), desc(QuantileDescending(quantile_p)) {
 }
 
 QuantileBindData::QuantileBindData(const vector<Value> &quantiles_p) {
@@ -76,7 +84,7 @@ QuantileBindData::QuantileBindData(const vector<Value> &quantiles_p) {
 	for (idx_t i = 0; i < quantiles_p.size(); ++i) {
 		const auto &q = quantiles_p[i];
 		pos += (q > 0);
-		neg += (q < 0);
+		neg += QuantileDescending(q);
 		normalised.push_back(QuantileAbs(q));
 		order.push_back(i);
 	}

--- a/src/planner/binder/expression/bind_aggregate_expression.cpp
+++ b/src/planner/binder/expression/bind_aggregate_expression.cpp
@@ -61,6 +61,12 @@ static Value NegatePercentileValue(const Value &v, const bool desc) {
 		return v;
 	}
 
+	// A zero fraction has no sign to negate (-0 == 0), which would drop the descending order.
+	// Emit a negative zero so the sign survives to the aggregate bind data.
+	if (frac == 0) {
+		return Value::DOUBLE(-0.0);
+	}
+
 	const auto &type = v.type();
 	switch (type.id()) {
 	case LogicalTypeId::DECIMAL: {

--- a/test/sql/aggregate/aggregates/test_quantile_cont.test
+++ b/test/sql/aggregate/aggregates/test_quantile_cont.test
@@ -140,6 +140,16 @@ FROM
 ----
 1.2	1.2
 
+# p=0.0 with DESC ordering picks the largest value; negative zero must still read as descending
+query II
+SELECT
+    percentile_cont(0.0) WITHIN GROUP (ORDER BY x DESC),
+    quantile_cont(x, [0.0] ORDER BY x DESC),
+FROM
+    (VALUES (1), (2), (3), (4), (5)) _(x);
+----
+5.0	[5.0]
+
 # empty input
 query R
 SELECT quantile_cont(r, 0.1) FROM quantile WHERE 1=0

--- a/test/sql/aggregate/aggregates/test_quantile_disc.test
+++ b/test/sql/aggregate/aggregates/test_quantile_disc.test
@@ -100,6 +100,16 @@ FROM
 ----
 1.2	1.2
 
+# p=0.0 with DESC ordering picks the largest value; negative zero must still read as descending
+query II
+SELECT
+    percentile_disc(0.0) WITHIN GROUP (ORDER BY x DESC),
+    quantile_disc(x, [0.0] ORDER BY x DESC),
+FROM
+    (VALUES (1), (2), (3), (4), (5)) _(x);
+----
+5	[5]
+
 #
 # VARCHAR. Remember, this is dictionary ordering, not numeric ordering!
 #


### PR DESCRIPTION
`percentile_cont(0.0) WITHIN GROUP (ORDER BY x DESC)` gives the min instead of the max:

```sql
SELECT percentile_cont(0.0) WITHIN GROUP (ORDER BY x DESC) FROM range(1,6) t(x);
-- returns 1.0, expected 5.0
```

DESC gets passed to the aggregate as a negative fraction, but `0.0` negates to `-0.0` which isn't `< 0`, so a zero fraction loses the descending flag and reads as ascending. The fix keeps a real `-0.0` through the binder and checks the sign with `signbit` (kept it in the existing sign convention rather than rewiring how the order reaches the aggregate). `percentile_disc(0.0)` and the list form had the same thing.

Tests added in both quantile files, fail on main and pass with the fix.

Closes #23692
