### PR TITLE
TryLookupEntry now uses default schema as fallback

### DIFF
--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -462,13 +462,23 @@ vector<SimilarCatalogEntry> Catalog::SimilarEntriesInSchemas(ClientContext &cont
 }
 
 vector<CatalogSearchEntry> GetCatalogEntries(CatalogEntryRetriever &retriever, const string &catalog,
-                                             const string &schema) {
+                                             const string &schema, CatalogType lookup_type = CatalogType::INVALID) {
 	auto &context = retriever.GetContext();
 	vector<CatalogSearchEntry> entries;
 	auto &search_path = retriever.GetSearchPath();
 	if (IsInvalidCatalog(catalog) && IsInvalidSchema(schema)) {
-		// no catalog or schema provided - scan the entire search path
-		entries = search_path.Get();
+		// no catalog or schema provided - scan the entire search path. For non-table lookups, implicit catalogs that
+		// requested precedence (e.g. a view's own catalog while binding its body) are resolved to their default
+		// schema in place so they keep their priority; tables use the separate default-table mechanism instead.
+		//
+		// lookup_type is optional (CatalogType::INVALID means the caller did not specify one, e.g. callers that
+		// only ever pass a concrete catalog/schema); when unknown we treat it like a table lookup and skip the
+		// precedence resolution.
+		if (lookup_type == CatalogType::INVALID || lookup_type == CatalogType::TABLE_ENTRY) {
+			entries = search_path.Get();
+		} else {
+			entries = search_path.GetWithPrecedenceSchemas(context);
+		}
 	} else if (IsInvalidCatalog(catalog)) {
 		auto catalogs = search_path.GetCatalogsForSchema(schema);
 		for (auto &catalog_name : catalogs) {
@@ -920,9 +930,9 @@ CatalogEntryLookup Catalog::TryLookupEntry(CatalogEntryRetriever &retriever, con
 
 	// Special case for non-table entries (functions, macros, types): mirroring the default-table fallback above, if
 	// the entry could not be resolved through the regular search path we fall back to the default schema of any
-	// catalog flagged as an implicit search catalog (added to the path with an INVALID_SCHEMA entry, e.g. a view's
-	// own catalog while binding its body). Like the default-table lookup, this only kicks in when the entry is
-	// otherwise unresolved, so the search is never widened when it is not needed.
+	// catalog flagged as an implicit search catalog (added to the path with an INVALID_SCHEMA entry), but only
+	// if the catalog did not request precedence. Catalogs that requested precedence were already searched at their
+	// position in the search path.
 	if (lookup_info.GetCatalogType() != CatalogType::TABLE_ENTRY && allow_default_lookup && !result.Found()) {
 		result = TryLookupDefaultSchema(retriever, lookup_info);
 		if (result.error.HasError()) {
@@ -1018,7 +1028,9 @@ CatalogEntryLookup Catalog::TryLookupDefaultSchema(CatalogEntryRetriever &retrie
 CatalogEntryLookup Catalog::TryLookupEntry(CatalogEntryRetriever &retriever, const string &catalog,
                                            const string &schema, const EntryLookupInfo &lookup_info,
                                            OnEntryNotFound if_not_found) {
-	auto entries = GetCatalogEntries(retriever, catalog, schema);
+	// GetCatalogEntries resolves the search path, inlining the default schema of any implicit catalog that requested
+	// precedence (e.g. a view's own catalog while binding its body) for non-table lookups.
+	auto entries = GetCatalogEntries(retriever, catalog, schema, lookup_info.GetCatalogType());
 	vector<CatalogLookup> lookups;
 	vector<CatalogLookup> final_lookups;
 	lookups.reserve(entries.size());

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -462,26 +462,13 @@ vector<SimilarCatalogEntry> Catalog::SimilarEntriesInSchemas(ClientContext &cont
 }
 
 vector<CatalogSearchEntry> GetCatalogEntries(CatalogEntryRetriever &retriever, const string &catalog,
-                                             const string &schema, bool include_implicit_search_catalogs = false) {
+                                             const string &schema) {
 	auto &context = retriever.GetContext();
 	vector<CatalogSearchEntry> entries;
 	auto &search_path = retriever.GetSearchPath();
 	if (IsInvalidCatalog(catalog) && IsInvalidSchema(schema)) {
 		// no catalog or schema provided - scan the entire search path
 		entries = search_path.Get();
-
-		// Also include catch-all entries, if requested.
-		if (include_implicit_search_catalogs) {
-			auto implicit_search_catalogs = search_path.GetImplicitSearchCatalogs();
-			for (auto &entry : implicit_search_catalogs) {
-				auto catalog_entry = Catalog::GetCatalogEntry(retriever, entry.catalog);
-
-				if (!catalog_entry) {
-					continue;
-				}
-				entries.emplace_back(entry.catalog, catalog_entry->GetDefaultSchema());
-			}
-		}
 	} else if (IsInvalidCatalog(catalog)) {
 		auto catalogs = search_path.GetCatalogsForSchema(schema);
 		for (auto &catalog_name : catalogs) {
@@ -931,6 +918,18 @@ CatalogEntryLookup Catalog::TryLookupEntry(CatalogEntryRetriever &retriever, con
 		}
 	}
 
+	// Special case for non-table entries (functions, macros, types): mirroring the default-table fallback above, if
+	// the entry could not be resolved through the regular search path we fall back to the default schema of any
+	// catalog flagged as an implicit search catalog (added to the path with an INVALID_SCHEMA entry, e.g. a view's
+	// own catalog while binding its body). Like the default-table lookup, this only kicks in when the entry is
+	// otherwise unresolved, so the search is never widened when it is not needed.
+	if (lookup_info.GetCatalogType() != CatalogType::TABLE_ENTRY && allow_default_table_lookup && !result.Found()) {
+		result = TryLookupDefaultSchema(retriever, lookup_info);
+		if (result.error.HasError()) {
+			error_data = std::move(result.error);
+		}
+	}
+
 	if (result.Found()) {
 		return result;
 	}
@@ -995,12 +994,30 @@ CatalogEntryLookup Catalog::TryLookupDefaultTable(CatalogEntryRetriever &retriev
 	return {nullptr, nullptr, ErrorData()};
 }
 
+CatalogEntryLookup Catalog::TryLookupDefaultSchema(CatalogEntryRetriever &retriever,
+                                                   const EntryLookupInfo &lookup_info) {
+	// look for the entry in the default schema of every catalog that was flagged as an implicit search catalog
+	// (added to the search path with an INVALID_SCHEMA entry, e.g. a view's own catalog while binding its body)
+	auto &search_path = retriever.GetSearchPath();
+	for (auto &implicit_catalog : search_path.GetImplicitSearchCatalogs()) {
+		auto catalog_entry = GetCatalogEntry(retriever, implicit_catalog.catalog);
+		if (!catalog_entry) {
+			continue;
+		}
+		auto transaction = catalog_entry->GetCatalogTransaction(retriever.GetContext());
+		auto result = catalog_entry->TryLookupEntryInternal(transaction, catalog_entry->GetDefaultSchema(), lookup_info);
+		if (result.Found()) {
+			return result;
+		}
+	}
+
+	return {nullptr, nullptr, ErrorData()};
+}
+
 CatalogEntryLookup Catalog::TryLookupEntry(CatalogEntryRetriever &retriever, const string &catalog,
                                            const string &schema, const EntryLookupInfo &lookup_info,
                                            OnEntryNotFound if_not_found) {
-	auto entries =
-	    GetCatalogEntries(retriever, catalog, schema, lookup_info.GetCatalogType() != CatalogType::TABLE_ENTRY);
-
+	auto entries = GetCatalogEntries(retriever, catalog, schema);
 	vector<CatalogLookup> lookups;
 	vector<CatalogLookup> final_lookups;
 	lookups.reserve(entries.size());

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -986,6 +986,23 @@ CatalogEntryLookup Catalog::TryLookupEntry(CatalogEntryRetriever &retriever, con
                                            const string &schema, const EntryLookupInfo &lookup_info,
                                            OnEntryNotFound if_not_found) {
 	auto entries = GetCatalogEntries(retriever, catalog, schema);
+	// For unqualified lookups of non-table entries (functions, macros, types), also fall back to the default schema
+	// of any catalog that was explicitly flagged in the search path (via an INVALID_SCHEMA entry, e.g. when binding
+	// the body of a view). This allows a view to reference a macro/type stored in its own catalog's default schema.
+	// Table lookups are intentionally excluded so that default-table resolution and ambiguity detection keep matching
+	// the top-level search-path behavior. The fallback entries are appended last, giving them the lowest priority.
+	if (IsInvalidCatalog(catalog) && IsInvalidSchema(schema) &&
+	    lookup_info.GetCatalogType() != CatalogType::TABLE_ENTRY) {
+		auto &search_path = retriever.GetSearchPath();
+		for (auto &implicit_catalog : search_path.GetImplicitSearchCatalogs()) {
+			auto catalog_entry = Catalog::GetCatalogEntry(retriever, implicit_catalog);
+			if (!catalog_entry) {
+				continue;
+			}
+			entries.emplace_back(implicit_catalog, catalog_entry->GetDefaultSchema());
+		}
+	}
+
 	vector<CatalogLookup> lookups;
 	vector<CatalogLookup> final_lookups;
 	lookups.reserve(entries.size());

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -462,13 +462,26 @@ vector<SimilarCatalogEntry> Catalog::SimilarEntriesInSchemas(ClientContext &cont
 }
 
 vector<CatalogSearchEntry> GetCatalogEntries(CatalogEntryRetriever &retriever, const string &catalog,
-                                             const string &schema) {
+                                             const string &schema, bool include_implicit_search_catalogs = false) {
 	auto &context = retriever.GetContext();
 	vector<CatalogSearchEntry> entries;
 	auto &search_path = retriever.GetSearchPath();
 	if (IsInvalidCatalog(catalog) && IsInvalidSchema(schema)) {
 		// no catalog or schema provided - scan the entire search path
 		entries = search_path.Get();
+
+		// Also include catch-all entries, if requested.
+		if (include_implicit_search_catalogs) {
+			auto implicit_search_catalogs = search_path.GetImplicitSearchCatalogs();
+			for (auto &entry : implicit_search_catalogs) {
+				auto catalog_entry = Catalog::GetCatalogEntry(retriever, entry.catalog);
+
+				if (!catalog_entry) {
+					continue;
+				}
+				entries.emplace_back(entry.catalog, catalog_entry->GetDefaultSchema());
+			}
+		}
 	} else if (IsInvalidCatalog(catalog)) {
 		auto catalogs = search_path.GetCatalogsForSchema(schema);
 		for (auto &catalog_name : catalogs) {
@@ -985,23 +998,8 @@ CatalogEntryLookup Catalog::TryLookupDefaultTable(CatalogEntryRetriever &retriev
 CatalogEntryLookup Catalog::TryLookupEntry(CatalogEntryRetriever &retriever, const string &catalog,
                                            const string &schema, const EntryLookupInfo &lookup_info,
                                            OnEntryNotFound if_not_found) {
-	auto entries = GetCatalogEntries(retriever, catalog, schema);
-	// For unqualified lookups of non-table entries (functions, macros, types), also fall back to the default schema
-	// of any catalog that was explicitly flagged in the search path (via an INVALID_SCHEMA entry, e.g. when binding
-	// the body of a view). This allows a view to reference a macro/type stored in its own catalog's default schema.
-	// Table lookups are intentionally excluded so that default-table resolution and ambiguity detection keep matching
-	// the top-level search-path behavior. The fallback entries are appended last, giving them the lowest priority.
-	if (IsInvalidCatalog(catalog) && IsInvalidSchema(schema) &&
-	    lookup_info.GetCatalogType() != CatalogType::TABLE_ENTRY) {
-		auto &search_path = retriever.GetSearchPath();
-		for (auto &implicit_catalog : search_path.GetImplicitSearchCatalogs()) {
-			auto catalog_entry = Catalog::GetCatalogEntry(retriever, implicit_catalog);
-			if (!catalog_entry) {
-				continue;
-			}
-			entries.emplace_back(implicit_catalog, catalog_entry->GetDefaultSchema());
-		}
-	}
+	auto entries =
+	    GetCatalogEntries(retriever, catalog, schema, lookup_info.GetCatalogType() != CatalogType::TABLE_ENTRY);
 
 	vector<CatalogLookup> lookups;
 	vector<CatalogLookup> final_lookups;

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -467,16 +467,12 @@ vector<CatalogSearchEntry> GetCatalogEntries(CatalogEntryRetriever &retriever, c
 	vector<CatalogSearchEntry> entries;
 	auto &search_path = retriever.GetSearchPath();
 	if (IsInvalidCatalog(catalog) && IsInvalidSchema(schema)) {
-		// no catalog or schema provided - scan the entire search path. For non-table lookups, implicit catalogs that
-		// requested precedence (e.g. a view's own catalog while binding its body) are resolved to their default
-		// schema in place so they keep their priority; tables use the separate default-table mechanism instead.
-		//
-		// lookup_type is optional (CatalogType::INVALID means the caller did not specify one, e.g. callers that
-		// only ever pass a concrete catalog/schema); when unknown we treat it like a table lookup and skip the
-		// precedence resolution.
+		// no catalog or schema provided - scan the entire search path.
 		if (lookup_type == CatalogType::INVALID || lookup_type == CatalogType::TABLE_ENTRY) {
 			entries = search_path.Get();
 		} else {
+			// for non-table lookups, resolve implicit catalogs that requested precedence to their default schema in
+			// place
 			entries = search_path.GetWithPrecedenceSchemas(context);
 		}
 	} else if (IsInvalidCatalog(catalog)) {
@@ -928,11 +924,8 @@ CatalogEntryLookup Catalog::TryLookupEntry(CatalogEntryRetriever &retriever, con
 		}
 	}
 
-	// Special case for non-table entries (functions, macros, types): mirroring the default-table fallback above, if
-	// the entry could not be resolved through the regular search path we fall back to the default schema of any
-	// catalog flagged as an implicit search catalog (added to the path with an INVALID_SCHEMA entry), but only
-	// if the catalog did not request precedence. Catalogs that requested precedence were already searched at their
-	// position in the search path.
+	// Special case for non-table entries (functions, macros, types): Fall back to the default schema of any
+	// catalog flagged as an implicit search catalog. Ignored if the schema already had precedence.
 	if (lookup_info.GetCatalogType() != CatalogType::TABLE_ENTRY && allow_default_lookup && !result.Found()) {
 		result = TryLookupDefaultSchema(retriever, lookup_info);
 		if (result.error.HasError()) {
@@ -1007,7 +1000,6 @@ CatalogEntryLookup Catalog::TryLookupDefaultTable(CatalogEntryRetriever &retriev
 CatalogEntryLookup Catalog::TryLookupDefaultSchema(CatalogEntryRetriever &retriever,
                                                    const EntryLookupInfo &lookup_info) {
 	// look for the entry in the default schema of every catalog that was flagged as an implicit search catalog
-	// (added to the search path with an INVALID_SCHEMA entry, e.g. a view's own catalog while binding its body)
 	auto &search_path = retriever.GetSearchPath();
 	for (auto &implicit_catalog : search_path.GetImplicitSearchCatalogs()) {
 		auto catalog_entry = GetCatalogEntry(retriever, implicit_catalog.catalog);
@@ -1028,9 +1020,8 @@ CatalogEntryLookup Catalog::TryLookupDefaultSchema(CatalogEntryRetriever &retrie
 CatalogEntryLookup Catalog::TryLookupEntry(CatalogEntryRetriever &retriever, const string &catalog,
                                            const string &schema, const EntryLookupInfo &lookup_info,
                                            OnEntryNotFound if_not_found) {
-	// GetCatalogEntries resolves the search path, inlining the default schema of any implicit catalog that requested
-	// precedence (e.g. a view's own catalog while binding its body) for non-table lookups.
 	auto entries = GetCatalogEntries(retriever, catalog, schema, lookup_info.GetCatalogType());
+
 	vector<CatalogLookup> lookups;
 	vector<CatalogLookup> final_lookups;
 	lookups.reserve(entries.size());

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -878,7 +878,7 @@ static void ThrowDefaultTableAmbiguityException(CatalogEntryLookup &base_lookup,
 
 CatalogEntryLookup Catalog::TryLookupEntry(CatalogEntryRetriever &retriever, const vector<CatalogLookup> &lookups,
                                            const EntryLookupInfo &lookup_info, OnEntryNotFound if_not_found,
-                                           bool allow_default_table_lookup) {
+                                           bool allow_default_lookup) {
 	auto &context = retriever.GetContext();
 	reference_set_t<SchemaCatalogEntry> schemas;
 	bool all_errors = true;
@@ -902,7 +902,7 @@ CatalogEntryLookup Catalog::TryLookupEntry(CatalogEntryRetriever &retriever, con
 
 	// Special case for tables: we do a second lookup searching for catalogs with default tables that also match this
 	// lookup
-	if (lookup_info.GetCatalogType() == CatalogType::TABLE_ENTRY && allow_default_table_lookup) {
+	if (lookup_info.GetCatalogType() == CatalogType::TABLE_ENTRY && allow_default_lookup) {
 		if (!result.Found()) {
 			result = TryLookupDefaultTable(retriever, lookup_info, false);
 			if (result.error.HasError()) {
@@ -923,7 +923,7 @@ CatalogEntryLookup Catalog::TryLookupEntry(CatalogEntryRetriever &retriever, con
 	// catalog flagged as an implicit search catalog (added to the path with an INVALID_SCHEMA entry, e.g. a view's
 	// own catalog while binding its body). Like the default-table lookup, this only kicks in when the entry is
 	// otherwise unresolved, so the search is never widened when it is not needed.
-	if (lookup_info.GetCatalogType() != CatalogType::TABLE_ENTRY && allow_default_table_lookup && !result.Found()) {
+	if (lookup_info.GetCatalogType() != CatalogType::TABLE_ENTRY && allow_default_lookup && !result.Found()) {
 		result = TryLookupDefaultSchema(retriever, lookup_info);
 		if (result.error.HasError()) {
 			error_data = std::move(result.error);
@@ -1005,8 +1005,9 @@ CatalogEntryLookup Catalog::TryLookupDefaultSchema(CatalogEntryRetriever &retrie
 			continue;
 		}
 		auto transaction = catalog_entry->GetCatalogTransaction(retriever.GetContext());
-		auto result = catalog_entry->TryLookupEntryInternal(transaction, catalog_entry->GetDefaultSchema(), lookup_info);
-		if (result.Found()) {
+		auto result =
+		    catalog_entry->TryLookupEntryInternal(transaction, catalog_entry->GetDefaultSchema(), lookup_info);
+		if (result.Found() || result.error.HasError()) {
 			return result;
 		}
 	}
@@ -1044,9 +1045,9 @@ CatalogEntryLookup Catalog::TryLookupEntry(CatalogEntryRetriever &retriever, con
 		lookups.emplace_back(std::move(lookup));
 	}
 
-	bool allow_default_table_lookup = catalog.empty() && schema.empty();
+	bool allow_default_lookup = catalog.empty() && schema.empty();
 
-	return TryLookupEntry(retriever, lookups, lookup_info, if_not_found, allow_default_table_lookup);
+	return TryLookupEntry(retriever, lookups, lookup_info, if_not_found, allow_default_lookup);
 }
 
 CatalogEntry &Catalog::GetEntry(ClientContext &context, CatalogType catalog_type, const string &catalog_name,

--- a/src/catalog/catalog_search_path.cpp
+++ b/src/catalog/catalog_search_path.cpp
@@ -275,11 +275,11 @@ vector<string> CatalogSearchPath::GetSchemasForCatalog(const string &catalog) co
 	return schemas;
 }
 
-vector<string> CatalogSearchPath::GetImplicitSearchCatalogs() const {
-	vector<string> catalogs;
+vector<CatalogSearchEntry> CatalogSearchPath::GetImplicitSearchCatalogs() const {
+	vector<CatalogSearchEntry> catalogs;
 	for (auto &path : paths) {
 		if (path.schema.empty() && !path.catalog.empty()) {
-			catalogs.push_back(path.catalog);
+			catalogs.push_back(path);
 		}
 	}
 	return catalogs;

--- a/src/catalog/catalog_search_path.cpp
+++ b/src/catalog/catalog_search_path.cpp
@@ -275,6 +275,16 @@ vector<string> CatalogSearchPath::GetSchemasForCatalog(const string &catalog) co
 	return schemas;
 }
 
+vector<string> CatalogSearchPath::GetImplicitSearchCatalogs() const {
+	vector<string> catalogs;
+	for (auto &path : paths) {
+		if (path.schema.empty() && !path.catalog.empty()) {
+			catalogs.push_back(path.catalog);
+		}
+	}
+	return catalogs;
+}
+
 const CatalogSearchEntry &CatalogSearchPath::GetDefault() const {
 	D_ASSERT(paths.size() >= 2);
 	D_ASSERT(!paths[1].schema.empty());

--- a/src/catalog/catalog_search_path.cpp
+++ b/src/catalog/catalog_search_path.cpp
@@ -12,8 +12,9 @@
 
 namespace duckdb {
 
-CatalogSearchEntry::CatalogSearchEntry(string catalog_p, string schema_p)
-    : catalog(std::move(catalog_p)), schema(std::move(schema_p)) {
+CatalogSearchEntry::CatalogSearchEntry(string catalog_p, string schema_p, bool default_schema_precedence_p)
+    : catalog(std::move(catalog_p)), schema(std::move(schema_p)),
+      default_schema_precedence(default_schema_precedence_p) {
 }
 
 string CatalogSearchEntry::ToString() const {
@@ -276,13 +277,38 @@ vector<string> CatalogSearchPath::GetSchemasForCatalog(const string &catalog) co
 }
 
 vector<CatalogSearchEntry> CatalogSearchPath::GetImplicitSearchCatalogs() const {
+	// Get the implicit entries that were not resolved in place (i.e. those that are not flagged with
+	// default_schema_precedence)
 	vector<CatalogSearchEntry> catalogs;
 	for (auto &path : paths) {
-		if (path.schema.empty() && !path.catalog.empty()) {
+		if (path.schema.empty() && !path.catalog.empty() && !path.default_schema_precedence) {
 			catalogs.push_back(path);
 		}
 	}
 	return catalogs;
+}
+
+vector<CatalogSearchEntry> CatalogSearchPath::GetWithPrecedenceSchemas(ClientContext &context) const {
+	vector<CatalogSearchEntry> res;
+	for (auto &path : paths) {
+		if (path.schema.empty()) {
+			// implicit entry (the whole catalog should be considered). Only entries flagged with
+			// default_schema_precedence are resolved to the catalog's default schema in place, keeping their
+			// position in the search path so they retain their priority. The remaining implicit entries are only
+			// consulted as a last-resort fallback (see Catalog::TryLookupDefaultSchema)
+			if (path.catalog.empty() || !path.default_schema_precedence) {
+				continue;
+			}
+			auto catalog_entry = Catalog::GetCatalogEntry(context, path.catalog);
+			if (!catalog_entry) {
+				continue;
+			}
+			res.emplace_back(path.catalog, catalog_entry->GetDefaultSchema());
+		} else {
+			res.emplace_back(path);
+		}
+	}
+	return res;
 }
 
 const CatalogSearchEntry &CatalogSearchPath::GetDefault() const {

--- a/src/catalog/catalog_search_path.cpp
+++ b/src/catalog/catalog_search_path.cpp
@@ -277,8 +277,7 @@ vector<string> CatalogSearchPath::GetSchemasForCatalog(const string &catalog) co
 }
 
 vector<CatalogSearchEntry> CatalogSearchPath::GetImplicitSearchCatalogs() const {
-	// Get the implicit entries that were not resolved in place (i.e. those that are not flagged with
-	// default_schema_precedence)
+	// Get the implicit entries that were not already resolved by the precedence flag.
 	vector<CatalogSearchEntry> catalogs;
 	for (auto &path : paths) {
 		if (path.schema.empty() && !path.catalog.empty() && !path.default_schema_precedence) {
@@ -291,11 +290,8 @@ vector<CatalogSearchEntry> CatalogSearchPath::GetImplicitSearchCatalogs() const 
 vector<CatalogSearchEntry> CatalogSearchPath::GetWithPrecedenceSchemas(ClientContext &context) const {
 	vector<CatalogSearchEntry> res;
 	for (auto &path : paths) {
+		// Resolve implicit entries with default_schema_precedence to the catalog's default schema.
 		if (path.schema.empty()) {
-			// implicit entry (the whole catalog should be considered). Only entries flagged with
-			// default_schema_precedence are resolved to the catalog's default schema in place, keeping their
-			// position in the search path so they retain their priority. The remaining implicit entries are only
-			// consulted as a last-resort fallback (see Catalog::TryLookupDefaultSchema)
 			if (path.catalog.empty() || !path.default_schema_precedence) {
 				continue;
 			}

--- a/src/include/duckdb/catalog/catalog.hpp
+++ b/src/include/duckdb/catalog/catalog.hpp
@@ -429,7 +429,7 @@ private:
 	                                  const EntryLookupInfo &lookup_info, OnEntryNotFound if_not_found);
 	static CatalogEntryLookup TryLookupEntry(CatalogEntryRetriever &retriever, const vector<CatalogLookup> &lookups,
 	                                         const EntryLookupInfo &lookup_info, OnEntryNotFound if_not_found,
-	                                         bool allow_default_table_lookup);
+	                                         bool allow_default_lookup);
 	static CatalogEntryLookup TryLookupEntry(CatalogEntryRetriever &retriever, const string &catalog,
 	                                         const string &schema, const EntryLookupInfo &lookup_info,
 	                                         OnEntryNotFound if_not_found);

--- a/src/include/duckdb/catalog/catalog.hpp
+++ b/src/include/duckdb/catalog/catalog.hpp
@@ -439,7 +439,7 @@ private:
 	                                                const EntryLookupInfo &lookup_info,
 	                                                bool allow_ignore_at_clause = false);
 
-	//! Looks for a non-table entry (function, macro, type) in the default schema of any implicit search catalog
+	//! Looks for a non-table entry in the default schema of any implicit search catalog
 	static CatalogEntryLookup TryLookupDefaultSchema(CatalogEntryRetriever &retriever,
 	                                                 const EntryLookupInfo &lookup_info);
 

--- a/src/include/duckdb/catalog/catalog.hpp
+++ b/src/include/duckdb/catalog/catalog.hpp
@@ -439,6 +439,10 @@ private:
 	                                                const EntryLookupInfo &lookup_info,
 	                                                bool allow_ignore_at_clause = false);
 
+	//! Looks for a non-table entry (function, macro, type) in the default schema of any implicit search catalog
+	static CatalogEntryLookup TryLookupDefaultSchema(CatalogEntryRetriever &retriever,
+	                                                 const EntryLookupInfo &lookup_info);
+
 	//! Return an exception with did-you-mean suggestion.
 	static CatalogException CreateMissingEntryException(CatalogEntryRetriever &retriever,
 	                                                    const EntryLookupInfo &lookup_info,

--- a/src/include/duckdb/catalog/catalog_search_path.hpp
+++ b/src/include/duckdb/catalog/catalog_search_path.hpp
@@ -62,7 +62,7 @@ public:
 	DUCKDB_API vector<string> GetCatalogsForSchema(const string &schema) const;
 	//! Returns the catalogs that were added to the path with an INVALID (empty) schema. Such an entry signals that
 	//! the entire catalog should be considered during lookup (e.g. when binding the body of a view).
-	DUCKDB_API vector<string> GetImplicitSearchCatalogs() const;
+	DUCKDB_API vector<CatalogSearchEntry> GetImplicitSearchCatalogs() const;
 
 	DUCKDB_API bool SchemaInSearchPath(ClientContext &context, const string &catalog_name,
 	                                   const string &schema_name) const;

--- a/src/include/duckdb/catalog/catalog_search_path.hpp
+++ b/src/include/duckdb/catalog/catalog_search_path.hpp
@@ -19,10 +19,15 @@ namespace duckdb {
 class ClientContext;
 
 struct CatalogSearchEntry {
-	CatalogSearchEntry(string catalog, string schema);
+	CatalogSearchEntry(string catalog, string schema, bool default_schema_precedence = false);
 
 	string catalog;
 	string schema;
+	//! Only meaningful for implicit entries (added with an INVALID/empty schema, e.g. a view's own catalog while
+	//! binding its body). When true, the catalog's default schema is searched in place at this entry's position
+	//! (taking precedence over lower-priority entries such as the caller's SET search_path); when false the catalog
+	//! is only consulted as a last-resort fallback.
+	bool default_schema_precedence;
 
 public:
 	string ToString() const;
@@ -60,9 +65,15 @@ public:
 
 	DUCKDB_API vector<string> GetSchemasForCatalog(const string &catalog) const;
 	DUCKDB_API vector<string> GetCatalogsForSchema(const string &schema) const;
-	//! Returns the catalogs that were added to the path with an INVALID (empty) schema. Such an entry signals that
-	//! the entire catalog should be considered during lookup (e.g. when binding the body of a view).
+	//! Returns the catalogs that were added to the path with an INVALID (empty) schema and are only consulted as a
+	//! last-resort fallback (i.e. not flagged with default_schema_precedence). Such an entry signals that the entire
+	//! catalog should be considered during lookup (e.g. when binding the body of a view).
 	DUCKDB_API vector<CatalogSearchEntry> GetImplicitSearchCatalogs() const;
+	//! Returns the search path entries in order, with implicit entries flagged with default_schema_precedence
+	//! resolved to the corresponding catalog's default schema in place, so they retain their priority. Other
+	//! implicit (INVALID/empty schema) entries are omitted (they are handled as a fallback, see
+	//! GetImplicitSearchCatalogs).
+	DUCKDB_API vector<CatalogSearchEntry> GetWithPrecedenceSchemas(ClientContext &context) const;
 
 	DUCKDB_API bool SchemaInSearchPath(ClientContext &context, const string &catalog_name,
 	                                   const string &schema_name) const;

--- a/src/include/duckdb/catalog/catalog_search_path.hpp
+++ b/src/include/duckdb/catalog/catalog_search_path.hpp
@@ -23,10 +23,9 @@ struct CatalogSearchEntry {
 
 	string catalog;
 	string schema;
-	//! Only meaningful for implicit entries (added with an INVALID/empty schema, e.g. a view's own catalog while
-	//! binding its body). When true, the catalog's default schema is searched in place at this entry's position
-	//! (taking precedence over lower-priority entries such as the caller's SET search_path); when false the catalog
-	//! is only consulted as a last-resort fallback.
+
+	// For unqualified non-table lookups, search this implicit catalog's default schema at its position in the search
+	// path rather than as a fallback.
 	bool default_schema_precedence;
 
 public:
@@ -65,14 +64,9 @@ public:
 
 	DUCKDB_API vector<string> GetSchemasForCatalog(const string &catalog) const;
 	DUCKDB_API vector<string> GetCatalogsForSchema(const string &schema) const;
-	//! Returns the catalogs that were added to the path with an INVALID (empty) schema and are only consulted as a
-	//! last-resort fallback (i.e. not flagged with default_schema_precedence). Such an entry signals that the entire
-	//! catalog should be considered during lookup (e.g. when binding the body of a view).
+
 	DUCKDB_API vector<CatalogSearchEntry> GetImplicitSearchCatalogs() const;
-	//! Returns the search path entries in order, with implicit entries flagged with default_schema_precedence
-	//! resolved to the corresponding catalog's default schema in place, so they retain their priority. Other
-	//! implicit (INVALID/empty schema) entries are omitted (they are handled as a fallback, see
-	//! GetImplicitSearchCatalogs).
+
 	DUCKDB_API vector<CatalogSearchEntry> GetWithPrecedenceSchemas(ClientContext &context) const;
 
 	DUCKDB_API bool SchemaInSearchPath(ClientContext &context, const string &catalog_name,

--- a/src/include/duckdb/catalog/catalog_search_path.hpp
+++ b/src/include/duckdb/catalog/catalog_search_path.hpp
@@ -60,6 +60,9 @@ public:
 
 	DUCKDB_API vector<string> GetSchemasForCatalog(const string &catalog) const;
 	DUCKDB_API vector<string> GetCatalogsForSchema(const string &schema) const;
+	//! Returns the catalogs that were added to the path with an INVALID (empty) schema. Such an entry signals that
+	//! the entire catalog should be considered during lookup (e.g. when binding the body of a view).
+	DUCKDB_API vector<string> GetImplicitSearchCatalogs() const;
 
 	DUCKDB_API bool SchemaInSearchPath(ClientContext &context, const string &catalog_name,
 	                                   const string &schema_name) const;

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -516,7 +516,8 @@ private:
 	const string BindCatalog(string &catalog_name);
 	SchemaCatalogEntry &BindCreateSchema(CreateInfo &info);
 
-	vector<CatalogSearchEntry> GetSearchPath(Catalog &catalog, const string &schema_name);
+	vector<CatalogSearchEntry> GetSearchPath(Catalog &catalog, const string &schema_name,
+	                                         bool default_schema_precedence = false);
 
 	LogicalType BindLogicalTypeInternal(const unique_ptr<ParsedExpression> &type_expr);
 

--- a/src/planner/binder/statement/bind_create.cpp
+++ b/src/planner/binder/statement/bind_create.cpp
@@ -178,7 +178,7 @@ void Binder::BindView(ClientContext &context, const SelectStatement &stmt, const
 	}
 	view_binder->can_contain_nulls = true;
 
-	auto view_search_path = view_binder->GetSearchPath(catalog, schema_name);
+	auto view_search_path = view_binder->GetSearchPath(catalog, schema_name, true);
 	view_binder->entry_retriever.SetSearchPath(std::move(view_search_path));
 
 	auto copy = stmt.Copy();

--- a/src/planner/binder/tableref/bind_basetableref.cpp
+++ b/src/planner/binder/tableref/bind_basetableref.cpp
@@ -100,7 +100,8 @@ unique_ptr<BoundAtClause> Binder::BindAtClause(optional_ptr<AtClause> at_clause)
 	return make_uniq<BoundAtClause>(at_clause->Unit(), std::move(val));
 }
 
-vector<CatalogSearchEntry> Binder::GetSearchPath(Catalog &catalog, const string &schema_name) {
+vector<CatalogSearchEntry> Binder::GetSearchPath(Catalog &catalog, const string &schema_name,
+                                                 bool default_schema_precedence) {
 	vector<CatalogSearchEntry> view_search_path;
 	auto &catalog_name = catalog.GetName();
 	if (!schema_name.empty()) {
@@ -111,7 +112,7 @@ vector<CatalogSearchEntry> Binder::GetSearchPath(Catalog &catalog, const string 
 		view_search_path.emplace_back(catalog_name, default_schema);
 	}
 	//! Signal that this catalog should be checked, regardless of the schema in the reference
-	view_search_path.emplace_back(catalog_name, INVALID_SCHEMA);
+	view_search_path.emplace_back(catalog_name, INVALID_SCHEMA, default_schema_precedence);
 	return view_search_path;
 }
 
@@ -304,9 +305,10 @@ BoundStatement Binder::Bind(BaseTableRef &ref) {
 			}
 		}
 
-		// when binding a view, we always look into the catalog/schema where the view is stored first
+		// when binding a view, we always look into the catalog/schema where the view is stored first, and the view's
+		// own catalog takes precedence over the caller's search path when resolving unqualified entries
 		auto view_search_path =
-		    GetSearchPath(view_catalog_entry.ParentCatalog(), view_catalog_entry.ParentSchema().name);
+		    GetSearchPath(view_catalog_entry.ParentCatalog(), view_catalog_entry.ParentSchema().name, true);
 		view_binder->entry_retriever.SetSearchPath(std::move(view_search_path));
 		// propagate the AT clause through the view
 		view_binder->entry_retriever.SetAtClause(entry_at_clause);

--- a/src/planner/binder/tableref/bind_basetableref.cpp
+++ b/src/planner/binder/tableref/bind_basetableref.cpp
@@ -305,8 +305,7 @@ BoundStatement Binder::Bind(BaseTableRef &ref) {
 			}
 		}
 
-		// when binding a view, we always look into the catalog/schema where the view is stored first, and the view's
-		// own catalog takes precedence over the caller's search path when resolving unqualified entries
+		// when binding a view, we always look into the catalog/schema where the view is stored first
 		auto view_search_path =
 		    GetSearchPath(view_catalog_entry.ParentCatalog(), view_catalog_entry.ParentSchema().name, true);
 		view_binder->entry_retriever.SetSearchPath(std::move(view_search_path));

--- a/test/sql/attach/searchpath_fallback.test
+++ b/test/sql/attach/searchpath_fallback.test
@@ -1,5 +1,5 @@
 # name: test/sql/attach/searchpath_fallback.test
-# description: Tryout
+# description: Test the default schema fallback for queries.
 # group: [attach]
 
 

--- a/test/sql/attach/searchpath_fallback.test
+++ b/test/sql/attach/searchpath_fallback.test
@@ -2,6 +2,57 @@
 # description: Test the default schema fallback for queries.
 # group: [attach]
 
+
+# A view's owning catalog should take precedence over the caller's search path
+# for unqualified non-table entries in the catalog's default schema.
+# Validate the use of the correct macro.
+statement ok
+ATTACH ':memory:' AS view_path_c1;
+
+statement ok
+CREATE SCHEMA view_path_c1.s1;
+
+statement ok
+CREATE MACRO view_path_c1.main.fn() AS 1;
+
+statement ok
+ATTACH ':memory:' AS view_path_c2;
+
+statement ok
+CREATE MACRO view_path_c2.main.fn() AS 'caller';
+
+statement ok
+SET search_path = 'view_path_c2.main';
+
+statement ok
+CREATE VIEW view_path_c1.s1.v AS SELECT fn() AS result;
+
+# Verify CREATE VIEW used the owning catalog's INTEGER-returning macro.
+query T
+SELECT data_type
+FROM duckdb_columns()
+WHERE database_name = 'view_path_c1'
+  AND schema_name = 's1'
+  AND table_name = 'v'
+  AND column_name = 'result';
+----
+INTEGER
+
+# Verify rebinding the view also uses the owning catalog.
+query I
+FROM view_path_c1.s1.v;
+----
+1
+
+statement ok
+RESET search_path;
+
+statement ok
+DETACH view_path_c2;
+
+statement ok
+DETACH view_path_c1;
+
 # A view's owning catalog should take precedence over the caller's search path
 # for unqualified non-table entries in the catalog's default schema.
 statement ok
@@ -30,6 +81,16 @@ FROM view_path_c1.s1.v;
 ----
 1
 
+statement ok
+RESET search_path;
+
+statement ok
+DETACH view_path_c2;
+
+statement ok
+DETACH view_path_c1;
+
+
 # Test with views over default tables
 statement ok
 ATTACH ':memory:' AS dt (DEFAULT_TABLE 'real_t');
@@ -56,6 +117,9 @@ query I
 FROM c1.s1.vv;
 ----
 1
+
+statement ok
+DETACH dt;
 
 
 # Test with an alter column set type
@@ -84,6 +148,9 @@ query I
 FROM c2.s1.t;
 ----
 x
+
+statement ok
+DETACH c2;
 
 # Declare macro and use it in different catalog
 statement ok

--- a/test/sql/attach/searchpath_fallback.test
+++ b/test/sql/attach/searchpath_fallback.test
@@ -2,42 +2,112 @@
 # description: Test the default schema fallback for queries.
 # group: [attach]
 
-# Test with views over default tables
+# A view's owning catalog should take precedence over the caller's search path
+# for unqualified non-table entries in the catalog's default schema.
+statement ok
+ATTACH ':memory:' AS view_path_c1;
+
+statement ok
+CREATE SCHEMA view_path_c1.s1;
+
+statement ok
+CREATE MACRO view_path_c1.main.fn() AS 1;
+
+statement ok
+CREATE VIEW view_path_c1.s1.v AS SELECT fn() AS result;
+
+statement ok
+ATTACH ':memory:' AS view_path_c2;
+
+statement ok
+CREATE MACRO view_path_c2.main.fn() AS 2;
+
+statement ok
+SET search_path = 'view_path_c2.main';
+
 query I
+FROM view_path_c1.s1.v;
+----
+1
+
+# Test with views over default tables
+statement ok
 ATTACH ':memory:' AS dt (DEFAULT_TABLE 'real_t');
+
+statement ok
 CREATE TABLE dt.main.real_t(i INT);
+
+statement ok
 INSERT INTO dt.main.real_t values (1);
+
+statement ok
 ATTACH ':memory:' AS c1;
+
+statement ok
 CREATE SCHEMA c1.s1;
+
+statement ok
 CREATE TABLE c1.main.dt(i INT);
+
+statement ok
 CREATE VIEW c1.s1.vv AS SELECT * FROM dt;
+
+query I
 FROM c1.s1.vv;
 ----
 1
 
 
-# test with an alter column set type
-query I
+# Test with an alter column set type
+statement ok
 CREATE TYPE my_enum AS ENUM ('x');
+
+statement ok
 ATTACH ':memory:' AS c2;
+
+statement ok
 CREATE SCHEMA c2.s1;
+
+statement ok
 CREATE TYPE c2.my_enum AS ENUM ('y');
+
+statement ok
 CREATE TABLE c2.s1.t(a VARCHAR);
+
+statement ok
 INSERT INTO c2.s1.t VALUES ('x');
+
+statement ok
 ALTER TABLE c2.s1.t ALTER COLUMN a SET DATA TYPE my_enum;
+
+query I
 FROM c2.s1.t;
 ----
 x
 
 # Declare macro and use it in different catalog
-query I
+statement ok
 ATTACH ':memory:' as test;
+
+statement ok
 use test;
+
+statement ok
 ATTACH ':memory:' as test2;
+
+statement ok
 CREATE OR REPLACE MACRO fn(a) as a+1;
+
+statement ok
 CREATE SCHEMA other_schema;
+
+statement ok
 CREATE VIEW other_schema.some_view AS SELECT fn(1) AS t;
+
+statement ok
 use test2;
+
+query I
 from test.other_schema.some_view;
 ----
 2

--- a/test/sql/attach/searchpath_fallback.test
+++ b/test/sql/attach/searchpath_fallback.test
@@ -1,0 +1,44 @@
+# name: test/sql/attach/searchpath_fallback.test
+# description: Tryout
+# group: [attach]
+
+
+# Test with views over default tables
+query I
+ATTACH ':memory:' AS dt (DEFAULT_TABLE 'real_t');
+CREATE TABLE dt.main.real_t(i INT);
+INSERT INTO dt.main.real_t values (1);
+ATTACH ':memory:' AS c1;
+CREATE SCHEMA c1.s1;
+CREATE TABLE c1.main.dt(i INT);
+CREATE VIEW c1.s1.vv AS SELECT * FROM dt;
+FROM c1.s1.vv;
+----
+1
+
+
+# test with an alter column set type
+query I
+CREATE TYPE my_enum AS ENUM ('x');
+ATTACH ':memory:' AS c2;
+CREATE SCHEMA c2.s1;
+CREATE TYPE c2.my_enum AS ENUM ('y');
+CREATE TABLE c2.s1.t(a VARCHAR);
+INSERT INTO c2.s1.t VALUES ('x');
+ALTER TABLE c2.s1.t ALTER COLUMN a SET DATA TYPE my_enum;
+FROM c2.s1.t;
+----
+x
+
+# Declare macro and use it in different catalog
+query I
+ATTACH ':memory:' as test;
+use test;
+ATTACH ':memory:' as test2;
+CREATE OR REPLACE MACRO fn(a) as a+1;
+CREATE SCHEMA other_schema;
+CREATE VIEW other_schema.some_view AS SELECT fn(1) AS t;
+use test2;
+from test.other_schema.some_view;
+----
+2

--- a/test/sql/attach/searchpath_fallback.test
+++ b/test/sql/attach/searchpath_fallback.test
@@ -2,7 +2,6 @@
 # description: Test the default schema fallback for queries.
 # group: [attach]
 
-
 # A view's owning catalog should take precedence over the caller's search path
 # for unqualified non-table entries in the catalog's default schema.
 # Validate the use of the correct macro.

--- a/test/sql/attach/searchpath_fallback.test
+++ b/test/sql/attach/searchpath_fallback.test
@@ -2,7 +2,6 @@
 # description: Test the default schema fallback for queries.
 # group: [attach]
 
-
 # Test with views over default tables
 query I
 ATTACH ':memory:' AS dt (DEFAULT_TABLE 'real_t');


### PR DESCRIPTION
This PR fixes a bug where a reference to an default schema's macro in one catalog would not resolve in a *different* catalog.

This was because the default schema was missing in the Catalog search path.

Now, as an fallback, the default schema will be added to the path if the type could not be found.

For tables this was already the case. Now this is possible for other types as well.


