### PR TITLE
Fix "Resource deadlock avoided" when SET threads runs on a scheduler worker

### DIFF
--- a/src/include/duckdb/parallel/task_scheduler.hpp
+++ b/src/include/duckdb/parallel/task_scheduler.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb/common/atomic.hpp"
 #include "duckdb/common/common.hpp"
+#include "duckdb/common/optional_ptr.hpp"
 #include "duckdb/common/vector.hpp"
 #include "duckdb/parallel/task.hpp"
 #include "duckdb/common/array.hpp"
@@ -61,6 +62,10 @@ public:
 	//! Run tasks forever until "marker" is set to false, "marker" must remain valid until the thread is joined
 	void ExecuteForever(atomic<bool> *marker);
 	void ExecuteForever(atomic<bool> *marker, TaskSchedulerType pool_type);
+#ifndef DUCKDB_NO_THREADS
+	//! Run tasks forever on a worker owned by this scheduler
+	void ExecuteForeverOnInternalThread(atomic<bool> *marker, TaskSchedulerType pool_type);
+#endif
 	//! Run tasks until `marker` is set to false, `max_tasks` have been completed, or until there are no more tasks
 	//! available. Returns the number of tasks that were completed.
 	idx_t ExecuteTasks(atomic<bool> *marker, idx_t max_tasks);
@@ -99,6 +104,10 @@ private:
 
 private:
 	DatabaseInstance &db;
+#ifndef DUCKDB_NO_THREADS
+	//! The scheduler that owns the current internal worker thread, if any
+	static thread_local optional_ptr<TaskScheduler> current_worker_scheduler;
+#endif
 	//! Lock for modifying the thread count
 	mutex thread_lock;
 	//! The thread pools

--- a/src/parallel/task_scheduler.cpp
+++ b/src/parallel/task_scheduler.cpp
@@ -27,6 +27,10 @@
 
 namespace duckdb {
 
+#ifndef DUCKDB_NO_THREADS
+thread_local optional_ptr<TaskScheduler> TaskScheduler::current_worker_scheduler;
+#endif
+
 TaskScheduler::TaskScheduler(DatabaseInstance &db) : db(db) {
 	for (uint8_t i = 0; i < TASK_SCHEDULER_TYPE_COUNT; i++) {
 		pools[i] = make_uniq<TaskSchedulerPool>(db, static_cast<TaskSchedulerType>(i));
@@ -119,6 +123,21 @@ bool TaskScheduler::GetTaskInternal(shared_ptr<Task> &task, TaskSchedulerType po
 void TaskScheduler::ExecuteForever(atomic<bool> *marker) {
 	ExecuteForever(marker, TaskSchedulerType::REGULAR);
 }
+
+#ifndef DUCKDB_NO_THREADS
+void TaskScheduler::ExecuteForeverOnInternalThread(atomic<bool> *marker, const TaskSchedulerType pool_type) {
+	auto previous_scheduler = current_worker_scheduler;
+	D_ASSERT(!previous_scheduler);
+	current_worker_scheduler = this;
+	try {
+		ExecuteForever(marker, pool_type);
+	} catch (...) {
+		current_worker_scheduler = previous_scheduler;
+		throw;
+	}
+	current_worker_scheduler = previous_scheduler;
+}
+#endif
 
 bool TaskScheduler::TryDequeueAndProcessTask(const DBConfig &config, TaskSchedulerQueue &queue,
                                              shared_ptr<Task> &task) {
@@ -396,6 +415,13 @@ idx_t TaskScheduler::GetEstimatedCPUId() {
 }
 
 void TaskScheduler::RelaunchThreads() {
+#ifndef DUCKDB_NO_THREADS
+	if (current_worker_scheduler == this) {
+		// A worker cannot wait for the relaunch lock: another thread can hold it while joining this worker.
+		// Defer the relaunch until query cleanup runs on a thread that is not owned by this scheduler.
+		return;
+	}
+#endif
 	lock_guard<mutex> t(thread_lock);
 	for (auto &pool : pools) {
 		pool->RelaunchThreads(*this, false);

--- a/src/parallel/task_scheduler_pool.cpp
+++ b/src/parallel/task_scheduler_pool.cpp
@@ -119,7 +119,7 @@ static void SetThreadAffinity(thread &thread, const vector<int> &available_cpus,
 
 #ifndef DUCKDB_NO_THREADS
 static void ThreadExecuteTasks(TaskScheduler *scheduler, atomic<bool> *marker, const TaskSchedulerType pool_type) {
-	scheduler->ExecuteForever(marker, pool_type);
+	scheduler->ExecuteForeverOnInternalThread(marker, pool_type);
 }
 #endif
 
@@ -150,7 +150,10 @@ void TaskSchedulerPool::RelaunchThreads(TaskScheduler &scheduler, bool destroy) 
 		Signal(threads.size());
 		// now join the threads to ensure they are fully stopped before erasing them
 		for (idx_t i = 0; i < threads.size(); i++) {
-			threads[i]->internal_thread->join();
+			// A prior join failure can leave already-joined threads in the vector.
+			if (threads[i]->internal_thread->joinable()) {
+				threads[i]->internal_thread->join();
+			}
 		}
 		// erase the threads/markers
 		threads.clear();

--- a/test/api/test_threads.cpp
+++ b/test/api/test_threads.cpp
@@ -1,12 +1,75 @@
 #include "catch.hpp"
 #include "test_helpers.hpp"
 #include "duckdb/parallel/task_scheduler.hpp"
+#include "duckdb/parallel/task.hpp"
 #include "duckdb/common/virtual_file_system.hpp"
 #include "duckdb/main/settings.hpp"
 
+#include <chrono>
+#include <condition_variable>
 #include <thread>
 
 using namespace duckdb;
+
+#ifndef DUCKDB_NO_THREADS
+struct SetThreadsTaskState {
+	mutex lock;
+	std::condition_variable cv;
+	bool finished = false;
+	string error;
+};
+
+struct SetThreadsTask : Task {
+	SetThreadsTask(DuckDB &db_p, shared_ptr<SetThreadsTaskState> state_p) : db(db_p), state(std::move(state_p)) {
+	}
+
+	TaskExecutionResult Execute(TaskExecutionMode) override {
+		string error;
+		try {
+			Connection con(db);
+			auto result = con.Query("SET threads=1");
+			if (result->HasError()) {
+				error = result->GetError();
+			}
+		} catch (std::exception &ex) {
+			error = ex.what();
+		}
+		{
+			lock_guard<mutex> guard(state->lock);
+			state->error = std::move(error);
+			state->finished = true;
+		}
+		state->cv.notify_one();
+		return TaskExecutionResult::TASK_FINISHED;
+	}
+
+	DuckDB &db;
+	shared_ptr<SetThreadsTaskState> state;
+};
+
+TEST_CASE("Setting threads from a scheduler worker does not join the current thread", "[api]") {
+	DBConfig config;
+	config.options.maximum_threads = 2;
+	DuckDB db(nullptr, &config);
+	Connection con(db);
+	auto &scheduler = TaskScheduler::GetScheduler(*con.context);
+	auto producer = scheduler.CreateProducer();
+	auto state = make_shared_ptr<SetThreadsTaskState>();
+
+	scheduler.ScheduleTask(*producer, make_shared_ptr<SetThreadsTask>(db, state));
+	{
+		unique_lock<mutex> guard(state->lock);
+		REQUIRE(state->cv.wait_for(guard, std::chrono::seconds(5), [&] { return state->finished; }));
+		INFO(state->error);
+		REQUIRE(state->error.empty());
+	}
+
+	// The resize is deferred until query cleanup runs outside the scheduler pool.
+	REQUIRE(db.NumberOfThreads() == 2);
+	REQUIRE_NO_FAIL(con.Query("SELECT 42"));
+	REQUIRE(db.NumberOfThreads() == 1);
+}
+#endif
 
 void run_query_multiple_times(duckdb::unique_ptr<string> query, duckdb::unique_ptr<Connection> con) {
 	for (int i = 0; i < 10; ++i) {


### PR DESCRIPTION
## What this fixes

A query can crash during cleanup with `Resource deadlock avoided` (and sometimes a follow-up `Invalid argument` that aborts the process) when the global `threads` setting is changed from inside a task that is itself running on a scheduler worker.

## Why it happens

After a query runs, `ClientContext::CleanupInternal` calls `TaskScheduler::RelaunchThreads()`. `threads` is a database-global setting, so if a scheduler task opens an internal connection and runs `SET threads=...`, that cleanup ends up executing on a worker owned by the same scheduler.

`RelaunchThreads()` stops and joins every worker in the pool — including, in this case, the very thread that's calling it. A thread joining itself gives `Resource deadlock avoided`. Worse, if some workers were already joined before the self-join threw, a later retry tries to join an already-joined thread and throws `Invalid argument`. When that exception escapes during teardown, the process can abort.

The self-detection has to happen *before* acquiring `thread_lock`, because another thread may already hold that lock while waiting to join the current worker.

## The fix

- Each scheduler-owned worker records its owning scheduler in thread-local state for the lifetime of `ExecuteForever` (via a new `ExecuteForeverOnInternalThread`).
- `RelaunchThreads()` returns early if it's being called by one of its own workers. The requested thread count is still recorded, so the resize is applied later when the outer query cleans up on a normal (non-worker) thread.
- The pool join loop now checks `joinable()` before joining, so a relaunch can recover cleanly from a worker vector that a previous attempt left partially joined.

Deferred-resize semantics: a worker-originated global `threads` change no longer takes effect immediately — it lands on the next cleanup that runs off the pool. I'd appreciate a maintainer sanity-check that this is acceptable for worker-originated global settings.

## Test plan

- Confirmed the new regression test fails on the unpatched scheduler at the captured worker-side query error.
- Confirmed the changed scheduler and regression-test sources compile without diagnostics with MSVC 19.44.
- Linux RelWithDebInfo focused regression: **passed, 5 assertions in 1 test case**.
- Focused regression repetition: **passed 25/25 runs**.
- Existing `NumberOfThreads`/`RelaunchThreads` deadlock regression: **passed**.
- Three other enabled thread-setting API tests: **passed, 21 assertions**.
- `clang-format` 11.0.1 and `git diff --check`: **passed**.
- Linux under WSL (Ubuntu), RelWithDebInfo, GCC 13, Ninja: full patched `test/unittest` target built successfully.
- Windows/Visual Studio 2022, MSVC 19.44: the patched scheduler unity object/library and regression-test object/library compiled without diagnostics. The full Windows unit-test executable was not linked or run.
- New regression test on unpatched main: **failed as expected** — 1 failed test case; 2 assertions, 1 passed and 1 failed. The failure was at `REQUIRE(state->error.empty())` after worker-side `SET threads=1`.
- New regression test with the fix: **passed** — 5 assertions in 1 test case (0.086 seconds).
- Focused regression repetition with the fix: **passed 25/25 runs**.
- Existing `Test deadlock issue between NumberOfThreads and RelaunchThreads`: **passed** — 1 test case.
- Other enabled thread-setting API tests (`maximum_threads`, external threads, and async threads): **passed** — 21 assertions in 3 test cases.
- `clang-format` 11.0.1: **applied successfully** to all four modified files.
- `git diff --check`: **passed**.
- Exported patch clean-apply check against base `71f0c7a0bf10f60087b7bd42f524ae556c5a1967`: **passed**.

## Extension note

The reproducer comes from `ducklake-cdc` running `SET threads=1` on an internal connection. Since `threads` is database-global (not connection-local), that command mutates the shared scheduler regardless of this fix — the extension should drop it independently. This change only hardens core against the unsafe relaunch; it does not make `threads` connection-local.

Addresses duckdb/ducklake#1448.
