### PR TITLE
Add HTTPUtil::ShouldRetry(request, response) retry-classification hook

### DIFF
--- a/src/include/duckdb/common/http_util.hpp
+++ b/src/include/duckdb/common/http_util.hpp
@@ -12,6 +12,7 @@
 #include "duckdb/common/case_insensitive_map.hpp"
 #include "duckdb/common/enums/http_status_code.hpp"
 #include "duckdb/common/types/timestamp.hpp"
+#include "duckdb/common/winapi.hpp"
 #include <functional>
 
 namespace duckdb {
@@ -273,6 +274,12 @@ public:
 
 	virtual unique_ptr<HTTPResponse> SendRequest(BaseRequest &request, unique_ptr<HTTPClient> &client);
 	virtual void LogRequest(BaseRequest &request, optional_ptr<HTTPResponse> response);
+
+	//! Whether a failed request should be retried, possibly using HTTPResponse information, and allowing overrides
+	DUCKDB_API virtual bool ShouldRetry(const BaseRequest &request, const HTTPResponse &response);
+
+	//! Whether replaying this request is safe. POST is the only method we cannot assume is idempotent.
+	DUCKDB_API static bool IsIdempotent(RequestType type);
 
 	static void ParseHTTPProxyHost(string &proxy_value, string &hostname_out, idx_t &port_out, idx_t default_port = 80);
 	static void DecomposeURL(const string &url, string &path_out, string &proto_host_port_out);

--- a/src/main/http/http_util.cpp
+++ b/src/main/http/http_util.cpp
@@ -125,6 +125,14 @@ bool HTTPResponse::ShouldRetry() const {
 	}
 }
 
+bool HTTPUtil::IsIdempotent(RequestType type) {
+	return type != RequestType::POST_REQUEST;
+}
+
+bool HTTPUtil::ShouldRetry(const BaseRequest &request, const HTTPResponse &response) {
+	return response.ShouldRetry();
+}
+
 unique_ptr<HTTPResponse> HTTPUtil::Request(BaseRequest &request) {
 	unique_ptr<HTTPClient> client;
 	return SendRequest(request, client);
@@ -420,7 +428,7 @@ HTTPUtil::RunRequestWithRetry(const std::function<unique_ptr<HTTPResponse>(void)
 		}
 
 		// Note: request errors will always be retried
-		bool should_retry = !response || response->ShouldRetry();
+		bool should_retry = !response || params.http_util.ShouldRetry(request, *response);
 		if (!should_retry) {
 			auto response_code = static_cast<uint16_t>(response->status);
 			if (response_code >= 200 && response_code < 300) {


### PR DESCRIPTION
HTTPResponse::ShouldRetry() classifies on the status code alone, and is not virtual. Protocols that carry the retry discriminator in the response body cannot express themselves through it: S3 answers a stalled socket with HTTP 400 and <Code>RequestTimeout</Code> in the body, which is transient, while other 400s are fatal.

Add a virtual HTTPUtil::ShouldRetry(request, response) that RunRequestWithRetry dispatches through. The default delegates to HTTPResponse::ShouldRetry(), so behavior is unchanged for every existing caller.

The request is passed so an implementation can restrict retries to idempotent methods -- replaying a POST is not generally safe. HTTPUtil::IsIdempotent() exposes that test over core's RequestType.

Both are marked DUCKDB_API: they exist for out-of-tree implementations and have no in-tree callers, so without an export annotation they would not be reachable from an extension on Windows. This is the first use of DUCKDB_API in http_util.hpp, hence the added winapi.hpp include.


Goal of this PR is allowing simplifying https://github.com/duckdb/duckdb-httpfs/pull/365 by just override the `ShouldRetry` condition for 400 when timeout.