### PR TITLE
Validity fixes for reading arrow into a dictionary vector

### DIFF
--- a/src/function/table/arrow_conversion.cpp
+++ b/src/function/table/arrow_conversion.cpp
@@ -1474,8 +1474,11 @@ void ArrowToDuckDBConversion::ColumnArrowToDuckDBDictionary(Vector &vector, Arro
 
 	SelectionVector sel;
 	if (has_nulls) {
-		ValidityMask indices_validity;
-		GetValidityMask(indices_validity, array, chunk_offset, size, NumericCast<int64_t>(parent_offset));
+		// size may exceed STANDARD_VECTOR_SIZE, so the scratch mask must be sized for it.
+		ValidityMask indices_validity(size);
+		// validity must be read from the same effective offset as the indices
+		GetValidityMask(indices_validity, array, chunk_offset, size, NumericCast<int64_t>(parent_offset),
+		                nested_offset);
 		if (parent_mask && parent_mask->CanHaveNull()) {
 			auto &struct_validity_mask = *parent_mask;
 			for (idx_t i = 0; i < size; i++) {

--- a/test/arrow/CMakeLists.txt
+++ b/test/arrow/CMakeLists.txt
@@ -5,7 +5,8 @@ add_library_unity(
   arrow_roundtrip.cpp
   arrow_move_children.cpp
   arrow_filter_pushdown.cpp
-  arrow_dictionary_sentinel.cpp)
+  arrow_dictionary_sentinel.cpp
+  arrow_dict_nested_offset.cpp)
 set(UNITTEST_OBJECT_FILES
     ${UNITTEST_OBJECT_FILES} $<TARGET_OBJECTS:test_arrow_roundtrip>
     PARENT_SCOPE)

--- a/test/arrow/arrow_dict_nested_offset.cpp
+++ b/test/arrow/arrow_dict_nested_offset.cpp
@@ -1,0 +1,313 @@
+// ColumnArrowToDuckDBDictionary must read the indices validity from the same effective offset as the
+// indices (nested_offset); the no-gap control pins the trigger to the offsets gap, not multi-chunking.
+
+#include "catch.hpp"
+
+#include "arrow/arrow_test_helper.hpp"
+#include "duckdb/common/adbc/single_batch_array_stream.hpp"
+#include "duckdb/common/types/value.hpp"
+#include "duckdb/function/table/arrow.hpp"
+#include "duckdb/function/table/arrow/arrow_duck_schema.hpp"
+#include "duckdb/main/connection.hpp"
+#include "duckdb/main/database.hpp"
+
+#include <string>
+#include <vector>
+
+using namespace duckdb;
+
+namespace {
+
+// Stack-allocated Arrow structs need a no-op release; uniquely named to avoid ODR clashes.
+void NestedOffReleaseSchema(ArrowSchema *s) {
+	s->release = nullptr;
+}
+void NestedOffReleaseArray(ArrowArray *a) {
+	a->release = nullptr;
+}
+
+const int32_t DICT_VALUES[3] = {10, 20, 30};
+
+// Dict-encoded int32 child: slot j -> DICT_VALUES[j % 3], NULL at the given slots. Not copyable:
+// the Arrow structs point into the object itself.
+struct DictChild {
+	DictChild(idx_t len, const std::vector<idx_t> &null_slots)
+	    // padded so GetValidityMask's realignment branch (reads one extra byte) stays in bounds
+	    : indices(len), validity((len + 7) / 8 + 2, 0xFF) {
+		for (idx_t j = 0; j < len; j++) {
+			indices[j] = int32_t(j % 3);
+		}
+		for (auto slot : null_slots) {
+			validity[slot / 8] &= uint8_t(~(1u << (slot % 8)));
+		}
+		dict_schema.format = "i";
+		dict_schema.release = NestedOffReleaseSchema;
+		schema.format = "i";
+		schema.name = "item";
+		schema.flags = 2; // ARROW_FLAG_NULLABLE
+		schema.dictionary = &dict_schema;
+		schema.release = NestedOffReleaseSchema;
+		dict_buffers[0] = nullptr;
+		dict_buffers[1] = DICT_VALUES;
+		dict_array.length = 3;
+		dict_array.n_buffers = 2;
+		dict_array.buffers = dict_buffers;
+		dict_array.release = NestedOffReleaseArray;
+		buffers[0] = validity.data();
+		buffers[1] = indices.data();
+		array.length = int64_t(len);
+		array.null_count = int64_t(null_slots.size());
+		array.n_buffers = 2;
+		array.buffers = buffers;
+		array.dictionary = &dict_array;
+		array.release = NestedOffReleaseArray;
+	}
+	DictChild(const DictChild &) = delete;
+
+	bool IsNull(idx_t slot) const {
+		return (validity[slot / 8] & (1u << (slot % 8))) == 0;
+	}
+	int32_t ValueAt(idx_t slot) const {
+		return DICT_VALUES[indices[slot] % 3];
+	}
+
+	std::vector<int32_t> indices;
+	std::vector<uint8_t> validity;
+	const void *dict_buffers[2];
+	const void *buffers[2];
+	ArrowSchema dict_schema {};
+	ArrowSchema schema {};
+	ArrowArray dict_array {};
+	ArrowArray array {};
+};
+
+// Asserts one converted element matches the dict child at `slot`.
+void RequireSlot(const DictChild &child, idx_t slot, const Value &elem) {
+	INFO("child slot " << slot);
+	if (child.IsNull(slot)) {
+		REQUIRE(elem.IsNull());
+	} else {
+		REQUIRE(!elem.IsNull());
+		REQUIRE(elem.GetValue<int32_t>() == child.ValueAt(slot));
+	}
+}
+
+// One-element lists with offsets[0] == gap, so row r references child slot gap + r.
+std::vector<int32_t> OneElementListOffsets(idx_t rows, idx_t gap) {
+	std::vector<int32_t> offsets(rows + 1);
+	for (idx_t i = 0; i <= rows; i++) {
+		offsets[i] = int32_t(gap + i);
+	}
+	return offsets;
+}
+
+// Drives ColumnArrowToDuckDB on LIST(dict-int32), optionally via a STRUCT wrapper, for one chunk of
+// `size` rows starting at `chunk_offset`; row i must read child slot gap + chunk_offset + i.
+void CheckListOfDict(idx_t total_rows, idx_t chunk_offset, idx_t size, idx_t gap, const std::vector<idx_t> &null_slots,
+                     bool wrap_struct = false) {
+	DictChild child(gap + total_rows, null_slots);
+
+	ArrowSchema *struct_schema_children[1] = {&child.schema};
+	ArrowSchema struct_schema {};
+	struct_schema.format = "+s";
+	struct_schema.name = "s";
+	struct_schema.flags = 2;
+	struct_schema.n_children = 1;
+	struct_schema.children = struct_schema_children;
+	struct_schema.release = NestedOffReleaseSchema;
+
+	const void *struct_buffers[1] = {nullptr};
+	ArrowArray *struct_array_children[1] = {&child.array};
+	ArrowArray struct_array {};
+	struct_array.length = child.array.length;
+	struct_array.n_buffers = 1;
+	struct_array.buffers = struct_buffers;
+	struct_array.n_children = 1;
+	struct_array.children = struct_array_children;
+	struct_array.release = NestedOffReleaseArray;
+
+	auto offsets = OneElementListOffsets(total_rows, gap);
+	ArrowSchema *list_schema_children[1] = {wrap_struct ? &struct_schema : &child.schema};
+	ArrowSchema list_schema {};
+	list_schema.format = "+l";
+	list_schema.name = "l";
+	list_schema.flags = 2;
+	list_schema.n_children = 1;
+	list_schema.children = list_schema_children;
+	list_schema.release = NestedOffReleaseSchema;
+
+	const void *list_buffers[2] = {nullptr, offsets.data()};
+	ArrowArray *list_array_children[1] = {wrap_struct ? &struct_array : &child.array};
+	ArrowArray list_array {};
+	list_array.length = int64_t(total_rows);
+	list_array.n_buffers = 2;
+	list_array.buffers = list_buffers;
+	list_array.n_children = 1;
+	list_array.children = list_array_children;
+	list_array.release = NestedOffReleaseArray;
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	auto &context = *con.context;
+	auto arrow_type = ArrowType::GetArrowLogicalType(context, list_schema);
+	ArrowArrayScanState state(context);
+	state.owned_data = make_shared_ptr<ArrowArrayWrapper>();
+
+	// the real scan builds and caches the dictionary on the first chunk; later chunks must reuse it
+	if (chunk_offset > 0) {
+		Vector warmup(arrow_type->GetDuckType(true), STANDARD_VECTOR_SIZE);
+		ArrowToDuckDBConversion::ColumnArrowToDuckDB(warmup, list_array, 0, state, STANDARD_VECTOR_SIZE, *arrow_type,
+		                                             -1);
+	}
+
+	Vector result(arrow_type->GetDuckType(true), size);
+	ArrowToDuckDBConversion::ColumnArrowToDuckDB(result, list_array, chunk_offset, state, size, *arrow_type, -1);
+
+	for (idx_t i = 0; i < size; i++) {
+		INFO("row " << i);
+		auto row = result.GetValue(i);
+		auto &elems = ListValue::GetChildren(row);
+		REQUIRE(elems.size() == 1);
+		Value elem = wrap_struct ? StructValue::GetChildren(elems[0])[0] : elems[0];
+		RequireSlot(child, gap + chunk_offset + i, elem);
+	}
+}
+
+// Drives ColumnArrowToDuckDB on fixed-size ARRAY(dict-int32, k) with nonzero array.offset; row i
+// element e must read child slot (array_offset + i) * k + e.
+void CheckFixedArrayOfDict(idx_t k, idx_t array_offset, idx_t size, const std::vector<idx_t> &null_slots) {
+	DictChild child((array_offset + size) * k, null_slots);
+
+	std::string fmt = "+w:" + std::to_string(k);
+	ArrowSchema *arr_schema_children[1] = {&child.schema};
+	ArrowSchema arr_schema {};
+	arr_schema.format = fmt.c_str();
+	arr_schema.name = "arr";
+	arr_schema.flags = 2;
+	arr_schema.n_children = 1;
+	arr_schema.children = arr_schema_children;
+	arr_schema.release = NestedOffReleaseSchema;
+
+	const void *arr_buffers[1] = {nullptr};
+	ArrowArray *arr_array_children[1] = {&child.array};
+	ArrowArray arr_array {};
+	arr_array.length = int64_t(size);
+	arr_array.offset = int64_t(array_offset);
+	arr_array.n_buffers = 1;
+	arr_array.buffers = arr_buffers;
+	arr_array.n_children = 1;
+	arr_array.children = arr_array_children;
+	arr_array.release = NestedOffReleaseArray;
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	auto &context = *con.context;
+	auto arrow_type = ArrowType::GetArrowLogicalType(context, arr_schema);
+	ArrowArrayScanState state(context);
+	state.owned_data = make_shared_ptr<ArrowArrayWrapper>();
+
+	Vector result(arrow_type->GetDuckType(true), size);
+	ArrowToDuckDBConversion::ColumnArrowToDuckDB(result, arr_array, 0, state, size, *arrow_type, -1);
+
+	for (idx_t i = 0; i < size; i++) {
+		INFO("row " << i);
+		auto row = result.GetValue(i);
+		auto &elems = ListValue::GetChildren(row);
+		REQUIRE(elems.size() == k);
+		for (idx_t e = 0; e < k; e++) {
+			RequireSlot(child, (array_offset + i) * k + e, elems[e]);
+		}
+	}
+}
+
+} // namespace
+
+TEST_CASE("Dictionary child of LIST: single chunk with nonzero leading child offset", "[arrow]") {
+	// offsets[0] = 5: slot 10 is row 5, slot 0 is unused
+	CheckListOfDict(8, 0, 8, 5, {0, 10});
+}
+
+TEST_CASE("Dictionary child of LIST: multi-chunk, no leading gap (control, must pass)", "[arrow]") {
+	// second chunk with start_offset == chunk_offset == 2048: no divergence, passes even with the bug
+	CheckListOfDict(4096, 2048, 2048, 0, {3000});
+}
+
+TEST_CASE("Dictionary child of LIST: multi-chunk with leading gap (chunk_offset diverges)", "[arrow]") {
+	// second chunk with start_offset 2055 != chunk_offset 2048; slot 2055 is row 0
+	CheckListOfDict(4096, 2048, 2048, 7, {2055});
+}
+
+TEST_CASE("Dictionary child of fixed-size ARRAY: nonzero array.offset", "[arrow]") {
+	// array.offset = 2 shifts the child window by offset * k = 6; slot 6 is row 0 elem 0
+	CheckFixedArrayOfDict(3, 2, 4, {0, 6});
+}
+
+TEST_CASE("Dictionary inside STRUCT nested in LIST: nonzero leading child offset", "[arrow]") {
+	// the STRUCT branch forwards nested_offset to its dict child
+	CheckListOfDict(8, 0, 8, 5, {0, 10}, /*wrap_struct=*/true);
+}
+
+// End-to-end through the real arrow scan; a nonzero offsets[0] is what pyarrow slicing produces.
+TEST_CASE("Arrow scan of LIST(dict-encoded int32) with nonzero leading list offset", "[arrow]") {
+	const idx_t rows = 8;
+	const idx_t gap = 5;
+	DictChild child(gap + rows, {0, 6, 10});
+	auto offsets = OneElementListOffsets(rows, gap);
+
+	ArrowSchema *list_schema_children[1] = {&child.schema};
+	ArrowSchema list_schema {};
+	list_schema.format = "+l";
+	list_schema.name = "a";
+	list_schema.flags = 2;
+	list_schema.n_children = 1;
+	list_schema.children = list_schema_children;
+	list_schema.release = NestedOffReleaseSchema;
+
+	ArrowSchema *record_schema_children[1] = {&list_schema};
+	ArrowSchema record_schema {};
+	record_schema.format = "+s";
+	record_schema.n_children = 1;
+	record_schema.children = record_schema_children;
+	record_schema.release = NestedOffReleaseSchema;
+
+	const void *list_buffers[2] = {nullptr, offsets.data()};
+	ArrowArray *list_array_children[1] = {&child.array};
+	ArrowArray list_array {};
+	list_array.length = int64_t(rows);
+	list_array.n_buffers = 2;
+	list_array.buffers = list_buffers;
+	list_array.n_children = 1;
+	list_array.children = list_array_children;
+	list_array.release = NestedOffReleaseArray;
+
+	const void *record_buffers[1] = {nullptr};
+	ArrowArray *record_array_children[1] = {&list_array};
+	ArrowArray record_array {};
+	record_array.length = int64_t(rows);
+	record_array.n_buffers = 1;
+	record_array.buffers = record_buffers;
+	record_array.n_children = 1;
+	record_array.children = record_array_children;
+	record_array.release = NestedOffReleaseArray;
+
+	ArrowArrayStream stream {};
+	AdbcError err {};
+	REQUIRE(duckdb_adbc::BatchToArrayStream(&record_array, &record_schema, &stream, &err) == ADBC_STATUS_OK);
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	auto params = ArrowTestHelper::ConstructArrowScan(stream);
+	auto result = ArrowTestHelper::ScanArrowObject(con, params);
+	stream.release = nullptr;
+	REQUIRE(result);
+
+	auto &materialized = result->Cast<MaterializedQueryResult>();
+	REQUIRE(materialized.RowCount() == rows);
+	for (idx_t r = 0; r < rows; r++) {
+		INFO("row " << r);
+		auto row = materialized.GetValue(0, r);
+		auto &elems = ListValue::GetChildren(row);
+		REQUIRE(elems.size() == 1);
+		RequireSlot(child, gap + r, elems[0]);
+	}
+}

--- a/test/arrow/arrow_dict_nested_offset.cpp
+++ b/test/arrow/arrow_dict_nested_offset.cpp
@@ -1,15 +1,10 @@
-// ColumnArrowToDuckDBDictionary must read the indices validity from the same effective offset as the
-// indices (nested_offset); the no-gap control pins the trigger to the offsets gap, not multi-chunking.
+// Arrow scans of dictionary-encoded children of LIST/ARRAY/STRUCT with nonzero child offsets,
+// as produced by e.g. pyarrow slicing.
 
 #include "catch.hpp"
 
 #include "arrow/arrow_test_helper.hpp"
 #include "duckdb/common/adbc/single_batch_array_stream.hpp"
-#include "duckdb/common/types/value.hpp"
-#include "duckdb/function/table/arrow.hpp"
-#include "duckdb/function/table/arrow/arrow_duck_schema.hpp"
-#include "duckdb/main/connection.hpp"
-#include "duckdb/main/database.hpp"
 
 #include <string>
 #include <vector>
@@ -18,18 +13,17 @@ using namespace duckdb;
 
 namespace {
 
-// Stack-allocated Arrow structs need a no-op release; uniquely named to avoid ODR clashes.
-void NestedOffReleaseSchema(ArrowSchema *s) {
+// Stack-allocated Arrow structs need a no-op release.
+void ReleaseSchema(ArrowSchema *s) {
 	s->release = nullptr;
 }
-void NestedOffReleaseArray(ArrowArray *a) {
+void ReleaseArray(ArrowArray *a) {
 	a->release = nullptr;
 }
 
 const int32_t DICT_VALUES[3] = {10, 20, 30};
 
-// Dict-encoded int32 child: slot j -> DICT_VALUES[j % 3], NULL at the given slots. Not copyable:
-// the Arrow structs point into the object itself.
+// Dict-encoded int32 child: slot j holds 10 * (j % 3 + 1), NULL at the given slots.
 struct DictChild {
 	DictChild(idx_t len, const std::vector<idx_t> &null_slots)
 	    // padded so GetValidityMask's realignment branch (reads one extra byte) stays in bounds
@@ -41,18 +35,18 @@ struct DictChild {
 			validity[slot / 8] &= uint8_t(~(1u << (slot % 8)));
 		}
 		dict_schema.format = "i";
-		dict_schema.release = NestedOffReleaseSchema;
+		dict_schema.release = ReleaseSchema;
 		schema.format = "i";
 		schema.name = "item";
 		schema.flags = 2; // ARROW_FLAG_NULLABLE
 		schema.dictionary = &dict_schema;
-		schema.release = NestedOffReleaseSchema;
+		schema.release = ReleaseSchema;
 		dict_buffers[0] = nullptr;
 		dict_buffers[1] = DICT_VALUES;
 		dict_array.length = 3;
 		dict_array.n_buffers = 2;
 		dict_array.buffers = dict_buffers;
-		dict_array.release = NestedOffReleaseArray;
+		dict_array.release = ReleaseArray;
 		buffers[0] = validity.data();
 		buffers[1] = indices.data();
 		array.length = int64_t(len);
@@ -60,16 +54,9 @@ struct DictChild {
 		array.n_buffers = 2;
 		array.buffers = buffers;
 		array.dictionary = &dict_array;
-		array.release = NestedOffReleaseArray;
+		array.release = ReleaseArray;
 	}
 	DictChild(const DictChild &) = delete;
-
-	bool IsNull(idx_t slot) const {
-		return (validity[slot / 8] & (1u << (slot % 8))) == 0;
-	}
-	int32_t ValueAt(idx_t slot) const {
-		return DICT_VALUES[indices[slot] % 3];
-	}
 
 	std::vector<int32_t> indices;
 	std::vector<uint8_t> validity;
@@ -81,233 +68,171 @@ struct DictChild {
 	ArrowArray array {};
 };
 
-// Asserts one converted element matches the dict child at `slot`.
-void RequireSlot(const DictChild &child, idx_t slot, const Value &elem) {
-	INFO("child slot " << slot);
-	if (child.IsNull(slot)) {
-		REQUIRE(elem.IsNull());
-	} else {
-		REQUIRE(!elem.IsNull());
-		REQUIRE(elem.GetValue<int32_t>() == child.ValueAt(slot));
-	}
-}
-
-// One-element lists with offsets[0] == gap, so row r references child slot gap + r.
-std::vector<int32_t> OneElementListOffsets(idx_t rows, idx_t gap) {
-	std::vector<int32_t> offsets(rows + 1);
-	for (idx_t i = 0; i <= rows; i++) {
-		offsets[i] = int32_t(gap + i);
-	}
-	return offsets;
-}
-
-// Drives ColumnArrowToDuckDB on LIST(dict-int32), optionally via a STRUCT wrapper, for one chunk of
-// `size` rows starting at `chunk_offset`; row i must read child slot gap + chunk_offset + i.
-void CheckListOfDict(idx_t total_rows, idx_t chunk_offset, idx_t size, idx_t gap, const std::vector<idx_t> &null_slots,
-                     bool wrap_struct = false) {
-	DictChild child(gap + total_rows, null_slots);
-
-	ArrowSchema *struct_schema_children[1] = {&child.schema};
-	ArrowSchema struct_schema {};
-	struct_schema.format = "+s";
-	struct_schema.name = "s";
-	struct_schema.flags = 2;
-	struct_schema.n_children = 1;
-	struct_schema.children = struct_schema_children;
-	struct_schema.release = NestedOffReleaseSchema;
-
-	const void *struct_buffers[1] = {nullptr};
-	ArrowArray *struct_array_children[1] = {&child.array};
-	ArrowArray struct_array {};
-	struct_array.length = child.array.length;
-	struct_array.n_buffers = 1;
-	struct_array.buffers = struct_buffers;
-	struct_array.n_children = 1;
-	struct_array.children = struct_array_children;
-	struct_array.release = NestedOffReleaseArray;
-
-	auto offsets = OneElementListOffsets(total_rows, gap);
-	ArrowSchema *list_schema_children[1] = {wrap_struct ? &struct_schema : &child.schema};
-	ArrowSchema list_schema {};
-	list_schema.format = "+l";
-	list_schema.name = "l";
-	list_schema.flags = 2;
-	list_schema.n_children = 1;
-	list_schema.children = list_schema_children;
-	list_schema.release = NestedOffReleaseSchema;
-
-	const void *list_buffers[2] = {nullptr, offsets.data()};
-	ArrowArray *list_array_children[1] = {wrap_struct ? &struct_array : &child.array};
-	ArrowArray list_array {};
-	list_array.length = int64_t(total_rows);
-	list_array.n_buffers = 2;
-	list_array.buffers = list_buffers;
-	list_array.n_children = 1;
-	list_array.children = list_array_children;
-	list_array.release = NestedOffReleaseArray;
-
-	DuckDB db(nullptr);
-	Connection con(db);
-	auto &context = *con.context;
-	auto arrow_type = ArrowType::GetArrowLogicalType(context, list_schema);
-	ArrowArrayScanState state(context);
-	state.owned_data = make_shared_ptr<ArrowArrayWrapper>();
-
-	// the real scan builds and caches the dictionary on the first chunk; later chunks must reuse it
-	if (chunk_offset > 0) {
-		Vector warmup(arrow_type->GetDuckType(true), STANDARD_VECTOR_SIZE);
-		ArrowToDuckDBConversion::ColumnArrowToDuckDB(warmup, list_array, 0, state, STANDARD_VECTOR_SIZE, *arrow_type,
-		                                             -1);
-	}
-
-	Vector result(arrow_type->GetDuckType(true), size);
-	ArrowToDuckDBConversion::ColumnArrowToDuckDB(result, list_array, chunk_offset, state, size, *arrow_type, -1);
-
-	for (idx_t i = 0; i < size; i++) {
-		INFO("row " << i);
-		auto row = result.GetValue(i);
-		auto &elems = ListValue::GetChildren(row);
-		REQUIRE(elems.size() == 1);
-		Value elem = wrap_struct ? StructValue::GetChildren(elems[0])[0] : elems[0];
-		RequireSlot(child, gap + chunk_offset + i, elem);
-	}
-}
-
-// Drives ColumnArrowToDuckDB on fixed-size ARRAY(dict-int32, k) with nonzero array.offset; row i
-// element e must read child slot (array_offset + i) * k + e.
-void CheckFixedArrayOfDict(idx_t k, idx_t array_offset, idx_t size, const std::vector<idx_t> &null_slots) {
-	DictChild child((array_offset + size) * k, null_slots);
-
-	std::string fmt = "+w:" + std::to_string(k);
-	ArrowSchema *arr_schema_children[1] = {&child.schema};
-	ArrowSchema arr_schema {};
-	arr_schema.format = fmt.c_str();
-	arr_schema.name = "arr";
-	arr_schema.flags = 2;
-	arr_schema.n_children = 1;
-	arr_schema.children = arr_schema_children;
-	arr_schema.release = NestedOffReleaseSchema;
-
-	const void *arr_buffers[1] = {nullptr};
-	ArrowArray *arr_array_children[1] = {&child.array};
-	ArrowArray arr_array {};
-	arr_array.length = int64_t(size);
-	arr_array.offset = int64_t(array_offset);
-	arr_array.n_buffers = 1;
-	arr_array.buffers = arr_buffers;
-	arr_array.n_children = 1;
-	arr_array.children = arr_array_children;
-	arr_array.release = NestedOffReleaseArray;
-
-	DuckDB db(nullptr);
-	Connection con(db);
-	auto &context = *con.context;
-	auto arrow_type = ArrowType::GetArrowLogicalType(context, arr_schema);
-	ArrowArrayScanState state(context);
-	state.owned_data = make_shared_ptr<ArrowArrayWrapper>();
-
-	Vector result(arrow_type->GetDuckType(true), size);
-	ArrowToDuckDBConversion::ColumnArrowToDuckDB(result, arr_array, 0, state, size, *arrow_type, -1);
-
-	for (idx_t i = 0; i < size; i++) {
-		INFO("row " << i);
-		auto row = result.GetValue(i);
-		auto &elems = ListValue::GetChildren(row);
-		REQUIRE(elems.size() == k);
-		for (idx_t e = 0; e < k; e++) {
-			RequireSlot(child, (array_offset + i) * k + e, elems[e]);
+// LIST column with offsets[0] == gap: row r covers child slots gap + r * list_len onward.
+struct ListColumn {
+	ListColumn(DictChild &child, idx_t rows, idx_t gap, idx_t list_len = 1, bool wrap_struct = false)
+	    : offsets(rows + 1) {
+		for (idx_t i = 0; i <= rows; i++) {
+			offsets[i] = int32_t(gap + i * list_len);
 		}
+		if (wrap_struct) {
+			struct_schema_children[0] = &child.schema;
+			struct_schema.format = "+s";
+			struct_schema.name = "s";
+			struct_schema.flags = 2;
+			struct_schema.n_children = 1;
+			struct_schema.children = struct_schema_children;
+			struct_schema.release = ReleaseSchema;
+			struct_array_children[0] = &child.array;
+			struct_array.length = child.array.length;
+			struct_array.n_buffers = 1;
+			struct_array.buffers = struct_buffers;
+			struct_array.n_children = 1;
+			struct_array.children = struct_array_children;
+			struct_array.release = ReleaseArray;
+		}
+		schema_children[0] = wrap_struct ? &struct_schema : &child.schema;
+		schema.format = "+l";
+		schema.name = "a";
+		schema.flags = 2;
+		schema.n_children = 1;
+		schema.children = schema_children;
+		schema.release = ReleaseSchema;
+		buffers[0] = nullptr;
+		buffers[1] = offsets.data();
+		array_children[0] = wrap_struct ? &struct_array : &child.array;
+		array.length = int64_t(rows);
+		array.n_buffers = 2;
+		array.buffers = buffers;
+		array.n_children = 1;
+		array.children = array_children;
+		array.release = ReleaseArray;
 	}
+	ListColumn(const ListColumn &) = delete;
+
+	std::vector<int32_t> offsets;
+	ArrowSchema *struct_schema_children[1];
+	ArrowArray *struct_array_children[1];
+	ArrowSchema *schema_children[1];
+	ArrowArray *array_children[1];
+	const void *struct_buffers[1] = {nullptr};
+	const void *buffers[2];
+	ArrowSchema struct_schema {};
+	ArrowArray struct_array {};
+	ArrowSchema schema {};
+	ArrowArray array {};
+};
+
+// ARRAY(k) column: row r element e covers child slot (array_offset + r) * k + e.
+struct FixedArrayColumn {
+	FixedArrayColumn(DictChild &child, idx_t k, idx_t array_offset, idx_t rows) : fmt("+w:" + std::to_string(k)) {
+		schema_children[0] = &child.schema;
+		schema.format = fmt.c_str();
+		schema.name = "a";
+		schema.flags = 2;
+		schema.n_children = 1;
+		schema.children = schema_children;
+		schema.release = ReleaseSchema;
+		buffers[0] = nullptr;
+		array_children[0] = &child.array;
+		array.length = int64_t(rows);
+		array.offset = int64_t(array_offset);
+		array.n_buffers = 1;
+		array.buffers = buffers;
+		array.n_children = 1;
+		array.children = array_children;
+		array.release = ReleaseArray;
+	}
+	FixedArrayColumn(const FixedArrayColumn &) = delete;
+
+	std::string fmt;
+	ArrowSchema *schema_children[1];
+	ArrowArray *array_children[1];
+	const void *buffers[1];
+	ArrowSchema schema {};
+	ArrowArray array {};
+};
+
+// Scans the column through arrow_scan as a one-column batch and compares against the query.
+bool ScanMatches(ArrowSchema &col_schema, ArrowArray &col_array, const string &query) {
+	ArrowSchema *schema_children[1] = {&col_schema};
+	ArrowSchema record_schema {};
+	record_schema.format = "+s";
+	record_schema.n_children = 1;
+	record_schema.children = schema_children;
+	record_schema.release = ReleaseSchema;
+
+	ArrowArray *array_children[1] = {&col_array};
+	const void *buffers[1] = {nullptr};
+	ArrowArray record_array {};
+	record_array.length = col_array.length;
+	record_array.n_buffers = 1;
+	record_array.buffers = buffers;
+	record_array.n_children = 1;
+	record_array.children = array_children;
+	record_array.release = ReleaseArray;
+
+	ArrowArrayStream stream {};
+	AdbcError err {};
+	if (duckdb_adbc::BatchToArrayStream(&record_array, &record_schema, &stream, &err) != ADBC_STATUS_OK) {
+		return false;
+	}
+	DuckDB db(nullptr);
+	Connection con(db);
+	return ArrowTestHelper::RunArrowComparison(con, query, stream);
 }
 
 } // namespace
 
-TEST_CASE("Dictionary child of LIST: single chunk with nonzero leading child offset", "[arrow]") {
-	// offsets[0] = 5: slot 10 is row 5, slot 0 is unused
-	CheckListOfDict(8, 0, 8, 5, {0, 10});
+TEST_CASE("Arrow scan of LIST(dict int32) with nonzero leading child offset", "[arrow]") {
+	// offsets[0] = 5: row r reads child slot 5 + r, slots 0-4 are unused
+	DictChild child(13, {0, 6, 10});
+	ListColumn col(child, 8, 5);
+	REQUIRE(ScanMatches(col.schema, col.array,
+	                    "SELECT [CASE WHEN r + 5 IN (6, 10) THEN NULL ELSE (10 * ((r + 5) % 3 + 1))::INT END] "
+	                    "FROM range(8) t(r)"));
 }
 
-TEST_CASE("Dictionary child of LIST: multi-chunk, no leading gap (control, must pass)", "[arrow]") {
-	// second chunk with start_offset == chunk_offset == 2048: no divergence, passes even with the bug
-	CheckListOfDict(4096, 2048, 2048, 0, {3000});
+TEST_CASE("Arrow scan of LIST(dict int32) across chunks without leading offset - control", "[arrow]") {
+	// later chunks start at child slot == chunk_offset: no divergence, passes even with the bug
+	DictChild child(4096, {3000});
+	ListColumn col(child, 4096, 0);
+	REQUIRE(ScanMatches(col.schema, col.array,
+	                    "SELECT [CASE WHEN r = 3000 THEN NULL ELSE (10 * (r % 3 + 1))::INT END] "
+	                    "FROM range(4096) t(r)"));
 }
 
-TEST_CASE("Dictionary child of LIST: multi-chunk with leading gap (chunk_offset diverges)", "[arrow]") {
-	// second chunk with start_offset 2055 != chunk_offset 2048; slot 2055 is row 0
-	CheckListOfDict(4096, 2048, 2048, 7, {2055});
+TEST_CASE("Arrow scan of LIST(dict int32) across chunks with leading offset", "[arrow]") {
+	// the second chunk reads child slots from 2055 while chunk_offset is 2048; slot 2055 is row 2048
+	DictChild child(7 + 4096, {2055});
+	ListColumn col(child, 4096, 7);
+	REQUIRE(ScanMatches(col.schema, col.array,
+	                    "SELECT [CASE WHEN r = 2048 THEN NULL ELSE (10 * ((r + 7) % 3 + 1))::INT END] "
+	                    "FROM range(4096) t(r)"));
 }
 
-TEST_CASE("Dictionary child of fixed-size ARRAY: nonzero array.offset", "[arrow]") {
-	// array.offset = 2 shifts the child window by offset * k = 6; slot 6 is row 0 elem 0
-	CheckFixedArrayOfDict(3, 2, 4, {0, 6});
+TEST_CASE("Arrow scan of LIST(dict int32) with more child slots than rows per chunk", "[arrow]") {
+	// 6144 child slots in one chunk; slot 2054 is row 684 element 2, slot 6000 is row 2000 element 0
+	DictChild child(6144, {2054, 6000});
+	ListColumn col(child, 2048, 0, 3);
+	REQUIRE(ScanMatches(col.schema, col.array,
+	                    "SELECT (CASE WHEN r = 684 THEN [10, 20, NULL] WHEN r = 2000 THEN [NULL, 20, 30] "
+	                    "ELSE [10, 20, 30] END)::INT[] FROM range(2048) t(r)"));
 }
 
-TEST_CASE("Dictionary inside STRUCT nested in LIST: nonzero leading child offset", "[arrow]") {
-	// the STRUCT branch forwards nested_offset to its dict child
-	CheckListOfDict(8, 0, 8, 5, {0, 10}, /*wrap_struct=*/true);
+TEST_CASE("Arrow scan of LIST(STRUCT(dict int32)) with nonzero leading child offset", "[arrow]") {
+	DictChild child(13, {0, 6, 10});
+	ListColumn col(child, 8, 5, 1, /*wrap_struct=*/true);
+	REQUIRE(ScanMatches(col.schema, col.array,
+	                    "SELECT [{'item': CASE WHEN r + 5 IN (6, 10) THEN NULL "
+	                    "ELSE (10 * ((r + 5) % 3 + 1))::INT END}] FROM range(8) t(r)"));
 }
 
-// End-to-end through the real arrow scan; a nonzero offsets[0] is what pyarrow slicing produces.
-TEST_CASE("Arrow scan of LIST(dict-encoded int32) with nonzero leading list offset", "[arrow]") {
-	const idx_t rows = 8;
-	const idx_t gap = 5;
-	DictChild child(gap + rows, {0, 6, 10});
-	auto offsets = OneElementListOffsets(rows, gap);
-
-	ArrowSchema *list_schema_children[1] = {&child.schema};
-	ArrowSchema list_schema {};
-	list_schema.format = "+l";
-	list_schema.name = "a";
-	list_schema.flags = 2;
-	list_schema.n_children = 1;
-	list_schema.children = list_schema_children;
-	list_schema.release = NestedOffReleaseSchema;
-
-	ArrowSchema *record_schema_children[1] = {&list_schema};
-	ArrowSchema record_schema {};
-	record_schema.format = "+s";
-	record_schema.n_children = 1;
-	record_schema.children = record_schema_children;
-	record_schema.release = NestedOffReleaseSchema;
-
-	const void *list_buffers[2] = {nullptr, offsets.data()};
-	ArrowArray *list_array_children[1] = {&child.array};
-	ArrowArray list_array {};
-	list_array.length = int64_t(rows);
-	list_array.n_buffers = 2;
-	list_array.buffers = list_buffers;
-	list_array.n_children = 1;
-	list_array.children = list_array_children;
-	list_array.release = NestedOffReleaseArray;
-
-	const void *record_buffers[1] = {nullptr};
-	ArrowArray *record_array_children[1] = {&list_array};
-	ArrowArray record_array {};
-	record_array.length = int64_t(rows);
-	record_array.n_buffers = 1;
-	record_array.buffers = record_buffers;
-	record_array.n_children = 1;
-	record_array.children = record_array_children;
-	record_array.release = NestedOffReleaseArray;
-
-	ArrowArrayStream stream {};
-	AdbcError err {};
-	REQUIRE(duckdb_adbc::BatchToArrayStream(&record_array, &record_schema, &stream, &err) == ADBC_STATUS_OK);
-
-	DuckDB db(nullptr);
-	Connection con(db);
-	auto params = ArrowTestHelper::ConstructArrowScan(stream);
-	auto result = ArrowTestHelper::ScanArrowObject(con, params);
-	stream.release = nullptr;
-	REQUIRE(result);
-
-	auto &materialized = result->Cast<MaterializedQueryResult>();
-	REQUIRE(materialized.RowCount() == rows);
-	for (idx_t r = 0; r < rows; r++) {
-		INFO("row " << r);
-		auto row = materialized.GetValue(0, r);
-		auto &elems = ListValue::GetChildren(row);
-		REQUIRE(elems.size() == 1);
-		RequireSlot(child, gap + r, elems[0]);
-	}
+TEST_CASE("Arrow scan of fixed-size ARRAY(dict int32) with nonzero array offset", "[arrow]") {
+	// array.offset = 2 shifts the child window by 2 * 3 slots; slot 6 is row 0 element 0
+	DictChild child(18, {0, 6});
+	FixedArrayColumn col(child, 3, 2, 4);
+	REQUIRE(ScanMatches(col.schema, col.array,
+	                    "SELECT (CASE WHEN r = 0 THEN [NULL, 20, 30] ELSE [10, 20, 30] END)::INT[3] "
+	                    "FROM range(4) t(r)"));
 }


### PR DESCRIPTION
This fixes two bugs in reading Arrow arrays that hold a dictionary vector, into DuckDB:

1. The validity mask vector wasn't sized explicitly. A dictionary vector has an independent validity mask vector, i.e. not one that is associated with a same-size child vector (like a LIST or ARRAY child vector), so it must be sized specifically.
2. We didn't pass the offset when getting the validity mask. This is only a problem for _sliced_ array input, e.g.:
   ```
   t = pa.table({"tags": [["a"], ["b"], ["c"], ["d"], ...]})
   page = t.slice(5, 2048)
   duckdb.sql("SELECT * FROM page")
   ```
   In this example, DuckDB gets an `array.offset` passed in. This was already handled correctly for reading the data, but not for the validity mask.