### PR TITLE
Fix quoting rules in QualifiedName::ParseComponents

### DIFF
--- a/src/parser/qualified_name.cpp
+++ b/src/parser/qualified_name.cpp
@@ -35,6 +35,10 @@ string QualifiedName::ToString(QualifiedNameToStringMode mode) const {
 	return result;
 }
 
+//! This parses a superset of the strings that the actual SQL parser accepts: it allows whitespace, most special
+//! characters like ()'- and keywords without requiring double quotes. It only requires double quotes around .
+//! characters and doubled double quotes (which collapse into a single double quote). It's only possible to fully
+//! double quote a component or not quote it at all.
 vector<Identifier> QualifiedName::ParseComponents(const string &input) {
 	vector<Identifier> result;
 	idx_t idx = 0;

--- a/src/parser/qualified_name.cpp
+++ b/src/parser/qualified_name.cpp
@@ -72,6 +72,10 @@ quoted:
 				idx++;
 				continue;
 			}
+			if (entry.empty()) {
+				//! the SQL parser also rejects "" as a zero-length delimited identifier
+				throw ParserException("Zero-length delimited identifier in qualified name! (input: %s)", input);
+			}
 			//! unquote; a closing quote must end the component, e.g. "abc"xyz is not a valid identifier
 			idx++;
 			if (idx < input.size() && input[idx] != '.') {

--- a/src/parser/qualified_name.cpp
+++ b/src/parser/qualified_name.cpp
@@ -44,6 +44,11 @@ normal:
 	//! quote
 	for (; idx < input.size(); idx++) {
 		if (input[idx] == '"') {
+			if (!entry.empty()) {
+				//! a quote may only open a component, e.g. abc"xyz" is not a valid identifier
+				throw ParserException("Unexpected quote in the middle of a qualified name component! (input: %s)",
+				                      input);
+			}
 			idx++;
 			goto quoted;
 		} else if (input[idx] == '.') {
@@ -61,8 +66,18 @@ quoted:
 	//! look for another quote
 	for (; idx < input.size(); idx++) {
 		if (input[idx] == '"') {
-			//! unquote
+			if (idx + 1 < input.size() && input[idx + 1] == '"') {
+				//! escaped quote ("" inside a quoted identifier is a literal ")
+				entry += '"';
+				idx++;
+				continue;
+			}
+			//! unquote; a closing quote must end the component, e.g. "abc"xyz is not a valid identifier
 			idx++;
+			if (idx < input.size() && input[idx] != '.') {
+				throw ParserException("Unexpected character after a quoted identifier in a qualified name! (input: %s)",
+				                      input);
+			}
 			goto normal;
 		}
 		entry += input[idx];

--- a/test/sql/catalog/function/query_function.test
+++ b/test/sql/catalog/function/query_function.test
@@ -213,7 +213,7 @@ Catalog Error: Table with name FROM query('select 1 + 2;') does not exist!
 statement error
 FROM query_table('FROM query("select 1 + 2;")');
 ----
-Catalog Error: Table with name FROM query(select 1 + 2;) does not exist!
+Parser Error: Unexpected quote in the middle of a qualified name component! (input: FROM query("select 1 + 2;"))
 
 statement error
 FROM query_table('(SELECT 17 + 25)');

--- a/test/sql/pragma/test_table_info_quoted_names.test
+++ b/test/sql/pragma/test_table_info_quoted_names.test
@@ -1,0 +1,63 @@
+# name: test/sql/pragma/test_table_info_quoted_names.test
+# description: Test quoted identifier handling when parsing qualified names, e.g. in pragma_table_info
+# group: [pragma]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE SCHEMA "my.schema"
+
+statement ok
+CREATE TABLE "my.schema"."dotted.name"(i INTEGER)
+
+# a dot inside quotes is part of the name, not a separator
+query I
+SELECT count(*) FROM pragma_table_info('"my.schema"."dotted.name"')
+----
+1
+
+# a doubled quote inside a quoted identifier is a literal quote
+statement ok
+CREATE TABLE "quo""ted"(i INTEGER, j INTEGER)
+
+query I
+SELECT count(*) FROM pragma_table_info('"quo""ted"')
+----
+2
+
+# ...and does not silently match a table without the quote in its name
+statement ok
+CREATE TABLE quoted(i INTEGER)
+
+query I
+SELECT count(*) FROM pragma_table_info('"quo""ted"')
+----
+2
+
+# a table whose name is a single quote character
+statement ok
+CREATE TABLE """"(i INTEGER)
+
+query I
+SELECT count(*) FROM pragma_table_info('""""')
+----
+1
+
+# an unterminated quote is a parser error
+statement error
+SELECT * FROM pragma_table_info('"unterminated')
+----
+Unterminated quote
+
+# a quote in the middle of a component is a parser error, like in the SQL parser
+statement error
+SELECT * FROM pragma_table_info('abc"xyz"')
+----
+Unexpected quote in the middle
+
+# text directly after a closing quote is a parser error, like in the SQL parser
+statement error
+SELECT * FROM pragma_table_info('"abc"xyz')
+----
+Unexpected character after a quoted identifier

--- a/test/sql/pragma/test_table_info_quoted_names.test
+++ b/test/sql/pragma/test_table_info_quoted_names.test
@@ -61,3 +61,17 @@ statement error
 SELECT * FROM pragma_table_info('"abc"xyz')
 ----
 Unexpected character after a quoted identifier
+
+statement ok
+CREATE TABLE t(i INTEGER)
+
+# an empty quoted component is a parser error, not an absent schema
+statement error
+SELECT * FROM pragma_table_info('""."t"')
+----
+Zero-length delimited identifier
+
+statement error
+SELECT * FROM pragma_table_info('""')
+----
+Zero-length delimited identifier


### PR DESCRIPTION
`QualifiedName::ParseComponents` returned different results than the normal parser when parsing a qualified names: doubled double quotes would disapear instead of being replaced by a single double quote. It also allowed quotes in the middle of a name, which the normal parser rejects. This fixes those issues and adds some tests for these cases.
