### PR TITLE
Bump azure, unity_catalog extensions to v1.5-variegata HEAD

### DIFF
--- a/.github/config/extensions/azure.cmake
+++ b/.github/config/extensions/azure.cmake
@@ -2,6 +2,6 @@ if (NOT MINGW AND NOT ${WASM_ENABLED})
   duckdb_extension_load(azure
         LOAD_TESTS
         GIT_URL https://github.com/duckdb/duckdb-azure
-        GIT_TAG 563589b2f24290a4dcdd4247eaedf2b544f9dbcd
+        GIT_TAG 003214c96d0caa39d5c3e27a9e1976a0692c7d37
   )
 endif()

--- a/.github/config/extensions/unity_catalog.cmake
+++ b/.github/config/extensions/unity_catalog.cmake
@@ -1,7 +1,7 @@
 if(NOT MINGW AND NOT ${WASM_ENABLED} AND NOT ${MUSL_ENABLED})
   duckdb_extension_load(unity_catalog
             GIT_URL https://github.com/duckdb/unity_catalog
-            GIT_TAG e37b1b48f526c605b0d38e515ab099049b965f7d
+            GIT_TAG fd851475780ca064d9706a5025ea6e5d1d9d7e23
             LOAD_TESTS
   )
 endif()


### PR DESCRIPTION
- duckdb-azure: 563589b -> 003214c (v1.5-variegata branch)
- unity_catalog: e37b1b4 -> fd85147 (v1.5-variegata branch)