### PR TITLE
Use output column name in EXPLAIN for ORDER BY and TOP N

### DIFF
--- a/src/planner/binder/query_node/bind_select_node.cpp
+++ b/src/planner/binder/query_node/bind_select_node.cpp
@@ -271,11 +271,14 @@ static unique_ptr<Expression> CreateOrderExpression(unique_ptr<Expression> expr,
 	if (index >= sql_types.size()) {
 		throw BinderException(*expr, "ORDER term out of range - should be between 1 and %lld", sql_types.size());
 	}
-	auto result =
-	    make_uniq<BoundColumnRefExpression>(expr->GetAlias(), sql_types[index], ColumnBinding(table_index, index));
-	if (result->GetAlias().empty() && index < names.size()) {
-		result->SetAlias(names[index]);
+	Identifier alias;
+	if (index < names.size()) {
+		alias = names[index];
+	} else {
+		alias = expr->GetAlias();
 	}
+	auto result =
+	    make_uniq<BoundColumnRefExpression>(std::move(alias), sql_types[index], ColumnBinding(table_index, index));
 	return std::move(result);
 }
 

--- a/test/sql/explain/order_by_topn_explain_fqn.test
+++ b/test/sql/explain/order_by_topn_explain_fqn.test
@@ -1,0 +1,56 @@
+# name: test/sql/explain/order_by_topn_explain_fqn.test
+# description: Test fully qualified names in EXPLAIN output for ORDER BY and TOP N
+# group: [explain]
+
+statement ok
+SET profiling_renderer_settings = MAP {'operator_casing': 'upper'};
+
+statement ok
+CREATE TABLE date_table (d DATE);
+
+statement ok
+INSERT INTO date_table (d)
+SELECT
+    DATE '2025-01-01' + CAST(RANDOM() * 364 AS INT)
+FROM generate_series(1, 2500);
+
+query II
+EXPLAIN SELECT * from date_table ORDER BY d;
+----
+physical_plan	<REGEX>:.*Order By: memory\.main\.date_table\.d ASC.*
+
+query II
+EXPLAIN SELECT * from date_table ORDER BY d LIMIT 10;
+----
+physical_plan	<REGEX>:.*Order By: memory\.main\.date_table\.d ASC.*
+
+query II
+EXPLAIN SELECT * from date_table dt ORDER BY d;
+----
+physical_plan	<REGEX>:.*Order By: dt\.d ASC.*
+
+query II
+EXPLAIN SELECT * from date_table dt ORDER BY d LIMIT 10;
+----
+physical_plan	<REGEX>:.*Order By: dt\.d ASC.*
+
+query II
+EXPLAIN SELECT * from date_table dt ORDER BY dt.d;
+----
+physical_plan	<REGEX>:.*Order By: dt\.d ASC.*
+
+query II
+EXPLAIN SELECT * from date_table ORDER BY date_table.d;
+----
+physical_plan	<REGEX>:.*Order By: memory\.main\.date_table\.d ASC.*
+
+query II
+EXPLAIN SELECT d dc from date_table dt ORDER BY dc;
+----
+physical_plan	<REGEX>:.*Order By: dt.d ASC.*
+
+# Using FORMAT JSON because otherwise the explain output has a line break after "Order By:"
+query II
+EXPLAIN (FORMAT JSON) SELECT dayofweek(d) dw from date_table ORDER BY dw;
+----
+physical_plan	<REGEX>:.*"Order By": "dayofweek\(memory\.main\.date_table\.d\) ASC".*

--- a/test/sql/explain/order_by_topn_explain_fqn.test
+++ b/test/sql/explain/order_by_topn_explain_fqn.test
@@ -1,5 +1,5 @@
 # name: test/sql/explain/order_by_topn_explain_fqn.test
-# description: Test fully qualified names in EXPLAIN output for ORDER BY and TOP N
+# description: Test EXPLAIN output for ORDER BY and TOP N not having fully qualified names
 # group: [explain]
 
 statement ok
@@ -17,40 +17,39 @@ FROM generate_series(1, 2500);
 query II
 EXPLAIN SELECT * from date_table ORDER BY d;
 ----
-physical_plan	<REGEX>:.*Order By: memory\.main\.date_table\.d ASC.*
+physical_plan	<REGEX>:.*Order By: d ASC.*
 
 query II
 EXPLAIN SELECT * from date_table ORDER BY d LIMIT 10;
 ----
-physical_plan	<REGEX>:.*Order By: memory\.main\.date_table\.d ASC.*
+physical_plan	<REGEX>:.*Order By: d ASC.*
 
 query II
 EXPLAIN SELECT * from date_table dt ORDER BY d;
 ----
-physical_plan	<REGEX>:.*Order By: dt\.d ASC.*
+physical_plan	<REGEX>:.*Order By: d ASC.*
 
 query II
 EXPLAIN SELECT * from date_table dt ORDER BY d LIMIT 10;
 ----
-physical_plan	<REGEX>:.*Order By: dt\.d ASC.*
+physical_plan	<REGEX>:.*Order By: d ASC.*
 
 query II
 EXPLAIN SELECT * from date_table dt ORDER BY dt.d;
 ----
-physical_plan	<REGEX>:.*Order By: dt\.d ASC.*
+physical_plan	<REGEX>:.*Order By: d ASC.*
 
 query II
 EXPLAIN SELECT * from date_table ORDER BY date_table.d;
 ----
-physical_plan	<REGEX>:.*Order By: memory\.main\.date_table\.d ASC.*
+physical_plan	<REGEX>:.*Order By: d ASC.*
 
 query II
 EXPLAIN SELECT d dc from date_table dt ORDER BY dc;
 ----
-physical_plan	<REGEX>:.*Order By: dt.d ASC.*
+physical_plan	<REGEX>:.*Order By: dc ASC.*
 
-# Using FORMAT JSON because otherwise the explain output has a line break after "Order By:"
 query II
-EXPLAIN (FORMAT JSON) SELECT dayofweek(d) dw from date_table ORDER BY dw;
+EXPLAIN  SELECT dayofweek(d) dw from date_table ORDER BY dw;
 ----
-physical_plan	<REGEX>:.*"Order By": "dayofweek\(memory\.main\.date_table\.d\) ASC".*
+physical_plan	<REGEX>:.*Order By: dw ASC.*


### PR DESCRIPTION
Right now, `ORDER BY` and `TOP N` are special in the sense that they use fully qualified names in `explain` output. Other operators don't do that.

This PR changes them to use the output column name instead.

<details>
  <summary>Before</summary>

```
memory D explain select * from t1 order by d limit 1000;
╭─ Top N ───────────────────────────────╮
│ Top: 1000                             │
│ Order By: memory.main.t1.d ASC        │
│ ~1,000 rows                           │
╰───────────────────┬───────────────────╯
╭─ Seq Scan ────────┴───────────────────╮
│ Table: memory.main.t1                 │
│ Type: Sequential Scan                 │
│ Projections: a, d, b                  │
│ Filters: optional: Dynamic Filter (d) │
│ ~1,000 rows                           │
╰───────────────────────────────────────╯
```
</details>

<details>
  <summary>After</summary>

```
memory D explain select * from t1 order by d limit 1000;
╭─ Top N ───────────────────────────────╮
│ Top: 1000                             │
│ Order By: d ASC                       │
│ ~1,000 rows                           │
╰───────────────────┬───────────────────╯
╭─ Seq Scan ────────┴───────────────────╮
│ Table: memory.main.t1                 │
│ Type: Sequential Scan                 │
│ Projections: a, d, b                  │
│ Filters: optional: Dynamic Filter (d) │
│ ~1,000 rows                           │
╰───────────────────────────────────────╯
```
</details>