### PR TITLE
Fix IsComplete for Decimal

### DIFF
--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -719,9 +719,13 @@ bool LogicalType::IsComplete() const {
 				return false;
 			}
 			return type.AuxInfo()->Cast<StructTypeInfo>().child_types.empty();
-		case ExtraTypeInfoType::DECIMAL_TYPE_INFO:
-			return DecimalType::GetWidth(type) >= 1 && DecimalType::GetWidth(type) <= Decimal::MAX_WIDTH_DECIMAL &&
-			       DecimalType::GetScale(type) <= DecimalType::GetWidth(type);
+		case ExtraTypeInfoType::DECIMAL_TYPE_INFO: {
+			// A well-formed decimal is not incomplete
+			auto is_well_formed = DecimalType::GetWidth(type) >= 1 &&
+			                      DecimalType::GetWidth(type) <= Decimal::MAX_WIDTH_DECIMAL &&
+			                      DecimalType::GetScale(type) <= DecimalType::GetWidth(type);
+			return !is_well_formed;
+		}
 		default:
 			return false; // Nested types are checked by TypeVisitor recursion
 		}

--- a/test/api/CMakeLists.txt
+++ b/test/api/CMakeLists.txt
@@ -11,6 +11,7 @@ add_subdirectory(capi)
 set(TEST_API_OBJECTS
     test_api.cpp
     test_bind_statement.cpp
+    test_scalar_function_decimal_return.cpp
     test_config.cpp
     test_custom_allocator.cpp
     test_extension_setting_autoload.cpp

--- a/test/api/test_scalar_function_decimal_return.cpp
+++ b/test/api/test_scalar_function_decimal_return.cpp
@@ -1,0 +1,29 @@
+#include "catch.hpp"
+#include "test_helpers.hpp"
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/function/scalar_function.hpp"
+#include "duckdb/parser/parsed_data/create_scalar_function_info.hpp"
+
+using namespace duckdb;
+
+// f(NULL) folds to a constant before execution, so this body never runs.
+static void DecimalReturnExec(DataChunk &args, ExpressionState &state, Vector &result) {
+	result.SetVectorType(VectorType::CONSTANT_VECTOR);
+	ConstantVector::SetNull(result, true);
+}
+
+// A NULL argument folds to a constant typed via IsComplete; a concrete DECIMAL return type must survive.
+TEST_CASE("A decimal-returning function called with NULL keeps its DECIMAL type", "[api][scalar_function]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+
+	ScalarFunction fn("decimal_ret", {LogicalType::INTEGER}, LogicalType::DECIMAL(18, 3), DecimalReturnExec);
+	CreateScalarFunctionInfo info(fn);
+	con.context->RunFunctionInTransaction(
+	    [&]() { Catalog::GetSystemCatalog(*con.context).CreateFunction(*con.context, info); });
+
+	auto result = con.Query("SELECT typeof(decimal_ret(NULL))");
+	REQUIRE_NO_FAIL(*result);
+	REQUIRE(result->GetValue(0, 0).ToString() == "DECIMAL(18,3)");
+}

--- a/test/common/CMakeLists.txt
+++ b/test/common/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library_unity(
   test_parse_expression.cpp
   test_parse_load_statement.cpp
   test_parse_logical_type.cpp
+  test_logical_type_is_complete.cpp
   test_utf.cpp
   test_allocator_debug_info.cpp
   test_buffer_pool_reservation.cpp

--- a/test/common/test_logical_type_is_complete.cpp
+++ b/test/common/test_logical_type_is_complete.cpp
@@ -1,0 +1,53 @@
+#include "catch.hpp"
+#include "duckdb/common/types.hpp"
+#include "duckdb/common/types/decimal.hpp"
+
+using namespace duckdb;
+
+TEST_CASE("Test LogicalType::IsComplete for DECIMAL", "[is_complete]") {
+	SECTION("well-formed decimals are complete") {
+		// Regression: every well-formed DECIMAL was wrongly reported as incomplete.
+		REQUIRE(LogicalType::DECIMAL(18, 3).IsComplete());
+		REQUIRE(LogicalType::DECIMAL(1, 0).IsComplete());
+		REQUIRE(LogicalType::DECIMAL(10, 0).IsComplete());
+		REQUIRE(LogicalType::DECIMAL(10, 10).IsComplete()); // scale == width
+		REQUIRE(LogicalType::DECIMAL(Decimal::MAX_WIDTH_DECIMAL, 0).IsComplete());
+		REQUIRE(LogicalType::DECIMAL(Decimal::MAX_WIDTH_DECIMAL, Decimal::MAX_WIDTH_DECIMAL).IsComplete());
+	}
+
+	SECTION("ill-formed decimals are incomplete") {
+		// width 0 is not a valid decimal width
+		REQUIRE(!LogicalType::DECIMAL(0, 0).IsComplete());
+	}
+
+	SECTION("types containing a decimal are complete") {
+		// TypeVisitor recurses into children; a well-formed decimal node must not report the whole type incomplete.
+		const auto dec = LogicalType::DECIMAL(18, 3);
+		REQUIRE(LogicalType::LIST(dec).IsComplete());
+		REQUIRE(LogicalType::ARRAY(dec, 4).IsComplete());
+
+		child_list_t<LogicalType> struct_children;
+		struct_children.emplace_back("a", dec);
+		REQUIRE(LogicalType::STRUCT(struct_children).IsComplete());
+
+		REQUIRE(LogicalType::MAP(LogicalType::VARCHAR, dec).IsComplete());
+
+		child_list_t<LogicalType> nested_children;
+		nested_children.emplace_back("a", LogicalType::LIST(dec));
+		REQUIRE(LogicalType::STRUCT(nested_children).IsComplete());
+	}
+
+	SECTION("unrelated types are unaffected") {
+		REQUIRE(LogicalType(LogicalType::INTEGER).IsComplete());
+		REQUIRE(LogicalType(LogicalType::VARCHAR).IsComplete());
+
+		child_list_t<LogicalType> plain_children;
+		plain_children.emplace_back("a", LogicalType::INTEGER);
+		plain_children.emplace_back("b", LogicalType::VARCHAR);
+		REQUIRE(LogicalType::STRUCT(plain_children).IsComplete());
+
+		REQUIRE(!LogicalType(LogicalTypeId::INVALID).IsComplete());
+		REQUIRE(!LogicalType(LogicalTypeId::UNKNOWN).IsComplete());
+		REQUIRE(!LogicalType(LogicalTypeId::ANY).IsComplete());
+	}
+}


### PR DESCRIPTION
The completeness check for Decimal had to be negated. IsComplete returns a negated `return !TypeVisitor::Contains`, so a complete type in the TypeVisitor must return `false`.