### PR TITLE
Ensure NULL children when parent is NULL on Copy paths

### DIFF
--- a/src/common/types/column/column_data_collection.cpp
+++ b/src/common/types/column/column_data_collection.cpp
@@ -886,14 +886,16 @@ void ColumnDataCopyStruct(ColumnDataMetaData &meta_data, const UnifiedVectorForm
 	// copy the NULL values for the main struct vector
 	TemplatedColumnDataCopy<StructValueCopy>(meta_data, source_data, source, offset, copy_count);
 
-	// check if the copied range contains any NULL rows
+	// check if the copied range contains any NULL rows, children must not claim valid entries under them
+	auto &parent_validity = source_data.validity;
+	const bool parent_flat = !source_data.sel->IsSet();
 	bool parent_has_nulls = false;
-	if (source_data.validity.IsMaskSet()) {
-		for (idx_t i = 0; i < copy_count; i++) {
-			auto source_idx = source_data.sel->get_index(offset + i);
-			if (!source_data.validity.RowIsValidUnsafe(source_idx)) {
-				parent_has_nulls = true;
-				break;
+	if (parent_validity.IsMaskSet()) {
+		if (parent_flat) {
+			parent_has_nulls = !parent_validity.CheckAllValid(offset + copy_count, offset);
+		} else {
+			for (idx_t i = 0; i < copy_count && !parent_has_nulls; i++) {
+				parent_has_nulls = !parent_validity.RowIsValidUnsafe(source_data.sel->get_index(offset + i));
 			}
 		}
 	}
@@ -912,14 +914,28 @@ void ColumnDataCopyStruct(ColumnDataMetaData &meta_data, const UnifiedVectorForm
 
 		if (parent_has_nulls) {
 			D_ASSERT(!child_data.sel->IsSet());
-			// Broadcast and sync the validity of the struct vector to the child vector
-			// This requires creating a copy of the validity mask: we cannot modify the input validity
-			child_data.validity = ValidityMask(child_data.validity, child_data.validity.Capacity());
-			child_data.validity.EnsureWritable();
-			for (idx_t i = 0; i < copy_count; i++) {
-				auto source_idx = source_data.sel->get_index(offset + i);
-				if (!source_data.validity.RowIsValidUnsafe(source_idx)) {
-					child_data.validity.SetInvalidUnsafe(offset + i);
+			// only rows violating the child-NULL invariant need a patched validity mask
+			bool children_correctly_masked = true;
+			if (parent_flat) {
+				// parent and child validity are at identical positions
+				children_correctly_masked =
+				    !AnyChildValidUnderNullParent(parent_validity, child_data.validity, offset, copy_count);
+			} else {
+				for (idx_t i = 0; i < copy_count && children_correctly_masked; i++) {
+					auto source_idx = source_data.sel->get_index(offset + i);
+					children_correctly_masked =
+					    parent_validity.RowIsValidUnsafe(source_idx) && child_data.validity.RowIsValid(offset + i);
+				}
+			}
+			if (!children_correctly_masked) {
+				// requires a copy of the validity mask: we cannot modify the input validity
+				child_data.validity = ValidityMask(child_data.validity, child_data.validity.Capacity());
+				child_data.validity.EnsureWritable();
+				for (idx_t i = 0; i < copy_count; i++) {
+					auto source_idx = source_data.sel->get_index(offset + i);
+					if (!parent_validity.RowIsValidUnsafe(source_idx)) {
+						child_data.validity.SetInvalidUnsafe(offset + i);
+					}
 				}
 			}
 		}

--- a/src/common/types/column/column_data_collection.cpp
+++ b/src/common/types/column/column_data_collection.cpp
@@ -879,6 +879,19 @@ void ColumnDataCopy<list_entry_t>(ColumnDataMetaData &meta_data, const UnifiedVe
 	}
 }
 
+// Independent flat copy carrying patched_validity, so SetValidity does not mutate child's possibly-shared buffer.
+static unique_ptr<Vector> PatchedListChildCopy(const Vector &child, const ValidityMask &patched_validity) {
+	auto count = child.size();
+	SelectionVector identity(count);
+	for (idx_t i = 0; i < count; i++) {
+		identity.set_index(i, i);
+	}
+	auto copy = make_uniq<Vector>(child, identity, count);
+	copy->Flatten();
+	FlatVector::SetValidity(*copy, patched_validity);
+	return copy;
+}
+
 void ColumnDataCopyStruct(ColumnDataMetaData &meta_data, const UnifiedVectorFormat &source_data, Vector &source,
                           idx_t offset, idx_t copy_count) {
 	auto &segment = meta_data.segment;
@@ -912,8 +925,7 @@ void ColumnDataCopyStruct(ColumnDataMetaData &meta_data, const UnifiedVectorForm
 		UnifiedVectorFormat child_data;
 		child_vectors[child_idx].ToUnifiedFormat(child_data);
 
-		// child_source is handed to the copier and replaced by a patched copy on the violation path.
-		// note: patched_child must outlive the child_function call below, hence the outer scope.
+		// patched_child (if built below) must outlive the child_function call, hence the outer scope
 		reference<Vector> child_source = child_vectors[child_idx];
 		unique_ptr<Vector> patched_child;
 
@@ -942,13 +954,10 @@ void ColumnDataCopyStruct(ColumnDataMetaData &meta_data, const UnifiedVectorForm
 						child_data.validity.SetInvalidUnsafe(offset + i);
 					}
 				}
-				// Only a LIST child's element copy reads validity from the Vector (via
-				// GetConsecutiveChildListInfo), so it must carry the patched mask too; other child types read
-				// only source_data. SetValidity needs a flat buffer, so constant/dict children are left as-is.
+				// only a flat LIST child reads validity off the Vector (GetConsecutiveChildListInfo); patch a copy
 				if (child_vectors[child_idx].GetType().InternalType() == PhysicalType::LIST &&
 				    child_vectors[child_idx].GetVectorType() == VectorType::FLAT_VECTOR) {
-					patched_child = make_uniq<Vector>(Vector::Ref(child_vectors[child_idx]));
-					FlatVector::SetValidity(*patched_child, child_data.validity);
+					patched_child = PatchedListChildCopy(child_vectors[child_idx], child_data.validity);
 					child_source = *patched_child;
 				}
 			}
@@ -987,8 +996,7 @@ void ColumnDataCopyArray(ColumnDataMetaData &meta_data, const UnifiedVectorForma
 	ColumnDataMetaData child_meta_data(child_function, meta_data, child_index);
 	child_vector.ToUnifiedFormat(child_vector_data);
 
-	// child_source is handed to the copier and replaced by a patched copy on the violation path.
-	// note: patched_child must outlive the child_function call below, hence the outer scope.
+	// patched_child (if built below) must outlive the child_function call, hence the outer scope
 	reference<Vector> array_child_source = child_vector;
 	unique_ptr<Vector> patched_child;
 
@@ -998,21 +1006,22 @@ void ColumnDataCopyArray(ColumnDataMetaData &meta_data, const UnifiedVectorForma
 	if (source_data.validity.IsMaskSet()) {
 		child_vector_data.validity.EnsureWritable();
 		D_ASSERT(!child_vector_data.sel->IsSet());
+		// a child slot still valid under a NULL array row is an unreflected violation
+		bool child_violation = false;
 		for (idx_t i = 0; i < copy_count; i++) {
 			auto source_idx = source_data.sel->get_index(offset + i);
 			if (!source_data.validity.RowIsValid(source_idx)) {
 				for (idx_t j = 0; j < array_size; j++) {
-					child_vector_data.validity.SetInvalidUnsafe(source_idx * array_size + j);
+					auto slot = source_idx * array_size + j;
+					child_violation |= child_vector_data.validity.RowIsValid(slot);
+					child_vector_data.validity.SetInvalidUnsafe(slot);
 				}
 			}
 		}
-		// Only a LIST child's element copy reads validity from the Vector (via
-		// GetConsecutiveChildListInfo), so it must carry the patched mask too; other child types read
-		// only source_data. SetValidity needs a flat buffer, so constant/dict children are left as-is.
-		if (child_vector.GetType().InternalType() == PhysicalType::LIST &&
+		// only a flat LIST child reads validity off the Vector (GetConsecutiveChildListInfo); patch a copy
+		if (child_violation && child_vector.GetType().InternalType() == PhysicalType::LIST &&
 		    child_vector.GetVectorType() == VectorType::FLAT_VECTOR) {
-			patched_child = make_uniq<Vector>(Vector::Ref(child_vector));
-			FlatVector::SetValidity(*patched_child, child_vector_data.validity);
+			patched_child = PatchedListChildCopy(child_vector, child_vector_data.validity);
 			array_child_source = *patched_child;
 		}
 	}

--- a/src/common/types/column/column_data_collection.cpp
+++ b/src/common/types/column/column_data_collection.cpp
@@ -912,8 +912,10 @@ void ColumnDataCopyStruct(ColumnDataMetaData &meta_data, const UnifiedVectorForm
 		UnifiedVectorFormat child_data;
 		child_vectors[child_idx].ToUnifiedFormat(child_data);
 
-		// child_source will be handed to the copier.
+		// child_source is handed to the copier and replaced by a patched copy on the violation path.
+		// note: patched_child must outlive the child_function call below, hence the outer scope.
 		reference<Vector> child_source = child_vectors[child_idx];
+		unique_ptr<Vector> patched_child;
 
 		if (parent_has_nulls) {
 			D_ASSERT(!child_data.sel->IsSet());
@@ -940,10 +942,15 @@ void ColumnDataCopyStruct(ColumnDataMetaData &meta_data, const UnifiedVectorForm
 						child_data.validity.SetInvalidUnsafe(offset + i);
 					}
 				}
-				// Replace child_source with a child that is patched with the new validity mask
-				auto patched_child = make_uniq<Vector>(Vector::Ref(child_vectors[child_idx]));
-				FlatVector::SetValidity(*patched_child, child_data.validity);
-				child_source = *patched_child;
+				// Only a LIST child's element copy reads validity from the Vector (via
+				// GetConsecutiveChildListInfo), so it must carry the patched mask too; other child types read
+				// only source_data. SetValidity needs a flat buffer, so constant/dict children are left as-is.
+				if (child_vectors[child_idx].GetType().InternalType() == PhysicalType::LIST &&
+				    child_vectors[child_idx].GetVectorType() == VectorType::FLAT_VECTOR) {
+					patched_child = make_uniq<Vector>(Vector::Ref(child_vectors[child_idx]));
+					FlatVector::SetValidity(*patched_child, child_data.validity);
+					child_source = *patched_child;
+				}
 			}
 		}
 
@@ -980,8 +987,10 @@ void ColumnDataCopyArray(ColumnDataMetaData &meta_data, const UnifiedVectorForma
 	ColumnDataMetaData child_meta_data(child_function, meta_data, child_index);
 	child_vector.ToUnifiedFormat(child_vector_data);
 
-	// child_source will be handed to the copier.
+	// child_source is handed to the copier and replaced by a patched copy on the violation path.
+	// note: patched_child must outlive the child_function call below, hence the outer scope.
 	reference<Vector> array_child_source = child_vector;
+	unique_ptr<Vector> patched_child;
 
 	// Broadcast and sync the validity of the array vector to the child vector
 	// This requires creating a copy of the validity mask: we cannot modify the input validity
@@ -997,10 +1006,15 @@ void ColumnDataCopyArray(ColumnDataMetaData &meta_data, const UnifiedVectorForma
 				}
 			}
 		}
-		// Replace child_source with a child that is patched with the new validity mask
-		auto patched_child = make_uniq<Vector>(Vector::Ref(child_vector));
-		FlatVector::SetValidity(*patched_child, child_vector_data.validity);
-		array_child_source = *patched_child;
+		// Only a LIST child's element copy reads validity from the Vector (via
+		// GetConsecutiveChildListInfo), so it must carry the patched mask too; other child types read
+		// only source_data. SetValidity needs a flat buffer, so constant/dict children are left as-is.
+		if (child_vector.GetType().InternalType() == PhysicalType::LIST &&
+		    child_vector.GetVectorType() == VectorType::FLAT_VECTOR) {
+			patched_child = make_uniq<Vector>(Vector::Ref(child_vector));
+			FlatVector::SetValidity(*patched_child, child_vector_data.validity);
+			array_child_source = *patched_child;
+		}
 	}
 
 	auto is_constant = source.GetVectorType() == VectorType::CONSTANT_VECTOR;

--- a/src/common/types/column/column_data_collection.cpp
+++ b/src/common/types/column/column_data_collection.cpp
@@ -886,6 +886,18 @@ void ColumnDataCopyStruct(ColumnDataMetaData &meta_data, const UnifiedVectorForm
 	// copy the NULL values for the main struct vector
 	TemplatedColumnDataCopy<StructValueCopy>(meta_data, source_data, source, offset, copy_count);
 
+	// check if the copied range contains any NULL rows
+	bool parent_has_nulls = false;
+	if (source_data.validity.IsMaskSet()) {
+		for (idx_t i = 0; i < copy_count; i++) {
+			auto source_idx = source_data.sel->get_index(offset + i);
+			if (!source_data.validity.RowIsValid(source_idx)) {
+				parent_has_nulls = true;
+				break;
+			}
+		}
+	}
+
 	auto &child_types = StructType::GetChildTypes(source.GetType());
 	// now copy all the child vectors
 	D_ASSERT(meta_data.GetVectorMetaData().child_index.IsValid());
@@ -897,6 +909,19 @@ void ColumnDataCopyStruct(ColumnDataMetaData &meta_data, const UnifiedVectorForm
 
 		UnifiedVectorFormat child_data;
 		child_vectors[child_idx].ToUnifiedFormat(child_data);
+
+		if (parent_has_nulls) {
+			D_ASSERT(!child_data.sel->IsSet());
+			// Broadcast and sync the validity of the struct vector to the child vector
+			// This requires creating a copy of the validity mask: we cannot modify the input validity
+			child_data.validity = ValidityMask(child_data.validity, child_data.validity.Capacity());
+			for (idx_t i = 0; i < copy_count; i++) {
+				auto source_idx = source_data.sel->get_index(offset + i);
+				if (!source_data.validity.RowIsValid(source_idx)) {
+					child_data.validity.SetInvalid(offset + i);
+				}
+			}
+		}
 
 		child_function.function(child_meta_data, child_data, child_vectors[child_idx], offset, copy_count);
 	}
@@ -935,6 +960,7 @@ void ColumnDataCopyArray(ColumnDataMetaData &meta_data, const UnifiedVectorForma
 	// This requires creating a copy of the validity mask: we cannot modify the input validity
 	child_vector_data.validity = ValidityMask(child_vector_data.validity, child_vector_data.validity.Capacity());
 	if (source_data.validity.IsMaskSet()) {
+		D_ASSERT(!child_vector_data.sel->IsSet());
 		for (idx_t i = 0; i < copy_count; i++) {
 			auto source_idx = source_data.sel->get_index(offset + i);
 			if (!source_data.validity.RowIsValid(source_idx)) {

--- a/src/common/types/column/column_data_collection.cpp
+++ b/src/common/types/column/column_data_collection.cpp
@@ -952,7 +952,7 @@ void ColumnDataCopyStruct(ColumnDataMetaData &meta_data, const UnifiedVectorForm
 						child_data.validity.SetInvalidUnsafe(offset + i);
 					}
 				}
-				// only a flat LIST child reads validity off the Vector (GetConsecutiveChildListInfo); patch a copy
+				// only a flat LIST child reads validity off the Vector (GetConsecutiveChildListInfo). Patch a copy
 				if (child_vectors[child_idx].GetType().InternalType() == PhysicalType::LIST &&
 				    child_vectors[child_idx].GetVectorType() == VectorType::FLAT_VECTOR) {
 					patched_child = PatchedListChildCopy(child_vectors[child_idx], child_data.validity);
@@ -1016,7 +1016,7 @@ void ColumnDataCopyArray(ColumnDataMetaData &meta_data, const UnifiedVectorForma
 				}
 			}
 		}
-		// only a flat LIST child reads validity off the Vector (GetConsecutiveChildListInfo); patch a copy
+		// only a flat LIST child reads validity off the Vector (GetConsecutiveChildListInfo). Patch a copy
 		if (has_unreflected_child && child_vector.GetType().InternalType() == PhysicalType::LIST &&
 		    child_vector.GetVectorType() == VectorType::FLAT_VECTOR) {
 			patched_child = PatchedListChildCopy(child_vector, child_vector_data.validity);

--- a/src/common/types/column/column_data_collection.cpp
+++ b/src/common/types/column/column_data_collection.cpp
@@ -912,6 +912,9 @@ void ColumnDataCopyStruct(ColumnDataMetaData &meta_data, const UnifiedVectorForm
 		UnifiedVectorFormat child_data;
 		child_vectors[child_idx].ToUnifiedFormat(child_data);
 
+		// child_source will be handed to the copier.
+		reference<Vector> child_source = child_vectors[child_idx];
+
 		if (parent_has_nulls) {
 			D_ASSERT(!child_data.sel->IsSet());
 			// only rows violating the child-NULL invariant need a patched validity mask
@@ -937,10 +940,14 @@ void ColumnDataCopyStruct(ColumnDataMetaData &meta_data, const UnifiedVectorForm
 						child_data.validity.SetInvalidUnsafe(offset + i);
 					}
 				}
+				// Replace child_source with a child that is patched with the new validity mask
+				auto patched_child = make_uniq<Vector>(Vector::Ref(child_vectors[child_idx]));
+				FlatVector::SetValidity(*patched_child, child_data.validity);
+				child_source = *patched_child;
 			}
 		}
 
-		child_function.function(child_meta_data, child_data, child_vectors[child_idx], offset, copy_count);
+		child_function.function(child_meta_data, child_data, child_source.get(), offset, copy_count);
 	}
 }
 
@@ -973,6 +980,9 @@ void ColumnDataCopyArray(ColumnDataMetaData &meta_data, const UnifiedVectorForma
 	ColumnDataMetaData child_meta_data(child_function, meta_data, child_index);
 	child_vector.ToUnifiedFormat(child_vector_data);
 
+	// child_source will be handed to the copier.
+	reference<Vector> array_child_source = child_vector;
+
 	// Broadcast and sync the validity of the array vector to the child vector
 	// This requires creating a copy of the validity mask: we cannot modify the input validity
 	child_vector_data.validity = ValidityMask(child_vector_data.validity, child_vector_data.validity.Capacity());
@@ -987,16 +997,20 @@ void ColumnDataCopyArray(ColumnDataMetaData &meta_data, const UnifiedVectorForma
 				}
 			}
 		}
+		// Replace child_source with a child that is patched with the new validity mask
+		auto patched_child = make_uniq<Vector>(Vector::Ref(child_vector));
+		FlatVector::SetValidity(*patched_child, child_vector_data.validity);
+		array_child_source = *patched_child;
 	}
 
 	auto is_constant = source.GetVectorType() == VectorType::CONSTANT_VECTOR;
 	// If the array is constant, we need to copy the child vector n times
 	if (is_constant) {
 		for (idx_t i = 0; i < copy_count; i++) {
-			child_function.function(child_meta_data, child_vector_data, child_vector, 0, array_size);
+			child_function.function(child_meta_data, child_vector_data, array_child_source.get(), 0, array_size);
 		}
 	} else {
-		child_function.function(child_meta_data, child_vector_data, child_vector, offset * array_size,
+		child_function.function(child_meta_data, child_vector_data, array_child_source.get(), offset * array_size,
 		                        copy_count * array_size);
 	}
 }

--- a/src/common/types/column/column_data_collection.cpp
+++ b/src/common/types/column/column_data_collection.cpp
@@ -891,7 +891,7 @@ void ColumnDataCopyStruct(ColumnDataMetaData &meta_data, const UnifiedVectorForm
 	if (source_data.validity.IsMaskSet()) {
 		for (idx_t i = 0; i < copy_count; i++) {
 			auto source_idx = source_data.sel->get_index(offset + i);
-			if (!source_data.validity.RowIsValid(source_idx)) {
+			if (!source_data.validity.RowIsValidUnsafe(source_idx)) {
 				parent_has_nulls = true;
 				break;
 			}
@@ -915,10 +915,11 @@ void ColumnDataCopyStruct(ColumnDataMetaData &meta_data, const UnifiedVectorForm
 			// Broadcast and sync the validity of the struct vector to the child vector
 			// This requires creating a copy of the validity mask: we cannot modify the input validity
 			child_data.validity = ValidityMask(child_data.validity, child_data.validity.Capacity());
+			child_data.validity.EnsureWritable();
 			for (idx_t i = 0; i < copy_count; i++) {
 				auto source_idx = source_data.sel->get_index(offset + i);
-				if (!source_data.validity.RowIsValid(source_idx)) {
-					child_data.validity.SetInvalid(offset + i);
+				if (!source_data.validity.RowIsValidUnsafe(source_idx)) {
+					child_data.validity.SetInvalidUnsafe(offset + i);
 				}
 			}
 		}
@@ -960,12 +961,13 @@ void ColumnDataCopyArray(ColumnDataMetaData &meta_data, const UnifiedVectorForma
 	// This requires creating a copy of the validity mask: we cannot modify the input validity
 	child_vector_data.validity = ValidityMask(child_vector_data.validity, child_vector_data.validity.Capacity());
 	if (source_data.validity.IsMaskSet()) {
+		child_vector_data.validity.EnsureWritable();
 		D_ASSERT(!child_vector_data.sel->IsSet());
 		for (idx_t i = 0; i < copy_count; i++) {
 			auto source_idx = source_data.sel->get_index(offset + i);
 			if (!source_data.validity.RowIsValid(source_idx)) {
 				for (idx_t j = 0; j < array_size; j++) {
-					child_vector_data.validity.SetInvalid(source_idx * array_size + j);
+					child_vector_data.validity.SetInvalidUnsafe(source_idx * array_size + j);
 				}
 			}
 		}

--- a/src/common/types/column/column_data_collection.cpp
+++ b/src/common/types/column/column_data_collection.cpp
@@ -882,10 +882,8 @@ void ColumnDataCopy<list_entry_t>(ColumnDataMetaData &meta_data, const UnifiedVe
 // Independent flat copy carrying patched_validity, so SetValidity does not mutate child's possibly-shared buffer.
 static unique_ptr<Vector> PatchedListChildCopy(const Vector &child, const ValidityMask &patched_validity) {
 	auto count = child.size();
-	SelectionVector identity(count);
-	for (idx_t i = 0; i < count; i++) {
-		identity.set_index(i, i);
-	}
+	// a set (non-identity-optimized) selection forces a dictionary that Flatten materializes into a private buffer
+	SelectionVector identity(idx_t(0), count);
 	auto copy = make_uniq<Vector>(child, identity, count);
 	copy->Flatten();
 	FlatVector::SetValidity(*copy, patched_validity);
@@ -1006,20 +1004,20 @@ void ColumnDataCopyArray(ColumnDataMetaData &meta_data, const UnifiedVectorForma
 	if (source_data.validity.IsMaskSet()) {
 		child_vector_data.validity.EnsureWritable();
 		D_ASSERT(!child_vector_data.sel->IsSet());
-		// a child slot still valid under a NULL array row is an unreflected violation
-		bool child_violation = false;
+		// a child slot still valid under a NULL array row is unreflected
+		bool has_unreflected_child = false;
 		for (idx_t i = 0; i < copy_count; i++) {
 			auto source_idx = source_data.sel->get_index(offset + i);
 			if (!source_data.validity.RowIsValid(source_idx)) {
 				for (idx_t j = 0; j < array_size; j++) {
 					auto slot = source_idx * array_size + j;
-					child_violation |= child_vector_data.validity.RowIsValid(slot);
+					has_unreflected_child |= child_vector_data.validity.RowIsValid(slot);
 					child_vector_data.validity.SetInvalidUnsafe(slot);
 				}
 			}
 		}
 		// only a flat LIST child reads validity off the Vector (GetConsecutiveChildListInfo); patch a copy
-		if (child_violation && child_vector.GetType().InternalType() == PhysicalType::LIST &&
+		if (has_unreflected_child && child_vector.GetType().InternalType() == PhysicalType::LIST &&
 		    child_vector.GetVectorType() == VectorType::FLAT_VECTOR) {
 			patched_child = PatchedListChildCopy(child_vector, child_vector_data.validity);
 			array_child_source = *patched_child;

--- a/src/common/vector/array_vector.cpp
+++ b/src/common/vector/array_vector.cpp
@@ -89,22 +89,13 @@ void VectorArrayBuffer::VerifyInternal(const LogicalType &type, const SelectionV
 		child->Verify();
 		return;
 	}
-	// flat vector case - only verify children for valid (non-NULL) entries
-	idx_t selected_child_count = 0;
-	for (idx_t i = 0; i < count; i++) {
-		auto oidx = sel.get_index(i);
-		if (validity.RowIsValid(oidx)) {
-			selected_child_count += array_size;
-		}
-	}
-	SelectionVector child_sel(selected_child_count);
+	// recurse into all children (incl. under NULL rows, proven NULL above) to catch deeper violations
+	SelectionVector child_sel(count * array_size);
 	idx_t child_count = 0;
 	for (idx_t i = 0; i < count; i++) {
 		auto oidx = sel.get_index(i);
-		if (validity.RowIsValid(oidx)) {
-			for (idx_t r = 0; r < array_size; r++) {
-				child_sel.set_index(child_count++, oidx * array_size + r);
-			}
+		for (idx_t r = 0; r < array_size; r++) {
+			child_sel.set_index(child_count++, oidx * array_size + r);
 		}
 	}
 	child->Verify(child_sel, child_count);

--- a/src/common/vector/array_vector.cpp
+++ b/src/common/vector/array_vector.cpp
@@ -180,7 +180,16 @@ void VectorArrayBuffer::CopyInternal(const Vector &source, const SelectionVector
                                      idx_t source_offset, idx_t target_offset, idx_t copy_count) {
 	D_ASSERT(ArrayType::GetSize(source.GetType()) == array_size);
 
-	auto &source_child = ArrayVector::GetChild(source);
+	auto &raw_source_child = ArrayVector::GetChild(source);
+	// A sequence/FSST/dictionary child vector makes the copies below flatten past child_sel. Normalize it to a
+	// flat owned copy first so both the wholesale copy and the child-checkable scan see a flat vector.
+	unique_ptr<Vector> flat_child;
+	if (raw_source_child.GetVectorType() != VectorType::FLAT_VECTOR &&
+	    raw_source_child.GetVectorType() != VectorType::CONSTANT_VECTOR) {
+		flat_child = make_uniq<Vector>(Vector::Ref(raw_source_child));
+		flat_child->Flatten();
+	}
+	auto &source_child = flat_child ? *flat_child : raw_source_child;
 
 	// Copy only non-NULL rows to avoid copying garbage if the child entry for some reason wasn't NULLed
 	SelectionVector child_sel(copy_count * array_size);

--- a/src/common/vector/array_vector.cpp
+++ b/src/common/vector/array_vector.cpp
@@ -68,7 +68,8 @@ idx_t VectorArrayBuffer::GetAllocationSize() const {
 void VectorArrayBuffer::VerifyInternal(const LogicalType &type, const SelectionVector &sel, idx_t count) const {
 	D_ASSERT(type.InternalType() == PhysicalType::ARRAY);
 	// a child slot under a NULL array row must be NULL as well, we check before reading any child payload
-	if (child->GetVectorType() == VectorType::FLAT_VECTOR || child->GetVectorType() == VectorType::CONSTANT_VECTOR) {
+	if (child->GetVectorType() == VectorType::FLAT_VECTOR || child->GetVectorType() == VectorType::CONSTANT_VECTOR ||
+	    child->GetVectorType() == VectorType::DICTIONARY_VECTOR) {
 		auto child_validity = child->Validity();
 		for (idx_t i = 0; i < count; i++) {
 			auto item_idx = sel.get_index(i);
@@ -213,9 +214,15 @@ void VectorArrayBuffer::CopyInternal(const Vector &source, const SelectionVector
 	}
 	// NULL rows whose source slots are all NULL are handled by validity propagation in the wholesale copy
 	const auto child_vector_type = source_child.GetVectorType();
-	const bool child_checkable =
-	    child_vector_type == VectorType::FLAT_VECTOR || child_vector_type == VectorType::CONSTANT_VECTOR;
-	auto source_child_validity = source_child.Validity();
+
+	const bool child_checkable = child_vector_type == VectorType::FLAT_VECTOR ||
+	                             child_vector_type == VectorType::CONSTANT_VECTOR ||
+	                             child_vector_type == VectorType::DICTIONARY_VECTOR;
+	// ToUnifiedFormat is side-effect-free for these three types, so only if child_checkable we grab the sel vector
+	UnifiedVectorFormat source_child_format;
+	if (child_checkable) {
+		source_child.ToUnifiedFormat(source_child_format);
+	}
 	idx_t start_idx = 0;
 	for (idx_t i = 0; i < copy_count; i++) {
 		if (validity.RowIsValidUnsafe(target_offset + i)) {
@@ -225,7 +232,7 @@ void VectorArrayBuffer::CopyInternal(const Vector &source, const SelectionVector
 			auto source_idx = source_sel.get_index(source_offset + i);
 			bool all_null = true;
 			for (idx_t j = 0; j < array_size; j++) {
-				if (source_child_validity.IsValid(source_idx * array_size + j)) {
+				if (source_child_format.sel->get_index(source_idx * array_size + j)) {
 					all_null = false;
 					break;
 				}

--- a/src/common/vector/array_vector.cpp
+++ b/src/common/vector/array_vector.cpp
@@ -206,9 +206,14 @@ void VectorArrayBuffer::CopyInternal(const Vector &source, const SelectionVector
 		child->Copy(source_child, child_sel, source_count * array_size, 0, (target_offset + start) * array_size,
 		            rows * array_size);
 	};
+	// no NULL rows in the copied range - one wholesale copy
+	if (validity.CheckAllValid(target_offset + copy_count, target_offset)) {
+		copy_valid_slice(0, copy_count);
+		return;
+	}
 	idx_t start_idx = 0;
 	for (idx_t i = 0; i < copy_count; i++) {
-		if (validity.RowIsValid(target_offset + i)) {
+		if (validity.RowIsValidUnsafe(target_offset + i)) {
 			continue;
 		}
 		copy_valid_slice(start_idx, i);

--- a/src/common/vector/array_vector.cpp
+++ b/src/common/vector/array_vector.cpp
@@ -67,6 +67,23 @@ idx_t VectorArrayBuffer::GetAllocationSize() const {
 
 void VectorArrayBuffer::VerifyInternal(const LogicalType &type, const SelectionVector &sel, idx_t count) const {
 	D_ASSERT(type.InternalType() == PhysicalType::ARRAY);
+	// a child slot under a NULL array row must be NULL as well, we check before reading any child payload
+	if (child->GetVectorType() == VectorType::FLAT_VECTOR || child->GetVectorType() == VectorType::CONSTANT_VECTOR) {
+		auto child_validity = child->Validity();
+		for (idx_t i = 0; i < count; i++) {
+			auto item_idx = sel.get_index(i);
+			if (validity.RowIsValid(item_idx)) {
+				continue;
+			}
+			for (idx_t r = 0; r < array_size; r++) {
+				if (child_validity.IsValid(item_idx * array_size + r)) {
+					throw InternalException("A child of a NULL array must always be NULL"
+					                        "\nArray type: %s\nRow: %llu, Element: %llu",
+					                        type.ToString(), (uint64_t)item_idx, (uint64_t)r);
+				}
+			}
+		}
+	}
 	if (!sel.IsSet() && count == Size()) {
 		child->Verify();
 		return;
@@ -90,7 +107,6 @@ void VectorArrayBuffer::VerifyInternal(const LogicalType &type, const SelectionV
 		}
 	}
 	child->Verify(child_sel, child_count);
-	// FIXME: verify NULL-ness in child
 }
 
 buffer_ptr<VectorBuffer> VectorArrayBuffer::Flatten(const LogicalType &type) const {
@@ -174,16 +190,35 @@ void VectorArrayBuffer::CopyInternal(const Vector &source, const SelectionVector
 
 	auto &source_child = ArrayVector::GetChild(source);
 
-	// Create a selection vector for the child elements
+	// Copy only non-NULL rows to avoid copying garbage if the child entry for some reason wasn't NULLed
 	SelectionVector child_sel(copy_count * array_size);
+	auto copy_valid_slice = [&](idx_t start, idx_t end) {
+		if (end == start) {
+			return;
+		}
+		auto rows = end - start;
+		for (idx_t r = 0; r < rows; r++) {
+			auto source_idx = source_sel.get_index(source_offset + start + r);
+			for (idx_t j = 0; j < array_size; j++) {
+				child_sel.set_index(r * array_size + j, source_idx * array_size + j);
+			}
+		}
+		child->Copy(source_child, child_sel, source_count * array_size, 0, (target_offset + start) * array_size,
+		            rows * array_size);
+	};
+	idx_t start_idx = 0;
 	for (idx_t i = 0; i < copy_count; i++) {
-		auto source_idx = source_sel.get_index(source_offset + i);
+		if (validity.RowIsValid(target_offset + i)) {
+			continue;
+		}
+		copy_valid_slice(start_idx, i);
+		start_idx = i + 1;
 		for (idx_t j = 0; j < array_size; j++) {
-			child_sel.set_index(i * array_size + j, source_idx * array_size + j);
+			// recursive: descendants of a skipped slot must read NULL too
+			FlatVector::SetNull(*child, (target_offset + i) * array_size + j, true);
 		}
 	}
-	child->Copy(source_child, child_sel, source_count * array_size, 0, target_offset * array_size,
-	            copy_count * array_size);
+	copy_valid_slice(start_idx, copy_count);
 }
 
 void VectorArrayBuffer::SetValue(const LogicalType &type, idx_t index, const Value &val) {

--- a/src/common/vector/array_vector.cpp
+++ b/src/common/vector/array_vector.cpp
@@ -232,7 +232,8 @@ void VectorArrayBuffer::CopyInternal(const Vector &source, const SelectionVector
 			auto source_idx = source_sel.get_index(source_offset + i);
 			bool all_null = true;
 			for (idx_t j = 0; j < array_size; j++) {
-				if (source_child_format.sel->get_index(source_idx * array_size + j)) {
+				auto child_idx = source_child_format.sel->get_index(source_idx * array_size + j);
+				if (source_child_format.validity.RowIsValid(child_idx)) {
 					all_null = false;
 					break;
 				}

--- a/src/common/vector/array_vector.cpp
+++ b/src/common/vector/array_vector.cpp
@@ -211,11 +211,30 @@ void VectorArrayBuffer::CopyInternal(const Vector &source, const SelectionVector
 		copy_valid_slice(0, copy_count);
 		return;
 	}
+	// NULL rows whose source slots are all NULL are handled by validity propagation in the wholesale copy
+	const auto child_vector_type = source_child.GetVectorType();
+	const bool child_checkable =
+	    child_vector_type == VectorType::FLAT_VECTOR || child_vector_type == VectorType::CONSTANT_VECTOR;
+	auto source_child_validity = source_child.Validity();
 	idx_t start_idx = 0;
 	for (idx_t i = 0; i < copy_count; i++) {
 		if (validity.RowIsValidUnsafe(target_offset + i)) {
 			continue;
 		}
+		if (child_checkable) {
+			auto source_idx = source_sel.get_index(source_offset + i);
+			bool all_null = true;
+			for (idx_t j = 0; j < array_size; j++) {
+				if (source_child_validity.IsValid(source_idx * array_size + j)) {
+					all_null = false;
+					break;
+				}
+			}
+			if (all_null) {
+				continue;
+			}
+		}
+		// only rows violating the child-NULL invariant need isolation from the copied runs
 		copy_valid_slice(start_idx, i);
 		start_idx = i + 1;
 		for (idx_t j = 0; j < array_size; j++) {

--- a/src/common/vector/struct_vector.cpp
+++ b/src/common/vector/struct_vector.cpp
@@ -126,7 +126,8 @@ void VectorStructBuffer::VerifyInternal(const LogicalType &type, const Selection
 			}
 		} else {
 			if (child.GetVectorType() == VectorType::FLAT_VECTOR ||
-			    child.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+			    child.GetVectorType() == VectorType::CONSTANT_VECTOR ||
+			    child.GetVectorType() == VectorType::DICTIONARY_VECTOR) {
 				auto child_validity = child.Validity();
 				for (idx_t r = 0; r < Size(); r++) {
 					if (!validity.RowIsValid(r)) {

--- a/src/common/vector/struct_vector.cpp
+++ b/src/common/vector/struct_vector.cpp
@@ -255,7 +255,7 @@ namespace {
 
 // The nested-NULL invariant for struct children: "a child of a NULL parent must itself be NULL".
 // A NULL parent row is reflected when all its child slots are NULL, so a wholesale Copy carries the
-// NULLs and never reads child payload; it is unreflected when a child holds a value under it, which
+// NULLs and never reads child payload. It is unreflected when a child holds a value under it, which
 // only external (non-DuckDB) data produces.
 
 // True iff some physical source row has a NULL parent but a child holding a value (an unreflected row).
@@ -293,7 +293,7 @@ struct ChildNullReflection {
 	}
 
 private:
-	//! per-child validity, fetched once; an empty entry is a child that never holds a value (constant-NULL)
+	//! per-child validity, fetched once. An empty entry is a child that never holds a value (constant-NULL)
 	vector<optional_ptr<const ValidityMask>> child_masks;
 	//! false when the masks can't decide reflection: a child's validity isn't readable per row
 	//! (dictionary/sequence), or a child holds a value under every row (constant non-NULL)
@@ -312,7 +312,7 @@ ChildNullReflection ChildNullReflection::Check(const Vector &source, const vecto
 			continue;
 		}
 		if (child_vector_type == VectorType::CONSTANT_VECTOR && ConstantVector::IsNull(children[i])) {
-			// constant-NULL child never holds a value; its empty mask is already correct
+			// constant-NULL child never holds a value. Its empty mask is already correct
 			continue;
 		}
 		// constant non-NULL (a value under every row) or dictionary/sequence (validity unreadable):
@@ -336,13 +336,40 @@ void VectorStructBuffer::CopyInternal(const Vector &source, const SelectionVecto
 	auto &source_children = StructVector::GetEntries(source);
 	D_ASSERT(source_children.size() == children.size());
 
-	// Helper to copy slice of source_children into this.children
+	// The per-row split copy below reads children at source_offset + start. On a sequence/FSST/dictionary child
+	// vector VectorBuffer::Copy would then flatten past the source selection. Normalize such children to owned flat
+	// copies once (flat/constant ones are referenced as-is). This also lets the reflection check read their
+	// validity instead of falling back to isolating every NULL row.
+	auto is_flat_or_constant = [](const Vector &child) {
+		auto type = child.GetVectorType();
+		return type == VectorType::FLAT_VECTOR || type == VectorType::CONSTANT_VECTOR;
+	};
+	bool needs_normalization = false;
+	for (auto &child : source_children) {
+		if (!is_flat_or_constant(child)) {
+			needs_normalization = true;
+			break;
+		}
+	}
+	vector<Vector> normalized_children;
+	if (needs_normalization) {
+		normalized_children.reserve(source_children.size());
+		for (auto &child : source_children) {
+			normalized_children.emplace_back(Vector::Ref(child));
+			if (!is_flat_or_constant(child)) {
+				normalized_children.back().Flatten();
+			}
+		}
+	}
+	auto &copy_children = needs_normalization ? normalized_children : source_children;
+
+	// Helper to copy slice of copy_children into this.children
 	auto copy_children_slice = [&](idx_t start, idx_t end) {
 		if (end == start) {
 			return;
 		}
-		for (idx_t i = 0; i < source_children.size(); i++) {
-			children[i].Copy(source_children[i], source_sel, source_count, source_offset + start, target_offset + start,
+		for (idx_t i = 0; i < copy_children.size(); i++) {
+			children[i].Copy(copy_children[i], source_sel, source_count, source_offset + start, target_offset + start,
 			                 end - start);
 		}
 	};
@@ -355,7 +382,7 @@ void VectorStructBuffer::CopyInternal(const Vector &source, const SelectionVecto
 
 	// A NULL parent row is safe to copy wholesale when the children reflect it (all child slots NULL).
 	// Only unreflected rows must be isolated and NULLed.
-	auto reflection = ChildNullReflection::Check(source, source_children);
+	auto reflection = ChildNullReflection::Check(source, copy_children);
 	if (reflection.AllReflected()) {
 		copy_children_slice(0, copy_count);
 		return;

--- a/src/common/vector/struct_vector.cpp
+++ b/src/common/vector/struct_vector.cpp
@@ -254,9 +254,29 @@ void VectorStructBuffer::CopyInternal(const Vector &source, const SelectionVecto
                                       idx_t source_offset, idx_t target_offset, idx_t copy_count) {
 	auto &source_children = StructVector::GetEntries(source);
 	D_ASSERT(source_children.size() == children.size());
-	for (idx_t i = 0; i < source_children.size(); i++) {
-		children[i].Copy(source_children[i], source_sel, source_count, source_offset, target_offset, copy_count);
+	// Copy only non-NULL rows to avoid copying garbage if the child entry for some reason wasn't NULLed
+	auto copy_valid_slice = [&](idx_t start, idx_t end) {
+		if (end == start) {
+			return;
+		}
+		for (idx_t i = 0; i < source_children.size(); i++) {
+			children[i].Copy(source_children[i], source_sel, source_count, source_offset + start, target_offset + start,
+			                 end - start);
+		}
+	};
+	idx_t start_idx = 0;
+	for (idx_t i = 0; i < copy_count; i++) {
+		if (validity.RowIsValid(target_offset + i)) {
+			continue;
+		}
+		copy_valid_slice(start_idx, i);
+		start_idx = i + 1;
+		for (idx_t j = 0; j < children.size(); j++) {
+			// recursive: see VectorArrayBuffer::CopyInternal
+			FlatVector::SetNull(children[j], target_offset + i, true);
+		}
 	}
+	copy_valid_slice(start_idx, copy_count);
 }
 
 buffer_ptr<VectorBuffer> VectorStructBuffer::Flatten(const LogicalType &type) const {

--- a/src/common/vector/struct_vector.cpp
+++ b/src/common/vector/struct_vector.cpp
@@ -264,9 +264,14 @@ void VectorStructBuffer::CopyInternal(const Vector &source, const SelectionVecto
 			                 end - start);
 		}
 	};
+	// no NULL rows in the copied range - one wholesale copy
+	if (validity.CheckAllValid(target_offset + copy_count, target_offset)) {
+		copy_valid_slice(0, copy_count);
+		return;
+	}
 	idx_t start_idx = 0;
 	for (idx_t i = 0; i < copy_count; i++) {
-		if (validity.RowIsValid(target_offset + i)) {
+		if (validity.RowIsValidUnsafe(target_offset + i)) {
 			continue;
 		}
 		copy_valid_slice(start_idx, i);

--- a/src/common/vector/struct_vector.cpp
+++ b/src/common/vector/struct_vector.cpp
@@ -250,12 +250,93 @@ void VectorStructBuffer::ReserveInternal(idx_t new_size) {
 	capacity = new_size;
 }
 
+namespace {
+
+// The nested-NULL invariant for struct children: "a child of a NULL parent must itself be NULL".
+// A NULL parent row is reflected when all its child slots are NULL, so a wholesale Copy carries the
+// NULLs and never reads child payload; it is unreflected when a child holds a value under it, which
+// only external (non-DuckDB) data produces.
+
+// True iff some physical source row has a NULL parent but a child holding a value (an unreflected row).
+bool AnyParentNullUnreflected(const ValidityMask &parent_validity,
+                              const vector<optional_ptr<const ValidityMask>> &child_masks, idx_t source_size) {
+	for (auto &child_mask : child_masks) {
+		// an empty mask is a constant-NULL child, which never holds a value
+		if (child_mask && AnyChildValidUnderNullParent(parent_validity, *child_mask, 0, source_size)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+struct ChildNullReflection {
+	//! Inspect a struct source's children to see whether its NULL parent rows are reflected.
+	static ChildNullReflection Check(const Vector &source, const vector<Vector> &children);
+
+	//! Every NULL parent row in the copied source is reflected -> a single wholesale copy is safe.
+	bool AllReflected() const {
+		return all_reflected;
+	}
+	//! Whether this source row's NULL parent is reflected in the children (all child slots NULL).
+	//! Returns false whenever reflection can't be decided from the masks (see can_check).
+	bool RowReflectsNull(idx_t source_row) const {
+		if (!can_check) {
+			return false;
+		}
+		for (auto &child_mask : child_masks) {
+			if (child_mask && child_mask->RowIsValid(source_row)) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+private:
+	//! per-child validity, fetched once; an empty entry is a child that never holds a value (constant-NULL)
+	vector<optional_ptr<const ValidityMask>> child_masks;
+	//! false when the masks can't decide reflection: a child's validity isn't readable per row
+	//! (dictionary/sequence), or a child holds a value under every row (constant non-NULL)
+	bool can_check = true;
+	//! proven that every NULL parent row in the copied source is reflected
+	bool all_reflected = false;
+};
+
+ChildNullReflection ChildNullReflection::Check(const Vector &source, const vector<Vector> &children) {
+	ChildNullReflection result;
+	result.child_masks.resize(children.size());
+	for (idx_t i = 0; i < children.size(); i++) {
+		auto child_vector_type = children[i].GetVectorType();
+		if (child_vector_type == VectorType::FLAT_VECTOR) {
+			result.child_masks[i] = FlatVector::Validity(children[i]);
+			continue;
+		}
+		if (child_vector_type == VectorType::CONSTANT_VECTOR && ConstantVector::IsNull(children[i])) {
+			// constant-NULL child never holds a value; its empty mask is already correct
+			continue;
+		}
+		// constant non-NULL (a value under every row) or dictionary/sequence (validity unreadable):
+		// the masks can no longer decide reflection row by row
+		result.can_check = false;
+		break;
+	}
+	// a flat source lets us prove reflection for the whole vector with one word-wise scan: its
+	// physical rows align bit-for-bit with the child masks
+	const idx_t source_size = source.size();
+	if (result.can_check && source.GetVectorType() == VectorType::FLAT_VECTOR && source_size != 0) {
+		result.all_reflected = !AnyParentNullUnreflected(FlatVector::Validity(source), result.child_masks, source_size);
+	}
+	return result;
+}
+
+} // namespace
+
 void VectorStructBuffer::CopyInternal(const Vector &source, const SelectionVector &source_sel, idx_t source_count,
                                       idx_t source_offset, idx_t target_offset, idx_t copy_count) {
 	auto &source_children = StructVector::GetEntries(source);
 	D_ASSERT(source_children.size() == children.size());
-	// Copy only non-NULL rows to avoid copying garbage if the child entry for some reason wasn't NULLed
-	auto copy_valid_slice = [&](idx_t start, idx_t end) {
+
+	// Helper to copy slice of source_children into this.children
+	auto copy_children_slice = [&](idx_t start, idx_t end) {
 		if (end == start) {
 			return;
 		}
@@ -264,9 +345,18 @@ void VectorStructBuffer::CopyInternal(const Vector &source, const SelectionVecto
 			                 end - start);
 		}
 	};
-	// no NULL rows in the copied range - one wholesale copy
+
+	// If there are no NULL rows in the copied range we can copy all at once and are done
 	if (validity.CheckAllValid(target_offset + copy_count, target_offset)) {
-		copy_valid_slice(0, copy_count);
+		copy_children_slice(0, copy_count);
+		return;
+	}
+
+	// A NULL parent row is safe to copy wholesale when the children reflect it (all child slots NULL).
+	// Only unreflected rows must be isolated and NULLed.
+	auto reflection = ChildNullReflection::Check(source, source_children);
+	if (reflection.AllReflected()) {
+		copy_children_slice(0, copy_count);
 		return;
 	}
 	idx_t start_idx = 0;
@@ -274,14 +364,18 @@ void VectorStructBuffer::CopyInternal(const Vector &source, const SelectionVecto
 		if (validity.RowIsValidUnsafe(target_offset + i)) {
 			continue;
 		}
-		copy_valid_slice(start_idx, i);
+		if (reflection.RowReflectsNull(source_sel.get_index(source_offset + i))) {
+			continue;
+		}
+		// unreflected row: isolate it from the wholesale runs and NULL its children
+		copy_children_slice(start_idx, i);
 		start_idx = i + 1;
 		for (idx_t j = 0; j < children.size(); j++) {
 			// recursive: see VectorArrayBuffer::CopyInternal
 			FlatVector::SetNull(children[j], target_offset + i, true);
 		}
 	}
-	copy_valid_slice(start_idx, copy_count);
+	copy_children_slice(start_idx, copy_count);
 }
 
 buffer_ptr<VectorBuffer> VectorStructBuffer::Flatten(const LogicalType &type) const {

--- a/src/include/duckdb/common/types/validity_mask.hpp
+++ b/src/include/duckdb/common/types/validity_mask.hpp
@@ -96,16 +96,43 @@ public:
 		return CountValid(count) == 0;
 	}
 
+	//! Validity bits of the slice [row, row+count) that lies within one entry, low-aligned and zero-padded above.
+	//! Precondition: mask allocated, count in [1, BITS_PER_VALUE], (row % BITS_PER_VALUE) + count <= BITS_PER_VALUE.
+	inline V GetSliceWithinEntry(idx_t row, idx_t count) const {
+		const V entry = GetValidityEntryUnsafe(row / BITS_PER_VALUE) >> (row % BITS_PER_VALUE);
+		return count == BITS_PER_VALUE ? entry : (entry & EntryWithValidBits(count));
+	}
+
 	inline bool CheckAllValid(idx_t to, idx_t from) const {
 		if (CannotHaveNull()) {
 			return true;
 		}
-		for (idx_t i = from; i < to; i++) {
-			if (!RowIsValid(i)) {
+		// check validity in blocks of BITS_PER_VALUE at a time rather than row by row
+		for (idx_t i = from; i < to;) {
+			const idx_t bits = MinValue<idx_t>(BITS_PER_VALUE - i % BITS_PER_VALUE, to - i);
+			if (GetSliceWithinEntry(i, bits) != EntryWithValidBits(bits)) {
 				return false;
 			}
+			i += bits;
 		}
 		return true;
+	}
+
+	//! Returns `count` (1 to BITS_PER_VALUE) validity bits starting at `offset`, in the low bits, zero-padded above
+	inline V GetSliceEntry(idx_t offset, idx_t count) const {
+		D_ASSERT(count > 0 && count <= BITS_PER_VALUE);
+		if (CannotHaveNull()) {
+			return EntryWithValidBits(count);
+		}
+		const idx_t idx_in_entry = offset % BITS_PER_VALUE;
+		if (idx_in_entry + count <= BITS_PER_VALUE) {
+			return GetSliceWithinEntry(offset, count);
+		}
+		// slice includes a word boundary: stitch the high bits of this entry with the low bits of the next
+		const idx_t entry_idx = offset / BITS_PER_VALUE;
+		V result = GetValidityEntryUnsafe(entry_idx) >> idx_in_entry;
+		result |= GetValidityEntryUnsafe(entry_idx + 1) << (BITS_PER_VALUE - idx_in_entry);
+		return result & EntryWithValidBits(count);
 	}
 
 	idx_t CountValid(const idx_t count) const {
@@ -394,6 +421,24 @@ public:
 	void Write(WriteStream &writer, idx_t count);
 	void Read(ReadStream &reader, idx_t count);
 };
+
+//! Enforces the nested-NULL invariant: a child of a NULL parent must itself be NULL. Returns true iff
+//! some row in [offset, offset+count) is NULL in `parent` but valid in `child`. `parent` and `child`
+//! must be positionally aligned, as they are for a struct's children.
+inline bool AnyChildValidUnderNullParent(const ValidityMask &parent, const ValidityMask &child, idx_t offset,
+                                         idx_t count) {
+	for (idx_t done = 0; done < count; done += ValidityMask::BITS_PER_VALUE) {
+		auto bits = MinValue<idx_t>(ValidityMask::BITS_PER_VALUE, count - done);
+		auto parent_null = ~parent.GetSliceEntry(offset + done, bits) & ValidityMask::EntryWithValidBits(bits);
+		if (!parent_null) {
+			continue;
+		}
+		if (parent_null & child.GetSliceEntry(offset + done, bits)) {
+			return true;
+		}
+	}
+	return false;
+}
 
 //===--------------------------------------------------------------------===//
 // ValidityArray

--- a/test/common/CMakeLists.txt
+++ b/test/common/CMakeLists.txt
@@ -26,6 +26,7 @@ add_library_unity(
   test_strftime.cpp
   test_string_util.cpp
   test_substring_oob.cpp
+  test_nested_copy_null_child.cpp
   test_utf8_codepoint_oob.cpp
   test_temporary_memory_manager.cpp
   test_value_to_sql_string.cpp)

--- a/test/common/test_nested_copy_null_child.cpp
+++ b/test/common/test_nested_copy_null_child.cpp
@@ -462,6 +462,43 @@ TEST_CASE("Verify rejects non-NULL children under a NULL ARRAY row", "[copy]") {
 		VerifyVectorsGuard guard;
 		REQUIRE_THROWS(v.Verify(sel, row_count));
 	}
+
+	SECTION("deep violation is caught through two recursion levels (ARRAY(ARRAY(ARRAY)))") {
+		auto lvl1 = LogicalType::ARRAY(LogicalType::VARCHAR, ARRAY_SIZE);
+		auto lvl2 = LogicalType::ARRAY(lvl1, ARRAY_SIZE);
+		Vector v(LogicalType::ARRAY(lvl2, ARRAY_SIZE));
+		for (idx_t r = 0; r < row_count; r++) {
+			duckdb::vector<Value> mids;
+			for (idx_t a = 0; a < ARRAY_SIZE; a++) {
+				duckdb::vector<Value> inners;
+				for (idx_t b = 0; b < ARRAY_SIZE; b++) {
+					duckdb::vector<Value> leaves(ARRAY_SIZE, Value("ok"));
+					inners.push_back(Value::ARRAY(LogicalType::VARCHAR, leaves));
+				}
+				mids.push_back(Value::ARRAY(lvl1, inners));
+			}
+			v.SetValue(r, Value::ARRAY(lvl2, mids));
+		}
+		FlatVector::SetSize(v, row_count);
+		auto &mid_child = ArrayVector::GetChildMutable(v);
+		auto &inner_child = ArrayVector::GetChildMutable(mid_child);
+		// outer row NULL; middle and inner slots beneath it correctly NULL (reflected), but the deepest
+		// VARCHAR left valid -> the only violation is two levels down, reachable only via the recursion
+		FlatVector::ValidityMutable(v).SetInvalid(null_row);
+		for (idx_t e = 0; e < ARRAY_SIZE; e++) {
+			auto mid_slot = null_row * ARRAY_SIZE + e;
+			FlatVector::ValidityMutable(mid_child).SetInvalid(mid_slot);
+			for (idx_t f = 0; f < ARRAY_SIZE; f++) {
+				FlatVector::ValidityMutable(inner_child).SetInvalid(mid_slot * ARRAY_SIZE + f);
+			}
+		}
+		SelectionVector sel(row_count);
+		for (idx_t i = 0; i < row_count; i++) {
+			sel.set_index(i, i);
+		}
+		VerifyVectorsGuard guard;
+		REQUIRE_THROWS(v.Verify(sel, row_count));
+	}
 }
 
 namespace {

--- a/test/common/test_nested_copy_null_child.cpp
+++ b/test/common/test_nested_copy_null_child.cpp
@@ -332,6 +332,10 @@ TEST_CASE("Verify rejects non-NULL children under a NULL ARRAY row", "[copy]") {
 	// the provoked InternalException aborts instead of throwing in crash-on-assert builds
 	return;
 #endif
+	if (STANDARD_VECTOR_SIZE < 8) {
+		// the fixtures exceed the default vector capacity at tiny vector sizes
+		return;
+	}
 	const idx_t row_count = 4;
 	const idx_t null_row = 1;
 

--- a/test/common/test_nested_copy_null_child.cpp
+++ b/test/common/test_nested_copy_null_child.cpp
@@ -1,0 +1,538 @@
+#include "catch.hpp"
+#include "duckdb/common/allocator.hpp"
+#include "duckdb/common/enums/debug_verification_mode.hpp"
+#include "duckdb/common/types/column/column_data_collection.hpp"
+#include "duckdb/common/types/data_chunk.hpp"
+#include "duckdb/common/types/value.hpp"
+#include "duckdb/common/types/vector.hpp"
+#include "duckdb/common/vector/array_vector.hpp"
+#include "duckdb/common/vector/flat_vector.hpp"
+#include "duckdb/common/vector/list_vector.hpp"
+#include "duckdb/common/vector/struct_vector.hpp"
+#include "duckdb/main/config.hpp"
+
+#include <cstring>
+
+// Vector copies must not read the (undefined) descendants of NULL ARRAY/STRUCT rows and must mark
+// them NULL recursively in the target, even when the source marks them valid over garbage.
+
+using namespace duckdb;
+
+namespace {
+
+constexpr idx_t ARRAY_SIZE = 3;
+
+enum class Shape { ARRAY_VARCHAR, ARRAY_STRUCT_VARCHAR, STRUCT_ARRAY_VARCHAR, ARRAY_LIST_VARCHAR, STRUCT_LIST_VARCHAR };
+
+LogicalType StructOfVarchar() {
+	return LogicalType::STRUCT({{"s", LogicalType::VARCHAR}});
+}
+
+LogicalType MakeType(Shape shape) {
+	switch (shape) {
+	case Shape::ARRAY_VARCHAR:
+		return LogicalType::ARRAY(LogicalType::VARCHAR, ARRAY_SIZE);
+	case Shape::ARRAY_STRUCT_VARCHAR:
+		return LogicalType::ARRAY(StructOfVarchar(), ARRAY_SIZE);
+	case Shape::STRUCT_ARRAY_VARCHAR:
+		return LogicalType::STRUCT({{"arr", LogicalType::ARRAY(LogicalType::VARCHAR, ARRAY_SIZE)}});
+	case Shape::ARRAY_LIST_VARCHAR:
+		return LogicalType::ARRAY(LogicalType::LIST(LogicalType::VARCHAR), ARRAY_SIZE);
+	default:
+		return LogicalType::STRUCT({{"l", LogicalType::LIST(LogicalType::VARCHAR)}});
+	}
+}
+
+// > 12 bytes so copies go through StringHeap::AddBlob's heap path
+string LeafString(idx_t row, idx_t elem) {
+	return "val-r" + to_string(row) + "-e" + to_string(elem) + "-padding";
+}
+
+Value LeafList(idx_t row, idx_t elem) {
+	duckdb::vector<Value> strings;
+	for (idx_t s = 0; s <= elem; s++) {
+		strings.push_back(Value(LeafString(row, elem * 10 + s)));
+	}
+	return Value::LIST(LogicalType::VARCHAR, strings);
+}
+
+Value ValidValue(Shape shape, idx_t row) {
+	switch (shape) {
+	case Shape::ARRAY_VARCHAR: {
+		duckdb::vector<Value> leaves;
+		for (idx_t e = 0; e < ARRAY_SIZE; e++) {
+			leaves.push_back(Value(LeafString(row, e)));
+		}
+		return Value::ARRAY(LogicalType::VARCHAR, leaves);
+	}
+	case Shape::ARRAY_STRUCT_VARCHAR: {
+		duckdb::vector<Value> structs;
+		for (idx_t e = 0; e < ARRAY_SIZE; e++) {
+			structs.push_back(Value::STRUCT({{"s", Value(LeafString(row, e))}}));
+		}
+		return Value::ARRAY(StructOfVarchar(), structs);
+	}
+	case Shape::STRUCT_ARRAY_VARCHAR: {
+		duckdb::vector<Value> leaves;
+		for (idx_t e = 0; e < ARRAY_SIZE; e++) {
+			leaves.push_back(Value(LeafString(row, e)));
+		}
+		return Value::STRUCT({{"arr", Value::ARRAY(LogicalType::VARCHAR, leaves)}});
+	}
+	case Shape::ARRAY_LIST_VARCHAR: {
+		duckdb::vector<Value> lists;
+		for (idx_t e = 0; e < ARRAY_SIZE; e++) {
+			lists.push_back(LeafList(row, e));
+		}
+		return Value::ARRAY(LogicalType::LIST(LogicalType::VARCHAR), lists);
+	}
+	default:
+		return Value::STRUCT({{"l", LeafList(row, 2)}});
+	}
+}
+
+Vector &NestedChild(Shape shape, Vector &parent) {
+	switch (shape) {
+	case Shape::ARRAY_VARCHAR:
+	case Shape::ARRAY_STRUCT_VARCHAR:
+	case Shape::ARRAY_LIST_VARCHAR:
+		return ArrayVector::GetChildMutable(parent);
+	default:
+		return StructVector::GetEntries(parent)[0];
+	}
+}
+
+// claims 16 MiB over a 16-byte buffer; any payload read faults under ASAN
+string_t MakeUndefinedPayload(unsafe_unique_array<char> &backing) {
+	backing = make_unsafe_uniq_array<char>(16);
+	memset(backing.get(), 'x', 16);
+	return string_t(backing.get(), 1u << 24);
+}
+
+void PlantVarcharGarbage(Vector &leaf, idx_t slot_start, idx_t slot_count, string_t payload) {
+	auto &leaf_validity = FlatVector::ValidityMutable(leaf);
+	auto leaf_data = FlatVector::GetDataMutable<string_t>(leaf);
+	for (idx_t s = 0; s < slot_count; s++) {
+		leaf_validity.SetValid(slot_start + s);
+		leaf_data[slot_start + s] = payload;
+	}
+}
+
+// a copy that reads these entries builds a ~10^12-entry child selection (hang / OOM)
+void PlantListGarbage(Vector &list, idx_t slot_start, idx_t slot_count) {
+	auto &list_validity = FlatVector::ValidityMutable(list);
+	auto list_data = FlatVector::GetDataMutable<list_entry_t>(list);
+	for (idx_t s = 0; s < slot_count; s++) {
+		list_validity.SetValid(slot_start + s);
+		list_data[slot_start + s] = list_entry_t(1ULL << 40, 1ULL << 40);
+	}
+}
+
+// mark a NULL parent row's descendants valid over garbage, as Arrow-ingested data can
+void PlantUndefined(Shape shape, Vector &parent, idx_t row, string_t payload) {
+	auto &child = NestedChild(shape, parent);
+	switch (shape) {
+	case Shape::ARRAY_VARCHAR:
+		PlantVarcharGarbage(child, row * ARRAY_SIZE, ARRAY_SIZE, payload);
+		break;
+	case Shape::ARRAY_STRUCT_VARCHAR: {
+		auto &sv_validity = FlatVector::ValidityMutable(child);
+		for (idx_t e = 0; e < ARRAY_SIZE; e++) {
+			sv_validity.SetValid(row * ARRAY_SIZE + e);
+		}
+		PlantVarcharGarbage(StructVector::GetEntries(child)[0], row * ARRAY_SIZE, ARRAY_SIZE, payload);
+		break;
+	}
+	case Shape::STRUCT_ARRAY_VARCHAR:
+		FlatVector::ValidityMutable(child).SetValid(row);
+		PlantVarcharGarbage(ArrayVector::GetChildMutable(child), row * ARRAY_SIZE, ARRAY_SIZE, payload);
+		break;
+	case Shape::ARRAY_LIST_VARCHAR:
+		PlantListGarbage(child, row * ARRAY_SIZE, ARRAY_SIZE);
+		break;
+	default:
+		PlantListGarbage(child, row, 1);
+		break;
+	}
+}
+
+// the deepest sub-vector under a NULL row must read NULL in the target (proves the recursive SetNull)
+void RequireSkippedNull(Shape shape, Vector &target_parent, idx_t row) {
+	auto &child = NestedChild(shape, target_parent);
+	reference<Vector> leaf(child);
+	idx_t slot_start = row * ARRAY_SIZE;
+	idx_t slot_count = ARRAY_SIZE;
+	switch (shape) {
+	case Shape::ARRAY_STRUCT_VARCHAR:
+		leaf = StructVector::GetEntries(child)[0];
+		break;
+	case Shape::STRUCT_ARRAY_VARCHAR:
+		leaf = ArrayVector::GetChildMutable(child);
+		break;
+	case Shape::STRUCT_LIST_VARCHAR:
+		slot_start = row;
+		slot_count = 1;
+		break;
+	default:
+		break;
+	}
+	auto &leaf_validity = FlatVector::Validity(leaf.get());
+	for (idx_t s = 0; s < slot_count; s++) {
+		REQUIRE(!leaf_validity.RowIsValid(slot_start + s));
+	}
+}
+
+// a source chunk whose NULL parent rows carry valid-flagged garbage descendants
+struct CopyFixture {
+	CopyFixture(Shape shape, const duckdb::vector<bool> &is_null) : shape(shape), is_null(is_null) {
+		auto type = MakeType(shape);
+		auto payload = MakeUndefinedPayload(backing);
+		source.Initialize(allocator, {type});
+		source.SetChildCardinality(is_null.size());
+		expected.resize(is_null.size());
+		for (idx_t r = 0; r < is_null.size(); r++) {
+			if (is_null[r]) {
+				source.data[0].SetValue(r, Value(type));
+			} else {
+				expected[r] = ValidValue(shape, r);
+				source.data[0].SetValue(r, expected[r]);
+			}
+		}
+		for (idx_t r = 0; r < is_null.size(); r++) {
+			if (is_null[r]) {
+				PlantUndefined(shape, source.data[0], r, payload);
+			}
+		}
+	}
+
+	void RequireRow(Vector &target, idx_t target_row, idx_t src_row) {
+		if (is_null[src_row]) {
+			REQUIRE(target.GetValue(target_row).IsNull());
+			RequireSkippedNull(shape, target, target_row);
+		} else {
+			REQUIRE(target.GetValue(target_row) == expected[src_row]);
+		}
+	}
+
+	Shape shape;
+	duckdb::vector<bool> is_null;
+	Allocator allocator;
+	unsafe_unique_array<char> backing;
+	DataChunk source;
+	duckdb::vector<Value> expected;
+};
+
+// plain chunk copy - the streaming/buffered result path (SimpleBufferedData::Append)
+void RunCase(Shape shape, const duckdb::vector<bool> &is_null) {
+	CopyFixture f(shape, is_null);
+	DataChunk target;
+	target.Initialize(f.allocator, {MakeType(shape)});
+	f.source.Copy(target, 0);
+	target.data[0].Verify();
+	for (idx_t r = 0; r < is_null.size(); r++) {
+		f.RequireRow(target.data[0], r, r);
+	}
+}
+
+// copy with a reordering source selection (non-identity source_sel)
+void RunReorderCase(Shape shape, const duckdb::vector<bool> &is_null) {
+	CopyFixture f(shape, is_null);
+	auto row_count = is_null.size();
+	SelectionVector reorder(row_count);
+	for (idx_t i = 0; i < row_count; i++) {
+		reorder.set_index(i, row_count - 1 - i);
+	}
+	DataChunk target;
+	target.Initialize(f.allocator, {MakeType(shape)});
+	target.data[0].Copy(f.source.data[0], reorder, row_count, 0, 0, row_count);
+	FlatVector::SetSize(target.data[0], row_count);
+	target.data[0].Verify();
+	for (idx_t i = 0; i < row_count; i++) {
+		f.RequireRow(target.data[0], i, row_count - 1 - i);
+	}
+}
+
+// append onto a non-empty target (target_offset > 0)
+void RunAppendCase(Shape shape, const duckdb::vector<bool> &is_null) {
+	CopyFixture f(shape, is_null);
+	const idx_t prefix = 2;
+	DataChunk target;
+	target.Initialize(f.allocator, {MakeType(shape)});
+	duckdb::vector<Value> prefix_vals;
+	for (idx_t p = 0; p < prefix; p++) {
+		prefix_vals.push_back(ValidValue(shape, 100 + p));
+		target.data[0].SetValue(p, prefix_vals[p]);
+	}
+	FlatVector::SetSize(target.data[0], prefix);
+	target.data[0].Append(f.source.data[0], is_null.size());
+	target.data[0].Verify();
+	for (idx_t p = 0; p < prefix; p++) {
+		REQUIRE(target.data[0].GetValue(p) == prefix_vals[p]);
+	}
+	for (idx_t r = 0; r < is_null.size(); r++) {
+		f.RequireRow(target.data[0], prefix + r, r);
+	}
+}
+
+void RunCorpus(Shape shape) {
+	duckdb::vector<duckdb::vector<bool>> patterns = {
+	    {true, false, false, false, false}, // start
+	    {false, false, true, false, false}, // middle
+	    {false, false, false, false, true}, // end
+	    {true, true, true, true, true},     // all NULL
+	    {false, true, false, true, false},  // interleaved
+	};
+	for (auto &pattern : patterns) {
+		RunCase(shape, pattern);
+	}
+	// reorder/append add no run-boundary logic of their own; the interleaved pattern covers them
+	RunReorderCase(shape, patterns.back());
+	RunAppendCase(shape, patterns.back());
+}
+
+} // namespace
+
+TEST_CASE("copy ARRAY(VARCHAR) must not read child payloads under NULL rows", "[copy]") {
+	RunCorpus(Shape::ARRAY_VARCHAR);
+}
+
+TEST_CASE("copy ARRAY(STRUCT(VARCHAR)) must not read grandchild payloads under NULL rows", "[copy]") {
+	RunCorpus(Shape::ARRAY_STRUCT_VARCHAR);
+}
+
+TEST_CASE("copy STRUCT(ARRAY(VARCHAR)) must not read grandchild payloads under NULL rows", "[copy]") {
+	RunCorpus(Shape::STRUCT_ARRAY_VARCHAR);
+}
+
+TEST_CASE("copy ARRAY(LIST(VARCHAR)) must not read list entries under NULL rows", "[copy]") {
+	RunCorpus(Shape::ARRAY_LIST_VARCHAR);
+}
+
+TEST_CASE("copy STRUCT(LIST(VARCHAR)) must not read list entries under NULL rows", "[copy]") {
+	RunCorpus(Shape::STRUCT_LIST_VARCHAR);
+}
+
+namespace {
+
+// enable aggressive vector verification for a scope, restoring the previous mode on exit
+struct VerifyVectorsGuard {
+	VerifyVectorsGuard() : previous(DBConfigOptions::global_verification_mode) {
+		DBConfigOptions::global_verification_mode = DebugVerificationMode::VERIFY_VECTORS;
+	}
+	~VerifyVectorsGuard() {
+		DBConfigOptions::global_verification_mode = previous;
+	}
+	DebugVerificationMode previous;
+};
+
+} // namespace
+
+TEST_CASE("Verify rejects non-NULL children under a NULL ARRAY row", "[copy]") {
+#ifdef DUCKDB_CRASH_ON_ASSERT
+	// the provoked InternalException aborts instead of throwing in crash-on-assert builds
+	return;
+#endif
+	const idx_t row_count = 4;
+	const idx_t null_row = 1;
+
+	// ARRAY(child_type, ARRAY_SIZE) with every row valid over safe inlined strings
+	auto make_array = [&](const LogicalType &child_type) {
+		Vector v(LogicalType::ARRAY(child_type, ARRAY_SIZE));
+		for (idx_t r = 0; r < row_count; r++) {
+			duckdb::vector<Value> leaves;
+			for (idx_t e = 0; e < ARRAY_SIZE; e++) {
+				leaves.push_back(child_type.id() == LogicalTypeId::STRUCT ? Value::STRUCT({{"s", Value("ok")}})
+				                                                          : Value("ok"));
+			}
+			v.SetValue(r, Value::ARRAY(child_type, leaves));
+		}
+		FlatVector::SetSize(v, row_count);
+		return v;
+	};
+
+	SECTION("well-formed NULL row passes") {
+		auto v = make_array(LogicalType::VARCHAR);
+		// SetNull recursively nulls the child slots too, as the Copy fix does for normalized targets
+		FlatVector::SetNull(v, null_row, true);
+		VerifyVectorsGuard guard;
+		REQUIRE_NOTHROW(v.Verify());
+	}
+
+	SECTION("full-vector Verify") {
+		auto v = make_array(LogicalType::VARCHAR);
+		// mark the parent row NULL without touching its (still valid) child slots
+		FlatVector::ValidityMutable(v).SetInvalid(null_row);
+		VerifyVectorsGuard guard;
+		REQUIRE_THROWS(v.Verify());
+	}
+
+	SECTION("sliced Verify") {
+		auto v = make_array(LogicalType::VARCHAR);
+		FlatVector::ValidityMutable(v).SetInvalid(null_row);
+		SelectionVector sel(row_count);
+		for (idx_t i = 0; i < row_count; i++) {
+			sel.set_index(i, i);
+		}
+		VerifyVectorsGuard guard;
+		REQUIRE_THROWS(v.Verify(sel, row_count));
+	}
+
+	SECTION("grandchild under a correctly-NULL struct is caught by recursion (full path)") {
+		auto v = make_array(StructOfVarchar());
+		auto &struct_child = ArrayVector::GetChildMutable(v);
+		// parent array row NULL, its struct child slots correctly NULL, grandchild left valid
+		FlatVector::ValidityMutable(v).SetInvalid(null_row);
+		for (idx_t e = 0; e < ARRAY_SIZE; e++) {
+			FlatVector::ValidityMutable(struct_child).SetInvalid(null_row * ARRAY_SIZE + e);
+		}
+		VerifyVectorsGuard guard;
+		string message;
+		try {
+			v.Verify();
+		} catch (const std::exception &ex) {
+			message = ex.what();
+		}
+		REQUIRE(message.find("Struct NULL mismatch") != string::npos);
+	}
+
+	SECTION("grandchild under a correctly-NULL struct is caught by recursion (sliced path)") {
+		auto v = make_array(StructOfVarchar());
+		auto &struct_child = ArrayVector::GetChildMutable(v);
+		FlatVector::ValidityMutable(v).SetInvalid(null_row);
+		for (idx_t e = 0; e < ARRAY_SIZE; e++) {
+			FlatVector::ValidityMutable(struct_child).SetInvalid(null_row * ARRAY_SIZE + e);
+		}
+		SelectionVector sel(row_count);
+		for (idx_t i = 0; i < row_count; i++) {
+			sel.set_index(i, i);
+		}
+		VerifyVectorsGuard guard;
+		string message;
+		try {
+			v.Verify(sel, row_count);
+		} catch (const std::exception &ex) {
+			message = ex.what();
+		}
+		// the struct's own full-size NULL scan catches it even though the array sel excludes NULL rows
+		REQUIRE(message.find("Struct NULL mismatch") != string::npos);
+	}
+}
+
+namespace {
+
+void ScanSingleChunk(ColumnDataCollection &collection, DataChunk &result) {
+	collection.InitializeScanChunk(result);
+	ColumnDataScanState state;
+	collection.InitializeScan(state);
+	REQUIRE(collection.Scan(state, result));
+}
+
+} // namespace
+
+TEST_CASE("ColumnDataCollection append must not read child payloads under NULL rows", "[copy]") {
+	if (STANDARD_VECTOR_SIZE < 8) {
+		// the scan-back assumes all rows fit in a single chunk
+		return;
+	}
+	Allocator allocator;
+
+	SECTION("STRUCT(VARCHAR): garbage under a NULL row") {
+		auto type = StructOfVarchar();
+		unsafe_unique_array<char> backing;
+		auto payload = MakeUndefinedPayload(backing);
+		const idx_t row_count = 3;
+		const idx_t null_row = 1;
+		DataChunk chunk;
+		chunk.Initialize(allocator, {type});
+		chunk.SetChildCardinality(row_count);
+		duckdb::vector<Value> expected(row_count);
+		for (idx_t r = 0; r < row_count; r++) {
+			if (r == null_row) {
+				chunk.data[0].SetValue(r, Value(type));
+			} else {
+				expected[r] = Value::STRUCT({{"s", Value(LeafString(r, 0))}});
+				chunk.data[0].SetValue(r, expected[r]);
+			}
+		}
+		PlantVarcharGarbage(StructVector::GetEntries(chunk.data[0])[0], null_row, 1, payload);
+
+		ColumnDataCollection collection(allocator, {type});
+		collection.Append(chunk);
+
+		DataChunk result;
+		ScanSingleChunk(collection, result);
+		REQUIRE(result.size() == row_count);
+		REQUIRE(result.data[0].GetValue(null_row).IsNull());
+		// the child slot under the NULL row must read NULL in the collection
+		REQUIRE(!FlatVector::Validity(StructVector::GetEntries(result.data[0])[0]).RowIsValid(null_row));
+		for (idx_t r = 0; r < row_count; r++) {
+			if (r != null_row) {
+				REQUIRE(result.data[0].GetValue(r) == expected[r]);
+			}
+		}
+	}
+
+	SECTION("ARRAY(STRUCT(VARCHAR)): broadcast composes at depth 2") {
+		CopyFixture f(Shape::ARRAY_STRUCT_VARCHAR, {false, true, false, true, false});
+		ColumnDataCollection collection(f.allocator, {MakeType(Shape::ARRAY_STRUCT_VARCHAR)});
+		collection.Append(f.source);
+
+		DataChunk result;
+		ScanSingleChunk(collection, result);
+		REQUIRE(result.size() == f.is_null.size());
+		for (idx_t r = 0; r < f.is_null.size(); r++) {
+			f.RequireRow(result.data[0], r, r);
+		}
+	}
+
+	SECTION("well-formed NULLs round-trip") {
+		auto type = MakeType(Shape::ARRAY_STRUCT_VARCHAR);
+		const idx_t row_count = 4;
+		DataChunk chunk;
+		chunk.Initialize(allocator, {type});
+		chunk.SetChildCardinality(row_count);
+		duckdb::vector<Value> expected(row_count);
+		for (idx_t r = 0; r < row_count; r++) {
+			expected[r] = r % 2 ? Value(type) : ValidValue(Shape::ARRAY_STRUCT_VARCHAR, r);
+			chunk.data[0].SetValue(r, expected[r]);
+		}
+		ColumnDataCollection collection(allocator, {type});
+		collection.Append(chunk);
+
+		DataChunk result;
+		ScanSingleChunk(collection, result);
+		for (idx_t r = 0; r < row_count; r++) {
+			if (r % 2) {
+				REQUIRE(result.data[0].GetValue(r).IsNull());
+			} else {
+				REQUIRE(result.data[0].GetValue(r) == expected[r]);
+			}
+		}
+	}
+
+	SECTION("dictionary child sharing a slot with a NULL row is not corrupted") {
+		auto type = StructOfVarchar();
+		DataChunk chunk;
+		chunk.Initialize(allocator, {type});
+		chunk.SetChildCardinality(2);
+		auto shared = Value::STRUCT({{"s", Value(LeafString(0, 0))}});
+		chunk.data[0].SetValue(0, shared);
+		chunk.data[0].SetValue(1, Value::STRUCT({{"s", Value(LeafString(1, 0))}}));
+		// dictionary-encode the child so both rows read dict slot 0
+		SelectionVector dict_sel(2);
+		dict_sel.set_index(0, 0);
+		dict_sel.set_index(1, 0);
+		StructVector::GetEntries(chunk.data[0])[0].Slice(dict_sel, 2);
+		// NULL row 1 via the raw parent mask - its shared child slot stays valid-flagged
+		FlatVector::ValidityMutable(chunk.data[0]).SetInvalid(1);
+
+		ColumnDataCollection collection(allocator, {type});
+		collection.Append(chunk);
+
+		DataChunk result;
+		ScanSingleChunk(collection, result);
+		REQUIRE(result.data[0].GetValue(0) == shared);
+		REQUIRE(result.data[0].GetValue(1).IsNull());
+		REQUIRE(!FlatVector::Validity(StructVector::GetEntries(result.data[0])[0]).RowIsValid(1));
+	}
+}

--- a/test/common/test_nested_copy_null_child.cpp
+++ b/test/common/test_nested_copy_null_child.cpp
@@ -385,6 +385,19 @@ TEST_CASE("Verify rejects non-NULL children under a NULL ARRAY row", "[copy]") {
 		REQUIRE_THROWS(v.Verify(sel, row_count));
 	}
 
+	SECTION("dictionary child") {
+		auto v = make_array(LogicalType::VARCHAR);
+		auto &child = ArrayVector::GetChildMutable(v);
+		SelectionVector dict_sel(child.size());
+		for (idx_t i = 0; i < child.size(); i++) {
+			dict_sel.set_index(i, 0);
+		}
+		child.Slice(dict_sel, child.size());
+		FlatVector::ValidityMutable(v).SetInvalid(null_row);
+		VerifyVectorsGuard guard;
+		REQUIRE_THROWS(v.Verify());
+	}
+
 	SECTION("grandchild under a correctly-NULL struct is caught by recursion (full path)") {
 		auto v = make_array(StructOfVarchar());
 		auto &struct_child = ArrayVector::GetChildMutable(v);
@@ -516,6 +529,56 @@ TEST_CASE("ColumnDataCollection append must not read child payloads under NULL r
 				REQUIRE(result.data[0].GetValue(r) == expected[r]);
 			}
 		}
+	}
+
+	SECTION("STRUCT(LIST(VARCHAR)): a child under a NULL parent does not shift later lists") {
+		auto type = MakeType(Shape::STRUCT_LIST_VARCHAR);
+		const idx_t row_count = 3;
+		const idx_t null_row = 1;
+		DataChunk chunk;
+		chunk.Initialize(allocator, {type});
+		chunk.SetChildCardinality(row_count);
+		duckdb::vector<Value> expected(row_count);
+		for (idx_t r = 0; r < row_count; r++) {
+			expected[r] = ValidValue(Shape::STRUCT_LIST_VARCHAR, r);
+			chunk.data[0].SetValue(r, expected[r]);
+		}
+		// Leave the LIST child valid while marking only its STRUCT parent NULL.
+		FlatVector::ValidityMutable(chunk.data[0]).SetInvalid(null_row);
+
+		ColumnDataCollection collection(allocator, {type});
+		collection.Append(chunk);
+
+		DataChunk result;
+		ScanSingleChunk(collection, result);
+		REQUIRE(result.data[0].GetValue(0) == expected[0]);
+		REQUIRE(result.data[0].GetValue(null_row).IsNull());
+		REQUIRE(result.data[0].GetValue(2) == expected[2]);
+	}
+
+	SECTION("ARRAY(LIST(VARCHAR)): a child under a NULL parent does not shift later lists") {
+		auto type = MakeType(Shape::ARRAY_LIST_VARCHAR);
+		const idx_t row_count = 3;
+		const idx_t null_row = 1;
+		DataChunk chunk;
+		chunk.Initialize(allocator, {type});
+		chunk.SetChildCardinality(row_count);
+		duckdb::vector<Value> expected(row_count);
+		for (idx_t r = 0; r < row_count; r++) {
+			expected[r] = ValidValue(Shape::ARRAY_LIST_VARCHAR, r);
+			chunk.data[0].SetValue(r, expected[r]);
+		}
+		// Leave the LIST grandchildren valid while marking only the ARRAY parent row NULL.
+		FlatVector::ValidityMutable(chunk.data[0]).SetInvalid(null_row);
+
+		ColumnDataCollection collection(allocator, {type});
+		collection.Append(chunk);
+
+		DataChunk result;
+		ScanSingleChunk(collection, result);
+		REQUIRE(result.data[0].GetValue(0) == expected[0]);
+		REQUIRE(result.data[0].GetValue(null_row).IsNull());
+		REQUIRE(result.data[0].GetValue(2) == expected[2]);
 	}
 
 	SECTION("dictionary child sharing a slot with a NULL row is not corrupted") {

--- a/test/common/test_nested_copy_null_child.cpp
+++ b/test/common/test_nested_copy_null_child.cpp
@@ -6,6 +6,7 @@
 #include "duckdb/common/types/value.hpp"
 #include "duckdb/common/types/vector.hpp"
 #include "duckdb/common/vector/array_vector.hpp"
+#include "duckdb/common/vector/constant_vector.hpp"
 #include "duckdb/common/vector/flat_vector.hpp"
 #include "duckdb/common/vector/list_vector.hpp"
 #include "duckdb/common/vector/struct_vector.hpp"
@@ -102,7 +103,7 @@ Vector &NestedChild(Shape shape, Vector &parent) {
 	}
 }
 
-// claims 16 MiB over a 16-byte buffer; any payload read faults under ASAN
+// claims 16 MiB over a 16-byte buffer. Any payload read faults under ASAN
 string_t MakeUndefinedPayload(unsafe_unique_array<char> &backing) {
 	backing = make_unsafe_uniq_array<char>(16);
 	memset(backing.get(), 'x', 16);
@@ -289,7 +290,7 @@ void RunCorpus(Shape shape) {
 	for (auto &pattern : patterns) {
 		RunCase(shape, pattern);
 	}
-	// reorder/append add no run-boundary logic of their own; the interleaved pattern covers them
+	// reorder/append add no run-boundary logic of their own. The interleaved pattern covers them
 	RunReorderCase(shape, patterns.back());
 	RunAppendCase(shape, patterns.back());
 }
@@ -330,6 +331,202 @@ struct VerifyVectorsGuard {
 };
 
 } // namespace
+
+namespace {
+
+void ScanSingleChunk(ColumnDataCollection &collection, DataChunk &result); // defined below
+
+// The child vector representations a STRUCT/ARRAY child can take. The nested-NULL copy paths must handle each.
+// The engine keeps children in any of these, but only FLAT/CONSTANT were originally covered.
+enum class ChildRep { FLAT, CONSTANT, DICTIONARY, SEQUENCE };
+
+const char *RepName(ChildRep rep) {
+	switch (rep) {
+	case ChildRep::FLAT:
+		return "FLAT";
+	case ChildRep::CONSTANT:
+		return "CONSTANT";
+	case ChildRep::DICTIONARY:
+		return "DICTIONARY";
+	default:
+		return "SEQUENCE";
+	}
+}
+
+// Fill a freshly-allocated BIGINT leaf `child` (count logical rows) in representation `rep`. Logical row i holds
+// base+i, except CONSTANT which holds base everywhere. The child is left fully valid on purpose: under a NULL
+// parent it is then unreflected, which is exactly what the copy paths must isolate and NULL.
+void FillBigintChild(Vector &child, ChildRep rep, idx_t count, int64_t base = 100) {
+	switch (rep) {
+	case ChildRep::SEQUENCE:
+		child.Sequence(base, 1, count);
+		return;
+	case ChildRep::CONSTANT:
+		child.SetVectorType(VectorType::CONSTANT_VECTOR);
+		ConstantVector::GetData<int64_t>(child)[0] = base;
+		return;
+	default: {
+		auto data = FlatVector::GetDataMutable<int64_t>(child);
+		for (idx_t i = 0; i < count; i++) {
+			data[i] = base + int64_t(i);
+		}
+		if (rep == ChildRep::DICTIONARY) {
+			SelectionVector dict_sel(count);
+			for (idx_t i = 0; i < count; i++) {
+				dict_sel.set_index(i, i);
+			}
+			child.Slice(dict_sel, count);
+		}
+	}
+	}
+}
+
+// Copy a STRUCT(i BIGINT) / ARRAY(BIGINT) whose child is in representation `rep` through a (possibly reversed)
+// selection, starting at source_offset, then assert the target passes Verify (children under NULL rows were
+// nulled) and every copied row matches. source_offset > 0 exercises the sequence/FSST/dictionary child vector
+// flatten range that was the root cause of the sequence-child bug.
+void RunRepCopy(const LogicalType &type, bool is_array, ChildRep rep, bool reverse, idx_t source_offset) {
+	const idx_t row_count = 5;
+	const idx_t copy_count = row_count - source_offset;
+	const idx_t null_row = 1;
+	Vector source(type);
+	auto &child = is_array ? ArrayVector::GetChildMutable(source) : StructVector::GetEntries(source)[0];
+	FillBigintChild(child, rep, is_array ? row_count * ARRAY_SIZE : row_count);
+	FlatVector::SetSize(source, row_count);
+	FlatVector::ValidityMutable(source).SetInvalid(null_row);
+
+	SelectionVector sel(row_count);
+	for (idx_t r = 0; r < row_count; r++) {
+		sel.set_index(r, reverse ? row_count - r - 1 : r);
+	}
+
+	Vector target(type);
+	target.Copy(source, sel, row_count, source_offset, 0, copy_count);
+	FlatVector::SetSize(target, copy_count);
+
+	VerifyVectorsGuard guard;
+	target.Verify();
+	for (idx_t r = 0; r < copy_count; r++) {
+		auto src = sel.get_index(source_offset + r);
+		INFO("stream rep=" << RepName(rep) << " reverse=" << reverse << " offset=" << source_offset << " row=" << r);
+		if (src == null_row) {
+			REQUIRE(target.GetValue(r).IsNull());
+		} else {
+			REQUIRE(target.GetValue(r) == source.GetValue(src));
+		}
+	}
+}
+
+// Same source shapes, but through the buffered ColumnDataCollection append + scan-back path.
+void RunRepAppend(const LogicalType &type, bool is_array, ChildRep rep) {
+	const idx_t row_count = 5;
+	const idx_t null_row = 1;
+	Allocator allocator;
+	DataChunk chunk;
+	chunk.Initialize(allocator, {type});
+	chunk.SetChildCardinality(row_count);
+	auto &source = chunk.data[0];
+	auto &child = is_array ? ArrayVector::GetChildMutable(source) : StructVector::GetEntries(source)[0];
+	FillBigintChild(child, rep, is_array ? row_count * ARRAY_SIZE : row_count);
+	FlatVector::ValidityMutable(source).SetInvalid(null_row);
+	duckdb::vector<Value> expected(row_count);
+	for (idx_t r = 0; r < row_count; r++) {
+		expected[r] = source.GetValue(r);
+	}
+
+	ColumnDataCollection collection(allocator, {type});
+	collection.Append(chunk);
+	DataChunk result;
+	ScanSingleChunk(collection, result);
+	for (idx_t r = 0; r < row_count; r++) {
+		INFO("append rep=" << RepName(rep) << " row=" << r);
+		if (r == null_row) {
+			REQUIRE(result.data[0].GetValue(r).IsNull());
+		} else {
+			REQUIRE(result.data[0].GetValue(r) == expected[r]);
+		}
+	}
+}
+
+} // namespace
+
+TEST_CASE("copy preserves NULLs across child vector representations", "[copy]") {
+	if (STANDARD_VECTOR_SIZE < 8) {
+		return;
+	}
+	auto struct_type = LogicalType::STRUCT({{"i", LogicalType::BIGINT}});
+	auto array_type = LogicalType::ARRAY(LogicalType::BIGINT, ARRAY_SIZE);
+	for (auto rep : {ChildRep::FLAT, ChildRep::CONSTANT, ChildRep::DICTIONARY, ChildRep::SEQUENCE}) {
+		for (bool reverse : {false, true}) {
+			for (idx_t source_offset : {idx_t(0), idx_t(1)}) {
+				RunRepCopy(struct_type, false, rep, reverse, source_offset);
+				RunRepCopy(array_type, true, rep, reverse, source_offset);
+			}
+		}
+		RunRepAppend(struct_type, false, rep);
+		RunRepAppend(array_type, true, rep);
+	}
+}
+
+TEST_CASE("copy preserves NULLs for UNION and VARIANT (physical STRUCT)", "[copy]") {
+	if (STANDARD_VECTOR_SIZE < 8) {
+		return;
+	}
+	const idx_t row_count = 4;
+	const idx_t null_row = 1;
+	child_list_t<LogicalType> members;
+	members.emplace_back("name", LogicalType::VARCHAR);
+	members.emplace_back("age", LogicalType::SMALLINT);
+
+	duckdb::vector<std::pair<LogicalType, duckdb::vector<Value>>> cases;
+	{
+		duckdb::vector<Value> vals;
+		for (idx_t r = 0; r < row_count; r++) {
+			vals.push_back(Value::UNION(members, 0, Value(LeafString(r, 0))));
+		}
+		cases.emplace_back(LogicalType::UNION(members), std::move(vals));
+	}
+	{
+		auto variant_type = LogicalType::VARIANT();
+		duckdb::vector<Value> vals;
+		for (idx_t r = 0; r < row_count; r++) {
+			vals.push_back(Value(LeafString(r, 0)).DefaultCastAs(variant_type));
+		}
+		cases.emplace_back(variant_type, std::move(vals));
+	}
+
+	for (auto &test_case : cases) {
+		auto &type = test_case.first;
+		auto &vals = test_case.second;
+		// valid values, then raw-NULL the parent while its (physical STRUCT) children stay valid -> unreflected
+		Vector source(type);
+		for (idx_t r = 0; r < row_count; r++) {
+			source.SetValue(r, vals[r]);
+		}
+		FlatVector::SetSize(source, row_count);
+		FlatVector::ValidityMutable(source).SetInvalid(null_row);
+
+		SelectionVector rev(row_count);
+		for (idx_t r = 0; r < row_count; r++) {
+			rev.set_index(r, row_count - r - 1);
+		}
+		Vector target(type);
+		target.Copy(source, rev, row_count, 0, 0, row_count);
+		FlatVector::SetSize(target, row_count);
+
+		VerifyVectorsGuard guard;
+		target.Verify();
+		for (idx_t r = 0; r < row_count; r++) {
+			auto src = rev.get_index(r);
+			INFO("type=" << type.ToString() << " row=" << r);
+			if (src == null_row) {
+				REQUIRE(target.GetValue(r).IsNull());
+			} else {
+				REQUIRE(target.GetValue(r) == vals[src]);
+			}
+		}
+	}
+}
 
 TEST_CASE("Verify rejects non-NULL children under a NULL ARRAY row", "[copy]") {
 #ifdef DUCKDB_CRASH_ON_ASSERT
@@ -482,7 +679,7 @@ TEST_CASE("Verify rejects non-NULL children under a NULL ARRAY row", "[copy]") {
 		FlatVector::SetSize(v, row_count);
 		auto &mid_child = ArrayVector::GetChildMutable(v);
 		auto &inner_child = ArrayVector::GetChildMutable(mid_child);
-		// outer row NULL; middle and inner slots beneath it correctly NULL (reflected), but the deepest
+		// outer row NULL. Middle and inner slots beneath it correctly NULL (reflected), but the deepest
 		// VARCHAR left valid -> the only violation is two levels down, reachable only via the recursion
 		FlatVector::ValidityMutable(v).SetInvalid(null_row);
 		for (idx_t e = 0; e < ARRAY_SIZE; e++) {

--- a/test/common/test_nested_copy_null_child.cpp
+++ b/test/common/test_nested_copy_null_child.cpp
@@ -275,6 +275,10 @@ void RunAppendCase(Shape shape, const duckdb::vector<bool> &is_null) {
 }
 
 void RunCorpus(Shape shape) {
+	if (STANDARD_VECTOR_SIZE < 8) {
+		// the fixtures exceed the default vector capacity at tiny vector sizes
+		return;
+	}
 	duckdb::vector<duckdb::vector<bool>> patterns = {
 	    {true, false, false, false, false}, // start
 	    {false, false, true, false, false}, // middle

--- a/test/common/test_nested_copy_null_child.cpp
+++ b/test/common/test_nested_copy_null_child.cpp
@@ -437,6 +437,31 @@ TEST_CASE("Verify rejects non-NULL children under a NULL ARRAY row", "[copy]") {
 		// the struct's own full-size NULL scan catches it even though the array sel excludes NULL rows
 		REQUIRE(message.find("Struct NULL mismatch") != string::npos);
 	}
+
+	SECTION("grandchild under a correctly-NULL array is caught by recursion (sliced path)") {
+		auto inner_type = LogicalType::ARRAY(LogicalType::VARCHAR, ARRAY_SIZE);
+		Vector v(LogicalType::ARRAY(inner_type, ARRAY_SIZE));
+		for (idx_t r = 0; r < row_count; r++) {
+			duckdb::vector<Value> inner_arrays;
+			for (idx_t e = 0; e < ARRAY_SIZE; e++) {
+				duckdb::vector<Value> leaves(ARRAY_SIZE, Value("ok"));
+				inner_arrays.push_back(Value::ARRAY(LogicalType::VARCHAR, leaves));
+			}
+			v.SetValue(r, Value::ARRAY(inner_type, inner_arrays));
+		}
+		FlatVector::SetSize(v, row_count);
+		auto &inner_child = ArrayVector::GetChildMutable(v);
+		FlatVector::ValidityMutable(v).SetInvalid(null_row);
+		for (idx_t e = 0; e < ARRAY_SIZE; e++) {
+			FlatVector::ValidityMutable(inner_child).SetInvalid(null_row * ARRAY_SIZE + e);
+		}
+		SelectionVector sel(row_count);
+		for (idx_t i = 0; i < row_count; i++) {
+			sel.set_index(i, i);
+		}
+		VerifyVectorsGuard guard;
+		REQUIRE_THROWS(v.Verify(sel, row_count));
+	}
 }
 
 namespace {
@@ -605,5 +630,29 @@ TEST_CASE("ColumnDataCollection append must not read child payloads under NULL r
 		REQUIRE(result.data[0].GetValue(0) == shared);
 		REQUIRE(result.data[0].GetValue(1).IsNull());
 		REQUIRE(!FlatVector::Validity(StructVector::GetEntries(result.data[0])[0]).RowIsValid(1));
+	}
+
+	SECTION("patching a STRUCT(LIST) child does not change an aliased column") {
+		auto list_type = LogicalType::LIST(LogicalType::VARCHAR);
+		auto struct_type = LogicalType::STRUCT({{"l", list_type}});
+		const idx_t row_count = 2;
+		DataChunk chunk;
+		chunk.Initialize(allocator, {struct_type, list_type});
+		chunk.SetChildCardinality(row_count);
+		auto first = LeafList(0, 1);
+		auto second = LeafList(1, 1);
+		chunk.data[1].SetValue(0, first);
+		chunk.data[1].SetValue(1, second);
+		StructVector::GetEntries(chunk.data[0])[0].Reference(chunk.data[1]);
+		FlatVector::ValidityMutable(chunk.data[0]).SetInvalid(1);
+
+		ColumnDataCollection collection(allocator, {struct_type, list_type});
+		collection.Append(chunk);
+
+		DataChunk result;
+		ScanSingleChunk(collection, result);
+		REQUIRE(result.data[0].GetValue(1).IsNull());
+		REQUIRE(result.data[1].GetValue(0) == first);
+		REQUIRE(result.data[1].GetValue(1) == second);
 	}
 }


### PR DESCRIPTION
This PR:
- Broadcasts NULL rows into children in `ColumnDataCopyStruct` the same way that `ColumnDataCopyArray` does.
- Also ensures that `VectorBuffer::Copy` won't read undefined children of `NULL` ARRAY/STRUCT rows. This already works for other vector types (string and list vectors).
- Fixes the `FIXME: verify NULL-ness in child` in `VectorArrayBuffer::VerifyInternal`