### PR TITLE
SQLLogic Tester: Add support for `init_sqllogic` / `cleanup_sqllogic` which allows for running sqllogictest statements before and after a test in test configs

### DIFF
--- a/test/helpers/test_config.cpp
+++ b/test/helpers/test_config.cpp
@@ -44,6 +44,12 @@ static const TestConfigOption test_config_options[] = {
     {"debug_initialize", "Initialize buffers with all 0 or all 1", LogicalType::VARCHAR, nullptr},
     {"autoloading", "Loading strategy for extensions not bundled in", LogicalType::VARCHAR, nullptr},
     {"init_script", "Script to execute on init", LogicalType::VARCHAR, TestConfiguration::ParseConnectScript},
+    {"init_sqllogic",
+     "Path to a sqllogic script run (through the full test runner) after the database is "
+     "created, before the test body",
+     LogicalType::VARCHAR, nullptr},
+    {"cleanup_sqllogic", "Path to a sqllogic script run (through the full test runner) after the test body",
+     LogicalType::VARCHAR, nullptr},
     {"on_cleanup", "SQL statements to execute on test end", LogicalType::VARCHAR, nullptr},
     {"on_init", "SQL statements to execute on init", LogicalType::VARCHAR, nullptr},
     {"on_load", "SQL statements to execute on explicit load", LogicalType::VARCHAR, nullptr},
@@ -310,6 +316,14 @@ bool TestConfiguration::ShouldSkipTest(const string &test_name) {
 
 string TestConfiguration::OnInitCommand() {
 	return GetOptionOrDefault("on_init", string());
+}
+
+string TestConfiguration::GetInitSqllogic() {
+	return GetOptionOrDefault("init_sqllogic", string());
+}
+
+string TestConfiguration::GetCleanupSqllogic() {
+	return GetOptionOrDefault("cleanup_sqllogic", string());
 }
 
 string TestConfiguration::OnLoadCommand() {

--- a/test/include/test_config.hpp
+++ b/test/include/test_config.hpp
@@ -79,6 +79,8 @@ public:
 	string OnLoadCommand();
 	string OnConnectionCommand();
 	string OnCleanupCommand();
+	string GetInitSqllogic();
+	string GetCleanupSqllogic();
 	SortStyle GetDefaultSortStyle();
 	vector<string> ExtensionToBeLoadedOnLoad();
 	vector<string> ErrorMessagesToBeSkipped();

--- a/test/sqlite/sqllogic_test_runner.cpp
+++ b/test/sqlite/sqllogic_test_runner.cpp
@@ -786,11 +786,6 @@ void SQLLogicTestRunner::ExecuteInternal(SQLLogicParser &parser, const string &s
 		return;
 	}
 
-	idx_t skip_level = 0;
-	bool test_expr_executed = false;
-	bool file_tags_expr_seen = false;
-	vector<string> file_tags; // gets both implicit and file-spec'd
-
 	// for the original SQLite tests we convert floating point numbers to integers
 	// for our own tests this is undesirable since it hides certain errors
 	if (script.find("test/sqlite/select") != string::npos) {
@@ -816,6 +811,34 @@ void SQLLogicTestRunner::ExecuteInternal(SQLLogicParser &parser, const string &s
 
 	// initialize the database with the default dbpath
 	LoadDatabase(dbpath, true);
+
+	auto init_sqllogic = test_config.GetInitSqllogic();
+	if (!init_sqllogic.empty()) {
+		SQLLogicParser init_parser;
+		if (!init_parser.OpenFile(init_sqllogic)) {
+			FAIL("Could not find init_sqllogic '" + init_sqllogic + "'");
+		}
+		ExecuteScript(init_parser, script);
+	}
+
+	ExecuteScript(parser, script);
+
+	auto cleanup_sqllogic = test_config.GetCleanupSqllogic();
+	if (!cleanup_sqllogic.empty()) {
+		SQLLogicParser cleanup_parser;
+		if (!cleanup_parser.OpenFile(cleanup_sqllogic)) {
+			FAIL("Could not find cleanup_sqllogic '" + cleanup_sqllogic + "'");
+		}
+		ExecuteScript(cleanup_parser, script);
+	}
+}
+
+void SQLLogicTestRunner::ExecuteScript(SQLLogicParser &parser, const string &script) {
+	auto &test_config = TestConfiguration::Get();
+	idx_t skip_level = 0;
+	bool test_expr_executed = false;
+	bool file_tags_expr_seen = false;
+	vector<string> file_tags; // gets both implicit and file-spec'd
 
 	if (StringUtil::EndsWith(script, ".test_slow")) {
 		file_tags.emplace_back("slow");

--- a/test/sqlite/sqllogic_test_runner.hpp
+++ b/test/sqlite/sqllogic_test_runner.hpp
@@ -109,6 +109,7 @@ public:
 public:
 	void ExecuteFile(string script);
 	void ExecuteStream(std::istream &input, const string &source_name);
+	void ExecuteScript(SQLLogicParser &parser, const string &script);
 	virtual void LoadDatabase(string dbpath, bool load_extensions);
 
 	string ReplaceKeywords(string input);


### PR DESCRIPTION
Currently the test configs are limited to running SQL statements before and after tests - but sqllogic statements are more versatile (e.g. can include separate connections / databases). This PR adds support for running arbitrary sqllogic statements, e.g.:

###### my_init.test

```sql
statement ok
SET my_setting='true';
```

```json
"init_sqllogic": "my_init.test"
```