### PR TITLE
Handle infinite timestamp for parquet timestamp

### DIFF
--- a/extension/parquet/parquet_statistics.cpp
+++ b/extension/parquet/parquet_statistics.cpp
@@ -299,10 +299,10 @@ Value ParquetStatisticsUtils::ConvertValueInternal(const LogicalType &type, cons
 			auto val = Load<int64_t>(stats_data);
 			switch (schema_ele.type_info) {
 			case ParquetExtraTypeInfo::UNIT_MS:
-				timestamp_value = Timestamp::FromEpochMs(val);
+				timestamp_value = ParquetTimestampMsToTimestamp(val);
 				break;
 			case ParquetExtraTypeInfo::UNIT_NS:
-				timestamp_value = Timestamp::FromEpochNanoSeconds(val);
+				timestamp_value = ParquetTimestampNsToTimestamp(val);
 				break;
 			case ParquetExtraTypeInfo::UNIT_MICROS:
 			default:

--- a/test/sql/copy/parquet/timestamp_ms_stats.test
+++ b/test/sql/copy/parquet/timestamp_ms_stats.test
@@ -20,3 +20,26 @@ select timestamp from '{DATA_DIR}/parquet-testing/issue_5533_timestamp_ms_stats.
 2022-11-27 17:42:44.28
 2022-11-27 17:42:44.28
 
+statement ok
+CREATE TABLE timestamp_ms_infinity(ts TIMESTAMP_MS)
+
+statement ok
+INSERT INTO timestamp_ms_infinity VALUES ('-infinity'), ('infinity')
+
+statement ok
+COPY timestamp_ms_infinity TO '{TEST_DIR}/timestamp_ms_infinity.parquet' (FORMAT parquet)
+
+query II
+SELECT ts::VARCHAR, isinf(ts)
+FROM read_parquet('{TEST_DIR}/timestamp_ms_infinity.parquet')
+ORDER BY ts
+----
+-infinity	true
+infinity	true
+
+query I
+SELECT count(*)
+FROM read_parquet('{TEST_DIR}/timestamp_ms_infinity.parquet')
+WHERE ts IN ('-infinity'::TIMESTAMP_MS, 'infinity'::TIMESTAMP_MS)
+----
+2


### PR DESCRIPTION
Closes https://github.com/duckdb/duckdb/issues/23821

The root cause is, current implementation [doesn't handle inf](https://github.com/duckdb/duckdb/blob/da3d58bbb1628e6e703106f2a0eb6d3910437951/src/common/types/timestamp.cpp#L490), which is properly checked in [`ParquetTimestampMsToTimestamp`](https://github.com/duckdb/duckdb/blob/da3d58bbb1628e6e703106f2a0eb6d3910437951/extension/parquet/parquet_timestamp.cpp#L67-L69)