### PR TITLE
Fix Parquet bloom filter pruning for blobs

### DIFF
--- a/extension/parquet/parquet_statistics.cpp
+++ b/extension/parquet/parquet_statistics.cpp
@@ -22,6 +22,7 @@
 #include "duckdb/planner/expression/bound_comparison_expression.hpp"
 #include "duckdb/planner/expression/bound_conjunction_expression.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
+#include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "reader/uuid_column_reader.hpp"
 #include "duckdb/common/type_visitor.hpp"
 #include "column_reader.hpp"
@@ -670,18 +671,39 @@ unique_ptr<BaseStatistics> ParquetStatisticsUtils::TransformColumnStatistics(con
 	return row_group_stats;
 }
 
+static optional_ptr<const BoundConstantExpression> GetBloomFilterConstant(const Expression &expr) {
+	if (!BoundComparisonExpression::IsComparison(expr)) {
+		return nullptr;
+	}
+	auto &comp = expr.Cast<BoundFunctionExpression>();
+	if (comp.GetExpressionType() != ExpressionType::COMPARE_EQUAL) {
+		return nullptr;
+	}
+	auto &left = BoundComparisonExpression::Left(comp);
+	auto &right = BoundComparisonExpression::Right(comp);
+	optional_ptr<const Expression> column;
+	optional_ptr<const BoundConstantExpression> constant;
+	if (left.GetExpressionClass() == ExpressionClass::BOUND_REF &&
+	    right.GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
+		column = left;
+		constant = right.Cast<BoundConstantExpression>();
+	} else if (right.GetExpressionClass() == ExpressionClass::BOUND_REF &&
+	           left.GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
+		column = right;
+		constant = left.Cast<BoundConstantExpression>();
+	} else {
+		return nullptr;
+	}
+	if (column->Cast<BoundReferenceExpression>().Index() != 0 || constant->GetValue().IsNull() ||
+	    column->GetReturnType() != constant->GetValue().type()) {
+		return nullptr;
+	}
+	return constant;
+}
+
 static bool HasFilterConstants(const Expression &expr) {
 	if (BoundComparisonExpression::IsComparison(expr)) {
-		auto &comp = expr.Cast<BoundFunctionExpression>();
-		if (comp.GetExpressionType() != ExpressionType::COMPARE_EQUAL) {
-			return false;
-		}
-		auto &right = BoundComparisonExpression::Right(comp);
-		if (right.GetExpressionType() != ExpressionType::VALUE_CONSTANT) {
-			return false;
-		}
-		auto &constant = right.Cast<BoundConstantExpression>();
-		return !constant.GetValue().IsNull();
+		return GetBloomFilterConstant(expr) != nullptr;
 	}
 	if (expr.GetExpressionClass() != ExpressionClass::BOUND_CONJUNCTION) {
 		return false;
@@ -732,8 +754,8 @@ static uint64_t ValueXXH64(const Value &constant) {
 	case PhysicalType::DOUBLE:
 		return ValueXH64FixedWidth<double>(constant);
 	case PhysicalType::VARCHAR: {
-		auto val = constant.GetValue<string>();
-		return duckdb_zstd::XXH64(val.c_str(), val.length(), 0);
+		auto &val = StringValue::Get(constant);
+		return duckdb_zstd::XXH64(val.data(), val.size(), 0);
 	}
 	default:
 		return 0;
@@ -742,17 +764,11 @@ static uint64_t ValueXXH64(const Value &constant) {
 
 static bool ApplyBloomFilter(const Expression &expr, ParquetBloomFilter &bloom_filter) {
 	if (BoundComparisonExpression::IsComparison(expr)) {
-		auto &comp = expr.Cast<BoundFunctionExpression>();
-		if (comp.GetExpressionType() != ExpressionType::COMPARE_EQUAL) {
+		auto constant = GetBloomFilterConstant(expr);
+		if (!constant) {
 			return false;
 		}
-		auto &right = BoundComparisonExpression::Right(comp);
-		if (right.GetExpressionType() != ExpressionType::VALUE_CONSTANT) {
-			return false;
-		}
-		auto &constant = right.Cast<BoundConstantExpression>();
-		D_ASSERT(!constant.GetValue().IsNull());
-		auto hash = ValueXXH64(constant.GetValue());
+		auto hash = ValueXXH64(constant->GetValue());
 		return hash > 0 && !bloom_filter.FilterCheck(hash);
 	}
 	if (expr.GetExpressionClass() != ExpressionClass::BOUND_CONJUNCTION) {

--- a/test/sql/copy/parquet/bloom_filters.test
+++ b/test/sql/copy/parquet/bloom_filters.test
@@ -115,7 +115,45 @@ FROM assert_bloom_filter_hit('{TEST_DIR}/bloom1.parquet', 'r_blob', 'blob_200'::
 ----
 true
 
+# BLOB bloom filters must hash the raw bytes rather than the escaped display string
+statement ok
+COPY (SELECT from_hex('FF')::BLOB AS b FROM range(10))
+TO '{TEST_DIR}/bloom_blob.parquet' (FORMAT PARQUET, WRITE_BLOOM_FILTER TRUE, DICTIONARY_SIZE_LIMIT 1000);
 
+query I
+SELECT bool_and(b = from_hex('FF')::BLOB) FROM '{TEST_DIR}/bloom_blob.parquet';
+----
+true
+
+query I
+SELECT count(*) FROM '{TEST_DIR}/bloom_blob.parquet' WHERE b = from_hex('FF')::BLOB;
+----
+10
+
+query I
+SELECT bloom_filter_excludes
+FROM parquet_bloom_probe('{TEST_DIR}/bloom_blob.parquet', 'b', from_hex('FF')::BLOB);
+----
+false
+
+query I
+SELECT bloom_filter_excludes
+FROM parquet_bloom_probe('{TEST_DIR}/bloom_blob.parquet', 'b', from_hex('FE')::BLOB);
+----
+true
+
+# Computed expressions do not operate in the raw column's bloom filter domain
+query I
+SELECT count(*) FROM '{TEST_DIR}/bloom_blob.parquet' WHERE to_hex(b) = 'FF';
+----
+10
+
+query I
+SELECT count(*)
+FROM '{TEST_DIR}/bloom_blob.parquet' lhs
+JOIN '{TEST_DIR}/bloom_blob.parquet' rhs ON lhs.b = rhs.b;
+----
+100
 
 # some tests for dictionary_size_limit
 


### PR DESCRIPTION
Parquet bloom-filter pruning hashed `BLOB` constants using their escaped display representation (for example, `\xFF`) instead of their raw bytes. This could incorrectly exclude row groups containing matching values, affecting equality filters and join-filter pushdown. The Parquet encoding itself was not the cause. The fix hashes the raw `BLOB` payload and restricts bloom-filter pruning to direct column-to-constant equality predicates. Computed expressions such as `to_hex(blob) = ...` no longer probe the raw column's bloom filter.

fix: https://github.com/duckdb/duckdb/issues/23053
fix: https://github.com/duckdblabs/duckdb-internal/issues/9747