### PR TITLE
Add guard to prevent exception in `test_vector_types`

### DIFF
--- a/src/function/table/system/test_vector_types.cpp
+++ b/src/function/table/system/test_vector_types.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/function/table/system_functions.hpp"
 #include "duckdb/common/map.hpp"
 #include "duckdb/common/pair.hpp"
+#include "duckdb/common/type_visitor.hpp"
 #include "duckdb/main/client_context.hpp"
 
 namespace duckdb {
@@ -270,6 +271,10 @@ static unique_ptr<FunctionData> TestVectorTypesBind(ClientContext &context, Tabl
 			name += to_string(i + 1);
 		}
 		auto &input_val = input.inputs[i];
+		if (TypeVisitor::Contains(input_val.type(), LogicalTypeId::VARIANT)) {
+			throw NotImplementedException("Unimplemented type \"%s\" for test_vector_types");
+		}
+
 		names.emplace_back(name);
 		return_types.push_back(input_val.type());
 		result->types.push_back(input_val.type());

--- a/src/function/table/system/test_vector_types.cpp
+++ b/src/function/table/system/test_vector_types.cpp
@@ -272,7 +272,7 @@ static unique_ptr<FunctionData> TestVectorTypesBind(ClientContext &context, Tabl
 		}
 		auto &input_val = input.inputs[i];
 		if (TypeVisitor::Contains(input_val.type(), LogicalTypeId::VARIANT)) {
-			throw NotImplementedException("Unimplemented type \"%s\" for test_vector_types");
+			throw NotImplementedException("Unimplemented type for test_vector_types");
 		}
 
 		names.emplace_back(name);

--- a/test/sql/vector_types/vector_types_errors.test
+++ b/test/sql/vector_types/vector_types_errors.test
@@ -1,0 +1,13 @@
+# name: test/sql/vector_types/vector_types_error.test
+# description: Test unsupported inputs for test_vector_types
+# group: [vector_types]
+
+statement error
+FROM test_vector_types(NULL::VARIANT);
+----
+Unimplemented type for test_vector_types
+
+statement error
+FROM test_vector_types({a: 1, b: 2}::VARIANT);
+----
+Unimplemented type for test_vector_types

--- a/test/sql/vector_types/vector_types_errors.test
+++ b/test/sql/vector_types/vector_types_errors.test
@@ -1,4 +1,4 @@
-# name: test/sql/vector_types/vector_types_error.test
+# name: test/sql/vector_types/vector_types_errors.test
 # description: Test unsupported inputs for test_vector_types
 # group: [vector_types]
 


### PR DESCRIPTION
Resolves https://github.com/duckdblabs/duckdb-internal/issues/9748.

Adds a guard to prevent the usage of the `VARIANT` type. Previously the function would interpret the incoming `VARIANT` as a `STRUCT` type, which is semantically incorrect and leads to assertion failures in the debug build.