### PR TITLE
Implement TIMESTAMP_NS -> TIMESTAMPTZ_NS

### DIFF
--- a/extension/icu/icu-timezone.cpp
+++ b/extension/icu/icu-timezone.cpp
@@ -218,6 +218,7 @@ struct ICUFromNaiveTimestamp : public ICUDateFunc {
 		AddCast(casts, LogicalType::TIMESTAMP, LogicalType::TIMESTAMP_TZ);
 		AddCast(casts, LogicalType::TIMESTAMP_MS, LogicalType::TIMESTAMP_TZ);
 		AddCast(casts, LogicalType::TIMESTAMP_NS, LogicalType::TIMESTAMP_TZ);
+		AddCast(casts, LogicalType::TIMESTAMP_NS, LogicalType::TIMESTAMP_TZ_NS);
 		AddCast(casts, LogicalType::TIMESTAMP_S, LogicalType::TIMESTAMP_TZ);
 		AddCast(casts, LogicalType::DATE, LogicalType::TIMESTAMP_TZ);
 	}

--- a/test/sql/timezone/test_icu_casts.test
+++ b/test/sql/timezone/test_icu_casts.test
@@ -15,6 +15,10 @@ statement ok
 CREATE TABLE tstzs AS 
 	FROM VALUES ('2026-04-09 11:48:07.123456-07'::TIMESTAMPTZ) tbl(t);
 
+statement ok
+CREATE TABLE tsns AS
+	FROM VALUES ('2021-01-01 00:00:00.000000123'::TIMESTAMP_NS) tbl(t);
+
 query I
 select t::TIMESTAMP_NS from tstzs;
 ----
@@ -24,6 +28,11 @@ query I
 SELECT TIMESTAMPTZ_NS '2021-01-01 00:00:00.000000123+00'::TIMESTAMP_NS;
 ----
 2020-12-31 16:00:00.000000123
+
+query I
+select t::TIMESTAMPTZ_NS from tsns;
+----
+2021-01-01 00:00:00.000000123-08
 
 query I
 select t::TIMESTAMP from tstzs;


### PR DESCRIPTION
Currently it's not implemented.
```sql
memory D SELECT t::TIMESTAMPTZ_NS
         FROM (VALUES (TIMESTAMP_NS '2021-01-01 00:00:00.000000123')) tbl(t);
Conversion Error:
Unimplemented type for cast (TIMESTAMP_NS -> TIMESTAMPTZ_NS) when casting from source column t

LINE 1: SELECT t::TIMESTAMPTZ_NS
                ^
```