### PR TITLE
Fix epoch_ns for infinity timestamp

### DIFF
--- a/extension/core_functions/scalar/date/date_part.cpp
+++ b/extension/core_functions/scalar/date/date_part.cpp
@@ -2236,19 +2236,6 @@ ScalarFunctionSet EpochFun::GetFunctions() {
 	return set;
 }
 
-struct GetEpochNanosOperator {
-	static int64_t Operation(timestamp_ns_t timestamp) {
-		return Timestamp::GetEpochNanoSeconds(timestamp);
-	}
-};
-
-static void ExecuteGetNanosFromTimestampNs(DataChunk &input, ExpressionState &state, Vector &result) {
-	D_ASSERT(input.ColumnCount() == 1);
-
-	auto func = GetEpochNanosOperator::Operation;
-	UnaryExecutor::Execute<timestamp_ns_t, int64_t>(input.data[0], result, func);
-}
-
 ScalarFunctionSet EpochNsFun::GetFunctions() {
 	using OP = DatePart::EpochNanosecondsOperator;
 	auto operator_set = GetTimePartFunction<OP>();
@@ -2258,10 +2245,11 @@ ScalarFunctionSet EpochNsFun::GetFunctions() {
 	auto tstz_stats = OP::template PropagateStatistics<timestamp_t>;
 	operator_set.AddFunction(
 	    ScalarFunction({LogicalType::TIMESTAMP_TZ}, LogicalType::BIGINT, tstz_func, nullptr, tstz_stats));
+	auto tsns_func = DatePart::UnaryFunction<timestamp_ns_t, int64_t, OP>;
 	operator_set.AddFunction(
-	    ScalarFunction({LogicalType::TIMESTAMP_NS}, LogicalType::BIGINT, ExecuteGetNanosFromTimestampNs));
+	    ScalarFunction({LogicalType::TIMESTAMP_NS}, LogicalType::BIGINT, tsns_func));
 	operator_set.AddFunction(
-	    ScalarFunction({LogicalType::TIMESTAMP_TZ_NS}, LogicalType::BIGINT, ExecuteGetNanosFromTimestampNs));
+	    ScalarFunction({LogicalType::TIMESTAMP_TZ_NS}, LogicalType::BIGINT, tsns_func));
 	operator_set.SetUnaryArgProperties(ArgProperties().NonDecreasing());
 	return operator_set;
 }

--- a/extension/core_functions/scalar/date/date_part.cpp
+++ b/extension/core_functions/scalar/date/date_part.cpp
@@ -2246,10 +2246,8 @@ ScalarFunctionSet EpochNsFun::GetFunctions() {
 	operator_set.AddFunction(
 	    ScalarFunction({LogicalType::TIMESTAMP_TZ}, LogicalType::BIGINT, tstz_func, nullptr, tstz_stats));
 	auto tsns_func = DatePart::UnaryFunction<timestamp_ns_t, int64_t, OP>;
-	operator_set.AddFunction(
-	    ScalarFunction({LogicalType::TIMESTAMP_NS}, LogicalType::BIGINT, tsns_func));
-	operator_set.AddFunction(
-	    ScalarFunction({LogicalType::TIMESTAMP_TZ_NS}, LogicalType::BIGINT, tsns_func));
+	operator_set.AddFunction(ScalarFunction({LogicalType::TIMESTAMP_NS}, LogicalType::BIGINT, tsns_func));
+	operator_set.AddFunction(ScalarFunction({LogicalType::TIMESTAMP_TZ_NS}, LogicalType::BIGINT, tsns_func));
 	operator_set.SetUnaryArgProperties(ArgProperties().NonDecreasing());
 	return operator_set;
 }

--- a/test/sql/function/timestamp/test_date_part.test
+++ b/test/sql/function/timestamp/test_date_part.test
@@ -954,3 +954,16 @@ query I
 select epoch_ns(make_timestamp_ns(1732118940123456789))
 ----
 1732118940123456789
+
+foreach type TIMESTAMP_NS TIMESTAMPTZ_NS
+
+foreach value infinity -infinity
+
+query I
+select epoch_ns('{value}'::{type})
+----
+NULL
+
+endloop
+
+endloop


### PR DESCRIPTION
Closes https://github.com/duckdb/duckdb/issues/23833

The root cause is
- In the current implementation `epochns` has [specialization](https://github.com/duckdb/duckdb/blob/5a06216cbac11414a48eda43c6e262e2f3d8aec3/extension/core_functions/scalar/date/date_part.cpp#L2239-L2250) which converts from int64_t to timestamp_ns_t, which doesn't [check whether input timestamp is finite](https://github.com/duckdb/duckdb/blob/5a06216cbac11414a48eda43c6e262e2f3d8aec3/src/common/types/timestamp.cpp#L543-L546)
- In this PR, I delete the specialization, instead I delegate to the [existing operator](https://github.com/duckdb/duckdb/blob/5a06216cbac11414a48eda43c6e262e2f3d8aec3/extension/core_functions/scalar/date/date_part.cpp#L173-L184)