### PR TITLE
Fix canonical bindings for nested common subplans

### DIFF
--- a/src/optimizer/common_subplan_optimizer.cpp
+++ b/src/optimizer/common_subplan_optimizer.cpp
@@ -906,8 +906,11 @@ public:
 					new_bindings = cte_refs.back()->GetColumnBindings();
 				}
 				D_ASSERT(old_bindings[subplan_idx].size() == new_bindings.size());
+				D_ASSERT(subplan.canonical_bindings.size() == new_bindings.size());
 				for (idx_t i = 0; i < old_bindings[subplan_idx].size(); i++) {
 					replacer.replacement_bindings.emplace_back(old_bindings[subplan_idx][i], new_bindings[i]);
+					const auto inserted = generated_binding_map.emplace(new_bindings[i], subplan.canonical_bindings[i]);
+					D_ASSERT(inserted.second);
 				}
 			}
 
@@ -1056,6 +1059,11 @@ private:
 		const auto &table_index_map = state.table_index_map.GetMap();
 		arena_vector<ColumnBinding> canonical_bindings(state.allocator);
 		for (auto &cb : original_bindings) {
+			auto generated_entry = generated_binding_map.find(cb);
+			if (generated_entry != generated_binding_map.end()) {
+				canonical_bindings.push_back(generated_entry->second);
+				continue;
+			}
 			const auto canonical_table_index = to_canonical_table_index.at(cb.table_index);
 			auto &table_map = table_index_map.at(cb.table_index);
 			if (table_map.Empty<ConversionType::TO_CANONICAL>()) {
@@ -1161,6 +1169,8 @@ private:
 	subplan_map_t subplans;
 	//! Mapping from original table index to canonical table index
 	unordered_map<TableIndex, TableIndex> to_canonical_table_index;
+	//! Mapping from generated CTE bindings to canonical bindings
+	column_binding_map_t<ColumnBinding> generated_binding_map;
 	//! Minimum CTE index created by this optimizer
 	TableIndex min_cte_idx;
 };

--- a/test/optimizer/common_subplan_nested_cte.test
+++ b/test/optimizer/common_subplan_nested_cte.test
@@ -1,0 +1,73 @@
+# name: test/optimizer/common_subplan_nested_cte.test
+# description: Test canonical bindings after nested common subplan extraction
+# group: [optimizer]
+
+statement ok
+CREATE TABLE tag(id INTEGER, name VARCHAR);
+
+statement ok
+CREATE TABLE person_interest(person_id BIGINT, tag_id INTEGER);
+
+statement ok
+CREATE TABLE person_knows(person1_id BIGINT, person2_id BIGINT);
+
+statement ok
+INSERT INTO tag VALUES (1, 'Frank_Sinatra');
+
+statement ok
+INSERT INTO person_interest VALUES (1, 1), (2, 1);
+
+statement ok
+INSERT INTO person_knows VALUES (1, 10), (2, 10);
+
+# Extracting a nested common subplan creates new CTE reader bindings. A later
+# common subplan must retain the canonical identities of those generated bindings.
+query III
+WITH RECURSIVE
+interest_source AS (
+    SELECT * FROM person_interest
+),
+tag_source AS (
+    SELECT * FROM tag
+),
+knows_source AS (
+    SELECT * FROM person_knows
+),
+knows AS (
+    SELECT person1_id, person2_id
+    FROM knows_source
+    UNION ALL
+    SELECT person2_id, person1_id
+    FROM knows_source
+),
+interested_people AS (
+    SELECT interest.person_id
+    FROM interest_source interest
+    JOIN tag_source tag ON tag.id = interest.tag_id
+    WHERE tag.name = 'Frank_Sinatra'
+),
+friends_of_interested AS (
+    SELECT knows.person1_id AS interested_id,
+           knows.person2_id AS friend_id
+    FROM interested_people interested
+    JOIN knows ON interested.person_id = knows.person1_id
+)
+SELECT friend1.interested_id,
+       friend2.interested_id,
+       count(friend1.friend_id) AS mutual_friend_count
+FROM friends_of_interested friend1
+JOIN friends_of_interested friend2
+  ON friend1.friend_id = friend2.friend_id
+WHERE friend1.interested_id <> friend2.interested_id
+  AND (friend2.interested_id, friend1.interested_id) NOT IN (
+      SELECT person1_id, person2_id
+      FROM knows
+  )
+GROUP BY friend1.interested_id, friend2.interested_id
+ORDER BY mutual_friend_count DESC,
+         friend1.interested_id,
+         friend2.interested_id
+LIMIT 20;
+----
+1	2	1
+2	1	1


### PR DESCRIPTION
Nested subplan extraction creates new CTE/projection bindings after canonical table maps are built. Parent materialization later exposed these generated bindings and failed lookup.

fix: https://github.com/duckdblabs/duckdb-internal/issues/9953