### PR TITLE
`SHOW ALL` make `TABLES` optional

### DIFF
--- a/src/include/duckdb/parser/peg/inlined_grammar.gram
+++ b/src/include/duckdb/parser/peg/inlined_grammar.gram
@@ -1078,7 +1078,7 @@ DeleteUsingClause <- 'USING' List(TableRef)
 DescribeStatement <- ShowTables / ShowSelect / ShowAllTables / ShowQualifiedName
 
 ShowSelect <- ShowOrDescribeOrSummarize SelectStatementInternal
-ShowAllTables <- ShowOrDescribe 'ALL' 'TABLES'
+ShowAllTables <- ShowOrDescribe 'ALL' 'TABLES'?
 ShowQualifiedName <- ShowOrDescribeOrSummarize DescribeTarget?
 ShowTables <- ShowOrDescribe 'TABLES' 'FROM' QualifiedName
 DescribeTarget <- DescribeBaseTableName / DescribeStringLiteral

--- a/src/include/duckdb/parser/peg/inlined_grammar.hpp
+++ b/src/include/duckdb/parser/peg/inlined_grammar.hpp
@@ -998,7 +998,7 @@ const char INLINED_PEG_GRAMMAR[] = {
 	"DeleteUsingClause <- 'USING' List(TableRef)\n"
 	"DescribeStatement <- ShowTables / ShowSelect / ShowAllTables / ShowQualifiedName\n"
 	"ShowSelect <- ShowOrDescribeOrSummarize SelectStatementInternal\n"
-	"ShowAllTables <- ShowOrDescribe 'ALL' 'TABLES'\n"
+	"ShowAllTables <- ShowOrDescribe 'ALL' 'TABLES'?\n"
 	"ShowQualifiedName <- ShowOrDescribeOrSummarize DescribeTarget?\n"
 	"ShowTables <- ShowOrDescribe 'TABLES' 'FROM' QualifiedName\n"
 	"DescribeTarget <- DescribeBaseTableName / DescribeStringLiteral\n"

--- a/src/include/duckdb/parser/peg/transformer/peg_transformer.hpp
+++ b/src/include/duckdb/parser/peg/transformer/peg_transformer.hpp
@@ -5981,7 +5981,8 @@ public:
 	                                                 unique_ptr<SelectStatement> select_statement_internal);
 	static unique_ptr<TransformResultValue> TransformShowAllTablesInternal(PEGTransformer &transformer,
 	                                                                       ParseResult &parse_result);
-	static unique_ptr<QueryNode> TransformShowAllTables(PEGTransformer &transformer, const ShowType &show_or_describe);
+	static unique_ptr<QueryNode> TransformShowAllTables(PEGTransformer &transformer, const ShowType &show_or_describe,
+	                                                    const bool &has_result);
 	static unique_ptr<TransformResultValue> TransformShowQualifiedNameInternal(PEGTransformer &transformer,
 	                                                                           ParseResult &parse_result);
 	static unique_ptr<QueryNode> TransformShowQualifiedName(PEGTransformer &transformer,

--- a/src/parser/peg/grammar/statements/describe.gram
+++ b/src/parser/peg/grammar/statements/describe.gram
@@ -1,7 +1,7 @@
 DescribeStatement <- ShowTables / ShowSelect / ShowAllTables / ShowQualifiedName
 
 ShowSelect <- ShowOrDescribeOrSummarize SelectStatementInternal
-ShowAllTables <- ShowOrDescribe 'ALL' 'TABLES'
+ShowAllTables <- ShowOrDescribe 'ALL' 'TABLES'?
 ShowQualifiedName <- ShowOrDescribeOrSummarize DescribeTarget?
 ShowTables <- ShowOrDescribe 'TABLES' 'FROM' QualifiedName
 DescribeTarget <- DescribeBaseTableName / DescribeStringLiteral

--- a/src/parser/peg/transformer/transform_describe.cpp
+++ b/src/parser/peg/transformer/transform_describe.cpp
@@ -44,7 +44,8 @@ unique_ptr<QueryNode> PEGTransformerFactory::TransformShowTables(PEGTransformer 
 }
 
 unique_ptr<QueryNode> PEGTransformerFactory::TransformShowAllTables(PEGTransformer &transformer,
-                                                                    const ShowType &show_or_describe) {
+                                                                    const ShowType &show_or_describe,
+                                                                    const bool &has_result) {
 	auto result = make_uniq<ShowRef>();
 	// Legacy reasons, see bind_showref.cpp
 	result->SetTableName("__show_tables_expanded");

--- a/src/parser/peg/transformer/transform_generated.cpp
+++ b/src/parser/peg/transformer/transform_generated.cpp
@@ -3733,7 +3733,10 @@ unique_ptr<TransformResultValue> PEGTransformerFactory::TransformShowAllTablesIn
                                                                                        ParseResult &parse_result) {
 	auto &list_pr = parse_result.Cast<ListParseResult>();
 	auto show_or_describe = transformer.Transform<ShowType>(list_pr.GetChild(0));
-	auto result = TransformShowAllTables(transformer, show_or_describe);
+	bool has_result {};
+	auto &has_result_opt = list_pr.GetChild(2).Cast<OptionalParseResult>();
+	has_result = has_result_opt.HasResult();
+	auto result = TransformShowAllTables(transformer, show_or_describe, has_result);
 	return make_uniq<TypedTransformResult<unique_ptr<QueryNode>>>(std::move(result));
 }
 

--- a/src/parser/peg/transformer/transform_generated_trampoline.cpp
+++ b/src/parser/peg/transformer/transform_generated_trampoline.cpp
@@ -11156,8 +11156,12 @@ void PEGTransformerFactory::InitializeShowAllTablesTrampoline(PEGTransformer &tr
 unique_ptr<TransformResultValue> PEGTransformerFactory::FinalizeShowAllTablesTrampoline(PEGTransformer &transformer,
                                                                                         TransformStack &stack,
                                                                                         TransformStackFrame &frame) {
+	auto &list_pr = frame.parse_result.Cast<ListParseResult>();
 	auto show_or_describe = frame.TakeResult<ShowType>(0);
-	auto result = TransformShowAllTables(transformer, show_or_describe);
+	bool has_result {};
+	auto &has_result_opt = list_pr.GetChild(2).Cast<OptionalParseResult>();
+	has_result = has_result_opt.HasResult();
+	auto result = TransformShowAllTables(transformer, show_or_describe, has_result);
 	return make_uniq<TypedTransformResult<unique_ptr<QueryNode>>>(std::move(result));
 }
 

--- a/test/sql/attach/attach_show_all_tables.test
+++ b/test/sql/attach/attach_show_all_tables.test
@@ -1,5 +1,5 @@
 # name: test/sql/attach/attach_show_all_tables.test
-# description: Test various DDL statements on an attached database
+# description: Test SHOW ALL TABLES aliases on an attached database
 # group: [attach]
 
 statement ok
@@ -19,6 +19,34 @@ CREATE TABLE new_database.s1.tbl(c INTEGER);
 
 query IIIIII
 SHOW ALL TABLES
+----
+memory	main	tbl	[a]	[INTEGER]	false
+new_database	main	tbl	[b]	[INTEGER]	false
+new_database	s1	tbl	[c]	[INTEGER]	false
+
+query IIIIII
+SHOW ALL
+----
+memory	main	tbl	[a]	[INTEGER]	false
+new_database	main	tbl	[b]	[INTEGER]	false
+new_database	s1	tbl	[c]	[INTEGER]	false
+
+query IIIIII
+DESCRIBE ALL
+----
+memory	main	tbl	[a]	[INTEGER]	false
+new_database	main	tbl	[b]	[INTEGER]	false
+new_database	s1	tbl	[c]	[INTEGER]	false
+
+query IIIIII
+DESC ALL
+----
+memory	main	tbl	[a]	[INTEGER]	false
+new_database	main	tbl	[b]	[INTEGER]	false
+new_database	s1	tbl	[c]	[INTEGER]	false
+
+query IIIIII
+DESCRIBE ALL TABLES
 ----
 memory	main	tbl	[a]	[INTEGER]	false
 new_database	main	tbl	[b]	[INTEGER]	false


### PR DESCRIPTION
Part of: https://github.com/duckdblabs/duckdb-internal/issues/9093#util-03

These variations were broken, but used to work in the older parser: 

```sql
SHOW ALL;
DESCRIBE ALL;
DESC ALL;
```
This PR makes the trailing `TABLES` keyword optional 