### PR TITLE
Optimize stats writer for DICT_FSST

### DIFF
--- a/scripts/generate_enum_util.py
+++ b/scripts/generate_enum_util.py
@@ -14,6 +14,7 @@ blacklist = [
     "Type",
     "DictionaryAppendState",
     "DictFSSTMode",
+    "DictFSSTCompressResult",
     "ComplexJSONType",
     "UnavailableReason",
     "VirtualColumnBindingType",

--- a/src/include/duckdb/storage/compression/dict_fsst/compression.hpp
+++ b/src/include/duckdb/storage/compression/dict_fsst/compression.hpp
@@ -31,6 +31,8 @@ struct EncodedInput {
 	vector<string_t> data;
 };
 
+enum class DictFSSTCompressResult : uint8_t { FAILED, NEW_STRING, REPEATED_STRING };
+
 //===--------------------------------------------------------------------===//
 // Compress
 //===--------------------------------------------------------------------===//
@@ -48,8 +50,9 @@ public:
 	idx_t CalculateRequiredSpace() const;
 	DictionaryAppendState TryEncode();
 
-	bool CompressInternal(UnifiedVectorFormat &vector_format, const string_t &str, bool is_null,
-	                      EncodedInput &encoded_input, const idx_t i, idx_t count, bool fail_on_no_space);
+	DictFSSTCompressResult CompressInternal(UnifiedVectorFormat &vector_format, const string_t &str, bool is_null,
+	                                        EncodedInput &encoded_input, const idx_t i, idx_t count,
+	                                        bool fail_on_no_space);
 	void Compress(const Vector &scan_vector);
 	void FinalizeCompress();
 	void Flush(bool final);

--- a/src/storage/compression/dict_fsst/compression.cpp
+++ b/src/storage/compression/dict_fsst/compression.cpp
@@ -462,9 +462,17 @@ static inline bool AddToDictionary(DictFSSTCompressionState &state, const string
 	return true;
 }
 
-bool DictFSSTCompressionState::CompressInternal(UnifiedVectorFormat &vector_format, const string_t &str, bool is_null,
-                                                EncodedInput &encoded_input, const idx_t i, idx_t count,
-                                                bool fail_on_no_space) {
+static DictFSSTCompressResult GetCompressResult(bool success, bool new_string) {
+	if (!success) {
+		return DictFSSTCompressResult::FAILED;
+	}
+	return new_string ? DictFSSTCompressResult::NEW_STRING : DictFSSTCompressResult::REPEATED_STRING;
+}
+
+DictFSSTCompressResult DictFSSTCompressionState::CompressInternal(UnifiedVectorFormat &vector_format,
+                                                                  const string_t &str, bool is_null,
+                                                                  EncodedInput &encoded_input, const idx_t i,
+                                                                  idx_t count, bool fail_on_no_space) {
 	auto strings = UnifiedVectorFormat::GetData<string_t>(vector_format);
 	idx_t lookup = DConstants::INVALID_INDEX;
 
@@ -487,21 +495,25 @@ bool DictFSSTCompressionState::CompressInternal(UnifiedVectorFormat &vector_form
 	case DictionaryAppendState::REGULAR: {
 		if (append_state == DictionaryAppendState::REGULAR) {
 			if (lookup != DConstants::INVALID_INDEX) {
-				return AddLookup<DictionaryAppendState::REGULAR>(*this, lookup, recalculate_indices_space,
-				                                                 fail_on_no_space);
+				return GetCompressResult(AddLookup<DictionaryAppendState::REGULAR>(
+				                             *this, lookup, recalculate_indices_space, fail_on_no_space),
+				                         false);
 			} else {
-				//! This string does not exist in the dictionary, add it
-				return AddToDictionary<DictionaryAppendState::REGULAR>(*this, str, recalculate_indices_space,
-				                                                       fail_on_no_space);
+				// This string does not exist in the dictionary, add it
+				return GetCompressResult(AddToDictionary<DictionaryAppendState::REGULAR>(
+				                             *this, str, recalculate_indices_space, fail_on_no_space),
+				                         true);
 			}
 		} else {
 			if (lookup != DConstants::INVALID_INDEX) {
-				return AddLookup<DictionaryAppendState::NOT_ENCODED>(*this, lookup, recalculate_indices_space,
-				                                                     fail_on_no_space);
+				return GetCompressResult(AddLookup<DictionaryAppendState::NOT_ENCODED>(
+				                             *this, lookup, recalculate_indices_space, fail_on_no_space),
+				                         false);
 			} else {
-				//! This string does not exist in the dictionary, add it
-				return AddToDictionary<DictionaryAppendState::NOT_ENCODED>(*this, str, recalculate_indices_space,
-				                                                           fail_on_no_space);
+				// This string does not exist in the dictionary, add it
+				return GetCompressResult(AddToDictionary<DictionaryAppendState::NOT_ENCODED>(
+				                             *this, str, recalculate_indices_space, fail_on_no_space),
+				                         true);
 			}
 		}
 	}
@@ -520,24 +532,26 @@ bool DictFSSTCompressionState::CompressInternal(UnifiedVectorFormat &vector_form
 			                                                       fail_on_no_space);
 		}
 		if (fits) {
-			return fits;
+			return GetCompressResult(true, lookup == DConstants::INVALID_INDEX);
 		}
 		if (dictionary_encoding_buffer.empty()) {
 			//! The string doesn't fit, there are no strings left in the encoding buffer that could potentially
 			//  reduce the space used enough to store this string.
-			return false;
+			return DictFSSTCompressResult::FAILED;
 		}
 
 		// We lazily encode the new entries, if we're full but have entries in the buffer
 		// we flush these and try again to see if the size went down enough
 		FlushEncodingBuffer();
 		if (lookup != DConstants::INVALID_INDEX) {
-			return AddLookup<DictionaryAppendState::ENCODED>(*this, lookup, recalculate_indices_space,
-			                                                 fail_on_no_space);
+			return GetCompressResult(
+			    AddLookup<DictionaryAppendState::ENCODED>(*this, lookup, recalculate_indices_space, fail_on_no_space),
+			    false);
 		} else {
 			//! Not in the dictionary, add it
-			return AddToDictionary<DictionaryAppendState::ENCODED>(*this, str, recalculate_indices_space,
-			                                                       fail_on_no_space);
+			return GetCompressResult(AddToDictionary<DictionaryAppendState::ENCODED>(
+			                             *this, str, recalculate_indices_space, fail_on_no_space),
+			                         true);
 		}
 	}
 	case DictionaryAppendState::ENCODED_ALL_UNIQUE: {
@@ -632,8 +646,9 @@ bool DictFSSTCompressionState::CompressInternal(UnifiedVectorFormat &vector_form
 
 #endif
 		auto &string = encoded_input.data[i - encoded_input.offset];
-		return AddToDictionary<DictionaryAppendState::ENCODED_ALL_UNIQUE>(*this, string, recalculate_indices_space,
-		                                                                  fail_on_no_space);
+		return GetCompressResult(AddToDictionary<DictionaryAppendState::ENCODED_ALL_UNIQUE>(
+		                             *this, string, recalculate_indices_space, fail_on_no_space),
+		                         true);
 	}
 	};
 	throw InternalException("Unreachable");
@@ -830,27 +845,35 @@ void DictFSSTCompressionState::Compress(const Vector &scan_vector) {
 		auto idx = vector_format.sel->get_index(i);
 		auto &str = strings[idx];
 		auto is_null = !vector_format.validity.RowIsValid(idx);
+		DictFSSTCompressResult compress_result;
 		do {
-			if (CompressInternal(vector_format, str, is_null, encoded_input, i, count, false)) {
+			compress_result = CompressInternal(vector_format, str, is_null, encoded_input, i, count, false);
+			if (compress_result != DictFSSTCompressResult::FAILED) {
 				break;
 			}
 
 			if (append_state == DictionaryAppendState::REGULAR) {
 				append_state = TryEncode();
 				D_ASSERT(append_state != DictionaryAppendState::REGULAR);
-				if (CompressInternal(vector_format, str, is_null, encoded_input, i, count, false)) {
+				compress_result = CompressInternal(vector_format, str, is_null, encoded_input, i, count, false);
+				if (compress_result != DictFSSTCompressResult::FAILED) {
 					break;
 				}
 			}
 			Flush(false);
 			encoded_input.data.clear();
 			encoded_input.offset = 0;
-			if (!CompressInternal(vector_format, str, is_null, encoded_input, i, count, true)) {
+			compress_result = CompressInternal(vector_format, str, is_null, encoded_input, i, count, true);
+			if (compress_result == DictFSSTCompressResult::FAILED) {
 				throw FatalException("Compressing directly after Flush doesn't fit - expected to throw earlier!");
 			}
 		} while (false);
 		if (!is_null) {
-			stats_writer.Update(str);
+			if (compress_result == DictFSSTCompressResult::REPEATED_STRING) {
+				stats_writer.UpdateRepeated(str);
+			} else {
+				stats_writer.Update(str);
+			}
 		} else {
 			stats_writer.SetHasNull();
 		}

--- a/test/configs/stats_dependent_tests.json
+++ b/test/configs/stats_dependent_tests.json
@@ -34,6 +34,7 @@
         "test/sql/storage/min_string_length_too_large.test_slow",
         "test/sql/storage/total_string_length_repeated_insert.test",
         "test/sql/storage/compression/dictionary/total_string_length_dictionary.test",
+        "test/sql/storage/compression/dict_fsst/repeated_string_stats.test",
         "test/sql/types/geo/geometry_from_wkb_stats.test",
         "test/parquet/variant/variant_stats_propagation.test",
         "test/sql/types/geo/geometry_stats.test",

--- a/test/sql/storage/compression/dict_fsst/repeated_string_stats.test
+++ b/test/sql/storage/compression/dict_fsst/repeated_string_stats.test
@@ -1,0 +1,50 @@
+# name: test/sql/storage/compression/dict_fsst/repeated_string_stats.test
+# description: Test string statistics for repeated values with DictFSST compression
+# group: [dict_fsst]
+
+require vector_size 2048
+
+load {TEST_DIR}/repeated_string_stats.db readwrite
+
+statement ok
+PRAGMA force_compression = 'dict_fsst'
+
+# Use enough distinct string data to exercise the encoded dictionary path.
+statement ok
+CREATE TABLE repeated AS
+SELECT repeat(lpad((i % 200)::VARCHAR, 3, '0'), 20) AS value
+FROM range(100000) t(i)
+
+statement ok
+CHECKPOINT
+
+query I
+SELECT compression FROM pragma_storage_info('repeated') WHERE segment_type ILIKE 'VARCHAR' LIMIT 1
+----
+DICT_FSST
+
+query III
+SELECT s.min_string_length, s.max_string_length, s.total_string_length
+FROM (SELECT stats(value) s FROM repeated LIMIT 1)
+----
+60	60	6000000
+
+# Repeated values must retain min/max, Unicode, null, and additive length statistics.
+statement ok
+CREATE TABLE repeated_unicode AS
+SELECT CASE i % 4
+	WHEN 0 THEN 'alpha'
+	WHEN 1 THEN 'βeta'
+	WHEN 2 THEN 'zebra-long'
+	ELSE NULL
+END AS value
+FROM range(10000) t(i)
+
+statement ok
+CHECKPOINT
+
+query IIIIII
+SELECT s.min_string_length, s.max_string_length, s.total_string_length, s.has_unicode, s.has_null, s.has_no_null
+FROM (SELECT stats(value) s FROM repeated_unicode LIMIT 1)
+----
+5	10	50000	true	true	true

--- a/test/sql/storage/compression/dict_fsst/repeated_string_stats.test
+++ b/test/sql/storage/compression/dict_fsst/repeated_string_stats.test
@@ -18,11 +18,6 @@ FROM range(100000) t(i)
 statement ok
 CHECKPOINT
 
-query I
-SELECT compression FROM pragma_storage_info('repeated') WHERE segment_type ILIKE 'VARCHAR' LIMIT 1
-----
-DICT_FSST
-
 query III
 SELECT s.min_string_length, s.max_string_length, s.total_string_length
 FROM (SELECT stats(value) s FROM repeated LIMIT 1)


### PR DESCRIPTION
Hi team, after DICT_FSST has been enabled by default, I reran my [data ingestion benchmark](https://github.com/dentiny/duckdb/blob/3ddab96bb164ead583611abae3ad29a74646fbd6/benchmark/micro/appender_lineitem.cpp#L105-L119) and found for DICT_FSST encoding, stats writer is the hotspot and low-hanging fruit.
<img width="1600" height="700" alt="image" src="https://github.com/user-attachments/assets/00583208-f7c7-422a-bff6-7389c8c95a04" />

The reason is, whatever a new string is encountered, we always updates the string stats, even if the string has been met before (internally we update min/max/count/etc, which burns CPU unnecessarily)

Code reference
- Update stats during compression: https://github.com/duckdb/duckdb/blob/7c0fa265df67f4d8ed5cc4f94910c5677d127afd/src/storage/compression/dict_fsst/compression.cpp#L853
- How full stats update is done (min/max/count/etc): https://github.com/duckdb/duckdb/blob/7c0fa265df67f4d8ed5cc4f94910c5677d127afd/src/storage/statistics/string_stats.cpp#L537-L539

Improvement result for the ingestion benchmark (we've roughly achieve the theoretical upper-bound 8.2%)
| Metric | Before | After | Improvement |
|---|---:|---:|---:|
| Median | 0.512190 s | 0.476024 s | 7.06% |
| Mean | 0.513514 s | 0.476549 s | 7.20% |
| P95 | 0.529562 s | 0.494184 s | 6.68% |


