### PR TITLE
Add regression test to ensure default DICT_FSST

### DIFF
--- a/test/configs/storage_compatibility.json
+++ b/test/configs/storage_compatibility.json
@@ -147,6 +147,7 @@
         "test/sql/storage/types/variant/variant_stats_merging.test_slow",
         "test/parquet/variant/variant_legacy_encoding.test",
         "test/sql/types/variant/tpch_test.test",
+        "test/sql/storage/compression/default_storage_dict_fsst.test",
         "test/sql/storage/compression/roaring/roaring_bool_array_simple.test",
         "test/sql/storage/compression/roaring/roaring_bool_array_simple_w_null.test",
         "test/sql/storage/compression/roaring/roaring_bool_bitset_simple.test",

--- a/test/sql/storage/compression/default_storage_dict_fsst.test
+++ b/test/sql/storage/compression/default_storage_dict_fsst.test
@@ -1,0 +1,29 @@
+# name: test/sql/storage/compression/default_storage_dict_fsst.test
+# description: Test that default file-backed storage uses DICT_FSST for string compression
+# group: [compression]
+
+require vector_size 2048
+
+load {TEST_DIR}/default_storage_dict_fsst.db readwrite
+
+statement ok
+CREATE TABLE t AS
+SELECT concat('foobar-', (i % 2)::VARCHAR) AS s
+FROM range(0, 2000) tbl(i);
+
+statement ok
+CHECKPOINT
+
+query I
+SELECT count(*) FROM pragma_storage_info('t')
+WHERE segment_type = 'VARCHAR'
+  AND compression = 'DICT_FSST'
+----
+1
+
+query I
+SELECT count(*) FROM pragma_storage_info('t')
+WHERE segment_type = 'VARCHAR'
+  AND compression IN ('Dictionary', 'FSST')
+----
+0


### PR DESCRIPTION
Hi team, I want to add a regression test to ensure DICT_FSST is selected by default (which we miss previously). This PR was initially included in my storage version bumpup PR (commit [here](https://github.com/duckdb/duckdb/pull/23733/changes/3b05825219ff5bb5fef6651a59341a904e4173e0)), but somehow gets lost :(