### PR TITLE
Avoid corrupting buffered indexes during shutdown checkpoint

### DIFF
--- a/src/storage/checkpoint_manager.cpp
+++ b/src/storage/checkpoint_manager.cpp
@@ -689,14 +689,22 @@ void SingleFileCheckpointWriter::WriteTable(TableCatalogEntry &table, Serializer
 	// Write the table metadata
 	serializer.WriteProperty(100, "table", &table);
 
+	auto &info = table.GetStorage().GetDataTableInfo();
 	// If there is a context available, bind indexes before serialization.
 	// This is necessary so that buffered index operations are replayed before we checkpoint, otherwise
 	// we would lose them if there was a restart after this.
 	if (context && context->transaction.HasActiveTransaction()) {
-		auto &info = table.GetStorage().GetDataTableInfo();
 		info->BindIndexes(*context);
+	} else {
+		for (auto &index : info->GetIndexes().Indexes()) {
+			if (!index.IsBound() && index.Cast<UnboundIndex>().HasBufferedReplays()) {
+				throw IOException(
+				    "Cannot checkpoint table \"%s\" without a client context because an index has buffered "
+				    "WAL operations",
+				    table.name);
+			}
+		}
 	}
-	// FIXME: If we do not have a context, however, the unbound indexes have to be serialized to disk.
 
 	// Write the table data
 	auto table_lock = table.GetStorage().GetCheckpointLock();

--- a/test/sql/index/art/storage/test_art_wal_shutdown_checkpoint.test
+++ b/test/sql/index/art/storage/test_art_wal_shutdown_checkpoint.test
@@ -1,0 +1,43 @@
+# name: test/sql/index/art/storage/test_art_wal_shutdown_checkpoint.test
+# description: avoid checkpointing buffered index replays without a client context
+# group: [storage]
+
+load {TEST_DIR}/test_art_wal_shutdown_checkpoint.db
+
+statement ok
+SET index_scan_max_count = 1;
+
+statement ok
+PRAGMA wal_autocheckpoint='1TB';
+
+statement ok
+PRAGMA disable_checkpoint_on_shutdown;
+
+statement ok
+CREATE TABLE tbl(i INTEGER);
+
+statement ok
+CREATE INDEX idx ON tbl(i);
+
+statement ok
+INSERT INTO tbl VALUES (42), (43);
+
+# Replay the WAL, leaving the index unbound with buffered inserts.
+restart
+
+# A shutdown checkpoint has no client context in which to bind the index. It must
+# preserve the WAL instead of serializing the stale index storage information.
+restart
+
+query I
+SELECT count(*) FROM tbl WHERE i = 42;
+----
+1
+
+# The query above binds the index. A subsequent shutdown checkpoint can persist it.
+restart
+
+query I
+SELECT count(*) FROM tbl WHERE i = 42;
+----
+1


### PR DESCRIPTION
## Summary

- refuse to serialize an unbound index when it still contains buffered WAL replays and the checkpoint has no active client context
- preserve the WAL instead of persisting stale index storage during a shutdown checkpoint
- add a regression test covering WAL replay followed by a context-free shutdown checkpoint and restart

## Root cause

WAL recovery intentionally buffers index operations while an index remains lazily unbound. A normal checkpoint has a client context and binds the index before serialization, which applies those buffered operations. The shutdown checkpoint path has no client context, so it previously reused the unbound index's pre-WAL storage information and persisted an ART that did not contain the recovered rows. Index scans could then silently return wrong results.

The checkpoint now fails before serializing stale index metadata. On the shutdown path that leaves the WAL available for the next recovery. Once a query binds the index, a later checkpoint can persist it normally.

Fixes #23788.

## Validation

- reproduced the original two-engine failure with DuckDB 1.4.1: indexed count was `0`
- reran the reproducer against this branch: indexed count is `1`; a later read-only open also returns `1`
- `build/reldebug2/test/unittest 'test/sql/index/art/storage/test_art_wal_shutdown_checkpoint.test'`
- `build/reldebug2/test/unittest 'test/sql/index/art/storage/test_art_wal_checkpoint_minimal.test'`
- `scripts/format.py --fix -y HEAD`

## AI disclosure

Implemented and tested with assistance from OpenAI Codex. I reviewed the issue, reproduction, code changes, and test results.
