### PR TITLE
Fix LEFT JOIN null-aware filter reordering

### DIFF
--- a/src/include/duckdb/optimizer/join_order/filter_info.hpp
+++ b/src/include/duckdb/optimizer/join_order/filter_info.hpp
@@ -39,6 +39,9 @@ public:
 	ColumnBinding left_binding;
 	ColumnBinding right_binding;
 	bool from_residual_predicate = false;
+	//! This filter originated above an outer join and references its nullable side.
+	//! It must remain a filter after that join instead of becoming another join condition.
+	bool must_remain_post_join = false;
 	//! Index of the equivalence group for INNER equality/IS NOT DISTINCT FROM join filters.
 	//! All filters transitively connected by equality (a=b, b=c -> a=c all share the same index).
 	//! Used by cardinality estimation to skip redundant transitive conditions.

--- a/src/optimizer/join_order/query_graph_manager.cpp
+++ b/src/optimizer/join_order/query_graph_manager.cpp
@@ -212,6 +212,9 @@ static bool RelationSetsEqual(JoinRelationSet &left, JoinRelationSet &right) {
 void QueryGraphManager::BindFilterEndpoints() {
 	for (auto &filter_info : filters_and_bindings) {
 		auto &filter = filter_info->filter;
+		if (filter_info->must_remain_post_join) {
+			continue;
+		}
 		// now check if it can be used as a join predicate
 		if (BoundComparisonExpression::IsComparison(*filter)) {
 			auto &comparison = filter->Cast<BoundFunctionExpression>();

--- a/src/optimizer/join_order/relation_manager.cpp
+++ b/src/optimizer/join_order/relation_manager.cpp
@@ -178,6 +178,7 @@ static void PinFilterAfterLeftJoin(FilterInfo &filter, JoinRelationSet &nullable
                                    JoinRelationSetManager &set_manager) {
 	if (RelationSetsIntersect(filter.set.get(), nullable_set)) {
 		filter.set = set_manager.Union(filter.set.get(), left_join_set);
+		filter.must_remain_post_join = true;
 	}
 	if (filter.left_set && RelationSetsIntersect(*filter.left_set, nullable_set)) {
 		filter.left_set = &set_manager.Union(*filter.left_set, left_join_set);

--- a/test/optimizer/joins/left_join_reordering/test_reordering_left_joins.test
+++ b/test/optimizer/joins/left_join_reordering/test_reordering_left_joins.test
@@ -47,6 +47,27 @@ order by all;
 2	0	NULL	NULL
 2	1	NULL	NULL
 
+# A null-aware comparison that references both sides must also remain above the LEFT join.
+# Turning it into an additional join condition would preserve rows that should be filtered out.
+statement ok
+create table lj_indistinct_l(id integer, v integer);
+
+statement ok
+insert into lj_indistinct_l values (1, NULL), (2, 2), (3, 3);
+
+statement ok
+create table lj_indistinct_r(id integer, v integer);
+
+statement ok
+insert into lj_indistinct_r values (2, 2), (3, 99), (4, NULL);
+
+query I
+select count(*)
+from lj_indistinct_l l
+left join lj_indistinct_r r on l.id = r.id
+where l.v is not distinct from r.v;
+----
+2
 
 # filters (a ⟕ (b ⨝ c))
 query III


### PR DESCRIPTION
## Summary

- keep filters that originate above a `LEFT JOIN` out of the join graph when they reference the nullable side
- preserve those predicates as post-join filters during join-order reconstruction
- add a regression test for `IS NOT DISTINCT FROM` across both sides of a `LEFT JOIN`

## Root cause

The left-join pinning logic expanded a filter's relation set so it could not be pushed below the outer join. However, endpoint rebinding could subsequently classify the same comparison as a join predicate. For a null-aware comparison referencing both sides, that changed it from a post-join filter into an additional `LEFT JOIN` condition and incorrectly preserved a non-matching row.

## Validation

- `cmake --build build/reldebug2 --target unittest -j4`
- `build/reldebug2/test/unittest 'test/optimizer/joins/left_join_reordering/*'` (454 assertions, 3 test cases)
- verified the reported query returns `2` with the optimizer enabled and its plan keeps the comparison in a `Filter` above the `LEFT` hash join

Fixes #23688.

AI-assisted: I used OpenAI Codex while investigating and implementing this change, and reviewed and tested the resulting patch.
