### PR TITLE
Defer setting cardinality set for appender

### DIFF
--- a/src/include/duckdb/common/types/data_chunk.hpp
+++ b/src/include/duckdb/common/types/data_chunk.hpp
@@ -64,13 +64,17 @@ public:
 	void CheckCardinality(idx_t count_p);
 	//! Sets the cardinality of all child vectors of this chunk
 	void SetChildCardinality(idx_t count_p);
+	//! Sets only the logical cardinality; child vector sizes must be synchronized separately.
+	void SetCardinalityUnsafe(idx_t count_p) {
+		this->count = count_p;
+	}
 	//! Deprecated: use SetChildCardinality instead.
 	//! NOTE: this only sets the chunk's cardinality, it does NOT resize the child vectors (matching the historical
 	//! behavior on main). Callers that mutate the child vectors directly (e.g. Vector::Append/SetValue) and then call
 	//! SetCardinality rely on this - forwarding to SetChildCardinality would resize/overwrite their data.
 	[[deprecated("Use CheckCardinality (preferred) or SetChildCardinality instead")]] DUCKDB_API void
 	SetCardinality(idx_t count_p) {
-		this->count = count_p;
+		SetCardinalityUnsafe(count_p);
 	}
 	//! Deprecated: use SetChildCardinality instead
 	[[deprecated("Use CheckCardinality (preferred) or SetChildCardinality instead")]] DUCKDB_API void

--- a/src/main/appender.cpp
+++ b/src/main/appender.cpp
@@ -80,7 +80,7 @@ void BaseAppender::EndRow() {
 		throw InvalidInputException("Call to EndRow before all columns have been appended to!");
 	}
 	column = 0;
-	chunk.SetChildCardinality(chunk.size() + 1);
+	chunk.SetCardinalityUnsafe(chunk.size() + 1);
 	if (ShouldFlushChunk()) {
 		FlushChunk();
 	}
@@ -395,6 +395,7 @@ void BaseAppender::FlushChunk() {
 	if (chunk.size() == 0) {
 		return;
 	}
+	chunk.SetChildCardinality(chunk.size());
 	collection->Append(chunk);
 	chunk.Reset();
 	if (ShouldFlush()) {


### PR DESCRIPTION
Disclaimer: the performance metrics baseline is after stats writer optimization at https://github.com/duckdb/duckdb/pull/23846

After apply the stats write optimization, I reran the [data ingestion benchmark](https://github.com/dentiny/duckdb/blob/3ddab96bb164ead583611abae3ad29a74646fbd6/benchmark/micro/appender_lineitem.cpp#L105-L119) and found `SetChildCardinality` takes 11% of CPU utilization.
<img width="1112" height="582" alt="image" src="https://github.com/user-attachments/assets/95078e95-3a43-469d-9c12-1d8f9289c624" />

I think the CPU is burning unnecessarily because all children vectors's cardinality is updated after one row append; in the ingestion benchmark table it has 16 columns and 1M rows, children vector cardinality is updated for at least 16M times.

In this PR, I defer the vector cardinality update
- Only update data chunk's logical cardinality on row append
- Update all children vector's cardinality when we flush

Performance improvement
| Metric | Before Cardinality Optimization | After Cardinality Optimization | Latency Reduction |
|---|---:|---:|---:|
| Median | 0.483638 s | 0.431463 s | **10.79%** |
| Mean | 0.485812 s | 0.433207 s | **10.83%** |
| P95 | 0.499798 s | 0.448550 s | **10.25%** |