### PR TITLE
Cache Vector::size

### DIFF
--- a/src/storage/compression/rle.cpp
+++ b/src/storage/compression/rle.cpp
@@ -102,7 +102,8 @@ bool RLEAnalyze(AnalyzeState &state, const Vector &input) {
 	input.ToUnifiedFormat(vdata);
 
 	auto data = UnifiedVectorFormat::GetData<T>(vdata);
-	for (idx_t i = 0; i < input.size(); i++) {
+	const auto count = input.size();
+	for (idx_t i = 0; i < count; i++) {
 		auto idx = vdata.sel->get_index(i);
 		rle_state.state.Update(data, vdata.validity, idx);
 	}


### PR DESCRIPTION
Disclaimer: the benchmark result is using https://github.com/duckdb/duckdb/pull/23850 as baseline

After applying the cardinality update optimization, I reran the [data ingestion benchmark](https://github.com/dentiny/duckdb/blob/3ddab96bb164ead583611abae3ad29a74646fbd6/benchmark/micro/appender_lineitem.cpp#L105-L119) and found surprising `Vector::size` during RLE seems to be a small hotspot

Overall, it's involved in multiple callstacks and account for ~2.8% of CPU overhead.
<img width="1486" height="141" alt="image" src="https://github.com/user-attachments/assets/f1cf6be2-933e-4e1f-979c-876880f7fc17" />
<img width="1440" height="98" alt="image" src="https://github.com/user-attachments/assets/dbb02f78-c44f-43c4-91b3-e0624b1d309f" />

I **thought** compiler should have best of the knowledge to inline certain function call, but the flamegraph under release build clearly disagree with me.

Improvement comparison before and after the change -- this time the result contain too much noise since 2.8% is not a decisive improvement, but it's a strict improvement.
| Metric | Before Size Caching | After Size Caching | Latency Reduction |
|---|---:|---:|---:|
| Median | 0.430302 s | 0.411289 s | **4.42%** |
| Mean | 0.431983 s | 0.412350 s | **4.55%** |
| P95 | 0.446789 s | 0.421596 s | **5.64%** |

| Hotspot | Before Cache | After Cache |
|---|---:|---:|
| `RLEAnalyze<int>()` | 3.11% | **0.84%** |
| `RLEAnalyze<double>()` | 1.78% | **0.59%** |
| Combined RLE analysis | 4.89% | **1.43%** |
| `DetectBestCompressionMethod()` | 16.80% | **13.55%** |
| `Vector::size()` | 2.77% inclusive | **No independent frame** |