### PR TITLE
Inline Value::IsNan

### DIFF
--- a/src/common/types/value.cpp
+++ b/src/common/types/value.cpp
@@ -556,16 +556,6 @@ bool Value::DoubleIsFinite(double value) {
 }
 
 template <>
-bool Value::IsNan(float input) {
-	return std::isnan(input);
-}
-
-template <>
-bool Value::IsNan(double input) {
-	return std::isnan(input);
-}
-
-template <>
 bool Value::IsFinite(float input) {
 	return Value::FloatIsFinite(input);
 }

--- a/src/include/duckdb/common/types/value.hpp
+++ b/src/include/duckdb/common/types/value.hpp
@@ -20,6 +20,8 @@
 #include "duckdb/common/shared_ptr.hpp"
 #include "duckdb/common/insertion_order_preserving_map.hpp"
 
+#include <cmath>
+
 namespace duckdb {
 
 class String;
@@ -662,9 +664,13 @@ template <>
 DUCKDB_API interval_t Value::GetValueUnsafe() const;
 
 template <>
-DUCKDB_API bool Value::IsNan(float input);
+inline bool Value::IsNan(float input) {
+	return std::isnan(input);
+}
 template <>
-DUCKDB_API bool Value::IsNan(double input);
+inline bool Value::IsNan(double input) {
+	return std::isnan(input);
+}
 
 template <>
 DUCKDB_API bool Value::IsFinite(float input);


### PR DESCRIPTION
Disclaimer: the perf baseline is built upon https://github.com/duckdb/duckdb/pull/23851

After applying the Vector::size inline optimization, I reran the [data ingestion benchmark](https://github.com/dentiny/duckdb/blob/3ddab96bb164ead583611abae3ad29a74646fbd6/benchmark/micro/appender_lineitem.cpp#L105-L119) and found `Value::isnan` seems to be the next bottleneck

Observed from flamegraph, `Value::isnan` seems to take 5.27% CPU usage
<img width="1444" height="85" alt="image" src="https://github.com/user-attachments/assets/38f8bb78-7e78-4a31-a8c4-b67bde18e38f" />
<img width="1425" height="93" alt="image" src="https://github.com/user-attachments/assets/9bc4a8c1-5038-4fcc-a15f-80c5721d3c94" />

This PR brings the function definition into header file and inline it, performance change after the code change
| Metric | Before Inline | After Inline | Latency Reduction |
|---|---:|---:|---:|
| Median | 0.411289 s | 0.401222 s | **2.45%** |
| Mean | 0.412350 s | 0.402643 s | **2.35%** |
| P95 | 0.421596 s | 0.415949 s | **1.34%** |