### PR TITLE
In TableDescription, resolve catalog, schema, and table names through the catalog

### DIFF
--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -1466,9 +1466,9 @@ unique_ptr<TableDescription> ClientContext::TableInfo(const Identifier &database
 		if (!table) {
 			return;
 		}
-		// Create the table description.
-		result = make_uniq<TableDescription>(QualifiedName(database_name, schema_name, table_name));
-		auto &catalog = Catalog::GetCatalog(*this, database_name);
+		// Describe the table at its resolved location, not the input identifiers.
+		auto &catalog = table->ParentCatalog();
+		result = make_uniq<TableDescription>(QualifiedName(catalog.GetName(), table->ParentSchema().name, table->name));
 		result->readonly = catalog.GetAttached().IsReadOnly();
 		for (auto &column : table->GetColumns().Logical()) {
 			result->columns.emplace_back(column.Copy());

--- a/test/api/capi/test_capi_profiling.cpp
+++ b/test/api/capi/test_capi_profiling.cpp
@@ -437,7 +437,7 @@ TEST_CASE("Test profiling with the non-query appender", "[capi]") {
 	auto query_name_c_str = duckdb_get_varchar(query_name);
 	auto query_name_str = duckdb::string(query_name_c_str);
 
-	auto query = "INSERT INTO main.test FROM __duckdb_internal_appended_data";
+	auto query = "INSERT INTO memory.main.test FROM __duckdb_internal_appended_data";
 	REQUIRE(query_name_str == query);
 
 	duckdb_destroy_value(&query_name);

--- a/test/api/test_table_info.cpp
+++ b/test/api/test_table_info.cpp
@@ -35,3 +35,22 @@ TEST_CASE("Test table info api", "[api]") {
 	info = con.TableInfo("test");
 	REQUIRE(info.get() != nullptr);
 }
+
+TEST_CASE("Test table info reports the resolved table location", "[api]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+
+	// An unqualified lookup fills in the resolved catalog and schema.
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE t(i INTEGER)"));
+	auto info = con.TableInfo("t");
+	REQUIRE(info);
+	REQUIRE(info->qualified_name.Catalog() == "memory");
+	REQUIRE(info->qualified_name.Schema() == "main");
+	REQUIRE(info->qualified_name.Name() == "t");
+
+	// The name is reported with its DDL time casing, not the lookup casing.
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE \"FooBar\"(i INTEGER)"));
+	info = con.TableInfo("foobar");
+	REQUIRE(info);
+	REQUIRE(info->qualified_name.Name() == "FooBar");
+}

--- a/test/appender/test_appender.cpp
+++ b/test/appender/test_appender.cpp
@@ -880,3 +880,73 @@ TEST_CASE("Test appender_allocator_flush_threshold", "[appender]") {
 	}
 	appender_2.Close();
 }
+
+TEST_CASE("Test appender on a temp table in a read only database", "[appender]") {
+	auto dbdir = TestCreatePath("appender_temp_readonly");
+	DeleteDatabase(dbdir);
+
+	// Create the persistent database file, then reopen it read only.
+	{
+		DuckDB db(dbdir);
+		Connection con(db);
+		REQUIRE_NO_FAIL(con.Query("CREATE TABLE persistent(i INTEGER)"));
+	}
+
+	DBConfig readonly_config;
+	readonly_config.options.access_mode = AccessMode::READ_ONLY;
+	DuckDB db(dbdir, &readonly_config);
+	Connection con(db);
+
+	REQUIRE_NO_FAIL(con.Query("CREATE TEMP TABLE t(i INTEGER)"));
+
+	// The name resolves through the (writable) temp catalog, not the read only default database.
+	auto info = con.TableInfo("t");
+	REQUIRE(info);
+	REQUIRE(info->qualified_name.Catalog() == "temp");
+	REQUIRE(info->qualified_name.Schema() == "main");
+	REQUIRE(info->qualified_name.Name() == "t");
+	REQUIRE(info->readonly == false);
+
+	Appender appender(con, "t");
+	appender.BeginRow();
+	appender.Append<int32_t>(42);
+	appender.EndRow();
+	appender.Close();
+
+	auto result = con.Query("SELECT i FROM t");
+	REQUIRE(CHECK_COLUMN(result, 0, {42}));
+}
+
+TEST_CASE("Test appender when the search path resolves into a read only database", "[appender]") {
+	auto dbdir = TestCreatePath("appender_readonly_attach.db");
+	DeleteDatabase(dbdir);
+
+	// Create a persistent database file holding the target table.
+	{
+		DuckDB db(dbdir);
+		Connection con(db);
+		REQUIRE_NO_FAIL(con.Query("CREATE TABLE tbl(i INTEGER)"));
+	}
+
+	// Default (in-memory) database is writable; the table only exists in the read only attachment.
+	DuckDB db(nullptr);
+	Connection con(db);
+	REQUIRE_NO_FAIL(con.Query("ATTACH '" + dbdir + "' AS ro_attached (READ_ONLY)"));
+	// Keep memory.main as the default catalog so the name resolves into ro_attached via the search path.
+	REQUIRE_NO_FAIL(con.Query("SET search_path='memory.main,ro_attached.main'"));
+
+	auto info = con.TableInfo("tbl");
+	REQUIRE(info);
+	REQUIRE(info->qualified_name.Catalog() == "ro_attached");
+	REQUIRE(info->readonly == true);
+
+	bool failed = false;
+	try {
+		Appender appender(con, "tbl");
+	} catch (std::exception &ex) {
+		ErrorData error(ex);
+		REQUIRE(error.Message().find("Cannot append to a readonly database") != std::string::npos);
+		failed = true;
+	}
+	REQUIRE(failed);
+}


### PR DESCRIPTION
`ClientContext::TableInfo` resolved a table through the catalog search path but then filled the returned TableDescription's `readonly` and `qualified_name` fields from the caller's input rather than from the entry it actually found. So whenever the input was unqualified and the search path landed somewhere other than the default database, the two fields described the wrong catalog. As far as I can tell this only affects the appender.