### PR TITLE
Fix file handle lifecycle for external file cache with async IO

### DIFF
--- a/extension/parquet/include/thrift_tools.hpp
+++ b/extension/parquet/include/thrift_tools.hpp
@@ -184,7 +184,7 @@ public:
 		} else if (prefetch_mode && len < PREFETCH_FALLBACK_BUFFERSIZE && len > 0) {
 			auto file_size = file_handle.GetFileSize();
 			if (location >= file_size) {
-				file_handle.GetFileHandle().Read(context, buf, len, location);
+				file_handle.GetFileHandle()->Read(context, buf, len, location);
 				location += len;
 				return len;
 			}
@@ -192,14 +192,14 @@ public:
 			auto prefetch_buffer_fallback = ra_buffer.GetReadHead(location);
 			if (!prefetch_buffer_fallback ||
 			    location - prefetch_buffer_fallback->location + len > prefetch_buffer_fallback->size) {
-				file_handle.GetFileHandle().Read(context, buf, len, location);
+				file_handle.GetFileHandle()->Read(context, buf, len, location);
 				location += len;
 				return len;
 			}
 			memcpy(buf, prefetch_buffer_fallback->buffer_ptr + location - prefetch_buffer_fallback->location, len);
 		} else {
 			// No prefetch, do a regular (non-caching) read
-			file_handle.GetFileHandle().Read(context, buf, len, location);
+			file_handle.GetFileHandle()->Read(context, buf, len, location);
 		}
 
 		location += len;

--- a/src/include/duckdb/storage/external_file_cache/caching_file_system.hpp
+++ b/src/include/duckdb/storage/external_file_cache/caching_file_system.hpp
@@ -58,8 +58,8 @@ public:
 	DUCKDB_API ~CachingFileHandle();
 
 public:
-	//! Get the underlying FileHandle
-	DUCKDB_API FileHandle &GetFileHandle();
+	//! Get shared ownership of the underlying FileHandle
+	DUCKDB_API shared_ptr<FileHandle> GetFileHandle();
 	//! Get the buffer-manager-backed Allocator.
 	DUCKDB_API Allocator &GetBufferAllocator() const;
 	//! Read [nr_bytes] bytes at the requested [location].
@@ -111,7 +111,7 @@ private:
 	//! Used to ensure file handle and cached file metadata is only initialized once.
 	annotated_mutex file_handle_mutex;
 	//! File handle for the internal filesystem.
-	unique_ptr<FileHandle> file_handle;
+	shared_ptr<FileHandle> file_handle;
 	//! Last modified time and version tag (if FileHandle is opened)
 	timestamp_t last_modified;
 	string version_tag;

--- a/src/storage/external_file_cache/caching_file_system.cpp
+++ b/src/storage/external_file_cache/caching_file_system.cpp
@@ -66,8 +66,8 @@ public:
 				lk.unlock();
 
 				try {
-					auto &file_handle = caching_file_handle.GetFileHandle();
-					const idx_t file_size = file_handle.GetFileSize();
+					auto file_handle = caching_file_handle.GetFileHandle();
+					const idx_t file_size = file_handle->GetFileSize();
 					const idx_t offset = block_idx * block_size;
 					if (offset >= file_size) {
 						lk.lock();
@@ -178,6 +178,7 @@ bool CachingFileHandle::StripForceFullDownloadIfPresent() {
 
 shared_ptr<CachingFileHandle::CachedFile> CachingFileHandle::EnsureCachedFileCurrent() {
 	bool needs_reopen = false;
+	shared_ptr<CachedFile> current_cached_file;
 	{
 		annotated_lock_guard<annotated_mutex> guard(file_handle_mutex);
 		if (cached_file && cached_file->generation == external_file_cache.GetGeneration()) {
@@ -188,12 +189,13 @@ shared_ptr<CachingFileHandle::CachedFile> CachingFileHandle::EnsureCachedFileCur
 			file_handle.reset();
 		}
 		cached_file = external_file_cache.GetOrCreateCachedFile(path.path);
+		current_cached_file = cached_file;
 	}
 
 	if (needs_reopen) {
 		GetFileHandle();
 	}
-	return cached_file;
+	return current_cached_file;
 }
 
 CachingFileHandle::CachingFileHandle(QueryContext context, CachingFileSystem &caching_file_system_p,
@@ -228,10 +230,10 @@ CachingFileHandle::CachingFileHandle(QueryContext context, CachingFileSystem &ca
 CachingFileHandle::~CachingFileHandle() {
 }
 
-FileHandle &CachingFileHandle::GetFileHandle() {
+shared_ptr<FileHandle> CachingFileHandle::GetFileHandle() {
 	annotated_lock_guard<annotated_mutex> guard(file_handle_mutex);
 	if (file_handle) {
-		return *file_handle;
+		return file_handle;
 	}
 
 	// The caching file handle can service parallel block fetch tasks against a single shared FileHandle.
@@ -259,7 +261,7 @@ FileHandle &CachingFileHandle::GetFileHandle() {
 			cached_file->on_disk_file = file_handle->OnDiskFile();
 		}
 	}
-	return *file_handle;
+	return file_handle;
 }
 
 Allocator &CachingFileHandle::GetBufferAllocator() const {
@@ -272,8 +274,11 @@ FileBufferHandleGroup CachingFileHandle::Read(const idx_t nr_bytes, const idx_t 
 	}
 
 	// Only cache when file metadata is available.
-	const bool no_validation_metadata =
-	    Validate() && version_tag.empty() && (!last_modified.IsFinite() || last_modified == timestamp_t(0));
+	bool no_validation_metadata = false;
+	if (Validate()) {
+		annotated_lock_guard<annotated_mutex> guard(file_handle_mutex);
+		no_validation_metadata = version_tag.empty() && (!last_modified.IsFinite() || last_modified == timestamp_t(0));
+	}
 
 	if (!external_file_cache.IsEnabled() || !external_file_cache.ShouldCacheFile(path.path) || no_validation_metadata) {
 		auto buf = AllocateUncachedReadBuffer(external_file_cache.GetBufferManager(), nr_bytes);
@@ -327,9 +332,16 @@ FileBufferHandleGroup CachingFileHandle::Read(const idx_t nr_bytes, const idx_t 
 
 	// After all tasks complete, check if the cache was invalidated by another thread.
 	if (Validate()) {
+		string current_version_tag;
+		timestamp_t current_last_modified;
+		{
+			const annotated_lock_guard<annotated_mutex> file_handle_guard(file_handle_mutex);
+			current_version_tag = version_tag;
+			current_last_modified = last_modified;
+		}
 		const annotated_lock_guard<annotated_mutex> meta_guard(current_cached_file->meta_lock);
 		if (!ExternalFileCache::IsValid(true, current_cached_file->version_tag, current_cached_file->last_modified,
-		                                version_tag, last_modified)) {
+		                                current_version_tag, current_last_modified)) {
 			for (auto &block : blocks) {
 				block->Reinit();
 			}
@@ -342,7 +354,8 @@ FileBufferHandleGroup CachingFileHandle::Read(const idx_t nr_bytes, const idx_t 
 FileBufferHandleGroup CachingFileHandle::Read(idx_t &nr_bytes) {
 	if (!external_file_cache.IsEnabled() || !CanSeek()) {
 		auto buf = AllocateUncachedReadBuffer(external_file_cache.GetBufferManager(), nr_bytes);
-		nr_bytes = NumericCast<idx_t>(GetFileHandle().Read(context, buf.GetDataMutable(), nr_bytes));
+		auto file_handle = GetFileHandle();
+		nr_bytes = NumericCast<idx_t>(file_handle->Read(context, buf.GetDataMutable(), nr_bytes));
 		vector<FileBufferHandleGroup::MemoryHandle> mem_handles;
 		mem_handles.push_back({std::move(buf), 0, nr_bytes});
 		position += nr_bytes;
@@ -371,7 +384,7 @@ idx_t CachingFileHandle::GetFileSize() {
 		annotated_lock_guard<annotated_mutex> guard(current_cached_file->meta_lock);
 		return current_cached_file->file_size;
 	}
-	return GetFileHandle().GetFileSize();
+	return GetFileHandle()->GetFileSize();
 }
 
 timestamp_t CachingFileHandle::GetLastModifiedTime() {
@@ -380,7 +393,8 @@ timestamp_t CachingFileHandle::GetLastModifiedTime() {
 		annotated_lock_guard<annotated_mutex> guard(current_cached_file->meta_lock);
 		return current_cached_file->last_modified;
 	}
-	GetFileHandle();
+	auto file_handle = GetFileHandle();
+	annotated_lock_guard<annotated_mutex> guard(file_handle_mutex);
 	return last_modified;
 }
 
@@ -390,7 +404,8 @@ string CachingFileHandle::GetVersionTag() {
 		annotated_lock_guard<annotated_mutex> guard(current_cached_file->meta_lock);
 		return current_cached_file->version_tag;
 	}
-	GetFileHandle();
+	auto file_handle = GetFileHandle();
+	annotated_lock_guard<annotated_mutex> guard(file_handle_mutex);
 	return version_tag;
 }
 
@@ -417,7 +432,7 @@ bool CachingFileHandle::CanSeek() {
 		annotated_lock_guard<annotated_mutex> guard(current_cached_file->meta_lock);
 		return current_cached_file->can_seek;
 	}
-	return GetFileHandle().CanSeek();
+	return GetFileHandle()->CanSeek();
 }
 
 bool CachingFileHandle::IsRemoteFile() const {
@@ -430,7 +445,7 @@ bool CachingFileHandle::OnDiskFile() {
 		annotated_lock_guard<annotated_mutex> guard(current_cached_file->meta_lock);
 		return current_cached_file->on_disk_file;
 	}
-	return GetFileHandle().OnDiskFile();
+	return GetFileHandle()->OnDiskFile();
 }
 
 void ReadThroughputEstimator::AddSample(double seconds, idx_t bytes) {
@@ -468,16 +483,16 @@ bool ReadThroughputEstimator::TryEstimate(NetworkThroughputEstimate &result) con
 
 bool CachingFileHandle::TryGetNetworkThroughput(NetworkThroughputEstimate &result) {
 	// Remote files measure throughput in their own file system; local files fit it from this handle's own reads.
-	if (GetFileHandle().TryGetNetworkThroughput(result)) {
+	if (GetFileHandle()->TryGetNetworkThroughput(result)) {
 		return true;
 	}
 	return throughput_estimator.TryEstimate(result);
 }
 
 void CachingFileHandle::ReadAndRecord(QueryContext context, data_ptr_t buffer, idx_t nr_bytes, idx_t location) {
-	auto &handle = GetFileHandle();
+	auto handle = GetFileHandle();
 	const auto read_start = steady_clock::now();
-	handle.Read(context, buffer, nr_bytes, location);
+	handle->Read(context, buffer, nr_bytes, location);
 	RecordReadThroughput(duration<double>(steady_clock::now() - read_start).count(), nr_bytes);
 }
 

--- a/src/storage/external_file_cache/caching_file_system_wrapper.cpp
+++ b/src/storage/external_file_cache/caching_file_system_wrapper.cpp
@@ -206,8 +206,8 @@ FileType CachingFileSystemWrapper::GetFileType(FileHandle &handle) {
 		return underlying_file_system.GetFileType(handle);
 	}
 
-	auto &file_handle = caching_handle->GetFileHandle();
-	return underlying_file_system.GetFileType(file_handle);
+	auto file_handle = caching_handle->GetFileHandle();
+	return underlying_file_system.GetFileType(*file_handle);
 }
 
 FileMetadata CachingFileSystemWrapper::Stats(FileHandle &handle) {
@@ -216,8 +216,8 @@ FileMetadata CachingFileSystemWrapper::Stats(FileHandle &handle) {
 		return underlying_file_system.Stats(handle);
 	}
 
-	auto &file_handle = caching_handle->GetFileHandle();
-	return underlying_file_system.Stats(file_handle);
+	auto file_handle = caching_handle->GetFileHandle();
+	return underlying_file_system.Stats(*file_handle);
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/sql/storage/external_file_cache/external_file_cache_async_toggle.test
+++ b/test/sql/storage/external_file_cache/external_file_cache_async_toggle.test
@@ -1,0 +1,54 @@
+# name: test/sql/storage/external_file_cache/external_file_cache_async_toggle.test
+# description: Concurrent cache toggles must not invalidate file handles used by async Parquet reads
+# group: [external_file_cache]
+
+require parquet
+
+statement ok
+SET threads=4
+
+statement ok
+SET async_threads=4
+
+# Keep row-group I/O on the per-scan async path.
+statement ok
+SET read_ahead_depth=0
+
+statement ok
+SET cache_local_files=true
+
+statement ok
+SET GLOBAL debug_fs_random_seed=424242
+
+statement ok
+COPY (
+    SELECT i
+    FROM range(1000000) t(i)
+) TO '{TEST_DIR}/external_file_cache_async_toggle.parquet'
+(FORMAT PARQUET, ROW_GROUP_SIZE 50000)
+
+# Widen the interval between acquiring and using the shared file handle.
+statement ok
+SET GLOBAL debug_fs_delay_mean_ms=5
+
+statement ok
+SET GLOBAL debug_fs_delay_stddev_ms=5
+
+# Half the connections repeatedly disable the cache while the other half enable it.
+# Every connection also scans, so toggles overlap async reads from live CachingFileHandles.
+concurrentforeach enabled true false true false true false true false
+
+loop iteration 0 5
+
+statement ok
+SET enable_external_file_cache={enabled}
+
+query II
+SELECT count(*), sum(i)
+FROM read_parquet('{TEST_DIR}/external_file_cache_async_toggle.parquet', prefetch_strategy='whole_group')
+----
+1000000	499999500000
+
+endloop
+
+endloop


### PR DESCRIPTION
Closes https://github.com/duckdb/duckdb/issues/23880

The issue is
- An async Parquet task calls `CachingFileHandle::ReadAndRecord()`
- `GetFileHandle` locks `file_handle_mutex`, and return `FileHandle&`, then unlocks.
- Another connection toggles `enable_external_file_cache`, advancing the cache generation
- Another read enters `EnsureCachedFileCurrent` and found current generation stale, so it resets the file handle
- As of now, the first task still uses its borrowed `FileHandle&`, so invalid memory access

The fix introduced in this PR is to return a shared pointer of FileHandle to ensure even if handle gets invalidated later, all accesses are still valid.