### PR TITLE
[Secret] Add `TRANSACTION` persist-type for SECRET, added to the `MetaTransaction`

### DIFF
--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -4869,19 +4869,20 @@ const StringUtil::EnumStringLiteral *GetSecretPersistTypeValues() {
 	static constexpr StringUtil::EnumStringLiteral values[] {
 		{ static_cast<uint32_t>(SecretPersistType::DEFAULT), "DEFAULT" },
 		{ static_cast<uint32_t>(SecretPersistType::TEMPORARY), "TEMPORARY" },
-		{ static_cast<uint32_t>(SecretPersistType::PERSISTENT), "PERSISTENT" }
+		{ static_cast<uint32_t>(SecretPersistType::PERSISTENT), "PERSISTENT" },
+		{ static_cast<uint32_t>(SecretPersistType::TRANSACTION), "TRANSACTION" }
 	};
 	return values;
 }
 
 template<>
 const char* EnumUtil::ToChars<SecretPersistType>(SecretPersistType value) {
-	return StringUtil::EnumToString(GetSecretPersistTypeValues(), 3, "SecretPersistType", static_cast<uint32_t>(value));
+	return StringUtil::EnumToString(GetSecretPersistTypeValues(), 4, "SecretPersistType", static_cast<uint32_t>(value));
 }
 
 template<>
 SecretPersistType EnumUtil::FromString<SecretPersistType>(const char *value) {
-	return static_cast<SecretPersistType>(StringUtil::StringToEnum(GetSecretPersistTypeValues(), 3, "SecretPersistType", value));
+	return static_cast<SecretPersistType>(StringUtil::StringToEnum(GetSecretPersistTypeValues(), 4, "SecretPersistType", value));
 }
 
 const StringUtil::EnumStringLiteral *GetSecretSerializationTypeValues() {

--- a/src/include/duckdb/main/secret/secret.hpp
+++ b/src/include/duckdb/main/secret/secret.hpp
@@ -22,8 +22,8 @@ struct FileOpenerInfo;
 struct CreateSecretInfo;
 class FileOpener;
 
-//! Whether a secret is persistent or temporary
-enum class SecretPersistType : uint8_t { DEFAULT, TEMPORARY, PERSISTENT };
+//! The lifetime of a secret
+enum class SecretPersistType : uint8_t { DEFAULT, TEMPORARY, PERSISTENT, TRANSACTION };
 
 //! Input passed to a CreateSecretFunction
 struct CreateSecretInput {
@@ -41,7 +41,7 @@ struct CreateSecretInput {
 	case_insensitive_map_t<Value> options;
 	//! how to handle conflicts
 	OnCreateConflict on_conflict;
-	//! persistence of secret
+	//! lifetime of the secret
 	SecretPersistType persist_type;
 };
 

--- a/src/include/duckdb/main/secret/secret_manager.hpp
+++ b/src/include/duckdb/main/secret/secret_manager.hpp
@@ -33,7 +33,7 @@ public:
 	      secret((other.secret != nullptr) ? other.secret->Clone() : nullptr) {
 	}
 
-	//! Whether the secret is persistent
+	//! Lifetime of the secret
 	SecretPersistType persist_type;
 	//! The storage backend of the secret
 	string storage_mode;
@@ -87,7 +87,7 @@ struct SecretManagerConfig {
 	bool allow_persistent_secrets = DEFAULT_ALLOW_PERSISTENT_SECRETS;
 };
 
-//! The Secret Manager for DuckDB. Can handle both temporary and persistent secrets
+//! The Secret Manager for DuckDB. Handles transaction, temporary and persistent secrets
 class SecretManager {
 	friend struct SecretEntry;
 
@@ -98,6 +98,7 @@ public:
 	//! The default storage backends
 	static constexpr const char *TEMPORARY_STORAGE_NAME = "memory";
 	static constexpr const char *LOCAL_FILE_STORAGE_NAME = "local_file";
+	static constexpr const char *TRANSACTION_STORAGE_NAME = "transaction";
 
 	//! Static Helper Functions
 	DUCKDB_API static SecretManager &Get(ClientContext &context);
@@ -191,6 +192,8 @@ private:
 	//! Thread-safe accessors for secret_storages
 	vector<reference<SecretStorage>> GetSecretStorages();
 	optional_ptr<SecretStorage> GetSecretStorage(const Identifier &name);
+	optional_ptr<SecretStorage> GetTransactionSecretStorage(CatalogTransaction transaction);
+	SecretStorage &GetOrCreateTransactionSecretStorage(CatalogTransaction transaction);
 
 	//! Throw an exception if the secret manager is initialized
 	void ThrowOnSettingChangeIfInitialized();

--- a/src/include/duckdb/main/secret/secret_storage.hpp
+++ b/src/include/duckdb/main/secret/secret_storage.hpp
@@ -38,6 +38,7 @@ public:
 	virtual ~SecretStorage() = default;
 
 	//! Default storage backend offsets
+	static const int64_t TRANSACTION_STORAGE_OFFSET = 0;
 	static const int64_t TEMPORARY_STORAGE_OFFSET = 10;
 	static const int64_t LOCAL_FILE_STORAGE_OFFSET = 20;
 
@@ -85,6 +86,28 @@ protected:
 	const int64_t tie_break_offset;
 	//! Whether entries in this storage will survive duckdb reboots
 	bool persistent;
+};
+
+//! In-memory secret storage owned by a single transaction
+class TransactionSecretStorage : public SecretStorage {
+public:
+	explicit TransactionSecretStorage(const string &name_p);
+	~TransactionSecretStorage() override;
+
+public:
+	unique_ptr<SecretEntry> StoreSecret(unique_ptr<const BaseSecret> secret, OnCreateConflict on_conflict,
+	                                    optional_ptr<CatalogTransaction> transaction = nullptr) override;
+	vector<SecretEntry> AllSecrets(optional_ptr<CatalogTransaction> transaction = nullptr) override;
+	void DropSecretByName(const Identifier &name, OnEntryNotFound on_entry_not_found,
+	                      optional_ptr<CatalogTransaction> transaction = nullptr) override;
+	SecretMatch LookupSecret(const string &path, const string &type,
+	                         optional_ptr<CatalogTransaction> transaction = nullptr) override;
+	unique_ptr<SecretEntry> GetSecretByName(const string &name,
+	                                        optional_ptr<CatalogTransaction> transaction = nullptr) override;
+
+private:
+	mutex lock;
+	identifier_map_t<unique_ptr<SecretEntry>> secrets;
 };
 
 //! Wrapper struct around a SecretEntry to allow storing it

--- a/src/include/duckdb/transaction/meta_transaction.hpp
+++ b/src/include/duckdb/transaction/meta_transaction.hpp
@@ -20,6 +20,8 @@
 namespace duckdb {
 class AttachedDatabase;
 class ClientContext;
+class SecretManager;
+class SecretStorage;
 struct DatabaseModificationType;
 class Transaction;
 
@@ -39,6 +41,7 @@ class MetaTransaction {
 public:
 	DUCKDB_API MetaTransaction(ClientContext &context, timestamp_t start_timestamp,
 	                           transaction_t global_transaction_id);
+	DUCKDB_API ~MetaTransaction();
 
 	ClientContext &context;
 	//! The timestamp when the transaction started
@@ -83,6 +86,8 @@ public:
 	void DetachDatabase(AttachedDatabase &database);
 
 private:
+	friend class SecretManager;
+
 	//! Lock to prevent all_transactions and transactions from getting out of sync.
 	mutex lock;
 	//! The set of active transactions for each database.
@@ -99,6 +104,8 @@ private:
 	reference_map_t<AttachedDatabase, shared_ptr<AttachedDatabase>> referenced_databases;
 	//! Map of name -> database for databases that are in-use by this transaction.
 	identifier_map_t<reference<AttachedDatabase>> used_databases;
+	//! Secrets that only live for the duration of this transaction.
+	unique_ptr<SecretStorage> transaction_secret_storage;
 };
 
 } // namespace duckdb

--- a/src/main/secret/secret_manager.cpp
+++ b/src/main/secret/secret_manager.cpp
@@ -362,8 +362,9 @@ SecretMatch SecretManager::LookupSecret(CatalogTransaction transaction, const st
 }
 
 unique_ptr<SecretEntry> SecretManager::GetSecretByName(CatalogTransaction transaction, const string &name,
-                                                       const string &storage) {
+                                                       const string &storage_p) {
 	InitializeSecrets(transaction);
+	auto storage = Identifier(storage_p);
 	if (storage.empty() || storage == TRANSACTION_STORAGE_NAME) {
 		if (auto transaction_storage = GetTransactionSecretStorage(transaction)) {
 			auto result = transaction_storage->GetSecretByName(name, &transaction);
@@ -379,7 +380,7 @@ unique_ptr<SecretEntry> SecretManager::GetSecretByName(CatalogTransaction transa
 	bool found = false;
 
 	if (!storage.empty()) {
-		auto storage_lookup = GetSecretStorage(Identifier(storage));
+		auto storage_lookup = GetSecretStorage(storage);
 
 		if (!storage_lookup) {
 			throw InvalidInputException("Unknown secret storage found: '%s'", storage);

--- a/src/main/secret/secret_manager.cpp
+++ b/src/main/secret/secret_manager.cpp
@@ -278,6 +278,9 @@ unique_ptr<SecretEntry> SecretManager::CreateSecret(ClientContext &context, cons
 }
 
 BoundStatement SecretManager::BindCreateSecret(CatalogTransaction transaction, CreateSecretInput &info) {
+	if (info.persist_type == SecretPersistType::TRANSACTION || info.storage_type == TRANSACTION_STORAGE_NAME) {
+		throw BinderException("Transaction-scoped secrets cannot be created through SQL");
+	}
 	InitializeSecrets(transaction);
 
 	auto type = info.type;

--- a/src/main/secret/secret_manager.cpp
+++ b/src/main/secret/secret_manager.cpp
@@ -19,6 +19,7 @@
 #include "duckdb/parser/parsed_data/create_secret_info.hpp"
 #include "duckdb/parser/statement/create_statement.hpp"
 #include "duckdb/planner/operator/logical_create_secret.hpp"
+#include "duckdb/transaction/meta_transaction.hpp"
 
 namespace duckdb {
 
@@ -39,6 +40,7 @@ const BaseSecret &SecretMatch::GetSecret() const {
 
 constexpr const char *SecretManager::TEMPORARY_STORAGE_NAME;
 constexpr const char *SecretManager::LOCAL_FILE_STORAGE_NAME;
+constexpr const char *SecretManager::TRANSACTION_STORAGE_NAME;
 
 void SecretManager::Initialize(DatabaseInstance &db) {
 	lock_guard<mutex> lck(manager_lock);
@@ -78,6 +80,9 @@ void SecretManager::LoadSecretStorage(unique_ptr<SecretStorage> storage) {
 }
 
 void SecretManager::LoadSecretStorageInternal(unique_ptr<SecretStorage> storage) {
+	if (StringUtil::CIEquals(storage->GetName(), TRANSACTION_STORAGE_NAME)) {
+		throw InvalidConfigurationException("Secret Storage name '%s' is reserved!", storage->GetName());
+	}
 	if (secret_storages.find(Identifier(storage->GetName())) != secret_storages.end()) {
 		throw InvalidConfigurationException("Secret Storage with name '%s' already registered!", storage->GetName());
 	}
@@ -156,6 +161,13 @@ unique_ptr<SecretEntry> SecretManager::RegisterSecretInternal(CatalogTransaction
                                                               const Identifier &storage) {
 	//! Ensure we only create secrets for known types;
 	LookupTypeInternal(secret->GetType());
+	if (persist_type == SecretPersistType::TRANSACTION) {
+		if (!storage.empty()) {
+			throw InvalidInputException("Transaction secrets do not support explicit storage");
+		}
+		auto &backend = GetOrCreateTransactionSecretStorage(transaction);
+		return backend.StoreSecret(std::move(secret), on_conflict, &transaction);
+	}
 
 	//! Handle default for persist type
 	if (persist_type == SecretPersistType::DEFAULT) {
@@ -320,6 +332,13 @@ SecretMatch SecretManager::LookupSecret(CatalogTransaction transaction, const st
 
 	int64_t best_match_score = NumericLimits<int64_t>::Minimum();
 	unique_ptr<SecretEntry> best_match = nullptr;
+	if (auto transaction_storage = GetTransactionSecretStorage(transaction)) {
+		auto match = transaction_storage->LookupSecret(path, StringUtil::Lower(type), &transaction);
+		if (match.HasMatch()) {
+			best_match = std::move(match.secret_entry);
+			best_match_score = match.score;
+		}
+	}
 
 	for (const auto &storage_ref : GetSecretStorages()) {
 		if (!storage_ref.get().IncludeInLookups()) {
@@ -342,6 +361,16 @@ SecretMatch SecretManager::LookupSecret(CatalogTransaction transaction, const st
 unique_ptr<SecretEntry> SecretManager::GetSecretByName(CatalogTransaction transaction, const string &name,
                                                        const string &storage) {
 	InitializeSecrets(transaction);
+	if (storage.empty() || storage == TRANSACTION_STORAGE_NAME) {
+		if (auto transaction_storage = GetTransactionSecretStorage(transaction)) {
+			auto result = transaction_storage->GetSecretByName(name, &transaction);
+			if (result || storage == TRANSACTION_STORAGE_NAME) {
+				return result;
+			}
+		} else if (storage == TRANSACTION_STORAGE_NAME) {
+			return nullptr;
+		}
+	}
 
 	unique_ptr<SecretEntry> result = nullptr;
 	bool found = false;
@@ -376,6 +405,20 @@ void SecretManager::DropSecretByName(CatalogTransaction transaction, const Ident
                                      OnEntryNotFound on_entry_not_found, SecretPersistType persist_type,
                                      const Identifier &storage) {
 	InitializeSecrets(transaction);
+	auto transaction_storage = GetTransactionSecretStorage(transaction);
+	if (storage == TRANSACTION_STORAGE_NAME || persist_type == SecretPersistType::TRANSACTION) {
+		if (transaction_storage) {
+			return transaction_storage->DropSecretByName(name, on_entry_not_found, &transaction);
+		}
+		if (on_entry_not_found == OnEntryNotFound::THROW_EXCEPTION) {
+			throw InvalidInputException("Failed to remove non-existent transaction secret with name '%s'", name);
+		}
+		return;
+	}
+	if (storage.empty() && persist_type == SecretPersistType::DEFAULT && transaction_storage &&
+	    transaction_storage->GetSecretByName(name.GetIdentifierName(), &transaction)) {
+		return transaction_storage->DropSecretByName(name, on_entry_not_found, &transaction);
+	}
 
 	vector<reference<SecretStorage>> matches;
 
@@ -486,6 +529,12 @@ vector<SecretEntry> SecretManager::AllSecrets(CatalogTransaction transaction) {
 	InitializeSecrets(transaction);
 
 	vector<SecretEntry> result;
+	if (auto transaction_storage = GetTransactionSecretStorage(transaction)) {
+		auto transaction_secrets = transaction_storage->AllSecrets(&transaction);
+		for (auto &secret : transaction_secrets) {
+			result.push_back(std::move(secret));
+		}
+	}
 
 	// Add results from all backends to the result set
 	for (const auto &backend : secret_storages) {
@@ -636,6 +685,27 @@ optional_ptr<SecretStorage> SecretManager::GetSecretStorage(const Identifier &na
 	}
 
 	return nullptr;
+}
+
+optional_ptr<SecretStorage> SecretManager::GetTransactionSecretStorage(CatalogTransaction transaction) {
+	if (!transaction.HasContext()) {
+		return nullptr;
+	}
+	auto &meta_transaction = MetaTransaction::Get(transaction.GetContext());
+	lock_guard<mutex> guard(meta_transaction.lock);
+	return meta_transaction.transaction_secret_storage.get();
+}
+
+SecretStorage &SecretManager::GetOrCreateTransactionSecretStorage(CatalogTransaction transaction) {
+	if (!transaction.HasContext()) {
+		throw InvalidInputException("Transaction secrets require an active client transaction");
+	}
+	auto &meta_transaction = MetaTransaction::Get(transaction.GetContext());
+	lock_guard<mutex> guard(meta_transaction.lock);
+	if (!meta_transaction.transaction_secret_storage) {
+		meta_transaction.transaction_secret_storage = make_uniq<TransactionSecretStorage>(TRANSACTION_STORAGE_NAME);
+	}
+	return *meta_transaction.transaction_secret_storage;
 }
 
 vector<reference<SecretStorage>> SecretManager::GetSecretStorages() {

--- a/src/main/secret/secret_storage.cpp
+++ b/src/main/secret/secret_storage.cpp
@@ -15,6 +15,83 @@
 
 namespace duckdb {
 
+TransactionSecretStorage::TransactionSecretStorage(const string &name_p)
+    : SecretStorage(name_p, TRANSACTION_STORAGE_OFFSET) {
+}
+
+TransactionSecretStorage::~TransactionSecretStorage() = default;
+
+unique_ptr<SecretEntry> TransactionSecretStorage::StoreSecret(unique_ptr<const BaseSecret> secret,
+                                                              OnCreateConflict on_conflict,
+                                                              optional_ptr<CatalogTransaction> transaction) {
+	lock_guard<mutex> guard(lock);
+	auto entry = secrets.find(secret->GetName());
+	if (entry != secrets.end()) {
+		switch (on_conflict) {
+		case OnCreateConflict::ERROR_ON_CONFLICT:
+			throw InvalidInputException("Transaction secret with name '%s' already exists!", secret->GetName());
+		case OnCreateConflict::IGNORE_ON_CONFLICT:
+			return nullptr;
+		case OnCreateConflict::REPLACE_ON_CONFLICT:
+			secrets.erase(entry);
+			break;
+		default:
+			throw InternalException("Unsupported conflict mode for transaction secret");
+		}
+	}
+
+	auto result = make_uniq<SecretEntry>(std::move(secret));
+	result->persist_type = SecretPersistType::TRANSACTION;
+	result->storage_mode = storage_name;
+	auto secret_name = result->secret->GetName();
+	secrets.emplace(secret_name, make_uniq<SecretEntry>(*result));
+	return result;
+}
+
+vector<SecretEntry> TransactionSecretStorage::AllSecrets(optional_ptr<CatalogTransaction> transaction) {
+	lock_guard<mutex> guard(lock);
+	vector<SecretEntry> result;
+	for (auto &entry : secrets) {
+		result.emplace_back(*entry.second);
+	}
+	return result;
+}
+
+void TransactionSecretStorage::DropSecretByName(const Identifier &name, OnEntryNotFound on_entry_not_found,
+                                                optional_ptr<CatalogTransaction> transaction) {
+	lock_guard<mutex> guard(lock);
+	auto entry = secrets.find(name);
+	if (entry == secrets.end()) {
+		if (on_entry_not_found == OnEntryNotFound::THROW_EXCEPTION) {
+			throw InvalidInputException("Failed to remove non-existent transaction secret '%s'", name);
+		}
+		return;
+	}
+	secrets.erase(entry);
+}
+
+SecretMatch TransactionSecretStorage::LookupSecret(const string &path, const string &type,
+                                                   optional_ptr<CatalogTransaction> transaction) {
+	lock_guard<mutex> guard(lock);
+	auto best_match = SecretMatch();
+	for (auto &entry : secrets) {
+		if (entry.second->secret->GetType() == type) {
+			best_match = SelectBestMatch(*entry.second, path, tie_break_offset, best_match);
+		}
+	}
+	return best_match;
+}
+
+unique_ptr<SecretEntry> TransactionSecretStorage::GetSecretByName(const string &name,
+                                                                  optional_ptr<CatalogTransaction> transaction) {
+	lock_guard<mutex> guard(lock);
+	auto entry = secrets.find(Identifier(name));
+	if (entry == secrets.end()) {
+		return nullptr;
+	}
+	return make_uniq<SecretEntry>(*entry->second);
+}
+
 SecretMatch SecretStorage::SelectBestMatch(SecretEntry &secret_entry, const string &path, int64_t offset,
                                            SecretMatch &current_best) {
 	// Get secret match score

--- a/src/transaction/meta_transaction.cpp
+++ b/src/transaction/meta_transaction.cpp
@@ -6,6 +6,7 @@
 #include "duckdb/main/database.hpp"
 #include "duckdb/transaction/transaction_manager.hpp"
 #include "duckdb/catalog/catalog.hpp"
+#include "duckdb/main/secret/secret_storage.hpp"
 
 namespace duckdb {
 
@@ -15,6 +16,8 @@ MetaTransaction::MetaTransaction(ClientContext &context_p, timestamp_t start_tim
       transaction_validity(*context_p.db), active_query(MAXIMUM_QUERY_ID), modified_database(nullptr),
       is_read_only(false) {
 }
+
+MetaTransaction::~MetaTransaction() = default;
 
 MetaTransaction &MetaTransaction::Get(ClientContext &context) {
 	return context.transaction.ActiveTransaction();

--- a/test/secrets/test_custom_secret_storage.cpp
+++ b/test/secrets/test_custom_secret_storage.cpp
@@ -343,3 +343,106 @@ TEST_CASE("Secret storage name collision: manager loaded after", "[secret][.]") 
 	// This now fails with a name collision warning
 	REQUIRE_FAIL(con.Query("FROM duckdb_secrets();"));
 }
+
+static CreateSecretInput TransactionSecretInput(const string &name, const string &scope,
+                                                OnCreateConflict on_conflict = OnCreateConflict::ERROR_ON_CONFLICT) {
+	CreateSecretInput result;
+	result.type = "transaction_secret_type";
+	result.provider = "config";
+	result.name = Identifier(name);
+	result.scope = {scope};
+	result.on_conflict = on_conflict;
+	result.persist_type = SecretPersistType::TRANSACTION;
+	return result;
+}
+
+TEST_CASE("Transaction secrets are isolated and cleaned up", "[secret]") {
+	DuckDB db(nullptr);
+	Connection owner(db);
+	Connection other(db);
+	DemoSecretType::RegisterDemoSecret(*db.instance, "transaction_secret_type");
+
+	REQUIRE_NO_FAIL(owner.Query("CREATE SECRET global_secret (TYPE transaction_secret_type, SCOPE 's3://bucket')"));
+	auto &secret_manager = SecretManager::Get(*db.instance);
+
+	REQUIRE_NO_FAIL(owner.Query("BEGIN TRANSACTION READ ONLY"));
+	auto input = TransactionSecretInput("transaction_secret", "s3://bucket");
+	auto created_secret = secret_manager.CreateSecret(*owner.context, input);
+	REQUIRE(created_secret);
+	REQUIRE(created_secret->persist_type == SecretPersistType::TRANSACTION);
+	REQUIRE(created_secret->storage_mode == SecretManager::TRANSACTION_STORAGE_NAME);
+
+	auto owner_transaction = CatalogTransaction::GetSystemCatalogTransaction(*owner.context);
+	auto owner_match =
+	    secret_manager.LookupSecret(owner_transaction, "s3://bucket/data.parquet", "transaction_secret_type");
+	REQUIRE(owner_match.HasMatch());
+	REQUIRE(owner_match.GetSecret().GetName() == "transaction_secret");
+	REQUIRE(secret_manager.GetSecretByName(owner_transaction, "transaction_secret"));
+
+	auto all_secrets = secret_manager.AllSecrets(owner_transaction);
+	REQUIRE(std::any_of(all_secrets.begin(), all_secrets.end(),
+	                    [](const SecretEntry &entry) { return entry.secret->GetName() == "transaction_secret"; }));
+
+	other.BeginTransaction();
+	auto other_transaction = CatalogTransaction::GetSystemCatalogTransaction(*other.context);
+	REQUIRE(!secret_manager.GetSecretByName(other_transaction, "transaction_secret"));
+	auto other_match =
+	    secret_manager.LookupSecret(other_transaction, "s3://bucket/data.parquet", "transaction_secret_type");
+	REQUIRE(other_match.HasMatch());
+	REQUIRE(other_match.GetSecret().GetName() == "global_secret");
+	other.Rollback();
+
+	owner.Commit();
+	owner.BeginTransaction();
+	owner_transaction = CatalogTransaction::GetSystemCatalogTransaction(*owner.context);
+	REQUIRE(!secret_manager.GetSecretByName(owner_transaction, "transaction_secret"));
+	owner_match = secret_manager.LookupSecret(owner_transaction, "s3://bucket/data.parquet", "transaction_secret_type");
+	REQUIRE(owner_match.HasMatch());
+	REQUIRE(owner_match.GetSecret().GetName() == "global_secret");
+
+	auto rollback_input = TransactionSecretInput("rollback_secret", "s3://rollback");
+	REQUIRE(secret_manager.CreateSecret(*owner.context, rollback_input));
+	owner.Rollback();
+	owner.BeginTransaction();
+	owner_transaction = CatalogTransaction::GetSystemCatalogTransaction(*owner.context);
+	REQUIRE(!secret_manager.GetSecretByName(owner_transaction, "rollback_secret"));
+	owner.Rollback();
+}
+
+TEST_CASE("Transaction secret validation and conflicts", "[secret]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	DemoSecretType::RegisterDemoSecret(*db.instance, "transaction_secret_type");
+	auto &secret_manager = SecretManager::Get(*db.instance);
+
+	con.BeginTransaction();
+	auto input = TransactionSecretInput("conflicting_secret", "s3://original");
+	REQUIRE(secret_manager.CreateSecret(*con.context, input));
+	REQUIRE_THROWS(secret_manager.CreateSecret(*con.context, input));
+
+	input.on_conflict = OnCreateConflict::IGNORE_ON_CONFLICT;
+	REQUIRE(!secret_manager.CreateSecret(*con.context, input));
+
+	input.on_conflict = OnCreateConflict::REPLACE_ON_CONFLICT;
+	input.scope = {"s3://replacement"};
+	REQUIRE(secret_manager.CreateSecret(*con.context, input));
+	auto transaction = CatalogTransaction::GetSystemCatalogTransaction(*con.context);
+	auto stored_secret = secret_manager.GetSecretByName(transaction, "conflicting_secret");
+	REQUIRE(stored_secret);
+	REQUIRE(stored_secret->secret->GetScope()[0] == "s3://replacement");
+
+	secret_manager.DropSecretByName(transaction, "conflicting_secret", OnEntryNotFound::THROW_EXCEPTION,
+	                                SecretPersistType::TRANSACTION);
+	REQUIRE(!secret_manager.GetSecretByName(transaction, "conflicting_secret"));
+
+	input.name = "explicit_storage";
+	input.storage_type = SecretManager::TEMPORARY_STORAGE_NAME;
+	REQUIRE_THROWS(secret_manager.CreateSecret(*con.context, input));
+	con.Rollback();
+
+	input.storage_type = "";
+	auto secret = DemoSecretType::CreateDemoSecret(*con.context, input);
+	auto system_transaction = CatalogTransaction::GetSystemTransaction(*db.instance);
+	REQUIRE_THROWS(secret_manager.RegisterSecret(system_transaction, std::move(secret),
+	                                             OnCreateConflict::ERROR_ON_CONFLICT, SecretPersistType::TRANSACTION));
+}

--- a/test/secrets/test_custom_secret_storage.cpp
+++ b/test/secrets/test_custom_secret_storage.cpp
@@ -7,6 +7,7 @@
 #include "duckdb/main/secret/secret.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
 #include "duckdb/main/extension_manager.hpp"
+#include "duckdb/planner/logical_operator.hpp"
 
 using namespace duckdb;
 
@@ -417,6 +418,8 @@ TEST_CASE("Transaction secret validation and conflicts", "[secret]") {
 
 	con.BeginTransaction();
 	auto input = TransactionSecretInput("conflicting_secret", "s3://original");
+	auto transaction = CatalogTransaction::GetSystemCatalogTransaction(*con.context);
+	REQUIRE_THROWS(secret_manager.BindCreateSecret(transaction, input));
 	REQUIRE(secret_manager.CreateSecret(*con.context, input));
 	REQUIRE_THROWS(secret_manager.CreateSecret(*con.context, input));
 
@@ -426,7 +429,6 @@ TEST_CASE("Transaction secret validation and conflicts", "[secret]") {
 	input.on_conflict = OnCreateConflict::REPLACE_ON_CONFLICT;
 	input.scope = {"s3://replacement"};
 	REQUIRE(secret_manager.CreateSecret(*con.context, input));
-	auto transaction = CatalogTransaction::GetSystemCatalogTransaction(*con.context);
 	auto stored_secret = secret_manager.GetSecretByName(transaction, "conflicting_secret");
 	REQUIRE(stored_secret);
 	REQUIRE(stored_secret->secret->GetScope()[0] == "s3://replacement");

--- a/test/sql/secrets/create_transaction_secret.test
+++ b/test/sql/secrets/create_transaction_secret.test
@@ -1,0 +1,13 @@
+# name: test/sql/secrets/create_transaction_secret.test
+# description: Ensure transaction-scoped secrets cannot be created through SQL
+# group: [secrets]
+
+statement error
+CREATE TRANSACTION SECRET transaction_secret (TYPE HTTP);
+----
+<REGEX>:.*Parser Error.*syntax error.*
+
+statement error
+CREATE SECRET transaction_secret IN transaction (TYPE HTTP);
+----
+Binder Error: Transaction-scoped secrets cannot be created through SQL


### PR DESCRIPTION
This PR is made as part of duckdb-iceberg work

"vended" credentials are short-lived credentials issued by the catalog server to provide access to the data of a table, it seemed to me that it was the cleanest to model this in core as credentials attached to the transaction.