### PR TITLE
Add NOT conjunction simplification rule

### DIFF
--- a/src/include/duckdb/optimizer/rule/list.hpp
+++ b/src/include/duckdb/optimizer/rule/list.hpp
@@ -13,6 +13,7 @@
 #include "duckdb/optimizer/rule/list_comprehension_rewrite.hpp"
 #include "duckdb/optimizer/rule/move_constants.hpp"
 #include "duckdb/optimizer/rule/not_comparison_simplification.hpp"
+#include "duckdb/optimizer/rule/not_conjunction_simplification.hpp"
 #include "duckdb/optimizer/rule/enum_comparison.hpp"
 #include "duckdb/optimizer/rule/regex_optimizations.hpp"
 #include "duckdb/optimizer/rule/ordered_aggregate_optimizer.hpp"

--- a/src/include/duckdb/optimizer/rule/not_conjunction_simplification.hpp
+++ b/src/include/duckdb/optimizer/rule/not_conjunction_simplification.hpp
@@ -1,0 +1,24 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/optimizer/rule/not_conjunction_simplification.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/optimizer/rule.hpp"
+
+namespace duckdb {
+
+// Applies De Morgan's law: NOT(a AND b) -> (NOT a) OR (NOT b), NOT(a OR b) -> (NOT a) AND (NOT b)
+class NotConjunctionSimplificationRule : public Rule {
+public:
+	explicit NotConjunctionSimplificationRule(ExpressionRewriter &rewriter);
+
+	unique_ptr<Expression> Apply(LogicalOperator &op, vector<reference<Expression>> &bindings, bool &changes_made,
+	                             bool is_root) override;
+};
+
+} // namespace duckdb

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -92,6 +92,7 @@ Optimizer::Optimizer(Binder &binder, ClientContext &context) : context(context),
 	rewriter.rules.push_back(make_uniq<ListComprehensionRewriteRule>(rewriter));
 	rewriter.rules.push_back(make_uniq<ContainsToInClauseRule>(rewriter));
 	rewriter.rules.push_back(make_uniq<NotComparisonSimplificationRule>(rewriter));
+	rewriter.rules.push_back(make_uniq<NotConjunctionSimplificationRule>(rewriter));
 
 #ifdef DEBUG
 	for (auto &rule : rewriter.rules) {

--- a/src/optimizer/rule/CMakeLists.txt
+++ b/src/optimizer/rule/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library_unity(
   monotone_preimage.cpp
   move_constants.cpp
   not_comparison_simplification.cpp
+  not_conjunction_simplification.cpp
   ordered_aggregate_optimizer.cpp
   predicate_factoring.cpp
   regex_optimizations.cpp

--- a/src/optimizer/rule/not_conjunction_simplification.cpp
+++ b/src/optimizer/rule/not_conjunction_simplification.cpp
@@ -1,0 +1,45 @@
+#include "duckdb/optimizer/rule/not_conjunction_simplification.hpp"
+#include "duckdb/planner/expression/bound_operator_expression.hpp"
+#include "duckdb/planner/expression/bound_conjunction_expression.hpp"
+#include "duckdb/common/enums/expression_type.hpp"
+
+namespace duckdb {
+
+NotConjunctionSimplificationRule::NotConjunctionSimplificationRule(ExpressionRewriter &rewriter) : Rule(rewriter) {
+	auto op = make_uniq<ExpressionMatcher>(ExpressionClass::BOUND_OPERATOR);
+	op->expr_type = make_uniq<SpecificExpressionTypeMatcher>(ExpressionType::OPERATOR_NOT);
+	root = std::move(op);
+}
+
+unique_ptr<Expression> NotConjunctionSimplificationRule::Apply(LogicalOperator &op,
+                                                               vector<reference<Expression>> &bindings,
+                                                               bool &changes_made, bool is_root) {
+	auto &not_expr = bindings[0].get().Cast<BoundOperatorExpression>();
+	D_ASSERT(not_expr.GetExpressionType() == ExpressionType::OPERATOR_NOT);
+	D_ASSERT(not_expr.GetChildren().size() == 1);
+
+	auto &child = not_expr.GetChildrenMutable()[0];
+	if (child->GetExpressionClass() != ExpressionClass::BOUND_CONJUNCTION) {
+		return nullptr;
+	}
+
+	auto &conjunction = child->Cast<BoundConjunctionExpression>();
+	D_ASSERT(conjunction.GetExpressionType() == ExpressionType::CONJUNCTION_AND ||
+	         conjunction.GetExpressionType() == ExpressionType::CONJUNCTION_OR);
+	auto negated_type = conjunction.GetExpressionType() == ExpressionType::CONJUNCTION_AND
+	                        ? ExpressionType::CONJUNCTION_OR
+	                        : ExpressionType::CONJUNCTION_AND;
+
+	auto result = make_uniq<BoundConjunctionExpression>(negated_type);
+	result->GetChildrenMutable().reserve(conjunction.GetChildren().size());
+	for (auto &conj_child : conjunction.GetChildrenMutable()) {
+		auto negated_child = make_uniq<BoundOperatorExpression>(ExpressionType::OPERATOR_NOT, LogicalType::BOOLEAN);
+		negated_child->GetChildrenMutable().push_back(std::move(conj_child));
+		result->GetChildrenMutable().push_back(std::move(negated_child));
+	}
+
+	changes_made = true;
+	return std::move(result);
+}
+
+} // namespace duckdb

--- a/src/optimizer/rule/not_conjunction_simplification.cpp
+++ b/src/optimizer/rule/not_conjunction_simplification.cpp
@@ -26,6 +26,9 @@ unique_ptr<Expression> NotConjunctionSimplificationRule::Apply(LogicalOperator &
 	auto &conjunction = child->Cast<BoundConjunctionExpression>();
 	D_ASSERT(conjunction.GetExpressionType() == ExpressionType::CONJUNCTION_AND ||
 	         conjunction.GetExpressionType() == ExpressionType::CONJUNCTION_OR);
+	if (conjunction.IsVolatile() || conjunction.CanThrow()) {
+		return nullptr;
+	}
 	auto negated_type = conjunction.GetExpressionType() == ExpressionType::CONJUNCTION_AND
 	                        ? ExpressionType::CONJUNCTION_OR
 	                        : ExpressionType::CONJUNCTION_AND;

--- a/test/sql/optimizer/not_conjunction_simplification.test
+++ b/test/sql/optimizer/not_conjunction_simplification.test
@@ -1,0 +1,77 @@
+# name: test/sql/optimizer/not_conjunction_simplification.test
+# description: Test simplification of NOT-wrapped conjunctions
+# group: [optimizer]
+
+statement ok
+PRAGMA explain_output = 'OPTIMIZED_ONLY';
+
+statement ok
+CREATE TABLE t AS SELECT range AS i FROM range(1000000);
+
+statement ok
+CHECKPOINT;
+
+# NOT BETWEEN is bound to a NOT-wrapped conjunction
+query II
+EXPLAIN SELECT count() FROM t WHERE i NOT BETWEEN 10 AND 999989;
+----
+logical_opt	<REGEX>:.*OR.*
+
+query II
+EXPLAIN ANALYZE SELECT count() FROM t WHERE i NOT BETWEEN 10 AND 999989;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: [12] / 9.*
+
+query I
+SELECT count() FROM t WHERE i NOT BETWEEN 10 AND 999989;
+----
+20
+
+# Explicit NOT(AND)
+query II
+EXPLAIN ANALYZE SELECT count() FROM t WHERE NOT (i >= 10 AND i <= 999989);
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: [12] / 9.*
+
+query I
+SELECT count() FROM t WHERE NOT (i >= 10 AND i <= 999989);
+----
+20
+
+# NOT(OR) becomes two prunable predicates
+query II
+EXPLAIN ANALYZE SELECT count() FROM t WHERE NOT (i < 400000 OR i > 600000);
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: [1-8] / 9.*
+
+query I
+SELECT count() FROM t WHERE NOT (i < 400000 OR i > 600000);
+----
+200001
+
+# Preserve three-valued logic
+query II
+SELECT NOT (a AND b), (NOT a) OR (NOT b)
+FROM (VALUES (1, NULL::BOOLEAN, TRUE),
+             (2, NULL::BOOLEAN, FALSE),
+             (3, TRUE, NULL::BOOLEAN),
+             (4, FALSE, NULL::BOOLEAN)) v(id, a, b)
+ORDER BY id;
+----
+NULL	NULL
+true	true
+NULL	NULL
+true	true
+
+query II
+SELECT NOT (a OR b), (NOT a) AND (NOT b)
+FROM (VALUES (1, NULL::BOOLEAN, TRUE),
+             (2, NULL::BOOLEAN, FALSE),
+             (3, TRUE, NULL::BOOLEAN),
+             (4, FALSE, NULL::BOOLEAN)) v(id, a, b)
+ORDER BY id;
+----
+false	false
+NULL	NULL
+false	false
+NULL	NULL

--- a/test/sql/optimizer/not_conjunction_simplification.test
+++ b/test/sql/optimizer/not_conjunction_simplification.test
@@ -75,3 +75,35 @@ false	false
 NULL	NULL
 false	false
 NULL	NULL
+
+# Do not change the number of volatile function evaluations
+statement ok
+CREATE SEQUENCE s;
+
+statement ok
+CREATE TABLE volatile_t(a BOOLEAN);
+
+statement ok
+INSERT INTO volatile_t VALUES (false), (true);
+
+query I
+SELECT count(*) FROM volatile_t WHERE NOT (a AND nextval('s') > 0);
+----
+1
+
+query I
+SELECT currval('s');
+----
+2
+
+# Do not suppress errors by changing short-circuit behavior
+statement ok
+CREATE TABLE throwing_t(a BOOLEAN);
+
+statement ok
+INSERT INTO throwing_t VALUES (false);
+
+statement error
+SELECT count(*) FROM throwing_t WHERE NOT (a AND error('expected'));
+----
+expected


### PR DESCRIPTION
## Summary

Resolves #23703.

This PR adds a conjunction simplification rule to the expression rewriter. It
applies De Morgan's law to rewrite `NOT (a AND b)` as `NOT a OR NOT b` (and the
inverse for `OR`). This transforms `NOT BETWEEN` into comparisons that can be
pushed down.

## Results

```sql
CREATE TABLE t AS SELECT range AS i FROM range(1000000);
CHECKPOINT;
EXPLAIN ANALYZE SELECT count() FROM t WHERE i NOT BETWEEN 10 AND 999989;
```

### Before

```SQL
╭─ Summary ───────────╮
│ Total Time: 0.0017s │
╰─────────────────────╯
╭─ Ungrouped Aggregate ─────────────╮
│ Aggregates: count_star()          │
│ 1 row                         0µs │
╰─────────────────┒┎────────────────╯
╭─ Table Scan ────┚┖────────────────╮
│ Table: memory.main.t              │
│ Type: Sequential Scan             │
│ Filters:                          │
│ NOT ((i >= 10) AND (i <= 999989)) │
│ Row Groups Scanned: 9 / 9         │
│ 20 rows                    10.0ms │
╰───────────────────────────────────╯
```

### After

```SQL
╭─ Summary ───────────╮
│ Total Time: 0.0011s │
╰─────────────────────╯
╭─ Ungrouped Aggregate ────────────────╮
│ Aggregates: count_star()             │
│ 1 row                            0µs │
╰───────────────────┬──────────────────╯
╭─ Filter ──────────┴──────────────────╮
│ Expression: (i < 10) OR (i > 999989) │
│ 20 rows                          0µs │
╰───────────────────┒┎─────────────────╯
╭─ Table Scan ──────┚┖─────────────────╮
│ Table: memory.main.t                 │
│ Type: Sequential Scan                │
│ Projections: i                       │
│ Filters:                             │
│ optional: ((i < 10) OR (i > 999989)) │
│ Row Groups Scanned: 2 / 9            │
│ 139,840 rows                     0µs │
╰──────────────────────────────────────╯
```


