### PR TITLE
CURL CLI uses 5 minutes to detect an unresponsible server, let us adapt

### DIFF
--- a/src/include/duckdb/common/http_util.hpp
+++ b/src/include/duckdb/common/http_util.hpp
@@ -29,7 +29,7 @@ struct HTTPParams {
 	}
 	virtual ~HTTPParams();
 
-	static constexpr uint64_t DEFAULT_TIMEOUT_SECONDS = 30; // 30 sec
+	static constexpr uint64_t DEFAULT_TIMEOUT_SECONDS = 300; // 5 minutes
 	static constexpr uint64_t DEFAULT_RETRIES = 3;
 	static constexpr uint64_t DEFAULT_RETRY_WAIT_MS = 100;
 	static constexpr float DEFAULT_RETRY_BACKOFF = 4;


### PR DESCRIPTION
Goal would be allowing more slow / unresponsive server time to come back and actually send back responses. For S3 reads this is unheard of, but with layers of caching / compression / server side logic, this might be more friendly to users, and assumes that a query pointing to talk to a slow server should be honored.

It's always possible to configure, in a stricter or more relaxed direction, via:
```sql
SET http_timeout = X;
```