### PR TITLE
Storage: validate Roaring metadata bounds

### DIFF
--- a/src/include/duckdb/storage/compression/roaring/roaring.hpp
+++ b/src/include/duckdb/storage/compression/roaring/roaring.hpp
@@ -160,7 +160,7 @@ public:
 	void Reset();
 	// Write the metadata for the current segment
 	idx_t Serialize(data_ptr_t dest) const;
-	void Deserialize(data_ptr_t src, idx_t container_count);
+	void Deserialize(data_ptr_t src, idx_t container_count, idx_t available_size);
 
 private:
 	void AddBitsetContainer();
@@ -610,7 +610,7 @@ public:
 	explicit RoaringScanState(ColumnSegment &segment);
 
 public:
-	idx_t SkipVector(const ContainerMetadata &metadata);
+	idx_t SkipVector(const ContainerMetadata &metadata, idx_t container_size);
 	bool UseContainerStateCache(idx_t container_index, idx_t internal_offset);
 	ContainerMetadata GetContainerMetadata(idx_t container_index);
 	data_ptr_t GetStartOfContainerData(idx_t container_index);

--- a/src/storage/compression/roaring/metadata.cpp
+++ b/src/storage/compression/roaring/metadata.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/storage/compression/roaring/roaring.hpp"
 
+#include "duckdb/common/exception.hpp"
 #include "duckdb/common/numeric_utils.hpp"
 #include "duckdb/common/bitpacking.hpp"
 
@@ -153,14 +154,22 @@ idx_t ContainerMetadataCollection::Serialize(data_ptr_t dest) const {
 	return types_size + runs_size + arrays_size;
 }
 
-void ContainerMetadataCollection::Deserialize(data_ptr_t src, idx_t container_count) {
+static void VerifyMetadataRead(idx_t read_offset, idx_t read_size, idx_t available_size, const char *metadata_name) {
+	if (read_size > available_size || read_offset > available_size - read_size) {
+		throw IOException("Corrupted Roaring segment: %s metadata exceeds segment bounds", metadata_name);
+	}
+}
+
+void ContainerMetadataCollection::Deserialize(data_ptr_t src, idx_t container_count, idx_t available_size) {
 	container_type.resize(AlignValue<idx_t, BitpackingPrimitives::BITPACKING_ALGORITHM_GROUP_SIZE>(container_count));
 	count_in_segment = container_count;
 
 	// Load the types of the containers
 	idx_t types_size = BitpackingPrimitives::GetRequiredSize(container_type.size(), 2);
+	idx_t read_offset = 0;
+	VerifyMetadataRead(read_offset, types_size, available_size, "container type");
 	BitpackingPrimitives::UnPackBuffer<uint8_t>(container_type.data(), src, container_count, 2, true);
-	src += types_size;
+	read_offset += types_size;
 
 	// Figure out how many are run containers
 	idx_t runs_count = 0;
@@ -175,16 +184,18 @@ void ContainerMetadataCollection::Deserialize(data_ptr_t src, idx_t container_co
 	// Load the run containers
 	if (runs_count) {
 		idx_t runs_size = BitpackingPrimitives::GetRequiredSize(runs_count, RUN_CONTAINER_SIZE_BITWIDTH);
-		BitpackingPrimitives::UnPackBuffer<uint8_t>(number_of_runs.data(), src, runs_count, RUN_CONTAINER_SIZE_BITWIDTH,
-		                                            true);
-		src += runs_size;
+		VerifyMetadataRead(read_offset, runs_size, available_size, "run container");
+		BitpackingPrimitives::UnPackBuffer<uint8_t>(number_of_runs.data(), src + read_offset, runs_count,
+		                                            RUN_CONTAINER_SIZE_BITWIDTH, true);
+		read_offset += runs_size;
 	}
 
 	// Load the array/bitset containers
 	if (!cardinality.empty()) {
 		idx_t arrays_size = sizeof(uint8_t) * cardinality.size();
+		VerifyMetadataRead(read_offset, arrays_size, available_size, "array container");
 		arrays_in_segment = arrays_size;
-		memcpy(cardinality.data(), src, arrays_size);
+		memcpy(cardinality.data(), src + read_offset, arrays_size);
 	}
 }
 

--- a/src/storage/compression/roaring/scan.cpp
+++ b/src/storage/compression/roaring/scan.cpp
@@ -192,28 +192,30 @@ void BitsetContainerScanState::Verify() const {
 RoaringScanState::RoaringScanState(ColumnSegment &segment) : segment(segment) {
 	auto &buffer_manager = BufferManager::GetBufferManager(segment.GetDatabase());
 	handle = buffer_manager.Pin(segment.GetBlockHandle());
-	auto segment_size = segment.SegmentSize();
+	auto block_size = segment.GetBlockSize();
 	auto segment_block_offset = segment.GetBlockOffset();
-	if (segment_block_offset >= segment_size) {
-		throw InternalException("invalid segment_block_offset in RoaringScanState constructor");
+	if (segment_block_offset >= block_size || block_size - segment_block_offset < sizeof(idx_t)) {
+		throw IOException("Corrupted Roaring segment: invalid block offset");
 	}
+	auto available_segment_space = block_size - segment_block_offset;
 
 	auto base_ptr = handle.GetDataMutable() + segment_block_offset;
 	data_ptr = base_ptr + sizeof(idx_t);
 
 	// Deserialize the container metadata for this segment
 	auto metadata_offset = Load<idx_t>(base_ptr);
-	if (metadata_offset >= segment_size) {
-		throw InternalException("invalid metadata offset in RoaringScanState constructor");
+	if (metadata_offset >= available_segment_space - sizeof(idx_t)) {
+		throw IOException("Corrupted Roaring segment: metadata offset exceeds segment bounds");
 	}
 	auto metadata_ptr = data_ptr + metadata_offset;
+	auto available_metadata_space = available_segment_space - sizeof(idx_t) - metadata_offset;
 
 	auto segment_count = segment.count.load();
 	auto container_count = segment_count / ROARING_CONTAINER_SIZE;
 	if (segment_count % ROARING_CONTAINER_SIZE != 0) {
 		container_count++;
 	}
-	metadata_collection.Deserialize(metadata_ptr, container_count);
+	metadata_collection.Deserialize(metadata_ptr, container_count, available_metadata_space);
 	ContainerMetadataCollectionScanner scanner(metadata_collection);
 	data_start_position.reserve(container_count);
 	idx_t position = 0;
@@ -227,14 +229,20 @@ RoaringScanState::RoaringScanState(ColumnSegment &segment) : segment(segment) {
 		} else if (metadata.IsRun() && metadata.NumberOfRuns() < COMPRESSED_RUN_THRESHOLD) {
 			position = AlignValue<idx_t, sizeof(RunContainerRLEPair)>(position);
 		}
+		auto start_of_container = i * ROARING_CONTAINER_SIZE;
+		auto container_size = AlignValue<idx_t, ValidityMask::BITS_PER_VALUE>(
+		    MinValue<idx_t>(segment_count - start_of_container, ROARING_CONTAINER_SIZE));
+		auto data_size = SkipVector(metadata, container_size);
+		if (position > metadata_offset || data_size > metadata_offset - position) {
+			throw IOException("Corrupted Roaring segment: container data exceeds metadata offset");
+		}
 		data_start_position.push_back(position);
-		position += SkipVector(metadata);
+		position += data_size;
 	}
 }
 
-idx_t RoaringScanState::SkipVector(const ContainerMetadata &metadata) {
-	// NOTE: this doesn't care about smaller containers, since only the last container can be smaller
-	return metadata.GetDataSizeInBytes(ROARING_CONTAINER_SIZE);
+idx_t RoaringScanState::SkipVector(const ContainerMetadata &metadata, idx_t container_size) {
+	return metadata.GetDataSizeInBytes(container_size);
 }
 
 bool RoaringScanState::UseContainerStateCache(idx_t container_index, idx_t internal_offset) {

--- a/test/sql/storage/CMakeLists.txt
+++ b/test/sql/storage/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library_unity(
   OBJECT
   test_buffer_manager.cpp
   test_checksum.cpp
+  test_roaring_corruption.cpp
   test_storage.cpp
   test_database_size.cpp
   wal_torn_write.cpp)

--- a/test/sql/storage/test_roaring_corruption.cpp
+++ b/test/sql/storage/test_roaring_corruption.cpp
@@ -1,0 +1,65 @@
+#include "catch.hpp"
+#include "duckdb/common/checksum.hpp"
+#include "duckdb/common/file_system.hpp"
+#include "duckdb/common/helper.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/storage/storage_info.hpp"
+#include "test_helpers.hpp"
+
+using namespace duckdb;
+
+static void CorruptRoaringMetadataOffset(const string &path, block_id_t block_id, idx_t block_offset) {
+	auto fs = FileSystem::CreateLocal();
+	auto handle = fs->OpenFile(path, FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_READ);
+	auto block_location = Storage::FILE_HEADER_SIZE * 3 + NumericCast<idx_t>(block_id) * DEFAULT_BLOCK_ALLOC_SIZE;
+	auto block_data = duckdb::unique_ptr<data_t[]>(new data_t[DEFAULT_BLOCK_ALLOC_SIZE]);
+
+	handle->Read(QueryContext(), block_data.get(), DEFAULT_BLOCK_ALLOC_SIZE, block_location);
+
+	REQUIRE(block_offset + sizeof(idx_t) < Storage::DEFAULT_BLOCK_SIZE);
+	auto metadata_offset = Storage::DEFAULT_BLOCK_SIZE - block_offset - sizeof(idx_t) + 1;
+	REQUIRE(metadata_offset < Storage::DEFAULT_BLOCK_SIZE);
+	Store<idx_t>(metadata_offset, block_data.get() + DEFAULT_BLOCK_HEADER_STORAGE_SIZE + block_offset);
+
+	auto checksum = Checksum(block_data.get() + DEFAULT_BLOCK_HEADER_STORAGE_SIZE, Storage::DEFAULT_BLOCK_SIZE);
+	Store<uint64_t>(checksum, block_data.get());
+
+	handle->Write(QueryContext(), block_data.get(), DEFAULT_BLOCK_ALLOC_SIZE, block_location);
+	handle->Sync();
+}
+
+TEST_CASE("Roaring metadata offset cannot point outside block bounds", "[storage]") {
+	auto config = GetTestConfig();
+	config->SetOptionByName("default_block_size", Value::UBIGINT(DEFAULT_BLOCK_ALLOC_SIZE));
+	auto storage_database = TestCreatePath("roaring_corrupt_metadata_offset");
+
+	DeleteDatabase(storage_database);
+	block_id_t block_id;
+	idx_t block_offset;
+	{
+		DuckDB db(storage_database, config.get());
+		Connection con(db);
+		REQUIRE_NO_FAIL(con.Query("SET storage_compatibility_version='v1.2.0'"));
+		REQUIRE_NO_FAIL(con.Query("SET force_compression='roaring'"));
+		REQUIRE_NO_FAIL(con.Query("CREATE TABLE t AS SELECT CASE WHEN i % 3 = 0 THEN i::INTEGER ELSE NULL END AS v "
+		                          "FROM range(100000) tbl(i)"));
+		REQUIRE_NO_FAIL(con.Query("CHECKPOINT"));
+		auto result = con.Query("SELECT block_id, block_offset FROM pragma_storage_info('t') "
+		                        "WHERE compression='Roaring' AND segment_type='VALIDITY'");
+		REQUIRE(!result->HasError());
+		REQUIRE(result->RowCount() == 1);
+		block_id = result->GetValue(0, 0).GetValue<int64_t>();
+		block_offset = NumericCast<idx_t>(result->GetValue(1, 0).GetValue<int64_t>());
+	}
+
+	CorruptRoaringMetadataOffset(storage_database, block_id, block_offset);
+
+	{
+		DuckDB db(storage_database, config.get());
+		Connection con(db);
+		auto result = con.Query("SELECT count(v) FROM t");
+		REQUIRE(result->HasError());
+		REQUIRE(StringUtil::Contains(result->GetError(), "Corrupted Roaring segment"));
+	}
+	DeleteDatabase(storage_database);
+}


### PR DESCRIPTION
## Summary

Building on #23796, which validates the Roaring container count against the available metadata space, this adds bounds validation for `metadata_offset` against the segment's remaining block capacity and checks the actual metadata bytes consumed during deserialization.

Roaring stores `metadata_offset` relative to the data pointer after the segment header. For persistent column segments, scans may start at a non-zero `block_offset`, while `SegmentSize()` is the usable block size. A corrupted offset could therefore pass validation while making `metadata_ptr` point outside the block data.

The fix checks the offset against the remaining block space, passes the remaining metadata byte count into metadata deserialization, and validates the type/run/array metadata sections before reading them. It also verifies that decoded container payload offsets do not overlap or pass the metadata start.

A regression test creates a valid Roaring validity segment, corrupts the metadata offset while recomputing the block checksum, and verifies that scanning reports a corrupted Roaring segment instead of returning incorrect counts.

## Tests

- Build: `make reldebug`
- C++ regression: `build/reldebug/test/unittest "Roaring metadata offset cannot point outside block bounds"`
- Roaring storage sqllogictest: `build/reldebug/test/unittest test/sql/attach/attach_new_compression.test`
- Storage test group: `build/reldebug/test/unittest "[storage]"`
