### PR TITLE
Bump extensions for v1.5.5: quack, httpfs and aws

### DIFF
--- a/.github/config/extensions/aws.cmake
+++ b/.github/config/extensions/aws.cmake
@@ -2,6 +2,6 @@ if (NOT MINGW AND NOT ${WASM_ENABLED})
     duckdb_extension_load(aws
             LOAD_TESTS
             GIT_URL https://github.com/duckdb/duckdb-aws
-            GIT_TAG 08ad34f625e4a8e15221e462b96000ff29174447
+            GIT_TAG efa54a990e16c976576685dd4134d2478cf5a574
             )
 endif()

--- a/.github/config/extensions/httpfs.cmake
+++ b/.github/config/extensions/httpfs.cmake
@@ -1,5 +1,5 @@
 duckdb_extension_load(httpfs
     LOAD_TESTS
     GIT_URL https://github.com/duckdb/duckdb-httpfs
-    GIT_TAG 772952f082faeb5ec21fec55eaab902b8600e450
+    GIT_TAG f1ffc1f991f330ab989111a5150f263d04207440
 )

--- a/.github/config/extensions/quack.cmake
+++ b/.github/config/extensions/quack.cmake
@@ -1,5 +1,5 @@
 duckdb_extension_load(quack
     ## LOAD_TESTS
     GIT_URL https://github.com/duckdb/duckdb-quack
-    GIT_TAG 8e715ebb6d0fd6f36b1c705e431f5e3f33c45ef3
+    GIT_TAG c1548111c1bfd16207e22fd3cb7e4bde1335b9d0
 )


### PR DESCRIPTION
Brings in some work on `http_timeout`, currently manually set in quack and moved from total timeout to connection_timeout for CURL backend in httpfs, to be more friendly to slow producing servers that are still live.

Also bring in solutions to other issues `quack` side, and appending `duckdb/${VERSION}` to AWS API requests (S3 data plan already sorted out via HTTPUtil)