### PR TITLE
Add more missing includes

### DIFF
--- a/test/common/test_logical_type_is_complete.cpp
+++ b/test/common/test_logical_type_is_complete.cpp
@@ -1,6 +1,7 @@
 #include "catch.hpp"
 #include "duckdb/common/types.hpp"
 #include "duckdb/common/types/decimal.hpp"
+#include "duckdb/common/optional_idx.hpp"
 
 using namespace duckdb;
 

--- a/test/sqlite/test_sqllogictest.cpp
+++ b/test/sqlite/test_sqllogictest.cpp
@@ -12,6 +12,7 @@
 #include <string>
 #include <system_error>
 #include <vector>
+#include <duckdb/main/extension_helper.hpp>
 
 using namespace duckdb;
 


### PR DESCRIPTION
Non-unity builds have been temporarily disabled in CI because clangd-tidy jobs ran out of memory. So here's another PR with two missing includes.