### PR TITLE
Fix potential memory leak after realloc failure in /third_party/hyperloglog/sds.cpp

### DIFF
--- a/third_party/hyperloglog/sds.cpp
+++ b/third_party/hyperloglog/sds.cpp
@@ -1042,11 +1042,11 @@ sds *sdssplitargs(const char *line, int *argc) {
                 if (*p) p++;
             }
             /* add the token to the vector */
-            char **new_vector =(char **)realloc(vector, ((*argc) + 1) * sizeof(char *));
-            if (new_vector == NULL) {
+            char **tmp = (char **)realloc(vector, ((*argc) + 1) * sizeof(char *));
+            if (tmp == NULL) {
                 goto err;
             }
-            vector = new_vector;
+            vector = tmp;
             vector[*argc] = current;
             (*argc)++;
             current = NULL;

--- a/third_party/hyperloglog/sds.cpp
+++ b/third_party/hyperloglog/sds.cpp
@@ -1042,13 +1042,23 @@ sds *sdssplitargs(const char *line, int *argc) {
                 if (*p) p++;
             }
             /* add the token to the vector */
-            vector = (char**) realloc(vector,((*argc)+1)*sizeof(char*));
+            char **new_vector =(char **)realloc(vector, ((*argc) + 1) * sizeof(char *));
+            if (new_vector == NULL) {
+                goto err;
+            }
+            vector = new_vector;
             vector[*argc] = current;
             (*argc)++;
             current = NULL;
         } else {
             /* Even on empty input string return something not NULL. */
-            if (vector == NULL) vector = (char**) malloc(sizeof(void*));
+            if (vector == NULL) {
+                vector = (char**) malloc(sizeof(void*));
+                if (vector == NULL) {
+                    *argc = 0;
+                    return NULL;
+                }
+            }
             return vector;
         }
     }
@@ -1057,7 +1067,7 @@ err:
     while((*argc)--)
         sdsfree(vector[*argc]);
     free(vector);
-    if (current) sdsfree(current);
+    sdsfree(current);
     *argc = 0;
     return NULL;
 }


### PR DESCRIPTION
In the sdssplitargs() function, there is a potential memory leak on line 1045 after calling realloc()
https://github.com/duckdb/duckdb/blob/main/third_party/hyperloglog/sds.cpp#L1045

If an error occurs, realloc() returns NULL, and the original memory block is not freed. Since the result of the function is directly assigned to the vector variable, the former address of the allocated block is lost, which makes it impossible to release it later. 

```
sds *sdssplitargs(const char *line, int *argc) {
    const char *p = line;
    char *current = NULL;
    char **vector = NULL;
    ...
    ...
    }
```
```
....
....
 /* add the token to the vector */
            vector = (char**) realloc(vector,((*argc)+1)*sizeof(char*));
            vector[*argc] = current;
            (*argc)++;
            current = NULL;
...
...
```

To prevent this situation, it is recommended to first save the result of realloc() to a temporary pointer (tmp), check it for NULL, and assign it to the vector variable only upon successful reallocation. In case of an error, proceed to the handling of an exceptional situation (goto err), while maintaining access to the original memory block.


Found using the cppcheck static analyzer
Reporter: Guschin Egor (guschin058@yandex.ru)