### PR TITLE
Fix staged install check and alpha release versioning

### DIFF
--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -118,6 +118,9 @@ jobs:
         shell: bash
         run: |
           effective_git_describe="${{ github.event_name == 'workflow_dispatch' && inputs.override_git_describe || '' }}"
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && -z "${{ inputs.git_ref }}" && -z "$effective_git_describe" ]]; then
+            effective_git_describe="v2.0.0-alpha${{ github.run_number }}"
+          fi
           echo "effective_git_describe=$effective_git_describe" >> "$GITHUB_OUTPUT"
           echo "Using effective_git_describe=$effective_git_describe"
 

--- a/scripts/ci/check_staged_extensions.py
+++ b/scripts/ci/check_staged_extensions.py
@@ -32,7 +32,7 @@ def parse_args() -> argparse.Namespace:
 
 
 def cli_asset_url(asset_base_url: str, git_sha: str, version: str) -> str:
-    short_sha = git_sha[:7]
+    short_sha = git_sha[:10]
     base = asset_base_url.rstrip("/")
     if version:
         return f"{base}/{short_sha}/{version}/duckdb/duckdb/github_release/duckdb_cli-linux-amd64.gz"


### PR DESCRIPTION
CI step `Check staged extensions load/install` [fails](https://github.com/duckdb/duckdb/actions/runs/29572541861/job/87892049283#step:4:1):
```
Run python3 scripts/ci/check_staged_extensions.py \
Downloading staged CLI (1/2): https://duckdb-staging.duckdb.org/7560f82/duckdb/duckdb/github_release/duckdb_cli-linux-amd64.gz
Staged CLI is not ready yet: HTTP Error 403: Forbidden
Downloading staged CLI (2/2): https://duckdb-staging.duckdb.org/7560f82/duckdb/duckdb/github_release/duckdb_cli-linux-amd64.gz
Error: failed to download staged CLI after 2 attempts: HTTP Error 403: Forbidden
Error: Process completed with exit code 1.
```
because it uses the first 7 chars instead of the first 10 chars of the git sha.

Re-enable [alpha](https://github.com/duckdblabs/duckdb-internal/issues/8628) release [versioning](https://github.com/duckdb/duckdb/pull/23649) on main. We're explicitly not overriding a previously set version because the manual release and the implicitly scheduled release both use the event `workflow_dispatch`. (cc @carlopi).