### PR TITLE
Implement stats callback for sign

### DIFF
--- a/extension/core_functions/scalar/math/numeric.cpp
+++ b/extension/core_functions/scalar/math/numeric.cpp
@@ -13,6 +13,7 @@
 
 #include <cmath>
 #include <cstdint>
+#include <type_traits>
 
 namespace duckdb {
 
@@ -369,17 +370,98 @@ int8_t SignOperator::Operation(double input) {
 	}
 }
 
+// Returns whether we could safely produce output bounds.
+template <class T>
+bool SignStatsBounds(const BaseStatistics &input_stats, int8_t &min_sign, int8_t &max_sign) {
+	auto min = NumericStats::GetMin<T>(input_stats);
+	auto max = NumericStats::GetMax<T>(input_stats);
+	if constexpr (std::is_floating_point<T>::value) {
+		if (Value::IsNan(min) || Value::IsNan(max)) {
+			return false;
+		}
+	}
+	min_sign = SignOperator::Operation<T, int8_t>(min);
+	max_sign = SignOperator::Operation<T, int8_t>(max);
+	return true;
+}
+
+unique_ptr<BaseStatistics> PropagateSignStats(ClientContext &context, FunctionStatisticsInput &input) {
+	(void)context;
+	auto &child_stats = input.child_stats;
+	D_ASSERT(child_stats.size() == 1);
+	auto &input_stats = child_stats[0];
+	auto result = NumericStats::CreateEmpty(LogicalType::TINYINT);
+	result.CopyValidity(input_stats);
+	if (!input_stats.CanHaveNoNull()) {
+		return result.ToUnique();
+	}
+	if (!NumericStats::HasMinMax(input_stats)) {
+		return nullptr;
+	}
+
+	int8_t min_sign = 0;
+	int8_t max_sign = 0;
+	bool success = false;
+	switch (input.expr.GetChildren()[0]->GetReturnType().InternalType()) {
+	case PhysicalType::INT8:
+		success = SignStatsBounds<int8_t>(input_stats, min_sign, max_sign);
+		break;
+	case PhysicalType::INT16:
+		success = SignStatsBounds<int16_t>(input_stats, min_sign, max_sign);
+		break;
+	case PhysicalType::INT32:
+		success = SignStatsBounds<int32_t>(input_stats, min_sign, max_sign);
+		break;
+	case PhysicalType::INT64:
+		success = SignStatsBounds<int64_t>(input_stats, min_sign, max_sign);
+		break;
+	case PhysicalType::INT128:
+		success = SignStatsBounds<hugeint_t>(input_stats, min_sign, max_sign);
+		break;
+	case PhysicalType::UINT8:
+		success = SignStatsBounds<uint8_t>(input_stats, min_sign, max_sign);
+		break;
+	case PhysicalType::UINT16:
+		success = SignStatsBounds<uint16_t>(input_stats, min_sign, max_sign);
+		break;
+	case PhysicalType::UINT32:
+		success = SignStatsBounds<uint32_t>(input_stats, min_sign, max_sign);
+		break;
+	case PhysicalType::UINT64:
+		success = SignStatsBounds<uint64_t>(input_stats, min_sign, max_sign);
+		break;
+	case PhysicalType::UINT128:
+		success = SignStatsBounds<uhugeint_t>(input_stats, min_sign, max_sign);
+		break;
+	case PhysicalType::FLOAT:
+		success = SignStatsBounds<float>(input_stats, min_sign, max_sign);
+		break;
+	case PhysicalType::DOUBLE:
+		success = SignStatsBounds<double>(input_stats, min_sign, max_sign);
+		break;
+	default:
+		return nullptr;
+	}
+	if (!success) {
+		return nullptr;
+	}
+
+	NumericStats::SetMin(result, min_sign);
+	NumericStats::SetMax(result, max_sign);
+	return result.ToUnique();
+}
+
 } // namespace
 ScalarFunctionSet SignFun::GetFunctions() {
 	ScalarFunctionSet sign;
 	for (auto &type : LogicalType::Numeric()) {
 		if (type.id() == LogicalTypeId::DECIMAL) {
 			continue;
-		} else {
-			sign.AddFunction(
-			    ScalarFunction({type}, LogicalType::TINYINT,
-			                   ScalarFunction::GetScalarUnaryFunctionFixedReturn<int8_t, SignOperator>(type)));
 		}
+		ScalarFunction function({type}, LogicalType::TINYINT,
+		                        ScalarFunction::GetScalarUnaryFunctionFixedReturn<int8_t, SignOperator>(type));
+		function.SetStatisticsCallback(PropagateSignStats);
+		sign.AddFunction(function);
 	}
 	return sign;
 }

--- a/test/sql/optimizer/sign_row_group_pruning.test
+++ b/test/sql/optimizer/sign_row_group_pruning.test
@@ -10,10 +10,7 @@ USE db;
 
 statement ok
 CREATE TABLE integers AS
-    SELECT CASE WHEN range = 0 THEN 0
-                WHEN range % 2048 = 0 THEN NULL
-                ELSE range::INTEGER
-           END AS i
+    SELECT range::INTEGER AS i
     FROM range(6144);
 
 query I
@@ -25,18 +22,3 @@ query II
 EXPLAIN ANALYZE SELECT sum(i) FROM integers WHERE sign(i) = 0;
 ----
 analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
-
-statement ok
-CREATE TABLE reported_repro AS
-    SELECT CASE WHEN range % 10000 = 0 THEN NULL ELSE range::INTEGER END AS i
-    FROM range(6144);
-
-query I
-SELECT sum(i) FROM reported_repro WHERE sign(i) = 0;
-----
-NULL
-
-query II
-EXPLAIN ANALYZE SELECT sum(i) FROM reported_repro WHERE sign(i) = 0;
-----
-analyzed_plan	<REGEX>:.*Empty Result.*

--- a/test/sql/optimizer/sign_row_group_pruning.test
+++ b/test/sql/optimizer/sign_row_group_pruning.test
@@ -1,0 +1,42 @@
+# name: test/sql/optimizer/sign_row_group_pruning.test
+# description: Row-group pruning through the sign function
+# group: [optimizer]
+
+statement ok
+ATTACH '{TEST_DIR}/sign_prune.duckdb' AS db (ROW_GROUP_SIZE 2048);
+
+statement ok
+USE db;
+
+statement ok
+CREATE TABLE integers AS
+    SELECT CASE WHEN range = 0 THEN 0
+                WHEN range % 2048 = 0 THEN NULL
+                ELSE range::INTEGER
+           END AS i
+    FROM range(6144);
+
+query I
+SELECT sum(i) FROM integers WHERE sign(i) = 0;
+----
+0
+
+query II
+EXPLAIN ANALYZE SELECT sum(i) FROM integers WHERE sign(i) = 0;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
+
+statement ok
+CREATE TABLE reported_repro AS
+    SELECT CASE WHEN range % 10000 = 0 THEN NULL ELSE range::INTEGER END AS i
+    FROM range(6144);
+
+query I
+SELECT sum(i) FROM reported_repro WHERE sign(i) = 0;
+----
+NULL
+
+query II
+EXPLAIN ANALYZE SELECT sum(i) FROM reported_repro WHERE sign(i) = 0;
+----
+analyzed_plan	<REGEX>:.*Empty Result.*


### PR DESCRIPTION
Closes https://github.com/duckdb/duckdb/issues/23900

`SetUnaryArgProperties` would solve all non-nan values, but still special handle for NaN.
```sql
memory D SELECT
             floor('NaN'::DOUBLE) AS floor_nan,
             sign('NaN'::DOUBLE)  AS sign_nan;
┌───────────┬──────────┐
│ floor_nan │ sign_nan │
│  double   │   int8   │
├───────────┼──────────┤
│       nan │        0 │
└───────────┴──────────┘
```