### PR TITLE
Optimize CASE statement when all branches yield identical results

### DIFF
--- a/src/optimizer/rule/case_simplification.cpp
+++ b/src/optimizer/rule/case_simplification.cpp
@@ -42,6 +42,17 @@ unique_ptr<Expression> CaseSimplificationRule::Apply(LogicalOperator &op, vector
 		// no case checks left: return the ELSE expression
 		return std::move(root.ElseMutable());
 	}
+	// if all THEN branches are identical to the ELSE branch, we can just return the ELSE expression
+	bool all_identical = true;
+	for (auto &case_check : root.CaseChecks()) {
+		if (!Expression::Equals(case_check.then_expr, root.ElseMutable())) {
+			all_identical = false;
+			break;
+		}
+	}
+	if (all_identical) {
+		return std::move(root.ElseMutable());
+	}
 	return nullptr;
 }
 

--- a/src/optimizer/rule/case_simplification.cpp
+++ b/src/optimizer/rule/case_simplification.cpp
@@ -45,7 +45,7 @@ unique_ptr<Expression> CaseSimplificationRule::Apply(LogicalOperator &op, vector
 	// if all THEN branches are identical to the ELSE branch, we can just return the ELSE expression
 	bool all_identical = true;
 	for (auto &case_check : root.CaseChecks()) {
-		if (!Expression::Equals(case_check.then_expr, root.ElseMutable())) {
+		if (case_check.when_expr->IsVolatile() || !Expression::Equals(case_check.then_expr, root.ElseMutable())) {
 			all_identical = false;
 			break;
 		}

--- a/test/optimizer/case_simplification.test
+++ b/test/optimizer/case_simplification.test
@@ -32,3 +32,26 @@ query I nosort casenorm3
 EXPLAIN SELECT X+2 FROM test
 ----
 
+query I nosort casenorm4
+EXPLAIN SELECT CASE WHEN X>5 THEN X ELSE X END FROM test
+----
+
+query I nosort casenorm4
+EXPLAIN SELECT X FROM test
+----
+
+query I nosort casenorm5
+EXPLAIN SELECT CASE WHEN X>10 THEN X WHEN X>5 THEN X ELSE X END FROM test
+----
+
+query I nosort casenorm5
+EXPLAIN SELECT X FROM test
+----
+
+query I nosort casenorm6
+EXPLAIN SELECT CASE WHEN X>5 THEN X ELSE X+1 END FROM test
+----
+
+query I nosort casenorm6
+EXPLAIN SELECT CASE WHEN X>5 THEN X ELSE X+1 END FROM test
+----

--- a/test/optimizer/case_simplification.test
+++ b/test/optimizer/case_simplification.test
@@ -55,3 +55,11 @@ EXPLAIN SELECT CASE WHEN X>5 THEN X ELSE X+1 END FROM test
 query I nosort casenorm6
 EXPLAIN SELECT CASE WHEN X>5 THEN X ELSE X+1 END FROM test
 ----
+
+query I nosort casenorm7
+EXPLAIN SELECT CASE WHEN random() > 0.5 THEN X ELSE X END FROM test
+----
+
+query I nosort casenorm7
+EXPLAIN SELECT CASE WHEN random() > 0.5 THEN X ELSE X END FROM test
+----


### PR DESCRIPTION
Fixes #23838

When a `CASE` expression has all `THEN` branches identical to the `ELSE` branch, the entire `CASE` is replaced with the `ELSE` expression. This avoids unnecessary column reads and condition evaluation.

Example:

```sql
-- Before: evaluates b, reads both b and i
SELECT CASE WHEN b THEN i ELSE i END FROM t;

-- After optimization: only reads i
SELECT i FROM t;
```
Changes:

- `src/optimizer/rule/case_simplification.cpp`: Added identical-branch detection after existing constant-folding logic
- `test/optimizer/case_simplification.test`: Added tests for single-branch, multi-branch, and non-matching cases