### PR TITLE
EXTERNAL RESOURCES: external resources via table functions

### DIFF
--- a/src/function/table/system/CMakeLists.txt
+++ b/src/function/table/system/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library_unity(
   duckdb_extensions.cpp
   duckdb_external_file_cache.cpp
   external_resource_types.cpp
+  external_resources.cpp
   duckdb_functions.cpp
   duckdb_keywords.cpp
   duckdb_log.cpp

--- a/src/function/table/system/create_external_resource.cpp
+++ b/src/function/table/system/create_external_resource.cpp
@@ -1,8 +1,4 @@
 #include "duckdb/function/table/system_functions.hpp"
-#include "duckdb/catalog/catalog.hpp"
-#include "duckdb/catalog/catalog_entry/schema_catalog_entry.hpp"
-#include "duckdb/catalog/entry_lookup_info.hpp"
-#include "duckdb/common/enums/on_entry_not_found.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/types/value.hpp"
@@ -10,6 +6,7 @@
 #include "duckdb/main/connection.hpp"
 #include "duckdb/main/database.hpp"
 #include "duckdb/main/external_resource_type_registry.hpp"
+#include "duckdb/main/external_resources_manager.hpp"
 #include "duckdb/logging/log_type.hpp"
 #include "duckdb/logging/logger.hpp"
 #include "duckdb/parser/qualified_name.hpp"
@@ -73,22 +70,6 @@ static Value RequireResourceMap(const Value &value, const string &function_name,
 		    column, value.type().ToString());
 	}
 	return value.DefaultCastAs(LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR));
-}
-
-//! Resolve a table-producing callback (a table function or table macro) to its fully-qualified
-//! `catalog.schema.name` in `context`'s search path, so the returned deleter stays resolvable from any other
-//! connection later (e.g. when DETACH fires it). Returns empty if the callback can't be resolved.
-static string QualifyTableCallback(ClientContext &context, const string &name) {
-	EntryLookupInfo table_fn(CatalogType::TABLE_FUNCTION_ENTRY, QualifiedName::Parse(name));
-	auto entry = Catalog::GetEntry(context, table_fn, OnEntryNotFound::RETURN_NULL);
-	if (!entry) {
-		EntryLookupInfo table_macro(CatalogType::TABLE_MACRO_ENTRY, QualifiedName::Parse(name));
-		entry = Catalog::GetEntry(context, table_macro, OnEntryNotFound::RETURN_NULL);
-	}
-	if (!entry) {
-		return string();
-	}
-	return QualifiedName(entry->ParentCatalog().GetName(), entry->ParentSchema().name, entry->name).ToString();
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/function/table/system/create_external_resource.cpp
+++ b/src/function/table/system/create_external_resource.cpp
@@ -10,12 +10,32 @@
 #include "duckdb/main/connection.hpp"
 #include "duckdb/main/database.hpp"
 #include "duckdb/main/external_resource_type_registry.hpp"
+#include "duckdb/logging/log_type.hpp"
+#include "duckdb/logging/logger.hpp"
 #include "duckdb/parser/qualified_name.hpp"
 
 #include <chrono>
 #include <thread>
 
 namespace duckdb {
+
+//! Empty `extra_info` map for an ExternalResource log entry.
+static Value NoExtraInfo() {
+	return Value::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR, vector<Value>(), vector<Value>());
+}
+
+//! Single-entry `extra_info` map for an ExternalResource log entry.
+static Value ExtraInfo(const string &key, const string &value) {
+	return Value::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR, {Value(key)}, {Value(value)});
+}
+
+//! Log one recipe callback invocation (on response). `resource_type` may be empty (rendered NULL) when
+//! the callsite does not know it; `error` is empty on success.
+static void LogExternalResourceOperation(ClientContext &context, const string &resource_type,
+                                         const string &resource_name, const char *operation, const string &error,
+                                         const Value &extra_info) {
+	DUCKDB_LOG(context, ExternalResourceLogType, resource_type, resource_name, string(operation), error, extra_info);
+}
 
 //! Defaults for the readiness poll loop, both overridable per call via named parameters. A timeout of 0
 //! means wait indefinitely (rely on a terminal status or query cancellation).
@@ -94,7 +114,10 @@ static int64_t ReadSecondsParameter(const string &key, const Value &value, int64
 
 struct CreateExternalResourceBindData : public TableFunctionData {
 	string type_name;
+	string resource_name;
 	Value params;
+	//! When set (non-NULL), adopt this existing handle instead of calling `create` to provision a new one.
+	Value adopt_handle;
 	bool teardown_on_failure = true;
 	int64_t timeout_seconds = DEFAULT_READINESS_TIMEOUT_SECONDS;
 	int64_t poll_interval_seconds = DEFAULT_POLL_INTERVAL_SECONDS;
@@ -116,6 +139,10 @@ static unique_ptr<FunctionData> CreateExternalResourceBind(ClientContext &contex
 		auto key = StringUtil::Lower(np.first.GetIdentifierName());
 		if (key == "params" && !np.second.IsNull()) {
 			result->params = np.second;
+		} else if (key == "resource_name" && !np.second.IsNull()) {
+			result->resource_name = StringValue::Get(np.second);
+		} else if (key == "handle" && !np.second.IsNull()) {
+			result->adopt_handle = np.second;
 		} else if (key == "teardown_on_failure" && !np.second.IsNull()) {
 			result->teardown_on_failure = BooleanValue::Get(np.second);
 		} else if (key == "timeout_seconds" && !np.second.IsNull()) {
@@ -160,11 +187,6 @@ static void CreateExternalResourceFunction(ClientContext &context, TableFunction
 	if (!type) {
 		throw InvalidInputException("create_external_resource: unknown resource type \"%s\"", bind_data.type_name);
 	}
-	if (type->create_function.empty()) {
-		throw InvalidInputException("create_external_resource: resource type \"%s\" has no create function",
-		                            bind_data.type_name);
-	}
-
 	// Separate internal connection: the current connection's context lock is held here.
 	Connection con(DatabaseInstance::GetDatabase(context));
 	// Resolve the callbacks in the search path captured at registration, so unqualified names in a non-default
@@ -177,26 +199,45 @@ static void CreateExternalResourceFunction(ClientContext &context, TableFunction
 			    bind_data.type_name, type->search_path, set_res->GetError());
 		}
 	}
-	auto sql = "SELECT * FROM " + QualifiedName::Parse(type->create_function).ToString() + "(" +
-	           bind_data.params.ToSQLString() + ")";
-	auto result = con.Query(sql);
-	if (result->HasError()) {
-		throw IOException("create_external_resource: create function \"%s\" failed: %s", type->create_function,
-		                  result->GetError());
-	}
-	if (result->RowCount() == 0) {
-		throw InvalidInputException("create_external_resource: create function \"%s\" returned no rows",
-		                            type->create_function);
-	}
-	// Contract: `create` returns a single 'handle' column (a MAP; opaque to us, passed back to status/destroy).
-	auto handle = RequireResourceMap(result->GetValue(0, 0), type->create_function, "handle");
 
-	// Ownership: the resource now exists. We own its teardown until we successfully hand back the deleter
-	// binding below; on any failure in between (status 'failed', timeout, cancellation, malformed result,
-	// baseline violation) tear it down best-effort — unless teardown_on_failure is disabled, e.g. to inspect
-	// a rolled-back resource. This guard runs the destroy on every exit path, including exception unwinding.
+	// Provision (call `create`) or adopt (use the caller-supplied handle). A `create` returns a single
+	// 'handle' column (a MAP; opaque to us, passed back to status/destroy).
+	const bool adopting = !bind_data.adopt_handle.IsNull();
+	Value handle;
+	if (adopting) {
+		handle = RequireResourceMap(bind_data.adopt_handle, bind_data.type_name, "handle");
+	} else {
+		if (type->create_function.empty()) {
+			throw InvalidInputException("create_external_resource: resource type \"%s\" has no create function",
+			                            bind_data.type_name);
+		}
+		auto sql = "SELECT * FROM " + QualifiedName::Parse(type->create_function).ToString() + "(" +
+		           bind_data.params.ToSQLString() + ")";
+		auto result = con.Query(sql);
+		LogExternalResourceOperation(context, bind_data.type_name, bind_data.resource_name, "create",
+		                             result->HasError() ? result->GetError() : string(), NoExtraInfo());
+		if (result->HasError()) {
+			throw IOException("create_external_resource: create function \"%s\" failed: %s", type->create_function,
+			                  result->GetError());
+		}
+		if (result->RowCount() == 0) {
+			throw InvalidInputException("create_external_resource: create function \"%s\" returned no rows",
+			                            type->create_function);
+		}
+		handle = RequireResourceMap(result->GetValue(0, 0), type->create_function, "handle");
+	}
+
+	// Ownership: when we provisioned the resource, we own its teardown until we successfully hand back the
+	// deleter binding below; on any failure in between (status 'failed', timeout, cancellation, malformed
+	// result, baseline violation) tear it down best-effort. When a handle was supplied the resource
+	// already existed and is not ours to destroy on failure, so the guard stays disarmed regardless of
+	// teardown_on_failure.
+	bool teardown_on_failure = !adopting && bind_data.teardown_on_failure;
 	bool deleter_returned = false;
 	struct TeardownGuard {
+		ClientContext &context;
+		const string &resource_type;
+		const string &resource_name;
 		Connection &con;
 		const string &destroy_function;
 		const Value &handle;
@@ -207,12 +248,16 @@ static void CreateExternalResourceFunction(ClientContext &context, TableFunction
 				return;
 			}
 			try {
-				con.Query("SELECT * FROM " + QualifiedName::Parse(destroy_function).ToString() + "(" +
-				          handle.ToSQLString() + ")");
+				auto sql = "SELECT * FROM " + QualifiedName::Parse(destroy_function).ToString() + "(" +
+				           handle.ToSQLString() + ")";
+				auto res = con.Query(sql);
+				LogExternalResourceOperation(context, resource_type, resource_name, "destroy",
+				                             res->HasError() ? res->GetError() : string(), NoExtraInfo());
 			} catch (...) { // best-effort: never mask the original failure with a teardown error
 			}
 		}
-	} teardown_guard {con, type->destroy_function, handle, bind_data.teardown_on_failure, deleter_returned};
+	} teardown_guard {context, bind_data.type_name, bind_data.resource_name, con, type->destroy_function,
+	                  handle,  teardown_on_failure, deleter_returned};
 
 	if (type->status_function.empty()) {
 		throw InvalidInputException(
@@ -232,6 +277,14 @@ static void CreateExternalResourceFunction(ClientContext &context, TableFunction
 		auto status_sql = "SELECT state, result FROM " + QualifiedName::Parse(type->status_function).ToString() + "(" +
 		                  handle.ToSQLString() + ")";
 		auto sres = con.Query(status_sql);
+		string poll_state;
+		if (!sres->HasError() && sres->RowCount() > 0) {
+			auto sv = sres->GetValue(0, 0);
+			poll_state = sv.IsNull() ? string() : sv.ToString();
+		}
+		LogExternalResourceOperation(context, bind_data.type_name, bind_data.resource_name, "status",
+		                             sres->HasError() ? sres->GetError() : string(),
+		                             poll_state.empty() ? NoExtraInfo() : ExtraInfo("state", poll_state));
 		if (sres->HasError()) {
 			throw IOException("create_external_resource: status function \"%s\" failed: %s", type->status_function,
 			                  sres->GetError());
@@ -309,6 +362,8 @@ void CreateExternalResourceFun::RegisterFunction(BuiltinFunctions &set) {
 	TableFunction fn("create_external_resource", {LogicalType::VARCHAR}, CreateExternalResourceFunction,
 	                 CreateExternalResourceBind, CreateExternalResourceInit);
 	fn.named_parameters["params"] = LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR);
+	fn.named_parameters["resource_name"] = LogicalType::VARCHAR;
+	fn.named_parameters["handle"] = LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR);
 	fn.named_parameters["teardown_on_failure"] = LogicalType::BOOLEAN;
 	fn.named_parameters["timeout_seconds"] = LogicalType::BIGINT;
 	fn.named_parameters["poll_interval_seconds"] = LogicalType::BIGINT;
@@ -362,6 +417,9 @@ static void DestroyExternalResourceFunction(ClientContext &context, TableFunctio
 	auto sql = "SELECT * FROM " + QualifiedName::Parse(bind_data.deleter_function).ToString() + "(" +
 	           bind_data.deleter_payload.ToSQLString() + ")";
 	auto result = con.Query(sql);
+	// resource_type/name are unknown at this callsite (the deleter binding does not carry them).
+	LogExternalResourceOperation(context, string(), string(), "destroy",
+	                             result->HasError() ? result->GetError() : string(), NoExtraInfo());
 	if (result->HasError()) {
 		throw IOException("destroy_external_resource: deleter function \"%s\" failed: %s", bind_data.deleter_function,
 		                  result->GetError());

--- a/src/function/table/system/create_external_resource.cpp
+++ b/src/function/table/system/create_external_resource.cpp
@@ -1,4 +1,7 @@
 #include "duckdb/function/table/system_functions.hpp"
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/catalog/catalog_entry/schema_catalog_entry.hpp"
+#include "duckdb/common/error_data.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/types/value.hpp"
@@ -194,18 +197,26 @@ static void CreateExternalResourceFunction(ClientContext &context, TableFunction
 		}
 		auto sql = "SELECT * FROM " + QualifiedName::Parse(type->create_function).ToString() + "(" +
 		           bind_data.params.ToSQLString() + ")";
-		auto result = con.Query(sql);
-		LogExternalResourceOperation(context, bind_data.type_name, bind_data.resource_name, "create",
-		                             result->HasError() ? result->GetError() : string(), NoExtraInfo());
-		if (result->HasError()) {
-			throw IOException("create_external_resource: create function \"%s\" failed: %s", type->create_function,
-			                  result->GetError());
+		// Log the operation's real outcome: the callback query returning without error is not yet success, the
+		// result still has to satisfy the contract below. Logging from the catch also covers throws added later.
+		try {
+			auto result = con.Query(sql);
+			if (result->HasError()) {
+				throw IOException("create_external_resource: create function \"%s\" failed: %s", type->create_function,
+				                  result->GetError());
+			}
+			if (result->RowCount() == 0) {
+				throw InvalidInputException("create_external_resource: create function \"%s\" returned no rows",
+				                            type->create_function);
+			}
+			handle = RequireResourceMap(result->GetValue(0, 0), type->create_function, "handle");
+			LogExternalResourceOperation(context, bind_data.type_name, bind_data.resource_name, "create", string(),
+			                             NoExtraInfo());
+		} catch (std::exception &ex) {
+			LogExternalResourceOperation(context, bind_data.type_name, bind_data.resource_name, "create",
+			                             ErrorData(ex).RawMessage(), NoExtraInfo());
+			throw;
 		}
-		if (result->RowCount() == 0) {
-			throw InvalidInputException("create_external_resource: create function \"%s\" returned no rows",
-			                            type->create_function);
-		}
-		handle = RequireResourceMap(result->GetValue(0, 0), type->create_function, "handle");
 	}
 
 	// Ownership: when we provisioned the resource, we own its teardown until we successfully hand back the
@@ -234,7 +245,15 @@ static void CreateExternalResourceFunction(ClientContext &context, TableFunction
 				auto res = con.Query(sql);
 				LogExternalResourceOperation(context, resource_type, resource_name, "destroy",
 				                             res->HasError() ? res->GetError() : string(), NoExtraInfo());
-			} catch (...) { // best-effort: never mask the original failure with a teardown error
+			} catch (std::exception &ex) {
+				// best-effort: never mask the original failure with a teardown error, but do record it - a
+				// throwing Query() would otherwise leave the failed teardown invisible.
+				try {
+					LogExternalResourceOperation(context, resource_type, resource_name, "destroy",
+					                             ErrorData(ex).RawMessage(), NoExtraInfo());
+				} catch (...) { // logging must not throw out of a destructor
+				}
+			} catch (...) {
 			}
 		}
 	} teardown_guard {context, bind_data.type_name, bind_data.resource_name, con, type->destroy_function,
@@ -257,35 +276,41 @@ static void CreateExternalResourceFunction(ClientContext &context, TableFunction
 		context.InterruptCheck();
 		auto status_sql = "SELECT state, result FROM " + QualifiedName::Parse(type->status_function).ToString() + "(" +
 		                  handle.ToSQLString() + ")";
-		auto sres = con.Query(status_sql);
-		string poll_state;
-		if (!sres->HasError() && sres->RowCount() > 0) {
-			auto sv = sres->GetValue(0, 0);
-			poll_state = sv.IsNull() ? string() : sv.ToString();
+		// One log entry per poll, written once the poll's outcome is known, so a poll is never recorded as 'ok'
+		// only to fail validation a few lines later. The catch also covers the 'failed' and timeout throws.
+		bool ready = false;
+		try {
+			auto sres = con.Query(status_sql);
+			if (sres->HasError()) {
+				throw IOException("create_external_resource: status function \"%s\" failed: %s", type->status_function,
+				                  sres->GetError());
+			}
+			if (sres->RowCount() == 0) {
+				throw InvalidInputException("create_external_resource: status function \"%s\" returned no rows",
+				                            type->status_function);
+			}
+			auto state_val = sres->GetValue(0, 0);
+			auto status_state = state_val.IsNull() ? string() : state_val.ToString();
+			if (status_state == "failed") {
+				throw IOException("create_external_resource: resource \"%s\" reported state 'failed'",
+				                  bind_data.type_name);
+			}
+			if (status_state == "ready") {
+				status_result = RequireResourceMap(sres->GetValue(1, 0), type->status_function, "result");
+				ready = true;
+			} else if (has_deadline && std::chrono::steady_clock::now() >= deadline) {
+				throw IOException("create_external_resource: timed out awaiting readiness for \"%s\" (last state '%s')",
+				                  bind_data.type_name, status_state);
+			}
+			LogExternalResourceOperation(context, bind_data.type_name, bind_data.resource_name, "status", string(),
+			                             status_state.empty() ? NoExtraInfo() : ExtraInfo("state", status_state));
+		} catch (std::exception &ex) {
+			LogExternalResourceOperation(context, bind_data.type_name, bind_data.resource_name, "status",
+			                             ErrorData(ex).RawMessage(), NoExtraInfo());
+			throw;
 		}
-		LogExternalResourceOperation(context, bind_data.type_name, bind_data.resource_name, "status",
-		                             sres->HasError() ? sres->GetError() : string(),
-		                             poll_state.empty() ? NoExtraInfo() : ExtraInfo("state", poll_state));
-		if (sres->HasError()) {
-			throw IOException("create_external_resource: status function \"%s\" failed: %s", type->status_function,
-			                  sres->GetError());
-		}
-		if (sres->RowCount() == 0) {
-			throw InvalidInputException("create_external_resource: status function \"%s\" returned no rows",
-			                            type->status_function);
-		}
-		auto state_val = sres->GetValue(0, 0);
-		auto status_state = state_val.IsNull() ? string() : state_val.ToString();
-		if (status_state == "ready") {
-			status_result = RequireResourceMap(sres->GetValue(1, 0), type->status_function, "result");
+		if (ready) {
 			break;
-		}
-		if (status_state == "failed") {
-			throw IOException("create_external_resource: resource \"%s\" reported state 'failed'", bind_data.type_name);
-		}
-		if (has_deadline && std::chrono::steady_clock::now() >= deadline) {
-			throw IOException("create_external_resource: timed out awaiting readiness for \"%s\" (last state '%s')",
-			                  bind_data.type_name, status_state);
 		}
 		// Interruptible wait: sleep the poll interval in short slices, checking for cancellation between them.
 		// The slice is small so InterruptCheck() is called often enough to honor max_execution_time promptly
@@ -397,13 +422,17 @@ static void DestroyExternalResourceFunction(ClientContext &context, TableFunctio
 	Connection con(DatabaseInstance::GetDatabase(context));
 	auto sql = "SELECT * FROM " + QualifiedName::Parse(bind_data.deleter_function).ToString() + "(" +
 	           bind_data.deleter_payload.ToSQLString() + ")";
-	auto result = con.Query(sql);
 	// resource_type/name are unknown at this callsite (the deleter binding does not carry them).
-	LogExternalResourceOperation(context, string(), string(), "destroy",
-	                             result->HasError() ? result->GetError() : string(), NoExtraInfo());
-	if (result->HasError()) {
-		throw IOException("destroy_external_resource: deleter function \"%s\" failed: %s", bind_data.deleter_function,
-		                  result->GetError());
+	try {
+		auto result = con.Query(sql);
+		if (result->HasError()) {
+			throw IOException("destroy_external_resource: deleter function \"%s\" failed: %s",
+			                  bind_data.deleter_function, result->GetError());
+		}
+		LogExternalResourceOperation(context, string(), string(), "destroy", string(), NoExtraInfo());
+	} catch (std::exception &ex) {
+		LogExternalResourceOperation(context, string(), string(), "destroy", ErrorData(ex).RawMessage(), NoExtraInfo());
+		throw;
 	}
 	output.data[0].Append(Value::BOOLEAN(true));
 	state.done = true;

--- a/src/function/table/system/external_resources.cpp
+++ b/src/function/table/system/external_resources.cpp
@@ -108,6 +108,9 @@ static unique_ptr<FunctionData> RegisterExternalResourceBind(ClientContext &cont
                                                              vector<LogicalType> &return_types, vector<string> &names) {
 	auto result = make_uniq<RegisterExternalResourceBindData>();
 	auto &resource = result->resource;
+	if (input.inputs[0].IsNull() || input.inputs[1].IsNull()) {
+		throw InvalidInputException("register_external_resource: the type and name must not be NULL");
+	}
 	resource.type = StringValue::Get(input.inputs[0]);
 	resource.name = StringValue::Get(input.inputs[1]);
 	// The handle is the durable identity and doubles as the deleter payload.
@@ -123,7 +126,12 @@ static unique_ptr<FunctionData> RegisterExternalResourceBind(ClientContext &cont
 		} else if (key == "attached_db_type") {
 			resource.attached_db_type = StringValue::Get(np.second);
 		} else if (key == "deleter_function") {
-			resource.deleter_function = StringValue::Get(np.second);
+			// Qualify against the registering connection's search path: teardown runs the deleter on a separate
+			// internal connection. Fall back to the name as given when it does not resolve (yet) - the defining
+			// extension may not be loaded at registration time.
+			auto deleter = StringValue::Get(np.second);
+			auto qualified = QualifyTableCallback(context, deleter);
+			resource.deleter_function = qualified.empty() ? deleter : qualified;
 		}
 	}
 	return_types.emplace_back(LogicalType::BOOLEAN);

--- a/src/function/table/system/external_resources.cpp
+++ b/src/function/table/system/external_resources.cpp
@@ -1,0 +1,215 @@
+#include "duckdb/function/table/system_functions.hpp"
+
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/types/value.hpp"
+#include "duckdb/main/external_resources_manager.hpp"
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// duckdb_external_resources()
+//
+// Lists the external resources locally registered in this instance's ExternalResourcesManager
+// (managed = true).
+//===--------------------------------------------------------------------===//
+
+struct ExternalResourceRow {
+	string name;
+	string type;
+	Value handle;
+	string uri;
+	string attached_db_type;
+	bool managed;
+};
+
+struct ExternalResourcesGlobalState : public GlobalTableFunctionState {
+	ExternalResourcesGlobalState() : offset(0) {
+	}
+	vector<ExternalResourceRow> rows;
+	idx_t offset;
+};
+
+static unique_ptr<FunctionData> ExternalResourcesBind(ClientContext &context, TableFunctionBindInput &input,
+                                                      vector<LogicalType> &return_types, vector<string> &names) {
+	names.emplace_back("name");
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("type");
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("managed");
+	return_types.emplace_back(LogicalType::BOOLEAN);
+	names.emplace_back("uri");
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("attached_db_type");
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("handle");
+	return_types.emplace_back(LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR));
+	return nullptr;
+}
+
+static unique_ptr<GlobalTableFunctionState> ExternalResourcesInit(ClientContext &context,
+                                                                  TableFunctionInitInput &input) {
+	auto result = make_uniq<ExternalResourcesGlobalState>();
+	// Locally registered resources — always shown (managed = true).
+	for (auto &instance : ExternalResourcesManager::Get(context).List()) {
+		ExternalResourceRow row;
+		row.name = instance.name;
+		row.type = instance.type;
+		row.handle = instance.handle;
+		row.uri = instance.uri;
+		row.attached_db_type = instance.attached_db_type;
+		row.managed = true;
+		result->rows.push_back(std::move(row));
+	}
+	return std::move(result);
+}
+
+static Value NullableString(const string &s) {
+	return s.empty() ? Value(LogicalType::VARCHAR) : Value(s);
+}
+
+static void ExternalResourcesFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &state = data_p.global_state->Cast<ExternalResourcesGlobalState>();
+	auto empty_handle = Value(LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR));
+	idx_t count = 0;
+	while (state.offset < state.rows.size() && count < STANDARD_VECTOR_SIZE) {
+		auto &r = state.rows[state.offset++];
+		output.data[0].Append(NullableString(r.name));
+		output.data[1].Append(Value(r.type));
+		output.data[2].Append(Value::BOOLEAN(r.managed));
+		output.data[3].Append(NullableString(r.uri));
+		output.data[4].Append(NullableString(r.attached_db_type));
+		output.data[5].Append(r.handle.IsNull() ? empty_handle : r.handle);
+		count++;
+	}
+}
+
+void DuckDBExternalResourcesFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(TableFunction("duckdb_external_resources", {}, ExternalResourcesFunction, ExternalResourcesBind,
+	                              ExternalResourcesInit));
+}
+
+//===--------------------------------------------------------------------===//
+// register_external_resource(type, name, handle, uri := , attached_db_type := , deleter_function := )
+//
+// Registry write: record an already-provisioned resource in this instance's ExternalResourcesManager under
+// `name`, so it shows up in duckdb_external_resources() and can be torn down later. Pure — it provisions
+// nothing; feed it the result of create_external_resource(). The durable identity is (type, handle).
+//===--------------------------------------------------------------------===//
+
+struct RegisterExternalResourceBindData : public TableFunctionData {
+	ExternalResource resource;
+};
+
+struct RegisterExternalResourceState : public GlobalTableFunctionState {
+	bool done = false;
+};
+
+static unique_ptr<FunctionData> RegisterExternalResourceBind(ClientContext &context, TableFunctionBindInput &input,
+                                                             vector<LogicalType> &return_types, vector<string> &names) {
+	auto result = make_uniq<RegisterExternalResourceBindData>();
+	auto &resource = result->resource;
+	resource.type = StringValue::Get(input.inputs[0]);
+	resource.name = StringValue::Get(input.inputs[1]);
+	// The handle is the durable identity and doubles as the deleter payload.
+	resource.handle = input.inputs[2];
+	resource.deleter_payload = input.inputs[2];
+	for (auto &np : input.named_parameters) {
+		auto key = StringUtil::Lower(np.first.GetIdentifierName());
+		if (np.second.IsNull()) {
+			continue;
+		}
+		if (key == "uri") {
+			resource.uri = StringValue::Get(np.second);
+		} else if (key == "attached_db_type") {
+			resource.attached_db_type = StringValue::Get(np.second);
+		} else if (key == "deleter_function") {
+			resource.deleter_function = StringValue::Get(np.second);
+		}
+	}
+	return_types.emplace_back(LogicalType::BOOLEAN);
+	names.emplace_back("Success");
+	return std::move(result);
+}
+
+static unique_ptr<GlobalTableFunctionState> RegisterExternalResourceInit(ClientContext &context,
+                                                                         TableFunctionInitInput &input) {
+	return make_uniq<RegisterExternalResourceState>();
+}
+
+static void RegisterExternalResourceFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &state = data_p.global_state->Cast<RegisterExternalResourceState>();
+	if (state.done) {
+		return;
+	}
+	auto &bind_data = data_p.bind_data->Cast<RegisterExternalResourceBindData>();
+	// Add() validates name/type are non-empty and rejects a duplicate name.
+	ExternalResourcesManager::Get(context).Add(bind_data.resource);
+	output.data[0].Append(Value::BOOLEAN(true));
+	state.done = true;
+}
+
+void RegisterExternalResourceFun::RegisterFunction(BuiltinFunctions &set) {
+	TableFunction fn(
+	    "register_external_resource",
+	    {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR)},
+	    RegisterExternalResourceFunction, RegisterExternalResourceBind, RegisterExternalResourceInit);
+	fn.named_parameters["uri"] = LogicalType::VARCHAR;
+	fn.named_parameters["attached_db_type"] = LogicalType::VARCHAR;
+	fn.named_parameters["deleter_function"] = LogicalType::VARCHAR;
+	set.AddFunction(fn);
+}
+
+//===--------------------------------------------------------------------===//
+// deregister_external_resource(name)
+//
+// Registry write: forget a locally registered resource (ExternalResourcesManager::Remove). Does NOT tear
+// the resource down — that is destroy_external_resource's job. Throws if `name` is not registered.
+//===--------------------------------------------------------------------===//
+
+struct DeregisterExternalResourceBindData : public TableFunctionData {
+	string name;
+};
+
+struct DeregisterExternalResourceState : public GlobalTableFunctionState {
+	bool done = false;
+};
+
+static unique_ptr<FunctionData> DeregisterExternalResourceBind(ClientContext &context, TableFunctionBindInput &input,
+                                                               vector<LogicalType> &return_types,
+                                                               vector<string> &names) {
+	auto result = make_uniq<DeregisterExternalResourceBindData>();
+	if (input.inputs[0].IsNull() || StringValue::Get(input.inputs[0]).empty()) {
+		throw InvalidInputException("deregister_external_resource: the name must not be NULL or empty");
+	}
+	result->name = StringValue::Get(input.inputs[0]);
+	return_types.emplace_back(LogicalType::BOOLEAN);
+	names.emplace_back("Success");
+	return std::move(result);
+}
+
+static unique_ptr<GlobalTableFunctionState> DeregisterExternalResourceInit(ClientContext &context,
+                                                                           TableFunctionInitInput &input) {
+	return make_uniq<DeregisterExternalResourceState>();
+}
+
+static void DeregisterExternalResourceFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &state = data_p.global_state->Cast<DeregisterExternalResourceState>();
+	if (state.done) {
+		return;
+	}
+	auto &bind_data = data_p.bind_data->Cast<DeregisterExternalResourceBindData>();
+	auto removed = ExternalResourcesManager::Get(context).Remove(bind_data.name);
+	if (!removed) {
+		throw InvalidInputException("deregister_external_resource: \"%s\" is not registered", bind_data.name);
+	}
+	output.data[0].Append(Value::BOOLEAN(true));
+	state.done = true;
+}
+
+void DeregisterExternalResourceFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(TableFunction("deregister_external_resource", {LogicalType::VARCHAR},
+	                              DeregisterExternalResourceFunction, DeregisterExternalResourceBind,
+	                              DeregisterExternalResourceInit));
+}
+
+} // namespace duckdb

--- a/src/function/table/system_functions.cpp
+++ b/src/function/table/system_functions.cpp
@@ -36,7 +36,10 @@ void BuiltinFunctions::RegisterSQLiteFunctions() {
 	RegisterExternalResourceTypeFun::RegisterFunction(*this);
 	CreateExternalResourceFun::RegisterFunction(*this);
 	DestroyExternalResourceFun::RegisterFunction(*this);
+	RegisterExternalResourceFun::RegisterFunction(*this);
+	DeregisterExternalResourceFun::RegisterFunction(*this);
 	DuckDBExternalResourceTypesFun::RegisterFunction(*this);
+	DuckDBExternalResourcesFun::RegisterFunction(*this);
 	DuckDBMemoryFun::RegisterFunction(*this);
 	DuckDBEvictionQueuesFun::RegisterFunction(*this);
 	DuckDBExternalFileCacheFun::RegisterFunction(*this);

--- a/src/include/duckdb/function/table/system_functions.hpp
+++ b/src/include/duckdb/function/table/system_functions.hpp
@@ -100,7 +100,19 @@ struct DestroyExternalResourceFun {
 	static void RegisterFunction(BuiltinFunctions &set);
 };
 
+struct RegisterExternalResourceFun {
+	static void RegisterFunction(BuiltinFunctions &set);
+};
+
+struct DeregisterExternalResourceFun {
+	static void RegisterFunction(BuiltinFunctions &set);
+};
+
 struct DuckDBExternalResourceTypesFun {
+	static void RegisterFunction(BuiltinFunctions &set);
+};
+
+struct DuckDBExternalResourcesFun {
 	static void RegisterFunction(BuiltinFunctions &set);
 };
 

--- a/src/include/duckdb/logging/log_type.hpp
+++ b/src/include/duckdb/logging/log_type.hpp
@@ -196,4 +196,19 @@ public:
 	static string ConstructLogMessage(const string &pool, idx_t task_count);
 };
 
+class ExternalResourceLogType : public LogType {
+public:
+	static constexpr const char *NAME = "ExternalResource";
+	static constexpr LogLevel LEVEL = LogLevel::LOG_INFO;
+
+	ExternalResourceLogType();
+
+	static LogicalType GetLogType();
+
+	//! One recipe callback invocation (create/status/destroy), logged on response. `error` is empty on
+	//! success (rendered NULL); `resource_name` is empty for an anonymous resource (rendered NULL).
+	static string ConstructLogMessage(const string &resource_type, const string &resource_name, const string &operation,
+	                                  const string &error, const Value &extra_info);
+};
+
 } // namespace duckdb

--- a/src/include/duckdb/main/database.hpp
+++ b/src/include/duckdb/main/database.hpp
@@ -22,6 +22,7 @@ class LocalDatabaseFileSystem;
 class BufferManager;
 class DatabaseManager;
 class ExternalResourceTypeRegistry;
+class ExternalResourcesManager;
 class StorageManager;
 class Catalog;
 class TransactionManager;
@@ -56,6 +57,7 @@ public:
 	DUCKDB_API const BufferManager &GetBufferManager() const;
 	DUCKDB_API DatabaseManager &GetDatabaseManager();
 	DUCKDB_API ExternalResourceTypeRegistry &GetExternalResourceTypeRegistry();
+	DUCKDB_API ExternalResourcesManager &GetExternalResourcesManager();
 	DUCKDB_API FileSystem &GetFileSystem();
 	DUCKDB_API FileSystem &GetLocalFileSystem();
 	DUCKDB_API ExternalFileCache &GetExternalFileCache();
@@ -97,6 +99,7 @@ private:
 	shared_ptr<BufferManager> buffer_manager;
 	unique_ptr<DatabaseManager> db_manager;
 	unique_ptr<ExternalResourceTypeRegistry> external_resource_type_registry;
+	unique_ptr<ExternalResourcesManager> external_resources_manager;
 	unique_ptr<TaskScheduler> scheduler;
 	unique_ptr<ObjectCache> object_cache;
 	unique_ptr<ConnectionManager> connection_manager;

--- a/src/include/duckdb/main/external_resources_manager.hpp
+++ b/src/include/duckdb/main/external_resources_manager.hpp
@@ -47,6 +47,8 @@ string QualifyTableCallback(ClientContext &context, const string &name);
 //! In-memory, instance-scoped manager of external resource instances (shared across connections). The
 //! external resources themselves are durable, but this manager is not: it is the instance's local view of
 //! what it manages, rebuilt across restarts via REGISTER. A name is claimed by its first registration.
+//! Deliberately not transactional: the resource exists out in the world whether or not the transaction that
+//! registered it commits, so dropping the record on rollback would strand it with nothing left to reap it.
 class ExternalResourcesManager {
 public:
 	static ExternalResourcesManager &Get(DatabaseInstance &db);

--- a/src/include/duckdb/main/external_resources_manager.hpp
+++ b/src/include/duckdb/main/external_resources_manager.hpp
@@ -1,0 +1,60 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/main/external_resources_manager.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/mutex.hpp"
+#include "duckdb/common/types/value.hpp"
+#include "duckdb/common/vector.hpp"
+
+namespace duckdb {
+class DatabaseInstance;
+class ClientContext;
+
+//! A provisioned external resource this instance owns, registered under a local name (from CREATE/REGISTER
+//! EXTERNAL RESOURCE). The durable identity is `(type, handle)`: everything else is the binding derived
+//! from it by the type's status/destroy callbacks and cached here for display + teardown. Parallels
+//! ExternalResourceType (the recipe) — this is one provisioned instance of it.
+struct ExternalResource {
+	//! The local registration name (e.g. `yoooo`).
+	string name;
+	//! The resource type (provider) that provisioned it — the key into the type registry.
+	string type;
+	//! Opaque create handle: the resource's identity, passed back to status/destroy.
+	Value handle;
+	//! Endpoint + db type from the ready status result (for display / later ATTACH). May be empty.
+	string uri;
+	string attached_db_type;
+	//! Deleter binding for teardown: `<deleter_function>(<deleter_payload>)`. deleter_payload is the handle.
+	string deleter_function;
+	Value deleter_payload;
+};
+
+//! In-memory, instance-scoped manager of external resource instances (shared across connections). The
+//! external resources themselves are durable, but this manager is not: it is the instance's local view of
+//! what it manages, rebuilt across restarts via REGISTER. A name is claimed by its first registration.
+class ExternalResourcesManager {
+public:
+	static ExternalResourcesManager &Get(DatabaseInstance &db);
+	static ExternalResourcesManager &Get(ClientContext &context);
+
+	//! Register an instance. Throws if the name is already registered.
+	void Add(ExternalResource instance);
+	//! Remove the instance with the given name. Returns it if present, nullptr otherwise.
+	unique_ptr<ExternalResource> Remove(const string &name);
+	//! The registered instance with the given name, or nullptr if none.
+	unique_ptr<ExternalResource> Lookup(const string &name) const;
+	//! Snapshot of all registered instances, in registration order.
+	vector<ExternalResource> List() const;
+
+private:
+	mutable mutex lock;
+	vector<ExternalResource> instances;
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/main/external_resources_manager.hpp
+++ b/src/include/duckdb/main/external_resources_manager.hpp
@@ -21,7 +21,7 @@ class ClientContext;
 //! from it by the type's status/destroy callbacks and cached here for display + teardown. Parallels
 //! ExternalResourceType (the recipe) — this is one provisioned instance of it.
 struct ExternalResource {
-	//! The local registration name (e.g. `yoooo`).
+	//! The local registration name.
 	string name;
 	//! The resource type (provider) that provisioned it — the key into the type registry.
 	string type;
@@ -31,6 +31,7 @@ struct ExternalResource {
 	string uri;
 	string attached_db_type;
 	//! Deleter binding for teardown: `<deleter_function>(<deleter_payload>)`. deleter_payload is the handle.
+	//! Stored fully qualified where possible, see QualifyTableCallback.
 	string deleter_function;
 	Value deleter_payload;
 };

--- a/src/include/duckdb/main/external_resources_manager.hpp
+++ b/src/include/duckdb/main/external_resources_manager.hpp
@@ -16,10 +16,12 @@ namespace duckdb {
 class DatabaseInstance;
 class ClientContext;
 
-//! A provisioned external resource this instance owns, registered under a local name (from CREATE/REGISTER
-//! EXTERNAL RESOURCE). The durable identity is `(type, handle)`: everything else is the binding derived
-//! from it by the type's status/destroy callbacks and cached here for display + teardown. Parallels
-//! ExternalResourceType (the recipe) — this is one provisioned instance of it.
+//! An external resource this instance tracks, registered under a local name (from CREATE/REGISTER EXTERNAL
+//! RESOURCE). `name` is the local alias and the only key enforced here: `(type, handle)` identifies the
+//! external thing, but the handle is opaque - two different maps may well denote the same resource, and only
+//! the provider could say, at the cost of a round-trip that is not always possible. The rest is the binding
+//! kept for display + teardown: from the type's status callback on create, from the caller on register.
+//! Parallels ExternalResourceType (the recipe) — one provisioned instance of it.
 struct ExternalResource {
 	//! The local registration name.
 	string name;

--- a/src/include/duckdb/main/external_resources_manager.hpp
+++ b/src/include/duckdb/main/external_resources_manager.hpp
@@ -35,6 +35,12 @@ struct ExternalResource {
 	Value deleter_payload;
 };
 
+//! Resolve a table-producing callback (a table function or table macro) to its fully-qualified
+//! `catalog.schema.name` in `context`'s search path, so it stays resolvable from any other connection later:
+//! teardown runs the deleter on a separate internal connection, under a search path that need not match the
+//! one in effect at registration. Returns empty if the callback cannot be resolved.
+string QualifyTableCallback(ClientContext &context, const string &name);
+
 //! In-memory, instance-scoped manager of external resource instances (shared across connections). The
 //! external resources themselves are durable, but this manager is not: it is the instance's local view of
 //! what it manages, rebuilt across restarts via REGISTER. A name is claimed by its first registration.

--- a/src/logging/log_manager.cpp
+++ b/src/logging/log_manager.cpp
@@ -284,6 +284,7 @@ void LogManager::RegisterDefaultLogTypes() {
 	RegisterLogType(make_uniq<AdaptiveFilterLogType>());
 	RegisterLogType(make_uniq<ParquetPrefetchLogType>());
 	RegisterLogType(make_uniq<AsyncTaskScheduleLogType>());
+	RegisterLogType(make_uniq<ExternalResourceLogType>());
 }
 
 } // namespace duckdb

--- a/src/logging/log_types.cpp
+++ b/src/logging/log_types.cpp
@@ -360,4 +360,39 @@ string AsyncTaskScheduleLogType::ConstructLogMessage(const string &pool, idx_t t
 	return Value::STRUCT(std::move(child_list)).ToString();
 }
 
+//===--------------------------------------------------------------------===//
+// ExternalResourceLogType
+//===--------------------------------------------------------------------===//
+ExternalResourceLogType::ExternalResourceLogType() : LogType(NAME, LEVEL, GetLogType()) {
+}
+
+LogicalType ExternalResourceLogType::GetLogType() {
+	child_list_t<LogicalType> child_list = {
+	    {"resource_type", LogicalType::VARCHAR},
+	    {"resource_name", LogicalType::VARCHAR},
+	    {"operation", LogicalType::VARCHAR},
+	    {"outcome", LogicalType::VARCHAR},
+	    {"error", LogicalType::VARCHAR},
+	    {"extra_info", LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR)},
+	};
+	return LogicalType::STRUCT(child_list);
+}
+
+string ExternalResourceLogType::ConstructLogMessage(const string &resource_type, const string &resource_name,
+                                                    const string &operation, const string &error,
+                                                    const Value &extra_info) {
+	auto nullable = [](const string &s) {
+		return s.empty() ? Value(LogicalType::VARCHAR) : Value(s);
+	};
+	child_list_t<Value> child_list = {
+	    {"resource_type", nullable(resource_type)},
+	    {"resource_name", nullable(resource_name)},
+	    {"operation", Value(operation)},
+	    {"outcome", Value(error.empty() ? "ok" : "error")},
+	    {"error", nullable(error)},
+	    {"extra_info", extra_info},
+	};
+	return Value::STRUCT(std::move(child_list)).ToString();
+}
+
 } // namespace duckdb

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -43,6 +43,7 @@ add_library_unity(
   db_instance_cache.cpp
   error_manager.cpp
   external_resource_type_registry.cpp
+  external_resources_manager.cpp
   extension.cpp
   extension_callback_manager.cpp
   extension_install_info.cpp

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -21,6 +21,7 @@
 #include "duckdb/main/database_file_path_manager.hpp"
 #include "duckdb/main/database_manager.hpp"
 #include "duckdb/main/external_resource_type_registry.hpp"
+#include "duckdb/main/external_resources_manager.hpp"
 #include "duckdb/main/database_path_and_type.hpp"
 #include "duckdb/main/db_instance_cache.hpp"
 #include "duckdb/main/error_manager.hpp"
@@ -132,6 +133,13 @@ ExternalResourceTypeRegistry &DatabaseInstance::GetExternalResourceTypeRegistry(
 		throw InternalException("Missing external resource type registry");
 	}
 	return *external_resource_type_registry;
+}
+
+ExternalResourcesManager &DatabaseInstance::GetExternalResourcesManager() {
+	if (!external_resources_manager) {
+		throw InternalException("Missing external resources manager");
+	}
+	return *external_resources_manager;
 }
 
 Catalog &Catalog::GetSystemCatalog(DatabaseInstance &db) {
@@ -303,6 +311,7 @@ void DatabaseInstance::Initialize(const char *database_path, DBConfig *user_conf
 	local_db_file_system = make_uniq<LocalDatabaseFileSystem>(*this);
 	db_manager = make_uniq<DatabaseManager>(*this);
 	external_resource_type_registry = make_uniq<ExternalResourceTypeRegistry>();
+	external_resources_manager = make_uniq<ExternalResourcesManager>();
 	if (config.buffer_manager) {
 		buffer_manager = config.buffer_manager;
 	} else {

--- a/src/main/external_resources_manager.cpp
+++ b/src/main/external_resources_manager.cpp
@@ -1,0 +1,60 @@
+#include "duckdb/main/external_resources_manager.hpp"
+
+#include "duckdb/common/exception.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/main/database.hpp"
+
+namespace duckdb {
+
+ExternalResourcesManager &ExternalResourcesManager::Get(DatabaseInstance &db) {
+	return db.GetExternalResourcesManager();
+}
+
+ExternalResourcesManager &ExternalResourcesManager::Get(ClientContext &context) {
+	return ExternalResourcesManager::Get(*context.db);
+}
+
+void ExternalResourcesManager::Add(ExternalResource instance) {
+	if (instance.name.empty()) {
+		throw InvalidInputException("an external resource instance must have a name");
+	}
+	if (instance.type.empty()) {
+		throw InvalidInputException("external resource \"%s\": a type is required", instance.name);
+	}
+	lock_guard<mutex> guard(lock);
+	for (auto &existing : instances) {
+		if (existing.name == instance.name) {
+			throw InvalidInputException("external resource \"%s\" is already registered", instance.name);
+		}
+	}
+	instances.push_back(std::move(instance));
+}
+
+unique_ptr<ExternalResource> ExternalResourcesManager::Remove(const string &name) {
+	lock_guard<mutex> guard(lock);
+	for (idx_t i = 0; i < instances.size(); i++) {
+		if (instances[i].name == name) {
+			auto result = make_uniq<ExternalResource>(std::move(instances[i]));
+			instances.erase(instances.begin() + static_cast<int64_t>(i));
+			return result;
+		}
+	}
+	return nullptr;
+}
+
+unique_ptr<ExternalResource> ExternalResourcesManager::Lookup(const string &name) const {
+	lock_guard<mutex> guard(lock);
+	for (auto &instance : instances) {
+		if (instance.name == name) {
+			return make_uniq<ExternalResource>(instance);
+		}
+	}
+	return nullptr;
+}
+
+vector<ExternalResource> ExternalResourcesManager::List() const {
+	lock_guard<mutex> guard(lock);
+	return instances;
+}
+
+} // namespace duckdb

--- a/src/main/external_resources_manager.cpp
+++ b/src/main/external_resources_manager.cpp
@@ -1,10 +1,28 @@
 #include "duckdb/main/external_resources_manager.hpp"
 
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/catalog/catalog_entry/schema_catalog_entry.hpp"
+#include "duckdb/catalog/entry_lookup_info.hpp"
+#include "duckdb/common/enums/on_entry_not_found.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/database.hpp"
+#include "duckdb/parser/qualified_name.hpp"
 
 namespace duckdb {
+
+string QualifyTableCallback(ClientContext &context, const string &name) {
+	EntryLookupInfo table_fn(CatalogType::TABLE_FUNCTION_ENTRY, QualifiedName::Parse(name));
+	auto entry = Catalog::GetEntry(context, table_fn, OnEntryNotFound::RETURN_NULL);
+	if (!entry) {
+		EntryLookupInfo table_macro(CatalogType::TABLE_MACRO_ENTRY, QualifiedName::Parse(name));
+		entry = Catalog::GetEntry(context, table_macro, OnEntryNotFound::RETURN_NULL);
+	}
+	if (!entry) {
+		return string();
+	}
+	return QualifiedName(entry->ParentCatalog().GetName(), entry->ParentSchema().name, entry->name).ToString();
+}
 
 ExternalResourcesManager &ExternalResourcesManager::Get(DatabaseInstance &db) {
 	return db.GetExternalResourcesManager();

--- a/test/configs/encryption.json
+++ b/test/configs/encryption.json
@@ -33,6 +33,12 @@
       ]
     },
     {
+      "reason": "Calls a deleter by unqualified name: the internal connection running it uses the default catalog, not this config's attached one.",
+      "paths": [
+        "test/sql/table_function/external_resource_logging.test"
+      ]
+    },
+    {
       "reason": "Attached databases have a main schema, which is not implicit.",
       "paths": [
         "test/fuzzer/sqlsmith/current_schemas_null.test"

--- a/test/configs/force_storage_restart.json
+++ b/test/configs/force_storage_restart.json
@@ -10,7 +10,8 @@
       "paths": [
         "test/sql/table_function/external_resource_types.test",
         "test/sql/table_function/create_external_resource.test",
-        "test/sql/table_function/register_external_resource.test"
+        "test/sql/table_function/register_external_resource.test",
+        "test/sql/table_function/external_resource_logging.test"
       ]
     },
     {

--- a/test/configs/force_storage_restart.json
+++ b/test/configs/force_storage_restart.json
@@ -9,7 +9,8 @@
       "reason": "In-memory external resource type registry is instance-scoped and does not survive database restarts.",
       "paths": [
         "test/sql/table_function/external_resource_types.test",
-        "test/sql/table_function/create_external_resource.test"
+        "test/sql/table_function/create_external_resource.test",
+        "test/sql/table_function/register_external_resource.test"
       ]
     },
     {

--- a/test/sql/attach/attach_or_replace.test
+++ b/test/sql/attach/attach_or_replace.test
@@ -54,3 +54,23 @@ ATTACH '{TEST_DIR}/attach_or_replace.db' AS db2;
 statement ok
 SELECT * FROM db2.all_types;
 
+# ATTACH is not transactional: rolling back a transaction that replaced an attachment does not restore
+# the replaced one. The replacement is undone and the original stays detached, so the name is left
+# unattached entirely.
+statement ok
+ATTACH '{TEST_DIR}/attach_or_replace_txn.db' AS db3;
+
+statement ok
+BEGIN;
+
+statement ok
+ATTACH OR REPLACE '{TEST_DIR}/attach_or_replace_txn_new.db' AS db3;
+
+statement ok
+ROLLBACK;
+
+query I
+SELECT count(*) FROM duckdb_databases() WHERE database_name = 'db3';
+----
+0
+

--- a/test/sql/table_function/create_external_resource.test
+++ b/test/sql/table_function/create_external_resource.test
@@ -32,6 +32,13 @@ SELECT result FROM create_external_resource('mock@local');
 ----
 {uri='quack:localhost:9494', attached_db_type=quack, token=t1}
 
+# Supplying `handle :=` skips create and resolves the given handle via status. The returned handle is the
+# provided one (not what create would mint), and the endpoint still comes from the status poll.
+query TT
+SELECT handle, uri FROM create_external_resource('mock@local', handle := MAP {'id': 'adopted'});
+----
+{id=adopted}	quack:localhost:9494
+
 # End-to-end: capture the deleter binding and invoke it.
 statement ok
 SET VARIABLE dfn = (SELECT deleter_function FROM create_external_resource('mock@local'));
@@ -333,7 +340,7 @@ SELECT nextval('prov_count');
 5
 
 # LIMIT 0 runs cleanly; its provisioning is optimizer-dependent (pruned to an empty result with the optimizer,
-# runs once without it), so the count is intentionally not asserted -- use WITH EXTERNAL RESOURCE ... ATTACH
+# runs once without it), so the count is intentionally not asserted -- use ATTACH TO NEW TEMPORARY EXTERNAL RESOURCE
 # when provisioning must be guaranteed.
 statement ok
 SELECT * FROM create_external_resource('pc@local') LIMIT 0;

--- a/test/sql/table_function/external_resource_logging.test
+++ b/test/sql/table_function/external_resource_logging.test
@@ -1,0 +1,114 @@
+# name: test/sql/table_function/external_resource_logging.test
+# description: ExternalResource log entries record the outcome of the operation, not of the callback query
+# group: [table_function]
+
+# Mock recipe callbacks (non-TEMP macros, visible instance-wide to the internal connection).
+statement ok
+CREATE MACRO mock_create(p) AS TABLE SELECT MAP {'id': 'r1'} AS handle;
+
+statement ok
+CREATE MACRO mock_status(h) AS TABLE
+  SELECT 'ready' AS state, MAP {'uri': 'quack:localhost:9494', 'attached_db_type': 'quack'} AS result;
+
+statement ok
+CREATE MACRO mock_destroy(h) AS TABLE SELECT 'ok' AS status;
+
+statement ok
+CALL register_external_resource_type('mock@local', kind := 'catalog', create_function := 'mock_create',
+    status_function := 'mock_status', destroy_function := 'mock_destroy');
+
+statement ok
+CALL enable_logging('ExternalResource');
+
+# A successful create logs its two callback invocations, both without an error.
+statement ok
+SELECT * FROM create_external_resource('mock@local');
+
+query TTT
+SELECT operation, outcome, error IS NULL
+FROM duckdb_logs_parsed('ExternalResource') WHERE resource_type = 'mock@local' ORDER BY operation;
+----
+create	ok	true
+status	ok	true
+
+# The status poll records the observed state.
+query T
+SELECT extra_info['state']
+FROM duckdb_logs_parsed('ExternalResource') WHERE resource_type = 'mock@local' AND operation = 'status';
+----
+ready
+
+# A create whose callback query succeeds but whose result violates the contract is an operation failure:
+# it must not be recorded as 'ok' just because the query itself returned.
+statement ok
+CREATE MACRO scalar_create(p) AS TABLE SELECT 42 AS handle;
+
+statement ok
+CALL register_external_resource_type('scalarcreate@local', kind := 'catalog', create_function := 'scalar_create',
+    status_function := 'mock_status', destroy_function := 'mock_destroy');
+
+statement error
+SELECT * FROM create_external_resource('scalarcreate@local');
+----
+<REGEX>:.*must return a MAP.*
+
+query TT
+SELECT operation, outcome
+FROM duckdb_logs_parsed('ExternalResource') WHERE resource_type = 'scalarcreate@local';
+----
+create	error
+
+# Same for a create callback that returns no rows at all.
+statement ok
+CREATE MACRO empty_create(p) AS TABLE SELECT MAP {'id': 'x'} AS handle WHERE false;
+
+statement ok
+CALL register_external_resource_type('emptycreate@local', kind := 'catalog', create_function := 'empty_create',
+    status_function := 'mock_status', destroy_function := 'mock_destroy');
+
+statement error
+SELECT * FROM create_external_resource('emptycreate@local');
+----
+<REGEX>:.*returned no rows.*
+
+query TT
+SELECT operation, outcome
+FROM duckdb_logs_parsed('ExternalResource') WHERE resource_type = 'emptycreate@local';
+----
+create	error
+
+# A resource reporting 'failed' fails the operation, and the poll that observed it is logged as an error
+# rather than as a successful poll that happened to see a bad state.
+statement ok
+CREATE MACRO failed_status(h) AS TABLE SELECT 'failed' AS state, MAP {'id': 'r1'} AS result;
+
+statement ok
+CALL register_external_resource_type('failed@local', kind := 'catalog', create_function := 'mock_create',
+    status_function := 'failed_status', destroy_function := 'mock_destroy');
+
+statement error
+SELECT * FROM create_external_resource('failed@local');
+----
+<REGEX>:.*'failed'.*
+
+# The log is also the only evidence that the failed create tore its resource back down: create and status
+# are followed by the teardown guard's destroy.
+query TT
+SELECT operation, outcome
+FROM duckdb_logs_parsed('ExternalResource') WHERE resource_type = 'failed@local' ORDER BY operation;
+----
+create	ok
+destroy	ok
+status	error
+
+# With teardown_on_failure disabled, the resource is left behind: no destroy is logged.
+statement error
+SELECT * FROM create_external_resource('failed@local', teardown_on_failure := false);
+----
+<REGEX>:.*'failed'.*
+
+query I
+SELECT count(*)
+FROM duckdb_logs_parsed('ExternalResource') WHERE resource_type = 'failed@local' AND operation = 'destroy';
+----
+1

--- a/test/sql/table_function/external_resource_logging.test
+++ b/test/sql/table_function/external_resource_logging.test
@@ -112,3 +112,20 @@ SELECT count(*)
 FROM duckdb_logs_parsed('ExternalResource') WHERE resource_type = 'failed@local' AND operation = 'destroy';
 ----
 1
+
+# The log envelope: the type is registered under its own name and logs at INFO.
+query TTT
+SELECT DISTINCT type, log_level, scope FROM duckdb_logs_parsed('ExternalResource');
+----
+ExternalResource	INFO	CONNECTION
+
+# destroy_external_resource invokes a deleter binding directly, with no resource it can attribute the call
+# to: both identifying fields render as NULL rather than as empty strings.
+statement ok
+CALL destroy_external_resource('mock_destroy', MAP {'id': 'r1'});
+
+query TTT
+SELECT operation, outcome, resource_name IS NULL
+FROM duckdb_logs_parsed('ExternalResource') WHERE resource_type IS NULL;
+----
+destroy	ok	true

--- a/test/sql/table_function/register_external_resource.test
+++ b/test/sql/table_function/register_external_resource.test
@@ -1,0 +1,72 @@
+# name: test/sql/table_function/register_external_resource.test
+# description: register_external_resource / deregister_external_resource — registry writes into the instance manager
+# group: [table_function]
+
+# A registry that starts empty.
+query I
+SELECT count(*) FROM duckdb_external_resources();
+----
+0
+
+# Register an already-provisioned resource: appears as managed = true, with its cached display fields.
+statement ok
+CALL register_external_resource('mock@local', 'r1', MAP {'id': 'abc'},
+    uri := 'quack:localhost:9494', attached_db_type := 'quack', deleter_function := 'mock_destroy');
+
+query TTTTTT
+SELECT name, type, managed, uri, attached_db_type, handle FROM duckdb_external_resources();
+----
+r1	mock@local	true	quack:localhost:9494	quack	{id=abc}
+
+# The durable identity is (type, handle); the optional fields default to NULL when omitted.
+statement ok
+CALL register_external_resource('mock@local', 'r2', MAP {'id': 'def'});
+
+query TTTT
+SELECT name, uri, attached_db_type, handle FROM duckdb_external_resources() WHERE name = 'r2';
+----
+r2	NULL	NULL	{id=def}
+
+# A name is claimed by its first registration.
+statement error
+CALL register_external_resource('mock@local', 'r1', MAP {'id': 'other'});
+----
+<REGEX>:.*already registered.*
+
+# name and type are both required.
+statement error
+CALL register_external_resource('mock@local', '', MAP {'id': 'x'});
+----
+<REGEX>:.*must have a name.*
+
+statement error
+CALL register_external_resource('', 'r3', MAP {'id': 'x'});
+----
+<REGEX>:.*a type is required.*
+
+# Deregister removes the entry (without tearing the resource down).
+statement ok
+CALL deregister_external_resource('r1');
+
+query I
+SELECT count(*) FROM duckdb_external_resources();
+----
+1
+
+# Deregistering an unknown name is an error.
+statement error
+CALL deregister_external_resource('nope');
+----
+<REGEX>:.*not registered.*
+
+# The name frees up after deregistration and can be reclaimed.
+statement ok
+CALL deregister_external_resource('r2');
+
+statement ok
+CALL register_external_resource('mock@local', 'r1', MAP {'id': 'abc'});
+
+query I
+SELECT count(*) FROM duckdb_external_resources();
+----
+1

--- a/test/sql/table_function/register_external_resource.test
+++ b/test/sql/table_function/register_external_resource.test
@@ -44,6 +44,37 @@ CALL register_external_resource('', 'r3', MAP {'id': 'x'});
 ----
 <REGEX>:.*a type is required.*
 
+# NULL is rejected up front: it would otherwise reach StringValue::Get and surface as an internal error.
+statement error
+CALL register_external_resource(NULL, 'r3', MAP {'id': 'x'});
+----
+<REGEX>:.*must not be NULL.*
+
+statement error
+CALL register_external_resource('mock@local', NULL, MAP {'id': 'x'});
+----
+<REGEX>:.*must not be NULL.*
+
+# A registration survives the rollback of the transaction that made it. This is deliberate, and the opposite
+# of what a catalog entry would do: the resource is already provisioned out in the world, so forgetting the
+# record here would strand it with nothing left to reap it.
+statement ok
+BEGIN;
+
+statement ok
+CALL register_external_resource('mock@local', 'r_txn', MAP {'id': 'txn'});
+
+statement ok
+ROLLBACK;
+
+query I
+SELECT count(*) FROM duckdb_external_resources() WHERE name = 'r_txn';
+----
+1
+
+statement ok
+CALL deregister_external_resource('r_txn');
+
 # Deregister removes the entry (without tearing the resource down).
 statement ok
 CALL deregister_external_resource('r1');


### PR DESCRIPTION
Part 1/4 of https://github.com/duckdb/duckdb/pull/23736

Provision/register/destroy external resources via table functions, improving on existing `src/function/table/system/create_external_resource.cpp`, no new SQL syntax.

### Two registries

**Types** are recipes: a `kind` plus the *names* of lifecycle callbacks (`create`, `status`, `destroy`), resolved lazily when invoked, so an extension can register one without a compiled-in dependency on them. Registration captures the caller's search path, as views and macros do, since the callbacks run later on a different connection.
 - `register_external_resource_type(name, kind := , create_function := , ...)`
 - `duckdb_external_resource_types()`

**Instances** are what this DuckDB instance currently tracks: an in-memory, instance-scoped view, keyed by a local name.
 - `register_external_resource(type, name, handle, uri := , deleter_function := , ...)`
 - `deregister_external_resource(name)` — forgets the record, tears nothing down
 - `duckdb_external_resources()`

### Two operations
 - `create_external_resource(type)` invokes `create`, blocks polling `status` until `ready` (cancellable, `timeout_seconds`-bounded), enforces the catalog baseline (`uri` + `attached_db_type`), and returns a deleter binding. `handle :=` adopts an existing resource instead of provisioning. On failure a guard tears down what we provisioned — but not what we adopted.
 - `destroy_external_resource(deleter_function, payload)` invokes a deleter binding.

Both act on the *world*, not on the registries: creating a resource does not register it, and destroying one does not deregister it. Recording it is a separate, explicit step — which is what lets you register something provisioned elsewhere, or that outlived the process.

Implementation side: callbacks run on a separate internal connection, since the caller's context lock is held — hence non-TEMP callbacks, and fully-qualified callback names.