### PR TITLE
Add logging type to cover all load or install events

### DIFF
--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -653,7 +653,8 @@ String Catalog::AutoloadExtensionByConfigName(ClientContext &context, const Stri
 		auto extension_name =
 		    ExtensionHelper::FindExtensionInEntries(configuration_name.ToStdString(), EXTENSION_SETTINGS);
 		if (ExtensionHelper::CanAutoloadExtension(extension_name)) {
-			ExtensionHelper::AutoLoadExtension(context, extension_name);
+			ExtensionHelper::AutoLoadExtension(context, extension_name,
+			                                   "autoload for setting '" + configuration_name.ToStdString() + "'");
 			return extension_name;
 		}
 	}
@@ -729,7 +730,8 @@ bool Catalog::AutoLoadExtensionByCatalogEntry(DatabaseInstance &db, CatalogType 
 		}
 
 		if (!extension_name.empty() && ExtensionHelper::CanAutoloadExtension(extension_name)) {
-			ExtensionHelper::AutoLoadExtension(db, extension_name);
+			ExtensionHelper::AutoLoadExtension(db, extension_name,
+			                                   "autoload for " + CatalogTypeToString(type) + " '" + entry_name + "'");
 			return true;
 		}
 	}

--- a/src/execution/operator/helper/physical_load.cpp
+++ b/src/execution/operator/helper/physical_load.cpp
@@ -24,6 +24,7 @@ static void InstallFromRepository(ClientContext &context, const LoadInfo &info) 
 	options.throw_on_origin_mismatch = true;
 	options.version = info.version;
 	options.repository = repository;
+	options.reason = "explicit SQL INSTALL statement";
 
 	ExtensionHelper::InstallExtension(context, info.filename, options);
 }
@@ -36,6 +37,7 @@ SourceResultType PhysicalLoad::GetDataInternal(ExecutionContext &context, DataCh
 			options.force_install = info->load_type == LoadType::FORCE_INSTALL;
 			options.throw_on_origin_mismatch = true;
 			options.version = info->version;
+			options.reason = "explicit SQL INSTALL statement";
 			ExtensionHelper::InstallExtension(context.client, info->filename, options);
 		} else {
 			InstallFromRepository(context.client, *info);
@@ -45,6 +47,7 @@ SourceResultType PhysicalLoad::GetDataInternal(ExecutionContext &context, DataCh
 		ExtensionLoadOptions options;
 		options.extension_name = info->filename;
 		options.alias = info->alias;
+		options.reason = "explicit SQL LOAD statement";
 		ExtensionHelper::LoadExternalExtension(context.client, options);
 		// adds an explicitly set extension schema to the search path
 		ExtensionLoader::RefreshSearchPath(context.client);

--- a/src/function/built_in_functions.cpp
+++ b/src/function/built_in_functions.cpp
@@ -118,8 +118,7 @@ static unique_ptr<Expression> BindExtensionFunction(FunctionBindExpressionInput 
 		                      bound_function.GetName(), extension_name);
 	}
 	// auto-load the extension
-	ExtensionHelper::AutoLoadExtension(db, extension_name,
-	                                   "autoload for function '" + bound_function.GetName() + "'");
+	ExtensionHelper::AutoLoadExtension(db, extension_name, "autoload for function '" + bound_function.GetName() + "'");
 
 	// now find the function in the catalog
 	auto &catalog = Catalog::GetSystemCatalog(db);

--- a/src/function/built_in_functions.cpp
+++ b/src/function/built_in_functions.cpp
@@ -118,7 +118,8 @@ static unique_ptr<Expression> BindExtensionFunction(FunctionBindExpressionInput 
 		                      bound_function.GetName(), extension_name);
 	}
 	// auto-load the extension
-	ExtensionHelper::AutoLoadExtension(db, extension_name);
+	ExtensionHelper::AutoLoadExtension(db, extension_name,
+	                                   "autoload for function '" + bound_function.GetName() + "'");
 
 	// now find the function in the catalog
 	auto &catalog = Catalog::GetSystemCatalog(db);

--- a/src/include/duckdb/logging/log_type.hpp
+++ b/src/include/duckdb/logging/log_type.hpp
@@ -221,9 +221,10 @@ public:
 
 	static LogicalType GetLogType();
 
-	//! event is either "load" or "install"
+	//! event is either "load" or "install". A non-empty error indicates the event failed.
 	static string ConstructLogMessage(const char *event, const string &extension_name, const string &version,
-	                                   const string &install_mode, const string &source, const string &reason);
+	                                   const string &install_mode, const string &source, const string &reason,
+	                                   const string &error = "");
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/logging/log_type.hpp
+++ b/src/include/duckdb/logging/log_type.hpp
@@ -211,4 +211,19 @@ public:
 	                                  const string &error, const Value &extra_info);
 };
 
+//! Logs extension LOAD and INSTALL events, including an optional reason describing why they were triggered
+class ExtensionLoadInstallLogType : public LogType {
+public:
+	static constexpr const char *NAME = "ExtensionLoadInstall";
+	static constexpr LogLevel LEVEL = LogLevel::LOG_INFO;
+
+	ExtensionLoadInstallLogType();
+
+	static LogicalType GetLogType();
+
+	//! event is either "load" or "install"
+	static string ConstructLogMessage(const char *event, const string &extension_name, const string &version,
+	                                   const string &install_mode, const string &source, const string &reason);
+};
+
 } // namespace duckdb

--- a/src/include/duckdb/logging/log_type.hpp
+++ b/src/include/duckdb/logging/log_type.hpp
@@ -223,8 +223,8 @@ public:
 
 	//! event is either "load" or "install". A non-empty error indicates the event failed.
 	static string ConstructLogMessage(const char *event, const string &extension_name, const string &version,
-	                                   const string &install_mode, const string &source, const string &reason,
-	                                   const string &error = "");
+	                                  const string &install_mode, const string &source, const string &reason,
+	                                  const string &error = "");
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/main/extension_helper.hpp
+++ b/src/include/duckdb/main/extension_helper.hpp
@@ -91,6 +91,10 @@ struct ExtensionInstallOptions {
 	bool use_etags = false;
 	//! Throw an error when installing an extension with a different origin than the one that is installed
 	bool throw_on_origin_mismatch = false;
+	//! Optional human-readable reason describing why this install was triggered
+	//! (e.g. explicit SQL, or autoinstall of a dependency). Surfaced by the
+	//! ExtensionLoadInstall log type.
+	string reason;
 };
 
 class ExtensionHelper {
@@ -109,12 +113,15 @@ public:
 	static void LoadExternalExtension(DatabaseInstance &db, FileSystem &fs, const ExtensionLoadOptions &options);
 
 	//! Autoload an extension (depending on config, potentially a nop. Throws when installation fails)
-	static void AutoLoadExtension(ClientContext &context, const string &extension_name);
-	static void AutoLoadExtension(DatabaseInstance &db, const string &extension_name);
+	//! The optional reason describes why the autoload was triggered (surfaced by the ExtensionLoadInstall log type)
+	static void AutoLoadExtension(ClientContext &context, const string &extension_name, const string &reason = "");
+	static void AutoLoadExtension(DatabaseInstance &db, const string &extension_name, const string &reason = "");
 
 	//! Autoload an extension (depending on config, potentially a nop. Returns false on failure)
-	DUCKDB_API static bool TryAutoLoadExtension(DatabaseInstance &db, const string &extension_name) noexcept;
-	DUCKDB_API static bool TryAutoLoadExtension(ClientContext &context, const string &extension_name) noexcept;
+	DUCKDB_API static bool TryAutoLoadExtension(DatabaseInstance &db, const string &extension_name,
+	                                            const string &reason = "") noexcept;
+	DUCKDB_API static bool TryAutoLoadExtension(ClientContext &context, const string &extension_name,
+	                                            const string &reason = "") noexcept;
 
 	//! Autoload an extension, only if available locally
 	DUCKDB_API static bool TryAutoLoadAvailableExtension(DatabaseInstance &instance,

--- a/src/include/duckdb/main/extension_load_options.hpp
+++ b/src/include/duckdb/main/extension_load_options.hpp
@@ -21,6 +21,10 @@ struct ExtensionLoadOptions {
 
 	string extension_name;
 	Identifier alias;
+	//! Optional human-readable reason describing why this load was triggered
+	//! (e.g. explicit SQL, or autoload due to a missing function). Surfaced by the
+	//! ExtensionLoadInstall log type.
+	string reason;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/main/extension_manager.hpp
+++ b/src/include/duckdb/main/extension_manager.hpp
@@ -29,9 +29,10 @@ public:
 
 class ExtensionActiveLoad {
 public:
-	ExtensionActiveLoad(DatabaseInstance &db, ExtensionInfo &info, Identifier extension_name_p, Identifier alias_p)
+	ExtensionActiveLoad(DatabaseInstance &db, ExtensionInfo &info, Identifier extension_name_p, Identifier alias_p,
+	                    string reason_p = "")
 	    : db(db), load_lock(info.lock), info(info), extension_name(std::move(extension_name_p)),
-	      alias(std::move(alias_p)) {};
+	      alias(std::move(alias_p)), reason(std::move(reason_p)) {};
 
 	~ExtensionActiveLoad() = default;
 
@@ -40,6 +41,8 @@ public:
 	ExtensionInfo &info;
 	Identifier extension_name;
 	Identifier alias;
+	//! Optional reason describing why this load was triggered
+	string reason;
 
 public:
 	void FinishLoad(ExtensionInstallInfo &install_info);

--- a/src/logging/log_manager.cpp
+++ b/src/logging/log_manager.cpp
@@ -285,6 +285,7 @@ void LogManager::RegisterDefaultLogTypes() {
 	RegisterLogType(make_uniq<ParquetPrefetchLogType>());
 	RegisterLogType(make_uniq<AsyncTaskScheduleLogType>());
 	RegisterLogType(make_uniq<ExternalResourceLogType>());
+	RegisterLogType(make_uniq<ExtensionLoadInstallLogType>());
 }
 
 } // namespace duckdb

--- a/src/logging/log_types.cpp
+++ b/src/logging/log_types.cpp
@@ -387,9 +387,8 @@ ExtensionLoadInstallLogType::ExtensionLoadInstallLogType() : LogType(NAME, LEVEL
 
 LogicalType ExtensionLoadInstallLogType::GetLogType() {
 	child_list_t<LogicalType> child_list = {
-	    {"event", LogicalType::VARCHAR},        {"extension", LogicalType::VARCHAR},
-	    {"version", LogicalType::VARCHAR},      {"install_mode", LogicalType::VARCHAR},
-	    {"source", LogicalType::VARCHAR},       {"reason", LogicalType::VARCHAR},
+	    {"event", LogicalType::VARCHAR},        {"extension", LogicalType::VARCHAR}, {"version", LogicalType::VARCHAR},
+	    {"install_mode", LogicalType::VARCHAR}, {"source", LogicalType::VARCHAR},    {"reason", LogicalType::VARCHAR},
 	    {"error", LogicalType::VARCHAR},
 	};
 	return LogicalType::STRUCT(child_list);
@@ -416,14 +415,13 @@ string ExtensionLoadInstallLogType::ConstructLogMessage(const char *event, const
                                                         const string &version, const string &install_mode,
                                                         const string &source, const string &reason,
                                                         const string &error) {
-	auto or_null = [](const string &value) { return value.empty() ? Value() : Value(value); };
+	auto or_null = [](const string &value) {
+		return value.empty() ? Value() : Value(value);
+	};
 	child_list_t<Value> child_list = {
-	    {"event", Value(event)},
-	    {"extension", or_null(extension_name)},
-	    {"version", or_null(version)},
-	    {"install_mode", or_null(install_mode)},
-	    {"source", or_null(source)},
-	    {"reason", or_null(reason)},
+	    {"event", Value(event)},       {"extension", or_null(extension_name)},
+	    {"version", or_null(version)}, {"install_mode", or_null(install_mode)},
+	    {"source", or_null(source)},   {"reason", or_null(reason)},
 	    {"error", or_null(error)},
 	};
 	return Value::STRUCT(std::move(child_list)).ToString();

--- a/src/logging/log_types.cpp
+++ b/src/logging/log_types.cpp
@@ -390,6 +390,7 @@ LogicalType ExtensionLoadInstallLogType::GetLogType() {
 	    {"event", LogicalType::VARCHAR},        {"extension", LogicalType::VARCHAR},
 	    {"version", LogicalType::VARCHAR},      {"install_mode", LogicalType::VARCHAR},
 	    {"source", LogicalType::VARCHAR},       {"reason", LogicalType::VARCHAR},
+	    {"error", LogicalType::VARCHAR},
 	};
 	return LogicalType::STRUCT(child_list);
 }
@@ -413,7 +414,8 @@ string ExternalResourceLogType::ConstructLogMessage(const string &resource_type,
 
 string ExtensionLoadInstallLogType::ConstructLogMessage(const char *event, const string &extension_name,
                                                         const string &version, const string &install_mode,
-                                                        const string &source, const string &reason) {
+                                                        const string &source, const string &reason,
+                                                        const string &error) {
 	auto or_null = [](const string &value) { return value.empty() ? Value() : Value(value); };
 	child_list_t<Value> child_list = {
 	    {"event", Value(event)},
@@ -422,6 +424,7 @@ string ExtensionLoadInstallLogType::ConstructLogMessage(const char *event, const
 	    {"install_mode", or_null(install_mode)},
 	    {"source", or_null(source)},
 	    {"reason", or_null(reason)},
+	    {"error", or_null(error)},
 	};
 	return Value::STRUCT(std::move(child_list)).ToString();
 }

--- a/src/logging/log_types.cpp
+++ b/src/logging/log_types.cpp
@@ -22,6 +22,7 @@ constexpr LogLevel CheckpointLogType::LEVEL;
 constexpr LogLevel AdaptiveFilterLogType::LEVEL;
 constexpr LogLevel ParquetPrefetchLogType::LEVEL;
 constexpr LogLevel AsyncTaskScheduleLogType::LEVEL;
+constexpr LogLevel ExtensionLoadInstallLogType::LEVEL;
 
 //===--------------------------------------------------------------------===//
 // QueryLogType
@@ -378,6 +379,21 @@ LogicalType ExternalResourceLogType::GetLogType() {
 	return LogicalType::STRUCT(child_list);
 }
 
+//===--------------------------------------------------------------------===//
+// ExtensionLoadInstallLogType
+//===--------------------------------------------------------------------===//
+ExtensionLoadInstallLogType::ExtensionLoadInstallLogType() : LogType(NAME, LEVEL, GetLogType()) {
+}
+
+LogicalType ExtensionLoadInstallLogType::GetLogType() {
+	child_list_t<LogicalType> child_list = {
+	    {"event", LogicalType::VARCHAR},        {"extension", LogicalType::VARCHAR},
+	    {"version", LogicalType::VARCHAR},      {"install_mode", LogicalType::VARCHAR},
+	    {"source", LogicalType::VARCHAR},       {"reason", LogicalType::VARCHAR},
+	};
+	return LogicalType::STRUCT(child_list);
+}
+
 string ExternalResourceLogType::ConstructLogMessage(const string &resource_type, const string &resource_name,
                                                     const string &operation, const string &error,
                                                     const Value &extra_info) {
@@ -391,6 +407,21 @@ string ExternalResourceLogType::ConstructLogMessage(const string &resource_type,
 	    {"outcome", Value(error.empty() ? "ok" : "error")},
 	    {"error", nullable(error)},
 	    {"extra_info", extra_info},
+	};
+	return Value::STRUCT(std::move(child_list)).ToString();
+}
+
+string ExtensionLoadInstallLogType::ConstructLogMessage(const char *event, const string &extension_name,
+                                                        const string &version, const string &install_mode,
+                                                        const string &source, const string &reason) {
+	auto or_null = [](const string &value) { return value.empty() ? Value() : Value(value); };
+	child_list_t<Value> child_list = {
+	    {"event", Value(event)},
+	    {"extension", or_null(extension_name)},
+	    {"version", or_null(version)},
+	    {"install_mode", or_null(install_mode)},
+	    {"source", or_null(source)},
+	    {"reason", or_null(reason)},
 	};
 	return Value::STRUCT(std::move(child_list)).ToString();
 }

--- a/src/main/extension/extension_helper.cpp
+++ b/src/main/extension/extension_helper.cpp
@@ -203,7 +203,8 @@ string ExtensionHelper::AddExtensionInstallHintToErrorMsg(DatabaseInstance &db, 
 	return base_error;
 }
 
-bool ExtensionHelper::TryAutoLoadExtension(ClientContext &context, const string &extension_name) noexcept {
+bool ExtensionHelper::TryAutoLoadExtension(ClientContext &context, const string &extension_name,
+                                          const string &reason) noexcept {
 	if (context.db->ExtensionIsLoaded(extension_name)) {
 		return true;
 	}
@@ -213,9 +214,12 @@ bool ExtensionHelper::TryAutoLoadExtension(ClientContext &context, const string 
 			auto autoinstall_repo = ExtensionRepository::GetRepositoryByUrl(autoinstall_repo_setting);
 			ExtensionInstallOptions options;
 			options.repository = autoinstall_repo;
+			options.reason = reason;
 			ExtensionHelper::InstallExtension(context, extension_name, options);
 		}
-		ExtensionHelper::LoadExternalExtension(context, {extension_name});
+		ExtensionLoadOptions load_options(extension_name);
+		load_options.reason = reason;
+		ExtensionHelper::LoadExternalExtension(context, load_options);
 		return true;
 	} catch (...) {
 		return false;
@@ -230,7 +234,8 @@ static string GetAutoInstallExtensionsRepository(const DBConfig &config) {
 	return repository_url;
 }
 
-bool ExtensionHelper::TryAutoLoadExtension(DatabaseInstance &instance, const string &extension_name) noexcept {
+bool ExtensionHelper::TryAutoLoadExtension(DatabaseInstance &instance, const string &extension_name,
+                                          const string &reason) noexcept {
 	if (instance.ExtensionIsLoaded(extension_name)) {
 		return true;
 	}
@@ -242,10 +247,13 @@ bool ExtensionHelper::TryAutoLoadExtension(DatabaseInstance &instance, const str
 			auto autoinstall_repo = ExtensionRepository::GetRepositoryByUrl(repository_url);
 			ExtensionInstallOptions options;
 			options.repository = autoinstall_repo;
+			options.reason = reason;
 			ExtensionHelper::InstallExtension(instance, fs, extension_name, options);
 		}
 		if (Settings::Get<AutoloadKnownExtensionsSetting>(instance)) {
-			ExtensionHelper::LoadExternalExtension(instance, fs, {extension_name});
+			ExtensionLoadOptions load_options(extension_name);
+			load_options.reason = reason;
+			ExtensionHelper::LoadExternalExtension(instance, fs, load_options);
 			return true;
 		}
 		return false;
@@ -388,11 +396,11 @@ ExtensionUpdateResult ExtensionHelper::UpdateExtension(ClientContext &context, c
 	return update_result;
 }
 
-void ExtensionHelper::AutoLoadExtension(ClientContext &context, const string &extension_name) {
-	return ExtensionHelper::AutoLoadExtension(*context.db, extension_name);
+void ExtensionHelper::AutoLoadExtension(ClientContext &context, const string &extension_name, const string &reason) {
+	return ExtensionHelper::AutoLoadExtension(*context.db, extension_name, reason);
 }
 
-void ExtensionHelper::AutoLoadExtension(DatabaseInstance &db, const string &extension_name) {
+void ExtensionHelper::AutoLoadExtension(DatabaseInstance &db, const string &extension_name, const string &reason) {
 	if (db.ExtensionIsLoaded(extension_name)) {
 		// Avoid downloading again
 		return;
@@ -406,10 +414,13 @@ void ExtensionHelper::AutoLoadExtension(DatabaseInstance &db, const string &exte
 			auto autoinstall_repo = ExtensionRepository::GetRepositoryByUrl(repository_url);
 			ExtensionInstallOptions options;
 			options.repository = autoinstall_repo;
+			options.reason = reason;
 			ExtensionHelper::InstallExtension(db, fs, extension_name, options);
 		}
 #endif
-		ExtensionHelper::LoadExternalExtension(db, fs, {extension_name});
+		ExtensionLoadOptions load_options(extension_name);
+		load_options.reason = reason;
+		ExtensionHelper::LoadExternalExtension(db, fs, load_options);
 		DUCKDB_LOG_INFO(db, "Loaded extension '%s'", extension_name);
 	} catch (std::exception &e) {
 		ErrorData error(e);

--- a/src/main/extension/extension_helper.cpp
+++ b/src/main/extension/extension_helper.cpp
@@ -204,7 +204,7 @@ string ExtensionHelper::AddExtensionInstallHintToErrorMsg(DatabaseInstance &db, 
 }
 
 bool ExtensionHelper::TryAutoLoadExtension(ClientContext &context, const string &extension_name,
-                                          const string &reason) noexcept {
+                                           const string &reason) noexcept {
 	if (context.db->ExtensionIsLoaded(extension_name)) {
 		return true;
 	}
@@ -235,7 +235,7 @@ static string GetAutoInstallExtensionsRepository(const DBConfig &config) {
 }
 
 bool ExtensionHelper::TryAutoLoadExtension(DatabaseInstance &instance, const string &extension_name,
-                                          const string &reason) noexcept {
+                                           const string &reason) noexcept {
 	if (instance.ExtensionIsLoaded(extension_name)) {
 		return true;
 	}

--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -37,6 +37,12 @@ static void LogInstall(DatabaseInstance &db, const string &extension, optional_p
 	           EnumUtil::ToString(info->mode), source, reason);
 }
 
+//! Emit a structured log event for a failed install
+static void LogInstallFailure(DatabaseInstance &db, const string &extension, const string &reason,
+                              const string &error) {
+	DUCKDB_LOG(db, ExtensionLoadInstallLogType, "install", extension, "", "", "", reason, error);
+}
+
 const string ExtensionHelper::NormalizeVersionTag(const string &version_tag) {
 	if (!version_tag.empty() && version_tag[0] != 'v') {
 		return "v" + version_tag;
@@ -212,9 +218,15 @@ unique_ptr<ExtensionInstallInfo> ExtensionHelper::InstallExtension(DatabaseInsta
 	return nullptr;
 #endif
 	string local_path = ExtensionDirectory(db, fs);
-	auto info = InstallExtensionInternal(db, fs, local_path, extension, options);
-	LogInstall(db, ExtensionHelper::GetExtensionName(extension), info, options.reason);
-	return info;
+	auto extension_name = ExtensionHelper::GetExtensionName(extension);
+	try {
+		auto info = InstallExtensionInternal(db, fs, local_path, extension, options);
+		LogInstall(db, extension_name, info, options.reason);
+		return info;
+	} catch (std::exception &ex) {
+		LogInstallFailure(db, extension_name, options.reason, ErrorData(ex).RawMessage());
+		throw;
+	}
 }
 
 unique_ptr<ExtensionInstallInfo> ExtensionHelper::InstallExtension(ClientContext &context, const string &extension,
@@ -226,9 +238,15 @@ unique_ptr<ExtensionInstallInfo> ExtensionHelper::InstallExtension(ClientContext
 	auto &db = DatabaseInstance::GetDatabase(context);
 	auto &fs = FileSystem::GetFileSystem(context);
 	string local_path = ExtensionDirectory(context);
-	auto info = InstallExtensionInternal(db, fs, local_path, extension, options, context);
-	LogInstall(db, ExtensionHelper::GetExtensionName(extension), info, options.reason);
-	return info;
+	auto extension_name = ExtensionHelper::GetExtensionName(extension);
+	try {
+		auto info = InstallExtensionInternal(db, fs, local_path, extension, options, context);
+		LogInstall(db, extension_name, info, options.reason);
+		return info;
+	} catch (std::exception &ex) {
+		LogInstallFailure(db, extension_name, options.reason, ErrorData(ex).RawMessage());
+		throw;
+	}
 }
 
 static unsafe_unique_array<data_t> ReadExtensionFileFromDisk(FileSystem &fs, const string &path, idx_t &file_size) {

--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -33,8 +33,8 @@ static void LogInstall(DatabaseInstance &db, const string &extension, optional_p
 		return;
 	}
 	string source = info->full_path.empty() ? info->repository_url : info->full_path;
-	DUCKDB_LOG(db, ExtensionLoadInstallLogType, "install", extension, info->version,
-	           EnumUtil::ToString(info->mode), source, reason);
+	DUCKDB_LOG(db, ExtensionLoadInstallLogType, "install", extension, info->version, EnumUtil::ToString(info->mode),
+	           source, reason);
 }
 
 //! Emit a structured log event for a failed install

--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -13,6 +13,9 @@
 #include "duckdb/main/secret/secret_manager.hpp"
 #include "duckdb/main/settings.hpp"
 #include "duckdb/common/windows_undefs.hpp"
+#include "duckdb/common/enum_util.hpp"
+#include "duckdb/logging/log_type.hpp"
+#include "duckdb/logging/logger.hpp"
 
 #include <fstream>
 
@@ -21,6 +24,19 @@ namespace duckdb {
 //===--------------------------------------------------------------------===//
 // Install Extension
 //===--------------------------------------------------------------------===//
+
+//! Emit a structured log event for a completed install (no-op when nothing was installed)
+static void LogInstall(DatabaseInstance &db, const string &extension, optional_ptr<ExtensionInstallInfo> info,
+                       const string &reason) {
+	if (!info) {
+		// install was a no-op (e.g. already installed) - nothing to report
+		return;
+	}
+	string source = info->full_path.empty() ? info->repository_url : info->full_path;
+	DUCKDB_LOG(db, ExtensionLoadInstallLogType, "install", extension, info->version,
+	           EnumUtil::ToString(info->mode), source, reason);
+}
+
 const string ExtensionHelper::NormalizeVersionTag(const string &version_tag) {
 	if (!version_tag.empty() && version_tag[0] != 'v') {
 		return "v" + version_tag;
@@ -196,7 +212,9 @@ unique_ptr<ExtensionInstallInfo> ExtensionHelper::InstallExtension(DatabaseInsta
 	return nullptr;
 #endif
 	string local_path = ExtensionDirectory(db, fs);
-	return InstallExtensionInternal(db, fs, local_path, extension, options);
+	auto info = InstallExtensionInternal(db, fs, local_path, extension, options);
+	LogInstall(db, ExtensionHelper::GetExtensionName(extension), info, options.reason);
+	return info;
 }
 
 unique_ptr<ExtensionInstallInfo> ExtensionHelper::InstallExtension(ClientContext &context, const string &extension,
@@ -208,7 +226,9 @@ unique_ptr<ExtensionInstallInfo> ExtensionHelper::InstallExtension(ClientContext
 	auto &db = DatabaseInstance::GetDatabase(context);
 	auto &fs = FileSystem::GetFileSystem(context);
 	string local_path = ExtensionDirectory(context);
-	return InstallExtensionInternal(db, fs, local_path, extension, options, context);
+	auto info = InstallExtensionInternal(db, fs, local_path, extension, options, context);
+	LogInstall(db, ExtensionHelper::GetExtensionName(extension), info, options.reason);
+	return info;
 }
 
 static unsafe_unique_array<data_t> ReadExtensionFileFromDisk(FileSystem &fs, const string &path, idx_t &file_size) {

--- a/src/main/extension/extension_load.cpp
+++ b/src/main/extension/extension_load.cpp
@@ -613,6 +613,7 @@ ExtensionInitResult ExtensionHelper::InitialLoad(DatabaseInstance &db, FileSyste
 		}
 		// the extension load failed - try installing the extension
 		ExtensionInstallOptions options;
+		options.reason = "auto-install of missing extension during LOAD '" + extension + "'";
 		ExtensionHelper::InstallExtension(db, fs, extension, options);
 		// try loading again
 		if (!TryInitialLoad(db, fs, extension, result, error)) {

--- a/src/main/extension_manager.cpp
+++ b/src/main/extension_manager.cpp
@@ -43,6 +43,9 @@ void ExtensionActiveLoad::LoadFail(const ErrorData &error) {
 		ExtensionManager::Get(db).RemoveExtensionInfo(alias.GetIdentifierName());
 	}
 	DUCKDB_LOG_INFO(db, "Failed to load extension '%s': %s", extension_name.GetIdentifierName(), error.Message());
+
+	DUCKDB_LOG(db, ExtensionLoadInstallLogType, "load", extension_name.GetIdentifierName(), "", "", "", reason,
+	           error.Message());
 }
 
 ExtensionManager::ExtensionManager(DatabaseInstance &db) : db(db) {

--- a/src/main/extension_manager.cpp
+++ b/src/main/extension_manager.cpp
@@ -3,6 +3,8 @@
 #include "duckdb/planner/extension_callback.hpp"
 #include "duckdb/main/extension_helper.hpp"
 #include "duckdb/logging/log_manager.hpp"
+#include "duckdb/logging/log_type.hpp"
+#include "duckdb/common/enum_util.hpp"
 
 namespace duckdb {
 
@@ -27,6 +29,9 @@ void ExtensionActiveLoad::FinishLoad(ExtensionInstallInfo &install_info) {
 	}
 
 	DUCKDB_LOG_INFO(db, extension_name.GetIdentifierName());
+
+	DUCKDB_LOG(db, ExtensionLoadInstallLogType, "load", final_extension_name, install_info.version,
+	           EnumUtil::ToString(install_info.mode), install_info.full_path, reason);
 }
 
 void ExtensionActiveLoad::LoadFail(const ErrorData &error) {
@@ -148,7 +153,8 @@ unique_ptr<ExtensionActiveLoad> ExtensionManager::BeginLoad(const ExtensionLoadO
 
 	// we have an extension and we want to try to load it - instantiate the load
 	// we instantiate the ExtensionActiveLoad which also grabs the lock for loading the specific extension
-	auto result = make_uniq<ExtensionActiveLoad>(db, *info, Identifier(original_extension_name), options.alias);
+	auto result =
+	    make_uniq<ExtensionActiveLoad>(db, *info, Identifier(original_extension_name), options.alias, options.reason);
 
 	// we now have a lock for loading the extension
 	// HOWEVER - another thread might have finished loading in the meantime - double check to avoid a double load

--- a/src/planner/binder/tableref/bind_basetableref.cpp
+++ b/src/planner/binder/tableref/bind_basetableref.cpp
@@ -29,14 +29,16 @@ static bool TryLoadExtensionForReplacementScan(ClientContext &context, const str
 
 	for (const auto &entry : EXTENSION_FILE_POSTFIXES) {
 		if (StringUtil::EndsWith(lower_name, entry.name)) {
-			ExtensionHelper::AutoLoadExtension(context, entry.extension);
+			ExtensionHelper::AutoLoadExtension(context, entry.extension,
+			                                   "autoload for replacement scan of '" + table_name + "'");
 			return true;
 		}
 	}
 
 	for (const auto &entry : EXTENSION_FILE_CONTAINS) {
 		if (StringUtil::Contains(lower_name, entry.name)) {
-			ExtensionHelper::AutoLoadExtension(context, entry.extension);
+			ExtensionHelper::AutoLoadExtension(context, entry.extension,
+			                                   "autoload for replacement scan of '" + table_name + "'");
 			return true;
 		}
 	}

--- a/test/sql/logging/extension_load_install_logging.test
+++ b/test/sql/logging/extension_load_install_logging.test
@@ -1,0 +1,51 @@
+# name: test/sql/logging/extension_load_install_logging.test
+# description: LOAD/INSTALL events are surfaced through the ExtensionLoadInstall log type, including the reason
+# group: [logging]
+
+require skip_reload
+
+require notmingw
+
+require allow_unsigned_extensions
+
+statement ok
+CALL enable_logging('ExtensionLoadInstall', storage='memory');
+
+# An explicit INSTALL of an extension file surfaces as a structured log event with a reason
+statement ok
+SET extension_directory='{TEST_DIR}/extension_load_install_logging';
+
+statement ok
+INSTALL '{BUILD_DIRECTORY}/test/extension/loadable_extension_demo.duckdb_extension';
+
+query IIII
+SELECT event, extension, install_mode, reason FROM duckdb_logs_parsed('ExtensionLoadInstall') ORDER BY timestamp
+----
+install	loadable_extension_demo	CUSTOM_PATH	explicit SQL INSTALL statement
+
+statement ok
+CALL truncate_duckdb_logs()
+
+# An explicit LOAD of an extension file surfaces as a structured log event with a reason
+statement ok
+LOAD '{BUILD_DIRECTORY}/test/extension/loadable_extension_demo.duckdb_extension';
+
+query IIII
+SELECT event, extension, install_mode, reason FROM duckdb_logs_parsed('ExtensionLoadInstall') ORDER BY timestamp
+----
+load	loadable_extension_demo	NOT_INSTALLED	explicit SQL LOAD statement
+
+# The full structured type is available (event/extension/version/install_mode/source/reason)
+query I
+SELECT source LIKE '%loadable_extension_demo.duckdb_extension' FROM duckdb_logs_parsed('ExtensionLoadInstall') ORDER BY timestamp
+----
+true
+
+# Reloading an already-loaded extension is a no-op and emits no new event
+statement ok
+LOAD '{BUILD_DIRECTORY}/test/extension/loadable_extension_demo.duckdb_extension';
+
+query I
+SELECT count(*) FROM duckdb_logs_parsed('ExtensionLoadInstall')
+----
+1

--- a/test/sql/logging/extension_load_install_logging.test
+++ b/test/sql/logging/extension_load_install_logging.test
@@ -49,3 +49,31 @@ query I
 SELECT count(*) FROM duckdb_logs_parsed('ExtensionLoadInstall')
 ----
 1
+
+statement ok
+CALL truncate_duckdb_logs()
+
+# A failed LOAD is surfaced with the reason and the error populated
+statement error
+LOAD '{TEST_DIR}/does_not_exist.duckdb_extension';
+----
+not found
+
+query IIII
+SELECT event, extension, reason, error IS NOT NULL FROM duckdb_logs_parsed('ExtensionLoadInstall') ORDER BY timestamp
+----
+load	does_not_exist	explicit SQL LOAD statement	true
+
+statement ok
+CALL truncate_duckdb_logs()
+
+# A failed INSTALL is surfaced with the reason and the error populated
+statement error
+INSTALL '{TEST_DIR}/does_not_exist.duckdb_extension';
+----
+Failed to install
+
+query IIII
+SELECT event, extension, reason, error IS NOT NULL FROM duckdb_logs_parsed('ExtensionLoadInstall') ORDER BY timestamp
+----
+install	does_not_exist	explicit SQL INSTALL statement	true


### PR DESCRIPTION
Adds a new logging type: `ExtensionLoadInstall`

Example:
```sql
CALL enable_logging('ExtensionLoadInstall', storage='stdout');
SET autoload_known_extensions = true;
SET autoinstall_known_extensions = true;
SELECT broadcast('192.168.1.5/24'::inet);
```
```
0	DATABASE					2026-07-18 09:59:44.827796+00	ExtensionLoadInstall	INFO	"{'event': install, 'extension': inet, 'version': NULL, 'install_mode': NULL, 'source': NULL, 'reason': 'autoload for Scalar Function \'broadcast\'', 'error': 'Failed to download extension ""inet"" at URL ""http://extensions.duckdb.org/84d91709cd/osx_arm64/inet.duckdb_extension.gz"" (HTTP 404)
Extension ""inet"" is an existing extension.

For more info, visit https://duckdb.org/docs/current/extensions/troubleshooting?version=84d91709cd&platform=osx_arm64&extension=inet'}"
```

And similarly, on successful INSTALL or LOAD they will also be logged with a `reason`, that can be either of `explicit SQL LOAD statement`, indication of an attempted autoloading, or if done via C++ interface it can be supplied by relevant code bases (for example, extensions). `error` field will be `NULL` on success, or otherwise be the same as the error that would be raised.

This can be in particular handy to explain autoloading / auto-install behaviour I think. Similarly, it can be handy in using the logger to test autoloading and auto-install behaviour (not done as part of this PR).