### PR TITLE
Fix UBSan float-to-integer overflow in cardinality estimation

### DIFF
--- a/src/optimizer/join_order/relation_statistics_helper.cpp
+++ b/src/optimizer/join_order/relation_statistics_helper.cpp
@@ -526,8 +526,17 @@ RelationStats RelationStatisticsHelper::ExtractAggregationStats(LogicalAggregate
 		new_card = MinValue(new_card, static_cast<double>(child_stats.cardinality));
 	}
 
-	// an ungrouped aggregate has 1 row
-	stats.cardinality = aggr.groups.empty() ? 1 : LossyNumericCast<idx_t>(new_card);
+	auto max_idx_double = static_cast<double>(NumericLimits<idx_t>::Maximum());
+	if (aggr.groups.empty()) {
+		// an ungrouped aggregate has 1 row
+		stats.cardinality = 1;
+	} else if (new_card >= max_idx_double) {
+		// Clamp to idx_t maximum to prevent float-to-integer overflow
+		stats.cardinality = NumericLimits<idx_t>::Maximum();
+	} else {
+		stats.cardinality = LossyNumericCast<idx_t>(new_card);
+	}
+
 	stats.column_names = child_stats.column_names;
 	stats.stats_initialized = true;
 	const auto aggr_column_bindings = aggr.GetColumnBindings();
@@ -537,8 +546,9 @@ RelationStats RelationStatisticsHelper::ExtractAggregationStats(LogicalAggregate
 		const auto &binding = aggr_column_bindings[column_index];
 		if (binding.table_index == aggr.group_index && column_index < distinct_counts.size()) {
 			// Group column that we have the HLL of
-			stats.column_distinct_count.emplace_back(LossyNumericCast<idx_t>(distinct_counts[column_index]),
-			                                         DistinctCountSource::HLL);
+			auto dc = distinct_counts[column_index];
+			auto dc_idx = dc >= max_idx_double ? NumericLimits<idx_t>::Maximum() : LossyNumericCast<idx_t>(dc);
+			stats.column_distinct_count.emplace_back(dc_idx, DistinctCountSource::HLL);
 		} else {
 			// Non-group column, or we don't have the HLL
 			stats.column_distinct_count.emplace_back(child_stats.cardinality, DistinctCountSource::CARDINALITY);

--- a/test/optimizer/issue_23842.test
+++ b/test/optimizer/issue_23842.test
@@ -1,0 +1,12 @@
+# name: test/optimizer/issue_23842.test
+# description: UBSan float-to-integer overflow in join-order cardinality estimation
+# group: [optimizer]
+
+statement ok
+CREATE TABLE t AS SELECT 1 FROM range(600);
+
+# The subquery cross-joins t seven times, producing a cardinality estimate of 600^7
+# which exceeds the maximum value of idx_t and would cause a float-to-integer overflow
+# in ExtractAggregationStats without the clamp.
+statement ok
+EXPLAIN SELECT 1 FROM t GROUP BY NULL, (SELECT NULL FROM t,t,t,t,t,t,t);


### PR DESCRIPTION
Fixes #23842

A cross-join of a 600-row table with itself 7 times produces a cardinality estimate of ~2.79×10¹⁹, which exceeds the maximum value of `idx_t` (2⁶⁴ - 1). Casting this `double` to `idx_t` via `LossyNumericCast` is undefined behavior, causing UBSan to crash with `SIGILL`.

The fix clamps the `double` value by checking `>= static_cast<double>(NumericLimits<idx_t>::Maximum())` before the cast, and directly assigning `NumericLimits<idx_t>::Maximum()` when it would overflow. This avoids the cast entirely for out-of-range values.

**Changes:**
- `src/optimizer/join_order/relation_statistics_helper.cpp`: Clamp cardinality and distinct count estimates before `LossyNumericCast<idx_t>` in `ExtractAggregationStats`
- `test/optimizer/issue_23842.test`: Regression test using `EXPLAIN` to exercise the overflow path without executing the massive cross-join