### PR TITLE
fix: correct tpcd typo to tpch in ExtraTests.yml

### DIFF
--- a/.github/workflows/ExtraTests.yml
+++ b/.github/workflows/ExtraTests.yml
@@ -19,7 +19,7 @@ jobs:
     GEN: ninja
     BUILD_BENCHMARK: 1
     BUILD_JEMALLOC: 1
-    CORE_EXTENSIONS: "tpcd;tpcds;httpfs"
+    CORE_EXTENSIONS: "tpch;tpcds;httpfs"
 
   steps:
     - uses: actions/checkout@v6


### PR DESCRIPTION
ExtraTests.yml sets CORE_EXTENSIONS to `tpcd;tpcds;httpfs` but `tpcd` should be `tpch`. This means the TPC-H extension is not built for the regression test job, potentially causing TPC-H dependent tests to be skipped.