### PR TITLE
Optimize GLOB using string stats for row group pruning

### DIFF
--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -162,6 +162,7 @@
 #include "duckdb/optimizer/compressed_materialization.hpp"
 #include "duckdb/optimizer/join_order/relation_statistics_helper.hpp"
 #include "duckdb/optimizer/remove_unused_columns.hpp"
+#include "duckdb/optimizer/rule/like_optimizations.hpp"
 #include "duckdb/parallel/async_result.hpp"
 #include "duckdb/parallel/interrupt.hpp"
 #include "duckdb/parallel/meta_pipeline.hpp"
@@ -4117,6 +4118,24 @@ const char* EnumUtil::ToChars<PartitionedTupleDataType>(PartitionedTupleDataType
 template<>
 PartitionedTupleDataType EnumUtil::FromString<PartitionedTupleDataType>(const char *value) {
 	return static_cast<PartitionedTupleDataType>(StringUtil::StringToEnum(GetPartitionedTupleDataTypeValues(), 2, "PartitionedTupleDataType", value));
+}
+
+const StringUtil::EnumStringLiteral *GetPatternMatchTypeValues() {
+	static constexpr StringUtil::EnumStringLiteral values[] {
+		{ static_cast<uint32_t>(PatternMatchType::LIKE), "LIKE" },
+		{ static_cast<uint32_t>(PatternMatchType::GLOB), "GLOB" }
+	};
+	return values;
+}
+
+template<>
+const char* EnumUtil::ToChars<PatternMatchType>(PatternMatchType value) {
+	return StringUtil::EnumToString(GetPatternMatchTypeValues(), 2, "PatternMatchType", static_cast<uint32_t>(value));
+}
+
+template<>
+PatternMatchType EnumUtil::FromString<PatternMatchType>(const char *value) {
+	return static_cast<PatternMatchType>(StringUtil::StringToEnum(GetPatternMatchTypeValues(), 2, "PatternMatchType", value));
 }
 
 const StringUtil::EnumStringLiteral *GetPendingExecutionResultValues() {

--- a/src/include/duckdb/common/enum_util.hpp
+++ b/src/include/duckdb/common/enum_util.hpp
@@ -378,6 +378,8 @@ enum class PartitionedColumnDataType : uint8_t;
 
 enum class PartitionedTupleDataType : uint8_t;
 
+enum class PatternMatchType : uint8_t;
+
 enum class PendingExecutionResult : uint8_t;
 
 enum class PhysicalOperatorType : uint8_t;
@@ -1095,6 +1097,9 @@ const char* EnumUtil::ToChars<PartitionedColumnDataType>(PartitionedColumnDataTy
 
 template<>
 const char* EnumUtil::ToChars<PartitionedTupleDataType>(PartitionedTupleDataType value);
+
+template<>
+const char* EnumUtil::ToChars<PatternMatchType>(PatternMatchType value);
 
 template<>
 const char* EnumUtil::ToChars<PendingExecutionResult>(PendingExecutionResult value);
@@ -1912,6 +1917,9 @@ PartitionedColumnDataType EnumUtil::FromString<PartitionedColumnDataType>(const 
 
 template<>
 PartitionedTupleDataType EnumUtil::FromString<PartitionedTupleDataType>(const char *value);
+
+template<>
+PatternMatchType EnumUtil::FromString<PatternMatchType>(const char *value);
 
 template<>
 PendingExecutionResult EnumUtil::FromString<PendingExecutionResult>(const char *value);

--- a/src/include/duckdb/optimizer/rule/like_optimizations.hpp
+++ b/src/include/duckdb/optimizer/rule/like_optimizations.hpp
@@ -22,7 +22,7 @@ public:
 	                             bool is_root) override;
 
 	unique_ptr<Expression> ApplyRule(BoundFunctionExpression &expr, const ScalarFunction &function, string pattern,
-	                                 bool is_not_like) const;
+	                                 bool is_not_like, bool is_glob) const;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/optimizer/rule/like_optimizations.hpp
+++ b/src/include/duckdb/optimizer/rule/like_optimizations.hpp
@@ -13,6 +13,8 @@
 
 namespace duckdb {
 
+enum class PatternMatchType : uint8_t { LIKE, GLOB };
+
 // The Like Optimization rule rewrites LIKE to optimized scalar functions (e.g.: prefix, suffix, and contains)
 class LikeOptimizationRule : public Rule {
 public:
@@ -22,7 +24,7 @@ public:
 	                             bool is_root) override;
 
 	unique_ptr<Expression> ApplyRule(BoundFunctionExpression &expr, const ScalarFunction &function, string pattern,
-	                                 bool is_not_like, bool is_glob) const;
+	                                 bool is_not_like, PatternMatchType match_type) const;
 };
 
 } // namespace duckdb

--- a/src/optimizer/rule/like_optimizations.cpp
+++ b/src/optimizer/rule/like_optimizations.cpp
@@ -16,86 +16,113 @@ LikeOptimizationRule::LikeOptimizationRule(ExpressionRewriter &rewriter) : Rule(
 	func->matchers.push_back(make_uniq<ExpressionMatcher>());
 	func->matchers.push_back(make_uniq<ConstantExpressionMatcher>());
 	func->policy = SetMatcher::Policy::ORDERED;
-	// we match on LIKE ("~~") and NOT LIKE ("!~~")
-	func->function = make_uniq<ManyFunctionMatcher>(identifier_set_t {Identifier("!~~"), Identifier("~~")});
+	// we match on LIKE ("~~"), NOT LIKE ("!~~"), GLOB ("~~~"), and NOT GLOB ("!~~~")
+	func->function = make_uniq<ManyFunctionMatcher>(
+	    identifier_set_t {Identifier("!~~"), Identifier("~~"), Identifier("!~~~"), Identifier("~~~")});
 	root = std::move(func);
 }
 
-static bool PatternIsConstant(const string &pattern) {
+static bool PatternIsConstant(const string &pattern, bool is_glob) {
 	for (idx_t i = 0; i < pattern.size(); i++) {
-		if (pattern[i] == '%' || pattern[i] == '_') {
-			return false;
+		if (is_glob) {
+			if (pattern[i] == '*' || pattern[i] == '?' || pattern[i] == '[' || pattern[i] == '\\') {
+				return false;
+			}
+		} else {
+			if (pattern[i] == '%' || pattern[i] == '_') {
+				return false;
+			}
 		}
 	}
 	return true;
 }
 
-static bool PatternIsPrefix(const string &pattern) {
+static bool PatternIsPrefix(const string &pattern, bool is_glob) {
+	char wildcard_any = is_glob ? '*' : '%';
 	idx_t i;
 	for (i = pattern.size(); i > 0; i--) {
-		if (pattern[i - 1] != '%') {
+		if (pattern[i - 1] != wildcard_any) {
 			break;
 		}
 	}
 	if (i == pattern.size()) {
-		// no trailing %
+		// no trailing wildcard
 		// cannot be a prefix
 		return false;
 	}
 	// continue to look in the string
-	// if there is a % or _ in the string (besides at the very end) this is not a prefix match
+	// if there is a wildcard in the string (besides at the very end) this is not a prefix match
 	for (; i > 0; i--) {
-		if (pattern[i - 1] == '%' || pattern[i - 1] == '_') {
-			return false;
+		if (is_glob) {
+			if (pattern[i - 1] == '*' || pattern[i - 1] == '?' || pattern[i - 1] == '[' || pattern[i - 1] == '\\') {
+				return false;
+			}
+		} else {
+			if (pattern[i - 1] == '%' || pattern[i - 1] == '_') {
+				return false;
+			}
 		}
 	}
 	return true;
 }
 
-static bool PatternIsSuffix(const string &pattern) {
+static bool PatternIsSuffix(const string &pattern, bool is_glob) {
+	char wildcard_any = is_glob ? '*' : '%';
 	idx_t i;
 	for (i = 0; i < pattern.size(); i++) {
-		if (pattern[i] != '%') {
+		if (pattern[i] != wildcard_any) {
 			break;
 		}
 	}
 	if (i == 0) {
-		// no leading %
+		// no leading wildcard
 		// cannot be a suffix
 		return false;
 	}
 	// continue to look in the string
-	// if there is a % or _ in the string (besides at the beginning) this is not a suffix match
+	// if there is a wildcard in the string (besides at the beginning) this is not a suffix match
 	for (; i < pattern.size(); i++) {
-		if (pattern[i] == '%' || pattern[i] == '_') {
-			return false;
+		if (is_glob) {
+			if (pattern[i] == '*' || pattern[i] == '?' || pattern[i] == '[' || pattern[i] == '\\') {
+				return false;
+			}
+		} else {
+			if (pattern[i] == '%' || pattern[i] == '_') {
+				return false;
+			}
 		}
 	}
 	return true;
 }
 
-static bool PatternIsContains(const string &pattern) {
+static bool PatternIsContains(const string &pattern, bool is_glob) {
+	char wildcard_any = is_glob ? '*' : '%';
 	idx_t start;
 	idx_t end;
 	for (start = 0; start < pattern.size(); start++) {
-		if (pattern[start] != '%') {
+		if (pattern[start] != wildcard_any) {
 			break;
 		}
 	}
 	for (end = pattern.size(); end > 0; end--) {
-		if (pattern[end - 1] != '%') {
+		if (pattern[end - 1] != wildcard_any) {
 			break;
 		}
 	}
 	if (start == 0 || end == pattern.size()) {
-		// contains requires both a leading AND a trailing %
+		// contains requires both a leading AND a trailing wildcard
 		return false;
 	}
 	// check if there are any other special characters in the string
-	// if there is a % or _ in the string (besides at the beginning/end) this is not a contains match
 	for (idx_t i = start; i < end; i++) {
-		if (pattern[i] == '%' || pattern[i] == '_') {
-			return false;
+		if (is_glob) {
+			if (pattern[i] == '*' || pattern[i] == '?' || pattern[i] == '[' || pattern[i] == '\\') {
+				return false;
+			}
+		} else {
+			if (pattern[i] == '%' || pattern[i] == '_') {
+				return false;
+			}
 		}
 	}
 	return true;
@@ -120,32 +147,34 @@ unique_ptr<Expression> LikeOptimizationRule::Apply(LogicalOperator &op, vector<r
 	D_ASSERT(constant_value.type() == constant_expr.GetReturnType());
 	auto &patt_str = StringValue::Get(constant_value);
 
-	bool is_not_like = root.Function().GetName() == "!~~";
-	if (PatternIsConstant(patt_str)) {
+	bool is_not_like = root.Function().GetName() == "!~~" || root.Function().GetName() == "!~~~";
+	bool is_glob = root.Function().GetName() == "~~~" || root.Function().GetName() == "!~~~";
+	if (PatternIsConstant(patt_str, is_glob)) {
 		// Pattern is constant
 		return BoundComparisonExpression::Create(
 		    is_not_like ? ExpressionType::COMPARE_NOTEQUAL : ExpressionType::COMPARE_EQUAL,
 		    std::move(root.GetChildrenMutable()[0]), std::move(root.GetChildrenMutable()[1]));
-	} else if (PatternIsPrefix(patt_str)) {
+	} else if (PatternIsPrefix(patt_str, is_glob)) {
 		// Prefix LIKE pattern : [^%_]*[%]+, ignoring underscore
-		return ApplyRule(root, PrefixFun::GetFunction(), patt_str, is_not_like);
-	} else if (PatternIsSuffix(patt_str)) {
+		return ApplyRule(root, PrefixFun::GetFunction(), patt_str, is_not_like, is_glob);
+	} else if (PatternIsSuffix(patt_str, is_glob)) {
 		// Suffix LIKE pattern: [%]+[^%_]*, ignoring underscore
-		return ApplyRule(root, SuffixFun::GetFunction(), patt_str, is_not_like);
-	} else if (PatternIsContains(patt_str)) {
+		return ApplyRule(root, SuffixFun::GetFunction(), patt_str, is_not_like, is_glob);
+	} else if (PatternIsContains(patt_str, is_glob)) {
 		// Contains LIKE pattern: [%]+[^%_]*[%]+, ignoring underscore
-		return ApplyRule(root, GetStringContains(), patt_str, is_not_like);
+		return ApplyRule(root, GetStringContains(), patt_str, is_not_like, is_glob);
 	}
 	return nullptr;
 }
 
 unique_ptr<Expression> LikeOptimizationRule::ApplyRule(BoundFunctionExpression &expr, const ScalarFunction &function,
-                                                       string pattern, bool is_not_like) const {
+                                                       string pattern, bool is_not_like, bool is_glob) const {
 	// replace LIKE by an optimized function
 	auto result = function.Bind(GetContext(), std::move(expr.GetChildrenMutable()));
 
-	// removing "%" from the pattern
-	pattern.erase(std::remove(pattern.begin(), pattern.end(), '%'), pattern.end());
+	// removing wildcard from the pattern
+	char wildcard_any = is_glob ? '*' : '%';
+	pattern.erase(std::remove(pattern.begin(), pattern.end(), wildcard_any), pattern.end());
 
 	result->GetChildrenMutable()[1] = make_uniq<BoundConstantExpression>(Value(std::move(pattern)));
 

--- a/src/optimizer/rule/like_optimizations.cpp
+++ b/src/optimizer/rule/like_optimizations.cpp
@@ -22,9 +22,9 @@ LikeOptimizationRule::LikeOptimizationRule(ExpressionRewriter &rewriter) : Rule(
 	root = std::move(func);
 }
 
-static bool PatternIsConstant(const string &pattern, bool is_glob) {
+static bool PatternIsConstant(const string &pattern, PatternMatchType match_type) {
 	for (idx_t i = 0; i < pattern.size(); i++) {
-		if (is_glob) {
+		if (match_type == PatternMatchType::GLOB) {
 			if (pattern[i] == '*' || pattern[i] == '?' || pattern[i] == '[' || pattern[i] == '\\') {
 				return false;
 			}
@@ -37,8 +37,8 @@ static bool PatternIsConstant(const string &pattern, bool is_glob) {
 	return true;
 }
 
-static bool PatternIsPrefix(const string &pattern, bool is_glob) {
-	char wildcard_any = is_glob ? '*' : '%';
+static bool PatternIsPrefix(const string &pattern, PatternMatchType match_type) {
+	char wildcard_any = match_type == PatternMatchType::GLOB ? '*' : '%';
 	idx_t i;
 	for (i = pattern.size(); i > 0; i--) {
 		if (pattern[i - 1] != wildcard_any) {
@@ -53,7 +53,7 @@ static bool PatternIsPrefix(const string &pattern, bool is_glob) {
 	// continue to look in the string
 	// if there is a wildcard in the string (besides at the very end) this is not a prefix match
 	for (; i > 0; i--) {
-		if (is_glob) {
+		if (match_type == PatternMatchType::GLOB) {
 			if (pattern[i - 1] == '*' || pattern[i - 1] == '?' || pattern[i - 1] == '[' || pattern[i - 1] == '\\') {
 				return false;
 			}
@@ -66,8 +66,8 @@ static bool PatternIsPrefix(const string &pattern, bool is_glob) {
 	return true;
 }
 
-static bool PatternIsSuffix(const string &pattern, bool is_glob) {
-	char wildcard_any = is_glob ? '*' : '%';
+static bool PatternIsSuffix(const string &pattern, PatternMatchType match_type) {
+	char wildcard_any = match_type == PatternMatchType::GLOB ? '*' : '%';
 	idx_t i;
 	for (i = 0; i < pattern.size(); i++) {
 		if (pattern[i] != wildcard_any) {
@@ -82,7 +82,7 @@ static bool PatternIsSuffix(const string &pattern, bool is_glob) {
 	// continue to look in the string
 	// if there is a wildcard in the string (besides at the beginning) this is not a suffix match
 	for (; i < pattern.size(); i++) {
-		if (is_glob) {
+		if (match_type == PatternMatchType::GLOB) {
 			if (pattern[i] == '*' || pattern[i] == '?' || pattern[i] == '[' || pattern[i] == '\\') {
 				return false;
 			}
@@ -95,8 +95,8 @@ static bool PatternIsSuffix(const string &pattern, bool is_glob) {
 	return true;
 }
 
-static bool PatternIsContains(const string &pattern, bool is_glob) {
-	char wildcard_any = is_glob ? '*' : '%';
+static bool PatternIsContains(const string &pattern, PatternMatchType match_type) {
+	char wildcard_any = match_type == PatternMatchType::GLOB ? '*' : '%';
 	idx_t start;
 	idx_t end;
 	for (start = 0; start < pattern.size(); start++) {
@@ -115,7 +115,7 @@ static bool PatternIsContains(const string &pattern, bool is_glob) {
 	}
 	// check if there are any other special characters in the string
 	for (idx_t i = start; i < end; i++) {
-		if (is_glob) {
+		if (match_type == PatternMatchType::GLOB) {
 			if (pattern[i] == '*' || pattern[i] == '?' || pattern[i] == '[' || pattern[i] == '\\') {
 				return false;
 			}
@@ -148,32 +148,32 @@ unique_ptr<Expression> LikeOptimizationRule::Apply(LogicalOperator &op, vector<r
 	auto &patt_str = StringValue::Get(constant_value);
 
 	bool is_not_like = root.Function().GetName() == "!~~" || root.Function().GetName() == "!~~~";
-	bool is_glob = root.Function().GetName() == "~~~" || root.Function().GetName() == "!~~~";
-	if (PatternIsConstant(patt_str, is_glob)) {
+	PatternMatchType match_type = (root.Function().GetName() == "~~~" || root.Function().GetName() == "!~~~") ? PatternMatchType::GLOB : PatternMatchType::LIKE;
+	if (PatternIsConstant(patt_str, match_type)) {
 		// Pattern is constant
 		return BoundComparisonExpression::Create(
 		    is_not_like ? ExpressionType::COMPARE_NOTEQUAL : ExpressionType::COMPARE_EQUAL,
 		    std::move(root.GetChildrenMutable()[0]), std::move(root.GetChildrenMutable()[1]));
-	} else if (PatternIsPrefix(patt_str, is_glob)) {
+	} else if (PatternIsPrefix(patt_str, match_type)) {
 		// Prefix LIKE pattern : [^%_]*[%]+, ignoring underscore
-		return ApplyRule(root, PrefixFun::GetFunction(), patt_str, is_not_like, is_glob);
-	} else if (PatternIsSuffix(patt_str, is_glob)) {
+		return ApplyRule(root, PrefixFun::GetFunction(), patt_str, is_not_like, match_type);
+	} else if (PatternIsSuffix(patt_str, match_type)) {
 		// Suffix LIKE pattern: [%]+[^%_]*, ignoring underscore
-		return ApplyRule(root, SuffixFun::GetFunction(), patt_str, is_not_like, is_glob);
-	} else if (PatternIsContains(patt_str, is_glob)) {
+		return ApplyRule(root, SuffixFun::GetFunction(), patt_str, is_not_like, match_type);
+	} else if (PatternIsContains(patt_str, match_type)) {
 		// Contains LIKE pattern: [%]+[^%_]*[%]+, ignoring underscore
-		return ApplyRule(root, GetStringContains(), patt_str, is_not_like, is_glob);
+		return ApplyRule(root, GetStringContains(), patt_str, is_not_like, match_type);
 	}
 	return nullptr;
 }
 
 unique_ptr<Expression> LikeOptimizationRule::ApplyRule(BoundFunctionExpression &expr, const ScalarFunction &function,
-                                                       string pattern, bool is_not_like, bool is_glob) const {
+                                                       string pattern, bool is_not_like, PatternMatchType match_type) const {
 	// replace LIKE by an optimized function
 	auto result = function.Bind(GetContext(), std::move(expr.GetChildrenMutable()));
 
 	// removing wildcard from the pattern
-	char wildcard_any = is_glob ? '*' : '%';
+	char wildcard_any = match_type == PatternMatchType::GLOB ? '*' : '%';
 	pattern.erase(std::remove(pattern.begin(), pattern.end(), wildcard_any), pattern.end());
 
 	result->GetChildrenMutable()[1] = make_uniq<BoundConstantExpression>(Value(std::move(pattern)));

--- a/src/optimizer/rule/like_optimizations.cpp
+++ b/src/optimizer/rule/like_optimizations.cpp
@@ -148,7 +148,9 @@ unique_ptr<Expression> LikeOptimizationRule::Apply(LogicalOperator &op, vector<r
 	auto &patt_str = StringValue::Get(constant_value);
 
 	bool is_not_like = root.Function().GetName() == "!~~" || root.Function().GetName() == "!~~~";
-	PatternMatchType match_type = (root.Function().GetName() == "~~~" || root.Function().GetName() == "!~~~") ? PatternMatchType::GLOB : PatternMatchType::LIKE;
+	PatternMatchType match_type = (root.Function().GetName() == "~~~" || root.Function().GetName() == "!~~~")
+	                                  ? PatternMatchType::GLOB
+	                                  : PatternMatchType::LIKE;
 	if (PatternIsConstant(patt_str, match_type)) {
 		// Pattern is constant
 		return BoundComparisonExpression::Create(
@@ -168,7 +170,8 @@ unique_ptr<Expression> LikeOptimizationRule::Apply(LogicalOperator &op, vector<r
 }
 
 unique_ptr<Expression> LikeOptimizationRule::ApplyRule(BoundFunctionExpression &expr, const ScalarFunction &function,
-                                                       string pattern, bool is_not_like, PatternMatchType match_type) const {
+                                                       string pattern, bool is_not_like,
+                                                       PatternMatchType match_type) const {
 	// replace LIKE by an optimized function
 	auto result = function.Bind(GetContext(), std::move(expr.GetChildrenMutable()));
 

--- a/test/sql/optimizer/test_glob_row_group_pruning.test
+++ b/test/sql/optimizer/test_glob_row_group_pruning.test
@@ -1,0 +1,54 @@
+# name: test/sql/optimizer/test_glob_row_group_pruning.test
+# description: Row-group pruning on string columns using GLOB
+# group: [optimizer]
+
+statement ok
+ATTACH '{TEST_DIR}/glob_prune.duckdb' AS db (ROW_GROUP_SIZE 2048);
+
+statement ok
+USE db;
+
+statement ok
+CREATE TABLE t AS
+         SELECT CASE
+                    WHEN range < 2048 THEN 'aaa' || range::VARCHAR
+                    WHEN range < 4096 THEN 'mmm' || range::VARCHAR
+                    ELSE 'zzz' || range::VARCHAR
+                END AS s
+         FROM range(6144);
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM t WHERE s GLOB 'mmm*';
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
+
+query I
+SELECT count(*) FROM t WHERE s GLOB 'mmm*';
+----
+2048
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM t WHERE s GLOB 'qqq';
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 0 / 3.*
+
+query I
+SELECT count(*) FROM t WHERE s GLOB 'qqq';
+----
+0
+
+# Add a case with a glob that should not be optimized to a simple prefix due to a question mark
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM t WHERE s GLOB 'm?m*';
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 3 / 3.*
+
+query I
+SELECT count(*) FROM t WHERE s NOT GLOB 'qqq';
+----
+6144
+
+query I
+SELECT count(*) FROM t WHERE s NOT GLOB 'qqq';
+----
+6144

--- a/test/sql/optimizer/test_glob_row_group_pruning.test
+++ b/test/sql/optimizer/test_glob_row_group_pruning.test
@@ -47,8 +47,3 @@ query I
 SELECT count(*) FROM t WHERE s NOT GLOB 'qqq';
 ----
 6144
-
-query I
-SELECT count(*) FROM t WHERE s NOT GLOB 'qqq';
-----
-6144


### PR DESCRIPTION
Fixes #23906

This PR extends the `LikeOptimizationRule` to also handle `GLOB` (`~~~`) and `NOT GLOB` (`!~~~`) expressions. 

When a GLOB expression contains a constant prefix, suffix, or contains-pattern (e.g., `GLOB 'mmm*'`), it is now rewritten to use the optimized `prefix()`, `suffix()`, or `contains()` scalar functions. This allows the execution engine to leverage zone maps (string min/max statistics) and prune row groups rather than performing full sequential scans.

**Changes:**
- Included `~~~` and `!~~~` in the `LikeOptimizationRule` matcher.
- Parameterized wildcard boundary checks to support GLOB wildcards (`*`, `?`, `[`, `]`, `\`) versus LIKE wildcards (`%`, `_`).
- Added a test case (`test_glob_row_group_pruning.test`) to explicitly verify row group pruning on `GLOB` queries.