### PR TITLE
Propagate statistics for power expressions

### DIFF
--- a/extension/core_functions/scalar/math/numeric.cpp
+++ b/extension/core_functions/scalar/math/numeric.cpp
@@ -1040,10 +1040,63 @@ struct IEEEPowOperator {
 	}
 };
 
+unique_ptr<BaseStatistics> PropagatePowStats(ClientContext &context, FunctionStatisticsInput &input) {
+	D_ASSERT(input.child_stats.size() == 2);
+	auto &base_stats = input.child_stats[0];
+	auto &exponent_stats = input.child_stats[1];
+	if (!NumericStats::HasMinMax(base_stats) || !NumericStats::HasMinMax(exponent_stats)) {
+		return nullptr;
+	}
+
+	auto base_min = NumericStats::Min(base_stats).GetValue<double>();
+	auto base_max = NumericStats::Max(base_stats).GetValue<double>();
+	auto exponent_min = NumericStats::Min(exponent_stats).GetValue<double>();
+	auto exponent_max = NumericStats::Max(exponent_stats).GetValue<double>();
+	// Only constant non-negative integer exponents have safe bounds across the complete finite base domain
+	if (!Value::IsFinite(base_min) || !Value::IsFinite(base_max) || !Value::IsFinite(exponent_min) ||
+	    exponent_min != exponent_max || exponent_min < 0 || std::trunc(exponent_min) != exponent_min) {
+		return nullptr;
+	}
+
+	double result_min;
+	double result_max;
+	if (exponent_min == 0) {
+		result_min = 1;
+		result_max = 1;
+	} else {
+		auto power_min = std::pow(base_min, exponent_min);
+		auto power_max = std::pow(base_max, exponent_min);
+		if (!Value::IsFinite(power_min) || !Value::IsFinite(power_max)) {
+			return nullptr;
+		}
+		// Odd powers preserve order; even powers decrease toward zero and increase away from zero
+		if (std::fmod(exponent_min, 2) != 0) {
+			result_min = power_min;
+			result_max = power_max;
+		} else if (base_min <= 0 && base_max >= 0) {
+			result_min = 0;
+			result_max = MaxValue(power_min, power_max);
+		} else if (base_max < 0) {
+			result_min = power_max;
+			result_max = power_min;
+		} else {
+			result_min = power_min;
+			result_max = power_max;
+		}
+	}
+
+	auto result = NumericStats::CreateEmpty(input.expr.GetReturnType());
+	NumericStats::SetMin(result, Value::DOUBLE(result_min));
+	NumericStats::SetMax(result, Value::DOUBLE(result_max));
+	result.CombineValidity(base_stats, exponent_stats);
+	return result.ToUnique();
+}
+
 } // namespace
 ScalarFunction PowOperatorFun::GetFunction() {
 	ScalarFunction function({LogicalType::DOUBLE, LogicalType::DOUBLE}, LogicalType::DOUBLE, nullptr,
 	                        BindIEEEFloatingBinary<PowOperator, IEEEPowOperator>);
+	function.SetStatisticsCallback(PropagatePowStats);
 	function.SetFallible();
 	return function;
 }

--- a/extension/core_functions/scalar/math/numeric.cpp
+++ b/extension/core_functions/scalar/math/numeric.cpp
@@ -1044,26 +1044,31 @@ unique_ptr<BaseStatistics> PropagatePowStats(ClientContext &context, FunctionSta
 	D_ASSERT(input.child_stats.size() == 2);
 	auto &base_stats = input.child_stats[0];
 	auto &exponent_stats = input.child_stats[1];
-	if (!NumericStats::HasMinMax(base_stats) || !NumericStats::HasMinMax(exponent_stats)) {
+	if (!NumericStats::HasMinMax(exponent_stats)) {
 		return nullptr;
 	}
 
-	auto base_min = NumericStats::Min(base_stats).GetValue<double>();
-	auto base_max = NumericStats::Max(base_stats).GetValue<double>();
 	auto exponent_min = NumericStats::Min(exponent_stats).GetValue<double>();
 	auto exponent_max = NumericStats::Max(exponent_stats).GetValue<double>();
-	// Only constant non-negative integer exponents have safe bounds across the complete finite base domain
-	if (!Value::IsFinite(base_min) || !Value::IsFinite(base_max) || !Value::IsFinite(exponent_min) ||
-	    exponent_min != exponent_max || exponent_min < 0 || std::trunc(exponent_min) != exponent_min) {
-		return nullptr;
-	}
-
 	double result_min;
 	double result_max;
-	if (exponent_min == 0) {
+	if (exponent_min == 0 && exponent_max == 0) {
 		result_min = 1;
 		result_max = 1;
 	} else {
+		if (!Value::IsFinite(exponent_min) || exponent_min != exponent_max || exponent_min < 0 ||
+		    std::trunc(exponent_min) != exponent_min) {
+			return nullptr;
+		}
+		if (!NumericStats::HasMinMax(base_stats)) {
+			return nullptr;
+		}
+		auto base_min = NumericStats::Min(base_stats).GetValue<double>();
+		auto base_max = NumericStats::Max(base_stats).GetValue<double>();
+		// Positive integer exponents have safe bounds across the complete finite base domain
+		if (!Value::IsFinite(base_min) || !Value::IsFinite(base_max)) {
+			return nullptr;
+		}
 		auto power_min = std::pow(base_min, exponent_min);
 		auto power_max = std::pow(base_max, exponent_min);
 		if (!Value::IsFinite(power_min) || !Value::IsFinite(power_max)) {

--- a/test/configs/stats_dependent_tests.json
+++ b/test/configs/stats_dependent_tests.json
@@ -4,6 +4,7 @@
       "reason": "Statistics are not set without optimizers.",
       "paths": [
         "test/optimizer/statistics/statistics_numeric.test",
+        "test/sql/optimizer/power_zonemap_pruning.test",
         "test/fuzzer/pedro/vacuum_table_with_generated_column.test",
         "test/fuzzer/duckfuzz/bitstring_agg_uhugeint.test",
         "test/parquet/parquet_stats_function.test",

--- a/test/sql/optimizer/power_zonemap_pruning.test
+++ b/test/sql/optimizer/power_zonemap_pruning.test
@@ -35,11 +35,27 @@ SELECT s.min, s.max FROM (SELECT stats(power(x, 3)) s FROM power_stats LIMIT 1);
 ----
 -27.0	8.0
 
-# Any finite input raised to zero is one
+# Any non-NULL input raised to zero is one
 query II
 SELECT s.min, s.max FROM (SELECT stats(power(x, 0)) s FROM power_stats LIMIT 1);
 ----
 1.0	1.0
+
+statement ok
+CREATE TABLE power_zero AS
+SELECT CASE WHEN i < 122880 THEN 'inf'::DOUBLE ELSE 1.0 END AS x
+FROM range(245760) tbl(i);
+
+# Zero powers do not require finite base statistics
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM power_zero WHERE power(x, 0) > 1;
+----
+analyzed_plan	<REGEX>:.*Empty Result.*
+
+query I
+SELECT count(*) FROM power_zero WHERE power(x, 0) > 1;
+----
+0
 
 statement ok
 CREATE TABLE negative_power_stats(x INTEGER);

--- a/test/sql/optimizer/power_zonemap_pruning.test
+++ b/test/sql/optimizer/power_zonemap_pruning.test
@@ -1,0 +1,72 @@
+# name: test/sql/optimizer/power_zonemap_pruning.test
+# description: Power expressions use numeric statistics for row-group pruning
+# group: [optimizer]
+
+statement ok
+CREATE TABLE power_pruning AS
+SELECT CASE WHEN i < 122880 THEN 1 ELSE 100 END::INTEGER AS x
+FROM range(245760) tbl(i);
+
+query II
+EXPLAIN ANALYZE SELECT sum(x) FROM power_pruning WHERE power(x, 2) > 2500;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 2.*
+
+query I
+SELECT sum(x) FROM power_pruning WHERE power(x, 2) > 2500;
+----
+12288000
+
+statement ok
+CREATE TABLE power_stats(x INTEGER);
+
+statement ok
+INSERT INTO power_stats VALUES (-3), (2);
+
+# Even powers have an interior minimum when the input range crosses zero
+query II
+SELECT s.min, s.max FROM (SELECT stats(power(x, 2)) s FROM power_stats LIMIT 1);
+----
+0.0	9.0
+
+# Odd powers are increasing over the complete input range
+query II
+SELECT s.min, s.max FROM (SELECT stats(power(x, 3)) s FROM power_stats LIMIT 1);
+----
+-27.0	8.0
+
+# Any finite input raised to zero is one
+query II
+SELECT s.min, s.max FROM (SELECT stats(power(x, 0)) s FROM power_stats LIMIT 1);
+----
+1.0	1.0
+
+statement ok
+CREATE TABLE negative_power_stats(x INTEGER);
+
+statement ok
+INSERT INTO negative_power_stats VALUES (-3), (-2);
+
+# Even powers reverse the bounds of a negative-only input range
+query II
+SELECT s.min, s.max FROM (SELECT stats(power(x, 2)) s FROM negative_power_stats LIMIT 1);
+----
+4.0	9.0
+
+statement ok
+CREATE TABLE negative_exponent(x INTEGER);
+
+statement ok
+INSERT INTO negative_exponent VALUES (0), (1);
+
+statement ok
+SET ieee_floating_point_ops = false;
+
+# Unsupported negative exponents must not prune inputs that throw
+statement error
+SELECT count(*) FROM negative_exponent WHERE power(x, -2) < 0;
+----
+zero raised to a negative power is undefined
+
+statement ok
+RESET ieee_floating_point_ops;


### PR DESCRIPTION
## Summary

Resolves #23874 

This PR adds statistics propagation to the `power` scalar function for
constant, finite, non-negative integer exponents. Positive exponents derive
bounds from finite base statistics, while zero exponents produce `[1, 1]`
for any non-NULL base. This allows zonemap checks to prune row groups that
cannot match the filter.

## Results

```sql
CREATE TABLE power_pruning AS
SELECT CASE WHEN i < 122880 THEN 1 ELSE 100 END::INTEGER AS x
FROM range(245760) tbl(i);

CHECKPOINT;

EXPLAIN ANALYZE
SELECT sum(x) FROM power_pruning WHERE power(x, 2) > 2500;
```

### Before

```SQL
╭─ Ungrouped Aggregate ──────────────────╮
│ Aggregates: sum_no_overflow(#0)        │
│ 1 row                              0µs │
╰────────────────────┒┎──────────────────╯
╭─ Projection ───────┚┖──────────────────╮
│ Projections: x                         │
│ 122,880 rows                       0µs │
╰────────────────────┒┎──────────────────╯
╭─ Table Scan ───────┚┖──────────────────╮
│ Table: memory.main.power_pruning       │
│ Type: Sequential Scan                  │
│ Projections: x                         │
│ Filters:                               │
│ power(CAST(x AS DOUBLE), 2.0) > 2500.0 │
│ Row Groups Scanned: 2 / 2              │
│ 122,880 rows                       0µs │
╰────────────────────────────────────────╯
```

### After

```SQL
╭─ Ungrouped Aggregate ──────────────────╮
│ Aggregates: sum_no_overflow(#0)        │
│ 1 row                              0µs │
╰────────────────────┒┎──────────────────╯
╭─ Projection ───────┚┖──────────────────╮
│ Projections: x                         │
│ 122,880 rows                       0µs │
╰────────────────────┒┎──────────────────╯
╭─ Table Scan ───────┚┖──────────────────╮
│ Table: memory.main.power_pruning       │
│ Type: Sequential Scan                  │
│ Projections: x                         │
│ Filters:                               │
│ power(CAST(x AS DOUBLE), 2.0) > 2500.0 │
│ Row Groups Scanned: 1 / 2              │
│ 122,880 rows                       0µs │
╰────────────────────────────────────────╯
```
