### PR TITLE
Add monotonicity properties to scalar math functions

### DIFF
--- a/extension/core_functions/scalar/math/numeric.cpp
+++ b/extension/core_functions/scalar/math/numeric.cpp
@@ -1518,7 +1518,7 @@ struct ATanOperator {
 ScalarFunction AtanFun::GetFunction() {
 	ScalarFunction function({LogicalType::DOUBLE}, LogicalType::DOUBLE,
 	                        ScalarFunction::UnaryFunction<double, double, ATanOperator>);
-	function.SetUnaryArgProperties(ArgProperties().StrictlyIncreasing());
+	function.SetUnaryArgProperties(ArgProperties().NonDecreasing());
 	return function;
 }
 
@@ -1617,7 +1617,7 @@ struct SinhOperator {
 ScalarFunction SinhFun::GetFunction() {
 	ScalarFunction function({LogicalType::DOUBLE}, LogicalType::DOUBLE,
 	                        ScalarFunction::UnaryFunction<double, double, SinhOperator>);
-	function.SetUnaryArgProperties(ArgProperties().StrictlyIncreasing());
+	function.SetUnaryArgProperties(ArgProperties().NonDecreasing());
 	return function;
 }
 
@@ -1636,7 +1636,7 @@ struct AsinhOperator {
 ScalarFunction AsinhFun::GetFunction() {
 	ScalarFunction function({LogicalType::DOUBLE}, LogicalType::DOUBLE,
 	                        ScalarFunction::UnaryFunction<double, double, AsinhOperator>);
-	function.SetUnaryArgProperties(ArgProperties().StrictlyIncreasing());
+	function.SetUnaryArgProperties(ArgProperties().NonDecreasing());
 	return function;
 }
 
@@ -1655,7 +1655,7 @@ struct TanhOperator {
 ScalarFunction TanhFun::GetFunction() {
 	ScalarFunction function({LogicalType::DOUBLE}, LogicalType::DOUBLE,
 	                        ScalarFunction::UnaryFunction<double, double, TanhOperator>);
-	function.SetUnaryArgProperties(ArgProperties().StrictlyIncreasing());
+	function.SetUnaryArgProperties(ArgProperties().NonDecreasing());
 	return function;
 }
 

--- a/extension/core_functions/scalar/math/numeric.cpp
+++ b/extension/core_functions/scalar/math/numeric.cpp
@@ -1516,8 +1516,10 @@ struct ATanOperator {
 } // namespace
 
 ScalarFunction AtanFun::GetFunction() {
-	return ScalarFunction({LogicalType::DOUBLE}, LogicalType::DOUBLE,
-	                      ScalarFunction::UnaryFunction<double, double, ATanOperator>);
+	ScalarFunction function({LogicalType::DOUBLE}, LogicalType::DOUBLE,
+	                        ScalarFunction::UnaryFunction<double, double, ATanOperator>);
+	function.SetUnaryArgProperties(ArgProperties().StrictlyIncreasing());
+	return function;
 }
 
 //===--------------------------------------------------------------------===//
@@ -1613,8 +1615,10 @@ struct SinhOperator {
 } // namespace
 
 ScalarFunction SinhFun::GetFunction() {
-	return ScalarFunction({LogicalType::DOUBLE}, LogicalType::DOUBLE,
-	                      ScalarFunction::UnaryFunction<double, double, SinhOperator>);
+	ScalarFunction function({LogicalType::DOUBLE}, LogicalType::DOUBLE,
+	                        ScalarFunction::UnaryFunction<double, double, SinhOperator>);
+	function.SetUnaryArgProperties(ArgProperties().StrictlyIncreasing());
+	return function;
 }
 
 //===--------------------------------------------------------------------===//
@@ -1630,8 +1634,10 @@ struct AsinhOperator {
 } // namespace
 
 ScalarFunction AsinhFun::GetFunction() {
-	return ScalarFunction({LogicalType::DOUBLE}, LogicalType::DOUBLE,
-	                      ScalarFunction::UnaryFunction<double, double, AsinhOperator>);
+	ScalarFunction function({LogicalType::DOUBLE}, LogicalType::DOUBLE,
+	                        ScalarFunction::UnaryFunction<double, double, AsinhOperator>);
+	function.SetUnaryArgProperties(ArgProperties().StrictlyIncreasing());
+	return function;
 }
 
 //===--------------------------------------------------------------------===//
@@ -1647,8 +1653,10 @@ struct TanhOperator {
 } // namespace
 
 ScalarFunction TanhFun::GetFunction() {
-	return ScalarFunction({LogicalType::DOUBLE}, LogicalType::DOUBLE,
-	                      ScalarFunction::UnaryFunction<double, double, TanhOperator>);
+	ScalarFunction function({LogicalType::DOUBLE}, LogicalType::DOUBLE,
+	                        ScalarFunction::UnaryFunction<double, double, TanhOperator>);
+	function.SetUnaryArgProperties(ArgProperties().StrictlyIncreasing());
+	return function;
 }
 
 //===--------------------------------------------------------------------===//

--- a/test/sql/optimizer/monotone_function_zonemap_pruning.test
+++ b/test/sql/optimizer/monotone_function_zonemap_pruning.test
@@ -82,3 +82,52 @@ query I
 SELECT count(*) FROM d WHERE year(dt) BETWEEN 1975 AND 1976;
 ----
 731
+
+# Test row group pruning for strictly increasing math functions
+
+statement ok
+CREATE TABLE monotone_math AS
+SELECT CASE
+           WHEN i < 122880 THEN 0.0
+           ELSE 10.0
+       END::DOUBLE AS x
+FROM range(245760) tbl(i);
+
+query II
+SELECT count(*), sum(x)
+FROM monotone_math
+WHERE atan(x) > 1;
+----
+122880	1228800.0
+
+query II
+EXPLAIN ANALYZE
+SELECT sum(x)
+FROM monotone_math
+WHERE atan(x) > 1;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 2.*
+
+query II
+EXPLAIN ANALYZE
+SELECT sum(x)
+FROM monotone_math
+WHERE sinh(x) > 1;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 2.*
+
+query II
+EXPLAIN ANALYZE
+SELECT sum(x)
+FROM monotone_math
+WHERE asinh(x) > 1;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 2.*
+
+query II
+EXPLAIN ANALYZE
+SELECT sum(x)
+FROM monotone_math
+WHERE tanh(x) > 0.5;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 2.*


### PR DESCRIPTION
## Summary

Adds `StrictlyIncreasing()` argument properties to `atan`, `sinh`, `asinh`, and `tanh`, enabling statistics propagation and row-group pruning for these functions.

## Tests

Added regression tests to `monotone_function_zonemap_pruning.test`.
