### PR TITLE
Internal #9925: TimeZone 2026c Update

### DIFF
--- a/extension/icu/scripts/makedata.sh
+++ b/extension/icu/scripts/makedata.sh
@@ -29,7 +29,7 @@ then
 fi
 
 # download IANA and copy the latest Time Zone Data
-tz_version=2026b
+tz_version=2026c
 rm -rf icu-data
 git clone git@github.com:unicode-org/icu-data.git || true
 cp icu-data/tzdata/icunew/${tz_version}/44/*.txt ${data_path/version/$code_version}/misc

--- a/test/sql/timezone/test_icu_timezone.test
+++ b/test/sql/timezone/test_icu_timezone.test
@@ -1151,3 +1151,13 @@ query I
 select '2026-11-10'::timestamptz
 ----
 2026-11-10 00:00:00-07
+
+# 2026c
+# Alberta moved to permanent -07 on 2026-03-09.
+statement ok
+set TimeZone = 'America/Edmonton';
+
+query I
+select '2026-12-01'::TIMESTAMPTZ;
+----
+2026-12-01 00:00:00-06


### PR DESCRIPTION
* Update time zone tables to 2026c (Alberta permanent summer time)