### PR TITLE
Bump Postgres extension for 1.5

### DIFF
--- a/.github/config/extensions/postgres_scanner.cmake
+++ b/.github/config/extensions/postgres_scanner.cmake
@@ -4,7 +4,7 @@ if (NOT MINGW AND NOT ${WASM_ENABLED})
     duckdb_extension_load(postgres_scanner
             DONT_LINK
             GIT_URL https://github.com/duckdb/duckdb-postgres
-            GIT_TAG 9add648ccbc73f38c50dec91678050b3134d1244
+            GIT_TAG 41223e51559cd581f1c06e170b71c71df25bbaac
             SUBMODULES database-connector
             )
 endif()


### PR DESCRIPTION
This PR updates the Postgres extension adding the following fix, where the option registration was incorrect:

 - duckdb/duckdb-postgres#518