### PR TITLE
Fix recursive file read in shell

### DIFF
--- a/tools/shell/include/shell_state.hpp
+++ b/tools/shell/include/shell_state.hpp
@@ -38,6 +38,7 @@ using duckdb::optional_ptr;
 using duckdb::SQLIdentifier;
 using duckdb::SQLString;
 using duckdb::unordered_map;
+using duckdb::unordered_set;
 struct ShellState;
 using duckdb::InternalException;
 using duckdb::InvalidInputException;
@@ -246,6 +247,8 @@ public:
 	OptionType highlight_results = OptionType::DEFAULT;
 	//! Path to .duckdbrc file
 	string duckdb_rc_path;
+	//! Canonical paths of files currently being processed by .read
+	unordered_set<string> active_read_files;
 	//! Startup text to display
 	StartupText startup_text = StartupText::ALL;
 	//! Whether or not the loading resources message was displayed

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -2103,6 +2103,12 @@ bool ShellState::ReadFromFile(const string &file) {
 		PrintF(PrintOutput::STDERR, ".read cannot be used in -safe mode\n");
 		return false;
 	}
+	duckdb::LocalFileSystem lfs;
+	auto canonical_file = lfs.CanonicalizePath(file, nullptr);
+	if (!active_read_files.insert(canonical_file).second) {
+		PrintF(PrintOutput::STDERR, "Error: recursive .read of \"%s\"\n", file);
+		return false;
+	}
 	FILE *inSaved = in;
 	int savedLineno = lineno;
 	int rc;
@@ -2113,6 +2119,7 @@ bool ShellState::ReadFromFile(const string &file) {
 		rc = ProcessInput(InputMode::FILE);
 		fclose(in);
 	}
+	active_read_files.erase(canonical_file);
 	in = inSaved;
 	lineno = savedLineno;
 	return rc == 0;

--- a/tools/shell/tests/test_shell_basics.py
+++ b/tools/shell/tests/test_shell_basics.py
@@ -389,6 +389,12 @@ def test_read(shell, generated_file):
     result = test.run()
     result.check_stdout("42")
 
+def test_recursive_read(shell, tmp_path):
+    sql_file = tmp_path / "recursive_read.sql"
+    sql_file.write_text(f".read {sql_file.as_posix()}")
+    result = ShellTest(shell).statement(f".read {sql_file.as_posix()}").run()
+    result.check_stderr("recursive .read")
+
 @pytest.mark.parametrize('generated_file', ["select 42"], indirect=True)
 def test_execute_file(shell, generated_file):
     test = (


### PR DESCRIPTION
Closes https://github.com/duckdb/duckdb/issues/23823

Repro steps
- printf '.read /tmp/duckdb_self_read.sql\n' > /tmp/duckdb_self_read.sql
- /build/reldebug/duckdb
- .read /tmp/duckdb_self_read.sql

The root cause is, `/tmp/duckdb_self_read.sql` is read recursively which leads to stackoverflow.

Before change
```sql
memory D .read /tmp/duckdb_self_read.sql
zsh: segmentation fault  ./build/reldebug/duckdb
```
After change
```sql
memory D .read /tmp/duckdb_self_read.sql
Error: recursive .read of "/tmp/duckdb_self_read.sql"
```