### PR TITLE
Fix TopN late materialization with asymmetric join projections

### DIFF
--- a/src/optimizer/topn_window_elimination.cpp
+++ b/src/optimizer/topn_window_elimination.cpp
@@ -1018,6 +1018,13 @@ bool TopNWindowElimination::CanUseLateMaterialization(const LogicalWindow &windo
 				// We cannot use late materialization by scanning a single table.
 				return false;
 			}
+			if (join.HasProjectionMap()) {
+				const auto &projection_map =
+				    all_right_replaceable ? join.left_projection_map : join.right_projection_map;
+				if (projection_map.empty()) {
+					return false;
+				}
+			}
 
 			TableIndex replace_table_idx = all_right_replaceable ? right_idx : left_idx;
 			for (idx_t i = 0; i < projections.size(); i++) {

--- a/test/sql/optimizer/topn_window_elimination_late_materialization.test
+++ b/test/sql/optimizer/topn_window_elimination_late_materialization.test
@@ -151,3 +151,31 @@ WITH cte AS (SELECT a, b, c::TIMESTAMPTZ AS c FROM casted)
 SELECT * FROM cte QUALIFY row_number() OVER (PARTITION BY a ORDER BY c DESC) = 1
 ----
 x	false	2024-01-01 00:00:00+00
+
+# A join can have an explicit projection map on only the other side.
+statement ok
+CREATE TABLE filter_left (id INTEGER, sort_key INTEGER, x INTEGER, y INTEGER)
+
+statement ok
+INSERT INTO filter_left VALUES (1, 0, 5, 5), (1, 1, 1, 1)
+
+statement ok
+CREATE TABLE filter_right (id INTEGER, z INTEGER)
+
+statement ok
+INSERT INTO filter_right VALUES (1, 1)
+
+statement ok
+SET disabled_optimizers = 'filter_pushdown,join_order'
+
+query III
+SELECT l.id, l.x, l.y
+FROM filter_left l
+JOIN filter_right r USING (id)
+WHERE l.x + r.z < 5
+QUALIFY row_number() OVER (PARTITION BY l.id ORDER BY l.sort_key) = 1
+----
+1	1	1
+
+statement ok
+SET disabled_optimizers = ''


### PR DESCRIPTION
## Summary

- skip Top-N window late materialization for the unsafe asymmetric join projection-map case
- add a core-only regression test for a post-join filter followed by `QUALIFY row_number()`

## Root cause

An empty projection map means "project all columns". When only the other join side had an explicit projection map, late materialization appended a row ID to the selected side's empty map. That changed its meaning to "project only the row ID", dropped payload columns, and caused an out-of-range binding access.

The fix conservatively falls back to the existing `struct_pack` path only for that shape. The broader Top-N window rewrite remains enabled.

Fixes #23925.

## Validation

- reproduced the original spatial failure on DuckDB v1.5.4
- reproduced the same failure with the new core-only regression on the unpatched build
- `git diff --check`
- `build/pr/test/unittest.exe test/sql/optimizer/topn_window_elimination_late_materialization.test` (98 assertions)
