### PR TITLE
Skip Parquet bloom pruning for NaN

### DIFF
--- a/extension/parquet/parquet_statistics.cpp
+++ b/extension/parquet/parquet_statistics.cpp
@@ -877,19 +877,30 @@ static optional<uint64_t> ValueXXH64(const Value &constant, const ParquetColumnS
 static bool BloomFilterExcludes(const Value &constant, ParquetBloomFilter &bloom_filter,
                                 const ParquetColumnSchema &schema) {
 	// Floating-point equality treats positive and negative zero as equal, but Parquet hashes their bit patterns.
+	// Likewise, all NaN payloads compare equal, so no single hash can rule out a row group containing one.
 	switch (constant.type().InternalType()) {
-	case PhysicalType::FLOAT:
-		if (constant.GetValue<float>() == 0.0f) {
+	case PhysicalType::FLOAT: {
+		auto float_value = constant.GetValue<float>();
+		if (Value::IsNan(float_value)) {
+			return false;
+		}
+		if (float_value == 0.0f) {
 			return !bloom_filter.FilterCheck(ValueXH64FixedWidth(0.0f)) &&
 			       !bloom_filter.FilterCheck(ValueXH64FixedWidth(-0.0f));
 		}
 		break;
-	case PhysicalType::DOUBLE:
-		if (constant.GetValue<double>() == 0.0) {
+	}
+	case PhysicalType::DOUBLE: {
+		auto double_value = constant.GetValue<double>();
+		if (Value::IsNan(double_value)) {
+			return false;
+		}
+		if (double_value == 0.0) {
 			return !bloom_filter.FilterCheck(ValueXH64FixedWidth(0.0)) &&
 			       !bloom_filter.FilterCheck(ValueXH64FixedWidth(-0.0));
 		}
 		break;
+	}
 	default:
 		break;
 	}

--- a/test/sql/copy/parquet/bloom_filters.test
+++ b/test/sql/copy/parquet/bloom_filters.test
@@ -651,3 +651,33 @@ FROM read_parquet('{TEST_DIR}/bloom_ndf_signed_zero.parquet')
 WHERE x IS NOT DISTINCT FROM -0.0;
 ----
 2048
+
+statement ok
+COPY (
+	SELECT CASE
+		WHEN i < 2048 THEN '-NaN'::DOUBLE
+		WHEN i % 2 = 0 THEN -1.0::DOUBLE
+		ELSE 1.0::DOUBLE
+	END AS x
+	FROM range(4096) t(i)
+	ORDER BY i
+) TO '{TEST_DIR}/bloom_nan.parquet' (
+	FORMAT PARQUET,
+	ROW_GROUP_SIZE 2048,
+	WRITE_BLOOM_FILTER TRUE,
+	DICTIONARY_SIZE_LIMIT 1000
+);
+
+query I
+SELECT count(*)
+FROM read_parquet('{TEST_DIR}/bloom_nan.parquet')
+WHERE x = 'NaN'::DOUBLE;
+----
+2048
+
+query I
+SELECT count(*)
+FROM read_parquet('{TEST_DIR}/bloom_nan.parquet')
+WHERE x IS NOT DISTINCT FROM 'NaN'::DOUBLE;
+----
+2048


### PR DESCRIPTION
## Summary

- skip Parquet bloom-filter pruning for `FLOAT` and `DOUBLE` NaN equality constants
- prevent raw NaN payload differences from excluding matching row groups
- add a regression test covering the reported multi-row-group scan

## Root cause

DuckDB considers NaN values equal regardless of their IEEE payload, while Parquet bloom filters hash their raw bytes. Probing a bloom filter with one NaN encoding therefore cannot safely exclude a row group that may contain another encoding.

## Validation

- `unittest test/sql/copy/parquet/bloom_filters.test` (97 assertions passed)
- manually reproduced the original `0` result before the change and verified `5000` rows after it

Fixes #23921
