### PR TITLE
Capi add allocation handlers

### DIFF
--- a/src/include/duckdb/main/capi/cast/utils.hpp
+++ b/src/include/duckdb/main/capi/cast/utils.hpp
@@ -83,6 +83,9 @@ struct ToCStringCastWrapper {
 		auto result_data = result_string.GetData();
 
 		char *allocated_data = char_ptr_cast(duckdb_malloc(result_size + 1));
+		if (!allocated_data) {
+			return false;
+		}
 		memcpy(allocated_data, result_data, result_size);
 		allocated_data[result_size] = '\0';
 		result.data = allocated_data;

--- a/src/main/capi/cast/from_decimal-c.cpp
+++ b/src/main/capi/cast/from_decimal-c.cpp
@@ -34,6 +34,9 @@ bool CastDecimalCInternal(duckdb_result *source, duckdb_string &result, idx_t co
 		throw duckdb::InternalException("Unimplemented internal type for decimal");
 	}
 	result.data = reinterpret_cast<char *>(duckdb_malloc(sizeof(char) * (result_string.GetSize() + 1)));
+	if (!result.data) {
+		return false;
+	}
 	memcpy(result.data, result_string.GetData(), result_string.GetSize());
 	result.data[result_string.GetSize()] = '\0';
 	result.size = result_string.GetSize();

--- a/src/main/capi/duckdb_value-c.cpp
+++ b/src/main/capi/duckdb_value-c.cpp
@@ -136,6 +136,9 @@ duckdb_bignum duckdb_get_bignum(duckdb_value val) {
 	duckdb::Bignum::GetByteArray(byte_array, is_negative, duckdb::string_t(str));
 	auto size = byte_array.size();
 	auto data = reinterpret_cast<uint8_t *>(malloc(size));
+	if (!data) {
+		return {nullptr, 0, is_negative};
+	}
 	memcpy(data, byte_array.data(), size);
 	return {data, size, is_negative};
 }
@@ -288,6 +291,9 @@ duckdb_blob duckdb_get_blob(duckdb_value val) {
 	auto &str = duckdb::StringValue::Get(res);
 
 	auto result = reinterpret_cast<void *>(malloc(sizeof(char) * str.size()));
+	if (!result) {
+		return {nullptr, 0};
+	}
 	memcpy(result, str.c_str(), str.size());
 	return {result, str.size()};
 }
@@ -299,6 +305,9 @@ duckdb_bit duckdb_get_bit(duckdb_value val) {
 	auto &str = duckdb::StringValue::Get(v);
 	auto size = str.size();
 	auto data = reinterpret_cast<uint8_t *>(malloc(size));
+	if (!data) {
+		return {nullptr, 0};
+	}
 	memcpy(data, str.c_str(), size);
 	return {data, size};
 }
@@ -324,6 +333,9 @@ char *duckdb_get_varchar(duckdb_value value) {
 	auto &str = duckdb::StringValue::Get(str_val);
 
 	auto result = reinterpret_cast<char *>(malloc(sizeof(char) * (str.size() + 1)));
+	if (!result) {
+		return nullptr;
+	}
 	memcpy(result, str.c_str(), str.size());
 	result[str.size()] = '\0';
 	return result;
@@ -639,6 +651,9 @@ char *duckdb_value_to_string(duckdb_value val) {
 	auto str = v.ToSQLString();
 
 	auto result = reinterpret_cast<char *>(malloc(sizeof(char) * (str.size() + 1)));
+	if (!result) {
+		return nullptr;
+	}
 	memcpy(result, str.c_str(), str.size());
 	result[str.size()] = '\0';
 	return result;

--- a/src/main/capi/result-c.cpp
+++ b/src/main/capi/result-c.cpp
@@ -21,7 +21,9 @@ struct CStringConverter {
 	template <class SRC, class DST>
 	static DST Convert(SRC input) {
 		auto result = char_ptr_cast(duckdb_malloc(input.GetSize() + 1));
-		assert(result);
+		if (!result) {
+			return nullptr;
+		}
 		memcpy((void *)result, input.GetData(), input.GetSize());
 		auto write_arr = char_ptr_cast(result);
 		write_arr[input.GetSize()] = '\0';
@@ -40,7 +42,10 @@ struct CBlobConverter {
 		duckdb_blob result;
 		result.data = char_ptr_cast(duckdb_malloc(input.GetSize()));
 		result.size = input.GetSize();
-		assert(result.data);
+		if (!result.data) {
+			result.size = 0;
+			return result;
+		}
 		memcpy(result.data, input.GetData(), input.GetSize());
 		return result;
 	}

--- a/src/main/capi/table_description-c.cpp
+++ b/src/main/capi/table_description-c.cpp
@@ -118,6 +118,9 @@ char *duckdb_table_description_get_column_name(duckdb_table_description table_de
 
 	auto name = column.GetName();
 	auto result = reinterpret_cast<char *>(malloc(sizeof(char) * (name.size() + 1)));
+	if (result == nullptr) {
+		return nullptr;
+	}
 	memcpy(result, name.c_str(), name.size());
 	result[name.size()] = '\0';
 

--- a/src/main/capi/value-c.cpp
+++ b/src/main/capi/value-c.cpp
@@ -164,6 +164,9 @@ duckdb_blob duckdb_value_blob(duckdb_result *result, idx_t col, idx_t row) {
 		duckdb_blob result_blob;
 		result_blob.data = malloc(internal_result.size);
 		result_blob.size = internal_result.size;
+		if (!result_blob.data) {
+			return FetchDefaultValue::Operation<duckdb_blob>();
+		}
 		memcpy(result_blob.data, internal_result.data, internal_result.size);
 		return result_blob;
 	}


### PR DESCRIPTION
  Several C-API functions allocated their output via duckdb_malloc/malloc and then dereferenced the result unconditionally — memcpy into the buffer and/or a NUL-terminator write. If allocation failed, this was
  undefined behavior (NULL dereference). A couple of these sites guarded the pointer only with assert(), which is a no-op in release builds.

  This PR adds a NULL check after each such allocation and returns the C-API error sentinel on failure, matching how the C API already represents an "unavailable value" — so the affected call degrades gracefully instead of crashing.