### PR TITLE
Match secret SCOPE only on URI component boundaries

### DIFF
--- a/src/main/secret/secret.cpp
+++ b/src/main/secret/secret.cpp
@@ -11,6 +11,25 @@
 
 namespace duckdb {
 
+static bool IsScopeSeparator(char c) {
+	// a scope prefix may only match a path at a URI component boundary
+	return c == '/' || c == ':' || c == '?' || c == '#';
+}
+
+static bool ScopeMatches(const string &path, const string &prefix) {
+	if (prefix.empty()) {
+		return true;
+	}
+	if (!StringUtil::StartsWith(path, prefix)) {
+		return false;
+	}
+	if (path.size() == prefix.size()) {
+		return true;
+	}
+	// a strict prefix must end on a component boundary (avoids 's3://trusted' matching 's3://trusted-evil')
+	return IsScopeSeparator(prefix.back()) || IsScopeSeparator(path[prefix.size()]);
+}
+
 int64_t BaseSecret::MatchScore(const string &path) const {
 	int64_t longest_match = NumericLimits<int64_t>::Minimum();
 
@@ -24,7 +43,7 @@ int64_t BaseSecret::MatchScore(const string &path) const {
 			longest_match = 0;
 			continue;
 		}
-		if (StringUtil::StartsWith(path, prefix)) {
+		if (ScopeMatches(path, prefix)) {
 			longest_match = MaxValue<int64_t>(NumericCast<int64_t>(prefix.length()), longest_match);
 		}
 	}

--- a/src/main/secret/secret.cpp
+++ b/src/main/secret/secret.cpp
@@ -11,23 +11,92 @@
 
 namespace duckdb {
 
-static bool IsScopeSeparator(char c) {
-	// a scope prefix may only match a path at a URI component boundary
-	return c == '/' || c == ':' || c == '?' || c == '#';
+//! Terminates the authority component and separates path segments
+static bool IsPathSeparator(char c) {
+	return c == '/' || c == '?' || c == '#';
 }
 
-static bool ScopeMatches(const string &path, const string &prefix) {
+//! Locates the authority of a URI: everything between "scheme://" and the first '/', '?' or '#'
+//! Returns false for anything that is not a URI, such as a plain path or a bare bucket name
+static bool TryGetAuthority(const string &uri, idx_t &authority_begin, idx_t &authority_end) {
+	auto scheme_end = uri.find("://");
+	if (scheme_end == string::npos || scheme_end == 0) {
+		return false;
+	}
+	// RFC 3986: scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
+	if (!StringUtil::CharacterIsAlpha(uri[0])) {
+		return false;
+	}
+	for (idx_t i = 1; i < scheme_end; i++) {
+		auto c = uri[i];
+		if (!StringUtil::CharacterIsAlphaNumeric(c) && c != '+' && c != '-' && c != '.') {
+			return false;
+		}
+	}
+	authority_begin = scheme_end + 3;
+	authority_end = uri.size();
+	for (idx_t i = authority_begin; i < uri.size(); i++) {
+		if (IsPathSeparator(uri[i])) {
+			authority_end = i;
+			break;
+		}
+	}
+	return true;
+}
+
+//! A scope path must cover the requested path entirely or stop on a segment boundary within it
+static bool PathPrefixMatches(const string &path, const string &prefix) {
 	if (prefix.empty()) {
 		return true;
 	}
 	if (!StringUtil::StartsWith(path, prefix)) {
 		return false;
 	}
-	if (path.size() == prefix.size()) {
+	return path.size() == prefix.size() || IsPathSeparator(prefix.back()) || IsPathSeparator(path[prefix.size()]);
+}
+
+//! The scope authority must designate the host the request is actually sent to
+//! A scope may leave off the port, but it may never stop inside the userinfo of a longer authority
+static bool AuthorityMatches(const string &path_authority, const string &scope_authority) {
+	if (scope_authority.empty()) {
+		// a scheme-only scope such as 's3://' covers every host of that scheme
 		return true;
 	}
-	// a strict prefix must end on a component boundary (avoids 's3://trusted' matching 's3://trusted-evil')
-	return IsScopeSeparator(prefix.back()) || IsScopeSeparator(path[prefix.size()]);
+	if (path_authority == scope_authority) {
+		return true;
+	}
+	if (path_authority.size() <= scope_authority.size() || !StringUtil::StartsWith(path_authority, scope_authority)) {
+		return false;
+	}
+	// only a port may follow the host, and a port contains neither userinfo nor another host
+	auto remainder = path_authority.substr(scope_authority.size());
+	return remainder[0] == ':' && remainder.find('@') == string::npos;
+}
+
+static bool ScopeMatches(const string &path, const string &scope) {
+	if (scope.empty()) {
+		return true;
+	}
+	idx_t scope_authority_begin = 0;
+	idx_t scope_authority_end = 0;
+	idx_t path_authority_begin = 0;
+	idx_t path_authority_end = 0;
+	auto scope_is_uri = TryGetAuthority(scope, scope_authority_begin, scope_authority_end);
+	auto path_is_uri = TryGetAuthority(path, path_authority_begin, path_authority_end);
+	if (!scope_is_uri || !path_is_uri) {
+		// comparing a URI against a non-URI would weigh a host against a path segment
+		return !scope_is_uri && !path_is_uri && PathPrefixMatches(path, scope);
+	}
+	// scheme, authority and path are compared as separate components, never as one flat string
+	if (scope_authority_begin != path_authority_begin ||
+	    scope.substr(0, scope_authority_begin) != path.substr(0, path_authority_begin)) {
+		return false;
+	}
+	if (!AuthorityMatches(path.substr(path_authority_begin, path_authority_end - path_authority_begin),
+	                      scope.substr(scope_authority_begin, scope_authority_end - scope_authority_begin))) {
+		return false;
+	}
+	return PathPrefixMatches(path.substr(path_authority_end), scope.substr(scope_authority_end));
 }
 
 int64_t BaseSecret::MatchScore(const string &path) const {

--- a/test/sql/secrets/secret_scope_boundary.test
+++ b/test/sql/secrets/secret_scope_boundary.test
@@ -1,0 +1,94 @@
+# name: test/sql/secrets/secret_scope_boundary.test
+# description: Secret SCOPE matching must respect URI component boundaries (issue #22660)
+# group: [secrets]
+
+require noforcestorage
+
+# The scope matcher (BaseSecret::MatchScore) is type-independent string logic,
+# so we exercise it with generic HTTP-typed secrets.
+
+statement ok
+CREATE SECRET s_host (TYPE http, SCOPE 'http://127.0.0.1');
+
+# same host with an explicit port -> matches (':' is a component boundary)
+query I
+SELECT name FROM which_secret('http://127.0.0.1:8080/probe.txt', 'http')
+----
+s_host
+
+# same host with a path -> matches ('/' is a component boundary)
+query I
+SELECT name FROM which_secret('http://127.0.0.1/probe.txt', 'http')
+----
+s_host
+
+# scope equal to the full path -> matches (end of string)
+query I
+SELECT name FROM which_secret('http://127.0.0.1', 'http')
+----
+s_host
+
+# sibling host that merely shares a string prefix -> must NOT match
+query I
+SELECT count(*) FROM which_secret('http://127.0.0.10:8080/probe.txt', 'http')
+----
+0
+
+query I
+SELECT count(*) FROM which_secret('http://127.0.0.100/probe.txt', 'http')
+----
+0
+
+# scope whose next path character is an identifier char -> must NOT match
+statement ok
+CREATE SECRET s_sibling (TYPE http, SCOPE 'http://trusted');
+
+query I
+SELECT name FROM which_secret('http://trusted/data', 'http')
+----
+s_sibling
+
+query I
+SELECT count(*) FROM which_secret('http://trusted-evil/data', 'http')
+----
+0
+
+# the s3 bucket vector from the issue, exercised through the same matcher
+statement ok
+CREATE SECRET s3_bucket (TYPE http, SCOPE 's3://trusted');
+
+query I
+SELECT name FROM which_secret('s3://trusted/data.parquet', 'http')
+----
+s3_bucket
+
+query I
+SELECT count(*) FROM which_secret('s3://trusted-evil/data.parquet', 'http')
+----
+0
+
+# a scope that already ends on a separator keeps matching within the path
+statement ok
+CREATE SECRET s_trail (TYPE http, SCOPE 'http://example.com/data/');
+
+query I
+SELECT name FROM which_secret('http://example.com/data/file.csv', 'http')
+----
+s_trail
+
+# longest-matching scope still wins when several scopes match
+statement ok
+CREATE SECRET s_broad (TYPE http, SCOPE 'http://api.example.com');
+
+statement ok
+CREATE SECRET s_specific (TYPE http, SCOPE 'http://api.example.com/v2');
+
+query I
+SELECT name FROM which_secret('http://api.example.com/v2/data', 'http')
+----
+s_specific
+
+query I
+SELECT name FROM which_secret('http://api.example.com/v1/data', 'http')
+----
+s_broad

--- a/test/sql/secrets/secret_scope_boundary.test
+++ b/test/sql/secrets/secret_scope_boundary.test
@@ -1,5 +1,5 @@
 # name: test/sql/secrets/secret_scope_boundary.test
-# description: Secret SCOPE matching must respect URI component boundaries (issue #22660)
+# description: Secret SCOPE matching must compare URI components, not raw string prefixes (issue #22660)
 # group: [secrets]
 
 require noforcestorage
@@ -10,21 +10,27 @@ require noforcestorage
 statement ok
 CREATE SECRET s_host (TYPE http, SCOPE 'http://127.0.0.1');
 
-# same host with an explicit port -> matches (':' is a component boundary)
+# same host with an explicit port -> matches (the port is not part of the host)
 query I
 SELECT name FROM which_secret('http://127.0.0.1:8080/probe.txt', 'http')
 ----
 s_host
 
-# same host with a path -> matches ('/' is a component boundary)
+# same host with a path -> matches
 query I
 SELECT name FROM which_secret('http://127.0.0.1/probe.txt', 'http')
 ----
 s_host
 
-# scope equal to the full path -> matches (end of string)
+# scope equal to the full path -> matches
 query I
 SELECT name FROM which_secret('http://127.0.0.1', 'http')
+----
+s_host
+
+# a query string directly after the host -> matches
+query I
+SELECT name FROM which_secret('http://127.0.0.1?probe=1', 'http')
 ----
 s_host
 
@@ -39,7 +45,6 @@ SELECT count(*) FROM which_secret('http://127.0.0.100/probe.txt', 'http')
 ----
 0
 
-# scope whose next path character is an identifier char -> must NOT match
 statement ok
 CREATE SECRET s_sibling (TYPE http, SCOPE 'http://trusted');
 
@@ -67,6 +72,57 @@ SELECT count(*) FROM which_secret('s3://trusted-evil/data.parquet', 'http')
 ----
 0
 
+# userinfo must not be mistaken for the host: the requests below are sent to evil.com
+statement ok
+CREATE SECRET s_userinfo (TYPE http, SCOPE 'https://duckdb.org');
+
+query I
+SELECT name FROM which_secret('https://duckdb.org/data.csv', 'http')
+----
+s_userinfo
+
+query I
+SELECT count(*) FROM which_secret('https://duckdb.org:quack@evil.com', 'http')
+----
+0
+
+query I
+SELECT count(*) FROM which_secret('https://duckdb.org@evil.com/data.csv', 'http')
+----
+0
+
+# the same, for a scope that already spells out a port
+statement ok
+CREATE SECRET s_port (TYPE http, SCOPE 'https://example.org:443');
+
+query I
+SELECT name FROM which_secret('https://example.org:443/data.csv', 'http')
+----
+s_port
+
+query I
+SELECT count(*) FROM which_secret('https://example.org:443@evil.com/data.csv', 'http')
+----
+0
+
+# a scope may not be a fragment of the scheme
+statement ok
+CREATE SECRET s_scheme_fragment (TYPE http, SCOPE 'http');
+
+query I
+SELECT count(*) FROM which_secret('http://any-host.com/data.csv', 'http')
+----
+0
+
+# ... but a scheme-wide scope still covers every host of that scheme
+statement ok
+CREATE SECRET s_scheme (TYPE http, SCOPE 'gcs://');
+
+query I
+SELECT name FROM which_secret('gcs://any-bucket/data.parquet', 'http')
+----
+s_scheme
+
 # a scope that already ends on a separator keeps matching within the path
 statement ok
 CREATE SECRET s_trail (TYPE http, SCOPE 'http://example.com/data/');
@@ -76,13 +132,13 @@ SELECT name FROM which_secret('http://example.com/data/file.csv', 'http')
 ----
 s_trail
 
-# longest-matching scope still wins when several scopes match
 statement ok
 CREATE SECRET s_broad (TYPE http, SCOPE 'http://api.example.com');
 
 statement ok
 CREATE SECRET s_specific (TYPE http, SCOPE 'http://api.example.com/v2');
 
+# the longest matching scope wins when several scopes match
 query I
 SELECT name FROM which_secret('http://api.example.com/v2/data', 'http')
 ----
@@ -92,3 +148,29 @@ query I
 SELECT name FROM which_secret('http://api.example.com/v1/data', 'http')
 ----
 s_broad
+
+# path segments are matched whole, so 'v2' does not cover 'v20'
+query I
+SELECT name FROM which_secret('http://api.example.com/v20/data', 'http')
+----
+s_broad
+
+# a local path scope is not a URI, and keeps plain prefix semantics
+statement ok
+CREATE SECRET s_local (TYPE http, SCOPE '/home/data');
+
+query I
+SELECT name FROM which_secret('/home/data/file.csv', 'http')
+----
+s_local
+
+query I
+SELECT count(*) FROM which_secret('/home/database/file.csv', 'http')
+----
+0
+
+# '://' inside a local path does not turn it into a URI
+query I
+SELECT name FROM which_secret('/home/data/http://x', 'http')
+----
+s_local


### PR DESCRIPTION
### Summary

`BaseSecret::MatchScore` selected a secret whenever the requested path had the secret's `SCOPE` as a raw string prefix (`StringUtil::StartsWith`), so a secret could be sent to a host it was never scoped to:

- `SCOPE 'http://127.0.0.1'` was applied to `http://127.0.0.10:PORT/...`
- `SCOPE 's3://trusted'` was applied to `s3://trusted-evil/...`
- `SCOPE 'https://duckdb.org'` was applied to `https://duckdb.org:quack@evil.com`, where the scope stops inside the *userinfo* and the request is actually sent to `evil.com` (raised by @carlopi in review)
- `SCOPE 'http'` was applied to every `http://` URL

### Fix

Scope and path are now split into **scheme, authority and path** and compared component by component, rather than as one flat string:

- **scheme** must be equal, and must be a valid RFC 3986 scheme — so a local path that merely contains `://` is not mistaken for a URI
- **authority** must designate the host the request is actually sent to. A scope may leave off the port (`http://localhost` still covers `http://localhost:8080`), but it may not stop inside a longer authority unless only a port follows — which is what closes the userinfo bypass
- **path** segments are compared whole, so `/v2` no longer covers `/v20/...`

Behaviour that is deliberately preserved:

- `s3://bucket` -> `s3://bucket/key`, and a trailing-separator scope like `http://host/data/`
- a scheme-wide scope (`s3://`) still covers every host of that scheme
- an empty scope still matches everything, and the longest matching scope still wins
- non-URI scopes (local paths) keep plain prefix semantics

### Test plan

`test/sql/secrets/secret_scope_boundary.test` (sqllogictest, no extension or network needed) drives the matcher through `which_secret()` and covers every case above — both the bypasses and the matches that must keep working. It is picked up by the standard `test/unittest` run.

Verified locally on macOS/arm64:

- `build/release/test/unittest test/sql/secrets/secret_scope_boundary.test` — 35 assertions pass
- full fast suite `build/release/test/unittest` — **all tests passed (981140 assertions in 4646 test cases)**, no regressions
- `scripts/format.py --check` clean on both files with the pinned clang-format 11.0.1

`MatchScore` has a single caller (`secret_storage.cpp`), so the blast radius is limited to secret selection.

Fixes #22660