### PR TITLE
Optimizer: restrict equal-or-null rewrite to predicates

### DIFF
--- a/src/optimizer/rule/equal_or_null_simplification.cpp
+++ b/src/optimizer/rule/equal_or_null_simplification.cpp
@@ -7,6 +7,22 @@
 
 namespace duckdb {
 
+static bool IsPredicateRoot(LogicalOperator &op, bool is_root) {
+	if (!is_root) {
+		return false;
+	}
+	switch (op.type) {
+	case LogicalOperatorType::LOGICAL_FILTER:
+	case LogicalOperatorType::LOGICAL_COMPARISON_JOIN:
+	case LogicalOperatorType::LOGICAL_ANY_JOIN:
+	case LogicalOperatorType::LOGICAL_DELIM_JOIN:
+	case LogicalOperatorType::LOGICAL_ASOF_JOIN:
+		return true;
+	default:
+		return false;
+	}
+}
+
 EqualOrNullSimplification::EqualOrNullSimplification(ExpressionRewriter &rewriter) : Rule(rewriter) {
 	// match on OR conjunction
 	auto op = make_uniq<ConjunctionExpressionMatcher>();
@@ -86,6 +102,10 @@ static unique_ptr<Expression> TryRewriteEqualOrIsNull(Expression &equal_expr, Ex
 
 unique_ptr<Expression> EqualOrNullSimplification::Apply(LogicalOperator &op, vector<reference<Expression>> &bindings,
                                                         bool &changes_made, bool is_root) {
+	if (!IsPredicateRoot(op, is_root)) {
+		return nullptr;
+	}
+
 	const Expression &or_exp = bindings[0].get();
 
 	if (or_exp.GetExpressionType() != ExpressionType::CONJUNCTION_OR) {

--- a/src/optimizer/rule/equal_or_null_simplification.cpp
+++ b/src/optimizer/rule/equal_or_null_simplification.cpp
@@ -13,10 +13,7 @@ static bool IsPredicateRoot(LogicalOperator &op, bool is_root) {
 	}
 	switch (op.type) {
 	case LogicalOperatorType::LOGICAL_FILTER:
-	case LogicalOperatorType::LOGICAL_COMPARISON_JOIN:
 	case LogicalOperatorType::LOGICAL_ANY_JOIN:
-	case LogicalOperatorType::LOGICAL_DELIM_JOIN:
-	case LogicalOperatorType::LOGICAL_ASOF_JOIN:
 		return true;
 	default:
 		return false;

--- a/test/sql/optimizer/expression/test_equal_or_null_optimization.test
+++ b/test/sql/optimizer/expression/test_equal_or_null_optimization.test
@@ -18,10 +18,10 @@ SELECT i FROM test WHERE (i=j) OR (i IS NULL AND j IS NULL);
 2
 NULL
 
-query II nosort distinctrewrite1
+query II nosort nodistinctprojection1
 EXPLAIN SELECT (i=j) OR (i IS NULL AND j IS NULL) FROM test;
 ----
-physical_plan	<REGEX>:.*DISTINCT.*
+physical_plan	<REGEX>:.*OR.*
 
 query I rowsort
 SELECT i FROM test WHERE i IS NOT DISTINCT FROM j;
@@ -42,10 +42,26 @@ SELECT i FROM test WHERE (i IS NULL AND j IS NULL) OR (i=j);
 2
 NULL
 
-query II nosort distinctrewrite1
+query II nosort nodistinctprojection2
 EXPLAIN SELECT (i IS NULL AND j IS NULL) OR (i=j) FROM test;
 ----
-physical_plan	<REGEX>:.*DISTINCT.*
+physical_plan	<REGEX>:.*OR.*
+
+statement ok
+CREATE TABLE projection_test(a INTEGER, b INTEGER);
+
+statement ok
+INSERT INTO projection_test VALUES (0, NULL);
+
+query I
+SELECT a = b OR (a IS NULL AND b IS NULL) AS v FROM projection_test;
+----
+NULL
+
+query I
+SELECT (a IS NULL AND b IS NULL) OR a = b AS v FROM projection_test;
+----
+NULL
 
 # do a hash join
 query I rowsort

--- a/test/sql/optimizer/expression/test_equal_or_null_optimization.test
+++ b/test/sql/optimizer/expression/test_equal_or_null_optimization.test
@@ -63,6 +63,15 @@ SELECT (a IS NULL AND b IS NULL) OR a = b AS v FROM projection_test;
 ----
 NULL
 
+# A root expression of a comparison join operand is not a predicate root
+query I
+SELECT count(*)
+FROM (VALUES (0::INTEGER, NULL::INTEGER)) l(a, b)
+JOIN (VALUES (false)) r(c)
+  ON (l.a = l.b OR (l.a IS NULL AND l.b IS NULL)) = r.c;
+----
+0
+
 # do a hash join
 query I rowsort
 SELECT test1.i FROM test AS test1, test AS test2 WHERE (test1.i=test2.j) OR (test1.i IS NULL AND test2.j IS NULL) ORDER BY 1;


### PR DESCRIPTION
## Summary

EqualOrNullSimplification rewrites `a = b OR (a IS NULL AND b IS NULL)` to `a IS NOT DISTINCT FROM b`. That is only semantics-preserving when the expression is used as a predicate, where `false` and `NULL` both reject rows.

In projections, the rewrite changes SQL three-valued logic by turning `NULL` into `false`.

This restricts the rewrite to root filter/join predicates and keeps projection expressions unchanged.

Fixes #23685.

## Tests

- `build/reldebug/test/unittest test/sql/optimizer/expression/test_equal_or_null_optimization.test`
