### PR TITLE
Simplify boolean wrappers around comparisons

### DIFF
--- a/src/optimizer/rule/comparison_simplification.cpp
+++ b/src/optimizer/rule/comparison_simplification.cpp
@@ -111,6 +111,14 @@ unique_ptr<Expression> ComparisonSimplificationRule::Apply(LogicalOperator &op, 
 		// comparison with constant NULL, return NULL
 		return make_uniq<BoundConstantExpression>(Value(LogicalType::BOOLEAN));
 	}
+	if (BoundComparisonExpression::IsComparison(column_ref_expr) && !constant_value.IsNull() &&
+	    constant_value.type().id() == LogicalTypeId::BOOLEAN && BooleanValue::Get(constant_value)) {
+		if (expr.GetExpressionType() == ExpressionType::COMPARE_EQUAL ||
+		    (expr.GetExpressionType() == ExpressionType::COMPARE_NOT_DISTINCT_FROM && is_root &&
+		     op.type == LogicalOperatorType::LOGICAL_FILTER)) {
+			return column_ref_left ? std::move(left) : std::move(right);
+		}
+	}
 	if (column_ref_expr.GetExpressionClass() == ExpressionClass::BOUND_CAST) {
 		//! Here we check if we can apply the expression on the constant side
 		//! We can do this if the cast itself is invertible and casting the constant is

--- a/test/sql/optimizer/boolean_wrapper_pushdown.test
+++ b/test/sql/optimizer/boolean_wrapper_pushdown.test
@@ -1,0 +1,64 @@
+# name: test/sql/optimizer/boolean_wrapper_pushdown.test
+# description: Simplify boolean wrappers around filter predicates
+# group: [optimizer]
+
+require skip_reload
+
+statement ok
+ATTACH '{TEST_DIR}/boolean_wrapper_pushdown.duckdb' AS db (ROW_GROUP_SIZE 2048);
+
+statement ok
+USE db;
+
+statement ok
+CREATE TABLE integers AS SELECT range::BIGINT AS x FROM range(4096);
+
+query II
+EXPLAIN ANALYZE SELECT sum(rowid) FROM integers WHERE (x > 3000) = true;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 2.*
+
+query II
+EXPLAIN ANALYZE SELECT sum(rowid) FROM integers WHERE (x > 3000) IS TRUE;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 2.*
+
+statement ok
+CREATE TABLE booleans(p BOOLEAN);
+
+statement ok
+INSERT INTO booleans VALUES (true), (false), (NULL);
+
+# IS TRUE must retain its NULL semantics outside a root filter predicate
+query III
+SELECT p, p = true, p IS TRUE FROM booleans ORDER BY p NULLS LAST;
+----
+false	false	false
+true	true	true
+NULL	NULL	false
+
+# Rewriting a nested IS TRUE would incorrectly exclude the NULL row
+query I
+SELECT count(*) FROM booleans WHERE NOT (p IS TRUE);
+----
+2
+
+statement ok
+CREATE SEQUENCE s;
+
+# The rewrite must not duplicate volatile expressions
+query I
+SELECT count(*) FROM booleans WHERE (nextval('s') > 0) IS TRUE;
+----
+3
+
+query I
+SELECT currval('s');
+----
+3
+
+# The rewrite must preserve throwing expressions
+statement error
+SELECT count(*) FROM booleans WHERE (error('expected')::INTEGER > 0) IS TRUE;
+----
+expected


### PR DESCRIPTION
## Summary

Resolves #23626.

This PR simplifies Boolean wrappers around comparison predicates. It removes
safe `= TRUE` and root filter `IS TRUE` wrappers so the comparisons can be
pushed down while preserving NULL semantics.

## Results

```sql
CREATE TABLE t AS
    SELECT printf('%08d', i) AS s, i::BIGINT AS x
    FROM range(10000000) tbl(i);
CHECKPOINT;
EXPLAIN ANALYZE SELECT count(*) FROM t WHERE (x > 9999900) IS TRUE;
```

### Before

```text
╭─ Summary ───────────╮
│ Total Time: 0.0089s │
╰─────────────────────╯
╭─ Ungrouped Aggregate ───────────────────╮
│ Aggregates: count_star()                │
│ 1 row                               0µs │
╰────────────────────┒┎───────────────────╯
╭─ Table Scan ───────┚┖───────────────────╮
│ Table: memory.main.t                    │
│ Type: Sequential Scan                   │
│ Filters:                                │
│ (x > 9999900) IS NOT DISTINCT FROM true │
│ Row Groups Scanned: 82 / 82             │
│ 99 rows                          70.0ms │
╰─────────────────────────────────────────╯
```

### After

```text
╭─ Summary ───────────╮
│ Total Time: 0.0038s │
╰─────────────────────╯
╭─ Ungrouped Aggregate ──────╮
│ Aggregates: count_star()   │
│ 1 row                  0µs │
╰──────────────┒┎────────────╯
╭─ Table Scan ─┚┖────────────╮
│ Table: memory.main.t       │
│ Type: Sequential Scan      │
│ Filters: x > 9999900       │
│ Row Groups Scanned: 1 / 82 │
│ 99 rows                0µs │
╰────────────────────────────╯
```
