### PR TITLE
storage: validate metadata block indexes

### DIFF
--- a/src/storage/metadata/metadata_manager.cpp
+++ b/src/storage/metadata/metadata_manager.cpp
@@ -215,6 +215,9 @@ MetadataPointer MetadataManager::FromDiskPointer(MetaBlockPointer pointer) {
 MetadataPointer MetadataManager::FromDiskPointerInternal(unique_lock<mutex> &block_lock, MetaBlockPointer pointer) {
 	auto block_id = pointer.GetBlockId();
 	auto index = pointer.GetBlockIndex();
+	if (index >= METADATA_BLOCK_COUNT) {
+		throw IOException("Metadata block index %llu exceeds metadata block count %llu", index, METADATA_BLOCK_COUNT);
+	}
 
 	auto entry = blocks.find(block_id);
 	if (entry == blocks.end()) { // LCOV_EXCL_START
@@ -238,9 +241,14 @@ MetadataPointer MetadataManager::RegisterDiskPointer(MetaBlockPointer pointer) {
 }
 
 BlockPointer MetadataManager::ToBlockPointer(MetaBlockPointer meta_pointer, const idx_t metadata_block_size) {
+	auto index = meta_pointer.GetBlockIndex();
+	if (index >= MetadataManager::METADATA_BLOCK_COUNT) {
+		throw IOException("Metadata block index %llu exceeds metadata block count %llu", index,
+		                  MetadataManager::METADATA_BLOCK_COUNT);
+	}
 	BlockPointer result;
 	result.block_id = meta_pointer.GetBlockId();
-	result.offset = meta_pointer.GetBlockIndex() * NumericCast<uint32_t>(metadata_block_size) + meta_pointer.offset;
+	result.offset = index * NumericCast<uint32_t>(metadata_block_size) + meta_pointer.offset;
 	D_ASSERT(result.offset < metadata_block_size * MetadataManager::METADATA_BLOCK_COUNT);
 	return result;
 }
@@ -251,7 +259,10 @@ MetaBlockPointer MetadataManager::FromBlockPointer(BlockPointer block_pointer, c
 	}
 	idx_t index = block_pointer.offset / metadata_block_size;
 	auto offset = block_pointer.offset % metadata_block_size;
-	D_ASSERT(index < MetadataManager::METADATA_BLOCK_COUNT);
+	if (index >= MetadataManager::METADATA_BLOCK_COUNT) {
+		throw IOException("Metadata block offset %llu exceeds metadata block capacity %llu", block_pointer.offset,
+		                  metadata_block_size * MetadataManager::METADATA_BLOCK_COUNT);
+	}
 	D_ASSERT(offset < metadata_block_size);
 	MetaBlockPointer result;
 	result.block_pointer = idx_t(block_pointer.block_id) | index << 56ULL;

--- a/test/api/test_api.cpp
+++ b/test/api/test_api.cpp
@@ -1,12 +1,16 @@
 #include "catch.hpp"
 #include "test_helpers.hpp"
+#include "duckdb/common/checksum.hpp"
 #include "duckdb/parser/parser.hpp"
 #include "duckdb/planner/logical_operator.hpp"
 #include "duckdb/main/connection_manager.hpp"
 #include "duckdb/parser/statement/select_statement.hpp"
 #include "duckdb/parser/query_node/select_node.hpp"
+#include "duckdb/storage/metadata/metadata_manager.hpp"
+#include "duckdb/storage/storage_info.hpp"
 
 #include <chrono>
+#include <fstream>
 #include <thread>
 
 using namespace duckdb;
@@ -569,6 +573,60 @@ TEST_CASE("Test opening an invalid database file", "[api]") {
 		REQUIRE(StringUtil::Contains(ex.what(), "DuckDB"));
 	}
 	REQUIRE(!success);
+}
+
+TEST_CASE("Test opening a database with invalid metadata block index", "[api]") {
+	auto path = TestCreatePath("invalid_metadata_block_index.db");
+	TestDeleteFile(path);
+	{
+		DuckDB db(path);
+		Connection con(db);
+		REQUIRE_NO_FAIL(con.Query("CREATE TABLE t AS SELECT 42 AS i"));
+		REQUIRE_NO_FAIL(con.Query("CHECKPOINT"));
+	}
+
+	vector<data_t> header_buffer(Storage::FILE_HEADER_SIZE);
+	auto read_header = [&](std::fstream &file, idx_t location) {
+		file.seekg(location);
+		file.read(reinterpret_cast<char *>(header_buffer.data()), NumericCast<std::streamsize>(header_buffer.size()));
+		REQUIRE(file.good());
+		auto data = header_buffer.data() + Storage::DEFAULT_BLOCK_HEADER_SIZE;
+		auto iteration = Load<uint64_t>(data);
+		auto meta_block = Load<idx_t>(data + sizeof(uint64_t));
+		return std::make_pair(iteration, meta_block);
+	};
+
+	std::fstream file(path, std::ios::in | std::ios::out | std::ios::binary);
+	REQUIRE(file.is_open());
+	auto h1 = read_header(file, Storage::FILE_HEADER_SIZE);
+	auto h2 = read_header(file, Storage::FILE_HEADER_SIZE * 2);
+	auto active_header = h1.first > h2.first ? Storage::FILE_HEADER_SIZE : Storage::FILE_HEADER_SIZE * 2;
+	auto active_meta_block = h1.first > h2.first ? h1.second : h2.second;
+
+	file.seekg(active_header);
+	file.read(reinterpret_cast<char *>(header_buffer.data()), NumericCast<std::streamsize>(header_buffer.size()));
+	REQUIRE(file.good());
+	auto data = header_buffer.data() + Storage::DEFAULT_BLOCK_HEADER_SIZE;
+	auto invalid_meta_block =
+	    (active_meta_block & ~(idx_t(0xFF) << 56ULL)) | (idx_t(MetadataManager::METADATA_BLOCK_COUNT) << 56ULL);
+	Store<idx_t>(invalid_meta_block, data + sizeof(uint64_t));
+	auto checksum = Checksum(data, Storage::FILE_HEADER_SIZE - Storage::DEFAULT_BLOCK_HEADER_SIZE);
+	Store<uint64_t>(checksum, header_buffer.data());
+	file.seekp(active_header);
+	file.write(reinterpret_cast<const char *>(header_buffer.data()),
+	           NumericCast<std::streamsize>(header_buffer.size()));
+	REQUIRE(file.good());
+	file.close();
+
+	bool success = false;
+	try {
+		DuckDB db(path);
+		success = true;
+	} catch (std::exception &ex) {
+		REQUIRE(StringUtil::Contains(ex.what(), "Metadata block index"));
+	}
+	REQUIRE(!success);
+	TestDeleteFile(path);
 }
 
 TEST_CASE("Test large number of connections to a single database", "[api]") {


### PR DESCRIPTION
## Summary
- validate metadata sub-block indexes before constructing metadata reader pointers
- reject out-of-range legacy block pointer offsets when converting to `MetaBlockPointer`
- add a regression test for a checksum-valid database header with an invalid metadata block index

## Tests
- `build/reldebug/test/unittest "Test opening a database with invalid metadata block index"`
- `build/reldebug/test/unittest "[api]"`