### PR TITLE
Expose destructors, so they are callable module boundaries

### DIFF
--- a/src/include/duckdb/common/http_util.hpp
+++ b/src/include/duckdb/common/http_util.hpp
@@ -81,6 +81,8 @@ struct HTTPHeaders {
 public:
 	HTTPHeaders() = default;
 	explicit HTTPHeaders(DatabaseInstance &db);
+	// Out-of-line so the symbol is emitted/exported for loadable (WASM side-module) extensions.
+	DUCKDB_API ~HTTPHeaders();
 
 	void Insert(string key, string value);
 	bool HasHeader(const string &key) const;
@@ -114,6 +116,8 @@ private:
 
 struct HTTPResponse {
 	explicit HTTPResponse(HTTPStatusCode code);
+	// Out-of-line so the symbol is emitted/exported for loadable (WASM side-module) extensions.
+	DUCKDB_API ~HTTPResponse();
 
 	HTTPStatusCode status;
 	string url;
@@ -138,6 +142,10 @@ public:
 
 struct BaseRequest {
 	BaseRequest(RequestType type, const string &url, const HTTPHeaders &headers, HTTPParams &params);
+	// Out-of-line so the symbol is emitted/exported for loadable (WASM side-module) extensions.
+	// Non-virtual on purpose: these types carry no vtable and are only destroyed as their concrete
+	// stack type, so keeping the dtor non-virtual preserves object layout / ABI.
+	DUCKDB_API ~BaseRequest();
 
 	RequestType type;
 	string url;
@@ -189,6 +197,8 @@ struct GetRequestInfo : public BaseRequest {
 	      response_handler(std::move(response_handler_p)) {
 	}
 
+	DUCKDB_API ~GetRequestInfo();
+
 	std::function<bool(const_data_ptr_t data, idx_t data_length)> content_handler;
 	std::function<bool(const HTTPResponse &response)> response_handler;
 };
@@ -200,6 +210,7 @@ struct PutRequestInfo : public BaseRequest {
 	      buffer_in_len(buffer_in_len), content_type(content_type) {
 		request_body_length = buffer_in_len;
 	}
+	DUCKDB_API ~PutRequestInfo();
 
 	const_data_ptr_t buffer_in;
 	idx_t buffer_in_len;
@@ -210,12 +221,14 @@ struct HeadRequestInfo : public BaseRequest {
 	HeadRequestInfo(const string &path, const HTTPHeaders &headers, HTTPParams &params)
 	    : BaseRequest(RequestType::HEAD_REQUEST, path, headers, params) {
 	}
+	DUCKDB_API ~HeadRequestInfo();
 };
 
 struct DeleteRequestInfo : public BaseRequest {
 	DeleteRequestInfo(const string &path, const HTTPHeaders &headers, HTTPParams &params)
 	    : BaseRequest(RequestType::DELETE_REQUEST, path, headers, params) {
 	}
+	DUCKDB_API ~DeleteRequestInfo();
 };
 
 struct OptionsRequestInfo : public BaseRequest {
@@ -231,6 +244,8 @@ struct PostRequestInfo : public BaseRequest {
 	      buffer_in_len(buffer_in_len) {
 		request_body_length = buffer_in_len;
 	}
+
+	DUCKDB_API ~PostRequestInfo();
 
 	const_data_ptr_t buffer_in;
 	idx_t buffer_in_len;

--- a/src/main/http/http_util.cpp
+++ b/src/main/http/http_util.cpp
@@ -38,6 +38,8 @@ HTTPHeaders::HTTPHeaders(DatabaseInstance &db) {
 	headers.insert({"User-Agent", StringUtil::Format("%s %s", db.config.UserAgent(), DuckDB::SourceID())});
 }
 
+HTTPHeaders::~HTTPHeaders() = default;
+
 void HTTPHeaders::Insert(string key, string value) {
 	headers.insert(make_pair(std::move(key), std::move(value)));
 }
@@ -74,6 +76,8 @@ unique_ptr<HTTPResponse> TransformResponse(duckdb_httplib::Result &res) {
 
 HTTPResponse::HTTPResponse(HTTPStatusCode code) : status(code) {
 }
+
+HTTPResponse::~HTTPResponse() = default;
 
 bool HTTPResponse::HasHeader(const string &key) const {
 	return headers.HasHeader(key);
@@ -142,6 +146,15 @@ BaseRequest::BaseRequest(RequestType type, const string &url, const HTTPHeaders 
     : type(type), url(url), headers(MergeHeaders(headers, params)), params(params) {
 	HTTPUtil::DecomposeURL(url, path, proto_host_port);
 }
+
+// Out-of-line destructors: force the symbols to be emitted and exported from the main WASM module so
+// loadable side-module extensions (e.g. the aws/httpfs extensions) can link against them at load time.
+BaseRequest::~BaseRequest() = default;
+GetRequestInfo::~GetRequestInfo() = default;
+PutRequestInfo::~PutRequestInfo() = default;
+HeadRequestInfo::~HeadRequestInfo() = default;
+DeleteRequestInfo::~DeleteRequestInfo() = default;
+PostRequestInfo::~PostRequestInfo() = default;
 
 #ifndef DUCKDB_DISABLE_BUILTIN_HTTPLIB
 class HTTPLibClient : public HTTPClient {


### PR DESCRIPTION
Solve an issue encounterd in duckdb-wasm, where extensions don't carry a copy of duckdb library but rely on symbols being available from main module. A similar issue might surface on certain codepaths while using HTTPUtil from an extension AND dynamically loading extensions AND compiling extensions without EXTENSION_STATIC_BUILD.

Same as https://github.com/duckdb/duckdb/pull/23953, but needed also on `main`.