### PR TITLE
Fix TIME_NS read/write with parquet

### DIFF
--- a/extension/parquet/column_writer.cpp
+++ b/extension/parquet/column_writer.cpp
@@ -459,6 +459,7 @@ unique_ptr<ColumnWriter> ColumnWriter::CreateWriterRecursive(ClientContext &cont
 		return make_uniq<StandardColumnWriter<int32_t, int32_t>>(writer, std::move(schema), path_in_schema);
 	case LogicalTypeId::BIGINT:
 	case LogicalTypeId::TIME:
+	case LogicalTypeId::TIME_NS:
 		return make_uniq<StandardColumnWriter<int64_t, int64_t>>(writer, std::move(schema), path_in_schema);
 	case LogicalTypeId::TIMESTAMP:
 	case LogicalTypeId::TIMESTAMP_TZ:

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -419,6 +419,8 @@ LogicalType ParquetReader::DeriveLogicalType(const SchemaElement &s_ele, const P
 			}
 			if (s_ele.logicalType.TIME.isAdjustedToUTC) {
 				return LogicalType::TIME_TZ;
+			} else if (s_ele.logicalType.TIME.unit.__isset.NANOS) {
+				return LogicalType::TIME_NS;
 			}
 			return LogicalType::TIME;
 		}

--- a/extension/parquet/parquet_writer.cpp
+++ b/extension/parquet/parquet_writer.cpp
@@ -141,6 +141,7 @@ bool ParquetWriter::TryGetParquetType(const LogicalType &duckdb_type, optional_p
 		parquet_type = Type::BYTE_ARRAY;
 		break;
 	case LogicalTypeId::TIME:
+	case LogicalTypeId::TIME_NS:
 	case LogicalTypeId::TIME_TZ:
 		parquet_type = Type::INT64;
 		break;
@@ -269,6 +270,12 @@ void ParquetWriter::SetSchemaProperties(const LogicalType &duckdb_type, duckdb_p
 		schema_ele.logicalType.__isset.TIME = true;
 		schema_ele.logicalType.TIME.isAdjustedToUTC = (duckdb_type.id() == LogicalTypeId::TIME_TZ);
 		schema_ele.logicalType.TIME.unit.__isset.MICROS = true;
+		break;
+	case LogicalTypeId::TIME_NS:
+		schema_ele.__isset.logicalType = true;
+		schema_ele.logicalType.__isset.TIME = true;
+		schema_ele.logicalType.TIME.isAdjustedToUTC = false;
+		schema_ele.logicalType.TIME.unit.__isset.NANOS = true;
 		break;
 	case LogicalTypeId::TIMESTAMP_TZ:
 	case LogicalTypeId::TIMESTAMP:

--- a/src/function/cast/time_casts.cpp
+++ b/src/function/cast/time_casts.cpp
@@ -62,6 +62,9 @@ BoundCastInfo DefaultCasts::TimeCastSwitch(BindCastInput &input, const LogicalTy
 	case LogicalTypeId::VARCHAR:
 		// time to varchar
 		return BoundCastInfo(&VectorCastHelpers::StringCast<dtime_t, duckdb::StringCast>);
+	case LogicalTypeId::TIME_NS:
+		// time (us) to time (ns)
+		return BoundCastInfo(&VectorCastHelpers::TryCastLoop<dtime_t, dtime_ns_t, duckdb::TryCast>);
 	case LogicalTypeId::TIME_TZ:
 		// time to time with time zone
 		return BoundCastInfo(&VectorCastHelpers::TryCastLoop<dtime_t, dtime_tz_t, duckdb::TryCast>);

--- a/test/parquet/timens_parquet.test
+++ b/test/parquet/timens_parquet.test
@@ -66,3 +66,19 @@ TIME_NS	23:59:59.123456789
 query I nosort t0
 from '{TEST_DIR}/time_ns.parquet';
 ----
+
+# Combine TIME(MICROS) and TIME(NANOS) files without losing precision
+statement ok
+COPY (SELECT '12:34:56.123456'::TIME AS t)
+TO '{TEST_DIR}/time_micro.parquet' (FORMAT PARQUET);
+
+statement ok
+COPY (SELECT '12:34:56.123456789'::TIME_NS AS t)
+TO '{TEST_DIR}/time_nano.parquet' (FORMAT PARQUET);
+
+query TT rowsort
+SELECT typeof(t), t::VARCHAR
+FROM read_parquet(['{TEST_DIR}/time_micro.parquet', '{TEST_DIR}/time_nano.parquet'], union_by_name = true);
+----
+TIME_NS	12:34:56.123456
+TIME_NS	12:34:56.123456789

--- a/test/parquet/timens_parquet.test
+++ b/test/parquet/timens_parquet.test
@@ -49,6 +49,20 @@ from times
 statement ok
 copy times to '{TEST_DIR}/time_ns.parquet' (PARQUET_VERSION V2);
 
+query TT
+SELECT duckdb_type, logical_type LIKE 'TimeType%NANOS%'
+FROM parquet_schema('{TEST_DIR}/time_ns.parquet')
+WHERE name = 'tns';
+----
+TIME_NS	true
+
+query TT
+SELECT typeof(tns), tns::VARCHAR
+FROM '{TEST_DIR}/time_ns.parquet'
+WHERE tns = '23:59:59.123456789';
+----
+TIME_NS	23:59:59.123456789
+
 query I nosort t0
 from '{TEST_DIR}/time_ns.parquet';
 ----

--- a/test/sql/types/time/test_time_ns.test
+++ b/test/sql/types/time/test_time_ns.test
@@ -297,6 +297,12 @@ not recognized
 # Casts
 #
 
+# TIME => TIME_NS
+query I
+SELECT '23:59:59.123456'::TIME::TIME_NS;
+----
+23:59:59.123456
+
 # TIME_NS => TIME
 query II
 SELECT tns, tns::TIME t


### PR DESCRIPTION
Closes https://github.com/duckdb/duckdb/issues/23957
Closes https://github.com/duckdb/duckdb/issues/23956

I think there're two issues in the current parquet implementation:
- On write, we don't handle `TIME_NS` type, so it [fallbacks to `VARCHAR` type](https://github.com/duckdb/duckdb/blob/08cb7a49e91f14edc6dfa8b497268eabc6533f8d/extension/parquet/parquet_extension.cpp#L930-L932)
- On read, when `time.NANOS` set, we should convert into DuckDB `TIME_NS` logical type
- (not related to parquet) We don't have cast impl for TIME && TIME_NS