### PR TITLE
Skip win32 tests (if requested) in CI and consider alpha version as a (pre)release

### DIFF
--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -179,10 +179,12 @@ jobs:
 
     - name: Test
       shell: bash
+      if: ${{ !inputs.skip_tests }}
       run: python test/run.py
 
     - name: Tools Test
       shell: bash
+      if: ${{ !inputs.skip_tests }}
       run: |
         python scripts/ci/retry.py -- python -m pip install pytest
         python -m pytest tools/shell/tests --shell-binary duckdb.exe

--- a/src/main/extension.cpp
+++ b/src/main/extension.cpp
@@ -104,7 +104,7 @@ bool VersioningUtils::IsSupportedCAPIVersion(string &capi_version_string) {
 }
 
 bool VersioningUtils::IsReleaseVersion(const string &version_tag) {
-	return !StringUtil::Contains(version_tag, "-dev") && !StringUtil::Contains(version_tag, "-alpha");
+	return !StringUtil::Contains(version_tag, "-dev");
 }
 
 bool VersioningUtils::IsSupportedCAPIVersion(idx_t major, idx_t minor, idx_t patch) {

--- a/test/common/CMakeLists.txt
+++ b/test/common/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library_unity(
   test_substring_oob.cpp
   test_utf8_codepoint_oob.cpp
   test_temporary_memory_manager.cpp
+  test_versioning_utils.cpp
   test_value_to_sql_string.cpp)
 
 set(UNITTEST_OBJECT_FILES

--- a/test/common/test_versioning_utils.cpp
+++ b/test/common/test_versioning_utils.cpp
@@ -1,0 +1,11 @@
+#include "duckdb/main/extension.hpp"
+#include "catch.hpp"
+
+using namespace duckdb;
+
+TEST_CASE("Test release version detection", "[extension]") {
+	REQUIRE(VersioningUtils::IsReleaseVersion("v2.0.0"));
+	REQUIRE(VersioningUtils::IsReleaseVersion("v2.0.0-alpha35155"));
+	REQUIRE(VersioningUtils::IsReleaseVersion("v2.0.0-rc1"));
+	REQUIRE_FALSE(VersioningUtils::IsReleaseVersion("v2.0.0-dev123"));
+}


### PR DESCRIPTION
The CI run from lunch [failed](https://github.com/duckdb/duckdb/actions/runs/29735127576/job/88329760195) and this should fix both problems:
- windows 32-bit CI was running tests while it should not (lunch CI runs with disabled tests).
- the tests detected that "alpha" is not considered a (pre)release version.