### PR TITLE
Shrink the in-memory footprint of deleted rows

### DIFF
--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -6297,6 +6297,25 @@ VerifyExistenceType EnumUtil::FromString<VerifyExistenceType>(const char *value)
 	return static_cast<VerifyExistenceType>(StringUtil::StringToEnum(GetVerifyExistenceTypeValues(), 3, "VerifyExistenceType", value));
 }
 
+const StringUtil::EnumStringLiteral *GetVersionCompressionResultValues() {
+	static constexpr StringUtil::EnumStringLiteral values[] {
+		{ static_cast<uint32_t>(VersionCompressionResult::FULLY_COMPRESSED), "FULLY_COMPRESSED" },
+		{ static_cast<uint32_t>(VersionCompressionResult::PENDING), "PENDING" },
+		{ static_cast<uint32_t>(VersionCompressionResult::SETTLED), "SETTLED" }
+	};
+	return values;
+}
+
+template<>
+const char* EnumUtil::ToChars<VersionCompressionResult>(VersionCompressionResult value) {
+	return StringUtil::EnumToString(GetVersionCompressionResultValues(), 3, "VersionCompressionResult", static_cast<uint32_t>(value));
+}
+
+template<>
+VersionCompressionResult EnumUtil::FromString<VersionCompressionResult>(const char *value) {
+	return static_cast<VersionCompressionResult>(StringUtil::StringToEnum(GetVersionCompressionResultValues(), 3, "VersionCompressionResult", value));
+}
+
 const StringUtil::EnumStringLiteral *GetVertexTypeValues() {
 	static constexpr StringUtil::EnumStringLiteral values[] {
 		{ static_cast<uint32_t>(VertexType::XY), "XY" },

--- a/src/include/duckdb/common/enum_util.hpp
+++ b/src/include/duckdb/common/enum_util.hpp
@@ -564,6 +564,8 @@ enum class VectorType : uint8_t;
 
 enum class VerifyExistenceType : uint8_t;
 
+enum class VersionCompressionResult : uint8_t;
+
 enum class VertexType : uint8_t;
 
 enum class WALType : uint8_t;
@@ -1374,6 +1376,9 @@ const char* EnumUtil::ToChars<VectorType>(VectorType value);
 
 template<>
 const char* EnumUtil::ToChars<VerifyExistenceType>(VerifyExistenceType value);
+
+template<>
+const char* EnumUtil::ToChars<VersionCompressionResult>(VersionCompressionResult value);
 
 template<>
 const char* EnumUtil::ToChars<VertexType>(VertexType value);
@@ -2191,6 +2196,9 @@ VectorType EnumUtil::FromString<VectorType>(const char *value);
 
 template<>
 VerifyExistenceType EnumUtil::FromString<VerifyExistenceType>(const char *value);
+
+template<>
+VersionCompressionResult EnumUtil::FromString<VersionCompressionResult>(const char *value);
 
 template<>
 VertexType EnumUtil::FromString<VertexType>(const char *value);

--- a/src/include/duckdb/storage/table/chunk_info.hpp
+++ b/src/include/duckdb/storage/table/chunk_info.hpp
@@ -21,98 +21,33 @@ class Serializer;
 class Deserializer;
 class FixedSizeAllocator;
 
+//! The type of a serialized chunk info entry
+//! In-memory all chunk infos are represented by ChunkVectorInfo - CONSTANT_INFO (a fully deleted vector) and
+//! EMPTY_INFO (no deletes) only exist as tags in the serialized format
 enum class ChunkInfoType : uint8_t { CONSTANT_INFO, VECTOR_INFO, EMPTY_INFO };
 
-class ChunkInfo {
+//! ChunkVectorInfo holds the version information (the insert and delete ids) of the rows of a single vector within
+//! a row group. The insert and delete ids are stored as constants when all rows share the same id, and as per-row
+//! id arrays otherwise.
+class ChunkVectorInfo {
 public:
-	ChunkInfo(idx_t start, ChunkInfoType type) : start(start), type(type) {
-	}
-	virtual ~ChunkInfo() {
-	}
+	explicit ChunkVectorInfo(FixedSizeAllocator &allocator, idx_t start, transaction_t insert_id = 0);
+	ChunkVectorInfo(FixedSizeAllocator &allocator, idx_t start, transaction_t insert_id, transaction_t delete_id);
+	~ChunkVectorInfo();
 
 	//! The row index of the first row
 	idx_t start;
-	//! The ChunkInfo type
-	ChunkInfoType type;
 
 public:
 	//! Gets up to max_count entries from the chunk info. If the ret is 0>ret>max_count, the selection vector is filled
 	//! with the tuples
-	virtual idx_t GetSelVector(ScanOptions options, optional_ptr<SelectionVector> sel_vector,
-	                           idx_t max_count) const = 0;
-	//! Returns whether or not a single row in the ChunkInfo should be used or not for the given transaction
-	virtual bool Fetch(TransactionData transaction, row_t row) = 0;
-	virtual void CommitAppend(transaction_t commit_id, idx_t start, idx_t end) = 0;
+	idx_t GetSelVector(ScanOptions options, optional_ptr<SelectionVector> sel_vector, idx_t max_count) const;
 	idx_t GetRowCount(ScanOptions options, idx_t max_count);
-	virtual bool Cleanup(transaction_t lowest_transaction) const;
-	virtual string ToString(idx_t max_count) const = 0;
-
-	virtual bool HasDeletes(transaction_t transaction_id = MAX_TRANSACTION_ID) const = 0;
-	virtual bool HasUncommittedChanges() const = 0;
-
-	virtual void Write(WriteStream &writer, transaction_t transaction_id) const;
-	static unique_ptr<ChunkInfo> Read(FixedSizeAllocator &allocator, ReadStream &reader);
-
-public:
-	template <class TARGET>
-	TARGET &Cast() {
-		if (type != TARGET::TYPE) {
-			throw InternalException("Failed to cast chunk info to type - query result type mismatch");
-		}
-		return reinterpret_cast<TARGET &>(*this);
-	}
-
-	template <class TARGET>
-	const TARGET &Cast() const {
-		if (type != TARGET::TYPE) {
-			throw InternalException("Failed to cast chunk info to type - query result type mismatch");
-		}
-		return reinterpret_cast<const TARGET &>(*this);
-	}
-};
-
-class ChunkConstantInfo : public ChunkInfo {
-public:
-	static constexpr const ChunkInfoType TYPE = ChunkInfoType::CONSTANT_INFO;
-
-public:
-	explicit ChunkConstantInfo(idx_t start);
-
-	transaction_t insert_id;
-	transaction_t delete_id;
-
-public:
-	idx_t GetSelVector(ScanOptions options, optional_ptr<SelectionVector> sel_vector, idx_t max_count) const override;
-	bool Fetch(TransactionData transaction, row_t row) override;
-	void CommitAppend(transaction_t commit_id, idx_t start, idx_t end) override;
-	bool Cleanup(transaction_t lowest_transaction) const override;
-	string ToString(idx_t max_count) const override;
-
-	bool HasDeletes(transaction_t transaction_id = MAX_TRANSACTION_ID) const override;
-	bool HasUncommittedChanges() const override;
-
-	void Write(WriteStream &writer, transaction_t transaction_id) const override;
-	static unique_ptr<ChunkInfo> Read(ReadStream &reader);
-
-private:
-	template <class INSERT_OP, class DELETE_OP>
-	idx_t TemplatedGetSelVector(transaction_t start_time, transaction_t transaction_id, idx_t max_count) const;
-};
-
-class ChunkVectorInfo : public ChunkInfo {
-public:
-	static constexpr const ChunkInfoType TYPE = ChunkInfoType::VECTOR_INFO;
-
-public:
-	explicit ChunkVectorInfo(FixedSizeAllocator &allocator, idx_t start, transaction_t insert_id = 0);
-	~ChunkVectorInfo() override;
-
-public:
-	idx_t GetSelVector(ScanOptions options, optional_ptr<SelectionVector> sel_vector, idx_t max_count) const override;
-	bool Fetch(TransactionData transaction, row_t row) override;
-	void CommitAppend(transaction_t commit_id, idx_t start, idx_t end) override;
-	bool Cleanup(transaction_t lowest_transaction) const override;
-	string ToString(idx_t max_count) const override;
+	//! Returns whether or not a single row in the ChunkVectorInfo should be used or not for the given transaction
+	bool Fetch(TransactionData transaction, row_t row);
+	void CommitAppend(transaction_t commit_id, idx_t start, idx_t end);
+	bool Cleanup(transaction_t lowest_transaction) const;
+	string ToString(idx_t max_count) const;
 
 	void Append(idx_t start, idx_t end, transaction_t commit_id);
 
@@ -124,14 +59,21 @@ public:
 	idx_t Delete(transaction_t transaction_id, row_t rows[], idx_t count);
 	void CommitDelete(transaction_t commit_id, const DeleteInfo &info);
 
-	bool HasDeletes(transaction_t transaction_id = MAX_TRANSACTION_ID) const override;
-	bool HasUncommittedChanges() const override;
+	//! Attempts to compress the per-row insert/delete ids into constants
+	//! This is possible when the ids behave identically for all transactions with a start time of at least
+	//! lowest_active_start (i.e. all active and future transactions)
+	void CompressVersionIds(transaction_t lowest_active_start);
+
+	bool HasDeletes(transaction_t transaction_id = MAX_TRANSACTION_ID) const;
+	bool HasUncommittedChanges() const;
 	bool AnyDeleted() const;
 	bool HasConstantInsertionId() const;
 	transaction_t ConstantInsertId() const;
+	bool HasConstantDeleteId() const;
+	transaction_t ConstantDeleteId() const;
 
-	void Write(WriteStream &writer, transaction_t transaction_id) const override;
-	static unique_ptr<ChunkInfo> Read(FixedSizeAllocator &allocator, ReadStream &reader);
+	void Write(WriteStream &writer, transaction_t transaction_id) const;
+	static unique_ptr<ChunkVectorInfo> Read(FixedSizeAllocator &allocator, ReadStream &reader);
 
 private:
 	template <class INSERT_OP, class DELETE_OP>
@@ -142,6 +84,8 @@ private:
 	IndexPointer GetDeletedPointer() const;
 	IndexPointer GetInitializedInsertedPointer();
 	IndexPointer GetInitializedDeletedPointer();
+	//! Frees the per-row delete ids (if any)
+	void FreeDeleteData();
 
 private:
 	FixedSizeAllocator &allocator;
@@ -152,6 +96,8 @@ private:
 
 	//! The transaction ids of the transactions that deleted the tuples (if any)
 	IndexPointer deleted_data;
+	//! The constant delete id (if there is only one, e.g. because the entire vector was deleted in one transaction)
+	transaction_t constant_delete_id;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/table/chunk_info.hpp
+++ b/src/include/duckdb/storage/table/chunk_info.hpp
@@ -29,6 +29,19 @@ enum class ChunkInfoType : uint8_t { CONSTANT_INFO, VECTOR_INFO, EMPTY_INFO };
 //! ChunkVectorInfo holds the version information (the insert and delete ids) of the rows of a single vector within
 //! a row group. The insert and delete ids are stored as constants when all rows share the same id, and as per-row
 //! id arrays otherwise.
+
+//! The result of a CompressVersionIds pass over a vector
+enum class VersionCompressionResult : uint8_t {
+	//! No per-row id arrays remain - there is nothing left to compress
+	FULLY_COMPRESSED,
+	//! Some ids are not yet visible to all transactions - compression can succeed once the
+	//! lowest active start advances past them, without any further modifications
+	PENDING,
+	//! Per-row arrays remain that cannot compress without further modifications
+	//! (some rows are not deleted)
+	SETTLED
+};
+
 class ChunkVectorInfo {
 public:
 	explicit ChunkVectorInfo(FixedSizeAllocator &allocator, idx_t start, transaction_t insert_id = 0);
@@ -62,7 +75,14 @@ public:
 	//! Attempts to compress the per-row insert/delete ids into constants
 	//! This is possible when the ids behave identically for all transactions with a start time of at least
 	//! lowest_active_start (i.e. all active and future transactions)
-	void CompressVersionIds(transaction_t lowest_active_start);
+	VersionCompressionResult CompressVersionIds(transaction_t lowest_active_start);
+	//! Whether a compression pass could achieve anything for this vector (see recheck_compression)
+	bool RecheckCompression() const {
+		return recheck_compression;
+	}
+	//! Verifies (in DEBUG) that a disarmed recheck_compression matches the actual ids: nothing may be
+	//! compressible now or in the future without a modification that re-arms the check
+	void VerifyCachedCompressionState() const;
 
 	bool HasDeletes(transaction_t transaction_id = MAX_TRANSACTION_ID) const;
 	bool HasUncommittedChanges() const;
@@ -98,6 +118,11 @@ private:
 	IndexPointer deleted_data;
 	//! The constant delete id (if there is only one, e.g. because the entire vector was deleted in one transaction)
 	transaction_t constant_delete_id;
+	//! Whether a compression pass could achieve anything for this vector: armed by any id modification,
+	//! disarmed when a pass compresses the vector fully or finds it settled (live rows block the collapse
+	//! until a further delete re-arms it). CompressVersionIds returns the cached SETTLED without
+	//! re-scanning the ids while this is false.
+	bool recheck_compression = true;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/table/row_group.hpp
+++ b/src/include/duckdb/storage/table/row_group.hpp
@@ -238,6 +238,10 @@ public:
 	idx_t GetColumnCount() const;
 
 	vector<MetaBlockPointer> CheckpointDeletes(RowGroupWriter &writer);
+	//! Attempts to compress the version information of the row group
+	//! Per-row insert/delete ids that behave identically for all transactions with a start time of at least
+	//! lowest_active_start (i.e. all active and future transactions) are compressed into constants
+	void CompressVersionInfo(transaction_t lowest_active_start);
 
 	//! Direct accessors, fall outside of general use but can be useful to some extensions
 	ColumnData &GetRawColumnData(const StorageIndex &c) const;

--- a/src/include/duckdb/storage/table/row_version_manager.hpp
+++ b/src/include/duckdb/storage/table/row_version_manager.hpp
@@ -39,6 +39,11 @@ public:
 	idx_t DeleteRows(idx_t vector_idx, transaction_t transaction_id, row_t rows[], idx_t count);
 	void CommitDelete(idx_t vector_idx, transaction_t commit_id, const DeleteInfo &info);
 
+	//! Attempts to compress the per-row insert/delete ids of each vector into constants
+	//! This is possible when the ids behave identically for all transactions with a start time of at least
+	//! lowest_active_start (i.e. all active and future transactions)
+	void CompressVersionIds(transaction_t lowest_active_start);
+
 	vector<MetaBlockPointer> Checkpoint(RowGroupWriter &writer);
 	static shared_ptr<RowVersionManager> Deserialize(MetaBlockPointer delete_pointer, MetadataManager &manager);
 
@@ -50,7 +55,7 @@ public:
 private:
 	mutex version_lock;
 	FixedSizeAllocator allocator;
-	vector<unique_ptr<ChunkInfo>> vector_info;
+	vector<unique_ptr<ChunkVectorInfo>> vector_info;
 	optional_idx uncheckpointed_delete_commit;
 	vector<MetaBlockPointer> storage_pointers;
 
@@ -58,7 +63,7 @@ private:
 	FixedSizeAllocator &GetAllocator() {
 		return allocator;
 	}
-	optional_ptr<ChunkInfo> GetChunkInfo(idx_t vector_idx);
+	optional_ptr<ChunkVectorInfo> GetChunkInfo(idx_t vector_idx);
 	ChunkVectorInfo &GetVectorInfo(idx_t vector_idx);
 	void FillVectorInfo(idx_t vector_idx);
 };

--- a/src/include/duckdb/storage/table/row_version_manager.hpp
+++ b/src/include/duckdb/storage/table/row_version_manager.hpp
@@ -42,6 +42,8 @@ public:
 	//! Attempts to compress the per-row insert/delete ids of each vector into constants
 	//! This is possible when the ids behave identically for all transactions with a start time of at least
 	//! lowest_active_start (i.e. all active and future transactions)
+	//! Cheap when nothing can have changed: the pass only runs when version ids were modified since the
+	//! last pass, or when a previous pass left ids that can still compress once older transactions finish
 	void CompressVersionIds(transaction_t lowest_active_start);
 
 	vector<MetaBlockPointer> Checkpoint(RowGroupWriter &writer);
@@ -58,6 +60,10 @@ private:
 	vector<unique_ptr<ChunkVectorInfo>> vector_info;
 	optional_idx uncheckpointed_delete_commit;
 	vector<MetaBlockPointer> storage_pointers;
+	//! Whether a compression pass may achieve anything: set when version ids are modified, cleared when a
+	//! pass finds no ids that could still compress. For deserialized version info this is derived from the
+	//! deserialized content (with the current storage format checkpointed ids are always settled).
+	bool needs_compression_check = false;
 
 private:
 	FixedSizeAllocator &GetAllocator() {

--- a/src/storage/table/chunk_info.cpp
+++ b/src/storage/table/chunk_info.cpp
@@ -273,6 +273,8 @@ idx_t ChunkVectorInfo::Delete(transaction_t transaction_id, row_t rows[], idx_t 
 		constant_delete_id = transaction_id;
 		return count;
 	}
+	// we are materializing / modifying per-row delete ids - re-arm the compression check
+	recheck_compression = true;
 	auto segment = allocator.GetHandle(GetInitializedDeletedPointer());
 	auto deleted = segment.GetPtr<transaction_t>();
 
@@ -310,6 +312,8 @@ void ChunkVectorInfo::CommitDelete(transaction_t commit_id, const DeleteInfo &in
 		// all rows already share this exact deleted id - nothing to do
 		return;
 	}
+	// we are materializing / modifying per-row delete ids - re-arm the compression check
+	recheck_compression = true;
 	bool all_equal = true;
 	{
 		auto segment = allocator.GetHandle(GetInitializedDeletedPointer());
@@ -340,27 +344,70 @@ void ChunkVectorInfo::CommitDelete(transaction_t commit_id, const DeleteInfo &in
 	}
 }
 
-void ChunkVectorInfo::CompressVersionIds(transaction_t lowest_active_start) {
+void ChunkVectorInfo::VerifyCachedCompressionState() const {
+#ifdef DEBUG
+	if (recheck_compression) {
+		// armed - the next pass re-derives everything from the ids, there is no cached claim to verify
+		return;
+	}
+	// a disarmed check claims that nothing can compress, now or as older transactions finish, until a
+	// modification re-arms it. Both conditions below are independent of the lowest active start:
+	// per-row insert ids all become visible (or are reverted) eventually, so they must already be compressed
+	D_ASSERT(HasConstantInsertionId());
+	if (!HasConstantDeleteId()) {
+		// per-row delete ids may only remain because a live row blocks the collapse
+		auto segment = allocator.GetHandle(GetDeletedPointer());
+		auto deleted = segment.GetPtr<transaction_t>();
+		bool rows_alive = false;
+		for (idx_t i = 0; i < STANDARD_VECTOR_SIZE; i++) {
+			if (deleted[i] == NOT_DELETED_ID) {
+				rows_alive = true;
+				break;
+			}
+		}
+		D_ASSERT(rows_alive);
+	}
+#endif
+}
+
+VersionCompressionResult ChunkVectorInfo::CompressVersionIds(transaction_t lowest_active_start) {
+	if (!recheck_compression) {
+		// no ids were modified since this vector last settled - only a further modification
+		// (which re-arms the check) can make it compressible, so skip re-scanning the ids
+#ifdef DEBUG
+		VerifyCachedCompressionState();
+#endif
+		return HasConstantDeleteId() && HasConstantInsertionId() ? VersionCompressionResult::FULLY_COMPRESSED
+		                                                         : VersionCompressionResult::SETTLED;
+	}
+	bool pending = false;
 	if (!HasConstantDeleteId()) {
 		// check if all rows are deleted, with all deletes visible to all active and future transactions
 		// if so, the per-row delete ids are equivalent to a single constant delete id
-		bool can_compress = true;
+		bool rows_alive = false;
+		bool deletes_pending = false;
 		transaction_t max_delete_id = 0;
 		{
 			auto segment = allocator.GetHandle(GetDeletedPointer());
 			auto deleted = segment.GetPtr<transaction_t>();
 			for (idx_t i = 0; i < STANDARD_VECTOR_SIZE; i++) {
-				if (deleted[i] >= lowest_active_start) {
-					// the row is not deleted, or the delete is not yet visible to all transactions
-					can_compress = false;
-					break;
+				if (deleted[i] == NOT_DELETED_ID) {
+					// the row is not deleted - the ids cannot compress until it is
+					rows_alive = true;
+				} else if (deleted[i] >= lowest_active_start) {
+					// deleted, but the delete is not yet visible to all transactions - the ids can
+					// compress once the lowest active start advances past the delete id
+					deletes_pending = true;
+				} else {
+					max_delete_id = MaxValue(max_delete_id, deleted[i]);
 				}
-				max_delete_id = MaxValue(max_delete_id, deleted[i]);
 			}
 		}
-		if (can_compress) {
+		if (!rows_alive && !deletes_pending) {
 			FreeDeleteData();
 			constant_delete_id = max_delete_id;
+		} else if (!rows_alive) {
+			pending = true;
 		}
 	}
 	if (!HasConstantInsertionId()) {
@@ -382,8 +429,16 @@ void ChunkVectorInfo::CompressVersionIds(transaction_t lowest_active_start) {
 			allocator.Free(inserted_data);
 			inserted_data = IndexPointer();
 			constant_insert_id = 0;
+		} else {
+			// insert ids become visible to all transactions (or are reverted) eventually
+			pending = true;
 		}
 	}
+	recheck_compression = pending;
+	if (HasConstantDeleteId() && HasConstantInsertionId()) {
+		return VersionCompressionResult::FULLY_COMPRESSED;
+	}
+	return pending ? VersionCompressionResult::PENDING : VersionCompressionResult::SETTLED;
 }
 
 void ChunkVectorInfo::Append(idx_t start, idx_t end, transaction_t commit_id) {
@@ -397,6 +452,8 @@ void ChunkVectorInfo::Append(idx_t start, idx_t end, transaction_t commit_id) {
 		return;
 	}
 
+	// we are materializing / modifying per-row insert ids - re-arm the compression check
+	recheck_compression = true;
 	auto segment = allocator.GetHandle(GetInitializedInsertedPointer());
 	auto inserted = segment.GetPtr<transaction_t>();
 	for (idx_t i = start; i < end; i++) {
@@ -409,6 +466,8 @@ void ChunkVectorInfo::CommitAppend(transaction_t commit_id, idx_t start, idx_t e
 		constant_insert_id = commit_id;
 		return;
 	}
+	// we are modifying per-row insert ids - re-arm the compression check
+	recheck_compression = true;
 	auto segment = allocator.GetHandle(GetInsertedPointer());
 	auto inserted = segment.GetPtr<transaction_t>();
 
@@ -600,7 +659,10 @@ unique_ptr<ChunkVectorInfo> ChunkVectorInfo::Read(FixedSizeAllocator &allocator,
 	case ChunkInfoType::CONSTANT_INFO: {
 		// a fully deleted vector - the constant insert and delete ids of 0 are visible to all transactions
 		auto start = reader.Read<idx_t>();
-		return make_uniq<ChunkVectorInfo>(allocator, start, 0, 0);
+		auto result = make_uniq<ChunkVectorInfo>(allocator, start, 0, 0);
+		// both ids are constant - there is nothing left to compress
+		result->recheck_compression = false;
+		return result;
 	}
 	case ChunkInfoType::VECTOR_INFO: {
 		// a partially deleted vector - the deleted rows are stored as a boolean mask
@@ -609,13 +671,20 @@ unique_ptr<ChunkVectorInfo> ChunkVectorInfo::Read(FixedSizeAllocator &allocator,
 		ValidityMask mask;
 		mask.Read(reader, STANDARD_VECTOR_SIZE);
 
+		bool rows_alive = false;
 		auto segment = allocator.GetHandle(result->GetInitializedDeletedPointer());
 		auto deleted = segment.GetPtr<transaction_t>();
 		for (idx_t i = 0; i < STANDARD_VECTOR_SIZE; i++) {
 			if (mask.RowIsValid(i)) {
 				deleted[i] = 0;
+			} else {
+				rows_alive = true;
 			}
 		}
+		// the reconstructed ids are all visible to all transactions, so the vector can only be
+		// compressible if every row is deleted (in which case Write emits CONSTANT_INFO instead,
+		// so with the current format the ids are always settled here)
+		result->recheck_compression = !rows_alive;
 		return result;
 	}
 	default:

--- a/src/storage/table/chunk_info.cpp
+++ b/src/storage/table/chunk_info.cpp
@@ -44,140 +44,21 @@ static bool UseVersion(TransactionData transaction, transaction_t id) {
 	return StandardInsertOperator::UseInsertedVersion(transaction.start_time, transaction.transaction_id, id);
 }
 
-bool ChunkInfo::Cleanup(transaction_t lowest_transaction) const {
-	return false;
+ChunkVectorInfo::ChunkVectorInfo(FixedSizeAllocator &allocator_p, idx_t start, transaction_t insert_id_p)
+    : ChunkVectorInfo(allocator_p, start, insert_id_p, NOT_DELETED_ID) {
 }
 
-void ChunkInfo::Write(WriteStream &writer, transaction_t checkpoint_id) const {
-	writer.Write<ChunkInfoType>(type);
+ChunkVectorInfo::ChunkVectorInfo(FixedSizeAllocator &allocator_p, idx_t start, transaction_t insert_id_p,
+                                 transaction_t delete_id_p)
+    : start(start), allocator(allocator_p), constant_insert_id(insert_id_p), constant_delete_id(delete_id_p) {
 }
 
-unique_ptr<ChunkInfo> ChunkInfo::Read(FixedSizeAllocator &allocator, ReadStream &reader) {
-	auto type = reader.Read<ChunkInfoType>();
-	switch (type) {
-	case ChunkInfoType::EMPTY_INFO:
-		return nullptr;
-	case ChunkInfoType::CONSTANT_INFO:
-		return ChunkConstantInfo::Read(reader);
-	case ChunkInfoType::VECTOR_INFO:
-		return ChunkVectorInfo::Read(allocator, reader);
-	default:
-		throw SerializationException("Could not deserialize Chunk Info Type: unrecognized type");
-	}
-}
-
-idx_t ChunkInfo::GetRowCount(ScanOptions options, idx_t max_count) {
+idx_t ChunkVectorInfo::GetRowCount(ScanOptions options, idx_t max_count) {
 	return GetSelVector(options, nullptr, max_count);
 }
 
-//===--------------------------------------------------------------------===//
-// Constant info
-//===--------------------------------------------------------------------===//
-ChunkConstantInfo::ChunkConstantInfo(idx_t start)
-    : ChunkInfo(start, ChunkInfoType::CONSTANT_INFO), insert_id(0), delete_id(NOT_DELETED_ID) {
-}
-
-template <class INSERT_OP, class DELETE_OP>
-idx_t ChunkConstantInfo::TemplatedGetSelVector(transaction_t start_time, transaction_t transaction_id,
-                                               idx_t max_count) const {
-	if (INSERT_OP::UseInsertedVersion(start_time, transaction_id, insert_id) &&
-	    !DELETE_OP::IsDeleted(start_time, transaction_id, delete_id)) {
-		return max_count;
-	}
-	return 0;
-}
-
-idx_t ChunkConstantInfo::GetSelVector(ScanOptions options, optional_ptr<SelectionVector> sel_vector,
-                                      idx_t max_count) const {
-	auto &transaction = options.transaction;
-	if (options.insert_type == InsertedScanType::STANDARD) {
-		if (!StandardInsertOperator::UseInsertedVersion(transaction.start_time, transaction.transaction_id,
-		                                                insert_id)) {
-			return 0;
-		}
-	}
-	if (options.delete_type == DeletedScanType::STANDARD) {
-		if (StandardDeleteOperator::IsDeleted(transaction.start_time, transaction.transaction_id, delete_id)) {
-			return 0;
-		}
-	} else if (options.delete_type == DeletedScanType::OMIT_COMMITTED_DELETES) {
-		if (CommittedDeleteOperator::IsDeleted(transaction.start_time, transaction.transaction_id, delete_id)) {
-			return 0;
-		}
-	}
-	return max_count;
-}
-
-bool ChunkConstantInfo::Fetch(TransactionData transaction, row_t row) {
-	return UseVersion(transaction, insert_id) && !UseVersion(transaction, delete_id);
-}
-
-void ChunkConstantInfo::CommitAppend(transaction_t commit_id, idx_t start, idx_t end) {
-	D_ASSERT(start == 0 && end == STANDARD_VECTOR_SIZE);
-	insert_id = commit_id;
-}
-
-bool ChunkConstantInfo::HasDeletes(transaction_t transaction_id) const {
-	if (transaction_id == MAX_TRANSACTION_ID) {
-		transaction_id = TRANSACTION_ID_START - 1;
-	}
-	bool is_deleted = insert_id >= TRANSACTION_ID_START || delete_id <= transaction_id;
-	return is_deleted;
-}
-
-bool ChunkConstantInfo::HasUncommittedChanges() const {
-	return insert_id >= TRANSACTION_ID_START || (delete_id != NOT_DELETED_ID && delete_id >= TRANSACTION_ID_START);
-}
-
-bool ChunkConstantInfo::Cleanup(transaction_t lowest_transaction) const {
-	if (delete_id != NOT_DELETED_ID) {
-		// the chunk info is labeled as deleted - we need to keep it around
-		return false;
-	}
-	if (insert_id > lowest_transaction) {
-		// there are still transactions active that need this ChunkInfo
-		return false;
-	}
-	return true;
-}
-
-void ChunkConstantInfo::Write(WriteStream &writer, transaction_t checkpoint_id) const {
-	D_ASSERT(HasDeletes(checkpoint_id));
-	ChunkInfo::Write(writer, checkpoint_id);
-	writer.Write<idx_t>(start);
-}
-
-unique_ptr<ChunkInfo> ChunkConstantInfo::Read(ReadStream &reader) {
-	auto start = reader.Read<idx_t>();
-	auto info = make_uniq<ChunkConstantInfo>(start);
-	info->insert_id = 0;
-	info->delete_id = 0;
-	return std::move(info);
-}
-
-string ChunkConstantInfo::ToString(idx_t max_count) const {
-	string result;
-	result += "Constant [Count: " + to_string(max_count);
-	result += ", ";
-	result += "Insert Id: " + to_string(insert_id);
-	if (delete_id != NOT_DELETED_ID) {
-		result += ", Delete Id: " + to_string(delete_id);
-	}
-	result += "]";
-	return result;
-}
-
-//===--------------------------------------------------------------------===//
-// Vector info
-//===--------------------------------------------------------------------===//
-ChunkVectorInfo::ChunkVectorInfo(FixedSizeAllocator &allocator_p, idx_t start, transaction_t insert_id_p)
-    : ChunkInfo(start, ChunkInfoType::VECTOR_INFO), allocator(allocator_p), constant_insert_id(insert_id_p) {
-}
-
 ChunkVectorInfo::~ChunkVectorInfo() {
-	if (AnyDeleted()) {
-		allocator.Free(deleted_data);
-	}
+	FreeDeleteData();
 	if (!HasConstantInsertionId()) {
 		allocator.Free(inserted_data);
 	}
@@ -186,24 +67,28 @@ ChunkVectorInfo::~ChunkVectorInfo() {
 template <class INSERT_OP, class DELETE_OP>
 idx_t ChunkVectorInfo::TemplatedGetSelVector(transaction_t start_time, transaction_t transaction_id,
                                              optional_ptr<SelectionVector> sel_vector, idx_t max_count) const {
-	if (HasConstantInsertionId()) {
-		if (!AnyDeleted()) {
-			// all tuples have the same inserted id: and no tuples were deleted
+	if (HasConstantDeleteId()) {
+		// all tuples have the same deleted id
+		if (DELETE_OP::IsDeleted(start_time, transaction_id, ConstantDeleteId())) {
+			// all tuples are deleted
+			return 0;
+		}
+		// no tuples are deleted: we only have to check the inserted ids
+		if (HasConstantInsertionId()) {
+			// all tuples have the same inserted id as well
 			if (INSERT_OP::UseInsertedVersion(start_time, transaction_id, ConstantInsertId())) {
 				return max_count;
 			} else {
 				return 0;
 			}
 		}
-		if (!INSERT_OP::UseInsertedVersion(start_time, transaction_id, ConstantInsertId())) {
-			return 0;
-		}
-		// have to check deleted flag
+		// have to check inserted flag
+		auto insert_segment = allocator.GetHandle(GetInsertedPointer());
+		auto inserted = insert_segment.GetPtr<transaction_t>();
+
 		idx_t count = 0;
-		auto segment = allocator.GetHandle(GetDeletedPointer());
-		auto deleted = segment.GetPtr<transaction_t>();
 		for (idx_t i = 0; i < max_count; i++) {
-			if (DELETE_OP::IsDeleted(start_time, transaction_id, deleted[i])) {
+			if (!INSERT_OP::UseInsertedVersion(start_time, transaction_id, inserted[i])) {
 				continue;
 			}
 			if (sel_vector) {
@@ -213,14 +98,16 @@ idx_t ChunkVectorInfo::TemplatedGetSelVector(transaction_t start_time, transacti
 		}
 		return count;
 	}
-	if (!AnyDeleted()) {
-		// have to check inserted flag
-		auto insert_segment = allocator.GetHandle(GetInsertedPointer());
-		auto inserted = insert_segment.GetPtr<transaction_t>();
-
+	if (HasConstantInsertionId()) {
+		if (!INSERT_OP::UseInsertedVersion(start_time, transaction_id, ConstantInsertId())) {
+			return 0;
+		}
+		// have to check deleted flag
 		idx_t count = 0;
+		auto segment = allocator.GetHandle(GetDeletedPointer());
+		auto deleted = segment.GetPtr<transaction_t>();
 		for (idx_t i = 0; i < max_count; i++) {
-			if (!INSERT_OP::UseInsertedVersion(start_time, transaction_id, inserted[i])) {
+			if (DELETE_OP::IsDeleted(start_time, transaction_id, deleted[i])) {
 				continue;
 			}
 			if (sel_vector) {
@@ -275,6 +162,10 @@ idx_t ChunkVectorInfo::GetSelVector(ScanOptions options, optional_ptr<SelectionV
 			return TemplatedGetSelVector<IncludeAllInsertedOperator, StandardDeleteOperator>(
 			    transaction.start_time, transaction.transaction_id, sel_vector, max_count);
 		}
+		if (options.delete_type == DeletedScanType::INCLUDE_ALL_DELETED) {
+			// include all rows
+			return max_count;
+		}
 		if (options.delete_type == DeletedScanType::OMIT_COMMITTED_DELETES) {
 			return TemplatedGetSelVector<IncludeAllInsertedOperator, CommittedDeleteOperator>(
 			    transaction.start_time, transaction.transaction_id, sel_vector, max_count);
@@ -293,8 +184,8 @@ bool ChunkVectorInfo::Fetch(TransactionData transaction, row_t row) {
 		auto inserted = insert_segment.GetPtr<transaction_t>();
 		fetch_insert_id = inserted[row];
 	}
-	if (!AnyDeleted()) {
-		fetch_deleted_id = NOT_DELETED_ID;
+	if (HasConstantDeleteId()) {
+		fetch_deleted_id = ConstantDeleteId();
 	} else {
 		auto delete_segment = allocator.GetHandle(GetDeletedPointer());
 		auto deleted = delete_segment.GetPtr<transaction_t>();
@@ -312,7 +203,7 @@ IndexPointer ChunkVectorInfo::GetInsertedPointer() const {
 }
 
 IndexPointer ChunkVectorInfo::GetDeletedPointer() const {
-	if (!AnyDeleted()) {
+	if (HasConstantDeleteId()) {
 		throw InternalException("ChunkVectorInfo: deleted id requested but deletions were not initialized");
 	}
 	return deleted_data;
@@ -334,19 +225,54 @@ IndexPointer ChunkVectorInfo::GetInitializedInsertedPointer() {
 }
 
 IndexPointer ChunkVectorInfo::GetInitializedDeletedPointer() {
-	if (!AnyDeleted()) {
+	if (HasConstantDeleteId()) {
+		transaction_t constant_id = ConstantDeleteId();
+
 		deleted_data = allocator.New();
 		deleted_data.SetMetadata(1);
 		auto segment = allocator.GetHandle(deleted_data);
 		auto deleted = segment.GetPtr<transaction_t>();
 		for (idx_t i = 0; i < STANDARD_VECTOR_SIZE; i++) {
-			deleted[i] = NOT_DELETED_ID;
+			deleted[i] = constant_id;
 		}
 	}
 	return deleted_data;
 }
 
+void ChunkVectorInfo::FreeDeleteData() {
+	if (HasConstantDeleteId()) {
+		return;
+	}
+	allocator.Free(deleted_data);
+	deleted_data = IndexPointer();
+}
+
+static bool DeletesEntireVector(const row_t rows[], idx_t count) {
+	D_ASSERT(count == STANDARD_VECTOR_SIZE);
+	for (idx_t i = 0; i < count; i++) {
+		if (rows[i] != row_t(i)) {
+			return false;
+		}
+	}
+	return true;
+}
+
 idx_t ChunkVectorInfo::Delete(transaction_t transaction_id, row_t rows[], idx_t count) {
+	if (HasConstantDeleteId() && ConstantDeleteId() != NOT_DELETED_ID) {
+		// all rows in this vector share the same deleted id - the rows we are trying to delete are already deleted
+		if (ConstantDeleteId() == transaction_id) {
+			// the rows were deleted by this transaction already - skip
+			return 0;
+		}
+		// the rows were deleted by another transaction - conflict
+		throw TransactionException("Conflict on tuple deletion!");
+	}
+	if (HasConstantDeleteId() && count == STANDARD_VECTOR_SIZE && DeletesEntireVector(rows, count)) {
+		// no rows were deleted yet and we are deleting the entire vector
+		// all rows share the same deleted id - store it as a constant instead of materializing per-row delete ids
+		constant_delete_id = transaction_id;
+		return count;
+	}
 	auto segment = allocator.GetHandle(GetInitializedDeletedPointer());
 	auto deleted = segment.GetPtr<transaction_t>();
 
@@ -373,17 +299,89 @@ idx_t ChunkVectorInfo::Delete(transaction_t transaction_id, row_t rows[], idx_t 
 }
 
 void ChunkVectorInfo::CommitDelete(transaction_t commit_id, const DeleteInfo &info) {
-	auto segment = allocator.GetHandle(GetDeletedPointer());
-	auto deleted = segment.GetPtr<transaction_t>();
+	if (info.is_consecutive && info.count == STANDARD_VECTOR_SIZE) {
+		// the delete covers the entire vector - all rows share the same deleted id
+		// we can store the deleted id as a constant and free any per-row delete ids
+		FreeDeleteData();
+		constant_delete_id = commit_id;
+		return;
+	}
+	if (HasConstantDeleteId() && ConstantDeleteId() == commit_id) {
+		// all rows already share this exact deleted id - nothing to do
+		return;
+	}
+	bool all_equal = true;
+	{
+		auto segment = allocator.GetHandle(GetInitializedDeletedPointer());
+		auto deleted = segment.GetPtr<transaction_t>();
 
-	if (info.is_consecutive) {
-		for (idx_t i = 0; i < info.count; i++) {
-			deleted[i] = commit_id;
+		if (info.is_consecutive) {
+			for (idx_t i = 0; i < info.count; i++) {
+				deleted[i] = commit_id;
+			}
+		} else {
+			auto rows = info.GetRows();
+			for (idx_t i = 0; i < info.count; i++) {
+				deleted[rows[i]] = commit_id;
+			}
 		}
-	} else {
-		auto rows = info.GetRows();
-		for (idx_t i = 0; i < info.count; i++) {
-			deleted[rows[i]] = commit_id;
+		// check if all rows now share the same deleted id
+		for (idx_t i = 0; i < STANDARD_VECTOR_SIZE; i++) {
+			if (deleted[i] != commit_id) {
+				all_equal = false;
+				break;
+			}
+		}
+	}
+	if (all_equal) {
+		// all rows share the same deleted id - compress the per-row delete ids into a constant
+		FreeDeleteData();
+		constant_delete_id = commit_id;
+	}
+}
+
+void ChunkVectorInfo::CompressVersionIds(transaction_t lowest_active_start) {
+	if (!HasConstantDeleteId()) {
+		// check if all rows are deleted, with all deletes visible to all active and future transactions
+		// if so, the per-row delete ids are equivalent to a single constant delete id
+		bool can_compress = true;
+		transaction_t max_delete_id = 0;
+		{
+			auto segment = allocator.GetHandle(GetDeletedPointer());
+			auto deleted = segment.GetPtr<transaction_t>();
+			for (idx_t i = 0; i < STANDARD_VECTOR_SIZE; i++) {
+				if (deleted[i] >= lowest_active_start) {
+					// the row is not deleted, or the delete is not yet visible to all transactions
+					can_compress = false;
+					break;
+				}
+				max_delete_id = MaxValue(max_delete_id, deleted[i]);
+			}
+		}
+		if (can_compress) {
+			FreeDeleteData();
+			constant_delete_id = max_delete_id;
+		}
+	}
+	if (!HasConstantInsertionId()) {
+		// check if all inserts are visible to all active and future transactions
+		// if so, the per-row insert ids are equivalent to a single constant insert id
+		bool can_compress = true;
+		{
+			auto segment = allocator.GetHandle(GetInsertedPointer());
+			auto inserted = segment.GetPtr<transaction_t>();
+			for (idx_t i = 0; i < STANDARD_VECTOR_SIZE; i++) {
+				if (inserted[i] >= lowest_active_start) {
+					// the insert is not yet visible to all transactions
+					can_compress = false;
+					break;
+				}
+			}
+		}
+		if (can_compress) {
+			allocator.Free(inserted_data);
+			inserted_data = IndexPointer();
+			constant_insert_id = 0;
 		}
 	}
 }
@@ -445,11 +443,19 @@ bool ChunkVectorInfo::Cleanup(transaction_t lowest_transaction) const {
 }
 
 bool ChunkVectorInfo::HasDeletes(transaction_t transaction_id) const {
+	if (HasConstantInsertionId() && ConstantInsertId() >= TRANSACTION_ID_START) {
+		// the vector was inserted by a transaction that has not committed yet
+		// the rows have to be masked as deleted when writing a checkpoint
+		return true;
+	}
 	if (!AnyDeleted()) {
 		return false;
 	}
 	if (transaction_id == MAX_TRANSACTION_ID) {
 		return true;
+	}
+	if (HasConstantDeleteId()) {
+		return ConstantDeleteId() <= transaction_id;
 	}
 	auto segment = allocator.GetHandle(deleted_data);
 	auto deleted = segment.GetPtr<transaction_t>();
@@ -476,8 +482,8 @@ bool ChunkVectorInfo::HasUncommittedChanges() const {
 			}
 		}
 	}
-	if (!AnyDeleted()) {
-		return false;
+	if (HasConstantDeleteId()) {
+		return ConstantDeleteId() != NOT_DELETED_ID && ConstantDeleteId() >= TRANSACTION_ID_START;
 	}
 	auto delete_segment = allocator.GetHandle(GetDeletedPointer());
 	auto deleted = delete_segment.GetPtr<transaction_t>();
@@ -490,11 +496,18 @@ bool ChunkVectorInfo::HasUncommittedChanges() const {
 }
 
 bool ChunkVectorInfo::AnyDeleted() const {
-	return deleted_data.HasMetadata();
+	if (HasConstantDeleteId()) {
+		return ConstantDeleteId() != NOT_DELETED_ID;
+	}
+	return true;
 }
 
 bool ChunkVectorInfo::HasConstantInsertionId() const {
 	return !inserted_data.HasMetadata();
+}
+
+bool ChunkVectorInfo::HasConstantDeleteId() const {
+	return !deleted_data.HasMetadata();
 }
 
 string ChunkVectorInfo::ToString(idx_t max_count) const {
@@ -516,6 +529,23 @@ string ChunkVectorInfo::ToString(idx_t max_count) const {
 		}
 		result += "]";
 	}
+	if (HasConstantDeleteId()) {
+		if (ConstantDeleteId() != NOT_DELETED_ID) {
+			result += ", Delete Id: " + to_string(constant_delete_id);
+		}
+	} else {
+		result += ", Delete Ids: [";
+		auto segment = allocator.GetHandle(GetDeletedPointer());
+		auto deleted = segment.GetPtr<transaction_t>();
+
+		for (idx_t idx = 0; idx < max_count; idx++) {
+			if (idx > 0) {
+				result += ", ";
+			}
+			result += to_string(deleted[idx]);
+		}
+		result += "]";
+	}
 	result += "]";
 	return result;
 }
@@ -525,6 +555,13 @@ transaction_t ChunkVectorInfo::ConstantInsertId() const {
 		throw InternalException("ConstantInsertId() called but vector info does not have a constant insertion id");
 	}
 	return constant_insert_id;
+}
+
+transaction_t ChunkVectorInfo::ConstantDeleteId() const {
+	if (!HasConstantDeleteId()) {
+		throw InternalException("ConstantDeleteId() called but vector info does not have a constant delete id");
+	}
+	return constant_delete_id;
 }
 
 void ChunkVectorInfo::Write(WriteStream &writer, transaction_t checkpoint_id) const {
@@ -544,7 +581,7 @@ void ChunkVectorInfo::Write(WriteStream &writer, transaction_t checkpoint_id) co
 		return;
 	}
 	// write a boolean vector
-	ChunkInfo::Write(writer, checkpoint_id);
+	writer.Write<ChunkInfoType>(ChunkInfoType::VECTOR_INFO);
 	writer.Write<idx_t>(start);
 	ValidityMask mask(STANDARD_VECTOR_SIZE);
 	mask.Initialize(STANDARD_VECTOR_SIZE);
@@ -554,20 +591,36 @@ void ChunkVectorInfo::Write(WriteStream &writer, transaction_t checkpoint_id) co
 	mask.Write(writer, STANDARD_VECTOR_SIZE);
 }
 
-unique_ptr<ChunkInfo> ChunkVectorInfo::Read(FixedSizeAllocator &allocator, ReadStream &reader) {
-	auto start = reader.Read<idx_t>();
-	auto result = make_uniq<ChunkVectorInfo>(allocator, start);
-	ValidityMask mask;
-	mask.Read(reader, STANDARD_VECTOR_SIZE);
-
-	auto segment = allocator.GetHandle(result->GetInitializedDeletedPointer());
-	auto deleted = segment.GetPtr<transaction_t>();
-	for (idx_t i = 0; i < STANDARD_VECTOR_SIZE; i++) {
-		if (mask.RowIsValid(i)) {
-			deleted[i] = 0;
-		}
+unique_ptr<ChunkVectorInfo> ChunkVectorInfo::Read(FixedSizeAllocator &allocator, ReadStream &reader) {
+	auto type = reader.Read<ChunkInfoType>();
+	switch (type) {
+	case ChunkInfoType::EMPTY_INFO:
+		// no rows are deleted
+		return nullptr;
+	case ChunkInfoType::CONSTANT_INFO: {
+		// a fully deleted vector - the constant insert and delete ids of 0 are visible to all transactions
+		auto start = reader.Read<idx_t>();
+		return make_uniq<ChunkVectorInfo>(allocator, start, 0, 0);
 	}
-	return std::move(result);
+	case ChunkInfoType::VECTOR_INFO: {
+		// a partially deleted vector - the deleted rows are stored as a boolean mask
+		auto start = reader.Read<idx_t>();
+		auto result = make_uniq<ChunkVectorInfo>(allocator, start);
+		ValidityMask mask;
+		mask.Read(reader, STANDARD_VECTOR_SIZE);
+
+		auto segment = allocator.GetHandle(result->GetInitializedDeletedPointer());
+		auto deleted = segment.GetPtr<transaction_t>();
+		for (idx_t i = 0; i < STANDARD_VECTOR_SIZE; i++) {
+			if (mask.RowIsValid(i)) {
+				deleted[i] = 0;
+			}
+		}
+		return result;
+	}
+	default:
+		throw SerializationException("Could not deserialize Chunk Info Type: unrecognized type");
+	}
 }
 
 } // namespace duckdb

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -1836,6 +1836,18 @@ PersistentRowGroupData RowGroup::SerializeRowGroupInfo(idx_t row_group_start) co
 	return result;
 }
 
+void RowGroup::CompressVersionInfo(transaction_t lowest_active_start) {
+	if (HasUnloadedDeletes()) {
+		// deletes were not loaded - they are still stored in their compact serialized form
+		return;
+	}
+	auto vinfo = GetVersionInfo();
+	if (!vinfo) {
+		return;
+	}
+	vinfo->CompressVersionIds(lowest_active_start);
+}
+
 vector<MetaBlockPointer> RowGroup::CheckpointDeletes(RowGroupWriter &writer) {
 	if (HasUnloadedDeletes()) {
 		// deletes were not loaded so they cannot be changed

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -25,6 +25,7 @@
 #include "duckdb/storage/table/scan_state.hpp"
 #include "duckdb/storage/table_storage_info.hpp"
 #include "duckdb/transaction/duck_transaction.hpp"
+#include "duckdb/transaction/duck_transaction_manager.hpp"
 #include "duckdb/common/storage_compatibility.hpp"
 #include "duckdb/common/type_visitor.hpp"
 #include "duckdb/logging/log_type.hpp"
@@ -1711,6 +1712,8 @@ void RowGroupCollection::Checkpoint(TableDataWriter &writer, TableStatistics &gl
 	VacuumState vacuum_state;
 	InitializeVacuumState(checkpoint_state, vacuum_state, writer.GetRowGroupCount());
 
+	auto &transaction_manager = DuckTransactionManager::Get(GetAttached());
+	auto lowest_active_start = transaction_manager.LowestActiveStart();
 	try {
 		// schedule tasks
 		idx_t total_vacuum_tasks = 0;
@@ -1733,6 +1736,8 @@ void RowGroupCollection::Checkpoint(TableDataWriter &writer, TableStatistics &gl
 			if (!RefersToSameObject(row_group.GetCollection(), *this)) {
 				throw InternalException("RowGroup Vacuum - row group collection of row group changed");
 			}
+			// the row group is kept as-is: try to compress its version information
+			row_group.CompressVersionInfo(lowest_active_start);
 			if (writer.GetCheckpointOptions().type != CheckpointType::VACUUM_ONLY) {
 				DUCKDB_LOG(checkpoint_state.writer.GetDatabase(), CheckpointLogType, GetAttached(), *info, segment_idx,
 				           row_group, vacuum_state.row_start);

--- a/src/storage/table/row_version_manager.cpp
+++ b/src/storage/table/row_version_manager.cpp
@@ -31,7 +31,7 @@ idx_t RowVersionManager::GetRowCount(ScanOptions options, idx_t count) {
 	return total_count;
 }
 
-optional_ptr<ChunkInfo> RowVersionManager::GetChunkInfo(idx_t vector_idx) {
+optional_ptr<ChunkVectorInfo> RowVersionManager::GetChunkInfo(idx_t vector_idx) {
 	if (vector_idx >= vector_info.size()) {
 		return nullptr;
 	}
@@ -110,27 +110,16 @@ void RowVersionManager::AppendVersionInfo(TransactionData transaction, idx_t cou
 		idx_t vector_end =
 		    vector_idx == end_vector_idx ? row_group_end - end_vector_idx * STANDARD_VECTOR_SIZE : STANDARD_VECTOR_SIZE;
 		if (vector_start == 0 && vector_end == STANDARD_VECTOR_SIZE) {
-			// entire vector is encapsulated by append: append a single constant
-			auto constant_info = make_uniq<ChunkConstantInfo>(vector_idx * STANDARD_VECTOR_SIZE);
-			constant_info->insert_id = transaction.transaction_id;
-			constant_info->delete_id = NOT_DELETED_ID;
-			vector_info[vector_idx] = std::move(constant_info);
+			// entire vector is encapsulated by append: store a single constant insert id
+			vector_info[vector_idx] =
+			    make_uniq<ChunkVectorInfo>(allocator, vector_idx * STANDARD_VECTOR_SIZE, transaction.transaction_id);
 		} else {
 			// part of a vector is encapsulated: append to that part
-			optional_ptr<ChunkVectorInfo> new_info;
 			if (!vector_info[vector_idx]) {
 				// first time appending to this vector: create new info
-				auto insert_info = make_uniq<ChunkVectorInfo>(allocator, vector_idx * STANDARD_VECTOR_SIZE);
-				new_info = insert_info.get();
-				vector_info[vector_idx] = std::move(insert_info);
-			} else if (vector_info[vector_idx]->type == ChunkInfoType::VECTOR_INFO) {
-				// use existing vector
-				new_info = &vector_info[vector_idx]->Cast<ChunkVectorInfo>();
-			} else {
-				throw InternalException("Error in RowVersionManager::AppendVersionInfo - expected either a "
-				                        "ChunkVectorInfo or no version info");
+				vector_info[vector_idx] = make_uniq<ChunkVectorInfo>(allocator, vector_idx * STANDARD_VECTOR_SIZE);
 			}
-			new_info->Append(vector_start, vector_end, transaction.transaction_id);
+			vector_info[vector_idx]->Append(vector_start, vector_end, transaction.transaction_id);
 		}
 	}
 }
@@ -196,14 +185,8 @@ ChunkVectorInfo &RowVersionManager::GetVectorInfo(idx_t vector_idx) {
 	if (!vector_info[vector_idx]) {
 		// no info yet: create it
 		vector_info[vector_idx] = make_uniq<ChunkVectorInfo>(allocator, vector_idx * STANDARD_VECTOR_SIZE);
-	} else if (vector_info[vector_idx]->type == ChunkInfoType::CONSTANT_INFO) {
-		auto &constant = vector_info[vector_idx]->Cast<ChunkConstantInfo>();
-		// info exists but it's a constant info: convert to a vector info
-		auto new_info = make_uniq<ChunkVectorInfo>(allocator, vector_idx * STANDARD_VECTOR_SIZE, constant.insert_id);
-		vector_info[vector_idx] = std::move(new_info);
 	}
-	D_ASSERT(vector_info[vector_idx]->type == ChunkInfoType::VECTOR_INFO);
-	return vector_info[vector_idx]->Cast<ChunkVectorInfo>();
+	return *vector_info[vector_idx];
 }
 
 idx_t RowVersionManager::DeleteRows(idx_t vector_idx, transaction_t transaction_id, row_t rows[], idx_t count) {
@@ -219,6 +202,18 @@ void RowVersionManager::CommitDelete(idx_t vector_idx, transaction_t commit_id, 
 	GetVectorInfo(vector_idx).CommitDelete(commit_id, info);
 }
 
+void RowVersionManager::CompressVersionIds(transaction_t lowest_active_start) {
+	lock_guard<mutex> lock(version_lock);
+	for (auto &info : vector_info) {
+		if (info) {
+			info->CompressVersionIds(lowest_active_start);
+		}
+	}
+	// compression frees the per-row id segments - release any buffers that are now empty
+	// (Free keeps the last buffer with free space alive to prevent buffer creation fluctuation)
+	allocator.RemoveEmptyBuffers();
+}
+
 vector<MetaBlockPointer> RowVersionManager::Checkpoint(RowGroupWriter &writer) {
 	lock_guard<mutex> lock(version_lock);
 	auto &manager = *writer.GetMetadataManager();
@@ -230,8 +225,8 @@ vector<MetaBlockPointer> RowVersionManager::Checkpoint(RowGroupWriter &writer) {
 		// return the current set of pointers
 		return storage_pointers;
 	}
-	// first count how many ChunkInfo's we need to deserialize
-	vector<pair<idx_t, reference<ChunkInfo>>> to_serialize;
+	// first count how many chunk infos we need to serialize
+	vector<pair<idx_t, reference<ChunkVectorInfo>>> to_serialize;
 	for (idx_t vector_idx = 0; vector_idx < vector_info.size(); vector_idx++) {
 		auto chunk_info = vector_info[vector_idx].get();
 		if (!chunk_info) {
@@ -284,7 +279,7 @@ shared_ptr<RowVersionManager> RowVersionManager::Deserialize(MetaBlockPointer de
 		}
 
 		version_info->FillVectorInfo(vector_index);
-		version_info->vector_info[vector_index] = ChunkInfo::Read(version_info->GetAllocator(), source);
+		version_info->vector_info[vector_index] = ChunkVectorInfo::Read(version_info->GetAllocator(), source);
 	}
 	version_info->uncheckpointed_delete_commit = optional_idx();
 	return version_info;
@@ -298,22 +293,8 @@ bool RowVersionManager::HasUnserializedChanges() {
 bool RowVersionManager::HasDeletes() {
 	lock_guard<mutex> lock(version_lock);
 	for (auto &info : vector_info) {
-		if (!info) {
-			continue;
-		}
-		switch (info->type) {
-		case ChunkInfoType::CONSTANT_INFO:
-			if (info->Cast<ChunkConstantInfo>().delete_id != NOT_DELETED_ID) {
-				return true;
-			}
-			break;
-		case ChunkInfoType::VECTOR_INFO:
-			if (info->Cast<ChunkVectorInfo>().AnyDeleted()) {
-				return true;
-			}
-			break;
-		default:
-			break;
+		if (info && info->AnyDeleted()) {
+			return true;
 		}
 	}
 	return false;

--- a/src/storage/table/row_version_manager.cpp
+++ b/src/storage/table/row_version_manager.cpp
@@ -97,6 +97,7 @@ void RowVersionManager::FillVectorInfo(idx_t vector_idx) {
 void RowVersionManager::AppendVersionInfo(TransactionData transaction, idx_t count, idx_t row_group_start,
                                           idx_t row_group_end) {
 	lock_guard<mutex> lock(version_lock);
+	needs_compression_check = true;
 	idx_t start_vector_idx = row_group_start / STANDARD_VECTOR_SIZE;
 	idx_t end_vector_idx = (row_group_end - 1) / STANDARD_VECTOR_SIZE;
 
@@ -191,11 +192,13 @@ ChunkVectorInfo &RowVersionManager::GetVectorInfo(idx_t vector_idx) {
 
 idx_t RowVersionManager::DeleteRows(idx_t vector_idx, transaction_t transaction_id, row_t rows[], idx_t count) {
 	lock_guard<mutex> lock(version_lock);
+	needs_compression_check = true;
 	return GetVectorInfo(vector_idx).Delete(transaction_id, rows, count);
 }
 
 void RowVersionManager::CommitDelete(idx_t vector_idx, transaction_t commit_id, const DeleteInfo &info) {
 	lock_guard<mutex> lock(version_lock);
+	needs_compression_check = true;
 	if (!uncheckpointed_delete_commit.IsValid() || commit_id > uncheckpointed_delete_commit.GetIndex()) {
 		uncheckpointed_delete_commit = commit_id;
 	}
@@ -204,11 +207,29 @@ void RowVersionManager::CommitDelete(idx_t vector_idx, transaction_t commit_id, 
 
 void RowVersionManager::CompressVersionIds(transaction_t lowest_active_start) {
 	lock_guard<mutex> lock(version_lock);
+	if (!needs_compression_check) {
+		// no version ids were modified since the last pass, and the last pass left nothing
+		// that could still become compressible - nothing to do
+#ifdef DEBUG
+		// a cleared manager-level check implies every vector's check is disarmed - verify the
+		// per-vector claims that the skipped pass relies on
+		for (auto &info : vector_info) {
+			if (info) {
+				D_ASSERT(!info->RecheckCompression());
+				info->VerifyCachedCompressionState();
+			}
+		}
+#endif
+		return;
+	}
+	bool pending = false;
 	for (auto &info : vector_info) {
-		if (info) {
-			info->CompressVersionIds(lowest_active_start);
+		if (info && info->CompressVersionIds(lowest_active_start) == VersionCompressionResult::PENDING) {
+			// some ids can still compress once the lowest active start advances - check again next pass
+			pending = true;
 		}
 	}
+	needs_compression_check = pending;
 	// compression frees the per-row id segments - release any buffers that are now empty
 	// (Free keeps the last buffer with free space alive to prevent buffer creation fluctuation)
 	allocator.RemoveEmptyBuffers();
@@ -279,7 +300,13 @@ shared_ptr<RowVersionManager> RowVersionManager::Deserialize(MetaBlockPointer de
 		}
 
 		version_info->FillVectorInfo(vector_index);
-		version_info->vector_info[vector_index] = ChunkVectorInfo::Read(version_info->GetAllocator(), source);
+		auto info = ChunkVectorInfo::Read(version_info->GetAllocator(), source);
+		if (info && info->RecheckCompression()) {
+			// with the current storage format deserialized ids are always settled, but Read
+			// derives this from the deserialized content - follow its verdict
+			version_info->needs_compression_check = true;
+		}
+		version_info->vector_info[vector_index] = std::move(info);
 	}
 	version_info->uncheckpointed_delete_commit = optional_idx();
 	return version_info;

--- a/test/configs/force_storage.json
+++ b/test/configs/force_storage.json
@@ -42,6 +42,8 @@
       "reason": "Measures memory usage.",
       "paths": [
         "test/sql/delete/in_memory_bulk_delete.test_slow",
+        "test/sql/delete/bulk_delete_version_info_memory.test",
+        "test/sql/delete/piecemeal_delete_checkpoint_compress.test_slow",
         "test/sql/pragma/profiling/test_custom_profiling_memory_and_temp_dir.test_slow",
         "test/sql/index/art/vacuum/test_art_vacuum_strings.test_slow",
         "test/sql/index/art/vacuum/test_art_vacuum_integers.test_slow"

--- a/test/sql/delete/bulk_delete_version_info_memory.test
+++ b/test/sql/delete/bulk_delete_version_info_memory.test
@@ -1,0 +1,51 @@
+# name: test/sql/delete/bulk_delete_version_info_memory.test
+# description: Test that bulk deletes of full vectors do not hold on to per-row version info memory
+# group: [delete]
+
+# 10 full row groups
+statement ok
+CREATE TABLE a AS SELECT i FROM range(1228800) t(i)
+
+# deleting the entire table stores the delete ids as per-vector constants - not as per-row delete ids
+statement ok
+BEGIN
+
+query I
+DELETE FROM a
+----
+1228800
+
+query I
+SELECT memory_usage_bytes < 1000000 FROM duckdb_memory() WHERE tag='BASE_TABLE'
+----
+true
+
+statement ok
+ROLLBACK
+
+# rollback restores all rows
+query I
+SELECT COUNT(*) FROM a
+----
+1228800
+
+query I
+SELECT memory_usage_bytes < 1000000 FROM duckdb_memory() WHERE tag='BASE_TABLE'
+----
+true
+
+query I
+DELETE FROM a
+----
+1228800
+
+query I
+SELECT COUNT(*) FROM a
+----
+0
+
+# after committing the bulk delete the version info remains compressed
+query I
+SELECT memory_usage_bytes < 1000000 FROM duckdb_memory() WHERE tag='BASE_TABLE'
+----
+true

--- a/test/sql/delete/delete_compression_after_restart.test
+++ b/test/sql/delete/delete_compression_after_restart.test
@@ -1,0 +1,55 @@
+# name: test/sql/delete/delete_compression_after_restart.test
+# description: Deserialized version info is settled; deletes after a restart still compress
+# group: [delete]
+
+require vector_size 2048
+
+load {TEST_DIR}/delete_compression_after_restart.db
+
+statement ok
+CREATE TABLE tbl AS SELECT i FROM range(122880) t(i);
+
+statement ok
+CHECKPOINT
+
+# partial piecemeal deletes leaving one row per vector - the vectors cannot compress
+# (live rows block the collapse) and serialize as per-vector deletion masks
+query I
+DELETE FROM tbl WHERE i % 2048 <> 0 AND i % 2 = 0
+----
+61380
+
+query I
+DELETE FROM tbl WHERE i % 2 = 1
+----
+61440
+
+statement ok
+CHECKPOINT
+
+restart
+
+# the deserialized version info has nothing to compress - the pass finds nothing to do
+statement ok
+CHECKPOINT
+
+query III
+SELECT COUNT(*), MIN(i), MAX(i) FROM tbl
+----
+60	0	120832
+
+# deleting the survivors after the restart makes the deserialized vectors compressible again
+query I
+DELETE FROM tbl WHERE i % 2048 = 0
+----
+60
+
+statement ok
+CHECKPOINT
+
+restart
+
+query I
+SELECT COUNT(*) FROM tbl
+----
+0

--- a/test/sql/delete/delete_compression_blocked_by_old_snapshot.test
+++ b/test/sql/delete/delete_compression_blocked_by_old_snapshot.test
@@ -1,0 +1,92 @@
+# name: test/sql/delete/delete_compression_blocked_by_old_snapshot.test
+# description: Deletes hidden from an old snapshot compress at the next checkpoint after the snapshot closes
+# group: [delete]
+
+require vector_size 2048
+
+load {TEST_DIR}/delete_compression_blocked_by_old_snapshot.db
+
+statement ok
+SET debug_skip_checkpoint_on_commit=true
+
+# one full row group; vector 0 stays fully alive so the row group is never vacuumed away -
+# freeing the delete-id arrays of the other vectors then requires the compression pass
+statement ok
+CREATE TABLE tbl AS SELECT i FROM range(122880) t(i);
+
+statement ok
+CHECKPOINT
+
+statement ok
+SET VARIABLE base_mem = (SELECT memory_usage_bytes FROM duckdb_memory() WHERE tag='BASE_TABLE')
+
+# reader pinning the snapshot BEFORE the deletes commit
+statement ok con1
+BEGIN
+
+query I con1
+SELECT COUNT(*) FROM tbl
+----
+122880
+
+# fully delete all vectors but the first across two transactions (piecemeal - the per-vector
+# delete ids differ between the transactions, so the deletes cannot be compressed on commit)
+query I
+DELETE FROM tbl WHERE i >= 2048 AND i % 2 = 0
+----
+60416
+
+query I
+DELETE FROM tbl WHERE i >= 2048 AND i % 2 = 1
+----
+60416
+
+# the deletes materialized per-row delete ids (16KB per fully-deleted vector)
+query I
+SELECT memory_usage_bytes > getvariable('base_mem') + 900000 FROM duckdb_memory() WHERE tag='BASE_TABLE'
+----
+true
+
+# the deletes are not yet visible to con1's snapshot: the checkpoint cannot compress them
+statement ok
+CHECKPOINT
+
+query I
+SELECT memory_usage_bytes > getvariable('base_mem') + 900000 FROM duckdb_memory() WHERE tag='BASE_TABLE'
+----
+true
+
+query I con1
+SELECT COUNT(*) FROM tbl
+----
+122880
+
+statement ok con1
+COMMIT
+
+# NO modification of tbl happens past this point: the deletes must still compress now that
+# they are visible to all transactions. the write to a separate table makes the WAL
+# non-empty - a CHECKPOINT with an empty WAL is skipped entirely and never reaches the
+# compression pass
+statement ok
+CREATE TABLE other AS SELECT 1 AS i
+
+statement ok
+CHECKPOINT
+
+query I
+SELECT memory_usage_bytes < getvariable('base_mem') + 300000 FROM duckdb_memory() WHERE tag='BASE_TABLE'
+----
+true
+
+query II
+SELECT COUNT(*), MAX(i) FROM tbl
+----
+2048	2047
+
+restart
+
+query II
+SELECT COUNT(*), MAX(i) FROM tbl
+----
+2048	2047

--- a/test/sql/delete/full_vector_delete_conflict.test
+++ b/test/sql/delete/full_vector_delete_conflict.test
@@ -1,0 +1,83 @@
+# name: test/sql/delete/full_vector_delete_conflict.test
+# description: Verify snapshot visibility and conflict detection after a committed full-vector delete
+# group: [delete]
+
+statement ok
+CREATE TABLE tbl AS SELECT i FROM range(4096) t(i);
+
+statement ok
+SET immediate_transaction_mode=true
+
+statement ok con1
+BEGIN
+
+statement ok con2
+BEGIN
+
+# con1 deletes all rows (full vectors) and commits
+query I con1
+DELETE FROM tbl
+----
+4096
+
+statement ok con1
+COMMIT
+
+# con2 started before the delete committed - it must still see all rows
+query I con2
+SELECT COUNT(*) FROM tbl
+----
+4096
+
+# con2 must not be able to delete the rows that con1 already deleted
+statement error con2
+DELETE FROM tbl
+----
+Conflict on tuple deletion
+
+statement ok con2
+ROLLBACK
+
+# new transactions see the delete
+query I
+SELECT COUNT(*) FROM tbl
+----
+0
+
+# deleting from the fully deleted table is a no-op
+query I
+DELETE FROM tbl
+----
+0
+
+# conflict on an uncommitted partial delete, rollback, then full-vector delete
+statement ok
+CREATE TABLE tbl2 AS SELECT i FROM range(4096) t(i);
+
+statement ok con1
+BEGIN
+
+query I con1
+DELETE FROM tbl2 WHERE i < 100
+----
+100
+
+# the full-vector delete conflicts with the uncommitted partial delete
+statement error con2
+DELETE FROM tbl2
+----
+Conflict on tuple deletion
+
+statement ok con1
+ROLLBACK
+
+# after the rollback the entire table can be deleted
+query I con2
+DELETE FROM tbl2
+----
+4096
+
+query I
+SELECT COUNT(*) FROM tbl2
+----
+0

--- a/test/sql/delete/full_vector_delete_rollback.test
+++ b/test/sql/delete/full_vector_delete_rollback.test
@@ -1,0 +1,60 @@
+# name: test/sql/delete/full_vector_delete_rollback.test
+# description: Verify rollback and re-delete of full-vector deletes
+# group: [delete]
+
+statement ok
+CREATE TABLE tbl AS SELECT i FROM range(4096) t(i);
+
+statement ok
+SET immediate_transaction_mode=true
+
+statement ok con1
+BEGIN
+
+query I con1
+DELETE FROM tbl
+----
+4096
+
+# the deleting transaction sees its own delete
+query I con1
+SELECT COUNT(*) FROM tbl
+----
+0
+
+# other transactions still see all rows while the delete is uncommitted
+query I con2
+SELECT COUNT(*) FROM tbl
+----
+4096
+
+# other transactions conflict on the uncommitted full-vector delete
+statement error con2
+DELETE FROM tbl WHERE i < 100
+----
+Conflict on tuple deletion
+
+statement ok con1
+ROLLBACK
+
+# rollback restores all rows
+query I
+SELECT COUNT(*) FROM tbl
+----
+4096
+
+# rows can be deleted again after the rollback
+query I
+DELETE FROM tbl WHERE i < 2048
+----
+2048
+
+query I
+DELETE FROM tbl
+----
+2048
+
+query I
+SELECT COUNT(*) FROM tbl
+----
+0

--- a/test/sql/delete/piecemeal_delete_checkpoint_compress.test_slow
+++ b/test/sql/delete/piecemeal_delete_checkpoint_compress.test_slow
@@ -1,0 +1,49 @@
+# name: test/sql/delete/piecemeal_delete_checkpoint_compress.test_slow
+# description: Test that checkpointing compresses the version info of vectors fully deleted across transactions
+# group: [delete]
+
+statement ok
+SET threads=1
+
+# prevent automatic checkpoints on commit so that the explicit CHECKPOINT below performs the compression
+statement ok
+SET debug_skip_checkpoint_on_commit=true
+
+# 60 vectors in a single row group
+statement ok
+CREATE TABLE tbl AS SELECT i FROM range(122880) t(i);
+
+# fully delete every vector, but across two transactions (even ids, then odd ids). every vector ends up
+# fully deleted, but with two different delete commit ids, so the deletes cannot be compressed on commit -
+# only a checkpoint can compress them into a per-vector constant
+query I
+DELETE FROM tbl WHERE i % 2 = 0
+----
+61440
+
+query I
+DELETE FROM tbl WHERE i % 2 = 1
+----
+61440
+
+# before the checkpoint the per-row delete ids are materialized (multiple 16KB arrays)
+query I
+SELECT memory_usage_bytes > 300000 FROM duckdb_memory() WHERE tag='BASE_TABLE'
+----
+true
+
+statement ok
+CHECKPOINT
+
+# the checkpoint compresses the per-row delete ids into per-vector constants and releases the now-empty
+# version info buffers. under the default config this reaches 0; some configs may retain a single 256KB
+# allocator buffer, so assert a bound rather than an exact value
+query I
+SELECT memory_usage_bytes < 300000 FROM duckdb_memory() WHERE tag='BASE_TABLE'
+----
+true
+
+query I
+SELECT COUNT(*) FROM tbl
+----
+0

--- a/test/sql/storage/full_vector_delete_checkpoint.test
+++ b/test/sql/storage/full_vector_delete_checkpoint.test
@@ -1,0 +1,50 @@
+# name: test/sql/storage/full_vector_delete_checkpoint.test
+# description: Verify that full-vector deletes survive checkpoints and restarts
+# group: [storage]
+
+load {TEST_DIR}/full_vector_delete_checkpoint.db
+
+statement ok
+SET debug_skip_checkpoint_on_commit=true
+
+statement ok
+CREATE TABLE tbl AS SELECT i FROM range(8192) t(i);
+
+# delete some full vectors and a partial vector
+query I
+DELETE FROM tbl WHERE i < 5000
+----
+5000
+
+query III
+SELECT COUNT(*), MIN(i), MAX(i) FROM tbl
+----
+3192	5000	8191
+
+statement ok
+CHECKPOINT
+
+query III
+SELECT COUNT(*), MIN(i), MAX(i) FROM tbl
+----
+3192	5000	8191
+
+restart
+
+query III
+SELECT COUNT(*), MIN(i), MAX(i) FROM tbl
+----
+3192	5000	8191
+
+# delete the remainder and restart again
+query I
+DELETE FROM tbl
+----
+3192
+
+restart
+
+query I
+SELECT COUNT(*) FROM tbl
+----
+0

--- a/test/sql/storage/piecemeal_delete_checkpoint_compress.test
+++ b/test/sql/storage/piecemeal_delete_checkpoint_compress.test
@@ -1,0 +1,76 @@
+# name: test/sql/storage/piecemeal_delete_checkpoint_compress.test
+# description: Test that version info compressed during a checkpoint is correctly serialized and restored
+# group: [storage]
+
+load {TEST_DIR}/piecemeal_delete_checkpoint_compress.db
+
+statement ok
+CREATE TABLE tbl AS SELECT i FROM range(122880) t(i);
+
+statement ok
+CHECKPOINT
+
+# fully delete the first 30 vectors (61440 rows) across two transactions
+# the per-vector delete ids differ between the two transactions, so the deletes cannot be compressed on commit
+query I
+DELETE FROM tbl WHERE i < 61440 AND i % 2 = 0
+----
+30720
+
+query I
+DELETE FROM tbl WHERE i < 61440 AND i % 2 = 1
+----
+30720
+
+# the checkpoint compresses the version info before serializing it
+statement ok
+CHECKPOINT
+
+query III
+SELECT COUNT(*), MIN(i), MAX(i) FROM tbl
+----
+61440	61440	122879
+
+restart
+
+query III
+SELECT COUNT(*), MIN(i), MAX(i) FROM tbl
+----
+61440	61440	122879
+
+# an old snapshot must still block the compression: deletes that are not yet visible to all
+# transactions are not compressed
+statement ok
+SET immediate_transaction_mode=true
+
+statement ok con1
+BEGIN
+
+query I con2
+DELETE FROM tbl WHERE i < 100000
+----
+38560
+
+statement ok con2
+CHECKPOINT
+
+# con1 started before the delete committed - it must still see the rows
+query I con1
+SELECT COUNT(*) FROM tbl
+----
+61440
+
+statement ok con1
+COMMIT
+
+query III
+SELECT COUNT(*), MIN(i), MAX(i) FROM tbl
+----
+22880	100000	122879
+
+restart
+
+query III
+SELECT COUNT(*), MIN(i), MAX(i) FROM tbl
+----
+22880	100000	122879


### PR DESCRIPTION
## Problem

Deleting larger amounts of data can quickly hit the memory limits in DuckDB. Further, for observability use cases where DuckDB is continuously ingesting data, and most checkpoints are concurrent (i.e. don't allow vacuum), there can be some time before the memory of deletes can be reclaimed.

Deleting rows is disproportionately memory-hungry relative to the information a delete actually carries. As soon as a single row in a vector is deleted, `ChunkVectorInfo` materializes a full `STANDARD_VECTOR_SIZE × sizeof(transaction_t)` array of per-row delete commit ids — **16 KiB per vector** at default settings, i.e. ~8 bytes for every deleted row. That array is held until the row group is rewritten at a full checkpoint, and **indefinitely for in-memory databases**.

For a bulk delete (or deletion of a lot of "old data") this is almost entirely waste. After `DELETE FROM t` on a 100M-row table, ~815 MB of version-info memory is retained even though every row shares the same delete id. Under a tight memory limit the delete can fail outright:

```sql
SET memory_limit='300MB';
CREATE TABLE t AS SELECT range AS i FROM range(100_000_000);
DELETE FROM t;
-- Out of Memory Error: could not allocate block of size 256.0 KiB (287.2 MiB/286.1 MiB used)
```

## Approach

The insert side already had the pattern: a `constant_insert_id` collapses the per-row array to a single value when all rows share it. This PR mirrors that on the delete side and reclaims the freed memory, in a few independent steps:

1. **`constant_delete_id` (commit-time collapse).** When a delete covers an entire vector — the `DELETE FROM t` shape — the id is stored as a single constant and the per-row array is never allocated (`Delete()`) or freed on commit (`CommitDelete()`). The array is lazily re-materialized from the constant only when a *partial* modification needs per-row ids, which preserves write-write conflict detection and snapshot visibility exactly. Rollback / revert-commit route through the same paths.

2. **Checkpoint-time compression (piecemeal deletes).** Vectors deleted fully across *multiple* transactions carry distinct per-row commit ids, so they can't collapse on commit. Once every id is below the lowest active transaction start, the ids are indistinguishable from a single constant for all current and future snapshots. The checkpoint is the lifetime-safe place to do this collapse (it operates on the live `RowVersionManager` owned by the row group, unlike transaction cleanup which would dangle the pointer stored in `DeleteInfo`), and it runs for `VACUUM_ONLY` checkpoints too, so in-memory databases reclaim on `CHECKPOINT`. Fully-visible non-constant *insert* ids are collapsed in the same pass.

3. **Release empty buffers.** `FixedSizeAllocator::Free` intentionally keeps one empty buffer alive to avoid churn (an ART heuristic). That doesn't apply to the one-shot compression pass, so a fully-compressed row group would otherwise retain one 256 KiB buffer. `CompressVersionIds` now calls `RemoveEmptyBuffers()` at the end.

4. **Cleanup: remove `ChunkConstantInfo` and flatten the hierarchy.** With the above, `ChunkConstantInfo` was just a `ChunkVectorInfo` with both ids constant — a state now represented natively. Removing it also removes the constant→vector conversion in `RowVersionManager::GetVectorInfo` (where delete ids could previously be silently dropped). `ChunkVectorInfo` then became the only `ChunkInfo` subclass, so the base class is merged in: the class is non-virtual (per-vector-scan `GetSelVector` is no longer a virtual call), the in-memory `type` field and `Cast<>` machinery are gone.

**The on-disk format is unchanged.** `ChunkInfoType` (`EMPTY_INFO` / `CONSTANT_INFO` / `VECTOR_INFO`) survives purely as a serialization tag; `ChunkVectorInfo::Write` already emitted `CONSTANT_INFO` for fully-deleted vectors and `Read` reconstructs from the same tags.

## Measurements

100M-row table, `DELETE FROM t`, version-info memory (`BASE_TABLE`) retained after the delete:

| | before | after |
|---|---|---|
| memory retained | **815 MB** | **1.6 MB** (≈1.3 MB pre-existing data bookkeeping + one 256 KiB tail-vector array) |
| delete wall time | 2.31 s | 2.19 s |
| under `memory_limit='300MB'`, no spilling | **OOM mid-delete** | completes, 0 rows |

The peak is eliminated, not just the steady state, because the whole-vector path never allocates the array in the first place. Piecemeal multi-transaction deletes materialize arrays transiently and drop to **0 bytes** after the next full checkpoint (including in-memory `CHECKPOINT`).
