### PR TITLE
Scope untrusted PR/issue titles to step-level env in CI workflows

### DIFF
--- a/.github/workflows/NeedsDocumentation.yml
+++ b/.github/workflows/NeedsDocumentation.yml
@@ -15,7 +15,6 @@ env:
   # an event triggering this workflow is either an issue or a pull request,
   # hence only one of the numbers will be filled in the TITLE_PREFIX
   TITLE_PREFIX: "[duckdb/#${{ github.event.issue.number || github.event.pull_request.number }}]"
-  PUBLIC_ISSUE_TITLE: ${{ github.event.issue.title || github.event.pull_request.title }}
 
 jobs:
   create_documentation_issue:
@@ -36,6 +35,8 @@ jobs:
           fi
 
       - name: Create mirror issue if it does not yet exist
+        env:
+          PUBLIC_ISSUE_TITLE: ${{ github.event.issue.title || github.event.pull_request.title }}
         run: |
           if [ "${MIRROR_ISSUE_NUMBER}" == "" ]; then
             gh issue create --repo duckdb/duckdb-web --title "${TITLE_PREFIX} - ${PUBLIC_ISSUE_TITLE} needs documentation" --body "See https://github.com/duckdb/duckdb/issues/${{ github.event.issue.number || github.event.pull_request.number }}"

--- a/.github/workflows/PRNeedsMaintainerApproval.yml
+++ b/.github/workflows/PRNeedsMaintainerApproval.yml
@@ -7,7 +7,6 @@ on:
 env:
   GH_TOKEN: ${{ secrets.DUCKDBLABS_BOT_TOKEN }}
   TITLE_PREFIX: "[duckdb/#${{ github.event.pull_request.number }}]"
-  PUBLIC_PR_TITLE: ${{ github.event.pull_request.title }}
 
 jobs:
   create_or_label_issue:
@@ -28,6 +27,8 @@ jobs:
           fi
 
       - name: Create or label issue
+        env:
+          PUBLIC_PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           if [ "${MIRROR_ISSUE_NUMBER}" == "" ]; then
             gh issue create --repo duckdblabs/duckdb-internal --label "external action required" --label "Pull request" --title "${TITLE_PREFIX} - ${PUBLIC_PR_TITLE}" --body "Pull request ${TITLE_PREFIX} needs input from maintainers. See https://github.com/duckdb/duckdb/pull/${{ github.event.pull_request.number }}"


### PR DESCRIPTION
## Summary

- Moves `PUBLIC_PR_TITLE` and `PUBLIC_ISSUE_TITLE` from workflow-level `env:` to step-level `env:` blocks in `PRNeedsMaintainerApproval.yml` and `NeedsDocumentation.yml`
- Limits the scope of user-controlled input to only the steps that need it, following GitHub's recommended hardening for `pull_request_target` workflows

## Context

Both workflows use `pull_request_target` and process titles from external PRs/issues. While the values are already referenced as shell variables (not inline `${{ }}` in `run:` blocks), scoping them to step-level `env:` further reduces exposure surface per [GitHub's security hardening guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections).

## Test plan

- [x] Verified the diff only moves env var declarations from workflow-level to step-level
- [x] Confirmed no functional change — the same variables are set to the same values, just scoped more narrowly
- [x] Both `PRNeedsMaintainerApproval.yml` and `NeedsDocumentation.yml` follow the same pattern after the fix