### PR TITLE
ci: add Dependabot for GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
## Summary

Adds a Dependabot configuration to automatically monitor and update GitHub Actions dependencies on a monthly cadence.

- Introduces `.github/dependabot.yml` targeting the `github-actions` package ecosystem
- Scheduled to check for updates monthly to avoid noisy PRs while keeping actions current
- Helps ensure CI workflows use up-to-date action versions, picking up bug fixes and security patches

## Motivation

Several workflows in this repository pin GitHub Actions by major version tag (e.g. `v4`). Dependabot will open PRs when newer versions are available, making it easy to review and merge updates without manual tracking.

## Test plan

- [x] Valid YAML syntax verified
- [ ] Dependabot will begin opening PRs after merge (no CI impact until then)