### PR TITLE
Add verify compression to test FSST without regressing relassert

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -520,6 +520,7 @@ TEST_CONFIGS := \
 	test/configs/verify_statement_explain.json \
 	test/configs/verify_statement_prepare.json \
 	test/configs/verify_serializer.json \
+	test/configs/verify_compression.json \
 	test/configs/verify_stats.json \
 	test/configs/verify_statement_serialization.json \
 	test/configs/force_storage.json \

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -1690,19 +1690,20 @@ const StringUtil::EnumStringLiteral *GetDebugVerificationModeValues() {
 		{ static_cast<uint32_t>(DebugVerificationMode::NONE), "NONE" },
 		{ static_cast<uint32_t>(DebugVerificationMode::VERIFY_VECTORS), "VERIFY_VECTORS" },
 		{ static_cast<uint32_t>(DebugVerificationMode::VERIFY_SERIALIZATION), "VERIFY_SERIALIZATION" },
-		{ static_cast<uint32_t>(DebugVerificationMode::VERIFY_FUNCTIONS), "VERIFY_FUNCTIONS" }
+		{ static_cast<uint32_t>(DebugVerificationMode::VERIFY_FUNCTIONS), "VERIFY_FUNCTIONS" },
+		{ static_cast<uint32_t>(DebugVerificationMode::VERIFY_COMPRESSION), "VERIFY_COMPRESSION" }
 	};
 	return values;
 }
 
 template<>
 const char* EnumUtil::ToChars<DebugVerificationMode>(DebugVerificationMode value) {
-	return StringUtil::EnumToString(GetDebugVerificationModeValues(), 5, "DebugVerificationMode", static_cast<uint32_t>(value));
+	return StringUtil::EnumToString(GetDebugVerificationModeValues(), 6, "DebugVerificationMode", static_cast<uint32_t>(value));
 }
 
 template<>
 DebugVerificationMode EnumUtil::FromString<DebugVerificationMode>(const char *value) {
-	return static_cast<DebugVerificationMode>(StringUtil::StringToEnum(GetDebugVerificationModeValues(), 5, "DebugVerificationMode", value));
+	return static_cast<DebugVerificationMode>(StringUtil::StringToEnum(GetDebugVerificationModeValues(), 6, "DebugVerificationMode", value));
 }
 
 const StringUtil::EnumStringLiteral *GetDecimalBitWidthValues() {

--- a/src/include/duckdb/common/enums/debug_verification_mode.hpp
+++ b/src/include/duckdb/common/enums/debug_verification_mode.hpp
@@ -12,6 +12,13 @@
 
 namespace duckdb {
 
-enum class DebugVerificationMode : uint8_t { DEFAULT, NONE, VERIFY_VECTORS, VERIFY_SERIALIZATION, VERIFY_FUNCTIONS };
+enum class DebugVerificationMode : uint8_t {
+	DEFAULT,
+	NONE,
+	VERIFY_VECTORS,
+	VERIFY_SERIALIZATION,
+	VERIFY_FUNCTIONS,
+	VERIFY_COMPRESSION
+};
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/compression/dict_fsst/compression.hpp
+++ b/src/include/duckdb/storage/compression/dict_fsst/compression.hpp
@@ -93,6 +93,7 @@ public:
 
 	//! How many values have we compressed so far?
 	idx_t total_tuple_count = 0;
+	bool verify_compression = false;
 
 private:
 	void *encoder = nullptr;

--- a/src/storage/compression/dict_fsst/compression.cpp
+++ b/src/storage/compression/dict_fsst/compression.cpp
@@ -2,6 +2,7 @@
 #include "duckdb/common/typedefs.hpp"
 #include "fsst.h"
 #include "duckdb/common/fsst.hpp"
+#include "duckdb/main/config.hpp"
 
 #if defined(__MVS__) && !defined(alloca)
 #define alloca __builtin_alloca
@@ -18,7 +19,8 @@ DictFSSTCompressionState::DictFSSTCompressionState(ColumnDataCheckpointData &che
           MinValue(analyze_p.get()->total_count, info.GetBlockSize()) / 2, // maximum_size_p (amount of elements)
           1                                                                // maximum_target_capacity_p (byte capacity)
           ),
-      analyze(std::move(analyze_p)) {
+      analyze(std::move(analyze_p)),
+      verify_compression(DBConfigOptions::global_verification_mode == DebugVerificationMode::VERIFY_COMPRESSION) {
 	CreateEmptySegment();
 }
 
@@ -469,6 +471,22 @@ static DictFSSTCompressResult GetCompressResult(bool success, bool new_string) {
 	return new_string ? DictFSSTCompressResult::NEW_STRING : DictFSSTCompressResult::REPEATED_STRING;
 }
 
+static void VerifyFSSTCompressedString(void *decoder, const string_t &compressed_string,
+                                       const string_t &uncompressed_string, vector<unsigned char> &decompress_buffer) {
+	decompress_buffer.resize(uncompressed_string.GetSize() + 1 + 100);
+	auto decoded_std_string = FSSTPrimitives::DecompressValue(decoder, compressed_string.GetData(),
+	                                                          compressed_string.GetSize(), decompress_buffer);
+
+	if (decoded_std_string.size() != uncompressed_string.GetSize()) {
+		throw InternalException("FSST compression verification failed: decompressed string length mismatch");
+	}
+	string_t decompressed_string(reinterpret_cast<const char *>(decompress_buffer.data()),
+	                             UnsafeNumericCast<uint32_t>(uncompressed_string.GetSize()));
+	if (decompressed_string != uncompressed_string) {
+		throw InternalException("FSST compression verification failed: decompressed string mismatch");
+	}
+}
+
 DictFSSTCompressResult DictFSSTCompressionState::CompressInternal(UnifiedVectorFormat &vector_format,
                                                                   const string_t &str, bool is_null,
                                                                   EncodedInput &encoded_input, const idx_t i,
@@ -558,11 +576,13 @@ DictFSSTCompressResult DictFSSTCompressionState::CompressInternal(UnifiedVectorF
 		// Encode the input upfront, the 'current_string_map' is also encoded.
 		// no lookups are performed, everything is added.
 
-#ifdef DEBUG
-		auto temp_decoder = alloca(sizeof(duckdb_fsst_decoder_t));
-		duckdb_fsst_import(reinterpret_cast<duckdb_fsst_decoder_t *>(temp_decoder), fsst_serialized_symbol_table.get());
+		duckdb_fsst_decoder_t temp_decoder_storage;
+		void *temp_decoder = nullptr;
 		vector<unsigned char> decompress_buffer;
-#endif
+		if (verify_compression) {
+			temp_decoder = &temp_decoder_storage;
+			duckdb_fsst_import(&temp_decoder_storage, fsst_serialized_symbol_table.get());
+		}
 
 		if (encoded_input.data.empty()) {
 			encoded_input.offset = i;
@@ -609,42 +629,21 @@ DictFSSTCompressResult DictFSSTCompressionState::CompressInternal(UnifiedVectorF
 				uint32_t size = UnsafeNumericCast<uint32_t>(compressed_sizes[j]);
 				string_t encoded_string((const char *)compressed_ptrs[j], size); // NOLINT;
 
-#ifdef DEBUG
-				//! Verify that we can decompress the string
-				auto &uncompressed_str = strings[encoded_input.offset + j];
-				decompress_buffer.resize(uncompressed_str.GetSize() + 1 + 100);
-				auto decoded_std_string = FSSTPrimitives::DecompressValue(
-				    (void *)temp_decoder, reinterpret_cast<const char *>(compressed_ptrs[j]),
-				    (idx_t)compressed_sizes[j], decompress_buffer);
-
-				D_ASSERT(decoded_std_string.size() == uncompressed_str.GetSize());
-				string_t decompressed_string(reinterpret_cast<const char *>(decompress_buffer.data()),
-				                             UnsafeNumericCast<uint32_t>(uncompressed_str.GetSize()));
-				D_ASSERT(decompressed_string == uncompressed_str);
-#endif
+				if (verify_compression) {
+					VerifyFSSTCompressedString(temp_decoder, encoded_string, strings[encoded_input.offset + j],
+					                           decompress_buffer);
+				}
 
 				encoded_input.data.push_back(encoded_string);
 			}
 		}
 
-#ifdef DEBUG
-		//! Verify that we can decompress the strings (nothing weird happened to them)
-		for (idx_t j = encoded_input.offset; j < count; j++) {
-			auto &uncompressed_string = strings[j];
-			auto &compressed_string = encoded_input.data[j - encoded_input.offset];
-
-			decompress_buffer.resize(uncompressed_string.GetSize() + 1 + 100);
-			auto decoded_std_string =
-			    FSSTPrimitives::DecompressValue((void *)temp_decoder, (const char *)compressed_string.GetData(),
-			                                    compressed_string.GetSize(), decompress_buffer);
-
-			D_ASSERT(decoded_std_string.size() == uncompressed_string.GetSize());
-			string_t decompressed_string(reinterpret_cast<const char *>(decompress_buffer.data()),
-			                             UnsafeNumericCast<uint32_t>(uncompressed_string.GetSize()));
-			D_ASSERT(decompressed_string == uncompressed_string);
+		if (verify_compression) {
+			for (idx_t j = encoded_input.offset; j < count; j++) {
+				VerifyFSSTCompressedString(temp_decoder, encoded_input.data[j - encoded_input.offset], strings[j],
+				                           decompress_buffer);
+			}
 		}
-
-#endif
 		auto &string = encoded_input.data[i - encoded_input.offset];
 		return GetCompressResult(AddToDictionary<DictionaryAppendState::ENCODED_ALL_UNIQUE>(
 		                             *this, string, recalculate_indices_space, fail_on_no_space),

--- a/test/configs/verify_compression.json
+++ b/test/configs/verify_compression.json
@@ -1,0 +1,7 @@
+{
+  "description": "Run on persistent databases with compression verification enabled.",
+  "initial_db": "{TEST_DIR}/{BASE_TEST_NAME}__test__config__verify_compression.db",
+  "on_init": "SET debug_verification_mode='verify_compression';",
+  "skip_compiled": "true",
+  "inherit_skip_tests": "test/configs/force_storage.json"
+}


### PR DESCRIPTION
FSST is enabled in https://github.com/duckdb/duckdb/pull/23733/ and that caused a 10x increase in CI runtime for `relassert tests`:

<img width="942" height="396" alt="Screenshot 2026-07-20 at 15 29 15" src="https://github.com/user-attachments/assets/09c6d8a7-fb16-4e07-8471-0caed8a55668" />

The CI step `Test benchmark SQL` under `relassert tests` went from 5 min to [46 min](https://github.com/duckdb/duckdb/actions/runs/29404825757/job/87319226399#step:10:40).

I noticed that some fast tests also became much slower:
```
build/relassert/test/run --track-runtime=100 
CI detected, enabling retry=2 per batch
config: workers=12, retry=2, max_retries=4, batch_size=10, batch_timeout_seconds=300, runtime_threshold_seconds=100, fail_require_skip=False
.................................................. [ 50%]
........................................
warn: test/sql/table_function/duckdb_eviction_queues.test took 170.40s
.........
warn: test/sql/transactions/rollback_drop_column.test took 202.63s
. [100%]
```

I ran `test/sql/table_function/duckdb_eviction_queues.test` with relassert (+ `FORCE_DEBUG` + `FORCE_ASSERT`) under samply:

```text
duckdb::dict_fsst::DictFSSTCompressionState::CompressInternal
duckdb::dict_fsst::DictFSSTCompressionState::Compress
duckdb::ColumnDataCheckpointer::WriteToDisk()::$_0::operator()
duckdb::ColumnDataCheckpointer::ScanSegments
duckdb::ColumnDataCheckpointer::WriteToDisk
duckdb::ColumnDataCheckpointer::Checkpoint
duckdb::StandardColumnData::Checkpoint
duckdb::ColumnData::Checkpoint
duckdb::RowGroup::CheckpointColumn
duckdb::RowGroup::WriteToDisk
duckdb::OptimisticDataWriter::FlushToDisk
duckdb::OptimisticDataWriter::WriteNewRowGroup
duckdb::LocalTableStorage::WriteNewRowGroup
duckdb::LocalStorage::Append
duckdb::DataTable::LocalAppend
...
```
where `duckdb::dict_fsst::DictFSSTCompressionState::CompressInternal` takes 98% of the runtime.

Adding a runtime flag `debug_verification_mode = verify_compression` moves the logic from `#if DEBUG` to a release config test.


### Before (macbook)

```
build/relassert/test/unittest test/sql/table_function/duckdb_eviction_queues.test
Filters: test/sql/table_function/duckdb_eviction_queues.test
[1/1] (100%): test/sql/table_function/duckdb_eviction_queues.test took 89.065s                                                                                                                                                                                                                                                  
===============================================================================
All tests passed (23 assertions in 1 test case)
```

### After (macbook)
```
build/relassert/test/unittest test/sql/table_function/duckdb_eviction_queues.test  
Filters: test/sql/table_function/duckdb_eviction_queues.test
[1/1] (100%): test/sql/table_function/duckdb_eviction_queues.test took 1.562s                                                                                                                                                                                                                                                   
===============================================================================
All tests passed (23 assertions in 1 test case)
```

### After (CI)

With this PR, the CI step `Test benchmark SQL` went [back](https://github.com/duckdb/duckdb/actions/runs/29751728050/job/88394518100?pr=23967#step:10:40) to 4 min 44 sec.

cc @Tishj 