### PR TITLE
Bump Postgres extension on main

### DIFF
--- a/.github/config/extensions/postgres_scanner.cmake
+++ b/.github/config/extensions/postgres_scanner.cmake
@@ -4,7 +4,7 @@ if (NOT MINGW AND NOT ${WASM_ENABLED})
     duckdb_extension_load(postgres_scanner
             DONT_LINK
             GIT_URL https://github.com/duckdb/duckdb-postgres
-            GIT_TAG a4e03aad76a002e913e676cce1fc2600f64a614f
+            GIT_TAG 35ee7df236d661bfad08ad2a8aeb134d11c5a3f4
             SUBMODULES database-connector
             )
  endif()


### PR DESCRIPTION
This PR updates Postgres extension to make it easier to consume Redshift-related changes added in:

 - duckdb/duckdb-postgres#520

 Ref: duckdblabs/duckdb-internal#9970