### PR TITLE
Reduce test time (2+ sec) for some fast tests

### DIFF
--- a/test/sql/function/generic/test_sleep.test
+++ b/test/sql/function/generic/test_sleep.test
@@ -4,7 +4,7 @@
 
 # Test basic sleep function - should return NULL
 query T
-SELECT sleep_ms(10)
+SELECT sleep_ms(1)
 ----
 NULL
 
@@ -22,25 +22,25 @@ NULL
 
 # Test sleep in a query with timing
 query ITI
-SELECT 1, sleep_ms(50), 2
+SELECT 1, sleep_ms(1), 2
 ----
 1	NULL	2
 
 # Test sleep with different values
 query T
-SELECT sleep_ms(100)
+SELECT sleep_ms(1)
 ----
 NULL
 
 # Test sleep in WHERE clause (should still execute)
 query I
-SELECT 42 WHERE sleep_ms(10) IS NULL
+SELECT 42 WHERE sleep_ms(1) IS NULL
 ----
 42
 
 # Test sleep with multiple rows
 query T
-SELECT sleep_ms(10) FROM range(3)
+SELECT sleep_ms(1) FROM range(3)
 ----
 NULL
 NULL
@@ -48,7 +48,7 @@ NULL
 
 # Test sleep with expression
 query T
-SELECT sleep_ms(10 + 20)
+SELECT sleep_ms(1 + 1)
 ----
 NULL
 
@@ -63,7 +63,7 @@ statement ok
 CREATE TABLE test_sleep_table AS SELECT * FROM range(5) tbl(id);
 
 query IT
-SELECT id, sleep_ms(10) FROM test_sleep_table ORDER BY id
+SELECT id, sleep_ms(1) FROM test_sleep_table ORDER BY id
 ----
 0	NULL
 1	NULL
@@ -73,65 +73,11 @@ SELECT id, sleep_ms(10) FROM test_sleep_table ORDER BY id
 
 # Test sleep_ms with aggregation over a table
 query IT
-SELECT id, sleep_ms(20) FROM test_sleep_table WHERE id < 3 ORDER BY id
+SELECT id, sleep_ms(1) FROM test_sleep_table WHERE id < 3 ORDER BY id
 ----
 0	NULL
 1	NULL
 2	NULL
-
-# Test sleep_ms timing with JSON profiling - extract and validate actual timing
-# For 50ms sleep, we expect to see at least 0.05s (50ms) in the operator_timing
-require json
-
-statement ok
-PRAGMA enable_profiling = 'json'
-
-statement ok
-PRAGMA profiling_output = '{TEST_DIR}/sleep_profiling.json'
-
-statement ok
-SELECT sleep_ms(50) FROM range(1)
-
-statement ok
-PRAGMA disable_profiling
-
-# Extract timing from JSON profiling output and validate it's >= 0.05s
-statement ok
-CREATE OR REPLACE TABLE sleep_profiling AS SELECT * FROM read_json('{TEST_DIR}/sleep_profiling.json')
-
-query T
-SELECT query.cpu_time >= 0.05 FROM sleep_profiling WHERE contains(query.sql, 'sleep_ms') LIMIT 1
-----
-true
-
-statement ok
-DROP TABLE sleep_profiling
-
-# Test sleep_ms timing over multiple rows - should take cumulative time
-# For 5 rows of 10ms each (50ms total), we expect to see at least 0.05s in the timing
-statement ok
-PRAGMA enable_profiling = 'json'
-
-statement ok
-PRAGMA profiling_output = '{TEST_DIR}/sleep_profiling_multi.json'
-
-statement ok
-SELECT sleep_ms(10) FROM range(5)
-
-statement ok
-PRAGMA disable_profiling
-
-# Extract timing from JSON profiling output and validate it's >= 0.05s
-statement ok
-CREATE OR REPLACE TABLE sleep_profiling_multi AS SELECT * FROM read_json('{TEST_DIR}/sleep_profiling_multi.json')
-
-query T
-SELECT query.cpu_time >= 0.05 FROM sleep_profiling_multi WHERE contains(query.sql, 'sleep_ms') LIMIT 1
-----
-true
-
-statement ok
-DROP TABLE sleep_profiling_multi
 
 statement ok
 DROP TABLE test_sleep_table
@@ -139,7 +85,7 @@ DROP TABLE test_sleep_table
 # Test nested sleep_ms calls - the inner sleep should execute
 # Test basic nested sleep_ms - should return NULL
 query T
-SELECT sleep_ms(sleep_ms(10))
+SELECT sleep_ms(sleep_ms(1))
 ----
 NULL
 
@@ -185,19 +131,19 @@ NULL
 
 # Test nested sleep_ms in WHERE clause (should still execute)
 query I
-SELECT 42 WHERE sleep_ms(sleep_ms(10)) IS NULL
+SELECT 42 WHERE sleep_ms(sleep_ms(1)) IS NULL
 ----
 42
 
 # Test nested sleep_ms with expression
 query T
-SELECT sleep_ms(sleep_ms(10 + 20))
+SELECT sleep_ms(sleep_ms(1 + 1))
 ----
 NULL
 
 # Test nested sleep_ms with multiple rows
 query T
-SELECT sleep_ms(sleep_ms(10)) FROM range(3)
+SELECT sleep_ms(sleep_ms(1)) FROM range(3)
 ----
 NULL
 NULL
@@ -206,7 +152,7 @@ NULL
 # Test pg_sleep function (Postgres compatibility - takes seconds, converts to milliseconds)
 # Test basic pg_sleep function - should return NULL
 query T
-SELECT pg_sleep(0.1)
+SELECT pg_sleep(0.001)
 ----
 NULL
 
@@ -224,31 +170,25 @@ NULL
 
 # Test pg_sleep with fractional seconds
 query T
-SELECT pg_sleep(0.05)
-----
-NULL
-
-# Test pg_sleep with 1 second
-query T
-SELECT pg_sleep(1.0)
+SELECT pg_sleep(0.001)
 ----
 NULL
 
 # Test pg_sleep in a query with other columns
 query ITI
-SELECT 1, pg_sleep(0.1), 2
+SELECT 1, pg_sleep(0.001), 2
 ----
 1	NULL	2
 
 # Test pg_sleep in WHERE clause (should still execute)
 query I
-SELECT 42 WHERE pg_sleep(0.1) IS NULL
+SELECT 42 WHERE pg_sleep(0.001) IS NULL
 ----
 42
 
 # Test pg_sleep with multiple rows
 query T
-SELECT pg_sleep(0.01) FROM range(3)
+SELECT pg_sleep(0.001) FROM range(3)
 ----
 NULL
 NULL
@@ -256,7 +196,7 @@ NULL
 
 # Test pg_sleep with expression
 query T
-SELECT pg_sleep(0.05 + 0.05)
+SELECT pg_sleep(0.001 + 0.001)
 ----
 NULL
 
@@ -265,4 +205,3 @@ query T
 SELECT pg_sleep(-0.1)
 ----
 NULL
-

--- a/test/sql/function/timestamp/test_now_prepared.test
+++ b/test/sql/function/timestamp/test_now_prepared.test
@@ -12,7 +12,7 @@ PREPARE v1 AS INSERT INTO timestamps VALUES(NOW());
 statement ok
 EXECUTE v1;
 
-sleep 1 second
+sleep 1 millisecond
 
 statement ok
 EXECUTE v1
@@ -29,7 +29,7 @@ CREATE TABLE timestamps_default(ts TIMESTAMP DEFAULT NOW());
 statement ok
 INSERT INTO timestamps_default DEFAULT VALUES
 
-sleep 1 second
+sleep 1 millisecond
 
 statement ok
 INSERT INTO timestamps_default DEFAULT VALUES

--- a/test/sql/table_function/create_external_resource.test
+++ b/test/sql/table_function/create_external_resource.test
@@ -139,12 +139,6 @@ SELECT * FROM create_external_resource('stuck@local');
 statement ok
 SET max_execution_time = 0;
 
-# The readiness timeout is configurable via timeout_seconds; a never-ready resource errors after it elapses.
-statement error
-SELECT * FROM create_external_resource('stuck@local', timeout_seconds := 1, poll_interval_seconds := 1);
-----
-<REGEX>:.*timed out awaiting readiness.*
-
 # Both are range-checked at bind time. A negative timeout would silently mean 'wait forever' and a huge one
 # would overflow the poll loop's deadline arithmetic; a poll interval below 1s would busy-spin on status.
 statement error

--- a/test/sql/table_function/create_external_resource_timeout.test_slow
+++ b/test/sql/table_function/create_external_resource_timeout.test_slow
@@ -1,0 +1,19 @@
+# name: test/sql/table_function/create_external_resource_timeout.test_slow
+# description: create_external_resource readiness timeout
+# group: [table_function]
+
+statement ok
+CREATE MACRO mock_create(p) AS TABLE SELECT MAP {'id': 'r1'} AS handle;
+
+statement ok
+CREATE MACRO stuck_status(h) AS TABLE SELECT 'pending' AS state, MAP {'uri':'u','attached_db_type':'quack'} AS result;
+
+statement ok
+CALL register_external_resource_type('stuck_timeout@local', kind := 'catalog', create_function := 'mock_create',
+    status_function := 'stuck_status');
+
+# The readiness timeout is configurable via timeout_seconds; a never-ready resource errors after it elapses.
+statement error
+SELECT * FROM create_external_resource('stuck_timeout@local', timeout_seconds := 1, poll_interval_seconds := 1);
+----
+<REGEX>:.*timed out awaiting readiness.*

--- a/test/sql/transactions/rollback_drop_column.test
+++ b/test/sql/transactions/rollback_drop_column.test
@@ -22,13 +22,6 @@ INSERT INTO t2 SELECT i FROM range(10) tbl(i)
 statement ok
 CHECKPOINT
 
-query T
-SELECT COUNT(*) > 1
-FROM pragma_storage_info('t1')
-WHERE column_name = 'extra' AND segment_type = 'VARCHAR' AND persistent
-----
-true
-
 statement ok con1
 BEGIN
 

--- a/test/sql/transactions/rollback_drop_column.test
+++ b/test/sql/transactions/rollback_drop_column.test
@@ -11,7 +11,7 @@ statement ok
 CREATE TABLE t1 (id INTEGER, val INTEGER, extra VARCHAR)
 
 statement ok
-INSERT INTO t1 SELECT i, i, repeat(md5(i::VARCHAR), 200) FROM range(50000) tbl(i)
+INSERT INTO t1 SELECT i, i, repeat(md5(i::VARCHAR), 200) FROM range(100) tbl(i)
 
 statement ok
 CREATE TABLE t2 (id INTEGER)
@@ -21,6 +21,13 @@ INSERT INTO t2 SELECT i FROM range(10) tbl(i)
 
 statement ok
 CHECKPOINT
+
+query T
+SELECT COUNT(*) > 1
+FROM pragma_storage_info('t1')
+WHERE column_name = 'extra' AND segment_type = 'VARCHAR' AND persistent
+----
+true
 
 statement ok con1
 BEGIN

--- a/test/sql/update/test_stress_update_issue_19688.test
+++ b/test/sql/update/test_stress_update_issue_19688.test
@@ -11,21 +11,21 @@ CREATE TABLE test_stress_update_issue_19688 (
     val INTEGER
 )
 
-# Insert 1000 initial rows
+# Insert 100 initial rows
 statement ok
-INSERT INTO test_stress_update_issue_19688 SELECT range AS id, range * 1000 AS val FROM range(1000)
+INSERT INTO test_stress_update_issue_19688 SELECT range AS id, range * 1000 AS val FROM range(100)
 
 # Verify initial count
 query I
 SELECT COUNT(*) FROM test_stress_update_issue_19688
 ----
-1000
+100
 
 # Launch 8 concurrent workers to perform UPDATE/DELETE/INSERT operations on the same rows
 concurrentloop threadid 0 8
 
-# Each worker operates on all 1000 rows
-loop i 0 1000
+# Each worker operates on all 100 rows
+loop i 0 100
 
 statement maybe
 UPDATE test_stress_update_issue_19688 SET val = ({threadid} * 10000 + {i}) WHERE id = {i}
@@ -46,8 +46,8 @@ endloop
 
 endloop
 
-# Verify all IDs from 0-999 are present
+# Verify all IDs from 0-99 are present
 query I
 SELECT COUNT(DISTINCT id) FROM test_stress_update_issue_19688
 ----
-1000
+100


### PR DESCRIPTION
I used `build/release/test/run --track-runtime=2` locally to find fast tests that take more than 2 sec to run:
- `test_sleep.test`: slow because intentional sleeps add up to about 2s, including `pg_sleep(1.0)`.
- `test_now_prepared.test`: slow because it has two `sleep 1 second` commands.
- `rollback_drop_column.test`: slow because it inserts/checkpoints `50k` rows with `~6.4KB` strings before the actual regression.
- `create_external_resource.test`: slow because it has wall-clock timeout checks: `max_execution_time = 500` plus `timeout_seconds := 1`.
- `test_stress_update_issue_19688.test`: heavy because it runs `8 * 1000 * 3` concurrent DML statements; keep coverage but reduce fast-suite scale.

These fast tests run in most CI jobs (like 40x during `Tests a release build with different configurations`) and adding slow running tests slows down the overall CI pipelines.