### PR TITLE
Push down projections into shredded Parquet VARIANT columns

### DIFF
--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -592,6 +592,92 @@ ParquetColumnSchema ParquetReader::ParseColumnSchema(const SchemaElement &s_ele,
 	                                              parquet_options);
 }
 
+namespace {
+
+optional_idx FindSchemaChild(const ParquetColumnSchema &schema, const string &name) {
+	for (idx_t child_idx = 0; child_idx < schema.children.size(); child_idx++) {
+		if (schema.children[child_idx].name == name) {
+			return child_idx;
+		}
+	}
+	return optional_idx();
+}
+
+bool TryResolveVariantProjection(const ParquetColumnSchema &typed_value_schema, const ColumnIndex &logical_index,
+                                 ColumnIndex &physical_index) {
+	if (logical_index.HasPrimaryIndex() || typed_value_schema.type.id() != LogicalTypeId::STRUCT) {
+		return false;
+	}
+
+	auto field_idx = FindSchemaChild(typed_value_schema, logical_index.GetFieldName());
+	if (!field_idx.IsValid()) {
+		return false;
+	}
+	auto &field_schema = typed_value_schema.children[field_idx.GetIndex()];
+	if (field_schema.type.id() != LogicalTypeId::STRUCT) {
+		return false;
+	}
+
+	auto value_idx = FindSchemaChild(field_schema, "value");
+	auto typed_value_idx = FindSchemaChild(field_schema, "typed_value");
+	if (!value_idx.IsValid() || !typed_value_idx.IsValid()) {
+		return false;
+	}
+
+	vector<ColumnIndex> field_indexes;
+	field_indexes.emplace_back(value_idx.GetIndex());
+	if (!logical_index.HasChildren()) {
+		field_indexes.emplace_back(typed_value_idx.GetIndex());
+	} else {
+		vector<ColumnIndex> typed_value_indexes;
+		auto &nested_schema = field_schema.children[typed_value_idx.GetIndex()];
+		for (auto &child : logical_index.GetChildIndexes()) {
+			ColumnIndex nested_index;
+			if (!TryResolveVariantProjection(nested_schema, child, nested_index)) {
+				return false;
+			}
+			typed_value_indexes.push_back(std::move(nested_index));
+		}
+		field_indexes.emplace_back(typed_value_idx.GetIndex(), std::move(typed_value_indexes));
+	}
+	physical_index = ColumnIndex(field_idx.GetIndex(), std::move(field_indexes));
+	return true;
+}
+
+struct VariantProjection {
+	idx_t metadata_idx;
+	idx_t typed_value_idx;
+	vector<ColumnIndex> typed_value_indexes;
+};
+
+bool TryCreateVariantProjection(const ParquetColumnSchema &schema, const vector<ColumnIndex> &logical_indexes,
+                                VariantProjection &projection) {
+	if (logical_indexes.empty() || schema.children.size() != 3 || schema.children[2].name != "typed_value") {
+		return false;
+	}
+	if (schema.children[0].name == "metadata" && schema.children[1].name == "value") {
+		projection.metadata_idx = 0;
+	} else if (schema.children[1].name == "metadata" && schema.children[0].name == "value") {
+		projection.metadata_idx = 1;
+	} else {
+		return false;
+	}
+
+	projection.typed_value_idx = 2;
+	projection.typed_value_indexes.clear();
+	auto &typed_value_schema = schema.children[projection.typed_value_idx];
+	for (auto &logical_index : logical_indexes) {
+		ColumnIndex physical_index;
+		if (!TryResolveVariantProjection(typed_value_schema, logical_index, physical_index)) {
+			return false;
+		}
+		projection.typed_value_indexes.push_back(std::move(physical_index));
+	}
+	return true;
+}
+
+} // namespace
+
 unique_ptr<ColumnReader> ParquetReader::CreateReaderRecursive(ClientContext &context, const ColumnIndex &column_id,
                                                               const ParquetColumnSchema &schema) const {
 	auto &indexes = column_id.GetChildIndexes();
@@ -662,6 +748,17 @@ unique_ptr<ColumnReader> ParquetReader::CreateReaderRecursive(ClientContext &con
 		}
 		vector<unique_ptr<ColumnReader>> children;
 		children.resize(schema.children.size());
+
+		VariantProjection projection;
+		if (TryCreateVariantProjection(schema, indexes, projection)) {
+			children[projection.metadata_idx] = CreateReaderRecursive(context, ColumnIndex(projection.metadata_idx),
+			                                                          schema.children[projection.metadata_idx]);
+			children[projection.typed_value_idx] = CreateReaderRecursive(
+			    context, ColumnIndex(projection.typed_value_idx, std::move(projection.typed_value_indexes)),
+			    schema.children[projection.typed_value_idx]);
+			return make_uniq<VariantColumnReader>(context, *this, schema, std::move(children));
+		}
+
 		for (idx_t child_index = 0; child_index < schema.children.size(); child_index++) {
 			children[child_index] =
 			    CreateReaderRecursive(context, ColumnIndex(child_index), schema.children[child_index]);

--- a/extension/parquet/reader/variant/parquet_variant_shredding.cpp
+++ b/extension/parquet/reader/variant/parquet_variant_shredding.cpp
@@ -51,7 +51,8 @@ ShredPlan AnalyzeShred(const ShreddedGroupView &view, idx_t count, bool is_objec
 		//! A leaf is fully convertible if there is no binary leftover; an OBJECT field additionally must never
 		//! be missing (a NULL typed_value of a flat field would read as VARIANT_NULL, not "missing")
 		bool no_leftover = ValueAllNull(view, count);
-		bool no_missing = !is_object_field || view.leaf_format.validity.CheckAllValid(count);
+		bool no_missing =
+		    !is_object_field || view.leaf_format.validity.CheckAllValidSel(*view.leaf_format.sel, count);
 		plan.flat = no_leftover && no_missing;
 		break;
 	}

--- a/extension/parquet/reader/variant_column_reader.cpp
+++ b/extension/parquet/reader/variant_column_reader.cpp
@@ -18,6 +18,7 @@
 #include "duckdb/common/types/vector.hpp"
 #include "duckdb/common/unique_ptr.hpp"
 #include "duckdb/common/vector.hpp"
+#include "duckdb/common/vector/constant_vector.hpp"
 #include "parquet_column_schema.hpp"
 
 namespace duckdb_apache {
@@ -51,10 +52,10 @@ VariantColumnReader::VariantColumnReader(ClientContext &context, const ParquetRe
 		}
 	}
 
-	if (child_readers[0]->Schema().name == "metadata" && child_readers[1]->Schema().name == "value") {
+	if (schema.children[0].name == "metadata" && schema.children[1].name == "value") {
 		metadata_reader_idx = 0;
 		value_reader_idx = 1;
-	} else if (child_readers[1]->Schema().name == "metadata" && child_readers[0]->Schema().name == "value") {
+	} else if (schema.children[1].name == "metadata" && schema.children[0].name == "value") {
 		metadata_reader_idx = 1;
 		value_reader_idx = 0;
 	} else {
@@ -128,15 +129,16 @@ idx_t VariantColumnReader::Read(ColumnReaderInput &input, Vector &result) {
 	ColumnReaderInput metadata_reader_input(num_values, define_out, repeat_out);
 	auto metadata_values = child_readers[metadata_reader_idx]->Read(metadata_reader_input, metadata_intermediate);
 
-	ColumnReaderInput value_reader_input(num_values, define_out, repeat_out);
-	auto value_values = child_readers[value_reader_idx]->Read(value_reader_input, value_intermediate);
-
-	D_ASSERT(child_readers[metadata_reader_idx]->Schema().name == "metadata");
-	D_ASSERT(child_readers[value_reader_idx]->Schema().name == "value");
-
-	if (metadata_values != value_values) {
-		throw InvalidInputException(
-		    "The Variant column did not contain the same amount of values for 'metadata' and 'value'");
+	auto value_values = metadata_values;
+	if (child_readers[value_reader_idx]) {
+		ColumnReaderInput value_reader_input(num_values, define_out, repeat_out);
+		value_values = child_readers[value_reader_idx]->Read(value_reader_input, value_intermediate);
+		if (metadata_values != value_values) {
+			throw InvalidInputException(
+			    "The Variant column did not contain the same amount of values for 'metadata' and 'value'");
+		}
+	} else {
+		ConstantVector::SetNull(value_intermediate, count_t(num_values));
 	}
 
 	if (typed_value_reader) {

--- a/src/common/types/validity_mask.cpp
+++ b/src/common/types/validity_mask.cpp
@@ -154,6 +154,18 @@ void ValidityMask::CopySel(const ValidityMask &other, const SelectionVector &sel
 	}
 }
 
+bool ValidityMask::CheckAllValidSel(const SelectionVector &sel, idx_t count) const {
+	if (CannotHaveNull()) {
+		return true;
+	}
+	for (idx_t i = 0; i < count; i++) {
+		if (!RowIsValid(sel.get_index(i))) {
+			return false;
+		}
+	}
+	return true;
+}
+
 void ValidityMask::SliceInPlace(const ValidityMask &other, idx_t target_offset, idx_t source_offset, idx_t count) {
 	if (CannotHaveNull() && other.CannotHaveNull()) {
 		// Both validity masks are uninitialized, nothing to do

--- a/src/include/duckdb/common/types/validity_mask.hpp
+++ b/src/include/duckdb/common/types/validity_mask.hpp
@@ -383,6 +383,8 @@ public:
 	DUCKDB_API void Slice(const ValidityMask &other, idx_t source_offset, idx_t count);
 	DUCKDB_API void CopySel(const ValidityMask &other, const SelectionVector &sel, idx_t source_offset,
 	                        idx_t target_offset, idx_t count);
+	//! Like CheckAllValid(count), but sel maps each logical row to a physical validity index.
+	DUCKDB_API bool CheckAllValidSel(const SelectionVector &sel, idx_t count) const;
 	DUCKDB_API void CopyRange(const ValidityMask &other, idx_t count);
 	DUCKDB_API void Combine(const ValidityMask &other, idx_t count);
 	DUCKDB_API void Combine(const Vector &other, idx_t count);

--- a/test/parquet/parquet_variant_projection_pushdown.test
+++ b/test/parquet/parquet_variant_projection_pushdown.test
@@ -1,0 +1,94 @@
+# name: test/parquet/parquet_variant_projection_pushdown.test
+# description: Project paths from shredded Parquet VARIANT columns
+# group: [parquet]
+
+require parquet
+
+statement ok
+SET variant_minimum_shredding_size = 0
+
+statement ok
+COPY (
+	SELECT * FROM (VALUES
+		(0, {
+			'env': 'staging',
+			'nested': {'region': 'us', 'zone': 1, 'outside': 'inside'},
+			'items': [10, 11],
+			'outside': 'root'
+		}::VARIANT),
+		(1, {
+			'env': 42::VARIANT,
+			'nested': {'region': 'eu', 'zone': 2, 'outside': 99},
+			'items': [20],
+			'outside': 'tail'
+		}::VARIANT),
+		(2, 'scalar'::VARIANT),
+		(3, NULL::VARIANT)
+	) t(id, v)
+) TO '{TEST_DIR}/variant_projection.parquet' (
+	FORMAT PARQUET,
+	SHREDDING {
+		v: 'STRUCT(
+			env VARCHAR,
+			nested STRUCT(region VARCHAR, zone INTEGER),
+			items INTEGER[]
+		)'
+	}
+)
+
+# Project top-level and merged nested paths, including a value that does not match the shredding type.
+query IIII
+SELECT id, v.env::VARCHAR, v.nested.region::VARCHAR, v.nested.zone
+FROM '{TEST_DIR}/variant_projection.parquet'
+ORDER BY id
+----
+0	staging	us	1
+1	42	eu	2
+2	NULL	NULL	NULL
+3	NULL	NULL	NULL
+
+# A root path outside the shredding schema can live in the root binary value.
+query II
+SELECT id, v.outside::VARCHAR
+FROM '{TEST_DIR}/variant_projection.parquet'
+ORDER BY id
+----
+0	root
+1	tail
+2	NULL
+3	NULL
+
+# The same fallback is required below a shredded object.
+query II
+SELECT id, v.nested.outside::VARCHAR
+FROM '{TEST_DIR}/variant_projection.parquet'
+ORDER BY id
+----
+0	inside
+1	99
+2	NULL
+3	NULL
+
+# ARRAY traversal is not a supported physical projection path.
+query II
+SELECT id, v.items[1]
+FROM '{TEST_DIR}/variant_projection.parquet'
+ORDER BY id
+----
+0	10
+1	20
+2	NULL
+3	NULL
+
+# A full-column reference must preserve the complete VARIANT value.
+query I
+SELECT count(*)
+FROM '{TEST_DIR}/variant_projection.parquet'
+WHERE v = {
+	'env': 'staging',
+	'nested': {'region': 'us', 'zone': 1, 'outside': 'inside'},
+	'items': [10, 11],
+	'outside': 'root'
+}::VARIANT
+----
+1

--- a/test/parquet/parquet_variant_projection_pushdown_io.test
+++ b/test/parquet/parquet_variant_projection_pushdown_io.test
@@ -69,15 +69,3 @@ SELECT
 	(SELECT io.total_bytes_read FROM '{TEST_DIR}/variant_projection_full.json')
 ----
 true
-
-statement ok
-RESET disable_parquet_prefetching
-
-statement ok
-RESET enable_external_file_cache
-
-statement ok
-RESET tracked_metrics
-
-statement ok
-RESET profiling_output

--- a/test/parquet/parquet_variant_projection_pushdown_io.test
+++ b/test/parquet/parquet_variant_projection_pushdown_io.test
@@ -1,0 +1,83 @@
+# name: test/parquet/parquet_variant_projection_pushdown_io.test
+# description: Avoid reading unrelated Parquet leaves for projected VARIANT paths
+# group: [parquet]
+
+require parquet
+
+require json
+
+statement ok
+SET variant_minimum_shredding_size = 0
+
+statement ok
+COPY (
+	SELECT {
+		'nested': {'region': CASE WHEN i % 2 = 0 THEN 'us' ELSE 'eu' END, 'zone': i % 5},
+		'payload': repeat(md5((i * 99)::VARCHAR), 40)
+	}::VARIANT AS v
+	FROM range(300) t(i)
+) TO '{TEST_DIR}/variant_projection_io.parquet' (
+	FORMAT PARQUET,
+	COMPRESSION 'uncompressed',
+	SHREDDING {
+		v: 'STRUCT(
+			nested STRUCT(region VARCHAR, zone INTEGER),
+			payload VARCHAR
+		)'
+	}
+)
+
+statement ok
+SET disable_parquet_prefetching = true
+
+statement ok
+SET enable_external_file_cache = false
+
+# Read two paths with a shared prefix, but not the large payload sibling.
+statement ok
+CALL enable_profiling(
+	['io.total_bytes_read'],
+	format = 'json',
+	save_location = '{TEST_DIR}/variant_projection_selected.json'
+)
+
+statement ok
+SELECT sum(length(v.nested.region::VARCHAR)) + sum(v.nested.zone)
+FROM '{TEST_DIR}/variant_projection_io.parquet'
+
+statement ok
+CALL disable_profiling()
+
+# Use a full VARIANT scan as the control measurement.
+statement ok
+CALL enable_profiling(
+	['io.total_bytes_read'],
+	format = 'json',
+	save_location = '{TEST_DIR}/variant_projection_full.json'
+)
+
+statement ok
+SELECT sum(length(v::VARCHAR))
+FROM '{TEST_DIR}/variant_projection_io.parquet'
+
+statement ok
+CALL disable_profiling()
+
+query I
+SELECT
+	(SELECT io.total_bytes_read FROM '{TEST_DIR}/variant_projection_selected.json') * 50 <
+	(SELECT io.total_bytes_read FROM '{TEST_DIR}/variant_projection_full.json')
+----
+true
+
+statement ok
+RESET disable_parquet_prefetching
+
+statement ok
+RESET enable_external_file_cache
+
+statement ok
+RESET tracked_metrics
+
+statement ok
+RESET profiling_output


### PR DESCRIPTION
This avoids reading unrelated Parquet column chunks when a query accesses specific object fields from a shredded `VARIANT`.

Previously, the Parquet reader loaded the entire shredded `VARIANT`, including unrelated sibling fields. This change translates the logical `VARIANT` field paths recorded by the optimizer into physical projections of the Parquet `typed_value` tree.

For each selected object field, the reader retains:

- The field's `value` child, which contains partially shredded or type-mismatched values.
- The required portion of its `typed_value` subtree.

The root `metadata` column is always read, while the root `value` column and unrelated shredded siblings can be omitted.

Multiple paths with shared prefixes are supported.

If a path cannot be resolved safely (including array paths or fields outside the shredded schema) the reader conservatively falls back to reading the complete VARIANT.

On some of our use-cases we're speaking 10-100x less bytes read :)