### PR TITLE
Fix extra semicolon on export

### DIFF
--- a/src/execution/operator/persistent/physical_export.cpp
+++ b/src/execution/operator/persistent/physical_export.cpp
@@ -43,7 +43,7 @@ static void WriteCatalogEntries(stringstream &ss, catalog_entry_vector_t &entrie
 		} catch (const NotImplementedException &) {
 			ss << entry.get().ToSQL();
 		}
-		ss << ";\n";
+		ss << '\n';
 	}
 	ss << '\n';
 }

--- a/src/parser/parsed_data/create_type_info.cpp
+++ b/src/parser/parsed_data/create_type_info.cpp
@@ -36,7 +36,7 @@ string CreateTypeInfo::ToString() const {
 				result += ", ";
 			}
 		}
-		result += " );";
+		result += " )";
 	} else if (type.id() == LogicalTypeId::INVALID) {
 		// CREATE TYPE mood AS ENUM (SELECT 'happy')
 		D_ASSERT(query);


### PR DESCRIPTION
Closes https://github.com/duckdb/duckdb/issues/23976

Before change (v1.5.4)
```sql
DuckDB v1.5.4 (Variegata)
Enter ".help" for usage hints.
memory D CREATE TABLE x(i INTEGER);
memory D EXPORT DATABASE '/tmp/repro_table' (FORMAT CSV);
memory D SELECT content
         FROM read_text('/tmp/repro_table/schema.sql');
┌─────────────────────────────────┐
│             content             │
│             varchar             │
├─────────────────────────────────┤
│ CREATE TABLE x(i INTEGER);;\n\n │
└─────────────────────────────────┘
memory D 
memory D CREATE TYPE mood AS ENUM ('sad', 'ok');
memory D EXPORT DATABASE '/tmp/repro_enum' (FORMAT CSV);
memory D SELECT content
         FROM read_text('/tmp/repro_enum/schema.sql');
┌──────────────────────────────────────────────────────────────────────────────┐
│                                   content                                    │
│                                   varchar                                    │
├──────────────────────────────────────────────────────────────────────────────┤
│ CREATE TYPE mood AS ENUM ( 'sad', 'ok' );;;\nCREATE TABLE x(i INTEGER);;\n\n │
└──────────────────────────────────────────────────────────────────────────────┘
```
After change
```sql
memory D CREATE TABLE x(i INTEGER);
memory D EXPORT DATABASE '/tmp/repro_table' (FORMAT CSV);
memory D SELECT content
         FROM read_text('/tmp/repro_table/schema.sql');
┌────────────────────────────────┐
│            content             │
│            varchar             │
├────────────────────────────────┤
│ CREATE TABLE x(i INTEGER);\n\n │
└────────────────────────────────┘
memory D 
memory D CREATE TYPE mood AS ENUM ('sad', 'ok');
memory D EXPORT DATABASE '/tmp/repro_enum' (FORMAT CSV);
memory D SELECT content
         FROM read_text('/tmp/repro_enum/schema.sql');
┌───────────────────────────────────────────────────────────────────────────┐
│                                  content                                  │
│                                  varchar                                  │
├───────────────────────────────────────────────────────────────────────────┤
│ CREATE TYPE mood AS ENUM ( 'sad', 'ok' );\nCREATE TABLE x(i INTEGER);\n\n │
└───────────────────────────────────────────────────────────────────────────┘
```