### PR TITLE
Fix range joins on nested types with NULL elements

### DIFF
--- a/src/execution/physical_plan/plan_comparison_join.cpp
+++ b/src/execution/physical_plan/plan_comparison_join.cpp
@@ -20,6 +20,31 @@ static void RewriteJoinCondition(unique_ptr<Expression> &root_expr, idx_t offset
 	    root_expr, [&](BoundReferenceExpression &ref, unique_ptr<Expression> &expr) { ref.IndexMutable() += offset; });
 }
 
+//! Range comparisons on nested types cannot use the sort-based joins (piecewise merge / IE join).
+//! Those joins reduce a key to a single sort position with NULLS LAST, but for a nested value the
+//! comparison can be NULL or non-NULL depending on the other operand (e.g. [1, NULL] >= [0, 5] is
+//! TRUE while [1, NULL] >= [1, 5] is NULL), which a single sort position cannot represent.
+static bool HasNestedRangeCondition(const vector<JoinCondition> &conditions) {
+	for (auto &cond : conditions) {
+		if (!cond.IsComparison()) {
+			continue;
+		}
+		switch (cond.GetComparisonType()) {
+		case ExpressionType::COMPARE_LESSTHAN:
+		case ExpressionType::COMPARE_GREATERTHAN:
+		case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+		case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+			if (cond.GetLHS().GetReturnType().IsNested() || cond.GetRHS().GetReturnType().IsNested()) {
+				return true;
+			}
+			break;
+		default:
+			break;
+		}
+	}
+	return false;
+}
+
 PhysicalOperator &PhysicalPlanGenerator::PlanComparisonJoin(LogicalComparisonJoin &op) {
 	// now visit the children
 	D_ASSERT(op.children.size() == 2);
@@ -39,6 +64,11 @@ PhysicalOperator &PhysicalPlanGenerator::PlanComparisonJoin(LogicalComparisonJoi
 	bool has_equality = op.HasEquality(has_range);
 	bool can_merge = has_range > 0;
 	bool can_iejoin = has_range >= 2 && recursive_cte_tables.empty();
+	if (HasNestedRangeCondition(op.conditions)) {
+		// sort-based joins cannot represent nested range comparisons - use a nested loop join instead
+		can_merge = false;
+		can_iejoin = false;
+	}
 	switch (op.join_type) {
 	case JoinType::SEMI:
 	case JoinType::ANTI:

--- a/test/sql/join/inner/nested_range_join_null.test
+++ b/test/sql/join/inner/nested_range_join_null.test
@@ -1,0 +1,123 @@
+# name: test/sql/join/inner/nested_range_join_null.test
+# description: Range joins on nested types with NULL elements (issue #23955)
+# group: [inner]
+
+# A nested comparison can be NULL even when neither operand is top-level NULL, e.g. a list
+# containing a NULL element. Sort-based range joins (piecewise merge / IE join) cannot represent
+# this, so range joins on nested types must fall back to a nested loop join.
+
+# Force the sort-based join path (if it were still eligible) so this test guards the fix
+# regardless of the default thresholds.
+statement ok
+SET nested_loop_join_threshold=1;
+
+statement ok
+SET merge_join_threshold=1;
+
+statement ok
+CREATE TABLE l(a INT[]);
+
+statement ok
+INSERT INTO l VALUES (NULL), (NULL), (NULL), ([NULL]), ([881693051]);
+
+statement ok
+CREATE TABLE r(i INT);
+
+statement ok
+INSERT INTO r VALUES (1), (2), (3), (NULL), (NULL);
+
+# Ground truth: the projection of the comparison yields 3 TRUE and 22 NULL over the 25-row product.
+query II
+SELECT p, count(*) FROM (
+    SELECT (a < (CASE i WHEN i THEN [-768214738, -1891806940, 281316894] END)) AS p FROM l, r
+) GROUP BY p ORDER BY p
+----
+false	3
+NULL	22
+
+# issue #23955: NOT applied to the LIST comparison must keep exactly the 3 false rows
+query I
+SELECT count(*) FROM l, r
+WHERE NOT (a < (CASE i WHEN i THEN [-768214738, -1891806940, 281316894] END))
+----
+3
+
+# the direct comparison (no NOT rewrite) must be correct too - this is the true root cause
+query I
+SELECT count(*) FROM l, r
+WHERE a >= (CASE i WHEN i THEN [-768214738, -1891806940, 281316894] END)
+----
+3
+
+# full operator table - NULL comparison results must never match
+# [881693051] vs [5,6,7]: >=T >T <F <=F =F !=T ; [NULL] vs [5,6,7]: NULL ; NULL list: NULL
+query I
+SELECT count(*) FROM l, r WHERE a >= (CASE i WHEN i THEN [5,6,7] END)
+----
+3
+
+query I
+SELECT count(*) FROM l, r WHERE a > (CASE i WHEN i THEN [5,6,7] END)
+----
+3
+
+query I
+SELECT count(*) FROM l, r WHERE a < (CASE i WHEN i THEN [5,6,7] END)
+----
+0
+
+query I
+SELECT count(*) FROM l, r WHERE a <= (CASE i WHEN i THEN [5,6,7] END)
+----
+0
+
+# exactly which rows survive the range join - only the non-NULL comparison
+query I
+SELECT a FROM l, r WHERE a >= [5,6,7] ORDER BY a
+----
+[881693051]
+[881693051]
+[881693051]
+[881693051]
+[881693051]
+
+# structs behave the same way
+statement ok
+CREATE TABLE ls(a STRUCT(x INT));
+
+statement ok
+INSERT INTO ls VALUES (NULL), ({'x': NULL}), ({'x': 5});
+
+query I
+SELECT a FROM ls, r WHERE a >= {'x': 1} ORDER BY a
+----
+{'x': 5}
+{'x': 5}
+{'x': 5}
+{'x': 5}
+{'x': 5}
+
+# fixed-size arrays too
+statement ok
+CREATE TABLE la(a INT[2]);
+
+statement ok
+INSERT INTO la VALUES (NULL), ([NULL, NULL]), ([5, 6]);
+
+query I
+SELECT a FROM la, r WHERE a >= [1, 2]::INT[2] ORDER BY a
+----
+[5, 6]
+[5, 6]
+[5, 6]
+[5, 6]
+[5, 6]
+
+# nested range comparison must not select a sort-based join
+statement ok
+PRAGMA explain_output='PHYSICAL_ONLY';
+
+query II
+EXPLAIN SELECT count(*) FROM l, r WHERE a >= (CASE i WHEN i THEN [5,6,7] END)
+----
+physical_plan	<!REGEX>:.*(Piecewise Merge Join|IE Join).*


### PR DESCRIPTION
Fixes #23955.

### Root cause

A comparison between nested values (`LIST`/`STRUCT`/`ARRAY`) can evaluate to `NULL` even when neither operand is top-level `NULL` — for example when a list contains a `NULL` element (`[NULL] >= [5,6,7]` is `NULL`, not `true`).

The single inequality join condition in the repro is planned as a **piecewise merge join**. Sort-based range joins (piecewise merge join and IE join) reduce each key to a single sort position with `NULLS LAST`. That model cannot represent a nested comparison, because whether the result is `NULL` depends on the *other* operand:

```
[1, NULL] >= [0, 5]  -->  TRUE   (decided at element 0, never reaches the NULL)
[1, NULL] >= [1, 5]  -->  NULL   (element 0 equal, element 1 is NULL vs 5)
```

A row like `[NULL]` is not top-level `NULL`, so the merge join treated it as an ordinary key (sorted `NULLS LAST`, i.e. "greater than everything") and let it satisfy `>=`/`>`. This produced spurious matches for rows whose comparison should have been `NULL`. Because it only surfaces once the input is large enough to pick a merge join (small inputs fall back to a nested loop join), the direct comparison was silently wrong:

```sql
CREATE TABLE l(a INT[]);
INSERT INTO l VALUES (NULL), (NULL), (NULL), ([NULL]), ([881693051]);
CREATE TABLE r(i INT);
INSERT INTO r VALUES (1), (2), (3), (NULL), (NULL);

-- projection ground truth: 3 TRUE, 22 NULL
SELECT count(*) FROM l, r
  WHERE a >= (CASE i WHEN i THEN [-768214738, -1891806940, 281316894] END);
-- Expected: 3     Before: 6
```

The originally reported query hit this via the expression rewriter: `NOT(a < b)` is rewritten to `a >= b` (a sound rewrite), which then ran into the buggy range join.

### Fix

Fall back to a nested loop join when a range condition (`<`, `>`, `<=`, `>=`) operates on a nested type, so the comparison is evaluated with correct three-valued semantics. This is a plan-time guard in `PlanComparisonJoin`, matching the existing `TODO: Extend PWMJ to handle all comparisons` note. Scalar range joins are unaffected.

The earlier revision of this PR guarded the `NOT` optimizer rule instead; that only masked the reported query and left direct comparisons wrong (and needlessly disabled the null-safe `IS [NOT] DISTINCT FROM` rewrites). This revision fixes the actual root cause and reverts the optimizer rule to its original form.

### Trade-off

A nested range join now always uses a nested loop join, even when the data happens to contain no inner `NULL`s, because that cannot be known at plan time. Nested-type range joins are uncommon, and correctness takes precedence.

### Testing

New regression test `test/sql/join/inner/nested_range_join_null.test` forces the sort-based join path via low thresholds and checks result correctness for the issue repro, the direct `a >= …` form, the full operator table, and `LIST`/`STRUCT`/`ARRAY` keys, plus a plan assertion that a sort-based join is no longer chosen. The fix was verified against projection ground truth across INNER, LEFT OUTER, SEMI, ANTI, IE-join (two nested range conditions), and hash-join-with-nested-residual paths. Existing join, order, optimizer, nested-type, IE-join, merge, setops, distinct, and filter suites pass.

### Known adjacent limitation (out of scope)

The same underlying limitation affects the separate ASOF-join path (`PhysicalAsOfJoin` in `PlanAsOfJoin`), which is not touched by this change: an `ASOF JOIN ... ON l.a >= r.b` whose inequality key is a nested type containing a `NULL` element can still produce an incorrect match. This is a pre-existing issue independent of #23955 and much more exotic (ASOF ordering keys are effectively always scalar timestamps/numbers), so it is intentionally left for separate follow-up rather than expanded into this fix.
