### PR TITLE
Parse constant JSON paths once at bind time

### DIFF
--- a/benchmark/micro/json/json_extract_bare_key.benchmark
+++ b/benchmark/micro/json/json_extract_bare_key.benchmark
@@ -1,0 +1,19 @@
+# name: benchmark/micro/json/json_extract_bare_key.benchmark
+# description: Extract a top-level key from small JSON documents with the arrow operator
+# group: [json]
+
+name JSON extract bare key
+group json
+
+require json
+
+load
+CREATE TABLE docs AS
+SELECT json_object('id', i, 'user', json_object('name', 'user_' || i, 'tags', json_array(i % 10, i % 7)), 'ts', i * 1000) AS j
+FROM range(0, 5000000) t(i);
+
+run
+SELECT count(j->'user') FROM docs
+
+result I
+5000000

--- a/benchmark/micro/json/json_extract_deep_path.benchmark
+++ b/benchmark/micro/json/json_extract_deep_path.benchmark
@@ -1,0 +1,19 @@
+# name: benchmark/micro/json/json_extract_deep_path.benchmark
+# description: Extract a nested path from small JSON documents
+# group: [json]
+
+name JSON extract deep path
+group json
+
+require json
+
+load
+CREATE TABLE docs AS
+SELECT json_object('id', i, 'user', json_object('name', 'user_' || i, 'tags', json_array(i % 10, i % 7)), 'ts', i * 1000) AS j
+FROM range(0, 5000000) t(i);
+
+run
+SELECT count(j->'$.user.tags[0]') FROM docs
+
+result I
+5000000

--- a/benchmark/micro/json/json_extract_large_doc.benchmark
+++ b/benchmark/micro/json/json_extract_large_doc.benchmark
@@ -1,0 +1,24 @@
+# name: benchmark/micro/json/json_extract_large_doc.benchmark
+# description: Extract one path from larger JSON documents with many keys
+# group: [json]
+
+name JSON extract large doc
+group json
+
+require json
+
+load
+CREATE TABLE docs AS
+SELECT json_object(
+    'k00', i, 'k01', 'v' || i, 'k02', i % 100, 'k03', 'w' || i, 'k04', i * 2,
+    'k05', 'x' || i, 'k06', i % 7, 'k07', 'y' || i, 'k08', i * 3, 'k09', 'z' || i,
+    'payload', json_object('name', 'user_' || i, 'tags', json_array(i % 10, i % 7, i % 5, i % 3), 'meta', json_object('a', i, 'b', i + 1, 'c', i + 2)),
+    'k10', i, 'k11', 'v' || i, 'k12', i % 100, 'k13', 'w' || i, 'k14', i * 2,
+    'k15', 'x' || i, 'k16', i % 7, 'k17', 'y' || i, 'k18', i * 3, 'k19', 'z' || i) AS j
+FROM range(0, 2000000) t(i);
+
+run
+SELECT count(j->>'$.payload.name') FROM docs
+
+result I
+2000000

--- a/benchmark/micro/json/json_extract_many_paths.benchmark
+++ b/benchmark/micro/json/json_extract_many_paths.benchmark
@@ -1,0 +1,19 @@
+# name: benchmark/micro/json/json_extract_many_paths.benchmark
+# description: Extract a list of paths from small JSON documents
+# group: [json]
+
+name JSON extract many paths
+group json
+
+require json
+
+load
+CREATE TABLE docs AS
+SELECT json_object('id', i, 'user', json_object('name', 'user_' || i, 'tags', json_array(i % 10, i % 7)), 'ts', i * 1000) AS j
+FROM range(0, 5000000) t(i);
+
+run
+SELECT count(json_extract(j, ['$.user.name', '$.id', '$.ts'])) FROM docs
+
+result I
+5000000

--- a/benchmark/micro/json/json_extract_string_path.benchmark
+++ b/benchmark/micro/json/json_extract_string_path.benchmark
@@ -1,0 +1,19 @@
+# name: benchmark/micro/json/json_extract_string_path.benchmark
+# description: Extract a nested string value from small JSON documents
+# group: [json]
+
+name JSON extract string path
+group json
+
+require json
+
+load
+CREATE TABLE docs AS
+SELECT json_object('id', i, 'user', json_object('name', 'user_' || i, 'tags', json_array(i % 10, i % 7)), 'ts', i * 1000) AS j
+FROM range(0, 5000000) t(i);
+
+run
+SELECT count(j->>'$.user.name') FROM docs
+
+result I
+5000000

--- a/benchmark/micro/json/json_extract_wildcard.benchmark
+++ b/benchmark/micro/json/json_extract_wildcard.benchmark
@@ -1,0 +1,19 @@
+# name: benchmark/micro/json/json_extract_wildcard.benchmark
+# description: Extract a wildcard path from small JSON documents
+# group: [json]
+
+name JSON extract wildcard
+group json
+
+require json
+
+load
+CREATE TABLE docs AS
+SELECT json_object('id', i, 'user', json_object('name', 'user_' || i, 'tags', json_array(i % 10, i % 7)), 'ts', i * 1000) AS j
+FROM range(0, 5000000) t(i);
+
+run
+SELECT count(json_extract(j, '$.user.tags[*]')) FROM docs
+
+result I
+5000000

--- a/benchmark/micro/json/json_set_path.benchmark
+++ b/benchmark/micro/json/json_set_path.benchmark
@@ -1,0 +1,19 @@
+# name: benchmark/micro/json/json_set_path.benchmark
+# description: Set a nested path in small JSON documents
+# group: [json]
+
+name JSON set path
+group json
+
+require json
+
+load
+CREATE TABLE docs AS
+SELECT json_object('id', i, 'user', json_object('name', 'user_' || i, 'tags', json_array(i % 10, i % 7)), 'ts', i * 1000) AS j
+FROM range(0, 5000000) t(i);
+
+run
+SELECT count(json_set(j, '$.user.name', '"x"')) FROM docs
+
+result I
+5000000

--- a/benchmark/micro/json/json_transform_struct.benchmark
+++ b/benchmark/micro/json/json_transform_struct.benchmark
@@ -1,0 +1,19 @@
+# name: benchmark/micro/json/json_transform_struct.benchmark
+# description: Transform JSON documents into a typed struct
+# group: [json]
+
+name JSON transform struct
+group json
+
+require json
+
+load
+CREATE TABLE docs AS
+SELECT json_object('id', i, 'user', json_object('name', 'user_' || i, 'tags', json_array(i % 10, i % 7)), 'ts', i * 1000) AS j
+FROM range(0, 5000000) t(i);
+
+run
+SELECT count(json_transform(j, '{"id":"BIGINT","user":{"name":"VARCHAR","tags":"BIGINT[]"},"ts":"BIGINT"}')) FROM docs
+
+result I
+5000000

--- a/extension/json/include/json_common.hpp
+++ b/extension/json/include/json_common.hpp
@@ -363,6 +363,11 @@ public:
 	//! Validate JSON Path ($.field[index]... syntax), returns true if there are wildcards in the path
 	static JSONPathType ValidatePath(const char *ptr, const idx_t &len, const bool binder);
 
+	//! Parse a JSON path ($.field[index]... syntax, no wildcards) into path elements
+	static vector<JSONPathElement> ParsePathElements(const char *ptr, idx_t len, bool binder);
+	//! Get JSON value by walking pre-parsed path elements
+	static yyjson_val *GetPathElements(yyjson_val *val, const vector<JSONPathElement> &elements);
+
 public:
 	//! Same as BigQuery json_value
 	static inline optional<string_t> JSONValue(yyjson_val *val, yyjson_alc *alc, Vector &) {

--- a/extension/json/include/json_executors.hpp
+++ b/extension/json/include/json_executors.hpp
@@ -52,7 +52,9 @@ public:
 			if (info.path_type == JSONCommon::JSONPathType::REGULAR) {
 				UnaryExecutor::Execute<string_t, T>(inputs, result, [&](string_t input) -> optional<T> {
 					auto doc = JSONCommon::ReadDocument(input, JSONCommon::READ_FLAG, alc);
-					auto val = JSONCommon::GetUnsafe(doc->root, ptr, len);
+					// Use the path elements parsed at bind time when available
+					auto val = info.use_elements ? JSONCommon::GetPathElements(doc->root, info.elements)
+					                             : JSONCommon::GetUnsafe(doc->root, ptr, len);
 					if (SET_NULL_IF_NOT_FOUND && !val) {
 						return nullopt;
 					} else {
@@ -154,7 +156,9 @@ public:
 			auto doc = JSONCommon::ReadDocument(inputs[idx], JSONCommon::READ_FLAG, alc);
 			for (idx_t path_i = 0; path_i < num_paths; path_i++) {
 				auto child_idx = offset + path_i;
-				val = JSONCommon::GetUnsafe(doc->root, info.ptrs[path_i], info.lens[path_i]);
+				val = info.use_elements[path_i]
+				          ? JSONCommon::GetPathElements(doc->root, info.elements[path_i])
+				          : JSONCommon::GetUnsafe(doc->root, info.ptrs[path_i], info.lens[path_i]);
 				if (SET_NULL_IF_NOT_FOUND && !val) {
 					child_validity.SetInvalid(child_idx);
 				} else {

--- a/extension/json/include/json_functions.hpp
+++ b/extension/json/include/json_functions.hpp
@@ -38,6 +38,9 @@ public:
 	const JSONCommon::JSONPathType path_type;
 	const char *ptr;
 	const idx_t len;
+	//! Path elements parsed once at bind time (constant regular '$' paths only)
+	vector<JSONPathElement> elements;
+	bool use_elements = false;
 };
 
 struct JSONReadManyFunctionData : public FunctionData {
@@ -51,6 +54,9 @@ public:
 	const vector<string> paths;
 	vector<const char *> ptrs;
 	const vector<idx_t> lens;
+	//! Per-path elements parsed once at bind time (regular '$' paths only)
+	vector<vector<JSONPathElement>> elements;
+	vector<bool> use_elements;
 };
 
 struct JSONFunctionLocalState : public FunctionLocalState {

--- a/extension/json/json_common.cpp
+++ b/extension/json/json_common.cpp
@@ -264,39 +264,56 @@ JSONPathType JSONCommon::ValidatePath(const char *ptr, const idx_t &len, const b
 	return path_type;
 }
 
+//! Resolve a single path element against a JSON value
+static inline yyjson_val *GetPathElement(yyjson_val *val, const JSONPathElement &element) {
+	switch (element.type) {
+	case JSONPathElementType::KEY:
+		if (!unsafe_yyjson_is_obj(val)) {
+			return nullptr;
+		}
+		return yyjson_obj_getn(val, element.key.c_str(), element.key.size());
+	case JSONPathElementType::INDEX:
+	case JSONPathElementType::REVERSE_INDEX: {
+		if (!unsafe_yyjson_is_arr(val)) {
+			return nullptr;
+		}
+		auto array_index = element.index;
+		if (element.type == JSONPathElementType::REVERSE_INDEX && array_index != 0) {
+			array_index = unsafe_yyjson_get_len(val) - array_index;
+		}
+		return yyjson_arr_get(val, array_index);
+	}
+	case JSONPathElementType::APPEND:
+		// [#] always returns NULL in SQLite
+		return nullptr;
+	default: // LCOV_EXCL_START
+		throw InternalException("Invalid JSON path element encountered, call JSONCommon::ValidatePath first!");
+	} // LCOV_EXCL_STOP
+}
+
 yyjson_val *JSONCommon::GetPath(yyjson_val *val, const char *ptr, const idx_t &len) {
 	// Path has been validated at this point
 	JSONPathIterator iterator(ptr, len, false);
 	JSONPathElement element;
 	while (val != nullptr && iterator.Next(element)) {
-		switch (element.type) {
-		case JSONPathElementType::KEY: {
-			if (!unsafe_yyjson_is_obj(val)) {
-				return nullptr;
-			}
-			val = yyjson_obj_getn(val, element.key.c_str(), element.key.size());
-			break;
-		}
-		case JSONPathElementType::INDEX:
-		case JSONPathElementType::REVERSE_INDEX: {
-			if (!unsafe_yyjson_is_arr(val)) {
-				return nullptr;
-			}
-			auto array_index = element.index;
-			if (element.type == JSONPathElementType::REVERSE_INDEX && array_index != 0) {
-				array_index = unsafe_yyjson_get_len(val) - array_index;
-			}
-			val = yyjson_arr_get(val, array_index);
-			break;
-		}
-		case JSONPathElementType::APPEND: {
-			// [#] always returns NULL in SQLite
-			return nullptr;
-		}
-		default: // LCOV_EXCL_START
-			throw InternalException(
-			    "Invalid JSON Path encountered in JSONCommon::GetPath, call JSONCommon::ValidatePath first!");
-		} // LCOV_EXCL_STOP
+		val = GetPathElement(val, element);
+	}
+	return val;
+}
+
+vector<JSONPathElement> JSONCommon::ParsePathElements(const char *ptr, idx_t len, bool binder) {
+	vector<JSONPathElement> elements;
+	JSONPathIterator iterator(ptr, len, binder);
+	JSONPathElement element;
+	while (iterator.Next(element)) {
+		elements.push_back(element);
+	}
+	return elements;
+}
+
+yyjson_val *JSONCommon::GetPathElements(yyjson_val *val, const vector<JSONPathElement> &elements) {
+	for (idx_t i = 0; val != nullptr && i < elements.size(); i++) {
+		val = GetPathElement(val, elements[i]);
 	}
 	return val;
 }

--- a/extension/json/json_functions.cpp
+++ b/extension/json/json_functions.cpp
@@ -47,6 +47,11 @@ JSONPathType JSONReadFunctionData::CheckPath(const Value &path_val, string &path
 
 JSONReadFunctionData::JSONReadFunctionData(bool constant, string path_p, idx_t len, JSONPathType path_type_p)
     : constant(constant), path(std::move(path_p)), path_type(path_type_p), ptr(path.c_str()), len(len) {
+	if (constant && len != 0 && path[0] == '$' && path_type == JSONPathType::REGULAR) {
+		// The path was validated in CheckPath, parse it once so execution can skip tokenizing it per row
+		elements = JSONCommon::ParsePathElements(ptr, len, false);
+		use_elements = true;
+	}
 }
 
 unique_ptr<FunctionData> JSONReadFunctionData::Copy() const {
@@ -89,6 +94,16 @@ JSONReadManyFunctionData::JSONReadManyFunctionData(vector<string> paths_p, vecto
     : paths(std::move(paths_p)), lens(std::move(lens_p)) {
 	for (const auto &path : paths) {
 		ptrs.push_back(path.c_str());
+	}
+	for (idx_t i = 0; i < paths.size(); i++) {
+		if (lens[i] != 0 && paths[i][0] == '$') {
+			// The paths were validated in CheckPath, parse them once
+			elements.push_back(JSONCommon::ParsePathElements(ptrs[i], lens[i], false));
+			use_elements.push_back(true);
+		} else {
+			elements.emplace_back();
+			use_elements.push_back(false);
+		}
 	}
 }
 

--- a/extension/json/json_functions/json_modify.cpp
+++ b/extension/json/json_functions/json_modify.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/common/vector_operations/binary_executor.hpp"
 #include "duckdb/common/vector_operations/ternary_executor.hpp"
+#include "duckdb/execution/expression_executor.hpp"
 #include "json_common.hpp"
 #include "json_functions.hpp"
 
@@ -8,22 +9,18 @@ namespace duckdb {
 enum class JSONModifyType : uint8_t { SET, INSERT, REPLACE, REMOVE };
 
 //! Parse a JSONPath or bare key into path elements (throws on malformed paths and wildcards)
-static vector<JSONPathElement> ParseModifyPath(const string_t &path_str) {
+static vector<JSONPathElement> ParseModifyPath(const char *ptr, idx_t len, bool binder) {
 	vector<JSONPathElement> elements;
-	auto ptr = path_str.GetData();
-	auto len = path_str.GetSize();
 	if (len == 0) {
 		return elements; // The empty path addresses the whole document
 	}
 	if (*ptr == '$') {
-		JSONPathIterator iterator(ptr, len, false);
-		JSONPathElement element;
-		while (iterator.Next(element)) {
+		elements = JSONCommon::ParsePathElements(ptr, len, binder);
+		for (const auto &element : elements) {
 			if (element.type == JSONPathElementType::WILDCARD ||
 			    element.type == JSONPathElementType::RECURSIVE_WILDCARD) {
 				throw InvalidInputException("JSON path wildcards are not supported in JSON modification functions");
 			}
-			elements.push_back(element);
 		}
 	} else {
 		// Bare key name
@@ -34,6 +31,45 @@ static vector<JSONPathElement> ParseModifyPath(const string_t &path_str) {
 	}
 	return elements;
 }
+
+//! Bind data for the JSON modification functions, holds the path elements of a constant path
+struct JSONModifyFunctionData : public FunctionData {
+public:
+	JSONModifyFunctionData(bool constant_p, string path_p) : constant(constant_p), path(std::move(path_p)) {
+		if (constant && (path.empty() || path[0] != '/')) {
+			// JSONPath, bare key, or empty path: parse it once so execution can skip tokenizing it per row
+			elements = ParseModifyPath(path.c_str(), path.size(), true);
+			use_elements = true;
+		}
+	}
+	unique_ptr<FunctionData> Copy() const override {
+		return make_uniq<JSONModifyFunctionData>(constant, path);
+	}
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = other_p.Cast<JSONModifyFunctionData>();
+		return constant == other.constant && path == other.path;
+	}
+	static unique_ptr<FunctionData> Bind(BindScalarFunctionInput &input) {
+		auto &context = input.GetClientContext();
+		auto &arguments = input.GetArguments();
+		bool constant = false;
+		string path;
+		if (arguments[1]->IsFoldable()) {
+			const auto path_val = ExpressionExecutor::EvaluateScalar(context, *arguments[1]);
+			if (!path_val.IsNull()) {
+				constant = true;
+				path = path_val.DefaultCastAs(LogicalType::VARCHAR).GetValue<string>();
+			}
+		}
+		return make_uniq<JSONModifyFunctionData>(constant, std::move(path));
+	}
+
+public:
+	const bool constant;
+	const string path;
+	vector<JSONPathElement> elements;
+	bool use_elements = false;
+};
 
 //! Resolve an array path element to a position, returns false if it is out of range
 static bool ResolveArrayPosition(yyjson_mut_val *arr, const JSONPathElement &element, idx_t &pos) {
@@ -226,24 +262,35 @@ static void ModifyAtPointer(yyjson_mut_doc *doc, const string_t &path_str, yyjso
 	}
 }
 
-//! Apply a modification at a JSONPath or JSON Pointer, returns false if the root was removed
-static bool ModifyDocument(yyjson_mut_doc *doc, const string_t &path_str, yyjson_mut_val *new_val,
-                           JSONModifyType type) {
-	auto ptr = path_str.GetData();
-	auto len = path_str.GetSize();
-	if (len != 0 && *ptr == '/') {
-		ModifyAtPointer(doc, path_str, new_val, type);
+//! Apply a modification at pre-parsed path elements
+static void ModifyDocumentElements(yyjson_mut_doc *doc, const vector<JSONPathElement> &elements,
+                                   yyjson_mut_val *new_val, JSONModifyType type) {
+	if (elements.empty()) {
+		ModifyRoot(doc, type, new_val);
+		return;
+	}
+	const auto create = type == JSONModifyType::SET || type == JSONModifyType::INSERT;
+	JSONModifyTarget target;
+	if (ResolveParent(doc, elements, create, target) &&
+	    ApplyModify(doc, target.parent, elements.back(), type, new_val) && target.created) {
+		AttachChild(doc, target.attach_to, *target.attach_element, target.created);
+	}
+}
+
+//! Apply a modification at a JSONPath or JSON Pointer, using the bind data's path elements when available
+static bool ModifyDocument(yyjson_mut_doc *doc, const JSONModifyFunctionData &info, const string_t &path_str,
+                           yyjson_mut_val *new_val, JSONModifyType type) {
+	if (info.use_elements) {
+		ModifyDocumentElements(doc, info.elements, new_val, type);
+	} else if (info.constant) {
+		ModifyAtPointer(doc, string_t(info.path.c_str(), UnsafeNumericCast<uint32_t>(info.path.size())), new_val, type);
 	} else {
-		auto elements = ParseModifyPath(path_str);
-		if (elements.empty()) {
-			ModifyRoot(doc, type, new_val);
+		auto ptr = path_str.GetData();
+		auto len = path_str.GetSize();
+		if (len != 0 && *ptr == '/') {
+			ModifyAtPointer(doc, path_str, new_val, type);
 		} else {
-			const auto create = type == JSONModifyType::SET || type == JSONModifyType::INSERT;
-			JSONModifyTarget target;
-			if (ResolveParent(doc, elements, create, target) &&
-			    ApplyModify(doc, target.parent, elements.back(), type, new_val) && target.created) {
-				AttachChild(doc, target.attach_to, *target.attach_element, target.created);
-			}
+			ModifyDocumentElements(doc, ParseModifyPath(ptr, len, false), new_val, type);
 		}
 	}
 	return yyjson_mut_doc_get_root(doc) != nullptr;
@@ -251,6 +298,8 @@ static bool ModifyDocument(yyjson_mut_doc *doc, const string_t &path_str, yyjson
 
 //! Shared implementation of json_set, json_insert, and json_replace
 static void ModifyFunction(JSONModifyType type, DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &func_expr = state.expr.Cast<BoundFunctionExpression>();
+	const auto &info = func_expr.BindInfo()->Cast<JSONModifyFunctionData>();
 	auto &lstate = JSONFunctionLocalState::ResetAndGet(state);
 	auto alc = lstate.json_allocator->GetYYAlc();
 
@@ -262,7 +311,7 @@ static void ModifyFunction(JSONModifyType type, DataChunk &args, ExpressionState
 		    auto val_doc = JSONCommon::ReadDocument(val_str, JSONCommon::READ_FLAG, alc);
 		    auto new_val = yyjson_val_mut_copy(mut_doc, val_doc->root);
 
-		    ModifyDocument(mut_doc, path_str, new_val, type);
+		    ModifyDocument(mut_doc, info, path_str, new_val, type);
 		    return JSONCommon::WriteVal<yyjson_mut_val>(yyjson_mut_doc_get_root(mut_doc), alc);
 	    });
 
@@ -286,6 +335,8 @@ static void JsonReplaceFunction(DataChunk &args, ExpressionState &state, Vector 
 
 //! Remove the value at a path in a JSON document (no-op if the path does not exist)
 static void JsonRemoveFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &func_expr = state.expr.Cast<BoundFunctionExpression>();
+	const auto &info = func_expr.BindInfo()->Cast<JSONModifyFunctionData>();
 	auto &lstate = JSONFunctionLocalState::ResetAndGet(state);
 	auto alc = lstate.json_allocator->GetYYAlc();
 
@@ -294,7 +345,7 @@ static void JsonRemoveFunction(DataChunk &args, ExpressionState &state, Vector &
 		    auto doc = JSONCommon::ReadDocument(doc_str, JSONCommon::READ_FLAG, alc);
 		    auto mut_doc = yyjson_doc_mut_copy(doc, alc);
 
-		    if (!ModifyDocument(mut_doc, path_str, nullptr, JSONModifyType::REMOVE)) {
+		    if (!ModifyDocument(mut_doc, info, path_str, nullptr, JSONModifyType::REMOVE)) {
 			    return nullopt; // Removing the root leaves no document behind
 		    }
 		    return JSONCommon::WriteVal<yyjson_mut_val>(yyjson_mut_doc_get_root(mut_doc), alc);
@@ -305,25 +356,28 @@ static void JsonRemoveFunction(DataChunk &args, ExpressionState &state, Vector &
 
 ScalarFunctionSet JSONFunctions::GetSetFunction() {
 	ScalarFunction fun("json_set", {LogicalType::JSON(), LogicalType::VARCHAR, LogicalType::JSON()},
-	                   LogicalType::JSON(), JsonSetFunction, nullptr, nullptr, JSONFunctionLocalState::Init);
+	                   LogicalType::JSON(), JsonSetFunction, JSONModifyFunctionData::Bind, nullptr,
+	                   JSONFunctionLocalState::Init);
 	return ScalarFunctionSet(fun);
 }
 
 ScalarFunctionSet JSONFunctions::GetInsertFunction() {
 	ScalarFunction fun("json_insert", {LogicalType::JSON(), LogicalType::VARCHAR, LogicalType::JSON()},
-	                   LogicalType::JSON(), JsonInsertFunction, nullptr, nullptr, JSONFunctionLocalState::Init);
+	                   LogicalType::JSON(), JsonInsertFunction, JSONModifyFunctionData::Bind, nullptr,
+	                   JSONFunctionLocalState::Init);
 	return ScalarFunctionSet(fun);
 }
 
 ScalarFunctionSet JSONFunctions::GetReplaceFunction() {
 	ScalarFunction fun("json_replace", {LogicalType::JSON(), LogicalType::VARCHAR, LogicalType::JSON()},
-	                   LogicalType::JSON(), JsonReplaceFunction, nullptr, nullptr, JSONFunctionLocalState::Init);
+	                   LogicalType::JSON(), JsonReplaceFunction, JSONModifyFunctionData::Bind, nullptr,
+	                   JSONFunctionLocalState::Init);
 	return ScalarFunctionSet(fun);
 }
 
 ScalarFunctionSet JSONFunctions::GetRemoveFunction() {
 	ScalarFunction fun("json_remove", {LogicalType::JSON(), LogicalType::VARCHAR}, LogicalType::JSON(),
-	                   JsonRemoveFunction, nullptr, nullptr, JSONFunctionLocalState::Init);
+	                   JsonRemoveFunction, JSONModifyFunctionData::Bind, nullptr, JSONFunctionLocalState::Init);
 	return ScalarFunctionSet(fun);
 }
 

--- a/extension/json/json_functions/json_modify.cpp
+++ b/extension/json/json_functions/json_modify.cpp
@@ -38,8 +38,13 @@ public:
 	JSONModifyFunctionData(bool constant_p, string path_p) : constant(constant_p), path(std::move(path_p)) {
 		if (constant && (path.empty() || path[0] != '/')) {
 			// JSONPath, bare key, or empty path: parse it once so execution can skip tokenizing it per row
-			elements = ParseModifyPath(path.c_str(), path.size(), true);
-			use_elements = true;
+			try {
+				elements = ParseModifyPath(path.c_str(), path.size(), true);
+				use_elements = true;
+			} catch (const std::exception &) {
+				// Invalid path: parse per row instead, so the error surfaces only if a row is actually
+				// evaluated, keeping it catchable by TRY and silent in unreachable branches
+			}
 		}
 	}
 	unique_ptr<FunctionData> Copy() const override {
@@ -282,9 +287,10 @@ static bool ModifyDocument(yyjson_mut_doc *doc, const JSONModifyFunctionData &in
                            yyjson_mut_val *new_val, JSONModifyType type) {
 	if (info.use_elements) {
 		ModifyDocumentElements(doc, info.elements, new_val, type);
-	} else if (info.constant) {
+	} else if (info.constant && !info.path.empty() && info.path[0] == '/') {
 		ModifyAtPointer(doc, string_t(info.path.c_str(), UnsafeNumericCast<uint32_t>(info.path.size())), new_val, type);
 	} else {
+		// Non constant path, or a constant path that did not parse at bind time (the error surfaces here)
 		auto ptr = path_str.GetData();
 		auto len = path_str.GetSize();
 		if (len != 0 && *ptr == '/') {

--- a/test/sql/json/scalar/test_json_extract_input_types.test
+++ b/test/sql/json/scalar/test_json_extract_input_types.test
@@ -1,0 +1,88 @@
+# name: test/sql/json/scalar/test_json_extract_input_types.test
+# description: Extract results must not depend on the input being VARCHAR or JSON typed
+# group: [scalar]
+
+require json
+
+statement ok
+pragma enable_verification
+
+# VARCHAR and JSON typed inputs bind to different function overloads,
+# so comparing the two on adversarial documents must never show a difference.
+statement ok
+CREATE TABLE tricky (v VARCHAR);
+
+statement ok
+INSERT INTO tricky VALUES
+    ('{"a":1,"b":2}'),
+    ('{ "a" : 1 , "b" : [ 1 , 2 , 3 ] }'),
+    ('{"a":{"a":{"a":1}}}'),
+    ('{"x":"a\"b","a":"quoted \" inside"}'),
+    ('{"a\"b":1,"c":2}'),
+    ('{"a":"]}","b":"{["}'),
+    ('{"a":[[1,2],[3,[4,5]]],"b":{"c":[{"d":1}]}}'),
+    ('[1,"two",{"three":3},[4],null,true,false,1.5e2]'),
+    ('{"a":null,"b":false}'),
+    ('{"":1,"a":2}'),
+    ('{"a":1,"a":2}'),
+    ('{"日本":"語","a":"日本語"}'),
+    ('{"a":  {"b"  :  [  {"c" : "d,e]}"} ] } }'),
+    ('  {"a":1}  '),
+    ('{"tail":"' || repeat('x', 100) || '","a":9}'),
+    ('true'),
+    ('[]'),
+    ('{}'),
+    ('{"a":nan,"b":inf}'),
+    ('{"a":NaN,"b":-Infinity}'),
+    ('{"a":"true","b":"null"}');
+
+foreach path $.a $.b $.a.b $.b.c $[0] $[2] $[7] $.a[0] $.a[1] $.b.c[0].d $."a\"b" $.日本 $.missing $.a.a.a $.tail $[0][1] $
+
+query I
+SELECT count(*) FROM tricky WHERE json_extract(v, '${path}') IS DISTINCT FROM json_extract(v::JSON, '${path}')
+----
+0
+
+query I
+SELECT count(*) FROM tricky WHERE json_extract_string(v, '${path}') IS DISTINCT FROM json_extract_string(v::JSON, '${path}')
+----
+0
+
+endloop
+
+# The list form must also match
+query I
+SELECT count(*) FROM tricky WHERE json_extract(v, ['$.a', '$.b.c', '$[0]']) IS DISTINCT FROM json_extract(v::JSON, ['$.a', '$.b.c', '$[0]'])
+----
+0
+
+# Anchor a few absolute results on JSON typed inputs
+query T
+SELECT ('{ "user" : { "name" : "a\"b" } }'::JSON)->>'$.user.name'
+----
+a"b
+
+query T
+SELECT ('{"a":[10,20,30]}'::JSON)->'$.a[1]'
+----
+20
+
+query T
+SELECT ('[1,2]'::JSON)->1
+----
+2
+
+query T
+SELECT ('1'::JSON)->'$'
+----
+1
+
+query T
+SELECT ('{"a":{"b":"]}"}}'::JSON)->>'$.a.b'
+----
+]}
+
+query T
+SELECT ('{"a":[10,20,30]}'::JSON)->'$.a[#-1]'
+----
+30

--- a/test/sql/json/scalar/test_json_path_prepared.test
+++ b/test/sql/json/scalar/test_json_path_prepared.test
@@ -1,0 +1,64 @@
+# name: test/sql/json/scalar/test_json_path_prepared.test
+# description: Test JSON path functions with prepared statement parameters as paths
+# group: [scalar]
+
+require json
+
+statement ok
+pragma enable_verification
+
+statement ok
+PREPARE extract_stmt AS SELECT json_extract('{"a":1,"b":{"c":2}}', $1);
+
+query T
+EXECUTE extract_stmt('$.a')
+----
+1
+
+query T
+EXECUTE extract_stmt('$.b.c')
+----
+2
+
+query T
+EXECUTE extract_stmt('/b/c')
+----
+2
+
+statement ok
+PREPARE set_stmt AS SELECT json_set('{"a":1}', $1, '2');
+
+query T
+EXECUTE set_stmt('$.b')
+----
+{"a":1,"b":2}
+
+query T
+EXECUTE set_stmt('$.a')
+----
+{"a":2}
+
+statement ok
+PREPARE remove_stmt AS SELECT json_remove('{"a":1,"b":2}', $1);
+
+query T
+EXECUTE remove_stmt('$.a')
+----
+{"b":2}
+
+query T
+EXECUTE remove_stmt('$.c')
+----
+{"a":1,"b":2}
+
+# Malformed path through a parameter still raises the path error
+statement error
+EXECUTE set_stmt('$not_a_path')
+----
+JSON path error
+
+# Constant folding still works when the path comes from a scalar subquery
+query T
+SELECT json_set('{"a":1}', (SELECT '$.b'), '2')
+----
+{"a":1,"b":2}

--- a/test/sql/json/scalar/test_json_remove.test
+++ b/test/sql/json/scalar/test_json_remove.test
@@ -223,6 +223,12 @@ SELECT json_remove('{"a":1}', '$not_a_path')
 ----
 JSON path error
 
+# Constant modification path errors remain catchable by TRY
+query T
+SELECT TRY(json_remove('{"a":1}', '$[#-'))
+----
+NULL
+
 # Wildcards are not supported in modification functions
 statement error
 SELECT json_remove('{"a":[1,2]}', '$.a[*]')

--- a/test/sql/json/scalar/test_json_set.test
+++ b/test/sql/json/scalar/test_json_set.test
@@ -330,6 +330,23 @@ SELECT json_set('{"a":1}', '$not_a_path', '2')
 ----
 JSON path error
 
+# Constant modification path errors remain catchable by TRY
+query T
+SELECT TRY(json_set('{}', '$not_a_path', '1'))
+----
+NULL
+
+query T
+SELECT TRY(json_set('{"a":1}', '$.a[*]', '1'))
+----
+NULL
+
+# Unreachable modification calls must not fail before execution either
+query T
+SELECT CASE WHEN false THEN json_set('{}', '$not_a_path', '1') ELSE '{}'::JSON END
+----
+{}
+
 # Wildcards are not supported in modification functions
 statement error
 SELECT json_set('{"a":[1,2]}', '$.a[*]', '9')


### PR DESCRIPTION
Follows up on the proposal in #23959.

Constant JSON paths are currently re-tokenized for every row. The bind data already detects constant paths, validates them, and stores the normalized string, but execution re-parses that string per row, allocating a scratch buffer and a `string` per key segment each time. Bare keys and arrow paths are normalized into the quoted form (`$."key"`), which takes the allocating parser path, so the most common extract patterns pay this on every row.

Profiling `SELECT count(j->'user')` over 5 million small documents put 31% of the execution time inside path handling, most of it in `operator new` and `free` called from `ReadKey`, while the actual key comparison was around 1%. After this change the path share drops to 6.5% with no allocator frames left; document parsing is the dominant cost, as it should be.

Changes:
- `JSONCommon` gains `ParsePathElements` and `GetPathElements`: parse a validated path into `JSONPathElement`s once, walk them with no tokenization and no allocations
- `JSONReadFunctionData` and `JSONReadManyFunctionData` derive the parsed elements from the stored path string in their constructors, so `Copy()` and rebinds stay self contained
- The modification functions (`json_set`, `json_insert`, `json_replace`, `json_remove`) get bind data (`JSONModifyFunctionData`) with the same treatment, covering JSONPath, bare key, and empty paths
- Wildcard paths, JSON Pointer paths, and non constant paths are unchanged
- New micro benchmarks under `benchmark/micro/json/`, prepared statement tests, and a consistency test comparing VARCHAR and JSON typed inputs across adversarial documents

Benchmarks (single threaded to keep variance under 4%, medians of 5 on an 11 core Apple machine; multithreaded speedups are similar):

| benchmark | main | this PR | speedup |
|---|---|---|---|
| `json_extract_bare_key` | 451.6 ms | 342.0 ms | 1.32x |
| `json_extract_deep_path` | 443.4 ms | 350.5 ms | 1.27x |
| `json_extract_string_path` | 393.7 ms | 309.4 ms | 1.27x |
| `json_extract_many_paths` | 683.4 ms | 553.5 ms | 1.23x |
| `json_set_path` | 1154.1 ms | 868.5 ms | 1.33x |
| `json_extract_large_doc` | 437.2 ms | 410.5 ms | 1.06x |
| `json_extract_wildcard` | 590.9 ms | 589.5 ms | 1.00x |
| `json_transform_struct` | 486.5 ms | 471.0 ms | 1.03x |

Peak memory is unchanged (max RSS 521.7 MB vs 523.6 MB on the benchmark workload plus a 200 expression query): the bind data adds a few hundred bytes per expression, and execution allocates strictly less than before.

Two approaches I tried and rejected, in case they come up in review:
- Locating constant path targets by scanning the raw JSON text and parsing only the target span. Correct, and 1.2x on string valued targets, but character level skipping is not enough cheaper than yyjson parsing: container valued targets regressed up to 32%. Behavior that depends on data shape did not seem worth it.
- Copying the input into the allocator arena and parsing with `YYJSON_READ_INSITU`: the extra copy cancels the gain.
