### PR TITLE
StorageLock: wait on a condition variable instead of busy-spinning

### DIFF
--- a/src/storage/storage_lock.cpp
+++ b/src/storage/storage_lock.cpp
@@ -5,42 +5,52 @@
 #include "duckdb/common/assert.hpp"
 #include "duckdb/common/thread_annotation/thread_annotation.hpp"
 
+#include <condition_variable>
+
 namespace duckdb {
 
+// A phase-fair read-write lock: waiters sleep on a condition variable instead of busy-spinning.
+// A registering writer drains the readers ahead of it (no new readers are admitted past it), but a reader only
+// waits for writers registered before it - so neither side can starve the other.
 struct StorageLockInternals : enable_shared_from_this<StorageLockInternals> {
 public:
-	StorageLockInternals() : read_count(0) {
+	StorageLockInternals() : read_count(0), writer_active(false), writer_tickets(0), writers_done(0) {
 	}
 
-	mutex exclusive_lock;
-	atomic<idx_t> read_count;
+	mutex state_lock;
+	std::condition_variable state_cv;
+	idx_t read_count;
+	bool writer_active;
+	//! Incremented when a writer registers (blocking acquisition) or acquires (try/upgrade)
+	idx_t writer_tickets;
+	//! Incremented when a writer releases
+	idx_t writers_done;
 
 public:
 	unique_ptr<StorageLockKey> GetExclusiveLock() DUCKDB_NO_THREAD_SAFETY_ANALYSIS {
-		exclusive_lock.lock();
-		while (read_count != 0) {
-		}
+		unique_lock<mutex> guard(state_lock);
+		writer_tickets++;
+		state_cv.wait(guard, [&]() { return !writer_active && read_count == 0; });
+		writer_active = true;
 		return make_uniq<StorageLockKey>(shared_from_this(), StorageLockType::EXCLUSIVE);
 	}
 
-	unique_ptr<StorageLockKey> GetSharedLock() {
-		exclusive_lock.lock();
+	unique_ptr<StorageLockKey> GetSharedLock() DUCKDB_NO_THREAD_SAFETY_ANALYSIS {
+		unique_lock<mutex> guard(state_lock);
+		// wait for the writers registered before us (they drain and run first), but not for later ones
+		auto target = writer_tickets;
+		state_cv.wait(guard, [&]() { return !writer_active && writers_done >= target; });
 		read_count++;
-		exclusive_lock.unlock();
 		return make_uniq<StorageLockKey>(shared_from_this(), StorageLockType::SHARED);
 	}
 
 	unique_ptr<StorageLockKey> TryGetExclusiveLock() DUCKDB_NO_THREAD_SAFETY_ANALYSIS {
-		if (!exclusive_lock.try_lock()) {
-			// could not lock mutex
+		lock_guard<mutex> guard(state_lock);
+		if (writer_active || read_count != 0) {
 			return nullptr;
 		}
-		if (read_count != 0) {
-			// there are active readers - cannot get exclusive lock
-			exclusive_lock.unlock();
-			return nullptr;
-		}
-		// success!
+		writer_tickets++;
+		writer_active = true;
 		return make_uniq<StorageLockKey>(shared_from_this(), StorageLockType::EXCLUSIVE);
 	}
 
@@ -48,25 +58,37 @@ public:
 		if (lock.GetType() != StorageLockType::SHARED) {
 			throw InternalException("StorageLock::TryUpgradeLock called on an exclusive lock");
 		}
-		if (!exclusive_lock.try_lock()) {
-			// could not lock mutex
-			return nullptr;
-		}
-		if (read_count != 1) {
-			// other shared locks are active: failed to upgrade
+		lock_guard<mutex> guard(state_lock);
+		if (writer_active || read_count != 1) {
+			// other shared locks (or a writer) are active: failed to upgrade
 			D_ASSERT(read_count != 0);
-			exclusive_lock.unlock();
 			return nullptr;
 		}
-		// no other shared locks active: success!
+		// we are the only reader: grant the exclusive lock alongside the held shared lock (read_count stays 1)
+		writer_tickets++;
+		writer_active = true;
 		return make_uniq<StorageLockKey>(shared_from_this(), StorageLockType::EXCLUSIVE);
 	}
 
 	void ReleaseExclusiveLock() DUCKDB_NO_THREAD_SAFETY_ANALYSIS {
-		exclusive_lock.unlock();
+		{
+			lock_guard<mutex> guard(state_lock);
+			writer_active = false;
+			writers_done++;
+		}
+		state_cv.notify_all();
 	}
-	void ReleaseSharedLock() {
-		read_count--;
+	void ReleaseSharedLock() DUCKDB_NO_THREAD_SAFETY_ANALYSIS {
+		bool notify;
+		{
+			lock_guard<mutex> guard(state_lock);
+			read_count--;
+			notify = read_count == 0;
+		}
+		if (notify) {
+			// last reader left - wake a waiting writer
+			state_cv.notify_all();
+		}
 	}
 };
 


### PR DESCRIPTION
GetExclusiveLock currently takes the mutex and then spins in a tight loop until all shared holders have drained, burning a core for the entire wait - possibly a long time while waiting for a query to complete.

This became visible while performance-testing https://github.com/duckdb/duckdb/pull/23631

As it's (hopefully) an uncontroversial change of its own, I factored this into a separate small PR here.

It replaces the current implementation with a phase-fair read-write lock built on a condition variable:

- A registering writer drains the readers ahead of it: no new readers are admitted past it, so a steady stream of readers cannot starve an exclusive acquirer (e.g. a checkpoint). This matches the current behavior, where a waiting writer implicitly holds off new readers by sitting on the mutex they need.
- A reader only waits for writers registered before it (writer tickets), not for writers that arrive while it is waiting, so a steady stream of writers cannot starve readers either. This also matches the current behavior, where waiting readers and later writers queue on the same mutex.
- TryGetExclusiveLock and TryUpgradeLock keep their non-blocking semantics and success conditions; lock upgrade still grants the exclusive lock alongside the held shared lock (read_count stays at 1).

The only intended behavioral difference is that waiting no longer consumes CPU.