### PR TITLE
Add assert_true macro

### DIFF
--- a/src/catalog/default/default_functions.cpp
+++ b/src/catalog/default/default_functions.cpp
@@ -128,6 +128,10 @@ static const DefaultMacro internal_macros[] = {
      "(x, n) AS CASE ((abs(x) * power(10, n+1)) % 10) WHEN 5 THEN round(x/2, n) * 2 ELSE round(x, n) END"},
     {DEFAULT_SCHEMA, "roundbankers", "(x, n) AS round_even(x, n)"},
     {DEFAULT_SCHEMA, "nullif", "(a, b) AS CASE WHEN a=b THEN NULL ELSE a END"},
+    {DEFAULT_SCHEMA, "assert_true",
+     "(condition) AS CASE WHEN condition THEN NULL ELSE error('Assertion failed') END, "
+     "(condition, message) AS CASE WHEN condition THEN NULL ELSE "
+     "error(COALESCE('Assertion: ' || message, 'Assertion failed')) END"},
     {DEFAULT_SCHEMA, "list_append", "(l, e) AS list_concat(l, list_value(e))"},
     {DEFAULT_SCHEMA, "array_append", "(arr, el) AS list_append(arr, el)"},
     {DEFAULT_SCHEMA, "list_prepend", "(e, l) AS list_concat(list_value(e), l)"},

--- a/test/sql/function/generic/assert_true.test
+++ b/test/sql/function/generic/assert_true.test
@@ -1,0 +1,55 @@
+# name: test/sql/function/generic/assert_true.test
+# description: Test assert_true function
+# group: [generic]
+
+statement ok
+PRAGMA enable_verification
+
+# like Spark's assert_true, returns NULL when the assertion holds
+query I
+SELECT assert_true(true)
+----
+NULL
+
+query I
+SELECT assert_true(1 = 1, 'never shown')
+----
+NULL
+
+statement error
+SELECT assert_true(false)
+----
+Assertion failed
+
+statement error
+SELECT assert_true(NULL)
+----
+Assertion failed
+
+statement error
+SELECT assert_true(false, 'my custom message')
+----
+Assertion: my custom message
+
+# a NULL message still fires, falling back to the default assertion error
+statement error
+SELECT assert_true(false, NULL)
+----
+Assertion failed
+
+statement error
+SELECT assert_true(NULL, NULL)
+----
+Assertion failed
+
+statement error
+SELECT assert_true(i < 3, 'row ' || i || ' is too large') FROM range(5) t(i)
+----
+Assertion: row 3 is too large
+
+query I
+SELECT assert_true(i < 10) FROM range(3) t(i)
+----
+NULL
+NULL
+NULL

--- a/test/sql/function/generic/assert_true.test
+++ b/test/sql/function/generic/assert_true.test
@@ -2,14 +2,17 @@
 # description: Test assert_true function
 # group: [generic]
 
-statement ok
-PRAGMA enable_verification
-
 # like Spark's assert_true, returns NULL when the assertion holds
 query I
 SELECT assert_true(true)
 ----
 NULL
+
+# the message must be castable to VARCHAR, even when the assertion passes
+statement error
+SELECT assert_true(true, ['a','b'])
+----
+Cannot concatenate types VARCHAR and VARCHAR[]
 
 query I
 SELECT assert_true(1 = 1, 'never shown')


### PR DESCRIPTION
There is precedence in [Spark](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.assert_true.html) and [Databricks](https://docs.databricks.com/aws/en/sql/language-manual/functions/assert_true)