### PR TITLE
Call release dispatch in summary for (pre)releases

### DIFF
--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -1476,6 +1476,11 @@ jobs:
             run_python=true
           fi
 
+          run_release_dispatch=false
+          if [[ "$is_release_event" == "true" && "$is_duckdb_repo" == "true" && "$RELEASE_STATUS_SUCCESS" == "true" && -n "$OVERRIDE_GIT_DESCRIBE" ]]; then
+            run_release_dispatch=true
+          fi
+
           echo "summary dispatch context:"
           echo "  event_name=$EVENT_NAME"
           echo "  repository=$REPOSITORY"
@@ -1490,13 +1495,32 @@ jobs:
           echo "  run_vendor=$run_vendor"
           echo "  run_nightly=$run_nightly"
           echo "  run_python=$run_python"
+          echo "  run_release_dispatch=$run_release_dispatch"
 
           {
             echo "target_branch=$target_branch"
             echo "run_vendor=$run_vendor"
             echo "run_nightly=$run_nightly"
             echo "run_python=$run_python"
+            echo "run_release_dispatch=$run_release_dispatch"
           } >> "$GITHUB_OUTPUT"
+
+      - name: Run release dispatch
+        if: ${{ always() && steps.summary-context.outputs.run_release_dispatch == 'true' }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+          SOURCE_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh workflow run dispatch.yml \
+            --repo duckdb/duckdb-workflow-trigger \
+            --ref main \
+            --field event=core_ready \
+            --field duckdb_version="${{ needs.prepare.outputs.effective_git_describe }}" \
+            --field duckdb_commit="${{ needs.prepare.outputs.git_sha }}" \
+            --field status=success \
+            --field source_run_url="$SOURCE_RUN_URL" \
+            --field message="DuckDB Main CI release artifacts are ready"
 
       - name: Run ODBC Vendor
         if: ${{ always() && steps.summary-context.outputs.run_vendor == 'true' }}


### PR DESCRIPTION
### Context

Some downstream repositories want to receive a webhook for "release events" so they can produce and upload binaries.

Currently, we have a custom list of endpoints in the CI job summary that are called when the binaries of a duckdb (pre)release are produced.

We want to [improve](https://github.com/duckdblabs/duckdb-internal/issues/9742) the dispatch logic and endpoints so it's easier to add new repositories and automate/improve the release flow.

### How does the dispatcher work?

The release dispatcher accepts `core_ready` and `client_ready` workflow dispatch events, stores state internally, and dispatches successful events to registered downstream repository workflows.

Downstream workflows receive:

- `duckdb_version`
- `duckdb_commit`
- `payload`
  - for example `{"phase":"core_ready"}`
  - or `{"phase":"client_ready","name":"python"}`

### Configure dispatcher endpoints

Endpoints are configured in [endpoints.yml](https://github.com/duckdb/duckdb-workflow-trigger/blob/main/endpoints.yml) and grouped by hook.

- `core_ready` contains a list of `owner/repo/workflow.yml@ref` targets.
- `client_ready` is grouped by client name, and each client contains a list of targets.

For example, we could use:
```yaml
hooks:
  core_ready:
    - duckdb/duckdb-python/OnCoreReady.yml@main
  client_ready:
    python:
      - duckdb/foo/OnClientReady.yml@main
      - duckdb/bar/OnClientReady.yml@main
```

Use `core_ready` for workflows that should run after the DuckDB core release is ready.

Use `client_ready` for workflows that should run after a specific client release is ready. A hook entry can dispatch to one or more downstream workflows.

To add a downstream workflow, register it under the appropriate hook in `endpoints.yml`. For `client_ready`, use the client name as the mapping key so the outbound payload stays aligned with the downstream release.

### Future work

Later, we can extend the release event hooks for:
- custom extensions workflow (test with iceberg, ducklake, etc).
- (private) tests / benchmarks.
- github repo tagging.

Together, we can build a dashboard for a (pre)release status and track ahead of time what's blocking, breaking or missing for a "real" release.