### PR TITLE
Pass bind data to aggregate state size/init callbacks and batch state init

### DIFF
--- a/.github/patches/extensions/spatial/0002-aggregate-state-input-callbacks.patch
+++ b/.github/patches/extensions/spatial/0002-aggregate-state-input-callbacks.patch
@@ -1,3 +1,67 @@
+diff --git a/src/spatial/modules/geos/geos_module.cpp b/src/spatial/modules/geos/geos_module.cpp
+index e11c11b..b4a38bb 100644
+--- a/src/spatial/modules/geos/geos_module.cpp
++++ b/src/spatial/modules/geos/geos_module.cpp
+@@ -2675,7 +2675,7 @@ struct ST_Union_Agg {
+ 		}
+ 	};
+ 
+-	static idx_t StateSize(const BoundAggregateFunction &) {
++	static idx_t StateSize(AggregateStateInput &) {
+ 		return sizeof(State);
+ 	}
+ 
+@@ -2700,12 +2700,14 @@ struct ST_Union_Agg {
+ 		return GeosSerde::Deserialize(context, arena, ptr, size);
+ 	}
+ 
+-	static void Initialize(const BoundAggregateFunction &, data_ptr_t state_mem) {
+-		const auto state_ptr = new (state_mem) State();
+-		auto &state = *state_ptr;
+-		state.context = GEOS_init_r();
+-		GEOSContext_setErrorMessageHandler_r(
+-		    state.context, [](const char *message, void *) { throw InvalidInputException(message); }, nullptr);
++	static void Initialize(AggregateStateInput &, data_ptr_t *states, idx_t count) {
++		for (idx_t i = 0; i < count; i++) {
++			const auto state_ptr = new (states[i]) State();
++			auto &state = *state_ptr;
++			state.context = GEOS_init_r();
++			GEOSContext_setErrorMessageHandler_r(
++			    state.context, [](const char *message, void *) { throw InvalidInputException(message); }, nullptr);
++		}
+ 	}
+ 
+ 	static void Update(Vector inputs[], AggregateInputData &aggr, idx_t, Vector &state_vec, idx_t count) {
+@@ -2905,12 +2907,14 @@ struct GEOSCoverageAggFunction {
+ 		return GeosSerde::Deserialize(context, arena, ptr, size);
+ 	}
+ 
+-	static void Initialize(const BoundAggregateFunction &, data_ptr_t state_mem) {
+-		const auto state_ptr = new (state_mem) State();
+-		auto &state = *state_ptr;
+-		state.context = GEOS_init_r();
+-		GEOSContext_setErrorMessageHandler_r(
+-		    state.context, [](const char *message, void *) { throw InvalidInputException(message); }, nullptr);
++	static void Initialize(AggregateStateInput &, data_ptr_t *states, idx_t count) {
++		for (idx_t i = 0; i < count; i++) {
++			const auto state_ptr = new (states[i]) State();
++			auto &state = *state_ptr;
++			state.context = GEOS_init_r();
++			GEOSContext_setErrorMessageHandler_r(
++			    state.context, [](const char *message, void *) { throw InvalidInputException(message); }, nullptr);
++		}
+ 	}
+ 
+ 	static void Absorb(Vector &state_vec, Vector &combined, AggregateInputData &aggr_input_data, idx_t count) {
+@@ -2974,7 +2978,7 @@ struct GEOSCoverageAggFunction {
+ 		}
+ 	}
+ 
+-	static idx_t StateSize(const BoundAggregateFunction &) {
++	static idx_t StateSize(AggregateStateInput &) {
+ 		return sizeof(State);
+ 	}
+ 
 diff --git a/src/spatial/modules/mvt/mvt_module.cpp b/src/spatial/modules/mvt/mvt_module.cpp
 index 27f0c9f..5ce359f 100644
 --- a/src/spatial/modules/mvt/mvt_module.cpp

--- a/.github/patches/extensions/spatial/0002-aggregate-state-input-callbacks.patch
+++ b/.github/patches/extensions/spatial/0002-aggregate-state-input-callbacks.patch
@@ -1,0 +1,22 @@
+diff --git a/src/spatial/modules/mvt/mvt_module.cpp b/src/spatial/modules/mvt/mvt_module.cpp
+index 27f0c9f..5ce359f 100644
+--- a/src/spatial/modules/mvt/mvt_module.cpp
++++ b/src/spatial/modules/mvt/mvt_module.cpp
+@@ -1010,12 +1010,14 @@ struct ST_AsMVT {
+ 		MVTLayer layer;
+ 	};
+ 
+-	static idx_t StateSize(const BoundAggregateFunction &) {
++	static idx_t StateSize(AggregateStateInput &) {
+ 		return sizeof(State);
+ 	}
+ 
+-	static void Initialize(const BoundAggregateFunction &, data_ptr_t state_mem) {
+-		new (state_mem) State();
++	static void Initialize(AggregateStateInput &, data_ptr_t *states, idx_t count) {
++		for (idx_t i = 0; i < count; i++) {
++			new (states[i]) State();
++		}
+ 	}
+ 
+ 	//------------------------------------------------------------------------------------------------------------------

--- a/extension/core_functions/scalar/list/list_aggregates.cpp
+++ b/extension/core_functions/scalar/list/list_aggregates.cpp
@@ -233,7 +233,8 @@ void ListAggregatesFunction(DataChunk &args, ExpressionState &state, Vector &res
 	auto list_entries = UnifiedVectorFormat::GetData<list_entry_t>(lists_data);
 
 	// state_buffer holds the state for each list of this chunk
-	idx_t size = aggr.Function().GetStateSizeCallback()(aggr.Function());
+	AggregateStateInput state_input(aggr.Function(), aggr.BindInfo().get());
+	idx_t size = aggr.Function().GetStateSizeCallback()(state_input);
 	auto state_buffer = make_unsafe_uniq_array_uninitialized<data_t>(size * count);
 
 	// state vector for initialize and finalize
@@ -252,7 +253,7 @@ void ListAggregatesFunction(DataChunk &args, ExpressionState &state, Vector &res
 		// initialize the state for this list
 		auto state_ptr = state_buffer.get() + size * i;
 		states[i] = state_ptr;
-		aggr.Function().GetStateInitCallback()(aggr.Function(), states[i]);
+		aggr.Function().GetStateInitCallback()(state_input, &states[i], 1);
 
 		auto lists_index = lists_data.sel->get_index(i);
 		const auto &list_entry = list_entries[lists_index];

--- a/src/common/row_operations/row_aggregate.cpp
+++ b/src/common/row_operations/row_aggregate.cpp
@@ -16,14 +16,16 @@ void RowOperations::InitializeStates(TupleDataLayout &layout, Vector &addresses,
 	auto aggr_idx = layout.ColumnCount();
 
 	for (const auto &aggr : layout.GetAggregates()) {
+		AggregateStateInput state_input(aggr.function, aggr.GetFunctionData());
 		if (sel.IsSet()) {
 			for (idx_t i = 0; i < count; ++i) {
-				aggr.function.GetStateInitCallback()(aggr.function,
-				                                     pointers[sel.get_index_unsafe(i)] + offsets[aggr_idx]);
+				data_ptr_t state_ptr = pointers[sel.get_index_unsafe(i)] + offsets[aggr_idx];
+				aggr.function.GetStateInitCallback()(state_input, &state_ptr, 1);
 			}
 		} else {
 			for (idx_t i = 0; i < count; ++i) {
-				aggr.function.GetStateInitCallback()(aggr.function, pointers[i] + offsets[aggr_idx]);
+				data_ptr_t state_ptr = pointers[i] + offsets[aggr_idx];
+				aggr.function.GetStateInitCallback()(state_input, &state_ptr, 1);
 			}
 		}
 		++aggr_idx;

--- a/src/execution/operator/aggregate/aggregate_object.cpp
+++ b/src/execution/operator/aggregate/aggregate_object.cpp
@@ -16,7 +16,7 @@ AggregateObject::AggregateObject(BoundAggregateFunction function, FunctionData *
 
 AggregateObject::AggregateObject(BoundAggregateExpression &aggr)
     : AggregateObject(aggr.Function(), aggr.BindInfoMutable().get(), aggr.GetChildren().size(),
-                      AlignValue(aggr.Function().GetStateSizeCallback()(aggr.Function())), aggr.GetAggregateType(),
+                      AlignValue(aggr.Function().GetStateSize(aggr.BindInfoMutable().get())), aggr.GetAggregateType(),
                       aggr.GetReturnType().InternalType(), aggr.GetFilter().get()) {
 }
 
@@ -25,7 +25,7 @@ AggregateObject::AggregateObject(BoundAggregateExpression *aggr) : AggregateObje
 
 AggregateObject::AggregateObject(const BoundWindowExpression &window)
     : AggregateObject(*window.AggregateFunction(), window.BindInfo().get(), window.GetChildren().size(),
-                      AlignValue(window.AggregateFunction()->GetStateSizeCallback()(*window.AggregateFunction())),
+                      AlignValue(window.AggregateFunction()->GetStateSize(window.BindInfo().get())),
                       window.Distinct() ? AggregateType::DISTINCT : AggregateType::NON_DISTINCT,
                       window.GetReturnType().InternalType(), window.Filter().get()) {
 }

--- a/src/execution/operator/aggregate/physical_streaming_window.cpp
+++ b/src/execution/operator/aggregate/physical_streaming_window.cpp
@@ -41,9 +41,10 @@ public:
 			auto &aggregate = *wexpr.AggregateFunction();
 			bind_data = wexpr.BindInfo().get();
 			dtor = aggregate.GetCallbacks().GetStateDestructorCallback();
-			state.resize(aggregate.GetCallbacks().GetStateSizeCallback()(aggregate));
+			AggregateStateInput state_input(aggregate, bind_data);
+			state.resize(aggregate.GetCallbacks().GetStateSizeCallback()(state_input));
 			state_ptr = state.data();
-			aggregate.GetCallbacks().GetStateInitCallback()(aggregate, state.data());
+			aggregate.GetCallbacks().GetStateInitCallback()(state_input, &state_ptr, 1);
 			for (auto &child : wexpr.GetChildren()) {
 				arg_types.push_back(child->GetReturnType());
 				executor.AddExpression(*child);

--- a/src/execution/operator/aggregate/physical_ungrouped_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_ungrouped_aggregate.cpp
@@ -48,9 +48,10 @@ UngroupedAggregateState::UngroupedAggregateState(const vector<unique_ptr<Express
 		auto &aggregate = aggregate_expressions[i];
 		D_ASSERT(aggregate->GetExpressionClass() == ExpressionClass::BOUND_AGGREGATE);
 		auto &aggr = aggregate->Cast<BoundAggregateExpression>();
-		auto state =
-		    make_unsafe_uniq_array_uninitialized<data_t>(aggr.Function().GetStateSizeCallback()(aggr.Function()));
-		aggr.Function().GetStateInitCallback()(aggr.Function(), state.get());
+		AggregateStateInput state_input(aggr.Function(), aggr.BindInfo().get());
+		auto state = make_unsafe_uniq_array_uninitialized<data_t>(aggr.Function().GetStateSizeCallback()(state_input));
+		data_ptr_t state_ptr = state.get();
+		aggr.Function().GetStateInitCallback()(state_input, &state_ptr, 1);
 		aggregate_data.push_back(std::move(state));
 		bind_data.push_back(aggr.BindInfo() ? aggr.BindInfo()->Copy() : nullptr);
 		functions.push_back(aggr.Function());
@@ -68,8 +69,10 @@ UngroupedAggregateState::UngroupedAggregateState(const UngroupedAggregateState &
 	counts = make_uniq_array<idx_t>(functions.size());
 	for (idx_t i = 0; i < functions.size(); i++) {
 		auto &func = functions[i];
-		auto state = make_unsafe_uniq_array_uninitialized<data_t>(func.GetStateSizeCallback()(func));
-		func.GetStateInitCallback()(func, state.get());
+		AggregateStateInput state_input(func, global_state.bind_data[i].get());
+		auto state = make_unsafe_uniq_array_uninitialized<data_t>(func.GetStateSizeCallback()(state_input));
+		data_ptr_t state_ptr = state.get();
+		func.GetStateInitCallback()(state_input, &state_ptr, 1);
 		aggregate_data.push_back(std::move(state));
 		bind_data.push_back(global_state.bind_data[i] ? global_state.bind_data[i]->Copy() : nullptr);
 		counts[i] = 0;

--- a/src/execution/operator/projection/physical_pivot.cpp
+++ b/src/execution/operator/projection/physical_pivot.cpp
@@ -23,8 +23,10 @@ PhysicalPivot::PhysicalPivot(PhysicalPlan &physical_plan, vector<LogicalType> ty
 	for (auto &aggr_expr : bound_pivot.aggregates) {
 		auto &aggr = aggr_expr->Cast<BoundAggregateExpression>();
 		// for each aggregate, initialize an empty aggregate state and finalize it immediately
-		auto state = make_unsafe_uniq_array<data_t>(aggr.Function().GetStateSizeCallback()(aggr.Function()));
-		aggr.Function().GetStateInitCallback()(aggr.Function(), state.get());
+		AggregateStateInput state_input(aggr.Function(), aggr.BindInfo().get());
+		auto state = make_unsafe_uniq_array<data_t>(aggr.Function().GetStateSizeCallback()(state_input));
+		data_ptr_t state_ptr = state.get();
+		aggr.Function().GetStateInitCallback()(state_input, &state_ptr, 1);
 		Vector state_vector(Value::POINTER(CastPointerToValue(state.get())), count_t(1));
 		Vector result_vector(aggr_expr->GetReturnType());
 		AggregateFinalizeInputData aggr_input_data(aggr, physical_plan.ArenaRef());

--- a/src/execution/radix_partitioned_hashtable.cpp
+++ b/src/execution/radix_partitioned_hashtable.cpp
@@ -1073,9 +1073,11 @@ SourceResultType RadixPartitionedHashTable::GetData(ExecutionContext &context, D
 			for (idx_t i = 0; i < op.aggregates.size(); i++) {
 				D_ASSERT(op.aggregates[i]->GetExpressionClass() == ExpressionClass::BOUND_AGGREGATE);
 				auto &aggr = op.aggregates[i]->Cast<BoundAggregateExpression>();
-				auto aggr_state = make_unsafe_uniq_array_uninitialized<data_t>(
-				    aggr.Function().GetStateSizeCallback()(aggr.Function()));
-				aggr.Function().GetStateInitCallback()(aggr.Function(), aggr_state.get());
+				AggregateStateInput state_input(aggr.Function(), aggr.BindInfo().get());
+				auto aggr_state =
+				    make_unsafe_uniq_array_uninitialized<data_t>(aggr.Function().GetStateSizeCallback()(state_input));
+				data_ptr_t state_ptr = aggr_state.get();
+				aggr.Function().GetStateInitCallback()(state_input, &state_ptr, 1);
 
 				AggregateFinalizeInputData aggr_input_data(aggr, allocator);
 				Vector state_vector(Value::POINTER(CastPointerToValue(aggr_state.get())), count_t(1));

--- a/src/function/aggregate/distributive/count.cpp
+++ b/src/function/aggregate/distributive/count.cpp
@@ -271,7 +271,8 @@ struct CountFunction : public BaseCountFunction {
 
 AggregateStateLayout GetCountStateType(AggregateLayoutInput &input) {
 	auto &function = input.function;
-	return AggregateStateLayout(LogicalType::BIGINT, AlignValue(function.GetStateSizeCallback()(function)));
+	AggregateStateInput state_input(function, input.bind_data);
+	return AggregateStateLayout(LogicalType::BIGINT, AlignValue(function.GetStateSizeCallback()(state_input)));
 }
 
 unique_ptr<BaseStatistics> CountPropagateStats(ClientContext &context, BoundAggregateExpression &expr,

--- a/src/function/aggregate/distributive/count.cpp
+++ b/src/function/aggregate/distributive/count.cpp
@@ -271,7 +271,7 @@ struct CountFunction : public BaseCountFunction {
 
 AggregateStateLayout GetCountStateType(AggregateLayoutInput &input) {
 	auto &function = input.function;
-	AggregateStateInput state_input(function, input.bind_data);
+	AggregateStateInput state_input(function, input.bind_data.get());
 	return AggregateStateLayout(LogicalType::BIGINT, AlignValue(function.GetStateSizeCallback()(state_input)));
 }
 

--- a/src/function/aggregate/sorted_aggregate_function.cpp
+++ b/src/function/aggregate/sorted_aggregate_function.cpp
@@ -213,9 +213,13 @@ struct SortedAggregateState : ListAggState {};
 //! When the caller provides a local state slot (e.g. the hash table scan), this state survives across finalize
 //! calls instead of being re-instantiated for every result chunk.
 struct SortedAggregateFinalizeState : FunctionLocalState {
+	static idx_t StateSize(const SortedAggregateBindData &order_bind) {
+		AggregateStateInput input(order_bind.function, order_bind.bind_info.get());
+		return order_bind.function.GetCallbacks().GetStateSizeCallback()(input);
+	}
+
 	explicit SortedAggregateFinalizeState(const SortedAggregateBindData &order_bind)
-	    : thread(order_bind.context), context(order_bind.context, thread, nullptr),
-	      agg_state(order_bind.function.GetCallbacks().GetStateSizeCallback()(order_bind.function)),
+	    : thread(order_bind.context), context(order_bind.context, thread, nullptr), agg_state(StateSize(order_bind)),
 	      agg_state_vec(Value::POINTER(CastPointerToValue(agg_state.data())), count_t(1)) {
 		auto &buffer_allocator = BufferManager::GetBufferManager(order_bind.context).GetBufferAllocator();
 		rows.Initialize(buffer_allocator, {order_bind.buffered_struct_type});
@@ -382,6 +386,8 @@ struct SortedAggregateFunction {
 		auto cluster_update = aggr.GetCallbacks().GetStateClusterUpdateCallback();
 		auto update = aggr.GetCallbacks().GetStateUpdateCallback();
 		auto finalize = aggr.GetCallbacks().GetStateFinalizeCallback();
+		AggregateStateInput state_input(aggr, bind_info);
+		data_ptr_t agg_state_ptr = agg_state.data();
 
 		auto sdata = states.Values<SortedAggregateState *>();
 
@@ -433,7 +439,7 @@ struct SortedAggregateFunction {
 			auto global_source = sort->GetGlobalSourceState(client, *global_sink);
 			auto local_source = sort->GetLocalSourceState(context, *global_source);
 
-			initialize(aggr, agg_state.data());
+			initialize(state_input, &agg_state_ptr, 1);
 			for (;;) {
 				OperatorSourceInput source {*global_source, *local_source, interrupt};
 				scanned.Reset();
@@ -453,7 +459,7 @@ struct SortedAggregateFunction {
 							destructor(agg_state_vec, aggr_bind_info, 1);
 						}
 
-						initialize(aggr, agg_state.data());
+						initialize(state_input, &agg_state_ptr, 1);
 					}
 					const auto input_count = MinValue(state_unprocessed[sorted], scanned.size() - consumed);
 					for (column_t col_idx = 0; col_idx < scanned.ColumnCount(); ++col_idx) {
@@ -498,7 +504,7 @@ struct SortedAggregateFunction {
 		}
 
 		for (; sorted < count; ++sorted) {
-			initialize(aggr, agg_state.data());
+			initialize(state_input, &agg_state_ptr, 1);
 
 			// Finalize a single value at the next offset
 			agg_state_vec.SetVectorType(states.GetVectorType());

--- a/src/function/scalar/system/aggregate_export.cpp
+++ b/src/function/scalar/system/aggregate_export.cpp
@@ -410,7 +410,7 @@ void AggregateStateFinalize(DataChunk &input, ExpressionState &state_p, Vector &
 	auto &local_state = ExecuteFunctionState::GetFunctionState(state_p)->Cast<FinalizeState>();
 	local_state.allocator.Reset();
 
-	D_ASSERT(bind_data.state_size == bind_data.aggr.GetStateSizeCallback()(bind_data.aggr));
+	D_ASSERT(bind_data.state_size == bind_data.aggr.GetStateSize(bind_data.bind_data.get()));
 	D_ASSERT(input.data.size() == 1);
 
 	auto &layout = local_state.layout;
@@ -441,7 +441,7 @@ void AggregateStateCombine(DataChunk &input, ExpressionState &state_p, Vector &r
 	auto &local_state = ExecuteFunctionState::GetFunctionState(state_p)->Cast<CombineState>();
 	local_state.allocator.Reset();
 
-	D_ASSERT(bind_data.state_size == bind_data.aggr.GetStateSizeCallback()(bind_data.aggr));
+	D_ASSERT(bind_data.state_size == bind_data.aggr.GetStateSize(bind_data.bind_data.get()));
 	D_ASSERT(input.data.size() == 2);
 	D_ASSERT(input.data[0].GetType() == result.GetType());
 
@@ -459,13 +459,14 @@ void AggregateStateCombine(DataChunk &input, ExpressionState &state_p, Vector &r
 	auto validity1 = input.data[1].Validity();
 
 	// Initialize both state buffers and build address vectors for all rows
+	AggregateStateInput state_input(bind_data.aggr, bind_data.bind_data.get());
 	auto state0_writer = FlatVector::Writer<data_ptr_t>(local_state.addresses0, count);
 	auto state1_writer = FlatVector::Writer<data_ptr_t>(local_state.addresses1, count);
 	for (idx_t i = 0; i < count; i++) {
-		auto ptr0 = local_state.state_buffer0.get() + i * layout.total_state_size;
-		auto ptr1 = local_state.state_buffer1.get() + i * layout.total_state_size;
-		bind_data.aggr.GetStateInitCallback()(bind_data.aggr, ptr0);
-		bind_data.aggr.GetStateInitCallback()(bind_data.aggr, ptr1);
+		data_ptr_t ptr0 = local_state.state_buffer0.get() + i * layout.total_state_size;
+		data_ptr_t ptr1 = local_state.state_buffer1.get() + i * layout.total_state_size;
+		bind_data.aggr.GetStateInitCallback()(state_input, &ptr0, 1);
+		bind_data.aggr.GetStateInitCallback()(state_input, &ptr1, 1);
 		state0_writer.WriteValue(ptr0);
 		state1_writer.WriteValue(ptr1);
 	}
@@ -558,8 +559,8 @@ unique_ptr<ExportAggregateBindData> BindExportedAggregate(ClientContext &context
 		                        StringUtil::ToString(bound_args, ", "), StringUtil::ToString(argument_types, ", "));
 	}
 
-	return make_uniq<ExportAggregateBindData>(bound_aggr, std::move(bind_info),
-	                                          bound_aggr.GetStateSizeCallback()(bound_aggr));
+	const auto state_size = bound_aggr.GetStateSize(bind_info.get());
+	return make_uniq<ExportAggregateBindData>(bound_aggr, std::move(bind_info), state_size);
 }
 
 // parses the "parameters" property of an AGGREGATE_STATE type
@@ -643,7 +644,7 @@ unique_ptr<ExportAggregateBindData> BindAggregateStateInternal(ClientContext &co
 	auto reconstructed = FunctionBinder::BindSortedAggregateState(context, inner->aggr, std::move(inner->bind_data),
 	                                                              buffer_struct, orders, argument_count);
 	BoundAggregateFunction wrapper(reconstructed.first);
-	const auto state_size = wrapper.GetStateSizeCallback()(wrapper);
+	const auto state_size = wrapper.GetStateSize(reconstructed.second.get());
 	return make_uniq<ExportAggregateBindData>(std::move(wrapper), std::move(reconstructed.second), state_size);
 }
 
@@ -771,9 +772,10 @@ void CombineAggrUpdate(Vector inputs[], AggregateInputData &aggr_input_data, idx
 	Vector target_vec(LogicalType::POINTER);
 	auto target_data = FlatVector::Writer<data_ptr_t>(target_vec, count);
 
+	AggregateStateInput state_input(underlying_aggr, bind_data.bind_data.get());
 	for (idx_t i = 0; i < count; i++) {
-		auto temp_ptr = temp_state_buf.get() + i * aligned_size;
-		underlying_aggr.GetStateInitCallback()(underlying_aggr, temp_ptr);
+		data_ptr_t temp_ptr = temp_state_buf.get() + i * aligned_size;
+		underlying_aggr.GetStateInitCallback()(state_input, &temp_ptr, 1);
 		source_data.WriteValue(temp_ptr);
 		target_data.WriteValue(state_values[i].GetValue());
 	}

--- a/src/function/window/window_aggregate_states.cpp
+++ b/src/function/window/window_aggregate_states.cpp
@@ -3,7 +3,7 @@
 namespace duckdb {
 
 WindowAggregateStates::WindowAggregateStates(ClientContext &client, const AggregateObject &aggr)
-    : client(client), aggr(aggr), state_size(aggr.function.GetStateSizeCallback()(aggr.function)),
+    : client(client), aggr(aggr), state_size(aggr.function.GetStateSize(aggr.GetFunctionData())),
       allocator(Allocator::Get(client)) {
 }
 
@@ -16,9 +16,10 @@ void WindowAggregateStates::Initialize(idx_t count) {
 
 	statef = make_uniq<Vector>(LogicalType::POINTER, count);
 	auto state_f_data = FlatVector::Writer<data_ptr_t>(*statef, count);
+	AggregateStateInput state_input(aggr.function, aggr.GetFunctionData());
 	for (idx_t i = 0; i < count; ++i, state_ptr += state_size) {
 		state_f_data.WriteValue(state_ptr);
-		aggr.function.GetStateInitCallback()(aggr.function, state_ptr);
+		aggr.function.GetStateInitCallback()(state_input, &state_ptr, 1);
 	}
 
 	// Prevent conversion of results to constants

--- a/src/function/window/window_aggregator.cpp
+++ b/src/function/window/window_aggregator.cpp
@@ -11,7 +11,7 @@ namespace duckdb {
 //===--------------------------------------------------------------------===//
 WindowAggregator::WindowAggregator(const BoundWindowExpression &wexpr)
     : wexpr(wexpr), aggr(wexpr), result_type(wexpr.GetReturnType()),
-      state_size(aggr.function.GetStateSizeCallback()(aggr.function)), exclude_mode(wexpr.WindowExclude()) {
+      state_size(aggr.function.GetStateSize(aggr.GetFunctionData())), exclude_mode(wexpr.WindowExclude()) {
 	for (auto &child : wexpr.GetChildren()) {
 		arg_types.emplace_back(child->GetReturnType());
 	}

--- a/src/function/window/window_custom_aggregator.cpp
+++ b/src/function/window/window_custom_aggregator.cpp
@@ -72,10 +72,12 @@ public:
 WindowCustomAggregatorLocalState::WindowCustomAggregatorLocalState(ExecutionContext &context,
                                                                    const AggregateObject &aggr,
                                                                    const WindowExcludeMode exclude_mode)
-    : WindowAggregatorLocalState(context), aggr(aggr), state(aggr.function.GetStateSizeCallback()(aggr.function)),
+    : WindowAggregatorLocalState(context), aggr(aggr), state(aggr.function.GetStateSize(aggr.GetFunctionData())),
       statef(Value::POINTER(CastPointerToValue(state.data())), count_t(1)), frames(3, {0, 0}) {
 	// if we have a frame-by-frame method, share the single state
-	aggr.function.GetStateInitCallback()(aggr.function, state.data());
+	AggregateStateInput state_input(aggr.function, aggr.GetFunctionData());
+	data_ptr_t state_ptr = state.data();
+	aggr.function.GetStateInitCallback()(state_input, &state_ptr, 1);
 
 	InitSubFrames(frames, exclude_mode);
 }

--- a/src/function/window/window_naive_aggregator.cpp
+++ b/src/function/window/window_naive_aggregator.cpp
@@ -234,9 +234,10 @@ void WindowNaiveLocalState::Evaluate(ExecutionContext &context, const WindowAggr
 	EqualRow equal_row(*this);
 	RowSet row_set(STANDARD_VECTOR_SIZE, hash_row, equal_row);
 
+	AggregateStateInput state_input(aggr.function, aggr.GetFunctionData());
 	WindowAggregator::EvaluateSubFrames(bounds, aggregator.exclude_mode, count, row_idx, frames, [&](idx_t rid) {
-		auto agg_state = fdata[rid];
-		aggr.function.GetStateInitCallback()(aggr.function, agg_state);
+		data_ptr_t agg_state = fdata[rid];
+		aggr.function.GetStateInitCallback()(state_input, &agg_state, 1);
 
 		//	Reset the DISTINCT hash table
 		row_set.clear();

--- a/src/function/window/window_segment_tree.cpp
+++ b/src/function/window/window_segment_tree.cpp
@@ -156,7 +156,7 @@ WindowSegmentTreePart::WindowSegmentTreePart(ArenaAllocator &allocator, const Ag
                                              unique_ptr<WindowCursor> cursor_p, const ValidityArray &filter_mask)
     : allocator(allocator), aggr(aggr),
       order_insensitive(aggr.function.GetOrderDependent() == AggregateOrderDependent::NOT_ORDER_DEPENDENT),
-      filter_mask(filter_mask), state_size(aggr.function.GetStateSizeCallback()(aggr.function)),
+      filter_mask(filter_mask), state_size(aggr.function.GetStateSize(aggr.GetFunctionData())),
       state(state_size * STANDARD_VECTOR_SIZE), cursor(std::move(cursor_p)), statep(LogicalType::POINTER),
       statel(LogicalType::POINTER), statef(LogicalType::POINTER), flush_count(0) {
 	auto &inputs = cursor->chunk;
@@ -456,10 +456,8 @@ void WindowSegmentTreePart::Evaluate(const WindowSegmentTreeGlobalState &tree, c
 
 void WindowSegmentTreePart::Initialize(idx_t count) {
 	auto fdata = FlatVector::GetDataMutable<data_ptr_t>(statef);
-	for (idx_t rid = 0; rid < count; ++rid) {
-		auto state_ptr = fdata[rid];
-		aggr.function.GetStateInitCallback()(aggr.function, state_ptr);
-	}
+	AggregateStateInput state_input(aggr.function, aggr.GetFunctionData());
+	aggr.function.GetStateInitCallback()(state_input, fdata, count);
 }
 
 void WindowSegmentTreePart::EvaluateUpperLevels(const WindowSegmentTreeGlobalState &tree, const idx_t *begins,

--- a/src/include/duckdb/function/aggregate_function.hpp
+++ b/src/include/duckdb/function/aggregate_function.hpp
@@ -775,7 +775,7 @@ public:
 	}
 
 	//! Sizes an aggregate state by constructing an AggregateStateInput and invoking the state-size callback
-	idx_t GetStateSize(optional_ptr<FunctionData> bind_data) const {
+	idx_t GetStateSize(optional_ptr<const FunctionData> bind_data) const {
 		D_ASSERT(callbacks.state_size);
 		AggregateStateInput input(*this, bind_data);
 		return callbacks.state_size(input);

--- a/src/include/duckdb/function/aggregate_function.hpp
+++ b/src/include/duckdb/function/aggregate_function.hpp
@@ -78,9 +78,9 @@ private:
 };
 
 //! The type used for sizing hashed aggregate function states
-typedef idx_t (*aggregate_size_t)(const BoundAggregateFunction &function);
-//! The type used for initializing hashed aggregate function states
-typedef void (*aggregate_initialize_t)(const BoundAggregateFunction &function, data_ptr_t state);
+typedef idx_t (*aggregate_size_t)(AggregateStateInput &input);
+//! The type used for initializing hashed aggregate function states (batched: initializes `count` states)
+typedef void (*aggregate_initialize_t)(AggregateStateInput &input, data_ptr_t *states, idx_t count);
 //! The type used for updating hashed aggregate functions
 typedef void (*aggregate_update_t)(Vector inputs[], AggregateInputData &aggr_input_data, idx_t input_count,
                                    Vector &state, idx_t count);
@@ -638,7 +638,7 @@ public:
 	static void WireStructStateType(AggregateFunction &result);
 
 	template <class STATE>
-	static idx_t StateSize(const BoundAggregateFunction &) {
+	static idx_t StateSize(AggregateStateInput &) {
 		return sizeof(STATE);
 	}
 
@@ -662,18 +662,20 @@ public:
 	};
 
 	template <class STATE, class OP, AggregateDestructorType destructor_type = AggregateDestructorType::STANDARD>
-	static void StateInitialize(const BoundAggregateFunction &, data_ptr_t state) {
+	static void StateInitialize(AggregateStateInput &, data_ptr_t *states, idx_t count) {
 		// FIXME: we should remove the "destructor_type" option in the future
 #if !defined(__GNUC__) || (__GNUC__ >= 5)
 		static_assert(std::is_trivially_move_constructible<STATE>::value ||
 		                  destructor_type == AggregateDestructorType::LEGACY,
 		              "Aggregate state must be trivially move constructible");
 #endif
-		if constexpr (OperationHasInitialize<STATE, OP>::value) {
-			OP::Initialize(*reinterpret_cast<STATE *>(state));
-		} else {
-			// if the operation does not define an Initialize method - initialize the state by zero-initializing it
-			memset(state, 0, sizeof(STATE));
+		for (idx_t i = 0; i < count; i++) {
+			if constexpr (OperationHasInitialize<STATE, OP>::value) {
+				OP::Initialize(*reinterpret_cast<STATE *>(states[i]));
+			} else {
+				// if the operation does not define an Initialize method - initialize the state by zero-initializing it
+				memset(states[i], 0, sizeof(STATE));
+			}
 		}
 	}
 
@@ -770,6 +772,13 @@ public:
 		D_ASSERT(callbacks.get_state_type);
 		AggregateLayoutInput input(*this, bind_data);
 		return callbacks.get_state_type(input);
+	}
+
+	//! Sizes an aggregate state by constructing an AggregateStateInput and invoking the state-size callback
+	idx_t GetStateSize(optional_ptr<FunctionData> bind_data) const {
+		D_ASSERT(callbacks.state_size);
+		AggregateStateInput input(*this, bind_data);
+		return callbacks.state_size(input);
 	}
 };
 

--- a/src/include/duckdb/function/aggregate_state.hpp
+++ b/src/include/duckdb/function/aggregate_state.hpp
@@ -62,6 +62,17 @@ struct AggregateLayoutInput {
 	optional_ptr<FunctionData> bind_data;
 };
 
+//! Input to the state size/init callbacks - bundles the bound aggregate function with its bind data so that the
+//! callbacks can size and initialize states using any constant parameters stored in the bind data.
+struct AggregateStateInput {
+	AggregateStateInput(const BoundAggregateFunction &function_p, optional_ptr<FunctionData> bind_data_p)
+	    : function(function_p), bind_data(bind_data_p) {
+	}
+
+	const BoundAggregateFunction &function;
+	optional_ptr<FunctionData> bind_data;
+};
+
 //! The input data provided to the finalize callback of an aggregate function.
 //! If the function defines an "init_local_state_finalize" callback, the local state is initialized on construction.
 //! Callers can instead pass in an externally-owned local state - this way the local state can be kept alive and

--- a/src/include/duckdb/function/aggregate_state.hpp
+++ b/src/include/duckdb/function/aggregate_state.hpp
@@ -65,12 +65,12 @@ struct AggregateLayoutInput {
 //! Input to the state size/init callbacks - bundles the bound aggregate function with its bind data so that the
 //! callbacks can size and initialize states using any constant parameters stored in the bind data.
 struct AggregateStateInput {
-	AggregateStateInput(const BoundAggregateFunction &function_p, optional_ptr<FunctionData> bind_data_p)
+	AggregateStateInput(const BoundAggregateFunction &function_p, optional_ptr<const FunctionData> bind_data_p)
 	    : function(function_p), bind_data(bind_data_p) {
 	}
 
 	const BoundAggregateFunction &function;
-	optional_ptr<FunctionData> bind_data;
+	optional_ptr<const FunctionData> bind_data;
 };
 
 //! The input data provided to the finalize callback of an aggregate function.

--- a/src/main/capi/aggregate_function-c.cpp
+++ b/src/main/capi/aggregate_function-c.cpp
@@ -68,8 +68,8 @@ unique_ptr<FunctionData> CAPIAggregateBind(BindAggregateFunctionInput &input) {
 	return make_uniq<CAggregateFunctionBindData>(info);
 }
 
-idx_t CAPIAggregateStateSize(const BoundAggregateFunction &function) {
-	auto &function_info = function.GetExtraFunctionInfo().Cast<duckdb::CAggregateFunctionInfo>();
+idx_t CAPIAggregateStateSize(AggregateStateInput &input) {
+	auto &function_info = input.function.GetExtraFunctionInfo().Cast<duckdb::CAggregateFunctionInfo>();
 	CAggregateExecuteInfo exec_info(function_info);
 	auto c_function_info = reinterpret_cast<duckdb_function_info>(&exec_info);
 	auto result = function_info.state_size(c_function_info);
@@ -79,13 +79,16 @@ idx_t CAPIAggregateStateSize(const BoundAggregateFunction &function) {
 	return result;
 }
 
-void CAPIAggregateStateInit(const BoundAggregateFunction &function, data_ptr_t state) {
-	auto &function_info = function.GetExtraFunctionInfo().Cast<duckdb::CAggregateFunctionInfo>();
+void CAPIAggregateStateInit(AggregateStateInput &input, data_ptr_t *states, idx_t count) {
+	auto &function_info = input.function.GetExtraFunctionInfo().Cast<duckdb::CAggregateFunctionInfo>();
 	CAggregateExecuteInfo exec_info(function_info);
 	auto c_function_info = reinterpret_cast<duckdb_function_info>(&exec_info);
-	function_info.state_init(c_function_info, reinterpret_cast<duckdb_aggregate_state>(state));
-	if (!exec_info.success) {
-		throw InvalidInputException(exec_info.error);
+	// the V1 C init callback is single-state; drive it once per requested state
+	for (idx_t i = 0; i < count; i++) {
+		function_info.state_init(c_function_info, reinterpret_cast<duckdb_aggregate_state>(states[i]));
+		if (!exec_info.success) {
+			throw InvalidInputException(exec_info.error);
+		}
 	}
 }
 

--- a/test/api/CMakeLists.txt
+++ b/test/api/CMakeLists.txt
@@ -12,6 +12,7 @@ set(TEST_API_OBJECTS
     test_api.cpp
     test_bind_statement.cpp
     test_scalar_function_decimal_return.cpp
+    test_aggregate_state_bind_data.cpp
     test_config.cpp
     test_custom_allocator.cpp
     test_extension_setting_autoload.cpp

--- a/test/api/test_aggregate_state_bind_data.cpp
+++ b/test/api/test_aggregate_state_bind_data.cpp
@@ -1,0 +1,165 @@
+#include "catch.hpp"
+#include "test_helpers.hpp"
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/types/vector.hpp"
+#include "duckdb/execution/expression_executor.hpp"
+#include "duckdb/function/aggregate_function.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
+#include "duckdb/planner/expression.hpp"
+
+using namespace duckdb;
+
+// A custom aggregate whose per-group initial value comes from bind data. offset_sum(v, k) returns
+// k + sum(v) for each group. The offset k is a constant argument, folded at bind time and stored in
+// bind data. State init reads it back to seed every group's state, and state size dereferences the bind
+// data. This exercises that the state size and state init callbacks receive the bind data the bind
+// callback produced. A call site that threaded the wrong or no bind data would seed a wrong offset (a
+// wrong result) or hit the null check in size (a query error), so the wiring is checked, not assumed.
+
+namespace {
+
+struct OffsetSumBindData : public FunctionData {
+	explicit OffsetSumBindData(int64_t offset_p) : offset(offset_p) {
+	}
+
+	int64_t offset;
+
+	unique_ptr<FunctionData> Copy() const override {
+		return make_uniq<OffsetSumBindData>(offset);
+	}
+	bool Equals(const FunctionData &other_p) const override {
+		return offset == other_p.Cast<OffsetSumBindData>().offset;
+	}
+};
+
+struct OffsetSumState {
+	int64_t sum;
+	int64_t offset_seen;
+};
+
+unique_ptr<FunctionData> OffsetSumBind(BindAggregateFunctionInput &input) {
+	auto &arguments = input.GetArguments();
+	D_ASSERT(arguments.size() == 2);
+	if (!arguments[1]->IsFoldable()) {
+		throw BinderException("offset_sum: the offset argument must be constant");
+	}
+	Value offset_val = ExpressionExecutor::EvaluateScalar(input.GetClientContext(), *arguments[1]);
+	return make_uniq<OffsetSumBindData>(offset_val.GetValue<int64_t>());
+}
+
+// Reads the bind data: a call site that threads no bind data trips this in every build.
+idx_t OffsetSumSize(AggregateStateInput &input) {
+	if (!input.bind_data) {
+		throw InternalException("offset_sum: state size callback received no bind data");
+	}
+	return sizeof(OffsetSumState);
+}
+
+// Batched init: seeds each state's offset from the bind data.
+void OffsetSumInit(AggregateStateInput &input, data_ptr_t *states, idx_t count) {
+	auto &bind = input.bind_data->Cast<OffsetSumBindData>();
+	for (idx_t i = 0; i < count; i++) {
+		auto &state = *reinterpret_cast<OffsetSumState *>(states[i]);
+		state.sum = 0;
+		state.offset_seen = bind.offset;
+	}
+}
+
+void OffsetSumUpdate(Vector inputs[], AggregateInputData &, idx_t input_count, Vector &state_vector, idx_t count) {
+	D_ASSERT(input_count == 2);
+	UnifiedVectorFormat sdata;
+	state_vector.ToUnifiedFormat(sdata);
+	auto states = UnifiedVectorFormat::GetData<OffsetSumState *>(sdata);
+
+	UnifiedVectorFormat vdata;
+	inputs[0].ToUnifiedFormat(vdata);
+	auto vals = UnifiedVectorFormat::GetData<int64_t>(vdata);
+	for (idx_t i = 0; i < count; i++) {
+		auto vidx = vdata.sel->get_index(i);
+		if (!vdata.validity.RowIsValid(vidx)) {
+			continue;
+		}
+		auto &state = *states[sdata.sel->get_index(i)];
+		state.sum += vals[vidx];
+	}
+}
+
+void OffsetSumCombine(Vector &source, Vector &target, AggregateInputData &, idx_t count) {
+	UnifiedVectorFormat sdata;
+	source.ToUnifiedFormat(sdata);
+	auto sources = UnifiedVectorFormat::GetData<OffsetSumState *>(sdata);
+	auto targets = FlatVector::GetDataMutable<OffsetSumState *>(target);
+	for (idx_t i = 0; i < count; i++) {
+		auto &s = *sources[sdata.sel->get_index(i)];
+		auto &t = *targets[i];
+		// offset_seen is identical across partials (same bind data); only the running sum merges
+		t.sum += s.sum;
+	}
+}
+
+void OffsetSumFinalize(Vector &state_vector, AggregateFinalizeInputData &, Vector &result, idx_t count, idx_t offset) {
+	UnifiedVectorFormat sdata;
+	state_vector.ToUnifiedFormat(sdata);
+	auto states = UnifiedVectorFormat::GetData<OffsetSumState *>(sdata);
+	auto res = FlatVector::GetDataMutable<int64_t>(result);
+	for (idx_t i = 0; i < count; i++) {
+		auto &state = *states[sdata.sel->get_index(i)];
+		res[offset + i] = state.sum + state.offset_seen;
+	}
+}
+
+void RegisterOffsetSum(Connection &con) {
+	AggregateFunction fn("offset_sum", {LogicalType::BIGINT, LogicalType::BIGINT}, LogicalType::BIGINT, OffsetSumSize,
+	                     OffsetSumInit, OffsetSumUpdate, OffsetSumCombine, OffsetSumFinalize,
+	                     FunctionNullHandling::DEFAULT_NULL_HANDLING, nullptr, OffsetSumBind);
+	CreateAggregateFunctionInfo info(fn);
+	con.context->RunFunctionInTransaction(
+	    [&]() { Catalog::GetSystemCatalog(*con.context).CreateFunction(*con.context, info); });
+}
+
+} // namespace
+
+TEST_CASE("Aggregate state size and init callbacks receive bind data", "[api][aggregate_function]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	RegisterOffsetSum(con);
+
+	// Ungrouped aggregation: the single state is seeded from the bound offset via init.
+	{
+		auto result = con.Query("SELECT offset_sum(v, 100) FROM (VALUES (1),(2),(3)) t(v)");
+		REQUIRE_NO_FAIL(*result);
+		REQUIRE(result->GetValue(0, 0) == Value::BIGINT(106));
+	}
+
+	// Grouped aggregation: every group's state must be seeded with the same bound offset.
+	{
+		auto result = con.Query("SELECT k, offset_sum(v, 10) FROM (VALUES ('a', 1), ('a', 2), ('b', 5)) t(k, v) "
+		                        "GROUP BY k ORDER BY k");
+		REQUIRE_NO_FAIL(*result);
+		REQUIRE(result->GetValue(1, 0) == Value::BIGINT(13)); // a: 10 + (1 + 2)
+		REQUIRE(result->GetValue(1, 1) == Value::BIGINT(15)); // b: 10 + 5
+	}
+
+	// Windowed aggregation exercises the window state size and init call sites.
+	{
+		auto result = con.Query("SELECT offset_sum(v, 1000) OVER () FROM (VALUES (1),(2),(3)) t(v)");
+		REQUIRE_NO_FAIL(*result);
+		REQUIRE(result->GetValue(0, 0) == Value::BIGINT(1006));
+	}
+
+	// A different offset must produce a different result: proves init reads the value, not a constant.
+	{
+		auto result = con.Query("SELECT offset_sum(v, 0) FROM (VALUES (1),(2),(3)) t(v)");
+		REQUIRE_NO_FAIL(*result);
+		REQUIRE(result->GetValue(0, 0) == Value::BIGINT(6));
+	}
+
+	// NULL values are skipped, but the offset still seeds the state.
+	{
+		auto result = con.Query("SELECT offset_sum(v, 7) FROM (VALUES (1), (NULL), (2)) t(v)");
+		REQUIRE_NO_FAIL(*result);
+		REQUIRE(result->GetValue(0, 0) == Value::BIGINT(10)); // 7 + (1 + 2)
+	}
+}


### PR DESCRIPTION
This PR changes the size and init callback signatures of aggregate functions to pass in a `AggregateStateInput`, which contains both the `BoundAggregateFunction` (which it already got) and an `optional_ptr<FunctionData> bind_data` (which is the addition).

One other change is that the init callback now gets the `state`s for all groups at once (i.e. `data_ptr_t *states, idx_t count`) so that it gets called for the batch of groups instead of once per group. Note that `update`, `combine`, `finalize`, and `destroy` already take an array of states.

This is prep work for the new C API. Adding the bind data to size and init allows us to generalize across callbacks, and batching init is to avoid ABI crossings.

I've patched the v1 C API bridge to make sure the batched init works correctly without any consumer changes.