### PR TITLE
Add explicit user agent to avoid r2's 403 forbidden

### DIFF
--- a/scripts/ci/check_staged_extensions.py
+++ b/scripts/ci/check_staged_extensions.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 
 DEFAULT_ASSET_BASE_URL = "https://duckdb-staging.duckdb.org"
+DOWNLOAD_USER_AGENT = "duckdb-ci/check-staged-extensions"
 DOWNLOAD_RETRIES = 2
 DOWNLOAD_RETRY_SECONDS = 10
 EXTENSION_SEPARATOR_TRANSLATION = str.maketrans({",": " ", ";": " "})
@@ -44,7 +45,8 @@ def download_cli(url: str, target: Path) -> None:
     for attempt in range(1, DOWNLOAD_RETRIES + 1):
         try:
             print(f"Downloading staged CLI ({attempt}/{DOWNLOAD_RETRIES}): {url}", flush=True)
-            with urllib.request.urlopen(url, timeout=60) as response:
+            request = urllib.request.Request(url, headers={"User-Agent": DOWNLOAD_USER_AGENT})
+            with urllib.request.urlopen(request, timeout=60) as response:
                 compressed = response.read()
             target.write_bytes(gzip.decompress(compressed))
             target.chmod(0o755)


### PR DESCRIPTION
CI [failed](https://github.com/duckdb/duckdb/actions/runs/29821811422/job/88653211459#step:4:11) on main because Python `urllib` used the default `Python-urllib/...` user agent, which Cloudflare blocked with 403 / error 1010.

The R2 object was fine; `curl` worked because its user agent was allowed.

Fix: set an explicit user agent in `scripts/ci/check_staged_extensions.py`:

```python
DOWNLOAD_USER_AGENT = "duckdb-ci/check-staged-extensions"
```