### PR TITLE
Spill wide string payloads of aggregate states

### DIFF
--- a/benchmark/micro/aggregate/first_wide_payload.benchmark
+++ b/benchmark/micro/aggregate/first_wide_payload.benchmark
@@ -1,0 +1,17 @@
+# name: benchmark/micro/aggregate/first_wide_payload.benchmark
+# description: DISTINCT ON retaining a wide VARCHAR payload for every group
+# group: [aggregate]
+
+name First wide payload
+group aggregate
+
+load
+CREATE TABLE docs AS
+SELECT i AS k, repeat(md5(i::VARCHAR), 25) AS wide
+FROM range(0, 4000000) t(i);
+
+run
+SELECT count(wide) FROM (SELECT DISTINCT ON (k) k, wide FROM docs) s
+
+result I
+4000000

--- a/benchmark/micro/aggregate/first_wide_payload.benchmark
+++ b/benchmark/micro/aggregate/first_wide_payload.benchmark
@@ -1,17 +1,24 @@
 # name: benchmark/micro/aggregate/first_wide_payload.benchmark
-# description: DISTINCT ON retaining a wide VARCHAR payload for every group
+# description: DISTINCT ON retaining a wide VARCHAR payload for every group, spilling under a memory limit
 # group: [aggregate]
 
 name First wide payload
 group aggregate
 
+cache first_wide_payload.duckdb
+
 load
 CREATE TABLE docs AS
 SELECT i AS k, repeat(md5(i::VARCHAR), 25) AS wide
-FROM range(0, 4000000) t(i);
+FROM range(0, 8000000) t(i);
+
+init
+set temp_directory='${BENCHMARK_DIR}/first_wide_payload.duckdb.tmp';
+set memory_limit='4GB';
+set preserve_insertion_order=false;
 
 run
 SELECT count(wide) FROM (SELECT DISTINCT ON (k) k, wide FROM docs) s
 
 result I
-4000000
+8000000

--- a/src/common/row_operations/row_aggregate.cpp
+++ b/src/common/row_operations/row_aggregate.cpp
@@ -51,6 +51,10 @@ void RowOperations::UpdateStates(RowOperationsState &state, AggregateObject &agg
                                  DataChunk &payload, idx_t arg_idx, optional_ptr<const ClusteredAggr> clustered) {
 	auto count = addresses.size();
 	AggregateInputData aggr_input_data(aggr, state.allocator);
+	if (aggr.state_export_mode == AggregateStateExportMode::NONE) {
+		// Exported states are read as raw bytes, so their payloads cannot live on a payload heap
+		aggr_input_data.payload_heap = state.payload_heap;
+	}
 	auto cluster_update = aggr.function.GetStateClusterUpdateCallback();
 	aggr_input_data.clustered = cluster_update ? clustered : nullptr;
 	auto inputs = aggr.child_count ? payload.data.data() + arg_idx : nullptr;
@@ -132,6 +136,7 @@ void RowOperations::CombineStates(RowOperationsState &state, TupleDataLayout &la
 	for (auto &aggr : layout.GetAggregates()) {
 		D_ASSERT(aggr.function.HasStateCombineCallback());
 		AggregateInputData aggr_input_data(aggr, state.allocator, AggregateCombineType::ALLOW_DESTRUCTIVE);
+		aggr_input_data.payload_heap = state.payload_heap;
 		aggr.function.GetStateCombineCallback()(sources, targets, aggr_input_data, count);
 
 		// Move to the next aggregate states
@@ -177,6 +182,7 @@ void RowOperations::FinalizeStates(RowOperationsState &state, TupleDataLayout &l
 		auto &target = result.data[aggr_idx + i];
 		auto &aggr = aggregates[i];
 		AggregateFinalizeInputData finalize_input_data(aggr, state.allocator, state.local_states[i].get());
+		finalize_input_data.payload_heap = state.payload_heap;
 		aggr.function.GetStateFinalizeCallback()(addresses_copy, finalize_input_data, target, result.size(), 0);
 		FlatVector::SetSize(target, count_t(result.size()));
 

--- a/src/common/row_operations/row_aggregate.cpp
+++ b/src/common/row_operations/row_aggregate.cpp
@@ -136,7 +136,10 @@ void RowOperations::CombineStates(RowOperationsState &state, TupleDataLayout &la
 	for (auto &aggr : layout.GetAggregates()) {
 		D_ASSERT(aggr.function.HasStateCombineCallback());
 		AggregateInputData aggr_input_data(aggr, state.allocator, AggregateCombineType::ALLOW_DESTRUCTIVE);
-		aggr_input_data.payload_heap = state.payload_heap;
+		if (aggr.state_export_mode == AggregateStateExportMode::NONE) {
+			// Exported states are read as raw bytes, so combining must not move payloads to a payload heap
+			aggr_input_data.payload_heap = state.payload_heap;
+		}
 		aggr.function.GetStateCombineCallback()(sources, targets, aggr_input_data, count);
 
 		// Move to the next aggregate states
@@ -182,7 +185,9 @@ void RowOperations::FinalizeStates(RowOperationsState &state, TupleDataLayout &l
 		auto &target = result.data[aggr_idx + i];
 		auto &aggr = aggregates[i];
 		AggregateFinalizeInputData finalize_input_data(aggr, state.allocator, state.local_states[i].get());
-		finalize_input_data.payload_heap = state.payload_heap;
+		if (aggr.state_export_mode == AggregateStateExportMode::NONE) {
+			finalize_input_data.payload_heap = state.payload_heap;
+		}
 		aggr.function.GetStateFinalizeCallback()(addresses_copy, finalize_input_data, target, result.size(), 0);
 		FlatVector::SetSize(target, count_t(result.size()));
 

--- a/src/execution/CMakeLists.txt
+++ b/src/execution/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library_unity(
   OBJECT
   adaptive_filter.cpp
   aggregate_hashtable.cpp
+  aggregate_payload_heap.cpp
   base_aggregate_hashtable.cpp
   column_binding_resolver.cpp
   expression_executor.cpp

--- a/src/execution/aggregate_hashtable.cpp
+++ b/src/execution/aggregate_hashtable.cpp
@@ -11,6 +11,7 @@
 #include "duckdb/common/types/row/tuple_data_iterator.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/execution/expression_executor.hpp"
+#include "duckdb/execution/aggregate_payload_heap.hpp"
 #include "duckdb/execution/ht_entry.hpp"
 #include "duckdb/planner/expression/bound_aggregate_expression.hpp"
 #include "duckdb/common/atomic.hpp"
@@ -165,6 +166,11 @@ void GroupedAggregateHashTable::Repartition() {
 
 shared_ptr<ArenaAllocator> GroupedAggregateHashTable::GetAggregateAllocator() {
 	return aggregate_allocator;
+}
+
+void GroupedAggregateHashTable::InitializePayloadHeap(AggregatePayloadRegistry &registry) {
+	payload_heap = make_uniq<AggregatePayloadHeap>(registry);
+	state.row_state.payload_heap = payload_heap.get();
 }
 
 GroupedAggregateHashTable::~GroupedAggregateHashTable() {

--- a/src/execution/aggregate_payload_heap.cpp
+++ b/src/execution/aggregate_payload_heap.cpp
@@ -1,0 +1,52 @@
+#include "duckdb/execution/aggregate_payload_heap.hpp"
+
+#include <cstring>
+
+namespace duckdb {
+
+AggregatePayloadRegistry::AggregatePayloadRegistry(BufferManager &buffer_manager_p) : buffer_manager(buffer_manager_p) {
+}
+
+uint32_t AggregatePayloadRegistry::RegisterBlock(shared_ptr<BlockHandle> block) {
+	lock_guard<mutex> guard(lock);
+	blocks.push_back(std::move(block));
+	return UnsafeNumericCast<uint32_t>(blocks.size() - 1);
+}
+
+BufferHandle AggregatePayloadRegistry::PinBlock(uint32_t block_idx) {
+	shared_ptr<BlockHandle> block;
+	{
+		lock_guard<mutex> guard(lock);
+		block = blocks[block_idx];
+	}
+	return buffer_manager.Pin(block);
+}
+
+AggregatePayloadHeap::AggregatePayloadHeap(AggregatePayloadRegistry &registry_p) : registry(registry_p) {
+}
+
+AggregatePayloadHandle AggregatePayloadHeap::Append(const char *data, uint32_t length) {
+	if (current_offset + length > current_capacity) {
+		// Dropping the pin makes the previous block evictable, only the block being written stays pinned
+		const auto capacity = MaxValue<idx_t>(registry.buffer_manager.GetBlockSize(), length);
+		auto buffer_handle = registry.buffer_manager.Allocate(MemoryTag::HASH_TABLE, capacity, false);
+		current_block_idx = registry.RegisterBlock(buffer_handle.GetBlockHandle());
+		current_pin = std::move(buffer_handle);
+		current_offset = 0;
+		current_capacity = capacity;
+	}
+	memcpy(current_pin.GetDataMutable() + current_offset, data, length);
+	AggregatePayloadHandle handle;
+	handle.block_idx = current_block_idx;
+	handle.offset = UnsafeNumericCast<uint32_t>(current_offset);
+	handle.length = length;
+	current_offset += length;
+	return handle;
+}
+
+const char *AggregatePayloadHeap::Read(const AggregatePayloadHandle &handle, BufferHandle &pin) {
+	pin = registry.PinBlock(handle.block_idx);
+	return const_char_ptr_cast(pin.Ptr()) + handle.offset;
+}
+
+} // namespace duckdb

--- a/src/execution/aggregate_payload_heap.cpp
+++ b/src/execution/aggregate_payload_heap.cpp
@@ -44,9 +44,13 @@ AggregatePayloadHandle AggregatePayloadHeap::Append(const char *data, uint32_t l
 	return handle;
 }
 
-const char *AggregatePayloadHeap::Read(const AggregatePayloadHandle &handle, BufferHandle &pin) {
-	pin = registry.PinBlock(handle.block_idx);
-	return const_char_ptr_cast(pin.Ptr()) + handle.offset;
+const char *AggregatePayloadHeap::Read(const AggregatePayloadHandle &handle) {
+	if (!read_pin_valid || read_block_idx != handle.block_idx) {
+		read_pin = registry.PinBlock(handle.block_idx);
+		read_block_idx = handle.block_idx;
+		read_pin_valid = true;
+	}
+	return const_char_ptr_cast(read_pin.Ptr()) + handle.offset;
 }
 
 } // namespace duckdb

--- a/src/execution/operator/aggregate/aggregate_object.cpp
+++ b/src/execution/operator/aggregate/aggregate_object.cpp
@@ -18,6 +18,7 @@ AggregateObject::AggregateObject(BoundAggregateExpression &aggr)
     : AggregateObject(aggr.Function(), aggr.BindInfoMutable().get(), aggr.GetChildren().size(),
                       AlignValue(aggr.Function().GetStateSizeCallback()(aggr.Function())), aggr.GetAggregateType(),
                       aggr.GetReturnType().InternalType(), aggr.GetFilter().get()) {
+	state_export_mode = aggr.StateExportMode();
 }
 
 AggregateObject::AggregateObject(BoundAggregateExpression *aggr) : AggregateObject(*aggr) {

--- a/src/execution/radix_partitioned_hashtable.cpp
+++ b/src/execution/radix_partitioned_hashtable.cpp
@@ -7,6 +7,7 @@
 #include "duckdb/common/types/row/tuple_data_collection.hpp"
 #include "duckdb/common/types/row/tuple_data_iterator.hpp"
 #include "duckdb/execution/aggregate_hashtable.hpp"
+#include "duckdb/execution/aggregate_payload_heap.hpp"
 #include "duckdb/execution/executor.hpp"
 #include "duckdb/execution/ht_entry.hpp"
 #include "duckdb/execution/operator/aggregate/physical_hash_aggregate.hpp"
@@ -170,6 +171,8 @@ public:
 	//! Temporary memory state for managing this hash table's memory usage
 	unique_ptr<TemporaryMemoryState> temporary_memory_state;
 	atomic<idx_t> minimum_reservation;
+	//! Registry of spillable blocks holding string payloads owned by aggregate states
+	shared_ptr<AggregatePayloadRegistry> payload_registry;
 
 	//! Whether we've called Finalize
 	bool finalized;
@@ -214,6 +217,7 @@ public:
 
 RadixHTGlobalSinkState::RadixHTGlobalSinkState(ClientContext &context_p, const RadixPartitionedHashTable &radix_ht_p)
     : context(context_p), temporary_memory_state(TemporaryMemoryManager::Get(context).Register(context)),
+      payload_registry(make_shared_ptr<AggregatePayloadRegistry>(BufferManager::GetBufferManager(context_p))),
       finalized(false), external(false), active_threads(0),
       number_of_threads(TaskScheduler::GetScheduler(context).NumberOfThreads()),
       memory_limit(BufferManager::GetBufferManager(context).GetOperatorMemoryLimit()),
@@ -600,6 +604,7 @@ void RadixPartitionedHashTable::Sink(ExecutionContext &context, DataChunk &chunk
 	if (!lstate.ht) {
 		lstate.local_sink_capacity = gstate.config.sink_capacity;
 		lstate.ht = CreateHT(context.client, lstate.local_sink_capacity, gstate.config.GetRadixBits());
+		lstate.ht->InitializePayloadHeap(*gstate.payload_registry);
 		if (gstate.number_of_threads > RadixHTConfig::GROW_STRATEGY_THREAD_THRESHOLD) {
 			// Not using grow strategy, so we enable the HLL to potentially adapt later
 			lstate.ht->EnableHLL(true);
@@ -822,6 +827,8 @@ private:
 	TupleDataLayout layout;
 	ArenaAllocator aggregate_allocator;
 	RowOperationsState row_state;
+	//! Heap view over the sink's payload registry for materializing heap-backed state values
+	unique_ptr<AggregatePayloadHeap> payload_heap;
 
 	//! State and chunk for scanning
 	TupleDataScanState scan_state;
@@ -944,6 +951,7 @@ void RadixHTLocalSourceState::Finalize(RadixHTGlobalSinkState &sink, RadixHTGlob
 		    MaxValue(NextPowerOfTwo(thread_limit / size_per_entry), GroupedAggregateHashTable::InitialCapacity());
 
 		ht = sink.radix_ht.CreateHT(gstate.context, MinValue<idx_t>(capacity, capacity_limit), 0);
+		ht->InitializePayloadHeap(*sink.payload_registry);
 	} else {
 		ht->Abandon();
 	}
@@ -1006,6 +1014,11 @@ void RadixHTLocalSourceState::Scan(RadixHTGlobalSinkState &sink, RadixHTGlobalSo
 		return;
 	}
 
+	if (!payload_heap) {
+		// The payload heap is only used for reading here, finalizing materializes heap-backed values
+		payload_heap = make_uniq<AggregatePayloadHeap>(*sink.payload_registry);
+		row_state.payload_heap = payload_heap.get();
+	}
 	const auto group_cols = layout.ColumnCount() - 1;
 	RowOperations::FinalizeStates(row_state, layout, scan_state.chunk_state.row_locations, scan_chunk, group_cols);
 

--- a/src/function/aggregate/distributive/first_last_any.cpp
+++ b/src/function/aggregate/distributive/first_last_any.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/common/clustered_aggregate.hpp"
 #include "duckdb/common/exception.hpp"
+#include "duckdb/execution/aggregate_payload_heap.hpp"
 #include "duckdb/function/aggregate/distributive_functions.hpp"
 #include "duckdb/function/aggregate/distributive_function_utils.hpp"
 #include "duckdb/function/create_sort_key.hpp"
@@ -36,15 +37,26 @@ struct FirstStringStateBase {
 	bool is_set;
 	//! The size of the arena allocation for a non-inlined string value - not part of the exported state
 	uint32_t alloc_size;
+	//! When non-zero, the value lives on spillable payload heap block (heap_block - 1) instead
+	uint32_t heap_block;
+	uint32_t heap_offset;
 
 	void Assign(string_t input, AggregateInputData &input_data) {
 		if (input.IsInlined()) {
 			value = input;
 			alloc_size = 0;
+			heap_block = 0;
+		} else if (input_data.payload_heap) {
+			// Store the payload on a spillable heap block, the state keeps a handle instead of a pointer
+			auto len = UnsafeNumericCast<uint32_t>(input.GetSize());
+			auto handle = input_data.payload_heap->Append(input.GetData(), len);
+			heap_block = handle.block_idx + 1;
+			heap_offset = handle.offset;
+			alloc_size = len;
 		} else {
 			auto len = UnsafeNumericCast<uint32_t>(input.GetSize());
 			char *ptr;
-			if (alloc_size >= len) {
+			if (heap_block == 0 && alloc_size >= len) {
 				ptr = value.GetDataWriteable();
 			} else {
 				alloc_size = UnsafeNumericCast<uint32_t>(NextPowerOfTwo(len));
@@ -52,7 +64,18 @@ struct FirstStringStateBase {
 			}
 			memcpy(ptr, input.GetData(), len);
 			value = string_t(ptr, len);
+			heap_block = 0;
 		}
+	}
+
+	//! Materialize a heap-backed value (the pin must stay alive while the result is in use)
+	string_t Materialize(optional_ptr<AggregatePayloadHeap> heap, BufferHandle &pin) const {
+		D_ASSERT(heap_block != 0 && heap);
+		AggregatePayloadHandle handle;
+		handle.block_idx = heap_block - 1;
+		handle.offset = heap_offset;
+		handle.length = alloc_size;
+		return string_t(heap->Read(handle, pin), alloc_size);
 	}
 };
 
@@ -187,7 +210,16 @@ struct FirstFunctionStringBase : public FirstFunctionBase {
 	template <class STATE, class OP>
 	static void Combine(const STATE &source, STATE &target, AggregateInputData &input_data) {
 		if (source.is_set && (LAST || !target.is_set)) {
-			SetValue<STATE>(target, input_data, source.value, !source.value_is_valid);
+			if (source.value_is_valid && source.heap_block != 0) {
+				// Heap handles stay valid within the operator, copy the handle instead of the bytes
+				target.is_set = true;
+				target.value_is_valid = true;
+				target.heap_block = source.heap_block;
+				target.heap_offset = source.heap_offset;
+				target.alloc_size = source.alloc_size;
+			} else {
+				SetValue<STATE>(target, input_data, source.value, !source.value_is_valid);
+			}
 		}
 	}
 };
@@ -238,6 +270,10 @@ struct FirstFunctionString : FirstFunctionStringBase<LAST, SKIP_NULLS> {
 	static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
 		if (!state.is_set || !state.value_is_valid) {
 			finalize_data.ReturnNull();
+		} else if (state.heap_block != 0) {
+			BufferHandle pin;
+			target = StringVector::AddStringOrBlob(finalize_data.result,
+			                                       state.Materialize(finalize_data.input.payload_heap, pin));
 		} else {
 			target = StringVector::AddStringOrBlob(finalize_data.result, state.value);
 		}
@@ -308,6 +344,11 @@ struct FirstVectorFunction : FirstFunctionStringBase<LAST, SKIP_NULLS> {
 	static void Finalize(STATE &state, AggregateFinalizeData &finalize_data) {
 		if (!state.is_set || !state.value_is_valid) {
 			finalize_data.ReturnNull();
+		} else if (state.heap_block != 0) {
+			BufferHandle pin;
+			CreateSortKeyHelpers::DecodeSortKey(state.Materialize(finalize_data.input.payload_heap, pin),
+			                                    finalize_data.result, finalize_data.result_idx,
+			                                    OrderModifiers(OrderType::ASCENDING, OrderByNullType::NULLS_LAST));
 		} else {
 			CreateSortKeyHelpers::DecodeSortKey(state.value, finalize_data.result, finalize_data.result_idx,
 			                                    OrderModifiers(OrderType::ASCENDING, OrderByNullType::NULLS_LAST));

--- a/src/function/aggregate/distributive/first_last_any.cpp
+++ b/src/function/aggregate/distributive/first_last_any.cpp
@@ -41,12 +41,16 @@ struct FirstStringStateBase {
 	uint32_t heap_block;
 	uint32_t heap_offset;
 
+	//! Payloads below this size stay on the arena: they pin little memory per group,
+	//! and the indirection costs more than it saves
+	static constexpr idx_t MINIMUM_HEAP_PAYLOAD_SIZE = 32;
+
 	void Assign(string_t input, AggregateInputData &input_data, bool allow_heap) {
 		if (input.IsInlined()) {
 			value = input;
 			alloc_size = 0;
 			heap_block = 0;
-		} else if (allow_heap && input_data.payload_heap) {
+		} else if (allow_heap && input.GetSize() >= MINIMUM_HEAP_PAYLOAD_SIZE && input_data.payload_heap) {
 			// Store the payload on a spillable heap block, the state keeps a handle instead of a pointer
 			auto len = UnsafeNumericCast<uint32_t>(input.GetSize());
 			auto handle = input_data.payload_heap->Append(input.GetData(), len);

--- a/src/function/aggregate/distributive/first_last_any.cpp
+++ b/src/function/aggregate/distributive/first_last_any.cpp
@@ -41,12 +41,12 @@ struct FirstStringStateBase {
 	uint32_t heap_block;
 	uint32_t heap_offset;
 
-	void Assign(string_t input, AggregateInputData &input_data) {
+	void Assign(string_t input, AggregateInputData &input_data, bool allow_heap) {
 		if (input.IsInlined()) {
 			value = input;
 			alloc_size = 0;
 			heap_block = 0;
-		} else if (input_data.payload_heap) {
+		} else if (allow_heap && input_data.payload_heap) {
 			// Store the payload on a spillable heap block, the state keeps a handle instead of a pointer
 			auto len = UnsafeNumericCast<uint32_t>(input.GetSize());
 			auto handle = input_data.payload_heap->Append(input.GetData(), len);
@@ -68,14 +68,14 @@ struct FirstStringStateBase {
 		}
 	}
 
-	//! Materialize a heap-backed value (the pin must stay alive while the result is in use)
-	string_t Materialize(optional_ptr<AggregatePayloadHeap> heap, BufferHandle &pin) const {
+	//! Materialize a heap-backed value (valid until the next read from or append to the heap)
+	string_t Materialize(optional_ptr<AggregatePayloadHeap> heap) const {
 		D_ASSERT(heap_block != 0 && heap);
 		AggregatePayloadHandle handle;
 		handle.block_idx = heap_block - 1;
 		handle.offset = heap_offset;
 		handle.length = alloc_size;
-		return string_t(heap->Read(handle, pin), alloc_size);
+		return string_t(heap->Read(handle), alloc_size);
 	}
 };
 
@@ -203,7 +203,9 @@ struct FirstFunctionStringBase : public FirstFunctionBase {
 		} else {
 			state.is_set = true;
 			state.value_is_valid = true;
-			state.Assign(value, input_data);
+			// last overwrites its value for every row, which would keep appending to the payload heap,
+			// so it stays on the arena until the heap supports in-place reuse
+			state.Assign(value, input_data, !LAST);
 		}
 	}
 
@@ -271,9 +273,8 @@ struct FirstFunctionString : FirstFunctionStringBase<LAST, SKIP_NULLS> {
 		if (!state.is_set || !state.value_is_valid) {
 			finalize_data.ReturnNull();
 		} else if (state.heap_block != 0) {
-			BufferHandle pin;
 			target = StringVector::AddStringOrBlob(finalize_data.result,
-			                                       state.Materialize(finalize_data.input.payload_heap, pin));
+			                                       state.Materialize(finalize_data.input.payload_heap));
 		} else {
 			target = StringVector::AddStringOrBlob(finalize_data.result, state.value);
 		}
@@ -345,8 +346,7 @@ struct FirstVectorFunction : FirstFunctionStringBase<LAST, SKIP_NULLS> {
 		if (!state.is_set || !state.value_is_valid) {
 			finalize_data.ReturnNull();
 		} else if (state.heap_block != 0) {
-			BufferHandle pin;
-			CreateSortKeyHelpers::DecodeSortKey(state.Materialize(finalize_data.input.payload_heap, pin),
+			CreateSortKeyHelpers::DecodeSortKey(state.Materialize(finalize_data.input.payload_heap),
 			                                    finalize_data.result, finalize_data.result_idx,
 			                                    OrderModifiers(OrderType::ASCENDING, OrderByNullType::NULLS_LAST));
 		} else {

--- a/src/include/duckdb/common/row_operations/row_operations.hpp
+++ b/src/include/duckdb/common/row_operations/row_operations.hpp
@@ -24,6 +24,7 @@ struct AggregateFilterDataSet;
 class DataChunk;
 class TupleDataLayout;
 struct SelectionVector;
+class AggregatePayloadHeap;
 class StringHeap;
 struct UnifiedVectorFormat;
 
@@ -35,6 +36,8 @@ struct RowOperationsState {
 	unique_ptr<Vector> addresses; // Re-usable vector for row_aggregate.cpp
 	//! Per-aggregate slots in which the aggregates can cache state across finalize calls
 	vector<unique_ptr<FunctionLocalState>> local_states;
+	//! Spillable heap for state-owned string payloads (set by the hash aggregate)
+	optional_ptr<AggregatePayloadHeap> payload_heap;
 };
 
 // RowOperations contains a set of operations that operate on data using a TupleDataLayout

--- a/src/include/duckdb/execution/aggregate_hashtable.hpp
+++ b/src/include/duckdb/execution/aggregate_hashtable.hpp
@@ -20,6 +20,8 @@
 
 namespace duckdb {
 
+class AggregatePayloadHeap;
+class AggregatePayloadRegistry;
 class BlockHandle;
 
 struct FlushMoveState;
@@ -58,6 +60,8 @@ public:
 	//! The hash table load factor, when a resize is triggered
 	constexpr static double LOAD_FACTOR = 1.5;
 
+	//! Initialize the spillable heap for state-owned string payloads
+	void InitializePayloadHeap(AggregatePayloadRegistry &registry);
 	//! Get the layout of this HT
 	shared_ptr<TupleDataLayout> GetLayoutPtr();
 	const TupleDataLayout &GetLayout() const;
@@ -196,6 +200,8 @@ private:
 	shared_ptr<ArenaAllocator> aggregate_allocator;
 	//! Owning arena allocators that this HT has data from
 	vector<shared_ptr<ArenaAllocator>> stored_allocators;
+	//! Spillable heap for state-owned string payloads (initialized by the radix partitioned hash table)
+	unique_ptr<AggregatePayloadHeap> payload_heap;
 
 	//! Append state
 	struct AggregateHTAppendState {

--- a/src/include/duckdb/execution/aggregate_payload_heap.hpp
+++ b/src/include/duckdb/execution/aggregate_payload_heap.hpp
@@ -1,0 +1,63 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/execution/aggregate_payload_heap.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/mutex.hpp"
+#include "duckdb/storage/buffer_manager.hpp"
+
+namespace duckdb {
+
+//! Handle to a string payload stored on a registered payload block
+struct AggregatePayloadHandle {
+	uint32_t block_idx;
+	uint32_t offset;
+	uint32_t length;
+};
+
+//! Shared registry of buffer-managed blocks holding string payloads owned by aggregate states.
+//! Blocks are unpinned once full, so the buffer manager can offload them to temporary storage
+//! instead of failing the query when the payloads exceed the memory limit.
+class AggregatePayloadRegistry {
+public:
+	explicit AggregatePayloadRegistry(BufferManager &buffer_manager);
+
+	//! Register a block, returns its index
+	uint32_t RegisterBlock(shared_ptr<BlockHandle> block);
+	//! Pin a registered block for reading
+	BufferHandle PinBlock(uint32_t block_idx);
+
+public:
+	BufferManager &buffer_manager;
+
+private:
+	mutex lock;
+	vector<shared_ptr<BlockHandle>> blocks;
+};
+
+//! Per-thread writer over the shared registry. Only the block currently being written stays pinned.
+class AggregatePayloadHeap {
+public:
+	explicit AggregatePayloadHeap(AggregatePayloadRegistry &registry);
+
+	//! Append a payload, the returned handle stays valid for the registry's lifetime
+	AggregatePayloadHandle Append(const char *data, uint32_t length);
+	//! Pin the block of a handle and return a pointer to the payload (valid while the pin is held)
+	const char *Read(const AggregatePayloadHandle &handle, BufferHandle &pin);
+
+public:
+	AggregatePayloadRegistry &registry;
+
+private:
+	BufferHandle current_pin;
+	uint32_t current_block_idx = 0;
+	idx_t current_offset = 0;
+	idx_t current_capacity = 0;
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/execution/aggregate_payload_heap.hpp
+++ b/src/include/duckdb/execution/aggregate_payload_heap.hpp
@@ -47,8 +47,9 @@ public:
 
 	//! Append a payload, the returned handle stays valid for the registry's lifetime
 	AggregatePayloadHandle Append(const char *data, uint32_t length);
-	//! Pin the block of a handle and return a pointer to the payload (valid while the pin is held)
-	const char *Read(const AggregatePayloadHandle &handle, BufferHandle &pin);
+	//! Read a payload (valid until the next Read or Append on this heap).
+	//! Subsequent reads mostly hit the same block, so the pin of the last read block is cached.
+	const char *Read(const AggregatePayloadHandle &handle);
 
 public:
 	AggregatePayloadRegistry &registry;
@@ -58,6 +59,10 @@ private:
 	uint32_t current_block_idx = 0;
 	idx_t current_offset = 0;
 	idx_t current_capacity = 0;
+	//! Cached pin of the block last read from
+	BufferHandle read_pin;
+	uint32_t read_block_idx = 0;
+	bool read_pin_valid = false;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/execution/operator/aggregate/aggregate_object.hpp
+++ b/src/include/duckdb/execution/operator/aggregate/aggregate_object.hpp
@@ -41,6 +41,8 @@ struct AggregateObject { // NOLINT: work-around bug in clang-tidy
 	AggregateType aggr_type;
 	PhysicalType return_type;
 	optional_ptr<const Expression> filter = nullptr;
+	//! Exported states are read as raw bytes, so their payloads cannot live on a payload heap
+	AggregateStateExportMode state_export_mode = AggregateStateExportMode::NONE;
 
 public:
 	bool IsDistinct() const {

--- a/src/include/duckdb/function/aggregate_state.hpp
+++ b/src/include/duckdb/function/aggregate_state.hpp
@@ -18,6 +18,7 @@
 
 namespace duckdb {
 class BoundAggregateFunction;
+class AggregatePayloadHeap;
 struct AggregateObject;
 
 enum class AggregateType : uint8_t { NON_DISTINCT = 1, DISTINCT = 2 };
@@ -49,6 +50,8 @@ struct AggregateInputData {
 	AggregateCombineType combine_type;
 	optional_ptr<const ClusteredAggr> clustered;
 	optional_ptr<const Vector> combine_multiplicities;
+	//! Spillable heap for state-owned string payloads (set by the hash aggregate)
+	optional_ptr<AggregatePayloadHeap> payload_heap;
 };
 
 //! Input to the get_state_type callback - bundles the bound aggregate function with its bind data so that the

--- a/test/sql/aggregate/aggregates/export_state_wide_payload.test
+++ b/test/sql/aggregate/aggregates/export_state_wide_payload.test
@@ -1,0 +1,31 @@
+# name: test/sql/aggregate/aggregates/export_state_wide_payload.test
+# description: Exported aggregate states must survive parallel combines of wide string payloads
+# group: [aggregates]
+
+statement ok
+SET threads=4;
+
+statement ok
+PRAGMA verify_parallelism;
+
+statement ok
+CREATE TABLE input AS
+SELECT i % 10000 AS g, repeat(md5((i % 10000)::VARCHAR), 10) AS s
+FROM range(1000000) t(i);
+
+# every row of a group carries the same value, so any combine order must produce it exactly
+query I
+SELECT count(*)
+FROM (
+	SELECT g,
+	       finalize(first(s) EXPORT_STATE) AS f,
+	       finalize(last(s) EXPORT_STATE) AS l,
+	       finalize(any_value(s) EXPORT_STATE) AS a
+	FROM input
+	GROUP BY g
+) grouped
+WHERE f <> repeat(md5(g::VARCHAR), 10)
+   OR l <> repeat(md5(g::VARCHAR), 10)
+   OR a <> repeat(md5(g::VARCHAR), 10);
+----
+0

--- a/test/sql/aggregate/aggregates/first_wide_payload_spill.test_slow
+++ b/test/sql/aggregate/aggregates/first_wide_payload_spill.test_slow
@@ -1,0 +1,43 @@
+# name: test/sql/aggregate/aggregates/first_wide_payload_spill.test_slow
+# description: Wide VARCHAR payloads retained per group must spill instead of failing under a memory limit
+# group: [aggregates]
+
+require skip_reload
+
+statement ok
+SET memory_limit='256MB';
+
+statement ok
+SET temp_directory='__TEST_DIR__/first_wide_payload_spill';
+
+statement ok
+SET preserve_insertion_order=false;
+
+# 1M groups x 800 byte payloads is roughly 800MB of state payloads, far above the limit
+query I
+SELECT count(wide) FROM (
+    SELECT DISTINCT ON (k) k, wide
+    FROM (SELECT i AS k, repeat(md5(i::VARCHAR), 25) AS wide FROM range(1000000) t(i)) s1
+) s2;
+----
+1000000
+
+# The payloads must round-trip through the spill intact
+query III
+SELECT count(*), min(strlen(wide)), max(strlen(wide)) FROM (
+    SELECT DISTINCT ON (k) k, wide
+    FROM (SELECT i AS k, repeat(md5(i::VARCHAR), 25) AS wide FROM range(1000000) t(i)) s1
+) s2;
+----
+1000000	800	800
+
+# Spot check exact values survive
+query I
+SELECT count(*) FROM (
+    SELECT k, first(wide) AS w
+    FROM (SELECT i % 100000 AS k, repeat(md5((i % 100000)::VARCHAR), 25) AS wide FROM range(1000000) t(i)) s1
+    GROUP BY k
+) s2
+WHERE w != repeat(md5(k::VARCHAR), 25);
+----
+0


### PR DESCRIPTION
`DISTINCT ON (k)` over wide VARCHAR columns compiles to a hash aggregate with `first(col)` per payload column. The string states copy each retained value into the hash table's arena allocator and keep a raw pointer. Those arenas are tracked against the memory limit but live outside the spillable page layout: they cannot be offloaded, cannot be relocated, and `Combine` chains every thread local arena's lifetime to the end of the query. With many groups and wide payloads, tracked but unreclaimable memory grows until allocation fails, while the temporary directory sits unused.

The asymmetry is easy to reproduce. The same 3.2 GB of strings (4M groups x 800 bytes) under a 1 GB memory limit:

| the same strings, in a different role | result |
|---|---|
| as group keys (`GROUP BY k, wide`) | succeeds by spilling |
| as fixed size payloads (`first(hash)`) | succeeds |
| as `first(wide)` state payloads (`DISTINCT ON`) | `Out of Memory Error` at 952.3/953.6 MiB |

This PR adds a payload heap for state owned strings: buffer managed blocks shared per hash aggregate through a registry, where only the block currently being written stays pinned. Full blocks are unpinned, so the buffer manager can offload them to temporary storage under pressure, exactly like the rest of the aggregation's intermediates. States store a `(block, offset, length)` handle instead of a pointer, and materialize under a short lived pin at finalize.

With this, the failing query above completes at the same 1 GB limit, with 2.29 GB observed moving through the temporary directory at peak.

It is also faster in memory. `Combine` copies a 16 byte handle instead of re-copying the payload through a fresh arena allocation for every group, and appends are bump allocations into 256 KiB blocks instead of per string tracked allocations with power of two rounding. On the included `first_wide_payload` benchmark, measured with alternating runs and rebuilds between states to cancel machine drift:

| benchmark | main | this PR |
|---|---|---|
| `first_wide_payload` (in memory) | 3.13 s | 0.59 s (5.3x) |
| same query at a 1 GB limit | fails | ~14 s, no cliff |

Decisions that came out of measuring rather than guessing:
- Reads cache the pin of the last read block; states finalize in insertion order, so nearly all reads hit the cache (this alone was worth 1.6x on the finalize path)
- Payloads under 32 bytes stay on the arena: they pin little memory per group and the indirection costs more than it saves (`any_value` over UUIDs regressed 33% without this and is at parity with it)
- `last()` stays on the arena: it overwrites its value for every row, which would keep appending garbage to the heap; its pathological case (few groups, many rows) is exactly the case where the arena is memory safe
- Aggregates bound with `EXPORT_STATE` stay on the arena, since exported states are read as raw bytes (`AggregateObject` now carries the export mode so the hash aggregate can tell)

Verification:
- Full fast test suite: 4828 test cases, 986230 assertions, all pass
- Aggregate suite under a `FORCE_ASSERT` build: all pass
- All 19 existing aggregate micro benchmarks A/B against main: flat within noise
- New regression test `first_wide_payload_spill.test_slow` locks the spill behavior (1M groups x 800 bytes under a 256 MB limit, verifying counts, lengths, and exact values through the spill)

Scope and follow ups: this covers `first`, `any_value`, and the sort key state used for arbitrary types. `min`, `max`, `arg_min`, `arg_max`, and `string_agg` hold state payloads the same way and can adopt the heap with the same pattern; heap block compaction would let `last()` join too. Happy to do those as follow ups.
