### PR TITLE
Use optimized checkout action and simplify CI workflows

### DIFF
--- a/.github/workflows/Extensions.yml
+++ b/.github/workflows/Extensions.yml
@@ -30,6 +30,10 @@ on:
       runners:
         type: string
         required: true
+      runner_provider:
+        type: string
+        required: false
+        default: ''
       save_cache:
         type: boolean
         required: false
@@ -73,6 +77,11 @@ on:
         type: string
         required: false
         default: '{}'
+      runner_provider:
+        description: 'Runner provider for duckdb-ci checkout when using Namespace runners'
+        type: string
+        required: false
+        default: ''
       save_cache:
         description: 'Override whether extension build caches should be saved'
         type: boolean
@@ -219,9 +228,11 @@ jobs:
     needs:
       - extensions-build
     steps:
-      - uses: actions/checkout@v6
+      - name: "Checkout"
+        uses: duckdb/duckdb-ci/.github/actions/checkout@main
         with:
-          fetch-depth: 0
+          runner_provider: ${{ inputs.runner_provider || (startsWith(fromJSON(inputs.runners).linux_x64 || 'ubuntu-latest', 'namespace-profile-') && 'namespace' || 'github') }}
+          fetch_depth: 0
           ref: ${{ inputs.git_ref }}
 
       - uses: ./.github/actions/ccache-action

--- a/.github/workflows/Extensions.yml
+++ b/.github/workflows/Extensions.yml
@@ -32,8 +32,7 @@ on:
         required: true
       runner_provider:
         type: string
-        required: false
-        default: ''
+        required: true
       save_cache:
         type: boolean
         required: false
@@ -181,7 +180,7 @@ jobs:
       - name: "Checkout"
         uses: duckdb/duckdb-ci/.github/actions/checkout@main
         with:
-          runner_provider: ${{ inputs.runner_provider || (startsWith(fromJSON(inputs.runners).linux_x64 || 'ubuntu-latest', 'namespace-profile-') && 'namespace' || 'github') }}
+          runner_provider: ${{ inputs.runner_provider }}
           fetch_depth: 0
           ref: ${{ inputs.git_ref }}
 

--- a/.github/workflows/Extensions.yml
+++ b/.github/workflows/Extensions.yml
@@ -38,56 +38,6 @@ on:
         type: boolean
         required: false
         default: false
-  workflow_dispatch:
-    inputs:
-      override_git_describe:
-        description: 'Version tag to override git describe. Use to produce binaries'
-        type: string
-      git_ref:
-        description: 'Set to override the DuckDB version, leave empty for current commit'
-        type: string
-        required: false
-        default: ''
-      extra_exclude_archs:
-        description: 'Inject more architectures to skip'
-        type: string
-        required: false
-        default: ''
-      opt_in_archs:
-        description: 'Semicolon-separated list of architectures to opt into'
-        type: string
-        required: false
-        default: 'windows_arm64;'
-      skip_tests:
-        description: 'Set to true to skip all testing'
-        type: boolean
-        required: false
-        default: false
-      run_all:
-        type: boolean
-        required: false
-        default: true
-      run_disk_clean_step:
-        description: 'Disabling this can result in faster builds, but may run out of space on some runners'
-        type: boolean
-        required: false
-        default: true
-      runners:
-        description: 'JSON object with runner labels, e.g. {"linux_x64":"ubuntu-latest","linux_22_x64":"ubuntu-22.04","linux_arm64":"ubuntu-24.04-arm"}'
-        type: string
-        required: false
-        default: '{}'
-      runner_provider:
-        description: 'Runner provider for duckdb-ci checkout when using Namespace runners'
-        type: string
-        required: false
-        default: ''
-      save_cache:
-        description: 'Override whether extension build caches should be saved'
-        type: boolean
-        required: false
-        default: false
-
 concurrency:
   group: extensions-${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}-${{ inputs.override_git_describe }}
   cancel-in-progress: true

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -323,8 +323,10 @@ jobs:
     runs-on: ${{ needs.prepare.outputs.runner_linux_x64 }}
 
     steps:
-    - uses: actions/checkout@v6
+    - name: "Checkout"
+      uses: duckdb/duckdb-ci/.github/actions/checkout@main
       with:
+        runner_provider: ${{ needs.prepare.outputs.runner_provider }}
         ref: ${{ needs.prepare.outputs.git_sha }}
     - name: Install tools
       timeout-minutes: 10
@@ -368,6 +370,7 @@ jobs:
       run_slow_tests: ${{ needs.prepare.outputs.run_slow_tests == 'true' }}
       runner_linux_x64: ${{ needs.prepare.outputs.runner_linux_x64 }}
       runner_linux_small: ${{ needs.prepare.outputs.runner_linux_small }}
+      runner_provider: ${{ needs.prepare.outputs.runner_provider }}
       save_cache: ${{ fromJson(needs.prepare.outputs.save_cache) }}
 
  tidy-check:
@@ -382,9 +385,11 @@ jobs:
       CLANGD_BINARY: clangd-20
 
     steps:
-    - uses: actions/checkout@v6
+    - name: "Checkout"
+      uses: duckdb/duckdb-ci/.github/actions/checkout@main
       with:
-        fetch-depth: 0
+        runner_provider: ${{ needs.prepare.outputs.runner_provider }}
+        fetch_depth: 0
         ref: ${{ needs.prepare.outputs.git_sha }}
 
     - name: Install
@@ -426,6 +431,7 @@ jobs:
       run_all: ${{ github.event_name != 'workflow_dispatch' || inputs.run_all }}
       opt_in_archs: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch') && 'windows_arm64;linux_amd64_musl;linux_arm64_musl' || '' }}
       runners: ${{ needs.prepare.outputs.runners }}
+      runner_provider: ${{ needs.prepare.outputs.runner_provider }}
       save_cache: ${{ fromJson(needs.prepare.outputs.save_cache) }}
 
  wasm-eh:
@@ -439,8 +445,10 @@ jobs:
       GEN: make
 
     steps:
-    - uses: actions/checkout@v6
+    - name: "Checkout"
+      uses: duckdb/duckdb-ci/.github/actions/checkout@main
       with:
+        runner_provider: ${{ needs.prepare.outputs.runner_provider }}
         ref: ${{ needs.prepare.outputs.git_sha }}
 
     - uses: emscripten-core/setup-emsdk@v16
@@ -626,11 +634,12 @@ jobs:
       OVERRIDE_GIT_DESCRIBE: ${{ needs.prepare.outputs.effective_git_describe }}
 
     steps:
-    - uses: actions/checkout@v6
+    - name: "Checkout"
+      uses: duckdb/duckdb-ci/.github/actions/checkout@main
       with:
+        runner_provider: ${{ needs.prepare.outputs.runner_provider }}
         ref: ${{ needs.prepare.outputs.git_sha }}
-        fetch-depth: 0
-        fetch-tags: true
+        fetch_depth: 0
 
     - name: Install tools
       timeout-minutes: 10
@@ -734,8 +743,10 @@ jobs:
     runs-on: ${{ needs.prepare.outputs.runner_linux_x64 }}
 
     steps:
-    - uses: actions/checkout@v6
+    - name: "Checkout"
+      uses: duckdb/duckdb-ci/.github/actions/checkout@main
       with:
+        runner_provider: ${{ needs.prepare.outputs.runner_provider }}
         ref: ${{ needs.prepare.outputs.git_sha }}
 
     - name: Check staged extension install/load
@@ -761,11 +772,12 @@ jobs:
       OVERRIDE_GIT_DESCRIBE: ${{ needs.prepare.outputs.effective_git_describe }}
 
     steps:
-    - uses: actions/checkout@v6
+    - name: "Checkout"
+      uses: duckdb/duckdb-ci/.github/actions/checkout@main
       with:
+        runner_provider: ${{ needs.prepare.outputs.runner_provider }}
         ref: ${{ needs.prepare.outputs.git_sha }}
-        fetch-depth: 0
-        fetch-tags: true
+        fetch_depth: 0
 
     - name: Install tools
       timeout-minutes: 10
@@ -933,6 +945,7 @@ jobs:
     with:
       git_ref: ${{ needs.prepare.outputs.git_sha }}
       runner_macos_arm64: ${{ needs.prepare.outputs.runner_macos_14_arm64 }}
+      runner_provider: ${{ needs.prepare.outputs.runner_provider }}
 
  windows:
     if: ${{ contains(fromJson(needs.prepare.outputs.enabled_jobs), 'windows') }}
@@ -945,6 +958,7 @@ jobs:
       override_git_describe: ${{ needs.prepare.outputs.effective_git_describe }}
       git_ref: ${{ needs.prepare.outputs.git_sha }}
       runners: ${{ needs.prepare.outputs.runners }}
+      runner_provider: ${{ needs.prepare.outputs.runner_provider }}
       skip_tests: ${{ fromJson(needs.prepare.outputs.skip_tests) }}
       run_all: ${{ github.event_name != 'workflow_dispatch' || inputs.run_all }}
 
@@ -980,9 +994,11 @@ jobs:
       GEN: ninja
 
     steps:
-      - uses: actions/checkout@v6
+      - name: "Checkout"
+        uses: duckdb/duckdb-ci/.github/actions/checkout@main
         with:
-          fetch-depth: 0
+          runner_provider: ${{ needs.prepare.outputs.runner_provider }}
+          fetch_depth: 0
           ref: ${{ needs.prepare.outputs.git_sha }}
 
       - name: Install dependencies
@@ -1211,8 +1227,10 @@ jobs:
       DUCKDB_TEST_DESCRIPTION: 'Compiled with ALTERNATIVE_VERIFY=1 DISABLE_STRING_INLINE=1 DESTROY_UNPINNED_BLOCKS=1 DISABLE_POINTER_SALT=1. Use require no_alternative_verify to skip.'
 
     steps:
-      - uses: actions/checkout@v6
+      - name: "Checkout"
+        uses: duckdb/duckdb-ci/.github/actions/checkout@main
         with:
+          runner_provider: ${{ needs.prepare.outputs.runner_provider }}
           ref: ${{ needs.prepare.outputs.git_sha }}
 
       - name: Install
@@ -1263,8 +1281,10 @@ jobs:
       DUCKDB_TEST_DESCRIPTION: 'Compiled with STANDARD_VECTOR_SIZE=2. Use require vector_size 2048 to skip tests.'
 
     steps:
-      - uses: actions/checkout@v6
+      - name: "Checkout"
+        uses: duckdb/duckdb-ci/.github/actions/checkout@main
         with:
+          runner_provider: ${{ needs.prepare.outputs.runner_provider }}
           ref: ${{ needs.prepare.outputs.git_sha }}
 
       - name: Install
@@ -1296,8 +1316,10 @@ jobs:
       DUCKDB_TEST_DESCRIPTION: 'Tests run with thread sanitizer.'
 
     steps:
-    - uses: actions/checkout@v6
+    - name: "Checkout"
+      uses: duckdb/duckdb-ci/.github/actions/checkout@main
       with:
+        runner_provider: ${{ needs.prepare.outputs.runner_provider }}
         ref: ${{ needs.prepare.outputs.git_sha }}
 
     - name: Install
@@ -1340,8 +1362,10 @@ jobs:
       - linux-release
 
     steps:
-    - uses: actions/checkout@v6
+    - name: "Checkout"
+      uses: duckdb/duckdb-ci/.github/actions/checkout@main
       with:
+        runner_provider: ${{ needs.prepare.outputs.runner_provider }}
         ref: ${{ needs.prepare.outputs.git_sha }}
 
     - uses: actions/setup-python@v6

--- a/.github/workflows/OSX.yml
+++ b/.github/workflows/OSX.yml
@@ -10,18 +10,6 @@ on:
         type: boolean
       run_all:
         type: boolean
-  workflow_dispatch:
-    inputs:
-      override_git_describe:
-        type: string
-      git_ref:
-        type: string
-      skip_tests:
-        type: boolean
-        default: false
-      run_all:
-        type: boolean
-        default: true
   push:
     branches-ignore:
       - 'main'

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -24,8 +24,6 @@ on:
       save_cache:
         default: false
         type: boolean
-  repository_dispatch:
-
 concurrency:
   group: regression-${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}
   cancel-in-progress: true

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -18,6 +18,9 @@ on:
       runner_linux_small:
         default: ubuntu-latest
         type: string
+      runner_provider:
+        default: ''
+        type: string
       save_cache:
         default: false
         type: boolean
@@ -45,6 +48,10 @@ on:
         description: 'Optional small runner label override'
         default: ubuntu-latest
         type: string
+      runner_provider:
+        description: 'Runner provider for duckdb-ci checkout when using Namespace runners'
+        default: ''
+        type: string
       save_cache:
         default: false
         type: boolean
@@ -68,9 +75,11 @@ jobs:
       GEN: ninja
 
     steps:
-      - uses: actions/checkout@v6
+      - name: "Checkout"
+        uses: duckdb/duckdb-ci/.github/actions/checkout@main
         with:
-          fetch-depth: 0
+          runner_provider: ${{ inputs.runner_provider || (startsWith(inputs.runner_linux_x64, 'namespace-profile-') && 'namespace' || 'github') }}
+          fetch_depth: 0
           ref: ${{ env.GIT_REF }}
 
       - name: Install tools
@@ -237,8 +246,10 @@ jobs:
             benchmarks: .github/regression/tpcds_sf3.csv
 
     steps:
-      - uses: actions/checkout@v6
+      - name: "Checkout"
+        uses: duckdb/duckdb-ci/.github/actions/checkout@main
         with:
+          runner_provider: namespace
           ref: ${{ env.GIT_REF }}
 
       - name: Install
@@ -380,8 +391,10 @@ jobs:
       EXTENSION_STATIC_BUILD: 1
 
     steps:
-      - uses: actions/checkout@v6
+      - name: "Checkout"
+        uses: duckdb/duckdb-ci/.github/actions/checkout@main
         with:
+          runner_provider: ${{ inputs.runner_provider || (startsWith(inputs.runner_linux_small, 'namespace-profile-') && 'namespace' || 'github') }}
           ref: ${{ env.GIT_REF }}
 
       - name: Install

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -24,37 +24,6 @@ on:
       save_cache:
         default: false
         type: boolean
-  workflow_dispatch:
-    inputs:
-      git_ref:
-        description: 'Git ref to test for current release'
-        type: string
-      base_hash:
-        description: 'Base hash'
-        type: string
-      build_current_release:
-        description: 'Build and upload linux-release-build in this workflow'
-        default: true
-        type: boolean
-      run_slow_tests:
-        description: 'Run slow tests when applicable'
-        default: false
-        type: boolean
-      runner_linux_x64:
-        description: 'Optional x64 runner label override'
-        default: ubuntu-latest
-        type: string
-      runner_linux_small:
-        description: 'Optional small runner label override'
-        default: ubuntu-latest
-        type: string
-      runner_provider:
-        description: 'Runner provider for duckdb-ci checkout when using Namespace runners'
-        default: ''
-        type: string
-      save_cache:
-        default: false
-        type: boolean
   repository_dispatch:
 
 concurrency:

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -19,7 +19,7 @@ on:
         default: ubuntu-latest
         type: string
       runner_provider:
-        default: ''
+        required: true
         type: string
       save_cache:
         default: false
@@ -45,7 +45,7 @@ jobs:
       - name: "Checkout"
         uses: duckdb/duckdb-ci/.github/actions/checkout@main
         with:
-          runner_provider: ${{ inputs.runner_provider || (startsWith(inputs.runner_linux_x64, 'namespace-profile-') && 'namespace' || 'github') }}
+          runner_provider: ${{ inputs.runner_provider }}
           fetch_depth: 0
           ref: ${{ env.GIT_REF }}
 
@@ -361,7 +361,7 @@ jobs:
       - name: "Checkout"
         uses: duckdb/duckdb-ci/.github/actions/checkout@main
         with:
-          runner_provider: ${{ inputs.runner_provider || (startsWith(inputs.runner_linux_small, 'namespace-profile-') && 'namespace' || 'github') }}
+          runner_provider: ${{ inputs.runner_provider }}
           ref: ${{ env.GIT_REF }}
 
       - name: Install

--- a/.github/workflows/Swift.yml
+++ b/.github/workflows/Swift.yml
@@ -7,7 +7,7 @@ on:
       runner_macos_arm64:
         type: string
       runner_provider:
-        default: ''
+        required: true
         type: string
 concurrency:
   group: swift-${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}
@@ -37,13 +37,13 @@ jobs:
       - name: Checkout
         uses: duckdb/duckdb-ci/.github/actions/checkout@main
         with:
-          runner_provider: ${{ inputs.runner_provider || (startsWith(inputs.runner_macos_arm64 || 'macos-14', 'namespace-profile-') && 'namespace' || 'github') }}
+          runner_provider: ${{ inputs.runner_provider }}
           # we need tags for the ubiquity build script to run without errors
           fetch_depth: '0'
           ref: ${{ inputs.git_ref != '' && inputs.git_ref || github.sha }}
 
       - name: Configure Xcode Caching
-        if: ${{ startsWith(inputs.runner_macos_arm64 || 'macos-14', 'namespace-profile-') }}
+        if: ${{ inputs.runner_provider == 'namespace' }}
         uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: |

--- a/.github/workflows/Swift.yml
+++ b/.github/workflows/Swift.yml
@@ -9,8 +9,6 @@ on:
       runner_provider:
         default: ''
         type: string
-  repository_dispatch:
-
 concurrency:
   group: swift-${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}
   cancel-in-progress: true

--- a/.github/workflows/Swift.yml
+++ b/.github/workflows/Swift.yml
@@ -6,9 +6,16 @@ on:
         type: string
       runner_macos_arm64:
         type: string
+      runner_provider:
+        default: ''
+        type: string
   workflow_dispatch:
     inputs:
       git_ref:
+        type: string
+      runner_provider:
+        description: 'Runner provider for duckdb-ci checkout when using Namespace runners'
+        default: ''
         type: string
   repository_dispatch:
 
@@ -38,10 +45,11 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: duckdb/duckdb-ci/.github/actions/checkout@main
         with:
+          runner_provider: ${{ inputs.runner_provider || (startsWith(inputs.runner_macos_arm64 || 'macos-14', 'namespace-profile-') && 'namespace' || 'github') }}
           # we need tags for the ubiquity build script to run without errors
-          fetch-depth: '0'
+          fetch_depth: '0'
           ref: ${{ inputs.git_ref != '' && inputs.git_ref || github.sha }}
 
       - name: Configure Xcode Caching

--- a/.github/workflows/Swift.yml
+++ b/.github/workflows/Swift.yml
@@ -9,14 +9,6 @@ on:
       runner_provider:
         default: ''
         type: string
-  workflow_dispatch:
-    inputs:
-      git_ref:
-        type: string
-      runner_provider:
-        description: 'Runner provider for duckdb-ci checkout when using Namespace runners'
-        default: ''
-        type: string
   repository_dispatch:
 
 concurrency:

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -14,7 +14,7 @@ on:
         type: string
       runner_provider:
         type: string
-        default: ''
+        required: true
 concurrency:
   group: windows-${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}-${{ inputs.override_git_describe }}
   cancel-in-progress: true
@@ -37,7 +37,7 @@ jobs:
     - name: "Checkout"
       uses: duckdb/duckdb-ci/.github/actions/checkout@main
       with:
-        runner_provider: ${{ inputs.runner_provider || (startsWith(fromJSON(inputs.runners).windows_2022_x64 || 'windows-2022', 'namespace-profile-') && 'namespace' || 'github') }}
+        runner_provider: ${{ inputs.runner_provider }}
         fetch_depth: 0
         ref: ${{ inputs.git_ref }}
 
@@ -146,7 +146,7 @@ jobs:
     - name: "Checkout"
       uses: duckdb/duckdb-ci/.github/actions/checkout@main
       with:
-        runner_provider: ${{ inputs.runner_provider || (startsWith(fromJSON(inputs.runners).windows_2022_x64 || 'windows-2022', 'namespace-profile-') && 'namespace' || 'github') }}
+        runner_provider: ${{ inputs.runner_provider }}
         fetch_depth: 0
         ref: ${{ inputs.git_ref }}
 
@@ -262,7 +262,7 @@ jobs:
        - name: "Checkout"
          uses: duckdb/duckdb-ci/.github/actions/checkout@main
          with:
-           runner_provider: ${{ inputs.runner_provider || (startsWith(fromJSON(inputs.runners).windows_2022_x64 || 'windows-2022', 'namespace-profile-') && 'namespace' || 'github') }}
+           runner_provider: ${{ inputs.runner_provider }}
            ref: ${{ inputs.git_ref }}
 
        - uses: actions/setup-python@v6

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -12,6 +12,9 @@ on:
         type: boolean
       runners:
         type: string
+      runner_provider:
+        type: string
+        default: ''
   workflow_dispatch:
     inputs:
       override_git_describe:
@@ -29,6 +32,11 @@ on:
         type: string
         required: false
         default: '{}'
+      runner_provider:
+        description: 'Runner provider for duckdb-ci checkout when using Namespace runners'
+        type: string
+        required: false
+        default: ''
 
 concurrency:
   group: windows-${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}-${{ inputs.override_git_describe }}
@@ -49,9 +57,11 @@ jobs:
     env:
       GEN: ninja
     steps:
-    - uses: actions/checkout@v6
+    - name: "Checkout"
+      uses: duckdb/duckdb-ci/.github/actions/checkout@main
       with:
-        fetch-depth: 0
+        runner_provider: ${{ inputs.runner_provider || (startsWith(fromJSON(inputs.runners).windows_2022_x64 || 'windows-2022', 'namespace-profile-') && 'namespace' || 'github') }}
+        fetch_depth: 0
         ref: ${{ inputs.git_ref }}
 
     - uses: actions/setup-python@v6
@@ -156,9 +166,11 @@ jobs:
       GEN: ninja
 
     steps:
-    - uses: actions/checkout@v6
+    - name: "Checkout"
+      uses: duckdb/duckdb-ci/.github/actions/checkout@main
       with:
-        fetch-depth: 0
+        runner_provider: ${{ inputs.runner_provider || (startsWith(fromJSON(inputs.runners).windows_2022_x64 || 'windows-2022', 'namespace-profile-') && 'namespace' || 'github') }}
+        fetch_depth: 0
         ref: ${{ inputs.git_ref }}
 
     - uses: actions/setup-python@v6
@@ -270,8 +282,10 @@ jobs:
        ENABLE_EXTENSION_AUTOLOADING: 1
        ENABLE_EXTENSION_AUTOINSTALL: 1
      steps:
-       - uses: actions/checkout@v6
+       - name: "Checkout"
+         uses: duckdb/duckdb-ci/.github/actions/checkout@main
          with:
+           runner_provider: ${{ inputs.runner_provider || (startsWith(fromJSON(inputs.runners).windows_2022_x64 || 'windows-2022', 'namespace-profile-') && 'namespace' || 'github') }}
            ref: ${{ inputs.git_ref }}
 
        - uses: actions/setup-python@v6

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -15,29 +15,6 @@ on:
       runner_provider:
         type: string
         default: ''
-  workflow_dispatch:
-    inputs:
-      override_git_describe:
-        type: string
-      git_ref:
-        type: string
-      skip_tests:
-        type: boolean
-        default: false
-      run_all:
-        type: boolean
-        default: true
-      runners:
-        description: 'JSON object with runner labels, e.g. {"windows_2022_x64":"windows-2022","linux_slim":"ubuntu-latest"}'
-        type: string
-        required: false
-        default: '{}'
-      runner_provider:
-        description: 'Runner provider for duckdb-ci checkout when using Namespace runners'
-        type: string
-        required: false
-        default: ''
-
 concurrency:
   group: windows-${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}-${{ inputs.override_git_describe }}
   cancel-in-progress: true

--- a/test/sql/pragma/test_pragma_version.test
+++ b/test/sql/pragma/test_pragma_version.test
@@ -37,7 +37,7 @@ statement ok
 SET VARIABLE v_or_latest = (select CASE WHEN getvariable('v') ILIKE 'v%-dev%' THEN 'latest' WHEN getvariable('v') ILIKE 'v%-alpha%' THEN 'latest' WHEN getvariable('v') ILIKE 'v0.0.1' THEN 'latest' ELSE getvariable('v') END);
 
 statement ok
-SET VARIABLE codename = (select CASE WHEN getvariable('v') ILIKE 'v%-dev%' THEN 'Development Version' WHEN getvariable('v') ILIKE 'v%-alpha%' THEN 'Development Version' WHEN getvariable('v') ILIKE 'v0.0.1' THEN 'Unknown Version' ELSE '%' END);
+SET VARIABLE codename = (select CASE WHEN getvariable('v') ILIKE 'v%-dev%' THEN 'Development Version' WHEN getvariable('v') ILIKE 'v0.0.1' THEN 'Unknown Version' ELSE '%' END);
 
 query I
 select count(*) FROM (select codename from pragma_version() WHERE codename LIKE getvariable('codename'));


### PR DESCRIPTION
- Use namespace optimized checkout action if applicable. Only works on namespace runners.
- Remove `workflow_dispatch` and `repository_dispatch` for non-reachable, nested CI workflows.
- Make `runner_provider` a required input parameter and simplify expressions.
- Fix SQL test for alpha version release ([failed](https://github.com/duckdb/duckdb/actions/runs/29881484475/job/88803238572) on main). This was a leftover from #23649.