### PR TITLE
Windows CLI: opt into the Segment Heap via application manifest (~2.2x faster multi-threaded materialization)

### DIFF
--- a/tools/shell/CMakeLists.txt
+++ b/tools/shell/CMakeLists.txt
@@ -75,9 +75,9 @@ if(WIN32 AND NOT MINGW)
   set(CMAKE_RC_FLAGS
       "${CMAKE_RC_FLAGS} -D DUCKDB_COPYRIGHT_YEAR=\"${DUCKDB_COPYRIGHT_YEAR}\"")
   target_sources(shell PRIVATE rc/duckdb.rc)
-  # Opt into the Windows Segment Heap: the default NT heap serializes
-  # multi-threaded allocation, making parallel workloads ~2x slower (#24027).
-  # CMake merges .manifest sources into the linker manifest via mt.exe.
+  # Opt into the Windows Segment Heap to avoid the default NT heap's lock
+  # contention under multi-threaded allocation (see #24027). CMake merges
+  # .manifest sources into the linker manifest via mt.exe.
   target_sources(shell PRIVATE rc/duckdb.manifest)
 endif()
 

--- a/tools/shell/CMakeLists.txt
+++ b/tools/shell/CMakeLists.txt
@@ -75,6 +75,10 @@ if(WIN32 AND NOT MINGW)
   set(CMAKE_RC_FLAGS
       "${CMAKE_RC_FLAGS} -D DUCKDB_COPYRIGHT_YEAR=\"${DUCKDB_COPYRIGHT_YEAR}\"")
   target_sources(shell PRIVATE rc/duckdb.rc)
+  # Opt into the Windows Segment Heap: the default NT heap serializes
+  # multi-threaded allocation, making parallel workloads ~2x slower (#24027).
+  # CMake merges .manifest sources into the linker manifest via mt.exe.
+  target_sources(shell PRIVATE rc/duckdb.manifest)
 endif()
 
 set_target_properties(shell PROPERTIES OUTPUT_NAME duckdb)

--- a/tools/shell/rc/duckdb.manifest
+++ b/tools/shell/rc/duckdb.manifest
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Opt the shell into the Windows Segment Heap. The default (legacy) NT heap
+     serializes multi-threaded allocation; on parallel workloads dominated by
+     materialization this makes the CLI ~2x slower (see duckdb/duckdb#24027).
+     Ignored by Windows versions without Segment Heap support (pre-10 2004). -->
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <heapType xmlns="http://schemas.microsoft.com/SMI/2020/WindowsSettings">SegmentHeap</heapType>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/tools/shell/rc/duckdb.manifest
+++ b/tools/shell/rc/duckdb.manifest
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<!-- Opt the shell into the Windows Segment Heap. The default (legacy) NT heap
-     serializes multi-threaded allocation; on parallel workloads dominated by
-     materialization this makes the CLI ~2x slower (see duckdb/duckdb#24027).
-     Ignored by Windows versions without Segment Heap support (pre-10 2004). -->
+<!-- Opt the process into the Windows Segment Heap, avoiding the default
+     NT heap's lock contention under multi-threaded allocation (see #24027).
+     Ignored by Windows versions without Segment Heap support. -->
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>


### PR DESCRIPTION
Addresses the CLI side of #24027.

## What

Adds a `<heapType>SegmentHeap</heapType>` application-manifest entry to the Windows shell, opting the process into the Windows Segment Heap instead of the default (legacy) NT heap.

Two-file change: a new `tools/shell/rc/duckdb.manifest` plus one `target_sources` line in the existing `if(WIN32 AND NOT MINGW)` block. CMake's documented `.manifest`-source mechanism merges it into the linker-generated manifest via `mt.exe`, so the existing `trustInfo` section is preserved.

## Why

On multi-threaded workloads dominated by materialization (`CREATE TABLE AS` over wide joins), the legacy process heap's lock serializes DuckDB's allocation from the row-group append path (`Vector::Initialize` → `Allocator::DefaultAllocate` → `malloc` → `ntdll!RtlAllocateHeap` + `RtlEnterCriticalSection` — stack-sampling evidence in #24027). This is why the released CLI regresses past ~4 threads on that workload while the R client (whose host `Rscript.exe` already ships this manifest entry) keeps scaling.

Measured on the **released 1.5.4 Windows CLI**, changing nothing but the manifest (byte-identical binary otherwise), 6 wide `LEFT JOIN`s re-materializing an 8M-row table at 8 threads:

| binary | time |
|---|---:|
| official CLI (legacy heap) | 14.8–16.1 s |
| same binary, SegmentHeap manifest | **7.0–7.2 s** |

That matches R's 7.0–7.4 s on the identical workload. Full analysis, cross-checks (two from-source MinGW builds, Python wheel in a patched host, R DLL cross-hosted via ctypes) and the reproduction harness: #24027 and https://github.com/BragaD/duckdb-windows-msvc-scaling

## Notes

- The `heapType` element is ignored by Windows versions without Segment Heap support (pre-Windows 10 2004), so this is a no-op there.
- The Segment Heap has known trade-offs on some allocation patterns (Chromium famously enabled and reverted it), so it is worth validating against DuckDB's broader Windows benchmarks — on this workload the effect is uniformly positive across five different binaries.
- Verified by patching the manifest of the released `duckdb.exe` (mt-style merge result is equivalent); I don't have an MSVC toolchain available to exercise the CMake wiring locally, so relying on Windows CI for that.
- MinGW from-source builds are outside the touched block; they can embed the same manifest via `windres` if desired.
