### PR TITLE
Deduplicate JSON object keys in VARIANT casts

### DIFF
--- a/src/include/duckdb/function/cast/variant/json_to_variant.hpp
+++ b/src/include/duckdb/function/cast/variant/json_to_variant.hpp
@@ -37,6 +37,10 @@ public:
 	yyjson_doc *doc = nullptr;
 };
 
+static inline string_t GetString(yyjson_val *val) {
+	return string_t(unsafe_yyjson_get_str(val), NumericCast<uint32_t>(unsafe_yyjson_get_len(val)));
+}
+
 } // namespace
 
 template <bool WRITE_DATA, bool IGNORE_NULLS>
@@ -98,14 +102,13 @@ static bool ConvertJSONObject(yyjson_val *obj, ToVariantGlobalResultData &result
 	entries.reserve(iter.max);
 
 	while (auto key = yyjson_obj_iter_next(&iter)) {
-		auto key_string = string_t(yyjson_get_str(key), NumericCast<uint32_t>(unsafe_yyjson_get_len(key)));
-		auto existing_entry = key_to_entry.find(key_string);
+		auto key_string = GetString(key);
+		auto inserted_entry = key_to_entry.emplace(key_string, entries.size());
 		auto val = yyjson_obj_iter_get_val(key);
-		if (existing_entry == key_to_entry.end()) {
-			key_to_entry.emplace(key_string, entries.size());
+		if (inserted_entry.second) {
 			entries.push_back({key, val});
 		} else {
-			entries[existing_entry->second].value = val;
+			entries[inserted_entry.first->second].value = val;
 		}
 	}
 
@@ -132,14 +135,11 @@ static bool ConvertJSONObject(yyjson_val *obj, ToVariantGlobalResultData &result
 
 	//! Iterate over all the children in the Object
 	for (const auto &entry : entries) {
-		auto key = entry.key;
-		auto key_string = yyjson_get_str(key);
-		uint32_t key_string_len = NumericCast<uint32_t>(unsafe_yyjson_get_len(key));
+		auto key_string = GetString(entry.key);
 
 		if (WRITE_DATA) {
-			auto str = string_t(key_string, key_string_len);
 			auto keys_index = start_key_index++;
-			auto dictionary_index = result.GetOrCreateIndex(str);
+			auto dictionary_index = result.GetOrCreateIndex(key_string);
 
 			//! Set the keys_index
 			variant.keys_index_data[start_child_index] = keys_index;
@@ -155,14 +155,6 @@ static bool ConvertJSONObject(yyjson_val *obj, ToVariantGlobalResultData &result
 	}
 	return true;
 }
-
-namespace {
-
-static inline string_t GetString(yyjson_val *val) {
-	return string_t(unsafe_yyjson_get_str(val), NumericCast<uint32_t>(unsafe_yyjson_get_len(val)));
-}
-
-} // namespace
 
 template <bool WRITE_DATA>
 static bool ConvertJSONPrimitive(yyjson_val *val, ToVariantGlobalResultData &result, idx_t result_index, bool is_root) {

--- a/src/include/duckdb/function/cast/variant/json_to_variant.hpp
+++ b/src/include/duckdb/function/cast/variant/json_to_variant.hpp
@@ -86,6 +86,29 @@ static bool ConvertJSONObject(yyjson_val *obj, ToVariantGlobalResultData &result
 	yyjson_obj_iter iter;
 	yyjson_obj_iter_init(obj, &iter);
 
+	struct JSONObjectEntry {
+		yyjson_val *key;
+		yyjson_val *value;
+	};
+
+	// Maps object keys to their entry index.
+	string_map_t<idx_t> key_to_entry;
+	vector<JSONObjectEntry> entries;
+	key_to_entry.reserve(iter.max);
+	entries.reserve(iter.max);
+
+	while (auto key = yyjson_obj_iter_next(&iter)) {
+		auto key_string = string_t(yyjson_get_str(key), NumericCast<uint32_t>(unsafe_yyjson_get_len(key)));
+		auto existing_entry = key_to_entry.find(key_string);
+		auto val = yyjson_obj_iter_get_val(key);
+		if (existing_entry == key_to_entry.end()) {
+			key_to_entry.emplace(key_string, entries.size());
+			entries.push_back({key, val});
+		} else {
+			entries[existing_entry->second].value = val;
+		}
+	}
+
 	auto keys_offset_data = OffsetData::GetKeys(result.offsets);
 	auto children_offset_data = OffsetData::GetChildren(result.offsets);
 	auto values_offset_data = OffsetData::GetValues(result.offsets);
@@ -97,7 +120,7 @@ static bool ConvertJSONObject(yyjson_val *obj, ToVariantGlobalResultData &result
 	auto &variant = result.variant;
 	auto &children_list_entry = variant.children_data[result_index];
 	auto &keys_list_entry = variant.keys_data[result_index];
-	uint32_t count = NumericCast<uint32_t>(iter.max);
+	uint32_t count = NumericCast<uint32_t>(entries.size());
 	auto start_child_index = children_list_entry.offset + children_offset_data[result_index];
 	WriteContainerData<WRITE_DATA>(result.variant, result_index, blob_offset_data[result_index], count,
 	                               children_offset_data[result_index]);
@@ -108,8 +131,8 @@ static bool ConvertJSONObject(yyjson_val *obj, ToVariantGlobalResultData &result
 	keys_offset_data[result_index] += count;
 
 	//! Iterate over all the children in the Object
-	yyjson_val *key, *val;
-	while ((key = yyjson_obj_iter_next(&iter))) {
+	for (const auto &entry : entries) {
+		auto key = entry.key;
 		auto key_string = yyjson_get_str(key);
 		uint32_t key_string_len = NumericCast<uint32_t>(unsafe_yyjson_get_len(key));
 
@@ -125,7 +148,7 @@ static bool ConvertJSONObject(yyjson_val *obj, ToVariantGlobalResultData &result
 			result.keys_selvec.set_index(keys_list_entry.offset + keys_index, dictionary_index);
 		}
 
-		val = yyjson_obj_iter_get_val(key);
+		auto val = entry.value;
 		if (!ConvertJSON<WRITE_DATA, IGNORE_NULLS>(val, result, result_index, false)) {
 			return false;
 		}

--- a/src/include/duckdb/function/cast/variant/json_to_variant.hpp
+++ b/src/include/duckdb/function/cast/variant/json_to_variant.hpp
@@ -135,9 +135,8 @@ static bool ConvertJSONObject(yyjson_val *obj, ToVariantGlobalResultData &result
 
 	//! Iterate over all the children in the Object
 	for (const auto &entry : entries) {
-		auto key_string = GetString(entry.key);
-
 		if (WRITE_DATA) {
+			auto key_string = GetString(entry.key);
 			auto keys_index = start_key_index++;
 			auto dictionary_index = result.GetOrCreateIndex(key_string);
 

--- a/test/sql/storage/types/variant/variant_duplicate_keys_shredding.test
+++ b/test/sql/storage/types/variant/variant_duplicate_keys_shredding.test
@@ -1,0 +1,29 @@
+# name: test/sql/storage/types/variant/variant_duplicate_keys_shredding.test
+# description: Test shredding VARIANT values converted from JSON objects with duplicate keys
+# group: [variant]
+
+require json
+
+load {TEST_DIR}/variant_duplicate_keys_shredding.db readwrite v1.5.0
+
+statement ok
+SET variant_minimum_shredding_size = 0;
+
+statement ok
+CREATE TABLE variants AS
+SELECT '{"a":1,"a":2}'::JSON::VARIANT AS v;
+
+statement ok
+CHECKPOINT;
+
+restart
+
+query I
+SELECT DISTINCT vector_type(v) FROM variants;
+----
+SHREDDED_VECTOR
+
+query III
+SELECT (v).a, variant_keys(v), v::JSON FROM variants;
+----
+2	[a]	{"a":2}

--- a/test/sql/types/variant/json_cast.test
+++ b/test/sql/types/variant/json_cast.test
@@ -44,6 +44,17 @@ FROM (SELECT '{"outer":{"a":1,"b":2,"a":3}}'::JSON::VARIANT AS v);
 ----
 3	[a, b]	{"outer":{"a":3,"b":2}}
 
+query III
+SELECT (v).a, variant_keys(v), v::JSON
+FROM (
+	VALUES
+		('{"a":null,"a":[1,2]}'::JSON::VARIANT),
+		('{"a":[1,2],"a":null}'::JSON::VARIANT)
+) t(v);
+----
+[1, 2]	[a]	{"a":[1,2]}
+NULL	[a]	{"a":null}
+
 query II
 SELECT (v).a, variant_keys(v)
 FROM (

--- a/test/sql/types/variant/json_cast.test
+++ b/test/sql/types/variant/json_cast.test
@@ -1,4 +1,5 @@
 # name: test/sql/types/variant/json_cast.test
+# description: Test casts between JSON and VARIANT
 # group: [variant]
 
 require json
@@ -29,6 +30,29 @@ SELECT
 FROM src;
 ----
 1.2345678901234568e+29	DOUBLE
+
+# Duplicate object keys use the last value
+query III
+SELECT (v).a, variant_keys(v), v::JSON
+FROM (SELECT '{"a":1,"a":2}'::JSON::VARIANT AS v);
+----
+2	[a]	{"a":2}
+
+query III
+SELECT (v.outer).a, variant_keys(v, 'outer'), v::JSON
+FROM (SELECT '{"outer":{"a":1,"b":2,"a":3}}'::JSON::VARIANT AS v);
+----
+3	[a, b]	{"outer":{"a":3,"b":2}}
+
+query II
+SELECT (v).a, variant_keys(v)
+FROM (
+	SELECT j::VARIANT AS v
+	FROM (VALUES ('{"a":1,"a":2}'::JSON), ('{"a":3,"b":4,"a":5}'::JSON)) t(j)
+);
+----
+2	[a]
+5	[a, b]
 
 # ---------- VARIANT -> JSON ----------
 


### PR DESCRIPTION
## Summary

Resolves #23819 

JSON objects with duplicate keys could produce different results for field extraction, key enumeration, and JSON round-tripping after conversion to `VARIANT`. This PR uses the last value for each duplicate key during conversion so these operations have the same behavior.

## Results

```sql
WITH data AS (
    SELECT '{"a":1,"a":2}'::JSON::VARIANT AS v
)
SELECT
    (v).a AS extracted,
    variant_keys(v) AS keys,
    v::JSON AS round_trip
FROM data;
```

### Before

```text
┌───────────┬───────────┬────────────┐
│ extracted │   keys    │ round_trip │
│  variant  │ varchar[] │    json    │
├───────────┼───────────┼────────────┤
│ 1         │ [a, a]    │ {"a":2}    │
└───────────┴───────────┴────────────┘
```

### After

```text
┌───────────┬───────────┬────────────┐
│ extracted │   keys    │ round_trip │
│  variant  │ varchar[] │    json    │
├───────────┼───────────┼────────────┤
│ 2         │ [a]       │ {"a":2}    │
└───────────┴───────────┴────────────┘
```
