### PR TITLE
Rewrite DISTINCT aggregates as CTEs

### DIFF
--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -3848,19 +3848,20 @@ const StringUtil::EnumStringLiteral *GetOptimizerTypeValues() {
 		{ static_cast<uint32_t>(OptimizerType::REMOTE_PUSHDOWN), "REMOTE_PUSHDOWN" },
 		{ static_cast<uint32_t>(OptimizerType::GROUPING_SETS), "GROUPING_SETS" },
 		{ static_cast<uint32_t>(OptimizerType::TYPE_PUSHDOWN), "TYPE_PUSHDOWN" },
-		{ static_cast<uint32_t>(OptimizerType::SCALAR_FN_PUSHDOWN), "SCALAR_FN_PUSHDOWN" }
+		{ static_cast<uint32_t>(OptimizerType::SCALAR_FN_PUSHDOWN), "SCALAR_FN_PUSHDOWN" },
+		{ static_cast<uint32_t>(OptimizerType::DISTINCT_AGGREGATE_REWRITE), "DISTINCT_AGGREGATE_REWRITE" }
 	};
 	return values;
 }
 
 template<>
 const char* EnumUtil::ToChars<OptimizerType>(OptimizerType value) {
-	return StringUtil::EnumToString(GetOptimizerTypeValues(), 43, "OptimizerType", static_cast<uint32_t>(value));
+	return StringUtil::EnumToString(GetOptimizerTypeValues(), 44, "OptimizerType", static_cast<uint32_t>(value));
 }
 
 template<>
 OptimizerType EnumUtil::FromString<OptimizerType>(const char *value) {
-	return static_cast<OptimizerType>(StringUtil::StringToEnum(GetOptimizerTypeValues(), 43, "OptimizerType", value));
+	return static_cast<OptimizerType>(StringUtil::StringToEnum(GetOptimizerTypeValues(), 44, "OptimizerType", value));
 }
 
 const StringUtil::EnumStringLiteral *GetOrderByColumnTypeValues() {

--- a/src/common/enums/optimizer_type.cpp
+++ b/src/common/enums/optimizer_type.cpp
@@ -55,6 +55,7 @@ static const DefaultOptimizerType internal_optimizer_types[] = {
     {"grouping_sets", OptimizerType::GROUPING_SETS},
     {"type_pushdown", OptimizerType::TYPE_PUSHDOWN},
     {"scalar_fn_pushdown", OptimizerType::SCALAR_FN_PUSHDOWN},
+    {"distinct_aggregate_rewrite", OptimizerType::DISTINCT_AGGREGATE_REWRITE},
     {nullptr, OptimizerType::INVALID}};
 
 string OptimizerTypeToString(OptimizerType type) {

--- a/src/include/duckdb/common/enums/optimizer_type.hpp
+++ b/src/include/duckdb/common/enums/optimizer_type.hpp
@@ -57,6 +57,7 @@ enum class OptimizerType : uint32_t {
 	GROUPING_SETS = 40,
 	TYPE_PUSHDOWN = 41,
 	SCALAR_FN_PUSHDOWN = 42,
+	DISTINCT_AGGREGATE_REWRITE = 43
 };
 
 string OptimizerTypeToString(OptimizerType type);

--- a/src/include/duckdb/optimizer/aggregate_rewrite_helper.hpp
+++ b/src/include/duckdb/optimizer/aggregate_rewrite_helper.hpp
@@ -1,0 +1,30 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/optimizer/aggregate_rewrite_helper.hpp
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/planner/column_binding_map.hpp"
+#include "duckdb/planner/logical_operator.hpp"
+
+namespace duckdb {
+class LogicalAggregate;
+class Optimizer;
+
+struct AggregateRewriteHelper {
+	static vector<Identifier> GenerateColumnNames(const string &prefix, idx_t column_count);
+	static unique_ptr<Expression> CopyAndRebind(const Expression &expr,
+	                                            const column_binding_map_t<ColumnBinding> &replacement_map);
+	static void StageVolatileAggregateInputs(Optimizer &optimizer, LogicalAggregate &aggr,
+	                                         unique_ptr<LogicalOperator> &child);
+	static unique_ptr<LogicalOperator> CreateCTERef(Optimizer &optimizer, TableIndex cte_index,
+	                                                const vector<LogicalType> &input_types,
+	                                                const vector<Identifier> &input_names,
+	                                                const vector<ColumnBinding> &input_bindings,
+	                                                column_binding_map_t<ColumnBinding> &replacement_map);
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/optimizer/distinct_aggregate_rewriter.hpp
+++ b/src/include/duckdb/optimizer/distinct_aggregate_rewriter.hpp
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/optimizer/distinct_aggregate_rewriter.hpp
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/planner/column_binding_map.hpp"
+#include "duckdb/planner/expression/bound_columnref_expression.hpp"
+#include "duckdb/planner/logical_operator_visitor.hpp"
+
+namespace duckdb {
+class Optimizer;
+
+//! The DistinctAggregateRewriter rewrites eligible DISTINCT aggregates into explicit GROUP BY operations.
+class DistinctAggregateRewriter : public LogicalOperatorVisitor {
+public:
+	explicit DistinctAggregateRewriter(Optimizer &optimizer);
+
+	void VisitOperator(unique_ptr<LogicalOperator> &op) override;
+
+private:
+	bool TryRewrite(unique_ptr<LogicalOperator> &op);
+	unique_ptr<Expression> VisitReplace(BoundColumnRefExpression &expr, unique_ptr<Expression> *expr_ptr) override;
+
+private:
+	Optimizer &optimizer;
+	column_binding_map_t<ColumnBinding> replacement_map;
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/optimizer/distinct_aggregate_rewriter.hpp
+++ b/src/include/duckdb/optimizer/distinct_aggregate_rewriter.hpp
@@ -14,7 +14,8 @@
 namespace duckdb {
 class Optimizer;
 
-//! The DistinctAggregateRewriter rewrites eligible DISTINCT aggregates into explicit GROUP BY operations.
+//! The DistinctAggregateRewriter turns each DISTINCT argument/filter set into a deduplication aggregate followed by
+//! a non-distinct aggregate. Multiple sets share the original input through a CTE and join on the original group keys.
 class DistinctAggregateRewriter : public LogicalOperatorVisitor {
 public:
 	explicit DistinctAggregateRewriter(Optimizer &optimizer);

--- a/src/include/duckdb/optimizer/grouping_sets_optimizer.hpp
+++ b/src/include/duckdb/optimizer/grouping_sets_optimizer.hpp
@@ -26,6 +26,7 @@ public:
 
 private:
 	bool TryRewriteGroupingSets(unique_ptr<LogicalOperator> &op);
+	bool TryExpandGroupingSets(unique_ptr<LogicalOperator> &op);
 	unique_ptr<Expression> VisitReplace(BoundColumnRefExpression &expr, unique_ptr<Expression> *expr_ptr) override;
 
 private:

--- a/src/include/duckdb/optimizer/grouping_sets_optimizer.hpp
+++ b/src/include/duckdb/optimizer/grouping_sets_optimizer.hpp
@@ -14,10 +14,9 @@
 namespace duckdb {
 class Optimizer;
 
-//! The GroupingSetsOptimizer rewrites aggregates over multiple grouping sets (ROLLUP/CUBE/GROUPING SETS) into a
-//! cascade of aggregations connected through materialized CTEs. The finest grouping set is computed over the base
-//! data with the aggregate states exported, after which coarser grouping sets are computed by combining the states
-//! of a finer grouping set - instead of re-scanning and re-aggregating the base data for every grouping set.
+//! The GroupingSetsOptimizer rewrites aggregates over multiple grouping sets (ROLLUP/CUBE/GROUPING SETS) into
+//! explicit aggregate branches. Compatible aggregates use a cascade that combines exported states; other aggregates
+//! use one branch per grouping set over a shared materialized input.
 class GroupingSetsOptimizer : public LogicalOperatorVisitor {
 public:
 	explicit GroupingSetsOptimizer(Optimizer &optimizer);

--- a/src/optimizer/CMakeLists.txt
+++ b/src/optimizer/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library_unity(
   duckdb_optimizer
   OBJECT
   aggregate_function_rewriter.cpp
+  aggregate_rewrite_helper.cpp
   build_probe_side_optimizer.cpp
   column_binding_replacer.cpp
   column_lifetime_analyzer.cpp

--- a/src/optimizer/CMakeLists.txt
+++ b/src/optimizer/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library_unity(
   cte_filter_pusher.cpp
   cte_inlining.cpp
   deliminator.cpp
+  distinct_aggregate_rewriter.cpp
   expression_heuristics.cpp
   expression_rewriter.cpp
   filter_combiner.cpp

--- a/src/optimizer/aggregate_rewrite_helper.cpp
+++ b/src/optimizer/aggregate_rewrite_helper.cpp
@@ -56,6 +56,7 @@ static void StageVolatileExpression(unique_ptr<Expression> &expr, TableIndex pro
 
 void AggregateRewriteHelper::StageVolatileAggregateInputs(Optimizer &optimizer, LogicalAggregate &aggr,
                                                           unique_ptr<LogicalOperator> &child) {
+	// Branching rewrites must not multiply the evaluation of volatile aggregate inputs.
 	bool has_volatile_input = false;
 	for (auto &group : aggr.groups) {
 		has_volatile_input |= group->IsVolatile();

--- a/src/optimizer/aggregate_rewrite_helper.cpp
+++ b/src/optimizer/aggregate_rewrite_helper.cpp
@@ -1,0 +1,123 @@
+#include "duckdb/optimizer/aggregate_rewrite_helper.hpp"
+
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/optimizer/optimizer.hpp"
+#include "duckdb/planner/binder.hpp"
+#include "duckdb/planner/expression/bound_aggregate_expression.hpp"
+#include "duckdb/planner/expression/bound_columnref_expression.hpp"
+#include "duckdb/planner/expression_iterator.hpp"
+#include "duckdb/planner/operator/logical_aggregate.hpp"
+#include "duckdb/planner/operator/logical_cteref.hpp"
+#include "duckdb/planner/operator/logical_projection.hpp"
+
+namespace duckdb {
+
+vector<Identifier> AggregateRewriteHelper::GenerateColumnNames(const string &prefix, idx_t column_count) {
+	vector<Identifier> result;
+	result.reserve(column_count);
+	for (idx_t col_idx = 0; col_idx < column_count; col_idx++) {
+		result.emplace_back(StringUtil::Format("%s_%llu", prefix, col_idx));
+	}
+	return result;
+}
+
+static void RebindExpression(unique_ptr<Expression> &expr, const column_binding_map_t<ColumnBinding> &replacement_map) {
+	if (!expr || replacement_map.empty()) {
+		return;
+	}
+	ExpressionIterator::VisitExpressionMutable<BoundColumnRefExpression>(
+	    expr, [&](BoundColumnRefExpression &colref, unique_ptr<Expression> &) {
+		    auto entry = replacement_map.find(colref.Binding());
+		    if (entry != replacement_map.end()) {
+			    colref.BindingMutable() = entry->second;
+		    }
+	    });
+}
+
+unique_ptr<Expression>
+AggregateRewriteHelper::CopyAndRebind(const Expression &expr,
+                                      const column_binding_map_t<ColumnBinding> &replacement_map) {
+	auto result = expr.Copy();
+	RebindExpression(result, replacement_map);
+	return result;
+}
+
+static void StageVolatileExpression(unique_ptr<Expression> &expr, TableIndex projection_index,
+                                    vector<unique_ptr<Expression>> &projection_expressions) {
+	if (!expr || !expr->IsVolatile()) {
+		return;
+	}
+	auto return_type = expr->GetReturnType();
+	const auto column_index = projection_expressions.size();
+	projection_expressions.push_back(std::move(expr));
+	expr = make_uniq<BoundColumnRefExpression>(return_type,
+	                                           ColumnBinding(projection_index, ProjectionIndex(column_index)));
+}
+
+void AggregateRewriteHelper::StageVolatileAggregateInputs(Optimizer &optimizer, LogicalAggregate &aggr,
+                                                          unique_ptr<LogicalOperator> &child) {
+	bool has_volatile_input = false;
+	for (auto &group : aggr.groups) {
+		has_volatile_input |= group->IsVolatile();
+	}
+	for (auto &expr : aggr.expressions) {
+		has_volatile_input |= expr->IsVolatile();
+	}
+	if (!has_volatile_input) {
+		return;
+	}
+
+	child->ResolveOperatorTypes();
+	auto child_bindings = child->GetColumnBindings();
+	auto projection_index = optimizer.binder.GenerateTableIndex();
+
+	column_binding_map_t<ColumnBinding> projection_replacements;
+	vector<unique_ptr<Expression>> projection_expressions;
+	projection_expressions.reserve(child_bindings.size());
+	for (idx_t col_idx = 0; col_idx < child_bindings.size(); col_idx++) {
+		projection_replacements[child_bindings[col_idx]] = ColumnBinding(projection_index, ProjectionIndex(col_idx));
+		projection_expressions.push_back(
+		    make_uniq<BoundColumnRefExpression>(child->types[col_idx], child_bindings[col_idx]));
+	}
+
+	for (auto &group : aggr.groups) {
+		StageVolatileExpression(group, projection_index, projection_expressions);
+	}
+	for (auto &expr : aggr.expressions) {
+		auto &aggregate = expr->Cast<BoundAggregateExpression>();
+		for (auto &child_expr : aggregate.GetChildrenMutable()) {
+			StageVolatileExpression(child_expr, projection_index, projection_expressions);
+		}
+		if (aggregate.GetOrderBys()) {
+			for (auto &order : aggregate.GetOrderBysMutable()->orders) {
+				StageVolatileExpression(order.expression, projection_index, projection_expressions);
+			}
+		}
+		StageVolatileExpression(aggregate.GetFilterMutable(), projection_index, projection_expressions);
+	}
+
+	for (auto &group : aggr.groups) {
+		RebindExpression(group, projection_replacements);
+	}
+	for (auto &expr : aggr.expressions) {
+		RebindExpression(expr, projection_replacements);
+	}
+
+	auto projection = make_uniq<LogicalProjection>(projection_index, std::move(projection_expressions));
+	projection->children.push_back(std::move(child));
+	child = std::move(projection);
+}
+
+unique_ptr<LogicalOperator> AggregateRewriteHelper::CreateCTERef(Optimizer &optimizer, TableIndex cte_index,
+                                                                 const vector<LogicalType> &input_types,
+                                                                 const vector<Identifier> &input_names,
+                                                                 const vector<ColumnBinding> &input_bindings,
+                                                                 column_binding_map_t<ColumnBinding> &replacement_map) {
+	auto cte_ref_index = optimizer.binder.GenerateTableIndex();
+	for (idx_t col_idx = 0; col_idx < input_bindings.size(); col_idx++) {
+		replacement_map[input_bindings[col_idx]] = ColumnBinding(cte_ref_index, ProjectionIndex(col_idx));
+	}
+	return make_uniq<LogicalCTERef>(cte_ref_index, cte_index, input_types, input_names);
+}
+
+} // namespace duckdb

--- a/src/optimizer/distinct_aggregate_rewriter.cpp
+++ b/src/optimizer/distinct_aggregate_rewriter.cpp
@@ -1,17 +1,15 @@
 #include "duckdb/optimizer/distinct_aggregate_rewriter.hpp"
 
 #include "duckdb/common/string_util.hpp"
+#include "duckdb/optimizer/aggregate_rewrite_helper.hpp"
 #include "duckdb/optimizer/optimizer.hpp"
 #include "duckdb/planner/binder.hpp"
 #include "duckdb/planner/bound_result_modifier.hpp"
 #include "duckdb/planner/expression/bound_aggregate_expression.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
-#include "duckdb/planner/expression_iterator.hpp"
 #include "duckdb/planner/operator/logical_aggregate.hpp"
 #include "duckdb/planner/operator/logical_comparison_join.hpp"
 #include "duckdb/planner/operator/logical_cross_product.hpp"
-#include "duckdb/planner/operator/logical_cteref.hpp"
-#include "duckdb/planner/operator/logical_filter.hpp"
 #include "duckdb/planner/operator/logical_materialized_cte.hpp"
 #include "duckdb/planner/operator/logical_projection.hpp"
 
@@ -38,34 +36,6 @@ struct BranchResult {
 	vector<idx_t> aggregate_indices;
 };
 
-static vector<Identifier> GenerateColumnNames(const string &prefix, idx_t column_count) {
-	vector<Identifier> result;
-	result.reserve(column_count);
-	for (idx_t col_idx = 0; col_idx < column_count; col_idx++) {
-		result.emplace_back(StringUtil::Format("%s_%llu", prefix, col_idx));
-	}
-	return result;
-}
-
-static bool EqualAggregateChildren(const BoundAggregateExpression &left, const BoundAggregateExpression &right) {
-	if (left.GetChildren().size() != right.GetChildren().size()) {
-		return false;
-	}
-	for (idx_t child_idx = 0; child_idx < left.GetChildren().size(); child_idx++) {
-		if (!Expression::Equals(*left.GetChildren()[child_idx], *right.GetChildren()[child_idx])) {
-			return false;
-		}
-	}
-	return true;
-}
-
-static bool EqualAggregateFilters(const BoundAggregateExpression &left, const BoundAggregateExpression &right) {
-	if (!left.GetFilter() || !right.GetFilter()) {
-		return !left.GetFilter() && !right.GetFilter();
-	}
-	return Expression::Equals(*left.GetFilter(), *right.GetFilter());
-}
-
 static optional_idx FindExpression(const vector<unique_ptr<Expression>> &expressions, const Expression &needle) {
 	for (idx_t expr_idx = 0; expr_idx < expressions.size(); expr_idx++) {
 		if (Expression::Equals(*expressions[expr_idx], needle)) {
@@ -80,117 +50,13 @@ static void AddOrderExpressions(DistinctAggregateSet &set, const BoundAggregateE
 		return;
 	}
 	for (auto &order : aggregate.GetOrderBys()->orders) {
+		if (FindExpression(aggregate.GetChildren(), *order.expression).IsValid()) {
+			continue;
+		}
 		if (!FindExpression(set.order_expressions, *order.expression).IsValid()) {
 			set.order_expressions.push_back(order.expression->Copy());
 		}
 	}
-}
-
-static unique_ptr<Expression> CopyAndRebind(const Expression &expr,
-                                            const column_binding_map_t<ColumnBinding> &replacement_map) {
-	auto result = expr.Copy();
-	if (replacement_map.empty()) {
-		return result;
-	}
-	ExpressionIterator::VisitExpressionMutable<BoundColumnRefExpression>(
-	    result, [&](BoundColumnRefExpression &colref, unique_ptr<Expression> &) {
-		    auto entry = replacement_map.find(colref.Binding());
-		    if (entry != replacement_map.end()) {
-			    colref.BindingMutable() = entry->second;
-		    }
-	    });
-	return result;
-}
-
-static void RebindDistinctAggregateExpression(unique_ptr<Expression> &expr,
-                                              const column_binding_map_t<ColumnBinding> &replacement_map) {
-	if (!expr || replacement_map.empty()) {
-		return;
-	}
-	ExpressionIterator::VisitExpressionMutable<BoundColumnRefExpression>(
-	    expr, [&](BoundColumnRefExpression &colref, unique_ptr<Expression> &) {
-		    auto entry = replacement_map.find(colref.Binding());
-		    if (entry != replacement_map.end()) {
-			    colref.BindingMutable() = entry->second;
-		    }
-	    });
-}
-
-static bool StageDistinctAggregateExpression(unique_ptr<Expression> &expr, TableIndex projection_index,
-                                             vector<unique_ptr<Expression>> &projection_expressions,
-                                             bool force = false) {
-	if (!expr || (!force && !expr->IsVolatile())) {
-		return false;
-	}
-	auto return_type = expr->GetReturnType();
-	const auto column_index = projection_expressions.size();
-	projection_expressions.push_back(std::move(expr));
-	expr = make_uniq<BoundColumnRefExpression>(return_type,
-	                                           ColumnBinding(projection_index, ProjectionIndex(column_index)));
-	return true;
-}
-
-static bool StageVolatileDistinctAggregateInputs(Optimizer &optimizer, LogicalAggregate &aggr,
-                                                 unique_ptr<LogicalOperator> &child) {
-	child->ResolveOperatorTypes();
-	auto child_bindings = child->GetColumnBindings();
-	auto projection_index = optimizer.binder.GenerateTableIndex();
-
-	column_binding_map_t<ColumnBinding> projection_replacements;
-	vector<unique_ptr<Expression>> projection_expressions;
-	projection_expressions.reserve(child_bindings.size());
-	for (idx_t col_idx = 0; col_idx < child_bindings.size(); col_idx++) {
-		projection_replacements[child_bindings[col_idx]] = ColumnBinding(projection_index, ProjectionIndex(col_idx));
-		projection_expressions.push_back(
-		    make_uniq<BoundColumnRefExpression>(child->types[col_idx], child_bindings[col_idx]));
-	}
-
-	bool staged = false;
-	for (auto &group : aggr.groups) {
-		staged |= StageDistinctAggregateExpression(group, projection_index, projection_expressions);
-	}
-	for (auto &expr : aggr.expressions) {
-		auto &aggregate = expr->Cast<BoundAggregateExpression>();
-		bool has_volatile_payload = false;
-		for (auto &child_expr : aggregate.GetChildrenMutable()) {
-			has_volatile_payload |= child_expr->IsVolatile();
-			staged |= StageDistinctAggregateExpression(child_expr, projection_index, projection_expressions);
-		}
-		if (aggregate.GetOrderBys()) {
-			for (auto &order : aggregate.GetOrderBysMutable()->orders) {
-				has_volatile_payload |= order.expression->IsVolatile();
-				staged |= StageDistinctAggregateExpression(order.expression, projection_index, projection_expressions);
-			}
-		}
-		const bool stage_filter =
-		    aggregate.GetFilter() && (has_volatile_payload || aggregate.GetFilter()->IsVolatile());
-		staged |= StageDistinctAggregateExpression(aggregate.GetFilterMutable(), projection_index,
-		                                           projection_expressions, stage_filter);
-	}
-
-	if (!staged) {
-		return false;
-	}
-
-	for (auto &group : aggr.groups) {
-		RebindDistinctAggregateExpression(group, projection_replacements);
-	}
-	for (auto &expr : aggr.expressions) {
-		RebindDistinctAggregateExpression(expr, projection_replacements);
-	}
-
-	auto projection = make_uniq<LogicalProjection>(projection_index, std::move(projection_expressions));
-	projection->children.push_back(std::move(child));
-	child = std::move(projection);
-	return true;
-}
-
-static bool CanRewriteDistinctAggregate(const BoundAggregateExpression &) {
-	return true;
-}
-
-static bool CanRewriteRegularAggregate(const BoundAggregateExpression &) {
-	return true;
 }
 
 static unique_ptr<BoundAggregateExpression> CreateFinalAggregate(const BoundAggregateExpression &source,
@@ -209,13 +75,19 @@ static unique_ptr<BoundAggregateExpression> CreateFinalAggregate(const BoundAggr
 	if (source.GetOrderBys()) {
 		result->GetOrderBysMutable() = make_uniq<BoundOrderModifier>();
 		for (auto &order : source.GetOrderBys()->orders) {
-			auto order_idx = FindExpression(set.order_expressions, *order.expression);
-			D_ASSERT(order_idx.IsValid());
+			auto order_idx = FindExpression(source.GetChildren(), *order.expression);
+			idx_t column_offset;
+			if (order_idx.IsValid()) {
+				column_offset = input_column_offset + order_idx.GetIndex();
+			} else {
+				order_idx = FindExpression(set.order_expressions, *order.expression);
+				D_ASSERT(order_idx.IsValid());
+				column_offset = order_column_offset + order_idx.GetIndex();
+			}
 			result->GetOrderBysMutable()->orders.emplace_back(
 			    order.type, order.null_order,
-			    make_uniq<BoundColumnRefExpression>(
-			        order.expression->GetReturnType(),
-			        ColumnBinding(input_table, ProjectionIndex(order_column_offset + order_idx.GetIndex()))));
+			    make_uniq<BoundColumnRefExpression>(order.expression->GetReturnType(),
+			                                        ColumnBinding(input_table, ProjectionIndex(column_offset))));
 		}
 	} else {
 		result->GetOrderBysMutable().reset();
@@ -227,14 +99,6 @@ static unique_ptr<BoundAggregateExpression> CreateFinalAggregate(const BoundAggr
 		result->GetFilterMutable().reset();
 	}
 	return result;
-}
-
-static unique_ptr<LogicalOperator> CreateFilter(unique_ptr<LogicalOperator> input, const Expression &filter_expr,
-                                                const column_binding_map_t<ColumnBinding> &input_replacements) {
-	auto filter = make_uniq<LogicalFilter>();
-	filter->expressions.push_back(CopyAndRebind(filter_expr, input_replacements));
-	filter->children.push_back(std::move(input));
-	return std::move(filter);
 }
 
 static unique_ptr<LogicalOperator> CreateProjection(Optimizer &optimizer, unique_ptr<LogicalOperator> child,
@@ -265,20 +129,24 @@ static BranchResult CreateDistinctBranch(Optimizer &optimizer, LogicalAggregate 
                                          const column_binding_map_t<ColumnBinding> &input_replacements) {
 	const idx_t group_count = aggr.groups.size();
 	auto &source_aggregate = aggr.expressions[set.source_index]->Cast<BoundAggregateExpression>();
-	if (source_aggregate.GetFilter()) {
-		input = CreateFilter(std::move(input), *source_aggregate.GetFilter(), input_replacements);
-	}
 
 	vector<unique_ptr<Expression>> distinct_groups;
-	distinct_groups.reserve(group_count + source_aggregate.GetChildren().size() + set.order_expressions.size());
+	distinct_groups.reserve(group_count + source_aggregate.GetChildren().size() + set.order_expressions.size() +
+	                        (source_aggregate.GetFilter() ? 1 : 0));
 	for (auto &group : aggr.groups) {
-		distinct_groups.push_back(CopyAndRebind(*group, input_replacements));
+		distinct_groups.push_back(AggregateRewriteHelper::CopyAndRebind(*group, input_replacements));
 	}
 	for (auto &child : source_aggregate.GetChildren()) {
-		distinct_groups.push_back(CopyAndRebind(*child, input_replacements));
+		distinct_groups.push_back(AggregateRewriteHelper::CopyAndRebind(*child, input_replacements));
 	}
 	for (auto &order_expr : set.order_expressions) {
-		distinct_groups.push_back(CopyAndRebind(*order_expr, input_replacements));
+		distinct_groups.push_back(AggregateRewriteHelper::CopyAndRebind(*order_expr, input_replacements));
+	}
+	optional_idx filter_column_offset;
+	if (source_aggregate.GetFilter()) {
+		filter_column_offset = distinct_groups.size();
+		distinct_groups.push_back(
+		    AggregateRewriteHelper::CopyAndRebind(*source_aggregate.GetFilter(), input_replacements));
 	}
 
 	auto distinct_group_index = optimizer.binder.GenerateTableIndex();
@@ -287,9 +155,6 @@ static BranchResult CreateDistinctBranch(Optimizer &optimizer, LogicalAggregate 
 	    make_uniq<LogicalAggregate>(distinct_group_index, distinct_aggregate_index, vector<unique_ptr<Expression>>());
 	distinct->groups = std::move(distinct_groups);
 	distinct->children.push_back(std::move(input));
-	if (aggr.has_estimated_cardinality) {
-		distinct->SetEstimatedCardinality(aggr.estimated_cardinality);
-	}
 
 	vector<unique_ptr<Expression>> final_groups;
 	final_groups.reserve(group_count);
@@ -303,8 +168,8 @@ static BranchResult CreateDistinctBranch(Optimizer &optimizer, LogicalAggregate 
 	const auto order_column_offset = group_count + source_aggregate.GetChildren().size();
 	for (auto aggregate_idx : set.aggregate_indices) {
 		auto &aggregate = aggr.expressions[aggregate_idx]->Cast<BoundAggregateExpression>();
-		final_aggregates.push_back(
-		    CreateFinalAggregate(aggregate, set, distinct_group_index, group_count, order_column_offset));
+		final_aggregates.push_back(CreateFinalAggregate(aggregate, set, distinct_group_index, group_count,
+		                                                order_column_offset, filter_column_offset));
 	}
 
 	auto final_group_index = optimizer.binder.GenerateTableIndex();
@@ -323,126 +188,20 @@ static BranchResult CreateDistinctBranch(Optimizer &optimizer, LogicalAggregate 
 	return result;
 }
 
-static BranchResult CreateGroupedFilteredDistinctBranch(
-    Optimizer &optimizer, LogicalAggregate &aggr, const DistinctAggregateSet &set,
-    unique_ptr<LogicalOperator> domain_input, const column_binding_map_t<ColumnBinding> &domain_replacements,
-    unique_ptr<LogicalOperator> distinct_input, const column_binding_map_t<ColumnBinding> &distinct_replacements) {
-	const idx_t group_count = aggr.groups.size();
-	auto &source_aggregate = aggr.expressions[set.source_index]->Cast<BoundAggregateExpression>();
-	D_ASSERT(group_count > 0);
-	D_ASSERT(source_aggregate.GetFilter());
-
-	vector<unique_ptr<Expression>> domain_groups;
-	domain_groups.reserve(group_count);
-	for (auto &group : aggr.groups) {
-		domain_groups.push_back(CopyAndRebind(*group, domain_replacements));
-	}
-
-	auto domain_group_index = optimizer.binder.GenerateTableIndex();
-	auto domain_aggregate_index = optimizer.binder.GenerateTableIndex();
-	auto domain =
-	    make_uniq<LogicalAggregate>(domain_group_index, domain_aggregate_index, vector<unique_ptr<Expression>>());
-	domain->groups = std::move(domain_groups);
-	domain->children.push_back(std::move(domain_input));
-	if (aggr.has_estimated_cardinality) {
-		domain->SetEstimatedCardinality(aggr.estimated_cardinality);
-	}
-
-	distinct_input = CreateFilter(std::move(distinct_input), *source_aggregate.GetFilter(), distinct_replacements);
-
-	vector<unique_ptr<Expression>> distinct_groups;
-	distinct_groups.reserve(group_count + source_aggregate.GetChildren().size() + set.order_expressions.size());
-	for (auto &group : aggr.groups) {
-		distinct_groups.push_back(CopyAndRebind(*group, distinct_replacements));
-	}
-	for (auto &child : source_aggregate.GetChildren()) {
-		distinct_groups.push_back(CopyAndRebind(*child, distinct_replacements));
-	}
-	for (auto &order_expr : set.order_expressions) {
-		distinct_groups.push_back(CopyAndRebind(*order_expr, distinct_replacements));
-	}
-
-	auto distinct_group_index = optimizer.binder.GenerateTableIndex();
-	auto distinct_aggregate_index = optimizer.binder.GenerateTableIndex();
-	auto distinct =
-	    make_uniq<LogicalAggregate>(distinct_group_index, distinct_aggregate_index, vector<unique_ptr<Expression>>());
-	distinct->groups = std::move(distinct_groups);
-	distinct->children.push_back(std::move(distinct_input));
-	if (aggr.has_estimated_cardinality) {
-		distinct->SetEstimatedCardinality(aggr.estimated_cardinality);
-	}
-
-	const auto distinct_column_count =
-	    group_count + source_aggregate.GetChildren().size() + set.order_expressions.size();
-	vector<unique_ptr<Expression>> marker_projection_expressions;
-	marker_projection_expressions.reserve(distinct_column_count + 1);
-	for (idx_t col_idx = 0; col_idx < distinct_column_count; col_idx++) {
-		marker_projection_expressions.push_back(make_uniq<BoundColumnRefExpression>(
-		    distinct->groups[col_idx]->GetReturnType(), ColumnBinding(distinct_group_index, ProjectionIndex(col_idx))));
-	}
-	marker_projection_expressions.push_back(make_uniq<BoundConstantExpression>(Value::BOOLEAN(true)));
-	auto marker_projection_index = optimizer.binder.GenerateTableIndex();
-	auto marker_projection =
-	    make_uniq<LogicalProjection>(marker_projection_index, std::move(marker_projection_expressions));
-	marker_projection->children.push_back(std::move(distinct));
-
-	auto join = make_uniq<LogicalComparisonJoin>(JoinType::LEFT);
-	for (idx_t group_idx = 0; group_idx < group_count; group_idx++) {
-		auto left = make_uniq<BoundColumnRefExpression>(aggr.groups[group_idx]->GetReturnType(),
-		                                                ColumnBinding(domain_group_index, ProjectionIndex(group_idx)));
-		auto right =
-		    make_uniq<BoundColumnRefExpression>(aggr.groups[group_idx]->GetReturnType(),
-		                                        ColumnBinding(marker_projection_index, ProjectionIndex(group_idx)));
-		join->conditions.emplace_back(std::move(left), std::move(right), ExpressionType::COMPARE_NOT_DISTINCT_FROM);
-	}
-	join->children.push_back(std::move(domain));
-	join->children.push_back(std::move(marker_projection));
-
-	vector<unique_ptr<Expression>> final_groups;
-	final_groups.reserve(group_count);
-	for (idx_t group_idx = 0; group_idx < group_count; group_idx++) {
-		final_groups.push_back(make_uniq<BoundColumnRefExpression>(
-		    aggr.groups[group_idx]->GetReturnType(), ColumnBinding(domain_group_index, ProjectionIndex(group_idx))));
-	}
-
-	vector<unique_ptr<Expression>> final_aggregates;
-	final_aggregates.reserve(set.aggregate_indices.size());
-	const auto order_column_offset = group_count + source_aggregate.GetChildren().size();
-	for (auto aggregate_idx : set.aggregate_indices) {
-		auto &aggregate = aggr.expressions[aggregate_idx]->Cast<BoundAggregateExpression>();
-		final_aggregates.push_back(CreateFinalAggregate(aggregate, set, marker_projection_index, group_count,
-		                                                order_column_offset, distinct_column_count));
-	}
-
-	auto final_group_index = optimizer.binder.GenerateTableIndex();
-	auto final_aggregate_index = optimizer.binder.GenerateTableIndex();
-	auto final = make_uniq<LogicalAggregate>(final_group_index, final_aggregate_index, std::move(final_aggregates));
-	final->groups = std::move(final_groups);
-	final->children.push_back(std::move(join));
-	if (aggr.has_estimated_cardinality) {
-		final->SetEstimatedCardinality(aggr.estimated_cardinality);
-	}
-
-	BranchResult result;
-	result.aggregate_indices = set.aggregate_indices;
-	result.plan = CreateProjection(optimizer, std::move(final), final_group_index, final_aggregate_index, aggr.groups,
-	                               aggr.expressions, result.aggregate_indices, result.table_index);
-	return result;
-}
-
 static BranchResult CreateRegularBranch(Optimizer &optimizer, LogicalAggregate &aggr,
                                         const vector<idx_t> &aggregate_indices, unique_ptr<LogicalOperator> input,
                                         const column_binding_map_t<ColumnBinding> &input_replacements) {
 	vector<unique_ptr<Expression>> regular_groups;
 	regular_groups.reserve(aggr.groups.size());
 	for (auto &group : aggr.groups) {
-		regular_groups.push_back(CopyAndRebind(*group, input_replacements));
+		regular_groups.push_back(AggregateRewriteHelper::CopyAndRebind(*group, input_replacements));
 	}
 
 	vector<unique_ptr<Expression>> regular_aggregates;
 	regular_aggregates.reserve(aggregate_indices.size());
 	for (auto aggregate_idx : aggregate_indices) {
-		regular_aggregates.push_back(CopyAndRebind(*aggr.expressions[aggregate_idx], input_replacements));
+		regular_aggregates.push_back(
+		    AggregateRewriteHelper::CopyAndRebind(*aggr.expressions[aggregate_idx], input_replacements));
 	}
 
 	auto regular_group_index = optimizer.binder.GenerateTableIndex();
@@ -460,18 +219,6 @@ static BranchResult CreateRegularBranch(Optimizer &optimizer, LogicalAggregate &
 	result.plan = CreateProjection(optimizer, std::move(regular), regular_group_index, regular_aggregate_index,
 	                               aggr.groups, aggr.expressions, result.aggregate_indices, result.table_index);
 	return result;
-}
-
-static unique_ptr<LogicalOperator> CreateCTERef(Optimizer &optimizer, TableIndex cte_index,
-                                                const vector<LogicalType> &input_types,
-                                                const vector<Identifier> &input_names,
-                                                const vector<ColumnBinding> &input_bindings,
-                                                column_binding_map_t<ColumnBinding> &replacement_map) {
-	auto cte_ref_index = optimizer.binder.GenerateTableIndex();
-	for (idx_t col_idx = 0; col_idx < input_bindings.size(); col_idx++) {
-		replacement_map[input_bindings[col_idx]] = ColumnBinding(cte_ref_index, ProjectionIndex(col_idx));
-	}
-	return make_uniq<LogicalCTERef>(cte_ref_index, cte_index, input_types, input_names);
 }
 
 static unique_ptr<LogicalOperator> JoinBranches(const vector<BranchResult> &branches,
@@ -540,7 +287,7 @@ bool DistinctAggregateRewriter::TryRewrite(unique_ptr<LogicalOperator> &op) {
 		return false;
 	}
 
-	StageVolatileDistinctAggregateInputs(optimizer, aggr, op->children[0]);
+	AggregateRewriteHelper::StageVolatileAggregateInputs(optimizer, aggr, op->children[0]);
 
 	vector<DistinctAggregateSet> distinct_sets;
 	vector<idx_t> regular_aggregates;
@@ -548,19 +295,14 @@ bool DistinctAggregateRewriter::TryRewrite(unique_ptr<LogicalOperator> &op) {
 		auto &expr = aggr.expressions[aggregate_idx];
 		auto &aggregate = expr->Cast<BoundAggregateExpression>();
 		if (!aggregate.IsDistinct()) {
-			if (!CanRewriteRegularAggregate(aggregate)) {
-				return false;
-			}
 			regular_aggregates.push_back(aggregate_idx);
 			continue;
-		}
-		if (!CanRewriteDistinctAggregate(aggregate)) {
-			return false;
 		}
 		bool found_match = false;
 		for (auto &set : distinct_sets) {
 			auto &other = aggr.expressions[set.source_index]->Cast<BoundAggregateExpression>();
-			if (EqualAggregateChildren(aggregate, other) && EqualAggregateFilters(aggregate, other)) {
+			if (Expression::ListEquals(aggregate.GetChildren(), other.GetChildren()) &&
+			    Expression::Equals(aggregate.GetFilter(), other.GetFilter())) {
 				set.aggregate_indices.push_back(aggregate_idx);
 				AddOrderExpressions(set, aggregate);
 				found_match = true;
@@ -576,19 +318,7 @@ bool DistinctAggregateRewriter::TryRewrite(unique_ptr<LogicalOperator> &op) {
 		return false;
 	}
 
-	bool has_grouped_filtered_distinct = false;
-	if (!aggr.groups.empty()) {
-		for (auto &set : distinct_sets) {
-			auto &source_aggregate = aggr.expressions[set.source_index]->Cast<BoundAggregateExpression>();
-			if (source_aggregate.GetFilter()) {
-				has_grouped_filtered_distinct = true;
-				break;
-			}
-		}
-	}
-
-	const bool needs_cte =
-	    distinct_sets.size() + (regular_aggregates.empty() ? 0 : 1) > 1 || has_grouped_filtered_distinct;
+	const bool needs_cte = distinct_sets.size() + (regular_aggregates.empty() ? 0 : 1) > 1;
 	vector<LogicalType> input_types;
 	vector<Identifier> input_names;
 	vector<ColumnBinding> input_bindings;
@@ -596,7 +326,7 @@ bool DistinctAggregateRewriter::TryRewrite(unique_ptr<LogicalOperator> &op) {
 	if (needs_cte) {
 		op->children[0]->ResolveOperatorTypes();
 		input_types = op->children[0]->types;
-		input_names = GenerateColumnNames("__distinct_input", input_types.size());
+		input_names = AggregateRewriteHelper::GenerateColumnNames("__distinct_input", input_types.size());
 		input_bindings = op->children[0]->GetColumnBindings();
 		cte_index = optimizer.binder.GenerateTableIndex();
 	}
@@ -607,23 +337,14 @@ bool DistinctAggregateRewriter::TryRewrite(unique_ptr<LogicalOperator> &op) {
 		if (!needs_cte) {
 			return std::move(op->children[0]);
 		}
-		return CreateCTERef(optimizer, cte_index, input_types, input_names, input_bindings, input_replacements);
+		return AggregateRewriteHelper::CreateCTERef(optimizer, cte_index, input_types, input_names, input_bindings,
+		                                            input_replacements);
 	};
 
 	for (auto &set : distinct_sets) {
-		auto &source_aggregate = aggr.expressions[set.source_index]->Cast<BoundAggregateExpression>();
-		BranchResult branch;
-		if (!aggr.groups.empty() && source_aggregate.GetFilter()) {
-			column_binding_map_t<ColumnBinding> domain_replacements;
-			column_binding_map_t<ColumnBinding> distinct_replacements;
-			branch = CreateGroupedFilteredDistinctBranch(optimizer, aggr, set, CreateBranchInput(domain_replacements),
-			                                             domain_replacements, CreateBranchInput(distinct_replacements),
-			                                             distinct_replacements);
-		} else {
-			column_binding_map_t<ColumnBinding> input_replacements;
-			branch =
-			    CreateDistinctBranch(optimizer, aggr, set, CreateBranchInput(input_replacements), input_replacements);
-		}
+		column_binding_map_t<ColumnBinding> input_replacements;
+		auto branch =
+		    CreateDistinctBranch(optimizer, aggr, set, CreateBranchInput(input_replacements), input_replacements);
 		branch_plans.push_back(std::move(branch.plan));
 		branches.push_back(std::move(branch));
 	}

--- a/src/optimizer/distinct_aggregate_rewriter.cpp
+++ b/src/optimizer/distinct_aggregate_rewriter.cpp
@@ -102,32 +102,94 @@ static unique_ptr<Expression> CopyAndRebind(const Expression &expr,
 	return result;
 }
 
-static bool CanRewriteDistinctAggregate(const BoundAggregateExpression &aggregate) {
-	if (aggregate.StateExportMode() != AggregateStateExportMode::NONE) {
+static void RebindDistinctAggregateExpression(unique_ptr<Expression> &expr,
+                                              const column_binding_map_t<ColumnBinding> &replacement_map) {
+	if (!expr || replacement_map.empty()) {
+		return;
+	}
+	ExpressionIterator::VisitExpressionMutable<BoundColumnRefExpression>(
+	    expr, [&](BoundColumnRefExpression &colref, unique_ptr<Expression> &) {
+		    auto entry = replacement_map.find(colref.Binding());
+		    if (entry != replacement_map.end()) {
+			    colref.BindingMutable() = entry->second;
+		    }
+	    });
+}
+
+static bool StageDistinctAggregateExpression(unique_ptr<Expression> &expr, TableIndex projection_index,
+                                             vector<unique_ptr<Expression>> &projection_expressions,
+                                             bool force = false) {
+	if (!expr || (!force && !expr->IsVolatile())) {
 		return false;
 	}
-	if (aggregate.GetFilter() && aggregate.GetFilter()->IsVolatile()) {
-		return false;
-	}
-	for (auto &child : aggregate.GetChildren()) {
-		if (child->IsVolatile()) {
-			return false;
-		}
-	}
-	if (aggregate.GetOrderBys()) {
-		for (auto &order : aggregate.GetOrderBys()->orders) {
-			if (order.expression->IsVolatile()) {
-				return false;
-			}
-		}
-	}
+	auto return_type = expr->GetReturnType();
+	const auto column_index = projection_expressions.size();
+	projection_expressions.push_back(std::move(expr));
+	expr = make_uniq<BoundColumnRefExpression>(return_type,
+	                                           ColumnBinding(projection_index, ProjectionIndex(column_index)));
 	return true;
 }
 
-static bool CanRewriteRegularAggregate(const BoundAggregateExpression &aggregate) {
-	if (aggregate.StateExportMode() != AggregateStateExportMode::NONE) {
+static bool StageVolatileDistinctAggregateInputs(Optimizer &optimizer, LogicalAggregate &aggr,
+                                                 unique_ptr<LogicalOperator> &child) {
+	child->ResolveOperatorTypes();
+	auto child_bindings = child->GetColumnBindings();
+	auto projection_index = optimizer.binder.GenerateTableIndex();
+
+	column_binding_map_t<ColumnBinding> projection_replacements;
+	vector<unique_ptr<Expression>> projection_expressions;
+	projection_expressions.reserve(child_bindings.size());
+	for (idx_t col_idx = 0; col_idx < child_bindings.size(); col_idx++) {
+		projection_replacements[child_bindings[col_idx]] = ColumnBinding(projection_index, ProjectionIndex(col_idx));
+		projection_expressions.push_back(
+		    make_uniq<BoundColumnRefExpression>(child->types[col_idx], child_bindings[col_idx]));
+	}
+
+	bool staged = false;
+	for (auto &group : aggr.groups) {
+		staged |= StageDistinctAggregateExpression(group, projection_index, projection_expressions);
+	}
+	for (auto &expr : aggr.expressions) {
+		auto &aggregate = expr->Cast<BoundAggregateExpression>();
+		bool has_volatile_payload = false;
+		for (auto &child_expr : aggregate.GetChildrenMutable()) {
+			has_volatile_payload |= child_expr->IsVolatile();
+			staged |= StageDistinctAggregateExpression(child_expr, projection_index, projection_expressions);
+		}
+		if (aggregate.GetOrderBys()) {
+			for (auto &order : aggregate.GetOrderBysMutable()->orders) {
+				has_volatile_payload |= order.expression->IsVolatile();
+				staged |= StageDistinctAggregateExpression(order.expression, projection_index, projection_expressions);
+			}
+		}
+		const bool stage_filter =
+		    aggregate.GetFilter() && (has_volatile_payload || aggregate.GetFilter()->IsVolatile());
+		staged |= StageDistinctAggregateExpression(aggregate.GetFilterMutable(), projection_index,
+		                                           projection_expressions, stage_filter);
+	}
+
+	if (!staged) {
 		return false;
 	}
+
+	for (auto &group : aggr.groups) {
+		RebindDistinctAggregateExpression(group, projection_replacements);
+	}
+	for (auto &expr : aggr.expressions) {
+		RebindDistinctAggregateExpression(expr, projection_replacements);
+	}
+
+	auto projection = make_uniq<LogicalProjection>(projection_index, std::move(projection_expressions));
+	projection->children.push_back(std::move(child));
+	child = std::move(projection);
+	return true;
+}
+
+static bool CanRewriteDistinctAggregate(const BoundAggregateExpression &) {
+	return true;
+}
+
+static bool CanRewriteRegularAggregate(const BoundAggregateExpression &) {
 	return true;
 }
 
@@ -450,7 +512,7 @@ bool DistinctAggregateRewriter::TryRewrite(unique_ptr<LogicalOperator> &op) {
 		return false;
 	}
 	auto &aggr = op->Cast<LogicalAggregate>();
-	if (aggr.grouping_sets.size() > 1 || !aggr.grouping_functions.empty() || aggr.expressions.empty()) {
+	if (aggr.grouping_sets.size() > 1 || aggr.expressions.empty()) {
 		return false;
 	}
 	if (aggr.grouping_sets.size() == 1) {
@@ -464,13 +526,26 @@ bool DistinctAggregateRewriter::TryRewrite(unique_ptr<LogicalOperator> &op) {
 		}
 	}
 
+	bool has_distinct = false;
+	for (auto &expr : aggr.expressions) {
+		if (expr->GetExpressionClass() != ExpressionClass::BOUND_AGGREGATE) {
+			return false;
+		}
+		auto &aggregate = expr->Cast<BoundAggregateExpression>();
+		if (aggregate.IsDistinct()) {
+			has_distinct = true;
+		}
+	}
+	if (!has_distinct) {
+		return false;
+	}
+
+	StageVolatileDistinctAggregateInputs(optimizer, aggr, op->children[0]);
+
 	vector<DistinctAggregateSet> distinct_sets;
 	vector<idx_t> regular_aggregates;
 	for (idx_t aggregate_idx = 0; aggregate_idx < aggr.expressions.size(); aggregate_idx++) {
 		auto &expr = aggr.expressions[aggregate_idx];
-		if (expr->GetExpressionClass() != ExpressionClass::BOUND_AGGREGATE) {
-			return false;
-		}
 		auto &aggregate = expr->Cast<BoundAggregateExpression>();
 		if (!aggregate.IsDistinct()) {
 			if (!CanRewriteRegularAggregate(aggregate)) {
@@ -571,7 +646,7 @@ bool DistinctAggregateRewriter::TryRewrite(unique_ptr<LogicalOperator> &op) {
 	auto joined = JoinBranches(branches, std::move(branch_plans), aggr.groups);
 
 	vector<unique_ptr<Expression>> projection_expressions;
-	projection_expressions.reserve(aggr.groups.size() + aggr.expressions.size());
+	projection_expressions.reserve(aggr.groups.size() + aggr.expressions.size() + aggr.grouping_functions.size());
 	const auto final_projection_index = optimizer.binder.GenerateTableIndex();
 	for (idx_t group_idx = 0; group_idx < aggr.groups.size(); group_idx++) {
 		projection_expressions.push_back(
@@ -586,6 +661,11 @@ bool DistinctAggregateRewriter::TryRewrite(unique_ptr<LogicalOperator> &op) {
 		replacement_map[ColumnBinding(aggr.aggregate_index, ProjectionIndex(aggregate_idx))] =
 		    ColumnBinding(final_projection_index, ProjectionIndex(aggr.groups.size() + aggregate_idx));
 	}
+	for (idx_t grouping_idx = 0; grouping_idx < aggr.grouping_functions.size(); grouping_idx++) {
+		projection_expressions.push_back(make_uniq<BoundConstantExpression>(Value::BIGINT(0)));
+		replacement_map[ColumnBinding(aggr.groupings_index, ProjectionIndex(grouping_idx))] = ColumnBinding(
+		    final_projection_index, ProjectionIndex(aggr.groups.size() + aggr.expressions.size() + grouping_idx));
+	}
 
 	unique_ptr<LogicalOperator> result =
 	    make_uniq<LogicalProjection>(final_projection_index, std::move(projection_expressions));
@@ -598,7 +678,7 @@ bool DistinctAggregateRewriter::TryRewrite(unique_ptr<LogicalOperator> &op) {
 		auto cte_name = Identifier(StringUtil::Format("__distinct_aggregate_cte_%llu", cte_index.index));
 		result = make_uniq<LogicalMaterializedCTE>(std::move(cte_name), cte_index, input_types.size(),
 		                                           std::move(op->children[0]), std::move(result),
-		                                           CTEMaterialize::CTE_MATERIALIZE_ALWAYS);
+		                                           CTEMaterialize::CTE_MATERIALIZE_DEFAULT);
 		if (aggr.has_estimated_cardinality) {
 			result->SetEstimatedCardinality(aggr.estimated_cardinality);
 		}

--- a/src/optimizer/distinct_aggregate_rewriter.cpp
+++ b/src/optimizer/distinct_aggregate_rewriter.cpp
@@ -3,12 +3,15 @@
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/optimizer/optimizer.hpp"
 #include "duckdb/planner/binder.hpp"
+#include "duckdb/planner/bound_result_modifier.hpp"
 #include "duckdb/planner/expression/bound_aggregate_expression.hpp"
+#include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression_iterator.hpp"
 #include "duckdb/planner/operator/logical_aggregate.hpp"
 #include "duckdb/planner/operator/logical_comparison_join.hpp"
 #include "duckdb/planner/operator/logical_cross_product.hpp"
 #include "duckdb/planner/operator/logical_cteref.hpp"
+#include "duckdb/planner/operator/logical_filter.hpp"
 #include "duckdb/planner/operator/logical_materialized_cte.hpp"
 #include "duckdb/planner/operator/logical_projection.hpp"
 
@@ -26,6 +29,7 @@ struct DistinctAggregateSet {
 
 	idx_t source_index;
 	vector<idx_t> aggregate_indices;
+	vector<unique_ptr<Expression>> order_expressions;
 };
 
 struct BranchResult {
@@ -55,6 +59,33 @@ static bool EqualAggregateChildren(const BoundAggregateExpression &left, const B
 	return true;
 }
 
+static bool EqualAggregateFilters(const BoundAggregateExpression &left, const BoundAggregateExpression &right) {
+	if (!left.GetFilter() || !right.GetFilter()) {
+		return !left.GetFilter() && !right.GetFilter();
+	}
+	return Expression::Equals(*left.GetFilter(), *right.GetFilter());
+}
+
+static optional_idx FindExpression(const vector<unique_ptr<Expression>> &expressions, const Expression &needle) {
+	for (idx_t expr_idx = 0; expr_idx < expressions.size(); expr_idx++) {
+		if (Expression::Equals(*expressions[expr_idx], needle)) {
+			return expr_idx;
+		}
+	}
+	return optional_idx();
+}
+
+static void AddOrderExpressions(DistinctAggregateSet &set, const BoundAggregateExpression &aggregate) {
+	if (!aggregate.GetOrderBys()) {
+		return;
+	}
+	for (auto &order : aggregate.GetOrderBys()->orders) {
+		if (!FindExpression(set.order_expressions, *order.expression).IsValid()) {
+			set.order_expressions.push_back(order.expression->Copy());
+		}
+	}
+}
+
 static unique_ptr<Expression> CopyAndRebind(const Expression &expr,
                                             const column_binding_map_t<ColumnBinding> &replacement_map) {
 	auto result = expr.Copy();
@@ -75,7 +106,7 @@ static bool CanRewriteDistinctAggregate(const BoundAggregateExpression &aggregat
 	if (aggregate.StateExportMode() != AggregateStateExportMode::NONE) {
 		return false;
 	}
-	if (aggregate.GetFilter() || aggregate.GetOrderBys()) {
+	if (aggregate.GetFilter() && aggregate.GetFilter()->IsVolatile()) {
 		return false;
 	}
 	for (auto &child : aggregate.GetChildren()) {
@@ -83,11 +114,28 @@ static bool CanRewriteDistinctAggregate(const BoundAggregateExpression &aggregat
 			return false;
 		}
 	}
+	if (aggregate.GetOrderBys()) {
+		for (auto &order : aggregate.GetOrderBys()->orders) {
+			if (order.expression->IsVolatile()) {
+				return false;
+			}
+		}
+	}
+	return true;
+}
+
+static bool CanRewriteRegularAggregate(const BoundAggregateExpression &aggregate) {
+	if (aggregate.StateExportMode() != AggregateStateExportMode::NONE) {
+		return false;
+	}
 	return true;
 }
 
 static unique_ptr<BoundAggregateExpression> CreateFinalAggregate(const BoundAggregateExpression &source,
-                                                                 TableIndex input_table, idx_t input_column_offset) {
+                                                                 const DistinctAggregateSet &set,
+                                                                 TableIndex input_table, idx_t input_column_offset,
+                                                                 idx_t order_column_offset,
+                                                                 optional_idx filter_column_offset = optional_idx()) {
 	auto result = unique_ptr_cast<Expression, BoundAggregateExpression>(source.Copy());
 	result->GetAggregateTypeMutable() = AggregateType::NON_DISTINCT;
 	result->GetChildrenMutable().clear();
@@ -96,7 +144,35 @@ static unique_ptr<BoundAggregateExpression> CreateFinalAggregate(const BoundAggr
 		result->GetChildrenMutable().push_back(make_uniq<BoundColumnRefExpression>(
 		    child->GetReturnType(), ColumnBinding(input_table, ProjectionIndex(input_column_offset + child_idx))));
 	}
+	if (source.GetOrderBys()) {
+		result->GetOrderBysMutable() = make_uniq<BoundOrderModifier>();
+		for (auto &order : source.GetOrderBys()->orders) {
+			auto order_idx = FindExpression(set.order_expressions, *order.expression);
+			D_ASSERT(order_idx.IsValid());
+			result->GetOrderBysMutable()->orders.emplace_back(
+			    order.type, order.null_order,
+			    make_uniq<BoundColumnRefExpression>(
+			        order.expression->GetReturnType(),
+			        ColumnBinding(input_table, ProjectionIndex(order_column_offset + order_idx.GetIndex()))));
+		}
+	} else {
+		result->GetOrderBysMutable().reset();
+	}
+	if (filter_column_offset.IsValid()) {
+		result->GetFilterMutable() = make_uniq<BoundColumnRefExpression>(
+		    LogicalType::BOOLEAN, ColumnBinding(input_table, ProjectionIndex(filter_column_offset.GetIndex())));
+	} else {
+		result->GetFilterMutable().reset();
+	}
 	return result;
+}
+
+static unique_ptr<LogicalOperator> CreateFilter(unique_ptr<LogicalOperator> input, const Expression &filter_expr,
+                                                const column_binding_map_t<ColumnBinding> &input_replacements) {
+	auto filter = make_uniq<LogicalFilter>();
+	filter->expressions.push_back(CopyAndRebind(filter_expr, input_replacements));
+	filter->children.push_back(std::move(input));
+	return std::move(filter);
 }
 
 static unique_ptr<LogicalOperator> CreateProjection(Optimizer &optimizer, unique_ptr<LogicalOperator> child,
@@ -127,14 +203,20 @@ static BranchResult CreateDistinctBranch(Optimizer &optimizer, LogicalAggregate 
                                          const column_binding_map_t<ColumnBinding> &input_replacements) {
 	const idx_t group_count = aggr.groups.size();
 	auto &source_aggregate = aggr.expressions[set.source_index]->Cast<BoundAggregateExpression>();
+	if (source_aggregate.GetFilter()) {
+		input = CreateFilter(std::move(input), *source_aggregate.GetFilter(), input_replacements);
+	}
 
 	vector<unique_ptr<Expression>> distinct_groups;
-	distinct_groups.reserve(group_count + source_aggregate.GetChildren().size());
+	distinct_groups.reserve(group_count + source_aggregate.GetChildren().size() + set.order_expressions.size());
 	for (auto &group : aggr.groups) {
 		distinct_groups.push_back(CopyAndRebind(*group, input_replacements));
 	}
 	for (auto &child : source_aggregate.GetChildren()) {
 		distinct_groups.push_back(CopyAndRebind(*child, input_replacements));
+	}
+	for (auto &order_expr : set.order_expressions) {
+		distinct_groups.push_back(CopyAndRebind(*order_expr, input_replacements));
 	}
 
 	auto distinct_group_index = optimizer.binder.GenerateTableIndex();
@@ -156,9 +238,11 @@ static BranchResult CreateDistinctBranch(Optimizer &optimizer, LogicalAggregate 
 
 	vector<unique_ptr<Expression>> final_aggregates;
 	final_aggregates.reserve(set.aggregate_indices.size());
+	const auto order_column_offset = group_count + source_aggregate.GetChildren().size();
 	for (auto aggregate_idx : set.aggregate_indices) {
 		auto &aggregate = aggr.expressions[aggregate_idx]->Cast<BoundAggregateExpression>();
-		final_aggregates.push_back(CreateFinalAggregate(aggregate, distinct_group_index, group_count));
+		final_aggregates.push_back(
+		    CreateFinalAggregate(aggregate, set, distinct_group_index, group_count, order_column_offset));
 	}
 
 	auto final_group_index = optimizer.binder.GenerateTableIndex();
@@ -166,6 +250,113 @@ static BranchResult CreateDistinctBranch(Optimizer &optimizer, LogicalAggregate 
 	auto final = make_uniq<LogicalAggregate>(final_group_index, final_aggregate_index, std::move(final_aggregates));
 	final->groups = std::move(final_groups);
 	final->children.push_back(std::move(distinct));
+	if (aggr.has_estimated_cardinality) {
+		final->SetEstimatedCardinality(aggr.estimated_cardinality);
+	}
+
+	BranchResult result;
+	result.aggregate_indices = set.aggregate_indices;
+	result.plan = CreateProjection(optimizer, std::move(final), final_group_index, final_aggregate_index, aggr.groups,
+	                               aggr.expressions, result.aggregate_indices, result.table_index);
+	return result;
+}
+
+static BranchResult CreateGroupedFilteredDistinctBranch(
+    Optimizer &optimizer, LogicalAggregate &aggr, const DistinctAggregateSet &set,
+    unique_ptr<LogicalOperator> domain_input, const column_binding_map_t<ColumnBinding> &domain_replacements,
+    unique_ptr<LogicalOperator> distinct_input, const column_binding_map_t<ColumnBinding> &distinct_replacements) {
+	const idx_t group_count = aggr.groups.size();
+	auto &source_aggregate = aggr.expressions[set.source_index]->Cast<BoundAggregateExpression>();
+	D_ASSERT(group_count > 0);
+	D_ASSERT(source_aggregate.GetFilter());
+
+	vector<unique_ptr<Expression>> domain_groups;
+	domain_groups.reserve(group_count);
+	for (auto &group : aggr.groups) {
+		domain_groups.push_back(CopyAndRebind(*group, domain_replacements));
+	}
+
+	auto domain_group_index = optimizer.binder.GenerateTableIndex();
+	auto domain_aggregate_index = optimizer.binder.GenerateTableIndex();
+	auto domain =
+	    make_uniq<LogicalAggregate>(domain_group_index, domain_aggregate_index, vector<unique_ptr<Expression>>());
+	domain->groups = std::move(domain_groups);
+	domain->children.push_back(std::move(domain_input));
+	if (aggr.has_estimated_cardinality) {
+		domain->SetEstimatedCardinality(aggr.estimated_cardinality);
+	}
+
+	distinct_input = CreateFilter(std::move(distinct_input), *source_aggregate.GetFilter(), distinct_replacements);
+
+	vector<unique_ptr<Expression>> distinct_groups;
+	distinct_groups.reserve(group_count + source_aggregate.GetChildren().size() + set.order_expressions.size());
+	for (auto &group : aggr.groups) {
+		distinct_groups.push_back(CopyAndRebind(*group, distinct_replacements));
+	}
+	for (auto &child : source_aggregate.GetChildren()) {
+		distinct_groups.push_back(CopyAndRebind(*child, distinct_replacements));
+	}
+	for (auto &order_expr : set.order_expressions) {
+		distinct_groups.push_back(CopyAndRebind(*order_expr, distinct_replacements));
+	}
+
+	auto distinct_group_index = optimizer.binder.GenerateTableIndex();
+	auto distinct_aggregate_index = optimizer.binder.GenerateTableIndex();
+	auto distinct =
+	    make_uniq<LogicalAggregate>(distinct_group_index, distinct_aggregate_index, vector<unique_ptr<Expression>>());
+	distinct->groups = std::move(distinct_groups);
+	distinct->children.push_back(std::move(distinct_input));
+	if (aggr.has_estimated_cardinality) {
+		distinct->SetEstimatedCardinality(aggr.estimated_cardinality);
+	}
+
+	const auto distinct_column_count =
+	    group_count + source_aggregate.GetChildren().size() + set.order_expressions.size();
+	vector<unique_ptr<Expression>> marker_projection_expressions;
+	marker_projection_expressions.reserve(distinct_column_count + 1);
+	for (idx_t col_idx = 0; col_idx < distinct_column_count; col_idx++) {
+		marker_projection_expressions.push_back(make_uniq<BoundColumnRefExpression>(
+		    distinct->groups[col_idx]->GetReturnType(), ColumnBinding(distinct_group_index, ProjectionIndex(col_idx))));
+	}
+	marker_projection_expressions.push_back(make_uniq<BoundConstantExpression>(Value::BOOLEAN(true)));
+	auto marker_projection_index = optimizer.binder.GenerateTableIndex();
+	auto marker_projection =
+	    make_uniq<LogicalProjection>(marker_projection_index, std::move(marker_projection_expressions));
+	marker_projection->children.push_back(std::move(distinct));
+
+	auto join = make_uniq<LogicalComparisonJoin>(JoinType::LEFT);
+	for (idx_t group_idx = 0; group_idx < group_count; group_idx++) {
+		auto left = make_uniq<BoundColumnRefExpression>(aggr.groups[group_idx]->GetReturnType(),
+		                                                ColumnBinding(domain_group_index, ProjectionIndex(group_idx)));
+		auto right =
+		    make_uniq<BoundColumnRefExpression>(aggr.groups[group_idx]->GetReturnType(),
+		                                        ColumnBinding(marker_projection_index, ProjectionIndex(group_idx)));
+		join->conditions.emplace_back(std::move(left), std::move(right), ExpressionType::COMPARE_NOT_DISTINCT_FROM);
+	}
+	join->children.push_back(std::move(domain));
+	join->children.push_back(std::move(marker_projection));
+
+	vector<unique_ptr<Expression>> final_groups;
+	final_groups.reserve(group_count);
+	for (idx_t group_idx = 0; group_idx < group_count; group_idx++) {
+		final_groups.push_back(make_uniq<BoundColumnRefExpression>(
+		    aggr.groups[group_idx]->GetReturnType(), ColumnBinding(domain_group_index, ProjectionIndex(group_idx))));
+	}
+
+	vector<unique_ptr<Expression>> final_aggregates;
+	final_aggregates.reserve(set.aggregate_indices.size());
+	const auto order_column_offset = group_count + source_aggregate.GetChildren().size();
+	for (auto aggregate_idx : set.aggregate_indices) {
+		auto &aggregate = aggr.expressions[aggregate_idx]->Cast<BoundAggregateExpression>();
+		final_aggregates.push_back(CreateFinalAggregate(aggregate, set, marker_projection_index, group_count,
+		                                                order_column_offset, distinct_column_count));
+	}
+
+	auto final_group_index = optimizer.binder.GenerateTableIndex();
+	auto final_aggregate_index = optimizer.binder.GenerateTableIndex();
+	auto final = make_uniq<LogicalAggregate>(final_group_index, final_aggregate_index, std::move(final_aggregates));
+	final->groups = std::move(final_groups);
+	final->children.push_back(std::move(join));
 	if (aggr.has_estimated_cardinality) {
 		final->SetEstimatedCardinality(aggr.estimated_cardinality);
 	}
@@ -281,31 +472,48 @@ bool DistinctAggregateRewriter::TryRewrite(unique_ptr<LogicalOperator> &op) {
 			return false;
 		}
 		auto &aggregate = expr->Cast<BoundAggregateExpression>();
-		if (!CanRewriteDistinctAggregate(aggregate)) {
-			return false;
-		}
 		if (!aggregate.IsDistinct()) {
+			if (!CanRewriteRegularAggregate(aggregate)) {
+				return false;
+			}
 			regular_aggregates.push_back(aggregate_idx);
 			continue;
+		}
+		if (!CanRewriteDistinctAggregate(aggregate)) {
+			return false;
 		}
 		bool found_match = false;
 		for (auto &set : distinct_sets) {
 			auto &other = aggr.expressions[set.source_index]->Cast<BoundAggregateExpression>();
-			if (EqualAggregateChildren(aggregate, other)) {
+			if (EqualAggregateChildren(aggregate, other) && EqualAggregateFilters(aggregate, other)) {
 				set.aggregate_indices.push_back(aggregate_idx);
+				AddOrderExpressions(set, aggregate);
 				found_match = true;
 				break;
 			}
 		}
 		if (!found_match) {
 			distinct_sets.emplace_back(aggregate_idx);
+			AddOrderExpressions(distinct_sets.back(), aggregate);
 		}
 	}
 	if (distinct_sets.empty()) {
 		return false;
 	}
 
-	const bool needs_cte = distinct_sets.size() + (regular_aggregates.empty() ? 0 : 1) > 1;
+	bool has_grouped_filtered_distinct = false;
+	if (!aggr.groups.empty()) {
+		for (auto &set : distinct_sets) {
+			auto &source_aggregate = aggr.expressions[set.source_index]->Cast<BoundAggregateExpression>();
+			if (source_aggregate.GetFilter()) {
+				has_grouped_filtered_distinct = true;
+				break;
+			}
+		}
+	}
+
+	const bool needs_cte =
+	    distinct_sets.size() + (regular_aggregates.empty() ? 0 : 1) > 1 || has_grouped_filtered_distinct;
 	vector<LogicalType> input_types;
 	vector<Identifier> input_names;
 	vector<ColumnBinding> input_bindings;
@@ -328,9 +536,19 @@ bool DistinctAggregateRewriter::TryRewrite(unique_ptr<LogicalOperator> &op) {
 	};
 
 	for (auto &set : distinct_sets) {
-		column_binding_map_t<ColumnBinding> input_replacements;
-		auto branch =
-		    CreateDistinctBranch(optimizer, aggr, set, CreateBranchInput(input_replacements), input_replacements);
+		auto &source_aggregate = aggr.expressions[set.source_index]->Cast<BoundAggregateExpression>();
+		BranchResult branch;
+		if (!aggr.groups.empty() && source_aggregate.GetFilter()) {
+			column_binding_map_t<ColumnBinding> domain_replacements;
+			column_binding_map_t<ColumnBinding> distinct_replacements;
+			branch = CreateGroupedFilteredDistinctBranch(optimizer, aggr, set, CreateBranchInput(domain_replacements),
+			                                             domain_replacements, CreateBranchInput(distinct_replacements),
+			                                             distinct_replacements);
+		} else {
+			column_binding_map_t<ColumnBinding> input_replacements;
+			branch =
+			    CreateDistinctBranch(optimizer, aggr, set, CreateBranchInput(input_replacements), input_replacements);
+		}
 		branch_plans.push_back(std::move(branch.plan));
 		branches.push_back(std::move(branch));
 	}

--- a/src/optimizer/distinct_aggregate_rewriter.cpp
+++ b/src/optimizer/distinct_aggregate_rewriter.cpp
@@ -144,6 +144,7 @@ static BranchResult CreateDistinctBranch(Optimizer &optimizer, LogicalAggregate 
 	}
 	optional_idx filter_column_offset;
 	if (source_aggregate.GetFilter()) {
+		// Keeping FILTER as a deduplication key preserves argument evaluation and groups with no qualifying rows.
 		filter_column_offset = distinct_groups.size();
 		distinct_groups.push_back(
 		    AggregateRewriteHelper::CopyAndRebind(*source_aggregate.GetFilter(), input_replacements));
@@ -226,6 +227,7 @@ static unique_ptr<LogicalOperator> JoinBranches(const vector<BranchResult> &bran
                                                 const vector<unique_ptr<Expression>> &groups) {
 	D_ASSERT(!branch_plans.empty());
 	if (groups.empty()) {
+		// Ungrouped aggregate branches each produce one row, including for empty inputs.
 		auto result = std::move(branch_plans[0]);
 		for (idx_t branch_idx = 1; branch_idx < branch_plans.size(); branch_idx++) {
 			result = LogicalCrossProduct::Create(std::move(result), std::move(branch_plans[branch_idx]));
@@ -233,6 +235,7 @@ static unique_ptr<LogicalOperator> JoinBranches(const vector<BranchResult> &bran
 		return result;
 	}
 
+	// Every branch consumes the same rows and retains every original group; null-safe inner joins preserve NULL keys.
 	auto result = std::move(branch_plans[0]);
 	const auto anchor_table = branches[0].table_index;
 	for (idx_t branch_idx = 1; branch_idx < branch_plans.size(); branch_idx++) {
@@ -396,6 +399,7 @@ bool DistinctAggregateRewriter::TryRewrite(unique_ptr<LogicalOperator> &op) {
 	}
 
 	if (needs_cte) {
+		// DEFAULT keeps the shared input eligible for direct streaming fan-out during CTE planning.
 		auto cte_name = Identifier(StringUtil::Format("__distinct_aggregate_cte_%llu", cte_index.index));
 		result = make_uniq<LogicalMaterializedCTE>(std::move(cte_name), cte_index, input_types.size(),
 		                                           std::move(op->children[0]), std::move(result),

--- a/src/optimizer/distinct_aggregate_rewriter.cpp
+++ b/src/optimizer/distinct_aggregate_rewriter.cpp
@@ -1,0 +1,408 @@
+#include "duckdb/optimizer/distinct_aggregate_rewriter.hpp"
+
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/optimizer/optimizer.hpp"
+#include "duckdb/planner/binder.hpp"
+#include "duckdb/planner/expression/bound_aggregate_expression.hpp"
+#include "duckdb/planner/expression_iterator.hpp"
+#include "duckdb/planner/operator/logical_aggregate.hpp"
+#include "duckdb/planner/operator/logical_comparison_join.hpp"
+#include "duckdb/planner/operator/logical_cross_product.hpp"
+#include "duckdb/planner/operator/logical_cteref.hpp"
+#include "duckdb/planner/operator/logical_materialized_cte.hpp"
+#include "duckdb/planner/operator/logical_projection.hpp"
+
+namespace duckdb {
+
+DistinctAggregateRewriter::DistinctAggregateRewriter(Optimizer &optimizer_p) : optimizer(optimizer_p) {
+}
+
+namespace {
+
+struct DistinctAggregateSet {
+	explicit DistinctAggregateSet(idx_t source_index) : source_index(source_index) {
+		aggregate_indices.push_back(source_index);
+	}
+
+	idx_t source_index;
+	vector<idx_t> aggregate_indices;
+};
+
+struct BranchResult {
+	unique_ptr<LogicalOperator> plan;
+	TableIndex table_index;
+	vector<idx_t> aggregate_indices;
+};
+
+static vector<Identifier> GenerateColumnNames(const string &prefix, idx_t column_count) {
+	vector<Identifier> result;
+	result.reserve(column_count);
+	for (idx_t col_idx = 0; col_idx < column_count; col_idx++) {
+		result.emplace_back(StringUtil::Format("%s_%llu", prefix, col_idx));
+	}
+	return result;
+}
+
+static bool EqualAggregateChildren(const BoundAggregateExpression &left, const BoundAggregateExpression &right) {
+	if (left.GetChildren().size() != right.GetChildren().size()) {
+		return false;
+	}
+	for (idx_t child_idx = 0; child_idx < left.GetChildren().size(); child_idx++) {
+		if (!Expression::Equals(*left.GetChildren()[child_idx], *right.GetChildren()[child_idx])) {
+			return false;
+		}
+	}
+	return true;
+}
+
+static unique_ptr<Expression> CopyAndRebind(const Expression &expr,
+                                            const column_binding_map_t<ColumnBinding> &replacement_map) {
+	auto result = expr.Copy();
+	if (replacement_map.empty()) {
+		return result;
+	}
+	ExpressionIterator::VisitExpressionMutable<BoundColumnRefExpression>(
+	    result, [&](BoundColumnRefExpression &colref, unique_ptr<Expression> &) {
+		    auto entry = replacement_map.find(colref.Binding());
+		    if (entry != replacement_map.end()) {
+			    colref.BindingMutable() = entry->second;
+		    }
+	    });
+	return result;
+}
+
+static bool CanRewriteDistinctAggregate(const BoundAggregateExpression &aggregate) {
+	if (aggregate.StateExportMode() != AggregateStateExportMode::NONE) {
+		return false;
+	}
+	if (aggregate.GetFilter() || aggregate.GetOrderBys()) {
+		return false;
+	}
+	for (auto &child : aggregate.GetChildren()) {
+		if (child->IsVolatile()) {
+			return false;
+		}
+	}
+	return true;
+}
+
+static unique_ptr<BoundAggregateExpression> CreateFinalAggregate(const BoundAggregateExpression &source,
+                                                                 TableIndex input_table, idx_t input_column_offset) {
+	auto result = unique_ptr_cast<Expression, BoundAggregateExpression>(source.Copy());
+	result->GetAggregateTypeMutable() = AggregateType::NON_DISTINCT;
+	result->GetChildrenMutable().clear();
+	for (idx_t child_idx = 0; child_idx < source.GetChildren().size(); child_idx++) {
+		auto &child = source.GetChildren()[child_idx];
+		result->GetChildrenMutable().push_back(make_uniq<BoundColumnRefExpression>(
+		    child->GetReturnType(), ColumnBinding(input_table, ProjectionIndex(input_column_offset + child_idx))));
+	}
+	return result;
+}
+
+static unique_ptr<LogicalOperator> CreateProjection(Optimizer &optimizer, unique_ptr<LogicalOperator> child,
+                                                    TableIndex child_group_index, TableIndex child_aggregate_index,
+                                                    const vector<unique_ptr<Expression>> &groups,
+                                                    const vector<unique_ptr<Expression>> &aggregates,
+                                                    const vector<idx_t> &aggregate_indices,
+                                                    TableIndex &projection_index) {
+	vector<unique_ptr<Expression>> projection_expressions;
+	projection_expressions.reserve(groups.size() + aggregate_indices.size());
+	for (idx_t group_idx = 0; group_idx < groups.size(); group_idx++) {
+		projection_expressions.push_back(make_uniq<BoundColumnRefExpression>(
+		    groups[group_idx]->GetReturnType(), ColumnBinding(child_group_index, ProjectionIndex(group_idx))));
+	}
+	for (idx_t aggregate_idx = 0; aggregate_idx < aggregate_indices.size(); aggregate_idx++) {
+		auto &source = aggregates[aggregate_indices[aggregate_idx]];
+		projection_expressions.push_back(make_uniq<BoundColumnRefExpression>(
+		    source->GetReturnType(), ColumnBinding(child_aggregate_index, ProjectionIndex(aggregate_idx))));
+	}
+	projection_index = optimizer.binder.GenerateTableIndex();
+	auto projection = make_uniq<LogicalProjection>(projection_index, std::move(projection_expressions));
+	projection->children.push_back(std::move(child));
+	return std::move(projection);
+}
+
+static BranchResult CreateDistinctBranch(Optimizer &optimizer, LogicalAggregate &aggr, const DistinctAggregateSet &set,
+                                         unique_ptr<LogicalOperator> input,
+                                         const column_binding_map_t<ColumnBinding> &input_replacements) {
+	const idx_t group_count = aggr.groups.size();
+	auto &source_aggregate = aggr.expressions[set.source_index]->Cast<BoundAggregateExpression>();
+
+	vector<unique_ptr<Expression>> distinct_groups;
+	distinct_groups.reserve(group_count + source_aggregate.GetChildren().size());
+	for (auto &group : aggr.groups) {
+		distinct_groups.push_back(CopyAndRebind(*group, input_replacements));
+	}
+	for (auto &child : source_aggregate.GetChildren()) {
+		distinct_groups.push_back(CopyAndRebind(*child, input_replacements));
+	}
+
+	auto distinct_group_index = optimizer.binder.GenerateTableIndex();
+	auto distinct_aggregate_index = optimizer.binder.GenerateTableIndex();
+	auto distinct =
+	    make_uniq<LogicalAggregate>(distinct_group_index, distinct_aggregate_index, vector<unique_ptr<Expression>>());
+	distinct->groups = std::move(distinct_groups);
+	distinct->children.push_back(std::move(input));
+	if (aggr.has_estimated_cardinality) {
+		distinct->SetEstimatedCardinality(aggr.estimated_cardinality);
+	}
+
+	vector<unique_ptr<Expression>> final_groups;
+	final_groups.reserve(group_count);
+	for (idx_t group_idx = 0; group_idx < group_count; group_idx++) {
+		final_groups.push_back(make_uniq<BoundColumnRefExpression>(
+		    aggr.groups[group_idx]->GetReturnType(), ColumnBinding(distinct_group_index, ProjectionIndex(group_idx))));
+	}
+
+	vector<unique_ptr<Expression>> final_aggregates;
+	final_aggregates.reserve(set.aggregate_indices.size());
+	for (auto aggregate_idx : set.aggregate_indices) {
+		auto &aggregate = aggr.expressions[aggregate_idx]->Cast<BoundAggregateExpression>();
+		final_aggregates.push_back(CreateFinalAggregate(aggregate, distinct_group_index, group_count));
+	}
+
+	auto final_group_index = optimizer.binder.GenerateTableIndex();
+	auto final_aggregate_index = optimizer.binder.GenerateTableIndex();
+	auto final = make_uniq<LogicalAggregate>(final_group_index, final_aggregate_index, std::move(final_aggregates));
+	final->groups = std::move(final_groups);
+	final->children.push_back(std::move(distinct));
+	if (aggr.has_estimated_cardinality) {
+		final->SetEstimatedCardinality(aggr.estimated_cardinality);
+	}
+
+	BranchResult result;
+	result.aggregate_indices = set.aggregate_indices;
+	result.plan = CreateProjection(optimizer, std::move(final), final_group_index, final_aggregate_index, aggr.groups,
+	                               aggr.expressions, result.aggregate_indices, result.table_index);
+	return result;
+}
+
+static BranchResult CreateRegularBranch(Optimizer &optimizer, LogicalAggregate &aggr,
+                                        const vector<idx_t> &aggregate_indices, unique_ptr<LogicalOperator> input,
+                                        const column_binding_map_t<ColumnBinding> &input_replacements) {
+	vector<unique_ptr<Expression>> regular_groups;
+	regular_groups.reserve(aggr.groups.size());
+	for (auto &group : aggr.groups) {
+		regular_groups.push_back(CopyAndRebind(*group, input_replacements));
+	}
+
+	vector<unique_ptr<Expression>> regular_aggregates;
+	regular_aggregates.reserve(aggregate_indices.size());
+	for (auto aggregate_idx : aggregate_indices) {
+		regular_aggregates.push_back(CopyAndRebind(*aggr.expressions[aggregate_idx], input_replacements));
+	}
+
+	auto regular_group_index = optimizer.binder.GenerateTableIndex();
+	auto regular_aggregate_index = optimizer.binder.GenerateTableIndex();
+	auto regular =
+	    make_uniq<LogicalAggregate>(regular_group_index, regular_aggregate_index, std::move(regular_aggregates));
+	regular->groups = std::move(regular_groups);
+	regular->children.push_back(std::move(input));
+	if (aggr.has_estimated_cardinality) {
+		regular->SetEstimatedCardinality(aggr.estimated_cardinality);
+	}
+
+	BranchResult result;
+	result.aggregate_indices = aggregate_indices;
+	result.plan = CreateProjection(optimizer, std::move(regular), regular_group_index, regular_aggregate_index,
+	                               aggr.groups, aggr.expressions, result.aggregate_indices, result.table_index);
+	return result;
+}
+
+static unique_ptr<LogicalOperator> CreateCTERef(Optimizer &optimizer, TableIndex cte_index,
+                                                const vector<LogicalType> &input_types,
+                                                const vector<Identifier> &input_names,
+                                                const vector<ColumnBinding> &input_bindings,
+                                                column_binding_map_t<ColumnBinding> &replacement_map) {
+	auto cte_ref_index = optimizer.binder.GenerateTableIndex();
+	for (idx_t col_idx = 0; col_idx < input_bindings.size(); col_idx++) {
+		replacement_map[input_bindings[col_idx]] = ColumnBinding(cte_ref_index, ProjectionIndex(col_idx));
+	}
+	return make_uniq<LogicalCTERef>(cte_ref_index, cte_index, input_types, input_names);
+}
+
+static unique_ptr<LogicalOperator> JoinBranches(const vector<BranchResult> &branches,
+                                                vector<unique_ptr<LogicalOperator>> branch_plans,
+                                                const vector<unique_ptr<Expression>> &groups) {
+	D_ASSERT(!branch_plans.empty());
+	if (groups.empty()) {
+		auto result = std::move(branch_plans[0]);
+		for (idx_t branch_idx = 1; branch_idx < branch_plans.size(); branch_idx++) {
+			result = LogicalCrossProduct::Create(std::move(result), std::move(branch_plans[branch_idx]));
+		}
+		return result;
+	}
+
+	auto result = std::move(branch_plans[0]);
+	const auto anchor_table = branches[0].table_index;
+	for (idx_t branch_idx = 1; branch_idx < branch_plans.size(); branch_idx++) {
+		auto join = make_uniq<LogicalComparisonJoin>(JoinType::INNER);
+		for (idx_t group_idx = 0; group_idx < groups.size(); group_idx++) {
+			auto left = make_uniq<BoundColumnRefExpression>(groups[group_idx]->GetReturnType(),
+			                                                ColumnBinding(anchor_table, ProjectionIndex(group_idx)));
+			auto right = make_uniq<BoundColumnRefExpression>(
+			    groups[group_idx]->GetReturnType(),
+			    ColumnBinding(branches[branch_idx].table_index, ProjectionIndex(group_idx)));
+			join->conditions.emplace_back(std::move(left), std::move(right), ExpressionType::COMPARE_NOT_DISTINCT_FROM);
+		}
+		join->children.push_back(std::move(result));
+		join->children.push_back(std::move(branch_plans[branch_idx]));
+		result = std::move(join);
+	}
+	return result;
+}
+
+} // namespace
+
+bool DistinctAggregateRewriter::TryRewrite(unique_ptr<LogicalOperator> &op) {
+	if (op->type != LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY || op->children.size() != 1) {
+		return false;
+	}
+	auto &aggr = op->Cast<LogicalAggregate>();
+	if (aggr.grouping_sets.size() > 1 || !aggr.grouping_functions.empty() || aggr.expressions.empty()) {
+		return false;
+	}
+	if (aggr.grouping_sets.size() == 1) {
+		if (aggr.grouping_sets[0].size() != aggr.groups.size()) {
+			return false;
+		}
+		for (idx_t group_idx = 0; group_idx < aggr.groups.size(); group_idx++) {
+			if (aggr.grouping_sets[0].find(ProjectionIndex(group_idx)) == aggr.grouping_sets[0].end()) {
+				return false;
+			}
+		}
+	}
+
+	vector<DistinctAggregateSet> distinct_sets;
+	vector<idx_t> regular_aggregates;
+	for (idx_t aggregate_idx = 0; aggregate_idx < aggr.expressions.size(); aggregate_idx++) {
+		auto &expr = aggr.expressions[aggregate_idx];
+		if (expr->GetExpressionClass() != ExpressionClass::BOUND_AGGREGATE) {
+			return false;
+		}
+		auto &aggregate = expr->Cast<BoundAggregateExpression>();
+		if (!CanRewriteDistinctAggregate(aggregate)) {
+			return false;
+		}
+		if (!aggregate.IsDistinct()) {
+			regular_aggregates.push_back(aggregate_idx);
+			continue;
+		}
+		bool found_match = false;
+		for (auto &set : distinct_sets) {
+			auto &other = aggr.expressions[set.source_index]->Cast<BoundAggregateExpression>();
+			if (EqualAggregateChildren(aggregate, other)) {
+				set.aggregate_indices.push_back(aggregate_idx);
+				found_match = true;
+				break;
+			}
+		}
+		if (!found_match) {
+			distinct_sets.emplace_back(aggregate_idx);
+		}
+	}
+	if (distinct_sets.empty()) {
+		return false;
+	}
+
+	const bool needs_cte = distinct_sets.size() + (regular_aggregates.empty() ? 0 : 1) > 1;
+	vector<LogicalType> input_types;
+	vector<Identifier> input_names;
+	vector<ColumnBinding> input_bindings;
+	TableIndex cte_index;
+	if (needs_cte) {
+		op->children[0]->ResolveOperatorTypes();
+		input_types = op->children[0]->types;
+		input_names = GenerateColumnNames("__distinct_input", input_types.size());
+		input_bindings = op->children[0]->GetColumnBindings();
+		cte_index = optimizer.binder.GenerateTableIndex();
+	}
+
+	vector<BranchResult> branches;
+	vector<unique_ptr<LogicalOperator>> branch_plans;
+	auto CreateBranchInput = [&](column_binding_map_t<ColumnBinding> &input_replacements) {
+		if (!needs_cte) {
+			return std::move(op->children[0]);
+		}
+		return CreateCTERef(optimizer, cte_index, input_types, input_names, input_bindings, input_replacements);
+	};
+
+	for (auto &set : distinct_sets) {
+		column_binding_map_t<ColumnBinding> input_replacements;
+		auto branch =
+		    CreateDistinctBranch(optimizer, aggr, set, CreateBranchInput(input_replacements), input_replacements);
+		branch_plans.push_back(std::move(branch.plan));
+		branches.push_back(std::move(branch));
+	}
+	if (!regular_aggregates.empty()) {
+		column_binding_map_t<ColumnBinding> input_replacements;
+		auto branch = CreateRegularBranch(optimizer, aggr, regular_aggregates, CreateBranchInput(input_replacements),
+		                                  input_replacements);
+		branch_plans.push_back(std::move(branch.plan));
+		branches.push_back(std::move(branch));
+	}
+
+	vector<ColumnBinding> aggregate_bindings(aggr.expressions.size());
+	for (auto &branch : branches) {
+		for (idx_t local_idx = 0; local_idx < branch.aggregate_indices.size(); local_idx++) {
+			aggregate_bindings[branch.aggregate_indices[local_idx]] =
+			    ColumnBinding(branch.table_index, ProjectionIndex(aggr.groups.size() + local_idx));
+		}
+	}
+
+	auto joined = JoinBranches(branches, std::move(branch_plans), aggr.groups);
+
+	vector<unique_ptr<Expression>> projection_expressions;
+	projection_expressions.reserve(aggr.groups.size() + aggr.expressions.size());
+	const auto final_projection_index = optimizer.binder.GenerateTableIndex();
+	for (idx_t group_idx = 0; group_idx < aggr.groups.size(); group_idx++) {
+		projection_expressions.push_back(
+		    make_uniq<BoundColumnRefExpression>(aggr.groups[group_idx]->GetReturnType(),
+		                                        ColumnBinding(branches[0].table_index, ProjectionIndex(group_idx))));
+		replacement_map[ColumnBinding(aggr.group_index, ProjectionIndex(group_idx))] =
+		    ColumnBinding(final_projection_index, ProjectionIndex(group_idx));
+	}
+	for (idx_t aggregate_idx = 0; aggregate_idx < aggr.expressions.size(); aggregate_idx++) {
+		projection_expressions.push_back(make_uniq<BoundColumnRefExpression>(
+		    aggr.expressions[aggregate_idx]->GetReturnType(), aggregate_bindings[aggregate_idx]));
+		replacement_map[ColumnBinding(aggr.aggregate_index, ProjectionIndex(aggregate_idx))] =
+		    ColumnBinding(final_projection_index, ProjectionIndex(aggr.groups.size() + aggregate_idx));
+	}
+
+	unique_ptr<LogicalOperator> result =
+	    make_uniq<LogicalProjection>(final_projection_index, std::move(projection_expressions));
+	result->children.push_back(std::move(joined));
+	if (aggr.has_estimated_cardinality) {
+		result->SetEstimatedCardinality(aggr.estimated_cardinality);
+	}
+
+	if (needs_cte) {
+		auto cte_name = Identifier(StringUtil::Format("__distinct_aggregate_cte_%llu", cte_index.index));
+		result = make_uniq<LogicalMaterializedCTE>(std::move(cte_name), cte_index, input_types.size(),
+		                                           std::move(op->children[0]), std::move(result),
+		                                           CTEMaterialize::CTE_MATERIALIZE_ALWAYS);
+		if (aggr.has_estimated_cardinality) {
+			result->SetEstimatedCardinality(aggr.estimated_cardinality);
+		}
+	}
+
+	result->ResolveOperatorTypes();
+	op = std::move(result);
+	return true;
+}
+
+void DistinctAggregateRewriter::VisitOperator(unique_ptr<LogicalOperator> &op) {
+	LogicalOperatorVisitor::VisitOperator(op);
+	TryRewrite(op);
+}
+
+unique_ptr<Expression> DistinctAggregateRewriter::VisitReplace(BoundColumnRefExpression &expr,
+                                                               unique_ptr<Expression> *expr_ptr) {
+	auto entry = replacement_map.find(expr.Binding());
+	if (entry != replacement_map.end()) {
+		expr.BindingMutable() = entry->second;
+	}
+	return nullptr;
+}
+
+} // namespace duckdb

--- a/src/optimizer/grouping_sets_optimizer.cpp
+++ b/src/optimizer/grouping_sets_optimizer.cpp
@@ -9,6 +9,7 @@
 #include "duckdb/planner/binder.hpp"
 #include "duckdb/planner/expression/bound_aggregate_expression.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
+#include "duckdb/planner/expression_iterator.hpp"
 #include "duckdb/planner/operator/logical_aggregate.hpp"
 #include "duckdb/planner/operator/logical_cteref.hpp"
 #include "duckdb/planner/operator/logical_materialized_cte.hpp"
@@ -66,6 +67,137 @@ static bool CanRewriteAggregate(const BoundAggregateExpression &aggregate) {
 	return true;
 }
 
+static vector<Identifier> GenerateGroupingSetColumnNames(const string &prefix, idx_t column_count) {
+	vector<Identifier> result;
+	result.reserve(column_count);
+	for (idx_t col_idx = 0; col_idx < column_count; col_idx++) {
+		result.emplace_back(StringUtil::Format("%s_%llu", prefix, col_idx));
+	}
+	return result;
+}
+
+static unique_ptr<Expression> CopyAndRebindGroupingSet(const Expression &expr,
+                                                       const column_binding_map_t<ColumnBinding> &replacement_map) {
+	auto result = expr.Copy();
+	if (replacement_map.empty()) {
+		return result;
+	}
+	ExpressionIterator::VisitExpressionMutable<BoundColumnRefExpression>(
+	    result, [&](BoundColumnRefExpression &colref, unique_ptr<Expression> &) {
+		    auto entry = replacement_map.find(colref.Binding());
+		    if (entry != replacement_map.end()) {
+			    colref.BindingMutable() = entry->second;
+		    }
+	    });
+	return result;
+}
+
+static void RebindGroupingSetExpression(unique_ptr<Expression> &expr,
+                                        const column_binding_map_t<ColumnBinding> &replacement_map) {
+	if (!expr || replacement_map.empty()) {
+		return;
+	}
+	ExpressionIterator::VisitExpressionMutable<BoundColumnRefExpression>(
+	    expr, [&](BoundColumnRefExpression &colref, unique_ptr<Expression> &) {
+		    auto entry = replacement_map.find(colref.Binding());
+		    if (entry != replacement_map.end()) {
+			    colref.BindingMutable() = entry->second;
+		    }
+	    });
+}
+
+static bool StageGroupingSetExpression(unique_ptr<Expression> &expr, TableIndex projection_index,
+                                       vector<unique_ptr<Expression>> &projection_expressions, bool force = false) {
+	if (!expr || (!force && !expr->IsVolatile())) {
+		return false;
+	}
+	auto return_type = expr->GetReturnType();
+	const auto column_index = projection_expressions.size();
+	projection_expressions.push_back(std::move(expr));
+	expr = make_uniq<BoundColumnRefExpression>(return_type,
+	                                           ColumnBinding(projection_index, ProjectionIndex(column_index)));
+	return true;
+}
+
+static bool StageVolatileGroupingSetInputs(Optimizer &optimizer, LogicalAggregate &aggr,
+                                           unique_ptr<LogicalOperator> &child) {
+	child->ResolveOperatorTypes();
+	auto child_bindings = child->GetColumnBindings();
+	auto projection_index = optimizer.binder.GenerateTableIndex();
+
+	column_binding_map_t<ColumnBinding> projection_replacements;
+	vector<unique_ptr<Expression>> projection_expressions;
+	projection_expressions.reserve(child_bindings.size());
+	for (idx_t col_idx = 0; col_idx < child_bindings.size(); col_idx++) {
+		projection_replacements[child_bindings[col_idx]] = ColumnBinding(projection_index, ProjectionIndex(col_idx));
+		projection_expressions.push_back(
+		    make_uniq<BoundColumnRefExpression>(child->types[col_idx], child_bindings[col_idx]));
+	}
+
+	bool staged = false;
+	for (auto &group : aggr.groups) {
+		staged |= StageGroupingSetExpression(group, projection_index, projection_expressions);
+	}
+	for (auto &expr : aggr.expressions) {
+		auto &aggregate = expr->Cast<BoundAggregateExpression>();
+		bool has_volatile_payload = false;
+		for (auto &child_expr : aggregate.GetChildrenMutable()) {
+			has_volatile_payload |= child_expr->IsVolatile();
+			staged |= StageGroupingSetExpression(child_expr, projection_index, projection_expressions);
+		}
+		if (aggregate.GetOrderBys()) {
+			for (auto &order : aggregate.GetOrderBysMutable()->orders) {
+				has_volatile_payload |= order.expression->IsVolatile();
+				staged |= StageGroupingSetExpression(order.expression, projection_index, projection_expressions);
+			}
+		}
+		const bool stage_filter =
+		    aggregate.GetFilter() && (has_volatile_payload || aggregate.GetFilter()->IsVolatile());
+		staged |= StageGroupingSetExpression(aggregate.GetFilterMutable(), projection_index, projection_expressions,
+		                                     stage_filter);
+	}
+
+	if (!staged) {
+		return false;
+	}
+
+	for (auto &group : aggr.groups) {
+		RebindGroupingSetExpression(group, projection_replacements);
+	}
+	for (auto &expr : aggr.expressions) {
+		RebindGroupingSetExpression(expr, projection_replacements);
+	}
+
+	auto projection = make_uniq<LogicalProjection>(projection_index, std::move(projection_expressions));
+	projection->children.push_back(std::move(child));
+	child = std::move(projection);
+	return true;
+}
+
+static unique_ptr<LogicalOperator> CreateGroupingSetCTERef(Optimizer &optimizer, TableIndex cte_index,
+                                                           const vector<LogicalType> &input_types,
+                                                           const vector<Identifier> &input_names,
+                                                           const vector<ColumnBinding> &input_bindings,
+                                                           column_binding_map_t<ColumnBinding> &replacement_map) {
+	auto cte_ref_index = optimizer.binder.GenerateTableIndex();
+	for (idx_t col_idx = 0; col_idx < input_bindings.size(); col_idx++) {
+		replacement_map[input_bindings[col_idx]] = ColumnBinding(cte_ref_index, ProjectionIndex(col_idx));
+	}
+	return make_uniq<LogicalCTERef>(cte_ref_index, cte_index, input_types, input_names);
+}
+
+static int64_t GetGroupingValue(const GroupingSet &grouping_set,
+                                const unsafe_vector<ProjectionIndex> &grouping_function) {
+	int64_t grouping_value = 0;
+	for (idx_t i = 0; i < grouping_function.size(); i++) {
+		if (grouping_set.find(grouping_function[i]) == grouping_set.end()) {
+			// we do not group on this column in this grouping set
+			grouping_value += 1LL << (grouping_function.size() - (i + 1));
+		}
+	}
+	return grouping_value;
+}
+
 //! Order the grouping sets so that each set can be computed by re-aggregating an already-computed superset
 static bool FindCascade(const vector<GroupingSet> &grouping_sets, vector<GroupingSetLevel> &levels) {
 	// order the grouping sets by size (descending) - supersets must be computed before their subsets
@@ -95,6 +227,113 @@ static bool FindCascade(const vector<GroupingSet> &grouping_sets, vector<Groupin
 	return true;
 }
 
+bool GroupingSetsOptimizer::TryExpandGroupingSets(unique_ptr<LogicalOperator> &op) {
+	auto &aggr = op->Cast<LogicalAggregate>();
+	const idx_t group_count = aggr.groups.size();
+	const idx_t aggregate_count = aggr.expressions.size();
+
+	StageVolatileGroupingSetInputs(optimizer, aggr, op->children[0]);
+
+	op->children[0]->ResolveOperatorTypes();
+	auto input_types = op->children[0]->types;
+	auto input_names = GenerateGroupingSetColumnNames("__grouping_sets_input", input_types.size());
+	auto input_bindings = op->children[0]->GetColumnBindings();
+	const auto cte_index = optimizer.binder.GenerateTableIndex();
+
+	vector<unique_ptr<LogicalOperator>> branches(aggr.grouping_sets.size());
+	for (idx_t grouping_set_idx = 0; grouping_set_idx < aggr.grouping_sets.size(); grouping_set_idx++) {
+		auto &grouping_set = aggr.grouping_sets[grouping_set_idx];
+
+		column_binding_map_t<ColumnBinding> input_replacements;
+		auto branch_child =
+		    CreateGroupingSetCTERef(optimizer, cte_index, input_types, input_names, input_bindings, input_replacements);
+
+		map<ProjectionIndex, idx_t> group_positions;
+		vector<unique_ptr<Expression>> branch_groups;
+		branch_groups.reserve(grouping_set.size());
+		for (auto &group_idx : grouping_set) {
+			group_positions[group_idx] = branch_groups.size();
+			branch_groups.push_back(CopyAndRebindGroupingSet(*aggr.groups[group_idx], input_replacements));
+		}
+
+		vector<unique_ptr<Expression>> branch_aggregates;
+		branch_aggregates.reserve(aggregate_count);
+		for (auto &expr : aggr.expressions) {
+			branch_aggregates.push_back(CopyAndRebindGroupingSet(*expr, input_replacements));
+		}
+
+		auto branch_group_index = optimizer.binder.GenerateTableIndex();
+		auto branch_aggregate_index = optimizer.binder.GenerateTableIndex();
+		auto branch_aggregate =
+		    make_uniq<LogicalAggregate>(branch_group_index, branch_aggregate_index, std::move(branch_aggregates));
+		branch_aggregate->groups = std::move(branch_groups);
+		branch_aggregate->children.push_back(std::move(branch_child));
+		if (aggr.has_estimated_cardinality) {
+			branch_aggregate->SetEstimatedCardinality(aggr.estimated_cardinality);
+		}
+
+		vector<unique_ptr<Expression>> projection_expressions;
+		projection_expressions.reserve(group_count + aggregate_count + aggr.grouping_functions.size());
+		for (idx_t group_idx = 0; group_idx < group_count; group_idx++) {
+			auto &group_type = aggr.groups[group_idx]->GetReturnType();
+			auto entry = group_positions.find(ProjectionIndex(group_idx));
+			if (entry == group_positions.end()) {
+				projection_expressions.push_back(make_uniq<BoundConstantExpression>(Value(group_type)));
+			} else {
+				projection_expressions.push_back(make_uniq<BoundColumnRefExpression>(
+				    group_type, ColumnBinding(branch_group_index, ProjectionIndex(entry->second))));
+			}
+		}
+		for (idx_t aggregate_idx = 0; aggregate_idx < aggregate_count; aggregate_idx++) {
+			projection_expressions.push_back(make_uniq<BoundColumnRefExpression>(
+			    aggr.expressions[aggregate_idx]->GetReturnType(),
+			    ColumnBinding(branch_aggregate_index, ProjectionIndex(aggregate_idx))));
+		}
+		for (auto &grouping_function : aggr.grouping_functions) {
+			projection_expressions.push_back(
+			    make_uniq<BoundConstantExpression>(Value::BIGINT(GetGroupingValue(grouping_set, grouping_function))));
+		}
+
+		auto projection =
+		    make_uniq<LogicalProjection>(optimizer.binder.GenerateTableIndex(), std::move(projection_expressions));
+		projection->children.push_back(std::move(branch_aggregate));
+		branches[grouping_set_idx] = std::move(projection);
+	}
+
+	const idx_t column_count = group_count + aggregate_count + aggr.grouping_functions.size();
+	const auto union_index = optimizer.binder.GenerateTableIndex();
+	unique_ptr<LogicalOperator> result = make_uniq<LogicalSetOperation>(union_index, column_count, std::move(branches),
+	                                                                    LogicalOperatorType::LOGICAL_UNION, true);
+	if (aggr.has_estimated_cardinality) {
+		result->SetEstimatedCardinality(aggr.estimated_cardinality);
+	}
+
+	auto cte_name = Identifier(StringUtil::Format("__grouping_sets_input_cte_%llu", cte_index.index));
+	result = make_uniq<LogicalMaterializedCTE>(std::move(cte_name), cte_index, input_types.size(),
+	                                           std::move(op->children[0]), std::move(result),
+	                                           CTEMaterialize::CTE_MATERIALIZE_DEFAULT);
+	if (aggr.has_estimated_cardinality) {
+		result->SetEstimatedCardinality(aggr.estimated_cardinality);
+	}
+
+	for (idx_t group_idx = 0; group_idx < group_count; group_idx++) {
+		replacement_map[ColumnBinding(aggr.group_index, ProjectionIndex(group_idx))] =
+		    ColumnBinding(union_index, ProjectionIndex(group_idx));
+	}
+	for (idx_t aggregate_idx = 0; aggregate_idx < aggregate_count; aggregate_idx++) {
+		replacement_map[ColumnBinding(aggr.aggregate_index, ProjectionIndex(aggregate_idx))] =
+		    ColumnBinding(union_index, ProjectionIndex(group_count + aggregate_idx));
+	}
+	for (idx_t grouping_idx = 0; grouping_idx < aggr.grouping_functions.size(); grouping_idx++) {
+		replacement_map[ColumnBinding(aggr.groupings_index, ProjectionIndex(grouping_idx))] =
+		    ColumnBinding(union_index, ProjectionIndex(group_count + aggregate_count + grouping_idx));
+	}
+
+	result->ResolveOperatorTypes();
+	op = std::move(result);
+	return true;
+}
+
 bool GroupingSetsOptimizer::TryRewriteGroupingSets(unique_ptr<LogicalOperator> &op) {
 	if (op->type != LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY || op->children.size() != 1) {
 		return false;
@@ -104,17 +343,18 @@ bool GroupingSetsOptimizer::TryRewriteGroupingSets(unique_ptr<LogicalOperator> &
 		// the rewrite is only beneficial when multiple grouping sets are computed
 		return false;
 	}
+	bool can_cascade = true;
 	for (auto &expr : aggr.expressions) {
 		if (expr->GetExpressionClass() != ExpressionClass::BOUND_AGGREGATE) {
 			return false;
 		}
 		if (!CanRewriteAggregate(expr->Cast<BoundAggregateExpression>())) {
-			return false;
+			can_cascade = false;
 		}
 	}
 	vector<GroupingSetLevel> levels;
-	if (!FindCascade(aggr.grouping_sets, levels)) {
-		return false;
+	if (!can_cascade || !FindCascade(aggr.grouping_sets, levels)) {
+		return TryExpandGroupingSets(op);
 	}
 
 	const idx_t group_count = aggr.groups.size();

--- a/src/optimizer/grouping_sets_optimizer.cpp
+++ b/src/optimizer/grouping_sets_optimizer.cpp
@@ -5,11 +5,11 @@
 #include "duckdb/function/aggregate/distributive_functions.hpp"
 #include "duckdb/function/function_binder.hpp"
 #include "duckdb/function/scalar/generic_common.hpp"
+#include "duckdb/optimizer/aggregate_rewrite_helper.hpp"
 #include "duckdb/optimizer/optimizer.hpp"
 #include "duckdb/planner/binder.hpp"
 #include "duckdb/planner/expression/bound_aggregate_expression.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
-#include "duckdb/planner/expression_iterator.hpp"
 #include "duckdb/planner/operator/logical_aggregate.hpp"
 #include "duckdb/planner/operator/logical_cteref.hpp"
 #include "duckdb/planner/operator/logical_materialized_cte.hpp"
@@ -67,125 +67,6 @@ static bool CanRewriteAggregate(const BoundAggregateExpression &aggregate) {
 	return true;
 }
 
-static vector<Identifier> GenerateGroupingSetColumnNames(const string &prefix, idx_t column_count) {
-	vector<Identifier> result;
-	result.reserve(column_count);
-	for (idx_t col_idx = 0; col_idx < column_count; col_idx++) {
-		result.emplace_back(StringUtil::Format("%s_%llu", prefix, col_idx));
-	}
-	return result;
-}
-
-static unique_ptr<Expression> CopyAndRebindGroupingSet(const Expression &expr,
-                                                       const column_binding_map_t<ColumnBinding> &replacement_map) {
-	auto result = expr.Copy();
-	if (replacement_map.empty()) {
-		return result;
-	}
-	ExpressionIterator::VisitExpressionMutable<BoundColumnRefExpression>(
-	    result, [&](BoundColumnRefExpression &colref, unique_ptr<Expression> &) {
-		    auto entry = replacement_map.find(colref.Binding());
-		    if (entry != replacement_map.end()) {
-			    colref.BindingMutable() = entry->second;
-		    }
-	    });
-	return result;
-}
-
-static void RebindGroupingSetExpression(unique_ptr<Expression> &expr,
-                                        const column_binding_map_t<ColumnBinding> &replacement_map) {
-	if (!expr || replacement_map.empty()) {
-		return;
-	}
-	ExpressionIterator::VisitExpressionMutable<BoundColumnRefExpression>(
-	    expr, [&](BoundColumnRefExpression &colref, unique_ptr<Expression> &) {
-		    auto entry = replacement_map.find(colref.Binding());
-		    if (entry != replacement_map.end()) {
-			    colref.BindingMutable() = entry->second;
-		    }
-	    });
-}
-
-static bool StageGroupingSetExpression(unique_ptr<Expression> &expr, TableIndex projection_index,
-                                       vector<unique_ptr<Expression>> &projection_expressions, bool force = false) {
-	if (!expr || (!force && !expr->IsVolatile())) {
-		return false;
-	}
-	auto return_type = expr->GetReturnType();
-	const auto column_index = projection_expressions.size();
-	projection_expressions.push_back(std::move(expr));
-	expr = make_uniq<BoundColumnRefExpression>(return_type,
-	                                           ColumnBinding(projection_index, ProjectionIndex(column_index)));
-	return true;
-}
-
-static bool StageVolatileGroupingSetInputs(Optimizer &optimizer, LogicalAggregate &aggr,
-                                           unique_ptr<LogicalOperator> &child) {
-	child->ResolveOperatorTypes();
-	auto child_bindings = child->GetColumnBindings();
-	auto projection_index = optimizer.binder.GenerateTableIndex();
-
-	column_binding_map_t<ColumnBinding> projection_replacements;
-	vector<unique_ptr<Expression>> projection_expressions;
-	projection_expressions.reserve(child_bindings.size());
-	for (idx_t col_idx = 0; col_idx < child_bindings.size(); col_idx++) {
-		projection_replacements[child_bindings[col_idx]] = ColumnBinding(projection_index, ProjectionIndex(col_idx));
-		projection_expressions.push_back(
-		    make_uniq<BoundColumnRefExpression>(child->types[col_idx], child_bindings[col_idx]));
-	}
-
-	bool staged = false;
-	for (auto &group : aggr.groups) {
-		staged |= StageGroupingSetExpression(group, projection_index, projection_expressions);
-	}
-	for (auto &expr : aggr.expressions) {
-		auto &aggregate = expr->Cast<BoundAggregateExpression>();
-		bool has_volatile_payload = false;
-		for (auto &child_expr : aggregate.GetChildrenMutable()) {
-			has_volatile_payload |= child_expr->IsVolatile();
-			staged |= StageGroupingSetExpression(child_expr, projection_index, projection_expressions);
-		}
-		if (aggregate.GetOrderBys()) {
-			for (auto &order : aggregate.GetOrderBysMutable()->orders) {
-				has_volatile_payload |= order.expression->IsVolatile();
-				staged |= StageGroupingSetExpression(order.expression, projection_index, projection_expressions);
-			}
-		}
-		const bool stage_filter =
-		    aggregate.GetFilter() && (has_volatile_payload || aggregate.GetFilter()->IsVolatile());
-		staged |= StageGroupingSetExpression(aggregate.GetFilterMutable(), projection_index, projection_expressions,
-		                                     stage_filter);
-	}
-
-	if (!staged) {
-		return false;
-	}
-
-	for (auto &group : aggr.groups) {
-		RebindGroupingSetExpression(group, projection_replacements);
-	}
-	for (auto &expr : aggr.expressions) {
-		RebindGroupingSetExpression(expr, projection_replacements);
-	}
-
-	auto projection = make_uniq<LogicalProjection>(projection_index, std::move(projection_expressions));
-	projection->children.push_back(std::move(child));
-	child = std::move(projection);
-	return true;
-}
-
-static unique_ptr<LogicalOperator> CreateGroupingSetCTERef(Optimizer &optimizer, TableIndex cte_index,
-                                                           const vector<LogicalType> &input_types,
-                                                           const vector<Identifier> &input_names,
-                                                           const vector<ColumnBinding> &input_bindings,
-                                                           column_binding_map_t<ColumnBinding> &replacement_map) {
-	auto cte_ref_index = optimizer.binder.GenerateTableIndex();
-	for (idx_t col_idx = 0; col_idx < input_bindings.size(); col_idx++) {
-		replacement_map[input_bindings[col_idx]] = ColumnBinding(cte_ref_index, ProjectionIndex(col_idx));
-	}
-	return make_uniq<LogicalCTERef>(cte_ref_index, cte_index, input_types, input_names);
-}
-
 static int64_t GetGroupingValue(const GroupingSet &grouping_set,
                                 const unsafe_vector<ProjectionIndex> &grouping_function) {
 	int64_t grouping_value = 0;
@@ -232,11 +113,11 @@ bool GroupingSetsOptimizer::TryExpandGroupingSets(unique_ptr<LogicalOperator> &o
 	const idx_t group_count = aggr.groups.size();
 	const idx_t aggregate_count = aggr.expressions.size();
 
-	StageVolatileGroupingSetInputs(optimizer, aggr, op->children[0]);
+	AggregateRewriteHelper::StageVolatileAggregateInputs(optimizer, aggr, op->children[0]);
 
 	op->children[0]->ResolveOperatorTypes();
 	auto input_types = op->children[0]->types;
-	auto input_names = GenerateGroupingSetColumnNames("__grouping_sets_input", input_types.size());
+	auto input_names = AggregateRewriteHelper::GenerateColumnNames("__grouping_sets_input", input_types.size());
 	auto input_bindings = op->children[0]->GetColumnBindings();
 	const auto cte_index = optimizer.binder.GenerateTableIndex();
 
@@ -245,21 +126,21 @@ bool GroupingSetsOptimizer::TryExpandGroupingSets(unique_ptr<LogicalOperator> &o
 		auto &grouping_set = aggr.grouping_sets[grouping_set_idx];
 
 		column_binding_map_t<ColumnBinding> input_replacements;
-		auto branch_child =
-		    CreateGroupingSetCTERef(optimizer, cte_index, input_types, input_names, input_bindings, input_replacements);
+		auto branch_child = AggregateRewriteHelper::CreateCTERef(optimizer, cte_index, input_types, input_names,
+		                                                         input_bindings, input_replacements);
 
 		map<ProjectionIndex, idx_t> group_positions;
 		vector<unique_ptr<Expression>> branch_groups;
 		branch_groups.reserve(grouping_set.size());
 		for (auto &group_idx : grouping_set) {
 			group_positions[group_idx] = branch_groups.size();
-			branch_groups.push_back(CopyAndRebindGroupingSet(*aggr.groups[group_idx], input_replacements));
+			branch_groups.push_back(AggregateRewriteHelper::CopyAndRebind(*aggr.groups[group_idx], input_replacements));
 		}
 
 		vector<unique_ptr<Expression>> branch_aggregates;
 		branch_aggregates.reserve(aggregate_count);
 		for (auto &expr : aggr.expressions) {
-			branch_aggregates.push_back(CopyAndRebindGroupingSet(*expr, input_replacements));
+			branch_aggregates.push_back(AggregateRewriteHelper::CopyAndRebind(*expr, input_replacements));
 		}
 
 		auto branch_group_index = optimizer.binder.GenerateTableIndex();

--- a/src/optimizer/grouping_sets_optimizer.cpp
+++ b/src/optimizer/grouping_sets_optimizer.cpp
@@ -235,6 +235,7 @@ bool GroupingSetsOptimizer::TryRewriteGroupingSets(unique_ptr<LogicalOperator> &
 	}
 	vector<GroupingSetLevel> levels;
 	if (!can_cascade || !FindCascade(aggr.grouping_sets, levels)) {
+		// Explicit branches support arbitrary aggregates and expose single grouping sets to subsequent rewrites.
 		return TryExpandGroupingSets(op);
 	}
 

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -13,6 +13,7 @@
 #include "duckdb/optimizer/cte_inlining.hpp"
 #include "duckdb/optimizer/cte_filter_pusher.hpp"
 #include "duckdb/optimizer/deliminator.hpp"
+#include "duckdb/optimizer/distinct_aggregate_rewriter.hpp"
 #include "duckdb/optimizer/empty_result_pullup.hpp"
 #include "duckdb/optimizer/expression_heuristics.hpp"
 #include "duckdb/optimizer/filter_pullup.hpp"
@@ -252,6 +253,12 @@ void Optimizer::RunBuiltInOptimizers() {
 	RunOptimizer(OptimizerType::GROUPING_SETS, [&]() {
 		GroupingSetsOptimizer grouping_sets_optimizer(*this);
 		grouping_sets_optimizer.VisitOperator(plan);
+	});
+
+	// rewrite eligible DISTINCT aggregates into explicit aggregate plans
+	RunOptimizer(OptimizerType::DISTINCT_AGGREGATE_REWRITE, [&]() {
+		DistinctAggregateRewriter distinct_aggregate_rewriter(*this);
+		distinct_aggregate_rewriter.VisitOperator(plan);
 	});
 
 	// try to inline CTEs instead of materialization

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -249,7 +249,7 @@ void Optimizer::RunBuiltInOptimizers() {
 		plan = deliminator.Optimize(std::move(plan));
 	});
 
-	// rewrite aggregates over multiple grouping sets (ROLLUP/CUBE/GROUPING SETS) into a cascade of aggregations
+	// rewrite aggregates over multiple grouping sets (ROLLUP/CUBE/GROUPING SETS) into explicit aggregate plans
 	RunOptimizer(OptimizerType::GROUPING_SETS, [&]() {
 		GroupingSetsOptimizer grouping_sets_optimizer(*this);
 		grouping_sets_optimizer.VisitOperator(plan);

--- a/test/sql/aggregate/distinct/rewrite/distinct_aggregate_rewrite.test
+++ b/test/sql/aggregate/distinct/rewrite/distinct_aggregate_rewrite.test
@@ -185,3 +185,141 @@ ORDER BY g;
 1	NULL
 2	NULL
 3	NULL
+
+# GROUPING() with a regular GROUP BY is constant after rewrite
+query III
+SELECT GROUPING(g), g, count(DISTINCT x)
+FROM distinct_rewrite_nulls
+GROUP BY g
+ORDER BY g NULLS FIRST;
+----
+0	NULL	0
+0	1	1
+0	2	1
+
+# DISTINCT aggregate state export is finalized over the deduplicated rows
+query II
+SELECT finalize(sum(DISTINCT x) EXPORT_STATE),
+       finalize(count(DISTINCT x) EXPORT_STATE)
+FROM distinct_rewrite_nulls;
+----
+9	2
+
+statement ok
+CREATE TABLE distinct_rewrite_grouping_sets(course VARCHAR, type VARCHAR, value INTEGER);
+
+statement ok
+INSERT INTO distinct_rewrite_grouping_sets VALUES
+	('CS', 'B', 1),
+	('CS', 'P', 1),
+	('CS', 'P', 2),
+	('Math', 'M', 2),
+	('Math', 'M', 2),
+	('Math', NULL, 3);
+
+# grouping sets with distinct aggregates are expanded before the distinct rewrite
+query TTIIII
+SELECT course, type, sum(DISTINCT value), count(DISTINCT value), GROUPING(course), GROUPING(type)
+FROM distinct_rewrite_grouping_sets
+GROUP BY CUBE(course, type)
+ORDER BY GROUPING(course), GROUPING(type), course, type NULLS FIRST;
+----
+CS	B	1	1	0	0
+CS	P	3	2	0	0
+Math	NULL	3	1	0	0
+Math	M	2	1	0	0
+CS	NULL	3	2	0	1
+Math	NULL	5	2	0	1
+NULL	NULL	3	1	1	0
+NULL	B	1	1	1	0
+NULL	M	2	1	1	0
+NULL	P	3	2	1	0
+NULL	NULL	6	3	1	1
+
+# state-export distinct aggregates also go through the grouping-set expansion
+query TTIII
+SELECT course, type, finalize(sum(DISTINCT value) EXPORT_STATE), GROUPING(course), GROUPING(type)
+FROM distinct_rewrite_grouping_sets
+GROUP BY CUBE(course, type)
+ORDER BY GROUPING(course), GROUPING(type), course, type NULLS FIRST;
+----
+CS	B	1	0	0
+CS	P	3	0	0
+Math	NULL	3	0	0
+Math	M	2	0	0
+CS	NULL	3	0	1
+Math	NULL	5	0	1
+NULL	NULL	3	1	0
+NULL	B	1	1	0
+NULL	M	2	1	0
+NULL	P	3	1	0
+NULL	NULL	6	1	1
+
+statement ok
+PRAGMA disable_verification
+
+statement ok
+CREATE SEQUENCE distinct_rewrite_seq_child START 1;
+
+# volatile DISTINCT arguments are staged before distinct-set matching
+query II
+SELECT count(DISTINCT nextval('distinct_rewrite_seq_child')),
+       sum(DISTINCT nextval('distinct_rewrite_seq_child'))
+FROM range(4);
+----
+4	26
+
+query I
+SELECT currval('distinct_rewrite_seq_child');
+----
+8
+
+statement ok
+CREATE SEQUENCE distinct_rewrite_seq_filter START 1;
+
+# volatile FILTER expressions are staged before branch fan-out
+query II
+SELECT count(DISTINCT i) FILTER (WHERE nextval('distinct_rewrite_seq_filter') % 2 = 0),
+       sum(i)
+FROM range(5) tbl(i);
+----
+2	10
+
+query I
+SELECT currval('distinct_rewrite_seq_filter');
+----
+5
+
+statement ok
+CREATE SEQUENCE distinct_rewrite_seq_filtered_arg START 1;
+
+# volatile arguments are evaluated even when a non-volatile FILTER rejects every row
+query I
+SELECT count(DISTINCT nextval('distinct_rewrite_seq_filtered_arg')) FILTER (WHERE false)
+FROM range(4);
+----
+0
+
+query I
+SELECT currval('distinct_rewrite_seq_filtered_arg');
+----
+4
+
+statement ok
+CREATE SEQUENCE distinct_rewrite_seq_grouping_sets START 1;
+
+# grouping-set expansion stages volatile DISTINCT inputs before UNION fan-out
+query III
+SELECT g, count(DISTINCT nextval('distinct_rewrite_seq_grouping_sets')), GROUPING(g)
+FROM (VALUES (1), (2), (1)) tbl(g)
+GROUP BY CUBE(g)
+ORDER BY GROUPING(g), g;
+----
+1	2	0
+2	1	0
+NULL	3	1
+
+query I
+SELECT currval('distinct_rewrite_seq_grouping_sets');
+----
+3

--- a/test/sql/aggregate/distinct/rewrite/distinct_aggregate_rewrite.test
+++ b/test/sql/aggregate/distinct/rewrite/distinct_aggregate_rewrite.test
@@ -32,6 +32,14 @@ FROM distinct_rewrite;
 ----
 7	11	21	495
 
+# optimizer-generated CTEs use direct streaming fan-out
+query II
+EXPLAIN ANALYZE
+SELECT count(DISTINCT x), count(DISTINCT y)
+FROM distinct_rewrite;
+----
+analyzed_plan	<REGEX>:.*Execution Mode: STREAMING_FANOUT.*Fanout Mode: DIRECT.*Direct Consumers: 2.*Buffered Consumers: 0.*
+
 # grouped mixed distinct/non-distinct aggregates
 query III
 SELECT g, count(DISTINCT x), sum(y)

--- a/test/sql/aggregate/distinct/rewrite/distinct_aggregate_rewrite.test
+++ b/test/sql/aggregate/distinct/rewrite/distinct_aggregate_rewrite.test
@@ -1,0 +1,88 @@
+# name: test/sql/aggregate/distinct/rewrite/distinct_aggregate_rewrite.test
+# description: DISTINCT aggregate logical rewrites
+# group: [rewrite]
+
+statement ok
+CREATE TABLE distinct_rewrite AS
+	SELECT i % 4 AS g, CASE WHEN i % 5 = 0 THEN NULL ELSE i % 7 END AS x, i % 11 AS y
+	FROM range(100) tbl(i);
+
+# ungrouped shared distinct input
+query III
+SELECT count(DISTINCT x), sum(DISTINCT x), avg(DISTINCT x) FROM distinct_rewrite;
+----
+7	21	3
+
+# grouped shared distinct input
+query III
+SELECT g, count(DISTINCT x), sum(DISTINCT x)
+FROM distinct_rewrite
+GROUP BY g
+ORDER BY g;
+----
+0	7	21
+1	7	21
+2	7	21
+3	7	21
+
+# ungrouped mixed distinct/non-distinct aggregates
+query IIII
+SELECT count(DISTINCT x), count(DISTINCT y), sum(DISTINCT x), sum(y)
+FROM distinct_rewrite;
+----
+7	11	21	495
+
+# grouped mixed distinct/non-distinct aggregates
+query III
+SELECT g, count(DISTINCT x), sum(y)
+FROM distinct_rewrite
+GROUP BY g
+ORDER BY g;
+----
+0	7	122
+1	7	125
+2	7	128
+3	7	120
+
+statement ok
+CREATE TABLE distinct_rewrite_nulls(g INTEGER, x INTEGER, y INTEGER);
+
+statement ok
+INSERT INTO distinct_rewrite_nulls VALUES
+	(NULL, NULL, 1),
+	(NULL, NULL, 2),
+	(1, NULL, 3),
+	(1, 4, 4),
+	(1, 4, 5),
+	(2, 5, 6),
+	(2, NULL, 7);
+
+# multi distinct inputs with NULL group keys
+query IIIII
+SELECT g, count(DISTINCT x), count(DISTINCT y), sum(DISTINCT x), sum(y)
+FROM distinct_rewrite_nulls
+GROUP BY g
+ORDER BY g NULLS FIRST;
+----
+NULL	0	2	NULL	3
+1	1	3	4	12
+2	1	2	5	13
+
+# empty ungrouped input
+query III
+SELECT count(DISTINCT x), sum(DISTINCT x), avg(DISTINCT x)
+FROM distinct_rewrite_nulls
+WHERE false;
+----
+0	NULL	NULL
+
+# aggregate-local filters stay on the existing physical DISTINCT path
+query II
+SELECT g, count(DISTINCT x) FILTER (WHERE y > 3)
+FROM distinct_rewrite_nulls
+GROUP BY g
+ORDER BY g NULLS FIRST;
+----
+NULL	0
+1	1
+2	1

--- a/test/sql/aggregate/distinct/rewrite/distinct_aggregate_rewrite.test
+++ b/test/sql/aggregate/distinct/rewrite/distinct_aggregate_rewrite.test
@@ -76,7 +76,69 @@ WHERE false;
 ----
 0	NULL	NULL
 
-# aggregate-local filters stay on the existing physical DISTINCT path
+statement ok
+CREATE TABLE distinct_rewrite_order(g INTEGER, s VARCHAR, y INTEGER, keep BOOLEAN);
+
+statement ok
+INSERT INTO distinct_rewrite_order VALUES
+	(1, 'a', 2, true),
+	(1, 'b', 1, false),
+	(1, 'b', 4, true),
+	(1, 'c', 3, true),
+	(2, 'a', 5, false),
+	(2, 'd', 1, true),
+	(2, 'd', 2, true),
+	(3, NULL, 3, true);
+
+# distinct aggregate ORDER BY
+query IT
+SELECT count(DISTINCT s), string_agg(DISTINCT s, ',' ORDER BY s DESC)
+FROM distinct_rewrite_order;
+----
+4	d,c,b,a
+
+# grouped distinct aggregate ORDER BY
+query IT
+SELECT g, string_agg(DISTINCT s, ',' ORDER BY s DESC)
+FROM distinct_rewrite_order
+GROUP BY g
+ORDER BY g;
+----
+1	c,b,a
+2	d,a
+3	NULL
+
+# regular aggregate filters can be kept in the regular branch
+query III
+SELECT g, count(DISTINCT s), sum(y) FILTER (WHERE keep)
+FROM distinct_rewrite_order
+GROUP BY g
+ORDER BY g;
+----
+1	3	9
+2	2	3
+3	0	3
+
+# regular aggregate ORDER BY can be kept in the regular branch
+query IIT
+SELECT g, count(DISTINCT s), string_agg(y::VARCHAR, ',' ORDER BY y DESC)
+FROM distinct_rewrite_order
+GROUP BY g
+ORDER BY g;
+----
+1	3	4,3,2,1
+2	2	5,2,1
+3	0	3
+
+# ungrouped distinct aggregate filters
+query IT
+SELECT count(DISTINCT s) FILTER (WHERE keep),
+       string_agg(DISTINCT s, ',' ORDER BY s DESC) FILTER (WHERE keep)
+FROM distinct_rewrite_order;
+----
+4	d,c,b,a
+
+# grouped distinct aggregate filters preserve groups with no matching distinct values
 query II
 SELECT g, count(DISTINCT x) FILTER (WHERE y > 3)
 FROM distinct_rewrite_nulls
@@ -86,3 +148,40 @@ ORDER BY g NULLS FIRST;
 NULL	0
 1	1
 2	1
+
+# grouped distinct aggregate filters can be combined with ORDER BY
+query IIT
+SELECT g,
+       count(DISTINCT s) FILTER (WHERE keep),
+       string_agg(DISTINCT s, ',' ORDER BY s DESC) FILTER (WHERE keep)
+FROM distinct_rewrite_order
+GROUP BY g
+ORDER BY g;
+----
+1	3	c,b,a
+2	1	d
+3	0	NULL
+
+# same distinct arguments with different filters are separate branches
+query III
+SELECT g,
+       count(DISTINCT s) FILTER (WHERE keep),
+       count(DISTINCT s) FILTER (WHERE NOT keep)
+FROM distinct_rewrite_order
+GROUP BY g
+ORDER BY g;
+----
+1	3	1
+2	1	1
+3	0	0
+
+# filtered grouped list aggregates must see empty inputs, not artificial left-join NULLs
+query II
+SELECT g, list(DISTINCT s ORDER BY s) FILTER (WHERE keep AND y < 0)
+FROM distinct_rewrite_order
+GROUP BY g
+ORDER BY g;
+----
+1	NULL
+2	NULL
+3	NULL

--- a/test/sql/aggregate/distinct/rewrite/distinct_aggregate_rewrite.test
+++ b/test/sql/aggregate/distinct/rewrite/distinct_aggregate_rewrite.test
@@ -352,20 +352,23 @@ statement ok
 PRAGMA disable_verification
 
 statement ok
-CREATE SEQUENCE distinct_rewrite_seq_child START 1;
+CREATE SEQUENCE distinct_rewrite_seq_count START 1;
 
-# volatile DISTINCT arguments are staged before distinct-set matching
+statement ok
+CREATE SEQUENCE distinct_rewrite_seq_sum START 1;
+
+# each volatile DISTINCT argument is staged and evaluated once per row
 query II
-SELECT count(DISTINCT nextval('distinct_rewrite_seq_child')),
-       sum(DISTINCT nextval('distinct_rewrite_seq_child'))
+SELECT count(DISTINCT nextval('distinct_rewrite_seq_count')),
+       sum(DISTINCT nextval('distinct_rewrite_seq_sum'))
 FROM range(4);
 ----
-4	26
+4	10
 
-query I
-SELECT currval('distinct_rewrite_seq_child');
+query II
+SELECT currval('distinct_rewrite_seq_count'), currval('distinct_rewrite_seq_sum');
 ----
-8
+4	4
 
 statement ok
 CREATE SEQUENCE distinct_rewrite_seq_filter START 1;
@@ -434,4 +437,4 @@ WHERE p_partkey = ps_partkey
 GROUP BY p_brand, p_type, p_size
 ORDER BY supplier_cnt DESC, p_brand, p_type, p_size;
 ----
-logical_opt	<REGEX>:.*"Groups":\s*\[[^\]]*"ps_suppkey"[^\]]*\].*"Expressions":\s*"count_star\(\)".*
+logical_opt	<REGEX>:.*"Groups":\s*\[[^\]]*"ps_suppkey"[^\]]*\].*"Expressions":\s*"(count_star\(\)|count\(#[0-9]+\) EXPORT_STATE)".*

--- a/test/sql/aggregate/distinct/rewrite/distinct_aggregate_rewrite.test
+++ b/test/sql/aggregate/distinct/rewrite/distinct_aggregate_rewrite.test
@@ -97,6 +97,13 @@ FROM distinct_rewrite_order;
 ----
 4	d,c,b,a
 
+# distinct aggregate ORDER BY derived from its argument
+query T
+SELECT string_agg(DISTINCT s, ',' ORDER BY unicode(s) DESC)
+FROM distinct_rewrite_order;
+----
+d,c,b,a
+
 # grouped distinct aggregate ORDER BY
 query IT
 SELECT g, string_agg(DISTINCT s, ',' ORDER BY s DESC)
@@ -186,6 +193,33 @@ ORDER BY g;
 2	NULL
 3	NULL
 
+statement ok
+CREATE TABLE distinct_rewrite_filter_errors(g INTEGER, value VARCHAR, keep BOOLEAN);
+
+statement ok
+INSERT INTO distinct_rewrite_filter_errors VALUES (1, 'bad', false), (1, '1', true);
+
+# FILTER does not suppress evaluation errors in aggregate arguments
+statement error
+SELECT count(DISTINCT value::INTEGER) FILTER (WHERE keep)
+FROM distinct_rewrite_filter_errors;
+----
+<REGEX>:Conversion Error:.*
+
+statement error
+SELECT g, count(DISTINCT value::INTEGER) FILTER (WHERE keep)
+FROM distinct_rewrite_filter_errors
+GROUP BY g;
+----
+<REGEX>:Conversion Error:.*
+
+# FILTER also does not suppress evaluation errors in a derived aggregate order
+statement error
+SELECT string_agg(DISTINCT value, ',' ORDER BY value::INTEGER) FILTER (WHERE keep)
+FROM distinct_rewrite_filter_errors;
+----
+<REGEX>:Conversion Error:.*
+
 # GROUPING() with a regular GROUP BY is constant after rewrite
 query III
 SELECT GROUPING(g), g, count(DISTINCT x)
@@ -204,6 +238,57 @@ SELECT finalize(sum(DISTINCT x) EXPORT_STATE),
 FROM distinct_rewrite_nulls;
 ----
 9	2
+
+statement ok
+CREATE TABLE part(p_partkey BIGINT NOT NULL, p_brand VARCHAR NOT NULL, p_type VARCHAR NOT NULL,
+                  p_size INTEGER NOT NULL);
+
+statement ok
+CREATE TABLE partsupp(ps_partkey BIGINT NOT NULL, ps_suppkey BIGINT NOT NULL);
+
+statement ok
+CREATE TABLE supplier(s_suppkey BIGINT NOT NULL, s_comment VARCHAR NOT NULL);
+
+statement ok
+INSERT INTO part VALUES
+	(1, 'Brand#11', 'SMALL BRUSHED', 49),
+	(2, 'Brand#11', 'SMALL BRUSHED', 49),
+	(3, 'Brand#45', 'SMALL BRUSHED', 49),
+	(4, 'Brand#22', 'MEDIUM POLISHED STEEL', 14),
+	(5, 'Brand#22', 'LARGE BRUSHED', 3),
+	(6, 'Brand#33', 'LARGE BRUSHED', 2);
+
+statement ok
+INSERT INTO partsupp VALUES
+	(1, 10), (1, 20), (2, 10), (2, 30),
+	(3, 60), (4, 70), (5, 40), (5, 50), (6, 80);
+
+statement ok
+INSERT INTO supplier VALUES
+	(10, 'regular supplier'),
+	(20, 'Customer service Complaints pending'),
+	(30, 'regular supplier'),
+	(40, 'regular supplier'),
+	(50, 'regular supplier'),
+	(60, 'regular supplier'),
+	(70, 'regular supplier'),
+	(80, 'regular supplier');
+
+# TPC-H Q16 shape, including ORDER BY on the DISTINCT aggregate result
+query TTII
+SELECT p_brand, p_type, p_size, count(DISTINCT ps_suppkey) AS supplier_cnt
+FROM partsupp, part
+WHERE p_partkey = ps_partkey
+  AND p_brand <> 'Brand#45'
+  AND p_type NOT LIKE 'MEDIUM POLISHED%'
+  AND p_size IN (49, 14, 23, 45, 19, 3, 36, 9)
+  AND ps_suppkey NOT IN (
+      SELECT s_suppkey FROM supplier WHERE s_comment LIKE '%Customer%Complaints%')
+GROUP BY p_brand, p_type, p_size
+ORDER BY supplier_cnt DESC, p_brand, p_type, p_size;
+----
+Brand#11	SMALL BRUSHED	49	2
+Brand#22	LARGE BRUSHED	3	2
 
 statement ok
 CREATE TABLE distinct_rewrite_grouping_sets(course VARCHAR, type VARCHAR, value INTEGER);
@@ -323,3 +408,22 @@ query I
 SELECT currval('distinct_rewrite_seq_grouping_sets');
 ----
 3
+
+statement ok
+PRAGMA explain_output='optimized_only';
+
+# Q16 uses explicit deduplication followed by a regular count; the ORDER BY label remains SQL-level text
+query II
+EXPLAIN (FORMAT JSON)
+SELECT p_brand, p_type, p_size, count(DISTINCT ps_suppkey) AS supplier_cnt
+FROM partsupp, part
+WHERE p_partkey = ps_partkey
+  AND p_brand <> 'Brand#45'
+  AND p_type NOT LIKE 'MEDIUM POLISHED%'
+  AND p_size IN (49, 14, 23, 45, 19, 3, 36, 9)
+  AND ps_suppkey NOT IN (
+      SELECT s_suppkey FROM supplier WHERE s_comment LIKE '%Customer%Complaints%')
+GROUP BY p_brand, p_type, p_size
+ORDER BY supplier_cnt DESC, p_brand, p_type, p_size;
+----
+logical_opt	<REGEX>:.*"Groups":\s*\[[^\]]*"ps_suppkey"[^\]]*\].*"Expressions":\s*"count_star\(\)".*

--- a/test/sql/optimizer/test_fd_derived_groups.test
+++ b/test/sql/optimizer/test_fd_derived_groups.test
@@ -113,14 +113,13 @@ EXPLAIN (FORMAT JSON) SELECT x, (x - random()) * 2, count(*) FROM t GROUP BY x, 
 ----
 logical_opt	<REGEX>:.*"Groups":\s*\[\s*"[^"]*"\s*,\s*".*
 
-# Multiple grouping sets: positional groups must not collapse, because the position of groups
-# matters semantically in the grouping sets. (ROLLUP/CUBE that the grouping_sets optimizer can
-# fold into a cascade are expanded into single-set aggregates before this optimizer runs, so we
-# use a non-cascadable grouping set here to exercise the multi-grouping-set guard directly.)
+# Multiple grouping sets: positional groups must not collapse. This can appear either as a
+# single aggregate with two positional groups, or as a grouping-sets rewrite with separate
+# singleton aggregate branches.
 query II
 EXPLAIN (FORMAT JSON) SELECT x, x-1, count(*) FROM t GROUP BY GROUPING SETS ((x), (x-1));
 ----
-logical_opt	<REGEX>:.*"Groups":\s*\[\s*"[^"]*"\s*,\s*".*
+logical_opt	<REGEX>:.*("Groups":\s*\[\s*"[^"]*"\s*,\s*"|CTE.*UNION.*"Groups":\s*"x".*"Groups":\s*"\(x - 1\)").*
 
 # No raw-column base: synthesising one would need an injectivity proof per derived.
 query II


### PR DESCRIPTION
`DISTINCT` aggregates currently build and drive separate hash tables from inside the physical ungrouped and hash aggregate operators. That makes a substantial part of aggregation invisible at the logical plan level: the optimizer cannot reason about it, the profiler cannot report it as ordinary operators, and extensions that replace or inspect aggregate plans need a second path for work hidden inside the physical aggregate.

These aggregates are now rewritten into explicit logical aggregate plans instead. A distinct aggregate first groups by the original group keys and its distinct arguments, then evaluates the original aggregate without `DISTINCT`. Aggregates with the same distinct arguments and filter share that deduplication branch. Queries with multiple distinct sets, or a mix of distinct and regular aggregates, read from a shared CTE and combine the branch results with a cross product for ungrouped queries or null-safe joins on the group keys for grouped queries.

There are several semantic details behind that basic shape. Aggregate `FILTER` and `ORDER BY` expressions are preserved in the rewritten branch. Volatile group, argument, order, and filter expressions are staged once before CTE fan-out so the rewrite does not multiply their evaluation. Result bindings are remapped through a final projection, including references from result modifiers.

The distinct pass runs after the grouping-sets optimizer. I widened that optimizer so aggregates that cannot use the existing state-combining cascade are expanded into one explicit branch per grouping set over a shared CTE. The distinct pass can then rewrite each resulting single-set aggregate. This avoids depending on the physical grouping-set implementation as a semantic fallback for distinct aggregates and also keeps `GROUPING()` values explicit in the plan.

With streaming CTE fan-out, the shared input is delivered directly to all aggregate branches without materializing it first. The regression coverage checks `EXPLAIN ANALYZE` for `STREAMING_FANOUT`, two direct consumers, and zero buffered consumers. The broader tests cover grouped and ungrouped aggregates, shared and independent distinct sets, mixed regular aggregates, empty and NULL inputs, filters, aggregate ordering, volatile expressions, grouping sets and `GROUPING()`, and exported aggregate states.

I also measured the multi-distinct case that originally regressed:

```sql
SELECT COUNT(DISTINCT l_linenumber), COUNT(DISTINCT l_orderkey)
FROM lineitem;
```

On TPC-H SF100: Across two opposing-order `hyperfine` batches with two warmups and five fresh-process measurements per implementation in each batch, the rewrite had a 1.028 s mean and 1.024 s median (0.989-1.069 s), while disabling `distinct_aggregate_rewrite` had a 0.975 s mean and 0.975 s median (0.965-0.986 s). That is a 5.4% mean and 5.0% median regression for this workload. Three fresh-process RSS samples averaged 5.47 GiB for the rewrite and 5.10 GiB for the legacy path, about 372 MiB or 7.1% more. Sampling still shows aggregate hash-table lookup as the dominant work; direct CTE dispatch is not an obvious hotspot, so I have not added a branch-specific heuristic here.

I am deliberately retaining the legacy physical distinct infrastructure for optimizer-disabled execution and comparison in this PR. Removing it is a follow-up once the logical rewrite has had enough coverage across platforms and workloads; the performance and memory result above is the main remaining trade-off to investigate before making that removal.

Fix: https://github.com/duckdblabs/duckdb-internal/issues/9677