### PR TITLE
Use fixed length for commit sha abbreviation

### DIFF
--- a/.github/workflows/StagedUpload.yml
+++ b/.github/workflows/StagedUpload.yml
@@ -33,7 +33,7 @@ jobs:
          AWS_ACCESS_KEY_ID: ${{ secrets.S3_DUCKDB_STAGING_ID }}
          AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DUCKDB_STAGING_KEY }}
        run: |
-          TARGET=$(git log -1 --format=%h)
+          TARGET=$(git log -1 --format=%H | cut -c1-10)
           mkdir to_be_uploaded
           rclone copy \
             --no-traverse \

--- a/scripts/upload-assets-to-staging.sh
+++ b/scripts/upload-assets-to-staging.sh
@@ -49,7 +49,7 @@ if [ -z "${AWS_ACCESS_KEY_ID:-}" ] || [ -z "${AWS_SECRET_ACCESS_KEY:-}" ]; then
   fi
 fi
 
-TARGET=$(git log -1 --format=%h)
+TARGET=$(git log -1 --format=%H | cut -c1-10)
 
 if [ "${UPLOAD_ASSETS_TO_STAGING_TARGET:-}" ]; then
   TARGET="$UPLOAD_ASSETS_TO_STAGING_TARGET"


### PR DESCRIPTION
### Context

I noticed that (alpha) release binaries are uploaded to two dirs:

```
duckdb-staging/b8591243bd/v2.0.0-alpha35309/duckdb/duckdb/github_release/
duckdb-staging/b8591243bd4/v2.0.0-alpha35309/duckdb/duckdb/github_release/
```
notice the extra `4` in the commit hash!

The reason is that:

```shell
git log -1 --format=%h
```
gives an abbreviated git commit hash, but the length _depends_ on the git database.


### Changes

So, we use a fixed length of 10 for all abbreviations.