### PR TITLE
Define UPDATE ... FROM and MERGE behavior for multi-matched target rows

### DIFF
--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -67,6 +67,7 @@
 #include "duckdb/common/enums/regex_match_operator_semantics.hpp"
 #include "duckdb/common/enums/relation_type.hpp"
 #include "duckdb/common/enums/row_group_append_mode.hpp"
+#include "duckdb/common/enums/row_id_handling.hpp"
 #include "duckdb/common/enums/set_operation_type.hpp"
 #include "duckdb/common/enums/set_scope.hpp"
 #include "duckdb/common/enums/set_type.hpp"
@@ -4830,6 +4831,25 @@ const char* EnumUtil::ToChars<RowGroupAppendMode>(RowGroupAppendMode value) {
 template<>
 RowGroupAppendMode EnumUtil::FromString<RowGroupAppendMode>(const char *value) {
 	return static_cast<RowGroupAppendMode>(StringUtil::StringToEnum(GetRowGroupAppendModeValues(), 3, "RowGroupAppendMode", value));
+}
+
+const StringUtil::EnumStringLiteral *GetRowIdHandlingValues() {
+	static constexpr StringUtil::EnumStringLiteral values[] {
+		{ static_cast<uint32_t>(RowIdHandling::ASSUME_UNIQUE), "ASSUME_UNIQUE" },
+		{ static_cast<uint32_t>(RowIdHandling::KEEP_FIRST), "KEEP_FIRST" },
+		{ static_cast<uint32_t>(RowIdHandling::ERROR), "ERROR" }
+	};
+	return values;
+}
+
+template<>
+const char* EnumUtil::ToChars<RowIdHandling>(RowIdHandling value) {
+	return StringUtil::EnumToString(GetRowIdHandlingValues(), 3, "RowIdHandling", static_cast<uint32_t>(value));
+}
+
+template<>
+RowIdHandling EnumUtil::FromString<RowIdHandling>(const char *value) {
+	return static_cast<RowIdHandling>(StringUtil::StringToEnum(GetRowIdHandlingValues(), 3, "RowIdHandling", value));
 }
 
 const StringUtil::EnumStringLiteral *GetSampleMethodValues() {

--- a/src/execution/operator/persistent/physical_insert.cpp
+++ b/src/execution/operator/persistent/physical_insert.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/common/types/conflict_manager.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/execution/expression_executor.hpp"
+#include "duckdb/execution/row_id_deduplicator.hpp"
 #include "duckdb/execution/index/art/art.hpp"
 #include "duckdb/function/create_sort_key.hpp"
 #include "duckdb/main/client_context.hpp"
@@ -288,20 +289,14 @@ static idx_t PerformOnConflictAction(InsertLocalState &lstate, InsertGlobalState
 	return update_chunk.size();
 }
 
-// TODO: should we use a hash table to keep track of this instead?
 static void RegisterUpdatedRows(InsertLocalState &lstate, const Vector &row_ids, idx_t count) {
-	// Insert all rows, if any of the rows has already been updated before, we throw an error
-	auto data = FlatVector::GetData<row_t>(row_ids);
-
-	auto &updated_rows = lstate.updated_rows;
-	for (idx_t i = 0; i < count; i++) {
-		auto result = updated_rows.insert(data[i]);
-		if (result.second == false) {
-			// This is following postgres behavior:
-			throw InvalidInputException(
-			    "ON CONFLICT DO UPDATE can not update the same row twice in the same command. Ensure that no rows "
-			    "proposed for insertion within the same command have duplicate constrained values");
-		}
+	// Register all row-ids; a distinct count below `count` means a row-id repeated, which we reject.
+	auto distinct = RegisterRowIds(lstate.updated_rows, row_ids, count);
+	if (distinct != count) {
+		// This is following postgres behavior:
+		throw InvalidInputException(
+		    "ON CONFLICT DO UPDATE can not update the same row twice in the same command. Ensure that no rows "
+		    "proposed for insertion within the same command have duplicate constrained values");
 	}
 }
 

--- a/src/execution/operator/persistent/physical_merge_into.cpp
+++ b/src/execution/operator/persistent/physical_merge_into.cpp
@@ -2,6 +2,7 @@
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/parser/statement/merge_into_statement.hpp"
 #include "duckdb/parser/query_node/merge_query_node.hpp"
+#include "duckdb/common/types/vector.hpp"
 
 namespace duckdb {
 
@@ -119,6 +120,26 @@ public:
 	idx_t finalize_idx = 0;
 	vector<unique_ptr<GlobalSinkState>> sink_states;
 	atomic<idx_t> merged_count;
+	//! Target row-ids already matched by a WHEN MATCHED modifying action, to detect a second action on a row.
+	mutex match_lock;
+	unordered_set<row_t> matched_rows;
+
+	//! Record the matched target rows; throw if any row was already matched (cardinality violation). The matched
+	//! chunk is sliced from the input, so read the row-ids through a unified format rather than assuming flat.
+	void CheckMatchedRows(DataChunk &matched, idx_t row_id_index) {
+		UnifiedVectorFormat row_id_format;
+		matched.data[row_id_index].ToUnifiedFormat(row_id_format);
+		auto row_id_data = UnifiedVectorFormat::GetData<row_t>(row_id_format);
+		lock_guard<mutex> glock(match_lock);
+		for (idx_t i = 0; i < matched.size(); i++) {
+			auto row_id = row_id_data[row_id_format.sel->get_index(i)];
+			if (!matched_rows.insert(row_id).second) {
+				throw InvalidInputException(
+				    "MERGE INTO command cannot affect the same target row more than once. A target row matched more "
+				    "than one source row; ensure the source rows are deduplicated or the ON condition is unique.");
+			}
+		}
+	}
 
 	optional_ptr<DataChunk> ComputeActionInput(ClientContext &context, MergeIntoOperator &action, DataChunk &chunk,
 	                                           MergeIntoLocalState &local_state,
@@ -187,6 +208,15 @@ public:
 				if (!input_chunk) {
 					// no data for this action - move to next action
 					continue;
+				}
+				// A WHEN MATCHED update/delete must not affect the same target row twice (cardinality violation).
+				// Checked here, on the freshly condition-selected rows (which still carry the row-id column), so
+				// rows filtered out by the action condition are not counted - matching PostgreSQL. Runs once per
+				// input chunk: on a BLOCKED resume input_chunk is still set and we skip re-checking.
+				if (range.condition == MergeActionCondition::WHEN_MATCHED &&
+				    (action->action_type == MergeActionType::MERGE_UPDATE ||
+				     action->action_type == MergeActionType::MERGE_DELETE)) {
+					CheckMatchedRows(*input_chunk, op.row_id_index);
 				}
 			}
 			// process the action

--- a/src/execution/operator/persistent/physical_merge_into.cpp
+++ b/src/execution/operator/persistent/physical_merge_into.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/execution/operator/persistent/physical_merge_into.hpp"
 #include "duckdb/execution/expression_executor.hpp"
+#include "duckdb/execution/row_id_deduplicator.hpp"
 #include "duckdb/parser/statement/merge_into_statement.hpp"
 #include "duckdb/parser/query_node/merge_query_node.hpp"
 #include "duckdb/common/types/vector.hpp"
@@ -124,20 +125,15 @@ public:
 	mutex match_lock;
 	unordered_set<row_t> matched_rows;
 
-	//! Record the matched target rows; throw if any row was already matched (cardinality violation). The matched
-	//! chunk is sliced from the input, so read the row-ids through a unified format rather than assuming flat.
+	//! Record the matched target rows; throw if any row was already matched (cardinality violation). Uses the
+	//! shared row-id registration primitive; a distinct count below the input count means a row-id repeated.
 	void CheckMatchedRows(DataChunk &matched, idx_t row_id_index) {
-		UnifiedVectorFormat row_id_format;
-		matched.data[row_id_index].ToUnifiedFormat(row_id_format);
-		auto row_id_data = UnifiedVectorFormat::GetData<row_t>(row_id_format);
 		lock_guard<mutex> glock(match_lock);
-		for (idx_t i = 0; i < matched.size(); i++) {
-			auto row_id = row_id_data[row_id_format.sel->get_index(i)];
-			if (!matched_rows.insert(row_id).second) {
-				throw InvalidInputException(
-				    "MERGE INTO command cannot affect the same target row more than once. A target row matched more "
-				    "than one source row; ensure the source rows are deduplicated or the ON condition is unique.");
-			}
+		auto distinct = RegisterRowIds(matched_rows, matched.data[row_id_index], matched.size());
+		if (distinct != matched.size()) {
+			throw InvalidInputException(
+			    "MERGE INTO command cannot affect the same target row more than once. A target row matched more "
+			    "than one source row; ensure the source rows are deduplicated or the ON condition is unique.");
 		}
 	}
 

--- a/src/execution/operator/persistent/physical_update.cpp
+++ b/src/execution/operator/persistent/physical_update.cpp
@@ -22,12 +22,13 @@ PhysicalUpdate::PhysicalUpdate(PhysicalPlan &physical_plan, vector<LogicalType> 
                                vector<unique_ptr<Expression>> expressions,
                                vector<unique_ptr<Expression>> bound_defaults,
                                vector<unique_ptr<BoundConstraint>> bound_constraints, idx_t estimated_cardinality,
-                               bool return_chunk, bool capture_old_rows, vector<idx_t> old_row_columns)
+                               bool return_chunk, bool capture_old_rows, vector<idx_t> old_row_columns,
+                               bool update_from)
     : PhysicalOperator(physical_plan, PhysicalOperatorType::UPDATE, std::move(types), estimated_cardinality),
       tableref(tableref), table(table), columns(std::move(columns)), expressions(std::move(expressions)),
       bound_defaults(std::move(bound_defaults)), bound_constraints(std::move(bound_constraints)),
       return_chunk(return_chunk), capture_old_rows(capture_old_rows), old_row_columns(std::move(old_row_columns)),
-      index_update(false) {
+      update_from(update_from), index_update(false) {
 	auto &indexes = table.GetDataTableInfo().get()->GetIndexes();
 	auto index_columns = indexes.GetRequiredColumns();
 
@@ -135,6 +136,19 @@ static void AppendReturnRows(ColumnDataCollection &collection, DataChunk &combin
 	collection.Append(combined);
 }
 
+// Deduplicate rows by row-id against the rows already updated in this statement, keeping the first occurrence.
+// Fills `sel` with the positions of the distinct new rows and returns their count. Requires holding g_state.lock.
+static idx_t DeduplicateUpdatedRowIds(UpdateGlobalState &g_state, Vector &row_ids, idx_t count, SelectionVector &sel) {
+	auto row_id_data = FlatVector::GetData<row_t>(row_ids);
+	idx_t new_count = 0;
+	for (idx_t i = 0; i < count; i++) {
+		if (g_state.updated_rows.insert(row_id_data[i]).second) {
+			sel.set_index(new_count++, i);
+		}
+	}
+	return new_count;
+}
+
 SinkResultType PhysicalUpdate::Sink(ExecutionContext &context, DataChunk &chunk, OperatorSinkInput &input) const {
 	auto &g_state = input.global_state.Cast<UpdateGlobalState>();
 	auto &l_state = input.local_state.Cast<UpdateLocalState>();
@@ -162,28 +176,43 @@ SinkResultType PhysicalUpdate::Sink(ExecutionContext &context, DataChunk &chunk,
 
 	// Regular in-place update.
 	if (!update_is_del_and_insert) {
+		// UPDATE ... FROM may match a target row more than once. Deduplicate by row-id so each row is updated at
+		// most once (first match wins), matching the del+insert path and keeping transition tables predictable.
+		idx_t update_count = update_chunk.size();
+		SelectionVector sel;
+		Vector update_row_ids(Vector::Ref(row_ids));
+		if (update_from) {
+			sel.Initialize(update_chunk.size());
+			lock_guard<mutex> glock(g_state.lock);
+			update_count = DeduplicateUpdatedRowIds(g_state, row_ids, update_chunk.size(), sel);
+			if (update_count != update_chunk.size()) {
+				update_chunk.Slice(sel, update_count);
+				update_row_ids.Slice(row_ids, sel, update_count);
+			}
+		}
+
 		if (return_chunk) {
 			// (re)reference all output columns first, then validate + set the cardinality. mock_chunk is not reset
 			// here, but with return_chunk the update projects every table column, so all columns are referenced.
 			for (idx_t i = 0; i < columns.size(); i++) {
 				mock_chunk.data[columns[i].index].Reference(update_chunk.data[i]);
 			}
-			mock_chunk.CheckCardinality(update_chunk.size());
+			mock_chunk.CheckCardinality(update_count);
 		}
 		auto &update_state = l_state.GetUpdateState(table, tableref, context.client);
-		table.Update(update_state, context.client, tableref, row_ids, columns, update_chunk);
+		table.Update(update_state, context.client, tableref, update_row_ids, columns, update_chunk);
 
 		if (return_chunk) {
 			lock_guard<mutex> glock(g_state.lock);
 			if (capture_old_rows) {
-				// In-place update: every input row is affected, so no selection vector is needed.
+				// When we deduplicated, apply the selection vector to the OLD columns so they line up with NEW.
 				AppendReturnRows(g_state.return_collection, l_state.combined_chunk, mock_chunk, chunk,
-				                 mock_chunk.ColumnCount(), old_row_columns, update_chunk.size(), nullptr);
+				                 mock_chunk.ColumnCount(), old_row_columns, update_count, update_from ? &sel : nullptr);
 			} else {
 				g_state.return_collection.Append(mock_chunk);
 			}
 		}
-		g_state.updated_count += chunk.size();
+		g_state.updated_count += update_count;
 		return SinkResultType::NEED_MORE_INPUT;
 	}
 
@@ -193,17 +222,8 @@ SinkResultType PhysicalUpdate::Sink(ExecutionContext &context, DataChunk &chunk,
 	// This is required since we might see the same row_id multiple times, e.g.,
 	// during an UPDATE containing joins.
 	SelectionVector sel(update_chunk.size());
-	idx_t update_count = 0;
-	auto row_id_data = FlatVector::GetData<row_t>(row_ids);
-
 	lock_guard<mutex> glock(g_state.lock);
-	for (idx_t i = 0; i < update_chunk.size(); i++) {
-		auto row_id = row_id_data[i];
-		const auto is_new = g_state.updated_rows.insert(row_id).second;
-		if (is_new) {
-			sel.set_index(update_count++, i);
-		}
-	}
+	idx_t update_count = DeduplicateUpdatedRowIds(g_state, row_ids, update_chunk.size(), sel);
 
 	// The update chunk now contains exactly those rows that we are deleting.
 	Vector del_row_ids(Vector::Ref(row_ids));
@@ -247,7 +267,7 @@ SinkResultType PhysicalUpdate::Sink(ExecutionContext &context, DataChunk &chunk,
 		}
 	}
 
-	g_state.updated_count += chunk.size();
+	g_state.updated_count += update_count;
 	return SinkResultType::NEED_MORE_INPUT;
 }
 

--- a/src/execution/operator/persistent/physical_update.cpp
+++ b/src/execution/operator/persistent/physical_update.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/common/types/column/column_data_collection.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/execution/expression_executor.hpp"
+#include "duckdb/execution/row_id_deduplicator.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/parallel/thread_context.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
@@ -23,12 +24,12 @@ PhysicalUpdate::PhysicalUpdate(PhysicalPlan &physical_plan, vector<LogicalType> 
                                vector<unique_ptr<Expression>> bound_defaults,
                                vector<unique_ptr<BoundConstraint>> bound_constraints, idx_t estimated_cardinality,
                                bool return_chunk, bool capture_old_rows, vector<idx_t> old_row_columns,
-                               bool update_from)
+                               RowIdHandling row_id_handling)
     : PhysicalOperator(physical_plan, PhysicalOperatorType::UPDATE, std::move(types), estimated_cardinality),
       tableref(tableref), table(table), columns(std::move(columns)), expressions(std::move(expressions)),
       bound_defaults(std::move(bound_defaults)), bound_constraints(std::move(bound_constraints)),
       return_chunk(return_chunk), capture_old_rows(capture_old_rows), old_row_columns(std::move(old_row_columns)),
-      update_from(update_from), index_update(false) {
+      row_id_handling(row_id_handling), index_update(false) {
 	auto &indexes = table.GetDataTableInfo().get()->GetIndexes();
 	auto index_columns = indexes.GetRequiredColumns();
 
@@ -136,19 +137,6 @@ static void AppendReturnRows(ColumnDataCollection &collection, DataChunk &combin
 	collection.Append(combined);
 }
 
-// Deduplicate rows by row-id against the rows already updated in this statement, keeping the first occurrence.
-// Fills `sel` with the positions of the distinct new rows and returns their count. Requires holding g_state.lock.
-static idx_t DeduplicateUpdatedRowIds(UpdateGlobalState &g_state, Vector &row_ids, idx_t count, SelectionVector &sel) {
-	auto row_id_data = FlatVector::GetData<row_t>(row_ids);
-	idx_t new_count = 0;
-	for (idx_t i = 0; i < count; i++) {
-		if (g_state.updated_rows.insert(row_id_data[i]).second) {
-			sel.set_index(new_count++, i);
-		}
-	}
-	return new_count;
-}
-
 SinkResultType PhysicalUpdate::Sink(ExecutionContext &context, DataChunk &chunk, OperatorSinkInput &input) const {
 	auto &g_state = input.global_state.Cast<UpdateGlobalState>();
 	auto &l_state = input.local_state.Cast<UpdateLocalState>();
@@ -176,15 +164,19 @@ SinkResultType PhysicalUpdate::Sink(ExecutionContext &context, DataChunk &chunk,
 
 	// Regular in-place update.
 	if (!update_is_del_and_insert) {
-		// UPDATE ... FROM may match a target row more than once. Deduplicate by row-id so each row is updated at
-		// most once (first match wins), matching the del+insert path and keeping transition tables predictable.
+		// Apply the duplicate row-id policy: ASSUME_UNIQUE keeps the lock-free path; KEEP_FIRST (UPDATE ... FROM)
+		// deduplicates so each row is updated at most once, keeping RETURNING and transition tables predictable.
 		idx_t update_count = update_chunk.size();
 		SelectionVector sel;
 		Vector update_row_ids(Vector::Ref(row_ids));
-		if (update_from) {
+		const bool deduplicate = row_id_handling != RowIdHandling::ASSUME_UNIQUE;
+		if (deduplicate) {
 			sel.Initialize(update_chunk.size());
 			lock_guard<mutex> glock(g_state.lock);
-			update_count = DeduplicateUpdatedRowIds(g_state, row_ids, update_chunk.size(), sel);
+			update_count = RegisterRowIds(g_state.updated_rows, row_ids, update_chunk.size(), sel);
+			if (row_id_handling == RowIdHandling::ERROR && update_count != update_chunk.size()) {
+				throw InvalidInputException("UPDATE command cannot update the same row more than once");
+			}
 			if (update_count != update_chunk.size()) {
 				update_chunk.Slice(sel, update_count);
 				update_row_ids.Slice(row_ids, sel, update_count);
@@ -207,7 +199,7 @@ SinkResultType PhysicalUpdate::Sink(ExecutionContext &context, DataChunk &chunk,
 			if (capture_old_rows) {
 				// When we deduplicated, apply the selection vector to the OLD columns so they line up with NEW.
 				AppendReturnRows(g_state.return_collection, l_state.combined_chunk, mock_chunk, chunk,
-				                 mock_chunk.ColumnCount(), old_row_columns, update_count, update_from ? &sel : nullptr);
+				                 mock_chunk.ColumnCount(), old_row_columns, update_count, deduplicate ? &sel : nullptr);
 			} else {
 				g_state.return_collection.Append(mock_chunk);
 			}
@@ -218,16 +210,23 @@ SinkResultType PhysicalUpdate::Sink(ExecutionContext &context, DataChunk &chunk,
 
 	// We update an index or a complex type, so we need to split the UPDATE into DELETE + INSERT.
 
-	// Keep track of the rows that have not yet been deleted in this UPDATE.
-	// This is required since we might see the same row_id multiple times, e.g.,
-	// during an UPDATE containing joins.
+	// Apply the duplicate row-id policy. This path holds the lock for its whole body (the append is serialized),
+	// so deduplication runs under it. ASSUME_UNIQUE (plain UPDATE and MERGE-driven updates) keeps every row;
+	// KEEP_FIRST (UPDATE ... FROM) drops repeated row-ids so we never delete+insert the same row twice.
 	SelectionVector sel(update_chunk.size());
 	lock_guard<mutex> glock(g_state.lock);
-	idx_t update_count = DeduplicateUpdatedRowIds(g_state, row_ids, update_chunk.size(), sel);
+	idx_t update_count = update_chunk.size();
+	const bool deduplicate = row_id_handling != RowIdHandling::ASSUME_UNIQUE;
+	if (deduplicate) {
+		update_count = RegisterRowIds(g_state.updated_rows, row_ids, update_chunk.size(), sel);
+		if (row_id_handling == RowIdHandling::ERROR && update_count != update_chunk.size()) {
+			throw InvalidInputException("UPDATE command cannot update the same row more than once");
+		}
+	}
 
 	// The update chunk now contains exactly those rows that we are deleting.
 	Vector del_row_ids(Vector::Ref(row_ids));
-	if (update_count != update_chunk.size()) {
+	if (deduplicate && update_count != update_chunk.size()) {
 		update_chunk.Slice(sel, update_count);
 		del_row_ids.Slice(row_ids, sel, update_count);
 	}
@@ -241,9 +240,12 @@ SinkResultType PhysicalUpdate::Sink(ExecutionContext &context, DataChunk &chunk,
 		for (idx_t i = 0; i < table.ColumnCount(); i++) {
 			column_ids.emplace_back(i);
 		};
-		// We need to fetch the previous index keys to add them to the delete index.
+		// Fetch the previous index keys for exactly the rows we delete. Use the deduplicated row-ids
+		// (del_row_ids) so Fetch, Delete, and LocalAppend all operate on the same rows; flatten first because
+		// deduplication slices del_row_ids into a dictionary vector, which Fetch cannot read.
+		del_row_ids.Flatten();
 		auto fetch_state = ColumnFetchState();
-		table.Fetch(transaction, delete_chunk, column_ids, row_ids, update_count, fetch_state);
+		table.Fetch(transaction, delete_chunk, column_ids, del_row_ids, update_count, fetch_state);
 	}
 
 	auto &delete_state = l_state.GetDeleteState(table, tableref, context.client);
@@ -259,9 +261,9 @@ SinkResultType PhysicalUpdate::Sink(ExecutionContext &context, DataChunk &chunk,
 	table.LocalAppend(tableref, context.client, mock_chunk, bound_constraints, del_row_ids, delete_chunk);
 	if (return_chunk) {
 		if (capture_old_rows) {
-			// Apply the dedup/del+insert selection vector to the OLD columns so they line up with the NEW image.
+			// Apply the dedup selection vector to the OLD columns so they line up with the NEW image.
 			AppendReturnRows(g_state.return_collection, l_state.combined_chunk, mock_chunk, chunk,
-			                 mock_chunk.ColumnCount(), old_row_columns, update_count, &sel);
+			                 mock_chunk.ColumnCount(), old_row_columns, update_count, deduplicate ? &sel : nullptr);
 		} else {
 			g_state.return_collection.Append(mock_chunk);
 		}

--- a/src/execution/physical_plan/plan_merge_into.cpp
+++ b/src/execution/physical_plan/plan_merge_into.cpp
@@ -38,7 +38,8 @@ unique_ptr<MergeIntoOperator> PlanMergeIntoAction(ClientContext &context, Logica
 		                                          op.table.GetStorage(), std::move(action.columns),
 		                                          std::move(action.expressions), std::move(defaults),
 		                                          std::move(bound_constraints), cardinality, op.return_chunk,
-		                                          /*capture_old_rows=*/false, /*old_row_columns=*/vector<idx_t>());
+		                                          /*capture_old_rows=*/false, /*old_row_columns=*/vector<idx_t>(),
+		                                          /*update_from=*/false);
 		auto &cast_update = result->op->Cast<PhysicalUpdate>();
 		cast_update.update_is_del_and_insert = action.update_is_del_and_insert;
 		break;

--- a/src/execution/physical_plan/plan_merge_into.cpp
+++ b/src/execution/physical_plan/plan_merge_into.cpp
@@ -39,7 +39,7 @@ unique_ptr<MergeIntoOperator> PlanMergeIntoAction(ClientContext &context, Logica
 		                                          std::move(action.expressions), std::move(defaults),
 		                                          std::move(bound_constraints), cardinality, op.return_chunk,
 		                                          /*capture_old_rows=*/false, /*old_row_columns=*/vector<idx_t>(),
-		                                          /*update_from=*/false);
+		                                          /*row_id_handling=*/RowIdHandling::ASSUME_UNIQUE);
 		auto &cast_update = result->op->Cast<PhysicalUpdate>();
 		cast_update.update_is_del_and_insert = action.update_is_del_and_insert;
 		break;

--- a/src/execution/physical_plan/plan_update.cpp
+++ b/src/execution/physical_plan/plan_update.cpp
@@ -9,10 +9,10 @@ namespace duckdb {
 
 PhysicalOperator &DuckCatalog::PlanUpdate(ClientContext &context, PhysicalPlanGenerator &planner, LogicalUpdate &op,
                                           PhysicalOperator &plan) {
-	auto &update = planner.Make<PhysicalUpdate>(op.types, op.table.Cast<DuckTableEntry>(), op.table.GetStorage(),
-	                                            op.columns, std::move(op.expressions), std::move(op.bound_defaults),
-	                                            std::move(op.bound_constraints), op.estimated_cardinality,
-	                                            op.return_chunk, op.capture_old_rows, std::move(op.old_row_columns));
+	auto &update = planner.Make<PhysicalUpdate>(
+	    op.types, op.table.Cast<DuckTableEntry>(), op.table.GetStorage(), op.columns, std::move(op.expressions),
+	    std::move(op.bound_defaults), std::move(op.bound_constraints), op.estimated_cardinality, op.return_chunk,
+	    op.capture_old_rows, std::move(op.old_row_columns), op.update_from);
 	auto &cast_update = update.Cast<PhysicalUpdate>();
 	cast_update.update_is_del_and_insert = op.update_is_del_and_insert;
 	cast_update.children.push_back(plan);

--- a/src/execution/physical_plan/plan_update.cpp
+++ b/src/execution/physical_plan/plan_update.cpp
@@ -12,7 +12,7 @@ PhysicalOperator &DuckCatalog::PlanUpdate(ClientContext &context, PhysicalPlanGe
 	auto &update = planner.Make<PhysicalUpdate>(
 	    op.types, op.table.Cast<DuckTableEntry>(), op.table.GetStorage(), op.columns, std::move(op.expressions),
 	    std::move(op.bound_defaults), std::move(op.bound_constraints), op.estimated_cardinality, op.return_chunk,
-	    op.capture_old_rows, std::move(op.old_row_columns), op.update_from);
+	    op.capture_old_rows, std::move(op.old_row_columns), op.row_id_handling);
 	auto &cast_update = update.Cast<PhysicalUpdate>();
 	cast_update.update_is_del_and_insert = op.update_is_del_and_insert;
 	cast_update.children.push_back(plan);

--- a/src/include/duckdb/common/enum_util.hpp
+++ b/src/include/duckdb/common/enum_util.hpp
@@ -438,6 +438,8 @@ enum class ResultModifierType : uint8_t;
 
 enum class RowGroupAppendMode : uint8_t;
 
+enum class RowIdHandling : uint8_t;
+
 enum class SampleMethod : uint8_t;
 
 enum class SampleType : uint8_t;
@@ -1191,6 +1193,9 @@ const char* EnumUtil::ToChars<ResultModifierType>(ResultModifierType value);
 
 template<>
 const char* EnumUtil::ToChars<RowGroupAppendMode>(RowGroupAppendMode value);
+
+template<>
+const char* EnumUtil::ToChars<RowIdHandling>(RowIdHandling value);
 
 template<>
 const char* EnumUtil::ToChars<SampleMethod>(SampleMethod value);
@@ -2017,6 +2022,9 @@ ResultModifierType EnumUtil::FromString<ResultModifierType>(const char *value);
 
 template<>
 RowGroupAppendMode EnumUtil::FromString<RowGroupAppendMode>(const char *value);
+
+template<>
+RowIdHandling EnumUtil::FromString<RowIdHandling>(const char *value);
 
 template<>
 SampleMethod EnumUtil::FromString<SampleMethod>(const char *value);

--- a/src/include/duckdb/common/enums/row_id_handling.hpp
+++ b/src/include/duckdb/common/enums/row_id_handling.hpp
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/enums/row_id_handling.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/constants.hpp"
+
+namespace duckdb {
+
+//! How a data-modifying operator handles a target row-id that appears more than once in its input (e.g. an
+//! UPDATE ... FROM whose join matches a target row via several source rows). Decouples the duplicate-row-id
+//! policy from the SQL syntax that produced it.
+enum class RowIdHandling : uint8_t {
+	//! Row-ids are assumed unique; do not deduplicate (keeps the lock-free path). Used by plain UPDATE.
+	ASSUME_UNIQUE = 0,
+	//! Deduplicate row-ids, keeping the first occurrence of each. Used by UPDATE ... FROM.
+	KEEP_FIRST = 1,
+	//! Raise a cardinality error when a row-id repeats. (MERGE enforces this at the outer MERGE operator.)
+	ERROR = 2
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/execution/operator/persistent/physical_update.hpp
+++ b/src/include/duckdb/execution/operator/persistent/physical_update.hpp
@@ -25,8 +25,8 @@ public:
 	PhysicalUpdate(PhysicalPlan &physical_plan, vector<LogicalType> types, DuckTableEntry &tableref, DataTable &table,
 	               vector<PhysicalIndex> columns, vector<unique_ptr<Expression>> expressions,
 	               vector<unique_ptr<Expression>> bound_defaults, vector<unique_ptr<BoundConstraint>> bound_constraints,
-	               idx_t estimated_cardinality, bool return_chunk, bool capture_old_rows,
-	               vector<idx_t> old_row_columns);
+	               idx_t estimated_cardinality, bool return_chunk, bool capture_old_rows, vector<idx_t> old_row_columns,
+	               bool update_from);
 
 	DuckTableEntry &tableref;
 	DataTable &table;
@@ -41,6 +41,9 @@ public:
 	bool capture_old_rows;
 	//! Input-chunk index of each captured OLD physical column, in physical table order (only when capture_old_rows)
 	vector<idx_t> old_row_columns;
+	//! If set, the update source may match a target row more than once (UPDATE ... FROM): deduplicate row-ids
+	//! so each row is updated at most once (first match wins).
+	bool update_from;
 	//! Set to true, if we are updating an index column.
 	bool index_update;
 

--- a/src/include/duckdb/execution/operator/persistent/physical_update.hpp
+++ b/src/include/duckdb/execution/operator/persistent/physical_update.hpp
@@ -11,6 +11,7 @@
 #include "duckdb/execution/physical_operator.hpp"
 #include "duckdb/planner/expression.hpp"
 #include "duckdb/planner/bound_constraint.hpp"
+#include "duckdb/common/enums/row_id_handling.hpp"
 
 namespace duckdb {
 class DataTable;
@@ -26,7 +27,7 @@ public:
 	               vector<PhysicalIndex> columns, vector<unique_ptr<Expression>> expressions,
 	               vector<unique_ptr<Expression>> bound_defaults, vector<unique_ptr<BoundConstraint>> bound_constraints,
 	               idx_t estimated_cardinality, bool return_chunk, bool capture_old_rows, vector<idx_t> old_row_columns,
-	               bool update_from);
+	               RowIdHandling row_id_handling);
 
 	DuckTableEntry &tableref;
 	DataTable &table;
@@ -41,9 +42,9 @@ public:
 	bool capture_old_rows;
 	//! Input-chunk index of each captured OLD physical column, in physical table order (only when capture_old_rows)
 	vector<idx_t> old_row_columns;
-	//! If set, the update source may match a target row more than once (UPDATE ... FROM): deduplicate row-ids
-	//! so each row is updated at most once (first match wins).
-	bool update_from;
+	//! How to handle a target row-id that appears more than once in the input (e.g. UPDATE ... FROM): keep the
+	//! lock-free path (ASSUME_UNIQUE), deduplicate keeping the first match (KEEP_FIRST), or error (ERROR).
+	RowIdHandling row_id_handling;
 	//! Set to true, if we are updating an index column.
 	bool index_update;
 

--- a/src/include/duckdb/execution/row_id_deduplicator.hpp
+++ b/src/include/duckdb/execution/row_id_deduplicator.hpp
@@ -1,0 +1,42 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/execution/row_id_deduplicator.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/optional_ptr.hpp"
+#include "duckdb/common/types.hpp"
+#include "duckdb/common/types/vector.hpp"
+#include "duckdb/common/unordered_set.hpp"
+#include "duckdb/common/vector/vector_iterator.hpp"
+
+namespace duckdb {
+
+//! Registers the first `count` row-ids of `row_ids` into `seen`, handling any vector layout. When `sel` is
+//! provided, records the input position of each first-seen row-id (keep-first deduplication). Returns the number
+//! of distinct (first-seen) row-ids. The caller owns its locking and duplicate policy: keep-first by slicing with
+//! `sel`, or raise its own error when the returned count is less than `count`. Shared by UPDATE, MERGE, and
+//! ON CONFLICT DO UPDATE, which otherwise duplicated this row-id iteration.
+inline idx_t RegisterRowIds(unordered_set<row_t> &seen, const Vector &row_ids, idx_t count,
+                            optional_ptr<SelectionVector> sel = nullptr) {
+	idx_t distinct_count = 0;
+	for (const auto &entry : row_ids.Values<row_t>()) {
+		// the caller may pass fewer meaningful entries than the vector holds (e.g. conflict row-ids)
+		if (entry.GetIndex() >= count) {
+			break;
+		}
+		if (seen.insert(entry.GetValue()).second) {
+			if (sel) {
+				sel->set_index(distinct_count, entry.GetIndex());
+			}
+			distinct_count++;
+		}
+	}
+	return distinct_count;
+}
+
+} // namespace duckdb

--- a/src/include/duckdb/planner/operator/logical_update.hpp
+++ b/src/include/duckdb/planner/operator/logical_update.hpp
@@ -38,6 +38,9 @@ public:
 	vector<unique_ptr<Expression>> bound_defaults;
 	vector<unique_ptr<BoundConstraint>> bound_constraints;
 	bool update_is_del_and_insert;
+	//! if set, the update source may match a target row more than once (UPDATE ... FROM), so the operator
+	//! deduplicates row-ids and updates each row at most once (first match wins)
+	bool update_from = false;
 
 public:
 	void Serialize(Serializer &serializer) const override;

--- a/src/include/duckdb/planner/operator/logical_update.hpp
+++ b/src/include/duckdb/planner/operator/logical_update.hpp
@@ -11,6 +11,7 @@
 #include "duckdb/planner/logical_operator.hpp"
 #include "duckdb/planner/bound_constraint.hpp"
 #include "duckdb/common/index_map.hpp"
+#include "duckdb/common/enums/row_id_handling.hpp"
 
 namespace duckdb {
 class TableCatalogEntry;
@@ -38,9 +39,9 @@ public:
 	vector<unique_ptr<Expression>> bound_defaults;
 	vector<unique_ptr<BoundConstraint>> bound_constraints;
 	bool update_is_del_and_insert;
-	//! if set, the update source may match a target row more than once (UPDATE ... FROM), so the operator
-	//! deduplicates row-ids and updates each row at most once (first match wins)
-	bool update_from = false;
+	//! how to handle a target row-id appearing more than once in the input (e.g. UPDATE ... FROM): keep the
+	//! lock-free path (ASSUME_UNIQUE), deduplicate keeping the first match (KEEP_FIRST), or error (ERROR)
+	RowIdHandling row_id_handling = RowIdHandling::ASSUME_UNIQUE;
 
 public:
 	void Serialize(Serializer &serializer) const override;

--- a/src/include/duckdb/storage/serialization/logical_operator.json
+++ b/src/include/duckdb/storage/serialization/logical_operator.json
@@ -855,6 +855,12 @@
         "id": 208,
         "name": "old_row_columns",
         "type": "vector<idx_t>"
+      },
+      {
+        "id": 209,
+        "name": "update_from",
+        "type": "bool",
+        "default": "false"
       }
     ],
     "constructor": [

--- a/src/include/duckdb/storage/serialization/logical_operator.json
+++ b/src/include/duckdb/storage/serialization/logical_operator.json
@@ -858,9 +858,9 @@
       },
       {
         "id": 209,
-        "name": "update_from",
-        "type": "bool",
-        "default": "false"
+        "name": "row_id_handling",
+        "type": "RowIdHandling",
+        "default": "RowIdHandling::ASSUME_UNIQUE"
       }
     ],
     "constructor": [

--- a/src/planner/binder/statement/bind_update.cpp
+++ b/src/planner/binder/statement/bind_update.cpp
@@ -206,6 +206,9 @@ BoundStatement Binder::BindNode(UpdateQueryNode &node) {
 		update->return_chunk = true;
 	}
 	update->capture_old_rows = capture_old_rows;
+	// UPDATE ... FROM can match a target row via multiple source rows; flag it so the operator deduplicates
+	// row-ids and updates each row at most once (first match wins).
+	update->update_from = node.from_table != nullptr;
 	// bind the default values
 	auto &catalog_name = table.ParentCatalog().GetName();
 	auto &schema_name = table.ParentSchema().name;

--- a/src/planner/binder/statement/bind_update.cpp
+++ b/src/planner/binder/statement/bind_update.cpp
@@ -206,9 +206,9 @@ BoundStatement Binder::BindNode(UpdateQueryNode &node) {
 		update->return_chunk = true;
 	}
 	update->capture_old_rows = capture_old_rows;
-	// UPDATE ... FROM can match a target row via multiple source rows; flag it so the operator deduplicates
-	// row-ids and updates each row at most once (first match wins).
-	update->update_from = node.from_table != nullptr;
+	// UPDATE ... FROM can match a target row via multiple source rows, so deduplicate keeping the first match;
+	// a plain UPDATE cannot produce duplicate row-ids, so it keeps the lock-free path.
+	update->row_id_handling = node.from_table ? RowIdHandling::KEEP_FIRST : RowIdHandling::ASSUME_UNIQUE;
 	// bind the default values
 	auto &catalog_name = table.ParentCatalog().GetName();
 	auto &schema_name = table.ParentSchema().name;

--- a/src/storage/serialization/serialize_logical_operator.cpp
+++ b/src/storage/serialization/serialize_logical_operator.cpp
@@ -911,6 +911,7 @@ void LogicalUpdate::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<bool>(206, "update_is_del_and_insert", update_is_del_and_insert);
 	serializer.WritePropertyWithDefault<bool>(207, "capture_old_rows", capture_old_rows, false);
 	serializer.WritePropertyWithDefault<vector<idx_t>>(208, "old_row_columns", old_row_columns);
+	serializer.WritePropertyWithDefault<bool>(209, "update_from", update_from, false);
 }
 
 unique_ptr<LogicalOperator> LogicalUpdate::Deserialize(Deserializer &deserializer) {
@@ -924,6 +925,7 @@ unique_ptr<LogicalOperator> LogicalUpdate::Deserialize(Deserializer &deserialize
 	deserializer.ReadPropertyWithDefault<bool>(206, "update_is_del_and_insert", result->update_is_del_and_insert);
 	deserializer.ReadPropertyWithExplicitDefault<bool>(207, "capture_old_rows", result->capture_old_rows, false);
 	deserializer.ReadPropertyWithDefault<vector<idx_t>>(208, "old_row_columns", result->old_row_columns);
+	deserializer.ReadPropertyWithExplicitDefault<bool>(209, "update_from", result->update_from, false);
 	return std::move(result);
 }
 

--- a/src/storage/serialization/serialize_logical_operator.cpp
+++ b/src/storage/serialization/serialize_logical_operator.cpp
@@ -911,7 +911,7 @@ void LogicalUpdate::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<bool>(206, "update_is_del_and_insert", update_is_del_and_insert);
 	serializer.WritePropertyWithDefault<bool>(207, "capture_old_rows", capture_old_rows, false);
 	serializer.WritePropertyWithDefault<vector<idx_t>>(208, "old_row_columns", old_row_columns);
-	serializer.WritePropertyWithDefault<bool>(209, "update_from", update_from, false);
+	serializer.WritePropertyWithDefault<RowIdHandling>(209, "row_id_handling", row_id_handling, RowIdHandling::ASSUME_UNIQUE);
 }
 
 unique_ptr<LogicalOperator> LogicalUpdate::Deserialize(Deserializer &deserializer) {
@@ -925,7 +925,7 @@ unique_ptr<LogicalOperator> LogicalUpdate::Deserialize(Deserializer &deserialize
 	deserializer.ReadPropertyWithDefault<bool>(206, "update_is_del_and_insert", result->update_is_del_and_insert);
 	deserializer.ReadPropertyWithExplicitDefault<bool>(207, "capture_old_rows", result->capture_old_rows, false);
 	deserializer.ReadPropertyWithDefault<vector<idx_t>>(208, "old_row_columns", result->old_row_columns);
-	deserializer.ReadPropertyWithExplicitDefault<bool>(209, "update_from", result->update_from, false);
+	deserializer.ReadPropertyWithExplicitDefault<RowIdHandling>(209, "row_id_handling", result->row_id_handling, RowIdHandling::ASSUME_UNIQUE);
 	return std::move(result);
 }
 

--- a/test/configs/encryption.json
+++ b/test/configs/encryption.json
@@ -71,6 +71,7 @@
         "test/sql/trigger/trigger_after_update_referencing.test",
         "test/sql/trigger/trigger_after_update_old_new.test",
         "test/sql/trigger/trigger_after_update_old_new_wal.test",
+        "test/sql/trigger/trigger_update_from_multi_match.test",
         "test/sql/trigger/trigger_after_delete_referencing.test",
         "test/sql/trigger/trigger_referencing_validation.test",
         "test/sql/trigger/trigger_multiple_per_event.test",

--- a/test/sql/merge/merge_multi_match_error.test
+++ b/test/sql/merge/merge_multi_match_error.test
@@ -1,0 +1,151 @@
+# name: test/sql/merge/merge_multi_match_error.test
+# description: MERGE raises a cardinality error when a WHEN MATCHED action would affect a target row twice
+# group: [merge]
+
+statement ok
+CREATE TABLE target (k INTEGER, v INTEGER);
+
+statement ok
+INSERT INTO target VALUES (1, 10);
+
+statement ok
+CREATE TABLE source (k INTEGER, v INTEGER);
+
+# two source rows match the single target row
+statement ok
+INSERT INTO source VALUES (1, 100), (1, 200);
+
+# WHEN MATCHED UPDATE affecting the same target row twice -> cardinality error
+statement error
+MERGE INTO target USING source ON target.k = source.k
+WHEN MATCHED THEN UPDATE SET v = source.v;
+----
+cannot affect the same target row more than once
+
+# WHEN MATCHED DELETE with the same multi-match -> also an error
+statement error
+MERGE INTO target USING source ON target.k = source.k
+WHEN MATCHED THEN DELETE;
+----
+cannot affect the same target row more than once
+
+# target unchanged after the failed merges
+query II
+SELECT k, v FROM target;
+----
+1	10
+
+# single match succeeds
+statement ok
+DELETE FROM source WHERE v = 200;
+
+statement ok
+MERGE INTO target USING source ON target.k = source.k
+WHEN MATCHED THEN UPDATE SET v = source.v;
+
+query II
+SELECT k, v FROM target;
+----
+1	100
+
+# ── conditional WHEN MATCHED: the error tracks actions actually taken, not raw matches ──
+statement ok
+CREATE TABLE tc (k INTEGER, v INTEGER);
+
+statement ok
+INSERT INTO tc VALUES (1, 10);
+
+statement ok
+CREATE TABLE sc (k INTEGER, v INTEGER);
+
+statement ok
+INSERT INTO sc VALUES (1, 50), (1, 200);
+
+# two sources match k=1, but only one passes the action condition -> one action -> no error (matches PostgreSQL)
+statement ok
+MERGE INTO tc USING sc ON tc.k = sc.k
+WHEN MATCHED AND sc.v > 100 THEN UPDATE SET v = sc.v;
+
+query II
+SELECT k, v FROM tc;
+----
+1	200
+
+# now both sources pass the condition -> two actions on the same row -> error
+statement ok
+UPDATE sc SET v = 150 WHERE v = 50;
+
+statement error
+MERGE INTO tc USING sc ON tc.k = sc.k
+WHEN MATCHED AND sc.v > 100 THEN UPDATE SET v = sc.v;
+----
+cannot affect the same target row more than once
+
+# ── multiple matches but no matched-modifying action: no error ──────────────────
+statement ok
+CREATE TABLE t_ins (k INTEGER, v INTEGER);
+
+statement ok
+INSERT INTO t_ins VALUES (1, 10);
+
+statement ok
+CREATE TABLE s_ins (k INTEGER, v INTEGER);
+
+statement ok
+INSERT INTO s_ins VALUES (2, 1), (2, 2);
+
+# both source rows are NOT MATCHED (k=2 not in target); INSERT only -> no cardinality check
+statement ok
+MERGE INTO t_ins USING s_ins ON t_ins.k = s_ins.k
+WHEN NOT MATCHED THEN INSERT VALUES (s_ins.k, s_ins.v);
+
+query I
+SELECT count(*) FROM t_ins;
+----
+3
+
+# ── WHEN NOT MATCHED BY SOURCE modifies each target row at most once: no error ───
+statement ok
+CREATE TABLE t_src (k INTEGER, v INTEGER);
+
+statement ok
+INSERT INTO t_src VALUES (1, 10), (2, 20);
+
+statement ok
+CREATE TABLE s_src (k INTEGER, v INTEGER);
+
+# two source rows, neither matching the targets
+statement ok
+INSERT INTO s_src VALUES (9, 1), (9, 2);
+
+statement ok
+MERGE INTO t_src USING s_src ON t_src.k = s_src.k
+WHEN NOT MATCHED BY SOURCE THEN UPDATE SET v = 0;
+
+query II rowsort
+SELECT k, v FROM t_src;
+----
+1	0
+2	0
+
+# ── unique matches over many rows still succeed ─────────────────────────────────
+statement ok
+CREATE TABLE t_big (k INTEGER, v INTEGER);
+
+statement ok
+INSERT INTO t_big SELECT i, 0 FROM range(1, 3000) tbl(i);
+
+statement ok
+CREATE TABLE s_big (k INTEGER, v INTEGER);
+
+statement ok
+INSERT INTO s_big SELECT i, i FROM range(1, 3000) tbl(i);
+
+statement ok
+MERGE INTO t_big USING s_big ON t_big.k = s_big.k
+WHEN MATCHED THEN UPDATE SET v = s_big.v;
+
+query I
+SELECT count(*) FROM t_big WHERE v = k;
+----
+2999

--- a/test/sql/returning/returning_update.test
+++ b/test/sql/returning/returning_update.test
@@ -111,48 +111,33 @@ INSERT INTO table2 VALUES (1, 1, 1), (2, 2, 2), (3, 3, 3), (100, 100, 100), (200
 statement ok
 INSERT INTO table3 VALUES (1, 4, 4), (2, 6, 7), (8, 8, 8);
 
-# update with a cross product
-# because each row of table3 is joined with each row of table 2, only the first tuples
-# for every c3 = t2.c2 are respected in the update
+# update with a cross product: each row of table3 joins with every row of table2, but UPDATE ... FROM now
+# updates each target row at most once (one arbitrary match), so RETURNING yields one row per target row and
+# the winning c3 is one of the matching t2.c2 values (which one is unspecified).
 query III rowsort
 UPDATE table3
 SET c3 = t2.c2
 FROM table2 AS t2
-RETURNING *;
+RETURNING a3, b3, c3 IN (1, 2, 3, 100, 200);
 ----
 1	4	1
-1	4	100
-1	4	2
-1	4	200
-1	4	3
 2	6	1
-2	6	100
-2	6	2
-2	6	200
-2	6	3
 8	8	1
-8	8	100
-8	8	2
-8	8	200
-8	8	3
 
-# depending on the vector size, the updates of the above test
-# can occur in a different order than as they are written (see the rowsort arg).
-# When the updates occur in a different order, a different result is recorded
-# therefore the IN (1, 200) clause for c3.
+# the stored c3 is one of the matching t2.c2 values (which one is unspecified)
 query III
-SELECT a3, b3, c3 IN (1, 200) FROM table3;
+SELECT a3, b3, c3 IN (1, 2, 3, 100, 200) FROM table3;
 ----
 1	4	1
 2	6	1
 8	8	1
 
-# update using other table (automatic join should happen here)
+# update using other table (automatic join should happen here); a3 = a2 matches at most one row
 query III
 UPDATE table3
 SET b3 = t2.b2
 FROM table2 AS t2
-WHERE table3.a3 = t2.a2 RETURNING a3, b3, c3 IN (1, 200);
+WHERE table3.a3 = t2.a2 RETURNING a3, b3, c3 IN (1, 2, 3, 100, 200);
 ----
 1	1	1
 2	2	1

--- a/test/sql/trigger/trigger_update_from_multi_match.test
+++ b/test/sql/trigger/trigger_update_from_multi_match.test
@@ -1,0 +1,91 @@
+# name: test/sql/trigger/trigger_update_from_multi_match.test
+# description: UPDATE ... FROM multi-match dedup makes AFTER UPDATE transition tables predictable
+# group: [trigger]
+
+require noforcestorage
+
+statement ok
+CREATE TABLE t (id INTEGER, v INTEGER);
+
+statement ok
+INSERT INTO t VALUES (1, 0), (2, 0);
+
+statement ok
+CREATE TABLE audit (id INTEGER, old_v INTEGER, new_v INTEGER);
+
+statement ok
+CREATE TRIGGER trg AFTER UPDATE ON t
+REFERENCING OLD TABLE AS o NEW TABLE AS n
+FOR EACH STATEMENT
+    INSERT INTO audit SELECT o.id, o.v, n.v FROM o JOIN n ON o.id = n.id;
+
+statement ok
+CREATE TABLE src (id INTEGER, v INTEGER);
+
+# each target row matched by two source rows
+statement ok
+INSERT INTO src VALUES (1, 10), (1, 20), (2, 30), (2, 40);
+
+statement ok
+UPDATE t SET v = src.v FROM src WHERE t.id = src.id;
+
+# each target row is updated once, so the transition tables carry exactly one image per row
+query I
+SELECT count(*) FROM audit;
+----
+2
+
+# OLD image holds the pre-update values; NEW image holds one of the matching source values
+query I
+SELECT count(*) FROM audit WHERE old_v = 0 AND (new_v IN (10, 20) AND id = 1 OR new_v IN (30, 40) AND id = 2);
+----
+2
+
+# the base table also ends up with one row per id, each updated once
+query I
+SELECT count(*) FROM t WHERE (id = 1 AND v IN (10, 20)) OR (id = 2 AND v IN (30, 40));
+----
+2
+
+# ── del+insert path + OLD/NEW capture + multi-match ──────────────────────────────
+# A LIST column forces the update through the del+insert path, so this exercises the OLD-capture
+# selection-vector slicing on that path (AppendReturnRows with a dedup sel) together with multi-match.
+statement ok
+CREATE TABLE tl (id INTEGER, vals INTEGER[]);
+
+statement ok
+INSERT INTO tl VALUES (1, [0]), (2, [0]);
+
+statement ok
+CREATE TABLE tl_audit (id INTEGER, old_len INTEGER, new_len INTEGER);
+
+statement ok
+CREATE TRIGGER trg_l AFTER UPDATE ON tl
+REFERENCING OLD TABLE AS o NEW TABLE AS n
+FOR EACH STATEMENT
+    INSERT INTO tl_audit SELECT o.id, len(o.vals), len(n.vals) FROM o JOIN n ON o.id = n.id;
+
+statement ok
+CREATE TABLE sl (id INTEGER, vals INTEGER[]);
+
+# each target matched by two source rows; per id the matching lists share a length so len is deterministic
+# even though which list wins is arbitrary (id=1 -> length 2, id=2 -> length 3)
+statement ok
+INSERT INTO sl VALUES (1, [9, 9]), (1, [1, 1]), (2, [8, 8, 8]), (2, [7, 7, 7]);
+
+statement ok
+UPDATE tl SET vals = sl.vals FROM sl WHERE tl.id = sl.id;
+
+# one transition image per target row; OLD length is the pre-update [0] (len 1), NEW length is the match length
+query III rowsort
+SELECT id, old_len, new_len FROM tl_audit;
+----
+1	1	2
+2	1	3
+
+# base table updated once per row to a matching list
+query II rowsort
+SELECT id, len(vals) FROM tl;
+----
+1	2
+2	3

--- a/test/sql/update/test_update_from.test
+++ b/test/sql/update/test_update_from.test
@@ -100,23 +100,24 @@ SELECT * FROM test
 ----
 1
 
-# test with multiple updates per row (which is undefined),
-# but in this case the last value in the table will win
-# FIXME:
-mode skip instable
-
+# multiple source rows match the single target row. UPDATE ... FROM now updates each row at most once
+# (one arbitrary match wins) rather than the previous undefined last-write-wins.
 statement ok
 INSERT INTO src VALUES (7)
 
 statement ok
 UPDATE test SET a=s.a FROM src s
 
+# exactly one row remains, updated to one of the matching source values
 query I
-SELECT * FROM test
+SELECT count(*) FROM test
 ----
-7
+1
 
-mode unskip
+query I
+SELECT a IN (2, 7) FROM test
+----
+true
 
 # test described in issue 1035
 

--- a/test/sql/update/update_from_multi_match.test
+++ b/test/sql/update/update_from_multi_match.test
@@ -1,0 +1,238 @@
+# name: test/sql/update/update_from_multi_match.test
+# description: UPDATE ... FROM updates each target row at most once when matched by multiple source rows
+# group: [update]
+
+# ── basic multi-match: one target row, many source matches ──────────────────────
+statement ok
+CREATE TABLE t (id INTEGER, v INTEGER);
+
+statement ok
+INSERT INTO t VALUES (1, 0);
+
+statement ok
+CREATE TABLE s (id INTEGER, v INTEGER);
+
+statement ok
+INSERT INTO s VALUES (1, 10), (1, 20), (1, 30);
+
+statement ok
+UPDATE t SET v = s.v FROM s WHERE t.id = s.id;
+
+# the single row is updated exactly once to one of the matching values
+query I
+SELECT count(*) FROM t;
+----
+1
+
+query I
+SELECT v IN (10, 20, 30) FROM t;
+----
+true
+
+# ── every target row updated once, none dropped or duplicated ───────────────────
+statement ok
+CREATE TABLE t2 (id INTEGER, v INTEGER);
+
+statement ok
+INSERT INTO t2 SELECT i, -1 FROM range(1, 2000) tbl(i);
+
+statement ok
+CREATE TABLE s2 (id INTEGER, v INTEGER);
+
+# two source matches for every target id (cross-chunk: ~4000 join rows)
+statement ok
+INSERT INTO s2 SELECT i, i * 10 FROM range(1, 2000) tbl(i);
+
+statement ok
+INSERT INTO s2 SELECT i, i * 100 FROM range(1, 2000) tbl(i);
+
+statement ok
+UPDATE t2 SET v = s2.v FROM s2 WHERE t2.id = s2.id;
+
+# same number of rows, every row updated exactly once to one of its two matches
+query I
+SELECT count(*) FROM t2;
+----
+1999
+
+query I
+SELECT count(*) FROM t2 WHERE v = id * 10 OR v = id * 100;
+----
+1999
+
+query I
+SELECT count(*) FROM t2 WHERE v = -1;
+----
+0
+
+# ── RETURNING yields one row per updated target, not one per match ───────────────
+statement ok
+CREATE TABLE t3 (id INTEGER, v INTEGER);
+
+statement ok
+INSERT INTO t3 VALUES (1, 0), (2, 0);
+
+statement ok
+CREATE TABLE s3 (id INTEGER, v INTEGER);
+
+statement ok
+INSERT INTO s3 VALUES (1, 11), (1, 12), (2, 21), (2, 22);
+
+query I rowsort
+UPDATE t3 SET v = s3.v FROM s3 WHERE t3.id = s3.id RETURNING id;
+----
+1
+2
+
+# ── reported row count reflects rows actually updated, not the number of join matches ──
+statement ok
+CREATE TABLE tcnt (id INTEGER, v INTEGER);
+
+statement ok
+INSERT INTO tcnt VALUES (1, 0);
+
+statement ok
+CREATE TABLE scnt (id INTEGER, v INTEGER);
+
+statement ok
+INSERT INTO scnt VALUES (1, 10), (1, 20), (1, 30);
+
+# 3 join matches, 1 target row updated -> reports 1 (matches PostgreSQL's "UPDATE 1")
+query I
+UPDATE tcnt SET v = scnt.v FROM scnt WHERE tcnt.id = scnt.id;
+----
+1
+
+# two target rows, each matched twice -> reports 2
+statement ok
+CREATE TABLE tcnt2 (id INTEGER, v INTEGER);
+
+statement ok
+INSERT INTO tcnt2 VALUES (1, 0), (2, 0);
+
+statement ok
+CREATE TABLE scnt2 (id INTEGER, v INTEGER);
+
+statement ok
+INSERT INTO scnt2 VALUES (1, 11), (1, 12), (2, 21), (2, 22);
+
+query I
+UPDATE tcnt2 SET v = scnt2.v FROM scnt2 WHERE tcnt2.id = scnt2.id;
+----
+2
+
+# del+insert path reports the distinct count too (this over-count existed before dedup was unified)
+statement ok
+SET force_update_to_del_and_insert = true;
+
+query I
+UPDATE tcnt2 SET v = scnt2.v FROM scnt2 WHERE tcnt2.id = scnt2.id;
+----
+2
+
+statement ok
+SET force_update_to_del_and_insert = false;
+
+# plain UPDATE (no FROM) still reports every affected row
+query I
+UPDATE tcnt2 SET v = v + 1;
+----
+2
+
+# ── self-join multi-match: each row still updated once ──────────────────────────
+statement ok
+CREATE TABLE t_self (id INTEGER, v INTEGER);
+
+statement ok
+INSERT INTO t_self VALUES (1, 5), (1, 6), (2, 7);
+
+# id=1 has two rows; joining on id makes each id=1 row match two partners
+statement ok
+UPDATE t_self SET v = o.v FROM t_self o WHERE t_self.id = o.id;
+
+query I
+SELECT count(*) FROM t_self;
+----
+3
+
+# ── forced del+insert path deduplicates identically across chunks ────────────────
+statement ok
+SET force_update_to_del_and_insert = true;
+
+statement ok
+CREATE TABLE t5 (id INTEGER, v INTEGER);
+
+statement ok
+INSERT INTO t5 SELECT i, -1 FROM range(1, 2000) tbl(i);
+
+statement ok
+CREATE TABLE s5 (id INTEGER, v INTEGER);
+
+statement ok
+INSERT INTO s5 SELECT i, i * 10 FROM range(1, 2000) tbl(i);
+
+statement ok
+INSERT INTO s5 SELECT i, i * 100 FROM range(1, 2000) tbl(i);
+
+statement ok
+UPDATE t5 SET v = s5.v FROM s5 WHERE t5.id = s5.id;
+
+query I
+SELECT count(*) FROM t5;
+----
+1999
+
+query I
+SELECT count(*) FROM t5 WHERE v = id * 10 OR v = id * 100;
+----
+1999
+
+statement ok
+SET force_update_to_del_and_insert = false;
+
+# ── zero matches: nothing updated, no error ─────────────────────────────────────
+statement ok
+CREATE TABLE t6 (id INTEGER, v INTEGER);
+
+statement ok
+INSERT INTO t6 VALUES (1, 100);
+
+statement ok
+CREATE TABLE s6 (id INTEGER, v INTEGER);
+
+statement ok
+INSERT INTO s6 VALUES (2, 1), (3, 2);
+
+statement ok
+UPDATE t6 SET v = s6.v FROM s6 WHERE t6.id = s6.id;
+
+query I
+SELECT v FROM t6;
+----
+100
+
+# ── del+insert path (LIST column forces del+insert) dedups the same way ──────────
+statement ok
+CREATE TABLE t4 (id INTEGER, v INTEGER[]);
+
+statement ok
+INSERT INTO t4 VALUES (1, [0]);
+
+statement ok
+CREATE TABLE s4 (id INTEGER, v INTEGER[]);
+
+statement ok
+INSERT INTO s4 VALUES (1, [10]), (1, [20]);
+
+statement ok
+UPDATE t4 SET v = s4.v FROM s4 WHERE t4.id = s4.id;
+
+query I
+SELECT count(*) FROM t4;
+----
+1
+
+query I
+SELECT len(v) FROM t4;
+----
+1

--- a/test/sql/update/update_from_multi_match.test
+++ b/test/sql/update/update_from_multi_match.test
@@ -236,3 +236,30 @@ query I
 SELECT len(v) FROM t4;
 ----
 1
+
+# ── indexed target (del+insert path) with duplicate matches ──────────────────────
+# Fetch, Delete, and LocalAppend must all operate on the deduplicated row-ids; otherwise Fetch reads the
+# wrong rows and a valid UPDATE fails with a spurious duplicate-key error.
+statement ok
+CREATE TABLE target_pk (id INTEGER PRIMARY KEY, value INTEGER);
+
+statement ok
+INSERT INTO target_pk VALUES (1, 0), (2, 0);
+
+statement ok
+CREATE TABLE source_dup (id INTEGER, value INTEGER);
+
+statement ok
+INSERT INTO source_dup VALUES (1, 10), (1, 11), (2, 20), (2, 21);
+
+query I rowsort
+UPDATE target_pk SET value = source_dup.value FROM source_dup WHERE target_pk.id = source_dup.id RETURNING id;
+----
+1
+2
+
+# each target row updated exactly once to one of its matches
+query I
+SELECT count(*) FROM target_pk WHERE (id = 1 AND value IN (10, 11)) OR (id = 2 AND value IN (20, 21));
+----
+2


### PR DESCRIPTION
## Summary

When a join matches the same target row more than once, DuckDB's two UPDATE Sink paths disagreed: the in-place path applied **every** match (undefined, last-write-wins) while the del+insert path silently deduplicated. This made results and trigger transition tables unpredictable. This PR defines the behavior, matching PostgreSQL/SQLite:

- **`UPDATE … FROM` → deduplicate to one arbitrary match.** Each target row is updated at most once (first match in arrival order wins; which one is unspecified, as in PG/SQLite). A new `update_from` flag on `Logical`/`PhysicalUpdate` gates row-id dedup in the in-place path (shared `updated_rows` set, factored into `DeduplicateUpdatedRowIds`). Plain `UPDATE … WHERE` keeps its lock-free path.
- **`MERGE` → cardinality error on the second action.** A `WHEN MATCHED` UPDATE/DELETE that would affect the same target row twice raises *"cannot affect the same target row more than once"*. Detection runs on the condition-selected rows, so a `WHEN MATCHED AND …` that filters two matches down to one action does **not** error (matches PostgreSQL). `WHEN NOT MATCHED` / `WHEN NOT MATCHED BY SOURCE` are unaffected.
- **Row count fix.** The reported UPDATE count now reflects rows actually updated (distinct), not the number of join matches — also correcting a pre-existing over-count on the del+insert path.

## Compatibility
Verified SQLite locally (one arbitrary match, no error; no MERGE); PostgreSQL behavior from its docs (same for `UPDATE … FROM`; MERGE raises the cardinality violation). The split here mirrors both.

## Tests
- `test/sql/update/update_from_multi_match.test` — basic, cross-chunk (in-place & forced del+insert), RETURNING, self-join, zero-match, row-count assertions, LIST/del+insert.
- `test/sql/merge/merge_multi_match_error.test` — UPDATE/DELETE cardinality errors, conditional `WHEN MATCHED AND`, insert-only, not-matched-by-source, large unique-match.
- `test/sql/trigger/trigger_update_from_multi_match.test` — predictable OLD/NEW transition tables under multi-match, for both the in-place and **del+insert + OLD-capture** paths.
- Updated `test_update_from.test` and `returning_update.test` from the old undefined behavior to the new defined behavior.
