### PR TITLE
Push down safe ILIKE prefix ranges

### DIFF
--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -19,6 +19,7 @@
 #include "duckdb/planner/table_filter.hpp"
 #include "duckdb/common/operator/add.hpp"
 #include "duckdb/common/operator/subtract.hpp"
+#include "duckdb/common/string_util.hpp"
 #include "duckdb/common/types/interval.hpp"
 #include "duckdb/optimizer/column_lifetime_analyzer.hpp"
 #include "duckdb/planner/expression_iterator.hpp"
@@ -464,7 +465,9 @@ FilterPushdownResult FilterCombiner::TryPushdownLikeFilter(TableFilterSet &table
 		return FilterPushdownResult::NO_PUSHDOWN;
 	}
 	auto &func = expr.Cast<BoundFunctionExpression>();
-	if (func.Function().GetName() != "~~") {
+	auto &function_name = func.Function().GetName();
+	const bool case_insensitive = function_name == "~~*";
+	if (function_name != "~~" && !case_insensitive) {
 		return FilterPushdownResult::NO_PUSHDOWN;
 	}
 	if (func.GetChildren()[0]->GetExpressionClass() != ExpressionClass::BOUND_COLUMN_REF ||
@@ -500,12 +503,42 @@ FilterPushdownResult FilterCombiner::TryPushdownLikeFilter(TableFilterSet &table
 		}
 		prefix += c;
 	}
-	if (equality) {
+	if (equality && !case_insensitive) {
 		//! If the LIKE has no special characters we can turn it into an equality and push that down
 		auto equal_filter =
 		    CreateComparisonExpression(*func.GetChildren()[0], ExpressionType::COMPARE_EQUAL, Value(prefix));
 		table_filters.PushFilter(proj_index, make_uniq<ExpressionFilter>(std::move(equal_filter)));
 		return FilterPushdownResult::PUSHED_DOWN_FULLY;
+	}
+	if (case_insensitive) {
+		// ASCII case variants fall between the uppercase prefix and the successor of the lowercase prefix.
+		string lower_bound_prefix;
+		string upper_bound_prefix;
+		lower_bound_prefix.reserve(prefix.size());
+		upper_bound_prefix.reserve(prefix.size());
+		for (auto c : prefix) {
+			auto ascii_byte = static_cast<uint8_t>(c);
+			if (ascii_byte & 0x80) {
+				return FilterPushdownResult::NO_PUSHDOWN;
+			}
+			auto lower_ascii_byte = StringUtil::ASCII_TO_LOWER_MAP[ascii_byte];
+			// U+0130 and U+212A lowercase to ASCII i and k, so ASCII bounds are not safe for these characters.
+			if (lower_ascii_byte == 'i' || lower_ascii_byte == 'k') {
+				return FilterPushdownResult::NO_PUSHDOWN;
+			}
+			lower_bound_prefix.push_back(UnsafeNumericCast<char>(StringUtil::ASCII_TO_UPPER_MAP[ascii_byte]));
+			upper_bound_prefix.push_back(UnsafeNumericCast<char>(lower_ascii_byte));
+		}
+		if (lower_bound_prefix.empty() || !Utf8Proc::FindNextLegalUTF8(upper_bound_prefix)) {
+			return FilterPushdownResult::NO_PUSHDOWN;
+		}
+		auto lower_bound = CreateComparisonExpression(
+		    *func.GetChildren()[0], ExpressionType::COMPARE_GREATERTHANOREQUALTO, Value(std::move(lower_bound_prefix)));
+		table_filters.PushFilter(proj_index, make_uniq<ExpressionFilter>(std::move(lower_bound)));
+		auto upper_bound = CreateComparisonExpression(*func.GetChildren()[0], ExpressionType::COMPARE_LESSTHAN,
+		                                              Value(std::move(upper_bound_prefix)));
+		table_filters.PushFilter(proj_index, make_uniq<ExpressionFilter>(std::move(upper_bound)));
+		return FilterPushdownResult::PUSHED_DOWN_PARTIALLY;
 	}
 
 	//! We have a prefix - we can push down the prefix using a bound (x >= PREFIX AND x < next_prefix)

--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -459,6 +459,31 @@ FilterPushdownResult FilterCombiner::TryPushdownPrefixFilter(TableFilterSet &tab
 	return FilterPushdownResult::NO_PUSHDOWN;
 }
 
+static bool GetCaseInsensitivePrefixBounds(const string &prefix, string &min_prefix, string &max_prefix) {
+	min_prefix.reserve(prefix.size());
+	max_prefix.reserve(prefix.size());
+	for (auto c : prefix) {
+		auto byte = static_cast<uint8_t>(c);
+		if (byte & 0x80) {
+			return false;
+		}
+		auto lower_byte = StringUtil::ASCII_TO_LOWER_MAP[byte];
+		min_prefix.push_back(UnsafeNumericCast<char>(StringUtil::ASCII_TO_UPPER_MAP[byte]));
+		switch (lower_byte) {
+		case 'i':
+			max_prefix += "\xC4\xB0"; // U+0130 LATIN CAPITAL LETTER I WITH DOT ABOVE
+			break;
+		case 'k':
+			max_prefix += "\xE2\x84\xAA"; // U+212A KELVIN SIGN
+			break;
+		default:
+			max_prefix.push_back(UnsafeNumericCast<char>(lower_byte));
+			break;
+		}
+	}
+	return !min_prefix.empty() && Utf8Proc::FindNextLegalUTF8(max_prefix);
+}
+
 FilterPushdownResult FilterCombiner::TryPushdownLikeFilter(TableFilterSet &table_filters,
                                                            const vector<ColumnIndex> &column_ids, Expression &expr) {
 	if (expr.GetExpressionClass() != ExpressionClass::BOUND_FUNCTION) {
@@ -511,32 +536,16 @@ FilterPushdownResult FilterCombiner::TryPushdownLikeFilter(TableFilterSet &table
 		return FilterPushdownResult::PUSHED_DOWN_FULLY;
 	}
 	if (case_insensitive) {
-		// ASCII case variants fall between the uppercase prefix and the successor of the lowercase prefix.
-		string lower_bound_prefix;
-		string upper_bound_prefix;
-		lower_bound_prefix.reserve(prefix.size());
-		upper_bound_prefix.reserve(prefix.size());
-		for (auto c : prefix) {
-			auto ascii_byte = static_cast<uint8_t>(c);
-			if (ascii_byte & 0x80) {
-				return FilterPushdownResult::NO_PUSHDOWN;
-			}
-			auto lower_ascii_byte = StringUtil::ASCII_TO_LOWER_MAP[ascii_byte];
-			// U+0130 and U+212A lowercase to ASCII i and k, so ASCII bounds are not safe for these characters.
-			if (lower_ascii_byte == 'i' || lower_ascii_byte == 'k') {
-				return FilterPushdownResult::NO_PUSHDOWN;
-			}
-			lower_bound_prefix.push_back(UnsafeNumericCast<char>(StringUtil::ASCII_TO_UPPER_MAP[ascii_byte]));
-			upper_bound_prefix.push_back(UnsafeNumericCast<char>(lower_ascii_byte));
-		}
-		if (lower_bound_prefix.empty() || !Utf8Proc::FindNextLegalUTF8(upper_bound_prefix)) {
+		string min_prefix;
+		string max_prefix;
+		if (!GetCaseInsensitivePrefixBounds(prefix, min_prefix, max_prefix)) {
 			return FilterPushdownResult::NO_PUSHDOWN;
 		}
 		auto lower_bound = CreateComparisonExpression(
-		    *func.GetChildren()[0], ExpressionType::COMPARE_GREATERTHANOREQUALTO, Value(std::move(lower_bound_prefix)));
+		    *func.GetChildren()[0], ExpressionType::COMPARE_GREATERTHANOREQUALTO, Value(std::move(min_prefix)));
 		table_filters.PushFilter(proj_index, make_uniq<ExpressionFilter>(std::move(lower_bound)));
 		auto upper_bound = CreateComparisonExpression(*func.GetChildren()[0], ExpressionType::COMPARE_LESSTHAN,
-		                                              Value(std::move(upper_bound_prefix)));
+		                                              Value(std::move(max_prefix)));
 		table_filters.PushFilter(proj_index, make_uniq<ExpressionFilter>(std::move(upper_bound)));
 		return FilterPushdownResult::PUSHED_DOWN_PARTIALLY;
 	}

--- a/test/sql/copy/parquet/parquet_expression_filter_pruning.test
+++ b/test/sql/copy/parquet/parquet_expression_filter_pruning.test
@@ -291,3 +291,90 @@ FROM '{TEST_DIR}/expr_prune_prefix_utf8_boundary.parquet'
 WHERE prefix(s, chr(255)) OR prefix(s, 'zz')
 ----
 analyzed_plan	<REGEX>:(?s).*Row Groups Scanned: 1 / 2.*
+
+# ILIKE uses conservative ASCII bounds while retaining the original filter
+query I
+SELECT count(*)
+FROM '{TEST_DIR}/expr_prune_prefix_or.parquet'
+WHERE s ILIKE 'P0000%'
+----
+100
+
+query II
+EXPLAIN ANALYZE SELECT count(*)
+FROM '{TEST_DIR}/expr_prune_prefix_or.parquet'
+WHERE s ILIKE 'P0000%'
+----
+analyzed_plan	<REGEX>:(?s).*Row Groups Scanned: 1 / 4.*
+
+query I
+SELECT count(*)
+FROM '{TEST_DIR}/expr_prune_prefix_or.parquet'
+WHERE s ILIKE 'P000000'
+----
+1
+
+query II
+EXPLAIN ANALYZE SELECT count(*)
+FROM '{TEST_DIR}/expr_prune_prefix_or.parquet'
+WHERE s ILIKE 'P000000'
+----
+analyzed_plan	<REGEX>:(?s).*Row Groups Scanned: 1 / 4.*
+
+# ASCII bounds retain both case variants and the ILIKE filter removes false positives
+statement ok
+COPY (
+	SELECT CASE
+		WHEN range < 2048 THEN 'P0000' || lpad(range::VARCHAR, 4, '0')
+		WHEN range < 4096 THEN 'p0000' || lpad((range - 2048)::VARCHAR, 4, '0')
+		WHEN range < 6144 THEN 'Q0000' || lpad((range - 4096)::VARCHAR, 4, '0')
+		ELSE 'z0000' || lpad((range - 6144)::VARCHAR, 4, '0')
+	END AS s
+	FROM range(8192)
+) TO '{TEST_DIR}/expr_prune_ilike_case.parquet' (FORMAT PARQUET, ROW_GROUP_SIZE 2048)
+
+query I
+SELECT count(*)
+FROM '{TEST_DIR}/expr_prune_ilike_case.parquet'
+WHERE s ILIKE 'p0000%'
+----
+4096
+
+query II
+EXPLAIN ANALYZE SELECT count(*)
+FROM '{TEST_DIR}/expr_prune_ilike_case.parquet'
+WHERE s ILIKE 'p0000%'
+----
+analyzed_plan	<REGEX>:(?s).*Row Groups Scanned: 3 / 4.*
+
+# Unicode characters that lowercase to ASCII must not be excluded by ASCII bounds
+statement ok
+COPY (
+	SELECT CASE
+		WHEN range < 2048 THEN 'İ' || lpad(range::VARCHAR, 4, '0')
+		WHEN range < 4096 THEN 'K' || lpad((range - 2048)::VARCHAR, 4, '0')
+		ELSE 'z' || lpad((range - 4096)::VARCHAR, 4, '0')
+	END AS s
+	FROM range(6144)
+) TO '{TEST_DIR}/expr_prune_ilike_unicode.parquet' (FORMAT PARQUET, ROW_GROUP_SIZE 2048)
+
+query I
+SELECT count(*)
+FROM '{TEST_DIR}/expr_prune_ilike_unicode.parquet'
+WHERE s ILIKE 'i%'
+----
+2048
+
+query I
+SELECT count(*)
+FROM '{TEST_DIR}/expr_prune_ilike_unicode.parquet'
+WHERE s ILIKE 'k%'
+----
+2048
+
+query I
+SELECT count(*)
+FROM '{TEST_DIR}/expr_prune_ilike_unicode.parquet'
+WHERE s ILIKE 'İ%'
+----
+2048

--- a/test/sql/copy/parquet/parquet_expression_filter_pruning.test
+++ b/test/sql/copy/parquet/parquet_expression_filter_pruning.test
@@ -347,34 +347,57 @@ WHERE s ILIKE 'p0000%'
 ----
 analyzed_plan	<REGEX>:(?s).*Row Groups Scanned: 3 / 4.*
 
-# Unicode characters that lowercase to ASCII must not be excluded by ASCII bounds
+# ILIKE bounds include Unicode characters that lowercase to ASCII
 statement ok
 COPY (
 	SELECT CASE
-		WHEN range < 2048 THEN 'İ' || lpad(range::VARCHAR, 4, '0')
-		WHEN range < 4096 THEN 'K' || lpad((range - 2048)::VARCHAR, 4, '0')
-		ELSE 'z' || lpad((range - 4096)::VARCHAR, 4, '0')
+		WHEN range < 2048 THEN 'A' || lpad(range::VARCHAR, 4, '0')
+		WHEN range < 4096 THEN 'İ' || lpad((range - 2048)::VARCHAR, 4, '0')
+		WHEN range < 6144 THEN 'K' || lpad((range - 4096)::VARCHAR, 4, '0')
+		WHEN range < 8192 THEN 'z' || lpad((range - 6144)::VARCHAR, 4, '0')
+		ELSE 'Å' || lpad((range - 8192)::VARCHAR, 4, '0')
 	END AS s
-	FROM range(6144)
-) TO '{TEST_DIR}/expr_prune_ilike_unicode.parquet' (FORMAT PARQUET, ROW_GROUP_SIZE 2048)
+	FROM range(10240)
+) TO '{TEST_DIR}/expr_prune_ilike_unicode_bounds.parquet' (FORMAT PARQUET, ROW_GROUP_SIZE 2048)
 
 query I
 SELECT count(*)
-FROM '{TEST_DIR}/expr_prune_ilike_unicode.parquet'
+FROM '{TEST_DIR}/expr_prune_ilike_unicode_bounds.parquet'
 WHERE s ILIKE 'i%'
 ----
 2048
 
+query II
+EXPLAIN ANALYZE SELECT count(*)
+FROM '{TEST_DIR}/expr_prune_ilike_unicode_bounds.parquet'
+WHERE s ILIKE 'i%'
+----
+analyzed_plan	<REGEX>:(?s).*Row Groups Scanned: 2 / 5.*
+
 query I
 SELECT count(*)
-FROM '{TEST_DIR}/expr_prune_ilike_unicode.parquet'
+FROM '{TEST_DIR}/expr_prune_ilike_unicode_bounds.parquet'
 WHERE s ILIKE 'k%'
 ----
 2048
 
+query II
+EXPLAIN ANALYZE SELECT count(*)
+FROM '{TEST_DIR}/expr_prune_ilike_unicode_bounds.parquet'
+WHERE s ILIKE 'k%'
+----
+analyzed_plan	<REGEX>:(?s).*Row Groups Scanned: 3 / 5.*
+
 query I
 SELECT count(*)
-FROM '{TEST_DIR}/expr_prune_ilike_unicode.parquet'
+FROM '{TEST_DIR}/expr_prune_ilike_unicode_bounds.parquet'
 WHERE s ILIKE 'İ%'
 ----
 2048
+
+query II
+EXPLAIN ANALYZE SELECT count(*)
+FROM '{TEST_DIR}/expr_prune_ilike_unicode_bounds.parquet'
+WHERE s ILIKE 'İ%'
+----
+analyzed_plan	<REGEX>:(?s).*Row Groups Scanned: 5 / 5.*


### PR DESCRIPTION
## Summary

Resolves #23743 

Case-insensitive `ILIKE` filters were not converted into ranges, preventing Parquet row-group pruning. This PR uses the uppercase prefix as the inclusive lower bound and the successor of the lowercase prefix as the exclusive upper bound for `ILIKE` filters. Prefixes containing non-ASCII characters or `i`/`k` are skipped because Unicode case folding can map `İ`/`K` to those ASCII characters.

## Results

```sql
COPY (
    SELECT i::INTEGER AS x,
           'p' || lpad(i::VARCHAR, 6, '0') AS s
    FROM range(8192) r(i)
) TO '/tmp/collate_prune.parquet'
  (FORMAT parquet, ROW_GROUP_SIZE 2048);

EXPLAIN ANALYZE
SELECT sum(x)
FROM '/tmp/collate_prune.parquet'
WHERE s ILIKE 'P0000%';
```

### Before

```text
╭─ Table Scan ────────────────────────────╮
│ Function: PARQUET_SCAN                  │
│ Projections: x                          │
│ Filters: s ~~* 'P0000%'                 │
│ Total Files Read: 1                     │
│ Filename(s): /tmp/collate_prune.parquet │
│ Row Groups Scanned: 4 / 4               │
│ 100 rows                            0µs │
╰─────────────────────────────────────────╯
```

### After

```text
╭─ Filter ────────────────────────────────╮
│ Expression: s ~~* 'P0000%'              │
│ 100 rows                            0µs │
╰────────────────────┒┎───────────────────╯
╭─ Table Scan ───────┚┖───────────────────╮
│ Function: PARQUET_SCAN                  │
│ Projections: s, x                       │
│ Filters:                                │
│ (s >= 'P0000') AND (s < 'p0001')        │
│ Total Files Read: 1                     │
│ Filename(s): /tmp/collate_prune.parquet │
│ Row Groups Scanned: 1 / 4               │
│ 100 rows                            0µs │
╰─────────────────────────────────────────╯
```


