### PR TITLE
Auto-rollback failed implicitly-wrapped multi-statements on all paths

### DIFF
--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -276,7 +276,11 @@ ErrorData ClientContext::EndQueryInternal(ClientContextLock &lock, bool success,
 				}
 			} else if (invalidate_transaction) {
 				D_ASSERT(!success);
-				ValidChecker::Invalidate(ActiveTransaction(), "Failed to commit");
+				if (transaction.GetAutoRollback()) {
+					transaction.Rollback(previous_error);
+				} else {
+					ValidChecker::Invalidate(ActiveTransaction(), "Failed to commit");
+				}
 			}
 		}
 	} catch (std::exception &ex) {

--- a/test/api/test_pending_query.cpp
+++ b/test/api/test_pending_query.cpp
@@ -244,3 +244,35 @@ TEST_CASE("Test Pending Query Prepared Statements API", "[api][.]") {
 		REQUIRE_THROWS(pending_query->Execute());
 	}
 }
+
+TEST_CASE("Auto-rollback of a failed implicitly-wrapped multi-statement via the pending API", "[api]") {
+	// The preprocessor implicitly wraps some statements in a BEGIN/COMMIT, and a failure inside one
+	// must auto-rollback so the connection stays usable without a manual ROLLBACK. This has to hold
+	// on the pending API path too (used by client drivers), which previously skipped auto-rollback.
+	// The CTAS here is load-bearing: a bare PIVOT ends in a SELECT and is not wrapped.
+	DuckDB db;
+	Connection con(db);
+	const char *pivot = "CREATE TEMP TABLE t AS PIVOT (SELECT 'x' AS k, 1 AS v) ON k USING first(does_not_exist)";
+
+	// Parse + expand, then drive each statement through the pending API (no auto-rollback net).
+	auto statements = con.context->ParseStatements(string(pivot));
+	REQUIRE(statements.size() > 1);
+	bool saw_error = false;
+	for (auto &stmt : statements) {
+		auto pending = con.context->PendingQuery(std::move(stmt), false);
+		if (pending->HasError()) {
+			saw_error = true;
+			break;
+		}
+		auto res = pending->Execute();
+		if (res->HasError()) {
+			saw_error = true;
+			break;
+		}
+	}
+	REQUIRE(saw_error);
+
+	// The connection must be usable again WITHOUT a manual ROLLBACK.
+	auto result = con.Query("SELECT 42");
+	REQUIRE(CHECK_COLUMN(result, 0, {42}));
+}


### PR DESCRIPTION
The StatementPreprocessor wraps multi-statement bodies (e.g. a PIVOT inside a CTAS) in an implicit BEGIN/COMMIT with auto_rollback set, so a failure rolls the whole thing back and leaves the connection usable. That was only honored in ClientContext::Query(); statements executed via the pending API (as client drivers such as the Python and Node bindings do) skipped it, leaving the connection stuck in an aborted transaction until a manual ROLLBACK or reconnect.

Honor auto_rollback in EndQueryInternal, the shared cleanup path all execution routes funnel through, so Query, prepared Execute, and a directly-driven PendingQuery all recover.