### PR TITLE
Plumbing for HTTP response content encoding

### DIFF
--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -4812,6 +4812,25 @@ RequestType EnumUtil::FromString<RequestType>(const char *value) {
 	return static_cast<RequestType>(StringUtil::StringToEnum(GetRequestTypeValues(), 6, "RequestType", value));
 }
 
+const StringUtil::EnumStringLiteral *GetResponseContentEncodingModeValues() {
+	static constexpr StringUtil::EnumStringLiteral values[] {
+		{ static_cast<uint32_t>(ResponseContentEncodingMode::IDENTITY_DECODE_FALLBACK), "IDENTITY_DECODE_FALLBACK" },
+		{ static_cast<uint32_t>(ResponseContentEncodingMode::IDENTITY_NO_DECODE), "IDENTITY_NO_DECODE" },
+		{ static_cast<uint32_t>(ResponseContentEncodingMode::NEGOTIATE), "NEGOTIATE" }
+	};
+	return values;
+}
+
+template<>
+const char* EnumUtil::ToChars<ResponseContentEncodingMode>(ResponseContentEncodingMode value) {
+	return StringUtil::EnumToString(GetResponseContentEncodingModeValues(), 3, "ResponseContentEncodingMode", static_cast<uint32_t>(value));
+}
+
+template<>
+ResponseContentEncodingMode EnumUtil::FromString<ResponseContentEncodingMode>(const char *value) {
+	return static_cast<ResponseContentEncodingMode>(StringUtil::StringToEnum(GetResponseContentEncodingModeValues(), 3, "ResponseContentEncodingMode", value));
+}
+
 const StringUtil::EnumStringLiteral *GetResultModifierTypeValues() {
 	static constexpr StringUtil::EnumStringLiteral values[] {
 		{ static_cast<uint32_t>(ResultModifierType::LIMIT_MODIFIER), "LIMIT_MODIFIER" },

--- a/src/common/virtual_file_system.cpp
+++ b/src/common/virtual_file_system.cpp
@@ -151,6 +151,10 @@ unique_ptr<FileHandle> VirtualFileSystem::OpenFileExtended(const OpenFileInfo &f
 			compression = FileCompressionType::UNCOMPRESSED;
 		}
 	}
+	if (compression != FileCompressionType::UNCOMPRESSED) {
+		// a CompressedFileSystem wrapper is applied to the returned handle below
+		flags |= FileOpenFlags(FileOpenFlags::FILE_FLAGS_COMPRESSION_WRAPPER_UPSTREAM);
+	}
 
 	// open the base file handle in UNCOMPRESSED mode
 	flags.SetCompression(FileCompressionType::UNCOMPRESSED);

--- a/src/include/duckdb/common/enum_util.hpp
+++ b/src/include/duckdb/common/enum_util.hpp
@@ -436,6 +436,8 @@ enum class RenderMode : uint8_t;
 
 enum class RequestType : uint8_t;
 
+enum class ResponseContentEncodingMode : uint8_t;
+
 enum class ResultModifierType : uint8_t;
 
 enum class RowGroupAppendMode : uint8_t;
@@ -1190,6 +1192,9 @@ const char* EnumUtil::ToChars<RenderMode>(RenderMode value);
 
 template<>
 const char* EnumUtil::ToChars<RequestType>(RequestType value);
+
+template<>
+const char* EnumUtil::ToChars<ResponseContentEncodingMode>(ResponseContentEncodingMode value);
 
 template<>
 const char* EnumUtil::ToChars<ResultModifierType>(ResultModifierType value);
@@ -2019,6 +2024,9 @@ RenderMode EnumUtil::FromString<RenderMode>(const char *value);
 
 template<>
 RequestType EnumUtil::FromString<RequestType>(const char *value);
+
+template<>
+ResponseContentEncodingMode EnumUtil::FromString<ResponseContentEncodingMode>(const char *value);
 
 template<>
 ResultModifierType EnumUtil::FromString<ResultModifierType>(const char *value);

--- a/src/include/duckdb/common/file_open_flags.hpp
+++ b/src/include/duckdb/common/file_open_flags.hpp
@@ -32,6 +32,7 @@ public:
 	static constexpr idx_t FILE_FLAGS_MULTI_CLIENT_ACCESS = idx_t(1 << 11);
 	static constexpr idx_t FILE_FLAGS_DISABLE_LOGGING = idx_t(1 << 12);
 	static constexpr idx_t FILE_FLAGS_ENABLE_EXTENSION_INSTALL = idx_t(1 << 13);
+	static constexpr idx_t FILE_FLAGS_COMPRESSION_WRAPPER_UPSTREAM = idx_t(1 << 14);
 
 public:
 	FileOpenFlags() = default;
@@ -131,6 +132,9 @@ public:
 	}
 	inline bool EnableExtensionInstall() const {
 		return flags & FILE_FLAGS_ENABLE_EXTENSION_INSTALL;
+	}
+	inline bool HasUpstreamCompressionWrapper() const {
+		return flags & FILE_FLAGS_COMPRESSION_WRAPPER_UPSTREAM;
 	}
 	inline idx_t GetFlagsInternal() const {
 		return flags;

--- a/src/include/duckdb/common/http_util.hpp
+++ b/src/include/duckdb/common/http_util.hpp
@@ -140,6 +140,16 @@ public:
 	bool ShouldRetry() const;
 };
 
+//! How a HTTPClient advertises (Accept-Encoding) and handles the response Content-Encoding
+enum class ResponseContentEncodingMode : uint8_t {
+	//! Advertise identity, if the server responds with an encoded body anyway, deliver it decoded (or error)
+	IDENTITY_DECODE_FALLBACK,
+	//! Advertise identity, never decode (response bytes are passed through untouched)
+	IDENTITY_NO_DECODE,
+	//! Advertise what the client can decode, deliver the body decoded
+	NEGOTIATE
+};
+
 struct BaseRequest {
 	BaseRequest(RequestType type, const string &url, const HTTPHeaders &headers, HTTPParams &params);
 	// Out-of-line so the symbol is emitted/exported for loadable (WASM side-module) extensions.
@@ -170,6 +180,9 @@ struct BaseRequest {
 	bool have_time_to_fst_byte = false;
 	double time_to_fst_byte_sec = 0;
 	idx_t bytes_received = 0;
+
+	//! How to advertise and handle response content encoding.
+	ResponseContentEncodingMode response_content_encoding = ResponseContentEncodingMode::IDENTITY_DECODE_FALLBACK;
 
 	template <class TARGET>
 	TARGET &Cast() {

--- a/src/main/http/http_util.cpp
+++ b/src/main/http/http_util.cpp
@@ -183,13 +183,20 @@ public:
 	}
 	unique_ptr<HTTPResponse> Get(GetRequestInfo &info) override {
 		auto headers = TransformHeaders(info.headers, info.params);
+		// this client cannot decode encoded responses: always request identity
+		if (headers.find("Accept-Encoding") == headers.end()) {
+			headers.emplace("Accept-Encoding", "identity");
+		}
 		if (!info.response_handler && !info.content_handler) {
-			return TransformResult(client->Get(info.path, headers));
+			auto result = TransformResult(client->Get(info.path, headers));
+			WarnIfEncoded(info, *result);
+			return result;
 		} else {
 			return TransformResult(client->Get(
 			    info.path, headers,
 			    [&](const duckdb_httplib::Response &response) {
 				    auto http_response = TransformResponse(response);
+				    WarnIfEncoded(info, *http_response);
 				    return info.response_handler(*http_response);
 			    },
 			    [&](const char *data, size_t data_length) {
@@ -220,6 +227,26 @@ public:
 	unique_ptr<duckdb_httplib::Client> client;
 
 private:
+	void WarnIfEncoded(const GetRequestInfo &info, const HTTPResponse &response) {
+		if (info.response_content_encoding == ResponseContentEncodingMode::IDENTITY_NO_DECODE) {
+			return;
+		}
+		if (!info.params.logger || !response.HasHeader("Content-Encoding")) {
+			return;
+		}
+		const auto encoding = StringUtil::Lower(response.GetHeaderValue("Content-Encoding"));
+		if (encoding.empty() || encoding == "identity") {
+			return;
+		}
+		auto &logger = *info.params.logger;
+		if (logger.ShouldLog(DefaultLogType::NAME, LogLevel::LOG_WARNING)) {
+			logger.WriteLog(
+			    DefaultLogType::NAME, LogLevel::LOG_WARNING,
+			    "HTTP GET to '%s' returned Content-Encoding \"%s\" despite requesting an identity transfer.", info.url,
+			    encoding);
+		}
+	}
+
 	duckdb_httplib::Headers TransformHeaders(const HTTPHeaders &header_map, const HTTPParams &params) {
 		duckdb_httplib::Headers headers;
 		for (auto &entry : header_map) {

--- a/test/common/test_caching_file_system_wrapper.cpp
+++ b/test/common/test_caching_file_system_wrapper.cpp
@@ -156,6 +156,37 @@ public:
 	}
 };
 
+class OpenFlagsRecordingFileSystem : public LocalFileSystem {
+public:
+	mutable annotated_mutex mu;
+	vector<FileOpenFlags> open_flags DUCKDB_GUARDED_BY(mu);
+
+	string GetName() const override {
+		return "OpenFlagsRecordingFileSystem";
+	}
+
+	unique_ptr<FileHandle> OpenFile(const string &path, FileOpenFlags flags,
+	                                optional_ptr<FileOpener> opener = nullptr) override {
+		const annotated_lock_guard<annotated_mutex> lock(mu);
+		open_flags.push_back(flags);
+		return LocalFileSystem::OpenFile(path, flags, opener);
+	}
+
+	FileOpenFlags GetLastOpenFlags() const {
+		const annotated_lock_guard<annotated_mutex> lock(mu);
+		D_ASSERT(!open_flags.empty());
+		return open_flags.back();
+	}
+
+	bool CanHandleFile(const string &path) override {
+		return StringUtil::StartsWith(path, TestDirectoryPath());
+	}
+
+	bool CanSeek() override {
+		return true;
+	}
+};
+
 //===----------------------------------------------------------------------===//
 // CachingFileSystemWrapper Tests
 //===----------------------------------------------------------------------===//
@@ -558,6 +589,30 @@ TEST_CASE("Request over-sized range read", "[file_system][caching]") {
 	const idx_t actual_read = handle->Read(QueryContext(), &buffer[0], test_content.length() + 1);
 	REQUIRE(actual_read == test_content.length());
 	REQUIRE(buffer.substr(0, test_content.length()) == test_content);
+}
+
+TEST_CASE("CachingFileSystemWrapper preserves upstream compression wrapper flag", "[file_system][caching]") {
+	DuckDB db = MakeCacheLocalFilesDB();
+	auto &db_instance = *db.instance;
+	auto recording_fs = make_uniq<OpenFlagsRecordingFileSystem>();
+	auto *recording_fs_ptr = recording_fs.get();
+	auto caching_wrapper =
+	    make_shared_ptr<CachingFileSystemWrapper>(*recording_fs, db_instance, CachingMode::ALWAYS_CACHE);
+
+	const string test_content = "File used for caching flag propagation testing";
+	TestFileGuard test_file("test_caching_flags.txt", test_content);
+
+	FileOpenFlags flags {FileFlags::FILE_FLAGS_READ};
+	flags |= FileOpenFlags(FileOpenFlags::FILE_FLAGS_COMPRESSION_WRAPPER_UPSTREAM);
+
+	auto handle = caching_wrapper->OpenFile(test_file.GetPath(), flags);
+	string buffer(TEST_BUFFER_SIZE, '\0');
+	handle->Read(QueryContext(), &buffer[0], test_content.length(), /*location=*/0);
+	REQUIRE(buffer.substr(0, test_content.length()) == test_content);
+
+	auto observed_flags = recording_fs_ptr->GetLastOpenFlags();
+	REQUIRE(observed_flags.HasUpstreamCompressionWrapper());
+	REQUIRE(observed_flags.RequireParallelAccess());
 }
 
 TEST_CASE("CachingFileSystemWrapper concurrent reads same block", "[file_system][caching]") {

--- a/test/common/test_file_system.cpp
+++ b/test/common/test_file_system.cpp
@@ -41,6 +41,29 @@ static void create_dummy_file(string fname) {
 	outfile.close();
 }
 
+class OpenFlagsRecordingFileSystem : public LocalFileSystem {
+public:
+	vector<FileOpenFlags> open_flags;
+
+	string GetName() const override {
+		return "OpenFlagsRecordingFileSystem";
+	}
+
+	unique_ptr<FileHandle> OpenFile(const string &path, FileOpenFlags flags,
+	                                optional_ptr<FileOpener> opener = nullptr) override {
+		open_flags.push_back(flags);
+		return LocalFileSystem::OpenFile(path, flags, opener);
+	}
+
+	bool CanHandleFile(const string &path) override {
+		return StringUtil::StartsWith(path, TestDirectoryPath());
+	}
+
+	bool CanSeek() override {
+		return true;
+	}
+};
+
 TEST_CASE("Make sure the file:// protocol works as expected", "[file_system]") {
 	duckdb::unique_ptr<FileSystem> fs = FileSystem::CreateLocal();
 	auto dname = fs->JoinPath(fs->GetWorkingDirectory(), TestCreatePath("TEST_DIR"));
@@ -274,6 +297,43 @@ TEST_CASE("re-register subsystem", "[file_system]") {
 	// Re-register an already registered subfilesystem should throw.
 	auto second_local_filesystem = FileSystem::CreateLocal();
 	REQUIRE_THROWS(vfs.RegisterSubSystem(std::move(second_local_filesystem)));
+}
+
+TEST_CASE("VirtualFileSystem marks upstream compression wrapper", "[file_system]") {
+	duckdb::VirtualFileSystem vfs;
+	auto recording_filesystem = make_uniq<OpenFlagsRecordingFileSystem>();
+	auto *recording_filesystem_ptr = recording_filesystem.get();
+	vfs.RegisterSubSystem(std::move(recording_filesystem));
+
+	auto local_filesystem = FileSystem::CreateLocal();
+	auto run_case = [&](const string &filename, FileCompressionType compression, bool expect_wrapper) {
+		const auto path = TestCreatePath(filename);
+		if (local_filesystem->FileExists(path)) {
+			local_filesystem->RemoveFile(path);
+		}
+
+		FileOpenFlags flags(FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE);
+		flags.SetCompression(compression);
+
+		const auto open_count = recording_filesystem_ptr->open_flags.size();
+		auto handle = vfs.OpenFile(path, flags);
+		REQUIRE(handle);
+		REQUIRE(recording_filesystem_ptr->open_flags.size() == open_count + 1);
+
+		auto observed_flags = recording_filesystem_ptr->open_flags.back();
+		REQUIRE(observed_flags.Compression() == FileCompressionType::UNCOMPRESSED);
+		REQUIRE(observed_flags.HasUpstreamCompressionWrapper() == expect_wrapper);
+
+		handle.reset();
+		if (local_filesystem->FileExists(path)) {
+			local_filesystem->RemoveFile(path);
+		}
+	};
+
+	run_case("vfs_explicit_gzip", FileCompressionType::GZIP, true);
+	run_case("vfs_auto_detect_gzip.gz", FileCompressionType::AUTO_DETECT, true);
+	run_case("vfs_auto_detect_uncompressed.csv", FileCompressionType::AUTO_DETECT, false);
+	run_case("vfs_explicit_uncompressed.gz", FileCompressionType::UNCOMPRESSED, false);
 }
 
 struct CanonicalizationTest {


### PR DESCRIPTION
Core plumbing for handling `Content-Encoding` on HTTP responses. 

## Motivation

Currently (most of the time) no `Accept-Encoding` header is announced and the `Content-Encoding` header is silently ignored when returned by the server. An absent `Accept-Encoding` header means any content coding is [acceptable](https://www.rfc-editor.org/rfc/rfc9110.html#section-12.5.3-10.1), so we implicitly accept encodings we have no way to handle. Most (likely all) servers will serve uncompressed data anyway, but being explicit with `Accept-Encoding: identity` removes that. Making this configurable per request would also let extensions (and core) opt-in to content encoding, which could lower bandwidth usage in the future.

Secondly, in order to ensure decompression of data doesn't happen twice, once in DuckDB and once in the http layer (httpfs), we must trickle down the presence of a compressor wrapped around the filesystem. This is mainly to avoid problems with S3, as S3 will always respond with exactly the bytes that were originally uploaded. More specifically, when data is uploaded to S3 with a `Content-Encoding: gzip` header present, S3 will still respond with the compressed data and `Content-Encoding: gzip` while the client states `Accept-Encoding: identity`.

The current way in DuckDB to deal with data in S3, uploaded with `Content-Encoding: gzip`, is to append a `.gz` file extension or to set the compression type explicitly (`read_json('....json', compression = 'gzip')`). If we trickle down the presence of a compression wrapper, we can still support this data by disabling the decoding in `httpfs`. 
HTTP spec wise, `.gz` and `Content-Encoding: gzip` would mean it is encoded [twice](https://www.rfc-editor.org/rfc/rfc9110.html#name-content-encoding:~:text=Such%20a%20content%20coding%20would%20only%20be%20listed%20if%2C%20for%20some%20bizarre%20reason%2C%20it%20is%20applied%20a%20second%20time%20to%20form%20the%20representation). A traditional web server would never respond with this combination, but S3 simply returns whatever was uploaded.
It is my opinion that we should assume data is only compressed once, this assumption is what keeps files that were uploaded with a `.gz` file extension and `Content-Encoding: gzip` readable. Since S3 does no content encoding on its own, a user would have to actively upload doubly compressed data to end up in an unsupported state.

## Changes

Adds an option to `BaseRequest` to specify the `ResponseContentEncodingMode`:
- `IDENTITY_DECODE_FALLBACK` (default, requests identity, decodes if it receives another `CE` back)
- `IDENTITY_NO_DECODE` (request identity and pass whatever it receives through)
- `NEGOTIATE` (announce supported encodings and hand decoded bytes back). 

This is on an individual request basis.

The built-in httplib client now sends `Accept-Encoding: identity` on every GET unless the caller already set the header, and logs a warning when a response still carries a `Content-Encoding`. Previously httplib itself sent an empty `Accept-Encoding` on buffered GETs, which means the same thing per the spec, and no header at all on streaming GETs.

For passing down the presence of a compression wrapper, a bit is added to `FileOpenFlags` which is set by `VirtualFileSystem` when it resolved a compression type.

Closes duckdblabs/duckdb-internal#9991