### PR TITLE
TopNWindowElimination Fixes

### DIFF
--- a/src/include/duckdb/function/aggregate/minmax_n_helpers.hpp
+++ b/src/include/duckdb/function/aggregate/minmax_n_helpers.hpp
@@ -3,6 +3,7 @@
 #include "duckdb/common/common.hpp"
 #include "duckdb/storage/arena_allocator.hpp"
 #include "duckdb/common/algorithm.hpp"
+#include "duckdb/common/operator/comparison_operators.hpp"
 #include "duckdb/common/pair.hpp"
 #include "duckdb/common/types/string_type.hpp"
 #include "duckdb/common/types/vector.hpp"
@@ -379,7 +380,7 @@ struct ValueOrNull {
 
 	bool operator>(const ValueOrNull &other) const {
 		if (is_valid && other.is_valid) {
-			return value > other.value;
+			return GreaterThan::Operation(value, other.value);
 		}
 		if (!is_valid && !other.is_valid) {
 			return false;

--- a/src/include/duckdb/optimizer/topn_window_elimination.hpp
+++ b/src/include/duckdb/optimizer/topn_window_elimination.hpp
@@ -28,6 +28,8 @@ struct TopNWindowEliminationParameters {
 	bool include_row_number;
 	//! Whether the val or arg column contains null values
 	bool can_be_null = false;
+	//! The number of semantic window partitions
+	idx_t partition_count = 0;
 };
 
 class TopNWindowElimination : public BaseColumnPruner {
@@ -61,7 +63,8 @@ private:
 	unique_ptr<LogicalOperator>
 	UpdateTopmostBindings(idx_t window_idx, unique_ptr<LogicalOperator> op, const vector<LogicalType> &types,
 	                      const map<idx_t, idx_t> &group_idxs, const vector<ColumnBinding> &topmost_bindings,
-	                      vector<ColumnBinding> &new_bindings, ColumnBindingReplacer &replacer);
+	                      vector<ColumnBinding> &new_bindings, ColumnBindingReplacer &replacer,
+	                      const TopNWindowEliminationParameters &params);
 	TopNWindowEliminationParameters ExtractOptimizerParameters(const LogicalWindow &window, const LogicalFilter &filter,
 	                                                           const vector<ColumnBinding> &bindings,
 	                                                           vector<unique_ptr<Expression>> &aggregate_payload);

--- a/src/optimizer/topn_window_elimination.cpp
+++ b/src/optimizer/topn_window_elimination.cpp
@@ -151,21 +151,39 @@ idx_t TraverseAndFindAggregateOffset(const unique_ptr<LogicalOperator> &op) {
 	return aggregate.groups.size();
 }
 
-string GetLHSRowIdColumnName(const unique_ptr<LogicalOperator> &op, idx_t column_id) {
+struct LHSColumnInfo {
+	string name;
+	LogicalType type;
+	ColumnBinding binding;
+};
+
+LHSColumnInfo GetLHSColumnInfo(const unique_ptr<LogicalOperator> &op, idx_t column_id) {
+	D_ASSERT(column_id < op->types.size());
+	const auto bindings = op->GetColumnBindings();
+	D_ASSERT(column_id < bindings.size());
+
+	LHSColumnInfo result;
+	result.type = op->types[column_id];
+	result.binding = bindings[column_id];
+
 	reference<LogicalOperator> current_op = *op;
+	auto get_binding = result.binding;
 
 	if (op.get()->type != LogicalOperatorType::LOGICAL_GET) {
 		D_ASSERT(op.get()->type == LogicalOperatorType::LOGICAL_PROJECTION);
 		D_ASSERT(op.get()->expressions.size() > column_id &&
 		         op.get()->expressions[column_id]->type == ExpressionType::BOUND_COLUMN_REF);
 		const auto &colref = op.get()->expressions[column_id]->Cast<BoundColumnRefExpression>();
-		column_id = colref.binding.column_index;
+		get_binding = colref.binding;
 		current_op = *op.get()->children[0];
 	}
 
 	const auto &logical_get = current_op.get().Cast<LogicalGet>();
-	const auto column_index = logical_get.GetColumnIds()[column_id];
-	return logical_get.GetColumnName(column_index);
+	D_ASSERT(get_binding.table_index == logical_get.table_index);
+	D_ASSERT(get_binding.column_index < logical_get.GetColumnIds().size());
+	const auto column_index = logical_get.GetColumnIds()[get_binding.column_index];
+	result.name = logical_get.GetColumnName(column_index);
+	return result;
 }
 
 } // namespace
@@ -1199,13 +1217,12 @@ unique_ptr<LogicalOperator> TopNWindowElimination::ConstructJoin(unique_ptr<Logi
 	for (idx_t i = 0; i < rowid_column_count; i++) {
 		const idx_t lhs_rowid_idx = lhs->types.size() - (rowid_column_count - i);
 		const idx_t rhs_rowid_idx = rhs_binding_offset + i;
-		const auto &alias = GetLHSRowIdColumnName(lhs, lhs_rowid_idx);
+		const auto lhs_column = GetLHSColumnInfo(lhs, lhs_rowid_idx);
 
 		JoinCondition condition;
 		condition.comparison = ExpressionType::COMPARE_EQUAL;
-		condition.left = make_uniq<BoundColumnRefExpression>(alias, lhs->types[lhs_rowid_idx],
-		                                                     ColumnBinding {lhs->GetTableIndex()[0], lhs_rowid_idx});
-		condition.right = make_uniq<BoundColumnRefExpression>(alias, rhs->types[aggregate_offset + i],
+		condition.left = make_uniq<BoundColumnRefExpression>(lhs_column.name, lhs_column.type, lhs_column.binding);
+		condition.right = make_uniq<BoundColumnRefExpression>(lhs_column.name, rhs->types[aggregate_offset + i],
 		                                                      ColumnBinding {GetAggregateIdx(rhs), rhs_rowid_idx});
 		join->conditions.push_back(std::move(condition));
 	}

--- a/src/optimizer/topn_window_elimination.cpp
+++ b/src/optimizer/topn_window_elimination.cpp
@@ -351,6 +351,10 @@ TopNWindowElimination::CreateAggregateOperator(LogicalWindow &window, vector<uni
 	                                             optimizer.binder.GenerateTableIndex(), std::move(select_list));
 	aggregate->groupings_index = optimizer.binder.GenerateTableIndex();
 	aggregate->groups = std::move(window_expr.partitions);
+	if (aggregate->groups.empty() && params.limit == 1) {
+		// A constant group preserves the window's empty-input behavior.
+		aggregate->groups.push_back(make_uniq<BoundConstantExpression>(Value::BOOLEAN(true)));
+	}
 	aggregate->children.push_back(std::move(window.children[0]));
 	aggregate->ResolveOperatorTypes();
 

--- a/src/optimizer/topn_window_elimination.cpp
+++ b/src/optimizer/topn_window_elimination.cpp
@@ -141,16 +141,6 @@ ColumnBinding GetRowNumberColumnBinding(const unique_ptr<LogicalOperator> &op) {
 	}
 }
 
-idx_t TraverseAndFindAggregateOffset(const unique_ptr<LogicalOperator> &op) {
-	reference<LogicalOperator> current_op = *op;
-	while (current_op.get().type != LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY) {
-		D_ASSERT(!current_op.get().children.empty());
-		current_op = *current_op.get().children[0];
-	}
-	const auto &aggregate = current_op.get().Cast<LogicalAggregate>();
-	return aggregate.groups.size();
-}
-
 struct LHSColumnInfo {
 	string name;
 	LogicalType type;
@@ -278,7 +268,7 @@ unique_ptr<LogicalOperator> TopNWindowElimination::OptimizeInternal(unique_ptr<L
 	}
 
 	op = UpdateTopmostBindings(window_idx, std::move(op), topmost_types, group_projection_idxs, topmost_bindings,
-	                           new_bindings, replacer);
+	                           new_bindings, replacer, params);
 
 	replacer.stop_operator = op.get();
 
@@ -763,7 +753,8 @@ unique_ptr<LogicalOperator>
 TopNWindowElimination::UpdateTopmostBindings(idx_t window_idx, unique_ptr<LogicalOperator> op,
                                              const vector<LogicalType> &types, const map<idx_t, idx_t> &group_idxs,
                                              const vector<ColumnBinding> &topmost_bindings,
-                                             vector<ColumnBinding> &new_bindings, ColumnBindingReplacer &replacer) {
+                                             vector<ColumnBinding> &new_bindings, ColumnBindingReplacer &replacer,
+                                             const TopNWindowEliminationParameters &params) {
 	// The top-most operator's column order is:
 	// [projected groups][aggregate args/value][row number]
 	// Now set the new bindings according to this order and remember replacements in replacer
@@ -803,8 +794,8 @@ TopNWindowElimination::UpdateTopmostBindings(idx_t window_idx, unique_ptr<Logica
 		current_column_idx = 0;
 	}
 	if (op->type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN) {
-		// We do not have an aggregate index, so we need to set an offset to hit the correct columns
-		current_column_idx = TraverseAndFindAggregateOffset(op->children[1]);
+		// The late-materialized LHS contains the semantic partitions, not synthetic aggregate groups.
+		current_column_idx = params.partition_count;
 	}
 
 	// Project the args/value
@@ -870,6 +861,7 @@ TopNWindowElimination::ExtractOptimizerParameters(const LogicalWindow &window, c
 	params.include_row_number = BindingsReferenceRowNumber(bindings, window);
 	params.payload_type = aggregate_payload.size() > 1 ? TopNPayloadType::STRUCT_PACK : TopNPayloadType::SINGLE_COLUMN;
 	auto &window_expr = window.expressions[0]->Cast<BoundWindowExpression>();
+	params.partition_count = window_expr.partitions.size();
 	params.order_type = window_expr.orders[0].type;
 
 	VisitExpression(&window_expr.orders[0].expression);

--- a/test/optimizer/topn_window_elimination.test_slow
+++ b/test/optimizer/topn_window_elimination.test_slow
@@ -20,6 +20,28 @@ CREATE TABLE tbl2(generated_col AS (x + 1), x INTEGER, y VARCHAR)
 statement ok
 INSERT INTO tbl2 VALUES (0, 'a'), (1, 'b'), (null, 'c')
 
+# An unpartitioned top-1 window must not turn empty input into a NULL row
+statement ok
+CREATE TABLE empty_topn(s INTEGER, p INTEGER)
+
+query I
+SELECT p
+FROM empty_topn
+QUALIFY row_number() OVER (ORDER BY s) <= 1
+----
+
+# The window input can be empty even when the base table is not
+statement ok
+INSERT INTO empty_topn VALUES (1, 42)
+
+# random() is in [0, 1), so this runtime filter rejects s = 1
+query I
+SELECT p
+FROM empty_topn
+WHERE s < random()
+QUALIFY row_number() OVER (ORDER BY s) <= 1
+----
+
 statement ok
 CREATE MACRO window_fun(table_name, col_names, sort_order, topn) AS TABLE
 FROM query(

--- a/test/optimizer/topn_window_elimination.test_slow
+++ b/test/optimizer/topn_window_elimination.test_slow
@@ -42,6 +42,19 @@ WHERE s < random()
 QUALIFY row_number() OVER (ORDER BY s) <= 1
 ----
 
+# NaN sorts after all finite floating-point values
+query II
+WITH floating_values(id, val) AS (
+	VALUES (1, 0.0::DOUBLE), (2, 'NaN'::DOUBLE), (3, -1.0::DOUBLE)
+)
+SELECT id, val
+FROM floating_values
+QUALIFY row_number() OVER (ORDER BY val ASC NULLS LAST) <= 2
+ORDER BY id
+----
+1	0.0
+3	-1.0
+
 statement ok
 CREATE MACRO window_fun(table_name, col_names, sort_order, topn) AS TABLE
 FROM query(

--- a/test/optimizer/topn_window_elimination_parquet.test_slow
+++ b/test/optimizer/topn_window_elimination_parquet.test_slow
@@ -19,6 +19,24 @@ COPY (SELECT * FROM VALUES (0, [0], null), (0, [1], 1), (1, [2], null), (null, [
 statement ok
 COPY (SELECT * FROM VALUES (0, 'a'), (1, 'b'), (null, 'c'), t(x, y)) TO '__TEST_DIR__/tbl2.parquet'
 
+# Regression test: late materialization must use the actual bindings of a projected GET.
+# The pushed-down filter creates a gap in the GET's projection ids before the row ids are appended.
+statement ok
+COPY (SELECT r % 2 AS grp, r AS a, r + 10 AS b, r + 20 AS c,
+             r % 3 = 0 AS excluded, r AS sort_key
+      FROM range(1, 7) t(r)) TO '__TEST_DIR__/projected_get.parquet' (FORMAT parquet)
+
+query IIII
+WITH source AS (SELECT * FROM read_parquet('__TEST_DIR__/projected_get.parquet'))
+SELECT grp, a, b, c
+FROM source
+WHERE NOT excluded
+QUALIFY row_number() OVER (PARTITION BY grp ORDER BY sort_key DESC) = 1
+ORDER BY ALL
+----
+0	4	14	24
+1	5	15	25
+
 # test min_max
 foreach sort_order ASC DESC
 

--- a/test/sql/aggregate/aggregates/arg_min_max_nulls_last.test
+++ b/test/sql/aggregate/aggregates/arg_min_max_nulls_last.test
@@ -62,3 +62,25 @@ SELECT grp, arg_min_nulls_last(arg, val, 2) FROM tbl GROUP BY grp ORDER BY grp
 1	[5, NULL]
 2	[NULL]
 3	[1]
+
+# NaN sorts after all finite values and before NULL
+foreach fp_type FLOAT DOUBLE
+
+query II
+WITH floating_values(id, val) AS (
+	VALUES (1, 0::${fp_type}), (2, 'NaN'::${fp_type}), (3, -1::${fp_type}), (4, NULL::${fp_type})
+)
+SELECT arg_min_nulls_last(id, val, 4), arg_max_nulls_last(id, val, 4) FROM floating_values
+----
+[3, 1, 2, 4]	[2, 1, 3, 4]
+
+# Check that heap ordering does not depend on input order
+query II
+WITH floating_values(id, val) AS (
+	VALUES (2, 'NaN'::${fp_type}), (4, NULL::${fp_type}), (3, -1::${fp_type}), (1, 0::${fp_type})
+)
+SELECT arg_min_nulls_last(id, val, 4), arg_max_nulls_last(id, val, 4) FROM floating_values
+----
+[3, 1, 2, 4]	[2, 1, 3, 4]
+
+endloop


### PR DESCRIPTION
fixes https://github.com/duckdblabs/duckdb-internal/issues/10038

Fix: Track and rewrite column bindings by their actual column binding identities instead of assuming that projected column positions match the underlying scan.

fixes https://github.com/duckdblabs/duckdb-internal/issues/9902
fixes https://github.com/duckdb/duckdb/issues/23675

Fix: Prevent `NULL` result from `arg_[min/max]` aggregate on empty input by introducing a constant group by. This impacts performance a bit but is way simpler than adding a `count_star` aggregate and a filter on that. I resorted to the simpler solution here as column bindings are hard enough in this optimizer.

fixes https://github.com/duckdblabs/duckdb-internal/issues/9903
fixes https://github.com/duckdb/duckdb/issues/23676

Fix: Use `GreaterThan::Operation` in null-preserving `arg_[min/max]` rather than `>` comparator.