### PR TITLE
Add batch index support to PhysicalColumnDataScan

### DIFF
--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -4412,6 +4412,25 @@ PipelineBroadcastExchangeConsumerMode EnumUtil::FromString<PipelineBroadcastExch
 	return static_cast<PipelineBroadcastExchangeConsumerMode>(StringUtil::StringToEnum(GetPipelineBroadcastExchangeConsumerModeValues(), 4, "PipelineBroadcastExchangeConsumerMode", value));
 }
 
+const StringUtil::EnumStringLiteral *GetPipelineBroadcastExchangeOrderModeValues() {
+	static constexpr StringUtil::EnumStringLiteral values[] {
+		{ static_cast<uint32_t>(PipelineBroadcastExchangeOrderMode::UNORDERED), "UNORDERED" },
+		{ static_cast<uint32_t>(PipelineBroadcastExchangeOrderMode::SEQUENTIAL), "SEQUENTIAL" },
+		{ static_cast<uint32_t>(PipelineBroadcastExchangeOrderMode::BATCH_INDEX), "BATCH_INDEX" }
+	};
+	return values;
+}
+
+template<>
+const char* EnumUtil::ToChars<PipelineBroadcastExchangeOrderMode>(PipelineBroadcastExchangeOrderMode value) {
+	return StringUtil::EnumToString(GetPipelineBroadcastExchangeOrderModeValues(), 3, "PipelineBroadcastExchangeOrderMode", static_cast<uint32_t>(value));
+}
+
+template<>
+PipelineBroadcastExchangeOrderMode EnumUtil::FromString<PipelineBroadcastExchangeOrderMode>(const char *value) {
+	return static_cast<PipelineBroadcastExchangeOrderMode>(StringUtil::StringToEnum(GetPipelineBroadcastExchangeOrderModeValues(), 3, "PipelineBroadcastExchangeOrderMode", value));
+}
+
 const StringUtil::EnumStringLiteral *GetPipelineInputModeValues() {
 	static constexpr StringUtil::EnumStringLiteral values[] {
 		{ static_cast<uint32_t>(PipelineInputMode::SCHEDULED_SOURCE), "SCHEDULED_SOURCE" },

--- a/src/execution/operator/persistent/physical_batch_copy_to_file.cpp
+++ b/src/execution/operator/persistent/physical_batch_copy_to_file.cpp
@@ -11,6 +11,7 @@
 #include "duckdb/parallel/base_pipeline_event.hpp"
 #include "duckdb/parallel/executor_task.hpp"
 #include "duckdb/storage/buffer_manager.hpp"
+#include "duckdb/storage/storage_info.hpp"
 #include "duckdb/logging/logger.hpp"
 #include "duckdb/logging/log_type.hpp"
 
@@ -45,6 +46,10 @@ InsertionOrderPreservingMap<string> PhysicalBatchCopyToFile::ParamsToString() co
 	InsertionOrderPreservingMap<string> result;
 	result["FORMAT"] = StringUtil::Upper(function.name.GetIdentifierName());
 	return result;
+}
+
+OperatorPartitionInfo PhysicalBatchCopyToFile::RequiredPartitionInfo() const {
+	return OperatorPartitionInfo::BatchIndex(batch_size.IsValid() ? batch_size : optional_idx(DEFAULT_ROW_GROUP_SIZE));
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/execution/operator/persistent/physical_batch_insert.cpp
+++ b/src/execution/operator/persistent/physical_batch_insert.cpp
@@ -9,6 +9,7 @@
 #include "duckdb/storage/table/row_group_collection.hpp"
 #include "duckdb/storage/table/scan_state.hpp"
 #include "duckdb/storage/table_io_manager.hpp"
+#include "duckdb/storage/storage_info.hpp"
 #include "duckdb/transaction/duck_transaction.hpp"
 #include "duckdb/transaction/local_storage.hpp"
 #include "duckdb/common/types/column/column_data_collection.hpp"
@@ -19,14 +20,19 @@ PhysicalBatchInsert::PhysicalBatchInsert(PhysicalPlan &physical_plan, vector<Log
                                          DuckTableEntry &table, vector<unique_ptr<BoundConstraint>> bound_constraints_p,
                                          idx_t estimated_cardinality)
     : PhysicalOperator(physical_plan, PhysicalOperatorType::BATCH_INSERT, std::move(types_p), estimated_cardinality),
-      insert_table(&table), insert_types(table.GetTypes()), bound_constraints(std::move(bound_constraints_p)) {
+      insert_table(&table), insert_types(table.GetTypes()), bound_constraints(std::move(bound_constraints_p)),
+      preferred_batch_size(table.GetStorage().GetRowGroupSize()) {
 }
 
 PhysicalBatchInsert::PhysicalBatchInsert(PhysicalPlan &physical_plan, LogicalOperator &op, SchemaCatalogEntry &schema,
                                          unique_ptr<BoundCreateTableInfo> info_p, idx_t estimated_cardinality)
     : PhysicalOperator(physical_plan, PhysicalOperatorType::BATCH_CREATE_TABLE_AS, op.types, estimated_cardinality),
-      insert_table(nullptr), schema(&schema), info(std::move(info_p)) {
+      insert_table(nullptr), schema(&schema), info(std::move(info_p)), preferred_batch_size(DEFAULT_ROW_GROUP_SIZE) {
 	PhysicalInsert::GetInsertInfo(*info, insert_types);
+}
+
+OperatorPartitionInfo PhysicalBatchInsert::RequiredPartitionInfo() const {
+	return OperatorPartitionInfo::BatchIndex(preferred_batch_size);
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/execution/operator/scan/physical_column_data_scan.cpp
+++ b/src/execution/operator/scan/physical_column_data_scan.cpp
@@ -64,8 +64,7 @@ PhysicalColumnDataScan::PhysicalColumnDataScan(PhysicalPlan &physical_plan, vect
 class PhysicalColumnDataGlobalScanState : public GlobalSourceState {
 public:
 	PhysicalColumnDataGlobalScanState(ClientContext &context, const ColumnDataCollection &collection,
-	                                  const vector<column_t> &column_ids,
-	                                  const OperatorPartitionInfo &partition_info)
+	                                  const vector<column_t> &column_ids, const OperatorPartitionInfo &partition_info)
 	    : batch_size(GetColumnDataScanBatchSize(context, partition_info)),
 	      max_threads(ColumnDataScanBatchCount(collection.Count(), batch_size)) {
 		collection.InitializeScan(global_scan_state, column_ids);

--- a/src/execution/operator/scan/physical_column_data_scan.cpp
+++ b/src/execution/operator/scan/physical_column_data_scan.cpp
@@ -11,36 +11,64 @@
 #include "duckdb/main/client_config.hpp"
 #include "duckdb/parallel/meta_pipeline.hpp"
 #include "duckdb/parallel/pipeline.hpp"
+#include "duckdb/storage/storage_info.hpp"
 
 namespace duckdb {
 
-static constexpr idx_t COLUMN_DATA_SCAN_BATCH_SIZE = STANDARD_VECTOR_SIZE * 50ULL;
-
 static idx_t ColumnDataScanBatchCount(idx_t count, idx_t batch_size) {
 	return MaxValue<idx_t>(count / batch_size + (count % batch_size != 0), 1);
+}
+
+static idx_t GetColumnDataScanBatchSize(ClientContext &context, const OperatorPartitionInfo &partition_info) {
+	if (ClientConfig::GetConfig(context).verify_parallelism) {
+		return STANDARD_VECTOR_SIZE;
+	}
+	if (partition_info.preferred_batch_size.IsValid() && partition_info.preferred_batch_size.GetIndex() > 0) {
+		return partition_info.preferred_batch_size.GetIndex();
+	}
+	return DEFAULT_ROW_GROUP_SIZE;
+}
+
+static vector<column_t> GenerateColumnDataColumnIds(const vector<LogicalType> &types) {
+	vector<column_t> column_ids;
+	column_ids.reserve(types.size());
+	for (idx_t i = 0; i < types.size(); i++) {
+		column_ids.push_back(i);
+	}
+	return column_ids;
 }
 
 PhysicalColumnDataScan::PhysicalColumnDataScan(PhysicalPlan &physical_plan, vector<LogicalType> types,
                                                PhysicalOperatorType op_type, idx_t estimated_cardinality,
                                                optionally_owned_ptr<ColumnDataCollection> collection_p)
     : PhysicalOperator(physical_plan, op_type, std::move(types), estimated_cardinality),
-      collection(std::move(collection_p)) {
+      collection(std::move(collection_p)), column_ids(GenerateColumnDataColumnIds(this->types)) {
+}
+
+PhysicalColumnDataScan::PhysicalColumnDataScan(PhysicalPlan &physical_plan, vector<LogicalType> types,
+                                               PhysicalOperatorType op_type, idx_t estimated_cardinality,
+                                               optionally_owned_ptr<ColumnDataCollection> collection_p,
+                                               vector<column_t> column_ids_p)
+    : PhysicalOperator(physical_plan, op_type, std::move(types), estimated_cardinality),
+      collection(std::move(collection_p)), column_ids(std::move(column_ids_p)) {
+	D_ASSERT(this->types.size() == column_ids.size());
 }
 
 PhysicalColumnDataScan::PhysicalColumnDataScan(PhysicalPlan &physical_plan, vector<LogicalType> types,
                                                PhysicalOperatorType op_type, idx_t estimated_cardinality,
                                                TableIndex cte_index)
     : PhysicalOperator(physical_plan, op_type, std::move(types), estimated_cardinality), collection(nullptr),
-      cte_index(cte_index) {
+      column_ids(GenerateColumnDataColumnIds(this->types)), cte_index(cte_index) {
 }
 
 class PhysicalColumnDataGlobalScanState : public GlobalSourceState {
 public:
-	PhysicalColumnDataGlobalScanState(ClientContext &context, const ColumnDataCollection &collection)
-	    : batch_size(ClientConfig::GetConfig(context).verify_parallelism ? STANDARD_VECTOR_SIZE
-	                                                                     : COLUMN_DATA_SCAN_BATCH_SIZE),
+	PhysicalColumnDataGlobalScanState(ClientContext &context, const ColumnDataCollection &collection,
+	                                  const vector<column_t> &column_ids,
+	                                  const OperatorPartitionInfo &partition_info)
+	    : batch_size(GetColumnDataScanBatchSize(context, partition_info)),
 	      max_threads(ColumnDataScanBatchCount(collection.Count(), batch_size)) {
-		collection.InitializeScan(global_scan_state);
+		collection.InitializeScan(global_scan_state, column_ids);
 	}
 
 	idx_t MaxThreads() override {
@@ -102,7 +130,16 @@ unique_ptr<GlobalSourceState> PhysicalColumnDataScan::GetGlobalSourceState(Clien
 	if (!collection) {
 		return make_uniq<GlobalSourceState>();
 	}
-	return make_uniq<PhysicalColumnDataGlobalScanState>(context, *collection);
+	return GetGlobalSourceState(context, OperatorPartitionInfo::NoPartitionInfo());
+}
+
+unique_ptr<GlobalSourceState>
+PhysicalColumnDataScan::GetGlobalSourceState(ClientContext &context,
+                                             const OperatorPartitionInfo &partition_info) const {
+	if (!collection) {
+		return make_uniq<GlobalSourceState>();
+	}
+	return make_uniq<PhysicalColumnDataGlobalScanState>(context, *collection, column_ids, partition_info);
 }
 
 unique_ptr<LocalSourceState> PhysicalColumnDataScan::GetLocalSourceState(ExecutionContext &,
@@ -120,8 +157,14 @@ SourceResultType PhysicalColumnDataScan::GetDataInternal(ExecutionContext &conte
 	}
 
 	auto &entry = lstate.entries[lstate.entry_index++];
-	collection->ScanAtIndex(gstate.global_scan_state, lstate.local_scan_state, chunk, entry.chunk_index,
-	                        entry.segment_index, entry.row_index);
+	if (column_ids.empty()) {
+		chunk.Reset();
+		auto &chunk_data = collection->GetSegments()[entry.segment_index]->chunk_data[entry.chunk_index];
+		chunk.SetChildCardinality(chunk_data.count);
+	} else {
+		collection->ScanAtIndex(gstate.global_scan_state, lstate.local_scan_state, chunk, entry.chunk_index,
+		                        entry.segment_index, entry.row_index);
+	}
 	return SourceResultType::HAVE_MORE_OUTPUT;
 }
 

--- a/src/execution/operator/scan/physical_column_data_scan.cpp
+++ b/src/execution/operator/scan/physical_column_data_scan.cpp
@@ -251,7 +251,7 @@ void PhysicalColumnDataScan::BuildPipelines(Pipeline &current, MetaPipeline &met
 				return;
 			}
 			if (cte.ShouldUseBufferedConsumer(current)) {
-				cte.RegisterBufferedConsumer(source.consumer_idx);
+				cte.RegisterBufferedConsumer(current, source.consumer_idx);
 				current.AddDataflowDependency(cte_dependency);
 				DUCKDB_LOG(current.GetClientContext(), PhysicalOperatorLogType, cte, "PhysicalCTE", "SelectConsumer",
 				           {{"consumer", to_string(source.consumer_idx)}, {"mode", "BUFFERED"}});

--- a/src/execution/operator/scan/physical_column_data_scan.cpp
+++ b/src/execution/operator/scan/physical_column_data_scan.cpp
@@ -4,13 +4,21 @@
 #include "duckdb/logging/logger.hpp"
 
 #include "duckdb/common/types/column/column_data_collection.hpp"
+#include "duckdb/common/types/column/column_data_collection_segment.hpp"
 #include "duckdb/execution/operator/aggregate/physical_hash_aggregate.hpp"
 #include "duckdb/execution/operator/join/physical_delim_join.hpp"
 #include "duckdb/execution/operator/set/physical_cte.hpp"
+#include "duckdb/main/client_config.hpp"
 #include "duckdb/parallel/meta_pipeline.hpp"
 #include "duckdb/parallel/pipeline.hpp"
 
 namespace duckdb {
+
+static constexpr idx_t COLUMN_DATA_SCAN_BATCH_SIZE = STANDARD_VECTOR_SIZE * 50ULL;
+
+static idx_t ColumnDataScanBatchCount(idx_t count, idx_t batch_size) {
+	return MaxValue<idx_t>(count / batch_size + (count % batch_size != 0), 1);
+}
 
 PhysicalColumnDataScan::PhysicalColumnDataScan(PhysicalPlan &physical_plan, vector<LogicalType> types,
                                                PhysicalOperatorType op_type, idx_t estimated_cardinality,
@@ -28,8 +36,10 @@ PhysicalColumnDataScan::PhysicalColumnDataScan(PhysicalPlan &physical_plan, vect
 
 class PhysicalColumnDataGlobalScanState : public GlobalSourceState {
 public:
-	explicit PhysicalColumnDataGlobalScanState(const ColumnDataCollection &collection)
-	    : max_threads(MaxValue<idx_t>(collection.ChunkCount(), 1)) {
+	PhysicalColumnDataGlobalScanState(ClientContext &context, const ColumnDataCollection &collection)
+	    : batch_size(ClientConfig::GetConfig(context).verify_parallelism ? STANDARD_VECTOR_SIZE
+	                                                                     : COLUMN_DATA_SCAN_BATCH_SIZE),
+	      max_threads(ColumnDataScanBatchCount(collection.Count(), batch_size)) {
 		collection.InitializeScan(global_scan_state);
 	}
 
@@ -40,19 +50,59 @@ public:
 public:
 	ColumnDataParallelScanState global_scan_state;
 
+	const idx_t batch_size;
 	const idx_t max_threads;
+	idx_t next_batch_index = 0;
+};
+
+struct ColumnDataScanEntry {
+	ColumnDataScanEntry(idx_t chunk_index_p, idx_t segment_index_p, idx_t row_index_p)
+	    : chunk_index(chunk_index_p), segment_index(segment_index_p), row_index(row_index_p) {
+	}
+
+	idx_t chunk_index;
+	idx_t segment_index;
+	idx_t row_index;
 };
 
 class PhysicalColumnDataLocalScanState : public LocalSourceState {
 public:
+	bool AssignTask(const ColumnDataCollection &collection, PhysicalColumnDataGlobalScanState &gstate) {
+		entries.clear();
+		entry_index = 0;
+		batch_index = DConstants::INVALID_INDEX;
+
+		idx_t task_count = 0;
+		lock_guard<mutex> l(gstate.global_scan_state.lock);
+		while (task_count < gstate.batch_size) {
+			idx_t chunk_index;
+			idx_t segment_index;
+			idx_t row_index;
+			if (!collection.NextScanIndex(gstate.global_scan_state.scan_state, chunk_index, segment_index, row_index)) {
+				break;
+			}
+			entries.emplace_back(chunk_index, segment_index, row_index);
+			task_count += collection.GetSegments()[segment_index]->chunk_data[chunk_index].count;
+		}
+
+		if (entries.empty()) {
+			return false;
+		}
+		batch_index = gstate.next_batch_index++;
+		return true;
+	}
+
 	ColumnDataLocalScanState local_scan_state;
+	vector<ColumnDataScanEntry> entries;
+	idx_t entry_index = 0;
+	idx_t batch_index = DConstants::INVALID_INDEX;
 };
 
 unique_ptr<GlobalSourceState> PhysicalColumnDataScan::GetGlobalSourceState(ClientContext &context) const {
 	if (!collection) {
 		return make_uniq<GlobalSourceState>();
 	}
-	return make_uniq<PhysicalColumnDataGlobalScanState>(*collection);
+	return make_uniq<PhysicalColumnDataGlobalScanState>(context, *collection);
 }
 
 unique_ptr<LocalSourceState> PhysicalColumnDataScan::GetLocalSourceState(ExecutionContext &,
@@ -64,8 +114,33 @@ SourceResultType PhysicalColumnDataScan::GetDataInternal(ExecutionContext &conte
                                                          OperatorSourceInput &input) const {
 	auto &gstate = input.global_state.Cast<PhysicalColumnDataGlobalScanState>();
 	auto &lstate = input.local_state.Cast<PhysicalColumnDataLocalScanState>();
-	collection->Scan(gstate.global_scan_state, lstate.local_scan_state, chunk);
-	return chunk.size() == 0 ? SourceResultType::FINISHED : SourceResultType::HAVE_MORE_OUTPUT;
+	if (lstate.entry_index >= lstate.entries.size() && !lstate.AssignTask(*collection, gstate)) {
+		chunk.Reset();
+		return SourceResultType::FINISHED;
+	}
+
+	auto &entry = lstate.entries[lstate.entry_index++];
+	collection->ScanAtIndex(gstate.global_scan_state, lstate.local_scan_state, chunk, entry.chunk_index,
+	                        entry.segment_index, entry.row_index);
+	return SourceResultType::HAVE_MORE_OUTPUT;
+}
+
+bool PhysicalColumnDataScan::SupportsPartitioning(const OperatorPartitionInfo &partition_info) const {
+	if (partition_info.RequiresPartitionColumns()) {
+		return false;
+	}
+	if (!partition_info.RequiresBatchIndex()) {
+		return false;
+	}
+	return type == PhysicalOperatorType::COLUMN_DATA_SCAN || type == PhysicalOperatorType::CTE_SCAN;
+}
+
+OperatorPartitionData PhysicalColumnDataScan::GetPartitionData(ExecutionContext &context, DataChunk &chunk,
+                                                               GlobalSourceState &gstate, LocalSourceState &lstate_p,
+                                                               const OperatorPartitionInfo &partition_info) const {
+	D_ASSERT(SupportsPartitioning(partition_info));
+	auto &lstate = lstate_p.Cast<PhysicalColumnDataLocalScanState>();
+	return OperatorPartitionData(lstate.batch_index);
 }
 
 ProgressData PhysicalColumnDataScan::GetProgress(ClientContext &context, GlobalSourceState &gstate) const {

--- a/src/execution/operator/scan/physical_column_data_scan.cpp
+++ b/src/execution/operator/scan/physical_column_data_scan.cpp
@@ -177,6 +177,9 @@ bool PhysicalColumnDataScan::SupportsPartitioning(const OperatorPartitionInfo &p
 	if (!partition_info.RequiresBatchIndex()) {
 		return false;
 	}
+	if (type == PhysicalOperatorType::CTE_SCAN && cte_source) {
+		return cte_source->SupportsPartitioning(partition_info);
+	}
 	return type == PhysicalOperatorType::COLUMN_DATA_SCAN || type == PhysicalOperatorType::CTE_SCAN;
 }
 

--- a/src/execution/operator/scan/physical_column_data_scan.cpp
+++ b/src/execution/operator/scan/physical_column_data_scan.cpp
@@ -23,6 +23,9 @@ static idx_t GetColumnDataScanBatchSize(ClientContext &context, const OperatorPa
 	if (ClientConfig::GetConfig(context).verify_parallelism) {
 		return STANDARD_VECTOR_SIZE;
 	}
+	if (!partition_info.RequiresBatchIndex()) {
+		return STANDARD_VECTOR_SIZE;
+	}
 	if (partition_info.preferred_batch_size.IsValid() && partition_info.preferred_batch_size.GetIndex() > 0) {
 		return partition_info.preferred_batch_size.GetIndex();
 	}

--- a/src/execution/operator/scan/physical_column_data_scan.cpp
+++ b/src/execution/operator/scan/physical_column_data_scan.cpp
@@ -11,6 +11,7 @@
 #include "duckdb/main/client_config.hpp"
 #include "duckdb/parallel/meta_pipeline.hpp"
 #include "duckdb/parallel/pipeline.hpp"
+#include "duckdb/parallel/task_scheduler.hpp"
 #include "duckdb/storage/storage_info.hpp"
 
 namespace duckdb {
@@ -19,17 +20,22 @@ static idx_t ColumnDataScanBatchCount(idx_t count, idx_t batch_size) {
 	return MaxValue<idx_t>(count / batch_size + (count % batch_size != 0), 1);
 }
 
-static idx_t GetColumnDataScanBatchSize(ClientContext &context, const OperatorPartitionInfo &partition_info) {
+static idx_t GetColumnDataScanBatchSize(ClientContext &context, idx_t collection_count,
+                                        const OperatorPartitionInfo &partition_info) {
 	if (ClientConfig::GetConfig(context).verify_parallelism) {
 		return STANDARD_VECTOR_SIZE;
 	}
 	if (!partition_info.RequiresBatchIndex()) {
 		return STANDARD_VECTOR_SIZE;
 	}
+	idx_t preferred_batch_size = DEFAULT_ROW_GROUP_SIZE;
 	if (partition_info.preferred_batch_size.IsValid() && partition_info.preferred_batch_size.GetIndex() > 0) {
-		return partition_info.preferred_batch_size.GetIndex();
+		preferred_batch_size = partition_info.preferred_batch_size.GetIndex();
 	}
-	return DEFAULT_ROW_GROUP_SIZE;
+	auto thread_count = MaxValue<idx_t>(TaskScheduler::GetScheduler(context).NumberOfThreads(), 1);
+	auto rows_per_thread = collection_count / thread_count + (collection_count % thread_count != 0);
+	auto parallelism_cap = MaxValue<idx_t>(STANDARD_VECTOR_SIZE, rows_per_thread);
+	return MinValue(preferred_batch_size, parallelism_cap);
 }
 
 static vector<column_t> GenerateColumnDataColumnIds(const vector<LogicalType> &types) {
@@ -68,7 +74,7 @@ class PhysicalColumnDataGlobalScanState : public GlobalSourceState {
 public:
 	PhysicalColumnDataGlobalScanState(ClientContext &context, const ColumnDataCollection &collection,
 	                                  const vector<column_t> &column_ids, const OperatorPartitionInfo &partition_info)
-	    : batch_size(GetColumnDataScanBatchSize(context, partition_info)),
+	    : batch_size(GetColumnDataScanBatchSize(context, collection.Count(), partition_info)),
 	      max_threads(ColumnDataScanBatchCount(collection.Count(), batch_size)) {
 		collection.InitializeScan(global_scan_state, column_ids);
 	}

--- a/src/execution/operator/set/physical_cte.cpp
+++ b/src/execution/operator/set/physical_cte.cpp
@@ -202,6 +202,7 @@ public:
 	}
 
 	void FinalizeBatches() {
+		annotated_lock_guard<annotated_mutex> guard(lhs_lock);
 		if (!ordered_data) {
 			return;
 		}
@@ -552,8 +553,7 @@ ProgressData PhysicalCTE::GetSinkProgress(ClientContext &context, GlobalSinkStat
 	if (!state.working_table_ref) {
 		return ProgressData {0, 1, true};
 	}
-	auto &working_table = *state.working_table_ref;
-	auto count = double(working_table.Count());
+	auto count = double(state.ordered_data ? state.ordered_data->Count() : state.working_table_ref->Count());
 	ProgressData progress;
 	progress.done = count;
 	progress.total = count + source_progress.total;

--- a/src/execution/operator/set/physical_cte.cpp
+++ b/src/execution/operator/set/physical_cte.cpp
@@ -2,6 +2,7 @@
 
 #include "duckdb/common/atomic.hpp"
 #include "duckdb/common/enum_util.hpp"
+#include "duckdb/common/types/batched_data_collection.hpp"
 #include "duckdb/common/types/column/column_data_collection.hpp"
 #include "duckdb/logging/log_type.hpp"
 #include "duckdb/logging/logger.hpp"
@@ -43,6 +44,7 @@ public:
 class CTEConsumerLocalSourceState : public LocalSourceState {
 public:
 	shared_ptr<DataChunk> current_chunk;
+	optional_idx batch_index;
 };
 
 PhysicalCTEConsumerSource::PhysicalCTEConsumerSource(PhysicalPlan &physical_plan, vector<LogicalType> types,
@@ -65,7 +67,31 @@ SourceResultType PhysicalCTEConsumerSource::GetDataInternal(ExecutionContext &co
                                                             OperatorSourceInput &input) const {
 	auto &gstate = input.global_state.Cast<CTEConsumerGlobalSourceState>();
 	auto &lstate = input.local_state.Cast<CTEConsumerLocalSourceState>();
-	return gstate.exchange->Scan(gstate.consumer_idx, chunk, lstate.current_chunk, input.interrupt_state);
+	return gstate.exchange->Scan(gstate.consumer_idx, chunk, lstate.current_chunk, lstate.batch_index,
+	                             input.interrupt_state);
+}
+
+OperatorPartitionData PhysicalCTEConsumerSource::GetPartitionData(ExecutionContext &context, DataChunk &chunk,
+                                                                  GlobalSourceState &gstate,
+                                                                  LocalSourceState &lstate_p,
+                                                                  const OperatorPartitionInfo &partition_info) const {
+	D_ASSERT(SupportsPartitioning(partition_info));
+	auto &lstate = lstate_p.Cast<CTEConsumerLocalSourceState>();
+	D_ASSERT(lstate.batch_index.IsValid());
+	return OperatorPartitionData(lstate.batch_index.GetIndex());
+}
+
+bool PhysicalCTEConsumerSource::SupportsPartitioning(const OperatorPartitionInfo &partition_info) const {
+	return exchange->SupportsBatchIndex() && partition_info.RequiresBatchIndex() &&
+	       !partition_info.RequiresPartitionColumns();
+}
+
+OrderPreservationType PhysicalCTEConsumerSource::SourceOrder() const {
+	return exchange->SourceOrder();
+}
+
+bool PhysicalCTEConsumerSource::ParallelSource() const {
+	return !exchange->PreservesOrder();
 }
 
 ProgressData PhysicalCTEConsumerSource::GetProgress(ClientContext &context, GlobalSourceState &gstate) const {
@@ -118,6 +144,7 @@ public:
 	optional_ptr<ColumnDataCollection> working_table_ref;
 	shared_ptr<PipelineBroadcastExchange> exchange;
 	CTEExecutionMode execution_mode;
+	unique_ptr<BatchedDataCollection> ordered_data;
 
 	annotated_mutex lhs_lock;
 
@@ -130,8 +157,15 @@ private:
 			D_ASSERT(op.working_table);
 			op.working_table->Reset();
 			working_table_ref = op.working_table.get();
+			if (op.use_batch_index) {
+				ordered_data = make_uniq<BatchedDataCollection>(context, op.working_table->Types(),
+				                                                op.working_table->GetAllocatorType());
+			} else {
+				ordered_data.reset();
+			}
 		} else {
 			working_table_ref = nullptr;
+			ordered_data.reset();
 		}
 		GlobalSinkState::Reset(context);
 	}
@@ -149,15 +183,37 @@ public:
 		annotated_lock_guard<annotated_mutex> guard(lhs_lock);
 		working_table_ref->Combine(input);
 	}
+
+	void MergeBatches(BatchedDataCollection &input) {
+		annotated_lock_guard<annotated_mutex> guard(lhs_lock);
+		D_ASSERT(ordered_data);
+		ordered_data->Merge(input);
+	}
+
+	void FinalizeBatches() {
+		if (!ordered_data) {
+			return;
+		}
+		D_ASSERT(working_table_ref);
+		auto collection = ordered_data->FetchCollection();
+		working_table_ref->Combine(*collection);
+		ordered_data.reset();
+	}
 };
 
 class CTELocalState : public LocalSinkState {
 public:
-	explicit CTELocalState(ClientContext &context, const PhysicalCTE &op) : execution_mode(op.GetExecutionMode()) {
+	explicit CTELocalState(ClientContext &context, const PhysicalCTE &op)
+	    : execution_mode(op.GetExecutionMode()), use_batch_index(op.use_batch_index) {
 		if (execution_mode != CTEExecutionMode::STREAMING_FANOUT) {
 			D_ASSERT(op.working_table);
-			lhs_data = make_uniq<ColumnDataCollection>(context, op.working_table->Types());
-			lhs_data->InitializeAppend(append_state);
+			if (use_batch_index) {
+				lhs_batches = make_uniq<BatchedDataCollection>(context, op.working_table->Types(),
+				                                               op.working_table->GetAllocatorType());
+			} else {
+				lhs_data = make_uniq<ColumnDataCollection>(context, op.working_table->Types());
+				lhs_data->InitializeAppend(append_state);
+			}
 		}
 		if (execution_mode != CTEExecutionMode::MATERIALIZED) {
 			D_ASSERT(op.exchange);
@@ -167,8 +223,10 @@ public:
 
 	unique_ptr<LocalSinkState> distinct_state;
 	unique_ptr<ColumnDataCollection> lhs_data;
+	unique_ptr<BatchedDataCollection> lhs_batches;
 	ColumnDataAppendState append_state;
 	CTEExecutionMode execution_mode;
+	bool use_batch_index;
 	CTESinkExecutionState sink_execution_state = CTESinkExecutionState::ACTIVE;
 	// Combine can be retried after a blocked exchange finish.
 	CTECombineState combine_state = CTECombineState::PENDING;
@@ -176,8 +234,14 @@ public:
 
 	void Append(DataChunk &input) {
 		D_ASSERT(execution_mode != CTEExecutionMode::STREAMING_FANOUT);
-		D_ASSERT(lhs_data);
-		lhs_data->Append(append_state, input);
+		if (use_batch_index) {
+			D_ASSERT(lhs_batches);
+			D_ASSERT(partition_info.batch_index.IsValid());
+			lhs_batches->Append(input, partition_info.batch_index.GetIndex());
+		} else {
+			D_ASSERT(lhs_data);
+			lhs_data->Append(append_state, input);
+		}
 	}
 };
 
@@ -197,7 +261,7 @@ SinkResultType PhysicalCTE::Sink(ExecutionContext &context, DataChunk &chunk, Op
 	if (lstate.execution_mode != CTEExecutionMode::MATERIALIZED) {
 		D_ASSERT(gstate.exchange);
 		D_ASSERT(lstate.exchange_state);
-		result = gstate.exchange->Push(chunk, *lstate.exchange_state, input.interrupt_state);
+		result = gstate.exchange->Push(chunk, *lstate.exchange_state, lstate.partition_info, input.interrupt_state);
 		if (result == SinkResultType::BLOCKED) {
 			if (lstate.sink_execution_state != CTESinkExecutionState::BLOCKED) {
 				DUCKDB_LOG(context.client, PhysicalOperatorLogType, *this, "PhysicalCTE", "ExchangeBlocked",
@@ -223,11 +287,21 @@ SinkResultType PhysicalCTE::Sink(ExecutionContext &context, DataChunk &chunk, Op
 	return result;
 }
 
+SinkNextBatchType PhysicalCTE::NextBatch(ExecutionContext &context, OperatorSinkNextBatchInput &input) const {
+	auto &gstate = input.global_state.Cast<CTEGlobalState>();
+	auto &lstate = input.local_state.Cast<CTELocalState>();
+	if (lstate.execution_mode == CTEExecutionMode::MATERIALIZED) {
+		return SinkNextBatchType::READY;
+	}
+	D_ASSERT(gstate.exchange);
+	return gstate.exchange->NextBatch(lstate.partition_info, input.interrupt_state);
+}
+
 SinkCombineResultType PhysicalCTE::Combine(ExecutionContext &context, OperatorSinkCombineInput &input) const {
 	auto &lstate = input.local_state.Cast<CTELocalState>();
 	if (lstate.execution_mode != CTEExecutionMode::MATERIALIZED) {
 		D_ASSERT(lstate.exchange_state);
-		auto result = exchange->FinishLocal(*lstate.exchange_state, input.interrupt_state);
+		auto result = exchange->FinishLocal(*lstate.exchange_state, lstate.partition_info, input.interrupt_state);
 		if (result == SinkCombineResultType::BLOCKED) {
 			return result;
 		}
@@ -235,8 +309,13 @@ SinkCombineResultType PhysicalCTE::Combine(ExecutionContext &context, OperatorSi
 	if (lstate.execution_mode != CTEExecutionMode::STREAMING_FANOUT &&
 	    lstate.combine_state == CTECombineState::PENDING) {
 		auto &gstate = input.global_state.Cast<CTEGlobalState>();
-		D_ASSERT(lstate.lhs_data);
-		gstate.MergeIT(*lstate.lhs_data);
+		if (lstate.use_batch_index) {
+			D_ASSERT(lstate.lhs_batches);
+			gstate.MergeBatches(*lstate.lhs_batches);
+		} else {
+			D_ASSERT(lstate.lhs_data);
+			gstate.MergeIT(*lstate.lhs_data);
+		}
 		lstate.combine_state = CTECombineState::COMBINED;
 	}
 
@@ -245,8 +324,9 @@ SinkCombineResultType PhysicalCTE::Combine(ExecutionContext &context, OperatorSi
 
 SinkFinalizeType PhysicalCTE::Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
                                        OperatorSinkFinalizeInput &input) const {
+	auto &gstate = input.global_state.Cast<CTEGlobalState>();
+	gstate.FinalizeBatches();
 	if (exchange && UseStreamingExchange()) {
-		auto &gstate = input.global_state.Cast<CTEGlobalState>();
 		gstate.exchange->Finish();
 		gstate.exchange->FinishDirectConsumers();
 		DUCKDB_LOG(context, PhysicalOperatorLogType, *this, "PhysicalCTE", "ProducerFinished",
@@ -267,6 +347,11 @@ void PhysicalCTE::BuildPipelines(Pipeline &current, MetaPipeline &meta_pipeline)
 		exchange->SetLogOperator(*this);
 		// Prepared plans rebuild pipelines while keeping the physical CTE and consumer indexes.
 		exchange->ResetConsumerRegistrations();
+	}
+
+	if (meta_pipeline.HasRecursiveCTE() && use_batch_index) {
+		use_batch_index = false;
+		parallel = false;
 	}
 
 	auto &state = meta_pipeline.GetState();

--- a/src/execution/operator/set/physical_cte.cpp
+++ b/src/execution/operator/set/physical_cte.cpp
@@ -17,8 +17,10 @@ enum class CTECombineState : uint8_t { PENDING, COMBINED };
 
 class CTEConsumerGlobalSourceState : public GlobalSourceState {
 public:
-	CTEConsumerGlobalSourceState(shared_ptr<PipelineBroadcastExchange> exchange_p, idx_t consumer_idx_p)
-	    : exchange(std::move(exchange_p)), consumer_idx(consumer_idx_p) {
+	CTEConsumerGlobalSourceState(shared_ptr<PipelineBroadcastExchange> exchange_p, idx_t consumer_idx_p,
+	                             bool use_batch_index)
+	    : exchange(std::move(exchange_p)), consumer_idx(consumer_idx_p),
+	      max_threads(use_batch_index || !exchange->PreservesOrder() ? exchange->MaxThreads() : 1) {
 	}
 
 	~CTEConsumerGlobalSourceState() override {
@@ -26,7 +28,7 @@ public:
 	}
 
 	idx_t MaxThreads() override {
-		return exchange->MaxThreads();
+		return max_threads;
 	}
 
 	void Unregister() {
@@ -38,15 +40,18 @@ public:
 
 	shared_ptr<PipelineBroadcastExchange> exchange;
 	idx_t consumer_idx;
+	idx_t max_threads;
 	atomic<bool> unregistered {false};
 };
 
 class CTEConsumerLocalSourceState : public LocalSourceState {
 public:
-	shared_ptr<DataChunk> current_chunk;
+	explicit CTEConsumerLocalSourceState(shared_ptr<PipelineBroadcastExchangeScanState> scan_state_p)
+	    : scan_state(std::move(scan_state_p)) {
+	}
+
+	shared_ptr<PipelineBroadcastExchangeScanState> scan_state;
 	optional_idx exchange_batch_index;
-	optional_idx previous_exchange_batch_index;
-	idx_t local_batch_index = 0;
 };
 
 PhysicalCTEConsumerSource::PhysicalCTEConsumerSource(PhysicalPlan &physical_plan, vector<LogicalType> types,
@@ -57,19 +62,25 @@ PhysicalCTEConsumerSource::PhysicalCTEConsumerSource(PhysicalPlan &physical_plan
 }
 
 unique_ptr<GlobalSourceState> PhysicalCTEConsumerSource::GetGlobalSourceState(ClientContext &context) const {
-	return make_uniq<CTEConsumerGlobalSourceState>(exchange, consumer_idx);
+	return GetGlobalSourceState(context, OperatorPartitionInfo::NoPartitionInfo());
+}
+
+unique_ptr<GlobalSourceState>
+PhysicalCTEConsumerSource::GetGlobalSourceState(ClientContext &context,
+                                                const OperatorPartitionInfo &partition_info) const {
+	return make_uniq<CTEConsumerGlobalSourceState>(exchange, consumer_idx, partition_info.RequiresBatchIndex());
 }
 
 unique_ptr<LocalSourceState> PhysicalCTEConsumerSource::GetLocalSourceState(ExecutionContext &context,
                                                                             GlobalSourceState &gstate) const {
-	return make_uniq<CTEConsumerLocalSourceState>();
+	return make_uniq<CTEConsumerLocalSourceState>(exchange->GetScanState());
 }
 
 SourceResultType PhysicalCTEConsumerSource::GetDataInternal(ExecutionContext &context, DataChunk &chunk,
                                                             OperatorSourceInput &input) const {
 	auto &gstate = input.global_state.Cast<CTEConsumerGlobalSourceState>();
 	auto &lstate = input.local_state.Cast<CTEConsumerLocalSourceState>();
-	return gstate.exchange->Scan(gstate.consumer_idx, chunk, lstate.current_chunk, lstate.exchange_batch_index,
+	return gstate.exchange->Scan(gstate.consumer_idx, chunk, *lstate.scan_state, lstate.exchange_batch_index,
 	                             input.interrupt_state);
 }
 
@@ -79,15 +90,7 @@ OperatorPartitionData PhysicalCTEConsumerSource::GetPartitionData(ExecutionConte
 	D_ASSERT(SupportsPartitioning(partition_info));
 	auto &lstate = lstate_p.Cast<CTEConsumerLocalSourceState>();
 	D_ASSERT(lstate.exchange_batch_index.IsValid());
-	// Exchange batch indexes are producer-global; source partition indexes are pipeline-local.
-	if (!lstate.previous_exchange_batch_index.IsValid()) {
-		lstate.previous_exchange_batch_index = lstate.exchange_batch_index;
-	} else if (lstate.previous_exchange_batch_index != lstate.exchange_batch_index) {
-		D_ASSERT(lstate.exchange_batch_index.GetIndex() > lstate.previous_exchange_batch_index.GetIndex());
-		lstate.previous_exchange_batch_index = lstate.exchange_batch_index;
-		lstate.local_batch_index++;
-	}
-	return OperatorPartitionData(lstate.local_batch_index);
+	return OperatorPartitionData(lstate.exchange_batch_index.GetIndex());
 }
 
 bool PhysicalCTEConsumerSource::SupportsPartitioning(const OperatorPartitionInfo &partition_info) const {
@@ -100,7 +103,7 @@ OrderPreservationType PhysicalCTEConsumerSource::SourceOrder() const {
 }
 
 bool PhysicalCTEConsumerSource::ParallelSource() const {
-	return !exchange->PreservesOrder();
+	return exchange->OrderMode() != PipelineBroadcastExchangeOrderMode::SEQUENTIAL;
 }
 
 ProgressData PhysicalCTEConsumerSource::GetProgress(ClientContext &context, GlobalSourceState &gstate) const {
@@ -350,6 +353,8 @@ SinkFinalizeType PhysicalCTE::Finalize(Pipeline &pipeline, Event &event, ClientC
 void PhysicalCTE::BuildPipelines(Pipeline &current, MetaPipeline &meta_pipeline) {
 	D_ASSERT(children.size() == 2);
 	pipeline_selection_state = CTEPipelineSelectionState::UNRESOLVED;
+	preferred_batch_size = optional_idx();
+	conflicting_batch_sizes = false;
 	op_state.reset();
 	sink_state.reset();
 	if (exchange) {
@@ -411,7 +416,11 @@ bool PhysicalCTE::TryRegisterDirectConsumer(Pipeline &pipeline, idx_t consumer_i
 	if (!exchange) {
 		return false;
 	}
-	return exchange->TryRegisterDirectConsumer(pipeline, consumer_idx);
+	if (!exchange->TryRegisterDirectConsumer(pipeline, consumer_idx)) {
+		return false;
+	}
+	RegisterBatchPreference(pipeline);
+	return true;
 }
 
 bool PhysicalCTE::ShouldUseBufferedConsumer(Pipeline &pipeline) const {
@@ -426,9 +435,10 @@ bool PhysicalCTE::ShouldUseBufferedConsumer(Pipeline &pipeline) const {
 	return pipeline.CanStopSourceEarly();
 }
 
-void PhysicalCTE::RegisterBufferedConsumer(idx_t consumer_idx) {
+void PhysicalCTE::RegisterBufferedConsumer(Pipeline &pipeline, idx_t consumer_idx) {
 	D_ASSERT(exchange);
 	exchange->SelectBufferedConsumer(consumer_idx);
+	RegisterBatchPreference(pipeline);
 }
 
 void PhysicalCTE::RegisterMaterializedConsumer(idx_t consumer_idx) {
@@ -449,6 +459,25 @@ CTEExecutionMode PhysicalCTE::GetExecutionMode() const {
 		return CTEExecutionMode::HYBRID_FANOUT;
 	}
 	return CTEExecutionMode::STREAMING_FANOUT;
+}
+
+void PhysicalCTE::RegisterBatchPreference(Pipeline &pipeline) {
+	auto sink = pipeline.GetSink();
+	if (!sink) {
+		return;
+	}
+	auto partition_info = sink->RequiredPartitionInfo();
+	if (!partition_info.RequiresBatchIndex() || !partition_info.preferred_batch_size.IsValid() ||
+	    conflicting_batch_sizes) {
+		return;
+	}
+	auto batch_size = partition_info.preferred_batch_size.GetIndex();
+	if (!preferred_batch_size.IsValid()) {
+		preferred_batch_size = batch_size;
+	} else if (preferred_batch_size.GetIndex() != batch_size) {
+		preferred_batch_size = optional_idx();
+		conflicting_batch_sizes = true;
+	}
 }
 
 bool PhysicalCTE::UseStreamingExchange() const {
@@ -496,6 +525,10 @@ InsertionOrderPreservingMap<string> PhysicalCTE::ParamsToString() const {
 	}
 	if (exchange) {
 		auto summary = exchange->GetConsumerSummary();
+		result["Order Mode"] = EnumUtil::ToString(exchange->OrderMode());
+		if (preferred_batch_size.IsValid()) {
+			result["Preferred Batch Size"] = StringUtil::Format("%llu", preferred_batch_size.GetIndex());
+		}
 		if (summary.materialized > 0) {
 			result["Materialized Consumers"] = StringUtil::Format("%llu", summary.materialized);
 		}

--- a/src/execution/operator/set/physical_cte.cpp
+++ b/src/execution/operator/set/physical_cte.cpp
@@ -307,7 +307,8 @@ SinkNextBatchType PhysicalCTE::NextBatch(ExecutionContext &context, OperatorSink
 		return SinkNextBatchType::READY;
 	}
 	D_ASSERT(gstate.exchange);
-	return gstate.exchange->NextBatch(lstate.partition_info, input.interrupt_state);
+	D_ASSERT(lstate.exchange_state);
+	return gstate.exchange->NextBatch(*lstate.exchange_state, lstate.partition_info, input.interrupt_state);
 }
 
 SinkCombineResultType PhysicalCTE::Combine(ExecutionContext &context, OperatorSinkCombineInput &input) const {

--- a/src/execution/operator/set/physical_cte.cpp
+++ b/src/execution/operator/set/physical_cte.cpp
@@ -44,7 +44,9 @@ public:
 class CTEConsumerLocalSourceState : public LocalSourceState {
 public:
 	shared_ptr<DataChunk> current_chunk;
-	optional_idx batch_index;
+	optional_idx exchange_batch_index;
+	optional_idx previous_exchange_batch_index;
+	idx_t local_batch_index = 0;
 };
 
 PhysicalCTEConsumerSource::PhysicalCTEConsumerSource(PhysicalPlan &physical_plan, vector<LogicalType> types,
@@ -67,18 +69,25 @@ SourceResultType PhysicalCTEConsumerSource::GetDataInternal(ExecutionContext &co
                                                             OperatorSourceInput &input) const {
 	auto &gstate = input.global_state.Cast<CTEConsumerGlobalSourceState>();
 	auto &lstate = input.local_state.Cast<CTEConsumerLocalSourceState>();
-	return gstate.exchange->Scan(gstate.consumer_idx, chunk, lstate.current_chunk, lstate.batch_index,
+	return gstate.exchange->Scan(gstate.consumer_idx, chunk, lstate.current_chunk, lstate.exchange_batch_index,
 	                             input.interrupt_state);
 }
 
 OperatorPartitionData PhysicalCTEConsumerSource::GetPartitionData(ExecutionContext &context, DataChunk &chunk,
-                                                                  GlobalSourceState &gstate,
-                                                                  LocalSourceState &lstate_p,
+                                                                  GlobalSourceState &gstate, LocalSourceState &lstate_p,
                                                                   const OperatorPartitionInfo &partition_info) const {
 	D_ASSERT(SupportsPartitioning(partition_info));
 	auto &lstate = lstate_p.Cast<CTEConsumerLocalSourceState>();
-	D_ASSERT(lstate.batch_index.IsValid());
-	return OperatorPartitionData(lstate.batch_index.GetIndex());
+	D_ASSERT(lstate.exchange_batch_index.IsValid());
+	// Exchange batch indexes are producer-global; source partition indexes are pipeline-local.
+	if (!lstate.previous_exchange_batch_index.IsValid()) {
+		lstate.previous_exchange_batch_index = lstate.exchange_batch_index;
+	} else if (lstate.previous_exchange_batch_index != lstate.exchange_batch_index) {
+		D_ASSERT(lstate.exchange_batch_index.GetIndex() > lstate.previous_exchange_batch_index.GetIndex());
+		lstate.previous_exchange_batch_index = lstate.exchange_batch_index;
+		lstate.local_batch_index++;
+	}
+	return OperatorPartitionData(lstate.local_batch_index);
 }
 
 bool PhysicalCTEConsumerSource::SupportsPartitioning(const OperatorPartitionInfo &partition_info) const {

--- a/src/execution/operator/set/physical_cte.cpp
+++ b/src/execution/operator/set/physical_cte.cpp
@@ -17,10 +17,9 @@ enum class CTECombineState : uint8_t { PENDING, COMBINED };
 
 class CTEConsumerGlobalSourceState : public GlobalSourceState {
 public:
-	CTEConsumerGlobalSourceState(shared_ptr<PipelineBroadcastExchange> exchange_p, idx_t consumer_idx_p,
-	                             bool use_batch_index)
+	CTEConsumerGlobalSourceState(shared_ptr<PipelineBroadcastExchange> exchange_p, idx_t consumer_idx_p)
 	    : exchange(std::move(exchange_p)), consumer_idx(consumer_idx_p),
-	      max_threads(use_batch_index || !exchange->PreservesOrder() ? exchange->MaxThreads() : 1) {
+	      max_threads(exchange->PreservesOrder() ? 1 : exchange->MaxThreads()) {
 	}
 
 	~CTEConsumerGlobalSourceState() override {
@@ -68,7 +67,7 @@ unique_ptr<GlobalSourceState> PhysicalCTEConsumerSource::GetGlobalSourceState(Cl
 unique_ptr<GlobalSourceState>
 PhysicalCTEConsumerSource::GetGlobalSourceState(ClientContext &context,
                                                 const OperatorPartitionInfo &partition_info) const {
-	return make_uniq<CTEConsumerGlobalSourceState>(exchange, consumer_idx, partition_info.RequiresBatchIndex());
+	return make_uniq<CTEConsumerGlobalSourceState>(exchange, consumer_idx);
 }
 
 unique_ptr<LocalSourceState> PhysicalCTEConsumerSource::GetLocalSourceState(ExecutionContext &context,
@@ -215,21 +214,22 @@ public:
 
 class CTELocalState : public LocalSinkState {
 public:
-	explicit CTELocalState(ClientContext &context, const PhysicalCTE &op)
+	explicit CTELocalState(ExecutionContext &context, const PhysicalCTE &op)
 	    : execution_mode(op.GetExecutionMode()), use_batch_index(op.use_batch_index) {
 		if (execution_mode != CTEExecutionMode::STREAMING_FANOUT) {
 			D_ASSERT(op.working_table);
 			if (use_batch_index) {
-				lhs_batches = make_uniq<BatchedDataCollection>(context, op.working_table->Types(),
+				lhs_batches = make_uniq<BatchedDataCollection>(context.client, op.working_table->Types(),
 				                                               op.working_table->GetAllocatorType());
 			} else {
-				lhs_data = make_uniq<ColumnDataCollection>(context, op.working_table->Types());
+				lhs_data = make_uniq<ColumnDataCollection>(context.client, op.working_table->Types());
 				lhs_data->InitializeAppend(append_state);
 			}
 		}
 		if (execution_mode != CTEExecutionMode::MATERIALIZED) {
 			D_ASSERT(op.exchange);
-			exchange_state = op.exchange->GetLocalState(context);
+			D_ASSERT(context.pipeline);
+			exchange_state = op.exchange->GetLocalState(context.client, context.pipeline->GetBaseBatchIndex());
 		}
 	}
 
@@ -262,7 +262,7 @@ unique_ptr<GlobalSinkState> PhysicalCTE::GetGlobalSinkState(ClientContext &conte
 }
 
 unique_ptr<LocalSinkState> PhysicalCTE::GetLocalSinkState(ExecutionContext &context) const {
-	auto state = make_uniq<CTELocalState>(context.client, *this);
+	auto state = make_uniq<CTELocalState>(context, *this);
 	return std::move(state);
 }
 
@@ -374,6 +374,11 @@ void PhysicalCTE::BuildPipelines(Pipeline &current, MetaPipeline &meta_pipeline)
 	    current, *this, MetaPipelineType::REGULAR,
 	    exchange ? MetaPipelineDependencyMode::NO_DEPENDENCY : MetaPipelineDependencyMode::ADD_DEPENDENCY);
 	child_meta_pipeline.Build(children[0]);
+	if (exchange) {
+		vector<shared_ptr<Pipeline>> producer_pipelines;
+		child_meta_pipeline.GetPipelines(producer_pipelines, false);
+		exchange->SetProducerPipelines(producer_pipelines);
+	}
 
 	for (auto &cte_scan : cte_scans) {
 		state.cte_dependencies.insert(make_pair(cte_scan, reference<Pipeline>(*child_meta_pipeline.GetBasePipeline())));

--- a/src/execution/operator/set/physical_cte.cpp
+++ b/src/execution/operator/set/physical_cte.cpp
@@ -414,7 +414,7 @@ void PhysicalCTE::BuildPipelines(Pipeline &current, MetaPipeline &meta_pipeline)
 	}
 	if (last_child_ptr) {
 		meta_pipeline.AddRecursiveDependencies(side_effect_pipelines, *last_child_ptr, RecursiveDependencyMode::FORCE,
-		                                       exchange ? DataflowDependencyMode::SKIP
+		                                       exchange ? DataflowDependencyMode::SKIP_CONFLICTING
 		                                                : DataflowDependencyMode::INCLUDE);
 	}
 }

--- a/src/execution/operator/set/physical_recursive_cte_runtime.cpp
+++ b/src/execution/operator/set/physical_recursive_cte_runtime.cpp
@@ -170,7 +170,7 @@ public:
 	}
 
 	bool TaskBlockedOnResult() const override {
-		return pipeline_executor.RemainingSinkChunk();
+		return pipeline.IsStreamingResultPipeline() && pipeline_executor.RemainingSinkChunk();
 	}
 
 private:

--- a/src/execution/physical_operator.cpp
+++ b/src/execution/physical_operator.cpp
@@ -133,6 +133,12 @@ unique_ptr<GlobalSourceState> PhysicalOperator::GetGlobalSourceState(ClientConte
 	return make_uniq<GlobalSourceState>();
 }
 
+unique_ptr<GlobalSourceState>
+PhysicalOperator::GetGlobalSourceState(ClientContext &context, const OperatorPartitionInfo &partition_info) const {
+	(void)partition_info;
+	return GetGlobalSourceState(context);
+}
+
 // LCOV_EXCL_START
 SourceResultType PhysicalOperator::GetData(ExecutionContext &context, DataChunk &chunk,
                                            OperatorSourceInput &input) const {

--- a/src/execution/physical_plan/plan_column_data_get.cpp
+++ b/src/execution/physical_plan/plan_column_data_get.cpp
@@ -7,8 +7,9 @@ namespace duckdb {
 PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalColumnDataGet &op) {
 	D_ASSERT(op.children.empty());
 	D_ASSERT(op.collection);
+	op.ResolveOperatorTypes();
 	return Make<PhysicalColumnDataScan>(op.types, PhysicalOperatorType::COLUMN_DATA_SCAN, op.estimated_cardinality,
-	                                    std::move(op.collection));
+	                                    std::move(op.collection), op.GetColumnIds());
 }
 
 } // namespace duckdb

--- a/src/execution/physical_plan/plan_cte.cpp
+++ b/src/execution/physical_plan/plan_cte.cpp
@@ -28,23 +28,29 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalMaterializedCTE &op) 
 
 	// Create the working_table that the PhysicalCTE will use for evaluation.
 	auto working_table = make_shared_ptr<ColumnDataCollection>(context, op.children[0]->types);
+
+	// Add the ColumnDataCollection to the context of this PhysicalPlanGenerator
+	recursive_cte_tables[op.table_index] = working_table;
+	materialized_ctes[op.table_index] = vector<const_reference<PhysicalOperator>>();
+
+	// Create the plan for the left side. This is the materialization.
+	auto &left = CreatePlan(*op.children[0]);
+	const auto cte_body_order = OrderPreservationRecursive(left);
+	const auto preserve_cte_order = !cte_body_has_side_effects && PreserveInsertionOrder(left);
+	const auto use_batch_index = preserve_cte_order && UseBatchIndex(left);
+	const auto source_order = preserve_cte_order ? cte_body_order : OrderPreservationType::NO_ORDER;
+	materialized_cte_orders[op.table_index] = source_order;
+
 	shared_ptr<PipelineBroadcastExchange> exchange;
 	if (use_exchange) {
 		auto completion_mode = cte_body_has_side_effects
 		                           ? PipelineBroadcastExchangeCompletionMode::RUN_TO_COMPLETION
 		                           : PipelineBroadcastExchangeCompletionMode::STOP_WHEN_UNCONSUMED;
-		exchange = make_shared_ptr<PipelineBroadcastExchange>(context, op.children[0]->types, completion_mode);
-	}
-
-	// Add the ColumnDataCollection to the context of this PhysicalPlanGenerator
-	recursive_cte_tables[op.table_index] = working_table;
-	if (exchange) {
+		exchange = make_shared_ptr<PipelineBroadcastExchange>(context, op.children[0]->types, completion_mode,
+		                                                     source_order, use_batch_index);
 		materialized_cte_exchanges[op.table_index] = exchange;
 	}
-	materialized_ctes[op.table_index] = vector<const_reference<PhysicalOperator>>();
 
-	// Create the plan for the left side. This is the materialization.
-	auto &left = CreatePlan(*op.children[0]);
 	// Initialize an empty vector to collect the scan operators.
 	auto &right = CreatePlan(*op.children[1]);
 
@@ -54,6 +60,9 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalMaterializedCTE &op) 
 	cast_cte.exchange = exchange;
 	cast_cte.cte_scans = materialized_ctes[op.table_index];
 	cast_cte.cte_body_has_side_effects = cte_body_has_side_effects;
+	cast_cte.preserve_order = preserve_cte_order;
+	cast_cte.use_batch_index = use_batch_index;
+	cast_cte.parallel = !preserve_cte_order || use_batch_index;
 	return cte;
 }
 

--- a/src/execution/physical_plan/plan_cte.cpp
+++ b/src/execution/physical_plan/plan_cte.cpp
@@ -47,7 +47,7 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalMaterializedCTE &op) 
 		                           ? PipelineBroadcastExchangeCompletionMode::RUN_TO_COMPLETION
 		                           : PipelineBroadcastExchangeCompletionMode::STOP_WHEN_UNCONSUMED;
 		exchange = make_shared_ptr<PipelineBroadcastExchange>(context, op.children[0]->types, completion_mode,
-		                                                     source_order, use_batch_index);
+		                                                      source_order, use_batch_index);
 		materialized_cte_exchanges[op.table_index] = exchange;
 	}
 

--- a/src/execution/physical_plan/plan_cte.cpp
+++ b/src/execution/physical_plan/plan_cte.cpp
@@ -36,7 +36,7 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalMaterializedCTE &op) 
 	// Create the plan for the left side. This is the materialization.
 	auto &left = CreatePlan(*op.children[0]);
 	const auto cte_body_order = OrderPreservationRecursive(left);
-	const auto preserve_cte_order = !cte_body_has_side_effects && PreserveInsertionOrder(left);
+	const auto preserve_cte_order = PreserveInsertionOrder(left);
 	const auto use_batch_index = preserve_cte_order && UseBatchIndex(left);
 	const auto source_order = preserve_cte_order ? cte_body_order : OrderPreservationType::NO_ORDER;
 	materialized_cte_orders[op.table_index] = source_order;

--- a/src/execution/physical_plan/plan_recursive_cte.cpp
+++ b/src/execution/physical_plan/plan_recursive_cte.cpp
@@ -113,25 +113,25 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalCTERef &op) {
 		auto &chunk_scan = Make<PhysicalColumnDataScan>(op.chunk_types, PhysicalOperatorType::CTE_SCAN,
 		                                                op.estimated_cardinality, op.cte_index);
 
+		auto cte = recursive_cte_tables.find(op.cte_index);
+		if (cte == recursive_cte_tables.end()) {
+			throw InvalidInputException("Referenced materialized CTE does not exist.");
+		}
+
 		auto &cast_chunk_scan = chunk_scan.Cast<PhysicalColumnDataScan>();
+		cast_chunk_scan.collection = cte->second.get();
+		auto cte_order = materialized_cte_orders.find(op.cte_index);
+		if (cte_order != materialized_cte_orders.end()) {
+			cast_chunk_scan.source_order = cte_order->second;
+		}
+
 		auto exchange = materialized_cte_exchanges.find(op.cte_index);
 		if (exchange != materialized_cte_exchanges.end()) {
-			auto cte = recursive_cte_tables.find(op.cte_index);
-			if (cte == recursive_cte_tables.end()) {
-				throw InvalidInputException("Referenced materialized CTE does not exist.");
-			}
 			// Exchange consumers can still be converted to materialized scans during pipeline construction.
-			cast_chunk_scan.collection = cte->second.get();
 			auto consumer_idx = exchange->second->RegisterConsumer();
 			auto &source = Make<PhysicalCTEConsumerSource>(op.chunk_types, op.estimated_cardinality, op.cte_index,
 			                                               exchange->second, consumer_idx);
 			cast_chunk_scan.cte_source = source;
-		} else {
-			auto cte = recursive_cte_tables.find(op.cte_index);
-			if (cte == recursive_cte_tables.end()) {
-				throw InvalidInputException("Referenced materialized CTE does not exist.");
-			}
-			cast_chunk_scan.collection = cte->second.get();
 		}
 		materialized_cte->second.push_back(cast_chunk_scan);
 		return chunk_scan;

--- a/src/include/duckdb/common/enum_util.hpp
+++ b/src/include/duckdb/common/enum_util.hpp
@@ -396,6 +396,8 @@ enum class PhysicalType : uint8_t;
 
 enum class PipelineBroadcastExchangeConsumerMode : uint8_t;
 
+enum class PipelineBroadcastExchangeOrderMode : uint8_t;
+
 enum class PipelineInputMode : uint8_t;
 
 enum class PragmaType : uint8_t;
@@ -1140,6 +1142,9 @@ const char* EnumUtil::ToChars<PhysicalType>(PhysicalType value);
 
 template<>
 const char* EnumUtil::ToChars<PipelineBroadcastExchangeConsumerMode>(PipelineBroadcastExchangeConsumerMode value);
+
+template<>
+const char* EnumUtil::ToChars<PipelineBroadcastExchangeOrderMode>(PipelineBroadcastExchangeOrderMode value);
 
 template<>
 const char* EnumUtil::ToChars<PipelineInputMode>(PipelineInputMode value);
@@ -1984,6 +1989,9 @@ PhysicalType EnumUtil::FromString<PhysicalType>(const char *value);
 
 template<>
 PipelineBroadcastExchangeConsumerMode EnumUtil::FromString<PipelineBroadcastExchangeConsumerMode>(const char *value);
+
+template<>
+PipelineBroadcastExchangeOrderMode EnumUtil::FromString<PipelineBroadcastExchangeOrderMode>(const char *value);
 
 template<>
 PipelineInputMode EnumUtil::FromString<PipelineInputMode>(const char *value);

--- a/src/include/duckdb/execution/operator/helper/physical_batch_collector.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_batch_collector.hpp
@@ -37,6 +37,10 @@ public:
 	bool ParallelSink() const override {
 		return true;
 	}
+
+	PipelineExternalInputSupport GetExternalInputSupport() const override {
+		return PipelineExternalInputSupport::SUPPORTED;
+	}
 };
 
 //===--------------------------------------------------------------------===//

--- a/src/include/duckdb/execution/operator/helper/physical_buffered_batch_collector.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_buffered_batch_collector.hpp
@@ -45,6 +45,10 @@ public:
 		return true;
 	}
 
+	PipelineExternalInputSupport GetExternalInputSupport() const override {
+		return PipelineExternalInputSupport::SUPPORTED;
+	}
+
 	bool IsStreaming() const override {
 		return true;
 	}

--- a/src/include/duckdb/execution/operator/persistent/physical_batch_copy_to_file.hpp
+++ b/src/include/duckdb/execution/operator/persistent/physical_batch_copy_to_file.hpp
@@ -58,9 +58,7 @@ public:
 	unique_ptr<GlobalSinkState> GetGlobalSinkState(ClientContext &context) const override;
 	SinkNextBatchType NextBatch(ExecutionContext &context, OperatorSinkNextBatchInput &input) const override;
 
-	OperatorPartitionInfo RequiredPartitionInfo() const override {
-		return OperatorPartitionInfo::BatchIndex();
-	}
+	OperatorPartitionInfo RequiredPartitionInfo() const override;
 
 	bool IsSink() const override {
 		return true;

--- a/src/include/duckdb/execution/operator/persistent/physical_batch_copy_to_file.hpp
+++ b/src/include/duckdb/execution/operator/persistent/physical_batch_copy_to_file.hpp
@@ -68,6 +68,10 @@ public:
 		return true;
 	}
 
+	PipelineExternalInputSupport GetExternalInputSupport() const override {
+		return PipelineExternalInputSupport::SUPPORTED;
+	}
+
 public:
 	void AddLocalBatch(ClientContext &context, GlobalSinkState &gstate, LocalSinkState &state) const;
 	void AddRawBatchData(ClientContext &context, GlobalSinkState &gstate_p, idx_t batch_index,

--- a/src/include/duckdb/execution/operator/persistent/physical_batch_insert.hpp
+++ b/src/include/duckdb/execution/operator/persistent/physical_batch_insert.hpp
@@ -35,6 +35,8 @@ public:
 	optional_ptr<SchemaCatalogEntry> schema;
 	//! Create table info, in case of CREATE TABLE AS
 	unique_ptr<BoundCreateTableInfo> info;
+	//! Preferred input batch size
+	optional_idx preferred_batch_size;
 
 public:
 	// Source interface
@@ -55,9 +57,7 @@ public:
 	SinkFinalizeType Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
 	                          OperatorSinkFinalizeInput &input) const override;
 
-	OperatorPartitionInfo RequiredPartitionInfo() const override {
-		return OperatorPartitionInfo::BatchIndex();
-	}
+	OperatorPartitionInfo RequiredPartitionInfo() const override;
 
 	bool IsSink() const override {
 		return true;

--- a/src/include/duckdb/execution/operator/persistent/physical_batch_insert.hpp
+++ b/src/include/duckdb/execution/operator/persistent/physical_batch_insert.hpp
@@ -67,6 +67,10 @@ public:
 		return true;
 	}
 
+	PipelineExternalInputSupport GetExternalInputSupport() const override {
+		return PipelineExternalInputSupport::SUPPORTED;
+	}
+
 private:
 	bool ExecuteTask(ClientContext &context, GlobalSinkState &gstate_p, LocalSinkState &lstate_p) const;
 	void ExecuteTasks(ClientContext &context, GlobalSinkState &gstate_p, LocalSinkState &lstate_p) const;

--- a/src/include/duckdb/execution/operator/scan/physical_column_data_scan.hpp
+++ b/src/include/duckdb/execution/operator/scan/physical_column_data_scan.hpp
@@ -22,6 +22,9 @@ public:
 public:
 	PhysicalColumnDataScan(PhysicalPlan &physical_plan, vector<LogicalType> types, PhysicalOperatorType op_type,
 	                       idx_t estimated_cardinality, optionally_owned_ptr<ColumnDataCollection> collection);
+	PhysicalColumnDataScan(PhysicalPlan &physical_plan, vector<LogicalType> types, PhysicalOperatorType op_type,
+	                       idx_t estimated_cardinality, optionally_owned_ptr<ColumnDataCollection> collection,
+	                       vector<column_t> column_ids);
 
 	PhysicalColumnDataScan(PhysicalPlan &physical_plan, vector<LogicalType> types, PhysicalOperatorType op_type,
 	                       idx_t estimated_cardinality, TableIndex cte_index);
@@ -29,12 +32,16 @@ public:
 	//! (optionally owned) column data collection to scan
 	optionally_owned_ptr<ColumnDataCollection> collection;
 	optional_ptr<PhysicalOperator> cte_source;
+	//! Column ids scanned from the underlying collection
+	vector<column_t> column_ids;
 
 	TableIndex cte_index;
 	optional_idx delim_index;
 
 public:
 	unique_ptr<GlobalSourceState> GetGlobalSourceState(ClientContext &context) const override;
+	unique_ptr<GlobalSourceState> GetGlobalSourceState(ClientContext &context,
+	                                                   const OperatorPartitionInfo &partition_info) const override;
 	unique_ptr<LocalSourceState> GetLocalSourceState(ExecutionContext &context,
 	                                                 GlobalSourceState &gstate) const override;
 	SourceResultType GetDataInternal(ExecutionContext &context, DataChunk &chunk,

--- a/src/include/duckdb/execution/operator/scan/physical_column_data_scan.hpp
+++ b/src/include/duckdb/execution/operator/scan/physical_column_data_scan.hpp
@@ -40,15 +40,25 @@ public:
 	SourceResultType GetDataInternal(ExecutionContext &context, DataChunk &chunk,
 	                                 OperatorSourceInput &input) const override;
 	ProgressData GetProgress(ClientContext &context, GlobalSourceState &gstate) const override;
+	OperatorPartitionData GetPartitionData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
+	                                       LocalSourceState &lstate,
+	                                       const OperatorPartitionInfo &partition_info) const override;
 
 	bool IsSource() const override {
 		return true;
+	}
+	bool SupportsPartitioning(const OperatorPartitionInfo &partition_info) const override;
+
+	OrderPreservationType SourceOrder() const override {
+		return source_order;
 	}
 
 	InsertionOrderPreservingMap<string> ParamsToString() const override;
 	bool ParallelSource() const override {
 		return true;
 	}
+
+	OrderPreservationType source_order = OrderPreservationType::INSERTION_ORDER;
 
 public:
 	void BuildPipelines(Pipeline &current, MetaPipeline &meta_pipeline) override;

--- a/src/include/duckdb/execution/operator/set/physical_cte.hpp
+++ b/src/include/duckdb/execution/operator/set/physical_cte.hpp
@@ -29,6 +29,8 @@ public:
 	                          TableIndex cte_index, shared_ptr<PipelineBroadcastExchange> exchange, idx_t consumer_idx);
 
 	unique_ptr<GlobalSourceState> GetGlobalSourceState(ClientContext &context) const override;
+	unique_ptr<GlobalSourceState> GetGlobalSourceState(ClientContext &context,
+	                                                   const OperatorPartitionInfo &partition_info) const override;
 	unique_ptr<LocalSourceState> GetLocalSourceState(ExecutionContext &context,
 	                                                 GlobalSourceState &gstate) const override;
 	SourceResultType GetDataInternal(ExecutionContext &context, DataChunk &chunk,
@@ -76,6 +78,8 @@ public:
 	bool preserve_order = false;
 	bool use_batch_index = false;
 	bool parallel = true;
+	optional_idx preferred_batch_size;
+	bool conflicting_batch_sizes = false;
 
 public:
 	// Sink interface
@@ -98,7 +102,8 @@ public:
 	}
 
 	OperatorPartitionInfo RequiredPartitionInfo() const override {
-		return use_batch_index ? OperatorPartitionInfo::BatchIndex() : OperatorPartitionInfo::NoPartitionInfo();
+		return use_batch_index ? OperatorPartitionInfo::BatchIndex(preferred_batch_size)
+		                       : OperatorPartitionInfo::NoPartitionInfo();
 	}
 
 	bool SinkOrderDependent() const override {
@@ -114,12 +119,15 @@ public:
 	void BuildPipelines(Pipeline &current, MetaPipeline &meta_pipeline) override;
 	bool TryRegisterDirectConsumer(Pipeline &pipeline, idx_t consumer_idx);
 	bool ShouldUseBufferedConsumer(Pipeline &pipeline) const;
-	void RegisterBufferedConsumer(idx_t consumer_idx);
+	void RegisterBufferedConsumer(Pipeline &pipeline, idx_t consumer_idx);
 	void RegisterMaterializedConsumer(idx_t consumer_idx);
 	CTEExecutionMode GetExecutionMode() const;
 	bool UseStreamingExchange() const;
 
 	vector<const_reference<PhysicalOperator>> GetSources() const override;
+
+private:
+	void RegisterBatchPreference(Pipeline &pipeline);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/execution/operator/set/physical_cte.hpp
+++ b/src/include/duckdb/execution/operator/set/physical_cte.hpp
@@ -33,16 +33,19 @@ public:
 	                                                 GlobalSourceState &gstate) const override;
 	SourceResultType GetDataInternal(ExecutionContext &context, DataChunk &chunk,
 	                                 OperatorSourceInput &input) const override;
+	OperatorPartitionData GetPartitionData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
+	                                       LocalSourceState &lstate,
+	                                       const OperatorPartitionInfo &partition_info) const override;
 	ProgressData GetProgress(ClientContext &context, GlobalSourceState &gstate) const override;
 	void SourceFinished(ClientContext &context, GlobalSourceState &gstate) const override;
+	bool SupportsPartitioning(const OperatorPartitionInfo &partition_info) const override;
+	OrderPreservationType SourceOrder() const override;
 
 	bool IsSource() const override {
 		return true;
 	}
 
-	bool ParallelSource() const override {
-		return true;
-	}
+	bool ParallelSource() const override;
 
 	InsertionOrderPreservingMap<string> ParamsToString() const override;
 
@@ -70,6 +73,9 @@ public:
 	Identifier ctename;
 	bool cte_body_has_side_effects = false;
 	CTEPipelineSelectionState pipeline_selection_state = CTEPipelineSelectionState::UNRESOLVED;
+	bool preserve_order = false;
+	bool use_batch_index = false;
+	bool parallel = true;
 
 public:
 	// Sink interface
@@ -79,6 +85,7 @@ public:
 	unique_ptr<LocalSinkState> GetLocalSinkState(ExecutionContext &context) const override;
 
 	SinkCombineResultType Combine(ExecutionContext &context, OperatorSinkCombineInput &input) const override;
+	SinkNextBatchType NextBatch(ExecutionContext &context, OperatorSinkNextBatchInput &input) const override;
 	SinkFinalizeType Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
 	                          OperatorSinkFinalizeInput &input) const override;
 
@@ -87,11 +94,15 @@ public:
 	}
 
 	bool ParallelSink() const override {
-		return true;
+		return parallel;
+	}
+
+	OperatorPartitionInfo RequiredPartitionInfo() const override {
+		return use_batch_index ? OperatorPartitionInfo::BatchIndex() : OperatorPartitionInfo::NoPartitionInfo();
 	}
 
 	bool SinkOrderDependent() const override {
-		return false;
+		return preserve_order;
 	}
 
 	InsertionOrderPreservingMap<string> ParamsToString() const override;

--- a/src/include/duckdb/execution/partition_info.hpp
+++ b/src/include/duckdb/execution/partition_info.hpp
@@ -41,18 +41,22 @@ struct OperatorPartitionInfo {
 	OperatorPartitionInfo() = default;
 	explicit OperatorPartitionInfo(bool batch_index) : batch_index(batch_index) {
 	}
+	OperatorPartitionInfo(bool batch_index, optional_idx preferred_batch_size)
+	    : batch_index(batch_index), preferred_batch_size(preferred_batch_size) {
+	}
 	explicit OperatorPartitionInfo(vector<column_t> partition_columns_p)
 	    : partition_columns(std::move(partition_columns_p)) {
 	}
 
 	bool batch_index = false;
+	optional_idx preferred_batch_size;
 	vector<column_t> partition_columns;
 
 	static OperatorPartitionInfo NoPartitionInfo() {
 		return OperatorPartitionInfo(false);
 	}
-	static OperatorPartitionInfo BatchIndex() {
-		return OperatorPartitionInfo(true);
+	static OperatorPartitionInfo BatchIndex(optional_idx preferred_batch_size = optional_idx()) {
+		return OperatorPartitionInfo(true, preferred_batch_size);
 	}
 	static OperatorPartitionInfo PartitionColumns(vector<column_t> columns) {
 		return OperatorPartitionInfo(std::move(columns));

--- a/src/include/duckdb/execution/physical_operator.hpp
+++ b/src/include/duckdb/execution/physical_operator.hpp
@@ -138,6 +138,8 @@ public:
 	virtual unique_ptr<LocalSourceState> GetLocalSourceState(ExecutionContext &context,
 	                                                         GlobalSourceState &gstate) const;
 	virtual unique_ptr<GlobalSourceState> GetGlobalSourceState(ClientContext &context) const;
+	virtual unique_ptr<GlobalSourceState> GetGlobalSourceState(ClientContext &context,
+	                                                           const OperatorPartitionInfo &partition_info) const;
 
 protected:
 	virtual SourceResultType GetDataInternal(ExecutionContext &context, DataChunk &chunk,

--- a/src/include/duckdb/execution/physical_plan_generator.hpp
+++ b/src/include/duckdb/execution/physical_plan_generator.hpp
@@ -81,6 +81,7 @@ public:
 	unordered_map<TableIndex, shared_ptr<ColumnDataCollection>> recurring_cte_tables;
 	//! Materialized CTE ids must be collected.
 	unordered_map<TableIndex, vector<const_reference<PhysicalOperator>>> materialized_ctes;
+	unordered_map<TableIndex, OrderPreservationType> materialized_cte_orders;
 	//! The index for duplicate eliminated joins.
 	idx_t delim_index = 0;
 	//! Tracks whether we are planning the recursive member of a recursive CTE.

--- a/src/include/duckdb/optimizer/remove_unused_columns.hpp
+++ b/src/include/duckdb/optimizer/remove_unused_columns.hpp
@@ -22,6 +22,7 @@ namespace duckdb {
 class Binder;
 class BoundColumnRefExpression;
 class ClientContext;
+class LogicalColumnDataGet;
 class Optimizer;
 
 struct ReferencedExtractComponent {
@@ -148,6 +149,7 @@ private:
 private:
 	template <class T>
 	void ClearUnusedExpressions(vector<T> &list, TableIndex table_idx, bool replace = true);
+	void RemoveColumnsFromLogicalColumnDataGet(LogicalColumnDataGet &get);
 	void RemoveColumnsFromLogicalGet(LogicalGet &get, unique_ptr<LogicalOperator> &op_ref);
 	void CheckPushdownExtract(LogicalOperator &op);
 	void RewriteExpressions(LogicalProjection &proj, idx_t expression_count);

--- a/src/include/duckdb/parallel/meta_pipeline.hpp
+++ b/src/include/duckdb/parallel/meta_pipeline.hpp
@@ -20,7 +20,7 @@ enum class MetaPipelineType : uint8_t {
 
 enum class MetaPipelineDependencyMode : uint8_t { ADD_DEPENDENCY, NO_DEPENDENCY };
 enum class RecursiveDependencyMode : uint8_t { RESPECT_PARALLELISM, FORCE };
-enum class DataflowDependencyMode : uint8_t { INCLUDE, SKIP };
+enum class DataflowDependencyMode : uint8_t { INCLUDE, SKIP_CONFLICTING };
 
 //! MetaPipeline represents a set of pipelines that all have the same sink
 class MetaPipeline : public enable_shared_from_this<MetaPipeline> {

--- a/src/include/duckdb/parallel/pipeline.hpp
+++ b/src/include/duckdb/parallel/pipeline.hpp
@@ -148,10 +148,18 @@ public:
 	bool IsExternalInput() const {
 		return input_mode == PipelineInputMode::EXTERNAL_INPUT;
 	}
+	void SetExternalStreamingResultProducer() {
+		external_streaming_result_producer = true;
+	}
+	bool IsStreamingResultPipeline() const;
 	void SetExternalInputEvent(const shared_ptr<Event> &event);
 	void CompleteExternalInput();
-	bool CanUseExternalInput() const;
+	bool CanUseExternalInput(const OperatorPartitionInfo &source_partition_info) const;
 	bool CanStopSourceEarly() const;
+
+	idx_t GetBaseBatchIndex() const {
+		return base_batch_index;
+	}
 
 	//! Registers a new batch index for a pipeline executor - returns the current minimum batch index
 	idx_t RegisterNewBatchIndex();
@@ -189,6 +197,8 @@ private:
 	idx_t base_batch_index = 0;
 	//! How this pipeline receives input chunks
 	PipelineInputMode input_mode = PipelineInputMode::SCHEDULED_SOURCE;
+	//! Whether this pipeline directly feeds a streaming result collector
+	bool external_streaming_result_producer = false;
 	//! Event that represents execution of an externally fed pipeline
 	weak_ptr<Event> external_input_event DUCKDB_GUARDED_BY(external_input_lock);
 	ExternalInputEventState external_input_event_state DUCKDB_GUARDED_BY(external_input_lock) =

--- a/src/include/duckdb/parallel/pipeline.hpp
+++ b/src/include/duckdb/parallel/pipeline.hpp
@@ -42,6 +42,7 @@ public:
 
 	Pipeline &pipeline;
 	unique_ptr<PipelineExecutor> pipeline_executor;
+	optional_idx reserved_batch_index;
 
 	string TaskType() const override {
 		return "PipelineTask";

--- a/src/include/duckdb/parallel/pipeline_broadcast_exchange.hpp
+++ b/src/include/duckdb/parallel/pipeline_broadcast_exchange.hpp
@@ -12,8 +12,10 @@
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/deque.hpp"
 #include "duckdb/common/enums/operator_result_type.hpp"
+#include "duckdb/common/enums/order_preservation_type.hpp"
 #include "duckdb/common/mutex.hpp"
 #include "duckdb/common/types/data_chunk.hpp"
+#include "duckdb/execution/partition_info.hpp"
 #include "duckdb/execution/progress_data.hpp"
 #include "duckdb/parallel/interrupt.hpp"
 
@@ -26,6 +28,7 @@ class PipelineExecutor;
 class PhysicalOperator;
 
 enum class PipelineBroadcastExchangeCompletionMode : uint8_t { STOP_WHEN_UNCONSUMED, RUN_TO_COMPLETION };
+enum class PipelineBroadcastExchangeOrderMode : uint8_t { UNORDERED, SEQUENTIAL, BATCH_INDEX };
 enum class PipelineBroadcastExchangeLocalMode : uint8_t { DIRECT_ONLY, BUFFERED };
 enum class PipelineBroadcastExchangeDirectPushState : uint8_t { NOT_STARTED, RESUMING, ACTIVE, FINISHED };
 enum class PipelineBroadcastExchangeConsumerMode : uint8_t { UNRESOLVED, BUFFERED, DIRECT, MATERIALIZED };
@@ -66,13 +69,23 @@ class PipelineBroadcastExchange {
 
 public:
 	PipelineBroadcastExchange(ClientContext &context, vector<LogicalType> types_p,
-	                          PipelineBroadcastExchangeCompletionMode completion_mode_p);
+	                          PipelineBroadcastExchangeCompletionMode completion_mode_p,
+	                          OrderPreservationType source_order_p, bool use_batch_index_p);
 
 	const vector<LogicalType> &Types() const {
 		return types;
 	}
 	bool RunToCompletion() const {
 		return completion_mode == PipelineBroadcastExchangeCompletionMode::RUN_TO_COMPLETION;
+	}
+	bool PreservesOrder() const {
+		return order_mode != PipelineBroadcastExchangeOrderMode::UNORDERED;
+	}
+	bool SupportsBatchIndex() const {
+		return order_mode == PipelineBroadcastExchangeOrderMode::BATCH_INDEX;
+	}
+	OrderPreservationType SourceOrder() const {
+		return source_order;
 	}
 
 	unique_ptr<PipelineBroadcastExchangeLocalState> GetLocalState(ClientContext &context) const;
@@ -86,15 +99,17 @@ public:
 	void SetLogOperator(const PhysicalOperator &op);
 
 	SinkResultType Push(DataChunk &chunk, PipelineBroadcastExchangeLocalState &lstate,
-	                    const InterruptState &interrupt_state);
+	                    const SourcePartitionInfo &partition_info, const InterruptState &interrupt_state);
+	SinkNextBatchType NextBatch(const SourcePartitionInfo &partition_info, const InterruptState &interrupt_state);
 	SinkCombineResultType FinishLocal(PipelineBroadcastExchangeLocalState &lstate,
+	                                  const SourcePartitionInfo &partition_info,
 	                                  const InterruptState &interrupt_state);
 	void Finish();
 	void FinishDirectConsumers();
 	void Cancel();
 
 	SourceResultType Scan(idx_t consumer_idx, DataChunk &chunk, shared_ptr<DataChunk> &current_chunk,
-	                      const InterruptState &interrupt_state);
+	                      optional_idx &batch_index, const InterruptState &interrupt_state);
 	void UnregisterConsumer(idx_t consumer_idx);
 
 	ProgressData ScanProgress(idx_t consumer_idx, idx_t estimated_cardinality) const;
@@ -120,7 +135,7 @@ private:
 	enum class WatermarkState : uint8_t { BELOW_HIGH_WATERMARK, ABOVE_HIGH_WATERMARK };
 	enum class WriterWakeMode : uint8_t { LOW_WATERMARK, FORCE };
 	enum class AppendAdmission : uint8_t { READY, BLOCKED, UNCONSUMED, CANCELLED };
-	enum class BufferedPushState : uint8_t { NOT_REQUIRED, APPENDED, BLOCKED, UNCONSUMED, CANCELLED };
+	enum class BufferedPushState : uint8_t { NOT_REQUIRED, APPENDED, STAGED, BLOCKED, UNCONSUMED, CANCELLED };
 	enum class ExchangeLogEvent : uint8_t {
 		SPOOL_CREATED,
 		HIGH_WATERMARK_BLOCKED,
@@ -155,7 +170,9 @@ public:
 	~PipelineBroadcastExchange();
 
 private:
-	BufferedPushState Append(DataChunk &chunk, const InterruptState &interrupt_state);
+	BufferedPushState Append(DataChunk &chunk, idx_t batch_index, idx_t min_batch_index,
+	                         const InterruptState &interrupt_state);
+	BufferedPushState FlushReadyBatches(idx_t min_batch_index, const InterruptState &interrupt_state);
 	SinkResultType CompletePush(DataChunk &chunk, PipelineBroadcastExchangeLocalState &lstate,
 	                            BufferedPushState buffered_state);
 	void RecordProducedRows(idx_t count);
@@ -167,16 +184,21 @@ private:
 	PipelineBroadcastExchangeConsumerSummary GetConsumerSummaryLocked() const DUCKDB_REQUIRES(lock);
 	AppendAdmission PrepareAppendLocked(const InterruptState &interrupt_state, vector<ExchangeLogEntry> &log_entries)
 	    DUCKDB_REQUIRES(lock);
-	AppendAdmission ReserveAppendLocked(const InterruptState &interrupt_state, AppendReservation &reservation,
+	AppendAdmission ReserveAppendLocked(idx_t batch_index, const InterruptState &interrupt_state,
+	                                    AppendReservation &reservation,
 	                                    vector<ExchangeLogEntry> &log_entries) DUCKDB_REQUIRES(lock);
+	AppendAdmission PrepareStageLocked(idx_t batch_index, const InterruptState &interrupt_state,
+	                                   vector<ExchangeLogEntry> &log_entries) DUCKDB_REQUIRES(lock);
 	BufferedPushState CompleteAppendLocked(const AppendReservation &reservation, shared_ptr<DataChunk> copy,
-	                                       idx_t row_count, vector<InterruptState> &readers,
+	                                       idx_t row_count, bool record_produced_rows,
+	                                       vector<InterruptState> &readers,
 	                                       vector<InterruptState> &appenders, vector<ExchangeLogEntry> &log_entries)
 	    DUCKDB_REQUIRES(lock);
 	void AbortAppendReservation(vector<InterruptState> &readers, vector<InterruptState> &writers,
 	                            vector<InterruptState> &appenders) DUCKDB_REQUIRES(lock);
 	SourceResultType ReserveScanLocked(idx_t consumer_idx, const InterruptState &interrupt_state,
-	                                   shared_ptr<DataChunk> &next_chunk, SpoolReadReservation &spool_read,
+	                                   shared_ptr<DataChunk> &next_chunk, optional_idx &batch_index,
+	                                   SpoolReadReservation &spool_read,
 	                                   vector<InterruptState> &writers, vector<ExchangeLogEntry> &log_entries)
 	    DUCKDB_REQUIRES(lock);
 	void CompleteSpoolReadLocked(idx_t consumer_idx, const SpoolReadReservation &spool_read, DataChunk &chunk,
@@ -200,6 +222,8 @@ private:
 	ClientContext &context;
 	vector<LogicalType> types;
 	PipelineBroadcastExchangeCompletionMode completion_mode;
+	PipelineBroadcastExchangeOrderMode order_mode;
+	OrderPreservationType source_order;
 	idx_t max_threads;
 	unique_ptr<BufferState> buffer;
 

--- a/src/include/duckdb/parallel/pipeline_broadcast_exchange.hpp
+++ b/src/include/duckdb/parallel/pipeline_broadcast_exchange.hpp
@@ -56,13 +56,17 @@ private:
 	friend class PipelineBroadcastExchange;
 	SinkResultType Push(DataChunk &chunk, const SourcePartitionInfo &partition_info,
 	                    const InterruptState &interrupt_state);
+	SinkNextBatchType NextBatch(const SourcePartitionInfo &partition_info, const InterruptState &interrupt_state);
 	SinkCombineResultType Finish(const SourcePartitionInfo &partition_info, const InterruptState &interrupt_state);
 	bool HasDirectConsumers() const;
 	bool DirectConsumersFinished() const;
 	void ResetPush();
+	OperatorPartitionData GetSourcePartitionData(const SourcePartitionInfo &partition_info) const;
+	optional_idx GetSourceMinBatchIndex(const SourcePartitionInfo &partition_info) const;
 
 	vector<unique_ptr<PipelineExecutor>> direct_executors;
 	idx_t direct_idx = 0;
+	idx_t direct_next_batch_idx = 0;
 	idx_t direct_finalize_idx = 0;
 	idx_t producer_base_batch_index;
 	bool supports_batch_index;
@@ -112,7 +116,8 @@ public:
 
 	SinkResultType Push(DataChunk &chunk, PipelineBroadcastExchangeLocalState &lstate,
 	                    const SourcePartitionInfo &partition_info, const InterruptState &interrupt_state);
-	SinkNextBatchType NextBatch(const SourcePartitionInfo &partition_info, const InterruptState &interrupt_state);
+	SinkNextBatchType NextBatch(PipelineBroadcastExchangeLocalState &lstate, const SourcePartitionInfo &partition_info,
+	                            const InterruptState &interrupt_state);
 	SinkCombineResultType FinishLocal(PipelineBroadcastExchangeLocalState &lstate,
 	                                  const SourcePartitionInfo &partition_info, const InterruptState &interrupt_state);
 	void Finish();

--- a/src/include/duckdb/parallel/pipeline_broadcast_exchange.hpp
+++ b/src/include/duckdb/parallel/pipeline_broadcast_exchange.hpp
@@ -102,8 +102,7 @@ public:
 	                    const SourcePartitionInfo &partition_info, const InterruptState &interrupt_state);
 	SinkNextBatchType NextBatch(const SourcePartitionInfo &partition_info, const InterruptState &interrupt_state);
 	SinkCombineResultType FinishLocal(PipelineBroadcastExchangeLocalState &lstate,
-	                                  const SourcePartitionInfo &partition_info,
-	                                  const InterruptState &interrupt_state);
+	                                  const SourcePartitionInfo &partition_info, const InterruptState &interrupt_state);
 	void Finish();
 	void FinishDirectConsumers();
 	void Cancel();
@@ -185,22 +184,20 @@ private:
 	AppendAdmission PrepareAppendLocked(const InterruptState &interrupt_state, vector<ExchangeLogEntry> &log_entries)
 	    DUCKDB_REQUIRES(lock);
 	AppendAdmission ReserveAppendLocked(idx_t batch_index, const InterruptState &interrupt_state,
-	                                    AppendReservation &reservation,
-	                                    vector<ExchangeLogEntry> &log_entries) DUCKDB_REQUIRES(lock);
+	                                    AppendReservation &reservation, vector<ExchangeLogEntry> &log_entries)
+	    DUCKDB_REQUIRES(lock);
 	AppendAdmission PrepareStageLocked(idx_t batch_index, const InterruptState &interrupt_state,
 	                                   vector<ExchangeLogEntry> &log_entries) DUCKDB_REQUIRES(lock);
 	BufferedPushState CompleteAppendLocked(const AppendReservation &reservation, shared_ptr<DataChunk> copy,
-	                                       idx_t row_count, bool record_produced_rows,
-	                                       vector<InterruptState> &readers,
+	                                       idx_t row_count, bool record_produced_rows, vector<InterruptState> &readers,
 	                                       vector<InterruptState> &appenders, vector<ExchangeLogEntry> &log_entries)
 	    DUCKDB_REQUIRES(lock);
 	void AbortAppendReservation(vector<InterruptState> &readers, vector<InterruptState> &writers,
 	                            vector<InterruptState> &appenders) DUCKDB_REQUIRES(lock);
 	SourceResultType ReserveScanLocked(idx_t consumer_idx, const InterruptState &interrupt_state,
 	                                   shared_ptr<DataChunk> &next_chunk, optional_idx &batch_index,
-	                                   SpoolReadReservation &spool_read,
-	                                   vector<InterruptState> &writers, vector<ExchangeLogEntry> &log_entries)
-	    DUCKDB_REQUIRES(lock);
+	                                   SpoolReadReservation &spool_read, vector<InterruptState> &writers,
+	                                   vector<ExchangeLogEntry> &log_entries) DUCKDB_REQUIRES(lock);
 	void CompleteSpoolReadLocked(idx_t consumer_idx, const SpoolReadReservation &spool_read, DataChunk &chunk,
 	                             vector<InterruptState> &readers, vector<InterruptState> &writers,
 	                             vector<ExchangeLogEntry> &log_entries) DUCKDB_REQUIRES(lock);

--- a/src/include/duckdb/parallel/pipeline_broadcast_exchange.hpp
+++ b/src/include/duckdb/parallel/pipeline_broadcast_exchange.hpp
@@ -48,12 +48,14 @@ struct PipelineBroadcastExchangeConsumerSummary {
 
 class PipelineBroadcastExchangeLocalState {
 public:
-	PipelineBroadcastExchangeLocalState(ClientContext &context, const PipelineBroadcastExchange &exchange);
+	PipelineBroadcastExchangeLocalState(ClientContext &context, const PipelineBroadcastExchange &exchange,
+	                                    idx_t producer_base_batch_index);
 	~PipelineBroadcastExchangeLocalState();
 
 private:
 	friend class PipelineBroadcastExchange;
-	SinkResultType Push(DataChunk &chunk, const InterruptState &interrupt_state);
+	SinkResultType Push(DataChunk &chunk, const SourcePartitionInfo &partition_info,
+	                    const InterruptState &interrupt_state);
 	SinkCombineResultType Finish(const InterruptState &interrupt_state);
 	bool HasDirectConsumers() const;
 	bool DirectConsumersFinished() const;
@@ -62,6 +64,8 @@ private:
 	vector<unique_ptr<PipelineExecutor>> direct_executors;
 	idx_t direct_idx = 0;
 	idx_t direct_finalize_idx = 0;
+	idx_t producer_base_batch_index;
+	bool supports_batch_index;
 	PipelineBroadcastExchangeLocalMode mode = PipelineBroadcastExchangeLocalMode::BUFFERED;
 	PipelineBroadcastExchangeDirectPushState direct_push_state = PipelineBroadcastExchangeDirectPushState::NOT_STARTED;
 };
@@ -93,9 +97,11 @@ public:
 		return source_order;
 	}
 
-	unique_ptr<PipelineBroadcastExchangeLocalState> GetLocalState(ClientContext &context) const;
+	unique_ptr<PipelineBroadcastExchangeLocalState> GetLocalState(ClientContext &context,
+	                                                              idx_t producer_base_batch_index) const;
 	shared_ptr<PipelineBroadcastExchangeScanState> GetScanState() const;
 
+	void SetProducerPipelines(const vector<shared_ptr<Pipeline>> &pipelines);
 	idx_t RegisterConsumer();
 	bool TryRegisterDirectConsumer(Pipeline &pipeline, idx_t consumer_idx);
 	void SelectBufferedConsumer(idx_t consumer_idx);
@@ -229,6 +235,7 @@ private:
 	PipelineBroadcastExchangeOrderMode order_mode;
 	OrderPreservationType source_order;
 	idx_t max_threads;
+	vector<reference<Pipeline>> producer_pipelines;
 	unique_ptr<BufferState> buffer;
 
 	mutable annotated_mutex lock;

--- a/src/include/duckdb/parallel/pipeline_broadcast_exchange.hpp
+++ b/src/include/duckdb/parallel/pipeline_broadcast_exchange.hpp
@@ -56,7 +56,7 @@ private:
 	friend class PipelineBroadcastExchange;
 	SinkResultType Push(DataChunk &chunk, const SourcePartitionInfo &partition_info,
 	                    const InterruptState &interrupt_state);
-	SinkCombineResultType Finish(const InterruptState &interrupt_state);
+	SinkCombineResultType Finish(const SourcePartitionInfo &partition_info, const InterruptState &interrupt_state);
 	bool HasDirectConsumers() const;
 	bool DirectConsumersFinished() const;
 	void ResetPush();

--- a/src/include/duckdb/parallel/pipeline_broadcast_exchange.hpp
+++ b/src/include/duckdb/parallel/pipeline_broadcast_exchange.hpp
@@ -14,6 +14,7 @@
 #include "duckdb/common/enums/operator_result_type.hpp"
 #include "duckdb/common/enums/order_preservation_type.hpp"
 #include "duckdb/common/mutex.hpp"
+#include "duckdb/common/set.hpp"
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/execution/partition_info.hpp"
 #include "duckdb/execution/progress_data.hpp"
@@ -24,6 +25,7 @@ namespace duckdb {
 class ClientContext;
 class Pipeline;
 class PipelineBroadcastExchange;
+class PipelineBroadcastExchangeScanState;
 class PipelineExecutor;
 class PhysicalOperator;
 
@@ -84,11 +86,15 @@ public:
 	bool SupportsBatchIndex() const {
 		return order_mode == PipelineBroadcastExchangeOrderMode::BATCH_INDEX;
 	}
+	PipelineBroadcastExchangeOrderMode OrderMode() const {
+		return order_mode;
+	}
 	OrderPreservationType SourceOrder() const {
 		return source_order;
 	}
 
 	unique_ptr<PipelineBroadcastExchangeLocalState> GetLocalState(ClientContext &context) const;
+	shared_ptr<PipelineBroadcastExchangeScanState> GetScanState() const;
 
 	idx_t RegisterConsumer();
 	bool TryRegisterDirectConsumer(Pipeline &pipeline, idx_t consumer_idx);
@@ -107,7 +113,7 @@ public:
 	void FinishDirectConsumers();
 	void Cancel();
 
-	SourceResultType Scan(idx_t consumer_idx, DataChunk &chunk, shared_ptr<DataChunk> &current_chunk,
+	SourceResultType Scan(idx_t consumer_idx, DataChunk &chunk, PipelineBroadcastExchangeScanState &scan_state,
 	                      optional_idx &batch_index, const InterruptState &interrupt_state);
 	void UnregisterConsumer(idx_t consumer_idx);
 
@@ -119,6 +125,8 @@ public:
 	PipelineBroadcastExchangeConsumerSummary GetConsumerSummary() const;
 
 private:
+	friend class PipelineBroadcastExchangeScanState;
+
 	struct ChunkPool;
 	struct BroadcastSpool;
 	struct BroadcastSpoolReader;
@@ -128,7 +136,6 @@ private:
 	struct BufferState;
 
 	enum class ConsumerLifecycle : uint8_t { ACTIVE, INACTIVE };
-	enum class ConsumerReadState : uint8_t { IDLE, READING };
 	enum class ProducerState : uint8_t { ACTIVE, FINISHED, CANCELLED };
 	enum class AppendReservationState : uint8_t { IDLE, RESERVED };
 	enum class WatermarkState : uint8_t { BELOW_HIGH_WATERMARK, ABOVE_HIGH_WATERMARK };
@@ -160,9 +167,8 @@ private:
 		idx_t rows_read = 0;
 		PipelineBroadcastExchangeConsumerMode mode = PipelineBroadcastExchangeConsumerMode::UNRESOLVED;
 		ConsumerLifecycle lifecycle = ConsumerLifecycle::ACTIVE;
-		ConsumerReadState read_state = ConsumerReadState::IDLE;
-		idx_t read_position = 0;
-		shared_ptr<BroadcastSpoolReader> shared_reader;
+		bool exhausted = false;
+		set<idx_t> in_flight_reads;
 	};
 
 public:
@@ -195,6 +201,7 @@ private:
 	void AbortAppendReservation(vector<InterruptState> &readers, vector<InterruptState> &writers,
 	                            vector<InterruptState> &appenders) DUCKDB_REQUIRES(lock);
 	SourceResultType ReserveScanLocked(idx_t consumer_idx, const InterruptState &interrupt_state,
+	                                   PipelineBroadcastExchangeScanState &scan_state,
 	                                   shared_ptr<DataChunk> &next_chunk, optional_idx &batch_index,
 	                                   SpoolReadReservation &spool_read, vector<InterruptState> &writers,
 	                                   vector<ExchangeLogEntry> &log_entries) DUCKDB_REQUIRES(lock);

--- a/src/include/duckdb/parallel/pipeline_executor.hpp
+++ b/src/include/duckdb/parallel/pipeline_executor.hpp
@@ -65,9 +65,10 @@ public:
 	//! Returns true if execution is finished, false if Execute should be called again
 	PipelineExecuteResult Execute(idx_t max_chunks);
 	//! Pushes a chunk from an external producer through this pipeline into the sink
-	PipelineExecuteResult PushExternal(DataChunk &input, const OperatorPartitionData &partition_data);
+	PipelineExecuteResult PushExternal(DataChunk &input, const OperatorPartitionData &partition_data,
+	                                   optional_idx source_min_batch_index);
 	//! Finalizes an externally-fed pipeline executor after the producer is exhausted
-	PipelineExecuteResult FinishExternal();
+	PipelineExecuteResult FinishExternal(optional_idx source_min_batch_index);
 
 	//! Called after depleting the source: finalizes the execution of this pipeline executor
 	//! This should only be called once per PipelineExecutor.
@@ -187,7 +188,8 @@ private:
 
 	//! Notifies the sink that a new batch has started
 	SinkNextBatchType NextBatch(DataChunk &source_chunk, const bool have_more_output);
-	SinkNextBatchType NextBatch(OperatorPartitionData next_data, bool force = false);
+	SinkNextBatchType NextBatch(OperatorPartitionData next_data, bool force = false,
+	                            optional_idx external_min_batch_index = optional_idx());
 	OperatorPartitionData ToPipelinePartitionData(const OperatorPartitionData &source_data) const;
 
 	//! Tries to flush all state from intermediate operators. Will return true if all state is flushed, false in the

--- a/src/include/duckdb/parallel/pipeline_executor.hpp
+++ b/src/include/duckdb/parallel/pipeline_executor.hpp
@@ -65,7 +65,7 @@ public:
 	//! Returns true if execution is finished, false if Execute should be called again
 	PipelineExecuteResult Execute(idx_t max_chunks);
 	//! Pushes a chunk from an external producer through this pipeline into the sink
-	PipelineExecuteResult PushExternal(DataChunk &input);
+	PipelineExecuteResult PushExternal(DataChunk &input, const OperatorPartitionData &partition_data);
 	//! Finalizes an externally-fed pipeline executor after the producer is exhausted
 	PipelineExecuteResult FinishExternal();
 
@@ -159,6 +159,8 @@ private:
 	bool should_flush_current_idx = true;
 	//! Whether this executor has already run at least once
 	bool has_executed = false;
+	//! Whether an externally-fed sink has observed its initial batch
+	bool external_batch_initialized = false;
 
 private:
 	void StartOperator(PhysicalOperator &op);
@@ -185,6 +187,8 @@ private:
 
 	//! Notifies the sink that a new batch has started
 	SinkNextBatchType NextBatch(DataChunk &source_chunk, const bool have_more_output);
+	SinkNextBatchType NextBatch(OperatorPartitionData next_data, bool force = false);
+	OperatorPartitionData ToPipelinePartitionData(const OperatorPartitionData &source_data) const;
 
 	//! Tries to flush all state from intermediate operators. Will return true if all state is flushed, false in the
 	//! case of a blocked sink.

--- a/src/include/duckdb/parallel/pipeline_executor.hpp
+++ b/src/include/duckdb/parallel/pipeline_executor.hpp
@@ -67,6 +67,11 @@ public:
 	//! Pushes a chunk from an external producer through this pipeline into the sink
 	PipelineExecuteResult PushExternal(DataChunk &input, const OperatorPartitionData &partition_data,
 	                                   optional_idx source_min_batch_index);
+	//! Advances an externally-fed pipeline to the producer's next batch
+	PipelineExecuteResult NextBatchExternal(const OperatorPartitionData &partition_data,
+	                                        optional_idx source_min_batch_index);
+	//! Completes the current batch of an externally-fed pipeline
+	PipelineExecuteResult FinishBatchExternal(optional_idx source_min_batch_index);
 	//! Finalizes an externally-fed pipeline executor after the producer is exhausted
 	PipelineExecuteResult FinishExternal(optional_idx source_min_batch_index);
 

--- a/src/include/duckdb/parallel/pipeline_executor.hpp
+++ b/src/include/duckdb/parallel/pipeline_executor.hpp
@@ -57,7 +57,7 @@ private:
 //! The Pipeline class represents an execution pipeline
 class PipelineExecutor {
 public:
-	PipelineExecutor(ClientContext &context, Pipeline &pipeline);
+	PipelineExecutor(ClientContext &context, Pipeline &pipeline, optional_idx reserved_batch_index = optional_idx());
 
 	//! Fully execute a pipeline with a source and a sink until the source is completely exhausted
 	PipelineExecuteResult Execute();

--- a/src/include/duckdb/planner/operator/logical_column_data_get.hpp
+++ b/src/include/duckdb/planner/operator/logical_column_data_get.hpp
@@ -32,10 +32,14 @@ public:
 	TableIndex table_index;
 	//! The types of the chunk
 	vector<LogicalType> chunk_types;
+	//! Column ids that are scanned from the collection
+	vector<column_t> column_ids;
 	//! (optionally owned) column data collection
 	optionally_owned_ptr<ColumnDataCollection> collection;
 
 public:
+	void SetColumnIds(vector<column_t> column_ids);
+	const vector<column_t> &GetColumnIds() const;
 	vector<ColumnBinding> GetColumnBindings() override;
 
 	void Serialize(Serializer &serializer) const override;
@@ -46,8 +50,12 @@ public:
 
 protected:
 	void ResolveTypes() override {
-		// types are resolved in the constructor
-		this->types = chunk_types;
+		types.clear();
+		types.reserve(column_ids.size());
+		for (auto column_id : column_ids) {
+			D_ASSERT(column_id < chunk_types.size());
+			types.push_back(chunk_types[column_id]);
+		}
 	}
 };
 } // namespace duckdb

--- a/src/include/duckdb/storage/serialization/logical_operator.json
+++ b/src/include/duckdb/storage/serialization/logical_operator.json
@@ -283,13 +283,19 @@
         "id": 202,
         "name": "collection",
         "type": "optionally_owned_ptr<ColumnDataCollection>"
+      },
+      {
+        "id": 203,
+        "name": "column_ids",
+        "type": "vector<column_t>"
       }
     ],
     "constructor": [
       "table_index",
       "chunk_types",
       "collection"
-    ]
+    ],
+    "custom_implementation": true
   },
   {
     "class": "LogicalDelimGet",

--- a/src/optimizer/common_subplan_optimizer.cpp
+++ b/src/optimizer/common_subplan_optimizer.cpp
@@ -8,6 +8,7 @@
 #include "duckdb/common/serializer/binary_serializer.hpp"
 #include "duckdb/common/arena_containers/arena_unordered_map.hpp"
 #include "duckdb/common/arena_containers/arena_vector.hpp"
+#include "duckdb/common/unordered_set.hpp"
 #include "duckdb/planner/filter/expression_filter.hpp"
 #include "duckdb/planner/column_binding_map.hpp"
 
@@ -91,6 +92,7 @@ private:
 			restore_original_table_index.clear();
 			restore_original_table_filter_index.clear();
 			column_ids.clear();
+			chunk_column_ids.clear();
 			projection_ids.clear();
 			table_indices.clear();
 			projection_maps.clear();
@@ -318,6 +320,39 @@ private:
 				break;
 			}
 		}
+		if (op.type == LogicalOperatorType::LOGICAL_CHUNK_GET) {
+			auto &get = op.Cast<LogicalColumnDataGet>();
+			switch (TYPE) {
+			case ConversionType::TO_CANONICAL: {
+				D_ASSERT(chunk_column_ids.empty());
+				chunk_column_ids = get.GetColumnIds();
+
+				unordered_set<column_t> selected_columns;
+				for (auto column_id : chunk_column_ids) {
+					if (!selected_columns.insert(column_id).second) {
+						return false;
+					}
+				}
+
+				// Expose all collection columns so pruning does not change the scan signature.
+				vector<column_t> all_column_ids;
+				all_column_ids.reserve(get.chunk_types.size());
+				for (idx_t column_id = 0; column_id < get.chunk_types.size(); column_id++) {
+					all_column_ids.push_back(column_id);
+				}
+				get.SetColumnIds(std::move(all_column_ids));
+
+				auto &column_index_map = table_index_map.at(table_indices[0]);
+				for (idx_t column_idx = 0; column_idx < chunk_column_ids.size(); column_idx++) {
+					column_index_map.Insert(ProjectionIndex(column_idx), ProjectionIndex(chunk_column_ids[column_idx]));
+				}
+				break;
+			}
+			case ConversionType::RESTORE_ORIGINAL:
+				get.SetColumnIds(std::move(chunk_column_ids));
+				break;
+			}
+		}
 		return true;
 	}
 
@@ -415,6 +450,7 @@ private:
 
 	//! Utility to temporarily store column ids, projection_ids, table indices, expression info and children
 	vector<ColumnIndex> column_ids;
+	vector<column_t> chunk_column_ids;
 	vector<ProjectionIndex> projection_ids;
 	vector<pair<string, optional_idx>> expression_info;
 	vector<unique_ptr<LogicalOperator>> children;

--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -15,6 +15,7 @@
 #include "duckdb/planner/expression_iterator.hpp"
 #include "duckdb/planner/filter/expression_filter.hpp"
 #include "duckdb/planner/operator/logical_aggregate.hpp"
+#include "duckdb/planner/operator/logical_column_data_get.hpp"
 #include "duckdb/planner/operator/logical_comparison_join.hpp"
 #include "duckdb/planner/operator/logical_distinct.hpp"
 #include "duckdb/planner/operator/logical_filter.hpp"
@@ -323,6 +324,12 @@ void RemoveUnusedColumns::VisitOperator(unique_ptr<LogicalOperator> &op_ref) {
 			RemoveUnusedColumns remove(*this, true);
 			remove.VisitOperator(op.children[0]);
 		}
+		return;
+	}
+	case LogicalOperatorType::LOGICAL_CHUNK_GET: {
+		LogicalOperatorVisitor::VisitOperatorExpressions(op);
+		auto &get = op.Cast<LogicalColumnDataGet>();
+		RemoveColumnsFromLogicalColumnDataGet(get);
 		return;
 	}
 	case LogicalOperatorType::LOGICAL_DISTINCT: {
@@ -731,6 +738,16 @@ void RemoveUnusedColumns::CheckPushdownExtract(LogicalOperator &op) {
 		throw InternalException("CheckPushdownExtract not supported for LogicalOperatorType::%s",
 		                        EnumUtil::ToString(op.type));
 	}
+}
+
+void RemoveUnusedColumns::RemoveColumnsFromLogicalColumnDataGet(LogicalColumnDataGet &get) {
+	if (everything_referenced) {
+		return;
+	}
+
+	auto column_ids = get.GetColumnIds();
+	ClearUnusedExpressions(column_ids, get.table_index);
+	get.SetColumnIds(std::move(column_ids));
 }
 
 void RemoveUnusedColumns::RemoveColumnsFromLogicalGet(LogicalGet &get, unique_ptr<LogicalOperator> &op_ref) {

--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -571,20 +571,9 @@ bool Executor::ResultCollectorIsBlocked() {
 	if (!HasStreamingResultCollector()) {
 		return false;
 	}
-	if (completed_pipelines + 1 != total_pipelines) {
-		// The result collector is always in the last pipeline
-		return false;
-	}
-	if (to_be_rescheduled_tasks.empty()) {
-		return false;
-	}
 	for (auto &kv : to_be_rescheduled_tasks) {
 		auto &task = kv.second;
 		if (task->TaskBlockedOnResult()) {
-			// At least one of the blocked tasks is connected to a result collector
-			// This task could be the only task that could unblock the other non-result-collector tasks
-			// To prevent a scenario where we halt indefinitely, we return here so it can be unblocked by a call to
-			// Fetch
 			return true;
 		}
 	}

--- a/src/parallel/meta_pipeline.cpp
+++ b/src/parallel/meta_pipeline.cpp
@@ -183,15 +183,26 @@ void MetaPipeline::AddRecursiveDependencies(const vector<shared_ptr<Pipeline>> &
 	const auto thread_count = TaskScheduler::GetScheduler(executor.context).NumberOfThreads();
 	for (; it != child_meta_pipelines.end(); it++) {
 		for (auto &pipeline : it->get()->pipelines) {
-			if (dataflow_mode == DataflowDependencyMode::SKIP && pipeline->HasDataflowDependencies()) {
-				continue;
-			}
 			if (dependency_mode == RecursiveDependencyMode::RESPECT_PARALLELISM &&
 			    !PipelineExceedsThreadCount(*pipeline, thread_count)) {
 				continue;
 			}
 			auto &pipeline_deps = pipeline_dependencies[*pipeline];
 			for (auto &new_dependency : new_dependencies) {
+				if (dataflow_mode == DataflowDependencyMode::SKIP_CONFLICTING) {
+					bool conflicts_with_dataflow = false;
+					for (auto &dataflow_dependency : pipeline->GetDataflowDependencies()) {
+						auto dependency = dataflow_dependency.lock();
+						D_ASSERT(dependency);
+						if (RefersToSameObject(*dependency, *new_dependency)) {
+							conflicts_with_dataflow = true;
+							break;
+						}
+					}
+					if (conflicts_with_dataflow) {
+						continue;
+					}
+				}
 				if (dependency_mode == RecursiveDependencyMode::RESPECT_PARALLELISM &&
 				    !PipelineExceedsThreadCount(*new_dependency, thread_count)) {
 					continue;

--- a/src/parallel/pipeline.cpp
+++ b/src/parallel/pipeline.cpp
@@ -236,6 +236,10 @@ bool Pipeline::CanUseExternalInput(const OperatorPartitionInfo &source_partition
 	if (required_partition_info.RequiresPartitionColumns()) {
 		return false;
 	}
+	if (required_partition_info.RequiresBatchIndex() && base_batch_index != 0) {
+		// Later ordered sink pipelines rely on pipeline dependencies to sequence their batch ranges.
+		return false;
+	}
 	if (required_partition_info.RequiresBatchIndex() && !source_partition_info.RequiresBatchIndex()) {
 		return false;
 	}

--- a/src/parallel/pipeline.cpp
+++ b/src/parallel/pipeline.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/common/tree_renderer/text_tree_renderer.hpp"
 #include "duckdb/execution/executor.hpp"
 #include "duckdb/execution/operator/aggregate/physical_ungrouped_aggregate.hpp"
+#include "duckdb/execution/operator/helper/physical_result_collector.hpp"
 #include "duckdb/execution/operator/scan/physical_table_scan.hpp"
 #include "duckdb/execution/operator/set/physical_recursive_cte.hpp"
 #include "duckdb/main/client_context.hpp"
@@ -25,9 +26,7 @@ PipelineTask::PipelineTask(Pipeline &pipeline_p, shared_ptr<Event> event_p)
 }
 
 bool PipelineTask::TaskBlockedOnResult() const {
-	// If this returns true, it means the pipeline this task belongs to has a cached chunk
-	// that was the result of the Sink method returning BLOCKED
-	return pipeline_executor->RemainingSinkChunk();
+	return pipeline.IsStreamingResultPipeline() && pipeline_executor->RemainingSinkChunk();
 }
 
 const PipelineExecutor &PipelineTask::GetPipelineExecutor() const {
@@ -218,14 +217,26 @@ void Pipeline::SetExternalInput() {
 	external_input_event_state = ExternalInputEventState::EXTERNAL_INPUT_UNSET;
 }
 
-bool Pipeline::CanUseExternalInput() const {
+bool Pipeline::IsStreamingResultPipeline() const {
+	if (external_streaming_result_producer) {
+		return true;
+	}
+	return sink && sink->type == PhysicalOperatorType::RESULT_COLLECTOR &&
+	       sink->Cast<PhysicalResultCollector>().IsStreaming();
+}
+
+bool Pipeline::CanUseExternalInput(const OperatorPartitionInfo &source_partition_info) const {
 	if (!sink || !sink->ParallelSink() || sink->SinkOrderDependent()) {
 		return false;
 	}
 	if (sink->GetExternalInputSupport() != PipelineExternalInputSupport::SUPPORTED) {
 		return false;
 	}
-	if (sink->RequiredPartitionInfo().AnyRequired()) {
+	auto required_partition_info = sink->RequiredPartitionInfo();
+	if (required_partition_info.RequiresPartitionColumns()) {
+		return false;
+	}
+	if (required_partition_info.RequiresBatchIndex() && !source_partition_info.RequiresBatchIndex()) {
 		return false;
 	}
 	for (auto &op_ref : operators) {

--- a/src/parallel/pipeline.cpp
+++ b/src/parallel/pipeline.cpp
@@ -164,7 +164,7 @@ bool Pipeline::ScheduleParallel(shared_ptr<Event> &event) {
 	// Handle partition requirements specific to scheduling
 	auto partition_info = sink->RequiredPartitionInfo();
 	if (partition_info.batch_index) {
-		if (!source->SupportsPartitioning(OperatorPartitionInfo::BatchIndex())) {
+		if (!source->SupportsPartitioning(partition_info)) {
 			throw InternalException(
 			    "Attempting to schedule a pipeline where the sink requires batch index but source does not support it");
 		}
@@ -363,10 +363,11 @@ void Pipeline::ResetForReschedule(bool reset_sink) {
 		throw InternalException("Source of pipeline does not have IsSource set");
 	}
 	auto source_state = GetSourceState();
+	auto partition_info = sink ? sink->RequiredPartitionInfo() : OperatorPartitionInfo::NoPartitionInfo();
 	if (allow_reuse && source_state && source_state->SupportsReuse()) {
 		source_state->Reset(client);
 	} else {
-		SetSourceState(ToSharedSourceState(source->GetGlobalSourceState(client)));
+		SetSourceState(ToSharedSourceState(source->GetGlobalSourceState(client, partition_info)));
 	}
 	initialized = true;
 }
@@ -377,7 +378,8 @@ void Pipeline::ResetSource(bool force) {
 	}
 	auto source_state = GetSourceState();
 	if (force || !source_state) {
-		SetSourceState(ToSharedSourceState(source->GetGlobalSourceState(GetClientContext())));
+		auto partition_info = sink ? sink->RequiredPartitionInfo() : OperatorPartitionInfo::NoPartitionInfo();
+		SetSourceState(ToSharedSourceState(source->GetGlobalSourceState(GetClientContext(), partition_info)));
 	}
 }
 

--- a/src/parallel/pipeline.cpp
+++ b/src/parallel/pipeline.cpp
@@ -23,6 +23,11 @@ static shared_ptr<GlobalSourceState> ToSharedSourceState(unique_ptr<GlobalSource
 
 PipelineTask::PipelineTask(Pipeline &pipeline_p, shared_ptr<Event> event_p)
     : ExecutorTask(pipeline_p.executor, std::move(event_p)), pipeline(pipeline_p) {
+	auto sink = pipeline.GetSink();
+	if (sink && sink->RequiredPartitionInfo().AnyRequired()) {
+		// Account for every task before lazy executor construction can advance the batch minimum.
+		reserved_batch_index = pipeline.RegisterNewBatchIndex();
+	}
 }
 
 bool PipelineTask::TaskBlockedOnResult() const {
@@ -35,7 +40,7 @@ const PipelineExecutor &PipelineTask::GetPipelineExecutor() const {
 
 TaskExecutionResult PipelineTask::ExecuteTask(TaskExecutionMode mode) {
 	if (!pipeline_executor) {
-		pipeline_executor = make_uniq<PipelineExecutor>(pipeline.GetClientContext(), pipeline);
+		pipeline_executor = make_uniq<PipelineExecutor>(pipeline.GetClientContext(), pipeline, reserved_batch_index);
 	}
 
 	pipeline_executor->SetTaskForInterrupts(shared_from_this());

--- a/src/parallel/pipeline_broadcast_exchange.cpp
+++ b/src/parallel/pipeline_broadcast_exchange.cpp
@@ -749,14 +749,18 @@ SinkResultType PipelineBroadcastExchange::CompletePush(DataChunk &chunk, Pipelin
 	return SinkResultType::NEED_MORE_INPUT;
 }
 
-SinkNextBatchType PipelineBroadcastExchange::NextBatch(const SourcePartitionInfo &partition_info,
+SinkNextBatchType PipelineBroadcastExchange::NextBatch(PipelineBroadcastExchangeLocalState &lstate,
+                                                       const SourcePartitionInfo &partition_info,
                                                        const InterruptState &interrupt_state) {
 	if (!SupportsBatchIndex()) {
 		return SinkNextBatchType::READY;
 	}
 	D_ASSERT(partition_info.min_batch_index.IsValid());
 	auto result = FlushReadyBatches(partition_info.min_batch_index.GetIndex(), interrupt_state);
-	return result == BufferedPushState::BLOCKED ? SinkNextBatchType::BLOCKED : SinkNextBatchType::READY;
+	if (result == BufferedPushState::BLOCKED) {
+		return SinkNextBatchType::BLOCKED;
+	}
+	return lstate.NextBatch(partition_info, interrupt_state);
 }
 
 SinkCombineResultType PipelineBroadcastExchange::FinishLocal(PipelineBroadcastExchangeLocalState &lstate,
@@ -777,32 +781,8 @@ SinkResultType PipelineBroadcastExchangeLocalState::Push(DataChunk &chunk, const
 	if (direct_push_state != PipelineBroadcastExchangeDirectPushState::RESUMING) {
 		direct_idx = 0;
 	}
-	OperatorPartitionData source_partition_data(0);
-	optional_idx source_min_batch_index;
-	if (supports_batch_index) {
-		if (!partition_info.batch_index.IsValid() || !partition_info.min_batch_index.IsValid()) {
-			throw InternalException("Batch-indexed pipeline broadcast exchange received incomplete partition info");
-		}
-		auto batch_index = partition_info.batch_index.GetIndex();
-		auto producer_min_batch_index = partition_info.min_batch_index.GetIndex();
-		if (batch_index <= producer_base_batch_index) {
-			throw InternalException("Pipeline broadcast exchange received invalid producer batch index %llu",
-			                        batch_index);
-		}
-		if (producer_min_batch_index < producer_base_batch_index || producer_min_batch_index > batch_index) {
-			throw InternalException("Pipeline broadcast exchange received invalid producer minimum batch index %llu",
-			                        producer_min_batch_index);
-		}
-		source_partition_data.batch_index = batch_index - producer_base_batch_index - 1;
-		source_min_batch_index = producer_min_batch_index - producer_base_batch_index;
-		if (source_partition_data.batch_index >= PipelineBuildState::BATCH_INCREMENT - 2) {
-			throw InternalException("Pipeline broadcast exchange received producer batch index outside its pipeline");
-		}
-		if (source_min_batch_index.GetIndex() >= PipelineBuildState::BATCH_INCREMENT) {
-			throw InternalException("Pipeline broadcast exchange received producer minimum batch index outside its "
-			                        "pipeline");
-		}
-	}
+	auto source_partition_data = GetSourcePartitionData(partition_info);
+	auto source_min_batch_index = GetSourceMinBatchIndex(partition_info);
 	for (; direct_idx < direct_executors.size(); direct_idx++) {
 		auto &executor = *direct_executors[direct_idx];
 		executor.SetInterruptState(interrupt_state);
@@ -826,24 +806,40 @@ SinkResultType PipelineBroadcastExchangeLocalState::Push(DataChunk &chunk, const
 	return SinkResultType::NEED_MORE_INPUT;
 }
 
-SinkCombineResultType PipelineBroadcastExchangeLocalState::Finish(const SourcePartitionInfo &partition_info,
-                                                                  const InterruptState &interrupt_state) {
-	optional_idx source_min_batch_index;
-	if (supports_batch_index) {
-		if (!partition_info.min_batch_index.IsValid()) {
-			throw InternalException("Batch-indexed pipeline broadcast exchange received no minimum batch index");
+SinkNextBatchType PipelineBroadcastExchangeLocalState::NextBatch(const SourcePartitionInfo &partition_info,
+                                                                 const InterruptState &interrupt_state) {
+	auto source_min_batch_index = GetSourceMinBatchIndex(partition_info);
+	if (!partition_info.batch_index.IsValid()) {
+		throw InternalException("Batch-indexed pipeline broadcast exchange received no batch index");
+	}
+	auto batch_index = partition_info.batch_index.GetIndex();
+	auto max_batch_index = producer_base_batch_index + PipelineBuildState::BATCH_INCREMENT - 1;
+	const bool finalize = batch_index == max_batch_index;
+	OperatorPartitionData source_partition_data(0);
+	if (!finalize) {
+		source_partition_data = GetSourcePartitionData(partition_info);
+	}
+
+	for (; direct_next_batch_idx < direct_executors.size(); direct_next_batch_idx++) {
+		auto &executor = *direct_executors[direct_next_batch_idx];
+		executor.SetInterruptState(interrupt_state);
+		PipelineExecuteResult result;
+		if (finalize || executor.IsFinishedProcessing()) {
+			result = executor.FinishBatchExternal(source_min_batch_index);
+		} else {
+			result = executor.NextBatchExternal(source_partition_data, source_min_batch_index);
 		}
-		auto producer_min_batch_index = partition_info.min_batch_index.GetIndex();
-		if (producer_min_batch_index < producer_base_batch_index) {
-			throw InternalException("Pipeline broadcast exchange received invalid producer minimum batch index %llu",
-			                        producer_min_batch_index);
-		}
-		source_min_batch_index = producer_min_batch_index - producer_base_batch_index;
-		if (source_min_batch_index.GetIndex() >= PipelineBuildState::BATCH_INCREMENT) {
-			throw InternalException("Pipeline broadcast exchange received producer minimum batch index outside its "
-			                        "pipeline");
+		if (result == PipelineExecuteResult::INTERRUPTED) {
+			return SinkNextBatchType::BLOCKED;
 		}
 	}
+	direct_next_batch_idx = 0;
+	return SinkNextBatchType::READY;
+}
+
+SinkCombineResultType PipelineBroadcastExchangeLocalState::Finish(const SourcePartitionInfo &partition_info,
+                                                                  const InterruptState &interrupt_state) {
+	auto source_min_batch_index = GetSourceMinBatchIndex(partition_info);
 	for (; direct_finalize_idx < direct_executors.size(); direct_finalize_idx++) {
 		auto &executor = *direct_executors[direct_finalize_idx];
 		executor.SetInterruptState(interrupt_state);
@@ -856,6 +852,51 @@ SinkCombineResultType PipelineBroadcastExchangeLocalState::Finish(const SourcePa
 		}
 	}
 	return SinkCombineResultType::FINISHED;
+}
+
+OperatorPartitionData
+PipelineBroadcastExchangeLocalState::GetSourcePartitionData(const SourcePartitionInfo &partition_info) const {
+	OperatorPartitionData result(0);
+	if (!supports_batch_index) {
+		return result;
+	}
+	if (!partition_info.batch_index.IsValid()) {
+		throw InternalException("Batch-indexed pipeline broadcast exchange received no batch index");
+	}
+	auto batch_index = partition_info.batch_index.GetIndex();
+	if (batch_index <= producer_base_batch_index) {
+		throw InternalException("Pipeline broadcast exchange received invalid producer batch index %llu", batch_index);
+	}
+	result.batch_index = batch_index - producer_base_batch_index - 1;
+	if (result.batch_index >= PipelineBuildState::BATCH_INCREMENT - 2) {
+		throw InternalException("Pipeline broadcast exchange received producer batch index outside its pipeline");
+	}
+	return result;
+}
+
+optional_idx
+PipelineBroadcastExchangeLocalState::GetSourceMinBatchIndex(const SourcePartitionInfo &partition_info) const {
+	if (!supports_batch_index) {
+		return optional_idx();
+	}
+	if (!partition_info.min_batch_index.IsValid()) {
+		throw InternalException("Batch-indexed pipeline broadcast exchange received no minimum batch index");
+	}
+	auto producer_min_batch_index = partition_info.min_batch_index.GetIndex();
+	if (producer_min_batch_index < producer_base_batch_index) {
+		throw InternalException("Pipeline broadcast exchange received invalid producer minimum batch index %llu",
+		                        producer_min_batch_index);
+	}
+	if (partition_info.batch_index.IsValid() && producer_min_batch_index > partition_info.batch_index.GetIndex()) {
+		throw InternalException("Pipeline broadcast exchange received invalid producer minimum batch index %llu",
+		                        producer_min_batch_index);
+	}
+	auto result = producer_min_batch_index - producer_base_batch_index;
+	if (result >= PipelineBuildState::BATCH_INCREMENT) {
+		throw InternalException("Pipeline broadcast exchange received producer minimum batch index outside its "
+		                        "pipeline");
+	}
+	return optional_idx(result);
 }
 
 bool PipelineBroadcastExchangeLocalState::HasDirectConsumers() const {

--- a/src/parallel/pipeline_broadcast_exchange.cpp
+++ b/src/parallel/pipeline_broadcast_exchange.cpp
@@ -769,7 +769,7 @@ SinkCombineResultType PipelineBroadcastExchange::FinishLocal(PipelineBroadcastEx
 			return SinkCombineResultType::BLOCKED;
 		}
 	}
-	return lstate.Finish(interrupt_state);
+	return lstate.Finish(partition_info, interrupt_state);
 }
 
 SinkResultType PipelineBroadcastExchangeLocalState::Push(DataChunk &chunk, const SourcePartitionInfo &partition_info,
@@ -778,18 +778,29 @@ SinkResultType PipelineBroadcastExchangeLocalState::Push(DataChunk &chunk, const
 		direct_idx = 0;
 	}
 	OperatorPartitionData source_partition_data(0);
+	optional_idx source_min_batch_index;
 	if (supports_batch_index) {
-		if (!partition_info.batch_index.IsValid()) {
-			throw InternalException("Batch-indexed pipeline broadcast exchange received no batch index");
+		if (!partition_info.batch_index.IsValid() || !partition_info.min_batch_index.IsValid()) {
+			throw InternalException("Batch-indexed pipeline broadcast exchange received incomplete partition info");
 		}
 		auto batch_index = partition_info.batch_index.GetIndex();
+		auto producer_min_batch_index = partition_info.min_batch_index.GetIndex();
 		if (batch_index <= producer_base_batch_index) {
 			throw InternalException("Pipeline broadcast exchange received invalid producer batch index %llu",
 			                        batch_index);
 		}
+		if (producer_min_batch_index < producer_base_batch_index || producer_min_batch_index > batch_index) {
+			throw InternalException("Pipeline broadcast exchange received invalid producer minimum batch index %llu",
+			                        producer_min_batch_index);
+		}
 		source_partition_data.batch_index = batch_index - producer_base_batch_index - 1;
+		source_min_batch_index = producer_min_batch_index - producer_base_batch_index;
 		if (source_partition_data.batch_index >= PipelineBuildState::BATCH_INCREMENT - 2) {
 			throw InternalException("Pipeline broadcast exchange received producer batch index outside its pipeline");
+		}
+		if (source_min_batch_index.GetIndex() >= PipelineBuildState::BATCH_INCREMENT) {
+			throw InternalException("Pipeline broadcast exchange received producer minimum batch index outside its "
+			                        "pipeline");
 		}
 	}
 	for (; direct_idx < direct_executors.size(); direct_idx++) {
@@ -798,7 +809,7 @@ SinkResultType PipelineBroadcastExchangeLocalState::Push(DataChunk &chunk, const
 		if (executor.IsFinishedProcessing()) {
 			continue;
 		}
-		auto result = executor.PushExternal(chunk, source_partition_data);
+		auto result = executor.PushExternal(chunk, source_partition_data, source_min_batch_index);
 		if (result == PipelineExecuteResult::INTERRUPTED) {
 			direct_push_state = PipelineBroadcastExchangeDirectPushState::RESUMING;
 			return SinkResultType::BLOCKED;
@@ -815,13 +826,30 @@ SinkResultType PipelineBroadcastExchangeLocalState::Push(DataChunk &chunk, const
 	return SinkResultType::NEED_MORE_INPUT;
 }
 
-SinkCombineResultType PipelineBroadcastExchangeLocalState::Finish(const InterruptState &interrupt_state) {
+SinkCombineResultType PipelineBroadcastExchangeLocalState::Finish(const SourcePartitionInfo &partition_info,
+                                                                  const InterruptState &interrupt_state) {
+	optional_idx source_min_batch_index;
+	if (supports_batch_index) {
+		if (!partition_info.min_batch_index.IsValid()) {
+			throw InternalException("Batch-indexed pipeline broadcast exchange received no minimum batch index");
+		}
+		auto producer_min_batch_index = partition_info.min_batch_index.GetIndex();
+		if (producer_min_batch_index < producer_base_batch_index) {
+			throw InternalException("Pipeline broadcast exchange received invalid producer minimum batch index %llu",
+			                        producer_min_batch_index);
+		}
+		source_min_batch_index = producer_min_batch_index - producer_base_batch_index;
+		if (source_min_batch_index.GetIndex() >= PipelineBuildState::BATCH_INCREMENT) {
+			throw InternalException("Pipeline broadcast exchange received producer minimum batch index outside its "
+			                        "pipeline");
+		}
+	}
 	for (; direct_finalize_idx < direct_executors.size(); direct_finalize_idx++) {
 		auto &executor = *direct_executors[direct_finalize_idx];
 		executor.SetInterruptState(interrupt_state);
 		auto result = PipelineExecuteResult::NOT_FINISHED;
 		while (result == PipelineExecuteResult::NOT_FINISHED) {
-			result = executor.FinishExternal();
+			result = executor.FinishExternal(source_min_batch_index);
 		}
 		if (result == PipelineExecuteResult::INTERRUPTED) {
 			return SinkCombineResultType::BLOCKED;

--- a/src/parallel/pipeline_broadcast_exchange.cpp
+++ b/src/parallel/pipeline_broadcast_exchange.cpp
@@ -509,7 +509,9 @@ PipelineBroadcastExchange::ConsumerState::operator=(ConsumerState &&other) noexc
 PipelineBroadcastExchange::~PipelineBroadcastExchange() = default;
 
 PipelineBroadcastExchangeLocalState::PipelineBroadcastExchangeLocalState(ClientContext &context,
-                                                                         const PipelineBroadcastExchange &exchange) {
+                                                                         const PipelineBroadcastExchange &exchange,
+                                                                         idx_t producer_base_batch_index_p)
+    : producer_base_batch_index(producer_base_batch_index_p), supports_batch_index(exchange.SupportsBatchIndex()) {
 	vector<reference<Pipeline>> direct_pipeline_refs;
 	{
 		annotated_lock_guard<annotated_mutex> guard(exchange.lock);
@@ -549,12 +551,22 @@ PipelineBroadcastExchange::PipelineBroadcastExchange(ClientContext &context, vec
 	buffer = make_uniq<BufferState>(context, types, max_threads);
 }
 
-unique_ptr<PipelineBroadcastExchangeLocalState> PipelineBroadcastExchange::GetLocalState(ClientContext &context) const {
-	return make_uniq<PipelineBroadcastExchangeLocalState>(context, *this);
+unique_ptr<PipelineBroadcastExchangeLocalState>
+PipelineBroadcastExchange::GetLocalState(ClientContext &context, idx_t producer_base_batch_index) const {
+	return make_uniq<PipelineBroadcastExchangeLocalState>(context, *this, producer_base_batch_index);
 }
 
 shared_ptr<PipelineBroadcastExchangeScanState> PipelineBroadcastExchange::GetScanState() const {
 	return make_shared_ptr<PipelineBroadcastExchangeScanState>();
+}
+
+void PipelineBroadcastExchange::SetProducerPipelines(const vector<shared_ptr<Pipeline>> &pipelines) {
+	D_ASSERT(!pipelines.empty());
+	annotated_lock_guard<annotated_mutex> guard(lock);
+	producer_pipelines.clear();
+	for (auto &pipeline : pipelines) {
+		producer_pipelines.push_back(*pipeline);
+	}
 }
 
 idx_t PipelineBroadcastExchange::RegisterConsumer() {
@@ -577,10 +589,16 @@ void PipelineBroadcastExchange::SelectMaterializedConsumer(idx_t consumer_idx) {
 }
 
 bool PipelineBroadcastExchange::TryRegisterDirectConsumer(Pipeline &pipeline, idx_t consumer_idx) {
-	if (!pipeline.CanUseExternalInput()) {
+	auto source_partition_info =
+	    SupportsBatchIndex() ? OperatorPartitionInfo::BatchIndex() : OperatorPartitionInfo::NoPartitionInfo();
+	if (!pipeline.CanUseExternalInput(source_partition_info)) {
 		return false;
 	}
 	annotated_lock_guard<annotated_mutex> guard(lock);
+	auto required_partition_info = pipeline.GetSink()->RequiredPartitionInfo();
+	if (required_partition_info.RequiresBatchIndex() && producer_pipelines.size() != 1) {
+		return false;
+	}
 	D_ASSERT(consumer_idx < consumers.size());
 	auto &consumer = consumers[consumer_idx];
 	if (consumer.mode == PipelineBroadcastExchangeConsumerMode::DIRECT) {
@@ -590,6 +608,11 @@ bool PipelineBroadcastExchange::TryRegisterDirectConsumer(Pipeline &pipeline, id
 	consumer.mode = PipelineBroadcastExchangeConsumerMode::DIRECT;
 	DeactivateConsumerLocked(consumer, buffer->BasePosition());
 	direct_pipelines.push_back(pipeline);
+	if (pipeline.IsStreamingResultPipeline()) {
+		for (auto &producer_pipeline : producer_pipelines) {
+			producer_pipeline.get().SetExternalStreamingResultProducer();
+		}
+	}
 	return true;
 }
 
@@ -606,6 +629,7 @@ void PipelineBroadcastExchange::ResetConsumerRegistrations() {
 	buffer->EndExecution();
 	ResetExchangeStateLocked();
 	direct_pipelines.clear();
+	producer_pipelines.clear();
 	blocked_readers.clear();
 	blocked_writers.clear();
 	blocked_appenders.clear();
@@ -685,7 +709,7 @@ SinkResultType PipelineBroadcastExchange::Push(DataChunk &chunk, PipelineBroadca
 	if (lstate.HasDirectConsumers() &&
 	    (lstate.direct_push_state == PipelineBroadcastExchangeDirectPushState::NOT_STARTED ||
 	     lstate.direct_push_state == PipelineBroadcastExchangeDirectPushState::RESUMING)) {
-		auto direct_result = lstate.Push(chunk, interrupt_state);
+		auto direct_result = lstate.Push(chunk, partition_info, interrupt_state);
 		if (direct_result == SinkResultType::BLOCKED) {
 			return SinkResultType::BLOCKED;
 		}
@@ -748,9 +772,25 @@ SinkCombineResultType PipelineBroadcastExchange::FinishLocal(PipelineBroadcastEx
 	return lstate.Finish(interrupt_state);
 }
 
-SinkResultType PipelineBroadcastExchangeLocalState::Push(DataChunk &chunk, const InterruptState &interrupt_state) {
+SinkResultType PipelineBroadcastExchangeLocalState::Push(DataChunk &chunk, const SourcePartitionInfo &partition_info,
+                                                         const InterruptState &interrupt_state) {
 	if (direct_push_state != PipelineBroadcastExchangeDirectPushState::RESUMING) {
 		direct_idx = 0;
+	}
+	OperatorPartitionData source_partition_data(0);
+	if (supports_batch_index) {
+		if (!partition_info.batch_index.IsValid()) {
+			throw InternalException("Batch-indexed pipeline broadcast exchange received no batch index");
+		}
+		auto batch_index = partition_info.batch_index.GetIndex();
+		if (batch_index <= producer_base_batch_index) {
+			throw InternalException("Pipeline broadcast exchange received invalid producer batch index %llu",
+			                        batch_index);
+		}
+		source_partition_data.batch_index = batch_index - producer_base_batch_index - 1;
+		if (source_partition_data.batch_index >= PipelineBuildState::BATCH_INCREMENT - 2) {
+			throw InternalException("Pipeline broadcast exchange received producer batch index outside its pipeline");
+		}
 	}
 	for (; direct_idx < direct_executors.size(); direct_idx++) {
 		auto &executor = *direct_executors[direct_idx];
@@ -758,7 +798,7 @@ SinkResultType PipelineBroadcastExchangeLocalState::Push(DataChunk &chunk, const
 		if (executor.IsFinishedProcessing()) {
 			continue;
 		}
-		auto result = executor.PushExternal(chunk);
+		auto result = executor.PushExternal(chunk, source_partition_data);
 		if (result == PipelineExecuteResult::INTERRUPTED) {
 			direct_push_state = PipelineBroadcastExchangeDirectPushState::RESUMING;
 			return SinkResultType::BLOCKED;

--- a/src/parallel/pipeline_broadcast_exchange.cpp
+++ b/src/parallel/pipeline_broadcast_exchange.cpp
@@ -2,6 +2,7 @@
 
 #include "duckdb/common/types/column/column_data_collection.hpp"
 #include "duckdb/common/types/selection_vector.hpp"
+#include "duckdb/common/map.hpp"
 #include "duckdb/logging/log_type.hpp"
 #include "duckdb/logging/logger.hpp"
 #include "duckdb/parallel/pipeline.hpp"
@@ -110,6 +111,7 @@ struct PipelineBroadcastExchange::BroadcastSpool {
 	struct ChunkEntry {
 		idx_t row_offset;
 		idx_t row_count;
+		idx_t batch_index;
 	};
 
 	BroadcastSpool(ClientContext &context, const vector<LogicalType> &types, idx_t base_position_p)
@@ -118,12 +120,12 @@ struct PipelineBroadcastExchange::BroadcastSpool {
 		collection.InitializeAppend(append_state);
 	}
 
-	void Append(DataChunk &chunk) {
+	void Append(DataChunk &chunk, idx_t batch_index) {
 		annotated_lock_guard<annotated_mutex> guard(lock);
 		D_ASSERT(chunk.size() > 0);
 		auto row_offset = collection.Count();
 		collection.Append(append_state, chunk);
-		chunks.push_back(ChunkEntry {row_offset, chunk.size()});
+		chunks.push_back(ChunkEntry {row_offset, chunk.size(), batch_index});
 		next_position++;
 		append_generation++;
 	}
@@ -177,6 +179,14 @@ struct PipelineBroadcastExchange::BroadcastSpool {
 		return position >= base_position && position < next_position;
 	}
 
+	idx_t BatchIndex(idx_t position) {
+		annotated_lock_guard<annotated_mutex> guard(lock);
+		if (position < base_position || position >= next_position) {
+			throw InternalException("Attempted to inspect retired pipeline broadcast spool chunk");
+		}
+		return chunks[position - base_position].batch_index;
+	}
+
 	void InitializeReader(BroadcastSpoolReader &reader) {
 		annotated_lock_guard<annotated_mutex> guard(lock);
 		ResetReaderLocked(reader);
@@ -222,12 +232,15 @@ PipelineBroadcastExchange::BroadcastSpoolReader::BroadcastSpoolReader(BroadcastS
 struct PipelineBroadcastExchange::AppendReservation {
 	shared_ptr<BroadcastSpool> shared_spool;
 	idx_t position = 0;
+	idx_t batch_index = DConstants::INVALID_INDEX;
+	bool pending = false;
 };
 
 struct PipelineBroadcastExchange::SpoolReadReservation {
 	shared_ptr<BroadcastSpool> spool;
 	shared_ptr<BroadcastSpoolReader> reader;
 	idx_t position = 0;
+	idx_t batch_index = DConstants::INVALID_INDEX;
 
 	bool IsSet() const {
 		return spool != nullptr;
@@ -236,6 +249,7 @@ struct PipelineBroadcastExchange::SpoolReadReservation {
 
 struct PipelineBroadcastExchange::BufferedChunk {
 	shared_ptr<DataChunk> chunk;
+	idx_t batch_index;
 };
 
 struct PipelineBroadcastExchange::BufferState {
@@ -254,10 +268,13 @@ struct PipelineBroadcastExchange::BufferState {
 
 	void Reset() {
 		chunks.clear();
+		pending_batches.clear();
 		shared_spool.reset();
 		base_position = 0;
 		next_position = 0;
 		buffered_chunks = 0;
+		pending_chunks = 0;
+		min_batch_index = 0;
 	}
 
 	shared_ptr<DataChunk> Copy(DataChunk &chunk) {
@@ -276,6 +293,22 @@ struct PipelineBroadcastExchange::BufferState {
 		return buffered_chunks;
 	}
 
+	idx_t PendingCount() const {
+		return pending_chunks;
+	}
+
+	idx_t MinBatchIndex() const {
+		return min_batch_index;
+	}
+
+	void UpdateMinBatchIndex(idx_t new_min_batch_index) {
+		min_batch_index = MaxValue(min_batch_index, new_min_batch_index);
+	}
+
+	bool HasReadyBatch() const {
+		return !pending_batches.empty() && pending_batches.begin()->first <= min_batch_index;
+	}
+
 	bool HasSharedSpool() const {
 		return shared_spool != nullptr;
 	}
@@ -284,14 +317,42 @@ struct PipelineBroadcastExchange::BufferState {
 		return chunks.empty() && !shared_spool;
 	}
 
-	void ReserveAppend(AppendReservation &reservation) const {
+	void ReserveAppend(AppendReservation &reservation, idx_t batch_index) const {
 		reservation.shared_spool = shared_spool;
 		reservation.position = next_position;
+		reservation.batch_index = batch_index;
+		reservation.pending = false;
+	}
+
+	shared_ptr<DataChunk> ReservePendingAppend(AppendReservation &reservation) const {
+		D_ASSERT(HasReadyBatch());
+		auto &pending = pending_batches.begin()->second.front();
+		reservation.shared_spool = shared_spool;
+		reservation.position = next_position;
+		reservation.batch_index = pending.batch_index;
+		reservation.pending = true;
+		return pending.chunk;
+	}
+
+	void Stage(shared_ptr<DataChunk> copy, idx_t batch_index) {
+		pending_batches[batch_index].push_back({std::move(copy), batch_index});
+		pending_chunks++;
 	}
 
 	void CompleteAppend(const AppendReservation &reservation, shared_ptr<DataChunk> copy) {
+		if (reservation.pending) {
+			D_ASSERT(HasReadyBatch());
+			auto pending_entry = pending_batches.begin();
+			D_ASSERT(pending_entry->first == reservation.batch_index);
+			D_ASSERT(pending_entry->second.front().chunk == copy);
+			pending_entry->second.pop_front();
+			pending_chunks--;
+			if (pending_entry->second.empty()) {
+				pending_batches.erase(pending_entry);
+			}
+		}
 		if (!reservation.shared_spool) {
-			chunks.push_back({std::move(copy)});
+			chunks.push_back({std::move(copy), reservation.batch_index});
 		}
 		buffered_chunks++;
 		D_ASSERT(next_position == reservation.position);
@@ -299,7 +360,7 @@ struct PipelineBroadcastExchange::BufferState {
 	}
 
 	void ReserveRead(idx_t position, shared_ptr<BroadcastSpoolReader> &reader, shared_ptr<DataChunk> &next_chunk,
-	                 SpoolReadReservation &spool_read) const {
+	                 optional_idx &batch_index, SpoolReadReservation &spool_read) const {
 		D_ASSERT(position < next_position);
 		if (shared_spool) {
 			if (!shared_spool->HasPosition(position)) {
@@ -311,19 +372,22 @@ struct PipelineBroadcastExchange::BufferState {
 			spool_read.spool = shared_spool;
 			spool_read.reader = reader;
 			spool_read.position = position;
+			spool_read.batch_index = shared_spool->BatchIndex(position);
+			batch_index = spool_read.batch_index;
 			return;
 		}
 		D_ASSERT(position >= base_position);
 		auto chunk_idx = position - base_position;
 		D_ASSERT(chunk_idx < chunks.size());
 		next_chunk = chunks[chunk_idx].chunk;
+		batch_index = chunks[chunk_idx].batch_index;
 	}
 
 	void CreateSharedSpool() {
 		D_ASSERT(!shared_spool);
 		shared_spool = make_shared_ptr<BroadcastSpool>(context, types, base_position);
 		for (auto &chunk : chunks) {
-			shared_spool->Append(*chunk.chunk);
+			shared_spool->Append(*chunk.chunk, chunk.batch_index);
 		}
 		chunks.clear();
 	}
@@ -344,8 +408,10 @@ struct PipelineBroadcastExchange::BufferState {
 
 	void Release() {
 		chunks.clear();
+		pending_batches.clear();
 		shared_spool.reset();
 		buffered_chunks = 0;
+		pending_chunks = 0;
 		base_position = next_position;
 	}
 
@@ -353,10 +419,13 @@ struct PipelineBroadcastExchange::BufferState {
 	const vector<LogicalType> &types;
 	shared_ptr<ChunkPool> chunk_pool;
 	deque<BufferedChunk> chunks;
+	map<idx_t, deque<BufferedChunk>> pending_batches;
 	shared_ptr<BroadcastSpool> shared_spool;
 	idx_t base_position = 0;
 	idx_t next_position = 0;
 	idx_t buffered_chunks = 0;
+	idx_t pending_chunks = 0;
+	idx_t min_batch_index = 0;
 };
 
 PipelineBroadcastExchange::ConsumerState::ConsumerState() = default;
@@ -396,9 +465,16 @@ void PipelineBroadcastExchange::SetLogOperator(const PhysicalOperator &op) {
 PipelineBroadcastExchangeLocalState::~PipelineBroadcastExchangeLocalState() = default;
 
 PipelineBroadcastExchange::PipelineBroadcastExchange(ClientContext &context, vector<LogicalType> types_p,
-                                                     PipelineBroadcastExchangeCompletionMode completion_mode_p)
+                                                     PipelineBroadcastExchangeCompletionMode completion_mode_p,
+                                                     OrderPreservationType source_order_p, bool use_batch_index_p)
     : context(context), types(std::move(types_p)), completion_mode(completion_mode_p),
+      order_mode(use_batch_index_p ? PipelineBroadcastExchangeOrderMode::BATCH_INDEX
+                                   : source_order_p == OrderPreservationType::NO_ORDER
+                                         ? PipelineBroadcastExchangeOrderMode::UNORDERED
+                                         : PipelineBroadcastExchangeOrderMode::SEQUENTIAL),
+      source_order(source_order_p),
       max_threads(NumericCast<idx_t>(TaskScheduler::GetScheduler(context).NumberOfThreads())) {
+	D_ASSERT(!use_batch_index_p || source_order_p != OrderPreservationType::NO_ORDER);
 	buffer = make_uniq<BufferState>(context, types, max_threads);
 }
 
@@ -530,6 +606,7 @@ void PipelineBroadcastExchange::DeactivateConsumerLocked(ConsumerState &consumer
 }
 
 SinkResultType PipelineBroadcastExchange::Push(DataChunk &chunk, PipelineBroadcastExchangeLocalState &lstate,
+                                               const SourcePartitionInfo &partition_info,
                                                const InterruptState &interrupt_state) {
 	if (lstate.HasDirectConsumers() &&
 	    (lstate.direct_push_state == PipelineBroadcastExchangeDirectPushState::NOT_STARTED ||
@@ -541,7 +618,15 @@ SinkResultType PipelineBroadcastExchange::Push(DataChunk &chunk, PipelineBroadca
 	}
 
 	if (lstate.mode == PipelineBroadcastExchangeLocalMode::BUFFERED) {
-		auto append_result = Append(chunk, interrupt_state);
+		idx_t batch_index = DConstants::INVALID_INDEX;
+		idx_t min_batch_index = DConstants::INVALID_INDEX;
+		if (SupportsBatchIndex()) {
+			D_ASSERT(partition_info.batch_index.IsValid());
+			D_ASSERT(partition_info.min_batch_index.IsValid());
+			batch_index = partition_info.batch_index.GetIndex();
+			min_batch_index = partition_info.min_batch_index.GetIndex();
+		}
+		auto append_result = Append(chunk, batch_index, min_batch_index, interrupt_state);
 		if (append_result == BufferedPushState::BLOCKED) {
 			return SinkResultType::BLOCKED;
 		}
@@ -552,7 +637,8 @@ SinkResultType PipelineBroadcastExchange::Push(DataChunk &chunk, PipelineBroadca
 
 SinkResultType PipelineBroadcastExchange::CompletePush(DataChunk &chunk, PipelineBroadcastExchangeLocalState &lstate,
                                                        BufferedPushState buffered_state) {
-	if (buffered_state != BufferedPushState::APPENDED && buffered_state != BufferedPushState::CANCELLED) {
+	if (buffered_state != BufferedPushState::APPENDED && buffered_state != BufferedPushState::STAGED &&
+	    buffered_state != BufferedPushState::CANCELLED) {
 		RecordProducedRows(chunk.size());
 	}
 	const auto direct_consumers_finished = lstate.DirectConsumersFinished();
@@ -565,8 +651,26 @@ SinkResultType PipelineBroadcastExchange::CompletePush(DataChunk &chunk, Pipelin
 	return SinkResultType::NEED_MORE_INPUT;
 }
 
+SinkNextBatchType PipelineBroadcastExchange::NextBatch(const SourcePartitionInfo &partition_info,
+                                                       const InterruptState &interrupt_state) {
+	if (!SupportsBatchIndex()) {
+		return SinkNextBatchType::READY;
+	}
+	D_ASSERT(partition_info.min_batch_index.IsValid());
+	auto result = FlushReadyBatches(partition_info.min_batch_index.GetIndex(), interrupt_state);
+	return result == BufferedPushState::BLOCKED ? SinkNextBatchType::BLOCKED : SinkNextBatchType::READY;
+}
+
 SinkCombineResultType PipelineBroadcastExchange::FinishLocal(PipelineBroadcastExchangeLocalState &lstate,
+                                                             const SourcePartitionInfo &partition_info,
                                                              const InterruptState &interrupt_state) {
+	if (SupportsBatchIndex()) {
+		D_ASSERT(partition_info.min_batch_index.IsValid());
+		auto result = FlushReadyBatches(partition_info.min_batch_index.GetIndex(), interrupt_state);
+		if (result == BufferedPushState::BLOCKED) {
+			return SinkCombineResultType::BLOCKED;
+		}
+	}
 	return lstate.Finish(interrupt_state);
 }
 
@@ -653,20 +757,43 @@ PipelineBroadcastExchange::PrepareAppendLocked(const InterruptState &interrupt_s
 }
 
 PipelineBroadcastExchange::AppendAdmission
-PipelineBroadcastExchange::ReserveAppendLocked(const InterruptState &interrupt_state, AppendReservation &reservation,
+PipelineBroadcastExchange::ReserveAppendLocked(idx_t batch_index, const InterruptState &interrupt_state,
+                                               AppendReservation &reservation,
                                                vector<ExchangeLogEntry> &log_entries) {
 	auto admission = PrepareAppendLocked(interrupt_state, log_entries);
 	if (admission != AppendAdmission::READY) {
 		return admission;
 	}
 	append_reservation_state = AppendReservationState::RESERVED;
-	buffer->ReserveAppend(reservation);
+	buffer->ReserveAppend(reservation, batch_index);
+	return AppendAdmission::READY;
+}
+
+PipelineBroadcastExchange::AppendAdmission
+PipelineBroadcastExchange::PrepareStageLocked(idx_t batch_index, const InterruptState &interrupt_state,
+                                              vector<ExchangeLogEntry> &log_entries) {
+	if (producer_state != ProducerState::ACTIVE) {
+		return AppendAdmission::CANCELLED;
+	}
+	if (active_consumers == 0) {
+		return AppendAdmission::UNCONSUMED;
+	}
+	if (batch_index > buffer->MinBatchIndex() &&
+	    buffer->PendingCount() >= PIPELINE_BROADCAST_HIGH_WATERMARK_CHUNKS) {
+		if (watermark_state == WatermarkState::BELOW_HIGH_WATERMARK) {
+			watermark_state = WatermarkState::ABOVE_HIGH_WATERMARK;
+			log_entries.push_back(
+			    {ExchangeLogEvent::HIGH_WATERMARK_BLOCKED, active_consumers, buffer->PendingCount()});
+		}
+		blocked_writers.push_back(interrupt_state);
+		return AppendAdmission::BLOCKED;
+	}
 	return AppendAdmission::READY;
 }
 
 PipelineBroadcastExchange::BufferedPushState PipelineBroadcastExchange::CompleteAppendLocked(
-    const AppendReservation &reservation, shared_ptr<DataChunk> copy, idx_t row_count, vector<InterruptState> &readers,
-    vector<InterruptState> &appenders, vector<ExchangeLogEntry> &log_entries) {
+    const AppendReservation &reservation, shared_ptr<DataChunk> copy, idx_t row_count, bool record_produced_rows,
+    vector<InterruptState> &readers, vector<InterruptState> &appenders, vector<ExchangeLogEntry> &log_entries) {
 	D_ASSERT(append_reservation_state == AppendReservationState::RESERVED);
 	append_reservation_state = AppendReservationState::IDLE;
 	if (producer_state == ProducerState::CANCELLED) {
@@ -683,7 +810,9 @@ PipelineBroadcastExchange::BufferedPushState PipelineBroadcastExchange::Complete
 	}
 	buffer->CompleteAppend(reservation, std::move(copy));
 	WakeReadersLocked(readers);
-	RecordProducedRows(row_count);
+	if (record_produced_rows) {
+		RecordProducedRows(row_count);
+	}
 	WakeAppendersLocked(appenders);
 	return BufferedPushState::APPENDED;
 }
@@ -701,13 +830,101 @@ void PipelineBroadcastExchange::AbortAppendReservation(vector<InterruptState> &r
 	WakeAppendersLocked(appenders);
 }
 
-PipelineBroadcastExchange::BufferedPushState PipelineBroadcastExchange::Append(DataChunk &chunk,
-                                                                               const InterruptState &interrupt_state) {
+PipelineBroadcastExchange::BufferedPushState
+PipelineBroadcastExchange::FlushReadyBatches(idx_t min_batch_index, const InterruptState &interrupt_state) {
+	D_ASSERT(SupportsBatchIndex());
+	bool appended = false;
+	while (true) {
+		vector<ExchangeLogEntry> log_entries;
+		AppendAdmission admission;
+		AppendReservation reservation;
+		shared_ptr<DataChunk> copy;
+		try {
+			annotated_lock_guard<annotated_mutex> guard(lock);
+			buffer->UpdateMinBatchIndex(min_batch_index);
+			if (!buffer->HasReadyBatch()) {
+				return appended ? BufferedPushState::APPENDED : BufferedPushState::NOT_REQUIRED;
+			}
+			admission = PrepareAppendLocked(interrupt_state, log_entries);
+			if (admission == AppendAdmission::READY) {
+				append_reservation_state = AppendReservationState::RESERVED;
+				copy = buffer->ReservePendingAppend(reservation);
+			}
+		} catch (...) {
+			Cancel();
+			throw;
+		}
+		LogTransitions(log_entries);
+		if (admission == AppendAdmission::BLOCKED) {
+			return BufferedPushState::BLOCKED;
+		}
+		if (admission == AppendAdmission::UNCONSUMED) {
+			return BufferedPushState::UNCONSUMED;
+		}
+		if (admission == AppendAdmission::CANCELLED) {
+			return BufferedPushState::CANCELLED;
+		}
+
+		try {
+			if (reservation.shared_spool) {
+				reservation.shared_spool->Append(*copy, reservation.batch_index);
+			}
+		} catch (...) {
+			vector<InterruptState> readers;
+			vector<InterruptState> writers;
+			vector<InterruptState> appenders;
+			{
+				annotated_lock_guard<annotated_mutex> guard(lock);
+				AbortAppendReservation(readers, writers, appenders);
+			}
+			CallbackAll(readers);
+			CallbackAll(writers);
+			CallbackAll(appenders);
+			buffer->EndExecution();
+			throw;
+		}
+
+		vector<InterruptState> readers;
+		vector<InterruptState> writers;
+		vector<InterruptState> appenders;
+		log_entries.clear();
+		BufferedPushState result;
+		{
+			annotated_lock_guard<annotated_mutex> guard(lock);
+			result = CompleteAppendLocked(reservation, std::move(copy), 0, false, readers, appenders, log_entries);
+			WakeWritersLocked(writers, log_entries, WriterWakeMode::FORCE);
+		}
+		CallbackAll(readers);
+		CallbackAll(writers);
+		CallbackAll(appenders);
+		LogTransitions(log_entries);
+		if (result != BufferedPushState::APPENDED) {
+			return result;
+		}
+		appended = true;
+	}
+}
+
+PipelineBroadcastExchange::BufferedPushState PipelineBroadcastExchange::Append(
+    DataChunk &chunk, idx_t batch_index, idx_t min_batch_index, const InterruptState &interrupt_state) {
+	if (SupportsBatchIndex()) {
+		auto flush_result = FlushReadyBatches(min_batch_index, interrupt_state);
+		if (flush_result == BufferedPushState::BLOCKED || flush_result == BufferedPushState::UNCONSUMED ||
+		    flush_result == BufferedPushState::CANCELLED) {
+			return flush_result;
+		}
+	}
+
 	vector<ExchangeLogEntry> log_entries;
 	AppendAdmission admission;
 	try {
 		annotated_lock_guard<annotated_mutex> guard(lock);
-		admission = PrepareAppendLocked(interrupt_state, log_entries);
+		if (SupportsBatchIndex()) {
+			buffer->UpdateMinBatchIndex(min_batch_index);
+		}
+		admission = SupportsBatchIndex() && batch_index > buffer->MinBatchIndex()
+		                ? PrepareStageLocked(batch_index, interrupt_state, log_entries)
+		                : PrepareAppendLocked(interrupt_state, log_entries);
 	} catch (...) {
 		Cancel();
 		throw;
@@ -732,9 +949,22 @@ PipelineBroadcastExchange::BufferedPushState PipelineBroadcastExchange::Append(D
 	}
 	AppendReservation reservation;
 	log_entries.clear();
+	bool staged = false;
 	try {
 		annotated_lock_guard<annotated_mutex> guard(lock);
-		admission = ReserveAppendLocked(interrupt_state, reservation, log_entries);
+		if (SupportsBatchIndex()) {
+			buffer->UpdateMinBatchIndex(min_batch_index);
+		}
+		if (SupportsBatchIndex() && batch_index > buffer->MinBatchIndex()) {
+			admission = PrepareStageLocked(batch_index, interrupt_state, log_entries);
+			if (admission == AppendAdmission::READY) {
+				buffer->Stage(copy, batch_index);
+				RecordProducedRows(chunk.size());
+				staged = true;
+			}
+		} else {
+			admission = ReserveAppendLocked(batch_index, interrupt_state, reservation, log_entries);
+		}
 	} catch (...) {
 		Cancel();
 		throw;
@@ -749,10 +979,13 @@ PipelineBroadcastExchange::BufferedPushState PipelineBroadcastExchange::Append(D
 	if (admission == AppendAdmission::CANCELLED) {
 		return BufferedPushState::CANCELLED;
 	}
+	if (staged) {
+		return BufferedPushState::STAGED;
+	}
 
 	try {
 		if (reservation.shared_spool) {
-			reservation.shared_spool->Append(*copy);
+			reservation.shared_spool->Append(*copy, reservation.batch_index);
 		}
 	} catch (...) {
 		vector<InterruptState> readers;
@@ -775,7 +1008,7 @@ PipelineBroadcastExchange::BufferedPushState PipelineBroadcastExchange::Append(D
 	BufferedPushState result;
 	{
 		annotated_lock_guard<annotated_mutex> guard(lock);
-		result = CompleteAppendLocked(reservation, std::move(copy), chunk.size(), readers, appenders, log_entries);
+		result = CompleteAppendLocked(reservation, std::move(copy), chunk.size(), true, readers, appenders, log_entries);
 	}
 	CallbackAll(readers);
 	CallbackAll(appenders);
@@ -837,6 +1070,7 @@ void PipelineBroadcastExchange::Cancel() {
 
 SourceResultType PipelineBroadcastExchange::Scan(idx_t consumer_idx, DataChunk &chunk,
                                                  shared_ptr<DataChunk> &current_chunk,
+                                                 optional_idx &batch_index,
                                                  const InterruptState &interrupt_state) {
 	vector<InterruptState> writers;
 	vector<InterruptState> readers;
@@ -844,9 +1078,11 @@ SourceResultType PipelineBroadcastExchange::Scan(idx_t consumer_idx, DataChunk &
 	shared_ptr<DataChunk> next_chunk;
 	SpoolReadReservation spool_read;
 	SourceResultType result;
+	batch_index = optional_idx();
 	{
 		annotated_lock_guard<annotated_mutex> guard(lock);
-		result = ReserveScanLocked(consumer_idx, interrupt_state, next_chunk, spool_read, writers, log_entries);
+		result = ReserveScanLocked(consumer_idx, interrupt_state, next_chunk, batch_index, spool_read, writers,
+		                           log_entries);
 	}
 
 	if (spool_read.IsSet()) {
@@ -892,6 +1128,7 @@ SourceResultType PipelineBroadcastExchange::Scan(idx_t consumer_idx, DataChunk &
 
 SourceResultType PipelineBroadcastExchange::ReserveScanLocked(idx_t consumer_idx, const InterruptState &interrupt_state,
                                                               shared_ptr<DataChunk> &next_chunk,
+                                                              optional_idx &batch_index,
                                                               SpoolReadReservation &spool_read,
                                                               vector<InterruptState> &writers,
                                                               vector<ExchangeLogEntry> &log_entries) {
@@ -905,7 +1142,7 @@ SourceResultType PipelineBroadcastExchange::ReserveScanLocked(idx_t consumer_idx
 		return SourceResultType::BLOCKED;
 	}
 	if (consumer.position < buffer->NextPosition()) {
-		buffer->ReserveRead(consumer.position, consumer.shared_reader, next_chunk, spool_read);
+		buffer->ReserveRead(consumer.position, consumer.shared_reader, next_chunk, batch_index, spool_read);
 		if (spool_read.IsSet()) {
 			consumer.read_state = ConsumerReadState::READING;
 			consumer.read_position = consumer.position;
@@ -1037,7 +1274,7 @@ ProgressData PipelineBroadcastExchange::SinkProgress(const ProgressData &source_
 }
 
 idx_t PipelineBroadcastExchange::MaxThreads() const {
-	return MaxValue<idx_t>(max_threads, 1);
+	return PreservesOrder() ? 1 : MaxValue<idx_t>(max_threads, 1);
 }
 
 idx_t PipelineBroadcastExchange::RegisteredConsumerCount() const {

--- a/src/parallel/pipeline_broadcast_exchange.cpp
+++ b/src/parallel/pipeline_broadcast_exchange.cpp
@@ -240,7 +240,6 @@ struct PipelineBroadcastExchange::SpoolReadReservation {
 	shared_ptr<BroadcastSpool> spool;
 	shared_ptr<BroadcastSpoolReader> reader;
 	idx_t position = 0;
-	idx_t batch_index = DConstants::INVALID_INDEX;
 
 	bool IsSet() const {
 		return spool != nullptr;
@@ -372,15 +371,19 @@ struct PipelineBroadcastExchange::BufferState {
 			spool_read.spool = shared_spool;
 			spool_read.reader = reader;
 			spool_read.position = position;
-			spool_read.batch_index = shared_spool->BatchIndex(position);
-			batch_index = spool_read.batch_index;
+			auto stored_batch_index = shared_spool->BatchIndex(position);
+			if (stored_batch_index != DConstants::INVALID_INDEX) {
+				batch_index = stored_batch_index;
+			}
 			return;
 		}
 		D_ASSERT(position >= base_position);
 		auto chunk_idx = position - base_position;
 		D_ASSERT(chunk_idx < chunks.size());
 		next_chunk = chunks[chunk_idx].chunk;
-		batch_index = chunks[chunk_idx].batch_index;
+		if (chunks[chunk_idx].batch_index != DConstants::INVALID_INDEX) {
+			batch_index = chunks[chunk_idx].batch_index;
+		}
 	}
 
 	void CreateSharedSpool() {
@@ -468,10 +471,9 @@ PipelineBroadcastExchange::PipelineBroadcastExchange(ClientContext &context, vec
                                                      PipelineBroadcastExchangeCompletionMode completion_mode_p,
                                                      OrderPreservationType source_order_p, bool use_batch_index_p)
     : context(context), types(std::move(types_p)), completion_mode(completion_mode_p),
-      order_mode(use_batch_index_p ? PipelineBroadcastExchangeOrderMode::BATCH_INDEX
-                                   : source_order_p == OrderPreservationType::NO_ORDER
-                                         ? PipelineBroadcastExchangeOrderMode::UNORDERED
-                                         : PipelineBroadcastExchangeOrderMode::SEQUENTIAL),
+      order_mode(use_batch_index_p                                   ? PipelineBroadcastExchangeOrderMode::BATCH_INDEX
+                 : source_order_p == OrderPreservationType::NO_ORDER ? PipelineBroadcastExchangeOrderMode::UNORDERED
+                                                                     : PipelineBroadcastExchangeOrderMode::SEQUENTIAL),
       source_order(source_order_p),
       max_threads(NumericCast<idx_t>(TaskScheduler::GetScheduler(context).NumberOfThreads())) {
 	D_ASSERT(!use_batch_index_p || source_order_p != OrderPreservationType::NO_ORDER);
@@ -758,8 +760,7 @@ PipelineBroadcastExchange::PrepareAppendLocked(const InterruptState &interrupt_s
 
 PipelineBroadcastExchange::AppendAdmission
 PipelineBroadcastExchange::ReserveAppendLocked(idx_t batch_index, const InterruptState &interrupt_state,
-                                               AppendReservation &reservation,
-                                               vector<ExchangeLogEntry> &log_entries) {
+                                               AppendReservation &reservation, vector<ExchangeLogEntry> &log_entries) {
 	auto admission = PrepareAppendLocked(interrupt_state, log_entries);
 	if (admission != AppendAdmission::READY) {
 		return admission;
@@ -778,12 +779,10 @@ PipelineBroadcastExchange::PrepareStageLocked(idx_t batch_index, const Interrupt
 	if (active_consumers == 0) {
 		return AppendAdmission::UNCONSUMED;
 	}
-	if (batch_index > buffer->MinBatchIndex() &&
-	    buffer->PendingCount() >= PIPELINE_BROADCAST_HIGH_WATERMARK_CHUNKS) {
+	if (batch_index > buffer->MinBatchIndex() && buffer->PendingCount() >= PIPELINE_BROADCAST_HIGH_WATERMARK_CHUNKS) {
 		if (watermark_state == WatermarkState::BELOW_HIGH_WATERMARK) {
 			watermark_state = WatermarkState::ABOVE_HIGH_WATERMARK;
-			log_entries.push_back(
-			    {ExchangeLogEvent::HIGH_WATERMARK_BLOCKED, active_consumers, buffer->PendingCount()});
+			log_entries.push_back({ExchangeLogEvent::HIGH_WATERMARK_BLOCKED, active_consumers, buffer->PendingCount()});
 		}
 		blocked_writers.push_back(interrupt_state);
 		return AppendAdmission::BLOCKED;
@@ -905,8 +904,9 @@ PipelineBroadcastExchange::FlushReadyBatches(idx_t min_batch_index, const Interr
 	}
 }
 
-PipelineBroadcastExchange::BufferedPushState PipelineBroadcastExchange::Append(
-    DataChunk &chunk, idx_t batch_index, idx_t min_batch_index, const InterruptState &interrupt_state) {
+PipelineBroadcastExchange::BufferedPushState PipelineBroadcastExchange::Append(DataChunk &chunk, idx_t batch_index,
+                                                                               idx_t min_batch_index,
+                                                                               const InterruptState &interrupt_state) {
 	if (SupportsBatchIndex()) {
 		auto flush_result = FlushReadyBatches(min_batch_index, interrupt_state);
 		if (flush_result == BufferedPushState::BLOCKED || flush_result == BufferedPushState::UNCONSUMED ||
@@ -1008,7 +1008,8 @@ PipelineBroadcastExchange::BufferedPushState PipelineBroadcastExchange::Append(
 	BufferedPushState result;
 	{
 		annotated_lock_guard<annotated_mutex> guard(lock);
-		result = CompleteAppendLocked(reservation, std::move(copy), chunk.size(), true, readers, appenders, log_entries);
+		result =
+		    CompleteAppendLocked(reservation, std::move(copy), chunk.size(), true, readers, appenders, log_entries);
 	}
 	CallbackAll(readers);
 	CallbackAll(appenders);
@@ -1026,6 +1027,10 @@ void PipelineBroadcastExchange::Finish() {
 	vector<ExchangeLogEntry> log_entries;
 	{
 		annotated_lock_guard<annotated_mutex> guard(lock);
+		if (active_consumers > 0 && buffer->PendingCount() > 0) {
+			throw InternalException("Finishing ordered pipeline broadcast exchange with %llu pending chunks",
+			                        buffer->PendingCount());
+		}
 		if (producer_state == ProducerState::ACTIVE) {
 			producer_state = ProducerState::FINISHED;
 		}
@@ -1069,8 +1074,7 @@ void PipelineBroadcastExchange::Cancel() {
 }
 
 SourceResultType PipelineBroadcastExchange::Scan(idx_t consumer_idx, DataChunk &chunk,
-                                                 shared_ptr<DataChunk> &current_chunk,
-                                                 optional_idx &batch_index,
+                                                 shared_ptr<DataChunk> &current_chunk, optional_idx &batch_index,
                                                  const InterruptState &interrupt_state) {
 	vector<InterruptState> writers;
 	vector<InterruptState> readers;
@@ -1081,8 +1085,8 @@ SourceResultType PipelineBroadcastExchange::Scan(idx_t consumer_idx, DataChunk &
 	batch_index = optional_idx();
 	{
 		annotated_lock_guard<annotated_mutex> guard(lock);
-		result = ReserveScanLocked(consumer_idx, interrupt_state, next_chunk, batch_index, spool_read, writers,
-		                           log_entries);
+		result =
+		    ReserveScanLocked(consumer_idx, interrupt_state, next_chunk, batch_index, spool_read, writers, log_entries);
 	}
 
 	if (spool_read.IsSet()) {

--- a/src/parallel/pipeline_broadcast_exchange.cpp
+++ b/src/parallel/pipeline_broadcast_exchange.cpp
@@ -232,7 +232,8 @@ PipelineBroadcastExchange::BroadcastSpoolReader::BroadcastSpoolReader(BroadcastS
 struct PipelineBroadcastExchange::AppendReservation {
 	shared_ptr<BroadcastSpool> shared_spool;
 	idx_t position = 0;
-	idx_t batch_index = DConstants::INVALID_INDEX;
+	idx_t producer_batch_index = DConstants::INVALID_INDEX;
+	idx_t exchange_batch_index = DConstants::INVALID_INDEX;
 	bool pending = false;
 };
 
@@ -249,6 +250,17 @@ struct PipelineBroadcastExchange::SpoolReadReservation {
 struct PipelineBroadcastExchange::BufferedChunk {
 	shared_ptr<DataChunk> chunk;
 	idx_t batch_index;
+};
+
+class PipelineBroadcastExchangeScanState {
+	friend class PipelineBroadcastExchange;
+
+public:
+	PipelineBroadcastExchangeScanState() = default;
+
+private:
+	shared_ptr<DataChunk> current_chunk;
+	shared_ptr<PipelineBroadcastExchange::BroadcastSpoolReader> spool_reader;
 };
 
 struct PipelineBroadcastExchange::BufferState {
@@ -268,12 +280,16 @@ struct PipelineBroadcastExchange::BufferState {
 	void Reset() {
 		chunks.clear();
 		pending_batches.clear();
+		active_batches.clear();
 		shared_spool.reset();
 		base_position = 0;
 		next_position = 0;
 		buffered_chunks = 0;
 		pending_chunks = 0;
 		min_batch_index = 0;
+		producer_pipeline_index = DConstants::INVALID_INDEX;
+		producer_pipeline_offset = 0;
+		max_local_batch_index = 0;
 	}
 
 	shared_ptr<DataChunk> Copy(DataChunk &chunk) {
@@ -305,7 +321,22 @@ struct PipelineBroadcastExchange::BufferState {
 	}
 
 	bool HasReadyBatch() const {
-		return !pending_batches.empty() && pending_batches.begin()->first <= min_batch_index;
+		return !pending_batches.empty() && pending_batches.begin()->first <= min_batch_index &&
+		       (active_batches.empty() || pending_batches.begin()->first <= *active_batches.begin());
+	}
+
+	void RegisterActiveBatch(idx_t batch_index) {
+		active_batches.insert(batch_index);
+	}
+
+	void UnregisterActiveBatch(idx_t batch_index) {
+		auto entry = active_batches.find(batch_index);
+		D_ASSERT(entry != active_batches.end());
+		active_batches.erase(entry);
+	}
+
+	bool HasEarlierActiveBatch(idx_t batch_index) const {
+		return !active_batches.empty() && *active_batches.begin() < batch_index;
 	}
 
 	bool HasSharedSpool() const {
@@ -316,19 +347,53 @@ struct PipelineBroadcastExchange::BufferState {
 		return chunks.empty() && !shared_spool;
 	}
 
-	void ReserveAppend(AppendReservation &reservation, idx_t batch_index) const {
+	idx_t ExchangeBatchIndex(idx_t producer_batch_index) {
+		if (producer_batch_index == DConstants::INVALID_INDEX) {
+			return DConstants::INVALID_INDEX;
+		}
+		auto pipeline_index = producer_batch_index / PipelineBuildState::BATCH_INCREMENT;
+		auto local_batch_index = producer_batch_index % PipelineBuildState::BATCH_INCREMENT;
+		if (local_batch_index == 0) {
+			throw InternalException("Pipeline broadcast exchange received an uninitialized batch index");
+		}
+		if (producer_pipeline_index == DConstants::INVALID_INDEX) {
+			producer_pipeline_index = pipeline_index;
+		} else if (pipeline_index != producer_pipeline_index) {
+			if (pipeline_index < producer_pipeline_index) {
+				throw InternalException("Pipeline broadcast producer index decreased from %llu to %llu",
+				                        producer_pipeline_index, pipeline_index);
+			}
+			producer_pipeline_offset += max_local_batch_index;
+			producer_pipeline_index = pipeline_index;
+			max_local_batch_index = 0;
+		}
+		if (local_batch_index < max_local_batch_index) {
+			throw InternalException("Pipeline broadcast exchange emitted batch %llu after batch %llu",
+			                        local_batch_index, max_local_batch_index);
+		}
+		max_local_batch_index = MaxValue(max_local_batch_index, local_batch_index);
+		auto result = producer_pipeline_offset + local_batch_index - 1;
+		if (result >= PipelineBuildState::BATCH_INCREMENT - 1) {
+			throw InternalException("Pipeline broadcast exchange exceeded the batch index range");
+		}
+		return result;
+	}
+
+	void ReserveAppend(AppendReservation &reservation, idx_t producer_batch_index) {
 		reservation.shared_spool = shared_spool;
 		reservation.position = next_position;
-		reservation.batch_index = batch_index;
+		reservation.producer_batch_index = producer_batch_index;
+		reservation.exchange_batch_index = ExchangeBatchIndex(producer_batch_index);
 		reservation.pending = false;
 	}
 
-	shared_ptr<DataChunk> ReservePendingAppend(AppendReservation &reservation) const {
+	shared_ptr<DataChunk> ReservePendingAppend(AppendReservation &reservation) {
 		D_ASSERT(HasReadyBatch());
 		auto &pending = pending_batches.begin()->second.front();
 		reservation.shared_spool = shared_spool;
 		reservation.position = next_position;
-		reservation.batch_index = pending.batch_index;
+		reservation.producer_batch_index = pending.batch_index;
+		reservation.exchange_batch_index = ExchangeBatchIndex(pending.batch_index);
 		reservation.pending = true;
 		return pending.chunk;
 	}
@@ -342,7 +407,7 @@ struct PipelineBroadcastExchange::BufferState {
 		if (reservation.pending) {
 			D_ASSERT(HasReadyBatch());
 			auto pending_entry = pending_batches.begin();
-			D_ASSERT(pending_entry->first == reservation.batch_index);
+			D_ASSERT(pending_entry->first == reservation.producer_batch_index);
 			D_ASSERT(pending_entry->second.front().chunk == copy);
 			pending_entry->second.pop_front();
 			pending_chunks--;
@@ -351,7 +416,7 @@ struct PipelineBroadcastExchange::BufferState {
 			}
 		}
 		if (!reservation.shared_spool) {
-			chunks.push_back({std::move(copy), reservation.batch_index});
+			chunks.push_back({std::move(copy), reservation.exchange_batch_index});
 		}
 		buffered_chunks++;
 		D_ASSERT(next_position == reservation.position);
@@ -423,12 +488,16 @@ struct PipelineBroadcastExchange::BufferState {
 	shared_ptr<ChunkPool> chunk_pool;
 	deque<BufferedChunk> chunks;
 	map<idx_t, deque<BufferedChunk>> pending_batches;
+	multiset<idx_t> active_batches;
 	shared_ptr<BroadcastSpool> shared_spool;
 	idx_t base_position = 0;
 	idx_t next_position = 0;
 	idx_t buffered_chunks = 0;
 	idx_t pending_chunks = 0;
 	idx_t min_batch_index = 0;
+	idx_t producer_pipeline_index = DConstants::INVALID_INDEX;
+	idx_t producer_pipeline_offset = 0;
+	idx_t max_local_batch_index = 0;
 };
 
 PipelineBroadcastExchange::ConsumerState::ConsumerState() = default;
@@ -482,6 +551,10 @@ PipelineBroadcastExchange::PipelineBroadcastExchange(ClientContext &context, vec
 
 unique_ptr<PipelineBroadcastExchangeLocalState> PipelineBroadcastExchange::GetLocalState(ClientContext &context) const {
 	return make_uniq<PipelineBroadcastExchangeLocalState>(context, *this);
+}
+
+shared_ptr<PipelineBroadcastExchangeScanState> PipelineBroadcastExchange::GetScanState() const {
+	return make_shared_ptr<PipelineBroadcastExchangeScanState>();
 }
 
 idx_t PipelineBroadcastExchange::RegisterConsumer() {
@@ -574,9 +647,8 @@ void PipelineBroadcastExchange::ResetExchangeStateLocked() {
 
 void PipelineBroadcastExchange::ResetConsumerReadStateLocked(ConsumerState &consumer, idx_t position) {
 	consumer.position = position;
-	consumer.read_state = ConsumerReadState::IDLE;
-	consumer.read_position = position;
-	consumer.shared_reader.reset();
+	consumer.exhausted = false;
+	consumer.in_flight_reads.clear();
 }
 
 void PipelineBroadcastExchange::ResetConsumerRegistrationLocked(ConsumerState &consumer) {
@@ -866,7 +938,7 @@ PipelineBroadcastExchange::FlushReadyBatches(idx_t min_batch_index, const Interr
 
 		try {
 			if (reservation.shared_spool) {
-				reservation.shared_spool->Append(*copy, reservation.batch_index);
+				reservation.shared_spool->Append(*copy, reservation.exchange_batch_index);
 			}
 		} catch (...) {
 			vector<InterruptState> readers;
@@ -907,6 +979,20 @@ PipelineBroadcastExchange::FlushReadyBatches(idx_t min_batch_index, const Interr
 PipelineBroadcastExchange::BufferedPushState PipelineBroadcastExchange::Append(DataChunk &chunk, idx_t batch_index,
                                                                                idx_t min_batch_index,
                                                                                const InterruptState &interrupt_state) {
+	if (SupportsBatchIndex()) {
+		annotated_lock_guard<annotated_mutex> guard(lock);
+		buffer->RegisterActiveBatch(batch_index);
+	}
+	auto unregister_active_batch = [&](idx_t *) {
+		if (!SupportsBatchIndex()) {
+			return;
+		}
+		annotated_lock_guard<annotated_mutex> guard(lock);
+		buffer->UnregisterActiveBatch(batch_index);
+	};
+	unique_ptr<idx_t, decltype(unregister_active_batch)> active_batch_guard(
+	    SupportsBatchIndex() ? &batch_index : nullptr, unregister_active_batch);
+
 	if (SupportsBatchIndex()) {
 		auto flush_result = FlushReadyBatches(min_batch_index, interrupt_state);
 		if (flush_result == BufferedPushState::BLOCKED || flush_result == BufferedPushState::UNCONSUMED ||
@@ -955,7 +1041,8 @@ PipelineBroadcastExchange::BufferedPushState PipelineBroadcastExchange::Append(D
 		if (SupportsBatchIndex()) {
 			buffer->UpdateMinBatchIndex(min_batch_index);
 		}
-		if (SupportsBatchIndex() && batch_index > buffer->MinBatchIndex()) {
+		if (SupportsBatchIndex() && (batch_index > buffer->MinBatchIndex() ||
+		                             buffer->HasEarlierActiveBatch(batch_index) || buffer->HasReadyBatch())) {
 			admission = PrepareStageLocked(batch_index, interrupt_state, log_entries);
 			if (admission == AppendAdmission::READY) {
 				buffer->Stage(copy, batch_index);
@@ -985,7 +1072,7 @@ PipelineBroadcastExchange::BufferedPushState PipelineBroadcastExchange::Append(D
 
 	try {
 		if (reservation.shared_spool) {
-			reservation.shared_spool->Append(*copy, reservation.batch_index);
+			reservation.shared_spool->Append(*copy, reservation.exchange_batch_index);
 		}
 	} catch (...) {
 		vector<InterruptState> readers;
@@ -1074,8 +1161,8 @@ void PipelineBroadcastExchange::Cancel() {
 }
 
 SourceResultType PipelineBroadcastExchange::Scan(idx_t consumer_idx, DataChunk &chunk,
-                                                 shared_ptr<DataChunk> &current_chunk, optional_idx &batch_index,
-                                                 const InterruptState &interrupt_state) {
+                                                 PipelineBroadcastExchangeScanState &scan_state,
+                                                 optional_idx &batch_index, const InterruptState &interrupt_state) {
 	vector<InterruptState> writers;
 	vector<InterruptState> readers;
 	vector<ExchangeLogEntry> log_entries;
@@ -1085,8 +1172,8 @@ SourceResultType PipelineBroadcastExchange::Scan(idx_t consumer_idx, DataChunk &
 	batch_index = optional_idx();
 	{
 		annotated_lock_guard<annotated_mutex> guard(lock);
-		result =
-		    ReserveScanLocked(consumer_idx, interrupt_state, next_chunk, batch_index, spool_read, writers, log_entries);
+		result = ReserveScanLocked(consumer_idx, interrupt_state, scan_state, next_chunk, batch_index, spool_read,
+		                           writers, log_entries);
 	}
 
 	if (spool_read.IsSet()) {
@@ -1099,7 +1186,7 @@ SourceResultType PipelineBroadcastExchange::Scan(idx_t consumer_idx, DataChunk &
 			{
 				annotated_lock_guard<annotated_mutex> guard(lock);
 				auto &consumer = consumers[consumer_idx];
-				consumer.read_state = ConsumerReadState::IDLE;
+				consumer.in_flight_reads.erase(spool_read.position);
 				producer_state = ProducerState::CANCELLED;
 				DeactivateAllConsumersLocked();
 				TryReleaseBufferedStorageLocked();
@@ -1124,34 +1211,28 @@ SourceResultType PipelineBroadcastExchange::Scan(idx_t consumer_idx, DataChunk &
 	CallbackAll(writers);
 	LogTransitions(log_entries);
 	if (next_chunk) {
-		current_chunk = std::move(next_chunk);
-		chunk.Reference(*current_chunk);
+		scan_state.current_chunk = std::move(next_chunk);
+		chunk.Reference(*scan_state.current_chunk);
 	}
 	return result;
 }
 
-SourceResultType PipelineBroadcastExchange::ReserveScanLocked(idx_t consumer_idx, const InterruptState &interrupt_state,
-                                                              shared_ptr<DataChunk> &next_chunk,
-                                                              optional_idx &batch_index,
-                                                              SpoolReadReservation &spool_read,
-                                                              vector<InterruptState> &writers,
-                                                              vector<ExchangeLogEntry> &log_entries) {
+SourceResultType PipelineBroadcastExchange::ReserveScanLocked(
+    idx_t consumer_idx, const InterruptState &interrupt_state, PipelineBroadcastExchangeScanState &scan_state,
+    shared_ptr<DataChunk> &next_chunk, optional_idx &batch_index, SpoolReadReservation &spool_read,
+    vector<InterruptState> &writers, vector<ExchangeLogEntry> &log_entries) {
 	D_ASSERT(consumer_idx < consumers.size());
 	auto &consumer = consumers[consumer_idx];
 	if (consumer.lifecycle != ConsumerLifecycle::ACTIVE || producer_state == ProducerState::CANCELLED) {
 		return SourceResultType::FINISHED;
 	}
-	if (consumer.read_state == ConsumerReadState::READING) {
-		blocked_readers.push_back(interrupt_state);
-		return SourceResultType::BLOCKED;
-	}
 	if (consumer.position < buffer->NextPosition()) {
-		buffer->ReserveRead(consumer.position, consumer.shared_reader, next_chunk, batch_index, spool_read);
+		auto position = consumer.position++;
+		buffer->ReserveRead(position, scan_state.spool_reader, next_chunk, batch_index, spool_read);
 		if (spool_read.IsSet()) {
-			consumer.read_state = ConsumerReadState::READING;
-			consumer.read_position = consumer.position;
+			auto inserted = consumer.in_flight_reads.insert(position);
+			D_ASSERT(inserted.second);
 		} else {
-			consumer.position++;
 			consumer.rows_read += next_chunk->size();
 			RetireChunksLocked();
 			WakeWritersLocked(writers, log_entries);
@@ -1159,9 +1240,12 @@ SourceResultType PipelineBroadcastExchange::ReserveScanLocked(idx_t consumer_idx
 		return SourceResultType::HAVE_MORE_OUTPUT;
 	}
 	if (producer_state == ProducerState::FINISHED) {
-		consumer.lifecycle = ConsumerLifecycle::INACTIVE;
-		D_ASSERT(active_consumers > 0);
-		active_consumers--;
+		consumer.exhausted = true;
+		if (consumer.in_flight_reads.empty()) {
+			consumer.lifecycle = ConsumerLifecycle::INACTIVE;
+			D_ASSERT(active_consumers > 0);
+			active_consumers--;
+		}
 		RetireChunksLocked();
 		WakeWritersLocked(writers, log_entries, WriterWakeMode::FORCE);
 		return SourceResultType::FINISHED;
@@ -1177,20 +1261,22 @@ void PipelineBroadcastExchange::CompleteSpoolReadLocked(idx_t consumer_idx, cons
                                                         vector<ExchangeLogEntry> &log_entries) {
 	D_ASSERT(consumer_idx < consumers.size());
 	auto &consumer = consumers[consumer_idx];
-	D_ASSERT(consumer.read_state == ConsumerReadState::READING);
-	D_ASSERT(consumer.read_position == spool_read.position);
-	consumer.read_state = ConsumerReadState::IDLE;
+	auto entry = consumer.in_flight_reads.find(spool_read.position);
+	D_ASSERT(entry != consumer.in_flight_reads.end());
+	consumer.in_flight_reads.erase(entry);
 	if (consumer.lifecycle != ConsumerLifecycle::ACTIVE || producer_state == ProducerState::CANCELLED) {
 		chunk.Reset();
-		consumer.shared_reader.reset();
 		RetireChunksLocked();
 		WakeWritersLocked(writers, log_entries, WriterWakeMode::FORCE);
 		WakeReadersLocked(readers);
 		return;
 	}
-	D_ASSERT(consumer.position == spool_read.position);
-	consumer.position++;
 	consumer.rows_read += chunk.size();
+	if (consumer.exhausted && consumer.in_flight_reads.empty()) {
+		consumer.lifecycle = ConsumerLifecycle::INACTIVE;
+		D_ASSERT(active_consumers > 0);
+		active_consumers--;
+	}
 	RetireChunksLocked();
 	WakeWritersLocked(writers, log_entries);
 	WakeReadersLocked(readers);
@@ -1209,11 +1295,11 @@ void PipelineBroadcastExchange::UnregisterConsumer(idx_t consumer_idx) {
 		if (consumer.lifecycle != ConsumerLifecycle::ACTIVE) {
 			return;
 		}
+		if (consumer.exhausted) {
+			return;
+		}
 		consumer.lifecycle = ConsumerLifecycle::INACTIVE;
 		consumer.position = buffer->NextPosition();
-		if (consumer.read_state != ConsumerReadState::READING) {
-			consumer.shared_reader.reset();
-		}
 		D_ASSERT(active_consumers > 0);
 		active_consumers--;
 		RetireChunksLocked();
@@ -1278,7 +1364,7 @@ ProgressData PipelineBroadcastExchange::SinkProgress(const ProgressData &source_
 }
 
 idx_t PipelineBroadcastExchange::MaxThreads() const {
-	return PreservesOrder() ? 1 : MaxValue<idx_t>(max_threads, 1);
+	return order_mode == PipelineBroadcastExchangeOrderMode::SEQUENTIAL ? 1 : MaxValue<idx_t>(max_threads, 1);
 }
 
 idx_t PipelineBroadcastExchange::RegisteredConsumerCount() const {
@@ -1342,39 +1428,22 @@ void PipelineBroadcastExchange::CreateSharedSpoolLocked(vector<ExchangeLogEntry>
 }
 
 void PipelineBroadcastExchange::RetireChunksLocked() {
-	if (buffer->HasSharedSpool()) {
-		idx_t min_position = buffer->NextPosition();
-		bool found_reader = false;
-		for (auto &consumer : consumers) {
-			if (consumer.read_state == ConsumerReadState::READING) {
-				found_reader = true;
-				min_position = MinValue(min_position, consumer.read_position);
-			}
-			if (consumer.lifecycle == ConsumerLifecycle::ACTIVE) {
-				found_reader = true;
-				min_position = MinValue(min_position, consumer.position);
-			}
-		}
-		if (!found_reader) {
-			min_position = buffer->NextPosition();
-		}
-		buffer->RetireBefore(min_position);
-		TryReleaseBufferedStorageLocked();
-		return;
-	}
 	if (buffer->Empty()) {
 		return;
 	}
 	idx_t min_position = buffer->NextPosition();
-	bool found_active = false;
+	bool found_reader = false;
 	for (auto &consumer : consumers) {
-		if (consumer.lifecycle != ConsumerLifecycle::ACTIVE) {
-			continue;
+		if (!consumer.in_flight_reads.empty()) {
+			found_reader = true;
+			min_position = MinValue(min_position, *consumer.in_flight_reads.begin());
 		}
-		found_active = true;
-		min_position = MinValue(min_position, consumer.position);
+		if (consumer.lifecycle == ConsumerLifecycle::ACTIVE) {
+			found_reader = true;
+			min_position = MinValue(min_position, consumer.position);
+		}
 	}
-	if (!found_active) {
+	if (!found_reader) {
 		min_position = buffer->NextPosition();
 	}
 	buffer->RetireBefore(min_position);
@@ -1386,10 +1455,9 @@ void PipelineBroadcastExchange::TryReleaseBufferedStorageLocked() {
 		return;
 	}
 	for (auto &consumer : consumers) {
-		if (consumer.read_state == ConsumerReadState::READING) {
+		if (!consumer.in_flight_reads.empty()) {
 			return;
 		}
-		consumer.shared_reader.reset();
 	}
 	buffer->Release();
 }
@@ -1401,9 +1469,6 @@ void PipelineBroadcastExchange::DeactivateAllConsumersLocked() {
 		}
 		consumer.lifecycle = ConsumerLifecycle::INACTIVE;
 		consumer.position = buffer->NextPosition();
-		if (consumer.read_state != ConsumerReadState::READING) {
-			consumer.shared_reader.reset();
-		}
 	}
 	active_consumers = 0;
 }

--- a/src/parallel/pipeline_broadcast_exchange.cpp
+++ b/src/parallel/pipeline_broadcast_exchange.cpp
@@ -316,8 +316,12 @@ struct PipelineBroadcastExchange::BufferState {
 		return min_batch_index;
 	}
 
-	void UpdateMinBatchIndex(idx_t new_min_batch_index) {
-		min_batch_index = MaxValue(min_batch_index, new_min_batch_index);
+	bool UpdateMinBatchIndex(idx_t new_min_batch_index) {
+		if (new_min_batch_index <= min_batch_index) {
+			return false;
+		}
+		min_batch_index = new_min_batch_index;
+		return true;
 	}
 
 	bool HasReadyBatch() const {
@@ -1016,25 +1020,33 @@ PipelineBroadcastExchange::FlushReadyBatches(idx_t min_batch_index, const Interr
 	bool appended = false;
 	while (true) {
 		vector<ExchangeLogEntry> log_entries;
+		vector<InterruptState> writers;
 		AppendAdmission admission;
 		AppendReservation reservation;
 		shared_ptr<DataChunk> copy;
+		bool has_ready_batch;
 		try {
 			annotated_lock_guard<annotated_mutex> guard(lock);
-			buffer->UpdateMinBatchIndex(min_batch_index);
-			if (!buffer->HasReadyBatch()) {
-				return appended ? BufferedPushState::APPENDED : BufferedPushState::NOT_REQUIRED;
+			if (buffer->UpdateMinBatchIndex(min_batch_index)) {
+				WakeWritersLocked(writers, log_entries, WriterWakeMode::FORCE);
 			}
-			admission = PrepareAppendLocked(interrupt_state, log_entries);
-			if (admission == AppendAdmission::READY) {
-				append_reservation_state = AppendReservationState::RESERVED;
-				copy = buffer->ReservePendingAppend(reservation);
+			has_ready_batch = buffer->HasReadyBatch();
+			if (has_ready_batch) {
+				admission = PrepareAppendLocked(interrupt_state, log_entries);
+				if (admission == AppendAdmission::READY) {
+					append_reservation_state = AppendReservationState::RESERVED;
+					copy = buffer->ReservePendingAppend(reservation);
+				}
 			}
 		} catch (...) {
 			Cancel();
 			throw;
 		}
+		CallbackAll(writers);
 		LogTransitions(log_entries);
+		if (!has_ready_batch) {
+			return appended ? BufferedPushState::APPENDED : BufferedPushState::NOT_REQUIRED;
+		}
 		if (admission == AppendAdmission::BLOCKED) {
 			return BufferedPushState::BLOCKED;
 		}
@@ -1065,7 +1077,7 @@ PipelineBroadcastExchange::FlushReadyBatches(idx_t min_batch_index, const Interr
 		}
 
 		vector<InterruptState> readers;
-		vector<InterruptState> writers;
+		writers.clear();
 		vector<InterruptState> appenders;
 		log_entries.clear();
 		BufferedPushState result;

--- a/src/parallel/pipeline_executor.cpp
+++ b/src/parallel/pipeline_executor.cpp
@@ -65,6 +65,7 @@ void PipelineExecutor::Reset() {
 	done_flushing = false;
 	remaining_sink_chunk = false;
 	next_batch_blocked = false;
+	external_batch_initialized = false;
 	finished_processing_idx = -1;
 	source_profiling_finalized = false;
 	source_finish_notification_state = SourceFinishNotificationState::PENDING;
@@ -214,20 +215,29 @@ SinkNextBatchType PipelineExecutor::NextBatch(DataChunk &source_chunk, const boo
 		D_ASSERT(local_source_state);
 		D_ASSERT(global_source_state);
 		// if we retrieved data - initialize the next batch index
-		auto partition_data = pipeline.source->GetPartitionData(context, source_chunk, *global_source_state,
-		                                                        *local_source_state, required_partition_info);
-		auto batch_index = partition_data.batch_index;
-		// we start with the base_batch_index as a valid starting value. Make sure that next batch is called below
-		next_data = std::move(partition_data);
-		next_data.batch_index = pipeline.base_batch_index + batch_index + 1;
-		if (next_data.batch_index >= max_batch_index) {
-			throw InternalException("Pipeline batch index - invalid batch index %llu returned by source operator",
-			                        batch_index);
-		}
+		auto source_data = pipeline.source->GetPartitionData(context, source_chunk, *global_source_state,
+		                                                     *local_source_state, required_partition_info);
+		next_data = ToPipelinePartitionData(source_data);
 	} else if (have_more_output) {
 		next_data.batch_index = partition_info.batch_index.GetIndex();
 	}
-	if (next_data.batch_index == partition_info.batch_index.GetIndex()) {
+	return NextBatch(std::move(next_data));
+}
+
+OperatorPartitionData PipelineExecutor::ToPipelinePartitionData(const OperatorPartitionData &source_data) const {
+	auto max_batch_index = pipeline.base_batch_index + PipelineBuildState::BATCH_INCREMENT - 1;
+	OperatorPartitionData result(pipeline.base_batch_index + source_data.batch_index + 1);
+	result.partition_data = source_data.partition_data;
+	if (result.batch_index >= max_batch_index) {
+		throw InternalException("Pipeline batch index - invalid batch index %llu returned by source operator",
+		                        source_data.batch_index);
+	}
+	return result;
+}
+
+SinkNextBatchType PipelineExecutor::NextBatch(OperatorPartitionData next_data, bool force) {
+	auto &partition_info = local_sink_state->partition_info;
+	if (!force && next_data.batch_index == partition_info.batch_index.GetIndex()) {
 		// no changes, return
 		return SinkNextBatchType::READY;
 	}
@@ -355,13 +365,22 @@ PipelineExecuteResult PipelineExecutor::Execute() {
 	return Execute(NumericLimits<idx_t>::Maximum());
 }
 
-PipelineExecuteResult PipelineExecutor::PushExternal(DataChunk &input) {
+PipelineExecuteResult PipelineExecutor::PushExternal(DataChunk &input,
+                                                     const OperatorPartitionData &source_partition_data) {
 	D_ASSERT(pipeline.sink);
 	D_ASSERT(pipeline.IsExternalInput());
 	if (IsFinished()) {
 		return PipelineExecuteResult::FINISHED;
 	}
-	if (!remaining_sink_chunk) {
+	if (required_partition_info.AnyRequired() && !remaining_sink_chunk) {
+		auto next_batch_result = NextBatch(ToPipelinePartitionData(source_partition_data), !external_batch_initialized);
+		next_batch_blocked = next_batch_result == SinkNextBatchType::BLOCKED;
+		if (next_batch_blocked) {
+			return PipelineExecuteResult::INTERRUPTED;
+		}
+		external_batch_initialized = true;
+	}
+	if (!remaining_sink_chunk && !next_batch_blocked) {
 		context.thread.profiler.StartOperator(pipeline.source.get());
 		context.thread.profiler.EndOperator(&input);
 	}
@@ -375,6 +394,15 @@ PipelineExecuteResult PipelineExecutor::FinishExternal() {
 	D_ASSERT(pipeline.IsExternalInput());
 	if (finalized) {
 		return PipelineExecuteResult::FINISHED;
+	}
+	if (required_partition_info.AnyRequired()) {
+		auto max_batch_index = pipeline.base_batch_index + PipelineBuildState::BATCH_INCREMENT - 1;
+		auto next_batch_result = NextBatch(OperatorPartitionData(max_batch_index), !external_batch_initialized);
+		next_batch_blocked = next_batch_result == SinkNextBatchType::BLOCKED;
+		if (next_batch_blocked) {
+			return PipelineExecuteResult::INTERRUPTED;
+		}
+		external_batch_initialized = true;
 	}
 
 	ExecutionBudget chunk_budget(NumericLimits<idx_t>::Maximum());

--- a/src/parallel/pipeline_executor.cpp
+++ b/src/parallel/pipeline_executor.cpp
@@ -19,7 +19,7 @@ PipelineExecutor::PipelineExecutor(ClientContext &context_p, Pipeline &pipeline_
 		local_sink_state = pipeline.sink->GetLocalSinkState(context);
 		required_partition_info = pipeline.sink->RequiredPartitionInfo();
 		if (required_partition_info.AnyRequired()) {
-			D_ASSERT(pipeline.source->SupportsPartitioning(OperatorPartitionInfo::BatchIndex()));
+			D_ASSERT(pipeline.source->SupportsPartitioning(required_partition_info));
 			auto &partition_info = local_sink_state->partition_info;
 			D_ASSERT(!partition_info.batch_index.IsValid());
 			// batch index is not set yet - initialize before fetching anything
@@ -83,7 +83,7 @@ void PipelineExecutor::Reset() {
 		required_partition_info = pipeline.sink->RequiredPartitionInfo();
 		local_sink_state->partition_info = SourcePartitionInfo();
 		if (required_partition_info.AnyRequired()) {
-			D_ASSERT(pipeline.source->SupportsPartitioning(OperatorPartitionInfo::BatchIndex()));
+			D_ASSERT(pipeline.source->SupportsPartitioning(required_partition_info));
 			auto &partition_info = local_sink_state->partition_info;
 			D_ASSERT(!partition_info.batch_index.IsValid());
 			partition_info.batch_index = pipeline.RegisterNewBatchIndex();

--- a/src/parallel/pipeline_executor.cpp
+++ b/src/parallel/pipeline_executor.cpp
@@ -23,7 +23,8 @@ PipelineExecutor::PipelineExecutor(ClientContext &context_p, Pipeline &pipeline_
 			auto &partition_info = local_sink_state->partition_info;
 			D_ASSERT(!partition_info.batch_index.IsValid());
 			// batch index is not set yet - initialize before fetching anything
-			partition_info.batch_index = pipeline.RegisterNewBatchIndex();
+			partition_info.batch_index =
+			    pipeline.IsExternalInput() ? pipeline.GetBaseBatchIndex() : pipeline.RegisterNewBatchIndex();
 			partition_info.min_batch_index = partition_info.batch_index;
 		}
 	}
@@ -87,7 +88,8 @@ void PipelineExecutor::Reset() {
 			D_ASSERT(pipeline.source->SupportsPartitioning(required_partition_info));
 			auto &partition_info = local_sink_state->partition_info;
 			D_ASSERT(!partition_info.batch_index.IsValid());
-			partition_info.batch_index = pipeline.RegisterNewBatchIndex();
+			partition_info.batch_index =
+			    pipeline.IsExternalInput() ? pipeline.GetBaseBatchIndex() : pipeline.RegisterNewBatchIndex();
 			partition_info.min_batch_index = partition_info.batch_index;
 		}
 	}
@@ -235,9 +237,35 @@ OperatorPartitionData PipelineExecutor::ToPipelinePartitionData(const OperatorPa
 	return result;
 }
 
-SinkNextBatchType PipelineExecutor::NextBatch(OperatorPartitionData next_data, bool force) {
+SinkNextBatchType PipelineExecutor::NextBatch(OperatorPartitionData next_data, bool force,
+                                              optional_idx external_min_batch_index) {
 	auto &partition_info = local_sink_state->partition_info;
+	optional_idx mapped_external_min_batch_index;
+	if (pipeline.IsExternalInput()) {
+		if (!external_min_batch_index.IsValid()) {
+			throw InternalException("External pipeline did not provide a minimum batch index");
+		}
+		auto min_batch_offset = external_min_batch_index.GetIndex();
+		if (min_batch_offset >= PipelineBuildState::BATCH_INCREMENT) {
+			throw InternalException("External pipeline minimum batch index is outside its pipeline");
+		}
+		auto min_batch_index = pipeline.GetBaseBatchIndex() + min_batch_offset;
+		if (min_batch_index > next_data.batch_index) {
+			throw InternalException("External pipeline minimum batch index %llu exceeds current batch index %llu",
+			                        min_batch_index, next_data.batch_index);
+		}
+		if (min_batch_index < partition_info.min_batch_index.GetIndex()) {
+			throw InternalException("External pipeline minimum batch index decreased from %llu to %llu",
+			                        partition_info.min_batch_index.GetIndex(), min_batch_index);
+		}
+		mapped_external_min_batch_index = min_batch_index;
+	} else if (external_min_batch_index.IsValid()) {
+		throw InternalException("Source-driven pipeline received an external minimum batch index");
+	}
 	if (!force && next_data.batch_index == partition_info.batch_index.GetIndex()) {
+		if (mapped_external_min_batch_index.IsValid()) {
+			partition_info.min_batch_index = mapped_external_min_batch_index;
+		}
 		// no changes, return
 		return SinkNextBatchType::READY;
 	}
@@ -273,7 +301,11 @@ SinkNextBatchType PipelineExecutor::NextBatch(OperatorPartitionData next_data, b
 		return SinkNextBatchType::BLOCKED;
 	}
 
-	partition_info.min_batch_index = pipeline.UpdateBatchIndex(current_batch, next_data.batch_index);
+	if (mapped_external_min_batch_index.IsValid()) {
+		partition_info.min_batch_index = mapped_external_min_batch_index;
+	} else {
+		partition_info.min_batch_index = pipeline.UpdateBatchIndex(current_batch, next_data.batch_index);
+	}
 
 	return SinkNextBatchType::READY;
 }
@@ -366,14 +398,16 @@ PipelineExecuteResult PipelineExecutor::Execute() {
 }
 
 PipelineExecuteResult PipelineExecutor::PushExternal(DataChunk &input,
-                                                     const OperatorPartitionData &source_partition_data) {
+                                                     const OperatorPartitionData &source_partition_data,
+                                                     optional_idx source_min_batch_index) {
 	D_ASSERT(pipeline.sink);
 	D_ASSERT(pipeline.IsExternalInput());
 	if (IsFinished()) {
 		return PipelineExecuteResult::FINISHED;
 	}
 	if (required_partition_info.AnyRequired() && !remaining_sink_chunk) {
-		auto next_batch_result = NextBatch(ToPipelinePartitionData(source_partition_data), !external_batch_initialized);
+		auto next_batch_result = NextBatch(ToPipelinePartitionData(source_partition_data), !external_batch_initialized,
+		                                   source_min_batch_index);
 		next_batch_blocked = next_batch_result == SinkNextBatchType::BLOCKED;
 		if (next_batch_blocked) {
 			return PipelineExecuteResult::INTERRUPTED;
@@ -389,7 +423,7 @@ PipelineExecuteResult PipelineExecutor::PushExternal(DataChunk &input,
 	return PushInputChunk(input, chunk_budget, PipelineInputChunkMode::PUSH_INPUT);
 }
 
-PipelineExecuteResult PipelineExecutor::FinishExternal() {
+PipelineExecuteResult PipelineExecutor::FinishExternal(optional_idx source_min_batch_index) {
 	D_ASSERT(pipeline.sink);
 	D_ASSERT(pipeline.IsExternalInput());
 	if (finalized) {
@@ -397,7 +431,8 @@ PipelineExecuteResult PipelineExecutor::FinishExternal() {
 	}
 	if (required_partition_info.AnyRequired()) {
 		auto max_batch_index = pipeline.base_batch_index + PipelineBuildState::BATCH_INCREMENT - 1;
-		auto next_batch_result = NextBatch(OperatorPartitionData(max_batch_index), !external_batch_initialized);
+		auto next_batch_result =
+		    NextBatch(OperatorPartitionData(max_batch_index), !external_batch_initialized, source_min_batch_index);
 		next_batch_blocked = next_batch_result == SinkNextBatchType::BLOCKED;
 		if (next_batch_blocked) {
 			return PipelineExecuteResult::INTERRUPTED;

--- a/src/parallel/pipeline_executor.cpp
+++ b/src/parallel/pipeline_executor.cpp
@@ -406,13 +406,10 @@ PipelineExecuteResult PipelineExecutor::PushExternal(DataChunk &input,
 		return PipelineExecuteResult::FINISHED;
 	}
 	if (required_partition_info.AnyRequired() && !remaining_sink_chunk) {
-		auto next_batch_result = NextBatch(ToPipelinePartitionData(source_partition_data), !external_batch_initialized,
-		                                   source_min_batch_index);
-		next_batch_blocked = next_batch_result == SinkNextBatchType::BLOCKED;
-		if (next_batch_blocked) {
-			return PipelineExecuteResult::INTERRUPTED;
+		auto next_batch_result = NextBatchExternal(source_partition_data, source_min_batch_index);
+		if (next_batch_result != PipelineExecuteResult::NOT_FINISHED) {
+			return next_batch_result;
 		}
-		external_batch_initialized = true;
 	}
 	if (!remaining_sink_chunk && !next_batch_blocked) {
 		context.thread.profiler.StartOperator(pipeline.source.get());
@@ -423,7 +420,44 @@ PipelineExecuteResult PipelineExecutor::PushExternal(DataChunk &input,
 	return PushInputChunk(input, chunk_budget, PipelineInputChunkMode::PUSH_INPUT);
 }
 
+PipelineExecuteResult PipelineExecutor::NextBatchExternal(const OperatorPartitionData &source_partition_data,
+                                                          optional_idx source_min_batch_index) {
+	D_ASSERT(pipeline.sink);
+	D_ASSERT(pipeline.IsExternalInput());
+	if (IsFinished()) {
+		return PipelineExecuteResult::FINISHED;
+	}
+	if (!required_partition_info.AnyRequired()) {
+		return PipelineExecuteResult::NOT_FINISHED;
+	}
+	auto next_batch_result =
+	    NextBatch(ToPipelinePartitionData(source_partition_data), !external_batch_initialized, source_min_batch_index);
+	next_batch_blocked = next_batch_result == SinkNextBatchType::BLOCKED;
+	if (next_batch_blocked) {
+		return PipelineExecuteResult::INTERRUPTED;
+	}
+	external_batch_initialized = true;
+	return PipelineExecuteResult::NOT_FINISHED;
+}
+
 PipelineExecuteResult PipelineExecutor::FinishExternal(optional_idx source_min_batch_index) {
+	D_ASSERT(pipeline.sink);
+	D_ASSERT(pipeline.IsExternalInput());
+	if (finalized) {
+		return PipelineExecuteResult::FINISHED;
+	}
+	auto finish_batch_result = FinishBatchExternal(source_min_batch_index);
+	if (finish_batch_result == PipelineExecuteResult::INTERRUPTED) {
+		return finish_batch_result;
+	}
+
+	ExecutionBudget chunk_budget(NumericLimits<idx_t>::Maximum());
+	exhausted_source = true;
+	exhausted_pipeline = true;
+	return FlushAndFinalize(chunk_budget);
+}
+
+PipelineExecuteResult PipelineExecutor::FinishBatchExternal(optional_idx source_min_batch_index) {
 	D_ASSERT(pipeline.sink);
 	D_ASSERT(pipeline.IsExternalInput());
 	if (finalized) {
@@ -439,11 +473,7 @@ PipelineExecuteResult PipelineExecutor::FinishExternal(optional_idx source_min_b
 		}
 		external_batch_initialized = true;
 	}
-
-	ExecutionBudget chunk_budget(NumericLimits<idx_t>::Maximum());
-	exhausted_source = true;
-	exhausted_pipeline = true;
-	return FlushAndFinalize(chunk_budget);
+	return PipelineExecuteResult::NOT_FINISHED;
 }
 
 bool PipelineExecutor::IsFinishedProcessing() const {

--- a/src/parallel/pipeline_executor.cpp
+++ b/src/parallel/pipeline_executor.cpp
@@ -13,7 +13,7 @@
 
 namespace duckdb {
 
-PipelineExecutor::PipelineExecutor(ClientContext &context_p, Pipeline &pipeline_p)
+PipelineExecutor::PipelineExecutor(ClientContext &context_p, Pipeline &pipeline_p, optional_idx reserved_batch_index)
     : pipeline(pipeline_p), thread(context_p), context(context_p, thread, &pipeline_p) {
 	if (pipeline.sink) {
 		local_sink_state = pipeline.sink->GetLocalSinkState(context);
@@ -23,8 +23,13 @@ PipelineExecutor::PipelineExecutor(ClientContext &context_p, Pipeline &pipeline_
 			auto &partition_info = local_sink_state->partition_info;
 			D_ASSERT(!partition_info.batch_index.IsValid());
 			// batch index is not set yet - initialize before fetching anything
-			partition_info.batch_index =
-			    pipeline.IsExternalInput() ? pipeline.GetBaseBatchIndex() : pipeline.RegisterNewBatchIndex();
+			if (pipeline.IsExternalInput()) {
+				D_ASSERT(!reserved_batch_index.IsValid());
+				partition_info.batch_index = pipeline.GetBaseBatchIndex();
+			} else {
+				partition_info.batch_index =
+				    reserved_batch_index.IsValid() ? reserved_batch_index.GetIndex() : pipeline.RegisterNewBatchIndex();
+			}
 			partition_info.min_batch_index = partition_info.batch_index;
 		}
 	}
@@ -335,7 +340,7 @@ PipelineExecuteResult PipelineExecutor::Execute(idx_t max_chunks) {
 			// the operators have to be called with the same input chunk to produce the rest of the output
 			D_ASSERT(source_chunk.size() > 0);
 			result = ExecutePushInternal(source_chunk, chunk_budget);
-		} else if (exhausted_pipeline && !next_batch_blocked && !done_flushing) {
+		} else if (exhausted_pipeline && (!next_batch_blocked || done_flushing)) {
 			// The pipeline was exhausted, try flushing all operators
 			return FlushAndFinalize(chunk_budget);
 		} else if (!exhausted_pipeline || next_batch_blocked) {
@@ -353,7 +358,8 @@ PipelineExecuteResult PipelineExecutor::Execute(idx_t max_chunks) {
 				}
 			}
 
-			if (required_partition_info.AnyRequired()) {
+			if (required_partition_info.AnyRequired() &&
+			    (source_result != SourceResultType::FINISHED || source_chunk.size() > 0)) {
 				auto next_batch_result = NextBatch(source_chunk, source_result == SourceResultType::HAVE_MORE_OUTPUT);
 				next_batch_blocked = next_batch_result == SinkNextBatchType::BLOCKED;
 				if (next_batch_blocked) {
@@ -613,6 +619,14 @@ PipelineExecuteResult PipelineExecutor::FlushAndFinalize(ExecutionBudget &chunk_
 			return PipelineExecuteResult::NOT_FINISHED;
 		}
 		done_flushing = true;
+	}
+	if (required_partition_info.AnyRequired() && !pipeline.IsExternalInput()) {
+		DataChunk empty_chunk;
+		auto next_batch_result = NextBatch(empty_chunk, false);
+		next_batch_blocked = next_batch_result == SinkNextBatchType::BLOCKED;
+		if (next_batch_blocked) {
+			return PipelineExecuteResult::INTERRUPTED;
+		}
 	}
 	return PushFinalize();
 }

--- a/src/planner/operator/logical_column_data_get.cpp
+++ b/src/planner/operator/logical_column_data_get.cpp
@@ -80,9 +80,8 @@ unique_ptr<LogicalOperator> LogicalColumnDataGet::Deserialize(Deserializer &dese
 	auto chunk_types = deserializer.ReadPropertyWithDefault<vector<LogicalType>>(201, "chunk_types");
 	auto collection =
 	    deserializer.ReadPropertyWithDefault<optionally_owned_ptr<ColumnDataCollection>>(202, "collection");
-	auto result =
-	    duckdb::unique_ptr<LogicalColumnDataGet>(new LogicalColumnDataGet(table_index, std::move(chunk_types),
-	                                                                      std::move(collection)));
+	auto result = duckdb::unique_ptr<LogicalColumnDataGet>(
+	    new LogicalColumnDataGet(table_index, std::move(chunk_types), std::move(collection)));
 	if (deserializer.CanDeserializeProperty(203, "column_ids")) {
 		deserializer.ReadProperty(203, "column_ids", result->column_ids);
 	}

--- a/src/planner/operator/logical_column_data_get.cpp
+++ b/src/planner/operator/logical_column_data_get.cpp
@@ -1,15 +1,27 @@
 #include "duckdb/planner/operator/logical_column_data_get.hpp"
 
+#include "duckdb/common/serializer/deserializer.hpp"
+#include "duckdb/common/serializer/serializer.hpp"
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/main/config.hpp"
 
 namespace duckdb {
+
+static vector<column_t> GenerateColumnDataColumnIds(idx_t column_count) {
+	vector<column_t> column_ids;
+	column_ids.reserve(column_count);
+	for (idx_t i = 0; i < column_count; i++) {
+		column_ids.push_back(i);
+	}
+	return column_ids;
+}
 
 LogicalColumnDataGet::LogicalColumnDataGet(TableIndex table_index, vector<LogicalType> types,
                                            unique_ptr<ColumnDataCollection> collection_p)
     : LogicalOperator(LogicalOperatorType::LOGICAL_CHUNK_GET), table_index(table_index),
       collection(std::move(collection_p)) {
 	D_ASSERT(!types.empty());
+	column_ids = GenerateColumnDataColumnIds(types.size());
 	chunk_types = std::move(types);
 }
 
@@ -17,6 +29,7 @@ LogicalColumnDataGet::LogicalColumnDataGet(TableIndex table_index, vector<Logica
                                            ColumnDataCollection &to_scan)
     : LogicalOperator(LogicalOperatorType::LOGICAL_CHUNK_GET), table_index(table_index), collection(to_scan) {
 	D_ASSERT(!types.empty());
+	column_ids = GenerateColumnDataColumnIds(types.size());
 	chunk_types = std::move(types);
 }
 
@@ -25,11 +38,20 @@ LogicalColumnDataGet::LogicalColumnDataGet(TableIndex table_index, vector<Logica
     : LogicalOperator(LogicalOperatorType::LOGICAL_CHUNK_GET), table_index(table_index),
       collection(std::move(collection_p)) {
 	D_ASSERT(!types.empty());
+	column_ids = GenerateColumnDataColumnIds(types.size());
 	chunk_types = std::move(types);
 }
 
+void LogicalColumnDataGet::SetColumnIds(vector<column_t> column_ids_p) {
+	column_ids = std::move(column_ids_p);
+}
+
+const vector<column_t> &LogicalColumnDataGet::GetColumnIds() const {
+	return column_ids;
+}
+
 vector<ColumnBinding> LogicalColumnDataGet::GetColumnBindings() {
-	return GenerateColumnBindings(table_index, chunk_types.size());
+	return GenerateColumnBindings(table_index, column_ids.size());
 }
 
 vector<TableIndex> LogicalColumnDataGet::GetTableIndex() const {
@@ -43,6 +65,28 @@ string LogicalColumnDataGet::GetName() const {
 	}
 #endif
 	return LogicalOperator::GetName();
+}
+
+void LogicalColumnDataGet::Serialize(Serializer &serializer) const {
+	LogicalOperator::Serialize(serializer);
+	serializer.WritePropertyWithDefault<TableIndex>(200, "table_index", table_index);
+	serializer.WritePropertyWithDefault<vector<LogicalType>>(201, "chunk_types", chunk_types);
+	serializer.WritePropertyWithDefault<optionally_owned_ptr<ColumnDataCollection>>(202, "collection", collection);
+	serializer.WriteProperty(203, "column_ids", column_ids);
+}
+
+unique_ptr<LogicalOperator> LogicalColumnDataGet::Deserialize(Deserializer &deserializer) {
+	auto table_index = deserializer.ReadPropertyWithDefault<TableIndex>(200, "table_index");
+	auto chunk_types = deserializer.ReadPropertyWithDefault<vector<LogicalType>>(201, "chunk_types");
+	auto collection =
+	    deserializer.ReadPropertyWithDefault<optionally_owned_ptr<ColumnDataCollection>>(202, "collection");
+	auto result =
+	    duckdb::unique_ptr<LogicalColumnDataGet>(new LogicalColumnDataGet(table_index, std::move(chunk_types),
+	                                                                      std::move(collection)));
+	if (deserializer.CanDeserializeProperty(203, "column_ids")) {
+		deserializer.ReadProperty(203, "column_ids", result->column_ids);
+	}
+	return std::move(result);
 }
 
 } // namespace duckdb

--- a/src/planner/operator/logical_column_data_get.cpp
+++ b/src/planner/operator/logical_column_data_get.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/planner/operator/logical_column_data_get.hpp"
 
+#include "duckdb/common/exception.hpp"
 #include "duckdb/common/serializer/deserializer.hpp"
 #include "duckdb/common/serializer/serializer.hpp"
 #include "duckdb/common/types/data_chunk.hpp"
@@ -21,16 +22,16 @@ LogicalColumnDataGet::LogicalColumnDataGet(TableIndex table_index, vector<Logica
     : LogicalOperator(LogicalOperatorType::LOGICAL_CHUNK_GET), table_index(table_index),
       collection(std::move(collection_p)) {
 	D_ASSERT(!types.empty());
-	column_ids = GenerateColumnDataColumnIds(types.size());
 	chunk_types = std::move(types);
+	SetColumnIds(GenerateColumnDataColumnIds(chunk_types.size()));
 }
 
 LogicalColumnDataGet::LogicalColumnDataGet(TableIndex table_index, vector<LogicalType> types,
                                            ColumnDataCollection &to_scan)
     : LogicalOperator(LogicalOperatorType::LOGICAL_CHUNK_GET), table_index(table_index), collection(to_scan) {
 	D_ASSERT(!types.empty());
-	column_ids = GenerateColumnDataColumnIds(types.size());
 	chunk_types = std::move(types);
+	SetColumnIds(GenerateColumnDataColumnIds(chunk_types.size()));
 }
 
 LogicalColumnDataGet::LogicalColumnDataGet(TableIndex table_index, vector<LogicalType> types,
@@ -38,12 +39,19 @@ LogicalColumnDataGet::LogicalColumnDataGet(TableIndex table_index, vector<Logica
     : LogicalOperator(LogicalOperatorType::LOGICAL_CHUNK_GET), table_index(table_index),
       collection(std::move(collection_p)) {
 	D_ASSERT(!types.empty());
-	column_ids = GenerateColumnDataColumnIds(types.size());
 	chunk_types = std::move(types);
+	SetColumnIds(GenerateColumnDataColumnIds(chunk_types.size()));
 }
 
 void LogicalColumnDataGet::SetColumnIds(vector<column_t> column_ids_p) {
+	for (auto column_id : column_ids_p) {
+		if (column_id >= chunk_types.size()) {
+			throw SerializationException("LogicalColumnDataGet column id %llu is out of bounds for %llu chunk types",
+			                             column_id, chunk_types.size());
+		}
+	}
 	column_ids = std::move(column_ids_p);
+	ResolveTypes();
 }
 
 const vector<column_t> &LogicalColumnDataGet::GetColumnIds() const {
@@ -72,7 +80,8 @@ void LogicalColumnDataGet::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<TableIndex>(200, "table_index", table_index);
 	serializer.WritePropertyWithDefault<vector<LogicalType>>(201, "chunk_types", chunk_types);
 	serializer.WritePropertyWithDefault<optionally_owned_ptr<ColumnDataCollection>>(202, "collection", collection);
-	serializer.WriteProperty(203, "column_ids", column_ids);
+	serializer.WritePropertyWithDefault<vector<column_t>>(203, "column_ids", column_ids,
+	                                                      GenerateColumnDataColumnIds(chunk_types.size()));
 }
 
 unique_ptr<LogicalOperator> LogicalColumnDataGet::Deserialize(Deserializer &deserializer) {
@@ -83,7 +92,9 @@ unique_ptr<LogicalOperator> LogicalColumnDataGet::Deserialize(Deserializer &dese
 	auto result = duckdb::unique_ptr<LogicalColumnDataGet>(
 	    new LogicalColumnDataGet(table_index, std::move(chunk_types), std::move(collection)));
 	if (deserializer.CanDeserializeProperty(203, "column_ids")) {
-		deserializer.ReadProperty(203, "column_ids", result->column_ids);
+		vector<column_t> column_ids;
+		deserializer.ReadProperty(203, "column_ids", column_ids);
+		result->SetColumnIds(std::move(column_ids));
 	}
 	return std::move(result);
 }

--- a/src/storage/serialization/serialize_logical_operator.cpp
+++ b/src/storage/serialization/serialize_logical_operator.cpp
@@ -347,21 +347,6 @@ unique_ptr<LogicalOperator> LogicalCTERef::Deserialize(Deserializer &deserialize
 	return std::move(result);
 }
 
-void LogicalColumnDataGet::Serialize(Serializer &serializer) const {
-	LogicalOperator::Serialize(serializer);
-	serializer.WritePropertyWithDefault<TableIndex>(200, "table_index", table_index);
-	serializer.WritePropertyWithDefault<vector<LogicalType>>(201, "chunk_types", chunk_types);
-	serializer.WritePropertyWithDefault<optionally_owned_ptr<ColumnDataCollection>>(202, "collection", collection);
-}
-
-unique_ptr<LogicalOperator> LogicalColumnDataGet::Deserialize(Deserializer &deserializer) {
-	auto table_index = deserializer.ReadPropertyWithDefault<TableIndex>(200, "table_index");
-	auto chunk_types = deserializer.ReadPropertyWithDefault<vector<LogicalType>>(201, "chunk_types");
-	auto collection = deserializer.ReadPropertyWithDefault<optionally_owned_ptr<ColumnDataCollection>>(202, "collection");
-	auto result = duckdb::unique_ptr<LogicalColumnDataGet>(new LogicalColumnDataGet(table_index, std::move(chunk_types), std::move(collection)));
-	return std::move(result);
-}
-
 void LogicalComparisonJoin::Serialize(Serializer &serializer) const {
 	LogicalOperator::Serialize(serializer);
 	serializer.WriteProperty<JoinType>(200, "join_type", join_type);

--- a/test/api/test_pending_query.cpp
+++ b/test/api/test_pending_query.cpp
@@ -290,6 +290,23 @@ TEST_CASE("Stream results from materialized CTE exchanges", "[api]") {
 		}
 		REQUIRE(count == 1000000);
 	}
+	SECTION("Ordered sink pipeline sequencing") {
+		auto pending = con.PendingQuery("WITH c1 AS MATERIALIZED (SELECT i FROM range(10000) t(i)), "
+		                                "c2 AS MATERIALIZED (SELECT i FROM c1), "
+		                                "c3 AS MATERIALIZED (SELECT i + 10000 AS i FROM c1) "
+		                                "SELECT i FROM c2 UNION ALL SELECT i FROM c3",
+		                                true);
+		REQUIRE(!pending->HasError());
+
+		auto result = pending->Execute();
+		REQUIRE(result->type == QueryResultType::STREAM_RESULT);
+		idx_t count = 0;
+		while (auto chunk = result->Fetch()) {
+			REQUIRE(chunk->GetValue(0, 0).GetValue<int64_t>() == NumericCast<int64_t>(count));
+			count += chunk->size();
+		}
+		REQUIRE(count == 20000);
+	}
 }
 
 static void parallel_pending_query(Connection *conn, bool *correct, size_t threadnr) {

--- a/test/api/test_pending_query.cpp
+++ b/test/api/test_pending_query.cpp
@@ -256,6 +256,42 @@ TEST_CASE("Interrupt is observed by PendingQueryResult::ExecuteTask", "[api]") {
 	REQUIRE(saw_error);
 }
 
+TEST_CASE("Stream results from materialized CTE exchanges", "[api]") {
+	DuckDB db;
+	Connection con(db);
+
+	REQUIRE_NO_FAIL(con.Query("SET threads=4"));
+	REQUIRE_NO_FAIL(con.Query("SET streaming_buffer_size='16KB'"));
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE integers AS SELECT i FROM range(1000000) t(i)"));
+
+	SECTION("Direct batch-indexed exchange") {
+		auto pending = con.PendingQuery("WITH c AS MATERIALIZED (SELECT i FROM integers) SELECT i FROM c", true);
+		REQUIRE(!pending->HasError());
+
+		auto result = pending->Execute();
+		REQUIRE(result->type == QueryResultType::STREAM_RESULT);
+		idx_t count = 0;
+		while (auto chunk = result->Fetch()) {
+			REQUIRE(chunk->GetValue(0, 0).GetValue<int64_t>() == NumericCast<int64_t>(count));
+			count += chunk->size();
+		}
+		REQUIRE(count == 1000000);
+	}
+	SECTION("Buffered unordered exchange") {
+		REQUIRE_NO_FAIL(con.Query("SET preserve_insertion_order=false"));
+		auto pending = con.PendingQuery("WITH c AS MATERIALIZED (SELECT i FROM integers) SELECT i FROM c", true);
+		REQUIRE(!pending->HasError());
+
+		auto result = pending->Execute();
+		REQUIRE(result->type == QueryResultType::STREAM_RESULT);
+		idx_t count = 0;
+		while (auto chunk = result->Fetch()) {
+			count += chunk->size();
+		}
+		REQUIRE(count == 1000000);
+	}
+}
+
 static void parallel_pending_query(Connection *conn, bool *correct, size_t threadnr) {
 	correct[threadnr] = true;
 	for (size_t i = 0; i < 100; i++) {

--- a/test/api/test_threads.cpp
+++ b/test/api/test_threads.cpp
@@ -1,8 +1,12 @@
 #include "catch.hpp"
 #include "test_helpers.hpp"
+#include "duckdb/execution/operator/scan/physical_column_data_scan.hpp"
+#include "duckdb/execution/physical_plan_generator.hpp"
+#include "duckdb/main/materialized_query_result.hpp"
 #include "duckdb/parallel/task_scheduler.hpp"
 #include "duckdb/common/virtual_file_system.hpp"
 #include "duckdb/main/settings.hpp"
+#include "duckdb/storage/storage_info.hpp"
 
 #include <thread>
 
@@ -132,6 +136,43 @@ TEST_CASE("Test async threads", "[api]") {
 	con.Query("SET async_threads=2");
 	REQUIRE(scheduler.NumberOfAsyncThreads() == 2);
 }
+
+static idx_t ColumnDataScanMaxThreads(Connection &con, MaterializedQueryResult &result,
+                                      const OperatorPartitionInfo &partition_info) {
+	PhysicalPlan physical_plan(Allocator::Get(*con.context));
+	auto &scan = physical_plan.Make<PhysicalColumnDataScan>(result.types, PhysicalOperatorType::COLUMN_DATA_SCAN,
+	                                                        result.Collection().Count(), result.Collection());
+	auto source_state = scan.GetGlobalSourceState(*con.context, partition_info);
+	return source_state->MaxThreads();
+}
+
+#if STANDARD_VECTOR_SIZE <= 4096
+TEST_CASE("Column data scan batch sizes preserve source parallelism", "[api]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	REQUIRE_NO_FAIL(con.Query("SET threads=8"));
+
+	const idx_t small_count = STANDARD_VECTOR_SIZE * 16;
+	auto small_result = con.Query(StringUtil::Format("SELECT i FROM range(%llu) t(i)", small_count));
+	REQUIRE(!small_result->HasError());
+	auto &small_materialized = *small_result;
+
+	REQUIRE(ColumnDataScanMaxThreads(con, small_materialized, OperatorPartitionInfo::NoPartitionInfo()) == 16);
+	REQUIRE(ColumnDataScanMaxThreads(con, small_materialized, OperatorPartitionInfo::BatchIndex()) == 8);
+	REQUIRE(ColumnDataScanMaxThreads(con, small_materialized,
+	                                 OperatorPartitionInfo::BatchIndex(DEFAULT_ROW_GROUP_SIZE)) == 8);
+
+#if STANDARD_VECTOR_SIZE >= 512
+	const idx_t large_count = DEFAULT_ROW_GROUP_SIZE * 8 + STANDARD_VECTOR_SIZE;
+	auto large_result = con.Query(StringUtil::Format("SELECT i FROM range(%llu) t(i)", large_count));
+	REQUIRE(!large_result->HasError());
+	auto &large_materialized = *large_result;
+	REQUIRE(ColumnDataScanMaxThreads(con, large_materialized, OperatorPartitionInfo::BatchIndex()) == 9);
+	REQUIRE(ColumnDataScanMaxThreads(con, large_materialized,
+	                                 OperatorPartitionInfo::BatchIndex(DEFAULT_ROW_GROUP_SIZE)) == 9);
+#endif
+}
+#endif
 #endif
 
 #ifdef DUCKDB_NO_THREADS

--- a/test/issues/internal/test_5457.test
+++ b/test/issues/internal/test_5457.test
@@ -21,4 +21,4 @@ SELECT 42;
 statement error
 EXPLAIN SELECT 42;
 ----
-failed to allocate
+<REGEX>:.*Out of Memory Error.*

--- a/test/sql/copy/parquet/cte_batch_exchange.test
+++ b/test/sql/copy/parquet/cte_batch_exchange.test
@@ -1,0 +1,41 @@
+# name: test/sql/copy/parquet/cte_batch_exchange.test
+# description: Test batch-indexed direct CTE input for Parquet writes
+# group: [parquet]
+
+require parquet
+
+statement ok
+PRAGMA threads=4;
+
+statement ok
+CREATE TABLE cte_parquet_source AS SELECT i FROM range(1000000) t(i);
+
+query II
+EXPLAIN ANALYZE
+COPY (
+	WITH c AS MATERIALIZED (SELECT i FROM cte_parquet_source)
+	SELECT i FROM c
+) TO '{TEST_DIR}/cte_batch_exchange.parquet' (FORMAT parquet);
+----
+analyzed_plan	<REGEX>:.*Fanout Mode: DIRECT.*Order Mode: BATCH_INDEX.*Preferred Batch Size: 122880.*
+
+query III
+SELECT count(*), min(i), max(i)
+FROM read_parquet('{TEST_DIR}/cte_batch_exchange.parquet');
+----
+1000000	0	999999
+
+query I
+SELECT row_group_num_rows
+FROM parquet_metadata('{TEST_DIR}/cte_batch_exchange.parquet')
+ORDER BY row_group_id;
+----
+122880
+122880
+122880
+122880
+122880
+122880
+122880
+122880
+16960

--- a/test/sql/cte/dml_cte.test
+++ b/test/sql/cte/dml_cte.test
@@ -580,6 +580,17 @@ SELECT sel.* FROM sel;
 1	10
 2	20
 
+# The dependency also applies when the SELECT CTE streams through an exchange.
+statement ok
+TRUNCATE t1;
+
+query I
+WITH ins AS (INSERT INTO t1 VALUES (1, 10), (2, 20) RETURNING i),
+     sel AS MATERIALIZED (SELECT * FROM t1)
+SELECT count(*) FROM sel;
+----
+2
+
 # INSERT followed by UPDATE on the same table: the UPDATE's scan is initialised
 # after the INSERT completes, so it sees the newly inserted rows and updates them.
 statement ok

--- a/test/sql/cte/materialized/materialized_cte_order_preservation.test
+++ b/test/sql/cte/materialized/materialized_cte_order_preservation.test
@@ -2,6 +2,8 @@
 # description: Test order preservation for materialized CTE scans
 # group: [materialized]
 
+require vector_size 2048
+
 statement ok
 PRAGMA threads=4;
 

--- a/test/sql/cte/materialized/materialized_cte_order_preservation.test
+++ b/test/sql/cte/materialized/materialized_cte_order_preservation.test
@@ -6,11 +6,23 @@ statement ok
 PRAGMA threads=4;
 
 statement ok
+CREATE TABLE cte_order_batch AS SELECT i FROM range(1000000) tbl(i);
+
+query II
+EXPLAIN ANALYZE
+WITH t(i) AS MATERIALIZED (
+	SELECT i FROM cte_order_batch
+)
+SELECT i FROM t LIMIT 5 OFFSET 500000;
+----
+analyzed_plan	<REGEX>:.*Fanout Mode: BUFFERED.*Order Mode: BATCH_INDEX.*
+
+statement ok
 PRAGMA verify_parallelism;
 
 query I
 WITH t(i) AS MATERIALIZED (
-	SELECT i FROM range(1000000) tbl(i)
+	SELECT i FROM cte_order_batch
 )
 SELECT i FROM t LIMIT 5 OFFSET 500000;
 ----
@@ -19,6 +31,23 @@ SELECT i FROM t LIMIT 5 OFFSET 500000;
 500002
 500003
 500004
+
+query I
+WITH t(i) AS MATERIALIZED (
+	SELECT i FROM range(1000000) tbl(i)
+)
+SELECT i FROM t WHERE i % 100000 = 0;
+----
+0
+100000
+200000
+300000
+400000
+500000
+600000
+700000
+800000
+900000
 
 query II
 WITH t(i) AS MATERIALIZED (

--- a/test/sql/cte/materialized/materialized_cte_order_preservation.test
+++ b/test/sql/cte/materialized/materialized_cte_order_preservation.test
@@ -48,3 +48,27 @@ SELECT (SELECT i FROM t LIMIT 1), (SELECT i FROM t LIMIT 1);
 
 statement ok
 SET preserve_insertion_order=true;
+
+query I
+WITH t(i, j) AS MATERIALIZED (
+	SELECT i, i + 1
+	FROM range(10000) tbl(i)
+	ORDER BY i DESC
+)
+SELECT j FROM t LIMIT 5;
+----
+10000
+9999
+9998
+9997
+9996
+
+query I
+WITH t(i, j) AS MATERIALIZED (
+	SELECT i, i + 1
+	FROM range(10000) tbl(i)
+	ORDER BY i DESC
+)
+SELECT count(*) FROM t;
+----
+10000

--- a/test/sql/cte/materialized/materialized_cte_order_preservation.test
+++ b/test/sql/cte/materialized/materialized_cte_order_preservation.test
@@ -5,6 +5,87 @@
 statement ok
 PRAGMA threads=4;
 
+statement ok
+PRAGMA verify_parallelism;
+
+query I
+WITH t(i) AS MATERIALIZED (
+	SELECT i FROM range(1000000) tbl(i)
+)
+SELECT i FROM t LIMIT 5 OFFSET 500000;
+----
+500000
+500001
+500002
+500003
+500004
+
+query II
+WITH t(i) AS MATERIALIZED (
+	SELECT i FROM range(1000000) tbl(i)
+)
+SELECT (SELECT i FROM t LIMIT 1 OFFSET 500000), (SELECT sum(i) FROM t);
+----
+500000	499999500000
+
+query II
+WITH t(i) AS MATERIALIZED (
+	SELECT i FROM range(1000000) tbl(i)
+)
+SELECT (SELECT i FROM t LIMIT 1 OFFSET 100000), (SELECT i FROM t LIMIT 1 OFFSET 900000);
+----
+100000	900000
+
+query I
+WITH t(i) AS MATERIALIZED (
+	SELECT i FROM range(200000) tbl(i)
+	UNION ALL
+	SELECT i + 200000 FROM range(200000) tbl(i)
+)
+SELECT i FROM t LIMIT 5 OFFSET 250000;
+----
+250000
+250001
+250002
+250003
+250004
+
+statement ok
+CREATE TABLE cte_order_left AS SELECT i FROM range(4000) tbl(i);
+
+statement ok
+CREATE TABLE cte_order_right AS SELECT i + 4000 AS i FROM range(4000) tbl(i);
+
+query I
+WITH t AS MATERIALIZED (
+	SELECT * FROM cte_order_left
+	UNION ALL
+	SELECT * FROM cte_order_right
+)
+SELECT i FROM t LIMIT 5 OFFSET 5000;
+----
+5000
+5001
+5002
+5003
+5004
+
+statement ok
+PREPARE ordered_cte AS
+WITH t(i) AS MATERIALIZED (
+	SELECT i FROM range(500000) tbl(i)
+)
+SELECT i FROM t LIMIT 1 OFFSET 300000;
+
+loop i 0 5
+
+query I
+EXECUTE ordered_cte;
+----
+300000
+
+endloop
+
 query I
 WITH t(i) AS MATERIALIZED (
 	SELECT i
@@ -72,3 +153,16 @@ WITH t(i, j) AS MATERIALIZED (
 SELECT count(*) FROM t;
 ----
 10000
+
+statement ok
+SET threads=1;
+
+query I
+WITH t(i) AS MATERIALIZED (
+	VALUES (1), (2), (3), (4), (5)
+)
+SELECT i FROM t LIMIT 3 OFFSET 1;
+----
+2
+3
+4

--- a/test/sql/cte/materialized/materialized_cte_order_preservation.test
+++ b/test/sql/cte/materialized/materialized_cte_order_preservation.test
@@ -17,6 +17,21 @@ SELECT i FROM t LIMIT 5 OFFSET 500000;
 ----
 analyzed_plan	<REGEX>:.*Fanout Mode: BUFFERED.*Order Mode: BATCH_INDEX.*
 
+query II
+EXPLAIN ANALYZE
+CREATE TABLE cte_order_direct AS
+WITH t(i) AS MATERIALIZED (
+	SELECT i FROM cte_order_batch
+)
+SELECT i FROM t;
+----
+analyzed_plan	<REGEX>:.*Fanout Mode: DIRECT.*Order Mode: BATCH_INDEX.*Preferred Batch Size: 122880.*
+
+query III
+SELECT count(*), min(i), max(i) FROM cte_order_direct;
+----
+1000000	0	999999
+
 statement ok
 PRAGMA verify_parallelism;
 
@@ -34,7 +49,7 @@ SELECT i FROM t LIMIT 5 OFFSET 500000;
 
 query I
 WITH t(i) AS MATERIALIZED (
-	SELECT i FROM range(1000000) tbl(i)
+	SELECT i FROM cte_order_batch
 )
 SELECT i FROM t WHERE i % 100000 = 0;
 ----
@@ -48,6 +63,34 @@ SELECT i FROM t WHERE i % 100000 = 0;
 700000
 800000
 900000
+
+query I
+CREATE TABLE cte_order_sparse AS
+WITH t(i) AS MATERIALIZED (
+	SELECT i FROM cte_order_batch WHERE i % 100000 = 0
+)
+SELECT i FROM t;
+----
+10
+
+query III
+SELECT count(*), min(i), max(i) FROM cte_order_sparse;
+----
+10	0	900000
+
+query I
+CREATE TABLE cte_order_empty AS
+WITH t(i) AS MATERIALIZED (
+	SELECT i FROM cte_order_batch WHERE false
+)
+SELECT i FROM t;
+----
+0
+
+query I
+SELECT count(*) FROM cte_order_empty;
+----
+0
 
 query II
 WITH t(i) AS MATERIALIZED (
@@ -84,6 +127,18 @@ CREATE TABLE cte_order_left AS SELECT i FROM range(4000) tbl(i);
 
 statement ok
 CREATE TABLE cte_order_right AS SELECT i + 4000 AS i FROM range(4000) tbl(i);
+
+query II
+EXPLAIN ANALYZE
+CREATE TABLE cte_order_union_copy AS
+WITH t AS MATERIALIZED (
+	SELECT * FROM cte_order_left
+	UNION ALL
+	SELECT * FROM cte_order_right
+)
+SELECT i FROM t;
+----
+analyzed_plan	<REGEX>:.*Fanout Mode: BUFFERED.*Order Mode: BATCH_INDEX.*Preferred Batch Size: 122880.*
 
 query I
 WITH t AS MATERIALIZED (
@@ -122,6 +177,26 @@ WITH t(i) AS MATERIALIZED (
 	ORDER BY i DESC
 )
 SELECT i FROM t LIMIT 5;
+----
+9999
+9998
+9997
+9996
+9995
+
+query I
+CREATE TABLE cte_order_sorted_copy AS
+WITH t(i) AS MATERIALIZED (
+	SELECT i
+	FROM range(10000) tbl(i)
+	ORDER BY i DESC
+)
+SELECT i FROM t;
+----
+10000
+
+query I
+SELECT i FROM cte_order_sorted_copy LIMIT 5;
 ----
 9999
 9998

--- a/test/sql/cte/materialized/materialized_cte_order_preservation.test
+++ b/test/sql/cte/materialized/materialized_cte_order_preservation.test
@@ -1,0 +1,50 @@
+# name: test/sql/cte/materialized/materialized_cte_order_preservation.test
+# description: Test order preservation for materialized CTE scans
+# group: [materialized]
+
+statement ok
+PRAGMA threads=4;
+
+query I
+WITH t(i) AS MATERIALIZED (
+	SELECT i
+	FROM range(10000) tbl(i)
+	ORDER BY i DESC
+)
+SELECT i FROM t LIMIT 5;
+----
+9999
+9998
+9997
+9996
+9995
+
+statement ok
+SET preserve_insertion_order=false;
+
+query I
+WITH t(i) AS MATERIALIZED (
+	SELECT i
+	FROM range(10000) tbl(i)
+	ORDER BY i DESC
+)
+SELECT i FROM t LIMIT 5;
+----
+9999
+9998
+9997
+9996
+9995
+
+query II
+WITH t(i) AS MATERIALIZED (
+	SELECT i
+	FROM range(10000) tbl(i)
+	ORDER BY i DESC
+)
+SELECT (SELECT i FROM t LIMIT 1), (SELECT i FROM t LIMIT 1);
+----
+9999	9999
+
+statement ok
+SET preserve_insertion_order=true;

--- a/test/sql/cte/materialized/materialized_cte_prepared.test
+++ b/test/sql/cte/materialized/materialized_cte_prepared.test
@@ -49,6 +49,33 @@ WHERE tag IN ('ALLOCATOR', 'IN_MEMORY_TABLE')
 0	ALLOCATOR
 0	IN_MEMORY_TABLE
 
+# Batch-aware direct consumers reset their external executors between prepared executions.
+statement ok
+CREATE TABLE prepared_batch_source AS SELECT i FROM range(100000) t(i);
+
+statement ok
+CREATE TABLE prepared_batch_target(i BIGINT);
+
+statement ok
+PREPARE direct_batch_cte AS
+INSERT INTO prepared_batch_target
+WITH c AS MATERIALIZED (SELECT i FROM prepared_batch_source)
+SELECT i FROM c;
+
+loop i 0 5
+
+query I
+EXECUTE direct_batch_cte
+----
+100000
+
+endloop
+
+query III
+SELECT count(*), min(i), max(i) FROM prepared_batch_target;
+----
+500000	0	99999
+
 statement ok
 create table a(i integer);
 

--- a/test/sql/json/test_json_serialize_plan.test
+++ b/test/sql/json/test_json_serialize_plan.test
@@ -34,6 +34,18 @@ SELECT json_serialize_plan('SELECT *, 1 + 2 FROM tbl1', skip_null := true, skip_
 ----
 <REGEX>:.*LOGICAL_PROJECTION.*LOGICAL_GET.*
 
+# Optimized IN clauses use LogicalColumnDataGet internally
+query II
+SELECT plan::VARCHAR LIKE '%LOGICAL_CHUNK_GET%', plan::VARCHAR NOT LIKE '%"column_ids"%'
+FROM (
+	SELECT json_serialize_plan(
+		'SELECT i FROM range(20) t(i) WHERE i IN (1, 3, 5, 7, 9, 11)',
+		skip_default := true, optimize := true
+	) plan
+);
+----
+true	true
+
 # Example with syntax error
 query I
 SELECT json_serialize_plan('SELECT AND LAUNCH ROCKETS WHERE 1 = 1');

--- a/test/sql/json/test_json_serialize_plan.test
+++ b/test/sql/json/test_json_serialize_plan.test
@@ -46,6 +46,24 @@ FROM (
 ----
 true	true
 
+# Projected LogicalColumnDataGet plans serialize their underlying column ids
+query I
+SELECT column_name FROM (DESCRIBE SELECT 42 AS a, 84 AS b);
+----
+a
+b
+
+query II
+SELECT plan::VARCHAR LIKE '%LOGICAL_CHUNK_GET%', plan::VARCHAR LIKE '%"column_ids"%'
+FROM (
+	SELECT json_serialize_plan(
+		'SELECT column_name FROM (DESCRIBE SELECT 42 AS a, 84 AS b)',
+		skip_default := true, optimize := true
+	) plan
+);
+----
+true	true
+
 # Example with syntax error
 query I
 SELECT json_serialize_plan('SELECT AND LAUNCH ROCKETS WHERE 1 = 1');

--- a/tools/shell/tests/test_last_result.py
+++ b/tools/shell/tests/test_last_result.py
@@ -84,5 +84,41 @@ def test_last_result_alias_self_join(shell):
     assert 'd1' not in result.stderr
     result.check_stdout("a")
 
+def test_last_result_common_subplan_column_pruning(shell):
+    common_subplan_query = """
+        SELECT sum(a)
+        FROM (
+            SELECT retained.a
+            FROM _ AS retained
+            JOIN range(100) generated ON retained.a = generated.range
+        )
+        UNION ALL
+        SELECT sum(b)
+        FROM (
+            SELECT retained.b
+            FROM _ AS retained
+            JOIN range(100) generated ON retained.a = generated.range
+        )
+    """
+    retained_result = """
+        SELECT i::BIGINT AS a, (i * 10)::BIGINT AS b
+        FROM range(100) t(i)
+    """
+    test = (
+        ShellTest(shell)
+        .statement(".maxrows 2")
+        .statement("SET profiling_renderer_settings = MAP {'operator_casing': 'upper'}")
+        .statement("PRAGMA explain_output='optimized_only'")
+        .statement(retained_result)
+        .statement("EXPLAIN " + common_subplan_query)
+        .statement(retained_result)
+        .statement(common_subplan_query)
+    )
+    result = test.run()
+    result.check_stdout("__common_subplan_1")
+    assert result.stdout.count("CTE_SCAN") == 2
+    assert "4950" in result.stdout
+    assert "49500" in result.stdout
+
 
 # fmt: on


### PR DESCRIPTION
This PR adds batch-index support to `PhysicalColumnDataScan` and propagates those indexes through materialized CTE execution. The motivating case is scanning a retained `ColumnDataCollection` while preserving insertion order. Without batch indexes, the scan has to run sequentially:

```sql
CREATE TABLE T AS FROM range(1000000000);

SELECT random() FROM T; -- 0.623s
SELECT random() FROM _; -- 5.905s

SET preserve_insertion_order=false;
SELECT random() FROM _; -- 0.643s
```

Assigning one batch index per emitted vector would recover parallelism, but would also create 2048-row batches. Batch-oriented consumers such as table and Parquet writes would then store and merge those small batches, introducing another full data-copy pass. Instead, I group existing collection chunks into scan tasks using the downstream operator's preferred batch size. The default is the storage row-group size. This keeps the scan parallel while producing batches that can be consumed directly by table and Parquet writers.

## Implementation

`OperatorPartitionInfo` can now carry a preferred batch size. A `PhysicalColumnDataScan` that is asked for batch indexes claims coarse scan tasks, assigns each task a monotonically increasing index, and keeps all chunks from that task on the same local scan state. Scans that do not request batch indexes retain the existing vector-sized task granularity. The scan also supports projected collection columns so column pruning does not invalidate the physical scan.

Materialized CTE planning now records whether the CTE body preserves order and whether its sources can provide batch indexes. Ordered materialization uses `BatchedDataCollection`, while the streaming CTE exchange carries batch metadata through both its in-memory chunk pool and shared spool. Producer-global indexes are normalized into a dense exchange-local namespace, including across ordered multi-pipeline producers.

For a compatible consumer pipeline, the exchange can propagate batch indexes directly into an externally fed `PipelineExecutor`. This avoids buffering and copying the CTE result before batch collectors, table inserts, and Parquet writes. The executor initializes, advances, and finalizes the downstream batch state using the same global batch-index namespace as regular source-driven pipelines.

Streaming result tasks are identified explicitly when they are fed through a direct CTE exchange. This replaces the previous assumption that a blocked result collector always belongs to the last incomplete pipeline, which is not true when the CTE producer and consumer pipelines execute concurrently.

`LogicalColumnDataGet` serializes projected column IDs as an optional property. Older serialized plans omit this property and continue to deserialize as a scan of all collection columns.

## Fallbacks and limitations

The new paths are deliberately conservative:

- A batch-indexed direct consumer is used only when exactly one pipeline produces the CTE. Ordered multi-producer inputs, such as `UNION ALL`, use the buffered exchange because their local batch namespaces cannot yet be forwarded directly without collisions.
- Ordered buffered exchange scans remain single-threaded. Parallel chunk-level scans could split one logical batch across downstream local sink states, causing duplicate batch ownership and additional merging. Parallel batch-preserving execution uses the direct exchange path.
- Direct exchange remains limited to sinks and intermediate operators that explicitly support external input. Order-dependent sinks, fixed-order or non-parallel operators, and partition-column metadata fall back to buffered or materialized execution.
- Recursive CTE execution continues to use the existing non-exchange fallback.
- If consumers request conflicting preferred batch sizes, the CTE uses the default row-group-sized batches.

These cases affect execution strategy only; they do not change query results. Unordered and non-batch-indexed `ColumnDataCollection` scans retain their previous behavior.

## Performance

On a matched release build with 100 million rows and eight threads:

| Query | Main | This branch |
| --- | ---: | ---: |
| Ordered retained collection scan | 0.550s | 0.074s |
| Direct table scan | - | 0.075s |
| CTAS from retained collection | 0.470s | 0.072s |
| Unordered retained collection scan | - | 0.079s |

For a 20-million-row reldebug CTAS, the direct CTE path had a 67ms median versus 62ms for a plain table CTAS.

Fix: https://github.com/duckdblabs/duckdb-internal/issues/9019