### PR TITLE
Improve star bind error message

### DIFF
--- a/src/include/duckdb/parser/qualified_name.hpp
+++ b/src/include/duckdb/parser/qualified_name.hpp
@@ -114,6 +114,7 @@ struct QualifiedColumnName {
 	static QualifiedColumnName Parse(string &input);
 
 	string ToString() const;
+	string ToDisplayString() const;
 
 	void Serialize(Serializer &serializer) const;
 	static QualifiedColumnName Deserialize(Deserializer &deserializer);

--- a/src/include/duckdb/parser/qualified_name.hpp
+++ b/src/include/duckdb/parser/qualified_name.hpp
@@ -150,6 +150,7 @@ struct QualifiedColumnName {
 	static QualifiedColumnName Parse(string &input);
 
 	string ToString() const;
+	string ToDisplayString() const;
 
 	void Serialize(Serializer &serializer) const;
 	static QualifiedColumnName Deserialize(Deserializer &deserializer);

--- a/src/parser/qualified_name.cpp
+++ b/src/parser/qualified_name.cpp
@@ -180,6 +180,21 @@ string QualifiedColumnName::ToString() const {
 	return result;
 }
 
+string QualifiedColumnName::ToDisplayString() const {
+	string result;
+	if (!catalog.empty()) {
+		result += catalog.GetIdentifierName() + ".";
+	}
+	if (!schema.empty()) {
+		result += schema.GetIdentifierName() + ".";
+	}
+	if (!table.empty()) {
+		result += table.GetIdentifierName() + ".";
+	}
+	result += column.GetIdentifierName();
+	return result;
+}
+
 bool QualifiedColumnName::IsQualified() const {
 	return !catalog.empty() || !schema.empty() || !table.empty();
 }

--- a/src/parser/qualified_name.cpp
+++ b/src/parser/qualified_name.cpp
@@ -195,6 +195,21 @@ string QualifiedColumnName::ToString() const {
 	return result;
 }
 
+string QualifiedColumnName::ToDisplayString() const {
+	string result;
+	if (!catalog.empty()) {
+		result += SQLQuotedIdentifier::ToString(catalog) + ".";
+	}
+	if (!schema.empty()) {
+		result += SQLQuotedIdentifier::ToString(schema) + ".";
+	}
+	if (!table.empty()) {
+		result += SQLQuotedIdentifier::ToString(table) + ".";
+	}
+	result += SQLQuotedIdentifier::ToString(column);
+	return result;
+}
+
 bool QualifiedColumnName::IsQualified() const {
 	return !catalog.empty() || !schema.empty() || !table.empty();
 }

--- a/src/planner/bind_context.cpp
+++ b/src/planner/bind_context.cpp
@@ -450,8 +450,8 @@ unique_ptr<ColumnRefExpression> BindContext::PositionToColumn(PositionalReferenc
 	return make_uniq<ColumnRefExpression>(column_name, table_name);
 }
 
-struct ExclusionListInfo {
-	explicit ExclusionListInfo(vector<unique_ptr<ParsedExpression>> &new_select_list)
+struct StarBindInfo {
+	explicit StarBindInfo(vector<unique_ptr<ParsedExpression>> &new_select_list)
 	    : new_select_list(new_select_list) {
 	}
 
@@ -461,7 +461,7 @@ struct ExclusionListInfo {
 	identifier_set_t replaced_columns;
 };
 
-bool CheckExclusionList(StarExpression &expr, const QualifiedColumnName &qualified_name, ExclusionListInfo &info) {
+bool CheckExclusionList(StarExpression &expr, const QualifiedColumnName &qualified_name, StarBindInfo &info) {
 	if (expr.ExcludeList().find(qualified_name) != expr.ExcludeList().end()) {
 		info.excluded_qualified_columns.insert(qualified_name);
 		return true;
@@ -470,7 +470,7 @@ bool CheckExclusionList(StarExpression &expr, const QualifiedColumnName &qualifi
 }
 
 bool HandleRename(StarExpression &expr, const QualifiedColumnName &qualified_name,
-                  unique_ptr<ParsedExpression> &new_expr, ExclusionListInfo &info) {
+                  unique_ptr<ParsedExpression> &new_expr, StarBindInfo &info) {
 	auto replace_entry = expr.ReplaceList().find(qualified_name.column);
 	if (replace_entry != expr.ReplaceList().end()) {
 		if (info.replaced_columns.find(replace_entry->first) == info.replaced_columns.end()) {
@@ -494,7 +494,7 @@ void BindContext::GenerateAllColumnExpressions(StarExpression &expr,
 	if (bindings_list.empty()) {
 		throw BinderException("* expression without FROM clause!");
 	}
-	ExclusionListInfo exclusion_info(new_select_list);
+	StarBindInfo star_info(new_select_list);
 	if (expr.RelationName().empty()) {
 		// SELECT * case
 		// bind all expressions of each table in-order
@@ -505,7 +505,7 @@ void BindContext::GenerateAllColumnExpressions(StarExpression &expr,
 			auto &binding_alias = binding.GetBindingAlias();
 			for (auto &column_name : column_names) {
 				QualifiedColumnName qualified_column(binding_alias, column_name);
-				if (CheckExclusionList(expr, qualified_column, exclusion_info)) {
+				if (CheckExclusionList(expr, qualified_column, star_info)) {
 					continue;
 				}
 				// check if this column is a USING column
@@ -528,14 +528,14 @@ void BindContext::GenerateAllColumnExpressions(StarExpression &expr,
 							    make_uniq<ColumnRefExpression>(column_name, child_binding));
 						}
 						coalesce->SetAlias(column_name);
-						if (HandleRename(expr, qualified_column, coalesce, exclusion_info)) {
+						if (HandleRename(expr, qualified_column, coalesce, star_info)) {
 							new_select_list.push_back(std::move(coalesce));
 						}
 					} else {
 						// primary binding: output the qualified column ref
 						auto new_expr = make_uniq_base<ParsedExpression, ColumnRefExpression>(
 						    column_name, using_binding.primary_binding);
-						if (HandleRename(expr, qualified_column, new_expr, exclusion_info)) {
+						if (HandleRename(expr, qualified_column, new_expr, star_info)) {
 							new_select_list.push_back(std::move(new_expr));
 						}
 					}
@@ -544,7 +544,7 @@ void BindContext::GenerateAllColumnExpressions(StarExpression &expr,
 				}
 				auto new_expr =
 				    CreateColumnReference(binding_alias, column_name, ColumnBindType::DO_NOT_EXPAND_GENERATED_COLUMNS);
-				if (HandleRename(expr, qualified_column, new_expr, exclusion_info)) {
+				if (HandleRename(expr, qualified_column, new_expr, star_info)) {
 					new_select_list.push_back(std::move(new_expr));
 				}
 			}
@@ -579,24 +579,24 @@ void BindContext::GenerateAllColumnExpressions(StarExpression &expr,
 			column_names[1] = expr.RelationName();
 			for (auto &child : struct_children) {
 				QualifiedColumnName qualified_name(child.first);
-				if (CheckExclusionList(expr, qualified_name, exclusion_info)) {
+				if (CheckExclusionList(expr, qualified_name, star_info)) {
 					continue;
 				}
 				column_names[2] = child.first;
 				unique_ptr<ParsedExpression> new_expr = make_uniq<ColumnRefExpression>(column_names);
-				if (HandleRename(expr, qualified_name, new_expr, exclusion_info)) {
+				if (HandleRename(expr, qualified_name, new_expr, star_info)) {
 					new_select_list.push_back(std::move(new_expr));
 				}
 			}
 		} else {
 			for (auto &column_name : column_names) {
 				QualifiedColumnName qualified_name(binding_alias, column_name);
-				if (CheckExclusionList(expr, qualified_name, exclusion_info)) {
+				if (CheckExclusionList(expr, qualified_name, star_info)) {
 					continue;
 				}
 				auto new_expr =
 				    CreateColumnReference(binding_alias, column_name, ColumnBindType::DO_NOT_EXPAND_GENERATED_COLUMNS);
-				if (HandleRename(expr, qualified_name, new_expr, exclusion_info)) {
+				if (HandleRename(expr, qualified_name, new_expr, star_info)) {
 					new_select_list.push_back(std::move(new_expr));
 				}
 			}
@@ -613,8 +613,7 @@ void BindContext::GenerateAllColumnExpressions(StarExpression &expr,
 
 	//! Verify correctness of the exclude list
 	for (auto &excluded : expr.ExcludeList()) {
-		if (exclusion_info.excluded_qualified_columns.find(excluded) ==
-		    exclusion_info.excluded_qualified_columns.end()) {
+		if (star_info.excluded_qualified_columns.find(excluded) == star_info.excluded_qualified_columns.end()) {
 			throw BinderException("Column \"%s\" in EXCLUDE list not found in %s", excluded.ToString(),
 			                      expr.RelationName().empty() ? "FROM clause" : expr.RelationName().c_str());
 		}
@@ -622,7 +621,7 @@ void BindContext::GenerateAllColumnExpressions(StarExpression &expr,
 
 	//! Verify correctness of the replace list
 	for (auto &entry : expr.ReplaceList()) {
-		if (exclusion_info.excluded_columns.find(entry.first) == exclusion_info.excluded_columns.end()) {
+		if (star_info.excluded_columns.find(entry.first) == star_info.excluded_columns.end()) {
 			throw BinderException("Column \"%s\" in REPLACE list not found in %s", entry.first.GetIdentifierName(),
 			                      expr.RelationName().empty() ? string("FROM clause")
 			                                                  : expr.RelationName().GetIdentifierName());

--- a/src/planner/bind_context.cpp
+++ b/src/planner/bind_context.cpp
@@ -451,14 +451,14 @@ unique_ptr<ColumnRefExpression> BindContext::PositionToColumn(PositionalReferenc
 }
 
 struct StarBindInfo {
-	explicit StarBindInfo(vector<unique_ptr<ParsedExpression>> &new_select_list)
-	    : new_select_list(new_select_list) {
+	explicit StarBindInfo(vector<unique_ptr<ParsedExpression>> &new_select_list) : new_select_list(new_select_list) {
 	}
 
 	vector<unique_ptr<ParsedExpression>> &new_select_list;
 	identifier_set_t excluded_columns;
 	qualified_column_set_t excluded_qualified_columns;
 	identifier_set_t replaced_columns;
+	vector<Identifier> candidate_columns;
 };
 
 bool CheckExclusionList(StarExpression &expr, const QualifiedColumnName &qualified_name, StarBindInfo &info) {
@@ -489,6 +489,20 @@ bool HandleRename(StarExpression &expr, const QualifiedColumnName &qualified_nam
 	return true;
 }
 
+string CandidateColumnMessage(const vector<Identifier> &candidate_columns, const Identifier &missing_column) {
+	identifier_set_t unique_columns;
+	vector<Identifier> candidates;
+	for (auto &candidate_column : candidate_columns) {
+		if (unique_columns.find(candidate_column) != unique_columns.end()) {
+			continue;
+		}
+		unique_columns.insert(candidate_column);
+		candidates.push_back(candidate_column);
+	}
+	auto closest_candidates = StringUtil::TopNJaroWinkler(IdentifiersToStrings(candidates), missing_column);
+	return StringUtil::CandidatesMessage(closest_candidates, "Candidate bindings");
+}
+
 void BindContext::GenerateAllColumnExpressions(StarExpression &expr,
                                                vector<unique_ptr<ParsedExpression>> &new_select_list) {
 	if (bindings_list.empty()) {
@@ -504,6 +518,7 @@ void BindContext::GenerateAllColumnExpressions(StarExpression &expr,
 			auto &column_names = binding.GetColumnNames();
 			auto &binding_alias = binding.GetBindingAlias();
 			for (auto &column_name : column_names) {
+				star_info.candidate_columns.push_back(column_name);
 				QualifiedColumnName qualified_column(binding_alias, column_name);
 				if (CheckExclusionList(expr, qualified_column, star_info)) {
 					continue;
@@ -578,6 +593,7 @@ void BindContext::GenerateAllColumnExpressions(StarExpression &expr,
 			column_names[0] = binding->GetAlias();
 			column_names[1] = expr.RelationName();
 			for (auto &child : struct_children) {
+				star_info.candidate_columns.push_back(child.first);
 				QualifiedColumnName qualified_name(child.first);
 				if (CheckExclusionList(expr, qualified_name, star_info)) {
 					continue;
@@ -590,6 +606,7 @@ void BindContext::GenerateAllColumnExpressions(StarExpression &expr,
 			}
 		} else {
 			for (auto &column_name : column_names) {
+				star_info.candidate_columns.push_back(column_name);
 				QualifiedColumnName qualified_name(binding_alias, column_name);
 				if (CheckExclusionList(expr, qualified_name, star_info)) {
 					continue;
@@ -614,17 +631,21 @@ void BindContext::GenerateAllColumnExpressions(StarExpression &expr,
 	//! Verify correctness of the exclude list
 	for (auto &excluded : expr.ExcludeList()) {
 		if (star_info.excluded_qualified_columns.find(excluded) == star_info.excluded_qualified_columns.end()) {
-			throw BinderException("Column \"%s\" in EXCLUDE list not found in %s", excluded.ToString(),
-			                      expr.RelationName().empty() ? "FROM clause" : expr.RelationName().c_str());
+			auto candidate_str = CandidateColumnMessage(star_info.candidate_columns, excluded.column);
+			throw BinderException("Column \"%s\" in EXCLUDE list not found in %s%s", excluded.ToDisplayString(),
+			                      expr.RelationName().empty() ? "FROM clause" : expr.RelationName().c_str(),
+			                      candidate_str);
 		}
 	}
 
 	//! Verify correctness of the replace list
 	for (auto &entry : expr.ReplaceList()) {
 		if (star_info.excluded_columns.find(entry.first) == star_info.excluded_columns.end()) {
-			throw BinderException("Column \"%s\" in REPLACE list not found in %s", entry.first.GetIdentifierName(),
+			auto candidate_str = CandidateColumnMessage(star_info.candidate_columns, entry.first);
+			throw BinderException("Column \"%s\" in REPLACE list not found in %s%s", entry.first.GetIdentifierName(),
 			                      expr.RelationName().empty() ? string("FROM clause")
-			                                                  : expr.RelationName().GetIdentifierName());
+			                                                  : expr.RelationName().GetIdentifierName(),
+			                      candidate_str);
 		}
 	}
 }

--- a/src/planner/bind_context.cpp
+++ b/src/planner/bind_context.cpp
@@ -502,34 +502,34 @@ unique_ptr<ColumnRefExpression> BindContext::PositionToColumn(PositionalReferenc
 	return make_uniq<ColumnRefExpression>(column_name, table_name);
 }
 
-struct ExclusionListInfo {
-	explicit ExclusionListInfo(vector<unique_ptr<ParsedExpression>> &new_select_list)
-	    : new_select_list(new_select_list) {
+struct StarBindState {
+	explicit StarBindState(vector<unique_ptr<ParsedExpression>> &new_select_list) : new_select_list(new_select_list) {
 	}
 
 	vector<unique_ptr<ParsedExpression>> &new_select_list;
 	identifier_set_t excluded_columns;
 	qualified_column_set_t excluded_qualified_columns;
 	identifier_set_t replaced_columns;
+	vector<Identifier> candidate_columns;
 };
 
-bool CheckExclusionList(StarExpression &expr, const QualifiedColumnName &qualified_name, ExclusionListInfo &info) {
+bool CheckExclusionList(StarExpression &expr, const QualifiedColumnName &qualified_name, StarBindState &state) {
 	if (expr.ExcludeList().find(qualified_name) != expr.ExcludeList().end()) {
-		info.excluded_qualified_columns.insert(qualified_name);
+		state.excluded_qualified_columns.insert(qualified_name);
 		return true;
 	}
 	return false;
 }
 
 bool HandleRename(StarExpression &expr, const QualifiedColumnName &qualified_name,
-                  unique_ptr<ParsedExpression> &new_expr, ExclusionListInfo &info) {
+                  unique_ptr<ParsedExpression> &new_expr, StarBindState &state) {
 	auto replace_entry = expr.ReplaceList().find(qualified_name.column);
 	if (replace_entry != expr.ReplaceList().end()) {
-		if (info.replaced_columns.find(replace_entry->first) == info.replaced_columns.end()) {
+		if (state.replaced_columns.find(replace_entry->first) == state.replaced_columns.end()) {
 			new_expr = replace_entry->second->Copy();
 			new_expr->SetAlias(replace_entry->first);
-			info.replaced_columns.insert(replace_entry->first);
-			info.excluded_columns.insert(replace_entry->first);
+			state.replaced_columns.insert(replace_entry->first);
+			state.excluded_columns.insert(replace_entry->first);
 		} else {
 			return false;
 		}
@@ -541,12 +541,26 @@ bool HandleRename(StarExpression &expr, const QualifiedColumnName &qualified_nam
 	return true;
 }
 
+string CandidateColumnMessage(const vector<Identifier> &candidate_columns, const Identifier &missing_column) {
+	identifier_set_t unique_columns;
+	vector<Identifier> candidates;
+	for (auto &candidate_column : candidate_columns) {
+		if (unique_columns.find(candidate_column) != unique_columns.end()) {
+			continue;
+		}
+		unique_columns.insert(candidate_column);
+		candidates.push_back(candidate_column);
+	}
+	auto closest_candidates = StringUtil::TopNJaroWinkler(IdentifiersToStrings(candidates), missing_column);
+	return StringUtil::CandidatesMessage(closest_candidates, "Candidate bindings");
+}
+
 void BindContext::GenerateAllColumnExpressions(StarExpression &expr,
                                                vector<unique_ptr<ParsedExpression>> &new_select_list) {
 	if (bindings_list.empty()) {
 		throw BinderException("* expression without FROM clause!");
 	}
-	ExclusionListInfo exclusion_info(new_select_list);
+	StarBindState star_state(new_select_list);
 	if (expr.RelationName().empty()) {
 		// SELECT * case
 		// bind all expressions of each table in-order
@@ -556,8 +570,9 @@ void BindContext::GenerateAllColumnExpressions(StarExpression &expr,
 			auto &column_names = binding.GetColumnNames();
 			auto &binding_alias = binding.GetBindingAlias();
 			for (auto &column_name : column_names) {
+				star_state.candidate_columns.push_back(column_name);
 				QualifiedColumnName qualified_column(binding_alias, column_name);
-				if (CheckExclusionList(expr, qualified_column, exclusion_info)) {
+				if (CheckExclusionList(expr, qualified_column, star_state)) {
 					continue;
 				}
 				// check if this column is a USING column
@@ -580,14 +595,14 @@ void BindContext::GenerateAllColumnExpressions(StarExpression &expr,
 							    make_uniq<ColumnRefExpression>(column_name, child_binding));
 						}
 						coalesce->SetAlias(column_name);
-						if (HandleRename(expr, qualified_column, coalesce, exclusion_info)) {
+						if (HandleRename(expr, qualified_column, coalesce, star_state)) {
 							new_select_list.push_back(std::move(coalesce));
 						}
 					} else {
 						// primary binding: output the qualified column ref
 						auto new_expr = make_uniq_base<ParsedExpression, ColumnRefExpression>(
 						    column_name, using_binding.primary_binding);
-						if (HandleRename(expr, qualified_column, new_expr, exclusion_info)) {
+						if (HandleRename(expr, qualified_column, new_expr, star_state)) {
 							new_select_list.push_back(std::move(new_expr));
 						}
 					}
@@ -596,7 +611,7 @@ void BindContext::GenerateAllColumnExpressions(StarExpression &expr,
 				}
 				auto new_expr =
 				    CreateColumnReference(binding_alias, column_name, ColumnBindType::DO_NOT_EXPAND_GENERATED_COLUMNS);
-				if (HandleRename(expr, qualified_column, new_expr, exclusion_info)) {
+				if (HandleRename(expr, qualified_column, new_expr, star_state)) {
 					new_select_list.push_back(std::move(new_expr));
 				}
 			}
@@ -630,25 +645,27 @@ void BindContext::GenerateAllColumnExpressions(StarExpression &expr,
 			column_names[0] = binding->GetAlias();
 			column_names[1] = expr.RelationName();
 			for (auto &child : struct_children) {
+				star_state.candidate_columns.push_back(child.first);
 				QualifiedColumnName qualified_name(child.first);
-				if (CheckExclusionList(expr, qualified_name, exclusion_info)) {
+				if (CheckExclusionList(expr, qualified_name, star_state)) {
 					continue;
 				}
 				column_names[2] = child.first;
 				unique_ptr<ParsedExpression> new_expr = make_uniq<ColumnRefExpression>(column_names);
-				if (HandleRename(expr, qualified_name, new_expr, exclusion_info)) {
+				if (HandleRename(expr, qualified_name, new_expr, star_state)) {
 					new_select_list.push_back(std::move(new_expr));
 				}
 			}
 		} else {
 			for (auto &column_name : column_names) {
+				star_state.candidate_columns.push_back(column_name);
 				QualifiedColumnName qualified_name(binding_alias, column_name);
-				if (CheckExclusionList(expr, qualified_name, exclusion_info)) {
+				if (CheckExclusionList(expr, qualified_name, star_state)) {
 					continue;
 				}
 				auto new_expr =
 				    CreateColumnReference(binding_alias, column_name, ColumnBindType::DO_NOT_EXPAND_GENERATED_COLUMNS);
-				if (HandleRename(expr, qualified_name, new_expr, exclusion_info)) {
+				if (HandleRename(expr, qualified_name, new_expr, star_state)) {
 					new_select_list.push_back(std::move(new_expr));
 				}
 			}
@@ -665,19 +682,22 @@ void BindContext::GenerateAllColumnExpressions(StarExpression &expr,
 
 	//! Verify correctness of the exclude list
 	for (auto &excluded : expr.ExcludeList()) {
-		if (exclusion_info.excluded_qualified_columns.find(excluded) ==
-		    exclusion_info.excluded_qualified_columns.end()) {
-			throw BinderException("Column \"%s\" in EXCLUDE list not found in %s", excluded.ToString(),
-			                      expr.RelationName().empty() ? "FROM clause" : expr.RelationName().c_str());
+		if (star_state.excluded_qualified_columns.find(excluded) == star_state.excluded_qualified_columns.end()) {
+			auto candidate_str = CandidateColumnMessage(star_state.candidate_columns, excluded.column);
+			throw BinderException("Column %s in EXCLUDE list not found in %s%s", excluded.ToDisplayString(),
+			                      expr.RelationName().empty() ? "FROM clause" : expr.RelationName().c_str(),
+			                      candidate_str);
 		}
 	}
 
 	//! Verify correctness of the replace list
 	for (auto &entry : expr.ReplaceList()) {
-		if (exclusion_info.excluded_columns.find(entry.first) == exclusion_info.excluded_columns.end()) {
-			throw BinderException("Column %s in REPLACE list not found in %s", entry.first,
+		if (star_state.excluded_columns.find(entry.first) == star_state.excluded_columns.end()) {
+			auto candidate_str = CandidateColumnMessage(star_state.candidate_columns, entry.first);
+			throw BinderException("Column %s in REPLACE list not found in %s%s", entry.first,
 			                      expr.RelationName().empty() ? string("FROM clause")
-			                                                  : expr.RelationName().GetIdentifierName());
+			                                                  : expr.RelationName().GetIdentifierName(),
+			                      candidate_str);
 		}
 	}
 }

--- a/test/sql/projection/select_star_exclude.test
+++ b/test/sql/projection/select_star_exclude.test
@@ -143,8 +143,18 @@ SELECT * EXCLUDE (blabla) FROM integers
 ----
 
 statement error
+SELECT * EXCLUDE (ii) FROM integers
+----
+<REGEX>:.*Binder Error.*not found in FROM clause.*Candidate bindings: "i".*
+
+statement error
 SELECT integers.* EXCLUDE (blabla) FROM integers
 ----
+
+statement error
+SELECT integers.* EXCLUDE (ii) FROM integers
+----
+<REGEX>:.*Binder Error.*not found in integers.*Candidate bindings: "i".*
 
 # EXCEPT is accepted interchangeably with EXCLUDE
 query II

--- a/test/sql/projection/select_star_exclude.test
+++ b/test/sql/projection/select_star_exclude.test
@@ -143,8 +143,23 @@ SELECT * EXCLUDE (blabla) FROM integers
 ----
 
 statement error
+SELECT * EXCLUDE (type) FROM (SELECT 'hello' AS greeting)
+----
+<REGEX>:.*Binder Error.*Column "type" in EXCLUDE list not found in FROM clause.*Candidate bindings: "greeting".*
+
+statement error
+SELECT * EXCLUDE (ii) FROM integers
+----
+<REGEX>:.*Binder Error.*not found in FROM clause.*Candidate bindings: "i".*
+
+statement error
 SELECT integers.* EXCLUDE (blabla) FROM integers
 ----
+
+statement error
+SELECT integers.* EXCLUDE (ii) FROM integers
+----
+<REGEX>:.*Binder Error.*not found in integers.*Candidate bindings: "i".*
 
 # EXCEPT is accepted interchangeably with EXCLUDE
 query II

--- a/test/sql/projection/select_star_replace.test
+++ b/test/sql/projection/select_star_replace.test
@@ -41,9 +41,19 @@ SELECT * REPLACE (i+100 AS blabla) FROM integers
 <REGEX>:.*Binder Error.*not found in FROM clause.*
 
 statement error
+SELECT * REPLACE (i+100 AS ii) FROM integers
+----
+<REGEX>:.*Binder Error.*not found in FROM clause.*Candidate bindings: "i".*
+
+statement error
 SELECT integers.* REPLACE (i+100 AS blabla) FROM integers
 ----
 <REGEX>:.*Binder Error.*not found in integers.*
+
+statement error
+SELECT integers.* REPLACE (i+100 AS ii) FROM integers
+----
+<REGEX>:.*Binder Error.*not found in integers.*Candidate bindings: "i".*
 
 # column cannot occur in both exclude and replace list
 statement error

--- a/test/sql/projection/select_star_replace.test
+++ b/test/sql/projection/select_star_replace.test
@@ -41,9 +41,24 @@ SELECT * REPLACE (i+100 AS blabla) FROM integers
 <REGEX>:.*Binder Error.*not found in FROM clause.*
 
 statement error
+SELECT * REPLACE (42 AS type) FROM (SELECT 'hello' AS greeting)
+----
+<REGEX>:.*Binder Error.*Column "type" in REPLACE list not found in FROM clause.*Candidate bindings: "greeting".*
+
+statement error
+SELECT * REPLACE (i+100 AS ii) FROM integers
+----
+<REGEX>:.*Binder Error.*not found in FROM clause.*Candidate bindings: "i".*
+
+statement error
 SELECT integers.* REPLACE (i+100 AS blabla) FROM integers
 ----
 <REGEX>:.*Binder Error.*not found in integers.*
+
+statement error
+SELECT integers.* REPLACE (i+100 AS ii) FROM integers
+----
+<REGEX>:.*Binder Error.*not found in integers.*Candidate bindings: "i".*
 
 # column cannot occur in both exclude and replace list
 statement error


### PR DESCRIPTION
Improves missing-column messages for `SELECT * EXCLUDE (...)` and `SELECT * REPLACE (...)`:

- avoids double-quoting in error messages
- adds candidate binding suggestions for missing `EXCLUDE` columns
- adds candidate binding suggestions for missing `REPLACE` columns
- adds `QualifiedColumnName::ToDisplayString()` for diagnostic formatting
- renames `ExclusionListInfo` to `StarBindInfo`

For example:

```sql
SELECT * EXCLUDE (type) FROM (SELECT 'hello' AS greeting);
-- Binder Error:
-- Column ""type"" in EXCLUDE list not found in FROM clause
```

is now:

```sql
SELECT * EXCLUDE (type) FROM (SELECT 'hello' AS greeting);
-- Binder Error:
-- Column "type" in EXCLUDE list not found in FROM clause
-- Candidate bindings: "greeting"
```

Fixes https://github.com/duckdblabs/duckdb-internal/issues/9091