### PR TITLE
Guard concurrent-ALTER storage check with IsDuckTable() (fix v1.5.5 INTERNAL on non-DuckTable extension catalog entries)

### DIFF
--- a/src/transaction/commit_state.cpp
+++ b/src/transaction/commit_state.cpp
@@ -272,7 +272,8 @@ void CommitState::CommitEntry(UndoFlags type, data_ptr_t data, CommitInfo &info)
 		D_ASSERT(catalog.IsDuckCatalog());
 
 		auto &new_entry = old_entry.Parent();
-		if (old_entry.type == CatalogType::TABLE_ENTRY && new_entry.type == CatalogType::TABLE_ENTRY) {
+		if (old_entry.type == CatalogType::TABLE_ENTRY && new_entry.type == CatalogType::TABLE_ENTRY &&
+		    old_entry.Cast<TableCatalogEntry>().IsDuckTable() && new_entry.Cast<TableCatalogEntry>().IsDuckTable()) {
 			auto &old_storage = old_entry.Cast<DuckTableEntry>().GetStorage();
 			auto &new_storage = new_entry.Cast<DuckTableEntry>().GetStorage();
 			if (!RefersToSameObject(old_storage, new_storage) && old_storage.IsMainTable()) {


### PR DESCRIPTION
This is a small back-port targeting the **`v1.5-variegata`** release branch.

### Problem

`CommitState::CommitEntry` unconditionally casts `TABLE_ENTRY → TABLE_ENTRY` catalog commits to `DuckTableEntry`:

```cpp
if (old_entry.type == CatalogType::TABLE_ENTRY && new_entry.type == CatalogType::TABLE_ENTRY) {
    auto &old_storage = old_entry.Cast<DuckTableEntry>().GetStorage();
    ...
```

Extension-provided catalog entries (a `TableCatalogEntry` subclass that is **not** a `DuckTableEntry`) share `CatalogType::TABLE_ENTRY`, so committing an `ALTER`/replace of such an entry hits the cast and aborts with:

```
INTERNAL Error: Calling GetStorage on a TableCatalogEntry that is not a DuckTableEntry
```

This is a regression introduced in `v1.5.5` by #23861 (`8a7db16bcd`) and is not present on `v1.5.4`. It is discussed in issue #24092. `main` already avoids the cast in this path; this PR restores the same safety for the `v1.5.x` line with a minimal change.

### Fix

Gate the storage comparison on both entries actually being DuckDB tables, using the existing `TableCatalogEntry::IsDuckTable()` helper (already used elsewhere in this same function). The concurrent-ALTER conflict detection is preserved unchanged for real DuckDB tables and is skipped for extension-owned catalog entries, which manage their own transactional semantics.

### Notes

- Minimal, low-risk: adds a condition to an existing `if`; no behavioral change for `DuckTableEntry` commits.
- Uses `IsDuckTable()`, consistent with the surrounding code.

Thank you for reviewing — happy to adjust the approach (or defer to a back-port of the `main` rework) if you’d prefer.
