### PR TITLE
Nested build side dynamic filters pushdown

### DIFF
--- a/src/execution/operator/join/physical_join.cpp
+++ b/src/execution/operator/join/physical_join.cpp
@@ -47,6 +47,25 @@ void PhysicalJoin::BuildJoinPipelines(Pipeline &current, MetaPipeline &meta_pipe
 	if (build_rhs) {
 		// on the RHS (build side), we construct a child MetaPipeline with this operator as its sink
 		auto &child_meta_pipeline = meta_pipeline.CreateChildMetaPipeline(current, op, MetaPipelineType::JOIN_BUILD);
+		// register filter sets published at Finalize, so consuming scans can order behind this build
+		// (see PhysicalTableScan::BuildPipelines)
+		switch (op.type) {
+		case PhysicalOperatorType::HASH_JOIN:
+		case PhysicalOperatorType::PIECEWISE_MERGE_JOIN:
+		case PhysicalOperatorType::NESTED_LOOP_JOIN: {
+			auto &join = op.Cast<PhysicalComparisonJoin>();
+			if (join.filter_pushdown) {
+				for (auto &probe : join.filter_pushdown->probe_info) {
+					if (probe.dynamic_filters) {
+						state.filter_set_producers[*probe.dynamic_filters].push_back(child_meta_pipeline);
+					}
+				}
+			}
+			break;
+		}
+		default:
+			break;
+		}
 		child_meta_pipeline.Build(op.children[1]);
 		if (op.children[1].get().CanSaturateThreads(current.GetClientContext())) {
 			// if the build side can saturate all available threads,

--- a/src/execution/operator/scan/physical_table_scan.cpp
+++ b/src/execution/operator/scan/physical_table_scan.cpp
@@ -10,6 +10,8 @@
 #include "duckdb/main/database.hpp"
 #include "duckdb/execution/physical_table_scan_enum.hpp"
 #include "duckdb/main/settings.hpp"
+#include "duckdb/parallel/meta_pipeline.hpp"
+#include "duckdb/parallel/pipeline.hpp"
 
 #include <utility>
 
@@ -435,6 +437,42 @@ void PhysicalTableScan::GetMetrics(ClientContext &context, GlobalSourceState &gs
 	TableFunctionGetMetricsInput input(context, bind_data.get(), state.local_state.get(), gstate.global_state.get(),
 	                                   operator_metrics);
 	function.get_metrics(input);
+}
+
+void PhysicalTableScan::BuildPipelines(Pipeline &current, MetaPipeline &meta_pipeline) {
+	PhysicalOperator::BuildPipelines(current, meta_pipeline);
+	if (!dynamic_filters || function.global_initialization == TableFunctionInitialization::INITIALIZE_ON_SCHEDULE) {
+		// no filters, or the source snapshots filters at schedule time - before any producer can publish
+		return;
+	}
+	if (meta_pipeline.HasRecursiveCTE()) {
+		// the recursive CTE scheduler has no eager-finalize exemption - an ordering edge would deadlock
+		return;
+	}
+	auto &state = meta_pipeline.GetState();
+	auto producers = state.filter_set_producers.find(*dynamic_filters);
+	if (producers == state.filter_set_producers.end()) {
+		return;
+	}
+	for (auto &producer_ref : producers->second) {
+		auto &producer = producer_ref.get();
+		// only order behind a producer whose sibling build hosts this scan - the TemporaryMemoryManager
+		// barrier otherwise finalizes the producer after this scan, so its filters would arrive too late
+		bool inside_sibling_build = false;
+		for (auto &enclosing_ref : state.join_build_stack) {
+			auto &enclosing = enclosing_ref.get();
+			if (!RefersToSameObject(enclosing, producer) &&
+			    RefersToSameObject(*enclosing.GetParent(), *producer.GetParent())) {
+				inside_sibling_build = true;
+				break;
+			}
+		}
+		if (!inside_sibling_build) {
+			continue;
+		}
+		current.AddDependency(producer.GetBasePipeline());
+		producer.SetEagerBuildFinalize();
+	}
 }
 
 } // namespace duckdb

--- a/src/include/duckdb/execution/operator/scan/physical_table_scan.hpp
+++ b/src/include/duckdb/execution/operator/scan/physical_table_scan.hpp
@@ -91,6 +91,8 @@ public:
 	void GetMetrics(ClientContext &context, GlobalSourceState &gstate_p, LocalSourceState &lstate,
 	                OperatorMetrics &operator_metrics) const;
 
+	void BuildPipelines(Pipeline &current, MetaPipeline &meta_pipeline) override;
+
 private:
 	string GetFilterInfo(const TableFilterSet &filter_set) const;
 };

--- a/src/include/duckdb/optimizer/join_filter_pushdown_optimizer.hpp
+++ b/src/include/duckdb/optimizer/join_filter_pushdown_optimizer.hpp
@@ -25,7 +25,8 @@ public:
 public:
 	void VisitOperator(LogicalOperator &op) override;
 	static void GetPushdownFilterTargets(LogicalOperator &op, vector<JoinFilterPushdownColumn> columns,
-	                                     vector<PushdownFilterTarget> &targets, bool include_nested_build_targets = false);
+	                                     vector<PushdownFilterTarget> &targets,
+	                                     bool include_nested_build_targets = false);
 
 	static bool IsFiltering(const unique_ptr<LogicalOperator> &op);
 

--- a/src/include/duckdb/optimizer/join_filter_pushdown_optimizer.hpp
+++ b/src/include/duckdb/optimizer/join_filter_pushdown_optimizer.hpp
@@ -25,7 +25,7 @@ public:
 public:
 	void VisitOperator(LogicalOperator &op) override;
 	static void GetPushdownFilterTargets(LogicalOperator &op, vector<JoinFilterPushdownColumn> columns,
-	                                     vector<PushdownFilterTarget> &targets);
+	                                     vector<PushdownFilterTarget> &targets, bool include_nested_build_targets = false);
 
 	static bool IsFiltering(const unique_ptr<LogicalOperator> &op);
 

--- a/src/include/duckdb/parallel/meta_pipeline.hpp
+++ b/src/include/duckdb/parallel/meta_pipeline.hpp
@@ -60,6 +60,11 @@ public:
 	const reference_map_t<Pipeline, vector<reference<Pipeline>>> &GetDependencies() const;
 	//! Whether the sink of this pipeline is a join build
 	MetaPipelineType Type() const;
+	//! Whether this build should Finalize before sibling builds scan (it publishes filters they consume) -
+	//! exempts it from the waiting side of the TemporaryMemoryManager barrier
+	bool HasEagerBuildFinalize() const;
+	//! Mark this join build as eager-finalize
+	void SetEagerBuildFinalize();
 	//! Whether this MetaPipeline has a recursive CTE
 	bool HasRecursiveCTE() const;
 	//! Set the flag that this MetaPipeline is a recursive CTE pipeline
@@ -113,6 +118,8 @@ private:
 	optional_ptr<PhysicalOperator> sink;
 	//! The type of this MetaPipeline (regular, join build)
 	MetaPipelineType type;
+	//! Whether this join build must be able to Finalize before sibling builds scan
+	bool build_eager_finalize = false;
 	//! Whether this MetaPipeline is a the recursive pipeline of a recursive CTE
 	bool recursive_cte;
 	//! All pipelines with a different source, but the same sink

--- a/src/include/duckdb/parallel/pipeline.hpp
+++ b/src/include/duckdb/parallel/pipeline.hpp
@@ -19,6 +19,7 @@
 
 namespace duckdb {
 
+class DynamicTableFilterSet;
 class Executor;
 class Event;
 class MetaPipeline;
@@ -65,6 +66,10 @@ public:
 	reference_map_t<const PhysicalOperator, reference<Pipeline>> delim_join_dependencies;
 	//! Materialized CTE scan dependencies
 	reference_map_t<const PhysicalOperator, reference<Pipeline>> cte_dependencies;
+	//! Join builds that publish dynamic filter sets during their Finalize, by filter set identity
+	reference_map_t<DynamicTableFilterSet, vector<reference<MetaPipeline>>> filter_set_producers;
+	//! JOIN_BUILD meta pipelines enclosing the operator currently being built
+	vector<reference<MetaPipeline>> join_build_stack;
 
 public:
 	void SetPipelineSource(Pipeline &pipeline, PhysicalOperator &op);

--- a/src/optimizer/join_filter_pushdown_optimizer.cpp
+++ b/src/optimizer/join_filter_pushdown_optimizer.cpp
@@ -156,9 +156,31 @@ static void PushdownProjectionColumns(LogicalProjection &proj, const vector<Join
 	}
 }
 
+static bool CanPushdownNestedBuildSide(const LogicalOperator &op) {
+	if (op.type == LogicalOperatorType::LOGICAL_CROSS_PRODUCT) {
+		return true;
+	}
+	if (op.type != LogicalOperatorType::LOGICAL_COMPARISON_JOIN) {
+		return false;
+	}
+	switch (op.Cast<LogicalComparisonJoin>().join_type) {
+	case JoinType::INNER:
+	case JoinType::RIGHT:
+	case JoinType::RIGHT_SEMI:
+	case JoinType::RIGHT_ANTI:
+		// the right child's rows pass through unmodified - removing a right row only removes output rows
+		// carrying its column values, and those cannot pass the producing join's filter anyway
+		return true;
+	default:
+		// left/outer null-extend the right child, mark/single/semi/anti use it to select left rows
+		return false;
+	}
+}
+
 void JoinFilterPushdownOptimizer::GetPushdownFilterTargets(LogicalOperator &op,
                                                            vector<JoinFilterPushdownColumn> columns,
-                                                           vector<PushdownFilterTarget> &targets) {
+                                                           vector<PushdownFilterTarget> &targets,
+                                                           bool include_nested_build_targets) {
 	auto &probe_child = op;
 	switch (probe_child.type) {
 	case LogicalOperatorType::LOGICAL_LIMIT:
@@ -166,16 +188,20 @@ void JoinFilterPushdownOptimizer::GetPushdownFilterTargets(LogicalOperator &op,
 		// LIMIT/TOP_N determines which rows are part of the probe side before the join.
 		// Pushing a join filter below it can change which rows survive the limit/offset.
 		break;
-	case LogicalOperatorType::LOGICAL_ORDER_BY:
-	case LogicalOperatorType::LOGICAL_DISTINCT:
+	case LogicalOperatorType::LOGICAL_COMPARISON_JOIN:
 	case LogicalOperatorType::LOGICAL_CROSS_PRODUCT:
-		// does not affect probe side - recurse into left child
-		// FIXME: we can probably recurse into more operators here (e.g. window, unnest)
-		GetPushdownFilterTargets(*probe_child.children[0], std::move(columns), targets);
+		if (include_nested_build_targets && CanPushdownNestedBuildSide(probe_child)) {
+			// nested joins do not remap bindings - filters that resolve in the build side can be pushed there
+			GetPushdownFilterTargets(*probe_child.children[1], columns, targets, include_nested_build_targets);
+		}
+		GetPushdownFilterTargets(*probe_child.children[0], std::move(columns), targets, include_nested_build_targets);
 		break;
 	case LogicalOperatorType::LOGICAL_FILTER:
-	case LogicalOperatorType::LOGICAL_COMPARISON_JOIN:
-		GetPushdownFilterTargets(*probe_child.children[0], std::move(columns), targets);
+	case LogicalOperatorType::LOGICAL_ORDER_BY:
+	case LogicalOperatorType::LOGICAL_DISTINCT:
+		// does not affect probe side - recurse into left child
+		// FIXME: we can probably recurse into more operators here (e.g. window, unnest)
+		GetPushdownFilterTargets(*probe_child.children[0], std::move(columns), targets, include_nested_build_targets);
 		break;
 	case LogicalOperatorType::LOGICAL_UNNEST: {
 		auto &unnest = probe_child.Cast<LogicalUnnest>();
@@ -186,7 +212,7 @@ void JoinFilterPushdownOptimizer::GetPushdownFilterTargets(LogicalOperator &op,
 				return;
 			}
 		}
-		GetPushdownFilterTargets(*probe_child.children[0], std::move(columns), targets);
+		GetPushdownFilterTargets(*probe_child.children[0], std::move(columns), targets, include_nested_build_targets);
 		break;
 	}
 	case LogicalOperatorType::LOGICAL_EXCEPT:
@@ -213,7 +239,7 @@ void JoinFilterPushdownOptimizer::GetPushdownFilterTargets(LogicalOperator &op,
 				continue;
 			}
 			// then recurse into the child
-			GetPushdownFilterTargets(*child, std::move(child_columns), targets);
+			GetPushdownFilterTargets(*child, std::move(child_columns), targets, include_nested_build_targets);
 
 			// for EXCEPT we can only recurse into the first (left) child
 			if (probe_child.type == LogicalOperatorType::LOGICAL_EXCEPT) {
@@ -264,7 +290,8 @@ void JoinFilterPushdownOptimizer::GetPushdownFilterTargets(LogicalOperator &op,
 		if (projected_columns.empty()) {
 			return;
 		}
-		GetPushdownFilterTargets(*probe_child.children[0], std::move(projected_columns), targets);
+		GetPushdownFilterTargets(*probe_child.children[0], std::move(projected_columns), targets,
+		                         include_nested_build_targets);
 		break;
 	}
 	case LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY: {
@@ -281,7 +308,7 @@ void JoinFilterPushdownOptimizer::GetPushdownFilterTargets(LogicalOperator &op,
 				return;
 			}
 		}
-		GetPushdownFilterTargets(*probe_child.children[0], std::move(columns), targets);
+		GetPushdownFilterTargets(*probe_child.children[0], std::move(columns), targets, include_nested_build_targets);
 		break;
 	}
 	default:
@@ -313,6 +340,8 @@ bool JoinFilterPushdownOptimizer::IsFiltering(const unique_ptr<LogicalOperator> 
 }
 
 void JoinFilterPushdownOptimizer::GenerateJoinFilters(LogicalComparisonJoin &join) {
+	static constexpr idx_t INCLUDE_NESTED_BUILD_TARGETS_ROW_THRESHOLD = 8192;
+
 	if (!JoinFilterPushdownUtil::JoinTypeIsSupported(join.join_type)) {
 		return;
 	}
@@ -353,9 +382,15 @@ void JoinFilterPushdownOptimizer::GenerateJoinFilters(LogicalComparisonJoin &joi
 		// could not generate any filters - bail-out
 		return;
 	}
+	// nested-build targets make this build finalize early (see PhysicalTableScan::BuildPipelines), committing
+	// memory before sibling builds report theirs to the TemporaryMemoryManager - only allow small builds
+	const auto build_estimate = join.children[1]->EstimateCardinality(optimizer.GetContext());
+	const bool include_nested_build_targets = build_estimate <= INCLUDE_NESTED_BUILD_TARGETS_ROW_THRESHOLD;
+
 	// recurse the query tree to find the LogicalGets in which we can push the filter info
 	vector<PushdownFilterTarget> pushdown_filter_targets;
-	GetPushdownFilterTargets(*join.children[0], pushdown_columns, pushdown_filter_targets);
+	GetPushdownFilterTargets(*join.children[0], pushdown_columns, pushdown_filter_targets,
+	                         include_nested_build_targets);
 	for (auto &target : pushdown_filter_targets) {
 		auto &get = target.get;
 		// pushdown info can be applied to this LogicalGet - push the dynamic table filter set

--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -264,6 +264,12 @@ void Executor::ScheduleEventsInternal(ScheduleEventData &event_data) {
 			auto child1_entry = event_map.find(child1_base);
 			D_ASSERT(child1_entry != event_map.end());
 
+			if (child1->HasEagerBuildFinalize()) {
+				// must Finalize before a sibling's scans consume its filters - cannot wait on any sibling
+				// (consumers instead wait on its completion through their pipeline dependencies)
+				continue;
+			}
+
 			for (auto &child2 : children) {
 				if (child2->Type() != MetaPipelineType::JOIN_BUILD || RefersToSameObject(*child1, *child2)) {
 					continue; // We don't want to depend on itself

--- a/src/parallel/meta_pipeline.cpp
+++ b/src/parallel/meta_pipeline.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/parallel/meta_pipeline.hpp"
 
+#include "duckdb/common/assert.hpp"
 #include "duckdb/execution/executor.hpp"
 
 namespace duckdb {
@@ -70,6 +71,16 @@ MetaPipelineType MetaPipeline::Type() const {
 	return type;
 }
 
+bool MetaPipeline::HasEagerBuildFinalize() const {
+	return build_eager_finalize;
+}
+
+void MetaPipeline::SetEagerBuildFinalize() {
+	D_ASSERT(type == MetaPipelineType::JOIN_BUILD);
+	D_ASSERT(!HasRecursiveCTE());
+	build_eager_finalize = true;
+}
+
 bool MetaPipeline::HasRecursiveCTE() const {
 	return recursive_cte;
 }
@@ -85,7 +96,14 @@ void MetaPipeline::AssignNextBatchIndex(Pipeline &pipeline) {
 void MetaPipeline::Build(PhysicalOperator &op) {
 	D_ASSERT(pipelines.size() == 1);
 	D_ASSERT(children.empty());
+	if (type == MetaPipelineType::JOIN_BUILD) {
+		state.join_build_stack.push_back(*this);
+	}
 	op.BuildPipelines(*pipelines.back(), *this);
+	if (type == MetaPipelineType::JOIN_BUILD) {
+		D_ASSERT(RefersToSameObject(state.join_build_stack.back().get(), *this));
+		state.join_build_stack.pop_back();
+	}
 }
 
 void MetaPipeline::Ready() const {

--- a/test/configs/stats_dependent_tests.json
+++ b/test/configs/stats_dependent_tests.json
@@ -54,6 +54,12 @@
         "test/sql/copy/parquet/read_ahead/readahead_io_budget.test_slow",
         "test/sql/types/geo/geometry_vertex_extract.test"
       ]
+    },
+    {
+      "reason": "Dynamic join filter pushdown pruning requires the optimizer and is not preserved across logical plan serialization.",
+      "paths": [
+        "test/optimizer/pushdown/join_filter_pushdown_nested_build.test"
+      ]
     }
     ]
 }

--- a/test/optimizer/pushdown/join_filter_pushdown_nested_build.test
+++ b/test/optimizer/pushdown/join_filter_pushdown_nested_build.test
@@ -1,0 +1,226 @@
+# name: test/optimizer/pushdown/join_filter_pushdown_nested_build.test
+# description: Join filter pushdown to scans on nested join build sides
+# group: [pushdown]
+
+require json
+
+# fix the plan shape: (small_probe JOIN fact) JOIN dim
+# fact sits on the build side of the nested join, dim produces the dynamic filter
+statement ok
+SET disabled_optimizers TO 'join_order,build_side_probe_side,compressed_materialization';
+
+statement ok
+CREATE TABLE small_probe AS SELECT range AS pk FROM range(100);
+
+statement ok
+CREATE TABLE fact AS SELECT range % 100 AS probe_key, range // 2500 AS dim_key FROM range(500000);
+
+statement ok
+CREATE TABLE dim AS SELECT range AS id, 'val_' || range AS val FROM range(200);
+
+statement ok
+CREATE TABLE mid AS SELECT range AS mk FROM range(100);
+
+query I
+SELECT count(*) FROM small_probe
+JOIN fact ON small_probe.pk = fact.probe_key
+JOIN dim ON fact.dim_key = dim.id
+WHERE dim.val = 'val_150';
+----
+2500
+
+# the dynamic filter on dim_key must be wired into the fact scan
+statement ok
+SET profiling_renderer_settings = MAP {'operator_casing': 'upper'};
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM small_probe
+JOIN fact ON small_probe.pk = fact.probe_key
+JOIN dim ON fact.dim_key = dim.id
+WHERE dim.val = 'val_150';
+----
+analyzed_plan	<REGEX>:.*Dynamic Filters: dim_key.*
+
+# deep consumer: the filter target sits two build levels down
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM small_probe
+JOIN (SELECT fact.dim_key, fact.probe_key FROM mid JOIN fact ON mid.mk = fact.probe_key) sub
+    ON small_probe.pk = sub.probe_key
+JOIN dim ON sub.dim_key = dim.id
+WHERE dim.val = 'val_150';
+----
+analyzed_plan	<REGEX>:.*Dynamic Filters: dim_key.*
+
+query I
+SELECT count(*) FROM small_probe
+JOIN (SELECT fact.dim_key, fact.probe_key FROM mid JOIN fact ON mid.mk = fact.probe_key) sub
+    ON small_probe.pk = sub.probe_key
+JOIN dim ON sub.dim_key = dim.id
+WHERE dim.val = 'val_150';
+----
+2500
+
+# the filter must also arrive before the fact scan runs: dim_key is clustered,
+# so a timely filter prunes all but one row group of the 500k-row fact table
+statement ok
+PRAGMA enable_profiling = 'json';
+
+statement ok
+PRAGMA profiling_output = '{TEST_DIR}/nested_build_profiling.json';
+
+statement ok
+SET tracked_metrics = ['query.total_rows_scanned'];
+
+statement ok
+SELECT count(*) FROM small_probe
+JOIN fact ON small_probe.pk = fact.probe_key
+JOIN dim ON fact.dim_key = dim.id
+WHERE dim.val = 'val_150';
+
+statement ok
+PRAGMA disable_profiling;
+
+statement ok
+RESET enable_profiling;
+
+statement ok
+RESET profiling_output;
+
+statement ok
+CREATE OR REPLACE TABLE metrics_output AS SELECT * FROM '{TEST_DIR}/nested_build_profiling.json';
+
+query I
+SELECT CASE WHEN query.total_rows_scanned < 300000 THEN 'true' ELSE 'false' END FROM metrics_output;
+----
+true
+
+# correctness with the filter wired: same result as a fresh connection without pushdown
+query I
+SELECT count(*) FROM small_probe
+JOIN fact ON small_probe.pk = fact.probe_key
+JOIN dim ON fact.dim_key = dim.id
+WHERE dim.val = 'val_199';
+----
+2500
+
+# nested LEFT join: the null-rejecting join condition above converts this to INNER
+# upstream, so pushdown remains valid - results must stay correct either way
+query I
+SELECT count(*) FROM small_probe
+LEFT JOIN fact ON small_probe.pk = fact.probe_key
+JOIN dim ON fact.dim_key = dim.id
+WHERE dim.val = 'val_150';
+----
+2500
+
+# three sibling builds: the producer's barrier exemption must not deadlock through
+# the third sibling's barrier edges (regression test for a transitive event cycle)
+query I
+SELECT count(*) FROM small_probe
+JOIN mid ON small_probe.pk = mid.mk
+JOIN fact ON small_probe.pk = fact.probe_key
+JOIN dim ON fact.dim_key = dim.id
+WHERE dim.val = 'val_150';
+----
+2500
+
+# natural shape: build/probe side optimizer swaps fact onto the nested build side itself
+statement ok
+SET disabled_optimizers TO 'join_order,compressed_materialization';
+
+statement ok
+CREATE TABLE huge_probe AS SELECT range AS hk FROM range(2000000);
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM fact
+JOIN huge_probe ON fact.probe_key = huge_probe.hk
+JOIN dim ON fact.dim_key = dim.id
+WHERE dim.val = 'val_150';
+----
+analyzed_plan	<REGEX>:.*Dynamic Filters: dim_key.*
+
+query I
+SELECT count(*) FROM fact
+JOIN huge_probe ON fact.probe_key = huge_probe.hk
+JOIN dim ON fact.dim_key = dim.id
+WHERE dim.val = 'val_150';
+----
+2500
+
+# non-hash producer: all comparison joins publish their filters at Finalize, so a
+# piecewise merge join must give its nested consumer the same ordering guarantee
+statement ok
+SET disabled_optimizers TO 'join_order,build_side_probe_side,compressed_materialization';
+
+statement ok
+CREATE TABLE dim_range AS SELECT range AS id FROM range(10);
+
+query II
+EXPLAIN SELECT count(*) FROM small_probe
+JOIN fact ON small_probe.pk = fact.probe_key
+JOIN dim_range ON fact.dim_key < dim_range.id;
+----
+physical_plan	<REGEX>:.*PIECEWISE_MERGE_JOIN.*
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM small_probe
+JOIN fact ON small_probe.pk = fact.probe_key
+JOIN dim_range ON fact.dim_key < dim_range.id;
+----
+analyzed_plan	<REGEX>:.*optional: \(dim_key <= 9\).*
+
+# the range filter must arrive before the fact scan runs
+statement ok
+PRAGMA enable_profiling = 'json';
+
+statement ok
+PRAGMA profiling_output = '{TEST_DIR}/nested_build_profiling_pwmj.json';
+
+statement ok
+SET tracked_metrics = ['query.total_rows_scanned'];
+
+statement ok
+SELECT count(*) FROM small_probe
+JOIN fact ON small_probe.pk = fact.probe_key
+JOIN dim_range ON fact.dim_key < dim_range.id;
+
+statement ok
+PRAGMA disable_profiling;
+
+statement ok
+RESET enable_profiling;
+
+statement ok
+RESET profiling_output;
+
+statement ok
+CREATE OR REPLACE TABLE metrics_output AS SELECT * FROM '{TEST_DIR}/nested_build_profiling_pwmj.json';
+
+query I
+SELECT CASE WHEN query.total_rows_scanned < 300000 THEN 'true' ELSE 'false' END FROM metrics_output;
+----
+true
+
+query I
+SELECT count(*) FROM small_probe
+JOIN fact ON small_probe.pk = fact.probe_key
+JOIN dim_range ON fact.dim_key < dim_range.id;
+----
+112500
+
+# nested shape inside a recursive CTE: the recursive scheduler replicates the sibling
+# build barrier without the eager-finalize exemption, so consumers there must not
+# order behind producers (regression test for an unschedulable dependency cycle)
+query I
+WITH RECURSIVE r(lvl) AS (
+  SELECT 0
+  UNION ALL
+  SELECT lvl + 1
+  FROM r
+  JOIN fact ON fact.probe_key = r.lvl
+  JOIN dim ON fact.dim_key = dim.id
+  WHERE dim.val = 'val_150' AND lvl < 2
+)
+SELECT count(*) FROM r;
+----
+651


### PR DESCRIPTION
Currently, the dynamic filters are only pushed down to probe side of join. The filter is produced at the build's `Finalize`, and because the `TemporaryMemoryManager` barrier holds every sibling build's Finalize until all of them have finished scanning — it only becomes available after the build side scans are already done. Routing such a filter to a build side scan would therefore be pointless: it would arrive too late to prune anything. This PR lets the filter reach a nested build-side scan by allowing a small producing build (cardinality below a threshold 8192) to finalize early, ahead of its sibling builds' scans. Pipeline construction records which build publishes each filter set, along with the stack of enclosing builds. A scan that finds itself in a sibling build of such a producer then orders its pipeline after that build and exempts the producer from the sibling build barrier, so the producer finalizes eagerly. The small build publishes its filter first, the sibling scan runs afterwards and prunes with it, and the added ordering edge can never form a cycle. Some results of Join Order Benchmark (IMDB) are quite good:

| Query   | main (ms) | PR (ms) | speedup |
|---------|-----------|---------|---------|
| 05a     | 26.9      | 4.0     | 6.7×    |
| 05b     | 21.8      | 11.9    | 1.83×   |
| 05c     | 109.1     | 86.7    | 1.26×   |
| 13b     | 58.2      | 51.6    | 1.13×   |
| 13c     | 43.4      | 36.2    | 1.20×   |
| 33b     | 44.9      | 30.8    | 1.46×   |