### PR TITLE
Catalog: trim search_path entry whitespace

### DIFF
--- a/src/catalog/catalog_search_path.cpp
+++ b/src/catalog/catalog_search_path.cpp
@@ -28,7 +28,8 @@ string CatalogSearchEntry::ToString() const {
 string CatalogSearchEntry::WriteOptionallyQuoted(const Identifier &input) {
 	auto &name = input.GetIdentifierName();
 	for (idx_t i = 0; i < name.size(); i++) {
-		if (name[i] == '.' || name[i] == ',' || name[i] == '"') {
+		if (name[i] == '.' || name[i] == ',' || name[i] == '"' ||
+		    ((i == 0 || i + 1 == name.size()) && StringUtil::CharacterIsSpace(name[i]))) {
 			return "\"" + StringUtil::Replace(name, "\"", "\"\"") + "\"";
 		}
 	}
@@ -46,11 +47,19 @@ string CatalogSearchEntry::ListToString(const vector<CatalogSearchEntry> &input)
 	return result;
 }
 
+static void SkipUnquotedWhitespace(const string &input, idx_t &idx) {
+	while (idx < input.size() && StringUtil::CharacterIsSpace(input[idx])) {
+		idx++;
+	}
+}
+
 CatalogSearchEntry CatalogSearchEntry::ParseInternal(const string &input, idx_t &idx) {
 	string catalog;
 	string schema;
 	string entry;
+	idx_t entry_end = 0;
 	bool finished = false;
+	SkipUnquotedWhitespace(input, idx);
 normal:
 	for (; idx < input.size(); idx++) {
 		if (input[idx] == '"') {
@@ -63,6 +72,9 @@ normal:
 			goto separator;
 		}
 		entry += input[idx];
+		if (!StringUtil::CharacterIsSpace(input[idx])) {
+			entry_end = entry.size();
+		}
 	}
 	finished = true;
 	goto separator;
@@ -75,14 +87,17 @@ quoted:
 			if (idx < input.size() && input[idx] == '"') {
 				// escaped quote
 				entry += input[idx];
+				entry_end = entry.size();
 				continue;
 			}
 			goto normal;
 		}
 		entry += input[idx];
+		entry_end = entry.size();
 	}
 	throw ParserException("Unterminated quote in qualified name!");
 separator:
+	entry.resize(entry_end);
 	if (entry.empty()) {
 		throw ParserException("Unexpected dot - empty CatalogSearchEntry");
 	}
@@ -97,10 +112,12 @@ separator:
 		throw ParserException("Too many dots - expected [schema] or [catalog.schema] for CatalogSearchEntry");
 	}
 	entry = "";
+	entry_end = 0;
 	idx++;
 	if (finished) {
 		goto final;
 	}
+	SkipUnquotedWhitespace(input, idx);
 	goto normal;
 final:
 	if (schema.empty()) {

--- a/test/sql/catalog/test_set_search_path.test
+++ b/test/sql/catalog/test_set_search_path.test
@@ -50,6 +50,33 @@ statement ok
 SET SEARCH_PATH = 'test,test2';
 
 statement ok
+SET SEARCH_PATH = 'test, test2';
+
+query I
+SELECT MAIN.CURRENT_SETTING('search_path');
+----
+test,test2
+
+statement ok
+SET SEARCH_PATH = ' test , test2 ';
+
+query I
+SELECT MAIN.CURRENT_SETTING('search_path');
+----
+test,test2
+
+statement ok
+CREATE SCHEMA " test_space";
+
+statement ok
+SET SEARCH_PATH = 'test, " test_space"';
+
+query I
+SELECT MAIN.CURRENT_SETTING('search_path');
+----
+test," test_space"
+
+statement ok
 SET SEARCH_PATH = '"test","test2"';
 
 statement ok


### PR DESCRIPTION
`SET search_path` accepts a string that is parsed into catalog/schema entries. Whitespace around separators is currently treated as part of the identifier, so a common value like `'s1, s2'` looks for a schema named `' s2'`.

This PR skips whitespace outside quoted identifiers while parsing search path entries. Whitespace inside quoted identifiers is preserved, and identifiers with leading or trailing whitespace are quoted when formatting a search path so `current_setting('search_path')` remains unambiguous.

The sqllogictest coverage includes whitespace around search path entries and a quoted schema name with leading whitespace.

Tests:
- `make reldebug`
- `build/reldebug/test/unittest test/sql/catalog/test_set_search_path.test`
