### PR TITLE
Catalog: resolve default schemas in search_path

### DIFF
--- a/src/catalog/catalog_search_path.cpp
+++ b/src/catalog/catalog_search_path.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/catalog/catalog_search_path.hpp"
+#include "duckdb/catalog/catalog_entry/schema_catalog_entry.hpp"
 #include "duckdb/catalog/default/default_schemas.hpp"
 
 #include "duckdb/catalog/catalog.hpp"
@@ -18,7 +19,7 @@ CatalogSearchEntry::CatalogSearchEntry(Identifier catalog_p, Identifier schema_p
 }
 
 string CatalogSearchEntry::ToString() const {
-	if (catalog.empty()) {
+	if (catalog.empty() || (catalog == SYSTEM_CATALOG && DefaultSchemaGenerator::IsDefaultSchema(schema))) {
 		return WriteOptionallyQuoted(schema);
 	} else {
 		return WriteOptionallyQuoted(catalog) + "." + WriteOptionallyQuoted(schema);
@@ -172,7 +173,11 @@ void CatalogSearchPath::Set(vector<CatalogSearchEntry> new_paths, CatalogSetPath
 		if (schema_entry) {
 			// we are setting a schema - update the catalog and schema
 			if (path.GetCatalog().empty()) {
-				path.SetCatalog(GetDefault().GetCatalog());
+				if (DefaultSchemaGenerator::IsDefaultSchema(path.GetSchema())) {
+					path.SetCatalog(schema_entry->catalog.GetName());
+				} else {
+					path.SetCatalog(GetDefault().GetCatalog());
+				}
 			}
 			continue;
 		}
@@ -192,7 +197,9 @@ void CatalogSearchPath::Set(vector<CatalogSearchEntry> new_paths, CatalogSetPath
 		throw CatalogException("%s: No catalog + schema named \"%s\" found.", GetSetName(set_type), path.ToString());
 	}
 	if (set_type == CatalogSetPathType::SET_SCHEMA) {
-		if (new_paths[0].GetCatalog() == TEMP_CATALOG || new_paths[0].GetCatalog() == SYSTEM_CATALOG) {
+		if (new_paths[0].GetCatalog() == TEMP_CATALOG ||
+		    (new_paths[0].GetCatalog() == SYSTEM_CATALOG &&
+		     !DefaultSchemaGenerator::IsDefaultSchema(new_paths[0].GetSchema()))) {
 			throw CatalogException("%s cannot be set to internal schema \"%s\"", GetSetName(set_type),
 			                       new_paths[0].GetCatalog().GetIdentifierName());
 		}

--- a/test/sql/catalog/test_set_search_path.test
+++ b/test/sql/catalog/test_set_search_path.test
@@ -267,3 +267,29 @@ query I
 SELECT current_query();
 ----
 SELECT current_query();
+
+statement ok
+SET search_path = information_schema;
+
+query I
+SELECT current_setting('search_path');
+----
+information_schema
+
+query I
+SELECT count(*) > 0 FROM schemata WHERE schema_name = 'main';
+----
+true
+
+statement ok
+SET schema = information_schema;
+
+query I
+SELECT current_schema();
+----
+information_schema
+
+query I
+SELECT count(*) > 0 FROM schemata WHERE schema_name = 'main';
+----
+true


### PR DESCRIPTION
`SET search_path` and `SET schema` accept unqualified schema names and store the resolved catalog/schema entry. For generated default schemas such as `information_schema` and `pg_catalog`, the lookup finds the schema in the system catalog, but the stored path used the current default catalog. As a result, `current_schema()` reported `information_schema` while unqualified lookups such as `schemata` still failed.

This PR uses the matched schema entry's catalog for default schemas, while preserving the existing formatting for default schema search path entries. Regular user schemas keep the previous current-catalog behavior, and non-default internal schemas remain rejected for `SET schema`.

The sqllogictest coverage resolves `information_schema` through both `search_path` and `schema`.

Tests:
- `make reldebug`
- `build/reldebug/test/unittest test/sql/catalog/test_set_search_path.test`
- `build/reldebug/test/unittest test/sql/settings/set_schema_temp_main.test`
- `build/reldebug/test/unittest test/sql/settings/drop_set_schema.test`
