### PR TITLE
Set OVERRIDE_GIT_DESCRIBE in extensions.yml

### DIFF
--- a/.github/workflows/Extensions.yml
+++ b/.github/workflows/Extensions.yml
@@ -263,6 +263,7 @@ jobs:
           EXTENSION_TESTS_ONLY: 1
           ENABLE_EXTENSION_AUTOLOADING: 1
           ENABLE_EXTENSION_AUTOINSTALL: 1
+          OVERRIDE_GIT_DESCRIBE: ${{ inputs.override_git_describe }}
         run: python3 scripts/ci/retry.py -- make release
 
       - name: Run Tests
@@ -277,6 +278,7 @@ jobs:
         env:
           GENERATE_EXTENSION_ENTRIES: 1
           LOCAL_EXTENSION_REPO: build/release/repository_other
+          OVERRIDE_GIT_DESCRIBE: ${{ inputs.override_git_describe }}
         run: |
           python3 scripts/ci/retry.py -- make release
 
@@ -314,6 +316,7 @@ jobs:
         id: check_extension_entries
         env:
           EXTENSION_CONFIGS: '.github/config/in_tree_extensions.cmake;.github/config/out_of_tree_extensions.cmake'
+          OVERRIDE_GIT_DESCRIBE: ${{ inputs.override_git_describe }}
         run: |
           make check-extension-entries
 


### PR DESCRIPTION
The CI job `extensions / Deploy extensions` [failed](https://github.com/duckdb/duckdb/actions/runs/30057353676/job/89397607366#logs) because the release version was not detected/set: 
```
-- Found Git: /usr/bin/git (found version "2.54.0")
-- GIT_COMMIT_HASH has length 11 different than the expected 10
-- git hash 8806a9f863, version v1.6.0-dev11260, extension folder 8806a9f863
-- Build workers: compile=12 link_release=4 link_non_release=2
```
and autoload tests failed with:
```
Load autocomplete at build/release/repository/v2.0.0-alpha35572/
linux_amd64/autocomplete.duckdb_extension
Invalid Input Error: Failed to load 'build/release/repository/
v2.0.0-alpha35572/linux_amd64/autocomplete.duckdb_extension',
The file was built specifically for DuckDB version 'v2.0.0-alpha35572' and can only
be loaded with that version of DuckDB. (this version of DuckDB is '8806a9f863')
```

So, we set `OVERRIDE_GIT_DESCRIBE` explicitly in the extensions deploy job.

Note: the extension's CI jobs itself are using a local, temporary git tag to "fake" the release version as a git tag. I think it's better to also use `OVERRIDE_GIT_DESCRIBE` in most places (or a more descriptive variable name), and remove the different ways of detecting versions in CI to reduce complexity.