### PR TITLE
Parallelize `UNION ALL` branches when `preserve_insertion_order` is false

### DIFF
--- a/src/execution/operator/set/physical_union.cpp
+++ b/src/execution/operator/set/physical_union.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/execution/operator/set/physical_union.hpp"
 
+#include "duckdb/main/settings.hpp"
 #include "duckdb/parallel/meta_pipeline.hpp"
 #include "duckdb/parallel/pipeline.hpp"
 #include "duckdb/parallel/thread_context.hpp"
@@ -46,7 +47,7 @@ void PhysicalUnion::BuildPipelines(Pipeline &current, MetaPipeline &meta_pipelin
 		order_matters = true;
 	}
 	if (sink) {
-		if (sink->SinkOrderDependent()) {
+		if (Settings::Get<PreserveInsertionOrderSetting>(current.GetClientContext()) && sink->SinkOrderDependent()) {
 			order_matters = true;
 		}
 		auto partition_info = sink->RequiredPartitionInfo();

--- a/test/sql/setops/union_all_preserve_insertion_order.test_slow
+++ b/test/sql/setops/union_all_preserve_insertion_order.test_slow
@@ -1,0 +1,71 @@
+# name: test/sql/setops/union_all_preserve_insertion_order.test_slow
+# description: Ensure order is preserved when doing a multi-file UNION ALL BY NAME with preserve_insertion_order = false
+# group: [setops]
+
+require parquet
+
+statement ok
+COPY (SELECT range AS i FROM range(0, 500000)) TO '{TEST_DIR}/uaf0.parquet' (FORMAT parquet)
+
+statement ok
+COPY (SELECT range AS i FROM range(500000, 1000000)) TO '{TEST_DIR}/uaf1.parquet' (FORMAT parquet)
+
+statement ok
+COPY (SELECT range AS i FROM range(1000000, 1500000)) TO '{TEST_DIR}/uaf2.parquet' (FORMAT parquet)
+
+statement ok
+COPY (SELECT range AS i FROM range(1500000, 2000000)) TO '{TEST_DIR}/uaf3.parquet' (FORMAT parquet)
+
+statement ok
+CREATE OR REPLACE TABLE t AS
+    SELECT * FROM read_parquet('{TEST_DIR}/uaf0.parquet') UNION ALL BY NAME
+    SELECT * FROM read_parquet('{TEST_DIR}/uaf1.parquet') UNION ALL BY NAME
+    SELECT * FROM read_parquet('{TEST_DIR}/uaf2.parquet') UNION ALL BY NAME
+    SELECT * FROM read_parquet('{TEST_DIR}/uaf3.parquet')
+
+query I
+SELECT i FROM t LIMIT 4 OFFSET 499998
+----
+499998
+499999
+500000
+500001
+
+statement ok
+SET preserve_insertion_order=false
+
+statement ok
+CREATE OR REPLACE TABLE t AS
+    SELECT * FROM read_parquet('{TEST_DIR}/uaf0.parquet') UNION ALL BY NAME
+    SELECT * FROM read_parquet('{TEST_DIR}/uaf1.parquet') UNION ALL BY NAME
+    SELECT * FROM read_parquet('{TEST_DIR}/uaf2.parquet') UNION ALL BY NAME
+    SELECT * FROM read_parquet('{TEST_DIR}/uaf3.parquet')
+
+query I
+SELECT count(*) FROM t
+----
+2000000
+
+# Ensure that the fixed order needed for ORDER BY is honored even when preserve_insertion_order is off
+statement ok
+CREATE OR REPLACE TABLE agg AS
+    (SELECT i // 250000 AS k, count(*) AS c FROM read_parquet('{TEST_DIR}/uaf0.parquet') GROUP BY k ORDER BY k) UNION ALL BY NAME
+    (SELECT i // 250000 AS k, count(*) AS c FROM read_parquet('{TEST_DIR}/uaf1.parquet') GROUP BY k ORDER BY k) UNION ALL BY NAME
+    (SELECT i // 250000 AS k, count(*) AS c FROM read_parquet('{TEST_DIR}/uaf2.parquet') GROUP BY k ORDER BY k) UNION ALL BY NAME
+    (SELECT i // 250000 AS k, count(*) AS c FROM read_parquet('{TEST_DIR}/uaf3.parquet') GROUP BY k ORDER BY k)
+
+# read the result back in order and check every row
+statement ok
+SET preserve_insertion_order=true
+
+query II
+SELECT k, c FROM agg
+----
+0	250000
+1	250000
+2	250000
+3	250000
+4	250000
+5	250000
+6	250000
+7	250000


### PR DESCRIPTION
Respect `preserve_insertion_order` when deciding branch order dependencies in `PhysicalUnion`

Look here for more info: https://github.com/duckdblabs/duckdb-internal/issues/8831