### PR TITLE
Fix UNNEST Pushdown

### DIFF
--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -561,9 +561,6 @@ void RemoveUnusedColumns::WritePushdownExtractColumns(
 
 static unique_ptr<Expression> ConstructStructExtractFromPath(ClientContext &context, unique_ptr<Expression> target,
                                                              const ColumnIndex &path) {
-	auto extract_function = GetKeyExtractFunction();
-	auto bind_callback = extract_function.GetBindCallback();
-
 	auto &struct_type = target->return_type;
 	D_ASSERT(struct_type.id() == LogicalTypeId::STRUCT);
 	reference<const LogicalType> type_iter(struct_type);
@@ -572,14 +569,19 @@ static unique_ptr<Expression> ConstructStructExtractFromPath(ClientContext &cont
 		auto child_index = path_iter.get().GetPrimaryIndex();
 		auto &child_types = StructType::GetChildTypes(type_iter.get());
 		D_ASSERT(child_index < child_types.size());
-		auto &key = child_types[child_index].first;
+		auto is_unnamed = StructType::IsUnnamed(type_iter.get());
+		auto function = is_unnamed ? GetIndexExtractFunction() : GetKeyExtractFunction();
+
 		type_iter = child_types[child_index].second;
 
-		auto function = extract_function;
 		vector<unique_ptr<Expression>> arguments(2);
 		arguments[0] = (std::move(target));
-		arguments[1] = (make_uniq<BoundConstantExpression>(Value(key)));
-		auto bind_info = bind_callback(context, function, arguments);
+		if (is_unnamed) {
+			arguments[1] = make_uniq<BoundConstantExpression>(Value::BIGINT(NumericCast<int64_t>(child_index + 1)));
+		} else {
+			arguments[1] = make_uniq<BoundConstantExpression>(Value(child_types[child_index].first));
+		}
+		auto bind_info = function.GetBindCallback()(context, function, arguments);
 		auto return_type = function.GetReturnType();
 		target = make_uniq<BoundFunctionExpression>(return_type, std::move(function), std::move(arguments),
 		                                            std::move(bind_info));

--- a/test/sql/types/struct/struct_projection_pushdown_unnamed.test
+++ b/test/sql/types/struct/struct_projection_pushdown_unnamed.test
@@ -1,0 +1,28 @@
+# name: test/sql/types/struct/struct_projection_pushdown_unnamed.test
+# description: Test projection pushdown through mixed named and unnamed structs
+# group: [struct]
+
+statement ok
+PRAGMA enable_verification
+
+# Unnamed struct followed by a named struct
+query I
+SELECT x[2].k
+FROM (SELECT unnest([(0, {'k': 42})]) AS x)
+WHERE x[2] IS NOT NULL;
+----
+42
+
+# Switch between unnamed and named structs multiple times in one extract path
+query I
+SELECT x[2].payload[2].value
+FROM (SELECT unnest([(0, {'payload': (10, {'value': 42})})]) AS x);
+----
+42
+
+# Named struct followed by an unnamed struct
+query I
+SELECT x.payload[2].value
+FROM (SELECT unnest([{'payload': (10, {'value': 42})}]) AS x);
+----
+42


### PR DESCRIPTION
fixes https://github.com/duckdb/duckdb/issues/23338
fixes https://github.com/duckdblabs/duckdb-internal/issues/9743

The unused columns optimizer rebuilds pushed-down struct extraction paths but would always use a string field name which could cause binder errors in queries such as
```sql
SELECT x[2].k
FROM (
    SELECT unnest([(0, {'k': 42})]) AS x
);
```

The patch now checks each struct in the path:
- Named struct → extract by field name.
- Unnamed struct → extract by its 1-based numeric index.