### PR TITLE
push down scalar functions for queries with LIMIT

### DIFF
--- a/src/optimizer/type_pushdown.cpp
+++ b/src/optimizer/type_pushdown.cpp
@@ -12,6 +12,7 @@
 #include "duckdb/planner/logical_operator.hpp"
 #include "duckdb/planner/logical_operator_visitor.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
+#include "duckdb/planner/operator/logical_limit.hpp"
 #include "duckdb/planner/operator/logical_projection.hpp"
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
@@ -55,10 +56,24 @@ void FindGetsAndProjections(LogicalOperator &op, Analyses &analyses, Projections
 		LogicalProjection &projection = op.Cast<LogicalProjection>();
 		D_ASSERT(projection.children.size() == 1);
 		auto &child = *projection.children[0];
-		if (!IsPassthrough(projection) || child.type != LogicalOperatorType::LOGICAL_GET) {
+		if (!IsPassthrough(projection)) {
 			break;
 		}
-		if (auto &get = child.Cast<LogicalGet>(); get.function.projection_expression_pushdown != nullptr) {
+
+		LogicalGet *get = nullptr;
+
+		// queries with LIMIT may include a STREAMING_LIMIT between PROJECTION and GET.
+		// See test/optimizer/pushdown/scalar_function_pushdown_limit.test
+		if (child.type == LogicalOperatorType::LOGICAL_LIMIT) {
+			if (auto &limit = child.Cast<LogicalLimit>();
+			    limit.children.size() == 1 && limit.children[0]->type == LogicalOperatorType::LOGICAL_GET) {
+				get = &limit.children[0]->Cast<LogicalGet>();
+			}
+		} else if (child.type == LogicalOperatorType::LOGICAL_GET) {
+			get = &child.Cast<LogicalGet>();
+		}
+
+		if (get != nullptr && get->function.projection_expression_pushdown != nullptr) {
 			projections.emplace(projection.table_index, projection);
 		}
 		break;

--- a/test/optimizer/pushdown/scalar_function_pushdown_limit.test
+++ b/test/optimizer/pushdown/scalar_function_pushdown_limit.test
@@ -1,0 +1,22 @@
+# name: test/optimizer/pushdown/scalar_function_pushdown_limit.test
+# description: Test Parquet With Pushing Down Scalar Function With Limit
+# group: [pushdown]
+
+require parquet
+
+statement ok
+CREATE TABLE pep_test (str VARCHAR);
+
+statement ok
+INSERT INTO pep_test VALUES ('Hello'), ('Hi'), ('Hey');
+
+statement ok
+COPY (SELECT * FROM pep_test) TO '{TEST_DIR}/pe-pushdown-limit.parquet';
+
+statement ok
+CREATE VIEW pe AS SELECT str FROM '{TEST_DIR}/pe-pushdown-limit.parquet';
+
+query II
+EXPLAIN (FORMAT json) SELECT strlen(str) FROM pe LIMIT 1;
+----
+physical_plan	<!REGEX>:.*PROJECTION.*


### PR DESCRIPTION
Queries like

```
CREATE VIEW pe AS SELECT str FROM 'test.parquet';
EXPLAIN (FORMAT json) SELECT strlen(str) FROM pe LIMIT 1;
```

didn't do pushdown as duckdb inserted STREAMING_LIMIT between a projection and a get. This PR fixes this issue.