### PR TITLE
Fix active query race

### DIFF
--- a/src/transaction/meta_transaction.cpp
+++ b/src/transaction/meta_transaction.cpp
@@ -199,6 +199,7 @@ idx_t MetaTransaction::GetActiveQuery() {
 }
 
 void MetaTransaction::SetActiveQuery(transaction_t query_number) {
+	lock_guard<mutex> guard(lock);
 	active_query = query_number;
 	for (auto &entry : transactions) {
 		entry.second.transaction.active_query = query_number;


### PR DESCRIPTION
Fix data race in MetaTransaction::SetActiveQuery by guarding active_query updates with the transaction lock

<details>
<summary>Can be reproduced using a cpp test</summary>


```cpp
#include "catch.hpp"

#include "duckdb.hpp"
#include "duckdb/catalog/catalog.hpp"
#include "duckdb/main/client_context.hpp"
#include "duckdb/transaction/meta_transaction.hpp"
#include "duckdb/transaction/transaction.hpp"

#include <atomic>
#include <thread>
#include <vector>

using namespace duckdb;

TEST_CASE("MetaTransaction::SetActiveQuery is serialized with GetTransaction", "[meta_transaction]") {
        DuckDB db(nullptr);
        Connection con(db);
        REQUIRE_FALSE(con.Query("ATTACH ':memory:' AS d1")->HasError());
        REQUIRE_FALSE(con.Query("ATTACH ':memory:' AS d2")->HasError());
        REQUIRE_FALSE(con.Query("BEGIN TRANSACTION")->HasError());

        auto &context = *con.context;
        auto &meta = context.transaction.ActiveTransaction();
        auto &cat1 = Catalog::GetCatalog(context, "d1");
        auto &cat2 = Catalog::GetCatalog(context, "d2");
        Transaction::Get(context, cat1);
        Transaction::Get(context, cat2);

        constexpr int NUM_READERS = 4;
        constexpr uint64_t READS_PER_THREAD = 400000;
        std::atomic<bool> stop {false};
        std::atomic<uint64_t> query_number {1000};

        std::thread writer([&] {
                while (!stop.load(std::memory_order_relaxed)) {
                        meta.SetActiveQuery(query_number.fetch_add(1)); // here we are mutating
                }
        });

        std::vector<std::thread> readers;
        for (int r = 0; r < NUM_READERS; r++) {
                readers.emplace_back([&] {
                        for (uint64_t i = 0; i < READS_PER_THREAD; i++) {
                                // here we are reading (might crash here: meta_transaction.cpp:72 active_query assert)
                                (void)Transaction::Get(context, cat2);
                        }
                });
        }
        for (auto &t : readers) {
                t.join();
        }
        stop.store(true);
        writer.join();

        REQUIRE(query_number.load() > 1000);
        REQUIRE_FALSE(con.Query("ROLLBACK")->HasError());
}
```
</details>