### PR TITLE
Arena allocate the memory for each aggregate state in TDigest

### DIFF
--- a/extension/core_functions/aggregate/holistic/approximate_quantile.cpp
+++ b/extension/core_functions/aggregate/holistic/approximate_quantile.cpp
@@ -119,20 +119,20 @@ struct ApproxQuantileOperation {
 			return;
 		}
 		if (!state.h) {
-			state.h = new duckdb_tdigest::TDigest(100);
+			state.h = new duckdb_tdigest::TDigest(unary_input.input.allocator, 100);
 		}
 		state.h->add(val);
 		state.pos++;
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
+	static void Combine(const STATE &source, STATE &target, AggregateInputData &aggr_input_data) {
 		if (source.pos == 0) {
 			return;
 		}
 		D_ASSERT(source.h);
 		if (!target.h) {
-			target.h = new duckdb_tdigest::TDigest(100);
+			target.h = new duckdb_tdigest::TDigest(aggr_input_data.allocator, 100);
 		}
 		target.h->merge(source.h);
 		target.pos += source.pos;
@@ -269,7 +269,7 @@ void ApproxQuantileImportState(AggregateImportInputData &input) {
 		if (!count_entry.IsValid() || !min_entry.IsValid() || !max_entry.IsValid() || !centroid_list.IsValid()) {
 			throw InvalidInputException("Invalid approx_quantile state - the state fields cannot be NULL");
 		}
-		std::vector<duckdb_tdigest::Centroid> centroids;
+		arena_vector<duckdb_tdigest::Centroid> centroids(input.allocator);
 		centroids.reserve(centroid_list.GetListLength());
 		for (const auto centroid_entry : centroid_list.GetChildValues()) {
 			const auto mean_entry = centroid_entry.template GetChildValue<0>();
@@ -279,8 +279,8 @@ void ApproxQuantileImportState(AggregateImportInputData &input) {
 			}
 			centroids.emplace_back(mean_entry.GetValue(), weight_entry.GetValue());
 		}
-		auto digest = make_uniq<duckdb_tdigest::TDigest>(std::move(centroids), std::vector<duckdb_tdigest::Centroid>(),
-		                                                 100, 0, 0);
+		auto digest = make_uniq<duckdb_tdigest::TDigest>(
+		    std::move(centroids), duckdb::arena_vector<duckdb_tdigest::Centroid>(input.allocator), 100, 0, 0);
 		digest->setMinMax(min_entry.GetValue(), max_entry.GetValue());
 		state.pos = count_entry.GetValue();
 		state.h = digest.release();

--- a/test/sql/aggregate/aggregates/test_approx_quantile.test
+++ b/test/sql/aggregate/aggregates/test_approx_quantile.test
@@ -310,3 +310,27 @@ query I
 SELECT RESERVOIR_QUANTILE(0., 0.9, 1000);
 ----
 0
+
+# Test fix for APPROX_QUANTILE memory not being tracked
+statement ok
+SET memory_limit='80MB';
+
+statement ok
+SET threads=4;
+
+statement ok
+CREATE OR REPLACE TABLE tdigest_memory_test AS
+    SELECT i AS grp, random() AS r
+    FROM range(100000) g(i)
+    CROSS JOIN range(4) h(j);
+
+statement error
+SELECT grp, APPROX_QUANTILE(r, 0.5) FROM tdigest_memory_test GROUP BY grp;
+----
+Out of Memory
+
+statement ok
+RESET memory_limit;
+
+statement ok
+RESET threads;

--- a/third_party/tdigest/t_digest.hpp
+++ b/third_party/tdigest/t_digest.hpp
@@ -24,6 +24,8 @@
 #include <utility>
 #include <vector>
 
+#include "duckdb/common/arena_containers/arena_vector.hpp"
+
 #ifdef min
 #undef min
 #endif
@@ -74,10 +76,10 @@ private:
 };
 
 struct CentroidList {
-	explicit CentroidList(const std::vector<Centroid> &s) : iter(s.cbegin()), end(s.cend()) {
+	explicit CentroidList(const duckdb::arena_vector<Centroid> &s) : iter(s.cbegin()), end(s.cend()) {
 	}
-	std::vector<Centroid>::const_iterator iter;
-	std::vector<Centroid>::const_iterator end;
+	duckdb::arena_vector<Centroid>::const_iterator iter;
+	duckdb::arena_vector<Centroid>::const_iterator end;
 
 	bool advance() {
 		return ++iter != end;
@@ -116,25 +118,24 @@ class TDigest {
 	using TDigestQueue = std::priority_queue<const TDigest *, std::vector<const TDigest *>, TDigestComparator>;
 
 public:
-	TDigest() : TDigest(1000) {
+	explicit TDigest(duckdb::ArenaAllocator &allocator, Value compression = 1000) : TDigest(allocator, compression, 0) {
 	}
 
-	explicit TDigest(Value compression) : TDigest(compression, 0) {
+	TDigest(duckdb::ArenaAllocator &allocator, Value compression, Index bufferSize)
+	    : TDigest(allocator, compression, bufferSize, 0) {
 	}
 
-	TDigest(Value compression, Index bufferSize) : TDigest(compression, bufferSize, 0) {
-	}
-
-	TDigest(Value compression, Index unmergedSize, Index mergedSize)
+	TDigest(duckdb::ArenaAllocator &allocator, Value compression, Index unmergedSize, Index mergedSize)
 	    : compression_(compression), maxProcessed_(processedSize(mergedSize, compression)),
-	      maxUnprocessed_(unprocessedSize(unmergedSize, compression)) {
+	      maxUnprocessed_(unprocessedSize(unmergedSize, compression)), processed_(allocator), unprocessed_(allocator),
+	      cumulative_(allocator) {
 		processed_.reserve(maxProcessed_);
 		unprocessed_.reserve(maxUnprocessed_ + 1);
 	}
 
-	TDigest(std::vector<Centroid> &&processed, std::vector<Centroid> &&unprocessed, Value compression,
+	TDigest(duckdb::arena_vector<Centroid> &&processed, duckdb::arena_vector<Centroid> &&unprocessed, Value compression,
 	        Index unmergedSize, Index mergedSize)
-	    : TDigest(compression, unmergedSize, mergedSize) {
+	    : TDigest(processed.get_allocator().GetAllocator(), compression, unmergedSize, mergedSize) {
 		processed_ = std::move(processed);
 		unprocessed_ = std::move(unprocessed);
 
@@ -147,7 +148,7 @@ public:
 		updateCumulative();
 	}
 
-	static Weight weight(std::vector<Centroid> &centroids) noexcept {
+	static Weight weight(duckdb::arena_vector<Centroid> &centroids) noexcept {
 		Weight w = 0.0;
 		for (auto centroid : centroids) {
 			w += centroid.weight();
@@ -188,11 +189,11 @@ public:
 		add(others.cbegin(), others.cend());
 	}
 
-	const std::vector<Centroid> &processed() const {
+	const duckdb::arena_vector<Centroid> &processed() const {
 		return processed_;
 	}
 
-	const std::vector<Centroid> &unprocessed() const {
+	const duckdb::arena_vector<Centroid> &unprocessed() const {
 		return unprocessed_;
 	}
 
@@ -418,7 +419,7 @@ public:
 		return true;
 	}
 
-	inline void add(std::vector<Centroid>::const_iterator iter, std::vector<Centroid>::const_iterator end) {
+	inline void add(duckdb::arena_vector<Centroid>::const_iterator iter, duckdb::arena_vector<Centroid>::const_iterator end) {
 		while (iter != end) {
 			const size_t diff = size_t(std::distance(iter, end));
 			const size_t room = maxUnprocessed_ - unprocessed_.size();
@@ -447,11 +448,11 @@ private:
 
 	Value unprocessedWeight_ = 0.0;
 
-	std::vector<Centroid> processed_;
+	duckdb::arena_vector<Centroid> processed_;
 
-	std::vector<Centroid> unprocessed_;
+	duckdb::arena_vector<Centroid> unprocessed_;
 
-	std::vector<Weight> cumulative_;
+	duckdb::arena_vector<Weight> cumulative_;
 
 	// return mean of i-th centroid
 	inline Value mean(size_t i) const noexcept {
@@ -507,7 +508,7 @@ private:
 			total += processed_.size();
 		}
 
-		std::vector<Centroid> sorted;
+		duckdb::arena_vector<Centroid> sorted(processed_.get_allocator());
 		sorted.reserve(total);
 
 		while (!pq.empty()) {
@@ -586,7 +587,7 @@ private:
 		return checkWeights(processed_, processedWeight_);
 	}
 
-	size_t checkWeights(const std::vector<Centroid> &sorted, Value total) {
+	size_t checkWeights(const duckdb::arena_vector<Centroid> &sorted, Value total) {
 		size_t badWeight = 0;
 		auto k1 = 0.0;
 		auto q = 0.0;


### PR DESCRIPTION
As previously memory was not tracked in APPROX_QUANTILE, which, in the case of exceeding memory on the host kills the process, instead of failing gracefully.

This is solved by allocating the memory using an arena.