### PR TITLE
Replace old lambda syntax in micro-extended benchmark

### DIFF
--- a/benchmark/micro/compression/zstd/zstd_read.benchmark
+++ b/benchmark/micro/compression/zstd/zstd_read.benchmark
@@ -9,7 +9,7 @@ storage persistent v1.2.0
 load
 DROP TABLE IF EXISTS zstd_strings;
 PRAGMA force_compression='zstd';
-set variable my_string = (list_reduce([chr(((i % 26) + ord('a'))::INTEGER) for i in range(8000)], (x, y) -> concat(x, y)));
+set variable my_string = (list_reduce([chr(((i % 26) + ord('a'))::INTEGER) for i in range(8000)], lamda x, y: concat(x, y)));
 create table zstd_strings as select getvariable('my_string') as data from range(2_500_000) tbl(i);
 checkpoint;
 

--- a/benchmark/micro/compression/zstd/zstd_read.benchmark
+++ b/benchmark/micro/compression/zstd/zstd_read.benchmark
@@ -9,7 +9,7 @@ storage persistent v1.2.0
 load
 DROP TABLE IF EXISTS zstd_strings;
 PRAGMA force_compression='zstd';
-set variable my_string = (list_reduce([chr(((i % 26) + ord('a'))::INTEGER) for i in range(8000)], lamda x, y: concat(x, y)));
+set variable my_string = (list_reduce([chr(((i % 26) + ord('a'))::INTEGER) for i in range(8000)], lambda x, y: concat(x, y)));
 create table zstd_strings as select getvariable('my_string') as data from range(2_500_000) tbl(i);
 checkpoint;
 

--- a/benchmark/micro/compression/zstd/zstd_store.benchmark
+++ b/benchmark/micro/compression/zstd/zstd_store.benchmark
@@ -10,7 +10,7 @@ require_reinit
 load
 DROP TABLE IF EXISTS zstd_strings;
 PRAGMA force_compression='zstd';
-set variable my_string = (list_reduce([chr(((i % 26) + ord('a'))::INTEGER) for i in range(4096)], (x, y) -> concat(x, y)));
+set variable my_string = (list_reduce([chr(((i % 26) + ord('a'))::INTEGER) for i in range(4096)], lamda x, y: concat(x, y)));
 create table test_compression as select getvariable('my_string') as data from range(2_500_000) tbl(i);
 checkpoint;
 

--- a/benchmark/micro/compression/zstd/zstd_store.benchmark
+++ b/benchmark/micro/compression/zstd/zstd_store.benchmark
@@ -10,7 +10,7 @@ require_reinit
 load
 DROP TABLE IF EXISTS zstd_strings;
 PRAGMA force_compression='zstd';
-set variable my_string = (list_reduce([chr(((i % 26) + ord('a'))::INTEGER) for i in range(4096)], lamda x, y: concat(x, y)));
+set variable my_string = (list_reduce([chr(((i % 26) + ord('a'))::INTEGER) for i in range(4096)], lambda x, y: concat(x, y)));
 create table test_compression as select getvariable('my_string') as data from range(2_500_000) tbl(i);
 checkpoint;
 

--- a/benchmark/micro/lambdas/list_filter_where.benchmark
+++ b/benchmark/micro/lambdas/list_filter_where.benchmark
@@ -10,4 +10,4 @@ CREATE TABLE tbl (l INTEGER[], where_l BOOLEAN[]);
 INSERT INTO tbl VALUES (range(100000), [x % 13 != 0 for x in range(100000)]);
 
 run
-SELECT list_filter(l, lamda x, x_i: where_l[x_i]) FROM tbl;
+SELECT list_filter(l, lambda x, x_i: where_l[x_i]) FROM tbl;

--- a/benchmark/micro/lambdas/list_filter_where.benchmark
+++ b/benchmark/micro/lambdas/list_filter_where.benchmark
@@ -10,4 +10,4 @@ CREATE TABLE tbl (l INTEGER[], where_l BOOLEAN[]);
 INSERT INTO tbl VALUES (range(100000), [x % 13 != 0 for x in range(100000)]);
 
 run
-SELECT list_filter(l, (x, x_i) -> where_l[x_i]) FROM tbl;
+SELECT list_filter(l, lamda x, x_i: where_l[x_i]) FROM tbl;

--- a/benchmark/micro/lambdas/list_reduce/complex_expression.benchmark
+++ b/benchmark/micro/lambdas/list_reduce/complex_expression.benchmark
@@ -10,4 +10,4 @@ load
 CREATE TABLE tbl AS SELECT range(i, i + 1) || range(i + 1, i + 2) || range(i + 2, i + 3) || range(i + 3, i + 4) || range(i, i + 1) || range(i + 1, i + 2) || range(i + 2, i + 3) || range(i + 3, i + 4) || range(i + 1, i + 2) || range(i + 2, i + 3) AS l FROM range(500000) t(i);
 
 run
-SELECT list_reduce(l, (x, y) -> list_reduce(l, (a, b) -> x + y + a + b)) FROM tbl;
+SELECT list_reduce(l, lamda x, y: list_reduce(l, lamda a, b: x + y + a + b)) FROM tbl;

--- a/benchmark/micro/lambdas/list_reduce/complex_expression.benchmark
+++ b/benchmark/micro/lambdas/list_reduce/complex_expression.benchmark
@@ -10,4 +10,4 @@ load
 CREATE TABLE tbl AS SELECT range(i, i + 1) || range(i + 1, i + 2) || range(i + 2, i + 3) || range(i + 3, i + 4) || range(i, i + 1) || range(i + 1, i + 2) || range(i + 2, i + 3) || range(i + 3, i + 4) || range(i + 1, i + 2) || range(i + 2, i + 3) AS l FROM range(500000) t(i);
 
 run
-SELECT list_reduce(l, lamda x, y: list_reduce(l, lamda a, b: x + y + a + b)) FROM tbl;
+SELECT list_reduce(l, lambda x, y: list_reduce(l, lambda a, b: x + y + a + b)) FROM tbl;

--- a/benchmark/micro/lambdas/list_reduce/list_length_2.benchmark
+++ b/benchmark/micro/lambdas/list_reduce/list_length_2.benchmark
@@ -10,4 +10,4 @@ load
 CREATE TABLE tbl AS SELECT range(i, i + 1) || range(i + 1, i + 2) AS l FROM range(5000000) t(i); 
 
 run
-SELECT list_reduce(l, (x, y) -> x + y) FROM tbl;
+SELECT list_reduce(l, lamda x, y: x + y) FROM tbl;

--- a/benchmark/micro/lambdas/list_reduce/list_length_2.benchmark
+++ b/benchmark/micro/lambdas/list_reduce/list_length_2.benchmark
@@ -10,4 +10,4 @@ load
 CREATE TABLE tbl AS SELECT range(i, i + 1) || range(i + 1, i + 2) AS l FROM range(5000000) t(i); 
 
 run
-SELECT list_reduce(l, lamda x, y: x + y) FROM tbl;
+SELECT list_reduce(l, lambda x, y: x + y) FROM tbl;

--- a/benchmark/micro/lambdas/list_reduce/list_length_5000.benchmark
+++ b/benchmark/micro/lambdas/list_reduce/list_length_5000.benchmark
@@ -10,4 +10,4 @@ load
 CREATE TABLE t2 AS SELECT range(5000) as l FROM range(10000);
 
 run
-SELECT list_reduce(l, lamda x, y: x + y) FROM t2;
+SELECT list_reduce(l, lambda x, y: x + y) FROM t2;

--- a/benchmark/micro/lambdas/list_reduce/list_length_5000.benchmark
+++ b/benchmark/micro/lambdas/list_reduce/list_length_5000.benchmark
@@ -10,4 +10,4 @@ load
 CREATE TABLE t2 AS SELECT range(5000) as l FROM range(10000);
 
 run
-SELECT list_reduce(l, (x, y) -> x + y) FROM t2;
+SELECT list_reduce(l, lamda x, y: x + y) FROM t2;

--- a/benchmark/micro/lambdas/list_reduce/list_variable_length.benchmark
+++ b/benchmark/micro/lambdas/list_reduce/list_variable_length.benchmark
@@ -10,4 +10,4 @@ load
 CREATE TABLE tbl AS SELECT range((i * 95823983533) % 100000 + 1) AS l from range(5000) t(i);
 
 run
-SELECT list_reduce(l, (x, y) -> x + y) FROM tbl;
+SELECT list_reduce(l, lamda x, y: x + y) FROM tbl;

--- a/benchmark/micro/lambdas/list_reduce/list_variable_length.benchmark
+++ b/benchmark/micro/lambdas/list_reduce/list_variable_length.benchmark
@@ -10,4 +10,4 @@ load
 CREATE TABLE tbl AS SELECT range((i * 95823983533) % 100000 + 1) AS l from range(5000) t(i);
 
 run
-SELECT list_reduce(l, lamda x, y: x + y) FROM tbl;
+SELECT list_reduce(l, lambda x, y: x + y) FROM tbl;

--- a/benchmark/micro/lambdas/list_reduce/varchar.benchmark
+++ b/benchmark/micro/lambdas/list_reduce/varchar.benchmark
@@ -16,4 +16,4 @@ CREATE TEMPORARY TABLE concat_strings_tmp AS SELECT 'a' || s1 || repeat(s2, s2::
 CREATE TABLE tbl AS SELECT string_split(l, '1') || string_split(l, '0') || string_split(l, '2') AS l FROM concat_strings_tmp;
 
 run
-SELECT list_reduce(l, (a, b) -> a || b) FROM tbl;
+SELECT list_reduce(l, lamda a, b: a || b) FROM tbl;

--- a/benchmark/micro/lambdas/list_reduce/varchar.benchmark
+++ b/benchmark/micro/lambdas/list_reduce/varchar.benchmark
@@ -16,4 +16,4 @@ CREATE TEMPORARY TABLE concat_strings_tmp AS SELECT 'a' || s1 || repeat(s2, s2::
 CREATE TABLE tbl AS SELECT string_split(l, '1') || string_split(l, '0') || string_split(l, '2') AS l FROM concat_strings_tmp;
 
 run
-SELECT list_reduce(l, lamda a, b: a || b) FROM tbl;
+SELECT list_reduce(l, lambda a, b: a || b) FROM tbl;

--- a/benchmark/micro/lambdas/list_transform_select.benchmark
+++ b/benchmark/micro/lambdas/list_transform_select.benchmark
@@ -10,4 +10,4 @@ CREATE TABLE tbl (l INTEGER[], sel INTEGER[]);
 INSERT INTO tbl VALUES (range(100000), range(100000));
 
 run
-SELECT list_transform(sel, x -> l[x]) FROM tbl;
+SELECT list_transform(sel, lamda x: l[x]) FROM tbl;

--- a/benchmark/micro/lambdas/list_transform_select.benchmark
+++ b/benchmark/micro/lambdas/list_transform_select.benchmark
@@ -10,4 +10,4 @@ CREATE TABLE tbl (l INTEGER[], sel INTEGER[]);
 INSERT INTO tbl VALUES (range(100000), range(100000));
 
 run
-SELECT list_transform(sel, lamda x: l[x]) FROM tbl;
+SELECT list_transform(sel, lambda x: l[x]) FROM tbl;

--- a/benchmark/micro/lambdas/list_transform_zip.benchmark
+++ b/benchmark/micro/lambdas/list_transform_zip.benchmark
@@ -10,4 +10,4 @@ CREATE TABLE tbl (l INTEGER[], zip VARCHAR[]);
 INSERT INTO tbl VALUES (range(100000), [x::VARCHAR || (x + 1)::VARCHAR for x in range(100000)]);
 
 run
-SELECT list_transform(l, lamda x, x_i: (x, zip[x_i])) FROM tbl;
+SELECT list_transform(l, lambda x, x_i: (x, zip[x_i])) FROM tbl;

--- a/benchmark/micro/lambdas/list_transform_zip.benchmark
+++ b/benchmark/micro/lambdas/list_transform_zip.benchmark
@@ -10,4 +10,4 @@ CREATE TABLE tbl (l INTEGER[], zip VARCHAR[]);
 INSERT INTO tbl VALUES (range(100000), [x::VARCHAR || (x + 1)::VARCHAR for x in range(100000)]);
 
 run
-SELECT list_transform(l, (x, x_i) -> (x, zip[x_i])) FROM tbl;
+SELECT list_transform(l, lamda x, x_i: (x, zip[x_i])) FROM tbl;

--- a/benchmark/micro/list/list_extract_null.benchmark
+++ b/benchmark/micro/list/list_extract_null.benchmark
@@ -7,7 +7,7 @@ group micro
 subgroup list
 
 load
-CREATE TABLE t1 as SELECT list_transform(range(0,1000), lamda a: if(e % a = 0, null, a)) as l FROM range(0,10000) as r(e);
+CREATE TABLE t1 as SELECT list_transform(range(0,1000), lambda a: if(e % a = 0, null, a)) as l FROM range(0,10000) as r(e);
 
 run
 SELECT count(list_extract(l, 5)) FROM t1;

--- a/benchmark/micro/list/list_extract_null.benchmark
+++ b/benchmark/micro/list/list_extract_null.benchmark
@@ -7,7 +7,7 @@ group micro
 subgroup list
 
 load
-CREATE TABLE t1 as SELECT list_transform(range(0,1000), a -> if(e % a = 0, null, a)) as l FROM range(0,10000) as r(e);
+CREATE TABLE t1 as SELECT list_transform(range(0,1000), lamda a: if(e % a = 0, null, a)) as l FROM range(0,10000) as r(e);
 
 run
 SELECT count(list_extract(l, 5)) FROM t1;

--- a/benchmark/micro/list/list_extract_struct.benchmark
+++ b/benchmark/micro/list/list_extract_struct.benchmark
@@ -7,7 +7,7 @@ group micro
 subgroup list
 
 load
-CREATE TABLE t1 as SELECT list_transform(range(0,1000), lamda x: {'foo': x, 'bar': (-x)::VARCHAR}) as l
+CREATE TABLE t1 as SELECT list_transform(range(0,1000), lambda x: {'foo': x, 'bar': (-x)::VARCHAR}) as l
 FROM range(0,10000) as r(e);
 
 run

--- a/benchmark/micro/list/list_extract_struct.benchmark
+++ b/benchmark/micro/list/list_extract_struct.benchmark
@@ -7,7 +7,7 @@ group micro
 subgroup list
 
 load
-CREATE TABLE t1 as SELECT list_transform(range(0,1000), x -> {'foo': x, 'bar': (-x)::VARCHAR}) as l
+CREATE TABLE t1 as SELECT list_transform(range(0,1000), lamda x: {'foo': x, 'bar': (-x)::VARCHAR}) as l
 FROM range(0,10000) as r(e);
 
 run

--- a/benchmark/micro/list/list_extract_struct_null.benchmark
+++ b/benchmark/micro/list/list_extract_struct_null.benchmark
@@ -7,7 +7,7 @@ group micro
 subgroup list
 
 load
-CREATE TABLE t1 as SELECT list_transform(range(0,1000), lamda x: if(e % x = 0, null, {'foo': x, 'bar': (-x)::VARCHAR})) as l
+CREATE TABLE t1 as SELECT list_transform(range(0,1000), lambda x: if(e % x = 0, null, {'foo': x, 'bar': (-x)::VARCHAR})) as l
 FROM range(0,10000) as r(e);
 
 run

--- a/benchmark/micro/list/list_extract_struct_null.benchmark
+++ b/benchmark/micro/list/list_extract_struct_null.benchmark
@@ -7,7 +7,7 @@ group micro
 subgroup list
 
 load
-CREATE TABLE t1 as SELECT list_transform(range(0,1000), x -> if(e % x = 0, null, {'foo': x, 'bar': (-x)::VARCHAR})) as l
+CREATE TABLE t1 as SELECT list_transform(range(0,1000), lamda x: if(e % x = 0, null, {'foo': x, 'bar': (-x)::VARCHAR})) as l
 FROM range(0,10000) as r(e);
 
 run


### PR DESCRIPTION
Some `.benchmark` files of micro-extended benchmark include lambda functions that use the old syntax. Hence, these queries are failing with error.
```
Binder Error: Deprecated lambda arrow (->) detected. Please transition to the new lambda syntax, i.e.., lambda x, i: x + i, before DuckDB's next release.
Use SET lambda_syntax='ENABLE_SINGLE_ARROW' to revert to the deprecated behavior.
For more information, see https://duckdb.org/docs/current/sql/functions/lambda.html.
```

This PR replaces the old syntax with the new one as suggested in the error message.