### PR TITLE
Actually block when no tasks available

### DIFF
--- a/src/include/duckdb/execution/executor.hpp
+++ b/src/include/duckdb/execution/executor.hpp
@@ -113,9 +113,7 @@ public:
 	void RegisterTask() {
 		executor_tasks++;
 	}
-	void UnregisterTask() {
-		executor_tasks--;
-	}
+	void UnregisterTask();
 
 	idx_t GetTotalPipelines() const {
 		return total_pipelines;

--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -507,6 +507,16 @@ void Executor::SignalTaskRescheduled(lock_guard<mutex> &) {
 	task_reschedule.notify_one();
 }
 
+void Executor::UnregisterTask() {
+	{
+		// Wake any thread blocked in `WaitForTask`.
+		// A finished task may have scheduled follow-up tasks or completed the query.
+		lock_guard<mutex> l(executor_lock);
+		task_reschedule.notify_all();
+	}
+	executor_tasks--;
+}
+
 void Executor::WaitForTask() {
 #ifndef DUCKDB_NO_THREADS
 	static constexpr std::chrono::microseconds WAIT_TIME_MS = std::chrono::microseconds(WAIT_TIME * 1000);
@@ -514,7 +524,8 @@ void Executor::WaitForTask() {
 	std::unique_lock<mutex> l(executor_lock);
 	auto end = TimePoint::Tick();
 	auto blocked_micros = NumericCast<idx_t>(TimePoint::ElapsedMicros(begin, end));
-	if (to_be_rescheduled_tasks.empty()) {
+
+	if (ExecutionIsFinished()) {
 		blocked_thread_time += blocked_micros;
 		return;
 	}
@@ -523,7 +534,14 @@ void Executor::WaitForTask() {
 		blocked_thread_time += blocked_micros;
 		return;
 	}
-
+	auto &scheduler = TaskScheduler::GetScheduler(context);
+	if (scheduler.GetTaskCountForProducer(*producer) > 0) {
+		// A task is available for the calling thread, the next step will make progress without waiting
+		blocked_thread_time += blocked_micros;
+		return;
+	}
+	// Nothing to run on this thread, all remaining tasks are either running on other threads or descheduled.
+	// Wait (bounded), but wake up on task completion or reschedule.
 	blocked_thread_time += blocked_micros + WAIT_TIME_MS.count();
 	task_reschedule.wait_for(l, WAIT_TIME_MS);
 #endif

--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -508,12 +508,14 @@ void Executor::SignalTaskRescheduled(lock_guard<mutex> &) {
 }
 
 void Executor::UnregisterTask() {
+#ifndef DUCKDB_NO_THREADS
 	{
 		// Wake any thread blocked in `WaitForTask`.
 		// A finished task may have scheduled follow-up tasks or completed the query.
 		lock_guard<mutex> l(executor_lock);
 		task_reschedule.notify_all();
 	}
+#endif
 	executor_tasks--;
 }
 


### PR DESCRIPTION
`Executor::WaitForTask` only really waited if there were tasks that had been explicitly de-scheduled/blocked (`!to_be_rescheduled_tasks.empty()`). 

This PR changes it so that `WaitForTask` also blocks if there are no more work in the producer queue because background workers have picked up all remaining tasks. We therefore also introduce a wake-up when unregistering a task, as there may now be threads waiting in `WaitForTask` that can pick-up/make progress on follow-up tasks.

The motivation for this PR came from working on the new C-API, where we implement a state-machine for streaming query results. When the user calls `step()` and the state machine returns "WAITING", the API-consumer can optionally call a `wait()` command to essentially block until the next `step()` will (likely) make progress. Internally this calls `WaitForTask()`, but we observed that this would rarely block at all, causing fetching results even from simple single-row select queries to spin hundreds of times in the state machine loop. With the changes in this PR the iterations are down to just a handful.

Im not 100% sure this PR is the best solution long-term though, as this will still not block entirely, just up to 20ms (the WAIT_TIME constant in `Executor`). Ideally we should add some sort of explicit wakeup signal/callback so that api-consumers can block or yield their own threads until there's a result ready. Open to suggestions!

