### PR TITLE
CSV: handle skipped empty files during schema detection

### DIFF
--- a/src/execution/operator/csv_scanner/sniffer/csv_sniffer.cpp
+++ b/src/execution/operator/csv_scanner/sniffer/csv_sniffer.cpp
@@ -90,7 +90,13 @@ AdaptiveSnifferResult CSVSniffer::MinimalSniff() {
 
 	auto state_machine =
 	    make_shared_ptr<CSVStateMachine>(options, options.dialect_options.state_machine_options, state_machine_cache);
-	ColumnCountScanner count_scanner(buffer_manager, state_machine, error_handler, result_size);
+	CSVIterator first_iterator;
+	if (options.dialect_options.skip_rows.IsSetByUser()) {
+		state_machine->dialect_options.skip_rows = options.dialect_options.skip_rows.GetValue();
+		first_iterator =
+		    BaseScanner::SkipCSVRows(buffer_manager, state_machine, options.dialect_options.skip_rows.GetValue());
+	}
+	ColumnCountScanner count_scanner(buffer_manager, state_machine, error_handler, result_size, first_iterator);
 	auto &sniffed_column_counts = count_scanner.ParseChunk();
 	if (sniffed_column_counts.result_position == 0) {
 		// The file is an empty file, we just return
@@ -105,6 +111,9 @@ AdaptiveSnifferResult CSVSniffer::MinimalSniff() {
 	scanner->error_handler->SetIgnoreErrors(true);
 	// Parse chunk and read csv with info candidate
 	auto &data_chunk = scanner->ParseChunk().ToChunk();
+	if (data_chunk.size() == 0) {
+		return {{}, {}, false};
+	}
 	idx_t start_row = 0;
 	if (sniffed_column_counts.result_position == 2) {
 		// If equal to two, we will only use the second row for type checking
@@ -145,6 +154,9 @@ AdaptiveSnifferResult CSVSniffer::MinimalSniff() {
 
 SnifferResult CSVSniffer::AdaptiveSniff(const CSVSchema &file_schema) {
 	auto min_sniff_res = MinimalSniff();
+	if (min_sniff_res.names.empty()) {
+		return min_sniff_res.ToSnifferResult();
+	}
 	bool run_full = error_handler->AnyErrors() || detection_error_handler->AnyErrors();
 	// Check if we are happy with the result or if we need to do more sniffing
 	if (!error_handler->AnyErrors() && !detection_error_handler->AnyErrors()) {

--- a/src/execution/operator/csv_scanner/table_function/csv_file_scanner.cpp
+++ b/src/execution/operator/csv_scanner/table_function/csv_file_scanner.cpp
@@ -35,7 +35,9 @@ CSVFileScan::CSVFileScan(ClientContext &context, const OpenFileInfo &file_p, CSV
 			options.file_path = file.path;
 			CSVSniffer sniffer(options, file_options, buffer_manager, state_machine_cache, false);
 			auto result = sniffer.AdaptiveSniff(file_schema);
-			SetNamesAndTypes(result.names, result.return_types);
+			if (!result.names.empty()) {
+				SetNamesAndTypes(result.names, result.return_types);
+			}
 		}
 	}
 	if (options.dialect_options.num_cols == 0) {

--- a/src/execution/operator/csv_scanner/table_function/csv_multi_file_info.cpp
+++ b/src/execution/operator/csv_scanner/table_function/csv_multi_file_info.cpp
@@ -10,6 +10,15 @@
 
 namespace duckdb {
 
+static idx_t RowsReadAfterSniffing(const CSVSniffer &sniffer, const CSVReaderOptions &options) {
+	auto lines_sniffed = sniffer.LinesSniffed();
+	auto header_rows = options.dialect_options.header.GetValue() ? 1 : 0;
+	auto skipped_rows =
+	    options.dialect_options.skip_rows.IsSetByUser() ? 0 : options.dialect_options.skip_rows.GetValue();
+	auto non_data_rows = skipped_rows + header_rows;
+	return lines_sniffed > non_data_rows ? lines_sniffed - non_data_rows : 0;
+}
+
 unique_ptr<MultiFileReaderInterface> CSVMultiFileInfo::CreateInterface(ClientContext &context) {
 	return make_uniq<CSVMultiFileInfo>();
 }
@@ -83,8 +92,7 @@ CSVSchema CSVSchemaDiscovery::SchemaDiscovery(ClientContext &context, shared_ptr
 	{
 		CSVSniffer sniffer(options, file_options, buffer_manager, CSVStateMachineCache::Get(context));
 		auto sniffer_result = sniffer.SniffCSV();
-		idx_t rows_read = sniffer.LinesSniffed() -
-		                  (options.dialect_options.skip_rows.GetValue() + options.dialect_options.header.GetValue());
+		idx_t rows_read = RowsReadAfterSniffing(sniffer, options);
 
 		schemas.emplace_back(sniffer_result.names, sniffer_result.return_types, file_paths[0].path, rows_read,
 		                     buffer_manager->GetBuffer(0)->actual_size == 0);
@@ -108,8 +116,7 @@ CSVSchema CSVSchemaDiscovery::SchemaDiscovery(ClientContext &context, shared_ptr
 		// reader
 		CSVSniffer sniffer(option_copy, file_options, file_buffer_manager, CSVStateMachineCache::Get(context));
 		auto sniffer_result = sniffer.SniffCSV();
-		idx_t rows_read = sniffer.LinesSniffed() - (option_copy.dialect_options.skip_rows.GetValue() +
-		                                            option_copy.dialect_options.header.GetValue());
+		idx_t rows_read = RowsReadAfterSniffing(sniffer, option_copy);
 		if (file_buffer_manager->GetBuffer(0)->actual_size == 0) {
 			schemas.emplace_back(true);
 		} else {

--- a/test/sql/copy/csv/test_glob_type.test
+++ b/test/sql/copy/csv/test_glob_type.test
@@ -45,3 +45,14 @@ query I
 SELECT typeof(bar) FROM read_csv(['{DATA_DIR}/csv/17451/1.csv','{DATA_DIR}/csv/17451/1.csv','{DATA_DIR}/csv/17451/1.csv','{DATA_DIR}/csv/17451/1.csv','{DATA_DIR}/csv/17451/1.csv','{DATA_DIR}/csv/17451/1.csv','{DATA_DIR}/csv/17451/1.csv','{DATA_DIR}/csv/17451/1.csv','{DATA_DIR}/csv/17451/1.csv','{DATA_DIR}/csv/17451/1.csv','{DATA_DIR}/csv/17451/1.csv','{DATA_DIR}/csv/17451/2.csv','{DATA_DIR}/csv/17451/extra/3.csv'], files_to_sniff = -1) limit 1
 ----
 VARCHAR
+
+statement ok
+COPY (SELECT 'a,b' AS line UNION ALL SELECT '1,2') TO '{TEST_DIR}/skip_one_row_data.csv' (HEADER 0, QUOTE '')
+
+statement ok
+COPY (SELECT 'skip me' AS line) TO '{TEST_DIR}/skip_one_row_empty.csv' (HEADER 0, QUOTE '')
+
+query II
+SELECT * FROM read_csv(['{TEST_DIR}/skip_one_row_data.csv', '{TEST_DIR}/skip_one_row_empty.csv'], skip=1)
+----
+1	2


### PR DESCRIPTION
When a CSV file is read with an explicit `skip` option, the sniffer already starts counting rows after the skipped prefix. Multi-file schema discovery still subtracted the explicit skip from `LinesSniffed()`, which could mark a file with one data row as having zero rows and let a later skipped-empty file disturb the inferred schema.

This PR keeps explicit `skip` handling consistent across schema discovery and adaptive sniffing. It does not subtract user-provided `skip` a second time when accounting for sniffed rows, applies `skip` before minimal adaptive sniffing counts columns, and preserves the existing file schema when adaptive sniffing finds no rows after `skip`.

Add sqllogictest coverage for a multi-file read where one file has data after `skip` and another file is empty after `skip`.

Tests:
- `make reldebug`
- `build/reldebug/test/unittest test/sql/copy/csv/test_glob_type.test`
- `build/reldebug/test/unittest test/sql/copy/csv/test_skip_header.test`
- `build/reldebug/test/unittest test/sql/copy/csv/test_sniff_csv_options.test`
- `build/reldebug/test/unittest test/sql/copy/csv/parallel/test_parallel_csv.test`