### PR TITLE
CSV: report empty multi-file schemas as input errors

### DIFF
--- a/src/execution/operator/csv_scanner/table_function/csv_multi_file_info.cpp
+++ b/src/execution/operator/csv_scanner/table_function/csv_multi_file_info.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/execution/operator/csv_scanner/csv_buffer.hpp"
 #include "duckdb/execution/operator/persistent/csv_rejects_table.hpp"
 #include "duckdb/common/bind_helpers.hpp"
+#include "duckdb/common/exception.hpp"
 #include "duckdb/parallel/async_result.hpp"
 #include "duckdb/parallel/callback_async_task.hpp"
 
@@ -143,6 +144,10 @@ CSVSchema CSVSchemaDiscovery::SchemaDiscovery(ClientContext &context, shared_ptr
 	if (names.empty()) {
 		names = StringsToIdentifiers(best_schema.GetNames());
 		return_types = best_schema.GetTypes();
+	}
+	if (names.empty() && return_types.empty()) {
+		throw InvalidInputException("No columns found in CSV files. Provide the columns option or ensure at least one "
+		                            "file contains a header or data row.");
 	}
 	if (only_header_or_empty_files == current_file && !options.columns_set) {
 		for (idx_t i = 0; i < return_types.size(); i++) {

--- a/test/sql/copy/csv/test_glob_type.test
+++ b/test/sql/copy/csv/test_glob_type.test
@@ -45,3 +45,14 @@ query I
 SELECT typeof(bar) FROM read_csv(['{DATA_DIR}/csv/17451/1.csv','{DATA_DIR}/csv/17451/1.csv','{DATA_DIR}/csv/17451/1.csv','{DATA_DIR}/csv/17451/1.csv','{DATA_DIR}/csv/17451/1.csv','{DATA_DIR}/csv/17451/1.csv','{DATA_DIR}/csv/17451/1.csv','{DATA_DIR}/csv/17451/1.csv','{DATA_DIR}/csv/17451/1.csv','{DATA_DIR}/csv/17451/1.csv','{DATA_DIR}/csv/17451/1.csv','{DATA_DIR}/csv/17451/2.csv','{DATA_DIR}/csv/17451/extra/3.csv'], files_to_sniff = -1) limit 1
 ----
 VARCHAR
+
+statement ok
+COPY (SELECT 1 WHERE false) TO '{TEST_DIR}/empty_glob_1.csv' (HEADER 0)
+
+statement ok
+COPY (SELECT 1 WHERE false) TO '{TEST_DIR}/empty_glob_2.csv' (HEADER 0)
+
+statement error
+SELECT * FROM read_csv_auto(['{TEST_DIR}/empty_glob_1.csv', '{TEST_DIR}/empty_glob_2.csv'])
+----
+No columns found in CSV files.


### PR DESCRIPTION
Multi-file CSV schema discovery can finish without any discovered columns when every sniffed file is empty. The bind path then returns an empty table-function schema, which is reported by the generic table-function binder as an INTERNAL error.

This PR detects the empty discovered schema in the CSV bind path and raises an `InvalidInputException` with an actionable message instead. This keeps the generic binder invariant intact while reporting the bad input at the CSV layer.

Add sqllogictest coverage for a multi-file read over empty CSV files.

Tests:
- `make reldebug`
- `build/reldebug/test/unittest test/sql/copy/csv/test_glob_type.test`
- `build/reldebug/test/unittest test/sql/copy/csv/allow_empty.test`
- `build/reldebug/test/unittest test/sql/copy/csv/code_cov/csv_type_detection.test`