### PR TITLE
Use bloom filters to prune row groups for LIST columns

### DIFF
--- a/extension/parquet/include/parquet_statistics.hpp
+++ b/extension/parquet/include/parquet_statistics.hpp
@@ -60,9 +60,11 @@ struct ParquetStatisticsUtils {
 
 	static bool BloomFilterSupported(const ParquetColumnSchema &schema);
 
+	//! Probes the bloom filter of a leaf column chunk - list_depth is the number of LIST levels the filter expression
+	//! has to traverse before it reaches that leaf
 	static bool BloomFilterExcludes(const TableFilter &filter, const duckdb_parquet::ColumnMetaData &column_meta_data,
 	                                duckdb_apache::thrift::protocol::TProtocol &file_proto, Allocator &allocator,
-	                                const ParquetColumnSchema &schema);
+	                                const ParquetColumnSchema &schema, idx_t list_depth = 0);
 
 	static unique_ptr<BaseStatistics> CreateNumericStats(const LogicalType &type, const ParquetColumnSchema &schema_ele,
 	                                                     const duckdb_parquet::Statistics &parquet_stats);

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1487,6 +1487,26 @@ ColumnReader &ParquetReaderScanState::GetColumnReader(idx_t i) {
 	return *column_readers[i];
 }
 
+//! The leaf column chunk of a LIST holds every element of every list in the row group, so a constant that its bloom
+//! filter excludes cannot occur at any position of any list - descend to that leaf and report how many LIST levels
+//! separate it from the column itself
+static optional_ptr<const ParquetColumnSchema> GetListLeafSchema(const ParquetColumnSchema &schema, idx_t &list_depth) {
+	reference<const ParquetColumnSchema> current(schema);
+	list_depth = 0;
+	while (current.get().type.id() == LogicalTypeId::LIST) {
+		if (current.get().schema_type != ParquetColumnSchemaType::COLUMN || current.get().children.size() != 1) {
+			return nullptr;
+		}
+		current = current.get().children[0];
+		list_depth++;
+	}
+	auto &leaf = current.get();
+	if (list_depth == 0 || leaf.schema_type != ParquetColumnSchemaType::COLUMN || leaf.type.IsNested()) {
+		return nullptr;
+	}
+	return leaf;
+}
+
 void ParquetReader::PrepareRowGroupBuffer(ClientContext &context, ParquetReaderScanState &state, idx_t i) {
 	auto &group = GetGroup(state);
 	auto col_idx = MultiFileLocalIndex(i);
@@ -1533,12 +1553,21 @@ void ParquetReader::PrepareRowGroupBuffer(ClientContext &context, ParquetReaderS
 				prune_result = expr_filter.CheckStatistics(context, *stats);
 			}
 			// check the bloom filter if present
-			if (prune_result == FilterPropagateResult::NO_PRUNING_POSSIBLE && !column_reader.Type().IsNested() &&
-			    is_column && ParquetStatisticsUtils::BloomFilterSupported(column_reader.Schema()) &&
-			    ParquetStatisticsUtils::BloomFilterExcludes(filter, group.columns[schema_column_index].meta_data,
-			                                                *state.thrift_file_proto, allocator,
-			                                                column_reader.Schema())) {
-				prune_result = FilterPropagateResult::FILTER_ALWAYS_FALSE;
+			if (prune_result == FilterPropagateResult::NO_PRUNING_POSSIBLE) {
+				idx_t list_depth = 0;
+				optional_ptr<const ParquetColumnSchema> bloom_schema;
+				if (is_column && !is_generated_column && !column_reader.Type().IsNested()) {
+					bloom_schema = column_reader.Schema();
+				} else if (is_column) {
+					bloom_schema = GetListLeafSchema(column_reader.Schema(), list_depth);
+				}
+				if (bloom_schema && bloom_schema->column_index < group.columns.size() &&
+				    ParquetStatisticsUtils::BloomFilterSupported(*bloom_schema) &&
+				    ParquetStatisticsUtils::BloomFilterExcludes(
+				        filter, group.columns[bloom_schema->column_index].meta_data, *state.thrift_file_proto,
+				        allocator, *bloom_schema, list_depth)) {
+					prune_result = FilterPropagateResult::FILTER_ALWAYS_FALSE;
+				}
 			}
 
 			if (prune_result == FilterPropagateResult::FILTER_ALWAYS_FALSE) {

--- a/extension/parquet/parquet_statistics.cpp
+++ b/extension/parquet/parquet_statistics.cpp
@@ -673,7 +673,33 @@ unique_ptr<BaseStatistics> ParquetStatisticsUtils::TransformColumnStatistics(con
 	return row_group_stats;
 }
 
-static optional_ptr<const BoundConstantExpression> GetBloomFilterConstant(const Expression &expr) {
+//! Whether the expression reads the leaf column that owns the bloom filter - for a leaf that sits below list_depth
+//! LIST levels this means unwrapping that many list extracts first
+static bool IsBloomFilterColumnRef(const Expression &expr, idx_t list_depth) {
+	reference<const Expression> current(expr);
+	for (idx_t i = 0; i < list_depth; i++) {
+		auto &child = current.get();
+		if (child.GetExpressionClass() != ExpressionClass::BOUND_FUNCTION) {
+			return false;
+		}
+		auto &func = child.Cast<BoundFunctionExpression>();
+		auto &function_name = func.Function().GetName();
+		if (function_name != "list_extract" && function_name != "array_extract") {
+			return false;
+		}
+		auto &children = func.GetChildren();
+		if (children.size() != 2 || children[0]->GetReturnType().id() != LogicalTypeId::LIST ||
+		    children[1]->GetExpressionClass() != ExpressionClass::BOUND_CONSTANT) {
+			return false;
+		}
+		current = *children[0];
+	}
+	auto &base = current.get();
+	return base.GetExpressionClass() == ExpressionClass::BOUND_REF &&
+	       base.Cast<BoundReferenceExpression>().Index() == 0;
+}
+
+static optional_ptr<const BoundConstantExpression> GetBloomFilterConstant(const Expression &expr, idx_t list_depth) {
 	if (!BoundComparisonExpression::IsComparison(expr)) {
 		return nullptr;
 	}
@@ -685,27 +711,25 @@ static optional_ptr<const BoundConstantExpression> GetBloomFilterConstant(const 
 	auto &right = BoundComparisonExpression::Right(comp);
 	optional_ptr<const Expression> column;
 	optional_ptr<const BoundConstantExpression> constant;
-	if (left.GetExpressionClass() == ExpressionClass::BOUND_REF &&
-	    right.GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
+	if (right.GetExpressionClass() == ExpressionClass::BOUND_CONSTANT && IsBloomFilterColumnRef(left, list_depth)) {
 		column = left;
 		constant = right.Cast<BoundConstantExpression>();
-	} else if (right.GetExpressionClass() == ExpressionClass::BOUND_REF &&
-	           left.GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
+	} else if (left.GetExpressionClass() == ExpressionClass::BOUND_CONSTANT &&
+	           IsBloomFilterColumnRef(right, list_depth)) {
 		column = right;
 		constant = left.Cast<BoundConstantExpression>();
 	} else {
 		return nullptr;
 	}
-	if (column->Cast<BoundReferenceExpression>().Index() != 0 || constant->GetValue().IsNull() ||
-	    column->GetReturnType() != constant->GetValue().type()) {
+	if (constant->GetValue().IsNull() || column->GetReturnType() != constant->GetValue().type()) {
 		return nullptr;
 	}
 	return constant;
 }
 
-static bool HasFilterConstants(const Expression &expr) {
+static bool HasFilterConstants(const Expression &expr, idx_t list_depth) {
 	if (BoundComparisonExpression::IsComparison(expr)) {
-		return GetBloomFilterConstant(expr) != nullptr;
+		return GetBloomFilterConstant(expr, list_depth) != nullptr;
 	}
 	if (expr.GetExpressionClass() != ExpressionClass::BOUND_CONJUNCTION) {
 		return false;
@@ -713,15 +737,15 @@ static bool HasFilterConstants(const Expression &expr) {
 	bool child_has_constant = false;
 	ExpressionIterator::EnumerateChildren(expr, [&](const Expression &child) {
 		if (!child_has_constant) {
-			child_has_constant = HasFilterConstants(child);
+			child_has_constant = HasFilterConstants(child, list_depth);
 		}
 	});
 	return child_has_constant;
 }
 
-static bool HasFilterConstants(const TableFilter &duckdb_filter) {
+static bool HasFilterConstants(const TableFilter &duckdb_filter, idx_t list_depth) {
 	auto &expr_filter = ExpressionFilter::GetExpressionFilter(duckdb_filter, "ParquetStatistics::HasFilterConstants");
-	return HasFilterConstants(*expr_filter.expr);
+	return HasFilterConstants(*expr_filter.expr, list_depth);
 }
 
 template <class T>
@@ -854,9 +878,9 @@ static optional<uint64_t> ValueXXH64(const Value &constant, const ParquetColumnS
 }
 
 static bool ApplyBloomFilter(const Expression &expr, ParquetBloomFilter &bloom_filter,
-                             const ParquetColumnSchema &schema) {
+                             const ParquetColumnSchema &schema, idx_t list_depth) {
 	if (BoundComparisonExpression::IsComparison(expr)) {
-		auto constant = GetBloomFilterConstant(expr);
+		auto constant = GetBloomFilterConstant(expr, list_depth);
 		if (!constant) {
 			return false;
 		}
@@ -869,14 +893,16 @@ static bool ApplyBloomFilter(const Expression &expr, ParquetBloomFilter &bloom_f
 	switch (expr.GetExpressionType()) {
 	case ExpressionType::CONJUNCTION_AND: {
 		bool any_children_true = false;
-		ExpressionIterator::EnumerateChildren(
-		    expr, [&](const Expression &child) { any_children_true |= ApplyBloomFilter(child, bloom_filter, schema); });
+		ExpressionIterator::EnumerateChildren(expr, [&](const Expression &child) {
+			any_children_true |= ApplyBloomFilter(child, bloom_filter, schema, list_depth);
+		});
 		return any_children_true;
 	}
 	case ExpressionType::CONJUNCTION_OR: {
 		bool all_children_true = true;
-		ExpressionIterator::EnumerateChildren(
-		    expr, [&](const Expression &child) { all_children_true &= ApplyBloomFilter(child, bloom_filter, schema); });
+		ExpressionIterator::EnumerateChildren(expr, [&](const Expression &child) {
+			all_children_true &= ApplyBloomFilter(child, bloom_filter, schema, list_depth);
+		});
 		return all_children_true;
 	}
 	default:
@@ -885,9 +911,9 @@ static bool ApplyBloomFilter(const Expression &expr, ParquetBloomFilter &bloom_f
 }
 
 static bool ApplyBloomFilter(const TableFilter &duckdb_filter, ParquetBloomFilter &bloom_filter,
-                             const ParquetColumnSchema &schema) {
+                             const ParquetColumnSchema &schema, idx_t list_depth) {
 	auto &expr_filter = ExpressionFilter::GetExpressionFilter(duckdb_filter, "ParquetStatistics::ApplyBloomFilter");
-	return ApplyBloomFilter(*expr_filter.expr, bloom_filter, schema);
+	return ApplyBloomFilter(*expr_filter.expr, bloom_filter, schema, list_depth);
 }
 
 bool ParquetStatisticsUtils::BloomFilterSupported(const ParquetColumnSchema &schema) {
@@ -950,8 +976,8 @@ bool ParquetStatisticsUtils::BloomFilterSupported(const ParquetColumnSchema &sch
 bool ParquetStatisticsUtils::BloomFilterExcludes(const TableFilter &duckdb_filter,
                                                  const duckdb_parquet::ColumnMetaData &column_meta_data,
                                                  TProtocol &file_proto, Allocator &allocator,
-                                                 const ParquetColumnSchema &schema) {
-	if (!HasFilterConstants(duckdb_filter) || !column_meta_data.__isset.bloom_filter_offset ||
+                                                 const ParquetColumnSchema &schema, idx_t list_depth) {
+	if (!HasFilterConstants(duckdb_filter, list_depth) || !column_meta_data.__isset.bloom_filter_offset ||
 	    column_meta_data.bloom_filter_offset <= 0) {
 		return false;
 	}
@@ -1008,7 +1034,7 @@ bool ParquetStatisticsUtils::BloomFilterExcludes(const TableFilter &duckdb_filte
 	auto new_buffer = make_uniq<ResizeableBuffer>(allocator, bloom_filter_data_size);
 	transport.read(new_buffer->ptr, UnsafeNumericCast<uint32_t>(bloom_filter_data_size));
 	ParquetBloomFilter bloom_filter(std::move(new_buffer));
-	return ApplyBloomFilter(duckdb_filter, bloom_filter, schema);
+	return ApplyBloomFilter(duckdb_filter, bloom_filter, schema, list_depth);
 }
 
 ParquetBloomFilter::ParquetBloomFilter(idx_t num_entries, double bloom_filter_false_positive_ratio) {

--- a/src/common/multi_file/multi_file_column_mapper.cpp
+++ b/src/common/multi_file/multi_file_column_mapper.cpp
@@ -214,6 +214,12 @@ static bool IsTriviallyMappable(const MultiFileColumnDefinition &global_column,
 	if (local_column.type != global_column.type) {
 		return false;
 	}
+	if (global_column.children.empty()) {
+		// the global column does not describe any children - MultiFileColumnDefinition only expands them for structs,
+		// while readers also expand list/map elements. the identical type already guarantees the nested layout
+		// matches, so there is nothing left that could map non-trivially
+		return true;
+	}
 	if (local_column.children.size() != global_column.children.size()) {
 		// child count difference - cannot map trivially
 		return false;

--- a/test/sql/copy/parquet/bloom_filters.test
+++ b/test/sql/copy/parquet/bloom_filters.test
@@ -500,6 +500,23 @@ SELECT count(*) FROM read_parquet('{TEST_DIR}/bloom_list.parquet') WHERE deep_li
 ----
 205
 
+# min/max pruning reaches the list elements as well
+statement ok
+COPY (SELECT [i::INTEGER, (i + 1)::INTEGER] AS l FROM range(20480) t(i))
+TO '{TEST_DIR}/bloom_list_sorted.parquet' (
+    FORMAT PARQUET, ROW_GROUP_SIZE 2048, DICTIONARY_SIZE_LIMIT 100000, WRITE_BLOOM_FILTER TRUE
+);
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM read_parquet('{TEST_DIR}/bloom_list_sorted.parquet') WHERE l[1] = 5000;
+----
+analyzed_plan	<REGEX>:(?s).*Row Groups Scanned: 1 / 10.*
+
+query I
+SELECT count(*) FROM read_parquet('{TEST_DIR}/bloom_list_sorted.parquet') WHERE l[1] = 5000;
+----
+1
+
 # lists of strings
 statement ok
 COPY (SELECT ['string_' || ((i % 100) * 2)::VARCHAR] AS s FROM range(20480) t(i))

--- a/test/sql/copy/parquet/bloom_filters.test
+++ b/test/sql/copy/parquet/bloom_filters.test
@@ -410,6 +410,130 @@ JOIN '{TEST_DIR}/bloom_blob.parquet' rhs ON lhs.b = rhs.b;
 ----
 100
 
+# A list stores all of its elements in a single leaf column chunk, so the leaf bloom filter covers every position
+statement ok
+COPY (
+    SELECT
+        [v, v + 2] AS list_value,
+        [[[v, v + 2]]] AS deep_list,
+        i::BIGINT AS payload
+    FROM (
+        SELECT i, ((i % 100) * 2)::INTEGER AS v
+        FROM range(20480) t(i)
+    ) data
+) TO '{TEST_DIR}/bloom_list.parquet' (
+    FORMAT PARQUET,
+    ROW_GROUP_SIZE 2048,
+    DICTIONARY_SIZE_LIMIT 1000,
+    WRITE_BLOOM_FILTER TRUE
+);
+
+# odd values never occur as a list element, but they do fall within the min/max of every row group
+query II
+EXPLAIN ANALYZE
+SELECT list_value, payload FROM read_parquet('{TEST_DIR}/bloom_list.parquet') WHERE list_value[1] = 101;
+----
+analyzed_plan	<REGEX>:(?s).*Row Groups Scanned: 0 / 10.*
+
+query I
+SELECT count(*) FROM read_parquet('{TEST_DIR}/bloom_list.parquet') WHERE list_value[1] = 101;
+----
+0
+
+query II
+EXPLAIN ANALYZE
+SELECT deep_list, payload FROM read_parquet('{TEST_DIR}/bloom_list.parquet') WHERE deep_list[1][1][1] = 101;
+----
+analyzed_plan	<REGEX>:(?s).*Row Groups Scanned: 0 / 10.*
+
+query II
+EXPLAIN ANALYZE
+SELECT payload FROM read_parquet('{TEST_DIR}/bloom_list.parquet')
+WHERE list_value[1] = 101 OR list_value[2] = 103;
+----
+analyzed_plan	<REGEX>:(?s).*Row Groups Scanned: 0 / 10.*
+
+# list_extract spelled out and negative indexing reach the same leaf
+query II
+EXPLAIN ANALYZE
+SELECT payload FROM read_parquet('{TEST_DIR}/bloom_list.parquet') WHERE list_extract(list_value, 2) = 101;
+----
+analyzed_plan	<REGEX>:(?s).*Row Groups Scanned: 0 / 10.*
+
+query II
+EXPLAIN ANALYZE
+SELECT payload FROM read_parquet('{TEST_DIR}/bloom_list.parquet') WHERE list_value[-1] = 101;
+----
+analyzed_plan	<REGEX>:(?s).*Row Groups Scanned: 0 / 10.*
+
+# the bloom filter covers the element domain, not the position - 200 only ever occurs at position 2
+query II
+EXPLAIN ANALYZE
+SELECT payload FROM read_parquet('{TEST_DIR}/bloom_list.parquet') WHERE list_value[1] = 200;
+----
+analyzed_plan	<REGEX>:(?s).*Row Groups Scanned: 10 / 10.*
+
+query I
+SELECT count(*) FROM read_parquet('{TEST_DIR}/bloom_list.parquet') WHERE list_value[1] = 200;
+----
+0
+
+# matching values must not be pruned away
+query I
+SELECT count(*) FROM read_parquet('{TEST_DIR}/bloom_list.parquet') WHERE list_value[1] = 100;
+----
+205
+
+query I
+SELECT count(*) FROM read_parquet('{TEST_DIR}/bloom_list.parquet') WHERE list_value[2] = 100;
+----
+205
+
+query I
+SELECT count(*) FROM read_parquet('{TEST_DIR}/bloom_list.parquet') WHERE deep_list[1][1][2] = 102;
+----
+205
+
+# a partially extracted list is not an element lookup
+query I
+SELECT count(*) FROM read_parquet('{TEST_DIR}/bloom_list.parquet') WHERE deep_list[1][1] = [100, 102];
+----
+205
+
+# lists of strings
+statement ok
+COPY (SELECT ['string_' || ((i % 100) * 2)::VARCHAR] AS s FROM range(20480) t(i))
+TO '{TEST_DIR}/bloom_list_string.parquet' (
+    FORMAT PARQUET, ROW_GROUP_SIZE 2048, DICTIONARY_SIZE_LIMIT 1000, WRITE_BLOOM_FILTER TRUE
+);
+
+query II
+EXPLAIN ANALYZE SELECT s FROM read_parquet('{TEST_DIR}/bloom_list_string.parquet') WHERE s[1] = 'string_101';
+----
+analyzed_plan	<REGEX>:(?s).*Row Groups Scanned: 0 / 10.*
+
+query I
+SELECT count(*) FROM read_parquet('{TEST_DIR}/bloom_list_string.parquet') WHERE s[1] = 'string_100';
+----
+205
+
+# lists of structs have more than one leaf - no pruning, but results must stay correct
+statement ok
+COPY (SELECT [{'a': ((i % 100) * 2)::INTEGER}] AS l FROM range(20480) t(i))
+TO '{TEST_DIR}/bloom_list_struct.parquet' (
+    FORMAT PARQUET, ROW_GROUP_SIZE 2048, DICTIONARY_SIZE_LIMIT 1000, WRITE_BLOOM_FILTER TRUE
+);
+
+query I
+SELECT count(*) FROM read_parquet('{TEST_DIR}/bloom_list_struct.parquet') WHERE l[1].a = 101;
+----
+0
+
+query I
+SELECT count(*) FROM read_parquet('{TEST_DIR}/bloom_list_struct.parquet') WHERE l[1].a = 100;
+----
+205
+
 # some tests for dictionary_size_limit
 
 # no bloom filter, dict limit too low


### PR DESCRIPTION
Fixes #24149.

Bloom filters were not used to prune row groups when filtering on LIST
elements. Investigating that surfaced a second, larger problem: LIST
columns were getting no row group pruning at all.

### LIST columns received no row group pruning (min/max or bloom)

`MultiFileColumnDefinition` only expands children for structs, so the
global definition of a LIST column has no children, while readers do
expand the list element. `IsTriviallyMappable` compared the two child
counts and concluded an `INTEGER[]` column could not be mapped trivially
onto an identical `INTEGER[]` column.

That routed every LIST column through an identity `remap_struct` inside an
`ExpressionColumnReader`. `ParquetColumnSchema::Stats` returns `nullptr`
for EXPRESSION schemas, so `PrepareRowGroupBuffer` skipped its entire
filter block. When the global column describes no children, the identical
type already guarantees the nested layout matches, so nothing can map
non-trivially. This also drops a per-row `remap_struct` call.

### Bloom filters now reach LIST elements

A LIST column stores every element of every list in one leaf column chunk,
so the leaf bloom filter covers the whole element domain of the row group.
A constant the filter excludes cannot occur at any position of any list,
which makes `list_col[i] = constant` prunable.

The reader never probed those filters: the bloom check was gated on the
column not being nested, `BloomFilterSupported()` had no LIST case, and
`GetBloomFilterConstant()` only matched a bare column reference. This
descends LIST levels to the primitive leaf, probes that leaf's chunk, and
matches filter expressions that unwrap the matching number of
`list_extract`/`array_extract` calls. Columns with more than one leaf below
the list (lists of structs, maps, arrays) are left alone.

### Result
EXPLAIN ANALYZE SELECT list_value, payload FROM read_parquet(...)
WHERE list_value[1] = 101;

before: Row Groups Scanned: 10 / 10 Data Read: 802.1 kB
after: Row Groups Scanned: 0 / 10 Data Read: 17.8 kB


Nested lists prune as well, and list min/max row group pruning works again
as a side effect. Regression test added to
`test/sql/copy/parquet/bloom_filters.test`.