### PR TITLE
Share the PEG grammar between parsers created without a cache

### DIFF
--- a/src/include/duckdb/parser/parser.hpp
+++ b/src/include/duckdb/parser/parser.hpp
@@ -108,6 +108,5 @@ private:
 	ParserCache &GetCache();
 
 	ParserOptions options;
-	unique_ptr<ParserCache> local_cache;
 };
 } // namespace duckdb

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -27,10 +27,8 @@ ParserCache &Parser::GetCache() {
 	if (options.parser_cache) {
 		return *options.parser_cache;
 	}
-	if (!local_cache) {
-		local_cache = make_uniq<ParserCache>();
-	}
-	return *local_cache;
+	static ParserCache shared_cache;
+	return shared_cache;
 }
 
 static bool ReplaceUnicodeSpaces(const string &query, string &new_query, vector<UnicodeSpace> &unicode_spaces) {


### PR DESCRIPTION
Parser::GetCache() built a private ParserCache, and therefore a private copy of the whole PEG grammar, whenever options.parser_cache was not set. Constructing the grammar costs ~0.86ms and produces the same immutable result every time.

Query parsing goes through ClientContext, which passes the DatabaseInstance's cache, so it was unaffected. Everything that constructs a bare Parser paid a full grammar build per instance:

```
src/parser/parsed_data/create_view_info.cpp  ParseSelect / FromCreateView
src/main/appender.cpp
src/function/pragma/pragma_queries.cpp
extension/json/json_functions/json_serialize_sql.cpp   (per row!)
extension/json/json_functions/json_serialize_plan.cpp
```

Falling back to a process-wide cache instead. ParserCache already guards itself with a mutex and hands out an immutable shared_ptr<PEGMatcher>, so sharing one between threads is no different from sharing the DatabaseInstance's.

```
SELECT sum(length(json_serialize_sql('SELECT ' || i))) FROM range(200);
  before 0.173s   after 0.010s   (17x)
... FROM range(400);
  before 0.340s   after 0.015s   (23x)
```
Per bare-Parser construction: 0.86ms -> 0.04ms. On a query workload that only reaches this path through view parsing the end-to-end win is 1-5%.