### PR TITLE
test harness: LOCAL_{TEMP,DATA}_DIR, add --env-passthrough, remote temp-dir fixes

### DIFF
--- a/scripts/test_storage_compatibility.py
+++ b/scripts/test_storage_compatibility.py
@@ -204,14 +204,14 @@ def execute_test(i, test):
         with open(worker_test_config, 'w') as f:
             json.dump(config_contents, f)
         # The durable db (initial_db) lives outside test_temp_dir, so destroy is indifferent;
-        # pin test_temp_dir as the exact base with both levels off (replaces --test-temp-dir).
+        # pin test_temp_dir as the exact root with both levels off (replaces --test-temp-dir).
         # The enclosing TemporaryDirectory cleans everything up, so destroy=never just retains
         # until then.
         unittest_cmd = [
             unittest_program,
             '--test-config',
             worker_test_config,
-            '--temp-dir-base',
+            '--temp-dir-root',
             test_temp_dir,
             '--temp-dir-run-id',
             'off',

--- a/scripts/test_zero_initialize.py
+++ b/scripts/test_zero_initialize.py
@@ -141,12 +141,12 @@ for test in test_list:
     print(f"Running test {test}")
     clear_directories(test_dirs)
     # TEMP_DIR must BE the given dir exactly and survive for the post-run byte diff below,
-    # so pin the base with both levels off and destroy=never (the dirs are pre-rmtree'd
+    # so pin the root with both levels off and destroy=never (the dirs are pre-rmtree'd
     # above, so the default create=on-absent is fine). --database-destroy off keeps the
     # generated DB files (otherwise the harness deletes loaded DBs under TEMP_DIR, leaving
     # the retained dir empty and the compare with nothing to diff).
     temp_dir_flags = lambda d: [
-        '--temp-dir-base',
+        '--temp-dir-root',
         d,
         '--temp-dir-run-id',
         'off',

--- a/test/README.md
+++ b/test/README.md
@@ -12,22 +12,31 @@ Within SQL tests, the test runner (unittest) guarantees that these environment v
 |------------------|----------------------------|-------------------------------------------------------------|------------------------------------------------------------------------------------|
 | `TEST_NAME` | e.g. `test/path/filename.test` | N/A |                                                                                    |
 | `TEST_NAME__NO_SLASH` | e.g. `test_path_filename.test` | N/A | is always `TEST_NAME s@/@_@g` (keeps the body suffix)                               |
-| `TEST_ID` | e.g. `test_path_filename_test` | N/A | per-test identity: the full `TEST_NAME` sanitized to one path component (every char outside `[A-Za-z0-9_-]` → `_`, including `.`); the body suffix is kept so siblings differing only by suffix (`foo.test` vs `foo.test_slow`) stay distinct; the `[TEST_ID]` path level under `TEMP_DIR_BASE` |
+| `TEST_ID` | e.g. `test_path_filename_test` | N/A | per-test identity: the full `TEST_NAME` sanitized to one path component (every char outside `[A-Za-z0-9_-]` → `_`, including `.`); the body suffix is kept so siblings differing only by suffix (`foo.test` vs `foo.test_slow`) stay distinct; the `[TEST_ID]` path level under `TEMP_DIR_ROOT` |
 | `TEST_UUID` | random UUID (as string) | N/A | defined per invocation                                                             |
-| `RUN_ID` | generated (`<ts>--<mnemonic>`) | `unittest --run-id <id>` | per-run identity; the `[RUN_ID]` path level; shared across a run's tests            |
+| `RUN_ID` | generated (`<ts>--<mnemonic>`) | `unittest --run-id <id>`<br/>also `DUCKDB_TEST_RUN_ID`, config `run_id` | per-run identity; the `[RUN_ID]` path level; shared across a run's tests            |
 | `WORKING_DIR`    | e.g., `/Users/me/src/duckdb`     | `unittest --test-dir <path>`                                | default: wherever duckdb was sourced and built <br/> AKA: `{WORKING_DIRECTORY}`    |
 | `BUILD_DIR`      | `{WORKING_DIR}/build/release` | N/A                                                         | read-only; derived from unittest path <br/> AKA: `{BUILD_DIRECTORY}`               |
-| `DATA_DIR`  | `{WORKING_DIR}/data`        | `unittest --data-dir <path>`<br/>also `DUCKDB_TEST_DATA_DIR`, config `data_dir`, or a `test_env` entry | copy of `duckdb/data/**`, to test AWS/Azure/other VFS reads; may be relative or absolute/remote (e.g. `az://...`). See [Data directory](#data-directory). |
-| `TEMP_DIR_BASE` | `{WORKING_DIR}/duckdb_unittest_tempdir` | `unittest --temp-dir-base <path>` | root of the temp-dir tree; may be local or remote (e.g. `s3://`)                    |
-| `TEMP_DIR` | `{TEMP_DIR_BASE}/[RUN_ID]/[TEST_ID]` | `--temp-dir-run-id {on,off}` / `--temp-dir-test-id {on,off}` (include/omit each level); `--temp-dir-{create,destroy}` govern lifecycle | the per-test temp dir; use to test VFS writes <br/> AKA: `{TEST_DIR}`, deprecated `__TEST_DIR__` |
+| `DATA_DIR`  | `{WORKING_DIR}/data`        | `unittest --data-dir <path>`<br/>also `DUCKDB_TEST_DATA_DIR`, config `data_dir` | copy of `duckdb/data/**`, to test AWS/Azure/other VFS reads; may be relative or absolute/remote (e.g. `az://...`). See [Data directory](#data-directory). |
+| `TEMP_DIR_ROOT` | `{WORKING_DIR}/duckdb_unittest_tempdir` | `unittest --temp-dir-root <path>`<br/>also `DUCKDB_TEST_TEMP_DIR_ROOT`, config `temp_dir_root` | root of the temp-dir tree; may be local or remote (e.g. `s3://`)                    |
+| `TEMP_DIR` | `{TEMP_DIR_ROOT}/[RUN_ID]/[TEST_ID]` | `--temp-dir-run-id {on,off}` / `--temp-dir-test-id {on,off}` (include/omit each level); `--temp-dir-destroy` governs lifecycle | the per-test temp dir; use to test VFS writes <br/> AKA: `{TEST_DIR}`, deprecated `__TEST_DIR__` |
 | `TEMP_DIR_ABSOLUTE` | absolute path to `{TEMP_DIR}` | N/A | use when a test requires an absolute path, e.g. `file://` URIs                     |
+| `LOCAL_TEMP_DIR` | `{TEMP_DIR}` | `unittest --local-temp-dir-root <path>` (root only; must be local, and requires a remote `TEMP_DIR_ROOT` — pins the local tree somewhere chosen instead of the default. Against a differing local `TEMP_DIR_ROOT` it is an error, since that is already its own `LOCAL_TEMP_DIR`; use `DUCKDB_TEST_TEMP_DIR_ROOT` to redirect the whole tree)<br/>also `DUCKDB_TEST_LOCAL_TEMP_DIR_ROOT`, config `local_temp_dir_root` | guaranteed-**local** temp dir — the same path when `TEMP_DIR_ROOT` is local, a separate local tree (same `[RUN_ID]/[TEST_ID]` levels, same lifecycle) when it is remote. Use to stage/spill locally in a test that targets a remote root. |
+| `LOCAL_DATA_DIR` | `{DATA_DIR}` | `unittest --local-data-dir <path>` (must be local, and must equal `--data-dir` when that is itself local)<br/>also `DUCKDB_TEST_LOCAL_DATA_DIR`, config `local_data_dir` | guaranteed-**local** data dir; falls back to `{WORKING_DIR}/data` when `DATA_DIR` is remote |
 | `CATALOG_DIR` | `{TEMP_DIR}/{TEST_UUID}` | N/A | a per-test catalog dir; NOT guaranteed to exist (create on demand)                 |
+| *(any)* | N/A | `unittest --env-passthrough <NAME>` (repeatable, or comma-separated)<br/>also `DUCKDB_TEST_ENV_PASSTHROUGH`, config `env_passthrough` | pre-registers a **caller's** env var for `{NAME}` substitution in every test, with no `require-env`/`test-env` in the body. Unlike `require-env`'s per-test skip, a named-but-absent var fails the whole invocation at startup. Names above are reserved and rejected. |
+
+Every name in the table above is **reserved**: the runner resolves it itself, once per invocation or
+once per test. Neither `--env-passthrough` nor a config `test_env` entry may set one — naming a
+reserved variable fails the whole invocation at startup rather than silently shadowing the resolved
+value. Use the matching option (`--data-dir`, `--temp-dir-root`, `--local-data-dir`, …) instead;
+`test_env` is for a suite's *own* variables.
 
 Some tests require a particular environment variables to be set so they can properly run, usually this can be seen via `require-env VAR` in the test.
 
 ### Data directory
 
-`DATA_DIR` is where tests read fixture data from (`{DATA_DIR}` in tests). Set it with `--data-dir <path>`, `DUCKDB_TEST_DATA_DIR=<path>`, a `data_dir` config option, or a `test_env` entry.
+`DATA_DIR` is where tests read fixture data from (`{DATA_DIR}` in tests). Set it with `--data-dir <path>`, `DUCKDB_TEST_DATA_DIR=<path>`, a `data_dir` config option.
 
 - **Default (unset):** `{WORKING_DIR}/data`. This follows the working directory: an out-of-tree extension test `chdir`s into its own source dir mid-run, so its `DATA_DIR` becomes `<extension>/data` — intentional, since those tests ship their own `data/` and address it relative to the repo root.
 - **Set, relative:** used verbatim and resolved against the *current* cwd at read time, so it likewise follows a test's `chdir`.
@@ -37,20 +46,24 @@ Some tests require a particular environment variables to be set so they can prop
 
 Every test gets one scratch directory, written in-test as `{TEST_DIR}`. Its path is up to three nested levels:
 
-    TEMP_DIR_BASE / [RUN_ID] / [TEST_ID]
+    TEMP_DIR_ROOT / [RUN_ID] / [TEST_ID]
 
-- **`TEMP_DIR_BASE`** — the root (`duckdb_unittest_tempdir`, or `--temp-dir-base`); may be local or remote (`s3://…`).
+- **`TEMP_DIR_ROOT`** — the root (`duckdb_unittest_tempdir`, or `--temp-dir-root`); may be local or remote (`s3://…`). Normalized when parsed, so `.`/`..` segments are folded (lexically — no disk access) and `TEMP_DIR_ROOT` reports the resolved form. A relative root stays relative. An empty root is rejected at startup.
 - **`RUN_ID`** — per-run isolation, shared across a run's tests; toggle with `--temp-dir-run-id` (a fixed id co-locates many `unittest` batches under one dir; a bind-mount turns it off).
 - **`TEST_ID`** — per-test isolation; toggle with `--temp-dir-test-id`. Resolved per-test (the name isn't known until the test runs) and materialized lazily on first use.
 
-Lifecycle is one create × one destroy disposition, inherited down every level: `--temp-dir-create {never,on-absent,always}` and `--temp-dir-destroy {never,on-success,always}` (defaults `on-absent` / `on-success`).
+Lifecycle is one destroy disposition, inherited down every level: `--temp-dir-destroy {never,on-success,always}` (default `on-success`). Creation is unconditional `mkdir -p`, and each level records whether it already existed, so a destroy reclaims only what the run itself made — including the run root, which is retained (never recursively removed) when the run merely adopted it. Both cover the HOME sandbox and the `LOCAL_TEMP_DIR` tree too — `--temp-dir-destroy never` keeps everything a run made, for inspection.
+
+A **remote** `TEMP_DIR_ROOT` clamps destroy to `never`: object stores create-on-write, so the test owns materialization and `unittest` never mkdir/rm's a remote root. `LOCAL_TEMP_DIR` covers what still needs to be local in that configuration — see the contract table above. It is a full local tree (`[RUN_ID]/[TEST_ID]`, same disposition), rooted at the default local root or at `--local-temp-dir-root`.
+
+Every `--temp-dir-*` flag above (plus `--run-id`, `--database-destroy`, `--env-passthrough`) is a standard test-config option: each also takes a `DUCKDB_TEST_<NAME>` env var and can be set from a `--test-config` file. CLI beats env; a config file loaded later beats both.
 
 The **loaded database files** under `TEMP_DIR` have their own disposition, `--temp-dir-destroy`'s independent sibling: `--database-destroy {on,off,on-success}` (default `on-success`). A DB's keep/destroy is not per-se a temp-dir property, so it is a separate knob — use `off` to retain the generated DB files inside a retained temp dir (e.g. to diff them after the run, as `test_zero_initialize.py` does); `on-success` mirrors `--temp-dir-destroy` so a failed test's DB survives for inspection.
 
 **Naming — read once, then stop worrying:**
 - `{TEST_DIR}` (the token nearly all tests use) and the `TEMP_DIR` env var are the **same directory** — synonyms. Prefer `{TEST_DIR}`; `{TEMP_DIR}` and the deprecated `__TEST_DIR__` also resolve to it.
 - `{TEST_DIR}`/`TEMP_DIR` is **relative** (to `WORKING_DIR`) *by default* — deliberately, so absolute machine paths don't leak into compared test output. When a test genuinely needs an absolute path (e.g. a `file://` URI), use **`TEMP_DIR_ABSOLUTE`**.
-- `TEMP_DIR_BASE` is the root only; `CATALOG_DIR` is `{TEST_DIR}/{TEST_UUID}` (create on demand).
+- `TEMP_DIR_ROOT` is the root only; `CATALOG_DIR` is `{TEST_DIR}/{TEST_UUID}` (create on demand).
 
 **Extension tests are the one exception.** Out-of-tree extension tests `chdir` into their own source dir mid-run, so a *relative* `{TEST_DIR}` would resolve against the wrong directory. For those (only), the runner pins `{TEST_DIR}`/`TEMP_DIR` to the absolute path — captured before the chdir; everything else stays relative.
 

--- a/test/api/test_windows_unicode_path.cpp
+++ b/test/api/test_windows_unicode_path.cpp
@@ -34,6 +34,8 @@ TEST_CASE("Issue #6931 - test windows unicode path", "[windows]") {
 	string dirname = "Moseguí_i_González";
 	auto test_directory = TestDirectoryPath() + "/" + dirname;
 	auto current_directory = TestGetCurrentDirectory();
+	// TestDirectoryPath() is absolute whenever the temp-dir-root is, so anchor rather than concatenate.
+	auto absolute_directory = TestMakeAbsolute(test_directory, current_directory);
 	TestCreateDirectory(test_directory);
 	TestChangeDirectory(test_directory);
 
@@ -44,9 +46,10 @@ TEST_CASE("Issue #6931 - test windows unicode path", "[windows]") {
 	// relative path TOWARDS folder with accents
 	TestConnectToDatabase(dirname + "/" + "test.db");
 
-	// absolute path with folder with accents
-	TestConnectToDatabase(current_directory + "/" + test_directory + "/" + "test.db");
-
-	// revert current working directory
+	// Restore before the last leg, which does not need the chdir: a throw while still inside the temp
+	// dir leaves every later test resolving relative paths from there.
 	TestChangeDirectory(current_directory);
+
+	// absolute path with folder with accents
+	TestConnectToDatabase(absolute_directory + "/" + "test.db");
 }

--- a/test/common/test_file_system.cpp
+++ b/test/common/test_file_system.cpp
@@ -43,7 +43,7 @@ static void create_dummy_file(string fname) {
 
 TEST_CASE("Make sure the file:// protocol works as expected", "[file_system]") {
 	duckdb::unique_ptr<FileSystem> fs = FileSystem::CreateLocal();
-	auto dname = fs->JoinPath(fs->GetWorkingDirectory(), TestCreatePath("TEST_DIR"));
+	auto dname = TestMakeAbsolute(TestCreatePath("TEST_DIR"), fs->GetWorkingDirectory());
 	auto dname_converted_slashes = StringUtil::Replace(dname, "\\", "/");
 
 	// handle differences between windows and linux

--- a/test/helpers/test_config.cpp
+++ b/test/helpers/test_config.cpp
@@ -1,5 +1,6 @@
 #include "test_config.hpp"
 #include "duckdb/common/types.hpp"
+#include "duckdb/common/path.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/enum_util.hpp"
 #include "test_helpers.hpp"
@@ -27,6 +28,34 @@ static const TestConfigOption test_config_options[] = {
      "Root dir for test data (DATA_DIR / {DATA_DIR}); default {WORKING_DIR}/data. Relative values "
      "resolve per test cwd; absolute/remote (e.g. az://...) values are used verbatim.",
      LogicalType::VARCHAR, nullptr},
+    {"local_data_dir",
+     "Local-FS counterpart of data_dir (LOCAL_DATA_DIR / {LOCAL_DATA_DIR}); default {WORKING_DIR}/data. "
+     "Must be local, and must equal data_dir when that is itself local -- a local data_dir is already "
+     "its own LOCAL_DATA_DIR.",
+     LogicalType::VARCHAR, TestConfiguration::CheckLocalDataDir},
+    {"temp_dir_root",
+     "Root of the temp-dir tree (TEMP_DIR_ROOT / $ROOT); default duckdb_unittest_tempdir. May be local "
+     "or remote (e.g. az://...); a remote root is never created or reaped by unittest.",
+     LogicalType::VARCHAR, TestConfiguration::SetTempDirRootOption},
+    {"local_temp_dir_root",
+     "Root of the LOCAL_TEMP_DIR tree when temp_dir_root is remote; default duckdb_unittest_tempdir. "
+     "Must be local; an error against a differing local temp_dir_root, which is already its own "
+     "LOCAL_TEMP_DIR.",
+     LogicalType::VARCHAR, TestConfiguration::SetLocalTempDirRootOption},
+    {"run_id", "Run identity (RUN_ID env, and the [RUN_ID] path level); 'auto' or absent generates one",
+     LogicalType::VARCHAR, TestConfiguration::SetRunIdOption},
+    {"temp_dir_run_id", "Include the [RUN_ID] level in TEMP_DIR: on, off", LogicalType::VARCHAR,
+     TestConfiguration::SetTempDirRunIdOption},
+    {"temp_dir_test_id", "Include the [TEST_ID] level in TEMP_DIR: on, off", LogicalType::VARCHAR,
+     TestConfiguration::SetTempDirTestIdOption},
+    {"temp_dir_destroy", "Temp-dir destroy disposition: never, on-success, always", LogicalType::VARCHAR,
+     TestConfiguration::SetTempDirDestroyOption},
+    {"database_destroy", "Loaded-database destroy disposition: on, off, on-success", LogicalType::VARCHAR,
+     TestConfiguration::SetDatabaseDestroyOption},
+    {"env_passthrough",
+     "Env var names pre-registered for {NAME} substitution in every test, read from the real process "
+     "env; a named-but-absent var fails the whole invocation at startup",
+     LogicalType::LIST(LogicalType::VARCHAR), TestConfiguration::AppendEnvPassthrough},
     {"max_threads", "Max threads to use during tests", LogicalType::BIGINT, nullptr},
     {"max_test_threads", "Max threads to be used by the test runner itself (for e.g. concurrent loop)",
      LogicalType::BIGINT, nullptr},
@@ -124,7 +153,7 @@ void TestConfiguration::Initialize() {
 	working_dir = FileSystem::GetWorkingDirectory();
 	test_uuid = UUID::ToString(UUID::GenerateRandomUUID());
 	// NOTE: UpdateEnvironment() is intentionally NOT called here. It runs once in main()
-	// after PrepareTempDir(), so TEMP_DIR/TEMP_DIR_BASE reflect the final --temp-dir-*
+	// after PrepareTempDir(), so TEMP_DIR/TEMP_DIR_ROOT reflect the final --temp-dir-*
 	// context. test_env is consumed only at test-run time, so deferring is safe.
 	// (ChangeWorkingDirectory still refreshes it on an actual cwd change.)
 }
@@ -139,22 +168,41 @@ void TestConfiguration::UpdateEnvironment() {
 	// DATA_DIR: an explicit override (--data-dir / DUCKDB_TEST_DATA_DIR / config data_dir) is read fresh
 	// here, so it survives cwd changes -- an absolute/remote value stays put, a relative value is resolved
 	// per test cwd. Absent an override, default to <cwd>/data, which re-anchors on an extension chdir.
+	// Every name set here is reserved against every external input (IsReservedEnvName, test_helpers.cpp).
 	auto data_dir_override = GetOptionOrDefault("data_dir", string());
-	test_env["DATA_DIR"] = data_dir_override.empty() ? working_dir + "/data" : data_dir_override;
+	string default_data_dir = working_dir + "/data";
+	test_env["DATA_DIR"] = data_dir_override.empty() ? default_data_dir : data_dir_override;
 
 	string temp_dir = TestDirectoryPath();
-	auto fs = FileSystem::CreateLocal();
-	string temp_dir_absolute = temp_dir;
-	if (!fs->IsPathAbsolute(temp_dir_absolute)) {
-		temp_dir_absolute = fs->JoinPath(working_dir, temp_dir_absolute);
-	}
-	// TEMP_DIR here is the run-id root ($BASE/[RUN_ID]); the per-test path overrides it per
-	// runner with the full $BASE/[RUN_ID]/[TEST_ID] once a test name is known.
-	test_env["TEMP_DIR"] = temp_dir;                      // run-root ($BASE/$RUN_ID); per-test gets +=$TEST_ID
+	string temp_dir_absolute = TestMakeAbsolute(temp_dir, working_dir);
+	// TEMP_DIR here is the run-id root ($ROOT/[RUN_ID]); the per-test path overrides it per
+	// runner with the full $ROOT/[RUN_ID]/[TEST_ID] once a test name is known.
+	test_env["TEMP_DIR"] = temp_dir;                      // run-root ($ROOT/$RUN_ID); per-test gets +=$TEST_ID
 	test_env["TEMP_DIR_ABSOLUTE"] = temp_dir_absolute;    // absolute form of TEMP_DIR
-	test_env["TEMP_DIR_BASE"] = GetTempDirBase();         // $BASE; default duckdb_unittest_tempdir
+	test_env["TEMP_DIR_ROOT"] = GetTempDirRoot();         // $ROOT; default duckdb_unittest_tempdir
 	test_env["RUN_ID"] = GetTempDirRunId();               // RUN_ID (--run-id, or generated); always set
 	test_env["CATALOG_DIR"] = temp_dir + "/" + test_uuid; // _not_ guaranteed to exist
+
+	// Local-FS variants of DATA_DIR / TEMP_DIR. Computed, never overlaid: these are reserved names
+	// (IsReservedEnvName), so an option is the only way to influence them and there is no later
+	// `test_env` overlay to reconcile against.
+	auto local_data_dir_override = GetOptionOrDefault("local_data_dir", string());
+	if (!local_data_dir_override.empty()) {
+		test_env["LOCAL_DATA_DIR"] = local_data_dir_override;
+	} else {
+		test_env["LOCAL_DATA_DIR"] =
+		    Path::FromString(test_env["DATA_DIR"]).IsRemote() ? default_data_dir : test_env["DATA_DIR"];
+	}
+	test_env["LOCAL_TEMP_DIR"] = LocalTestDirectoryPath();
+
+	// Passthrough configured env vars as test env (no `require-env` required.)
+	// main() already validated, but null check defensively.
+	for (auto &name : GetEnvPassthroughNames()) {
+		auto value = std::getenv(name.c_str());
+		if (value) {
+			test_env[name] = value;
+		}
+	}
 
 	// Re-overlay caller `test_env` config entries so they win over the standard defaults just recomputed
 	// above (important when a cwd change re-runs UpdateEnvironment).
@@ -265,7 +313,7 @@ bool TestConfiguration::TryParseOption(const string &name, const Value &value) {
 		}
 	}
 	auto parameter = to_cast.DefaultCastAs(test_config.type);
-	if (test_config.on_set_option) {
+	if (test_config.on_set_option && !ignore_option_side_effects) {
 		test_config.on_set_option(parameter);
 	}
 	options[test_config.name] = parameter;
@@ -402,6 +450,86 @@ void TestConfiguration::ParseConnectScript(const Value &input) {
 	test_config.ParseOption("on_init", Value(init_cmd));
 }
 
+// Each defers to the test_helpers setter of record and turns its bool return into the error, so a
+// knob's valid-value list lives in exactly one place.
+static void SetTempDirOption(const string &option, bool (*setter)(const string &), const Value &input,
+                             const char *expects) {
+	if (!setter(input.ToString())) {
+		throw std::runtime_error(option + " expects one of: " + expects);
+	}
+}
+
+void TestConfiguration::SetTempDirRootOption(const Value &input) {
+	SetTempDirRoot(input.ToString());
+}
+
+void TestConfiguration::SetLocalTempDirRootOption(const Value &input) {
+	SetLocalTempDirRoot(input.ToString());
+}
+
+void TestConfiguration::SetRunIdOption(const Value &input) {
+	SetRunId(input.ToString());
+}
+
+void TestConfiguration::SetTempDirRunIdOption(const Value &input) {
+	SetTempDirOption("--temp-dir-run-id", SetTempDirRunIdInPath, input, "on, off");
+}
+
+void TestConfiguration::SetTempDirTestIdOption(const Value &input) {
+	SetTempDirOption("--temp-dir-test-id", SetTempDirTestId, input, "on, off");
+}
+
+void TestConfiguration::SetTempDirDestroyOption(const Value &input) {
+	SetTempDirOption("--temp-dir-destroy", SetTempDirDestroy, input, "never, on-success, always");
+}
+
+void TestConfiguration::SetDatabaseDestroyOption(const Value &input) {
+	SetTempDirOption("--database-destroy", SetDatabaseDestroy, input, "on, off, on-success");
+}
+
+void TestConfiguration::AppendEnvPassthrough(const Value &input) {
+	// Accumulates rather than replaces; repeated uses of flag extends
+	for (auto &name : ListValue::GetChildren(input)) {
+		AddEnvPassthrough(name.ToString());
+	}
+}
+
+void TestConfiguration::CheckLocalDataDir(const Value &input) {
+	if (Path::FromString(input.ToString()).IsRemote()) {
+		throw std::runtime_error("--local-data-dir must be a local path, got: " + input.ToString());
+	}
+}
+
+bool TestConfiguration::ValidateTestEnv(string &error) {
+	LoadTestEnvFromConfig();
+	string reserved;
+	for (auto &name : test_env_from_config_keys) {
+		if (IsReservedEnvName(name)) {
+			reserved += (reserved.empty() ? "" : ", ") + name;
+		}
+	}
+	if (reserved.empty()) {
+		return true;
+	}
+	error = "config `test_env`: reserved by the test runner, cannot be overridden: " + reserved +
+	        "\nThese are resolved per invocation (or per test) by the runner itself; use the matching "
+	        "option instead (e.g. --data-dir, --temp-dir-root, --local-data-dir).";
+	return false;
+}
+
+bool TestConfiguration::ValidateDataDirs(string &error) {
+	// Only an explicit LOCAL_DATA_DIR can trip this: the derived value IS DATA_DIR whenever that is local.
+	const auto &data_dir = test_env["DATA_DIR"];
+	const auto &local_data_dir = test_env["LOCAL_DATA_DIR"];
+	if (Path::FromString(data_dir).IsRemote() || Path::Normalize(data_dir) == Path::Normalize(local_data_dir)) {
+		return true;
+	}
+	error = "local-data-dir must equal data-dir when that is local, which is already its own LOCAL_DATA_DIR "
+	        "(data-dir: " +
+	        data_dir + ", local-data-dir: " + local_data_dir + ")";
+	return false;
+}
+
 void TestConfiguration::CheckSortStyle(const Value &input) {
 	SortStyle sort_style;
 	if (!TryParseSortStyle(input.ToString(), sort_style)) {
@@ -475,6 +603,10 @@ void TestConfiguration::LoadConfig(const string &config_path) {
 			auto cwd = TestGetCurrentDirectory();
 			auto path = TestJoinPath(cwd, path_value.ToString());
 			TestConfiguration inherit_config;
+			// Harvesting skip_tests only: the option hooks below write process-global lifecycle state
+			// (temp-dir roots, run id, dispositions, env-passthrough), so an inherited config would
+			// otherwise replace what the actual invocation selected.
+			inherit_config.ignore_option_side_effects = true;
 			inherit_config.LoadConfig(path);
 
 			tests_to_be_skipped.insert(inherit_config.tests_to_be_skipped.begin(),
@@ -541,6 +673,8 @@ void TestConfiguration::ClearTestDirOverride() {
 	test_dir_override.clear();
 }
 
+// Every {KEYWORD} substituted here is reserved against every external input (IsReservedEnvName,
+// test_helpers.cpp): ReplaceKeywords substitutes env vars first, so a passthrough would shadow them.
 void TestConfiguration::ProcessPath(string &path, const string &test_name) {
 	// {TEST_DIR} normally follows the current cwd (TestDirectoryPath()); an active override pins it to
 	// the absolute, main-cwd-anchored temp dir instead (extension runner, post-chdir -- see the header).

--- a/test/helpers/test_helpers.cpp
+++ b/test/helpers/test_helpers.cpp
@@ -2,6 +2,7 @@
 #include "catch.hpp"
 
 #include "duckdb/common/file_system.hpp"
+#include "duckdb/common/path.hpp"
 #include "duckdb/common/value_operations/value_operations.hpp"
 #include "compare_result.hpp"
 #include "duckdb/main/query_result.hpp"
@@ -28,20 +29,28 @@ static case_insensitive_set_t required_requires;
 static bool delete_test_path = true;
 static bool emit_on_skip = false; // --emit-on-skip opt-in: emit a [SKIP_TEST] marker per skipped test
 
-// --temp-dir-* family state: TEMP_DIR = $BASE/[RUN_ID]/[TEST_ID] (see DISPOSITIONS.md).
-static string temp_dir_base = TESTING_DIRECTORY_NAME; // $BASE; default duckdb_unittest_tempdir
-static bool temp_dir_run_id_in_path = true;           // --temp-dir-run-id {on|off}: RUN_ID as a path level
-static string temp_dir_run_id;                        // RUN_ID value (--run-id, or generated when absent)
+// --temp-dir-* family state: TEMP_DIR = $ROOT/[RUN_ID]/[TEST_ID]
+static bool temp_dir_run_id_in_path = true; // --temp-dir-run-id {on|off}: RUN_ID as a path level
+static string temp_dir_run_id;              // RUN_ID value (--run-id, or generated when absent)
 static bool temp_dir_test_id = true;
-static TempDirCreate temp_dir_create = TempDirCreate::ON_ABSENT;
 static TempDirDestroy temp_dir_destroy = TempDirDestroy::ON_SUCCESS;
 // --database-destroy: independent of the temp-dir dispositions (see test_helpers.hpp).
 static DatabaseDestroy database_destroy = DatabaseDestroy::ON_SUCCESS;
-// Levels THIS invocation created (outermost..leaf), split by lifecycle so each
-// destroy step reclaims only what its own step made.
-static vector<string> temp_dir_run_created_levels;  // $BASE..$RUN_ID (main / Prepare|DestroyTempDir)
-static vector<string> temp_dir_test_created_levels; // $TEST_ID (per-test path)
-static string temp_dir_active_test_leaf;            // currently-materialized TEST_ID dir ("" when none)
+
+// The primary (--temp-dir-root, may be remote) and, when that is remote, the local tree behind
+// LOCAL_TEMP_DIR. Paths, not strings: easily composed, and remoteness is a state instead of a parse.
+static Path primary_root = Path::FromString(TESTING_DIRECTORY_NAME);
+static Path local_root;                     // resolved lazily; see LocalRoot()
+static bool local_root_resolved = false;    // Path() is ".", not empty, so track this separately
+static string local_temp_dir_root_override; // --local-temp-dir-root ("" -> the default local root)
+
+// Levels THIS invocation created, split by lifecycle step so each destroy reclaims only its own. One
+// set, not one per root: a remote root is env-var passthrough only -- unittest holds no credentials, so
+// it can never mkdir or reap one, and the local tree is the only thing with a lifecycle.
+static vector<string> run_created_levels;  // $ROOT..$RUN_ID
+static vector<string> test_created_levels; // $TEST_ID
+static vector<string> home_created_levels; // the HOME sandbox sibling
+static string active_test_leaf;            // currently-materialized $TEST_ID dir ("" when none)
 
 bool NO_FAIL(QueryResult &result) {
 	if (result.HasError()) {
@@ -99,6 +108,15 @@ string TestJoinPath(string path1, string path2) {
 	return fs->JoinPath(path1, path2);
 }
 
+string TestMakeAbsolute(const string &path, const string &anchor) {
+	// Path::IsAbsolute handles URI schemes correctly
+	auto parsed = Path::FromString(path);
+	if (parsed.IsAbsolute()) {
+		return path;
+	}
+	return Path::FromString(anchor).Join(parsed).ToString();
+}
+
 void SetEmitOnSkip(bool emit) {
 	emit_on_skip = emit;
 }
@@ -116,17 +134,92 @@ bool IsRequired(string require) {
 }
 
 // -----------------------------------------------------------------------------
+// --env-passthrough NAME: env vars pre-registered for {NAME} substitution -- see test_helpers.hpp.
+// Case-SENSITIVE, matching both env var names and the test_env map these land in.
+static duckdb::set<string> env_passthrough_names;
+
+// Every name the runner resolves for itself -- passing one through would silently replace it with the
+// ambient shell's. Covers both namespaces, because ReplaceKeywords substitutes env vars BEFORE
+// ProcessPath, so a passthrough beats a {KEYWORD} too. Keep in sync with the three sites that own
+// these: TestConfiguration::UpdateEnvironment, TestConfiguration::ProcessPath, RunSQLLogicTest.
+static const char *const RESERVED_ENV_NAMES[] = {
+    // test_env keys (UpdateEnvironment, plus RunSQLLogicTest's per-test overrides)
+    "BUILD_DIR", "CATALOG_DIR", "DATA_DIR", "LOCAL_DATA_DIR", "LOCAL_TEMP_DIR", "RUN_ID", "TEMP_DIR",
+    "TEMP_DIR_ABSOLUTE", "TEMP_DIR_ROOT", "TEST_ID", "TEST_NAME", "TEST_NAME__NO_SLASH", "TEST_UUID", "WORKING_DIR",
+    // {KEYWORD} substitutions (ProcessPath, and ReplaceKeywords' own {BUILD_DIRECTORY})
+    "BASE_TEST_NAME", "BUILD_DIRECTORY", "TEST_DIR", "UUID", "WORKING_DIRECTORY"};
+
+bool IsReservedEnvName(const string &name) {
+	for (auto &reserved : RESERVED_ENV_NAMES) {
+		if (StringUtil::CIEquals(name, reserved)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+void AddEnvPassthrough(string name) {
+	env_passthrough_names.insert(name);
+}
+
+const duckdb::set<string> &GetEnvPassthroughNames() {
+	return env_passthrough_names;
+}
+
+bool ValidateEnvPassthrough(string &error) {
+	string missing;
+	string reserved;
+	for (auto &name : env_passthrough_names) {
+		if (!std::getenv(name.c_str())) {
+			missing += (missing.empty() ? "" : ", ") + name;
+		}
+		if (IsReservedEnvName(name)) {
+			reserved += (reserved.empty() ? "" : ", ") + name;
+		}
+	}
+	if (!reserved.empty()) {
+		error = "--env-passthrough: reserved by the test runner, cannot be passed through: " + reserved;
+		return false;
+	}
+	if (!missing.empty()) {
+		error = "--env-passthrough: missing from the environment: " + missing;
+		return false;
+	}
+	return true;
+}
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
 // --temp-dir-* family
 //
 
-static string ResolveRunId(); // resolved RUN_ID value (always set; generated even when off); defined below
+static string ResolveRunId(); // always set, generated when --run-id is absent; defined below
 
-void SetTempDirBase(const string &base) {
-	temp_dir_base = base;
+void SetLocalTempDirRoot(const string &root) {
+	if (root.empty()) {
+		throw std::runtime_error("--local-temp-dir-root requires a non-empty value");
+	}
+	if (Path::FromString(root).IsRemote()) {
+		throw std::runtime_error("--local-temp-dir-root must be a local path, got: " + root);
+	}
+	local_temp_dir_root_override = root;
 }
 
-string GetTempDirBase() {
-	return temp_dir_base;
+string GetLocalTempDirRoot() {
+	return local_temp_dir_root_override;
+}
+
+void SetTempDirRoot(const string &root) {
+	// Check string: Path::FromString("") -> "." (path identity). Reject "" as invalid, but
+	// don't confuse the acceptable ".".
+	if (root.empty()) {
+		throw std::runtime_error("--temp-dir-root requires a non-empty value");
+	}
+	primary_root = Path::FromString(root);
+}
+
+string GetTempDirRoot() {
+	return primary_root.ToString();
 }
 
 string GetTempDirRunId() {
@@ -134,9 +227,8 @@ string GetTempDirRunId() {
 }
 
 void SetRunId(const string &id) {
-	// The run identity → RUN_ID env (and the path segment when --temp-dir-run-id on). "auto"
-	// (or absent) generates one on first resolve; any other value is a caller-supplied fixed id
-	// (pytest passes one shared id so a run's many unittest batches co-locate).
+	// Any value but "auto" is a caller-fixed id -- pytest passes one so a run's many unittest
+	// batches co-locate under a single RUN_ID.
 	temp_dir_run_id = (id == "auto") ? "" : id;
 }
 
@@ -156,19 +248,6 @@ bool SetTempDirTestId(const string &mode) {
 		temp_dir_test_id = true;
 	} else if (mode == "off") {
 		temp_dir_test_id = false;
-	} else {
-		return false;
-	}
-	return true;
-}
-
-bool SetTempDirCreate(const string &mode) {
-	if (mode == "never") {
-		temp_dir_create = TempDirCreate::NEVER;
-	} else if (mode == "on-absent") {
-		temp_dir_create = TempDirCreate::ON_ABSENT;
-	} else if (mode == "always") {
-		temp_dir_create = TempDirCreate::ALWAYS;
 	} else {
 		return false;
 	}
@@ -213,28 +292,9 @@ bool DatabaseDestroyFires(bool success) {
 	}
 }
 
-// Join a leaf onto a parent. Remote parents are appended as pure strings (no VFS/mkdir);
-// local parents use the platform path join. An empty leaf yields the parent unchanged.
-static string JoinTempLevel(const string &parent, const string &leaf) {
-	if (leaf.empty()) {
-		return parent;
-	}
-	if (FileSystem::IsRemoteFile(parent)) {
-		if (parent.empty()) {
-			return leaf;
-		}
-		return (parent.back() == '/') ? parent + leaf : parent + "/" + leaf;
-	}
-	duckdb::unique_ptr<FileSystem> fs = FileSystem::CreateLocal();
-	return fs->JoinPath(parent, leaf);
-}
-
-// RUN_ID auto value: sortable timestamp + a memorable mnemonic, e.g.
-// 2026-07-01T14-30-22Z--crimson-torus-07 (UTC). Mirrors the pytest driver's run-id shape
-// (test/py/driver/mnemonic.py: <ISO-basic>--<word>-<word>-<NN>) but uses DISTINCT word
-// banks — colors + shapes here vs the driver's adjectives + animals — so the run id's
-// vocabulary reveals its source: a color-shape run id was minted by the unittest binary, an
-// adjective-animal one by pytest.
+// RUN_ID auto value: sortable UTC timestamp + mnemonic, e.g. 2026-07-01T14-30-22Z--crimson-torus-07.
+// Same shape as the pytest driver's, but colors+shapes here vs its adjectives+animals -- so an id's
+// vocabulary reveals which side minted it.
 static const char *const TEMP_DIR_COLORS[] = {"crimson", "scarlet", "azure",   "cobalt", "teal",    "olive",
                                               "maroon",  "indigo",  "violet",  "coral",  "ochre",   "umber",
                                               "jade",    "ivory",   "slate",   "sienna", "magenta", "cyan",
@@ -259,50 +319,53 @@ static string GenerateAutoRunId() {
 	return string(ts) + "--" + color + "-" + shape + "-" + digits;
 }
 
-// Resolved RUN_ID value ("" when off). AUTO generates once and caches for the invocation.
+// The caller's --run-id, or a generated one, cached for the invocation. Always resolved, even when
+// RUN_ID is not a path segment (TreeRunIdRoot gates that) -- the env var exists either way.
 static string ResolveRunId() {
-	// The RUN_ID value is always resolved — the caller's --run-id, or a generated one when none
-	// was given — so the RUN_ID env var is populated even when run-id is not a TEMP_DIR path
-	// segment. Path inclusion is gated separately in ResolveRunIdRoot().
 	if (temp_dir_run_id.empty()) {
 		temp_dir_run_id = GenerateAutoRunId();
 	}
 	return temp_dir_run_id;
 }
 
-// $BASE/[RUN_ID] -- the run-id root; stable across the invocation. String-only (no IO).
-static string ResolveRunIdRoot() {
-	// run-id is a TEMP_DIR path segment only when --temp-dir-run-id on; the value still exists
-	// as the RUN_ID env var either way.
+// $ROOT/[RUN_ID] -- stable across the invocation, no IO.
+static Path TreeRunIdRoot(const Path &root) {
 	if (!temp_dir_run_id_in_path) {
-		return temp_dir_base;
+		return root;
 	}
-	return JoinTempLevel(temp_dir_base, ResolveRunId());
+	return root.Join(ResolveRunId());
 }
 
-// The HOME sandbox: a SIBLING of the run-id root ("<run-root>-home"), never *inside* it. HOME must
-// not fall within any {TEST_DIR} a test whitelists via allowed_directories -- else ~/.duckdb
-// (extensions, secrets) becomes an allowed path and permission tests (e.g. INSTALL-is-denied) break.
-// A sibling holds in both regimes: default {TEST_DIR}=$BASE/$RUN_ID/$TEST_ID (sibling under $RUN_ID),
-// managed {TEST_DIR}=$BASE (sibling of $BASE). Materialized by PrepareTempDir, reclaimed by DestroyTempDir.
-static string ResolveHomeDir() {
-	return ResolveRunIdRoot() + "-home";
+// The tree LOCAL_TEMP_DIR and HOME resolve against. A local primary IS the local tree, invariantly -- the
+// two can never be different local dirs, and PrepareTempDir rejects a --local-temp-dir-root that would
+// make them so. Resolved lazily: the local tree must be absolute (it outlives any test chdir) and the cwd
+// is only final once main() has changed into it.
+static const Path &LocalRoot() {
+	if (!primary_root.IsRemote()) {
+		return primary_root;
+	}
+	if (!local_root_resolved) {
+		const string &raw =
+		    local_temp_dir_root_override.empty() ? string(TESTING_DIRECTORY_NAME) : local_temp_dir_root_override;
+		local_root = Path::FromString(TestMakeAbsolute(raw, TestGetCurrentDirectory()));
+		local_root_resolved = true;
+	}
+	return local_root;
 }
 
+// A SIBLING of the run-id root, never inside it: HOME within a {TEST_DIR} that a test whitelists via
+// allowed_directories would make ~/.duckdb an allowed path and break permission tests (INSTALL-is-denied
+// and friends). Resolved against the local tree -- a scheme'd URI cannot back ~/.duckdb.
 string GetTempDirHome() {
-	return ResolveHomeDir();
+	// A sibling suffix, not a child, so this is string concatenation -- Path composes children only.
+	return TreeRunIdRoot(LocalRoot()).ToString() + "-home";
 }
 
-// Test identity: sanitize the FULL test name to a single filesystem- and shell-safe path component.
-// Shared by the TEST_ID env var and the temp-dir leaf (ResolveTestId) so they agree.
+// The FULL test name as one filesystem- and shell-safe path component. Shared by the TEST_ID env var
+// and the temp-dir leaf so they agree. The body suffix is kept (dropping it would collide foo.test with
+// foo.test_slow onto one dir); everything unsafe is mapped, not just '/' and '.', because Catch2 case
+// names are free-form prose and the leaf must survive unquoted in tests that shell out via system().
 string TestNameToId(const string &name) {
-	// Keep the whole name, including any body suffix (.test / .test_slow / .test_coverage): dropping it
-	// would collide siblings that differ only by suffix (foo.test vs foo.test_slow) onto one TEST_ID and
-	// one temp dir. Map every char outside [A-Za-z0-9_-] to '_' -- notably '.' -> '_', so the suffix
-	// survives as a distinct, path-safe segment (foo_test vs foo_test_slow). SQL names are path-like
-	// (only '/' and '.' need mapping); C++ Catch2 case names are free-form ("Test replaying mismatching
-	// WAL files"), so spaces/quotes/parens/etc. must go too -- else the leaf is unusable as an unquoted
-	// shell path in tests that shell out via system() (e.g. `cp $TEST_DIR/a $TEST_DIR/b`).
 	string id;
 	id.reserve(name.size());
 	for (char c : name) {
@@ -330,9 +393,9 @@ static string ResolveTestId() {
 	return TestNameToId(name);
 }
 
-// Full resolved path $BASE/[RUN_ID]/[TEST_ID]. String-only (no IO).
-static string ResolveTempDirPath() {
-	return JoinTempLevel(ResolveRunIdRoot(), ResolveTestId());
+// Full resolved path $ROOT/[RUN_ID]/[TEST_ID] for `tree`. No IO.
+static Path TreeTestPath(const Path &root) {
+	return TreeRunIdRoot(root).Join(ResolveTestId());
 }
 
 static bool DirectoryIsEmpty(FileSystem &fs, const string &path) {
@@ -341,10 +404,9 @@ static bool DirectoryIsEmpty(FileSystem &fs, const string &path) {
 	return empty;
 }
 
-// mkdir-p `path`, recording into `created` (outermost..leaf) which levels did not
-// previously exist so the matching destroy step removes only what it created. The walk
-// stops at the first pre-existing ancestor, so shared/parent levels created by an earlier
-// lifecycle step (or a prior run) are never recorded here.
+// mkdir-p `path`, recording into `created` (outermost..leaf) the levels that did not already exist,
+// so the matching destroy removes only what it made. The walk stops at the first pre-existing
+// ancestor -- levels owned by an earlier lifecycle step or a prior run are never recorded.
 static void RecordAndCreateLevels(FileSystem &fs, const string &path, vector<string> &created) {
 	vector<string> to_create; // innermost first
 	string p = path;
@@ -361,11 +423,13 @@ static void RecordAndCreateLevels(FileSystem &fs, const string &path, vector<str
 	created = to_create;
 }
 
-// Recursive bottom-up reclaim: remove `leaf` (and its contents), then walk up `created`
-// removing each ancestor iff it is empty and this step created it; stop at the first
-// non-empty / not-this-step-created level. Shared by both destroy lifecycle steps.
+// Remove `leaf` recursively iff this step created it, then walk `created` bottom-up removing each
+// ancestor iff it is empty and this step created it. Stops at the first level that is neither.
 static void ReclaimLevels(FileSystem &fs, const string &leaf, const vector<string> &created) {
-	if (fs.DirectoryExists(leaf)) {
+	// The leaf obeys the same rule as its ancestors: reclaim only what THIS step created. RemoveDirectory
+	// is always recursive, so a run that adopted a pre-existing dir -- a reused --run-id, or $ROOT itself
+	// when --temp-dir-run-id is off -- would otherwise delete contents it does not own.
+	if (!created.empty() && created.back() == leaf && fs.DirectoryExists(leaf)) {
 		try {
 			fs.RemoveDirectory(leaf); // recursive
 		} catch (...) {
@@ -402,105 +466,97 @@ static bool DestroyFires(TempDirDestroy disposition, bool success) {
 	}
 }
 
-bool PrepareTempDir(string &error) {
-	if (temp_dir_base.empty()) {
-		error = "the --temp-dir-* family requires a non-empty base";
+// mkdir-p the local tree's $ROOT/[RUN_ID], recording what it created so destroy reclaims only that.
+static void PrepareLocalTree() {
+	duckdb::unique_ptr<FileSystem> fs = FileSystem::CreateLocal();
+	RecordAndCreateLevels(*fs, TreeRunIdRoot(LocalRoot()).ToString(), run_created_levels);
+}
+
+static bool PrepareTempDirInternal(string &error) {
+	// Checked here, not at set time: it depends on two options, which arrive in any order from the CLI,
+	// the environment and a config file.
+	// Naming the same local root twice is redundant, not a conflict; only a divergent one is an error.
+	if (!GetLocalTempDirRoot().empty() && !primary_root.IsRemote() &&
+	    Path::Normalize(GetLocalTempDirRoot()) != primary_root.ToString()) {
+		error = "--local-temp-dir-root conflicts with a local --temp-dir-root, which is already its own "
+		        "LOCAL_TEMP_DIR; it applies only to a remote root. To relocate the whole tree, set "
+		        "--temp-dir-root / DUCKDB_TEST_TEMP_DIR_ROOT instead (temp-dir-root: " +
+		        primary_root.ToString() + ", local-temp-dir-root: " + GetLocalTempDirRoot() + ")";
 		return false;
 	}
-	// Remote clamp: a remote base forces create=NEVER + destroy=NEVER; nothing to
-	// materialize here (object stores create-on-write; the test owns materialization).
-	if (FileSystem::IsRemoteFile(temp_dir_base)) {
-		return true;
-	}
+	PrepareLocalTree();
+	// LAST, and this ordering is load-bearing: HOME is a sibling of the run root, so creating it earlier
+	// would materialize $ROOT behind PrepareLocalTree's back, RecordAndCreateLevels would read it as
+	// pre-existing, and it would never be reclaimed. Unconditional -- some code errors if
+	// home_directory is set but absent.
 	duckdb::unique_ptr<FileSystem> fs = FileSystem::CreateLocal();
-	string root = ResolveRunIdRoot(); // $BASE/[RUN_ID]
-	switch (temp_dir_create) {
-	case TempDirCreate::NEVER:
-		if (!fs->DirectoryExists(root)) {
-			error = "temp dir does not exist and --temp-dir-create=never: " + root;
-			return false;
-		}
-		break;
-	case TempDirCreate::ON_ABSENT:
-		RecordAndCreateLevels(*fs, root, temp_dir_run_created_levels);
-		break;
-	case TempDirCreate::ALWAYS:
-		if (fs->DirectoryExists(root)) {
-			fs->RemoveDirectory(root); // recursive
-		}
-		RecordAndCreateLevels(*fs, root, temp_dir_run_created_levels);
-		break;
-	}
-	// HOME sandbox (sibling of the run root). Always materialized -- HOME must exist regardless of the
-	// temp-dir create disposition (some code errors if home_directory is set but absent).
-	string home = ResolveHomeDir();
-	if (!fs->DirectoryExists(home)) {
-		fs->CreateDirectoriesRecursive(home);
-	}
+	RecordAndCreateLevels(*fs, GetTempDirHome(), home_created_levels);
 	return true;
 }
 
-void DestroyTempDir(bool success) {
-	// Remote clamp: destroy is forced to NEVER for remote bases.
-	if (FileSystem::IsRemoteFile(temp_dir_base)) {
-		return;
+bool PrepareTempDir(string &error) {
+	// Every mkdir/rmdir above is a syscall that can fail for reasons the caller can do nothing about
+	// (permissions, ENOSPC, a race). Funnel them into `error` -- this function's whole contract is to
+	// report startup failures, and an escaping exception would terminate instead.
+	try {
+		return PrepareTempDirInternal(error);
+	} catch (std::exception &ex) {
+		error = ErrorData(ex).Message();
+		return false;
 	}
+}
+
+void DestroyTempDir(bool success) {
 	if (!DestroyFires(temp_dir_destroy, success)) {
 		return;
 	}
 	duckdb::unique_ptr<FileSystem> fs = FileSystem::CreateLocal();
-	// Remove the HOME sandbox sibling first, so the $BASE-empty check in the ancestor walk below can
-	// still reclaim the base when the run owns it.
-	string home = ResolveHomeDir();
-	if (fs->DirectoryExists(home)) {
-		try {
-			fs->RemoveDirectory(home); // recursive
-		} catch (...) {
-		}
-	}
-	// Remove the run-id root recursively (subsumes any leftover per-test dirs), then reclaim
-	// this-run-created ancestors up to (but not past) a pre-existing $BASE.
-	ReclaimLevels(*fs, ResolveRunIdRoot(), temp_dir_run_created_levels);
+	// HOME first: it sits under $ROOT, so leaving it would fail the emptiness check in the ancestor
+	// walk below and strand a root this run owns. Reclaimed on the same created/adopted rule --
+	// co-located batches share one HOME path, and an adopted one may be another batch's live sandbox.
+	ReclaimLevels(*fs, GetTempDirHome(), home_created_levels);
+	// The root subsumes any leftover per-test dirs; ancestors go only up to a pre-existing $ROOT.
+	ReclaimLevels(*fs, TreeRunIdRoot(LocalRoot()).ToString(), run_created_levels);
 }
 
+// Fired at test end with THIS test's pass/fail. Only the $TEST_ID level is in scope -- $RUN_ID/$ROOT
+// were made by PrepareTempDir, so ReclaimLevels stops there.
 void DestroyTestTempDir(bool success) {
-	// TEST_ID destroy: fired at test end using THIS test's pass/fail. Reclaims only the
-	// $TEST_ID level this test's path created -- $RUN_ID/$BASE pre-existed (created by
-	// PrepareTempDir at startup), so ReclaimLevels stops there.
-	if (!FileSystem::IsRemoteFile(temp_dir_base)) {
-		string leaf = temp_dir_active_test_leaf;
-		if (!leaf.empty() && DestroyFires(temp_dir_destroy, success)) {
-			duckdb::unique_ptr<FileSystem> fs = FileSystem::CreateLocal();
-			ReclaimLevels(*fs, leaf, temp_dir_test_created_levels);
+	if (!active_test_leaf.empty() && DestroyFires(temp_dir_destroy, success)) {
+		duckdb::unique_ptr<FileSystem> fs = FileSystem::CreateLocal();
+		ReclaimLevels(*fs, active_test_leaf, test_created_levels);
+	}
+	active_test_leaf.clear();
+	test_created_levels.clear();
+}
+
+// $ROOT/[RUN_ID]/[TEST_ID], materializing the $TEST_ID level on first request -- lazily, because the
+// test name isn't known until a test runs. Records only what this per-test path creates.
+static string MaterializeLocalTestPath() {
+	string path = TreeTestPath(LocalRoot()).ToString();
+	string root = TreeRunIdRoot(LocalRoot()).ToString();
+	if (path != root && path != active_test_leaf) {
+		active_test_leaf = path;
+		test_created_levels.clear();
+		duckdb::unique_ptr<FileSystem> fs = FileSystem::CreateLocal();
+		if (!fs->DirectoryExists(path)) {
+			RecordAndCreateLevels(*fs, path, test_created_levels);
 		}
 	}
-	temp_dir_active_test_leaf.clear();
-	temp_dir_test_created_levels.clear();
+	return path;
 }
 // -----------------------------------------------------------------------------
 
 string TestDirectoryPath() {
-	string path = ResolveTempDirPath(); // $BASE/[RUN_ID]/[TEST_ID]
-	// Remote base: pure string, no mkdir (the test owns materialization).
-	if (FileSystem::IsRemoteFile(temp_dir_base)) {
-		return path;
+	// A remote root is a pure string -- the test owns materialization there. Otherwise it IS the local tree.
+	if (primary_root.IsRemote()) {
+		return TreeTestPath(primary_root).ToString();
 	}
-	// $TEST_ID is resolved and materialized here, lazily, the first time a given test's
-	// dir is requested (the test name isn't known until a test runs; $BASE/$RUN_ID were
-	// already materialized by PrepareTempDir at startup). We record only the levels this
-	// per-test path creates so DestroyTestTempDir reclaims exactly those.
-	string root = ResolveRunIdRoot();
-	if (path != root && path != temp_dir_active_test_leaf) {
-		temp_dir_active_test_leaf = path;
-		temp_dir_test_created_levels.clear();
-		if (temp_dir_create != TempDirCreate::NEVER) {
-			duckdb::unique_ptr<FileSystem> fs = FileSystem::CreateLocal();
-			if (!fs->DirectoryExists(path)) {
-				RecordAndCreateLevels(*fs, path, temp_dir_test_created_levels);
-			}
-		}
-	}
-	return path;
+	return MaterializeLocalTestPath();
+}
+
+string LocalTestDirectoryPath() {
+	return MaterializeLocalTestPath();
 }
 
 void SetDeleteTestPath(bool delete_path) {

--- a/test/include/test_config.hpp
+++ b/test/include/test_config.hpp
@@ -105,11 +105,35 @@ public:
 	static void AppendSelectTagSet(const Value &tag_set);
 	static void AppendSkipTagSet(const Value &tag_set);
 
+	//! --temp-dir-* family + run-id + env-passthrough: on_set_option hooks bridging the generic option
+	//! table to the test_helpers setters of record (see test_helpers.hpp).
+	static void SetTempDirRootOption(const Value &input);
+	static void SetLocalTempDirRootOption(const Value &input);
+	static void SetRunIdOption(const Value &input);
+	static void SetTempDirRunIdOption(const Value &input);
+	static void SetTempDirTestIdOption(const Value &input);
+	static void SetTempDirDestroyOption(const Value &input);
+	static void SetDatabaseDestroyOption(const Value &input);
+	static void AppendEnvPassthrough(const Value &input);
+	static void CheckLocalDataDir(const Value &input);
+
+	//! false + `error` set when LOCAL_DATA_DIR was pinned away from a DATA_DIR that is itself local.
+	//! Call after UpdateEnvironment(), which is where both are resolved.
+	bool ValidateDataDirs(string &error);
+	//! false + `error` set when a config `test_env` entry names a runner-resolved variable
+	//! (IsReservedEnvName). Engine-populated names are reserved against every external input.
+	bool ValidateTestEnv(string &error);
+
 	string GetLocalExtensionRepository() const;
 	void SetLocalExtensionRepository(const string &repo);
 
 private:
 	void LoadTestEnvFromConfig();
+
+	//! Parse options into this instance without running their on_set_option hooks. Set on a
+	//! throwaway config loaded only for its `skip_tests` -- the hooks write process-global
+	//! lifecycle state that belongs to the selected invocation, not to an inherited file.
+	bool ignore_option_side_effects = false;
 
 	//! Give preference to settings from loaded configs
 	bool test_env_from_config_loaded = false;

--- a/test/include/test_helpers.hpp
+++ b/test/include/test_helpers.hpp
@@ -46,6 +46,9 @@ void DeleteDatabase(string path);
 void TestDeleteDirectory(string path);
 void TestCreateDirectory(string path);
 string TestJoinPath(string path1, string path2);
+//! `path` made absolute against `anchor`. Already-absolute inputs are returned unchanged, including
+//! a scheme'd URI (az://...) -- absolute, but not local.
+string TestMakeAbsolute(const string &path, const string &anchor);
 void TestDeleteFile(string path);
 void TestChangeDirectory(string path);
 
@@ -56,9 +59,9 @@ string TestGetCurrentDirectory();
 string TestDirectoryPath();
 string TestCreatePath(string suffix);
 
-//! The HOME sandbox dir ("<run-root>-home"): a sibling of the run root, never inside any {TEST_DIR}.
-//! main points HOME/USERPROFILE here once per invocation (isolates ~/.duckdb without landing inside a
-//! test-whitelisted dir). Materialized by PrepareTempDir, reclaimed by DestroyTempDir.
+//! The HOME sandbox ("<run-root>-home"), a sibling of the run root and never inside any {TEST_DIR}.
+//! main points HOME/USERPROFILE here once per invocation. Always local -- a scheme'd URI cannot back
+//! ~/.duckdb, so a remote root resolves against the local tree.
 string GetTempDirHome();
 
 void SetEmitTestEvents(bool emit);
@@ -68,21 +71,15 @@ unique_ptr<DBConfig> GetTestConfig();
 bool TestIsInternalError(unordered_set<string> &internal_error_messages, const string &error);
 
 // -----------------------------------------------------------------------------
-// --temp-dir-* family: TEMP_DIR = $BASE / [$RUN_ID] / [$TEST_ID]
+// --temp-dir-* family: TEMP_DIR = $ROOT / [$RUN_ID] / [$TEST_ID]
 //
-// Two independent, toggleable nesting levels plus create/destroy dispositions
-// inherited down every level. See test/py/DISPOSITIONS.md.
+// Two independent, toggleable nesting levels, plus a destroy disposition
+// inherited down every level.
 //
-//   $BASE    -- root; default "duckdb_unittest_tempdir" or --temp-dir-base <p>
+//   $ROOT    -- root; default "duckdb_unittest_tempdir" or --temp-dir-root <p>
 //   $RUN_ID  -- per-invocation isolation ($TS--$RANDTAG when auto, or a caller id)
 //   $TEST_ID -- per-test isolation (full test name, sanitized); resolved at test-run time
 //
-//! Create disposition: what to do about existence.
-enum class TempDirCreate : uint8_t {
-	NEVER,     //! must pre-exist (error if absent)
-	ON_ABSENT, //! mkdir-p, never clobber (default)
-	ALWAYS     //! force-fresh (delete + recreate)
-};
 //! Destroy disposition: what to do about the dir at end-of-invocation / end-of-test.
 enum class TempDirDestroy : uint8_t {
 	NEVER,      //! retain
@@ -99,10 +96,16 @@ enum class DatabaseDestroy : uint8_t {
 	ON_SUCCESS //! delete on pass, retain on fail (default)
 };
 
-//! Overrides the default base ("duckdb_unittest_tempdir"). Env TEMP_DIR_BASE.
-void SetTempDirBase(const string &base);
-//! Returns the resolved base ("duckdb_unittest_tempdir" by default).
-string GetTempDirBase();
+//! Overrides the default root ("duckdb_unittest_tempdir"). Env TEMP_DIR_ROOT.
+void SetTempDirRoot(const string &root);
+//! Returns the resolved root ("duckdb_unittest_tempdir" by default).
+string GetTempDirRoot();
+//! Root for the LOCAL_TEMP_DIR tree when the primary root is remote -- pins local output somewhere
+//! chosen instead of the default local root. Must itself be local, and is an error against a
+//! differing local primary, which is already its own LOCAL_TEMP_DIR.
+void SetLocalTempDirRoot(const string &root);
+//! The --local-temp-dir-root override, or "" when unset (the default local root is used).
+string GetLocalTempDirRoot();
 //! Returns the resolved RUN_ID value ("" when RUN_ID is off).
 string GetTempDirRunId();
 //! --temp-dir-run-id {off|auto|<id>}: off => no RUN_ID level; auto => generated
@@ -111,19 +114,22 @@ void SetRunId(const string &id);
 bool SetTempDirRunIdInPath(const string &mode);
 //! --temp-dir-test-id {on|off}. Returns false on an unrecognized value.
 bool SetTempDirTestId(const string &mode);
-//! String setters used by the CLI; return false on an unrecognized value.
-bool SetTempDirCreate(const string &mode);
+//! String setter used by the CLI; returns false on an unrecognized value.
 bool SetTempDirDestroy(const string &mode);
 //! --database-destroy {on|off|on-success}. Returns false on an unrecognized value.
 bool SetDatabaseDestroy(const string &mode);
 //! Whether the post-test DB cleanup should delete, given this test's pass/fail (on-success aware).
 bool DatabaseDestroyFires(bool success);
-//! Materializes $BASE + $RUN_ID once, at startup (main). Fills error + returns false on failure.
+//! Materializes $ROOT + $RUN_ID once, at startup (main). Fills error + returns false on failure.
 bool PrepareTempDir(string &error);
 //! Executes the run-id-level destroy disposition (recursive, bottom-up "destroy only what I created").
 void DestroyTempDir(bool success);
 //! Executes the TEST_ID destroy disposition using THIS test's pass/fail (called at test end).
 void DestroyTestTempDir(bool success);
+//! LOCAL_TEMP_DIR: the guaranteed-local temp dir -- same composition, lifecycle and per-test
+//! $TEST_ID level as TestDirectoryPath(). It IS TestDirectoryPath() when the root is local; a
+//! separate local tree rooted at the default local root when remote.
+string LocalTestDirectoryPath();
 // -----------------------------------------------------------------------------
 
 void SetEmitOnSkip(bool emit);
@@ -131,6 +137,22 @@ bool EmitOnSkipEnabled();
 void SetDebugInitialize(int value);
 void AddRequire(string require);
 bool IsRequired(string require);
+
+// -----------------------------------------------------------------------------
+// --env-passthrough NAME (repeatable; also DUCKDB_TEST_ENV_PASSTHROUGH / config `env_passthrough`,
+// comma-separated): pre-registers an env var for {NAME} substitution in every test, the treatment
+// DATA_DIR/TEMP_DIR get, so no require-env/test-env is needed in the body. Unlike require-env's
+// per-test skip, a named-but-absent var fails the whole invocation at startup.
+//! True for a name the runner resolves for itself (TEMP_DIR, DATA_DIR, LOCAL_*, RUN_ID, the
+//! {KEYWORD} substitutions, ...). These are reserved against EVERY external input -- neither
+//! --env-passthrough nor a config `test_env` entry may set one: the runner computes them, once
+//! per invocation or once per test, and an override would silently shadow the resolved value.
+bool IsReservedEnvName(const string &name);
+void AddEnvPassthrough(string name);
+const duckdb::set<string> &GetEnvPassthroughNames();
+//! false + `error` set if a --env-passthrough name is reserved by the runner, or absent from the env.
+bool ValidateEnvPassthrough(string &error);
+// -----------------------------------------------------------------------------
 
 bool NO_FAIL(QueryResult &result);
 bool NO_FAIL(duckdb::unique_ptr<QueryResult> result);

--- a/test/py/test_temp_dir_contract.py
+++ b/test/py/test_temp_dir_contract.py
@@ -1,0 +1,587 @@
+"""Contract checks for the unittest binary's --temp-dir-* family.
+
+These assert lifecycle behaviour that no .test file can observe: what exists on disk *after* a
+run, and what a run is allowed to create on an error path. Every case here corresponds to a
+regression the full sqllogictest suite passed straight through.
+
+Point at a binary with DUCKDB_UNITTEST_BINARY, or let discovery find
+build/{debug,reldebug,release}/test/unittest under DUCKDB_ROOT (default: cwd) or its parent --
+the parent covers an out-of-tree extension building this repo as a submodule.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+# A trivial always-passing body; the temp dir is materialized either way.
+TRIVIAL = """# name: probe.test
+# group: [compat]
+
+query I
+SELECT 42
+----
+42
+"""
+
+# Dumps the substituted contract vars so the harness can assert on them from outside.
+PROBE = """# name: probe.test
+# group: [compat]
+
+statement ok
+COPY (SELECT '{{TEMP_DIR}}' AS temp_dir, '{{TEMP_DIR_ABSOLUTE}}' AS temp_dir_absolute,
+             '{{TEMP_DIR_ROOT}}' AS temp_dir_root, '{{LOCAL_TEMP_DIR}}' AS local_temp_dir,
+             '{{DATA_DIR}}' AS data_dir, '{{LOCAL_DATA_DIR}}' AS local_data_dir,
+             '{{RUN_ID}}' AS run_id, '{{TEST_ID}}' AS test_id)
+     TO '{out}' (FORMAT csv, HEADER)
+"""
+
+
+def _discover_binary():
+    explicit = os.environ.get("DUCKDB_UNITTEST_BINARY")
+    if explicit:
+        return Path(explicit)
+    root = Path(os.environ.get("DUCKDB_ROOT", os.getcwd()))
+    for base in (root, root.parent):
+        for flavour in ("debug", "reldebug", "release"):
+            candidate = base / "build" / flavour / "test" / "unittest"
+            if candidate.is_file():
+                return candidate
+    return None
+
+
+@pytest.fixture(scope="session")
+def unittest_bin() -> Path:
+    binary = _discover_binary()
+    if binary is None or not binary.is_file():
+        pytest.skip("no unittest binary; set DUCKDB_UNITTEST_BINARY")
+    # Confirm it actually loads here. A binary built against a newer libc/libstdc++ dies before main,
+    # which would otherwise surface as every assertion failing for its own inscrutable reason.
+    probe = subprocess.run([str(binary), "--help"], capture_output=True, text=True, timeout=60)
+    if "not found" in probe.stderr and "version `" in probe.stderr:
+        pytest.fail(f"{binary} cannot run here:\n{probe.stderr.strip().splitlines()[0]}")
+    return binary
+
+
+@pytest.fixture(scope="session")
+def duckdb_root() -> Path:
+    return Path(os.environ.get("DUCKDB_ROOT", os.getcwd()))
+
+
+@pytest.fixture
+def run(unittest_bin: Path, duckdb_root: Path):
+    """Run the binary against a .test body fed on stdin. Returns the CompletedProcess."""
+
+    def _run(body: str = TRIVIAL, *args: str, env: dict | None = None) -> subprocess.CompletedProcess:
+        # Every case here asserts on an exact configuration, and every option also has a
+        # DUCKDB_TEST_<NAME> form -- so an ambient one silently rewrites what is under test. Drop the
+        # whole prefix, then let the case put back only what it means to set.
+        ambient = {k: v for k, v in os.environ.items() if not k.startswith("DUCKDB_TEST_")}
+        return subprocess.run(
+            [str(unittest_bin), "--test-dir", str(duckdb_root), "--stdin", *args],
+            input=body,
+            capture_output=True,
+            text=True,
+            env={**ambient, **(env or {})},
+            timeout=300,
+        )
+
+    return _run
+
+
+@pytest.fixture
+def probe(run, tmp_path: Path):
+    """Run a body that dumps the contract vars; return them as a dict."""
+
+    def _probe(*args: str, env: dict | None = None) -> dict:
+        out = tmp_path / "vars.csv"
+        result = run(PROBE.format(out=out.as_posix()), *args, env=env)
+        assert out.is_file(), f"probe produced no output:\n{result.stdout}\n{result.stderr}"
+        with out.open() as handle:
+            return next(iter(csv.DictReader(handle)))
+
+    return _probe
+
+
+def tree(root: Path) -> set:
+    """Every path under `root`, relative and posix-normalised. Empty when root is absent."""
+    if not root.exists():
+        return set()
+    return {p.relative_to(root).as_posix() for p in root.rglob("*")} | {"."}
+
+
+def homes(root: Path) -> list:
+    return sorted(p for p in root.rglob("*-home") if p.is_dir())
+
+
+def events(result) -> list:
+    """The [TEST_EVENT] JSON objects on stdout/stderr, in order."""
+    found = []
+    for line in (result.stdout + result.stderr).splitlines():
+        match = re.search(r"\{.*\"event\".*\}", line)
+        if match:
+            found.append(json.loads(match.group(0)))
+    return found
+
+
+# -----------------------------------------------------------------------------
+# Reclaim: a run gives back exactly what it created
+#
+
+
+def test_run_created_root_and_ancestors_are_reclaimed(run, tmp_path):
+    """PrepareTempDir must not materialize $ROOT behind RecordAndCreateLevels' back."""
+    root = tmp_path / "a" / "b" / "root"
+    assert run(TRIVIAL, "--temp-dir-root", str(root)).returncode == 0
+    assert not (tmp_path / "a").exists(), f"leaked: {tree(tmp_path)}"
+
+
+def test_preexisting_root_is_kept(run, tmp_path):
+    """Reclaim stops at a root the run did not create."""
+    root = tmp_path / "root"
+    root.mkdir()
+    assert run(TRIVIAL, "--temp-dir-root", str(root)).returncode == 0
+    assert root.is_dir()
+    assert tree(root) == {"."}, f"run root not reclaimed: {tree(root)}"
+
+
+def test_adopted_run_root_is_not_recursively_removed(run, tmp_path):
+    """RemoveDirectory is always recursive, so reclaiming a root the run merely adopted would take a
+    co-located batch's live tree with it. Reclaim is gated on having created the level."""
+    root = tmp_path / "root"
+    (root / "R" / "other_batch").mkdir(parents=True)
+    (root / "R" / "other_batch" / "inflight.db").write_text("x")
+    assert run(TRIVIAL, "--temp-dir-root", str(root), "--run-id", "R").returncode == 0
+    assert (root / "R" / "other_batch" / "inflight.db").is_file(), f"adopted root reaped: {tree(root)}"
+
+
+def test_run_id_off_does_not_delete_the_caller_supplied_root(run, tmp_path):
+    """With run-id off the run root IS $ROOT; a naive reclaim deletes the caller's directory."""
+    root = tmp_path / "root"
+    root.mkdir()
+    (root / "PRECIOUS.txt").write_text("x")
+    assert run(TRIVIAL, "--temp-dir-root", str(root), "--temp-dir-run-id", "off").returncode == 0
+    assert (root / "PRECIOUS.txt").is_file(), f"caller's root reaped: {tree(root)}"
+
+
+def test_empty_root_is_rejected(run):
+    """Path::FromString("") is ".", so an empty root must be caught before it parses -- otherwise
+    it silently roots the whole tree at the cwd."""
+    result = run(TRIVIAL, "--temp-dir-root", "")
+    assert result.returncode != 0, "empty root accepted"
+    assert "non-empty" in result.stdout + result.stderr
+
+
+def test_empty_root_is_rejected_via_env(run):
+    result = run(TRIVIAL, env={"DUCKDB_TEST_TEMP_DIR_ROOT": ""})
+    assert result.returncode != 0, "empty root accepted via env"
+    assert "non-empty" in result.stdout + result.stderr
+
+
+def test_relative_root_stays_relative(probe):
+    """TEMP_DIR is deliberately relative so machine paths stay out of compared output; Path
+    round-tripping must not absolutise or otherwise renormalise it."""
+    variables = probe(
+        "--temp-dir-root", "rel-root", "--run-id", "R", "--temp-dir-run-id", "off", "--temp-dir-test-id", "off"
+    )
+    assert variables["temp_dir"] == "rel-root"
+    assert Path(variables["temp_dir_absolute"]).is_absolute()
+
+
+def test_trailing_separator_in_root_does_not_double_up(probe, tmp_path):
+    plain = probe("--temp-dir-root", str(tmp_path / "b"), "--run-id", "R")
+    slashed = probe("--temp-dir-root", str(tmp_path / "b") + "/", "--run-id", "R")
+    assert plain["temp_dir"] == slashed["temp_dir"]
+    assert "//" not in plain["temp_dir"]
+
+
+def test_dot_segments_in_root_are_collapsed(probe, tmp_path):
+    """Path folds . and .. at parse time, so TEMP_DIR_ROOT reports the resolved form. Desired, and
+    pinned because it is user-visible -- string composition used to pass them through."""
+    real = tmp_path / "bar"
+    real.mkdir()
+    noisy = tmp_path / "foo" / ".." / "bar" / "." / ""
+    variables = probe("--temp-dir-root", str(noisy), "--run-id", "R")
+    assert variables["temp_dir_root"] == str(real)
+    assert ".." not in variables["temp_dir"]
+    assert variables["temp_dir"] == f"{real}/R/_stdin_"
+
+
+def test_unwritable_root_reports_instead_of_terminating(run, tmp_path):
+    """PrepareTempDir's contract is to report startup failures through `error`; an escaping
+    IOException from mkdir/rmdir used to abort the process instead."""
+    denied = tmp_path / "ro"
+    denied.mkdir()
+    denied.chmod(0o500)
+    try:
+        result = run(TRIVIAL, "--temp-dir-root", str(denied / "root"))
+        assert result.returncode != 0
+        output = result.stdout + result.stderr
+        assert "Failed to prepare temp directory" in output
+        assert "terminate called" not in output
+    finally:
+        denied.chmod(0o700)
+
+
+# -----------------------------------------------------------------------------
+# HOME sandbox: follows the temp-dir dispositions, never inside {TEST_DIR}
+#
+
+
+def test_destroy_never_keeps_the_home_sandbox(run, tmp_path):
+    """'keep everything for inspection' must include HOME -- it holds ~/.duckdb."""
+    root = tmp_path / "root"
+    root.mkdir()
+    assert run(TRIVIAL, "--temp-dir-root", str(root), "--temp-dir-destroy", "never").returncode == 0
+    assert homes(root), f"HOME reaped despite destroy=never: {tree(root)}"
+
+
+def test_destroy_on_success_reaps_the_home_sandbox(run, tmp_path):
+    root = tmp_path / "root"
+    root.mkdir()
+    assert run(TRIVIAL, "--temp-dir-root", str(root), "--temp-dir-destroy", "on-success").returncode == 0
+    assert not homes(root), f"HOME retained: {tree(root)}"
+
+
+def test_home_sandbox_is_a_sibling_never_inside_the_test_dir(probe, tmp_path):
+    """HOME inside a {TEST_DIR} would make ~/.duckdb an allowed_directories path."""
+    root = tmp_path / "root"
+    root.mkdir()
+    variables = probe("--temp-dir-root", str(root), "--temp-dir-destroy", "never")
+    (home,) = homes(root)
+    test_dir = Path(variables["temp_dir_absolute"])
+    assert home not in test_dir.parents and home != test_dir
+
+
+def test_home_sandbox_follows_the_pinned_local_tree(run, tmp_path):
+    """HOME is a local-only concern, so it lives with the local tree wherever that is pinned."""
+    sweep = tmp_path / "sweep"
+    assert (
+        run(
+            TRIVIAL,
+            "--temp-dir-root",
+            "az://bucket/tmp",
+            "--local-temp-dir-root",
+            str(sweep),
+            "--temp-dir-destroy",
+            "never",
+        ).returncode
+        == 0
+    )
+    assert homes(sweep), f"HOME did not follow the local tree: {tree(sweep)}"
+
+
+# -----------------------------------------------------------------------------
+# LOCAL_TEMP_DIR: a TEMP_DIR that is never remote
+#
+
+
+def test_local_temp_dir_is_temp_dir_when_the_root_is_local(probe, tmp_path):
+    """The invariant with no exceptions: local primary => one tree, one create/reap path."""
+    root = tmp_path / "root"
+    root.mkdir()
+    variables = probe("--temp-dir-root", str(root))
+    assert variables["local_temp_dir"] == variables["temp_dir"]
+
+
+def test_local_temp_dir_carries_the_test_id_level(probe, tmp_path):
+    """It tracks TEMP_DIR in use and intent, so it is per-test, not per-run."""
+    root = tmp_path / "root"
+    root.mkdir()
+    variables = probe("--temp-dir-root", str(root), "--temp-dir-test-id", "on")
+    assert variables["test_id"]
+    assert variables["local_temp_dir"].endswith(variables["test_id"])
+
+
+def test_remote_root_yields_a_distinct_local_tree(probe):
+    """A remote root must neither crash nor leave LOCAL_TEMP_DIR remote."""
+    variables = probe("--temp-dir-root", "az://bucket/tmp")
+    assert variables["temp_dir"].startswith("az://")
+    assert not variables["local_temp_dir"].startswith("az://")
+    assert variables["local_temp_dir"] != variables["temp_dir"]
+    assert Path(variables["local_temp_dir"]).is_absolute()
+    assert variables["local_temp_dir"].endswith(variables["test_id"])
+
+
+def test_remote_root_does_not_crash(run):
+    """Regression: TEMP_DIR_ABSOLUTE used to JoinPath a scheme'd URI onto the cwd and throw."""
+    result = run(TRIVIAL, "--temp-dir-root", "az://bucket/tmp")
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "cannot join incompatible paths" not in result.stdout + result.stderr
+
+
+def test_remote_root_reclaims_the_local_tree(run, duckdb_root):
+    """The local tree is local, so the remote clamp must not exempt it from reclaim. Scoped to this
+    run's own id: the default local root is shared, so a before/after snapshot of it would measure
+    whatever else is running -- including this file's other tests, and anything under pytest -n."""
+    local_root = duckdb_root / "duckdb_unittest_tempdir"
+    run_id = "local-tree-reclaim"
+    assert run(TRIVIAL, "--temp-dir-root", "az://bucket/tmp", "--run-id", run_id).returncode == 0
+    assert not (local_root / run_id).exists(), "local tree run root leaked"
+    assert not (local_root / f"{run_id}-home").exists(), "local tree HOME sandbox leaked"
+
+
+def test_local_temp_dir_root_redirects_the_local_tree(probe, tmp_path):
+    """Without it the local tree lands in the source tree, which is the reason to want it."""
+    sweep = tmp_path / "sweep"
+    variables = probe("--temp-dir-root", "az://bucket/tmp", "--local-temp-dir-root", str(sweep))
+    assert variables["local_temp_dir"].startswith(str(sweep))
+    assert variables["temp_dir"].startswith("az://")
+    assert "duckdb_unittest_tempdir" not in variables["local_temp_dir"]
+
+
+@pytest.mark.parametrize("primary", ["unset", "local"])
+def test_local_temp_dir_root_is_rejected_against_a_local_primary(run, tmp_path, primary):
+    """LOCAL_TEMP_DIR and TEMP_DIR must never be two different local dirs -- a local primary is its
+    own LOCAL_TEMP_DIR, so pinning the local tree elsewhere fails rather than diverging."""
+    args = ["--local-temp-dir-root", str(tmp_path / "sweep")]
+    if primary == "local":
+        (tmp_path / "root").mkdir()
+        args += ["--temp-dir-root", str(tmp_path / "root")]
+    result = run(TRIVIAL, *args)
+    assert result.returncode != 0
+    assert "conflicts with a local" in result.stdout + result.stderr
+    assert not (tmp_path / "sweep").exists()
+
+
+def test_local_temp_dir_root_matching_the_primary_is_accepted(probe, tmp_path):
+    """Naming the same local root twice is redundant, not a contradiction."""
+    root = tmp_path / "root"
+    root.mkdir()
+    variables = probe("--temp-dir-root", str(root), "--local-temp-dir-root", str(root))
+    assert variables["local_temp_dir"] == variables["temp_dir"]
+    assert variables["temp_dir"].startswith(str(root))
+
+
+def test_local_temp_dir_root_rejects_a_remote_value(run):
+    result = run(TRIVIAL, "--local-temp-dir-root", "az://bucket/x")
+    assert result.returncode != 0
+    assert "must be a local path" in result.stdout + result.stderr
+
+
+# -----------------------------------------------------------------------------
+# LOCAL_DATA_DIR
+#
+
+
+def test_local_data_dir_defaults_to_data_dir(probe):
+    variables = probe()
+    assert variables["local_data_dir"] == variables["data_dir"]
+
+
+def test_local_data_dir_diverging_from_a_local_data_dir_is_rejected(run, tmp_path):
+    """Same rule as --local-temp-dir-root: a local DATA_DIR is already its own LOCAL_DATA_DIR."""
+    result = run(TRIVIAL, "--local-data-dir", str(tmp_path / "elsewhere"))
+    assert result.returncode != 0
+    assert "must equal data-dir" in result.stdout + result.stderr
+
+
+def test_local_data_dir_backs_a_remote_data_dir(probe, tmp_path):
+    local = tmp_path / "local-data"
+    variables = probe("--data-dir", "az://bucket/data", "--local-data-dir", str(local))
+    assert variables["data_dir"].startswith("az://")
+    assert variables["local_data_dir"] == str(local)
+
+
+def test_local_data_dir_rejects_a_remote_value(run):
+    result = run(TRIVIAL, "--local-data-dir", "az://bucket/x")
+    assert result.returncode != 0
+    assert "must be a local path" in result.stdout + result.stderr
+
+
+# -----------------------------------------------------------------------------
+# [TEST_EVENT] stream
+#
+
+
+def test_begin_and_end_report_the_same_temp_dir(run, tmp_path):
+    """`test-env TEMP_DIR <default>` resolves to the config's run-root value and overwrites the
+    runner's per-test one, so reading the live map at end time made the two events disagree."""
+    body = """# name: rewrite.test
+# group: [compat]
+
+test-env TEMP_DIR /unused-default
+
+query I
+SELECT 1
+----
+1
+"""
+    result = run(body, "--temp-dir-root", str(tmp_path / "b"), "--run-id", "R", "--emit-test-events")
+    emitted = events(result)
+    assert [e["event"] for e in emitted] == ["begin", "end"], emitted
+    assert emitted[0]["temp_dir"] == emitted[1]["temp_dir"]
+    assert emitted[0]["temp_dir"].endswith("/R/_stdin_"), emitted[0]["temp_dir"]
+
+
+def test_events_carry_the_driver_supplied_prefix(run, tmp_path):
+    root = tmp_path / "driver-root"
+    result = run(TRIVIAL, "--temp-dir-root", str(root), "--emit-test-events")
+    for event in events(result):
+        assert event["temp_dir"].startswith(str(root))
+
+
+# -----------------------------------------------------------------------------
+# --env-passthrough
+#
+
+
+def test_env_passthrough_substitutes_without_require_env(run):
+    body = """# name: probe.test
+# group: [compat]
+
+query I
+SELECT '{MY_THING}'
+----
+hello
+"""
+    result = run(body, "--env-passthrough", "MY_THING", env={"MY_THING": "hello"})
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_env_passthrough_missing_var_fails_the_whole_invocation(unittest_bin):
+    """Unlike require-env's per-test skip, this is loud and total."""
+    env = {k: v for k, v in os.environ.items() if k != "MY_THING"}
+    result = subprocess.run(
+        [str(unittest_bin), "--env-passthrough", "MY_THING"], capture_output=True, text=True, env=env, timeout=300
+    )
+    assert result.returncode != 0
+    assert "missing from the environment: MY_THING" in result.stdout + result.stderr
+
+
+@pytest.mark.parametrize("reserved", ["TEMP_DIR", "DATA_DIR", "RUN_ID", "LOCAL_TEMP_DIR"])
+def test_env_passthrough_rejects_reserved_names(run, reserved):
+    """Passing one through would silently shadow the value the runner resolved."""
+    result = run(TRIVIAL, "--env-passthrough", reserved, env={reserved: "/hijacked"})
+    assert result.returncode != 0
+    assert "reserved by the test runner" in result.stdout + result.stderr
+
+
+def test_env_passthrough_accumulates_across_forms(run):
+    body = """# name: probe.test
+# group: [compat]
+
+query II
+SELECT '{ONE}', '{TWO}'
+----
+1	2
+"""
+    result = run(body, "--env-passthrough", "ONE", "--env-passthrough", "TWO", env={"ONE": "1", "TWO": "2"})
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+# -----------------------------------------------------------------------------
+# Option surface: CLI, DUCKDB_TEST_<NAME> and --test-config must agree
+#
+
+
+def test_run_id_via_cli_env_and_config_agree(probe, tmp_path):
+    root = tmp_path / "root"
+    root.mkdir()
+    config = tmp_path / "cfg.json"
+    config.write_text(json.dumps({"temp_dir_root": str(root), "run_id": "from-config"}))
+
+    via_cli = probe("--temp-dir-root", str(root), "--run-id", "pinned")
+    via_env = probe(env={"DUCKDB_TEST_TEMP_DIR_ROOT": str(root), "DUCKDB_TEST_RUN_ID": "pinned"})
+    via_config = probe("--test-config", str(config))
+
+    assert via_cli["run_id"] == via_env["run_id"] == "pinned"
+    assert via_config["run_id"] == "from-config"
+    assert via_cli["temp_dir"] == via_env["temp_dir"]
+
+
+def test_cli_beats_env(probe, tmp_path):
+    root = tmp_path / "root"
+    root.mkdir()
+    variables = probe("--run-id", "from-cli", "--temp-dir-root", str(root), env={"DUCKDB_TEST_RUN_ID": "from-env"})
+    assert variables["run_id"] == "from-cli"
+
+
+@pytest.mark.parametrize(
+    "flag,value,expected",
+    [
+        ("--temp-dir-destroy", "bogus", "never, on-success, always"),
+        ("--temp-dir-run-id", "maybe", "on, off"),
+        ("--database-destroy", "bogus", "on, off, on-success"),
+    ],
+)
+def test_invalid_disposition_is_rejected(run, flag, value, expected):
+    result = run(TRIVIAL, flag, value)
+    assert result.returncode != 0
+    assert expected in result.stdout + result.stderr
+
+
+# -----------------------------------------------------------------------------
+# Ownership: a run configures, creates and reclaims only its own
+#
+
+
+def test_inherited_skip_config_does_not_replace_temp_options(probe, tmp_path, duckdb_root):
+    """A config loaded solely to harvest another's `skip_tests` must not execute the option table's
+    process-global side effects, or the inherited root silently replaces the selected one."""
+    inherited = tmp_path / "inherited.json"
+    inherited.write_text(json.dumps({"temp_dir_root": str(tmp_path / "inherited-root")}))
+    outer = tmp_path / "outer.json"
+    # inherit_skip_tests resolves against the binary's cwd (--test-dir), so keep the path relative:
+    # joining an absolute one onto the cwd throws.
+    outer.write_text(
+        json.dumps(
+            {
+                "temp_dir_root": str(tmp_path / "selected-root"),
+                "inherit_skip_tests": os.path.relpath(inherited, duckdb_root),
+            }
+        )
+    )
+    variables = probe("--test-config", str(outer))
+    assert variables["temp_dir_root"] == str(tmp_path / "selected-root")
+
+
+@pytest.mark.parametrize("name", ["TEMP_DIR", "LOCAL_TEMP_DIR", "DATA_DIR", "LOCAL_DATA_DIR", "RUN_ID"])
+def test_config_test_env_cannot_override_a_reserved_name(run, tmp_path, name):
+    """Engine-resolved variables are reserved against every external input. A `test_env` entry naming
+    one must abort at startup rather than silently shadow the value the runner computed."""
+    config = tmp_path / "cfg.json"
+    config.write_text(json.dumps({"test_env": [{"env_name": name, "env_value": "/hijacked"}]}))
+    result = run(TRIVIAL, "--test-config", str(config))
+    assert result.returncode != 0
+    output = result.stdout + result.stderr
+    assert "reserved by the test runner" in output and name in output
+
+
+def test_config_test_env_allows_its_own_names(probe, tmp_path):
+    """The reservation is only over runner-resolved names -- a suite's own variables still work."""
+    config = tmp_path / "cfg.json"
+    config.write_text(json.dumps({"test_env": [{"env_name": "MY_SUITE_THING", "env_value": "ok"}]}))
+    variables = probe("--test-config", str(config))
+    assert variables["temp_dir"]
+
+
+def test_home_sandbox_the_run_did_not_create_is_kept(run, tmp_path):
+    """HOME needs the same created/adopted tracking as the run and test levels -- batches co-located
+    under a fixed --run-id share one HOME path, so a reaping run can take a live one with it."""
+    root = tmp_path / "root"
+    (root / "R").mkdir(parents=True)
+    home = root / "R-home"
+    home.mkdir()
+    (home / "marker").write_text("x")
+    assert run(TRIVIAL, "--temp-dir-root", str(root), "--run-id", "R").returncode == 0
+    assert (home / "marker").is_file(), f"adopted HOME reaped: {tree(root)}"
+
+
+def test_per_test_dir_is_not_recreated_after_cleanup(run, tmp_path):
+    """DestroyTestTempDir runs while the runner is alive, so the destructor's loaded-database
+    ownership check must use a path snapshotted at construction -- resolving it there calls a
+    MATERIALIZING accessor and recreates the leaf just reclaimed. Only observable once an adopted
+    run root is correctly retained."""
+    root = tmp_path / "root"
+    (root / "R").mkdir(parents=True)
+    result = run(TRIVIAL, "--temp-dir-root", str(root), "--run-id", "R", "--initial-db", "{TEST_DIR}/db")
+    assert result.returncode == 0, result.stdout + result.stderr
+    leftovers = sorted(p.name for p in (root / "R").iterdir())
+    assert leftovers == [], f"per-test dir recreated after cleanup: {leftovers}"

--- a/test/sqlite/sqllogic_test_runner.cpp
+++ b/test/sqlite/sqllogic_test_runner.cpp
@@ -39,6 +39,7 @@ SQLLogicTestRunner::SQLLogicTestRunner(string dbpath) : dbpath(std::move(dbpath)
 	config = GetTestConfig();
 	config->SetOptionByName("allow_unredacted_secrets", true);
 	config->options.load_extensions = false;
+	test_dir_prefix = TestDirectoryPath();
 
 	auto &test_config = TestConfiguration::Get();
 	autoloading_mode = test_config.GetExtensionAutoLoadingMode();
@@ -96,7 +97,7 @@ SQLLogicTestRunner::~SQLLogicTestRunner() {
 				continue;
 			}
 			// only delete database files that were created during the tests
-			if (!StringUtil::StartsWith(loaded_path, TestDirectoryPath())) {
+			if (!StringUtil::StartsWith(loaded_path, test_dir_prefix)) {
 				continue;
 			}
 			DeleteDatabase(loaded_path);
@@ -149,6 +150,10 @@ void SQLLogicTestRunner::CountSkipMode() {
 }
 
 void SQLLogicTestRunner::EmitBegin(const string &test_name) {
+	// Snapshotted before the enabled check and before the body runs: this is the dir the harness just
+	// assigned, and it must survive any test-env rewrite so end still reports what begin did.
+	auto entry = environment_variables.find("TEMP_DIR");
+	emit_temp_dir = entry == environment_variables.end() ? "" : entry->second;
 	if (!EmitTestEventsEnabled()) {
 		return;
 	}
@@ -156,6 +161,9 @@ void SQLLogicTestRunner::EmitBegin(const string &test_name) {
 	auto obj = writer.CreateObject();
 	obj.AddString("event", "begin");
 	obj.AddString("name", test_name);
+	// Lets a consumer verify which invocation emitted this rather than inferring it from which
+	// subprocess it launched: under --temp-dir-root the prefix is what the driver passed in.
+	obj.AddString("temp_dir", emit_temp_dir);
 	writer.SetRoot(obj);
 	SQLLogicTestLogger::EmitTestEvent(writer.ToString());
 }
@@ -177,6 +185,7 @@ void SQLLogicTestRunner::EmitEnd(const string &test_name, const string &status, 
 	if (!data.empty()) {
 		obj.AddString("data", data);
 	}
+	obj.AddString("temp_dir", emit_temp_dir);
 	writer.SetRoot(obj);
 	SQLLogicTestLogger::EmitTestEvent(writer.ToString());
 }

--- a/test/sqlite/sqllogic_test_runner.hpp
+++ b/test/sqlite/sqllogic_test_runner.hpp
@@ -143,6 +143,15 @@ private:
 	static void AddSkipReason(const string &reason);
 
 private:
+	//! The TEMP_DIR the harness assigned this test, snapshotted by EmitBegin. Both events report it, so
+	//! a body that rewrites TEMP_DIR via test-env cannot make them name different invocations.
+	string emit_temp_dir;
+
+	//! This test's temp dir, snapshotted at construction for the destructor's loaded-database
+	//! ownership check. Resolving it there instead would call a MATERIALIZING accessor after
+	//! DestroyTestTempDir has already reclaimed the leaf, recreating the directory just removed.
+	string test_dir_prefix;
+
 	static mutex skip_reason_lock;
 	static map<string, idx_t> skip_reason_counts;
 };

--- a/test/sqlite/test_sqllogictest.cpp
+++ b/test/sqlite/test_sqllogictest.cpp
@@ -46,17 +46,13 @@ static void register_sqllogic_test_case(void (*test_fun)(), const string &path, 
 template <bool AUTO_SWITCH_TEST_DIR>
 static void RunSQLLogicTest(const string &name, optional_ptr<std::istream> input) {
 	const auto test_dir_path = TestDirectoryPath(); // can vary between tests, and does IO
+	// Tracks TEMP_DIR test-for-test, on the same materialization schedule.
+	const auto local_test_dir_path = LocalTestDirectoryPath();
 	// Absolute (main-cwd-anchored) form of the per-test temp dir we just materialized. Captured HERE,
 	// before the AUTO_SWITCH_TEST_DIR block below may chdir into an extension source dir: it names the
 	// physical dir regardless of the cwd in effect when {TEST_DIR}/TEMP_DIR are later substituted.
 	// (After the extension chdir the relative test_dir_path would resolve to a non-existent sibling.)
-	string test_dir_absolute = test_dir_path;
-	{
-		auto local_fs = FileSystem::CreateLocal();
-		if (!FileSystem::IsRemoteFile(test_dir_absolute) && !local_fs->IsPathAbsolute(test_dir_absolute)) {
-			test_dir_absolute = local_fs->JoinPath(TestGetCurrentDirectory(), test_dir_absolute);
-		}
-	}
+	string test_dir_absolute = TestMakeAbsolute(test_dir_path, TestGetCurrentDirectory());
 	// HOME is NOT touched per-test: main sets it once to the run-wide sandbox (GetTempDirHome(), a
 	// sibling of the run root). Pointing HOME at {TEST_DIR} here would put ~/.duckdb inside a dir tests
 	// whitelist via allowed_directories, breaking permission tests (e.g. INSTALL-is-denied).
@@ -110,7 +106,8 @@ static void RunSQLLogicTest(const string &name, optional_ptr<std::istream> input
 	for (auto &kv : test_config.GetTestEnvMap()) {
 		runner.environment_variables[kv.first] = kv.second;
 	}
-	// Per runner vars
+	// Per runner vars. Every name set here is reserved against --env-passthrough
+	// (IsReservedEnvName, test_helpers.cpp).
 	runner.environment_variables["WORKING_DIR"] = TestGetCurrentDirectory();
 	runner.environment_variables["TEST_NAME"] = name;
 	runner.environment_variables["TEST_NAME__NO_SLASH"] = StringUtil::Replace(name, "/", "_");
@@ -118,6 +115,9 @@ static void RunSQLLogicTest(const string &name, optional_ptr<std::istream> input
 	// TEMP_DIR -> assigned per-test to $BASE[/$RUN_ID][/$TEST_ID] -- RUN_ID and TEST_ID when enabled
 	// (absolute in the extension case; see temp_dir_for_test above).
 	runner.environment_variables["TEMP_DIR"] = temp_dir_for_test;
+	// A separate local tree is already absolute, so only the base-is-local case needs chdir pinning.
+	runner.environment_variables["LOCAL_TEMP_DIR"] =
+	    (local_test_dir_path == test_dir_path) ? temp_dir_for_test : local_test_dir_path;
 	// TEMP_DIR_ABSOLUTE is always the main-cwd-anchored absolute path captured before any extension
 	// chdir -- computing it from the post-chdir cwd here would point at the wrong (extension) tree.
 	runner.environment_variables["TEMP_DIR_ABSOLUTE"] = test_dir_absolute;

--- a/test/unittest.cpp
+++ b/test/unittest.cpp
@@ -15,10 +15,19 @@ int main(int argc_in, char *argv[]) {
 	string test_directory = DUCKDB_ROOT_DIRECTORY;
 
 	auto &test_config = TestConfiguration::Get();
-	test_config.Initialize();
+	try {
+		// Applies every DUCKDB_TEST_<NAME> fallback, so a bad env value surfaces here.
+		test_config.Initialize();
+	} catch (std::exception &ex) {
+		fprintf(stderr, "%s\n", ex.what());
+		return 1;
+	}
 	bool keep_home = false;
 	bool use_stdin = false;
 
+	// The --temp-dir-* family, --run-id and --env-passthrough live in TestConfiguration's option table,
+	// so ParseArgument handles them below and Initialize() already applied their env fallbacks. What
+	// remains here is what that table cannot express.
 	idx_t argc = NumericCast<idx_t>(argc_in);
 	int new_argc = 0;
 	auto new_argv = duckdb::unique_ptr<char *[]>(new char *[argc]);
@@ -26,35 +35,6 @@ int main(int argc_in, char *argv[]) {
 		string argument(argv[i]);
 		if (argument == "--test-dir") {
 			test_directory = string(argv[++i]);
-		} else if (argument == "--temp-dir-base") {
-			SetTempDirBase(string(argv[++i]));
-		} else if (argument == "--run-id") {
-			SetRunId(string(argv[++i]));
-		} else if (argument == "--temp-dir-run-id") {
-			if (!SetTempDirRunIdInPath(string(argv[++i]))) {
-				fprintf(stderr, "--temp-dir-run-id expects one of: on, off\n");
-				return 1;
-			}
-		} else if (argument == "--temp-dir-test-id") {
-			if (!SetTempDirTestId(string(argv[++i]))) {
-				fprintf(stderr, "--temp-dir-test-id expects one of: on, off\n");
-				return 1;
-			}
-		} else if (argument == "--temp-dir-create") {
-			if (!SetTempDirCreate(string(argv[++i]))) {
-				fprintf(stderr, "--temp-dir-create expects one of: never, on-absent, always\n");
-				return 1;
-			}
-		} else if (argument == "--temp-dir-destroy") {
-			if (!SetTempDirDestroy(string(argv[++i]))) {
-				fprintf(stderr, "--temp-dir-destroy expects one of: never, on-success, always\n");
-				return 1;
-			}
-		} else if (argument == "--database-destroy") {
-			if (!SetDatabaseDestroy(string(argv[++i]))) {
-				fprintf(stderr, "--database-destroy expects one of: on, off, on-success\n");
-				return 1;
-			}
 		} else if (argument == "--require") {
 			AddRequire(string(argv[++i]));
 		} else if (argument == "--emit-on-skip") {
@@ -77,10 +57,19 @@ int main(int argc_in, char *argv[]) {
 			}
 		}
 	}
+
+	// Before any temp-dir prep or test runs: a named-but-absent var kills the whole invocation, unlike
+	// require-env's per-test skip.
+	string env_error;
+	if (!ValidateEnvPassthrough(env_error) || !test_config.ValidateTestEnv(env_error)) {
+		fprintf(stderr, "%s\n", env_error.c_str());
+		return 1;
+	}
+
 	test_config.ChangeWorkingDirectory(test_directory);
 
-	// Resolve + provision $BASE/[RUN_ID] per the create disposition (the TEST_ID level is
-	// materialized later, on the per-test path, once a test name is known).
+	// Resolve + provision $BASE/[RUN_ID] (the TEST_ID level is materialized later, on the
+	// per-test path, once a test name is known).
 	string prep_error;
 	if (!PrepareTempDir(prep_error)) {
 		fprintf(stderr, "Failed to prepare temp directory: %s\n", prep_error.c_str());
@@ -90,21 +79,18 @@ int main(int argc_in, char *argv[]) {
 	// after PrepareTempDir so TEMP_DIR reflects the materialized run root.
 	test_config.UpdateEnvironment();
 
-	// HOME points at the dedicated sandbox (a sibling of the run root), absolute and set ONCE for the
-	// whole invocation -- no per-test override. This isolates ~/.duckdb (extensions, secrets) without
-	// ever landing inside a {TEST_DIR} that a test whitelists via allowed_directories. Absolute because a
-	// relative home is meaningless and would shift under any test chdir.
-	string home_dir = GetTempDirHome();
-	{
-		auto local_fs = FileSystem::CreateLocal();
-		if (!local_fs->IsPathAbsolute(home_dir)) {
-			home_dir = local_fs->JoinPath(TestGetCurrentDirectory(), home_dir);
-		}
+	string data_dir_error;
+	if (!test_config.ValidateDataDirs(data_dir_error)) {
+		fprintf(stderr, "%s\n", data_dir_error.c_str());
+		return 1;
 	}
 
-	// A remote base cannot be a home dir; skip the override there.
-	bool remote_base = FileSystem::IsRemoteFile(GetTempDirBase());
-	if (!keep_home && !remote_base) {
+	// Set ONCE per invocation, never per-test, so ~/.duckdb (extensions, secrets) is isolated without
+	// landing inside a {TEST_DIR} a test whitelists. Absolute because a relative home would shift under
+	// any test chdir.
+	string home_dir = TestMakeAbsolute(GetTempDirHome(), TestGetCurrentDirectory());
+
+	if (!keep_home) {
 #ifdef DUCKDB_WINDOWS
 		if (_putenv_s("USERPROFILE", home_dir.c_str()) != 0) {
 			fprintf(stderr, "Failed to set USERPROFILE environment variable\n");


### PR DESCRIPTION
test harness: remote temp-dir root, LOCAL_* dirs, --env-passthrough

Makes the --temp-dir-* family usable against a remote root (az://, s3://) and folds its knobs
into the standard test-config option table, so each also takes a `DUCKDB_TEST_<NAME>` env var
and a config-file key.

Local variants

New: `LOCAL_TEMP_DIR` is a guaranteed-local temp dir within tests. The underlying machinery
allows HOME to function correctly in local FS even when working with remote temp dirs.2 common cases:
- If `--temp-dir-root` is local -> both local, and TEMP_DIR = LOCAL_TEMP_DIR
- If `--temp-dir-root` is remote -> LOCAL_ initiated in local fs (def. duckdb_unittest_tempdir)
- all roots can be specified; rare to specify `local` variants, but possible
- DATA_DIR has same LOCAL_ alternate (def. data), useful for certain file comparison checks

Lifecycle

- A run reclaims only what it created, at every level including the run root: a root merely
  adopted -- a reused `--run-id`, or `$ROOT` under `--temp-dir-run-id off` -- is retained.
  Removal is recursive, so otherwise a successful run deletes a caller-supplied root outright,
  or a co-located batch's live tree.
- Co-location is therefore safe only when the driver creates the shared run root itself; a
  batch that created it still reaps it.
- Dropped `--temp-dir-create`. Nothing consumed it, and `never` never cohered: it could not
  create the [TEST_ID] leaf, could not be satisfied under a generated run-id, and still deleted
  the root it refused to create. Creation is unconditional mkdir -p; the created-levels
  bookkeeping is the property that actually mattered.
- A remote root is passthrough only -- unittest holds no credentials, so it never creates or
  reaps one.

`--env-passthrough NAME` pre-registers a caller's env var for `{NAME}` substitution in every
test, the treatment `TEMP_DIR`/`DATA_DIR` already get. A named-but-absent var fails the whole
invocation at startup, unlike `require-env`'s per-test skip. Names the runner resolves for
itself are reserved, including the `{KEYWORD}` substitutions: env substitution runs first, so
an unreserved `{TEST_DIR}` would be silently shadowed run-wide.

Test events `begin` and `end` carry the temp dir, so a consumer identifies the emitting
invocation directly instead of inferring it from the subprocess it launched. It is snapshotted
at `begin`, so a body that rewrites `TEMP_DIR` cannot make the two disagree.

Fixes

- `TEMP_DIR_ABSOLUTE` was wrong against a remote root, joining a scheme'd URI onto the cwd.
- HOME derived from `$ROOT` and hit the same join; it resolves against the local tree now,
  rather than crashing or leaking to the ambient `$HOME`.
- `PrepareTempDir` reports a failed mkdir/rmdir through its error out-param instead of letting
  the exception terminate the process.
- Roots are normalized when parsed (`.`/`..` fold, `TEMP_DIR_ROOT` reports the resolved form);
  an empty root is rejected.

Notes

- `TEMP_DIR_ROOT` and the `LOCAL_*` roots can come from the ambient environment, e.g. to
  default to `/tmp/duckdb/` instead of `./duckdb_unittest_tempdir`.
- test/py/test_temp_dir_contract.py covers what no .test file can observe: what survives on
  disk after a run, and what a run may create on an error path. Standalone for now.
