### PR TITLE
Track full source span of parsed nodes, not just offset

### DIFF
--- a/src/common/error_data.cpp
+++ b/src/common/error_data.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/common/error_data.hpp"
 
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/span.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/to_string.hpp"
 #include "duckdb/common/types.hpp"
@@ -141,7 +142,22 @@ void ErrorData::AddErrorLocation(const string &query) {
 	if (!query.empty()) {
 		auto entry = extra_info.find("position");
 		if (entry != extra_info.end()) {
-			raw_message = QueryErrorContext::Format(query, raw_message, std::stoull(entry->second));
+			// the span (if present) carries the length so we can underline the full source range
+			idx_t error_length = 0;
+			auto span_entry = extra_info.find("span");
+			if (span_entry != extra_info.end()) {
+				auto comma = span_entry->second.find(',');
+				if (comma != string::npos) {
+					// value is formatted as "[start,length]"
+					auto length_str = span_entry->second.substr(comma + 1);
+					if (!length_str.empty() && length_str.back() == ']') {
+						length_str.pop_back();
+					}
+					error_length = std::stoull(length_str);
+				}
+				extra_info.erase(span_entry);
+			}
+			raw_message = QueryErrorContext::Format(query, raw_message, std::stoull(entry->second), error_length);
 			extra_info.erase(entry);
 		}
 	}
@@ -155,7 +171,7 @@ void ErrorData::AddErrorLocation(const string &query) {
 	final_message = ConstructFinalMessage();
 }
 
-void ErrorData::AddQueryLocation(optional_idx query_location) {
+void ErrorData::AddQueryLocation(Span query_location) {
 	Exception::SetQueryLocation(query_location, extra_info);
 }
 

--- a/src/common/error_data.cpp
+++ b/src/common/error_data.cpp
@@ -1,7 +1,7 @@
 #include "duckdb/common/error_data.hpp"
 
 #include "duckdb/common/exception.hpp"
-#include "duckdb/common/span.hpp"
+#include "duckdb/common/query_location.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/to_string.hpp"
 #include "duckdb/common/types.hpp"
@@ -142,20 +142,20 @@ void ErrorData::AddErrorLocation(const string &query) {
 	if (!query.empty()) {
 		auto entry = extra_info.find("position");
 		if (entry != extra_info.end()) {
-			// the span (if present) carries the length so we can underline the full source range
+			// the query location (if present) carries the length so we can underline the full source range
 			idx_t error_length = 0;
-			auto span_entry = extra_info.find("span");
-			if (span_entry != extra_info.end()) {
-				auto comma = span_entry->second.find(',');
+			auto location_entry = extra_info.find("location");
+			if (location_entry != extra_info.end()) {
+				auto comma = location_entry->second.find(',');
 				if (comma != string::npos) {
 					// value is formatted as "[start,length]"
-					auto length_str = span_entry->second.substr(comma + 1);
+					auto length_str = location_entry->second.substr(comma + 1);
 					if (!length_str.empty() && length_str.back() == ']') {
 						length_str.pop_back();
 					}
 					error_length = std::stoull(length_str);
 				}
-				extra_info.erase(span_entry);
+				extra_info.erase(location_entry);
 			}
 			raw_message = QueryErrorContext::Format(query, raw_message, std::stoull(entry->second), error_length);
 			extra_info.erase(entry);
@@ -171,7 +171,7 @@ void ErrorData::AddErrorLocation(const string &query) {
 	final_message = ConstructFinalMessage();
 }
 
-void ErrorData::AddQueryLocation(Span query_location) {
+void ErrorData::AddQueryLocation(QueryLocation query_location) {
 	Exception::SetQueryLocation(query_location, extra_info);
 }
 

--- a/src/common/exception.cpp
+++ b/src/common/exception.cpp
@@ -1,5 +1,5 @@
 #include "duckdb/common/exception.hpp"
-#include "duckdb/common/span.hpp"
+#include "duckdb/common/query_location.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/to_string.hpp"
 #include "duckdb/common/types.hpp"
@@ -190,7 +190,7 @@ unordered_map<string, string> Exception::InitializeExtraInfo(const TableRef &ref
 	return InitializeExtraInfo(ref.query_location);
 }
 
-unordered_map<string, string> Exception::InitializeExtraInfo(Span error_location) {
+unordered_map<string, string> Exception::InitializeExtraInfo(QueryLocation error_location) {
 	unordered_map<string, string> result;
 	SetQueryLocation(error_location, result);
 	return result;
@@ -207,19 +207,19 @@ bool Exception::IsExecutionError(ExceptionType type) {
 	}
 }
 
-unordered_map<string, string> Exception::InitializeExtraInfo(const string &subtype, Span error_location) {
+unordered_map<string, string> Exception::InitializeExtraInfo(const string &subtype, QueryLocation error_location) {
 	unordered_map<string, string> result;
 	result["error_subtype"] = subtype;
 	SetQueryLocation(error_location, result);
 	return result;
 }
 
-void Exception::SetQueryLocation(Span error_location, unordered_map<string, string> &extra_info) {
+void Exception::SetQueryLocation(QueryLocation error_location, unordered_map<string, string> &extra_info) {
 	if (error_location.IsValid()) {
 		// "position" is the start offset (kept for backwards compatibility with existing consumers)
 		extra_info["position"] = to_string(error_location.offset);
-		// "span" is the structured [start, length] source range
-		extra_info["span"] = "[" + to_string(error_location.offset) + "," + to_string(error_location.length) + "]";
+		// "location" is the structured [start, length] source range
+		extra_info["location"] = "[" + to_string(error_location.offset) + "," + to_string(error_location.length) + "]";
 	}
 }
 
@@ -240,11 +240,11 @@ TypeMismatchException::TypeMismatchException(const PhysicalType type_1, const Ph
 }
 
 TypeMismatchException::TypeMismatchException(const LogicalType &type_1, const LogicalType &type_2, const string &msg)
-    : TypeMismatchException(Span(), type_1, type_2, msg) {
+    : TypeMismatchException(QueryLocation(), type_1, type_2, msg) {
 }
 
-TypeMismatchException::TypeMismatchException(Span error_location, const LogicalType &type_1, const LogicalType &type_2,
-                                             const string &msg)
+TypeMismatchException::TypeMismatchException(QueryLocation error_location, const LogicalType &type_1,
+                                             const LogicalType &type_2, const string &msg)
     : Exception(Exception::InitializeExtraInfo(error_location), ExceptionType::MISMATCH_TYPE,
                 "Type " + type_1.ToString() + " does not match with " + type_2.ToString() + ". " + msg) {
 }

--- a/src/common/exception.cpp
+++ b/src/common/exception.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/span.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/to_string.hpp"
 #include "duckdb/common/types.hpp"
@@ -189,7 +190,7 @@ unordered_map<string, string> Exception::InitializeExtraInfo(const TableRef &ref
 	return InitializeExtraInfo(ref.query_location);
 }
 
-unordered_map<string, string> Exception::InitializeExtraInfo(optional_idx error_location) {
+unordered_map<string, string> Exception::InitializeExtraInfo(Span error_location) {
 	unordered_map<string, string> result;
 	SetQueryLocation(error_location, result);
 	return result;
@@ -206,16 +207,19 @@ bool Exception::IsExecutionError(ExceptionType type) {
 	}
 }
 
-unordered_map<string, string> Exception::InitializeExtraInfo(const string &subtype, optional_idx error_location) {
+unordered_map<string, string> Exception::InitializeExtraInfo(const string &subtype, Span error_location) {
 	unordered_map<string, string> result;
 	result["error_subtype"] = subtype;
 	SetQueryLocation(error_location, result);
 	return result;
 }
 
-void Exception::SetQueryLocation(optional_idx error_location, unordered_map<string, string> &extra_info) {
+void Exception::SetQueryLocation(Span error_location, unordered_map<string, string> &extra_info) {
 	if (error_location.IsValid()) {
-		extra_info["position"] = to_string(error_location.GetIndex());
+		// "position" is the start offset (kept for backwards compatibility with existing consumers)
+		extra_info["position"] = to_string(error_location.offset);
+		// "span" is the structured [start, length] source range
+		extra_info["span"] = "[" + to_string(error_location.offset) + "," + to_string(error_location.length) + "]";
 	}
 }
 
@@ -236,11 +240,11 @@ TypeMismatchException::TypeMismatchException(const PhysicalType type_1, const Ph
 }
 
 TypeMismatchException::TypeMismatchException(const LogicalType &type_1, const LogicalType &type_2, const string &msg)
-    : TypeMismatchException(optional_idx(), type_1, type_2, msg) {
+    : TypeMismatchException(Span(), type_1, type_2, msg) {
 }
 
-TypeMismatchException::TypeMismatchException(optional_idx error_location, const LogicalType &type_1,
-                                             const LogicalType &type_2, const string &msg)
+TypeMismatchException::TypeMismatchException(Span error_location, const LogicalType &type_1, const LogicalType &type_2,
+                                             const string &msg)
     : Exception(Exception::InitializeExtraInfo(error_location), ExceptionType::MISMATCH_TYPE,
                 "Type " + type_1.ToString() + " does not match with " + type_2.ToString() + ". " + msg) {
 }

--- a/src/common/exception/binder_exception.cpp
+++ b/src/common/exception/binder_exception.cpp
@@ -32,7 +32,7 @@ BinderException BinderException::NoMatchingFunction(const Identifier &catalog_na
                                                     const Identifier &name, const vector<LogicalType> &arguments,
                                                     const vector<pair<Identifier, LogicalType>> &named_arguments,
                                                     const vector<string> &candidates) {
-	auto extra_info = Exception::InitializeExtraInfo("NO_MATCHING_FUNCTION", Span());
+	auto extra_info = Exception::InitializeExtraInfo("NO_MATCHING_FUNCTION", QueryLocation());
 	// no matching function was found, throw an error
 	string call_str = Function::CallToString(catalog_name, schema_name, name, arguments, named_arguments);
 	string candidate_str;

--- a/src/common/exception/binder_exception.cpp
+++ b/src/common/exception/binder_exception.cpp
@@ -32,7 +32,7 @@ BinderException BinderException::NoMatchingFunction(const Identifier &catalog_na
                                                     const Identifier &name, const vector<LogicalType> &arguments,
                                                     const vector<pair<Identifier, LogicalType>> &named_arguments,
                                                     const vector<string> &candidates) {
-	auto extra_info = Exception::InitializeExtraInfo("NO_MATCHING_FUNCTION", optional_idx());
+	auto extra_info = Exception::InitializeExtraInfo("NO_MATCHING_FUNCTION", Span());
 	// no matching function was found, throw an error
 	string call_str = Function::CallToString(catalog_name, schema_name, name, arguments, named_arguments);
 	string candidate_str;

--- a/src/common/exception/catalog_exception.cpp
+++ b/src/common/exception/catalog_exception.cpp
@@ -1,5 +1,5 @@
 #include "duckdb/common/exception/catalog_exception.hpp"
-#include "duckdb/common/span.hpp"
+#include "duckdb/common/query_location.hpp"
 #include "duckdb/common/to_string.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/catalog/entry_lookup_info.hpp"
@@ -63,7 +63,7 @@ CatalogException CatalogException::MissingEntry(const string &type, const Identi
 
 CatalogException CatalogException::EntryAlreadyExists(CatalogType type, const Identifier &name,
                                                       QueryErrorContext context) {
-	auto extra_info = Exception::InitializeExtraInfo("ENTRY_ALREADY_EXISTS", Span());
+	auto extra_info = Exception::InitializeExtraInfo("ENTRY_ALREADY_EXISTS", QueryLocation());
 	extra_info["name"] = name.GetIdentifierName();
 	extra_info["type"] = CatalogTypeToString(type);
 	return CatalogException(extra_info, StringUtil::Format("%s with name \"%s\" already exists!",

--- a/src/common/exception/catalog_exception.cpp
+++ b/src/common/exception/catalog_exception.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/common/exception/catalog_exception.hpp"
+#include "duckdb/common/span.hpp"
 #include "duckdb/common/to_string.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/catalog/entry_lookup_info.hpp"
@@ -62,7 +63,7 @@ CatalogException CatalogException::MissingEntry(const string &type, const Identi
 
 CatalogException CatalogException::EntryAlreadyExists(CatalogType type, const Identifier &name,
                                                       QueryErrorContext context) {
-	auto extra_info = Exception::InitializeExtraInfo("ENTRY_ALREADY_EXISTS", optional_idx());
+	auto extra_info = Exception::InitializeExtraInfo("ENTRY_ALREADY_EXISTS", Span());
 	extra_info["name"] = name.GetIdentifierName();
 	extra_info["type"] = CatalogTypeToString(type);
 	return CatalogException(extra_info, StringUtil::Format("%s with name \"%s\" already exists!",

--- a/src/common/exception/conversion_exception.cpp
+++ b/src/common/exception/conversion_exception.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/common/exception/conversion_exception.hpp"
+#include "duckdb/common/span.hpp"
 #include "duckdb/common/types.hpp"
 
 namespace duckdb {
@@ -16,7 +17,7 @@ ConversionException::ConversionException(const LogicalType &orig_type, const Log
 ConversionException::ConversionException(const string &msg) : Exception(ExceptionType::CONVERSION, msg) {
 }
 
-ConversionException::ConversionException(optional_idx error_location, const string &msg)
+ConversionException::ConversionException(Span error_location, const string &msg)
     : Exception(Exception::InitializeExtraInfo(error_location), ExceptionType::CONVERSION, msg) {
 }
 

--- a/src/common/exception/conversion_exception.cpp
+++ b/src/common/exception/conversion_exception.cpp
@@ -1,5 +1,5 @@
 #include "duckdb/common/exception/conversion_exception.hpp"
-#include "duckdb/common/span.hpp"
+#include "duckdb/common/query_location.hpp"
 #include "duckdb/common/types.hpp"
 
 namespace duckdb {
@@ -17,7 +17,7 @@ ConversionException::ConversionException(const LogicalType &orig_type, const Log
 ConversionException::ConversionException(const string &msg) : Exception(ExceptionType::CONVERSION, msg) {
 }
 
-ConversionException::ConversionException(Span error_location, const string &msg)
+ConversionException::ConversionException(QueryLocation error_location, const string &msg)
     : Exception(Exception::InitializeExtraInfo(error_location), ExceptionType::CONVERSION, msg) {
 }
 

--- a/src/common/exception/parser_exception.cpp
+++ b/src/common/exception/parser_exception.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/common/exception/parser_exception.hpp"
+#include "duckdb/common/span.hpp"
 #include "duckdb/common/to_string.hpp"
 #include "duckdb/parser/query_error_context.hpp"
 
@@ -11,8 +12,7 @@ ParserException::ParserException(const unordered_map<string, string> &extra_info
     : Exception(extra_info, ExceptionType::PARSER, msg) {
 }
 
-ParserException ParserException::SyntaxError(const string &query, const string &error_message,
-                                             optional_idx error_location) {
+ParserException ParserException::SyntaxError(const string &query, const string &error_message, Span error_location) {
 	return ParserException(Exception::InitializeExtraInfo("SYNTAX_ERROR", error_location), error_message);
 }
 } // namespace duckdb

--- a/src/common/exception/parser_exception.cpp
+++ b/src/common/exception/parser_exception.cpp
@@ -1,5 +1,5 @@
 #include "duckdb/common/exception/parser_exception.hpp"
-#include "duckdb/common/span.hpp"
+#include "duckdb/common/query_location.hpp"
 #include "duckdb/common/to_string.hpp"
 #include "duckdb/parser/query_error_context.hpp"
 
@@ -12,7 +12,8 @@ ParserException::ParserException(const unordered_map<string, string> &extra_info
     : Exception(extra_info, ExceptionType::PARSER, msg) {
 }
 
-ParserException ParserException::SyntaxError(const string &query, const string &error_message, Span error_location) {
+ParserException ParserException::SyntaxError(const string &query, const string &error_message,
+                                             QueryLocation error_location) {
 	return ParserException(Exception::InitializeExtraInfo("SYNTAX_ERROR", error_location), error_message);
 }
 } // namespace duckdb

--- a/src/common/operator/cast_operators.cpp
+++ b/src/common/operator/cast_operators.cpp
@@ -38,7 +38,7 @@ namespace duckdb {
 
 ConversionException TryCast::UnimplementedErrorMessage(PhysicalType source, PhysicalType target,
                                                        optional_ptr<CastParameters> parameters) {
-	Span query_location;
+	QueryLocation query_location;
 	if (parameters) {
 		query_location = parameters->query_location;
 		if (parameters->cast_source && parameters->cast_target) {
@@ -1817,7 +1817,7 @@ template <>
 bool TryCastToGeometry::Operation(string_t input, string_t &result, Vector &result_vector, CastParameters &parameters) {
 	// Pass the query location of the cast source if available.
 	return Geometry::FromString(input, result, StringVector::GetStringHeap(result_vector), parameters.strict,
-	                            parameters.cast_source ? parameters.cast_source->GetQueryLocation() : Span());
+	                            parameters.cast_source ? parameters.cast_source->GetQueryLocation() : QueryLocation());
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/common/operator/cast_operators.cpp
+++ b/src/common/operator/cast_operators.cpp
@@ -38,7 +38,7 @@ namespace duckdb {
 
 ConversionException TryCast::UnimplementedErrorMessage(PhysicalType source, PhysicalType target,
                                                        optional_ptr<CastParameters> parameters) {
-	optional_idx query_location;
+	Span query_location;
 	if (parameters) {
 		query_location = parameters->query_location;
 		if (parameters->cast_source && parameters->cast_target) {
@@ -1817,7 +1817,7 @@ template <>
 bool TryCastToGeometry::Operation(string_t input, string_t &result, Vector &result_vector, CastParameters &parameters) {
 	// Pass the query location of the cast source if available.
 	return Geometry::FromString(input, result, StringVector::GetStringHeap(result_vector), parameters.strict,
-	                            parameters.cast_source ? parameters.cast_source->GetQueryLocation() : optional_idx());
+	                            parameters.cast_source ? parameters.cast_source->GetQueryLocation() : Span());
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/common/types/geometry.cpp
+++ b/src/common/types/geometry.cpp
@@ -315,14 +315,15 @@ public:
 		auto msg = StringUtil::Format("Failed to parse geometry: %s at offset %lu",
 		                              StringUtil::Format(raw_msg, args...), byte_offset);
 		if (query_location.IsValid()) {
-			const auto expr_offset = optional_idx(query_location.GetIndex() + byte_offset);
-			return InvalidInputException(Exception::InitializeExtraInfo(expr_offset), msg);
+			// point at the specific byte within the WKT literal where parsing failed
+			const Span expr_span(query_location.Start() + byte_offset, 0);
+			return InvalidInputException(Exception::InitializeExtraInfo(expr_span), msg);
 		} else {
 			return InvalidInputException(msg);
 		}
 	}
 
-	void SetQueryLocation(optional_idx location) {
+	void SetQueryLocation(Span location) {
 		query_location = location;
 	}
 
@@ -336,7 +337,7 @@ private:
 	const char *beg;
 	const char *pos;
 	const char *end;
-	optional_idx query_location;
+	Span query_location;
 };
 
 void FromStringRecursive(TextReader &reader, BlobWriter &writer, uint32_t depth, bool parent_has_z, bool parent_has_m) {
@@ -1098,7 +1099,7 @@ void Geometry::ToBinary(const Vector &source, Vector &result) {
 }
 
 bool Geometry::FromString(const string_t &wkt_text, string_t &result, StringHeap &heap, bool strict,
-                          optional_idx query_location) {
+                          Span query_location) {
 	TextReader reader(wkt_text.GetData(), static_cast<uint32_t>(wkt_text.GetSize()));
 	reader.SetQueryLocation(query_location);
 	BlobWriter writer;

--- a/src/common/types/geometry.cpp
+++ b/src/common/types/geometry.cpp
@@ -316,14 +316,14 @@ public:
 		                              StringUtil::Format(raw_msg, args...), byte_offset);
 		if (query_location.IsValid()) {
 			// point at the specific byte within the WKT literal where parsing failed
-			const Span expr_span(query_location.Start() + byte_offset, 0);
-			return InvalidInputException(Exception::InitializeExtraInfo(expr_span), msg);
+			const QueryLocation expr_location(query_location.Start() + byte_offset, 0);
+			return InvalidInputException(Exception::InitializeExtraInfo(expr_location), msg);
 		} else {
 			return InvalidInputException(msg);
 		}
 	}
 
-	void SetQueryLocation(Span location) {
+	void SetQueryLocation(QueryLocation location) {
 		query_location = location;
 	}
 
@@ -337,7 +337,7 @@ private:
 	const char *beg;
 	const char *pos;
 	const char *end;
-	Span query_location;
+	QueryLocation query_location;
 };
 
 void FromStringRecursive(TextReader &reader, BlobWriter &writer, uint32_t depth, bool parent_has_z, bool parent_has_m) {
@@ -1099,7 +1099,7 @@ void Geometry::ToBinary(const Vector &source, Vector &result) {
 }
 
 bool Geometry::FromString(const string_t &wkt_text, string_t &result, StringHeap &heap, bool strict,
-                          Span query_location) {
+                          QueryLocation query_location) {
 	TextReader reader(wkt_text.GetData(), static_cast<uint32_t>(wkt_text.GetSize()));
 	reader.SetQueryLocation(query_location);
 	BlobWriter writer;

--- a/src/common/util/util_parsed_expression.cpp
+++ b/src/common/util/util_parsed_expression.cpp
@@ -312,6 +312,7 @@ void ParsedExpression::CopyBase(const ParsedExpression &other) {
 	type = other.type;
 	alias = other.alias;
 	query_location = other.query_location;
+	query_location.length = other.query_location.length;
 }
 
 bool BetweenExpression::Equals(const ParsedExpression &other) const {

--- a/src/function/cast/default_casts.cpp
+++ b/src/function/cast/default_casts.cpp
@@ -42,7 +42,7 @@ void HandleCastError::AssignError(const string &error_message, CastParameters &p
 }
 
 void HandleCastError::AssignError(const string &error_message, string *error_message_ptr,
-                                  optional_ptr<const Expression> cast_source, optional_idx error_location) {
+                                  optional_ptr<const Expression> cast_source, Span error_location) {
 	string column;
 	if (cast_source && cast_source->HasAlias()) {
 		column = " when casting from source column " + cast_source->GetAlias();

--- a/src/function/cast/default_casts.cpp
+++ b/src/function/cast/default_casts.cpp
@@ -42,7 +42,7 @@ void HandleCastError::AssignError(const string &error_message, CastParameters &p
 }
 
 void HandleCastError::AssignError(const string &error_message, string *error_message_ptr,
-                                  optional_ptr<const Expression> cast_source, Span error_location) {
+                                  optional_ptr<const Expression> cast_source, QueryLocation error_location) {
 	string column;
 	if (cast_source && cast_source->HasAlias()) {
 		column = " when casting from source column " + cast_source->GetAlias();

--- a/src/include/duckdb/common/error_data.hpp
+++ b/src/include/duckdb/common/error_data.hpp
@@ -53,7 +53,7 @@ public:
 	DUCKDB_API void AddErrorLocation(const string &query);
 	DUCKDB_API void ConvertErrorToJSON();
 
-	DUCKDB_API void AddQueryLocation(optional_idx query_location);
+	DUCKDB_API void AddQueryLocation(Span query_location);
 	DUCKDB_API void AddQueryLocation(QueryErrorContext error_context);
 	DUCKDB_API void AddQueryLocation(const ParsedExpression &ref);
 	DUCKDB_API void AddQueryLocation(const TableRef &ref);

--- a/src/include/duckdb/common/error_data.hpp
+++ b/src/include/duckdb/common/error_data.hpp
@@ -53,7 +53,7 @@ public:
 	DUCKDB_API void AddErrorLocation(const string &query);
 	DUCKDB_API void ConvertErrorToJSON();
 
-	DUCKDB_API void AddQueryLocation(Span query_location);
+	DUCKDB_API void AddQueryLocation(QueryLocation query_location);
 	DUCKDB_API void AddQueryLocation(QueryErrorContext error_context);
 	DUCKDB_API void AddQueryLocation(const ParsedExpression &ref);
 	DUCKDB_API void AddQueryLocation(const TableRef &ref);

--- a/src/include/duckdb/common/exception.hpp
+++ b/src/include/duckdb/common/exception.hpp
@@ -25,7 +25,7 @@ class QueryErrorContext;
 class TableRef;
 struct hugeint_t;
 class optional_idx; // NOLINT: matching std style
-struct Span;
+struct QueryLocation;
 
 inline void AssertRestrictFunction(const void *left_start, const void *left_end, const void *right_start,
                                    const void *right_end, const char *fname, int linenr) {
@@ -117,8 +117,9 @@ public:
 	DUCKDB_API static unordered_map<string, string> InitializeExtraInfo(const ParsedExpression &expr);
 	DUCKDB_API static unordered_map<string, string> InitializeExtraInfo(const QueryErrorContext &error_context);
 	DUCKDB_API static unordered_map<string, string> InitializeExtraInfo(const TableRef &ref);
-	DUCKDB_API static unordered_map<string, string> InitializeExtraInfo(Span error_location);
-	DUCKDB_API static unordered_map<string, string> InitializeExtraInfo(const string &subtype, Span error_location);
+	DUCKDB_API static unordered_map<string, string> InitializeExtraInfo(QueryLocation error_location);
+	DUCKDB_API static unordered_map<string, string> InitializeExtraInfo(const string &subtype,
+	                                                                    QueryLocation error_location);
 
 	//! Whether this exception type can occur during execution of a query
 	DUCKDB_API static bool IsExecutionError(ExceptionType type);
@@ -146,7 +147,7 @@ public:
 		return (message + "\n" + GetStackTrace());
 	}
 
-	DUCKDB_API static void SetQueryLocation(Span error_location, unordered_map<string, string> &extra_info);
+	DUCKDB_API static void SetQueryLocation(QueryLocation error_location, unordered_map<string, string> &extra_info);
 };
 
 //===--------------------------------------------------------------------===//
@@ -395,7 +396,7 @@ class TypeMismatchException : public Exception {
 public:
 	DUCKDB_API TypeMismatchException(const PhysicalType type_1, const PhysicalType type_2, const string &msg);
 	DUCKDB_API TypeMismatchException(const LogicalType &type_1, const LogicalType &type_2, const string &msg);
-	DUCKDB_API TypeMismatchException(Span error_location, const LogicalType &type_1, const LogicalType &type_2,
+	DUCKDB_API TypeMismatchException(QueryLocation error_location, const LogicalType &type_1, const LogicalType &type_2,
 	                                 const string &msg);
 	DUCKDB_API explicit TypeMismatchException(const string &msg);
 };

--- a/src/include/duckdb/common/exception.hpp
+++ b/src/include/duckdb/common/exception.hpp
@@ -25,6 +25,7 @@ class QueryErrorContext;
 class TableRef;
 struct hugeint_t;
 class optional_idx; // NOLINT: matching std style
+struct Span;
 
 inline void AssertRestrictFunction(const void *left_start, const void *left_end, const void *right_start,
                                    const void *right_end, const char *fname, int linenr) {
@@ -116,9 +117,8 @@ public:
 	DUCKDB_API static unordered_map<string, string> InitializeExtraInfo(const ParsedExpression &expr);
 	DUCKDB_API static unordered_map<string, string> InitializeExtraInfo(const QueryErrorContext &error_context);
 	DUCKDB_API static unordered_map<string, string> InitializeExtraInfo(const TableRef &ref);
-	DUCKDB_API static unordered_map<string, string> InitializeExtraInfo(optional_idx error_location);
-	DUCKDB_API static unordered_map<string, string> InitializeExtraInfo(const string &subtype,
-	                                                                    optional_idx error_location);
+	DUCKDB_API static unordered_map<string, string> InitializeExtraInfo(Span error_location);
+	DUCKDB_API static unordered_map<string, string> InitializeExtraInfo(const string &subtype, Span error_location);
 
 	//! Whether this exception type can occur during execution of a query
 	DUCKDB_API static bool IsExecutionError(ExceptionType type);
@@ -146,7 +146,7 @@ public:
 		return (message + "\n" + GetStackTrace());
 	}
 
-	DUCKDB_API static void SetQueryLocation(optional_idx error_location, unordered_map<string, string> &extra_info);
+	DUCKDB_API static void SetQueryLocation(Span error_location, unordered_map<string, string> &extra_info);
 };
 
 //===--------------------------------------------------------------------===//
@@ -395,7 +395,7 @@ class TypeMismatchException : public Exception {
 public:
 	DUCKDB_API TypeMismatchException(const PhysicalType type_1, const PhysicalType type_2, const string &msg);
 	DUCKDB_API TypeMismatchException(const LogicalType &type_1, const LogicalType &type_2, const string &msg);
-	DUCKDB_API TypeMismatchException(optional_idx error_location, const LogicalType &type_1, const LogicalType &type_2,
+	DUCKDB_API TypeMismatchException(Span error_location, const LogicalType &type_1, const LogicalType &type_2,
 	                                 const string &msg);
 	DUCKDB_API explicit TypeMismatchException(const string &msg);
 };

--- a/src/include/duckdb/common/exception/binder_exception.hpp
+++ b/src/include/duckdb/common/exception/binder_exception.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/span.hpp"
 #include "duckdb/common/vector.hpp"
 #include "duckdb/common/pair.hpp"
 #include "duckdb/parser/query_error_context.hpp"
@@ -47,7 +48,7 @@ public:
 	}
 
 	template <typename... ARGS>
-	explicit BinderException(optional_idx error_location, const string &msg, ARGS &&...params)
+	explicit BinderException(Span error_location, const string &msg, ARGS &&...params)
 	    : BinderException(Exception::InitializeExtraInfo(error_location),
 	                      ConstructMessage(msg, std::forward<ARGS>(params)...)) {
 	}

--- a/src/include/duckdb/common/exception/binder_exception.hpp
+++ b/src/include/duckdb/common/exception/binder_exception.hpp
@@ -9,7 +9,7 @@
 #pragma once
 
 #include "duckdb/common/exception.hpp"
-#include "duckdb/common/span.hpp"
+#include "duckdb/common/query_location.hpp"
 #include "duckdb/common/vector.hpp"
 #include "duckdb/common/pair.hpp"
 #include "duckdb/parser/query_error_context.hpp"
@@ -48,7 +48,7 @@ public:
 	}
 
 	template <typename... ARGS>
-	explicit BinderException(Span error_location, const string &msg, ARGS &&...params)
+	explicit BinderException(QueryLocation error_location, const string &msg, ARGS &&...params)
 	    : BinderException(Exception::InitializeExtraInfo(error_location),
 	                      ConstructMessage(msg, std::forward<ARGS>(params)...)) {
 	}

--- a/src/include/duckdb/common/exception/conversion_exception.hpp
+++ b/src/include/duckdb/common/exception/conversion_exception.hpp
@@ -10,14 +10,14 @@
 
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/optional_idx.hpp"
-#include "duckdb/common/span.hpp"
+#include "duckdb/common/query_location.hpp"
 
 namespace duckdb {
 class ConversionException : public Exception {
 public:
 	DUCKDB_API explicit ConversionException(const string &msg);
 
-	DUCKDB_API explicit ConversionException(Span error_location, const string &msg);
+	DUCKDB_API explicit ConversionException(QueryLocation error_location, const string &msg);
 
 	DUCKDB_API ConversionException(const PhysicalType orig_type, const PhysicalType new_type);
 
@@ -29,7 +29,7 @@ public:
 	}
 
 	template <typename... ARGS>
-	explicit ConversionException(Span error_location, const string &msg, ARGS &&...params)
+	explicit ConversionException(QueryLocation error_location, const string &msg, ARGS &&...params)
 	    : ConversionException(error_location, ConstructMessage(msg, std::forward<ARGS>(params)...)) {
 	}
 };

--- a/src/include/duckdb/common/exception/conversion_exception.hpp
+++ b/src/include/duckdb/common/exception/conversion_exception.hpp
@@ -10,13 +10,14 @@
 
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/optional_idx.hpp"
+#include "duckdb/common/span.hpp"
 
 namespace duckdb {
 class ConversionException : public Exception {
 public:
 	DUCKDB_API explicit ConversionException(const string &msg);
 
-	DUCKDB_API explicit ConversionException(optional_idx error_location, const string &msg);
+	DUCKDB_API explicit ConversionException(Span error_location, const string &msg);
 
 	DUCKDB_API ConversionException(const PhysicalType orig_type, const PhysicalType new_type);
 
@@ -28,7 +29,7 @@ public:
 	}
 
 	template <typename... ARGS>
-	explicit ConversionException(optional_idx error_location, const string &msg, ARGS &&...params)
+	explicit ConversionException(Span error_location, const string &msg, ARGS &&...params)
 	    : ConversionException(error_location, ConstructMessage(msg, std::forward<ARGS>(params)...)) {
 	}
 };

--- a/src/include/duckdb/common/exception/parser_exception.hpp
+++ b/src/include/duckdb/common/exception/parser_exception.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/optional_idx.hpp"
+#include "duckdb/common/span.hpp"
 #include "duckdb/common/unordered_map.hpp"
 
 namespace duckdb {
@@ -25,7 +26,7 @@ public:
 	    : ParserException(ConstructMessage(msg, std::forward<ARGS>(params)...)) {
 	}
 	template <typename... ARGS>
-	explicit ParserException(optional_idx error_location, const string &msg, ARGS &&...params)
+	explicit ParserException(Span error_location, const string &msg, ARGS &&...params)
 	    : ParserException(Exception::InitializeExtraInfo(error_location),
 	                      ConstructMessage(msg, std::forward<ARGS>(params)...)) {
 	}
@@ -34,7 +35,7 @@ public:
 	    : ParserException(Exception::InitializeExtraInfo(expr), ConstructMessage(msg, std::forward<ARGS>(params)...)) {
 	}
 
-	static ParserException SyntaxError(const string &query, const string &error_message, optional_idx error_location);
+	static ParserException SyntaxError(const string &query, const string &error_message, Span error_location);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/common/exception/parser_exception.hpp
+++ b/src/include/duckdb/common/exception/parser_exception.hpp
@@ -10,7 +10,7 @@
 
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/optional_idx.hpp"
-#include "duckdb/common/span.hpp"
+#include "duckdb/common/query_location.hpp"
 #include "duckdb/common/unordered_map.hpp"
 
 namespace duckdb {
@@ -26,7 +26,7 @@ public:
 	    : ParserException(ConstructMessage(msg, std::forward<ARGS>(params)...)) {
 	}
 	template <typename... ARGS>
-	explicit ParserException(Span error_location, const string &msg, ARGS &&...params)
+	explicit ParserException(QueryLocation error_location, const string &msg, ARGS &&...params)
 	    : ParserException(Exception::InitializeExtraInfo(error_location),
 	                      ConstructMessage(msg, std::forward<ARGS>(params)...)) {
 	}
@@ -35,7 +35,7 @@ public:
 	    : ParserException(Exception::InitializeExtraInfo(expr), ConstructMessage(msg, std::forward<ARGS>(params)...)) {
 	}
 
-	static ParserException SyntaxError(const string &query, const string &error_message, Span error_location);
+	static ParserException SyntaxError(const string &query, const string &error_message, QueryLocation error_location);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/common/operator/cast_operators.hpp
+++ b/src/include/duckdb/common/operator/cast_operators.hpp
@@ -11,6 +11,7 @@
 #include "duckdb/common/assert.hpp"
 #include "duckdb/common/constants.hpp"
 #include "duckdb/common/hugeint.hpp"
+#include "duckdb/common/span.hpp"
 #include "duckdb/common/limits.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/typedefs.hpp"
@@ -82,8 +83,7 @@ struct Cast {
 struct HandleCastError {
 	static void AssignError(const string &error_message, CastParameters &parameters);
 	static void AssignError(const string &error_message, string *error_message_ptr,
-	                        optional_ptr<const Expression> cast_source = nullptr,
-	                        optional_idx error_location = optional_idx());
+	                        optional_ptr<const Expression> cast_source = nullptr, Span error_location = Span());
 };
 
 //===--------------------------------------------------------------------===//

--- a/src/include/duckdb/common/operator/cast_operators.hpp
+++ b/src/include/duckdb/common/operator/cast_operators.hpp
@@ -11,7 +11,7 @@
 #include "duckdb/common/assert.hpp"
 #include "duckdb/common/constants.hpp"
 #include "duckdb/common/hugeint.hpp"
-#include "duckdb/common/span.hpp"
+#include "duckdb/common/query_location.hpp"
 #include "duckdb/common/limits.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/typedefs.hpp"
@@ -83,7 +83,8 @@ struct Cast {
 struct HandleCastError {
 	static void AssignError(const string &error_message, CastParameters &parameters);
 	static void AssignError(const string &error_message, string *error_message_ptr,
-	                        optional_ptr<const Expression> cast_source = nullptr, Span error_location = Span());
+	                        optional_ptr<const Expression> cast_source = nullptr,
+	                        QueryLocation error_location = QueryLocation());
 };
 
 //===--------------------------------------------------------------------===//

--- a/src/include/duckdb/common/query_location.hpp
+++ b/src/include/duckdb/common/query_location.hpp
@@ -1,7 +1,7 @@
 //===----------------------------------------------------------------------===//
 //                         DuckDB
 //
-// duckdb/common/span.hpp
+// duckdb/common/query_location.hpp
 //
 //
 //===----------------------------------------------------------------------===//
@@ -12,10 +12,10 @@
 
 namespace duckdb {
 
-//! A Span references a contiguous region [offset, offset + length) of the source query text.
-//! An invalid Span (offset == INVALID_OFFSET) marks "no known location" - e.g. for expressions
+//! A QueryLocation references a contiguous region [offset, offset + length) of the source query text.
+//! An invalid QueryLocation (offset == INVALID_OFFSET) marks "no known location" - e.g. for expressions
 //! that are synthesized during binding/optimization and have no corresponding source text.
-struct Span {
+struct QueryLocation {
 	static constexpr uint32_t INVALID_OFFSET = uint32_t(-1);
 
 	//! Start byte of the region (INVALID_OFFSET when the location is unknown)
@@ -23,25 +23,25 @@ struct Span {
 	//! Length of the region in bytes (0 for a point / unknown extent)
 	uint32_t length = 0;
 
-	Span() = default;
-	//! Construct from (offset, length). If either value does not fit in a uint32_t the Span is left invalid.
-	Span(idx_t offset_p, idx_t length_p) {
+	QueryLocation() = default;
+	//! Construct from (offset, length). If either value does not fit in a uint32_t the QueryLocation is left invalid.
+	QueryLocation(idx_t offset_p, idx_t length_p) {
 		if (offset_p < INVALID_OFFSET && length_p < INVALID_OFFSET) {
 			offset = static_cast<uint32_t>(offset_p);
 			length = static_cast<uint32_t>(length_p);
 		}
 	}
-	//! Bridge from optional_idx (start-only), yielding a zero-length Span. An invalid or out-of-range idx
-	//! yields an invalid Span. Intended mainly for extensions and the few core sites that only have an
-	//! offset (casts, raw parser byte positions, legacy deserialization); prefer threading a real Span.
-	Span(optional_idx idx) { // NOLINT: allow implicit conversion from optional_idx
+	//! Bridge from optional_idx (start-only), yielding a zero-length QueryLocation. An invalid or out-of-range idx
+	//! yields an invalid QueryLocation. Intended mainly for extensions and the few core sites that only have an
+	//! offset (casts, raw parser byte positions, legacy deserialization); prefer threading a real QueryLocation.
+	QueryLocation(optional_idx idx) { // NOLINT: allow implicit conversion from optional_idx
 		if (idx.IsValid() && idx.GetIndex() < INVALID_OFFSET) {
 			offset = static_cast<uint32_t>(idx.GetIndex());
 		}
 	}
 
-	static Span Invalid() {
-		return Span();
+	static QueryLocation Invalid() {
+		return QueryLocation();
 	}
 
 	bool IsValid() const {
@@ -70,8 +70,8 @@ struct Span {
 		return GetOffset();
 	}
 
-	//! Returns the smallest Span enclosing both this and other. Invalid spans are ignored.
-	Span Merge(const Span &other) const {
+	//! Returns the smallest QueryLocation enclosing both this and other. Invalid locations are ignored.
+	QueryLocation Merge(const QueryLocation &other) const {
 		if (!IsValid()) {
 			return other;
 		}
@@ -82,13 +82,13 @@ struct Span {
 		auto this_end = End();
 		auto other_end = other.End();
 		auto new_end = this_end > other_end ? this_end : other_end;
-		return Span(new_start, new_end - new_start);
+		return QueryLocation(new_start, new_end - new_start);
 	}
 
-	bool operator==(const Span &rhs) const {
+	bool operator==(const QueryLocation &rhs) const {
 		return offset == rhs.offset && length == rhs.length;
 	}
-	bool operator!=(const Span &rhs) const {
+	bool operator!=(const QueryLocation &rhs) const {
 		return !(*this == rhs);
 	}
 };

--- a/src/include/duckdb/common/span.hpp
+++ b/src/include/duckdb/common/span.hpp
@@ -1,0 +1,96 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/span.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/optional_idx.hpp"
+
+namespace duckdb {
+
+//! A Span references a contiguous region [offset, offset + length) of the source query text.
+//! An invalid Span (offset == INVALID_OFFSET) marks "no known location" - e.g. for expressions
+//! that are synthesized during binding/optimization and have no corresponding source text.
+struct Span {
+	static constexpr uint32_t INVALID_OFFSET = uint32_t(-1);
+
+	//! Start byte of the region (INVALID_OFFSET when the location is unknown)
+	uint32_t offset = INVALID_OFFSET;
+	//! Length of the region in bytes (0 for a point / unknown extent)
+	uint32_t length = 0;
+
+	Span() = default;
+	//! Construct from (offset, length). If either value does not fit in a uint32_t the Span is left invalid.
+	Span(idx_t offset_p, idx_t length_p) {
+		if (offset_p < INVALID_OFFSET && length_p < INVALID_OFFSET) {
+			offset = static_cast<uint32_t>(offset_p);
+			length = static_cast<uint32_t>(length_p);
+		}
+	}
+	//! Bridge from optional_idx (start-only), yielding a zero-length Span. An invalid or out-of-range idx
+	//! yields an invalid Span. Intended mainly for extensions and the few core sites that only have an
+	//! offset (casts, raw parser byte positions, legacy deserialization); prefer threading a real Span.
+	Span(optional_idx idx) { // NOLINT: allow implicit conversion from optional_idx
+		if (idx.IsValid() && idx.GetIndex() < INVALID_OFFSET) {
+			offset = static_cast<uint32_t>(idx.GetIndex());
+		}
+	}
+
+	static Span Invalid() {
+		return Span();
+	}
+
+	bool IsValid() const {
+		return offset != INVALID_OFFSET;
+	}
+	void SetInvalid() {
+		offset = INVALID_OFFSET;
+		length = 0;
+	}
+
+	//! Start byte of the region
+	uint32_t Start() const {
+		return offset;
+	}
+	//! One-past-the-end byte of the region
+	uint32_t End() const {
+		return offset + length;
+	}
+
+	//! Bridge back to optional_idx (start offset only) for legacy single-position consumers
+	optional_idx GetOffset() const {
+		return IsValid() ? optional_idx(offset) : optional_idx();
+	}
+	//! Implicit bridge to optional_idx (start offset only). Length is dropped.
+	operator optional_idx() const { // NOLINT: allow implicit conversion to optional_idx
+		return GetOffset();
+	}
+
+	//! Returns the smallest Span enclosing both this and other. Invalid spans are ignored.
+	Span Merge(const Span &other) const {
+		if (!IsValid()) {
+			return other;
+		}
+		if (!other.IsValid()) {
+			return *this;
+		}
+		auto new_start = offset < other.offset ? offset : other.offset;
+		auto this_end = End();
+		auto other_end = other.End();
+		auto new_end = this_end > other_end ? this_end : other_end;
+		return Span(new_start, new_end - new_start);
+	}
+
+	bool operator==(const Span &rhs) const {
+		return offset == rhs.offset && length == rhs.length;
+	}
+	bool operator!=(const Span &rhs) const {
+		return !(*this == rhs);
+	}
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/common/types/geometry.hpp
+++ b/src/include/duckdb/common/types/geometry.hpp
@@ -11,7 +11,7 @@
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/types.hpp"
 #include "duckdb/common/pair.hpp"
-#include "duckdb/common/span.hpp"
+#include "duckdb/common/query_location.hpp"
 #include "duckdb/storage/storage_info.hpp"
 #include <limits>
 #include <cmath>
@@ -275,7 +275,7 @@ public:
 
 	//! Convert from WKT
 	DUCKDB_API static bool FromString(const string_t &wkt_text, string_t &result, StringHeap &heap, bool strict,
-	                                  Span query_location);
+	                                  QueryLocation query_location);
 	DUCKDB_API static bool FromString(const string_t &wkt_text, string_t &result, Vector &result_vector, bool strict);
 
 	//! Convert to WKT

--- a/src/include/duckdb/common/types/geometry.hpp
+++ b/src/include/duckdb/common/types/geometry.hpp
@@ -11,6 +11,7 @@
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/types.hpp"
 #include "duckdb/common/pair.hpp"
+#include "duckdb/common/span.hpp"
 #include "duckdb/storage/storage_info.hpp"
 #include <limits>
 #include <cmath>
@@ -274,7 +275,7 @@ public:
 
 	//! Convert from WKT
 	DUCKDB_API static bool FromString(const string_t &wkt_text, string_t &result, StringHeap &heap, bool strict,
-	                                  optional_idx query_location);
+	                                  Span query_location);
 	DUCKDB_API static bool FromString(const string_t &wkt_text, string_t &result, Vector &result_vector, bool strict);
 
 	//! Convert to WKT

--- a/src/include/duckdb/function/cast/cast_function_set.hpp
+++ b/src/include/duckdb/function/cast/cast_function_set.hpp
@@ -27,7 +27,7 @@ struct GetCastFunctionInput {
 	}
 
 	optional_ptr<ClientContext> context;
-	optional_idx query_location;
+	Span query_location;
 };
 
 struct BindCastFunction {

--- a/src/include/duckdb/function/cast/cast_function_set.hpp
+++ b/src/include/duckdb/function/cast/cast_function_set.hpp
@@ -27,7 +27,7 @@ struct GetCastFunctionInput {
 	}
 
 	optional_ptr<ClientContext> context;
-	Span query_location;
+	QueryLocation query_location;
 };
 
 struct BindCastFunction {

--- a/src/include/duckdb/function/cast/default_casts.hpp
+++ b/src/include/duckdb/function/cast/default_casts.hpp
@@ -12,6 +12,7 @@
 #include "duckdb/common/types/vector.hpp"
 #include "duckdb/common/helper.hpp"
 #include "duckdb/common/optional_ptr.hpp"
+#include "duckdb/common/span.hpp"
 #include "duckdb/function/scalar_function.hpp"
 
 namespace duckdb {
@@ -82,7 +83,7 @@ struct CastParameters {
 	//! Local state
 	optional_ptr<FunctionLocalState> local_state;
 	//! Query location (if any)
-	optional_idx query_location;
+	Span query_location;
 	//! In the case of a nested type, when facing a cast error, if we nullify the parent
 	bool nullify_parent = false;
 };
@@ -150,7 +151,7 @@ struct BindCastInput {
 	CastFunctionSet &function_set;
 	optional_ptr<BindCastInfo> info;
 	optional_ptr<ClientContext> context;
-	optional_idx query_location;
+	Span query_location;
 
 public:
 	DUCKDB_API BoundCastInfo GetCastFunction(const LogicalType &source, const LogicalType &target);

--- a/src/include/duckdb/function/cast/default_casts.hpp
+++ b/src/include/duckdb/function/cast/default_casts.hpp
@@ -12,7 +12,7 @@
 #include "duckdb/common/types/vector.hpp"
 #include "duckdb/common/helper.hpp"
 #include "duckdb/common/optional_ptr.hpp"
-#include "duckdb/common/span.hpp"
+#include "duckdb/common/query_location.hpp"
 #include "duckdb/function/scalar_function.hpp"
 
 namespace duckdb {
@@ -83,7 +83,7 @@ struct CastParameters {
 	//! Local state
 	optional_ptr<FunctionLocalState> local_state;
 	//! Query location (if any)
-	Span query_location;
+	QueryLocation query_location;
 	//! In the case of a nested type, when facing a cast error, if we nullify the parent
 	bool nullify_parent = false;
 };
@@ -151,7 +151,7 @@ struct BindCastInput {
 	CastFunctionSet &function_set;
 	optional_ptr<BindCastInfo> info;
 	optional_ptr<ClientContext> context;
-	Span query_location;
+	QueryLocation query_location;
 
 public:
 	DUCKDB_API BoundCastInfo GetCastFunction(const LogicalType &source, const LogicalType &target);

--- a/src/include/duckdb/parser/base_expression.hpp
+++ b/src/include/duckdb/parser/base_expression.hpp
@@ -12,6 +12,7 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/identifier.hpp"
 #include "duckdb/common/optional_idx.hpp"
+#include "duckdb/common/span.hpp"
 
 namespace duckdb {
 
@@ -42,13 +43,18 @@ public:
 		type = new_type;
 	}
 
-	//! Returns the location in the query (if any)
-	optional_idx GetQueryLocation() const {
+	//! Returns the source span in the query (if any). Implicitly converts to optional_idx (start offset).
+	Span GetQueryLocation() const {
 		return query_location;
 	}
 
 	//! Sets the location in the query
 	void SetQueryLocation(optional_idx location) {
+		query_location = location;
+	}
+
+	//! Sets the source span in the query
+	void SetQueryLocation(Span location) {
 		query_location = location;
 	}
 
@@ -87,8 +93,8 @@ protected:
 	//! The alias of the expression,
 	Identifier alias;
 
-	//! The location in the query (if any)
-	optional_idx query_location;
+	//! The source span in the query (if any)
+	Span query_location;
 
 protected:
 	//! Sets the class of the expression unsafely. In general expressions are immutable and should not be changed after

--- a/src/include/duckdb/parser/base_expression.hpp
+++ b/src/include/duckdb/parser/base_expression.hpp
@@ -12,7 +12,7 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/identifier.hpp"
 #include "duckdb/common/optional_idx.hpp"
-#include "duckdb/common/span.hpp"
+#include "duckdb/common/query_location.hpp"
 
 namespace duckdb {
 
@@ -43,8 +43,8 @@ public:
 		type = new_type;
 	}
 
-	//! Returns the source span in the query (if any). Implicitly converts to optional_idx (start offset).
-	Span GetQueryLocation() const {
+	//! Returns the source location in the query (if any). Implicitly converts to optional_idx (start offset).
+	QueryLocation GetQueryLocation() const {
 		return query_location;
 	}
 
@@ -53,8 +53,8 @@ public:
 		query_location = location;
 	}
 
-	//! Sets the source span in the query
-	void SetQueryLocation(Span location) {
+	//! Sets the source location in the query
+	void SetQueryLocation(QueryLocation location) {
 		query_location = location;
 	}
 
@@ -93,8 +93,8 @@ protected:
 	//! The alias of the expression,
 	Identifier alias;
 
-	//! The source span in the query (if any)
-	Span query_location;
+	//! The source location in the query (if any)
+	QueryLocation query_location;
 
 protected:
 	//! Sets the class of the expression unsafely. In general expressions are immutable and should not be changed after

--- a/src/include/duckdb/parser/parser.hpp
+++ b/src/include/duckdb/parser/parser.hpp
@@ -54,7 +54,7 @@ public:
 	//! separator-only run (no statement). Throws ParserException on syntax error.
 	//!
 	//! Does NOT populate `stmt->query` — the caller owns the source string and can slice it
-	//! using `stmt->stmt_span` if needed.
+	//! using `stmt->stmt_location` if needed.
 	DUCKDB_API unique_ptr<SQLStatement> ParseTopLevelStatement(vector<MatcherToken> &tokens, idx_t &token_cursor);
 
 	//! Run the `parse_function` extensions over the tail of `query` starting at `token_cursor`,

--- a/src/include/duckdb/parser/parser.hpp
+++ b/src/include/duckdb/parser/parser.hpp
@@ -54,7 +54,7 @@ public:
 	//! separator-only run (no statement). Throws ParserException on syntax error.
 	//!
 	//! Does NOT populate `stmt->query` — the caller owns the source string and can slice it
-	//! using `stmt->stmt_location` / `stmt->stmt_length` if needed.
+	//! using `stmt->stmt_span` if needed.
 	DUCKDB_API unique_ptr<SQLStatement> ParseTopLevelStatement(vector<MatcherToken> &tokens, idx_t &token_cursor);
 
 	//! Run the `parse_function` extensions over the tail of `query` starting at `token_cursor`,

--- a/src/include/duckdb/parser/peg/transformer/parse_result.hpp
+++ b/src/include/duckdb/parser/peg/transformer/parse_result.hpp
@@ -138,21 +138,22 @@ public:
 	//! Source length: for leaf tokens the token length; for composite results the enclosing extent of children
 	optional_idx length;
 
-	//! Returns the source span [offset, offset+length) of this parse result (length 0 when unknown)
-	Span GetSpan() const {
+	//! Returns the source location [offset, offset+length) of this parse result (length 0 when unknown)
+	QueryLocation GetLocation() const {
 		if (!offset.IsValid()) {
-			return Span();
+			return QueryLocation();
 		}
-		return Span(offset.GetIndex(), length.IsValid() ? length.GetIndex() : 0);
+		return QueryLocation(offset.GetIndex(), length.IsValid() ? length.GetIndex() : 0);
 	}
 
-	//! Grow this result's span so it encloses the given child's span (used to build composite spans bottom-up)
+	//! Grow this result's location so it encloses the given child's location (used to build composite
+	//! locations bottom-up)
 	void EncloseChild(const ParseResult &child) {
-		auto child_span = child.GetSpan();
-		if (!offset.IsValid() || !child_span.IsValid()) {
+		auto child_location = child.GetLocation();
+		if (!offset.IsValid() || !child_location.IsValid()) {
 			return;
 		}
-		auto enclosing = GetSpan().Merge(child_span);
+		auto enclosing = GetLocation().Merge(child_location);
 		length = enclosing.length;
 	}
 

--- a/src/include/duckdb/parser/peg/transformer/parse_result.hpp
+++ b/src/include/duckdb/parser/peg/transformer/parse_result.hpp
@@ -115,7 +115,8 @@ inline const char *ParseResultToString(ParseResultType type) {
 
 class ParseResult {
 public:
-	explicit ParseResult(ParseResultType type, optional_idx offset) : type(type), offset(offset) {
+	explicit ParseResult(ParseResultType type, optional_idx offset, optional_idx length = optional_idx())
+	    : type(type), offset(offset), length(length) {
 	}
 	virtual ~ParseResult() = default;
 
@@ -134,6 +135,26 @@ public:
 	ParseResultType type;
 	string name;
 	optional_idx offset;
+	//! Source length: for leaf tokens the token length; for composite results the enclosing extent of children
+	optional_idx length;
+
+	//! Returns the source span [offset, offset+length) of this parse result (length 0 when unknown)
+	Span GetSpan() const {
+		if (!offset.IsValid()) {
+			return Span();
+		}
+		return Span(offset.GetIndex(), length.IsValid() ? length.GetIndex() : 0);
+	}
+
+	//! Grow this result's span so it encloses the given child's span (used to build composite spans bottom-up)
+	void EncloseChild(const ParseResult &child) {
+		auto child_span = child.GetSpan();
+		if (!offset.IsValid() || !child_span.IsValid()) {
+			return;
+		}
+		auto enclosing = GetSpan().Merge(child_span);
+		length = enclosing.length;
+	}
 
 	virtual void ToStringInternal(std::stringstream &ss, std::unordered_set<const ParseResult *> &visited,
 	                              const std::string &indent, bool is_last) const {
@@ -157,8 +178,8 @@ struct IdentifierParseResult : ParseResult {
 	static constexpr ParseResultType TYPE = ParseResultType::IDENTIFIER;
 	Identifier identifier;
 
-	explicit IdentifierParseResult(string identifier_p, optional_idx offset)
-	    : ParseResult(TYPE, offset), identifier(std::move(identifier_p)) {
+	explicit IdentifierParseResult(string identifier_p, optional_idx offset, optional_idx length = optional_idx())
+	    : ParseResult(TYPE, offset, length), identifier(std::move(identifier_p)) {
 	}
 
 	void ToStringInternal(std::stringstream &ss, std::unordered_set<const ParseResult *> &visited,
@@ -185,8 +206,8 @@ struct KeywordParseResult : ParseResult {
 	static constexpr ParseResultType TYPE = ParseResultType::KEYWORD;
 	string keyword;
 
-	explicit KeywordParseResult(string keyword_p, optional_idx offset)
-	    : ParseResult(TYPE, offset), keyword(std::move(keyword_p)) {
+	explicit KeywordParseResult(string keyword_p, optional_idx offset, optional_idx length = optional_idx())
+	    : ParseResult(TYPE, offset, length), keyword(std::move(keyword_p)) {
 	}
 
 	void ToStringInternal(std::stringstream &ss, std::unordered_set<const ParseResult *> &visited,
@@ -203,6 +224,9 @@ public:
 	explicit ListParseResult(vector<reference<ParseResult>> results_p, string name_p, optional_idx offset)
 	    : ParseResult(TYPE, offset), children(std::move(results_p)) {
 		name = std::move(name_p);
+		for (auto &child : children) {
+			EncloseChild(child.get());
+		}
 	}
 
 	vector<reference<ParseResult>> GetChildren() const {
@@ -252,6 +276,9 @@ struct RepeatParseResult : ParseResult {
 
 	explicit RepeatParseResult(vector<reference<ParseResult>> results_p, optional_idx offset)
 	    : ParseResult(TYPE, offset), children(std::move(results_p)) {
+		for (auto &child : children) {
+			EncloseChild(child.get());
+		}
 	}
 
 	vector<reference<ParseResult>> GetChildren() const {
@@ -300,6 +327,7 @@ struct OptionalParseResult : ParseResult {
 	explicit OptionalParseResult(optional_ptr<ParseResult> result_p, optional_idx offset)
 	    : ParseResult(TYPE, offset), optional_result(result_p) {
 		name = result_p->name;
+		EncloseChild(*result_p);
 	}
 
 	bool HasResult() const {
@@ -341,6 +369,7 @@ public:
 	explicit ChoiceParseResult(ParseResult &parse_result_p, idx_t selected_idx_p, optional_idx offset)
 	    : ParseResult(TYPE, offset), result(parse_result_p), selected_idx(selected_idx_p) {
 		name = parse_result_p.name;
+		EncloseChild(parse_result_p);
 	}
 
 	ParseResult &GetResult() {
@@ -367,8 +396,8 @@ class NumberParseResult : public ParseResult {
 public:
 	static constexpr ParseResultType TYPE = ParseResultType::NUMBER;
 
-	explicit NumberParseResult(string number_p, optional_idx offset)
-	    : ParseResult(TYPE, offset), number(std::move(number_p)) {
+	explicit NumberParseResult(string number_p, optional_idx offset, optional_idx length = optional_idx())
+	    : ParseResult(TYPE, offset, length), number(std::move(number_p)) {
 	}
 	string number;
 
@@ -383,8 +412,9 @@ class StringLiteralParseResult : public ParseResult {
 public:
 	static constexpr ParseResultType TYPE = ParseResultType::STRING;
 
-	explicit StringLiteralParseResult(string string_p, SpecialStringCharacter string_type_p, optional_idx offset)
-	    : ParseResult(TYPE, offset), result(std::move(string_p)), string_type(string_type_p) {
+	explicit StringLiteralParseResult(string string_p, SpecialStringCharacter string_type_p, optional_idx offset,
+	                                  optional_idx length = optional_idx())
+	    : ParseResult(TYPE, offset, length), result(std::move(string_p)), string_type(string_type_p) {
 	}
 
 	string GetRawString() const {
@@ -528,8 +558,8 @@ class OperatorParseResult : public ParseResult {
 public:
 	static constexpr ParseResultType TYPE = ParseResultType::OPERATOR;
 
-	explicit OperatorParseResult(string operator_p, optional_idx offset)
-	    : ParseResult(TYPE, offset), operator_token(std::move(operator_p)) {
+	explicit OperatorParseResult(string operator_p, optional_idx offset, optional_idx length = optional_idx())
+	    : ParseResult(TYPE, offset, length), operator_token(std::move(operator_p)) {
 	}
 	string operator_token;
 

--- a/src/include/duckdb/parser/peg/transformer/peg_transformer.hpp
+++ b/src/include/duckdb/parser/peg/transformer/peg_transformer.hpp
@@ -230,14 +230,14 @@ public:
 			auto bridged = TryBridgeTransformResult<T>(*base_result);
 			if (bridged) {
 				auto bridged_result = std::move(bridged->value);
-				SetResultLocation(bridged_result, parse_result.offset);
+				SetResultLocation(bridged_result, parse_result.GetSpan());
 				return bridged_result;
 			}
 			throw InternalException("Transformer for rule '" + parse_result.name + "' returned an unexpected type.");
 		}
 
 		auto result = std::move(typed_result_ptr->value);
-		SetResultLocation(result, parse_result.offset);
+		SetResultLocation(result, parse_result.GetSpan());
 		return result;
 	}
 
@@ -281,27 +281,27 @@ public:
 	void ExtractCTEsRecursive(CommonTableExpressionMap &cte_map);
 	bool IsWindowFrameDefault(WindowBoundary start, WindowBoundary end);
 	unique_ptr<WindowExpression> GetWindowClause(const Identifier &window_name);
-	void SetQueryLocation(ParsedExpression &expr, optional_idx query_location);
-	void SetQueryLocation(TableRef &ref, optional_idx query_location);
+	void SetQueryLocation(ParsedExpression &expr, Span query_location);
+	void SetQueryLocation(TableRef &ref, Span query_location);
 
 private:
 	template <typename T>
-	void SetResultLocation(T &, optional_idx) {
+	void SetResultLocation(T &, Span) {
 	}
-	void SetResultLocation(unique_ptr<ParsedExpression> &expr, optional_idx offset) {
+	void SetResultLocation(unique_ptr<ParsedExpression> &expr, Span span) {
 		if (!expr) {
 			return;
 		}
-		if (offset.IsValid() && !expr->GetQueryLocation().IsValid()) {
-			SetQueryLocation(*expr, offset);
+		if (span.IsValid() && !expr->HasQueryLocation()) {
+			SetQueryLocation(*expr, span);
 		}
 	}
-	void SetResultLocation(unique_ptr<TableRef> &ref, optional_idx offset) {
+	void SetResultLocation(unique_ptr<TableRef> &ref, Span span) {
 		if (!ref) {
 			return;
 		}
-		if (offset.IsValid() && !ref->query_location.IsValid()) {
-			SetQueryLocation(*ref, offset.GetIndex());
+		if (span.IsValid() && !ref->query_location.IsValid()) {
+			SetQueryLocation(*ref, span);
 		}
 	}
 

--- a/src/include/duckdb/parser/peg/transformer/peg_transformer.hpp
+++ b/src/include/duckdb/parser/peg/transformer/peg_transformer.hpp
@@ -230,14 +230,14 @@ public:
 			auto bridged = TryBridgeTransformResult<T>(*base_result);
 			if (bridged) {
 				auto bridged_result = std::move(bridged->value);
-				SetResultLocation(bridged_result, parse_result.GetSpan());
+				SetResultLocation(bridged_result, parse_result.GetLocation());
 				return bridged_result;
 			}
 			throw InternalException("Transformer for rule '" + parse_result.name + "' returned an unexpected type.");
 		}
 
 		auto result = std::move(typed_result_ptr->value);
-		SetResultLocation(result, parse_result.GetSpan());
+		SetResultLocation(result, parse_result.GetLocation());
 		return result;
 	}
 
@@ -281,27 +281,27 @@ public:
 	void ExtractCTEsRecursive(CommonTableExpressionMap &cte_map);
 	bool IsWindowFrameDefault(WindowBoundary start, WindowBoundary end);
 	unique_ptr<WindowExpression> GetWindowClause(const Identifier &window_name);
-	void SetQueryLocation(ParsedExpression &expr, Span query_location);
-	void SetQueryLocation(TableRef &ref, Span query_location);
+	void SetQueryLocation(ParsedExpression &expr, QueryLocation query_location);
+	void SetQueryLocation(TableRef &ref, QueryLocation query_location);
 
 private:
 	template <typename T>
-	void SetResultLocation(T &, Span) {
+	void SetResultLocation(T &, QueryLocation) {
 	}
-	void SetResultLocation(unique_ptr<ParsedExpression> &expr, Span span) {
+	void SetResultLocation(unique_ptr<ParsedExpression> &expr, QueryLocation location) {
 		if (!expr) {
 			return;
 		}
-		if (span.IsValid() && !expr->HasQueryLocation()) {
-			SetQueryLocation(*expr, span);
+		if (location.IsValid() && !expr->HasQueryLocation()) {
+			SetQueryLocation(*expr, location);
 		}
 	}
-	void SetResultLocation(unique_ptr<TableRef> &ref, Span span) {
+	void SetResultLocation(unique_ptr<TableRef> &ref, QueryLocation location) {
 		if (!ref) {
 			return;
 		}
-		if (span.IsValid() && !ref->query_location.IsValid()) {
-			SetQueryLocation(*ref, span);
+		if (location.IsValid() && !ref->query_location.IsValid()) {
+			SetQueryLocation(*ref, location);
 		}
 	}
 

--- a/src/include/duckdb/parser/query_error_context.hpp
+++ b/src/include/duckdb/parser/query_error_context.hpp
@@ -9,7 +9,7 @@
 #pragma once
 
 #include "duckdb/common/optional_idx.hpp"
-#include "duckdb/common/span.hpp"
+#include "duckdb/common/query_location.hpp"
 
 namespace duckdb {
 class ParsedExpression;
@@ -17,11 +17,11 @@ class ParsedExpression;
 class QueryErrorContext {
 public:
 	QueryErrorContext(const ParsedExpression &expr); // NOLINT: allow implicit conversion from expression
-	explicit QueryErrorContext(Span query_location_p = Span()) : query_location(query_location_p) {
+	explicit QueryErrorContext(QueryLocation query_location_p = QueryLocation()) : query_location(query_location_p) {
 	}
 
-	//! The source span in which the error should be thrown
-	Span query_location;
+	//! The source location in which the error should be thrown
+	QueryLocation query_location;
 
 public:
 	static string Format(const string &query, const string &error_message, optional_idx error_loc,

--- a/src/include/duckdb/parser/query_error_context.hpp
+++ b/src/include/duckdb/parser/query_error_context.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "duckdb/common/optional_idx.hpp"
+#include "duckdb/common/span.hpp"
 
 namespace duckdb {
 class ParsedExpression;
@@ -16,15 +17,15 @@ class ParsedExpression;
 class QueryErrorContext {
 public:
 	QueryErrorContext(const ParsedExpression &expr); // NOLINT: allow implicit conversion from expression
-	explicit QueryErrorContext(optional_idx query_location_p = optional_idx()) : query_location(query_location_p) {
+	explicit QueryErrorContext(Span query_location_p = Span()) : query_location(query_location_p) {
 	}
 
-	//! The location in which the error should be thrown
-	optional_idx query_location;
+	//! The source span in which the error should be thrown
+	Span query_location;
 
 public:
 	static string Format(const string &query, const string &error_message, optional_idx error_loc,
-	                     bool add_line_indicator = true);
+	                     idx_t error_length = 0, bool add_line_indicator = true);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/parser/sql_statement.hpp
+++ b/src/include/duckdb/parser/sql_statement.hpp
@@ -13,7 +13,7 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/printer.hpp"
 #include "duckdb/common/named_parameter_map.hpp"
-#include "duckdb/common/span.hpp"
+#include "duckdb/common/query_location.hpp"
 
 namespace duckdb {
 
@@ -30,8 +30,8 @@ public:
 
 	//! The statement type
 	StatementType type;
-	//! The source span of the statement within the query string
-	Span stmt_span = Span(0, 0);
+	//! The source location of the statement within the query string
+	QueryLocation stmt_location = QueryLocation(0, 0);
 	//! The map of named parameter to param index
 	identifier_map_t<idx_t> named_param_map;
 	//! Whether the statement contains any anonymous (? or $N) parameters

--- a/src/include/duckdb/parser/sql_statement.hpp
+++ b/src/include/duckdb/parser/sql_statement.hpp
@@ -13,6 +13,7 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/printer.hpp"
 #include "duckdb/common/named_parameter_map.hpp"
+#include "duckdb/common/span.hpp"
 
 namespace duckdb {
 
@@ -29,10 +30,8 @@ public:
 
 	//! The statement type
 	StatementType type;
-	//! The statement location within the query string
-	idx_t stmt_location = 0;
-	//! The statement length within the query string
-	idx_t stmt_length = 0;
+	//! The source span of the statement within the query string
+	Span stmt_span = Span(0, 0);
 	//! The map of named parameter to param index
 	identifier_map_t<idx_t> named_param_map;
 	//! Whether the statement contains any anonymous (? or $N) parameters

--- a/src/include/duckdb/parser/tableref.hpp
+++ b/src/include/duckdb/parser/tableref.hpp
@@ -11,7 +11,7 @@
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/identifier.hpp"
 #include "duckdb/common/optional_idx.hpp"
-#include "duckdb/common/span.hpp"
+#include "duckdb/common/query_location.hpp"
 #include "duckdb/common/enums/tableref_type.hpp"
 #include "duckdb/parser/parsed_data/sample_options.hpp"
 #include "duckdb/main/external_dependencies.hpp"
@@ -33,8 +33,8 @@ public:
 	Identifier alias;
 	//! Sample options (if any)
 	unique_ptr<SampleOptions> sample;
-	//! The source span in the query (if any)
-	Span query_location;
+	//! The source location in the query (if any)
+	QueryLocation query_location;
 	//! External dependencies of this table function
 	shared_ptr<ExternalDependency> external_dependency;
 	//! Aliases for the column names

--- a/src/include/duckdb/parser/tableref.hpp
+++ b/src/include/duckdb/parser/tableref.hpp
@@ -11,6 +11,7 @@
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/identifier.hpp"
 #include "duckdb/common/optional_idx.hpp"
+#include "duckdb/common/span.hpp"
 #include "duckdb/common/enums/tableref_type.hpp"
 #include "duckdb/parser/parsed_data/sample_options.hpp"
 #include "duckdb/main/external_dependencies.hpp"
@@ -32,8 +33,8 @@ public:
 	Identifier alias;
 	//! Sample options (if any)
 	unique_ptr<SampleOptions> sample;
-	//! The location in the query (if any)
-	optional_idx query_location;
+	//! The source span in the query (if any)
+	Span query_location;
 	//! External dependencies of this table function
 	shared_ptr<ExternalDependency> external_dependency;
 	//! Aliases for the column names

--- a/src/include/duckdb/planner/expression_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder.hpp
@@ -45,7 +45,7 @@ struct SelectBindState;
 
 struct BoundColumnReferenceInfo {
 	Identifier name;
-	Span query_location;
+	QueryLocation query_location;
 };
 
 struct BindResult {

--- a/src/include/duckdb/planner/expression_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder.hpp
@@ -45,7 +45,7 @@ struct SelectBindState;
 
 struct BoundColumnReferenceInfo {
 	Identifier name;
-	optional_idx query_location;
+	Span query_location;
 };
 
 struct BindResult {

--- a/src/include/duckdb/storage/serialization/expression.json
+++ b/src/include/duckdb/storage/serialization/expression.json
@@ -29,6 +29,16 @@
         "name": "query_location",
         "type": "optional_idx",
         "default": "optional_idx()"
+      },
+      {
+        "id": 104,
+        "name": "query_location_length",
+        "type": "uint32_t",
+        "property": "query_location.length",
+        "default": "0",
+        "version": "v2.0.0",
+        "equals_skip": true,
+        "hash_skip": true
       }
     ]
   },

--- a/src/include/duckdb/storage/serialization/parsed_expression.json
+++ b/src/include/duckdb/storage/serialization/parsed_expression.json
@@ -38,6 +38,16 @@
         "type": "optional_idx",
         "default": "optional_idx()",
         "equals_skip": true
+      },
+      {
+        "id": 104,
+        "name": "query_location_length",
+        "type": "uint32_t",
+        "property": "query_location.length",
+        "default": "0",
+        "version": "v2.0.0",
+        "equals_skip": true,
+        "hash_skip": true
       }
     ]
   },

--- a/src/include/duckdb/storage/serialization/tableref.json
+++ b/src/include/duckdb/storage/serialization/tableref.json
@@ -26,6 +26,16 @@
         "name": "query_location",
         "type": "optional_idx",
         "default": "optional_idx()"
+      },
+      {
+        "id": 104,
+        "name": "query_location_length",
+        "type": "uint32_t",
+        "property": "query_location.length",
+        "default": "0",
+        "version": "v2.0.0",
+        "equals_skip": true,
+        "hash_skip": true
       }
     ]
   },

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -1040,7 +1040,12 @@ unique_ptr<PendingQueryResult> ClientContext::PendingStatementOrPreparedStatemen
     ClientContextLock &lock, const string &query, unique_ptr<SQLStatement> statement,
     shared_ptr<PreparedStatementData> &prepared, const PendingQueryParameters &parameters) {
 	if (statement) {
-		StatementVerification(lock, query, statement, parameters);
+		try {
+			StatementVerification(lock, query, statement, parameters);
+		} catch (std::exception &ex) {
+			// preserve extra error data (like query location)
+			return ErrorResult<PendingQueryResult>(ErrorData(ex), query);
+		}
 	}
 	return PendingStatementOrPreparedStatement(lock, query, std::move(statement), prepared, parameters);
 }

--- a/src/main/parse_iterator.cpp
+++ b/src/main/parse_iterator.cpp
@@ -114,14 +114,13 @@ bool ParseIterator::Peek() {
 			// the statement's start to the next statement's start (or end of input) so the trailing
 			// `;` and inter-statement whitespace end up inside stmt->query — downstream consumers
 			// (logging, error reporting, EXPLAIN) rely on that shape.
-			idx_t stmt_loc = stmt->stmt_location;
+			idx_t stmt_loc = stmt->stmt_span.offset;
 			idx_t end_loc = sql.size();
 			if (token_cursor < tokens->size() && (*tokens)[token_cursor].type != TokenType::END_OF_INPUT) {
 				end_loc = (*tokens)[token_cursor].offset;
 			}
 			stmt->query = sql.substr(stmt_loc, end_loc - stmt_loc);
-			stmt->stmt_location = 0;
-			stmt->stmt_length = stmt->query.size();
+			stmt->stmt_span = Span(0, stmt->query.size());
 			if (stmt->type == StatementType::CREATE_STATEMENT) {
 				auto &create = stmt->Cast<CreateStatement>();
 				create.info->sql = stmt->query;

--- a/src/main/parse_iterator.cpp
+++ b/src/main/parse_iterator.cpp
@@ -110,17 +110,17 @@ bool ParseIterator::Peek() {
 		}
 		if (stmt) {
 			// ParseTopLevelStatement doesn't populate stmt->query (it operates on tokens, not the
-			// source string). Mirror Parser::ParseQuery's per-statement post-processing: span from
+			// source string). Mirror Parser::ParseQuery's per-statement post-processing: extend from
 			// the statement's start to the next statement's start (or end of input) so the trailing
 			// `;` and inter-statement whitespace end up inside stmt->query — downstream consumers
 			// (logging, error reporting, EXPLAIN) rely on that shape.
-			idx_t stmt_loc = stmt->stmt_span.offset;
+			idx_t stmt_loc = stmt->stmt_location.offset;
 			idx_t end_loc = sql.size();
 			if (token_cursor < tokens->size() && (*tokens)[token_cursor].type != TokenType::END_OF_INPUT) {
 				end_loc = (*tokens)[token_cursor].offset;
 			}
 			stmt->query = sql.substr(stmt_loc, end_loc - stmt_loc);
-			stmt->stmt_span = Span(0, stmt->query.size());
+			stmt->stmt_location = QueryLocation(0, stmt->query.size());
 			if (stmt->type == StatementType::CREATE_STATEMENT) {
 				auto &create = stmt->Cast<CreateStatement>();
 				create.info->sql = stmt->query;

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -287,14 +287,14 @@ void Parser::ParseQuery(const string &query_p) {
 
 	if (!statements.empty()) {
 		for (idx_t i = 0; i + 1 < statements.size(); i++) {
-			auto start = statements[i]->stmt_span.offset;
-			statements[i]->stmt_span = Span(start, statements[i + 1]->stmt_span.offset - start);
+			auto start = statements[i]->stmt_location.offset;
+			statements[i]->stmt_location = QueryLocation(start, statements[i + 1]->stmt_location.offset - start);
 		}
-		statements.back()->stmt_span =
-		    Span(statements.back()->stmt_span.offset, query.size() - statements.back()->stmt_span.offset);
+		statements.back()->stmt_location = QueryLocation(statements.back()->stmt_location.offset,
+		                                                 query.size() - statements.back()->stmt_location.offset);
 		for (auto &statement : statements) {
-			statement->query = query.substr(statement->stmt_span.offset, statement->stmt_span.length);
-			statement->stmt_span = Span(0, statement->query.size());
+			statement->query = query.substr(statement->stmt_location.offset, statement->stmt_location.length);
+			statement->stmt_location = QueryLocation(0, statement->query.size());
 			if (statement->type == StatementType::CREATE_STATEMENT) {
 				auto &create = statement->Cast<CreateStatement>();
 				create.info->sql = statement->query;
@@ -336,12 +336,12 @@ unique_ptr<SQLStatement> Parser::TryParseExtensionStatement(vector<MatcherToken>
 			throw ParserException("Extension returned consumed_tokens=%llu — only %llu tokens are available",
 			                      (uint64_t)consumed, (uint64_t)simple_tokens.size());
 		}
-		// The claimed span runs from the failure point to the end of the last consumed token;
+		// The claimed region runs from the failure point to the end of the last consumed token;
 		// advancing the cursor by consumed_tokens lands on a token boundary.
 		auto &last_token = tokens[token_cursor + consumed - 1];
-		const idx_t span_end_byte = last_token.offset + last_token.length;
+		const idx_t end_byte = last_token.offset + last_token.length;
 		auto estmt = make_uniq<ExtensionStatement>(ext, std::move(result.parse_data));
-		estmt->stmt_span = Span(failure_byte, span_end_byte - failure_byte);
+		estmt->stmt_location = QueryLocation(failure_byte, end_byte - failure_byte);
 		token_cursor += consumed;
 		return std::move(estmt);
 	}

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -287,13 +287,14 @@ void Parser::ParseQuery(const string &query_p) {
 
 	if (!statements.empty()) {
 		for (idx_t i = 0; i + 1 < statements.size(); i++) {
-			statements[i]->stmt_length = statements[i + 1]->stmt_location - statements[i]->stmt_location;
+			auto start = statements[i]->stmt_span.offset;
+			statements[i]->stmt_span = Span(start, statements[i + 1]->stmt_span.offset - start);
 		}
-		statements.back()->stmt_length = query.size() - statements.back()->stmt_location;
+		statements.back()->stmt_span =
+		    Span(statements.back()->stmt_span.offset, query.size() - statements.back()->stmt_span.offset);
 		for (auto &statement : statements) {
-			statement->query = query.substr(statement->stmt_location, statement->stmt_length);
-			statement->stmt_location = 0;
-			statement->stmt_length = statement->query.size();
+			statement->query = query.substr(statement->stmt_span.offset, statement->stmt_span.length);
+			statement->stmt_span = Span(0, statement->query.size());
 			if (statement->type == StatementType::CREATE_STATEMENT) {
 				auto &create = statement->Cast<CreateStatement>();
 				create.info->sql = statement->query;
@@ -340,8 +341,7 @@ unique_ptr<SQLStatement> Parser::TryParseExtensionStatement(vector<MatcherToken>
 		auto &last_token = tokens[token_cursor + consumed - 1];
 		const idx_t span_end_byte = last_token.offset + last_token.length;
 		auto estmt = make_uniq<ExtensionStatement>(ext, std::move(result.parse_data));
-		estmt->stmt_location = failure_byte;
-		estmt->stmt_length = span_end_byte - failure_byte;
+		estmt->stmt_span = Span(failure_byte, span_end_byte - failure_byte);
 		token_cursor += consumed;
 		return std::move(estmt);
 	}

--- a/src/parser/peg/matcher.cpp
+++ b/src/parser/peg/matcher.cpp
@@ -75,10 +75,11 @@ public:
 		}
 		auto &token_text = state.tokens[state.token_index].text;
 		auto start_offset = optional_idx(state.tokens[state.token_index].offset);
+		auto token_length = optional_idx(state.tokens[state.token_index].length);
 		if (!MatchKeyword(state)) {
 			return nullptr;
 		}
-		auto result = state.allocator.Allocate(make_uniq<KeywordParseResult>(token_text, start_offset));
+		auto result = state.allocator.Allocate(make_uniq<KeywordParseResult>(token_text, start_offset, token_length));
 		result->name = name;
 		return result;
 	}
@@ -526,6 +527,7 @@ public:
 		}
 		const auto &token_text = state.tokens[state.token_index].text;
 		auto start_offset = optional_idx(state.tokens[state.token_index].offset);
+		auto token_length = optional_idx(state.tokens[state.token_index].length);
 		if (!MatchIdentifier(state)) {
 			return nullptr;
 		}
@@ -541,7 +543,7 @@ public:
 			result_text = result_text.substr(1, result_text.size() - 2);
 			result_text = StringUtil::Replace(result_text, "''", "'");
 		}
-		return state.allocator.Allocate(make_uniq<IdentifierParseResult>(result_text, start_offset));
+		return state.allocator.Allocate(make_uniq<IdentifierParseResult>(result_text, start_offset, token_length));
 	}
 
 	TokenType GetTokenType() const {
@@ -700,6 +702,7 @@ public:
 		}
 		auto &token_text = state.tokens[state.token_index].text;
 		auto start_offset = optional_idx(state.tokens[state.token_index].offset);
+		auto token_length = optional_idx(state.tokens[state.token_index].length);
 		if (!MatchReservedIdentifier(state)) {
 			return nullptr;
 		}
@@ -710,7 +713,7 @@ public:
 		} else if (!state.preserve_identifier_case) {
 			result_text = StringUtil::Lower(result_text);
 		}
-		return state.allocator.Allocate(make_uniq<IdentifierParseResult>(result_text, start_offset));
+		return state.allocator.Allocate(make_uniq<IdentifierParseResult>(result_text, start_offset, token_length));
 	}
 
 private:
@@ -759,6 +762,7 @@ public:
 
 		auto &token = state.tokens[state.token_index];
 		auto start_offset = optional_idx(token.offset);
+		auto token_length = optional_idx(token.length);
 		auto string_info = GetSpecialStringInfo(token.text);
 
 		if (!MatchStringLiteral(state, string_info)) {
@@ -775,7 +779,7 @@ public:
 		stripped_string = StringUtil::Replace(stripped_string, "''", "'");
 
 		auto result = state.allocator.Allocate(
-		    make_uniq<StringLiteralParseResult>(stripped_string, string_info.type, start_offset));
+		    make_uniq<StringLiteralParseResult>(stripped_string, string_info.type, start_offset, token_length));
 		result->name = name;
 		return result;
 	}
@@ -831,10 +835,11 @@ public:
 		}
 		auto &token_text = state.tokens[state.token_index].text;
 		auto start_offset = optional_idx(state.tokens[state.token_index].offset);
+		auto token_length = optional_idx(state.tokens[state.token_index].length);
 		if (!MatchNumberLiteral(state)) {
 			return nullptr;
 		}
-		auto result = state.allocator.Allocate(make_uniq<NumberParseResult>(token_text, start_offset));
+		auto result = state.allocator.Allocate(make_uniq<NumberParseResult>(token_text, start_offset, token_length));
 		result->name = name;
 		return result;
 	}
@@ -937,10 +942,11 @@ public:
 		}
 		auto &token_text = state.tokens[state.token_index].text;
 		auto start_offset = optional_idx(state.tokens[state.token_index].offset);
+		auto token_length = optional_idx(state.tokens[state.token_index].length);
 		if (!MatchOperator(state)) {
 			return nullptr;
 		}
-		return state.allocator.Allocate(make_uniq<OperatorParseResult>(token_text, start_offset));
+		return state.allocator.Allocate(make_uniq<OperatorParseResult>(token_text, start_offset, token_length));
 	}
 
 	SuggestionType AddSuggestionInternal(MatchState &state) const override {
@@ -1007,10 +1013,11 @@ public:
 		}
 		auto &token_text = state.tokens[state.token_index].text;
 		auto start_offset = optional_idx(state.tokens[state.token_index].offset);
+		auto token_length = optional_idx(state.tokens[state.token_index].length);
 		if (!MatchArithmeticOperator(state)) {
 			return nullptr;
 		}
-		return state.allocator.Allocate(make_uniq<OperatorParseResult>(token_text, start_offset));
+		return state.allocator.Allocate(make_uniq<OperatorParseResult>(token_text, start_offset, token_length));
 	}
 
 	SuggestionType AddSuggestionInternal(MatchState &state) const override {

--- a/src/parser/peg/transformer/peg_transformer.cpp
+++ b/src/parser/peg/transformer/peg_transformer.cpp
@@ -115,13 +115,13 @@ void TransformStack::SetResultLocation(ParseResult &parse_result, TransformResul
 		return;
 	}
 	auto *expression_result = dynamic_cast<TypedTransformResult<unique_ptr<ParsedExpression>> *>(&result);
-	if (expression_result && expression_result->value && !expression_result->value->GetQueryLocation().IsValid()) {
-		transformer.SetQueryLocation(*expression_result->value, parse_result.offset);
+	if (expression_result && expression_result->value && !expression_result->value->HasQueryLocation()) {
+		transformer.SetQueryLocation(*expression_result->value, parse_result.GetSpan());
 		return;
 	}
 	auto *table_ref_result = dynamic_cast<TypedTransformResult<unique_ptr<TableRef>> *>(&result);
 	if (table_ref_result && table_ref_result->value && !table_ref_result->value->query_location.IsValid()) {
-		transformer.SetQueryLocation(*table_ref_result->value, parse_result.offset.GetIndex());
+		transformer.SetQueryLocation(*table_ref_result->value, parse_result.GetSpan());
 		return;
 	}
 }
@@ -291,8 +291,7 @@ unique_ptr<SQLStatement> PEGTransformer::CreatePivotStatement(unique_ptr<SQLStat
 		enum_stmt->query = enum_stmt->ToString();
 		result->statements.push_back(std::move(enum_stmt));
 	}
-	result->stmt_location = statement->stmt_location;
-	result->stmt_length = statement->stmt_length;
+	result->stmt_span = statement->stmt_span;
 	statement->query = statement->ToString();
 	result->statements.push_back(std::move(statement));
 	return std::move(result);
@@ -335,11 +334,11 @@ unique_ptr<WindowExpression> PEGTransformer::GetWindowClause(const Identifier &w
 	return unique_ptr_cast<ParsedExpression, WindowExpression>(it->second->Copy());
 }
 
-void PEGTransformer::SetQueryLocation(ParsedExpression &expr, optional_idx query_location) {
+void PEGTransformer::SetQueryLocation(ParsedExpression &expr, Span query_location) {
 	expr.SetQueryLocation(query_location);
 }
 
-void PEGTransformer::SetQueryLocation(TableRef &ref, optional_idx query_location) {
+void PEGTransformer::SetQueryLocation(TableRef &ref, Span query_location) {
 	ref.query_location = query_location;
 }
 

--- a/src/parser/peg/transformer/peg_transformer.cpp
+++ b/src/parser/peg/transformer/peg_transformer.cpp
@@ -116,12 +116,12 @@ void TransformStack::SetResultLocation(ParseResult &parse_result, TransformResul
 	}
 	auto *expression_result = dynamic_cast<TypedTransformResult<unique_ptr<ParsedExpression>> *>(&result);
 	if (expression_result && expression_result->value && !expression_result->value->HasQueryLocation()) {
-		transformer.SetQueryLocation(*expression_result->value, parse_result.GetSpan());
+		transformer.SetQueryLocation(*expression_result->value, parse_result.GetLocation());
 		return;
 	}
 	auto *table_ref_result = dynamic_cast<TypedTransformResult<unique_ptr<TableRef>> *>(&result);
 	if (table_ref_result && table_ref_result->value && !table_ref_result->value->query_location.IsValid()) {
-		transformer.SetQueryLocation(*table_ref_result->value, parse_result.GetSpan());
+		transformer.SetQueryLocation(*table_ref_result->value, parse_result.GetLocation());
 		return;
 	}
 }
@@ -291,7 +291,7 @@ unique_ptr<SQLStatement> PEGTransformer::CreatePivotStatement(unique_ptr<SQLStat
 		enum_stmt->query = enum_stmt->ToString();
 		result->statements.push_back(std::move(enum_stmt));
 	}
-	result->stmt_span = statement->stmt_span;
+	result->stmt_location = statement->stmt_location;
 	statement->query = statement->ToString();
 	result->statements.push_back(std::move(statement));
 	return std::move(result);
@@ -334,11 +334,11 @@ unique_ptr<WindowExpression> PEGTransformer::GetWindowClause(const Identifier &w
 	return unique_ptr_cast<ParsedExpression, WindowExpression>(it->second->Copy());
 }
 
-void PEGTransformer::SetQueryLocation(ParsedExpression &expr, Span query_location) {
+void PEGTransformer::SetQueryLocation(ParsedExpression &expr, QueryLocation query_location) {
 	expr.SetQueryLocation(query_location);
 }
 
-void PEGTransformer::SetQueryLocation(TableRef &ref, Span query_location) {
+void PEGTransformer::SetQueryLocation(TableRef &ref, QueryLocation query_location) {
 	ref.query_location = query_location;
 }
 

--- a/src/parser/peg/transformer/peg_transformer_factory.cpp
+++ b/src/parser/peg/transformer/peg_transformer_factory.cpp
@@ -1,6 +1,6 @@
 #include "duckdb/parser/peg/transformer/peg_transformer.hpp"
 #include "duckdb/common/enums/trigger_type.hpp"
-#include "duckdb/common/span.hpp"
+#include "duckdb/common/query_location.hpp"
 #include "duckdb/parser/peg/matcher.hpp"
 #include "duckdb/common/to_string.hpp"
 #include "duckdb/parser/sql_statement.hpp"
@@ -81,7 +81,7 @@ static unique_ptr<SQLStatement> ExtractAndTransformStatement(PEGTransformer &tra
 		auto start = stmt_pr.offset.GetIndex();
 		idx_t end_index =
 		    terminator_offset.IsValid() ? terminator_offset.GetIndex() : (tokens.back().offset + tokens.back().length);
-		stmt->stmt_span = Span(start, end_index - start);
+		stmt->stmt_location = QueryLocation(start, end_index - start);
 	}
 
 	return stmt;
@@ -117,7 +117,8 @@ unique_ptr<SQLStatement> PEGTransformerFactory::TransformTopLevelStatement(vecto
 		}
 		auto &error_token = tokens[error_token_idx];
 		auto error_message = "syntax error at or near \"" + error_token.text + "\"";
-		throw ParserException::SyntaxError(token_stream, error_message, Span(error_token.offset, error_token.length));
+		throw ParserException::SyntaxError(token_stream, error_message,
+		                                   QueryLocation(error_token.offset, error_token.length));
 	}
 
 	// Advance the caller's cursor past the consumed tokens.

--- a/src/parser/peg/transformer/peg_transformer_factory.cpp
+++ b/src/parser/peg/transformer/peg_transformer_factory.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/parser/peg/transformer/peg_transformer.hpp"
 #include "duckdb/common/enums/trigger_type.hpp"
+#include "duckdb/common/span.hpp"
 #include "duckdb/parser/peg/matcher.hpp"
 #include "duckdb/common/to_string.hpp"
 #include "duckdb/parser/sql_statement.hpp"
@@ -77,12 +78,10 @@ static unique_ptr<SQLStatement> ExtractAndTransformStatement(PEGTransformer &tra
 
 	// Calculate location and length cleanly
 	if (stmt_pr.offset.IsValid()) {
-		stmt->stmt_location = stmt_pr.offset.GetIndex();
-
+		auto start = stmt_pr.offset.GetIndex();
 		idx_t end_index =
 		    terminator_offset.IsValid() ? terminator_offset.GetIndex() : (tokens.back().offset + tokens.back().length);
-
-		stmt->stmt_length = end_index - stmt->stmt_location;
+		stmt->stmt_span = Span(start, end_index - start);
 	}
 
 	return stmt;
@@ -118,7 +117,7 @@ unique_ptr<SQLStatement> PEGTransformerFactory::TransformTopLevelStatement(vecto
 		}
 		auto &error_token = tokens[error_token_idx];
 		auto error_message = "syntax error at or near \"" + error_token.text + "\"";
-		throw ParserException::SyntaxError(token_stream, error_message, error_token.offset);
+		throw ParserException::SyntaxError(token_stream, error_message, Span(error_token.offset, error_token.length));
 	}
 
 	// Advance the caller's cursor past the consumed tokens.

--- a/src/parser/query_error_context.cpp
+++ b/src/parser/query_error_context.cpp
@@ -10,7 +10,7 @@ QueryErrorContext::QueryErrorContext(const ParsedExpression &expr) : query_locat
 }
 
 string QueryErrorContext::Format(const string &query, const string &error_message, optional_idx error_loc,
-                                 bool add_line_indicator) {
+                                 idx_t error_length, bool add_line_indicator) {
 	static constexpr idx_t MAX_LINE_RENDER_WIDTH = 120;
 	if (!error_loc.IsValid()) {
 		// no location in query provided
@@ -154,11 +154,26 @@ string QueryErrorContext::Format(const string &query, const string &error_messag
 	}
 	error_render_width += line_indicator.size() + begin_trunc.size();
 
+	// get the render width of the caret indicator, covering the full span length (clamped to the visible line)
+	idx_t caret_width = 0;
+	idx_t error_end_in_line = (error_location - error_line_start) + error_length;
+	idx_t display_end_in_line = end_pos - error_line_start;
+	for (idx_t i = epos; i < positions.size(); i++) {
+		if (positions[i] >= error_end_in_line || positions[i] >= display_end_in_line) {
+			break;
+		}
+		caret_width += render_widths[i];
+	}
+	if (caret_width == 0) {
+		// always render at least one caret
+		caret_width = 1;
+	}
+
 	// now first print the error message plus the current line (or a subset of the line)
 	string result = error_message;
 	result += "\n\n" + line_indicator + begin_trunc + query.substr(start_pos, end_pos - start_pos) + end_trunc;
-	// print an arrow pointing at the error location
-	result += "\n" + string(error_render_width, ' ') + "^";
+	// print arrows pointing at the error location
+	result += "\n" + string(error_render_width, ' ') + string(caret_width, '^');
 	return result;
 }
 

--- a/src/parser/query_error_context.cpp
+++ b/src/parser/query_error_context.cpp
@@ -154,7 +154,7 @@ string QueryErrorContext::Format(const string &query, const string &error_messag
 	}
 	error_render_width += line_indicator.size() + begin_trunc.size();
 
-	// get the render width of the caret indicator, covering the full span length (clamped to the visible line)
+	// get the render width of the caret indicator, covering the full location length (clamped to the visible line)
 	idx_t caret_width = 0;
 	idx_t error_end_in_line = (error_location - error_line_start) + error_length;
 	idx_t display_end_in_line = end_pos - error_line_start;

--- a/src/planner/binder/statement/bind_pragma.cpp
+++ b/src/planner/binder/statement/bind_pragma.cpp
@@ -65,7 +65,7 @@ unique_ptr<BoundPragmaInfo> Binder::BindPragma(PragmaInfo &info, QueryErrorConte
 
 BoundStatement Binder::Bind(PragmaStatement &stmt) {
 	// bind the pragma function
-	QueryErrorContext error_context(stmt.stmt_span);
+	QueryErrorContext error_context(stmt.stmt_location);
 	auto bound_info = BindPragma(*stmt.info, error_context);
 	if (!bound_info->function.function) {
 		throw BinderException("PRAGMA function does not have a function specified");

--- a/src/planner/binder/statement/bind_pragma.cpp
+++ b/src/planner/binder/statement/bind_pragma.cpp
@@ -65,7 +65,7 @@ unique_ptr<BoundPragmaInfo> Binder::BindPragma(PragmaInfo &info, QueryErrorConte
 
 BoundStatement Binder::Bind(PragmaStatement &stmt) {
 	// bind the pragma function
-	QueryErrorContext error_context(stmt.stmt_location);
+	QueryErrorContext error_context(stmt.stmt_span);
 	auto bound_info = BindPragma(*stmt.info, error_context);
 	if (!bound_info->function.function) {
 		throw BinderException("PRAGMA function does not have a function specified");

--- a/src/planner/expression_binder.cpp
+++ b/src/planner/expression_binder.cpp
@@ -98,6 +98,32 @@ BindResult ExpressionBinder::BindExpression(unique_ptr<ParsedExpression> &expr, 
 	}
 }
 
+//! Reconstruct the source span from an error's extra info (prefers "span" so the length is kept)
+static Span ExtractSpan(const unordered_map<string, string> &info) {
+	auto pos_entry = info.find("position");
+	if (pos_entry == info.end()) {
+		return Span();
+	}
+	uint64_t start;
+	if (!TryCast::Operation<string_t, uint64_t>(string_t(pos_entry->second), start)) {
+		return Span();
+	}
+	uint64_t length = 0;
+	auto span_entry = info.find("span");
+	if (span_entry != info.end()) {
+		// value is formatted as "[start,length]"
+		auto comma = span_entry->second.find(',');
+		if (comma != string::npos) {
+			auto len_str = span_entry->second.substr(comma + 1);
+			if (!len_str.empty() && len_str.back() == ']') {
+				len_str.pop_back();
+			}
+			TryCast::Operation<string_t, uint64_t>(string_t(len_str), length);
+		}
+	}
+	return Span(start, length);
+}
+
 static bool CombineMissingColumns(ErrorData &current, ErrorData new_error) {
 	auto &current_info = current.ExtraInfo();
 	auto &new_info = new_error.ExtraInfo();
@@ -159,17 +185,12 @@ static bool CombineMissingColumns(ErrorData &current, ErrorData new_error) {
 	}
 	// get a new top-n
 	auto top_candidates = StringUtil::TopNStrings(scores);
-	// get query location
-	QueryErrorContext context;
-	current_entry = current_info.find("position");
-	new_entry = new_info.find("position");
-	uint64_t position;
-	if (current_entry != current_info.end() &&
-	    TryCast::Operation<string_t, uint64_t>(current_entry->second, position)) {
-		context = QueryErrorContext(position);
-	} else if (new_entry != new_info.end() && TryCast::Operation<string_t, uint64_t>(new_entry->second, position)) {
-		context = QueryErrorContext(position);
+	// get query location (prefer the current error's span, fall back to the new error's)
+	auto span = ExtractSpan(current_info);
+	if (!span.IsValid()) {
+		span = ExtractSpan(new_info);
 	}
+	QueryErrorContext context(span);
 	// generate a new (combined) error
 	current = BinderException::ColumnNotFound(Identifier(column_name), StringsToIdentifiers(top_candidates), context);
 	return true;

--- a/src/planner/expression_binder.cpp
+++ b/src/planner/expression_binder.cpp
@@ -98,30 +98,30 @@ BindResult ExpressionBinder::BindExpression(unique_ptr<ParsedExpression> &expr, 
 	}
 }
 
-//! Reconstruct the source span from an error's extra info (prefers "span" so the length is kept)
-static Span ExtractSpan(const unordered_map<string, string> &info) {
+//! Reconstruct the source location from an error's extra info (prefers "location" so the length is kept)
+static QueryLocation ExtractLocation(const unordered_map<string, string> &info) {
 	auto pos_entry = info.find("position");
 	if (pos_entry == info.end()) {
-		return Span();
+		return QueryLocation();
 	}
 	uint64_t start;
 	if (!TryCast::Operation<string_t, uint64_t>(string_t(pos_entry->second), start)) {
-		return Span();
+		return QueryLocation();
 	}
 	uint64_t length = 0;
-	auto span_entry = info.find("span");
-	if (span_entry != info.end()) {
+	auto location_entry = info.find("location");
+	if (location_entry != info.end()) {
 		// value is formatted as "[start,length]"
-		auto comma = span_entry->second.find(',');
+		auto comma = location_entry->second.find(',');
 		if (comma != string::npos) {
-			auto len_str = span_entry->second.substr(comma + 1);
+			auto len_str = location_entry->second.substr(comma + 1);
 			if (!len_str.empty() && len_str.back() == ']') {
 				len_str.pop_back();
 			}
 			TryCast::Operation<string_t, uint64_t>(string_t(len_str), length);
 		}
 	}
-	return Span(start, length);
+	return QueryLocation(start, length);
 }
 
 static bool CombineMissingColumns(ErrorData &current, ErrorData new_error) {
@@ -185,12 +185,12 @@ static bool CombineMissingColumns(ErrorData &current, ErrorData new_error) {
 	}
 	// get a new top-n
 	auto top_candidates = StringUtil::TopNStrings(scores);
-	// get query location (prefer the current error's span, fall back to the new error's)
-	auto span = ExtractSpan(current_info);
-	if (!span.IsValid()) {
-		span = ExtractSpan(new_info);
+	// get query location (prefer the current error's location, fall back to the new error's)
+	auto location = ExtractLocation(current_info);
+	if (!location.IsValid()) {
+		location = ExtractLocation(new_info);
 	}
-	QueryErrorContext context(span);
+	QueryErrorContext context(location);
 	// generate a new (combined) error
 	current = BinderException::ColumnNotFound(Identifier(column_name), StringsToIdentifiers(top_candidates), context);
 	return true;

--- a/src/planner/statement_preprocessor.cpp
+++ b/src/planner/statement_preprocessor.cpp
@@ -107,7 +107,7 @@ void UnpackMultiStatement(MultiStatement &multi_statement, const CurrentTransact
 vector<unique_ptr<SQLStatement>> StatementPreprocessor::TryReparsePragma(unique_ptr<SQLStatement> statement) const {
 	// Try reparsing
 	const auto info = statement->Cast<PragmaStatement>().info->Copy();
-	QueryErrorContext error_context(statement->stmt_location);
+	QueryErrorContext error_context(statement->stmt_span);
 	const auto binder = Binder::CreateBinder(context);
 	const auto bound_info = binder->BindPragma(*info, error_context);
 	if (bound_info->function.query) {

--- a/src/planner/statement_preprocessor.cpp
+++ b/src/planner/statement_preprocessor.cpp
@@ -107,7 +107,7 @@ void UnpackMultiStatement(MultiStatement &multi_statement, const CurrentTransact
 vector<unique_ptr<SQLStatement>> StatementPreprocessor::TryReparsePragma(unique_ptr<SQLStatement> statement) const {
 	// Try reparsing
 	const auto info = statement->Cast<PragmaStatement>().info->Copy();
-	QueryErrorContext error_context(statement->stmt_span);
+	QueryErrorContext error_context(statement->stmt_location);
 	const auto binder = Binder::CreateBinder(context);
 	const auto bound_info = binder->BindPragma(*info, error_context);
 	if (bound_info->function.query) {

--- a/src/storage/serialization/serialize_expression.cpp
+++ b/src/storage/serialization/serialize_expression.cpp
@@ -17,6 +17,9 @@ void Expression::Serialize(Serializer &serializer) const {
 	serializer.WriteProperty<ExpressionType>(101, "type", type);
 	serializer.WritePropertyWithDefault<Identifier>(102, "alias", alias);
 	serializer.WritePropertyWithDefault<optional_idx>(103, "query_location", query_location, optional_idx());
+	if (serializer.ShouldSerialize(StorageVersion::V2_0_0)) {
+		serializer.WritePropertyWithDefault<uint32_t>(104, "query_location_length", query_location.length, 0);
+	}
 }
 
 unique_ptr<Expression> Expression::Deserialize(Deserializer &deserializer) {
@@ -24,6 +27,7 @@ unique_ptr<Expression> Expression::Deserialize(Deserializer &deserializer) {
 	auto type = deserializer.ReadProperty<ExpressionType>(101, "type");
 	auto alias = deserializer.ReadPropertyWithDefault<Identifier>(102, "alias");
 	auto query_location = deserializer.ReadPropertyWithExplicitDefault<optional_idx>(103, "query_location", optional_idx());
+	auto query_location_length = deserializer.ReadPropertyWithExplicitDefault<uint32_t>(104, "query_location_length", 0);
 	deserializer.Set<ExpressionType>(type);
 	unique_ptr<Expression> result;
 	switch (expression_class) {
@@ -84,6 +88,7 @@ unique_ptr<Expression> Expression::Deserialize(Deserializer &deserializer) {
 	deserializer.Unset<ExpressionType>();
 	result->alias = std::move(alias);
 	result->query_location = query_location;
+	result->query_location.length = query_location_length;
 	return result;
 }
 

--- a/src/storage/serialization/serialize_parsed_expression.cpp
+++ b/src/storage/serialization/serialize_parsed_expression.cpp
@@ -14,6 +14,9 @@ void ParsedExpression::Serialize(Serializer &serializer) const {
 	serializer.WriteProperty<ExpressionType>(101, "type", type);
 	serializer.WritePropertyWithDefault<Identifier>(102, "alias", alias);
 	serializer.WritePropertyWithDefault<optional_idx>(103, "query_location", query_location, optional_idx());
+	if (serializer.ShouldSerialize(StorageVersion::V2_0_0)) {
+		serializer.WritePropertyWithDefault<uint32_t>(104, "query_location_length", query_location.length, 0);
+	}
 }
 
 unique_ptr<ParsedExpression> ParsedExpression::Deserialize(Deserializer &deserializer) {
@@ -21,6 +24,7 @@ unique_ptr<ParsedExpression> ParsedExpression::Deserialize(Deserializer &deseria
 	auto type = deserializer.ReadProperty<ExpressionType>(101, "type");
 	auto alias = deserializer.ReadPropertyWithDefault<Identifier>(102, "alias");
 	auto query_location = deserializer.ReadPropertyWithExplicitDefault<optional_idx>(103, "query_location", optional_idx());
+	auto query_location_length = deserializer.ReadPropertyWithExplicitDefault<uint32_t>(104, "query_location_length", 0);
 	deserializer.Set<ExpressionType>(type);
 	unique_ptr<ParsedExpression> result;
 	switch (expression_class) {
@@ -87,6 +91,7 @@ unique_ptr<ParsedExpression> ParsedExpression::Deserialize(Deserializer &deseria
 	deserializer.Unset<ExpressionType>();
 	result->alias = std::move(alias);
 	result->query_location = query_location;
+	result->query_location.length = query_location_length;
 	return result;
 }
 

--- a/src/storage/serialization/serialize_tableref.cpp
+++ b/src/storage/serialization/serialize_tableref.cpp
@@ -15,6 +15,9 @@ void TableRef::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<Identifier>(101, "alias", alias);
 	serializer.WritePropertyWithDefault<unique_ptr<SampleOptions>>(102, "sample", sample);
 	serializer.WritePropertyWithDefault<optional_idx>(103, "query_location", query_location, optional_idx());
+	if (serializer.ShouldSerialize(StorageVersion::V2_0_0)) {
+		serializer.WritePropertyWithDefault<uint32_t>(104, "query_location_length", query_location.length, 0);
+	}
 }
 
 unique_ptr<TableRef> TableRef::Deserialize(Deserializer &deserializer) {
@@ -22,6 +25,7 @@ unique_ptr<TableRef> TableRef::Deserialize(Deserializer &deserializer) {
 	auto alias = deserializer.ReadPropertyWithDefault<Identifier>(101, "alias");
 	auto sample = deserializer.ReadPropertyWithDefault<unique_ptr<SampleOptions>>(102, "sample");
 	auto query_location = deserializer.ReadPropertyWithExplicitDefault<optional_idx>(103, "query_location", optional_idx());
+	auto query_location_length = deserializer.ReadPropertyWithExplicitDefault<uint32_t>(104, "query_location_length", 0);
 	unique_ptr<TableRef> result;
 	switch (type) {
 	case TableReferenceType::BASE_TABLE:
@@ -57,6 +61,7 @@ unique_ptr<TableRef> TableRef::Deserialize(Deserializer &deserializer) {
 	result->alias = std::move(alias);
 	result->sample = std::move(sample);
 	result->query_location = query_location;
+	result->query_location.length = query_location_length;
 	return result;
 }
 

--- a/test/api/test_parse_statement_iterator.cpp
+++ b/test/api/test_parse_statement_iterator.cpp
@@ -162,8 +162,8 @@ TEST_CASE("ParseIterator: statement query text is populated and normalized", "[a
 	REQUIRE(s0);
 	REQUIRE(StringUtil::Contains(s0->query, "SELECT 1"));
 	REQUIRE_FALSE(StringUtil::Contains(s0->query, "SELECT 2"));
-	REQUIRE(s0->stmt_span.offset == 0);
-	REQUIRE(s0->stmt_span.length == s0->query.size());
+	REQUIRE(s0->stmt_location.offset == 0);
+	REQUIRE(s0->stmt_location.length == s0->query.size());
 
 	Parser reparser(ctx.GetParserOptions());
 	reparser.ParseQuery(s0->query);

--- a/test/api/test_parse_statement_iterator.cpp
+++ b/test/api/test_parse_statement_iterator.cpp
@@ -162,8 +162,8 @@ TEST_CASE("ParseIterator: statement query text is populated and normalized", "[a
 	REQUIRE(s0);
 	REQUIRE(StringUtil::Contains(s0->query, "SELECT 1"));
 	REQUIRE_FALSE(StringUtil::Contains(s0->query, "SELECT 2"));
-	REQUIRE(s0->stmt_location == 0);
-	REQUIRE(s0->stmt_length == s0->query.size());
+	REQUIRE(s0->stmt_span.offset == 0);
+	REQUIRE(s0->stmt_span.length == s0->query.size());
 
 	Parser reparser(ctx.GetParserOptions());
 	reparser.ParseQuery(s0->query);

--- a/test/api/test_plan_serialization.cpp
+++ b/test/api/test_plan_serialization.cpp
@@ -25,7 +25,8 @@ static void test_helper(string sql, duckdb::vector<string> fixtures = duckdb::ve
 	for (auto &statement : p.statements) {
 		con.context->transaction.BeginTransaction();
 		// Should that be the default "ToString"?
-		string statement_sql(statement->query.c_str() + statement->stmt_span.offset, statement->stmt_span.length);
+		string statement_sql(statement->query.c_str() + statement->stmt_location.offset,
+		                     statement->stmt_location.length);
 		Planner planner(*con.context);
 		planner.CreatePlan(std::move(statement));
 		auto plan = std::move(planner.plan);
@@ -57,7 +58,8 @@ static void test_helper_multi_db(string sql, duckdb::vector<string> fixtures = d
 	for (auto &statement : p.statements) {
 		con.context->transaction.BeginTransaction();
 		// Should that be the default "ToString"?
-		string statement_sql(statement->query.c_str() + statement->stmt_span.offset, statement->stmt_span.length);
+		string statement_sql(statement->query.c_str() + statement->stmt_location.offset,
+		                     statement->stmt_location.length);
 		Planner planner(*con.context);
 		planner.CreatePlan(std::move(statement));
 		auto plan = std::move(planner.plan);

--- a/test/api/test_plan_serialization.cpp
+++ b/test/api/test_plan_serialization.cpp
@@ -25,7 +25,7 @@ static void test_helper(string sql, duckdb::vector<string> fixtures = duckdb::ve
 	for (auto &statement : p.statements) {
 		con.context->transaction.BeginTransaction();
 		// Should that be the default "ToString"?
-		string statement_sql(statement->query.c_str() + statement->stmt_location, statement->stmt_length);
+		string statement_sql(statement->query.c_str() + statement->stmt_span.offset, statement->stmt_span.length);
 		Planner planner(*con.context);
 		planner.CreatePlan(std::move(statement));
 		auto plan = std::move(planner.plan);
@@ -57,7 +57,7 @@ static void test_helper_multi_db(string sql, duckdb::vector<string> fixtures = d
 	for (auto &statement : p.statements) {
 		con.context->transaction.BeginTransaction();
 		// Should that be the default "ToString"?
-		string statement_sql(statement->query.c_str() + statement->stmt_location, statement->stmt_length);
+		string statement_sql(statement->query.c_str() + statement->stmt_span.offset, statement->stmt_span.length);
 		Planner planner(*con.context);
 		planner.CreatePlan(std::move(statement));
 		auto plan = std::move(planner.plan);

--- a/test/api/test_prepared_api.cpp
+++ b/test/api/test_prepared_api.cpp
@@ -403,7 +403,7 @@ TEST_CASE("PREPARE multiple statements", "[prepared]") {
 	// we can use ExtractStatements to execute the individual statements though
 	auto statements = con.ExtractStatements(query);
 	for (auto &statement : statements) {
-		string stmt = query.substr(statement->stmt_span.offset, statement->stmt_span.length);
+		string stmt = query.substr(statement->stmt_location.offset, statement->stmt_location.length);
 		prepared = con.Prepare(stmt);
 		REQUIRE(!prepared->HasError());
 

--- a/test/api/test_prepared_api.cpp
+++ b/test/api/test_prepared_api.cpp
@@ -403,7 +403,7 @@ TEST_CASE("PREPARE multiple statements", "[prepared]") {
 	// we can use ExtractStatements to execute the individual statements though
 	auto statements = con.ExtractStatements(query);
 	for (auto &statement : statements) {
-		string stmt = query.substr(statement->stmt_location, statement->stmt_length);
+		string stmt = query.substr(statement->stmt_span.offset, statement->stmt_span.length);
 		prepared = con.Prepare(stmt);
 		REQUIRE(!prepared->HasError());
 

--- a/test/common/test_parse_expression.cpp
+++ b/test/common/test_parse_expression.cpp
@@ -1,9 +1,60 @@
 #include "catch.hpp"
 #include "duckdb/parser/parser.hpp"
+#include "duckdb/common/span.hpp"
 #include "test_helpers.hpp"
 
 using namespace duckdb;
 using namespace std;
+
+TEST_CASE("Span type semantics", "[parse_expression]") {
+	// invalid sentinel (used for synthesized expressions with no source location)
+	REQUIRE(!Span().IsValid());
+	REQUIRE(!Span::Invalid().IsValid());
+
+	Span s(5, 3);
+	REQUIRE(s.IsValid());
+	REQUIRE(s.Start() == 5);
+	REQUIRE(s.End() == 8);
+
+	// trivial conversion both ways with optional_idx
+	optional_idx as_idx = s;
+	REQUIRE(as_idx.GetIndex() == 5);
+	Span from_idx = optional_idx(9);
+	REQUIRE(from_idx.offset == 9);
+	REQUIRE(from_idx.length == 0);
+	REQUIRE(!Span(optional_idx()).IsValid());
+
+	// merge produces the smallest enclosing span and ignores invalid spans
+	auto merged = Span(2, 2).Merge(Span(6, 1)); // [2,4) U [6,7) -> [2,7)
+	REQUIRE(merged.offset == 2);
+	REQUIRE(merged.length == 5);
+	REQUIRE(Span(2, 2).Merge(Span::Invalid()) == Span(2, 2));
+	REQUIRE(Span::Invalid().Merge(Span(2, 2)) == Span(2, 2));
+}
+
+TEST_CASE("Parsed expressions carry source spans", "[parse_expression]") {
+	// Note: ParseExpressionList wraps the input in a SELECT, so offsets are relative to that wrapper.
+	// The span length is what matters here and is independent of the wrapper.
+
+	// a numeric constant spans its own token
+	auto result = Parser::ParseExpressionList("42");
+	REQUIRE(result.size() == 1);
+	auto span = result[0]->GetQueryLocation();
+	REQUIRE(span.IsValid());
+	REQUIRE(span.length == 2);
+
+	// a column reference encloses the full identifier
+	result = Parser::ParseExpressionList("abc");
+	span = result[0]->GetQueryLocation();
+	REQUIRE(span.IsValid());
+	REQUIRE(span.length == 3);
+
+	// a qualified column reference encloses the whole qualified name (tbl.abc)
+	result = Parser::ParseExpressionList("tbl.abc");
+	span = result[0]->GetQueryLocation();
+	REQUIRE(span.IsValid());
+	REQUIRE(span.length == 7);
+}
 
 TEST_CASE("Parse Expression List valid expressions", "[parse_expression]") {
 	auto result = Parser::ParseExpressionList("x");

--- a/test/common/test_parse_expression.cpp
+++ b/test/common/test_parse_expression.cpp
@@ -1,59 +1,59 @@
 #include "catch.hpp"
 #include "duckdb/parser/parser.hpp"
-#include "duckdb/common/span.hpp"
+#include "duckdb/common/query_location.hpp"
 #include "test_helpers.hpp"
 
 using namespace duckdb;
 using namespace std;
 
-TEST_CASE("Span type semantics", "[parse_expression]") {
+TEST_CASE("QueryLocation type semantics", "[parse_expression]") {
 	// invalid sentinel (used for synthesized expressions with no source location)
-	REQUIRE(!Span().IsValid());
-	REQUIRE(!Span::Invalid().IsValid());
+	REQUIRE(!QueryLocation().IsValid());
+	REQUIRE(!QueryLocation::Invalid().IsValid());
 
-	Span s(5, 3);
-	REQUIRE(s.IsValid());
-	REQUIRE(s.Start() == 5);
-	REQUIRE(s.End() == 8);
+	QueryLocation location(5, 3);
+	REQUIRE(location.IsValid());
+	REQUIRE(location.Start() == 5);
+	REQUIRE(location.End() == 8);
 
 	// trivial conversion both ways with optional_idx
-	optional_idx as_idx = s;
+	optional_idx as_idx = location;
 	REQUIRE(as_idx.GetIndex() == 5);
-	Span from_idx = optional_idx(9);
+	QueryLocation from_idx = optional_idx(9);
 	REQUIRE(from_idx.offset == 9);
 	REQUIRE(from_idx.length == 0);
-	REQUIRE(!Span(optional_idx()).IsValid());
+	REQUIRE(!QueryLocation(optional_idx()).IsValid());
 
-	// merge produces the smallest enclosing span and ignores invalid spans
-	auto merged = Span(2, 2).Merge(Span(6, 1)); // [2,4) U [6,7) -> [2,7)
+	// merge produces the smallest enclosing location and ignores invalid locations
+	auto merged = QueryLocation(2, 2).Merge(QueryLocation(6, 1)); // [2,4) U [6,7) -> [2,7)
 	REQUIRE(merged.offset == 2);
 	REQUIRE(merged.length == 5);
-	REQUIRE(Span(2, 2).Merge(Span::Invalid()) == Span(2, 2));
-	REQUIRE(Span::Invalid().Merge(Span(2, 2)) == Span(2, 2));
+	REQUIRE(QueryLocation(2, 2).Merge(QueryLocation::Invalid()) == QueryLocation(2, 2));
+	REQUIRE(QueryLocation::Invalid().Merge(QueryLocation(2, 2)) == QueryLocation(2, 2));
 }
 
-TEST_CASE("Parsed expressions carry source spans", "[parse_expression]") {
+TEST_CASE("Parsed expressions carry source locations", "[parse_expression]") {
 	// Note: ParseExpressionList wraps the input in a SELECT, so offsets are relative to that wrapper.
-	// The span length is what matters here and is independent of the wrapper.
+	// The location length is what matters here and is independent of the wrapper.
 
 	// a numeric constant spans its own token
 	auto result = Parser::ParseExpressionList("42");
 	REQUIRE(result.size() == 1);
-	auto span = result[0]->GetQueryLocation();
-	REQUIRE(span.IsValid());
-	REQUIRE(span.length == 2);
+	auto location = result[0]->GetQueryLocation();
+	REQUIRE(location.IsValid());
+	REQUIRE(location.length == 2);
 
 	// a column reference encloses the full identifier
 	result = Parser::ParseExpressionList("abc");
-	span = result[0]->GetQueryLocation();
-	REQUIRE(span.IsValid());
-	REQUIRE(span.length == 3);
+	location = result[0]->GetQueryLocation();
+	REQUIRE(location.IsValid());
+	REQUIRE(location.length == 3);
 
 	// a qualified column reference encloses the whole qualified name (tbl.abc)
 	result = Parser::ParseExpressionList("tbl.abc");
-	span = result[0]->GetQueryLocation();
-	REQUIRE(span.IsValid());
-	REQUIRE(span.length == 7);
+	location = result[0]->GetQueryLocation();
+	REQUIRE(location.IsValid());
+	REQUIRE(location.length == 7);
 }
 
 TEST_CASE("Parse Expression List valid expressions", "[parse_expression]") {

--- a/test/configs/verify_statement_explain.json
+++ b/test/configs/verify_statement_explain.json
@@ -27,16 +27,12 @@
     {
       "reason": "Random errors",
       "paths": [
-        "test/sql/binder/column_ref_as_alias.test",
-        "test/sql/cast/cast_error_location.test",
         "test/sql/pragma/test_pragma_sanitized_inputs.test",
         "test/sql/storage/wal/wal_autocheckpoint_entries.test",
         "test/sql/transactions/statement-preprocessor/multistatement_is_transactional.test",
         "test/sql/transactions/statement-preprocessor/multistatement_is_transactional_chained_PRAGMA.test",
         "test/sql/copy/csv/glob/read_csv_glob.test",
         "test/sql/copy/parquet/parquet_list.test",
-        "test/sql/error/lineitem_errors.test",
-        "test/sql/error/qualified_column_error.test",
         "test/sql/copy_database/copy_table_with_sequence.test",
         "test/sql/copy_database/copy_database_simple.test",
         "test/sql/copy_database/copy_database_errors.test"

--- a/test/sql/error/error_location_multicaret.test
+++ b/test/sql/error/error_location_multicaret.test
@@ -1,0 +1,34 @@
+# name: test/sql/error/error_location_multicaret.test
+# description: Error carets should span the full source range of the offending token
+# group: [error]
+
+# column reference: caret spans the whole column name (foo_bar_col -> 11 carets)
+statement error
+SELECT foo_bar_col FROM (SELECT 1 AS a)
+----
+^^^^^^^^^^^
+
+# qualified table reference: caret spans the whole qualified name (xyz.abc -> 7 carets)
+statement error
+SELECT xyz.abc FROM range(3) t(a)
+----
+^^^^^^^
+
+# syntax error: caret spans the offending token (LAUNCH -> 6 carets)
+statement error
+SELECT 1 WHERE zzz LAUNCH
+----
+^^^^^^
+
+# cast error: caret spans the cast suffix (::utinyint -> 10 carets)
+statement error
+SELECT 12345::utinyint
+----
+^^^^^^^^^^
+
+# single-character identifier still produces a single caret
+statement error
+SELECT q FROM (SELECT 1 AS a)
+----
+LINE 1: SELECT q FROM (SELECT 1 AS a)
+               ^

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -1030,8 +1030,8 @@ SuccessState ShellState::ExecuteSQL(const string &zSql) {
 			if (!statement) {
 				continue; // a peel that preprocessing swallowed
 			}
-			idx_t start_pos = statement->stmt_span.offset;
-			idx_t len = statement->stmt_span.length;
+			idx_t start_pos = statement->stmt_location.offset;
+			idx_t len = statement->stmt_location.length;
 			while (len > 0 && IsSpace(zSql[start_pos])) {
 				start_pos++;
 				len--;

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -1030,8 +1030,8 @@ SuccessState ShellState::ExecuteSQL(const string &zSql) {
 			if (!statement) {
 				continue; // a peel that preprocessing swallowed
 			}
-			idx_t start_pos = statement->stmt_location;
-			idx_t len = statement->stmt_length;
+			idx_t start_pos = statement->stmt_span.offset;
+			idx_t len = statement->stmt_span.length;
 			while (len > 0 && IsSpace(zSql[start_pos])) {
 				start_pos++;
 				len--;


### PR DESCRIPTION
This PR introduces a ~~`Span`~~ `QueryLocation` class which replaces a lot of the `optional_idx query_location` fields that various AST nodes previously carried around. This enables us to print slightly more precise error messages right now, but will also allow us to improve error messages/diagnostics much more in the future.

A `QueryLocation` is basically just a `{offset uint32_t, length uint32_t}` tuple that represent some span of source code, with some conveniences methods to merge or detect invalid spans. 

Using `QueryLocation`s instead of a single `query_location` offset makes the location of internal nodes much clearer to express. E.g. in the case of composite expressions, the location of `a + b` is simply the span containing both the span of `a` and the span of `b` (although we currently don't do this for binary operators, but I'll revisit that in a future PR).

As a first step, this PR makes the formatting of error messages take advantage of this change by printing out multi-character underlines when the error query location has a valid length, e.g:

```sql
select struct_extract((1, 2), add(x,2)) from range(0, 10) r(x);

-- We used to print this:
Binder Error:
The '"index"' argument in function 'struct_extract' must be a constant expression                                                                           
                                                                                                                                                            
LINE 1: select struct_extract((1, 2), add(x,2)) from range(0, 10) r(x);  
                                         ^

-- We now print this: (notice the underlined "add(x,2)")
Binder Error:
The '"index"' argument in function 'struct_extract' must be a constant expression

LINE 1: select struct_extract((1, 2), add(x,2)) from range(0, 10) r(x);
                                      ^^^^^^^^
```
