### PR TITLE
Fix partitioned Parquet writes when SHREDDING names only some VARIANT columns

### DIFF
--- a/extension/parquet/parquet_writer.cpp
+++ b/extension/parquet/parquet_writer.cpp
@@ -1303,6 +1303,19 @@ static bool HasPreparedShreddingTypes(const ShreddingType &shredding_types) {
 	return shredding_types.set || !shredding_types.children.types->empty();
 }
 
+//! The prepared layout only reports shredding derived by analysis; the user's spec is already
+//! in our options, because every file of a COPY is built from the same ParquetOptions.
+static void MergePreparedShreddingTypes(ShreddingType &target, const ShreddingType &source) {
+	for (auto &entry : *source.children.types) {
+		Identifier name(entry.first);
+		if (target.GetChild(name)) {
+			//! An explicit spec wins - a column carrying one is never analyzed
+			continue;
+		}
+		target.AddChild(name, entry.second.Copy());
+	}
+}
+
 void ParquetWriter::InitializeSchemaFromPreparedRowGroup(const PreparedRowGroup &prepared) {
 	auto &layout = prepared.layout;
 	if (file_meta_data.schema.empty()) {
@@ -1310,16 +1323,24 @@ void ParquetWriter::InitializeSchemaFromPreparedRowGroup(const PreparedRowGroup 
 			throw InternalException("Prepared Parquet row group is missing schema");
 		}
 		if (HasPreparedShreddingTypes(layout.shredding_types)) {
-			options.shredding_types = layout.shredding_types.Copy();
+			MergePreparedShreddingTypes(options.shredding_types, layout.shredding_types);
 			InitializeColumnWriters();
 		}
 		auto unique_columns = InitializeColumnWriterSchemaIndices();
-		D_ASSERT(unique_columns == prepared.row_group.columns.size());
 		D_ASSERT(file_meta_data.schema.size() == layout.schema.size());
 		file_meta_data.schema = layout.schema;
 		InitializeColumnOrders(unique_columns);
 	}
 	InitializeStatsUnifiers();
+
+	//! A batch prepared by one file's writer can be flushed into another's. If their leaf
+	//! layouts differ, the leaf indices in the prepared states address the wrong column.
+	if (written_stats && stats_accumulator->stats_unifiers.size() != prepared.row_group.columns.size()) {
+		throw InternalException(
+		    "Parquet writer for '%s' has %llu leaf columns but is flushing a row group prepared with %llu. "
+		    "The prepared layout and the writer's shredding schema disagree.",
+		    options.file_name, stats_accumulator->stats_unifiers.size(), prepared.row_group.columns.size());
+	}
 }
 
 void ParquetWriter::Finalize() {

--- a/extension/parquet/writer/variant/analyze_variant.cpp
+++ b/extension/parquet/writer/variant/analyze_variant.cpp
@@ -238,7 +238,9 @@ bool VariantColumnWriter::TryExportPreparedShreddingType(ShreddingType &result) 
 		result = analyzed_shredding_type.Copy();
 		return true;
 	}
-	return StructColumnWriter::TryExportPreparedShreddingType(result);
+	//! Not delegating to StructColumnWriter: it would report the physical children of an
+	//! already-shredded VARIANT (metadata/value/typed_value) as if they were a shredding spec.
+	return false;
 }
 
 } // namespace duckdb

--- a/test/sql/copy/parquet/partitioned_variant_partial_shredding.test
+++ b/test/sql/copy/parquet/partitioned_variant_partial_shredding.test
@@ -1,0 +1,91 @@
+# name: test/sql/copy/parquet/partitioned_variant_partial_shredding.test
+# description: Partitioned COPY where SHREDDING names only some of the VARIANT columns
+# group: [parquet]
+
+require parquet
+
+# A batch is prepared by the writer of whichever output file was current at the time, but a
+# partitioned COPY can flush it into a different file. The VARIANT column that SHREDDING does
+# not name has its layout derived by analysis, so the two writers must still agree on the leaf
+# columns. They used to not: the receiving writer rebuilt its column writers from the prepared
+# layout, which described the physical children of the already-shredded columns rather than a
+# shredding schema, and came out with fewer leaves than the batch was prepared with. The files
+# were written with corrupt column offsets, or - with RETURN_STATS, where the leaf index is
+# also used to address a stats unifier - the write died on an out-of-bounds access or on
+# "Incorrect size for stats in UnifyMinMax".
+
+statement ok
+CREATE TABLE t AS
+SELECT (i % 3) AS part,
+       {'k': 'v' || (i % 2)}::VARIANT AS shredded,
+       CASE WHEN i % 5 = 0 THEN {'lvl': 'warn'}::VARIANT ELSE ('msg ' || i)::VARIANT END AS unshredded
+FROM range(2000) t(i);
+
+statement ok
+COPY t TO '{TEST_DIR}/partial_shredding' (FORMAT parquet, PARTITION_BY ('part'), OVERWRITE_OR_IGNORE,
+                                          SHREDDING {shredded: 'STRUCT(k VARCHAR)'});
+
+query I
+SELECT count(*) FROM read_parquet('{TEST_DIR}/partial_shredding/**/*.parquet');
+----
+2000
+
+# Every partition was written, and every one of them can be read back
+query I
+SELECT count(DISTINCT filename) FROM read_parquet('{TEST_DIR}/partial_shredding/**/*.parquet', filename = true);
+----
+3
+
+# The named column is shredded on its declared key
+query I
+SELECT count(DISTINCT path_in_schema) FROM parquet_metadata('{TEST_DIR}/partial_shredding/**/*.parquet')
+WHERE path_in_schema = 'shredded, typed_value, k, typed_value';
+----
+1
+
+# The unnamed column keeps whatever layout analysis chose, consistently across partitions
+query I
+SELECT count(DISTINCT path_in_schema) FROM parquet_metadata('{TEST_DIR}/partial_shredding/**/*.parquet')
+WHERE path_in_schema LIKE 'unshredded%';
+----
+3
+
+# Values survive, including the ones that do not fit the shredded layout
+query II
+SELECT count(*), count(*) FILTER (WHERE unshredded.lvl::VARCHAR = 'warn')
+FROM read_parquet('{TEST_DIR}/partial_shredding/**/*.parquet');
+----
+2000	400
+
+query I
+SELECT count(DISTINCT shredded.k::VARCHAR) FROM read_parquet('{TEST_DIR}/partial_shredding/**/*.parquet');
+----
+2
+
+# RETURN_STATS is the path that used to fail loudest: the leaf index also selects a stats unifier
+statement ok
+COPY t TO '{TEST_DIR}/partial_shredding_stats' (FORMAT parquet, PARTITION_BY ('part'), OVERWRITE_OR_IGNORE,
+                                                SHREDDING {shredded: 'STRUCT(k VARCHAR)'}, RETURN_STATS true);
+
+query I
+SELECT count(*) FROM read_parquet('{TEST_DIR}/partial_shredding_stats/**/*.parquet');
+----
+2000
+
+# Naming every VARIANT column, and naming none, were always fine - keep them covered
+statement ok
+COPY t TO '{TEST_DIR}/full_shredding' (FORMAT parquet, PARTITION_BY ('part'), OVERWRITE_OR_IGNORE, RETURN_STATS true,
+                                       SHREDDING {shredded: 'STRUCT(k VARCHAR)', unshredded: 'VARCHAR'});
+
+query I
+SELECT count(*) FROM read_parquet('{TEST_DIR}/full_shredding/**/*.parquet');
+----
+2000
+
+statement ok
+COPY t TO '{TEST_DIR}/no_shredding' (FORMAT parquet, PARTITION_BY ('part'), OVERWRITE_OR_IGNORE, RETURN_STATS true);
+
+query I
+SELECT count(*) FROM read_parquet('{TEST_DIR}/no_shredding/**/*.parquet');
+----
+2000


### PR DESCRIPTION
A partitioned COPY prepares a batch with the writer of whichever output file is
current at the time, then flushes it into whichever file is current when the
flush runs - not necessarily the same one. Both writers are built from the same
ParquetOptions, so they only ever disagree about shredding a writer derived for
itself by analysis. The prepared layout exists to carry that across.

It carried the wrong thing. ColumnWriter::TryExportPreparedShreddingType walks
the physical child writers, so a VARIANT already shredded from an explicit spec
exported a ShreddingType whose children were metadata, value and typed_value
rather than the user's field types. InitializeSchemaFromPreparedRowGroup fed
that back through InitializeColumnWriters(), building a tree matching neither
the prepared batch nor the writer's own options, and the rebuild replaced
options.shredding_types outright, dropping the explicit spec for every column
analysis had nothing to say about. On a table with two VARIANTs and a spec
naming one: batch prepared with 12 leaf columns, receiving writer had 11, and
rebuilding from the exported layout left it with 8.

The stale leaf index then addressed the wrong column. Without RETURN_STATS that
wrote files with invalid column offsets, readable only as "metadata is corrupt".
With it the index also selects a stats unifier, giving "Attempted to access
index N within vector of size N" or, when it landed in range, "Incorrect size
for stats in UnifyMinMax".

Unpartitioned writes were unaffected - one writer prepares and flushes every
batch. Naming every VARIANT column was safe too, since then nothing is analyzed
and there is nothing to export.

- VariantColumnWriter::TryExportPreparedShreddingType reports only what analysis
  derived, instead of falling back to the generic implementation.
- InitializeSchemaFromPreparedRowGroup merges the prepared shredding types into
  options.shredding_types, so an explicit spec survives and wins.
- The writer's leaf count is checked against the prepared row group in release
  builds. VerifyPreparedRowGroup already asserted this, but only under D_ASSERT,
  which is why the mismatch escaped.