### PR TITLE
Fix INSTEAD OF triggers being silently accepted on base tables

### DIFF
--- a/src/planner/binder/statement/bind_create.cpp
+++ b/src/planner/binder/statement/bind_create.cpp
@@ -617,6 +617,10 @@ SchemaCatalogEntry &Binder::BindCreateTriggerInfo(CreateTriggerInfo &create_trig
 		}
 	}
 
+	if (create_trigger_info.timing == TriggerTiming::INSTEAD_OF) {
+		throw NotImplementedException("INSTEAD OF triggers are not yet supported");
+	}
+
 	// Validate UPDATE OF columns exist
 	if (create_trigger_info.event_type == TriggerEventType::UPDATE_EVENT && !create_trigger_info.columns.empty()) {
 		for (const auto &col_name : create_trigger_info.columns) {

--- a/test/sql/trigger/create_trigger_parse.test
+++ b/test/sql/trigger/create_trigger_parse.test
@@ -104,6 +104,13 @@ CREATE TRIGGER trg_on_view AFTER INSERT ON base_view FOR EACH STATEMENT
 ----
 CREATE TRIGGER requires a base table, not a view or subquery
 
+# INSTEAD OF triggers are not yet supported (even on a base table)
+statement error
+CREATE TRIGGER trg_instead_of INSTEAD OF INSERT ON base_tbl FOR EACH STATEMENT
+    INSERT INTO base_tbl VALUES (1);
+----
+INSTEAD OF triggers are not yet supported
+
 # CREATE TRIGGER on a non-DuckDB table is rejected
 require sqlite_scanner
 


### PR DESCRIPTION
## Summary

Fixes #23858.

`INSTEAD OF` triggers on base tables were silently accepted by the binder but never fired — the DML executed normally as if no trigger existed, causing silent data loss.

- Reject `INSTEAD OF` triggers at bind time in `BindCreateTriggerInfo` with a clear `NotImplementedException: INSTEAD OF triggers are not yet supported`
- Added a test case in `create_trigger_parse.test` verifying the error is raised

## Background

As a first step, `INSTEAD OF` triggers are now rejected at bind time with a clear `NotImplementedException`. This is the correct behavior since `INSTEAD OF` triggers have no defined semantics on base tables in standard SQL — they only make sense on views (as implemented in PostgreSQL), where they allow DML on non-updatable views to be redirected to custom logic.

If there is demand in the future, we can add proper `INSTEAD OF` trigger support scoped to views only, following the PostgreSQL model. That work is non-trivial (it requires view DML rewriting at the binder level) and is better handled as a separate feature rather than leaving a silently broken stub in place.

## Test plan

- [ ] `build/reldebug/test/unittest "test/sql/trigger/*"` — all 23 trigger test cases pass (1636 assertions)
- [ ] `CREATE TRIGGER ... INSTEAD OF INSERT ON base_table ...` now raises `Not implemented Error: INSTEAD OF triggers are not yet supported`
- [ ] `BEFORE` and `AFTER` triggers continue to work correctly
