### PR TITLE
Regression test OVERWRITE vs OVERWRITE_OR_IGNORE for partitioned COPY

### DIFF
--- a/test/sql/copy/partitioned/hive_partitioning_overwrite.test
+++ b/test/sql/copy/partitioned/hive_partitioning_overwrite.test
@@ -45,3 +45,131 @@ statement error
 COPY (SELECT 84 AS part_col) TO '{TEST_DIR}/overwrite_test' (FORMAT PARQUET, PARTITION_BY (part_col), OVERWRITE 1, OVERWRITE_OR_IGNORE 1);
 ----
 OVERWRITE
+
+# === Issue #10282: multi-thread write then fewer-thread rewrite ===
+# OVERWRITE must recursively clear so orphan data_N.parquet files / partitions do not remain.
+# OVERWRITE_OR_IGNORE intentionally does NOT clear; it only clobbers same filenames.
+
+# Multi-threaded write creates multiple data_*.parquet files per partition
+statement ok
+SET threads = 4;
+
+statement ok
+COPY (
+	SELECT range % 2 AS p, range AS v
+	FROM range(100_000)
+) TO '{TEST_DIR}/mt_overwrite' (FORMAT PARQUET, PARTITION_BY (p));
+
+# Several files from parallel writers
+query I
+SELECT count(*) >= 2 FROM glob('{TEST_DIR}/mt_overwrite/**/*.parquet');
+----
+true
+
+query II
+SELECT p, count(*)
+FROM read_parquet('{TEST_DIR}/mt_overwrite/**/*.parquet', hive_partitioning = true)
+GROUP BY p
+ORDER BY p;
+----
+0	50000
+1	50000
+
+# Single-threaded rewrite of a smaller dataset with OVERWRITE: orphans must be gone
+statement ok
+SET threads = 1;
+
+statement ok
+COPY (
+	SELECT range % 2 AS p, range AS v
+	FROM range(100)
+) TO '{TEST_DIR}/mt_overwrite' (FORMAT PARQUET, PARTITION_BY (p), OVERWRITE);
+
+# One file per partition (single thread)
+query I
+SELECT count(*) FROM glob('{TEST_DIR}/mt_overwrite/**/*.parquet');
+----
+2
+
+query II
+SELECT p, count(*)
+FROM read_parquet('{TEST_DIR}/mt_overwrite/**/*.parquet', hive_partitioning = true)
+GROUP BY p
+ORDER BY p;
+----
+0	50
+1	50
+
+# OVERWRITE also drops partition directories that no longer appear in the data
+statement ok
+SET threads = 4;
+
+statement ok
+COPY (
+	SELECT range % 3 AS p, range AS v
+	FROM range(30_000)
+) TO '{TEST_DIR}/mt_overwrite_parts' (FORMAT PARQUET, PARTITION_BY (p), OVERWRITE);
+
+query I
+SELECT count(DISTINCT p)
+FROM read_parquet('{TEST_DIR}/mt_overwrite_parts/**/*.parquet', hive_partitioning = true);
+----
+3
+
+statement ok
+SET threads = 1;
+
+statement ok
+COPY (
+	SELECT 0 AS p, range AS v
+	FROM range(10)
+) TO '{TEST_DIR}/mt_overwrite_parts' (FORMAT PARQUET, PARTITION_BY (p), OVERWRITE);
+
+query I
+SELECT count(*) FROM glob('{TEST_DIR}/mt_overwrite_parts/**/*.parquet');
+----
+1
+
+query II
+SELECT p, count(*)
+FROM read_parquet('{TEST_DIR}/mt_overwrite_parts/**/*.parquet', hive_partitioning = true)
+GROUP BY ALL
+ORDER BY ALL;
+----
+0	10
+
+# Separate case: OVERWRITE_OR_IGNORE leaves partition dirs that the new write does not touch
+# (intentional after #12240 — use OVERWRITE for idempotent rebuilds)
+statement ok
+SET threads = 1;
+
+statement ok
+COPY (
+	SELECT range % 3 AS p, range AS v
+	FROM range(300)
+) TO '{TEMP_DIR}/or_ignore_parts' (FORMAT PARQUET, PARTITION_BY (p));
+
+query I
+SELECT count(DISTINCT p)
+FROM read_parquet('{TEMP_DIR}/or_ignore_parts/**/*.parquet', hive_partitioning = true);
+----
+3
+
+statement ok
+COPY (
+	SELECT 0 AS p, range AS v
+	FROM range(10)
+) TO '{TEMP_DIR}/or_ignore_parts' (FORMAT PARQUET, PARTITION_BY (p), OVERWRITE_OR_IGNORE);
+
+# Partitions p=1 and p=2 remain
+query I
+SELECT count(DISTINCT p)
+FROM read_parquet('{TEMP_DIR}/or_ignore_parts/**/*.parquet', hive_partitioning = true);
+----
+3
+
+query I
+SELECT count(*) >= 10
+FROM read_parquet('{TEMP_DIR}/or_ignore_parts/**/*.parquet', hive_partitioning = true);
+----
+true


### PR DESCRIPTION
## What the issue is

Partitioned `COPY` with fewer threads than a previous write can leave **orphan `data_N.parquet` files** (and untouched partition directories) when the wrong overwrite flag is used. Readers that glob `**/*.parquet` then mix generations — classic lake “I overwrote the table but old rows came back” failure.

Historical reports (including on 1.4.x) used `OVERWRITE_OR_IGNORE`. After [#12240](https://github.com/duckdb/duckdb/pull/12240) the product split is intentional:

| Mode | Behavior |
|------|----------|
| default | Error if target directory non-empty |
| **`OVERWRITE`** | Recursive clear + rewrite — correct full replace |
| **`OVERWRITE_OR_IGNORE`** | **No directory clear**; clobber same filenames only; leave orphans |

So the bug is often **mis-selected mode** plus missing regression coverage that multi-thread → fewer-thread rewrite with `OVERWRITE` actually drops extras. This PR locks the correct `OVERWRITE` behavior with a multi-thread test and documents (in-test) that `OVERWRITE_OR_IGNORE` deliberately leaves untouched partitions.

Fixes #10282

## Why I solved it that way

- **Do not change `OVERWRITE_OR_IGNORE` to delete again.** That was a deliberate split for append-style workflows (`#12225` / pattern files). Silently flipping it would break those users.
- **Do not attempt remote S3 directory purge in this PR** — large infra surface; local FS semantics are what most CI and the original repro exercise.
- **Ship a hard regression test** for the multi-thread stale-file scenario under `OVERWRITE`, plus an explicit `OVERWRITE_OR_IGNORE` case that *expects* leftover partitions so the intentional behavior cannot rot into “half clear.”

Note: this branch is **test-only** on tip. Runtime `CheckDirectory` / `OVERWRITE` recursive remove already does the right thing on main; the gap was coverage and a clear statement of which flag to use for idempotent rebuilds. If docs still say OR_IGNORE “overwrites directories,” a docs-only follow-up can fix wording — the behavioral contract is asserted here in SQL.

## How I did it

Extended `test/sql/copy/partitioned/hive_partitioning_overwrite.test`:

1. **Multi-thread write** (`SET threads=4`) of 100k rows partitioned by `p` → assert ≥2 parquet files and 50k rows per partition.
2. **Single-thread OVERWRITE** of 100 rows → assert exactly 2 files left, 50 rows per partition (no orphan `data_N` from the 4-thread write).
3. **Partition directory drop:** write 3 partitions, OVERWRITE with only `p=0` → one file, only partition 0.
4. **OR_IGNORE contrast:** write 3 partitions, `OVERWRITE_OR_IGNORE` with only `p=0` → still 3 distinct partitions (orphans remain by design).

Comments in the test spell out the #10282 / #12240 product rule for future readers.

## What the impact is

- **Correctness:** Guards the lake-replace path users actually need (`OVERWRITE`).
- **Compatibility:** No runtime change; OR_IGNORE semantics untouched.
- **DX:** Issue reporters can be pointed at `OVERWRITE` + this test as the supported rebuild recipe.
- **Residual risk:** Remote object stores may still need separate “purge prefix” work — out of scope; local/POSIX behavior is what this locks.

## Testing plan

```bash
GEN=ninja make reldebug
build/reldebug/test/run test/sql/copy/partitioned/hive_partitioning_overwrite.test
```

Manual sketch:

```sql
SET threads=4;
COPY (SELECT range%2 AS p, range AS v FROM range(100000))
TO 'mt' (FORMAT PARQUET, PARTITION_BY (p));

SET threads=1;
COPY (SELECT range%2 AS p, range AS v FROM range(100))
TO 'mt' (FORMAT PARQUET, PARTITION_BY (p), OVERWRITE);

SELECT count(*) FROM glob('mt/**/*.parquet');  -- 2
SELECT p, count(*) FROM read_parquet('mt/**/*.parquet', hive_partitioning=true)
GROUP BY p ORDER BY p;  -- 0|50, 1|50
```

## Everything else

- Related: #12240 (mode split), #12225 (append / ignore behavior).
- Out of scope: making OR_IGNORE recursive-delete; S3/GCS full prefix clear; changing default COPY conflict mode.
- Recommended issue comment: “For idempotent partition rebuilds use `OVERWRITE`. `OVERWRITE_OR_IGNORE` only clobbers colliding filenames and will leave stale `data_N` files when thread counts shrink.”

Suggested reviewers: @Mytherin @pdet
