### PR TITLE
Prefer UTF-8-safe dialects for non-strict CSV auto_detect

### DIFF
--- a/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
+++ b/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
@@ -485,12 +485,9 @@ void StringValueResult::AddValueToVector(const char *value_ptr, idx_t size, bool
 		// We only evaluate if a string is utf8 valid, if it's actually a varchar
 		if (parse_types[chunk_col_id].validate_utf8 &&
 		    !Utf8Proc::IsValid(value_ptr, UnsafeNumericCast<uint32_t>(size))) {
-			bool force_error = !state_machine.options.ignore_errors.GetValue() && sniffing;
-			// Invalid unicode, we must error
-			if (force_error) {
-				HandleUnicodeError(cur_col_id, last_position);
-			}
-			// If we got here, we are ignoring errors, hence we must ignore this line.
+			// During sniffing, record the error instead of force-throwing so DetectTypes can skip
+			// dialects that corrupt multi-byte UTF-8 (issue #23330). Non-sniff scans still surface
+			// INVALID_ENCODING via current_errors / HandleErrors.
 			current_errors.Insert(INVALID_ENCODING, cur_col_id, chunk_col_id, last_position);
 			static_cast<string_t *>(vector_ptr[chunk_col_id])[number_of_rows] = StringVector::AddStringOrBlob(
 			    parse_chunk.data[chunk_col_id], string_t(value_ptr, UnsafeNumericCast<uint32_t>(0)));

--- a/src/execution/operator/csv_scanner/sniffer/csv_sniffer.cpp
+++ b/src/execution/operator/csv_scanner/sniffer/csv_sniffer.cpp
@@ -75,6 +75,17 @@ void CSVSniffer::SetResultOptions() const {
 	                                options.sniffer_user_mismatch_error, found_date, found_timestamp);
 	options.dialect_options.num_cols = best_candidate->GetStateMachine().dialect_options.num_cols;
 	options.dialect_options.rows_until_header = best_candidate->GetStateMachine().dialect_options.rows_until_header;
+
+	// Non-strict mode enables unquoted escape when quote != escape and escape != 0.
+	// That can strip multi-byte UTF-8 (issue #23330). If user did not set escape, prefer quote==escape.
+	auto &state_opts = options.dialect_options.state_machine_options;
+	if (!state_opts.strict_mode.GetValue() && !state_opts.escape.IsSetByUser()) {
+		const auto escape = state_opts.escape.GetValue();
+		const auto quote = state_opts.quote.GetValue();
+		if (escape != '\0' && escape != quote) {
+			state_opts.escape.Set(quote, false);
+		}
+	}
 }
 
 AdaptiveSnifferResult CSVSniffer::MinimalSniff() {

--- a/src/execution/operator/csv_scanner/sniffer/dialect_detection.cpp
+++ b/src/execution/operator/csv_scanner/sniffer/dialect_detection.cpp
@@ -2,6 +2,7 @@
 #include "duckdb/execution/operator/csv_scanner/sniffer/csv_sniffer.hpp"
 #include "duckdb/main/client_data.hpp"
 #include "duckdb/execution/operator/csv_scanner/csv_reader_options.hpp"
+#include <algorithm>
 
 namespace duckdb {
 
@@ -350,8 +351,11 @@ void CSVSniffer::AnalyzeDialectCandidate(unique_ptr<ColumnCountScanner> scanner,
 
 	const bool comments_are_acceptable = AreCommentsAcceptable(sniffed_column_counts, num_cols, options);
 
+	// Only treat clean quoted dialects as "quoted" for preference. Dialects that need
+	// non-strict relaxations (e.g. content after a closing quote) can break multi-byte UTF-8
+	// under strict_mode=false (issue #23330) and must not displace safer no-quote candidates.
 	const bool quoted =
-	    scanner->ever_quoted &&
+	    scanner->ever_quoted && !scanner->used_unstrictness &&
 	    sniffed_column_counts.state_machine.dialect_options.state_machine_options.quote.GetValue() != '\0';
 
 	// For our columns to match, we either don't have them manually set, or they match in value with the sniffed value
@@ -380,9 +384,10 @@ void CSVSniffer::AnalyzeDialectCandidate(unique_ptr<ColumnCountScanner> scanner,
 		}
 		auto &sniffing_state_machine = scanner->GetStateMachine();
 
-		if (!successful_candidates.empty() && successful_candidates.front()->ever_quoted) {
-			// Give preference to quoted boys.
-			if (!scanner->ever_quoted) {
+		if (!successful_candidates.empty() && successful_candidates.front()->ever_quoted &&
+		    !successful_candidates.front()->used_unstrictness) {
+			// Give preference to clean quoted dialects only (see #23330).
+			if (!scanner->ever_quoted || scanner->used_unstrictness) {
 				return;
 			} else {
 				// Give preference to one that got escaped
@@ -453,6 +458,23 @@ void CSVSniffer::AnalyzeDialectCandidate(unique_ptr<ColumnCountScanner> scanner,
 		} else if (!options.null_padding) {
 			sniffing_state_machine.dialect_options.skip_rows = dirty_notes_minus_comments;
 		}
+		// Do not let unstrict dialects wipe safer candidates (issue #23330).
+		if (scanner->used_unstrictness) {
+			bool have_clean = false;
+			for (auto &c : successful_candidates) {
+				if (!c->used_unstrictness) {
+					have_clean = true;
+					break;
+				}
+			}
+			if (have_clean) {
+				// Keep clean candidates; still record this dialect for later ranking if columns match.
+				sniffing_state_machine.dialect_options.num_cols = num_cols;
+				lines_sniffed = sniffed_column_counts.result_position;
+				successful_candidates.emplace_back(std::move(scanner));
+				return;
+			}
+		}
 		successful_candidates.clear();
 		sniffing_state_machine.dialect_options.num_cols = num_cols;
 		lines_sniffed = sniffed_column_counts.result_position;
@@ -505,71 +527,69 @@ void CSVSniffer::RefineCandidates() {
 		// No candidates to refine
 		return;
 	}
-	if (candidates.size() == 1 || candidates[0]->FinishedFile()) {
-		// Only one candidate nothing to refine, or all candidates already checked
+	if (candidates.size() > 1 && !candidates[0]->FinishedFile()) {
+		for (idx_t i = 1; i <= options.sample_size_chunks; i++) {
+			vector<unique_ptr<ColumnCountScanner>> successful_candidates;
+			bool done = candidates.empty();
+			for (auto &cur_candidate : candidates) {
+				const bool finished_file = cur_candidate->FinishedFile();
+				if (successful_candidates.empty()) {
+					lines_sniffed += cur_candidate->GetResult().result_position;
+				}
+				if (finished_file || i == options.sample_size_chunks) {
+					// we finished the file or our chunk sample successfully
+					if (!cur_candidate->GetResult().error) {
+						successful_candidates.push_back(std::move(cur_candidate));
+					}
+					done = true;
+					continue;
+				}
+				if (RefineCandidateNextChunk(*cur_candidate) && !cur_candidate->GetResult().error) {
+					successful_candidates.push_back(std::move(cur_candidate));
+				}
+			}
+			candidates = std::move(successful_candidates);
+			if (done) {
+				break;
+			}
+		}
+	}
+	// Rank remaining dialect candidates. Always run this — including when the sample already
+	// finished the file (small inputs) — so safer dialects win under strict_mode=false (#23330).
+	if (candidates.size() <= 1) {
 		return;
 	}
 
-	for (idx_t i = 1; i <= options.sample_size_chunks; i++) {
-		vector<unique_ptr<ColumnCountScanner>> successful_candidates;
-		bool done = candidates.empty();
-		for (auto &cur_candidate : candidates) {
-			const bool finished_file = cur_candidate->FinishedFile();
-			if (successful_candidates.empty()) {
-				lines_sniffed += cur_candidate->GetResult().result_position;
-			}
-			if (finished_file || i == options.sample_size_chunks) {
-				// we finished the file or our chunk sample successfully
-				if (!cur_candidate->GetResult().error) {
-					successful_candidates.push_back(std::move(cur_candidate));
-				}
-				done = true;
-				continue;
-			}
-			if (RefineCandidateNextChunk(*cur_candidate) && !cur_candidate->GetResult().error) {
-				successful_candidates.push_back(std::move(cur_candidate));
-			}
+	auto is_safe_escape = [](const ColumnCountScanner &scanner) {
+		const auto &opts = scanner.state_machine->state_machine_options;
+		// quote==escape or escape==\0 disables unquoted_escape
+		return opts.escape == '\0' || opts.quote == opts.escape;
+	};
+
+	// Lower score is better.
+	auto candidate_score = [&](const ColumnCountScanner &scanner) {
+		idx_t score = 0;
+		if (scanner.used_unstrictness) {
+			// Penalize dialects that need non-strict relaxations (can break multi-byte UTF-8).
+			score += 1000;
 		}
-		candidates = std::move(successful_candidates);
-		if (done) {
-			break;
+		if (!scanner.ever_quoted) {
+			score += 100;
 		}
-	}
-	// If we have multiple candidates with quotes set, we will give the preference to ones
-	// that have actually quoted values, otherwise we will choose quotes = \0
-	vector<unique_ptr<ColumnCountScanner>> successful_candidates = std::move(candidates);
-	if (!successful_candidates.empty()) {
-		bool ever_quoted = false;
-		for (idx_t i = 0; i < successful_candidates.size(); i++) {
-			unique_ptr<ColumnCountScanner> cc_best_candidate = std::move(successful_candidates[i]);
-			if (cc_best_candidate->ever_quoted) {
-				if (cc_best_candidate->ever_escaped) {
-					// It can't be better than this
-					candidates.clear();
-					candidates.push_back(std::move(cc_best_candidate));
-					return;
-				}
-				if (!ever_quoted) {
-					ever_quoted = true;
-					candidates.clear();
-				}
-				candidates.push_back(std::move(cc_best_candidate));
-			} else if (!ever_quoted) {
-				candidates.push_back(std::move(cc_best_candidate));
-			}
+		if (!is_safe_escape(scanner)) {
+			score += 10;
 		}
-	}
-	if (candidates.size() > 1) {
-		successful_candidates = std::move(candidates);
-		for (idx_t i = 0; i < successful_candidates.size(); i++) {
-			if (successful_candidates[i]->state_machine->state_machine_options.quote ==
-			    successful_candidates[i]->state_machine->state_machine_options.escape) {
-				candidates.push_back(std::move(std::move(successful_candidates[i])));
-				return;
-			}
+		// Prefer dialects that actually saw escapes when quotes are in use.
+		if (scanner.ever_quoted && !scanner.ever_escaped) {
+			score += 1;
 		}
-		candidates.push_back(std::move(std::move(successful_candidates[0])));
-	}
+		return score;
+	};
+
+	stable_sort(candidates.begin(), candidates.end(),
+	            [&](const unique_ptr<ColumnCountScanner> &a, const unique_ptr<ColumnCountScanner> &b) {
+		            return candidate_score(*a) < candidate_score(*b);
+	            });
 }
 
 NewLineIdentifier CSVSniffer::DetectNewLineDelimiter(CSVBufferManager &buffer_manager) {

--- a/src/include/duckdb/execution/operator/csv_scanner/base_scanner.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/base_scanner.hpp
@@ -337,6 +337,9 @@ protected:
 					ever_escaped = true;
 					T::SetEscaped(result);
 				}
+				// UNQUOTED means content continued after a closing quote (non-strict relaxation).
+				// Mark on entry from QUOTED as well as while staying in UNQUOTED (issue #23330).
+				used_unstrictness = true;
 				T::SetUnquoted(result);
 				iterator.pos.buffer_pos++;
 				break;

--- a/test/sql/copy/csv/test_23330_utf8_copy_autodetect.test
+++ b/test/sql/copy/csv/test_23330_utf8_copy_autodetect.test
@@ -1,0 +1,87 @@
+# name: test/sql/copy/csv/test_23330_utf8_copy_autodetect.test
+# description: COPY auto_detect under strict_mode=false must not break valid UTF-8 (issue #23330)
+# group: [csv]
+
+# Repro-shaped pipe-delimited file: leading apostrophe + multi-byte UTF-8 (ã, é, 田)
+statement ok
+COPY (
+	SELECT * FROM (VALUES
+		(2512, 'Abdelwahab, Adil', 'm'),
+		(54, '''Ivanzinho'' Oliveira, Ivã', 'm'),
+		(3, 'José María', 'm'),
+		(4, 'O''Brien', 'm'),
+		(5, '田中太郎', 'm'),
+		(6, 'Müller', 'm')
+	) t(id, name, sex)
+) TO '{TEMP_DIR}/utf8_names.csv' (HEADER true, DELIM '|', QUOTE '');
+
+# read_csv_auto (default strict_mode=true) succeeds
+query I
+SELECT count(*) FROM read_csv_auto('{TEMP_DIR}/utf8_names.csv', delim='|');
+----
+6
+
+query I
+SELECT name FROM read_csv_auto('{TEMP_DIR}/utf8_names.csv', delim='|') WHERE id = 54;
+----
+'Ivanzinho' Oliveira, Ivã
+
+query I
+SELECT name FROM read_csv_auto('{TEMP_DIR}/utf8_names.csv', delim='|') WHERE id = 3;
+----
+José María
+
+# Same options as the issue: COPY with auto_detect + strict_mode false
+statement ok
+CREATE TABLE foo (id BIGINT, name VARCHAR, sex VARCHAR);
+
+statement ok
+COPY foo FROM '{TEMP_DIR}/utf8_names.csv' WITH (
+	format 'csv', delim '|', auto_detect true, header true, strict_mode false
+);
+
+query I
+SELECT count(*) FROM foo;
+----
+6
+
+query I
+SELECT name FROM foo WHERE id = 54;
+----
+'Ivanzinho' Oliveira, Ivã
+
+query I
+SELECT name FROM foo WHERE id = 3;
+----
+José María
+
+query I
+SELECT name FROM foo WHERE id = 5;
+----
+田中太郎
+
+# read_csv with the same non-strict auto_detect path
+query I
+SELECT count(*) FROM read_csv('{TEMP_DIR}/utf8_names.csv', delim='|', header=true, auto_detect=true, strict_mode=false);
+----
+6
+
+# Explicit quote/escape still works when set by the user (no unquoted_escape: quote==escape)
+statement ok
+CREATE TABLE bar AS SELECT * FROM foo LIMIT 0;
+
+statement ok
+COPY bar FROM '{TEMP_DIR}/utf8_names.csv' WITH (
+	format 'csv', delim '|', header true, strict_mode false, quote '"', escape '"'
+);
+
+query I
+SELECT count(*) FROM bar;
+----
+6
+
+# Explicit unquoted-escape remains available when the user sets escape != quote
+query I
+SELECT count(*) FROM read_csv('{DATA_DIR}/csv/unquoted_escape/plain.csv', escape='\', sep=',', strict_mode=false, nullstr='\N');
+----
+10


### PR DESCRIPTION
## Problem

With `strict_mode=false` and `auto_detect=true`, `COPY` / `read_csv` can pick a dialect that enables unquoted escape and then fail valid UTF-8 that `read_csv_auto` (strict default) loads fine. See #23330.

## Solution

When sniffing under non-strict mode, prefer dialect candidates that do not rely on non-strict quote/escape relaxations if they fit the sample equally well. Explicit user-set escape / unquoted-escape behavior is left alone.

Fixes #23330

### Test

```bash
build/reldebug/test/unittest test/sql/copy/csv/test_23330_utf8_copy_autodetect.test
build/reldebug/test/unittest test/sql/copy/csv/unquoted_escape/
```