### PR TITLE
Fix quoting around extension semantic version pattern

### DIFF
--- a/extension/extension_build_tools.cmake
+++ b/extension/extension_build_tools.cmake
@@ -432,7 +432,7 @@ function(duckdb_extension_generate_version OUTPUT_VAR WORKING_DIR)
             message(FATAL_ERROR "git is available (at ${GIT_EXECUTABLE}) but has failed to execute 'log -1 --format=%h'.")
         endif()
         execute_process(
-                COMMAND ${GIT_EXECUTABLE} describe --tags --always --match '${VERSIONING_TAG_MATCH}'
+                COMMAND ${GIT_EXECUTABLE} describe --tags --always --match "${VERSIONING_TAG_MATCH}"
                 WORKING_DIRECTORY ${WORKING_DIR}
                 RESULT_VARIABLE GIT_RESULT
                 OUTPUT_VARIABLE GIT_DESCRIBE


### PR DESCRIPTION
 CMake recognizes double quotes as CMake syntax, but not single quotes. Therefore the single quotes become literal characters in the argument sent to Git.

The intended argument list is:

```
[git, describe, --tags, --always, --match, v*.*.*]
```

The actual argument list is effectively:

```
[git, describe, --tags, --always, --match, 'v*.*.*']
```

Since no tag matches the `'v.*.*.*'` pattern that makes the `EXT_VERSION_*` macro be the commit hash instead of the semantic version tag.