### PR TITLE
Fix fill() interpolation for large DOUBLE ordering spans

### DIFF
--- a/src/function/window/window_value_function.cpp
+++ b/src/function/window/window_value_function.cpp
@@ -1249,12 +1249,17 @@ static double FillSlopeFunc(WindowCursor &cursor, idx_t row_idx, idx_t prev_vali
 	const auto x0 = LossyFillCast<double>(cursor.GetCell<T>(0, prev_valid));
 	const auto x1 = LossyFillCast<double>(cursor.GetCell<T>(0, next_valid));
 
-	const auto den = (x1 - x0);
+	auto den = (x1 - x0);
 	if (den == 0) {
 		// Duplicate X values, so pick the first.
 		return 0;
 	}
-	const auto num = (x - x0);
+	auto num = x - x0;
+	if (!std::isfinite(den)) {
+		const auto scale = MaxValue(std::abs(x0), std::abs(x1));
+		num = x / scale - x0 / scale;
+		den = x1 / scale - x0 / scale;
+	}
 	return num / den;
 }
 

--- a/test/sql/window/test_fill_orderby.test
+++ b/test/sql/window/test_fill_orderby.test
@@ -48,6 +48,21 @@ qualify filled <> permuted
 
 endloop
 
+# Regression: large DOUBLE ordering span should not overflow
+query R
+SELECT fill(y ORDER BY x) OVER ()
+FROM (
+    VALUES
+        (-1e308::DOUBLE, 1::DOUBLE),
+        (0::DOUBLE, NULL),
+        (1e308::DOUBLE, 3::DOUBLE)
+) t(x, y)
+ORDER BY x;
+----
+1.0
+2.0
+3.0
+
 # Single values
 query III
 with source as (


### PR DESCRIPTION
Fixes: #23987 