### PR TITLE
Fix validity column update check in zonemap

### DIFF
--- a/src/storage/table/column_data.cpp
+++ b/src/storage/table/column_data.cpp
@@ -445,12 +445,11 @@ FilterPropagateResult ColumnData::CheckZonemap(ColumnScanState &state, TableFilt
 			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 		}
 	}
-	lock_guard<mutex> l(update_lock);
-	if (!updates) {
+	auto update_stats = GetUpdateStatistics();
+	if (!update_stats) {
 		// no updates - return original result
 		return prune_result;
 	}
-	auto update_stats = updates->GetStatistics();
 	// combine the update and original prune result
 	auto context = state.context.GetClientContext();
 	FilterPropagateResult update_result =

--- a/src/storage/table/standard_column_data.cpp
+++ b/src/storage/table/standard_column_data.cpp
@@ -186,7 +186,11 @@ void StandardColumnData::UpdateColumn(TransactionData transaction, DuckTableEntr
 }
 
 unique_ptr<BaseStatistics> StandardColumnData::GetUpdateStatistics() {
-	auto stats = updates ? updates->GetStatistics() : nullptr;
+	unique_ptr<BaseStatistics> stats;
+	{
+		lock_guard<mutex> update_guard(update_lock);
+		stats = updates ? updates->GetStatistics() : nullptr;
+	}
 	auto validity_stats = validity->GetUpdateStatistics();
 	if (!stats && !validity_stats) {
 		return nullptr;

--- a/test/sql/storage/wal/wal_null_update_row_group_pruning.test
+++ b/test/sql/storage/wal/wal_null_update_row_group_pruning.test
@@ -1,0 +1,60 @@
+# name: test/sql/storage/wal/wal_null_update_row_group_pruning.test
+# description: Test row-group pruning after WAL replay of NULL updates
+# group: [wal]
+
+require skip_reload
+
+load {TEST_DIR}/wal_null_update_row_group_pruning.db
+
+statement ok
+PRAGMA disable_checkpoint_on_shutdown
+
+statement ok
+PRAGMA wal_autocheckpoint='1TB';
+
+statement ok
+CREATE TABLE test AS SELECT i::BIGINT AS a FROM range(2048) tbl(i);
+
+statement ok
+CREATE TABLE distinct_test AS SELECT 1::BIGINT AS a FROM range(2048);
+
+statement ok
+CHECKPOINT;
+
+statement ok
+UPDATE test SET a = NULL WHERE a = 3;
+
+statement ok
+UPDATE distinct_test SET a = NULL WHERE rowid = 3;
+
+query I
+SELECT count(*) FROM test WHERE a IS NULL;
+----
+1
+
+query I
+SELECT count(*) FROM distinct_test WHERE a IS DISTINCT FROM 1;
+----
+1
+
+restart
+
+query I
+SELECT count(*) FROM test WHERE a IS NULL;
+----
+1
+
+query I
+SELECT count(*) FROM test WHERE CASE WHEN a IS NULL THEN true ELSE false END;
+----
+1
+
+query I
+SELECT count(*) FROM distinct_test WHERE a IS DISTINCT FROM 1;
+----
+1
+
+query I
+SELECT count(*) FROM distinct_test WHERE CASE WHEN a IS DISTINCT FROM 1 THEN true ELSE false END;
+----
+1


### PR DESCRIPTION
Closes https://github.com/duckdb/duckdb/issues/24180

The bug is, in the current implementation we only check base column updates, but not validity column update; so zonemap is not reliable after a NULL-related updates.