### PR TITLE
Alternate benchmark runs for old and new

### DIFF
--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -202,7 +202,7 @@ jobs:
     if: ${{ github.repository_owner == 'duckdb' }}
     needs:
       - linux-base
-    runs-on: namespace-profile-linux-x64
+    runs-on: namespace-profile-linux-small
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -125,10 +125,16 @@ jobs:
         include:
           - name: Ingestion Perf
             benchmarks: .github/regression/ingestion.csv
-          - name: Micro + TPCH-PARQUET
-            benchmarks: .github/regression/micro.csv .github/regression/tpch_parquet.csv
-          - name: H2OAI + IMDB + CSV
-            benchmarks: .github/regression/h2oai.csv .github/regression/imdb.csv .github/regression/csv.csv
+          - name: Micro
+            benchmarks: .github/regression/tpch_parquet.csv
+          - name: TPCH-PARQUET
+            benchmarks: .github/regression/tpch_parquet.csv
+          - name: H2OAI
+            benchmarks: .github/regression/h2oai.csv
+          - name: IMDB
+            benchmarks: .github/regression/imdb.csv
+          - name: CSV
+            benchmarks: .github/regression/csv.csv
           - name: RealNest
             benchmarks: .github/regression/realnest.csv
             data_setup: |

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -209,8 +209,10 @@ jobs:
         include:
           - name: TPCH SF10
             benchmarks: .github/regression/tpch_sf10.csv
+            threads: 4
           - name: TPCDS SF3
             benchmarks: .github/regression/tpcds_sf3.csv
+            threads: 4
 
     steps:
       - name: "Checkout"
@@ -255,6 +257,7 @@ jobs:
             --clear-benchmark-cache \
             --disable-timeout \
             --max-timeout 3600 \
+            --threads ${{ matrix.threads }} \
             --timed-runs 30
 
   regression-bench-fivetran:

--- a/scripts/regression/benchmark.py
+++ b/scripts/regression/benchmark.py
@@ -23,6 +23,7 @@ STDOUT_HEADER = '''====================================================
 # timeouts in seconds
 MAX_TIMEOUT = 3600
 DEFAULT_TIMEOUT = 600
+DEFAULT_TIMED_RUNS = 10
 
 
 @dataclass
@@ -38,7 +39,7 @@ class BenchmarkRunnerConfig:
     max_timeout: int = MAX_TIMEOUT
     root_dir: str = ""
     no_summary: bool = False
-    timed_runs: Optional[int] = None
+    timed_runs: Optional[int] = DEFAULT_TIMED_RUNS
     runner_label: str = "benchmark"
 
     @classmethod
@@ -50,7 +51,7 @@ class BenchmarkRunnerConfig:
         max_timeout = kwargs.get("max_timeout", MAX_TIMEOUT)
         root_dir = kwargs.get("root_dir", "")
         no_summary = kwargs.get("no_summary", False)
-        timed_runs = kwargs.get("timed_runs", None)
+        timed_runs = kwargs.get("timed_runs", DEFAULT_TIMED_RUNS)
         runner_label = kwargs.get("runner_label", "benchmark")
 
         config = cls(
@@ -86,7 +87,12 @@ class BenchmarkRunnerConfig:
         parser.add_argument(
             "--no-summary", type=str, default=False, help="No failures summary is outputted when passing this flag."
         )
-        parser.add_argument("--timed-runs", type=int, help="Number of timed runs per benchmark.")
+        parser.add_argument(
+            "--timed-runs",
+            type=int,
+            default=DEFAULT_TIMED_RUNS,
+            help=f"Number of timed runs per benchmark (default: {DEFAULT_TIMED_RUNS}).",
+        )
 
         # Parse arguments
         parsed_args = parser.parse_args()

--- a/scripts/regression/benchmark.py
+++ b/scripts/regression/benchmark.py
@@ -132,7 +132,7 @@ class BenchmarkRunner:
         except:
             return False
 
-    def construct_args(self, benchmark_path):
+    def construct_args(self, benchmark_path, timed_runs_override: Optional[int] = None):
         benchmark_args = []
         benchmark_args.extend([self.config.benchmark_runner, benchmark_path])
         if self.config.root_dir:
@@ -145,12 +145,15 @@ class BenchmarkRunner:
             benchmark_args.extend(["--disable-timeout"])
         if self.config.no_summary:
             benchmark_args.extend(["--no-summary"])
-        if self.config.timed_runs is not None and self.supports_timed_runs:
-            benchmark_args.extend(["--timed-runs", str(self.config.timed_runs)])
+        timed_runs = self.config.timed_runs if timed_runs_override is None else timed_runs_override
+        if timed_runs is not None and self.supports_timed_runs:
+            benchmark_args.extend(["--timed-runs", str(timed_runs)])
         return benchmark_args
 
-    def run_benchmark_once(self, benchmark) -> Tuple[Optional[List[float]], Optional[str]]:
-        benchmark_args = self.construct_args(benchmark)
+    def run_benchmark_once(
+        self, benchmark, timed_runs_override: Optional[int] = None
+    ) -> Tuple[Optional[List[float]], Optional[str]]:
+        benchmark_args = self.construct_args(benchmark, timed_runs_override)
         timeout_seconds = DEFAULT_TIMEOUT
         if self.config.disable_timeout:
             timeout_seconds = self.config.max_timeout
@@ -202,6 +205,12 @@ class BenchmarkRunner:
             print(err)
             return None, err
 
+    def complete_benchmark(self, benchmark, timings: List[float]) -> Tuple[Union[float, str], Optional[str]]:
+        if not timings:
+            return 'Failed to run benchmark ' + benchmark, "Benchmark did not produce any timings"
+        self.complete_timings.extend(timings)
+        return float(statistics.median(timings)), None
+
     def run_benchmark(self, benchmark) -> Tuple[Union[float, str], Optional[str]]:
         requested_runs = self.config.timed_runs if self.config.timed_runs is not None else 0
         timings = []
@@ -214,8 +223,7 @@ class BenchmarkRunner:
             timings.extend(run_timings)
             if self.supports_timed_runs or len(timings) >= requested_runs:
                 break
-        self.complete_timings.extend(timings)
-        return float(statistics.median(timings)), None
+        return self.complete_benchmark(benchmark, timings)
 
     def run_benchmarks(self, benchmark_list: List[str]):
         results = {}

--- a/scripts/regression/test_runner.py
+++ b/scripts/regression/test_runner.py
@@ -2,7 +2,7 @@ import os
 import math
 import functools
 import shutil
-from benchmark import BenchmarkRunner, BenchmarkRunnerConfig
+from benchmark import BenchmarkRunner, BenchmarkRunnerConfig, DEFAULT_TIMED_RUNS
 from dataclasses import dataclass
 from typing import Optional, List, Union, Dict
 from pathlib import Path
@@ -45,7 +45,12 @@ parser.add_argument("--disable-timeout", action="store_true", help="Disable time
 parser.add_argument("--max-timeout", type=int, default=3600, help="Set maximum timeout in seconds (default: 3600).")
 parser.add_argument("--root-dir", type=str, default="", help="Root directory.")
 parser.add_argument("--no-summary", type=str, default=False, help="No summary in the end.")
-parser.add_argument("--timed-runs", type=int, help="Number of timed runs per benchmark.")
+parser.add_argument(
+    "--timed-runs",
+    type=int,
+    default=DEFAULT_TIMED_RUNS,
+    help=f"Number of timed runs per benchmark (default: {DEFAULT_TIMED_RUNS}).",
+)
 parser.add_argument(
     "--clear-benchmark-cache", action="store_true", help="Clear benchmark caches prior to running", default=False
 )

--- a/scripts/regression/test_runner.py
+++ b/scripts/regression/test_runner.py
@@ -88,6 +88,7 @@ REGRESSION_THRESHOLD_PERCENTAGE = 0.1
 REGRESSION_THRESHOLD_SECONDS = regression_threshold_seconds
 # hide benchmark changes that are below the noise floor in the final report
 DISPLAY_THRESHOLD_PERCENTAGE = 2.0
+TIMED_RUN_BATCH_SIZE = 5
 
 ANSI_RED = "\033[31m"
 ANSI_GREEN = "\033[32m"
@@ -441,7 +442,6 @@ def run_benchmarks_alternating(old_runner: BenchmarkRunner, new_runner: Benchmar
     old_failures = {}
     new_failures = {}
     requested_runs = max(timed_runs, 1) if timed_runs is not None else 1
-    timed_runs_override = 1 if timed_runs is not None else None
 
     for benchmark in benchmark_list:
         old_timings = []
@@ -449,32 +449,43 @@ def run_benchmarks_alternating(old_runner: BenchmarkRunner, new_runner: Benchmar
         old_failure = None
         new_failure = None
 
-        for _ in range(requested_runs):
-            old_run_timings, old_failure = old_runner.run_benchmark_once(benchmark, timed_runs_override)
-            if old_failure:
-                break
-            if not old_run_timings:
-                old_failure = "Benchmark did not produce any timings"
-                break
-            old_timings.extend(old_run_timings)
+        while len(old_timings) < requested_runs or len(new_timings) < requested_runs:
+            if len(old_timings) < requested_runs:
+                timed_runs_override = None
+                if timed_runs is not None:
+                    timed_runs_override = min(TIMED_RUN_BATCH_SIZE, requested_runs - len(old_timings))
 
-            new_run_timings, new_failure = new_runner.run_benchmark_once(benchmark, timed_runs_override)
-            if new_failure:
-                break
-            if not new_run_timings:
-                new_failure = "Benchmark did not produce any timings"
-                break
-            new_timings.extend(new_run_timings)
+                old_run_timings, old_failure = old_runner.run_benchmark_once(benchmark, timed_runs_override)
+                if old_failure is None and not old_run_timings:
+                    old_failure = "Benchmark did not produce any timings"
+                if old_run_timings:
+                    old_timings.extend(old_run_timings)
 
-        old_results[benchmark], old_failures[benchmark] = old_runner.complete_benchmark(benchmark, old_timings)
-        new_results[benchmark], new_failures[benchmark] = new_runner.complete_benchmark(benchmark, new_timings)
+            if len(new_timings) < requested_runs:
+                timed_runs_override = None
+                if timed_runs is not None:
+                    timed_runs_override = min(TIMED_RUN_BATCH_SIZE, requested_runs - len(new_timings))
+
+                new_run_timings, new_failure = new_runner.run_benchmark_once(benchmark, timed_runs_override)
+                if new_failure is None and not new_run_timings:
+                    new_failure = "Benchmark did not produce any timings"
+                if new_run_timings:
+                    new_timings.extend(new_run_timings)
+
+            if old_failure or new_failure:
+                break
 
         if old_failure:
             old_results[benchmark] = 'Failed to run benchmark ' + benchmark
             old_failures[benchmark] = old_failure
+        else:
+            old_results[benchmark], old_failures[benchmark] = old_runner.complete_benchmark(benchmark, old_timings)
+
         if new_failure:
             new_results[benchmark] = 'Failed to run benchmark ' + benchmark
             new_failures[benchmark] = new_failure
+        else:
+            new_results[benchmark], new_failures[benchmark] = new_runner.complete_benchmark(benchmark, new_timings)
 
     return old_results, old_failures, new_results, new_failures
 

--- a/scripts/regression/test_runner.py
+++ b/scripts/regression/test_runner.py
@@ -325,9 +325,23 @@ def print_banner(title: str):
     print("")
 
 
-def print_aggregate_report(
-    rows: List[BenchmarkRow], common_prefix: str, result_text: str, total_count: int, hidden_noise_count: int
+def print_benchmark_report(
+    rows: List[BenchmarkRow],
+    common_prefix: str,
+    result_text: str,
+    total_count: int,
+    hidden_noise_count: int,
+    time_a: Union[float, str],
+    time_b: Union[float, str],
 ):
+    buckets = {
+        BUCKET_UNCHANGED: [row for row in rows if row.bucket == BUCKET_UNCHANGED],
+        BUCKET_FASTER: [row for row in rows if row.bucket == BUCKET_FASTER],
+        BUCKET_SLOWER: [row for row in rows if row.bucket == BUCKET_SLOWER],
+        BUCKET_REGRESSION: [row for row in rows if row.bucket == BUCKET_REGRESSION],
+        BUCKET_FAILURE: [row for row in rows if row.bucket == BUCKET_FAILURE],
+    }
+
     print_banner("BENCHMARK QUERY AGGREGATES")
     print(f"suite: {suite_name()}")
     if common_prefix:
@@ -341,11 +355,13 @@ def print_aggregate_report(
     print(f"display threshold: +/-{DISPLAY_THRESHOLD_PERCENTAGE:.1f}%")
     print(f"hidden noise: {hidden_noise_count} benchmarks below +/-{DISPLAY_THRESHOLD_PERCENTAGE:.1f}%")
     print(f"result: {result_text}")
-    print("")
-    if len(rows) == 0:
-        print("0 benchmarks above display threshold")
-    else:
-        render_table(rows)
+    print_geomean_summary(time_a, time_b)
+    print_bucket("UNCHANGED / NOISE", buckets[BUCKET_UNCHANGED], hidden_noise_count)
+    print_bucket("FASTER", buckets[BUCKET_FASTER])
+    print_bucket("SLOWER BELOW THRESHOLD", buckets[BUCKET_SLOWER])
+    print_bucket("REGRESSIONS", buckets[BUCKET_REGRESSION])
+    if len(buckets[BUCKET_FAILURE]) > 0:
+        print_bucket("FAILURES", buckets[BUCKET_FAILURE])
 
 
 def print_bucket(title: str, rows: List[BenchmarkRow], hidden_noise_count: int = 0):
@@ -358,25 +374,6 @@ def print_bucket(title: str, rows: List[BenchmarkRow], hidden_noise_count: int =
         print("0 benchmarks")
         return
     render_table(rows)
-
-
-def print_impact_bucket_summary(rows: List[BenchmarkRow], result_text: str, hidden_noise_count: int):
-    buckets = {
-        BUCKET_UNCHANGED: [row for row in rows if row.bucket == BUCKET_UNCHANGED],
-        BUCKET_FASTER: [row for row in rows if row.bucket == BUCKET_FASTER],
-        BUCKET_SLOWER: [row for row in rows if row.bucket == BUCKET_SLOWER],
-        BUCKET_REGRESSION: [row for row in rows if row.bucket == BUCKET_REGRESSION],
-        BUCKET_FAILURE: [row for row in rows if row.bucket == BUCKET_FAILURE],
-    }
-    print("")
-    print_banner("IMPACT BUCKETS SUMMARY")
-    print(f"result: {result_text}")
-    print_bucket("UNCHANGED / NOISE", buckets[BUCKET_UNCHANGED], hidden_noise_count)
-    print_bucket("FASTER", buckets[BUCKET_FASTER])
-    print_bucket("SLOWER BELOW THRESHOLD", buckets[BUCKET_SLOWER])
-    print_bucket("REGRESSIONS", buckets[BUCKET_REGRESSION])
-    if len(buckets[BUCKET_FAILURE]) > 0:
-        print_bucket("FAILURES", buckets[BUCKET_FAILURE])
 
 
 def print_geomean_summary(time_a: Union[float, str], time_b: Union[float, str]):
@@ -564,12 +561,9 @@ else:
     result_text = "no regressions detected"
 
 common_prefix = benchmark_common_prefix([result.benchmark for result in all_results])
-print_aggregate_report(visible_rows, common_prefix, result_text, len(rows), hidden_noise_count)
-
 time_a = geomean(old_runner.complete_timings)
 time_b = geomean(new_runner.complete_timings)
-print_geomean_summary(time_a, time_b)
-print_impact_bucket_summary(visible_rows, result_text, hidden_noise_count)
+print_benchmark_report(visible_rows, common_prefix, result_text, len(rows), hidden_noise_count, time_a, time_b)
 
 # nuke cached benchmark data between runs
 if not keep_benchmark_data:

--- a/scripts/regression/test_runner.py
+++ b/scripts/regression/test_runner.py
@@ -435,6 +435,50 @@ class BenchmarkResult:
     new_failure: Optional[str] = None
 
 
+def run_benchmarks_alternating(old_runner: BenchmarkRunner, new_runner: BenchmarkRunner, benchmark_list: List[str]):
+    old_results = {}
+    new_results = {}
+    old_failures = {}
+    new_failures = {}
+    requested_runs = max(timed_runs, 1) if timed_runs is not None else 1
+    timed_runs_override = 1 if timed_runs is not None else None
+
+    for benchmark in benchmark_list:
+        old_timings = []
+        new_timings = []
+        old_failure = None
+        new_failure = None
+
+        for _ in range(requested_runs):
+            old_run_timings, old_failure = old_runner.run_benchmark_once(benchmark, timed_runs_override)
+            if old_failure:
+                break
+            if not old_run_timings:
+                old_failure = "Benchmark did not produce any timings"
+                break
+            old_timings.extend(old_run_timings)
+
+            new_run_timings, new_failure = new_runner.run_benchmark_once(benchmark, timed_runs_override)
+            if new_failure:
+                break
+            if not new_run_timings:
+                new_failure = "Benchmark did not produce any timings"
+                break
+            new_timings.extend(new_run_timings)
+
+        old_results[benchmark], old_failures[benchmark] = old_runner.complete_benchmark(benchmark, old_timings)
+        new_results[benchmark], new_failures[benchmark] = new_runner.complete_benchmark(benchmark, new_timings)
+
+        if old_failure:
+            old_results[benchmark] = 'Failed to run benchmark ' + benchmark
+            old_failures[benchmark] = old_failure
+        if new_failure:
+            new_results[benchmark] = 'Failed to run benchmark ' + benchmark
+            new_failures[benchmark] = new_failure
+
+    return old_results, old_failures, new_results, new_failures
+
+
 multiply_percentage = 1.0 + REGRESSION_THRESHOLD_PERCENTAGE
 other_results: List[BenchmarkResult] = []
 error_list: List[BenchmarkResult] = []
@@ -450,8 +494,9 @@ for i in range(NUMBER_REPETITIONS):
 '''
     )
 
-    old_results, old_failures = old_runner.run_benchmarks(benchmark_list)
-    new_results, new_failures = new_runner.run_benchmarks(benchmark_list)
+    old_results, old_failures, new_results, new_failures = run_benchmarks_alternating(
+        old_runner, new_runner, benchmark_list
+    )
 
     for benchmark in benchmark_list:
         old_res = old_results[benchmark]


### PR DESCRIPTION
- Run new and old benchmark queries interleaved to reduce impact from "noisy neighbors" on the same VM instance.
- Batch timed runs per 5, with 10 timed runs (default), so the benchmark process overhead is low but still interleaving the queries between old and new.
- Use 4 duckdb threads and "small" (4 vCPU cores) for TPCH SF=10 and TPCDS SF=3.
- Split long (10+ min) benchmarks into separate CI jobs.

### [Before](https://github.com/duckdb/duckdb/actions/runs/30104049396/job/89521615131#step:9:6942) `Bench TPCDS SF3`

```
geomean: 0.019s -> 0.024s  +21.2%

benchmark  old     new     delta     change 
---------  ------  ------  --------  -------
q98        0.018s  0.017s  -<0.001s  -3.1%  
q59        0.057s  0.055s  -0.002s   -3.5%  
q67        0.330s  0.306s  -0.024s   -7.4%  
q57        0.033s  0.034s  <0.001s   +2.8%  
q97        0.053s  0.054s  +0.002s   +3.0%  
q93        0.013s  0.013s  <0.001s   +4.5%  
q92        0.006s  0.006s  <0.001s   +5.8%  
q95        0.082s  0.087s  +0.005s   +5.9%  
...
q40        0.006s  0.008s  +0.002s   +26.9% 
q68        0.019s  0.024s  +0.005s   +28.9% 
q75        0.078s  0.100s  +0.023s   +29.0% 
q65        0.063s  0.081s  +0.018s   +29.0% 
q11        0.062s  0.080s  +0.018s   +29.4% 
q42        0.005s  0.006s  +0.001s   +29.5% 
q45        0.014s  0.018s  +0.004s   +30.9% 
q84        0.006s  0.008s  +0.002s   +32.4% 
q05        0.021s  0.028s  +0.007s   +32.4% 
q52        0.005s  0.007s  +0.002s   +34.4% 
q55        0.005s  0.007s  +0.002s   +36.1% 
q01        0.019s  0.026s  +0.007s   +37.9% 
q73        0.012s  0.018s  +0.006s   +49.8% 
q71        0.014s  0.022s  +0.009s   +65.1% 
q66        0.023s  0.043s  +0.019s   +83.3% 
q70        0.016s  0.030s  +0.014s   +90.1% 
q69        0.013s  0.026s  +0.013s   +98.6% 
q72        0.042s  0.085s  +0.043s   +101.0%
q74        0.037s  0.077s  +0.040s   +109.2%
```

### [After](https://github.com/duckdb/duckdb/actions/runs/30264268590/job/89974319429?pr=24184#step:9:10730) `Bench TPCDS SF3`

```
geomean: 0.026s -> 0.026s  -0.1%

UNCHANGED / NOISE
85 benchmarks below +/-2.0%

FASTER
benchmark  old     new     delta     change
---------  ------  ------  --------  ------
q27        0.050s  0.049s  -0.001s   -2.1% 
q08        0.024s  0.024s  -<0.001s  -2.3% 
q86        0.012s  0.012s  -<0.001s  -2.3% 
q30        0.016s  0.015s  -<0.001s  -2.5% 
q97        0.060s  0.059s  -0.002s   -2.5% 
q55        0.009s  0.009s  -<0.001s  -2.6% 
q21        0.005s  0.005s  -<0.001s  -2.8% 
q90        0.004s  0.004s  -<0.001s  -3.8% 

SLOWER BELOW THRESHOLD
benchmark  old     new     delta    change
---------  ------  ------  -------  ------
q35        0.049s  0.050s  +0.001s  +2.3% 
q06        0.019s  0.020s  <0.001s  +3.1% 
q84        0.006s  0.006s  <0.001s  +3.5% 
q91        0.006s  0.006s  <0.001s  +3.6% 
q81        0.018s  0.019s  <0.001s  +3.6% 
q16        0.006s  0.007s  <0.001s  +3.7% 

REGRESSIONS
0 benchmarks
```

note: CI failure in `Vector Sizes` is unrelated and fix in this [PR](https://github.com/duckdb/duckdb/pull/24190).