### PR TITLE
Parquet reader: count each column chunk once in the prefetch pre-check

### DIFF
--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -2,6 +2,7 @@
 
 #include <string.h>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "duckdb/common/optional_ptr.hpp"
@@ -1879,10 +1880,16 @@ ParquetPrefetchStrategy ParquetReader::RegisterRowGroupReads(ClientContext &cont
 	state.group_offset = GetRowGroupOffset(*this, state.group_index);
 
 	uint64_t to_scan_compressed_bytes = 0;
+	unordered_set<idx_t> counted_column_ids;
 	for (idx_t i = 0; i < column_ids.size(); i++) {
 		auto col_idx = MultiFileLocalIndex(i);
 		PrepareRowGroupBuffer(context, state, col_idx);
-		to_scan_compressed_bytes += state.GetColumnReader(i).TotalCompressedSize();
+		// column_ids can reference the same physical column more than once (e.g. the target scan of a MERGE
+		// whose source materializes a CTE over the target) - count each column chunk only once so the sum
+		// stays comparable to the physical byte span of the row group below
+		if (counted_column_ids.insert(column_ids[col_idx].GetId()).second) {
+			to_scan_compressed_bytes += state.GetColumnReader(i).TotalCompressedSize();
+		}
 	}
 
 	auto &group = GetGroup(state);


### PR DESCRIPTION
Fixes #24186 (the user-visible spurious `IOException`; the plan-side duplication it defends against is discussed below).

## Problem

`ParquetReader::RegisterRowGroupReads` sums `TotalCompressedSize()` once per `column_ids` **entry** and compares the total against the physical byte span of the row group; a total exceeding the span is treated as "incorrectly set page offsets" (remote files throw, local files fall back to synchronous reads).

Distinct column chunks occupy disjoint byte ranges inside the row-group span, so a duplicate-free `column_ids` list can never exceed it. But the planner can hand the scan a `column_ids` list that references the same physical column more than once: a `MERGE INTO` an ATTACHed Iceberg table whose source contains a materialized CTE over the target (explicit `MATERIALIZED`, or any CTE referenced twice → auto-materialized) produces `column_ids=[0,1,0,2]` — the ON-key file column appears twice (runtime-verified with a diagnostic build, details in #24186). The duplicated chunk is counted twice, the sum exceeds the span, and the scan fails with the misleading page-offsets error on a healthy file that DuckDB's own Iceberg writer produced moments earlier. Reproduces down to a 1-row, 2-column table with default optimizers (self-contained repro in the issue).

## Fix

Count each distinct column id once in the pre-check accounting. This also keeps `scan_percentage` (used to choose whole-group vs column-wise prefetch) meaningful for such plans.

The duplicated entries are benign for the actual read path — each `column_readers` entry reads its column independently — so only the accounting needs the guard. Verified at runtime on v1.5.5, where the same accounting lived in `ParquetReader::Scan`: a source build with the equivalent dedupe completes the repro `MERGE` with provably correct results (the repro merges the target into itself via `COALESCE`, so the table must come out unchanged — full-table hash checksums are identical before/after). On this branch, the patched translation unit compiles against current `main` headers and the file is byte-identical under the pinned `clang-format` 11.0.1. I could not re-run the Iceberg repro against a `main`/nightly build in our environment for an unrelated reason: the nightly Iceberg writer emits avro `codec: deflate`, which the REST catalog used in the repro (Lakekeeper) rejects at `CREATE TABLE`.

## Testing

I'd appreciate guidance here. The only reproduction we found requires the out-of-tree `iceberg` extension plus a remote (httpfs) file — `MERGE INTO` only targets catalog tables, so an in-tree sqllogictest cannot exercise this path directly. Options considered:

- land this defensive dedupe with #24186 as the evidence (this PR), and/or
- fix the duplication at its source — wherever `MERGE INTO` planning emits the duplicated ON-key binding for the target scan — which should be observable in-tree via `EXPLAIN`. Happy to attempt that as a follow-up if you can point me at the right place in the planner.
