### PR TITLE
Fix small CI issues on main

### DIFF
--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -683,7 +683,7 @@ jobs:
             python3.12   \
             perl-IPC-Cmd
           git config --global --add safe.directory \"$PWD\"
-          make -C \"$PWD\"
+          make -C \"$PWD\" CMAKE_VARS_BUILD=-DGIT_COMMIT_HASH=${{ needs.prepare.outputs.git_sha }}
         "
 
     - name: CLI check

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -819,7 +819,7 @@ jobs:
             python3 \
             samurai
           git config --global --add safe.directory \"$PWD\"
-          make -C \"$PWD\"
+          make -C \"$PWD\" CMAKE_VARS_BUILD=-DGIT_COMMIT_HASH=${{ needs.prepare.outputs.git_sha }}
         "
 
     - name: Deploy

--- a/scripts/ci/check_staged_extensions.py
+++ b/scripts/ci/check_staged_extensions.py
@@ -3,6 +3,7 @@
 import argparse
 import gzip
 import os
+import platform
 import subprocess
 import sys
 import tempfile
@@ -17,6 +18,27 @@ DOWNLOAD_USER_AGENT = "duckdb-ci/check-staged-extensions"
 DOWNLOAD_RETRIES = 2
 DOWNLOAD_RETRY_SECONDS = 10
 EXTENSION_SEPARATOR_TRANSLATION = str.maketrans({",": " ", ";": " "})
+
+
+def normalize_arch(machine: str) -> str:
+    machine = machine.lower()
+    if machine in {"x86_64", "amd64"}:
+        return "amd64"
+    if machine in {"aarch64", "arm64"}:
+        return "arm64"
+    return machine
+
+
+def cli_asset_name(system: str | None = None, machine: str | None = None) -> str:
+    system = (system or platform.system()).lower()
+    arch = normalize_arch(machine or platform.machine())
+
+    if system == "linux" and arch in {"amd64", "arm64"}:
+        return f"duckdb_cli-linux-{arch}.gz"
+    if system == "darwin" and arch in {"amd64", "arm64"}:
+        return f"duckdb_cli-osx-{arch}.gz"
+
+    raise RuntimeError(f"unsupported staged CLI platform: {system}/{arch}")
 
 
 def parse_args() -> argparse.Namespace:
@@ -35,9 +57,10 @@ def parse_args() -> argparse.Namespace:
 def cli_asset_url(asset_base_url: str, git_sha: str, version: str) -> str:
     short_sha = git_sha[:10]
     base = asset_base_url.rstrip("/")
+    asset_name = cli_asset_name()
     if version:
-        return f"{base}/{short_sha}/{version}/duckdb/duckdb/github_release/duckdb_cli-linux-amd64.gz"
-    return f"{base}/{short_sha}/duckdb/duckdb/github_release/duckdb_cli-linux-amd64.gz"
+        return f"{base}/{short_sha}/{version}/duckdb/duckdb/github_release/{asset_name}"
+    return f"{base}/{short_sha}/duckdb/duckdb/github_release/{asset_name}"
 
 
 def download_cli(url: str, target: Path) -> None:

--- a/test/api/test_config.cpp
+++ b/test/api/test_config.cpp
@@ -1,5 +1,6 @@
 #include "catch.hpp"
 #include "test_helpers.hpp"
+#include "duckdb/common/http_util.hpp"
 #include "duckdb/common/local_file_system.hpp"
 
 #include <set>
@@ -129,6 +130,14 @@ TEST_CASE("Test user_agent", "[api]") {
 		Connection con(db);
 		auto res = con.Query("PRAGMA user_agent");
 		REQUIRE_THAT(res->GetValue(0, 0).ToString(), Catch::Matchers::Matches("duckdb/.*(.*) go"));
+	}
+	{
+		DuckDB db(nullptr);
+		HTTPHeaders headers(*db.instance);
+		auto user_agent = headers.GetHeaderValue("User-Agent");
+		REQUIRE(!user_agent.empty());
+		REQUIRE(user_agent.back() != ' ');
+		REQUIRE(user_agent.back() != '\t');
 	}
 }
 

--- a/test/sql/subquery/any_all/test_multi_column_mark_join_nulls.test
+++ b/test/sql/subquery/any_all/test_multi_column_mark_join_nulls.test
@@ -3,7 +3,7 @@
 # group: [any_all]
 
 # A non-matching NULL row only makes the result unknown when no column is decisively unequal.
-query IIII
+query IIII rowsort
 SELECT a, b,
        row(a, b) IN (SELECT * FROM (VALUES (2, 6), (3, 7), (3, NULL::INT), (4, 8)) rhs(x, y)),
        row(a, b) NOT IN (SELECT * FROM (VALUES (2, 6), (3, 7), (3, NULL::INT), (4, 8)) rhs(x, y))
@@ -13,13 +13,13 @@ FROM (VALUES (1, 5), (2, 6), (3, 9), (9, 8), (3, NULL::INT),
 1	5	false	true
 2	6	true	false
 3	9	NULL	NULL
-9	8	false	true
 3	NULL	NULL	NULL
+9	8	false	true
 NULL	8	NULL	NULL
 NULL	NULL	NULL	NULL
 
 # Cover NULLs in every build column and a build row containing only NULLs.
-query IIII
+query IIII rowsort
 SELECT a, b,
        row(a, b) IN (SELECT * FROM (VALUES (2, 6), (NULL::INT, 7), (4, NULL::INT),
                                            (NULL::INT, NULL::INT)) rhs(x, y)),
@@ -40,7 +40,7 @@ SELECT row(NULL::INT, 8) IN (SELECT * FROM (VALUES (2, 6), (3, 7)) rhs(x, y)),
 false	true
 
 # Exercise more than two equality conditions.
-query TII
+query TII rowsort
 SELECT k,
        row(a, b, c, d, e, f) IN (
            SELECT * FROM (VALUES (1, 1, 1, 1, 1, 1),


### PR DESCRIPTION
- Support linux and macOS in check_staged_extensions.py.
- Force commit sha in CLI docker build.
- User agent [cannot](https://github.com/duckdb/duckdb/actions/runs/30085594993/job/89489247391#step:4:12) end with whitespace (results in `ERROR Invalid headers`, caused by missing git sha).

Sort mark join null query rows in test results. This [failed](https://github.com/duckdb/duckdb/actions/runs/30264268590/job/89972476511?pr=24184#step:7:21) in an unrelated PR for "Vector sizes":
```
Error: Wrong result in query! (test/sql/subquery/any_all/test_multi_column_mark_join_nulls.test:6)!
================================================================================
SELECT a, b,
       row(a, b) IN (SELECT * FROM (VALUES (2, 6), (3, 7), (3, NULL::INT), (4, 8)) rhs(x, y)),
       row(a, b) NOT IN (SELECT * FROM (VALUES (2, 6), (3, 7), (3, NULL::INT), (4, 8)) rhs(x, y))
FROM (VALUES (1, 5), (2, 6), (3, 9), (9, 8), (3, NULL::INT),
             (NULL::INT, 8), (NULL::INT, NULL::INT)) lhs(a, b);
================================================================================
Mismatch on row 3, column b(index 2)
NULL <> 9
================================================================================
Expected result:
================================================================================
1	5	false	true
2	6	true	false
3	9	NULL	NULL
9	8	false	true
3	NULL	NULL	NULL
NULL	8	NULL	NULL
NULL	NULL	NULL	NULL

================================================================================
Actual result:
================================================================================
1	5	0	1
2	6	1	0
3	NULL	NULL	NULL
NULL	8	NULL	NULL
NULL	NULL	NULL	NULL
3	9	NULL	NULL
9	8	0	1

reproduce:
build/reldebug/test/unittest test/sql/subquery/any_all/test_multi_column_mark_join_nulls.test
```