### PR TITLE
Flush and fsync optimistically written blocks before the WAL lock at commit

### DIFF
--- a/src/include/duckdb/storage/optimistic_data_writer.hpp
+++ b/src/include/duckdb/storage/optimistic_data_writer.hpp
@@ -52,6 +52,9 @@ public:
 	//! Rollback
 	void Rollback();
 
+	//! Whether this writer can write to disk at all (not temporary / in-memory / read-only)
+	bool CanWriteToDisk() const;
+
 	//! Return the client context.
 	ClientContext &GetClientContext() {
 		return context;

--- a/src/include/duckdb/transaction/duck_transaction.hpp
+++ b/src/include/duckdb/transaction/duck_transaction.hpp
@@ -64,6 +64,7 @@ public:
 	void SetModifications(DatabaseModificationType type) override;
 
 	bool ShouldWriteToWAL(AttachedDatabase &db);
+	ErrorData PreFlushOptimisticBlocks(AttachedDatabase &db) noexcept;
 	ErrorData WriteToWAL(ClientContext &context, AttachedDatabase &db,
 	                     unique_ptr<StorageCommitState> &commit_state) noexcept;
 	//! Commit the current transaction with the given commit identifier. Returns an error message if the transaction

--- a/src/include/duckdb/transaction/local_storage.hpp
+++ b/src/include/duckdb/transaction/local_storage.hpp
@@ -85,6 +85,14 @@ public:
 	//! Write a new row group to disk (if possible)
 	void WriteNewRowGroup(idx_t flushed_row_group_idx);
 	void FlushBlocks();
+	//! Whether Flush() takes the bulk-append path for this storage: the append covers at least one
+	//! full row group and there are no deletes. Only depends on transaction-local state, i.e. this
+	//! can be decided before taking any locks.
+	bool IsBulkAppend() const;
+	//! Whether the optimistic writer of this storage writes to disk (not temporary / in-memory / read-only)
+	bool WritesToDisk() const;
+	//! Whether this storage holds optimistically written (flushed) row groups
+	bool HasFlushedRowGroups() const;
 	void Rollback();
 	idx_t EstimatedSize();
 
@@ -115,6 +123,7 @@ class LocalTableManager {
 public:
 	shared_ptr<LocalTableStorage> MoveEntry(DataTable &table);
 	reference_map_t<DataTable, shared_ptr<LocalTableStorage>> MoveEntries();
+	vector<shared_ptr<LocalTableStorage>> GetEntries() const;
 	optional_ptr<LocalTableStorage> GetStorage(DataTable &table) const;
 	LocalTableStorage &GetOrCreateStorage(ClientContext &context, DataTable &table);
 	idx_t EstimatedSize() const;
@@ -213,10 +222,16 @@ public:
 		return context;
 	}
 
+	void FlushBulkAppendBlocksAndSync(AttachedDatabase &db);
+	bool SyncedFlushedBlocks() const {
+		return synced_flushed_blocks;
+	}
+
 private:
 	ClientContext &context;
 	DuckTransaction &transaction;
 	LocalTableManager table_manager;
+	bool synced_flushed_blocks = false;
 
 private:
 	void Flush(DataTable &table, LocalTableStorage &storage, optional_ptr<StorageCommitState> commit_state);

--- a/src/storage/local_storage.cpp
+++ b/src/storage/local_storage.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/planner/table_filter.hpp"
 #include "duckdb/storage/data_table.hpp"
 #include "duckdb/storage/partial_block_manager.hpp"
+#include "duckdb/storage/storage_manager.hpp"
 #include "duckdb/storage/table/append_state.hpp"
 #include "duckdb/storage/table/data_table_info.hpp"
 #include "duckdb/storage/table/row_group.hpp"
@@ -155,6 +156,22 @@ void LocalTableStorage::FlushBlocks() {
 		optimistic_writer.WriteUnflushedRowGroups(*row_groups);
 	}
 	optimistic_writer.FinalFlush();
+}
+
+bool LocalTableStorage::WritesToDisk() const {
+	return optimistic_writer.CanWriteToDisk();
+}
+
+bool LocalTableStorage::HasFlushedRowGroups() const {
+	return !row_groups->flushed_row_groups.empty();
+}
+
+bool LocalTableStorage::IsBulkAppend() const {
+	if (is_dropped || deleted_rows != 0) {
+		return false;
+	}
+	auto &collection = *row_groups->collection;
+	return collection.GetTotalRows() >= collection.GetRowGroupSize();
 }
 
 ErrorData LocalTableStorage::AppendToIndexes(DuckTransaction &transaction, RowGroupCollection &source,
@@ -325,6 +342,16 @@ shared_ptr<LocalTableStorage> LocalTableManager::MoveEntry(DataTable &table) {
 reference_map_t<DataTable, shared_ptr<LocalTableStorage>> LocalTableManager::MoveEntries() {
 	lock_guard<mutex> l(table_storage_lock);
 	return std::move(table_storage);
+}
+
+vector<shared_ptr<LocalTableStorage>> LocalTableManager::GetEntries() const {
+	lock_guard<mutex> l(table_storage_lock);
+	vector<shared_ptr<LocalTableStorage>> result;
+	result.reserve(table_storage.size());
+	for (auto &entry : table_storage) {
+		result.push_back(entry.second);
+	}
+	return result;
 }
 
 idx_t LocalTableManager::EstimatedSize() const {
@@ -577,13 +604,16 @@ void LocalStorage::Flush(DataTable &table, LocalTableStorage &storage, optional_
 	}
 
 	auto append_count = storage.GetCollection().GetTotalRows() - storage.deleted_rows;
-	const auto row_group_size = storage.GetCollection().GetRowGroupSize();
 
 	TableAppendState append_state;
 	table.AppendLock(transaction, append_state);
-	if ((append_state.row_start == 0 || storage.GetCollection().GetTotalRows() >= row_group_size) &&
-	    storage.deleted_rows == 0) {
-		// table is currently empty OR we are bulk appending: move over the storage directly
+	if (storage.IsBulkAppend() ||
+	    (append_state.row_start == 0 && storage.deleted_rows == 0 && !storage.WritesToDisk())) {
+		// bulk append (at least one full row group, no deletes): move over the storage directly.
+		// Appends to an empty table are also merged directly if the table cannot be written to
+		// disk (temporary / in-memory / read-only, e.g. WAL replay of a read-only attach) -
+		// there are no optimistically written blocks to manage, and merging avoids re-appending
+		// row by row.
 		// first flush any outstanding blocks
 		storage.FlushBlocks();
 		// Append to the indexes.
@@ -594,6 +624,9 @@ void LocalStorage::Flush(DataTable &table, LocalTableStorage &storage, optional_
 		// check if we have written data
 		// if we have, we cannot merge to disk after all
 		// so we need to revert the data we have already written
+		// this only happens for transactions that deleted rows after bulk-appending: a pure bulk
+		// append always takes the merge path above, using its pre-flushed blocks as written
+		D_ASSERT(!storage.HasFlushedRowGroups() || storage.deleted_rows > 0);
 		storage.Rollback();
 		// append to the indexes
 		storage.AppendToIndexes(transaction, append_state);
@@ -608,6 +641,24 @@ void LocalStorage::Flush(DataTable &table, LocalTableStorage &storage, optional_
 	// Verify that our index memory is stable.
 	table.VerifyIndexBuffers();
 #endif
+}
+
+void LocalStorage::FlushBulkAppendBlocksAndSync(AttachedDatabase &db) {
+	bool requires_sync = false;
+	for (auto &storage : table_manager.GetEntries()) {
+		if (storage->IsBulkAppend()) {
+			// Flush() is guaranteed to take the bulk path - the blocks will be used as written
+			storage->FlushBlocks();
+			requires_sync |= storage->HasFlushedRowGroups();
+		}
+	}
+	if (requires_sync) {
+		// the WAL will reference the flushed row groups (flushed just now or already during the
+		// statement, e.g. by batch inserts) - persist them now so that the commit does not have
+		// to FileSync while holding the WAL lock
+		db.GetStorageManager().GetBlockManager().FileSync();
+		synced_flushed_blocks = true;
+	}
 }
 
 void LocalStorage::Commit(optional_ptr<StorageCommitState> commit_state) {

--- a/src/storage/local_storage.cpp
+++ b/src/storage/local_storage.cpp
@@ -2,6 +2,7 @@
 #include "duckdb/transaction/commit_state.hpp"
 
 #include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
+#include "duckdb/main/attached_database.hpp"
 #include "duckdb/planner/table_filter.hpp"
 #include "duckdb/storage/data_table.hpp"
 #include "duckdb/storage/partial_block_manager.hpp"

--- a/src/storage/optimistic_data_writer.cpp
+++ b/src/storage/optimistic_data_writer.cpp
@@ -25,15 +25,19 @@ OptimisticDataWriter::OptimisticDataWriter(DataTable &table, OptimisticDataWrite
 OptimisticDataWriter::~OptimisticDataWriter() {
 }
 
+bool OptimisticDataWriter::CanWriteToDisk() const {
+	auto &attached = table.GetAttached();
+	auto &storage_manager = StorageManager::Get(attached);
+	return !table.IsTemporary() && !storage_manager.InMemory() && !attached.IsReadOnly();
+}
+
 bool OptimisticDataWriter::PrepareWrite() {
 	// check if optimistic writing is enabled
 	if (!Settings::Get<EnableOptimisticWriteSetting>(context)) {
 		return false;
 	}
 	// check if we should pre-emptively write the table to disk
-	auto &attached = table.GetAttached();
-	auto &storage_manager = StorageManager::Get(attached);
-	if (table.IsTemporary() || storage_manager.InMemory() || attached.IsReadOnly()) {
+	if (!CanWriteToDisk()) {
 		return false;
 	}
 	// we should! write the second-to-last row group to disk
@@ -118,12 +122,16 @@ void OptimisticWriteCollection::FinalizeFlush() {
 }
 
 void OptimisticDataWriter::WriteUnflushedRowGroups(OptimisticWriteCollection &row_groups) {
+	auto total_row_groups = row_groups.collection->GetRowGroupCount();
+	if (row_groups.flushed_row_groups.size() == total_row_groups && row_groups.partial_block_managers.empty()) {
+		// everything is flushed already and there is nothing to merge - a repeated call ends up here
+		return;
+	}
 	// we finished writing a complete row group
 	if (!PrepareWrite()) {
 		return;
 	}
 	// add any incomplete row groups to the set of unflushed row groups
-	auto total_row_groups = row_groups.collection->GetRowGroupCount();
 	for (idx_t i = 0; i < total_row_groups; i++) {
 		// check if this row group was flushed
 		auto entry = row_groups.flushed_row_groups.find(i);

--- a/src/transaction/duck_transaction.cpp
+++ b/src/transaction/duck_transaction.cpp
@@ -206,6 +206,21 @@ bool DuckTransaction::ShouldWriteToWAL(AttachedDatabase &db) {
 	return true;
 }
 
+ErrorData DuckTransaction::PreFlushOptimisticBlocks(AttachedDatabase &db) noexcept {
+	ErrorData error;
+	if (!ShouldWriteToWAL(db)) {
+		return error;
+	}
+	try {
+		storage->FlushBulkAppendBlocksAndSync(db);
+	} catch (std::exception &ex) {
+		// fail the commit: the flush machinery cannot safely be re-run after an error, and a failed
+		// fsync must not be retried (the retry can succeed without the data being durable)
+		error = ErrorData(ex);
+	}
+	return error;
+}
+
 ErrorData DuckTransaction::WriteToWAL(ClientContext &context, AttachedDatabase &db,
                                       unique_ptr<StorageCommitState> &commit_state) noexcept {
 	ErrorData error_data;
@@ -222,13 +237,11 @@ ErrorData DuckTransaction::WriteToWAL(ClientContext &context, AttachedDatabase &
 
 		auto wal_timer = profiler.StartTimer<MetricStorageWriteToWALLatency>();
 		undo_buffer.WriteToWAL(*wal, commit_state.get());
-		if (commit_state->HasRowGroupData()) {
-			// if we have optimistically written any data AND we are writing to the WAL, we have written references to
-			// optimistically written blocks
-			// hence we need to ensure those optimistically written blocks are persisted
-			storage_manager.GetBlockManager().FileSync();
-		}
 		wal_timer.EndTimer();
+
+		// no FileSync is required here: any optimistically written blocks that the WAL references
+		// have already been synced by FlushBulkAppendBlocksAndSync, before the commit locks were taken
+		D_ASSERT(!commit_state->HasRowGroupData() || storage->SyncedFlushedBlocks());
 
 	} catch (std::exception &ex) {
 		// Call RevertCommit() outside this try-catch as it itself may throw

--- a/src/transaction/duck_transaction_manager.cpp
+++ b/src/transaction/duck_transaction_manager.cpp
@@ -297,6 +297,8 @@ void DuckTransactionManager::CleanupTransactions() {
 
 ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Transaction &transaction_p) {
 	auto &transaction = transaction_p.Cast<DuckTransaction>();
+	// flush the transaction-local blocks of bulk appends before taking any commit locks (see PreFlushOptimisticBlocks)
+	ErrorData error = transaction.PreFlushOptimisticBlocks(db);
 	unique_lock<mutex> t_lock(transaction_lock);
 	if (!db.IsSystem() && !db.IsTemporary()) {
 		if (transaction.ChangesMade()) {
@@ -311,7 +313,6 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 	unique_ptr<StorageLockKey> lock;
 	auto undo_properties = transaction.GetUndoProperties();
 	auto checkpoint_decision = CanCheckpoint(transaction, lock, undo_properties);
-	ErrorData error;
 	unique_lock<mutex> held_wal_lock;
 	unique_ptr<StorageCommitState> commit_state;
 	bool skip_wal_write_due_to_checkpoint = false;
@@ -329,7 +330,7 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 			skip_wal_write_due_to_checkpoint = true;
 		}
 	}
-	bool should_write_to_wal = transaction.ShouldWriteToWAL(db);
+	bool should_write_to_wal = !error.HasError() && transaction.ShouldWriteToWAL(db);
 	if (should_write_to_wal) {
 		auto &storage_manager = db.GetStorageManager().Cast<SingleFileStorageManager>();
 		// if we are committing changes and we are not doing a "checkpoint instead of WAL write"

--- a/test/sql/storage/optimistic_write/concurrent_bulk_append_commits.test_slow
+++ b/test/sql/storage/optimistic_write/concurrent_bulk_append_commits.test_slow
@@ -1,0 +1,55 @@
+# name: test/sql/storage/optimistic_write/concurrent_bulk_append_commits.test_slow
+# description: Concurrent bulk-append commits to separate tables flush their blocks before the WAL lock
+# group: [optimistic_write]
+
+load __TEST_DIR__/concurrent_bulk_append_commits.db
+
+statement ok
+SET checkpoint_threshold='999999GB';
+
+loop i 0 8
+
+statement ok
+CREATE TABLE t${i} (r BIGINT, s VARCHAR);
+
+# seed row: the table being non-empty forces the commit off the empty-table fast path, so
+# the bulk-append decision depends on the append being at least one row group
+statement ok
+INSERT INTO t${i} VALUES (-1, 'seed');
+
+endloop
+
+# concurrent commits of two-row-group appends to separate tables: each commit pre-flushes and
+# fsyncs its transaction-local blocks before taking the WAL lock, so the flushes overlap and
+# only the WAL append serializes
+concurrentloop i 0 8
+
+statement ok
+INSERT INTO t${i} SELECT r, repeat('abcdefgh', 25) || r FROM range(245000) tt(r);
+
+endloop
+
+loop i 0 8
+
+query III
+SELECT COUNT(*), MIN(r), MAX(r) FROM t${i}
+----
+245001	-1	244999
+
+endloop
+
+restart
+
+loop i 0 8
+
+query III
+SELECT COUNT(*), MIN(r), MAX(r) FROM t${i}
+----
+245001	-1	244999
+
+query I
+SELECT s = repeat('abcdefgh', 25) || r FROM t${i} WHERE r = 122880
+----
+true
+
+endloop


### PR DESCRIPTION
## Problem

A committing bulk append currently does all of its I/O while holding the WAL lock: `LocalStorage::Commit` flushes the remaining optimistically written blocks, the block manager is `FileSync`'ed (the `ROW_GROUP_DATA` entries in the WAL reference those blocks, so they must be durable before the WAL entry), and only then the actual WAL append happens.

On filesystems where fsync is expensive, e.g. network/remote storage, the WAL lock is then held for a substantial amount of time, although the WAL append itself takes milliseconds. Every other commit convoys behind it, including small commits to unrelated tables that would need the lock for microseconds.

## Approach

None of that I/O needs WAL ordering: the blocks are transaction-private until `MergeStorage`. `CommitTransaction` now calls `DuckTransaction::PreFlushOptimisticBlocks` **before** acquiring the transaction/WAL locks:

- It flushes the blocks of every table whose append takes the bulk-append path — at least one full row group and no deletes (`LocalTableStorage::IsBulkAppend`, which `LocalStorage::Flush` shares, so the decision cannot diverge). The decision depends only on transaction-local state, and the blocks are guaranteed to be used as written.
- It `FileSync`s the block manager if the commit references flushed row groups — whether flushed by the pre-flush itself or already during the statement (e.g. by batch inserts, which previously also paid their fsync under the WAL lock).
- Row-start assignment (`AppendLock`/`MergeStorage`) and the WAL append remain under the WAL lock, preserving per-table WAL order = row order.

For the bulk-append decision to be lock-free, `LocalStorage::Flush` no longer merges appends to an empty table directly for on-disk tables: appends below one row group now take the regular row-append path like any other small append. The direct merge for empty tables is kept only where the optimistic writer cannot write to disk (temporary / in-memory / read-only, e.g. WAL replay of a read-only attach), where there are no optimistically written blocks to manage.

With that, every commit that references optimistically written blocks from the WAL has already flushed and synced them before taking any lock, and the `FileSync` under the WAL lock is gone entirely. Two assertions pin the invariant: `LocalStorage::Flush` asserts that flushed blocks are only ever reverted by transactions that deleted rows after appending, and `WriteToWAL` asserts that WAL block references imply the pre-flush synced.

A commit that ends up skipping the WAL write in favor of an inline checkpoint pays one fsync it previously didn't; pure bulk appends rarely take that path (their WAL estimate is the KB-scale block-pointer size, not the data size).

**A pre-flush failure fails the commit**, exactly as a failure of the same flush under the WAL lock would. Retrying is not an option: the flush machinery cannot safely be re-run after an error (already-flushed partial blocks stay registered; a mid-`WriteToDisk` throw leaves dangling segment references), and a failed fsync must not be retried either — the retry can succeed without the data actually being durable.

The concurrency window is unchanged: optimistic writes already run mid-INSERT, long before commit, and `Truncate` only reclaims free-listed blocks.

## Measurements

8 concurrent single-statement commits of ~50MB appends to separate tables, with fsync latency simulated via an injected delay in `LocalFileSystem::FileSync` (db file / WAL file):

| fsync latency (db/wal) | before | after | |
|---|---|---|---|
| none injected (macOS fsync, ~0.1ms) | 1.24s | 0.82s | 1.5x |
| 10ms / 10ms   | 1.65s | 1.15s | 1.4x |
| 100ms / 100ms | 5.10s | 3.86s | 1.3x |
| 100ms / 10ms  | 2.68s | 1.55s | 1.7x |

The first row is a plain laptop with no simulated latency: even with sub-millisecond fsyncs the pre-flush wins 1.5x, because the commit-time flush of the trailing (incomplete) row group - its compression and block writes - now runs in parallel across the committers instead of serialized under the WAL lock. As fsync latency grows, the overlapped db-file fsyncs add to the gap; the whole gap scales with commit concurrency.

The convoy effect shows most clearly in a mixed workload with 8 connections each committing one ~50MB bulk append concurrently with 8 connections each running 50 small 1000-row commits:

| fsync latency (db/wal) | before | after | |
|---|---|---|---|
| 100ms / 0ms  | 2.50s | 1.26s | 2.0x |
| 100ms / 10ms | 8.00s | 6.49s | 1.2x |

In the first row the small commits need the WAL lock only for their (tiny) WAL appends, but spend most of their time queued behind the bulk commits' under-lock fsyncs; the pre-flush removes that wait entirely. The second row shows the remaining serialized cost: with ~850 commits each paying a 10ms WAL sync under the lock, the WAL sync itself dominates both sides — batching WAL syncs across commits (group commit) would be the natural follow-up for slow-fsync storage.

## Future work

- **Group commit**: the per-commit WAL sync stays serialized under the WAL lock (see above).
- The **checkpoint-instead-of-WAL path** still holds the WAL lock for the full inline checkpoint; unchanged here.
- Per-transaction **write-sequence tracking in the block manager** (`my last write seq > synced-up-to seq`) would let commits skip fsyncs already covered by someone else's sync. Wider interface change, left out of this PR.
