### PR TITLE
Add support for `enable_optimistic_write` setting which disables optimistic writing

### DIFF
--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -667,6 +667,13 @@
         "default_value": "false"
     },
     {
+        "name": "enable_optimistic_write",
+        "description": "Whether or not to optimistically write large appends to disk before committing. Disable this to keep bulk appends in memory (e.g. for in-memory benchmarks).",
+        "type": "BOOLEAN",
+        "default_scope": "global",
+        "default_value": "true"
+    },
+    {
         "name": "enable_optimizer",
         "description": "Whether or not query optimization is enabled",
         "type": "BOOLEAN",

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -1029,6 +1029,18 @@ struct EnableObjectCacheSetting {
 	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
+struct EnableOptimisticWriteSetting {
+	using RETURN_TYPE = bool;
+	static constexpr const char *Name = "enable_optimistic_write";
+	static constexpr const char *Description =
+	    "Whether or not to optimistically write large appends to disk before committing. Disable this to keep bulk "
+	    "appends in memory (e.g. for in-memory benchmarks).";
+	static constexpr const char *InputType = "BOOLEAN";
+	static constexpr const char *DefaultValue = "true";
+	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
+	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+};
+
 struct EnableOptimizerSetting {
 	using RETURN_TYPE = bool;
 	static constexpr const char *Name = "enable_optimizer";

--- a/src/include/duckdb/storage/compression/alp/algorithm/alp.hpp
+++ b/src/include/duckdb/storage/compression/alp/algorithm/alp.hpp
@@ -14,6 +14,7 @@
 #include "duckdb/common/pair.hpp"
 #include "duckdb/common/limits.hpp"
 #include "duckdb/common/types/hash.hpp"
+#include "duckdb/common/types/value.hpp"
 #include "duckdb/storage/compression/alp/alp_constants.hpp"
 #include "duckdb/storage/compression/alp/alp_utils.hpp"
 

--- a/src/include/duckdb/storage/compression/alp/alp_scan.hpp
+++ b/src/include/duckdb/storage/compression/alp/alp_scan.hpp
@@ -11,6 +11,7 @@
 #include "duckdb/storage/compression/alp/algorithm/alp.hpp"
 
 #include "duckdb/common/limits.hpp"
+#include "duckdb/common/vector/flat_vector.hpp"
 #include "duckdb/storage/buffer_manager.hpp"
 
 #include "duckdb/storage/table/column_segment.hpp"

--- a/src/include/duckdb/storage/compression/alprd/alprd_scan.hpp
+++ b/src/include/duckdb/storage/compression/alprd/alprd_scan.hpp
@@ -12,6 +12,7 @@
 #include "duckdb/storage/compression/alprd/alprd_constants.hpp"
 
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/vector/flat_vector.hpp"
 #include "duckdb/function/compression_function.hpp"
 #include "duckdb/storage/buffer_manager.hpp"
 

--- a/src/include/duckdb/storage/compression/chimp/chimp_scan.hpp
+++ b/src/include/duckdb/storage/compression/chimp/chimp_scan.hpp
@@ -13,6 +13,7 @@
 
 #include "duckdb/common/limits.hpp"
 #include "duckdb/common/numeric_utils.hpp"
+#include "duckdb/common/vector/flat_vector.hpp"
 #include "duckdb/function/compression_function.hpp"
 #include "duckdb/storage/buffer_manager.hpp"
 

--- a/src/include/duckdb/storage/compression/patas/patas_scan.hpp
+++ b/src/include/duckdb/storage/compression/patas/patas_scan.hpp
@@ -15,6 +15,7 @@
 #include "duckdb/storage/compression/patas/algorithm/patas.hpp"
 #include "duckdb/storage/compression/patas/patas.hpp"
 
+#include "duckdb/common/vector/flat_vector.hpp"
 #include "duckdb/function/compression_function.hpp"
 #include "duckdb/storage/buffer_manager.hpp"
 

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -150,6 +150,7 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_GLOBAL(EnableLogging),
     DUCKDB_SETTING(EnableMacroDependenciesSetting),
     DUCKDB_SETTING(EnableObjectCacheSetting),
+    DUCKDB_SETTING(EnableOptimisticWriteSetting),
     DUCKDB_SETTING(EnableOptimizerSetting),
     DUCKDB_LOCAL(EnableProfilingSetting),
     DUCKDB_LOCAL(EnableProgressBarSetting),
@@ -249,12 +250,12 @@ static const ConfigurationOption internal_options[] = {
 
 static const ConfigurationAlias setting_aliases[] = {DUCKDB_SETTING_ALIAS("configure_metrics", 30),
                                                      DUCKDB_SETTING_ALIAS("custom_profiling_settings", 30),
-                                                     DUCKDB_SETTING_ALIAS("memory_limit", 128),
+                                                     DUCKDB_SETTING_ALIAS("memory_limit", 129),
                                                      DUCKDB_SETTING_ALIAS("null_order", 61),
-                                                     DUCKDB_SETTING_ALIAS("profile_output", 151),
-                                                     DUCKDB_SETTING_ALIAS("user", 170),
+                                                     DUCKDB_SETTING_ALIAS("profile_output", 152),
+                                                     DUCKDB_SETTING_ALIAS("user", 171),
                                                      DUCKDB_SETTING_ALIAS("wal_autocheckpoint", 29),
-                                                     DUCKDB_SETTING_ALIAS("worker_threads", 168),
+                                                     DUCKDB_SETTING_ALIAS("worker_threads", 169),
                                                      FINAL_ALIAS};
 
 vector<ConfigurationOption> DBConfig::GetOptions() {

--- a/src/storage/optimistic_data_writer.cpp
+++ b/src/storage/optimistic_data_writer.cpp
@@ -26,6 +26,10 @@ OptimisticDataWriter::~OptimisticDataWriter() {
 }
 
 bool OptimisticDataWriter::PrepareWrite() {
+	// check if optimistic writing is enabled
+	if (!Settings::Get<EnableOptimisticWriteSetting>(context)) {
+		return false;
+	}
 	// check if we should pre-emptively write the table to disk
 	auto &attached = table.GetAttached();
 	auto &storage_manager = StorageManager::Get(attached);

--- a/test/api/test_reset.cpp
+++ b/test/api/test_reset.cpp
@@ -148,6 +148,7 @@ OptionValueSet GetValueForOption(const string &name, const LogicalType &type) {
 	    {"checkpoint_on_detach", {"ENABLED"}},
 	    {"debug_verify_statement", {"copy_statement"}},
 	    {"enable_caching_operators", {false}},
+	    {"enable_optimistic_write", {false}},
 	    {"enable_optimizer", {false}},
 	    {"parallelize_sequential_sources", {false}},
 	    {"initial_column_segment_size", {4096}},


### PR DESCRIPTION
Currently optimistic writing is always done when we insert more rows than a specific threshold. This PR adds the `enable_optimistic_write` setting which allows this behavior to be disabled, e.g.:

```sql
SET enable_optimistic_write=false;
```