### PR TITLE
Fix vector operations deprecation warning

### DIFF
--- a/src/include/duckdb/common/vector_operations/vector_operations.hpp
+++ b/src/include/duckdb/common/vector_operations/vector_operations.hpp
@@ -321,12 +321,12 @@ struct VectorOperations {
 		}
 		LessThanEquals(left, right, result);
 	}
-	[[deprecated("count parameter is deprecated; call Comparator without count instead")]] static void
+	[[deprecated("count parameter is deprecated; call Comparator with ExpressionType instead")]] static void
 	Comparator(const Vector &left, const Vector &right, Vector &result, idx_t count) {
 		if (count != left.size()) {
 			throw InternalException("Comparator: count (%llu) does not match vector size (%llu)", count, left.size());
 		}
-		Comparator(left, right, result, false);
+		Comparator(left, right, result, ExpressionType::COMPARE_EQUAL);
 	}
 	[[deprecated("count parameter is deprecated; call DistinctFrom without count instead")]] static void
 	DistinctFrom(const Vector &left, const Vector &right, Vector &result, idx_t count) {


### PR DESCRIPTION
There are many compiler [warnings](https://github.com/duckdb/duckdb/actions/runs/30274150761/job/90004006374?pr=24190#step:9:114) in the linux release CI job for this deprecation:
```
In file included from /home/runner/work/duckdb/duckdb/src/include/duckdb/common/vector_operations/binary_executor.hpp:17,
                 from /home/runner/work/duckdb/duckdb/src/include/duckdb/function/scalar_function.hpp:11,
                 from /home/runner/work/duckdb/duckdb/src/include/duckdb/function/cast/default_casts.hpp:15,
                 from /home/runner/work/duckdb/duckdb/src/include/duckdb/main/config.hpp:28,
                 from /home/runner/work/duckdb/duckdb/src/include/duckdb/main/database.hpp:13,
                 from /home/runner/work/duckdb/duckdb/src/include/duckdb.hpp:12,
                 from /home/runner/work/duckdb/duckdb/test/sqlite/result_helper.hpp:11,
                 from /home/runner/work/duckdb/duckdb/test/sqlite/result_helper.cpp:1,
                 from /home/runner/work/duckdb/duckdb/build/release/test/sqlite/ub_test_sqlite.cpp:2:
/home/runner/work/duckdb/duckdb/src/include/duckdb/common/vector_operations/vector_operations.hpp: In static member function ‘static void duckdb::VectorOperations::Comparator(const duckdb::Vector&, const duckdb::Vector&, duckdb::Vector&, duckdb::idx_t)’:
Warning: /home/runner/work/duckdb/duckdb/src/include/duckdb/common/vector_operations/vector_operations.hpp:329:27: warning: ‘static void duckdb::VectorOperations::Comparator(const duckdb::Vector&, const duckdb::Vector&, duckdb::Vector&, duckdb::idx_t)’ is deprecated: count parameter is deprecated; call Comparator without count instead [-Wdeprecated-declarations]
  329 |                 Comparator(left, right, result, false);
      |                 ~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/runner/work/duckdb/duckdb/src/include/duckdb/common/vector_operations/vector_operations.hpp:325:9: note: declared here
  325 |         Comparator(const Vector &left, const Vector &right, Vector &result, idx_t count) {
      |         ^~~~~~~~~~
```