### PR TITLE
Add `capitalize_identifier` setting for uppercase identifier folding (v1.5)

### DIFF
--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -194,6 +194,13 @@
         ]
     },
     {
+        "name": "capitalize_identifier",
+        "description": "When preserve_identifier_case is false, uppercase non-quoted identifiers instead of lowercasing them (no effect when preserve_identifier_case is true)",
+        "type": "BOOLEAN",
+        "default_scope": "local",
+        "default_value": "false"
+    },
+    {
         "name": "catalog_error_max_schemas",
         "description": "The maximum number of schemas the system will scan for \\\"did you mean...\\\" style errors in the catalog",
         "type": "UBIGINT",

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -360,6 +360,18 @@ struct BlockAllocatorMemorySetting {
 	static Value GetSetting(const ClientContext &context);
 };
 
+struct CapitalizeIdentifierSetting {
+	using RETURN_TYPE = bool;
+	static constexpr const char *Name = "capitalize_identifier";
+	static constexpr const char *Description =
+	    "When preserve_identifier_case is false, uppercase non-quoted identifiers instead of lowercasing them (no "
+	    "effect when preserve_identifier_case is true)";
+	static constexpr const char *InputType = "BOOLEAN";
+	static constexpr const char *DefaultValue = "false";
+	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
+	static constexpr idx_t SettingIndex = 15;
+};
+
 struct CatalogErrorMaxSchemasSetting {
 	using RETURN_TYPE = idx_t;
 	static constexpr const char *Name = "catalog_error_max_schemas";
@@ -368,7 +380,7 @@ struct CatalogErrorMaxSchemasSetting {
 	static constexpr const char *InputType = "UBIGINT";
 	static constexpr const char *DefaultValue = "100";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = 15;
+	static constexpr idx_t SettingIndex = 16;
 };
 
 struct CheckpointThresholdSetting {
@@ -390,7 +402,7 @@ struct CurrentTransactionInvalidationPolicySetting {
 	static constexpr const char *InputType = "VARCHAR";
 	static constexpr const char *DefaultValue = "STANDARD_POLICY";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = 16;
+	static constexpr idx_t SettingIndex = 17;
 	static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
@@ -401,7 +413,7 @@ struct CustomExtensionRepositorySetting {
 	static constexpr const char *InputType = "VARCHAR";
 	static constexpr const char *DefaultValue = "";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = 17;
+	static constexpr idx_t SettingIndex = 18;
 };
 
 struct CustomProfilingSettingsSetting {
@@ -431,7 +443,7 @@ struct DebugAsofIejoinSetting {
 	static constexpr const char *InputType = "BOOLEAN";
 	static constexpr const char *DefaultValue = "false";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = 18;
+	static constexpr idx_t SettingIndex = 19;
 };
 
 struct DebugCheckpointAbortSetting {
@@ -442,7 +454,7 @@ struct DebugCheckpointAbortSetting {
 	static constexpr const char *InputType = "VARCHAR";
 	static constexpr const char *DefaultValue = "NONE";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = 19;
+	static constexpr idx_t SettingIndex = 20;
 	static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
@@ -453,7 +465,7 @@ struct DebugCheckpointSleepMsSetting {
 	static constexpr const char *InputType = "UBIGINT";
 	static constexpr const char *DefaultValue = "0";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = 20;
+	static constexpr idx_t SettingIndex = 21;
 };
 
 struct DebugEvictionQueueSleepMicroSecondsSetting {
@@ -464,7 +476,7 @@ struct DebugEvictionQueueSleepMicroSecondsSetting {
 	static constexpr const char *InputType = "UBIGINT";
 	static constexpr const char *DefaultValue = "0";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = 21;
+	static constexpr idx_t SettingIndex = 22;
 };
 
 struct DebugForceExternalSetting {
@@ -486,7 +498,7 @@ struct DebugForceNoCrossProductSetting {
 	static constexpr const char *InputType = "BOOLEAN";
 	static constexpr const char *DefaultValue = "false";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = 22;
+	static constexpr idx_t SettingIndex = 23;
 };
 
 struct DebugPhysicalTableScanExecutionStrategySetting {
@@ -497,7 +509,7 @@ struct DebugPhysicalTableScanExecutionStrategySetting {
 	static constexpr const char *InputType = "VARCHAR";
 	static constexpr const char *DefaultValue = "DEFAULT";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = 23;
+	static constexpr idx_t SettingIndex = 24;
 	static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
@@ -508,7 +520,7 @@ struct DebugSkipCheckpointOnCommitSetting {
 	static constexpr const char *InputType = "BOOLEAN";
 	static constexpr const char *DefaultValue = "false";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = 24;
+	static constexpr idx_t SettingIndex = 25;
 };
 
 struct DebugVerifyBlocksSetting {
@@ -518,7 +530,7 @@ struct DebugVerifyBlocksSetting {
 	static constexpr const char *InputType = "BOOLEAN";
 	static constexpr const char *DefaultValue = "false";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = 25;
+	static constexpr idx_t SettingIndex = 26;
 };
 
 struct DebugVerifyVectorSetting {
@@ -528,7 +540,7 @@ struct DebugVerifyVectorSetting {
 	static constexpr const char *InputType = "VARCHAR";
 	static constexpr const char *DefaultValue = "NONE";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = 26;
+	static constexpr idx_t SettingIndex = 27;
 	static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
@@ -539,7 +551,7 @@ struct DebugWindowModeSetting {
 	static constexpr const char *InputType = "VARCHAR";
 	static constexpr const char *DefaultValue = "WINDOW";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = 27;
+	static constexpr idx_t SettingIndex = 28;
 	static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
@@ -551,7 +563,7 @@ struct DefaultBlockSizeSetting {
 	static constexpr const char *InputType = "UBIGINT";
 	static constexpr const char *DefaultValue = "262144";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = 28;
+	static constexpr idx_t SettingIndex = 29;
 	static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
@@ -562,7 +574,7 @@ struct DefaultCollationSetting {
 	static constexpr const char *InputType = "VARCHAR";
 	static constexpr const char *DefaultValue = "";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = 29;
+	static constexpr idx_t SettingIndex = 30;
 	static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
@@ -573,7 +585,7 @@ struct DefaultNullOrderSetting {
 	static constexpr const char *InputType = "VARCHAR";
 	static constexpr const char *DefaultValue = "NULLS_LAST";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = 30;
+	static constexpr idx_t SettingIndex = 31;
 	static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
@@ -584,7 +596,7 @@ struct DefaultOrderSetting {
 	static constexpr const char *InputType = "VARCHAR";
 	static constexpr const char *DefaultValue = "ASCENDING";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = 31;
+	static constexpr idx_t SettingIndex = 32;
 	static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
@@ -605,7 +617,7 @@ struct DeprecatedUsingKeySyntaxSetting {
 	static constexpr const char *InputType = "VARCHAR";
 	static constexpr const char *DefaultValue = "DEFAULT";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = 32;
+	static constexpr idx_t SettingIndex = 33;
 	static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
@@ -618,7 +630,7 @@ struct DisableDatabaseInvalidationSetting {
 	static constexpr const char *InputType = "BOOLEAN";
 	static constexpr const char *DefaultValue = "false";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = 33;
+	static constexpr idx_t SettingIndex = 34;
 	static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
@@ -629,7 +641,7 @@ struct DisableTimestamptzCastsSetting {
 	static constexpr const char *InputType = "BOOLEAN";
 	static constexpr const char *DefaultValue = "false";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = 34;
+	static constexpr idx_t SettingIndex = 35;
 };
 
 struct DisabledCompressionMethodsSetting {
@@ -679,7 +691,7 @@ struct DuckDBAPISetting {
 	static constexpr const char *InputType = "VARCHAR";
 	static constexpr const char *DefaultValue = "";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = 35;
+	static constexpr idx_t SettingIndex = 36;
 	static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
@@ -691,7 +703,7 @@ struct DynamicOrFilterThresholdSetting {
 	static constexpr const char *InputType = "UBIGINT";
 	static constexpr const char *DefaultValue = "50";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = 36;
+	static constexpr idx_t SettingIndex = 37;
 };
 
 struct EnableCachingOperatorsSetting {
@@ -713,7 +725,7 @@ struct EnableExternalAccessSetting {
 	static constexpr const char *InputType = "BOOLEAN";
 	static constexpr const char *DefaultValue = "true";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = 37;
+	static constexpr idx_t SettingIndex = 38;
 	static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
@@ -724,7 +736,7 @@ struct EnableExternalFileCacheSetting {
 	static constexpr const char *InputType = "BOOLEAN";
 	static constexpr const char *DefaultValue = "true";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = 38;
+	static constexpr idx_t SettingIndex = 39;
 	static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
@@ -736,7 +748,7 @@ struct EnableFSSTVectorsSetting {
 	static constexpr const char *InputType = "BOOLEAN";
 	static constexpr const char *DefaultValue = "false";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = 39;
+	static constexpr idx_t SettingIndex = 40;
 };
 
 struct EnableHTTPLoggingSetting {
@@ -756,7 +768,7 @@ struct EnableHTTPMetadataCacheSetting {
 	static constexpr const char *InputType = "BOOLEAN";
 	static constexpr const char *DefaultValue = "false";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = 40;
+	static constexpr idx_t SettingIndex = 41;
 };
 
 struct EnableLogging {
@@ -777,7 +789,7 @@ struct EnableMacroDependenciesSetting {
 	static constexpr const char *InputType = "BOOLEAN";
 	static constexpr const char *DefaultValue = "false";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = 41;
+	static constexpr idx_t SettingIndex = 42;
 };
 
 struct EnableObjectCacheSetting {
@@ -787,7 +799,7 @@ struct EnableObjectCacheSetting {
 	static constexpr const char *InputType = "BOOLEAN";
 	static constexpr const char *DefaultValue = "false";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = 42;
+	static constexpr idx_t SettingIndex = 43;
 };
 
 struct EnableProfilingSetting {
@@ -833,7 +845,7 @@ struct EnableViewDependenciesSetting {
 	static constexpr const char *InputType = "BOOLEAN";
 	static constexpr const char *DefaultValue = "false";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = 43;
+	static constexpr idx_t SettingIndex = 44;
 };
 
 struct EnabledLogTypes {
@@ -853,7 +865,7 @@ struct ErrorsAsJSONSetting {
 	static constexpr const char *InputType = "BOOLEAN";
 	static constexpr const char *DefaultValue = "false";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = 44;
+	static constexpr idx_t SettingIndex = 45;
 };
 
 struct ExperimentalMetadataReuseSetting {
@@ -863,7 +875,7 @@ struct ExperimentalMetadataReuseSetting {
 	static constexpr const char *InputType = "BOOLEAN";
 	static constexpr const char *DefaultValue = "true";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = 45;
+	static constexpr idx_t SettingIndex = 46;
 };
 
 struct ExplainOutputSetting {
@@ -873,7 +885,7 @@ struct ExplainOutputSetting {
 	static constexpr const char *InputType = "VARCHAR";
 	static constexpr const char *DefaultValue = "PHYSICAL_ONLY";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = 46;
+	static constexpr idx_t SettingIndex = 47;
 	static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
@@ -894,7 +906,7 @@ struct ExtensionDirectorySetting {
 	static constexpr const char *InputType = "VARCHAR";
 	static constexpr const char *DefaultValue = "";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = 47;
+	static constexpr idx_t SettingIndex = 48;
 };
 
 struct ExternalThreadsSetting {
@@ -904,7 +916,7 @@ struct ExternalThreadsSetting {
 	static constexpr const char *InputType = "UBIGINT";
 	static constexpr const char *DefaultValue = "1";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = 48;
+	static constexpr idx_t SettingIndex = 49;
 	static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
@@ -915,7 +927,7 @@ struct FileSearchPathSetting {
 	static constexpr const char *InputType = "VARCHAR";
 	static constexpr const char *DefaultValue = "";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = 49;
+	static constexpr idx_t SettingIndex = 50;
 };
 
 struct ForceBitpackingModeSetting {
@@ -925,7 +937,7 @@ struct ForceBitpackingModeSetting {
 	static constexpr const char *InputType = "VARCHAR";
 	static constexpr const char *DefaultValue = "AUTO";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = 50;
+	static constexpr idx_t SettingIndex = 51;
 	static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
@@ -938,7 +950,7 @@ struct ForceColumnMetadataReuseSetting {
 	static constexpr const char *InputType = "BOOLEAN";
 	static constexpr const char *DefaultValue = "false";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = 51;
+	static constexpr idx_t SettingIndex = 52;
 };
 
 struct ForceCompressionSetting {
@@ -948,7 +960,7 @@ struct ForceCompressionSetting {
 	static constexpr const char *InputType = "VARCHAR";
 	static constexpr const char *DefaultValue = "auto";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = 52;
+	static constexpr idx_t SettingIndex = 53;
 	static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
@@ -981,7 +993,7 @@ struct GeometryMinimumShreddingSize {
 	static constexpr const char *InputType = "BIGINT";
 	static constexpr const char *DefaultValue = "30000";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = 53;
+	static constexpr idx_t SettingIndex = 54;
 };
 
 struct HomeDirectorySetting {
@@ -991,7 +1003,7 @@ struct HomeDirectorySetting {
 	static constexpr const char *InputType = "VARCHAR";
 	static constexpr const char *DefaultValue = "";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = 54;
+	static constexpr idx_t SettingIndex = 55;
 	static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
@@ -1024,7 +1036,7 @@ struct HTTPProxyPasswordSetting {
 	static constexpr const char *InputType = "VARCHAR";
 	static constexpr const char *DefaultValue = "";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = 55;
+	static constexpr idx_t SettingIndex = 56;
 };
 
 struct HTTPProxyUsernameSetting {
@@ -1034,7 +1046,7 @@ struct HTTPProxyUsernameSetting {
 	static constexpr const char *InputType = "VARCHAR";
 	static constexpr const char *DefaultValue = "";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = 56;
+	static constexpr idx_t SettingIndex = 57;
 };
 
 struct IeeeFloatingPointOpsSetting {
@@ -1045,7 +1057,7 @@ struct IeeeFloatingPointOpsSetting {
 	static constexpr const char *InputType = "BOOLEAN";
 	static constexpr const char *DefaultValue = "true";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = 57;
+	static constexpr idx_t SettingIndex = 58;
 };
 
 struct IgnoreUnknownCrsSetting {
@@ -1056,7 +1068,7 @@ struct IgnoreUnknownCrsSetting {
 	static constexpr const char *InputType = "BOOLEAN";
 	static constexpr const char *DefaultValue = "false";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = 58;
+	static constexpr idx_t SettingIndex = 59;
 };
 
 struct ImmediateTransactionModeSetting {
@@ -1067,7 +1079,7 @@ struct ImmediateTransactionModeSetting {
 	static constexpr const char *InputType = "BOOLEAN";
 	static constexpr const char *DefaultValue = "false";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = 59;
+	static constexpr idx_t SettingIndex = 60;
 };
 
 struct IndexScanMaxCountSetting {
@@ -1079,7 +1091,7 @@ struct IndexScanMaxCountSetting {
 	static constexpr const char *InputType = "UBIGINT";
 	static constexpr const char *DefaultValue = "2048";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = 60;
+	static constexpr idx_t SettingIndex = 61;
 };
 
 struct IndexScanPercentageSetting {
@@ -1091,7 +1103,7 @@ struct IndexScanPercentageSetting {
 	static constexpr const char *InputType = "DOUBLE";
 	static constexpr const char *DefaultValue = "0.001";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = 61;
+	static constexpr idx_t SettingIndex = 62;
 	static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
@@ -1103,7 +1115,7 @@ struct IntegerDivisionSetting {
 	static constexpr const char *InputType = "BOOLEAN";
 	static constexpr const char *DefaultValue = "false";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = 62;
+	static constexpr idx_t SettingIndex = 63;
 };
 
 struct LambdaSyntaxSetting {
@@ -1114,7 +1126,7 @@ struct LambdaSyntaxSetting {
 	static constexpr const char *InputType = "VARCHAR";
 	static constexpr const char *DefaultValue = "DEFAULT";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = 63;
+	static constexpr idx_t SettingIndex = 64;
 	static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
@@ -1126,7 +1138,7 @@ struct LateMaterializationMaxRowsSetting {
 	static constexpr const char *InputType = "UBIGINT";
 	static constexpr const char *DefaultValue = "50";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = 64;
+	static constexpr idx_t SettingIndex = 65;
 };
 
 struct LockConfigurationSetting {
@@ -1136,7 +1148,7 @@ struct LockConfigurationSetting {
 	static constexpr const char *InputType = "BOOLEAN";
 	static constexpr const char *DefaultValue = "false";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = 65;
+	static constexpr idx_t SettingIndex = 66;
 };
 
 struct LogQueryPathSetting {
@@ -1147,7 +1159,7 @@ struct LogQueryPathSetting {
 	static constexpr const char *InputType = "VARCHAR";
 	static constexpr const char *DefaultValue = "";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = 66;
+	static constexpr idx_t SettingIndex = 67;
 	static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
@@ -1190,7 +1202,7 @@ struct MaxExpressionDepthSetting {
 	static constexpr const char *InputType = "UBIGINT";
 	static constexpr const char *DefaultValue = "1000";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = 67;
+	static constexpr idx_t SettingIndex = 68;
 };
 
 struct MaxMemorySetting {
@@ -1221,7 +1233,7 @@ struct MaxVacuumTasksSetting {
 	static constexpr const char *InputType = "UBIGINT";
 	static constexpr const char *DefaultValue = "100";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = 68;
+	static constexpr idx_t SettingIndex = 69;
 };
 
 struct MergeJoinThresholdSetting {
@@ -1231,7 +1243,7 @@ struct MergeJoinThresholdSetting {
 	static constexpr const char *InputType = "UBIGINT";
 	static constexpr const char *DefaultValue = "1000";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = 69;
+	static constexpr idx_t SettingIndex = 70;
 };
 
 struct NestedLoopJoinThresholdSetting {
@@ -1242,7 +1254,7 @@ struct NestedLoopJoinThresholdSetting {
 	static constexpr const char *InputType = "UBIGINT";
 	static constexpr const char *DefaultValue = "5";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = 70;
+	static constexpr idx_t SettingIndex = 71;
 };
 
 struct OldImplicitCastingSetting {
@@ -1252,7 +1264,7 @@ struct OldImplicitCastingSetting {
 	static constexpr const char *InputType = "BOOLEAN";
 	static constexpr const char *DefaultValue = "false";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = 71;
+	static constexpr idx_t SettingIndex = 72;
 };
 
 struct OrderByNonIntegerLiteralSetting {
@@ -1263,7 +1275,7 @@ struct OrderByNonIntegerLiteralSetting {
 	static constexpr const char *InputType = "BOOLEAN";
 	static constexpr const char *DefaultValue = "false";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = 72;
+	static constexpr idx_t SettingIndex = 73;
 };
 
 struct OrderedAggregateThresholdSetting {
@@ -1273,7 +1285,7 @@ struct OrderedAggregateThresholdSetting {
 	static constexpr const char *InputType = "UBIGINT";
 	static constexpr const char *DefaultValue = "262144";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = 73;
+	static constexpr idx_t SettingIndex = 74;
 	static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
@@ -1285,7 +1297,7 @@ struct PartitionedWriteFlushThresholdSetting {
 	static constexpr const char *InputType = "UBIGINT";
 	static constexpr const char *DefaultValue = "524288";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = 74;
+	static constexpr idx_t SettingIndex = 75;
 };
 
 struct PartitionedWriteMaxOpenFilesSetting {
@@ -1296,7 +1308,7 @@ struct PartitionedWriteMaxOpenFilesSetting {
 	static constexpr const char *InputType = "UBIGINT";
 	static constexpr const char *DefaultValue = "100";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = 75;
+	static constexpr idx_t SettingIndex = 76;
 };
 
 struct PasswordSetting {
@@ -1306,7 +1318,7 @@ struct PasswordSetting {
 	static constexpr const char *InputType = "VARCHAR";
 	static constexpr const char *DefaultValue = "";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = 76;
+	static constexpr idx_t SettingIndex = 77;
 };
 
 struct PerfectHtThresholdSetting {
@@ -1316,7 +1328,7 @@ struct PerfectHtThresholdSetting {
 	static constexpr const char *InputType = "UBIGINT";
 	static constexpr const char *DefaultValue = "12";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = 77;
+	static constexpr idx_t SettingIndex = 78;
 	static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
@@ -1328,7 +1340,7 @@ struct PinThreadsSetting {
 	static constexpr const char *InputType = "VARCHAR";
 	static constexpr const char *DefaultValue = "auto";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = 78;
+	static constexpr idx_t SettingIndex = 79;
 	static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
@@ -1340,7 +1352,7 @@ struct PivotFilterThresholdSetting {
 	static constexpr const char *InputType = "UBIGINT";
 	static constexpr const char *DefaultValue = "20";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = 79;
+	static constexpr idx_t SettingIndex = 80;
 };
 
 struct PivotLimitSetting {
@@ -1350,7 +1362,7 @@ struct PivotLimitSetting {
 	static constexpr const char *InputType = "UBIGINT";
 	static constexpr const char *DefaultValue = "100000";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = 80;
+	static constexpr idx_t SettingIndex = 81;
 };
 
 struct PreferRangeJoinsSetting {
@@ -1360,7 +1372,7 @@ struct PreferRangeJoinsSetting {
 	static constexpr const char *InputType = "BOOLEAN";
 	static constexpr const char *DefaultValue = "false";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = 81;
+	static constexpr idx_t SettingIndex = 82;
 };
 
 struct PreserveIdentifierCaseSetting {
@@ -1371,7 +1383,7 @@ struct PreserveIdentifierCaseSetting {
 	static constexpr const char *InputType = "BOOLEAN";
 	static constexpr const char *DefaultValue = "true";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = 82;
+	static constexpr idx_t SettingIndex = 83;
 };
 
 struct PreserveInsertionOrderSetting {
@@ -1383,7 +1395,7 @@ struct PreserveInsertionOrderSetting {
 	static constexpr const char *InputType = "BOOLEAN";
 	static constexpr const char *DefaultValue = "true";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = 83;
+	static constexpr idx_t SettingIndex = 84;
 };
 
 struct ProduceArrowStringViewSetting {
@@ -1394,7 +1406,7 @@ struct ProduceArrowStringViewSetting {
 	static constexpr const char *InputType = "BOOLEAN";
 	static constexpr const char *DefaultValue = "false";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = 84;
+	static constexpr idx_t SettingIndex = 85;
 };
 
 struct ProfileOutputSetting {
@@ -1447,7 +1459,7 @@ struct ScalarSubqueryErrorOnMultipleRowsSetting {
 	static constexpr const char *InputType = "BOOLEAN";
 	static constexpr const char *DefaultValue = "true";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = 85;
+	static constexpr idx_t SettingIndex = 86;
 };
 
 struct SchedulerProcessPartialSetting {
@@ -1462,7 +1474,7 @@ struct SchedulerProcessPartialSetting {
 	static constexpr const char *DefaultValue = "false";
 #endif
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = 86;
+	static constexpr idx_t SettingIndex = 87;
 };
 
 struct SchemaSetting {
@@ -1504,7 +1516,7 @@ struct StorageBlockPrefetchSetting {
 	static constexpr const char *InputType = "VARCHAR";
 	static constexpr const char *DefaultValue = "REMOTE_ONLY";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = 87;
+	static constexpr idx_t SettingIndex = 88;
 	static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
@@ -1546,7 +1558,7 @@ struct TempFileEncryptionSetting {
 	static constexpr const char *InputType = "BOOLEAN";
 	static constexpr const char *DefaultValue = "false";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = 88;
+	static constexpr idx_t SettingIndex = 89;
 	static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
@@ -1567,7 +1579,7 @@ struct UsernameSetting {
 	static constexpr const char *InputType = "VARCHAR";
 	static constexpr const char *DefaultValue = "";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = 89;
+	static constexpr idx_t SettingIndex = 90;
 };
 
 struct VacuumRebuildIndexesSetting {
@@ -1580,7 +1592,7 @@ struct VacuumRebuildIndexesSetting {
 	static constexpr const char *InputType = "UBIGINT";
 	static constexpr const char *DefaultValue = "0";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = 90;
+	static constexpr idx_t SettingIndex = 91;
 	static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
@@ -1593,7 +1605,7 @@ struct ValidateExternalFileCacheSetting {
 	static constexpr const char *InputType = "VARCHAR";
 	static constexpr const char *DefaultValue = "VALIDATE_ALL";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = 91;
+	static constexpr idx_t SettingIndex = 92;
 	static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
@@ -1605,7 +1617,7 @@ struct VariantMinimumShreddingSizeSetting {
 	static constexpr const char *InputType = "BIGINT";
 	static constexpr const char *DefaultValue = "30000";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = 92;
+	static constexpr idx_t SettingIndex = 93;
 };
 
 struct WalAutocheckpointEntriesSetting {
@@ -1616,7 +1628,7 @@ struct WalAutocheckpointEntriesSetting {
 	static constexpr const char *InputType = "UBIGINT";
 	static constexpr const char *DefaultValue = "0";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = 93;
+	static constexpr idx_t SettingIndex = 94;
 };
 
 struct WarningsAsErrorsSetting {
@@ -1626,7 +1638,7 @@ struct WarningsAsErrorsSetting {
 	static constexpr const char *InputType = "BOOLEAN";
 	static constexpr const char *DefaultValue = "false";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = 94;
+	static constexpr idx_t SettingIndex = 95;
 	static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
@@ -1638,7 +1650,7 @@ struct WriteBufferRowGroupCountSetting {
 	static constexpr const char *InputType = "UBIGINT";
 	static constexpr const char *DefaultValue = "5";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = 95;
+	static constexpr idx_t SettingIndex = 96;
 };
 
 struct WriteBufferRowGroupMemoryLimitSetting {
@@ -1662,11 +1674,11 @@ struct ZstdMinStringLengthSetting {
 	static constexpr const char *InputType = "UBIGINT";
 	static constexpr const char *DefaultValue = "4096";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = 96;
+	static constexpr idx_t SettingIndex = 97;
 };
 
 struct GeneratedSettingInfo {
-	static constexpr idx_t MaxSettingIndex = 97;
+	static constexpr idx_t MaxSettingIndex = 98;
 };
 
 //===----------------------------------------------------------------------===//

--- a/src/include/duckdb/parser/parser_options.hpp
+++ b/src/include/duckdb/parser/parser_options.hpp
@@ -18,6 +18,7 @@ class ParserExtension;
 
 struct ParserOptions {
 	bool preserve_identifier_case = true;
+	bool capitalize_identifier = false;
 	bool integer_division = false;
 	idx_t max_expression_depth = 1000;
 	optional_ptr<const ExtensionCallbackManager> extensions;

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -1464,6 +1464,7 @@ SettingLookupResult ClientContext::TryGetCurrentUserSetting(idx_t setting_index,
 ParserOptions ClientContext::GetParserOptions() const {
 	ParserOptions options;
 	options.preserve_identifier_case = Settings::Get<PreserveIdentifierCaseSetting>(*this);
+	options.capitalize_identifier = Settings::Get<CapitalizeIdentifierSetting>(*this);
 	options.integer_division = Settings::Get<IntegerDivisionSetting>(*this);
 	options.max_expression_depth = Settings::Get<MaxExpressionDepthSetting>(*this);
 	options.extensions = DBConfig::GetConfig(*this).GetCallbackManager();

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -89,6 +89,7 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_SETTING(AutoinstallKnownExtensionsSetting),
     DUCKDB_SETTING(AutoloadKnownExtensionsSetting),
     DUCKDB_GLOBAL(BlockAllocatorMemorySetting),
+    DUCKDB_SETTING(CapitalizeIdentifierSetting),
     DUCKDB_SETTING(CatalogErrorMaxSchemasSetting),
     DUCKDB_GLOBAL(CheckpointThresholdSetting),
     DUCKDB_SETTING_CALLBACK(CurrentTransactionInvalidationPolicySetting),
@@ -211,12 +212,12 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_SETTING(ZstdMinStringLengthSetting),
     FINAL_SETTING};
 
-static const ConfigurationAlias setting_aliases[] = {DUCKDB_SETTING_ALIAS("memory_limit", 101),
-                                                     DUCKDB_SETTING_ALIAS("null_order", 43),
-                                                     DUCKDB_SETTING_ALIAS("profiling_output", 120),
-                                                     DUCKDB_SETTING_ALIAS("user", 135),
-                                                     DUCKDB_SETTING_ALIAS("wal_autocheckpoint", 25),
-                                                     DUCKDB_SETTING_ALIAS("worker_threads", 134),
+static const ConfigurationAlias setting_aliases[] = {DUCKDB_SETTING_ALIAS("memory_limit", 102),
+                                                     DUCKDB_SETTING_ALIAS("null_order", 44),
+                                                     DUCKDB_SETTING_ALIAS("profiling_output", 121),
+                                                     DUCKDB_SETTING_ALIAS("user", 136),
+                                                     DUCKDB_SETTING_ALIAS("wal_autocheckpoint", 26),
+                                                     DUCKDB_SETTING_ALIAS("worker_threads", 135),
                                                      FINAL_ALIAS};
 
 vector<ConfigurationOption> DBConfig::GetOptions() {

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -265,6 +265,7 @@ void Parser::ParseQuery(const string &query) {
 			}
 		}
 		PostgresParser::SetPreserveIdentifierCase(options.preserve_identifier_case);
+		PostgresParser::SetCapitalizeIdentifier(options.capitalize_identifier);
 		bool parsing_succeed = false;
 		// Creating a new scope to prevent multiple PostgresParser destructors being called
 		// which led to some memory issues

--- a/test/configs/enable_verification_for_debug.json
+++ b/test/configs/enable_verification_for_debug.json
@@ -349,6 +349,7 @@
         "test/sql/setops/test_union_by_name.test",
         "test/sql/setops/union_all_projection_pushdown.test",
         "test/sql/settings/setting_preserve_identifier_case.test",
+        "test/sql/settings/setting_capitalize_identifier.test",
         "test/sql/show_select/test_describe_all.test",
         "test/sql/show_select/test_summarize.test",
         "test/sql/storage/append_strings_to_persistent.test",

--- a/test/configs/one_schema_per_test.json
+++ b/test/configs/one_schema_per_test.json
@@ -45,6 +45,7 @@
       "reason": "Tests that list types / tables / schemas DB-wide, so can't come with extra schemas",
       "paths": [
         "test/sql/settings/setting_preserve_identifier_case.test",
+        "test/sql/settings/setting_capitalize_identifier.test",
         "test/sql/types/enum/test_enum_duckdb_types.test",
         "test/sql/generated_columns/virtual/gcol_duckdb_columns.test",
         "test/sql/constraints/foreignkey/fk_4365.test",

--- a/test/sql/settings/setting_capitalize_identifier.test
+++ b/test/sql/settings/setting_capitalize_identifier.test
@@ -60,6 +60,12 @@ QuotedName	MixedCol
 statement ok
 DROP TABLE "QuotedName"
 
+# string literals are not folded
+query I
+SELECT 'MyString';
+----
+MyString
+
 # with capitalize_identifier back to false, preserve_identifier_case=false lowercases as before
 statement ok
 SET capitalize_identifier TO false;
@@ -74,3 +80,43 @@ query III
 SELECT duckdb_tables.schema_name, duckdb_tables.table_name, column_name FROM duckdb_tables JOIN duckdb_columns USING (table_oid);
 ----
 myschema	integers	i
+
+statement ok
+DROP SCHEMA myschema CASCADE
+
+# RESET restores the defaults
+statement ok
+SET capitalize_identifier TO true;
+
+statement ok
+RESET capitalize_identifier;
+
+query I
+SELECT value FROM duckdb_settings() WHERE name='capitalize_identifier'
+----
+false
+
+statement ok
+RESET preserve_identifier_case;
+
+query I
+SELECT value FROM duckdb_settings() WHERE name='preserve_identifier_case'
+----
+true
+
+# identifier case is preserved again once both settings are back to their defaults
+statement ok
+CREATE TABLE MyTable(i INTEGER);
+
+query I
+SELECT table_name FROM duckdb_tables;
+----
+MyTable
+
+statement ok
+DROP TABLE MyTable
+
+statement error
+SET capitalize_identifier TO 'bogus';
+----
+<REGEX>:.*Could not convert string 'bogus' to BOOL.*

--- a/test/sql/settings/setting_capitalize_identifier.test
+++ b/test/sql/settings/setting_capitalize_identifier.test
@@ -1,0 +1,76 @@
+# name: test/sql/settings/setting_capitalize_identifier.test
+# description: Test capitalize_identifier setting
+# group: [settings]
+
+query I
+SELECT value FROM duckdb_settings() WHERE name='capitalize_identifier'
+----
+false
+
+# capitalize_identifier has no effect while preserve_identifier_case is true
+statement ok
+SET capitalize_identifier TO true;
+
+query I
+SELECT value FROM duckdb_settings() WHERE name='capitalize_identifier'
+----
+true
+
+statement ok
+CREATE SCHEMA MySchema;
+
+statement ok
+CREATE TABLE MySchema.Integers(i INTEGER);
+
+query III
+SELECT duckdb_tables.schema_name, duckdb_tables.table_name, column_name FROM duckdb_tables JOIN duckdb_columns USING (table_oid);
+----
+MySchema	Integers	i
+
+statement ok
+DROP SCHEMA MySchema CASCADE
+
+# with preserve_identifier_case=false, capitalize_identifier uppercases non-quoted identifiers
+statement ok
+SET preserve_identifier_case TO false;
+
+statement ok
+CREATE SCHEMA MySchema;
+
+statement ok
+CREATE TABLE MySchema.Integers(i INTEGER);
+
+query III
+SELECT duckdb_tables.schema_name, duckdb_tables.table_name, column_name FROM duckdb_tables JOIN duckdb_columns USING (table_oid);
+----
+MYSCHEMA	INTEGERS	I
+
+statement ok
+DROP SCHEMA MYSCHEMA CASCADE
+
+# quoted identifiers are still preserved exactly
+statement ok
+CREATE TABLE "QuotedName"("MixedCol" INTEGER);
+
+query II
+SELECT table_name, column_name FROM duckdb_tables JOIN duckdb_columns USING (table_oid);
+----
+QuotedName	MixedCol
+
+statement ok
+DROP TABLE "QuotedName"
+
+# with capitalize_identifier back to false, preserve_identifier_case=false lowercases as before
+statement ok
+SET capitalize_identifier TO false;
+
+statement ok
+CREATE SCHEMA MySchema;
+
+statement ok
+CREATE TABLE MySchema.Integers(i INTEGER);
+
+query III
+SELECT duckdb_tables.schema_name, duckdb_tables.table_name, column_name FROM duckdb_tables JOIN duckdb_columns USING (table_oid);
+----
+myschema	integers	i

--- a/test/sql/settings/setting_capitalize_identifier.test
+++ b/test/sql/settings/setting_capitalize_identifier.test
@@ -53,7 +53,7 @@ statement ok
 CREATE TABLE "QuotedName"("MixedCol" INTEGER);
 
 query II
-SELECT table_name, column_name FROM duckdb_tables JOIN duckdb_columns USING (table_oid);
+SELECT duckdb_tables.table_name, column_name FROM duckdb_tables JOIN duckdb_columns USING (table_oid);
 ----
 QuotedName	MixedCol
 

--- a/third_party/libpg_query/include/parser/scansup.hpp
+++ b/third_party/libpg_query/include/parser/scansup.hpp
@@ -27,4 +27,7 @@ bool scanner_isspace(char ch);
 void set_preserve_identifier_case(bool downcase);
 bool get_preserve_identifier_case();
 
+void set_capitalize_identifier(bool capitalize);
+bool get_capitalize_identifier();
+
 }

--- a/third_party/libpg_query/include/postgres_parser.hpp
+++ b/third_party/libpg_query/include/postgres_parser.hpp
@@ -32,6 +32,7 @@ public:
 	static duckdb::vector<duckdb_libpgquery::PGKeyword> KeywordList();
 
 	static void SetPreserveIdentifierCase(bool downcase);
+	static void SetCapitalizeIdentifier(bool capitalize);
 };
 
 }

--- a/third_party/libpg_query/postgres_parser.cpp
+++ b/third_party/libpg_query/postgres_parser.cpp
@@ -48,4 +48,8 @@ void PostgresParser::SetPreserveIdentifierCase(bool preserve) {
 	duckdb_libpgquery::set_preserve_identifier_case(preserve);
 }
 
+void PostgresParser::SetCapitalizeIdentifier(bool capitalize) {
+	duckdb_libpgquery::set_capitalize_identifier(capitalize);
+}
+
 }

--- a/third_party/libpg_query/src_backend_parser_scansup.cpp
+++ b/third_party/libpg_query/src_backend_parser_scansup.cpp
@@ -79,6 +79,21 @@ bool get_preserve_identifier_case() {
 	return pg_preserve_identifier_case;
 }
 
+#ifdef __MVS__
+static __tlssim<bool> pg_capitalize_identifier_impl(false);
+#define pg_capitalize_identifier (*pg_capitalize_identifier_impl.access())
+#else
+static __thread bool pg_capitalize_identifier = false;
+#endif
+
+void set_capitalize_identifier(bool capitalize) {
+	pg_capitalize_identifier = capitalize;
+}
+
+bool get_capitalize_identifier() {
+	return pg_capitalize_identifier;
+}
+
 /*
  * a workhorse for downcase_truncate_identifier
  */
@@ -103,10 +118,17 @@ char *downcase_identifier(const char *ident, int len, bool warn, bool truncate) 
 		unsigned char ch = (unsigned char)ident[i];
 
 		if (!get_preserve_identifier_case()) {
-			if (ch >= 'A' && ch <= 'Z')
-				ch += 'a' - 'A';
-			else if (enc_is_single_byte && IS_HIGHBIT_SET(ch) && isupper(ch))
-				ch = tolower(ch);
+			if (get_capitalize_identifier()) {
+				if (ch >= 'a' && ch <= 'z')
+					ch -= 'a' - 'A';
+				else if (enc_is_single_byte && IS_HIGHBIT_SET(ch) && islower(ch))
+					ch = toupper(ch);
+			} else {
+				if (ch >= 'A' && ch <= 'Z')
+					ch += 'a' - 'A';
+				else if (enc_is_single_byte && IS_HIGHBIT_SET(ch) && isupper(ch))
+					ch = tolower(ch);
+			}
 		}
 		result[i] = (char)ch;
 	}

--- a/third_party/libpg_query/src_backend_parser_scansup.cpp
+++ b/third_party/libpg_query/src_backend_parser_scansup.cpp
@@ -101,9 +101,13 @@ char *downcase_identifier(const char *ident, int len, bool warn, bool truncate) 
 	char *result;
 	int i;
 	bool enc_is_single_byte;
+	bool preserve_case;
+	bool capitalize;
 
 	result = (char *)palloc(len + 1);
 	enc_is_single_byte = pg_database_encoding_max_length() == 1;
+	preserve_case = get_preserve_identifier_case();
+	capitalize = get_capitalize_identifier();
 
 	/*
 	 * SQL99 specifies Unicode-aware case normalization, which we don't yet
@@ -117,8 +121,8 @@ char *downcase_identifier(const char *ident, int len, bool warn, bool truncate) 
 	for (i = 0; i < len; i++) {
 		unsigned char ch = (unsigned char)ident[i];
 
-		if (!get_preserve_identifier_case()) {
-			if (get_capitalize_identifier()) {
+		if (!preserve_case) {
+			if (capitalize) {
 				if (ch >= 'a' && ch <= 'z')
 					ch -= 'a' - 'A';
 				else if (enc_is_single_byte && IS_HIGHBIT_SET(ch) && islower(ch))


### PR DESCRIPTION
Original patch and authorship: @MartinNeupauer.

This adds a `capitalize_identifier` setting (meaningful only when `preserve_identifier_case=false`) that folds unquoted identifiers to **uppercase** instead of lowercase — matching the default identifier-folding behavior of Snowflake, Oracle, and DB2.

Closes: https://github.com/duckdb/duckdb/discussions/24197

There's two ways to approach solving this:
1. add a new param `capitalize_identifier` that only works when `preserve_identifier_case=false` (what this PR does)
2. modify  `preserve_identifier_case` to have three states: `on`, `lowercase`, `uppercase` (potential backcompat issues; could theoretically land in 2.0)


Targeting `v1.5-variegata` rather than `main`, since this patch was originally written against the pre-PEG-parser `third_party/libpg_query`-based identifier scanner. `main` has since moved to the in-house PEG parser (`src/parser/peg/matcher.cpp`), so the equivalent change there would need to be reimplemented against that parser rather than cherry-picked — that port isn't done yet.