### PR TITLE
Fix indexed DELETE column resolution

### DIFF
--- a/src/execution/physical_plan/plan_delete.cpp
+++ b/src/execution/physical_plan/plan_delete.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
+#include "duckdb/common/constants.hpp"
 #include "duckdb/execution/operator/persistent/physical_delete.hpp"
 #include "duckdb/execution/physical_plan_generator.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
@@ -11,9 +12,19 @@ PhysicalOperator &DuckCatalog::PlanDelete(ClientContext &context, PhysicalPlanGe
                                           PhysicalOperator &plan) {
 	// Get the row_id column index.
 	auto &bound_ref = op.expressions[0]->Cast<BoundReferenceExpression>();
+	// Convert storage-column-to-expression mappings to storage-column-to-chunk mappings.
+	auto return_columns = std::move(op.return_columns);
+	for (auto &return_column_idx : return_columns) {
+		if (return_column_idx == DConstants::INVALID_INDEX) {
+			continue;
+		}
+		const auto expression_idx = return_column_idx;
+		D_ASSERT(expression_idx < op.expressions.size());
+		return_column_idx = op.expressions[expression_idx]->Cast<BoundReferenceExpression>().Index();
+	}
 	auto &del = planner.Make<PhysicalDelete>(op.types, op.table.Cast<DuckTableEntry>(), op.table.GetStorage(),
 	                                         std::move(op.bound_constraints), bound_ref.Index(),
-	                                         op.estimated_cardinality, op.return_chunk, std::move(op.return_columns));
+	                                         op.estimated_cardinality, op.return_chunk, std::move(return_columns));
 	del.children.push_back(plan);
 	return del;
 }

--- a/src/planner/binder.cpp
+++ b/src/planner/binder.cpp
@@ -435,7 +435,7 @@ void Binder::BindDeleteReturningColumns(TableCatalogEntry &table, LogicalGet &ge
 	}
 }
 
-//! Helper: convert scan column mapping to projection expression mapping for MERGE INTO
+//! Helper: convert scan column mapping to expression mapping
 static void ConvertScanToProjectionMapping(TableCatalogEntry &table, const vector<idx_t> &scan_return_columns,
                                            vector<idx_t> &return_columns,
                                            vector<unique_ptr<Expression>> &projection_expressions,

--- a/src/planner/binder/statement/bind_delete.cpp
+++ b/src/planner/binder/statement/bind_delete.cpp
@@ -78,24 +78,36 @@ BoundStatement Binder::BindNode(DeleteQueryNode &node) {
 	auto del = make_uniq<LogicalDelete>(table, GenerateTableIndex());
 	del->bound_constraints = BindConstraints(table);
 
+	auto is_duck_table = table.IsDuckTable();
+	if (is_duck_table) {
+		// Bind the row id before the table columns so it remains the first delete expression.
+		BindRowIdColumns(table, get, del->expressions);
+	}
+
 	// Add columns to the scan to avoid fetching by row ID in PhysicalDelete:
 	// - If RETURNING: add all physical columns (for RETURNING projection)
 	// - Else if unique indexes exist: add only indexed columns (for delete index tracking)
 	if (!node.returning_list.empty()) {
 		// Add all physical columns for RETURNING
-		BindDeleteReturningColumns(table, get, del->return_columns);
-	} else if (table.IsDuckTable()) {
+		if (is_duck_table) {
+			BindDeleteReturningColumns(table, get, del->return_columns, del->expressions, get);
+		} else {
+			BindDeleteReturningColumns(table, get, del->return_columns);
+		}
+	} else if (is_duck_table) {
 		// Only optimize for DuckDB tables (not attached external tables like SQLite)
 		auto &storage = table.GetStorage();
 		if (storage.HasUniqueIndexes()) {
-			BindDeleteIndexColumns(table, get, del->return_columns);
+			BindDeleteIndexColumns(table, get, del->return_columns, del->expressions, get);
 		}
 	}
 
 	del->AddChild(std::move(root));
 
-	// bind the row id columns and add them to the projection list
-	BindRowIdColumns(table, get, del->expressions);
+	if (!is_duck_table) {
+		// Bind external table row IDs after the returning columns to preserve their scan layout.
+		BindRowIdColumns(table, get, del->expressions);
+	}
 
 	if (!node.returning_list.empty()) {
 		del->return_chunk = true;

--- a/test/sql/delete/test_delete_indexed.test
+++ b/test/sql/delete/test_delete_indexed.test
@@ -294,3 +294,39 @@ SELECT * FROM t WHERE j = 30;
 # cleanup
 statement ok
 DROP TABLE source;
+
+# DELETE USING with an indexed table
+
+statement ok
+CREATE TABLE delete_using_indexed(id INTEGER PRIMARY KEY, payload VARCHAR);
+
+statement ok
+INSERT INTO delete_using_indexed SELECT range, range::VARCHAR FROM range(10);
+
+query I
+DELETE FROM delete_using_indexed USING range(100) source(i) WHERE source.i = 0;
+----
+10
+
+query I
+SELECT count(*) FROM delete_using_indexed;
+----
+0
+
+# Verify deleted keys can be inserted again
+statement ok
+INSERT INTO delete_using_indexed SELECT range, range::VARCHAR FROM range(10);
+
+query I rowsort
+DELETE FROM delete_using_indexed USING range(100) source(i) WHERE source.i = 0 RETURNING id;
+----
+0
+1
+2
+3
+4
+5
+6
+7
+8
+9


### PR DESCRIPTION
## Summary

Resolves #24102

This PR fixes a crash in indexed `DELETE ... USING` queries when optimization changes the child output layout. The
change tracks target columns through optimization and resolves their final positions before execution.

## Root Cause

`LogicalDelete::return_columns` stored pre-optimization `DataChunk` positions for indexed and `RETURNING` columns.
Join reordering could change the final output order, causing `PhysicalDelete` to reference a vector from the `USING` side with an incompatible type.

## Solution

For internal DuckDB tables, keep the required columns as bound expressions through optimization and resolve their final chunk positions during physical planning. 
