### PR TITLE
CSV: remove unreachable type check

### DIFF
--- a/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
+++ b/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
@@ -626,22 +626,6 @@ void StringValueResult::AddPossiblyEscapedValue(StringValueResult &result, const
 				result.cur_col_id++;
 				result.chunk_col_id++;
 			} else {
-				if (result.parse_chunk.data[result.chunk_col_id].GetType() != LogicalType::VARCHAR) {
-					// We cant have escapes on non varchar columns
-					result.current_errors.Insert(CAST_ERROR, result.cur_col_id, result.chunk_col_id,
-					                             result.last_position);
-					if (!result.state_machine.options.IgnoreErrors()) {
-						// We have to write the cast error message.
-						std::ostringstream error;
-						// Casting Error Message
-						error << "Could not convert string \"" << std::string(value_ptr, length) << "\" to \'"
-						      << LogicalTypeIdToString(result.parse_types[result.chunk_col_id].type_id) << "\'";
-						auto error_string = error.str();
-						FullLinePosition::SanitizeError(error_string);
-						result.current_errors.ModifyErrorMessageOfLastError(error_string);
-					}
-					return;
-				}
 				auto value = StringValueScanner::RemoveEscape(
 				    value_ptr, length, result.state_machine.dialect_options.state_machine_options.escape.GetValue(),
 				    result.state_machine.dialect_options.state_machine_options.quote.GetValue(),


### PR DESCRIPTION
AddPossiblyEscapedValue checks whether the target parse vector is VARCHAR before choosing between cast-error handling and escape removal. The VARCHAR branch repeats the same non-VARCHAR condition, so its cast-error block can never execute.

Remove the unreachable duplicate check while leaving the existing non-VARCHAR error path and VARCHAR escape-removal path unchanged.

Tests:
- DUCKDB_EXTENSIONS=json make reldebug -j4
- build/reldebug/test/unittest test/sql/copy/csv/afl/test_fuzz_4793.test --use-colour no
- build/reldebug/test/unittest test/sql/copy/csv/unquoted_escape/basic.test --use-colour no
- build/reldebug/test/unittest test/sql/copy/csv/test_escape_long_value.test --use-colour no
- build/reldebug/test/unittest test/sql/copy/csv/test_quoted_later_escaped.test --use-colour no