### PR TITLE
Fix nested schema lookup

### DIFF
--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -162,11 +162,21 @@ optional_ptr<CatalogEntry> Catalog::CreateTable(CatalogTransaction transaction, 
 	return CreateTable(transaction, *schema, info);
 }
 
+static SchemaCatalogEntry &GetCreateSchema(Catalog &catalog, CatalogTransaction transaction, CreateInfo &info) {
+	auto &qname = info.GetQualifiedName();
+	auto &path = qname.Path();
+	if (path.size() > 3) {
+		vector<Identifier> schema_path(path.begin() + 1, path.end() - 1);
+		return *catalog.GetSchema(transaction, schema_path, OnEntryNotFound::THROW_EXCEPTION);
+	}
+	return catalog.GetSchema(transaction, qname.Schema());
+}
+
 //===--------------------------------------------------------------------===//
 // View
 //===--------------------------------------------------------------------===//
 optional_ptr<CatalogEntry> Catalog::CreateView(CatalogTransaction transaction, CreateViewInfo &info) {
-	auto &schema = GetSchema(transaction, info.GetQualifiedName().Schema());
+	auto &schema = GetCreateSchema(*this, transaction, info);
 	return CreateView(transaction, schema, info);
 }
 
@@ -183,7 +193,7 @@ optional_ptr<CatalogEntry> Catalog::CreateView(CatalogTransaction transaction, S
 // Sequence
 //===--------------------------------------------------------------------===//
 optional_ptr<CatalogEntry> Catalog::CreateSequence(CatalogTransaction transaction, CreateSequenceInfo &info) {
-	auto &schema = GetSchema(transaction, info.GetQualifiedName().Schema());
+	auto &schema = GetCreateSchema(*this, transaction, info);
 	return CreateSequence(transaction, schema, info);
 }
 
@@ -200,7 +210,7 @@ optional_ptr<CatalogEntry> Catalog::CreateSequence(CatalogTransaction transactio
 // Type
 //===--------------------------------------------------------------------===//
 optional_ptr<CatalogEntry> Catalog::CreateType(CatalogTransaction transaction, CreateTypeInfo &info) {
-	auto &schema = GetSchema(transaction, info.GetQualifiedName().Schema());
+	auto &schema = GetCreateSchema(*this, transaction, info);
 	return CreateType(transaction, schema, info);
 }
 
@@ -274,7 +284,7 @@ optional_ptr<CatalogEntry> Catalog::CreatePragmaFunction(CatalogTransaction tran
 // Function
 //===--------------------------------------------------------------------===//
 optional_ptr<CatalogEntry> Catalog::CreateFunction(CatalogTransaction transaction, CreateFunctionInfo &info) {
-	auto &schema = GetSchema(transaction, info.GetQualifiedName().Schema());
+	auto &schema = GetCreateSchema(*this, transaction, info);
 	return CreateFunction(transaction, schema, info);
 }
 

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -165,6 +165,7 @@ optional_ptr<CatalogEntry> Catalog::CreateTable(CatalogTransaction transaction, 
 static SchemaCatalogEntry &GetCreateSchema(Catalog &catalog, CatalogTransaction transaction, CreateInfo &info) {
 	auto &qname = info.GetQualifiedName();
 	auto &path = qname.Path();
+	// Path is [catalog, schema_path..., name]
 	if (path.size() > 3) {
 		vector<Identifier> schema_path(path.begin() + 1, path.end() - 1);
 		return *catalog.GetSchema(transaction, schema_path, OnEntryNotFound::THROW_EXCEPTION);

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -154,8 +154,7 @@ optional_ptr<CatalogEntry> Catalog::CreateTable(CatalogTransaction transaction, 
 	optional_ptr<SchemaCatalogEntry> schema;
 	if (path.size() > 3) {
 		// nested table ([catalog, schema_path..., name]): navigate the (nested) schema path
-		vector<Identifier> schema_path(path.begin() + 1, path.end() - 1);
-		schema = GetSchema(transaction, schema_path, OnEntryNotFound::THROW_EXCEPTION);
+		schema = GetSchema(transaction, qname.GetSchemaPath(), OnEntryNotFound::THROW_EXCEPTION);
 	} else {
 		schema = GetSchema(transaction, qname.Schema());
 	}
@@ -167,8 +166,7 @@ static SchemaCatalogEntry &GetCreateSchema(Catalog &catalog, CatalogTransaction 
 	auto &path = qname.Path();
 	// Path is [catalog, schema_path..., name]
 	if (path.size() > 3) {
-		vector<Identifier> schema_path(path.begin() + 1, path.end() - 1);
-		return *catalog.GetSchema(transaction, schema_path, OnEntryNotFound::THROW_EXCEPTION);
+		return *catalog.GetSchema(transaction, qname.GetSchemaPath(), OnEntryNotFound::THROW_EXCEPTION);
 	}
 	return catalog.GetSchema(transaction, qname.Schema());
 }

--- a/src/include/duckdb/parser/qualified_name.hpp
+++ b/src/include/duckdb/parser/qualified_name.hpp
@@ -69,6 +69,8 @@ struct QualifiedName {
 	const vector<Identifier> &Path() const {
 		return path;
 	}
+	//! Return the schema components from a resolved path of the form [catalog, schema_path..., name]
+	vector<Identifier> GetSchemaPath() const;
 
 	//! Return a copy of this name with the name replaced, keeping the catalog/schema qualification
 	QualifiedName WithName(Identifier name) const {

--- a/src/parser/qualified_name.cpp
+++ b/src/parser/qualified_name.cpp
@@ -35,6 +35,13 @@ string QualifiedName::ToString(QualifiedNameToStringMode mode) const {
 	return result;
 }
 
+vector<Identifier> QualifiedName::GetSchemaPath() const {
+	if (path.size() <= 2) {
+		return {};
+	}
+	return vector<Identifier>(path.begin() + 1, path.end() - 1);
+}
+
 //! This parses a superset of the strings that the actual SQL parser accepts: it allows whitespace, most special
 //! characters like ()'- and keywords without requiring double quotes. It only requires double quotes around .
 //! characters and doubled double quotes (which collapse into a single double quote). It's only possible to fully

--- a/src/planner/binder/statement/bind_create.cpp
+++ b/src/planner/binder/statement/bind_create.cpp
@@ -242,7 +242,7 @@ QualifiedName Binder::ResolveCatalog(CatalogEntryRetriever &retriever, const Qua
 QualifiedName Binder::BindTableName(CatalogEntryRetriever &retriever, const QualifiedName &name) {
 	auto resolved = ResolveCatalog(retriever, name, false);
 	auto &path = resolved.Path();
-	vector<Identifier> schema_path(path.begin() + 1, path.end() - 1);
+	auto schema_path = resolved.GetSchemaPath();
 	if (schema_path.size() <= 1) {
 		// unqualified, or qualified with a single schema level: keep the (catalog, schema, name) shape so that the
 		// regular search-path based lookup applies
@@ -290,7 +290,7 @@ SchemaCatalogEntry &Binder::BindSchema(CreateInfo &info) {
 	// resolve the target into [catalog, schema_path..., name] and fetch the (possibly nested) schema it lives in
 	SearchSchema(info);
 	auto &path = info.GetQualifiedName().Path();
-	vector<Identifier> schema_path(path.begin() + 1, path.end() - 1);
+	auto schema_path = info.GetQualifiedName().GetSchemaPath();
 	auto &schema_obj = *Catalog::GetSchema(context, path.front(), schema_path, OnEntryNotFound::THROW_EXCEPTION);
 	D_ASSERT(schema_obj.type == CatalogType::SCHEMA_ENTRY);
 	if (!info.temporary) {

--- a/src/planner/binder/statement/bind_drop.cpp
+++ b/src/planner/binder/statement/bind_drop.cpp
@@ -61,7 +61,7 @@ BoundStatement Binder::Bind(DropStatement &stmt) {
 		// leading components form the catalog; default_catalog=false leaves the catalog empty when none is given.
 		auto resolved = ResolveCatalog(context, stmt.info->GetQualifiedName(), false);
 		auto &rpath = resolved.Path();
-		vector<Identifier> schema_path(rpath.begin() + 1, rpath.end() - 1);
+		auto schema_path = resolved.GetSchemaPath();
 		if (schema_path.size() > 1) {
 			// a nested schema was given - navigate to it and drop from it. Keep the full resolved path so execution
 			// navigates the same nested schema (and no-ops for IF EXISTS).

--- a/src/planner/operator/logical_create_table.cpp
+++ b/src/planner/operator/logical_create_table.cpp
@@ -11,8 +11,8 @@ LogicalCreateTable::LogicalCreateTable(SchemaCatalogEntry &schema, unique_ptr<Bo
 // resolve the (possibly nested) schema [catalog, schema_path..., name] the table will be created in
 static SchemaCatalogEntry &ResolveCreateSchema(ClientContext &context, CreateInfo &info) {
 	auto &path = info.GetQualifiedName().Path();
-	vector<Identifier> schema_path(path.begin() + 1, path.end() - 1);
-	return *Catalog::GetSchema(context, path.front(), schema_path, OnEntryNotFound::THROW_EXCEPTION);
+	return *Catalog::GetSchema(context, path.front(), info.GetQualifiedName().GetSchemaPath(),
+	                           OnEntryNotFound::THROW_EXCEPTION);
 }
 
 LogicalCreateTable::LogicalCreateTable(ClientContext &context, unique_ptr<CreateInfo> unbound_info)

--- a/test/sql/catalog/nested_schema/nested_table.test
+++ b/test/sql/catalog/nested_schema/nested_table.test
@@ -44,6 +44,15 @@ SELECT database_name, schema_name, table_name FROM duckdb_tables() WHERE table_n
 ----
 db2	a	tt
 
+# create a view in a nested schema
+statement ok
+CREATE VIEW s1.child.v1 AS SELECT 42 AS x;
+
+query I
+SELECT x FROM s1.child.v1;
+----
+42
+
 # dropping a table in a nested schema
 statement ok
 DROP TABLE s1.child.t1;


### PR DESCRIPTION
Closes https://github.com/duckdb/duckdb/issues/24220

Current implementation for `Schema()` only [returns the leaf schema](https://github.com/duckdb/duckdb/blob/e0692f2bf6fe5c6f68e376d8c3e244380a4152ec/src/include/duckdb/parser/qualified_name.hpp#L60-L61), so all prev nested schemas are ignored.
In this PR, I explicitly extract all schemas out.