### PR TITLE
[WIP] Add support for querying from nested schemas

### DIFF
--- a/src/function/scalar_macro_function.cpp
+++ b/src/function/scalar_macro_function.cpp
@@ -34,7 +34,7 @@ void RemoveQualificationRecursive(unique_ptr<ParsedExpression> &root_expr) {
 	    *root_expr, [&](ColumnRefExpression &col_ref) {
 		    auto &col_names = col_ref.ColumnNamesMutable();
 		    if (col_names.size() == 2 &&
-		        col_names[0].GetIdentifierName().find(DummyBinding::DUMMY_NAME) != string::npos) {
+		        StringUtil::StartsWith(col_names[0].GetIdentifierName(), DummyBinding::DUMMY_NAME)) {
 			    col_names.erase(col_names.begin());
 		    }
 	    });

--- a/src/include/duckdb/parser/expression/columnref_expression.hpp
+++ b/src/include/duckdb/parser/expression/columnref_expression.hpp
@@ -40,7 +40,6 @@ public:
 
 	bool IsQualified() const;
 	const Identifier &GetColumnName() const;
-	const Identifier &GetTableName() const;
 	bool IsScalar() const override {
 		return false;
 	}

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -344,6 +344,9 @@ public:
 	optional_ptr<Binding> GetMatchingBinding(const Identifier &catalog_name, const Identifier &schema_name,
 	                                         const Identifier &table_name, const Identifier &column_name,
 	                                         ErrorData &error);
+	//! Look up a binding for a (possibly nested) table qualification
+	optional_ptr<Binding> GetMatchingBinding(const BindingAlias &alias, const Identifier &column_name,
+	                                         ErrorData &error);
 
 	void SetBindingMode(BindingMode mode);
 	BindingMode GetBindingMode();

--- a/src/include/duckdb/planner/binding_alias.hpp
+++ b/src/include/duckdb/planner/binding_alias.hpp
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include "duckdb/common/case_insensitive_map.hpp"
 #include "duckdb/common/identifier.hpp"
 #include "duckdb/parser/qualified_name.hpp"
 
@@ -20,23 +19,33 @@ struct BindingAlias {
 	explicit BindingAlias(Identifier alias);
 	BindingAlias(Identifier schema, Identifier alias);
 	BindingAlias(Identifier catalog, Identifier schema, Identifier alias);
+	//! Construct from an explicit catalog + (possibly nested) schema path + alias
+	BindingAlias(Identifier catalog, const vector<Identifier> &schema_path, Identifier alias);
 	explicit BindingAlias(const StandardEntry &entry);
 
 	bool IsSet() const;
 	const Identifier &GetAlias() const;
 
+	//! The catalog, or an empty identifier if none was specified
 	const Identifier &GetCatalog() const {
-		return qualified_name.Catalog();
+		return catalog;
 	}
+	//! The immediate (innermost) schema, or an empty identifier if there is none
 	const Identifier &GetSchema() const {
 		return qualified_name.Schema();
 	}
+	//! The full (possibly nested) schema path, outermost schema first (empty if unqualified)
+	vector<Identifier> GetSchemaPath() const;
 
+	//! Whether the (possibly less specific) `other` reference matches this (fully-qualified) binding alias
 	bool Matches(const BindingAlias &other) const;
 	bool operator==(const BindingAlias &other) const;
 	string ToString() const;
 
 private:
+	//! The catalog (empty if unqualified)
+	Identifier catalog;
+	//! The (possibly nested) schema path followed by the alias: [schema path..., alias]
 	QualifiedName qualified_name;
 };
 

--- a/src/include/duckdb/planner/column_qualifier.hpp
+++ b/src/include/duckdb/planner/column_qualifier.hpp
@@ -51,6 +51,10 @@ private:
 private:
 	unique_ptr<ParsedExpression> QualifyColumnNameWithManyDotsInternal(ColumnRefExpression &col_ref, ErrorData &error,
 	                                                                   idx_t &struct_extract_start);
+	//! Whether the given (possibly nested) table qualification matches a binding in the current bind context
+	bool TableBindingExists(const BindingAlias &alias);
+	//! Whether any binding in the current bind context has the given table name (ignoring catalog/schema)
+	bool TableNameExists(const Identifier &table_name);
 
 	unique_ptr<ParsedExpression> QualifyColumnNameInternal(ColumnRefExpression &col_ref, ErrorData &error);
 };

--- a/src/parser/expression/columnref_expression.cpp
+++ b/src/parser/expression/columnref_expression.cpp
@@ -51,19 +51,9 @@ bool ColumnRefExpression::IsQualified() const {
 }
 
 const Identifier &ColumnRefExpression::GetColumnName() const {
-	D_ASSERT(column_names.size() <= 4);
+	D_ASSERT(!column_names.empty());
+	// the column name is always the last component
 	return column_names.back();
-}
-
-const Identifier &ColumnRefExpression::GetTableName() const {
-	D_ASSERT(column_names.size() >= 2 && column_names.size() <= 4);
-	if (column_names.size() == 4) {
-		return column_names[2];
-	}
-	if (column_names.size() == 3) {
-		return column_names[1];
-	}
-	return column_names[0];
 }
 
 Identifier ColumnRefExpression::GetName() const {

--- a/src/parser/parsed_data/create_index_info.cpp
+++ b/src/parser/parsed_data/create_index_info.cpp
@@ -19,7 +19,8 @@ static void RemoveTableQualificationRecursive(unique_ptr<ParsedExpression> &root
 	ParsedExpressionIterator::VisitExpressionMutable<ColumnRefExpression>(
 	    *root_expr, [&](ColumnRefExpression &col_ref) {
 		    auto &col_names = col_ref.ColumnNamesMutable();
-		    if (col_ref.IsQualified() && col_ref.GetTableName() == table_name) {
+		    // the table qualifier is the component directly before the column name
+		    if (col_ref.IsQualified() && col_names[col_names.size() - 2] == table_name) {
 			    col_names.erase(col_names.begin());
 		    }
 	    });

--- a/src/planner/bind_context.cpp
+++ b/src/planner/bind_context.cpp
@@ -28,9 +28,21 @@ string MinimumUniqueAlias(const BindingAlias &alias, const BindingAlias &other) 
 	if (alias.GetAlias() != other.GetAlias()) {
 		return alias.GetAlias().GetIdentifierName();
 	}
-	if (alias.GetSchema() != other.GetSchema()) {
-		return alias.GetSchema() + "." + alias.GetAlias();
+	// the table names are equal - qualify with as much of the (nested) schema path as needed to disambiguate,
+	// walking from the innermost schema outwards
+	auto schema_path = alias.GetSchemaPath();
+	auto other_path = other.GetSchemaPath();
+	string qualification = alias.GetAlias().GetIdentifierName();
+	for (idx_t i = 0; i < schema_path.size(); i++) {
+		auto &schema = schema_path[schema_path.size() - 1 - i];
+		qualification = schema.GetIdentifierName() + "." + qualification;
+		bool other_matches = i < other_path.size() && other_path[other_path.size() - 1 - i] == schema;
+		if (!other_matches) {
+			// this schema component distinguishes the two - we are done
+			return qualification;
+		}
 	}
+	// the schema paths are identical - fall back to the fully qualified name
 	return alias.ToString();
 }
 
@@ -190,20 +202,6 @@ unique_ptr<ParsedExpression> BindContext::ExpandGeneratedColumn(TableBinding &ta
 	return result;
 }
 
-unique_ptr<ParsedExpression> BindContext::CreateColumnReference(const BindingAlias &table_alias,
-                                                                const Identifier &column_name,
-                                                                ColumnBindType bind_type) {
-	return CreateColumnReference(table_alias.GetCatalog(), table_alias.GetSchema(), table_alias.GetAlias(), column_name,
-	                             bind_type);
-}
-
-unique_ptr<ParsedExpression> BindContext::CreateColumnReference(const Identifier &table_name,
-                                                                const Identifier &column_name,
-                                                                ColumnBindType bind_type) {
-	string schema_name;
-	return CreateColumnReference(Identifier(schema_name), table_name, column_name, bind_type);
-}
-
 static bool ColumnIsGenerated(Binding &binding, column_t index) {
 	if (binding.GetBindingType() != BindingType::TABLE) {
 		return false;
@@ -219,6 +217,46 @@ static bool ColumnIsGenerated(Binding &binding, column_t index) {
 	D_ASSERT(catalog_entry->type == CatalogType::TABLE_ENTRY);
 	auto &table_entry = catalog_entry->Cast<TableCatalogEntry>();
 	return table_entry.GetColumn(LogicalIndex(index)).Generated();
+}
+
+unique_ptr<ParsedExpression> BindContext::CreateColumnReference(const BindingAlias &table_alias,
+                                                                const Identifier &column_name,
+                                                                ColumnBindType bind_type) {
+	ErrorData error;
+	// emit the full (possibly nested) schema path so the produced reference is unambiguous
+	vector<Identifier> names;
+	if (!table_alias.GetCatalog().empty()) {
+		names.push_back(table_alias.GetCatalog());
+	}
+	for (auto &schema : table_alias.GetSchemaPath()) {
+		names.push_back(schema);
+	}
+	names.push_back(table_alias.GetAlias());
+	names.push_back(column_name);
+
+	auto result = make_uniq<ColumnRefExpression>(names);
+	auto binding = GetBinding(table_alias, column_name, error);
+	if (!binding) {
+		return std::move(result);
+	}
+	auto column_index = binding->GetBindingIndex(column_name);
+	if (bind_type == ColumnBindType::EXPAND_GENERATED_COLUMNS && ColumnIsGenerated(*binding, column_index)) {
+		return ExpandGeneratedColumn(binding->Cast<TableBinding>(), column_name);
+	}
+	auto &column_names = binding->GetColumnNames();
+	if (column_index < column_names.size() && column_names[column_index] != column_name) {
+		// because of case insensitivity in the binder we rename the column to the original name
+		// as it appears in the binding itself
+		result->SetAlias(column_names[column_index]);
+	}
+	return std::move(result);
+}
+
+unique_ptr<ParsedExpression> BindContext::CreateColumnReference(const Identifier &table_name,
+                                                                const Identifier &column_name,
+                                                                ColumnBindType bind_type) {
+	string schema_name;
+	return CreateColumnReference(Identifier(schema_name), table_name, column_name, bind_type);
 }
 
 unique_ptr<ParsedExpression> BindContext::CreateColumnReference(const Identifier &catalog_name,
@@ -269,8 +307,12 @@ string GetCandidateAlias(const BindingAlias &main_alias, const BindingAlias &new
 	if (!main_alias.GetCatalog().empty() && !new_alias.GetCatalog().empty()) {
 		candidate += new_alias.GetCatalog() + ".";
 	}
-	if (!main_alias.GetSchema().empty() && !new_alias.GetSchema().empty()) {
-		candidate += new_alias.GetSchema() + ".";
+	// include as many (nested) schema components as the reference alias provides
+	auto main_path = main_alias.GetSchemaPath();
+	auto new_path = new_alias.GetSchemaPath();
+	idx_t schema_components = MinValue<idx_t>(main_path.size(), new_path.size());
+	for (idx_t i = 0; i < schema_components; i++) {
+		candidate += new_path[new_path.size() - schema_components + i].GetIdentifierName() + ".";
 	}
 	candidate += new_alias.GetAlias();
 	return candidate;
@@ -389,16 +431,24 @@ optional_ptr<Binding> BindContext::GetBinding(const Identifier &name, ErrorData 
 }
 
 BindingAlias GetBindingAlias(ColumnRefExpression &colref) {
-	if (colref.ColumnNames().size() <= 1 || colref.ColumnNames().size() > 4) {
-		throw InternalException("Cannot get binding alias from column ref unless it has 2..4 entries");
+	auto &names = colref.ColumnNames();
+	if (names.size() <= 1) {
+		throw InternalException("Cannot get binding alias from column ref unless it has 2 or more entries");
 	}
-	if (colref.ColumnNames().size() >= 4) {
-		return BindingAlias(colref.ColumnNames()[0], colref.ColumnNames()[1], colref.ColumnNames()[2]);
+	// the last entry is the column name, the second-to-last is the table name
+	// the remaining leading entries are the qualification: [catalog, schema path...] (a real table's reference always
+	// carries the catalog, so for 4+ entries the leading entry is the catalog and the rest are the schema path)
+	auto &table_name = names[names.size() - 2];
+	if (names.size() == 2) {
+		return BindingAlias(table_name);
 	}
-	if (colref.ColumnNames().size() == 3) {
-		return BindingAlias(colref.ColumnNames()[0], colref.ColumnNames()[1]);
+	if (names.size() == 3) {
+		// schema.table.column
+		return BindingAlias(names[0], table_name);
 	}
-	return BindingAlias(colref.ColumnNames()[0]);
+	auto &catalog = names[0];
+	vector<Identifier> schema_path(names.begin() + 1, names.end() - 2);
+	return BindingAlias(catalog, schema_path, table_name);
 }
 
 BindResult BindContext::BindColumn(ColumnRefExpression &colref, idx_t depth) {

--- a/src/planner/binder.cpp
+++ b/src/planner/binder.cpp
@@ -326,14 +326,17 @@ optional_ptr<Binding> Binder::GetMatchingBinding(const Identifier &schema_name, 
 optional_ptr<Binding> Binder::GetMatchingBinding(const Identifier &catalog_name, const Identifier &schema_name,
                                                  const Identifier &table_name, const Identifier &column_name,
                                                  ErrorData &error) {
-	optional_ptr<Binding> binding;
-	if (macro_binding && table_name == macro_binding->GetAlias()) {
-		binding = optional_ptr<Binding>(macro_binding.get());
-	} else {
-		BindingAlias alias(catalog_name, schema_name, table_name);
-		binding = bind_context.GetBinding(alias, column_name, error);
+	BindingAlias alias(catalog_name, schema_name, table_name);
+	return GetMatchingBinding(alias, column_name, error);
+}
+
+optional_ptr<Binding> Binder::GetMatchingBinding(const BindingAlias &alias, const Identifier &column_name,
+                                                 ErrorData &error) {
+	if (macro_binding && alias.GetSchemaPath().empty() && alias.GetCatalog().empty() &&
+	    alias.GetAlias() == macro_binding->GetAlias()) {
+		return optional_ptr<Binding>(macro_binding.get());
 	}
-	return binding;
+	return bind_context.GetBinding(alias, column_name, error);
 }
 
 void Binder::SetBindingMode(BindingMode mode) {
@@ -391,8 +394,9 @@ void VerifyNotExcluded(const ParsedExpression &root_expr) {
 		    if (!column_ref.IsQualified()) {
 			    return;
 		    }
-		    auto &table_name = column_ref.GetTableName();
-		    if (table_name == "excluded") {
+		    // the table qualifier is the component directly before the column name
+		    auto &names = column_ref.ColumnNames();
+		    if (names[names.size() - 2] == "excluded") {
 			    throw NotImplementedException(
 			        "'excluded' qualified columns are not supported in the RETURNING clause yet");
 		    }

--- a/src/planner/binder/expression/bind_columnref_expression.cpp
+++ b/src/planner/binder/expression/bind_columnref_expression.cpp
@@ -103,7 +103,9 @@ BindResult ExpressionBinder::BindExpression(ColumnRefExpression &col_ref_p, idx_
 	BindResult result;
 	auto &col_ref = expr->Cast<ColumnRefExpression>();
 	D_ASSERT(col_ref.IsQualified());
-	auto &table_name = col_ref.GetTableName();
+	// the table qualifier is the component directly before the column name
+	auto &names = col_ref.ColumnNames();
+	auto &table_name = names[names.size() - 2];
 
 	if (binder.macro_binding && table_name == binder.macro_binding->GetAlias()) {
 		result = binder.macro_binding->Bind(col_ref, depth);

--- a/src/planner/binder/expression/bind_macro_expression.cpp
+++ b/src/planner/binder/expression/bind_macro_expression.cpp
@@ -63,7 +63,9 @@ void ExpressionBinder::ReplaceMacroParameters(unique_ptr<ParsedExpression> &expr
 
 		bool bind_macro_parameter = false;
 		if (col_ref.IsQualified()) {
-			if (col_ref.GetTableName().GetIdentifierName().find(DummyBinding::DUMMY_NAME) != string::npos) {
+			// the table qualifier is the component directly before the column name
+			auto &names = col_ref.ColumnNames();
+			if (names[names.size() - 2].GetIdentifierName().find(DummyBinding::DUMMY_NAME) != string::npos) {
 				bind_macro_parameter = true;
 			}
 		} else {

--- a/src/planner/binder/expression/bind_macro_expression.cpp
+++ b/src/planner/binder/expression/bind_macro_expression.cpp
@@ -65,7 +65,7 @@ void ExpressionBinder::ReplaceMacroParameters(unique_ptr<ParsedExpression> &expr
 		if (col_ref.IsQualified()) {
 			// the table qualifier is the component directly before the column name
 			auto &names = col_ref.ColumnNames();
-			if (names[names.size() - 2].GetIdentifierName().find(DummyBinding::DUMMY_NAME) != string::npos) {
+			if (StringUtil::StartsWith(names[names.size() - 2].GetIdentifierName(), DummyBinding::DUMMY_NAME)) {
 				bind_macro_parameter = true;
 			}
 		} else {

--- a/src/planner/binder/tableref/bind_pivot.cpp
+++ b/src/planner/binder/tableref/bind_pivot.cpp
@@ -65,7 +65,8 @@ static void ExtractPivotExpressions(ParsedExpression &root_expr, identifier_set_
 	ParsedExpressionIterator::VisitExpression<ColumnRefExpression>(
 	    root_expr, [&](const ColumnRefExpression &child_colref) {
 		    if (child_colref.IsQualified()) {
-			    if (child_colref.ColumnNames()[0].GetIdentifierName().find(DummyBinding::DUMMY_NAME) != string::npos &&
+			    if (StringUtil::StartsWith(child_colref.ColumnNames()[0].GetIdentifierName(),
+			                               DummyBinding::DUMMY_NAME) &&
 			        macro_binding && macro_binding->HasMatchingBinding(Identifier(child_colref.GetName()))) {
 				    throw ParameterNotResolvedException();
 			    }

--- a/src/planner/binding_alias.cpp
+++ b/src/planner/binding_alias.cpp
@@ -1,9 +1,22 @@
 #include "duckdb/planner/binding_alias.hpp"
 #include "duckdb/catalog/catalog_entry/schema_catalog_entry.hpp"
 #include "duckdb/catalog/catalog.hpp"
-#include "duckdb/parser/keyword_helper.hpp"
+#include "duckdb/catalog/standard_entry.hpp"
+#include "duckdb/common/sql_identifier.hpp"
 
 namespace duckdb {
+
+//! Build a QualifiedName holding [schema path..., alias], skipping empty schema components
+static QualifiedName MakeSchemaAlias(const vector<Identifier> &schema_path, Identifier alias) {
+	vector<Identifier> path;
+	for (auto &schema : schema_path) {
+		// an empty identifier means the schema is absent
+		if (!schema.empty()) {
+			path.push_back(schema);
+		}
+	}
+	return QualifiedName(std::move(path), std::move(alias));
+}
 
 BindingAlias::BindingAlias() {
 }
@@ -12,15 +25,20 @@ BindingAlias::BindingAlias(Identifier alias_p) : qualified_name(std::move(alias_
 }
 
 BindingAlias::BindingAlias(Identifier schema_p, Identifier alias_p)
-    : qualified_name(Identifier(), std::move(schema_p), std::move(alias_p)) {
-}
-
-BindingAlias::BindingAlias(const StandardEntry &entry)
-    : qualified_name(entry.ParentCatalog().GetName(), entry.schema.name, entry.name) {
+    : qualified_name(MakeSchemaAlias({std::move(schema_p)}, std::move(alias_p))) {
 }
 
 BindingAlias::BindingAlias(Identifier catalog_p, Identifier schema_p, Identifier alias_p)
-    : qualified_name(std::move(catalog_p), std::move(schema_p), std::move(alias_p)) {
+    : catalog(std::move(catalog_p)), qualified_name(MakeSchemaAlias({std::move(schema_p)}, std::move(alias_p))) {
+}
+
+BindingAlias::BindingAlias(Identifier catalog_p, const vector<Identifier> &schema_path_p, Identifier alias_p)
+    : catalog(std::move(catalog_p)), qualified_name(MakeSchemaAlias(schema_path_p, std::move(alias_p))) {
+}
+
+BindingAlias::BindingAlias(const StandardEntry &entry)
+    : catalog(entry.ParentCatalog().GetName()),
+      qualified_name(MakeSchemaAlias(entry.schema.GetSchemaPath(), entry.name)) {
 }
 
 bool BindingAlias::IsSet() const {
@@ -34,29 +52,75 @@ const Identifier &BindingAlias::GetAlias() const {
 	return qualified_name.Name();
 }
 
+vector<Identifier> BindingAlias::GetSchemaPath() const {
+	auto &path = qualified_name.Path();
+	// the path is [schema path..., alias] - everything but the trailing alias is the schema path
+	vector<Identifier> result;
+	for (idx_t i = 0; i + 1 < path.size(); i++) {
+		result.push_back(path[i]);
+	}
+	return result;
+}
+
 string BindingAlias::ToString() const {
-	return qualified_name.ToString();
+	// QualifiedName::ToString only renders [catalog, schema, name], so we render the full (possibly nested) path here
+	string result;
+	if (!catalog.empty()) {
+		result += SQLIdentifier(catalog);
+	}
+	for (auto &component : qualified_name.Path()) {
+		if (!result.empty()) {
+			result += ".";
+		}
+		result += SQLIdentifier(component);
+	}
+	return result;
 }
 
 bool BindingAlias::Matches(const BindingAlias &other) const {
-	// we match based on the specificity of the other entry
-	// i.e. "tbl" matches "catalog.schema.tbl"
-	// but "schema2.tbl" does not match "schema.tbl"
-	if (!other.GetCatalog().empty()) {
-		if (GetCatalog() != other.GetCatalog()) {
+	// we match based on the specificity of the other (reference) entry
+	// i.e. "tbl" matches "catalog.schema.tbl", and "schema2.tbl" matches "catalog.schema1.schema2.tbl"
+	// but "schema1.tbl" does not match "catalog.schema1.schema2.tbl" (schema1 is not the immediate schema)
+	if (qualified_name.Name() != other.qualified_name.Name()) {
+		return false;
+	}
+	if (!other.catalog.empty()) {
+		// the reference specifies a catalog - it must be present and equal
+		if (catalog != other.catalog) {
 			return false;
 		}
 	}
-	if (!other.GetSchema().empty()) {
-		if (GetSchema() != other.GetSchema()) {
+	// the reference's schema qualification must be a suffix of this binding's (nested) schema path
+	auto &path = qualified_name.Path();
+	auto &other_path = other.qualified_name.Path();
+	if (other_path.size() > path.size()) {
+		return false;
+	}
+	// compare the schema components, from the immediate schema outwards (the alias itself already matched)
+	for (idx_t i = 1; i < other_path.size(); i++) {
+		if (path[path.size() - 1 - i] != other_path[other_path.size() - 1 - i]) {
 			return false;
 		}
 	}
-	return qualified_name.Name() == other.qualified_name.Name();
+	return true;
 }
 
 bool BindingAlias::operator==(const BindingAlias &other) const {
-	return qualified_name == other.qualified_name;
+	// QualifiedName::operator== only compares [catalog, schema, name], so we compare the full path here
+	if (catalog != other.catalog) {
+		return false;
+	}
+	auto &path = qualified_name.Path();
+	auto &other_path = other.qualified_name.Path();
+	if (path.size() != other_path.size()) {
+		return false;
+	}
+	for (idx_t i = 0; i < path.size(); i++) {
+		if (path[i] != other_path[i]) {
+			return false;
+		}
+	}
+	return true;
 }
 
 } // namespace duckdb

--- a/src/planner/column_qualifier.cpp
+++ b/src/planner/column_qualifier.cpp
@@ -86,40 +86,40 @@ unique_ptr<ParsedExpression> ColumnQualifier::CreateStructExtract(unique_ptr<Par
 	return std::move(extract_fun);
 }
 
-unique_ptr<ParsedExpression> ColumnQualifier::CreateStructPack(ColumnRefExpression &col_ref) {
-	if (col_ref.ColumnNames().size() > 3) {
-		return nullptr;
+// Build the candidate table-qualification interpretations for a reference "[qualifiers...].table", in precedence
+// order (most top-level first): "catalog + schema path" before "schema path only".
+static vector<BindingAlias> GetTableQualifications(const vector<Identifier> &names, idx_t table_index) {
+	vector<BindingAlias> result;
+	auto &table = names[table_index];
+	if (table_index >= 1) {
+		// interpret names[0] as the catalog and names[1..table_index-1] as the schema path
+		vector<Identifier> schema_path;
+		for (idx_t i = 1; i < table_index; i++) {
+			schema_path.push_back(names[i]);
+		}
+		result.emplace_back(names[0], std::move(schema_path), table);
 	}
+	// interpret all qualifiers as a (nested) schema path with no catalog
+	vector<Identifier> schema_path;
+	for (idx_t i = 0; i < table_index; i++) {
+		schema_path.push_back(names[i]);
+	}
+	result.emplace_back(Identifier(), std::move(schema_path), table);
+	return result;
+}
+
+unique_ptr<ParsedExpression> ColumnQualifier::CreateStructPack(ColumnRefExpression &col_ref) {
 	D_ASSERT(!col_ref.ColumnNames().empty());
 
-	// get a matching binding
+	// the whole reference names a table - try to interpret it as "[catalog.][schema path.]table"
 	ErrorData error;
 	optional_ptr<Binding> binding;
-	switch (col_ref.ColumnNames().size()) {
-	case 1: {
-		// single entry - this must be the table name
-		BindingAlias alias(col_ref.ColumnNames()[0]);
+	auto &names = col_ref.ColumnNames();
+	for (auto &alias : GetTableQualifications(names, names.size() - 1)) {
 		binding = binder.bind_context.GetBinding(alias, error);
-		break;
-	}
-	case 2: {
-		// two entries - this can either be "catalog.table" or "schema.table" - try both
-		BindingAlias alias(col_ref.ColumnNames()[0], col_ref.ColumnNames()[1]);
-		binding = binder.bind_context.GetBinding(alias, error);
-		if (!binding) {
-			alias = BindingAlias(col_ref.ColumnNames()[0], Identifier::InvalidSchema(), col_ref.ColumnNames()[1]);
-			binding = binder.bind_context.GetBinding(alias, error);
+		if (binding) {
+			break;
 		}
-		break;
-	}
-	case 3: {
-		// three entries - this must be "catalog.schema.table"
-		BindingAlias alias(col_ref.ColumnNames()[0], col_ref.ColumnNames()[1], col_ref.ColumnNames()[2]);
-		binding = binder.bind_context.GetBinding(alias, error);
-		break;
-	}
-	default:
-		throw InternalException("Expected 1, 2 or 3 column names for CreateStructPack");
 	}
 	if (!binding) {
 		return nullptr;
@@ -347,61 +347,54 @@ unique_ptr<ParsedExpression> ColumnQualifier::QualifyColumnNameWithManyDotsInter
                                                                                     ErrorData &error,
                                                                                     idx_t &struct_extract_start) {
 	// two or more dots (i.e. "part1.part2.part3.part4...")
-	// -> part1 is a catalog, part2 is a schema, part3 is a table, part4 is a column name, part 5 and beyond are
-	// struct fields
-	// -> part1 is a catalog, part2 is a table, part3 is a column name, part4 and beyond are struct fields
-	// -> part1 is a schema, part2 is a table, part3 is a column name, part4 and beyond are struct fields
-	// -> part1 is a table, part2 is a column name, part3 and beyond are struct fields
-	// -> part1 is a column, part2 and beyond are struct fields
+	// the reference can be qualified with an arbitrarily deep catalog/schema path, e.g.:
+	// -> catalog.schema1.schema2...table.column.field...
+	// -> schema1.schema2...table.column.field...
+	// -> catalog.table.column.field...
+	// -> table.column.field...
+	// -> column.field...
 
-	// we always prefer the most top-level view
-	// i.e. in case of multiple resolution options, we resolve in order:
-	// -> 1. resolve "part1" as a catalog
-	// -> 2. resolve "part1" as a schema
-	// -> 3. resolve "part1" as a table
-	// -> 4. resolve "part1" as a column
-
-	// first check if part1 is a catalog
-	ErrorData fully_qualified_error;
-	optional_ptr<Binding> binding;
-	if (col_ref.ColumnNames().size() > 3) {
-		binding = binder.GetMatchingBinding(col_ref.ColumnNames()[0], col_ref.ColumnNames()[1],
-		                                    col_ref.ColumnNames()[2], col_ref.ColumnNames()[3], fully_qualified_error);
-		if (binding) {
-			// part1 is a catalog - the column reference is "catalog.schema.table.column"
-			struct_extract_start = 4;
-			return binder.bind_context.CreateColumnReference(binding->GetBindingAlias(), col_ref.ColumnNames()[3]);
+	// we always prefer the most top-level view - i.e. we resolve the table as far to the right as possible (so the
+	// leading components are treated as catalog/schema rather than column/struct fields), and within a given table
+	// position we prefer treating the leading component as a catalog over a schema
+	auto &names = col_ref.ColumnNames();
+	// we could not find the column - remember the most specific error to return. In order of preference:
+	//  2. the table qualification matched a binding, but it has no such column
+	//  1. the table name matches a binding, but the catalog/schema qualification does not
+	//  0. the shallowest "table.column" error (nothing matched)
+	ErrorData best_error;
+	idx_t best_error_priority = 0;
+	// try each possible table position, from the most-qualified (table furthest to the right) to the least
+	for (idx_t table_index = names.size() - 2;; table_index--) {
+		auto &column_name = names[table_index + 1];
+		for (auto &alias : GetTableQualifications(names, table_index)) {
+			ErrorData attempt_error;
+			auto binding = binder.GetMatchingBinding(alias, column_name, attempt_error);
+			if (binding) {
+				struct_extract_start = table_index + 2;
+				return binder.bind_context.CreateColumnReference(binding->GetBindingAlias(), column_name);
+			}
+			idx_t priority = 0;
+			if (TableBindingExists(alias)) {
+				// the full qualification matched a binding, but it has no such column
+				priority = 2;
+			} else if (TableNameExists(alias.GetAlias())) {
+				// the table name matches a binding, but the catalog/schema qualification does not
+				priority = 1;
+			}
+			// prefer the first (most-qualified) error of the highest priority we have seen
+			if (priority > best_error_priority || (priority == best_error_priority && !best_error.HasError())) {
+				best_error = std::move(attempt_error);
+				best_error_priority = priority;
+			}
 		}
-	}
-	ErrorData catalog_table_error;
-	binding = binder.GetMatchingBinding(col_ref.ColumnNames()[0], Identifier::InvalidSchema(), col_ref.ColumnNames()[1],
-	                                    col_ref.ColumnNames()[2], catalog_table_error);
-	if (binding) {
-		// part1 is a catalog - the column reference is "catalog.table.column"
-		struct_extract_start = 3;
-		return binder.bind_context.CreateColumnReference(binding->GetBindingAlias(), col_ref.ColumnNames()[2]);
-	}
-	ErrorData schema_table_error;
-	binding = binder.GetMatchingBinding(col_ref.ColumnNames()[0], col_ref.ColumnNames()[1], col_ref.ColumnNames()[2],
-	                                    schema_table_error);
-	if (binding) {
-		// part1 is a schema - the column reference is "schema.table.column"
-		// any additional fields are turned into struct_extract calls
-		struct_extract_start = 3;
-		return binder.bind_context.CreateColumnReference(binding->GetBindingAlias(), col_ref.ColumnNames()[2]);
-	}
-	ErrorData table_column_error;
-	binding = binder.GetMatchingBinding(col_ref.ColumnNames()[0], col_ref.ColumnNames()[1], table_column_error);
-	if (binding) {
-		// part1 is a table
-		// the column reference is "table.column"
-		// any additional fields are turned into struct_extract calls
-		struct_extract_start = 2;
-		return binder.bind_context.CreateColumnReference(binding->GetBindingAlias(), col_ref.ColumnNames()[1]);
+		if (table_index == 0) {
+			break;
+		}
 	}
 	// part1 could be a column
 	ErrorData unused_error;
-	auto result_expr = QualifyColumnName(col_ref, col_ref.ColumnNames()[0], unused_error);
+	auto result_expr = QualifyColumnName(col_ref, names[0], unused_error);
 	if (result_expr) {
 		// it is! add the struct extract calls
 		struct_extract_start = 1;
@@ -412,81 +405,28 @@ unique_ptr<ParsedExpression> ColumnQualifier::QualifyColumnNameWithManyDotsInter
 		return struct_pack;
 	}
 
-	// we could not find the column - return an error
-	// try to find out which error to return
-	optional_idx catalog_pos;
-	optional_idx schema_pos;
-	optional_idx table_pos;
-	for (const auto &binding_entry : binder.bind_context.GetBindingsList()) {
-		auto &alias = binding_entry->GetBindingAlias();
-		string catalog = alias.GetCatalog().GetIdentifierName();
-		string schema = alias.GetSchema().GetIdentifierName();
-		string table = alias.GetAlias().GetIdentifierName();
-		auto entry = binding_entry->GetStandardEntry();
-		if (entry) {
-			catalog = entry->ParentCatalog().GetName().GetIdentifierName();
-			schema = entry->ParentSchema().name.GetIdentifierName();
-		}
-
-		for (idx_t i = 0; i < 3; i++) {
-			if (catalog == col_ref.ColumnNames()[i]) {
-				catalog_pos = i;
-			}
-			if (schema == col_ref.ColumnNames()[i]) {
-				schema_pos = i;
-			}
-			if (table == col_ref.ColumnNames()[i]) {
-				table_pos = i;
-			}
-		}
-	}
-
-	error = std::move(table_column_error);
-	if (table_pos.IsValid()) {
-		// we have a valid table
-		if (table_pos.GetIndex() == 0) {
-			// the first column is a valid table - return the error as if we were binding the column as the second
-
-		} else if (table_pos.GetIndex() == 1) {
-			// the first column is a valid table
-			// this means either the first column is a catalog OR the first column is a schema
-			if (catalog_pos.IsValid()) {
-				// catalog.table
-				error = std::move(catalog_table_error);
-			} else {
-				// assume schema.table otherwise
-				error = std::move(schema_table_error);
-			}
-		} else if (col_ref.ColumnNames().size() > 3) {
-			// the second column is a valid table
-			// return the fully qualified error if we have enough components
-			error = std::move(fully_qualified_error);
-		}
-	} else if (catalog_pos.IsValid()) {
-		// the first column is a catalog
-		if (schema_pos.IsValid()) {
-			// AND a valid schema - this is likely "catalog.schema.table"
-			if (col_ref.ColumnNames().size() > 3) {
-				error = std::move(fully_qualified_error);
-			} else {
-				error = std::move(catalog_table_error);
-			}
-		} else {
-			// but no valid schema - this could be either "catalog.schema.table" or "catalog.table"
-			// return "catalog.table" for now
-			error = std::move(catalog_table_error);
-		}
-	} else if (schema_pos.IsValid()) {
-		// we did not find a catalog or a table, but we did find a schema
-		if (schema_pos.GetIndex() == 0) {
-			// "schema.table"
-			error = std::move(schema_table_error);
-		} else if (schema_pos.GetIndex() == 1 && col_ref.ColumnNames().size() > 3) {
-			// catalog.schema.table
-			error = std::move(fully_qualified_error);
-		}
-	}
+	// we could not find the column - return the most specific error we encountered
+	error = std::move(best_error);
 	return nullptr;
+}
+
+bool ColumnQualifier::TableNameExists(const Identifier &table_name) {
+	for (const auto &binding_entry : binder.bind_context.GetBindingsList()) {
+		if (binding_entry->GetBindingAlias().GetAlias() == table_name) {
+			return true;
+		}
+	}
+	return false;
+}
+
+bool ColumnQualifier::TableBindingExists(const BindingAlias &alias) {
+	try {
+		ErrorData error;
+		return binder.bind_context.GetBinding(alias, error) != nullptr;
+	} catch (const std::exception &) {
+		// an ambiguity between multiple matching tables still means the table qualification exists
+		return true;
+	}
 }
 
 unique_ptr<ParsedExpression> ColumnQualifier::QualifyColumnNameWithManyDots(ColumnRefExpression &col_ref,

--- a/src/planner/expression_binder.cpp
+++ b/src/planner/expression_binder.cpp
@@ -404,7 +404,7 @@ bool ExpressionBinder::IsPotentialAlias(const ColumnRefExpression &colref) {
 		return true;
 	}
 	if (colref.ColumnNames().size() == 2) {
-		return colref.GetTableName() == "alias";
+		return colref.ColumnNames()[0] == "alias";
 	}
 	return false;
 }

--- a/src/planner/expression_binder/table_function_binder.cpp
+++ b/src/planner/expression_binder/table_function_binder.cpp
@@ -35,7 +35,7 @@ BindResult TableFunctionBinder::BindColumnReference(unique_ptr<ParsedExpression>
 		if (binder.macro_binding && binder.macro_binding->HasMatchingBinding(Identifier(col_ref.GetName()))) {
 			throw ParameterNotResolvedException();
 		}
-	} else if (col_ref.ColumnNames()[0].GetIdentifierName().find(DummyBinding::DUMMY_NAME) != string::npos &&
+	} else if (StringUtil::StartsWith(col_ref.ColumnNames()[0].GetIdentifierName(), DummyBinding::DUMMY_NAME) &&
 	           binder.macro_binding && binder.macro_binding->HasMatchingBinding(Identifier(col_ref.GetName()))) {
 		throw ParameterNotResolvedException();
 	}

--- a/test/configs/force_storage.json
+++ b/test/configs/force_storage.json
@@ -10,6 +10,7 @@
         "test/sql/catalog/nested_schema/drop_nested_schema.test",
         "test/sql/catalog/nested_schema/nested_table.test",
         "test/sql/catalog/nested_schema/nested_table_dml.test",
+        "test/sql/catalog/nested_schema/nested_table_columnref.test",
         "test/sql/show_select/test_describe_all.test",
         "test/sql/catalog/function/attached_macro.test",
         "test/sql/catalog/test_temporary.test",

--- a/test/configs/storage_compatibility.json
+++ b/test/configs/storage_compatibility.json
@@ -208,7 +208,8 @@
         "test/sql/catalog/nested_schema/create_nested_schema.test",
         "test/sql/catalog/nested_schema/drop_nested_schema.test",
         "test/sql/catalog/nested_schema/nested_table.test",
-        "test/sql/catalog/nested_schema/nested_table_dml.test"
+        "test/sql/catalog/nested_schema/nested_table_dml.test",
+        "test/sql/catalog/nested_schema/nested_table_columnref.test"
       ]
     },
     {

--- a/test/sql/catalog/nested_schema/nested_table_columnref.test
+++ b/test/sql/catalog/nested_schema/nested_table_columnref.test
@@ -1,0 +1,162 @@
+# name: test/sql/catalog/nested_schema/nested_table_columnref.test
+# description: Test qualified column references to tables in nested schemas
+# group: [nested_schema]
+
+statement ok
+CREATE SCHEMA s1;
+
+statement ok
+CREATE SCHEMA s1.s2;
+
+statement ok
+CREATE TABLE s1.s2.tbl(i INTEGER, s STRUCT(a INTEGER, b INTEGER));
+
+statement ok
+INSERT INTO s1.s2.tbl VALUES (1, {'a': 10, 'b': 20});
+
+# schema1.schema2.table.column
+query I
+SELECT s1.s2.tbl.i FROM s1.s2.tbl;
+----
+1
+
+# catalog.schema1.schema2.table.column
+query I
+SELECT memory.s1.s2.tbl.i FROM s1.s2.tbl;
+----
+1
+
+# table.column
+query I
+SELECT tbl.i FROM s1.s2.tbl;
+----
+1
+
+# unqualified column
+query I
+SELECT i FROM s1.s2.tbl;
+----
+1
+
+# schema1.schema2.table.column.field (struct field access on a nested-schema table)
+query I
+SELECT s1.s2.tbl.s.a FROM s1.s2.tbl;
+----
+10
+
+# table.column.field
+query I
+SELECT tbl.s.b FROM s1.s2.tbl;
+----
+20
+
+# catalog.schema1.schema2.table.column.field
+query I
+SELECT memory.s1.s2.tbl.s.a FROM s1.s2.tbl;
+----
+10
+
+# column.field (unqualified struct column)
+query I
+SELECT s.a FROM s1.s2.tbl;
+----
+10
+
+# referencing the whole nested-schema table produces a struct (implicit struct_pack)
+query I
+SELECT s1.s2.tbl FROM s1.s2.tbl;
+----
+{'i': 1, 's': {'a': 10, 'b': 20}}
+
+query I
+SELECT s2.tbl FROM s1.s2.tbl;
+----
+{'i': 1, 's': {'a': 10, 'b': 20}}
+
+# the innermost schema alone qualifies the table
+query I
+SELECT s2.tbl.i FROM s1.s2.tbl;
+----
+1
+
+# a non-immediate schema does not qualify the table
+statement error
+SELECT s1.tbl.i FROM s1.s2.tbl;
+----
+<REGEX>:.*not found.*
+
+# a bogus catalog/schema qualifier errors
+statement error
+SELECT nope.s2.tbl.i FROM s1.s2.tbl;
+----
+<REGEX>:.*not found.*
+
+# disambiguation between same-named tables in different nested schemas
+statement ok
+CREATE SCHEMA s1.s3;
+
+statement ok
+CREATE TABLE s1.s2.dup(a INTEGER);
+
+statement ok
+CREATE TABLE s1.s3.dup(b INTEGER);
+
+statement ok
+INSERT INTO s1.s2.dup VALUES (100);
+
+statement ok
+INSERT INTO s1.s3.dup VALUES (200);
+
+# disambiguate by the innermost schema
+query II
+SELECT s2.dup.a, s3.dup.b FROM s1.s2.dup, s1.s3.dup;
+----
+100	200
+
+# disambiguate by the full schema path
+query II
+SELECT s1.s2.dup.a, s1.s3.dup.b FROM s1.s2.dup, s1.s3.dup;
+----
+100	200
+
+# a shared outer schema does not disambiguate the tables
+statement error
+SELECT s1.dup.a FROM s1.s2.dup, s1.s3.dup;
+----
+<REGEX>:.*not found.*
+
+# same immediate schema, different outer schema -> ambiguous when referenced by the immediate schema only
+statement ok
+CREATE SCHEMA s4;
+
+statement ok
+CREATE SCHEMA s4.s2;
+
+statement ok
+CREATE TABLE s4.s2.dup(a INTEGER);
+
+statement ok
+INSERT INTO s4.s2.dup VALUES (300);
+
+# "s2.dup" now matches both s1.s2.dup and s4.s2.dup (both have column a) -> ambiguous, and the hint shows the full paths
+statement error
+SELECT s2.dup.a FROM s1.s2.dup, s4.s2.dup;
+----
+<REGEX>:.*Ambiguous.*s1.s2.dup.*s4.s2.dup.*
+
+# the full path resolves the ambiguity
+query II
+SELECT s1.s2.dup.a AS x, s4.s2.dup.a AS y FROM s1.s2.dup, s4.s2.dup;
+----
+100	300
+
+# aliasing a nested-schema table hides its schema qualification
+query I
+SELECT t.i FROM s1.s2.tbl AS t;
+----
+1
+
+statement error
+SELECT s1.s2.tbl.i FROM s1.s2.tbl AS t;
+----
+<REGEX>:.*not found.*


### PR DESCRIPTION
Follow-up to https://github.com/duckdb/duckdb/pull/24076

Add support for querying data from nested schemas and disambiguation between nested schemas, e.g. this works now:

```sql

CREATE SCHEMA s1;
CREATE SCHEMA s1.s2;
CREATE TABLE s1.s2.tbl(i INTEGER, s STRUCT(a INTEGER, b INTEGER));
INSERT INTO s1.s2.tbl VALUES (1, {'a': 10, 'b': 20});
SELECT s1.s2.tbl.s.a FROM s1.s2.tbl;
┌─────────────────┐
│ (s1.s2.tbl.s).a │
│      int32      │
├─────────────────┤
│              10 │
└─────────────────┘
```