### PR TITLE
Make sure dictionary vectors don't contain invalid values

### DIFF
--- a/extension/parquet/include/column_reader.hpp
+++ b/extension/parquet/include/column_reader.hpp
@@ -306,6 +306,13 @@ private:
 		}
 	}
 
+	//! The caller wraps the result in a dictionary that still spans the rows we skipped over, so those rows must hold
+	//! a defined value instead of uninitialized memory - zero is an empty string for string_t, and 0 otherwise
+	template <class VALUE_TYPE>
+	static void ZeroSkippedRows(VALUE_TYPE *result_ptr, idx_t row_offset, idx_t skip_count) {
+		memset(result_ptr + row_offset, 0, sizeof(VALUE_TYPE) * skip_count);
+	}
+
 	template <class VALUE_TYPE, class CONVERSION, bool HAS_DEFINES, bool CHECKED>
 	void PlainSelectTemplatedInternal(ByteBuffer &plain_data, const uint8_t *__restrict defines,
 	                                  const uint64_t num_values, Vector &result, const SelectionVector &sel,
@@ -319,6 +326,7 @@ private:
 			// perform any skips forward if required
 			PlainSkipTemplatedInternal<CONVERSION, HAS_DEFINES, CHECKED>(plain_data, defines,
 			                                                             next_entry - current_entry, current_entry);
+			ZeroSkippedRows<VALUE_TYPE>(result_ptr, current_entry, next_entry - current_entry);
 			// read this row
 			if (HAS_DEFINES && defines[next_entry] != MaxDefine()) {
 				result_mask.SetInvalid(next_entry);
@@ -331,6 +339,7 @@ private:
 			// skip forward to the end of where we are selecting
 			PlainSkipTemplatedInternal<CONVERSION, HAS_DEFINES, CHECKED>(plain_data, defines,
 			                                                             num_values - current_entry, current_entry);
+			ZeroSkippedRows<VALUE_TYPE>(result_ptr, current_entry, num_values - current_entry);
 		}
 	}
 

--- a/src/common/vector/dictionary_vector.cpp
+++ b/src/common/vector/dictionary_vector.cpp
@@ -46,6 +46,9 @@ void DictionaryBuffer::VerifyInternal(const LogicalType &type, const SelectionVe
 		throw InternalException("Dictionary expression type mismatch - type %s does not match child type %s", type,
 		                        child.GetType());
 	}
+	// consumers may read any entry in [0, dictionary size), not only the ones the selection vector references - e.g.
+	// ColumnDataCollection copies the whole dictionary to keep it compressed - so verify the entire child
+	child.Verify();
 	if (!sel.IsSet()) {
 		// sel is not set - directly pass in the dictionary
 		child.Verify(sel_vector, count);

--- a/src/common/vector/flat_vector.cpp
+++ b/src/common/vector/flat_vector.cpp
@@ -76,6 +76,18 @@ void StandardVectorBuffer::VerifyInternal(const LogicalType &type, const Selecti
 			throw InternalException("Count %d out of range for capacity %d", count, Capacity());
 		}
 	}
+	if (type.id() == LogicalTypeId::VARCHAR) {
+		// verify the strings themselves - this catches entries a producer left uninitialized
+		// only for actual VARCHAR: BLOB/BIT/VARINT/aggregate states share the physical type but are not UTF8
+		// ForceVerify: we only get here in VERIFY_VECTORS mode, which is also run against release builds
+		const auto strings = reinterpret_cast<const string_t *>(data_ptr);
+		for (idx_t i = 0; i < count; i++) {
+			const auto idx = sel.get_index(i);
+			if (validity.RowIsValid(idx)) {
+				strings[idx].ForceVerify();
+			}
+		}
+	}
 }
 
 buffer_ptr<VectorBuffer> StandardVectorBuffer::SliceInternal(const LogicalType &type, idx_t offset, idx_t end) {

--- a/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
+++ b/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
@@ -857,6 +857,17 @@ void StringValueResult::NullPaddingQuotedNewlineCheck() const {
 	}
 }
 
+void StringValueResult::InvalidateUnwrittenColumns(idx_t first_unwritten_col) {
+	// A borked row is sliced out of the chunk later on, but the slice still spans it - the columns we never got around
+	// to writing must not be left as uninitialized string_t values with their valid bit set
+	if (borked_rows.find(static_cast<idx_t>(number_of_rows)) == borked_rows.end()) {
+		return;
+	}
+	for (idx_t col_idx = first_unwritten_col; col_idx < validity_mask.size(); col_idx++) {
+		validity_mask[col_idx]->SetInvalid(static_cast<idx_t>(number_of_rows));
+	}
+}
+
 bool StringValueResult::AddRowInternal() {
 	LinePosition current_line_start = {iterator.pos.buffer_idx, iterator.pos.buffer_pos, buffer_size};
 	idx_t current_line_size = current_line_start - current_line_position.end;
@@ -873,13 +884,7 @@ bool StringValueResult::AddRowInternal() {
 
 	const auto chunk_col_id_before = chunk_col_id;
 	if (current_errors.HandleErrors(*this)) {
-		// Before we add row, invalid all columns that are not populated for this row (i.e., CSV rows have fewer fields
-		// than expected). Otherwise, uninitialized string_t with valid bits set would lead invalid memory access.
-		if (borked_rows.find(static_cast<idx_t>(number_of_rows)) != borked_rows.end()) {
-			for (idx_t cur_col_idx = chunk_col_id_before; cur_col_idx < validity_mask.size(); ++cur_col_idx) {
-				validity_mask[cur_col_idx]->SetInvalid(static_cast<idx_t>(number_of_rows));
-			}
-		}
+		InvalidateUnwrittenColumns(chunk_col_id_before);
 
 		D_ASSERT(buffer_handles.find(current_line_position.begin.buffer_idx) != buffer_handles.end());
 		D_ASSERT(buffer_handles.find(current_line_position.end.buffer_idx) != buffer_handles.end());
@@ -2034,7 +2039,9 @@ void StringValueScanner::FinishBoundaryScan(const bool moved) {
 	}
 	const bool found_error =
 	    result.current_errors.HasErrorType(UNTERMINATED_QUOTES) || result.current_errors.HasErrorType(INVALID_STATE);
+	auto chunk_col_id_before = result.chunk_col_id;
 	if (result.current_errors.HandleErrors(result)) {
+		result.InvalidateUnwrittenColumns(chunk_col_id_before);
 		result.number_of_rows++;
 	}
 	if (states.IsQuotedCurrent() && !found_error) {
@@ -2043,7 +2050,9 @@ void StringValueScanner::FinishBoundaryScan(const bool moved) {
 			// quotes
 			result.current_errors.Insert(UNTERMINATED_QUOTES, result.cur_col_id, result.chunk_col_id,
 			                             result.last_position);
+			chunk_col_id_before = result.chunk_col_id;
 			if (result.current_errors.HandleErrors(result)) {
+				result.InvalidateUnwrittenColumns(chunk_col_id_before);
 				result.number_of_rows++;
 			}
 		} else {

--- a/src/function/scalar/variant/variant_utils.cpp
+++ b/src/function/scalar/variant/variant_utils.cpp
@@ -241,6 +241,13 @@ void VariantUtils::FinalizeVariantKeys(Vector &variant, OrderedOwningStringMap<u
 		it++;
 	}
 
+	//! The caller slices this vector into a dictionary that still spans every key slot, but only the distinct keys are
+	//! written above - zero the remaining slots so they hold empty strings instead of uninitialized memory
+	auto keys_entry_size = ListVector::GetListSize(keys);
+	if (dictionary.size() < keys_entry_size) {
+		memset(keys_entry_data + dictionary.size(), 0, sizeof(string_t) * (keys_entry_size - dictionary.size()));
+	}
+
 	if (!already_sorted) {
 		//! Adjust the selection vector to point to the right dictionary index
 		for (idx_t i = 0; i < sel_size; i++) {

--- a/src/include/duckdb/execution/operator/csv_scanner/string_value_scanner.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/string_value_scanner.hpp
@@ -278,6 +278,8 @@ public:
 	//! Handles EmptyLine states
 	static inline bool EmptyLine(StringValueResult &result, const idx_t buffer_pos);
 	inline bool AddRowInternal();
+	//! Marks the columns of a borked row that were never written as NULL
+	void InvalidateUnwrittenColumns(idx_t first_unwritten_col);
 	//! Force the throw of a Unicode error
 	void HandleUnicodeError(idx_t col_idx, LinePosition &error_position);
 	bool HandleTooManyColumnsError(const char *value_ptr, const idx_t size);

--- a/test/sql/copy/parquet/parquet_filter_dictionary_materialize.test
+++ b/test/sql/copy/parquet/parquet_filter_dictionary_materialize.test
@@ -1,0 +1,40 @@
+# name: test/sql/copy/parquet/parquet_filter_dictionary_materialize.test
+# description: Materialize a dictionary vector produced by a filtered Parquet scan
+# group: [parquet]
+
+require parquet
+
+# the last row is removed by the join filter pushed into the scan, so the decoded chunk backing the
+# dictionary has an entry that is never materialized - materializing the result must not read it
+statement ok
+COPY (SELECT i::BIGINT AS k, 'this is a sufficiently long string value number ' || i AS v,
+             'and here is another long string value number ' || i AS w
+      FROM range(1, 181) t(i))
+TO '{TEST_DIR}/dict_probe_side.parquet' (FORMAT parquet);
+
+statement ok
+COPY (SELECT ((i % 179) + 1)::BIGINT AS k FROM range(0, 409) t(i))
+TO '{TEST_DIR}/dict_build_side.parquet' (FORMAT parquet);
+
+query III
+SELECT count(*), count(DISTINCT b.v), count(DISTINCT b.w)
+FROM '{TEST_DIR}/dict_build_side.parquet' a JOIN '{TEST_DIR}/dict_probe_side.parquet' b ON (a.k=b.k)
+----
+409	179	179
+
+query II
+SELECT b.v, b.w
+FROM '{TEST_DIR}/dict_build_side.parquet' a JOIN '{TEST_DIR}/dict_probe_side.parquet' b ON (a.k=b.k)
+ORDER BY a.k LIMIT 2
+----
+this is a sufficiently long string value number 1	and here is another long string value number 1
+this is a sufficiently long string value number 1	and here is another long string value number 1
+
+statement ok
+SET disabled_optimizers='join_order';
+
+query III
+SELECT count(*), count(DISTINCT b.v), count(DISTINCT b.w)
+FROM '{TEST_DIR}/dict_build_side.parquet' a JOIN '{TEST_DIR}/dict_probe_side.parquet' b ON (a.k=b.k)
+----
+409	179	179


### PR DESCRIPTION
We had this case where we read a dictionary page from a parquet file with a filter on a different column. the selection vector lead to particular values not being filled, which lead to crashes/address sanitizer issues when e.g. copying this vector around. 

This PR fixes this by filling those slots with 0 or the empty string, and adds a verification call to ensure this does not happen elsewhere. 
