### PR TITLE
Fix bench runs

### DIFF
--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -51,6 +51,7 @@ jobs:
 
       - name: Install tools
         run: python3 scripts/ci/retry.py --timeout 2m -- make toolsci
+        timeout-minutes: 10
 
       - uses: ./.github/actions/ccache-action
 
@@ -145,8 +146,8 @@ jobs:
           ref: ${{ env.GIT_REF }}
 
       - name: Install
-        run: |
-          python3 scripts/ci/retry.py -- make toolsci
+        run: python3 scripts/ci/retry.py --timeout 2m -- make toolsci
+        timeout-minutes: 10
 
       - name: Download current release artifact
         uses: actions/download-artifact@v8
@@ -229,8 +230,8 @@ jobs:
           ref: ${{ env.GIT_REF }}
 
       - name: Install
-        run: |
-          python3 scripts/ci/retry.py -- make toolsci
+        run: python3 scripts/ci/retry.py --timeout 2m -- make toolsci
+        timeout-minutes: 10
 
       - name: Download current release artifact
         uses: actions/download-artifact@v8
@@ -280,8 +281,8 @@ jobs:
           ref: ${{ env.GIT_REF }}
 
       - name: Install
-        run: |
-          python3 scripts/ci/retry.py -- make toolsci
+        run: python3 scripts/ci/retry.py --timeout 2m -- make toolsci
+        timeout-minutes: 10
 
       - name: Checkout Private Regression
         if: ${{ github.repository == 'duckdb/duckdb' && github.ref_name == 'main' }}
@@ -330,8 +331,8 @@ jobs:
           ref: ${{ env.GIT_REF }}
 
       - name: Install
-        run: |
-          python3 scripts/ci/retry.py -- make toolsci
+        run: python3 scripts/ci/retry.py --timeout 2m -- make toolsci
+        timeout-minutes: 10
 
       - name: Download current release artifact
         uses: actions/download-artifact@v8
@@ -375,8 +376,8 @@ jobs:
           ref: ${{ env.GIT_REF }}
 
       - name: Install
-        run: |
-          python3 scripts/ci/retry.py -- make toolsci
+        run: python3 scripts/ci/retry.py --timeout 2m -- make toolsci
+        timeout-minutes: 10
 
       - name: Download current release artifact
         uses: actions/download-artifact@v8
@@ -417,8 +418,9 @@ jobs:
 
       - name: Install
         run: |
-          python3 scripts/ci/retry.py -- make toolsci
-          python3 scripts/ci/retry.py -- pip install tqdm
+          python3 scripts/ci/retry.py --timeout 2m -- make toolsci
+          python3 scripts/ci/retry.py --timeout 2m -- pip install tqdm
+        timeout-minutes: 10
 
       - name: Download current release artifact
         uses: actions/download-artifact@v8

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -126,9 +126,7 @@ jobs:
           - name: Ingestion Perf
             benchmarks: .github/regression/ingestion.csv
           - name: Micro
-            benchmarks: .github/regression/tpch_parquet.csv
-          - name: TPCH-PARQUET
-            benchmarks: .github/regression/tpch_parquet.csv
+            benchmarks: .github/regression/micro.csv
           - name: H2OAI
             benchmarks: .github/regression/h2oai.csv
           - name: IMDB
@@ -219,6 +217,9 @@ jobs:
           - name: TPCDS SF3
             benchmarks: .github/regression/tpcds_sf3.csv
             threads: 4
+          - name: TPCH-PARQUET SF1
+            benchmarks: .github/regression/tpch_parquet.csv
+            threads: 2
 
     steps:
       - name: "Checkout"


### PR DESCRIPTION
I made a typo when [splitting](https://github.com/duckdb/duckdb/pull/24184) the benchmarks:
```
          - name: Micro
            benchmarks: .github/regression/tpch_parquet.csv
          - name: TPCH-PARQUET
            benchmarks: .github/regression/tpch_parquet.csv
```
so the `Micro` benchmark was actually running `tpch_parquet.csv` again.

### Changes 
- Move TPC-H parquet to namespace.
- Re-enable micro bench in CI.
- Add timeout to install command and CI step.