### PR TITLE
[MultiFileReader] Add column indexes to `DynamicFilterPushdown` parameters

### DIFF
--- a/.github/config/extensions/delta.cmake
+++ b/.github/config/extensions/delta.cmake
@@ -3,5 +3,6 @@ if(NOT MINGW AND NOT ${WASM_ENABLED})
             GIT_URL https://github.com/duckdb/duckdb-delta
             GIT_TAG e74cf88ebf64a6638de443025510d8269c31616a
             SUBMODULES extension-ci-tools
+            APPLY_PATCHES
   )
 endif()

--- a/.github/config/extensions/ducklake.cmake
+++ b/.github/config/extensions/ducklake.cmake
@@ -2,4 +2,5 @@ duckdb_extension_load(ducklake
     LOAD_TESTS
     GIT_URL https://github.com/duckdb/ducklake
     GIT_TAG eb7b95df82fc3ba0ace777e34ef1c81280477042
+    APPLY_PATCHES
 )

--- a/.github/patches/extensions/delta/0001-dynamic_filter_pushdown_info.patch
+++ b/.github/patches/extensions/delta/0001-dynamic_filter_pushdown_info.patch
@@ -1,0 +1,38 @@
+diff --git a/src/functions/delta_scan/delta_multi_file_list.cpp b/src/functions/delta_scan/delta_multi_file_list.cpp
+index 3f01498..a0d2c28 100644
+--- a/src/functions/delta_scan/delta_multi_file_list.cpp
++++ b/src/functions/delta_scan/delta_multi_file_list.cpp
+@@ -1002,9 +1002,14 @@ void DeltaMultiFileList::ReportFilterPushdown(ClientContext &context, DeltaMulti
+ }
+ 
+ unique_ptr<MultiFileList>
+-DeltaMultiFileList::DynamicFilterPushdown(ClientContext &context, const MultiFileOptions &options,
+-                                          const vector<Identifier> &names, const vector<LogicalType> &types,
+-                                          const vector<column_t> &column_ids, TableFilterSet &filters) const {
++DeltaMultiFileList::DynamicFilterPushdown(MultiFileDynamicPushdownInfo &dynamic_pushdown_info) const {
++	auto &options = dynamic_pushdown_info.options;
++	auto &names = dynamic_pushdown_info.column_names;
++	auto &types = dynamic_pushdown_info.column_types;
++	auto &column_ids = dynamic_pushdown_info.column_ids;
++	auto &context = dynamic_pushdown_info.context;
++	auto &filters = dynamic_pushdown_info.filters;
++
+ 	auto pushdown_mode = GetDeltaFilterPushdownMode(context, options);
+ 	if (pushdown_mode == DeltaFilterPushdownMode::NONE || pushdown_mode == DeltaFilterPushdownMode::CONSTANT_ONLY) {
+ 		return nullptr;
+diff --git a/src/include/functions/delta_scan/delta_multi_file_list.hpp b/src/include/functions/delta_scan/delta_multi_file_list.hpp
+index 3e95151..24b3ffd 100644
+--- a/src/include/functions/delta_scan/delta_multi_file_list.hpp
++++ b/src/include/functions/delta_scan/delta_multi_file_list.hpp
+@@ -108,10 +108,7 @@ public:
+ 	                                                MultiFilePushdownInfo &info,
+ 	                                                vector<unique_ptr<Expression>> &filters) const override;
+ 
+-	unique_ptr<MultiFileList> DynamicFilterPushdown(ClientContext &context, const MultiFileOptions &options,
+-	                                                const vector<Identifier> &names, const vector<LogicalType> &types,
+-	                                                const vector<column_t> &column_ids,
+-	                                                TableFilterSet &filters) const override;
++	unique_ptr<MultiFileList> DynamicFilterPushdown(MultiFileDynamicPushdownInfo &pushdown_info) const override;
+ 
+ 	unique_ptr<DeltaMultiFileList> PushdownInternal(ClientContext &context, TableFilterSet &new_filters,
+ 	                                                vector<column_t> column_indexes) const;

--- a/.github/patches/extensions/ducklake/0001-dynamic_filter_pushdown_info.patch
+++ b/.github/patches/extensions/ducklake/0001-dynamic_filter_pushdown_info.patch
@@ -1,0 +1,38 @@
+diff --git a/src/include/storage/ducklake_multi_file_list.hpp b/src/include/storage/ducklake_multi_file_list.hpp
+index 6c8d3a9a..0e02b96b 100644
+--- a/src/include/storage/ducklake_multi_file_list.hpp
++++ b/src/include/storage/ducklake_multi_file_list.hpp
+@@ -30,10 +30,7 @@ public:
+ 	DuckLakeMultiFileList(DuckLakeFunctionInfo &read_info, vector<DuckLakeFileListEntry> files_to_scan);
+ 	DuckLakeMultiFileList(DuckLakeFunctionInfo &read_info, const DuckLakeInlinedTableInfo &inlined_table);
+ 
+-	unique_ptr<MultiFileList> DynamicFilterPushdown(ClientContext &context, const MultiFileOptions &options,
+-	                                                const vector<Identifier> &names, const vector<LogicalType> &types,
+-	                                                const vector<column_t> &column_ids,
+-	                                                TableFilterSet &filters) const override;
++	unique_ptr<MultiFileList> DynamicFilterPushdown(MultiFileDynamicPushdownInfo &pushdown_info) const override;
+ 
+ 	unique_ptr<MultiFileList> ComplexFilterPushdown(ClientContext &context, const MultiFileOptions &options,
+ 	                                                MultiFilePushdownInfo &info,
+diff --git a/src/storage/ducklake_multi_file_list.cpp b/src/storage/ducklake_multi_file_list.cpp
+index bd557b54..4e8ee078 100644
+--- a/src/storage/ducklake_multi_file_list.cpp
++++ b/src/storage/ducklake_multi_file_list.cpp
+@@ -56,9 +56,14 @@ void DuckLakeMultiFileList::AddFilterToPushdownInfo(FilterPushdownInfo &pushdown
+ }
+ 
+ unique_ptr<MultiFileList>
+-DuckLakeMultiFileList::DynamicFilterPushdown(ClientContext &context, const MultiFileOptions &options,
+-                                             const vector<Identifier> &names, const vector<LogicalType> &types,
+-                                             const vector<column_t> &column_ids, TableFilterSet &filters) const {
++DuckLakeMultiFileList::DynamicFilterPushdown(MultiFileDynamicPushdownInfo &dynamic_pushdown_info) const {
++	auto &options = dynamic_pushdown_info.options;
++	auto &names = dynamic_pushdown_info.column_names;
++	auto &types = dynamic_pushdown_info.column_types;
++	auto &column_ids = dynamic_pushdown_info.column_ids;
++	auto &context = dynamic_pushdown_info.context;
++	auto &filters = dynamic_pushdown_info.filters;
++
+ 	if (read_info.scan_type != DuckLakeScanType::SCAN_TABLE || !filters.HasFilters()) {
+ 		// filter pushdown is only supported when scanning full tables
+ 		return nullptr;

--- a/.github/patches/extensions/iceberg/0002-dynamic_filter_pushdown_info.patch
+++ b/.github/patches/extensions/iceberg/0002-dynamic_filter_pushdown_info.patch
@@ -1,0 +1,38 @@
+diff --git a/src/include/planning/iceberg_multi_file_list.hpp b/src/include/planning/iceberg_multi_file_list.hpp
+index b2bc0cd0..a6da48f0 100644
+--- a/src/include/planning/iceberg_multi_file_list.hpp
++++ b/src/include/planning/iceberg_multi_file_list.hpp
+@@ -177,10 +177,7 @@ public:
+ 
+ public:
+ 	//! MultiFileList API
+-	unique_ptr<MultiFileList> DynamicFilterPushdown(ClientContext &context, const MultiFileOptions &options,
+-	                                                const vector<Identifier> &names, const vector<LogicalType> &types,
+-	                                                const vector<column_t> &column_ids,
+-	                                                TableFilterSet &filters) const override;
++	unique_ptr<MultiFileList> DynamicFilterPushdown(MultiFileDynamicPushdownInfo &pushdown_info) const override;
+ 	unique_ptr<MultiFileList> ComplexFilterPushdown(ClientContext &context, const MultiFileOptions &options,
+ 	                                                MultiFilePushdownInfo &info,
+ 	                                                vector<unique_ptr<Expression>> &filters) const override;
+diff --git a/src/planning/iceberg_multi_file_list.cpp b/src/planning/iceberg_multi_file_list.cpp
+index f1c78937..d4cbed8f 100644
+--- a/src/planning/iceberg_multi_file_list.cpp
++++ b/src/planning/iceberg_multi_file_list.cpp
+@@ -411,9 +411,14 @@ unique_ptr<IcebergMultiFileList> IcebergMultiFileList::PushdownInternal(ClientCo
+ }
+ 
+ unique_ptr<MultiFileList>
+-IcebergMultiFileList::DynamicFilterPushdown(ClientContext &context, const MultiFileOptions &options,
+-                                            const vector<Identifier> &names, const vector<LogicalType> &types,
+-                                            const vector<column_t> &column_ids, TableFilterSet &filters) const {
++IcebergMultiFileList::DynamicFilterPushdown(MultiFileDynamicPushdownInfo &pushdown_info) const {
++	auto &options = pushdown_info.options;
++	auto &names = pushdown_info.column_names;
++	auto &types = pushdown_info.column_types;
++	auto &column_ids = pushdown_info.column_ids;
++	auto &context = pushdown_info.context;
++	auto &filters = pushdown_info.filters;
++
+ 	if (!filters.HasFilters()) {
+ 		return nullptr;
+ 	}

--- a/src/common/multi_file/multi_file_list.cpp
+++ b/src/common/multi_file/multi_file_list.cpp
@@ -23,8 +23,11 @@ MultiFilePushdownInfo::MultiFilePushdownInfo(LogicalGet &get)
 }
 
 MultiFilePushdownInfo::MultiFilePushdownInfo(TableIndex table_index, const vector<Identifier> &column_names,
-                                             const vector<column_t> &column_ids, ExtraOperatorInfo &extra_info)
-    : table_index(table_index), column_names(column_names), column_ids(column_ids), extra_info(extra_info) {
+                                             const vector<ColumnIndex> &column_indexes, ExtraOperatorInfo &extra_info)
+    : table_index(table_index), column_names(column_names), column_indexes(column_indexes), extra_info(extra_info) {
+	for (auto &col_id : column_indexes) {
+		column_ids.push_back(col_id.GetPrimaryIndex());
+	}
 }
 
 // Helper method to do Filter Pushdown into a MultiFileList
@@ -51,24 +54,25 @@ bool PushdownInternal(ClientContext &context, const MultiFileOptions &options, M
 }
 
 bool PushdownInternal(ClientContext &context, const MultiFileOptions &options, const vector<Identifier> &names,
-                      const vector<LogicalType> &types, const vector<column_t> &column_ids,
+                      const vector<LogicalType> &types, const vector<ColumnIndex> &column_indexes,
                       const TableFilterSet &filters, vector<OpenFileInfo> &expanded_files) {
 	TableIndex table_index(0);
 	ExtraOperatorInfo extra_info;
 
 	// construct the pushdown info
-	MultiFilePushdownInfo info(table_index, names, column_ids, extra_info);
+	MultiFilePushdownInfo info(table_index, names, column_indexes, extra_info);
 
 	// construct the set of expressions from the table filters
 	vector<unique_ptr<Expression>> filter_expressions;
 	for (auto &entry : filters) {
 		auto filter_idx = entry.GetIndex();
-		idx_t column_idx = column_ids[filter_idx];
-		if (IsVirtualColumn(column_idx)) {
+		auto &column_idx = column_indexes[filter_idx];
+		auto primary_index = column_idx.GetPrimaryIndex();
+		if (IsVirtualColumn(primary_index)) {
 			continue;
 		}
 		auto column_ref =
-		    make_uniq<BoundColumnRefExpression>(types[column_idx], ColumnBinding(table_index, entry.GetIndex()));
+		    make_uniq<BoundColumnRefExpression>(types[primary_index], ColumnBinding(table_index, entry.GetIndex()));
 		auto &expr_filter = ExpressionFilter::GetExpressionFilter(entry.Filter(), "MultiFilePushdownInfo::Pushdown");
 		auto filter_expr = expr_filter.ToExpression(*column_ref);
 		filter_expressions.push_back(std::move(filter_expr));
@@ -202,18 +206,22 @@ unique_ptr<MultiFileList> MultiFileList::ComplexFilterPushdown(ClientContext &co
 	return nullptr;
 }
 
-unique_ptr<MultiFileList> MultiFileList::DynamicFilterPushdown(ClientContext &context, const MultiFileOptions &options,
-                                                               const vector<Identifier> &names,
-                                                               const vector<LogicalType> &types,
-                                                               const vector<column_t> &column_ids,
-                                                               TableFilterSet &filters) const {
+unique_ptr<MultiFileList>
+MultiFileList::DynamicFilterPushdown(MultiFileDynamicPushdownInfo &dynamic_pushdown_info) const {
+	auto &options = dynamic_pushdown_info.options;
+	auto &names = dynamic_pushdown_info.column_names;
+	auto &types = dynamic_pushdown_info.column_types;
+	auto &column_indexes = dynamic_pushdown_info.column_indexes;
+	auto &context = dynamic_pushdown_info.context;
+	auto &filters = dynamic_pushdown_info.filters;
+
 	if (!options.hive_partitioning && !options.filename) {
 		return nullptr;
 	}
 
 	// FIXME: don't copy list until first file is filtered
 	auto file_copy = GetAllFiles();
-	auto res = PushdownInternal(context, options, names, types, column_ids, filters, file_copy);
+	auto res = PushdownInternal(context, options, names, types, column_indexes, filters, file_copy);
 	if (res) {
 		return make_uniq<SimpleMultiFileList>(std::move(file_copy));
 	}

--- a/src/common/multi_file/multi_file_reader.cpp
+++ b/src/common/multi_file/multi_file_reader.cpp
@@ -209,13 +209,21 @@ unique_ptr<MultiFileList> MultiFileReader::ComplexFilterPushdown(ClientContext &
 	return files.ComplexFilterPushdown(context, options, info, filters);
 }
 
-unique_ptr<MultiFileList> MultiFileReader::DynamicFilterPushdown(ClientContext &context, const MultiFileList &files,
-                                                                 const MultiFileOptions &options,
-                                                                 const vector<Identifier> &names,
-                                                                 const vector<LogicalType> &types,
-                                                                 const vector<column_t> &column_ids,
-                                                                 TableFilterSet &filters) {
-	return files.DynamicFilterPushdown(context, options, names, types, column_ids, filters);
+MultiFileDynamicPushdownInfo::MultiFileDynamicPushdownInfo(ClientContext &context, const MultiFileOptions &options,
+                                                           const vector<Identifier> &column_names,
+                                                           const vector<LogicalType> &column_types,
+                                                           const vector<ColumnIndex> &column_indexes,
+                                                           TableFilterSet &filters)
+    : context(context), options(options), column_names(column_names), column_types(column_types),
+      column_indexes(column_indexes), filters(filters) {
+	for (auto &column_id : column_indexes) {
+		column_ids.push_back(column_id.GetPrimaryIndex());
+	}
+}
+
+unique_ptr<MultiFileList> MultiFileReader::DynamicFilterPushdown(const MultiFileList &files,
+                                                                 MultiFileDynamicPushdownInfo &pushdown_info) {
+	return files.DynamicFilterPushdown(pushdown_info);
 }
 
 bool MultiFileReader::Bind(MultiFileOptions &options, MultiFileList &files, vector<LogicalType> &return_types,

--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -256,13 +256,14 @@ public:
 	}
 
 	static unique_ptr<MultiFileList> MultiFileFilterPushdown(ClientContext &context, const MultiFileBindData &data,
-	                                                         const vector<column_t> &column_ids,
+	                                                         const vector<ColumnIndex> &column_indexes,
 	                                                         optional_ptr<TableFilterSet> filters) {
 		if (!filters) {
 			return nullptr;
 		}
-		auto new_list = data.multi_file_reader->DynamicFilterPushdown(context, *data.file_list, data.file_options,
-		                                                              data.names, data.types, column_ids, *filters);
+		MultiFileDynamicPushdownInfo pushdown_info(context, data.file_options, data.names, data.types, column_indexes,
+		                                           *filters);
+		auto new_list = data.multi_file_reader->DynamicFilterPushdown(*data.file_list, pushdown_info);
 		return new_list;
 	}
 
@@ -587,7 +588,7 @@ public:
 		}
 
 		// before instantiating a scan trigger a dynamic filter pushdown if possible
-		auto new_list = MultiFileFilterPushdown(context, bind_data, input.column_ids, input.filters);
+		auto new_list = MultiFileFilterPushdown(context, bind_data, input.column_indexes, input.filters);
 		if (new_list) {
 			result = make_uniq<MultiFileGlobalState>(std::move(new_list));
 		} else {

--- a/src/include/duckdb/common/multi_file/multi_file_list.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_list.hpp
@@ -20,6 +20,7 @@ class MultiFileList;
 class NodeStatistics;
 class LogicalGet;
 class TableFilterSet;
+struct MultiFileDynamicPushdownInfo;
 
 enum class FileExpandResult : uint8_t { NO_FILES, SINGLE_FILE, MULTIPLE_FILES };
 enum class MultiFileListScanType { ALWAYS_FETCH, FETCH_IF_AVAILABLE };
@@ -74,7 +75,7 @@ public:
 struct MultiFilePushdownInfo {
 	explicit MultiFilePushdownInfo(LogicalGet &get);
 	MultiFilePushdownInfo(TableIndex table_index, const vector<Identifier> &column_names,
-	                      const vector<column_t> &column_ids, ExtraOperatorInfo &extra_info);
+	                      const vector<ColumnIndex> &column_indexes, ExtraOperatorInfo &extra_info);
 
 	TableIndex table_index;
 	const vector<Identifier> &column_names;
@@ -108,11 +109,7 @@ public:
 	virtual unique_ptr<MultiFileList> ComplexFilterPushdown(ClientContext &context, const MultiFileOptions &options,
 	                                                        MultiFilePushdownInfo &info,
 	                                                        vector<unique_ptr<Expression>> &filters) const;
-	virtual unique_ptr<MultiFileList> DynamicFilterPushdown(ClientContext &context, const MultiFileOptions &options,
-	                                                        const vector<Identifier> &names,
-	                                                        const vector<LogicalType> &types,
-	                                                        const vector<column_t> &column_ids,
-	                                                        TableFilterSet &filters) const;
+	virtual unique_ptr<MultiFileList> DynamicFilterPushdown(MultiFileDynamicPushdownInfo &dynamic_pushdown_info) const;
 
 	virtual vector<OpenFileInfo> GetAllFiles() const = 0;
 	virtual FileExpandResult GetExpandResult() const = 0;

--- a/src/include/duckdb/common/multi_file/multi_file_reader.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_reader.hpp
@@ -30,6 +30,19 @@ class DataChunk;
 
 enum class ReaderInitializeType { INITIALIZED, SKIP_READING_FILE };
 
+struct MultiFileDynamicPushdownInfo {
+	MultiFileDynamicPushdownInfo(ClientContext &context, const MultiFileOptions &options,
+	                             const vector<Identifier> &column_names, const vector<LogicalType> &column_types,
+	                             const vector<ColumnIndex> &column_indexes, TableFilterSet &filters);
+	ClientContext &context;
+	const MultiFileOptions &options;
+	const vector<Identifier> &column_names;
+	const vector<LogicalType> &column_types;
+	const vector<ColumnIndex> &column_indexes;
+	vector<column_t> column_ids;
+	TableFilterSet &filters;
+};
+
 struct MultiFileReaderVirtualColumnBinding {
 public:
 	enum class VirtualColumnBindingType : uint8_t { COLUMN_REFERENCE, EXPRESSION, CONSTANT };
@@ -123,10 +136,8 @@ public:
 	                                                                   const MultiFileOptions &options,
 	                                                                   MultiFilePushdownInfo &info,
 	                                                                   vector<unique_ptr<Expression>> &filters);
-	DUCKDB_API virtual unique_ptr<MultiFileList>
-	DynamicFilterPushdown(ClientContext &context, const MultiFileList &files, const MultiFileOptions &options,
-	                      const vector<Identifier> &names, const vector<LogicalType> &types,
-	                      const vector<column_t> &column_ids, TableFilterSet &filters);
+	DUCKDB_API virtual unique_ptr<MultiFileList> DynamicFilterPushdown(const MultiFileList &files,
+	                                                                   MultiFileDynamicPushdownInfo &pushdown_info);
 	//! Try to use the MultiFileReader for binding. Returns true if a bind could be made, returns false if the
 	//! MultiFileReader can not perform the bind and binding should be performed on 1 or more files in the MultiFileList
 	//! directly.


### PR DESCRIPTION
Add `MultiFileDynamicPushdownInfo` to make the method easier to extend in the future.
Added `column_indexes`, but kept `column_ids` for backwards compatibility.

Reason for the change is that IcebergMultiFileList expected a 1-to-1 mapping from column_id -> filter, which is violated when we pushdown variant extracts.

This makes it possible to upgrade that map from `column_t` to `ColumnIndex`, which restores the constraint again.