### PR TITLE
fix: incorrect join order of joins without ON clause

### DIFF
--- a/src/include/duckdb/parser/peg/inlined_grammar.gram
+++ b/src/include/duckdb/parser/peg/inlined_grammar.gram
@@ -1733,7 +1733,7 @@ JoinClause <- JoinByClause / RegularJoinClause / JoinWithoutOnClause
 RegularJoinClause <- Asof? JoinType? 'JOIN' TableRef JoinQualifier
 JoinByClause <- 'JOIN' 'BY' Parens('TYPE' ColLabel) TableRef JoinQualifier
 Asof <- 'ASOF'
-JoinWithoutOnClause <- JoinPrefix 'JOIN' TableRef
+JoinWithoutOnClause <- JoinPrefix 'JOIN' InnerTableRef
 JoinQualifier <- OnClause / UsingClause
 OnClause <- 'ON' Expression
 UsingClause <- 'USING' Parens(List(ColumnName))

--- a/src/include/duckdb/parser/peg/inlined_grammar.hpp
+++ b/src/include/duckdb/parser/peg/inlined_grammar.hpp
@@ -1578,7 +1578,7 @@ const char INLINED_PEG_GRAMMAR[] = {
 	"RegularJoinClause <- Asof? JoinType? 'JOIN' TableRef JoinQualifier\n"
 	"JoinByClause <- 'JOIN' 'BY' Parens('TYPE' ColLabel) TableRef JoinQualifier\n"
 	"Asof <- 'ASOF'\n"
-	"JoinWithoutOnClause <- JoinPrefix 'JOIN' TableRef\n"
+	"JoinWithoutOnClause <- JoinPrefix 'JOIN' InnerTableRef\n"
 	"JoinQualifier <- OnClause / UsingClause\n"
 	"OnClause <- 'ON' Expression\n"
 	"UsingClause <- 'USING' Parens(List(ColumnName))\n"

--- a/src/include/duckdb/parser/peg/transformer/peg_transformer.hpp
+++ b/src/include/duckdb/parser/peg/transformer/peg_transformer.hpp
@@ -7778,7 +7778,7 @@ public:
 	static unique_ptr<TransformResultValue> TransformJoinWithoutOnClauseInternal(PEGTransformer &transformer,
 	                                                                             ParseResult &parse_result);
 	static unique_ptr<TableRef> TransformJoinWithoutOnClause(PEGTransformer &transformer, const JoinPrefix &join_prefix,
-	                                                         unique_ptr<TableRef> table_ref);
+	                                                         unique_ptr<TableRef> inner_table_ref);
 	static unique_ptr<TransformResultValue> TransformJoinQualifierInternal(PEGTransformer &transformer,
 	                                                                       ParseResult &parse_result);
 	static unique_ptr<TransformResultValue> TransformOnClauseInternal(PEGTransformer &transformer,

--- a/src/parser/peg/grammar/statements/select.gram
+++ b/src/parser/peg/grammar/statements/select.gram
@@ -106,7 +106,7 @@ JoinClause <- JoinByClause / RegularJoinClause / JoinWithoutOnClause
 RegularJoinClause <- Asof? JoinType? 'JOIN' TableRef JoinQualifier
 JoinByClause <- 'JOIN' 'BY' Parens('TYPE' ColLabel) TableRef JoinQualifier
 Asof <- 'ASOF'
-JoinWithoutOnClause <- JoinPrefix 'JOIN' TableRef
+JoinWithoutOnClause <- JoinPrefix 'JOIN' InnerTableRef
 JoinQualifier <- OnClause / UsingClause
 OnClause <- 'ON' Expression
 UsingClause <- 'USING' Parens(List(ColumnName))

--- a/src/parser/peg/transformer/transform_generated.cpp
+++ b/src/parser/peg/transformer/transform_generated.cpp
@@ -9036,8 +9036,8 @@ unique_ptr<TransformResultValue>
 PEGTransformerFactory::TransformJoinWithoutOnClauseInternal(PEGTransformer &transformer, ParseResult &parse_result) {
 	auto &list_pr = parse_result.Cast<ListParseResult>();
 	auto join_prefix = transformer.Transform<JoinPrefix>(list_pr.GetChild(0));
-	auto table_ref = transformer.Transform<unique_ptr<TableRef>>(list_pr.GetChild(2));
-	auto result = TransformJoinWithoutOnClause(transformer, join_prefix, std::move(table_ref));
+	auto inner_table_ref = transformer.Transform<unique_ptr<TableRef>>(list_pr.GetChild(2));
+	auto result = TransformJoinWithoutOnClause(transformer, join_prefix, std::move(inner_table_ref));
 	return make_uniq<TypedTransformResult<unique_ptr<TableRef>>>(std::move(result));
 }
 

--- a/src/parser/peg/transformer/transform_generated_trampoline.cpp
+++ b/src/parser/peg/transformer/transform_generated_trampoline.cpp
@@ -21452,7 +21452,7 @@ void PEGTransformerFactory::InitializeJoinWithoutOnClauseTrampoline(PEGTransform
                                                                     TransformStackFrame &frame) {
 	auto &list_pr = frame.parse_result.Cast<ListParseResult>();
 	frame.ReserveChildSlots(2);
-	stack.PushFrame(list_pr.GetChild(2), TABLE_REF_OPS, TransformFrameResultTarget(frame.frame_index, 1));
+	stack.PushFrame(list_pr.GetChild(2), INNER_TABLE_REF_OPS, TransformFrameResultTarget(frame.frame_index, 1));
 	stack.PushFrame(list_pr.GetChild(0), JOIN_PREFIX_OPS, TransformFrameResultTarget(frame.frame_index, 0));
 }
 
@@ -21460,8 +21460,8 @@ unique_ptr<TransformResultValue>
 PEGTransformerFactory::FinalizeJoinWithoutOnClauseTrampoline(PEGTransformer &transformer, TransformStack &stack,
                                                              TransformStackFrame &frame) {
 	auto join_prefix = frame.TakeResult<JoinPrefix>(0);
-	auto table_ref = frame.TakeResult<unique_ptr<TableRef>>(1);
-	auto result = TransformJoinWithoutOnClause(transformer, join_prefix, std::move(table_ref));
+	auto inner_table_ref = frame.TakeResult<unique_ptr<TableRef>>(1);
+	auto result = TransformJoinWithoutOnClause(transformer, join_prefix, std::move(inner_table_ref));
 	return make_uniq<TypedTransformResult<unique_ptr<TableRef>>>(std::move(result));
 }
 

--- a/src/parser/peg/transformer/transform_select.cpp
+++ b/src/parser/peg/transformer/transform_select.cpp
@@ -425,51 +425,6 @@ QualifiedName PEGTransformerFactory::TransformSchemaReservedIdentifierOrStringLi
 	return result;
 }
 
-static bool IsConditionlessJoin(const JoinRef &join) {
-	if (join.condition || !join.using_columns.empty()) {
-		return false;
-	}
-	if (join.ref_type != JoinRefType::CROSS && join.ref_type != JoinRefType::POSITIONAL &&
-	    join.ref_type != JoinRefType::NATURAL) {
-		return false;
-	}
-	return true;
-}
-
-static unique_ptr<TableRef> ReassociateJoins(unique_ptr<TableRef> root) {
-	// Left-rotate while the current node is a conditionless join and its right child is a join.
-	// This converts right-associative join trees (from PEG grammar) to left-associative.
-	while (root->type == TableReferenceType::JOIN) {
-		auto &current = root->Cast<JoinRef>();
-		if (!IsConditionlessJoin(current) || !current.right || current.right->type != TableReferenceType::JOIN) {
-			break;
-		}
-		// Left rotation:
-		//   current(left=A, right=inner(left=B, right=C))
-		//   => inner(left=current(left=A, right=B), right=C)
-		auto inner = std::move(current.right);
-		auto &inner_join = inner->Cast<JoinRef>();
-		current.right = std::move(inner_join.left);
-		inner_join.left = std::move(root);
-		root = std::move(inner);
-	}
-	return root;
-}
-
-//! Check whether the RHS TableRef of a JoinOrPivot parse result has its own JoinOrPivot* entries.
-//! This distinguishes PEG right-recursion (has entries) from parenthesized joins (no entries).
-//! Navigation: JoinOrPivot → Choice → JoinClause → Choice → JoinWithoutOnClause → child(2)=TableRef → child(1)=Optional
-static bool RHSTableRefHasJoinOrPivot(ParseResult &join_or_pivot_pr) {
-	auto &jop_list = join_or_pivot_pr.Cast<ListParseResult>();
-	auto &jop_choice = jop_list.Child<ChoiceParseResult>(0);
-	auto &join_clause = jop_choice.GetResult().Cast<ListParseResult>();
-	auto &jc_choice = join_clause.Child<ChoiceParseResult>(0);
-	auto &join_impl = jc_choice.GetResult().Cast<ListParseResult>();
-	// For JoinWithoutOnClause the TableRef is at index 2
-	auto &table_ref = join_impl.Child<ListParseResult>(2);
-	return table_ref.Child<OptionalParseResult>(1).HasResult();
-}
-
 unique_ptr<TableRef> PEGTransformerFactory::TransformTableRef(PEGTransformer &transformer, ParseResult &parse_result) {
 	auto &list_pr = parse_result.Cast<ListParseResult>();
 	auto inner_table_ref = transformer.Transform<unique_ptr<TableRef>>(list_pr.Child<ListParseResult>(0));
@@ -483,11 +438,7 @@ unique_ptr<TableRef> PEGTransformerFactory::TransformTableRef(PEGTransformer &tr
 		if (transform_join_or_pivot->type == TableReferenceType::JOIN) {
 			auto &join_ref = transform_join_or_pivot->Cast<JoinRef>();
 			join_ref.left = std::move(inner_table_ref);
-			if (IsConditionlessJoin(join_ref) && RHSTableRefHasJoinOrPivot(join_or_pivot)) {
-				inner_table_ref = ReassociateJoins(std::move(transform_join_or_pivot));
-			} else {
-				inner_table_ref = std::move(transform_join_or_pivot);
-			}
+			inner_table_ref = std::move(transform_join_or_pivot);
 		} else if (transform_join_or_pivot->type == TableReferenceType::PIVOT) {
 			auto &pivot_ref = transform_join_or_pivot->Cast<PivotRef>();
 			pivot_ref.source = std::move(inner_table_ref);
@@ -537,11 +488,7 @@ unique_ptr<TransformResultValue> PEGTransformerFactory::FinalizeTableRefTrampoli
 		if (transform_join_or_pivot->type == TableReferenceType::JOIN) {
 			auto &join_ref = transform_join_or_pivot->Cast<JoinRef>();
 			join_ref.left = std::move(inner_table_ref);
-			if (IsConditionlessJoin(join_ref) && RHSTableRefHasJoinOrPivot(repeat_children[i].get())) {
-				inner_table_ref = ReassociateJoins(std::move(transform_join_or_pivot));
-			} else {
-				inner_table_ref = std::move(transform_join_or_pivot);
-			}
+			inner_table_ref = std::move(transform_join_or_pivot);
 		} else if (transform_join_or_pivot->type == TableReferenceType::PIVOT) {
 			auto &pivot_ref = transform_join_or_pivot->Cast<PivotRef>();
 			pivot_ref.source = std::move(inner_table_ref);
@@ -1611,11 +1558,11 @@ unique_ptr<AtClause> PEGTransformerFactory::TransformAtSpecifier(PEGTransformer 
 
 unique_ptr<TableRef> PEGTransformerFactory::TransformJoinWithoutOnClause(PEGTransformer &transformer,
                                                                          const JoinPrefix &join_prefix,
-                                                                         unique_ptr<TableRef> table_ref) {
+                                                                         unique_ptr<TableRef> inner_table_ref) {
 	auto result = make_uniq<JoinRef>();
 	result->ref_type = join_prefix.ref_type;
 	result->type = join_prefix.join_type;
-	result->right = std::move(table_ref);
+	result->right = std::move(inner_table_ref);
 	return std::move(result);
 }
 

--- a/test/sql/join/natural/natural_join.test
+++ b/test/sql/join/natural/natural_join.test
@@ -54,6 +54,36 @@ SELECT * FROM t1 NATURAL JOIN t2 NATURAL JOIN t3
 ----
 1	2	3
 
+# natural join chain followed by a qualified join
+statement ok
+CREATE TABLE issue24045_a(x INTEGER);
+
+statement ok
+CREATE TABLE issue24045_b(x INTEGER);
+
+statement ok
+CREATE TABLE issue24045_c(x INTEGER);
+
+statement ok
+CREATE TABLE issue24045_d(y INTEGER);
+
+statement ok
+INSERT INTO issue24045_a VALUES (1);
+
+statement ok
+INSERT INTO issue24045_c VALUES (1);
+
+statement ok
+INSERT INTO issue24045_d VALUES (9);
+
+query II
+SELECT issue24045_c.x, issue24045_d.y
+FROM issue24045_a NATURAL LEFT JOIN issue24045_b
+NATURAL JOIN issue24045_c
+RIGHT JOIN issue24045_d ON true
+----
+1	9
+
 # no matching columns
 statement error
 select * from (values (1)) tbl(a) natural join (values (1), (2)) tbl2(b) order by 1, 2


### PR DESCRIPTION
Fixes #24045

The problem was that the grammar rule for joins without ON clauses created a right-associated join chain. That was then partially undone by custom transformation logic, but in some cases this transformation did not work correctly.

The fix restricts joins without ON clauses to their immediate `InnerTableRef`. Any following joins remain in the chain to be parsed, creating the expected left-associated join chain.


