### PR TITLE
fix: join nullability in the delim join CTE rewriter

### DIFF
--- a/src/planner/subquery/delim_join_cte_rewriter.cpp
+++ b/src/planner/subquery/delim_join_cte_rewriter.cpp
@@ -635,13 +635,16 @@ static bool ExpressionIsNotNull(ClientContext &context, LogicalOperator &op, con
 		if (!GetBoundColumnRefBinding(expr, binding)) {
 			return false;
 		}
+		auto join_type = op.Cast<LogicalComparisonJoin>().join_type;
 		optional_ptr<LogicalOperator> binding_child;
-		for (auto &child : op.children) {
+		for (idx_t child_idx = 0; child_idx < op.children.size(); child_idx++) {
+			auto &child = op.children[child_idx];
 			auto child_bindings = child->GetColumnBindings();
 			if (std::find(child_bindings.begin(), child_bindings.end(), binding) == child_bindings.end()) {
 				continue;
 			}
-			if (binding_child) {
+			if (binding_child || (child_idx == 0 && IsRightOuterJoin(join_type)) ||
+			    (child_idx == 1 && (IsLeftOuterJoin(join_type) || join_type == JoinType::SINGLE))) {
 				return false;
 			}
 			binding_child = *child;

--- a/test/sql/subquery/exists/test_issue_23979.test
+++ b/test/sql/subquery/exists/test_issue_23979.test
@@ -1,0 +1,48 @@
+# name: test/sql/subquery/exists/test_issue_23979.test
+# description: Correlated EXISTS with a column null-extended by an outer join
+# group: [exists]
+
+statement ok
+CREATE TABLE issue23979_l(o INTEGER PRIMARY KEY);
+
+statement ok
+INSERT INTO issue23979_l VALUES (1), (2);
+
+statement ok
+CREATE TABLE issue23979_r(o INTEGER PRIMARY KEY, wh INTEGER NOT NULL);
+
+statement ok
+INSERT INTO issue23979_r VALUES (1, 1);
+
+statement ok
+CREATE TABLE issue23979_s2(o INTEGER, wh INTEGER);
+
+statement ok
+INSERT INTO issue23979_s2 VALUES (1, 2), (2, 3);
+
+statement ok
+SET delim_join_as_cte=true;
+
+query IITTT
+SELECT l.o,
+       r.wh,
+       r.wh <> s2.wh AS direct_comparison,
+       EXISTS (
+           SELECT 1
+           FROM issue23979_s2 x
+           WHERE x.o = l.o
+             AND r.wh <> x.wh
+       ) AS correlated_exists,
+       EXISTS (
+           SELECT 1
+           FROM issue23979_s2 x
+           WHERE x.o = l.o
+             AND (r.wh + 0) <> x.wh
+       ) AS equivalent_rewrite
+FROM issue23979_l l
+LEFT JOIN issue23979_r r USING (o)
+JOIN issue23979_s2 s2 USING (o)
+ORDER BY l.o;
+----
+1	1	1	1	1
+2	NULL	NULL	0	0


### PR DESCRIPTION
Fixes #23979 when `delim_join_as_cte=true`.

The nullability check didn't check if columns come from the right side of a LEFT join, or similar.

Therefore in the example some columns were marked as not nullable even though they could be null, that allowed the optimization to rewrite the expression to a form that didn't handle nulls correctly.

