### PR TITLE
[Bug Fix] Skip extension-owned tables during checkpoints

### DIFF
--- a/src/storage/checkpoint_manager.cpp
+++ b/src/storage/checkpoint_manager.cpp
@@ -134,7 +134,11 @@ static catalog_entry_vector_t GetCatalogEntries(vector<reference<SchemaCatalogEn
 				return;
 			}
 			if (entry.type == CatalogType::TABLE_ENTRY) {
-				tables.push_back(entry.Cast<TableCatalogEntry>());
+				auto &table = entry.Cast<TableCatalogEntry>();
+				if (!table.IsDuckTable()) {
+					return;
+				}
+				tables.push_back(table);
 			} else if (entry.type == CatalogType::VIEW_ENTRY) {
 				views.push_back(entry.Cast<ViewCatalogEntry>());
 			} else {

--- a/src/storage/table/in_memory_checkpoint.cpp
+++ b/src/storage/table/in_memory_checkpoint.cpp
@@ -32,7 +32,10 @@ void InMemoryCheckpointer::CreateCheckpoint() {
 		auto &schema = schema_ref.get();
 		schema.Scan(CatalogType::TABLE_ENTRY, [&](CatalogEntry &entry) {
 			if (entry.type == CatalogType::TABLE_ENTRY) {
-				tables.push_back(entry.Cast<TableCatalogEntry>());
+				auto &table = entry.Cast<TableCatalogEntry>();
+				if (table.IsDuckTable()) {
+					tables.push_back(table);
+				}
 			}
 		});
 	}

--- a/test/api/test_storage_extension_alias.cpp
+++ b/test/api/test_storage_extension_alias.cpp
@@ -4,6 +4,13 @@
 #include "duckdb/storage/storage_extension.hpp"
 #include "duckdb/transaction/duck_transaction_manager.hpp"
 #include "duckdb/catalog/duck_catalog.hpp"
+#include "duckdb/catalog/catalog_entry/duck_schema_entry.hpp"
+#include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
+#include "duckdb/function/table_function.hpp"
+#include "duckdb/main/attached_database.hpp"
+#include "duckdb/parser/parsed_data/create_schema_info.hpp"
+#include "duckdb/planner/parsed_data/bound_create_table_info.hpp"
+#include "duckdb/storage/table_storage_info.hpp"
 
 using namespace duckdb;
 
@@ -14,6 +21,71 @@ struct DummyStorageExtension : StorageExtension {
 		attach = [](optional_ptr<StorageExtensionInfo>, ClientContext &, AttachedDatabase &db, const string &,
 		            AttachInfo &info, AttachOptions &) -> unique_ptr<Catalog> {
 			return make_uniq_base<Catalog, DuckCatalog>(db);
+		};
+		create_transaction_manager = [](optional_ptr<StorageExtensionInfo>, AttachedDatabase &db,
+		                                Catalog &) -> unique_ptr<TransactionManager> {
+			return make_uniq<DuckTransactionManager>(db);
+		};
+	}
+};
+
+class DummyExternalTableEntry : public TableCatalogEntry {
+public:
+	DummyExternalTableEntry(Catalog &catalog, SchemaCatalogEntry &schema, CreateTableInfo &info)
+	    : TableCatalogEntry(catalog, schema, info) {
+	}
+
+	unique_ptr<BaseStatistics> GetStatistics(ClientContext &, column_t) override {
+		return nullptr;
+	}
+
+	TableFunction GetScanFunction(ClientContext &, unique_ptr<FunctionData> &) override {
+		throw NotImplementedException("Dummy external tables cannot be scanned");
+	}
+
+	TableStorageInfo GetStorageInfo(ClientContext &) override {
+		return {};
+	}
+};
+
+class DummyExternalSchemaEntry : public DuckSchemaEntry {
+public:
+	DummyExternalSchemaEntry(Catalog &catalog, CreateSchemaInfo &info) : DuckSchemaEntry(catalog, info) {
+	}
+
+	optional_ptr<CatalogEntry> CreateTable(CatalogTransaction transaction, BoundCreateTableInfo &info) override {
+		auto table = make_uniq<DummyExternalTableEntry>(catalog, *this, info.Base());
+		return AddEntry(transaction, std::move(table), info.Base().on_conflict);
+	}
+};
+
+class DummyExternalCatalog : public DuckCatalog {
+public:
+	explicit DummyExternalCatalog(AttachedDatabase &db) : DuckCatalog(db) {
+	}
+
+	void ReplaceDefaultSchema(CatalogTransaction transaction) {
+		auto &schemas = GetSchemaCatalogSet();
+		(void)schemas.DropEntry(transaction, DEFAULT_SCHEMA, true, true);
+
+		CreateSchemaInfo info;
+		info.SetQualifiedName(QualifiedName({Identifier::DefaultSchema()}, Identifier()));
+		info.internal = true;
+
+		LogicalDependencyList dependencies;
+		auto schema = make_uniq<DummyExternalSchemaEntry>(*this, info);
+		REQUIRE(schemas.CreateEntry(transaction, DEFAULT_SCHEMA, std::move(schema), dependencies));
+	}
+};
+
+struct DummyExternalStorageExtension : StorageExtension {
+	DummyExternalStorageExtension() {
+		attach = [](optional_ptr<StorageExtensionInfo>, ClientContext &, AttachedDatabase &db, const string &,
+		            AttachInfo &, AttachOptions &) -> unique_ptr<Catalog> {
+			auto catalog = make_uniq<DummyExternalCatalog>(db);
+			catalog->Initialize(false);
+			catalog->ReplaceDefaultSchema(CatalogTransaction::GetSystemTransaction(db.GetDatabase()));
+			return std::move(catalog);
 		};
 		create_transaction_manager = [](optional_ptr<StorageExtensionInfo>, AttachedDatabase &db,
 		                                Catalog &) -> unique_ptr<TransactionManager> {
@@ -63,4 +135,16 @@ TEST_CASE("Test storage extension lookup alias", "[api]") {
 		     "Query: " +
 		     query + "\n" + "Error: " + result->GetError());
 	}
+}
+
+TEST_CASE("Checkpoint skips extension-owned table entries", "[api]") {
+	DBConfig config;
+	StorageExtension::Register(config, "dummy_external", make_shared_ptr<DummyExternalStorageExtension>());
+
+	DuckDB db(nullptr, &config);
+	Connection con(db);
+
+	REQUIRE_NO_FAIL(con.Query("ATTACH ':memory:' AS external_db (TYPE dummy_external)"));
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE external_db.tbl(i INTEGER)"));
+	REQUIRE_NO_FAIL(con.Query("FORCE CHECKPOINT external_db"));
 }


### PR DESCRIPTION
Fixes #24233.

## Summary

Skip extension-owned `TableCatalogEntry` implementations when DuckDB writes single-file or in-memory checkpoints.

## Problem

Storage extensions can reuse `DuckCatalog` and `DuckSchemaEntry` while providing their own `TableCatalogEntry` subclass. Such entries have `CatalogType::TABLE_ENTRY`, but `IsDuckTable()` returns false and they do not own DuckDB `DataTable` storage.

The checkpoint table collection currently selects every `TABLE_ENTRY`. It later constructs `TableDataWriter`, which casts the entry to `DuckTableEntry` before asserting `table_p.IsDuckTable()`. A forced or automatic checkpoint therefore invalidates the attached database:

```text
Checkpoint failed for database "...".
Assertion triggered in table_data_writer.cpp: table_p.IsDuckTable()
```

This was observed with the Lance storage extension after catalog-changing DDL, including `CREATE OR REPLACE TABLE`, when an automatic checkpoint ran. It is separate from #24093: that PR guards the transaction commit storage comparison, while this failure occurs in checkpoint table-data serialization.

## Fix

- Filter non-Duck table entries out of the single-file checkpoint catalog list.
- Apply the same guard when in-memory checkpoints collect tables.
- Keep schemas and other supported catalog objects unchanged.

Extension-owned table metadata and data remain the extension's responsibility. Native `DuckTableEntry` checkpoint behavior is unchanged.

## Test

Add a minimal storage extension in the API tests that:

1. attaches a `DuckCatalog`-derived catalog;
2. installs a `DuckSchemaEntry`-derived schema;
3. creates a non-Duck `TableCatalogEntry`; and
4. runs `FORCE CHECKPOINT` on the attached database.

Without the fix, the test fails at `TableDataWriter` with the `table_p.IsDuckTable()` assertion. With the fix, it passes.

Validated with:

```text
make debug
build/debug/test/unittest "Checkpoint skips extension-owned table entries"
build/debug/test/unittest "Test storage extension lookup*"
scripts/format.py --check HEAD
```
