### PR TITLE
Make `AtClause::Unit()` return an `Identifier`

### DIFF
--- a/.github/config/extensions/unity_catalog.cmake
+++ b/.github/config/extensions/unity_catalog.cmake
@@ -3,5 +3,6 @@ if(NOT MINGW AND NOT ${WASM_ENABLED} AND NOT ${MUSL_ENABLED})
             GIT_URL https://github.com/duckdb/unity_catalog
             GIT_TAG b593157d114ce57c044eb8adc48ab164f2e10c11
             LOAD_TESTS
+            APPLY_PATCHES
   )
 endif()

--- a/.github/patches/extensions/delta/0001-at-clause-unit-identifier.patch
+++ b/.github/patches/extensions/delta/0001-at-clause-unit-identifier.patch
@@ -1,0 +1,13 @@
+diff --git a/src/storage/delta_catalog.cpp b/src/storage/delta_catalog.cpp
+index ace86df..a3413f5 100644
+--- a/src/storage/delta_catalog.cpp
++++ b/src/storage/delta_catalog.cpp
+@@ -12,7 +12,7 @@
+ namespace duckdb {
+ 
+ idx_t ParseDeltaVersionFromAtClause(const BoundAtClause &at_clause) {
+-	if (StringUtil::Lower(at_clause.Unit()) != "version") {
++	if (at_clause.Unit() != "version") {
+ 		throw InvalidConfigurationException("Delta tables only support at_clause with unit 'version'");
+ 	}
+ 	Value version_value = at_clause.GetValue();

--- a/.github/patches/extensions/ducklake/0001-at-clause-unit-identifier.patch
+++ b/.github/patches/extensions/ducklake/0001-at-clause-unit-identifier.patch
@@ -1,0 +1,36 @@
+diff --git a/src/storage/ducklake_metadata_manager.cpp b/src/storage/ducklake_metadata_manager.cpp
+index ca8e9bb..de8bdd6 100644
+--- a/src/storage/ducklake_metadata_manager.cpp
++++ b/src/storage/ducklake_metadata_manager.cpp
+@@ -4355,13 +4355,13 @@ unique_ptr<DuckLakeSnapshot> DuckLakeMetadataManager::GetSnapshot(BoundAtClause
+ 	unique_ptr<QueryResult> result;
+ 	const string timestamp_order = bound == SnapshotBound::LOWER_BOUND ? "ASC" : "DESC";
+ 	const string timestamp_condition = bound == SnapshotBound::LOWER_BOUND ? ">" : "<";
+-	if (StringUtil::CIEquals(unit, "version")) {
++	if (unit == "version") {
+ 		result = Query(StringUtil::Format(R"(
+ SELECT snapshot_id, schema_version, next_catalog_id, next_file_id
+ FROM {METADATA_CATALOG}.ducklake_snapshot
+ WHERE snapshot_id = %llu;)",
+ 		                                  val.DefaultCastAs(LogicalType::UBIGINT).GetValue<idx_t>()));
+-	} else if (StringUtil::CIEquals(unit, "timestamp")) {
++	} else if (unit == "timestamp") {
+ 		result = Query(StringUtil::Format(
+ 		    R"(
+ SELECT snapshot_id, schema_version, next_catalog_id, next_file_id
+@@ -4378,11 +4378,13 @@ WHERE snapshot_id = (
+ 	}
+ 	if (result->HasError()) {
+ 		result->GetErrorObject().Throw(StringUtil::Format(
+-		    "Failed to query snapshot at %s %s for DuckLake: ", StringUtil::Lower(unit), val.ToString()));
++		    "Failed to query snapshot at %s %s for DuckLake: ", StringUtil::Lower(unit.GetIdentifierName()),
++		    val.ToString()));
+ 	}
+ 	auto snapshot = ParseSnapshot(*result);
+ 	if (!snapshot) {
+-		throw InvalidInputException("No snapshot found at %s %s", StringUtil::Lower(unit), val.ToString());
++		throw InvalidInputException("No snapshot found at %s %s", StringUtil::Lower(unit.GetIdentifierName()),
++		                            val.ToString());
+ 	}
+ 	return snapshot;
+ }

--- a/.github/patches/extensions/iceberg/0003-at-clause-unit-identifier.patch
+++ b/.github/patches/extensions/iceberg/0003-at-clause-unit-identifier.patch
@@ -1,0 +1,22 @@
+diff --git a/src/planning/snapshot/iceberg_snapshot_lookup.cpp b/src/planning/snapshot/iceberg_snapshot_lookup.cpp
+index 8b7dd413..49852872 100644
+--- a/src/planning/snapshot/iceberg_snapshot_lookup.cpp
++++ b/src/planning/snapshot/iceberg_snapshot_lookup.cpp
+@@ -13,13 +13,14 @@ IcebergSnapshotLookup IcebergSnapshotLookup::FromAtClause(optional_ptr<BoundAtCl
+ 	if (value.IsNull()) {
+ 		throw InvalidInputException("NULL values can not be used as the 'unit' of a time travel clause");
+ 	}
+-	if (StringUtil::CIEquals(unit, "version")) {
++	if (unit == "version") {
+ 		return FromSnapshotId(value.DefaultCastAs(LogicalType::BIGINT).GetValue<int64_t>());
+-	} else if (StringUtil::CIEquals(unit, "timestamp")) {
++	} else if (unit == "timestamp") {
+ 		return FromTimestamp(value.DefaultCastAs(LogicalType::TIMESTAMP_MS).GetValue<timestamp_ms_t>());
+ 	} else {
+ 		throw InvalidInputException(
+-		    "Unit '%s' for time travel is not valid, supported options are 'version' and 'timestamp'", unit);
++		    "Unit '%s' for time travel is not valid, supported options are 'version' and 'timestamp'",
++		    unit.GetIdentifierName());
+ 	}
+ }
+ 

--- a/.github/patches/extensions/unity_catalog/0001-at-clause-unit-identifier.patch
+++ b/.github/patches/extensions/unity_catalog/0001-at-clause-unit-identifier.patch
@@ -1,0 +1,13 @@
+diff --git a/src/storage/uc_table_set.cpp b/src/storage/uc_table_set.cpp
+index 886ed7f..ccd4229 100644
+--- a/src/storage/uc_table_set.cpp
++++ b/src/storage/uc_table_set.cpp
+@@ -24,7 +24,7 @@
+ namespace duckdb {
+ 
+ static idx_t ParseDeltaVersionFromAtClause(const BoundAtClause &at_clause) {
+-	if (StringUtil::Lower(at_clause.Unit()) != "version") {
++	if (at_clause.Unit() != "version") {
+ 		throw InvalidConfigurationException("Delta tables only support at_clause with unit 'version'");
+ 	}
+ 	Value version_value = at_clause.GetValue();

--- a/src/common/exception/catalog_exception.cpp
+++ b/src/common/exception/catalog_exception.cpp
@@ -26,7 +26,8 @@ CatalogException CatalogException::MissingEntry(const EntryLookupInfo &lookup_in
 	}
 	string version_info;
 	if (at_clause) {
-		version_info += " at " + StringUtil::Lower(at_clause->Unit()) + " " + at_clause->GetValue().ToString();
+		version_info +=
+		    " at " + StringUtil::Lower(at_clause->Unit().GetIdentifierName()) + " " + at_clause->GetValue().ToString();
 	}
 
 	auto extra_info = Exception::InitializeExtraInfo("MISSING_ENTRY", context.query_location);

--- a/src/include/duckdb/parser/tableref/at_clause.hpp
+++ b/src/include/duckdb/parser/tableref/at_clause.hpp
@@ -15,10 +15,10 @@ namespace duckdb {
 //! The AT clause specifies which version of a table to read
 class AtClause {
 public:
-	AtClause(string unit, unique_ptr<ParsedExpression> expr);
+	AtClause(Identifier unit, unique_ptr<ParsedExpression> expr);
 
 public:
-	const string &Unit() {
+	const Identifier &Unit() {
 		return unit;
 	}
 	unique_ptr<ParsedExpression> &ExpressionMutable() {
@@ -35,7 +35,7 @@ public:
 
 private:
 	//! The unit (e.g. TIMESTAMP or VERSION)
-	string unit;
+	Identifier unit;
 	//! The expression that determines which value of the unit we want to read
 	unique_ptr<ParsedExpression> expr;
 };

--- a/src/include/duckdb/planner/tableref/bound_at_clause.hpp
+++ b/src/include/duckdb/planner/tableref/bound_at_clause.hpp
@@ -15,11 +15,11 @@ namespace duckdb {
 //! The AT clause specifies which version of a table to read
 class BoundAtClause {
 public:
-	BoundAtClause(string unit_p, Value value_p) : unit(std::move(unit_p)), val(std::move(value_p)) {
+	BoundAtClause(Identifier unit_p, Value value_p) : unit(std::move(unit_p)), val(std::move(value_p)) {
 	}
 
 public:
-	const string &Unit() const {
+	const Identifier &Unit() const {
 		return unit;
 	}
 	const Value &GetValue() const {
@@ -28,7 +28,7 @@ public:
 
 private:
 	//! The unit (e.g. TIMESTAMP or VERSION)
-	string unit;
+	Identifier unit;
 	//! The value that is associated with the unit (e.g. TIMESTAMP '2020-01-01')
 	Value val;
 };

--- a/src/include/duckdb/storage/serialization/tableref.json
+++ b/src/include/duckdb/storage/serialization/tableref.json
@@ -346,7 +346,7 @@
       {
         "id": 1,
         "name": "unit",
-        "type": "string"
+        "type": "Identifier"
       },
       {
         "id": 2,

--- a/src/parser/peg/transformer/transform_select.cpp
+++ b/src/parser/peg/transformer/transform_select.cpp
@@ -1734,7 +1734,7 @@ unique_ptr<AtClause> PEGTransformerFactory::TransformAtClause(PEGTransformer &tr
 
 unique_ptr<AtClause> PEGTransformerFactory::TransformAtSpecifier(PEGTransformer &transformer, const string &at_unit,
                                                                  unique_ptr<ParsedExpression> expression) {
-	return make_uniq<AtClause>(at_unit, std::move(expression));
+	return make_uniq<AtClause>(Identifier(at_unit), std::move(expression));
 }
 
 unique_ptr<TableRef> PEGTransformerFactory::TransformJoinWithoutOnClause(PEGTransformer &transformer,

--- a/src/parser/tableref/at_clause.cpp
+++ b/src/parser/tableref/at_clause.cpp
@@ -2,7 +2,7 @@
 
 namespace duckdb {
 
-AtClause::AtClause(string unit_p, unique_ptr<ParsedExpression> expr_p)
+AtClause::AtClause(Identifier unit_p, unique_ptr<ParsedExpression> expr_p)
     : unit(std::move(unit_p)), expr(std::move(expr_p)) {
 }
 

--- a/src/storage/serialization/serialize_tableref.cpp
+++ b/src/storage/serialization/serialize_tableref.cpp
@@ -66,12 +66,12 @@ unique_ptr<TableRef> TableRef::Deserialize(Deserializer &deserializer) {
 }
 
 void AtClause::Serialize(Serializer &serializer) const {
-	serializer.WritePropertyWithDefault<string>(1, "unit", unit);
+	serializer.WritePropertyWithDefault<Identifier>(1, "unit", unit);
 	serializer.WritePropertyWithDefault<unique_ptr<ParsedExpression>>(2, "expr", expr);
 }
 
 unique_ptr<AtClause> AtClause::Deserialize(Deserializer &deserializer) {
-	auto unit = deserializer.ReadPropertyWithDefault<string>(1, "unit");
+	auto unit = deserializer.ReadPropertyWithDefault<Identifier>(1, "unit");
 	auto expr = deserializer.ReadPropertyWithDefault<unique_ptr<ParsedExpression>>(2, "expr");
 	auto result = duckdb::unique_ptr<AtClause>(new AtClause(std::move(unit), std::move(expr)));
 	return result;


### PR DESCRIPTION
The AT clause unit (`VERSION`/`TIMESTAMP`) is case-insensitive, so every
consumer had to spell that out by hand. `Identifier` encodes exactly that
invariant, so consumers can now compare with `==` instead:

https://github.com/duckdb/ducklake/blob/d318a545571d7d46eb751fa2aa5f6f4389285d3c/src/storage/ducklake_metadata_manager.cpp#L4109

`Identifier` serializes as its raw string, so the serialization format is
unchanged.
