### PR TITLE
Add `Value::GetValue<Identifier>()`

### DIFF
--- a/src/common/types/value.cpp
+++ b/src/common/types/value.cpp
@@ -1423,6 +1423,11 @@ DUCKDB_API Value Value::GetValue() const {
 	return Value(*this);
 }
 
+template <>
+DUCKDB_API Identifier Value::GetValue() const {
+	return Identifier(GetValue<string>());
+}
+
 uintptr_t Value::GetPointer() const {
 	D_ASSERT(type() == LogicalType::POINTER);
 	return value_.pointer;

--- a/src/include/duckdb/common/types/value.hpp
+++ b/src/include/duckdb/common/types/value.hpp
@@ -609,6 +609,10 @@ template <>
 DUCKDB_API interval_t Value::GetValue() const;
 template <>
 DUCKDB_API Value Value::GetValue() const;
+// Not a logical type like the specializations above, but a semantic wrapper around the string value. It mirrors the
+// implicit Value(const Identifier &) constructor, so identifiers can round-trip through a Value.
+template <>
+DUCKDB_API Identifier Value::GetValue() const;
 
 template <>
 DUCKDB_API bool Value::GetValueUnsafe() const;

--- a/src/parser/peg/transformer/transform_copy.cpp
+++ b/src/parser/peg/transformer/transform_copy.cpp
@@ -29,7 +29,7 @@ void SetCopyOptions(unique_ptr<CopyInfo> &info, vector<GenericCopyOption> &optio
 				}
 				vector<unique_ptr<ParsedExpression>> func_children;
 				for (const auto &partition : option.children) {
-					func_children.push_back(make_uniq<ColumnRefExpression>(Identifier(partition.GetValue<string>())));
+					func_children.push_back(make_uniq<ColumnRefExpression>(partition.GetValue<Identifier>()));
 				}
 				auto row_func = make_uniq<FunctionExpression>("row", std::move(func_children));
 				info->parsed_options[option.name.GetIdentifierName()] = std::move(row_func);


### PR DESCRIPTION
`Value` already had an implicit constructor from `Identifier`, but no way back out, so every identifier that round-tripped through a `Value` (for instance via `named_parameters`) had to be unwrapped as `Identifier(value.GetValue<string>())` at the far end. This adds the missing specialization so the round trip is symmetric, and uses it in the `COPY ... PARTITION_BY` transformer.

Note this is ergonomics rather than safety: the stored `Value` is a plain `VARCHAR` that does not record whether it ever held an identifier, so `GetValue<Identifier>()` is a caller assertion just like the explicit constructor was.
