### PR TITLE
Don't push filters on volatile groups through aggregates

### DIFF
--- a/src/optimizer/pushdown/pushdown_aggregate.cpp
+++ b/src/optimizer/pushdown/pushdown_aggregate.cpp
@@ -9,6 +9,19 @@ namespace duckdb {
 
 using Filter = FilterPushdown::Filter;
 
+static bool IsVolatile(LogicalAggregate &proj, const Expression &expr) {
+	bool is_volatile = false;
+	ExpressionIterator::VisitExpression<BoundColumnRefExpression>(expr, [&](const BoundColumnRefExpression &colref) {
+		D_ASSERT(colref.binding.table_index == proj.group_index);
+		D_ASSERT(colref.binding.column_index < proj.groups.size());
+		D_ASSERT(colref.depth == 0);
+		if (proj.groups[colref.binding.column_index]->IsVolatile()) {
+			is_volatile = true;
+		}
+	});
+	return is_volatile;
+}
+
 static unique_ptr<Expression> ReplaceGroupBindings(LogicalAggregate &proj, unique_ptr<Expression> root_expr) {
 	ExpressionIterator::VisitExpressionMutable<BoundColumnRefExpression>(
 	    root_expr, [&](BoundColumnRefExpression &colref, unique_ptr<Expression> &expr) {
@@ -71,6 +84,9 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownAggregate(unique_ptr<Logical
 			}
 		}
 		if (!can_pushdown_filter) {
+			continue;
+		}
+		if (IsVolatile(aggr, *f.filter)) {
 			continue;
 		}
 		// no aggregate! we can push this down

--- a/test/optimizer/pushdown/filter_cannot_pushdown.test
+++ b/test/optimizer/pushdown/filter_cannot_pushdown.test
@@ -81,13 +81,11 @@ explain select nextval('s1') as g, count(*) as c from range(3) group by 1 having
 ----
 logical_opt	<REGEX>:.*g > 1.*
 
+statement ok
+create table volatile_group as select nextval('s1') as g, count(*) as c from range(3) group by 1 having g > 1;
+
 query II
-select nextval('s1') as g, count(*) as c from range(3) group by 1 having g > 1 order by g;
+select * from volatile_group order by g;
 ----
 2	1
 3	1
-
-query I
-select currval('s1');
-----
-3

--- a/test/optimizer/pushdown/filter_cannot_pushdown.test
+++ b/test/optimizer/pushdown/filter_cannot_pushdown.test
@@ -72,3 +72,22 @@ GROUP BY result;
 False
 
 endloop
+
+statement ok
+create sequence s1 start 1;
+
+query II
+explain select nextval('s1') as g, count(*) as c from range(3) group by 1 having g > 1;
+----
+logical_opt	<REGEX>:.*g > 1.*
+
+query II
+select nextval('s1') as g, count(*) as c from range(3) group by 1 having g > 1 order by g;
+----
+2	1
+3	1
+
+query I
+select currval('s1');
+----
+3


### PR DESCRIPTION
Fixes: https://github.com/duckdb/duckdb/issues/24207

Filters on volatile group expressions like `nextval()` were pushed below the aggregate, causing the expression to be re-evaluated and producing wrong results. We now skip pushdown for those.