### PR TITLE
Fix LIMIT pushdown through a volatile projection with an OFFSET

### DIFF
--- a/src/optimizer/limit_pushdown.cpp
+++ b/src/optimizer/limit_pushdown.cpp
@@ -20,6 +20,16 @@ bool LimitPushdown::CanOptimize(duckdb::LogicalOperator &op) {
 			// Push down only when limit value is smaller than 8192.
 			// when physical_limit is introduced, it will end a parallel pipeline
 			// restrict the limit value to be small so that remaining operations run fast without parallelization.
+			if (limit.offset_val.Type() == LimitNodeType::CONSTANT_VALUE && limit.offset_val.GetConstantValue() > 0) {
+				// If we push the limit below the projection, the offset rows are discarded before the
+				// projection runs, so a volatile expression produces different values for the rows we keep.
+				auto &projection = op.children[0]->Cast<LogicalProjection>();
+				for (auto &expr : projection.expressions) {
+					if (expr->IsVolatile()) {
+						return false;
+					}
+				}
+			}
 			return true;
 		}
 	}

--- a/test/optimizer/limit_pushdown.test
+++ b/test/optimizer/limit_pushdown.test
@@ -72,7 +72,10 @@ EXPLAIN SELECT nextval('s') AS v FROM integers LIMIT 1 OFFSET 1
 ----
 logical_opt	<REGEX>:.*LIMIT.*PROJECTION.*
 
+statement ok
+CREATE TABLE offset_result AS SELECT nextval('s') AS v FROM integers LIMIT 1 OFFSET 1
+
 query I
-SELECT nextval('s') AS v FROM integers LIMIT 1 OFFSET 1
+SELECT v FROM offset_result
 ----
 2

--- a/test/optimizer/limit_pushdown.test
+++ b/test/optimizer/limit_pushdown.test
@@ -63,3 +63,16 @@ query II
 EXPLAIN SELECT i FROM integers LIMIT 8192
 ----
 logical_opt	<REGEX>:.*LIMIT.*PROJECTION.*
+
+statement ok
+CREATE SEQUENCE s START 1
+
+query II
+EXPLAIN SELECT nextval('s') AS v FROM integers LIMIT 1 OFFSET 1
+----
+logical_opt	<REGEX>:.*LIMIT.*PROJECTION.*
+
+query I
+SELECT nextval('s') AS v FROM integers LIMIT 1 OFFSET 1
+----
+2


### PR DESCRIPTION
Fixes: https://github.com/duckdb/duckdb/issues/24206


`LimitPushdown` moves a constant `LIMIT` below its child `PROJECTION`. When the limit has an offset, this discards the offset rows before the projection runs, so a volatile expression produces different values for the rows we keep. 