### PR TITLE
Re-enable clangd-tidy check in CI

### DIFF
--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -404,9 +404,14 @@ jobs:
     - name: Install clangd-tidy
       run: python3 scripts/ci/retry.py -- make install-clangd-tidy
 
-    - name: Tidy Check Diff
-      if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
-      run: DUCKDB_GIT_BASE_BRANCH=${{ github.base_ref }} make tidy-check-diff
+    - name: Tidy Check (clangd)
+      run: |
+        mkdir -p ~/.config/clangd
+        cat > ~/.config/clangd/config.yaml <<'EOF'
+        Diagnostics:
+          UnusedIncludes: None
+        EOF
+        make tidy-check-clangd 'CLANGD_TIDY_QUERY_DRIVER=/usr/bin/**/g++*,/usr/bin/**/gcc*'
 
     - name: Upload clangd-tidy logs
       if: ${{ failure() }}

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ ifndef CMAKE_BUILD_PARALLEL_LEVEL
 CMAKE_BUILD_PARALLEL_LEVEL := $(CI_BUILD_JOBS)
 endif
 export CMAKE_BUILD_PARALLEL_LEVEL
-export CI_TIDY_JOBS := $(shell jobs=$$(( $(CI_CPU_COUNT) * 25 / 100 )); [ $$jobs -lt 1 ] && jobs=1; echo $$jobs)
+export CI_TIDY_JOBS := $(shell jobs=$$(( $(CI_CPU_COUNT) * 50 / 100 )); [ $$jobs -lt 1 ] && jobs=1; echo $$jobs)
 
 # Assume Ninja is the default generator (if missing), but verify ninja exists.
 # Cache Ninja detection so we only probe `ninja --version` once.

--- a/scripts/run-clangd-tidy.py
+++ b/scripts/run-clangd-tidy.py
@@ -12,8 +12,7 @@ import sys
 import time
 
 
-MAX_CHUNK_CHARS = 100000
-MAX_CHUNK_FILES = 200
+TARGET_CHUNK_COUNT = 10
 MAX_FAILED_CHUNKS = 2
 MAX_RETRIES = 2
 RETRY_BACKOFF_MS = 500
@@ -43,19 +42,18 @@ def is_ignored_file(path, repo_root):
     return relative == 'third_party' or relative.startswith('third_party' + os.sep)
 
 
-def chunk_files(files, max_chars=MAX_CHUNK_CHARS, max_files=MAX_CHUNK_FILES):
-    chunk = []
-    current_chars = 0
-    for path in files:
-        path_len = len(path) + 1
-        if chunk and (len(chunk) >= max_files or current_chars + path_len > max_chars):
-            yield chunk
-            chunk = []
-            current_chars = 0
-        chunk.append(path)
-        current_chars += path_len
-    if chunk:
-        yield chunk
+def chunk_files(files, target_chunk_count=TARGET_CHUNK_COUNT):
+    if not files:
+        return
+    chunk_count = min(target_chunk_count, len(files))
+    chunk_size, remainder = divmod(len(files), chunk_count)
+    start = 0
+    for chunk_index in range(chunk_count):
+        end = start + chunk_size
+        if chunk_index < remainder:
+            end += 1
+        yield files[start:end]
+        start = end
 
 
 def load_files(build_path):

--- a/scripts/run-clangd-tidy.py
+++ b/scripts/run-clangd-tidy.py
@@ -14,6 +14,7 @@ import time
 
 MAX_CHUNK_CHARS = 100000
 MAX_CHUNK_FILES = 100
+MAX_FAILED_CHUNKS = 4
 MAX_RETRIES = 2
 RETRY_BACKOFF_MS = 500
 ERROR_TAIL_LINES = 120
@@ -143,15 +144,11 @@ def print_output_tail(label, text):
 def write_attempt_logs(log_dir, attempt_id, chunk, result):
     stdout_path = os.path.join(log_dir, f'attempt-{attempt_id}.stdout.log')
     stderr_path = os.path.join(log_dir, f'attempt-{attempt_id}.stderr.log')
-    files_path = os.path.join(log_dir, f'attempt-{attempt_id}.files.txt')
     with open(stdout_path, 'w', encoding='utf-8') as handle:
         handle.write(result.stdout or '')
     with open(stderr_path, 'w', encoding='utf-8') as handle:
         handle.write(result.stderr or '')
-    with open(files_path, 'w', encoding='utf-8') as handle:
-        for entry in chunk:
-            handle.write(entry + '\n')
-    return stdout_path, stderr_path, files_path
+    return stdout_path, stderr_path
 
 
 def run_chunk_with_retries(base_command, chunk, repo_root, env, log_dir, pch_root, clangd_binary, attempt_counter):
@@ -165,25 +162,24 @@ def run_chunk_with_retries(base_command, chunk, repo_root, env, log_dir, pch_roo
         command = base_command + ['--clangd-executable', clangd_wrapper] + chunk
         start = time.monotonic()
         print(
-            f'clangd-tidy attempt {attempt_id} (retry {retries}/{MAX_RETRIES}, files {len(chunk)}): ' f'{chunk[0]}',
+            f'attempt {attempt_id} (retry {retries}/{MAX_RETRIES}, files {len(chunk)}): ' f'{chunk[0]}',
             flush=True,
         )
         result = subprocess.run(command, check=False, cwd=repo_root, env=env, text=True, capture_output=True)
         elapsed = time.monotonic() - start
-        stdout_path, stderr_path, _ = write_attempt_logs(log_dir, attempt_id, chunk, result)
+        stdout_path, stderr_path = write_attempt_logs(log_dir, attempt_id, chunk, result)
         pch_size = format_bytes(directory_size(pch_dir))
         print(
-            f'clangd-tidy attempt {attempt_id} finished with exit code {result.returncode} '
-            f'in {elapsed:.1f}s; pch size: {pch_size}',
+            f'attempt {attempt_id} finished exit={result.returncode} ' f'in {elapsed:.1f}s; pch size: {pch_size}',
             flush=True,
         )
         if result.returncode == 0:
-            return True
+            return None
         retryable = is_retryable_failure(result)
         if retries >= MAX_RETRIES or not retryable:
             if retryable:
                 print(
-                    f'clangd-tidy retry limit reached after attempt {attempt_id}; '
+                    f'retry limit reached after attempt {attempt_id}; '
                     f'not retrying. stdout: {stdout_path}; stderr: {stderr_path}',
                     flush=True,
                 )
@@ -192,12 +188,17 @@ def run_chunk_with_retries(base_command, chunk, repo_root, env, log_dir, pch_roo
                 print_output_tail('stdout', result.stdout)
                 print_output_tail('stderr', result.stderr)
                 print(
-                    f'clangd-tidy attempt {attempt_id} failed with a non-retryable error; '
+                    f'attempt {attempt_id} failed with a non-retryable error; '
                     f'not retrying. stdout: {stdout_path}; stderr: {stderr_path}',
                     flush=True,
                 )
                 reset_pch_dir(pch_dir)
-            return False
+            return {
+                'attempt_id': attempt_id,
+                'stdout_path': stdout_path,
+                'stderr_path': stderr_path,
+                'retryable': retryable,
+            }
         reset_pch_dir(pch_dir)
         delay = (RETRY_BACKOFF_MS / 1000.0) * (2**retries) + random.uniform(0.0, 0.2)
         print(
@@ -210,12 +211,22 @@ def run_chunk_with_retries(base_command, chunk, repo_root, env, log_dir, pch_roo
 
 
 def process_chunk(
-    base_command, chunk, repo_root, env, log_dir, pch_root, clangd_binary, attempt_counter, hard_failures
+    base_command, chunk, chunk_index, chunk_count, repo_root, env, log_dir, pch_root, clangd_binary, attempt_counter
 ):
-    ok = run_chunk_with_retries(base_command, chunk, repo_root, env, log_dir, pch_root, clangd_binary, attempt_counter)
-    if ok:
-        return
-    hard_failures.extend(chunk)
+    failure = run_chunk_with_retries(
+        base_command, chunk, repo_root, env, log_dir, pch_root, clangd_binary, attempt_counter
+    )
+    if not failure:
+        return None
+    failure.update(
+        {
+            'chunk_index': chunk_index,
+            'chunk_count': chunk_count,
+            'file_count': len(chunk),
+            'first_file': chunk[0],
+        }
+    )
+    return failure
 
 
 def main():
@@ -275,31 +286,41 @@ def main():
     run_env['PYTHONUNBUFFERED'] = '1'
 
     attempt_counter = [0]
-    hard_failures = []
+    failed_chunks = []
     chunks = list(chunk_files(files))
     print(f'Running clangd-tidy on {len(files)} files in {len(chunks)} chunks', flush=True)
-    for chunk in chunks:
-        process_chunk(
+    for chunk_index, chunk in enumerate(chunks, 1):
+        failure = process_chunk(
             base_command,
             chunk,
+            chunk_index,
+            len(chunks),
             repo_root,
             run_env,
             log_dir,
             pch_root,
             args.clangd_binary,
             attempt_counter,
-            hard_failures,
         )
-        if hard_failures:
-            break
+        if failure:
+            failed_chunks.append(failure)
+            if len(failed_chunks) >= MAX_FAILED_CHUNKS:
+                print(f'failed chunk limit reached ({MAX_FAILED_CHUNKS}); stopping clangd-tidy', flush=True)
+                break
 
-    if hard_failures:
-        print('clangd-tidy hard failures after retries:', file=sys.stderr)
-        for failed in hard_failures:
-            print(f'  {failed}', file=sys.stderr)
+    if failed_chunks:
+        print('clangd-tidy failed chunks after retries:', file=sys.stderr)
+        for failure in failed_chunks:
+            print(
+                f"  chunk {failure['chunk_index']}/{failure['chunk_count']}, "
+                f"attempt {failure['attempt_id']}, files {failure['file_count']}, "
+                f"first file: {failure['first_file']}, stdout: {failure['stdout_path']}, "
+                f"stderr: {failure['stderr_path']}",
+                file=sys.stderr,
+            )
     print(f'clangd-tidy logs written to: {log_dir}')
 
-    return 1 if hard_failures else 0
+    return 1 if failed_chunks else 0
 
 
 if __name__ == '__main__':

--- a/scripts/run-clangd-tidy.py
+++ b/scripts/run-clangd-tidy.py
@@ -124,13 +124,17 @@ def is_retryable_failure(result):
 
 
 def write_attempt_logs(log_dir, attempt_id, chunk, result):
-    with open(os.path.join(log_dir, f'attempt-{attempt_id}.stdout.log'), 'w', encoding='utf-8') as handle:
+    stdout_path = os.path.join(log_dir, f'attempt-{attempt_id}.stdout.log')
+    stderr_path = os.path.join(log_dir, f'attempt-{attempt_id}.stderr.log')
+    files_path = os.path.join(log_dir, f'attempt-{attempt_id}.files.txt')
+    with open(stdout_path, 'w', encoding='utf-8') as handle:
         handle.write(result.stdout or '')
-    with open(os.path.join(log_dir, f'attempt-{attempt_id}.stderr.log'), 'w', encoding='utf-8') as handle:
+    with open(stderr_path, 'w', encoding='utf-8') as handle:
         handle.write(result.stderr or '')
-    with open(os.path.join(log_dir, f'attempt-{attempt_id}.files.txt'), 'w', encoding='utf-8') as handle:
+    with open(files_path, 'w', encoding='utf-8') as handle:
         for entry in chunk:
             handle.write(entry + '\n')
+    return stdout_path, stderr_path, files_path
 
 
 def run_chunk_with_retries(base_command, chunk, repo_root, env, log_dir, pch_root, clangd_binary, attempt_counter):
@@ -144,13 +148,12 @@ def run_chunk_with_retries(base_command, chunk, repo_root, env, log_dir, pch_roo
         command = base_command + ['--clangd-executable', clangd_wrapper] + chunk
         start = time.monotonic()
         print(
-            f'clangd-tidy attempt {attempt_id} (retry {retries}/{MAX_RETRIES}, files {len(chunk)}): '
-            f'{chunk[0]}',
+            f'clangd-tidy attempt {attempt_id} (retry {retries}/{MAX_RETRIES}, files {len(chunk)}): ' f'{chunk[0]}',
             flush=True,
         )
         result = subprocess.run(command, check=False, cwd=repo_root, env=env, text=True, capture_output=True)
         elapsed = time.monotonic() - start
-        write_attempt_logs(log_dir, attempt_id, chunk, result)
+        stdout_path, stderr_path, _ = write_attempt_logs(log_dir, attempt_id, chunk, result)
         pch_size = format_bytes(directory_size(pch_dir))
         print(
             f'clangd-tidy attempt {attempt_id} finished with exit code {result.returncode} '
@@ -162,10 +165,26 @@ def run_chunk_with_retries(base_command, chunk, repo_root, env, log_dir, pch_roo
         retryable = is_retryable_failure(result)
         if retries >= MAX_RETRIES or not retryable:
             if retryable:
+                print(
+                    f'clangd-tidy retry limit reached after attempt {attempt_id}; '
+                    f'not retrying. stdout: {stdout_path}; stderr: {stderr_path}',
+                    flush=True,
+                )
                 reset_pch_dir(pch_dir)
+            else:
+                print(
+                    f'clangd-tidy attempt {attempt_id} failed with a non-retryable error; '
+                    f'not retrying. stdout: {stdout_path}; stderr: {stderr_path}',
+                    flush=True,
+                )
             return False
         reset_pch_dir(pch_dir)
         delay = (RETRY_BACKOFF_MS / 1000.0) * (2**retries) + random.uniform(0.0, 0.2)
+        print(
+            f'retrying clangd-tidy after attempt {attempt_id}; retry {retries + 1}/{MAX_RETRIES} '
+            f'in {delay:.2f}s. stdout: {stdout_path}; stderr: {stderr_path}',
+            flush=True,
+        )
         time.sleep(delay)
         retries += 1
 

--- a/scripts/run-clangd-tidy.py
+++ b/scripts/run-clangd-tidy.py
@@ -12,11 +12,15 @@ import sys
 import time
 
 
-TARGET_CHUNK_COUNT = 10
-MAX_FAILED_CHUNKS = 2
+# Amount of evenly sized filename chunks.
+TARGET_CHUNK_COUNT = 8
+
+MAX_FAILED_CHUNKS = 3
 MAX_RETRIES = 2
-RETRY_BACKOFF_MS = 500
+
 ERROR_TAIL_LINES = 2000
+
+RETRY_BACKOFF_MS = 500
 RETRY_PATTERNS = (
     'invalid header end',
     'broken pipe',

--- a/scripts/run-clangd-tidy.py
+++ b/scripts/run-clangd-tidy.py
@@ -13,8 +13,10 @@ import time
 
 
 MAX_CHUNK_CHARS = 100000
+MAX_CHUNK_FILES = 100
 MAX_RETRIES = 2
 RETRY_BACKOFF_MS = 500
+ERROR_TAIL_LINES = 120
 RETRY_PATTERNS = (
     'invalid header end',
     'broken pipe',
@@ -40,12 +42,12 @@ def is_ignored_file(path, repo_root):
     return relative == 'third_party' or relative.startswith('third_party' + os.sep)
 
 
-def chunk_files(files, max_chars=MAX_CHUNK_CHARS):
+def chunk_files(files, max_chars=MAX_CHUNK_CHARS, max_files=MAX_CHUNK_FILES):
     chunk = []
     current_chars = 0
     for path in files:
         path_len = len(path) + 1
-        if chunk and current_chars + path_len > max_chars:
+        if chunk and (len(chunk) >= max_files or current_chars + path_len > max_chars):
             yield chunk
             chunk = []
             current_chars = 0
@@ -123,6 +125,21 @@ def is_retryable_failure(result):
     return any(pattern in lower for pattern in RETRY_PATTERNS)
 
 
+def print_output_tail(label, text):
+    lines = (text or '').splitlines()
+    if not lines:
+        return
+    shown = lines[-ERROR_TAIL_LINES:]
+    omitted = len(lines) - len(shown)
+    print(f'--- clangd-tidy {label} tail ({len(shown)} lines', end='', flush=True)
+    if omitted > 0:
+        print(f', {omitted} omitted', end='', flush=True)
+    print(') ---', flush=True)
+    for line in shown:
+        print(line, flush=True)
+    print(f'--- end clangd-tidy {label} tail ---', flush=True)
+
+
 def write_attempt_logs(log_dir, attempt_id, chunk, result):
     stdout_path = os.path.join(log_dir, f'attempt-{attempt_id}.stdout.log')
     stderr_path = os.path.join(log_dir, f'attempt-{attempt_id}.stderr.log')
@@ -172,11 +189,14 @@ def run_chunk_with_retries(base_command, chunk, repo_root, env, log_dir, pch_roo
                 )
                 reset_pch_dir(pch_dir)
             else:
+                print_output_tail('stdout', result.stdout)
+                print_output_tail('stderr', result.stderr)
                 print(
                     f'clangd-tidy attempt {attempt_id} failed with a non-retryable error; '
                     f'not retrying. stdout: {stdout_path}; stderr: {stderr_path}',
                     flush=True,
                 )
+                reset_pch_dir(pch_dir)
             return False
         reset_pch_dir(pch_dir)
         delay = (RETRY_BACKOFF_MS / 1000.0) * (2**retries) + random.uniform(0.0, 0.2)
@@ -195,16 +215,7 @@ def process_chunk(
     ok = run_chunk_with_retries(base_command, chunk, repo_root, env, log_dir, pch_root, clangd_binary, attempt_counter)
     if ok:
         return
-    if len(chunk) == 1:
-        hard_failures.append(chunk[0])
-        return
-    mid = len(chunk) // 2
-    process_chunk(
-        base_command, chunk[:mid], repo_root, env, log_dir, pch_root, clangd_binary, attempt_counter, hard_failures
-    )
-    process_chunk(
-        base_command, chunk[mid:], repo_root, env, log_dir, pch_root, clangd_binary, attempt_counter, hard_failures
-    )
+    hard_failures.extend(chunk)
 
 
 def main():
@@ -279,6 +290,8 @@ def main():
             attempt_counter,
             hard_failures,
         )
+        if hard_failures:
+            break
 
     if hard_failures:
         print('clangd-tidy hard failures after retries:', file=sys.stderr)

--- a/scripts/run-clangd-tidy.py
+++ b/scripts/run-clangd-tidy.py
@@ -13,11 +13,11 @@ import time
 
 
 MAX_CHUNK_CHARS = 100000
-MAX_CHUNK_FILES = 100
-MAX_FAILED_CHUNKS = 4
+MAX_CHUNK_FILES = 200
+MAX_FAILED_CHUNKS = 2
 MAX_RETRIES = 2
 RETRY_BACKOFF_MS = 500
-ERROR_TAIL_LINES = 120
+ERROR_TAIL_LINES = 2000
 RETRY_PATTERNS = (
     'invalid header end',
     'broken pipe',
@@ -187,11 +187,6 @@ def run_chunk_with_retries(base_command, chunk, repo_root, env, log_dir, pch_roo
             else:
                 print_output_tail('stdout', result.stdout)
                 print_output_tail('stderr', result.stderr)
-                print(
-                    f'attempt {attempt_id} failed with a non-retryable error; '
-                    f'not retrying. stdout: {stdout_path}; stderr: {stderr_path}',
-                    flush=True,
-                )
                 reset_pch_dir(pch_dir)
             return {
                 'attempt_id': attempt_id,

--- a/scripts/run-clangd-tidy.py
+++ b/scripts/run-clangd-tidy.py
@@ -6,6 +6,7 @@ import multiprocessing
 import os
 import random
 import shlex
+import shutil
 import subprocess
 import sys
 import time
@@ -86,6 +87,34 @@ exec {shlex.quote(clangd_binary)} "$@" --pch-storage=disk
     return wrapper_path
 
 
+def format_bytes(size):
+    suffixes = ('B', 'KiB', 'MiB', 'GiB', 'TiB')
+    value = float(size)
+    for suffix in suffixes:
+        if value < 1024 or suffix == suffixes[-1]:
+            return f'{value:.1f} {suffix}'
+        value /= 1024
+
+
+def directory_size(path):
+    total = 0
+    if not os.path.exists(path):
+        return total
+    for root, _, files in os.walk(path):
+        for filename in files:
+            file_path = os.path.join(root, filename)
+            try:
+                total += os.path.getsize(file_path)
+            except OSError:
+                pass
+    return total
+
+
+def reset_pch_dir(pch_dir):
+    shutil.rmtree(pch_dir, ignore_errors=True)
+    os.makedirs(pch_dir, exist_ok=True)
+
+
 def is_retryable_failure(result):
     if result.returncode == 0:
         return False
@@ -106,19 +135,36 @@ def write_attempt_logs(log_dir, attempt_id, chunk, result):
 
 def run_chunk_with_retries(base_command, chunk, repo_root, env, log_dir, pch_root, clangd_binary, attempt_counter):
     retries = 0
+    pch_dir = os.path.join(pch_root, 'current')
+    os.makedirs(pch_dir, exist_ok=True)
     while True:
         attempt_counter[0] += 1
         attempt_id = attempt_counter[0]
-        attempt_pch_dir = os.path.join(pch_root, f'attempt-{attempt_id}')
-        os.makedirs(attempt_pch_dir, exist_ok=True)
-        clangd_wrapper = create_attempt_clangd_wrapper(log_dir, clangd_binary, attempt_pch_dir, attempt_id)
+        clangd_wrapper = create_attempt_clangd_wrapper(log_dir, clangd_binary, pch_dir, attempt_id)
         command = base_command + ['--clangd-executable', clangd_wrapper] + chunk
+        start = time.monotonic()
+        print(
+            f'clangd-tidy attempt {attempt_id} (retry {retries}/{MAX_RETRIES}, files {len(chunk)}): '
+            f'{chunk[0]}',
+            flush=True,
+        )
         result = subprocess.run(command, check=False, cwd=repo_root, env=env, text=True, capture_output=True)
+        elapsed = time.monotonic() - start
         write_attempt_logs(log_dir, attempt_id, chunk, result)
+        pch_size = format_bytes(directory_size(pch_dir))
+        print(
+            f'clangd-tidy attempt {attempt_id} finished with exit code {result.returncode} '
+            f'in {elapsed:.1f}s; pch size: {pch_size}',
+            flush=True,
+        )
         if result.returncode == 0:
             return True
-        if retries >= MAX_RETRIES or not is_retryable_failure(result):
+        retryable = is_retryable_failure(result)
+        if retries >= MAX_RETRIES or not retryable:
+            if retryable:
+                reset_pch_dir(pch_dir)
             return False
+        reset_pch_dir(pch_dir)
         delay = (RETRY_BACKOFF_MS / 1000.0) * (2**retries) + random.uniform(0.0, 0.2)
         time.sleep(delay)
         retries += 1
@@ -200,7 +246,9 @@ def main():
 
     attempt_counter = [0]
     hard_failures = []
-    for chunk in chunk_files(files):
+    chunks = list(chunk_files(files))
+    print(f'Running clangd-tidy on {len(files)} files in {len(chunks)} chunks', flush=True)
+    for chunk in chunks:
         process_chunk(
             base_command,
             chunk,

--- a/scripts/run-clangd-tidy.py
+++ b/scripts/run-clangd-tidy.py
@@ -5,6 +5,7 @@ import json
 import multiprocessing
 import os
 import random
+import re
 import shlex
 import shutil
 import subprocess
@@ -20,6 +21,14 @@ MAX_RETRIES = 2
 
 ERROR_TAIL_LINES = 2000
 
+FORCE_COLOR_OUTPUT = True
+ANSI_RESET = '\033[0m'
+ANSI_BOLD = '\033[1m'
+ANSI_GRAY = '\033[90m'
+ANSI_RED = '\033[31m'
+ANSI_YELLOW = '\033[33m'
+ANSI_CYAN = '\033[36m'
+
 RETRY_BACKOFF_MS = 500
 RETRY_PATTERNS = (
     'invalid header end',
@@ -29,6 +38,30 @@ RETRY_PATTERNS = (
     'failed to read message',
     'jsonrpc',
 )
+
+
+def color_text(text, color):
+    if not FORCE_COLOR_OUTPUT:
+        return text
+    return f'{color}{text}{ANSI_RESET}'
+
+
+def print_status(message, file=None):
+    if file is None:
+        file = sys.stdout
+    print(color_text(message, ANSI_GRAY), file=file, flush=True)
+
+
+def color_diagnostic_line(line):
+    if re.search(r'\berror:', line, re.IGNORECASE):
+        return color_text(line, ANSI_RED)
+    if re.search(r'\bwarning:', line, re.IGNORECASE):
+        return color_text(line, ANSI_YELLOW)
+    if re.match(r'^[^:\s][^:]*:\d+:\d+:', line):
+        return color_text(line, ANSI_BOLD)
+    if re.match(r'^\s*\|?\s*\^', line):
+        return color_text(line, ANSI_CYAN)
+    return line
 
 
 def make_absolute(path, directory):
@@ -134,13 +167,14 @@ def print_output_tail(label, text):
         return
     shown = lines[-ERROR_TAIL_LINES:]
     omitted = len(lines) - len(shown)
-    print(f'--- clangd-tidy {label} tail ({len(shown)} lines', end='', flush=True)
+    message = f'--- clangd-tidy {label} tail ({len(shown)} lines'
     if omitted > 0:
-        print(f', {omitted} omitted', end='', flush=True)
-    print(') ---', flush=True)
+        message += f', {omitted} omitted'
+    message += ') ---'
+    print_status(message)
     for line in shown:
-        print(line, flush=True)
-    print(f'--- end clangd-tidy {label} tail ---', flush=True)
+        print(color_diagnostic_line(line), flush=True)
+    print_status(f'--- end clangd-tidy {label} tail ---')
 
 
 def write_attempt_logs(log_dir, attempt_id, chunk, result):
@@ -163,27 +197,20 @@ def run_chunk_with_retries(base_command, chunk, repo_root, env, log_dir, pch_roo
         clangd_wrapper = create_attempt_clangd_wrapper(log_dir, clangd_binary, pch_dir, attempt_id)
         command = base_command + ['--clangd-executable', clangd_wrapper] + chunk
         start = time.monotonic()
-        print(
-            f'attempt {attempt_id} (retry {retries}/{MAX_RETRIES}, files {len(chunk)}): ' f'{chunk[0]}',
-            flush=True,
-        )
+        print_status(f'attempt {attempt_id} (retry {retries}/{MAX_RETRIES}, files {len(chunk)}): {chunk[0]}')
         result = subprocess.run(command, check=False, cwd=repo_root, env=env, text=True, capture_output=True)
         elapsed = time.monotonic() - start
         stdout_path, stderr_path = write_attempt_logs(log_dir, attempt_id, chunk, result)
         pch_size = format_bytes(directory_size(pch_dir))
-        print(
-            f'attempt {attempt_id} finished exit={result.returncode} ' f'in {elapsed:.1f}s; pch size: {pch_size}',
-            flush=True,
-        )
+        print_status(f'attempt {attempt_id} finished exit={result.returncode} in {elapsed:.1f}s; pch size: {pch_size}')
         if result.returncode == 0:
             return None
         retryable = is_retryable_failure(result)
         if retries >= MAX_RETRIES or not retryable:
             if retryable:
-                print(
+                print_status(
                     f'retry limit reached after attempt {attempt_id}; '
-                    f'not retrying. stdout: {stdout_path}; stderr: {stderr_path}',
-                    flush=True,
+                    f'not retrying. stdout: {stdout_path}; stderr: {stderr_path}'
                 )
                 reset_pch_dir(pch_dir)
             else:
@@ -198,10 +225,9 @@ def run_chunk_with_retries(base_command, chunk, repo_root, env, log_dir, pch_roo
             }
         reset_pch_dir(pch_dir)
         delay = (RETRY_BACKOFF_MS / 1000.0) * (2**retries) + random.uniform(0.0, 0.2)
-        print(
+        print_status(
             f'retrying clangd-tidy after attempt {attempt_id}; retry {retries + 1}/{MAX_RETRIES} '
-            f'in {delay:.2f}s. stdout: {stdout_path}; stderr: {stderr_path}',
-            flush=True,
+            f'in {delay:.2f}s. stdout: {stdout_path}; stderr: {stderr_path}'
         )
         time.sleep(delay)
         retries += 1
@@ -261,8 +287,8 @@ def main():
     except Exception:
         print('Unable to run clangd-tidy or clangd.', file=sys.stderr)
         return 1
-    print(f'Using clangd-tidy: {clangd_tidy_version}')
-    print(f'Using clangd: {clangd_version}')
+    print_status(f'Using clangd-tidy: {clangd_tidy_version}')
+    print_status(f'Using clangd: {clangd_version}')
 
     log_dir = os.path.join(build_path, 'clangd-tidy-logs')
     os.makedirs(log_dir, exist_ok=True)
@@ -285,7 +311,7 @@ def main():
     attempt_counter = [0]
     failed_chunks = []
     chunks = list(chunk_files(files))
-    print(f'Running clangd-tidy on {len(files)} files in {len(chunks)} chunks', flush=True)
+    print_status(f'Running clangd-tidy on {len(files)} files in {len(chunks)} chunks')
     for chunk_index, chunk in enumerate(chunks, 1):
         failure = process_chunk(
             base_command,
@@ -302,20 +328,20 @@ def main():
         if failure:
             failed_chunks.append(failure)
             if len(failed_chunks) >= MAX_FAILED_CHUNKS:
-                print(f'failed chunk limit reached ({MAX_FAILED_CHUNKS}); stopping clangd-tidy', flush=True)
+                print_status(f'failed chunk limit reached ({MAX_FAILED_CHUNKS}); stopping clangd-tidy')
                 break
 
     if failed_chunks:
-        print('clangd-tidy failed chunks after retries:', file=sys.stderr)
+        print_status('clangd-tidy failed chunks after retries:', file=sys.stderr)
         for failure in failed_chunks:
-            print(
+            print_status(
                 f"  chunk {failure['chunk_index']}/{failure['chunk_count']}, "
                 f"attempt {failure['attempt_id']}, files {failure['file_count']}, "
                 f"first file: {failure['first_file']}, stdout: {failure['stdout_path']}, "
                 f"stderr: {failure['stderr_path']}",
                 file=sys.stderr,
             )
-    print(f'clangd-tidy logs written to: {log_dir}')
+    print_status(f'clangd-tidy logs written to: {log_dir}')
 
     return 1 if failed_chunks else 0
 

--- a/src/common/arrow/physical_arrow_collector.cpp
+++ b/src/common/arrow/physical_arrow_collector.cpp
@@ -2,6 +2,7 @@
 #include "duckdb/common/arrow/physical_arrow_collector.hpp"
 #include "duckdb/common/arrow/physical_arrow_batch_collector.hpp"
 #include "duckdb/common/arrow/arrow_query_result.hpp"
+#include "duckdb/common/assert.hpp"
 #include "duckdb/main/prepared_statement_data.hpp"
 #include "duckdb/execution/physical_plan_generator.hpp"
 #include "duckdb/main/client_context.hpp"

--- a/src/function/table/system/duckdb_constraints.cpp
+++ b/src/function/table/system/duckdb_constraints.cpp
@@ -316,15 +316,15 @@ void DuckDBConstraintsFunction(ClientContext &context, TableFunctionInput &data_
 				column_index_list.push_back(Value::UBIGINT(col_index.index));
 			}
 			for (auto &name : info.column_names) {
-				column_name_list.push_back(Value(std::move(name)));
+				column_name_list.push_back(Value(name));
 			}
 			for (auto &name : info.referenced_columns) {
-				referenced_column_name_list.push_back(Value(std::move(name)));
+				referenced_column_name_list.push_back(Value(name));
 			}
 			constraint_column_indexes.Append(Value::LIST(LogicalType::BIGINT, std::move(column_index_list)));
 			constraint_column_names.Append(Value::LIST(LogicalType::VARCHAR, std::move(column_name_list)));
 			constraint_name_vec.Append(Value(std::move(constraint_name)));
-			referenced_table.Append(info.referenced_table.empty() ? Value() : Value(std::move(info.referenced_table)));
+			referenced_table.Append(info.referenced_table.empty() ? Value() : Value(info.referenced_table));
 			referenced_column_names.Append(Value::LIST(LogicalType::VARCHAR, std::move(referenced_column_name_list)));
 			count++;
 		}

--- a/src/parser/peg/transformer/transform_expression.cpp
+++ b/src/parser/peg/transformer/transform_expression.cpp
@@ -159,7 +159,7 @@ unique_ptr<ParsedExpression> PEGTransformerFactory::TransformFunctionExpression(
     MethodArguments function_expression_arguments, optional<vector<OrderByNode>> within_group_clause,
     optional<unique_ptr<ParsedExpression>> filter_clause, const bool &has_result,
     optional<unique_ptr<WindowExpression>> over_clause) {
-	auto qualified_function = function_identifier;
+	const auto &qualified_function = function_identifier;
 	bool export_clause = has_result;
 	auto distinct = function_expression_arguments.distinct;
 	auto function_children = std::move(function_expression_arguments.arguments);


### PR DESCRIPTION
Originally, clangd-tidy was enabled [here](https://github.com/duckdb/duckdb/pull/21745).

The CI check for `clangd-tidy` was disabled in [this](https://github.com/duckdb/duckdb/pull/23196) PR because the CI job ran very slowly:
<img width="822" height="550" alt="Screenshot 2026-07-29 at 10 40 35" src="https://github.com/user-attachments/assets/38d540c5-a188-4ec4-8f39-51533df183f0" />

The job failed because the script exhausted all disk space (160 GiB!). The script kept recreating precompiled header files from scratch after a tidy error, but it did not remove the previously created files.

Fixes https://github.com/duckdblabs/duckdb-internal/issues/9770.

### Changes
- Re-enable the `clangd-tidy` check in CI (for PRs and on main).
- Write `clangd-tidy` disk stats and tidy attempts to CI output.
- Use 8 evenly sized chunks and print failures immediately in CI output.
- Stop after max 3 failed chunks (so at most 3x 2000 error lines, 3x ~200 files).

### Tidy fixes
- Fix `performance-unnecessary-copy-initialization` error (missing `const auto`).
- Remove ineffective `std::move()` calls.

### Disk usage

The disk usage is kept at 40 GiB (25% of that CI runner instance):

```
attempt 1 (retry 0/2, files 204): tools/utils/test_platform.cpp
attempt 1 finished exit=0 in 38.2s; pch size: 5.8 GiB
attempt 2 (retry 0/2, files 204): src/optimizer/window_self_join.cpp
attempt 2 finished exit=0 in 36.1s; pch size: 11.0 GiB
attempt 3 (retry 0/2, files 203): src/planner/binder/tableref/bind_showref.cpp
attempt 3 finished exit=0 in 29.0s; pch size: 14.8 GiB
attempt 4 (retry 0/2, files 203): src/parser/peg/transformer/transform_copy.cpp
attempt 4 finished exit=0 in 27.3s; pch size: 18.8 GiB
attempt 5 (retry 0/2, files 203): src/function/scalar/system/aggregate_export.cpp
attempt 5 finished exit=0 in 32.0s; pch size: 23.7 GiB
attempt 6 (retry 0/2, files 203): src/common/crypto/md5.cpp
attempt 6 finished exit=0 in 29.9s; pch size: 28.1 GiB
attempt 7 (retry 0/2, files 203): src/execution/operator/helper/physical_disconnect.cpp
attempt 7 finished exit=0 in 38.5s; pch size: 34.3 GiB
attempt 8 (retry 0/2, files 203): src/main/relation/delim_get_relation.cpp
attempt 8 finished exit=0 in 35.7s; pch size: 40.4 GiB
```

### Measurements

Originally, clangd-tidy took ~9 min to run. I did some experiments on how to use the CI instance (16 vCPU, 32 GiB RAM) more efficiently:

chunks | concurrency | average CPU | duration
--- | --- | --- | ---
100-file chunks | `-j4` | 53% | [10m17s](https://cloud.namespace.so/rrete04q43id4/actions/job/90520079762)
200-file chunks | `-j4` | 55% | [6m59s](https://cloud.namespace.so/rrete04q43id4/actions/job/90520079762)
10 evenly sized chunks | `-j8` | 95% | [4m16s](https://cloud.namespace.so/rrete04q43id4/actions/job/90523783761)
8 evenly sized chunks | `-j8` | 93% | [4m28s](https://cloud.namespace.so/rrete04q43id4/actions/job/90525308431)

It's better to use fewer (10 -> 8) chunks because an error clears the precompiled header directory causing clangd to rebuild included header files from scratch.