### PR TITLE
Only define EXT_VERSION_<NAME> for the sources that read it

### DIFF
--- a/extension/README.md
+++ b/extension/README.md
@@ -148,6 +148,36 @@ results in:
 ...
 ```
 
+# Reporting an extension version
+
+An extension can report its version through the `EXT_VERSION_<NAME_UPPERCASE>` macro, which DuckDB defines to
+the extension version configured at build time:
+```cpp
+std::string ParquetExtension::Version() const {
+#ifdef EXT_VERSION_PARQUET
+	return EXT_VERSION_PARQUET;
+#else
+	return "";
+#endif
+}
+```
+By default the macro is defined for every source file of the extension, including any third party code it
+vendors. Since the version defaults to a git commit hash - DuckDB's for in-tree extensions, the extension's own
+otherwise - that puts a value which changes on every commit on all of their compiler command lines, forcing a
+recompile of the whole extension for a string that a single file reads.
+
+An extension avoids that by declaring which of its sources actually read the macro, in its own `CMakeLists.txt`:
+```cmake
+project(ParquetExtension)
+
+# Before any subdirectory or target, which would otherwise inherit the directory-wide definition
+set_extension_version_sources(parquet parquet_extension.cpp)
+```
+Only the listed sources then get `EXT_VERSION_<NAME>`, and a version change recompiles those rather than
+everything. It has to be called before the extension declares any targets or adds any subdirectories, because
+those inherit the directory-wide definition at the point they are created. Out-of-tree extensions can use it
+too; their version is their own commit hash, so it changes on every commit in their repository.
+
 # VCPKG dependency management
 DuckDB extensions can use [VCPKG](https://vcpkg.io/en/) to manage their dependencies. Check out the [Extension Template](https://github.com/duckdb/extension-template) for an example
 on how to set up vcpkg in extensions. 

--- a/extension/core_functions/CMakeLists.txt
+++ b/extension/core_functions/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 3.5...3.29)
 
 project(CoreFunctionsExtension)
 
+# Before any subdirectory or target, which would otherwise inherit the
+# directory-wide definition
+set_extension_version_sources(core_functions core_functions_extension.cpp)
+
 include_directories(include)
 add_subdirectory(aggregate)
 add_subdirectory(scalar)

--- a/extension/extension_build_tools.cmake
+++ b/extension/extension_build_tools.cmake
@@ -634,6 +634,25 @@ endforeach()
 
 
 
+# Declares which of an extension's sources read EXT_VERSION_<NAME>. DuckDB defines it for the whole extension
+# directory by default; this narrows it down to just the listed sources, so that a version change recompiles
+# those instead of the entire extension and anything it vendors. Worth doing because the version defaults to a
+# git commit hash - DuckDB's for in-tree extensions, the extension's own otherwise - and so changes constantly.
+# Must be called from the extension's own CMakeLists before it declares any targets or subdirectories, as those
+# inherit the directory-wide definition at the point they are created.
+function(set_extension_version_sources EXT_NAME)
+    string(TOUPPER ${EXT_NAME} EXT_NAME_UPPERCASE)
+    if ("${DUCKDB_EXTENSION_${EXT_NAME_UPPERCASE}_EXT_VERSION}" STREQUAL "")
+        return()
+    endif()
+    set(DEFINITION EXT_VERSION_${EXT_NAME_UPPERCASE}="${DUCKDB_EXTENSION_${EXT_NAME_UPPERCASE}_EXT_VERSION}")
+    remove_definitions(-D${DEFINITION})
+    if (NOT ARGN)
+        return()
+    endif()
+    set_property(SOURCE ${ARGN} APPEND PROPERTY COMPILE_DEFINITIONS ${DEFINITION})
+endfunction()
+
 # Add subdirectories for registered extensions
 foreach(EXT_NAME IN LISTS DUCKDB_EXTENSION_NAMES)
     string(TOUPPER ${EXT_NAME} EXT_NAME_UPPERCASE)

--- a/extension/icu/CMakeLists.txt
+++ b/extension/icu/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 2.8.12...3.29)
 
 project(ICUExtension)
 
+# Before any subdirectory or target, which would otherwise inherit the
+# directory-wide definition
+set_extension_version_sources(icu icu_extension.cpp)
+
 include_directories(include)
 option(WITH_INTERNAL_ICU "Use vendored copy of icu" TRUE)
 if(WITH_INTERNAL_ICU)

--- a/extension/json/CMakeLists.txt
+++ b/extension/json/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 2.8.12...3.29)
 
 project(JSONExtension)
 
+# Before any subdirectory or target, which would otherwise inherit the
+# directory-wide definition
+set_extension_version_sources(json json_extension.cpp)
+
 include_directories(include)
 add_subdirectory(json_functions)
 

--- a/extension/parquet/CMakeLists.txt
+++ b/extension/parquet/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 3.5...3.29)
 
 project(ParquetExtension)
 
+# Before any subdirectory or target, which would otherwise inherit the
+# directory-wide definition
+set_extension_version_sources(parquet parquet_extension.cpp)
+
 include_directories(
   include ../../third_party/lz4 ../../third_party/parquet
   ../../third_party/thrift ../../third_party/snappy

--- a/extension/tpcds/CMakeLists.txt
+++ b/extension/tpcds/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 2.8.12...3.29)
 
 project(TpcdsExtension)
 
+# Before any subdirectory or target, which would otherwise inherit the
+# directory-wide definition
+set_extension_version_sources(tpcds tpcds_extension.cpp)
+
 include_directories(include)
 include_directories(dsdgen/include)
 add_subdirectory(dsdgen)

--- a/extension/tpch/CMakeLists.txt
+++ b/extension/tpch/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 2.8.12...3.29)
 
 project(TpchExtension)
 
+# Before any subdirectory or target, which would otherwise inherit the
+# directory-wide definition
+set_extension_version_sources(tpch tpch_extension.cpp)
+
 include_directories(dbgen/include)
 include_directories(include)
 add_subdirectory(dbgen)


### PR DESCRIPTION
DuckDB defines `EXT_VERSION_<NAME>` for an extension's entire directory. For
in-tree extensions that value defaults to DuckDB's own commit hash. So every
commit changes the compiler command line of every source file of every
extension, and of the third party code they vendor. The only thing reading the
macro is `<name>_extension.cpp`, to implement `Version()`.

An extension can now declare which of its sources read it:

    set_extension_version_sources(parquet parquet_extension.cpp)

That drops the directory-wide definition inherited from DuckDB and applies it to
the listed sources instead. It has to be called before the extension declares
any targets or adds any subdirectories, since those inherit the directory-wide
definition at the point they are created.

For this build:

    DUCKDB_LINKER=lld make release BUILD_EXTENSIONS="json;icu;tpch;tpcds;httpfs"

a new commit now invalidates 12 objects instead of 428. With ccache warm that is
a 10 second rebuild instead of 15. Those 416 translation units were ccache hits
rather than real compiles, but still had to be preprocessed. It is also much
clearer which files actually need recompiling.

Out-of-tree extensions are unaffected unless they opt in. Their version comes
from their own repository, so it does not change when DuckDB does.
