### PR TITLE
Fix table filter canonicalization in common subplan optimizer

### DIFF
--- a/src/optimizer/common_subplan_optimizer.cpp
+++ b/src/optimizer/common_subplan_optimizer.cpp
@@ -64,7 +64,7 @@ class PlanSignatureTableIndexMap {
 public:
 	explicit PlanSignatureTableIndexMap(ArenaAllocator &allocator_p)
 	    : allocator(allocator_p), table_index_map(allocator), to_canonical_table_index(allocator),
-	      restore_original_table_index(allocator) {
+	      restore_original_table_index(allocator), restore_original_table_filter_index(allocator) {
 	}
 
 public:
@@ -89,6 +89,7 @@ private:
 			// Clear temporary data structures
 			to_canonical_table_index.clear();
 			restore_original_table_index.clear();
+			restore_original_table_filter_index.clear();
 			column_ids.clear();
 			projection_ids.clear();
 			table_indices.clear();
@@ -267,6 +268,25 @@ private:
 					}
 				}
 
+				for (auto &entry : get.table_filters) {
+					D_ASSERT(entry.GetIndex().GetIndex() < column_ids.size());
+					const auto canonical_index =
+					    ProjectionIndex(column_ids[entry.GetIndex().GetIndex()].GetPrimaryIndex());
+					if (!restore_original_table_filter_index.emplace(canonical_index, entry.GetIndex()).second) {
+						restore_original_table_filter_index.clear();
+						return false;
+					}
+				}
+				if (!restore_original_table_filter_index.empty()) {
+					TableFilterSet remapped_filters;
+					for (auto &entry : get.table_filters) {
+						const auto canonical_index =
+						    ProjectionIndex(column_ids[entry.GetIndex().GetIndex()].GetPrimaryIndex());
+						remapped_filters.PushFilter(canonical_index, entry.TakeFilter());
+					}
+					get.table_filters = std::move(remapped_filters);
+				}
+
 				// Store mapping for base tables
 				auto &column_index_map = table_index_map.at(table_indices[0]);
 				if (projection_ids.empty()) {
@@ -287,6 +307,14 @@ private:
 				get.GetMutableColumnIds() = std::move(column_ids);
 				D_ASSERT(get.projection_ids.empty());
 				get.projection_ids = std::move(projection_ids);
+				if (!restore_original_table_filter_index.empty()) {
+					TableFilterSet remapped_filters;
+					for (auto &entry : get.table_filters) {
+						remapped_filters.PushFilter(restore_original_table_filter_index.at(entry.GetIndex()),
+						                            entry.TakeFilter());
+					}
+					get.table_filters = std::move(remapped_filters);
+				}
 				break;
 			}
 		}
@@ -378,6 +406,8 @@ private:
 	//! Temporary map from original table index to canonical table index (and reverse)
 	arena_unordered_map<TableIndex, TableIndex> to_canonical_table_index;
 	arena_unordered_map<TableIndex, TableIndex> restore_original_table_index;
+	//! Temporary map from canonical table filter index to original table filter index
+	arena_unordered_map<ProjectionIndex, ProjectionIndex> restore_original_table_filter_index;
 	//! Temporary vector to store table indices
 	vector<TableIndex> table_indices;
 	//! Temporary vector to store projection maps

--- a/test/sql/optimizer/test_common_subplan_table_filters.test
+++ b/test/sql/optimizer/test_common_subplan_table_filters.test
@@ -1,0 +1,63 @@
+# name: test/sql/optimizer/test_common_subplan_table_filters.test
+# description: Common subplan signatures preserve table filter column identities
+# group: [optimizer]
+
+statement ok
+CREATE TABLE csp_filter_key(a INTEGER, b INTEGER);
+
+statement ok
+INSERT INTO csp_filter_key VALUES (1, 0), (2, 2), (3, 0), (4, 4);
+
+# Filters on different base columns can have the same projection index
+query TI rowsort
+SELECT 'a', count(*) FROM csp_filter_key WHERE a > 1
+UNION ALL
+SELECT 'b', count(*) FROM csp_filter_key WHERE b > 1;
+----
+a	3
+b	2
+
+# Multiple filters retain their association with the correct base columns
+query TI rowsort
+SELECT 'a', count(*) FROM csp_filter_key WHERE a > 1 AND b < 3
+UNION ALL
+SELECT 'b', count(*) FROM csp_filter_key WHERE a < 3 AND b > 1;
+----
+a	2
+b	1
+
+# IN filters on different base columns must not share a subplan
+query TI rowsort
+SELECT 'a', count(*) FROM csp_filter_key WHERE a IN (2, 3, 4)
+UNION ALL
+SELECT 'b', count(*) FROM csp_filter_key WHERE b IN (2, 3, 4);
+----
+a	3
+b	2
+
+# Genuinely identical filtered subplans remain equivalent
+query TI rowsort
+SELECT 'x', count(*) FROM csp_filter_key WHERE a > 1
+UNION ALL
+SELECT 'y', count(*) FROM csp_filter_key WHERE a > 1;
+----
+x	3
+y	3
+
+statement ok
+PRAGMA explain_output='optimized_only';
+
+# Different table filters must not be extracted as a common subplan
+query II
+EXPLAIN SELECT 'a', count(*) FROM csp_filter_key WHERE a > 1
+UNION ALL
+SELECT 'b', count(*) FROM csp_filter_key WHERE b > 1;
+----
+logical_opt	<!REGEX>:.*CTE.*
+
+query II
+EXPLAIN SELECT 'x', count(*) FROM csp_filter_key WHERE a > 1
+UNION ALL
+SELECT 'y', count(*) FROM csp_filter_key WHERE a > 1;
+----
+logical_opt	<REGEX>:.*CTE.*


### PR DESCRIPTION
  Fixes #23679.

  Table filter keys in `LogicalGet` refer to positions in `column_ids`. When the common subplan optimizer builds a canonical plan signature, it temporarily replaces `column_ids` with all table columns, but previously left the table filter keys
  unchanged.

  This could give filters on different base columns the same signature. For example, `a > 1` and `b > 1` could both use projection index `0`, causing one branch of a `UNION ALL` to reuse the wrong subplan.

  Remap table filter keys to their base column indexes while serializing the signature, then restore their original indexes afterward. If a unique reverse mapping cannot be constructed, common subplan materialization is skipped for that operator.

  The regression tests cover different filter columns, multiple filters, `IN` filters, and verify that identical filtered subplans can still be materialized.