### PR TITLE
Fix failed checkpoint marker recovery

### DIFF
--- a/src/storage/wal_replay.cpp
+++ b/src/storage/wal_replay.cpp
@@ -1359,7 +1359,7 @@ void WriteAheadLogDeserializer::ReplayUpdate() {
 
 void WriteAheadLogDeserializer::ReplayCheckpoint() {
 	if (state.checkpoint_position.IsValid()) {
-		throw InvalidInputException("WAL cannot contain more than one checkpoint marker");
+		throw DataCorruptionException("WAL cannot contain more than one checkpoint marker");
 	}
 	auto entry = WALCheckpoint::Deserialize(deserializer);
 	state.checkpoint_id = entry.meta_block;

--- a/src/storage/wal_replay.cpp
+++ b/src/storage/wal_replay.cpp
@@ -56,6 +56,7 @@ public:
 	idx_t wal_version = 1;
 	optional_idx current_position;
 	optional_idx checkpoint_position;
+	optional_idx checkpoint_end_position;
 	optional_idx expected_checkpoint_id;
 	WALReplayState replay_state;
 
@@ -293,6 +294,8 @@ private:
 	                                    WALReplayState replay_state = WALReplayState::MAIN_WAL);
 	void CopyOverWAL(BufferedFileReader &reader, FileHandle &target, data_ptr_t buffer, idx_t buffer_size,
 	                 idx_t copy_end);
+	void RemoveCheckpointFromWAL(const ReplayState &checkpoint_state, BufferedFileReader &main_wal_reader,
+	                             const string &recovery_path);
 	void MergeIntoRecoveryWAL(Connection &con, const ReplayState &checkpoint_state, BufferedFileReader &main_wal_reader,
 	                          const string &recovery_path, unique_ptr<FileHandle> checkpoint_handle);
 
@@ -346,6 +349,30 @@ void WriteAheadLogReplayer::CopyOverWAL(BufferedFileReader &reader, FileHandle &
 
 		target.Write(buffer, read_count);
 	}
+}
+
+void WriteAheadLogReplayer::RemoveCheckpointFromWAL(const ReplayState &checkpoint_state,
+                                                    BufferedFileReader &main_wal_reader, const string &recovery_path) {
+	D_ASSERT(checkpoint_state.checkpoint_position.IsValid());
+	D_ASSERT(checkpoint_state.checkpoint_end_position.IsValid());
+
+	auto recovery_handle =
+	    fs.OpenFile(recovery_path, FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE_NEW);
+
+	static constexpr idx_t BATCH_SIZE = Storage::DEFAULT_BLOCK_SIZE;
+	auto buffer = make_uniq_array<data_t>(BATCH_SIZE);
+
+	// Preserve every WAL entry except the failed checkpoint marker itself.
+	main_wal_reader.Reset();
+	CopyOverWAL(main_wal_reader, *recovery_handle, buffer.get(), BATCH_SIZE,
+	            checkpoint_state.checkpoint_position.GetIndex());
+	main_wal_reader.Seek(checkpoint_state.checkpoint_end_position.GetIndex());
+	CopyOverWAL(main_wal_reader, *recovery_handle, buffer.get(), BATCH_SIZE, main_wal_reader.FileSize());
+
+	recovery_handle->Sync();
+	recovery_handle.reset();
+	main_wal_reader.handle.reset();
+	fs.MoveFile(recovery_path, main_wal_path);
 }
 
 void WriteAheadLogReplayer::MergeIntoRecoveryWAL(Connection &con, const ReplayState &checkpoint_state,
@@ -430,7 +457,11 @@ unique_ptr<WriteAheadLog> WriteAheadLogReplayer::ReplayLog(unique_ptr<FileHandle
 			// read the current entry (deserialize only)
 			checkpoint_state.current_position = reader.CurrentOffset();
 			auto deserializer = WriteAheadLogDeserializer::GetEntryDeserializer(checkpoint_state, reader, true);
-			if (deserializer.ReplayEntry()) {
+			auto is_wal_flush = deserializer.ReplayEntry();
+			if (checkpoint_state.checkpoint_position.IsValid() && !checkpoint_state.checkpoint_end_position.IsValid()) {
+				checkpoint_state.checkpoint_end_position = reader.CurrentOffset();
+			}
+			if (is_wal_flush) {
 				// check if the file is exhausted
 				if (reader.Finished()) {
 					// we finished reading the file: break
@@ -451,7 +482,13 @@ unique_ptr<WriteAheadLog> WriteAheadLogReplayer::ReplayLog(unique_ptr<FileHandle
 		}
 	} // LCOV_EXCL_STOP
 	unique_ptr<FileHandle> checkpoint_handle;
-	if (checkpoint_state.checkpoint_id.IsValid()) {
+	unique_ptr<BufferedFileReader> rewritten_wal_reader;
+	bool remove_failed_checkpoint_marker = false;
+	// A serialization error can leave a partially deserialized checkpoint marker in the replay state. Only reconcile
+	// checkpoints after the complete marker entry has been consumed.
+	bool has_complete_checkpoint_marker =
+	    checkpoint_state.checkpoint_id.IsValid() && checkpoint_state.checkpoint_end_position.IsValid();
+	if (has_complete_checkpoint_marker) {
 		if (replay_state == WALReplayState::CHECKPOINT_WAL) {
 			throw InvalidInputException(
 			    "Failure while replaying checkpoint WAL file \"%s\": checkpoint WAL cannot contain a checkpoint marker",
@@ -471,6 +508,9 @@ unique_ptr<WriteAheadLog> WriteAheadLogReplayer::ReplayLog(unique_ptr<FileHandle
 			if (checkpoint_was_successful) {
 				// the contents of the WAL have already been checkpointed and there is no checkpoint WAL - we are done
 				return nullptr;
+			}
+			if (!storage_manager.GetAttached().IsReadOnly()) {
+				remove_failed_checkpoint_marker = true;
 			}
 		} else {
 			// we have a checkpoint WAL
@@ -512,12 +552,23 @@ unique_ptr<WriteAheadLog> WriteAheadLogReplayer::ReplayLog(unique_ptr<FileHandle
 		auto expected_id = checkpoint_state.expected_checkpoint_id.GetIndex();
 		WriteAheadLogDeserializer::ThrowVersionError(expected_id - 1, expected_id);
 	}
+	if (remove_failed_checkpoint_marker) {
+		// The checkpoint failed, but its marker cannot remain in a WAL that will become writable again.
+		auto recovery_path = database.GetStorageManager().GetRecoveryWALPath();
+		RemoveCheckpointFromWAL(checkpoint_state, reader, recovery_path);
+
+		// Open the rewritten WAL for replay.
+		auto main_handle = fs.OpenFile(wal_path, FileFlags::FILE_FLAGS_READ);
+		rewritten_wal_reader = make_uniq<BufferedFileReader>(fs, std::move(main_handle));
+	}
 
 	// we need to recover from the WAL: actually set up the replay state
 	ReplayState state(database, *con.context, replay_state);
 
-	// reset the reader - we are going to read the WAL from the beginning again
-	reader.Reset();
+	// Reset the reader - we are going to read the WAL from the beginning again. If we removed a failed checkpoint
+	// marker, use the reader for the rewritten WAL instead of the original file handle.
+	auto &wal_reader = rewritten_wal_reader ? *rewritten_wal_reader : reader;
+	wal_reader.Reset();
 
 	// replay the WAL
 	// note that everything is wrapped inside a try/catch block here
@@ -527,7 +578,7 @@ unique_ptr<WriteAheadLog> WriteAheadLogReplayer::ReplayLog(unique_ptr<FileHandle
 	try {
 		while (true) {
 			// read the current entry
-			auto deserializer = WriteAheadLogDeserializer::GetEntryDeserializer(state, reader);
+			auto deserializer = WriteAheadLogDeserializer::GetEntryDeserializer(state, wal_reader);
 			if (deserializer.ReplayEntry()) {
 				con.Commit();
 
@@ -537,9 +588,9 @@ unique_ptr<WriteAheadLog> WriteAheadLogReplayer::ReplayLog(unique_ptr<FileHandle
 				}
 				state.replay_index_infos.clear();
 
-				successful_offset = reader.CurrentOffset();
+				successful_offset = wal_reader.CurrentOffset();
 				// check if the file is exhausted
-				if (reader.Finished()) {
+				if (wal_reader.Finished()) {
 					// we finished reading the file: break
 					all_succeeded = true;
 					break;
@@ -1307,6 +1358,9 @@ void WriteAheadLogDeserializer::ReplayUpdate() {
 }
 
 void WriteAheadLogDeserializer::ReplayCheckpoint() {
+	if (state.checkpoint_position.IsValid()) {
+		throw InvalidInputException("WAL cannot contain more than one checkpoint marker");
+	}
 	auto entry = WALCheckpoint::Deserialize(deserializer);
 	state.checkpoint_id = entry.meta_block;
 	state.checkpoint_position = state.current_position;

--- a/src/storage/wal_replay.cpp
+++ b/src/storage/wal_replay.cpp
@@ -1,12 +1,15 @@
 #include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
 #include "duckdb/catalog/duck_catalog.hpp"
+#include "duckdb/common/assert.hpp"
 #include "duckdb/common/checksum.hpp"
 #include "duckdb/common/encryption_functions.hpp"
 #include "duckdb/common/encryption_key_manager.hpp"
+#include "duckdb/common/numeric_utils.hpp"
 #include "duckdb/common/serializer/binary_deserializer.hpp"
 #include "duckdb/common/serializer/buffered_file_reader.hpp"
 #include "duckdb/common/serializer/memory_stream.hpp"
+#include "duckdb/common/vector_size.hpp"
 #include "duckdb/common/enums/checkpoint_abort.hpp"
 #include "duckdb/execution/index/art/art.hpp"
 #include "duckdb/execution/index/index_type_set.hpp"
@@ -294,8 +297,6 @@ private:
 	                                    WALReplayState replay_state = WALReplayState::MAIN_WAL);
 	void CopyOverWAL(BufferedFileReader &reader, FileHandle &target, data_ptr_t buffer, idx_t buffer_size,
 	                 idx_t copy_end);
-	void RemoveCheckpointFromWAL(const ReplayState &checkpoint_state, BufferedFileReader &main_wal_reader,
-	                             const string &recovery_path);
 	void MergeIntoRecoveryWAL(Connection &con, const ReplayState &checkpoint_state, BufferedFileReader &main_wal_reader,
 	                          const string &recovery_path, unique_ptr<FileHandle> checkpoint_handle);
 
@@ -349,30 +350,6 @@ void WriteAheadLogReplayer::CopyOverWAL(BufferedFileReader &reader, FileHandle &
 
 		target.Write(buffer, read_count);
 	}
-}
-
-void WriteAheadLogReplayer::RemoveCheckpointFromWAL(const ReplayState &checkpoint_state,
-                                                    BufferedFileReader &main_wal_reader, const string &recovery_path) {
-	D_ASSERT(checkpoint_state.checkpoint_position.IsValid());
-	D_ASSERT(checkpoint_state.checkpoint_end_position.IsValid());
-
-	auto recovery_handle =
-	    fs.OpenFile(recovery_path, FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE_NEW);
-
-	static constexpr idx_t BATCH_SIZE = Storage::DEFAULT_BLOCK_SIZE;
-	auto buffer = make_uniq_array<data_t>(BATCH_SIZE);
-
-	// Preserve every WAL entry except the failed checkpoint marker itself.
-	main_wal_reader.Reset();
-	CopyOverWAL(main_wal_reader, *recovery_handle, buffer.get(), BATCH_SIZE,
-	            checkpoint_state.checkpoint_position.GetIndex());
-	main_wal_reader.Seek(checkpoint_state.checkpoint_end_position.GetIndex());
-	CopyOverWAL(main_wal_reader, *recovery_handle, buffer.get(), BATCH_SIZE, main_wal_reader.FileSize());
-
-	recovery_handle->Sync();
-	recovery_handle.reset();
-	main_wal_reader.handle.reset();
-	fs.MoveFile(recovery_path, main_wal_path);
 }
 
 void WriteAheadLogReplayer::MergeIntoRecoveryWAL(Connection &con, const ReplayState &checkpoint_state,
@@ -450,6 +427,8 @@ unique_ptr<WriteAheadLog> WriteAheadLogReplayer::ReplayLog(unique_ptr<FileHandle
 	// first deserialize the WAL to look for a checkpoint flag
 	// if there is a checkpoint flag, we might have already flushed the contents of the WAL to disk
 	ReplayState checkpoint_state(database, *con.context, replay_state);
+	idx_t last_wal_flush_end = 0;
+	idx_t checkpoint_truncate_offset = 0;
 	try {
 		idx_t replay_entry_count = 0;
 		while (true) {
@@ -460,8 +439,10 @@ unique_ptr<WriteAheadLog> WriteAheadLogReplayer::ReplayLog(unique_ptr<FileHandle
 			auto is_wal_flush = deserializer.ReplayEntry();
 			if (checkpoint_state.checkpoint_position.IsValid() && !checkpoint_state.checkpoint_end_position.IsValid()) {
 				checkpoint_state.checkpoint_end_position = reader.CurrentOffset();
+				checkpoint_truncate_offset = last_wal_flush_end;
 			}
 			if (is_wal_flush) {
+				last_wal_flush_end = reader.CurrentOffset();
 				// check if the file is exhausted
 				if (reader.Finished()) {
 					// we finished reading the file: break
@@ -482,17 +463,21 @@ unique_ptr<WriteAheadLog> WriteAheadLogReplayer::ReplayLog(unique_ptr<FileHandle
 		}
 	} // LCOV_EXCL_STOP
 	unique_ptr<FileHandle> checkpoint_handle;
-	unique_ptr<BufferedFileReader> rewritten_wal_reader;
-	bool remove_failed_checkpoint_marker = false;
+	bool truncate_failed_checkpoint_marker = false;
 	// A serialization error can leave a partially deserialized checkpoint marker in the replay state. Only reconcile
 	// checkpoints after the complete marker entry has been consumed.
-	bool has_complete_checkpoint_marker =
-	    checkpoint_state.checkpoint_id.IsValid() && checkpoint_state.checkpoint_end_position.IsValid();
-	if (has_complete_checkpoint_marker) {
+	if (checkpoint_state.checkpoint_id.IsValid() && checkpoint_state.checkpoint_end_position.IsValid()) {
 		if (replay_state == WALReplayState::CHECKPOINT_WAL) {
 			throw InvalidInputException(
 			    "Failure while replaying checkpoint WAL file \"%s\": checkpoint WAL cannot contain a checkpoint marker",
 			    wal_path);
+		}
+		auto checkpoint_end = checkpoint_state.checkpoint_end_position.GetIndex();
+		// The scan stops at either the final WAL_FLUSH or a torn tail. In both cases, current_position is the start of
+		// the final entry attempt. It must directly follow the checkpoint marker.
+		bool checkpoint_marker_at_end = checkpoint_state.current_position.GetIndex() == checkpoint_end;
+		if (!checkpoint_marker_at_end) {
+			throw DataCorruptionException("WAL checkpoint marker must be at the end of the WAL");
 		}
 		// there is a checkpoint flag
 		// this means a checkpoint was on-going when we crashed
@@ -510,7 +495,7 @@ unique_ptr<WriteAheadLog> WriteAheadLogReplayer::ReplayLog(unique_ptr<FileHandle
 				return nullptr;
 			}
 			if (!storage_manager.GetAttached().IsReadOnly()) {
-				remove_failed_checkpoint_marker = true;
+				truncate_failed_checkpoint_marker = true;
 			}
 		} else {
 			// we have a checkpoint WAL
@@ -552,22 +537,27 @@ unique_ptr<WriteAheadLog> WriteAheadLogReplayer::ReplayLog(unique_ptr<FileHandle
 		auto expected_id = checkpoint_state.expected_checkpoint_id.GetIndex();
 		WriteAheadLogDeserializer::ThrowVersionError(expected_id - 1, expected_id);
 	}
-	if (remove_failed_checkpoint_marker) {
-		// The checkpoint failed, but its marker cannot remain in a WAL that will become writable again.
-		auto recovery_path = database.GetStorageManager().GetRecoveryWALPath();
-		RemoveCheckpointFromWAL(checkpoint_state, reader, recovery_path);
+	unique_ptr<BufferedFileReader> truncated_wal_reader;
+	if (truncate_failed_checkpoint_marker) {
+		// The failed checkpoint marker is the logical end of the WAL and must not become writable again. Truncate to
+		// the preceding commit boundary, which is zero if the WAL only contained its header before the marker.
+		reader.handle.reset();
+		auto truncate_handle = fs.OpenFile(wal_path, FileFlags::FILE_FLAGS_WRITE);
+		fs.Truncate(*truncate_handle, NumericCast<int64_t>(checkpoint_truncate_offset));
+		truncate_handle->Sync();
+		truncate_handle.reset();
 
-		// Open the rewritten WAL for replay.
+		if (checkpoint_truncate_offset == 0) {
+			return make_uniq<WriteAheadLog>(storage_manager, wal_path);
+		}
 		auto main_handle = fs.OpenFile(wal_path, FileFlags::FILE_FLAGS_READ);
-		rewritten_wal_reader = make_uniq<BufferedFileReader>(fs, std::move(main_handle));
+		truncated_wal_reader = make_uniq<BufferedFileReader>(fs, std::move(main_handle));
 	}
-
 	// we need to recover from the WAL: actually set up the replay state
 	ReplayState state(database, *con.context, replay_state);
 
-	// Reset the reader - we are going to read the WAL from the beginning again. If we removed a failed checkpoint
-	// marker, use the reader for the rewritten WAL instead of the original file handle.
-	auto &wal_reader = rewritten_wal_reader ? *rewritten_wal_reader : reader;
+	// reset the reader - we are going to read the WAL from the beginning again
+	auto &wal_reader = truncated_wal_reader ? *truncated_wal_reader : reader;
 	wal_reader.Reset();
 
 	// replay the WAL

--- a/test/sql/storage/CMakeLists.txt
+++ b/test/sql/storage/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library_unity(
   test_checksum.cpp
   test_storage.cpp
   test_database_size.cpp
+  wal_checkpoint_marker.cpp
   wal_torn_write.cpp)
 set(UNITTEST_OBJECT_FILES
     ${UNITTEST_OBJECT_FILES} $<TARGET_OBJECTS:test_sql_storage>

--- a/test/sql/storage/concurrent_wal/double_interrupted_checkpoint.test_slow
+++ b/test/sql/storage/concurrent_wal/double_interrupted_checkpoint.test_slow
@@ -1,0 +1,104 @@
+# name: test/sql/storage/concurrent_wal/double_interrupted_checkpoint.test_slow
+# description: Test recovery after two interrupted checkpoints where the second has a concurrent commit
+# group: [concurrent_wal]
+
+statement ok
+ATTACH '{TEST_DIR}/double_interrupted_checkpoint.db' AS db
+
+statement ok
+SET wal_autocheckpoint = '1TB'
+
+statement ok
+PRAGMA disable_checkpoint_on_shutdown
+
+statement ok
+CREATE TABLE db.t(i BIGINT)
+
+statement ok
+INSERT INTO db.t SELECT * FROM range(10)
+
+statement ok
+CHECKPOINT db
+
+restart
+
+statement ok
+ATTACH '{TEST_DIR}/double_interrupted_checkpoint.db' AS db
+
+statement ok
+SET wal_autocheckpoint = '1TB'
+
+statement ok
+PRAGMA disable_checkpoint_on_shutdown
+
+statement ok
+INSERT INTO db.t VALUES (10)
+
+statement ok
+PRAGMA debug_checkpoint_abort = 'before_header'
+
+statement error
+CHECKPOINT db
+----
+Checkpoint aborted before header write
+
+restart
+
+query I
+SELECT count(*) FROM glob('{TEST_DIR}/double_interrupted_checkpoint.db.wal*')
+----
+1
+
+statement ok
+ATTACH '{TEST_DIR}/double_interrupted_checkpoint.db' AS db
+
+statement ok
+SET wal_autocheckpoint = '1TB'
+
+statement ok
+PRAGMA disable_checkpoint_on_shutdown
+
+statement ok
+SET debug_checkpoint_sleep_ms = 500
+
+statement ok
+PRAGMA debug_checkpoint_abort = 'before_header'
+
+concurrentloop threadid 0 2
+
+onlyif threadid=0
+statement ok
+SELECT sleep_ms(200)
+
+onlyif threadid=1
+statement ok
+SELECT sleep_ms(100)
+
+onlyif threadid=1
+statement ok
+INSERT INTO db.t
+SELECT 11
+WHERE sleep_ms(300) IS NULL
+
+onlyif threadid=0
+statement error
+CHECKPOINT db
+----
+Checkpoint aborted before header write
+
+endloop
+
+restart
+
+query I
+SELECT count(*) FROM glob('{TEST_DIR}/double_interrupted_checkpoint.db.wal*')
+----
+2
+
+statement ok
+ATTACH '{TEST_DIR}/double_interrupted_checkpoint.db' AS db
+
+query I
+SELECT count(*) FROM db.t
+----
+12

--- a/test/sql/storage/wal_checkpoint_marker.cpp
+++ b/test/sql/storage/wal_checkpoint_marker.cpp
@@ -1,5 +1,6 @@
 #include "catch.hpp"
 #include "duckdb/common/enums/wal_type.hpp"
+#include "duckdb/common/exception.hpp"
 #include "duckdb/common/local_file_system.hpp"
 #include "duckdb/common/serializer/binary_serializer.hpp"
 #include "duckdb/common/serializer/buffered_file_writer.hpp"
@@ -215,6 +216,7 @@ TEST_CASE("Reject multiple checkpoint markers before changing WAL files", "[stor
 		DuckDB db(database_path, config.get());
 	} catch (std::exception &ex) {
 		threw = true;
+		REQUIRE(ErrorData(ex).Type() == ExceptionType::DATA_CORRUPTION);
 		REQUIRE(StringUtil::Contains(ex.what(), "WAL cannot contain more than one checkpoint marker"));
 	}
 	REQUIRE(threw);

--- a/test/sql/storage/wal_checkpoint_marker.cpp
+++ b/test/sql/storage/wal_checkpoint_marker.cpp
@@ -45,21 +45,25 @@ static void WriteTornLegacyCheckpointMarker(FileSystem &fs, const string &path) 
 	writer.Sync();
 }
 
-static void WriteCheckpointMarkers(DuckDB &db, Connection &con, idx_t count) {
+static idx_t WriteCheckpointMarkers(DuckDB &db, Connection &con, idx_t count) {
 	auto database_name = DatabaseManager::GetDefaultDatabase(*con.context);
 	auto attached_database = db.instance->GetDatabaseManager().GetDatabase(database_name);
 	REQUIRE(attached_database);
 	auto wal = attached_database->GetStorageManager().GetWAL();
 	REQUIRE(wal);
+	REQUIRE(count > 0);
 
+	idx_t marker_end = 0;
 	for (idx_t marker_idx = 0; marker_idx < count; marker_idx++) {
 		// These deliberately do not match the current database root, which models an unsuccessful checkpoint.
 		wal->WriteCheckpoint(MetaBlockPointer(1000000 + marker_idx, 0));
+		marker_end = wal->Initialize().GetFileSize();
 		wal->Flush();
 	}
+	return marker_end;
 }
 
-TEST_CASE("Remove a failed checkpoint marker before making its WAL writable", "[storage][wal]") {
+TEST_CASE("Truncate a failed checkpoint marker before making its WAL writable", "[storage][wal]") {
 	auto config = GetTestConfig();
 	config->options.checkpoint_wal_size = idx_t(-1);
 	config->options.checkpoint_on_shutdown = false;
@@ -77,7 +81,6 @@ TEST_CASE("Remove a failed checkpoint marker before making its WAL writable", "[
 		REQUIRE_NO_FAIL(con.Query("CHECKPOINT"));
 		REQUIRE_NO_FAIL(con.Query("INSERT INTO integers VALUES (42)"));
 		WriteCheckpointMarkers(db, con, 1);
-		REQUIRE_NO_FAIL(con.Query("INSERT INTO integers VALUES (84)"));
 	}
 
 	REQUIRE(fs.FileExists(wal_path));
@@ -89,7 +92,7 @@ TEST_CASE("Remove a failed checkpoint marker before making its WAL writable", "[
 		Connection con(db);
 		auto result = con.Query("SELECT * FROM integers ORDER BY i");
 		REQUIRE_FALSE(result->HasError());
-		REQUIRE(CHECK_COLUMN(result, 0, {42, 84}));
+		REQUIRE(CHECK_COLUMN(result, 0, {42}));
 	}
 
 	auto wal_size_without_marker = fs.GetFileSize(*fs.OpenFile(wal_path, FileFlags::FILE_FLAGS_READ));
@@ -98,6 +101,90 @@ TEST_CASE("Remove a failed checkpoint marker before making its WAL writable", "[
 
 	DeleteDatabase(database_path);
 	RemoveCheckpointRecoveryFiles(fs, database_path);
+}
+
+TEST_CASE("Reject a checkpoint marker that is not at the end of the WAL", "[storage][wal]") {
+	auto config = GetTestConfig();
+	config->options.checkpoint_wal_size = idx_t(-1);
+	config->options.checkpoint_on_shutdown = false;
+
+	auto database_path = TestCreatePath("checkpoint_marker_not_at_end");
+	auto wal_path = database_path + ".wal";
+	LocalFileSystem fs;
+	DeleteDatabase(database_path);
+	RemoveCheckpointRecoveryFiles(fs, database_path);
+
+	{
+		DuckDB db(database_path, config.get());
+		Connection con(db);
+		REQUIRE_NO_FAIL(con.Query("CREATE TABLE integers(i INTEGER)"));
+		REQUIRE_NO_FAIL(con.Query("CHECKPOINT"));
+		REQUIRE_NO_FAIL(con.Query("INSERT INTO integers VALUES (42)"));
+		WriteCheckpointMarkers(db, con, 1);
+		REQUIRE_NO_FAIL(con.Query("INSERT INTO integers VALUES (84)"));
+	}
+	auto wal_contents = ReadFile(fs, wal_path);
+
+	bool threw = false;
+	try {
+		DuckDB db(database_path, config.get());
+	} catch (std::exception &ex) {
+		threw = true;
+		REQUIRE(ErrorData(ex).Type() == ExceptionType::DATA_CORRUPTION);
+		REQUIRE(StringUtil::Contains(ex.what(), "WAL checkpoint marker must be at the end of the WAL"));
+	}
+	REQUIRE(threw);
+
+	REQUIRE(ReadFile(fs, wal_path) == wal_contents);
+	REQUIRE_FALSE(fs.FileExists(database_path + ".wal.recovery"));
+
+	DeleteDatabase(database_path);
+	RemoveCheckpointRecoveryFiles(fs, database_path);
+}
+
+TEST_CASE("Recover a missing or torn WAL flush following a checkpoint marker", "[storage][wal]") {
+	auto config = GetTestConfig();
+	config->options.checkpoint_wal_size = idx_t(-1);
+	config->options.checkpoint_on_shutdown = false;
+	config->options.abort_on_wal_failure = false;
+
+	LocalFileSystem fs;
+	for (idx_t flush_bytes = 0; flush_bytes <= 1; flush_bytes++) {
+		auto database_path = TestCreatePath("torn_checkpoint_flush_" + to_string(flush_bytes));
+		auto wal_path = database_path + ".wal";
+		DeleteDatabase(database_path);
+		RemoveCheckpointRecoveryFiles(fs, database_path);
+
+		idx_t marker_end;
+		{
+			DuckDB db(database_path, config.get());
+			Connection con(db);
+			REQUIRE_NO_FAIL(con.Query("CREATE TABLE integers(i INTEGER)"));
+			REQUIRE_NO_FAIL(con.Query("CHECKPOINT"));
+			REQUIRE_NO_FAIL(con.Query("INSERT INTO integers VALUES (42)"));
+			marker_end = WriteCheckpointMarkers(db, con, 1);
+		}
+
+		auto wal_handle = fs.OpenFile(wal_path, FileFlags::FILE_FLAGS_WRITE);
+		REQUIRE(marker_end + flush_bytes < wal_handle->GetFileSize());
+		fs.Truncate(*wal_handle, marker_end + flush_bytes);
+		wal_handle->Sync();
+		wal_handle.reset();
+
+		{
+			DuckDB db(database_path, config.get());
+			Connection con(db);
+			auto result = con.Query("SELECT * FROM integers ORDER BY i");
+			REQUIRE_FALSE(result->HasError());
+			REQUIRE(CHECK_COLUMN(result, 0, {42}));
+		}
+
+		REQUIRE(fs.GetFileSize(*fs.OpenFile(wal_path, FileFlags::FILE_FLAGS_READ)) < marker_end);
+		REQUIRE_FALSE(fs.FileExists(database_path + ".wal.recovery"));
+
+		DeleteDatabase(database_path);
+		RemoveCheckpointRecoveryFiles(fs, database_path);
+	}
 }
 
 TEST_CASE("Treat an incomplete checkpoint marker as a torn WAL entry", "[storage][wal]") {
@@ -136,7 +223,7 @@ TEST_CASE("Treat an incomplete checkpoint marker as a torn WAL entry", "[storage
 	RemoveCheckpointRecoveryFiles(fs, database_path);
 }
 
-TEST_CASE("Reject a mismatched WAL generation before removing its checkpoint marker", "[storage][wal]") {
+TEST_CASE("Reject a mismatched WAL generation before truncating its checkpoint marker", "[storage][wal]") {
 	auto config = GetTestConfig();
 	config->options.checkpoint_wal_size = idx_t(-1);
 	config->options.checkpoint_on_shutdown = false;

--- a/test/sql/storage/wal_checkpoint_marker.cpp
+++ b/test/sql/storage/wal_checkpoint_marker.cpp
@@ -1,0 +1,229 @@
+#include "catch.hpp"
+#include "duckdb/common/enums/wal_type.hpp"
+#include "duckdb/common/local_file_system.hpp"
+#include "duckdb/common/serializer/binary_serializer.hpp"
+#include "duckdb/common/serializer/buffered_file_writer.hpp"
+#include "duckdb/main/attached_database.hpp"
+#include "duckdb/main/database_manager.hpp"
+#include "duckdb/storage/storage_manager.hpp"
+#include "duckdb/storage/write_ahead_log.hpp"
+#include "test_helpers.hpp"
+
+using namespace duckdb;
+
+static void RemoveCheckpointRecoveryFiles(FileSystem &fs, const string &database_path) {
+	fs.TryRemoveFile(database_path + ".wal.checkpoint");
+	fs.TryRemoveFile(database_path + ".wal.recovery");
+}
+
+static duckdb::vector<data_t> ReadFile(FileSystem &fs, const string &path) {
+	auto handle = fs.OpenFile(path, FileFlags::FILE_FLAGS_READ);
+	auto size = handle->GetFileSize();
+	duckdb::vector<data_t> result(size);
+	if (size > 0) {
+		handle->Read(QueryContext(), result.data(), size, 0);
+	}
+	return result;
+}
+
+static void WriteFile(FileSystem &fs, const string &path, const duckdb::vector<data_t> &contents) {
+	BufferedFileWriter writer(fs, path, FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE_NEW);
+	if (!contents.empty()) {
+		writer.WriteData(contents.data(), contents.size());
+	}
+	writer.Sync();
+}
+
+static void WriteTornLegacyCheckpointMarker(FileSystem &fs, const string &path) {
+	BufferedFileWriter writer(fs, path, FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE_NEW);
+	BinarySerializer serializer(writer);
+	serializer.Begin();
+	serializer.WriteProperty(100, "wal_type", WALType::CHECKPOINT);
+	serializer.WriteProperty(101, "meta_block", MetaBlockPointer(1000000, 0));
+	// Deliberately omit serializer.End() to model a torn WAL v1 checkpoint entry.
+	writer.Sync();
+}
+
+static void WriteCheckpointMarkers(DuckDB &db, Connection &con, idx_t count) {
+	auto database_name = DatabaseManager::GetDefaultDatabase(*con.context);
+	auto attached_database = db.instance->GetDatabaseManager().GetDatabase(database_name);
+	REQUIRE(attached_database);
+	auto wal = attached_database->GetStorageManager().GetWAL();
+	REQUIRE(wal);
+
+	for (idx_t marker_idx = 0; marker_idx < count; marker_idx++) {
+		// These deliberately do not match the current database root, which models an unsuccessful checkpoint.
+		wal->WriteCheckpoint(MetaBlockPointer(1000000 + marker_idx, 0));
+		wal->Flush();
+	}
+}
+
+TEST_CASE("Remove a failed checkpoint marker before making its WAL writable", "[storage][wal]") {
+	auto config = GetTestConfig();
+	config->options.checkpoint_wal_size = idx_t(-1);
+	config->options.checkpoint_on_shutdown = false;
+
+	auto database_path = TestCreatePath("failed_checkpoint_marker");
+	auto wal_path = database_path + ".wal";
+	LocalFileSystem fs;
+	DeleteDatabase(database_path);
+	RemoveCheckpointRecoveryFiles(fs, database_path);
+
+	{
+		DuckDB db(database_path, config.get());
+		Connection con(db);
+		REQUIRE_NO_FAIL(con.Query("CREATE TABLE integers(i INTEGER)"));
+		REQUIRE_NO_FAIL(con.Query("CHECKPOINT"));
+		REQUIRE_NO_FAIL(con.Query("INSERT INTO integers VALUES (42)"));
+		WriteCheckpointMarkers(db, con, 1);
+		REQUIRE_NO_FAIL(con.Query("INSERT INTO integers VALUES (84)"));
+	}
+
+	REQUIRE(fs.FileExists(wal_path));
+	REQUIRE_FALSE(fs.FileExists(database_path + ".wal.checkpoint"));
+	auto wal_size_with_marker = fs.GetFileSize(*fs.OpenFile(wal_path, FileFlags::FILE_FLAGS_READ));
+
+	{
+		DuckDB db(database_path, config.get());
+		Connection con(db);
+		auto result = con.Query("SELECT * FROM integers ORDER BY i");
+		REQUIRE_FALSE(result->HasError());
+		REQUIRE(CHECK_COLUMN(result, 0, {42, 84}));
+	}
+
+	auto wal_size_without_marker = fs.GetFileSize(*fs.OpenFile(wal_path, FileFlags::FILE_FLAGS_READ));
+	REQUIRE(wal_size_without_marker < wal_size_with_marker);
+	REQUIRE_FALSE(fs.FileExists(database_path + ".wal.recovery"));
+
+	DeleteDatabase(database_path);
+	RemoveCheckpointRecoveryFiles(fs, database_path);
+}
+
+TEST_CASE("Treat an incomplete checkpoint marker as a torn WAL entry", "[storage][wal]") {
+	auto config = GetTestConfig();
+	config->options.checkpoint_wal_size = idx_t(-1);
+	config->options.checkpoint_on_shutdown = false;
+	config->options.abort_on_wal_failure = false;
+
+	auto database_path = TestCreatePath("torn_checkpoint_marker");
+	auto wal_path = database_path + ".wal";
+	LocalFileSystem fs;
+	DeleteDatabase(database_path);
+	RemoveCheckpointRecoveryFiles(fs, database_path);
+
+	{
+		DuckDB db(database_path, config.get());
+		Connection con(db);
+		REQUIRE_NO_FAIL(con.Query("CREATE TABLE integers(i INTEGER)"));
+		REQUIRE_NO_FAIL(con.Query("CHECKPOINT"));
+	}
+	WriteTornLegacyCheckpointMarker(fs, wal_path);
+	auto torn_wal_contents = ReadFile(fs, wal_path);
+
+	{
+		DuckDB db(database_path, config.get());
+		Connection con(db);
+		auto result = con.Query("SELECT COUNT(*) FROM integers");
+		REQUIRE_FALSE(result->HasError());
+		REQUIRE(CHECK_COLUMN(result, 0, {0}));
+	}
+
+	REQUIRE(ReadFile(fs, wal_path) == torn_wal_contents);
+	REQUIRE_FALSE(fs.FileExists(database_path + ".wal.recovery"));
+
+	DeleteDatabase(database_path);
+	RemoveCheckpointRecoveryFiles(fs, database_path);
+}
+
+TEST_CASE("Reject a mismatched WAL generation before removing its checkpoint marker", "[storage][wal]") {
+	auto config = GetTestConfig();
+	config->options.checkpoint_wal_size = idx_t(-1);
+	config->options.checkpoint_on_shutdown = false;
+	config->options.storage_compatibility = StorageCompatibility::FromString("v1.4.0");
+
+	auto database_path = TestCreatePath("mismatched_checkpoint_marker");
+	auto wal_path = database_path + ".wal";
+	LocalFileSystem fs;
+	DeleteDatabase(database_path);
+	RemoveCheckpointRecoveryFiles(fs, database_path);
+
+	{
+		DuckDB db(database_path, config.get());
+		Connection con(db);
+		REQUIRE_NO_FAIL(con.Query("CREATE TABLE integers(i INTEGER)"));
+		REQUIRE_NO_FAIL(con.Query("CHECKPOINT"));
+		REQUIRE_NO_FAIL(con.Query("INSERT INTO integers VALUES (42)"));
+		WriteCheckpointMarkers(db, con, 1);
+	}
+	auto old_wal_contents = ReadFile(fs, wal_path);
+
+	// Recover this WAL and advance the database to the next checkpoint generation.
+	{
+		DuckDB db(database_path, config.get());
+		Connection con(db);
+		REQUIRE_NO_FAIL(con.Query("CHECKPOINT"));
+	}
+	WriteFile(fs, wal_path, old_wal_contents);
+
+	bool threw = false;
+	try {
+		DuckDB db(database_path, config.get());
+	} catch (std::exception &ex) {
+		threw = true;
+		REQUIRE(StringUtil::Contains(ex.what(), "older version"));
+	}
+	REQUIRE(threw);
+
+	REQUIRE(ReadFile(fs, wal_path) == old_wal_contents);
+	REQUIRE_FALSE(fs.FileExists(database_path + ".wal.recovery"));
+
+	DeleteDatabase(database_path);
+	RemoveCheckpointRecoveryFiles(fs, database_path);
+}
+
+TEST_CASE("Reject multiple checkpoint markers before changing WAL files", "[storage][wal]") {
+	auto config = GetTestConfig();
+	config->options.checkpoint_wal_size = idx_t(-1);
+	config->options.checkpoint_on_shutdown = false;
+
+	auto database_path = TestCreatePath("multiple_checkpoint_markers");
+	auto wal_path = database_path + ".wal";
+	auto checkpoint_wal_path = database_path + ".wal.checkpoint";
+	auto recovery_wal_path = database_path + ".wal.recovery";
+	LocalFileSystem fs;
+	DeleteDatabase(database_path);
+	RemoveCheckpointRecoveryFiles(fs, database_path);
+
+	{
+		DuckDB db(database_path, config.get());
+		Connection con(db);
+		REQUIRE_NO_FAIL(con.Query("CREATE TABLE integers(i INTEGER)"));
+		REQUIRE_NO_FAIL(con.Query("CHECKPOINT"));
+		REQUIRE_NO_FAIL(con.Query("INSERT INTO integers VALUES (42)"));
+		WriteCheckpointMarkers(db, con, 2);
+	}
+
+	auto main_wal_contents = ReadFile(fs, wal_path);
+	{
+		auto checkpoint_handle =
+		    fs.OpenFile(checkpoint_wal_path, FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE_NEW);
+		checkpoint_handle->Sync();
+	}
+
+	bool threw = false;
+	try {
+		DuckDB db(database_path, config.get());
+	} catch (std::exception &ex) {
+		threw = true;
+		REQUIRE(StringUtil::Contains(ex.what(), "WAL cannot contain more than one checkpoint marker"));
+	}
+	REQUIRE(threw);
+
+	REQUIRE(ReadFile(fs, wal_path) == main_wal_contents);
+	REQUIRE(fs.FileExists(checkpoint_wal_path));
+	REQUIRE(fs.GetFileSize(*fs.OpenFile(checkpoint_wal_path, FileFlags::FILE_FLAGS_READ)) == 0);
+	REQUIRE_FALSE(fs.FileExists(recovery_wal_path));
+
+	DeleteDatabase(database_path);
+	RemoveCheckpointRecoveryFiles(fs, database_path);
+}


### PR DESCRIPTION
**Problem**
The checkpoint marker is written to the main WAL first, while the `.wal.checkpoint` file is created lazily when concurrent transactions are present. 

If the checkpoint does not complete and the `.wal.checkpoint` file has not yet been created, recovery replays the main WAL, but the original implementation leaves the failed marker in place.

Once the main WAL becomes writable again after recovery, a subsequent checkpoint may write a second marker, corrupting the recovery boundary.

**Fix**
Remove the failed marker!
- Track the start and end offsets of each complete checkpoint marker.
- After validating the WAL generation, use `.wal.recovery` to remove the failed marker while preserving transactions before and after it.
- Continue treating incomplete markers as a torn WAL.
- If multiple markers are found, fail immediately before modifying any files.

**Other && TODO**
Creating `.wal.checkpoint` earlier could reduce the likelihood of this state, but it would affect persistence ordering, empty-file cleanup, and `Initialized()` semantics.

It would also not handle WAL files left behind by older versions. For this reason, this change preserves lazy creation and fixes the recovery logic instead.