### PR TITLE
Add `Upper`, `Lower` and `StartsWith` helpers to `Identifier`

### DIFF
--- a/extension/core_functions/scalar/debug/index_key.cpp
+++ b/extension/core_functions/scalar/debug/index_key.cpp
@@ -29,7 +29,7 @@ static TableDescription ExtractTableDescription(const child_list_t<LogicalType> 
 	fields["table"] = "";
 
 	for (idx_t i = 0; i < field_types.size(); i++) {
-		auto field_name = StringUtil::Lower(field_types[i].first.GetIdentifierName());
+		auto field_name = field_types[i].first.Lower();
 
 		if (fields.find(field_name) == fields.end()) {
 			throw BinderException("index_key: unknown field '%s' in path", field_types[i].first.GetIdentifierName());

--- a/extension/parquet/parquet_extension.cpp
+++ b/extension/parquet/parquet_extension.cpp
@@ -239,8 +239,7 @@ static unique_ptr<FunctionData> ParquetWriteBind(ClientContext &context, CopyFun
 				const auto &struct_children = StructValue::GetChildren(shredding_types_value);
 				D_ASSERT(StructType::GetChildTypes(struct_type).size() == struct_children.size());
 				for (idx_t i = 0; i < struct_children.size(); i++) {
-					const auto &col_name =
-					    StringUtil::Lower(StructType::GetChildName(struct_type, i).GetIdentifierName());
+					const auto &col_name = StructType::GetChildName(struct_type, i).Lower();
 					auto it = variant_names.find(Identifier(col_name));
 					if (it == variant_names.end()) {
 						string names;

--- a/extension/parquet/parquet_field_id.cpp
+++ b/extension/parquet/parquet_field_id.cpp
@@ -141,7 +141,7 @@ void FieldID::GetFieldIDs(const Value &field_ids_value, ChildFieldIDs &field_ids
 	const auto &struct_children = StructValue::GetChildren(field_ids_value);
 	D_ASSERT(StructType::GetChildTypes(struct_type).size() == struct_children.size());
 	for (idx_t i = 0; i < struct_children.size(); i++) {
-		const auto &col_name = StringUtil::Lower(StructType::GetChildName(struct_type, i).GetIdentifierName());
+		const auto &col_name = StructType::GetChildName(struct_type, i).Lower();
 		if (col_name == FieldID::DUCKDB_FIELD_ID) {
 			continue;
 		}

--- a/src/catalog/default/default_schemas.cpp
+++ b/src/catalog/default/default_schemas.cpp
@@ -27,8 +27,7 @@ unique_ptr<CatalogEntry> DefaultSchemaGenerator::CreateDefaultEntry(CatalogTrans
                                                                     const Identifier &entry_name) {
 	if (IsDefaultSchema(entry_name)) {
 		CreateSchemaInfo info;
-		info.SetQualifiedName(
-		    QualifiedName({Identifier(StringUtil::Lower(entry_name.GetIdentifierName()))}, Identifier()));
+		info.SetQualifiedName(QualifiedName({Identifier(entry_name.Lower())}, Identifier()));
 		info.internal = true;
 		return make_uniq_base<CatalogEntry, DuckSchemaEntry>(catalog, info);
 	}

--- a/src/catalog/default/default_views.cpp
+++ b/src/catalog/default/default_views.cpp
@@ -222,8 +222,8 @@ static const DefaultView internal_views[] = {
 
 static unique_ptr<CreateViewInfo> GetDefaultView(ClientContext &context, const Identifier &input_schema,
                                                  const Identifier &input_name) {
-	auto schema = StringUtil::Lower(input_schema.GetIdentifierName());
-	auto name = StringUtil::Lower(input_name.GetIdentifierName());
+	auto schema = input_schema.Lower();
+	auto name = input_name.Lower();
 	for (idx_t index = 0; internal_views[index].name != nullptr; index++) {
 		if (internal_views[index].schema == schema && internal_views[index].name == name) {
 			auto result = make_uniq<CreateViewInfo>();

--- a/src/common/identifier.cpp
+++ b/src/common/identifier.cpp
@@ -6,6 +6,18 @@
 
 namespace duckdb {
 
+string Identifier::Upper() const {
+	return StringUtil::Upper(value);
+}
+
+string Identifier::Lower() const {
+	return StringUtil::Lower(value);
+}
+
+bool Identifier::StartsWith(const string &prefix) const {
+	return StringUtil::CIStartsWith(value, prefix);
+}
+
 hash_t Identifier::Hash() const {
 	return StringUtil::CIHash(value);
 }

--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -690,7 +690,7 @@ vector<string> StringUtil::TopNLevenshtein(const vector<string> &strings, const 
 
 vector<string> StringUtil::TopNJaroWinkler(const vector<string> &strings, const Identifier &target, idx_t n,
                                            double threshold) {
-	return TopNJaroWinkler(strings, StringUtil::Lower(target.GetIdentifierName()), n, threshold);
+	return TopNJaroWinkler(strings, target.Lower(), n, threshold);
 }
 
 vector<string> StringUtil::TopNJaroWinkler(const vector<string> &strings, const string &target, idx_t n,

--- a/src/execution/operator/csv_scanner/util/csv_reader_options.cpp
+++ b/src/execution/operator/csv_scanner/util/csv_reader_options.cpp
@@ -643,7 +643,7 @@ string CSVReaderOptions::GetUserDefinedParameters() const {
 void CSVReaderOptions::FromNamedParameters(const named_parameter_map_t &in, ClientContext &context,
                                            MultiFileOptions &file_options) {
 	for (auto &kv : in) {
-		auto loption = StringUtil::Lower(kv.first.GetIdentifierName());
+		auto loption = kv.first.Lower();
 		if (MultiFileReader().ParseOption(loption, kv.second, file_options, context)) {
 			continue;
 		}

--- a/src/execution/operator/persistent/physical_batch_copy_to_file.cpp
+++ b/src/execution/operator/persistent/physical_batch_copy_to_file.cpp
@@ -43,7 +43,7 @@ PhysicalBatchCopyToFile::PhysicalBatchCopyToFile(PhysicalPlan &physical_plan, ve
 
 InsertionOrderPreservingMap<string> PhysicalBatchCopyToFile::ParamsToString() const {
 	InsertionOrderPreservingMap<string> result;
-	result["FORMAT"] = StringUtil::Upper(function.name.GetIdentifierName());
+	result["FORMAT"] = function.name.Upper();
 	return result;
 }
 

--- a/src/execution/operator/persistent/physical_copy_to_file.cpp
+++ b/src/execution/operator/persistent/physical_copy_to_file.cpp
@@ -3559,7 +3559,7 @@ PhysicalCopyToFile::~PhysicalCopyToFile() {
 
 InsertionOrderPreservingMap<string> PhysicalCopyToFile::ParamsToString() const {
 	InsertionOrderPreservingMap<string> result;
-	result["FORMAT"] = StringUtil::Upper(function.name.GetIdentifierName());
+	result["FORMAT"] = function.name.Upper();
 	return result;
 }
 

--- a/src/execution/operator/scan/physical_table_scan.cpp
+++ b/src/execution/operator/scan/physical_table_scan.cpp
@@ -355,7 +355,7 @@ InsertionOrderPreservingMap<string> PhysicalTableScan::ParamsToString() const {
 			result[it.first] = it.second;
 		}
 	} else {
-		result["Function"] = StringUtil::Upper(function.name.GetIdentifierName());
+		result["Function"] = function.name.Upper();
 	}
 	if (function.projection_pushdown) {
 		string projections;

--- a/src/function/scalar_macro_function.cpp
+++ b/src/function/scalar_macro_function.cpp
@@ -33,8 +33,7 @@ void RemoveQualificationRecursive(unique_ptr<ParsedExpression> &root_expr) {
 	ParsedExpressionIterator::VisitExpressionMutable<ColumnRefExpression>(
 	    *root_expr, [&](ColumnRefExpression &col_ref) {
 		    auto &col_names = col_ref.ColumnNamesMutable();
-		    if (col_names.size() == 2 &&
-		        StringUtil::StartsWith(col_names[0].GetIdentifierName(), DummyBinding::DUMMY_NAME)) {
+		    if (col_names.size() == 2 && col_names[0].StartsWith(DummyBinding::DUMMY_NAME)) {
 			    col_names.erase(col_names.begin());
 		    }
 	    });

--- a/src/function/table/system/create_external_resource.cpp
+++ b/src/function/table/system/create_external_resource.cpp
@@ -116,7 +116,7 @@ static unique_ptr<FunctionData> CreateExternalResourceBind(ClientContext &contex
 	result->type_name = StringValue::Get(input.inputs[0]);
 	result->params = Value::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR, vector<Value>(), vector<Value>());
 	for (auto &np : input.named_parameters) {
-		auto key = StringUtil::Lower(np.first.GetIdentifierName());
+		auto key = np.first.Lower();
 		if (key == "params" && !np.second.IsNull()) {
 			result->params = np.second;
 		} else if (key == "resource_name" && !np.second.IsNull()) {

--- a/src/function/table/system/duckdb_constraints.cpp
+++ b/src/function/table/system/duckdb_constraints.cpp
@@ -179,10 +179,10 @@ ExtraConstraintInfo GetExtraConstraintInfo(const TableCatalogEntry &table, const
 string GetConstraintName(const TableCatalogEntry &table, Constraint &constraint, const ExtraConstraintInfo &info) {
 	string result = table.name + "_";
 	for (auto &col : info.column_names) {
-		result += StringUtil::Lower(col.GetIdentifierName()) + "_";
+		result += col.Lower() + "_";
 	}
 	for (auto &col : info.referenced_columns) {
-		result += StringUtil::Lower(col.GetIdentifierName()) + "_";
+		result += col.Lower() + "_";
 	}
 	switch (constraint.type) {
 	case ConstraintType::CHECK:

--- a/src/function/table/system/external_resource_types.cpp
+++ b/src/function/table/system/external_resource_types.cpp
@@ -37,7 +37,7 @@ static unique_ptr<FunctionData> RegisterExternalResourceTypeBind(ClientContext &
 	type.search_path = CatalogSearchEntry::ListToString(ClientData::Get(context).catalog_search_path->GetSetPaths());
 
 	for (auto &np : input.named_parameters) {
-		auto key = StringUtil::Lower(np.first.GetIdentifierName());
+		auto key = np.first.Lower();
 		auto value = np.second.IsNull() ? string() : StringValue::Get(np.second);
 		if (key == "kind") {
 			type.kind = value;

--- a/src/function/table/system/external_resources.cpp
+++ b/src/function/table/system/external_resources.cpp
@@ -49,7 +49,7 @@ static unique_ptr<FunctionData> ExternalResourcesBind(ClientContext &context, Ta
                                                       vector<LogicalType> &return_types, vector<string> &names) {
 	auto result = make_uniq<ExternalResourcesBindData>();
 	for (auto &np : input.named_parameters) {
-		if (StringUtil::Lower(np.first.GetIdentifierName()) == "discover" && !np.second.IsNull()) {
+		if (np.first.Lower() == "discover" && !np.second.IsNull()) {
 			result->discover = BooleanValue::Get(np.second);
 		}
 	}
@@ -245,7 +245,7 @@ static unique_ptr<FunctionData> RegisterExternalResourceBind(ClientContext &cont
 	resource.handle = input.inputs[2];
 	resource.deleter_payload = input.inputs[2];
 	for (auto &np : input.named_parameters) {
-		auto key = StringUtil::Lower(np.first.GetIdentifierName());
+		auto key = np.first.Lower();
 		if (np.second.IsNull()) {
 			continue;
 		}

--- a/src/include/duckdb/common/identifier.hpp
+++ b/src/include/duckdb/common/identifier.hpp
@@ -77,6 +77,13 @@ public:
 		return value.c_str();
 	}
 
+	//! The raw name converted to upper case
+	DUCKDB_API string Upper() const;
+	//! The raw name converted to lower case
+	DUCKDB_API string Lower() const;
+	//! Whether the identifier starts with the given prefix (case-insensitive)
+	DUCKDB_API bool StartsWith(const string &prefix) const;
+
 	//! Case-insensitive hash of the identifier
 	DUCKDB_API hash_t Hash() const;
 

--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -198,7 +198,7 @@ public:
 
 		MultiFileOptions file_options;
 		for (auto &kv : input.named_parameters) {
-			auto loption = StringUtil::Lower(kv.first.GetIdentifierName());
+			auto loption = kv.first.Lower();
 			if (loption == "allow_empty") {
 				multi_file_reader->ParseOption(loption, kv.second, file_options, context);
 				if (file_options.allow_empty) {
@@ -214,7 +214,7 @@ public:
 
 		auto options = interface->InitializeOptions(context, input.info);
 		for (auto &kv : input.named_parameters) {
-			auto loption = StringUtil::Lower(kv.first.GetIdentifierName());
+			auto loption = kv.first.Lower();
 			if (multi_file_reader->ParseOption(loption, kv.second, file_options, context)) {
 				continue;
 			}

--- a/src/main/secret/secret_manager.cpp
+++ b/src/main/secret/secret_manager.cpp
@@ -635,8 +635,7 @@ void SecretManager::AutoloadExtensionForType(const string &type) {
 }
 
 void SecretManager::ThrowTypeNotFoundError(const Identifier &type, const string &secret_path) {
-	auto entry =
-	    ExtensionHelper::FindExtensionInEntries(StringUtil::Lower(type.GetIdentifierName()), EXTENSION_SECRET_TYPES);
+	auto entry = ExtensionHelper::FindExtensionInEntries(type.Lower(), EXTENSION_SECRET_TYPES);
 	string error_message;
 
 	if (!entry.empty() && db) {

--- a/src/parser/expression/function_expression.cpp
+++ b/src/parser/expression/function_expression.cpp
@@ -17,8 +17,7 @@ FunctionExpression::FunctionExpression(const QualifiedName &function_name,
                                        unique_ptr<ParsedExpression> filter, unique_ptr<OrderModifier> order_bys_p,
                                        bool distinct, bool is_operator, bool export_state_p)
     : ParsedExpression(ExpressionType::FUNCTION, ExpressionClass::FUNCTION),
-      qualified_name {function_name.Catalog(), function_name.Schema(),
-                      Identifier(StringUtil::Lower(function_name.Name().GetIdentifierName()))},
+      qualified_name {function_name.Catalog(), function_name.Schema(), Identifier(function_name.Name().Lower())},
       is_operator(is_operator), distinct(distinct), filter(std::move(filter)), order_bys(std::move(order_bys_p)),
       export_state(export_state_p) {
 	arguments.reserve(children_p.size());
@@ -42,8 +41,7 @@ FunctionExpression::FunctionExpression(const QualifiedName &function_name, vecto
                                        unique_ptr<ParsedExpression> filter, unique_ptr<OrderModifier> order_bys_p,
                                        bool distinct, bool is_operator, bool export_state)
     : ParsedExpression(ExpressionType::FUNCTION, ExpressionClass::FUNCTION),
-      qualified_name {function_name.Catalog(), function_name.Schema(),
-                      Identifier(StringUtil::Lower(function_name.Name().GetIdentifierName()))},
+      qualified_name {function_name.Catalog(), function_name.Schema(), Identifier(function_name.Name().Lower())},
       is_operator(is_operator), arguments(std::move(children)), distinct(distinct), filter(std::move(filter)),
       order_bys(std::move(order_bys_p)), export_state(export_state) {
 	D_ASSERT(!function_name.Name().empty());

--- a/src/parser/peg/transformer/transform_create_secret.cpp
+++ b/src/parser/peg/transformer/transform_create_secret.cpp
@@ -23,10 +23,10 @@ unique_ptr<CreateStatement> PEGTransformerFactory::TransformCreateSecretStmt(
 		info->SetSecretName(*secret_name);
 	}
 	if (secret_storage_specifier) {
-		info->storage_type = Identifier(StringUtil::Lower(secret_storage_specifier->GetIdentifierName()));
+		info->storage_type = Identifier(secret_storage_specifier->Lower());
 	}
 	for (const auto &option : generic_copy_option_list) {
-		auto lower_name = StringUtil::Lower(option.name.GetIdentifierName());
+		auto lower_name = option.name.Lower();
 		if (lower_name == "scope") {
 			info->scope = option.GetFirstChildOrExpression();
 			continue;

--- a/src/parser/peg/transformer/transform_create_table.cpp
+++ b/src/parser/peg/transformer/transform_create_table.cpp
@@ -384,8 +384,7 @@ ColumnConstraintEntry PEGTransformerFactory::TransformColumnCompression(PEGTrans
                                                                         const Identifier &col_id_or_string) {
 	ColumnConstraintEntry entry;
 	entry.constraint_name = "ColumnCompression";
-	entry.compression_type =
-	    EnumUtil::FromString<CompressionType>(StringUtil::Lower(col_id_or_string.GetIdentifierName()));
+	entry.compression_type = EnumUtil::FromString<CompressionType>(col_id_or_string.Lower());
 	return entry;
 }
 

--- a/src/parser/peg/transformer/transform_describe.cpp
+++ b/src/parser/peg/transformer/transform_describe.cpp
@@ -84,7 +84,7 @@ unique_ptr<QueryNode> PEGTransformerFactory::TransformShowQualifiedName(PEGTrans
 				}
 			} else if (IsInvalidSchema(base_table.GetQualifiedName().Schema())) {
 				// Logic for unqualified relations (databases, tables, variables)
-				auto table_name = StringUtil::Lower(base_table.Table().GetIdentifierName());
+				auto table_name = base_table.Table().Lower();
 				if (table_name == "databases" || table_name == "tables" || table_name == "schemas" ||
 				    table_name == "variables") {
 					showref->SetTableName(Identifier("\"" + table_name + "\""));

--- a/src/parser/peg/transformer/transform_explain.cpp
+++ b/src/parser/peg/transformer/transform_explain.cpp
@@ -21,7 +21,7 @@ unique_ptr<SQLStatement> PEGTransformerFactory::TransformExplainStatement(
 	auto format = ProfilerPrintFormat::Default();
 	if (explain_option_list) {
 		for (auto option : *explain_option_list) {
-			auto option_name = StringUtil::Lower(option.name.GetIdentifierName());
+			auto option_name = option.name.Lower();
 			if (option_name == "format") {
 				if (format_is_set) {
 					throw InvalidInputException("FORMAT can not be provided more than once");
@@ -59,7 +59,7 @@ GenericCopyOption PEGTransformerFactory::TransformExplainOption(PEGTransformer &
                                                                 const Identifier &explain_option_name,
                                                                 optional<unique_ptr<ParsedExpression>> expression) {
 	GenericCopyOption copy_option;
-	copy_option.name = Identifier(StringUtil::Lower(explain_option_name.GetIdentifierName()));
+	copy_option.name = Identifier(explain_option_name.Lower());
 	if (!expression) {
 		return copy_option;
 	}

--- a/src/parser/peg/transformer/transform_export.cpp
+++ b/src/parser/peg/transformer/transform_export.cpp
@@ -27,9 +27,9 @@ PEGTransformerFactory::TransformExportStatement(PEGTransformer &transformer, con
 				info->format = option.children[0].GetValue<string>();
 				info->is_format_auto_detected = false;
 			} else if (option.expression) {
-				info->parsed_options[StringUtil::Upper(option.name.GetIdentifierName())] = option.expression->Copy();
+				info->parsed_options[option.name.Upper()] = option.expression->Copy();
 			} else {
-				info->options[StringUtil::Upper(option.name.GetIdentifierName())] = option.children;
+				info->options[option.name.Upper()] = option.children;
 			}
 		}
 	}

--- a/src/parser/peg/transformer/transform_expression.cpp
+++ b/src/parser/peg/transformer/transform_expression.cpp
@@ -175,7 +175,7 @@ unique_ptr<ParsedExpression> PEGTransformerFactory::TransformFunctionExpression(
 		// COUNT(*) gets converted into COUNT()
 		function_children.clear();
 	}
-	auto lowercase_name = StringUtil::Lower(qualified_function.Name().GetIdentifierName());
+	auto lowercase_name = qualified_function.Name().Lower();
 
 	if (over_clause) {
 		if (transformer.in_window_definition) {

--- a/src/parser/peg/transformer/transform_generic_copy_option.cpp
+++ b/src/parser/peg/transformer/transform_generic_copy_option.cpp
@@ -81,7 +81,7 @@ GenericCopyOption
 PEGTransformerFactory::TransformGenericCopyOption(PEGTransformer &transformer, const Identifier &copy_option_name,
                                                   optional<GenericCopyOptionValue> generic_copy_option_value) {
 	GenericCopyOption copy_option;
-	copy_option.name = Identifier(StringUtil::Lower(copy_option_name.GetIdentifierName()));
+	copy_option.name = Identifier(copy_option_name.Lower());
 	if (!generic_copy_option_value || !generic_copy_option_value->has_value) {
 		return copy_option;
 	}

--- a/src/parser/query_node/insert_query_node.cpp
+++ b/src/parser/query_node/insert_query_node.cpp
@@ -64,7 +64,7 @@ string InsertQueryNode::ToString() const {
 			result += "(";
 			auto &cols = conflict_info.indexed_columns;
 			for (auto it = cols.begin(); it != cols.end();) {
-				result += StringUtil::Lower(it->GetIdentifierName());
+				result += it->Lower();
 				if (++it != cols.end()) {
 					result += ", ";
 				}
@@ -89,7 +89,7 @@ string InsertQueryNode::ToString() const {
 				if (i) {
 					result += ", ";
 				}
-				result += StringUtil::Lower(column.GetIdentifierName()) + " = " + expr->ToString();
+				result += column.Lower() + " = " + expr->ToString();
 			}
 			// (optional) where clause
 			if (set_info.condition) {

--- a/src/planner/binder/expression/bind_macro_expression.cpp
+++ b/src/planner/binder/expression/bind_macro_expression.cpp
@@ -65,7 +65,7 @@ void ExpressionBinder::ReplaceMacroParameters(unique_ptr<ParsedExpression> &expr
 		if (col_ref.IsQualified()) {
 			// the table qualifier is the component directly before the column name
 			auto &names = col_ref.ColumnNames();
-			if (StringUtil::StartsWith(names[names.size() - 2].GetIdentifierName(), DummyBinding::DUMMY_NAME)) {
+			if (names[names.size() - 2].StartsWith(DummyBinding::DUMMY_NAME)) {
 				bind_macro_parameter = true;
 			}
 		} else {

--- a/src/planner/binder/tableref/bind_pivot.cpp
+++ b/src/planner/binder/tableref/bind_pivot.cpp
@@ -65,9 +65,8 @@ static void ExtractPivotExpressions(ParsedExpression &root_expr, identifier_set_
 	ParsedExpressionIterator::VisitExpression<ColumnRefExpression>(
 	    root_expr, [&](const ColumnRefExpression &child_colref) {
 		    if (child_colref.IsQualified()) {
-			    if (StringUtil::StartsWith(child_colref.ColumnNames()[0].GetIdentifierName(),
-			                               DummyBinding::DUMMY_NAME) &&
-			        macro_binding && macro_binding->HasMatchingBinding(Identifier(child_colref.GetName()))) {
+			    if (child_colref.ColumnNames()[0].StartsWith(DummyBinding::DUMMY_NAME) && macro_binding &&
+			        macro_binding->HasMatchingBinding(Identifier(child_colref.GetName()))) {
 				    throw ParameterNotResolvedException();
 			    }
 			    throw BinderException(child_colref, "PIVOT expression cannot contain qualified columns");

--- a/src/planner/expression_binder/table_function_binder.cpp
+++ b/src/planner/expression_binder/table_function_binder.cpp
@@ -35,8 +35,8 @@ BindResult TableFunctionBinder::BindColumnReference(unique_ptr<ParsedExpression>
 		if (binder.macro_binding && binder.macro_binding->HasMatchingBinding(Identifier(col_ref.GetName()))) {
 			throw ParameterNotResolvedException();
 		}
-	} else if (StringUtil::StartsWith(col_ref.ColumnNames()[0].GetIdentifierName(), DummyBinding::DUMMY_NAME) &&
-	           binder.macro_binding && binder.macro_binding->HasMatchingBinding(Identifier(col_ref.GetName()))) {
+	} else if (col_ref.ColumnNames()[0].StartsWith(DummyBinding::DUMMY_NAME) && binder.macro_binding &&
+	           binder.macro_binding->HasMatchingBinding(Identifier(col_ref.GetName()))) {
 		throw ParameterNotResolvedException();
 	}
 

--- a/src/planner/operator/logical_get.cpp
+++ b/src/planner/operator/logical_get.cpp
@@ -435,10 +435,10 @@ vector<TableIndex> LogicalGet::GetTableIndex() const {
 string LogicalGet::GetName() const {
 #ifdef DEBUG
 	if (DBConfigOptions::debug_print_bindings) {
-		return StringUtil::Upper(function.name.GetIdentifierName()) + StringUtil::Format(" #%llu", table_index.index);
+		return function.name.Upper() + StringUtil::Format(" #%llu", table_index.index);
 	}
 #endif
-	return StringUtil::Upper(function.name.GetIdentifierName());
+	return function.name.Upper();
 }
 
 } // namespace duckdb


### PR DESCRIPTION
Code dealing with identifiers regularly needs the raw name in a normalized
casing, or wants to check a case-insensitive prefix. Doing that today requires
reaching for `StringUtil::Lower(id.GetIdentifierName())` and friends, which is
verbose and forces callers to unwrap the identifier just to do something that
is inherently identifier-shaped.

`Identifier::Upper()` and `Identifier::Lower()` return the raw name converted
to upper/lower case, and `Identifier::StartsWith(prefix)` performs a
case-insensitive prefix check, matching the case-insensitive semantics of the
rest of the type. All existing call sites are converted to use them, including
the `DummyBinding::DUMMY_NAME` prefix checks that were previously
case-sensitive.
