### PR TITLE
Add detect_string_types option to read_json

### DIFF
--- a/extension/json/include/json_reader_options.hpp
+++ b/extension/json/include/json_reader_options.hpp
@@ -116,6 +116,8 @@ struct JSONReaderOptions {
 	idx_t maximum_sample_files = 32;
 	//! Whether we auto-detect and convert JSON strings to integers
 	bool convert_strings_to_integers = false;
+	//! Whether we auto-detect DATE/TIME/TIMESTAMP/UUID types from JSON strings
+	bool detect_string_types = true;
 	//! If a struct contains more fields than this threshold with at least 80% similar types,
 	//! we infer it as MAP type
 	idx_t map_inference_threshold = 200;

--- a/extension/json/include/json_structure.hpp
+++ b/extension/json/include/json_structure.hpp
@@ -33,7 +33,8 @@ public:
 	JSONStructureDescription &GetOrCreateDescription(LogicalTypeId type);
 
 	bool ContainsVarchar() const;
-	void InitializeCandidateTypes(idx_t max_depth, bool convert_strings_to_integers, idx_t depth = 0);
+	void InitializeCandidateTypes(idx_t max_depth, bool convert_strings_to_integers, bool detect_string_types,
+	                              idx_t depth = 0);
 	void RefineCandidateTypes(yyjson_val *vals[], idx_t val_count, Vector &string_vector, ArenaAllocator &allocator,
 	                          MutableDateFormatMap &date_format_map);
 

--- a/extension/json/json_functions/json_structure.cpp
+++ b/extension/json/json_functions/json_structure.cpp
@@ -111,7 +111,7 @@ bool JSONStructureNode::ContainsVarchar() const {
 }
 
 void JSONStructureNode::InitializeCandidateTypes(const idx_t max_depth, const bool convert_strings_to_integers,
-                                                 const idx_t depth) {
+                                                 const bool detect_string_types, const idx_t depth) {
 	if (depth >= max_depth) {
 		return;
 	}
@@ -122,17 +122,17 @@ void JSONStructureNode::InitializeCandidateTypes(const idx_t max_depth, const bo
 	auto &description = descriptions[0];
 	if (description.type == LogicalTypeId::VARCHAR && !initialized) {
 		// We loop through the candidate types and format templates from back to front
-		if (convert_strings_to_integers) {
-			description.candidate_types = {LogicalTypeId::UUID, LogicalTypeId::BIGINT, LogicalTypeId::TIMESTAMP,
-			                               LogicalTypeId::DATE, LogicalTypeId::TIME};
-		} else {
+		if (detect_string_types) {
 			description.candidate_types = {LogicalTypeId::UUID, LogicalTypeId::TIMESTAMP, LogicalTypeId::DATE,
 			                               LogicalTypeId::TIME};
+		}
+		if (convert_strings_to_integers) {
+			description.candidate_types.emplace_back(LogicalTypeId::BIGINT);
 		}
 		initialized = true;
 	} else {
 		for (auto &child : description.children) {
-			child.InitializeCandidateTypes(max_depth, convert_strings_to_integers, depth + 1);
+			child.InitializeCandidateTypes(max_depth, convert_strings_to_integers, detect_string_types, depth + 1);
 		}
 	}
 }

--- a/extension/json/json_functions/read_json.cpp
+++ b/extension/json/json_functions/read_json.cpp
@@ -113,7 +113,8 @@ public:
 			if (!node.ContainsVarchar()) { // Can't refine non-VARCHAR types
 				continue;
 			}
-			node.InitializeCandidateTypes(options.max_depth, options.convert_strings_to_integers);
+			node.InitializeCandidateTypes(options.max_depth, options.convert_strings_to_integers,
+			                              options.detect_string_types);
 			node.RefineCandidateTypes(scan_state.values, next, string_vector, allocator,
 			                          auto_detect_state.date_format_map);
 		}
@@ -258,6 +259,7 @@ TableFunctionSet CreateJSONFunctionInfo(string name, shared_ptr<JSONScanInfo> in
 	table_function.named_parameters["maximum_depth"] = LogicalType::BIGINT;
 	table_function.named_parameters["field_appearance_threshold"] = LogicalType::DOUBLE;
 	table_function.named_parameters["convert_strings_to_integers"] = LogicalType::BOOLEAN;
+	table_function.named_parameters["detect_string_types"] = LogicalType::BOOLEAN;
 	table_function.named_parameters["map_inference_threshold"] = LogicalType::BIGINT;
 	return MultiFileReader::CreateFunctionSet(table_function);
 }

--- a/extension/json/json_multi_file_info.cpp
+++ b/extension/json/json_multi_file_info.cpp
@@ -201,6 +201,10 @@ bool JSONMultiFileInfo::ParseOption(ClientContext &context, const string &key, c
 		options.convert_strings_to_integers = BooleanValue::Get(value);
 		return true;
 	}
+	if (loption == "detect_string_types") {
+		options.detect_string_types = BooleanValue::Get(value);
+		return true;
+	}
 	return false;
 }
 

--- a/test/sql/json/table/read_json_detect_string_types.test
+++ b/test/sql/json/table/read_json_detect_string_types.test
@@ -1,0 +1,115 @@
+# name: test/sql/json/table/read_json_detect_string_types.test
+# description: Test read_json detect_string_types parameter
+# group: [table]
+
+require json
+
+statement ok
+copy (select * from (values ('{"d": "25-11-2025", "t": "12:34:56", "ts": "2023-02-07T19:12:28.123Z", "u": "BBD05AE7-76E5-4F1A-A31F-247408251FC9"}'))) to '{TEMP_DIR}/detect_string_types.json' (format csv, quote '', header 0)
+
+# by default, we detect DATE/TIME/TIMESTAMP/UUID types from strings
+query IIII
+select typeof(d), typeof(t), typeof(ts), typeof(u) from read_json_auto('{TEMP_DIR}/detect_string_types.json')
+----
+DATE	TIME	TIMESTAMP	UUID
+
+# with detect_string_types=false everything stays VARCHAR
+query IIII
+select typeof(d), typeof(t), typeof(ts), typeof(u) from read_json_auto('{TEMP_DIR}/detect_string_types.json', detect_string_types=false)
+----
+VARCHAR	VARCHAR	VARCHAR	VARCHAR
+
+# and the original strings are preserved exactly (formatting/case is not lost)
+query IIII
+select d, t, ts, u from read_json_auto('{TEMP_DIR}/detect_string_types.json', detect_string_types=false)
+----
+25-11-2025	12:34:56	2023-02-07T19:12:28.123Z	BBD05AE7-76E5-4F1A-A31F-247408251FC9
+
+# also works for read_ndjson
+query IIII
+select typeof(d), typeof(t), typeof(ts), typeof(u) from read_ndjson('{TEMP_DIR}/detect_string_types.json', detect_string_types=false)
+----
+VARCHAR	VARCHAR	VARCHAR	VARCHAR
+
+# detection is also disabled in nested structs and lists
+statement ok
+copy (select * from (values ('{"nested": {"d": "25-11-2025"}, "list": ["2023-02-07T19:12:28.123Z"]}'))) to '{TEMP_DIR}/detect_string_types_nested.json' (format csv, quote '', header 0)
+
+query II
+select typeof(nested), typeof(list) from read_json_auto('{TEMP_DIR}/detect_string_types_nested.json')
+----
+STRUCT(d DATE)	TIMESTAMP[]
+
+query II
+select typeof(nested), typeof(list) from read_json_auto('{TEMP_DIR}/detect_string_types_nested.json', detect_string_types=false)
+----
+STRUCT(d VARCHAR)	VARCHAR[]
+
+# convert_strings_to_integers is independent of detect_string_types
+statement ok
+copy (select * from (values ('{"i": "42", "d": "25-11-2025"}'))) to '{TEMP_DIR}/detect_string_types_int.json' (format csv, quote '', header 0)
+
+query II
+select typeof(i), typeof(d) from read_json_auto('{TEMP_DIR}/detect_string_types_int.json', detect_string_types=false, convert_strings_to_integers=true)
+----
+BIGINT	VARCHAR
+
+# with both options enabled, integers and temporals are both detected
+query II
+select typeof(i), typeof(d) from read_json_auto('{TEMP_DIR}/detect_string_types_int.json', convert_strings_to_integers=true)
+----
+BIGINT	DATE
+
+# records=false: bare string values are also kept as VARCHAR
+statement ok
+copy (select * from (values ('"25-11-2025"'))) to '{TEMP_DIR}/detect_string_types_bare.json' (format csv, quote '', header 0)
+
+query II
+select typeof(json), json from read_json('{TEMP_DIR}/detect_string_types_bare.json', records=false)
+----
+DATE	2025-11-25
+
+query II
+select typeof(json), json from read_json('{TEMP_DIR}/detect_string_types_bare.json', records=false, detect_string_types=false)
+----
+VARCHAR	25-11-2025
+
+# multi-file schema merging with union_by_name also respects the setting
+statement ok
+copy (select * from (values ('{"a": "25-11-2025"}'))) to '{TEMP_DIR}/detect_string_types_f1.json' (format csv, quote '', header 0)
+
+statement ok
+copy (select * from (values ('{"b": "bbd05ae7-76e5-4f1a-a31f-247408251fc9"}'))) to '{TEMP_DIR}/detect_string_types_f2.json' (format csv, quote '', header 0)
+
+query II
+select typeof(a), typeof(b) from read_json_auto(['{TEMP_DIR}/detect_string_types_f1.json', '{TEMP_DIR}/detect_string_types_f2.json'], union_by_name=true, detect_string_types=false) limit 1
+----
+VARCHAR	VARCHAR
+
+# inferred MAP value types also respect the setting
+query I
+select distinct typeof(a) from read_json_auto('{DATA_DIR}/json/map_of_dates.jsonl', map_inference_threshold=25)
+----
+MAP(VARCHAR, DATE)
+
+query I
+select distinct typeof(a) from read_json_auto('{DATA_DIR}/json/map_of_dates.jsonl', map_inference_threshold=25, detect_string_types=false)
+----
+MAP(VARCHAR, VARCHAR)
+
+# explicitly requested types still work with detect_string_types=false
+query II
+select typeof(d), d from read_json('{TEMP_DIR}/detect_string_types.json', columns={d: 'DATE'}, dateformat='%d-%m-%Y', detect_string_types=false)
+----
+DATE	2025-11-25
+
+# dateformat/timestampformat only apply to detection when it is enabled
+query II
+select typeof(d), d from read_json_auto('{TEMP_DIR}/detect_string_types.json', dateformat='%d-%m-%Y', detect_string_types=false)
+----
+VARCHAR	25-11-2025
+
+statement error
+select * from read_json_auto('{TEMP_DIR}/detect_string_types.json', detect_string_types=NULL)
+----
+Binder Error


### PR DESCRIPTION
Implements the feature requested in discussion https://github.com/duckdb/duckdb/discussions/24259.

## Motivation

`read_json` schema auto-detection converts JSON strings that look like dates/times/timestamps/UUIDs into those types. This is often desirable, but when JSON documents are passed through SQL steps and must round-trip unchanged, the original text becomes unrecoverable:

```sql
-- {"formatted_date": "25-11-2025"} is read as DATE and re-serializes as "2025-11-25"
-- {"id": "BBD05AE7-..."} is read as UUID and re-serializes lowercased
SELECT * FROM read_json('docs.json');
```

There is currently no way to opt out of this detection short of specifying the full schema manually via `columns` (which requires knowing the schema up front, defeating the purpose of auto-detection).

## Change

Adds a `detect_string_types` BOOLEAN parameter (default `true`) to `read_json`, `read_ndjson`, `read_json_auto`, and `read_ndjson_auto`. When set to `false`, auto-detection no longer infers `DATE`/`TIME`/`TIMESTAMP`/`UUID` from strings — they stay `VARCHAR`, preserving the original text exactly:

```sql
SELECT * FROM read_json('docs.json', detect_string_types=false);
```

- `convert_strings_to_integers` remains independent: with `detect_string_types=false, convert_strings_to_integers=true`, integer-like strings are still detected as `BIGINT` while temporals/UUIDs stay `VARCHAR`.
- Explicitly requested types (via `columns`) and `dateformat`/`timestampformat` are unaffected.
- Default behavior is unchanged.

The implementation gates the string candidate types (`UUID`/`TIMESTAMP`/`DATE`/`TIME`) in `JSONStructureNode::InitializeCandidateTypes` on the new option, so no candidate refinement work is done for these types when disabled.

## Testing

Added `test/sql/json/table/read_json_detect_string_types.test` covering default behavior, the new flag (top-level and nested structs/lists), both combinations with `convert_strings_to_integers`, `records=false` (bare values), multi-file schema merging with `union_by_name`, inferred MAP value types, interaction with `columns`/`dateformat`, and NULL argument handling.
