### PR TITLE
Leverage bloom filter to prune parquet struct

### DIFF
--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -48,6 +48,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/common/types/vector.hpp"
 #include "duckdb/common/vector_size.hpp"
+#include "duckdb/function/scalar/struct_utils.hpp"
 #include "duckdb/logging/log_type.hpp"
 #include "duckdb/logging/logger.hpp"
 #include "duckdb/main/client_context.hpp"
@@ -1483,8 +1484,8 @@ static FilterPropagateResult CheckParquetFloatFilter(ClientContext &context, Col
 	return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 }
 
-static bool TryGetListBloomFilterLeaf(ColumnReader &column_reader, const Expression &expr,
-                                      optional_ptr<ColumnReader> &leaf_reader) {
+static bool TryGetNestedBloomFilterLeaf(ColumnReader &column_reader, const Expression &expr,
+                                        optional_ptr<ColumnReader> &leaf_reader) {
 	if (expr.GetExpressionClass() == ExpressionClass::BOUND_REF) {
 		if (expr.Cast<BoundReferenceExpression>().Index() != 0) {
 			return false;
@@ -1498,14 +1499,31 @@ static bool TryGetListBloomFilterLeaf(ColumnReader &column_reader, const Express
 
 	auto &function = expr.Cast<BoundFunctionExpression>();
 	if (function.GetChildren().empty() ||
-	    !TryGetListBloomFilterLeaf(column_reader, *function.GetChildren()[0], leaf_reader)) {
+	    !TryGetNestedBloomFilterLeaf(column_reader, *function.GetChildren()[0], leaf_reader)) {
 		return false;
 	}
+
+	// Handle LIST type.
 	if (leaf_reader->Type().id() == LogicalTypeId::LIST &&
 	    (function.Function().GetName() == "list_extract" || function.Function().GetName() == "array_extract")) {
 		leaf_reader = &leaf_reader->Cast<ListColumnReader>().GetChildReader();
 		return true;
 	}
+
+	// Handle STRUCT type.
+	if (leaf_reader->Type().id() == LogicalTypeId::STRUCT) {
+		idx_t child_idx;
+		if (!TryGetStructExtractChildIndex(function, child_idx)) {
+			return false;
+		}
+		auto &struct_reader = leaf_reader->Cast<StructColumnReader>();
+		if (child_idx >= struct_reader.child_readers.size() || !struct_reader.child_readers[child_idx]) {
+			return false;
+		}
+		leaf_reader = struct_reader.child_readers[child_idx].get();
+		return true;
+	}
+
 	return false;
 }
 
@@ -1553,7 +1571,7 @@ static bool TryGetBloomFilterLeaf(ColumnReader &column_reader, const TableFilter
 		return false;
 	}
 
-	if (!TryGetListBloomFilterLeaf(column_reader, *column_expr, leaf_reader) ||
+	if (!TryGetNestedBloomFilterLeaf(column_reader, *column_expr, leaf_reader) ||
 	    leaf_reader->Type() != constant->GetValue().type()) {
 		return false;
 	}
@@ -1608,8 +1626,8 @@ void ParquetReader::PrepareRowGroupBuffer(ClientContext &context, ParquetReaderS
 					// no pruning possible for expressions
 					prune_result = FilterPropagateResult::NO_PRUNING_POSSIBLE;
 				} else if (!is_generated_column && has_min_max &&
-				           (column_reader.Type().id() == LogicalTypeId::FLOAT ||
-				            column_reader.Type().id() == LogicalTypeId::DOUBLE) &&
+			           (column_reader.Type().id() == LogicalTypeId::FLOAT ||
+			            column_reader.Type().id() == LogicalTypeId::DOUBLE) &&
 				           parquet_options.can_have_nan) {
 					// floating point columns can have NaN values in addition to the min/max bounds defined in the file
 					// in order to do optimal pruning - we prune based on the [min, max] of the file followed by pruning

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1626,8 +1626,8 @@ void ParquetReader::PrepareRowGroupBuffer(ClientContext &context, ParquetReaderS
 					// no pruning possible for expressions
 					prune_result = FilterPropagateResult::NO_PRUNING_POSSIBLE;
 				} else if (!is_generated_column && has_min_max &&
-			           (column_reader.Type().id() == LogicalTypeId::FLOAT ||
-			            column_reader.Type().id() == LogicalTypeId::DOUBLE) &&
+				           (column_reader.Type().id() == LogicalTypeId::FLOAT ||
+				            column_reader.Type().id() == LogicalTypeId::DOUBLE) &&
 				           parquet_options.can_have_nan) {
 					// floating point columns can have NaN values in addition to the min/max bounds defined in the file
 					// in order to do optimal pruning - we prune based on the [min, max] of the file followed by pruning

--- a/test/sql/copy/parquet/bloom_filters.test
+++ b/test/sql/copy/parquet/bloom_filters.test
@@ -111,6 +111,9 @@ COPY (
     SELECT
         [v, v + 2] AS list_value,
         [[[v, v + 2]]] AS deep_list,
+        {
+            'level_1': {'level_2': {'value': v}}
+        } AS struct_value,
         i::BIGINT AS payload
     FROM (
         SELECT i, ((i % 100) * 2)::INTEGER AS v
@@ -181,6 +184,22 @@ EXPLAIN ANALYZE
 SELECT deep_list, payload
 FROM read_parquet('{TEST_DIR}/bloom_list.parquet')
 WHERE deep_list[1][1][1] = 101;
+----
+analyzed_plan	<REGEX>:(?s).*Row Groups Scanned: 0 / 10.*
+
+# Deeply nested structs
+query I
+SELECT count(*)
+FROM read_parquet('{TEST_DIR}/bloom_list.parquet')
+WHERE struct_value.level_1.level_2.value = 101;
+----
+0
+
+query II
+EXPLAIN ANALYZE
+SELECT struct_value, payload
+FROM read_parquet('{TEST_DIR}/bloom_list.parquet')
+WHERE struct_value.level_1.level_2.value = 101;
 ----
 analyzed_plan	<REGEX>:(?s).*Row Groups Scanned: 0 / 10.*
 


### PR DESCRIPTION
Closes https://github.com/duckdb/duckdb/issues/24265

Followup PR for https://github.com/duckdb/duckdb/pull/24150, which leverages bloom filter to prune for LIST type.
Same root cause, on write, bloom filter records each leaf field's value, which could be used to prune.

Example case
```
STRUCT {
    user_id INTEGER,
    profile STRUCT {
        age INTEGER,
        name VARCHAR
    }
}
```
Parquet records bloom filter for `user_id`, `profile.age`, and `profile.name`