### PR TITLE
Add a `StartsWith` helper to `Identifier`

### DIFF
--- a/src/common/identifier.cpp
+++ b/src/common/identifier.cpp
@@ -6,6 +6,10 @@
 
 namespace duckdb {
 
+bool Identifier::StartsWith(const string &prefix) const {
+	return StringUtil::CIStartsWith(value, prefix);
+}
+
 hash_t Identifier::Hash() const {
 	return StringUtil::CIHash(value);
 }

--- a/src/function/scalar_macro_function.cpp
+++ b/src/function/scalar_macro_function.cpp
@@ -33,8 +33,7 @@ void RemoveQualificationRecursive(unique_ptr<ParsedExpression> &root_expr) {
 	ParsedExpressionIterator::VisitExpressionMutable<ColumnRefExpression>(
 	    *root_expr, [&](ColumnRefExpression &col_ref) {
 		    auto &col_names = col_ref.ColumnNamesMutable();
-		    if (col_names.size() == 2 &&
-		        StringUtil::StartsWith(col_names[0].GetIdentifierName(), DummyBinding::DUMMY_NAME)) {
+		    if (col_names.size() == 2 && col_names[0].StartsWith(DummyBinding::DUMMY_NAME)) {
 			    col_names.erase(col_names.begin());
 		    }
 	    });

--- a/src/include/duckdb/common/identifier.hpp
+++ b/src/include/duckdb/common/identifier.hpp
@@ -77,6 +77,9 @@ public:
 		return value.c_str();
 	}
 
+	//! Whether the identifier starts with the given prefix (case-insensitive)
+	DUCKDB_API bool StartsWith(const string &prefix) const;
+
 	//! Case-insensitive hash of the identifier
 	DUCKDB_API hash_t Hash() const;
 

--- a/src/planner/binder/expression/bind_macro_expression.cpp
+++ b/src/planner/binder/expression/bind_macro_expression.cpp
@@ -65,7 +65,7 @@ void ExpressionBinder::ReplaceMacroParameters(unique_ptr<ParsedExpression> &expr
 		if (col_ref.IsQualified()) {
 			// the table qualifier is the component directly before the column name
 			auto &names = col_ref.ColumnNames();
-			if (StringUtil::StartsWith(names[names.size() - 2].GetIdentifierName(), DummyBinding::DUMMY_NAME)) {
+			if (names[names.size() - 2].StartsWith(DummyBinding::DUMMY_NAME)) {
 				bind_macro_parameter = true;
 			}
 		} else {

--- a/src/planner/binder/tableref/bind_pivot.cpp
+++ b/src/planner/binder/tableref/bind_pivot.cpp
@@ -65,9 +65,8 @@ static void ExtractPivotExpressions(ParsedExpression &root_expr, identifier_set_
 	ParsedExpressionIterator::VisitExpression<ColumnRefExpression>(
 	    root_expr, [&](const ColumnRefExpression &child_colref) {
 		    if (child_colref.IsQualified()) {
-			    if (StringUtil::StartsWith(child_colref.ColumnNames()[0].GetIdentifierName(),
-			                               DummyBinding::DUMMY_NAME) &&
-			        macro_binding && macro_binding->HasMatchingBinding(Identifier(child_colref.GetName()))) {
+			    if (child_colref.ColumnNames()[0].StartsWith(DummyBinding::DUMMY_NAME) && macro_binding &&
+			        macro_binding->HasMatchingBinding(Identifier(child_colref.GetName()))) {
 				    throw ParameterNotResolvedException();
 			    }
 			    throw BinderException(child_colref, "PIVOT expression cannot contain qualified columns");

--- a/src/planner/expression_binder/table_function_binder.cpp
+++ b/src/planner/expression_binder/table_function_binder.cpp
@@ -35,8 +35,8 @@ BindResult TableFunctionBinder::BindColumnReference(unique_ptr<ParsedExpression>
 		if (binder.macro_binding && binder.macro_binding->HasMatchingBinding(Identifier(col_ref.GetName()))) {
 			throw ParameterNotResolvedException();
 		}
-	} else if (StringUtil::StartsWith(col_ref.ColumnNames()[0].GetIdentifierName(), DummyBinding::DUMMY_NAME) &&
-	           binder.macro_binding && binder.macro_binding->HasMatchingBinding(Identifier(col_ref.GetName()))) {
+	} else if (col_ref.ColumnNames()[0].StartsWith(DummyBinding::DUMMY_NAME) && binder.macro_binding &&
+	           binder.macro_binding->HasMatchingBinding(Identifier(col_ref.GetName()))) {
 		throw ParameterNotResolvedException();
 	}
 


### PR DESCRIPTION
Checking whether an identifier starts with a certain prefix required unwrapping
the identifier with `StringUtil::StartsWith(id.GetIdentifierName(), prefix)`,
which is both verbose and silently case-sensitive - even though every other
operation on `Identifier` is case-insensitive.

`Identifier::StartsWith(prefix)` does the prefix check using
`StringUtil::CIStartsWith`, matching the case-insensitive semantics of the rest
of the type. The `DummyBinding::DUMMY_NAME` prefix checks in the macro/pivot
binders are converted to it, which incidentally makes them case-insensitive as
they should have been.

Related to #24261
