### PR TITLE
fix(docs): Fix and extend documentation for `regr_` functions

### DIFF
--- a/extension/core_functions/aggregate/regression/functions.json
+++ b/extension/core_functions/aggregate/regression/functions.json
@@ -44,15 +44,15 @@
     {
         "name": "regr_sxx",
         "parameters": "y,x",
-        "description": "",
-        "example": "REGR_COUNT(y, x) * VAR_POP(x)",
+        "description": "Returns the sum of squared deviations of the independent variable for non-NULL pairs, sum((x - avg(x))^2), computed in a numerically stable way.",
+        "example": "regr_sxx(y, x)",
         "type": "aggregate_function",
         "struct": "RegrSXXFun"
     },
     {
         "name": "regr_sxy",
         "parameters": "y,x",
-        "description": "Returns the population covariance of input values",
+        "description": "Returns the sum of deviation products for non-NULL pairs, sum((y - avg(y)) * (x - avg(x))), computed in a numerically stable way.",
         "example": "REGR_COUNT(y, x) * COVAR_POP(y, x)",
         "type": "aggregate_function",
         "struct": "RegrSXYFun"
@@ -60,8 +60,8 @@
     {
         "name": "regr_syy",
         "parameters": "y,x",
-        "description": "",
-        "example": "REGR_COUNT(y, x) * VAR_POP(y)",
+        "description": "Returns the sum of squared deviations of the dependent variable for non-NULL pairs, sum((y - avg(y))^2), computed in a numerically stable way.",
+        "example": "regr_syy(y, x)",
         "type": "aggregate_function",
         "struct": "RegrSYYFun"
     }

--- a/extension/core_functions/include/core_functions/aggregate/regression_functions.hpp
+++ b/extension/core_functions/include/core_functions/aggregate/regression_functions.hpp
@@ -78,8 +78,8 @@ struct RegrSlopeFun {
 struct RegrSXXFun {
 	static constexpr const char *Name = "regr_sxx";
 	static constexpr const char *Parameters = "y,x";
-	static constexpr const char *Description = "";
-	static constexpr const char *Example = "REGR_COUNT(y, x) * VAR_POP(x)";
+	static constexpr const char *Description = "Returns the sum of squared deviations of the independent variable for non-NULL pairs, sum((x - avg(x))^2), computed in a numerically stable way.";
+	static constexpr const char *Example = "regr_sxx(y, x)";
 	static constexpr const char *Categories = "";
 
 	static AggregateFunction GetFunction();
@@ -88,7 +88,7 @@ struct RegrSXXFun {
 struct RegrSXYFun {
 	static constexpr const char *Name = "regr_sxy";
 	static constexpr const char *Parameters = "y,x";
-	static constexpr const char *Description = "Returns the population covariance of input values";
+	static constexpr const char *Description = "Returns the sum of deviation products for non-NULL pairs, sum((y - avg(y)) * (x - avg(x))), computed in a numerically stable way.";
 	static constexpr const char *Example = "REGR_COUNT(y, x) * COVAR_POP(y, x)";
 	static constexpr const char *Categories = "";
 
@@ -98,8 +98,8 @@ struct RegrSXYFun {
 struct RegrSYYFun {
 	static constexpr const char *Name = "regr_syy";
 	static constexpr const char *Parameters = "y,x";
-	static constexpr const char *Description = "";
-	static constexpr const char *Example = "REGR_COUNT(y, x) * VAR_POP(y)";
+	static constexpr const char *Description = "Returns the sum of squared deviations of the dependent variable for non-NULL pairs, sum((y - avg(y))^2), computed in a numerically stable way.";
+	static constexpr const char *Example = "regr_syy(y, x)";
 	static constexpr const char *Categories = "";
 
 	static AggregateFunction GetFunction();


### PR DESCRIPTION
A comprehensive documentation review found this inconsistency. The logic is made obvious by documenting the two adjacent functions.

This looks legit to me, but I have never used these functions. We could also drop the description and examples (which are wrong as they stand in the presence of NULL values) and wait for expert advice.

```
memory D SELECT regr_sxx(y, x), var_pop(x), regr_count(y, x) FROM VALUES (1, 2), (2, 3), (2, 3), (null, 4), (4, null) AS T(y, x);
┌────────────────────┬────────────┬──────────────────┐
│   regr_sxx(y, x)   │ var_pop(x) │ regr_count(y, x) │
│       double       │   double   │      uint32      │
├────────────────────┼────────────┼──────────────────┤
│ 0.6666666666666667 │        0.5 │                3 │
└────────────────────┴────────────┴──────────────────┘
memory D SELECT regr_sxy(y, x), covar_pop(y, x), regr_count(y, x) FROM VALUES (1, 2), (2, 3), (2, 3), (null, 4), (4, null) AS T(y, x);
┌────────────────────┬────────────────────┬──────────────────┐
│   regr_sxy(y, x)   │  covar_pop(y, x)   │ regr_count(y, x) │
│       double       │       double       │      uint32      │
├────────────────────┼────────────────────┼──────────────────┤
│ 0.6666666666666666 │ 0.2222222222222222 │                3 │
└────────────────────┴────────────────────┴──────────────────┘
memory D SELECT regr_syy(y, x), var_pop(y), regr_count(y, x) FROM VALUES (1, 2), (2, 3), (2, 3), (null, 4), (4, null) AS T(y, x);
┌────────────────────┬────────────┬──────────────────┐
│   regr_syy(y, x)   │ var_pop(y) │ regr_count(y, x) │
│       double       │   double   │      uint32      │
├────────────────────┼────────────┼──────────────────┤
│ 0.6666666666666666 │     1.1875 │                3 │
└────────────────────┴────────────┴──────────────────┘
```

@szarnyasg: I can't assign you as a reviewer, can you please take a look?