### PR TITLE
Re-enable MERGE for composite row ids

### DIFF
--- a/src/execution/CMakeLists.txt
+++ b/src/execution/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library_unity(
   perfect_aggregate_hashtable.cpp
   physical_operator.cpp
   physical_plan_generator.cpp
+  row_id_deduplicator.cpp
   radix_partitioned_hashtable.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_execution>

--- a/src/execution/operator/persistent/physical_insert.cpp
+++ b/src/execution/operator/persistent/physical_insert.cpp
@@ -82,11 +82,14 @@ InsertGlobalState::InsertGlobalState(ClientContext &context, const vector<Logica
 }
 
 InsertLocalState::InsertLocalState(ClientContext &context, const vector<LogicalType> &types,
-                                   const vector<unique_ptr<BoundConstraint>> &bound_constraints)
+                                   const vector<unique_ptr<BoundConstraint>> &bound_constraints, bool deduplicate_rows)
     : collection_index(DConstants::INVALID_INDEX), bound_constraints(bound_constraints) {
 	auto &allocator = Allocator::Get(context);
 	update_chunk.Initialize(allocator, types);
 	append_chunk.Initialize(allocator, types);
+	if (deduplicate_rows) {
+		updated_rows = make_uniq<RowIdDeduplicator>(context, vector<LogicalType> {LogicalType::ROW_TYPE});
+	}
 }
 
 ConstraintState &InsertLocalState::GetConstraintState(DataTable &table, TableCatalogEntry &table_ref) {
@@ -122,7 +125,8 @@ unique_ptr<GlobalSinkState> PhysicalInsert::GetGlobalSinkState(ClientContext &co
 }
 
 unique_ptr<LocalSinkState> PhysicalInsert::GetLocalSinkState(ExecutionContext &context) const {
-	return make_uniq<InsertLocalState>(context.client, insert_types, bound_constraints);
+	return make_uniq<InsertLocalState>(context.client, insert_types, bound_constraints,
+	                                   action_type == OnConflictAction::UPDATE);
 }
 
 bool AllConflictsMeetCondition(DataChunk &result) {
@@ -291,7 +295,8 @@ static idx_t PerformOnConflictAction(InsertLocalState &lstate, InsertGlobalState
 
 static void RegisterUpdatedRows(InsertLocalState &lstate, const Vector &row_ids, idx_t count) {
 	// Register all row-ids; a distinct count below `count` means a row-id repeated, which we reject.
-	auto distinct = RegisterRowIds(lstate.updated_rows, row_ids, count);
+	D_ASSERT(lstate.updated_rows);
+	auto distinct = lstate.updated_rows->Register(row_ids, count);
 	if (distinct != count) {
 		// This is following postgres behavior:
 		throw InvalidInputException(

--- a/src/execution/operator/persistent/physical_insert.cpp
+++ b/src/execution/operator/persistent/physical_insert.cpp
@@ -82,12 +82,13 @@ InsertGlobalState::InsertGlobalState(ClientContext &context, const vector<Logica
 }
 
 InsertLocalState::InsertLocalState(ClientContext &context, const vector<LogicalType> &types,
-                                   const vector<unique_ptr<BoundConstraint>> &bound_constraints, bool deduplicate_rows)
+                                   const vector<unique_ptr<BoundConstraint>> &bound_constraints,
+                                   OnConflictAction action_type)
     : collection_index(DConstants::INVALID_INDEX), bound_constraints(bound_constraints) {
 	auto &allocator = Allocator::Get(context);
 	update_chunk.Initialize(allocator, types);
 	append_chunk.Initialize(allocator, types);
-	if (deduplicate_rows) {
+	if (action_type == OnConflictAction::UPDATE) {
 		updated_rows = make_uniq<RowIdDeduplicator>(context, vector<LogicalType> {LogicalType::ROW_TYPE});
 	}
 }
@@ -125,8 +126,7 @@ unique_ptr<GlobalSinkState> PhysicalInsert::GetGlobalSinkState(ClientContext &co
 }
 
 unique_ptr<LocalSinkState> PhysicalInsert::GetLocalSinkState(ExecutionContext &context) const {
-	return make_uniq<InsertLocalState>(context.client, insert_types, bound_constraints,
-	                                   action_type == OnConflictAction::UPDATE);
+	return make_uniq<InsertLocalState>(context.client, insert_types, bound_constraints, action_type);
 }
 
 bool AllConflictsMeetCondition(DataChunk &result) {

--- a/src/execution/operator/persistent/physical_insert.cpp
+++ b/src/execution/operator/persistent/physical_insert.cpp
@@ -491,8 +491,9 @@ static idx_t HandleInsertConflicts(DuckTableEntry &table, ExecutionContext &cont
 	VerifyOnConflictCondition<GLOBAL>(context, combined_chunk, on_conflict_condition, constraint_state, tuples,
 	                                  data_table, local_storage);
 
-	if (&tuples == &lstate.update_chunk) {
-		// Allow updating duplicate rows for the 'update_chunk'
+	if (RefersToSameObject(tuples, lstate.update_chunk)) {
+		D_ASSERT(op.action_type == OnConflictAction::UPDATE);
+		// Reject updating the same target row more than once.
 		RegisterUpdatedRows(lstate, row_ids, conflict_count);
 	}
 	auto affected_tuples = PerformOnConflictAction<GLOBAL>(lstate, gstate, context, combined_chunk, table, row_ids, op);

--- a/src/execution/operator/persistent/physical_merge_into.cpp
+++ b/src/execution/operator/persistent/physical_merge_into.cpp
@@ -111,25 +111,36 @@ public:
 
 class MergeIntoGlobalState : public GlobalSinkState {
 public:
-	MergeIntoGlobalState(ClientContext &context, const PhysicalMergeInto &op) : op(op) {
+	MergeIntoGlobalState(ClientContext &context, const PhysicalMergeInto &op)
+	    : op(op), matched_rows(context, GetRowIdTypes(op)) {
 		for (auto &action : op.actions) {
 			sink_states.push_back(action->op ? action->op->GetGlobalSinkState(context) : nullptr);
 		}
 		merged_count = 0;
 	}
+
+	static vector<LogicalType> GetRowIdTypes(const PhysicalMergeInto &op) {
+		auto &input_types = op.children[0].get().types;
+		if (op.row_id_index >= input_types.size()) {
+			throw InternalException("MERGE row ID index is out of range");
+		}
+		auto row_id_offset = NumericCast<vector<LogicalType>::difference_type>(op.row_id_index);
+		return vector<LogicalType>(input_types.begin() + row_id_offset, input_types.end());
+	}
+
 	const PhysicalMergeInto &op;
 	idx_t finalize_idx = 0;
 	vector<unique_ptr<GlobalSinkState>> sink_states;
 	atomic<idx_t> merged_count;
 	//! Target row-ids already matched by a WHEN MATCHED modifying action, to detect a second action on a row.
 	mutex match_lock;
-	unordered_set<row_t> matched_rows;
+	RowIdDeduplicator matched_rows;
 
-	//! Record the matched target rows; throw if any row was already matched (cardinality violation). Uses the
-	//! shared row-id registration primitive; a distinct count below the input count means a row-id repeated.
+	//! Record the matched target rows; throw if any row was already matched (cardinality violation). A distinct
+	//! count below the input count means a row ID repeated.
 	void CheckMatchedRows(DataChunk &matched, idx_t row_id_index) {
 		lock_guard<mutex> glock(match_lock);
-		auto distinct = RegisterRowIds(matched_rows, matched.data[row_id_index], matched.size());
+		auto distinct = matched_rows.Register(matched, row_id_index);
 		if (distinct != matched.size()) {
 			throw InvalidInputException(
 			    "MERGE INTO command cannot affect the same target row more than once. A target row matched more "
@@ -313,6 +324,7 @@ void PhysicalMergeInto::ComputeMatches(MergeIntoLocalState &local_state, DataChu
 	not_matched.count = 0;
 	not_matched_by_source.count = 0;
 
+	// The first row-ID component is also the target-presence marker and must be non-NULL for target rows.
 	auto row_id_validity = chunk.data[row_id_index].Validity();
 	if (source_marker.IsValid()) {
 		// source marker - check both row id and source marker

--- a/src/execution/operator/persistent/physical_update.cpp
+++ b/src/execution/operator/persistent/physical_update.cpp
@@ -55,9 +55,10 @@ PhysicalUpdate::PhysicalUpdate(PhysicalPlan &physical_plan, vector<LogicalType> 
 //===--------------------------------------------------------------------===//
 class UpdateGlobalState : public GlobalSinkState {
 public:
-	explicit UpdateGlobalState(ClientContext &context, const vector<LogicalType> &return_types, bool deduplicate_rows)
+	explicit UpdateGlobalState(ClientContext &context, const vector<LogicalType> &return_types,
+	                           RowIdHandling row_id_handling)
 	    : updated_count(0), return_collection(context, return_types) {
-		if (deduplicate_rows) {
+		if (row_id_handling != RowIdHandling::ASSUME_UNIQUE) {
 			updated_rows = make_uniq<RowIdDeduplicator>(context, vector<LogicalType> {LogicalType::ROW_TYPE});
 		}
 	}
@@ -279,7 +280,7 @@ SinkResultType PhysicalUpdate::Sink(ExecutionContext &context, DataChunk &chunk,
 }
 
 unique_ptr<GlobalSinkState> PhysicalUpdate::GetGlobalSinkState(ClientContext &context) const {
-	return make_uniq<UpdateGlobalState>(context, GetTypes(), row_id_handling != RowIdHandling::ASSUME_UNIQUE);
+	return make_uniq<UpdateGlobalState>(context, GetTypes(), row_id_handling);
 }
 
 unique_ptr<LocalSinkState> PhysicalUpdate::GetLocalSinkState(ExecutionContext &context) const {

--- a/src/execution/operator/persistent/physical_update.cpp
+++ b/src/execution/operator/persistent/physical_update.cpp
@@ -55,13 +55,16 @@ PhysicalUpdate::PhysicalUpdate(PhysicalPlan &physical_plan, vector<LogicalType> 
 //===--------------------------------------------------------------------===//
 class UpdateGlobalState : public GlobalSinkState {
 public:
-	explicit UpdateGlobalState(ClientContext &context, const vector<LogicalType> &return_types)
+	explicit UpdateGlobalState(ClientContext &context, const vector<LogicalType> &return_types, bool deduplicate_rows)
 	    : updated_count(0), return_collection(context, return_types) {
+		if (deduplicate_rows) {
+			updated_rows = make_uniq<RowIdDeduplicator>(context, vector<LogicalType> {LogicalType::ROW_TYPE});
+		}
 	}
 
 	mutex lock;
 	atomic<idx_t> updated_count;
-	unordered_set<row_t> updated_rows;
+	unique_ptr<RowIdDeduplicator> updated_rows;
 	ColumnDataCollection return_collection;
 };
 
@@ -173,7 +176,8 @@ SinkResultType PhysicalUpdate::Sink(ExecutionContext &context, DataChunk &chunk,
 		if (deduplicate) {
 			sel.Initialize(update_chunk.size());
 			lock_guard<mutex> glock(g_state.lock);
-			update_count = RegisterRowIds(g_state.updated_rows, row_ids, update_chunk.size(), sel);
+			D_ASSERT(g_state.updated_rows);
+			update_count = g_state.updated_rows->Register(row_ids, update_chunk.size(), sel);
 			if (row_id_handling == RowIdHandling::ERROR && update_count != update_chunk.size()) {
 				throw InvalidInputException("UPDATE command cannot update the same row more than once");
 			}
@@ -218,7 +222,8 @@ SinkResultType PhysicalUpdate::Sink(ExecutionContext &context, DataChunk &chunk,
 	idx_t update_count = update_chunk.size();
 	const bool deduplicate = row_id_handling != RowIdHandling::ASSUME_UNIQUE;
 	if (deduplicate) {
-		update_count = RegisterRowIds(g_state.updated_rows, row_ids, update_chunk.size(), sel);
+		D_ASSERT(g_state.updated_rows);
+		update_count = g_state.updated_rows->Register(row_ids, update_chunk.size(), sel);
 		if (row_id_handling == RowIdHandling::ERROR && update_count != update_chunk.size()) {
 			throw InvalidInputException("UPDATE command cannot update the same row more than once");
 		}
@@ -274,7 +279,7 @@ SinkResultType PhysicalUpdate::Sink(ExecutionContext &context, DataChunk &chunk,
 }
 
 unique_ptr<GlobalSinkState> PhysicalUpdate::GetGlobalSinkState(ClientContext &context) const {
-	return make_uniq<UpdateGlobalState>(context, GetTypes());
+	return make_uniq<UpdateGlobalState>(context, GetTypes(), row_id_handling != RowIdHandling::ASSUME_UNIQUE);
 }
 
 unique_ptr<LocalSinkState> PhysicalUpdate::GetLocalSinkState(ExecutionContext &context) const {

--- a/src/execution/row_id_deduplicator.cpp
+++ b/src/execution/row_id_deduplicator.cpp
@@ -1,0 +1,66 @@
+#include "duckdb/execution/row_id_deduplicator.hpp"
+
+#include "duckdb/common/exception.hpp"
+#include "duckdb/execution/aggregate_hashtable.hpp"
+#include "duckdb/main/client_context.hpp"
+
+namespace duckdb {
+
+RowIdDeduplicator::RowIdDeduplicator(ClientContext &context, vector<LogicalType> row_id_types_p)
+    : row_id_types(std::move(row_id_types_p)), addresses(LogicalType::POINTER), new_groups(STANDARD_VECTOR_SIZE) {
+	if (row_id_types.empty()) {
+		throw InternalException("Cannot deduplicate an empty row ID");
+	}
+	row_id_chunk.InitializeEmpty(row_id_types);
+	hash_table = make_uniq<GroupedAggregateHashTable>(context, Allocator::Get(context), row_id_types);
+}
+
+RowIdDeduplicator::~RowIdDeduplicator() {
+}
+
+idx_t RowIdDeduplicator::Register(DataChunk &input, idx_t row_id_start, optional_ptr<SelectionVector> sel) {
+	if (row_id_start >= input.ColumnCount() || input.ColumnCount() - row_id_start != row_id_types.size()) {
+		throw InternalException("Row ID column range does not match the deduplicator types");
+	}
+	for (idx_t i = 0; i < row_id_types.size(); i++) {
+		auto &input_vector = input.data[row_id_start + i];
+		if (input_vector.GetType() != row_id_types[i]) {
+			throw InternalException("Row ID type mismatch in deduplicator");
+		}
+		row_id_chunk.data[i].Reference(input_vector);
+	}
+	row_id_chunk.SetCardinalityUnsafe(input.size());
+	return Register(row_id_chunk, sel);
+}
+
+idx_t RowIdDeduplicator::Register(const Vector &row_ids, idx_t count, optional_ptr<SelectionVector> sel) {
+	if (row_id_types.size() != 1 || row_ids.GetType() != row_id_types[0]) {
+		throw InternalException("Single row ID vector does not match the deduplicator types");
+	}
+	if (count > row_ids.size()) {
+		throw InternalException("Row ID count exceeds vector size");
+	}
+	row_id_chunk.data[0].Reference(row_ids);
+	row_id_chunk.SetCardinalityUnsafe(count);
+	return Register(row_id_chunk, sel);
+}
+
+idx_t RowIdDeduplicator::Register(DataChunk &row_ids, optional_ptr<SelectionVector> sel) {
+	auto count = row_ids.size();
+	if (count == 0) {
+		return 0;
+	}
+	addresses.Reserve(count);
+	auto &result_sel = sel ? *sel : new_groups;
+	if (result_sel.Capacity() < count) {
+		result_sel.Initialize(count);
+	}
+	auto distinct_count = hash_table->FindOrCreateGroups(row_ids, addresses, result_sel);
+	if (sel) {
+		// The hash table may discover new groups in probe order rather than input order.
+		result_sel.Sort(distinct_count);
+	}
+	return distinct_count;
+}
+
+} // namespace duckdb

--- a/src/include/duckdb/execution/operator/persistent/physical_insert.hpp
+++ b/src/include/duckdb/execution/operator/persistent/physical_insert.hpp
@@ -40,7 +40,7 @@ class InsertLocalState : public LocalSinkState {
 public:
 public:
 	InsertLocalState(ClientContext &context, const vector<LogicalType> &types,
-	                 const vector<unique_ptr<BoundConstraint>> &bound_constraints, bool deduplicate_rows);
+	                 const vector<unique_ptr<BoundConstraint>> &bound_constraints, OnConflictAction action_type);
 
 public:
 	ConstraintState &GetConstraintState(DataTable &table, TableCatalogEntry &table_ref);

--- a/src/include/duckdb/execution/operator/persistent/physical_insert.hpp
+++ b/src/include/duckdb/execution/operator/persistent/physical_insert.hpp
@@ -18,6 +18,7 @@
 #include "duckdb/storage/table/delete_state.hpp"
 #include "duckdb/storage/optimistic_data_writer.hpp"
 #include "duckdb/common/types/column/column_data_collection.hpp"
+#include "duckdb/execution/row_id_deduplicator.hpp"
 
 namespace duckdb {
 
@@ -39,7 +40,7 @@ class InsertLocalState : public LocalSinkState {
 public:
 public:
 	InsertLocalState(ClientContext &context, const vector<LogicalType> &types,
-	                 const vector<unique_ptr<BoundConstraint>> &bound_constraints);
+	                 const vector<unique_ptr<BoundConstraint>> &bound_constraints, bool deduplicate_rows);
 
 public:
 	ConstraintState &GetConstraintState(DataTable &table, TableCatalogEntry &table_ref);
@@ -53,7 +54,7 @@ public:
 	PhysicalIndex collection_index;
 	unique_ptr<OptimisticDataWriter> optimistic_writer;
 	// Rows that have been updated by a DO UPDATE conflict
-	unordered_set<row_t> updated_rows;
+	unique_ptr<RowIdDeduplicator> updated_rows;
 	idx_t update_count = 0;
 	unique_ptr<ConstraintState> constraint_state;
 	const vector<unique_ptr<BoundConstraint>> &bound_constraints;

--- a/src/include/duckdb/execution/row_id_deduplicator.hpp
+++ b/src/include/duckdb/execution/row_id_deduplicator.hpp
@@ -9,34 +9,33 @@
 #pragma once
 
 #include "duckdb/common/optional_ptr.hpp"
-#include "duckdb/common/types.hpp"
-#include "duckdb/common/types/vector.hpp"
-#include "duckdb/common/unordered_set.hpp"
-#include "duckdb/common/vector/vector_iterator.hpp"
+#include "duckdb/common/types/data_chunk.hpp"
 
 namespace duckdb {
 
-//! Registers the first `count` row-ids of `row_ids` into `seen`, handling any vector layout. When `sel` is
-//! provided, records the input position of each first-seen row-id (keep-first deduplication). Returns the number
-//! of distinct (first-seen) row-ids. The caller owns its locking and duplicate policy: keep-first by slicing with
-//! `sel`, or raise its own error when the returned count is less than `count`. Shared by UPDATE, MERGE, and
-//! ON CONFLICT DO UPDATE, which otherwise duplicated this row-id iteration.
-inline idx_t RegisterRowIds(unordered_set<row_t> &seen, const Vector &row_ids, idx_t count,
-                            optional_ptr<SelectionVector> sel = nullptr) {
-	idx_t distinct_count = 0;
-	for (const auto &entry : row_ids.Values<row_t>()) {
-		// the caller may pass fewer meaningful entries than the vector holds (e.g. conflict row-ids)
-		if (entry.GetIndex() >= count) {
-			break;
-		}
-		if (seen.insert(entry.GetValue()).second) {
-			if (sel) {
-				sel->set_index(distinct_count, entry.GetIndex());
-			}
-			distinct_count++;
-		}
-	}
-	return distinct_count;
-}
+class ClientContext;
+class GroupedAggregateHashTable;
+
+//! Registers row IDs across chunks. The caller owns locking and decides whether duplicates are kept or rejected.
+class RowIdDeduplicator {
+public:
+	RowIdDeduplicator(ClientContext &context, vector<LogicalType> row_id_types);
+	~RowIdDeduplicator();
+
+	//! Registers the trailing row-ID columns in input, starting at row_id_start.
+	idx_t Register(DataChunk &input, idx_t row_id_start, optional_ptr<SelectionVector> sel = nullptr);
+	//! Registers the first count entries of a single-column row-ID vector.
+	idx_t Register(const Vector &row_ids, idx_t count, optional_ptr<SelectionVector> sel = nullptr);
+
+private:
+	idx_t Register(DataChunk &row_ids, optional_ptr<SelectionVector> sel);
+
+private:
+	vector<LogicalType> row_id_types;
+	unique_ptr<GroupedAggregateHashTable> hash_table;
+	Vector addresses;
+	SelectionVector new_groups;
+	DataChunk row_id_chunk;
+};
 
 } // namespace duckdb

--- a/src/planner/binder/statement/bind_merge_into.cpp
+++ b/src/planner/binder/statement/bind_merge_into.cpp
@@ -438,7 +438,7 @@ BoundStatement Binder::BindNode(MergeQueryNode &node) {
 	}
 
 	merge_into->row_id_start = projection_expressions.size();
-	// finally bind the row id column and add them to the projection list
+	// Row ID columns must remain last: PhysicalMergeInto treats the trailing columns as one composite key.
 	BindRowIdColumns(table, get, projection_expressions);
 
 	auto proj = make_uniq<LogicalProjection>(proj_index, std::move(projection_expressions));

--- a/test/api/CMakeLists.txt
+++ b/test/api/CMakeLists.txt
@@ -32,6 +32,7 @@ set(TEST_API_OBJECTS
     test_operator_memory_limit.cpp
     test_query_profiler.cpp
     test_read_ahead_abandon.cpp
+    test_row_id_deduplicator.cpp
     test_dbdir.cpp
     test_pending_with_parameters.cpp
     test_parse_statement_iterator.cpp

--- a/test/api/test_row_id_deduplicator.cpp
+++ b/test/api/test_row_id_deduplicator.cpp
@@ -1,0 +1,117 @@
+#include "catch.hpp"
+#include "duckdb.hpp"
+#include "duckdb/execution/row_id_deduplicator.hpp"
+#include "test_helpers.hpp"
+
+using namespace duckdb; // NOLINT
+
+static void AppendRow(DataChunk &chunk, int32_t payload, const string &filename, int64_t file_row_number) {
+	chunk.data[0].Append(Value::INTEGER(payload));
+	chunk.data[1].Append(Value(filename));
+	chunk.data[2].Append(Value::BIGINT(file_row_number));
+}
+
+TEST_CASE("Deduplicate composite row IDs", "[row_id_deduplicator]") {
+	DuckDB db;
+	Connection con(db);
+	auto &context = *con.context;
+	RowIdDeduplicator deduplicator(context, {LogicalType::VARCHAR, LogicalType::BIGINT});
+
+	DataChunk first;
+	first.Initialize(context, {LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::BIGINT});
+	AppendRow(first, 10, "file-a.parquet", 0);
+	AppendRow(first, 20, "file-a.parquet", 1);
+	AppendRow(first, 30, "file-b.parquet", 0);
+	AppendRow(first, 40, "file-a.parquet", 0);
+	first.SetChildCardinality(4);
+
+	SelectionVector first_seen(first.size());
+	REQUIRE(deduplicator.Register(first, 1, first_seen) == 3);
+	REQUIRE(first_seen.get_index(0) == 0);
+	REQUIRE(first_seen.get_index(1) == 1);
+	REQUIRE(first_seen.get_index(2) == 2);
+
+	DataChunk second;
+	second.Initialize(context, {LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::BIGINT});
+	AppendRow(second, 50, "file-b.parquet", 0);
+	AppendRow(second, 60, "file-a.parquet", 2);
+	AppendRow(second, 70, "file-c.parquet", 0);
+	AppendRow(second, 80, "file-a.parquet", 2);
+	second.SetChildCardinality(4);
+
+	SelectionVector second_seen(second.size());
+	REQUIRE(deduplicator.Register(second, 1, second_seen) == 2);
+	REQUIRE(second_seen.get_index(0) == 1);
+	REQUIRE(second_seen.get_index(1) == 2);
+}
+
+TEST_CASE("Deduplicate sliced composite row IDs", "[row_id_deduplicator]") {
+	DuckDB db;
+	Connection con(db);
+	auto &context = *con.context;
+
+	DataChunk source;
+	source.Initialize(context, {LogicalType::VARCHAR, LogicalType::BIGINT});
+	source.data[0].Append(Value("file-a.parquet"));
+	source.data[1].Append(Value::BIGINT(0));
+	source.data[0].Append(Value("file-b.parquet"));
+	source.data[1].Append(Value::BIGINT(0));
+	source.data[0].Append(Value("file-a.parquet"));
+	source.data[1].Append(Value::BIGINT(0));
+	source.SetChildCardinality(3);
+
+	SelectionVector reverse(3);
+	reverse.set_index(0, 2);
+	reverse.set_index(1, 1);
+	reverse.set_index(2, 0);
+	DataChunk sliced;
+	sliced.Initialize(context, source.GetTypes());
+	sliced.Slice(source, reverse, 3);
+
+	RowIdDeduplicator deduplicator(context, source.GetTypes());
+	SelectionVector first_seen(sliced.size());
+	REQUIRE(deduplicator.Register(sliced, 0, first_seen) == 2);
+	REQUIRE(first_seen.get_index(0) == 0);
+	REQUIRE(first_seen.get_index(1) == 1);
+}
+
+TEST_CASE("Deduplicate a prefix of a row ID vector", "[row_id_deduplicator]") {
+	DuckDB db;
+	Connection con(db);
+	auto &context = *con.context;
+	RowIdDeduplicator deduplicator(context, {LogicalType::ROW_TYPE});
+
+	Vector row_ids(LogicalType::ROW_TYPE);
+	row_ids.Append(Value::BIGINT(10));
+	row_ids.Append(Value::BIGINT(11));
+	row_ids.Append(Value::BIGINT(10));
+	row_ids.Append(Value::BIGINT(12));
+
+	SelectionVector first_seen(3);
+	REQUIRE(deduplicator.Register(row_ids, 3, first_seen) == 2);
+	REQUIRE(first_seen.get_index(0) == 0);
+	REQUIRE(first_seen.get_index(1) == 1);
+
+	Vector last_row_id(LogicalType::ROW_TYPE);
+	last_row_id.Append(Value::BIGINT(12));
+	REQUIRE(deduplicator.Register(last_row_id, 1) == 1);
+}
+
+TEST_CASE("Preserve input order when row ID hashes collide", "[row_id_deduplicator]") {
+	DuckDB db;
+	Connection con(db);
+	auto &context = *con.context;
+	RowIdDeduplicator deduplicator(context, {LogicalType::ROW_TYPE});
+
+	Vector row_ids(LogicalType::ROW_TYPE);
+	// The first two values have the same initial hash-table bucket and salt.
+	row_ids.Append(Value::BIGINT(2589199));
+	row_ids.Append(Value::BIGINT(9044771));
+	row_ids.Append(Value::BIGINT(42));
+
+	SelectionVector first_seen(3);
+	REQUIRE(deduplicator.Register(row_ids, 3, first_seen) == 3);
+	REQUIRE(first_seen.get_index(0) == 0);
+	REQUIRE(first_seen.get_index(1) == 1);
+	REQUIRE(first_seen.get_index(2) == 2);
+}

--- a/test/api/test_row_id_deduplicator.cpp
+++ b/test/api/test_row_id_deduplicator.cpp
@@ -20,29 +20,43 @@ TEST_CASE("Deduplicate composite row IDs", "[row_id_deduplicator]") {
 	DataChunk first;
 	first.Initialize(context, {LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::BIGINT});
 	AppendRow(first, 10, "file-a.parquet", 0);
-	AppendRow(first, 20, "file-a.parquet", 1);
-	AppendRow(first, 30, "file-b.parquet", 0);
-	AppendRow(first, 40, "file-a.parquet", 0);
-	first.SetChildCardinality(4);
+	AppendRow(first, 20, "file-a.parquet", 0);
+	first.SetChildCardinality(2);
 
 	SelectionVector first_seen(first.size());
-	REQUIRE(deduplicator.Register(first, 1, first_seen) == 3);
+	REQUIRE(deduplicator.Register(first, 1, first_seen) == 1);
 	REQUIRE(first_seen.get_index(0) == 0);
-	REQUIRE(first_seen.get_index(1) == 1);
-	REQUIRE(first_seen.get_index(2) == 2);
 
 	DataChunk second;
 	second.Initialize(context, {LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::BIGINT});
-	AppendRow(second, 50, "file-b.parquet", 0);
-	AppendRow(second, 60, "file-a.parquet", 2);
-	AppendRow(second, 70, "file-c.parquet", 0);
-	AppendRow(second, 80, "file-a.parquet", 2);
-	second.SetChildCardinality(4);
+	AppendRow(second, 30, "file-a.parquet", 1);
+	AppendRow(second, 40, "file-b.parquet", 0);
+	second.SetChildCardinality(2);
 
 	SelectionVector second_seen(second.size());
 	REQUIRE(deduplicator.Register(second, 1, second_seen) == 2);
-	REQUIRE(second_seen.get_index(0) == 1);
-	REQUIRE(second_seen.get_index(1) == 2);
+	REQUIRE(second_seen.get_index(0) == 0);
+	REQUIRE(second_seen.get_index(1) == 1);
+
+	DataChunk third;
+	third.Initialize(context, {LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::BIGINT});
+	AppendRow(third, 50, "file-b.parquet", 0);
+	AppendRow(third, 60, "file-a.parquet", 2);
+	third.SetChildCardinality(2);
+
+	SelectionVector third_seen(third.size());
+	REQUIRE(deduplicator.Register(third, 1, third_seen) == 1);
+	REQUIRE(third_seen.get_index(0) == 1);
+
+	DataChunk fourth;
+	fourth.Initialize(context, {LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::BIGINT});
+	AppendRow(fourth, 70, "file-c.parquet", 0);
+	AppendRow(fourth, 80, "file-a.parquet", 2);
+	fourth.SetChildCardinality(2);
+
+	SelectionVector fourth_seen(fourth.size());
+	REQUIRE(deduplicator.Register(fourth, 1, fourth_seen) == 1);
+	REQUIRE(fourth_seen.get_index(0) == 0);
 }
 
 TEST_CASE("Deduplicate sliced composite row IDs", "[row_id_deduplicator]") {
@@ -56,23 +70,26 @@ TEST_CASE("Deduplicate sliced composite row IDs", "[row_id_deduplicator]") {
 	source.data[1].Append(Value::BIGINT(0));
 	source.data[0].Append(Value("file-b.parquet"));
 	source.data[1].Append(Value::BIGINT(0));
-	source.data[0].Append(Value("file-a.parquet"));
-	source.data[1].Append(Value::BIGINT(0));
-	source.SetChildCardinality(3);
+	source.SetChildCardinality(2);
 
-	SelectionVector reverse(3);
-	reverse.set_index(0, 2);
-	reverse.set_index(1, 1);
-	reverse.set_index(2, 0);
+	SelectionVector reverse(2);
+	reverse.set_index(0, 1);
+	reverse.set_index(1, 0);
 	DataChunk sliced;
 	sliced.Initialize(context, source.GetTypes());
-	sliced.Slice(source, reverse, 3);
+	sliced.Slice(source, reverse, 2);
 
 	RowIdDeduplicator deduplicator(context, source.GetTypes());
+	DataChunk existing;
+	existing.Initialize(context, source.GetTypes());
+	existing.data[0].Append(Value("file-a.parquet"));
+	existing.data[1].Append(Value::BIGINT(0));
+	existing.SetChildCardinality(1);
+	REQUIRE(deduplicator.Register(existing, 0) == 1);
+
 	SelectionVector first_seen(sliced.size());
-	REQUIRE(deduplicator.Register(sliced, 0, first_seen) == 2);
+	REQUIRE(deduplicator.Register(sliced, 0, first_seen) == 1);
 	REQUIRE(first_seen.get_index(0) == 0);
-	REQUIRE(first_seen.get_index(1) == 1);
 }
 
 TEST_CASE("Deduplicate a prefix of a row ID vector", "[row_id_deduplicator]") {
@@ -84,16 +101,13 @@ TEST_CASE("Deduplicate a prefix of a row ID vector", "[row_id_deduplicator]") {
 	Vector row_ids(LogicalType::ROW_TYPE);
 	row_ids.Append(Value::BIGINT(10));
 	row_ids.Append(Value::BIGINT(11));
-	row_ids.Append(Value::BIGINT(10));
-	row_ids.Append(Value::BIGINT(12));
 
-	SelectionVector first_seen(3);
-	REQUIRE(deduplicator.Register(row_ids, 3, first_seen) == 2);
+	SelectionVector first_seen(1);
+	REQUIRE(deduplicator.Register(row_ids, 1, first_seen) == 1);
 	REQUIRE(first_seen.get_index(0) == 0);
-	REQUIRE(first_seen.get_index(1) == 1);
 
 	Vector last_row_id(LogicalType::ROW_TYPE);
-	last_row_id.Append(Value::BIGINT(12));
+	last_row_id.Append(Value::BIGINT(11));
 	REQUIRE(deduplicator.Register(last_row_id, 1) == 1);
 }
 
@@ -104,14 +118,12 @@ TEST_CASE("Preserve input order when row ID hashes collide", "[row_id_deduplicat
 	RowIdDeduplicator deduplicator(context, {LogicalType::ROW_TYPE});
 
 	Vector row_ids(LogicalType::ROW_TYPE);
-	// The first two values have the same initial hash-table bucket and salt.
+	// These values have the same initial hash-table bucket and salt.
 	row_ids.Append(Value::BIGINT(2589199));
 	row_ids.Append(Value::BIGINT(9044771));
-	row_ids.Append(Value::BIGINT(42));
 
-	SelectionVector first_seen(3);
-	REQUIRE(deduplicator.Register(row_ids, 3, first_seen) == 3);
+	SelectionVector first_seen(2);
+	REQUIRE(deduplicator.Register(row_ids, 2, first_seen) == 2);
 	REQUIRE(first_seen.get_index(0) == 0);
 	REQUIRE(first_seen.get_index(1) == 1);
-	REQUIRE(first_seen.get_index(2) == 2);
 }


### PR DESCRIPTION
Fixes the issue discussed here: https://github.com/duckdb/duckdb/pull/24058#issuecomment-5107569952

The implementation assumed a single-column row identifier, which isn't true for Iceberg. This PR allows composite row ids using a `GroupedAggregateHashTable` and cleans up the implementation a bit.