### PR TITLE
Allow passing an Identifier to SQLQuotedIdentifier directly

### DIFF
--- a/src/catalog/catalog_search_path.cpp
+++ b/src/catalog/catalog_search_path.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/catalog/catalog.hpp"
 #include "duckdb/common/constants.hpp"
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/sql_identifier.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/database_manager.hpp"
@@ -29,7 +30,7 @@ string CatalogSearchEntry::WriteOptionallyQuoted(const Identifier &input) {
 	auto &name = input.GetIdentifierName();
 	for (idx_t i = 0; i < name.size(); i++) {
 		if (name[i] == '.' || name[i] == ',' || name[i] == '"') {
-			return "\"" + StringUtil::Replace(name, "\"", "\"\"") + "\"";
+			return SQLQuotedIdentifier::ToString(name);
 		}
 	}
 	return name;

--- a/src/include/duckdb/common/sql_identifier.hpp
+++ b/src/include/duckdb/common/sql_identifier.hpp
@@ -59,6 +59,9 @@ class SQLQuotedIdentifier {
 public:
 	explicit SQLQuotedIdentifier(const string &raw_string) : raw_string(raw_string) {
 	}
+	explicit SQLQuotedIdentifier(const char *raw_string) : raw_string(raw_string) {
+	}
+	explicit SQLQuotedIdentifier(const Identifier &id);
 
 	//! Emits an optionally quoted identifier including required escapes (i.e. ident -> ident, table -> "table")
 	static string ToString(const string &identifier);

--- a/src/parser/keyword_helper.cpp
+++ b/src/parser/keyword_helper.cpp
@@ -93,6 +93,9 @@ string SQLIdentifier::ToString(const string &identifier) {
 	return SQLQuotedIdentifier::ToString(identifier);
 }
 
+SQLQuotedIdentifier::SQLQuotedIdentifier(const Identifier &id) : raw_string(id.GetIdentifierName()) {
+}
+
 string SQLQuotedIdentifier::ToString(const string &identifier) {
 	return KeywordHelper::WriteQuotedAndEscaped(identifier, '"');
 }


### PR DESCRIPTION
`SQLIdentifier` could already be constructed from an `Identifier`, but
`SQLQuotedIdentifier` could not, so callers holding an `Identifier` had to
reach for `GetIdentifierName()` to get at the underlying string first. Giving
both helpers the same set of constructors removes that asymmetry, and lets
`CatalogSearchEntry::WriteOptionallyQuoted` drop its hand-rolled
`"\"" + StringUtil::Replace(name, "\"", "\"\"") + "\""` in favour of
`SQLQuotedIdentifier::ToString`, which does precisely the same escaping.

The added `const char *` overload is needed because `Identifier` is implicitly
constructible from a string literal, which would otherwise make
`SQLQuotedIdentifier("foo")` ambiguous between the `string` and `Identifier`
constructors.
