### PR TITLE
Shell query timeout

### DIFF
--- a/tools/shell/include/shell_state.hpp
+++ b/tools/shell/include/shell_state.hpp
@@ -241,6 +241,8 @@ public:
 	bool highlighting_enabled = true;
 	//! Whether or not we are running in safe mode
 	bool safe_mode = false;
+	//! Interrupt queries that run longer than this many milliseconds (0 = no timeout)
+	idx_t query_timeout_ms = 0;
 	//! Whether or not we are highlighting errors
 	OptionType highlight_errors = OptionType::DEFAULT;
 	//! Whether or not we are highlighting results
@@ -446,6 +448,7 @@ public:
 	static MetadataResult SetSeparator(ShellState &state, const vector<string> &args);
 	static MetadataResult EnableSafeMode(ShellState &state, const vector<string> &args);
 	static MetadataResult ToggleTimer(ShellState &state, const vector<string> &args);
+	static MetadataResult SetQueryTimeout(ShellState &state, const vector<string> &args);
 	SuccessState ChangeDirectory(const string &path);
 	SuccessState ShowDatabases();
 	void CloseOutputFile(FILE *file);

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -94,8 +94,18 @@
 #include "shell_highlight.hpp"
 #include "shell_manual.hpp"
 #include "shell_state.hpp"
+#include "duckdb/common/box_renderer.hpp"
 #include "duckdb/main/error_manager.hpp"
 #include "duckdb/main/client_config.hpp"
+
+#include <algorithm>
+#include <cmath>
+#ifndef DUCKDB_NO_THREADS
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+#endif
 
 using namespace duckdb_shell;
 
@@ -941,6 +951,78 @@ ShellState &ShellState::Get() {
 	return *GetReference();
 }
 
+//! Interrupts the connection once the timeout expires, unless the query finishes first
+class QueryWatchdog {
+public:
+	QueryWatchdog(duckdb::Connection &conn, idx_t timeout_ms) : conn(conn), timeout_ms(timeout_ms) {
+#ifndef DUCKDB_NO_THREADS
+		if (timeout_ms > 0) {
+			watch_thread = duckdb::make_uniq<std::thread>([this]() { Watch(); });
+		}
+#endif
+	}
+	~QueryWatchdog() {
+#ifndef DUCKDB_NO_THREADS
+		if (!watch_thread) {
+			return;
+		}
+		{
+			std::lock_guard<std::mutex> guard(lock);
+			query_finished = true;
+		}
+		cv.notify_all();
+		watch_thread->join();
+		if (fired) {
+			// clear the interrupt in case the query finished before the interrupt was seen
+			conn.context->ClearInterrupt();
+		}
+#endif
+	}
+
+	bool TimedOut() const {
+#ifndef DUCKDB_NO_THREADS
+		return fired;
+#else
+		return false;
+#endif
+	}
+
+	//! The progress of the query at the time the timeout fired
+	duckdb::QueryProgress GetProgress() const {
+#ifndef DUCKDB_NO_THREADS
+		return fired_progress;
+#else
+		return duckdb::QueryProgress();
+#endif
+	}
+
+private:
+#ifndef DUCKDB_NO_THREADS
+	void Watch() {
+		std::unique_lock<std::mutex> guard(lock);
+		if (cv.wait_for(guard, std::chrono::milliseconds(timeout_ms), [this]() { return query_finished; })) {
+			// the query finished before the timeout expired
+			return;
+		}
+		fired_progress = conn.context->GetQueryProgress();
+		fired = true;
+		conn.Interrupt();
+	}
+#endif
+
+private:
+	duckdb::Connection &conn;
+	idx_t timeout_ms;
+#ifndef DUCKDB_NO_THREADS
+	std::mutex lock;
+	std::condition_variable cv;
+	bool query_finished = false;
+	atomic<bool> fired {false};
+	duckdb::QueryProgress fired_progress;
+	duckdb::unique_ptr<std::thread> watch_thread;
+#endif
+};
+
 SuccessState ShellState::ExecuteStatement(unique_ptr<duckdb::SQLStatement> statement) {
 	if (statement->has_anonymous_parameters) {
 		PrintDatabaseError("Prepared statement parameters cannot be used directly\nTo use prepared "
@@ -949,6 +1031,7 @@ SuccessState ShellState::ExecuteStatement(unique_ptr<duckdb::SQLStatement> state
 	}
 	auto &con = *conn;
 	auto renderer = GetRenderer();
+	QueryWatchdog watchdog(con, query_timeout_ms);
 	unique_ptr<duckdb::QueryResult> result;
 	if (renderer->RequireMaterializedResult()) {
 		// we need to materialize the result prior to rendering
@@ -961,8 +1044,30 @@ SuccessState ShellState::ExecuteStatement(unique_ptr<duckdb::SQLStatement> state
 		result = con.SendQuery(std::move(statement));
 	}
 	auto &res = *result;
+	auto print_query_error = [&]() {
+		if (watchdog.TimedOut() && res.GetErrorObject().Type() == duckdb::ExceptionType::INTERRUPT) {
+			auto msg = "Query interrupted: run time exceeded .timeout of " + to_string(query_timeout_ms) + " ms";
+			auto progress = watchdog.GetProgress();
+			if (progress.GetPercentage() >= 0) {
+				auto format_count = [&](uint64_t count) {
+					auto str = to_string(count);
+					auto formatted = duckdb::BoxRenderer::TryFormatLargeNumber(str, decimal_separator);
+					return formatted.empty() ? str : formatted;
+				};
+				msg += StringUtil::Format(" (~%.1f%% completed", progress.GetPercentage());
+				if (progress.GetRowsProcessed() > 0 && progress.GetTotalRowsToProcess() > 0) {
+					msg += ", processed ~" + format_count(progress.GetRowsProcessed()) + " of ~" +
+					       format_count(progress.GetTotalRowsToProcess()) + " rows";
+				}
+				msg += ")";
+			}
+			PrintDatabaseError(msg);
+		} else {
+			PrintDatabaseError(res.GetError());
+		}
+	};
 	if (res.HasError()) {
-		PrintDatabaseError(res.GetError());
+		print_query_error();
 		return SuccessState::FAILURE;
 	}
 	auto &properties = res.properties;
@@ -986,6 +1091,11 @@ SuccessState ShellState::ExecuteStatement(unique_ptr<duckdb::SQLStatement> state
 	}
 	// analyze the query result so we know how long/wide the result will be
 	auto render_state = RenderQueryResult(*renderer, res);
+	if (res.HasError() && !seenInterrupt) {
+		// streaming results can hit an error mid-rendering - surface it after the partial result
+		print_query_error();
+		return SuccessState::FAILURE;
+	}
 	return render_state;
 }
 
@@ -2603,6 +2713,70 @@ SuccessState ShellState::ShowDatabases() {
 	result_list.push_back(std::move(result));
 	RenderTableMetadata(result_list);
 	return SuccessState::SUCCESS;
+}
+
+//! Parses a duration such as "500", "500ms", "10s", "2m" or "0.5h" into milliseconds
+static bool TryParseDuration(const string &arg, idx_t &result_ms) {
+	idx_t pos = 0;
+	while (pos < arg.size() && ((arg[pos] >= '0' && arg[pos] <= '9') || arg[pos] == '.')) {
+		pos++;
+	}
+	if (pos == 0) {
+		return false;
+	}
+	auto number = arg.substr(0, pos);
+	double value;
+	try {
+		size_t consumed;
+		value = std::stod(number, &consumed);
+		if (consumed != number.size()) {
+			return false;
+		}
+	} catch (...) {
+		return false;
+	}
+	double multiplier;
+	auto unit = StringUtil::Lower(arg.substr(pos));
+	if (unit.empty() || unit == "ms") {
+		multiplier = 1;
+	} else if (unit == "s") {
+		multiplier = 1000;
+	} else if (unit == "m" || unit == "min") {
+		multiplier = 60 * 1000;
+	} else if (unit == "h") {
+		multiplier = 60 * 60 * 1000;
+	} else {
+		return false;
+	}
+	auto total_ms = value * multiplier;
+	if (total_ms < 0 || total_ms >= 9007199254740992.0) { // 2^53 - stay within exact double integers
+		return false;
+	}
+	result_ms = duckdb::LossyNumericCast<idx_t>(std::round(total_ms));
+	return true;
+}
+
+MetadataResult ShellState::SetQueryTimeout(ShellState &state, const vector<string> &args) {
+#ifdef DUCKDB_NO_THREADS
+	state.PrintF(PrintOutput::STDERR, "Error: query timeout not available on this system.\n");
+	return MetadataResult::FAIL;
+#else
+	idx_t timeout_ms;
+	if (!TryParseDuration(args[1], timeout_ms)) {
+		state.PrintF(PrintOutput::STDERR, "Error: expected a duration such as 500, 500ms, 10s or 0.5h, got \"%s\"\n",
+		             args[1].c_str());
+		return MetadataResult::FAIL;
+	}
+	state.query_timeout_ms = timeout_ms;
+	if (timeout_ms > 0) {
+		// track query progress so that a timed-out query can report how far it got
+		state.ExecuteQuery("PRAGMA enable_progress_bar");
+		if (!state.stdout_is_console) {
+			state.ExecuteQuery("SET print_progress_bar=false");
+		}
+	}
+	return MetadataResult::SUCCESS;
+#endif
 }
 
 MetadataResult ShellState::ToggleTimer(ShellState &state, const vector<string> &args) {

--- a/tools/shell/shell_command_line_option.cpp
+++ b/tools/shell/shell_command_line_option.cpp
@@ -251,6 +251,8 @@ static const CommandLineOption command_line_options[] = {
     {"storage-version", 1, "VER", SetStorageVersion, nullptr,
      "database storage compatibility version to use. Default: 'v0.10.0'"},
     {"table", 0, "", nullptr, ToggleOutputMode<RenderMode::TABLE>, "set output mode to 'table'"},
+    {"timeout", 1, "DURATION", nullptr, ShellState::SetQueryTimeout,
+     "interrupt queries that run for longer than DURATION (e.g. 500ms, 10s, 0.5h)"},
     {"ui", 0, "", nullptr, LaunchUI, "launches a web interface using the ui extension (configurable with .ui_command)"},
     {"unredacted", 0, "", AllowUnredacted, nullptr, "allow printing unredacted secrets"},
     {"unsigned", 0, "", AllowUnsigned, nullptr, "allow loading of unsigned extensions"},

--- a/tools/shell/shell_metadata_command.cpp
+++ b/tools/shell/shell_metadata_command.cpp
@@ -1005,6 +1005,8 @@ static const MetadataCommand metadata_commands[] = {
     {"tables", 0, ShowTables, "?TABLE?", "List names of tables matching LIKE pattern TABLE", 2, ""},
     {"thousand_sep", 0, SetThousandSep, "SEP",
      "Sets the thousand separator used when rendering numbers. Only for duckbox mode.", 4, ""},
+    {"timeout", 2, ShellState::SetQueryTimeout, "DURATION",
+     "Interrupt queries that run for longer than DURATION (e.g. 500ms, 10s, 0.5h - 0 to disable)", 0, ""},
     {"timer", 2, ShellState::ToggleTimer, "on|off", "Turn SQL timer on or off", 0, ""},
     {"ui_command", 0, SetUICommand, "[command]", "Set the UI command", 0, ""},
     {"version", 1, ShowVersion, "", "Show the version", 0, ""},

--- a/tools/shell/tests/test_timeout.py
+++ b/tools/shell/tests/test_timeout.py
@@ -1,0 +1,103 @@
+# fmt: off
+
+import pytest
+from conftest import ShellTest
+
+# a query that runs for a very long time without the timeout
+SLOW_QUERY = "SELECT COUNT(*) FROM range(100000000) t1, range(10000) t2;"
+
+
+def test_timeout_interrupts_query(shell):
+    test = (
+        ShellTest(shell)
+        .statement(".timeout 100")
+        .statement(SLOW_QUERY)
+    )
+    result = test.run()
+    result.check_stderr("run time exceeded .timeout of 100 ms")
+    # progress context is reported alongside the timeout
+    result.check_stderr("% completed")
+
+
+def test_timeout_streaming_result(shell):
+    test = (
+        ShellTest(shell)
+        .statement(".mode csv")
+        .statement(".timeout 100")
+        .statement("SELECT * FROM range(100000000) t1, range(10000) t2;")
+    )
+    result = test.run()
+    result.check_stderr("run time exceeded .timeout of 100 ms")
+
+
+def test_timeout_command_line_argument(shell):
+    test = (
+        ShellTest(shell)
+        .add_argument("-timeout", "100")
+        .statement(SLOW_QUERY)
+    )
+    result = test.run()
+    result.check_stderr("run time exceeded .timeout of 100 ms")
+
+
+def test_timeout_query_completes_in_time(shell):
+    test = (
+        ShellTest(shell)
+        .statement(".timeout 100000")
+        .statement("SELECT 42 AS x;")
+        .statement("SELECT 84 AS y;")
+    )
+    result = test.run()
+    result.check_stdout("42")
+    result.check_stdout("84")
+
+
+def test_timeout_disable(shell):
+    test = (
+        ShellTest(shell)
+        .statement(".timeout 100")
+        .statement(".timeout 0")
+        .statement("SELECT COUNT(*) FROM range(10000000) t(i);")
+    )
+    result = test.run()
+    result.check_stdout("10000000")
+
+
+def test_timeout_duration_unit(shell):
+    test = (
+        ShellTest(shell)
+        .statement(".timeout 1s")
+        .statement(SLOW_QUERY)
+    )
+    result = test.run()
+    result.check_stderr("run time exceeded .timeout of 1000 ms")
+
+
+@pytest.mark.parametrize("duration", ["500ms", "10s", "2m", "2min", "0.5h", ".5s", "0"])
+def test_timeout_accepted_durations(shell, duration):
+    test = (
+        ShellTest(shell)
+        .statement(f".timeout {duration}")
+        .statement("SELECT 42 AS x;")
+    )
+    result = test.run()
+    result.check_stdout("42")
+
+
+@pytest.mark.parametrize("duration", ["xyz", "10x", "1.2.3", "s", "-100"])
+def test_timeout_invalid_argument(shell, duration):
+    test = (
+        ShellTest(shell)
+        .statement(f".timeout {duration}")
+    )
+    result = test.run()
+    result.check_stderr("expected a duration")
+
+
+def test_timeout_missing_argument(shell):
+    test = (
+        ShellTest(shell)
+        .statement(".timeout")
+    )
+    result = test.run()
+    result.check_stderr("Invalid usage of command '.timeout'")


### PR DESCRIPTION
This PR adds a CLI query timeout that can be set either with `.timeout 1m` or via a command line flag. When the timeout hits, an error is thrown that shows some progress info. 