### PR TITLE
Prune row groups for Parquet INTERVAL columns with bloom filters

### DIFF
--- a/extension/parquet/include/parquet_interval.hpp
+++ b/extension/parquet/include/parquet_interval.hpp
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// parquet_interval.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/helper.hpp"
+#include "duckdb/common/types/interval.hpp"
+#include "zstd/common/xxhash.hpp"
+
+namespace duckdb {
+
+struct ParquetIntervalUtils {
+	static constexpr const idx_t PARQUET_INTERVAL_SIZE = 12;
+
+	static void Encode(const interval_t &interval, data_ptr_t target) {
+		Store<uint32_t>(static_cast<uint32_t>(interval.months), target);
+		Store<uint32_t>(static_cast<uint32_t>(interval.days), target + sizeof(uint32_t));
+		Store<uint32_t>(static_cast<uint32_t>(interval.micros / Interval::MICROS_PER_MSEC),
+		                target + sizeof(uint32_t) * 2);
+	}
+
+	static uint64_t HashNormalized(const interval_t &interval) {
+		data_t bytes[PARQUET_INTERVAL_SIZE];
+		Encode(interval.Normalize(), bytes);
+		return duckdb_zstd::XXH64(bytes, sizeof(bytes), 0);
+	}
+};
+
+} // namespace duckdb

--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -82,6 +82,7 @@ class ParquetReader;
 class DataChunk;
 class Deserializer;
 class EncryptionUtil;
+enum class ParquetIntervalBloomFilterVersion : uint8_t;
 class PhysicalOperator;
 class Serializer;
 class TableFilter;
@@ -335,6 +336,7 @@ public:
 	shared_ptr<EncryptionUtil> encryption_util;
 	//! How many rows have been read from this file
 	atomic<idx_t> rows_read;
+	ParquetIntervalBloomFilterVersion interval_bloom_filter_version {};
 	//! Storage indices of columns where expressions like strlen/octet_length are pushed down
 	unordered_map<idx_t, ParquetReaderProjectionExpression> projection_expressions;
 
@@ -368,6 +370,9 @@ public:
 	idx_t GetDataSize() const;
 
 	const duckdb_parquet::FileMetaData *GetFileMetadata() const;
+	ParquetIntervalBloomFilterVersion GetIntervalBloomFilterVersion() const {
+		return interval_bloom_filter_version;
+	}
 	string static GetUniqueFileIdentifier(const duckdb_parquet::EncryptionAlgorithm &encryption_algorithm);
 
 	uint32_t Read(duckdb_apache::thrift::TBase &object, TProtocol &iprot) const;

--- a/extension/parquet/include/parquet_statistics.hpp
+++ b/extension/parquet/include/parquet_statistics.hpp
@@ -31,6 +31,7 @@ class TProtocol;
 namespace duckdb_parquet {
 class ColumnChunk;
 class ColumnMetaData;
+class FileMetaData;
 class SchemaElement;
 class Statistics;
 } // namespace duckdb_parquet
@@ -47,7 +48,14 @@ struct LogicalType;
 struct ParquetColumnSchema;
 class ResizeableBuffer;
 
+enum class ParquetIntervalBloomFilterVersion : uint8_t { NONE, NORMALIZED_V1 };
+
+enum class ParquetBloomFilterHashStrategy : uint8_t { STANDARD, NORMALIZED_INTERVAL_V1 };
+
 struct ParquetStatisticsUtils {
+	static constexpr const char *INTERVAL_BLOOM_FILTER_KEY = "duckdb.interval_bloom_filter";
+	static constexpr const char *INTERVAL_BLOOM_FILTER_VALUE = "normalized-v1";
+
 	static unique_ptr<BaseStatistics> TransformColumnStatistics(const ParquetColumnSchema &reader,
 	                                                            const vector<ColumnChunk> &columns, bool can_have_nan);
 
@@ -58,11 +66,16 @@ struct ParquetStatisticsUtils {
 
 	static Value ConvertValue(const LogicalType &type, const ParquetColumnSchema &schema_ele, const std::string &stats);
 
-	static bool BloomFilterSupported(const ParquetColumnSchema &schema);
+	static ParquetIntervalBloomFilterVersion
+	GetIntervalBloomFilterVersion(const duckdb_parquet::FileMetaData &file_meta_data);
+
+	static optional<ParquetBloomFilterHashStrategy>
+	GetBloomFilterHashStrategy(const ParquetColumnSchema &schema,
+	                           ParquetIntervalBloomFilterVersion interval_bloom_filter_version);
 
 	static bool BloomFilterExcludes(const TableFilter &filter, const duckdb_parquet::ColumnMetaData &column_meta_data,
 	                                duckdb_apache::thrift::protocol::TProtocol &file_proto, Allocator &allocator,
-	                                const ParquetColumnSchema &schema);
+	                                const ParquetColumnSchema &schema, ParquetBloomFilterHashStrategy hash_strategy);
 
 	static unique_ptr<BaseStatistics> CreateNumericStats(const LogicalType &type, const ParquetColumnSchema &schema_ele,
 	                                                     const duckdb_parquet::Statistics &parquet_stats);

--- a/extension/parquet/include/writer/parquet_write_operators.hpp
+++ b/extension/parquet/include/writer/parquet_write_operators.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "writer/parquet_write_stats.hpp"
+#include "parquet_interval.hpp"
 #include "parquet_timestamp.hpp"
 #include "zstd/common/xxhash.hpp"
 #include "duckdb/common/types/time.hpp"
@@ -248,7 +249,7 @@ struct ParquetStringOperator : public ParquetBaseStringOperator {
 };
 
 struct ParquetIntervalTargetType {
-	static constexpr const idx_t PARQUET_INTERVAL_SIZE = 12;
+	static constexpr const idx_t PARQUET_INTERVAL_SIZE = ParquetIntervalUtils::PARQUET_INTERVAL_SIZE;
 	data_t bytes[PARQUET_INTERVAL_SIZE];
 };
 
@@ -259,9 +260,7 @@ struct ParquetIntervalOperator : public BaseParquetOperator {
 			throw IOException("Parquet files do not support negative intervals");
 		}
 		TGT result;
-		Store<uint32_t>(input.months, result.bytes);
-		Store<uint32_t>(input.days, result.bytes + sizeof(uint32_t));
-		Store<uint32_t>(input.micros / 1000, result.bytes + sizeof(uint32_t) * 2);
+		ParquetIntervalUtils::Encode(input, result.bytes);
 		return result;
 	}
 
@@ -288,8 +287,7 @@ struct ParquetIntervalOperator : public BaseParquetOperator {
 	template <class SRC, class TGT>
 	static optional<uint64_t> GetExtraBloomFilterHash(const SRC &source_value, const TGT &) {
 		// Preserve the Parquet plain-encoding hash and add the hash used by DuckDB comparisons.
-		auto normalized_value = Operation<SRC, TGT>(source_value.Normalize());
-		return XXHash64<SRC, TGT>(normalized_value);
+		return ParquetIntervalUtils::HashNormalized(source_value);
 	}
 };
 

--- a/extension/parquet/include/writer/parquet_write_operators.hpp
+++ b/extension/parquet/include/writer/parquet_write_operators.hpp
@@ -34,6 +34,16 @@ struct BaseParquetOperator {
 	}
 
 	template <class SRC, class TGT>
+	static idx_t BloomFilterEntriesPerValue() {
+		return 1;
+	}
+
+	template <class SRC, class TGT>
+	static optional<uint64_t> GetExtraBloomFilterHash(const SRC &, const TGT &) {
+		return nullopt;
+	}
+
+	template <class SRC, class TGT>
 	static unique_ptr<ColumnWriterStatistics> InitializeStats() {
 		return nullptr;
 	}
@@ -268,6 +278,18 @@ struct ParquetIntervalOperator : public BaseParquetOperator {
 	template <class SRC, class TGT>
 	static uint64_t XXHash64(const TGT &target_value) {
 		return duckdb_zstd::XXH64(target_value.bytes, ParquetIntervalTargetType::PARQUET_INTERVAL_SIZE, 0);
+	}
+
+	template <class SRC, class TGT>
+	static idx_t BloomFilterEntriesPerValue() {
+		return 2;
+	}
+
+	template <class SRC, class TGT>
+	static optional<uint64_t> GetExtraBloomFilterHash(const SRC &source_value, const TGT &) {
+		// Preserve the Parquet plain-encoding hash and add the hash used by DuckDB comparisons.
+		auto normalized_value = Operation<SRC, TGT>(source_value.Normalize());
+		return XXHash64<SRC, TGT>(normalized_value);
 	}
 };
 

--- a/extension/parquet/include/writer/templated_column_writer.hpp
+++ b/extension/parquet/include/writer/templated_column_writer.hpp
@@ -295,8 +295,10 @@ public:
 		         state.encoding == duckdb_parquet::Encoding::PLAIN_DICTIONARY);
 
 		if (writer.EnableBloomFilters()) {
+			auto bloom_filter_entries =
+			    state.dictionary.GetSize() * OP::template BloomFilterEntriesPerValue<SRC, TGT>();
 			state.bloom_filter =
-			    make_uniq<ParquetBloomFilter>(state.dictionary.GetSize(), writer.BloomFilterFalsePositiveRatio());
+			    make_uniq<ParquetBloomFilter>(bloom_filter_entries, writer.BloomFilterFalsePositiveRatio());
 		}
 
 		state.dictionary.IterateValues([&](const SRC &src_value, const TGT &tgt_value) {
@@ -306,6 +308,10 @@ public:
 				// update the bloom filter
 				auto hash = OP::template XXHash64<SRC, TGT>(tgt_value);
 				state.bloom_filter->FilterInsert(hash);
+				auto extra_hash = OP::template GetExtraBloomFilterHash<SRC, TGT>(src_value, tgt_value);
+				if (extra_hash) {
+					state.bloom_filter->FilterInsert(*extra_hash);
+				}
 			}
 		});
 

--- a/extension/parquet/parquet_metadata.cpp
+++ b/extension/parquet/parquet_metadata.cpp
@@ -817,6 +817,7 @@ private:
 	unique_ptr<duckdb_apache::thrift::protocol::TCompactProtocolT<ThriftFileTransport>> protocol;
 	optional_ptr<Allocator> allocator;
 	unique_ptr<ExpressionFilter> filter;
+	optional<ParquetBloomFilterHashStrategy> hash_strategy;
 };
 
 template <>
@@ -859,6 +860,9 @@ void ParquetBloomProbeProcessor::InitializeInternal(ClientContext &context, Parq
 	    make_uniq<BoundReferenceExpression>(Identifier(probe_column_name), column_type, 0),
 	    make_uniq<BoundConstantExpression>(probe_constant.CastAs(context, column_type)));
 	filter = make_uniq<ExpressionFilter>(std::move(comparison));
+	auto &column_schema = reader.root_schema->children[probe_column_idx.GetIndex()];
+	hash_strategy =
+	    ParquetStatisticsUtils::GetBloomFilterHashStrategy(column_schema, reader.GetIntervalBloomFilterVersion());
 }
 
 idx_t ParquetBloomProbeProcessor::TotalRowCount(ParquetReader &reader) {
@@ -874,7 +878,8 @@ void ParquetBloomProbeProcessor::ReadRow(vector<reference<Vector>> &output, idx_
 
 	auto &column_schema = reader.root_schema->children[probe_column_idx.GetIndex()];
 	auto bloom_excludes =
-	    ParquetStatisticsUtils::BloomFilterExcludes(*filter, column.meta_data, *protocol, *allocator, column_schema);
+	    hash_strategy && ParquetStatisticsUtils::BloomFilterExcludes(*filter, column.meta_data, *protocol, *allocator,
+	                                                                 column_schema, *hash_strategy);
 
 	output[0].get().Append(Value(reader.file.path));
 	output[1].get().Append(Value::BIGINT(NumericCast<int64_t>(row_idx)));

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1286,6 +1286,7 @@ ParquetReader::ParquetReader(ClientContext &context_p, OpenFileInfo file_p, Parq
 			encryption_util = context_p.db->GetEncryptionUtil(true);
 		}
 	}
+	interval_bloom_filter_version = ParquetStatisticsUtils::GetIntervalBloomFilterVersion(*GetFileMetadata());
 	InitializeSchema(context_p);
 	// Length-pushdown rewrites these columns to BIGINT, update the local schema
 	for (const auto &[idx, expr] : projection_expressions) {
@@ -1333,6 +1334,7 @@ ParquetReader::ParquetReader(ClientContext &context_p, ParquetOptions parquet_op
                              shared_ptr<ParquetFileMetadataCache> metadata_p)
     : BaseFileReader(string()), fs(CachingFileSystem::Get(context_p)), allocator(BufferAllocator::Get(context_p)),
       metadata(std::move(metadata_p)), parquet_options(std::move(parquet_options_p)), rows_read(0) {
+	interval_bloom_filter_version = ParquetStatisticsUtils::GetIntervalBloomFilterVersion(*GetFileMetadata());
 	InitializeSchema(context_p);
 }
 
@@ -1503,6 +1505,11 @@ static bool TryGetNestedBloomFilterLeaf(ColumnReader &column_reader, const Expre
 		return false;
 	}
 
+	if (leaf_reader->Type().id() == LogicalTypeId::INTERVAL && function.GetChildren().size() == 1 &&
+	    function.Function().GetName() == "normalized_interval") {
+		return true;
+	}
+
 	// Handle LIST type.
 	if (leaf_reader->Type().id() == LogicalTypeId::LIST &&
 	    (function.Function().GetName() == "list_extract" || function.Function().GetName() == "array_extract")) {
@@ -1655,13 +1662,15 @@ void ParquetReader::PrepareRowGroupBuffer(ClientContext &context, ParquetReaderS
 						check_bloom_filter = prune_result != FilterPropagateResult::FILTER_ALWAYS_FALSE;
 					}
 				}
+				auto hash_strategy = bloom_reader ? ParquetStatisticsUtils::GetBloomFilterHashStrategy(
+				                                        bloom_reader->Schema(), interval_bloom_filter_version)
+				                                  : nullopt;
 				if (check_bloom_filter && bloom_reader && bloom_filter &&
 				    bloom_reader->Schema().schema_type == ParquetColumnSchemaType::COLUMN &&
-				    bloom_reader->ColumnIndex() < group.columns.size() &&
-				    ParquetStatisticsUtils::BloomFilterSupported(bloom_reader->Schema()) &&
+				    bloom_reader->ColumnIndex() < group.columns.size() && hash_strategy &&
 				    ParquetStatisticsUtils::BloomFilterExcludes(
 				        *bloom_filter, group.columns[bloom_reader->ColumnIndex()].meta_data, *state.thrift_file_proto,
-				        allocator, bloom_reader->Schema())) {
+				        allocator, bloom_reader->Schema(), *hash_strategy)) {
 					prune_result = FilterPropagateResult::FILTER_ALWAYS_FALSE;
 				}
 			}

--- a/extension/parquet/parquet_statistics.cpp
+++ b/extension/parquet/parquet_statistics.cpp
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "parquet_decimal_utils.hpp"
+#include "parquet_interval.hpp"
 #include "parquet_timestamp.hpp"
 #include "parquet_float16.hpp"
 #include "reader/string_column_reader.hpp"
@@ -880,12 +881,7 @@ static optional<uint64_t> TryHashTimestamp(const Value &constant, const ParquetC
 }
 
 static uint64_t HashNormalizedInterval(const Value &constant) {
-	auto interval = constant.GetValue<interval_t>().Normalize();
-	data_t bytes[12];
-	Store<uint32_t>(static_cast<uint32_t>(interval.months), bytes);
-	Store<uint32_t>(static_cast<uint32_t>(interval.days), bytes + sizeof(uint32_t));
-	Store<uint32_t>(static_cast<uint32_t>(interval.micros / Interval::MICROS_PER_MSEC), bytes + sizeof(uint32_t) * 2);
-	return duckdb_zstd::XXH64(bytes, sizeof(bytes), 0);
+	return ParquetIntervalUtils::HashNormalized(constant.GetValue<interval_t>());
 }
 
 // TODO we can only this if the parquet representation of the type exactly matches the duckdb rep!

--- a/extension/parquet/parquet_statistics.cpp
+++ b/extension/parquet/parquet_statistics.cpp
@@ -694,21 +694,39 @@ static optional_ptr<const Expression> GetOptionalFilterChild(const Expression &e
 	return nullptr;
 }
 
+static bool UsesNormalizedIntervalHash(ParquetBloomFilterHashStrategy hash_strategy) {
+	return hash_strategy == ParquetBloomFilterHashStrategy::NORMALIZED_INTERVAL_V1;
+}
+
+static bool IsBloomFilterColumn(const Expression &expr, ParquetBloomFilterHashStrategy hash_strategy) {
+	if (expr.GetExpressionClass() == ExpressionClass::BOUND_REF) {
+		return expr.Cast<BoundReferenceExpression>().Index() == 0;
+	}
+	if (!UsesNormalizedIntervalHash(hash_strategy) || expr.GetExpressionClass() != ExpressionClass::BOUND_FUNCTION) {
+		return false;
+	}
+	auto &function = expr.Cast<BoundFunctionExpression>();
+	if (function.Function().GetName() != "normalized_interval" || function.GetChildren().size() != 1) {
+		return false;
+	}
+	auto &child = *function.GetChildren()[0];
+	return child.GetExpressionClass() == ExpressionClass::BOUND_REF &&
+	       child.Cast<BoundReferenceExpression>().Index() == 0;
+}
+
 // Bloom filters can only probe IN lists over this column and constants of the same type.
-static optional_ptr<const BoundOperatorExpression> GetBloomFilterInExpression(const Expression &expr) {
+static optional_ptr<const BoundOperatorExpression>
+GetBloomFilterInExpression(const Expression &expr, ParquetBloomFilterHashStrategy hash_strategy) {
 	if (expr.GetExpressionClass() != ExpressionClass::BOUND_OPERATOR ||
 	    expr.GetExpressionType() != ExpressionType::COMPARE_IN) {
 		return nullptr;
 	}
 	auto &in_expr = expr.Cast<BoundOperatorExpression>();
 	auto &children = in_expr.GetChildren();
-	if (children.size() <= 1 || children[0]->GetExpressionClass() != ExpressionClass::BOUND_REF) {
+	if (children.size() <= 1 || !IsBloomFilterColumn(*children[0], hash_strategy)) {
 		return nullptr;
 	}
-	auto &column = children[0]->Cast<BoundReferenceExpression>();
-	if (column.Index() != 0) {
-		return nullptr;
-	}
+	auto &column = *children[0];
 	for (idx_t child_idx = 1; child_idx < children.size(); ++child_idx) {
 		if (children[child_idx]->GetExpressionClass() != ExpressionClass::BOUND_CONSTANT) {
 			return nullptr;
@@ -721,7 +739,8 @@ static optional_ptr<const BoundOperatorExpression> GetBloomFilterInExpression(co
 	return in_expr;
 }
 
-static optional_ptr<const BoundConstantExpression> GetBloomFilterConstant(const Expression &expr) {
+static optional_ptr<const BoundConstantExpression>
+GetBloomFilterConstant(const Expression &expr, ParquetBloomFilterHashStrategy hash_strategy) {
 	if (!BoundComparisonExpression::IsComparison(expr)) {
 		return nullptr;
 	}
@@ -734,34 +753,32 @@ static optional_ptr<const BoundConstantExpression> GetBloomFilterConstant(const 
 	auto &right = BoundComparisonExpression::Right(comp);
 	optional_ptr<const Expression> column;
 	optional_ptr<const BoundConstantExpression> constant;
-	if (left.GetExpressionClass() == ExpressionClass::BOUND_REF &&
-	    right.GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
+	if (IsBloomFilterColumn(left, hash_strategy) && right.GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
 		column = left;
 		constant = right.Cast<BoundConstantExpression>();
-	} else if (right.GetExpressionClass() == ExpressionClass::BOUND_REF &&
+	} else if (IsBloomFilterColumn(right, hash_strategy) &&
 	           left.GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
 		column = right;
 		constant = left.Cast<BoundConstantExpression>();
 	} else {
 		return nullptr;
 	}
-	if (column->Cast<BoundReferenceExpression>().Index() != 0 || constant->GetValue().IsNull() ||
-	    column->GetReturnType() != constant->GetValue().type()) {
+	if (constant->GetValue().IsNull() || column->GetReturnType() != constant->GetValue().type()) {
 		return nullptr;
 	}
 	return constant;
 }
 
-static bool HasFilterConstants(const Expression &expr) {
+static bool HasFilterConstants(const Expression &expr, ParquetBloomFilterHashStrategy hash_strategy) {
 	if (BoundComparisonExpression::IsComparison(expr)) {
-		return GetBloomFilterConstant(expr) != nullptr;
+		return GetBloomFilterConstant(expr, hash_strategy) != nullptr;
 	}
-	if (GetBloomFilterInExpression(expr)) {
+	if (GetBloomFilterInExpression(expr, hash_strategy)) {
 		return true;
 	}
 	auto optional_filter_child = GetOptionalFilterChild(expr);
 	if (optional_filter_child) {
-		return HasFilterConstants(*optional_filter_child);
+		return HasFilterConstants(*optional_filter_child, hash_strategy);
 	}
 	if (expr.GetExpressionClass() != ExpressionClass::BOUND_CONJUNCTION) {
 		return false;
@@ -769,15 +786,15 @@ static bool HasFilterConstants(const Expression &expr) {
 	bool child_has_constant = false;
 	ExpressionIterator::EnumerateChildren(expr, [&](const Expression &child) {
 		if (!child_has_constant) {
-			child_has_constant = HasFilterConstants(child);
+			child_has_constant = HasFilterConstants(child, hash_strategy);
 		}
 	});
 	return child_has_constant;
 }
 
-static bool HasFilterConstants(const TableFilter &duckdb_filter) {
+static bool HasFilterConstants(const TableFilter &duckdb_filter, ParquetBloomFilterHashStrategy hash_strategy) {
 	auto &expr_filter = ExpressionFilter::GetExpressionFilter(duckdb_filter, "ParquetStatistics::HasFilterConstants");
-	return HasFilterConstants(*expr_filter.expr);
+	return HasFilterConstants(*expr_filter.expr, hash_strategy);
 }
 
 template <class T>
@@ -862,10 +879,20 @@ static optional<uint64_t> TryHashTimestamp(const Value &constant, const ParquetC
 	}
 }
 
+static uint64_t HashNormalizedInterval(const Value &constant) {
+	auto interval = constant.GetValue<interval_t>().Normalize();
+	data_t bytes[12];
+	Store<uint32_t>(static_cast<uint32_t>(interval.months), bytes);
+	Store<uint32_t>(static_cast<uint32_t>(interval.days), bytes + sizeof(uint32_t));
+	Store<uint32_t>(static_cast<uint32_t>(interval.micros / Interval::MICROS_PER_MSEC), bytes + sizeof(uint32_t) * 2);
+	return duckdb_zstd::XXH64(bytes, sizeof(bytes), 0);
+}
+
 // TODO we can only this if the parquet representation of the type exactly matches the duckdb rep!
 // TODO TEST THIS!
 // TODO perhaps we can re-use some writer infra here
-static optional<uint64_t> ValueXXH64(const Value &constant, const ParquetColumnSchema &schema) {
+static optional<uint64_t> ValueXXH64(const Value &constant, const ParquetColumnSchema &schema,
+                                     ParquetBloomFilterHashStrategy hash_strategy) {
 	// Handle logical types whose Parquet representation needs special hashing.
 	switch (constant.type().id()) {
 	case LogicalTypeId::UUID: {
@@ -880,6 +907,9 @@ static optional<uint64_t> ValueXXH64(const Value &constant, const ParquetColumnS
 	case LogicalTypeId::TIMESTAMP:
 	case LogicalTypeId::TIMESTAMP_TZ:
 		return TryHashTimestamp(constant, schema);
+	case LogicalTypeId::INTERVAL:
+		return UsesNormalizedIntervalHash(hash_strategy) ? optional<uint64_t>(HashNormalizedInterval(constant))
+		                                                 : nullopt;
 	case LogicalTypeId::DECIMAL:
 		if (schema.parquet_type == duckdb_parquet::Type::INT32) {
 			return ValueXH64FixedWidth<int32_t>(constant);
@@ -929,7 +959,7 @@ static optional<uint64_t> ValueXXH64(const Value &constant, const ParquetColumnS
 }
 
 static bool BloomFilterExcludes(const Value &constant, ParquetBloomFilter &bloom_filter,
-                                const ParquetColumnSchema &schema) {
+                                const ParquetColumnSchema &schema, ParquetBloomFilterHashStrategy hash_strategy) {
 	// Floating-point equality treats positive and negative zero as equal, but Parquet hashes their bit patterns.
 	// Likewise, all NaN payloads compare equal, so no single hash can rule out a row group containing one.
 	switch (constant.type().InternalType()) {
@@ -959,26 +989,26 @@ static bool BloomFilterExcludes(const Value &constant, ParquetBloomFilter &bloom
 		break;
 	}
 
-	auto hash = ValueXXH64(constant, schema);
+	auto hash = ValueXXH64(constant, schema, hash_strategy);
 	return hash && !bloom_filter.FilterCheck(*hash);
 }
 
 static bool ApplyBloomFilter(const Expression &expr, ParquetBloomFilter &bloom_filter,
-                             const ParquetColumnSchema &schema) {
+                             const ParquetColumnSchema &schema, ParquetBloomFilterHashStrategy hash_strategy) {
 	if (BoundComparisonExpression::IsComparison(expr)) {
-		auto constant = GetBloomFilterConstant(expr);
+		auto constant = GetBloomFilterConstant(expr, hash_strategy);
 		if (!constant) {
 			return false;
 		}
-		return BloomFilterExcludes(constant->GetValue(), bloom_filter, schema);
+		return BloomFilterExcludes(constant->GetValue(), bloom_filter, schema, hash_strategy);
 	}
-	auto in_expr = GetBloomFilterInExpression(expr);
+	auto in_expr = GetBloomFilterInExpression(expr, hash_strategy);
 	if (in_expr) {
 		auto &children = in_expr->GetChildren();
 		// An IN filter is excluded only when every candidate is absent.
 		for (idx_t child_idx = 1; child_idx < children.size(); ++child_idx) {
 			auto &constant = children[child_idx]->Cast<BoundConstantExpression>().GetValue();
-			if (!BloomFilterExcludes(constant, bloom_filter, schema)) {
+			if (!BloomFilterExcludes(constant, bloom_filter, schema, hash_strategy)) {
 				return false;
 			}
 		}
@@ -986,7 +1016,7 @@ static bool ApplyBloomFilter(const Expression &expr, ParquetBloomFilter &bloom_f
 	}
 	auto optional_filter_child = GetOptionalFilterChild(expr);
 	if (optional_filter_child) {
-		return ApplyBloomFilter(*optional_filter_child, bloom_filter, schema);
+		return ApplyBloomFilter(*optional_filter_child, bloom_filter, schema, hash_strategy);
 	}
 	if (expr.GetExpressionClass() != ExpressionClass::BOUND_CONJUNCTION) {
 		return false;
@@ -994,14 +1024,16 @@ static bool ApplyBloomFilter(const Expression &expr, ParquetBloomFilter &bloom_f
 	switch (expr.GetExpressionType()) {
 	case ExpressionType::CONJUNCTION_AND: {
 		bool any_children_true = false;
-		ExpressionIterator::EnumerateChildren(
-		    expr, [&](const Expression &child) { any_children_true |= ApplyBloomFilter(child, bloom_filter, schema); });
+		ExpressionIterator::EnumerateChildren(expr, [&](const Expression &child) {
+			any_children_true |= ApplyBloomFilter(child, bloom_filter, schema, hash_strategy);
+		});
 		return any_children_true;
 	}
 	case ExpressionType::CONJUNCTION_OR: {
 		bool all_children_true = true;
-		ExpressionIterator::EnumerateChildren(
-		    expr, [&](const Expression &child) { all_children_true &= ApplyBloomFilter(child, bloom_filter, schema); });
+		ExpressionIterator::EnumerateChildren(expr, [&](const Expression &child) {
+			all_children_true &= ApplyBloomFilter(child, bloom_filter, schema, hash_strategy);
+		});
 		return all_children_true;
 	}
 	default:
@@ -1010,12 +1042,27 @@ static bool ApplyBloomFilter(const Expression &expr, ParquetBloomFilter &bloom_f
 }
 
 static bool ApplyBloomFilter(const TableFilter &duckdb_filter, ParquetBloomFilter &bloom_filter,
-                             const ParquetColumnSchema &schema) {
+                             const ParquetColumnSchema &schema, ParquetBloomFilterHashStrategy hash_strategy) {
 	auto &expr_filter = ExpressionFilter::GetExpressionFilter(duckdb_filter, "ParquetStatistics::ApplyBloomFilter");
-	return ApplyBloomFilter(*expr_filter.expr, bloom_filter, schema);
+	return ApplyBloomFilter(*expr_filter.expr, bloom_filter, schema, hash_strategy);
 }
 
-bool ParquetStatisticsUtils::BloomFilterSupported(const ParquetColumnSchema &schema) {
+ParquetIntervalBloomFilterVersion
+ParquetStatisticsUtils::GetIntervalBloomFilterVersion(const duckdb_parquet::FileMetaData &file_meta_data) {
+	if (!file_meta_data.__isset.key_value_metadata) {
+		return ParquetIntervalBloomFilterVersion::NONE;
+	}
+	for (const auto &kv : file_meta_data.key_value_metadata) {
+		if (kv.key == INTERVAL_BLOOM_FILTER_KEY && kv.__isset.value && kv.value == INTERVAL_BLOOM_FILTER_VALUE) {
+			return ParquetIntervalBloomFilterVersion::NORMALIZED_V1;
+		}
+	}
+	return ParquetIntervalBloomFilterVersion::NONE;
+}
+
+optional<ParquetBloomFilterHashStrategy>
+ParquetStatisticsUtils::GetBloomFilterHashStrategy(const ParquetColumnSchema &schema,
+                                                   ParquetIntervalBloomFilterVersion interval_bloom_filter_version) {
 	switch (schema.type.id()) {
 	case LogicalTypeId::TINYINT:
 	case LogicalTypeId::UTINYINT:
@@ -1030,56 +1077,75 @@ bool ParquetStatisticsUtils::BloomFilterSupported(const ParquetColumnSchema &sch
 	case LogicalTypeId::VARCHAR:
 	case LogicalTypeId::BLOB:
 	case LogicalTypeId::DATE:
-		return true;
+		return ParquetBloomFilterHashStrategy::STANDARD;
+	case LogicalTypeId::INTERVAL:
+		if (interval_bloom_filter_version == ParquetIntervalBloomFilterVersion::NORMALIZED_V1 &&
+		    schema.parquet_type == duckdb_parquet::Type::FIXED_LEN_BYTE_ARRAY && schema.type_length == 12) {
+			return ParquetBloomFilterHashStrategy::NORMALIZED_INTERVAL_V1;
+		}
+		return nullopt;
 	case LogicalTypeId::UUID:
-		return schema.parquet_type == duckdb_parquet::Type::FIXED_LEN_BYTE_ARRAY && schema.type_length == 16;
+		if (schema.parquet_type == duckdb_parquet::Type::FIXED_LEN_BYTE_ARRAY && schema.type_length == 16) {
+			return ParquetBloomFilterHashStrategy::STANDARD;
+		}
+		return nullopt;
 	case LogicalTypeId::DECIMAL:
 		// We currently only support decimal bloom filters backed by 32-bit or 64-bit integers.
-		return schema.parquet_type == duckdb_parquet::Type::INT32 || schema.parquet_type == duckdb_parquet::Type::INT64;
+		if (schema.parquet_type == duckdb_parquet::Type::INT32 || schema.parquet_type == duckdb_parquet::Type::INT64) {
+			return ParquetBloomFilterHashStrategy::STANDARD;
+		}
+		return nullopt;
 	case LogicalTypeId::TIMESTAMP:
 	case LogicalTypeId::TIMESTAMP_TZ:
 		// When type info is UNIT_NS, DuckDB type TIMESTAMP_NS/TIMESTAMP_TZ_NS is used.
-		return schema.parquet_type == duckdb_parquet::Type::INT64 &&
-		       (schema.type_info == ParquetExtraTypeInfo::UNIT_MS ||
-		        schema.type_info == ParquetExtraTypeInfo::UNIT_MICROS);
+		if (schema.parquet_type == duckdb_parquet::Type::INT64 &&
+		    (schema.type_info == ParquetExtraTypeInfo::UNIT_MS ||
+		     schema.type_info == ParquetExtraTypeInfo::UNIT_MICROS)) {
+			return ParquetBloomFilterHashStrategy::STANDARD;
+		}
+		return nullopt;
 	case LogicalTypeId::TIMESTAMP_NS:
 	case LogicalTypeId::TIMESTAMP_TZ_NS:
-		return schema.parquet_type == duckdb_parquet::Type::INT64 && schema.type_info == ParquetExtraTypeInfo::UNIT_NS;
+		if (schema.parquet_type == duckdb_parquet::Type::INT64 && schema.type_info == ParquetExtraTypeInfo::UNIT_NS) {
+			return ParquetBloomFilterHashStrategy::STANDARD;
+		}
+		return nullopt;
 	case LogicalTypeId::TIME:
 	case LogicalTypeId::TIME_TZ: {
 		// Nanosecond values lose sub-microsecond precision when read as TIME or TIME_TZ.
 		if (schema.parquet_type == duckdb_parquet::Type::INT32 && schema.type_info == ParquetExtraTypeInfo::UNIT_MS) {
-			return true;
+			return ParquetBloomFilterHashStrategy::STANDARD;
 		}
 		if (schema.parquet_type == duckdb_parquet::Type::INT64 &&
 		    schema.type_info == ParquetExtraTypeInfo::UNIT_MICROS) {
-			return true;
+			return ParquetBloomFilterHashStrategy::STANDARD;
 		}
-		return false;
+		return nullopt;
 	}
 	case LogicalTypeId::TIME_NS: {
 		if (schema.parquet_type == duckdb_parquet::Type::INT32 && schema.type_info == ParquetExtraTypeInfo::UNIT_MS) {
-			return true;
+			return ParquetBloomFilterHashStrategy::STANDARD;
 		}
 		if (schema.parquet_type == duckdb_parquet::Type::INT64 &&
 		    schema.type_info == ParquetExtraTypeInfo::UNIT_MICROS) {
-			return true;
+			return ParquetBloomFilterHashStrategy::STANDARD;
 		}
 		if (schema.parquet_type == duckdb_parquet::Type::INT64 && schema.type_info == ParquetExtraTypeInfo::UNIT_NS) {
-			return true;
+			return ParquetBloomFilterHashStrategy::STANDARD;
 		}
-		return false;
+		return nullopt;
 	}
 	default:
-		return false;
+		return nullopt;
 	}
 }
 
 bool ParquetStatisticsUtils::BloomFilterExcludes(const TableFilter &duckdb_filter,
                                                  const duckdb_parquet::ColumnMetaData &column_meta_data,
                                                  TProtocol &file_proto, Allocator &allocator,
-                                                 const ParquetColumnSchema &schema) {
-	if (!HasFilterConstants(duckdb_filter) || !column_meta_data.__isset.bloom_filter_offset ||
+                                                 const ParquetColumnSchema &schema,
+                                                 ParquetBloomFilterHashStrategy hash_strategy) {
+	if (!HasFilterConstants(duckdb_filter, hash_strategy) || !column_meta_data.__isset.bloom_filter_offset ||
 	    column_meta_data.bloom_filter_offset <= 0) {
 		return false;
 	}
@@ -1136,7 +1202,7 @@ bool ParquetStatisticsUtils::BloomFilterExcludes(const TableFilter &duckdb_filte
 	auto new_buffer = make_uniq<ResizeableBuffer>(allocator, bloom_filter_data_size);
 	transport.read(new_buffer->ptr, UnsafeNumericCast<uint32_t>(bloom_filter_data_size));
 	ParquetBloomFilter bloom_filter(std::move(new_buffer));
-	return ApplyBloomFilter(duckdb_filter, bloom_filter, schema);
+	return ApplyBloomFilter(duckdb_filter, bloom_filter, schema, hash_strategy);
 }
 
 ParquetBloomFilter::ParquetBloomFilter(idx_t num_entries, double bloom_filter_false_positive_ratio) {

--- a/extension/parquet/parquet_writer.cpp
+++ b/extension/parquet/parquet_writer.cpp
@@ -16,6 +16,7 @@
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/common/types/blob.hpp"
 #include "duckdb/common/types/geometry_crs.hpp"
+#include "duckdb/common/type_visitor.hpp"
 #include "writer/variant_column_writer.hpp"
 #include "duckdb/common/assert.hpp"
 #include "duckdb/common/case_insensitive_map.hpp"
@@ -40,6 +41,7 @@
 #include "duckdb/storage/statistics/geometry_stats.hpp"
 #include "parquet_column_schema.hpp"
 #include "parquet_geometry.hpp"
+#include "parquet_statistics.hpp"
 #include "thrift/TBase.h"
 #include "thrift/protocol/TCompactProtocol.h"
 #include "thrift/protocol/TProtocol.h"
@@ -535,6 +537,21 @@ ParquetWriter::ParquetWriter(ClientContext &context, FileSystem &fs, ParquetWrit
 		kv.__set_value(kv_pair.second);
 		file_meta_data.key_value_metadata.push_back(kv);
 		file_meta_data.__isset.key_value_metadata = true;
+	}
+
+	if (options.enable_bloom_filters) {
+		for (const auto &type : options.sql_types) {
+			if (!TypeVisitor::Contains(type, LogicalTypeId::INTERVAL)) {
+				continue;
+			}
+			duckdb_parquet::KeyValue kv;
+			kv.__set_key(ParquetStatisticsUtils::INTERVAL_BLOOM_FILTER_KEY);
+			kv.__set_value(ParquetStatisticsUtils::INTERVAL_BLOOM_FILTER_VALUE);
+			// Readers require this capability before probing the additional normalized hashes.
+			file_meta_data.key_value_metadata.push_back(std::move(kv));
+			file_meta_data.__isset.key_value_metadata = true;
+			break;
+		}
 	}
 
 	InitializeColumnWriters();

--- a/test/sql/copy/parquet/bloom_filter_interval.test
+++ b/test/sql/copy/parquet/bloom_filter_interval.test
@@ -1,0 +1,158 @@
+# name: test/sql/copy/parquet/bloom_filter_interval.test
+# description: Test bloom filters on INTERVAL columns
+# group: [parquet]
+
+require parquet
+
+statement ok
+COPY (
+	SELECT
+		((i % 100) * 2) * INTERVAL '1 day' AS iv,
+		i::BIGINT AS payload
+	FROM range(20480) t(i)
+) TO '{TEST_DIR}/bloom_interval.parquet' (
+	FORMAT PARQUET,
+	ROW_GROUP_SIZE 2048,
+	DICTIONARY_SIZE_LIMIT 1000,
+	BLOOM_FILTER_FALSE_POSITIVE_RATIO 0.0001
+);
+
+query I
+SELECT count(*)
+FROM parquet_kv_metadata('{TEST_DIR}/bloom_interval.parquet')
+WHERE key = 'duckdb.interval_bloom_filter'
+	AND decode(value) = 'normalized-v1';
+----
+1
+
+query I
+SELECT BOOL_AND(bloom_filter_excludes)
+FROM parquet_bloom_probe('{TEST_DIR}/bloom_interval.parquet', 'iv', INTERVAL '101 days');
+----
+true
+
+query II
+EXPLAIN ANALYZE
+SELECT sum(payload)
+FROM read_parquet('{TEST_DIR}/bloom_interval.parquet')
+WHERE iv = INTERVAL '101 days';
+----
+analyzed_plan	<REGEX>:(?s).*Row Groups Scanned: 0 / 10.*
+
+query II
+EXPLAIN ANALYZE
+SELECT sum(payload)
+FROM read_parquet('{TEST_DIR}/bloom_interval.parquet')
+WHERE iv IN (INTERVAL '101 days', INTERVAL '103 days');
+----
+analyzed_plan	<REGEX>:(?s).*Row Groups Scanned: 0 / 10.*
+
+# Nested INTERVAL columns use the same normalized bloom filter encoding.
+statement ok
+COPY (
+	SELECT
+		[((i % 100) * 2) * INTERVAL '1 day'] AS iv_list,
+		{'iv': ((i % 100) * 2) * INTERVAL '1 day'} AS iv_struct,
+		i::BIGINT AS payload
+	FROM range(20480) t(i)
+) TO '{TEST_DIR}/bloom_interval_nested.parquet' (
+	FORMAT PARQUET,
+	ROW_GROUP_SIZE 2048,
+	DICTIONARY_SIZE_LIMIT 1000,
+	BLOOM_FILTER_FALSE_POSITIVE_RATIO 0.0001
+);
+
+query I
+SELECT count(*)
+FROM parquet_kv_metadata('{TEST_DIR}/bloom_interval_nested.parquet')
+WHERE key = 'duckdb.interval_bloom_filter'
+	AND decode(value) = 'normalized-v1';
+----
+1
+
+query II
+EXPLAIN ANALYZE
+SELECT sum(payload)
+FROM read_parquet('{TEST_DIR}/bloom_interval_nested.parquet')
+WHERE iv_list[1] = INTERVAL '101 days';
+----
+analyzed_plan	<REGEX>:(?s).*Row Groups Scanned: 0 / 10.*
+
+query II
+EXPLAIN ANALYZE
+SELECT sum(payload)
+FROM read_parquet('{TEST_DIR}/bloom_interval_nested.parquet')
+WHERE iv_struct.iv = INTERVAL '101 days';
+----
+analyzed_plan	<REGEX>:(?s).*Row Groups Scanned: 0 / 10.*
+
+# Equivalent intervals can have different Parquet encodings.
+statement ok
+COPY (
+	SELECT
+		iv,
+		[iv] AS iv_list,
+		{'iv': iv} AS iv_struct
+	FROM (
+		SELECT CASE i % 4
+			WHEN 0 THEN INTERVAL '101 days'
+			WHEN 1 THEN INTERVAL '3 months 11 days'
+			WHEN 2 THEN INTERVAL '1 day'
+			ELSE INTERVAL '24 hours'
+		END AS iv
+		FROM range(4096) t(i)
+	)
+) TO '{TEST_DIR}/bloom_interval_equivalent.parquet' (
+	FORMAT PARQUET,
+	ROW_GROUP_SIZE 2048,
+	DICTIONARY_SIZE_LIMIT 1000,
+	BLOOM_FILTER_FALSE_POSITIVE_RATIO 0.0001
+);
+
+query I
+SELECT count(*)
+FROM read_parquet('{TEST_DIR}/bloom_interval_equivalent.parquet')
+WHERE iv = INTERVAL '101 days';
+----
+2048
+
+query I
+SELECT count(*)
+FROM read_parquet('{TEST_DIR}/bloom_interval_equivalent.parquet')
+WHERE iv_list[1] = INTERVAL '101 days';
+----
+2048
+
+query I
+SELECT count(*)
+FROM read_parquet('{TEST_DIR}/bloom_interval_equivalent.parquet')
+WHERE iv_struct.iv = INTERVAL '101 days';
+----
+2048
+
+query I
+SELECT count(*)
+FROM read_parquet('{TEST_DIR}/bloom_interval_equivalent.parquet')
+WHERE iv = INTERVAL '1 day';
+----
+2048
+
+query I
+SELECT count(*)
+FROM read_parquet('{TEST_DIR}/bloom_interval_equivalent.parquet')
+WHERE iv_list[1] = INTERVAL '1 day';
+----
+2048
+
+query I
+SELECT count(*)
+FROM read_parquet('{TEST_DIR}/bloom_interval_equivalent.parquet')
+WHERE iv_struct.iv = INTERVAL '1 day';
+----
+2048
+
+query I
+SELECT BOOL_AND(NOT bloom_filter_excludes)
+FROM parquet_bloom_probe('{TEST_DIR}/bloom_interval_equivalent.parquet', 'iv', INTERVAL '101 days');
+----
+true


### PR DESCRIPTION
Closes #24020.

## Problem

Parquet `INTERVAL` has no defined sort order, so min/max statistics cannot be used for row-group pruning. Although Bloom filters are available, DuckDB normalizes intervals before comparison: equal values such as `INTERVAL '101 days'` and `INTERVAL '3 months 11 days'` can have different 12-byte Parquet encodings and therefore different XXH64 hashes.

The predicate is also bound as `normalized_interval(column) = constant`, which the existing Bloom filter extraction did not recognize. Probing a filter containing only raw-encoding hashes with a normalized hash would risk false negatives, so this requires both writer and reader changes.

## Approach

- The writer inserts both the standard Parquet plain-encoding hash and a normalized-encoding hash for `INTERVAL` dictionary values. Bloom filters are sized for two entries per value.
- Files containing Bloom-filtered `INTERVAL` columns are marked with `duckdb.interval_bloom_filter=normalized-v1`.
- The reader uses the normalized hash only when this marker is present and the column is `INTERVAL` over `FIXED_LEN_BYTE_ARRAY(12)`. Equality, `IN`, `parquet_bloom_probe`, and nested `LIST`/`STRUCT` paths use the same capability and schema checks.

## Compatibility

Files without the marker retain the previous conservative behavior. Standard readers remain compatible because the raw hashes are still present; the additional normalized hashes can only increase false positives, not introduce false negatives.

## Testing

The new `bloom_filter_interval.test` covers absent equality and `IN` values pruning `0 / 10` row groups, marker and `parquet_bloom_probe` behavior, nested `LIST`/`STRUCT` columns, and equivalent intervals with different month/day and millisecond/day encodings.

The existing Parquet Bloom filter tests and the full `build/reldebug/test/unittest` suite pass.
