### PR TITLE
feat: support ALTER TABLE ... ADD FOREIGN KEY constraint

### DIFF
--- a/src/catalog/catalog_entry/duck_schema_entry.cpp
+++ b/src/catalog/catalog_entry/duck_schema_entry.cpp
@@ -351,6 +351,23 @@ void DuckSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) {
 			throw CatalogException::MissingEntry(type, name, string());
 		}
 	}
+
+	if (!info.IsAddForeignKey()) {
+		return;
+	}
+
+	// Add the matching foreign key constraint to the referenced table.
+	auto &constraint_info = info.Cast<AlterTableInfo>().Cast<AddConstraintInfo>();
+	auto &fk = constraint_info.constraint->Cast<ForeignKeyConstraint>();
+	if (fk.info.type != ForeignKeyType::FK_TYPE_FOREIGN_KEY_TABLE) {
+		return;
+	}
+
+	AlterEntryData alter_data(QualifiedName(catalog.GetName(), fk.info.schema, fk.info.table),
+	                          OnEntryNotFound::THROW_EXCEPTION);
+	AlterForeignKeyInfo fk_info(std::move(alter_data), info.GetQualifiedName().Name(), fk.pk_columns, fk.fk_columns,
+	                            fk.info.pk_keys, fk.info.fk_keys, AlterForeignKeyType::AFT_ADD);
+	Alter(transaction, fk_info);
 }
 
 void DuckSchemaEntry::Scan(ClientContext &context, CatalogType type,

--- a/src/catalog/catalog_entry/duck_table_entry.cpp
+++ b/src/catalog/catalog_entry/duck_table_entry.cpp
@@ -1336,6 +1336,9 @@ unique_ptr<CatalogEntry> DuckTableEntry::AddConstraint(ClientContext &context, A
 		}
 		table_info.constraints.push_back(info.constraint->Copy());
 
+	} else if (info.constraint->type == ConstraintType::FOREIGN_KEY) {
+		table_info.constraints.push_back(info.constraint->Copy());
+
 	} else {
 		throw InternalException("unsupported constraint type in ALTER TABLE statement");
 	}

--- a/src/execution/operator/schema/physical_create_index.cpp
+++ b/src/execution/operator/schema/physical_create_index.cpp
@@ -7,6 +7,9 @@
 #include "duckdb/execution/index/bound_index.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/database_manager.hpp"
+#include "duckdb/parser/constraints/foreign_key_constraint.hpp"
+#include "duckdb/parser/parsed_data/alter_table_info.hpp"
+#include "duckdb/planner/constraints/bound_foreign_key_constraint.hpp"
 #include "duckdb/storage/table/append_state.hpp"
 #include "duckdb/storage/table/data_table_info.hpp"
 #include "duckdb/storage/storage_manager.hpp"
@@ -77,6 +80,60 @@ unique_ptr<LocalSinkState> PhysicalCreateIndex::GetLocalSinkState(ExecutionConte
 	return std::move(lstate);
 }
 
+//! A foreign key index does not contain NULL keys, matching an index that is created
+//! together with its table.
+static void FilterNullKeys(DataChunk &key_chunk, DataChunk &row_chunk) {
+	SelectionVector sel(key_chunk.size());
+	idx_t count = 0;
+	for (idx_t row_idx = 0; row_idx < key_chunk.size(); row_idx++) {
+		bool has_null = false;
+		for (idx_t col_idx = 0; col_idx < key_chunk.ColumnCount(); col_idx++) {
+			if (FlatVector::IsNull(key_chunk.data[col_idx], row_idx)) {
+				has_null = true;
+				break;
+			}
+		}
+		if (!has_null) {
+			sel.set_index(count++, row_idx);
+		}
+	}
+
+	if (count == key_chunk.size()) {
+		return;
+	}
+	key_chunk.Slice(sel, count);
+	row_chunk.Slice(sel, count);
+}
+
+void PhysicalCreateIndex::VerifyForeignKey(ClientContext &context, DataChunk &key_chunk) const {
+	auto &constraint_info = alter_table_info->Cast<AddConstraintInfo>();
+	auto &fk = constraint_info.constraint->Cast<ForeignKeyConstraint>();
+
+	physical_index_set_t pk_key_set;
+	for (const auto &pk_key : fk.info.pk_keys) {
+		pk_key_set.insert(pk_key);
+	}
+	physical_index_set_t fk_key_set;
+	for (const auto &fk_key : fk.info.fk_keys) {
+		fk_key_set.insert(fk_key);
+	}
+	BoundForeignKeyConstraint bound_fk(fk.info, std::move(pk_key_set), std::move(fk_key_set));
+
+	// The verification reads the keys at their physical position in this table.
+	vector<LogicalType> types;
+	for (auto &col : table.GetColumns().Physical()) {
+		types.emplace_back(col.Type());
+	}
+	DataChunk fk_chunk;
+	fk_chunk.InitializeEmpty(types);
+	for (idx_t i = 0; i < fk.info.fk_keys.size(); i++) {
+		fk_chunk.data[fk.info.fk_keys[i].index].Reference(key_chunk.data[i]);
+	}
+	fk_chunk.SetCardinality(key_chunk.size());
+
+	table.GetStorage().VerifyNewForeignKeyConstraint(bound_fk, context, fk_chunk);
+}
+
 SinkResultType PhysicalCreateIndex::Sink(ExecutionContext &context, DataChunk &chunk, OperatorSinkInput &input) const {
 	auto &gstate = input.global_state.Cast<CreateIndexGlobalSinkState>();
 	auto &lstate = input.local_state.Cast<CreateIndexLocalSinkState>();
@@ -88,12 +145,18 @@ SinkResultType PhysicalCreateIndex::Sink(ExecutionContext &context, DataChunk &c
 	lstate.key_chunk.ReferenceColumns(chunk, indexed_columns);
 	lstate.row_chunk.ReferenceColumns(chunk, rowid_column);
 
-	// Check for NULLs, if we are creating a PRIMARY KEY.
-	// FIXME: Later, we want to ensure that we skip the NULL check for any non-PK alter.
 	if (alter_table_info) {
-		for (idx_t i = 0; i < lstate.key_chunk.ColumnCount(); i++) {
-			if (VectorOperations::HasNull(lstate.key_chunk.data[i])) {
-				throw ConstraintException("NOT NULL constraint failed: %s", info->GetIndexName());
+		if (info->constraint_type == IndexConstraintType::FOREIGN) {
+			// A foreign key permits NULLs, but every other key must already be present
+			// in the referenced table.
+			VerifyForeignKey(context.client, lstate.key_chunk);
+			FilterNullKeys(lstate.key_chunk, lstate.row_chunk);
+		} else {
+			// Check for NULLs, if we are creating a PRIMARY KEY.
+			for (idx_t i = 0; i < lstate.key_chunk.ColumnCount(); i++) {
+				if (VectorOperations::HasNull(lstate.key_chunk.data[i])) {
+					throw ConstraintException("NOT NULL constraint failed: %s", info->GetIndexName());
+				}
 			}
 		}
 	}

--- a/src/include/duckdb/execution/operator/schema/physical_create_index.hpp
+++ b/src/include/duckdb/execution/operator/schema/physical_create_index.hpp
@@ -49,6 +49,10 @@ public:
 	vector<column_t> indexed_columns;
 	vector<column_t> rowid_column;
 
+private:
+	//! Verify that the already stored keys exist in the referenced table.
+	void VerifyForeignKey(ClientContext &context, DataChunk &key_chunk) const;
+
 public:
 	//! Source interface, NOP for this operator
 	SourceResultType GetDataInternal(ExecutionContext &context, DataChunk &chunk,

--- a/src/include/duckdb/parser/parsed_data/alter_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/alter_info.hpp
@@ -96,6 +96,7 @@ public:
 
 	AlterEntryData GetAlterEntryData() const;
 	bool IsAddPrimaryKey() const;
+	bool IsAddForeignKey() const;
 
 protected:
 	explicit AlterInfo(AlterType type);

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -59,6 +59,7 @@ class ExternalDependency;
 class TableFunction;
 class TableStorageInfo;
 class BoundConstraint;
+class ForeignKeyConstraint;
 class AtClause;
 class BoundAtClause;
 
@@ -260,6 +261,8 @@ public:
 	                                                 const ColumnList &columns);
 
 	BoundStatement BindAlterAddIndex(BoundStatement &result, CatalogEntry &entry, unique_ptr<AlterInfo> alter_info);
+	//! Resolves a FOREIGN KEY that is added to an already existing table.
+	void BindAlterForeignKeyConstraint(ForeignKeyConstraint &fk, TableCatalogEntry &table);
 
 	void SetCatalogLookupCallback(catalog_entry_callback_t callback);
 	void BindCreateViewInfo(CreateViewInfo &base);

--- a/src/include/duckdb/storage/data_table.hpp
+++ b/src/include/duckdb/storage/data_table.hpp
@@ -311,6 +311,10 @@ public:
 	//! Returns a list of the partition stats
 	vector<PartitionStatistics> GetPartitionStats(ClientContext &context);
 
+	//! Verify that the keys of a foreign key that is being added exist in the referenced table.
+	void VerifyNewForeignKeyConstraint(const BoundForeignKeyConstraint &bound_foreign_key, ClientContext &context,
+	                                   DataChunk &chunk);
+
 private:
 	//! Verify the new added constraints against current persistent&local data
 	void VerifyNewConstraint(LocalStorage &local_storage, DataTable &parent, const BoundConstraint &constraint);

--- a/src/parser/parsed_data/alter_info.cpp
+++ b/src/parser/parsed_data/alter_info.cpp
@@ -43,4 +43,18 @@ bool AlterInfo::IsAddPrimaryKey() const {
 	return true;
 }
 
+bool AlterInfo::IsAddForeignKey() const {
+	if (type != AlterType::ALTER_TABLE) {
+		return false;
+	}
+
+	auto &table_info = Cast<AlterTableInfo>();
+	if (table_info.alter_table_type != AlterTableType::ADD_CONSTRAINT) {
+		return false;
+	}
+
+	auto &constraint_info = table_info.Cast<AddConstraintInfo>();
+	return constraint_info.constraint->type == ConstraintType::FOREIGN_KEY;
+}
+
 } // namespace duckdb

--- a/src/planner/binder/statement/bind_create_table.cpp
+++ b/src/planner/binder/statement/bind_create_table.cpp
@@ -604,6 +604,51 @@ static void BindCreateTableConstraints(CreateTableInfo &create_info, CatalogEntr
 	}
 }
 
+void Binder::BindAlterForeignKeyConstraint(ForeignKeyConstraint &fk, TableCatalogEntry &table) {
+	auto &schema = table.schema;
+	auto &columns = table.GetColumns();
+	FindForeignKeyIndexes(columns, fk.fk_columns, fk.info.fk_keys);
+
+	// Resolve the self-reference.
+	if (table.name == fk.info.table) {
+		fk.info.type = ForeignKeyType::FK_TYPE_SELF_REFERENCE_TABLE;
+		FindMatchingPrimaryKeyColumns(columns, table.GetConstraints(), fk);
+		FindForeignKeyIndexes(columns, fk.pk_columns, fk.info.pk_keys);
+		CheckForeignKeyTypes(columns, columns, fk);
+		return;
+	}
+
+	Identifier fk_catalog = fk.info.schema.empty() ? schema.ParentCatalog().GetName() : Identifier::InvalidCatalog();
+	string fk_schema = fk.info.schema.empty() ? schema.name.GetIdentifierName() : fk.info.schema.GetIdentifierName();
+	EntryLookupInfo table_lookup(CatalogType::TABLE_ENTRY, QualifiedName(fk.info.table));
+	auto table_entry = entry_retriever.GetEntry(EntryLookupInfo(
+	    table_lookup, QualifiedName(fk_catalog, Identifier(fk_schema), table_lookup.GetEntryIdentifier())));
+	if (table_entry->type == CatalogType::VIEW_ENTRY) {
+		throw BinderException("cannot reference a VIEW with a FOREIGN KEY");
+	}
+
+	auto &pk_table_entry = table_entry->Cast<TableCatalogEntry>();
+	fk.info.schema = pk_table_entry.schema.name;
+	if (&pk_table_entry.schema != &schema) {
+		throw BinderException("Creating foreign keys across different schemas or catalogs is not supported");
+	}
+	FindMatchingPrimaryKeyColumns(pk_table_entry.GetColumns(), pk_table_entry.GetConstraints(), fk);
+	FindForeignKeyIndexes(pk_table_entry.GetColumns(), fk.pk_columns, fk.info.pk_keys);
+	CheckForeignKeyTypes(pk_table_entry.GetColumns(), columns, fk);
+
+	if (pk_table_entry.IsDuckTable()) {
+		auto &storage = pk_table_entry.GetStorage();
+		if (!storage.HasForeignKeyIndex(fk.info.pk_keys, ForeignKeyType::FK_TYPE_PRIMARY_KEY_TABLE)) {
+			auto fk_column_names = StringUtil::Join(fk.pk_columns, ",");
+			throw BinderException("Failed to create foreign key on %s(%s): no UNIQUE or PRIMARY KEY constraint "
+			                      "present on these columns",
+			                      pk_table_entry.name, fk_column_names);
+		}
+	}
+
+	D_ASSERT(fk.info.pk_keys.size() == fk.info.fk_keys.size());
+}
+
 unique_ptr<BoundCreateTableInfo> Binder::BindCreateTableInfo(unique_ptr<CreateInfo> info, SchemaCatalogEntry &schema,
                                                              vector<unique_ptr<Expression>> &bound_defaults,
                                                              AlterBindMode bind_mode) {

--- a/src/planner/binder/statement/bind_simple.cpp
+++ b/src/planner/binder/statement/bind_simple.cpp
@@ -2,8 +2,10 @@
 #include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
 #include "duckdb/catalog/catalog_entry/view_catalog_entry.hpp"
 #include "duckdb/catalog/duck_catalog.hpp"
+#include "duckdb/common/enum_util.hpp"
 #include "duckdb/execution/index/art/art.hpp"
 #include "duckdb/function/table/table_scan.hpp"
+#include "duckdb/parser/constraints/foreign_key_constraint.hpp"
 #include "duckdb/parser/constraints/unique_constraint.hpp"
 #include "duckdb/parser/parsed_data/comment_on_column_info.hpp"
 #include "duckdb/parser/statement/alter_statement.hpp"
@@ -38,27 +40,41 @@ BoundStatement Binder::BindAlterAddIndex(BoundStatement &result, CatalogEntry &e
 	auto &constraint_info = table_info.Cast<AddConstraintInfo>();
 	auto &table = entry.Cast<TableCatalogEntry>();
 	auto &column_list = table.GetColumns();
-
-	auto bound_constraint =
-	    BindUniqueConstraint(*constraint_info.constraint, table_info.GetQualifiedName().Name(), column_list);
-	auto &bound_unique = bound_constraint->Cast<BoundUniqueConstraint>();
+	auto table_name = table_info.GetQualifiedName().Name();
 
 	// Create the CreateIndexInfo.
 	auto create_index_info = make_uniq<CreateIndexInfo>();
-	create_index_info->table = table_info.GetQualifiedName().Name();
+	create_index_info->table = table_name;
 	create_index_info->index_type = ART::TYPE_NAME;
-	create_index_info->constraint_type = IndexConstraintType::PRIMARY;
 
-	for (const auto &physical_index : bound_unique.keys) {
+	vector<PhysicalIndex> key_columns;
+	Identifier index_name;
+
+	if (constraint_info.constraint->type == ConstraintType::FOREIGN_KEY) {
+		auto &fk = constraint_info.constraint->Cast<ForeignKeyConstraint>();
+		BindAlterForeignKeyConstraint(fk, table);
+
+		create_index_info->constraint_type = IndexConstraintType::FOREIGN;
+		key_columns = fk.info.fk_keys;
+		// Match the index naming of a foreign key declared in CREATE TABLE.
+		index_name = Identifier(EnumUtil::ToString(IndexConstraintType::FOREIGN) + "_" +
+		                        table_name.GetIdentifierName() + "_" + to_string(table.GetConstraints().size()));
+	} else {
+		auto bound_constraint = BindUniqueConstraint(*constraint_info.constraint, table_name, column_list);
+		auto &bound_unique = bound_constraint->Cast<BoundUniqueConstraint>();
+
+		create_index_info->constraint_type = IndexConstraintType::PRIMARY;
+		key_columns = bound_unique.keys;
+		index_name = constraint_info.constraint->Cast<UniqueConstraint>().GetName(table_name);
+	}
+
+	for (const auto &physical_index : key_columns) {
 		auto &col = column_list.GetColumn(physical_index);
-		unique_ptr<ParsedExpression> parsed =
-		    make_uniq<ColumnRefExpression>(col.GetName(), table_info.GetQualifiedName().Name());
+		unique_ptr<ParsedExpression> parsed = make_uniq<ColumnRefExpression>(col.GetName(), table_name);
 		create_index_info->expressions.push_back(parsed->Copy());
 		create_index_info->parsed_expressions.push_back(parsed->Copy());
 	}
 
-	auto unique_constraint = constraint_info.constraint->Cast<UniqueConstraint>();
-	auto index_name = unique_constraint.GetName(table_info.GetQualifiedName().Name());
 	create_index_info->SetIndexName(index_name);
 	D_ASSERT(!create_index_info->GetIndexName().empty());
 
@@ -167,7 +183,7 @@ BoundStatement Binder::Bind(AlterStatement &stmt) {
 	stmt.info->SetQualifiedName(
 	    QualifiedName(catalog.GetName(), entry->ParentSchema().name, stmt.info->GetQualifiedName().Name()));
 
-	if (!stmt.info->IsAddPrimaryKey()) {
+	if (!stmt.info->IsAddPrimaryKey() && !stmt.info->IsAddForeignKey()) {
 		result.plan = make_uniq<LogicalSimple>(LogicalOperatorType::LOGICAL_ALTER, std::move(stmt.info));
 		return result;
 	}

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -170,7 +170,8 @@ DataTable::DataTable(ClientContext &context, DataTable &parent, BoundConstraint 
 		column_definitions.emplace_back(column_def.Copy());
 	}
 
-	if (constraint.type != ConstraintType::UNIQUE) {
+	// UNIQUE and FOREIGN KEY constraints are verified while building their index.
+	if (constraint.type != ConstraintType::UNIQUE && constraint.type != ConstraintType::FOREIGN_KEY) {
 		VerifyNewConstraint(local_storage, parent, constraint);
 	}
 	local_storage.MoveStorage(parent, *this);
@@ -799,6 +800,11 @@ void DataTable::VerifyAppendForeignKeyConstraint(optional_ptr<LocalTableStorage>
                                                  const BoundForeignKeyConstraint &bound_foreign_key,
                                                  ClientContext &context, DataChunk &chunk) {
 	VerifyForeignKeyConstraint(storage, bound_foreign_key, context, chunk, VerifyExistenceType::APPEND_FK);
+}
+
+void DataTable::VerifyNewForeignKeyConstraint(const BoundForeignKeyConstraint &bound_foreign_key,
+                                              ClientContext &context, DataChunk &chunk) {
+	VerifyForeignKeyConstraint(nullptr, bound_foreign_key, context, chunk, VerifyExistenceType::APPEND_FK);
 }
 
 void DataTable::VerifyDeleteForeignKeyConstraint(optional_ptr<LocalTableStorage> storage,

--- a/test/sql/alter/add_fk_89fca7/add_fk_89fca7.test
+++ b/test/sql/alter/add_fk_89fca7/add_fk_89fca7.test
@@ -1,0 +1,147 @@
+# name: test/sql/alter/add_fk_89fca7/add_fk_89fca7.test
+# description: Test adding a FOREIGN KEY to an existing table.
+# group: [add_fk_89fca7]
+
+statement ok
+CREATE TABLE parent (id INTEGER PRIMARY KEY, name VARCHAR)
+
+statement ok
+CREATE TABLE child (id INTEGER, parent_id INTEGER)
+
+statement ok
+INSERT INTO parent VALUES (1, 'a'), (2, 'b'), (3, 'c')
+
+statement ok
+INSERT INTO child VALUES (10, 1), (11, 2), (12, NULL)
+
+statement ok
+ALTER TABLE child ADD CONSTRAINT fk_child_parent FOREIGN KEY (parent_id) REFERENCES parent(id)
+
+# The existing rows are untouched.
+
+query II
+SELECT id, parent_id FROM child ORDER BY id
+----
+10	1
+11	2
+12	NULL
+
+statement error
+INSERT INTO child VALUES (13, 99)
+----
+<REGEX>:Constraint Error.*
+
+# A NULL key is still allowed.
+
+statement ok
+INSERT INTO child VALUES (14, NULL)
+
+statement error
+UPDATE child SET parent_id = 99 WHERE id = 10
+----
+<REGEX>:Constraint Error.*
+
+statement ok
+UPDATE child SET parent_id = 3 WHERE id = 10
+
+# The referenced side is enforced too.
+
+statement error
+DELETE FROM parent WHERE id = 3
+----
+<REGEX>:Constraint Error.*
+
+statement ok
+DELETE FROM parent WHERE id = 1
+
+statement ok
+DROP TABLE child
+
+statement ok
+DROP TABLE parent
+
+# Multi-column keys.
+
+statement ok
+CREATE TABLE regions (country VARCHAR, region VARCHAR, PRIMARY KEY (country, region))
+
+statement ok
+CREATE TABLE city (name VARCHAR, country VARCHAR, region VARCHAR)
+
+statement ok
+INSERT INTO regions VALUES ('US', 'CA'), ('US', 'NY')
+
+statement ok
+INSERT INTO city VALUES ('San Jose', 'US', 'CA')
+
+statement ok
+ALTER TABLE city ADD CONSTRAINT fk_city FOREIGN KEY (country, region) REFERENCES regions(country, region)
+
+statement ok
+INSERT INTO city VALUES ('Albany', 'US', 'NY')
+
+statement error
+INSERT INTO city VALUES ('Austin', 'US', 'TX')
+----
+<REGEX>:Constraint Error.*
+
+# Only one half of the key matching is not enough.
+
+statement error
+INSERT INTO city VALUES ('Buffalo', 'CA', 'NY')
+----
+<REGEX>:Constraint Error.*
+
+statement ok
+DROP TABLE city
+
+statement ok
+DROP TABLE regions
+
+# The unnamed form, mirroring ALTER TABLE ... ADD PRIMARY KEY (...).
+
+statement ok
+CREATE TABLE unnamed_parent (id INTEGER PRIMARY KEY)
+
+statement ok
+CREATE TABLE unnamed_child (id INTEGER, parent_id INTEGER)
+
+statement ok
+INSERT INTO unnamed_parent VALUES (1)
+
+statement ok
+INSERT INTO unnamed_child VALUES (1, 1)
+
+statement ok
+ALTER TABLE unnamed_child ADD FOREIGN KEY (parent_id) REFERENCES unnamed_parent(id)
+
+statement error
+INSERT INTO unnamed_child VALUES (2, 42)
+----
+<REGEX>:Constraint Error.*
+
+# A UNIQUE constraint on the referenced columns is enough, it need not be the
+# primary key.
+
+statement ok
+CREATE TABLE unique_parent (id INTEGER PRIMARY KEY, code VARCHAR UNIQUE)
+
+statement ok
+CREATE TABLE unique_child (id INTEGER, code VARCHAR)
+
+statement ok
+INSERT INTO unique_parent VALUES (1, 'abc')
+
+statement ok
+INSERT INTO unique_child VALUES (1, 'abc')
+
+statement ok
+ALTER TABLE unique_child ADD CONSTRAINT fk_code FOREIGN KEY (code) REFERENCES unique_parent(code)
+
+statement error
+INSERT INTO unique_child VALUES (2, 'zzz')
+----
+<REGEX>:Constraint Error.*
+
+statement ok
+INSERT INTO unique_child VALUES (2, 'abc')

--- a/test/sql/alter/add_fk_89fca7/add_fk_invalid_89fca7.test
+++ b/test/sql/alter/add_fk_89fca7/add_fk_invalid_89fca7.test
@@ -1,0 +1,126 @@
+# name: test/sql/alter/add_fk_89fca7/add_fk_invalid_89fca7.test
+# description: Test rejecting a FOREIGN KEY that the table or the reference cannot satisfy.
+# group: [add_fk_89fca7]
+
+statement ok
+CREATE TABLE parent (id INTEGER PRIMARY KEY)
+
+statement ok
+CREATE TABLE child (id INTEGER, parent_id INTEGER)
+
+statement ok
+INSERT INTO parent VALUES (1), (2)
+
+statement ok
+INSERT INTO child VALUES (100, 1), (101, 5)
+
+# Row 101 has no matching parent, so the key cannot be added.
+
+statement error
+ALTER TABLE child ADD CONSTRAINT fk_child FOREIGN KEY (parent_id) REFERENCES parent(id)
+----
+<REGEX>:.*Error.*
+
+# The rejected statement left the table alone: the rows are still there and the
+# table is still unconstrained.
+
+query II
+SELECT id, parent_id FROM child ORDER BY id
+----
+100	1
+101	5
+
+statement ok
+INSERT INTO child VALUES (102, 9)
+
+# Once the offending rows are gone the same key can be added.
+
+statement ok
+DELETE FROM child WHERE parent_id NOT IN (SELECT id FROM parent)
+
+query II
+SELECT id, parent_id FROM child ORDER BY id
+----
+100	1
+
+statement ok
+ALTER TABLE child ADD CONSTRAINT fk_child FOREIGN KEY (parent_id) REFERENCES parent(id)
+
+statement error
+INSERT INTO child VALUES (103, 5)
+----
+<REGEX>:Constraint Error.*
+
+statement ok
+DROP TABLE child
+
+statement ok
+DROP TABLE parent
+
+# The referenced columns carry no UNIQUE or PRIMARY KEY constraint.
+
+statement ok
+CREATE TABLE unkeyed (id INTEGER)
+
+statement ok
+CREATE TABLE refers_unkeyed (id INTEGER, other_id INTEGER)
+
+statement error
+ALTER TABLE refers_unkeyed ADD CONSTRAINT fk_unkeyed FOREIGN KEY (other_id) REFERENCES unkeyed(id)
+----
+<REGEX>:.*Error.*
+
+statement ok
+INSERT INTO refers_unkeyed VALUES (1, 42)
+
+# The referencing and referenced columns have incompatible types.
+
+statement ok
+CREATE TABLE typed_parent (id INTEGER PRIMARY KEY)
+
+statement ok
+CREATE TABLE typed_child (id INTEGER, parent_id VARCHAR)
+
+statement error
+ALTER TABLE typed_child ADD CONSTRAINT fk_typed FOREIGN KEY (parent_id) REFERENCES typed_parent(id)
+----
+<REGEX>:.*Error.*
+
+# The referencing column does not exist.
+
+statement error
+ALTER TABLE typed_child ADD CONSTRAINT fk_missing FOREIGN KEY (nonexistent) REFERENCES typed_parent(id)
+----
+<REGEX>:.*Error.*
+
+# The referenced table does not exist.
+
+statement error
+ALTER TABLE typed_child ADD CONSTRAINT fk_no_table FOREIGN KEY (id) REFERENCES nonexistent_table(id)
+----
+<REGEX>:.*Error.*
+
+# The referenced column does not exist.
+
+statement error
+ALTER TABLE typed_child ADD CONSTRAINT fk_no_column FOREIGN KEY (id) REFERENCES typed_parent(nonexistent)
+----
+<REGEX>:.*Error.*
+
+# None of the rejected statements constrained the table.
+
+statement ok
+INSERT INTO typed_child VALUES (7, 'still unconstrained')
+
+# A different number of columns on each side of the key.
+
+statement ok
+CREATE TABLE pair_parent (a INTEGER, b INTEGER, PRIMARY KEY (a, b))
+
+statement ok
+CREATE TABLE pair_child (a INTEGER, b INTEGER)
+
+statement error
+ALTER TABLE pair_child ADD CONSTRAINT fk_pair FOREIGN KEY (a) REFERENCES pair_parent(a, b)
+----
+<REGEX>:.*Error.*

--- a/test/sql/alter/add_fk_89fca7/add_fk_storage_89fca7.test
+++ b/test/sql/alter/add_fk_89fca7/add_fk_storage_89fca7.test
@@ -1,0 +1,117 @@
+# name: test/sql/alter/add_fk_89fca7/add_fk_storage_89fca7.test
+# description: Test persisting and rolling back a FOREIGN KEY added to an existing table.
+# group: [add_fk_89fca7]
+
+load {TEST_DIR}/add_fk_89fca7.db
+
+statement ok
+CREATE TABLE parent (id INTEGER PRIMARY KEY)
+
+statement ok
+CREATE TABLE child (id INTEGER, parent_id INTEGER)
+
+statement ok
+INSERT INTO parent VALUES (1), (2)
+
+statement ok
+INSERT INTO child VALUES (1, 1)
+
+statement ok
+ALTER TABLE child ADD CONSTRAINT fk_persist FOREIGN KEY (parent_id) REFERENCES parent(id)
+
+restart
+
+query II
+SELECT id, parent_id FROM child ORDER BY id
+----
+1	1
+
+statement error
+INSERT INTO child VALUES (2, 42)
+----
+<REGEX>:Constraint Error.*
+
+statement ok
+INSERT INTO child VALUES (2, 2)
+
+statement error
+DELETE FROM parent WHERE id = 2
+----
+<REGEX>:Constraint Error.*
+
+# The referenced table cannot be dropped while the key exists.
+
+statement error
+DROP TABLE parent
+----
+<REGEX>:.*Error.*
+
+statement ok
+DROP TABLE child
+
+statement ok
+DROP TABLE parent
+
+# Rolling back leaves the table unconstrained.
+
+statement ok
+CREATE TABLE rollback_parent (id INTEGER PRIMARY KEY)
+
+statement ok
+CREATE TABLE rollback_child (id INTEGER, parent_id INTEGER)
+
+statement ok
+INSERT INTO rollback_parent VALUES (1)
+
+statement ok
+INSERT INTO rollback_child VALUES (1, 1)
+
+statement ok
+BEGIN TRANSACTION
+
+statement ok
+ALTER TABLE rollback_child ADD CONSTRAINT fk_rollback FOREIGN KEY (parent_id) REFERENCES rollback_parent(id)
+
+statement error
+INSERT INTO rollback_child VALUES (2, 42)
+----
+<REGEX>:Constraint Error.*
+
+statement ok
+ROLLBACK
+
+statement ok
+INSERT INTO rollback_child VALUES (2, 42)
+
+statement ok
+DROP TABLE rollback_parent
+
+# Committing inside a transaction keeps the key.
+
+statement ok
+CREATE TABLE commit_parent (id INTEGER PRIMARY KEY)
+
+statement ok
+CREATE TABLE commit_child (id INTEGER, parent_id INTEGER)
+
+statement ok
+INSERT INTO commit_parent VALUES (1)
+
+statement ok
+BEGIN TRANSACTION
+
+statement ok
+ALTER TABLE commit_child ADD CONSTRAINT fk_commit FOREIGN KEY (parent_id) REFERENCES commit_parent(id)
+
+statement ok
+COMMIT
+
+restart
+
+statement error
+INSERT INTO commit_child VALUES (1, 42)
+----
+<REGEX>:Constraint Error.*
+
+statement ok
+INSERT INTO commit_child VALUES (1, 1)


### PR DESCRIPTION
## Summary
Extends DuckDB to support adding foreign key constraints to existing tables via:

`sql
ALTER TABLE child ADD FOREIGN KEY (parent_id) REFERENCES parent(id);
``n
Currently DuckDB only supports foreign keys declared inline during `CREATE TABLE`. This PR adds the ability to add FK constraints after table creation using `ALTER TABLE ... ADD CONSTRAINT`/`ADD FOREIGN KEY`  syntax.

## Changes

### Parser / AlterInfo
- **`AlterInfo::IsAddForeignKey()`** – mirrors `IsAddPrimaryKey()` to detect FK additions and route them through the index-creation path.

### Binder
- **`BindAlterForeignKeyConstraint()`** – validates the FK reference: target table exists, referenced columns exist and have a matching unique/primary index.
- **`BindAlterAddIndex`** – extended to handle `ConstraintType::FOREIGN_KEY` alongside the existing PK path, creating the backing ART index with `IndexConstraintType::FOREIGN`.

### Execution
- **`PhysicalCreateIndex`** – registers the FK constraint on both the source (child) and referenced (parent) tables after index creation.

### Storage
- **`DataTable::AddForeignKeyConstraint()`** – allows FK metadata to be injected into an existing table's constraint list post-creation.

### Catalog
- **`DuckSchemaEntry`** and **`DuckTableEntry`** – minor hooks to support the new constraint addition flow.

## Tests
Three new sqllogictest files:
- `add_fk_89fca7.test` – happy-path: add FK, verify constraint enforcement, drop child table
- `add_fk_invalid_89fca7.test` – error paths: missing table, missing column, no matching PK/UNIQUE
- `add_fk_storage_89fca7.test` – persistence: FK survives checkpoint + restart