### PR TITLE
Fix encrytion util access

### DIFF
--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1282,9 +1282,9 @@ ParquetReader::ParquetReader(ClientContext &context_p, OpenFileInfo file_p, Parq
 		}
 	} else {
 		metadata = std::move(metadata_p);
-		if (parquet_options.encryption_config) {
-			encryption_util = context_p.db->GetEncryptionUtil(true);
-		}
+	}
+	if (parquet_options.encryption_config && !encryption_util) {
+		encryption_util = context_p.db->GetEncryptionUtil(true);
 	}
 	InitializeSchema(context_p);
 	// Length-pushdown rewrites these columns to BIGINT, update the local schema

--- a/test/sql/copy/parquet/parquet_encryption.test
+++ b/test/sql/copy/parquet/parquet_encryption.test
@@ -96,3 +96,25 @@ query I
 SELECT * FROM read_parquet('{TEST_DIR}/encrypted256.parquet', encryption_config={footer_key: 'key256base64'})
 ----
 42
+
+# encrypted parquet metadata cache hits must initialize the reader encryption state
+statement ok
+SET parquet_metadata_cache=true
+
+statement ok
+COPY (SELECT 84 i) TO '{TEST_DIR}/encrypted_metadata_cache.parquet' (ENCRYPTION_CONFIG {footer_key: 'key256'})
+
+query I
+SELECT * FROM read_parquet('{TEST_DIR}/encrypted_metadata_cache.parquet', encryption_config={footer_key: 'key256'})
+----
+84
+
+query I
+SELECT * FROM read_parquet('{TEST_DIR}/encrypted_metadata_cache.parquet', encryption_config={footer_key: 'key256'})
+----
+84
+
+statement error
+SELECT * FROM read_parquet('{TEST_DIR}/encrypted_metadata_cache.parquet', encryption_config={footer_key: 'key192'})
+----
+Invalid Input Error: Computed AES tag differs from read AES tag, are you using the right key?


### PR DESCRIPTION
Closes https://github.com/duckdb/duckdb/issues/24311

The issue is
- When parquet metadata enabled, first access suffer cache miss, so we initialize the encryption util
- On the second access, we have a cache hit, so encryption util initialization is skipped, all later accesses suffer invalid memory access

There're two ways I could think of
- Ensure encryption util is initialized everywhere before access (basically all read functions)
- or, eager initialize the encryption util. Since it doesn't involve any IO operations so pick this way to reduce mind overhead