### PR TITLE
Handle hive NULL in string format

### DIFF
--- a/src/common/hive_partitioning.cpp
+++ b/src/common/hive_partitioning.cpp
@@ -131,13 +131,17 @@ std::map<string, string> HivePartitioning::Parse(const string &filename) {
 
 Value HivePartitioning::GetValue(ClientContext &context, const string &key, const string &str_val,
                                  const LogicalType &type) {
-	// Handle nulls
-	if (IsNull(str_val)) {
+	// On SQLNULL, DuckDB writes "__HIVE_DEFAULT_PARTITION__", instead of string version "NULL".
+	if (str_val == "__HIVE_DEFAULT_PARTITION__") {
 		return Value(type);
 	}
 	if (type.id() == LogicalTypeId::VARCHAR) {
 		// for string values we can directly return the type
 		return Value(Unescape(str_val));
+	}
+	// Handle Hive NULL markers for non-string partition types
+	if (StringUtil::CIEquals(str_val, "NULL")) {
+		return Value(type);
 	}
 	if (str_val.empty()) {
 		// empty strings are NULL for non-string types

--- a/src/include/duckdb/common/hive_partitioning.hpp
+++ b/src/include/duckdb/common/hive_partitioning.hpp
@@ -41,7 +41,7 @@ public:
 	DUCKDB_API static string Escape(const string &input);
 	//! Unescape a hive partition key or value encoded using URL encoding
 	DUCKDB_API static string Unescape(const string &input);
-	//! Whether the column is "NULL"/"__HIVE_DEFAULT_PARTITION"
+	//! Whether the value is a null marker when detecting Hive partition types
 	DUCKDB_API static bool IsNull(const string &input);
 };
 

--- a/test/sql/copy/parquet/parquet_hive_empty.test
+++ b/test/sql/copy/parquet/parquet_hive_empty.test
@@ -13,11 +13,11 @@ a	a
 b	(empty)
 c	NULL
 
-# filter on hive partitioning with NULL values
+# filter on hive partitioning with literal 'NULL' values
 query II
 select *
 from parquet_scan('{DATA_DIR}/parquet-testing/hive-partitioning/empty_string/*/*.parquet')
-WHERE key IS NULL
+WHERE key='NULL'
 ----
 c	NULL
 

--- a/test/sql/copy/parquet/parquet_hive_null.test
+++ b/test/sql/copy/parquet/parquet_hive_null.test
@@ -66,6 +66,24 @@ ORDER BY ALL
 ----
 1	NULL	NULL
 
+# Test that literal VARCHAR partition value 'NULL' is not read as SQL NULL
+statement ok
+CREATE TABLE test_literal_null_partition AS
+SELECT *
+FROM (VALUES ('NULL', 1), ('ok', 2)) v(p, id);
+
+statement ok
+COPY test_literal_null_partition TO '{TEST_DIR}/hive-literal-null-partition'
+(FORMAT PARQUET, PARTITION_BY (p), OVERWRITE);
+
+query III
+SELECT (p IS NULL)::INTEGER AS is_null, COALESCE((p='NULL')::INTEGER, -1) AS equals_literal, id
+FROM parquet_scan('{TEST_DIR}/hive-literal-null-partition/**/*.parquet', hive_partitioning=1)
+ORDER BY id
+----
+0	1	1
+0	0	2
+
 # Test that NULL values are written as __HIVE_DEFAULT_PARTITION__
 statement ok
 create table test_null_write as select 1 as c, NULL::INT as a, NULL::INT as b;


### PR DESCRIPTION
Closes https://github.com/duckdb/duckdb/issues/24309

The issue is
- When DuckDB writes hive partition for SQLNULL partition, it [writes `__HIVE_DEFAULT_PARTITION__`](https://github.com/duckdb/duckdb/blob/7becbbfed86ff04946fb657ba8eaa4303db2b579/src/execution/operator/persistent/physical_copy_to_file.cpp#L2984), instead of a string "NULL"
- But when DuckDB reads partition value in string format, it checks against in string format for [both](https://github.com/duckdb/duckdb/blob/7becbbfed86ff04946fb657ba8eaa4303db2b579/src/common/hive_partitioning.cpp#L94) `__HIVE_DEFAULT_PARTITION__` and `NULL`, which gets SQLNULL mixed with string "NULL"

Disclaimer:
- The overall goal for this PR is to ensure hive partition files are self-consistent
- For string type, only `__HIVE_DEFAULT_PARTITION__` is checked, because we don't have a way to tell
- For other types, I keep the existing behavior; no ambiguity here