### PR TITLE
Optimize unittest startup and reduce fast test runtime

### DIFF
--- a/scripts/ci/run_tests.py
+++ b/scripts/ci/run_tests.py
@@ -1605,7 +1605,7 @@ def parse_args(argv: list[str] | None = None):
     )
     parser.add_argument(
         "--track-runtime",
-        type=int,
+        type=float,
         nargs="?",
         const=DEFAULT_RUNTIME_THRESHOLD_SECONDS,
         default=None,

--- a/test/include/test_helpers.hpp
+++ b/test/include/test_helpers.hpp
@@ -32,6 +32,7 @@
 namespace duckdb {
 
 void RegisterSqllogictests();
+void RegisterSqllogictests(const vector<string> &test_paths);
 void RegisterSqllogictestStdin();
 bool SummarizeFailures();
 

--- a/test/smoke_tests.list
+++ b/test/smoke_tests.list
@@ -182,7 +182,7 @@ test/sql/storage/constraints/foreignkey/foreign_key_persistent.test
 test/sql/storage/delete/load_delete_modify.test
 test/sql/storage/extensions/extension_default.test
 test/sql/storage/lazy_load/lazy_load_limit.test
-test/sql/storage/memory/in_memory_compress.test
+test/sql/storage/memory/in_memory_disabled_zstd.test
 test/sql/storage/metadata/full_table_metadata_reuse.test
 test/sql/storage/mix/test_update_delete_string.test
 test/sql/storage/nested/struct_of_lists_unaligned.test

--- a/test/sql/extensions/allowed_directories_install.test
+++ b/test/sql/extensions/allowed_directories_install.test
@@ -13,7 +13,7 @@ SET enable_external_access=false;
 
 # error messsage `Failed to download extension` means duckdb
 statement error
-INSTALL bogus FROM 'http://not.existent';
+INSTALL bogus FROM 'http://example.com';
 ----
 Failed to download extension
 
@@ -23,6 +23,6 @@ set extension_directory='/tmp'
 
 # duckdb will throw permission error because /tmp is not allowed
 statement error
-INSTALL bogus FROM 'http://not.existent';
+INSTALL bogus FROM 'http://example.com';
 ----
 Permission Error: Cannot access directory

--- a/test/sql/secrets/create_secret_persistence_no_client_context.test
+++ b/test/sql/secrets/create_secret_persistence_no_client_context.test
@@ -20,6 +20,6 @@ set secret_directory='{TEST_DIR}/create_secret_persistence_no_client_context'
 # This will trigger Secret manager initialization in a way where there is no ClientContext available
 # if secret manager is correctly initialized the request will happen and return the correct error. 
 statement error
-INSTALL bogus FROM 'http://not.existent';
+INSTALL bogus FROM 'http://example.com';
 ----
 Failed to download extension

--- a/test/sqlite/test_sqllogictest.cpp
+++ b/test/sqlite/test_sqllogictest.cpp
@@ -35,6 +35,10 @@ static bool endsWith(const string &mainStr, const string &toMatch) {
 	        mainStr.compare(mainStr.size() - toMatch.size(), toMatch.size(), toMatch) == 0);
 }
 
+static bool IsSQLLogicTestFile(const string &path) {
+	return endsWith(path, ".test") || endsWith(path, ".test_slow") || endsWith(path, ".test_coverage");
+}
+
 static void register_sqllogic_test_case(void (*test_fun)(), const string &path, const string &tags) {
 	auto normalized_path = StringUtil::Replace(path, "\\", "/");
 	if (TestConfiguration::Get().ShouldSkipTest(normalized_path)) {
@@ -233,8 +237,8 @@ static string ParseGroupFromPath(string file) {
 
 namespace duckdb {
 
-void RegisterSqllogictests() {
-	vector<string> excludes = {
+static const vector<string> &SQLiteLogicTestExcludes() {
+	static vector<string> excludes = {
 	    // tested separately
 	    "test/select1.test", "test/select2.test", "test/select3.test", "test/select4.test",
 	    // feature not supported
@@ -273,19 +277,70 @@ void RegisterSqllogictests() {
 	    "test/index/view/10/slt_good_2.test",
 	    // strange error in hash comparison, results appear correct...
 	    "test/index/random/10/slt_good_7.test", "test/index/random/10/slt_good_9.test"};
+	return excludes;
+}
+
+static bool IsExcludedSQLiteLogicTest(const string &path) {
+	for (auto &excl : SQLiteLogicTestExcludes()) {
+		if (path.find(excl) != string::npos) {
+			return true;
+		}
+	}
+	return false;
+}
+
+static bool PathStartsWith(const string &path, const string &prefix) {
+	if (prefix.empty() || path.find(prefix) != 0) {
+		return false;
+	}
+	return path.size() == prefix.size() || path[prefix.size()] == '/';
+}
+
+static bool IsSQLiteLogicTestPath(FileSystem &fs, const string &path) {
+	auto sqlite_test_root = fs.JoinPath(fs.JoinPath("third_party", "sqllogictest"), "test");
+	auto normalized_path = StringUtil::Replace(path, "\\", "/");
+	auto normalized_root = StringUtil::Replace(sqlite_test_root, "\\", "/");
+	return PathStartsWith(normalized_path, normalized_root);
+}
+
+static bool IsExtensionTestPath(const string &path) {
+	auto normalized_path = StringUtil::Replace(path, "\\", "/");
+	for (const auto &extension_test_path : ExtensionHelper::LoadedExtensionTestPaths()) {
+		auto normalized_root = StringUtil::Replace(extension_test_path, "\\", "/");
+		if (PathStartsWith(normalized_path, normalized_root)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+void RegisterSqllogictests(const vector<string> &test_paths) {
+	duckdb::unique_ptr<FileSystem> fs = FileSystem::CreateLocal();
+	for (const auto &path : test_paths) {
+		if (IsSQLiteLogicTestPath(*fs, path)) {
+			if (!IsExcludedSQLiteLogicTest(path)) {
+				register_sqllogic_test_case(testRunner<>, path, "[sqlitelogic][.]");
+			}
+		} else if (IsExtensionTestPath(path)) {
+			register_sqllogic_test_case(testRunner<true>, path, ParseGroupFromPath(path));
+		} else {
+			register_sqllogic_test_case(testRunner<false>, path, ParseGroupFromPath(path));
+		}
+	}
+}
+
+void RegisterSqllogictests() {
 	duckdb::unique_ptr<FileSystem> fs = FileSystem::CreateLocal();
 	listFiles(*fs, fs->JoinPath(fs->JoinPath("third_party", "sqllogictest"), "test"), [&](const string &path) {
 		if (endsWith(path, ".test")) {
-			for (auto &excl : excludes) {
-				if (path.find(excl) != string::npos) {
-					return;
-				}
+			if (IsExcludedSQLiteLogicTest(path)) {
+				return;
 			}
 			register_sqllogic_test_case(testRunner<>, path, "[sqlitelogic][.]");
 		}
 	});
 	listFiles(*fs, "test", [&](const string &path) {
-		if (endsWith(path, ".test") || endsWith(path, ".test_slow") || endsWith(path, ".test_coverage")) {
+		if (IsSQLLogicTestFile(path)) {
 			// parse the name / group from the test
 			register_sqllogic_test_case(testRunner<false>, path, ParseGroupFromPath(path));
 		}
@@ -293,7 +348,7 @@ void RegisterSqllogictests() {
 
 	for (const auto &extension_test_path : ExtensionHelper::LoadedExtensionTestPaths()) {
 		listFiles(*fs, extension_test_path, [&](const string &path) {
-			if (endsWith(path, ".test") || endsWith(path, ".test_slow") || endsWith(path, ".test_coverage")) {
+			if (IsSQLLogicTestFile(path)) {
 				auto fun = testRunner<true>;
 				register_sqllogic_test_case(fun, path, ParseGroupFromPath(path));
 			}

--- a/test/unittest.cpp
+++ b/test/unittest.cpp
@@ -1,6 +1,8 @@
 #define CATCH_CONFIG_RUNNER
 #include "catch.hpp"
 #include <stdlib.h>
+#include <fstream>
+#include <unordered_set>
 
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/string_util.hpp"
@@ -11,6 +13,44 @@
 
 using namespace duckdb;
 
+static bool IsSQLLogicTestFile(const string &path) {
+	return StringUtil::EndsWith(path, ".test") || StringUtil::EndsWith(path, ".test_slow") ||
+	       StringUtil::EndsWith(path, ".test_coverage");
+}
+
+static bool TryReadExactSQLLogicTestFilter(const vector<string> &input_files, vector<string> &test_paths,
+                                           string &error) {
+	if (input_files.empty()) {
+		return false;
+	}
+	auto fs = FileSystem::CreateLocal();
+	unordered_set<string> seen_paths;
+	for (auto &input_file : input_files) {
+		std::ifstream file(input_file.c_str());
+		if (!file.is_open()) {
+			return false;
+		}
+		string line;
+		while (std::getline(file, line)) {
+			StringUtil::Trim(line);
+			if (line.empty() || line[0] == '#') {
+				continue;
+			}
+			if (!IsSQLLogicTestFile(line)) {
+				return false;
+			}
+			if (!fs->FileExists(line)) {
+				error = "Unable to find sqllogictest file from -f/--input-file: " + line;
+				return true;
+			}
+			if (seen_paths.insert(line).second) {
+				test_paths.push_back(line);
+			}
+		}
+	}
+	return !test_paths.empty();
+}
+
 int main(int argc_in, char *argv[]) {
 	string test_directory = DUCKDB_ROOT_DIRECTORY;
 
@@ -18,6 +58,8 @@ int main(int argc_in, char *argv[]) {
 	test_config.Initialize();
 	bool keep_home = false;
 	bool use_stdin = false;
+	vector<string> input_files;
+	unordered_set<idx_t> input_file_arg_indices;
 
 	idx_t argc = NumericCast<idx_t>(argc_in);
 	int new_argc = 0;
@@ -68,6 +110,11 @@ int main(int argc_in, char *argv[]) {
 		} else {
 			try {
 				if (!test_config.ParseArgument(argument, argc, argv, i)) {
+					if ((argument == "-f" || argument == "--input-file") && i + 1 < argc) {
+						input_files.push_back(argv[i + 1]);
+						input_file_arg_indices.insert(new_argc);
+						input_file_arg_indices.insert(new_argc + 1);
+					}
 					new_argv[new_argc] = argv[i];
 					new_argc++;
 				}
@@ -78,6 +125,25 @@ int main(int argc_in, char *argv[]) {
 		}
 	}
 	test_config.ChangeWorkingDirectory(test_directory);
+
+	vector<string> exact_sqllogic_tests;
+	string exact_sqllogic_error;
+	bool exact_sqllogic_filter =
+	    TryReadExactSQLLogicTestFilter(input_files, exact_sqllogic_tests, exact_sqllogic_error);
+	if (!exact_sqllogic_error.empty()) {
+		fprintf(stderr, "%s\n", exact_sqllogic_error.c_str());
+		return 1;
+	}
+	if (exact_sqllogic_filter) {
+		int filtered_argc = 0;
+		for (int i = 0; i < new_argc; i++) {
+			if (input_file_arg_indices.find(i) != input_file_arg_indices.end()) {
+				continue;
+			}
+			new_argv[filtered_argc++] = new_argv[i];
+		}
+		new_argc = filtered_argc;
+	}
 
 	// Resolve + provision $BASE/[RUN_ID] per the create disposition (the TEST_ID level is
 	// materialized later, on the per-test path, once a test name is known).
@@ -118,11 +184,13 @@ int main(int argc_in, char *argv[]) {
 #endif
 	}
 
-	if (use_stdin || test_config.GetSkipCompiledTests()) {
+	if (use_stdin || exact_sqllogic_filter || test_config.GetSkipCompiledTests()) {
 		Catch::getMutableRegistryHub().clearTests();
 	}
 	if (use_stdin) {
 		RegisterSqllogictestStdin();
+	} else if (exact_sqllogic_filter) {
+		RegisterSqllogictests(exact_sqllogic_tests);
 	} else {
 		RegisterSqllogictests();
 	}

--- a/test/unittest.cpp
+++ b/test/unittest.cpp
@@ -134,6 +134,7 @@ int main(int argc_in, char *argv[]) {
 		fprintf(stderr, "%s\n", exact_sqllogic_error.c_str());
 		return 1;
 	}
+	string exact_sqllogic_test_filter = "*";
 	if (exact_sqllogic_filter) {
 		int filtered_argc = 0;
 		for (int i = 0; i < new_argc; i++) {
@@ -142,6 +143,7 @@ int main(int argc_in, char *argv[]) {
 			}
 			new_argv[filtered_argc++] = new_argv[i];
 		}
+		new_argv[filtered_argc++] = const_cast<char *>(exact_sqllogic_test_filter.c_str());
 		new_argc = filtered_argc;
 	}
 


### PR DESCRIPTION
### Context
I wanted to understand why increasing the number of tests (from 10 to 200) in a test batch did not lower the total test runtime.

There are ~4500 fast tests and each test batch starts a new unittest process and that startup overhead is significant.

With one test (taking 21ms), the total process runtime is 83ms:

```shell
$ cat test/smoke_tests.list | head -n1 > one.txt
$ build/release/test/unittest -f one.txt
[1/1] (100%): test/common/test_cast_hugeint.test took 0.021s
=============================================================================== 
All tests passed (254 assertions in 1 test case)
build/release/test/unittest -f one.txt  0.05s user 0.03s system 104% cpu 0.083 total
```

With ten tests (taking 124ms in total), the total process runtime is 186ms:
```shell
$ cat test/smoke_tests.list| head -n10 > ten.txt
$ time build/release/test/unittest -f ten.txt | cat
[1/10] (10%): test/extension/autoloading_copy_function_target.test took 0.009s
[2/10] (20%): test/fuzzer/pedro/C_C++_API_query_verification.test took 0.007s
[3/10] (30%): test/fuzzer/sqlsmith/bitstring_agg_executor.test took 0.006s
[4/10] (40%): test/fuzzer/fuzz_not_operator.test took 0.006s
[5/10] (50%): test/fuzzer/afl/alter_if_exists.test took 0.044s
[6/10] (60%): test/fuzzer/public/cast_index_expression.test took 0.007s
[7/10] (70%): test/fuzzer/duckfuzz/arg_minmax_by_decimal.test took 0.007s
[8/10] (80%): test/common/test_cast_hugeint.test took 0.016s
[9/10] (90%): test/issues/general/test_1091.test took 0.017s
[10/10] (100%): test/issues/fuzz/argminmax_strings.test took 0.005s
=============================================================================== 
All tests passed (297 assertions in 10 test cases)
build/release/test/unittest -f ten.txt  0.16s user 0.07s system 121% cpu 0.186 total
```

### Matching file names is slow

I profiled a run with 10 tests `samply record -- build/release/test/unittest -f ten.txt`:
<img width="957" height="431" alt="Screenshot 2026-07-30 at 15 10 38" src="https://github.com/user-attachments/assets/6c60a455-9189-467e-bab7-7cf2f39147ff" />

- 17% used by `duckdb::RegisterSqllogictests` -> `duckdb::FileSystem::ListFiles`.
- 3% used by `Catch::TestSpec::matchesByFilter` -> `Catch::WildcardPattern::normaliseString`.

So, 40ms to match 10 file names. With 250 file names, matching took 150 ms.

**Solution:** if `-f` contains only file names, let Catch only register those listed test files. This dropped matching for 1, 10 and 250 file names to <1ms.

```shell
$ time build/release/test/unittest -f one.txt
[1/1] (100%): test/common/test_cast_hugeint.test took 0.026s
All tests passed (254 assertions in 1 test case)                                                                      
build/release/test/unittest -f one.txt  0.04s user 0.02s system 104% cpu 0.055 total

$ time build/release/test/unittest -f ten.txt
[10/10] (100%): test/issues/general/test_1091.test took 0.017s
All tests passed (297 assertions in 10 test cases)
build/release/test/unittest -f ten.txt  0.15s user 0.05s system 126% cpu 0.158 total
```

(Later, we might want to change/optimize how Catch matches these filenames/patterns by not normalizing the string. However, that would only solve the `matchesByFilter` but not `ListFiles` overhead.)

### Use example.com instead of non-existing domains

Profiling the 253 smoke tests, showed two ~0.5s gaps in the middle of the CPU usage bar:

<img width="1275" height="534" alt="Screenshot 2026-07-30 at 18 03 18" src="https://github.com/user-attachments/assets/21266ea1-c564-403b-9275-fd276f4d8726" />

We're using not existing domains in test files, and those need to be resolved by a DNS server.
```diff
 # error messsage `Failed to download extension` means duckdb
 statement error
-INSTALL bogus FROM 'http://not.existent';
+INSTALL bogus FROM 'http://example.com';
 ----
 Failed to download extension
```

Replacing those domains with `example.com` lowered the test time from ~550ms to ~50ms.

### Future work

After these changes, the 253 tests spent 75% in `SQLLogicTestRunner::ExecuteScript`.

The remaining time (20%) is spent in setup (`SQLLogicTestRunner::CreateDatabase` and `SQLLogicTestRunner::LoadExtension`):
<img width="832" height="184" alt="Screenshot 2026-07-31 at 09 05 04" src="https://github.com/user-attachments/assets/fa591bde-cfdb-4fa1-aba0-6955ffb013df" />

And 3.4% in teardown (`DuckDB::~DuckDB`):
<img width="760" height="163" alt="Screenshot 2026-07-31 at 09 07 05" src="https://github.com/user-attachments/assets/fd2f45ed-30e8-4ea1-a568-8e7dde6bb1d7" />
