### PR TITLE
Fix: segfauly in url_decode with TRY() on dictionary-encoded columns

### DIFF
--- a/extension/core_functions/scalar/string/url_encode.cpp
+++ b/extension/core_functions/scalar/string/url_encode.cpp
@@ -43,7 +43,9 @@ static void URLDecodeFunction(DataChunk &args, ExpressionState &state, Vector &r
 }
 
 ScalarFunction UrlDecodeFun::GetFunction() {
-	return ScalarFunction({LogicalType::VARCHAR}, LogicalType::VARCHAR, URLDecodeFunction);
+	ScalarFunction fun({LogicalType::VARCHAR}, LogicalType::VARCHAR, URLDecodeFunction);
+	fun.SetFallible();
+	return fun;
 }
 
 } // namespace duckdb

--- a/test/sql/function/string/test_url_encode.test
+++ b/test/sql/function/string/test_url_encode.test
@@ -34,3 +34,16 @@ statement error
 select url_decode('%FF%FF%FF');
 ----
 decoded value is invalid UTF8
+
+# invalid UTF8 through TRY() on a dictionary-encoded column must not crash
+statement ok
+CREATE TABLE t24268 AS SELECT '%c0' AS c FROM range(4096);
+
+statement ok
+CHECKPOINT;
+
+query I
+SELECT COUNT(*) FROM t24268 WHERE TRY(url_decode(c)) IS NULL
+----
+4096
+


### PR DESCRIPTION
## Summary
- `url_decode` throws `InvalidInputException` on invalid UTF-8 output but never called `SetFallible()`, so `BoundFunctionExpression::CanThrow()` reported `false`.
- `ExecuteFunctionState` uses `CanThrow()` to decide eligibility for its dictionary-vector caching fast path (`execute_function.cpp`). Believing `url_decode` couldn't throw, it ran it through that path.
- When the exception fired partway through the dictionary-build loop, `output_dictionary` was left corrupted. Subsequent per-row retries inside `TRY()` (`execute_operator.cpp`) then read through the corrupted cached dictionary, producing a wild pointer and segfaulting in `StringHeap::AddBlobToHeap`.
- Fix: mark `url_decode`'s `ScalarFunction` fallible via `SetFallible()`, matching its actual behavior. This excludes it from the dictionary fast path and lets `TRY()` handle the exception correctly, as it already does for other fallible functions.

Fixes #24268.

## Test plan
- [x] Added regression test in `test/sql/function/string/test_url_encode.test` reproducing the exact repro from #24268 (dictionary-encoded column via `CHECKPOINT`, `TRY(url_decode(c))` over invalid-UTF8 input).
- [x] Rebuilt debug build with ASAN/assertions (`make debug`) and confirmed the crash reproduces before the fix and is gone after.
- [x] Verified `url_decode` still round-trips valid input correctly (`url_decode(url_encode(...))` and doc example).
- [x] `build/debug/test/unittest test/sql/function/string/test_url_encode.test` passes.