### PR TITLE
Fix compilation on Windows

### DIFF
--- a/src/include/duckdb/common/enums/row_id_handling.hpp
+++ b/src/include/duckdb/common/enums/row_id_handling.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "duckdb/common/constants.hpp"
+#include "duckdb/common/windows_undefs.hpp"
 
 namespace duckdb {
 


### PR DESCRIPTION
`RowIdHandling` enum includes a member named `ERROR` that clashes with a macro defined in Windows headers. `windows_undefs.hpp` that is supposed to undef this macro, at least in some build configurations, is not included when `RowIdHandling` is being defined.

This PR adds include of the `windows_undefs.hpp` just before defining the problematic enum.