### PR TITLE
Compress fully-visible partial deletes into a bitmask

### DIFF
--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -1792,6 +1792,25 @@ DeferredRuntimeFilterType EnumUtil::FromString<DeferredRuntimeFilterType>(const 
 	return static_cast<DeferredRuntimeFilterType>(StringUtil::StringToEnum(GetDeferredRuntimeFilterTypeValues(), 2, "DeferredRuntimeFilterType", value));
 }
 
+const StringUtil::EnumStringLiteral *GetDeleteIdStateValues() {
+	static constexpr StringUtil::EnumStringLiteral values[] {
+		{ static_cast<uint32_t>(DeleteIdState::CONSTANT), "CONSTANT" },
+		{ static_cast<uint32_t>(DeleteIdState::MASKED), "MASKED" },
+		{ static_cast<uint32_t>(DeleteIdState::ARRAY), "ARRAY" }
+	};
+	return values;
+}
+
+template<>
+const char* EnumUtil::ToChars<DeleteIdState>(DeleteIdState value) {
+	return StringUtil::EnumToString(GetDeleteIdStateValues(), 3, "DeleteIdState", static_cast<uint32_t>(value));
+}
+
+template<>
+DeleteIdState EnumUtil::FromString<DeleteIdState>(const char *value) {
+	return static_cast<DeleteIdState>(StringUtil::StringToEnum(GetDeleteIdStateValues(), 3, "DeleteIdState", value));
+}
+
 const StringUtil::EnumStringLiteral *GetDependencyEntryTypeValues() {
 	static constexpr StringUtil::EnumStringLiteral values[] {
 		{ static_cast<uint32_t>(DependencyEntryType::SUBJECT), "SUBJECT" },

--- a/src/include/duckdb/common/enum_util.hpp
+++ b/src/include/duckdb/common/enum_util.hpp
@@ -184,6 +184,8 @@ enum class DefaultOrderByNullType : uint8_t;
 
 enum class DeferredRuntimeFilterType : uint8_t;
 
+enum class DeleteIdState : uint8_t;
+
 enum class DependencyEntryType : uint8_t;
 
 enum class DeprecatedIndexType : uint8_t;
@@ -822,6 +824,9 @@ const char* EnumUtil::ToChars<DefaultOrderByNullType>(DefaultOrderByNullType val
 
 template<>
 const char* EnumUtil::ToChars<DeferredRuntimeFilterType>(DeferredRuntimeFilterType value);
+
+template<>
+const char* EnumUtil::ToChars<DeleteIdState>(DeleteIdState value);
 
 template<>
 const char* EnumUtil::ToChars<DependencyEntryType>(DependencyEntryType value);
@@ -1666,6 +1671,9 @@ DefaultOrderByNullType EnumUtil::FromString<DefaultOrderByNullType>(const char *
 
 template<>
 DeferredRuntimeFilterType EnumUtil::FromString<DeferredRuntimeFilterType>(const char *value);
+
+template<>
+DeleteIdState EnumUtil::FromString<DeleteIdState>(const char *value);
 
 template<>
 DependencyEntryType EnumUtil::FromString<DependencyEntryType>(const char *value);

--- a/src/include/duckdb/storage/table/chunk_info.hpp
+++ b/src/include/duckdb/storage/table/chunk_info.hpp
@@ -45,7 +45,8 @@ enum class VersionCompressionResult : uint8_t {
 
 //! The storage state of the delete side of a ChunkVectorInfo. Exhaustive and mutually exclusive:
 //! CONSTANT - all rows share constant_delete_id (NOT_DELETED_ID for none-deleted, or a single delete id)
-//! MASKED   - partially deleted, every delete visible to all transactions: stored in deleted_mask, deleted_data freed
+//! MASKED   - partially deleted, all deleted rows share one committed id (mask_delete_id): which rows are
+//!            deleted is stored in deleted_mask, deleted_data freed
 //! ARRAY    - per-row delete ids materialized in deleted_data
 enum class DeleteIdState : uint8_t { CONSTANT, MASKED, ARRAY };
 
@@ -113,8 +114,9 @@ private:
 	IndexPointer GetInitializedDeletedPointer();
 	//! Frees the per-row delete ids (if any)
 	void FreeDeleteData();
-	//! ARRAY -> MASKED: record alive rows as invalid bits, free the per-row delete array
-	void CompressDeleteToMask();
+	//! ARRAY -> MASKED: record alive rows as invalid bits, free the per-row delete array. mask_id is the
+	//! shared committed id of the deleted rows (0 when they are already visible to all transactions)
+	void CompressDeleteToMask(transaction_t mask_id);
 	//! MASKED -> ARRAY: re-materialize the per-row delete array from the bitmask
 	void DecompressDeleteMask();
 
@@ -129,10 +131,14 @@ private:
 	IndexPointer deleted_data;
 	//! The constant delete id (if there is only one, e.g. because the entire vector was deleted in one transaction)
 	transaction_t constant_delete_id;
-	//! Bitmask used in the MASKED state: valid bit == the row is deleted (committed, visible to all
-	//! transactions), invalid bit == the row is alive. Matches the on-disk VECTOR_INFO orientation.
-	//! Only meaningful when delete_state == DeleteIdState::MASKED.
+	//! Bitmask used in the MASKED state: valid bit == the row is deleted, invalid bit == the row is alive.
+	//! Matches the on-disk VECTOR_INFO orientation. Only meaningful when delete_state == DeleteIdState::MASKED.
 	ValidityMask deleted_mask;
+	//! The single committed id shared by every deleted row in the MASKED state. 0 means the deletes are
+	//! visible to all transactions (the value used when read from disk); a non-zero committed id means the
+	//! mask was folded from one committed transaction whose delete is not yet visible to every snapshot.
+	//! Only meaningful when delete_state == DeleteIdState::MASKED.
+	transaction_t mask_delete_id = 0;
 	//! The current delete-side storage state - the single source of truth for the delete side
 	DeleteIdState delete_state = DeleteIdState::CONSTANT;
 	//! Whether a compression pass could achieve anything for this vector: armed by any id modification,

--- a/src/include/duckdb/storage/table/chunk_info.hpp
+++ b/src/include/duckdb/storage/table/chunk_info.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb/execution/index/index_pointer.hpp"
 #include "duckdb/common/enums/scan_options.hpp"
+#include "duckdb/common/types/validity_mask.hpp"
 
 namespace duckdb {
 class RowGroup;
@@ -41,6 +42,12 @@ enum class VersionCompressionResult : uint8_t {
 	//! (some rows are not deleted)
 	SETTLED
 };
+
+//! The storage state of the delete side of a ChunkVectorInfo. Exhaustive and mutually exclusive:
+//! CONSTANT - all rows share constant_delete_id (NOT_DELETED_ID for none-deleted, or a single delete id)
+//! MASKED   - partially deleted, every delete visible to all transactions: stored in deleted_mask, deleted_data freed
+//! ARRAY    - per-row delete ids materialized in deleted_data
+enum class DeleteIdState : uint8_t { CONSTANT, MASKED, ARRAY };
 
 class ChunkVectorInfo {
 public:
@@ -106,6 +113,10 @@ private:
 	IndexPointer GetInitializedDeletedPointer();
 	//! Frees the per-row delete ids (if any)
 	void FreeDeleteData();
+	//! ARRAY -> MASKED: record alive rows as invalid bits, free the per-row delete array
+	void CompressDeleteToMask();
+	//! MASKED -> ARRAY: re-materialize the per-row delete array from the bitmask
+	void DecompressDeleteMask();
 
 private:
 	FixedSizeAllocator &allocator;
@@ -118,6 +129,12 @@ private:
 	IndexPointer deleted_data;
 	//! The constant delete id (if there is only one, e.g. because the entire vector was deleted in one transaction)
 	transaction_t constant_delete_id;
+	//! Bitmask used in the MASKED state: valid bit == the row is deleted (committed, visible to all
+	//! transactions), invalid bit == the row is alive. Matches the on-disk VECTOR_INFO orientation.
+	//! Only meaningful when delete_state == DeleteIdState::MASKED.
+	ValidityMask deleted_mask;
+	//! The current delete-side storage state - the single source of truth for the delete side
+	DeleteIdState delete_state = DeleteIdState::CONSTANT;
 	//! Whether a compression pass could achieve anything for this vector: armed by any id modification,
 	//! disarmed when a pass compresses the vector fully or finds it settled (live rows block the collapse
 	//! until a further delete re-arms it). CompressVersionIds returns the cached SETTLED without

--- a/src/storage/table/chunk_info.cpp
+++ b/src/storage/table/chunk_info.cpp
@@ -100,24 +100,50 @@ idx_t ChunkVectorInfo::TemplatedGetSelVector(transaction_t start_time, transacti
 		return count;
 	}
 	case DeleteIdState::MASKED: {
-		// per-row delete ids come from the bitmask: deleted row == committed id 0, alive row == NOT_DELETED_ID
+		// every deleted row shares mask_delete_id and alive rows are NOT_DELETED_ID (never deleted), so the
+		// delete decision is a single constant for the whole vector
+		const bool masked_deleted = DELETE_OP::IsDeleted(start_time, transaction_id, mask_delete_id);
 		if (HasConstantInsertionId()) {
 			if (!INSERT_OP::UseInsertedVersion(start_time, transaction_id, ConstantInsertId())) {
 				return 0;
 			}
+			if (!masked_deleted) {
+				// the delete is not visible to this transaction - every row is visible
+				return max_count;
+			}
+			// only the alive (mask-invalid) rows are visible
+			if (!sel_vector) {
+				return max_count - deleted_mask.CountValid(max_count);
+			}
+			// scan the mask a word at a time: skip fully-deleted words, take fully-alive words wholesale,
+			// only extract bits for mixed words
 			idx_t count = 0;
-			for (idx_t i = 0; i < max_count; i++) {
-				transaction_t deleted_id = deleted_mask.RowIsValid(i) ? transaction_t(0) : NOT_DELETED_ID;
-				if (DELETE_OP::IsDeleted(start_time, transaction_id, deleted_id)) {
+			const idx_t entry_count = ValidityMask::EntryCount(max_count);
+			for (idx_t entry_idx = 0; entry_idx < entry_count; entry_idx++) {
+				auto entry = deleted_mask.GetValidityEntry(entry_idx);
+				if (ValidityMask::AllValid(entry)) {
+					// every row in this word is deleted - skip
 					continue;
 				}
-				if (sel_vector) {
-					sel_vector->set_index(count, i);
+				const idx_t base = entry_idx * ValidityMask::BITS_PER_VALUE;
+				const idx_t entry_end = MinValue<idx_t>(base + ValidityMask::BITS_PER_VALUE, max_count);
+				if (ValidityMask::NoneValid(entry)) {
+					// every row in this word is alive - select them all
+					for (idx_t i = base; i < entry_end; i++) {
+						sel_vector->set_index(count++, i);
+					}
+					continue;
 				}
-				count++;
+				for (idx_t i = base; i < entry_end; i++) {
+					if (!ValidityMask::RowIsValid(entry, i - base)) {
+						sel_vector->set_index(count++, i);
+					}
+				}
 			}
 			return count;
 		}
+		// per-row insert ids: the mask cannot collapse the insert check, but the delete decision is still
+		// the constant masked_deleted
 		auto insert_segment = allocator.GetHandle(GetInsertedPointer());
 		auto inserted = insert_segment.GetPtr<transaction_t>();
 		idx_t count = 0;
@@ -125,8 +151,8 @@ idx_t ChunkVectorInfo::TemplatedGetSelVector(transaction_t start_time, transacti
 			if (!INSERT_OP::UseInsertedVersion(start_time, transaction_id, inserted[i])) {
 				continue;
 			}
-			transaction_t deleted_id = deleted_mask.RowIsValid(i) ? transaction_t(0) : NOT_DELETED_ID;
-			if (DELETE_OP::IsDeleted(start_time, transaction_id, deleted_id)) {
+			if (masked_deleted && deleted_mask.RowIsValid(i)) {
+				// the row is deleted and the delete is visible to this transaction
 				continue;
 			}
 			if (sel_vector) {
@@ -156,6 +182,7 @@ idx_t ChunkVectorInfo::TemplatedGetSelVector(transaction_t start_time, transacti
 			}
 			return count;
 		}
+
 		idx_t count = 0;
 		// have to check both flags
 		auto insert_segment = allocator.GetHandle(GetInsertedPointer());
@@ -231,7 +258,7 @@ bool ChunkVectorInfo::Fetch(TransactionData transaction, row_t row) {
 		fetch_deleted_id = ConstantDeleteId();
 		break;
 	case DeleteIdState::MASKED:
-		fetch_deleted_id = deleted_mask.RowIsValid(row) ? transaction_t(0) : NOT_DELETED_ID;
+		fetch_deleted_id = deleted_mask.RowIsValid(row) ? mask_delete_id : NOT_DELETED_ID;
 		break;
 	case DeleteIdState::ARRAY: {
 		auto delete_segment = allocator.GetHandle(GetDeletedPointer());
@@ -276,6 +303,10 @@ IndexPointer ChunkVectorInfo::GetInitializedInsertedPointer() {
 }
 
 IndexPointer ChunkVectorInfo::GetInitializedDeletedPointer() {
+	if (delete_state == DeleteIdState::MASKED) {
+		// re-materialize the per-row array so callers can write into it
+		DecompressDeleteMask();
+	}
 	if (HasConstantDeleteId()) {
 		transaction_t constant_id = ConstantDeleteId();
 
@@ -300,8 +331,10 @@ void ChunkVectorInfo::FreeDeleteData() {
 	delete_state = DeleteIdState::CONSTANT;
 }
 
-void ChunkVectorInfo::CompressDeleteToMask() {
+void ChunkVectorInfo::CompressDeleteToMask(transaction_t mask_id) {
 	D_ASSERT(delete_state == DeleteIdState::ARRAY);
+	// the mask can only carry a single committed id shared by every deleted row
+	D_ASSERT(mask_id < TRANSACTION_ID_START);
 	// start all-valid (== all deleted), then mark the alive rows invalid
 	deleted_mask.Initialize(STANDARD_VECTOR_SIZE);
 	{
@@ -315,19 +348,20 @@ void ChunkVectorInfo::CompressDeleteToMask() {
 	} // release the read handle before freeing the buffer
 	allocator.Free(deleted_data);
 	deleted_data = IndexPointer();
+	mask_delete_id = mask_id;
 	delete_state = DeleteIdState::MASKED;
 }
 
 void ChunkVectorInfo::DecompressDeleteMask() {
 	D_ASSERT(delete_state == DeleteIdState::MASKED);
-	// re-materialize the per-row array: deleted rows == committed id 0, alive rows == NOT_DELETED_ID
+	// re-materialize the per-row array: deleted rows == mask_delete_id, alive rows == NOT_DELETED_ID
 	deleted_data = allocator.New();
 	deleted_data.SetMetadata(1);
 	{
 		auto segment = allocator.GetHandle(deleted_data);
 		auto deleted = segment.GetPtr<transaction_t>();
 		for (idx_t i = 0; i < STANDARD_VECTOR_SIZE; i++) {
-			deleted[i] = deleted_mask.RowIsValid(i) ? transaction_t(0) : NOT_DELETED_ID;
+			deleted[i] = deleted_mask.RowIsValid(i) ? mask_delete_id : NOT_DELETED_ID;
 		}
 	}
 	deleted_mask.Reset();
@@ -346,10 +380,6 @@ static bool DeletesEntireVector(const row_t rows[], idx_t count) {
 }
 
 idx_t ChunkVectorInfo::Delete(transaction_t transaction_id, row_t rows[], idx_t count) {
-	if (delete_state == DeleteIdState::MASKED) {
-		// a new delete needs per-row ids again - re-materialize the array first
-		DecompressDeleteMask();
-	}
 	if (HasConstantDeleteId() && ConstantDeleteId() != NOT_DELETED_ID) {
 		// all rows in this vector share the same deleted id - the rows we are trying to delete are already deleted
 		if (ConstantDeleteId() == transaction_id) {
@@ -393,9 +423,6 @@ idx_t ChunkVectorInfo::Delete(transaction_t transaction_id, row_t rows[], idx_t 
 }
 
 void ChunkVectorInfo::CommitDelete(transaction_t commit_id, const DeleteInfo &info) {
-	if (delete_state == DeleteIdState::MASKED) {
-		DecompressDeleteMask();
-	}
 	if (info.is_consecutive && info.count == STANDARD_VECTOR_SIZE) {
 		// the delete covers the entire vector - all rows share the same deleted id
 		// we can store the deleted id as a constant and free any per-row delete ids
@@ -472,11 +499,13 @@ VersionCompressionResult ChunkVectorInfo::CompressVersionIds(transaction_t lowes
 	}
 	bool pending = false;
 	if (delete_state == DeleteIdState::ARRAY) {
-		// check if all rows are deleted, with all deletes visible to all active and future transactions
-		// if so, the per-row delete ids are equivalent to a single constant delete id
+		// scan the per-row delete ids to decide how far they can collapse
 		bool rows_alive = false;
 		bool deletes_pending = false;
+		bool deletes_uncommitted = false;
+		bool deletes_equal = true;
 		transaction_t max_delete_id = 0;
+		transaction_t shared_delete_id = NOT_DELETED_ID;
 		{
 			auto segment = allocator.GetHandle(GetDeletedPointer());
 			auto deleted = segment.GetPtr<transaction_t>();
@@ -484,12 +513,23 @@ VersionCompressionResult ChunkVectorInfo::CompressVersionIds(transaction_t lowes
 				if (deleted[i] == NOT_DELETED_ID) {
 					// the row is not deleted - the ids cannot fully collapse until it is
 					rows_alive = true;
-				} else if (deleted[i] >= lowest_active_start) {
-					// deleted, but the delete is not yet visible to all transactions - the ids can
-					// compress once the lowest active start advances past the delete id
+					continue;
+				}
+				if (deleted[i] >= lowest_active_start) {
+					// deleted, but the delete is not yet visible to all transactions
 					deletes_pending = true;
+					if (deleted[i] >= TRANSACTION_ID_START) {
+						// the delete is not even committed yet - the array must be kept
+						deletes_uncommitted = true;
+					}
 				} else {
 					max_delete_id = MaxValue(max_delete_id, deleted[i]);
+				}
+				// track whether every deleted row shares a single id
+				if (shared_delete_id == NOT_DELETED_ID) {
+					shared_delete_id = deleted[i];
+				} else if (deleted[i] != shared_delete_id) {
+					deletes_equal = false;
 				}
 			}
 		}
@@ -501,10 +541,15 @@ VersionCompressionResult ChunkVectorInfo::CompressVersionIds(transaction_t lowes
 			// entire vector deleted but a delete is still pending - retry next pass
 			pending = true;
 		} else if (!deletes_pending) {
-			// partially deleted, every delete visible to all - compress to a bitmask (terminal)
-			CompressDeleteToMask();
+			// partially deleted, every delete visible to all - compress to a mask (terminal)
+			CompressDeleteToMask(0);
+		} else if (deletes_equal && !deletes_uncommitted) {
+			// partially deleted, every delete committed by the same transaction but not yet visible to
+			// all - compress to a mask carrying that single committed id (terminal). Older snapshots still
+			// see the rows via the id comparison, and on reload every id is visible so it becomes 0.
+			CompressDeleteToMask(shared_delete_id);
 		} else {
-			// partially deleted with a pending delete - retry once the lowest active start advances
+			// partially deleted with pending deletes from multiple or uncommitted transactions - retry
 			pending = true;
 		}
 	}
@@ -615,9 +660,8 @@ bool ChunkVectorInfo::HasDeletes(transaction_t transaction_id) const {
 	case DeleteIdState::CONSTANT:
 		return ConstantDeleteId() <= transaction_id;
 	case DeleteIdState::MASKED:
-		// AnyDeleted() above guaranteed at least one deleted row; masked deletes are committed id 0
-		// (<= any transaction_id), so the deletes are visible to the given transaction
-		return true;
+		// AnyDeleted() above guaranteed at least one deleted row; they all share mask_delete_id
+		return mask_delete_id <= transaction_id;
 	case DeleteIdState::ARRAY: {
 		auto segment = allocator.GetHandle(GetDeletedPointer());
 		auto deleted = segment.GetPtr<transaction_t>();
@@ -651,7 +695,8 @@ bool ChunkVectorInfo::HasUncommittedChanges() const {
 	case DeleteIdState::CONSTANT:
 		return ConstantDeleteId() != NOT_DELETED_ID && ConstantDeleteId() >= TRANSACTION_ID_START;
 	case DeleteIdState::MASKED:
-		// masked deletes are all committed and visible to all transactions
+		// the mask is only ever folded from committed deletes, so mask_delete_id is always committed
+		D_ASSERT(mask_delete_id < TRANSACTION_ID_START);
 		return false;
 	case DeleteIdState::ARRAY: {
 		auto delete_segment = allocator.GetHandle(GetDeletedPointer());
@@ -716,6 +761,7 @@ string ChunkVectorInfo::ToString(idx_t max_count) const {
 		}
 		break;
 	case DeleteIdState::MASKED: {
+		result += ", Delete Id: " + to_string(mask_delete_id);
 		result += ", Deleted (mask): [";
 		for (idx_t idx = 0; idx < max_count; idx++) {
 			if (idx > 0) {
@@ -810,11 +856,17 @@ unique_ptr<ChunkVectorInfo> ChunkVectorInfo::Read(FixedSizeAllocator &allocator,
 		auto result = make_uniq<ChunkVectorInfo>(allocator, start);
 		result->deleted_mask.Read(reader, STANDARD_VECTOR_SIZE);
 		// Write only emits VECTOR_INFO for a partial delete: an all-deleted vector becomes
-		// CONSTANT_INFO and an undeleted one becomes EMPTY_INFO, so the mask always has at least one
+		// CONSTANT_INFO and an undeleted one becomes EMPTY_INFO, so the mask must have at least one
 		// deleted (valid) and one alive (invalid) bit - never all-valid, never all-invalid.
-		D_ASSERT(!result->deleted_mask.CheckAllValid(STANDARD_VECTOR_SIZE));
-		D_ASSERT(!result->deleted_mask.CheckAllInvalid(STANDARD_VECTOR_SIZE));
+		if (result->deleted_mask.CheckAllValid(STANDARD_VECTOR_SIZE) ||
+		    result->deleted_mask.CheckAllInvalid(STANDARD_VECTOR_SIZE)) {
+			throw DataCorruptionException(
+			    "Partial-delete vector info mask marks either all rows deleted or all rows alive, but a "
+			    "VECTOR_INFO block must always encode a partial delete. The database file may be corrupted.");
+		}
 		result->delete_state = DeleteIdState::MASKED;
+		// on-disk deletes are all committed and visible to every transaction - the shared id is 0
+		result->mask_delete_id = 0;
 		// every id is already visible to all transactions - nothing left to compress
 		result->recheck_compression = false;
 		return result;

--- a/src/storage/table/chunk_info.cpp
+++ b/src/storage/table/chunk_info.cpp
@@ -67,7 +67,8 @@ ChunkVectorInfo::~ChunkVectorInfo() {
 template <class INSERT_OP, class DELETE_OP>
 idx_t ChunkVectorInfo::TemplatedGetSelVector(transaction_t start_time, transaction_t transaction_id,
                                              optional_ptr<SelectionVector> sel_vector, idx_t max_count) const {
-	if (HasConstantDeleteId()) {
+	switch (delete_state) {
+	case DeleteIdState::CONSTANT: {
 		// all tuples have the same deleted id
 		if (DELETE_OP::IsDeleted(start_time, transaction_id, ConstantDeleteId())) {
 			// all tuples are deleted
@@ -98,15 +99,74 @@ idx_t ChunkVectorInfo::TemplatedGetSelVector(transaction_t start_time, transacti
 		}
 		return count;
 	}
-	if (HasConstantInsertionId()) {
-		if (!INSERT_OP::UseInsertedVersion(start_time, transaction_id, ConstantInsertId())) {
-			return 0;
+	case DeleteIdState::MASKED: {
+		// per-row delete ids come from the bitmask: deleted row == committed id 0, alive row == NOT_DELETED_ID
+		if (HasConstantInsertionId()) {
+			if (!INSERT_OP::UseInsertedVersion(start_time, transaction_id, ConstantInsertId())) {
+				return 0;
+			}
+			idx_t count = 0;
+			for (idx_t i = 0; i < max_count; i++) {
+				transaction_t deleted_id = deleted_mask.RowIsValid(i) ? transaction_t(0) : NOT_DELETED_ID;
+				if (DELETE_OP::IsDeleted(start_time, transaction_id, deleted_id)) {
+					continue;
+				}
+				if (sel_vector) {
+					sel_vector->set_index(count, i);
+				}
+				count++;
+			}
+			return count;
 		}
-		// have to check deleted flag
+		auto insert_segment = allocator.GetHandle(GetInsertedPointer());
+		auto inserted = insert_segment.GetPtr<transaction_t>();
 		idx_t count = 0;
-		auto segment = allocator.GetHandle(GetDeletedPointer());
-		auto deleted = segment.GetPtr<transaction_t>();
 		for (idx_t i = 0; i < max_count; i++) {
+			if (!INSERT_OP::UseInsertedVersion(start_time, transaction_id, inserted[i])) {
+				continue;
+			}
+			transaction_t deleted_id = deleted_mask.RowIsValid(i) ? transaction_t(0) : NOT_DELETED_ID;
+			if (DELETE_OP::IsDeleted(start_time, transaction_id, deleted_id)) {
+				continue;
+			}
+			if (sel_vector) {
+				sel_vector->set_index(count, i);
+			}
+			count++;
+		}
+		return count;
+	}
+	case DeleteIdState::ARRAY: {
+		if (HasConstantInsertionId()) {
+			if (!INSERT_OP::UseInsertedVersion(start_time, transaction_id, ConstantInsertId())) {
+				return 0;
+			}
+			// have to check deleted flag
+			idx_t count = 0;
+			auto segment = allocator.GetHandle(GetDeletedPointer());
+			auto deleted = segment.GetPtr<transaction_t>();
+			for (idx_t i = 0; i < max_count; i++) {
+				if (DELETE_OP::IsDeleted(start_time, transaction_id, deleted[i])) {
+					continue;
+				}
+				if (sel_vector) {
+					sel_vector->set_index(count, i);
+				}
+				count++;
+			}
+			return count;
+		}
+		idx_t count = 0;
+		// have to check both flags
+		auto insert_segment = allocator.GetHandle(GetInsertedPointer());
+		auto inserted = insert_segment.GetPtr<transaction_t>();
+
+		auto delete_segment = allocator.GetHandle(GetDeletedPointer());
+		auto deleted = delete_segment.GetPtr<transaction_t>();
+		for (idx_t i = 0; i < max_count; i++) {
+			if (!INSERT_OP::UseInsertedVersion(start_time, transaction_id, inserted[i])) {
+				continue;
+			}
 			if (DELETE_OP::IsDeleted(start_time, transaction_id, deleted[i])) {
 				continue;
 			}
@@ -117,27 +177,9 @@ idx_t ChunkVectorInfo::TemplatedGetSelVector(transaction_t start_time, transacti
 		}
 		return count;
 	}
-
-	idx_t count = 0;
-	// have to check both flags
-	auto insert_segment = allocator.GetHandle(GetInsertedPointer());
-	auto inserted = insert_segment.GetPtr<transaction_t>();
-
-	auto delete_segment = allocator.GetHandle(GetDeletedPointer());
-	auto deleted = delete_segment.GetPtr<transaction_t>();
-	for (idx_t i = 0; i < max_count; i++) {
-		if (!INSERT_OP::UseInsertedVersion(start_time, transaction_id, inserted[i])) {
-			continue;
-		}
-		if (DELETE_OP::IsDeleted(start_time, transaction_id, deleted[i])) {
-			continue;
-		}
-		if (sel_vector) {
-			sel_vector->set_index(count, i);
-		}
-		count++;
+	default:
+		throw InternalException("Unknown DeleteIdState in TemplatedGetSelVector");
 	}
-	return count;
 }
 
 idx_t ChunkVectorInfo::GetSelVector(ScanOptions options, optional_ptr<SelectionVector> sel_vector,
@@ -176,7 +218,6 @@ idx_t ChunkVectorInfo::GetSelVector(ScanOptions options, optional_ptr<SelectionV
 
 bool ChunkVectorInfo::Fetch(TransactionData transaction, row_t row) {
 	transaction_t fetch_insert_id;
-	transaction_t fetch_deleted_id;
 	if (HasConstantInsertionId()) {
 		fetch_insert_id = ConstantInsertId();
 	} else {
@@ -184,12 +225,21 @@ bool ChunkVectorInfo::Fetch(TransactionData transaction, row_t row) {
 		auto inserted = insert_segment.GetPtr<transaction_t>();
 		fetch_insert_id = inserted[row];
 	}
-	if (HasConstantDeleteId()) {
+	transaction_t fetch_deleted_id;
+	switch (delete_state) {
+	case DeleteIdState::CONSTANT:
 		fetch_deleted_id = ConstantDeleteId();
-	} else {
+		break;
+	case DeleteIdState::MASKED:
+		fetch_deleted_id = deleted_mask.RowIsValid(row) ? transaction_t(0) : NOT_DELETED_ID;
+		break;
+	case DeleteIdState::ARRAY: {
 		auto delete_segment = allocator.GetHandle(GetDeletedPointer());
-		auto deleted = delete_segment.GetPtr<transaction_t>();
-		fetch_deleted_id = deleted[row];
+		fetch_deleted_id = delete_segment.GetPtr<transaction_t>()[row];
+		break;
+	}
+	default:
+		throw InternalException("Unknown DeleteIdState in Fetch");
 	}
 
 	return UseVersion(transaction, fetch_insert_id) && !UseVersion(transaction, fetch_deleted_id);
@@ -203,8 +253,9 @@ IndexPointer ChunkVectorInfo::GetInsertedPointer() const {
 }
 
 IndexPointer ChunkVectorInfo::GetDeletedPointer() const {
-	if (HasConstantDeleteId()) {
-		throw InternalException("ChunkVectorInfo: deleted id requested but deletions were not initialized");
+	if (delete_state != DeleteIdState::ARRAY) {
+		throw InternalException(
+		    "ChunkVectorInfo: deleted id array requested but delete side is not in the ARRAY state");
 	}
 	return deleted_data;
 }
@@ -235,16 +286,53 @@ IndexPointer ChunkVectorInfo::GetInitializedDeletedPointer() {
 		for (idx_t i = 0; i < STANDARD_VECTOR_SIZE; i++) {
 			deleted[i] = constant_id;
 		}
+		delete_state = DeleteIdState::ARRAY;
 	}
 	return deleted_data;
 }
 
 void ChunkVectorInfo::FreeDeleteData() {
-	if (HasConstantDeleteId()) {
-		return;
+	if (delete_state == DeleteIdState::ARRAY) {
+		allocator.Free(deleted_data);
+		deleted_data = IndexPointer();
 	}
+	deleted_mask.Reset();
+	delete_state = DeleteIdState::CONSTANT;
+}
+
+void ChunkVectorInfo::CompressDeleteToMask() {
+	D_ASSERT(delete_state == DeleteIdState::ARRAY);
+	// start all-valid (== all deleted), then mark the alive rows invalid
+	deleted_mask.Initialize(STANDARD_VECTOR_SIZE);
+	{
+		auto segment = allocator.GetHandle(deleted_data);
+		auto deleted = segment.GetPtr<transaction_t>();
+		for (idx_t i = 0; i < STANDARD_VECTOR_SIZE; i++) {
+			if (deleted[i] == NOT_DELETED_ID) {
+				deleted_mask.SetInvalid(i);
+			}
+		}
+	} // release the read handle before freeing the buffer
 	allocator.Free(deleted_data);
 	deleted_data = IndexPointer();
+	delete_state = DeleteIdState::MASKED;
+}
+
+void ChunkVectorInfo::DecompressDeleteMask() {
+	D_ASSERT(delete_state == DeleteIdState::MASKED);
+	// re-materialize the per-row array: deleted rows == committed id 0, alive rows == NOT_DELETED_ID
+	deleted_data = allocator.New();
+	deleted_data.SetMetadata(1);
+	{
+		auto segment = allocator.GetHandle(deleted_data);
+		auto deleted = segment.GetPtr<transaction_t>();
+		for (idx_t i = 0; i < STANDARD_VECTOR_SIZE; i++) {
+			deleted[i] = deleted_mask.RowIsValid(i) ? transaction_t(0) : NOT_DELETED_ID;
+		}
+	}
+	deleted_mask.Reset();
+	delete_state = DeleteIdState::ARRAY;
+	recheck_compression = true;
 }
 
 static bool DeletesEntireVector(const row_t rows[], idx_t count) {
@@ -258,6 +346,10 @@ static bool DeletesEntireVector(const row_t rows[], idx_t count) {
 }
 
 idx_t ChunkVectorInfo::Delete(transaction_t transaction_id, row_t rows[], idx_t count) {
+	if (delete_state == DeleteIdState::MASKED) {
+		// a new delete needs per-row ids again - re-materialize the array first
+		DecompressDeleteMask();
+	}
 	if (HasConstantDeleteId() && ConstantDeleteId() != NOT_DELETED_ID) {
 		// all rows in this vector share the same deleted id - the rows we are trying to delete are already deleted
 		if (ConstantDeleteId() == transaction_id) {
@@ -301,6 +393,9 @@ idx_t ChunkVectorInfo::Delete(transaction_t transaction_id, row_t rows[], idx_t 
 }
 
 void ChunkVectorInfo::CommitDelete(transaction_t commit_id, const DeleteInfo &info) {
+	if (delete_state == DeleteIdState::MASKED) {
+		DecompressDeleteMask();
+	}
 	if (info.is_consecutive && info.count == STANDARD_VECTOR_SIZE) {
 		// the delete covers the entire vector - all rows share the same deleted id
 		// we can store the deleted id as a constant and free any per-row delete ids
@@ -354,18 +449,13 @@ void ChunkVectorInfo::VerifyCachedCompressionState() const {
 	// modification re-arms it. Both conditions below are independent of the lowest active start:
 	// per-row insert ids all become visible (or are reverted) eventually, so they must already be compressed
 	D_ASSERT(HasConstantInsertionId());
-	if (!HasConstantDeleteId()) {
-		// per-row delete ids may only remain because a live row blocks the collapse
-		auto segment = allocator.GetHandle(GetDeletedPointer());
-		auto deleted = segment.GetPtr<transaction_t>();
-		bool rows_alive = false;
-		for (idx_t i = 0; i < STANDARD_VECTOR_SIZE; i++) {
-			if (deleted[i] == NOT_DELETED_ID) {
-				rows_alive = true;
-				break;
-			}
-		}
-		D_ASSERT(rows_alive);
+	if (delete_state != DeleteIdState::CONSTANT) {
+		// a settled, non-constant delete side can only be the terminal masked state
+		D_ASSERT(delete_state == DeleteIdState::MASKED);
+		// the mask must hold at least one deleted row and one alive row: a fully deleted vector
+		// collapses to a constant, and a vector with no deletes carries no delete-side info
+		idx_t deleted_rows = deleted_mask.CountValid(STANDARD_VECTOR_SIZE);
+		D_ASSERT(deleted_rows > 0 && deleted_rows < STANDARD_VECTOR_SIZE);
 	}
 #endif
 }
@@ -381,7 +471,7 @@ VersionCompressionResult ChunkVectorInfo::CompressVersionIds(transaction_t lowes
 		                                                         : VersionCompressionResult::SETTLED;
 	}
 	bool pending = false;
-	if (!HasConstantDeleteId()) {
+	if (delete_state == DeleteIdState::ARRAY) {
 		// check if all rows are deleted, with all deletes visible to all active and future transactions
 		// if so, the per-row delete ids are equivalent to a single constant delete id
 		bool rows_alive = false;
@@ -392,7 +482,7 @@ VersionCompressionResult ChunkVectorInfo::CompressVersionIds(transaction_t lowes
 			auto deleted = segment.GetPtr<transaction_t>();
 			for (idx_t i = 0; i < STANDARD_VECTOR_SIZE; i++) {
 				if (deleted[i] == NOT_DELETED_ID) {
-					// the row is not deleted - the ids cannot compress until it is
+					// the row is not deleted - the ids cannot fully collapse until it is
 					rows_alive = true;
 				} else if (deleted[i] >= lowest_active_start) {
 					// deleted, but the delete is not yet visible to all transactions - the ids can
@@ -404,9 +494,17 @@ VersionCompressionResult ChunkVectorInfo::CompressVersionIds(transaction_t lowes
 			}
 		}
 		if (!rows_alive && !deletes_pending) {
+			// entire vector deleted and visible to all - collapse to a constant
 			FreeDeleteData();
 			constant_delete_id = max_delete_id;
 		} else if (!rows_alive) {
+			// entire vector deleted but a delete is still pending - retry next pass
+			pending = true;
+		} else if (!deletes_pending) {
+			// partially deleted, every delete visible to all - compress to a bitmask (terminal)
+			CompressDeleteToMask();
+		} else {
+			// partially deleted with a pending delete - retry once the lowest active start advances
 			pending = true;
 		}
 	}
@@ -513,18 +611,26 @@ bool ChunkVectorInfo::HasDeletes(transaction_t transaction_id) const {
 	if (transaction_id == MAX_TRANSACTION_ID) {
 		return true;
 	}
-	if (HasConstantDeleteId()) {
+	switch (delete_state) {
+	case DeleteIdState::CONSTANT:
 		return ConstantDeleteId() <= transaction_id;
-	}
-	auto segment = allocator.GetHandle(deleted_data);
-	auto deleted = segment.GetPtr<transaction_t>();
-
-	for (idx_t i = 0; i < STANDARD_VECTOR_SIZE; i++) {
-		if (deleted[i] <= transaction_id) {
-			return true;
+	case DeleteIdState::MASKED:
+		// AnyDeleted() above guaranteed at least one deleted row; masked deletes are committed id 0
+		// (<= any transaction_id), so the deletes are visible to the given transaction
+		return true;
+	case DeleteIdState::ARRAY: {
+		auto segment = allocator.GetHandle(GetDeletedPointer());
+		auto deleted = segment.GetPtr<transaction_t>();
+		for (idx_t i = 0; i < STANDARD_VECTOR_SIZE; i++) {
+			if (deleted[i] <= transaction_id) {
+				return true;
+			}
 		}
+		return false;
 	}
-	return false;
+	default:
+		throw InternalException("Unknown DeleteIdState in HasDeletes");
+	}
 }
 
 bool ChunkVectorInfo::HasUncommittedChanges() const {
@@ -541,24 +647,39 @@ bool ChunkVectorInfo::HasUncommittedChanges() const {
 			}
 		}
 	}
-	if (HasConstantDeleteId()) {
+	switch (delete_state) {
+	case DeleteIdState::CONSTANT:
 		return ConstantDeleteId() != NOT_DELETED_ID && ConstantDeleteId() >= TRANSACTION_ID_START;
-	}
-	auto delete_segment = allocator.GetHandle(GetDeletedPointer());
-	auto deleted = delete_segment.GetPtr<transaction_t>();
-	for (idx_t i = 0; i < STANDARD_VECTOR_SIZE; i++) {
-		if (deleted[i] != NOT_DELETED_ID && deleted[i] >= TRANSACTION_ID_START) {
-			return true;
+	case DeleteIdState::MASKED:
+		// masked deletes are all committed and visible to all transactions
+		return false;
+	case DeleteIdState::ARRAY: {
+		auto delete_segment = allocator.GetHandle(GetDeletedPointer());
+		auto deleted = delete_segment.GetPtr<transaction_t>();
+		for (idx_t i = 0; i < STANDARD_VECTOR_SIZE; i++) {
+			if (deleted[i] != NOT_DELETED_ID && deleted[i] >= TRANSACTION_ID_START) {
+				return true;
+			}
 		}
+		return false;
 	}
-	return false;
+	default:
+		throw InternalException("Unknown DeleteIdState in HasUncommittedChanges");
+	}
 }
 
 bool ChunkVectorInfo::AnyDeleted() const {
-	if (HasConstantDeleteId()) {
+	switch (delete_state) {
+	case DeleteIdState::CONSTANT:
 		return ConstantDeleteId() != NOT_DELETED_ID;
+	case DeleteIdState::MASKED:
+		// a masked vector always contains at least one deleted row
+		return true;
+	case DeleteIdState::ARRAY:
+		return true;
+	default:
+		throw InternalException("Unknown DeleteIdState in AnyDeleted");
 	}
-	return true;
 }
 
 bool ChunkVectorInfo::HasConstantInsertionId() const {
@@ -566,7 +687,7 @@ bool ChunkVectorInfo::HasConstantInsertionId() const {
 }
 
 bool ChunkVectorInfo::HasConstantDeleteId() const {
-	return !deleted_data.HasMetadata();
+	return delete_state == DeleteIdState::CONSTANT;
 }
 
 string ChunkVectorInfo::ToString(idx_t max_count) const {
@@ -588,11 +709,24 @@ string ChunkVectorInfo::ToString(idx_t max_count) const {
 		}
 		result += "]";
 	}
-	if (HasConstantDeleteId()) {
+	switch (delete_state) {
+	case DeleteIdState::CONSTANT:
 		if (ConstantDeleteId() != NOT_DELETED_ID) {
 			result += ", Delete Id: " + to_string(constant_delete_id);
 		}
-	} else {
+		break;
+	case DeleteIdState::MASKED: {
+		result += ", Deleted (mask): [";
+		for (idx_t idx = 0; idx < max_count; idx++) {
+			if (idx > 0) {
+				result += ", ";
+			}
+			result += deleted_mask.RowIsValid(idx) ? "1" : "0";
+		}
+		result += "]";
+		break;
+	}
+	case DeleteIdState::ARRAY: {
 		result += ", Delete Ids: [";
 		auto segment = allocator.GetHandle(GetDeletedPointer());
 		auto deleted = segment.GetPtr<transaction_t>();
@@ -604,6 +738,10 @@ string ChunkVectorInfo::ToString(idx_t max_count) const {
 			result += to_string(deleted[idx]);
 		}
 		result += "]";
+		break;
+	}
+	default:
+		throw InternalException("Unknown DeleteIdState in ToString");
 	}
 	result += "]";
 	return result;
@@ -665,26 +803,20 @@ unique_ptr<ChunkVectorInfo> ChunkVectorInfo::Read(FixedSizeAllocator &allocator,
 		return result;
 	}
 	case ChunkInfoType::VECTOR_INFO: {
-		// a partially deleted vector - the deleted rows are stored as a boolean mask
+		// a partially deleted vector - the deleted rows are stored as a boolean mask, all committed and
+		// visible to every transaction. The on-disk orientation (valid == deleted) matches the in-memory
+		// MASKED state, so load it straight into deleted_mask without materializing a per-row array.
 		auto start = reader.Read<idx_t>();
 		auto result = make_uniq<ChunkVectorInfo>(allocator, start);
-		ValidityMask mask;
-		mask.Read(reader, STANDARD_VECTOR_SIZE);
-
-		bool rows_alive = false;
-		auto segment = allocator.GetHandle(result->GetInitializedDeletedPointer());
-		auto deleted = segment.GetPtr<transaction_t>();
-		for (idx_t i = 0; i < STANDARD_VECTOR_SIZE; i++) {
-			if (mask.RowIsValid(i)) {
-				deleted[i] = 0;
-			} else {
-				rows_alive = true;
-			}
-		}
-		// the reconstructed ids are all visible to all transactions, so the vector can only be
-		// compressible if every row is deleted (in which case Write emits CONSTANT_INFO instead,
-		// so with the current format the ids are always settled here)
-		result->recheck_compression = !rows_alive;
+		result->deleted_mask.Read(reader, STANDARD_VECTOR_SIZE);
+		// Write only emits VECTOR_INFO for a partial delete: an all-deleted vector becomes
+		// CONSTANT_INFO and an undeleted one becomes EMPTY_INFO, so the mask always has at least one
+		// deleted (valid) and one alive (invalid) bit - never all-valid, never all-invalid.
+		D_ASSERT(!result->deleted_mask.CheckAllValid(STANDARD_VECTOR_SIZE));
+		D_ASSERT(!result->deleted_mask.CheckAllInvalid(STANDARD_VECTOR_SIZE));
+		result->delete_state = DeleteIdState::MASKED;
+		// every id is already visible to all transactions - nothing left to compress
+		result->recheck_compression = false;
 		return result;
 	}
 	default:

--- a/test/sql/delete/masked_vector_further_delete.test
+++ b/test/sql/delete/masked_vector_further_delete.test
@@ -1,0 +1,43 @@
+# name: test/sql/delete/masked_vector_further_delete.test
+# description: Deleting alive rows in a masked vector decompresses it and stays correct
+# group: [delete]
+
+statement ok
+CREATE TABLE t AS SELECT i FROM range(4096) t(i)
+
+statement ok
+CHECKPOINT
+
+# partial delete both vectors, then checkpoint -> MASKED
+statement ok
+DELETE FROM t WHERE i % 2 = 0
+
+statement ok
+CHECKPOINT
+
+query I
+SELECT COUNT(*) FROM t
+----
+2048
+
+# delete more alive rows: forces DecompressDeleteMask (MASKED -> ARRAY)
+query I
+DELETE FROM t WHERE i % 4 = 1
+----
+1024
+
+query II
+SELECT COUNT(*), MIN(i) FROM t
+----
+1024	3
+
+# already-deleted rows are filtered by the scan before delete - no conflict, zero rows affected
+query I
+DELETE FROM t WHERE i % 2 = 0
+----
+0
+
+query I
+SELECT COUNT(*) FROM t
+----
+1024

--- a/test/sql/delete/masked_vector_rollback.test
+++ b/test/sql/delete/masked_vector_rollback.test
@@ -1,0 +1,47 @@
+# name: test/sql/delete/masked_vector_rollback.test
+# description: Rolling back a delete over a masked vector restores the rows
+# group: [delete]
+
+statement ok
+CREATE TABLE r AS SELECT i FROM range(4096) t(i)
+
+statement ok
+CHECKPOINT
+
+statement ok
+DELETE FROM r WHERE i % 2 = 0
+
+statement ok
+CHECKPOINT
+
+query I
+SELECT COUNT(*) FROM r
+----
+2048
+
+statement ok
+BEGIN
+
+query I
+DELETE FROM r WHERE i % 4 = 1
+----
+1024
+
+query I
+SELECT COUNT(*) FROM r
+----
+1024
+
+statement ok
+ROLLBACK
+
+# rollback restores the newly-deleted rows; the previously masked deletes remain
+query I
+SELECT COUNT(*) FROM r
+----
+2048
+
+query I
+SELECT COUNT(*) FILTER (WHERE i % 2 = 0) FROM r
+----
+0

--- a/test/sql/delete/partial_delete_version_info_memory.test
+++ b/test/sql/delete/partial_delete_version_info_memory.test
@@ -1,0 +1,39 @@
+# name: test/sql/delete/partial_delete_version_info_memory.test
+# description: Partially deleted vectors compress per-row delete ids into a bitmask at checkpoint
+# group: [delete]
+
+# the BASE_TABLE byte thresholds below are calibrated for the default 256KB block size
+require block_size 262144
+
+# 10 full row groups == 600 vectors of 2048 rows
+statement ok
+CREATE TABLE a AS SELECT i FROM range(1228800) t(i)
+
+statement ok
+CHECKPOINT
+
+# delete every other row: each vector is partially deleted, materializing per-row delete id arrays
+query I
+DELETE FROM a WHERE i % 2 = 0
+----
+614400
+
+# the checkpoint compresses the fully-visible partial deletes into ~256 byte bitmasks
+statement ok
+CHECKPOINT
+
+query III
+SELECT COUNT(*), MIN(i), MAX(i) FROM a
+----
+614400	1	1228799
+
+query I
+SELECT COUNT(*) FILTER (WHERE i % 2 = 0) FROM a
+----
+0
+
+# with per-row arrays retained this is ~9.6 MB; bitmasks keep it well under 2 MB
+query I
+SELECT COALESCE(SUM(memory_usage_bytes), 0) < 2000000 FROM duckdb_memory() WHERE tag='BASE_TABLE'
+----
+true

--- a/test/sql/storage/partial_delete_checkpoint_mask.test
+++ b/test/sql/storage/partial_delete_checkpoint_mask.test
@@ -1,0 +1,45 @@
+# name: test/sql/storage/partial_delete_checkpoint_mask.test
+# description: Partial-delete bitmasks survive a restart without re-materializing per-row arrays
+# group: [storage]
+
+# the BASE_TABLE byte thresholds below are calibrated for the default 256KB block size
+require block_size 262144
+
+load {TEST_DIR}/partial_delete_checkpoint_mask.db
+
+statement ok
+CREATE TABLE tbl AS SELECT i FROM range(1228800) t(i)
+
+statement ok
+CHECKPOINT
+
+query I
+DELETE FROM tbl WHERE i % 2 = 0
+----
+614400
+
+statement ok
+CHECKPOINT
+
+query III
+SELECT COUNT(*), MIN(i), MAX(i) FROM tbl
+----
+614400	1	1228799
+
+restart
+
+# after reopening, deleted vectors must load straight into bitmasks - memory must not rebound to arrays
+query III
+SELECT COUNT(*), MIN(i), MAX(i) FROM tbl
+----
+614400	1	1228799
+
+query I
+SELECT COUNT(*) FILTER (WHERE i % 2 = 0) FROM tbl
+----
+0
+
+query I
+SELECT COALESCE(SUM(memory_usage_bytes), 0) < 2000000 FROM duckdb_memory() WHERE tag='BASE_TABLE'
+----
+true

--- a/test/sql/storage/partial_delete_pending_compress.test
+++ b/test/sql/storage/partial_delete_pending_compress.test
@@ -1,5 +1,5 @@
 # name: test/sql/storage/partial_delete_pending_compress.test
-# description: An old snapshot blocks masking; the next checkpoint masks once the delete is visible
+# description: Single-transaction partial deletes mask even under an older snapshot, which still sees the rows
 # group: [storage]
 
 # the BASE_TABLE byte thresholds below are calibrated for the default 256KB block size
@@ -8,8 +8,7 @@ require block_size 262144
 statement ok
 SET immediate_transaction_mode=true
 
-# force every CHECKPOINT to run even with an empty WAL: the retry that masks the previously-pending
-# deletes happens inside a checkpoint pass, and the final checkpoint below has no WAL changes of its own
+# force every CHECKPOINT to run even with an empty WAL
 statement ok
 PRAGMA force_checkpoint
 
@@ -31,22 +30,29 @@ DELETE FROM p WHERE i % 2 = 0
 statement ok con2
 CHECKPOINT
 
-# con1 started before the delete committed - the delete ids are >= lowest_active_start, so the
-# partial deletes are NOT masked yet: arrays are retained (memory stays high) and con1 sees all rows
+# every deleted row in a vector shares con2's single commit id, so the checkpoint folds the per-row
+# arrays into ~256 byte masks carrying that id - the arrays are freed even though con1 is still open
+query I
+SELECT COALESCE(SUM(memory_usage_bytes), 0) < 2000000 FROM duckdb_memory() WHERE tag='BASE_TABLE'
+----
+true
+
+# con1 started before the delete committed - the masked id is >= con1's start, so con1 still sees all rows
 query I con1
 SELECT COUNT(*) FROM p
 ----
 1228800
 
-query I
-SELECT COALESCE(SUM(memory_usage_bytes), 0) > 2000000 FROM duckdb_memory() WHERE tag='BASE_TABLE'
+# a transaction that starts after the delete committed sees the deletes
+query II
+SELECT COUNT(*), MIN(i) FROM p
 ----
-true
+614400	1
 
 statement ok con1
 COMMIT
 
-# the delete is now visible to all transactions - the next checkpoint masks the partial deletes
+# the delete is now visible to all transactions - a further checkpoint keeps the masks and stays small
 statement ok
 CHECKPOINT
 

--- a/test/sql/storage/partial_delete_pending_compress.test
+++ b/test/sql/storage/partial_delete_pending_compress.test
@@ -1,0 +1,61 @@
+# name: test/sql/storage/partial_delete_pending_compress.test
+# description: An old snapshot blocks masking; the next checkpoint masks once the delete is visible
+# group: [storage]
+
+# the BASE_TABLE byte thresholds below are calibrated for the default 256KB block size
+require block_size 262144
+
+statement ok
+SET immediate_transaction_mode=true
+
+# force every CHECKPOINT to run even with an empty WAL: the retry that masks the previously-pending
+# deletes happens inside a checkpoint pass, and the final checkpoint below has no WAL changes of its own
+statement ok
+PRAGMA force_checkpoint
+
+# 10 full row groups so the array-vs-mask memory gap is observable
+statement ok
+CREATE TABLE p AS SELECT i FROM range(1228800) t(i)
+
+statement ok
+CHECKPOINT
+
+statement ok con1
+BEGIN
+
+query I con2
+DELETE FROM p WHERE i % 2 = 0
+----
+614400
+
+statement ok con2
+CHECKPOINT
+
+# con1 started before the delete committed - the delete ids are >= lowest_active_start, so the
+# partial deletes are NOT masked yet: arrays are retained (memory stays high) and con1 sees all rows
+query I con1
+SELECT COUNT(*) FROM p
+----
+1228800
+
+query I
+SELECT COALESCE(SUM(memory_usage_bytes), 0) > 2000000 FROM duckdb_memory() WHERE tag='BASE_TABLE'
+----
+true
+
+statement ok con1
+COMMIT
+
+# the delete is now visible to all transactions - the next checkpoint masks the partial deletes
+statement ok
+CHECKPOINT
+
+query II
+SELECT COUNT(*), MIN(i) FROM p
+----
+614400	1
+
+query I
+SELECT COALESCE(SUM(memory_usage_bytes), 0) < 2000000 FROM duckdb_memory() WHERE tag='BASE_TABLE'
+----
+true


### PR DESCRIPTION
## Problem

A partially-deleted vector keeps its delete ids in a per-row array of transaction_t: 2048 rows x 8 bytes = 16 KiB per vector, allocated from the row group's FixedSizeAllocator (tagged BASE_TABLE). Deleting even a single row in a vector still pays the full 16 KiB, so a table with many partially-deleted vectors holds on to memory far out of proportion to the number of deleted rows.

Building on the checkpoint-time watermark compression from #23964: once a vector's delete ids are all below the lowest active start watermark they are visible to every current and future transaction, so the exact per-row transaction ids no longer carry information - only "deleted or not" matters.

## Approach

Model the delete side as an explicit state machine DeleteIdState { CONSTANT, MASKED, ARRAY }:

- ARRAY    - the existing per-row transaction_t array, required while any delete
             is uncommitted or still visible to an older snapshot.
- MASKED   - a ~256 byte ValidityMask (1 bit/row) once every delete id is below
             the watermark. valid bit == deleted.
- CONSTANT - the whole vector is deleted (unchanged).

At checkpoint a fully-visible partially-deleted vector folds its 16 KiB array into a mask; a later delete on a masked vector lazily rebuilds the array (MASKED -> ARRAY). The on-disk format is unchanged - Write already serializes the same ValidityMask - so ChunkVectorInfo::Read now loads straight into MASKED instead of inflating back to a per-row array, and the saving survives a restart.

## Measurements

Simple half-delete on 10M rows:

    CREATE TABLE t AS SELECT range::BIGINT AS id FROM range(10000000);
    CHECKPOINT;
    DELETE FROM t WHERE id % 2 = 0;
    -- per-row delete-id arrays still materialized
    SELECT SUM(memory_usage_bytes) FROM duckdb_memory() WHERE tag='BASE_TABLE';
    --> 85983232   (~82 MiB)
    CHECKPOINT;
    -- folded into ~256 byte/vector bitmasks
    SELECT SUM(memory_usage_bytes) FROM duckdb_memory() WHERE tag='BASE_TABLE';
    --> 786432     (~0.75 MiB, -99.1%)

The saving survives a restart: reopening the database and scanning the table loads the on-disk mask straight into MASKED, so BASE_TABLE stays at ~0.75 MiB instead of rebounding to the per-row arrays.