### PR TITLE
Fix TopN window elimination with ROW_NUMBER argument ordering

### DIFF
--- a/src/optimizer/topn_window_elimination.cpp
+++ b/src/optimizer/topn_window_elimination.cpp
@@ -627,6 +627,9 @@ bool TopNWindowElimination::CanOptimize(LogicalOperator &op) {
 	}
 	auto &window_expr = window.expressions[0]->Cast<BoundWindowExpression>();
 
+	if (!window_expr.ArgOrders().empty()) {
+		return false;
+	}
 	if (window_expr.OrderBy().size() != 1) {
 		return false;
 	}

--- a/test/sql/optimizer/topn_window_elimination_argument_order.test
+++ b/test/sql/optimizer/topn_window_elimination_argument_order.test
@@ -1,0 +1,36 @@
+# name: test/sql/optimizer/topn_window_elimination_argument_order.test
+# description: Top-N window elimination must preserve ROW_NUMBER argument ordering
+# group: [optimizer]
+
+statement ok
+CREATE TABLE row_number_order (id INTEGER, g INTEGER, p INTEGER);
+
+statement ok
+INSERT INTO row_number_order VALUES (1, 1, 1), (2, 1, 2), (3, 1, 3), (4, 2, 1), (5, 2, 2);
+
+# Argument ordering ranks all rows in the full partition by id, independently of the window ordering.
+query III
+SELECT id, g, p
+FROM row_number_order
+QUALIFY ROW_NUMBER(ORDER BY id DESC) OVER (
+	PARTITION BY g
+	ORDER BY p ASC
+	ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+) <= 1
+ORDER BY g, id;
+----
+3	1	3
+5	2	2
+
+# With the default growing frame, each row is first when it enters the frame.
+query III
+SELECT id, g, p
+FROM row_number_order
+QUALIFY ROW_NUMBER(ORDER BY id DESC) OVER (PARTITION BY g ORDER BY p ASC) = 1
+ORDER BY g, id;
+----
+1	1	1
+2	1	2
+3	1	3
+4	2	1
+5	2	2


### PR DESCRIPTION
## Description

  This PR fixes #23678.

  `TopNWindowElimination` rewrites partitioned `ROW_NUMBER` filters into `arg_min` or `arg_max` aggregates. The rewrite uses the window `OrderBy()` but does not preserve `ROW_NUMBER`'s `ArgOrders()`, which can produce
  incorrect results when both orderings are present.

  The rule now skips the rewrite when `ArgOrders()` is non-empty, falling back to the regular window executor. Partitioned Top-N queries without argument ordering remain optimized.

  ## Tests

  Added regression tests for explicit full-partition frames and default frames that grow up to the current row.