### PR TITLE
Fix pipeline-dependent CTE metadata in EXPLAIN ANALYZE

### DIFF
--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -424,13 +424,13 @@ void Executor::InitializeInternal(PhysicalOperator &plan) {
 		physical_plan = &plan;
 
 		this->profiler = ClientData::Get(context).profiler;
-		profiler->Initialize(plan);
 		this->producer = scheduler.CreateProducer();
 
 		// build and ready the pipelines
 		PipelineBuildState state;
 		auto root_pipeline = make_shared_ptr<MetaPipeline>(*this, state, nullptr);
 		root_pipeline->Build(*physical_plan);
+		profiler->Initialize(plan);
 		root_pipeline->Ready();
 
 		// ready recursive cte pipelines too

--- a/test/sql/cte/materialized/materialized_cte_order_preservation.test
+++ b/test/sql/cte/materialized/materialized_cte_order_preservation.test
@@ -4,9 +4,6 @@
 
 require vector_size 2048
 
-# Failing randomly in CI: https://github.com/duckdb/duckdb/actions/runs/30609212704/job/91088291869#step:8:440
-mode skip flaky
-
 statement ok
 PRAGMA threads=4;
 


### PR DESCRIPTION
After #24084 landed, `materialized_cte_order_preservation.test` started failing intermittently in CI. The query result and ordering were correct, but `EXPLAIN ANALYZE` would occasionally retain `Execution Mode: PIPELINE_DEPENDENT` instead of reporting the buffered CTE fanout and batch-index mode selected during execution. #24340 temporarily skipped the test.

The physical plan cannot determine the CTE execution mode on its own. Direct, buffered, and materialized consumers are selected while building the pipelines. However, `QueryProfiler::Initialize` was called before pipeline construction and immediately copied each operator's `ParamsToString()` output into the profiling tree. This meant the profiler initially captured the unresolved CTE metadata.

Normally, the thread-local operator profiler refreshes this metadata when the operator starts executing. That made the output timing-dependent: an early-stopping consumer such as `LIMIT` can render `EXPLAIN ANALYZE` before the independent CTE producer has flushed its updated metadata. Depending on scheduling, the analyzed plan therefore contained either the initial unresolved metadata or the resolved runtime metadata.

I fixed this at the point where the invariant first becomes false: the profiling tree is now initialized after `MetaPipeline::Build` has resolved pipeline-dependent operator state. Initialization still happens before the pipelines are readied, verified, scheduled, or executed, so operator profiling is fully configured before any runtime work starts.

Plain `EXPLAIN` intentionally continues to show `PIPELINE_DEPENDENT`, since it does not build execution pipelines. `EXPLAIN ANALYZE` now consistently shows the execution mode that will actually be used. There are no public API, serialization, or plan-format changes.

I also removed the flaky-test skip added by #24340.
