### PR TITLE
[Bug] Fix issue with worker thread yielding in Async I/O

### DIFF
--- a/src/common/multi_file/multi_file_read_ahead.cpp
+++ b/src/common/multi_file/multi_file_read_ahead.cpp
@@ -52,12 +52,26 @@ bool ReadAheadJobCompletion::TryPark(const InterruptState &interrupt_state) {
 	return parked_scan.BlockTask(interrupt_state);
 }
 
+void ReadAheadJobCompletion::WaitForIO() {
+	shared_ptr<Task> task;
+	while (pending_io_tasks.load() > 0) {
+		// run scheduled I/O inline, the tasks may belong to any job but always make progress
+		if (executor->GetTask(task)) {
+			task->Execute(TaskExecutionMode::PROCESS_ALL);
+			task.reset();
+			continue;
+		}
+		// the remaining I/O is running on other threads, wait for it to finish
+		TaskScheduler::YieldThread();
+	}
+}
+
 MultiFileReadAhead::MultiFileReadAhead(ClientContext &context, idx_t read_ahead_depth_p,
                                        unique_ptr<ManagedAsyncMemoryGovernor> memory_governor_p)
     : read_ahead_depth(read_ahead_depth_p), memory_governor(std::move(memory_governor_p)) {
 	D_ASSERT(read_ahead_depth_p > 0);
 	backlog_budget = memory_governor ? memory_governor->BackpressureBudget() : NumericLimits<idx_t>::Maximum();
-	executor = make_uniq<TaskExecutor>(context, TaskSchedulerType::ASYNC);
+	executor = make_shared_ptr<TaskExecutor>(context, TaskSchedulerType::ASYNC);
 }
 
 unique_ptr<MultiFileReadAhead> MultiFileReadAhead::Create(ClientContext &context) {
@@ -146,7 +160,7 @@ bool MultiFileReadAhead::TryProduceJob(const ProduceJobCallback &claim_and_sched
 void MultiFileReadAhead::PushJob(unique_ptr<MultiFileScanJob> job, vector<unique_ptr<AsyncTask>> io_tasks) {
 	// beyond its scheduled I/O a job carries scan-state overhead (row-group sized decode buffers)
 	static constexpr idx_t MINIMUM_JOB_IO_CHARGE = 16ULL * 1024 * 1024;
-	auto completion = make_shared_ptr<ReadAheadJobCompletion>(io_tasks.size());
+	auto completion = make_shared_ptr<ReadAheadJobCompletion>(executor, io_tasks.size());
 	job->io_completion = completion;
 	for (auto &task : io_tasks) {
 		job->io_bytes += task->GetIOSize();
@@ -202,9 +216,7 @@ unique_ptr<LocalTableFunctionState> MultiFileReadAhead::TryPopState() {
 
 void MultiFileReadAhead::WaitForJob(MultiFileScanJob &job) {
 	if (job.io_completion) {
-		while (job.io_completion->PendingIOTasks() > 0) {
-			TaskScheduler::YieldThread();
-		}
+		job.io_completion->WaitForIO();
 	}
 	// the job's I/O has completed, release its budget charge
 	pending_io_bytes -= job.io_bytes;
@@ -239,9 +251,7 @@ MultiFileGlobalState::~MultiFileGlobalState() = default;
 MultiFileLocalState::~MultiFileLocalState() {
 	// job reads might still be going, wait for them before destroying ze job
 	if (job_state == MultiFileJobState::WAIT_IO && job.io_completion) {
-		while (job.io_completion->PendingIOTasks() > 0) {
-			TaskScheduler::YieldThread();
-		}
+		job.io_completion->WaitForIO();
 	}
 }
 

--- a/src/include/duckdb/common/multi_file/multi_file_read_ahead.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_read_ahead.hpp
@@ -29,7 +29,8 @@ struct LocalTableFunctionState;
 
 class ReadAheadJobCompletion {
 public:
-	explicit ReadAheadJobCompletion(idx_t io_task_count) : pending_io_tasks(io_task_count) {
+	ReadAheadJobCompletion(shared_ptr<TaskExecutor> executor_p, idx_t io_task_count)
+	    : executor(std::move(executor_p)), pending_io_tasks(io_task_count) {
 	}
 
 public:
@@ -41,8 +42,12 @@ public:
 	void FinishIOTask();
 	//! Try to park the calling scan task until the job's I/O completes, the last I/O task to finish wakes it.
 	bool TryPark(const InterruptState &interrupt_state);
+	//! Block until the job's I/O completed, running scheduled I/O inline so progress does not depend on pool threads
+	void WaitForIO();
 
 private:
+	//! Executor holding the scheduled I/O, waiters drain it inline
+	shared_ptr<TaskExecutor> executor;
 	atomic<idx_t> pending_io_tasks;
 	//! Holds the scan task parked on this job's I/O
 	StateWithBlockableTasks parked_scan;
@@ -123,8 +128,8 @@ private:
 	atomic<bool> done {false};
 	//! Threads that reserved a slot but have not pushed their job yet
 	atomic<idx_t> active_producers {0};
-	//! Async I/O executor (async pool).
-	unique_ptr<TaskExecutor> executor;
+	//! Async I/O executor (async pool)
+	shared_ptr<TaskExecutor> executor;
 };
 
 } // namespace duckdb

--- a/test/sql/parallelism/interquery/concurrent_set_async_threads_read_ahead.test
+++ b/test/sql/parallelism/interquery/concurrent_set_async_threads_read_ahead.test
@@ -1,0 +1,57 @@
+# name: test/sql/parallelism/interquery/concurrent_set_async_threads_read_ahead.test
+# description: SET async_threads=0 while multi-file read-ahead scans are in flight must not wedge them
+# group: [interquery]
+
+require parquet
+
+statement ok
+SET threads=2
+
+# keep every scan scheduling real async I/O, a cache hit schedules none
+statement ok
+SET enable_external_file_cache=false
+
+# the synchronous strategy waits for read-ahead I/O by spinning without draining it inline
+statement ok
+SET debug_physical_table_scan_execution_strategy='SYNCHRONOUS'
+
+loop i 0 8
+
+statement ok
+COPY (SELECT range AS i FROM range(500000)) TO '{TEST_DIR}/ra_race_{i}.parquet' (FORMAT parquet, ROW_GROUP_SIZE 2048)
+
+endloop
+
+concurrentloop threadid 0 3
+
+loop i 0 100
+
+onlyif threadid=0
+query I
+SELECT sum(i) FROM '{TEST_DIR}/ra_race_*.parquet'
+----
+999998000000
+
+onlyif threadid=1
+query I
+SELECT sum(i) FROM '{TEST_DIR}/ra_race_*.parquet'
+----
+999998000000
+
+endloop
+
+onlyif threadid=2
+statement ok
+SELECT sleep_ms(100)
+
+onlyif threadid=2
+statement ok
+SET async_threads=0
+
+endloop
+
+# the database must remain usable afterwards
+query I
+SELECT 42
+----
+42


### PR DESCRIPTION
This PR fixes an issue where we could enter a deadlock in a somewhat specific situation. If our worker thread can't be blocked, it would yield and wait for an async thread to do the reads. However, if we don't have async threads available, it could then enter a deadlock of forever waiting. 

The fix is straightforward: if that read has pending io tasks that are not being read by anyone else, that thread will do them instead of yielding.