### PR TITLE
Avoid mutating input buffers in decode(..., 'replace')

### DIFF
--- a/extension/core_functions/scalar/blob/encode.cpp
+++ b/extension/core_functions/scalar/blob/encode.cpp
@@ -60,7 +60,7 @@ void BinaryDecodeFunction(DataChunk &args, ExpressionState &state, Vector &resul
 	// decode is also a nop cast, but requires verification if the provided string is actually
 	BinaryExecutor::Execute<string_t, string_t, string_t>(
 	    args.data[0], args.data[1], result, [&](string_t input, string_t error_option) {
-		    auto input_data = input.GetDataWriteable();
+		    auto input_data = input.GetData();
 		    auto input_length = input.GetSize();
 
 		    if (Utf8Proc::Analyze(input_data, input_length) != UnicodeType::INVALID) {
@@ -69,9 +69,14 @@ void BinaryDecodeFunction(DataChunk &args, ExpressionState &state, Vector &resul
 		    auto const error_behavior = GetDecodeErrorBehavior(error_option);
 
 		    switch (error_behavior) {
-		    case DecodeErrorBehavior::REPLACE:
-			    Utf8Proc::MakeValid(input_data, input_length);
-			    return input;
+		    case DecodeErrorBehavior::REPLACE: {
+			    auto target = StringVector::EmptyString(result, input_length);
+			    auto output = target.GetDataWriteable();
+			    memcpy(output, input_data, input_length);
+			    Utf8Proc::MakeValid(output, input_length);
+			    target.Finalize();
+			    return target;
+		    }
 
 		    case DecodeErrorBehavior::IGNORE: {
 			    auto new_str = Utf8Proc::RemoveInvalid(input_data, input_length);

--- a/test/sql/function/blob/encode.test
+++ b/test/sql/function/blob/encode.test
@@ -35,4 +35,23 @@ SELECT decode(encode(a)) || a from (values ('hello'), ('world')) tbl(a);
 hellohello
 worldworld
 
+# decode with replacement should not modify its input
+statement ok
+CREATE TABLE invalid_blob(b BLOB);
+
+statement ok
+INSERT INTO invalid_blob VALUES ('AAAAAAAAAAAAAAAAAAAA\xC0'::BLOB);
+
+statement ok
+CHECKPOINT;
+
+query I
+SELECT decode(b, 'replace') FROM invalid_blob;
+----
+AAAAAAAAAAAAAAAAAAAA?
+
+query I
+SELECT hex(b) FROM invalid_blob;
+----
+4141414141414141414141414141414141414141C0
 


### PR DESCRIPTION
Fixes #24281.

`decode(blob, 'replace')` previously called `Utf8Proc::MakeValid()` directly on memory referenced by the input `string_t`. For non-inline values, that memory can be owned by a scanned input vector, including a storage-backed dictionary vector. A read-only query could therefore change the BLOB bytes observed by later reads.

This change copies invalid input into result-owned storage before applying UTF-8 replacement. Valid input retains the existing zero-copy path, while the `strict` and `ignore` behaviors are unchanged.

The regression test checkpoints a non-inline invalid BLOB, calls `decode(..., 'replace')`, and verifies both the replacement result and the original BLOB bytes.

Tests:

- `make reldebug`
- `build/reldebug/test/unittest test/sql/function/blob/encode.test`
- `build/reldebug/test/unittest test/fuzzer/pedro/utf8_invalid_unicode.test`
- `build/reldebug/test/unittest test/sql/storage/compression/string/blob.test`
