### PR TITLE
Add a warning when using OFFSET on result set without defined ordering

### DIFF
--- a/src/execution/physical_plan/plan_limit.cpp
+++ b/src/execution/physical_plan/plan_limit.cpp
@@ -140,9 +140,9 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalLimit &op) {
 	auto &plan = CreatePlan(*op.children[0]);
 	auto *limit_child = &plan;
 	auto total_limit = GetLimit(op.limit_val, op.offset_val);
-	if (!PreserveInsertionOrder(plan)) {
+	if (op.offset_val.Type() != LimitNodeType::UNSET && !PreserveInsertionOrder(plan)) {
 		DUCKDB_LOG_WARNING(context,
-		                   "LIMIT or OFFSET is applied to a query whose row order is not guaranteed - the result may "
+		                   "OFFSET is applied to a query whose row order is not guaranteed - the result may "
 		                   "differ between runs. This happens when the query contains order-breaking operators (e.g. "
 		                   "hash joins or aggregations), reads from a source that does not preserve order, or when "
 		                   "preserve_insertion_order=false. Add an ORDER BY to make the result deterministic.");

--- a/src/execution/physical_plan/plan_limit.cpp
+++ b/src/execution/physical_plan/plan_limit.cpp
@@ -7,6 +7,7 @@
 #include "duckdb/execution/operator/projection/physical_projection.hpp"
 #include "duckdb/execution/operator/scan/physical_table_scan.hpp"
 #include "duckdb/execution/physical_plan_generator.hpp"
+#include "duckdb/logging/logger.hpp"
 #include "duckdb/main/config.hpp"
 #include "duckdb/planner/operator/logical_limit.hpp"
 
@@ -139,6 +140,13 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalLimit &op) {
 	auto &plan = CreatePlan(*op.children[0]);
 	auto *limit_child = &plan;
 	auto total_limit = GetLimit(op.limit_val, op.offset_val);
+	if (!PreserveInsertionOrder(plan)) {
+		DUCKDB_LOG_WARNING(context,
+		                   "LIMIT or OFFSET is applied to a query whose row order is not guaranteed - the result may "
+		                   "differ between runs. This happens when the query contains order-breaking operators (e.g. "
+		                   "hash joins or aggregations), reads from a source that does not preserve order, or when "
+		                   "preserve_insertion_order=false. Add an ORDER BY to make the result deterministic.");
+	}
 	// Unpartitioned hash tables become expensive to Combine at large sizes
 	static constexpr idx_t LIMITED_DISTINCT_THRESHOLD = 100000;
 	if (total_limit.IsValid() && total_limit.GetIndex() <= LIMITED_DISTINCT_THRESHOLD) {

--- a/test/configs/force_storage_restart.json
+++ b/test/configs/force_storage_restart.json
@@ -48,6 +48,7 @@
         "test/sql/cte/recursive_cte_logging.test",
         "test/sql/cte/recursive_cte_invariant_build_logging.test",
         "test/logging/warnings_as_errors.test",
+        "test/logging/offset_order_warning.test",
         "test/sql/copy/parquet/multi_file/adaptive_filter_carryover.test",
         "test/sql/copy/parquet/parquet_prefetch_row_group_outcome.test",
         "test/sql/copy/parquet/parquet_prefetch_projection.test",

--- a/test/logging/limit_order_warning.test
+++ b/test/logging/limit_order_warning.test
@@ -1,0 +1,44 @@
+# name: test/logging/limit_order_warning.test
+# description: Test warning for LIMIT/OFFSET over non-deterministic row order
+# group: [logging]
+
+statement ok
+SET enable_logging=true;
+
+statement ok
+SET warnings_as_errors=true;
+
+statement ok
+SET preserve_insertion_order=true;
+
+statement ok
+CREATE TABLE t AS SELECT range i FROM range(100);
+
+# plain scan with preserve_insertion_order=true: deterministic, no warning
+statement ok
+SELECT i FROM t LIMIT 5;
+
+# limit over an aggregate: order is not guaranteed, warns
+statement error
+SELECT i % 3, COUNT(*) FROM t GROUP BY 1 LIMIT 2;
+----
+<REGEX>:.*row order is not guaranteed.*
+
+# same for OFFSET without LIMIT
+statement error
+SELECT i % 3, COUNT(*) FROM t GROUP BY 1 OFFSET 1;
+----
+<REGEX>:.*row order is not guaranteed.*
+
+# ORDER BY makes it deterministic again
+statement ok
+SELECT i % 3, COUNT(*) FROM t GROUP BY 1 ORDER BY 1 LIMIT 2;
+
+statement ok
+SET preserve_insertion_order=false;
+
+# without insertion order preservation even a plain scan warns
+statement error
+SELECT i FROM t LIMIT 5;
+----
+<REGEX>:.*row order is not guaranteed.*

--- a/test/logging/offset_order_warning.test
+++ b/test/logging/offset_order_warning.test
@@ -1,5 +1,5 @@
-# name: test/logging/limit_order_warning.test
-# description: Test warning for LIMIT/OFFSET over non-deterministic row order
+# name: test/logging/offset_order_warning.test
+# description: Test warning for OFFSET over non-deterministic row order
 # group: [logging]
 
 statement ok
@@ -16,29 +16,37 @@ CREATE TABLE t AS SELECT range i FROM range(100);
 
 # plain scan with preserve_insertion_order=true: deterministic, no warning
 statement ok
-SELECT i FROM t LIMIT 5;
+SELECT i FROM t OFFSET 5;
 
-# limit over an aggregate: order is not guaranteed, warns
-statement error
+# LIMIT without OFFSET does not warn, even if the order is not guaranteed
+statement ok
 SELECT i % 3, COUNT(*) FROM t GROUP BY 1 LIMIT 2;
-----
-<REGEX>:.*row order is not guaranteed.*
 
-# same for OFFSET without LIMIT
+# OFFSET over an aggregate: order is not guaranteed, warns
 statement error
 SELECT i % 3, COUNT(*) FROM t GROUP BY 1 OFFSET 1;
 ----
 <REGEX>:.*row order is not guaranteed.*
 
+# same for LIMIT combined with OFFSET
+statement error
+SELECT i % 3, COUNT(*) FROM t GROUP BY 1 LIMIT 2 OFFSET 1;
+----
+<REGEX>:.*row order is not guaranteed.*
+
 # ORDER BY makes it deterministic again
 statement ok
-SELECT i % 3, COUNT(*) FROM t GROUP BY 1 ORDER BY 1 LIMIT 2;
+SELECT i % 3, COUNT(*) FROM t GROUP BY 1 ORDER BY 1 OFFSET 1;
 
 statement ok
 SET preserve_insertion_order=false;
 
 # without insertion order preservation even a plain scan warns
 statement error
-SELECT i FROM t LIMIT 5;
+SELECT i FROM t OFFSET 5;
 ----
 <REGEX>:.*row order is not guaranteed.*
+
+# but not with LIMIT only
+statement ok
+SELECT i FROM t LIMIT 5;


### PR DESCRIPTION
```SQL
CREATE TABLE a AS FROM range(10000);
SET preserve_insertion_order = false;
FROM a OFFSET 10;
```
now throws a warning:

> OFFSET is applied to a query whose row order is not guaranteed - the result may differ between runs. This happens when the query contains order-breaking operators (e.g. hash joins or aggregations), reads from a source that does not preserve order, or when preserve_insertion_order=false. Add an ORDER BY to make the result deterministic.
