### PR TITLE
Remove multi-benchmark support and split CTE jobs

### DIFF
--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -125,22 +125,26 @@ jobs:
       matrix:
         include:
           - name: Ingestion Perf
-            benchmarks: .github/regression/ingestion.csv
+            benchmark: .github/regression/ingestion.csv
           - name: Micro
-            benchmarks: .github/regression/micro.csv
+            benchmark: .github/regression/micro.csv
           - name: H2OAI
-            benchmarks: .github/regression/h2oai.csv
+            benchmark: .github/regression/h2oai.csv
           - name: IMDB
-            benchmarks: .github/regression/imdb.csv
+            benchmark: .github/regression/imdb.csv
           - name: CSV
-            benchmarks: .github/regression/csv.csv
+            benchmark: .github/regression/csv.csv
           - name: RealNest
-            benchmarks: .github/regression/realnest.csv
+            benchmark: .github/regression/realnest.csv
             data_setup: |
               mkdir -p duckdb_benchmark_data
               python3 scripts/ci/retry.py -- wget -q https://blobs.duckdb.org/data/realnest/realnest.duckdb --output-document=duckdb_benchmark_data/real_nest.duckdb
-          - name: Recursive CTE + AoC24
-            benchmarks: benchmark/recursive_cte/recursive_cte.csv benchmark/aoc24/aoc24.csv
+          - name: Recursive CTE
+            benchmark: benchmark/recursive_cte/recursive_cte.csv
+            timed_runs: 7
+            regression_threshold_seconds: 0.01
+          - name: AoC24
+            benchmark: benchmark/aoc24/aoc24.csv
             timed_runs: 7
             regression_threshold_seconds: 0.01
 
@@ -179,38 +183,27 @@ jobs:
         if: ${{ matrix.data_setup }}
         run: ${{ matrix.data_setup }}
 
-      - name: Run regression benchmarks
+      - name: Run regression benchmark
         run: |
-          status=0
+          extra_args=(--clear-benchmark-cache)
+          if [[ "${{ matrix.benchmark }}" == ".github/regression/realnest.csv" ]]; then
+            extra_args=()
+          fi
 
-          for benchmark in ${{ matrix.benchmarks }}; do
-            extra_args=(--clear-benchmark-cache)
-            if [[ "$benchmark" == ".github/regression/realnest.csv" ]]; then
-              extra_args=()
-            fi
-            if [[ -n "${{ matrix.timed_runs }}" ]]; then
-              extra_args+=(--timed-runs "${{ matrix.timed_runs }}")
-            fi
-            if [[ -n "${{ matrix.regression_threshold_seconds }}" ]]; then
-              extra_args+=(--regression-threshold-seconds "${{ matrix.regression_threshold_seconds }}")
-            fi
+          if [[ -n "${{ matrix.timed_runs }}" ]]; then
+            extra_args+=(--timed-runs "${{ matrix.timed_runs }}")
+          fi
+          if [[ -n "${{ matrix.regression_threshold_seconds }}" ]]; then
+            extra_args+=(--regression-threshold-seconds "${{ matrix.regression_threshold_seconds }}")
+          fi
 
-            echo "::group::$(basename "$benchmark" .csv)"
-            if ! python scripts/regression/test_runner.py \
-              --old build/base/release/benchmark/benchmark_runner \
-              --new build/current/release/benchmark/benchmark_runner \
-              --benchmarks "$benchmark" \
-              --verbose \
-              --threads 2 \
-              "${extra_args[@]}"; then
-              status=1
-              echo "::error title=Regression suite failed::$(basename "$benchmark" .csv) in ${{ matrix.name }}"
-            else
-              echo "::endgroup::"
-            fi
-          done
-
-          exit $status
+          python scripts/regression/test_runner.py \
+            --old build/base/release/benchmark/benchmark_runner \
+            --new build/current/release/benchmark/benchmark_runner \
+            --benchmarks "${{ matrix.benchmark }}" \
+            --verbose \
+            --threads 2 \
+            "${extra_args[@]}"
 
   regression-bench-tpc:
     name: Bench ${{ matrix.name }}


### PR DESCRIPTION
The log group (needed for multiple benchmarks in one CI job) made it more difficult to find the regression because the log group hid the failing benchmark sometimes.

Most benchmarks were split into different CI jobs, so I also split the recently added CTE benchmarks (`recursive CTE` and `AoC24`) into their own job.