### PR TITLE
Reset batch indexes between recursive CTE iterations

### DIFF
--- a/src/include/duckdb/parallel/pipeline.hpp
+++ b/src/include/duckdb/parallel/pipeline.hpp
@@ -221,6 +221,7 @@ private:
 	void ScheduleSequentialTask(shared_ptr<Event> &event);
 	bool LaunchScanTasks(shared_ptr<Event> &event, idx_t max_threads);
 	void ResetSinkAndOperators();
+	void ResetBatchIndexes();
 	shared_ptr<GlobalSourceState> GetSourceState();
 	void SetSourceState(shared_ptr<GlobalSourceState> state);
 	void FinishSourceAndPreventBlocking(ClientContext &context);

--- a/src/parallel/pipeline.cpp
+++ b/src/parallel/pipeline.cpp
@@ -389,6 +389,9 @@ void Pipeline::ResetForReschedule(bool reset_sink) {
 	} else {
 		SetSourceState(ToSharedSourceState(source->GetGlobalSourceState(client, partition_info)));
 	}
+	if (partition_info.AnyRequired()) {
+		ResetBatchIndexes();
+	}
 	initialized = true;
 }
 
@@ -625,8 +628,15 @@ const vector<reference<PhysicalOperator>> &Pipeline::GetIntermediateOperators() 
 }
 
 void Pipeline::ClearSource() {
-	annotated_lock_guard<annotated_mutex> source_guard(source_state_lock);
-	source_state.reset();
+	{
+		annotated_lock_guard<annotated_mutex> source_guard(source_state_lock);
+		source_state.reset();
+	}
+	ResetBatchIndexes();
+}
+
+void Pipeline::ResetBatchIndexes() {
+	lock_guard<mutex> batch_guard(batch_lock);
 	batch_indexes.clear();
 }
 

--- a/test/sql/cte/recursive_cte_batch_index.test
+++ b/test/sql/cte/recursive_cte_batch_index.test
@@ -1,0 +1,107 @@
+# name: test/sql/cte/recursive_cte_batch_index.test
+# description: Reset batch index coordination between recursive CTE epochs
+# group: [cte]
+
+statement ok
+SET threads=4;
+
+statement ok
+SET preserve_insertion_order=true;
+
+# Regression from the Python replacement scan test, expressed with a reused materialized CTE.
+query I rowsort
+WITH RECURSIVE
+df(a) AS MATERIALIZED (VALUES (1), (2), (3)),
+RecursiveCTE AS (
+	SELECT Number FROM df t(Number)
+	UNION ALL
+	SELECT Number + (SELECT a FROM df OFFSET 2 LIMIT 1) + 1 AS new
+	FROM RecursiveCTE
+	WHERE new < 10
+)
+SELECT * FROM RecursiveCTE;
+----
+1
+2
+3
+5
+6
+7
+9
+
+# A batch-aware scalar subquery must restart from its base batch in every epoch.
+query I rowsort
+WITH RECURSIVE r(x) AS (
+	VALUES (1), (2), (3)
+	UNION ALL
+	SELECT x + (SELECT a FROM (VALUES (1), (2), (3)) df(a) LIMIT 1)
+	FROM r
+	WHERE x < 4
+)
+SELECT * FROM r;
+----
+1
+2
+2
+3
+3
+3
+4
+4
+4
+
+# Cover scheduled recursive execution without pooled executor reuse.
+statement ok
+SET enable_caching_operators=false;
+
+query I rowsort
+WITH RECURSIVE r(x) AS (
+	VALUES (1), (2), (3)
+	UNION ALL
+	SELECT x + (SELECT a FROM (VALUES (1), (2), (3)) df(a) LIMIT 1)
+	FROM r
+	WHERE x < 4
+)
+SELECT * FROM r;
+----
+1
+2
+2
+3
+3
+3
+4
+4
+4
+
+statement ok
+RESET enable_caching_operators;
+
+# UNION DISTINCT uses the same rescheduled batch-aware pipeline lifecycle.
+query I rowsort
+WITH RECURSIVE r(x) AS (
+	VALUES (1), (2), (3)
+	UNION
+	SELECT x + (SELECT a FROM (VALUES (1), (2), (3)) df(a) LIMIT 1)
+	FROM r
+	WHERE x < 4
+)
+SELECT * FROM r;
+----
+1
+2
+3
+4
+
+# Reset every executor placeholder when a broad epoch is followed by a narrow epoch.
+query II
+WITH RECURSIVE r(x) AS (
+	SELECT i FROM range(4096) t(i)
+	UNION ALL
+	SELECT x + (SELECT a FROM (VALUES (1), (2), (3)) df(a) LIMIT 1)
+	FROM r
+	WHERE x < 3
+)
+SELECT count(*), sum(x) FROM r;
+----
+4102	8386574


### PR DESCRIPTION
A duckdb-python query combining a replacement scan, a recursive CTE, and a scalar `LIMIT`/`OFFSET` subquery could fail with:

```text
INTERNAL Error: Pipeline batch index - gotten lower batch index 1
(down from previous batch index of 9999999999999)
```

The replacement scan was exposing a lifecycle problem in recursive pipeline reuse. Batch-aware pipeline executors register their current indexes in the pipeline-level batch coordinator. During finalization, they advance to the terminal batch index. The recursive execution introduced by #24031 reuses pipelines and cached or pooled `PipelineExecutor` instances across iterations, but `ResetForReschedule` reset the source and operator state without resetting this shared coordinator. The next iteration therefore restarted its source at batch 1 while the pipeline still contained terminal indexes from the previous iteration.

I now clear the batch coordinator when rescheduling a pipeline whose sink requires partition information. This happens before cached, pooled, or newly constructed executors prepare their local state, allowing the active executors to register again from the pipeline's base batch index. Clearing every old placeholder is important when a broad recursive iteration is followed by a narrower one using fewer executors. Pipelines that do not require partition information avoid the additional lock entirely.

I also moved the existing `ClearSource` cleanup through the same lock-protected helper. Its previous direct access to `batch_indexes` did not use the corresponding mutex.

The regression test includes a synthetic core equivalent of the Python replacement-scan query, a reduced `UNION ALL` case, execution with operator caching disabled, `UNION DISTINCT`, and a broad-to-narrow transition that changes the number of active executors.
