### PR TITLE
Fix false corruption error when reading FSST string segments for Clickbench Q11

### DIFF
--- a/src/storage/compression/dict_fsst/compression.cpp
+++ b/src/storage/compression/dict_fsst/compression.cpp
@@ -584,7 +584,8 @@ DictFSSTCompressResult DictFSSTCompressionState::CompressInternal(UnifiedVectorF
 		vector<unsigned char> decompress_buffer;
 		if (verify_compression) {
 			temp_decoder = &temp_decoder_storage;
-			duckdb_fsst_import(&temp_decoder_storage, fsst_serialized_symbol_table.get());
+			duckdb_fsst_import(&temp_decoder_storage, fsst_serialized_symbol_table.get(),
+			                   sizeof(duckdb_fsst_decoder_t));
 		}
 
 		if (encoded_input.data.empty()) {
@@ -784,7 +785,8 @@ DictionaryAppendState DictFSSTCompressionState::TryEncode() {
 
 #ifdef DEBUG
 	auto temp_decoder = alloca(sizeof(duckdb_fsst_decoder_t));
-	duckdb_fsst_import((duckdb_fsst_decoder_t *)temp_decoder, fsst_serialized_symbol_table.get());
+	duckdb_fsst_import((duckdb_fsst_decoder_t *)temp_decoder, fsst_serialized_symbol_table.get(),
+	                   sizeof(duckdb_fsst_decoder_t));
 
 	vector<unsigned char> decompress_buffer;
 #endif

--- a/src/storage/compression/dict_fsst/decompression.cpp
+++ b/src/storage/compression/dict_fsst/decompression.cpp
@@ -85,8 +85,11 @@ void CompressedStringScanState::Initialize(bool initialize_dictionary) {
 	case DictFSSTMode::FSST_ONLY:
 	case DictFSSTMode::DICT_FSST: {
 		decoder = new duckdb_fsst_decoder_t;
-		auto ret = duckdb_fsst_import(reinterpret_cast<duckdb_fsst_decoder_t *>(decoder), baseptr + symbol_table_dest);
-		if (ret == 0) {
+		// in FSST_ONLY / DICT_FSST modes a symbol table is always present, so any failure (out-of-bounds or a
+		// version mismatch) means the segment is corrupted
+		auto ret = duckdb_fsst_import(reinterpret_cast<duckdb_fsst_decoder_t *>(decoder), baseptr + symbol_table_dest,
+		                              symbol_table_size);
+		if (ret == DUCKDB_FSST_IMPORT_VERSION_MISMATCH || ret == DUCKDB_FSST_IMPORT_OUT_OF_BOUNDS) {
 			throw IOException("Failed to scan DICT_FSST string segment: invalid FSST symbol table. Database file "
 			                  "appears to be corrupted.");
 		}

--- a/src/storage/compression/fsst.cpp
+++ b/src/storage/compression/fsst.cpp
@@ -846,10 +846,6 @@ bool FSSTStorage::ParseFSSTSegmentHeader(data_ptr_t base_ptr, duckdb_fsst_decode
 	if (fsst_symbol_table_offset != expected_symbol_table_offset) {
 		ThrowInvalidFSSTSegment("bitpacking width did not match the stored layout");
 	}
-	if (sizeof(duckdb_fsst_decoder_t) > segment_capacity - fsst_symbol_table_offset) {
-		ThrowInvalidFSSTSegment("symbol table was out of range");
-	}
-
 	StringDictionaryContainer container;
 	container.size = Load<uint32_t>(data_ptr_cast(&header_ptr->dict_size));
 	container.end = Load<uint32_t>(data_ptr_cast(&header_ptr->dict_end));
@@ -858,8 +854,23 @@ bool FSSTStorage::ParseFSSTSegmentHeader(data_ptr_t base_ptr, duckdb_fsst_decode
 		ThrowInvalidFSSTSegment("dictionary was out of range");
 	}
 
+	// the symbol table occupies [symbol_table_offset, string_container_start), so its bytes end where the string
+	// dictionary container begins. Bound duckdb_fsst_import to that size so it can never read out of bounds.
+	const auto container_start = (container.end - container.size);
+	const auto expected_symbol_table_size = container_start - fsst_symbol_table_offset;
+	const auto consumed =
+	    duckdb_fsst_import(decoder_out, base_ptr + fsst_symbol_table_offset, expected_symbol_table_size);
+	// an inconsistent header is corruption; a version mismatch just means there is no symbol table (all strings are
+	// empty/null), in which case we report "no table" and the scan continues without a decoder
+	if (consumed == DUCKDB_FSST_IMPORT_OUT_OF_BOUNDS) {
+		ThrowInvalidFSSTSegment("symbol table was out of range");
+	}
+
 	*width_out = width;
-	return duckdb_fsst_import(decoder_out, base_ptr + fsst_symbol_table_offset);
+	// Currently, we allow an empty symbol table for a row group all strings are of length 0.
+	// This case is detected by reading a symbol table of size 0, which will fail on VERSION_MISSMATCH
+	// as the data we are reading is not really a fsst symbol table.
+	return consumed != DUCKDB_FSST_IMPORT_VERSION_MISMATCH;
 }
 
 // The calculation of offsets and counts while scanning or fetching is a bit tricky, for two reasons:

--- a/src/storage/compression/fsst.cpp
+++ b/src/storage/compression/fsst.cpp
@@ -868,7 +868,7 @@ bool FSSTStorage::ParseFSSTSegmentHeader(data_ptr_t base_ptr, duckdb_fsst_decode
 
 	*width_out = width;
 	// Currently, we allow an empty symbol table for a row group all strings are of length 0.
-	// This case is detected by reading a symbol table of size 0, which will fail on VERSION_MISSMATCH
+	// This case is detected by reading a symbol table of size 0, which will fail on VERSION_MISMATCH
 	// as the data we are reading is not really a fsst symbol table.
 	return consumed != DUCKDB_FSST_IMPORT_VERSION_MISMATCH;
 }

--- a/test/sql/storage/compression/fsst/fsst_small_symbol_table.test
+++ b/test/sql/storage/compression/fsst/fsst_small_symbol_table.test
@@ -1,0 +1,47 @@
+# name: test/sql/storage/compression/fsst/fsst_small_symbol_table.test
+# description: Read an FSST segment whose serialized symbol table is smaller than sizeof(duckdb_fsst_decoder_t)
+# group: [fsst]
+
+# small blocks so a single row group fills a block through the length index buffer
+statement ok
+ATTACH '{TEST_DIR}/fsst_small_symbol_table.db' AS db1 (BLOCK_SIZE 16384, STORAGE_VERSION 'v1.0.0')
+
+statement ok
+USE db1
+
+statement ok
+PRAGMA force_compression='fsst'
+
+# Mostly-empty rows keep the dictionary tiny while the length index buffer fills the block,
+# pushing the FSST symbol table to the very end of the segment. The serialized symbol table is
+# much smaller than sizeof(duckdb_fsst_decoder_t), and the reader must not reject such a segment.
+statement ok
+CREATE TABLE t AS
+SELECT CASE WHEN i % 997 = 0 THEN concat('BEEPBOOP-', (i % 3)::VARCHAR) ELSE '' END AS c0
+FROM range(200000) tab(i);
+
+statement ok
+CHECKPOINT
+
+query I
+SELECT DISTINCT compression FROM pragma_storage_info('t') WHERE segment_type ILIKE 'VARCHAR'
+----
+FSST
+
+# scans below read the persisted FSST segment (with its small symbol table) from disk
+query I
+SELECT count(*) FROM t
+----
+200000
+
+query I
+SELECT count(*) FILTER (WHERE c0 <> '') FROM t
+----
+201
+
+query II
+SELECT c0, count(*) FROM t WHERE c0 <> '' GROUP BY c0 ORDER BY c0
+----
+BEEPBOOP-0	67
+BEEPBOOP-1	67
+BEEPBOOP-2	67

--- a/third_party/fsst/fsst.h
+++ b/third_party/fsst/fsst.h
@@ -131,12 +131,16 @@ duckdb_fsst_export(
 void
 duckdb_fsst_destroy(duckdb_fsst_encoder_t*);
 
+#define DUCKDB_FSST_IMPORT_VERSION_MISMATCH 0xFFFFFFFEu
+#define DUCKDB_FSST_IMPORT_OUT_OF_BOUNDS    0xFFFFFFFFu
+
 /* Return a decoder structure from serialized format (typically used in a block-, file- or row-group header). */
-unsigned int                /* OUT: number of bytes consumed in buf (0 on failure). */
+unsigned int                /* OUT: bytes consumed (a symbol table was decoded), or one of the sentinels above on failure. */
 duckdb_fsst_import(
    duckdb_fsst_decoder_t *decoder, /* IN: this symbol table will be overwritten. */
-   unsigned char *buf       /* OUT: pointer to a byte-buffer where duckdb_fsst_export() serialized this symbol table. */
-); 
+   unsigned char *buf,      /* IN: pointer to a byte-buffer where duckdb_fsst_export() serialized this symbol table. */
+   size_t buf_size          /* IN: number of readable bytes in buf; import never reads past this. */
+);
 
 /* Return a decoder structure from an encoder. */
 duckdb_fsst_decoder_t

--- a/third_party/fsst/libfsst.cpp
+++ b/third_party/fsst/libfsst.cpp
@@ -426,16 +426,20 @@ extern "C" u32 duckdb_fsst_export(duckdb_fsst_encoder_t *encoder, u8 *buf) {
 
 #define FSST_CORRUPT 32774747032022883 /* 7-byte number in little endian containing "corrupt" */
 
-extern "C" u32 duckdb_fsst_import(duckdb_fsst_decoder_t *decoder, u8 *buf) {
+extern "C" u32 duckdb_fsst_import(duckdb_fsst_decoder_t *decoder, u8 *buf, size_t buf_size) {
 	u64 version = 0;
 	u32 code, pos = 17;
 	u8 lenHisto[8];
+
+	// the fixed header (version + zeroTerminated + lenHisto) needs 17 bytes; less than that cannot hold a table
+	if (buf_size < pos) return DUCKDB_FSST_IMPORT_OUT_OF_BOUNDS;
 
 	// version field (first 8 bytes) is now there just for future-proofness, unused still (skipped)
 	memcpy(&version, buf, 8);
 	version = swap64_if_be(version); // version is always little-endian encoded
 
-	if ((version>>32) != FSST_VERSION) return 0;
+	// version mismatch is not corruption: it is how an absent symbol table (all empty/null strings) is encoded
+	if ((version>>32) != FSST_VERSION) return DUCKDB_FSST_IMPORT_VERSION_MISMATCH;
 	decoder->zeroTerminated = buf[8]&1;
 	memcpy(lenHisto, buf+9, 8);
 
@@ -450,10 +454,15 @@ extern "C" u32 duckdb_fsst_import(duckdb_fsst_decoder_t *decoder, u8 *buf) {
 	// now get all symbols from the buffer
 	for(u32 l=1; l<=8; l++) { /* l = 1,2,3,4,5,6,7,8 */
 		for(u32 i=0; i < lenHisto[(l&7) /* 1,2,3,4,5,6,7,0 */]; i++, code++)  {
+			// a corrupt histogram (buf[9..16]) could describe more than 255 symbols (writing past the decoder
+			// arrays) or more bytes than buf_size (reading past the buffer); reject both as out-of-bounds
+			if (code >= 255) return DUCKDB_FSST_IMPORT_OUT_OF_BOUNDS;
 			decoder->len[code] = (l&7)+1; /* len = 2,3,4,5,6,7,8,1  */
 			decoder->symbol[code] = 0;
-			for(u32 j=0; j<decoder->len[code]; j++)
+			for(u32 j=0; j<decoder->len[code]; j++) {
+				if (pos >= buf_size) return DUCKDB_FSST_IMPORT_OUT_OF_BOUNDS;
 				((u8*) &decoder->symbol[code])[j] = buf[pos++]; // note this enforces 'little endian' symbols
+			}
 		}
 	}
 	if (decoder->zeroTerminated) lenHisto[0]++;
@@ -511,7 +520,7 @@ extern "C" duckdb_fsst_decoder_t duckdb_fsst_decoder(duckdb_fsst_encoder_t *enco
 	u8 buf[sizeof(duckdb_fsst_decoder_t)];
 	u32 cnt1 = duckdb_fsst_export(encoder, buf);
 	duckdb_fsst_decoder_t decoder;
-	u32 cnt2 = duckdb_fsst_import(&decoder, buf);
+	u32 cnt2 = duckdb_fsst_import(&decoder, buf, sizeof(buf));
 	assert(cnt1 == cnt2); (void) cnt1; (void) cnt2;
 	return decoder;
 }


### PR DESCRIPTION

https://github.com/duckdb/duckdb/pull/24016 added that before reading the symbol table, we check whether there is still `sizeof(duckdb_fsst_decoder_t)` (2304 bytes) of room in the segment. This was added to avoid out-of-bounds reads if the segment has been corrupted. 

However, the on-disk symbol table is a variable-length serialization that is usually smaller. Valid segments with a small symbol table (for example, a mostly-empty column) were wrongly rejected with `Data Corruption Error`. 

This, for example, led to a `DataCorruptionException` when running Clickbench Q11 on a non-corrupted, v1.0 database.

The proposed fix is to modify `duckdb_fsst_import` to include information about the buffer size, so that the out-of-bounds checks can happen internally.  

I also had to update the return of the import before. For segments with strings of length 0, DuckDB allows a  `duckdb_fsst_import` even if there is no symbol table, which is discovered by a version missmatch. Therefore, I the errors `DUCKDB_FSST_IMPORT_VERSION_MISMATCH` and `DUCKDB_FSST_IMPORT_OUT_OF_BOUNDS` to only throw on the 2nd one.

`fsst_small_symbol_table.test` reads back an FSST segment with a serialized symbol table that is smaller than `sizeof(duckdb_fsst_decoder_t)`, which allows reproducing the crash described above.