### PR TITLE
Fix wrong results and an out-of-bounds read in the LIST->ARRAY cast

### DIFF
--- a/src/function/cast/list_casts.cpp
+++ b/src/function/cast/list_casts.cpp
@@ -225,16 +225,19 @@ static bool ListToArrayCast(Vector &source, Vector &result, idx_t count, CastPar
 		// We can just cast the child vector directly
 		// Note: Its worth doing a CheckAllValid here, the slow path is significantly more expensive
 		if (FlatVector::ValidityMutable(result).CheckAllValid(count)) {
+			// Cast the entries the lists actually point at: the source child's size is unrelated to
+			// array_size * count, so casting the first child_count entries can both overrun the child and
+			// touch entries that no list references.
+			Vector source_slice(source_cc, child_sel, child_count);
 			Vector payload_vector(result_cc.GetType(), child_count);
 
-			bool ok = cast_data.child_cast_info.Cast(source_cc, payload_vector, child_count, child_parameters);
+			bool ok = cast_data.child_cast_info.Cast(source_slice, payload_vector, child_count, child_parameters);
 			if (all_ok && !ok) {
 				all_ok = false;
 				HandleCastError::AssignError(*child_parameters.error_message, parameters);
 			}
-			// Now do the actual copy onto the result vector, making sure to slice properly in case the lists are out of
-			// order
-			VectorOperations::Copy(payload_vector, result_cc, child_sel, child_count, 0, 0);
+			// The slice already put the entries in list order, so this is a straight copy
+			VectorOperations::Copy(payload_vector, result_cc, child_count, 0, 0);
 			return all_ok;
 		}
 

--- a/test/sql/types/nested/array/array_cast.test
+++ b/test/sql/types/nested/array/array_cast.test
@@ -170,3 +170,37 @@ query I
 SELECT TRY_CAST(l AS INTEGER[][3]) FROM VALUES (['foo']) as v(l);
 ----
 NULL
+
+# The LIST->ARRAY cast must only look at the child entries the lists point at. A filter leaves the
+# list child intact, so a surviving row can point past array_size * row_count.
+statement ok
+CREATE TABLE list_child_offset AS
+    SELECT i, [(i * 3 + 1)::VARCHAR, (i * 3 + 2)::VARCHAR, (i * 3 + 3)::VARCHAR] AS l
+    FROM range(100) t(i);
+
+query II
+SELECT i, l::INT[3] FROM list_child_offset WHERE i = 99
+----
+99	[298, 299, 300]
+
+query II
+SELECT i, l::INT[3] FROM list_child_offset WHERE i IN (50, 99) ORDER BY i
+----
+50	[151, 152, 153]
+99	[298, 299, 300]
+
+# ... and entries that no surviving row points at must not raise a cast error
+statement ok
+CREATE TABLE unreferenced_bad_child AS
+    SELECT i, CASE WHEN i = 0 THEN ['1', '2', '3'] ELSE ['x', 'y', 'z'] END AS l
+    FROM range(100) t(i);
+
+query I
+SELECT l::INT[3] FROM unreferenced_bad_child WHERE i = 0
+----
+[1, 2, 3]
+
+query I
+SELECT TRY_CAST(l AS INT[3]) FROM unreferenced_bad_child WHERE i = 1
+----
+[NULL, NULL, NULL]


### PR DESCRIPTION
The fast path cast the first array_size * count entries of the source list child, which has nothing to do with the entries the lists point at. A filter leaves the child holding every entry it had before, so a surviving row's entries can live past that window, and the cast then copied never-written payload memory into the result:

```sql
CREATE TABLE t AS
    SELECT i, [(i*3+1)::VARCHAR, (i*3+2)::VARCHAR, (i*3+3)::VARCHAR] AS l
    FROM range(100) t(i);
SELECT l::INT[3] FROM t WHERE i = 99;   -- [0, 0, 0], want [298, 299, 300]
```

In the other direction, a child smaller than that window was read past its end. At STANDARD_VECTOR_SIZE=8 that threw "Vector::SetSize out of range" from the Arrow scan of a fixed-size ARRAY(dict int32) with a nonzero array offset.

Cast the entries the selection references instead. Casting the child at its full size fixes both, but then raises conversion errors from entries no row references.

Found while making a sweep looking for errors at STANDARD_VECTOR_SIZE=8.