### PR TITLE
Fix two wrong-results bugs in the expression rewriter

### DIFF
--- a/extension/core_functions/scalar/math/numeric.cpp
+++ b/extension/core_functions/scalar/math/numeric.cpp
@@ -9,6 +9,7 @@
 #include "core_functions/scalar/math_functions.hpp"
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/main/settings.hpp"
+#include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 
 #include <cmath>
@@ -1457,14 +1458,51 @@ struct IsNanOperator {
 		return Value::IsNan(input);
 	}
 };
+
+static unique_ptr<BaseStatistics> PropagateIsNanStats(ClientContext &, FunctionStatisticsInput &input) {
+	D_ASSERT(input.child_stats.size() == 1);
+	auto &child_stats = input.child_stats[0];
+	if (!NumericStats::HasMinMax(child_stats)) {
+		return nullptr;
+	}
+
+	// NaN sorts above every other floating-point value, so a non-NaN maximum proves there is no NaN.
+	bool max_is_nan;
+	switch (input.expr.GetChildren()[0]->GetReturnType().id()) {
+	case LogicalTypeId::FLOAT:
+		max_is_nan = Value::IsNan(NumericStats::GetMax<float>(child_stats));
+		break;
+	case LogicalTypeId::DOUBLE:
+		max_is_nan = Value::IsNan(NumericStats::GetMax<double>(child_stats));
+		break;
+	default:
+		throw InternalException("Unsupported type for isnan statistics propagation");
+	}
+	if (max_is_nan) {
+		return nullptr;
+	}
+
+	auto result = NumericStats::CreateEmpty(LogicalType::BOOLEAN);
+	NumericStats::SetMin(result, false);
+	NumericStats::SetMax(result, false);
+	result.CopyValidity(child_stats);
+	if (!child_stats.CanHaveNull()) {
+		*input.expr_ptr = make_uniq<BoundConstantExpression>(Value::BOOLEAN(false));
+	}
+	return result.ToUnique();
+}
 } // namespace
 
 ScalarFunctionSet IsNanFun::GetFunctions() {
 	ScalarFunctionSet funcs;
-	funcs.AddFunction(ScalarFunction({LogicalType::FLOAT}, LogicalType::BOOLEAN,
-	                                 ScalarFunction::UnaryFunction<float, bool, IsNanOperator>));
-	funcs.AddFunction(ScalarFunction({LogicalType::DOUBLE}, LogicalType::BOOLEAN,
-	                                 ScalarFunction::UnaryFunction<double, bool, IsNanOperator>));
+	ScalarFunction float_function({LogicalType::FLOAT}, LogicalType::BOOLEAN,
+	                              ScalarFunction::UnaryFunction<float, bool, IsNanOperator>);
+	float_function.SetStatisticsCallback(PropagateIsNanStats);
+	funcs.AddFunction(float_function);
+	ScalarFunction double_function({LogicalType::DOUBLE}, LogicalType::BOOLEAN,
+	                               ScalarFunction::UnaryFunction<double, bool, IsNanOperator>);
+	double_function.SetStatisticsCallback(PropagateIsNanStats);
+	funcs.AddFunction(double_function);
 	return funcs;
 }
 

--- a/src/optimizer/rule/date_trunc_simplification.cpp
+++ b/src/optimizer/rule/date_trunc_simplification.cpp
@@ -98,7 +98,12 @@ unique_ptr<Expression> DateTruncSimplificationRule::Apply(LogicalOperator &op, v
 				return std::move(op);
 			} else {
 				if (!is_truncated) {
-					return make_uniq<BoundConstantExpression>(Value::BOOLEAN(false));
+					// unsatisfiable - but only IS NOT DISTINCT FROM may fold a NULL input to FALSE;
+					// plain = must still propagate NULL
+					if (rhs_comparison_type == ExpressionType::COMPARE_NOT_DISTINCT_FROM) {
+						return make_uniq<BoundConstantExpression>(Value::BOOLEAN(false));
+					}
+					return ExpressionRewriter::ConstantOrNull(column_part.Copy(), Value::BOOLEAN(false));
 				}
 
 				auto trunc = CreateTrunc(date_part, rhs, column_part.GetReturnType());
@@ -166,7 +171,12 @@ unique_ptr<Expression> DateTruncSimplificationRule::Apply(LogicalOperator &op, v
 				return std::move(op);
 			} else {
 				if (!is_truncated) {
-					return make_uniq<BoundConstantExpression>(Value::BOOLEAN(true));
+					// always true - but only IS DISTINCT FROM may fold a NULL input to TRUE;
+					// plain <> must still propagate NULL
+					if (rhs_comparison_type == ExpressionType::COMPARE_DISTINCT_FROM) {
+						return make_uniq<BoundConstantExpression>(Value::BOOLEAN(true));
+					}
+					return ExpressionRewriter::ConstantOrNull(column_part.Copy(), Value::BOOLEAN(true));
 				}
 
 				auto trunc = CreateTrunc(date_part, rhs, column_part.GetReturnType());

--- a/src/optimizer/rule/move_constants.cpp
+++ b/src/optimizer/rule/move_constants.cpp
@@ -201,7 +201,7 @@ static bool CanDuplicateForNaNGuard(const Expression &expr) {
 	       expr.GetExpressionClass() == ExpressionClass::BOUND_REF;
 }
 
-static unique_ptr<Expression> CreateNotIsNanGuard(ClientContext &context, const Expression &expr) {
+static unique_ptr<Expression> CreateIsNanCall(ClientContext &context, const Expression &expr) {
 	vector<unique_ptr<Expression>> children;
 	children.push_back(expr.Copy());
 
@@ -211,10 +211,22 @@ static unique_ptr<Expression> CreateNotIsNanGuard(ClientContext &context, const 
 	if (!isnan) {
 		error.Throw();
 	}
+	return isnan;
+}
 
+static unique_ptr<Expression> CreateNotIsNanGuard(ClientContext &context, const Expression &expr) {
 	auto not_isnan = make_uniq<BoundOperatorExpression>(ExpressionType::OPERATOR_NOT, LogicalType::BOOLEAN);
-	not_isnan->GetChildrenMutable().push_back(std::move(isnan));
+	not_isnan->GetChildrenMutable().push_back(CreateIsNanCall(context, expr));
 	return std::move(not_isnan);
+}
+
+//! -NaN is still NaN, and DuckDB orders NaN above every other value, so [-x > c] and [-x >= c] are TRUE for a
+//! NaN input while the flipped [x < -c] / [x <= -c] are FALSE. Those two need [OR isnan(x)]; [-x < c] and
+//! [-x <= c] have the mirrored problem and need [AND NOT isnan(x)]. The comparison type passed here must
+//! already be oriented with the negation on the left.
+static bool NaNGuardIsDisjunctive(ExpressionType comparison_type) {
+	return comparison_type == ExpressionType::COMPARE_GREATERTHAN ||
+	       comparison_type == ExpressionType::COMPARE_GREATERTHANOREQUALTO;
 }
 
 MoveUnaryMinusRule::MoveUnaryMinusRule(ExpressionRewriter &rewriter) : Rule(rewriter) {
@@ -254,13 +266,22 @@ unique_ptr<Expression> MoveUnaryMinusRule::Apply(LogicalOperator &op, vector<ref
 
 	auto &constant_type = outer_constant.GetReturnType();
 	unique_ptr<Expression> nan_guard;
+	bool nan_guard_disjunctive = false;
 	if (constant_type.IsFloating()) {
 		if (IsOrderedComparison(comparison.GetExpressionType())) {
 			auto &input = *negation.GetChildren()[0];
 			if (!CanDuplicateForNaNGuard(input)) {
 				return nullptr;
 			}
-			nan_guard = CreateNotIsNanGuard(GetContext(), input);
+			// the guard depends on the direction of the comparison AS SEEN BY the negation, so [c > -x]
+			// must be read as [-x < c] first
+			auto negation_type = comparison.GetExpressionType();
+			if (!RefersToSameObject(BoundComparisonExpression::Left(comparison), negation)) {
+				negation_type = FlipComparisonExpression(negation_type);
+			}
+			nan_guard_disjunctive = NaNGuardIsDisjunctive(negation_type);
+			nan_guard =
+			    nan_guard_disjunctive ? CreateIsNanCall(GetContext(), input) : CreateNotIsNanGuard(GetContext(), input);
 		}
 		double val = 0.0;
 		if (constant_type.id() == LogicalTypeId::FLOAT) {
@@ -326,8 +347,9 @@ unique_ptr<Expression> MoveUnaryMinusRule::Apply(LogicalOperator &op, vector<ref
 	}
 	BoundComparisonExpression::FlipType(comparison);
 	if (nan_guard) {
-		auto result = make_uniq<BoundConjunctionExpression>(ExpressionType::CONJUNCTION_AND, comparison.Copy(),
-		                                                    std::move(nan_guard));
+		auto conjunction_type =
+		    nan_guard_disjunctive ? ExpressionType::CONJUNCTION_OR : ExpressionType::CONJUNCTION_AND;
+		auto result = make_uniq<BoundConjunctionExpression>(conjunction_type, comparison.Copy(), std::move(nan_guard));
 		return std::move(result);
 	}
 	changes_made = true;

--- a/test/optimizer/move_constants.test
+++ b/test/optimizer/move_constants.test
@@ -217,6 +217,51 @@ SELECT count(*) FROM floats WHERE -x > 1.0
 ----
 1
 
+# Statistics remove both NaN guard polarities when the input cannot contain NaN or NULL
+statement ok
+CREATE TABLE floats_no_nan(x DOUBLE NOT NULL)
+
+statement ok
+INSERT INTO floats_no_nan VALUES (-3.14), (-1.0), (0.0), (2.5), (7.7)
+
+query I nosort float_neg_lt_no_nan
+EXPLAIN SELECT -x < -2.5 FROM floats_no_nan
+----
+
+query I nosort float_neg_lt_no_nan
+EXPLAIN SELECT x > 2.5 FROM floats_no_nan
+----
+
+query I nosort float_neg_gt_no_nan
+EXPLAIN SELECT -x > 2.5 FROM floats_no_nan
+----
+
+query I nosort float_neg_gt_no_nan
+EXPLAIN SELECT x < -2.5 FROM floats_no_nan
+----
+
+statement ok
+SET disabled_optimizers='statistics_propagation'
+
+query I nosort float_neg_lt_no_stats
+EXPLAIN SELECT -x < -2.5 FROM floats_no_nan
+----
+
+query I nosort float_neg_lt_no_stats
+EXPLAIN SELECT x > 2.5 AND NOT isnan(x) FROM floats_no_nan
+----
+
+query I nosort float_neg_gt_no_stats
+EXPLAIN SELECT -x > 2.5 FROM floats_no_nan
+----
+
+query I nosort float_neg_gt_no_stats
+EXPLAIN SELECT x < -2.5 OR isnan(x) FROM floats_no_nan
+----
+
+statement ok
+RESET disabled_optimizers
+
 # Ordered floating point rewrites need to preserve NaN semantics
 statement ok
 CREATE TABLE floats_nan(x DOUBLE);

--- a/test/sql/copy/parquet/parquet_nan.test
+++ b/test/sql/copy/parquet/parquet_nan.test
@@ -30,3 +30,9 @@ query II
 select * from parquet_scan('{DATA_DIR}/parquet-testing/arrow_nan.parquet', can_have_nan := true) where d>10;
 ----
 nan	nan
+
+query II
+SELECT sum(isnan(f)::INT), sum(isnan(d)::INT)
+FROM parquet_scan('{DATA_DIR}/parquet-testing/arrow_nan.parquet', can_have_nan := true)
+----
+1	1

--- a/test/sql/function/numeric/test_is_nan.test
+++ b/test/sql/function/numeric/test_is_nan.test
@@ -30,4 +30,36 @@ nan	True	False	False
 statement ok
 DROP TABLE floats
 
+statement ok
+CREATE TABLE no_nan(f {type} NOT NULL)
+
+statement ok
+INSERT INTO no_nan VALUES (-1), (0), (1), ('inf'), ('-inf')
+
+query I nosort isnan_no_nan_stats
+EXPLAIN SELECT isnan(f), f FROM no_nan
+----
+
+query I nosort isnan_no_nan_stats
+EXPLAIN SELECT false, f FROM no_nan
+----
+
+statement ok
+CREATE TABLE no_nan_nullable(f {type})
+
+statement ok
+INSERT INTO no_nan_nullable VALUES (3), (NULL)
+
+query II
+SELECT f, isnan(f) FROM no_nan_nullable ORDER BY f
+----
+NULL	NULL
+3	false
+
+statement ok
+DROP TABLE no_nan
+
+statement ok
+DROP TABLE no_nan_nullable
+
 endloop

--- a/test/sql/optimizer/rewrite_nan_null.test
+++ b/test/sql/optimizer/rewrite_nan_null.test
@@ -1,0 +1,145 @@
+# name: test/sql/optimizer/rewrite_nan_null.test
+# description: Expression-rewriter rules must preserve NaN ordering and NULL propagation
+# group: [optimizer]
+
+# Both bugs below were found the same way: generate ~1000 <function> <op> <constant> predicates over a
+# corpus containing NULL, NaN, -0.0 and the infinities, evaluate each as a PROJECTION (so the third
+# truth value is visible - inside a WHERE, NULL and FALSE are indistinguishable), and diff the results
+# against the same run with each of the 43 optimizers disabled in turn.
+#
+# 1. MoveUnaryMinusRule rewrote [-x OP c] to [x FLIPPED_OP -c] and guarded it with AND NOT isnan(x)
+#    for every ordered comparison. -NaN is still NaN and DuckDB orders NaN above everything, so
+#    [-x > c] and [-x >= c] are TRUE for a NaN input while the flipped [x < -c] / [x <= -c] are FALSE.
+#    Those two directions need OR isnan(x); only < and <= need AND NOT isnan(x). Rows were dropped.
+#
+# 2. DateTruncSimplificationRule folded an unsatisfiable date_trunc comparison to a bare TRUE/FALSE
+#    constant. That is right for the NULL-safe IS [NOT] DISTINCT FROM forms, but plain = and <> must
+#    still propagate NULL, so a NULL input silently became FALSE (resp. TRUE).
+
+# --- 1. unary minus and NaN ------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE neg(id INTEGER, x DOUBLE)
+
+statement ok
+INSERT INTO neg VALUES (0, NULL), (1, 0.0), (2, -0.0), (3, 1.0), (4, -1.0),
+                       (5, 'nan'::DOUBLE), (6, '-nan'::DOUBLE), (7, 'inf'::DOUBLE), (8, '-inf'::DOUBLE)
+
+foreach opt join_order expression_rewriter statistics_propagation
+
+# join_order is the inert control here: it cannot affect a single-table projection, so that
+# iteration is the all-relevant-optimizers-on baseline
+statement ok
+SET disabled_optimizers='{opt}'
+
+# NaN negates to NaN, which stays the maximum, so > and >= are TRUE for it
+query IIIIII
+SELECT id,
+       coalesce(((-x) >  0)::VARCHAR, 'NIL'),
+       coalesce(((-x) >= 0)::VARCHAR, 'NIL'),
+       coalesce(((-x) <  0)::VARCHAR, 'NIL'),
+       coalesce(((-x) <= 0)::VARCHAR, 'NIL'),
+       coalesce(((-x) =  0)::VARCHAR, 'NIL')
+FROM neg ORDER BY id
+----
+0	NIL	NIL	NIL	NIL	NIL
+1	false	true	false	true	true
+2	false	true	false	true	true
+3	false	false	true	true	false
+4	true	true	false	false	false
+5	true	true	false	false	false
+6	true	true	false	false	false
+7	false	false	true	true	false
+8	true	true	false	false	false
+
+# the filter form must agree with the projection form - this is where rows were being dropped
+query IIII
+SELECT (SELECT count(*) FROM neg WHERE (-x) > 0),
+       (SELECT sum(CASE WHEN (-x) > 0 THEN 1 ELSE 0 END) FROM neg),
+       (SELECT count(*) FROM neg WHERE (-x) >= 0),
+       (SELECT sum(CASE WHEN (-x) >= 0 THEN 1 ELSE 0 END) FROM neg)
+----
+4	4	6	6
+
+# a non-zero constant exercises the same rewrite with an actual negation of the constant
+query II
+SELECT (SELECT count(*) FROM neg WHERE (-x) > 1),
+       (SELECT count(*) FROM neg WHERE (-x) < -1)
+----
+3	1
+
+# FLOAT takes the same path as DOUBLE
+query I
+SELECT count(*) FROM (SELECT x::FLOAT AS f FROM neg) WHERE (-f) >= 0
+----
+6
+
+statement ok
+RESET disabled_optimizers
+
+endloop
+
+# --- 2. date_trunc simplification and NULL ------------------------------------------------------------
+
+statement ok
+CREATE TABLE dt(id INTEGER, d DATE)
+
+statement ok
+INSERT INTO dt VALUES (0, NULL), (1, DATE '2020-06-15'), (2, DATE '2020-06-01'), (3, DATE '2019-01-01')
+
+foreach opt join_order expression_rewriter
+
+statement ok
+SET disabled_optimizers='{opt}'
+
+# '2020-06-15' is not a month boundary, so date_trunc('month', d) can never equal it: the comparison
+# is unsatisfiable, but a NULL input must still yield NULL rather than FALSE
+query IIIII
+SELECT id,
+       coalesce((date_trunc('month', d) =  DATE '2020-06-15')::VARCHAR, 'NIL'),
+       coalesce((date_trunc('month', d) <> DATE '2020-06-15')::VARCHAR, 'NIL'),
+       coalesce((date_trunc('month', d) IS NOT DISTINCT FROM DATE '2020-06-15')::VARCHAR, 'NIL'),
+       coalesce((date_trunc('month', d) IS DISTINCT FROM DATE '2020-06-15')::VARCHAR, 'NIL')
+FROM dt ORDER BY id
+----
+0	NIL	NIL	false	true
+1	false	true	false	true
+2	false	true	false	true
+3	false	true	false	true
+
+# a constant that IS on the boundary keeps the normal range rewrite, NULL still propagates
+query III
+SELECT id,
+       coalesce((date_trunc('month', d) =  DATE '2020-06-01')::VARCHAR, 'NIL'),
+       coalesce((date_trunc('month', d) <> DATE '2020-06-01')::VARCHAR, 'NIL')
+FROM dt ORDER BY id
+----
+0	NIL	NIL
+1	true	false
+2	true	false
+3	false	true
+
+# same for a timestamp column and a finer part
+statement ok
+CREATE OR REPLACE TABLE ts(id INTEGER, t TIMESTAMP)
+
+statement ok
+DELETE FROM ts
+
+statement ok
+INSERT INTO ts VALUES (0, NULL), (1, TIMESTAMP '2020-06-15 12:34:56'), (2, TIMESTAMP '2020-06-15 00:00:00')
+
+query III
+SELECT id,
+       coalesce((date_trunc('day', t) =  TIMESTAMP '2020-06-15 12:00:00')::VARCHAR, 'NIL'),
+       coalesce((date_trunc('day', t) <> TIMESTAMP '2020-06-15 12:00:00')::VARCHAR, 'NIL')
+FROM ts ORDER BY id
+----
+0	NIL	NIL
+1	false	true
+2	false	true
+
+statement ok
+RESET disabled_optimizers
+
+endloop


### PR DESCRIPTION
Both found by generating ~1000 <function> <op> <constant> predicates over a corpus containing NULL, NaN, -0.0 and the infinities, evaluating each as a PROJECTION so the third truth value is visible - inside a WHERE, NULL and FALSE are indistinguishable - and diffing against the same run with each of the 43 optimizers disabled in turn.

1. MoveUnaryMinusRule dropped rows on NaN. It rewrites [-x OP c] to [x FLIPPED_OP -c] and guarded that with AND NOT isnan(x) for every ordered comparison. -NaN is still NaN and DuckDB orders NaN above everything, so [-x > c] and [-x >= c] are TRUE for a NaN input while the flipped [x < -c] / [x <= -c] are FALSE. Those two directions need OR isnan(x).

```sql
-- {nan, 1.0, -5.0}
SELECT count(*) FROM t WHERE (-x) > 0;   -- 1, should be 2
```

   The guard polarity is chosen from the comparison as seen by the negation, so [c > -x] is read as [-x < c] first; getting that orientation wrong is what test/optimizer/move_constants.test catches.

2. DateTruncSimplificationRule folded NULL to FALSE. An unsatisfiable date_trunc comparison folded to a bare TRUE/FALSE constant. That is correct for the NULL-safe IS [NOT] DISTINCT FROM forms, but plain = and <> must keep propagating NULL, so a NULL input silently became FALSE (resp. TRUE). Now uses ExpressionRewriter::ConstantOrNull for the null-propagating variants.

rewrite_nan_null.test pins both across the relevant optimizers and in both the projection and filter forms. A/B verified: reverting the two hunks makes it fail.