### PR TITLE
EXTERNAL RESOURCES: Unskip discovery tests now that the dependency landed

### DIFF
--- a/test/configs/force_storage_restart.json
+++ b/test/configs/force_storage_restart.json
@@ -13,7 +13,8 @@
         "test/sql/table_function/register_external_resource.test",
         "test/sql/table_function/external_resource_logging.test",
         "test/sql/table_function/external_resource_discovery.test",
-        "test/sql/table_function/external_resource_discovery_error.test"
+        "test/sql/table_function/external_resource_discovery_error.test",
+        "test/sql/attach/external_resource_discovery.test"
       ]
     },
     {

--- a/test/sql/attach/external_resource_discovery.test
+++ b/test/sql/attach/external_resource_discovery.test
@@ -5,8 +5,6 @@
 # The whole test exercises discovery — the type's `list_function` callback and
 # duckdb_external_resources(discover := true) — which lands in the external-resource discovery part.
 # Skip until that lands (then remove this mode skip / mode unskip).
-mode skip "discover not yet landed"
-
 # A resource type whose `list` callback enumerates what exists externally (handle/reference/state).
 statement ok
 CREATE MACRO qk_create(p) AS TABLE SELECT MAP {'id': 'q1'} AS handle;
@@ -56,4 +54,3 @@ SELECT reference, state FROM duckdb_external_resources(discover := true) WHERE m
 ----
 ref-q2	running
 
-mode unskip

--- a/test/sql/attach/external_resource_statements.test
+++ b/test/sql/attach/external_resource_statements.test
@@ -25,12 +25,8 @@ SHOW EXTERNAL RESOURCES;
 
 # SHOW ALL (the discovery union) desugars to duckdb_external_resources(discover := true); the discover
 # parameter and the list-callback union land in the external-resource discovery part, so skip it here.
-mode skip "discover not yet landed"
-
 statement ok
 SHOW ALL EXTERNAL RESOURCES;
-
-mode unskip
 
 # The grammar requires the pieces: DESTROY needs a name, REGISTER needs a handle. These are parser errors.
 statement error


### PR DESCRIPTION
Both files carry `mode skip "discover not yet landed"`, added when #24056 (the SQL surface, part 3/4) merged ahead of the discovery part. That part landed in #24024 on 2026-07-28, and the skip comment says outright "Skip until that lands (then remove this mode skip / mode unskip)".