### PR TITLE
Un-skip 75 stale entries across 15 test configs

### DIFF
--- a/test/configs/compressed_in_memory.json
+++ b/test/configs/compressed_in_memory.json
@@ -9,7 +9,6 @@
       "reason": "Unknown, to be investigated",
       "paths": [
         "test/fuzzer/sqlsmith/current_schemas_null.test",
-        "test/sql/settings/drop_set_schema.test",
         "test/sql/catalog/test_set_search_path.test",
         "test/sql/storage/temp_directory/max_swap_space_explicit.test",
         "test/sql/storage/temp_directory/max_swap_space_inmemory.test",

--- a/test/configs/disable_optimizer.json
+++ b/test/configs/disable_optimizer.json
@@ -120,19 +120,10 @@
       ]
     },
     {
-      "reason": "FIXME: crash.",
-      "paths": [
-        "test/sql/join/asof/test_asof_join_filter_pushdown.test"
-        ]
-    },
-    {
       "reason": "FIXME: binding bug.",
       "paths": [
-        "test/sql/merge/merge_into_invalid_column_reference.test",
-        "test/sql/merge/merge_into_by_source.test",
-        "test/sql/subquery/scalar/test_complex_correlated_subquery.test",
         "test/sql/join/natural/natural_join.test"
-        ]
+      ]
     }
   ]
 }

--- a/test/configs/force_storage_restart.json
+++ b/test/configs/force_storage_restart.json
@@ -98,8 +98,7 @@
       "reason": "total_string_length requires exact per-row-group stats; force_restart causes persistent row groups with unloaded columns where only bound-expansion is possible, making the stat unknown.",
       "paths": [
         "test/sql/storage/total_string_length_repeated_insert.test",
-        "test/sql/storage/compression/dictionary/total_string_length_dictionary.test",
-        "test/sql/storage/extended_string_stats.test"
+        "test/sql/storage/compression/dictionary/total_string_length_dictionary.test"
       ]
     },
     {

--- a/test/configs/latest_storage.json
+++ b/test/configs/latest_storage.json
@@ -14,23 +14,14 @@
     {
       "reason": "TODO",
       "paths": [
-        "test/extension/test_tags.test",
-        "test/extension/load_extension.test",
         "test/extension/autoloading_types.test",
-        "test/sql/settings/drop_set_schema.test",
-        "test/extension/test_custom_type_modifier_cast.test",
-        "test/extension/test_alias_point.test",
-        "test/extension/load_test_alias.test",
         "test/fuzzer/pedro/incomplete_checkpoint.test",
-        "test/sql/catalog/test_set_search_path.test",
         "test/sql/storage/temp_directory/max_swap_space_error.test",
         "test/sql/attach/attach_icu_collation.test",
-        "test/sql/function/list/lambdas/incorrect.test",
         "test/sql/json/test_json_serialize_sql.test",
         "test/sql/table_function/duckdb_databases.test",
         "test/sql/logging/file_system_logging_attach.test",
-        "test/sql/logging/file_system_logging_attach_deadlock.test",
-        "test/sql/storage/read_duckdb/read_duckdb_basic.test"
+        "test/sql/logging/file_system_logging_attach_deadlock.test"
       ]
     },
     {

--- a/test/configs/latest_storage_block_size_16kB.json
+++ b/test/configs/latest_storage_block_size_16kB.json
@@ -15,13 +15,9 @@
     {
       "reason": "TODO",
       "paths": [
-        "test/fuzzer/sqlsmith/current_schemas_null.test",
-        "test/sql/catalog/test_set_search_path.test",
         "test/sql/json/test_json_serialize_sql.test",
-        "test/sql/settings/drop_set_schema.test",
         "test/sql/storage/buffer_manager_temp_dir.test",
-        "test/sql/table_function/duckdb_databases.test",
-        "test/sql/storage/read_duckdb/read_duckdb_basic.test"
+        "test/sql/table_function/duckdb_databases.test"
       ]
     },
     {

--- a/test/configs/serialization_bwc_base.json
+++ b/test/configs/serialization_bwc_base.json
@@ -317,14 +317,6 @@
       "paths": [
         "test/sql/upsert/upsert_basic.test"
       ]
-    },
-    {
-      "reason": "Unknown failure (empty reason)",
-      "paths": [
-        "test/sql/catalog/function/test_recursive_macro.test",
-        "test/sql/storage/compression/dict_fsst/dictionary_covers_validity.test",
-        "test/sql/storage/compression/zstd/test_skipping.test"
-      ]
     }
   ]
 }

--- a/test/configs/serialization_bwc_v1.1.0.json
+++ b/test/configs/serialization_bwc_v1.1.0.json
@@ -129,8 +129,7 @@
       "reason": "Unknown failure (empty reason)",
       "paths": [
         "test/sql/copy/parquet/test_parquet_remote.test",
-        "test/sql/parallelism/intraquery/depth_first_evaluation_union_and_join.test",
-        "test/sql/types/enum/test_enum_to_numbers.test"
+        "test/sql/parallelism/intraquery/depth_first_evaluation_union_and_join.test"
       ]
     },
     {

--- a/test/configs/serialization_bwc_v1.1.1.json
+++ b/test/configs/serialization_bwc_v1.1.1.json
@@ -128,7 +128,6 @@
     {
       "reason": "Unknown failure (empty reason)",
       "paths": [
-        "test/sql/types/enum/test_enum_to_numbers.test",
         "test/sql/copy/csv/test_csv_remote.test",
         "test/sql/parallelism/intraquery/depth_first_evaluation_union_and_join.test"
       ]

--- a/test/configs/serialization_bwc_v1.1.2.json
+++ b/test/configs/serialization_bwc_v1.1.2.json
@@ -122,8 +122,7 @@
       "reason": "Unknown failure (empty reason)",
       "paths": [
         "test/sql/cte/recursive_cte_key_variant.test",
-        "test/sql/parallelism/intraquery/depth_first_evaluation_union_and_join.test",
-        "test/sql/types/enum/test_enum_to_numbers.test"
+        "test/sql/parallelism/intraquery/depth_first_evaluation_union_and_join.test"
       ]
     },
     {

--- a/test/configs/serialization_bwc_v1.1.3.json
+++ b/test/configs/serialization_bwc_v1.1.3.json
@@ -122,8 +122,7 @@
       "reason": "Unknown failure (empty reason)",
       "paths": [
         "test/sql/attach/attach_remote.test",
-        "test/sql/parallelism/intraquery/depth_first_evaluation_union_and_join.test",
-        "test/sql/types/enum/test_enum_to_numbers.test"
+        "test/sql/parallelism/intraquery/depth_first_evaluation_union_and_join.test"
       ]
     },
     {

--- a/test/configs/serialization_bwc_v1.4.0.json
+++ b/test/configs/serialization_bwc_v1.4.0.json
@@ -36,9 +36,7 @@
       "reason": "Unknown failure (empty reason)",
       "paths": [
         "test/sql/copy/parquet/test_parquet_remote.test",
-        "test/sql/cte/recursive_cte_key_variant.test",
-        "test/sql/table_function/test_information_schema_columns.test",
-        "test/sql/table_function/test_range_function.test"
+        "test/sql/cte/recursive_cte_key_variant.test"
       ]
     },
     {

--- a/test/configs/serialization_bwc_v1.4.2.json
+++ b/test/configs/serialization_bwc_v1.4.2.json
@@ -4,7 +4,6 @@
     {
       "reason": "Unknown failure (empty reason)",
       "paths": [
-        "test/sql/function/list/lambdas/test_lambda_storage.test",
         "test/sql/logging/http_log_timing.test",
         "test/sql/cte/recursive_cte_key_variant.test"
       ]

--- a/test/configs/v1_storage.json
+++ b/test/configs/v1_storage.json
@@ -14,23 +14,14 @@
     {
       "reason": "TODO",
       "paths": [
-        "test/extension/test_tags.test",
-        "test/extension/load_extension.test",
         "test/extension/autoloading_types.test",
-        "test/sql/settings/drop_set_schema.test",
-        "test/extension/test_custom_type_modifier_cast.test",
-        "test/extension/test_alias_point.test",
-        "test/extension/load_test_alias.test",
         "test/fuzzer/pedro/incomplete_checkpoint.test",
-        "test/sql/catalog/test_set_search_path.test",
         "test/sql/storage/temp_directory/max_swap_space_error.test",
         "test/sql/attach/attach_icu_collation.test",
-        "test/sql/function/list/lambdas/incorrect.test",
         "test/sql/json/test_json_serialize_sql.test",
         "test/sql/table_function/duckdb_databases.test",
         "test/sql/logging/file_system_logging_attach.test",
-        "test/sql/logging/file_system_logging_attach_deadlock.test",
-        "test/sql/storage/read_duckdb/read_duckdb_basic.test"
+        "test/sql/logging/file_system_logging_attach_deadlock.test"
       ]
     },
     {

--- a/test/configs/v1_storage_block_size_16kB.json
+++ b/test/configs/v1_storage_block_size_16kB.json
@@ -15,13 +15,9 @@
     {
       "reason": "TODO",
       "paths": [
-        "test/fuzzer/sqlsmith/current_schemas_null.test",
-        "test/sql/catalog/test_set_search_path.test",
         "test/sql/json/test_json_serialize_sql.test",
-        "test/sql/settings/drop_set_schema.test",
         "test/sql/storage/buffer_manager_temp_dir.test",
-        "test/sql/table_function/duckdb_databases.test",
-        "test/sql/storage/read_duckdb/read_duckdb_basic.test"
+        "test/sql/table_function/duckdb_databases.test"
       ]
     },
     {

--- a/test/configs/wal_verification.json
+++ b/test/configs/wal_verification.json
@@ -50,49 +50,17 @@
     {
       "reason": "FIXME: Unexpected (?) binder error.",
       "paths": [
-        "test/fuzzer/pedro/index_generated_column.test",
-        "test/sql/alter/add_col/test_add_col_stats.test",
-        "test/sql/alter/add_col/test_add_col_user_type.test",
-        "test/sql/alter/alter_type/alter_type_struct.test",
         "test/sql/alter/alter_type/test_alter_type.test",
-        "test/sql/alter/alter_type/test_alter_type_expression.test",
-        "test/sql/alter/alter_type/test_alter_type_multi_column.test",
-        "test/sql/alter/default/test_set_default.test",
-        "test/sql/alter/list/add_column_in_struct.test",
-        "test/sql/alter/list/drop_column_in_struct.test",
-        "test/sql/alter/list/rename_column_in_struct.test",
-        "test/sql/alter/map/add_column_in_struct.test",
-        "test/sql/alter/map/drop_column_in_struct.test",
-        "test/sql/alter/map/rename_column_in_struct.test",
-        "test/sql/alter/struct/add_col_nested_struct.test",
-        "test/sql/alter/struct/add_col_struct.test",
-        "test/sql/alter/struct/drop_col_nested_struct.test",
-        "test/sql/alter/struct/drop_col_struct.test",
-        "test/sql/alter/struct/rename_col_nested_struct.test",
-        "test/sql/alter/struct/rename_col_struct.test",
-        "test/sql/attach/attach_dependencies.test",
-        "test/sql/copy/partitioned/hive_partition_escape.test",
-        "test/sql/export/export_indexes.test",
         "test/sql/function/list/lambdas/arrow/table_functions_deprecated.test",
         "test/sql/function/list/lambdas/table_functions.test",
         "test/sql/function/list/test_lambda_with_struct_aliases.test",
-        "test/sql/generated_columns/virtual/rename.test",
-        "test/sql/generated_columns/virtual/rename_dependency.test",
-        "test/sql/index/art/constraints/test_art_compound_key_changes.test",
-        "test/sql/index/art/storage/test_art_storage.test",
-        "test/sql/index/art/types/test_art_expression_key.test",
-        "test/sql/index/art/types/test_art_union.test",
-        "test/sql/types/alias/type_with_schema.test",
-        "test/sql/types/struct/create_type_struct.test",
         "test/sql/types/enum/test_alter_enum.test",
-        "test/sql/types/enum/test_enum_schema.test",
         "test/sql/types/enum/test_enum_structs.test"
       ]
     },
     {
       "reason": "FIXME: Wrong result in query.",
       "paths": [
-        "test/sql/index/art/storage/test_art_duckdb_versions.test",
         "test/sql/storage/update/nop_update_tpch.test_slow",
         "test/sql/storage/optimistic_write/optimistic_write.test_slow",
         "test/sql/index/art/storage/test_art_reclaim_storage_pk_fk.test_slow",
@@ -105,12 +73,6 @@
       "paths": [
         "test/sql/alter/add_pk/test_add_pk_with_generated_column.test",
         "test/sql/storage/optimistic_write/optimistic_write_alter_type.test_slow"
-      ]
-    },
-    {
-      "reason": "FIXME: Query unexpectedly succeeded/failed.",
-      "paths": [
-        "test/fuzzer/sqlsmith/nullif_map_with_config.test"
       ]
     }
   ]


### PR DESCRIPTION
The 54 test configs carry 1853 skip_tests entries. 231 of them have a reason that admits ignorance - TODO, Unknown failure, FIXME: crash., FIXME: binding bug., FIXME: Wrong result in query. Re-running the 191 non-slow ones with skip_tests stripped shows 75 now pass, 116 still fail and 20 name a test file that no longer exists.

Here I iterated on the ones that looks to be now supporting, and confirmed passing with the config's skip list stripped, then re-confirmed against the edited config itself.
Let's clean this list, that has a tendency to rot, and let's see what CI thinks (CI passing is the main oracle here).