### PR TITLE
Prune hive partition directories during glob

### DIFF
--- a/src/common/hive_partitioning.cpp
+++ b/src/common/hive_partitioning.cpp
@@ -8,6 +8,7 @@
 #include "duckdb/planner/expression_iterator.hpp"
 #include "duckdb/planner/table_filter.hpp"
 #include "duckdb/common/multi_file/multi_file_list.hpp"
+#include "duckdb/common/multi_file/multi_file_options.hpp"
 #include "duckdb/common/vector/flat_vector.hpp"
 
 namespace duckdb {
@@ -82,6 +83,34 @@ ConvertKnownColRefToConstants(ClientContext &context, unique_ptr<Expression> &ex
 	}
 }
 
+//! The result of evaluating a single filter using only the values that are known from a path
+enum class PathFilterResult : uint8_t {
+	//! The filter cannot be evaluated using only the known values - the path might still match
+	UNKNOWN,
+	//! The filter evaluates to true for every file below the path
+	MATCH,
+	//! The filter evaluates to false for every file below the path - it can be pruned
+	PRUNE
+};
+
+//! Evaluates a filter using only the values that are known from a path
+static PathFilterResult
+EvaluateFilterOnPath(ClientContext &context, const Expression &filter,
+                     const unordered_map<ProjectionIndex, PartitioningColumnValue> &known_values,
+                     TableIndex table_index) {
+	auto filter_copy = filter.Copy();
+	ConvertKnownColRefToConstants(context, filter_copy, known_values, table_index);
+	Value result_value;
+	if (!filter_copy->IsScalar() || !filter_copy->IsFoldable() ||
+	    !ExpressionExecutor::TryEvaluateScalar(context, *filter_copy, result_value)) {
+		return PathFilterResult::UNKNOWN;
+	}
+	if (result_value.IsNull() || !result_value.GetValue<bool>()) {
+		return PathFilterResult::PRUNE;
+	}
+	return PathFilterResult::MATCH;
+}
+
 string HivePartitioning::Escape(const string &input) {
 	return StringUtil::URLEncode(input);
 }
@@ -129,6 +158,20 @@ std::map<string, string> HivePartitioning::Parse(const string &filename) {
 	return result;
 }
 
+HivePartitioningFilterInfo HivePartitioning::GetFilterInfo(const MultiFileOptions &options,
+                                                           const MultiFilePushdownInfo &info) {
+	HivePartitioningFilterInfo filter_info;
+	for (idx_t i = 0; i < info.column_ids.size(); i++) {
+		if (IsVirtualColumn(info.column_ids[i])) {
+			continue;
+		}
+		filter_info.column_map.insert({info.column_names[info.column_ids[i]].GetIdentifierName(), i});
+	}
+	filter_info.hive_enabled = options.hive_partitioning;
+	filter_info.filename_enabled = options.filename;
+	return filter_info;
+}
+
 Value HivePartitioning::GetValue(ClientContext &context, const string &key, const string &str_val,
                                  const LogicalType &type) {
 	// On SQLNULL, DuckDB writes "__HIVE_DEFAULT_PARTITION__", instead of string version "NULL".
@@ -157,12 +200,45 @@ Value HivePartitioning::GetValue(ClientContext &context, const string &key, cons
 	return value;
 }
 
+HivePathFilter::HivePathFilter(ClientContext &context, const vector<unique_ptr<Expression>> &filters_p,
+                               HivePartitioningFilterInfo filter_info_p, TableIndex table_index)
+    : context(context), filter_info(std::move(filter_info_p)), table_index(table_index) {
+	for (auto &filter : filters_p) {
+		filters.push_back(filter->Copy());
+	}
+	// a partial path is not a filename - only the hive partition keys it contains are known
+	filter_info.filename_enabled = false;
+}
+
+bool HivePathFilter::PrunePath(const string &path) {
+	// partitions are only parsed from components that are followed by a separator - add the separator of the directory
+	auto known_values = GetKnownColumnValues(path + "/", filter_info);
+	for (idx_t i = 0; i < filters.size(); i++) {
+		PathFilterResult result;
+		try {
+			result = EvaluateFilterOnPath(context, *filters[i], known_values, table_index);
+		} catch (std::exception &) {
+			// a directory can hold a partition value that does not convert to the type of the column - only the files
+			// that are actually read should report that, so leave the path alone
+			continue;
+		}
+		if (result != PathFilterResult::PRUNE) {
+			continue;
+		}
+		lock_guard<mutex> guard(lock);
+		pruning_filters.insert(i);
+		pruned_path_count++;
+		return true;
+	}
+	return false;
+}
+
 // TODO: this can still be improved by removing the parts of filter expressions that are true for all remaining files.
 //		 currently, only expressions that cannot be evaluated during pushdown are removed.
 void HivePartitioning::ApplyFiltersToFileList(ClientContext &context, vector<OpenFileInfo> &files,
                                               vector<unique_ptr<Expression>> &filters,
                                               const HivePartitioningFilterInfo &filter_info,
-                                              MultiFilePushdownInfo &info) {
+                                              MultiFilePushdownInfo &info, optional_ptr<HivePathFilter> path_filter) {
 	vector<OpenFileInfo> pruned_files;
 	vector<bool> have_preserved_filter(filters.size(), false);
 	vector<unique_ptr<Expression>> pruned_filters;
@@ -173,6 +249,18 @@ void HivePartitioning::ApplyFiltersToFileList(ClientContext &context, vector<Ope
 		return;
 	}
 
+	if (path_filter) {
+		// filters that already pruned paths while the file list was expanded are file filters as well
+		for (auto filter_idx : path_filter->GetPruningFilters()) {
+			info.extra_info.file_filters += filters[filter_idx]->ToString();
+			filters_applied_to_files.insert(filter_idx);
+		}
+		auto pruned_path_count = path_filter->GetPrunedPathCount();
+		if (pruned_path_count > 0) {
+			info.extra_info.pruned_directories = pruned_path_count;
+		}
+	}
+
 	for (idx_t i = 0; i < files.size(); i++) {
 		auto &file = files[i];
 		bool should_prune_file = false;
@@ -180,19 +268,15 @@ void HivePartitioning::ApplyFiltersToFileList(ClientContext &context, vector<Ope
 
 		for (idx_t j = 0; j < filters.size(); j++) {
 			auto &filter = filters[j];
-			unique_ptr<Expression> filter_copy = filter->Copy();
-			ConvertKnownColRefToConstants(context, filter_copy, known_values, table_index);
-			// Evaluate the filter, if it can be evaluated here, we can not prune this filter
-			Value result_value;
-
-			if (!filter_copy->IsScalar() || !filter_copy->IsFoldable() ||
-			    !ExpressionExecutor::TryEvaluateScalar(context, *filter_copy, result_value)) {
+			switch (EvaluateFilterOnPath(context, *filter, known_values, table_index)) {
+			case PathFilterResult::UNKNOWN:
 				// can not be evaluated only with the filename/hive columns added, we can not prune this filter
 				if (!have_preserved_filter[j]) {
 					pruned_filters.emplace_back(filter->Copy());
 					have_preserved_filter[j] = true;
 				}
-			} else if (result_value.IsNull() || !result_value.GetValue<bool>()) {
+				break;
+			case PathFilterResult::PRUNE:
 				// filter evaluates to false
 				should_prune_file = true;
 				// convert the filter to a table filter.
@@ -200,6 +284,10 @@ void HivePartitioning::ApplyFiltersToFileList(ClientContext &context, vector<Ope
 					info.extra_info.file_filters += filter->ToString();
 					filters_applied_to_files.insert(j);
 				}
+				break;
+			case PathFilterResult::MATCH:
+				// filter evaluates to true - it does not have to be evaluated again during the scan
+				break;
 			}
 		}
 

--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -12,6 +12,7 @@
 #include "duckdb/main/database.hpp"
 #include "duckdb/logging/file_system_logger.hpp"
 #include "duckdb/logging/log_manager.hpp"
+#include "duckdb/logging/logger.hpp"
 #include "duckdb/common/multi_file/multi_file_list.hpp"
 
 #include <cstdint>
@@ -2180,6 +2181,11 @@ bool LocalGlobResult::ExpandNextPath() const {
 	auto &current_path = next_dir.path;
 	expand_directories.pop();
 
+	if (!is_empty && PathIsPruned(current_path)) {
+		// no file below this directory can match - skip it entirely instead of listing its contents
+		return true;
+	}
+
 	auto &next_split = splits[split_index];
 	bool is_last_component = split_index + 1 == splits.size();
 	auto &next_component = next_split.path;
@@ -2207,7 +2213,10 @@ bool LocalGlobResult::ExpandNextPath() const {
 			}
 		}
 	} else {
-		// glob - need to resolve the glob
+		// glob - need to resolve the glob by listing the contents of the current path
+		if (context) {
+			DUCKDB_LOG_FILE_SYSTEM_LIST(*context, fs, current_path);
+		}
 		if (IsCrawl(next_component)) {
 			if (is_last_component) {
 				// the crawl is the last component - we are looking for files in this directory

--- a/src/common/multi_file/multi_file_list.cpp
+++ b/src/common/multi_file/multi_file_list.cpp
@@ -32,19 +32,12 @@ MultiFilePushdownInfo::MultiFilePushdownInfo(TableIndex table_index, const vecto
 
 // Helper method to do Filter Pushdown into a MultiFileList
 bool PushdownInternal(ClientContext &context, const MultiFileOptions &options, MultiFilePushdownInfo &info,
-                      vector<unique_ptr<Expression>> &filters, vector<OpenFileInfo> &expanded_files) {
-	HivePartitioningFilterInfo filter_info;
-	for (idx_t i = 0; i < info.column_ids.size(); i++) {
-		if (IsVirtualColumn(info.column_ids[i])) {
-			continue;
-		}
-		filter_info.column_map.insert({info.column_names[info.column_ids[i]].GetIdentifierName(), i});
-	}
-	filter_info.hive_enabled = options.hive_partitioning;
-	filter_info.filename_enabled = options.filename;
+                      vector<unique_ptr<Expression>> &filters, vector<OpenFileInfo> &expanded_files,
+                      optional_ptr<HivePathFilter> path_filter) {
+	auto filter_info = HivePartitioning::GetFilterInfo(options, info);
 
 	auto start_files = expanded_files.size();
-	HivePartitioning::ApplyFiltersToFileList(context, expanded_files, filters, filter_info, info);
+	HivePartitioning::ApplyFiltersToFileList(context, expanded_files, filters, filter_info, info, path_filter);
 
 	if (expanded_files.size() != start_files) {
 		return true;
@@ -53,9 +46,30 @@ bool PushdownInternal(ClientContext &context, const MultiFileOptions &options, M
 	return false;
 }
 
-bool PushdownInternal(ClientContext &context, const MultiFileOptions &options, const vector<Identifier> &names,
-                      const vector<LogicalType> &types, const vector<ColumnIndex> &column_indexes,
-                      const TableFilterSet &filters, vector<OpenFileInfo> &expanded_files) {
+// Installs a filter that prunes paths using the hive partition keys they contain, so that directories that can never
+// contain a matching file are never listed while the file list is expanded
+shared_ptr<HivePathFilter> InstallPathFilter(const MultiFileList &file_list, ClientContext &context,
+                                             const MultiFileOptions &options, const MultiFilePushdownInfo &info,
+                                             const vector<unique_ptr<Expression>> &filters) {
+	if (!options.hive_partitioning || !options.hive_directory_pruning) {
+		return nullptr;
+	}
+	if (file_list.GetFileCount().type == FileExpansionType::ALL_FILES_EXPANDED) {
+		// there is nothing left to expand - a path filter can no longer skip anything
+		return nullptr;
+	}
+	auto path_filter = make_shared_ptr<HivePathFilter>(context, filters, HivePartitioning::GetFilterInfo(options, info),
+	                                                   info.table_index);
+	file_list.SetPathFilter(path_filter);
+	return path_filter;
+}
+
+// Helper method to do dynamic Filter Pushdown into a MultiFileList - this expands the list itself, so that the path
+// filter is installed before any directory is listed
+bool PushdownInternal(const MultiFileList &file_list, ClientContext &context, const MultiFileOptions &options,
+                      const vector<Identifier> &names, const vector<LogicalType> &types,
+                      const vector<ColumnIndex> &column_indexes, const TableFilterSet &filters,
+                      vector<OpenFileInfo> &expanded_files) {
 	TableIndex table_index(0);
 	ExtraOperatorInfo extra_info;
 
@@ -77,29 +91,39 @@ bool PushdownInternal(ClientContext &context, const MultiFileOptions &options, c
 		auto filter_expr = expr_filter.ToExpression(*column_ref);
 		filter_expressions.push_back(std::move(filter_expr));
 	}
+	if (filter_expressions.empty()) {
+		// nothing to push down - expanding here would only prevent a later pushdown from pruning paths
+		return false;
+	}
+	// install the path filter before expanding - this way directories that can never match are never listed
+	auto path_filter = InstallPathFilter(file_list, context, options, info, filter_expressions);
 
-	// call the original PushdownInternal method
-	return PushdownInternal(context, options, info, filter_expressions, expanded_files);
+	// FIXME: don't copy list until first file is filtered
+	expanded_files = file_list.GetAllFiles();
+	return PushdownInternal(context, options, info, filter_expressions, expanded_files, path_filter);
 }
 
 //===--------------------------------------------------------------------===//
 // MultiFileListIterator
 //===--------------------------------------------------------------------===//
-MultiFileListIterationHelper MultiFileList::Files() const {
-	return MultiFileListIterationHelper(*this);
+MultiFileListIterationHelper MultiFileList::Files(MultiFileListScanType scan_type) const {
+	return MultiFileListIterationHelper(*this, scan_type);
 }
 
-MultiFileListIterationHelper::MultiFileListIterationHelper(const MultiFileList &file_list_p) : file_list(file_list_p) {
+MultiFileListIterationHelper::MultiFileListIterationHelper(const MultiFileList &file_list_p,
+                                                           MultiFileListScanType scan_type)
+    : file_list(file_list_p), scan_type(scan_type) {
 }
 
 MultiFileListIterationHelper::MultiFileListIterator::MultiFileListIterator(
-    optional_ptr<const MultiFileList> file_list_p)
+    optional_ptr<const MultiFileList> file_list_p, MultiFileListScanType scan_type)
     : file_list(file_list_p) {
 	if (!file_list) {
 		return;
 	}
 
 	file_list->InitializeScan(file_scan_data);
+	file_scan_data.scan_type = scan_type;
 	if (!file_list->Scan(file_scan_data, current_file)) {
 		// There is no first file: move iterator to nop state
 		file_list = nullptr;
@@ -121,10 +145,10 @@ void MultiFileListIterationHelper::MultiFileListIterator::Next() {
 
 MultiFileListIterationHelper::MultiFileListIterator MultiFileListIterationHelper::begin() { // NOLINT: match stl API
 	return MultiFileListIterationHelper::MultiFileListIterator(
-	    file_list.GetExpandResult() == FileExpandResult::NO_FILES ? nullptr : &file_list);
+	    file_list.GetExpandResult() == FileExpandResult::NO_FILES ? nullptr : &file_list, scan_type);
 }
 MultiFileListIterationHelper::MultiFileListIterator MultiFileListIterationHelper::end() { // NOLINT: match stl API
-	return MultiFileListIterationHelper::MultiFileListIterator(nullptr);
+	return MultiFileListIterationHelper::MultiFileListIterator(nullptr, scan_type);
 }
 
 MultiFileListIterationHelper::MultiFileListIterator &MultiFileListIterationHelper::MultiFileListIterator::operator++() {
@@ -172,6 +196,16 @@ MultiFileCount MultiFileList::GetFileCount(idx_t min_exact_count) const {
 	return MultiFileCount(GetTotalFileCount());
 }
 
+MultiFileListIterationHelper MultiFileList::SampleFiles(optional_idx min_files) const {
+	if (!min_files.IsValid()) {
+		// no sample - expand the files while iterating over them
+		return Files();
+	}
+	// expand at least "min_files", then iterate over every file that is available without any further I/O
+	GetFileCount(min_files.GetIndex());
+	return Files(MultiFileListScanType::FETCH_IF_AVAILABLE);
+}
+
 bool MultiFileList::Scan(MultiFileListScanData &iterator, OpenFileInfo &result_file) const {
 	D_ASSERT(iterator.current_file_idx != DConstants::INVALID_INDEX);
 	if (iterator.scan_type == MultiFileListScanType::FETCH_IF_AVAILABLE &&
@@ -196,10 +230,16 @@ unique_ptr<MultiFileList> MultiFileList::ComplexFilterPushdown(ClientContext &co
 	if (!options.hive_partitioning && !options.filename) {
 		return nullptr;
 	}
+	if (filters.empty()) {
+		// nothing to push down - expanding here would only prevent a later pushdown from pruning paths
+		return nullptr;
+	}
+	// install the path filter before expanding - this way directories that can never match are never listed
+	auto path_filter = InstallPathFilter(*this, context, options, info, filters);
 
 	// FIXME: don't copy list until first file is filtered
 	auto file_copy = GetAllFiles();
-	auto res = PushdownInternal(context, options, info, filters, file_copy);
+	auto res = PushdownInternal(context, options, info, filters, file_copy, path_filter);
 	if (res) {
 		return make_uniq<SimpleMultiFileList>(std::move(file_copy));
 	}
@@ -218,15 +258,22 @@ MultiFileList::DynamicFilterPushdown(MultiFileDynamicPushdownInfo &dynamic_pushd
 	if (!options.hive_partitioning && !options.filename) {
 		return nullptr;
 	}
-
-	// FIXME: don't copy list until first file is filtered
-	auto file_copy = GetAllFiles();
-	auto res = PushdownInternal(context, options, names, types, column_indexes, filters, file_copy);
+	vector<OpenFileInfo> file_copy;
+	auto res = PushdownInternal(*this, context, options, names, types, column_indexes, filters, file_copy);
 	if (res) {
 		return make_uniq<SimpleMultiFileList>(std::move(file_copy));
 	}
 
 	return nullptr;
+}
+
+void MultiFileList::SetPathFilter(const shared_ptr<HivePathFilter> &filter) const {
+	path_filter = filter;
+}
+
+bool MultiFileList::PathIsPruned(const string &path) const {
+	auto filter = path_filter.lock();
+	return filter && filter->PrunePath(path);
 }
 
 unique_ptr<NodeStatistics> MultiFileList::GetCardinality(ClientContext &context) const {
@@ -373,6 +420,15 @@ vector<OpenFileInfo> GlobMultiFileList::GetDisplayFileList(optional_idx max_file
 	return result;
 }
 
+void GlobMultiFileList::SetPathFilter(const shared_ptr<HivePathFilter> &filter) const {
+	lock_guard<mutex> lck(lock);
+	// the globs are expanded by the underlying file lists - they do the actual pruning
+	for (auto &file_list : file_lists) {
+		file_list->SetPathFilter(filter);
+	}
+	MultiFileList::SetPathFilter(filter);
+}
+
 bool GlobMultiFileList::ExpandNextPath() const {
 	if (current_glob >= globs.size()) {
 		return false;
@@ -381,6 +437,7 @@ bool GlobMultiFileList::ExpandNextPath() const {
 		// glob is not yet started for this file - start it and initiate the scan over this file
 		auto &fs = FileSystem::GetFileSystem(context);
 		auto glob_result = fs.GlobFileList(globs[current_glob], glob_input);
+		glob_result->SetPathFilter(path_filter.lock());
 		scan_state = MultiFileListScanData();
 		glob_result->InitializeScan(scan_state);
 		file_lists.push_back(std::move(glob_result));

--- a/src/common/multi_file/multi_file_reader.cpp
+++ b/src/common/multi_file/multi_file_reader.cpp
@@ -8,6 +8,7 @@
 #include "duckdb/function/function_set.hpp"
 #include "duckdb/function/table_function.hpp"
 #include "duckdb/main/config.hpp"
+#include "duckdb/main/settings.hpp"
 #include "duckdb/common/multi_file/multi_file_column_mapper.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
@@ -88,6 +89,7 @@ Value MultiFileReader::CreateValueFromFileList(const vector<string> &file_list) 
 void MultiFileReader::AddParameters(TableFunction &table_function) {
 	table_function.named_parameters["filename"] = LogicalType::ANY;
 	table_function.named_parameters["hive_partitioning"] = LogicalType::BOOLEAN;
+	table_function.named_parameters["hive_directory_pruning"] = LogicalType::BOOLEAN;
 	table_function.named_parameters["union_by_name"] = LogicalType::BOOLEAN;
 	table_function.named_parameters["hive_types"] = LogicalType::ANY;
 	table_function.named_parameters["hive_types_autocast"] = LogicalType::BOOLEAN;
@@ -157,6 +159,12 @@ bool MultiFileReader::ParseOption(const Identifier &key, const Value &val, Multi
 		}
 		options.hive_partitioning = BooleanValue::Get(val);
 		options.auto_detect_hive_partitioning = false;
+	} else if (key == "hive_directory_pruning") {
+		if (val.IsNull()) {
+			throw InvalidInputException("Cannot use NULL as argument for %s", key);
+		}
+		options.hive_directory_pruning = BooleanValue::Get(val);
+		options.explicit_hive_directory_pruning = true;
 	} else if (key == "union_by_name") {
 		if (val.IsNull()) {
 			throw InvalidInputException("Cannot use NULL as argument for %s", key);
@@ -249,8 +257,8 @@ void MultiFileReader::BindOptions(MultiFileOptions &options, MultiFileList &file
 	if (options.hive_partitioning) {
 		D_ASSERT(files.GetExpandResult() != FileExpandResult::NO_FILES);
 		auto partitions = HivePartitioning::Parse(files.GetFirstFile().path);
-		// verify that all files have the same hive partitioning scheme
-		for (const auto &file : files.Files()) {
+		// verify that the sampled files have the same hive partitioning scheme
+		for (const auto &file : files.SampleFiles(options.GetBindSampleSize())) {
 			auto file_partitions = HivePartitioning::Parse(file.path);
 			for (auto &part_info : partitions) {
 				if (file_partitions.find(part_info.first) == file_partitions.end()) {
@@ -709,6 +717,7 @@ void MultiFileOptions::AddBatchInfo(BindInfo &bind_info) const {
 	bind_info.InsertOption("filename", Value(filename_column));
 	bind_info.InsertOption("hive_partitioning", Value::BOOLEAN(hive_partitioning));
 	bind_info.InsertOption("auto_detect_hive_partitioning", Value::BOOLEAN(auto_detect_hive_partitioning));
+	bind_info.InsertOption("hive_directory_pruning", Value::BOOLEAN(hive_directory_pruning));
 	bind_info.InsertOption("union_by_name", Value::BOOLEAN(union_by_name));
 	bind_info.InsertOption("hive_types_autocast", Value::BOOLEAN(hive_types_autocast));
 	bind_info.InsertOption("allow_empty", Value::BOOLEAN(allow_empty));
@@ -736,7 +745,23 @@ void UnionByName::CombineUnionTypes(const vector<string> &col_names, const vecto
 	}
 }
 
-bool MultiFileOptions::AutoDetectHivePartitioningInternal(MultiFileList &files, ClientContext &context) {
+void MultiFileOptions::ResolveHiveDirectoryPruning(ClientContext &context) {
+	if (explicit_hive_directory_pruning) {
+		return;
+	}
+	hive_directory_pruning = Settings::Get<HiveDirectoryPruningSetting>(context);
+}
+
+optional_idx MultiFileOptions::GetBindSampleSize() const {
+	if (!hive_directory_pruning) {
+		// no directory is pruned afterwards - inspect every file
+		return optional_idx();
+	}
+	return HivePartitioning::BIND_SAMPLE_SIZE;
+}
+
+bool MultiFileOptions::AutoDetectHivePartitioningInternal(MultiFileList &files, ClientContext &context,
+                                                          optional_idx sample_size) {
 	auto first_file = files.GetFirstFile();
 	auto partitions = HivePartitioning::Parse(first_file.path);
 	if (partitions.empty()) {
@@ -744,7 +769,7 @@ bool MultiFileOptions::AutoDetectHivePartitioningInternal(MultiFileList &files, 
 		return false;
 	}
 
-	for (const auto &file : files.Files()) {
+	for (const auto &file : files.SampleFiles(sample_size)) {
 		auto new_partitions = HivePartitioning::Parse(file.path);
 		if (new_partitions.size() != partitions.size()) {
 			// partition count mismatch
@@ -764,7 +789,7 @@ void MultiFileOptions::AutoDetectHiveTypesInternal(MultiFileList &files, ClientC
 	const LogicalType candidates[] = {LogicalType::DATE, LogicalType::TIMESTAMP, LogicalType::BIGINT};
 
 	unordered_map<string, LogicalType> detected_types;
-	for (const auto &file : files.Files()) {
+	for (const auto &file : files.SampleFiles(GetBindSampleSize())) {
 		auto partitions = HivePartitioning::Parse(file.path);
 		if (partitions.empty()) {
 			return;
@@ -820,7 +845,7 @@ void MultiFileOptions::AutoDetectHivePartitioning(MultiFileList &files, ClientCo
 		auto_detect_hive_partitioning = false;
 	}
 	if (auto_detect_hive_partitioning) {
-		hive_partitioning = AutoDetectHivePartitioningInternal(files, context);
+		hive_partitioning = AutoDetectHivePartitioningInternal(files, context, GetBindSampleSize());
 	}
 	if (hive_partitioning && hive_types_autocast) {
 		AutoDetectHiveTypesInternal(files, context);

--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -853,6 +853,13 @@
         "struct": "GeometryMinimumShreddingSize"
     },
     {
+        "name": "hive_directory_pruning",
+        "description": "Whether or not directories whose hive partition keys cannot match a filter are skipped without being listed. Can be overridden per scan with the hive_directory_pruning named parameter.",
+        "type": "BOOLEAN",
+        "default_scope": "local",
+        "default_value": "false"
+    },
+    {
         "name": "home_directory",
         "description": "Sets the home directory used by the system",
         "type": "VARCHAR",

--- a/src/execution/operator/scan/physical_table_scan.cpp
+++ b/src/execution/operator/scan/physical_table_scan.cpp
@@ -374,6 +374,9 @@ InsertionOrderPreservingMap<string> PhysicalTableScan::ParamsToString() const {
 			result["Scanning Files"] = StringUtil::Format("%llu/%llu", extra_info.filtered_files.GetIndex(),
 			                                              extra_info.total_files.GetIndex());
 		}
+		if (extra_info.pruned_directories.IsValid()) {
+			result["Pruned Directories"] = to_string(extra_info.pruned_directories.GetIndex());
+		}
 	}
 
 	SetEstimatedCardinality(result, estimated_cardinality);

--- a/src/include/duckdb/common/extra_operator_info.hpp
+++ b/src/include/duckdb/common/extra_operator_info.hpp
@@ -29,6 +29,9 @@ public:
 		if (extra_info.filtered_files.IsValid()) {
 			filtered_files = extra_info.filtered_files.GetIndex();
 		}
+		if (extra_info.pruned_directories.IsValid()) {
+			pruned_directories = extra_info.pruned_directories.GetIndex();
+		}
 	}
 	ExtraOperatorInfo &operator=(ExtraOperatorInfo &&extra_info) noexcept {
 		if (this != &extra_info) {
@@ -39,6 +42,9 @@ public:
 			if (extra_info.filtered_files.IsValid()) {
 				filtered_files = extra_info.filtered_files.GetIndex();
 			}
+			if (extra_info.pruned_directories.IsValid()) {
+				pruned_directories = extra_info.pruned_directories.GetIndex();
+			}
 			sample_options = std::move(extra_info.sample_options);
 		}
 		return *this;
@@ -46,15 +52,19 @@ public:
 
 	bool operator==(const ExtraOperatorInfo &other) const {
 		return file_filters == other.file_filters && total_files == other.total_files &&
-		       filtered_files == other.filtered_files && sample_options == other.sample_options;
+		       filtered_files == other.filtered_files && pruned_directories == other.pruned_directories &&
+		       sample_options == other.sample_options;
 	}
 
 	//! Filters that have been pushed down into the main file list
 	string file_filters;
-	//! Total size of file list
+	//! Total size of file list - only counts the files that were expanded, directories that were pruned before they
+	//! were listed are not part of this
 	optional_idx total_files;
 	//! Size of file list after applying filters
 	optional_idx filtered_files;
+	//! Number of directories that were skipped without being listed because their hive partition keys could not match
+	optional_idx pruned_directories;
 	//! Sample options that have been pushed down into the table scan
 	unique_ptr<SampleOptions> sample_options;
 

--- a/src/include/duckdb/common/hive_partitioning.hpp
+++ b/src/include/duckdb/common/hive_partitioning.hpp
@@ -10,11 +10,13 @@
 
 #include "duckdb/common/types/column/partitioned_column_data.hpp"
 #include "duckdb/common/open_file_info.hpp"
+#include "duckdb/common/table_index.hpp"
 #include "duckdb/original/std/sstream.hpp"
 
 #include <iostream>
 
 namespace duckdb {
+struct MultiFileOptions;
 struct MultiFilePushdownInfo;
 
 struct HivePartitioningFilterInfo {
@@ -23,17 +25,62 @@ struct HivePartitioningFilterInfo {
 	bool filename_enabled;
 };
 
+//! Prunes paths for which the filters evaluate to false using only the hive partition keys found in the path itself.
+//! Because a hive partition key of a directory also applies to every file below it, this can be used to skip entire
+//! directories while a file list is being expanded.
+class HivePathFilter {
+public:
+	HivePathFilter(ClientContext &context, const vector<unique_ptr<Expression>> &filters,
+	               HivePartitioningFilterInfo filter_info, TableIndex table_index);
+
+	//! Returns true if no file below this path can match - i.e. the path does not need to be expanded
+	//! The path is a directory that is passed in without a trailing separator
+	bool PrunePath(const string &path);
+
+	//! The filters (by index) that have been used to prune paths so far
+	unordered_set<idx_t> GetPruningFilters() {
+		lock_guard<mutex> guard(lock);
+		return pruning_filters;
+	}
+
+	//! The number of paths that have been pruned so far
+	idx_t GetPrunedPathCount() {
+		lock_guard<mutex> guard(lock);
+		return pruned_path_count;
+	}
+
+private:
+	ClientContext &context;
+	//! Copies of the filters - the filters of the pushdown are modified while we are pruning
+	vector<unique_ptr<Expression>> filters;
+	HivePartitioningFilterInfo filter_info;
+	TableIndex table_index;
+	mutex lock;
+	unordered_set<idx_t> pruning_filters;
+	idx_t pruned_path_count = 0;
+};
+
 class HivePartitioning {
+public:
+	//! The number of files that is inspected to verify and auto-detect the hive partitioning scheme while binding
+	//! Binding only looks at a sample: expanding the entire file list there would defeat any filter pushdown that can
+	//! prune (and hence never list) entire directories afterwards
+	static constexpr idx_t BIND_SAMPLE_SIZE = 100;
+
 public:
 	//! Parse a filename that follows the hive partitioning scheme
 	DUCKDB_API static std::map<string, string> Parse(const string &filename);
+	//! Construct the filter info describing which columns can be obtained from the path of a file
+	DUCKDB_API static HivePartitioningFilterInfo GetFilterInfo(const MultiFileOptions &options,
+	                                                           const MultiFilePushdownInfo &info);
 	//! Prunes a list of filenames based on a set of filters, can be used by TableFunctions in the
 	//! pushdown_complex_filter function to skip files with filename-based filters. Also removes the filters that always
-	//! evaluate to true.
+	//! evaluate to true. Filters that already pruned paths through "path_filter" are reported as file filters as well.
 	DUCKDB_API static void ApplyFiltersToFileList(ClientContext &context, vector<OpenFileInfo> &files,
 	                                              vector<unique_ptr<Expression>> &filters,
 	                                              const HivePartitioningFilterInfo &filter_info,
-	                                              MultiFilePushdownInfo &info);
+	                                              MultiFilePushdownInfo &info,
+	                                              optional_ptr<HivePathFilter> path_filter = nullptr);
 
 	DUCKDB_API static Value GetValue(ClientContext &context, const string &key, const string &value,
 	                                 const LogicalType &type);

--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -112,6 +112,7 @@ public:
 		result->file_list = std::move(multi_file_list_p);
 		// auto-detect hive partitioning
 		result->file_options = std::move(file_options_p);
+		result->file_options.ResolveHiveDirectoryPruning(context);
 		result->bind_data = interface.InitializeBindData(*result, std::move(options_p));
 		result->interface = std::move(interface_p);
 

--- a/src/include/duckdb/common/multi_file/multi_file_list.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_list.hpp
@@ -16,6 +16,7 @@
 #include "duckdb/common/enums/file_glob_options.hpp"
 
 namespace duckdb {
+class HivePathFilter;
 class MultiFileList;
 class NodeStatistics;
 class LogicalGet;
@@ -43,17 +44,19 @@ struct MultiFileCount {
 
 class MultiFileListIterationHelper {
 public:
-	DUCKDB_API explicit MultiFileListIterationHelper(const MultiFileList &collection);
+	DUCKDB_API explicit MultiFileListIterationHelper(const MultiFileList &collection, MultiFileListScanType scan_type);
 
 private:
 	const MultiFileList &file_list;
+	//! Whether files that are not expanded yet are fetched, or the iteration stops at the last available file
+	MultiFileListScanType scan_type;
 
 private:
 	class MultiFileListIterator;
 
 	class MultiFileListIterator {
 	public:
-		DUCKDB_API explicit MultiFileListIterator(optional_ptr<const MultiFileList> file_list);
+		DUCKDB_API MultiFileListIterator(optional_ptr<const MultiFileList> file_list, MultiFileListScanType scan_type);
 
 		optional_ptr<const MultiFileList> file_list;
 		MultiFileListScanData file_scan_data;
@@ -91,8 +94,13 @@ public:
 	MultiFileList();
 	virtual ~MultiFileList();
 
-	//! Get Iterator over the files for pretty for loops
-	MultiFileListIterationHelper Files() const;
+	//! Get Iterator over the files for pretty for loops - by default every file is expanded while iterating,
+	//! "FETCH_IF_AVAILABLE" stops at the last file that is available without any further I/O
+	MultiFileListIterationHelper Files(MultiFileListScanType scan_type = MultiFileListScanType::ALWAYS_FETCH) const;
+	//! Get Iterator over a sample of the files: at least "min_files", plus any further files that are already
+	//! available - as opposed to Files() this never forces the entire list to be expanded
+	//! When "min_files" is not set every file is iterated over instead
+	MultiFileListIterationHelper SampleFiles(optional_idx min_files) const;
 
 	//! Initialize a sequential scan over a file list
 	void InitializeScan(MultiFileListScanData &iterator) const;
@@ -123,11 +131,23 @@ public:
 	virtual unique_ptr<NodeStatistics> GetCardinality(ClientContext &context) const;
 	virtual unique_ptr<MultiFileList> Copy() const;
 
+	//! Set the filter used to skip paths while the list is expanded - lists that expand paths lazily can use this to
+	//! avoid listing directories that can never contain a matching file. The list only observes the filter: it applies
+	//! for as long as the caller holds on to it
+	virtual void SetPathFilter(const shared_ptr<HivePathFilter> &filter) const;
+
 protected:
 	//! Whether or not the file at the index is available instantly - or if this requires additional I/O
 	virtual bool FileIsAvailable(idx_t i) const;
 	//! Get the i-th expanded file
 	virtual OpenFileInfo GetFile(idx_t i) const = 0;
+	//! Whether or not the given path can be skipped according to the path filter
+	bool PathIsPruned(const string &path) const;
+
+protected:
+	//! The path filter - only affects which paths are expanded, hence it can be set on a const file list
+	//! Held weakly so that it expires together with the pushdown that installed it
+	mutable weak_ptr<HivePathFilter> path_filter;
 
 public:
 	template <class TARGET>
@@ -198,6 +218,7 @@ public:
 	GlobMultiFileList(ClientContext &context, vector<string> globs, FileGlobInput input);
 
 	vector<OpenFileInfo> GetDisplayFileList(optional_idx max_files = optional_idx()) const override;
+	void SetPathFilter(const shared_ptr<HivePathFilter> &filter) const override;
 
 protected:
 	bool ExpandNextPath() const override;

--- a/src/include/duckdb/common/multi_file/multi_file_options.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_options.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "duckdb/common/case_insensitive_map.hpp"
+#include "duckdb/common/optional_idx.hpp"
 #include "duckdb/common/types.hpp"
 #include "duckdb/common/hive_partitioning.hpp"
 
@@ -22,6 +23,10 @@ struct MultiFileOptions {
 	bool filename = false;
 	bool hive_partitioning = false;
 	bool auto_detect_hive_partitioning = true;
+	//! Whether directories whose hive partition keys cannot match a filter are skipped without being listed
+	bool hive_directory_pruning = false;
+	//! Whether hive_directory_pruning was set explicitly - if it was not, the setting of the same name decides
+	bool explicit_hive_directory_pruning = false;
 	bool union_by_name = false;
 	bool hive_types_autocast = true;
 	bool allow_empty = false;
@@ -39,8 +44,15 @@ struct MultiFileOptions {
 	DUCKDB_API static MultiFileOptions Deserialize(Deserializer &source);
 	DUCKDB_API void AddBatchInfo(BindInfo &bind_info) const;
 	DUCKDB_API void AutoDetectHivePartitioning(MultiFileList &files, ClientContext &context);
-	DUCKDB_API static bool AutoDetectHivePartitioningInternal(MultiFileList &files, ClientContext &context);
+	DUCKDB_API static bool AutoDetectHivePartitioningInternal(MultiFileList &files, ClientContext &context,
+	                                                          optional_idx sample_size = optional_idx());
 	DUCKDB_API void AutoDetectHiveTypesInternal(MultiFileList &files, ClientContext &context);
+	//! Take over the value of the "hive_directory_pruning" setting unless the option was given explicitly - must be
+	//! called once the options have been parsed, directories are never pruned without it
+	DUCKDB_API void ResolveHiveDirectoryPruning(ClientContext &context);
+	//! The number of files that is inspected while binding - only a sample when directories can still be pruned
+	//! afterwards, since expanding the entire file list there would defeat that pruning
+	DUCKDB_API optional_idx GetBindSampleSize() const;
 	DUCKDB_API void VerifyHiveTypesArePartitions(const std::map<string, string> &partitions) const;
 	DUCKDB_API LogicalType GetHiveLogicalType(const string &hive_partition_column) const;
 	DUCKDB_API Value GetHivePartitionValue(const string &base, const string &entry, ClientContext &context) const;

--- a/src/include/duckdb/logging/file_system_logger.hpp
+++ b/src/include/duckdb/logging/file_system_logger.hpp
@@ -29,4 +29,7 @@ namespace duckdb {
 #define DUCKDB_LOG_FILE_SYSTEM_OPEN(HANDLE)              DUCKDB_LOG_FILE_SYSTEM(HANDLE, "OPEN");
 #define DUCKDB_LOG_FILE_SYSTEM_CLOSE(HANDLE)             DUCKDB_LOG_FILE_SYSTEM(HANDLE, "CLOSE");
 
+// Macro for logging operations on a path, for which there is no file handle to log to
+#define DUCKDB_LOG_FILE_SYSTEM_LIST(SOURCE, FS, PATH) DUCKDB_LOG(SOURCE, FileSystemLogType, FS, PATH, "LIST");
+
 } // namespace duckdb

--- a/src/include/duckdb/logging/log_type.hpp
+++ b/src/include/duckdb/logging/log_type.hpp
@@ -14,6 +14,7 @@
 namespace duckdb {
 
 struct FileHandle;
+class FileSystem;
 struct BaseRequest;
 struct HTTPResponse;
 class PhysicalOperator;
@@ -74,6 +75,8 @@ public:
 
 	static string ConstructLogMessage(const FileHandle &handle, const string &op, int64_t bytes, idx_t pos);
 	static string ConstructLogMessage(const FileHandle &handle, const string &op);
+	//! Log an operation on a path for which no file handle exists (e.g. listing a directory)
+	static string ConstructLogMessage(FileSystem &fs, const string &path, const string &op);
 };
 
 class HTTPLogType : public LogType {

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -1280,6 +1280,18 @@ struct GeometryMinimumShreddingSize {
 	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
+struct HiveDirectoryPruningSetting {
+	using RETURN_TYPE = bool;
+	static constexpr const char *Name = "hive_directory_pruning";
+	static constexpr const char *Description =
+	    "Whether or not directories whose hive partition keys cannot match a filter are skipped without being listed. "
+	    "Can be overridden per scan with the hive_directory_pruning named parameter.";
+	static constexpr const char *InputType = "BOOLEAN";
+	static constexpr const char *DefaultValue = "false";
+	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
+	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+};
+
 struct HomeDirectorySetting {
 	using RETURN_TYPE = string;
 	static constexpr const char *Name = "home_directory";

--- a/src/include/duckdb/storage/serialization/nodes.json
+++ b/src/include/duckdb/storage/serialization/nodes.json
@@ -694,6 +694,18 @@
         "id": 107,
         "name": "allow_empty",
         "type": "bool"
+      },
+      {
+        "id": 108,
+        "name": "hive_directory_pruning",
+        "type": "bool",
+        "default": "false"
+      },
+      {
+        "id": 109,
+        "name": "explicit_hive_directory_pruning",
+        "type": "bool",
+        "default": "false"
       }
     ],
     "pointer_type": "none"
@@ -1351,6 +1363,12 @@
         "id": 103,
         "name": "sample_options",
         "type": "unique_ptr<SampleOptions>"
+      },
+      {
+        "id": 104,
+        "name": "pruned_directories",
+        "type": "optional_idx",
+        "default": "optional_idx()"
       }
     ],
     "pointer_type": "none"

--- a/src/logging/log_types.cpp
+++ b/src/logging/log_types.cpp
@@ -42,8 +42,10 @@ string FileSystemLogType::ConstructLogMessage(const FileHandle &handle, const st
 	                          handle.file_system.GetName(), handle.path, op, bytes, pos);
 }
 string FileSystemLogType::ConstructLogMessage(const FileHandle &handle, const string &op) {
-	return StringUtil::Format("{\"fs\":\"%s\",\"path\":\"%s\",\"op\":\"%s\"}", handle.file_system.GetName(),
-	                          handle.path, op);
+	return ConstructLogMessage(handle.file_system, handle.path, op);
+}
+string FileSystemLogType::ConstructLogMessage(FileSystem &fs, const string &path, const string &op) {
+	return StringUtil::Format("{\"fs\":\"%s\",\"path\":\"%s\",\"op\":\"%s\"}", fs.GetName(), path, op);
 }
 
 LogicalType FileSystemLogType::GetLogType() {

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -173,6 +173,7 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_SETTING(ForceUpdateToDelAndInsertSetting),
     DUCKDB_GLOBAL(ForceVariantShredding),
     DUCKDB_SETTING(GeometryMinimumShreddingSize),
+    DUCKDB_SETTING(HiveDirectoryPruningSetting),
     DUCKDB_SETTING_CALLBACK(HomeDirectorySetting),
     DUCKDB_GLOBAL(HTTPProxySetting),
     DUCKDB_SETTING(HTTPProxyPasswordSetting),
@@ -250,12 +251,12 @@ static const ConfigurationOption internal_options[] = {
 
 static const ConfigurationAlias setting_aliases[] = {DUCKDB_SETTING_ALIAS("configure_metrics", 30),
                                                      DUCKDB_SETTING_ALIAS("custom_profiling_settings", 30),
-                                                     DUCKDB_SETTING_ALIAS("memory_limit", 129),
+                                                     DUCKDB_SETTING_ALIAS("memory_limit", 130),
                                                      DUCKDB_SETTING_ALIAS("null_order", 61),
-                                                     DUCKDB_SETTING_ALIAS("profile_output", 152),
-                                                     DUCKDB_SETTING_ALIAS("user", 171),
+                                                     DUCKDB_SETTING_ALIAS("profile_output", 153),
+                                                     DUCKDB_SETTING_ALIAS("user", 172),
                                                      DUCKDB_SETTING_ALIAS("wal_autocheckpoint", 29),
-                                                     DUCKDB_SETTING_ALIAS("worker_threads", 169),
+                                                     DUCKDB_SETTING_ALIAS("worker_threads", 170),
                                                      FINAL_ALIAS};
 
 vector<ConfigurationOption> DBConfig::GetOptions() {

--- a/src/planner/operator/logical_get.cpp
+++ b/src/planner/operator/logical_get.cpp
@@ -97,6 +97,9 @@ InsertionOrderPreservingMap<string> LogicalGet::ParamsToString() const {
 			result["Scanning Files"] = StringUtil::Format("%llu/%llu", extra_info.filtered_files.GetIndex(),
 			                                              extra_info.total_files.GetIndex());
 		}
+		if (extra_info.pruned_directories.IsValid()) {
+			result["Pruned Directories"] = to_string(extra_info.pruned_directories.GetIndex());
+		}
 	}
 
 	if (function.to_string) {

--- a/src/storage/serialization/serialize_nodes.cpp
+++ b/src/storage/serialization/serialize_nodes.cpp
@@ -356,6 +356,7 @@ void ExtraOperatorInfo::Serialize(Serializer &serializer) const {
 	serializer.WriteProperty<optional_idx>(101, "total_files", total_files);
 	serializer.WriteProperty<optional_idx>(102, "filtered_files", filtered_files);
 	serializer.WritePropertyWithDefault<unique_ptr<SampleOptions>>(103, "sample_options", sample_options);
+	serializer.WritePropertyWithDefault<optional_idx>(104, "pruned_directories", pruned_directories, optional_idx());
 }
 
 ExtraOperatorInfo ExtraOperatorInfo::Deserialize(Deserializer &deserializer) {
@@ -364,6 +365,7 @@ ExtraOperatorInfo ExtraOperatorInfo::Deserialize(Deserializer &deserializer) {
 	deserializer.ReadProperty<optional_idx>(101, "total_files", result.total_files);
 	deserializer.ReadProperty<optional_idx>(102, "filtered_files", result.filtered_files);
 	deserializer.ReadPropertyWithDefault<unique_ptr<SampleOptions>>(103, "sample_options", result.sample_options);
+	deserializer.ReadPropertyWithExplicitDefault<optional_idx>(104, "pruned_directories", result.pruned_directories, optional_idx());
 	return result;
 }
 
@@ -414,6 +416,8 @@ void MultiFileOptions::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<case_insensitive_map_t<LogicalType>>(105, "hive_types_schema", hive_types_schema);
 	serializer.WritePropertyWithDefault<string>(106, "filename_column", filename_column, MultiFileOptions::DEFAULT_FILENAME_COLUMN);
 	serializer.WritePropertyWithDefault<bool>(107, "allow_empty", allow_empty);
+	serializer.WritePropertyWithDefault<bool>(108, "hive_directory_pruning", hive_directory_pruning, false);
+	serializer.WritePropertyWithDefault<bool>(109, "explicit_hive_directory_pruning", explicit_hive_directory_pruning, false);
 }
 
 MultiFileOptions MultiFileOptions::Deserialize(Deserializer &deserializer) {
@@ -426,6 +430,8 @@ MultiFileOptions MultiFileOptions::Deserialize(Deserializer &deserializer) {
 	deserializer.ReadPropertyWithDefault<case_insensitive_map_t<LogicalType>>(105, "hive_types_schema", result.hive_types_schema);
 	deserializer.ReadPropertyWithExplicitDefault<string>(106, "filename_column", result.filename_column, MultiFileOptions::DEFAULT_FILENAME_COLUMN);
 	deserializer.ReadPropertyWithDefault<bool>(107, "allow_empty", result.allow_empty);
+	deserializer.ReadPropertyWithExplicitDefault<bool>(108, "hive_directory_pruning", result.hive_directory_pruning, false);
+	deserializer.ReadPropertyWithExplicitDefault<bool>(109, "explicit_hive_directory_pruning", result.explicit_hive_directory_pruning, false);
 	return result;
 }
 

--- a/test/configs/disable_optimizer.json
+++ b/test/configs/disable_optimizer.json
@@ -124,6 +124,12 @@
       "paths": [
         "test/sql/join/natural/natural_join.test"
       ]
+    },
+    {
+      "reason": "Counting directory listings requires filter pushdown from optimizer.",
+      "paths": [
+        "test/sql/copy/partitioned/hive_early_directory_pruning_listings.test"
+      ]
     }
   ]
 }

--- a/test/configs/force_storage_restart.json
+++ b/test/configs/force_storage_restart.json
@@ -115,6 +115,12 @@
         "test/optimizer/partition_stats_exactness.test",
         "test/optimizer/partition_stats_prepared.test"
       ]
+    },
+    {
+      "reason": "Restarting the database discards the log that the directory listings are counted from.",
+      "paths": [
+        "test/sql/copy/partitioned/hive_early_directory_pruning_listings.test"
+      ]
     }
   ]
 }

--- a/test/configs/verify_serializer.json
+++ b/test/configs/verify_serializer.json
@@ -9,6 +9,18 @@
       "paths": [
         "test/extension/test_extensible_filter.test"
       ]
+    },
+    {
+      "reason": "Filtering out every file leaves an empty file list that cannot be re-bound after serialization",
+      "paths": [
+        "test/sql/copy/partitioned/hive_early_directory_pruning.test"
+      ]
+    },
+    {
+      "reason": "The pushdown is not re-applied after serialization, so no directory is pruned",
+      "paths": [
+        "test/sql/copy/partitioned/hive_early_directory_pruning_listings.test"
+      ]
     }
   ]
 }

--- a/test/sql/copy/partitioned/hive_directory_pruning_option.test
+++ b/test/sql/copy/partitioned/hive_directory_pruning_option.test
@@ -1,0 +1,128 @@
+# name: test/sql/copy/partitioned/hive_directory_pruning_option.test
+# description: Test the hive_directory_pruning option that gates the pruning of hive partition directories
+# group: [partitioned]
+
+require parquet
+
+statement ok
+SET profiling_renderer_settings = MAP {'operator_casing': 'upper'};
+
+statement ok
+COPY (SELECT i AS k, i AS val FROM range(0,256) tbl(i)) TO '{TEST_DIR}/hive_pruning_option' (FORMAT PARQUET, PARTITION_BY (k));
+
+# the option is disabled by default
+query I
+SELECT current_setting('hive_directory_pruning')
+----
+false
+
+# by default the entire file list is expanded and no directory is pruned
+query II
+EXPLAIN SELECT * FROM parquet_scan('{TEST_DIR}/hive_pruning_option/**/*.parquet', HIVE_PARTITIONING=1) WHERE k=200;
+----
+physical_plan	<REGEX>:.*Scanning Files:\s*1/256.*
+
+query II
+EXPLAIN SELECT * FROM parquet_scan('{TEST_DIR}/hive_pruning_option/**/*.parquet', HIVE_PARTITIONING=1) WHERE k=200;
+----
+physical_plan	<!REGEX>:.*Pruned Directories.*
+
+# the scan returns what it returned before this option existed
+query II
+SELECT k, val FROM parquet_scan('{TEST_DIR}/hive_pruning_option/**/*.parquet', HIVE_PARTITIONING=1) WHERE k=200;
+----
+200	200
+
+query I
+SELECT COUNT(*) FROM parquet_scan('{TEST_DIR}/hive_pruning_option/**/*.parquet', HIVE_PARTITIONING=1);
+----
+256
+
+# the named parameter enables the pruning for a single scan
+query II
+EXPLAIN SELECT * FROM parquet_scan('{TEST_DIR}/hive_pruning_option/**/*.parquet', HIVE_PARTITIONING=1, HIVE_DIRECTORY_PRUNING=1) WHERE k=200;
+----
+physical_plan	<REGEX>:.*Pruned Directories:\s*[1-9][0-9]*.*
+
+query II
+SELECT k, val FROM parquet_scan('{TEST_DIR}/hive_pruning_option/**/*.parquet', HIVE_PARTITIONING=1, HIVE_DIRECTORY_PRUNING=1) WHERE k=200;
+----
+200	200
+
+# NULL is rejected like the other boolean options rather than being read as false
+statement error
+SELECT * FROM parquet_scan('{TEST_DIR}/hive_pruning_option/**/*.parquet', HIVE_DIRECTORY_PRUNING=NULL);
+----
+<REGEX>:.*Cannot use NULL as argument.*
+
+# the setting enables it for every scan, including scans over a bare path that take no named parameters
+statement ok
+SET hive_directory_pruning=true
+
+query II
+EXPLAIN SELECT * FROM parquet_scan('{TEST_DIR}/hive_pruning_option/**/*.parquet', HIVE_PARTITIONING=1) WHERE k=200;
+----
+physical_plan	<REGEX>:.*Pruned Directories:\s*[1-9][0-9]*.*
+
+query II
+EXPLAIN SELECT * FROM '{TEST_DIR}/hive_pruning_option/**/*.parquet' WHERE k=200;
+----
+physical_plan	<REGEX>:.*Pruned Directories:\s*[1-9][0-9]*.*
+
+query II
+SELECT k, val FROM '{TEST_DIR}/hive_pruning_option/**/*.parquet' WHERE k=200;
+----
+200	200
+
+# the named parameter takes precedence over the setting
+query II
+EXPLAIN SELECT * FROM parquet_scan('{TEST_DIR}/hive_pruning_option/**/*.parquet', HIVE_PARTITIONING=1, HIVE_DIRECTORY_PRUNING=0) WHERE k=200;
+----
+physical_plan	<REGEX>:.*Scanning Files:\s*1/256.*
+
+query II
+EXPLAIN SELECT * FROM parquet_scan('{TEST_DIR}/hive_pruning_option/**/*.parquet', HIVE_PARTITIONING=1, HIVE_DIRECTORY_PRUNING=0) WHERE k=200;
+----
+physical_plan	<!REGEX>:.*Pruned Directories.*
+
+# resetting brings back the default
+statement ok
+RESET hive_directory_pruning
+
+query II
+EXPLAIN SELECT * FROM parquet_scan('{TEST_DIR}/hive_pruning_option/**/*.parquet', HIVE_PARTITIONING=1) WHERE k=200;
+----
+physical_plan	<!REGEX>:.*Pruned Directories.*
+
+# the setting can also be set globally
+statement ok
+SET GLOBAL hive_directory_pruning=true
+
+query II
+EXPLAIN SELECT * FROM parquet_scan('{TEST_DIR}/hive_pruning_option/**/*.parquet', HIVE_PARTITIONING=1) WHERE k=200;
+----
+physical_plan	<REGEX>:.*Pruned Directories:\s*[1-9][0-9]*.*
+
+statement ok
+RESET GLOBAL hive_directory_pruning
+
+# with the pruning disabled binding keeps inspecting every file, so a plain file that sits past the bind sample
+# still keeps hive partitioning from being auto-detected
+statement ok
+COPY (SELECT 1 AS k, 0 AS val) TO '{TEST_DIR}/hive_pruning_option_mixed' (FORMAT PARQUET, PARTITION_BY (k));
+
+# fill the partition directory past the bind sample, so the plain file below is only reached by a full expansion
+loop i 0 150
+
+statement ok
+COPY (SELECT {i} AS val) TO '{TEST_DIR}/hive_pruning_option_mixed/k=1/f{i}.parquet' (FORMAT PARQUET);
+
+endloop
+
+statement ok
+COPY (SELECT 42 AS val) TO '{TEST_DIR}/hive_pruning_option_mixed/plain.parquet' (FORMAT PARQUET);
+
+statement error
+SELECT k FROM '{TEST_DIR}/hive_pruning_option_mixed/**/*.parquet';
+----
+<REGEX>:.*not found.*

--- a/test/sql/copy/partitioned/hive_dynamic_filter_pushdown.test
+++ b/test/sql/copy/partitioned/hive_dynamic_filter_pushdown.test
@@ -1,0 +1,54 @@
+# name: test/sql/copy/partitioned/hive_dynamic_filter_pushdown.test
+# description: Test filters that reach a hive partitioned scan as table filters, through DynamicFilterPushdown
+# group: [partitioned]
+
+require parquet
+
+statement ok
+SET hive_directory_pruning=true;
+
+statement ok
+COPY (SELECT i%4 AS k, i AS val FROM range(0,32) tbl(i)) TO '{TEST_DIR}/hive_dyn' (FORMAT PARQUET, PARTITION_BY (k));
+
+# a filter on a non-partition column only reaches the scan as a table filter - the partition column of the rows that
+# survive it must still be reconstructed from the path
+query II
+SELECT k, val FROM parquet_scan('{TEST_DIR}/hive_dyn/**/*.parquet', HIVE_PARTITIONING=1) WHERE val=17;
+----
+1	17
+
+# the same for a filter that is only known once the sub-query has been evaluated
+statement ok
+CREATE TABLE probe(k INTEGER);
+
+statement ok
+INSERT INTO probe VALUES (2);
+
+query I
+SELECT COUNT(*) FROM parquet_scan('{TEST_DIR}/hive_dyn/**/*.parquet', HIVE_PARTITIONING=1) WHERE k IN (SELECT k FROM probe);
+----
+8
+
+# grouping on the reconstructed key checks that its value is right, not only that a value is there
+query II
+SELECT DISTINCT k, COUNT(*) FROM parquet_scan('{TEST_DIR}/hive_dyn/**/*.parquet', HIVE_PARTITIONING=1) WHERE k IN (SELECT k FROM probe) GROUP BY k;
+----
+2	8
+
+# a partition filter and a non-partition filter on one scan, so both pushdown paths run together
+query II
+SELECT k, val FROM parquet_scan('{TEST_DIR}/hive_dyn/**/*.parquet', HIVE_PARTITIONING=1) WHERE k=3 AND val=19;
+----
+3	19
+
+# the filename column and the hive values come from the same path - they have to stay consistent
+query I
+SELECT COUNT(*) FROM parquet_scan('{TEST_DIR}/hive_dyn/**/*.parquet', HIVE_PARTITIONING=1, FILENAME=1) WHERE val=17 AND filename LIKE '%k=1%';
+----
+1
+
+# a filter that matches nothing must still return an empty result rather than an error
+query I
+SELECT COUNT(*) FROM parquet_scan('{TEST_DIR}/hive_dyn/**/*.parquet', HIVE_PARTITIONING=1) WHERE val=9999;
+----
+0

--- a/test/sql/copy/partitioned/hive_early_directory_pruning.test
+++ b/test/sql/copy/partitioned/hive_early_directory_pruning.test
@@ -1,0 +1,170 @@
+# name: test/sql/copy/partitioned/hive_early_directory_pruning.test
+# description: Test that hive partition filters prune directories before they are listed
+# group: [partitioned]
+
+require parquet
+
+statement ok
+SET profiling_renderer_settings = MAP {'operator_casing': 'upper'};
+
+statement ok
+SET hive_directory_pruning=true;
+
+# more partitions than are sampled while binding - the remaining directories are only listed if they can match
+statement ok
+COPY (SELECT i AS k, i AS val FROM range(0,256) tbl(i)) TO '{TEST_DIR}/hive_early_pruning' (FORMAT PARQUET, PARTITION_BY (k));
+
+query II
+SELECT k, val FROM parquet_scan('{TEST_DIR}/hive_early_pruning/**/*.parquet', HIVE_PARTITIONING=1) WHERE k=200;
+----
+200	200
+
+# the filter is reported even though it did its work while the list was expanded rather than on the file list
+query II
+EXPLAIN SELECT * FROM parquet_scan('{TEST_DIR}/hive_early_pruning/**/*.parquet', HIVE_PARTITIONING=1) WHERE k=200;
+----
+physical_plan	<REGEX>:.*PARQUET_SCAN.*File Filters:.*k = 200.*
+
+# the file count is below the total, so the directories that cannot match were skipped instead of being listed
+query II
+EXPLAIN SELECT * FROM parquet_scan('{TEST_DIR}/hive_early_pruning/**/*.parquet', HIVE_PARTITIONING=1) WHERE k=200;
+----
+physical_plan	<!REGEX>:.*Scanning Files:\s*[0-9]+\/256.*
+
+# the pruned directories are reported, and they account for the files that are missing from the file count
+query II
+EXPLAIN SELECT * FROM parquet_scan('{TEST_DIR}/hive_early_pruning/**/*.parquet', HIVE_PARTITIONING=1) WHERE k=200;
+----
+physical_plan	<REGEX>:.*Pruned Directories:\s*[1-9][0-9]*.*
+
+# without a hive filter all files are scanned
+query I
+SELECT COUNT(*) FROM parquet_scan('{TEST_DIR}/hive_early_pruning/**/*.parquet', HIVE_PARTITIONING=1);
+----
+256
+
+# a filter on a non-partition column cannot prune any directory
+query II
+EXPLAIN SELECT * FROM parquet_scan('{TEST_DIR}/hive_early_pruning/**/*.parquet', HIVE_PARTITIONING=1) WHERE val=200;
+----
+physical_plan	<!REGEX>:.*File Filters:.*
+
+query I
+SELECT COUNT(*) FROM parquet_scan('{TEST_DIR}/hive_early_pruning/**/*.parquet', HIVE_PARTITIONING=1) WHERE val=200;
+----
+1
+
+# ranges and disjunctions prune as well - a directory survives a disjunction if either side can still match
+query I
+SELECT COUNT(*) FROM parquet_scan('{TEST_DIR}/hive_early_pruning/**/*.parquet', HIVE_PARTITIONING=1) WHERE k>250;
+----
+5
+
+query I
+SELECT COUNT(*) FROM parquet_scan('{TEST_DIR}/hive_early_pruning/**/*.parquet', HIVE_PARTITIONING=1) WHERE k=200 OR k=201;
+----
+2
+
+# a filter that prunes every directory leaves an empty file list, which must still scan as an empty result
+query I
+SELECT COUNT(*) FROM parquet_scan('{TEST_DIR}/hive_early_pruning/**/*.parquet', HIVE_PARTITIONING=1) WHERE k=1000;
+----
+0
+
+# nested partitions - the rows that match the outer key are spread over several inner partitions
+statement ok
+COPY (SELECT i%150 AS k1, i//150 AS k2, i AS val FROM range(0,300) tbl(i)) TO '{TEST_DIR}/hive_early_pruning_nested' (FORMAT PARQUET, PARTITION_BY (k1, k2));
+
+query III
+SELECT k1, k2, val FROM parquet_scan('{TEST_DIR}/hive_early_pruning_nested/**/*.parquet', HIVE_PARTITIONING=1) WHERE k1=149 ORDER BY val;
+----
+149	0	149
+149	1	299
+
+query II
+EXPLAIN SELECT * FROM parquet_scan('{TEST_DIR}/hive_early_pruning_nested/**/*.parquet', HIVE_PARTITIONING=1) WHERE k1=149;
+----
+physical_plan	<!REGEX>:.*Scanning Files:\s*[0-9]+\/300.*
+
+# pruning an outer directory skips every inner directory below it, not just one level
+query II
+EXPLAIN SELECT * FROM parquet_scan('{TEST_DIR}/hive_early_pruning_nested/**/*.parquet', HIVE_PARTITIONING=1) WHERE k1=149;
+----
+physical_plan	<REGEX>:.*Pruned Directories:\s*[1-9][0-9]*.*
+
+# filtering on the inner key, where no outer directory can be pruned
+query I
+SELECT COUNT(*) FROM parquet_scan('{TEST_DIR}/hive_early_pruning_nested/**/*.parquet', HIVE_PARTITIONING=1) WHERE k2=1;
+----
+150
+
+# globs that match the partition directories explicitly are pruned as well
+query I
+SELECT COUNT(*) FROM parquet_scan('{TEST_DIR}/hive_early_pruning_nested/*/*/*.parquet', HIVE_PARTITIONING=1) WHERE k1=149;
+----
+2
+
+# a directory can hold a partition value that does not convert to the type of the hive column - pruning must not fail
+# a query over files that never carry that value
+statement ok
+COPY (SELECT k, 0 AS val FROM (VALUES ('1'), ('abc')) tbl(k)) TO '{TEST_DIR}/hive_badcast' (FORMAT PARQUET, PARTITION_BY (k));
+
+# fill "k=1" past the bind sample, so the type of "k" is detected without ever looking at "k=abc"
+loop i 0 150
+
+statement ok
+COPY (SELECT {i} AS val) TO '{TEST_DIR}/hive_badcast/k=1/f{i}.parquet' (FORMAT PARQUET);
+
+endloop
+
+# only the "f" files are read, so "k" is detected as BIGINT - the "k=abc" directory must not break the scan
+query I
+SELECT COUNT(*) FROM parquet_scan('{TEST_DIR}/hive_badcast/**/f*.parquet', HIVE_PARTITIONING=1) WHERE k=1;
+----
+150
+
+# a filter that prunes directories but no remaining file must still be reported as a file filter: every file it
+# would have pruned was skipped while the list was expanded, so the file-level pass never gets to see one
+statement ok
+COPY (SELECT i+1 AS k, i AS val FROM range(0,2) tbl(i)) TO '{TEST_DIR}/hive_matched' (FORMAT PARQUET, PARTITION_BY (k));
+
+# fill the matching partition past the bind sample, so every file that is left over matches the filter
+loop i 0 150
+
+statement ok
+COPY (SELECT {i} AS val) TO '{TEST_DIR}/hive_matched/k=1/f{i}.parquet' (FORMAT PARQUET);
+
+endloop
+
+query II
+EXPLAIN SELECT * FROM parquet_scan('{TEST_DIR}/hive_matched/**/*.parquet', HIVE_PARTITIONING=1) WHERE k=1;
+----
+physical_plan	<REGEX>:.*File Filters:.*k = 1.*
+
+# the k=2 file was never listed, so it is not part of the scan at all
+query I
+SELECT COUNT(*) FROM parquet_scan('{TEST_DIR}/hive_matched/**/*.parquet', HIVE_PARTITIONING=1) WHERE k=1;
+----
+151
+
+# binding samples files rather than expanding the whole list - the sample must still span more than the first
+# directory, otherwise a tree that mixes hive directories with plain files is wrongly auto-detected as hive
+statement ok
+COPY (SELECT 1 AS k, 0 AS val) TO '{TEST_DIR}/hive_mixed' (FORMAT PARQUET, PARTITION_BY (k));
+
+# more files in the first partition directory than are sampled, so the sample has to reach the file below
+loop i 0 150
+
+statement ok
+COPY (SELECT {i} AS val) TO '{TEST_DIR}/hive_mixed/k=1/f{i}.parquet' (FORMAT PARQUET);
+
+endloop
+
+statement ok
+COPY (SELECT 42 AS val) TO '{TEST_DIR}/hive_mixed/plain.parquet' (FORMAT PARQUET);
+
+# "k" is not a column: the plain file has no hive key, so hive partitioning must not be auto-detected
+statement error
+SELECT k FROM '{TEST_DIR}/hive_mixed/**/*.parquet';
+----
+<REGEX>:.*not found.*

--- a/test/sql/copy/partitioned/hive_early_directory_pruning_listings.test
+++ b/test/sql/copy/partitioned/hive_early_directory_pruning_listings.test
@@ -1,0 +1,56 @@
+# name: test/sql/copy/partitioned/hive_early_directory_pruning_listings.test
+# description: Test that hive partition filters keep directories from being listed at all
+# group: [partitioned]
+
+# Every other test here would also pass if the directories were listed first and their files discarded afterwards.
+# Counting the listings in the log is what shows that the I/O is avoided rather than wasted.
+# The counts of a filtered and an unfiltered scan are compared, so this needs the filter pushdown of the optimizer
+# and it needs the log to survive for the whole test
+
+require parquet
+
+statement ok
+SET hive_directory_pruning=true;
+
+statement ok
+COPY (SELECT i AS k, i AS val FROM range(0,256) tbl(i)) TO '{TEST_DIR}/hive_early_pruning' (FORMAT PARQUET, PARTITION_BY (k));
+
+# without a filter, every partition directory is crawled and globbed
+statement ok
+CALL truncate_duckdb_logs()
+
+statement ok
+CALL enable_logging('FileSystem')
+
+statement ok
+SELECT COUNT(*) FROM parquet_scan('{TEST_DIR}/hive_early_pruning/**/*.parquet', HIVE_PARTITIONING=1);
+
+statement ok
+CALL disable_logging()
+
+statement ok
+CREATE OR REPLACE TABLE listings_unfiltered AS SELECT COUNT(*) AS c FROM duckdb_logs_parsed('FileSystem') WHERE op='LIST';
+
+# with the filter, only the files sampled while binding and the matching partition are listed
+statement ok
+CALL truncate_duckdb_logs()
+
+statement ok
+CALL enable_logging('FileSystem')
+
+statement ok
+SELECT COUNT(*) FROM parquet_scan('{TEST_DIR}/hive_early_pruning/**/*.parquet', HIVE_PARTITIONING=1) WHERE k=200;
+
+statement ok
+CALL disable_logging()
+
+statement ok
+CREATE OR REPLACE TABLE listings_filtered AS SELECT COUNT(*) AS c FROM duckdb_logs_parsed('FileSystem') WHERE op='LIST';
+
+# the filter at least halves the number of directories that are listed
+# both counts are affected the same way when a config runs every statement more than once, so they are compared
+# against each other instead of against a fixed number
+query I
+SELECT (SELECT c FROM listings_filtered) * 2 < (SELECT c FROM listings_unfiltered)
+----
+true

--- a/test/sql/function/autocomplete/setting.test
+++ b/test/sql/function/autocomplete/setting.test
@@ -9,7 +9,7 @@ require icu
 require no_extension_autoloading "FIXME: ICU is not autoloaded on 'Set timez'"
 
 query II
-SELECT suggestion, suggestion_start FROM sql_auto_complete('SET e_directory') LIMIT 1;
+SELECT suggestion, suggestion_start FROM sql_auto_complete('SET ome_directory') LIMIT 1;
 ----
 home_directory	4
 


### PR DESCRIPTION
Supersedes https://github.com/duckdb/duckdb/pull/18518. Addresses part of #7620 for local filesystem.

Many details have been greatly simplified compared to earlier attempts thanks to additions like the Pagination API. Thank you again for taking the time to review this. Please note that Claude was used to write a significant amount of the code here, but I've attempted to simplify it as much as I could.

- [ ] Unrelated failure in Iceberg extension currently on main as of 2026/08/01 44200a30882062bb547a11672d35c282a715def5

# Overview

Prunes hive partition directories early, reducing I/O from listing files that would have been filtered out anyway, greatly reducing overall query time for Hive datasets with a large number of partitions and/or a significant number of Hive keys in the path.

Adds a new option `hive_directory_pruning` which defaults to false to keep existing behavior. When true, Hive filters are pushed into local globbing to prune directories to avoid listing paths exhaustively before filtering. 

Instead of reading all files to ensure Hive partition consistency etc., only a subset (defaulting to 100 files) are sampled. This could technically lead to allowing querying a path whose subpaths do not all have consistent types for their columns (that would normally require `union_by_name=true`), but I believe this to be an acceptable tradeoff.

Hive filters are pushed down as a `HivePathFilter` into `MultiFileList`, which then filters lists as `LocalGlobResult::ExpandNextPath()` is called to glob paths. It might make sense to abstract this to a generic path filter, but given `MultiFilePushdownInfo` and such are already Hive-aware I figured it wasn't a terrible move to keep things simple. Please let me know if you want this to be abstracted out though to support other types of path filtering.

`EXPLAIN` with this option enabled will show the number of pruned directories as a statistic to give the user a sense of how many directories were skipped over, since we can't give the number of files due to skipping them entirely.

# Out of scope

- S3 Support (would be nice as a follow-up)
- JOIN support (pruning on JOINs)
```
WITH filters AS (
    SELECT 2024 AS YEAR, 'TMAX' AS ELEMENT
)
SELECT DISTINCT ID
FROM '/Users/xevix/Downloads/data/noaa/by_year/**/*.parquet'
JOIN filters USING (year, element)
ORDER BY ALL;
```

# Results

Using [NOAA GHCN](https://registry.opendata.aws/noaa-ghcn/) data set.

```
memory D EXPLAIN ANALYZE SELECT DISTINCT ID
         FROM '/Users/xevix/Downloads/data/noaa/by_year/**/*.parquet'
         WHERE YEAR = 2024 AND ELEMENT = 'TMAX'
         ORDER BY ALL;
╭─ Summary ──────────╮
│ Total Time: 0.468s │
│ Data Read:  7.0 MB │
╰────────────────────╯
╭─ Order By ───────────────────────────────────────╮
│ 12,920 rows                                  0µs │
╰─────────────────────────┬────────────────────────╯
╭─ Hash Group By ─────────┴────────────────────────╮
│ Groups: #0                                       │
│ 12,920 rows                               10.0ms │
╰─────────────────────────┒┎───────────────────────╯
╭─ Projection ────────────┚┖───────────────────────╮
│ 3,633,379 rows                               0µs │
╰─────────────────────────┒┎───────────────────────╯
╭─ Table Scan ────────────┚┖───────────────────────╮
│ Function: PARQUET_SCAN                           │
│ Projections: ID                                  │
│ File Filters:                                    │
│ (YEAR = 2024)(ELEMENT = 'TMAX')                  │
│ Scanning Files: 8/13593                          │
│ Total Files Read: 8                              │
│ Filename(s):                                     │
│ /Users/xevix/Downloads/data/noaa/by_year/YEAR=2… │
│ /Users/xevix/Downloads/data/noaa/by_year/YEAR=2… │
│ /Users/xevix/Downloads/data/noaa/by_year/YEAR=2… │
│ /Users/xevix/Downloads/data/noaa/by_year/YEAR=2… │
│ /Users/xevix/Downloads/data/noaa/by_year/YEAR= … │
│ Row Groups Scanned: 8 / 8                        │
│ 3,633,379 rows                            10.0ms │
╰──────────────────────────────────────────────────╯

type .last to show the full tree, .web to open it in a browser
```

```
memory D SET hive_directory_pruning = true;
memory D EXPLAIN ANALYZE SELECT DISTINCT ID
         FROM '/Users/xevix/Downloads/data/noaa/by_year/**/*.parquet'
         WHERE YEAR = 2024 AND ELEMENT = 'TMAX'
         ORDER BY ALL;
╭─ Summary ───────────╮
│ Total Time: 0.0198s │
│ Data Read:   7.0 MB │
╰─────────────────────╯
╭─ Order By ───────────────────────────────────────╮
│ 12,920 rows                                  0µs │
╰─────────────────────────┬────────────────────────╯
╭─ Hash Group By ─────────┴────────────────────────╮
│ Groups: #0                                       │
│ 12,920 rows                               10.0ms │
╰─────────────────────────┒┎───────────────────────╯
╭─ Projection ────────────┚┖───────────────────────╮
│ 3,633,379 rows                               0µs │
╰─────────────────────────┒┎───────────────────────╯
╭─ Table Scan ────────────┚┖───────────────────────╮
│ Function: PARQUET_SCAN                           │
│ Projections: ID                                  │
│ File Filters:                                    │
│ (YEAR = 2024)(ELEMENT = 'TMAX')                  │
│ Scanning Files: 8/108                            │
│ Pruned Directories: 291                          │
│ Total Files Read: 8                              │
│ Filename(s):                                     │
│ /Users/xevix/Downloads/data/noaa/by_year/YEAR=2… │
│ /Users/xevix/Downloads/data/noaa/by_year/YEAR=2… │
│ /Users/xevix/Downloads/data/noaa/by_year/YEAR=2… │
│ /Users/xevix/Downloads/data/noaa/by_year/YEAR=2… │
│ /Users/xevix/Downloads/data/noaa/by_year/YEAR= … │
│ Row Groups Scanned: 8 / 8                        │
│ 3,633,379 rows                            20.0ms │
╰──────────────────────────────────────────────────╯
```

# Unrelated regression between 1.5.5 and main branch

It seems that the main branch at the time of writing performs slower than 1.5.5. I'm not sure why this is, but wanted to note that the added latency is confirmed to be between these two versions, and not this branch.

1.5.5
```
$ duckdb 
-- Loading resources from /Users/xevix/.duckdbrc
DuckDB v1.5.5 (Variegata)
Enter ".help" for usage hints.
memory D EXPLAIN ANALYZE SELECT DISTINCT ID
         FROM '/Users/xevix/Downloads/data/noaa/by_year/**/*.parquet'
         WHERE YEAR = 2024 AND ELEMENT = 'TMAX'
         ORDER BY ALL;
┌─────────────────────────────────────┐
│┌───────────────────────────────────┐│
││    Query Profiling Information    ││
│└───────────────────────────────────┘│
└─────────────────────────────────────┘
EXPLAIN ANALYZE SELECT DISTINCT ID FROM '/Users/xevix/Downloads/data/noaa/by_year/**/*.parquet' WHERE YEAR = 2024 AND ELEMENT = 'TMAX' ORDER BY ALL;
┌────────────────────────────────────────────────┐
│┌──────────────────────────────────────────────┐│
││              Total Time: 0.336s              ││
│└──────────────────────────────────────────────┘│
└────────────────────────────────────────────────┘
┌───────────────────────────┐
│           QUERY           │
└─────────────┬─────────────┘
┌─────────────┴─────────────┐
│      EXPLAIN_ANALYZE      │
│    ────────────────────   │
│                           │
│           0 rows          │
│           0.00s           │
└─────────────┬─────────────┘
┌─────────────┴─────────────┐
│          ORDER_BY         │
│    ────────────────────   │
│           ID ASC          │
│                           │
│                           │
│                           │
│        12,920 rows        │
│           0.00s           │
└─────────────┬─────────────┘
┌─────────────┴─────────────┐
│       HASH_GROUP_BY       │
│    ────────────────────   │
│         Groups: #0        │
│                           │
│                           │
│                           │
│        12,920 rows        │
│           0.01s           │
└─────────────┬─────────────┘
┌─────────────┴─────────────┐
│         PROJECTION        │
│    ────────────────────   │
│             ID            │
│                           │
│                           │
│                           │
│       3,633,379 rows      │
│           0.00s           │
└─────────────┬─────────────┘
┌─────────────┴─────────────┐
│         TABLE_SCAN        │
│    ────────────────────   │
│         Function:         │
│        PARQUET_SCAN       │
│                           │
│      Projections: ID      │
│                           │
│       File Filters:       │
│  (YEAR = 2024)(ELEMENT =  │
│          'TMAX')          │
│                           │
│      Scanning Files:      │
│          8/13593          │
│                           │
│    Total Files Read: 8    │
│                           │
│        Filename(s):       │
│   /Users/xevix/Downloads  │
│  /data/noaa/by_year/YEAR  │
│     =2024/ELEMENT=TMAX    │
│/0a916734b79044f889cda53b00│
│ 0d215d_0.snappy.parquet,  │
│   /Users/xevix/Downloads  │
│  /data/noaa/by_year/YEAR  │
│     =2024/ELEMENT=TMAX    │
│/0a916734b79044f889cda53b00│
│ 0d215d_1.snappy.parquet,  │
│   /Users/xevix/Downloads  │
│  /data/noaa/by_year/YEAR  │
│     =2024/ELEMENT=TMAX    │
│/0a916734b79044f889cda53b00│
│ 0d215d_2.snappy.parquet,  │
│   /Users/xevix/Downloads  │
│  /data/noaa/by_year/YEAR  │
│     =2024/ELEMENT=TMAX    │
│/0a916734b79044f889cda53b00│
│ 0d215d_3.snappy.parquet,  │
│   /Users/xevix/Downloads  │
│  /data/noaa/by_year/YEAR  │
│     =2024/ELEMENT=TMAX    │
│/0a916734b79044f889cda53b00│
│ 0d215d_4.snappy.parquet, .│
│             ..            │
│                           │
│                           │
│                           │
│       3,633,379 rows      │
│           0.01s           │
└───────────────────────────┘
Run Time (s): real 0.337 user 0.137312 sys 0.219440
```

main branch (44200a30882062bb547a11672d35c282a715def5)

```
$ ./build/release/duckdb
-- Loading resources from /Users/xevix/.duckdbrc
DuckDB v1.6.0-dev12056 (Development Version, 44200a3088)
Enter ".help" for usage hints.
memory D EXPLAIN ANALYZE SELECT DISTINCT ID
         FROM '/Users/xevix/Downloads/data/noaa/by_year/**/*.parquet'
         WHERE YEAR = 2024 AND ELEMENT = 'TMAX'
         ORDER BY ALL;
╭─ Summary ──────────╮
│ Total Time: 0.497s │
│ Data Read:  7.0 MB │
╰────────────────────╯
╭─ Order By ───────────────────────────────────────╮
│ 12,920 rows                                  0µs │
╰─────────────────────────┬────────────────────────╯
╭─ Hash Group By ─────────┴────────────────────────╮
│ Groups: #0                                       │
│ 12,920 rows                               10.0ms │
╰─────────────────────────┒┎───────────────────────╯
╭─ Projection ────────────┚┖───────────────────────╮
│ 3,633,379 rows                               0µs │
╰─────────────────────────┒┎───────────────────────╯
╭─ Table Scan ────────────┚┖───────────────────────╮
│ Function: PARQUET_SCAN                           │
│ Projections: ID                                  │
│ File Filters:                                    │
│ (YEAR = 2024)(ELEMENT = 'TMAX')                  │
│ Scanning Files: 8/13593                          │
│ Total Files Read: 8                              │
│ Filename(s):                                     │
│ /Users/xevix/Downloads/data/noaa/by_year/YEAR=2… │
│ /Users/xevix/Downloads/data/noaa/by_year/YEAR=2… │
│ /Users/xevix/Downloads/data/noaa/by_year/YEAR=2… │
│ /Users/xevix/Downloads/data/noaa/by_year/YEAR=2… │
│ /Users/xevix/Downloads/data/noaa/by_year/YEAR= … │
│ Row Groups Scanned: 8 / 8                        │
│ 3,633,379 rows                            20.0ms │
╰──────────────────────────────────────────────────╯
```

