### PR TITLE
Use unimplemented exception over internal one

### DIFF
--- a/src/catalog/catalog_entry/duck_table_entry.cpp
+++ b/src/catalog/catalog_entry/duck_table_entry.cpp
@@ -1377,7 +1377,8 @@ unique_ptr<CatalogEntry> DuckTableEntry::AddConstraint(ClientContext &context, A
 		table_info.constraints.push_back(info.constraint->Copy());
 
 	} else {
-		throw InternalException("unsupported constraint type in ALTER TABLE statement");
+		throw NotImplementedException("No support for adding %s constraints with ALTER TABLE",
+		                              EnumUtil::ToString(info.constraint->type));
 	}
 
 	// We create a physical table with a new constraint and a new unique index.


### PR DESCRIPTION
Closes https://github.com/duckdb/duckdb/issues/24377

Hi team, I think we should use `Unimplemented` exception instead of `Internal` exception -- we should never throw Internal exception.