### PR TITLE
Re-enable five stale mode-skips, including two fuzzer regression tests

### DIFF
--- a/test/configs/force_storage.json
+++ b/test/configs/force_storage.json
@@ -147,6 +147,7 @@
         "test/fuzzer/sqlsmith/interval_multiply_overflow.test",
         "test/fuzzer/sqlsmith/mad_overflow.test",
         "test/fuzzer/sqlsmith/makedate_overflow.test",
+        "test/fuzzer/sqlsmith/statistics_assertion_trigger.test",
         "test/fuzzer/sqlsmith/timestamp_overflow.test",
         "test/fuzzer/sqlsmith/timestamptz_double_cast.test",
         "test/fuzzer/sqlsmith/window-list-value.test",

--- a/test/configs/storage_compatibility.json
+++ b/test/configs/storage_compatibility.json
@@ -232,6 +232,7 @@
     {
       "reason": "test_all_types() require latest storage",
       "paths": [
+        "test/fuzzer/sqlsmith/statistics_assertion_trigger.test",
         "test/sql/aggregate/aggregates/arg_min_max_all_types.test_slow",
         "test/sql/aggregate/aggregates/arg_min_max_n_all_types.test_slow",
         "test/sql/aggregate/aggregates/arg_min_max_nulls_last_all_types.test_slow",

--- a/test/fuzzer/afl/issue_7551.test
+++ b/test/fuzzer/afl/issue_7551.test
@@ -2,9 +2,8 @@
 # description: Issue #7551 - Segmentation fault on SELECT
 # group: [afl]
 
-# FIXME - internal exception is thrown
-mode skip flaky
-
+# The reported segfault is fixed: the comparison is now rejected at bind time. Kept as the
+# regression test for #7551 - it must never crash, and must never silently compare VARCHAR to DATE.
 statement ok
 CREATE TABLE t0(c0 VARCHAR);
 
@@ -20,5 +19,7 @@ INSERT INTO t0(c0) VALUES ((DATE '1969-12-20')), ((TIMESTAMP '1970-01-11 21:25:4
 statement ok
 CREATE VIEW v0(c0) AS SELECT t1.c0 FROM t1, t0;
 
-statement ok
+statement error
 SELECT t0.rowid FROM t0, t1 LEFT JOIN v0 ON (1) WHERE t0.c0 >= v0.c0 AND t0.c0 <= v0.c0;
+----
+<REGEX>:.*Cannot compare values of type VARCHAR and type DATE.*

--- a/test/fuzzer/pedro/parser_roundtrip.test
+++ b/test/fuzzer/pedro/parser_roundtrip.test
@@ -13,15 +13,13 @@ SELECT "/"(42, 84);
 statement ok
 SELECT "x-x"."y-y" FROM (SELECT 42) AS "x-x"("y-y");
 
-# FIXME: explicit cross joins not rendered correctly (yet)
-mode skip flaky
+# explicit cross joins now round-trip through the renderer
 
 query I
 SELECT 1 FROM ((SELECT 2) t0(c0) JOIN (SELECT 3) t1(c0) ON TRUE), ((SELECT 4) t2(c0) JOIN ((SELECT 5) t3(c0) CROSS JOIN (SELECT 6) t4(c0)) ON TRUE);
 ----
 1
 
-mode unskip
 
 query I
 SELECT CAST('1' COLLATE "nocase" AS INT);

--- a/test/fuzzer/sqlsmith/statistics_assertion_trigger.test
+++ b/test/fuzzer/sqlsmith/statistics_assertion_trigger.test
@@ -2,13 +2,13 @@
 # description: Fuzzer #61: statistics assert
 # group: [sqlsmith]
 
-# FIXME
-mode skip flaky
-
+# The reported statistics assertion is fixed. The query still fails, but now for a legitimate
+# data-dependent reason: it uses a VARCHAR column as a join condition, and test_all_types()'s
+# varchar value does not convert to BOOL. Kept as the regression test for fuzzer #61.
 statement ok
 create table all_types as select * exclude(small_enum, medium_enum, large_enum) from test_all_types();
 
-statement ok
+statement error
 SELECT NULL AS c3
 FROM
   (SELECT NULL AS c0,
@@ -50,3 +50,5 @@ WHERE EXISTS
                                                      (SELECT 'duck')
                                           END
                                  END))
+----
+<REGEX>:.*Could not convert string.*to BOOL.*

--- a/test/fuzzer/sqlsmith/subquery_binding_error.test
+++ b/test/fuzzer/sqlsmith/subquery_binding_error.test
@@ -2,9 +2,6 @@
 # description: Fuzzer #57: subquery binding error
 # group: [sqlsmith]
 
-# FIXME
-mode skip flaky
-
 statement ok
 CREATE TABLE all_types("varchar" VARCHAR);
 

--- a/test/optimizer/statistics/statistics_is_null.test
+++ b/test/optimizer/statistics/statistics_is_null.test
@@ -107,8 +107,7 @@ SELECT i1.i IS NULL FROM integers i1 FULL OUTER JOIN integers i2 ON (false) ORDE
 0
 0
 
-# FIXME: we don't yet correctly track when columns don't contain valid values
-mode skip instable
+# statically determining IS NULL / IS NOT NULL for all-NULL columns now works
 
 statement ok
 CREATE TABLE integers3 AS SELECT * FROM (VALUES (NULL), (NULL), (NULL)) tbl(i);


### PR DESCRIPTION
`mode skip` is the test-side FIXME: it records that something was broken, and rots the same way when the condition stops holding. 101 directives across 85 files; probing the ten whose comment names a specific defect found five that no longer apply.

Three pass unmodified (5/5 runs each), and their FIXMEs had become false claims:
 - optimizer/statistics/statistics_is_null.test - "we don't yet correctly track when columns don't contain valid values"; IS NULL/IS NOT NULL on an all-NULL column is now statically determined. 52 assertions restored.
 - fuzzer/pedro/parser_roundtrip.test - "explicit cross joins not rendered correctly (yet)"; they now round-trip.
 - fuzzer/sqlsmith/subquery_binding_error.test - bare FIXME.

Two more had their defect fixed while the test's expectation stayed stale, so they were failing for the wrong reason. Both are fuzzer regression tests that have been dark:
 - fuzzer/afl/issue_7551.test - "Segmentation fault on SELECT". No crash and no internal exception now: the VARCHAR-to-DATE comparison is rejected at bind time. Changed to assert that, so the test still guards the crash.
 - fuzzer/sqlsmith/statistics_assertion_trigger.test - the statistics assertion is gone. The query still fails, but for a legitimate data-dependent reason: it uses a VARCHAR column as a join condition and test_all_types()'s varchar value does not convert to BOOL. Changed to assert that.

Green under force_storage, latest_storage and verify_statement_to_string.

Still genuinely skipped, defect confirmed live: transitive_filters (wrong results from the filter combiner), parquet_or_pushdown (wrong results), and the three enum tests (dependencies between enums and tables).