### PR TITLE
Range check float => int casts on the rounded value

### DIFF
--- a/src/include/duckdb/common/operator/numeric_cast.hpp
+++ b/src/include/duckdb/common/operator/numeric_cast.hpp
@@ -76,11 +76,14 @@ bool TryCastWithOverflowCheckFloat(SRC value, T &result, SRC min, SRC max) {
 	if (!Value::IsFinite<SRC>(value)) {
 		return false;
 	}
-	if (!(value >= min && value < max)) {
+	// PG FLOAT => INT casts use statistical rounding, and it is the ROUNDED value that has to fit the
+	// destination: 127.6 rounds to 128, which no TINYINT can hold, while -128.4 rounds to -128, which
+	// it can. Range checking before rounding gets both of those wrong.
+	auto rounded = std::nearbyint(value);
+	if (!(rounded >= min && rounded < max)) {
 		return false;
 	}
-	// PG FLOAT => INT casts use statistical rounding.
-	result = static_cast<T>(std::nearbyint(value));
+	result = static_cast<T>(rounded);
 	return true;
 }
 

--- a/test/sql/cast/float_integer_cast.test
+++ b/test/sql/cast/float_integer_cast.test
@@ -41,3 +41,98 @@ select cast(-1.5::{src} as {dst}) as x;
 endloop
 
 endloop
+
+# The range check applies to the ROUNDED value, like PG's dtoi2/dtoi4. A value below the destination
+# maximum can still round above it, and a value below the destination minimum can still round back
+# onto it - checking before rounding got both of those wrong, and the first one used to reach a
+# static_cast that is undefined behaviour for an out-of-range float (127.6::TINYINT returned -128).
+
+foreach src FLOAT DOUBLE
+
+# rounds up past the maximum
+
+statement error
+select cast(127.5::{src} as TINYINT)
+----
+can't be cast because the value is out of range for the destination type INT8
+
+statement error
+select cast(127.6::{src} as TINYINT)
+----
+can't be cast because the value is out of range for the destination type INT8
+
+statement error
+select cast(255.5::{src} as UTINYINT)
+----
+can't be cast because the value is out of range for the destination type UINT8
+
+statement error
+select cast(32767.5::{src} as SMALLINT)
+----
+can't be cast because the value is out of range for the destination type INT16
+
+statement error
+select cast(65535.5::{src} as USMALLINT)
+----
+can't be cast because the value is out of range for the destination type UINT16
+
+# just below it, and Banker's rounding still applies at the boundary
+
+query IIII
+select cast(127.4::{src} as TINYINT), cast(126.5::{src} as TINYINT),
+       cast(255.4::{src} as UTINYINT), cast(32766.5::{src} as SMALLINT)
+----
+127	126	255	32766
+
+# rounds back onto the minimum, so it fits after all
+
+query IIII
+select cast(-128.4::{src} as TINYINT), cast(-128.5::{src} as TINYINT),
+       cast(-0.4::{src} as UTINYINT), cast(-0.5::{src} as UTINYINT)
+----
+-128	-128	0	0
+
+# but one ulp further out does not
+
+statement error
+select cast(-128.6::{src} as TINYINT)
+----
+can't be cast because the value is out of range for the destination type INT8
+
+statement error
+select cast(-0.6::{src} as UTINYINT)
+----
+can't be cast because the value is out of range for the destination type UINT8
+
+# TRY_CAST reports the same thing as NULL rather than erroring
+
+query IIII
+select try_cast(127.6::{src} as TINYINT), try_cast(-128.6::{src} as TINYINT),
+       try_cast(-128.5::{src} as TINYINT), try_cast(-0.6::{src} as UTINYINT)
+----
+NULL	NULL	-128	NULL
+
+endloop
+
+# the wider destinations, where only DOUBLE carries enough precision to sit next to the boundary
+
+statement error
+select cast(2147483647.5::DOUBLE as INTEGER)
+----
+can't be cast because the value is out of range for the destination type INT32
+
+statement error
+select cast(-2147483648.6::DOUBLE as INTEGER)
+----
+can't be cast because the value is out of range for the destination type INT32
+
+query III
+select cast(2147483647.4::DOUBLE as INTEGER), cast(-2147483648.4::DOUBLE as INTEGER),
+       cast(4294967295.4::DOUBLE as UINTEGER)
+----
+2147483647	-2147483648	4294967295
+
+statement error
+select cast(4294967295.5::DOUBLE as UINTEGER)
+----
+can't be cast because the value is out of range for the destination type UINT32


### PR DESCRIPTION
TryCastWithOverflowCheckFloat checked the range before applying the statistical rounding, so a value below the destination maximum could still round above it. 127.6::TINYINT passed the check, rounded to 128.0, and reached a static_cast that is undefined behaviour for an out-of-range float - in practice it returned -128. The mirror case was rejected outright: -128.4 rounds to -128, which fits, but errored because -128.4 itself is below the minimum.

Check the rounded value instead, which is what postgres's `dtoi2`/`dtoi4` do:
```
127.6::TINYINT   throws (was UB, in regular cases -128)
127.5::TINYINT   throws (was UB, in regular cases -128)
-128.4::TINYINT  is -128 (was a Conversion Error)
126.5::TINYINT   is 126, Banker's rounding unchanged
```

The whole suite passes unchanged, which is also why the hole survived: no test covered either boundary.

I think this sort of makes sense, or more sense than current behaviour.