### PR TITLE
Trim sort key layout specializations under `SMALLER_BINARY`

### DIFF
--- a/src/common/sort/sorted_run.cpp
+++ b/src/common/sort/sorted_run.cpp
@@ -27,24 +27,11 @@ SortedRunScanState::SortedRunScanState(ClientContext &context, const Sort &sort_
 void SortedRunScanState::Scan(const SortedRun &sorted_run, const Vector &sort_key_pointers, DataChunk &chunk) {
 	const auto sort_key_type = sort.key_layout->GetSortKeyType();
 	switch (sort_key_type) {
-	case SortKeyType::NO_PAYLOAD_FIXED_8:
-		return TemplatedScan<SortKeyType::NO_PAYLOAD_FIXED_8>(sorted_run, sort_key_pointers, chunk);
-	case SortKeyType::NO_PAYLOAD_FIXED_16:
-		return TemplatedScan<SortKeyType::NO_PAYLOAD_FIXED_16>(sorted_run, sort_key_pointers, chunk);
-	case SortKeyType::NO_PAYLOAD_FIXED_24:
-		return TemplatedScan<SortKeyType::NO_PAYLOAD_FIXED_24>(sorted_run, sort_key_pointers, chunk);
-	case SortKeyType::NO_PAYLOAD_FIXED_32:
-		return TemplatedScan<SortKeyType::NO_PAYLOAD_FIXED_32>(sorted_run, sort_key_pointers, chunk);
-	case SortKeyType::NO_PAYLOAD_VARIABLE_32:
-		return TemplatedScan<SortKeyType::NO_PAYLOAD_VARIABLE_32>(sorted_run, sort_key_pointers, chunk);
-	case SortKeyType::PAYLOAD_FIXED_16:
-		return TemplatedScan<SortKeyType::PAYLOAD_FIXED_16>(sorted_run, sort_key_pointers, chunk);
-	case SortKeyType::PAYLOAD_FIXED_24:
-		return TemplatedScan<SortKeyType::PAYLOAD_FIXED_24>(sorted_run, sort_key_pointers, chunk);
-	case SortKeyType::PAYLOAD_FIXED_32:
-		return TemplatedScan<SortKeyType::PAYLOAD_FIXED_32>(sorted_run, sort_key_pointers, chunk);
-	case SortKeyType::PAYLOAD_VARIABLE_32:
-		return TemplatedScan<SortKeyType::PAYLOAD_VARIABLE_32>(sorted_run, sort_key_pointers, chunk);
+#define DUCKDB_SORT_KEY_CASE(SORT_KEY_TYPE)                                                                            \
+	case SortKeyType::SORT_KEY_TYPE:                                                                                   \
+		return TemplatedScan<SortKeyType::SORT_KEY_TYPE>(sorted_run, sort_key_pointers, chunk);
+		DUCKDB_FOR_EACH_SORT_KEY_TYPE(DUCKDB_SORT_KEY_CASE)
+#undef DUCKDB_SORT_KEY_CASE
 	default:
 		throw NotImplementedException("SortedRunMergerLocalState::ScanPartition for %s",
 		                              EnumUtil::ToString(sort_key_type));
@@ -192,14 +179,11 @@ static void TemplatedSetPayloadPointer(const Vector &key_locations, const Vector
 static void SetPayloadPointer(const Vector &key_locations, const Vector &payload_locations,
                               const SortKeyType &sort_key_type) {
 	switch (sort_key_type) {
-	case SortKeyType::PAYLOAD_FIXED_16:
-		return TemplatedSetPayloadPointer<SortKeyType::PAYLOAD_FIXED_16>(key_locations, payload_locations);
-	case SortKeyType::PAYLOAD_FIXED_24:
-		return TemplatedSetPayloadPointer<SortKeyType::PAYLOAD_FIXED_24>(key_locations, payload_locations);
-	case SortKeyType::PAYLOAD_FIXED_32:
-		return TemplatedSetPayloadPointer<SortKeyType::PAYLOAD_FIXED_32>(key_locations, payload_locations);
-	case SortKeyType::PAYLOAD_VARIABLE_32:
-		return TemplatedSetPayloadPointer<SortKeyType::PAYLOAD_VARIABLE_32>(key_locations, payload_locations);
+#define DUCKDB_SORT_KEY_CASE(SORT_KEY_TYPE)                                                                            \
+	case SortKeyType::SORT_KEY_TYPE:                                                                                   \
+		return TemplatedSetPayloadPointer<SortKeyType::SORT_KEY_TYPE>(key_locations, payload_locations);
+		DUCKDB_FOR_EACH_PAYLOAD_SORT_KEY_TYPE(DUCKDB_SORT_KEY_CASE)
+#undef DUCKDB_SORT_KEY_CASE
 	default:
 		throw NotImplementedException("SetPayloadPointer for %s", EnumUtil::ToString(sort_key_type));
 	}
@@ -274,24 +258,11 @@ static void TemplatedSort(ClientContext &context, TupleDataCollection &key_data,
 static void SortSwitch(ClientContext &context, TupleDataCollection &key_data, bool is_index_sort) {
 	const auto sort_key_type = key_data.GetLayout().GetSortKeyType();
 	switch (sort_key_type) {
-	case SortKeyType::NO_PAYLOAD_FIXED_8:
-		return TemplatedSort<SortKeyType::NO_PAYLOAD_FIXED_8>(context, key_data, is_index_sort);
-	case SortKeyType::NO_PAYLOAD_FIXED_16:
-		return TemplatedSort<SortKeyType::NO_PAYLOAD_FIXED_16>(context, key_data, is_index_sort);
-	case SortKeyType::NO_PAYLOAD_FIXED_24:
-		return TemplatedSort<SortKeyType::NO_PAYLOAD_FIXED_24>(context, key_data, is_index_sort);
-	case SortKeyType::NO_PAYLOAD_FIXED_32:
-		return TemplatedSort<SortKeyType::NO_PAYLOAD_FIXED_32>(context, key_data, is_index_sort);
-	case SortKeyType::NO_PAYLOAD_VARIABLE_32:
-		return TemplatedSort<SortKeyType::NO_PAYLOAD_VARIABLE_32>(context, key_data, is_index_sort);
-	case SortKeyType::PAYLOAD_FIXED_16:
-		return TemplatedSort<SortKeyType::PAYLOAD_FIXED_16>(context, key_data, is_index_sort);
-	case SortKeyType::PAYLOAD_FIXED_24:
-		return TemplatedSort<SortKeyType::PAYLOAD_FIXED_24>(context, key_data, is_index_sort);
-	case SortKeyType::PAYLOAD_FIXED_32:
-		return TemplatedSort<SortKeyType::PAYLOAD_FIXED_32>(context, key_data, is_index_sort);
-	case SortKeyType::PAYLOAD_VARIABLE_32:
-		return TemplatedSort<SortKeyType::PAYLOAD_VARIABLE_32>(context, key_data, is_index_sort);
+#define DUCKDB_SORT_KEY_CASE(SORT_KEY_TYPE)                                                                            \
+	case SortKeyType::SORT_KEY_TYPE:                                                                                   \
+		return TemplatedSort<SortKeyType::SORT_KEY_TYPE>(context, key_data, is_index_sort);
+		DUCKDB_FOR_EACH_SORT_KEY_TYPE(DUCKDB_SORT_KEY_CASE)
+#undef DUCKDB_SORT_KEY_CASE
 	default:
 		throw NotImplementedException("TemplatedSort for %s", EnumUtil::ToString(sort_key_type));
 	}
@@ -412,16 +383,11 @@ static void Reorder(ClientContext &context, unique_ptr<TupleDataCollection> &key
                     unique_ptr<TupleDataCollection> &payload_data) {
 	const auto sort_key_type = key_data->GetLayout().GetSortKeyType();
 	switch (sort_key_type) {
-	case SortKeyType::NO_PAYLOAD_VARIABLE_32:
-		return TemplatedReorder<SortKeyType::NO_PAYLOAD_VARIABLE_32>(context, key_data, payload_data);
-	case SortKeyType::PAYLOAD_FIXED_16:
-		return TemplatedReorder<SortKeyType::PAYLOAD_FIXED_16>(context, key_data, payload_data);
-	case SortKeyType::PAYLOAD_FIXED_24:
-		return TemplatedReorder<SortKeyType::PAYLOAD_FIXED_24>(context, key_data, payload_data);
-	case SortKeyType::PAYLOAD_FIXED_32:
-		return TemplatedReorder<SortKeyType::PAYLOAD_FIXED_32>(context, key_data, payload_data);
-	case SortKeyType::PAYLOAD_VARIABLE_32:
-		return TemplatedReorder<SortKeyType::PAYLOAD_VARIABLE_32>(context, key_data, payload_data);
+#define DUCKDB_SORT_KEY_CASE(SORT_KEY_TYPE)                                                                            \
+	case SortKeyType::SORT_KEY_TYPE:                                                                                   \
+		return TemplatedReorder<SortKeyType::SORT_KEY_TYPE>(context, key_data, payload_data);
+		DUCKDB_FOR_EACH_REORDERABLE_SORT_KEY_TYPE(DUCKDB_SORT_KEY_CASE)
+#undef DUCKDB_SORT_KEY_CASE
 	default:
 		throw NotImplementedException("TemplatedReorderPayload for %s", EnumUtil::ToString(sort_key_type));
 	}

--- a/src/common/sort/sorted_run_merger.cpp
+++ b/src/common/sort/sorted_run_merger.cpp
@@ -453,24 +453,11 @@ void SortedRunMergerLocalState::ComputePartitionBoundariesSwitch(SortedRunMerger
                                                                  const optional_idx &p_idx,
                                                                  unsafe_vector<STATE> &states) {
 	switch (sort_key_type) {
-	case SortKeyType::NO_PAYLOAD_FIXED_8:
-		return TemplatedComputePartitionBoundaries<STATE, SortKeyType::NO_PAYLOAD_FIXED_8>(gstate, p_idx, states);
-	case SortKeyType::NO_PAYLOAD_FIXED_16:
-		return TemplatedComputePartitionBoundaries<STATE, SortKeyType::NO_PAYLOAD_FIXED_16>(gstate, p_idx, states);
-	case SortKeyType::NO_PAYLOAD_FIXED_24:
-		return TemplatedComputePartitionBoundaries<STATE, SortKeyType::NO_PAYLOAD_FIXED_24>(gstate, p_idx, states);
-	case SortKeyType::NO_PAYLOAD_FIXED_32:
-		return TemplatedComputePartitionBoundaries<STATE, SortKeyType::NO_PAYLOAD_FIXED_32>(gstate, p_idx, states);
-	case SortKeyType::NO_PAYLOAD_VARIABLE_32:
-		return TemplatedComputePartitionBoundaries<STATE, SortKeyType::NO_PAYLOAD_VARIABLE_32>(gstate, p_idx, states);
-	case SortKeyType::PAYLOAD_FIXED_16:
-		return TemplatedComputePartitionBoundaries<STATE, SortKeyType::PAYLOAD_FIXED_16>(gstate, p_idx, states);
-	case SortKeyType::PAYLOAD_FIXED_24:
-		return TemplatedComputePartitionBoundaries<STATE, SortKeyType::PAYLOAD_FIXED_24>(gstate, p_idx, states);
-	case SortKeyType::PAYLOAD_FIXED_32:
-		return TemplatedComputePartitionBoundaries<STATE, SortKeyType::PAYLOAD_FIXED_32>(gstate, p_idx, states);
-	case SortKeyType::PAYLOAD_VARIABLE_32:
-		return TemplatedComputePartitionBoundaries<STATE, SortKeyType::PAYLOAD_VARIABLE_32>(gstate, p_idx, states);
+#define DUCKDB_SORT_KEY_CASE(SORT_KEY_TYPE)                                                                            \
+	case SortKeyType::SORT_KEY_TYPE:                                                                                   \
+		return TemplatedComputePartitionBoundaries<STATE, SortKeyType::SORT_KEY_TYPE>(gstate, p_idx, states);
+		DUCKDB_FOR_EACH_SORT_KEY_TYPE(DUCKDB_SORT_KEY_CASE)
+#undef DUCKDB_SORT_KEY_CASE
 	default:
 		throw NotImplementedException("SortedRunMergerLocalState::ComputePartitionBoundariesSwitch for %s",
 		                              EnumUtil::ToString(sort_key_type));
@@ -608,24 +595,11 @@ void SortedRunMergerLocalState::MergePartition(SortedRunMergerGlobalState &gstat
 template <class STATE>
 void SortedRunMergerLocalState::MergePartitionSwitch(SortedRunMergerGlobalState &gstate, unsafe_vector<STATE> &states) {
 	switch (sort_key_type) {
-	case SortKeyType::NO_PAYLOAD_FIXED_8:
-		return TemplatedMergePartition<STATE, SortKeyType::NO_PAYLOAD_FIXED_8>(gstate, states);
-	case SortKeyType::NO_PAYLOAD_FIXED_16:
-		return TemplatedMergePartition<STATE, SortKeyType::NO_PAYLOAD_FIXED_16>(gstate, states);
-	case SortKeyType::NO_PAYLOAD_FIXED_24:
-		return TemplatedMergePartition<STATE, SortKeyType::NO_PAYLOAD_FIXED_24>(gstate, states);
-	case SortKeyType::NO_PAYLOAD_FIXED_32:
-		return TemplatedMergePartition<STATE, SortKeyType::NO_PAYLOAD_FIXED_32>(gstate, states);
-	case SortKeyType::NO_PAYLOAD_VARIABLE_32:
-		return TemplatedMergePartition<STATE, SortKeyType::NO_PAYLOAD_VARIABLE_32>(gstate, states);
-	case SortKeyType::PAYLOAD_FIXED_16:
-		return TemplatedMergePartition<STATE, SortKeyType::PAYLOAD_FIXED_16>(gstate, states);
-	case SortKeyType::PAYLOAD_FIXED_24:
-		return TemplatedMergePartition<STATE, SortKeyType::PAYLOAD_FIXED_24>(gstate, states);
-	case SortKeyType::PAYLOAD_FIXED_32:
-		return TemplatedMergePartition<STATE, SortKeyType::PAYLOAD_FIXED_32>(gstate, states);
-	case SortKeyType::PAYLOAD_VARIABLE_32:
-		return TemplatedMergePartition<STATE, SortKeyType::PAYLOAD_VARIABLE_32>(gstate, states);
+#define DUCKDB_SORT_KEY_CASE(SORT_KEY_TYPE)                                                                            \
+	case SortKeyType::SORT_KEY_TYPE:                                                                                   \
+		return TemplatedMergePartition<STATE, SortKeyType::SORT_KEY_TYPE>(gstate, states);
+		DUCKDB_FOR_EACH_SORT_KEY_TYPE(DUCKDB_SORT_KEY_CASE)
+#undef DUCKDB_SORT_KEY_CASE
 	default:
 		throw NotImplementedException("SortedRunMergerLocalState::MergePartitionSwitch for %s",
 		                              EnumUtil::ToString(sort_key_type));
@@ -678,24 +652,11 @@ void SortedRunMergerLocalState::TemplatedMergePartition(SortedRunMergerGlobalSta
 
 void SortedRunMergerLocalState::ScanPartition(SortedRunMergerGlobalState &gstate, DataChunk &chunk) {
 	switch (sort_key_type) {
-	case SortKeyType::NO_PAYLOAD_FIXED_8:
-		return TemplatedScanPartition<SortKeyType::NO_PAYLOAD_FIXED_8>(gstate, chunk);
-	case SortKeyType::NO_PAYLOAD_FIXED_16:
-		return TemplatedScanPartition<SortKeyType::NO_PAYLOAD_FIXED_16>(gstate, chunk);
-	case SortKeyType::NO_PAYLOAD_FIXED_24:
-		return TemplatedScanPartition<SortKeyType::NO_PAYLOAD_FIXED_24>(gstate, chunk);
-	case SortKeyType::NO_PAYLOAD_FIXED_32:
-		return TemplatedScanPartition<SortKeyType::NO_PAYLOAD_FIXED_32>(gstate, chunk);
-	case SortKeyType::NO_PAYLOAD_VARIABLE_32:
-		return TemplatedScanPartition<SortKeyType::NO_PAYLOAD_VARIABLE_32>(gstate, chunk);
-	case SortKeyType::PAYLOAD_FIXED_16:
-		return TemplatedScanPartition<SortKeyType::PAYLOAD_FIXED_16>(gstate, chunk);
-	case SortKeyType::PAYLOAD_FIXED_24:
-		return TemplatedScanPartition<SortKeyType::PAYLOAD_FIXED_24>(gstate, chunk);
-	case SortKeyType::PAYLOAD_FIXED_32:
-		return TemplatedScanPartition<SortKeyType::PAYLOAD_FIXED_32>(gstate, chunk);
-	case SortKeyType::PAYLOAD_VARIABLE_32:
-		return TemplatedScanPartition<SortKeyType::PAYLOAD_VARIABLE_32>(gstate, chunk);
+#define DUCKDB_SORT_KEY_CASE(SORT_KEY_TYPE)                                                                            \
+	case SortKeyType::SORT_KEY_TYPE:                                                                                   \
+		return TemplatedScanPartition<SortKeyType::SORT_KEY_TYPE>(gstate, chunk);
+		DUCKDB_FOR_EACH_SORT_KEY_TYPE(DUCKDB_SORT_KEY_CASE)
+#undef DUCKDB_SORT_KEY_CASE
 	default:
 		throw NotImplementedException("SortedRunMergerLocalState::ScanPartition for %s",
 		                              EnumUtil::ToString(sort_key_type));
@@ -724,33 +685,12 @@ void SortedRunMergerLocalState::TemplatedScanPartition(SortedRunMergerGlobalStat
 void SortedRunMergerLocalState::MaterializePartition(SortedRunMergerGlobalState &gstate) {
 	unique_ptr<SortedRun> sorted_run;
 	switch (sort_key_type) {
-	case SortKeyType::NO_PAYLOAD_FIXED_8:
-		sorted_run = TemplatedMaterializePartition<SortKeyType::NO_PAYLOAD_FIXED_8>(gstate);
+#define DUCKDB_SORT_KEY_CASE(SORT_KEY_TYPE)                                                                            \
+	case SortKeyType::SORT_KEY_TYPE:                                                                                   \
+		sorted_run = TemplatedMaterializePartition<SortKeyType::SORT_KEY_TYPE>(gstate);                                \
 		break;
-	case SortKeyType::NO_PAYLOAD_FIXED_16:
-		sorted_run = TemplatedMaterializePartition<SortKeyType::NO_PAYLOAD_FIXED_16>(gstate);
-		break;
-	case SortKeyType::NO_PAYLOAD_FIXED_24:
-		sorted_run = TemplatedMaterializePartition<SortKeyType::NO_PAYLOAD_FIXED_24>(gstate);
-		break;
-	case SortKeyType::NO_PAYLOAD_FIXED_32:
-		sorted_run = TemplatedMaterializePartition<SortKeyType::NO_PAYLOAD_FIXED_32>(gstate);
-		break;
-	case SortKeyType::NO_PAYLOAD_VARIABLE_32:
-		sorted_run = TemplatedMaterializePartition<SortKeyType::NO_PAYLOAD_VARIABLE_32>(gstate);
-		break;
-	case SortKeyType::PAYLOAD_FIXED_16:
-		sorted_run = TemplatedMaterializePartition<SortKeyType::PAYLOAD_FIXED_16>(gstate);
-		break;
-	case SortKeyType::PAYLOAD_FIXED_24:
-		sorted_run = TemplatedMaterializePartition<SortKeyType::PAYLOAD_FIXED_24>(gstate);
-		break;
-	case SortKeyType::PAYLOAD_FIXED_32:
-		sorted_run = TemplatedMaterializePartition<SortKeyType::PAYLOAD_FIXED_32>(gstate);
-		break;
-	case SortKeyType::PAYLOAD_VARIABLE_32:
-		sorted_run = TemplatedMaterializePartition<SortKeyType::PAYLOAD_VARIABLE_32>(gstate);
-		break;
+		DUCKDB_FOR_EACH_SORT_KEY_TYPE(DUCKDB_SORT_KEY_CASE)
+#undef DUCKDB_SORT_KEY_CASE
 	default:
 		throw NotImplementedException("SortedRunMergerLocalState::MaterializePartition for %s",
 		                              EnumUtil::ToString(sort_key_type));

--- a/src/common/types/row/tuple_data_allocator.cpp
+++ b/src/common/types/row/tuple_data_allocator.cpp
@@ -382,22 +382,13 @@ void TemplatedSortKeySetPayload(const data_ptr_t row_locations[], const idx_t of
 void SortKeySetPayload(const data_ptr_t row_locations[], const idx_t offset, const idx_t count,
                        const SortKeyPayloadState &sort_key_payload_state) {
 	switch (sort_key_payload_state.sort_key_type) {
-	case SortKeyType::PAYLOAD_FIXED_16:
-		TemplatedSortKeySetPayload<SortKeyType::PAYLOAD_FIXED_16>(row_locations, offset, count,
-		                                                          sort_key_payload_state.sort_key_chunk_state);
+#define DUCKDB_SORT_KEY_CASE(SORT_KEY_TYPE)                                                                            \
+	case SortKeyType::SORT_KEY_TYPE:                                                                                   \
+		TemplatedSortKeySetPayload<SortKeyType::SORT_KEY_TYPE>(row_locations, offset, count,                           \
+		                                                       sort_key_payload_state.sort_key_chunk_state);           \
 		break;
-	case SortKeyType::PAYLOAD_FIXED_24:
-		TemplatedSortKeySetPayload<SortKeyType::PAYLOAD_FIXED_24>(row_locations, offset, count,
-		                                                          sort_key_payload_state.sort_key_chunk_state);
-		break;
-	case SortKeyType::PAYLOAD_FIXED_32:
-		TemplatedSortKeySetPayload<SortKeyType::PAYLOAD_FIXED_32>(row_locations, offset, count,
-		                                                          sort_key_payload_state.sort_key_chunk_state);
-		break;
-	case SortKeyType::PAYLOAD_VARIABLE_32:
-		TemplatedSortKeySetPayload<SortKeyType::PAYLOAD_VARIABLE_32>(row_locations, offset, count,
-		                                                             sort_key_payload_state.sort_key_chunk_state);
-		break;
+		DUCKDB_FOR_EACH_PAYLOAD_SORT_KEY_TYPE(DUCKDB_SORT_KEY_CASE)
+#undef DUCKDB_SORT_KEY_CASE
 	default:
 		throw NotImplementedException("SortKeySetPayload for %s",
 		                              EnumUtil::ToString(sort_key_payload_state.sort_key_type));

--- a/src/common/types/row/tuple_data_layout.cpp
+++ b/src/common/types/row/tuple_data_layout.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/common/types/row/tuple_data_layout.hpp"
 
+#include "duckdb/common/smaller_binary.hpp"
 #include "duckdb/common/sorting/sort_key.hpp"
 
 namespace duckdb {
@@ -199,6 +200,18 @@ void TupleDataLayout::Initialize(const vector<BoundOrderByNode> &orders, const L
 	if (sort_width != DConstants::INVALID_INDEX && has_payload) {
 		temp_row_width += 8;
 	}
+#if DUCKDB_SMALLER_BINARY(sort_key_layouts)
+	// Round the key up to the nearest layout that DUCKDB_FOR_EACH_SORT_KEY_TYPE still keeps. A key
+	// without payload widens to the 32-byte one rather than falling back to the variable-size key,
+	// which would cost far more than the wider row: a variable-size key compares through the heap.
+	if (has_payload) {
+		if (temp_row_width > 24) {
+			temp_row_width = DConstants::INVALID_INDEX;
+		}
+	} else if (temp_row_width > 8 && temp_row_width <= 32) {
+		temp_row_width = 32;
+	}
+#endif
 	if (temp_row_width <= 8) {
 		D_ASSERT(!has_payload);
 		row_width = 8;

--- a/src/common/types/row/tuple_data_scatter_gather.cpp
+++ b/src/common/types/row/tuple_data_scatter_gather.cpp
@@ -1291,33 +1291,12 @@ template <class T>
 TupleDataScatterFunction GetSortKeyScatterFunctionInternal(SortKeyType sort_key_type) {
 	TupleDataScatterFunction result;
 	switch (sort_key_type) {
-	case SortKeyType::NO_PAYLOAD_FIXED_8:
-		result.function = TupleDataSortKeyScatter<T, SortKeyType::NO_PAYLOAD_FIXED_8>;
+#define DUCKDB_SORT_KEY_CASE(SORT_KEY_TYPE)                                                                            \
+	case SortKeyType::SORT_KEY_TYPE:                                                                                   \
+		result.function = TupleDataSortKeyScatter<T, SortKeyType::SORT_KEY_TYPE>;                                      \
 		break;
-	case SortKeyType::NO_PAYLOAD_FIXED_16:
-		result.function = TupleDataSortKeyScatter<T, SortKeyType::NO_PAYLOAD_FIXED_16>;
-		break;
-	case SortKeyType::NO_PAYLOAD_FIXED_24:
-		result.function = TupleDataSortKeyScatter<T, SortKeyType::NO_PAYLOAD_FIXED_24>;
-		break;
-	case SortKeyType::NO_PAYLOAD_FIXED_32:
-		result.function = TupleDataSortKeyScatter<T, SortKeyType::NO_PAYLOAD_FIXED_32>;
-		break;
-	case SortKeyType::NO_PAYLOAD_VARIABLE_32:
-		result.function = TupleDataSortKeyScatter<T, SortKeyType::NO_PAYLOAD_VARIABLE_32>;
-		break;
-	case SortKeyType::PAYLOAD_FIXED_16:
-		result.function = TupleDataSortKeyScatter<T, SortKeyType::PAYLOAD_FIXED_16>;
-		break;
-	case SortKeyType::PAYLOAD_FIXED_24:
-		result.function = TupleDataSortKeyScatter<T, SortKeyType::PAYLOAD_FIXED_24>;
-		break;
-	case SortKeyType::PAYLOAD_FIXED_32:
-		result.function = TupleDataSortKeyScatter<T, SortKeyType::PAYLOAD_FIXED_32>;
-		break;
-	case SortKeyType::PAYLOAD_VARIABLE_32:
-		result.function = TupleDataSortKeyScatter<T, SortKeyType::PAYLOAD_VARIABLE_32>;
-		break;
+		DUCKDB_FOR_EACH_SORT_KEY_TYPE(DUCKDB_SORT_KEY_CASE)
+#undef DUCKDB_SORT_KEY_CASE
 	default:
 		throw NotImplementedException("GetSortKeyScatterFunction for %s", EnumUtil::ToString(sort_key_type));
 	}
@@ -1940,33 +1919,12 @@ template <class T>
 TupleDataGatherFunction GetSortKeyGatherFunctionInternal(SortKeyType sort_key_type) {
 	tuple_data_gather_function_t function = nullptr;
 	switch (sort_key_type) {
-	case SortKeyType::NO_PAYLOAD_FIXED_8:
-		function = TupleDataSortKeyGather<T, SortKeyType::NO_PAYLOAD_FIXED_8>;
+#define DUCKDB_SORT_KEY_CASE(SORT_KEY_TYPE)                                                                            \
+	case SortKeyType::SORT_KEY_TYPE:                                                                                   \
+		function = TupleDataSortKeyGather<T, SortKeyType::SORT_KEY_TYPE>;                                              \
 		break;
-	case SortKeyType::NO_PAYLOAD_FIXED_16:
-		function = TupleDataSortKeyGather<T, SortKeyType::NO_PAYLOAD_FIXED_16>;
-		break;
-	case SortKeyType::NO_PAYLOAD_FIXED_24:
-		function = TupleDataSortKeyGather<T, SortKeyType::NO_PAYLOAD_FIXED_24>;
-		break;
-	case SortKeyType::NO_PAYLOAD_FIXED_32:
-		function = TupleDataSortKeyGather<T, SortKeyType::NO_PAYLOAD_FIXED_32>;
-		break;
-	case SortKeyType::NO_PAYLOAD_VARIABLE_32:
-		function = TupleDataSortKeyGather<T, SortKeyType::NO_PAYLOAD_VARIABLE_32>;
-		break;
-	case SortKeyType::PAYLOAD_FIXED_16:
-		function = TupleDataSortKeyGather<T, SortKeyType::PAYLOAD_FIXED_16>;
-		break;
-	case SortKeyType::PAYLOAD_FIXED_24:
-		function = TupleDataSortKeyGather<T, SortKeyType::PAYLOAD_FIXED_24>;
-		break;
-	case SortKeyType::PAYLOAD_FIXED_32:
-		function = TupleDataSortKeyGather<T, SortKeyType::PAYLOAD_FIXED_32>;
-		break;
-	case SortKeyType::PAYLOAD_VARIABLE_32:
-		function = TupleDataSortKeyGather<T, SortKeyType::PAYLOAD_VARIABLE_32>;
-		break;
+		DUCKDB_FOR_EACH_SORT_KEY_TYPE(DUCKDB_SORT_KEY_CASE)
+#undef DUCKDB_SORT_KEY_CASE
 	default:
 		throw NotImplementedException("GetSortKeyGatherFunction for %s", EnumUtil::ToString(sort_key_type));
 	}

--- a/src/execution/operator/join/physical_asof_join.cpp
+++ b/src/execution/operator/join/physical_asof_join.cpp
@@ -276,33 +276,12 @@ AsOfPayloadScanner::AsOfPayloadScanner(const SortedRun &sorted_run, const SortSt
 	scan_chunk.Initialize(sorted_run.context, sort_strategy.payload_types);
 	const auto sort_key_type = sorted_run.key_data->GetLayout().GetSortKeyType();
 	switch (sort_key_type) {
-	case SortKeyType::NO_PAYLOAD_FIXED_8:
-		scan_func = &AsOfPayloadScanner::TemplatedScan<SortKeyType::NO_PAYLOAD_FIXED_8>;
+#define DUCKDB_SORT_KEY_CASE(SORT_KEY_TYPE)                                                                            \
+	case SortKeyType::SORT_KEY_TYPE:                                                                                   \
+		scan_func = &AsOfPayloadScanner::TemplatedScan<SortKeyType::SORT_KEY_TYPE>;                                    \
 		break;
-	case SortKeyType::NO_PAYLOAD_FIXED_16:
-		scan_func = &AsOfPayloadScanner::TemplatedScan<SortKeyType::NO_PAYLOAD_FIXED_16>;
-		break;
-	case SortKeyType::NO_PAYLOAD_FIXED_24:
-		scan_func = &AsOfPayloadScanner::TemplatedScan<SortKeyType::NO_PAYLOAD_FIXED_24>;
-		break;
-	case SortKeyType::NO_PAYLOAD_FIXED_32:
-		scan_func = &AsOfPayloadScanner::TemplatedScan<SortKeyType::NO_PAYLOAD_FIXED_32>;
-		break;
-	case SortKeyType::NO_PAYLOAD_VARIABLE_32:
-		scan_func = &AsOfPayloadScanner::TemplatedScan<SortKeyType::NO_PAYLOAD_VARIABLE_32>;
-		break;
-	case SortKeyType::PAYLOAD_FIXED_16:
-		scan_func = &AsOfPayloadScanner::TemplatedScan<SortKeyType::PAYLOAD_FIXED_16>;
-		break;
-	case SortKeyType::PAYLOAD_FIXED_24:
-		scan_func = &AsOfPayloadScanner::TemplatedScan<SortKeyType::PAYLOAD_FIXED_24>;
-		break;
-	case SortKeyType::PAYLOAD_FIXED_32:
-		scan_func = &AsOfPayloadScanner::TemplatedScan<SortKeyType::PAYLOAD_FIXED_32>;
-		break;
-	case SortKeyType::PAYLOAD_VARIABLE_32:
-		scan_func = &AsOfPayloadScanner::TemplatedScan<SortKeyType::PAYLOAD_VARIABLE_32>;
-		break;
+		DUCKDB_FOR_EACH_SORT_KEY_TYPE(DUCKDB_SORT_KEY_CASE)
+#undef DUCKDB_SORT_KEY_CASE
 	default:
 		throw NotImplementedException("AsOfPayloadScanner for %s", EnumUtil::ToString(sort_key_type));
 	}
@@ -962,33 +941,12 @@ void AsOfProbeBuffer::BeginLeftScan(TaskPtr task_p) {
 	//	Set up function pointer for sort type
 	const auto sort_key_type = left_group->key_data->GetLayout().GetSortKeyType();
 	switch (sort_key_type) {
-	case SortKeyType::NO_PAYLOAD_FIXED_8:
-		resolve_join_func = &AsOfProbeBuffer::ResolveJoin<SortKeyType::NO_PAYLOAD_FIXED_8>;
+#define DUCKDB_SORT_KEY_CASE(SORT_KEY_TYPE)                                                                            \
+	case SortKeyType::SORT_KEY_TYPE:                                                                                   \
+		resolve_join_func = &AsOfProbeBuffer::ResolveJoin<SortKeyType::SORT_KEY_TYPE>;                                 \
 		break;
-	case SortKeyType::NO_PAYLOAD_FIXED_16:
-		resolve_join_func = &AsOfProbeBuffer::ResolveJoin<SortKeyType::NO_PAYLOAD_FIXED_16>;
-		break;
-	case SortKeyType::NO_PAYLOAD_FIXED_24:
-		resolve_join_func = &AsOfProbeBuffer::ResolveJoin<SortKeyType::NO_PAYLOAD_FIXED_24>;
-		break;
-	case SortKeyType::NO_PAYLOAD_FIXED_32:
-		resolve_join_func = &AsOfProbeBuffer::ResolveJoin<SortKeyType::NO_PAYLOAD_FIXED_32>;
-		break;
-	case SortKeyType::NO_PAYLOAD_VARIABLE_32:
-		resolve_join_func = &AsOfProbeBuffer::ResolveJoin<SortKeyType::NO_PAYLOAD_VARIABLE_32>;
-		break;
-	case SortKeyType::PAYLOAD_FIXED_16:
-		resolve_join_func = &AsOfProbeBuffer::ResolveJoin<SortKeyType::PAYLOAD_FIXED_16>;
-		break;
-	case SortKeyType::PAYLOAD_FIXED_24:
-		resolve_join_func = &AsOfProbeBuffer::ResolveJoin<SortKeyType::PAYLOAD_FIXED_24>;
-		break;
-	case SortKeyType::PAYLOAD_FIXED_32:
-		resolve_join_func = &AsOfProbeBuffer::ResolveJoin<SortKeyType::PAYLOAD_FIXED_32>;
-		break;
-	case SortKeyType::PAYLOAD_VARIABLE_32:
-		resolve_join_func = &AsOfProbeBuffer::ResolveJoin<SortKeyType::PAYLOAD_VARIABLE_32>;
-		break;
+		DUCKDB_FOR_EACH_SORT_KEY_TYPE(DUCKDB_SORT_KEY_CASE)
+#undef DUCKDB_SORT_KEY_CASE
 	default:
 		throw NotImplementedException("Unsupported comparison type for ASOF join");
 	}

--- a/src/execution/operator/join/physical_iejoin.cpp
+++ b/src/execution/operator/join/physical_iejoin.cpp
@@ -657,33 +657,12 @@ IEJoinUnion::IEJoinUnion(IEJoinGlobalSourceState &gsource, const ChunkRange &chu
 
 	const auto sort_key_type = l2.GetSortKeyType();
 	switch (sort_key_type) {
-	case SortKeyType::NO_PAYLOAD_FIXED_8:
-		next_row_func = &IEJoinUnion::NextRow<SortKeyType::NO_PAYLOAD_FIXED_8>;
+#define DUCKDB_SORT_KEY_CASE(SORT_KEY_TYPE)                                                                            \
+	case SortKeyType::SORT_KEY_TYPE:                                                                                   \
+		next_row_func = &IEJoinUnion::NextRow<SortKeyType::SORT_KEY_TYPE>;                                             \
 		break;
-	case SortKeyType::NO_PAYLOAD_FIXED_16:
-		next_row_func = &IEJoinUnion::NextRow<SortKeyType::NO_PAYLOAD_FIXED_16>;
-		break;
-	case SortKeyType::NO_PAYLOAD_FIXED_24:
-		next_row_func = &IEJoinUnion::NextRow<SortKeyType::NO_PAYLOAD_FIXED_24>;
-		break;
-	case SortKeyType::NO_PAYLOAD_FIXED_32:
-		next_row_func = &IEJoinUnion::NextRow<SortKeyType::NO_PAYLOAD_FIXED_32>;
-		break;
-	case SortKeyType::NO_PAYLOAD_VARIABLE_32:
-		next_row_func = &IEJoinUnion::NextRow<SortKeyType::NO_PAYLOAD_VARIABLE_32>;
-		break;
-	case SortKeyType::PAYLOAD_FIXED_16:
-		next_row_func = &IEJoinUnion::NextRow<SortKeyType::PAYLOAD_FIXED_16>;
-		break;
-	case SortKeyType::PAYLOAD_FIXED_24:
-		next_row_func = &IEJoinUnion::NextRow<SortKeyType::PAYLOAD_FIXED_24>;
-		break;
-	case SortKeyType::PAYLOAD_FIXED_32:
-		next_row_func = &IEJoinUnion::NextRow<SortKeyType::PAYLOAD_FIXED_32>;
-		break;
-	case SortKeyType::PAYLOAD_VARIABLE_32:
-		next_row_func = &IEJoinUnion::NextRow<SortKeyType::PAYLOAD_VARIABLE_32>;
-		break;
+		DUCKDB_FOR_EACH_SORT_KEY_TYPE(DUCKDB_SORT_KEY_CASE)
+#undef DUCKDB_SORT_KEY_CASE
 	default:
 		throw NotImplementedException("IEJoinUnion for %s", EnumUtil::ToString(sort_key_type));
 	}

--- a/src/execution/operator/join/physical_piecewise_merge_join.cpp
+++ b/src/execution/operator/join/physical_piecewise_merge_join.cpp
@@ -452,24 +452,11 @@ static idx_t MergeJoinSimpleBlocks(PiecewiseMergeJoinState &lstate, MergeJoinGlo
 	const auto strict = MergeJoinStrictComparison(comparison);
 
 	switch (lstate.sort_key_type) {
-	case SortKeyType::NO_PAYLOAD_FIXED_8:
-		return TemplatedMergeJoinSimpleBlocks<SortKeyType::NO_PAYLOAD_FIXED_8>(lstate, gstate, match, strict);
-	case SortKeyType::NO_PAYLOAD_FIXED_16:
-		return TemplatedMergeJoinSimpleBlocks<SortKeyType::NO_PAYLOAD_FIXED_16>(lstate, gstate, match, strict);
-	case SortKeyType::NO_PAYLOAD_FIXED_24:
-		return TemplatedMergeJoinSimpleBlocks<SortKeyType::NO_PAYLOAD_FIXED_24>(lstate, gstate, match, strict);
-	case SortKeyType::NO_PAYLOAD_FIXED_32:
-		return TemplatedMergeJoinSimpleBlocks<SortKeyType::NO_PAYLOAD_FIXED_32>(lstate, gstate, match, strict);
-	case SortKeyType::NO_PAYLOAD_VARIABLE_32:
-		return TemplatedMergeJoinSimpleBlocks<SortKeyType::NO_PAYLOAD_VARIABLE_32>(lstate, gstate, match, strict);
-	case SortKeyType::PAYLOAD_FIXED_16:
-		return TemplatedMergeJoinSimpleBlocks<SortKeyType::PAYLOAD_FIXED_16>(lstate, gstate, match, strict);
-	case SortKeyType::PAYLOAD_FIXED_24:
-		return TemplatedMergeJoinSimpleBlocks<SortKeyType::PAYLOAD_FIXED_24>(lstate, gstate, match, strict);
-	case SortKeyType::PAYLOAD_FIXED_32:
-		return TemplatedMergeJoinSimpleBlocks<SortKeyType::PAYLOAD_FIXED_32>(lstate, gstate, match, strict);
-	case SortKeyType::PAYLOAD_VARIABLE_32:
-		return TemplatedMergeJoinSimpleBlocks<SortKeyType::PAYLOAD_VARIABLE_32>(lstate, gstate, match, strict);
+#define DUCKDB_SORT_KEY_CASE(SORT_KEY_TYPE)                                                                            \
+	case SortKeyType::SORT_KEY_TYPE:                                                                                   \
+		return TemplatedMergeJoinSimpleBlocks<SortKeyType::SORT_KEY_TYPE>(lstate, gstate, match, strict);
+		DUCKDB_FOR_EACH_SORT_KEY_TYPE(DUCKDB_SORT_KEY_CASE)
+#undef DUCKDB_SORT_KEY_CASE
 	default:
 		throw NotImplementedException("MergeJoinSimpleBlocks for %s", EnumUtil::ToString(lstate.sort_key_type));
 	}
@@ -614,24 +601,11 @@ static idx_t MergeJoinComplexBlocks(const SortKeyType &sort_key_type, ChunkMerge
 	const auto strict = MergeJoinStrictComparison(comparison);
 
 	switch (sort_key_type) {
-	case SortKeyType::NO_PAYLOAD_FIXED_8:
-		return TemplatedMergeJoinComplexBlocks<SortKeyType::NO_PAYLOAD_FIXED_8>(l, r, strict, prev_left_index);
-	case SortKeyType::NO_PAYLOAD_FIXED_16:
-		return TemplatedMergeJoinComplexBlocks<SortKeyType::NO_PAYLOAD_FIXED_16>(l, r, strict, prev_left_index);
-	case SortKeyType::NO_PAYLOAD_FIXED_24:
-		return TemplatedMergeJoinComplexBlocks<SortKeyType::NO_PAYLOAD_FIXED_24>(l, r, strict, prev_left_index);
-	case SortKeyType::NO_PAYLOAD_FIXED_32:
-		return TemplatedMergeJoinComplexBlocks<SortKeyType::NO_PAYLOAD_FIXED_32>(l, r, strict, prev_left_index);
-	case SortKeyType::NO_PAYLOAD_VARIABLE_32:
-		return TemplatedMergeJoinComplexBlocks<SortKeyType::NO_PAYLOAD_VARIABLE_32>(l, r, strict, prev_left_index);
-	case SortKeyType::PAYLOAD_FIXED_16:
-		return TemplatedMergeJoinComplexBlocks<SortKeyType::PAYLOAD_FIXED_16>(l, r, strict, prev_left_index);
-	case SortKeyType::PAYLOAD_FIXED_24:
-		return TemplatedMergeJoinComplexBlocks<SortKeyType::PAYLOAD_FIXED_24>(l, r, strict, prev_left_index);
-	case SortKeyType::PAYLOAD_FIXED_32:
-		return TemplatedMergeJoinComplexBlocks<SortKeyType::PAYLOAD_FIXED_32>(l, r, strict, prev_left_index);
-	case SortKeyType::PAYLOAD_VARIABLE_32:
-		return TemplatedMergeJoinComplexBlocks<SortKeyType::PAYLOAD_VARIABLE_32>(l, r, strict, prev_left_index);
+#define DUCKDB_SORT_KEY_CASE(SORT_KEY_TYPE)                                                                            \
+	case SortKeyType::SORT_KEY_TYPE:                                                                                   \
+		return TemplatedMergeJoinComplexBlocks<SortKeyType::SORT_KEY_TYPE>(l, r, strict, prev_left_index);
+		DUCKDB_FOR_EACH_SORT_KEY_TYPE(DUCKDB_SORT_KEY_CASE)
+#undef DUCKDB_SORT_KEY_CASE
 	default:
 		throw NotImplementedException("MergeJoinSimpleBlocks for %s", EnumUtil::ToString(sort_key_type));
 	}

--- a/src/execution/operator/join/physical_range_join.cpp
+++ b/src/execution/operator/join/physical_range_join.cpp
@@ -506,42 +506,13 @@ void PhysicalRangeJoin::SliceSortedPayload(DataChunk &chunk, GlobalSortedTable &
 	const auto sort_key_type = table.GetSortKeyType();
 
 	switch (sort_key_type) {
-	case SortKeyType::NO_PAYLOAD_FIXED_8:
-		TemplatedSliceSortedPayload<SortKeyType::NO_PAYLOAD_FIXED_8>(chunk, sorted, state, sort_keys, scan_state,
-		                                                             chunk_idx, result);
+#define DUCKDB_SORT_KEY_CASE(SORT_KEY_TYPE)                                                                            \
+	case SortKeyType::SORT_KEY_TYPE:                                                                                   \
+		TemplatedSliceSortedPayload<SortKeyType::SORT_KEY_TYPE>(chunk, sorted, state, sort_keys, scan_state,           \
+		                                                        chunk_idx, result);                                    \
 		break;
-	case SortKeyType::NO_PAYLOAD_FIXED_16:
-		TemplatedSliceSortedPayload<SortKeyType::NO_PAYLOAD_FIXED_16>(chunk, sorted, state, sort_keys, scan_state,
-		                                                              chunk_idx, result);
-		break;
-	case SortKeyType::NO_PAYLOAD_FIXED_24:
-		TemplatedSliceSortedPayload<SortKeyType::NO_PAYLOAD_FIXED_24>(chunk, sorted, state, sort_keys, scan_state,
-		                                                              chunk_idx, result);
-		break;
-	case SortKeyType::NO_PAYLOAD_FIXED_32:
-		TemplatedSliceSortedPayload<SortKeyType::NO_PAYLOAD_FIXED_32>(chunk, sorted, state, sort_keys, scan_state,
-		                                                              chunk_idx, result);
-		break;
-	case SortKeyType::NO_PAYLOAD_VARIABLE_32:
-		TemplatedSliceSortedPayload<SortKeyType::NO_PAYLOAD_VARIABLE_32>(chunk, sorted, state, sort_keys, scan_state,
-		                                                                 chunk_idx, result);
-		break;
-	case SortKeyType::PAYLOAD_FIXED_16:
-		TemplatedSliceSortedPayload<SortKeyType::PAYLOAD_FIXED_16>(chunk, sorted, state, sort_keys, scan_state,
-		                                                           chunk_idx, result);
-		break;
-	case SortKeyType::PAYLOAD_FIXED_24:
-		TemplatedSliceSortedPayload<SortKeyType::PAYLOAD_FIXED_24>(chunk, sorted, state, sort_keys, scan_state,
-		                                                           chunk_idx, result);
-		break;
-	case SortKeyType::PAYLOAD_FIXED_32:
-		TemplatedSliceSortedPayload<SortKeyType::PAYLOAD_FIXED_32>(chunk, sorted, state, sort_keys, scan_state,
-		                                                           chunk_idx, result);
-		break;
-	case SortKeyType::PAYLOAD_VARIABLE_32:
-		TemplatedSliceSortedPayload<SortKeyType::PAYLOAD_VARIABLE_32>(chunk, sorted, state, sort_keys, scan_state,
-		                                                              chunk_idx, result);
-		break;
+		DUCKDB_FOR_EACH_SORT_KEY_TYPE(DUCKDB_SORT_KEY_CASE)
+#undef DUCKDB_SORT_KEY_CASE
 	default:
 		throw NotImplementedException("MergeJoinSimpleBlocks for %s", EnumUtil::ToString(sort_key_type));
 	}

--- a/src/include/duckdb/common/smaller_binary.hpp
+++ b/src/include/duckdb/common/smaller_binary.hpp
@@ -167,3 +167,12 @@
 #ifndef DUCKDB_SB_FEATURE_mad_window
 #define DUCKDB_SB_FEATURE_mad_window DUCKDB_SB_DEFAULT // group: window_specialization
 #endif
+
+// --- sort_specialization: per-layout instances of the sorting stack -----------------------------
+// The whole sorting stack (run sort, merge, sort key scatter/gather, range joins) is templated on
+// SortKeyType, so each of the nine layouts is a full instance of it, ~70 KB. Trimming binds a
+// wider layout instead, which costs memory and time on every sort, not just code size.
+
+#ifndef DUCKDB_SB_FEATURE_sort_key_layouts
+#define DUCKDB_SB_FEATURE_sort_key_layouts DUCKDB_SB_DEFAULT // group: sort_specialization
+#endif

--- a/src/include/duckdb/common/sorting/sort_key.hpp
+++ b/src/include/duckdb/common/sorting/sort_key.hpp
@@ -11,6 +11,7 @@
 #include "duckdb/common/bswap.hpp"
 #include "duckdb/common/enum_util.hpp"
 #include "duckdb/common/fast_mem.hpp"
+#include "duckdb/common/smaller_binary.hpp"
 #include "duckdb/common/typedefs.hpp"
 #include "duckdb/common/types/string_type.hpp"
 
@@ -30,6 +31,71 @@ enum class SortKeyType : uint8_t {
 	PAYLOAD_FIXED_32 = 8,
 	PAYLOAD_VARIABLE_32 = 9,
 };
+
+//! Expands MACRO once for every SortKeyType that TupleDataLayout can produce.
+//! The entire sorting stack is templated on SortKeyType, so every entry here multiplies the
+//! amount of code generated for sorting, merging, scattering/gathering and the range joins.
+//! All nine together are ~623 KB of a Release build, ~70 KB each.
+//!
+//! The sort_key_layouts feature drops the three layouts that can be replaced by a wider one that
+//! is already there: a key without payload rounds up to NO_PAYLOAD_FIXED_32, and a payload key
+//! wider than 24 bytes falls back to PAYLOAD_VARIABLE_32. See TupleDataLayout::Initialize.
+//!
+//! What is left cannot go. NO_PAYLOAD_FIXED_8 and PAYLOAD_FIXED_16 are the BIGINT sort key, and
+//! VariableSortKey::Construct(int64_t) throws. PAYLOAD_FIXED_24 is what an index build over an
+//! 8-byte column uses (a 9-byte key plus the row pointer) and it is the most memory-sensitive sort
+//! we do: widening it fails test_art_mem_limit.test, which builds one under a 10MB memory_limit.
+//!
+//! This trades real time for code size. Order By over 20M rows, trimmed vs not, against a 1.19x
+//! noise band measured by running the same binary in both slots:
+//!   ORDER BY 1x INTEGER  NO_PAYLOAD_FIXED_8  kept          1.06x
+//!   ORDER BY 1x BIGINT   NO_PAYLOAD_FIXED_16 -> FIXED_32   1.56x
+//!   ORDER BY 2x BIGINT   NO_PAYLOAD_FIXED_24 -> FIXED_32   1.26x
+//!   ORDER BY 3x BIGINT   NO_PAYLOAD_FIXED_32 kept          1.03x
+//! for 297 KB off the dylib, the same whether this feature is trimmed on its own or as part of a
+//! full SMALLER_BINARY=1 build. Dropping NO_PAYLOAD_FIXED_32 and PAYLOAD_FIXED_24 as well, so that
+//! everything collapses onto the variable-size key, saves ~90 KB more but costs 1.6-2.4x instead,
+//! because a variable-size key compares through the heap. Re-measure before trimming further.
+#if DUCKDB_SMALLER_BINARY(sort_key_layouts)
+#define DUCKDB_FOR_EACH_SORT_KEY_TYPE(MACRO)                                                                           \
+	MACRO(NO_PAYLOAD_FIXED_8)                                                                                          \
+	MACRO(NO_PAYLOAD_FIXED_32)                                                                                         \
+	MACRO(NO_PAYLOAD_VARIABLE_32)                                                                                      \
+	MACRO(PAYLOAD_FIXED_16)                                                                                            \
+	MACRO(PAYLOAD_FIXED_24)                                                                                            \
+	MACRO(PAYLOAD_VARIABLE_32)
+#else
+#define DUCKDB_FOR_EACH_SORT_KEY_TYPE(MACRO)                                                                           \
+	MACRO(NO_PAYLOAD_FIXED_8)                                                                                          \
+	MACRO(NO_PAYLOAD_FIXED_16)                                                                                         \
+	MACRO(NO_PAYLOAD_FIXED_24)                                                                                         \
+	MACRO(NO_PAYLOAD_FIXED_32)                                                                                         \
+	MACRO(NO_PAYLOAD_VARIABLE_32)                                                                                      \
+	MACRO(PAYLOAD_FIXED_16)                                                                                            \
+	MACRO(PAYLOAD_FIXED_24)                                                                                            \
+	MACRO(PAYLOAD_FIXED_32)                                                                                            \
+	MACRO(PAYLOAD_VARIABLE_32)
+#endif
+
+//! Same as above, restricted to the sort key types that carry a payload pointer
+#if DUCKDB_SMALLER_BINARY(sort_key_layouts)
+#define DUCKDB_FOR_EACH_PAYLOAD_SORT_KEY_TYPE(MACRO)                                                                   \
+	MACRO(PAYLOAD_FIXED_16)                                                                                            \
+	MACRO(PAYLOAD_FIXED_24)                                                                                            \
+	MACRO(PAYLOAD_VARIABLE_32)
+#else
+#define DUCKDB_FOR_EACH_PAYLOAD_SORT_KEY_TYPE(MACRO)                                                                   \
+	MACRO(PAYLOAD_FIXED_16)                                                                                            \
+	MACRO(PAYLOAD_FIXED_24)                                                                                            \
+	MACRO(PAYLOAD_FIXED_32)                                                                                            \
+	MACRO(PAYLOAD_VARIABLE_32)
+#endif
+
+//! Same as above, restricted to the sort key types that need reordering when going external,
+//! i.e. those that are not constant size, or that carry a payload pointer
+#define DUCKDB_FOR_EACH_REORDERABLE_SORT_KEY_TYPE(MACRO)                                                               \
+	MACRO(NO_PAYLOAD_VARIABLE_32)                                                                                      \
+	DUCKDB_FOR_EACH_PAYLOAD_SORT_KEY_TYPE(MACRO)
 
 //! Forces a pointer size of 8 bytes (even on 32-bit)
 struct sort_key_ptr_t { // NOLINT: match stl case


### PR DESCRIPTION
The whole sorting stack - the run sort, the merger, the sort key scatter/gather and the three range joins - is templated on SortKeyType, and every dispatch site enumerated all 9 layouts by hand. That is 9 instances of vergesort, ska_sort and pdqsort in the binary, ~623 KB, and 17 near-identical switch statements to keep in sync.

Replace those switches with a DUCKDB_FOR_EACH_SORT_KEY_TYPE X-macro (plus the payload-only and reorderable subsets) so the enabled set is declared once, and register a sort_key_layouts feature that drops the three layouts replaceable by a wider one already present: a key without payload rounds up to NO_PAYLOAD_FIXED_32, and a payload key over 24 bytes falls back to PAYLOAD_VARIABLE_32.

The other six cannot go. NO_PAYLOAD_FIXED_8 and PAYLOAD_FIXED_16 are the BIGINT sort key and VariableSortKey::Construct(int64_t) throws; PAYLOAD_FIXED_24 is what an index build over an 8-byte column uses, and widening it fails test_art_mem_limit.test, which builds one under a 10MB memory_limit.

This buys code size with time. Order By over 20M rows, trimmed vs not, against a 1.19x noise band measured by running one binary in both slots:

```
  ORDER BY 1x INTEGER  NO_PAYLOAD_FIXED_8  kept          1.06x
  ORDER BY 1x BIGINT   NO_PAYLOAD_FIXED_16 -> FIXED_32   1.56x
  ORDER BY 2x BIGINT   NO_PAYLOAD_FIXED_24 -> FIXED_32   1.26x
  ORDER BY 3x BIGINT   NO_PAYLOAD_FIXED_32 kept          1.03x
```

Collapsing everything onto the variable-size key saves ~90 KB more but costs 1.6-2.4x, because a variable-size key compares through the heap.

----

Size measurements, duckdb CLI, macOS arm64:
```
                                    make   SMALLER_BINARY=1   +EXCEPT=sort_key_layouts
  before                      56,880,936         46,937,432                        n/a
  after                       56,880,936         46,640,152                 46,937,432
```

Both n/a-free columns are byte-identical before and after, so the feature is the only difference: -297,280 on the CLI, -297,296 on libduckdb.dylib, and the same whether it is trimmed alone or inside a full SMALLER_BINARY=1 build.