### PR TITLE
fix: prevent integer overflow when rounding at negative precision

### DIFF
--- a/extension/core_functions/scalar/math/numeric.cpp
+++ b/extension/core_functions/scalar/math/numeric.cpp
@@ -963,17 +963,26 @@ struct RoundIntegerOperator {
 				return 0;
 			}
 			const auto power_of_ten = POWERS_OF_TEN_CLASS::POWERS_OF_TEN[-precision];
-			auto addition = power_of_ten / 2;
-			if (input < 0) {
-				addition = -addition;
+			//	Divide and compute the remainder instead of adding, to avoid overflowing the
+			//	intermediate addition for values near the boundaries of the type
+			TA quotient = UnsafeNumericCast<TA>(input / power_of_ten);
+			TA remainder = UnsafeNumericCast<TA>(input % power_of_ten);
+			if (remainder < 0) {
+				remainder = -remainder;
 			}
-			addition += input;
-			addition /= power_of_ten;
-			if (addition) {
-				return UnsafeNumericCast<TR>(addition * power_of_ten);
-			} else {
+			//	Round half away from zero: round up when the remainder reaches half the power of ten
+			if (remainder >= power_of_ten - remainder) {
+				quotient += (input < 0) ? -1 : 1;
+			}
+			if (quotient == 0) {
 				return 0;
 			}
+			//	Multiply the rounded quotient back, checking for overflow
+			TA result;
+			if (!TryMultiplyOperator::Operation(quotient, UnsafeNumericCast<TA>(power_of_ten), result)) {
+				throw OutOfRangeException("Overflow in ROUND");
+			}
+			return UnsafeNumericCast<TR>(result);
 		} else {
 			//	Rounding integers to higher precision is a NOP
 			return input;

--- a/test/sql/function/numeric/test_round.test
+++ b/test/sql/function/numeric/test_round.test
@@ -58,6 +58,82 @@ SELECT round(1.0, (-2147483648)::INT);
 ----
 0
 
+# integer overflow when rounding at negative precision
+query I
+SELECT round(9223372036854775803::BIGINT, -1)
+----
+9223372036854775800
+
+query I
+SELECT round(-9223372036854775803::BIGINT, -1)
+----
+-9223372036854775800
+
+query I
+SELECT round(9223372036854775807::BIGINT, -2)
+----
+9223372036854775800
+
+statement error
+SELECT round(9223372036854775807::BIGINT, -1)
+----
+Out of Range Error: Overflow in ROUND
+
+query I
+SELECT round(123::TINYINT, -1)
+----
+120
+
+query I
+SELECT round(-123::TINYINT, -1)
+----
+-120
+
+query I
+SELECT round(99::TINYINT, -2)
+----
+100
+
+statement error
+SELECT round(127::TINYINT, -1)
+----
+Out of Range Error: Overflow in ROUND
+
+statement error
+SELECT round((-128)::TINYINT, -1)
+----
+Out of Range Error: Overflow in ROUND
+
+query I
+SELECT round(32760::SMALLINT, -1)
+----
+32760
+
+statement error
+SELECT round(32765::SMALLINT, -1)
+----
+Out of Range Error: Overflow in ROUND
+
+query I
+SELECT round(2147483640::INTEGER, -1)
+----
+2147483640
+
+statement error
+SELECT round(2147483645::INTEGER, -1)
+----
+Out of Range Error: Overflow in ROUND
+
+query I
+SELECT round(170141183460469231731687303715884105723::HUGEINT, -1)
+----
+170141183460469231731687303715884105720
+
+statement error
+SELECT round(170141183460469231731687303715884105727::HUGEINT, -1)
+----
+Out of Range Error: Overflow in ROUND
+
 query I
 SELECT round(1.0::DOUBLE, (-2147483648)::INT);
 ----


### PR DESCRIPTION
Summary:
- Avoid overflowing integer rounding factors when ROUND is called with very negative precision.
- Add sqllogictest coverage for boundary cases.

Tests:
- build/reldebug/test/unittest test/sql/function/numeric/test_round.test