### PR TITLE
Fix #24363: Preserve NULLs in Top-N window elimination when ORDER BY expression has no column references

### DIFF
--- a/src/optimizer/topn_window_elimination.cpp
+++ b/src/optimizer/topn_window_elimination.cpp
@@ -868,11 +868,15 @@ TopNWindowElimination::ExtractOptimizerParameters(const LogicalWindow &window, c
 	if (params.payload_type == TopNPayloadType::SINGLE_COLUMN && !aggregate_payload.empty()) {
 		VisitExpression(&aggregate_payload[0]);
 	}
-	for (const auto &column_ref : column_references) {
-		const auto &column_stats = stats->find(column_ref.first);
-		if (column_stats == stats->end() || column_stats->second->CanHaveNull()) {
-			params.can_be_null = true;
-			break;
+	if (column_references.empty()) {
+		params.can_be_null = true;
+	} else {
+		for (const auto &column_ref : column_references) {
+			const auto &column_stats = stats->find(column_ref.first);
+			if (column_stats == stats->end() || column_stats->second->CanHaveNull()) {
+				params.can_be_null = true;
+				break;
+			}
 		}
 	}
 	column_references.clear();

--- a/test/optimizer/topn_window_elimination.test_slow
+++ b/test/optimizer/topn_window_elimination.test_slow
@@ -470,3 +470,54 @@ ORDER BY 1;
 1	1	1	/User/hawkfish/file.txt	file.txt
 2	2	2	/User/hawkfish/file.txt	file.txt
 7	3	0	/User/hawkfish/file.txt	file.txt
+
+# Issue 24363: Top-N window elimination with ORDER BY NULL
+query II
+SELECT * FROM (
+    SELECT c0, row_number() OVER (PARTITION BY c0 ORDER BY NULL) AS c1
+    FROM (VALUES (3),(3)) AS t(c0)
+) AS u WHERE c1 <= 7;
+----
+3	1
+3	2
+
+# ORDER BY NULL with LIMIT 1
+query II
+SELECT * FROM (
+    SELECT c0, row_number() OVER (PARTITION BY c0 ORDER BY NULL) AS c1
+    FROM (VALUES (3),(3)) AS t(c0)
+) AS u WHERE c1 <= 1;
+----
+3	1
+
+# ORDER BY constant integer (ORDER BY 1)
+query II
+SELECT * FROM (
+    SELECT c0, row_number() OVER (PARTITION BY c0 ORDER BY 1) AS c1
+    FROM (VALUES (3),(3)) AS t(c0)
+) AS u WHERE c1 <= 7;
+----
+3	1
+3	2
+
+# ORDER BY expression evaluating to NULL
+query II
+SELECT * FROM (
+    SELECT c0, row_number() OVER (PARTITION BY c0 ORDER BY 1 + NULL) AS c1
+    FROM (VALUES (3),(3)) AS t(c0)
+) AS u WHERE c1 <= 7;
+----
+3	1
+3	2
+
+# Multiple partitions with ORDER BY NULL
+query II
+SELECT * FROM (
+    SELECT c0, row_number() OVER (PARTITION BY c0 ORDER BY NULL) AS c1
+    FROM (VALUES (1), (1), (2), (2), (2)) AS t(c0)
+) AS u WHERE c1 <= 2 ORDER BY c0, c1;
+----
+1	1
+1	2
+2	1
+2	2


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fixes [#24363](https://github.com/duckdb/duckdb/issues/24363), where applying a Top-N filter (e.g. `WHERE row_num <= N`) on a window function ordered by a constant `NULL` expression (`ORDER BY NULL`) resulted in 0 rows.

### Why are the changes needed?
When the `TopNWindowElimination` optimizer rule optimizes a window query into a Top-N aggregate, it checks whether the sort expressions can contain NULLs (`params.can_be_null`).
Previously, `params.can_be_null` was inferred only by checking statistics of referenced columns (`column_references`). When an `ORDER BY` clause has no column references (e.g., `ORDER BY NULL`, `ORDER BY 1 + NULL`, `ORDER BY COALESCE(NULL, NULL)`), `column_references` is empty, leaving `params.can_be_null` set to `false`.

When `params.can_be_null` is `false` and `limit > 1`, the optimizer selects standard `min_k` / `max_k` aggregates, which ignore NULL values—causing all rows ordered by constant `NULL` expressions to be dropped.

### How was this patch tested?
- Added unit tests in `test/optimizer/topn_window_elimination.test_slow` covering:
  - Exact repro (`ORDER BY NULL` with `limit > 1`)
  - `ORDER BY NULL` with `LIMIT 1`
  - Constant integer/string ordering (`ORDER BY 1`)
  - Compound expressions evaluating to NULL (`ORDER BY 1 + NULL`)
  - Multiple partitions with `ORDER BY NULL`