### PR TITLE
Fix #24378: Prevent false-positive generated column constraint checks when dropping columns with CASCADE

### DIFF
--- a/src/catalog/catalog_entry/duck_table_entry.cpp
+++ b/src/catalog/catalog_entry/duck_table_entry.cpp
@@ -823,12 +823,9 @@ unique_ptr<CatalogEntry> DuckTableEntry::RemoveColumn(ClientContext &context, Re
 	if (!removed_columns.empty() && !info.cascade) {
 		throw CatalogException("Cannot drop column: column is a dependency of 1 or more generated column(s)");
 	}
-	bool dropped_column_is_generated = false;
+	bool dropped_column_is_generated = columns.GetColumn(LogicalIndex(removed_index)).Generated();
 	for (auto &col : columns.Logical()) {
 		if (col.Logical() == removed_index || removed_columns.count(col.Logical())) {
-			if (col.Generated()) {
-				dropped_column_is_generated = true;
-			}
 			continue;
 		}
 		create_info->columns.AddColumn(col.Copy());

--- a/test/sql/generated_columns/virtual/check.test
+++ b/test/sql/generated_columns/virtual/check.test
@@ -45,3 +45,22 @@ statement error
 INSERT INTO chk VALUES (3);
 ----
 <REGEX>:.*Constraint Error.*constraint failed.*
+
+# Issue #24378: DROP COLUMN CASCADE with generated column and CHECK constraint
+statement ok
+CREATE TABLE test_24378 (
+	i INTEGER,
+	j INTEGER CHECK (j > 0),
+	k INTEGER GENERATED ALWAYS AS (j + 1)
+);
+
+statement ok
+ALTER TABLE test_24378 DROP COLUMN j CASCADE;
+
+statement ok
+INSERT INTO test_24378 VALUES (1);
+
+query I
+SELECT * FROM test_24378;
+----
+1


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fixes #24378.

When dropping a regular column via `ALTER TABLE ... DROP COLUMN ... CASCADE`, if the dropped column has dependent `GENERATED ALWAYS AS (...)` columns and the table has a `CHECK` constraint, `DuckTableEntry::RemoveColumn` previously failed with:

Binder Error: Column "..." referenced in CHECK constraint not found!


#### Root Cause
In `DuckTableEntry::RemoveColumn`, `dropped_column_is_generated` was calculated by iterating over all columns being removed (`removed_columns`). If **any** column in `removed_columns` was generated (including dependent generated columns dropped via `CASCADE`), `dropped_column_is_generated` was set to `true`.

When `UpdateConstraintsOnColumnDrop(..., bool is_generated)` was subsequently called with `is_generated = true`, it assumed the primary dropped column was generated and that existing constraints could not reference it. Therefore, it re-added all table constraints unchanged—causing `CHECK` constraints referencing the primary dropped column to remain on the altered table and fail binder verification.

#### Fix
Changed `dropped_column_is_generated` in `DuckTableEntry::RemoveColumn` to check only whether the primary dropped column (`removed_index`) is generated:

```cpp
bool dropped_column_is_generated = columns.GetColumn(LogicalIndex(removed_index)).Generated();
```

####  Why are the changes needed?
This enables standard schema migrations (ALTER TABLE ... DROP COLUMN ... CASCADE) on tables that contain regular columns, dependent generated columns, and table check constraints.

#### How was this patch tested?
* Added an sqllogictest regression test in test/sql/generated_columns/virtual/check.test verifying that dropping a regular column with CASCADE correctly drops both the dependent generated column and any check constraints referencing the dropped column.
* Ran full unit test suite (build/reldebug/test/unittest).