### PR TITLE
fix: disable streaming for bounded first_value frames

### DIFF
--- a/src/function/window/window_value_function.cpp
+++ b/src/function/window/window_value_function.cpp
@@ -779,10 +779,13 @@ struct WindowFirstValueExecutor : public WindowValueExecutor {
 
 	//! Streaming APIs
 	static bool CanStream(ClientContext &client, const BoundWindowExpression &wexpr, idx_t max_delta) {
+		// We can only stream first values if the frame start never moves past the first row
+		if (wexpr.WindowStart() != WindowBoundary::UNBOUNDED_PRECEDING) {
+			return false;
+		}
 		if (wexpr.IgnoreNulls()) {
 			// We can stream first values ignoring NULLs if they are "running totals"
-			return wexpr.WindowStart() == WindowBoundary::UNBOUNDED_PRECEDING &&
-			       wexpr.WindowEnd() == WindowBoundary::CURRENT_ROW_ROWS;
+			return wexpr.WindowEnd() == WindowBoundary::CURRENT_ROW_ROWS;
 		}
 		return true;
 	}

--- a/test/sql/window/test_streaming_window.test
+++ b/test/sql/window/test_streaming_window.test
@@ -326,6 +326,30 @@ explain select last_value(i IGNORE NULLS) over () from integers
 ----
 physical_plan	<!REGEX>:.*STREAMING_WINDOW.*
 
+# A bounded frame cannot be streamed: the first value changes as the frame moves
+query TT
+explain select i, first_value(i) over (ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) from integers
+----
+physical_plan	<!REGEX>:.*STREAMING_WINDOW.*
+
+statement ok
+create table first_value_bounded (i integer);
+
+statement ok
+INSERT INTO first_value_bounded VALUES (1), (2), (3), (4), (5);
+
+query II
+SELECT i, first_value(i) OVER (ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) FROM first_value_bounded
+----
+1	1
+2	1
+3	2
+4	3
+5	4
+
+statement ok
+DROP TABLE first_value_bounded;
+
 query TT
 explain select last_value(i IGNORE NULLS) over (ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) 
 from integers


### PR DESCRIPTION
Summary:
- Disable streaming execution for bounded first_value window frames.
- Add regression coverage for bounded first_value behavior in streaming window tests.

Tests:
- build/reldebug/test/unittest test/sql/window/test_streaming_window.test