### PR TITLE
Checks inline - throws out of line

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -58,6 +58,7 @@ add_library_unity(
   fsst.cpp
   gzip_file_system.cpp
   identifier.cpp
+  memory_safety.cpp
   hive_partitioning.cpp
   json_document.cpp
   pipe_file_system.cpp

--- a/src/common/memory_safety.cpp
+++ b/src/common/memory_safety.cpp
@@ -1,0 +1,27 @@
+#include "duckdb/common/memory_safety.hpp"
+
+#include "duckdb/common/exception.hpp"
+
+namespace duckdb {
+
+void ThrowNullDereference(const char *pointer_type) {
+	throw InternalException("Attempted to dereference %s that is NULL!", pointer_type);
+}
+
+void ThrowOptionalPointerNotSet() {
+	throw InternalException("Attempting to dereference an optional pointer that is not set");
+}
+
+void ThrowIndexOutOfBounds(const char *container, idx_t index, idx_t size) {
+	throw InternalException("Attempted to access index %lld within %s of size %lld", index, container, size);
+}
+
+void ThrowEmptyContainer(const char *operation, const char *container) {
+	throw InternalException("'%s' called on an empty %s!", operation, container);
+}
+
+void ThrowVectorError(const char *message) {
+	throw InternalException(message);
+}
+
+} // namespace duckdb

--- a/src/common/memory_safety.cpp
+++ b/src/common/memory_safety.cpp
@@ -4,24 +4,64 @@
 
 namespace duckdb {
 
-void ThrowNullDereference(const char *pointer_type) {
-	throw InternalException("Attempted to dereference %s that is NULL!", pointer_type);
+void ThrowNullUniquePtrDereference() {
+	throw InternalException("Attempted to dereference unique_ptr that is NULL!");
+}
+
+void ThrowNullSharedPtrDereference() {
+	throw InternalException("Attempted to dereference shared_ptr that is NULL!");
 }
 
 void ThrowOptionalPointerNotSet() {
 	throw InternalException("Attempting to dereference an optional pointer that is not set");
 }
 
-void ThrowIndexOutOfBounds(const char *container, idx_t index, idx_t size) {
-	throw InternalException("Attempted to access index %lld within %s of size %lld", index, container, size);
+void ThrowNullArrayPtrConstruction() {
+	throw InternalException("Attempted to construct an array_ptr from a NULL pointer");
 }
 
-void ThrowEmptyContainer(const char *operation, const char *container) {
-	throw InternalException("'%s' called on an empty %s!", operation, container);
+void ThrowArrayPtrIteratorOutOfRange() {
+	throw InternalException("array_ptr iterator dereferenced while iterator is out of range");
 }
 
-void ThrowVectorError(const char *message) {
-	throw InternalException(message);
+void ThrowVectorIndexOutOfBounds(idx_t index, idx_t size) {
+	throw InternalException("Attempted to access index %lld within vector of size %lld", index, size);
+}
+
+void ThrowDequeIndexOutOfBounds(idx_t index, idx_t size) {
+	throw InternalException("Attempted to access index %lld within deque of size %lld", index, size);
+}
+
+void ThrowArrayPtrIndexOutOfBounds(idx_t index, idx_t size) {
+	throw InternalException("Attempted to access index %lld within array_ptr of size %lld", index, size);
+}
+
+void ThrowVectorBackOnEmpty() {
+	throw InternalException("'back' called on an empty vector!");
+}
+
+void ThrowVectorPopBackOnEmpty() {
+	throw InternalException("'pop_back' called on an empty vector!");
+}
+
+void ThrowDequeFrontOnEmpty() {
+	throw InternalException("'front' called on an empty deque!");
+}
+
+void ThrowDequeBackOnEmpty() {
+	throw InternalException("'back' called on an empty deque!");
+}
+
+void ThrowQueueFrontOnEmpty() {
+	throw InternalException("'front' called on an empty queue!");
+}
+
+void ThrowQueueBackOnEmpty() {
+	throw InternalException("'back' called on an empty queue!");
+}
+
+void ThrowQueuePopOnEmpty() {
+	throw InternalException("'pop' called on an empty queue!");
 }
 
 } // namespace duckdb

--- a/src/include/duckdb/common/array_ptr.hpp
+++ b/src/include/duckdb/common/array_ptr.hpp
@@ -33,7 +33,7 @@ public:
 	}
 	DATA_TYPE &operator*() const {
 		if (DUCKDB_UNLIKELY(index >= size)) {
-			ThrowVectorError("array_ptr iterator dereferenced while iterator is out of range");
+			ThrowArrayPtrIteratorOutOfRange();
 		}
 		return ptr[index];
 	}
@@ -56,7 +56,7 @@ private:
 		return;
 #else
 		if (DUCKDB_UNLIKELY(null)) {
-			ThrowVectorError("Attempted to construct an array_ptr from a NULL pointer");
+			ThrowNullArrayPtrConstruction();
 		}
 #endif
 	}
@@ -66,7 +66,7 @@ private:
 		return;
 #else
 		if (DUCKDB_UNLIKELY(index >= size)) {
-			ThrowIndexOutOfBounds("array_ptr", index, size);
+			ThrowArrayPtrIndexOutOfBounds(index, size);
 		}
 #endif
 	}

--- a/src/include/duckdb/common/array_ptr.hpp
+++ b/src/include/duckdb/common/array_ptr.hpp
@@ -33,7 +33,7 @@ public:
 	}
 	DATA_TYPE &operator*() const {
 		if (DUCKDB_UNLIKELY(index >= size)) {
-			throw InternalException("array_ptr iterator dereferenced while iterator is out of range");
+			ThrowVectorError("array_ptr iterator dereferenced while iterator is out of range");
 		}
 		return ptr[index];
 	}
@@ -56,7 +56,7 @@ private:
 		return;
 #else
 		if (DUCKDB_UNLIKELY(null)) {
-			throw duckdb::InternalException("Attempted to construct an array_ptr from a NULL pointer");
+			ThrowVectorError("Attempted to construct an array_ptr from a NULL pointer");
 		}
 #endif
 	}
@@ -66,7 +66,7 @@ private:
 		return;
 #else
 		if (DUCKDB_UNLIKELY(index >= size)) {
-			throw InternalException("Attempted to access index %ld within array_ptr of size %ld", index, size);
+			ThrowIndexOutOfBounds("array_ptr", index, size);
 		}
 #endif
 	}

--- a/src/include/duckdb/common/deque.hpp
+++ b/src/include/duckdb/common/deque.hpp
@@ -41,7 +41,7 @@ private:
 		return;
 #else
 		if (DUCKDB_UNLIKELY(index >= size)) {
-			ThrowIndexOutOfBounds("deque", index, size);
+			ThrowDequeIndexOutOfBounds(index, size);
 		}
 #endif
 	}
@@ -89,28 +89,28 @@ public:
 
 	typename original::reference front() { // NOLINT: hiding on purpose
 		if (MemorySafety<SAFE>::ENABLED && original::empty()) {
-			ThrowEmptyContainer("front", "deque");
+			ThrowDequeFrontOnEmpty();
 		}
 		return get<SAFE>(0);
 	}
 
 	typename original::const_reference front() const { // NOLINT: hiding on purpose
 		if (MemorySafety<SAFE>::ENABLED && original::empty()) {
-			ThrowEmptyContainer("front", "deque");
+			ThrowDequeFrontOnEmpty();
 		}
 		return get<SAFE>(0);
 	}
 
 	typename original::reference back() { // NOLINT: hiding on purpose
 		if (MemorySafety<SAFE>::ENABLED && original::empty()) {
-			ThrowEmptyContainer("back", "deque");
+			ThrowDequeBackOnEmpty();
 		}
 		return get<SAFE>(original::size() - 1);
 	}
 
 	typename original::const_reference back() const { // NOLINT: hiding on purpose
 		if (MemorySafety<SAFE>::ENABLED && original::empty()) {
-			ThrowEmptyContainer("back", "deque");
+			ThrowDequeBackOnEmpty();
 		}
 		return get<SAFE>(original::size() - 1);
 	}

--- a/src/include/duckdb/common/deque.hpp
+++ b/src/include/duckdb/common/deque.hpp
@@ -41,7 +41,7 @@ private:
 		return;
 #else
 		if (DUCKDB_UNLIKELY(index >= size)) {
-			throw InternalException("Attempted to access index %ld within deque of size %ld", index, size);
+			ThrowIndexOutOfBounds("deque", index, size);
 		}
 #endif
 	}
@@ -89,28 +89,28 @@ public:
 
 	typename original::reference front() { // NOLINT: hiding on purpose
 		if (MemorySafety<SAFE>::ENABLED && original::empty()) {
-			throw InternalException("'front' called on an empty deque!");
+			ThrowEmptyContainer("front", "deque");
 		}
 		return get<SAFE>(0);
 	}
 
 	typename original::const_reference front() const { // NOLINT: hiding on purpose
 		if (MemorySafety<SAFE>::ENABLED && original::empty()) {
-			throw InternalException("'front' called on an empty deque!");
+			ThrowEmptyContainer("front", "deque");
 		}
 		return get<SAFE>(0);
 	}
 
 	typename original::reference back() { // NOLINT: hiding on purpose
 		if (MemorySafety<SAFE>::ENABLED && original::empty()) {
-			throw InternalException("'back' called on an empty deque!");
+			ThrowEmptyContainer("back", "deque");
 		}
 		return get<SAFE>(original::size() - 1);
 	}
 
 	typename original::const_reference back() const { // NOLINT: hiding on purpose
 		if (MemorySafety<SAFE>::ENABLED && original::empty()) {
-			throw InternalException("'back' called on an empty deque!");
+			ThrowEmptyContainer("back", "deque");
 		}
 		return get<SAFE>(original::size() - 1);
 	}

--- a/src/include/duckdb/common/memory_safety.hpp
+++ b/src/include/duckdb/common/memory_safety.hpp
@@ -18,10 +18,27 @@ struct MemorySafety {
 //! Reporters for a violated safety check. These are what the inline pointer and container accessors call when their
 //! check fails. Building the exception - not the throw - is what pushes an accessor past the inliner's budget, so it
 //! is kept out-of-line here and the accessors stay small enough to inline into their callers.
-[[noreturn]] DUCKDB_API void ThrowNullDereference(const char *pointer_type);
+//! There is one reporter per message rather than one reporter taking the message: passing a string literal makes the
+//! failing branch materialise the literal's address, which the machine outliner folds into a call, which forces a
+//! frame setup, which in turn makes the branch large enough to be split off as a named `.cold` fragment. With no
+//! literal to materialise the branch stays a bare tail call and no such fragment - nor its symbol - is emitted.
+//! Arguments already living in registers, such as an index and a size, cost nothing; only literals do.
+[[noreturn]] DUCKDB_API void ThrowNullUniquePtrDereference();
+[[noreturn]] DUCKDB_API void ThrowNullSharedPtrDereference();
 [[noreturn]] DUCKDB_API void ThrowOptionalPointerNotSet();
-[[noreturn]] DUCKDB_API void ThrowIndexOutOfBounds(const char *container, idx_t index, idx_t size);
-[[noreturn]] DUCKDB_API void ThrowEmptyContainer(const char *operation, const char *container);
-[[noreturn]] DUCKDB_API void ThrowVectorError(const char *message);
+[[noreturn]] DUCKDB_API void ThrowNullArrayPtrConstruction();
+[[noreturn]] DUCKDB_API void ThrowArrayPtrIteratorOutOfRange();
+
+[[noreturn]] DUCKDB_API void ThrowVectorIndexOutOfBounds(idx_t index, idx_t size);
+[[noreturn]] DUCKDB_API void ThrowDequeIndexOutOfBounds(idx_t index, idx_t size);
+[[noreturn]] DUCKDB_API void ThrowArrayPtrIndexOutOfBounds(idx_t index, idx_t size);
+
+[[noreturn]] DUCKDB_API void ThrowVectorBackOnEmpty();
+[[noreturn]] DUCKDB_API void ThrowVectorPopBackOnEmpty();
+[[noreturn]] DUCKDB_API void ThrowDequeFrontOnEmpty();
+[[noreturn]] DUCKDB_API void ThrowDequeBackOnEmpty();
+[[noreturn]] DUCKDB_API void ThrowQueueFrontOnEmpty();
+[[noreturn]] DUCKDB_API void ThrowQueueBackOnEmpty();
+[[noreturn]] DUCKDB_API void ThrowQueuePopOnEmpty();
 
 } // namespace duckdb

--- a/src/include/duckdb/common/memory_safety.hpp
+++ b/src/include/duckdb/common/memory_safety.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include "duckdb/common/winapi.hpp"
+#include "duckdb/common/typedefs.hpp"
+
 namespace duckdb {
 
 template <bool IS_ENABLED>
@@ -11,5 +14,14 @@ struct MemorySafety {
 	static constexpr bool ENABLED = IS_ENABLED;
 #endif
 };
+
+//! Reporters for a violated safety check. These are what the inline pointer and container accessors call when their
+//! check fails. Building the exception - not the throw - is what pushes an accessor past the inliner's budget, so it
+//! is kept out-of-line here and the accessors stay small enough to inline into their callers.
+[[noreturn]] DUCKDB_API void ThrowNullDereference(const char *pointer_type);
+[[noreturn]] DUCKDB_API void ThrowOptionalPointerNotSet();
+[[noreturn]] DUCKDB_API void ThrowIndexOutOfBounds(const char *container, idx_t index, idx_t size);
+[[noreturn]] DUCKDB_API void ThrowEmptyContainer(const char *operation, const char *container);
+[[noreturn]] DUCKDB_API void ThrowVectorError(const char *message);
 
 } // namespace duckdb

--- a/src/include/duckdb/common/optional_ptr.hpp
+++ b/src/include/duckdb/common/optional_ptr.hpp
@@ -31,7 +31,7 @@ public:
 	void CheckValid() const {
 		if (MemorySafety<SAFE>::ENABLED) {
 			if (!ptr) {
-				throw InternalException("Attempting to dereference an optional pointer that is not set");
+				ThrowOptionalPointerNotSet();
 			}
 		}
 	}

--- a/src/include/duckdb/common/queue.hpp
+++ b/src/include/duckdb/common/queue.hpp
@@ -44,35 +44,35 @@ public:
 
 	reference front() {
 		if (MemorySafety<SAFE>::ENABLED && original::empty()) {
-			ThrowEmptyContainer("front", "queue");
+			ThrowQueueFrontOnEmpty();
 		}
 		return original::front();
 	}
 
 	const_reference front() const {
 		if (MemorySafety<SAFE>::ENABLED && original::empty()) {
-			ThrowEmptyContainer("front", "queue");
+			ThrowQueueFrontOnEmpty();
 		}
 		return original::front();
 	}
 
 	reference back() {
 		if (MemorySafety<SAFE>::ENABLED && original::empty()) {
-			ThrowEmptyContainer("back", "queue");
+			ThrowQueueBackOnEmpty();
 		}
 		return original::back();
 	}
 
 	const_reference back() const {
 		if (MemorySafety<SAFE>::ENABLED && original::empty()) {
-			ThrowEmptyContainer("back", "queue");
+			ThrowQueueBackOnEmpty();
 		}
 		return original::back();
 	}
 
 	void pop() {
 		if (MemorySafety<SAFE>::ENABLED && original::empty()) {
-			ThrowEmptyContainer("pop", "queue");
+			ThrowQueuePopOnEmpty();
 		}
 		original::pop();
 	}

--- a/src/include/duckdb/common/queue.hpp
+++ b/src/include/duckdb/common/queue.hpp
@@ -44,35 +44,35 @@ public:
 
 	reference front() {
 		if (MemorySafety<SAFE>::ENABLED && original::empty()) {
-			throw InternalException("'front' called on an empty queue!");
+			ThrowEmptyContainer("front", "queue");
 		}
 		return original::front();
 	}
 
 	const_reference front() const {
 		if (MemorySafety<SAFE>::ENABLED && original::empty()) {
-			throw InternalException("'front' called on an empty queue!");
+			ThrowEmptyContainer("front", "queue");
 		}
 		return original::front();
 	}
 
 	reference back() {
 		if (MemorySafety<SAFE>::ENABLED && original::empty()) {
-			throw InternalException("'back' called on an empty queue!");
+			ThrowEmptyContainer("back", "queue");
 		}
 		return original::back();
 	}
 
 	const_reference back() const {
 		if (MemorySafety<SAFE>::ENABLED && original::empty()) {
-			throw InternalException("'back' called on an empty queue!");
+			ThrowEmptyContainer("back", "queue");
 		}
 		return original::back();
 	}
 
 	void pop() {
 		if (MemorySafety<SAFE>::ENABLED && original::empty()) {
-			throw InternalException("'pop' called on an empty queue!");
+			ThrowEmptyContainer("pop", "queue");
 		}
 		original::pop();
 	}

--- a/src/include/duckdb/common/shared_ptr_ipp.hpp
+++ b/src/include/duckdb/common/shared_ptr_ipp.hpp
@@ -23,7 +23,7 @@ private:
 		return;
 #else
 		if (DUCKDB_UNLIKELY(null)) {
-			throw duckdb::InternalException("Attempted to dereference shared_ptr that is NULL!");
+			ThrowNullDereference("shared_ptr");
 		}
 #endif
 	}

--- a/src/include/duckdb/common/shared_ptr_ipp.hpp
+++ b/src/include/duckdb/common/shared_ptr_ipp.hpp
@@ -23,7 +23,7 @@ private:
 		return;
 #else
 		if (DUCKDB_UNLIKELY(null)) {
-			ThrowNullDereference("shared_ptr");
+			ThrowNullSharedPtrDereference();
 		}
 #endif
 	}

--- a/src/include/duckdb/common/unique_ptr.hpp
+++ b/src/include/duckdb/common/unique_ptr.hpp
@@ -23,7 +23,7 @@ private:
 		return;
 #else
 		if (DUCKDB_UNLIKELY(null)) {
-			ThrowNullDereference("unique_ptr");
+			ThrowNullUniquePtrDereference();
 		}
 #endif
 	}
@@ -67,7 +67,7 @@ private:
 		return;
 #else
 		if (DUCKDB_UNLIKELY(null)) {
-			ThrowNullDereference("unique_ptr");
+			ThrowNullUniquePtrDereference();
 		}
 #endif
 	}
@@ -94,7 +94,7 @@ private:
 		return;
 #else
 		if (DUCKDB_UNLIKELY(null)) {
-			ThrowNullDereference("unique_ptr");
+			ThrowNullUniquePtrDereference();
 		}
 #endif
 	}

--- a/src/include/duckdb/common/unique_ptr.hpp
+++ b/src/include/duckdb/common/unique_ptr.hpp
@@ -23,7 +23,7 @@ private:
 		return;
 #else
 		if (DUCKDB_UNLIKELY(null)) {
-			throw duckdb::InternalException("Attempted to dereference unique_ptr that is NULL!");
+			ThrowNullDereference("unique_ptr");
 		}
 #endif
 	}
@@ -67,7 +67,7 @@ private:
 		return;
 #else
 		if (DUCKDB_UNLIKELY(null)) {
-			throw duckdb::InternalException("Attempted to dereference unique_ptr that is NULL!");
+			ThrowNullDereference("unique_ptr");
 		}
 #endif
 	}
@@ -94,7 +94,7 @@ private:
 		return;
 #else
 		if (DUCKDB_UNLIKELY(null)) {
-			throw duckdb::InternalException("Attempted to dereference unique_ptr that is NULL!");
+			ThrowNullDereference("unique_ptr");
 		}
 #endif
 	}

--- a/src/include/duckdb/common/vector.hpp
+++ b/src/include/duckdb/common/vector.hpp
@@ -41,7 +41,7 @@ private:
 		return;
 #else
 		if (DUCKDB_UNLIKELY(index >= size)) {
-			ThrowIndexOutOfBounds("vector", index, size);
+			ThrowVectorIndexOutOfBounds(index, size);
 		}
 #endif
 	}
@@ -98,21 +98,21 @@ public:
 
 	typename original::reference back() { // NOLINT: hiding on purpose
 		if (MemorySafety<SAFE>::ENABLED && original::empty()) {
-			ThrowEmptyContainer("back", "vector");
+			ThrowVectorBackOnEmpty();
 		}
 		return get<SAFE>(original::size() - 1);
 	}
 
 	typename original::const_reference back() const { // NOLINT: hiding on purpose
 		if (MemorySafety<SAFE>::ENABLED && original::empty()) {
-			ThrowEmptyContainer("back", "vector");
+			ThrowVectorBackOnEmpty();
 		}
 		return get<SAFE>(original::size() - 1);
 	}
 
 	void pop_back() { // NOLINT: hiding on purpose
 		if (MemorySafety<SAFE>::ENABLED && original::empty()) {
-			ThrowEmptyContainer("pop_back", "vector");
+			ThrowVectorPopBackOnEmpty();
 		}
 		original::pop_back();
 	}

--- a/src/include/duckdb/common/vector.hpp
+++ b/src/include/duckdb/common/vector.hpp
@@ -41,7 +41,7 @@ private:
 		return;
 #else
 		if (DUCKDB_UNLIKELY(index >= size)) {
-			throw InternalException("Attempted to access index %ld within vector of size %ld", index, size);
+			ThrowIndexOutOfBounds("vector", index, size);
 		}
 #endif
 	}
@@ -98,21 +98,21 @@ public:
 
 	typename original::reference back() { // NOLINT: hiding on purpose
 		if (MemorySafety<SAFE>::ENABLED && original::empty()) {
-			throw InternalException("'back' called on an empty vector!");
+			ThrowEmptyContainer("back", "vector");
 		}
 		return get<SAFE>(original::size() - 1);
 	}
 
 	typename original::const_reference back() const { // NOLINT: hiding on purpose
 		if (MemorySafety<SAFE>::ENABLED && original::empty()) {
-			throw InternalException("'back' called on an empty vector!");
+			ThrowEmptyContainer("back", "vector");
 		}
 		return get<SAFE>(original::size() - 1);
 	}
 
 	void pop_back() { // NOLINT: hiding on purpose
 		if (MemorySafety<SAFE>::ENABLED && original::empty()) {
-			throw InternalException("'pop_back' called on an empty vector!");
+			ThrowEmptyContainer("pop_back", "vector");
 		}
 		original::pop_back();
 	}


### PR DESCRIPTION
This is a code generation improvement, that should be both make code somewhat faster AND leaner.
Code size is easy to put a number on, it should be −2.44% of current CLI binary size, and the nice thing is that it can be enabled by default given the produced code is better.

Resulting behaviour (as demonstrated by no test changes) should be not affected.

Idea is: before exceptions would still need to be constructed and allocated on the function performing the check, and that would cause a cost in all code-paths (both regular, and the one where the check triggers). After the allocation and construction of exception is moved to the slow path. Given exceptions are meant to be exceptional, it should be sound that sinking code into codepath rarely taken is a win both on performances AND code-side.

I have not run proper benchmarks, let's see what CI thinks...

CI think this is mostly positive, with some randomness but on average across all benchmark suites it's about 8 to 9% faster.

Discovered while on a side-quest to figure out how to ship a lean(er) duckdb-wasm base binary.