### PR TITLE
Add TypeIdToChars and stop building error strings on the success path

### DIFF
--- a/src/common/exception.cpp
+++ b/src/common/exception.cpp
@@ -226,7 +226,7 @@ void Exception::SetQueryLocation(QueryLocation error_location, unordered_map<str
 }
 
 InvalidTypeException::InvalidTypeException(PhysicalType type, const string &msg)
-    : Exception(ExceptionType::INVALID_TYPE, "Invalid Type [" + TypeIdToString(type) + "]: " + msg) {
+    : Exception(ExceptionType::INVALID_TYPE, string("Invalid Type [") + TypeIdToChars(type) + "]: " + msg) {
 }
 
 InvalidTypeException::InvalidTypeException(const LogicalType &type, const string &msg)
@@ -237,8 +237,8 @@ InvalidTypeException::InvalidTypeException(const string &msg) : Exception(Except
 }
 
 TypeMismatchException::TypeMismatchException(const PhysicalType type_1, const PhysicalType type_2, const string &msg)
-    : Exception(ExceptionType::MISMATCH_TYPE,
-                "Type " + TypeIdToString(type_1) + " does not match with " + TypeIdToString(type_2) + ". " + msg) {
+    : Exception(ExceptionType::MISMATCH_TYPE, string("Type ") + TypeIdToChars(type_1) + " does not match with " +
+                                                  TypeIdToChars(type_2) + ". " + msg) {
 }
 
 TypeMismatchException::TypeMismatchException(const LogicalType &type_1, const LogicalType &type_2, const string &msg)
@@ -264,31 +264,33 @@ OutOfRangeException::OutOfRangeException(const string &msg) : Exception(Exceptio
 }
 
 OutOfRangeException::OutOfRangeException(const int64_t value, const PhysicalType orig_type, const PhysicalType new_type)
-    : Exception(ExceptionType::OUT_OF_RANGE, "Type " + TypeIdToString(orig_type) + " with value " +
+    : Exception(ExceptionType::OUT_OF_RANGE, string("Type ") + TypeIdToChars(orig_type) + " with value " +
                                                  to_string((intmax_t)value) +
                                                  " can't be cast because the value is out of range "
                                                  "for the destination type " +
-                                                 TypeIdToString(new_type)) {
+                                                 TypeIdToChars(new_type)) {
 }
 
 OutOfRangeException::OutOfRangeException(const double value, const PhysicalType orig_type, const PhysicalType new_type)
-    : Exception(ExceptionType::OUT_OF_RANGE, "Type " + TypeIdToString(orig_type) + " with value " + to_string(value) +
+    : Exception(ExceptionType::OUT_OF_RANGE, string("Type ") + TypeIdToChars(orig_type) + " with value " +
+                                                 to_string(value) +
                                                  " can't be cast because the value is out of range "
                                                  "for the destination type " +
-                                                 TypeIdToString(new_type)) {
+                                                 TypeIdToChars(new_type)) {
 }
 
 OutOfRangeException::OutOfRangeException(const hugeint_t value, const PhysicalType orig_type,
                                          const PhysicalType new_type)
-    : Exception(ExceptionType::OUT_OF_RANGE, "Type " + TypeIdToString(orig_type) + " with value " + value.ToString() +
+    : Exception(ExceptionType::OUT_OF_RANGE, string("Type ") + TypeIdToChars(orig_type) + " with value " +
+                                                 value.ToString() +
                                                  " can't be cast because the value is out of range "
                                                  "for the destination type " +
-                                                 TypeIdToString(new_type)) {
+                                                 TypeIdToChars(new_type)) {
 }
 
 OutOfRangeException::OutOfRangeException(const PhysicalType var_type, const idx_t length)
-    : Exception(ExceptionType::OUT_OF_RANGE,
-                "The value is too long to fit into type " + TypeIdToString(var_type) + "(" + to_string(length) + ")") {
+    : Exception(ExceptionType::OUT_OF_RANGE, string("The value is too long to fit into type ") +
+                                                 TypeIdToChars(var_type) + "(" + to_string(length) + ")") {
 }
 
 ConnectionException::ConnectionException(const string &msg) : Exception(ExceptionType::CONNECTION, msg) {

--- a/src/common/exception/conversion_exception.cpp
+++ b/src/common/exception/conversion_exception.cpp
@@ -6,7 +6,7 @@ namespace duckdb {
 
 ConversionException::ConversionException(const PhysicalType orig_type, const PhysicalType new_type)
     : Exception(ExceptionType::CONVERSION,
-                "Type " + TypeIdToString(orig_type) + " can't be cast as " + TypeIdToString(new_type)) {
+                string("Type ") + TypeIdToChars(orig_type) + " can't be cast as " + TypeIdToChars(new_type)) {
 }
 
 ConversionException::ConversionException(const LogicalType &orig_type, const LogicalType &new_type)

--- a/src/common/exception_format_value.cpp
+++ b/src/common/exception_format_value.cpp
@@ -34,7 +34,7 @@ ExceptionFormatValue::ExceptionFormatValue(const String &str_val) : ExceptionFor
 
 template <>
 ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(const PhysicalType &value) {
-	return ExceptionFormatValue(TypeIdToString(value));
+	return ExceptionFormatValue(string(TypeIdToChars(value)));
 }
 template <>
 ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(const LogicalType &value) {

--- a/src/common/operator/cast_operators.cpp
+++ b/src/common/operator/cast_operators.cpp
@@ -1139,7 +1139,7 @@ static bool TryCastTimestampBase(const SRC &input, DST &result, bool strict = tr
 }
 
 template <typename SRC, typename DST>
-static DST CastTimestampOperation(const SRC &input, const string &error_message) {
+static DST CastTimestampOperation(const SRC &input, const char *error_message) {
 	DST result;
 	if (!TryCast::Operation(input, result)) {
 		throw ConversionException(error_message);
@@ -1154,8 +1154,11 @@ static DST CastTimestampPrecisionOperation(const SRC &input) {
 
 template <typename SRC, typename DST>
 static DST CastTimestampTargetOperation(const SRC &input) {
-	return CastTimestampOperation<SRC, DST>(
-	    input, StringUtil::Format("Could not convert Timestamp to %s.", TypeIdToString(GetTypeId<DST>())));
+	DST result;
+	if (!TryCast::Operation(input, result)) {
+		throw ConversionException("Could not convert Timestamp to %s.", TypeIdToChars(GetTypeId<DST>()));
+	}
+	return result;
 }
 
 template <typename SRC>
@@ -1703,7 +1706,7 @@ bool CastFromBitToNumeric::Operation(string_t input, hugeint_t &result, CastPara
 	D_ASSERT(input.GetSize() > 1);
 
 	if (input.GetSize() - 1 > sizeof(hugeint_t)) {
-		HandleCastError::AssignError("Bitstring doesn't fit inside of " + TypeIdToString(GetTypeId<hugeint_t>()),
+		HandleCastError::AssignError(string("Bitstring doesn't fit inside of ") + TypeIdToChars(GetTypeId<hugeint_t>()),
 		                             parameters);
 		return false;
 	}
@@ -1716,8 +1719,8 @@ bool CastFromBitToNumeric::Operation(string_t input, uhugeint_t &result, CastPar
 	D_ASSERT(input.GetSize() > 1);
 
 	if (input.GetSize() - 1 > sizeof(uhugeint_t)) {
-		HandleCastError::AssignError("Bitstring doesn't fit inside of " + TypeIdToString(GetTypeId<uhugeint_t>()),
-		                             parameters);
+		HandleCastError::AssignError(
+		    string("Bitstring doesn't fit inside of ") + TypeIdToChars(GetTypeId<uhugeint_t>()), parameters);
 		return false;
 	}
 	Bit::BitToNumeric(input, result);

--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -272,7 +272,7 @@ const vector<LogicalType> LogicalType::AllTypes() {
 const PhysicalType ROW_TYPE = PhysicalType::INT64;
 
 // LCOV_EXCL_START
-string TypeIdToString(PhysicalType type) {
+const char *TypeIdToChars(PhysicalType type) noexcept {
 	switch (type) {
 	case PhysicalType::BOOL:
 		return "BOOL";
@@ -320,6 +320,10 @@ string TypeIdToString(PhysicalType type) {
 	return "INVALID";
 }
 // LCOV_EXCL_STOP
+
+string TypeIdToString(PhysicalType type) {
+	return string(TypeIdToChars(type));
+}
 
 idx_t GetTypeIdSize(PhysicalType type) {
 	switch (type) {

--- a/src/common/vector/flat_vector.cpp
+++ b/src/common/vector/flat_vector.cpp
@@ -403,7 +403,7 @@ Value StandardVectorBuffer::GetValue(const LogicalType &type, idx_t index) const
 			return Value::DECIMAL(reinterpret_cast<const hugeint_t *>(data_ptr)[index], width, scale);
 		default:
 			throw InternalException("Physical type '%s' has a width bigger than 38, which is not supported",
-			                        TypeIdToString(type.InternalType()));
+			                        TypeIdToChars(type.InternalType()));
 		}
 	}
 	case LogicalTypeId::ENUM: {

--- a/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
+++ b/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
@@ -445,8 +445,8 @@ void StringValueResult::AddValueToVector(const char *value_ptr, idx_t size, bool
 				    parse_types[chunk_col_id].width, parse_types[chunk_col_id].scale);
 				break;
 			default:
-				throw InternalException("Invalid Physical Type for Decimal Value. Physical Type: " +
-				                        TypeIdToString(parse_types[chunk_col_id].internal_type));
+				throw InternalException(string("Invalid Physical Type for Decimal Value. Physical Type: ") +
+				                        TypeIdToChars(parse_types[chunk_col_id].internal_type));
 			}
 
 		} else if (decimal_separator == '.') {
@@ -472,8 +472,8 @@ void StringValueResult::AddValueToVector(const char *value_ptr, idx_t size, bool
 				                               parse_types[chunk_col_id].width, parse_types[chunk_col_id].scale);
 				break;
 			default:
-				throw InternalException("Invalid Physical Type for Decimal Value. Physical Type: " +
-				                        TypeIdToString(parse_types[chunk_col_id].internal_type));
+				throw InternalException(string("Invalid Physical Type for Decimal Value. Physical Type: ") +
+				                        TypeIdToChars(parse_types[chunk_col_id].internal_type));
 			}
 		} else {
 			throw InvalidInputException("Decimals can only have ',' and '.' as decimal separators");

--- a/src/execution/operator/csv_scanner/sniffer/type_detection.cpp
+++ b/src/execution/operator/csv_scanner/sniffer/type_detection.cpp
@@ -272,8 +272,8 @@ bool CSVSniffer::CanYouCastIt(ClientContext &context, const string_t value, cons
 			}
 
 			default:
-				throw InternalException("Invalid Physical Type for Decimal Value. Physical Type: " +
-				                        TypeIdToString(type.InternalType()));
+				throw InternalException(string("Invalid Physical Type for Decimal Value. Physical Type: ") +
+				                        TypeIdToChars(type.InternalType()));
 			}
 
 		} else if (decimal_separator == '.') {
@@ -299,8 +299,8 @@ bool CSVSniffer::CanYouCastIt(ClientContext &context, const string_t value, cons
 			}
 
 			default:
-				throw InternalException("Invalid Physical Type for Decimal Value. Physical Type: " +
-				                        TypeIdToString(type.InternalType()));
+				throw InternalException(string("Invalid Physical Type for Decimal Value. Physical Type: ") +
+				                        TypeIdToChars(type.InternalType()));
 			}
 		}
 		throw InvalidInputException("Decimals can only have ',' and '.' as decimal separators");

--- a/src/function/cast/time_casts.cpp
+++ b/src/function/cast/time_casts.cpp
@@ -16,7 +16,7 @@ string TimestampCastErrorMessage(SRC input) {
 		return "Can't get TIME_NS of infinite TIMESTAMP";
 	}
 	if (std::is_same<DST, date_t>()) {
-		return StringUtil::Format("Could not convert Timestamp to %s.", TypeIdToString(GetTypeId<DST>()));
+		return StringUtil::Format("Could not convert Timestamp to %s.", TypeIdToChars(GetTypeId<DST>()));
 	}
 	return "Could not convert Timestamp to higher precision.";
 }

--- a/src/function/scalar/operator/arithmetic.cpp
+++ b/src/function/scalar/operator/arithmetic.cpp
@@ -66,7 +66,7 @@ static scalar_function_t GetScalarIntegerFunction(PhysicalType type) {
 		function = &ScalarFunction::BinaryFunction<uhugeint_t, uhugeint_t, uhugeint_t, OP>;
 		break;
 	default:
-		throw NotImplementedException("Unimplemented type for GetScalarBinaryFunction: %s", TypeIdToString(type));
+		throw NotImplementedException("Unimplemented type for GetScalarBinaryFunction: %s", TypeIdToChars(type));
 	}
 	return function;
 }

--- a/src/function/scalar/struct/struct_contains.cpp
+++ b/src/function/scalar/struct/struct_contains.cpp
@@ -172,7 +172,7 @@ static void StructSearchOp(const Vector &input_vector, const vector<Vector> &mem
 		return StructNestedOp<RETURN_TYPE, FIND_NULLS>(input_vector, members, target, count, result);
 	default:
 		throw NotImplementedException("This function has not been implemented for logical type %s",
-		                              TypeIdToString(target_type));
+		                              TypeIdToChars(target_type));
 	}
 }
 

--- a/src/function/scalar/system/aggregate_export.cpp
+++ b/src/function/scalar/system/aggregate_export.cpp
@@ -109,7 +109,7 @@ void TemplateDispatch(PhysicalType type, ARGS &&... args) {
 		break;
 	default:
 		throw NotImplementedException("Unsupported physical type for default aggregate state export: %s",
-		                              TypeIdToString(type));
+		                              TypeIdToChars(type));
 	}
 }
 

--- a/src/function/table/arrow_conversion.cpp
+++ b/src/function/table/arrow_conversion.cpp
@@ -691,7 +691,7 @@ static void FlattenRunEndsSwitch(Vector &result, ArrowRunEndEncodingState &run_e
 		break;
 	}
 	default:
-		throw NotImplementedException("RunEndEncoded value type '%s' not supported yet", TypeIdToString(physical_type));
+		throw NotImplementedException("RunEndEncoded value type '%s' not supported yet", TypeIdToChars(physical_type));
 	}
 }
 
@@ -746,7 +746,7 @@ void ArrowToDuckDBConversion::ColumnArrowToDuckDBRunEndEncoded(Vector &vector, c
 		FlattenRunEndsSwitch<int64_t>(vector, run_end_encoding, compressed_size, scan_offset, size);
 		break;
 	default:
-		throw NotImplementedException("Type '%s' not implemented for RunEndEncoding", TypeIdToString(physical_type));
+		throw NotImplementedException("Type '%s' not implemented for RunEndEncoding", TypeIdToChars(physical_type));
 	}
 }
 template <class SRC>
@@ -822,7 +822,7 @@ void ConvertDecimal(SRC src_ptr, Vector &vector, ArrowArray &array, idx_t size, 
 	}
 	default:
 		throw NotImplementedException("Unsupported physical type for Decimal: %s",
-		                              TypeIdToString(vector.GetType().InternalType()));
+		                              TypeIdToChars(vector.GetType().InternalType()));
 	}
 }
 

--- a/src/include/duckdb/common/operator/add.hpp
+++ b/src/include/duckdb/common/operator/add.hpp
@@ -87,7 +87,7 @@ struct AddOperatorOverflowCheck {
 	static inline TR Operation(TA left, TB right) {
 		TR result;
 		if (!TryAddOperator::Operation(left, right, result)) {
-			throw OutOfRangeException("Overflow in addition of %s (%s + %s)!", TypeIdToString(GetTypeId<TA>()),
+			throw OutOfRangeException("Overflow in addition of %s (%s + %s)!", TypeIdToChars(GetTypeId<TA>()),
 			                          NumericHelper::ToString(left), NumericHelper::ToString(right));
 		}
 		return result;

--- a/src/include/duckdb/common/operator/cast_operators.hpp
+++ b/src/include/duckdb/common/operator/cast_operators.hpp
@@ -58,15 +58,16 @@ template <class SRC, class DST>
 static string CastExceptionText(SRC input) {
 	if (std::is_same<SRC, string_t>()) {
 		return "Could not convert string '" + ConvertToString::Operation<SRC>(input) + "' to " +
-		       TypeIdToString(GetTypeId<DST>());
+		       TypeIdToChars(GetTypeId<DST>());
 	}
 	if (TypeIsNumber<SRC>() && TypeIsNumber<DST>()) {
-		return "Type " + TypeIdToString(GetTypeId<SRC>()) + " with value " + ConvertToString::Operation<SRC>(input) +
+		return string("Type ") + TypeIdToChars(GetTypeId<SRC>()) + " with value " +
+		       ConvertToString::Operation<SRC>(input) +
 		       " can't be cast because the value is out of range for the destination type " +
-		       TypeIdToString(GetTypeId<DST>());
+		       TypeIdToChars(GetTypeId<DST>());
 	}
-	return "Type " + TypeIdToString(GetTypeId<SRC>()) + " with value " + ConvertToString::Operation<SRC>(input) +
-	       " can't be cast to the destination type " + TypeIdToString(GetTypeId<DST>());
+	return string("Type ") + TypeIdToChars(GetTypeId<SRC>()) + " with value " + ConvertToString::Operation<SRC>(input) +
+	       " can't be cast to the destination type " + TypeIdToChars(GetTypeId<DST>());
 }
 
 struct Cast {
@@ -929,7 +930,7 @@ struct CastFromBitToNumeric {
 		// TODO: Allow conversion if the significant bytes of the bitstring can be cast to the target type
 		// Currently only allows bitstring -> numeric if the full bitstring fits inside the numeric type
 		if (input.GetSize() - 1 > sizeof(DST)) {
-			HandleCastError::AssignError("Bitstring doesn't fit inside of " + TypeIdToString(GetTypeId<DST>()),
+			HandleCastError::AssignError(string("Bitstring doesn't fit inside of ") + TypeIdToChars(GetTypeId<DST>()),
 			                             parameters);
 			return false;
 		}

--- a/src/include/duckdb/common/operator/multiply.hpp
+++ b/src/include/duckdb/common/operator/multiply.hpp
@@ -74,7 +74,7 @@ struct MultiplyOperatorOverflowCheck {
 	static inline TR Operation(TA left, TB right) {
 		TR result;
 		if (!TryMultiplyOperator::Operation(left, right, result)) {
-			throw OutOfRangeException("Overflow in multiplication of %s (%s * %s)!", TypeIdToString(GetTypeId<TA>()),
+			throw OutOfRangeException("Overflow in multiplication of %s (%s * %s)!", TypeIdToChars(GetTypeId<TA>()),
 			                          NumericHelper::ToString(left), NumericHelper::ToString(right));
 		}
 		return result;

--- a/src/include/duckdb/common/operator/subtract.hpp
+++ b/src/include/duckdb/common/operator/subtract.hpp
@@ -80,7 +80,7 @@ struct SubtractOperatorOverflowCheck {
 	static inline TR Operation(TA left, TB right) {
 		TR result;
 		if (!TrySubtractOperator::Operation(left, right, result)) {
-			throw OutOfRangeException("Overflow in subtraction of %s (%s - %s)!", TypeIdToString(GetTypeId<TA>()),
+			throw OutOfRangeException("Overflow in subtraction of %s (%s - %s)!", TypeIdToChars(GetTypeId<TA>()),
 			                          NumericHelper::ToString(left), NumericHelper::ToString(right));
 		}
 		return result;

--- a/src/include/duckdb/common/types.hpp
+++ b/src/include/duckdb/common/types.hpp
@@ -598,6 +598,8 @@ DUCKDB_API LogicalType TransformStringToLogicalType(const string &str, ClientCon
 //! The PhysicalType used by the row identifiers column
 extern const PhysicalType ROW_TYPE;
 
+//! Returns the name of a PhysicalType as a string literal - no allocation, cannot fail.
+DUCKDB_API const char *TypeIdToChars(PhysicalType type) noexcept;
 DUCKDB_API string TypeIdToString(PhysicalType type);
 DUCKDB_API idx_t GetTypeIdSize(PhysicalType type);
 DUCKDB_API bool TypeIsConstantSize(PhysicalType type);

--- a/src/include/duckdb/function/scalar/list/contains_or_position.hpp
+++ b/src/include/duckdb/function/scalar/list/contains_or_position.hpp
@@ -155,7 +155,7 @@ idx_t ListSearchOp(const Vector &list_v, const Vector &source_v, const Vector &t
 		return ListSearchNestedOp<RETURN_TYPE, FIND_NULLS>(list_v, source_v, target_v, result_v, target_count);
 	default:
 		throw NotImplementedException("This function has not been implemented for logical type %s",
-		                              TypeIdToString(type));
+		                              TypeIdToChars(type));
 	}
 }
 

--- a/src/main/capi/result-c.cpp
+++ b/src/main/capi/result-c.cpp
@@ -285,8 +285,8 @@ duckdb_state deprecated_duckdb_translate_column(MaterializedQueryResult &result,
 			break;
 		}
 		default:
-			throw std::runtime_error("Unsupported physical type for Decimal" +
-			                         TypeIdToString(result.GetTypes()[col].InternalType()));
+			throw std::runtime_error(string("Unsupported physical type for Decimal") +
+			                         TypeIdToChars(result.GetTypes()[col].InternalType()));
 		}
 		break;
 	}


### PR DESCRIPTION
TypeIdToString returns a string built from a short literal, so every one of its 1305 out-of-line call sites constructs (and usually immediately destroys) a std::string, on paths that are almost always error paths that never fire. It is also only non-throwing by accident: every PhysicalType name happens to fit libc++'s small-string buffer, so a longer name added later would silently turn an allocation failure into a new failure mode.

Split it the way EnumUtil already does - a const char * core with a string wrapper on top. TypeIdToChars returns the literal and is noexcept; TypeIdToString stays as string(TypeIdToChars(type)) so the public API is unchanged. In-tree callers move to TypeIdToChars, except where the result heads a string concatenation.

CastTimestampOperation took its error message by const string &, so both callers paid for it on every cast: CastTimestampTargetOperation ran StringUtil::Format per value, and CastTimestampPrecisionOperation allocated because its literal is 44 characters and does not fit the small-string buffer. Take a const char * instead and format at the throw site, so a successful cast builds nothing.

This should be neutral on native code size (−0.14%), minor positive on wasm code size, and possibly code-generations improves by moving code to slow path (although I have not run benchmarks, let's see what CI thinks).