### PR TITLE
[Parquet] Extend `read_parquet` `schema` option to make it possible to define nested schemas

### DIFF
--- a/extension/parquet/include/parquet.json
+++ b/extension/parquet/include/parquet.json
@@ -30,6 +30,11 @@
         "name": "identifier",
         "type": "Value",
         "default": "Value()"
+      },
+      {
+        "id": 106,
+        "name": "children",
+        "type": "vector<ParquetColumnDefinition>"
       }
     ],
     "pointer_type": "none"

--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -74,6 +74,8 @@ class FileMetaData;
 } // namespace duckdb_parquet
 
 namespace duckdb {
+
+class VariantNode;
 class Allocator;
 class ClientContext;
 class BaseStatistics;
@@ -243,6 +245,8 @@ public:
 struct ParquetColumnDefinition {
 public:
 	static ParquetColumnDefinition FromSchemaValue(ClientContext &context, const Value &column_value);
+	static ParquetColumnDefinition FromSchemaVariant(ClientContext &context, const Value &identifier,
+	                                                 const VariantNode &column_value);
 	MultiFileColumnDefinition ToMultiFileColumnDefinition() const;
 
 public:

--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -28,6 +28,7 @@
 #include "duckdb/common/multi_file/multi_file_adaptive_filter_cache.hpp"
 #include "duckdb/common/multi_file/multi_file_options.hpp"
 #include "duckdb/common/string_util.hpp"
+#include "duckdb/common/multi_file/multi_file_data.hpp"
 #include "duckdb/common/types/data_chunk.hpp"
 #include "column_reader.hpp"
 #include "parquet_prefetch_cost_model.hpp"
@@ -242,6 +243,7 @@ public:
 struct ParquetColumnDefinition {
 public:
 	static ParquetColumnDefinition FromSchemaValue(ClientContext &context, const Value &column_value);
+	MultiFileColumnDefinition ToMultiFileColumnDefinition() const;
 
 public:
 	// DEPRECATED, use 'identifier' instead
@@ -250,6 +252,7 @@ public:
 	LogicalType type;
 	Value default_value;
 	Value identifier;
+	vector<ParquetColumnDefinition> children;
 
 public:
 	void Serialize(Serializer &serializer) const;

--- a/extension/parquet/parquet_multi_file_info.cpp
+++ b/extension/parquet/parquet_multi_file_info.cpp
@@ -32,7 +32,7 @@
 #include "parquet_file_metadata_cache.hpp"
 #include "parquet_reader.hpp"
 #include "parquet_types.h"
-#include "duckdb/function/scalar/variant_utils.hpp"
+#include "duckdb/common/types/variant_iterator.hpp"
 
 namespace duckdb {
 class BaseStatistics;
@@ -237,13 +237,13 @@ static void VerifyParquetSchemaParameter(const Value &schema) {
 	auto &key_type = MapType::KeyType(map_type);
 	auto &value_type = MapType::ValueType(map_type);
 
+	if (value_type.id() != LogicalTypeId::STRUCT && value_type.id() != LogicalTypeId::VARIANT) {
+		throw InvalidInputException("'schema' expects the value type of the map to be either STRUCT or VARIANT");
+	}
 	if (key_type.id() != LogicalTypeId::INTEGER && key_type.id() != LogicalTypeId::VARCHAR) {
 		throw InvalidInputException(
 		    "'schema' expects the value type of the map to be either INTEGER or VARCHAR, not %s",
 		    LogicalTypeIdToString(key_type.id()));
-	}
-	if (value_type.id() != LogicalTypeId::STRUCT && value_type.id() != LogicalTypeId::VARIANT) {
-		throw InvalidInputException("'schema' expects the value type of the map to be either STRUCT or VARIANT");
 	}
 	if (value_type.id() != LogicalTypeId::STRUCT) {
 		return;
@@ -661,15 +661,20 @@ bool ParquetMultiFileInfo::ParseOption(ClientContext &context, const Identifier 
 			throw BinderException("Parquet schema cannot be empty");
 		}
 		options.schema.reserve(column_values.size());
-		for (idx_t i = 0; i < column_values.size(); i++) {
-			auto variant_value = column_values[i];
+		for (const auto &column_value : column_values) {
+			if (MapType::ValueType(schema_value.type()).id() == LogicalTypeId::STRUCT) {
+				options.schema.emplace_back(ParquetColumnDefinition::FromSchemaValue(context, column_value));
+				continue;
+			}
 
-			Vector tmp(variant_value, count_t(1));
-			RecursiveUnifiedVectorFormat format;
-			Vector::RecursiveToUnifiedFormat(tmp, 1, format);
-			UnifiedVariantVectorData vector_data(format);
-			auto column_def = VariantUtils::ConvertVariantToValue(vector_data, 0, 0);
-			options.schema.emplace_back(ParquetColumnDefinition::FromSchemaValue(context, column_def));
+			const auto &entry_values = StructValue::GetChildren(column_value);
+			Vector variant_vector(entry_values[1], count_t(1));
+			const VectorIterator<VectorVariantType> definitions(variant_vector);
+			if (!definitions.RowIsValid(0)) {
+				throw BinderException("Parquet schema definition cannot be NULL");
+			}
+			options.schema.emplace_back(
+			    ParquetColumnDefinition::FromSchemaVariant(context, entry_values[0], definitions[0]));
 		}
 		file_options.auto_detect_hive_partitioning = false;
 		return true;

--- a/extension/parquet/parquet_multi_file_info.cpp
+++ b/extension/parquet/parquet_multi_file_info.cpp
@@ -32,6 +32,7 @@
 #include "parquet_file_metadata_cache.hpp"
 #include "parquet_reader.hpp"
 #include "parquet_types.h"
+#include "duckdb/function/scalar/variant_utils.hpp"
 
 namespace duckdb {
 class BaseStatistics;
@@ -151,8 +152,7 @@ static void BindSchema(ClientContext &context, vector<LogicalType> &return_types
 		schema_col_names.push_back(Identifier(column.name));
 		schema_col_types.push_back(column.type);
 
-		auto res = MultiFileColumnDefinition(column.name, column.type);
-		res.identifier = column.identifier;
+		auto res = column.ToMultiFileColumnDefinition();
 #ifdef DEBUG
 		if (match_by_field_id) {
 			D_ASSERT(res.identifier.type().id() == LogicalTypeId::INTEGER);
@@ -160,8 +160,6 @@ static void BindSchema(ClientContext &context, vector<LogicalType> &return_types
 			D_ASSERT(res.identifier.type().id() == LogicalTypeId::VARCHAR);
 		}
 #endif
-
-		res.default_expression = make_uniq<ConstantExpression>(column.default_value);
 		reader_bind.schema.emplace_back(res);
 	}
 	ParseFileRowNumberOption(reader_bind, options, return_types, names);
@@ -231,9 +229,6 @@ static bool ParquetScanSupportPushdownExtract(const FunctionData &bind_data_p, c
 }
 
 static void VerifyParquetSchemaParameter(const Value &schema) {
-	LogicalType::MAP(LogicalType::BLOB, LogicalType::STRUCT({{{"name", LogicalType::VARCHAR},
-	                                                          {"type", LogicalType::VARCHAR},
-	                                                          {"default_value", LogicalType::VARCHAR}}}));
 	auto &map_type = schema.type();
 	if (map_type.id() != LogicalTypeId::MAP) {
 		throw InvalidInputException("'schema' expects a value of type MAP, not %s",
@@ -242,13 +237,21 @@ static void VerifyParquetSchemaParameter(const Value &schema) {
 	auto &key_type = MapType::KeyType(map_type);
 	auto &value_type = MapType::ValueType(map_type);
 
+	if (key_type.id() != LogicalTypeId::INTEGER && key_type.id() != LogicalTypeId::VARCHAR) {
+		throw InvalidInputException(
+		    "'schema' expects the value type of the map to be either INTEGER or VARCHAR, not %s",
+		    LogicalTypeIdToString(key_type.id()));
+	}
+	if (value_type.id() != LogicalTypeId::STRUCT && value_type.id() != LogicalTypeId::VARIANT) {
+		throw InvalidInputException("'schema' expects the value type of the map to be either STRUCT or VARIANT");
+	}
 	if (value_type.id() != LogicalTypeId::STRUCT) {
-		throw InvalidInputException("'schema' expects a STRUCT as the value type of the map");
+		return;
 	}
 	auto &children = StructType::GetChildTypes(value_type);
 	if (children.size() < 3) {
 		throw InvalidInputException(
-		    "'schema' expects the STRUCT to have 3 children, 'name', 'type' and 'default_value");
+		    "'schema' expects the STRUCT to have at least 3 children, 'name', 'type' and 'default_value'");
 	}
 	if (children[0].first != "name") {
 		throw InvalidInputException("'schema' expects the first field of the struct to be called 'name'");
@@ -266,13 +269,6 @@ static void VerifyParquetSchemaParameter(const Value &schema) {
 	}
 	if (children[2].first != "default_value") {
 		throw InvalidInputException("'schema' expects the third field of the struct to be called 'default_value'");
-	}
-	//! NOTE: default_value can be any type
-
-	if (key_type.id() != LogicalTypeId::INTEGER && key_type.id() != LogicalTypeId::VARCHAR) {
-		throw InvalidInputException(
-		    "'schema' expects the value type of the map to be either INTEGER or VARCHAR, not %s",
-		    LogicalTypeIdToString(key_type.id()));
 	}
 }
 
@@ -666,7 +662,14 @@ bool ParquetMultiFileInfo::ParseOption(ClientContext &context, const Identifier 
 		}
 		options.schema.reserve(column_values.size());
 		for (idx_t i = 0; i < column_values.size(); i++) {
-			options.schema.emplace_back(ParquetColumnDefinition::FromSchemaValue(context, column_values[i]));
+			auto variant_value = column_values[i];
+
+			Vector tmp(variant_value, count_t(1));
+			RecursiveUnifiedVectorFormat format;
+			Vector::RecursiveToUnifiedFormat(tmp, 1, format);
+			UnifiedVariantVectorData vector_data(format);
+			auto column_def = VariantUtils::ConvertVariantToValue(vector_data, 0, 0);
+			options.schema.emplace_back(ParquetColumnDefinition::FromSchemaValue(context, column_def));
 		}
 		file_options.auto_detect_hive_partitioning = false;
 		return true;

--- a/extension/parquet/parquet_multi_file_info.cpp
+++ b/extension/parquet/parquet_multi_file_info.cpp
@@ -270,6 +270,9 @@ static void VerifyParquetSchemaParameter(const Value &schema) {
 	if (children[2].first != "default_value") {
 		throw InvalidInputException("'schema' expects the third field of the struct to be called 'default_value'");
 	}
+	if (children.size() > 3 && children[3].first != "children") {
+		throw InvalidInputException("'schema' expects the fourth field of the struct to be called 'children'");
+	}
 }
 
 static void ParquetScanSerialize(Serializer &serializer, const optional_ptr<FunctionData> bind_data_p,

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -69,7 +69,7 @@
 #include "duckdb/planner/expression/bound_conjunction_expression.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
-#include "duckdb/common/types/variant/variant_builder.hpp"
+#include "duckdb/common/types/variant_iterator.hpp"
 
 namespace duckdb {
 
@@ -1220,6 +1220,10 @@ ParquetOptions::ParquetOptions(ClientContext &context) {
 	}
 }
 
+static void VerifyParquetSchemaChildCount(const string &name, const LogicalType &type, idx_t child_count);
+static void ParseParquetSchemaValueChildren(ClientContext &context, const Value &children_value,
+                                            vector<ParquetColumnDefinition> &result);
+
 ParquetColumnDefinition ParquetColumnDefinition::FromSchemaValue(ClientContext &context, const Value &column_value) {
 	ParquetColumnDefinition result;
 	auto &identifier = StructValue::GetChildren(column_value)[0];
@@ -1233,6 +1237,10 @@ ParquetColumnDefinition ParquetColumnDefinition::FromSchemaValue(ClientContext &
 	if (!children[2].TryCastAs(context, result.type, result.default_value, &error_message)) {
 		throw BinderException("Unable to cast Parquet schema default_value \"%s\" to %s", children[2].ToString(),
 		                      result.type.ToString());
+	}
+	if (children.size() > 3 && !children[3].IsNull()) {
+		ParseParquetSchemaValueChildren(context, children[3], result.children);
+		VerifyParquetSchemaChildCount(result.name, result.type, result.children.size());
 	}
 
 	return result;
@@ -1260,24 +1268,8 @@ static void VerifyParquetSchemaChildCount(const string &name, const LogicalType 
 	}
 }
 
-struct ParquetSchemaVariantSource {
-	explicit ParquetSchemaVariantSource(const VariantNode &node) : node(node) {
-	}
-
-	bool Emit(idx_t row, VariantBuilder &builder) const {
-		D_ASSERT(row == 0);
-		EmitIterator(node, builder);
-		return false;
-	}
-
-	const VariantNode &node;
-};
-
-static Value ParquetSchemaVariantToValue(const VariantNode &node) {
-	Vector result(LogicalType::VARIANT(), 1);
-	ParquetSchemaVariantSource source(node);
-	BuildVariant(source, 1, result);
-	return VariantValue::GetValue(result.GetValue(0));
+static bool ParquetSchemaVariantIsNull(const VariantNode &node) {
+	return node.IsNull() || node.GetTypeId() == VariantLogicalType::VARIANT_NULL;
 }
 
 static Value ParquetSchemaVariantIdentifier(const VariantNode &node) {
@@ -1296,6 +1288,12 @@ static ParquetColumnDefinition ParseParquetSchemaVariant(ClientContext &context,
 
 static void ParseParquetSchemaVariantChildren(ClientContext &context, const VariantNode &children_value,
                                               vector<ParquetColumnDefinition> &result) {
+	if (children_value.GetTypeId() == VariantLogicalType::OBJECT) {
+		auto object = children_value.GetObjectChildren();
+		if (!(object.begin() != object.end())) {
+			return;
+		}
+	}
 	if (children_value.GetTypeId() != VariantLogicalType::ARRAY) {
 		throw BinderException("Parquet schema 'children' must be a MAP(INTEGER/VARCHAR, VARIANT), not %s",
 		                      EnumUtil::ToString(children_value.GetTypeId()));
@@ -1357,13 +1355,19 @@ static ParquetColumnDefinition ParseParquetSchemaVariant(ClientContext &context,
 	result.identifier = identifier;
 	result.name = name->GetString().GetString();
 	result.type = TransformStringToLogicalType(type->GetString().GetString(), context);
-	auto untyped_default = ParquetSchemaVariantToValue(*default_value);
+	Value untyped_default;
+	if (!ParquetSchemaVariantIsNull(*default_value)) {
+		if (default_value->GetTypeId() != VariantLogicalType::VARCHAR) {
+			throw BinderException("Parquet schema default_value must be VARCHAR or NULL");
+		}
+		untyped_default = Value(default_value->GetString().GetString());
+	}
 	string error_message;
 	if (!untyped_default.TryCastAs(context, result.type, result.default_value, &error_message)) {
 		throw BinderException("Unable to cast Parquet schema default_value \"%s\" to %s", untyped_default.ToString(),
 		                      result.type.ToString());
 	}
-	if (children && !children->IsNull() && children->GetTypeId() != VariantLogicalType::VARIANT_NULL) {
+	if (children && !ParquetSchemaVariantIsNull(*children)) {
 		ParseParquetSchemaVariantChildren(context, *children, result.children);
 		VerifyParquetSchemaChildCount(result.name, result.type, result.children.size());
 	}
@@ -1373,6 +1377,42 @@ static ParquetColumnDefinition ParseParquetSchemaVariant(ClientContext &context,
 ParquetColumnDefinition ParquetColumnDefinition::FromSchemaVariant(ClientContext &context, const Value &identifier,
                                                                    const VariantNode &column_value) {
 	return ParseParquetSchemaVariant(context, identifier, column_value);
+}
+
+static void ParseParquetSchemaValueChildren(ClientContext &context, const Value &children_value,
+                                            vector<ParquetColumnDefinition> &result) {
+	if (children_value.type().id() == LogicalTypeId::STRUCT && StructType::GetChildCount(children_value.type()) == 0) {
+		return;
+	}
+	if (children_value.type().id() != LogicalTypeId::MAP) {
+		throw BinderException("Parquet schema 'children' must be a MAP(INTEGER/VARCHAR, STRUCT/VARIANT)");
+	}
+
+	const auto &key_type = MapType::KeyType(children_value.type());
+	const auto &value_type = MapType::ValueType(children_value.type());
+	if (key_type.id() != LogicalTypeId::INTEGER && key_type.id() != LogicalTypeId::VARCHAR) {
+		throw BinderException("Parquet schema child identifier must be an INTEGER or VARCHAR");
+	}
+	if (value_type.id() != LogicalTypeId::STRUCT && value_type.id() != LogicalTypeId::VARIANT) {
+		throw BinderException("Parquet schema child definition must be a STRUCT or VARIANT");
+	}
+
+	const auto &entries = ListValue::GetChildren(children_value);
+	result.reserve(entries.size());
+	for (const auto &entry : entries) {
+		if (value_type.id() == LogicalTypeId::STRUCT) {
+			result.emplace_back(ParquetColumnDefinition::FromSchemaValue(context, entry));
+			continue;
+		}
+
+		const auto &entry_values = StructValue::GetChildren(entry);
+		Vector variant_vector(entry_values[1], count_t(1));
+		const VectorIterator<VectorVariantType> definitions(variant_vector);
+		if (!definitions.RowIsValid(0)) {
+			throw BinderException("Parquet schema definition cannot be NULL");
+		}
+		result.emplace_back(ParquetColumnDefinition::FromSchemaVariant(context, entry_values[0], definitions[0]));
+	}
 }
 
 MultiFileColumnDefinition ParquetColumnDefinition::ToMultiFileColumnDefinition() const {

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -68,6 +68,7 @@
 #include "duckdb/planner/expression/bound_conjunction_expression.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
+#include "duckdb/function/scalar/variant_utils.hpp"
 
 namespace duckdb {
 
@@ -1219,22 +1220,80 @@ ParquetOptions::ParquetOptions(ClientContext &context) {
 }
 
 ParquetColumnDefinition ParquetColumnDefinition::FromSchemaValue(ClientContext &context, const Value &column_value) {
+	static constexpr const idx_t SCHEMA_NAME_INDEX = 0;
+	static constexpr const idx_t SCHEMA_TYPE_INDEX = 1;
+	static constexpr const idx_t SCHEMA_DEFAULT_VALUE_INDEX = 2;
+	static constexpr const idx_t SCHEMA_CHILDREN_INDEX = 3;
+
 	ParquetColumnDefinition result;
 	auto &identifier = StructValue::GetChildren(column_value)[0];
 	result.identifier = identifier;
 
-	const auto &column_def = StructValue::GetChildren(column_value)[1];
+	auto variant_value = StructValue::GetChildren(column_value)[1];
+	Vector tmp(variant_value, count_t(1));
+	RecursiveUnifiedVectorFormat format;
+	Vector::RecursiveToUnifiedFormat(tmp, 1, format);
+	UnifiedVariantVectorData vector_data(format);
+	auto column_def = VariantUtils::ConvertVariantToValue(vector_data, 0, 0);
+
 	D_ASSERT(column_def.type().id() == LogicalTypeId::STRUCT);
 
 	const auto children = StructValue::GetChildren(column_def);
-	result.name = StringValue::Get(children[0]);
-	result.type = TransformStringToLogicalType(StringValue::Get(children[1]), context);
+	if (children.size() < 3) {
+		throw BinderException("Parquet schema definition \"%s\" must have at least 'name', 'type' and 'default_value'",
+		                      column_def.ToString());
+	}
+	result.name = StringValue::Get(children[SCHEMA_NAME_INDEX]);
+	result.type = TransformStringToLogicalType(StringValue::Get(children[SCHEMA_TYPE_INDEX]), context);
 	string error_message;
-	if (!children[2].TryCastAs(context, result.type, result.default_value, &error_message)) {
-		throw BinderException("Unable to cast Parquet schema default_value \"%s\" to %s", children[2].ToString(),
-		                      result.type.ToString());
+	if (!children[SCHEMA_DEFAULT_VALUE_INDEX].TryCastAs(context, result.type, result.default_value, &error_message)) {
+		throw BinderException("Unable to cast Parquet schema default_value \"%s\" to %s",
+		                      children[SCHEMA_DEFAULT_VALUE_INDEX].ToString(), result.type.ToString());
 	}
 
+	if (children.size() > SCHEMA_CHILDREN_INDEX && !children[SCHEMA_CHILDREN_INDEX].IsNull()) {
+		auto &child_values = ListValue::GetChildren(children[SCHEMA_CHILDREN_INDEX]);
+		result.children.reserve(child_values.size());
+		for (const auto &child_value : child_values) {
+			result.children.emplace_back(ParquetColumnDefinition::FromSchemaValue(context, child_value));
+		}
+	}
+
+	return result;
+}
+
+MultiFileColumnDefinition ParquetColumnDefinition::ToMultiFileColumnDefinition() const {
+	MultiFileColumnDefinition result(name, type);
+	result.identifier = identifier;
+	result.default_expression = make_uniq<ConstantExpression>(default_value);
+
+	if (children.empty()) {
+		return result;
+	}
+
+	idx_t expected_children = 0;
+	switch (type.id()) {
+	case LogicalTypeId::STRUCT:
+		expected_children = StructType::GetChildTypes(type).size();
+		break;
+	case LogicalTypeId::LIST:
+		expected_children = 1;
+		break;
+	case LogicalTypeId::MAP:
+		expected_children = 2;
+		break;
+	default:
+		throw BinderException("Parquet schema column \"%s\" of type %s cannot define nested children", name,
+		                      type.ToString());
+	}
+	if (expected_children != children.size()) {
+		throw BinderException("Parquet schema column \"%s\" of type %s expects %d child definitions, not %d", name,
+		                      type.ToString(), expected_children, children.size());
+	}
+	result.children.reserve(children.size());
+	for (const auto &child : children) {
+		result.children.emplace_back(child.ToMultiFileColumnDefinition());
+	}
 	return result;
 }
 

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -23,6 +23,7 @@
 #include "thrift_tools.hpp"
 #include "parquet_prefetch_cost_model.hpp"
 #include "duckdb/common/encryption_state.hpp"
+#include "duckdb/common/enum_util.hpp"
 #include "duckdb/common/helper.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/planner/table_filter.hpp"
@@ -68,7 +69,7 @@
 #include "duckdb/planner/expression/bound_conjunction_expression.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
-#include "duckdb/function/scalar/variant_utils.hpp"
+#include "duckdb/common/types/variant/variant_builder.hpp"
 
 namespace duckdb {
 
@@ -1220,58 +1221,25 @@ ParquetOptions::ParquetOptions(ClientContext &context) {
 }
 
 ParquetColumnDefinition ParquetColumnDefinition::FromSchemaValue(ClientContext &context, const Value &column_value) {
-	static constexpr const idx_t SCHEMA_NAME_INDEX = 0;
-	static constexpr const idx_t SCHEMA_TYPE_INDEX = 1;
-	static constexpr const idx_t SCHEMA_DEFAULT_VALUE_INDEX = 2;
-	static constexpr const idx_t SCHEMA_CHILDREN_INDEX = 3;
-
 	ParquetColumnDefinition result;
 	auto &identifier = StructValue::GetChildren(column_value)[0];
 	result.identifier = identifier;
 
-	auto variant_value = StructValue::GetChildren(column_value)[1];
-	Vector tmp(variant_value, count_t(1));
-	RecursiveUnifiedVectorFormat format;
-	Vector::RecursiveToUnifiedFormat(tmp, 1, format);
-	UnifiedVariantVectorData vector_data(format);
-	auto column_def = VariantUtils::ConvertVariantToValue(vector_data, 0, 0);
-
-	D_ASSERT(column_def.type().id() == LogicalTypeId::STRUCT);
-
+	const auto &column_def = StructValue::GetChildren(column_value)[1];
 	const auto children = StructValue::GetChildren(column_def);
-	if (children.size() < 3) {
-		throw BinderException("Parquet schema definition \"%s\" must have at least 'name', 'type' and 'default_value'",
-		                      column_def.ToString());
-	}
-	result.name = StringValue::Get(children[SCHEMA_NAME_INDEX]);
-	result.type = TransformStringToLogicalType(StringValue::Get(children[SCHEMA_TYPE_INDEX]), context);
+	result.name = StringValue::Get(children[0]);
+	result.type = TransformStringToLogicalType(StringValue::Get(children[1]), context);
 	string error_message;
-	if (!children[SCHEMA_DEFAULT_VALUE_INDEX].TryCastAs(context, result.type, result.default_value, &error_message)) {
-		throw BinderException("Unable to cast Parquet schema default_value \"%s\" to %s",
-		                      children[SCHEMA_DEFAULT_VALUE_INDEX].ToString(), result.type.ToString());
-	}
-
-	if (children.size() > SCHEMA_CHILDREN_INDEX && !children[SCHEMA_CHILDREN_INDEX].IsNull()) {
-		auto &child_values = ListValue::GetChildren(children[SCHEMA_CHILDREN_INDEX]);
-		result.children.reserve(child_values.size());
-		for (const auto &child_value : child_values) {
-			result.children.emplace_back(ParquetColumnDefinition::FromSchemaValue(context, child_value));
-		}
+	if (!children[2].TryCastAs(context, result.type, result.default_value, &error_message)) {
+		throw BinderException("Unable to cast Parquet schema default_value \"%s\" to %s", children[2].ToString(),
+		                      result.type.ToString());
 	}
 
 	return result;
 }
 
-MultiFileColumnDefinition ParquetColumnDefinition::ToMultiFileColumnDefinition() const {
-	MultiFileColumnDefinition result(name, type);
-	result.identifier = identifier;
-	result.default_expression = make_uniq<ConstantExpression>(default_value);
-
-	if (children.empty()) {
-		return result;
-	}
-
-	idx_t expected_children = 0;
+static void VerifyParquetSchemaChildCount(const string &name, const LogicalType &type, idx_t child_count) {
+	idx_t expected_children;
 	switch (type.id()) {
 	case LogicalTypeId::STRUCT:
 		expected_children = StructType::GetChildTypes(type).size();
@@ -1286,10 +1254,137 @@ MultiFileColumnDefinition ParquetColumnDefinition::ToMultiFileColumnDefinition()
 		throw BinderException("Parquet schema column \"%s\" of type %s cannot define nested children", name,
 		                      type.ToString());
 	}
-	if (expected_children != children.size()) {
+	if (expected_children != child_count) {
 		throw BinderException("Parquet schema column \"%s\" of type %s expects %d child definitions, not %d", name,
-		                      type.ToString(), expected_children, children.size());
+		                      type.ToString(), expected_children, child_count);
 	}
+}
+
+struct ParquetSchemaVariantSource {
+	explicit ParquetSchemaVariantSource(const VariantNode &node) : node(node) {
+	}
+
+	bool Emit(idx_t row, VariantBuilder &builder) const {
+		D_ASSERT(row == 0);
+		EmitIterator(node, builder);
+		return false;
+	}
+
+	const VariantNode &node;
+};
+
+static Value ParquetSchemaVariantToValue(const VariantNode &node) {
+	Vector result(LogicalType::VARIANT(), 1);
+	ParquetSchemaVariantSource source(node);
+	BuildVariant(source, 1, result);
+	return VariantValue::GetValue(result.GetValue(0));
+}
+
+static Value ParquetSchemaVariantIdentifier(const VariantNode &node) {
+	switch (node.GetTypeId()) {
+	case VariantLogicalType::INT32:
+		return Value::INTEGER(node.GetData<int32_t>());
+	case VariantLogicalType::VARCHAR:
+		return Value(node.GetString().GetString());
+	default:
+		throw BinderException("Parquet schema child identifier must be an INTEGER or VARCHAR");
+	}
+}
+
+static ParquetColumnDefinition ParseParquetSchemaVariant(ClientContext &context, const Value &identifier,
+                                                         const VariantNode &column_value);
+
+static void ParseParquetSchemaVariantChildren(ClientContext &context, const VariantNode &children_value,
+                                              vector<ParquetColumnDefinition> &result) {
+	if (children_value.GetTypeId() != VariantLogicalType::ARRAY) {
+		throw BinderException("Parquet schema 'children' must be a MAP(INTEGER/VARCHAR, VARIANT), not %s",
+		                      EnumUtil::ToString(children_value.GetTypeId()));
+	}
+
+	auto entries = children_value.GetArrayChildren();
+	result.reserve(entries.size());
+	for (const auto &entry : entries) {
+		if (entry.GetTypeId() != VariantLogicalType::OBJECT) {
+			throw BinderException("Parquet schema 'children' must be a MAP(INTEGER/VARCHAR, VARIANT)");
+		}
+
+		optional<VariantNode> identifier_node;
+		optional<VariantNode> definition_node;
+		for (const auto &field : entry.GetObjectChildren()) {
+			if (field.key == "key") {
+				identifier_node = field.value;
+			} else if (field.key == "value") {
+				definition_node = field.value;
+			}
+		}
+		if (!identifier_node || !definition_node) {
+			throw BinderException("Parquet schema 'children' contains an invalid MAP entry");
+		}
+		result.emplace_back(
+		    ParseParquetSchemaVariant(context, ParquetSchemaVariantIdentifier(*identifier_node), *definition_node));
+	}
+}
+
+static ParquetColumnDefinition ParseParquetSchemaVariant(ClientContext &context, const Value &identifier,
+                                                         const VariantNode &column_value) {
+	if (column_value.GetTypeId() != VariantLogicalType::OBJECT) {
+		throw BinderException("Parquet schema definition must be an OBJECT");
+	}
+
+	optional<VariantNode> name;
+	optional<VariantNode> type;
+	optional<VariantNode> default_value;
+	optional<VariantNode> children;
+	for (const auto &field : column_value.GetObjectChildren()) {
+		if (field.key == "name") {
+			name = field.value;
+		} else if (field.key == "type") {
+			type = field.value;
+		} else if (field.key == "default_value") {
+			default_value = field.value;
+		} else if (field.key == "children") {
+			children = field.value;
+		}
+	}
+	if (!name || !type || !default_value) {
+		throw BinderException("Parquet schema definition must have 'name', 'type' and 'default_value'");
+	}
+	if (name->GetTypeId() != VariantLogicalType::VARCHAR || type->GetTypeId() != VariantLogicalType::VARCHAR) {
+		throw BinderException("Parquet schema definition 'name' and 'type' must be VARCHAR");
+	}
+
+	ParquetColumnDefinition result;
+	result.identifier = identifier;
+	result.name = name->GetString().GetString();
+	result.type = TransformStringToLogicalType(type->GetString().GetString(), context);
+	auto untyped_default = ParquetSchemaVariantToValue(*default_value);
+	string error_message;
+	if (!untyped_default.TryCastAs(context, result.type, result.default_value, &error_message)) {
+		throw BinderException("Unable to cast Parquet schema default_value \"%s\" to %s", untyped_default.ToString(),
+		                      result.type.ToString());
+	}
+	if (children && !children->IsNull() && children->GetTypeId() != VariantLogicalType::VARIANT_NULL) {
+		ParseParquetSchemaVariantChildren(context, *children, result.children);
+		VerifyParquetSchemaChildCount(result.name, result.type, result.children.size());
+	}
+	return result;
+}
+
+ParquetColumnDefinition ParquetColumnDefinition::FromSchemaVariant(ClientContext &context, const Value &identifier,
+                                                                   const VariantNode &column_value) {
+	return ParseParquetSchemaVariant(context, identifier, column_value);
+}
+
+MultiFileColumnDefinition ParquetColumnDefinition::ToMultiFileColumnDefinition() const {
+	MultiFileColumnDefinition result(name, type);
+	result.identifier = identifier;
+	result.default_expression = make_uniq<ConstantExpression>(default_value);
+
+	if (children.empty()) {
+		return result;
+	}
+
+	VerifyParquetSchemaChildCount(name, type, children.size());
 	result.children.reserve(children.size());
 	for (const auto &child : children) {
 		result.children.emplace_back(child.ToMultiFileColumnDefinition());

--- a/extension/parquet/serialize_parquet.cpp
+++ b/extension/parquet/serialize_parquet.cpp
@@ -52,6 +52,7 @@ void ParquetColumnDefinition::Serialize(Serializer &serializer) const {
 	serializer.WriteProperty<LogicalType>(103, "type", type);
 	serializer.WriteProperty<Value>(104, "default_value", default_value);
 	serializer.WritePropertyWithDefault<Value>(105, "identifier", identifier, Value());
+	serializer.WritePropertyWithDefault<vector<ParquetColumnDefinition>>(106, "children", children);
 }
 
 ParquetColumnDefinition ParquetColumnDefinition::Deserialize(Deserializer &deserializer) {
@@ -61,6 +62,7 @@ ParquetColumnDefinition ParquetColumnDefinition::Deserialize(Deserializer &deser
 	deserializer.ReadProperty<LogicalType>(103, "type", result.type);
 	deserializer.ReadProperty<Value>(104, "default_value", result.default_value);
 	deserializer.ReadPropertyWithExplicitDefault<Value>(105, "identifier", result.identifier, Value());
+	deserializer.ReadPropertyWithDefault<vector<ParquetColumnDefinition>>(106, "children", result.children);
 	return result;
 }
 

--- a/test/helpers/test_config.cpp
+++ b/test/helpers/test_config.cpp
@@ -92,7 +92,10 @@ static const TestConfigOption test_config_options[] = {
          LogicalType::STRUCT({{"reason", LogicalType::VARCHAR}, {"paths", LogicalType::LIST(LogicalType::VARCHAR)}})),
      nullptr},
     {"skip_compiled", "Skip compiled tests", LogicalType::BOOLEAN, nullptr},
-    {"skip_error_messages", "Skip compiled tests", LogicalType::LIST(LogicalType::VARCHAR), nullptr},
+    {"ignore_error_messages", "Error messages that cause SQLLogic tests to be skipped",
+     LogicalType::LIST(LogicalType::VARCHAR), nullptr},
+    {"skip_error_messages", "Deprecated alias for ignore_error_messages", LogicalType::LIST(LogicalType::VARCHAR),
+     nullptr},
     {"sort_style", "Default sort style if none is configured in the test (none, rowsort, valuesort)",
      LogicalType::VARCHAR, TestConfiguration::CheckSortStyle},
     {"statically_loaded_extensions", "Extensions to be loaded (from the statically available one)",
@@ -413,9 +416,12 @@ vector<string> TestConfiguration::ExtensionToBeLoadedOnLoad() {
 	return res;
 }
 
-vector<string> TestConfiguration::ErrorMessagesToBeSkipped() {
+vector<string> TestConfiguration::GetIgnoreErrorMessages() {
 	vector<string> res;
-	auto entry = options.find("skip_error_messages");
+	auto entry = options.find("ignore_error_messages");
+	if (entry == options.end()) {
+		entry = options.find("skip_error_messages");
+	}
 	if (entry != options.end()) {
 		vector<Value> ext_list = ListValue::GetChildren(entry->second);
 

--- a/test/include/test_config.hpp
+++ b/test/include/test_config.hpp
@@ -83,7 +83,7 @@ public:
 	string GetCleanupSqllogic();
 	SortStyle GetDefaultSortStyle();
 	vector<string> ExtensionToBeLoadedOnLoad();
-	vector<string> ErrorMessagesToBeSkipped();
+	vector<string> GetIgnoreErrorMessages();
 	string GetStorageVersion();
 	string GetTestEnv(const string &key, const string &default_value);
 	bool HasTestEnv(const string &key);

--- a/test/parquet/test_parquet_schema.test
+++ b/test/parquet/test_parquet_schema.test
@@ -373,7 +373,7 @@ FROM read_parquet(
 	schema=(
 		map {
 			'i': {name: 'i', type: 'BIGINT', default_value: NULL},
-			'missing': {name: 'missing', type: 'BIGINT', default_value: 9},
+			'missing': {name: 'missing', type: 'BIGINT', default_value: '9'},
 			's': {
 				name: 's',
 				type: 'STRUCT("inner" STRUCT(x BIGINT))',
@@ -385,11 +385,15 @@ FROM read_parquet(
 							type: 'STRUCT(x BIGINT)',
 							default_value: NULL,
 							children: map {
-								'x': {name: 'x', type: 'BIGINT', default_value: NULL}
+								'x': {
+									name: 'x',
+									type: 'BIGINT',
+									default_value: NULL
+								}
 							}
 						}
 					}
-				)::MAP(VARCHAR, VARIANT)
+				)
 			},
 			'l': {
 				name: 'l',
@@ -401,7 +405,11 @@ FROM read_parquet(
 						type: 'STRUCT(y BIGINT)',
 						default_value: NULL,
 						children: map {
-							'y': {name: 'y', type: 'BIGINT', default_value: NULL}
+							'y': {
+								name: 'y',
+								type: 'BIGINT',
+								default_value: NULL
+							}
 						}
 					}
 				}
@@ -412,29 +420,58 @@ FROM read_parquet(
 				default_value: NULL,
 				children: (
 					map {
-						'key': {name: 'key', type: 'BIGINT', default_value: NULL},
+						'key': {
+							name: 'key',
+							type: 'BIGINT',
+							default_value: NULL
+						},
 						'value': {
 							name: 'value',
 							type: 'STRUCT(z BIGINT)',
 							default_value: NULL,
 							children: map {
-								'z': {name: 'z', type: 'BIGINT', default_value: NULL}
+								'z': {
+									name: 'z',
+									type: 'BIGINT',
+									default_value: NULL
+								}
 							}
 						}
 					}
-				)::MAP(VARCHAR, VARIANT)
+				)
 			}
 		}
-	)::MAP(VARCHAR, VARIANT)
+	)
 )
 ----
 7	42	100	200	9
 
+# non-NULL defaults in VARIANT schema definitions must be VARCHAR
+statement error
+SELECT *
+FROM read_parquet(
+	'{TEMP_DIR}/nested_schema.parquet',
+	schema=map {
+		'i': ({name: 'i', type: 'BIGINT', default_value: 9})::VARIANT
+	}
+)
+----
+Binder Error: Parquet schema default_value must be VARCHAR or NULL
+
 # integer identifiers are supported recursively
 statement ok
 COPY (
-	SELECT struct_pack(f := 42::INTEGER) AS s
-) TO '{TEMP_DIR}/nested_field_ids.parquet' (FIELD_IDS {s: {__duckdb_field_id: 10, f: 11}})
+	SELECT {
+		'f': 42::INTEGER
+	} AS s
+) TO '{TEMP_DIR}/nested_field_ids.parquet' (
+	FIELD_IDS {
+		s: {
+			__duckdb_field_id: 10,
+			f: 11
+		}
+	}
+)
 
 query I
 SELECT s.f
@@ -447,11 +484,15 @@ FROM read_parquet(
 				type: 'STRUCT(f BIGINT)',
 				default_value: NULL,
 				children: map {
-					11: {name: 'f', type: 'BIGINT', default_value: NULL}
+					11: {
+						name: 'f',
+						type: 'BIGINT',
+						default_value: NULL
+					}
 				}
 			}
 		}
-	)::MAP(INTEGER, VARIANT)
+	)
 )
 ----
 42
@@ -467,10 +508,10 @@ FROM read_parquet(
 				name: 's',
 				type: 'STRUCT(f BIGINT)',
 				default_value: NULL,
-				children: (map {})::MAP(INTEGER, VARIANT)
+				children: {}
 			}
 		}
-	)::MAP(INTEGER, VARIANT)
+	)
 )
 ----
 Binder Error: Parquet schema column "s" of type STRUCT(f BIGINT) expects 1 child definitions, not 0

--- a/test/parquet/test_parquet_schema.test
+++ b/test/parquet/test_parquet_schema.test
@@ -366,13 +366,14 @@ COPY (
 		MAP([10::INTEGER], [struct_pack(z := 200::INTEGER)]) AS m
 ) TO '{TEMP_DIR}/nested_schema.parquet'
 
-query IIII
-SELECT i, s.inner.x, l[1].y, m[10].z
+query IIIII
+SELECT i, s.inner.x, l[1].y, m[10].z, missing
 FROM read_parquet(
 	'{TEMP_DIR}/nested_schema.parquet',
 	schema=(
 		map {
 			'i': {name: 'i', type: 'BIGINT', default_value: NULL},
+			'missing': {name: 'missing', type: 'BIGINT', default_value: 9},
 			's': {
 				name: 's',
 				type: 'STRUCT("inner" STRUCT(x BIGINT))',
@@ -395,7 +396,7 @@ FROM read_parquet(
 				type: 'STRUCT(y BIGINT)[]',
 				default_value: NULL,
 				children: map {
-					'element': {
+					'list': {
 						name: 'element',
 						type: 'STRUCT(y BIGINT)',
 						default_value: NULL,
@@ -427,4 +428,49 @@ FROM read_parquet(
 	)::MAP(VARCHAR, VARIANT)
 )
 ----
-7	42	100	200
+7	42	100	200	9
+
+# integer identifiers are supported recursively
+statement ok
+COPY (
+	SELECT struct_pack(f := 42::INTEGER) AS s
+) TO '{TEMP_DIR}/nested_field_ids.parquet' (FIELD_IDS {s: {__duckdb_field_id: 10, f: 11}})
+
+query I
+SELECT s.f
+FROM read_parquet(
+	'{TEMP_DIR}/nested_field_ids.parquet',
+	schema=(
+		map {
+			10: {
+				name: 's',
+				type: 'STRUCT(f BIGINT)',
+				default_value: NULL,
+				children: map {
+					11: {name: 'f', type: 'BIGINT', default_value: NULL}
+				}
+			}
+		}
+	)::MAP(INTEGER, VARIANT)
+)
+----
+42
+
+# supplied children are validated even when the map is empty
+statement error
+SELECT *
+FROM read_parquet(
+	'{TEMP_DIR}/nested_field_ids.parquet',
+	schema=(
+		map {
+			10: {
+				name: 's',
+				type: 'STRUCT(f BIGINT)',
+				default_value: NULL,
+				children: (map {})::MAP(INTEGER, VARIANT)
+			}
+		}
+	)::MAP(INTEGER, VARIANT)
+)
+----
+Binder Error: Parquet schema column "s" of type STRUCT(f BIGINT) expects 1 child definitions, not 0

--- a/test/parquet/test_parquet_schema.test
+++ b/test/parquet/test_parquet_schema.test
@@ -11,7 +11,7 @@ statement error
 SELECT *
 FROM read_parquet('{TEMP_DIR}/integers.parquet', schema=map{})
 ----
-Invalid Input Error: 'schema' expects a STRUCT as the value type of the map
+Invalid Input Error: 'schema' expects the value type of the map to be either STRUCT or VARIANT
 
 # can't combine with union_by_name
 statement error
@@ -355,3 +355,76 @@ from read_parquet(
 	},
 	filename=True
 ) where x = 1;
+
+# nested child schemas can be defined recursively through children maps
+statement ok
+COPY (
+	SELECT
+		7::INTEGER AS i,
+		struct_pack(inner := struct_pack(x := 42::INTEGER)) AS s,
+		[struct_pack(y := 100::INTEGER)] AS l,
+		MAP([10::INTEGER], [struct_pack(z := 200::INTEGER)]) AS m
+) TO '{TEMP_DIR}/nested_schema.parquet'
+
+query IIII
+SELECT i, s.inner.x, l[1].y, m[10].z
+FROM read_parquet(
+	'{TEMP_DIR}/nested_schema.parquet',
+	schema=(
+		map {
+			'i': {name: 'i', type: 'BIGINT', default_value: NULL},
+			's': {
+				name: 's',
+				type: 'STRUCT("inner" STRUCT(x BIGINT))',
+				default_value: NULL,
+				children: (
+					map {
+						'inner': {
+							name: 'inner',
+							type: 'STRUCT(x BIGINT)',
+							default_value: NULL,
+							children: map {
+								'x': {name: 'x', type: 'BIGINT', default_value: NULL}
+							}
+						}
+					}
+				)::MAP(VARCHAR, VARIANT)
+			},
+			'l': {
+				name: 'l',
+				type: 'STRUCT(y BIGINT)[]',
+				default_value: NULL,
+				children: map {
+					'element': {
+						name: 'element',
+						type: 'STRUCT(y BIGINT)',
+						default_value: NULL,
+						children: map {
+							'y': {name: 'y', type: 'BIGINT', default_value: NULL}
+						}
+					}
+				}
+			},
+			'm': {
+				name: 'm',
+				type: 'MAP(BIGINT, STRUCT(z BIGINT))',
+				default_value: NULL,
+				children: (
+					map {
+						'key': {name: 'key', type: 'BIGINT', default_value: NULL},
+						'value': {
+							name: 'value',
+							type: 'STRUCT(z BIGINT)',
+							default_value: NULL,
+							children: map {
+								'z': {name: 'z', type: 'BIGINT', default_value: NULL}
+							}
+						}
+					}
+				)::MAP(VARCHAR, VARIANT)
+			}
+		}
+	)::MAP(VARCHAR, VARIANT)
+)
+----
+7	42	100	200

--- a/test/sqlite/sqllogic_test_runner.cpp
+++ b/test/sqlite/sqllogic_test_runner.cpp
@@ -810,7 +810,7 @@ void SQLLogicTestRunner::ExecuteInternal(SQLLogicParser &parser, const string &s
 	}
 
 	ignore_error_messages.clear();
-	for (auto ignore : test_config.ErrorMessagesToBeSkipped()) {
+	for (auto ignore : test_config.GetIgnoreErrorMessages()) {
 		ignore_error_messages.insert(ignore);
 	}
 


### PR DESCRIPTION
This allows us to more easily test the `MultiFileColumnMapper`, rather than only being able to test it through extensions like `iceberg`, `delta`, or `ducklake`