### PR TITLE
Fix#24303 date_trunc comparisons with infinite timestamps

### DIFF
--- a/src/include/duckdb/optimizer/rule/date_trunc_simplification.hpp
+++ b/src/include/duckdb/optimizer/rule/date_trunc_simplification.hpp
@@ -66,6 +66,7 @@ public:
 	                                      const LogicalType &return_type);
 
 	bool DateIsTruncated(const BoundConstantExpression &date_part, const BoundConstantExpression &rhs);
+	bool IsInfinity(const Value &value);
 
 	unique_ptr<Expression> CastAndEvaluate(unique_ptr<Expression> rhs, const LogicalType &return_type);
 };

--- a/src/include/duckdb/optimizer/rule/date_trunc_simplification.hpp
+++ b/src/include/duckdb/optimizer/rule/date_trunc_simplification.hpp
@@ -67,6 +67,8 @@ public:
 
 	bool DateIsTruncated(const BoundConstantExpression &date_part, const BoundConstantExpression &rhs);
 	bool IsInfinity(const Value &value);
+	void ReplaceDateTruncWithColumn(unique_ptr<Expression> &column_side, unique_ptr<Expression> &constant_side,
+	                                const BoundColumnRefExpression &column_part);
 
 	unique_ptr<Expression> CastAndEvaluate(unique_ptr<Expression> rhs, const LogicalType &return_type);
 };

--- a/src/optimizer/rule/date_trunc_simplification.cpp
+++ b/src/optimizer/rule/date_trunc_simplification.cpp
@@ -63,19 +63,12 @@ unique_ptr<Expression> DateTruncSimplificationRule::Apply(LogicalOperator &op, v
 		rhs_comparison_type = FlipComparisonExpression(comparison_type);
 	}
 
+	auto &column_side = col_is_lhs ? left : right;
+	auto &constant_side = col_is_lhs ? right : left;
+
 	// date_trunc preserves temporal infinities, so only remove the function call.
 	if (IsInfinity(rhs.GetValue())) {
-		if (col_is_lhs) {
-			left = column_part.Copy();
-			if (rhs.GetReturnType().id() != left->GetReturnType().id()) {
-				right = CastAndEvaluate(std::move(right), left->GetReturnType());
-			}
-		} else {
-			right = column_part.Copy();
-			if (rhs.GetReturnType().id() != right->GetReturnType().id()) {
-				left = CastAndEvaluate(std::move(left), right->GetReturnType());
-			}
-		}
+		ReplaceDateTruncWithColumn(column_side, constant_side, column_part);
 		changes_made = true;
 		return nullptr;
 	}
@@ -236,29 +229,12 @@ unique_ptr<Expression> DateTruncSimplificationRule::Apply(LogicalOperator &op, v
 					return nullptr; // Something went wrong---don't do the optimization.
 				}
 
-				if (col_is_lhs) {
-					left = column_part.Copy();
-					right = std::move(trunc);
-				} else {
-					right = column_part.Copy();
-					left = std::move(trunc);
-				}
+				column_side = column_part.Copy();
+				constant_side = std::move(trunc);
 			} else {
 				// If the RHS is already truncated (i.e.  date_trunc(part, rhs) = rhs), then we can use
 				// it as-is.
-				if (col_is_lhs) {
-					left = column_part.Copy();
-					// Determine whether the RHS needs to be casted.
-					if (rhs.GetReturnType().id() != left->GetReturnType().id()) {
-						right = CastAndEvaluate(std::move(right), left->GetReturnType());
-					}
-				} else {
-					right = column_part.Copy();
-					// Determine whether the RHS needs to be casted.
-					if (rhs.GetReturnType().id() != right->GetReturnType().id()) {
-						left = CastAndEvaluate(std::move(left), right->GetReturnType());
-					}
-				}
+				ReplaceDateTruncWithColumn(column_side, constant_side, column_part);
 			}
 
 			changes_made = true;
@@ -278,13 +254,8 @@ unique_ptr<Expression> DateTruncSimplificationRule::Apply(LogicalOperator &op, v
 				return nullptr; // Something went wrong---don't do the optimization.
 			}
 
-			if (col_is_lhs) {
-				left = column_part.Copy();
-				right = std::move(trunc);
-			} else {
-				right = column_part.Copy();
-				left = std::move(trunc);
-			}
+			column_side = column_part.Copy();
+			constant_side = std::move(trunc);
 
 			// > needs to become >=, and <= needs to become <.
 			if (rhs_comparison_type == ExpressionType::COMPARE_GREATERTHAN) {
@@ -470,6 +441,15 @@ bool DateTruncSimplificationRule::IsInfinity(const Value &value) {
 		return value == Value::Infinity(value.type()) || value == Value::NegativeInfinity(value.type());
 	default:
 		return false;
+	}
+}
+
+void DateTruncSimplificationRule::ReplaceDateTruncWithColumn(unique_ptr<Expression> &column_side,
+                                                             unique_ptr<Expression> &constant_side,
+                                                             const BoundColumnRefExpression &column_part) {
+	column_side = column_part.Copy();
+	if (constant_side->GetReturnType().id() != column_side->GetReturnType().id()) {
+		constant_side = CastAndEvaluate(std::move(constant_side), column_side->GetReturnType());
 	}
 }
 

--- a/src/optimizer/rule/date_trunc_simplification.cpp
+++ b/src/optimizer/rule/date_trunc_simplification.cpp
@@ -63,6 +63,23 @@ unique_ptr<Expression> DateTruncSimplificationRule::Apply(LogicalOperator &op, v
 		rhs_comparison_type = FlipComparisonExpression(comparison_type);
 	}
 
+	// date_trunc preserves temporal infinities, so only remove the function call.
+	if (IsInfinity(rhs.GetValue())) {
+		if (col_is_lhs) {
+			left = column_part.Copy();
+			if (rhs.GetReturnType().id() != left->GetReturnType().id()) {
+				right = CastAndEvaluate(std::move(right), left->GetReturnType());
+			}
+		} else {
+			right = column_part.Copy();
+			if (rhs.GetReturnType().id() != right->GetReturnType().id()) {
+				left = CastAndEvaluate(std::move(left), right->GetReturnType());
+			}
+		}
+		changes_made = true;
+		return nullptr;
+	}
+
 	// Check whether trunc(date_part, constant_rhs) = constant_rhs.
 	const bool is_truncated = DateIsTruncated(date_part, rhs);
 
@@ -437,6 +454,23 @@ bool DateTruncSimplificationRule::DateIsTruncated(const BoundConstantExpression 
 	}
 
 	return (result == trunc_result);
+}
+
+bool DateTruncSimplificationRule::IsInfinity(const Value &value) {
+	if (value.IsNull()) {
+		return false;
+	}
+	switch (value.type().id()) {
+	case LogicalTypeId::TIMESTAMP:
+	case LogicalTypeId::TIMESTAMP_SEC:
+	case LogicalTypeId::TIMESTAMP_MS:
+	case LogicalTypeId::TIMESTAMP_NS:
+	case LogicalTypeId::TIMESTAMP_TZ:
+	case LogicalTypeId::TIMESTAMP_TZ_NS:
+		return value == Value::Infinity(value.type()) || value == Value::NegativeInfinity(value.type());
+	default:
+		return false;
+	}
 }
 
 unique_ptr<Expression> DateTruncSimplificationRule::CastAndEvaluate(unique_ptr<Expression> rhs,

--- a/test/optimizer/date_trunc_simplification.test
+++ b/test/optimizer/date_trunc_simplification.test
@@ -422,3 +422,91 @@ query I
 select * from test where date_trunc('quarter', d) >= '2025-04-01';
 ----
 
+#
+# check comparisons with infinity
+#
+
+statement ok
+create table infinity_test(d TIMESTAMP);
+
+statement ok
+insert into infinity_test values ('-infinity'), ('2025-01-01'), ('infinity'), (NULL);
+
+query IIIIII
+select date_trunc('day', d) = TIMESTAMP 'infinity',
+       date_trunc('day', d) != TIMESTAMP 'infinity',
+       date_trunc('day', d) < TIMESTAMP 'infinity',
+       date_trunc('day', d) <= TIMESTAMP 'infinity',
+       date_trunc('day', d) > TIMESTAMP 'infinity',
+       date_trunc('day', d) >= TIMESTAMP 'infinity'
+from infinity_test
+order by d;
+----
+false	true	true	true	false	false
+false	true	true	true	false	false
+true	false	false	true	false	true
+NULL	NULL	NULL	NULL	NULL	NULL
+
+query IIIIII
+select date_trunc('day', d) = TIMESTAMP '-infinity',
+       date_trunc('day', d) != TIMESTAMP '-infinity',
+       date_trunc('day', d) < TIMESTAMP '-infinity',
+       date_trunc('day', d) <= TIMESTAMP '-infinity',
+       date_trunc('day', d) > TIMESTAMP '-infinity',
+       date_trunc('day', d) >= TIMESTAMP '-infinity'
+from infinity_test
+order by d;
+----
+true	false	false	true	false	true
+false	true	false	false	true	true
+false	true	false	false	true	true
+NULL	NULL	NULL	NULL	NULL	NULL
+
+statement ok
+create table infinity_date_test(d DATE);
+
+statement ok
+insert into infinity_date_test values ('-infinity'), ('2025-01-01'), ('infinity'), (NULL);
+
+query IIIIII
+select TIMESTAMP 'infinity' = date_trunc('day', d),
+       TIMESTAMP 'infinity' != date_trunc('day', d),
+       TIMESTAMP 'infinity' < date_trunc('day', d),
+       TIMESTAMP 'infinity' <= date_trunc('day', d),
+       TIMESTAMP 'infinity' > date_trunc('day', d),
+       TIMESTAMP 'infinity' >= date_trunc('day', d)
+from infinity_date_test
+order by d;
+----
+false	true	false	false	true	true
+false	true	false	false	true	true
+true	false	false	true	false	true
+NULL	NULL	NULL	NULL	NULL	NULL
+
+query IIIIII
+select TIMESTAMP '-infinity' = date_trunc('day', d),
+       TIMESTAMP '-infinity' != date_trunc('day', d),
+       TIMESTAMP '-infinity' < date_trunc('day', d),
+       TIMESTAMP '-infinity' <= date_trunc('day', d),
+       TIMESTAMP '-infinity' > date_trunc('day', d),
+       TIMESTAMP '-infinity' >= date_trunc('day', d)
+from infinity_date_test
+order by d;
+----
+true	false	false	true	false	true
+false	true	true	true	false	false
+false	true	true	true	false	false
+NULL	NULL	NULL	NULL	NULL	NULL
+
+query IIII
+select date_trunc('day', d) is not distinct from TIMESTAMP 'infinity',
+       date_trunc('day', d) is distinct from TIMESTAMP 'infinity',
+       TIMESTAMP 'infinity' is not distinct from date_trunc('day', d),
+       TIMESTAMP 'infinity' is distinct from date_trunc('day', d)
+from infinity_test
+order by d;
+----
+false	true	false	true
+false	true	false	true
+true	false	true	false
+false	true	false	true

--- a/test/optimizer/date_trunc_simplification_icu.test
+++ b/test/optimizer/date_trunc_simplification_icu.test
@@ -82,3 +82,28 @@ select * from test2 where date_trunc('hour', d) >= '2025-11-02T02:30:00+00'::TIM
 ----
 2025-11-02 00:30:00-02:30
 2025-11-02 01:30:00-03:30
+
+#
+# check comparisons with infinity
+#
+
+statement ok
+create table infinity_tz_test(d TIMESTAMPTZ);
+
+statement ok
+insert into infinity_tz_test values ('-infinity'), ('2025-01-01'), ('infinity'), (NULL);
+
+query IIIIII
+select date_trunc('day', d) = 'infinity'::TIMESTAMPTZ,
+       date_trunc('day', d) != 'infinity'::TIMESTAMPTZ,
+       date_trunc('day', d) < 'infinity'::TIMESTAMPTZ,
+       date_trunc('day', d) <= 'infinity'::TIMESTAMPTZ,
+       date_trunc('day', d) > 'infinity'::TIMESTAMPTZ,
+       date_trunc('day', d) >= 'infinity'::TIMESTAMPTZ
+from infinity_tz_test
+order by d;
+----
+false	true	true	true	false	false
+false	true	true	true	false	false
+true	false	false	true	false	true
+NULL	NULL	NULL	NULL	NULL	NULL


### PR DESCRIPTION
Closes #24303
This PR fixes issue #24303 which `DateTruncSimplificationRule` produces incorrect results when comparing against `±infinity`.

`DateTruncSimplificationRule` rewrites predicates of the form `date_trunc(constant_part, column) OP constant` into a range predicates directly on the underlying column.

For finite constants, the rule can rewrite a `date_trunc` comparison into a range comparison safely. This does not work for infinity because adding an interval to infinity still produces infinity. For example: `date_trunc('day', d) = TIMESTAMP 'infinity'` was rewritten to the equivalent of: `d >= TIMESTAMP 'infinity' AND d < TIMESTAMP 'infinity'`.

Since date_trunc preserves temporal infinity values, comparisons against infinity can instead be simplified directly: `date_trunc(part, column) OP infinity` to `column OP infinity`.

And I add some tests covered:

- Positive and negative infinity
- All six comparison operators
- Infinity on either side of the comparison
- TIMESTAMP and DATE columns
- NULL and IS [NOT] DISTINCT FROM semantics
- The TIMESTAMPTZ path provided by ICU