### PR TITLE
fix: clamp negative substring offsets beyond string start

### DIFF
--- a/src/function/scalar/list/list_extract.cpp
+++ b/src/function/scalar/list/list_extract.cpp
@@ -97,7 +97,32 @@ static void ExecuteListExtract(Vector &result, const Vector &list, const Vector 
 static void ExecuteStringExtract(Vector &result, const Vector &input_vector, const Vector &subscript_vector) {
 	BinaryExecutor::Execute<string_t, int64_t, string_t>(
 	    input_vector, subscript_vector, result,
-	    [&](string_t input_string, int64_t subscript) { return SubstringUnicode(result, input_string, subscript, 1); });
+	    [&](string_t input_string, int64_t subscript) {
+		    // negative subscripts count from the end of the string; if the index is out of
+		    // range the result is empty
+		    if (subscript < 0) {
+			    const auto input_data = input_string.GetData();
+			    const auto input_size = input_string.GetSize();
+			    int64_t num_characters = 0;
+			    for (idx_t i = 0; i < input_size; i++) {
+				    if (IsCharacter(input_data[i])) {
+					    num_characters++;
+				    }
+			    }
+			    // -subscript can overflow for INT64_MIN, so compare against the negated count
+			    if (subscript < -num_characters) {
+				    // only subscripts within the supported range fall back to an empty string;
+				    // anything below that is left for SubstringUnicode to raise an error for
+				    const int64_t SUPPORTED_LOWER_BOUND = -static_cast<int64_t>(NumericLimits<uint32_t>::Maximum()) - 1;
+				    if (subscript >= SUPPORTED_LOWER_BOUND) {
+					    auto result_string = StringVector::EmptyString(result, 0);
+					    result_string.Finalize();
+					    return result_string;
+				    }
+			    }
+		    }
+		    return SubstringUnicode(result, input_string, subscript, 1);
+	    });
 }
 
 static void ListExtractFunction(DataChunk &args, ExpressionState &state, Vector &result) {

--- a/src/function/scalar/string/substring.cpp
+++ b/src/function/scalar/string/substring.cpp
@@ -123,6 +123,21 @@ string_t SubstringUnicode(Vector &result, string_t input, int64_t offset, int64_
 			start = -offset;
 			end = -offset - length;
 		}
+		// count the number of characters so we can clamp the scan positions to the string
+		int64_t num_characters = 0;
+		for (idx_t i = 0; i < input_size; i++) {
+			if (IsCharacter(input_data[i])) {
+				num_characters++;
+			}
+		}
+		// clamp the start position to one past the last character, and recompute the end position
+		// relative to the clamped start for positive lengths
+		start = MinValue<int64_t>(start, num_characters + 1);
+		if (length < 0) {
+			end = MinValue<int64_t>(end, num_characters + 1);
+		} else {
+			end = start - length;
+		}
 		if (end <= 0) {
 			end_pos = input_size;
 		}

--- a/test/sql/function/string/test_substring.test
+++ b/test/sql/function/string/test_substring.test
@@ -297,6 +297,30 @@ SELECT {FUN}(s, 0, -4294967297) FROM strings
 ----
 Out of Range Error: Substring length outside of supported range (< -4294967296)
 
+# negative offsets that reach beyond the start of the string clamp to the beginning
+query T
+SELECT {FUN}('hello', -100, 5)
+----
+hello
+
+query T
+SELECT {FUN}('hello', -6, 2)
+----
+he
+
+query T
+SELECT {FUN}('hello', -7, 3)
+----
+hel
+
+query T
+SELECT {FUN}(s, -100, 100) FROM strings
+----
+hello
+world
+b
+NULL
+
 endloop
 
 # SUBSTRING with FROM only (no FOR)

--- a/test/sql/function/string/test_substring_utf8.test
+++ b/test/sql/function/string/test_substring_utf8.test
@@ -37,6 +37,16 @@ SELECT {FUN}(s, -1, -4) FROM strings
 r🦆en
 
 query T
+SELECT {FUN}(s, -100, 100) FROM strings
+----
+twoñthree₡four🦆end
+
+query T
+SELECT {FUN}(s, -100, 3) FROM strings
+----
+two
+
+query T
 SELECT {FUN}(s, 0, -4) FROM strings
 ----
 (empty)


### PR DESCRIPTION
Summary:
- Clamp very negative substring offsets beyond the start of a string/list instead of overflowing offset arithmetic.
- Add regression coverage for substring and UTF-8 substring boundary cases.

Tests:
- build/reldebug/test/unittest test/sql/function/string/test_substring.test
- build/reldebug/test/unittest test/sql/function/string/test_substring_utf8.test
- build/reldebug/test/unittest test/sql/types/nested/list/test_list_extract.test
- build/reldebug/test/unittest test/sql/types/list/list_extract_internal_issue2747.test
- build/reldebug/test/unittest test/sql/types/list/list_extract_struct.test
- build/reldebug/test/unittest test/sql/types/list/nested_list_extract.test