### PR TITLE
Reject invalid imported approx_quantile states

### DIFF
--- a/extension/core_functions/aggregate/holistic/approximate_quantile.cpp
+++ b/extension/core_functions/aggregate/holistic/approximate_quantile.cpp
@@ -269,6 +269,10 @@ void ApproxQuantileImportState(AggregateImportInputData &input) {
 		if (!count_entry.IsValid() || !min_entry.IsValid() || !max_entry.IsValid() || !centroid_list.IsValid()) {
 			throw InvalidInputException("Invalid approx_quantile state - the state fields cannot be NULL");
 		}
+		if (count_entry.GetValue() != 0 && centroid_list.GetListLength() == 0) {
+			throw InvalidInputException(
+			    "Invalid approx_quantile state - non-zero count requires at least one centroid");
+		}
 		arena_vector<duckdb_tdigest::Centroid> centroids(input.allocator);
 		centroids.reserve(centroid_list.GetListLength());
 		for (const auto centroid_entry : centroid_list.GetChildValues()) {

--- a/test/sql/aggregate/aggregate_state_export/approx_quantile_export_state.test
+++ b/test/sql/aggregate/aggregate_state_export/approx_quantile_export_state.test
@@ -85,3 +85,13 @@ query I
 SELECT finalize(combine(approx_quantile(i, 0.5) EXPORT_STATE, (SELECT approx_quantile(j, 0.5) EXPORT_STATE FROM range(500, 1001) s(j)))) FROM range(1, 500) t(i);
 ----
 500
+
+# a non-empty state must contain at least one centroid
+statement error
+SELECT finalize(to_aggregate_state(
+    {'count': 1::UBIGINT, 'min': 0.0::DOUBLE, 'max': 0.0::DOUBLE,
+     'centroids': []::STRUCT(mean DOUBLE, weight DOUBLE)[]},
+    'approx_quantile', ['DOUBLE', 'FLOAT'], [NULL, 0.5::FLOAT]
+));
+----
+Invalid Input Error: Invalid approx_quantile state - non-zero count requires at least one centroid


### PR DESCRIPTION
 This PR validates imported `approx_quantile` aggregate states before constructing the TDigest.

  A state with a non-zero count and an empty centroid list currently reaches TDigest finalization and triggers an INTERNAL error when the digest accesses
  its first centroid. This change rejects that invalid combination at the import boundary with an `InvalidInputException`.

  The regression test constructs the invalid state through `to_aggregate_state` and verifies that it returns a user-facing input error instead of an
  INTERNAL error.

  Fixes #24279.

  Tests:
  - `make reldebug`
  - `build/reldebug/test/unittest test/sql/aggregate/aggregate_state_export/approx_quantile_export_state.test`
  - `build/reldebug/test/unittest 'test/sql/aggregate/aggregate_state_export/*'`
