### PR TITLE
Use smaller instance for extension load/install checks and skip a ducklake test on musl

### DIFF
--- a/.github/patches/extensions/ducklake/0004-disable-bucket-partitioning-on-musl.patch
+++ b/.github/patches/extensions/ducklake/0004-disable-bucket-partitioning-on-musl.patch
@@ -1,0 +1,12 @@
+diff --git a/test/sql/partitioning/bucket_partitioning.test b/test/sql/partitioning/bucket_partitioning.test
+--- a/test/sql/partitioning/bucket_partitioning.test
++++ b/test/sql/partitioning/bucket_partitioning.test
+@@ -7,6 +7,8 @@ require ducklake
+ 
+ require parquet
+ 
++require notmusl
++
+ test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
+ 
+ test-env DATA_PATH {TEST_DIR}

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -746,7 +746,7 @@ jobs:
       - prepare
       - extensions
       - linux-release-cli
-    runs-on: ${{ needs.prepare.outputs.runner_linux_x64 }}
+    runs-on: ${{ needs.prepare.outputs.runner_linux_small }}
 
     steps:
     - name: "Checkout"


### PR DESCRIPTION
The test `test/sql/partitioning/bucket_partitioning.test` is [failing](https://github.com/duckdb/duckdb/actions/runs/30775652218/job/91571353358#step:31:26) in CI for `linux_arm64_musl` with a timeout:
```
retrying failed test /duckdb_build_dir/build/release/_deps/ducklake_extension_fc-src/test/sql/partitioning/bucket_partitioning.test (attempt 1/2, retry 1/4)
retrying failed test /duckdb_build_dir/build/release/_deps/ducklake_extension_fc-src/test/sql/partitioning/bucket_partitioning.test (attempt 2/2, retry 2/4)
error: timeout (300s) for /duckdb_build_dir/build/release/_deps/ducklake_extension_fc-src/test/sql/partitioning/bucket_partitioning.test.
```

It fails for [multiple](https://github.com/duckdb/duckdb/actions/runs/30687876736/job/91337849587#step:31:26) days.