### PR TITLE
Fix VARIANT field extraction in index fetch

### DIFF
--- a/src/storage/table/variant_column_data.cpp
+++ b/src/storage/table/variant_column_data.cpp
@@ -467,8 +467,9 @@ void VariantColumnData::FetchRows(TransactionData transaction, ColumnFetchState 
 			VariantUtils::UnshredVariantData(intermediate, unshredded, 1);
 			variant_vec.SetValue(0, unshredded.GetValue(0));
 		} else {
-			sub_columns[0]->FetchRows(transaction, state, storage_index, &offset,
-			                          *FlatVector::IncrementalSelectionVector(), /*count=*/1, variant_vec, 0);
+			StorageIndex full_read(0);
+			sub_columns[0]->FetchRows(transaction, state, full_read, &offset, *FlatVector::IncrementalSelectionVector(),
+			                          /*count=*/1, variant_vec, 0);
 		}
 
 		if (!storage_index.IsPushdownExtract()) {

--- a/test/sql/storage/types/variant/index_fetch.test
+++ b/test/sql/storage/types/variant/index_fetch.test
@@ -12,7 +12,12 @@ SELECT v FROM tbl WHERE i=42;
 ----
 {'a': 42, 'b': 2}
 
-# Now test the same with a persistent db, checkpointed (shredded VARIANT)
+query I
+SELECT v['a']::INTEGER FROM tbl WHERE i=42;
+----
+42
+
+# Now test the same with a persistent DB. This row group stays unshredded because it is below the default threshold.
 
 statement ok
 ATTACH '{TEST_DIR}/variant_index_fetch.db' as db2 (STORAGE_VERSION 'v1.5.0');
@@ -33,6 +38,11 @@ query I
 SELECT v FROM tbl WHERE i=42;
 ----
 {'a': 42, 'b': 2}
+
+query I
+SELECT v['a']::INTEGER FROM tbl WHERE i=42;
+----
+42
 
 statement ok
 SET debug_force_fetch_row=true;


### PR DESCRIPTION
This PR fixes VARIANT field extraction when rows are fetched through an ART index.

  For unshredded VARIANT data, `VariantColumnData::FetchRows` forwarded the caller's field-based `StorageIndex` to the internal struct containing the
  VARIANT representation. `StructColumnData::FetchRows` expects positional child indexes for that struct, which could result in an INTERNAL error or
  incorrect NULL results.

  The unshredded branch now performs a full read of the internal VARIANT value and leaves field extraction and casting to the existing `VariantExtract`
  path.

  The checkpointed reproduction in the issue remains unshredded because the row group is below the default shredding threshold. Therefore, both reported
  behaviors share the same root cause.

  Regression tests cover field extraction through a primary-key lookup for both transient and checkpointed persisted-unshredded data while retaining the
  existing full VARIANT projection checks.

  This adapts the original diagnosis from #22167 to the current `FetchRows` implementation.

  Fixes #24064.

  Tests:
  - `make reldebug`
  - `build/reldebug/test/unittest test/sql/storage/types/variant/index_fetch.test`
  - `build/reldebug/test/unittest 'test/sql/storage/types/variant/*'`
  - `build/reldebug/test/unittest 'test/sql/function/variant/*'`
  - `build/reldebug/test/unittest 'test/sql/types/variant/*'`