### PR TITLE
add debug_ds extension to the benchmark runner

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -25,8 +25,14 @@ else()
   add_definitions(-DDUCKDB_ROOT_DIRECTORY="${PROJECT_SOURCE_DIR}")
 endif()
 
-add_executable(benchmark_runner benchmark_runner.cpp interpreted_benchmark.cpp
-                                ${BENCHMARK_OBJECT_FILES})
+add_executable(
+  benchmark_runner
+  benchmark_runner.cpp interpreted_benchmark.cpp
+  $<TARGET_OBJECTS:test_debug_fs_extension> ${BENCHMARK_OBJECT_FILES})
+
+target_include_directories(
+  benchmark_runner
+  PRIVATE ${PROJECT_SOURCE_DIR}/test/extension/debug_fs/include)
 
 target_link_libraries(benchmark_runner duckdb_static imdb test_helpers)
 link_extension_libraries(benchmark_runner "")

--- a/benchmark/interpreted_benchmark.cpp
+++ b/benchmark/interpreted_benchmark.cpp
@@ -12,6 +12,7 @@
 #include "duckdb/execution/operator/helper/physical_result_collector.hpp"
 #include "duckdb/common/arrow/physical_arrow_collector.hpp"
 #include "duckdb/parser/keyword_helper.hpp"
+#include "debug_fs_extension.hpp"
 
 #include <fstream>
 #include <sstream>
@@ -47,6 +48,9 @@ struct InterpretedBenchmarkState : public BenchmarkState {
 	explicit InterpretedBenchmarkState(string path, const string &version)
 	    : benchmark_config(GetBenchmarkConfig(version)),
 	      db(path.empty() ? nullptr : path.c_str(), benchmark_config.get()), con(db) {
+		//! Statically load the debug_fs extension so benchmarks can inject artificial I/O latency
+		//! (e.g. SET GLOBAL debug_fs_delay_mean_ms=...), mirroring how the unittest runner loads it.
+		db.LoadStaticExtension<DebugFsExtension>();
 		auto &instance = BenchmarkRunner::GetInstance();
 		auto res = con.Query("PRAGMA threads=" + to_string(instance.threads));
 		D_ASSERT(!res->HasError());


### PR DESCRIPTION
This will allow Lakehouse extensions to add a mean delay when requesting files over httpfs. This will make regressions much easier to catch since network delays will be much more noticeable.

```
SET debug_fs_delay_mean_ms=100;
```