### PR TITLE
Optimize `BLOB` sort key construction by using vectorize-friendly code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,8 @@ Test directives:
 
 Slow tests should use `.test_slow` extension instead of `.test`.
 
+Do not add `PRAGMA enable_verification` to tests - it should no longer be used in new tests.
+
 ## Code Formatting
 
 ```bash

--- a/src/function/scalar/create_sort_key.cpp
+++ b/src/function/scalar/create_sort_key.cpp
@@ -7,6 +7,8 @@
 #include "duckdb/common/vector/struct_vector.hpp"
 #include "duckdb/function/create_sort_key.hpp"
 
+#include "duckdb/common/bit_utils.hpp"
+#include "duckdb/common/bswap.hpp"
 #include "duckdb/common/enums/order_type.hpp"
 #include "duckdb/common/radix.hpp"
 #include "duckdb/function/scalar/generic_functions.hpp"
@@ -142,6 +144,60 @@ struct SortKeyVectorData {
 	data_t valid_byte;
 };
 
+//! Word-at-a-time (SWAR) primitives used to encode string/blob payloads
+struct SortKeyWord {
+	static constexpr idx_t SIZE = sizeof(uint64_t);
+	static constexpr uint64_t LSB = 0x0101010101010101ULL;
+	static constexpr uint64_t MSB = 0x8080808080808080ULL;
+	static constexpr uint64_t LOW7 = 0x7F7F7F7F7F7F7F7FULL;
+
+	//! Sets the high bit of every byte of `word` that is zero
+	static inline uint64_t ZeroBytes(uint64_t word) {
+		return ~(((word & LOW7) + LOW7) | word) & MSB;
+	}
+
+	//! Sets the high bit of every byte of `word` that has to be escaped (\x00 or \x01)
+	static inline uint64_t EscapedBytes(uint64_t word) {
+		// clearing the lowest bit maps both \x00 and \x01 - and nothing else - onto \x00
+		return ZeroBytes(word & ~LSB);
+	}
+
+	//! Adds one to every byte of `word`, wrapping around within each byte
+	static inline uint64_t IncrementBytes(uint64_t word) {
+		return ((word & LOW7) + LSB) ^ (word & MSB);
+	}
+
+	//! Sums up the individual bytes of `word` - only valid if the sum does not exceed 255
+	static inline idx_t SumBytes(uint64_t word) {
+		return static_cast<idx_t>((word * LSB) >> 56);
+	}
+
+	//! The number of bytes flagged in a mask returned by ZeroBytes/EscapedBytes
+	static inline idx_t CountFlagged(uint64_t mask) {
+		// every flagged byte has its high bit set - shift it down so each byte is a zero or a one
+		return SumBytes(mask >> 7);
+	}
+
+	//! The index of the first byte flagged in a mask returned by ZeroBytes/EscapedBytes
+	static inline idx_t FirstFlagged(uint64_t mask) {
+#if DUCKDB_IS_BIG_ENDIAN
+		return CountZeros<uint64_t>::Leading(mask) / 8;
+#else
+		return CountZeros<uint64_t>::Trailing(mask) / 8;
+#endif
+	}
+
+	template <bool FLIP_BYTES>
+	static inline data_t FlipByte(data_t byte) {
+		return FLIP_BYTES ? static_cast<data_t>(~byte) : byte;
+	}
+
+	template <bool FLIP_BYTES>
+	static inline uint64_t FlipWord(uint64_t word) {
+		return FLIP_BYTES ? ~word : word;
+	}
+};
+
 template <class T>
 struct SortKeyConstantOperator {
 	using TYPE = T;
@@ -150,32 +206,18 @@ struct SortKeyConstantOperator {
 		return sizeof(T);
 	}
 
-	static idx_t Encode(data_ptr_t result, TYPE input) {
-		Radix::EncodeData<T>(result, input);
-		return sizeof(T);
-	}
-
 	template <bool FLIP_BYTES>
 	static idx_t Encode(data_ptr_t result, TYPE input) {
 		Radix::EncodeData<T>(result, input);
 		if (FLIP_BYTES) {
-			for (idx_t b = 0; b < sizeof(T); b++) {
+			// flip word-at-a-time - the encoded size is a compile-time constant, so this fully unrolls
+			idx_t b = 0;
+			for (; b + SortKeyWord::SIZE <= sizeof(T); b += SortKeyWord::SIZE) {
+				Store<uint64_t>(~Load<uint64_t>(result + b), result + b);
+			}
+			for (; b < sizeof(T); b++) {
 				result[b] = static_cast<data_t>(~result[b]);
 			}
-		}
-		return sizeof(T);
-	}
-
-	static idx_t Decode(const_data_ptr_t input, Vector &result, TYPE &result_value, bool flip_bytes) {
-		if (flip_bytes) {
-			// descending order - so flip bytes
-			data_t flipped_bytes[sizeof(T)];
-			for (idx_t b = 0; b < sizeof(T); b++) {
-				flipped_bytes[b] = static_cast<data_t>(~input[b]);
-			}
-			result_value = Radix::DecodeData<T>(flipped_bytes);
-		} else {
-			result_value = Radix::DecodeData<T>(input);
 		}
 		return sizeof(T);
 	}
@@ -204,51 +246,22 @@ struct SortKeyVarcharOperator {
 		return input.GetSize() + 1;
 	}
 
-	static idx_t Encode(data_ptr_t result, TYPE input) {
-		auto input_data = const_data_ptr_cast(input.GetDataUnsafe());
-		auto input_size = input.GetSize();
-		for (idx_t r = 0; r < input_size; r++) {
-			result[r] = input_data[r] + 1;
-		}
-		result[input_size] = SortKeyVectorData::STRING_DELIMITER; // null-byte delimiter
-		return input_size + 1;
-	}
-
+	//! Strings are encoded by incrementing every byte, so that no byte collides with the delimiter.
+	//! That is a pure per-byte mapping, so we can apply it word-at-a-time.
 	template <bool FLIP_BYTES>
 	static idx_t Encode(data_ptr_t result, TYPE input) {
 		auto input_data = const_data_ptr_cast(input.GetDataUnsafe());
 		auto input_size = input.GetSize();
-		for (idx_t r = 0; r < input_size; r++) {
-			auto encoded_byte = static_cast<data_t>(input_data[r] + 1);
-			result[r] = FLIP_BYTES ? static_cast<data_t>(~encoded_byte) : encoded_byte;
+		idx_t pos = 0;
+		for (; pos + SortKeyWord::SIZE <= input_size; pos += SortKeyWord::SIZE) {
+			auto encoded = SortKeyWord::IncrementBytes(Load<uint64_t>(input_data + pos));
+			Store<uint64_t>(SortKeyWord::FlipWord<FLIP_BYTES>(encoded), result + pos);
 		}
-		auto delimiter = SortKeyVectorData::STRING_DELIMITER;
-		result[input_size] = FLIP_BYTES ? static_cast<data_t>(~delimiter) : delimiter;
+		for (; pos < input_size; pos++) {
+			result[pos] = SortKeyWord::FlipByte<FLIP_BYTES>(static_cast<data_t>(input_data[pos] + 1));
+		}
+		result[input_size] = SortKeyWord::FlipByte<FLIP_BYTES>(SortKeyVectorData::STRING_DELIMITER);
 		return input_size + 1;
-	}
-
-	static idx_t Decode(const_data_ptr_t input, Vector &result, TYPE &result_value, bool flip_bytes) {
-		// iterate until we encounter the string delimiter to figure out the string length
-		data_t string_delimiter = SortKeyVectorData::STRING_DELIMITER;
-		if (flip_bytes) {
-			string_delimiter = static_cast<data_t>(~string_delimiter);
-		}
-		idx_t pos;
-		for (pos = 0; input[pos] != string_delimiter; pos++) {
-		}
-		idx_t str_len = pos;
-		// now allocate the string data and fill it with the decoded data
-		result_value = StringVector::EmptyString(result, str_len);
-		auto str_data = data_ptr_cast(result_value.GetDataWriteable());
-		for (pos = 0; pos < str_len; pos++) {
-			if (flip_bytes) {
-				str_data[pos] = static_cast<data_t>((~input[pos]) - 1);
-			} else {
-				str_data[pos] = static_cast<data_t>(input[pos] - 1);
-			}
-		}
-		result_value.Finalize();
-		return pos + 1;
 	}
 
 	template <bool FLIP_BYTES>
@@ -281,86 +294,90 @@ struct SortKeyVarcharOperator {
 struct SortKeyBlobOperator {
 	using TYPE = string_t;
 
+	//! Number of words processed per iteration of the bulk loops
+	static constexpr idx_t BLOCK = 4;
+	static constexpr idx_t BLOCK_SIZE = BLOCK * SortKeyWord::SIZE;
+
 	static idx_t GetEncodeLength(TYPE input) {
-		auto input_data = data_ptr_t(input.GetDataUnsafe());
+		auto input_data = const_data_ptr_cast(input.GetDataUnsafe());
 		auto input_size = input.GetSize();
 		idx_t escaped_characters = 0;
-		for (idx_t r = 0; r < input_size; r++) {
-			if (input_data[r] <= 1) {
-				// we escape both \x00 and \x01
-				escaped_characters++;
+		idx_t pos = 0;
+		for (; pos + BLOCK_SIZE <= input_size; pos += BLOCK_SIZE) {
+			// the per-byte counts of an entire block fit in a single word, so we only sum them up once
+			uint64_t flagged = 0;
+			for (idx_t w = 0; w < BLOCK; w++) {
+				flagged += SortKeyWord::EscapedBytes(Load<uint64_t>(input_data + pos + w * SortKeyWord::SIZE)) >> 7;
 			}
+			escaped_characters += SortKeyWord::SumBytes(flagged);
 		}
-		return input.GetSize() + escaped_characters + 1;
+		for (; pos + SortKeyWord::SIZE <= input_size; pos += SortKeyWord::SIZE) {
+			escaped_characters +=
+			    SortKeyWord::CountFlagged(SortKeyWord::EscapedBytes(Load<uint64_t>(input_data + pos)));
+		}
+		for (; pos < input_size; pos++) {
+			// we escape both \x00 and \x01
+			escaped_characters += input_data[pos] <= SortKeyVectorData::BLOB_ESCAPE_CHARACTER ? 1 : 0;
+		}
+		return input_size + escaped_characters + 1;
 	}
 
-	static idx_t Encode(data_ptr_t result, TYPE input) {
-		auto input_data = data_ptr_t(input.GetDataUnsafe());
-		auto input_size = input.GetSize();
-		idx_t result_offset = 0;
-		for (idx_t r = 0; r < input_size; r++) {
-			if (input_data[r] <= 1) {
-				// we escape both \x00 and \x01 with \x01
-				result[result_offset++] = SortKeyVectorData::BLOB_ESCAPE_CHARACTER;
-				result[result_offset++] = input_data[r];
-			} else {
-				result[result_offset++] = input_data[r];
-			}
-		}
-		result[result_offset++] = SortKeyVectorData::STRING_DELIMITER; // null-byte delimiter
-		return result_offset;
-	}
-
+	//! Blobs are copied verbatim, except for \x00 and \x01 which are prefixed with an escape character.
+	//! Escapes are rare, so we copy word-at-a-time and only fall back to per-byte handling at an escape.
 	template <bool FLIP_BYTES>
 	static idx_t Encode(data_ptr_t result, TYPE input) {
-		auto input_data = data_ptr_t(input.GetDataUnsafe());
+		auto input_data = const_data_ptr_cast(input.GetDataUnsafe());
 		auto input_size = input.GetSize();
 		idx_t result_offset = 0;
-		for (idx_t r = 0; r < input_size; r++) {
-			if (input_data[r] <= 1) {
-				auto escape = SortKeyVectorData::BLOB_ESCAPE_CHARACTER;
-				result[result_offset++] = FLIP_BYTES ? static_cast<data_t>(~escape) : escape;
+		idx_t pos = 0;
+		while (pos + SortKeyWord::SIZE <= input_size) {
+			// bulk-copy BLOCK words at a time for as long as none of them contain a byte to escape
+			while (pos + BLOCK_SIZE <= input_size) {
+				uint64_t words[BLOCK];
+				uint64_t escapes = 0;
+				for (idx_t w = 0; w < BLOCK; w++) {
+					words[w] = Load<uint64_t>(input_data + pos + w * SortKeyWord::SIZE);
+					escapes |= SortKeyWord::EscapedBytes(words[w]);
+				}
+				if (escapes) {
+					break;
+				}
+				for (idx_t w = 0; w < BLOCK; w++) {
+					Store<uint64_t>(SortKeyWord::FlipWord<FLIP_BYTES>(words[w]),
+					                result + result_offset + w * SortKeyWord::SIZE);
+				}
+				pos += BLOCK_SIZE;
+				result_offset += BLOCK_SIZE;
 			}
-			result[result_offset++] = FLIP_BYTES ? static_cast<data_t>(~input_data[r]) : input_data[r];
+			if (pos + SortKeyWord::SIZE > input_size) {
+				break;
+			}
+			// we have at least one full word of input left, and hence at least SIZE + 1 bytes of result space,
+			// so we can always write out a full word - overshooting bytes are overwritten below
+			const auto word = Load<uint64_t>(input_data + pos);
+			Store<uint64_t>(SortKeyWord::FlipWord<FLIP_BYTES>(word), result + result_offset);
+			const auto escapes = SortKeyWord::EscapedBytes(word);
+			if (!escapes) {
+				pos += SortKeyWord::SIZE;
+				result_offset += SortKeyWord::SIZE;
+				continue;
+			}
+			// escape the first flagged byte - the remainder of the word is re-processed in the next iteration
+			const auto escape_pos = SortKeyWord::FirstFlagged(escapes);
+			result_offset += escape_pos;
+			result[result_offset++] = SortKeyWord::FlipByte<FLIP_BYTES>(SortKeyVectorData::BLOB_ESCAPE_CHARACTER);
+			result[result_offset++] = SortKeyWord::FlipByte<FLIP_BYTES>(input_data[pos + escape_pos]);
+			pos += escape_pos + 1;
 		}
-		auto delimiter = SortKeyVectorData::STRING_DELIMITER;
-		result[result_offset++] = FLIP_BYTES ? static_cast<data_t>(~delimiter) : delimiter;
+		for (; pos < input_size; pos++) {
+			if (input_data[pos] <= SortKeyVectorData::BLOB_ESCAPE_CHARACTER) {
+				// we escape both \x00 and \x01 with \x01
+				result[result_offset++] = SortKeyWord::FlipByte<FLIP_BYTES>(SortKeyVectorData::BLOB_ESCAPE_CHARACTER);
+			}
+			result[result_offset++] = SortKeyWord::FlipByte<FLIP_BYTES>(input_data[pos]);
+		}
+		result[result_offset++] = SortKeyWord::FlipByte<FLIP_BYTES>(SortKeyVectorData::STRING_DELIMITER);
 		return result_offset;
-	}
-
-	static idx_t Decode(const_data_ptr_t input, Vector &result, TYPE &result_value, bool flip_bytes) {
-		// scan until we find the delimiter, keeping in mind escapes
-		data_t string_delimiter = SortKeyVectorData::STRING_DELIMITER;
-		data_t escape_character = SortKeyVectorData::BLOB_ESCAPE_CHARACTER;
-		if (flip_bytes) {
-			string_delimiter = static_cast<data_t>(~string_delimiter);
-			escape_character = static_cast<data_t>(~escape_character);
-		}
-		idx_t blob_len = 0;
-		idx_t pos;
-		for (pos = 0; input[pos] != string_delimiter; pos++) {
-			blob_len++;
-			if (input[pos] == escape_character) {
-				// escape character - skip the next byte
-				pos++;
-			}
-		}
-		// now allocate the blob data and fill it with the decoded data
-		result_value = StringVector::EmptyString(result, blob_len);
-		auto str_data = data_ptr_cast(result_value.GetDataWriteable());
-		for (idx_t input_pos = 0, result_pos = 0; input_pos < pos; input_pos++) {
-			if (input[input_pos] == escape_character) {
-				// if we encounter an escape character - copy the NEXT byte
-				input_pos++;
-			}
-			if (flip_bytes) {
-				str_data[result_pos++] = static_cast<data_t>(~input[input_pos]);
-			} else {
-				str_data[result_pos++] = input[input_pos];
-			}
-		}
-		result_value.Finalize();
-		return pos + 1;
 	}
 
 	template <bool FLIP_BYTES>

--- a/test/sql/function/blob/create_sort_key_blob_escapes.test
+++ b/test/sql/function/blob/create_sort_key_blob_escapes.test
@@ -1,0 +1,104 @@
+# name: test/sql/function/blob/create_sort_key_blob_escapes.test
+# description: Test create_sort_key blob escaping around the word/block boundaries of the encoder
+# group: [blob]
+
+statement ok
+PRAGMA enable_verification
+
+# blobs are copied verbatim, except for \x00 and \x01 which are escaped with \x01
+query I
+SELECT hex(create_sort_key('\xAA\x00\xBB\x01\xCC'::BLOB, 'ASC NULLS LAST'))
+----
+01AA0100BB0101CC00
+
+query I
+SELECT hex(create_sort_key('\xAA\x00\xBB\x01\xCC'::BLOB, 'DESC NULLS LAST'))
+----
+0155FEFF44FEFE33FF
+
+# an escape at every position of a blob that spans multiple encoder words/blocks
+statement ok
+CREATE TABLE sweep AS
+SELECT len, pos, esc,
+       CASE WHEN pos >= len THEN repeat('\xAA'::BLOB, len)
+            ELSE repeat('\xAA'::BLOB, pos) || esc || repeat('\xAA'::BLOB, len - pos - 1)
+       END AS b
+FROM range(0, 81) l(len), range(0, 81) p(pos),
+     (VALUES ('\x00'::BLOB), ('\x01'::BLOB), ('\x02'::BLOB)) e(esc)
+WHERE pos <= len;
+
+# the key is the validity byte, the payload, one byte per escaped character and the delimiter
+query I
+SELECT count(*) FROM sweep
+WHERE octet_length(create_sort_key(b, 'ASC NULLS LAST')) <>
+      octet_length(b) + CASE WHEN pos < len AND esc <= '\x01'::BLOB THEN 1 ELSE 0 END + 2;
+----
+0
+
+# the sort key must order identically to the blobs themselves
+query I
+SELECT count(*) FROM (
+    SELECT row_number() OVER (ORDER BY b ASC, len, pos, esc) AS by_blob,
+           row_number() OVER (ORDER BY create_sort_key(b, 'ASC NULLS LAST') ASC, len, pos, esc) AS by_key
+    FROM sweep
+) WHERE by_blob <> by_key;
+----
+0
+
+query I
+SELECT count(*) FROM (
+    SELECT row_number() OVER (ORDER BY b DESC, len, pos, esc) AS by_blob,
+           row_number() OVER (ORDER BY create_sort_key(b, 'DESC NULLS LAST') ASC, len, pos, esc) AS by_key
+    FROM sweep
+) WHERE by_blob <> by_key;
+----
+0
+
+# two adjacent escapes at every position, so that an escape can straddle a word boundary
+statement ok
+CREATE TABLE sweep_pairs AS
+SELECT len, pos, repeat('\xAA'::BLOB, pos) || '\x01\x00'::BLOB || repeat('\xAA'::BLOB, len - pos - 2) AS b
+FROM range(2, 81) l(len), range(0, 81) p(pos)
+WHERE pos + 2 <= len;
+
+query I
+SELECT count(*) FROM sweep_pairs
+WHERE octet_length(create_sort_key(b, 'DESC NULLS FIRST')) <> octet_length(b) + 4;
+----
+0
+
+query I
+SELECT count(*) FROM (
+    SELECT row_number() OVER (ORDER BY b ASC, len, pos) AS by_blob,
+           row_number() OVER (ORDER BY create_sort_key(b, 'ASC NULLS FIRST') ASC, len, pos) AS by_key
+    FROM sweep_pairs
+) WHERE by_blob <> by_key;
+----
+0
+
+# blobs that consist purely of escaped characters
+query I
+SELECT count(*) FROM range(0, 81) l(len)
+WHERE octet_length(create_sort_key(repeat('\x00\x01'::BLOB, len), 'ASC NULLS LAST')) <> 4 * len + 2;
+----
+0
+
+# strings are encoded by incrementing every byte - verify the same boundaries for varchar
+statement ok
+CREATE TABLE strings AS
+SELECT len, repeat(chr(255), len) || repeat('a', len) AS s FROM range(0, 81) l(len);
+
+query I
+SELECT count(*) FROM strings
+WHERE octet_length(create_sort_key(s, 'ASC NULLS LAST')) <> octet_length(encode(s)) + 2;
+----
+0
+
+query I
+SELECT count(*) FROM (
+    SELECT row_number() OVER (ORDER BY s ASC, len) AS by_string,
+           row_number() OVER (ORDER BY create_sort_key(s, 'ASC NULLS LAST') ASC, len) AS by_key
+    FROM strings
+) WHERE by_string <> by_key;
+----
+0

--- a/test/sql/function/blob/create_sort_key_blob_escapes.test
+++ b/test/sql/function/blob/create_sort_key_blob_escapes.test
@@ -2,9 +2,6 @@
 # description: Test create_sort_key blob escaping around the word/block boundaries of the encoder
 # group: [blob]
 
-statement ok
-PRAGMA enable_verification
-
 # blobs are copied verbatim, except for \x00 and \x01 which are escaped with \x01
 query I
 SELECT hex(create_sort_key('\xAA\x00\xBB\x01\xCC'::BLOB, 'ASC NULLS LAST'))


### PR DESCRIPTION
When creating sort keys for blobs we encode them by escaping `\x00` and `\x01` with `\x01`, i.e. `\x00` is encoded as `\x01\x00` and `\x01` is encoded as `\x01\x01`. This is required to ensure that these bytes in blobs do not mess with the ordering "around" the blob - i.e. the `NULLS FIRST/NULLS LAST` encoding, multi-column sorts, etc. 

The current implementation of this encoding is naive and slow, as we do a per-byte check if this is required. This PR optimizes it to do detect the need for this encoding one `uint64_t` at a time allowing for faster encoding of sort keys for blob columns. This is a follow-up optimization to https://github.com/duckdb/duckdb/pull/24403 which switched to sorting on `BLOB` for collated columns, which found the need for speeding up blob sorts. 