### PR TITLE
Improve string literal casting

### DIFF
--- a/src/include/duckdb/parser/peg/inlined_grammar.gram
+++ b/src/include/duckdb/parser/peg/inlined_grammar.gram
@@ -171,7 +171,7 @@ RowType <- RowOrStruct ColIdTypeList?
 SetofType <- 'SETOF' Type
 UnionType <- 'UNION' ColIdTypeList
 ColIdTypeList <- Parens(List(ColIdType))
-MapType <- 'MAP' Parens(List(Type))
+MapType <- 'MAP' Parens(List(Type))?
 TupleType <- 'TUPLE' Parens(List(Type))
 ColIdType <- ColId Type
 ArrayBounds <- SquareBracketsArray / ArrayKeyword
@@ -1933,4 +1933,3 @@ OptFreeze <- 'FREEZE'
 OptVerbose <- 'VERBOSE'
 
 NameList <- Parens(List(ColId))
-

--- a/src/include/duckdb/parser/peg/inlined_grammar.gram
+++ b/src/include/duckdb/parser/peg/inlined_grammar.gram
@@ -1933,3 +1933,4 @@ OptFreeze <- 'FREEZE'
 OptVerbose <- 'VERBOSE'
 
 NameList <- Parens(List(ColId))
+

--- a/src/include/duckdb/parser/peg/inlined_grammar.gram
+++ b/src/include/duckdb/parser/peg/inlined_grammar.gram
@@ -1249,7 +1249,7 @@ SubqueryExists <- 'EXISTS'
 CaseExpression <- 'CASE' Expression? CaseWhenThen+ CaseElse? 'END'
 CaseWhenThen <- 'WHEN' Expression 'THEN' Expression
 CaseElse <- 'ELSE' Expression
-TypeLiteral <- ColId StringLiteral
+TypeLiteral <- Type StringLiteral
 IntervalLiteral <- 'INTERVAL' IntervalParameter Interval?
 IntervalParameter <- IntervalStringParameter / NumberLiteral / ParensExpression
 IntervalStringParameter <- StringLiteral

--- a/src/include/duckdb/parser/peg/inlined_grammar.hpp
+++ b/src/include/duckdb/parser/peg/inlined_grammar.hpp
@@ -1149,7 +1149,7 @@ const char INLINED_PEG_GRAMMAR[] = {
 	"CaseExpression <- 'CASE' Expression? CaseWhenThen+ CaseElse? 'END'\n"
 	"CaseWhenThen <- 'WHEN' Expression 'THEN' Expression\n"
 	"CaseElse <- 'ELSE' Expression\n"
-	"TypeLiteral <- ColId StringLiteral\n"
+	"TypeLiteral <- Type StringLiteral\n"
 	"IntervalLiteral <- 'INTERVAL' IntervalParameter Interval?\n"
 	"IntervalParameter <- IntervalStringParameter / NumberLiteral / ParensExpression\n"
 	"IntervalStringParameter <- StringLiteral\n"

--- a/src/include/duckdb/parser/peg/inlined_grammar.hpp
+++ b/src/include/duckdb/parser/peg/inlined_grammar.hpp
@@ -160,7 +160,7 @@ const char INLINED_PEG_GRAMMAR[] = {
 	"SetofType <- 'SETOF' Type\n"
 	"UnionType <- 'UNION' ColIdTypeList\n"
 	"ColIdTypeList <- Parens(List(ColIdType))\n"
-	"MapType <- 'MAP' Parens(List(Type))\n"
+	"MapType <- 'MAP' Parens(List(Type))?\n"
 	"TupleType <- 'TUPLE' Parens(List(Type))\n"
 	"ColIdType <- ColId Type\n"
 	"ArrayBounds <- SquareBracketsArray / ArrayKeyword\n"

--- a/src/include/duckdb/parser/peg/transformer/peg_transformer.hpp
+++ b/src/include/duckdb/parser/peg/transformer/peg_transformer.hpp
@@ -6503,7 +6503,7 @@ public:
 	                                                      unique_ptr<ParsedExpression> expression);
 	static unique_ptr<TransformResultValue> TransformTypeLiteralInternal(PEGTransformer &transformer,
 	                                                                     ParseResult &parse_result);
-	static unique_ptr<ParsedExpression> TransformTypeLiteral(PEGTransformer &transformer, const Identifier &col_id,
+	static unique_ptr<ParsedExpression> TransformTypeLiteral(PEGTransformer &transformer, const LogicalType &type,
 	                                                         const string &string_literal);
 	static unique_ptr<TransformResultValue> TransformIntervalLiteralInternal(PEGTransformer &transformer,
 	                                                                         ParseResult &parse_result);

--- a/src/include/duckdb/parser/peg/transformer/peg_transformer.hpp
+++ b/src/include/duckdb/parser/peg/transformer/peg_transformer.hpp
@@ -5260,7 +5260,8 @@ public:
 	                                                        const vector<pair<Identifier, LogicalType>> &col_id_type);
 	static unique_ptr<TransformResultValue> TransformMapTypeInternal(PEGTransformer &transformer,
 	                                                                 ParseResult &parse_result);
-	static unique_ptr<ParsedExpression> TransformMapType(PEGTransformer &transformer, const vector<LogicalType> &type);
+	static unique_ptr<ParsedExpression> TransformMapType(PEGTransformer &transformer,
+	                                                     const optional<vector<LogicalType>> &type);
 	static unique_ptr<TransformResultValue> TransformTupleTypeInternal(PEGTransformer &transformer,
 	                                                                   ParseResult &parse_result);
 	static unique_ptr<ParsedExpression> TransformTupleType(PEGTransformer &transformer,

--- a/src/parser/peg/grammar/statements/common.gram
+++ b/src/parser/peg/grammar/statements/common.gram
@@ -171,7 +171,7 @@ RowType <- RowOrStruct ColIdTypeList?
 SetofType <- 'SETOF' Type
 UnionType <- 'UNION' ColIdTypeList
 ColIdTypeList <- Parens(List(ColIdType))
-MapType <- 'MAP' Parens(List(Type))
+MapType <- 'MAP' Parens(List(Type))?
 TupleType <- 'TUPLE' Parens(List(Type))
 ColIdType <- ColId Type
 ArrayBounds <- SquareBracketsArray / ArrayKeyword

--- a/src/parser/peg/grammar/statements/expression.gram
+++ b/src/parser/peg/grammar/statements/expression.gram
@@ -62,7 +62,7 @@ SubqueryExists <- 'EXISTS'
 CaseExpression <- 'CASE' Expression? CaseWhenThen+ CaseElse? 'END'
 CaseWhenThen <- 'WHEN' Expression 'THEN' Expression
 CaseElse <- 'ELSE' Expression
-TypeLiteral <- ColId StringLiteral
+TypeLiteral <- Type StringLiteral
 IntervalLiteral <- 'INTERVAL' IntervalParameter Interval?
 IntervalParameter <- IntervalStringParameter / NumberLiteral / ParensExpression
 IntervalStringParameter <- StringLiteral

--- a/src/parser/peg/transformer/peg_transformer_factory.cpp
+++ b/src/parser/peg/transformer/peg_transformer_factory.cpp
@@ -367,7 +367,7 @@ bool PEGTransformerFactory::ConstructConstantFromExpression(const ParsedExpressi
 		}
 
 		auto cast_type = UnboundType::TryDefaultBind(cast.TargetType());
-		if (cast_type == LogicalType::INVALID || cast_type == LogicalTypeId::UNBOUND) {
+		if (cast_type.id() == LogicalTypeId::INVALID || cast_type.id() == LogicalTypeId::UNBOUND) {
 			return false;
 		}
 

--- a/src/parser/peg/transformer/transform_common.cpp
+++ b/src/parser/peg/transformer/transform_common.cpp
@@ -297,10 +297,12 @@ QualifiedName PEGTransformerFactory::TransformCatalogReservedSchemaTypeName(
 }
 
 unique_ptr<ParsedExpression> PEGTransformerFactory::TransformMapType(PEGTransformer &transformer,
-                                                                     const vector<LogicalType> &type) {
+                                                                     const optional<vector<LogicalType>> &type) {
 	vector<unique_ptr<ParsedExpression>> map_children;
-	for (auto &child_type : type) {
-		map_children.push_back(UnboundType::GetTypeExpression(child_type)->Copy());
+	if (type) {
+		for (auto &child_type : *type) {
+			map_children.push_back(UnboundType::GetTypeExpression(child_type)->Copy());
+		}
 	}
 	return make_uniq<TypeExpression>(Identifier("MAP"), std::move(map_children));
 }

--- a/src/parser/peg/transformer/transform_common.cpp
+++ b/src/parser/peg/transformer/transform_common.cpp
@@ -298,12 +298,10 @@ QualifiedName PEGTransformerFactory::TransformCatalogReservedSchemaTypeName(
 
 unique_ptr<ParsedExpression> PEGTransformerFactory::TransformMapType(PEGTransformer &transformer,
                                                                      const vector<LogicalType> &type) {
-	if (type.size() != 2) {
-		throw ParserException("Map type needs exactly two entries, key and value type.");
-	}
 	vector<unique_ptr<ParsedExpression>> map_children;
-	map_children.push_back(UnboundType::GetTypeExpression(type[0])->Copy());
-	map_children.push_back(UnboundType::GetTypeExpression(type[1])->Copy());
+	for (auto &child_type : type) {
+		map_children.push_back(UnboundType::GetTypeExpression(child_type)->Copy());
+	}
 	return make_uniq<TypeExpression>(Identifier("MAP"), std::move(map_children));
 }
 

--- a/src/parser/peg/transformer/transform_expression.cpp
+++ b/src/parser/peg/transformer/transform_expression.cpp
@@ -2679,17 +2679,10 @@ CaseCheck PEGTransformerFactory::TransformCaseWhenThen(PEGTransformer &transform
 }
 
 unique_ptr<ParsedExpression> PEGTransformerFactory::TransformTypeLiteral(PEGTransformer &transformer,
-                                                                         const Identifier &col_id,
+                                                                         const LogicalType &type,
                                                                          const string &string_literal) {
-	auto colid = col_id.GetIdentifierName();
-	auto type = LogicalType(TransformStringToLogicalTypeId(colid));
-	if (type.id() == LogicalTypeId::LIST || type.id() == LogicalTypeId::STRUCT) {
-		throw ParserException("Cannot convert to type %s, requires exactly one type modifier",
-		                      EnumUtil::ToString(type.id()));
-	}
 	auto child = make_uniq<ConstantExpression>(Value(string_literal));
-	auto unbound_type = LogicalType::UNBOUND(make_uniq<TypeExpression>(colid, vector<unique_ptr<ParsedExpression>>()));
-	auto result = make_uniq<CastExpression>(unbound_type, std::move(child));
+	auto result = make_uniq<CastExpression>(type, std::move(child));
 	return std::move(result);
 }
 

--- a/src/parser/peg/transformer/transform_generated.cpp
+++ b/src/parser/peg/transformer/transform_generated.cpp
@@ -1285,10 +1285,13 @@ unique_ptr<TransformResultValue> PEGTransformerFactory::TransformMapTypeInternal
                                                                                  ParseResult &parse_result) {
 	auto &list_pr = parse_result.Cast<ListParseResult>();
 	vector<LogicalType> type;
-	auto type_items = ExtractParseResultsFromList(ExtractResultFromParens(list_pr.GetChild(1)));
-	for (auto &type_item : type_items) {
-		auto type_value = transformer.Transform<LogicalType>(type_item.get());
-		type.push_back(type_value);
+	auto &type_opt = list_pr.GetChild(1).Cast<OptionalParseResult>();
+	if (type_opt.HasResult()) {
+		auto type_items = ExtractParseResultsFromList(ExtractResultFromParens(type_opt.GetResult()));
+		for (auto &type_item : type_items) {
+			auto type_value = transformer.Transform<LogicalType>(type_item.get());
+			type.push_back(type_value);
+		}
 	}
 	auto result = TransformMapType(transformer, type);
 	return make_uniq<TypedTransformResult<unique_ptr<ParsedExpression>>>(std::move(result));

--- a/src/parser/peg/transformer/transform_generated.cpp
+++ b/src/parser/peg/transformer/transform_generated.cpp
@@ -4955,9 +4955,9 @@ unique_ptr<TransformResultValue> PEGTransformerFactory::TransformCaseElseInterna
 unique_ptr<TransformResultValue> PEGTransformerFactory::TransformTypeLiteralInternal(PEGTransformer &transformer,
                                                                                      ParseResult &parse_result) {
 	auto &list_pr = parse_result.Cast<ListParseResult>();
-	auto col_id = transformer.Transform<Identifier>(list_pr.GetChild(0));
+	auto type = transformer.Transform<LogicalType>(list_pr.GetChild(0));
 	auto string_literal = transformer.Transform<string>(list_pr.GetChild(1));
-	auto result = TransformTypeLiteral(transformer, col_id, string_literal);
+	auto result = TransformTypeLiteral(transformer, type, string_literal);
 	return make_uniq<TypedTransformResult<unique_ptr<ParsedExpression>>>(std::move(result));
 }
 

--- a/src/parser/peg/transformer/transform_generated.cpp
+++ b/src/parser/peg/transformer/transform_generated.cpp
@@ -1284,14 +1284,16 @@ unique_ptr<TransformResultValue> PEGTransformerFactory::TransformColIdTypeListIn
 unique_ptr<TransformResultValue> PEGTransformerFactory::TransformMapTypeInternal(PEGTransformer &transformer,
                                                                                  ParseResult &parse_result) {
 	auto &list_pr = parse_result.Cast<ListParseResult>();
-	vector<LogicalType> type;
+	optional<vector<LogicalType>> type {};
 	auto &type_opt = list_pr.GetChild(1).Cast<OptionalParseResult>();
 	if (type_opt.HasResult()) {
-		auto type_items = ExtractParseResultsFromList(ExtractResultFromParens(type_opt.GetResult()));
-		for (auto &type_item : type_items) {
-			auto type_value = transformer.Transform<LogicalType>(type_item.get());
-			type.push_back(type_value);
+		vector<LogicalType> type_value;
+		auto type_value_items_1 = ExtractParseResultsFromList(ExtractResultFromParens(type_opt.GetResult()));
+		for (auto &type_value_item_1 : type_value_items_1) {
+			auto type_value_value_1 = transformer.Transform<LogicalType>(type_value_item_1.get());
+			type_value.push_back(type_value_value_1);
 		}
+		type = type_value;
 	}
 	auto result = TransformMapType(transformer, type);
 	return make_uniq<TypedTransformResult<unique_ptr<ParsedExpression>>>(std::move(result));

--- a/src/parser/peg/transformer/transform_generated_trampoline.cpp
+++ b/src/parser/peg/transformer/transform_generated_trampoline.cpp
@@ -13572,16 +13572,16 @@ void PEGTransformerFactory::InitializeTypeLiteralTrampoline(PEGTransformer &tran
                                                             TransformStackFrame &frame) {
 	auto &list_pr = frame.parse_result.Cast<ListParseResult>();
 	frame.ReserveChildSlots(1);
-	stack.PushFrame(list_pr.GetChild(0), COL_ID_OPS, TransformFrameResultTarget(frame.frame_index, 0));
+	stack.PushFrame(list_pr.GetChild(0), TYPE_OPS, TransformFrameResultTarget(frame.frame_index, 0));
 }
 
 unique_ptr<TransformResultValue> PEGTransformerFactory::FinalizeTypeLiteralTrampoline(PEGTransformer &transformer,
                                                                                       TransformStack &stack,
                                                                                       TransformStackFrame &frame) {
 	auto &list_pr = frame.parse_result.Cast<ListParseResult>();
-	auto col_id = frame.TakeResult<Identifier>(0);
+	auto type = frame.TakeResult<LogicalType>(0);
 	auto string_literal = TransformStringLiteral(transformer, list_pr.GetChild(1));
-	auto result = TransformTypeLiteral(transformer, col_id, string_literal);
+	auto result = TransformTypeLiteral(transformer, type, string_literal);
 	return make_uniq<TypedTransformResult<unique_ptr<ParsedExpression>>>(std::move(result));
 }
 

--- a/src/parser/peg/transformer/transform_generated_trampoline.cpp
+++ b/src/parser/peg/transformer/transform_generated_trampoline.cpp
@@ -6415,19 +6415,19 @@ unique_ptr<TransformResultValue> PEGTransformerFactory::FinalizeColIdTypeListTra
 void PEGTransformerFactory::InitializeMapTypeTrampoline(PEGTransformer &transformer, TransformStack &stack,
                                                         TransformStackFrame &frame) {
 	auto &list_pr = frame.parse_result.Cast<ListParseResult>();
-	auto &type_opt = list_pr.GetChild(1).Cast<OptionalParseResult>();
+	auto &list_opt = list_pr.GetChild(1).Cast<OptionalParseResult>();
 	idx_t dynamic_child_count = 0;
-	if (type_opt.HasResult()) {
-		auto list_items = ExtractParseResultsFromList(ExtractResultFromParens(type_opt.GetResult()));
+	if (list_opt.HasResult()) {
+		auto list_items = ExtractParseResultsFromList(ExtractResultFromParens(list_opt.GetResult()));
 		dynamic_child_count = list_items.size();
-		frame.ReserveChildSlots(dynamic_child_count);
+		frame.ReserveChildSlots(1 + dynamic_child_count - 1);
 		for (idx_t i = list_items.size(); i > 0; i--) {
 			auto child_idx = i - 1;
 			stack.PushFrame(list_items[child_idx].get(), TYPE_OPS,
 			                TransformFrameResultTarget(frame.frame_index, 0 + child_idx));
 		}
 	} else {
-		frame.ReserveChildSlots(0);
+		frame.ReserveChildSlots(1 - 1);
 	}
 }
 
@@ -6436,14 +6436,19 @@ unique_ptr<TransformResultValue> PEGTransformerFactory::FinalizeMapTypeTrampolin
                                                                                   TransformStackFrame &frame) {
 	auto &list_pr = frame.parse_result.Cast<ListParseResult>();
 	idx_t dynamic_child_count = 0;
-	auto &type_opt = list_pr.GetChild(1).Cast<OptionalParseResult>();
-	if (type_opt.HasResult()) {
-		auto dynamic_list_items = ExtractParseResultsFromList(ExtractResultFromParens(type_opt.GetResult()));
+	auto &dynamic_list_opt = list_pr.GetChild(1).Cast<OptionalParseResult>();
+	if (dynamic_list_opt.HasResult()) {
+		auto dynamic_list_items = ExtractParseResultsFromList(ExtractResultFromParens(dynamic_list_opt.GetResult()));
 		dynamic_child_count = dynamic_list_items.size();
 	}
-	vector<LogicalType> type;
-	for (idx_t i = 0; i < 0 + dynamic_child_count; i++) {
-		type.push_back(frame.TakeResult<LogicalType>(i));
+	optional<vector<LogicalType>> type {};
+	auto &type_opt = list_pr.GetChild(1).Cast<OptionalParseResult>();
+	if (type_opt.HasResult()) {
+		vector<LogicalType> type_value;
+		for (idx_t i = 0; i < 0 + dynamic_child_count; i++) {
+			type_value.push_back(frame.TakeResult<LogicalType>(i));
+		}
+		type = std::move(type_value);
 	}
 	auto result = TransformMapType(transformer, type);
 	return make_uniq<TypedTransformResult<unique_ptr<ParsedExpression>>>(std::move(result));

--- a/src/parser/peg/transformer/transform_generated_trampoline.cpp
+++ b/src/parser/peg/transformer/transform_generated_trampoline.cpp
@@ -6415,13 +6415,19 @@ unique_ptr<TransformResultValue> PEGTransformerFactory::FinalizeColIdTypeListTra
 void PEGTransformerFactory::InitializeMapTypeTrampoline(PEGTransformer &transformer, TransformStack &stack,
                                                         TransformStackFrame &frame) {
 	auto &list_pr = frame.parse_result.Cast<ListParseResult>();
-	auto list_items = ExtractParseResultsFromList(ExtractResultFromParens(list_pr.GetChild(1)));
-	auto dynamic_child_count = list_items.size();
-	frame.ReserveChildSlots(1 + dynamic_child_count - 1);
-	for (idx_t i = list_items.size(); i > 0; i--) {
-		auto child_idx = i - 1;
-		stack.PushFrame(list_items[child_idx].get(), TYPE_OPS,
-		                TransformFrameResultTarget(frame.frame_index, 0 + child_idx));
+	auto &type_opt = list_pr.GetChild(1).Cast<OptionalParseResult>();
+	idx_t dynamic_child_count = 0;
+	if (type_opt.HasResult()) {
+		auto list_items = ExtractParseResultsFromList(ExtractResultFromParens(type_opt.GetResult()));
+		dynamic_child_count = list_items.size();
+		frame.ReserveChildSlots(dynamic_child_count);
+		for (idx_t i = list_items.size(); i > 0; i--) {
+			auto child_idx = i - 1;
+			stack.PushFrame(list_items[child_idx].get(), TYPE_OPS,
+			                TransformFrameResultTarget(frame.frame_index, 0 + child_idx));
+		}
+	} else {
+		frame.ReserveChildSlots(0);
 	}
 }
 
@@ -6429,8 +6435,12 @@ unique_ptr<TransformResultValue> PEGTransformerFactory::FinalizeMapTypeTrampolin
                                                                                   TransformStack &stack,
                                                                                   TransformStackFrame &frame) {
 	auto &list_pr = frame.parse_result.Cast<ListParseResult>();
-	auto dynamic_list_items = ExtractParseResultsFromList(ExtractResultFromParens(list_pr.GetChild(1)));
-	auto dynamic_child_count = dynamic_list_items.size();
+	idx_t dynamic_child_count = 0;
+	auto &type_opt = list_pr.GetChild(1).Cast<OptionalParseResult>();
+	if (type_opt.HasResult()) {
+		auto dynamic_list_items = ExtractParseResultsFromList(ExtractResultFromParens(type_opt.GetResult()));
+		dynamic_child_count = dynamic_list_items.size();
+	}
 	vector<LogicalType> type;
 	for (idx_t i = 0; i < 0 + dynamic_child_count; i++) {
 		type.push_back(frame.TakeResult<LogicalType>(i));

--- a/src/parser/tableref/pivotref.cpp
+++ b/src/parser/tableref/pivotref.cpp
@@ -212,14 +212,9 @@ static bool TryFoldConstantForBackwardsCompatibility(const ParsedExpression &exp
 		}
 
 		// Try to default bind cast
-		LogicalType cast_type;
-		try {
-			cast_type = UnboundType::TryDefaultBind(cast.TargetType());
-		} catch (...) {
-			return false;
-		}
+		auto cast_type = UnboundType::TryDefaultBind(cast.TargetType());
 
-		if (cast_type == LogicalType::INVALID || cast_type == LogicalTypeId::UNBOUND) {
+		if (cast_type.id() == LogicalTypeId::INVALID || cast_type.id() == LogicalTypeId::UNBOUND) {
 			return false;
 		}
 

--- a/test/sql/copy/csv/auto/test_type_candidates.test
+++ b/test/sql/copy/csv/auto/test_type_candidates.test
@@ -29,7 +29,7 @@ SELECT * FROM read_csv_auto ('{TEST_DIR}/csv_file.csv', auto_type_candidates=['B
 statement error
 SELECT * FROM read_csv_auto ('{TEST_DIR}/csv_file.csv', auto_type_candidates=['MAP']);
 ----
-Value "MAP" can not be converted to a DuckDB Type.
+Binder Error: MAP type requires exactly two type modifiers: key type and value type
 
 query TTT
 SELECT typeof(column0), typeof(column1), typeof(column2) FROM read_csv_auto ('{TEST_DIR}/csv_file.csv', auto_type_candidates=['BIGINT', 'DOUBLE', 'VARCHAR']);

--- a/test/sql/types/type_literal.test
+++ b/test/sql/types/type_literal.test
@@ -12,6 +12,41 @@ SELECT INTEGER[] '[1,2,3]';
 ----
 [1, 2, 3]
 
+query I
+SELECT typeof(TIMESTAMP WITH TIME ZONE '2023-01-01 00:00:00+00');
+----
+TIMESTAMP WITH TIME ZONE
+
+query I
+SELECT typeof(TIME WITH TIME ZONE '12:00:00+00');
+----
+TIME WITH TIME ZONE
+
+query I
+SELECT typeof(CHARACTER VARYING 'text');
+----
+VARCHAR
+
+query I
+SELECT typeof(NATIONAL CHARACTER 'x');
+----
+VARCHAR
+
+query I
+SELECT typeof(NUMERIC(10, 2) '5.5');
+----
+DECIMAL(10,2)
+
+query I
+SELECT typeof(VARCHAR(5) '12345');
+----
+VARCHAR
+
+query I
+SELECT typeof(TIMESTAMP(3) '2024-01-01 00:00:00');
+----
+TIMESTAMP_MS
+
 statement ok
 CREATE TABLE Produce AS
   SELECT 'Kale' AS product, 51 AS sales, 'Q1' AS quarter, 2020 AS year;

--- a/test/sql/types/type_literal.test
+++ b/test/sql/types/type_literal.test
@@ -1,0 +1,19 @@
+# name: test/sql/types/type_literal.test
+# description: Test type literals with type modifiers
+# group: [types]
+
+query III
+SELECT typeof(DECIMAL(4,2) '1.23'), DECIMAL(4,2) '1.23', typeof(STRUCT(a INTEGER) '{"a": 42}');
+----
+DECIMAL(4,2)	1.23	STRUCT(a INTEGER)
+
+statement ok
+CREATE TABLE Produce AS
+  SELECT 'Kale' AS product, 51 AS sales, 'Q1' AS quarter, 2020 AS year;
+
+statement error
+SELECT * FROM Produce
+PIVOT(SUM(sales) FOR quarter IN ('Q1', 'Q2', Q3', $Q4'))
+ORDER BY ALL;
+----
+Type with name Q3 does not exist

--- a/test/sql/types/type_literal.test
+++ b/test/sql/types/type_literal.test
@@ -7,6 +7,11 @@ SELECT typeof(DECIMAL(4,2) '1.23'), DECIMAL(4,2) '1.23', typeof(STRUCT(a INTEGER
 ----
 DECIMAL(4,2)	1.23	STRUCT(a INTEGER)
 
+query I
+SELECT INTEGER[] '[1,2,3]';
+----
+[1, 2, 3]
+
 statement ok
 CREATE TABLE Produce AS
   SELECT 'Kale' AS product, 51 AS sales, 'Q1' AS quarter, 2020 AS year;


### PR DESCRIPTION
Part of: https://github.com/duckdblabs/duckdb-internal/issues/9093

Second or third stab at this type of casting, previous attempt here: https://github.com/duckdb/duckdb/pull/22567

This case was also caused by the incorrect transformer rule: https://github.com/duckdb/duckdb-fuzzer/issues/4490

Previously, the grammar rule checked for a `ColId` rather than `Type`, which was too narrow-sighted. For instance, casting a string literal to a list caused a parser issue: 
```sql
DuckDB v1.5.2 (Variegata)
Enter ".help" for usage hints.
memory D select integer[]'[1,2,3]';
Parser Error:
syntax error at or near "]"

LINE 1: select integer[]'[1,2,3]';
                       ^
```

This now works:
```sql
DuckDB v1.6.0-dev5576 (Development Version, a697a1c976)
Enter ".help" for usage hints.
memory D select integer[]'[1,2,3]'; 
┌──────────────────────────────┐
│ CAST('[1,2,3]' AS INTEGER[]) │
│           int32[]            │
├──────────────────────────────┤
│ [1, 2, 3]                    │
└──────────────────────────────┘
```

