### PR TITLE
Improve the performance of timezone function

### DIFF
--- a/extension/icu/icu-datefunc.cpp
+++ b/extension/icu/icu-datefunc.cpp
@@ -57,22 +57,67 @@ unique_ptr<FunctionData> ICUDateFunc::Bind(BindScalarFunctionInput &input) {
 	return make_uniq<BindData>(input.GetClientContext());
 }
 
-bool ICUDateFunc::TrySetTimeZone(Calendar *calendar, const string_t &tz_id) {
-	string tz_str = tz_id.GetString();
-	auto tz = ICUHelpers::TryGetTimeZone(tz_str);
-	if (!tz) {
+const ICUDateFunc::CalendarCacheState::CacheEntry &ICUDateFunc::CalendarCacheState::GetEntry(const string_t &tz_id) {
+	if (last && last->first.size() == tz_id.GetSize() &&
+	    memcmp(last->first.data(), tz_id.GetData(), tz_id.GetSize()) == 0) {
+		return last->second;
+	}
+	auto tz_str = tz_id.GetString();
+	auto entry = cache.find(tz_str);
+	if (entry == cache.end()) {
+		CacheEntry new_entry;
+		//	GetTimeZone may normalize the name - keep the original as the cache key
+		auto resolved = tz_str;
+		new_entry.tz = ICUHelpers::GetTimeZone(resolved, &new_entry.error);
+		if (new_entry.tz) {
+			new_entry.calendar = base_calendar->Copy();
+			new_entry.calendar->SetTimeZone(new_entry.tz->Copy());
+		}
+		entry = cache.emplace(std::move(tz_str), std::move(new_entry)).first;
+	}
+	last = &*entry;
+	return entry->second;
+}
+
+Calendar *ICUDateFunc::CalendarCacheState::GetCalendar(const string_t &tz_id) {
+	auto &entry = GetEntry(tz_id);
+	if (!entry.calendar) {
+		throw NotImplementedException(entry.error);
+	}
+	return entry.calendar.get();
+}
+
+void ICUDateFunc::CalendarCacheState::SetTimeZone(Calendar *calendar, const string_t &tz_id, string *error_message) {
+	auto &entry = GetEntry(tz_id);
+	if (!entry.tz) {
+		if (error_message) {
+			*error_message = entry.error;
+			return;
+		}
+		throw NotImplementedException(entry.error);
+	}
+	calendar->SetTimeZone(entry.tz->Copy());
+}
+
+bool ICUDateFunc::CalendarCacheState::TrySetTimeZone(Calendar *calendar, const string_t &tz_id) {
+	auto &entry = GetEntry(tz_id);
+	if (!entry.tz) {
 		return false;
 	}
-	calendar->SetTimeZone(std::move(tz));
+	calendar->SetTimeZone(entry.tz->Copy());
 	return true;
 }
 
-void ICUDateFunc::SetTimeZone(Calendar *calendar, const string_t &tz_id, string *error_message) {
-	string tz_str = tz_id.GetString();
-	auto tz = ICUHelpers::GetTimeZone(tz_str, error_message);
-	if (tz) {
-		calendar->SetTimeZone(std::move(tz));
-	}
+unique_ptr<FunctionLocalState>
+ICUDateFunc::InitCalendarCache(ExpressionState &state, const BoundFunctionExpression &expr, FunctionData *bind_data) {
+	auto &info = bind_data->Cast<BindData>();
+	return make_uniq<CalendarCacheState>(*info.calendar);
+}
+
+unique_ptr<FunctionLocalState> ICUDateFunc::InitCastCalendarCache(CastLocalStateParameters &parameters) {
+	auto &cast_data = parameters.cast_data->Cast<CastData>();
+	auto &info = cast_data.info->Cast<BindData>();
+	return make_uniq<CalendarCacheState>(*info.calendar);
 }
 
 timestamp_tz_t ICUDateFunc::GetTimeUnsafe(Calendar *calendar, uint64_t micros) {

--- a/extension/icu/icu-makedate.cpp
+++ b/extension/icu/icu-makedate.cpp
@@ -108,13 +108,11 @@ struct ICUMakeTimestampTZFunc : public ICUDateFunc {
 
 	template <typename T>
 	static void Execute(DataChunk &input, ExpressionState &state, Vector &result) {
-		auto &func_expr = state.expr.Cast<BoundFunctionExpression>();
-		auto &info = func_expr.BindInfo()->Cast<BindData>();
-		CalendarPtr calendar_ptr(info.calendar->Copy());
-		auto calendar = calendar_ptr.get();
+		auto &cache = ExecuteFunctionState::GetFunctionState(state)->Cast<CalendarCacheState>();
 
 		// Three cases: no TZ, constant TZ, variable TZ
 		if (input.ColumnCount() == 6) {
+			auto calendar = cache.GetBaseCalendar();
 			VariadicExecutor::Execute<timestamp_tz_t, T, T, T, T, T, double>(
 			    input, result, [&](T yyyy, T mm, T dd, T hr, T mn, double ss) {
 				    return Operation<T>(calendar, yyyy, mm, dd, hr, mn, ss);
@@ -126,7 +124,7 @@ struct ICUMakeTimestampTZFunc : public ICUDateFunc {
 				if (ConstantVector::IsNull(tz_vec)) {
 					throw InternalException("ICUMakeTimestamp called with constant NULL tz");
 				}
-				SetTimeZone(calendar, *ConstantVector::GetData<string_t>(tz_vec));
+				auto calendar = cache.GetCalendar(*ConstantVector::GetData<string_t>(tz_vec));
 				VariadicExecutor::Execute<timestamp_tz_t, T, T, T, T, T, double>(
 				    input, result, [&](T yyyy, T mm, T dd, T hr, T mn, double ss) {
 					    return Operation<T>(calendar, yyyy, mm, dd, hr, mn, ss);
@@ -134,8 +132,7 @@ struct ICUMakeTimestampTZFunc : public ICUDateFunc {
 			} else {
 				VariadicExecutor::Execute<timestamp_tz_t, T, T, T, T, T, double, string_t>(
 				    input, result, [&](T yyyy, T mm, T dd, T hr, T mn, double ss, string_t tz_id) {
-					    SetTimeZone(calendar, tz_id);
-					    return Operation<T>(calendar, yyyy, mm, dd, hr, mn, ss);
+					    return Operation<T>(cache.GetCalendar(tz_id), yyyy, mm, dd, hr, mn, ss);
 				    });
 			}
 		}
@@ -146,6 +143,7 @@ struct ICUMakeTimestampTZFunc : public ICUDateFunc {
 		ScalarFunction function({type, type, type, type, type, LogicalType::DOUBLE}, LogicalType::TIMESTAMP_TZ,
 		                        Execute<TA>, Bind);
 		function.SetFallible();
+		function.SetInitStateCallback(InitCalendarCache);
 		return function;
 	}
 
@@ -154,6 +152,7 @@ struct ICUMakeTimestampTZFunc : public ICUDateFunc {
 		ScalarFunction function({type, type, type, type, type, LogicalType::DOUBLE, LogicalType::VARCHAR},
 		                        LogicalType::TIMESTAMP_TZ, Execute<TA>, Bind);
 		function.SetFallible();
+		function.SetInitStateCallback(InitCalendarCache);
 		return function;
 	}
 

--- a/extension/icu/icu-strptime.cpp
+++ b/extension/icu/icu-strptime.cpp
@@ -130,8 +130,8 @@ struct ICUStrptime : public ICUDateFunc {
 		return nanos;
 	}
 
-	static inline void ParseOne(Calendar *calendar, string_t input, vector<StrpTimeFormat> &formats,
-	                            timestamp_tz_t &result) {
+	static inline void ParseOne(Calendar *calendar, CalendarCacheState &cache, string_t input,
+	                            vector<StrpTimeFormat> &formats, timestamp_tz_t &result) {
 		ParseResult parsed;
 		for (auto &format : formats) {
 			if (format.Parse(input, parsed)) {
@@ -141,7 +141,7 @@ struct ICUStrptime : public ICUDateFunc {
 				} else {
 					// Set TZ first, if any.
 					if (!parsed.tz.empty()) {
-						SetTimeZone(calendar, parsed.tz);
+						cache.SetTimeZone(calendar, parsed.tz);
 					}
 
 					result = GetTime(calendar, ToMicros(calendar, parsed, format));
@@ -153,8 +153,8 @@ struct ICUStrptime : public ICUDateFunc {
 		throw InvalidInputException(parsed.FormatError(input, formats[0].format_specifier));
 	}
 
-	static inline void ParseOne(Calendar *calendar, string_t input, vector<StrpTimeFormat> &formats,
-	                            timestamp_tz_ns_t &result) {
+	static inline void ParseOne(Calendar *calendar, CalendarCacheState &cache, string_t input,
+	                            vector<StrpTimeFormat> &formats, timestamp_tz_ns_t &result) {
 		ParseResult parsed;
 		for (auto &format : formats) {
 			if (format.Parse(input, parsed)) {
@@ -164,7 +164,7 @@ struct ICUStrptime : public ICUDateFunc {
 				} else {
 					// Set TZ first, if any.
 					if (!parsed.tz.empty()) {
-						SetTimeZone(calendar, parsed.tz);
+						cache.SetTimeZone(calendar, parsed.tz);
 					}
 					result = GetTimeNS(calendar, ToNanos(calendar, parsed, format));
 					return;
@@ -183,26 +183,27 @@ struct ICUStrptime : public ICUDateFunc {
 
 		auto &func_expr = state.expr.Cast<BoundFunctionExpression>();
 		auto &info = func_expr.BindInfo()->Cast<ICUStrptimeBindData>();
+		auto &cache = ExecuteFunctionState::GetFunctionState(state)->Cast<CalendarCacheState>();
 		CalendarPtr calendar_ptr(info.calendar->Copy());
 		auto calendar = calendar_ptr.get();
 
 		D_ASSERT(fmt_arg.GetVectorType() == VectorType::CONSTANT_VECTOR);
 		UnaryExecutor::Execute<string_t, T>(str_arg, result, [&](string_t input) {
 			T parsed;
-			ParseOne(calendar, input, info.formats, parsed);
+			ParseOne(calendar, cache, input, info.formats, parsed);
 			return parsed;
 		});
 	}
 
-	static inline bool TryParseOne(Calendar *calendar, string_t input, vector<StrpTimeFormat> &formats,
-	                               timestamp_tz_t &result) {
+	static inline bool TryParseOne(Calendar *calendar, CalendarCacheState &cache, string_t input,
+	                               vector<StrpTimeFormat> &formats, timestamp_tz_t &result) {
 		ParseResult parsed;
 		for (auto &format : formats) {
 			if (format.Parse(input, parsed)) {
 				if (parsed.is_special) {
 					result.value = parsed.ToTimestamp().value;
 					return true;
-				} else if (parsed.tz.empty() || TrySetTimeZone(calendar, parsed.tz)) {
+				} else if (parsed.tz.empty() || cache.TrySetTimeZone(calendar, parsed.tz)) {
 					if (TryGetTime(calendar, ToMicros(calendar, parsed, format), result)) {
 						return true;
 					}
@@ -213,15 +214,15 @@ struct ICUStrptime : public ICUDateFunc {
 		return false;
 	}
 
-	static inline bool TryParseOne(Calendar *calendar, string_t input, vector<StrpTimeFormat> &formats,
-	                               timestamp_tz_ns_t &result) {
+	static inline bool TryParseOne(Calendar *calendar, CalendarCacheState &cache, string_t input,
+	                               vector<StrpTimeFormat> &formats, timestamp_tz_ns_t &result) {
 		ParseResult parsed;
 		for (auto &format : formats) {
 			if (format.Parse(input, parsed)) {
 				if (parsed.is_special) {
 					result.value = parsed.ToTimestamp().value;
 					return true;
-				} else if (parsed.tz.empty() || TrySetTimeZone(calendar, parsed.tz)) {
+				} else if (parsed.tz.empty() || cache.TrySetTimeZone(calendar, parsed.tz)) {
 					if (TryGetTimeNS(calendar, ToNanos(calendar, parsed, format), result)) {
 						return true;
 					}
@@ -240,6 +241,7 @@ struct ICUStrptime : public ICUDateFunc {
 
 		auto &func_expr = state.expr.Cast<BoundFunctionExpression>();
 		auto &info = func_expr.BindInfo()->Cast<ICUStrptimeBindData>();
+		auto &cache = ExecuteFunctionState::GetFunctionState(state)->Cast<CalendarCacheState>();
 		CalendarPtr calendar_ptr(info.calendar->Copy());
 		auto calendar = calendar_ptr.get();
 
@@ -250,7 +252,7 @@ struct ICUStrptime : public ICUDateFunc {
 		} else {
 			UnaryExecutor::Execute<string_t, T>(str_arg, result, [&](string_t input) -> optional<T> {
 				T result;
-				if (TryParseOne(calendar, input, info.formats, result)) {
+				if (TryParseOne(calendar, cache, input, info.formats, result)) {
 					return result;
 				}
 				return nullopt;
@@ -290,6 +292,7 @@ struct ICUStrptime : public ICUDateFunc {
 					function = is_try ? TryParse<timestamp_tz_ns_t> : Parse<timestamp_tz_ns_t>;
 				}
 				bound_function.SetFunctionCallback(function);
+				bound_function.SetInitStateCallback(InitCalendarCache);
 				bound_function.SetReturnType(has_ns ? LogicalType::TIMESTAMP_TZ_NS : LogicalType::TIMESTAMP_TZ);
 				return make_uniq<ICUStrptimeBindData>(context, format);
 			}
@@ -317,6 +320,7 @@ struct ICUStrptime : public ICUDateFunc {
 					function = is_try ? TryParse<timestamp_tz_ns_t> : Parse<timestamp_tz_ns_t>;
 				}
 				bound_function.SetFunctionCallback(function);
+				bound_function.SetInitStateCallback(InitCalendarCache);
 				bound_function.SetReturnType(has_ns ? LogicalType::TIMESTAMP_TZ_NS : LogicalType::TIMESTAMP_TZ);
 				return make_uniq<ICUStrptimeBindData>(context, formats);
 			}
@@ -371,7 +375,8 @@ struct ICUStrptime : public ICUDateFunc {
 		TailPatch(name, loader, types);
 	}
 
-	static optional<timestamp_tz_t> VarcharToTimestampTZUS(CalendarPtr &cal, string_t input, CastParameters &parameters,
+	static optional<timestamp_tz_t> VarcharToTimestampTZUS(CalendarPtr &cal, CalendarCacheState &cache, string_t input,
+	                                                       CastParameters &parameters,
 	                                                       optional_ptr<int32_t> nanos = nullptr) {
 		timestamp_t us;
 		const auto str = input.GetData();
@@ -395,7 +400,7 @@ struct ICUStrptime : public ICUDateFunc {
 			// Change TZ if one was provided.
 			if (tz.GetSize()) {
 				string error_msg;
-				SetTimeZone(calendar, tz, &error_msg);
+				cache.SetTimeZone(calendar, tz, &error_msg);
 				if (!error_msg.empty()) {
 					HandleCastError::AssignError(error_msg, parameters);
 					return nullopt;
@@ -412,22 +417,25 @@ struct ICUStrptime : public ICUDateFunc {
 	static bool VarcharToTimestampTZ(Vector &source, Vector &result, idx_t count, CastParameters &parameters) {
 		auto &cast_data = parameters.cast_data->Cast<CastData>();
 		auto &info = cast_data.info->Cast<BindData>();
+		auto &cache = parameters.local_state->Cast<CalendarCacheState>();
 		CalendarPtr cal(info.calendar->Copy());
 
-		UnaryExecutor::Execute<string_t, timestamp_tz_t>(
-		    source, result, count, [&](string_t input) { return VarcharToTimestampTZUS(cal, input, parameters); });
+		UnaryExecutor::Execute<string_t, timestamp_tz_t>(source, result, count, [&](string_t input) {
+			return VarcharToTimestampTZUS(cal, cache, input, parameters);
+		});
 		return true;
 	}
 
 	static bool VarcharToTimestampTZNS(Vector &source, Vector &result, idx_t count, CastParameters &parameters) {
 		auto &cast_data = parameters.cast_data->Cast<CastData>();
 		auto &info = cast_data.info->Cast<BindData>();
+		auto &cache = parameters.local_state->Cast<CalendarCacheState>();
 		CalendarPtr cal(info.calendar->Copy());
 
 		UnaryExecutor::Execute<string_t, timestamp_tz_ns_t>(
 		    source, result, count, [&](string_t input) -> optional<timestamp_tz_ns_t> {
 			    int32_t nanos = 0;
-			    auto ts_us = VarcharToTimestampTZUS(cal, input, parameters, &nanos);
+			    auto ts_us = VarcharToTimestampTZUS(cal, cache, input, parameters, &nanos);
 			    if (!ts_us) {
 				    return nullopt;
 			    }
@@ -488,9 +496,9 @@ struct ICUStrptime : public ICUDateFunc {
 
 		switch (target.id()) {
 		case LogicalTypeId::TIMESTAMP_TZ:
-			return BoundCastInfo(VarcharToTimestampTZ, std::move(cast_data));
+			return BoundCastInfo(VarcharToTimestampTZ, std::move(cast_data), InitCastCalendarCache);
 		case LogicalTypeId::TIMESTAMP_TZ_NS:
-			return BoundCastInfo(VarcharToTimestampTZNS, std::move(cast_data));
+			return BoundCastInfo(VarcharToTimestampTZNS, std::move(cast_data), InitCastCalendarCache);
 		case LogicalTypeId::TIME_TZ:
 			return BoundCastInfo(VarcharToTimeTZ, std::move(cast_data));
 		default:

--- a/extension/icu/icu-timebucket.cpp
+++ b/extension/icu/icu-timebucket.cpp
@@ -338,9 +338,9 @@ struct ICUTimeBucket : public ICUDateFunc {
 
 	struct TimeZoneTernaryOperator {
 		static inline timestamp_tz_t Operation(interval_t bucket_width, timestamp_tz_t ts, string_t tz,
-		                                       TZCalendar &calendar_p) {
+		                                       TZCalendar &calendar_p, CalendarCacheState &cache) {
 			auto calendar = calendar_p.GetCalendar();
-			SetTimeZone(calendar, tz);
+			cache.SetTimeZone(calendar, tz);
 
 			timestamp_tz_t origin;
 			BucketWidthType bucket_width_type = ClassifyBucketWidthErrorThrow(bucket_width);
@@ -365,8 +365,9 @@ struct ICUTimeBucket : public ICUDateFunc {
 
 		auto &func_expr = state.expr.Cast<BoundFunctionExpression>();
 		auto &info = func_expr.BindInfo()->Cast<BindData>();
+		auto &cache = ExecuteFunctionState::GetFunctionState(state)->Cast<CalendarCacheState>();
 		TZCalendar calendar(*info.calendar, info.cal_setting);
-		SetTimeZone(calendar.GetCalendar(), string_t("UTC"));
+		cache.SetTimeZone(calendar.GetCalendar(), string_t("UTC"));
 
 		const auto &bucket_width_arg = args.data[0];
 		const auto &ts_arg = args.data[1];
@@ -418,8 +419,9 @@ struct ICUTimeBucket : public ICUDateFunc {
 
 		auto &func_expr = state.expr.Cast<BoundFunctionExpression>();
 		auto &info = func_expr.BindInfo()->Cast<BindData>();
+		auto &cache = ExecuteFunctionState::GetFunctionState(state)->Cast<CalendarCacheState>();
 		TZCalendar calendar(*info.calendar, info.cal_setting);
-		SetTimeZone(calendar.GetCalendar(), string_t("UTC"));
+		cache.SetTimeZone(calendar.GetCalendar(), string_t("UTC"));
 
 		const auto &bucket_width_arg = args.data[0];
 		const auto &ts_arg = args.data[1];
@@ -480,8 +482,9 @@ struct ICUTimeBucket : public ICUDateFunc {
 
 		auto &func_expr = state.expr.Cast<BoundFunctionExpression>();
 		auto &info = func_expr.BindInfo()->Cast<BindData>();
+		auto &cache = ExecuteFunctionState::GetFunctionState(state)->Cast<CalendarCacheState>();
 		TZCalendar calendar(*info.calendar, info.cal_setting);
-		SetTimeZone(calendar.GetCalendar(), string_t("UTC"));
+		cache.SetTimeZone(calendar.GetCalendar(), string_t("UTC"));
 
 		const auto &bucket_width_arg = args.data[0];
 		const auto &ts_arg = args.data[1];
@@ -546,6 +549,7 @@ struct ICUTimeBucket : public ICUDateFunc {
 
 		auto &func_expr = state.expr.Cast<BoundFunctionExpression>();
 		auto &info = func_expr.BindInfo()->Cast<BindData>();
+		auto &cache = ExecuteFunctionState::GetFunctionState(state)->Cast<CalendarCacheState>();
 		TZCalendar calendar(*info.calendar, info.cal_setting);
 
 		const auto &bucket_width_arg = args.data[0];
@@ -558,7 +562,7 @@ struct ICUTimeBucket : public ICUDateFunc {
 				throw InternalException("ICUTimeBucketTimeZone called with constant NULL bucket width or tz");
 			}
 			interval_t bucket_width = *ConstantVector::GetData<interval_t>(bucket_width_arg);
-			SetTimeZone(calendar.GetCalendar(), *ConstantVector::GetData<string_t>(tz_arg));
+			cache.SetTimeZone(calendar.GetCalendar(), *ConstantVector::GetData<string_t>(tz_arg));
 			timestamp_tz_t origin;
 			BucketWidthType bucket_width_type = ClassifyBucketWidth(bucket_width);
 			switch (bucket_width_type) {
@@ -593,7 +597,7 @@ struct ICUTimeBucket : public ICUDateFunc {
 				TernaryExecutor::Execute<interval_t, timestamp_tz_t, string_t, timestamp_tz_t>(
 				    bucket_width_arg, ts_arg, tz_arg, result,
 				    [&](interval_t bucket_width, timestamp_tz_t ts, string_t tz) {
-					    return TimeZoneTernaryOperator::Operation(bucket_width, ts, tz, calendar);
+					    return TimeZoneTernaryOperator::Operation(bucket_width, ts, tz, calendar, cache);
 				    });
 				break;
 			default:
@@ -602,7 +606,7 @@ struct ICUTimeBucket : public ICUDateFunc {
 		} else {
 			TernaryExecutor::Execute<interval_t, timestamp_tz_t, string_t, timestamp_tz_t>(
 			    bucket_width_arg, ts_arg, tz_arg, result, [&](interval_t bucket_width, timestamp_tz_t ts, string_t tz) {
-				    return TimeZoneTernaryOperator::Operation(bucket_width, ts, tz, calendar);
+				    return TimeZoneTernaryOperator::Operation(bucket_width, ts, tz, calendar, cache);
 			    });
 		}
 	}
@@ -619,6 +623,7 @@ struct ICUTimeBucket : public ICUDateFunc {
 		                               LogicalType::TIMESTAMP_TZ, ICUTimeBucketTimeZoneFunction, Bind));
 		for (auto &func : set.functions) {
 			func.SetFallible();
+			func.SetInitStateCallback(InitCalendarCache);
 			func.SetArgProperties(1, ArgProperties().NonDecreasing());
 		}
 		loader.RegisterFunction(set);

--- a/extension/icu/icu-timezone.cpp
+++ b/extension/icu/icu-timezone.cpp
@@ -499,10 +499,7 @@ void ICUToTimeTZ::AddCasts(ExtensionLoader &loader) {
 struct ICUTimeZoneFunc : public ICUDateFunc {
 	template <typename OP, typename SRC, typename DST>
 	static void Execute(DataChunk &input, ExpressionState &state, Vector &result) {
-		auto &func_expr = state.expr.Cast<BoundFunctionExpression>();
-		auto &info = func_expr.BindInfo()->Cast<BindData>();
-		CalendarPtr calendar_ptr(info.calendar->Copy());
-		auto calendar = calendar_ptr.get();
+		auto &cache = ExecuteFunctionState::GetFunctionState(state)->Cast<CalendarCacheState>();
 
 		// Two cases: constant TZ, variable TZ
 		D_ASSERT(input.ColumnCount() == 2);
@@ -512,13 +509,12 @@ struct ICUTimeZoneFunc : public ICUDateFunc {
 			if (ConstantVector::IsNull(tz_vec)) {
 				throw InternalException("ICUTimeZone called with constant NULL tz");
 			}
-			SetTimeZone(calendar, *ConstantVector::GetData<string_t>(tz_vec));
+			auto calendar = cache.GetCalendar(*ConstantVector::GetData<string_t>(tz_vec));
 			UnaryExecutor::Execute<SRC, DST>(ts_vec, result, [&](SRC ts) { return OP::Operation(calendar, ts); });
 		} else {
 			BinaryExecutor::Execute<string_t, SRC, DST>(tz_vec, ts_vec, result, [&](string_t tz_id, SRC ts) {
 				if (ts.IsFinite()) {
-					SetTimeZone(calendar, tz_id);
-					return OP::Operation(calendar, ts);
+					return OP::Operation(cache.GetCalendar(tz_id), ts);
 				} else {
 					return Cast::Operation<SRC, DST>(ts);
 				}
@@ -536,6 +532,7 @@ struct ICUTimeZoneFunc : public ICUDateFunc {
 		                               Execute<ICUToTimeTZ, dtime_tz_t, dtime_tz_t>, Bind));
 		for (auto &func : set.functions) {
 			func.SetFallible();
+			func.SetInitStateCallback(InitCalendarCache);
 		}
 		loader.RegisterFunction(set);
 	}

--- a/extension/icu/icu_extension.cpp
+++ b/extension/icu/icu_extension.cpp
@@ -337,11 +337,6 @@ unique_ptr<TimeZone> GetTimeZoneInternal(string &tz_str, vector<string> &candida
 	return nullptr;
 }
 
-unique_ptr<TimeZone> ICUHelpers::TryGetTimeZone(string &tz_str) {
-	vector<string> candidates;
-	return GetTimeZoneInternal(tz_str, candidates);
-}
-
 unique_ptr<TimeZone> ICUHelpers::GetTimeZone(string &tz_str, string *error_message) {
 	vector<string> candidates;
 	auto tz = GetTimeZoneInternal(tz_str, candidates);

--- a/extension/icu/include/icu-datefunc.hpp
+++ b/extension/icu/include/icu-datefunc.hpp
@@ -9,6 +9,8 @@
 #pragma once
 
 #include "duckdb/common/enums/date_part_specifier.hpp"
+#include "duckdb/common/unordered_map.hpp"
+#include "duckdb/execution/expression_executor_state.hpp"
 #include "duckdb/function/cast/default_casts.hpp"
 #include "duckdb/function/function.hpp"
 #include "tz_calendar.hpp"
@@ -42,13 +44,51 @@ struct ICUDateFunc {
 		duckdb::unique_ptr<FunctionData> info;
 	};
 
+	//! Per-thread cache of resolved time zones. Resolving a time zone name looks the name up and
+	//! then builds a zone and a calendar for it, so functions with per-row time zone arguments
+	//! must resolve each distinct zone only once per thread.
+	struct CalendarCacheState : public FunctionLocalState {
+		struct CacheEntry {
+			//! The resolved time zone (nullptr if the name is invalid)
+			duckdb::unique_ptr<TimeZone> tz;
+			//! Copy of the base calendar with the time zone applied (nullptr if the name is invalid)
+			CalendarPtr calendar;
+			//! The resolution error for invalid time zone names
+			string error;
+		};
+
+		explicit CalendarCacheState(Calendar &base) : base_calendar(base.Copy()) {
+		}
+
+		//! Returns a calendar for the time zone. Throws for unknown zones.
+		Calendar *GetCalendar(const string_t &tz_id);
+		//! Sets the time zone for the calendar.
+		//! For unknown zones, fills error_message if provided and throws otherwise.
+		void SetTimeZone(Calendar *calendar, const string_t &tz_id, string *error_message = nullptr);
+		//! Sets the time zone for the calendar and returns false if it is not valid.
+		bool TrySetTimeZone(Calendar *calendar, const string_t &tz_id);
+
+		Calendar *GetBaseCalendar() {
+			return base_calendar.get();
+		}
+
+	private:
+		const CacheEntry &GetEntry(const string_t &tz_id);
+
+		CalendarPtr base_calendar;
+		unordered_map<string, CacheEntry> cache;
+		//! Exploit locality for timestamp rows
+		const std::pair<const string, CacheEntry> *last = nullptr;
+	};
+
 	//! Binds a default calendar object for use by the function
 	static duckdb::unique_ptr<FunctionData> Bind(BindScalarFunctionInput &input);
+	//! Initializes a CalendarCacheState from the function's BindData
+	static duckdb::unique_ptr<FunctionLocalState>
+	InitCalendarCache(ExpressionState &state, const BoundFunctionExpression &expr, FunctionData *bind_data);
+	//! Initializes a CalendarCacheState from a cast's CastData
+	static duckdb::unique_ptr<FunctionLocalState> InitCastCalendarCache(CastLocalStateParameters &parameters);
 
-	//! Tries to set the time zone for the calendar and returns false if it is not valid.
-	static bool TrySetTimeZone(Calendar *calendar, const string_t &tz_id);
-	//! Sets the time zone for the calendar. Throws if it is not valid
-	static void SetTimeZone(Calendar *calendar, const string_t &tz_id, string *error_message = nullptr);
 	//! Gets the timestamp from the calendar, throwing if it is not in range.
 	static bool TryGetTime(Calendar *calendar, uint64_t micros, timestamp_tz_t &result);
 	//! Gets the timestamp from the calendar, throwing if it is not in range.

--- a/extension/icu/include/icu-helpers.hpp
+++ b/extension/icu/include/icu-helpers.hpp
@@ -14,8 +14,6 @@
 namespace duckdb {
 
 struct ICUHelpers {
-	//! Tries to get a time zone - returns nullptr if the timezone is not found
-	static unique_ptr<TimeZone> TryGetTimeZone(string &tz_str);
 	//! Gets a time zone - throws an error if the timezone is not found
 	static unique_ptr<TimeZone> GetTimeZone(string &tz_str, string *error_message = nullptr);
 


### PR DESCRIPTION
The ICU date functions that take a per-row time zone argument resolved the zone again for every row: a `string_t::GetString()` allocation, a lookup over the zone table, and then a fresh `TimeZone` plus a calendar to apply it to. This PR adds a thread-local cache keyed on the time zone name, so each distinct zone is resolved once per thread, plus a one-entry fast path for the common case of consecutive rows sharing a zone.

The map is currently unbounded and different casings of the same timezone could in theory cause it to grow pretty big, but I feel like it is very unlikely that people have so many different cases of the same timezone in the same table.

<details>
<summary>Some benchmarks</summary>

`make reldebug`, 14 cores, best of 3 runs of `SELECT bit_xor(hash(timezone(park_timezone, ts))) FROM bookings`.

2M rows, 5 distinct zones interleaved:

| threads | before | after | speedup |
|--------:|-------:|------:|--------:|
| 1  | 0.419s | 0.378s | 1.1x |
| 2  | 0.188s | 0.107s | 1.8x |
| 4  | 0.106s | 0.077s | 1.4x |
| 8  | 0.064s | 0.042s | 1.5x |
| 16 | 0.057s | 0.034s | 1.7x |

10M rows cycling through all 638 zones (zone changes every row):

| threads | before | after | speedup |
|--------:|-------:|------:|--------:|
| 1  | 2.508s | 1.464s | 1.7x |
| 2  | 1.257s | 0.710s | 1.8x |
| 8  | 0.373s | 0.205s | 1.8x |
| 16 | 0.297s | 0.122s | 2.4x |

100k rows, 638 zones:

| threads | before | after | speedup |
|--------:|-------:|------:|--------:|
| 1 | 0.019s | 0.010s | 1.9x |

</details>
