### PR TITLE
fix(core): register current_timestamp as an alias so it appears in duckdb_functions()

### DIFF
--- a/extension/core_functions/function_list.cpp
+++ b/extension/core_functions/function_list.cpp
@@ -145,6 +145,7 @@ static const StaticFunctionDefinition core_functions[] = {
 	DUCKDB_SCALAR_FUNCTION(CurrentSchemaFun),
 	DUCKDB_SCALAR_FUNCTION(CurrentSchemasFun),
 	DUCKDB_SCALAR_FUNCTION(CurrentSettingFun),
+	DUCKDB_SCALAR_FUNCTION_ALIAS(CurrentTimestampFun),
 	DUCKDB_SCALAR_FUNCTION(DamerauLevenshteinFun),
 	DUCKDB_SCALAR_FUNCTION_SET(DateDiffFun),
 	DUCKDB_SCALAR_FUNCTION_SET(DatePartFun),

--- a/extension/core_functions/include/core_functions/scalar/date_functions.hpp
+++ b/extension/core_functions/include/core_functions/scalar/date_functions.hpp
@@ -231,6 +231,12 @@ struct TransactionTimestampFun {
 	static constexpr const char *Name = "transaction_timestamp";
 };
 
+struct CurrentTimestampFun {
+	using ALIAS = GetCurrentTimestampFun;
+
+	static constexpr const char *Name = "current_timestamp";
+};
+
 struct HoursFun {
 	static constexpr const char *Name = "hour";
 	static constexpr const char *Parameters = "ts";

--- a/extension/core_functions/scalar/date/functions.json
+++ b/extension/core_functions/scalar/date/functions.json
@@ -131,7 +131,7 @@
         "description": "Returns the current timestamp",
         "example": "get_current_timestamp()",
         "type": "scalar_function",
-        "aliases": ["now", "transaction_timestamp"]
+        "aliases": ["now", "transaction_timestamp", "current_timestamp"]
     },
     {
         "struct": "HoursFun",

--- a/src/include/duckdb/main/extension_entries.hpp
+++ b/src/include/duckdb/main/extension_entries.hpp
@@ -299,6 +299,7 @@ static constexpr ExtensionFunctionEntry EXTENSION_FUNCTIONS[] = {
     {"current_schema", "core_functions", CatalogType::SCALAR_FUNCTION_ENTRY},
     {"current_schemas", "core_functions", CatalogType::SCALAR_FUNCTION_ENTRY},
     {"current_setting", "core_functions", CatalogType::SCALAR_FUNCTION_ENTRY},
+    {"current_timestamp", "core_functions", CatalogType::SCALAR_FUNCTION_ENTRY},
     {"damerau_levenshtein", "core_functions", CatalogType::SCALAR_FUNCTION_ENTRY},
     {"dbgen", "tpch", CatalogType::TABLE_FUNCTION_ENTRY},
     {"decode", "core_functions", CatalogType::SCALAR_FUNCTION_ENTRY},

--- a/test/sql/function/timestamp/current_time.test
+++ b/test/sql/function/timestamp/current_time.test
@@ -39,7 +39,7 @@ DATE
 
 endloop
 
-foreach func now get_current_timestamp transaction_timestamp
+foreach func now get_current_timestamp transaction_timestamp current_timestamp
 
 query I
 SELECT typeof({func}());

--- a/test/sql/function/timestamp/current_timestamp.test
+++ b/test/sql/function/timestamp/current_timestamp.test
@@ -23,7 +23,7 @@ SELECT SUFFIX(CURRENT_TIMESTAMP::VARCHAR, '-06');
 ----
 True
 
-foreach func now get_current_timestamp transaction_timestamp
+foreach func now get_current_timestamp transaction_timestamp current_timestamp
 
 query I
 SELECT SUFFIX({func}()::VARCHAR, '-06');
@@ -31,6 +31,13 @@ SELECT SUFFIX({func}()::VARCHAR, '-06');
 True
 
 endloop
+
+# https://github.com/duckdb/duckdb/issues/24446
+# current_timestamp should be listed in duckdb_functions(), like current_date is
+query I
+SELECT count(*) FROM duckdb_functions() WHERE function_name = 'current_timestamp';
+----
+1
 
 # Ago is a macro based on current_timestamp
 


### PR DESCRIPTION
Fixes #24446

## Problem

`current_date` shows up in `duckdb_functions()`, but `current_timestamp` doesn't, even though both are SQL-standard "current *" value keywords that behave the same way from a user's perspective.

`duckdb_functions()` reports catalog entries under their own registered name. `current_date` happens to work because the ICU extension literally registers a scalar function named `"current_date"` (`extension/icu/icu-current.cpp`). `CURRENT_TIMESTAMP`, on the other hand, is rewritten at bind time (`GetSQLValueFunctionName` in `src/planner/column_qualifier.cpp`) to a call to a differently-named function, `get_current_timestamp` — which is aliased as `now` / `transaction_timestamp`, but not `current_timestamp` itself. So the catalog never has an entry literally named `current_timestamp`, and it's invisible to `duckdb_functions()`.

## Fix

Add `current_timestamp` as an additional alias of `get_current_timestamp` in `extension/core_functions/scalar/date/functions.json`, mirroring the existing `now` / `transaction_timestamp` aliases. The generated files (`function_list.cpp`, `date_functions.hpp`) were produced by actually running `scripts/generate_functions.py`, and `extension_entries.hpp` was updated to match the existing entry pattern for the other aliases of this function.

This also makes `current_timestamp()` callable directly as a regular function (like `now()`), in addition to fixing the `duckdb_functions()` listing.

Extended the existing `current_time.test` / `current_timestamp.test` sqllogictests to include `current_timestamp` in the existing alias-coverage loops, and added a direct regression check against `duckdb_functions()`.

## Note on verification

I wasn't able to do a full local build (`cmake` isn't available in this environment) or run `build/reldebug/test/unittest`, so I couldn't execute the new/updated tests myself. The generated-file diffs were produced by the real generator script and match the existing pattern for `now`/`transaction_timestamp` exactly, but please have CI/a maintainer double check.

## Release note

`current_timestamp` (and thus `current_timestamp()`) is now listed in `duckdb_functions()`, consistent with `current_date`.

---

_Disclaimer: this change was drafted with the assistance of an AI coding agent (Claude), reviewed by me before submission; I was not able to fully build/test it locally in this environment, see note above._
