### PR TITLE
Use a bitmask instead of modulo when decoding bitpacked hugeints

### DIFF
--- a/src/storage/compression/bitpacking_hugeint.cpp
+++ b/src/storage/compression/bitpacking_hugeint.cpp
@@ -8,7 +8,7 @@ namespace duckdb {
 
 static void UnpackSingle(const uint32_t *__restrict &in, uhugeint_t *__restrict out, uint16_t delta, uint16_t shr) {
 	if (delta + shr < 32) {
-		*out = ((static_cast<uhugeint_t>(in[0])) >> shr) % (uhugeint_t(1) << delta);
+		*out = ((static_cast<uhugeint_t>(in[0])) >> shr) & ((uhugeint_t(1) << delta) - 1);
 	}
 
 	else if (delta + shr >= 32 && delta + shr < 64) {


### PR DESCRIPTION
`UnpackSingle`'s narrow branch computed `x % (uhugeint_t(1) << delta)`. `uhugeint_t::operator%` goes through `Uhugeint::DivMod`, a bit-at-a-time 128-bit division loop (`src/common/types/uhugeint.cpp:258`). The divisor is always a power of two, so a bitmask is equivalent and ~16x faster.

<details><summary>Some Benchmarks</summary>

| run  | modulo (ns/value) | mask (ns/value) | speedup |
|------|-------------------|-----------------|---------|
| 1    | 115.67            | 7.02            | 16.5x   |
| 2    | 107.36            | 6.39            | 16.8x   |
| 3    | 98.12             | 5.80            | 16.9x   |
| 4    | 93.89             | 5.49            | 17.1x   |
| 5    | 90.68             | 5.33            | 17.0x   |
| mean | 101.14            | 6.01            | 16.8x   |

```cpp
int main() {
      const size_t N = 10000;

      // the real code feeds `in[0] >> shr`, i.e. an unsigned 32-bit value
      std::mt19937_64 gen(42);
      std::vector<uhugeint_t> values(N);
      for (size_t i = 0; i < N; i++) {
              values[i] = uhugeint_t(static_cast<uint32_t>(gen()));
      }

      // delta is the bitpacking width; cycle through every width that reaches this branch
      auto t0 = Clock::now();
      for (size_t i = 0; i < N; i++) {
              const uint16_t delta = 1 + i % 31;
              std::ignore = values[i] % (uhugeint_t(1) << delta);
      }
      auto t1 = Clock::now();

      for (size_t i = 0; i < N; i++) {
              const uint16_t delta = 1 + i % 31;
              std::ignore = values[i] & ((uhugeint_t(1) << delta) - 1);
      }
      auto t2 = Clock::now();

      double old_ns = std::chrono::duration<double, std::nano>(t1 - t0).count() / N;
      double new_ns = std::chrono::duration<double, std::nano>(t2 - t1).count() / N;
      printf("modulo: %.2f ns/value\nmask:   %.2f ns/value\nspeedup: %.1fx\n", old_ns, new_ns, old_ns / new_ns);
}
```


</details>
