### PR TITLE
Fix integer underflow in VariantMetadata

### DIFF
--- a/extension/parquet/reader/variant/variant_binary_decoder.cpp
+++ b/extension/parquet/reader/variant/variant_binary_decoder.cpp
@@ -80,6 +80,10 @@ VariantMetadata::VariantMetadata(const string_t &metadata) : metadata(metadata) 
 	for (idx_t i = 0; i < dictionary_size; i++) {
 		auto next_offset = ReadVariableLengthLittleEndian(header.offset_size, metadata_data, metadata_offset,
 		                                                  metadata_buffer_capacity);
+		if (next_offset < last_offset) {
+			throw IOException(
+			    "Corrupted VARIANT 'metadata' buffer, the next dictionary offset is smaller than the last offset");
+		}
 		const idx_t string_size = next_offset - last_offset;
 		if (data_start + last_offset + string_size > metadata_buffer_capacity) {
 			throw IOException("Corrupted VARIANT 'metadata' buffer");

--- a/test/parquet/variant/variant_malicious.test
+++ b/test/parquet/variant/variant_malicious.test
@@ -7,3 +7,8 @@ statement error
 SELECT * FROM read_parquet('{DATA_DIR}/parquet-testing/variant_malicious.parquet');
 ----
 IO Error: Data corruption detected, read of length_in_bytes (1) would exceed buffer capacity
+
+statement error
+SELECT variant_bytes_to_variant('\x01\x02\xC8\x05\x0A\x00\x00\x00\x00\x00'::BLOB);
+----
+IO Error: Corrupted VARIANT 'metadata' buffer, the next dictionary offset is smaller than the last offset


### PR DESCRIPTION
The variant metadata binary decoder could underflow when subtracting consecutive dictionary offsets, and because the bounds check that follows wraps around by the same amount, the corrupted length slipped through leading to an error.

fixes: https://github.com/duckdb/duckdb/issues/24461
