### PR TITLE
Propagate validity statistics through `lower` and `upper`

### DIFF
--- a/src/function/scalar/string/caseconvert.cpp
+++ b/src/function/scalar/string/caseconvert.cpp
@@ -6,6 +6,8 @@
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/common/vector_operations/unary_executor.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "duckdb/storage/statistics/base_statistics.hpp"
+#include "duckdb/storage/statistics/string_stats.hpp"
 
 #include "utf8proc_wrapper.hpp"
 
@@ -136,7 +138,10 @@ static unique_ptr<BaseStatistics> CaseConvertPropagateStats(ClientContext &conte
 	if (!StringStats::CanContainUnicode(child_stats[0])) {
 		expr.FunctionMutable().SetFunctionCallback(CaseConvertFunctionASCII<IS_UPPER>);
 	}
-	return nullptr;
+	// case conversion is not order- or length-preserving, but it never turns a valid string into NULL
+	auto result = StringStats::CreateUnknown(expr.GetReturnType());
+	result.CopyValidity(child_stats[0]);
+	return result.ToUnique();
 }
 
 ScalarFunction LowerFun::GetFunction() {

--- a/test/optimizer/statistics/statistics_case_convert.test
+++ b/test/optimizer/statistics/statistics_case_convert.test
@@ -1,0 +1,62 @@
+# name: test/optimizer/statistics/statistics_case_convert.test
+# description: Statistics propagation for the lower/upper functions
+# group: [statistics]
+
+statement ok
+CREATE TABLE t_strict_null(s VARCHAR NOT NULL);
+
+statement ok
+INSERT INTO t_strict_null SELECT range::VARCHAR FROM range(6144);
+
+statement ok
+CREATE TABLE t_nullable(s VARCHAR);
+
+statement ok
+INSERT INTO t_nullable SELECT CASE WHEN range % 1024 = 0 THEN NULL ELSE range::VARCHAR END FROM range(6144);
+
+# the input cannot be NULL, so neither can lower(s): the scan is pruned entirely
+query II
+EXPLAIN SELECT count(*) FROM t_strict_null WHERE lower(s) IS NULL;
+----
+physical_plan	<REGEX>:.*Empty Result.*
+
+query I
+SELECT count(*) FROM t_strict_null WHERE lower(s) IS NULL;
+----
+0
+
+# upper(s) IS NOT NULL is always true - the filter is removed
+query II
+EXPLAIN SELECT count(*) FROM t_strict_null WHERE upper(s) IS NOT NULL;
+----
+physical_plan	<!REGEX>:.*IS NOT NULL.*
+
+query I
+SELECT count(*) FROM t_strict_null WHERE upper(s) IS NOT NULL;
+----
+6144
+
+# if the input can be NULL the filter must be kept
+query II
+EXPLAIN SELECT count(*) FROM t_nullable WHERE lower(s) IS NULL;
+----
+physical_plan	<REGEX>:.*IS NULL.*
+
+query I
+SELECT count(*) FROM t_nullable WHERE lower(s) IS NULL;
+----
+6
+
+query I
+SELECT count(*) FROM t_nullable WHERE upper(s) IS NOT NULL;
+----
+6138
+
+# case conversion is not byte-length preserving for unicode: only null-ness is propagated
+statement ok
+CREATE TABLE t_unicode AS SELECT 'ɐɐɐ' AS s FROM range(2048);
+
+query I
+SELECT count(*) FROM t_unicode WHERE strlen(upper(s)) > 6;
+----
+2048


### PR DESCRIPTION
## Summary

Resolves #24412

### Problem

A column known to contain no NULL values is still fully scanned for a `lower(s) IS NULL`
predicate:

```sql
CREATE TABLE t_strict_null(s VARCHAR NOT NULL);
INSERT INTO t_strict_null SELECT range::VARCHAR FROM range(6144);

EXPLAIN ANALYZE SELECT count(*) FROM t_strict_null WHERE lower(s) IS NULL;
```

`lower` never turns a valid string into NULL, so if `s` cannot be NULL then neither can
`lower(s)`, and the predicate is statically `false`.


### Before

```text
╭─ Summary ───────────╮
│ Total Time: 0.0011s │
╰─────────────────────╯
╭─ Ungrouped Aggregate ────────────╮
│ Aggregates: count_star()         │
│ 1 row                        0µs │
╰─────────────────┬────────────────╯
╭─ Table Scan ────┴────────────────╮
│ Table: memory.main.t_strict_null │
│ Type: Sequential Scan            │
│ Filters: lower(s) IS NULL        │
│ Row Groups Scanned: 1 / 1        │
│ 0 rows                       0µs │
╰──────────────────────────────────╯
```

### After

```text
╭─ Summary ───────────╮
│ Total Time: 0.0010s │
╰─────────────────────╯
╭─ Ungrouped Aggregate ────╮
│ Aggregates: count_star() │
│ 1 row                0µs │
╰─────────────┬────────────╯
╭─ Empty Result ───────────╮
│ 0 rows               0µs │
╰──────────────────────────╯
```

### Cause

`lower`/`upper` do register a statistics callback, but `CaseConvertPropagateStats` only used it
to swap in the ASCII kernel and then returned `nullptr`. With no statistics for `lower(s)`,
`StatisticsPropagator::PropagateExpression(BoundOperatorExpression &)` bails out before reaching
the `x IS NULL` → `false` rewrite, since that path requires statistics for every child.

`SELECT stats(lower(s))` showed the symptom directly — `has_null: true` for a `NOT NULL` column.

### Fix

`CaseConvertPropagateStats` now returns statistics that copy the child's validity:

```cpp
auto result = StringStats::CreateUnknown(expr.GetReturnType());
result.CopyValidity(child_stats[0]);
return result.ToUnique();
```

Case conversion can change string values and byte lengths, so `CreateUnknown` avoids making unsafe assumptions about them. Only nullability is copied, because `lower` and `upper` return `NULL` exactly when their input is `NULL`.


### Tests covered

New file `test/optimizer/statistics/statistics_case_convert.test`, which fails on `main` at the
first assertion. It covers:

- a `NOT NULL` column: `lower(s) IS NULL` plans to `Empty Result`, `upper(s) IS NOT NULL` has its
  filter removed as always-true, and both still return the correct counts (`0` / `6144`)
- a nullable column: the filter must be **kept** and return the true NULL count — the guard
  against over-eager pruning
- unicode input, confirming no length claims leak into the propagated statistics

Verified with the full fast suite (`build/reldebug/test/unittest`), and the affected queries were
run under `SET debug_verify_stats=true` over mixed NULL/ASCII/unicode data with no verification
failures.
