### PR TITLE
Guard against zero centroids in approx_quantile

### DIFF
--- a/extension/core_functions/aggregate/holistic/approximate_quantile.cpp
+++ b/extension/core_functions/aggregate/holistic/approximate_quantile.cpp
@@ -269,6 +269,10 @@ void ApproxQuantileImportState(AggregateImportInputData &input) {
 		if (!count_entry.IsValid() || !min_entry.IsValid() || !max_entry.IsValid() || !centroid_list.IsValid()) {
 			throw InvalidInputException("Invalid approx_quantile state - the state fields cannot be NULL");
 		}
+		if (count_entry.GetValue() > 0 && centroid_list.GetListLength() == 0) {
+			throw InvalidInputException("Invalid approx_quantile state - a state with a non-zero count must have "
+			                            "at least one centroid");
+		}
 		arena_vector<duckdb_tdigest::Centroid> centroids(input.allocator);
 		centroids.reserve(centroid_list.GetListLength());
 		for (const auto centroid_entry : centroid_list.GetChildValues()) {

--- a/test/sql/aggregate/aggregate_state_export/approx_quantile_export_state.test
+++ b/test/sql/aggregate/aggregate_state_export/approx_quantile_export_state.test
@@ -85,3 +85,21 @@ query I
 SELECT finalize(combine(approx_quantile(i, 0.5) EXPORT_STATE, (SELECT approx_quantile(j, 0.5) EXPORT_STATE FROM range(500, 1001) s(j)))) FROM range(1, 500) t(i);
 ----
 500
+
+statement error
+SELECT finalize(to_aggregate_state(
+    {'count': 100::UBIGINT, 'min': 0.0::DOUBLE, 'max': 1.0::DOUBLE,
+     'centroids': []::STRUCT(mean DOUBLE, weight DOUBLE)[]},
+    'approx_quantile', ['DOUBLE', 'FLOAT'], [NULL, 0.5]
+));
+----
+<REGEX>:Invalid Input Error:.*must have at least one centroid.*
+
+query I
+SELECT finalize(to_aggregate_state(
+    {'count': 0::UBIGINT, 'min': 0.0::DOUBLE, 'max': 1.0::DOUBLE,
+     'centroids': []::STRUCT(mean DOUBLE, weight DOUBLE)[]},
+    'approx_quantile', ['DOUBLE', 'FLOAT'], [NULL, 0.5]
+));
+----
+NULL


### PR DESCRIPTION
`ApproxQuantileImportState` only checked its fields for `NULL`, so a state with `count > 0` and an empty centroids list was accepted causing an internal error.


fixes: https://github.com/duckdb/duckdb/issues/24475