### PR TITLE
Fix crash in enum_first/enum_last on empty ENUM types

### DIFF
--- a/extension/core_functions/scalar/enum/enum_functions.cpp
+++ b/extension/core_functions/scalar/enum/enum_functions.cpp
@@ -5,8 +5,9 @@ namespace duckdb {
 static void EnumFirstFunction(DataChunk &input, ExpressionState &state, Vector &result) {
 	auto types = input.GetTypes();
 	D_ASSERT(types.size() == 1);
+	auto enum_size = EnumType::GetSize(types[0]);
 	auto &enum_vector = EnumType::GetValuesInsertOrder(types[0]);
-	auto val = Value(enum_vector.GetValue(0));
+	auto val = enum_size == 0 ? Value(LogicalType::VARCHAR) : enum_vector.GetValue(0);
 	result.Reference(val, count_t(input.size()));
 }
 
@@ -15,7 +16,7 @@ static void EnumLastFunction(DataChunk &input, ExpressionState &state, Vector &r
 	D_ASSERT(types.size() == 1);
 	auto enum_size = EnumType::GetSize(types[0]);
 	auto &enum_vector = EnumType::GetValuesInsertOrder(types[0]);
-	auto val = Value(enum_vector.GetValue(enum_size - 1));
+	auto val = enum_size == 0 ? Value(LogicalType::VARCHAR) : enum_vector.GetValue(enum_size - 1);
 	result.Reference(val, count_t(input.size()));
 }
 

--- a/test/sql/types/enum/test_enum.test
+++ b/test/sql/types/enum/test_enum.test
@@ -182,6 +182,11 @@ SELECT enum_range(NULL::mood) AS my_enum_range;
 ----
 []
 
+query II
+SELECT enum_first(NULL::mood), enum_last(NULL::mood);
+----
+NULL	NULL
+
 require skip_reload
 
 # CREATE TEMPORARY TYPE


### PR DESCRIPTION
`enum_first` and `enum_last` were not checking for empty ENUMs, leading to a segfault. They now return NULL instead.

fixes: https://github.com/duckdb/duckdb/issues/24476
fixes: https://github.com/duckdb/duckdb/issues/24477