### PR TITLE
Preserve trailing UTF-8 bytes in StringUtil::RTrim

### DIFF
--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -120,15 +120,14 @@ void StringUtil::LTrim(string &str) {
 
 // Remove trailing ' ', '\f', '\n', '\r', '\t', '\v'
 void StringUtil::RTrim(string &str) {
-	str.erase(find_if(str.rbegin(), str.rend(), [](char ch) { return ch > 0 && !CharacterIsSpace(ch); }).base(),
-	          str.end());
+	str.erase(find_if(str.rbegin(), str.rend(), [](char ch) { return !CharacterIsSpace(ch); }).base(), str.end());
 }
 
 void StringUtil::RTrim(string &str, const string &chars_to_trim) {
-	str.erase(find_if(str.rbegin(), str.rend(),
-	                  [&chars_to_trim](char ch) { return ch > 0 && chars_to_trim.find(ch) == string::npos; })
-	              .base(),
-	          str.end());
+	str.erase(
+	    find_if(str.rbegin(), str.rend(), [&chars_to_trim](char ch) { return chars_to_trim.find(ch) == string::npos; })
+	        .base(),
+	    str.end());
 }
 
 void StringUtil::Trim(string &str) {

--- a/test/common/test_string_util.cpp
+++ b/test/common/test_string_util.cpp
@@ -319,6 +319,26 @@ TEST_CASE("Test split quoted strings", "[string_util]") {
 	}
 }
 
+TEST_CASE("Test RTrim preserves trailing UTF-8", "[string_util]") {
+	string value = u8"abcé";
+	StringUtil::RTrim(value);
+	REQUIRE(value == u8"abcé");
+
+	value = u8"abcé   ";
+	StringUtil::RTrim(value);
+	REQUIRE(value == u8"abcé");
+}
+
+TEST_CASE("Test custom RTrim preserves UTF-8 paths", "[string_util]") {
+	string path = u8"/tmp/café";
+	StringUtil::RTrim(path, "/");
+	REQUIRE(path == u8"/tmp/café");
+
+	path = u8"/tmp/café///";
+	StringUtil::RTrim(path, "/");
+	REQUIRE(path == u8"/tmp/café");
+}
+
 TEST_CASE("Test path utilities", "[string_util]") {
 	SECTION("File name") {
 		REQUIRE("bin" == StringUtil::GetFileName("/usr/bin/"));


### PR DESCRIPTION
## Summary

`StringUtil::RTrim` currently treats bytes with a non-positive `char` value as trim candidates. On platforms with signed `char`, this removes trailing UTF-8 bytes from strings and paths.

This removes that sign check from both overloads. The predicates only need to recognize ASCII whitespace or the explicitly supplied trim bytes, so non-ASCII bytes should be preserved.

The custom overload is used by `PhysicalCopyToFile::GetTrimmedPath`, so this also protects COPY destinations whose final path component contains non-ASCII characters.

## Testing

- `CMAKE_BUILD_PARALLEL_LEVEL=6 make reldebug`
- `build/reldebug/test/unittest '*RTrim*'`
- `build/reldebug/test/unittest '[string_util]'`
- Direct clang-format validation for both changed files