### PR TITLE
Scan the full child span for Arrow ListView arrays

### DIFF
--- a/src/function/table/arrow_conversion.cpp
+++ b/src/function/table/arrow_conversion.cpp
@@ -156,24 +156,31 @@ static ArrowListOffsetData ConvertArrowListViewOffsetsTemplated(Vector &vector, 
 	// for that reason we need to keep track of the lowest offset, so we can skip all the data that comes before it
 	// when we scan the child data
 
-	auto lowest_offset = size ? offsets[0] : 0;
+	bool has_non_empty_entry = false;
+	BUFFER_TYPE lowest_offset = 0;
+	BUFFER_TYPE highest_offset = 0;
 	auto list_data = FlatVector::GetDataMutable<list_entry_t>(vector);
 	for (idx_t i = 0; i < size; i++) {
 		auto &le = list_data[i];
 		le.offset = offsets[i];
 		le.length = sizes[i];
-		list_size += le.length;
-		if (sizes[i] != 0) {
-			lowest_offset = MinValue(lowest_offset, offsets[i]);
+		if (le.length != 0) {
+			auto end_offset = offsets[i] + sizes[i];
+			if (!has_non_empty_entry) {
+				lowest_offset = offsets[i];
+				highest_offset = end_offset;
+				has_non_empty_entry = true;
+			} else {
+				lowest_offset = MinValue(lowest_offset, offsets[i]);
+				highest_offset = MaxValue(highest_offset, end_offset);
+			}
 		}
 	}
-	start_offset = lowest_offset;
-	if (start_offset) {
-		// We start scanning the child data at the 'start_offset' so we need to fix up the created list entries
-		for (idx_t i = 0; i < size; i++) {
-			auto &le = list_data[i];
-			le.offset = le.offset <= start_offset ? 0 : le.offset - start_offset;
-		}
+	start_offset = has_non_empty_entry ? lowest_offset : 0;
+	list_size = has_non_empty_entry ? highest_offset - lowest_offset : 0;
+	for (idx_t i = 0; i < size; i++) {
+		auto &le = list_data[i];
+		le.offset = le.length == 0 ? 0 : le.offset - start_offset;
 	}
 	return result;
 }

--- a/test/arrow/CMakeLists.txt
+++ b/test/arrow/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library_unity(
   arrow_filter_pushdown.cpp
   arrow_dictionary_sentinel.cpp
   arrow_dict_nested_offset.cpp
+  arrow_list_view_nested_offset.cpp
   arrow_output_version_buffers.cpp)
 set(UNITTEST_OBJECT_FILES
     ${UNITTEST_OBJECT_FILES} $<TARGET_OBJECTS:test_arrow_roundtrip>

--- a/test/arrow/arrow_list_view_nested_offset.cpp
+++ b/test/arrow/arrow_list_view_nested_offset.cpp
@@ -1,0 +1,111 @@
+#include "catch.hpp"
+
+#include "arrow/arrow_test_helper.hpp"
+#include "duckdb/common/adbc/single_batch_array_stream.hpp"
+
+#include <string>
+#include <utility>
+#include <vector>
+
+using namespace duckdb;
+
+namespace {
+
+void ListViewReleaseSchema(ArrowSchema *schema) {
+	schema->release = nullptr;
+}
+
+void ListViewReleaseArray(ArrowArray *array) {
+	array->release = nullptr;
+}
+
+template <class OFFSET_TYPE>
+struct ListViewColumn {
+	ListViewColumn(std::vector<OFFSET_TYPE> offsets_p, std::vector<OFFSET_TYPE> sizes_p, std::vector<int32_t> values_p)
+	    : offsets(std::move(offsets_p)), sizes(std::move(sizes_p)), values(std::move(values_p)) {
+		child_schema.format = "i";
+		child_schema.name = "item";
+		child_schema.flags = 2;
+		child_schema.release = ListViewReleaseSchema;
+		child_buffers[0] = nullptr;
+		child_buffers[1] = values.data();
+		child_array.length = int64_t(values.size());
+		child_array.n_buffers = 2;
+		child_array.buffers = child_buffers;
+		child_array.release = ListViewReleaseArray;
+
+		schema.format = sizeof(OFFSET_TYPE) == sizeof(int32_t) ? "+vl" : "+vL";
+		schema.name = "a";
+		schema.flags = 2;
+		schema.n_children = 1;
+		schema.children = schema_children;
+		schema.release = ListViewReleaseSchema;
+		schema_children[0] = &child_schema;
+
+		buffers[0] = nullptr;
+		buffers[1] = offsets.data();
+		buffers[2] = sizes.data();
+		array.length = int64_t(offsets.size());
+		array.n_buffers = 3;
+		array.buffers = buffers;
+		array.n_children = 1;
+		array.children = array_children;
+		array.release = ListViewReleaseArray;
+		array_children[0] = &child_array;
+	}
+	ListViewColumn(const ListViewColumn &) = delete;
+
+	std::vector<OFFSET_TYPE> offsets;
+	std::vector<OFFSET_TYPE> sizes;
+	std::vector<int32_t> values;
+	const void *child_buffers[2];
+	const void *buffers[3];
+	ArrowSchema *schema_children[1];
+	ArrowArray *array_children[1];
+	ArrowSchema child_schema {};
+	ArrowSchema schema {};
+	ArrowArray child_array {};
+	ArrowArray array {};
+};
+
+bool ListViewScanMatches(ArrowSchema &column_schema, ArrowArray &column_array, const string &query) {
+	ArrowSchema *schema_children[1] = {&column_schema};
+	ArrowSchema record_schema {};
+	record_schema.format = "+s";
+	record_schema.n_children = 1;
+	record_schema.children = schema_children;
+	record_schema.release = ListViewReleaseSchema;
+
+	ArrowArray *array_children[1] = {&column_array};
+	const void *buffers[1] = {nullptr};
+	ArrowArray record_array {};
+	record_array.length = column_array.length;
+	record_array.n_buffers = 1;
+	record_array.buffers = buffers;
+	record_array.n_children = 1;
+	record_array.children = array_children;
+	record_array.release = ListViewReleaseArray;
+
+	ArrowArrayStream stream {};
+	AdbcError error {};
+	if (duckdb_adbc::BatchToArrayStream(&record_array, &record_schema, &stream, &error) != ADBC_STATUS_OK) {
+		return false;
+	}
+	DuckDB db(nullptr);
+	Connection con(db);
+	return ArrowTestHelper::RunArrowComparison(con, query, stream);
+}
+
+} // namespace
+
+TEST_CASE("Arrow scan of ListView with disjoint child ranges", "[arrow]") {
+	ListViewColumn<int32_t> column({4, 0}, {3, 2}, {0, 1, 2, 3, 4, 5, 6});
+	REQUIRE(
+	    ListViewScanMatches(column.schema, column.array,
+	                        "SELECT CASE WHEN r = 0 THEN [4, 5, 6]::INT[] ELSE [0, 1]::INT[] END FROM range(2) t(r)"));
+}
+
+TEST_CASE("Arrow scan of ListView with overlapping child ranges", "[arrow]") {
+	ListViewColumn<int64_t> column({0, 0}, {3, 3}, {10, 20, 30});
+	REQUIRE(ListViewScanMatches(column.schema, column.array, "SELECT [10, 20, 30]::INT[] FROM range(2)"));
+}


### PR DESCRIPTION
## What problem does this solve?

Arrow ListView arrays store an offset and a size for each row. Unlike a regular ListArray, those ranges may be out of order, disjoint, or overlapping.

DuckDB currently adds all row sizes together and uses that sum as the length of the child scan. That only works when the referenced ranges form one tightly packed block. For example, offsets [4, 0] with sizes [3, 2] reference child[4:7] and child[0:2]. The required child span is child[0:7], but the current code scans only five values while the first list entry still points at offset four.

## What changed?

Compute the child span from the minimum referenced offset to the maximum offset plus size, then rebase each entry against the start of that span. Empty entries get an offset of zero. The existing 32-bit and 64-bit ListView paths use the same corrected calculation.

## Tests

The new C Data Interface tests cover:

- disjoint, out-of-order ranges with 32-bit offsets
- overlapping ranges with 64-bit offsets

Locally verified with:

- build/reldebug/test/unittest "Arrow scan of ListView*"
- build/reldebug/test/unittest "[arrow]"

No API changes.