### PR TITLE
Fix stale projection ids in LogicalGet after pushdown extract

### DIFF
--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -1102,30 +1102,29 @@ void RemoveUnusedColumns::RemoveColumnsFromLogicalGet(LogicalGet &get, unique_pt
 		get.table_filters = std::move(remapped_filters);
 	}
 
-	if (!get.function.filter_prune) {
-		return;
-	}
-	// Now set the projection cols by matching the "selection vector" that excludes filter columns
-	// with the "selection vector" that includes filter columns
-	idx_t col_idx = 0;
-	get.projection_ids.clear();
-	vector<ProjectionIndex> filtered_original_ids;
-	//! Find matching indices between the proj_sel and the col_sel
-	for (auto to_keep : proj_sel) {
-		for (; col_idx < col_sel.size(); col_idx++) {
-			if (to_keep == col_sel[col_idx]) {
-				filtered_original_ids.push_back(to_keep);
-				break;
+	if (get.function.filter_prune) {
+		// Now set the projection cols by matching the "selection vector" that excludes filter columns
+		// with the "selection vector" that includes filter columns
+		idx_t col_idx = 0;
+		get.projection_ids.clear();
+		vector<ProjectionIndex> filtered_original_ids;
+		//! Find matching indices between the proj_sel and the col_sel
+		for (auto to_keep : proj_sel) {
+			for (; col_idx < col_sel.size(); col_idx++) {
+				if (to_keep == col_sel[col_idx]) {
+					filtered_original_ids.push_back(to_keep);
+					break;
+				}
 			}
 		}
-	}
-	col_idx = 0;
-	for (auto col : filtered_original_ids) {
-		for (; col_idx < original_ids.size(); col_idx++) {
-			if (original_ids[col_idx] == col) {
-				get.projection_ids.push_back(ProjectionIndex(col_idx));
-			} else if (original_ids[col_idx] > col) {
-				break;
+		col_idx = 0;
+		for (auto col : filtered_original_ids) {
+			for (; col_idx < original_ids.size(); col_idx++) {
+				if (original_ids[col_idx] == col) {
+					get.projection_ids.push_back(ProjectionIndex(col_idx));
+				} else if (original_ids[col_idx] > col) {
+					break;
+				}
 			}
 		}
 	}
@@ -1142,6 +1141,14 @@ void RemoveUnusedColumns::RemoveColumnsFromLogicalGet(LogicalGet &get, unique_pt
 		// try to push filters back into the table scan
 		FilterPushdown pushdown(optimizer);
 		op_ref = pushdown.Rewrite(std::move(filter));
+		// if the filters could not be pushed back into the scan, the columns referenced by the
+		// remaining filter have to be included in the output of the scan. Since the projection can
+		// only prune columns when it projects out fewer columns than are scanned (see
+		// TableFunctionInitInput::CanRemoveFilterColumns), we fall back to outputting all columns
+		// in scan order
+		if (op_ref->type == LogicalOperatorType::LOGICAL_FILTER) {
+			get.projection_ids.clear();
+		}
 		return;
 	}
 }

--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -1102,21 +1102,6 @@ void RemoveUnusedColumns::RemoveColumnsFromLogicalGet(LogicalGet &get, unique_pt
 		get.table_filters = std::move(remapped_filters);
 	}
 
-	if (has_pushdown_extract && !filter_expressions.empty()) {
-		// if we have performed pushdown extract and we have filter expressions we might have adjusted the filter
-		// expressions remove the table filters and push a filter, then try to re-push the filters with the new set of
-		// projections
-		auto filter = make_uniq_base<LogicalOperator, LogicalFilter>();
-		filter->expressions = std::move(filter_expressions);
-		filter->children.push_back(std::move(op_ref));
-		get.table_filters.ClearFilters();
-
-		// try to push filters back into the table scan
-		FilterPushdown pushdown(optimizer);
-		op_ref = pushdown.Rewrite(std::move(filter));
-		return;
-	}
-
 	if (!get.function.filter_prune) {
 		return;
 	}
@@ -1143,6 +1128,21 @@ void RemoveUnusedColumns::RemoveColumnsFromLogicalGet(LogicalGet &get, unique_pt
 				break;
 			}
 		}
+	}
+
+	if (has_pushdown_extract && !filter_expressions.empty()) {
+		// if we have performed pushdown extract and we have filter expressions we might have adjusted the filter
+		// expressions remove the table filters and push a filter, then try to re-push the filters with the new set of
+		// projections
+		auto filter = make_uniq_base<LogicalOperator, LogicalFilter>();
+		filter->expressions = std::move(filter_expressions);
+		filter->children.push_back(std::move(op_ref));
+		get.table_filters.ClearFilters();
+
+		// try to push filters back into the table scan
+		FilterPushdown pushdown(optimizer);
+		op_ref = pushdown.Rewrite(std::move(filter));
+		return;
 	}
 }
 

--- a/test/sql/optimizer/late_materialization_pushdown_extract.test
+++ b/test/sql/optimizer/late_materialization_pushdown_extract.test
@@ -1,0 +1,45 @@
+# name: test/sql/optimizer/late_materialization_pushdown_extract.test
+# description: Late materialization with struct pushdown-extract filters and pruned columns
+# group: [optimizer]
+
+statement ok
+SET late_materialization_max_rows = 100;
+
+statement ok
+CREATE TABLE lm_pushdown_extract (
+    id INTEGER,
+    s STRUCT(a INTEGER, b VARCHAR),
+    x INTEGER
+);
+
+statement ok
+INSERT INTO lm_pushdown_extract VALUES (1, {'a': 1, 'b': NULL}, 10), (2, {'a': 2, 'b': 'y'}, 20);
+
+# The RHS scan of the late materialization rewrites the struct filter into a pushdown-extract
+# column and prunes column x. The projection ids must be rebuilt against the pruned column set,
+# otherwise resolving the rowid column fails (issue #24252).
+query II
+SELECT s, x FROM lm_pushdown_extract WHERE s.a = 1 ORDER BY id LIMIT 1
+----
+{'a': 1, 'b': NULL}	10
+
+# Same query without late materialization returns the same result
+statement ok
+SET disabled_optimizers = 'LATE_MATERIALIZATION';
+
+query II
+SELECT s, x FROM lm_pushdown_extract WHERE s.a = 1 ORDER BY id LIMIT 1
+----
+{'a': 1, 'b': NULL}	10
+
+statement ok
+SET disabled_optimizers = '';
+
+# The query must actually be executed as a late materialization (rowid equality join)
+statement ok
+PRAGMA explain_output = OPTIMIZED_ONLY
+
+query II
+EXPLAIN SELECT s, x FROM lm_pushdown_extract WHERE s.a = 1 ORDER BY id LIMIT 1
+----
+logical_opt	<!REGEX>:.*COMPARISON_JOIN.*rowid = rowid.*

--- a/test/sql/optimizer/late_materialization_pushdown_extract.test
+++ b/test/sql/optimizer/late_materialization_pushdown_extract.test
@@ -1,5 +1,5 @@
 # name: test/sql/optimizer/late_materialization_pushdown_extract.test
-# description: Late materialization with struct pushdown-extract filters and pruned columns
+# description: Struct pushdown-extract filters with pruned columns, with and without late materialization
 # group: [optimizer]
 
 statement ok
@@ -43,3 +43,41 @@ query II
 EXPLAIN SELECT s, x FROM lm_pushdown_extract WHERE s.a = 1 ORDER BY id LIMIT 1
 ----
 logical_opt	<!REGEX>:.*COMPARISON_JOIN.*rowid = rowid.*
+
+statement ok
+PRAGMA explain_output = PHYSICAL_ONLY
+
+# A filter that references multiple extracted fields cannot be pushed back into the scan,
+# it stays as a LogicalFilter on top of the scan. The scan then falls back to outputting
+# all its columns in scan order.
+statement ok
+CREATE TABLE pushdown_extract_multi (
+    s STRUCT(a INTEGER, b INTEGER),
+    x INTEGER
+);
+
+statement ok
+INSERT INTO pushdown_extract_multi VALUES (row(1, 11), 10), (row(2, 22), 20);
+
+query I
+SELECT x FROM pushdown_extract_multi WHERE s.a + s.b = 12
+----
+10
+
+# Mixed filter: one part can be pushed down, the other cannot
+query I
+SELECT x FROM pushdown_extract_multi WHERE s.a + s.b = 12 AND s.a = 1
+----
+10
+
+# A filter referencing an extracted field and a regular column
+query I
+SELECT x FROM pushdown_extract_multi WHERE s.a + x = 11
+----
+10
+
+# The same multi-column filter under late materialization
+query I
+SELECT x FROM pushdown_extract_multi WHERE s.a + s.b = 12 ORDER BY x LIMIT 1
+----
+10


### PR DESCRIPTION
fixes: #24252 

The RHS scan of the late materialization rewrites the struct filter into a pushdown-extract column and prunes column x, but it early returns before rebuilds the projection ids.

The fix is straightforward: return after rebuilds the projection ids.