### PR TITLE
Fix histogram overflow counts with duplicate bins

### DIFF
--- a/extension/core_functions/aggregate/nested/binned_histogram.cpp
+++ b/extension/core_functions/aggregate/nested/binned_histogram.cpp
@@ -71,7 +71,7 @@ struct HistogramBinState {
 			}
 		}
 
-		counts->resize(bin_list.length + 1);
+		counts->resize(bin_boundaries->size() + 1);
 	}
 };
 

--- a/test/sql/aggregate/aggregates/histogram_exact.test
+++ b/test/sql/aggregate/aggregates/histogram_exact.test
@@ -75,6 +75,17 @@ SELECT histogram_exact(r, [0, 1, 2, 3]) FROM range(4) t(r);
 ----
 {0=1, 1=1, 2=1, 3=1}
 
+# duplicate bounds in bins
+query I
+SELECT histogram_exact(n, [10, 10, 20]) FROM obs
+----
+{10=0, 20=1, 9223372036854775807=14}
+
+query I
+SELECT list_aggregate(map_values(histogram_exact(n, [10, 10, 20])), 'sum') FROM obs
+----
+15
+
 query I
 SELECT is_histogram_other_bin(NULL)
 ----

--- a/test/sql/aggregate/aggregates/test_binned_histogram.test
+++ b/test/sql/aggregate/aggregates/test_binned_histogram.test
@@ -115,7 +115,12 @@ SELECT histogram([n], [[x] for x in [10, 20, 30, 40, 50]]) FROM obs
 query I
 SELECT histogram(n, [10, 10, 10, 10]) FROM obs
 ----
-{10=3}
+{10=3, 9223372036854775807=12}
+
+query I
+SELECT list_aggregate(map_values(histogram(n, [10, 10, 10, 10])), 'sum') FROM obs
+----
+15
 
 # null WITHIN bins
 statement error


### PR DESCRIPTION

  ## Summary

  During histogram initialization, duplicate bin boundaries are removed, but the `counts` array was allocated using the original number of boundaries.

  The overflow bucket uses `bin_boundaries->size()` as its index, while finalization checks `counts.back()`. After deduplication, these positions can differ,
  causing overflow counts to be silently omitted.

  This change sizes `counts` using `bin_boundaries->size() + 1`, keeping the counts array aligned with the deduplicated boundaries.

  Regression tests cover duplicate boundaries in both `histogram` and `histogram_exact`, including checks that the output counts sum to the number of input rows.

  ## Tests

  - `build/reldebug/test/unittest`: 4,839 test cases and 1,015,124 assertions passed with no failures.

  Fixes #24440