### PR TITLE
add option to override connect display name

### DIFF
--- a/src/execution/operator/helper/physical_connect.cpp
+++ b/src/execution/operator/helper/physical_connect.cpp
@@ -40,7 +40,8 @@ SourceResultType PhysicalConnect::GetDataInternal(ExecutionContext &context, Dat
 		// (backend-safe), and unguessable, so it is not referenceable in SQL. It is owned by this
 		// connection and detached again by DISCONNECT (see PhysicalDisconnect).
 		AttachInfo attach_info;
-		attach_info.name = Identifier("__connect_" + UUID::ToString(UUID::GenerateRandomUUID()));
+		attach_info.name = Identifier(string(AttachedDatabase::GENERATED_CONNECT_NAME_PREFIX) +
+		                              UUID::ToString(UUID::GenerateRandomUUID()));
 		attach_info.path = info->name.GetIdentifierName();
 		attach_info.options = info->options;
 

--- a/src/include/duckdb/main/attached_database.hpp
+++ b/src/include/duckdb/main/attached_database.hpp
@@ -137,6 +137,10 @@ public:
 	void SetName(const Identifier &new_name) {
 		name = new_name;
 	}
+	//! Prefix of the generated name given to the implicit attach behind `CONNECT '<uri>'`.
+	static constexpr const char *GENERATED_CONNECT_NAME_PREFIX = "__connect_";
+	//! Whether this database still carries that generated name, i.e. has no user-facing name.
+	bool HasGeneratedConnectName() const;
 	bool IsSystem() const;
 	bool IsTemporary() const;
 	bool IsReadOnly() const;

--- a/src/main/attached_database.cpp
+++ b/src/main/attached_database.cpp
@@ -4,7 +4,9 @@
 #include "duckdb/catalog/duck_catalog.hpp"
 #include "duckdb/common/constants.hpp"
 #include "duckdb/common/enums/checkpoint_on_detach.hpp"
+#include "duckdb/common/exception/binder_exception.hpp"
 #include "duckdb/common/file_system.hpp"
+#include "duckdb/common/string_util.hpp"
 #include "duckdb/main/database.hpp"
 #include "duckdb/main/database_manager.hpp"
 #include "duckdb/main/settings.hpp"
@@ -176,6 +178,15 @@ AttachedDatabase::AttachedDatabase(DatabaseInstance &db, Catalog &catalog_p, Sto
 
 	optional_ptr<StorageExtensionInfo> storage_info = storage_extension->storage_info.get();
 	catalog = storage_extension->attach(storage_info, context, *this, name.GetIdentifierName(), info, options);
+	// The attach function may rename the database: extensions that resolve the path themselves know a
+	// better name for it than the caller did. Adopt it before anything reads the name back.
+	if (info.name != name) {
+		if (NameIsReserved(info.name)) {
+			throw BinderException("Attached database name \"%s\" cannot be used because it is a reserved name",
+			                      info.name.GetIdentifierName());
+		}
+		SetName(info.name);
+	}
 	stored_database_path = std::move(options.stored_database_path);
 	if (!catalog) {
 		throw InternalException("AttachedDatabase - attach function did not return a catalog");
@@ -210,6 +221,10 @@ bool AttachedDatabase::IsTemporary() const {
 }
 bool AttachedDatabase::IsReadOnly() const {
 	return type == AttachedDatabaseType::READ_ONLY_DATABASE;
+}
+
+bool AttachedDatabase::HasGeneratedConnectName() const {
+	return StringUtil::StartsWith(name.GetIdentifierName(), GENERATED_CONNECT_NAME_PREFIX);
 }
 
 bool AttachedDatabase::NameIsReserved(const Identifier &name) {

--- a/tools/shell/shell_prompt.cpp
+++ b/tools/shell/shell_prompt.cpp
@@ -284,11 +284,13 @@ string Prompt::HandleSetting(ShellState &state, const PromptComponent &component
 			auto connected = context.TryGetConnectedCatalog();
 			if (connected) {
 				auto &catalog = connected->GetCatalog();
-				// Ephemeral connections (CONNECT '<uri>') have no user-facing name; show the display (URI).
-				if (catalog.GetAttached().IsEphemeral()) {
+				auto &attached = catalog.GetAttached();
+				// If ephemeral connections (CONNECT '<uri>') have no user-facing name; show the display (URI)
+				// instead - unless the storage extension replaced it with a readable one during attach.
+				if (attached.IsEphemeral() && attached.HasGeneratedConnectName()) {
 					return catalog.GetConnectDisplay() + " ";
 				}
-				return catalog.GetAttached().GetName() + " ";
+				return attached.GetName() + " ";
 			}
 			return string();
 		}


### PR DESCRIPTION
Currently, if you run just `CONNECT` to connect to a postgres/rds/redshift instance, the display name on the CLI will default to the URI of the database.

The problem with that is that for certain services, this uri can be very ugly. This option gives extensions the ability to override the display name with something a little more user friendly.

Before
```
memory D connect 'redshift-attach-connect-test' (type redshift);
postgres://'redshift-attach-connect-test.ccg... D ... D 
```

After
```
memory D connect 'redshift-attach-connect-test' (type redshift);
redshift-attach-connect-test D  
```