### PR TITLE
Track and expose Pipeline's intra-MetaPipeline dependencies

### DIFF
--- a/src/include/duckdb/parallel/meta_pipeline.hpp
+++ b/src/include/duckdb/parallel/meta_pipeline.hpp
@@ -92,6 +92,10 @@ public:
 	                                      MetaPipelineType type = MetaPipelineType::REGULAR);
 
 private:
+	//! Register that 'dependant' depends on 'dependency', both within this MetaPipeline
+	void AddPipelineDependency(Pipeline &dependant, Pipeline &dependency);
+
+private:
 	//! The executor for all MetaPipelines in the query plan
 	Executor &executor;
 	//! The PipelineBuildState for all MetaPipelines in the query plan

--- a/src/include/duckdb/parallel/meta_pipeline.hpp
+++ b/src/include/duckdb/parallel/meta_pipeline.hpp
@@ -90,7 +90,8 @@ public:
 	                                      MetaPipelineType type = MetaPipelineType::REGULAR);
 
 private:
-	//! Register that 'dependant' depends on 'dependency', both within this MetaPipeline
+	//! Register that 'dependency' must have run before 'dependant' can start.
+	//! Both pipelines belong to this MetaPipeline, or to one of its descendants
 	static void AddPipelineDependency(Pipeline &dependant, Pipeline &dependency);
 
 private:

--- a/src/include/duckdb/parallel/meta_pipeline.hpp
+++ b/src/include/duckdb/parallel/meta_pipeline.hpp
@@ -52,8 +52,6 @@ public:
 	void GetMetaPipelines(vector<shared_ptr<MetaPipeline>> &result, bool recursive, bool skip);
 	//! Recursively gets the last child added
 	MetaPipeline &GetLastChild();
-	//! Get the dependencies of the Pipelines of this MetaPipeline
-	const reference_map_t<Pipeline, vector<reference<Pipeline>>> &GetDependencies() const;
 	//! Whether the sink of this pipeline is a join build
 	MetaPipelineType Type() const;
 	//! Whether this MetaPipeline has a recursive CTE
@@ -93,7 +91,7 @@ public:
 
 private:
 	//! Register that 'dependant' depends on 'dependency', both within this MetaPipeline
-	void AddPipelineDependency(Pipeline &dependant, Pipeline &dependency);
+	static void AddPipelineDependency(Pipeline &dependant, Pipeline &dependency);
 
 private:
 	//! The executor for all MetaPipelines in the query plan
@@ -110,8 +108,6 @@ private:
 	bool recursive_cte;
 	//! All pipelines with a different source, but the same sink
 	vector<shared_ptr<Pipeline>> pipelines;
-	//! Dependencies of Pipelines of this MetaPipeline
-	reference_map_t<Pipeline, vector<reference<Pipeline>>> pipeline_dependencies;
 	//! Other MetaPipelines that this MetaPipeline depends on
 	vector<shared_ptr<MetaPipeline>> children;
 	//! Next batch index

--- a/src/include/duckdb/parallel/pipeline.hpp
+++ b/src/include/duckdb/parallel/pipeline.hpp
@@ -86,10 +86,11 @@ public:
 	ClientContext &GetClientContext();
 
 	void AddDependency(shared_ptr<Pipeline> &pipeline);
+	//! The dependencies of this pipeline on pipelines of other MetaPipelines
 	vector<weak_ptr<Pipeline>> GetDependencies() const;
-	//! The MetaPipeline that owns this Pipeline (set when the Pipeline is created)
-	optional_ptr<MetaPipeline> GetMetaPipeline() const;
-	vector<reference<Pipeline>> GetAllDependencies();
+	//! All pipelines that must complete before this pipeline can start: the dependencies within the owning
+	//! MetaPipeline, followed by the dependencies across MetaPipelines
+	vector<reference<Pipeline>> GetAllDependencies() const;
 
 	void Ready();
 	void Reset();
@@ -145,10 +146,10 @@ private:
 
 	//! The parent pipelines (i.e. pipelines that are dependent on this pipeline to finish)
 	vector<weak_ptr<Pipeline>> parents;
-	//! The dependencies of this pipeline
+	//! The dependencies of this pipeline in other MetaPipeline
 	vector<weak_ptr<Pipeline>> dependencies;
-	//! The MetaPipeline that owns this pipeline
-	optional_ptr<MetaPipeline> meta_pipeline;
+	//! The dependencies of this pipeline within its MetaPipeline (mirror of MetaPipeline::pipeline_dependencies)
+	vector<weak_ptr<Pipeline>> intra_dependencies;
 
 	//! The base batch index of this pipeline
 	idx_t base_batch_index = 0;

--- a/src/include/duckdb/parallel/pipeline.hpp
+++ b/src/include/duckdb/parallel/pipeline.hpp
@@ -89,7 +89,7 @@ public:
 	vector<weak_ptr<Pipeline>> GetDependencies() const;
 	//! The MetaPipeline that owns this Pipeline (set when the Pipeline is created)
 	optional_ptr<MetaPipeline> GetMetaPipeline() const;
-	vector<reference<Pipeline>> GetAllDependencies() ;
+	vector<reference<Pipeline>> GetAllDependencies();
 
 	void Ready();
 	void Reset();

--- a/src/include/duckdb/parallel/pipeline.hpp
+++ b/src/include/duckdb/parallel/pipeline.hpp
@@ -87,6 +87,9 @@ public:
 
 	void AddDependency(shared_ptr<Pipeline> &pipeline);
 	vector<weak_ptr<Pipeline>> GetDependencies() const;
+	//! The MetaPipeline that owns this Pipeline (set when the Pipeline is created)
+	optional_ptr<MetaPipeline> GetMetaPipeline() const;
+	vector<reference<Pipeline>> GetAllDependencies() ;
 
 	void Ready();
 	void Reset();
@@ -144,6 +147,8 @@ private:
 	vector<weak_ptr<Pipeline>> parents;
 	//! The dependencies of this pipeline
 	vector<weak_ptr<Pipeline>> dependencies;
+	//! The MetaPipeline that owns this pipeline
+	optional_ptr<MetaPipeline> meta_pipeline;
 
 	//! The base batch index of this pipeline
 	idx_t base_batch_index = 0;

--- a/src/include/duckdb/parallel/pipeline.hpp
+++ b/src/include/duckdb/parallel/pipeline.hpp
@@ -88,8 +88,7 @@ public:
 	void AddDependency(shared_ptr<Pipeline> &pipeline);
 	//! The dependencies of this pipeline on pipelines of other MetaPipelines
 	vector<weak_ptr<Pipeline>> GetDependencies() const;
-	//! All pipelines that must complete before this pipeline can start: the dependencies within the owning
-	//! MetaPipeline, followed by the dependencies across MetaPipelines
+	//! All pipelines this pipeline waits on before it can start: 'intra_dependencies' and 'dependencies'
 	vector<reference<Pipeline>> GetAllDependencies() const;
 
 	void Ready();
@@ -146,9 +145,11 @@ private:
 
 	//! The parent pipelines (i.e. pipelines that are dependent on this pipeline to finish)
 	vector<weak_ptr<Pipeline>> parents;
-	//! The dependencies of this pipeline in other MetaPipelines
+	//! Pipelines that must have completed (sink finalized) before this pipeline can start
+	//! These always live in another MetaPipeline, since they have a different sink
 	vector<weak_ptr<Pipeline>> dependencies;
-	//! The dependencies of this pipeline within its own MetaPipeline
+	//! Pipelines that must have run (but not necessarily finalized) before this pipeline can start
+	//! These share this pipeline's sink, or the sink of one of its ancestor MetaPipelines
 	vector<weak_ptr<Pipeline>> intra_dependencies;
 
 	//! The base batch index of this pipeline
@@ -167,7 +168,7 @@ private:
 
 	bool ScheduleParallel(shared_ptr<Event> &event);
 
-	//! Add a dependency on a pipeline within the same MetaPipeline
+	//! Add a dependency that only has to have run (not finalized) before this pipeline can start
 	void AddIntraDependency(Pipeline &dependency);
 	//! Copy all dependencies (within and across MetaPipelines) of 'other'
 	void InheritDependencies(const Pipeline &other);

--- a/src/include/duckdb/parallel/pipeline.hpp
+++ b/src/include/duckdb/parallel/pipeline.hpp
@@ -89,7 +89,7 @@ public:
 	//! The dependencies of this pipeline on pipelines of other MetaPipelines
 	vector<weak_ptr<Pipeline>> GetDependencies() const;
 	//! All pipelines this pipeline waits on before it can start: 'intra_dependencies' and 'dependencies'
-	vector<reference<Pipeline>> GetAllDependencies() const;
+	vector<shared_ptr<Pipeline>> GetAllDependencies() const;
 
 	void Ready();
 	void Reset();

--- a/src/include/duckdb/parallel/pipeline.hpp
+++ b/src/include/duckdb/parallel/pipeline.hpp
@@ -145,11 +145,10 @@ private:
 
 	//! The parent pipelines (i.e. pipelines that are dependent on this pipeline to finish)
 	vector<weak_ptr<Pipeline>> parents;
-	//! Pipelines that must have completed (sink finalized) before this pipeline can start
-	//! These always live in another MetaPipeline, since they have a different sink
+	//! The dependencies of this pipeline in other MetaPipelines
 	vector<weak_ptr<Pipeline>> dependencies;
-	//! Pipelines that must have run (but not necessarily finalized) before this pipeline can start
-	//! These share this pipeline's sink, or the sink of one of its ancestor MetaPipelines
+	//! The dependencies of this pipeline in the same MetaPipeline (or sibling MetaPipelines in case of recursive
+	//! dependencies)
 	vector<weak_ptr<Pipeline>> intra_dependencies;
 
 	//! The base batch index of this pipeline
@@ -168,7 +167,8 @@ private:
 
 	bool ScheduleParallel(shared_ptr<Event> &event);
 
-	//! Add a dependency that only has to have run (not finalized) before this pipeline can start
+	//! Add a dependency on a pipeline within the same MetaPipeline (or sibling MetaPipelines in case of recursive
+	//! dependencies)
 	void AddIntraDependency(Pipeline &dependency);
 	//! Copy all dependencies (within and across MetaPipelines) of 'other'
 	void InheritDependencies(const Pipeline &other);

--- a/src/include/duckdb/parallel/pipeline.hpp
+++ b/src/include/duckdb/parallel/pipeline.hpp
@@ -146,9 +146,9 @@ private:
 
 	//! The parent pipelines (i.e. pipelines that are dependent on this pipeline to finish)
 	vector<weak_ptr<Pipeline>> parents;
-	//! The dependencies of this pipeline in other MetaPipeline
+	//! The dependencies of this pipeline in other MetaPipelines
 	vector<weak_ptr<Pipeline>> dependencies;
-	//! The dependencies of this pipeline within its MetaPipeline (mirror of MetaPipeline::pipeline_dependencies)
+	//! The dependencies of this pipeline within its own MetaPipeline
 	vector<weak_ptr<Pipeline>> intra_dependencies;
 
 	//! The base batch index of this pipeline
@@ -166,6 +166,11 @@ private:
 	bool LaunchScanTasks(shared_ptr<Event> &event, idx_t max_threads);
 
 	bool ScheduleParallel(shared_ptr<Event> &event);
+
+	//! Add a dependency on a pipeline within the same MetaPipeline
+	void AddIntraDependency(Pipeline &dependency);
+	//! Copy all dependencies (within and across MetaPipelines) of 'other'
+	void InheritDependencies(const Pipeline &other);
 };
 
 } // namespace duckdb

--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -189,32 +189,21 @@ void Executor::ScheduleEventsInternal(ScheduleEventData &event_data) {
 	auto &event_map = event_data.event_map;
 	for (auto &entry : event_map) {
 		auto &pipeline = entry.first.get();
-		for (auto &dependency : pipeline.dependencies) {
-			auto dep = dependency.lock();
-			D_ASSERT(dep);
-			auto event_map_entry = event_map.find(*dep);
-			if (event_map_entry == event_map.end()) {
+		for (auto &weak_dependency : pipeline.dependencies) {
+			auto dependency = weak_dependency.lock();
+			D_ASSERT(dependency);
+			auto dependency_entry = event_map.find(*dependency);
+			if (dependency_entry == event_map.end()) {
 				continue;
 			}
-			D_ASSERT(event_map_entry != event_map.end());
-			auto &dep_entry = event_map_entry->second;
-			entry.second.pipeline_event.AddDependency(dep_entry.pipeline_complete_event);
+			entry.second.pipeline_event.AddDependency(dependency_entry->second.pipeline_complete_event);
 		}
-	}
-
-	// set the dependencies for pipeline event
-	for (auto &meta_pipeline : event_data.meta_pipelines) {
-		for (auto &entry : meta_pipeline->GetDependencies()) {
-			auto &pipeline = entry.first.get();
-			auto root_entry = event_map.find(pipeline);
-			D_ASSERT(root_entry != event_map.end());
-			auto &pipeline_stack = root_entry->second;
-			for (auto &dependency : entry.second) {
-				auto event_entry = event_map.find(dependency);
-				D_ASSERT(event_entry != event_map.end());
-				auto &dependency_stack = event_entry->second;
-				pipeline_stack.pipeline_event.AddDependency(dependency_stack.pipeline_event);
-			}
+		for (auto &weak_dependency : pipeline.intra_dependencies) {
+			auto dependency = weak_dependency.lock();
+			D_ASSERT(dependency);
+			auto dependency_entry = event_map.find(*dependency);
+			D_ASSERT(dependency_entry != event_map.end());
+			entry.second.pipeline_event.AddDependency(dependency_entry->second.pipeline_event);
 		}
 	}
 

--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -189,19 +189,20 @@ void Executor::ScheduleEventsInternal(ScheduleEventData &event_data) {
 	auto &event_map = event_data.event_map;
 	for (auto &entry : event_map) {
 		auto &pipeline = entry.first.get();
-		for (auto &weak_dependency : pipeline.dependencies) {
-			auto dependency = weak_dependency.lock();
-			D_ASSERT(dependency);
-			auto dependency_entry = event_map.find(*dependency);
+		for (auto &dependency : pipeline.dependencies) {
+			auto dep = dependency.lock();
+			D_ASSERT(dep);
+			auto dependency_entry = event_map.find(*dep);
 			if (dependency_entry == event_map.end()) {
 				continue;
 			}
+			D_ASSERT(dependency_entry != event_map.end());
 			entry.second.pipeline_event.AddDependency(dependency_entry->second.pipeline_complete_event);
 		}
-		for (auto &weak_dependency : pipeline.intra_dependencies) {
-			auto dependency = weak_dependency.lock();
-			D_ASSERT(dependency);
-			auto dependency_entry = event_map.find(*dependency);
+		for (auto &dependency : pipeline.intra_dependencies) {
+			auto dep = dependency.lock();
+			D_ASSERT(dep);
+			auto dependency_entry = event_map.find(*dep);
 			D_ASSERT(dependency_entry != event_map.end());
 			entry.second.pipeline_event.AddDependency(dependency_entry->second.pipeline_event);
 		}

--- a/src/parallel/meta_pipeline.cpp
+++ b/src/parallel/meta_pipeline.cpp
@@ -110,7 +110,9 @@ MetaPipeline &MetaPipeline::CreateChildMetaPipeline(Pipeline &current, PhysicalO
 }
 
 Pipeline &MetaPipeline::CreatePipeline() {
-	pipelines.emplace_back(make_shared_ptr<Pipeline>(executor));
+	auto pipeline = make_shared_ptr<Pipeline>(executor);
+	pipeline->meta_pipeline = this;
+	pipelines.emplace_back(pipeline);
 	state.SetPipelineSink(*pipelines.back(), sink, next_batch_index++);
 	return *pipelines.back();
 }
@@ -243,6 +245,7 @@ void MetaPipeline::CreateChildPipeline(Pipeline &current, PhysicalOperator &op, 
 	pipelines.emplace_back(state.CreateChildPipeline(executor, current, op));
 	auto &child_pipeline = *pipelines.back();
 	child_pipeline.base_batch_index = current.base_batch_index;
+	child_pipeline.meta_pipeline = this;
 
 	// child pipeline has a dependency (within this MetaPipeline on all pipelines that were scheduled
 	// between 'current' and now (including 'current') - set them up

--- a/src/parallel/meta_pipeline.cpp
+++ b/src/parallel/meta_pipeline.cpp
@@ -225,6 +225,7 @@ Pipeline &MetaPipeline::CreateUnionPipeline(Pipeline &current, bool order_matter
 
 	// 'union_pipeline' inherits ALL dependencies of 'current' (within this MetaPipeline, and across MetaPipelines)
 	union_pipeline.dependencies = current.dependencies;
+	union_pipeline.intra_dependencies = current.intra_dependencies;
 	auto it = pipeline_dependencies.find(current);
 	if (it != pipeline_dependencies.end()) {
 		pipeline_dependencies[union_pipeline] = it->second;

--- a/src/parallel/meta_pipeline.cpp
+++ b/src/parallel/meta_pipeline.cpp
@@ -110,11 +110,14 @@ MetaPipeline &MetaPipeline::CreateChildMetaPipeline(Pipeline &current, PhysicalO
 }
 
 Pipeline &MetaPipeline::CreatePipeline() {
-	auto pipeline = make_shared_ptr<Pipeline>(executor);
-	pipeline->meta_pipeline = this;
-	pipelines.emplace_back(pipeline);
+	pipelines.emplace_back(make_shared_ptr<Pipeline>(executor));
 	state.SetPipelineSink(*pipelines.back(), sink, next_batch_index++);
 	return *pipelines.back();
+}
+
+void MetaPipeline::AddPipelineDependency(Pipeline &dependant, Pipeline &dependency) {
+	pipeline_dependencies[dependant].push_back(dependency);
+	dependant.intra_dependencies.push_back(weak_ptr<Pipeline>(dependency.shared_from_this()));
 }
 
 vector<shared_ptr<Pipeline>> MetaPipeline::AddDependenciesFrom(Pipeline &dependant, const Pipeline &start,
@@ -139,9 +142,8 @@ vector<shared_ptr<Pipeline>> MetaPipeline::AddDependenciesFrom(Pipeline &dependa
 	}
 
 	// add them to the dependencies
-	auto &explicit_deps = pipeline_dependencies[dependant];
 	for (auto &created_pipeline : created_pipelines) {
-		explicit_deps.push_back(*created_pipeline);
+		AddPipelineDependency(dependant, *created_pipeline);
 	}
 
 	return created_pipelines;
@@ -182,12 +184,11 @@ void MetaPipeline::AddRecursiveDependencies(const vector<shared_ptr<Pipeline>> &
 			if (!PipelineExceedsThreadCount(*pipeline, thread_count)) {
 				continue;
 			}
-			auto &pipeline_deps = pipeline_dependencies[*pipeline];
 			for (auto &new_dependency : new_dependencies) {
 				if (!PipelineExceedsThreadCount(*new_dependency, thread_count)) {
 					continue;
 				}
-				pipeline_deps.push_back(*new_dependency);
+				AddPipelineDependency(*pipeline, *new_dependency);
 			}
 		}
 	}
@@ -231,7 +232,7 @@ Pipeline &MetaPipeline::CreateUnionPipeline(Pipeline &current, bool order_matter
 
 	if (order_matters) {
 		// if we need to preserve order, or if the sink is not parallel, we set a dependency
-		pipeline_dependencies[union_pipeline].push_back(current);
+		AddPipelineDependency(union_pipeline, current);
 	}
 
 	return union_pipeline;
@@ -245,11 +246,10 @@ void MetaPipeline::CreateChildPipeline(Pipeline &current, PhysicalOperator &op, 
 	pipelines.emplace_back(state.CreateChildPipeline(executor, current, op));
 	auto &child_pipeline = *pipelines.back();
 	child_pipeline.base_batch_index = current.base_batch_index;
-	child_pipeline.meta_pipeline = this;
 
 	// child pipeline has a dependency (within this MetaPipeline on all pipelines that were scheduled
 	// between 'current' and now (including 'current') - set them up
-	pipeline_dependencies[child_pipeline].push_back(current);
+	AddPipelineDependency(child_pipeline, current);
 	AddDependenciesFrom(child_pipeline, last_pipeline, false);
 	D_ASSERT(pipeline_dependencies.find(child_pipeline) != pipeline_dependencies.end());
 }

--- a/src/parallel/meta_pipeline.cpp
+++ b/src/parallel/meta_pipeline.cpp
@@ -62,10 +62,6 @@ MetaPipeline &MetaPipeline::GetLastChild() {
 	return *current_children.get().back();
 }
 
-const reference_map_t<Pipeline, vector<reference<Pipeline>>> &MetaPipeline::GetDependencies() const {
-	return pipeline_dependencies;
-}
-
 MetaPipelineType MetaPipeline::Type() const {
 	return type;
 }
@@ -116,8 +112,7 @@ Pipeline &MetaPipeline::CreatePipeline() {
 }
 
 void MetaPipeline::AddPipelineDependency(Pipeline &dependant, Pipeline &dependency) {
-	pipeline_dependencies[dependant].push_back(dependency);
-	dependant.intra_dependencies.push_back(weak_ptr<Pipeline>(dependency.shared_from_this()));
+	dependant.AddIntraDependency(dependency);
 }
 
 vector<shared_ptr<Pipeline>> MetaPipeline::AddDependenciesFrom(Pipeline &dependant, const Pipeline &start,
@@ -224,12 +219,7 @@ Pipeline &MetaPipeline::CreateUnionPipeline(Pipeline &current, bool order_matter
 	state.SetPipelineSink(union_pipeline, sink, 0);
 
 	// 'union_pipeline' inherits ALL dependencies of 'current' (within this MetaPipeline, and across MetaPipelines)
-	union_pipeline.dependencies = current.dependencies;
-	union_pipeline.intra_dependencies = current.intra_dependencies;
-	auto it = pipeline_dependencies.find(current);
-	if (it != pipeline_dependencies.end()) {
-		pipeline_dependencies[union_pipeline] = it->second;
-	}
+	union_pipeline.InheritDependencies(current);
 
 	if (order_matters) {
 		// if we need to preserve order, or if the sink is not parallel, we set a dependency
@@ -252,7 +242,7 @@ void MetaPipeline::CreateChildPipeline(Pipeline &current, PhysicalOperator &op, 
 	// between 'current' and now (including 'current') - set them up
 	AddPipelineDependency(child_pipeline, current);
 	AddDependenciesFrom(child_pipeline, last_pipeline, false);
-	D_ASSERT(pipeline_dependencies.find(child_pipeline) != pipeline_dependencies.end());
+	D_ASSERT(!child_pipeline.intra_dependencies.empty());
 }
 
 } // namespace duckdb

--- a/src/parallel/pipeline.cpp
+++ b/src/parallel/pipeline.cpp
@@ -13,6 +13,7 @@
 #include "duckdb/parallel/pipeline_executor.hpp"
 #include "duckdb/parallel/task_scheduler.hpp"
 #include "duckdb/main/settings.hpp"
+#include "duckdb/parallel/meta_pipeline.hpp"
 
 namespace duckdb {
 
@@ -257,6 +258,28 @@ void Pipeline::AddDependency(shared_ptr<Pipeline> &pipeline) {
 
 vector<weak_ptr<Pipeline>> Pipeline::GetDependencies() const {
 	return dependencies;
+}
+
+optional_ptr<MetaPipeline> Pipeline::GetMetaPipeline() const {
+	return meta_pipeline;
+}
+
+vector<reference<Pipeline>> Pipeline::GetAllDependencies() {
+	vector<reference<Pipeline>> result;
+	if (meta_pipeline) {
+		auto &deps = meta_pipeline->GetDependencies();
+		auto it = deps.find(*this);
+		if (it != deps.end()) {
+			result.insert(result.end(), it->second.begin(), it->second.end());
+		}
+	}
+	for (auto &weak_dep : dependencies) {
+		auto dep = weak_dep.lock();
+		if (dep) {
+			result.push_back(*dep);
+		}
+	}
+	return result;
 }
 
 string Pipeline::ToString() const {

--- a/src/parallel/pipeline.cpp
+++ b/src/parallel/pipeline.cpp
@@ -260,17 +260,12 @@ vector<weak_ptr<Pipeline>> Pipeline::GetDependencies() const {
 	return dependencies;
 }
 
-optional_ptr<MetaPipeline> Pipeline::GetMetaPipeline() const {
-	return meta_pipeline;
-}
-
-vector<reference<Pipeline>> Pipeline::GetAllDependencies() {
+vector<reference<Pipeline>> Pipeline::GetAllDependencies() const {
 	vector<reference<Pipeline>> result;
-	if (meta_pipeline) {
-		auto &deps = meta_pipeline->GetDependencies();
-		auto it = deps.find(*this);
-		if (it != deps.end()) {
-			result.insert(result.end(), it->second.begin(), it->second.end());
+	for (auto &weak_dep : intra_dependencies) {
+		auto dep = weak_dep.lock();
+		if (dep) {
+			result.push_back(*dep);
 		}
 	}
 	for (auto &weak_dep : dependencies) {

--- a/src/parallel/pipeline.cpp
+++ b/src/parallel/pipeline.cpp
@@ -13,7 +13,6 @@
 #include "duckdb/parallel/pipeline_executor.hpp"
 #include "duckdb/parallel/task_scheduler.hpp"
 #include "duckdb/main/settings.hpp"
-#include "duckdb/parallel/meta_pipeline.hpp"
 
 namespace duckdb {
 
@@ -269,18 +268,18 @@ void Pipeline::InheritDependencies(const Pipeline &other) {
 	intra_dependencies = other.intra_dependencies;
 }
 
-vector<reference<Pipeline>> Pipeline::GetAllDependencies() const {
-	vector<reference<Pipeline>> result;
+vector<shared_ptr<Pipeline>> Pipeline::GetAllDependencies() const {
+	vector<shared_ptr<Pipeline>> result;
 	for (auto &weak_dep : intra_dependencies) {
 		auto dep = weak_dep.lock();
 		if (dep) {
-			result.push_back(*dep);
+			result.push_back(std::move(dep));
 		}
 	}
 	for (auto &weak_dep : dependencies) {
 		auto dep = weak_dep.lock();
 		if (dep) {
-			result.push_back(*dep);
+			result.push_back(std::move(dep));
 		}
 	}
 	return result;

--- a/src/parallel/pipeline.cpp
+++ b/src/parallel/pipeline.cpp
@@ -260,6 +260,15 @@ vector<weak_ptr<Pipeline>> Pipeline::GetDependencies() const {
 	return dependencies;
 }
 
+void Pipeline::AddIntraDependency(Pipeline &dependency) {
+	intra_dependencies.emplace_back(dependency.shared_from_this());
+}
+
+void Pipeline::InheritDependencies(const Pipeline &other) {
+	dependencies = other.dependencies;
+	intra_dependencies = other.intra_dependencies;
+}
+
 vector<reference<Pipeline>> Pipeline::GetAllDependencies() const {
 	vector<reference<Pipeline>> result;
 	for (auto &weak_dep : intra_dependencies) {


### PR DESCRIPTION
Adds a helper to track Pipeline's depedencies to other pipelines within a MetaPipeline. Pipeline currently only exposes `dependencies` which are cross-MetaPipeline depedencies. The rest are in `MetaPipeline::pipeline_depedencies`. This PR mirrors `pipeline_depedencies` to `Pipeline::intra_dependencies`, so that the dependencies can outlive MetaPipeline, which goes out of scope after plan construction. This is needed by extensions that inspect pipelines at execution time.