### PR TITLE
Fix variant shredding dropping case-distinct keys

### DIFF
--- a/extension/parquet/writer/variant/convert_variant.cpp
+++ b/extension/parquet/writer/variant/convert_variant.cpp
@@ -230,8 +230,7 @@ vector<idx_t> GetChildIndices(const UnifiedVariantVectorData &variant, idx_t row
 		}
 		return child_indices;
 	}
-	//! FIXME: The variant spec says that field names should be case-sensitive, not insensitive
-	case_insensitive_string_set_t shredded_fields = shredding_state->ObjectFields();
+	string_set_t shredded_fields = shredding_state->ObjectFields();
 
 	for (idx_t i = 0; i < nested_data.child_count; i++) {
 		auto keys_index = variant.GetKeysIndex(row, i + nested_data.children_idx);

--- a/src/function/variant/variant_shredding.cpp
+++ b/src/function/variant/variant_shredding.cpp
@@ -356,9 +356,9 @@ void VariantShreddingState::SetShredded(uint32_t row, uint32_t values_index, uin
 	count++;
 }
 
-case_insensitive_string_set_t VariantShreddingState::ObjectFields() {
+string_set_t VariantShreddingState::ObjectFields() {
 	D_ASSERT(type.id() == LogicalTypeId::STRUCT);
-	case_insensitive_string_set_t res;
+	string_set_t res;
 	auto &child_types = StructType::GetChildTypes(type);
 	for (auto &entry : child_types) {
 		auto &type = entry.first;

--- a/src/include/duckdb/function/variant/variant_shredding.hpp
+++ b/src/include/duckdb/function/variant/variant_shredding.hpp
@@ -106,7 +106,7 @@ public:
 public:
 	bool ValueIsShredded(UnifiedVariantVectorData &variant, idx_t row, uint32_t values_index);
 	void SetShredded(uint32_t row, uint32_t values_index, uint32_t result_idx);
-	case_insensitive_string_set_t ObjectFields();
+	string_set_t ObjectFields();
 	virtual const unordered_set<VariantLogicalType> &GetVariantTypes() = 0;
 
 public:

--- a/src/storage/table/variant_column_data.cpp
+++ b/src/storage/table/variant_column_data.cpp
@@ -82,7 +82,7 @@ bool FindShreddedColumnInternal(const ColumnData &shredded, reference<const Base
 	auto &object_children = StructType::GetChildTypes(typed_value.type);
 	optional_idx opt_index;
 	for (idx_t i = 0; i < object_children.size(); i++) {
-		if (field_name == object_children[i].first) {
+		if (field_name == object_children[i].first.GetIdentifierName()) {
 			opt_index = i;
 			break;
 		}

--- a/test/parquet/variant/pushdown/variant_case_sensitivity.test
+++ b/test/parquet/variant/pushdown/variant_case_sensitivity.test
@@ -3,6 +3,8 @@
 
 require parquet
 
+require json
+
 statement ok
 CREATE OR REPLACE VIEW vw AS SELECT
 	{'Foo': i::INTEGER}::VARIANT AS v
@@ -80,3 +82,15 @@ SELECT count(*) FROM (VALUES
 WHERE v.Foo = 3;
 ----
 1
+
+statement ok
+CREATE OR REPLACE TABLE src AS SELECT '{"foo": 2}'::JSON::VARIANT AS v;
+
+statement ok
+COPY src TO '{TEST_DIR}/variant_case_sensitivity_json.parquet' (SHREDDING {'v': 'STRUCT("Foo" INTEGER)'});
+
+query II
+SELECT v::VARCHAR, variant_extract(v, 'foo')::VARCHAR
+FROM '{TEST_DIR}/variant_case_sensitivity_json.parquet';
+----
+{'foo': 2}	2

--- a/test/sql/storage/types/variant/variant_case_sensitive_fields_shredded.test
+++ b/test/sql/storage/types/variant/variant_case_sensitive_fields_shredded.test
@@ -76,9 +76,23 @@ select v::VARCHAR, variant_keys(v), v.a, v.A from forced_shredding order by v::V
 statement ok
 checkpoint;
 
-query IIIII
-select v::VARCHAR, vector_type(v), variant_keys(v), v.a, v.A from forced_shredding order by v::VARCHAR;
+restart
+
+query III
+select v::VARCHAR, vector_type(v), variant_keys(v) from forced_shredding order by v::VARCHAR;
 ----
-{'A': 2}	SHREDDED_VECTOR	[A]	NULL	2
-{'a': 1}	SHREDDED_VECTOR	[a]	1	NULL
-{'b': 3}	SHREDDED_VECTOR	[b]	NULL	NULL
+{'A': 2}	SHREDDED_VECTOR	[A]
+{'a': 1}	SHREDDED_VECTOR	[a]
+{'b': 3}	SHREDDED_VECTOR	[b]
+
+# verify only the exact-case 'a' landed in the shredded typed_value column
+query III
+SELECT segment_type, stats.min::INTEGER, stats.max::INTEGER FROM pragma_storage_info('forced_shredding') WHERE column_path = '[0, 2, 1, 1, 1]'
+----
+INTEGER	1	1
+
+# verify 'A' and 'b' are both kept in the unshredded remainder
+query III
+SELECT count, stats.min::VARCHAR, stats.max::VARCHAR FROM pragma_storage_info('forced_shredding') WHERE column_path = '[0, 1, 1, 1]'
+----
+2	A	b

--- a/test/sql/storage/types/variant/variant_case_sensitive_fields_shredded.test
+++ b/test/sql/storage/types/variant/variant_case_sensitive_fields_shredded.test
@@ -48,3 +48,37 @@ restart
 
 statement ok
 checkpoint;
+
+statement ok
+set variant_minimum_shredding_size = 0;
+
+statement ok
+set force_variant_shredding = 'STRUCT(a INTEGER)';
+
+statement ok
+create or replace table forced_shredding(v VARIANT);
+
+statement ok
+insert into forced_shredding values
+	({'A': 2}),
+	({'a': 1}),
+	({'b': 3})
+;
+
+# the keys are intact before the checkpoint shreds the column
+query IIII
+select v::VARCHAR, variant_keys(v), v.a, v.A from forced_shredding order by v::VARCHAR;
+----
+{'A': 2}	[A]	NULL	2
+{'a': 1}	[a]	1	NULL
+{'b': 3}	[b]	NULL	NULL
+
+statement ok
+checkpoint;
+
+query IIIII
+select v::VARCHAR, vector_type(v), variant_keys(v), v.a, v.A from forced_shredding order by v::VARCHAR;
+----
+{'A': 2}	SHREDDED_VECTOR	[A]	NULL	2
+{'a': 1}	SHREDDED_VECTOR	[a]	1	NULL
+{'b': 3}	SHREDDED_VECTOR	[b]	NULL	NULL


### PR DESCRIPTION
If the shredding schema spells a field differently from the data (e.g. A vs a), the value was silently dropped. This PR makes field name matching against the shredding schema case-sensitive, both when writing shredded data and when reading it back.

Fixes: https://github.com/duckdb/duckdb/issues/24297
Fixes: https://github.com/duckdb/duckdb/issues/24379