### PR TITLE
Concurrent non-positional writes

### DIFF
--- a/scripts/generate_enum_util.py
+++ b/scripts/generate_enum_util.py
@@ -22,7 +22,6 @@ blacklist = [
     "ScheduleMode",
     "MemoryUpdateMode",
     "SchedulePolicy",
-    "DrainMode",
     "BatchDrainMode",
     "PendingTaskCountMode",
     "PartitionKeyTrackerState",

--- a/scripts/generate_enum_util.py
+++ b/scripts/generate_enum_util.py
@@ -23,6 +23,7 @@ blacklist = [
     "MemoryUpdateMode",
     "SchedulePolicy",
     "BatchDrainMode",
+    "AccountedWriteAdoption",
     "PendingTaskCountMode",
     "PartitionKeyTrackerState",
     "ClaimState",

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -40,6 +40,7 @@
 #include "duckdb/common/enums/expression_type.hpp"
 #include "duckdb/common/enums/file_compression_type.hpp"
 #include "duckdb/common/enums/file_glob_options.hpp"
+#include "duckdb/common/enums/file_write_mode.hpp"
 #include "duckdb/common/enums/filter_propagate_result.hpp"
 #include "duckdb/common/enums/function_errors.hpp"
 #include "duckdb/common/enums/http_status_code.hpp"
@@ -2534,6 +2535,25 @@ const char* EnumUtil::ToChars<FileNameSegmentType>(FileNameSegmentType value) {
 template<>
 FileNameSegmentType EnumUtil::FromString<FileNameSegmentType>(const char *value) {
 	return static_cast<FileNameSegmentType>(StringUtil::StringToEnum(GetFileNameSegmentTypeValues(), 4, "FileNameSegmentType", value));
+}
+
+const StringUtil::EnumStringLiteral *GetFileWriteModeValues() {
+	static constexpr StringUtil::EnumStringLiteral values[] {
+		{ static_cast<uint32_t>(FileWriteMode::SEQUENTIAL), "SEQUENTIAL" },
+		{ static_cast<uint32_t>(FileWriteMode::CONCURRENT_SEQUENTIAL), "CONCURRENT_SEQUENTIAL" },
+		{ static_cast<uint32_t>(FileWriteMode::POSITIONAL), "POSITIONAL" }
+	};
+	return values;
+}
+
+template<>
+const char* EnumUtil::ToChars<FileWriteMode>(FileWriteMode value) {
+	return StringUtil::EnumToString(GetFileWriteModeValues(), 3, "FileWriteMode", static_cast<uint32_t>(value));
+}
+
+template<>
+FileWriteMode EnumUtil::FromString<FileWriteMode>(const char *value) {
+	return static_cast<FileWriteMode>(StringUtil::StringToEnum(GetFileWriteModeValues(), 3, "FileWriteMode", value));
 }
 
 const StringUtil::EnumStringLiteral *GetFilterPropagateResultValues() {

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -100,7 +100,6 @@
 #include "duckdb/common/operator/decimal_cast_operators.hpp"
 #include "duckdb/common/printer.hpp"
 #include "duckdb/common/query_parameters.hpp"
-#include "duckdb/common/serializer/async_write_queue.hpp"
 #include "duckdb/common/sorting/sort_key.hpp"
 #include "duckdb/common/types.hpp"
 #include "duckdb/common/types/column/column_data_scan_states.hpp"
@@ -326,24 +325,6 @@ const char* EnumUtil::ToChars<AccessMode>(AccessMode value) {
 template<>
 AccessMode EnumUtil::FromString<AccessMode>(const char *value) {
 	return static_cast<AccessMode>(StringUtil::StringToEnum(GetAccessModeValues(), 4, "AccessMode", value));
-}
-
-const StringUtil::EnumStringLiteral *GetAccountedWriteAdoptionValues() {
-	static constexpr StringUtil::EnumStringLiteral values[] {
-		{ static_cast<uint32_t>(AccountedWriteAdoption::ACCEPTED), "ACCEPTED" },
-		{ static_cast<uint32_t>(AccountedWriteAdoption::REJECTED), "REJECTED" }
-	};
-	return values;
-}
-
-template<>
-const char* EnumUtil::ToChars<AccountedWriteAdoption>(AccountedWriteAdoption value) {
-	return StringUtil::EnumToString(GetAccountedWriteAdoptionValues(), 2, "AccountedWriteAdoption", static_cast<uint32_t>(value));
-}
-
-template<>
-AccountedWriteAdoption EnumUtil::FromString<AccountedWriteAdoption>(const char *value) {
-	return static_cast<AccountedWriteAdoption>(StringUtil::StringToEnum(GetAccountedWriteAdoptionValues(), 2, "AccountedWriteAdoption", value));
 }
 
 const StringUtil::EnumStringLiteral *GetAdaptiveFilterSourceValues() {

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -100,6 +100,7 @@
 #include "duckdb/common/operator/decimal_cast_operators.hpp"
 #include "duckdb/common/printer.hpp"
 #include "duckdb/common/query_parameters.hpp"
+#include "duckdb/common/serializer/async_write_queue.hpp"
 #include "duckdb/common/sorting/sort_key.hpp"
 #include "duckdb/common/types.hpp"
 #include "duckdb/common/types/column/column_data_scan_states.hpp"
@@ -325,6 +326,24 @@ const char* EnumUtil::ToChars<AccessMode>(AccessMode value) {
 template<>
 AccessMode EnumUtil::FromString<AccessMode>(const char *value) {
 	return static_cast<AccessMode>(StringUtil::StringToEnum(GetAccessModeValues(), 4, "AccessMode", value));
+}
+
+const StringUtil::EnumStringLiteral *GetAccountedWriteAdoptionValues() {
+	static constexpr StringUtil::EnumStringLiteral values[] {
+		{ static_cast<uint32_t>(AccountedWriteAdoption::ACCEPTED), "ACCEPTED" },
+		{ static_cast<uint32_t>(AccountedWriteAdoption::REJECTED), "REJECTED" }
+	};
+	return values;
+}
+
+template<>
+const char* EnumUtil::ToChars<AccountedWriteAdoption>(AccountedWriteAdoption value) {
+	return StringUtil::EnumToString(GetAccountedWriteAdoptionValues(), 2, "AccountedWriteAdoption", static_cast<uint32_t>(value));
+}
+
+template<>
+AccountedWriteAdoption EnumUtil::FromString<AccountedWriteAdoption>(const char *value) {
+	return static_cast<AccountedWriteAdoption>(StringUtil::StringToEnum(GetAccountedWriteAdoptionValues(), 2, "AccountedWriteAdoption", value));
 }
 
 const StringUtil::EnumStringLiteral *GetAdaptiveFilterSourceValues() {

--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -729,8 +729,8 @@ bool FileSystem::IsManuallySet() {
 	return false;
 }
 
-bool FileSystem::SupportsPositionalWrites(FileHandle &handle) {
-	return false;
+FileWriteMode FileSystem::GetWriteMode(FileHandle &handle) {
+	return FileWriteMode::SEQUENTIAL;
 }
 
 unique_ptr<FileHandle> FileSystem::OpenCompressedFile(QueryContext context, unique_ptr<FileHandle> handle, bool write) {
@@ -824,8 +824,8 @@ bool FileHandle::CanSeek() {
 	return file_system.CanSeek();
 }
 
-bool FileHandle::SupportsPositionalWrites() {
-	return file_system.SupportsPositionalWrites(*this);
+FileWriteMode FileHandle::GetWriteMode() {
+	return file_system.GetWriteMode(*this);
 }
 
 FileCompressionType FileHandle::GetFileCompressionType() {

--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -1848,8 +1848,8 @@ bool LocalFileSystem::CanSeek() {
 	return true;
 }
 
-bool LocalFileSystem::SupportsPositionalWrites(FileHandle &handle) {
-	return true;
+FileWriteMode LocalFileSystem::GetWriteMode(FileHandle &handle) {
+	return FileWriteMode::POSITIONAL;
 }
 
 bool LocalFileSystem::OnDiskFile(FileHandle &handle) {

--- a/src/common/serializer/async_file_writer.cpp
+++ b/src/common/serializer/async_file_writer.cpp
@@ -200,7 +200,7 @@ void AsyncFileWriter::WriteDataSynchronously(data_ptr_t buffer, idx_t write_size
 		if (remaining_size > 0) {
 			auto remaining_offset = total_written;
 			total_written += remaining_size;
-			if (SupportsPositionalWrites()) {
+			if (GetWriteMode() != FileWriteMode::SEQUENTIAL) {
 				Write(buffer + copied_prefix, remaining_size, remaining_offset);
 			} else {
 				Write(buffer + copied_prefix, remaining_size);
@@ -261,8 +261,8 @@ void AsyncFileWriter::LeaveBatch() noexcept {
 	write_queue->LeaveBatch();
 }
 
-bool AsyncFileWriter::SupportsPositionalWrites() {
-	return handle->SupportsPositionalWrites();
+FileWriteMode AsyncFileWriter::GetWriteMode() {
+	return handle->GetWriteMode();
 }
 
 bool AsyncFileWriter::IsLocalFile() {

--- a/src/common/serializer/async_write_queue.cpp
+++ b/src/common/serializer/async_write_queue.cpp
@@ -927,10 +927,10 @@ ManagedAsyncWriteStreamQueue::ManagedAsyncWriteStreamQueue(ClientContext &client
 	auto &scheduler = TaskScheduler::GetScheduler(client_context);
 	auto async_threads = scheduler.NumberOfAsyncThreads();
 
-	// Positional writes let multiple async requests drain one logical write queue concurrently.
-	// Otherwise the stream queue keeps one sequential request active so target ordering remains correct.
-	if (target.SupportsPositionalWrites()) {
-		drain_mode = DrainMode::POSITIONAL;
+	write_mode = target.GetWriteMode();
+	// Explicit-offset writes let multiple async requests drain one logical write queue concurrently. Sequential writes
+	// keep one request active because they use the file handle's shared stream position.
+	if (write_mode != FileWriteMode::SEQUENTIAL) {
 		max_active_drain_tasks = MaxValue<idx_t>(async_threads, 1);
 	}
 
@@ -1154,8 +1154,8 @@ bool ManagedAsyncWriteStreamQueue::TakePendingWriteRequest(AsyncWriteRequest &re
 	if (pending_writes.empty() || batch_depth > 0) {
 		return false;
 	}
-	if (drain_mode == DrainMode::SEQUENTIAL && submitted_requests > 0) {
-		// Non-positional targets write through the file handle's current position, so only one request may be active.
+	if (write_mode == FileWriteMode::SEQUENTIAL && submitted_requests > 0) {
+		// Cursor targets write through the file handle's current position, so only one request may be active.
 		return false;
 	}
 	if (policy == SchedulePolicy::THRESHOLD) {
@@ -1436,7 +1436,7 @@ void ManagedAsyncWriteStreamQueue::Write(data_ptr_t buffer, idx_t size, idx_t of
 	if (size == 0) {
 		return;
 	}
-	if (drain_mode == DrainMode::POSITIONAL) {
+	if (write_mode != FileWriteMode::SEQUENTIAL) {
 		target.Write(buffer, size, offset);
 	} else {
 		target.Write(buffer, size);

--- a/src/common/serializer/async_write_queue.cpp
+++ b/src/common/serializer/async_write_queue.cpp
@@ -33,8 +33,8 @@ idx_t AsyncWriteRequest::Size() const {
 	return payload ? payload->Size() : 0;
 }
 
-AsyncWriteQueue::PendingRequest::PendingRequest(AsyncWriteRequest request_p)
-    : request(std::move(request_p)), size(request.Size()) {
+AsyncWriteQueue::PendingRequest::PendingRequest(AsyncWriteRequest request_p, idx_t size_p) noexcept
+    : request(std::move(request_p)), size(size_p) {
 }
 
 idx_t AsyncWriteQueue::PendingRequest::Size() const {
@@ -140,11 +140,17 @@ void AsyncWriteQueue::Submit(AsyncWriteRequest request) {
 		return;
 	}
 
-	{
+	try {
 		lock_guard<mutex> guard(lock);
 		VerifyOpen();
-		pending_requests.emplace_back(std::move(request));
+		pending_requests.emplace_back(std::move(request), request_size);
 		pending_bytes += request_size;
+	} catch (...) {
+		auto error_ptr = std::current_exception();
+		auto error = ErrorDataFromExceptionPtr(error_ptr);
+		request.payload.reset();
+		CompleteRequest(request, request_size, error);
+		std::rethrow_exception(error_ptr);
 	}
 	ScheduleTasksInternal();
 }
@@ -486,8 +492,8 @@ void AsyncWriteQueue::VerifyOpen() const {
 	}
 }
 
-ManagedAsyncWriteQueue::PendingWrite::PendingWrite(AsyncWriteRequest request_p)
-    : request(std::move(request_p)), size(request.Size()) {
+ManagedAsyncWriteQueue::PendingWrite::PendingWrite(AsyncWriteRequest request_p, idx_t size_p) noexcept
+    : request(std::move(request_p)), size(size_p) {
 }
 
 idx_t ManagedAsyncWriteQueue::PendingWrite::Size() const {
@@ -532,12 +538,30 @@ void ManagedAsyncWriteQueue::RegisterWrite(AsyncWriteRequest request, ScheduleMo
 	RegisterWriteInternal(std::move(request), 0, schedule_mode);
 }
 
-void ManagedAsyncWriteQueue::RegisterAccountedWrite(AsyncWriteRequest request, ScheduleMode schedule_mode) {
-	auto request_size = request.Size();
-	RegisterWriteInternal(std::move(request), request_size, ScheduleMode::DEFER);
-	if (schedule_mode == ScheduleMode::ALLOW) {
-		SchedulePendingWrites(SchedulePolicy::FORCE);
-	}
+ManagedAsyncWriteQueue::AccountedWriteAdoption
+ManagedAsyncWriteQueue::TryAdoptAccountedWrite(AsyncWriteRequest &request, ErrorData &error) {
+	try {
+		if (!write_queue->IsAsync()) {
+			throw InternalException("Accounted async writes require an asynchronous write queue");
+		}
+		RethrowTaskError();
+
+		auto request_size = request.Size();
+		lock_guard<mutex> guard(lock);
+		VerifyOpen();
+		if (external_pending_bytes < request_size) {
+			throw InternalException("Accounted async write exceeds externally tracked bytes");
+		}
+		pending_writes.emplace_back(std::move(request), request_size);
+		external_pending_bytes -= request_size;
+		pending_bytes += request_size;
+		return AccountedWriteAdoption::ACCEPTED;
+	} catch (const std::exception &ex) {
+		error = ErrorData(ex);
+	} catch (...) { // LCOV_EXCL_START
+		error = ErrorData("Unknown exception while adopting an accounted async write");
+	} // LCOV_EXCL_STOP
+	return AccountedWriteAdoption::REJECTED;
 }
 
 void ManagedAsyncWriteQueue::AddExternalPendingBytes(idx_t bytes, bool update_memory) {
@@ -590,7 +614,7 @@ void ManagedAsyncWriteQueue::RegisterWriteInternal(AsyncWriteRequest request, id
 			D_ASSERT(external_pending_bytes >= accounted_external_bytes);
 			external_pending_bytes -= accounted_external_bytes;
 		}
-		pending_writes.emplace_back(std::move(request));
+		pending_writes.emplace_back(std::move(request), request_size);
 		pending_bytes += request_size;
 	}
 	UpdateMemoryState();
@@ -674,20 +698,20 @@ bool ManagedAsyncWriteQueue::TakePendingWriteRequest(AsyncWriteRequest &request,
 	}
 
 	auto request_size = pending_writes.front().Size();
+	auto completion = CreateCompletionAccounting(pending_writes.front().request.completion);
 	request = std::move(pending_writes.front().request);
 	pending_writes.pop_front();
 	D_ASSERT(pending_bytes >= request_size);
 	pending_bytes -= request_size;
 	submitted_bytes += request_size;
 	submitted_requests++;
-	// Attach accounting only on submission, so cancelled pending writes never carry it.
-	AddCompletionAccounting(request);
+	request.completion = std::move(completion);
 	return true;
 }
 
-void ManagedAsyncWriteQueue::AddCompletionAccounting(AsyncWriteRequest &request) {
-	auto user_completion = request.completion;
-	request.completion = [this, user_completion](idx_t offset, idx_t size, optional_ptr<const ErrorData> error) {
+AsyncWriteCompletionCallback
+ManagedAsyncWriteQueue::CreateCompletionAccounting(const AsyncWriteCompletionCallback &user_completion) {
+	return [this, user_completion](idx_t offset, idx_t size, optional_ptr<const ErrorData> error) {
 		CompleteSubmittedWrite(offset, size, error);
 		if (user_completion) {
 			user_completion(offset, size, error);
@@ -914,6 +938,34 @@ private:
 	idx_t size;
 };
 
+class ManagedAsyncWriteStreamQueue::MaterializedWritePayload : public AsyncWritePayload {
+public:
+	MaterializedWritePayload(data_ptr_t data_p, idx_t size_p) : data(data_p), size(size_p) {
+	}
+
+	MaterializedWritePayload(AllocatedData owned_data_p, idx_t size_p)
+	    : owned_data(std::move(owned_data_p)), data(owned_data.get()), size(size_p) {
+	}
+
+	void TakeOwnership(unique_ptr<AsyncWritePayload> payload_p) {
+		payload = std::move(payload_p);
+	}
+
+	data_ptr_t Ptr() override {
+		return data;
+	}
+
+	idx_t Size() const override {
+		return size;
+	}
+
+private:
+	unique_ptr<AsyncWritePayload> payload;
+	AllocatedData owned_data;
+	data_ptr_t data;
+	idx_t size;
+};
+
 ManagedAsyncWriteStreamQueue::ManagedAsyncWriteStreamQueue(ClientContext &client_context_p,
                                                            ManagedAsyncWriteStreamTarget &target_p)
     : client_context(client_context_p), target(target_p) {
@@ -951,15 +1003,24 @@ bool ManagedAsyncWriteStreamQueue::IsAsync() const {
 }
 
 bool ManagedAsyncWriteStreamQueue::HasError() {
-	return write_queue->HasError();
+	if (write_queue->HasError()) {
+		return true;
+	}
+	{
+		lock_guard<mutex> guard(lock);
+		if (local_error) {
+			return true;
+		}
+	}
+	return false;
 }
 
 void ManagedAsyncWriteStreamQueue::RegisterWrite(unique_ptr<AsyncWritePayload> payload, idx_t offset,
                                                  ScheduleMode schedule_mode) {
+	RethrowTaskError();
 	if (!payload || payload->Size() == 0) {
 		return;
 	}
-	RethrowTaskError();
 
 	auto write_size = payload->Size();
 	if (!write_queue->IsAsync()) {
@@ -977,6 +1038,9 @@ void ManagedAsyncWriteStreamQueue::RegisterWrite(unique_ptr<AsyncWritePayload> p
 	try {
 		{
 			lock_guard<mutex> guard(lock);
+			if (local_error) {
+				local_error->Throw();
+			}
 			VerifyOpen();
 			auto next_offset = ValidateRegistrationOffset(offset, write_size);
 			pending_writes.emplace_back(std::move(payload), offset);
@@ -1004,7 +1068,11 @@ void ManagedAsyncWriteStreamQueue::BeginBatch() {
 		VerifyOpen();
 		return;
 	}
+	RethrowTaskError();
 	lock_guard<mutex> guard(lock);
+	if (local_error) {
+		local_error->Throw();
+	}
 	VerifyOpen();
 	batch_depth++;
 }
@@ -1033,6 +1101,7 @@ void ManagedAsyncWriteStreamQueue::SchedulePendingWrites(SchedulePolicy policy) 
 		VerifyOpen();
 		return;
 	}
+	RethrowTaskError();
 	SchedulePendingWritesInternal(policy);
 }
 
@@ -1041,12 +1110,33 @@ void ManagedAsyncWriteStreamQueue::SchedulePendingWritesInternal(SchedulePolicy 
 		return;
 	}
 
+	lock_guard<mutex> submission_guard(submission_lock);
 	while (true) {
 		AsyncWriteRequest request;
-		if (!TakePendingWriteRequest(request, policy)) {
-			return;
+		try {
+			RethrowTaskError();
+			if (!TakePendingWriteRequest(request, policy)) {
+				return;
+			}
+		} catch (...) {
+			FailLocalScheduling(ErrorDataFromExceptionPtr(std::current_exception()));
+			RethrowTaskError();
 		}
-		write_queue->RegisterAccountedWrite(std::move(request));
+
+		auto request_size = request.Size();
+		ErrorData adoption_error;
+		auto adoption = write_queue->TryAdoptAccountedWrite(request, adoption_error);
+		if (adoption == ManagedAsyncWriteQueue::AccountedWriteAdoption::REJECTED) {
+			FailLocalScheduling(std::move(adoption_error), request_size);
+			RethrowTaskError();
+		}
+
+		try {
+			write_queue->SchedulePendingWrites(ManagedAsyncWriteQueue::SchedulePolicy::FORCE);
+		} catch (...) {
+			FailLocalScheduling(ErrorDataFromExceptionPtr(std::current_exception()));
+			RethrowTaskError();
+		}
 	}
 }
 
@@ -1151,6 +1241,9 @@ bool ManagedAsyncWriteStreamQueue::TakePendingWriteRequest(AsyncWriteRequest &re
 	};
 
 	lock_guard<mutex> guard(lock);
+	if (local_error) {
+		local_error->Throw();
+	}
 	if (pending_writes.empty() || batch_depth > 0) {
 		return false;
 	}
@@ -1177,17 +1270,28 @@ bool ManagedAsyncWriteStreamQueue::TakePendingWriteRequest(AsyncWriteRequest &re
 	}
 
 	auto write_offset = pending_writes.front().offset;
-	deque<PendingWrite> writes;
-	for (idx_t write_idx = 0; write_idx < end; write_idx++) {
-		writes.push_back(std::move(pending_writes.front()));
-		pending_writes.pop_front();
+	unique_ptr<AsyncWritePayload> payload;
+	if (write_mode == FileWriteMode::CONCURRENT_SEQUENTIAL) {
+		payload = CreateMaterializedPayload(end, selected_bytes);
+	} else {
+		deque<PendingWrite> writes;
+		for (idx_t write_idx = 0; write_idx < end; write_idx++) {
+			writes.push_back(std::move(pending_writes.front()));
+			pending_writes.pop_front();
+		}
+		payload = CreatePayload(std::move(writes), selected_bytes);
+	}
+	auto prepared_request = AsyncWriteRequest(std::move(payload), write_offset, std::move(completion));
+	if (write_mode == FileWriteMode::CONCURRENT_SEQUENTIAL) {
+		for (idx_t write_idx = 0; write_idx < end; write_idx++) {
+			pending_writes.pop_front();
+		}
 	}
 	D_ASSERT(pending_bytes >= selected_bytes);
 	pending_bytes -= selected_bytes;
 	submitted_bytes += selected_bytes;
 	submitted_requests++;
-	auto payload = CreatePayload(std::move(writes), selected_bytes);
-	request = AsyncWriteRequest(std::move(payload), write_offset, std::move(completion));
+	request = std::move(prepared_request);
 	return true;
 }
 
@@ -1204,6 +1308,36 @@ unique_ptr<AsyncWritePayload> ManagedAsyncWriteStreamQueue::CreatePayload(deque<
 	return make_uniq<CoalescedWritePayload>(client_context, std::move(writes), size);
 }
 
+unique_ptr<AsyncWritePayload> ManagedAsyncWriteStreamQueue::CreateMaterializedPayload(idx_t end, idx_t size) {
+	D_ASSERT(end > 0);
+	D_ASSERT(end <= pending_writes.size());
+	auto expected_offset = pending_writes.front().offset;
+	for (idx_t write_idx = 0; write_idx < end; write_idx++) {
+		auto &write = pending_writes[write_idx];
+		VerifyContiguousWrite(write, expected_offset);
+		expected_offset = NextWriteOffset(expected_offset, write.Size());
+	}
+
+	if (end == 1) {
+		auto &write = pending_writes.front();
+		auto data = write.payload->Ptr();
+		auto result = make_uniq<MaterializedWritePayload>(data, size);
+		result->TakeOwnership(std::move(write.payload));
+		return std::move(result);
+	}
+
+	auto data = BufferAllocator::Get(client_context).Allocate(size);
+	idx_t data_offset = 0;
+	for (idx_t write_idx = 0; write_idx < end; write_idx++) {
+		auto &write = pending_writes[write_idx];
+		auto write_size = write.Size();
+		memcpy(data.get() + data_offset, write.payload->Ptr(), write_size);
+		data_offset += write_size;
+	}
+	D_ASSERT(data_offset == size);
+	return make_uniq<MaterializedWritePayload>(std::move(data), size);
+}
+
 void ManagedAsyncWriteStreamQueue::CompleteSubmittedWrite(idx_t offset, idx_t size,
                                                           optional_ptr<const ErrorData> error) {
 	(void)offset;
@@ -1215,7 +1349,7 @@ void ManagedAsyncWriteStreamQueue::CompleteSubmittedWrite(idx_t offset, idx_t si
 		submitted_requests--;
 		D_ASSERT(submitted_bytes >= size);
 		submitted_bytes -= size;
-		refill = !error && !closed && batch_depth == 0 && !pending_writes.empty();
+		refill = !error && !closed && !local_error && batch_depth == 0 && !pending_writes.empty();
 		if (force_completion_refill) {
 			refill_policy = SchedulePolicy::FORCE;
 		}
@@ -1223,6 +1357,34 @@ void ManagedAsyncWriteStreamQueue::CompleteSubmittedWrite(idx_t offset, idx_t si
 	if (refill) {
 		SchedulePendingWritesInternal(refill_policy);
 	}
+}
+
+void ManagedAsyncWriteStreamQueue::FailLocalScheduling(ErrorData error, idx_t unaccepted_size) {
+	auto new_error = make_shared_ptr<ErrorData>(std::move(error));
+	idx_t discarded_bytes = 0;
+	{
+		lock_guard<mutex> guard(lock);
+		if (local_error) {
+			return;
+		}
+		if (unaccepted_size > 0) {
+			D_ASSERT(submitted_requests > 0);
+			submitted_requests--;
+			D_ASSERT(submitted_bytes >= unaccepted_size);
+			submitted_bytes -= unaccepted_size;
+		}
+		discarded_bytes = pending_bytes + unaccepted_size;
+		pending_writes.clear();
+		pending_bytes = 0;
+		batch_depth = 0;
+		force_completion_refill = false;
+		local_error = std::move(new_error);
+	}
+	write_queue->DiscardExternalPendingBytes(discarded_bytes);
+}
+
+shared_ptr<const ErrorData> ManagedAsyncWriteStreamQueue::GetLocalError() const {
+	return local_error;
 }
 
 void ManagedAsyncWriteStreamQueue::ApplyBackpressure() {
@@ -1389,6 +1551,9 @@ void ManagedAsyncWriteStreamQueue::Close() {
 void ManagedAsyncWriteStreamQueue::ResetNextOffset(idx_t offset) {
 	RethrowTaskError();
 	lock_guard<mutex> guard(lock);
+	if (local_error) {
+		local_error->Throw();
+	}
 	VerifyOpen();
 	VerifyDrained();
 	next_registration_offset = offset;
@@ -1399,6 +1564,14 @@ void ManagedAsyncWriteStreamQueue::ReleaseMemoryReservation() {
 }
 
 void ManagedAsyncWriteStreamQueue::RethrowTaskError() {
+	shared_ptr<const ErrorData> error;
+	{
+		lock_guard<mutex> guard(lock);
+		error = GetLocalError();
+	}
+	if (error) {
+		error->Throw();
+	}
 	write_queue->RethrowTaskError();
 }
 

--- a/src/common/serializer/async_write_queue.cpp
+++ b/src/common/serializer/async_write_queue.cpp
@@ -991,7 +991,7 @@ ManagedAsyncWriteStreamQueue::ManagedAsyncWriteStreamQueue(ClientContext &client
 }
 
 ManagedAsyncWriteStreamQueue::~ManagedAsyncWriteStreamQueue() {
-	lock_guard<mutex> guard(lock);
+	annotated_lock_guard<annotated_mutex> guard(lock);
 	auto drained = batch_depth == 0 && pending_writes.empty() && pending_bytes == 0 && submitted_bytes == 0 &&
 	               submitted_requests == 0;
 	D_ASSERT(closed || drained);
@@ -1007,7 +1007,7 @@ bool ManagedAsyncWriteStreamQueue::HasError() {
 		return true;
 	}
 	{
-		lock_guard<mutex> guard(lock);
+		annotated_lock_guard<annotated_mutex> guard(lock);
 		if (local_error) {
 			return true;
 		}
@@ -1037,7 +1037,7 @@ void ManagedAsyncWriteStreamQueue::RegisterWrite(unique_ptr<AsyncWritePayload> p
 	bool update_memory = true;
 	try {
 		{
-			lock_guard<mutex> guard(lock);
+			annotated_lock_guard<annotated_mutex> guard(lock);
 			if (local_error) {
 				local_error->Throw();
 			}
@@ -1069,7 +1069,7 @@ void ManagedAsyncWriteStreamQueue::BeginBatch() {
 		return;
 	}
 	RethrowTaskError();
-	lock_guard<mutex> guard(lock);
+	annotated_lock_guard<annotated_mutex> guard(lock);
 	if (local_error) {
 		local_error->Throw();
 	}
@@ -1081,7 +1081,7 @@ void ManagedAsyncWriteStreamQueue::LeaveBatch() noexcept {
 	if (!write_queue->IsAsync()) {
 		return;
 	}
-	lock_guard<mutex> guard(lock);
+	annotated_lock_guard<annotated_mutex> guard(lock);
 	if (batch_depth == 0) {
 		return;
 	}
@@ -1092,7 +1092,7 @@ bool ManagedAsyncWriteStreamQueue::HasOpenBatch() {
 	if (!write_queue->IsAsync()) {
 		return false;
 	}
-	lock_guard<mutex> guard(lock);
+	annotated_lock_guard<annotated_mutex> guard(lock);
 	return batch_depth > 0;
 }
 
@@ -1240,7 +1240,7 @@ bool ManagedAsyncWriteStreamQueue::TakePendingWriteRequest(AsyncWriteRequest &re
 		CompleteSubmittedWrite(offset, size, error);
 	};
 
-	lock_guard<mutex> guard(lock);
+	annotated_lock_guard<annotated_mutex> guard(lock);
 	if (local_error) {
 		local_error->Throw();
 	}
@@ -1344,7 +1344,7 @@ void ManagedAsyncWriteStreamQueue::CompleteSubmittedWrite(idx_t offset, idx_t si
 	bool refill = false;
 	auto refill_policy = SchedulePolicy::THRESHOLD;
 	{
-		lock_guard<mutex> guard(lock);
+		annotated_lock_guard<annotated_mutex> guard(lock);
 		D_ASSERT(submitted_requests > 0);
 		submitted_requests--;
 		D_ASSERT(submitted_bytes >= size);
@@ -1363,7 +1363,7 @@ void ManagedAsyncWriteStreamQueue::FailLocalScheduling(ErrorData error, idx_t un
 	auto new_error = make_shared_ptr<ErrorData>(std::move(error));
 	idx_t discarded_bytes = 0;
 	{
-		lock_guard<mutex> guard(lock);
+		annotated_lock_guard<annotated_mutex> guard(lock);
 		if (local_error) {
 			return;
 		}
@@ -1401,7 +1401,7 @@ void ManagedAsyncWriteStreamQueue::ApplyBackpressure() {
 	while (true) {
 		idx_t current_pending_bytes;
 		{
-			lock_guard<mutex> guard(lock);
+			annotated_lock_guard<annotated_mutex> guard(lock);
 			if (batch_depth > 0) {
 				return;
 			}
@@ -1419,7 +1419,7 @@ void ManagedAsyncWriteStreamQueue::ApplyBackpressure() {
 void ManagedAsyncWriteStreamQueue::WaitAll(BatchDrainMode batch_drain_mode) {
 	bool already_closed;
 	{
-		lock_guard<mutex> guard(lock);
+		annotated_lock_guard<annotated_mutex> guard(lock);
 		already_closed = closed;
 	}
 	if (already_closed) {
@@ -1441,7 +1441,7 @@ void ManagedAsyncWriteStreamQueue::WaitAll(BatchDrainMode batch_drain_mode) {
 		if (batch_opened_for_drain) {
 			return;
 		}
-		lock_guard<mutex> guard(lock);
+		annotated_lock_guard<annotated_mutex> guard(lock);
 		previous_batch_depth = batch_depth;
 		batch_depth = 0;
 		batch_opened_for_drain = true;
@@ -1450,11 +1450,11 @@ void ManagedAsyncWriteStreamQueue::WaitAll(BatchDrainMode batch_drain_mode) {
 		if (!preserve_batch || !batch_opened_for_drain) {
 			return;
 		}
-		lock_guard<mutex> guard(lock);
+		annotated_lock_guard<annotated_mutex> guard(lock);
 		batch_depth = previous_batch_depth;
 	};
 	auto set_force_completion_refill = [&](bool enabled) {
-		lock_guard<mutex> guard(lock);
+		annotated_lock_guard<annotated_mutex> guard(lock);
 		force_completion_refill = enabled;
 	};
 
@@ -1467,7 +1467,7 @@ void ManagedAsyncWriteStreamQueue::WaitAll(BatchDrainMode batch_drain_mode) {
 				SchedulePendingWritesInternal(SchedulePolicy::FORCE);
 			}
 			write_queue->WaitAll();
-			lock_guard<mutex> guard(lock);
+			annotated_lock_guard<annotated_mutex> guard(lock);
 			if (pending_writes.empty() && pending_bytes == 0 && submitted_bytes == 0 && submitted_requests == 0) {
 				break;
 			}
@@ -1499,7 +1499,7 @@ void ManagedAsyncWriteStreamQueue::VerifyDrained() const {
 void ManagedAsyncWriteStreamQueue::CancelPendingWritesAfterFailure() noexcept {
 	idx_t discarded_bytes;
 	{
-		lock_guard<mutex> guard(lock);
+		annotated_lock_guard<annotated_mutex> guard(lock);
 		D_ASSERT(submitted_requests == 0);
 		D_ASSERT(submitted_bytes == 0);
 		if (submitted_requests != 0 || submitted_bytes != 0) {
@@ -1518,7 +1518,7 @@ void ManagedAsyncWriteStreamQueue::CancelPendingWritesAfterFailure() noexcept {
 void ManagedAsyncWriteStreamQueue::Close() {
 	bool already_closed;
 	{
-		lock_guard<mutex> guard(lock);
+		annotated_lock_guard<annotated_mutex> guard(lock);
 		already_closed = closed;
 	}
 	if (already_closed) {
@@ -1543,14 +1543,14 @@ void ManagedAsyncWriteStreamQueue::Close() {
 		std::rethrow_exception(error);
 	}
 
-	lock_guard<mutex> guard(lock);
+	annotated_lock_guard<annotated_mutex> guard(lock);
 	VerifyDrained();
 	closed = true;
 }
 
 void ManagedAsyncWriteStreamQueue::ResetNextOffset(idx_t offset) {
 	RethrowTaskError();
-	lock_guard<mutex> guard(lock);
+	annotated_lock_guard<annotated_mutex> guard(lock);
 	if (local_error) {
 		local_error->Throw();
 	}
@@ -1566,7 +1566,7 @@ void ManagedAsyncWriteStreamQueue::ReleaseMemoryReservation() {
 void ManagedAsyncWriteStreamQueue::RethrowTaskError() {
 	shared_ptr<const ErrorData> error;
 	{
-		lock_guard<mutex> guard(lock);
+		annotated_lock_guard<annotated_mutex> guard(lock);
 		error = GetLocalError();
 	}
 	if (error) {

--- a/src/include/duckdb/common/enum_util.hpp
+++ b/src/include/duckdb/common/enum_util.hpp
@@ -244,6 +244,8 @@ enum class FileLockType : uint8_t;
 
 enum class FileNameSegmentType : uint8_t;
 
+enum class FileWriteMode : uint8_t;
+
 enum class FilterPropagateResult : uint8_t;
 
 enum class ForeignKeyType : uint8_t;
@@ -924,6 +926,9 @@ const char* EnumUtil::ToChars<FileLockType>(FileLockType value);
 
 template<>
 const char* EnumUtil::ToChars<FileNameSegmentType>(FileNameSegmentType value);
+
+template<>
+const char* EnumUtil::ToChars<FileWriteMode>(FileWriteMode value);
 
 template<>
 const char* EnumUtil::ToChars<FilterPropagateResult>(FilterPropagateResult value);
@@ -1786,6 +1791,9 @@ FileLockType EnumUtil::FromString<FileLockType>(const char *value);
 
 template<>
 FileNameSegmentType EnumUtil::FromString<FileNameSegmentType>(const char *value);
+
+template<>
+FileWriteMode EnumUtil::FromString<FileWriteMode>(const char *value);
 
 template<>
 FilterPropagateResult EnumUtil::FromString<FilterPropagateResult>(const char *value);

--- a/src/include/duckdb/common/enum_util.hpp
+++ b/src/include/duckdb/common/enum_util.hpp
@@ -42,8 +42,6 @@ enum class ARTScanResult : uint8_t;
 
 enum class AccessMode : uint8_t;
 
-enum class AccountedWriteAdoption : uint8_t;
-
 enum class AdaptiveFilterSource : uint8_t;
 
 enum class AggregateCombineType : uint8_t;
@@ -625,9 +623,6 @@ const char* EnumUtil::ToChars<ARTScanResult>(ARTScanResult value);
 
 template<>
 const char* EnumUtil::ToChars<AccessMode>(AccessMode value);
-
-template<>
-const char* EnumUtil::ToChars<AccountedWriteAdoption>(AccountedWriteAdoption value);
 
 template<>
 const char* EnumUtil::ToChars<AdaptiveFilterSource>(AdaptiveFilterSource value);
@@ -1493,9 +1488,6 @@ ARTScanResult EnumUtil::FromString<ARTScanResult>(const char *value);
 
 template<>
 AccessMode EnumUtil::FromString<AccessMode>(const char *value);
-
-template<>
-AccountedWriteAdoption EnumUtil::FromString<AccountedWriteAdoption>(const char *value);
 
 template<>
 AdaptiveFilterSource EnumUtil::FromString<AdaptiveFilterSource>(const char *value);

--- a/src/include/duckdb/common/enum_util.hpp
+++ b/src/include/duckdb/common/enum_util.hpp
@@ -42,6 +42,8 @@ enum class ARTScanResult : uint8_t;
 
 enum class AccessMode : uint8_t;
 
+enum class AccountedWriteAdoption : uint8_t;
+
 enum class AdaptiveFilterSource : uint8_t;
 
 enum class AggregateCombineType : uint8_t;
@@ -623,6 +625,9 @@ const char* EnumUtil::ToChars<ARTScanResult>(ARTScanResult value);
 
 template<>
 const char* EnumUtil::ToChars<AccessMode>(AccessMode value);
+
+template<>
+const char* EnumUtil::ToChars<AccountedWriteAdoption>(AccountedWriteAdoption value);
 
 template<>
 const char* EnumUtil::ToChars<AdaptiveFilterSource>(AdaptiveFilterSource value);
@@ -1488,6 +1493,9 @@ ARTScanResult EnumUtil::FromString<ARTScanResult>(const char *value);
 
 template<>
 AccessMode EnumUtil::FromString<AccessMode>(const char *value);
+
+template<>
+AccountedWriteAdoption EnumUtil::FromString<AccountedWriteAdoption>(const char *value);
 
 template<>
 AdaptiveFilterSource EnumUtil::FromString<AdaptiveFilterSource>(const char *value);

--- a/src/include/duckdb/common/enums/file_write_mode.hpp
+++ b/src/include/duckdb/common/enums/file_write_mode.hpp
@@ -1,0 +1,25 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/enums/file_write_mode.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/constants.hpp"
+
+namespace duckdb {
+
+//! The write ordering contract exposed by a file handle.
+enum class FileWriteMode : uint8_t {
+	//! Writes use the file handle's stream position and must execute one at a time.
+	SEQUENTIAL,
+	//! Contiguous writes receive logical offsets; the target admits them in order before backend work may overlap.
+	CONCURRENT_SEQUENTIAL,
+	//! Independent ranges may be written at arbitrary offsets and in arbitrary order.
+	POSITIONAL
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -11,6 +11,7 @@
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/enums/file_compression_type.hpp"
 #include "duckdb/common/enums/file_glob_options.hpp"
+#include "duckdb/common/enums/file_write_mode.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/error_data.hpp"
 #include "duckdb/common/file_buffer.hpp"
@@ -110,7 +111,7 @@ public:
 	DUCKDB_API virtual FileCompressionType GetFileCompressionType();
 
 	DUCKDB_API virtual bool CanSeek();
-	DUCKDB_API bool SupportsPositionalWrites();
+	DUCKDB_API FileWriteMode GetWriteMode();
 	DUCKDB_API bool IsPipe();
 	DUCKDB_API bool OnDiskFile();
 	//! Try to obtain a network throughput estimate (Local files return false).
@@ -312,8 +313,8 @@ public:
 
 	//! If FS was manually set by the user
 	DUCKDB_API virtual bool IsManuallySet();
-	//! Whether positional writes to this handle can be issued independently and out of order
-	DUCKDB_API virtual bool SupportsPositionalWrites(FileHandle &handle);
+	//! Return the write ordering contract for this handle.
+	DUCKDB_API virtual FileWriteMode GetWriteMode(FileHandle &handle);
 	//! Whether or not we can seek into the file
 	DUCKDB_API virtual bool CanSeek();
 	//! Whether or not the FS handles plain files on disk. This is relevant for certain optimizations, as random reads

--- a/src/include/duckdb/common/local_file_system.hpp
+++ b/src/include/duckdb/common/local_file_system.hpp
@@ -33,7 +33,7 @@ public:
 	int64_t Read(FileHandle &handle, void *buffer, int64_t nr_bytes) override;
 	//! Write nr_bytes from the buffer into the file, moving the file pointer forward by nr_bytes.
 	int64_t Write(FileHandle &handle, void *buffer, int64_t nr_bytes) override;
-	bool SupportsPositionalWrites(FileHandle &handle) override;
+	FileWriteMode GetWriteMode(FileHandle &handle) override;
 	//! Excise a range of the file. The file-system is free to deallocate this
 	//! range (sparse file support). Reads to the range will succeed but will return
 	//! undefined data.

--- a/src/include/duckdb/common/serializer/async_file_writer.hpp
+++ b/src/include/duckdb/common/serializer/async_file_writer.hpp
@@ -106,8 +106,8 @@ private:
 	//! Leave a registration batch without scheduling, blocking, or throwing.
 	void LeaveBatch() noexcept;
 
-	//! Return whether the file handle supports independent positional writes.
-	bool SupportsPositionalWrites() override;
+	//! Return the file handle's write ordering contract.
+	FileWriteMode GetWriteMode() override;
 	//! Return whether this writer targets a local file-like handle.
 	bool IsLocalFile() override;
 	//! Write bytes to the underlying file handle at the assigned logical stream offset.

--- a/src/include/duckdb/common/serializer/async_write_queue.hpp
+++ b/src/include/duckdb/common/serializer/async_write_queue.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/deque.hpp"
+#include "duckdb/common/enums/file_write_mode.hpp"
 #include "duckdb/common/error_data.hpp"
 #include "duckdb/common/mutex.hpp"
 #include "duckdb/common/optional_ptr.hpp"
@@ -72,7 +73,7 @@ class AsyncWriteTarget {
 public:
 	virtual ~AsyncWriteTarget() = default;
 
-	//! Write a specific byte range using the target's positional write path.
+	//! Write a specific byte range using the target's explicit-offset write path.
 	virtual void Write(data_ptr_t buffer, idx_t size, idx_t offset) = 0;
 };
 
@@ -186,11 +187,11 @@ class ManagedAsyncWriteStreamTarget {
 public:
 	virtual ~ManagedAsyncWriteStreamTarget() = default;
 
-	//! Whether contiguous registered writes can safely drain concurrently through positional writes.
-	virtual bool SupportsPositionalWrites() = 0;
+	//! Return the target's write ordering contract.
+	virtual FileWriteMode GetWriteMode() = 0;
 	//! Whether this target is a local file-like target. Remote targets use larger coalesced writes.
 	virtual bool IsLocalFile() = 0;
-	//! Write a specific byte range using the target's positional write path.
+	//! Write a specific byte range using the target's explicit-offset write path.
 	virtual void Write(data_ptr_t buffer, idx_t size, idx_t offset) = 0;
 	//! Write bytes using the target's sequential write path.
 	virtual void Write(data_ptr_t buffer, idx_t size) = 0;
@@ -327,8 +328,6 @@ public:
 	enum class ScheduleMode : uint8_t { ALLOW, DEFER };
 	//! Whether to schedule only enough request capacity for normal overlap, or force all pending bytes to drain.
 	enum class SchedulePolicy : uint8_t { THRESHOLD, FORCE };
-	//! Whether async requests can write independent target ranges or must use the target's current stream position.
-	enum class DrainMode : uint8_t { SEQUENTIAL, POSITIONAL };
 	//! Whether waiting for scheduled writes should preserve an open registration batch.
 	enum class BatchDrainMode : uint8_t { PRESERVE_BATCH, FORCE_CLOSE_BATCH };
 
@@ -424,8 +423,8 @@ private:
 
 	//! Managed queue that owns TMM reservation, backpressure, and task scheduling for physical write requests.
 	unique_ptr<ManagedAsyncWriteQueue> write_queue;
-	//! Whether async requests may drain independent ranges concurrently using positional writes.
-	DrainMode drain_mode = DrainMode::SEQUENTIAL;
+	//! The write ordering contract exposed by the target.
+	FileWriteMode write_mode = FileWriteMode::SEQUENTIAL;
 	//! Maximum number of submitted/running drain requests for this queue.
 	idx_t max_active_drain_tasks = 1;
 	//! Size below which adjacent writes are coalesced before reaching the target.

--- a/src/include/duckdb/common/serializer/async_write_queue.hpp
+++ b/src/include/duckdb/common/serializer/async_write_queue.hpp
@@ -448,7 +448,7 @@ private:
 	bool limit_coalesced_write_size = false;
 
 	//! Protects state shared between the registering thread and async completion callbacks.
-	mutex lock;
+	mutable annotated_mutex lock;
 	//! Serializes selection, materialization, accounting transfer, and lower-queue publication.
 	mutex submission_lock;
 	//! Pending payloads in registration order with pre-assigned logical offsets.

--- a/src/include/duckdb/common/serializer/async_write_queue.hpp
+++ b/src/include/duckdb/common/serializer/async_write_queue.hpp
@@ -111,7 +111,7 @@ public:
 private:
 	struct PendingRequest {
 		PendingRequest() = default;
-		explicit PendingRequest(AsyncWriteRequest request);
+		PendingRequest(AsyncWriteRequest request, idx_t size) noexcept;
 
 		idx_t Size() const;
 
@@ -201,6 +201,7 @@ public:
 //! Requests may target independent offsets; stream ordering and coalescing live in ManagedAsyncWriteStreamQueue.
 class ManagedAsyncWriteQueue : private AsyncWriteTarget {
 	friend class ManagedAsyncWriteStreamQueue;
+	friend class ManagedAsyncWriteQueueTest;
 
 public:
 	//! Whether registering a payload may schedule an async drain request immediately.
@@ -241,8 +242,10 @@ public:
 	DUCKDB_API void RethrowTaskError();
 
 private:
+	enum class AccountedWriteAdoption : uint8_t { ACCEPTED, REJECTED };
+
 	struct PendingWrite {
-		explicit PendingWrite(AsyncWriteRequest request);
+		PendingWrite(AsyncWriteRequest request, idx_t size) noexcept;
 
 		idx_t Size() const;
 
@@ -251,8 +254,9 @@ private:
 	};
 
 private:
-	//! Add one positional request whose bytes are already tracked as external pending bytes.
-	void RegisterAccountedWrite(AsyncWriteRequest request, ScheduleMode schedule_mode = ScheduleMode::ALLOW);
+	//! Try to adopt one positional request whose bytes are already tracked as external pending bytes.
+	//! The request is consumed if and only if ACCEPTED is returned.
+	AccountedWriteAdoption TryAdoptAccountedWrite(AsyncWriteRequest &request, ErrorData &error);
 	//! Track bytes held by a wrapper before they become positional requests.
 	void AddExternalPendingBytes(idx_t bytes, bool update_memory = true);
 	//! Stop tracking wrapper-held bytes that will never become positional requests.
@@ -275,8 +279,8 @@ private:
 
 	//! Move one pending positional write into a physical async request.
 	bool TakePendingWriteRequest(AsyncWriteRequest &request, SchedulePolicy policy);
-	//! Wrap a request callback so submitted-byte accounting is released before user callbacks run.
-	void AddCompletionAccounting(AsyncWriteRequest &request);
+	//! Prepare a callback that releases submitted-byte accounting before user callbacks run.
+	AsyncWriteCompletionCallback CreateCompletionAccounting(const AsyncWriteCompletionCallback &user_completion);
 	//! Release byte accounting for one submitted physical request.
 	void CompleteSubmittedWrite(idx_t offset, idx_t size, optional_ptr<const ErrorData> error);
 
@@ -378,6 +382,7 @@ private:
 	};
 
 	class CoalescedWritePayload;
+	class MaterializedWritePayload;
 
 private:
 	//! Schedule drain requests from already registered pending writes.
@@ -398,8 +403,14 @@ private:
 	bool TakePendingWriteRequest(AsyncWriteRequest &request, SchedulePolicy policy);
 	//! Convert one or more contiguous pending writes into a lazily materialized payload.
 	unique_ptr<AsyncWritePayload> CreatePayload(deque<PendingWrite> writes, idx_t size);
+	//! Materialize one pending concurrent-sequential physical request before publishing it to the lower queue.
+	unique_ptr<AsyncWritePayload> CreateMaterializedPayload(idx_t end, idx_t size);
 	//! Release byte accounting for one submitted physical request.
 	void CompleteSubmittedWrite(idx_t offset, idx_t size, optional_ptr<const ErrorData> error);
+	//! Latch one local scheduling failure, stop publication, and discard unsubmitted stream work.
+	void FailLocalScheduling(ErrorData error, idx_t unaccepted_size = 0);
+	//! Return the locally latched scheduling failure, if any. Caller must hold lock.
+	shared_ptr<const ErrorData> GetLocalError() const DUCKDB_REQUIRES(lock);
 
 	//! Validate a new registration against the contiguous offset contract.
 	idx_t ValidateRegistrationOffset(idx_t offset, idx_t write_size) const;
@@ -438,6 +449,8 @@ private:
 
 	//! Protects state shared between the registering thread and async completion callbacks.
 	mutex lock;
+	//! Serializes selection, materialization, accounting transfer, and lower-queue publication.
+	mutex submission_lock;
 	//! Pending payloads in registration order with pre-assigned logical offsets.
 	deque<PendingWrite> pending_writes;
 	//! Bytes queued in pending_writes that have not been submitted to AsyncWriteQueue yet.
@@ -454,6 +467,8 @@ private:
 	idx_t next_registration_offset = 0;
 	//! Set after Close() has drained the queue. Further write registration is rejected.
 	bool closed = false;
+	//! First failure that occurred before a request entered the lower async queue.
+	shared_ptr<const ErrorData> local_error DUCKDB_GUARDED_BY(lock);
 };
 
 } // namespace duckdb

--- a/test/common/test_async_file_writer.cpp
+++ b/test/common/test_async_file_writer.cpp
@@ -72,12 +72,12 @@ private:
 
 class BlockingWriteFileSystem : public TrackingWriteFileSystem {
 public:
-	explicit BlockingWriteFileSystem(bool positional_supported_p, bool local_file_p = true)
-	    : TrackingWriteFileSystem(local_file_p), positional_supported(positional_supported_p) {
+	explicit BlockingWriteFileSystem(FileWriteMode write_mode_p, bool local_file_p = true)
+	    : TrackingWriteFileSystem(local_file_p), write_mode(write_mode_p) {
 	}
 
 	void Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override {
-		if (!positional_supported) {
+		if (write_mode == FileWriteMode::SEQUENTIAL) {
 			throw NotImplementedException("Injected missing positional write support");
 		}
 		if (nr_bytes == 0) {
@@ -95,8 +95,8 @@ public:
 		}
 	}
 
-	bool SupportsPositionalWrites(FileHandle &handle) override {
-		return positional_supported;
+	FileWriteMode GetWriteMode(FileHandle &handle) override {
+		return write_mode;
 	}
 
 	int64_t Write(FileHandle &handle, void *buffer, int64_t nr_bytes) override {
@@ -154,7 +154,7 @@ private:
 	}
 
 private:
-	const bool positional_supported;
+	const FileWriteMode write_mode;
 
 	mutex block_lock;
 	std::condition_variable cv;
@@ -173,14 +173,14 @@ public:
 		throw NotImplementedException("Injected missing positional write support");
 	}
 
-	bool SupportsPositionalWrites(FileHandle &) override {
-		return false;
+	FileWriteMode GetWriteMode(FileHandle &) override {
+		return FileWriteMode::SEQUENTIAL;
 	}
 };
 
 class SequentialExplicitOffsetWriteFileSystem : public BlockingWriteFileSystem {
 public:
-	SequentialExplicitOffsetWriteFileSystem() : BlockingWriteFileSystem(false, false) {
+	SequentialExplicitOffsetWriteFileSystem() : BlockingWriteFileSystem(FileWriteMode::SEQUENTIAL, false) {
 	}
 
 	void Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override {
@@ -200,6 +200,120 @@ public:
 
 private:
 	idx_t next_write_offset = 0;
+};
+
+class ConcurrentSequentialWriteFileSystem : public TrackingWriteFileSystem {
+public:
+	explicit ConcurrentSequentialWriteFileSystem(bool block_backend_writes_p = true)
+	    : TrackingWriteFileSystem(false), block_backend_writes(block_backend_writes_p) {
+	}
+
+	FileWriteMode GetWriteMode(FileHandle &) override {
+		return FileWriteMode::CONCURRENT_SEQUENTIAL;
+	}
+
+	void Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override {
+		if (nr_bytes == 0) {
+			TrackingWriteFileSystem::Write(handle, buffer, nr_bytes, location);
+			return;
+		}
+
+		auto write_size = UnsafeNumericCast<idx_t>(nr_bytes);
+		{
+			unique_lock<mutex> guard(state_lock);
+			if (!state_cv.wait_for(guard, std::chrono::seconds(5),
+			                       [&]() { return location == next_admission_offset; })) {
+				throw InternalException("Concurrent-sequential write was not admitted in stream order");
+			}
+			admitted_offsets.push_back(location);
+			next_admission_offset += write_size;
+			active_backend_writes++;
+			max_active_backend_writes = MaxValue(max_active_backend_writes, active_backend_writes);
+			entered_backend_writes++;
+			state_cv.notify_all();
+			if (block_backend_writes) {
+				state_cv.wait(guard, [&]() { return release_all_writes || IsReleased(location); });
+			}
+		}
+
+		TrackingWriteFileSystem::Write(handle, buffer, nr_bytes, location);
+		{
+			lock_guard<mutex> guard(state_lock);
+			D_ASSERT(active_backend_writes > 0);
+			active_backend_writes--;
+			completed_offsets.push_back(location);
+		}
+		state_cv.notify_all();
+	}
+
+	bool WaitForBackendWrites(idx_t count) {
+		unique_lock<mutex> guard(state_lock);
+		return state_cv.wait_for(guard, std::chrono::seconds(5), [&]() { return entered_backend_writes >= count; });
+	}
+
+	bool WaitForCompletedWrites(idx_t count) {
+		unique_lock<mutex> guard(state_lock);
+		return state_cv.wait_for(guard, std::chrono::seconds(5), [&]() { return completed_offsets.size() >= count; });
+	}
+
+	void ReleaseWrite(idx_t offset) {
+		{
+			lock_guard<mutex> guard(state_lock);
+			released_offsets.push_back(offset);
+		}
+		state_cv.notify_all();
+	}
+
+	void ReleaseAllWrites() {
+		{
+			lock_guard<mutex> guard(state_lock);
+			release_all_writes = true;
+		}
+		state_cv.notify_all();
+	}
+
+	idx_t EnteredBackendWrites() {
+		lock_guard<mutex> guard(state_lock);
+		return entered_backend_writes;
+	}
+
+	idx_t MaxActiveBackendWrites() {
+		lock_guard<mutex> guard(state_lock);
+		return max_active_backend_writes;
+	}
+
+	vector<idx_t> AdmittedOffsets() {
+		lock_guard<mutex> guard(state_lock);
+		return admitted_offsets;
+	}
+
+	vector<idx_t> CompletedOffsets() {
+		lock_guard<mutex> guard(state_lock);
+		return completed_offsets;
+	}
+
+private:
+	bool IsReleased(idx_t offset) const {
+		for (auto released_offset : released_offsets) {
+			if (released_offset == offset) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+private:
+	const bool block_backend_writes;
+	mutex state_lock;
+	std::condition_variable state_cv;
+	vector<idx_t> admitted_offsets;
+	vector<idx_t> released_offsets;
+	vector<idx_t> completed_offsets;
+	idx_t next_admission_offset = 0;
+	idx_t entered_backend_writes = 0;
+	idx_t active_backend_writes = 0;
+	idx_t max_active_backend_writes = 0;
+	bool release_all_writes = false;
 };
 
 class FailingBlockedWriteFileSystem : public TrackingWriteFileSystem {
@@ -546,7 +660,7 @@ static void TestQueuedDrainTaskCoversNewTinyTail(bool local_file, const string &
 	AsyncThreadBlocker async_thread_blocker(*con->context, NumericCast<idx_t>(scheduler.NumberOfAsyncThreads()));
 	REQUIRE(async_thread_blocker.WaitForStarted());
 
-	BlockingWriteFileSystem fs(true, local_file);
+	BlockingWriteFileSystem fs(FileWriteMode::POSITIONAL, local_file);
 	auto path = TestCreatePath(path_name);
 	if (fs.FileExists(path)) {
 		fs.RemoveFile(path);
@@ -769,7 +883,7 @@ TEST_CASE("AsyncFileWriter flush preserves an open batch", "[async_file_writer]"
 TEST_CASE("AsyncFileWriter drains positional writes on multiple async threads", "[async_file_writer]") {
 	DuckDB db(nullptr);
 	auto con = CreateConnectionWithAsyncThreads(db, 2);
-	BlockingWriteFileSystem fs(true, false);
+	BlockingWriteFileSystem fs(FileWriteMode::POSITIONAL, false);
 	auto path = TestCreatePath("async_file_writer_parallel_positional.tmp");
 	if (fs.FileExists(path)) {
 		fs.RemoveFile(path);
@@ -814,7 +928,7 @@ TEST_CASE("AsyncFileWriter drains positional writes on multiple async threads", 
 TEST_CASE("AsyncFileWriter drains non-positional writes on one async thread", "[async_file_writer]") {
 	DuckDB db(nullptr);
 	auto con = CreateConnectionWithAsyncThreads(db, 2);
-	BlockingWriteFileSystem fs(false, false);
+	BlockingWriteFileSystem fs(FileWriteMode::SEQUENTIAL, false);
 	auto path = TestCreatePath("async_file_writer_parallel_non_positional.tmp");
 	if (fs.FileExists(path)) {
 		fs.RemoveFile(path);
@@ -849,10 +963,107 @@ TEST_CASE("AsyncFileWriter drains non-positional writes on one async thread", "[
 	fs.RemoveFile(path);
 }
 
+TEST_CASE("AsyncFileWriter admits concurrent-sequential writes in order before overlapping backend work",
+          "[async_file_writer]") {
+	DuckDB db(nullptr);
+	auto con = CreateConnectionWithAsyncThreads(db, 2);
+	ConcurrentSequentialWriteFileSystem fs;
+	auto path = TestCreatePath("async_file_writer_parallel_concurrent_sequential.tmp");
+	if (fs.FileExists(path)) {
+		fs.RemoveFile(path);
+	}
+
+	string first(AsyncWriteConfig::DRAIN_TASK_BYTE_BUDGET + 1, 'a');
+	string second(AsyncWriteConfig::DRAIN_TASK_BYTE_BUDGET + 1, 'b');
+
+	AsyncFileWriter writer(*con->context, fs, path);
+	{
+		auto batch_guard = writer.StartBatch();
+		writer.WriteData(make_uniq<StringAsyncWriteBuffer>(first));
+		writer.WriteData(make_uniq<StringAsyncWriteBuffer>(second));
+		batch_guard.Finish();
+	}
+
+	auto saw_two_backend_writes = fs.WaitForBackendWrites(2);
+	auto admitted_offsets = fs.AdmittedOffsets();
+	auto max_active_backend_writes = fs.MaxActiveBackendWrites();
+	bool completed_later_write_first = false;
+	if (saw_two_backend_writes) {
+		fs.ReleaseWrite(first.size());
+		if (fs.WaitForCompletedWrites(1)) {
+			auto completed_offsets = fs.CompletedOffsets();
+			completed_later_write_first = completed_offsets[0] == first.size();
+		}
+	}
+	fs.ReleaseAllWrites();
+	writer.Close();
+
+	REQUIRE(saw_two_backend_writes);
+	REQUIRE(admitted_offsets == vector<idx_t> {0, first.size()});
+	REQUIRE(max_active_backend_writes >= 2);
+	REQUIRE(completed_later_write_first);
+	REQUIRE(ReadFile(path) == first + second);
+	fs.RemoveFile(path);
+}
+
+TEST_CASE("AsyncFileWriter concurrent-sequential writes use the configured async worker capacity",
+          "[async_file_writer]") {
+	DuckDB db(nullptr);
+	auto con = CreateConnectionWithAsyncThreads(db, 3);
+	ConcurrentSequentialWriteFileSystem fs;
+	auto path = TestCreatePath("async_file_writer_concurrent_sequential_worker_capacity.tmp");
+	if (fs.FileExists(path)) {
+		fs.RemoveFile(path);
+	}
+
+	auto write_size = AsyncWriteConfig::DRAIN_TASK_BYTE_BUDGET + 1;
+	AsyncFileWriter writer(*con->context, fs, path);
+	{
+		auto batch_guard = writer.StartBatch();
+		for (idx_t write_idx = 0; write_idx < 4; write_idx++) {
+			writer.WriteData(make_uniq<StringAsyncWriteBuffer>(
+			    string(UnsafeNumericCast<size_t>(write_size), UnsafeNumericCast<char>('a' + write_idx))));
+		}
+		batch_guard.Finish();
+	}
+
+	auto saw_three_backend_writes = fs.WaitForBackendWrites(3);
+	std::this_thread::sleep_for(std::chrono::milliseconds(50));
+	auto entered_before_release = fs.EnteredBackendWrites();
+	fs.ReleaseAllWrites();
+	writer.Close();
+
+	REQUIRE(saw_three_backend_writes);
+	REQUIRE(entered_before_release == 3);
+	REQUIRE(fs.EnteredBackendWrites() == 4);
+	REQUIRE(fs.MaxActiveBackendWrites() == 3);
+	REQUIRE(fs.OpenFile(path, FileFlags::FILE_FLAGS_READ)->GetFileSize() == 4 * write_size);
+	fs.RemoveFile(path);
+}
+
+TEST_CASE("AsyncFileWriter uses concurrent-sequential offsets without async threads", "[async_file_writer]") {
+	DuckDB db(nullptr);
+	auto con = CreateConnectionWithNoAsyncThreads(db);
+	ConcurrentSequentialWriteFileSystem fs(false);
+	auto path = TestCreatePath("async_file_writer_sync_concurrent_sequential.tmp");
+	if (fs.FileExists(path)) {
+		fs.RemoveFile(path);
+	}
+
+	AsyncFileWriter writer(*con->context, fs, path);
+	writer.WriteData(const_data_ptr_cast("abcdef"), 6);
+	writer.Close();
+
+	REQUIRE(fs.AdmittedOffsets() == vector<idx_t> {0});
+	REQUIRE(fs.write_offsets == vector<idx_t> {0});
+	REQUIRE(ReadFile(path) == "abcdef");
+	fs.RemoveFile(path);
+}
+
 TEST_CASE("AsyncFileWriter waits for remote coalesce threshold before first drain", "[async_file_writer]") {
 	DuckDB db(nullptr);
 	auto con = CreateConnectionWithAsyncThreads(db, 2);
-	BlockingWriteFileSystem fs(true, false);
+	BlockingWriteFileSystem fs(FileWriteMode::POSITIONAL, false);
 	auto path = TestCreatePath("async_file_writer_remote_coalesce_start.tmp");
 	if (fs.FileExists(path)) {
 		fs.RemoveFile(path);
@@ -880,7 +1091,7 @@ TEST_CASE("AsyncFileWriter waits for remote coalesce threshold before first drai
 TEST_CASE("AsyncFileWriter coalesces remote non-positional writes", "[async_file_writer]") {
 	DuckDB db(nullptr);
 	auto con = CreateConnectionWithAsyncThreads(db, 2);
-	BlockingWriteFileSystem fs(false, false);
+	BlockingWriteFileSystem fs(FileWriteMode::SEQUENTIAL, false);
 	auto path = TestCreatePath("async_file_writer_remote_non_positional_coalesce.tmp");
 	if (fs.FileExists(path)) {
 		fs.RemoveFile(path);
@@ -909,7 +1120,7 @@ TEST_CASE("AsyncFileWriter coalesces remote non-positional writes", "[async_file
 TEST_CASE("AsyncFileWriter does not eagerly schedule tiny remote tails after one large write", "[async_file_writer]") {
 	DuckDB db(nullptr);
 	auto con = CreateConnectionWithAsyncThreads(db, 4);
-	BlockingWriteFileSystem fs(true, false);
+	BlockingWriteFileSystem fs(FileWriteMode::POSITIONAL, false);
 	auto path = TestCreatePath("async_file_writer_remote_large_then_tiny.tmp");
 	if (fs.FileExists(path)) {
 		fs.RemoveFile(path);
@@ -940,7 +1151,7 @@ TEST_CASE("AsyncFileWriter close force-drains remote non-positional tail after s
           "[async_file_writer]") {
 	DuckDB db(nullptr);
 	auto con = CreateConnectionWithAsyncThreads(db, 2);
-	BlockingWriteFileSystem fs(false, false);
+	BlockingWriteFileSystem fs(FileWriteMode::SEQUENTIAL, false);
 	auto path = TestCreatePath("async_file_writer_remote_non_positional_close_tail.tmp");
 	if (fs.FileExists(path)) {
 		fs.RemoveFile(path);
@@ -1065,7 +1276,7 @@ TEST_CASE("AsyncFileWriter does not treat sequential explicit-offset writes as p
 TEST_CASE("AsyncFileWriter rethrows non-positional async write errors on close", "[async_file_writer]") {
 	DuckDB db(nullptr);
 	auto con = CreateConnectionWithAsyncThreads(db, 1);
-	BlockingWriteFileSystem fs(false, false);
+	BlockingWriteFileSystem fs(FileWriteMode::SEQUENTIAL, false);
 	auto path = TestCreatePath("async_file_writer_non_positional_error.tmp");
 	if (fs.FileExists(path)) {
 		fs.RemoveFile(path);

--- a/test/common/test_async_file_writer.cpp
+++ b/test/common/test_async_file_writer.cpp
@@ -14,6 +14,35 @@
 
 using namespace duckdb;
 
+namespace duckdb {
+
+class ManagedAsyncWriteQueueTest {
+public:
+	static bool TryAdopt(ManagedAsyncWriteQueue &queue, AsyncWriteRequest &request, ErrorData &error) {
+		return queue.TryAdoptAccountedWrite(request, error) == ManagedAsyncWriteQueue::AccountedWriteAdoption::ACCEPTED;
+	}
+
+	static void AddExternalPendingBytes(ManagedAsyncWriteQueue &queue, idx_t size) {
+		queue.AddExternalPendingBytes(size);
+	}
+
+	static void DiscardExternalPendingBytes(ManagedAsyncWriteQueue &queue, idx_t size) {
+		queue.DiscardExternalPendingBytes(size);
+	}
+
+	static idx_t ExternalPendingBytes(ManagedAsyncWriteQueue &queue) {
+		lock_guard<mutex> guard(queue.lock);
+		return queue.external_pending_bytes;
+	}
+
+	static idx_t PendingBytes(ManagedAsyncWriteQueue &queue) {
+		lock_guard<mutex> guard(queue.lock);
+		return queue.pending_bytes;
+	}
+};
+
+} // namespace duckdb
+
 namespace {
 
 class TrackingWriteFileSystem : public LocalFileSystem {
@@ -236,14 +265,24 @@ public:
 			}
 		}
 
-		TrackingWriteFileSystem::Write(handle, buffer, nr_bytes, location);
-		{
-			lock_guard<mutex> guard(state_lock);
-			D_ASSERT(active_backend_writes > 0);
-			active_backend_writes--;
-			completed_offsets.push_back(location);
+		try {
+			TrackingWriteFileSystem::Write(handle, buffer, nr_bytes, location);
+			{
+				lock_guard<mutex> guard(state_lock);
+				D_ASSERT(active_backend_writes > 0);
+				active_backend_writes--;
+				completed_offsets.push_back(location);
+			}
+			state_cv.notify_all();
+		} catch (...) {
+			{
+				lock_guard<mutex> guard(state_lock);
+				D_ASSERT(active_backend_writes > 0);
+				active_backend_writes--;
+			}
+			state_cv.notify_all();
+			throw;
 		}
-		state_cv.notify_all();
 	}
 
 	bool WaitForBackendWrites(idx_t count) {
@@ -395,6 +434,60 @@ private:
 	string data;
 };
 
+class BlockingMaterializationState {
+public:
+	void Materialize() {
+		unique_lock<mutex> guard(lock);
+		entered = true;
+		cv.notify_all();
+		cv.wait(guard, [&]() { return released; });
+		if (fail) {
+			throw IOException("Injected payload materialization failure");
+		}
+	}
+
+	bool WaitForEntered() {
+		unique_lock<mutex> guard(lock);
+		return cv.wait_for(guard, std::chrono::seconds(5), [&]() { return entered; });
+	}
+
+	void Release(bool fail_p) {
+		{
+			lock_guard<mutex> guard(lock);
+			fail = fail_p;
+			released = true;
+		}
+		cv.notify_all();
+	}
+
+private:
+	mutex lock;
+	std::condition_variable cv;
+	bool entered = false;
+	bool released = false;
+	bool fail = false;
+};
+
+class BlockingMaterializationAsyncWriteBuffer : public AsyncWriteBuffer {
+public:
+	BlockingMaterializationAsyncWriteBuffer(string data_p, shared_ptr<BlockingMaterializationState> state_p)
+	    : data(std::move(data_p)), state(std::move(state_p)) {
+	}
+
+	data_ptr_t Ptr() override {
+		state->Materialize();
+		return data_ptr_cast(data.data());
+	}
+
+	idx_t Size() const override {
+		return data.size();
+	}
+
+private:
+	string data;
+	shared_ptr<BlockingMaterializationState> state;
+};
+
 class TrackingAsyncWriteTarget : public AsyncWriteTarget {
 public:
 	void Write(data_ptr_t buffer, idx_t size, idx_t offset) override {
@@ -406,6 +499,16 @@ public:
 	mutex lock;
 	vector<string> writes;
 	vector<idx_t> offsets;
+};
+
+class FailingAsyncWriteTarget : public AsyncWriteTarget {
+public:
+	void Write(data_ptr_t buffer, idx_t size, idx_t offset) override {
+		(void)buffer;
+		(void)size;
+		(void)offset;
+		throw IOException("Injected managed queue failure");
+	}
 };
 
 class BlockingAsyncWriteTarget : public AsyncWriteTarget {
@@ -540,6 +643,17 @@ static string ReadFile(const string &path) {
 	return result;
 }
 
+static string CaptureException(const std::function<void()> &action) {
+	try {
+		action();
+	} catch (const std::exception &ex) {
+		return ex.what();
+	} catch (...) {
+		return "unknown exception";
+	}
+	return string();
+}
+
 static unique_ptr<Connection> CreateConnectionWithAsyncThreads(DuckDB &db, idx_t async_threads = 1) {
 	auto con = make_uniq<Connection>(db);
 	REQUIRE_NO_FAIL(con->Query("SET async_threads=" + to_string(async_threads)));
@@ -651,6 +765,63 @@ TEST_CASE("ManagedAsyncWriteQueue accepts non-contiguous positional writes", "[a
 	}
 	REQUIRE(saw_first);
 	REQUIRE(saw_second);
+}
+
+TEST_CASE("ManagedAsyncWriteQueue reports accounted request adoption ownership", "[async_write_queue]") {
+	DuckDB db(nullptr);
+	auto con = CreateConnectionWithAsyncThreads(db);
+	{
+		TrackingAsyncWriteTarget target;
+		ManagedAsyncWriteQueue queue(*con->context, target);
+		idx_t completion_count = 0;
+		bool completion_error = false;
+		auto completion = [&](idx_t, idx_t, optional_ptr<const ErrorData> error) {
+			completion_count++;
+			completion_error = completion_error || error;
+		};
+		AsyncWriteRequest request(make_uniq<StringAsyncWriteBuffer>("abc"), 7, completion);
+
+		ManagedAsyncWriteQueueTest::AddExternalPendingBytes(queue, 3);
+		ErrorData acceptance_error;
+		auto adopted = ManagedAsyncWriteQueueTest::TryAdopt(queue, request, acceptance_error);
+		REQUIRE(adopted);
+		REQUIRE(!acceptance_error.HasError());
+		REQUIRE(request.payload == nullptr);
+		REQUIRE(ManagedAsyncWriteQueueTest::ExternalPendingBytes(queue) == 0);
+		REQUIRE(ManagedAsyncWriteQueueTest::PendingBytes(queue) == 3);
+
+		queue.SchedulePendingWrites(ManagedAsyncWriteQueue::SchedulePolicy::FORCE);
+		queue.Close();
+		REQUIRE(target.writes == vector<string> {"abc"});
+		REQUIRE(target.offsets == vector<idx_t> {7});
+		REQUIRE(completion_count == 1);
+		REQUIRE(!completion_error);
+	}
+
+	{
+		FailingAsyncWriteTarget target;
+		ManagedAsyncWriteQueue queue(*con->context, target);
+		queue.RegisterWrite(make_uniq<StringAsyncWriteBuffer>("failed"), 0);
+		auto wait_error = CaptureException([&]() { queue.WaitAll(); });
+		REQUIRE(wait_error.find("Injected managed queue failure") != string::npos);
+
+		idx_t completion_count = 0;
+		AsyncWriteRequest request(make_uniq<StringAsyncWriteBuffer>("abc"), 7,
+		                          [&](idx_t, idx_t, optional_ptr<const ErrorData>) { completion_count++; });
+		ManagedAsyncWriteQueueTest::AddExternalPendingBytes(queue, 3);
+		ErrorData rejection_error;
+		auto adopted = ManagedAsyncWriteQueueTest::TryAdopt(queue, request, rejection_error);
+		REQUIRE(!adopted);
+		REQUIRE(rejection_error.HasError());
+		REQUIRE(request.payload != nullptr);
+		REQUIRE(ManagedAsyncWriteQueueTest::ExternalPendingBytes(queue) == 3);
+		REQUIRE(ManagedAsyncWriteQueueTest::PendingBytes(queue) == 0);
+		REQUIRE(completion_count == 0);
+
+		ManagedAsyncWriteQueueTest::DiscardExternalPendingBytes(queue, 3);
+		auto close_error = CaptureException([&]() { queue.Close(); });
+		REQUIRE(close_error == wait_error);
+	}
 }
 
 static void TestQueuedDrainTaskCoversNewTinyTail(bool local_file, const string &path_name) {
@@ -1058,6 +1229,92 @@ TEST_CASE("AsyncFileWriter uses concurrent-sequential offsets without async thre
 	REQUIRE(fs.write_offsets == vector<idx_t> {0});
 	REQUIRE(ReadFile(path) == "abcdef");
 	fs.RemoveFile(path);
+}
+
+TEST_CASE("AsyncFileWriter stops concurrent-sequential publication after refill materialization failure",
+          "[async_file_writer]") {
+	DuckDB db(nullptr);
+	auto con = CreateConnectionWithAsyncThreads(db, 1);
+	ConcurrentSequentialWriteFileSystem fs;
+	auto path = TestCreatePath("async_file_writer_concurrent_sequential_materialization_error.tmp");
+	if (fs.FileExists(path)) {
+		fs.RemoveFile(path);
+	}
+
+	auto first_size = AsyncWriteConfig::DRAIN_TASK_BYTE_BUDGET + 1;
+	auto second_size = AsyncWriteConfig::REMOTE_COALESCE_THRESHOLD + 1;
+	auto materialization = make_shared_ptr<BlockingMaterializationState>();
+	AsyncFileWriter writer(*con->context, fs, path);
+	writer.WriteData(make_uniq<StringAsyncWriteBuffer>(string(UnsafeNumericCast<size_t>(first_size), 'a')));
+	auto first_entered = fs.WaitForBackendWrites(1);
+	writer.WriteData(make_uniq<BlockingMaterializationAsyncWriteBuffer>(
+	    string(UnsafeNumericCast<size_t>(second_size), 'b'), materialization));
+	writer.WriteData(make_uniq<StringAsyncWriteBuffer>("tail"));
+
+	fs.ReleaseAllWrites();
+	auto materialization_entered = materialization->WaitForEntered();
+	std::atomic<bool> wait_started(false);
+	std::atomic<bool> wait_finished(false);
+	string wait_error;
+	std::thread wait_thread([&]() {
+		wait_started.store(true);
+		wait_error = CaptureException([&]() { writer.WaitAll(); });
+		wait_finished.store(true);
+	});
+	while (!wait_started.load()) {
+		std::this_thread::yield();
+	}
+	std::this_thread::sleep_for(std::chrono::milliseconds(50));
+	auto wait_blocked_on_materialization = !wait_finished.load();
+	materialization->Release(true);
+	wait_thread.join();
+
+	auto write_error = CaptureException([&]() { writer.WriteData(make_uniq<StringAsyncWriteBuffer>("later")); });
+	auto close_error = CaptureException([&]() { writer.Close(); });
+	auto repeated_close_error = CaptureException([&]() { writer.Close(); });
+
+	REQUIRE(first_entered);
+	REQUIRE(materialization_entered);
+	REQUIRE(wait_blocked_on_materialization);
+	REQUIRE(wait_error.find("Injected payload materialization failure") != string::npos);
+	REQUIRE(write_error == wait_error);
+	REQUIRE(close_error == wait_error);
+	REQUIRE(repeated_close_error == wait_error);
+	REQUIRE(fs.EnteredBackendWrites() == 1);
+	if (fs.FileExists(path)) {
+		fs.RemoveFile(path);
+	}
+}
+
+TEST_CASE("AsyncFileWriter drains accepted concurrent-sequential writes before discarding a failed tail",
+          "[async_file_writer]") {
+	DuckDB db(nullptr);
+	auto con = CreateConnectionWithAsyncThreads(db, 2);
+	ConcurrentSequentialWriteFileSystem fs;
+	auto path = TestCreatePath("async_file_writer_concurrent_sequential_accepted_error.tmp");
+	if (fs.FileExists(path)) {
+		fs.RemoveFile(path);
+	}
+
+	auto write_size = AsyncWriteConfig::DRAIN_TASK_BYTE_BUDGET + 1;
+	AsyncFileWriter writer(*con->context, fs, path);
+	writer.WriteData(make_uniq<StringAsyncWriteBuffer>(string(UnsafeNumericCast<size_t>(write_size), 'a')));
+	writer.WriteData(make_uniq<StringAsyncWriteBuffer>(string(UnsafeNumericCast<size_t>(write_size), 'b')));
+	auto accepted_writes_entered = fs.WaitForBackendWrites(2);
+	writer.WriteData(make_uniq<StringAsyncWriteBuffer>("tail"));
+
+	fs.fail_writes = true;
+	fs.ReleaseAllWrites();
+	auto close_error = CaptureException([&]() { writer.Close(); });
+	auto repeated_close_error = CaptureException([&]() { writer.Close(); });
+
+	REQUIRE(accepted_writes_entered);
+	REQUIRE(close_error.find("Injected async write failure") != string::npos);
+	REQUIRE(repeated_close_error == close_error);
+	REQUIRE(fs.EnteredBackendWrites() == 2);
+	if (fs.FileExists(path)) {
+		fs.RemoveFile(path);
+	}
 }
 
 TEST_CASE("AsyncFileWriter waits for remote coalesce threshold before first drain", "[async_file_writer]") {

--- a/test/extension/debug_fs/debug_file_system.cpp
+++ b/test/extension/debug_fs/debug_file_system.cpp
@@ -194,9 +194,9 @@ idx_t DebugFileSystem::SeekPosition(FileHandle &handle) {
 	return inner.file_system.SeekPosition(inner);
 }
 
-bool DebugFileSystem::SupportsPositionalWrites(FileHandle &handle) {
+FileWriteMode DebugFileSystem::GetWriteMode(FileHandle &handle) {
 	auto &inner = *handle.Cast<DebugFileHandle>().inner;
-	return inner.file_system.SupportsPositionalWrites(inner);
+	return inner.file_system.GetWriteMode(inner);
 }
 
 bool DebugFileSystem::OnDiskFile(FileHandle &handle) {

--- a/test/extension/debug_fs/include/debug_file_system.hpp
+++ b/test/extension/debug_fs/include/debug_file_system.hpp
@@ -57,7 +57,7 @@ public:
 	void Seek(FileHandle &handle, idx_t location) override;
 	void Reset(FileHandle &handle) override;
 	idx_t SeekPosition(FileHandle &handle) override;
-	bool SupportsPositionalWrites(FileHandle &handle) override;
+	FileWriteMode GetWriteMode(FileHandle &handle) override;
 	bool OnDiskFile(FileHandle &handle) override;
 	bool Trim(FileHandle &handle, idx_t offset_bytes, idx_t length_bytes) override;
 	bool TryGetNetworkThroughput(FileHandle &handle, NetworkThroughputEstimate &result) override;


### PR DESCRIPTION
This PR replaces `FileSystem::SupportsPositionalWrites()` with `FileWriteMode` that distinguishes sequential, concurrent-sequential, and positional writes. This lets the async file writer represent different backend behaviour.

This PR only adds the core infrastructure. The local filesystem has positional writes and other filesystems remain sequential by default; HTTPFS will opt into concurrent-sequential writes (which is why I'm doing this - I'm blocked on the HTTPFS write rework).