### PR TITLE
Maintain better compatibility with older DuckDB versions in SETOF returning functions

### DIFF
--- a/extension/icu/icu-table-range.cpp
+++ b/extension/icu/icu-table-range.cpp
@@ -235,6 +235,7 @@ struct ICUTableRange {
 		                             nullptr, Bind<false>, nullptr, RangeDateTimeLocalInit);
 		range_function.in_out_function = ICUTableRangeFunction<false>;
 		range_function.cardinality = Cardinality;
+		range_function.return_type = TableFunctionReturnType::SET_RETURNING_FUNCTION;
 		range.AddFunction(range_function);
 
 		loader.RegisterFunction(range);

--- a/src/function/table/range.cpp
+++ b/src/function/table/range.cpp
@@ -396,6 +396,7 @@ void RangeTableFunction::RegisterFunction(BuiltinFunctions &set) {
 	range_function.cardinality = RangeCardinality;
 	range_function.is_repeatable = RangeIsRepeatable;
 	range_function.parallelism = TableFunctionParallelism::FORCE_SINGLE_THREADED;
+	range_function.return_type = TableFunctionReturnType::SET_RETURNING_FUNCTION;
 
 	// single argument range: (end) - implicit start = 0 and increment = 1
 	range.AddFunction(range_function);
@@ -411,6 +412,7 @@ void RangeTableFunction::RegisterFunction(BuiltinFunctions &set) {
 	range_in_out.cardinality = RangeDateTimeCardinality;
 	range_in_out.is_repeatable = RangeIsRepeatable;
 	range_in_out.parallelism = TableFunctionParallelism::FORCE_SINGLE_THREADED;
+	range_in_out.return_type = TableFunctionReturnType::SET_RETURNING_FUNCTION;
 	range.AddFunction(range_in_out);
 	set.AddFunction(range);
 	// generate_series: similar to range, but inclusive instead of exclusive bounds on the RHS

--- a/src/include/duckdb/planner/bind_context.hpp
+++ b/src/include/duckdb/planner/bind_context.hpp
@@ -119,6 +119,10 @@ public:
 	void AddGenericBinding(TableIndex index, const Identifier &alias, const vector<Identifier> &names,
 	                       const vector<LogicalType> &types);
 
+	//! Registers an alternative name for a column of the binding with the given index
+	//! The alias can be bound like a regular column, but is not emitted by *
+	void AddColumnAlias(TableIndex index, const Identifier &column_alias, column_t column_index);
+
 	//! Adds a base table with the given alias to the CTE BindContext.
 	//! We need this to correctly bind recursive CTEs with multiple references.
 	void AddCTEBinding(TableIndex index, BindingAlias alias, const vector<Identifier> &names,

--- a/src/include/duckdb/planner/table_binding.hpp
+++ b/src/include/duckdb/planner/table_binding.hpp
@@ -42,6 +42,11 @@ public:
 	bool TryGetBindingIndex(const Identifier &column_name, column_t &column_index);
 	column_t GetBindingIndex(const Identifier &column_name);
 	bool HasMatchingBinding(const Identifier &column_name);
+	//! Register an alternative name for an existing column - the alias can be bound, but is hidden from *
+	void AddColumnAlias(const Identifier &column_alias, column_t column_index);
+	//! Returns the name under which a column is registered in this binding (this can differ from the provided name
+	//! because of case insensitivity, or because the column is referenced through a column alias)
+	const Identifier &GetRegisteredColumnName(const Identifier &column_name);
 	virtual ErrorData ColumnNotFoundError(const Identifier &column_name) const;
 	virtual BindResult Bind(ColumnRefExpression &colref, idx_t depth);
 	virtual optional_ptr<StandardEntry> GetStandardEntry();
@@ -77,6 +82,8 @@ public:
 
 protected:
 	void Initialize();
+	//! Set the alias of the column reference to the name under which the column is registered in this binding
+	void SetBoundColumnAlias(ColumnRefExpression &colref);
 
 protected:
 	//! The type of Binding

--- a/src/planner/bind_context.cpp
+++ b/src/planner/bind_context.cpp
@@ -243,11 +243,11 @@ unique_ptr<ParsedExpression> BindContext::CreateColumnReference(const BindingAli
 	if (bind_type == ColumnBindType::EXPAND_GENERATED_COLUMNS && ColumnIsGenerated(*binding, column_index)) {
 		return ExpandGeneratedColumn(binding->Cast<TableBinding>(), column_name);
 	}
-	auto &column_names = binding->GetColumnNames();
-	if (column_index < column_names.size() && column_names[column_index] != column_name) {
+	auto &registered_name = binding->GetRegisteredColumnName(column_name);
+	if (registered_name != column_name) {
 		// because of case insensitivity in the binder we rename the column to the original name
 		// as it appears in the binding itself
-		result->SetAlias(column_names[column_index]);
+		result->SetAlias(registered_name);
 	}
 	return std::move(result);
 }
@@ -285,11 +285,11 @@ unique_ptr<ParsedExpression> BindContext::CreateColumnReference(const Identifier
 	if (bind_type == ColumnBindType::EXPAND_GENERATED_COLUMNS && ColumnIsGenerated(*binding, column_index)) {
 		return ExpandGeneratedColumn(binding->Cast<TableBinding>(), column_name);
 	}
-	auto &column_names = binding->GetColumnNames();
-	if (column_index < column_names.size() && column_names[column_index] != column_name) {
+	auto &registered_name = binding->GetRegisteredColumnName(column_name);
+	if (registered_name != column_name) {
 		// because of case insensitivity in the binder we rename the column to the original name
 		// as it appears in the binding itself
-		result->SetAlias(column_names[column_index]);
+		result->SetAlias(registered_name);
 	}
 	return std::move(result);
 }
@@ -783,6 +783,16 @@ void BindContext::AddSubquery(TableIndex index, const Identifier &alias, TableFu
 void BindContext::AddGenericBinding(TableIndex index, const Identifier &alias, const vector<Identifier> &names,
                                     const vector<LogicalType> &types) {
 	AddBinding(make_uniq<Binding>(BindingType::BASE, BindingAlias(alias), types, names, index));
+}
+
+void BindContext::AddColumnAlias(TableIndex index, const Identifier &column_alias, column_t column_index) {
+	for (auto &binding : bindings_list) {
+		if (binding->GetIndex() == index) {
+			binding->AddColumnAlias(column_alias, column_index);
+			return;
+		}
+	}
+	throw InternalException("AddColumnAlias - no binding found with the given table index");
 }
 
 void BindContext::AddCTEBinding(unique_ptr<CTEBinding> binding) {

--- a/src/planner/binder/tableref/bind_table_function.cpp
+++ b/src/planner/binder/tableref/bind_table_function.cpp
@@ -177,13 +177,28 @@ static string GetAlias(const TableFunctionRef &ref) {
 	return string();
 }
 
-static void ApplyPostgresSetofAliasCompatibility(const TableFunction &table_function, const TableFunctionRef &ref,
-                                                 vector<Identifier> &return_names) {
+//! Postgres names the single column of a set-returning function after the alias of the function
+//! (e.g. "SELECT t FROM generate_series(1, 2) t" returns the values, not a struct)
+//! returns the original column name, which is kept available as a column alias
+static Identifier ApplyPostgresSetofAliasCompatibility(const TableFunction &table_function, const TableFunctionRef &ref,
+                                                       vector<Identifier> &return_names) {
 	if (table_function.return_type != TableFunctionReturnType::SET_RETURNING_FUNCTION || ref.alias.empty() ||
 	    !ref.column_name_alias.empty() || return_names.size() != 1) {
+		return Identifier();
+	}
+	auto original_name = return_names[0];
+	return_names[0] = ref.alias;
+	return original_name;
+}
+
+//! Keep the original column name of a set-returning function bindable, e.g. "SELECT t.generate_series FROM
+//! generate_series(1, 2) t" - the original name is hidden from * since the column is emitted under the alias
+static void AddPostgresSetofColumnAlias(BindContext &bind_context, TableIndex bind_index,
+                                        const Identifier &original_name) {
+	if (original_name.empty()) {
 		return;
 	}
-	return_names[0] = ref.alias;
+	bind_context.AddColumnAlias(bind_index, original_name, 0);
 }
 
 BoundStatement Binder::BindTableFunctionInternal(TableFunction &table_function, const TableFunctionRef &ref,
@@ -221,9 +236,10 @@ BoundStatement Binder::BindTableFunctionInternal(TableFunction &table_function, 
 						    table_function.name);
 					}
 				}
-				ApplyPostgresSetofAliasCompatibility(table_function, ref, return_names);
+				auto setof_column_name = ApplyPostgresSetofAliasCompatibility(table_function, ref, return_names);
 				BoundStatement result;
 				bind_context.AddGenericBinding(bind_index, Identifier(function_name), return_names, new_plan->types);
+				AddPostgresSetofColumnAlias(bind_context, bind_index, setof_column_name);
 				result.names = return_names;
 				result.types = new_plan->types;
 				result.plan = std::move(new_plan);
@@ -284,7 +300,7 @@ BoundStatement Binder::BindTableFunctionInternal(TableFunction &table_function, 
 		throw InternalException("Failed to bind \"%s\": Table function must return at least one column",
 		                        table_function.name);
 	}
-	ApplyPostgresSetofAliasCompatibility(table_function, ref, return_names);
+	auto setof_column_name = ApplyPostgresSetofAliasCompatibility(table_function, ref, return_names);
 	// overwrite the names with any supplied aliases
 	for (idx_t i = 0; i < column_name_alias.size() && i < return_names.size(); i++) {
 		return_names[i] = column_name_alias[i];
@@ -317,6 +333,7 @@ BoundStatement Binder::BindTableFunctionInternal(TableFunction &table_function, 
 	if (ref.with_ordinality == OrdinalityType::WITH_ORDINALITY && correlated_columns.empty()) {
 		bind_context.AddTableFunction(bind_index, Identifier(function_name), return_names, return_types,
 		                              get->GetMutableColumnIds(), get->GetTable().get(), std::move(virtual_columns));
+		AddPostgresSetofColumnAlias(bind_context, bind_index, setof_column_name);
 
 		auto window_index = GenerateTableIndex();
 		auto window = make_uniq<duckdb::LogicalWindow>(window_index);
@@ -348,6 +365,7 @@ BoundStatement Binder::BindTableFunctionInternal(TableFunction &table_function, 
 	BoundStatement result;
 	bind_context.AddTableFunction(bind_index, Identifier(function_name), return_names, return_types,
 	                              get->GetMutableColumnIds(), get->GetTable().get(), std::move(virtual_columns));
+	AddPostgresSetofColumnAlias(bind_context, bind_index, setof_column_name);
 	result.names = std::move(return_names);
 	result.types = std::move(return_types);
 	result.plan = std::move(get);

--- a/src/planner/table_binding.cpp
+++ b/src/planner/table_binding.cpp
@@ -92,6 +92,27 @@ bool Binding::HasMatchingBinding(const Identifier &column_name) {
 	return TryGetBindingIndex(column_name, result);
 }
 
+void Binding::AddColumnAlias(const Identifier &column_alias, column_t column_index) {
+	D_ASSERT(column_index < names.size());
+	if (name_map.find(column_alias) != name_map.end()) {
+		// a column with this name already exists - the alias is not required
+		return;
+	}
+	name_map[column_alias] = column_index;
+}
+
+const Identifier &Binding::GetRegisteredColumnName(const Identifier &column_name) {
+	auto entry = name_map.find(column_name);
+	return entry == name_map.end() ? column_name : entry->first;
+}
+
+void Binding::SetBoundColumnAlias(ColumnRefExpression &colref) {
+	if (!colref.GetAlias().empty()) {
+		return;
+	}
+	colref.SetAlias(GetRegisteredColumnName(colref.GetColumnName()));
+}
+
 ErrorData Binding::ColumnNotFoundError(const Identifier &column_name) const {
 	return ErrorData(ExceptionType::BINDER, StringUtil::Format("Values list \"%s\" does not have a column named \"%s\"",
 	                                                           GetAlias(), column_name));
@@ -108,9 +129,7 @@ BindResult Binding::Bind(ColumnRefExpression &colref, idx_t depth) {
 	binding.table_index = index;
 	binding.column_index = ProjectionIndex(column_index);
 	LogicalType sql_type = types[column_index];
-	if (colref.GetAlias().empty()) {
-		colref.SetAlias(names[column_index]);
-	}
+	SetBoundColumnAlias(colref);
 	return BindResult(make_uniq<BoundColumnRefExpression>(Identifier(colref.GetName()), sql_type, binding, depth));
 }
 
@@ -288,9 +307,7 @@ BindResult TableBinding::Bind(ColumnRefExpression &colref, idx_t depth) {
 	} else {
 		// normal column: fetch type from base column
 		col_type = types[column_index];
-		if (colref.GetAlias().empty()) {
-			colref.SetAlias(names[column_index]);
-		}
+		SetBoundColumnAlias(colref);
 	}
 	ColumnBinding binding = GetColumnBinding(column_index);
 	return BindResult(make_uniq<BoundColumnRefExpression>(Identifier(colref.GetName()), col_type, binding, depth));

--- a/test/sql/table_function/postgres_setof_compatibility.test
+++ b/test/sql/table_function/postgres_setof_compatibility.test
@@ -46,3 +46,84 @@ select column_name, column_type from (describe select * from unnest([1, 2]) t(i)
 ----
 i	INTEGER
 
+# the original column name remains available as a column alias
+query I
+select i.generate_series from generate_series(1, 2) i;
+----
+1
+2
+
+query I
+select i.unnest from unnest([1, 2]) i;
+----
+1
+2
+
+query I
+select r.unnest from unnest(range(0, 3)) as r;
+----
+0
+1
+2
+
+query I
+select i.i from unnest([1, 2]) i;
+----
+1
+2
+
+# the name of the result column follows the name that is used to reference it
+query TT
+select column_name, column_type from (describe select i from unnest([1, 2]) i);
+----
+i	INTEGER
+
+query TT
+select column_name, column_type from (describe select i.unnest from unnest([1, 2]) i);
+----
+unnest	INTEGER
+
+# star expansion does not emit the original column name
+query TT
+select column_name, column_type from (describe select i.* from unnest([1, 2]) i);
+----
+i	INTEGER
+
+# explicit column aliases take precedence - the original name is not kept around
+statement error
+select t.unnest from unnest([1, 2]) t(v);
+----
+<REGEX>:Binder Error:.*
+
+# the alias can be identical to the original column name
+query I
+select unnest.unnest from unnest([1, 2]) unnest;
+----
+1
+2
+
+# lateral unnest
+statement ok
+create table lists as select * from (values (1, [10, 20]), (2, [30])) t(id, l);
+
+query II
+select lst.id, x.unnest from lists lst, unnest(lst.l) as x order by 1, 2;
+----
+1	10
+1	20
+2	30
+
+# with ordinality
+query II
+select g.generate_series, g.ordinality from generate_series(1, 3) with ordinality as g;
+----
+1	1
+2	2
+3	3
+
+query I
+select g from generate_series(1, 3) with ordinality as g;
+----
+1
+2
+3

--- a/test/sql/table_function/postgres_setof_compatibility.test
+++ b/test/sql/table_function/postgres_setof_compatibility.test
@@ -18,11 +18,23 @@ select column_name, column_type from (describe select * from generate_series(1, 
 ----
 i	BIGINT
 
+# range behaves like generate_series, even though Postgres does not have it
 query I
 select r from range(1, 3) r;
 ----
-{'range': 1}
-{'range': 2}
+1
+2
+
+query TT
+select column_name, column_type from (describe select * from range(1, 3) r);
+----
+r	BIGINT
+
+query I
+select r.range from range(1, 3) r;
+----
+1
+2
 
 query I
 select i from range(1, 3) r(i);


### PR DESCRIPTION
Follow-up to https://github.com/duckdb/duckdb/pull/22694

After the above PR this breaks:

```sql
select t.unnest from unnest([1,2,3]) t;
┌────────┐
│ unnest │
│ int32  │
├────────┤
│      1 │
│      2 │
│      3 │
└────────┘
```

Which used to be a common pattern in queries. This PR rectifies this by exposing the old `unnest` column as a virtual column, also for set-of returning functions, which allows this code to keep on working. 