### PR TITLE
Iterative benchmark runs and make report easier to understand

### DIFF
--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -141,10 +141,8 @@ jobs:
               python3 scripts/ci/retry.py -- wget -q https://blobs.duckdb.org/data/realnest/realnest.duckdb --output-document=duckdb_benchmark_data/real_nest.duckdb
           - name: Recursive CTE
             benchmark: benchmark/recursive_cte/recursive_cte.csv
-            regression_threshold_seconds: 0.01
           - name: AoC24
             benchmark: benchmark/aoc24/aoc24.csv
-            regression_threshold_seconds: 0.01
 
     steps:
       - uses: actions/checkout@v6
@@ -183,13 +181,9 @@ jobs:
 
       - name: Run regression benchmark
         run: |
-          extra_args=(--clear-benchmark-cache)
+          extra_args=(--benchmark-cache=clear)
           if [[ "${{ matrix.benchmark }}" == ".github/regression/realnest.csv" ]]; then
             extra_args=()
-          fi
-
-          if [[ -n "${{ matrix.regression_threshold_seconds }}" ]]; then
-            extra_args+=(--regression-threshold-seconds "${{ matrix.regression_threshold_seconds }}")
           fi
 
           python scripts/regression/test_runner.py \
@@ -260,9 +254,8 @@ jobs:
             --new build/current/release/benchmark/benchmark_runner \
             --benchmarks ${{ matrix.benchmarks }} \
             --verbose \
-            --clear-benchmark-cache \
+            --benchmark-cache=clear \
             --disable-timeout \
-            --max-timeout 3600 \
             --threads ${{ matrix.threads }}
 
   regression-bench-fivetran:
@@ -314,7 +307,7 @@ jobs:
 
       - name: Run regression benchmark
         run: |
-          python scripts/regression/test_runner.py --old build/base/release/benchmark/benchmark_runner --new build/current/release/benchmark/benchmark_runner --benchmarks benchmark/fivetran/benchmark_list.csv --verbose --threads 2 --clear-benchmark-cache
+          python scripts/regression/test_runner.py --old build/base/release/benchmark/benchmark_runner --new build/current/release/benchmark/benchmark_runner --benchmarks benchmark/fivetran/benchmark_list.csv --verbose --threads 2 --benchmark-cache=clear
 
   regression-test-storage:
     name: Storage Size Regression Test

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -141,11 +141,9 @@ jobs:
               python3 scripts/ci/retry.py -- wget -q https://blobs.duckdb.org/data/realnest/realnest.duckdb --output-document=duckdb_benchmark_data/real_nest.duckdb
           - name: Recursive CTE
             benchmark: benchmark/recursive_cte/recursive_cte.csv
-            timed_runs: 7
             regression_threshold_seconds: 0.01
           - name: AoC24
             benchmark: benchmark/aoc24/aoc24.csv
-            timed_runs: 7
             regression_threshold_seconds: 0.01
 
     steps:
@@ -190,9 +188,6 @@ jobs:
             extra_args=()
           fi
 
-          if [[ -n "${{ matrix.timed_runs }}" ]]; then
-            extra_args+=(--timed-runs "${{ matrix.timed_runs }}")
-          fi
           if [[ -n "${{ matrix.regression_threshold_seconds }}" ]]; then
             extra_args+=(--regression-threshold-seconds "${{ matrix.regression_threshold_seconds }}")
           fi
@@ -268,8 +263,7 @@ jobs:
             --clear-benchmark-cache \
             --disable-timeout \
             --max-timeout 3600 \
-            --threads ${{ matrix.threads }} \
-            --timed-runs 30
+            --threads ${{ matrix.threads }}
 
   regression-bench-fivetran:
     name: Bench Fivetran

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -191,6 +191,7 @@ jobs:
             --new build/current/release/benchmark/benchmark_runner \
             --benchmarks "${{ matrix.benchmark }}" \
             --verbose \
+            --early-stop \
             --threads 2 \
             "${extra_args[@]}"
 
@@ -254,6 +255,7 @@ jobs:
             --new build/current/release/benchmark/benchmark_runner \
             --benchmarks ${{ matrix.benchmarks }} \
             --verbose \
+            --early-stop \
             --benchmark-cache=clear \
             --disable-timeout \
             --threads ${{ matrix.threads }}
@@ -307,7 +309,7 @@ jobs:
 
       - name: Run regression benchmark
         run: |
-          python scripts/regression/test_runner.py --old build/base/release/benchmark/benchmark_runner --new build/current/release/benchmark/benchmark_runner --benchmarks benchmark/fivetran/benchmark_list.csv --verbose --threads 2 --benchmark-cache=clear
+          python scripts/regression/test_runner.py --old build/base/release/benchmark/benchmark_runner --new build/current/release/benchmark/benchmark_runner --benchmarks benchmark/fivetran/benchmark_list.csv --verbose --early-stop --threads 2 --benchmark-cache=clear
 
   regression-test-storage:
     name: Storage Size Regression Test

--- a/scripts/regression/benchmark.py
+++ b/scripts/regression/benchmark.py
@@ -1,14 +1,12 @@
-import subprocess
-import statistics
-from io import StringIO
 import csv
-from dataclasses import dataclass
-import argparse
-from typing import Optional, Union, Tuple, List
-import functools
 import os
+import subprocess
+from io import StringIO
+from typing import List, Optional, Tuple
 
-print = functools.partial(print, flush=True)
+
+DEFAULT_PROCESS_TIMEOUT = 600
+DISABLED_RUNNER_TIMEOUT = 3600
 
 STDERR_HEADER = '''====================================================
 ==============         STDERR          =============
@@ -20,232 +18,79 @@ STDOUT_HEADER = '''====================================================
 ====================================================
 '''
 
-# timeouts in seconds
-MAX_TIMEOUT = 3600
-DEFAULT_TIMEOUT = 600
-DEFAULT_TIMED_RUNS = 10
-
-
-@dataclass
-class BenchmarkRunnerConfig:
-    "Configuration for a BenchmarkRunner"
-
-    benchmark_runner: str
-    benchmark_file: str
-    verbose: bool = False
-    threads: Optional[int] = None
-    memory_limit: Optional[str] = None
-    disable_timeout: bool = False
-    max_timeout: int = MAX_TIMEOUT
-    root_dir: str = ""
-    no_summary: bool = False
-    timed_runs: Optional[int] = DEFAULT_TIMED_RUNS
-    runner_label: str = "benchmark"
-
-    @classmethod
-    def from_params(cls, benchmark_runner, benchmark_file, **kwargs) -> "BenchmarkRunnerConfig":
-        verbose = kwargs.get("verbose", False)
-        threads = kwargs.get("threads", None)
-        memory_limit = kwargs.get("memory_limit", None)
-        disable_timeout = kwargs.get("disable_timeout", False)
-        max_timeout = kwargs.get("max_timeout", MAX_TIMEOUT)
-        root_dir = kwargs.get("root_dir", "")
-        no_summary = kwargs.get("no_summary", False)
-        timed_runs = kwargs.get("timed_runs", DEFAULT_TIMED_RUNS)
-        runner_label = kwargs.get("runner_label", "benchmark")
-
-        config = cls(
-            benchmark_runner=benchmark_runner,
-            benchmark_file=benchmark_file,
-            verbose=verbose,
-            threads=threads,
-            memory_limit=memory_limit,
-            disable_timeout=disable_timeout,
-            max_timeout=max_timeout,
-            root_dir=root_dir,
-            no_summary=no_summary,
-            timed_runs=timed_runs,
-            runner_label=runner_label,
-        )
-        return config
-
-    @classmethod
-    def from_args(cls) -> "BenchmarkRunnerConfig":
-        parser = argparse.ArgumentParser(description="Benchmark script with old and new runners.")
-
-        # Define the arguments
-        parser.add_argument("--path", type=str, help="Path to the benchmark_runner executable", required=True)
-        parser.add_argument("--benchmarks", type=str, help="Path to the benchmark file.", required=True)
-        parser.add_argument("--verbose", action="store_true", help="Enable verbose output.")
-        parser.add_argument("--threads", type=int, help="Number of threads to use.")
-        parser.add_argument("--memory_limit", type=str, help="Memory limit to use.")
-        parser.add_argument("--disable-timeout", action="store_true", help="Disable timeout.")
-        parser.add_argument(
-            "--max-timeout", type=int, default=3600, help="Set maximum timeout in seconds (default: 3600)."
-        )
-        parser.add_argument("--root-dir", type=str, default="", help="Root directory.")
-        parser.add_argument(
-            "--no-summary", type=str, default=False, help="No failures summary is outputted when passing this flag."
-        )
-        parser.add_argument(
-            "--timed-runs",
-            type=int,
-            default=DEFAULT_TIMED_RUNS,
-            help=f"Number of timed runs per benchmark (default: {DEFAULT_TIMED_RUNS}).",
-        )
-
-        # Parse arguments
-        parsed_args = parser.parse_args()
-
-        # Create an instance of BenchmarkRunnerConfig using parsed arguments
-        config = cls(
-            benchmark_runner=parsed_args.path,
-            benchmark_file=parsed_args.benchmarks,
-            verbose=parsed_args.verbose,
-            threads=parsed_args.threads,
-            memory_limit=parsed_args.memory_limit,
-            disable_timeout=parsed_args.disable_timeout,
-            max_timeout=parsed_args.max_timeout,
-            root_dir=parsed_args.root_dir,
-            no_summary=parsed_args.no_summary,
-            timed_runs=parsed_args.timed_runs,
-        )
-        return config
-
 
 class BenchmarkRunner:
-    def __init__(self, config: BenchmarkRunnerConfig):
-        self.config = config
-        self.complete_timings = []
-        self.benchmark_list: List[str] = []
-        with open(self.config.benchmark_file, 'r') as f:
-            self.benchmark_list = [x.strip() for x in f.read().split('\n') if len(x) > 0]
-        self.supports_timed_runs = self.detect_timed_runs_support()
+    def __init__(
+        self,
+        path: str,
+        label: str,
+        threads: Optional[int] = None,
+        memory_limit: Optional[str] = None,
+        verbose: bool = False,
+        disable_timeout: bool = False,
+    ):
+        self.path = path
+        self.label = label
+        self.threads = threads
+        self.memory_limit = memory_limit
+        self.verbose = verbose
+        self.disable_timeout = disable_timeout
 
-    def detect_timed_runs_support(self):
-        if self.config.timed_runs is None:
-            return False
-        benchmark_args = [self.config.benchmark_runner]
-        if self.config.root_dir:
-            benchmark_args.extend(['--root-dir', self.config.root_dir])
-        benchmark_args.extend(["--help"])
+    def run(self, benchmark: str, timed_runs: int) -> Tuple[Optional[List[float]], Optional[str]]:
+        arguments = [self.path, benchmark]
+        if self.threads is not None:
+            arguments.append(f"--threads={self.threads}")
+        if self.memory_limit is not None:
+            arguments.append(f"--memory_limit={self.memory_limit}")
+        if self.disable_timeout:
+            arguments.append("--disable-timeout")
+        arguments.extend(["--timed-runs", str(timed_runs)])
+
+        process_timeout = DISABLED_RUNNER_TIMEOUT if self.disable_timeout else DEFAULT_PROCESS_TIMEOUT
         try:
-            proc = subprocess.run(
-                benchmark_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=DEFAULT_TIMEOUT
+            process = subprocess.run(
+                arguments,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=process_timeout,
+                text=True,
+                check=False,
             )
-            output = proc.stdout.decode('utf8') + proc.stderr.decode('utf8')
-            return "--timed-runs" in output
-        except:
-            return False
-
-    def construct_args(self, benchmark_path, timed_runs_override: Optional[int] = None):
-        benchmark_args = []
-        benchmark_args.extend([self.config.benchmark_runner, benchmark_path])
-        if self.config.root_dir:
-            benchmark_args.extend(['--root-dir', self.config.root_dir])
-        if self.config.threads:
-            benchmark_args.extend([f"--threads={self.config.threads}"])
-        if self.config.memory_limit:
-            benchmark_args.extend([f"--memory_limit={self.config.memory_limit}"])
-        if self.config.disable_timeout:
-            benchmark_args.extend(["--disable-timeout"])
-        if self.config.no_summary:
-            benchmark_args.extend(["--no-summary"])
-        timed_runs = self.config.timed_runs if timed_runs_override is None else timed_runs_override
-        if timed_runs is not None and self.supports_timed_runs:
-            benchmark_args.extend(["--timed-runs", str(timed_runs)])
-        return benchmark_args
-
-    def run_benchmark_once(
-        self, benchmark, timed_runs_override: Optional[int] = None
-    ) -> Tuple[Optional[List[float]], Optional[str]]:
-        benchmark_args = self.construct_args(benchmark, timed_runs_override)
-        timeout_seconds = DEFAULT_TIMEOUT
-        if self.config.disable_timeout:
-            timeout_seconds = self.config.max_timeout
-
-        try:
-            proc = subprocess.run(
-                benchmark_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=timeout_seconds
-            )
-            out = proc.stdout.decode('utf8')
-            err = proc.stderr.decode('utf8')
-            returncode = proc.returncode
         except subprocess.TimeoutExpired:
-            print("Failed to run benchmark " + benchmark)
-            print(f"Aborted due to exceeding the limit of {timeout_seconds} seconds")
-            return None, f"Aborted due to exceeding the limit of {timeout_seconds} seconds"
-        if returncode != 0:
-            print("Failed to run benchmark " + benchmark)
-            print(STDERR_HEADER)
-            print(err)
-            print(STDOUT_HEADER)
-            print(out)
-            if 'HTTP' in err:
-                print("Ignoring HTTP error and terminating the running of the regression tests")
-                exit(0)
-            return None, err
-        if self.config.verbose:
-            if os.getenv('CI') == 'true':
-                print(f"::group::raw output: {self.config.runner_label} {benchmark}")
-                print(err)
-                print("::endgroup::")
+            message = f"Aborted after exceeding the {process_timeout}-second process limit"
+            print(f"Failed to run benchmark {benchmark}: {message}", flush=True)
+            return None, message
+
+        if process.returncode != 0:
+            print(f"Failed to run benchmark {benchmark}", flush=True)
+            print(STDERR_HEADER, flush=True)
+            print(process.stderr, flush=True)
+            print(STDOUT_HEADER, flush=True)
+            print(process.stdout, flush=True)
+            return None, process.stderr or process.stdout or f"Benchmark runner exited with code {process.returncode}"
+
+        if self.verbose:
+            if os.getenv("CI") == "true":
+                print(f"::group::raw output: {self.label} {benchmark}", flush=True)
+                print(process.stderr, flush=True)
+                print("::endgroup::", flush=True)
             else:
-                print(err)
-        # read the input CSV
-        f = StringIO(err)
-        csv_reader = csv.reader(f, delimiter='\t')
-        header = True
+                print(process.stderr, flush=True)
+
         timings = []
         try:
-            for row in csv_reader:
-                if len(row) == 0:
-                    continue
-                if header:
-                    header = False
-                else:
+            rows = csv.reader(StringIO(process.stderr), delimiter='\t')
+            next(rows)
+            for row in rows:
+                if row:
                     timings.append(float(row[2]))
-            return timings, None
-        except:
-            print("Failed to run benchmark " + benchmark)
-            print(err)
-            return None, err
+        except (IndexError, StopIteration, ValueError) as exception:
+            message = f"Could not parse benchmark timings: {exception}"
+            print(f"Failed to run benchmark {benchmark}: {message}", flush=True)
+            return None, message
 
-    def complete_benchmark(self, benchmark, timings: List[float]) -> Tuple[Union[float, str], Optional[str]]:
-        if not timings:
-            return 'Failed to run benchmark ' + benchmark, "Benchmark did not produce any timings"
-        self.complete_timings.extend(timings)
-        return float(statistics.median(timings)), None
-
-    def run_benchmark(self, benchmark) -> Tuple[Union[float, str], Optional[str]]:
-        requested_runs = self.config.timed_runs if self.config.timed_runs is not None else 0
-        timings = []
-        while True:
-            run_timings, failure_message = self.run_benchmark_once(benchmark)
-            if failure_message:
-                return 'Failed to run benchmark ' + benchmark, failure_message
-            if not run_timings:
-                return 'Failed to run benchmark ' + benchmark, "Benchmark did not produce any timings"
-            timings.extend(run_timings)
-            if self.supports_timed_runs or len(timings) >= requested_runs:
-                break
-        return self.complete_benchmark(benchmark, timings)
-
-    def run_benchmarks(self, benchmark_list: List[str]):
-        results = {}
-        failures = {}
-        for benchmark in benchmark_list:
-            result, failure_message = self.run_benchmark(benchmark)
-            results[benchmark] = result
-            failures[benchmark] = failure_message if failure_message else None
-        return results, failures
-
-
-def main():
-    config = BenchmarkRunnerConfig.from_args()
-    runner = BenchmarkRunner(config)
-    runner.run_benchmarks(runner.benchmark_list)
-
-
-if __name__ == "__main__":
-    main()
+        if len(timings) != timed_runs:
+            message = f"Expected {timed_runs} benchmark timings, received {len(timings)}"
+            print(f"Failed to run benchmark {benchmark}: {message}", flush=True)
+            return None, message
+        return timings, None

--- a/scripts/regression/comparison.py
+++ b/scripts/regression/comparison.py
@@ -5,7 +5,7 @@ from typing import List, Tuple
 
 
 CONFIRMATION_TARGET_SECONDS = 3.0
-MIN_CONFIRMATION_RUNS = 15
+MIN_CONFIRMATION_RUNS = 30
 MAX_CONFIRMATION_RUNS = 100
 SAMPLE_BATCH_SIZE = 5
 
@@ -56,15 +56,13 @@ def benchmark_measurement(old_timings: List[float], new_timings: List[float]) ->
 
 def confirmation_run_count(measurement: BenchmarkMeasurement) -> int:
     faster_side_median = min(measurement.old_timing, measurement.new_timing)
-    estimated_runs = math.ceil(CONFIRMATION_TARGET_SECONDS / faster_side_median)
+    estimated_batches = math.ceil(CONFIRMATION_TARGET_SECONDS / faster_side_median / SAMPLE_BATCH_SIZE)
+    estimated_runs = estimated_batches * SAMPLE_BATCH_SIZE
     return max(MIN_CONFIRMATION_RUNS, min(MAX_CONFIRMATION_RUNS, estimated_runs))
 
 
 def sampling_batch_sizes(requested_runs: int) -> List[int]:
     if requested_runs <= 0:
         raise ValueError("Requested benchmark runs must be greater than zero")
-    full_batches, remainder = divmod(requested_runs, SAMPLE_BATCH_SIZE)
-    batch_sizes = [SAMPLE_BATCH_SIZE] * full_batches
-    if remainder:
-        batch_sizes.append(remainder)
-    return batch_sizes
+    batch_count = math.ceil(requested_runs / SAMPLE_BATCH_SIZE)
+    return [SAMPLE_BATCH_SIZE] * batch_count

--- a/scripts/regression/comparison.py
+++ b/scripts/regression/comparison.py
@@ -4,17 +4,15 @@ from dataclasses import dataclass
 from typing import List, Tuple
 
 
+CONFIRMATION_TARGET_SECONDS = 3.0
+MIN_CONFIRMATION_RUNS = 15
+MAX_CONFIRMATION_RUNS = 100
+
+
 @dataclass
-class PairedBenchmarkMeasurement:
+class BenchmarkMeasurement:
     old_timing: float
     new_timing: float
-    ratio: float
-    ratio_interval: Tuple[float, float]
-    runs: int
-
-
-@dataclass
-class RegressionMeasurement:
     ratio: float
     ratio_interval: Tuple[float, float]
     runs: int
@@ -39,61 +37,23 @@ def median_confidence_interval(values: List[float], confidence: float = 0.95) ->
     return ordered[lower_order - 1], ordered[count - lower_order]
 
 
-def validate_paired_timings(old_timings: List[float], new_timings: List[float]):
+def benchmark_measurement(old_timings: List[float], new_timings: List[float]) -> BenchmarkMeasurement:
     if not old_timings or len(old_timings) != len(new_timings):
         raise ValueError("Paired benchmark timings must be non-empty and have equal length")
     if any(not math.isfinite(timing) or timing <= 0 for timing in old_timings + new_timings):
         raise ValueError("Benchmark timings must be finite and greater than zero")
 
-
-def paired_measurement(old_timings: List[float], new_timings: List[float]) -> PairedBenchmarkMeasurement:
-    validate_paired_timings(old_timings, new_timings)
-
     ratios = [new_timing / old_timing for old_timing, new_timing in zip(old_timings, new_timings)]
-    old_timing = float(statistics.median(old_timings))
-    ratio = float(statistics.median(ratios))
-    return PairedBenchmarkMeasurement(
-        old_timing=old_timing,
-        new_timing=old_timing * ratio,
-        ratio=ratio,
-        ratio_interval=median_confidence_interval(ratios),
-        runs=len(ratios),
-    )
-
-
-def regression_measurement(
-    old_timings: List[float],
-    new_timings: List[float],
-    regression_threshold_percentage: float,
-    regression_threshold_seconds: float,
-) -> RegressionMeasurement:
-    validate_paired_timings(old_timings, new_timings)
-    if regression_threshold_percentage < 0 or regression_threshold_seconds < 0:
-        raise ValueError("Regression thresholds must not be negative")
-
-    threshold_multiplier = 1.0 + regression_threshold_percentage
-    ratios = [
-        new_timing / ((old_timing + regression_threshold_seconds) * threshold_multiplier)
-        for old_timing, new_timing in zip(old_timings, new_timings)
-    ]
-    return RegressionMeasurement(
+    return BenchmarkMeasurement(
+        old_timing=float(statistics.median(old_timings)),
+        new_timing=float(statistics.median(new_timings)),
         ratio=float(statistics.median(ratios)),
         ratio_interval=median_confidence_interval(ratios),
         runs=len(ratios),
     )
 
 
-def confirmation_run_count(
-    measurement: PairedBenchmarkMeasurement,
-    target_seconds: float,
-    minimum_runs: int,
-    maximum_runs: int,
-) -> int:
-    if target_seconds <= 0:
-        raise ValueError("Confirmation time must be greater than zero")
-    if minimum_runs <= 0 or maximum_runs < minimum_runs:
-        raise ValueError("Invalid confirmation run bounds")
-
-    faster_timing = min(measurement.old_timing, measurement.new_timing)
-    estimated_runs = math.ceil(target_seconds / faster_timing)
-    return max(minimum_runs, min(maximum_runs, estimated_runs))
+def confirmation_run_count(measurement: BenchmarkMeasurement) -> int:
+    faster_side_median = min(measurement.old_timing, measurement.new_timing)
+    estimated_runs = math.ceil(CONFIRMATION_TARGET_SECONDS / faster_side_median)
+    return max(MIN_CONFIRMATION_RUNS, min(MAX_CONFIRMATION_RUNS, estimated_runs))

--- a/scripts/regression/comparison.py
+++ b/scripts/regression/comparison.py
@@ -7,6 +7,7 @@ from typing import List, Tuple
 CONFIRMATION_TARGET_SECONDS = 3.0
 MIN_CONFIRMATION_RUNS = 15
 MAX_CONFIRMATION_RUNS = 100
+SAMPLE_BATCH_SIZE = 5
 
 
 @dataclass
@@ -57,3 +58,13 @@ def confirmation_run_count(measurement: BenchmarkMeasurement) -> int:
     faster_side_median = min(measurement.old_timing, measurement.new_timing)
     estimated_runs = math.ceil(CONFIRMATION_TARGET_SECONDS / faster_side_median)
     return max(MIN_CONFIRMATION_RUNS, min(MAX_CONFIRMATION_RUNS, estimated_runs))
+
+
+def sampling_batch_sizes(requested_runs: int) -> List[int]:
+    if requested_runs <= 0:
+        raise ValueError("Requested benchmark runs must be greater than zero")
+    full_batches, remainder = divmod(requested_runs, SAMPLE_BATCH_SIZE)
+    batch_sizes = [SAMPLE_BATCH_SIZE] * full_batches
+    if remainder:
+        batch_sizes.append(remainder)
+    return batch_sizes

--- a/scripts/regression/comparison.py
+++ b/scripts/regression/comparison.py
@@ -1,0 +1,97 @@
+import math
+import statistics
+from dataclasses import dataclass
+from typing import List, Tuple
+
+
+@dataclass
+class PairedBenchmarkMeasurement:
+    old_timing: float
+    new_timing: float
+    ratio: float
+    ratio_interval: Tuple[float, float]
+    runs: int
+
+
+@dataclass
+class SamplingDecision:
+    collect_more: bool
+    reason: str
+
+
+def median_confidence_interval(values: List[float], confidence: float = 0.95) -> Tuple[float, float]:
+    """Return a distribution-free confidence interval for the population median."""
+    if not values:
+        raise ValueError("Cannot compute a confidence interval without values")
+
+    ordered = sorted(values)
+    count = len(ordered)
+    lower_order = None
+    for order in range(1, count // 2 + 1):
+        tail_probability = sum(math.comb(count, index) for index in range(order)) / (2**count)
+        coverage = 1.0 - 2.0 * tail_probability
+        if coverage >= confidence:
+            lower_order = order
+
+    if lower_order is None:
+        return -math.inf, math.inf
+    return ordered[lower_order - 1], ordered[count - lower_order]
+
+
+def paired_measurement(old_timings: List[float], new_timings: List[float]) -> PairedBenchmarkMeasurement:
+    if not old_timings or len(old_timings) != len(new_timings):
+        raise ValueError("Paired benchmark timings must be non-empty and have equal length")
+    if any(not math.isfinite(timing) or timing <= 0 for timing in old_timings + new_timings):
+        raise ValueError("Benchmark timings must be finite and greater than zero")
+
+    ratios = [new_timing / old_timing for old_timing, new_timing in zip(old_timings, new_timings)]
+    old_timing = float(statistics.median(old_timings))
+    ratio = float(statistics.median(ratios))
+    return PairedBenchmarkMeasurement(
+        old_timing=old_timing,
+        new_timing=old_timing * ratio,
+        ratio=ratio,
+        ratio_interval=median_confidence_interval(ratios),
+        runs=len(ratios),
+    )
+
+
+def sampling_decision(
+    measurement: PairedBenchmarkMeasurement,
+    measured_seconds: float,
+    minimum_runs: int,
+    maximum_runs: int,
+    maximum_adaptive_seconds: float,
+    display_threshold_percentage: float,
+    regression_threshold_percentage: float,
+    regression_threshold_seconds: float,
+) -> SamplingDecision:
+    if measurement.runs < minimum_runs:
+        return SamplingDecision(True, "minimum timed runs not reached")
+    if measurement.runs >= maximum_runs:
+        return SamplingDecision(False, "maximum timed runs reached")
+    if measured_seconds >= maximum_adaptive_seconds:
+        return SamplingDecision(False, "adaptive timing budget reached")
+
+    display_ratio = display_threshold_percentage / 100.0
+    change = measurement.ratio - 1.0
+    lower_ratio, upper_ratio = measurement.ratio_interval
+    if abs(change) <= display_ratio:
+        return SamplingDecision(False, "old and new timings are within the display threshold")
+
+    if change < 0:
+        if upper_ratio < 1.0 - display_ratio:
+            return SamplingDecision(False, "improvement is statistically stable")
+        return SamplingDecision(True, "visible improvement is statistically uncertain")
+
+    regression_ratio = (
+        (measurement.old_timing + regression_threshold_seconds) * (1.0 + regression_threshold_percentage)
+    ) / measurement.old_timing
+    if measurement.ratio > regression_ratio:
+        if lower_ratio > regression_ratio:
+            return SamplingDecision(False, "regression is statistically stable")
+        return SamplingDecision(True, "regression is statistically uncertain")
+
+    if lower_ratio > 1.0 + display_ratio:
+        return SamplingDecision(False, "slowdown is statistically stable")
+    return SamplingDecision(True, "visible slowdown is statistically uncertain")

--- a/scripts/regression/comparison.py
+++ b/scripts/regression/comparison.py
@@ -1,7 +1,7 @@
 import math
 import statistics
 from dataclasses import dataclass
-from typing import List, Tuple
+from typing import List
 
 
 CONFIRMATION_TARGET_SECONDS = 3.0
@@ -13,29 +13,13 @@ SAMPLE_BATCH_SIZE = 5
 @dataclass
 class BenchmarkMeasurement:
     old_timing: float
+    old_min: float
+    old_max: float
     new_timing: float
+    new_min: float
+    new_max: float
     ratio: float
-    ratio_interval: Tuple[float, float]
     runs: int
-
-
-def median_confidence_interval(values: List[float], confidence: float = 0.95) -> Tuple[float, float]:
-    """Return a distribution-free confidence interval for the population median."""
-    if not values:
-        raise ValueError("Cannot compute a confidence interval without values")
-
-    ordered = sorted(values)
-    count = len(ordered)
-    lower_order = None
-    for order in range(1, count // 2 + 1):
-        tail_probability = sum(math.comb(count, index) for index in range(order)) / (2**count)
-        coverage = 1.0 - 2.0 * tail_probability
-        if coverage >= confidence:
-            lower_order = order
-
-    if lower_order is None:
-        return -math.inf, math.inf
-    return ordered[lower_order - 1], ordered[count - lower_order]
 
 
 def benchmark_measurement(old_timings: List[float], new_timings: List[float]) -> BenchmarkMeasurement:
@@ -44,13 +28,17 @@ def benchmark_measurement(old_timings: List[float], new_timings: List[float]) ->
     if any(not math.isfinite(timing) or timing <= 0 for timing in old_timings + new_timings):
         raise ValueError("Benchmark timings must be finite and greater than zero")
 
-    ratios = [new_timing / old_timing for old_timing, new_timing in zip(old_timings, new_timings)]
+    old_timing = float(statistics.median(old_timings))
+    new_timing = float(statistics.median(new_timings))
     return BenchmarkMeasurement(
-        old_timing=float(statistics.median(old_timings)),
-        new_timing=float(statistics.median(new_timings)),
-        ratio=float(statistics.median(ratios)),
-        ratio_interval=median_confidence_interval(ratios),
-        runs=len(ratios),
+        old_timing=old_timing,
+        old_min=min(old_timings),
+        old_max=max(old_timings),
+        new_timing=new_timing,
+        new_min=min(new_timings),
+        new_max=max(new_timings),
+        ratio=new_timing / old_timing,
+        runs=len(old_timings),
     )
 
 

--- a/scripts/regression/comparison.py
+++ b/scripts/regression/comparison.py
@@ -14,9 +14,10 @@ class PairedBenchmarkMeasurement:
 
 
 @dataclass
-class SamplingDecision:
-    collect_more: bool
-    reason: str
+class RegressionMeasurement:
+    ratio: float
+    ratio_interval: Tuple[float, float]
+    runs: int
 
 
 def median_confidence_interval(values: List[float], confidence: float = 0.95) -> Tuple[float, float]:
@@ -38,11 +39,15 @@ def median_confidence_interval(values: List[float], confidence: float = 0.95) ->
     return ordered[lower_order - 1], ordered[count - lower_order]
 
 
-def paired_measurement(old_timings: List[float], new_timings: List[float]) -> PairedBenchmarkMeasurement:
+def validate_paired_timings(old_timings: List[float], new_timings: List[float]):
     if not old_timings or len(old_timings) != len(new_timings):
         raise ValueError("Paired benchmark timings must be non-empty and have equal length")
     if any(not math.isfinite(timing) or timing <= 0 for timing in old_timings + new_timings):
         raise ValueError("Benchmark timings must be finite and greater than zero")
+
+
+def paired_measurement(old_timings: List[float], new_timings: List[float]) -> PairedBenchmarkMeasurement:
+    validate_paired_timings(old_timings, new_timings)
 
     ratios = [new_timing / old_timing for old_timing, new_timing in zip(old_timings, new_timings)]
     old_timing = float(statistics.median(old_timings))
@@ -56,42 +61,39 @@ def paired_measurement(old_timings: List[float], new_timings: List[float]) -> Pa
     )
 
 
-def sampling_decision(
-    measurement: PairedBenchmarkMeasurement,
-    measured_seconds: float,
-    minimum_runs: int,
-    maximum_runs: int,
-    maximum_adaptive_seconds: float,
-    display_threshold_percentage: float,
+def regression_measurement(
+    old_timings: List[float],
+    new_timings: List[float],
     regression_threshold_percentage: float,
     regression_threshold_seconds: float,
-) -> SamplingDecision:
-    if measurement.runs < minimum_runs:
-        return SamplingDecision(True, "minimum timed runs not reached")
-    if measurement.runs >= maximum_runs:
-        return SamplingDecision(False, "maximum timed runs reached")
-    if measured_seconds >= maximum_adaptive_seconds:
-        return SamplingDecision(False, "adaptive timing budget reached")
+) -> RegressionMeasurement:
+    validate_paired_timings(old_timings, new_timings)
+    if regression_threshold_percentage < 0 or regression_threshold_seconds < 0:
+        raise ValueError("Regression thresholds must not be negative")
 
-    display_ratio = display_threshold_percentage / 100.0
-    change = measurement.ratio - 1.0
-    lower_ratio, upper_ratio = measurement.ratio_interval
-    if abs(change) <= display_ratio:
-        return SamplingDecision(False, "old and new timings are within the display threshold")
+    threshold_multiplier = 1.0 + regression_threshold_percentage
+    ratios = [
+        new_timing / ((old_timing + regression_threshold_seconds) * threshold_multiplier)
+        for old_timing, new_timing in zip(old_timings, new_timings)
+    ]
+    return RegressionMeasurement(
+        ratio=float(statistics.median(ratios)),
+        ratio_interval=median_confidence_interval(ratios),
+        runs=len(ratios),
+    )
 
-    if change < 0:
-        if upper_ratio < 1.0 - display_ratio:
-            return SamplingDecision(False, "improvement is statistically stable")
-        return SamplingDecision(True, "visible improvement is statistically uncertain")
 
-    regression_ratio = (
-        (measurement.old_timing + regression_threshold_seconds) * (1.0 + regression_threshold_percentage)
-    ) / measurement.old_timing
-    if measurement.ratio > regression_ratio:
-        if lower_ratio > regression_ratio:
-            return SamplingDecision(False, "regression is statistically stable")
-        return SamplingDecision(True, "regression is statistically uncertain")
+def confirmation_run_count(
+    measurement: PairedBenchmarkMeasurement,
+    target_seconds: float,
+    minimum_runs: int,
+    maximum_runs: int,
+) -> int:
+    if target_seconds <= 0:
+        raise ValueError("Confirmation time must be greater than zero")
+    if minimum_runs <= 0 or maximum_runs < minimum_runs:
+        raise ValueError("Invalid confirmation run bounds")
 
-    if lower_ratio > 1.0 + display_ratio:
-        return SamplingDecision(False, "slowdown is statistically stable")
-    return SamplingDecision(True, "visible slowdown is statistically uncertain")
+    faster_timing = min(measurement.old_timing, measurement.new_timing)
+    estimated_runs = math.ceil(target_seconds / faster_timing)
+    return max(minimum_runs, min(maximum_runs, estimated_runs))

--- a/scripts/regression/test_comparison.py
+++ b/scripts/regression/test_comparison.py
@@ -9,136 +9,74 @@ import unittest
 from pathlib import Path
 
 from scripts.regression.comparison import (
+    benchmark_measurement,
     confirmation_run_count,
     median_confidence_interval,
-    paired_measurement,
-    regression_measurement,
 )
 
 
-class TestPairedComparison(unittest.TestCase):
+class TestBenchmarkComparison(unittest.TestCase):
     def test_median_confidence_interval(self):
-        lower, upper = median_confidence_interval(list(range(1, 21)))
-        self.assertEqual((lower, upper), (6, 15))
+        self.assertEqual(median_confidence_interval(list(range(1, 21))), (6, 15))
         self.assertEqual(median_confidence_interval([1.0] * 20), (1.0, 1.0))
-        self.assertEqual(median_confidence_interval([1.0] * 6), (1.0, 1.0))
         self.assertEqual(median_confidence_interval([1.0] * 4), (-math.inf, math.inf))
 
-    def test_q53_uses_paired_change_instead_of_pooled_medians(self):
-        old = [
-            0.015359,
-            0.015292,
-            0.014707,
-            0.014988,
-            0.014316,
-            0.015348,
-            0.014787,
-            0.014339,
-            0.014135,
-            0.014171,
-            0.016209,
-            0.015087,
-            0.015156,
-            0.014618,
-            0.014771,
-            0.016077,
-            0.014951,
-            0.015016,
-            0.014579,
-            0.014426,
-            0.020085,
-            0.019983,
-            0.021580,
-            0.021364,
-            0.022356,
-            0.021520,
-            0.021329,
-            0.019311,
-            0.020324,
-            0.024281,
-        ]
-        new = [
-            0.016120,
-            0.014158,
-            0.014453,
-            0.014663,
-            0.013699,
-            0.017042,
-            0.014953,
-            0.013993,
-            0.013678,
-            0.013685,
-            0.015336,
-            0.014745,
-            0.014687,
-            0.013690,
-            0.013658,
-            0.024608,
-            0.021533,
-            0.023831,
-            0.022940,
-            0.021340,
-            0.021216,
-            0.019005,
-            0.020576,
-            0.019424,
-            0.022571,
-            0.021240,
-            0.019692,
-            0.018916,
-            0.020069,
-            0.019921,
-        ]
+    def test_measurement_uses_paired_ratios_and_separate_medians(self):
+        old = [1.0, 2.0, 100.0]
+        new = [0.9, 1.8, 110.0]
+        measurement = benchmark_measurement(old, new)
+        self.assertEqual(measurement.old_timing, 2.0)
+        self.assertEqual(measurement.new_timing, 1.8)
+        self.assertAlmostEqual(measurement.ratio, 0.9)
 
-        measurement = paired_measurement(old, new)
-        pooled_new = sum(sorted(new)[14:16]) / 2
-        pooled_old = sum(sorted(old)[14:16]) / 2
-        self.assertAlmostEqual((pooled_new / pooled_old - 1.0) * 100.0, 18.1, places=1)
-        self.assertAlmostEqual((measurement.ratio - 1.0) * 100.0, -2.2, places=1)
+    def test_measurement_validation(self):
+        with self.assertRaises(ValueError):
+            benchmark_measurement([], [])
+        with self.assertRaises(ValueError):
+            benchmark_measurement([1.0], [1.0, 2.0])
+        with self.assertRaises(ValueError):
+            benchmark_measurement([0.0], [1.0])
+        with self.assertRaises(ValueError):
+            benchmark_measurement([1.0], [math.inf])
 
-    def test_regression_measurement_includes_both_thresholds(self):
-        below_threshold = regression_measurement([1.0] * 10, [1.15] * 10, 0.1, 0.05)
-        above_threshold = regression_measurement([1.0] * 10, [1.20] * 10, 0.1, 0.05)
-        self.assertLess(below_threshold.ratio, 1.0)
-        self.assertGreater(above_threshold.ratio, 1.0)
-        self.assertGreater(above_threshold.ratio_interval[0], 1.0)
-
-    def test_confirmation_runs_scale_with_runtime(self):
+    def test_confirmation_runs_scale_with_faster_side_median(self):
         cases = [
             (0.02, 100),
             (0.05, 60),
-            (0.1, 30),
-            (0.3, 15),
-            (0.5, 15),
-            (4.0, 15),
+            (0.10, 30),
+            (0.30, 15),
+            (0.50, 15),
+            (4.00, 15),
         ]
         for timing, expected_runs in cases:
             with self.subTest(timing=timing):
-                measurement = paired_measurement([timing] * 10, [timing * 1.01] * 10)
-                self.assertEqual(confirmation_run_count(measurement, 3.0, 15, 100), expected_runs)
-
-    def test_confirmation_run_validation(self):
-        measurement = paired_measurement([1.0] * 10, [1.0] * 10)
-        with self.assertRaises(ValueError):
-            confirmation_run_count(measurement, 0.0, 6, 100)
-        with self.assertRaises(ValueError):
-            confirmation_run_count(measurement, 3.0, 10, 6)
+                measurement = benchmark_measurement([timing] * 10, [timing * 1.2] * 10)
+                self.assertEqual(confirmation_run_count(measurement), expected_runs)
 
 
 class TestRegressionRunnerIntegration(unittest.TestCase):
     repository_root = Path(__file__).resolve().parents[2]
 
-    runner_source = """#!/usr/bin/env python3
+    stable_runner_source = """#!/usr/bin/env python3
 import os
 import sys
+from pathlib import Path
 
 label = os.path.basename(sys.argv[0])
-if "--help" in sys.argv:
-    print("--timed-runs")
-    raise SystemExit(0)
 runs = int(sys.argv[sys.argv.index("--timed-runs") + 1])
 with open(os.environ["BENCHMARK_ORDER_LOG"], "a", encoding="utf-8") as order_log:
-    order_log.write(label + "\\n")
+    order_log.write(f"{label}:{runs}\\n")
+cache_path = os.getenv("BENCHMARK_CACHE_PATH")
+expected_cache_state = os.getenv("EXPECTED_BENCHMARK_CACHE_STATE")
+if expected_cache_state:
+    actual_cache_state = "present" if Path(cache_path).exists() else "absent"
+    if actual_cache_state != expected_cache_state:
+        print(f"expected benchmark cache to be {expected_cache_state}, found {actual_cache_state}", file=sys.stderr)
+        raise SystemExit(1)
+expected_memory_limit = os.getenv("EXPECTED_MEMORY_LIMIT")
+if expected_memory_limit and f"--memory_limit={expected_memory_limit}" not in sys.argv:
+    print("memory limit was not forwarded", file=sys.stderr)
+    raise SystemExit(1)
 timing = float(os.environ["BENCHMARK_NEW_TIMING"]) if label == "new" else 1.0
 print("name\\trun\\ttiming", file=sys.stderr)
 for run in range(1, runs + 1):
@@ -151,12 +89,9 @@ import sys
 from pathlib import Path
 
 label = os.path.basename(sys.argv[0])
-if "--help" in sys.argv:
-    print("--timed-runs")
-    raise SystemExit(0)
 runs = int(sys.argv[sys.argv.index("--timed-runs") + 1])
 with open(os.environ["BENCHMARK_ORDER_LOG"], "a", encoding="utf-8") as order_log:
-    order_log.write(label + "\\n")
+    order_log.write(f"{label}:{runs}\\n")
 counter_path = Path(os.environ["BENCHMARK_COUNTER_DIR"]) / f"{label}.count"
 invocation = int(counter_path.read_text(encoding="utf-8")) if counter_path.exists() else 0
 counter_path.write_text(str(invocation + 1), encoding="utf-8")
@@ -172,12 +107,9 @@ import sys
 from pathlib import Path
 
 label = os.path.basename(sys.argv[0])
-if "--help" in sys.argv:
-    print("--timed-runs")
-    raise SystemExit(0)
 runs = int(sys.argv[sys.argv.index("--timed-runs") + 1])
 with open(os.environ["BENCHMARK_ORDER_LOG"], "a", encoding="utf-8") as order_log:
-    order_log.write(label + "\\n")
+    order_log.write(f"{label}:{runs}\\n")
 counter_path = Path(os.environ["BENCHMARK_COUNTER_DIR"]) / f"{label}.count"
 invocation = int(counter_path.read_text(encoding="utf-8")) if counter_path.exists() else 0
 counter_path.write_text(str(invocation + 1), encoding="utf-8")
@@ -192,11 +124,31 @@ for run in range(1, runs + 1):
     print(f"fake.benchmark\\t{run}\\t{timing}", file=sys.stderr)
 """
 
-    def run_regression_test(self, runner_source, new_timing="0.95", extra_args=None, ci=False):
+    malformed_runner_source = """#!/usr/bin/env python3
+import sys
+
+print("name\\trun\\ttiming", file=sys.stderr)
+print("not-a-valid-timing-row", file=sys.stderr)
+"""
+
+    def run_regression_test(
+        self,
+        runner_source,
+        new_timing="0.95",
+        extra_args=None,
+        ci=False,
+        create_cache=False,
+        expected_cache_state=None,
+        expected_memory_limit=None,
+    ):
         with tempfile.TemporaryDirectory() as temp_directory:
             temp_path = Path(temp_directory)
-            for label in ("old", "new"):
-                runner_path = temp_path / label
+            runner_paths = {
+                "old": temp_path / "build" / "base" / "release" / "benchmark" / "old",
+                "new": temp_path / "build" / "current" / "release" / "benchmark" / "new",
+            }
+            for label, runner_path in runner_paths.items():
+                runner_path.parent.mkdir(parents=True, exist_ok=True)
                 runner_path.write_text(runner_source, encoding="utf-8")
                 runner_path.chmod(runner_path.stat().st_mode | stat.S_IXUSR)
             benchmark_list = temp_path / "benchmarks.csv"
@@ -206,6 +158,15 @@ for run in range(1, runs + 1):
             env["BENCHMARK_ORDER_LOG"] = str(order_log)
             env["BENCHMARK_COUNTER_DIR"] = str(temp_path)
             env["BENCHMARK_NEW_TIMING"] = new_timing
+            if create_cache:
+                cache_path = temp_path / "build" / "duckdb_benchmark_data"
+                cache_path.mkdir()
+                (cache_path / "marker").write_text("cached", encoding="utf-8")
+                env["BENCHMARK_CACHE_PATH"] = str(cache_path)
+            if expected_cache_state:
+                env["EXPECTED_BENCHMARK_CACHE_STATE"] = expected_cache_state
+            if expected_memory_limit:
+                env["EXPECTED_MEMORY_LIMIT"] = expected_memory_limit
             if ci:
                 env["CI"] = "true"
 
@@ -213,9 +174,9 @@ for run in range(1, runs + 1):
                 sys.executable,
                 str(self.repository_root / "scripts/regression/test_runner.py"),
                 "--old",
-                str(temp_path / "old"),
+                str(runner_paths["old"]),
                 "--new",
-                str(temp_path / "new"),
+                str(runner_paths["new"]),
                 "--benchmarks",
                 str(benchmark_list),
                 "--verbose",
@@ -234,61 +195,99 @@ for run in range(1, runs + 1):
             order = order_log.read_text(encoding="utf-8").splitlines() if order_log.exists() else []
             return process, order
 
-    def test_non_regression_stops_after_initial_runs(self):
-        process, order = self.run_regression_test(self.runner_source)
+    def test_non_regression_stops_after_two_initial_batches(self):
+        process, order = self.run_regression_test(self.stable_runner_source)
         self.assertEqual(process.returncode, 0, process.stdout + process.stderr)
-        self.assertEqual(order, ["old", "new", "new", "old"])
+        self.assertEqual(order, ["old:5", "new:5", "new:5", "old:5"])
         plain_output = re.sub(r"\x1b\[[0-9;]*m", "", process.stdout)
-        self.assertIn(
-            "timing: 10 initial runs; regression confirmation targets 3s",
-            plain_output,
-        )
-        self.assertRegex(plain_output, r"fake\s+1\.000s\s+0\.950s\s+-0\.050s\s+-5\.0%\s+10")
+        self.assertIn("initial sampling: 10 runs per binary in 2 batches of 5", plain_output)
+        self.assertIn("geomean (initial 10 samples): 1.000s -> 0.950s  -5.0%", plain_output)
 
-    def test_stable_regression_is_confirmed(self):
-        process, order = self.run_regression_test(self.runner_source, new_timing="1.3")
+    def test_stable_regression_is_confirmed_from_independent_samples(self):
+        process, order = self.run_regression_test(self.stable_runner_source, new_timing="1.3")
         self.assertEqual(process.returncode, 1, process.stdout + process.stderr)
-        self.assertEqual(order, ["old", "new", "new", "old", "old", "new", "new", "old"])
+        self.assertEqual(
+            order,
+            ["old:5", "new:5", "new:5", "old:5", "old:8", "new:8", "new:7", "old:7"],
+        )
         plain_output = re.sub(r"\x1b\[[0-9;]*m", "", process.stdout)
         self.assertIn("regression confirmation: fake.benchmark: 15 paired runs", plain_output)
-        self.assertIn("confirmed regression", plain_output)
+        self.assertIn("95% CI for PR/base median ratio: 1.300x to 1.300x", plain_output)
+        self.assertIn("regression limit: 1.100x (confirmed regression)", plain_output)
         self.assertRegex(plain_output, r"fake\s+1\.000s\s+1\.300s\s+\+0\.300s\s+\+30\.0%\s+10\+15")
 
-    def test_rejected_regression_candidate_does_not_warn(self):
+    def test_nofail_reports_confirmed_regression_without_failing(self):
+        process, _ = self.run_regression_test(self.stable_runner_source, new_timing="1.3", extra_args=["--nofail"])
+        self.assertEqual(process.returncode, 0, process.stdout + process.stderr)
+        self.assertIn("regression detected", process.stdout)
+        self.assertIn("REGRESSIONS", process.stdout)
+
+    def test_benchmark_cache_is_kept_by_default(self):
+        process, _ = self.run_regression_test(
+            self.stable_runner_source,
+            create_cache=True,
+            expected_cache_state="present",
+        )
+        self.assertEqual(process.returncode, 0, process.stdout + process.stderr)
+
+    def test_benchmark_cache_can_be_cleared(self):
+        process, _ = self.run_regression_test(
+            self.stable_runner_source,
+            extra_args=["--benchmark-cache=clear"],
+            create_cache=True,
+            expected_cache_state="absent",
+        )
+        self.assertEqual(process.returncode, 0, process.stdout + process.stderr)
+
+    def test_memory_limit_is_forwarded_to_both_runners(self):
+        process, _ = self.run_regression_test(
+            self.stable_runner_source,
+            extra_args=["--memory-limit", "512MB"],
+            expected_memory_limit="512MB",
+        )
+        self.assertEqual(process.returncode, 0, process.stdout + process.stderr)
+
+    def test_rejected_candidate_uses_confirmation_for_row_and_initial_for_geomean(self):
         process, order = self.run_regression_test(self.rejected_candidate_runner_source, ci=True)
         self.assertEqual(process.returncode, 0, process.stdout + process.stderr)
-        self.assertEqual(order, ["old", "new", "new", "old", "old", "new", "new", "old"])
+        self.assertEqual(
+            order,
+            ["old:5", "new:5", "new:5", "old:5", "old:8", "new:8", "new:7", "old:7"],
+        )
         plain_output = re.sub(r"\x1b\[[0-9;]*m", "", process.stdout)
         self.assertIn("regression rejected", plain_output)
-        self.assertIn("UNCONFIRMED REGRESSION CANDIDATES\n0 benchmarks", plain_output)
-        self.assertNotIn("::warning title=Unconfirmed regression benchmark::", plain_output)
+        self.assertIn("geomean (initial 10 samples): 1.000s -> 1.300s  +30.0%", plain_output)
+        self.assertIn("INCONCLUSIVE REGRESSION CANDIDATES\n0 benchmarks", plain_output)
+        self.assertNotIn("::warning title=Inconclusive regression benchmark::", plain_output)
 
-    def test_inconclusive_regression_candidate_warns(self):
-        process, order = self.run_regression_test(self.inconclusive_candidate_runner_source, ci=True)
+    def test_inconclusive_candidate_warns_without_failing(self):
+        process, _ = self.run_regression_test(self.inconclusive_candidate_runner_source, ci=True)
         self.assertEqual(process.returncode, 0, process.stdout + process.stderr)
-        self.assertEqual(order, ["old", "new", "new", "old", "old", "new", "new", "old"])
         plain_output = re.sub(r"\x1b\[[0-9;]*m", "", process.stdout)
         self.assertIn("regression inconclusive", plain_output)
-        self.assertIn("UNCONFIRMED REGRESSION CANDIDATES", plain_output)
-        self.assertIn("::warning title=Unconfirmed regression benchmark::", plain_output)
+        self.assertIn("INCONCLUSIVE REGRESSION CANDIDATES", plain_output)
+        self.assertIn("::warning title=Inconclusive regression benchmark::", plain_output)
         self.assertIn("10+15", plain_output)
 
-    def test_runner_without_timed_run_support_fails_early(self):
-        runner_source = """#!/usr/bin/env python3
-import os
-import sys
-
-label = os.path.basename(sys.argv[0])
-if "--help" in sys.argv:
-    print("legacy benchmark runner")
-    raise SystemExit(0)
-with open(os.environ["BENCHMARK_ORDER_LOG"], "a", encoding="utf-8") as order_log:
-    order_log.write(label + "\\n")
-"""
-        process, order = self.run_regression_test(runner_source)
+    def test_malformed_runner_output_is_a_failure(self):
+        process, _ = self.run_regression_test(self.malformed_runner_source)
         self.assertEqual(process.returncode, 1, process.stdout + process.stderr)
-        self.assertIn("requires both benchmark runners to support --timed-runs", process.stdout)
+        self.assertIn("Could not parse benchmark timings", process.stdout)
+        self.assertIn("benchmark failure detected", process.stdout)
+
+    def test_removed_sampling_option_is_rejected(self):
+        process, order = self.run_regression_test(self.stable_runner_source, extra_args=["--initial-runs", "20"])
+        self.assertEqual(process.returncode, 2, process.stdout + process.stderr)
+        self.assertIn("unrecognized arguments: --initial-runs 20", process.stderr)
         self.assertEqual(order, [])
+
+    def test_removed_cache_flags_are_rejected(self):
+        for removed_flag in ("--clear-benchmark-cache", "--keep-benchmark-data"):
+            with self.subTest(removed_flag=removed_flag):
+                process, order = self.run_regression_test(self.stable_runner_source, extra_args=[removed_flag])
+                self.assertEqual(process.returncode, 2, process.stdout + process.stderr)
+                self.assertIn(f"unrecognized arguments: {removed_flag}", process.stderr)
+                self.assertEqual(order, [])
 
 
 if __name__ == "__main__":

--- a/scripts/regression/test_comparison.py
+++ b/scripts/regression/test_comparison.py
@@ -8,26 +8,18 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from scripts.regression.comparison import (
-    benchmark_measurement,
-    confirmation_run_count,
-    median_confidence_interval,
-    sampling_batch_sizes,
-)
+from scripts.regression.comparison import benchmark_measurement, confirmation_run_count, sampling_batch_sizes
 
 
 class TestBenchmarkComparison(unittest.TestCase):
-    def test_median_confidence_interval(self):
-        self.assertEqual(median_confidence_interval(list(range(1, 21))), (6, 15))
-        self.assertEqual(median_confidence_interval([1.0] * 20), (1.0, 1.0))
-        self.assertEqual(median_confidence_interval([1.0] * 4), (-math.inf, math.inf))
-
-    def test_measurement_uses_paired_ratios_and_separate_medians(self):
-        old = [1.0, 2.0, 100.0]
-        new = [0.9, 1.8, 110.0]
-        measurement = benchmark_measurement(old, new)
-        self.assertEqual(measurement.old_timing, 2.0)
-        self.assertEqual(measurement.new_timing, 1.8)
+    def test_measurement_uses_medians_and_observed_ranges(self):
+        measurement = benchmark_measurement([1.0, 10.0, 100.0], [0.9, 9.0, 200.0])
+        self.assertEqual(measurement.old_timing, 10.0)
+        self.assertEqual(measurement.old_min, 1.0)
+        self.assertEqual(measurement.old_max, 100.0)
+        self.assertEqual(measurement.new_timing, 9.0)
+        self.assertEqual(measurement.new_min, 0.9)
+        self.assertEqual(measurement.new_max, 200.0)
         self.assertAlmostEqual(measurement.ratio, 0.9)
 
     def test_measurement_validation(self):
@@ -41,30 +33,14 @@ class TestBenchmarkComparison(unittest.TestCase):
             benchmark_measurement([1.0], [math.inf])
 
     def test_confirmation_runs_scale_with_faster_side_median(self):
-        cases = [
-            (0.02, 100),
-            (0.05, 60),
-            (0.10, 30),
-            (0.30, 30),
-            (0.50, 30),
-            (4.00, 30),
-        ]
+        cases = [(0.02, 100), (0.05, 60), (0.10, 30), (0.30, 30), (4.00, 30)]
         for timing, expected_runs in cases:
             with self.subTest(timing=timing):
                 measurement = benchmark_measurement([timing] * 10, [timing * 1.2] * 10)
                 self.assertEqual(confirmation_run_count(measurement), expected_runs)
 
-    def test_sampling_batch_sizes(self):
-        cases = [
-            (1, [5]),
-            (4, [5]),
-            (5, [5]),
-            (6, [5, 5]),
-            (10, [5, 5]),
-            (15, [5, 5, 5]),
-            (84, [5] * 17),
-            (100, [5] * 20),
-        ]
+    def test_sampling_batches_round_up_to_five(self):
+        cases = [(1, [5]), (5, [5]), (6, [5, 5]), (12, [5, 5, 5]), (84, [5] * 17)]
         for requested_runs, expected_batches in cases:
             with self.subTest(requested_runs=requested_runs):
                 self.assertEqual(sampling_batch_sizes(requested_runs), expected_batches)
@@ -89,23 +65,31 @@ expected_cache_state = os.getenv("EXPECTED_BENCHMARK_CACHE_STATE")
 if expected_cache_state:
     actual_cache_state = "present" if Path(cache_path).exists() else "absent"
     if actual_cache_state != expected_cache_state:
-        print(f"expected benchmark cache to be {expected_cache_state}, found {actual_cache_state}", file=sys.stderr)
         raise SystemExit(1)
 expected_memory_limit = os.getenv("EXPECTED_MEMORY_LIMIT")
 if expected_memory_limit and f"--memory_limit={expected_memory_limit}" not in sys.argv:
-    print("memory limit was not forwarded", file=sys.stderr)
     raise SystemExit(1)
-timing = (
-    float(os.environ["BENCHMARK_NEW_TIMING"])
-    if label == "new"
-    else float(os.environ["BENCHMARK_OLD_TIMING"])
-)
+timing = float(os.environ["BENCHMARK_NEW_TIMING"] if label == "new" else os.environ["BENCHMARK_OLD_TIMING"])
 print("name\\trun\\ttiming", file=sys.stderr)
 for run in range(1, runs + 1):
-    print(f"fake.benchmark\\t{run}\\t{timing}", file=sys.stderr)
+    print(f"{sys.argv[1]}\\t{run}\\t{timing}", file=sys.stderr)
 """
 
-    rejected_candidate_runner_source = """#!/usr/bin/env python3
+    range_runner_source = """#!/usr/bin/env python3
+import os
+import sys
+
+label = os.path.basename(sys.argv[0])
+runs = int(sys.argv[sys.argv.index("--timed-runs") + 1])
+with open(os.environ["BENCHMARK_ORDER_LOG"], "a", encoding="utf-8") as order_log:
+    order_log.write(f"{label}:{runs}\\n")
+values = [0.229, 0.235, 0.244, 0.255, 0.267] if label == "new" else [0.219, 0.225, 0.231, 0.240, 0.248]
+print("name\\trun\\ttiming", file=sys.stderr)
+for run in range(1, runs + 1):
+    print(f"{sys.argv[1]}\\t{run}\\t{values[(run - 1) % len(values)]}", file=sys.stderr)
+"""
+
+    adaptive_early_stop_runner_source = """#!/usr/bin/env python3
 import os
 import sys
 from pathlib import Path
@@ -117,56 +101,10 @@ with open(os.environ["BENCHMARK_ORDER_LOG"], "a", encoding="utf-8") as order_log
 counter_path = Path(os.environ["BENCHMARK_COUNTER_DIR"]) / f"{label}.count"
 invocation = int(counter_path.read_text(encoding="utf-8")) if counter_path.exists() else 0
 counter_path.write_text(str(invocation + 1), encoding="utf-8")
-timing = 1.3 if label == "new" and invocation < 2 else 1.0
+timing = 1.03 if label == "new" and invocation < 2 else 1.0
 print("name\\trun\\ttiming", file=sys.stderr)
 for run in range(1, runs + 1):
-    print(f"fake.benchmark\\t{run}\\t{timing}", file=sys.stderr)
-"""
-
-    inconclusive_candidate_runner_source = """#!/usr/bin/env python3
-import os
-import sys
-from pathlib import Path
-
-label = os.path.basename(sys.argv[0])
-runs = int(sys.argv[sys.argv.index("--timed-runs") + 1])
-with open(os.environ["BENCHMARK_ORDER_LOG"], "a", encoding="utf-8") as order_log:
-    order_log.write(f"{label}:{runs}\\n")
-counter_path = Path(os.environ["BENCHMARK_COUNTER_DIR"]) / f"{label}.count"
-invocation = int(counter_path.read_text(encoding="utf-8")) if counter_path.exists() else 0
-counter_path.write_text(str(invocation + 1), encoding="utf-8")
-print("name\\trun\\ttiming", file=sys.stderr)
-for run in range(1, runs + 1):
-    if label == "old":
-        timing = 1.0
-    elif invocation < 2 or run not in (3, 5):
-        timing = 1.3
-    else:
-        timing = 1.0
-    print(f"fake.benchmark\\t{run}\\t{timing}", file=sys.stderr)
-"""
-
-    noisy_improvement_runner_source = """#!/usr/bin/env python3
-import os
-import sys
-from pathlib import Path
-
-label = os.path.basename(sys.argv[0])
-runs = int(sys.argv[sys.argv.index("--timed-runs") + 1])
-with open(os.environ["BENCHMARK_ORDER_LOG"], "a", encoding="utf-8") as order_log:
-    order_log.write(f"{label}:{runs}\\n")
-counter_path = Path(os.environ["BENCHMARK_COUNTER_DIR"]) / f"{label}.count"
-invocation = int(counter_path.read_text(encoding="utf-8")) if counter_path.exists() else 0
-counter_path.write_text(str(invocation + 1), encoding="utf-8")
-print("name\\trun\\ttiming", file=sys.stderr)
-for run in range(1, runs + 1):
-    if label == "old":
-        timing = 1.0
-    elif invocation < 2 or run not in (3, 5):
-        timing = 0.95
-    else:
-        timing = 1.0
-    print(f"fake.benchmark\\t{run}\\t{timing}", file=sys.stderr)
+    print(f"{sys.argv[1]}\\t{run}\\t{timing}", file=sys.stderr)
 """
 
     early_stop_after_twenty_runner_source = """#!/usr/bin/env python3
@@ -186,41 +124,27 @@ for run in range(1, runs + 1):
     if label == "old":
         timing = 1.0
     elif invocation < 2:
-        timing = 1.3
-    elif invocation < 4 and run == 1:
-        timing = 0.9
-    elif invocation < 4 and run == 2:
+        timing = 1.03
+    elif invocation < 4 and run <= 3:
         timing = 1.1
     else:
         timing = 1.0
-    print(f"fake.benchmark\\t{run}\\t{timing}", file=sys.stderr)
+    print(f"{sys.argv[1]}\\t{run}\\t{timing}", file=sys.stderr)
 """
 
-    wide_noise_runner_source = """#!/usr/bin/env python3
+    multi_query_runner_source = """#!/usr/bin/env python3
 import os
 import sys
-from pathlib import Path
 
 label = os.path.basename(sys.argv[0])
 runs = int(sys.argv[sys.argv.index("--timed-runs") + 1])
+benchmark = sys.argv[1]
 with open(os.environ["BENCHMARK_ORDER_LOG"], "a", encoding="utf-8") as order_log:
     order_log.write(f"{label}:{runs}\\n")
-counter_path = Path(os.environ["BENCHMARK_COUNTER_DIR"]) / f"{label}.count"
-invocation = int(counter_path.read_text(encoding="utf-8")) if counter_path.exists() else 0
-counter_path.write_text(str(invocation + 1), encoding="utf-8")
+timing = 1.1 if label == "new" and benchmark == "q1.benchmark" else 1.0
 print("name\\trun\\ttiming", file=sys.stderr)
 for run in range(1, runs + 1):
-    if label == "old":
-        timing = 1.0
-    elif invocation < 2:
-        timing = 1.3
-    elif run <= 2:
-        timing = 0.9
-    elif run == 3:
-        timing = 1.0
-    else:
-        timing = 1.1
-    print(f"fake.benchmark\\t{run}\\t{timing}", file=sys.stderr)
+    print(f"{benchmark}\\t{run}\\t{timing}", file=sys.stderr)
 """
 
     malformed_runner_source = """#!/usr/bin/env python3
@@ -237,9 +161,11 @@ print("not-a-valid-timing-row", file=sys.stderr)
         old_timing="1.0",
         extra_args=None,
         ci=False,
+        benchmarks=None,
         create_cache=False,
         expected_cache_state=None,
         expected_memory_limit=None,
+        step_summary=False,
     ):
         with tempfile.TemporaryDirectory() as temp_directory:
             temp_path = Path(temp_directory)
@@ -247,13 +173,14 @@ print("not-a-valid-timing-row", file=sys.stderr)
                 "old": temp_path / "build" / "base" / "release" / "benchmark" / "old",
                 "new": temp_path / "build" / "current" / "release" / "benchmark" / "new",
             }
-            for label, runner_path in runner_paths.items():
+            for runner_path in runner_paths.values():
                 runner_path.parent.mkdir(parents=True, exist_ok=True)
                 runner_path.write_text(runner_source, encoding="utf-8")
                 runner_path.chmod(runner_path.stat().st_mode | stat.S_IXUSR)
             benchmark_list = temp_path / "benchmarks.csv"
-            benchmark_list.write_text("fake.benchmark\n", encoding="utf-8")
+            benchmark_list.write_text("\n".join(benchmarks or ["fake.benchmark"]) + "\n", encoding="utf-8")
             order_log = temp_path / "order.log"
+            summary_path = temp_path / "summary.md"
             env = os.environ.copy()
             env["BENCHMARK_ORDER_LOG"] = str(order_log)
             env["BENCHMARK_COUNTER_DIR"] = str(temp_path)
@@ -270,6 +197,8 @@ print("not-a-valid-timing-row", file=sys.stderr)
                 env["EXPECTED_MEMORY_LIMIT"] = expected_memory_limit
             if ci:
                 env["CI"] = "true"
+            if step_summary:
+                env["GITHUB_STEP_SUMMARY"] = str(summary_path)
 
             command = [
                 sys.executable,
@@ -294,236 +223,168 @@ print("not-a-valid-timing-row", file=sys.stderr)
                 check=False,
             )
             order = order_log.read_text(encoding="utf-8").splitlines() if order_log.exists() else []
-            return process, order
+            summary = summary_path.read_text(encoding="utf-8") if summary_path.exists() else ""
+            return process, order, summary
 
     @staticmethod
-    def expected_order(confirmation_runs=0):
-        order = ["old:5", "new:5", "old:5", "new:5"]
-        if not confirmation_runs:
-            return order
-        for batch_size in sampling_batch_sizes(confirmation_runs):
-            order.extend([f"old:{batch_size}", f"new:{batch_size}"])
+    def expected_order(total_runs):
+        order = []
+        for batch_index, batch_size in enumerate(sampling_batch_sizes(total_runs)):
+            if batch_index % 2 == 0:
+                order.extend([f"old:{batch_size}", f"new:{batch_size}"])
+            else:
+                order.extend([f"new:{batch_size}", f"old:{batch_size}"])
         return order
 
-    def test_non_regression_stops_after_two_initial_batches(self):
-        process, order = self.run_regression_test(self.stable_runner_source)
+    def test_stable_adaptive_query_stops_after_initial_samples(self):
+        process, order, _ = self.run_regression_test(self.stable_runner_source)
         self.assertEqual(process.returncode, 0, process.stdout + process.stderr)
-        self.assertEqual(order, self.expected_order())
+        self.assertEqual(order, self.expected_order(10))
         plain_output = re.sub(r"\x1b\[[0-9;]*m", "", process.stdout)
-        self.assertNotIn("BENCHMARK QUERY RESULTS", plain_output)
-        self.assertIn("suite: 1 benchmarks", plain_output)
-        self.assertIn(
-            "sampling: 10 initial pairs; 30–100 confirmation pairs outside ±2%, with early noise stop",
-            plain_output,
-        )
-        self.assertIn("regression: fail when the 95% CI is above +10.0%", plain_output)
-        self.assertIn("median change +0.0% | within ±2%; done", plain_output)
-        self.assertIn("geomean: 1.000s -> 1.000s  +0.0%  (initial 10 samples)\nresult: no regressions", plain_output)
+        self.assertIn("sampling: adaptive; 10 initial pairs, then 30–100 confirmation pairs outside ±2%", plain_output)
+        self.assertIn("query regression: median change ≥ +10.0% (warning)", plain_output)
+        self.assertIn("CI failure: geomean change ≥ +10.0% or ≥ +50.0ms", plain_output)
+        self.assertNotIn("confidence", plain_output.lower())
+        self.assertNotIn("UNCERTAIN", plain_output)
         self.assertIn("UNCHANGED (±2%)\n1 benchmarks", plain_output)
-        self.assertNotIn("\nFASTER\n", plain_output)
-        self.assertNotIn("\nSLOWER (+2%…+10%)\n", plain_output)
-        self.assertNotIn("\nUNCERTAIN REGRESSIONS\n", plain_output)
-        self.assertNotIn("\nREGRESSIONS\n", plain_output)
-        self.assertLess(plain_output.index("UNCHANGED (±2%)"), plain_output.index("geomean:"))
-        self.assertTrue(plain_output.rstrip().endswith("result: no regressions"))
-        self.assertIn("\033[90msuite: 1 benchmarks\033[0m", process.stdout)
-        self.assertIn(
-            "\033[90msampling: 10 initial pairs; 30–100 confirmation pairs outside ±2%, "
-            "with early noise stop\033[0m",
-            process.stdout,
-        )
-        self.assertIn("\033[90mregression: fail when the 95% CI is above +10.0%\033[0m", process.stdout)
-        self.assertIn("\033[90mUNCHANGED (±2%)\033[0m\n\033[90m1 benchmarks\033[0m", process.stdout)
-        self.assertIn("  +0.0%  \033[90m(initial 10 samples)\033[0m", process.stdout)
-        self.assertIn("result: \033[32mno regressions\033[0m", process.stdout)
+        self.assertTrue(plain_output.rstrip().endswith("result: passed; no query regressions"))
 
-    def test_noise_boundaries_do_not_receive_confirmation_samples(self):
+    def test_noise_boundaries_are_inclusive(self):
         for new_timing in ("0.98", "1.02"):
             with self.subTest(new_timing=new_timing):
-                process, order = self.run_regression_test(self.stable_runner_source, new_timing=new_timing)
+                process, order, _ = self.run_regression_test(self.stable_runner_source, new_timing=new_timing)
                 self.assertEqual(process.returncode, 0, process.stdout + process.stderr)
-                self.assertEqual(order, self.expected_order())
+                self.assertEqual(order, self.expected_order(10))
+                plain_output = re.sub(r"\x1b\[[0-9;]*m", "", process.stdout)
+                self.assertIn("UNCHANGED (±2%)", plain_output)
 
-    def test_within_noise_geomean_uses_sign_color(self):
-        cases = [
-            ("0.999", "\033[32m-0.1%\033[0m"),
-            ("1.001", "\033[31m+0.1%\033[0m"),
-        ]
-        for new_timing, colored_change in cases:
-            with self.subTest(new_timing=new_timing):
-                process, order = self.run_regression_test(self.stable_runner_source, new_timing=new_timing)
-                self.assertEqual(process.returncode, 0, process.stdout + process.stderr)
-                self.assertEqual(order, self.expected_order())
-                self.assertIn(
-                    f"{colored_change}  \033[90m(initial 10 samples)\033[0m",
-                    process.stdout,
+    def test_adaptive_batches_alternate_and_full_budget_is_default(self):
+        process, order, _ = self.run_regression_test(self.stable_runner_source, new_timing="1.08")
+        self.assertEqual(process.returncode, 1, process.stdout + process.stderr)
+        self.assertEqual(order, self.expected_order(40))
+        plain_output = re.sub(r"\x1b\[[0-9;]*m", "", process.stdout)
+        self.assertIn("confirm: fake.benchmark: 30 pairs", plain_output)
+        self.assertIn("10+30", plain_output)
+        self.assertIn("result: failed; geomean regression; no query regressions", plain_output)
+
+    def test_adaptive_early_stop_after_ten_confirmation_samples(self):
+        process, order, _ = self.run_regression_test(
+            self.adaptive_early_stop_runner_source, extra_args=["--early-stop"]
+        )
+        self.assertEqual(process.returncode, 0, process.stdout + process.stderr)
+        self.assertEqual(order, self.expected_order(20))
+        self.assertIn(
+            "confirm: fake.benchmark: 10 pairs | median change +0.0% | within ±2% (stopped early)",
+            process.stdout,
+        )
+
+    def test_adaptive_early_stop_after_twenty_confirmation_samples(self):
+        process, order, _ = self.run_regression_test(
+            self.early_stop_after_twenty_runner_source, extra_args=["--early-stop"]
+        )
+        self.assertEqual(process.returncode, 0, process.stdout + process.stderr)
+        self.assertEqual(order, self.expected_order(30))
+        self.assertIn(
+            "confirm: fake.benchmark: 20 pairs | median change +0.0% | within ±2% (stopped early)",
+            process.stdout,
+        )
+
+    def test_fixed_samples_round_up_and_run_every_sample(self):
+        process, order, _ = self.run_regression_test(self.stable_runner_source, extra_args=["--samples", "12"])
+        self.assertEqual(process.returncode, 0, process.stdout + process.stderr)
+        self.assertEqual(order, self.expected_order(15))
+        plain_output = re.sub(r"\x1b\[[0-9;]*m", "", process.stdout)
+        self.assertIn("sampling: fixed; 15 samples per binary (--samples=12 rounded up)", plain_output)
+        self.assertIn("geomean: 1s -> 1s", plain_output)
+        self.assertIn("(15 samples)", plain_output)
+
+    def test_fixed_samples_can_early_stop(self):
+        process, order, _ = self.run_regression_test(
+            self.stable_runner_source, extra_args=["--samples", "30", "--early-stop"]
+        )
+        self.assertEqual(process.returncode, 0, process.stdout + process.stderr)
+        self.assertEqual(order, self.expected_order(10))
+        plain_output = re.sub(r"\x1b\[[0-9;]*m", "", process.stdout)
+        self.assertIn("sampling: fixed; 30 samples per binary (--samples=30); median early stop", plain_output)
+        self.assertIn("(up to 30 samples)", plain_output)
+
+    def test_compact_table_shows_gray_observed_ranges(self):
+        process, _, _ = self.run_regression_test(self.range_runner_source, extra_args=["--samples", "5"])
+        self.assertEqual(process.returncode, 0, process.stdout + process.stderr)
+        plain_output = re.sub(r"\x1b\[[0-9;]*m", "", process.stdout)
+        self.assertIn("benchmark  base median          PR median            delta median   runs", plain_output)
+        self.assertIn("fake       231ms [219ms…248ms]  244ms [229ms…267ms]  +13ms (+5.6%)", plain_output)
+        self.assertIn("231ms \033[90m[219ms…248ms]\033[0m", process.stdout)
+        self.assertIn("244ms \033[90m[229ms…267ms]\033[0m", process.stdout)
+
+    def test_exact_ten_percent_query_regression_warns_but_suite_can_pass(self):
+        benchmarks = ["q1.benchmark", "q2.benchmark", "q3.benchmark", "q4.benchmark", "q5.benchmark"]
+        process, _, summary = self.run_regression_test(
+            self.multi_query_runner_source,
+            ci=True,
+            benchmarks=benchmarks,
+            step_summary=True,
+        )
+        self.assertEqual(process.returncode, 0, process.stdout + process.stderr)
+        plain_output = re.sub(r"\x1b\[[0-9;]*m", "", process.stdout)
+        self.assertIn("::warning title=Benchmark query regression::", plain_output)
+        self.assertIn("REGRESSIONS (≥+10%)", plain_output)
+        self.assertIn("q1", plain_output)
+        self.assertTrue(plain_output.rstrip().endswith("result: passed; 1 query regression"))
+        self.assertIn("## Query Regressions", summary)
+        self.assertIn("| Benchmark | Base median | PR median | Delta median | Runs |", summary)
+        self.assertNotIn("confidence", summary.lower())
+
+    def test_geomean_relative_threshold_fails_ci(self):
+        process, _, _ = self.run_regression_test(self.stable_runner_source, old_timing="1", new_timing="1.1", ci=True)
+        self.assertEqual(process.returncode, 1, process.stdout + process.stderr)
+        self.assertIn("::error title=Geomean benchmark regression::", process.stdout)
+        self.assertIn("result: \033[31mfailed; geomean regression\033[0m", process.stdout)
+
+    def test_geomean_absolute_threshold_fails_ci(self):
+        process, _, _ = self.run_regression_test(self.stable_runner_source, old_timing="1", new_timing="1.05", ci=True)
+        self.assertEqual(process.returncode, 1, process.stdout + process.stderr)
+        self.assertIn("::error title=Geomean benchmark regression::", process.stdout)
+        self.assertIn("+50ms (+5.0%)", process.stdout)
+
+    def test_nofail_suppresses_only_geomean_gate(self):
+        process, _, _ = self.run_regression_test(
+            self.stable_runner_source, old_timing="1", new_timing="1.1", ci=True, extra_args=["--nofail"]
+        )
+        self.assertEqual(process.returncode, 0, process.stdout + process.stderr)
+        self.assertIn("::warning title=Geomean benchmark regression::", process.stdout)
+        self.assertIn("result: \033[32mpassed (--nofail)\033[0m", process.stdout)
+
+        process, _, _ = self.run_regression_test(self.malformed_runner_source, extra_args=["--nofail"])
+        self.assertEqual(process.returncode, 1, process.stdout + process.stderr)
+        self.assertIn("benchmark failure", process.stdout)
+
+    def test_invalid_samples_are_rejected(self):
+        for samples in ("0", "-1"):
+            with self.subTest(samples=samples):
+                process, order, _ = self.run_regression_test(
+                    self.stable_runner_source, extra_args=["--samples", samples]
                 )
+                self.assertEqual(process.returncode, 2, process.stdout + process.stderr)
+                self.assertIn("must be greater than zero", process.stderr)
+                self.assertEqual(order, [])
 
-    def test_improvement_receives_confirmation_and_is_classified_by_median(self):
-        process, order = self.run_regression_test(self.noisy_improvement_runner_source)
-        self.assertEqual(process.returncode, 0, process.stdout + process.stderr)
-        self.assertEqual(order, self.expected_order(30))
-        plain_output = re.sub(r"\x1b\[[0-9;]*m", "", process.stdout)
-        self.assertIn(
-            "initial: fake.benchmark: 10 pairs | median change -5.0% | confirming with 30 pairs", plain_output
-        )
-        self.assertIn(
-            "confirm: fake.benchmark: 30 pairs | median change -5.0% | 95% CI -5.0%…+0.0% | "
-            "faster (uncertain; budget exhausted)",
-            plain_output,
-        )
-        self.assertRegex(
-            plain_output,
-            r"FASTER\nbenchmark[^\n]*\n-+[^\n]*\nfake\s+1\.000s\s+0\.950s\s+-0\.050s\s+-5\.0%\s+"
-            r"-5\.0%…\+0\.0%\s+uncertain\s+10\+30",
-        )
-        self.assertIn("geomean: 1.000s -> 0.950s  -5.0%  (initial 10 samples)", plain_output)
-        self.assertIn("\033[32m-5.0%\033[0m  \033[90m(initial 10 samples)\033[0m", process.stdout)
-
-    def test_slowdown_below_regression_limit_receives_confirmation(self):
-        process, order = self.run_regression_test(self.stable_runner_source, new_timing="1.08", ci=True)
-        self.assertEqual(process.returncode, 0, process.stdout + process.stderr)
-        self.assertEqual(order, self.expected_order(30))
-        plain_output = re.sub(r"\x1b\[[0-9;]*m", "", process.stdout)
-        self.assertIn("median change +8.0% | 95% CI +8.0%…+8.0% | slower (confident)", plain_output)
-        self.assertRegex(
-            plain_output,
-            r"SLOWER \(\+2%…\+10%\)\nbenchmark[^\n]*\n-+[^\n]*\nfake\s+1\.000s\s+1\.080s\s+"
-            r"\+0\.080s\s+\+8\.0%\s+\+8\.0%…\+8\.0%\s+confident\s+10\+30",
-        )
-        self.assertNotIn("::warning title=Inconclusive regression benchmark::", plain_output)
-        self.assertIn("\033[31m+8.0%\033[0m  \033[90m(initial 10 samples)\033[0m", process.stdout)
-
-    def test_stable_regression_is_confirmed_from_independent_samples(self):
-        process, order = self.run_regression_test(self.stable_runner_source, new_timing="1.3")
-        self.assertEqual(process.returncode, 1, process.stdout + process.stderr)
-        self.assertEqual(order, self.expected_order(30))
-        plain_output = re.sub(r"\x1b\[[0-9;]*m", "", process.stdout)
-        self.assertIn(
-            "confirm: fake.benchmark: 30 pairs | median change +30.0% | 95% CI +30.0%…+30.0% | "
-            "regression (confirmed)",
-            plain_output,
-        )
-        self.assertRegex(
-            plain_output,
-            r"fake\s+1\.000s\s+1\.300s\s+\+0\.300s\s+\+30\.0%\s+\+30\.0%…\+30\.0%\s+" r"confirmed regression\s+10\+30",
-        )
-        self.assertIn("result: \033[31mregression detected\033[0m", process.stdout)
-
-    def test_confirmation_uses_fixed_five_run_batches_and_rounds_up(self):
-        process, order = self.run_regression_test(
+    def test_benchmark_cache_and_memory_limit_options_are_preserved(self):
+        process, _, _ = self.run_regression_test(
             self.stable_runner_source,
-            old_timing="0.036",
-            new_timing="0.045",
-        )
-        self.assertEqual(process.returncode, 1, process.stdout + process.stderr)
-        self.assertEqual(order, self.expected_order(85))
-        self.assertTrue(all(entry.endswith(":5") for entry in order))
-        plain_output = re.sub(r"\x1b\[[0-9;]*m", "", process.stdout)
-        self.assertIn(
-            "initial: fake.benchmark: 10 pairs | median change +25.0% | confirming with 85 pairs",
-            plain_output,
-        )
-        self.assertIn("confirm: fake.benchmark: 85 pairs", plain_output)
-        self.assertIn("10+85", plain_output)
-
-    def test_nofail_reports_confirmed_regression_without_failing(self):
-        process, _ = self.run_regression_test(self.stable_runner_source, new_timing="1.3", extra_args=["--nofail"])
-        self.assertEqual(process.returncode, 0, process.stdout + process.stderr)
-        self.assertIn("regression detected", process.stdout)
-        self.assertIn("REGRESSIONS", process.stdout)
-
-    def test_benchmark_cache_is_kept_by_default(self):
-        process, _ = self.run_regression_test(
-            self.stable_runner_source,
-            create_cache=True,
-            expected_cache_state="present",
-        )
-        self.assertEqual(process.returncode, 0, process.stdout + process.stderr)
-
-    def test_benchmark_cache_can_be_cleared(self):
-        process, _ = self.run_regression_test(
-            self.stable_runner_source,
-            extra_args=["--benchmark-cache=clear"],
+            extra_args=["--benchmark-cache=clear", "--memory-limit", "512MB"],
             create_cache=True,
             expected_cache_state="absent",
-        )
-        self.assertEqual(process.returncode, 0, process.stdout + process.stderr)
-
-    def test_memory_limit_is_forwarded_to_both_runners(self):
-        process, _ = self.run_regression_test(
-            self.stable_runner_source,
-            extra_args=["--memory-limit", "512MB"],
             expected_memory_limit="512MB",
         )
         self.assertEqual(process.returncode, 0, process.stdout + process.stderr)
 
-    def test_rejected_candidate_uses_confirmation_for_row_and_initial_for_geomean(self):
-        process, order = self.run_regression_test(self.rejected_candidate_runner_source, ci=True)
-        self.assertEqual(process.returncode, 0, process.stdout + process.stderr)
-        self.assertEqual(order, self.expected_order(10))
-        plain_output = re.sub(r"\x1b\[[0-9;]*m", "", process.stdout)
-        self.assertIn("within ±2% (confident; stopped early)", plain_output)
-        self.assertIn("geomean: 1.000s -> 1.300s  +30.0%  (initial 10 samples)", plain_output)
-        self.assertNotIn("UNCERTAIN REGRESSIONS", plain_output)
-        self.assertNotIn("::warning title=Inconclusive regression benchmark::", plain_output)
-
-    def test_confirmation_stops_after_twenty_pairs_when_noise_ci_becomes_confident(self):
-        process, order = self.run_regression_test(self.early_stop_after_twenty_runner_source)
-        self.assertEqual(process.returncode, 0, process.stdout + process.stderr)
-        self.assertEqual(order, self.expected_order(20))
-        plain_output = re.sub(r"\x1b\[[0-9;]*m", "", process.stdout)
-        self.assertIn(
-            "confirm: fake.benchmark: 20 pairs | median change +0.0% | 95% CI +0.0%…+0.0% | "
-            "within ±2% (confident; stopped early)",
-            plain_output,
-        )
-
-    def test_confirmation_does_not_stop_when_median_is_noise_but_ci_is_wide(self):
-        process, order = self.run_regression_test(self.wide_noise_runner_source)
-        self.assertEqual(process.returncode, 0, process.stdout + process.stderr)
-        self.assertEqual(order, self.expected_order(30))
-        plain_output = re.sub(r"\x1b\[[0-9;]*m", "", process.stdout)
-        self.assertIn(
-            "confirm: fake.benchmark: 30 pairs | median change +0.0% | 95% CI -10.0%…+10.0% | " "within ±2%; no change",
-            plain_output,
-        )
-
-    def test_inconclusive_candidate_warns_without_failing(self):
-        process, _ = self.run_regression_test(self.inconclusive_candidate_runner_source, ci=True)
-        self.assertEqual(process.returncode, 0, process.stdout + process.stderr)
-        plain_output = re.sub(r"\x1b\[[0-9;]*m", "", process.stdout)
-        self.assertIn("regression (uncertain; budget exhausted)", plain_output)
-        self.assertIn("UNCERTAIN REGRESSIONS", plain_output)
-        self.assertIn("::warning title=Inconclusive regression benchmark::", plain_output)
-        self.assertIn("10+30", plain_output)
-        self.assertIn("result: \033[33muncertain regressions\033[0m", process.stdout)
-        self.assertLess(plain_output.index("UNCERTAIN REGRESSIONS"), plain_output.index("geomean:"))
-        self.assertTrue(plain_output.rstrip().endswith("result: uncertain regressions"))
-
-    def test_malformed_runner_output_is_a_failure(self):
-        process, _ = self.run_regression_test(self.malformed_runner_source)
+    def test_failure_details_precede_final_result(self):
+        process, _, _ = self.run_regression_test(self.malformed_runner_source)
         self.assertEqual(process.returncode, 1, process.stdout + process.stderr)
-        self.assertIn("Could not parse benchmark timings", process.stdout)
-        self.assertIn("benchmark failure", process.stdout)
-        self.assertIn("result: \033[31mbenchmark failure\033[0m", process.stdout)
         plain_output = re.sub(r"\x1b\[[0-9;]*m", "", process.stdout)
         self.assertLess(plain_output.index("FAILURES SUMMARY"), plain_output.index("geomean:"))
-        self.assertTrue(plain_output.rstrip().endswith("result: benchmark failure"))
-
-    def test_removed_sampling_option_is_rejected(self):
-        process, order = self.run_regression_test(self.stable_runner_source, extra_args=["--initial-runs", "20"])
-        self.assertEqual(process.returncode, 2, process.stdout + process.stderr)
-        self.assertIn("unrecognized arguments: --initial-runs 20", process.stderr)
-        self.assertEqual(order, [])
-
-    def test_removed_cache_flags_are_rejected(self):
-        for removed_flag in ("--clear-benchmark-cache", "--keep-benchmark-data"):
-            with self.subTest(removed_flag=removed_flag):
-                process, order = self.run_regression_test(self.stable_runner_source, extra_args=[removed_flag])
-                self.assertEqual(process.returncode, 2, process.stdout + process.stderr)
-                self.assertIn(f"unrecognized arguments: {removed_flag}", process.stderr)
-                self.assertEqual(order, [])
+        self.assertTrue(plain_output.rstrip().endswith("result: failed; benchmark failure; no query regressions"))
 
 
 if __name__ == "__main__":

--- a/scripts/regression/test_comparison.py
+++ b/scripts/regression/test_comparison.py
@@ -12,6 +12,7 @@ from scripts.regression.comparison import (
     benchmark_measurement,
     confirmation_run_count,
     median_confidence_interval,
+    sampling_batch_sizes,
 )
 
 
@@ -53,6 +54,23 @@ class TestBenchmarkComparison(unittest.TestCase):
                 measurement = benchmark_measurement([timing] * 10, [timing * 1.2] * 10)
                 self.assertEqual(confirmation_run_count(measurement), expected_runs)
 
+    def test_sampling_batch_sizes(self):
+        cases = [
+            (1, [1]),
+            (4, [4]),
+            (5, [5]),
+            (6, [5, 1]),
+            (10, [5, 5]),
+            (15, [5, 5, 5]),
+            (84, [5] * 16 + [4]),
+            (100, [5] * 20),
+        ]
+        for requested_runs, expected_batches in cases:
+            with self.subTest(requested_runs=requested_runs):
+                self.assertEqual(sampling_batch_sizes(requested_runs), expected_batches)
+        with self.assertRaises(ValueError):
+            sampling_batch_sizes(0)
+
 
 class TestRegressionRunnerIntegration(unittest.TestCase):
     repository_root = Path(__file__).resolve().parents[2]
@@ -77,7 +95,11 @@ expected_memory_limit = os.getenv("EXPECTED_MEMORY_LIMIT")
 if expected_memory_limit and f"--memory_limit={expected_memory_limit}" not in sys.argv:
     print("memory limit was not forwarded", file=sys.stderr)
     raise SystemExit(1)
-timing = float(os.environ["BENCHMARK_NEW_TIMING"]) if label == "new" else 1.0
+timing = (
+    float(os.environ["BENCHMARK_NEW_TIMING"])
+    if label == "new"
+    else float(os.environ["BENCHMARK_OLD_TIMING"])
+)
 print("name\\trun\\ttiming", file=sys.stderr)
 for run in range(1, runs + 1):
     print(f"fake.benchmark\\t{run}\\t{timing}", file=sys.stderr)
@@ -117,7 +139,7 @@ print("name\\trun\\ttiming", file=sys.stderr)
 for run in range(1, runs + 1):
     if label == "old":
         timing = 1.0
-    elif invocation < 2 or run % 3 != 0:
+    elif invocation < 2 or (run != 3 and not (invocation == 2 and run == 5)):
         timing = 1.3
     else:
         timing = 1.0
@@ -140,7 +162,7 @@ print("name\\trun\\ttiming", file=sys.stderr)
 for run in range(1, runs + 1):
     if label == "old":
         timing = 1.0
-    elif invocation < 2 or run % 3 != 0:
+    elif invocation < 2 or (run != 3 and not (invocation == 2 and run == 5)):
         timing = 0.95
     else:
         timing = 1.0
@@ -158,6 +180,7 @@ print("not-a-valid-timing-row", file=sys.stderr)
         self,
         runner_source,
         new_timing="1.0",
+        old_timing="1.0",
         extra_args=None,
         ci=False,
         create_cache=False,
@@ -181,6 +204,7 @@ print("not-a-valid-timing-row", file=sys.stderr)
             env["BENCHMARK_ORDER_LOG"] = str(order_log)
             env["BENCHMARK_COUNTER_DIR"] = str(temp_path)
             env["BENCHMARK_NEW_TIMING"] = new_timing
+            env["BENCHMARK_OLD_TIMING"] = old_timing
             if create_cache:
                 cache_path = temp_path / "build" / "duckdb_benchmark_data"
                 cache_path.mkdir()
@@ -218,13 +242,25 @@ print("not-a-valid-timing-row", file=sys.stderr)
             order = order_log.read_text(encoding="utf-8").splitlines() if order_log.exists() else []
             return process, order
 
+    @staticmethod
+    def expected_order(confirmation_runs=0):
+        order = ["old:5", "new:5", "new:5", "old:5"]
+        if not confirmation_runs:
+            return order
+        for batch_index, batch_size in enumerate(sampling_batch_sizes(confirmation_runs), start=2):
+            if batch_index % 2 == 0:
+                order.extend([f"old:{batch_size}", f"new:{batch_size}"])
+            else:
+                order.extend([f"new:{batch_size}", f"old:{batch_size}"])
+        return order
+
     def test_non_regression_stops_after_two_initial_batches(self):
         process, order = self.run_regression_test(self.stable_runner_source)
         self.assertEqual(process.returncode, 0, process.stdout + process.stderr)
-        self.assertEqual(order, ["old:5", "new:5", "new:5", "old:5"])
+        self.assertEqual(order, self.expected_order())
         plain_output = re.sub(r"\x1b\[[0-9;]*m", "", process.stdout)
         self.assertIn("initial sampling: 10 runs per binary in 2 batches of 5", plain_output)
-        self.assertIn("within noise threshold", plain_output)
+        self.assertIn("median change +0.0% | within ±2%; done", plain_output)
         self.assertIn("geomean (initial 10 samples): 1.000s -> 1.000s  +0.0%", plain_output)
 
     def test_noise_boundaries_do_not_receive_confirmation_samples(self):
@@ -232,50 +268,72 @@ print("not-a-valid-timing-row", file=sys.stderr)
             with self.subTest(new_timing=new_timing):
                 process, order = self.run_regression_test(self.stable_runner_source, new_timing=new_timing)
                 self.assertEqual(process.returncode, 0, process.stdout + process.stderr)
-                self.assertEqual(order, ["old:5", "new:5", "new:5", "old:5"])
+                self.assertEqual(order, self.expected_order())
 
     def test_improvement_receives_confirmation_and_is_classified_by_median(self):
         process, order = self.run_regression_test(self.noisy_improvement_runner_source)
         self.assertEqual(process.returncode, 0, process.stdout + process.stderr)
-        self.assertEqual(
-            order,
-            ["old:5", "new:5", "new:5", "old:5", "old:8", "new:8", "new:7", "old:7"],
-        )
+        self.assertEqual(order, self.expected_order(15))
         plain_output = re.sub(r"\x1b\[[0-9;]*m", "", process.stdout)
-        self.assertIn("confirmation sampling: fake.benchmark: 15 paired runs", plain_output)
-        self.assertIn("95% CI for PR/base median ratio: 0.950x to 1.000x; faster", plain_output)
-        self.assertRegex(plain_output, r"FASTER\nbenchmark[^\n]*\n-+[^\n]*\nfake\s+1\.000s\s+0\.950s")
+        self.assertIn(
+            "initial: fake.benchmark: 10 pairs | median change -5.0% | confirming with 15 pairs", plain_output
+        )
+        self.assertIn(
+            "confirmation: fake.benchmark: 15 pairs | median change -5.0% | 95% CI -5.0%…+0.0% | "
+            "faster (uncertain; budget exhausted)",
+            plain_output,
+        )
+        self.assertRegex(
+            plain_output,
+            r"FASTER\nbenchmark[^\n]*\n-+[^\n]*\nfake\s+1\.000s\s+0\.950s\s+-0\.050s\s+-5\.0%\s+"
+            r"-5\.0%…\+0\.0%\s+uncertain\s+10\+15",
+        )
         self.assertIn("geomean (initial 10 samples): 1.000s -> 0.950s  -5.0%", plain_output)
 
     def test_slowdown_below_regression_limit_receives_confirmation(self):
         process, order = self.run_regression_test(self.stable_runner_source, new_timing="1.08", ci=True)
         self.assertEqual(process.returncode, 0, process.stdout + process.stderr)
-        self.assertEqual(
-            order,
-            ["old:5", "new:5", "new:5", "old:5", "old:8", "new:8", "new:7", "old:7"],
-        )
+        self.assertEqual(order, self.expected_order(15))
         plain_output = re.sub(r"\x1b\[[0-9;]*m", "", process.stdout)
-        self.assertIn(
-            "1.080x; 95% CI for PR/base median ratio: 1.080x to 1.080x; slower below regression limit", plain_output
-        )
+        self.assertIn("median change +8.0% | 95% CI +8.0%…+8.0% | slower (confident)", plain_output)
         self.assertRegex(
             plain_output,
-            r"SLOWER BELOW REGRESSION LIMIT\nbenchmark[^\n]*\n-+[^\n]*\nfake\s+1\.000s\s+1\.080s",
+            r"SLOWER BELOW REGRESSION LIMIT\nbenchmark[^\n]*\n-+[^\n]*\nfake\s+1\.000s\s+1\.080s\s+"
+            r"\+0\.080s\s+\+8\.0%\s+\+8\.0%…\+8\.0%\s+confident\s+10\+15",
         )
         self.assertNotIn("::warning title=Inconclusive regression benchmark::", plain_output)
 
     def test_stable_regression_is_confirmed_from_independent_samples(self):
         process, order = self.run_regression_test(self.stable_runner_source, new_timing="1.3")
         self.assertEqual(process.returncode, 1, process.stdout + process.stderr)
-        self.assertEqual(
-            order,
-            ["old:5", "new:5", "new:5", "old:5", "old:8", "new:8", "new:7", "old:7"],
-        )
+        self.assertEqual(order, self.expected_order(15))
         plain_output = re.sub(r"\x1b\[[0-9;]*m", "", process.stdout)
-        self.assertIn("confirmation sampling: fake.benchmark: 15 paired runs", plain_output)
-        self.assertIn("95% CI for PR/base median ratio: 1.300x to 1.300x", plain_output)
-        self.assertIn("confirmed regression", plain_output)
-        self.assertRegex(plain_output, r"fake\s+1\.000s\s+1\.300s\s+\+0\.300s\s+\+30\.0%\s+10\+15")
+        self.assertIn(
+            "confirmation: fake.benchmark: 15 pairs | median change +30.0% | 95% CI +30.0%…+30.0% | "
+            "regression (confirmed)",
+            plain_output,
+        )
+        self.assertRegex(
+            plain_output,
+            r"fake\s+1\.000s\s+1\.300s\s+\+0\.300s\s+\+30\.0%\s+\+30\.0%…\+30\.0%\s+" r"confirmed regression\s+10\+15",
+        )
+
+    def test_confirmation_uses_alternating_five_run_batches(self):
+        process, order = self.run_regression_test(
+            self.stable_runner_source,
+            old_timing="0.036",
+            new_timing="0.045",
+        )
+        self.assertEqual(process.returncode, 1, process.stdout + process.stderr)
+        self.assertEqual(order, self.expected_order(84))
+        self.assertTrue(all(int(entry.split(":")[1]) <= 5 for entry in order))
+        plain_output = re.sub(r"\x1b\[[0-9;]*m", "", process.stdout)
+        self.assertIn(
+            "initial: fake.benchmark: 10 pairs | median change +25.0% | confirming with 84 pairs",
+            plain_output,
+        )
+        self.assertIn("confirmation: fake.benchmark: 84 pairs", plain_output)
+        self.assertIn("10+84", plain_output)
 
     def test_nofail_reports_confirmed_regression_without_failing(self):
         process, _ = self.run_regression_test(self.stable_runner_source, new_timing="1.3", extra_args=["--nofail"])
@@ -311,12 +369,9 @@ print("not-a-valid-timing-row", file=sys.stderr)
     def test_rejected_candidate_uses_confirmation_for_row_and_initial_for_geomean(self):
         process, order = self.run_regression_test(self.rejected_candidate_runner_source, ci=True)
         self.assertEqual(process.returncode, 0, process.stdout + process.stderr)
-        self.assertEqual(
-            order,
-            ["old:5", "new:5", "new:5", "old:5", "old:8", "new:8", "new:7", "old:7"],
-        )
+        self.assertEqual(order, self.expected_order(15))
         plain_output = re.sub(r"\x1b\[[0-9;]*m", "", process.stdout)
-        self.assertIn("within noise threshold", plain_output)
+        self.assertIn("within ±2%; no change", plain_output)
         self.assertIn("geomean (initial 10 samples): 1.000s -> 1.300s  +30.0%", plain_output)
         self.assertIn("INCONCLUSIVE REGRESSION CANDIDATES\n0 benchmarks", plain_output)
         self.assertNotIn("::warning title=Inconclusive regression benchmark::", plain_output)
@@ -325,7 +380,7 @@ print("not-a-valid-timing-row", file=sys.stderr)
         process, _ = self.run_regression_test(self.inconclusive_candidate_runner_source, ci=True)
         self.assertEqual(process.returncode, 0, process.stdout + process.stderr)
         plain_output = re.sub(r"\x1b\[[0-9;]*m", "", process.stdout)
-        self.assertIn("regression inconclusive", plain_output)
+        self.assertIn("regression (uncertain; budget exhausted)", plain_output)
         self.assertIn("INCONCLUSIVE REGRESSION CANDIDATES", plain_output)
         self.assertIn("::warning title=Inconclusive regression benchmark::", plain_output)
         self.assertIn("10+15", plain_output)

--- a/scripts/regression/test_comparison.py
+++ b/scripts/regression/test_comparison.py
@@ -1,0 +1,257 @@
+import math
+import os
+import re
+import stat
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.regression.comparison import median_confidence_interval, paired_measurement, sampling_decision
+
+
+class TestPairedComparison(unittest.TestCase):
+    def make_decision(self, measurement, measured_seconds=1.0, minimum_runs=20, maximum_runs=100):
+        return sampling_decision(
+            measurement,
+            measured_seconds=measured_seconds,
+            minimum_runs=minimum_runs,
+            maximum_runs=maximum_runs,
+            maximum_adaptive_seconds=10.0,
+            display_threshold_percentage=2.0,
+            regression_threshold_percentage=0.1,
+            regression_threshold_seconds=0.05,
+        )
+
+    def test_median_confidence_interval(self):
+        lower, upper = median_confidence_interval(list(range(1, 21)))
+        self.assertEqual((lower, upper), (6, 15))
+        self.assertEqual(median_confidence_interval([1.0] * 20), (1.0, 1.0))
+        self.assertEqual(median_confidence_interval([1.0] * 4), (-math.inf, math.inf))
+
+    def test_q53_uses_paired_change_instead_of_pooled_medians(self):
+        old = [
+            0.015359,
+            0.015292,
+            0.014707,
+            0.014988,
+            0.014316,
+            0.015348,
+            0.014787,
+            0.014339,
+            0.014135,
+            0.014171,
+            0.016209,
+            0.015087,
+            0.015156,
+            0.014618,
+            0.014771,
+            0.016077,
+            0.014951,
+            0.015016,
+            0.014579,
+            0.014426,
+            0.020085,
+            0.019983,
+            0.021580,
+            0.021364,
+            0.022356,
+            0.021520,
+            0.021329,
+            0.019311,
+            0.020324,
+            0.024281,
+        ]
+        new = [
+            0.016120,
+            0.014158,
+            0.014453,
+            0.014663,
+            0.013699,
+            0.017042,
+            0.014953,
+            0.013993,
+            0.013678,
+            0.013685,
+            0.015336,
+            0.014745,
+            0.014687,
+            0.013690,
+            0.013658,
+            0.024608,
+            0.021533,
+            0.023831,
+            0.022940,
+            0.021340,
+            0.021216,
+            0.019005,
+            0.020576,
+            0.019424,
+            0.022571,
+            0.021240,
+            0.019692,
+            0.018916,
+            0.020069,
+            0.019921,
+        ]
+
+        measurement = paired_measurement(old, new)
+        pooled_change = sorted(new)[14:16]
+        pooled_new = sum(pooled_change) / 2
+        pooled_old = sum(sorted(old)[14:16]) / 2
+        self.assertAlmostEqual((pooled_new / pooled_old - 1.0) * 100.0, 18.1, places=1)
+        self.assertAlmostEqual((measurement.ratio - 1.0) * 100.0, -2.2, places=1)
+        self.assertTrue(self.make_decision(measurement).collect_more)
+
+    def test_close_results_stop_at_the_minimum(self):
+        measurement = paired_measurement([1.0] * 20, [1.01] * 20)
+        decision = self.make_decision(measurement)
+        self.assertFalse(decision.collect_more)
+        self.assertIn("display threshold", decision.reason)
+
+    def test_stable_visible_results_stop(self):
+        improvement = paired_measurement([1.0] * 20, [0.95] * 20)
+        slowdown = paired_measurement([1.0] * 20, [1.05] * 20)
+        regression = paired_measurement([1.0] * 20, [1.20] * 20)
+        self.assertFalse(self.make_decision(improvement).collect_more)
+        self.assertFalse(self.make_decision(slowdown).collect_more)
+        self.assertFalse(self.make_decision(regression).collect_more)
+
+    def test_minimum_run_time_and_sample_caps(self):
+        measurement = paired_measurement([1.0] * 10, [1.05] * 10)
+        self.assertTrue(self.make_decision(measurement, measured_seconds=20.0).collect_more)
+
+        measurement = paired_measurement([1.0] * 20, [1.01, 1.10] * 10)
+        time_decision = self.make_decision(measurement, measured_seconds=10.0)
+        self.assertFalse(time_decision.collect_more)
+        self.assertIn("budget", time_decision.reason)
+
+        measurement = paired_measurement([1.0] * 100, [1.01, 1.10] * 50)
+        run_decision = self.make_decision(measurement, maximum_runs=100)
+        self.assertFalse(run_decision.collect_more)
+        self.assertIn("maximum timed runs", run_decision.reason)
+
+
+class TestRegressionRunnerIntegration(unittest.TestCase):
+    def test_adaptive_runner_alternates_batches_and_reports_runs(self):
+        repository_root = Path(__file__).resolve().parents[2]
+        runner_source = '''#!/usr/bin/env python3
+import os
+import sys
+
+label = os.path.basename(sys.argv[0])
+if "--help" in sys.argv:
+    print("--timed-runs")
+    raise SystemExit(0)
+runs = 5
+if "--timed-runs" in sys.argv:
+    runs = int(sys.argv[sys.argv.index("--timed-runs") + 1])
+with open(os.environ["BENCHMARK_ORDER_LOG"], "a", encoding="utf-8") as order_log:
+    order_log.write(label + "\\n")
+timing = 0.95 if label == "new" else 1.0
+print("name\\trun\\ttiming", file=sys.stderr)
+for run in range(1, runs + 1):
+    print(f"fake.benchmark\\t{run}\\t{timing}", file=sys.stderr)
+'''
+        with tempfile.TemporaryDirectory() as temp_directory:
+            temp_path = Path(temp_directory)
+            for label in ("old", "new"):
+                runner_path = temp_path / label
+                runner_path.write_text(runner_source, encoding="utf-8")
+                runner_path.chmod(runner_path.stat().st_mode | stat.S_IXUSR)
+            benchmark_list = temp_path / "benchmarks.csv"
+            benchmark_list.write_text("fake.benchmark\n", encoding="utf-8")
+            order_log = temp_path / "order.log"
+            env = os.environ.copy()
+            env["BENCHMARK_ORDER_LOG"] = str(order_log)
+
+            process = subprocess.run(
+                [
+                    sys.executable,
+                    str(repository_root / "scripts/regression/test_runner.py"),
+                    "--old",
+                    str(temp_path / "old"),
+                    "--new",
+                    str(temp_path / "new"),
+                    "--benchmarks",
+                    str(benchmark_list),
+                ],
+                cwd=repository_root,
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(process.returncode, 0, process.stdout + process.stderr)
+            self.assertEqual(
+                order_log.read_text(encoding="utf-8").splitlines(),
+                ["old", "new", "new", "old", "old", "new", "new", "old"],
+            )
+            plain_output = re.sub(r"\x1b\[[0-9;]*m", "", process.stdout)
+            self.assertIn("paired median, 20-100 timed runs", plain_output)
+            self.assertRegex(plain_output, r"fake\s+1\.000s\s+0\.950s\s+-0\.050s\s+-5\.0%\s+20")
+
+    def test_runner_without_timed_run_support_uses_legacy_sampling(self):
+        repository_root = Path(__file__).resolve().parents[2]
+        runner_source = '''#!/usr/bin/env python3
+import os
+import sys
+
+label = os.path.basename(sys.argv[0])
+if "--help" in sys.argv:
+    print("legacy benchmark runner")
+    raise SystemExit(0)
+with open(os.environ["BENCHMARK_ORDER_LOG"], "a", encoding="utf-8") as order_log:
+    order_log.write(label + "\\n")
+timing = 0.95 if label == "new" else 1.0
+print("name\\trun\\ttiming", file=sys.stderr)
+for run in range(1, 6):
+    print(f"fake.benchmark\\t{run}\\t{timing}", file=sys.stderr)
+'''
+        with tempfile.TemporaryDirectory() as temp_directory:
+            temp_path = Path(temp_directory)
+            for label in ("old", "new"):
+                runner_path = temp_path / label
+                runner_path.write_text(runner_source, encoding="utf-8")
+                runner_path.chmod(runner_path.stat().st_mode | stat.S_IXUSR)
+            benchmark_list = temp_path / "benchmarks.csv"
+            benchmark_list.write_text("fake.benchmark\n", encoding="utf-8")
+            order_log = temp_path / "order.log"
+            env = os.environ.copy()
+            env["BENCHMARK_ORDER_LOG"] = str(order_log)
+
+            process = subprocess.run(
+                [
+                    sys.executable,
+                    str(repository_root / "scripts/regression/test_runner.py"),
+                    "--old",
+                    str(temp_path / "old"),
+                    "--new",
+                    str(temp_path / "new"),
+                    "--benchmarks",
+                    str(benchmark_list),
+                    "--timed-runs",
+                    "20",
+                ],
+                cwd=repository_root,
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(process.returncode, 0, process.stdout + process.stderr)
+            self.assertIn("Adaptive paired sampling disabled", process.stdout)
+            self.assertEqual(
+                order_log.read_text(encoding="utf-8").splitlines(),
+                ["old", "new", "old", "new", "old", "new", "old", "new"],
+            )
+            self.assertIn("timing: median of 20 timed runs", process.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/regression/test_comparison.py
+++ b/scripts/regression/test_comparison.py
@@ -324,6 +324,8 @@ print("not-a-valid-timing-row", file=sys.stderr)
         self.assertNotIn("\nSLOWER (+2%…+10%)\n", plain_output)
         self.assertNotIn("\nUNCERTAIN REGRESSIONS\n", plain_output)
         self.assertNotIn("\nREGRESSIONS\n", plain_output)
+        self.assertLess(plain_output.index("UNCHANGED (±2%)"), plain_output.index("geomean:"))
+        self.assertTrue(plain_output.rstrip().endswith("result: no regressions"))
         self.assertIn("\033[90msuite: 1 benchmarks\033[0m", process.stdout)
         self.assertIn(
             "\033[90msampling: 10 initial pairs; 30–100 confirmation pairs outside ±2%, "
@@ -331,7 +333,8 @@ print("not-a-valid-timing-row", file=sys.stderr)
             process.stdout,
         )
         self.assertIn("\033[90mregression: fail when the 95% CI is above +10.0%\033[0m", process.stdout)
-        self.assertIn("\033[90m+0.0%\033[0m  \033[90m(initial 10 samples)\033[0m", process.stdout)
+        self.assertIn("\033[90mUNCHANGED (±2%)\033[0m\n\033[90m1 benchmarks\033[0m", process.stdout)
+        self.assertIn("  +0.0%  \033[90m(initial 10 samples)\033[0m", process.stdout)
         self.assertIn("result: \033[32mno regressions\033[0m", process.stdout)
 
     def test_noise_boundaries_do_not_receive_confirmation_samples(self):
@@ -340,6 +343,21 @@ print("not-a-valid-timing-row", file=sys.stderr)
                 process, order = self.run_regression_test(self.stable_runner_source, new_timing=new_timing)
                 self.assertEqual(process.returncode, 0, process.stdout + process.stderr)
                 self.assertEqual(order, self.expected_order())
+
+    def test_within_noise_geomean_uses_sign_color(self):
+        cases = [
+            ("0.999", "\033[32m-0.1%\033[0m"),
+            ("1.001", "\033[31m+0.1%\033[0m"),
+        ]
+        for new_timing, colored_change in cases:
+            with self.subTest(new_timing=new_timing):
+                process, order = self.run_regression_test(self.stable_runner_source, new_timing=new_timing)
+                self.assertEqual(process.returncode, 0, process.stdout + process.stderr)
+                self.assertEqual(order, self.expected_order())
+                self.assertIn(
+                    f"{colored_change}  \033[90m(initial 10 samples)\033[0m",
+                    process.stdout,
+                )
 
     def test_improvement_receives_confirmation_and_is_classified_by_median(self):
         process, order = self.run_regression_test(self.noisy_improvement_runner_source)
@@ -480,6 +498,8 @@ print("not-a-valid-timing-row", file=sys.stderr)
         self.assertIn("::warning title=Inconclusive regression benchmark::", plain_output)
         self.assertIn("10+30", plain_output)
         self.assertIn("result: \033[33muncertain regressions\033[0m", process.stdout)
+        self.assertLess(plain_output.index("UNCERTAIN REGRESSIONS"), plain_output.index("geomean:"))
+        self.assertTrue(plain_output.rstrip().endswith("result: uncertain regressions"))
 
     def test_malformed_runner_output_is_a_failure(self):
         process, _ = self.run_regression_test(self.malformed_runner_source)
@@ -487,6 +507,9 @@ print("not-a-valid-timing-row", file=sys.stderr)
         self.assertIn("Could not parse benchmark timings", process.stdout)
         self.assertIn("benchmark failure", process.stdout)
         self.assertIn("result: \033[31mbenchmark failure\033[0m", process.stdout)
+        plain_output = re.sub(r"\x1b\[[0-9;]*m", "", process.stdout)
+        self.assertLess(plain_output.index("FAILURES SUMMARY"), plain_output.index("geomean:"))
+        self.assertTrue(plain_output.rstrip().endswith("result: benchmark failure"))
 
     def test_removed_sampling_option_is_rejected(self):
         process, order = self.run_regression_test(self.stable_runner_source, extra_args=["--initial-runs", "20"])

--- a/scripts/regression/test_comparison.py
+++ b/scripts/regression/test_comparison.py
@@ -8,26 +8,20 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from scripts.regression.comparison import median_confidence_interval, paired_measurement, sampling_decision
+from scripts.regression.comparison import (
+    confirmation_run_count,
+    median_confidence_interval,
+    paired_measurement,
+    regression_measurement,
+)
 
 
 class TestPairedComparison(unittest.TestCase):
-    def make_decision(self, measurement, measured_seconds=1.0, minimum_runs=20, maximum_runs=100):
-        return sampling_decision(
-            measurement,
-            measured_seconds=measured_seconds,
-            minimum_runs=minimum_runs,
-            maximum_runs=maximum_runs,
-            maximum_adaptive_seconds=10.0,
-            display_threshold_percentage=2.0,
-            regression_threshold_percentage=0.1,
-            regression_threshold_seconds=0.05,
-        )
-
     def test_median_confidence_interval(self):
         lower, upper = median_confidence_interval(list(range(1, 21)))
         self.assertEqual((lower, upper), (6, 15))
         self.assertEqual(median_confidence_interval([1.0] * 20), (1.0, 1.0))
+        self.assertEqual(median_confidence_interval([1.0] * 6), (1.0, 1.0))
         self.assertEqual(median_confidence_interval([1.0] * 4), (-math.inf, math.inf))
 
     def test_q53_uses_paired_change_instead_of_pooled_medians(self):
@@ -97,46 +91,44 @@ class TestPairedComparison(unittest.TestCase):
         ]
 
         measurement = paired_measurement(old, new)
-        pooled_change = sorted(new)[14:16]
-        pooled_new = sum(pooled_change) / 2
+        pooled_new = sum(sorted(new)[14:16]) / 2
         pooled_old = sum(sorted(old)[14:16]) / 2
         self.assertAlmostEqual((pooled_new / pooled_old - 1.0) * 100.0, 18.1, places=1)
         self.assertAlmostEqual((measurement.ratio - 1.0) * 100.0, -2.2, places=1)
-        self.assertTrue(self.make_decision(measurement).collect_more)
 
-    def test_close_results_stop_at_the_minimum(self):
-        measurement = paired_measurement([1.0] * 20, [1.01] * 20)
-        decision = self.make_decision(measurement)
-        self.assertFalse(decision.collect_more)
-        self.assertIn("display threshold", decision.reason)
+    def test_regression_measurement_includes_both_thresholds(self):
+        below_threshold = regression_measurement([1.0] * 10, [1.15] * 10, 0.1, 0.05)
+        above_threshold = regression_measurement([1.0] * 10, [1.20] * 10, 0.1, 0.05)
+        self.assertLess(below_threshold.ratio, 1.0)
+        self.assertGreater(above_threshold.ratio, 1.0)
+        self.assertGreater(above_threshold.ratio_interval[0], 1.0)
 
-    def test_stable_visible_results_stop(self):
-        improvement = paired_measurement([1.0] * 20, [0.95] * 20)
-        slowdown = paired_measurement([1.0] * 20, [1.05] * 20)
-        regression = paired_measurement([1.0] * 20, [1.20] * 20)
-        self.assertFalse(self.make_decision(improvement).collect_more)
-        self.assertFalse(self.make_decision(slowdown).collect_more)
-        self.assertFalse(self.make_decision(regression).collect_more)
+    def test_confirmation_runs_scale_with_runtime(self):
+        cases = [
+            (0.02, 100),
+            (0.05, 60),
+            (0.1, 30),
+            (0.3, 10),
+            (0.5, 6),
+            (4.0, 6),
+        ]
+        for timing, expected_runs in cases:
+            with self.subTest(timing=timing):
+                measurement = paired_measurement([timing] * 10, [timing * 1.01] * 10)
+                self.assertEqual(confirmation_run_count(measurement, 3.0, 6, 100), expected_runs)
 
-    def test_minimum_run_time_and_sample_caps(self):
-        measurement = paired_measurement([1.0] * 10, [1.05] * 10)
-        self.assertTrue(self.make_decision(measurement, measured_seconds=20.0).collect_more)
-
-        measurement = paired_measurement([1.0] * 20, [1.01, 1.10] * 10)
-        time_decision = self.make_decision(measurement, measured_seconds=10.0)
-        self.assertFalse(time_decision.collect_more)
-        self.assertIn("budget", time_decision.reason)
-
-        measurement = paired_measurement([1.0] * 100, [1.01, 1.10] * 50)
-        run_decision = self.make_decision(measurement, maximum_runs=100)
-        self.assertFalse(run_decision.collect_more)
-        self.assertIn("maximum timed runs", run_decision.reason)
+    def test_confirmation_run_validation(self):
+        measurement = paired_measurement([1.0] * 10, [1.0] * 10)
+        with self.assertRaises(ValueError):
+            confirmation_run_count(measurement, 0.0, 6, 100)
+        with self.assertRaises(ValueError):
+            confirmation_run_count(measurement, 3.0, 10, 6)
 
 
 class TestRegressionRunnerIntegration(unittest.TestCase):
-    def test_adaptive_runner_alternates_batches_and_reports_runs(self):
-        repository_root = Path(__file__).resolve().parents[2]
-        runner_source = '''#!/usr/bin/env python3
+    repository_root = Path(__file__).resolve().parents[2]
+
+    runner_source = """#!/usr/bin/env python3
 import os
 import sys
 
@@ -144,16 +136,37 @@ label = os.path.basename(sys.argv[0])
 if "--help" in sys.argv:
     print("--timed-runs")
     raise SystemExit(0)
-runs = 5
-if "--timed-runs" in sys.argv:
-    runs = int(sys.argv[sys.argv.index("--timed-runs") + 1])
+runs = int(sys.argv[sys.argv.index("--timed-runs") + 1])
 with open(os.environ["BENCHMARK_ORDER_LOG"], "a", encoding="utf-8") as order_log:
     order_log.write(label + "\\n")
-timing = 0.95 if label == "new" else 1.0
+timing = float(os.environ["BENCHMARK_NEW_TIMING"]) if label == "new" else 1.0
 print("name\\trun\\ttiming", file=sys.stderr)
 for run in range(1, runs + 1):
     print(f"fake.benchmark\\t{run}\\t{timing}", file=sys.stderr)
-'''
+"""
+
+    noisy_runner_source = """#!/usr/bin/env python3
+import os
+import sys
+from pathlib import Path
+
+label = os.path.basename(sys.argv[0])
+if "--help" in sys.argv:
+    print("--timed-runs")
+    raise SystemExit(0)
+runs = int(sys.argv[sys.argv.index("--timed-runs") + 1])
+with open(os.environ["BENCHMARK_ORDER_LOG"], "a", encoding="utf-8") as order_log:
+    order_log.write(label + "\\n")
+counter_path = Path(os.environ["BENCHMARK_COUNTER_DIR"]) / f"{label}.count"
+invocation = int(counter_path.read_text(encoding="utf-8")) if counter_path.exists() else 0
+counter_path.write_text(str(invocation + 1), encoding="utf-8")
+timing = 1.3 if label == "new" and invocation < 2 else 1.0
+print("name\\trun\\ttiming", file=sys.stderr)
+for run in range(1, runs + 1):
+    print(f"fake.benchmark\\t{run}\\t{timing}", file=sys.stderr)
+"""
+
+    def run_regression_test(self, runner_source, new_timing="0.95", extra_args=None, ci=False):
         with tempfile.TemporaryDirectory() as temp_directory:
             temp_path = Path(temp_directory)
             for label in ("old", "new"):
@@ -165,38 +178,68 @@ for run in range(1, runs + 1):
             order_log = temp_path / "order.log"
             env = os.environ.copy()
             env["BENCHMARK_ORDER_LOG"] = str(order_log)
+            env["BENCHMARK_COUNTER_DIR"] = str(temp_path)
+            env["BENCHMARK_NEW_TIMING"] = new_timing
+            if ci:
+                env["CI"] = "true"
 
+            command = [
+                sys.executable,
+                str(self.repository_root / "scripts/regression/test_runner.py"),
+                "--old",
+                str(temp_path / "old"),
+                "--new",
+                str(temp_path / "new"),
+                "--benchmarks",
+                str(benchmark_list),
+                "--verbose",
+            ]
+            if extra_args:
+                command.extend(extra_args)
             process = subprocess.run(
-                [
-                    sys.executable,
-                    str(repository_root / "scripts/regression/test_runner.py"),
-                    "--old",
-                    str(temp_path / "old"),
-                    "--new",
-                    str(temp_path / "new"),
-                    "--benchmarks",
-                    str(benchmark_list),
-                ],
-                cwd=repository_root,
+                command,
+                cwd=self.repository_root,
                 env=env,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 text=True,
                 check=False,
             )
+            order = order_log.read_text(encoding="utf-8").splitlines() if order_log.exists() else []
+            return process, order
 
-            self.assertEqual(process.returncode, 0, process.stdout + process.stderr)
-            self.assertEqual(
-                order_log.read_text(encoding="utf-8").splitlines(),
-                ["old", "new", "new", "old", "old", "new", "new", "old"],
-            )
-            plain_output = re.sub(r"\x1b\[[0-9;]*m", "", process.stdout)
-            self.assertIn("paired median, 20-100 timed runs", plain_output)
-            self.assertRegex(plain_output, r"fake\s+1\.000s\s+0\.950s\s+-0\.050s\s+-5\.0%\s+20")
+    def test_non_regression_stops_after_initial_runs(self):
+        process, order = self.run_regression_test(self.runner_source)
+        self.assertEqual(process.returncode, 0, process.stdout + process.stderr)
+        self.assertEqual(order, ["old", "new", "new", "old"])
+        plain_output = re.sub(r"\x1b\[[0-9;]*m", "", process.stdout)
+        self.assertIn(
+            "timing: 10 initial runs; regression confirmation targets 3s",
+            plain_output,
+        )
+        self.assertRegex(plain_output, r"fake\s+1\.000s\s+0\.950s\s+-0\.050s\s+-5\.0%\s+10")
+
+    def test_stable_regression_is_confirmed(self):
+        process, order = self.run_regression_test(self.runner_source, new_timing="1.3")
+        self.assertEqual(process.returncode, 1, process.stdout + process.stderr)
+        self.assertEqual(order, ["old", "new", "new", "old", "old", "new", "new", "old"])
+        plain_output = re.sub(r"\x1b\[[0-9;]*m", "", process.stdout)
+        self.assertIn("regression confirmation: fake.benchmark: 6 paired runs", plain_output)
+        self.assertIn("confirmed regression", plain_output)
+        self.assertRegex(plain_output, r"fake\s+1\.000s\s+1\.300s\s+\+0\.300s\s+\+30\.0%\s+10\+6")
+
+    def test_noisy_regression_candidate_does_not_fail(self):
+        process, order = self.run_regression_test(self.noisy_runner_source, ci=True)
+        self.assertEqual(process.returncode, 0, process.stdout + process.stderr)
+        self.assertEqual(order, ["old", "new", "new", "old", "old", "new", "new", "old"])
+        plain_output = re.sub(r"\x1b\[[0-9;]*m", "", process.stdout)
+        self.assertIn("regression not confirmed", plain_output)
+        self.assertIn("UNCONFIRMED REGRESSION CANDIDATES", plain_output)
+        self.assertIn("::warning title=Unconfirmed regression benchmark::", plain_output)
+        self.assertIn("10+6", plain_output)
 
     def test_runner_without_timed_run_support_fails_early(self):
-        repository_root = Path(__file__).resolve().parents[2]
-        runner_source = '''#!/usr/bin/env python3
+        runner_source = """#!/usr/bin/env python3
 import os
 import sys
 
@@ -206,47 +249,11 @@ if "--help" in sys.argv:
     raise SystemExit(0)
 with open(os.environ["BENCHMARK_ORDER_LOG"], "a", encoding="utf-8") as order_log:
     order_log.write(label + "\\n")
-timing = 0.95 if label == "new" else 1.0
-print("name\\trun\\ttiming", file=sys.stderr)
-for run in range(1, 6):
-    print(f"fake.benchmark\\t{run}\\t{timing}", file=sys.stderr)
-'''
-        with tempfile.TemporaryDirectory() as temp_directory:
-            temp_path = Path(temp_directory)
-            for label in ("old", "new"):
-                runner_path = temp_path / label
-                runner_path.write_text(runner_source, encoding="utf-8")
-                runner_path.chmod(runner_path.stat().st_mode | stat.S_IXUSR)
-            benchmark_list = temp_path / "benchmarks.csv"
-            benchmark_list.write_text("fake.benchmark\n", encoding="utf-8")
-            order_log = temp_path / "order.log"
-            env = os.environ.copy()
-            env["BENCHMARK_ORDER_LOG"] = str(order_log)
-
-            process = subprocess.run(
-                [
-                    sys.executable,
-                    str(repository_root / "scripts/regression/test_runner.py"),
-                    "--old",
-                    str(temp_path / "old"),
-                    "--new",
-                    str(temp_path / "new"),
-                    "--benchmarks",
-                    str(benchmark_list),
-                    "--timed-runs",
-                    "20",
-                ],
-                cwd=repository_root,
-                env=env,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                text=True,
-                check=False,
-            )
-
-            self.assertEqual(process.returncode, 1, process.stdout + process.stderr)
-            self.assertIn("requires both benchmark runners to support --timed-runs", process.stdout)
-            self.assertFalse(order_log.exists())
+"""
+        process, order = self.run_regression_test(runner_source)
+        self.assertEqual(process.returncode, 1, process.stdout + process.stderr)
+        self.assertIn("requires both benchmark runners to support --timed-runs", process.stdout)
+        self.assertEqual(order, [])
 
 
 if __name__ == "__main__":

--- a/scripts/regression/test_comparison.py
+++ b/scripts/regression/test_comparison.py
@@ -194,7 +194,7 @@ for run in range(1, runs + 1):
             self.assertIn("paired median, 20-100 timed runs", plain_output)
             self.assertRegex(plain_output, r"fake\s+1\.000s\s+0\.950s\s+-0\.050s\s+-5\.0%\s+20")
 
-    def test_runner_without_timed_run_support_uses_legacy_sampling(self):
+    def test_runner_without_timed_run_support_fails_early(self):
         repository_root = Path(__file__).resolve().parents[2]
         runner_source = '''#!/usr/bin/env python3
 import os
@@ -244,13 +244,9 @@ for run in range(1, 6):
                 check=False,
             )
 
-            self.assertEqual(process.returncode, 0, process.stdout + process.stderr)
-            self.assertIn("Adaptive paired sampling disabled", process.stdout)
-            self.assertEqual(
-                order_log.read_text(encoding="utf-8").splitlines(),
-                ["old", "new", "old", "new", "old", "new", "old", "new"],
-            )
-            self.assertIn("timing: median of 20 timed runs", process.stdout)
+            self.assertEqual(process.returncode, 1, process.stdout + process.stderr)
+            self.assertIn("requires both benchmark runners to support --timed-runs", process.stdout)
+            self.assertFalse(order_log.exists())
 
 
 if __name__ == "__main__":

--- a/scripts/regression/test_comparison.py
+++ b/scripts/regression/test_comparison.py
@@ -108,14 +108,14 @@ class TestPairedComparison(unittest.TestCase):
             (0.02, 100),
             (0.05, 60),
             (0.1, 30),
-            (0.3, 10),
-            (0.5, 6),
-            (4.0, 6),
+            (0.3, 15),
+            (0.5, 15),
+            (4.0, 15),
         ]
         for timing, expected_runs in cases:
             with self.subTest(timing=timing):
                 measurement = paired_measurement([timing] * 10, [timing * 1.01] * 10)
-                self.assertEqual(confirmation_run_count(measurement, 3.0, 6, 100), expected_runs)
+                self.assertEqual(confirmation_run_count(measurement, 3.0, 15, 100), expected_runs)
 
     def test_confirmation_run_validation(self):
         measurement = paired_measurement([1.0] * 10, [1.0] * 10)
@@ -145,7 +145,7 @@ for run in range(1, runs + 1):
     print(f"fake.benchmark\\t{run}\\t{timing}", file=sys.stderr)
 """
 
-    noisy_runner_source = """#!/usr/bin/env python3
+    rejected_candidate_runner_source = """#!/usr/bin/env python3
 import os
 import sys
 from pathlib import Path
@@ -163,6 +163,32 @@ counter_path.write_text(str(invocation + 1), encoding="utf-8")
 timing = 1.3 if label == "new" and invocation < 2 else 1.0
 print("name\\trun\\ttiming", file=sys.stderr)
 for run in range(1, runs + 1):
+    print(f"fake.benchmark\\t{run}\\t{timing}", file=sys.stderr)
+"""
+
+    inconclusive_candidate_runner_source = """#!/usr/bin/env python3
+import os
+import sys
+from pathlib import Path
+
+label = os.path.basename(sys.argv[0])
+if "--help" in sys.argv:
+    print("--timed-runs")
+    raise SystemExit(0)
+runs = int(sys.argv[sys.argv.index("--timed-runs") + 1])
+with open(os.environ["BENCHMARK_ORDER_LOG"], "a", encoding="utf-8") as order_log:
+    order_log.write(label + "\\n")
+counter_path = Path(os.environ["BENCHMARK_COUNTER_DIR"]) / f"{label}.count"
+invocation = int(counter_path.read_text(encoding="utf-8")) if counter_path.exists() else 0
+counter_path.write_text(str(invocation + 1), encoding="utf-8")
+print("name\\trun\\ttiming", file=sys.stderr)
+for run in range(1, runs + 1):
+    if label == "old":
+        timing = 1.0
+    elif invocation < 2 or run % 2 == 0:
+        timing = 1.3
+    else:
+        timing = 1.0
     print(f"fake.benchmark\\t{run}\\t{timing}", file=sys.stderr)
 """
 
@@ -224,19 +250,28 @@ for run in range(1, runs + 1):
         self.assertEqual(process.returncode, 1, process.stdout + process.stderr)
         self.assertEqual(order, ["old", "new", "new", "old", "old", "new", "new", "old"])
         plain_output = re.sub(r"\x1b\[[0-9;]*m", "", process.stdout)
-        self.assertIn("regression confirmation: fake.benchmark: 6 paired runs", plain_output)
+        self.assertIn("regression confirmation: fake.benchmark: 15 paired runs", plain_output)
         self.assertIn("confirmed regression", plain_output)
-        self.assertRegex(plain_output, r"fake\s+1\.000s\s+1\.300s\s+\+0\.300s\s+\+30\.0%\s+10\+6")
+        self.assertRegex(plain_output, r"fake\s+1\.000s\s+1\.300s\s+\+0\.300s\s+\+30\.0%\s+10\+15")
 
-    def test_noisy_regression_candidate_does_not_fail(self):
-        process, order = self.run_regression_test(self.noisy_runner_source, ci=True)
+    def test_rejected_regression_candidate_does_not_warn(self):
+        process, order = self.run_regression_test(self.rejected_candidate_runner_source, ci=True)
         self.assertEqual(process.returncode, 0, process.stdout + process.stderr)
         self.assertEqual(order, ["old", "new", "new", "old", "old", "new", "new", "old"])
         plain_output = re.sub(r"\x1b\[[0-9;]*m", "", process.stdout)
-        self.assertIn("regression not confirmed", plain_output)
+        self.assertIn("regression rejected", plain_output)
+        self.assertIn("UNCONFIRMED REGRESSION CANDIDATES\n0 benchmarks", plain_output)
+        self.assertNotIn("::warning title=Unconfirmed regression benchmark::", plain_output)
+
+    def test_inconclusive_regression_candidate_warns(self):
+        process, order = self.run_regression_test(self.inconclusive_candidate_runner_source, ci=True)
+        self.assertEqual(process.returncode, 0, process.stdout + process.stderr)
+        self.assertEqual(order, ["old", "new", "new", "old", "old", "new", "new", "old"])
+        plain_output = re.sub(r"\x1b\[[0-9;]*m", "", process.stdout)
+        self.assertIn("regression inconclusive", plain_output)
         self.assertIn("UNCONFIRMED REGRESSION CANDIDATES", plain_output)
         self.assertIn("::warning title=Unconfirmed regression benchmark::", plain_output)
-        self.assertIn("10+6", plain_output)
+        self.assertIn("10+15", plain_output)
 
     def test_runner_without_timed_run_support_fails_early(self):
         runner_source = """#!/usr/bin/env python3

--- a/scripts/regression/test_comparison.py
+++ b/scripts/regression/test_comparison.py
@@ -45,9 +45,9 @@ class TestBenchmarkComparison(unittest.TestCase):
             (0.02, 100),
             (0.05, 60),
             (0.10, 30),
-            (0.30, 15),
-            (0.50, 15),
-            (4.00, 15),
+            (0.30, 30),
+            (0.50, 30),
+            (4.00, 30),
         ]
         for timing, expected_runs in cases:
             with self.subTest(timing=timing):
@@ -56,13 +56,13 @@ class TestBenchmarkComparison(unittest.TestCase):
 
     def test_sampling_batch_sizes(self):
         cases = [
-            (1, [1]),
-            (4, [4]),
+            (1, [5]),
+            (4, [5]),
             (5, [5]),
-            (6, [5, 1]),
+            (6, [5, 5]),
             (10, [5, 5]),
             (15, [5, 5, 5]),
-            (84, [5] * 16 + [4]),
+            (84, [5] * 17),
             (100, [5] * 20),
         ]
         for requested_runs, expected_batches in cases:
@@ -139,7 +139,7 @@ print("name\\trun\\ttiming", file=sys.stderr)
 for run in range(1, runs + 1):
     if label == "old":
         timing = 1.0
-    elif invocation < 2 or (run != 3 and not (invocation == 2 and run == 5)):
+    elif invocation < 2 or run not in (3, 5):
         timing = 1.3
     else:
         timing = 1.0
@@ -162,10 +162,64 @@ print("name\\trun\\ttiming", file=sys.stderr)
 for run in range(1, runs + 1):
     if label == "old":
         timing = 1.0
-    elif invocation < 2 or (run != 3 and not (invocation == 2 and run == 5)):
+    elif invocation < 2 or run not in (3, 5):
         timing = 0.95
     else:
         timing = 1.0
+    print(f"fake.benchmark\\t{run}\\t{timing}", file=sys.stderr)
+"""
+
+    early_stop_after_twenty_runner_source = """#!/usr/bin/env python3
+import os
+import sys
+from pathlib import Path
+
+label = os.path.basename(sys.argv[0])
+runs = int(sys.argv[sys.argv.index("--timed-runs") + 1])
+with open(os.environ["BENCHMARK_ORDER_LOG"], "a", encoding="utf-8") as order_log:
+    order_log.write(f"{label}:{runs}\\n")
+counter_path = Path(os.environ["BENCHMARK_COUNTER_DIR"]) / f"{label}.count"
+invocation = int(counter_path.read_text(encoding="utf-8")) if counter_path.exists() else 0
+counter_path.write_text(str(invocation + 1), encoding="utf-8")
+print("name\\trun\\ttiming", file=sys.stderr)
+for run in range(1, runs + 1):
+    if label == "old":
+        timing = 1.0
+    elif invocation < 2:
+        timing = 1.3
+    elif invocation < 4 and run == 1:
+        timing = 0.9
+    elif invocation < 4 and run == 2:
+        timing = 1.1
+    else:
+        timing = 1.0
+    print(f"fake.benchmark\\t{run}\\t{timing}", file=sys.stderr)
+"""
+
+    wide_noise_runner_source = """#!/usr/bin/env python3
+import os
+import sys
+from pathlib import Path
+
+label = os.path.basename(sys.argv[0])
+runs = int(sys.argv[sys.argv.index("--timed-runs") + 1])
+with open(os.environ["BENCHMARK_ORDER_LOG"], "a", encoding="utf-8") as order_log:
+    order_log.write(f"{label}:{runs}\\n")
+counter_path = Path(os.environ["BENCHMARK_COUNTER_DIR"]) / f"{label}.count"
+invocation = int(counter_path.read_text(encoding="utf-8")) if counter_path.exists() else 0
+counter_path.write_text(str(invocation + 1), encoding="utf-8")
+print("name\\trun\\ttiming", file=sys.stderr)
+for run in range(1, runs + 1):
+    if label == "old":
+        timing = 1.0
+    elif invocation < 2:
+        timing = 1.3
+    elif run <= 2:
+        timing = 0.9
+    elif run == 3:
+        timing = 1.0
+    else:
+        timing = 1.1
     print(f"fake.benchmark\\t{run}\\t{timing}", file=sys.stderr)
 """
 
@@ -244,14 +298,11 @@ print("not-a-valid-timing-row", file=sys.stderr)
 
     @staticmethod
     def expected_order(confirmation_runs=0):
-        order = ["old:5", "new:5", "new:5", "old:5"]
+        order = ["old:5", "new:5", "old:5", "new:5"]
         if not confirmation_runs:
             return order
-        for batch_index, batch_size in enumerate(sampling_batch_sizes(confirmation_runs), start=2):
-            if batch_index % 2 == 0:
-                order.extend([f"old:{batch_size}", f"new:{batch_size}"])
-            else:
-                order.extend([f"new:{batch_size}", f"old:{batch_size}"])
+        for batch_size in sampling_batch_sizes(confirmation_runs):
+            order.extend([f"old:{batch_size}", f"new:{batch_size}"])
         return order
 
     def test_non_regression_stops_after_two_initial_batches(self):
@@ -259,9 +310,29 @@ print("not-a-valid-timing-row", file=sys.stderr)
         self.assertEqual(process.returncode, 0, process.stdout + process.stderr)
         self.assertEqual(order, self.expected_order())
         plain_output = re.sub(r"\x1b\[[0-9;]*m", "", process.stdout)
-        self.assertIn("initial sampling: 10 runs per binary in 2 batches of 5", plain_output)
+        self.assertNotIn("BENCHMARK QUERY RESULTS", plain_output)
+        self.assertIn("suite: 1 benchmarks", plain_output)
+        self.assertIn(
+            "sampling: 10 initial pairs; 30–100 confirmation pairs outside ±2%, with early noise stop",
+            plain_output,
+        )
+        self.assertIn("regression: fail when the 95% CI is above +10.0%", plain_output)
         self.assertIn("median change +0.0% | within ±2%; done", plain_output)
-        self.assertIn("geomean (initial 10 samples): 1.000s -> 1.000s  +0.0%", plain_output)
+        self.assertIn("geomean: 1.000s -> 1.000s  +0.0%  (initial 10 samples)\nresult: no regressions", plain_output)
+        self.assertIn("UNCHANGED (±2%)\n1 benchmarks", plain_output)
+        self.assertNotIn("\nFASTER\n", plain_output)
+        self.assertNotIn("\nSLOWER (+2%…+10%)\n", plain_output)
+        self.assertNotIn("\nUNCERTAIN REGRESSIONS\n", plain_output)
+        self.assertNotIn("\nREGRESSIONS\n", plain_output)
+        self.assertIn("\033[90msuite: 1 benchmarks\033[0m", process.stdout)
+        self.assertIn(
+            "\033[90msampling: 10 initial pairs; 30–100 confirmation pairs outside ±2%, "
+            "with early noise stop\033[0m",
+            process.stdout,
+        )
+        self.assertIn("\033[90mregression: fail when the 95% CI is above +10.0%\033[0m", process.stdout)
+        self.assertIn("\033[90m+0.0%\033[0m  \033[90m(initial 10 samples)\033[0m", process.stdout)
+        self.assertIn("result: \033[32mno regressions\033[0m", process.stdout)
 
     def test_noise_boundaries_do_not_receive_confirmation_samples(self):
         for new_timing in ("0.98", "1.02"):
@@ -273,67 +344,70 @@ print("not-a-valid-timing-row", file=sys.stderr)
     def test_improvement_receives_confirmation_and_is_classified_by_median(self):
         process, order = self.run_regression_test(self.noisy_improvement_runner_source)
         self.assertEqual(process.returncode, 0, process.stdout + process.stderr)
-        self.assertEqual(order, self.expected_order(15))
+        self.assertEqual(order, self.expected_order(30))
         plain_output = re.sub(r"\x1b\[[0-9;]*m", "", process.stdout)
         self.assertIn(
-            "initial: fake.benchmark: 10 pairs | median change -5.0% | confirming with 15 pairs", plain_output
+            "initial: fake.benchmark: 10 pairs | median change -5.0% | confirming with 30 pairs", plain_output
         )
         self.assertIn(
-            "confirmation: fake.benchmark: 15 pairs | median change -5.0% | 95% CI -5.0%…+0.0% | "
+            "confirm: fake.benchmark: 30 pairs | median change -5.0% | 95% CI -5.0%…+0.0% | "
             "faster (uncertain; budget exhausted)",
             plain_output,
         )
         self.assertRegex(
             plain_output,
             r"FASTER\nbenchmark[^\n]*\n-+[^\n]*\nfake\s+1\.000s\s+0\.950s\s+-0\.050s\s+-5\.0%\s+"
-            r"-5\.0%…\+0\.0%\s+uncertain\s+10\+15",
+            r"-5\.0%…\+0\.0%\s+uncertain\s+10\+30",
         )
-        self.assertIn("geomean (initial 10 samples): 1.000s -> 0.950s  -5.0%", plain_output)
+        self.assertIn("geomean: 1.000s -> 0.950s  -5.0%  (initial 10 samples)", plain_output)
+        self.assertIn("\033[32m-5.0%\033[0m  \033[90m(initial 10 samples)\033[0m", process.stdout)
 
     def test_slowdown_below_regression_limit_receives_confirmation(self):
         process, order = self.run_regression_test(self.stable_runner_source, new_timing="1.08", ci=True)
         self.assertEqual(process.returncode, 0, process.stdout + process.stderr)
-        self.assertEqual(order, self.expected_order(15))
+        self.assertEqual(order, self.expected_order(30))
         plain_output = re.sub(r"\x1b\[[0-9;]*m", "", process.stdout)
         self.assertIn("median change +8.0% | 95% CI +8.0%…+8.0% | slower (confident)", plain_output)
         self.assertRegex(
             plain_output,
-            r"SLOWER BELOW REGRESSION LIMIT\nbenchmark[^\n]*\n-+[^\n]*\nfake\s+1\.000s\s+1\.080s\s+"
-            r"\+0\.080s\s+\+8\.0%\s+\+8\.0%…\+8\.0%\s+confident\s+10\+15",
+            r"SLOWER \(\+2%…\+10%\)\nbenchmark[^\n]*\n-+[^\n]*\nfake\s+1\.000s\s+1\.080s\s+"
+            r"\+0\.080s\s+\+8\.0%\s+\+8\.0%…\+8\.0%\s+confident\s+10\+30",
         )
         self.assertNotIn("::warning title=Inconclusive regression benchmark::", plain_output)
+        self.assertIn("\033[31m+8.0%\033[0m  \033[90m(initial 10 samples)\033[0m", process.stdout)
 
     def test_stable_regression_is_confirmed_from_independent_samples(self):
         process, order = self.run_regression_test(self.stable_runner_source, new_timing="1.3")
         self.assertEqual(process.returncode, 1, process.stdout + process.stderr)
-        self.assertEqual(order, self.expected_order(15))
+        self.assertEqual(order, self.expected_order(30))
         plain_output = re.sub(r"\x1b\[[0-9;]*m", "", process.stdout)
         self.assertIn(
-            "confirmation: fake.benchmark: 15 pairs | median change +30.0% | 95% CI +30.0%…+30.0% | "
+            "confirm: fake.benchmark: 30 pairs | median change +30.0% | 95% CI +30.0%…+30.0% | "
             "regression (confirmed)",
             plain_output,
         )
         self.assertRegex(
             plain_output,
-            r"fake\s+1\.000s\s+1\.300s\s+\+0\.300s\s+\+30\.0%\s+\+30\.0%…\+30\.0%\s+" r"confirmed regression\s+10\+15",
+            r"fake\s+1\.000s\s+1\.300s\s+\+0\.300s\s+\+30\.0%\s+\+30\.0%…\+30\.0%\s+" r"confirmed regression\s+10\+30",
         )
+        self.assertIn("result: \033[31mregression detected\033[0m", process.stdout)
 
-    def test_confirmation_uses_alternating_five_run_batches(self):
+    def test_confirmation_uses_fixed_five_run_batches_and_rounds_up(self):
         process, order = self.run_regression_test(
             self.stable_runner_source,
             old_timing="0.036",
             new_timing="0.045",
         )
         self.assertEqual(process.returncode, 1, process.stdout + process.stderr)
-        self.assertEqual(order, self.expected_order(84))
-        self.assertTrue(all(int(entry.split(":")[1]) <= 5 for entry in order))
+        self.assertEqual(order, self.expected_order(85))
+        self.assertTrue(all(entry.endswith(":5") for entry in order))
         plain_output = re.sub(r"\x1b\[[0-9;]*m", "", process.stdout)
         self.assertIn(
-            "initial: fake.benchmark: 10 pairs | median change +25.0% | confirming with 84 pairs",
+            "initial: fake.benchmark: 10 pairs | median change +25.0% | confirming with 85 pairs",
             plain_output,
         )
-        self.assertIn("confirmation: fake.benchmark: 84 pairs", plain_output)
-        self.assertIn("10+84", plain_output)
+        self.assertIn("confirm: fake.benchmark: 85 pairs", plain_output)
+        self.assertIn("10+85", plain_output)
 
     def test_nofail_reports_confirmed_regression_without_failing(self):
         process, _ = self.run_regression_test(self.stable_runner_source, new_timing="1.3", extra_args=["--nofail"])
@@ -369,27 +443,50 @@ print("not-a-valid-timing-row", file=sys.stderr)
     def test_rejected_candidate_uses_confirmation_for_row_and_initial_for_geomean(self):
         process, order = self.run_regression_test(self.rejected_candidate_runner_source, ci=True)
         self.assertEqual(process.returncode, 0, process.stdout + process.stderr)
-        self.assertEqual(order, self.expected_order(15))
+        self.assertEqual(order, self.expected_order(10))
         plain_output = re.sub(r"\x1b\[[0-9;]*m", "", process.stdout)
-        self.assertIn("within ±2%; no change", plain_output)
-        self.assertIn("geomean (initial 10 samples): 1.000s -> 1.300s  +30.0%", plain_output)
-        self.assertIn("INCONCLUSIVE REGRESSION CANDIDATES\n0 benchmarks", plain_output)
+        self.assertIn("within ±2% (confident; stopped early)", plain_output)
+        self.assertIn("geomean: 1.000s -> 1.300s  +30.0%  (initial 10 samples)", plain_output)
+        self.assertNotIn("UNCERTAIN REGRESSIONS", plain_output)
         self.assertNotIn("::warning title=Inconclusive regression benchmark::", plain_output)
+
+    def test_confirmation_stops_after_twenty_pairs_when_noise_ci_becomes_confident(self):
+        process, order = self.run_regression_test(self.early_stop_after_twenty_runner_source)
+        self.assertEqual(process.returncode, 0, process.stdout + process.stderr)
+        self.assertEqual(order, self.expected_order(20))
+        plain_output = re.sub(r"\x1b\[[0-9;]*m", "", process.stdout)
+        self.assertIn(
+            "confirm: fake.benchmark: 20 pairs | median change +0.0% | 95% CI +0.0%…+0.0% | "
+            "within ±2% (confident; stopped early)",
+            plain_output,
+        )
+
+    def test_confirmation_does_not_stop_when_median_is_noise_but_ci_is_wide(self):
+        process, order = self.run_regression_test(self.wide_noise_runner_source)
+        self.assertEqual(process.returncode, 0, process.stdout + process.stderr)
+        self.assertEqual(order, self.expected_order(30))
+        plain_output = re.sub(r"\x1b\[[0-9;]*m", "", process.stdout)
+        self.assertIn(
+            "confirm: fake.benchmark: 30 pairs | median change +0.0% | 95% CI -10.0%…+10.0% | " "within ±2%; no change",
+            plain_output,
+        )
 
     def test_inconclusive_candidate_warns_without_failing(self):
         process, _ = self.run_regression_test(self.inconclusive_candidate_runner_source, ci=True)
         self.assertEqual(process.returncode, 0, process.stdout + process.stderr)
         plain_output = re.sub(r"\x1b\[[0-9;]*m", "", process.stdout)
         self.assertIn("regression (uncertain; budget exhausted)", plain_output)
-        self.assertIn("INCONCLUSIVE REGRESSION CANDIDATES", plain_output)
+        self.assertIn("UNCERTAIN REGRESSIONS", plain_output)
         self.assertIn("::warning title=Inconclusive regression benchmark::", plain_output)
-        self.assertIn("10+15", plain_output)
+        self.assertIn("10+30", plain_output)
+        self.assertIn("result: \033[33muncertain regressions\033[0m", process.stdout)
 
     def test_malformed_runner_output_is_a_failure(self):
         process, _ = self.run_regression_test(self.malformed_runner_source)
         self.assertEqual(process.returncode, 1, process.stdout + process.stderr)
         self.assertIn("Could not parse benchmark timings", process.stdout)
-        self.assertIn("benchmark failure detected", process.stdout)
+        self.assertIn("benchmark failure", process.stdout)
+        self.assertIn("result: \033[31mbenchmark failure\033[0m", process.stdout)
 
     def test_removed_sampling_option_is_rejected(self):
         process, order = self.run_regression_test(self.stable_runner_source, extra_args=["--initial-runs", "20"])

--- a/scripts/regression/test_comparison.py
+++ b/scripts/regression/test_comparison.py
@@ -117,8 +117,31 @@ print("name\\trun\\ttiming", file=sys.stderr)
 for run in range(1, runs + 1):
     if label == "old":
         timing = 1.0
-    elif invocation < 2 or run % 2 == 0:
+    elif invocation < 2 or run % 3 != 0:
         timing = 1.3
+    else:
+        timing = 1.0
+    print(f"fake.benchmark\\t{run}\\t{timing}", file=sys.stderr)
+"""
+
+    noisy_improvement_runner_source = """#!/usr/bin/env python3
+import os
+import sys
+from pathlib import Path
+
+label = os.path.basename(sys.argv[0])
+runs = int(sys.argv[sys.argv.index("--timed-runs") + 1])
+with open(os.environ["BENCHMARK_ORDER_LOG"], "a", encoding="utf-8") as order_log:
+    order_log.write(f"{label}:{runs}\\n")
+counter_path = Path(os.environ["BENCHMARK_COUNTER_DIR"]) / f"{label}.count"
+invocation = int(counter_path.read_text(encoding="utf-8")) if counter_path.exists() else 0
+counter_path.write_text(str(invocation + 1), encoding="utf-8")
+print("name\\trun\\ttiming", file=sys.stderr)
+for run in range(1, runs + 1):
+    if label == "old":
+        timing = 1.0
+    elif invocation < 2 or run % 3 != 0:
+        timing = 0.95
     else:
         timing = 1.0
     print(f"fake.benchmark\\t{run}\\t{timing}", file=sys.stderr)
@@ -134,7 +157,7 @@ print("not-a-valid-timing-row", file=sys.stderr)
     def run_regression_test(
         self,
         runner_source,
-        new_timing="0.95",
+        new_timing="1.0",
         extra_args=None,
         ci=False,
         create_cache=False,
@@ -201,7 +224,45 @@ print("not-a-valid-timing-row", file=sys.stderr)
         self.assertEqual(order, ["old:5", "new:5", "new:5", "old:5"])
         plain_output = re.sub(r"\x1b\[[0-9;]*m", "", process.stdout)
         self.assertIn("initial sampling: 10 runs per binary in 2 batches of 5", plain_output)
+        self.assertIn("within noise threshold", plain_output)
+        self.assertIn("geomean (initial 10 samples): 1.000s -> 1.000s  +0.0%", plain_output)
+
+    def test_noise_boundaries_do_not_receive_confirmation_samples(self):
+        for new_timing in ("0.98", "1.02"):
+            with self.subTest(new_timing=new_timing):
+                process, order = self.run_regression_test(self.stable_runner_source, new_timing=new_timing)
+                self.assertEqual(process.returncode, 0, process.stdout + process.stderr)
+                self.assertEqual(order, ["old:5", "new:5", "new:5", "old:5"])
+
+    def test_improvement_receives_confirmation_and_is_classified_by_median(self):
+        process, order = self.run_regression_test(self.noisy_improvement_runner_source)
+        self.assertEqual(process.returncode, 0, process.stdout + process.stderr)
+        self.assertEqual(
+            order,
+            ["old:5", "new:5", "new:5", "old:5", "old:8", "new:8", "new:7", "old:7"],
+        )
+        plain_output = re.sub(r"\x1b\[[0-9;]*m", "", process.stdout)
+        self.assertIn("confirmation sampling: fake.benchmark: 15 paired runs", plain_output)
+        self.assertIn("95% CI for PR/base median ratio: 0.950x to 1.000x; faster", plain_output)
+        self.assertRegex(plain_output, r"FASTER\nbenchmark[^\n]*\n-+[^\n]*\nfake\s+1\.000s\s+0\.950s")
         self.assertIn("geomean (initial 10 samples): 1.000s -> 0.950s  -5.0%", plain_output)
+
+    def test_slowdown_below_regression_limit_receives_confirmation(self):
+        process, order = self.run_regression_test(self.stable_runner_source, new_timing="1.08", ci=True)
+        self.assertEqual(process.returncode, 0, process.stdout + process.stderr)
+        self.assertEqual(
+            order,
+            ["old:5", "new:5", "new:5", "old:5", "old:8", "new:8", "new:7", "old:7"],
+        )
+        plain_output = re.sub(r"\x1b\[[0-9;]*m", "", process.stdout)
+        self.assertIn(
+            "1.080x; 95% CI for PR/base median ratio: 1.080x to 1.080x; slower below regression limit", plain_output
+        )
+        self.assertRegex(
+            plain_output,
+            r"SLOWER BELOW REGRESSION LIMIT\nbenchmark[^\n]*\n-+[^\n]*\nfake\s+1\.000s\s+1\.080s",
+        )
+        self.assertNotIn("::warning title=Inconclusive regression benchmark::", plain_output)
 
     def test_stable_regression_is_confirmed_from_independent_samples(self):
         process, order = self.run_regression_test(self.stable_runner_source, new_timing="1.3")
@@ -211,9 +272,9 @@ print("not-a-valid-timing-row", file=sys.stderr)
             ["old:5", "new:5", "new:5", "old:5", "old:8", "new:8", "new:7", "old:7"],
         )
         plain_output = re.sub(r"\x1b\[[0-9;]*m", "", process.stdout)
-        self.assertIn("regression confirmation: fake.benchmark: 15 paired runs", plain_output)
+        self.assertIn("confirmation sampling: fake.benchmark: 15 paired runs", plain_output)
         self.assertIn("95% CI for PR/base median ratio: 1.300x to 1.300x", plain_output)
-        self.assertIn("regression limit: 1.100x (confirmed regression)", plain_output)
+        self.assertIn("confirmed regression", plain_output)
         self.assertRegex(plain_output, r"fake\s+1\.000s\s+1\.300s\s+\+0\.300s\s+\+30\.0%\s+10\+15")
 
     def test_nofail_reports_confirmed_regression_without_failing(self):
@@ -255,7 +316,7 @@ print("not-a-valid-timing-row", file=sys.stderr)
             ["old:5", "new:5", "new:5", "old:5", "old:8", "new:8", "new:7", "old:7"],
         )
         plain_output = re.sub(r"\x1b\[[0-9;]*m", "", process.stdout)
-        self.assertIn("regression rejected", plain_output)
+        self.assertIn("within noise threshold", plain_output)
         self.assertIn("geomean (initial 10 samples): 1.000s -> 1.300s  +30.0%", plain_output)
         self.assertIn("INCONCLUSIVE REGRESSION CANDIDATES\n0 benchmarks", plain_output)
         self.assertNotIn("::warning title=Inconclusive regression benchmark::", plain_output)

--- a/scripts/regression/test_runner.py
+++ b/scripts/regression/test_runner.py
@@ -12,15 +12,17 @@ from comparison import (
     CONFIRMATION_TARGET_SECONDS,
     MAX_CONFIRMATION_RUNS,
     MIN_CONFIRMATION_RUNS,
+    SAMPLE_BATCH_SIZE,
     BenchmarkMeasurement,
     benchmark_measurement,
     confirmation_run_count,
+    sampling_batch_sizes,
 )
 
 
 print = functools.partial(print, flush=True)
 
-INITIAL_BATCH_SIZE = 5
+INITIAL_BATCH_SIZE = SAMPLE_BATCH_SIZE
 INITIAL_RUNS = 2 * INITIAL_BATCH_SIZE
 REGRESSION_LIMIT = 1.10
 NOISE_THRESHOLD = 0.02
@@ -68,6 +70,8 @@ class BenchmarkRow:
     new_timing: str
     delta: str
     change: str
+    confidence_interval: str
+    confidence: str
     runs: str
     bucket: str
     percentage: float = 0
@@ -111,9 +115,7 @@ def run_paired_samples(
     old_timings = []
     new_timings = []
     batch_index = initial_batch_index
-    batch_sizes = [(requested_runs + 1) // 2, requested_runs // 2]
-
-    for batch_size in batch_sizes:
+    for batch_size in sampling_batch_sizes(requested_runs):
         if batch_index % 2 == 0:
             old_batch, old_failure = old_runner.run(benchmark, batch_size)
             new_batch, new_failure = new_runner.run(benchmark, batch_size)
@@ -169,11 +171,12 @@ def run_paired_benchmark(
     is_candidate = (
         initial_measurement.ratio < 1.0 - NOISE_THRESHOLD or initial_measurement.ratio > 1.0 + NOISE_THRESHOLD
     )
+    requested_confirmation_runs = confirmation_run_count(initial_measurement) if is_candidate else 0
     if verbose:
-        decision = "additional sampling required" if is_candidate else "within noise threshold"
+        decision = f"confirming with {requested_confirmation_runs} pairs" if is_candidate else "within ±2%; done"
         print(
-            f"initial sampling: {benchmark}: {initial_count} paired runs, "
-            f"median PR/base {initial_measurement.ratio:.3f}x ({decision})"
+            f"initial: {benchmark}: {initial_count} pairs | "
+            f"median change {format_ratio_change(initial_measurement.ratio)} | {decision}"
         )
 
     if not is_candidate:
@@ -184,7 +187,6 @@ def run_paired_benchmark(
             initial_runs=initial_count,
         )
 
-    requested_confirmation_runs = confirmation_run_count(initial_measurement)
     old_confirmation, new_confirmation, old_failure, new_failure, _ = run_paired_samples(
         old_runner,
         new_runner,
@@ -208,26 +210,17 @@ def run_paired_benchmark(
     if confirmation_measurement.ratio > REGRESSION_LIMIT:
         if lower_bound > REGRESSION_LIMIT:
             outcome = OUTCOME_CONFIRMED_REGRESSION
-            decision = "confirmed regression"
         else:
             outcome = OUTCOME_UNCONFIRMED_REGRESSION
-            decision = "regression inconclusive"
-    elif confirmation_measurement.ratio > 1.0 + NOISE_THRESHOLD:
-        outcome = OUTCOME_NO_REGRESSION
-        decision = "slower below regression limit"
-    elif confirmation_measurement.ratio < 1.0 - NOISE_THRESHOLD:
-        outcome = OUTCOME_NO_REGRESSION
-        decision = "faster"
     else:
         outcome = OUTCOME_NO_REGRESSION
-        decision = "within noise threshold"
 
     if verbose:
         print(
-            f"confirmation sampling: {benchmark}: {confirmation_count} paired runs, "
-            f"median PR/base {confirmation_measurement.ratio:.3f}x; "
-            f"{CONFIDENCE_PERCENTAGE}% CI for PR/base median ratio: {lower_bound:.3f}x to {upper_bound:.3f}x; "
-            f"{decision}"
+            f"confirmation: {benchmark}: {confirmation_count} pairs | "
+            f"median change {format_ratio_change(confirmation_measurement.ratio)} | "
+            f"{CONFIDENCE_PERCENTAGE}% CI {format_ratio_interval((lower_bound, upper_bound))} | "
+            f"{measurement_status(confirmation_measurement, outcome)}"
         )
 
     return BenchmarkResult(
@@ -266,20 +259,53 @@ def format_delta_seconds(delta: float) -> str:
 
 
 def format_percentage(value: float) -> str:
-    return f"{value:+.1f}%" if math.isfinite(value) else "+inf%"
+    if math.isfinite(value):
+        return f"{value:+.1f}%"
+    return "-inf%" if value < 0 else "+inf%"
 
 
-def regression_delta(measurement: BenchmarkMeasurement) -> str:
-    delta_seconds = measurement.new_timing - measurement.old_timing
-    delta_percentage = ((measurement.new_timing / measurement.old_timing) - 1.0) * 100.0
-    return f"{format_delta_seconds(delta_seconds)} ({format_percentage(delta_percentage)})"
+def ratio_change(ratio: float) -> float:
+    return (ratio - 1.0) * 100.0
+
+
+def format_ratio_change(ratio: float) -> str:
+    return format_percentage(ratio_change(ratio))
+
+
+def format_ratio_interval(ratio_interval: Tuple[float, float]) -> str:
+    lower_bound, upper_bound = ratio_interval
+    return f"{format_ratio_change(lower_bound)}…{format_ratio_change(upper_bound)}"
+
+
+def direction_confidence(measurement: BenchmarkMeasurement) -> str:
+    lower_bound, upper_bound = measurement.ratio_interval
+    if measurement.ratio < 1.0 - NOISE_THRESHOLD:
+        return "confident" if upper_bound < 1.0 - NOISE_THRESHOLD else "uncertain"
+    if measurement.ratio > 1.0 + NOISE_THRESHOLD:
+        return "confident" if lower_bound > 1.0 + NOISE_THRESHOLD else "uncertain"
+    return "within noise"
+
+
+def measurement_status(measurement: BenchmarkMeasurement, outcome: str) -> str:
+    if outcome == OUTCOME_CONFIRMED_REGRESSION:
+        return "regression (confirmed)"
+    if outcome == OUTCOME_UNCONFIRMED_REGRESSION:
+        return "regression (uncertain; budget exhausted)"
+    if measurement.ratio < 1.0 - NOISE_THRESHOLD:
+        confidence = direction_confidence(measurement)
+        suffix = "confident" if confidence == "confident" else "uncertain; budget exhausted"
+        return f"faster ({suffix})"
+    if measurement.ratio > 1.0 + NOISE_THRESHOLD:
+        confidence = direction_confidence(measurement)
+        suffix = "confident" if confidence == "confident" else "uncertain; budget exhausted"
+        return f"slower ({suffix})"
+    return "within ±2%; no change"
 
 
 def confidence_text(result: BenchmarkResult) -> str:
     if result.measurement is None:
         return "unavailable"
-    lower_bound, upper_bound = result.measurement.ratio_interval
-    return f"{lower_bound:.3f}x to {upper_bound:.3f}x"
+    return format_ratio_interval(result.measurement.ratio_interval)
 
 
 def emit_github_error(title: str, message: str):
@@ -299,22 +325,27 @@ def report_regression(
         message = f"{suite}: {result.benchmark} failed while comparing base and PR benchmark runs"
         old_timing = "failed"
         new_timing = "failed"
-        summary_delta = "benchmark run failed"
+        delta = "failed"
+        median_change = "failed"
+        confidence = "unavailable"
         failure_summary.append(result)
     else:
         measurement = result.measurement
         assert measurement is not None
         old_timing = format_seconds(measurement.old_timing)
         new_timing = format_seconds(measurement.new_timing)
-        summary_delta = regression_delta(measurement)
+        delta = format_delta_seconds(measurement.new_timing - measurement.old_timing)
+        median_change = format_ratio_change(measurement.ratio)
+        confidence = confidence_text(result)
         message = (
-            f"{suite}: {result.benchmark} regressed from {old_timing} to {new_timing} ({summary_delta}); "
-            f"{CONFIDENCE_PERCENTAGE}% CI for PR/base median ratio {confidence_text(result)}, "
-            f"regression limit {REGRESSION_LIMIT:.3f}x"
+            f"{suite}: {result.benchmark} regressed from {old_timing} to {new_timing}; "
+            f"median change {median_change}, delta {delta}, {CONFIDENCE_PERCENTAGE}% CI {confidence}, "
+            f"regression limit {format_ratio_change(REGRESSION_LIMIT)}"
         )
     emit_github_error("Regression benchmark", message)
     summary_lines.append(
-        f"| `{result.benchmark}` | `{old_timing}` | `{new_timing}` | `{summary_delta}` | `{format_run_count(result)}` |"
+        f"| `{result.benchmark}` | `{old_timing}` | `{new_timing}` | `{delta}` | `{median_change}` | "
+        f"`{confidence}` | `{format_run_count(result)}` |"
     )
 
 
@@ -323,17 +354,18 @@ def report_unconfirmed(result: BenchmarkResult, suite: str, summary_lines: List[
     assert measurement is not None
     old_timing = format_seconds(measurement.old_timing)
     new_timing = format_seconds(measurement.new_timing)
-    delta = regression_delta(measurement)
+    delta = format_delta_seconds(measurement.new_timing - measurement.old_timing)
+    median_change = format_ratio_change(measurement.ratio)
     confidence = confidence_text(result)
     message = (
-        f"{suite}: {result.benchmark} has a confirmation median above the regression limit but remains "
-        f"inconclusive ({delta}); {CONFIDENCE_PERCENTAGE}% CI for PR/base median ratio {confidence}, "
-        f"regression limit {REGRESSION_LIMIT:.3f}x"
+        f"{suite}: {result.benchmark} has median change {median_change}, delta {delta}, and "
+        f"{CONFIDENCE_PERCENTAGE}% CI {confidence}; regression limit {format_ratio_change(REGRESSION_LIMIT)} "
+        f"is uncertain after the confirmation budget"
     )
     emit_github_warning("Inconclusive regression benchmark", message)
     summary_lines.append(
-        f"| `{result.benchmark}` | `{old_timing}` | `{new_timing}` | `{delta}` | "
-        f"`{format_run_count(result)}` | `{confidence}` |"
+        f"| `{result.benchmark}` | `{old_timing}` | `{new_timing}` | `{delta}` | `{median_change}` | "
+        f"`{confidence}` | `{format_run_count(result)}` |"
     )
 
 
@@ -383,17 +415,35 @@ def format_run_count(result: BenchmarkResult) -> str:
     return str(result.initial_runs)
 
 
+def result_confidence(result: BenchmarkResult) -> str:
+    if result.outcome == OUTCOME_CONFIRMED_REGRESSION:
+        return "confirmed regression"
+    if result.outcome == OUTCOME_UNCONFIRMED_REGRESSION:
+        return "uncertain regression"
+    assert result.measurement is not None
+    return direction_confidence(result.measurement)
+
+
 def benchmark_row(result: BenchmarkResult, display_name: str) -> BenchmarkRow:
     bucket = classify_result(result)
     if result.outcome == OUTCOME_FAILURE:
         return BenchmarkRow(
-            result, display_name, "failed", "failed", "failed", "failed", format_run_count(result), bucket
+            result=result,
+            display_name=display_name,
+            old_timing="failed",
+            new_timing="failed",
+            delta="failed",
+            change="failed",
+            confidence_interval="unavailable",
+            confidence="failed",
+            runs=format_run_count(result),
+            bucket=bucket,
         )
 
     measurement = result.measurement
     assert measurement is not None
     delta = measurement.new_timing - measurement.old_timing
-    percentage = ((measurement.new_timing / measurement.old_timing) - 1.0) * 100.0
+    percentage = ratio_change(measurement.ratio)
     return BenchmarkRow(
         result=result,
         display_name=display_name,
@@ -401,6 +451,8 @@ def benchmark_row(result: BenchmarkResult, display_name: str) -> BenchmarkRow:
         new_timing=format_seconds(measurement.new_timing),
         delta=format_delta_seconds(delta),
         change=format_percentage(percentage),
+        confidence_interval=format_ratio_interval(measurement.ratio_interval),
+        confidence=result_confidence(result),
         runs=format_run_count(result),
         bucket=bucket,
         percentage=percentage,
@@ -438,8 +490,20 @@ def row_sort_key(row: BenchmarkRow):
 def render_table(rows: List[BenchmarkRow]):
     if not rows:
         return
-    headers = ["benchmark", "base", "PR", "delta", "change", "runs"]
-    plain_rows = [[row.display_name, row.old_timing, row.new_timing, row.delta, row.change, row.runs] for row in rows]
+    headers = ["benchmark", "base", "PR", "delta", "median change", "95% CI", "confidence", "runs"]
+    plain_rows = [
+        [
+            row.display_name,
+            row.old_timing,
+            row.new_timing,
+            row.delta,
+            row.change,
+            row.confidence_interval,
+            row.confidence,
+            row.runs,
+        ]
+        for row in rows
+    ]
     widths = [len(header) for header in headers]
     for plain_row in plain_rows:
         for index, value in enumerate(plain_row):
@@ -451,7 +515,7 @@ def render_table(rows: List[BenchmarkRow]):
         cells = []
         for index, value in enumerate(plain_row):
             padded = value.ljust(widths[index])
-            if headers[index] == "change":
+            if headers[index] == "median change":
                 padded = color_change(row.bucket, padded)
             cells.append(padded)
         print("  ".join(cells))
@@ -461,7 +525,7 @@ def print_bucket(title: str, rows: List[BenchmarkRow], unchanged_count: int = 0)
     print("")
     print(title)
     if title == "UNCHANGED / NOISE":
-        print(f"{unchanged_count} benchmarks whose median change is within +/-2%")
+        print(f"{unchanged_count} benchmarks whose median change is within ±2%")
     elif rows:
         render_table(rows)
     else:
@@ -522,12 +586,13 @@ def print_benchmark_report(
     print(f"initial sampling: {INITIAL_RUNS} runs per binary in 2 batches of {INITIAL_BATCH_SIZE}")
     print(
         f"confirmation sampling: ceil({CONFIRMATION_TARGET_SECONDS:g}s / faster-side median), "
-        f"clamped to {MIN_CONFIRMATION_RUNS}-{MAX_CONFIRMATION_RUNS} runs per binary"
+        f"clamped to {MIN_CONFIRMATION_RUNS}-{MAX_CONFIRMATION_RUNS} runs per binary in batches of "
+        f"{SAMPLE_BATCH_SIZE}"
     )
-    print(f"confirmation candidates: initial median outside +/-{NOISE_THRESHOLD * 100:.0f}%")
-    print(f"regression limit: {REGRESSION_LIMIT:.3f}x (+{(REGRESSION_LIMIT - 1.0) * 100:.0f}%)")
+    print(f"confirmation candidates: initial median change outside ±{NOISE_THRESHOLD * 100:.0f}%")
+    print(f"regression limit: {format_ratio_change(REGRESSION_LIMIT)}")
     print(
-        f"reporting: confirmation median with +/-{NOISE_THRESHOLD * 100:.0f}% noise threshold; "
+        f"reporting: confirmation median with ±{NOISE_THRESHOLD * 100:.0f}% noise threshold; "
         f"regressions require {CONFIDENCE_PERCENTAGE}% confidence"
     )
     print(f"result: {result_text}")
@@ -593,8 +658,8 @@ def main() -> int:
         summary_lines = [
             f"## Regression Suite: `{suite}`",
             "",
-            "| Benchmark | Base | PR | Delta | Runs |",
-            "| --- | --- | --- | --- | --- |",
+            "| Benchmark | Base | PR | Delta | Median change | 95% CI | Runs |",
+            "| --- | --- | --- | --- | --- | --- | --- |",
         ]
         for result in failing_results:
             report_regression(result, suite, failure_summary, summary_lines)
@@ -604,8 +669,8 @@ def main() -> int:
         summary_lines = [
             f"## Inconclusive Regression Candidates: `{suite}`",
             "",
-            "| Benchmark | Base | PR | Delta | Runs | 95% PR/base median ratio interval |",
-            "| --- | --- | --- | --- | --- | --- |",
+            "| Benchmark | Base | PR | Delta | Median change | 95% CI | Runs |",
+            "| --- | --- | --- | --- | --- | --- | --- |",
         ]
         for result in inconclusive_results:
             report_unconfirmed(result, suite, summary_lines)

--- a/scripts/regression/test_runner.py
+++ b/scripts/regression/test_runner.py
@@ -166,9 +166,11 @@ def run_paired_benchmark(
         return failed_benchmark_result(benchmark, old_failure, new_failure, None, initial_count, 0)
 
     initial_measurement = benchmark_measurement(old_initial, new_initial)
-    is_candidate = initial_measurement.ratio > REGRESSION_LIMIT
+    is_candidate = (
+        initial_measurement.ratio < 1.0 - NOISE_THRESHOLD or initial_measurement.ratio > 1.0 + NOISE_THRESHOLD
+    )
     if verbose:
-        decision = "regression candidate" if is_candidate else "initial sampling complete"
+        decision = "additional sampling required" if is_candidate else "within noise threshold"
         print(
             f"initial sampling: {benchmark}: {initial_count} paired runs, "
             f"median PR/base {initial_measurement.ratio:.3f}x ({decision})"
@@ -203,21 +205,29 @@ def run_paired_benchmark(
 
     confirmation_measurement = benchmark_measurement(old_confirmation, new_confirmation)
     lower_bound, upper_bound = confirmation_measurement.ratio_interval
-    if lower_bound > REGRESSION_LIMIT:
-        outcome = OUTCOME_CONFIRMED_REGRESSION
-        decision = "confirmed regression"
-    elif upper_bound <= REGRESSION_LIMIT:
+    if confirmation_measurement.ratio > REGRESSION_LIMIT:
+        if lower_bound > REGRESSION_LIMIT:
+            outcome = OUTCOME_CONFIRMED_REGRESSION
+            decision = "confirmed regression"
+        else:
+            outcome = OUTCOME_UNCONFIRMED_REGRESSION
+            decision = "regression inconclusive"
+    elif confirmation_measurement.ratio > 1.0 + NOISE_THRESHOLD:
         outcome = OUTCOME_NO_REGRESSION
-        decision = "regression rejected"
+        decision = "slower below regression limit"
+    elif confirmation_measurement.ratio < 1.0 - NOISE_THRESHOLD:
+        outcome = OUTCOME_NO_REGRESSION
+        decision = "faster"
     else:
-        outcome = OUTCOME_UNCONFIRMED_REGRESSION
-        decision = "regression inconclusive"
+        outcome = OUTCOME_NO_REGRESSION
+        decision = "within noise threshold"
 
     if verbose:
         print(
-            f"regression confirmation: {benchmark}: {confirmation_count} paired runs, "
+            f"confirmation sampling: {benchmark}: {confirmation_count} paired runs, "
+            f"median PR/base {confirmation_measurement.ratio:.3f}x; "
             f"{CONFIDENCE_PERCENTAGE}% CI for PR/base median ratio: {lower_bound:.3f}x to {upper_bound:.3f}x; "
-            f"regression limit: {REGRESSION_LIMIT:.3f}x ({decision})"
+            f"{decision}"
         )
 
     return BenchmarkResult(
@@ -316,8 +326,8 @@ def report_unconfirmed(result: BenchmarkResult, suite: str, summary_lines: List[
     delta = regression_delta(measurement)
     confidence = confidence_text(result)
     message = (
-        f"{suite}: {result.benchmark} looked regressive during initial sampling but remains inconclusive "
-        f"({delta}); {CONFIDENCE_PERCENTAGE}% CI for PR/base median ratio {confidence}, "
+        f"{suite}: {result.benchmark} has a confirmation median above the regression limit but remains "
+        f"inconclusive ({delta}); {CONFIDENCE_PERCENTAGE}% CI for PR/base median ratio {confidence}, "
         f"regression limit {REGRESSION_LIMIT:.3f}x"
     )
     emit_github_warning("Inconclusive regression benchmark", message)
@@ -359,10 +369,10 @@ def classify_result(result: BenchmarkResult) -> str:
         return BUCKET_UNCONFIRMED
 
     assert result.measurement is not None
-    lower_ratio, upper_ratio = result.measurement.ratio_interval
-    if lower_ratio > 1.0 + NOISE_THRESHOLD:
+    ratio = result.measurement.ratio
+    if ratio > 1.0 + NOISE_THRESHOLD:
         return BUCKET_SLOWER
-    if upper_ratio < 1.0 - NOISE_THRESHOLD:
+    if ratio < 1.0 - NOISE_THRESHOLD:
         return BUCKET_FASTER
     return BUCKET_UNCHANGED
 
@@ -451,7 +461,7 @@ def print_bucket(title: str, rows: List[BenchmarkRow], unchanged_count: int = 0)
     print("")
     print(title)
     if title == "UNCHANGED / NOISE":
-        print(f"{unchanged_count} benchmarks whose {CONFIDENCE_PERCENTAGE}% interval overlaps +/-2%")
+        print(f"{unchanged_count} benchmarks whose median change is within +/-2%")
     elif rows:
         render_table(rows)
     else:
@@ -514,8 +524,12 @@ def print_benchmark_report(
         f"confirmation sampling: ceil({CONFIRMATION_TARGET_SECONDS:g}s / faster-side median), "
         f"clamped to {MIN_CONFIRMATION_RUNS}-{MAX_CONFIRMATION_RUNS} runs per binary"
     )
+    print(f"confirmation candidates: initial median outside +/-{NOISE_THRESHOLD * 100:.0f}%")
     print(f"regression limit: {REGRESSION_LIMIT:.3f}x (+{(REGRESSION_LIMIT - 1.0) * 100:.0f}%)")
-    print(f"confidence: {CONFIDENCE_PERCENTAGE}%; noise threshold: +/-{NOISE_THRESHOLD * 100:.0f}%")
+    print(
+        f"reporting: confirmation median with +/-{NOISE_THRESHOLD * 100:.0f}% noise threshold; "
+        f"regressions require {CONFIDENCE_PERCENTAGE}% confidence"
+    )
     print(f"result: {result_text}")
     print_geomean_summary(old_geomean, new_geomean)
     print_bucket("UNCHANGED / NOISE", buckets[BUCKET_UNCHANGED], len(buckets[BUCKET_UNCHANGED]))

--- a/scripts/regression/test_runner.py
+++ b/scripts/regression/test_runner.py
@@ -70,8 +70,8 @@ parser.add_argument(
 parser.add_argument(
     "--min-confirmation-runs",
     type=int,
-    default=6,
-    help="Minimum paired timed runs used to confirm a regression (default: 6).",
+    default=15,
+    help="Minimum paired timed runs used to confirm a regression (default: 15).",
 )
 parser.add_argument(
     "--max-confirmation-runs",
@@ -666,14 +666,20 @@ def run_paired_benchmark(old_runner: BenchmarkRunner, new_runner: BenchmarkRunne
         REGRESSION_THRESHOLD_PERCENTAGE,
         REGRESSION_THRESHOLD_SECONDS,
     )
-    confirmed = confirmation_regression.ratio_interval[0] > 1.0
-    outcome = OUTCOME_CONFIRMED_REGRESSION if confirmed else OUTCOME_UNCONFIRMED_REGRESSION
+    lower_bound, upper_bound = confirmation_regression.ratio_interval
+    if lower_bound > 1.0:
+        outcome = OUTCOME_CONFIRMED_REGRESSION
+        decision = "confirmed regression"
+    elif upper_bound <= 1.0:
+        outcome = OUTCOME_NO_REGRESSION
+        decision = "regression rejected"
+    else:
+        outcome = OUTCOME_UNCONFIRMED_REGRESSION
+        decision = "regression inconclusive"
     all_old_timings = old_initial + old_confirmation
     all_new_timings = new_initial + new_confirmation
     combined_measurement = paired_measurement(all_old_timings, all_new_timings)
     if verbose:
-        decision = "confirmed regression" if confirmed else "regression not confirmed"
-        lower_bound, upper_bound = confirmation_regression.ratio_interval
         print(
             f"regression confirmation: {benchmark}: {confirmation_count} paired runs, "
             f"threshold interval {lower_bound:.3f}x to {upper_bound:.3f}x ({decision})"

--- a/scripts/regression/test_runner.py
+++ b/scripts/regression/test_runner.py
@@ -107,8 +107,6 @@ if max_adaptive_time_seconds <= 0:
     parser.error("--max-adaptive-time-seconds must be greater than zero")
 
 
-# Legacy runners without --timed-runs support retain the old confirmation loop.
-NUMBER_REPETITIONS = 5
 # the threshold at which we consider something a regression (percentage)
 REGRESSION_THRESHOLD_PERCENTAGE = 0.1
 # minimal seconds diff for something to be a regression (for very fast benchmarks)
@@ -374,13 +372,10 @@ def print_benchmark_report(
     if common_prefix:
         print(f"common prefix: {common_prefix}")
     print(f"benchmarks: {total_count}")
-    if adaptive_sampling:
-        print(
-            f"timing: paired median, {timed_runs}-{max_timed_runs} timed runs, "
-            f"{max_adaptive_time_seconds:g}s adaptive budget"
-        )
-    else:
-        print(f"timing: median of {timed_runs} timed runs")
+    print(
+        f"timing: paired median, {timed_runs}-{max_timed_runs} timed runs, "
+        f"{max_adaptive_time_seconds:g}s adaptive budget"
+    )
     print(f"threshold: +{REGRESSION_THRESHOLD_PERCENTAGE * 100.0:.1f}% and +{REGRESSION_THRESHOLD_SECONDS:.3f}s")
     print(f"display threshold: +/-{DISPLAY_THRESHOLD_PERCENTAGE:.1f}%")
     print(f"hidden noise: {hidden_noise_count} benchmarks below +/-{DISPLAY_THRESHOLD_PERCENTAGE:.1f}%")
@@ -470,62 +465,6 @@ class BenchmarkResult:
     runs: int = 0
 
 
-def run_benchmarks_legacy(old_runner: BenchmarkRunner, new_runner: BenchmarkRunner, benchmark_list: List[str]):
-    old_results = {}
-    new_results = {}
-    old_failures = {}
-    new_failures = {}
-    run_counts = {}
-    requested_runs = max(timed_runs, 1) if timed_runs is not None else 1
-
-    for benchmark in benchmark_list:
-        old_timings = []
-        new_timings = []
-        old_failure = None
-        new_failure = None
-
-        while len(old_timings) < requested_runs or len(new_timings) < requested_runs:
-            if len(old_timings) < requested_runs:
-                timed_runs_override = None
-                if timed_runs is not None:
-                    timed_runs_override = min(TIMED_RUN_BATCH_SIZE, requested_runs - len(old_timings))
-
-                old_run_timings, old_failure = old_runner.run_benchmark_once(benchmark, timed_runs_override)
-                if old_failure is None and not old_run_timings:
-                    old_failure = "Benchmark did not produce any timings"
-                if old_run_timings:
-                    old_timings.extend(old_run_timings)
-
-            if len(new_timings) < requested_runs:
-                timed_runs_override = None
-                if timed_runs is not None:
-                    timed_runs_override = min(TIMED_RUN_BATCH_SIZE, requested_runs - len(new_timings))
-
-                new_run_timings, new_failure = new_runner.run_benchmark_once(benchmark, timed_runs_override)
-                if new_failure is None and not new_run_timings:
-                    new_failure = "Benchmark did not produce any timings"
-                if new_run_timings:
-                    new_timings.extend(new_run_timings)
-
-            if old_failure or new_failure:
-                break
-
-        if old_failure:
-            old_results[benchmark] = 'Failed to run benchmark ' + benchmark
-            old_failures[benchmark] = old_failure
-        else:
-            old_results[benchmark], old_failures[benchmark] = old_runner.complete_benchmark(benchmark, old_timings)
-
-        if new_failure:
-            new_results[benchmark] = 'Failed to run benchmark ' + benchmark
-            new_failures[benchmark] = new_failure
-        else:
-            new_results[benchmark], new_failures[benchmark] = new_runner.complete_benchmark(benchmark, new_timings)
-        run_counts[benchmark] = min(len(old_timings), len(new_timings))
-
-    return old_results, old_failures, new_results, new_failures, run_counts
-
-
 def run_paired_benchmark(old_runner: BenchmarkRunner, new_runner: BenchmarkRunner, benchmark: str) -> BenchmarkResult:
     old_timings = []
     new_timings = []
@@ -596,45 +535,11 @@ def run_paired_benchmark(old_runner: BenchmarkRunner, new_runner: BenchmarkRunne
 
 
 multiply_percentage = 1.0 + REGRESSION_THRESHOLD_PERCENTAGE
-adaptive_sampling = old_runner.supports_timed_runs and new_runner.supports_timed_runs
-if adaptive_sampling:
-    all_results = [run_paired_benchmark(old_runner, new_runner, benchmark) for benchmark in benchmark_list]
-else:
-    print("Adaptive paired sampling disabled because a benchmark runner does not support --timed-runs")
-    other_results: List[BenchmarkResult] = []
-    error_list: List[BenchmarkResult] = []
-    for i in range(NUMBER_REPETITIONS):
-        regression_list: List[BenchmarkResult] = []
-        if len(benchmark_list) == 0:
-            break
-        print(
-            f'''====================================================
-==============      ITERATION {i}        =============
-==============      REMAINING {len(benchmark_list)}        =============
-====================================================
-'''
-        )
+if not old_runner.supports_timed_runs or not new_runner.supports_timed_runs:
+    print("Adaptive paired sampling requires both benchmark runners to support --timed-runs")
+    exit(1)
 
-        old_results, old_failures, new_results, new_failures, run_counts = run_benchmarks_legacy(
-            old_runner, new_runner, benchmark_list
-        )
-
-        for benchmark in benchmark_list:
-            old_res = old_results[benchmark]
-            new_res = new_results[benchmark]
-            old_fail = old_failures[benchmark]
-            new_fail = new_failures[benchmark]
-            runs = run_counts[benchmark]
-
-            if isinstance(old_res, str) or isinstance(new_res, str):
-                error_list.append(BenchmarkResult(benchmark, old_res, new_res, old_fail, new_fail, runs))
-            elif (not no_regression_fail) and is_regression(old_res, new_res):
-                regression_list.append(BenchmarkResult(benchmark, old_res, new_res, runs=runs))
-            else:
-                other_results.append(BenchmarkResult(benchmark, old_res, new_res, runs=runs))
-        benchmark_list = [res.benchmark for res in regression_list]
-
-    all_results = other_results + regression_list + error_list
+all_results = [run_paired_benchmark(old_runner, new_runner, benchmark) for benchmark in benchmark_list]
 
 final_regression_results = [
     result

--- a/scripts/regression/test_runner.py
+++ b/scripts/regression/test_runner.py
@@ -3,9 +3,13 @@ import math
 import functools
 import shutil
 from benchmark import BenchmarkRunner, BenchmarkRunnerConfig
-from comparison import paired_measurement, sampling_decision
+from comparison import (
+    confirmation_run_count,
+    paired_measurement,
+    regression_measurement,
+)
 from dataclasses import dataclass
-from typing import Optional, List, Union, Dict
+from typing import Optional, List, Union, Dict, Tuple
 from pathlib import Path
 
 print = functools.partial(print, flush=True)
@@ -22,7 +26,7 @@ def is_number(s):
 # Geometric mean of an array of numbers
 def geomean(xs):
     if len(xs) == 0:
-        return 'EMPTY'
+        return "EMPTY"
     for entry in xs:
         if not is_number(entry):
             return entry
@@ -43,32 +47,49 @@ parser.add_argument("--threads", type=int, help="Number of threads to use.")
 parser.add_argument("--memory_limit", type=str, help="Memory limit to use.")
 parser.add_argument("--nofail", action="store_true", help="Do not fail on regression.")
 parser.add_argument("--disable-timeout", action="store_true", help="Disable timeout.")
-parser.add_argument("--max-timeout", type=int, default=3600, help="Set maximum timeout in seconds (default: 3600).")
+parser.add_argument(
+    "--max-timeout",
+    type=int,
+    default=3600,
+    help="Set maximum timeout in seconds (default: 3600).",
+)
 parser.add_argument("--root-dir", type=str, default="", help="Root directory.")
 parser.add_argument("--no-summary", type=str, default=False, help="No summary in the end.")
 parser.add_argument(
-    "--timed-runs",
+    "--initial-runs",
     type=int,
-    default=20,
-    help="Minimum number of timed runs per benchmark (default: 20).",
+    default=10,
+    help="Number of initial paired timed runs for each benchmark (default: 10).",
 )
 parser.add_argument(
-    "--max-timed-runs",
+    "--confirmation-time-seconds",
+    type=float,
+    default=3.0,
+    help="Target measured time per runner when confirming a regression (default: 3 seconds).",
+)
+parser.add_argument(
+    "--min-confirmation-runs",
+    type=int,
+    default=6,
+    help="Minimum paired timed runs used to confirm a regression (default: 6).",
+)
+parser.add_argument(
+    "--max-confirmation-runs",
     type=int,
     default=100,
-    help="Maximum number of timed runs per benchmark (default: 100).",
+    help="Maximum paired timed runs used to confirm a regression (default: 100).",
 )
 parser.add_argument(
-    "--max-adaptive-time-seconds",
-    type=float,
-    default=10.0,
-    help="Maximum combined measured time before adaptive sampling stops (default: 10 seconds).",
+    "--clear-benchmark-cache",
+    action="store_true",
+    help="Clear benchmark caches prior to running",
+    default=False,
 )
 parser.add_argument(
-    "--clear-benchmark-cache", action="store_true", help="Clear benchmark caches prior to running", default=False
-)
-parser.add_argument(
-    "--keep-benchmark-data", action="store_true", help="Benchmark data will not be deleted between tests", default=False
+    "--keep-benchmark-data",
+    action="store_true",
+    help="Benchmark data will not be deleted between tests",
+    default=False,
 )
 parser.add_argument(
     "--regression-threshold-seconds",
@@ -95,16 +116,19 @@ no_summary = args.no_summary
 clear_benchmark_cache = args.clear_benchmark_cache
 keep_benchmark_data = args.keep_benchmark_data
 regression_threshold_seconds = args.regression_threshold_seconds
-timed_runs = args.timed_runs
-max_timed_runs = args.max_timed_runs
-max_adaptive_time_seconds = args.max_adaptive_time_seconds
+initial_runs = args.initial_runs
+confirmation_time_seconds = args.confirmation_time_seconds
+min_confirmation_runs = args.min_confirmation_runs
+max_confirmation_runs = args.max_confirmation_runs
 
-if timed_runs <= 0:
-    parser.error("--timed-runs must be greater than zero")
-if max_timed_runs < timed_runs:
-    parser.error("--max-timed-runs must be greater than or equal to --timed-runs")
-if max_adaptive_time_seconds <= 0:
-    parser.error("--max-adaptive-time-seconds must be greater than zero")
+if initial_runs <= 0:
+    parser.error("--initial-runs must be greater than zero")
+if confirmation_time_seconds <= 0:
+    parser.error("--confirmation-time-seconds must be greater than zero")
+if min_confirmation_runs < 6:
+    parser.error("--min-confirmation-runs must be at least 6")
+if max_confirmation_runs < min_confirmation_runs:
+    parser.error("--max-confirmation-runs must be greater than or equal to --min-confirmation-runs")
 
 
 # the threshold at which we consider something a regression (percentage)
@@ -113,21 +137,27 @@ REGRESSION_THRESHOLD_PERCENTAGE = 0.1
 REGRESSION_THRESHOLD_SECONDS = regression_threshold_seconds
 # hide benchmark changes that are below the noise floor in the final report
 DISPLAY_THRESHOLD_PERCENTAGE = 2.0
-TIMED_RUN_BATCH_SIZE = 5
 
 ANSI_RED = "\033[31m"
 ANSI_GREEN = "\033[32m"
+ANSI_YELLOW = "\033[33m"
 ANSI_RESET = "\033[0m"
 
 BUCKET_UNCHANGED = "unchanged"
 BUCKET_FASTER = "faster"
 BUCKET_SLOWER = "slower"
 BUCKET_REGRESSION = "regression"
+BUCKET_UNCONFIRMED = "unconfirmed"
 BUCKET_FAILURE = "failure"
+
+OUTCOME_NO_REGRESSION = "no_regression"
+OUTCOME_CONFIRMED_REGRESSION = "confirmed_regression"
+OUTCOME_UNCONFIRMED_REGRESSION = "unconfirmed_regression"
+OUTCOME_FAILURE = "failure"
 
 
 def in_ci():
-    return os.getenv('CI') == 'true'
+    return os.getenv("CI") == "true"
 
 
 def suite_name():
@@ -178,6 +208,11 @@ def emit_github_error(title: str, message: str):
         print(f"::error title={title}::{message}")
 
 
+def emit_github_warning(title: str, message: str):
+    if in_ci():
+        print(f"::warning title={title}::{message}")
+
+
 def benchmark_timing_summary(regression: "BenchmarkResult"):
     old_timing = format_seconds(regression.old_result)
     new_timing = format_seconds(regression.new_result)
@@ -205,6 +240,24 @@ def report_regression(regression: "BenchmarkResult", summary: List[dict], summar
             "new_failure": regression.new_failure,
         }
         summary.append(new_data)
+
+
+def report_unconfirmed(result: "BenchmarkResult", summary_lines: List[str]):
+    if isinstance(result.old_result, str) or isinstance(result.new_result, str):
+        raise ValueError("An unconfirmed regression must have benchmark timings")
+    old_timing, new_timing = benchmark_timing_summary(result)
+    delta = regression_delta(result.old_result, result.new_result)
+    lower_bound, upper_bound = result.confirmation_interval
+    confidence = f"{lower_bound:.3f}x to {upper_bound:.3f}x"
+    message = (
+        f"{suite_name()}: {result.benchmark} looked regressive during initial sampling but was not confirmed "
+        f"({delta}, confirmation interval {confidence})"
+    )
+    emit_github_warning("Unconfirmed regression benchmark", message)
+    summary_lines.append(
+        f"| `{result.benchmark}` | `{old_timing}` | `{new_timing}` | `{delta}` | "
+        f"`{result.initial_runs}+{result.confirmation_runs}` | `{confidence}` |"
+    )
 
 
 @dataclass
@@ -243,20 +296,27 @@ def benchmark_display_names(benchmarks: List[str]) -> Dict[str, str]:
     return display_names
 
 
-def is_regression(old_value: float, new_value: float) -> bool:
-    return (old_value + REGRESSION_THRESHOLD_SECONDS) * multiply_percentage < new_value
-
-
 def classify_result(result: "BenchmarkResult") -> str:
     if isinstance(result.old_result, str) or isinstance(result.new_result, str):
         return BUCKET_FAILURE
-    if is_regression(result.old_result, result.new_result):
+    if result.outcome == OUTCOME_CONFIRMED_REGRESSION:
         return BUCKET_REGRESSION
-    if result.new_result > result.old_result:
+    if result.outcome == OUTCOME_UNCONFIRMED_REGRESSION:
+        return BUCKET_UNCONFIRMED
+
+    display_ratio = DISPLAY_THRESHOLD_PERCENTAGE / 100.0
+    lower_ratio, upper_ratio = result.ratio_interval
+    if lower_ratio > 1.0 + display_ratio:
         return BUCKET_SLOWER
-    if result.new_result < result.old_result:
+    if upper_ratio < 1.0 - display_ratio:
         return BUCKET_FASTER
     return BUCKET_UNCHANGED
+
+
+def format_run_count(result: "BenchmarkResult") -> str:
+    if result.confirmation_runs > 0:
+        return f"{result.initial_runs}+{result.confirmation_runs}"
+    return str(result.initial_runs)
 
 
 def benchmark_row(result: "BenchmarkResult", display_name: str) -> BenchmarkRow:
@@ -268,7 +328,7 @@ def benchmark_row(result: "BenchmarkResult", display_name: str) -> BenchmarkRow:
             new_timing=format_seconds(result.new_result),
             delta="failed",
             change="failed",
-            runs=str(result.runs),
+            runs=format_run_count(result),
             bucket=BUCKET_FAILURE,
         )
     delta = result.new_result - result.old_result
@@ -280,14 +340,14 @@ def benchmark_row(result: "BenchmarkResult", display_name: str) -> BenchmarkRow:
         new_timing=format_seconds(result.new_result),
         delta=format_delta_seconds(delta),
         change=format_percentage(percentage),
-        runs=str(result.runs),
+        runs=format_run_count(result),
         bucket=classify_result(result),
         percentage=percentage,
     )
 
 
 def show_in_report(row: BenchmarkRow) -> bool:
-    if row.bucket in (BUCKET_REGRESSION, BUCKET_FAILURE):
+    if row.bucket in (BUCKET_REGRESSION, BUCKET_UNCONFIRMED, BUCKET_FAILURE):
         return True
     if not math.isfinite(row.percentage):
         return True
@@ -297,6 +357,8 @@ def show_in_report(row: BenchmarkRow) -> bool:
 def color_change(row: BenchmarkRow, value: str) -> str:
     if row.bucket in (BUCKET_REGRESSION, BUCKET_SLOWER, BUCKET_FAILURE):
         return f"{ANSI_RED}{value}{ANSI_RESET}"
+    if row.bucket == BUCKET_UNCONFIRMED:
+        return f"{ANSI_YELLOW}{value}{ANSI_RESET}"
     if row.bucket == BUCKET_FASTER:
         return f"{ANSI_GREEN}{value}{ANSI_RESET}"
     return value
@@ -307,12 +369,13 @@ def row_sort_key(row: BenchmarkRow):
         BUCKET_UNCHANGED: 0,
         BUCKET_FASTER: 1,
         BUCKET_SLOWER: 2,
-        BUCKET_REGRESSION: 3,
-        BUCKET_FAILURE: 4,
+        BUCKET_UNCONFIRMED: 3,
+        BUCKET_REGRESSION: 4,
+        BUCKET_FAILURE: 5,
     }
     if row.bucket == BUCKET_FASTER:
         bucket_value = -row.percentage
-    elif row.bucket in (BUCKET_SLOWER, BUCKET_REGRESSION):
+    elif row.bucket in (BUCKET_SLOWER, BUCKET_UNCONFIRMED, BUCKET_REGRESSION):
         bucket_value = row.percentage
     else:
         bucket_value = 0
@@ -323,7 +386,17 @@ def render_table(rows: List[BenchmarkRow]):
     if len(rows) == 0:
         return
     headers = ["benchmark", "old", "new", "delta", "change", "runs"]
-    plain_rows = [[row.display_name, row.old_timing, row.new_timing, row.delta, row.change, row.runs] for row in rows]
+    plain_rows = [
+        [
+            row.display_name,
+            row.old_timing,
+            row.new_timing,
+            row.delta,
+            row.change,
+            row.runs,
+        ]
+        for row in rows
+    ]
     widths = [len(header) for header in headers]
     for plain_row in plain_rows:
         for index, value in enumerate(plain_row):
@@ -363,6 +436,7 @@ def print_benchmark_report(
         BUCKET_UNCHANGED: [row for row in rows if row.bucket == BUCKET_UNCHANGED],
         BUCKET_FASTER: [row for row in rows if row.bucket == BUCKET_FASTER],
         BUCKET_SLOWER: [row for row in rows if row.bucket == BUCKET_SLOWER],
+        BUCKET_UNCONFIRMED: [row for row in rows if row.bucket == BUCKET_UNCONFIRMED],
         BUCKET_REGRESSION: [row for row in rows if row.bucket == BUCKET_REGRESSION],
         BUCKET_FAILURE: [row for row in rows if row.bucket == BUCKET_FAILURE],
     }
@@ -372,10 +446,8 @@ def print_benchmark_report(
     if common_prefix:
         print(f"common prefix: {common_prefix}")
     print(f"benchmarks: {total_count}")
-    print(
-        f"timing: paired median, {timed_runs}-{max_timed_runs} timed runs, "
-        f"{max_adaptive_time_seconds:g}s adaptive budget"
-    )
+    print(f"timing: {initial_runs} initial runs; regression confirmation targets {confirmation_time_seconds:g}s")
+    print(f"confirmation runs: {min_confirmation_runs}-{max_confirmation_runs}")
     print(f"threshold: +{REGRESSION_THRESHOLD_PERCENTAGE * 100.0:.1f}% and +{REGRESSION_THRESHOLD_SECONDS:.3f}s")
     print(f"display threshold: +/-{DISPLAY_THRESHOLD_PERCENTAGE:.1f}%")
     print(f"hidden noise: {hidden_noise_count} benchmarks below +/-{DISPLAY_THRESHOLD_PERCENTAGE:.1f}%")
@@ -384,6 +456,7 @@ def print_benchmark_report(
     print_bucket("UNCHANGED / NOISE", buckets[BUCKET_UNCHANGED], hidden_noise_count)
     print_bucket("FASTER", buckets[BUCKET_FASTER])
     print_bucket("SLOWER BELOW THRESHOLD", buckets[BUCKET_SLOWER])
+    print_bucket("UNCONFIRMED REGRESSION CANDIDATES", buckets[BUCKET_UNCONFIRMED])
     print_bucket("REGRESSIONS", buckets[BUCKET_REGRESSION])
     if len(buckets[BUCKET_FAILURE]) > 0:
         print_bucket("FAILURES", buckets[BUCKET_FAILURE])
@@ -416,7 +489,7 @@ def print_geomean_summary(time_a: Union[float, str], time_b: Union[float, str]):
         delta=format_delta_seconds(time_b - time_a),
         change=format_percentage(delta_pct),
         runs="",
-        bucket=BUCKET_SLOWER if delta_pct > 0 else BUCKET_FASTER if delta_pct < 0 else BUCKET_UNCHANGED,
+        bucket=(BUCKET_SLOWER if delta_pct > 0 else BUCKET_FASTER if delta_pct < 0 else BUCKET_UNCHANGED),
         percentage=delta_pct,
     )
     print(f"geomean: {format_seconds(time_a)} -> {format_seconds(time_b)}  {color_change(row, row.change)}")
@@ -431,8 +504,8 @@ if not os.path.isfile(new_runner_path):
     exit(1)
 
 if clear_benchmark_cache:
-    old_cache_path = os.path.join(os.path.dirname(old_runner_path), '..', '..', '..', 'duckdb_benchmark_data')
-    new_cache_path = os.path.join(os.path.dirname(new_runner_path), '..', '..', '..', 'duckdb_benchmark_data')
+    old_cache_path = os.path.join(os.path.dirname(old_runner_path), "..", "..", "..", "duckdb_benchmark_data")
+    new_cache_path = os.path.join(os.path.dirname(new_runner_path), "..", "..", "..", "duckdb_benchmark_data")
     try:
         shutil.rmtree(old_cache_path)
     except:
@@ -463,15 +536,28 @@ class BenchmarkResult:
     old_failure: Optional[str] = None
     new_failure: Optional[str] = None
     runs: int = 0
+    initial_runs: int = 0
+    confirmation_runs: int = 0
+    outcome: str = OUTCOME_NO_REGRESSION
+    ratio_interval: Tuple[float, float] = (-math.inf, math.inf)
+    confirmation_interval: Tuple[float, float] = (-math.inf, math.inf)
 
 
-def run_paired_benchmark(old_runner: BenchmarkRunner, new_runner: BenchmarkRunner, benchmark: str) -> BenchmarkResult:
+def run_paired_samples(
+    old_runner: BenchmarkRunner,
+    new_runner: BenchmarkRunner,
+    benchmark: str,
+    requested_runs: int,
+    initial_batch_index: int,
+):
     old_timings = []
     new_timings = []
-    batch_index = 0
+    batch_index = initial_batch_index
 
-    while len(old_timings) < max_timed_runs:
-        batch_size = min(TIMED_RUN_BATCH_SIZE, max_timed_runs - len(old_timings))
+    batch_sizes = [(requested_runs + 1) // 2, requested_runs // 2]
+    for batch_size in batch_sizes:
+        if batch_size == 0:
+            continue
         if batch_index % 2 == 0:
             old_batch, old_failure = old_runner.run_benchmark_once(benchmark, batch_size)
             new_batch, new_failure = new_runner.run_benchmark_once(benchmark, batch_size)
@@ -482,61 +568,132 @@ def run_paired_benchmark(old_runner: BenchmarkRunner, new_runner: BenchmarkRunne
         old_batch = old_batch or []
         new_batch = new_batch or []
         if old_failure or new_failure:
-            failure_result = 'Failed to run benchmark ' + benchmark
-            return BenchmarkResult(
-                benchmark,
-                failure_result,
-                failure_result,
-                old_failure,
-                new_failure,
-                min(len(old_timings), len(new_timings)),
-            )
+            return old_timings, new_timings, old_failure, new_failure, batch_index
         if not old_batch or not new_batch:
             failure = "Benchmark did not produce any timings"
-            failure_result = 'Failed to run benchmark ' + benchmark
-            return BenchmarkResult(
-                benchmark,
-                failure_result,
-                failure_result,
+            return (
+                old_timings,
+                new_timings,
                 failure if not old_batch else None,
                 failure if not new_batch else None,
-                min(len(old_timings), len(new_timings)),
+                batch_index,
             )
         if len(old_batch) != len(new_batch):
             failure = f"Paired benchmark batches produced different run counts: {len(old_batch)} and {len(new_batch)}"
-            failure_result = 'Failed to run benchmark ' + benchmark
-            return BenchmarkResult(benchmark, failure_result, failure_result, failure, failure, len(old_timings))
+            return old_timings, new_timings, failure, failure, batch_index
 
         old_timings.extend(old_batch)
         new_timings.extend(new_batch)
         batch_index += 1
 
-        measurement = paired_measurement(old_timings, new_timings)
-        measured_seconds = math.fsum(old_timings) + math.fsum(new_timings)
-        decision = sampling_decision(
-            measurement,
-            measured_seconds,
-            timed_runs,
-            max_timed_runs,
-            max_adaptive_time_seconds,
-            DISPLAY_THRESHOLD_PERCENTAGE,
-            REGRESSION_THRESHOLD_PERCENTAGE,
-            REGRESSION_THRESHOLD_SECONDS,
+    return old_timings, new_timings, None, None, batch_index
+
+
+def failed_benchmark_result(
+    benchmark: str,
+    old_failure: Optional[str],
+    new_failure: Optional[str],
+    initial_count: int,
+    confirmation_count: int,
+) -> BenchmarkResult:
+    failure_result = "Failed to run benchmark " + benchmark
+    return BenchmarkResult(
+        benchmark,
+        failure_result,
+        failure_result,
+        old_failure,
+        new_failure,
+        initial_count + confirmation_count,
+        initial_count,
+        confirmation_count,
+        OUTCOME_FAILURE,
+    )
+
+
+def run_paired_benchmark(old_runner: BenchmarkRunner, new_runner: BenchmarkRunner, benchmark: str) -> BenchmarkResult:
+    old_initial, new_initial, old_failure, new_failure, batch_index = run_paired_samples(
+        old_runner, new_runner, benchmark, initial_runs, 0
+    )
+    initial_count = min(len(old_initial), len(new_initial))
+    if old_failure or new_failure:
+        return failed_benchmark_result(benchmark, old_failure, new_failure, initial_count, 0)
+
+    initial_measurement = paired_measurement(old_initial, new_initial)
+    initial_regression = regression_measurement(
+        old_initial,
+        new_initial,
+        REGRESSION_THRESHOLD_PERCENTAGE,
+        REGRESSION_THRESHOLD_SECONDS,
+    )
+    is_candidate = initial_regression.ratio > 1.0
+    if verbose:
+        decision = "regression candidate" if is_candidate else "initial sampling complete"
+        print(
+            f"initial sampling: {benchmark}: {initial_count} paired runs, "
+            f"{(initial_measurement.ratio - 1.0) * 100.0:+.1f}% ({decision})"
         )
-        if verbose:
-            print(
-                f"adaptive sampling: {benchmark}: {measurement.runs} paired runs, "
-                f"{(measurement.ratio - 1.0) * 100.0:+.1f}% ({decision.reason})"
-            )
-        if not decision.collect_more:
-            return BenchmarkResult(benchmark, measurement.old_timing, measurement.new_timing, runs=measurement.runs)
 
-    raise RuntimeError("Adaptive benchmark loop exceeded its configured run limit")
+    if not is_candidate:
+        return BenchmarkResult(
+            benchmark,
+            initial_measurement.old_timing,
+            initial_measurement.new_timing,
+            runs=initial_count,
+            initial_runs=initial_count,
+            ratio_interval=initial_measurement.ratio_interval,
+        )
+
+    requested_confirmation_runs = confirmation_run_count(
+        initial_measurement,
+        confirmation_time_seconds,
+        min_confirmation_runs,
+        max_confirmation_runs,
+    )
+    old_confirmation, new_confirmation, old_failure, new_failure, _ = run_paired_samples(
+        old_runner,
+        new_runner,
+        benchmark,
+        requested_confirmation_runs,
+        batch_index,
+    )
+    confirmation_count = min(len(old_confirmation), len(new_confirmation))
+    if old_failure or new_failure:
+        return failed_benchmark_result(benchmark, old_failure, new_failure, initial_count, confirmation_count)
+
+    confirmation_regression = regression_measurement(
+        old_confirmation,
+        new_confirmation,
+        REGRESSION_THRESHOLD_PERCENTAGE,
+        REGRESSION_THRESHOLD_SECONDS,
+    )
+    confirmed = confirmation_regression.ratio_interval[0] > 1.0
+    outcome = OUTCOME_CONFIRMED_REGRESSION if confirmed else OUTCOME_UNCONFIRMED_REGRESSION
+    all_old_timings = old_initial + old_confirmation
+    all_new_timings = new_initial + new_confirmation
+    combined_measurement = paired_measurement(all_old_timings, all_new_timings)
+    if verbose:
+        decision = "confirmed regression" if confirmed else "regression not confirmed"
+        lower_bound, upper_bound = confirmation_regression.ratio_interval
+        print(
+            f"regression confirmation: {benchmark}: {confirmation_count} paired runs, "
+            f"threshold interval {lower_bound:.3f}x to {upper_bound:.3f}x ({decision})"
+        )
+
+    return BenchmarkResult(
+        benchmark,
+        combined_measurement.old_timing,
+        combined_measurement.new_timing,
+        runs=initial_count + confirmation_count,
+        initial_runs=initial_count,
+        confirmation_runs=confirmation_count,
+        outcome=outcome,
+        ratio_interval=combined_measurement.ratio_interval,
+        confirmation_interval=confirmation_regression.ratio_interval,
+    )
 
 
-multiply_percentage = 1.0 + REGRESSION_THRESHOLD_PERCENTAGE
 if not old_runner.supports_timed_runs or not new_runner.supports_timed_runs:
-    print("Adaptive paired sampling requires both benchmark runners to support --timed-runs")
+    print("Paired benchmark sampling requires both benchmark runners to support --timed-runs")
     exit(1)
 
 all_results = [run_paired_benchmark(old_runner, new_runner, benchmark) for benchmark in benchmark_list]
@@ -546,8 +703,9 @@ final_regression_results = [
     for result in all_results
     if isinstance(result.old_result, str)
     or isinstance(result.new_result, str)
-    or ((not no_regression_fail) and is_regression(result.old_result, result.new_result))
+    or ((not no_regression_fail) and result.outcome == OUTCOME_CONFIRMED_REGRESSION)
 ]
+unconfirmed_results = [result for result in all_results if result.outcome == OUTCOME_UNCONFIRMED_REGRESSION]
 display_names = benchmark_display_names([result.benchmark for result in all_results])
 rows = [benchmark_row(result, display_names[result.benchmark]) for result in all_results]
 rows.sort(key=row_sort_key)
@@ -568,12 +726,26 @@ if len(final_regression_results) > 0:
         report_regression(regression, summary, summary_lines)
     append_step_summary(summary_lines + [""])
 
+if len(unconfirmed_results) > 0:
+    summary_lines = [
+        f"## Unconfirmed Regression Candidates: `{suite_name()}`",
+        "",
+        "| Benchmark | Base | PR | Delta | Runs | Confirmation interval |",
+        "| --- | --- | --- | --- | --- | --- |",
+    ]
+    for result in unconfirmed_results:
+        report_unconfirmed(result, summary_lines)
+    append_step_summary(summary_lines + [""])
+
 has_failures = any(row.bucket == BUCKET_FAILURE for row in rows)
 has_regressions = any(row.bucket == BUCKET_REGRESSION for row in rows)
+has_unconfirmed = any(row.bucket == BUCKET_UNCONFIRMED for row in rows)
 if has_failures:
     result_text = "benchmark failure detected"
 elif has_regressions:
     result_text = "regression detected"
+elif has_unconfirmed:
+    result_text = "no confirmed regressions; noisy candidates reported"
 else:
     result_text = "no regressions detected"
 
@@ -585,19 +757,27 @@ successful_results = [
 ]
 time_a = geomean([result.old_result for result in successful_results])
 time_b = geomean([result.new_result for result in successful_results])
-print_benchmark_report(visible_rows, common_prefix, result_text, len(rows), hidden_noise_count, time_a, time_b)
+print_benchmark_report(
+    visible_rows,
+    common_prefix,
+    result_text,
+    len(rows),
+    hidden_noise_count,
+    time_a,
+    time_b,
+)
 
 # nuke cached benchmark data between runs
 if not keep_benchmark_data:
     if os.path.isdir("duckdb_benchmark_data"):
-        shutil.rmtree('duckdb_benchmark_data')
+        shutil.rmtree("duckdb_benchmark_data")
 
 if summary and not no_summary:
     print(
-        '''\n\n====================================================
+        """\n\n====================================================
 ================  FAILURES SUMMARY  ================
 ====================================================
-'''
+"""
     )
     # check the value is "true" otherwise you'll see the prefix in local run outputs
     prefix = "::error::" if in_ci() else ""

--- a/scripts/regression/test_runner.py
+++ b/scripts/regression/test_runner.py
@@ -21,11 +21,10 @@ from comparison import (
 
 print = functools.partial(print, flush=True)
 
-INITIAL_BATCH_SIZE = SAMPLE_BATCH_SIZE
-INITIAL_RUNS = 2 * INITIAL_BATCH_SIZE
+INITIAL_RUNS = 2 * SAMPLE_BATCH_SIZE
 REGRESSION_LIMIT = 1.10
 NOISE_THRESHOLD = 0.02
-CONFIDENCE_PERCENTAGE = 95
+GEOMEAN_REGRESSION_SECONDS = 0.050
 
 ANSI_RED = "\033[31m"
 ANSI_GREEN = "\033[32m"
@@ -37,12 +36,10 @@ BUCKET_UNCHANGED = "unchanged"
 BUCKET_FASTER = "faster"
 BUCKET_SLOWER = "slower"
 BUCKET_REGRESSION = "regression"
-BUCKET_UNCONFIRMED = "unconfirmed"
 BUCKET_FAILURE = "failure"
 
 OUTCOME_NO_REGRESSION = "no_regression"
-OUTCOME_CONFIRMED_REGRESSION = "confirmed_regression"
-OUTCOME_UNCONFIRMED_REGRESSION = "unconfirmed_regression"
+OUTCOME_REGRESSION = "regression"
 OUTCOME_FAILURE = "failure"
 
 
@@ -57,24 +54,25 @@ class BenchmarkResult:
     confirmation_runs: int = 0
     outcome: str = OUTCOME_NO_REGRESSION
 
-    @property
-    def runs(self) -> int:
-        return self.initial_runs + self.confirmation_runs
-
 
 @dataclass
 class BenchmarkRow:
-    result: Optional[BenchmarkResult]
     display_name: str
     old_timing: str
+    old_range: str
     new_timing: str
+    new_range: str
     delta: str
-    change: str
-    confidence_interval: str
-    confidence: str
     runs: str
     bucket: str
     percentage: float = 0
+
+
+def positive_integer(value: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be greater than zero")
+    return parsed
 
 
 def parse_arguments():
@@ -84,8 +82,14 @@ def parse_arguments():
     parser.add_argument("--benchmarks", required=True, help="Path to the benchmark list.")
     parser.add_argument("--threads", type=int, help="Number of threads used by each benchmark runner.")
     parser.add_argument("--memory-limit", help="Memory limit used by each benchmark runner.")
+    parser.add_argument(
+        "--samples", type=positive_integer, help="Fixed samples per binary; rounded up to a batch of five."
+    )
+    parser.add_argument(
+        "--early-stop", action="store_true", help="Stop after a ten-sample checkpoint within ±2 percent."
+    )
     parser.add_argument("--verbose", action="store_true", help="Print raw benchmark runner output.")
-    parser.add_argument("--nofail", action="store_true", help="Report confirmed regressions without failing.")
+    parser.add_argument("--nofail", action="store_true", help="Report a geomean regression without failing.")
     parser.add_argument("--disable-timeout", action="store_true", help="Disable the benchmark runner timeout.")
     parser.add_argument(
         "--benchmark-cache",
@@ -105,39 +109,52 @@ def clear_benchmark_caches(runner_paths: List[str]):
         shutil.rmtree(cache_path, ignore_errors=True)
 
 
+def within_noise(measurement: BenchmarkMeasurement) -> bool:
+    return 1.0 - NOISE_THRESHOLD <= measurement.ratio <= 1.0 + NOISE_THRESHOLD
+
+
+def measurement_outcome(measurement: BenchmarkMeasurement) -> str:
+    return OUTCOME_REGRESSION if measurement.ratio >= REGRESSION_LIMIT else OUTCOME_NO_REGRESSION
+
+
 def run_paired_samples(
     old_runner: BenchmarkRunner,
     new_runner: BenchmarkRunner,
     benchmark: str,
     requested_runs: int,
-    stop_on_confident_noise: bool = False,
+    initial_batch_index: int,
+    early_stop: bool = False,
 ):
     old_timings = []
     new_timings = []
+    batch_index = initial_batch_index
     batch_sizes = sampling_batch_sizes(requested_runs)
     planned_runs = sum(batch_sizes)
     for batch_size in batch_sizes:
-        old_batch, old_failure = old_runner.run(benchmark, batch_size)
-        new_batch, new_failure = new_runner.run(benchmark, batch_size)
+        if batch_index % 2 == 0:
+            old_batch, old_failure = old_runner.run(benchmark, batch_size)
+            new_batch, new_failure = new_runner.run(benchmark, batch_size)
+        else:
+            new_batch, new_failure = new_runner.run(benchmark, batch_size)
+            old_batch, old_failure = old_runner.run(benchmark, batch_size)
 
         old_batch = old_batch or []
         new_batch = new_batch or []
         if old_failure or new_failure:
-            return old_timings, new_timings, old_failure, new_failure, False
+            return old_timings, new_timings, old_failure, new_failure, batch_index, False
         if len(old_batch) != len(new_batch):
             failure = f"Paired benchmark batches produced different run counts: {len(old_batch)} and {len(new_batch)}"
-            return old_timings, new_timings, failure, failure, False
+            return old_timings, new_timings, failure, failure, batch_index, False
 
         old_timings.extend(old_batch)
         new_timings.extend(new_batch)
+        batch_index += 1
         completed_runs = len(old_timings)
-        if stop_on_confident_noise and completed_runs < planned_runs and completed_runs % (2 * SAMPLE_BATCH_SIZE) == 0:
-            measurement = benchmark_measurement(old_timings, new_timings)
-            lower_bound, upper_bound = measurement.ratio_interval
-            if lower_bound >= 1.0 - NOISE_THRESHOLD and upper_bound <= 1.0 + NOISE_THRESHOLD:
-                return old_timings, new_timings, None, None, True
+        if early_stop and completed_runs < planned_runs and completed_runs % (2 * SAMPLE_BATCH_SIZE) == 0:
+            if within_noise(benchmark_measurement(old_timings, new_timings)):
+                return old_timings, new_timings, None, None, batch_index, True
 
-    return old_timings, new_timings, None, None, False
+    return old_timings, new_timings, None, None, batch_index, False
 
 
 def failed_benchmark_result(
@@ -159,20 +176,64 @@ def failed_benchmark_result(
     )
 
 
-def run_paired_benchmark(
-    old_runner: BenchmarkRunner, new_runner: BenchmarkRunner, benchmark: str, verbose: bool
+def measurement_status(measurement: BenchmarkMeasurement, stopped_early: bool = False) -> str:
+    if stopped_early:
+        return "within ±2% (stopped early)"
+    if measurement.ratio >= REGRESSION_LIMIT:
+        return "regression"
+    if measurement.ratio > 1.0 + NOISE_THRESHOLD:
+        return "slower"
+    if measurement.ratio < 1.0 - NOISE_THRESHOLD:
+        return "faster"
+    return "within ±2%; no change"
+
+
+def run_fixed_benchmark(
+    old_runner: BenchmarkRunner,
+    new_runner: BenchmarkRunner,
+    benchmark: str,
+    samples: int,
+    early_stop: bool,
+    verbose: bool,
 ) -> BenchmarkResult:
-    old_initial, new_initial, old_failure, new_failure, _ = run_paired_samples(
-        old_runner, new_runner, benchmark, INITIAL_RUNS
+    old_timings, new_timings, old_failure, new_failure, _, stopped_early = run_paired_samples(
+        old_runner, new_runner, benchmark, samples, 0, early_stop
+    )
+    run_count = min(len(old_timings), len(new_timings))
+    if old_failure or new_failure:
+        return failed_benchmark_result(benchmark, old_failure, new_failure, None, run_count, 0)
+
+    measurement = benchmark_measurement(old_timings, new_timings)
+    if verbose:
+        print(
+            f"samples: {benchmark}: {run_count} pairs | "
+            f"median change {format_ratio_change(measurement.ratio)} | {measurement_status(measurement, stopped_early)}"
+        )
+    return BenchmarkResult(
+        benchmark=benchmark,
+        initial_measurement=measurement,
+        measurement=measurement,
+        initial_runs=run_count,
+        outcome=measurement_outcome(measurement),
+    )
+
+
+def run_adaptive_benchmark(
+    old_runner: BenchmarkRunner,
+    new_runner: BenchmarkRunner,
+    benchmark: str,
+    early_stop: bool,
+    verbose: bool,
+) -> BenchmarkResult:
+    old_initial, new_initial, old_failure, new_failure, batch_index, _ = run_paired_samples(
+        old_runner, new_runner, benchmark, INITIAL_RUNS, 0
     )
     initial_count = min(len(old_initial), len(new_initial))
     if old_failure or new_failure:
         return failed_benchmark_result(benchmark, old_failure, new_failure, None, initial_count, 0)
 
     initial_measurement = benchmark_measurement(old_initial, new_initial)
-    is_candidate = (
-        initial_measurement.ratio < 1.0 - NOISE_THRESHOLD or initial_measurement.ratio > 1.0 + NOISE_THRESHOLD
-    )
+    is_candidate = not within_noise(initial_measurement)
     requested_confirmation_runs = confirmation_run_count(initial_measurement) if is_candidate else 0
     if verbose:
         decision = f"confirming with {requested_confirmation_runs} pairs" if is_candidate else "within ±2%; done"
@@ -187,14 +248,16 @@ def run_paired_benchmark(
             initial_measurement=initial_measurement,
             measurement=initial_measurement,
             initial_runs=initial_count,
+            outcome=measurement_outcome(initial_measurement),
         )
 
-    old_confirmation, new_confirmation, old_failure, new_failure, stopped_early = run_paired_samples(
+    old_confirmation, new_confirmation, old_failure, new_failure, _, stopped_early = run_paired_samples(
         old_runner,
         new_runner,
         benchmark,
         requested_confirmation_runs,
-        stop_on_confident_noise=True,
+        batch_index,
+        early_stop,
     )
     confirmation_count = min(len(old_confirmation), len(new_confirmation))
     if old_failure or new_failure:
@@ -207,31 +270,19 @@ def run_paired_benchmark(
             confirmation_count,
         )
 
-    confirmation_measurement = benchmark_measurement(old_confirmation, new_confirmation)
-    lower_bound, upper_bound = confirmation_measurement.ratio_interval
-    if confirmation_measurement.ratio > REGRESSION_LIMIT:
-        if lower_bound > REGRESSION_LIMIT:
-            outcome = OUTCOME_CONFIRMED_REGRESSION
-        else:
-            outcome = OUTCOME_UNCONFIRMED_REGRESSION
-    else:
-        outcome = OUTCOME_NO_REGRESSION
-
+    measurement = benchmark_measurement(old_confirmation, new_confirmation)
     if verbose:
         print(
             f"confirm: {benchmark}: {confirmation_count} pairs | "
-            f"median change {format_ratio_change(confirmation_measurement.ratio)} | "
-            f"{CONFIDENCE_PERCENTAGE}% CI {format_ratio_interval((lower_bound, upper_bound))} | "
-            f"{measurement_status(confirmation_measurement, outcome, stopped_early)}"
+            f"median change {format_ratio_change(measurement.ratio)} | {measurement_status(measurement, stopped_early)}"
         )
-
     return BenchmarkResult(
         benchmark=benchmark,
         initial_measurement=initial_measurement,
-        measurement=confirmation_measurement,
+        measurement=measurement,
         initial_runs=initial_count,
         confirmation_runs=confirmation_count,
-        outcome=outcome,
+        outcome=measurement_outcome(measurement),
     )
 
 
@@ -248,18 +299,6 @@ def append_step_summary(lines: List[str]):
         summary_file.write("\n")
 
 
-def format_seconds(value: float) -> str:
-    return f"{value:.3f}s"
-
-
-def format_delta_seconds(delta: float) -> str:
-    if delta == 0:
-        return "0.000s"
-    if abs(delta) < 0.001:
-        return "-<0.001s" if delta < 0 else "<0.001s"
-    return f"{delta:+.3f}s"
-
-
 def format_percentage(value: float) -> str:
     if math.isfinite(value):
         return f"{value:+.1f}%"
@@ -274,42 +313,48 @@ def format_ratio_change(ratio: float) -> str:
     return format_percentage(ratio_change(ratio))
 
 
-def format_ratio_interval(ratio_interval: Tuple[float, float]) -> str:
-    lower_bound, upper_bound = ratio_interval
-    return f"{format_ratio_change(lower_bound)}…{format_ratio_change(upper_bound)}"
+def duration_unit(value: float):
+    value = abs(value)
+    if value >= 1.0:
+        return 1.0, "s"
+    if value >= 0.001:
+        return 1000.0, "ms"
+    if value >= 0.000001:
+        return 1000000.0, "µs"
+    return 1000000000.0, "ns"
 
 
-def direction_confidence(measurement: BenchmarkMeasurement) -> str:
-    lower_bound, upper_bound = measurement.ratio_interval
-    if measurement.ratio < 1.0 - NOISE_THRESHOLD:
-        return "confident" if upper_bound < 1.0 - NOISE_THRESHOLD else "uncertain"
-    if measurement.ratio > 1.0 + NOISE_THRESHOLD:
-        return "confident" if lower_bound > 1.0 + NOISE_THRESHOLD else "uncertain"
-    return "within noise"
+def format_duration(value: float, unit=None, signed: bool = False) -> str:
+    scale, suffix = unit or duration_unit(value)
+    scaled = value * scale
+    if signed and scaled > 0:
+        prefix = "+"
+    else:
+        prefix = ""
+    return f"{prefix}{scaled:.3g}{suffix}"
 
 
-def measurement_status(measurement: BenchmarkMeasurement, outcome: str, stopped_early: bool = False) -> str:
-    if stopped_early:
-        return "within ±2% (confident; stopped early)"
-    if outcome == OUTCOME_CONFIRMED_REGRESSION:
-        return "regression (confirmed)"
-    if outcome == OUTCOME_UNCONFIRMED_REGRESSION:
-        return "regression (uncertain; budget exhausted)"
-    if measurement.ratio < 1.0 - NOISE_THRESHOLD:
-        confidence = direction_confidence(measurement)
-        suffix = "confident" if confidence == "confident" else "uncertain; budget exhausted"
-        return f"faster ({suffix})"
-    if measurement.ratio > 1.0 + NOISE_THRESHOLD:
-        confidence = direction_confidence(measurement)
-        suffix = "confident" if confidence == "confident" else "uncertain; budget exhausted"
-        return f"slower ({suffix})"
-    return "within ±2%; no change"
+def timing_parts(timing: float, minimum: float, maximum: float) -> Tuple[str, str]:
+    unit = duration_unit(timing)
+    return format_duration(timing, unit), f"[{format_duration(minimum, unit)}…{format_duration(maximum, unit)}]"
 
 
-def confidence_text(result: BenchmarkResult) -> str:
-    if result.measurement is None:
-        return "unavailable"
-    return format_ratio_interval(result.measurement.ratio_interval)
+def delta_text(measurement: BenchmarkMeasurement) -> str:
+    delta = measurement.new_timing - measurement.old_timing
+    unit = duration_unit(delta) if delta else duration_unit(measurement.old_timing)
+    return f"{format_duration(delta, unit, signed=True)} ({format_ratio_change(measurement.ratio)})"
+
+
+def gray(value: str) -> str:
+    return f"{ANSI_GRAY}{value}{ANSI_RESET}"
+
+
+def color_change(bucket: str, value: str) -> str:
+    if bucket in (BUCKET_REGRESSION, BUCKET_SLOWER, BUCKET_FAILURE):
+        return f"{ANSI_RED}{value}{ANSI_RESET}"
+    if bucket == BUCKET_FASTER:
+        return f"{ANSI_GREEN}{value}{ANSI_RESET}"
+    return f"{ANSI_GRAY}{value}{ANSI_RESET}"
 
 
 def emit_github_error(title: str, message: str):
@@ -320,57 +365,6 @@ def emit_github_error(title: str, message: str):
 def emit_github_warning(title: str, message: str):
     if in_ci():
         print(f"::warning title={title}::{message}")
-
-
-def report_regression(
-    result: BenchmarkResult, suite: str, failure_summary: List[BenchmarkResult], summary_lines: List[str]
-):
-    if result.outcome == OUTCOME_FAILURE:
-        message = f"{suite}: {result.benchmark} failed while comparing base and PR benchmark runs"
-        old_timing = "failed"
-        new_timing = "failed"
-        delta = "failed"
-        median_change = "failed"
-        confidence = "unavailable"
-        failure_summary.append(result)
-    else:
-        measurement = result.measurement
-        assert measurement is not None
-        old_timing = format_seconds(measurement.old_timing)
-        new_timing = format_seconds(measurement.new_timing)
-        delta = format_delta_seconds(measurement.new_timing - measurement.old_timing)
-        median_change = format_ratio_change(measurement.ratio)
-        confidence = confidence_text(result)
-        message = (
-            f"{suite}: {result.benchmark} regressed from {old_timing} to {new_timing}; "
-            f"median change {median_change}, delta {delta}, {CONFIDENCE_PERCENTAGE}% CI {confidence}, "
-            f"regression limit {format_ratio_change(REGRESSION_LIMIT)}"
-        )
-    emit_github_error("Regression benchmark", message)
-    summary_lines.append(
-        f"| `{result.benchmark}` | `{old_timing}` | `{new_timing}` | `{delta}` | `{median_change}` | "
-        f"`{confidence}` | `{format_run_count(result)}` |"
-    )
-
-
-def report_unconfirmed(result: BenchmarkResult, suite: str, summary_lines: List[str]):
-    measurement = result.measurement
-    assert measurement is not None
-    old_timing = format_seconds(measurement.old_timing)
-    new_timing = format_seconds(measurement.new_timing)
-    delta = format_delta_seconds(measurement.new_timing - measurement.old_timing)
-    median_change = format_ratio_change(measurement.ratio)
-    confidence = confidence_text(result)
-    message = (
-        f"{suite}: {result.benchmark} has median change {median_change}, delta {delta}, and "
-        f"{CONFIDENCE_PERCENTAGE}% CI {confidence}; regression limit {format_ratio_change(REGRESSION_LIMIT)} "
-        f"is uncertain after the confirmation budget"
-    )
-    emit_github_warning("Inconclusive regression benchmark", message)
-    summary_lines.append(
-        f"| `{result.benchmark}` | `{old_timing}` | `{new_timing}` | `{delta}` | `{median_change}` | "
-        f"`{confidence}` | `{format_run_count(result)}` |"
-    )
 
 
 def benchmark_common_prefix(benchmarks: List[str]) -> str:
@@ -399,16 +393,12 @@ def benchmark_display_names(benchmarks: List[str]) -> Dict[str, str]:
 def classify_result(result: BenchmarkResult) -> str:
     if result.outcome == OUTCOME_FAILURE:
         return BUCKET_FAILURE
-    if result.outcome == OUTCOME_CONFIRMED_REGRESSION:
+    if result.outcome == OUTCOME_REGRESSION:
         return BUCKET_REGRESSION
-    if result.outcome == OUTCOME_UNCONFIRMED_REGRESSION:
-        return BUCKET_UNCONFIRMED
-
     assert result.measurement is not None
-    ratio = result.measurement.ratio
-    if ratio > 1.0 + NOISE_THRESHOLD:
+    if result.measurement.ratio > 1.0 + NOISE_THRESHOLD:
         return BUCKET_SLOWER
-    if ratio < 1.0 - NOISE_THRESHOLD:
+    if result.measurement.ratio < 1.0 - NOISE_THRESHOLD:
         return BUCKET_FASTER
     return BUCKET_UNCHANGED
 
@@ -419,81 +409,26 @@ def format_run_count(result: BenchmarkResult) -> str:
     return str(result.initial_runs)
 
 
-def result_confidence(result: BenchmarkResult) -> str:
-    if result.outcome == OUTCOME_CONFIRMED_REGRESSION:
-        return "confirmed regression"
-    if result.outcome == OUTCOME_UNCONFIRMED_REGRESSION:
-        return "uncertain regression"
-    assert result.measurement is not None
-    return direction_confidence(result.measurement)
-
-
 def benchmark_row(result: BenchmarkResult, display_name: str) -> BenchmarkRow:
     bucket = classify_result(result)
     if result.outcome == OUTCOME_FAILURE:
-        return BenchmarkRow(
-            result=result,
-            display_name=display_name,
-            old_timing="failed",
-            new_timing="failed",
-            delta="failed",
-            change="failed",
-            confidence_interval="unavailable",
-            confidence="failed",
-            runs=format_run_count(result),
-            bucket=bucket,
-        )
+        return BenchmarkRow(display_name, "failed", "", "failed", "", "failed", format_run_count(result), bucket)
 
     measurement = result.measurement
     assert measurement is not None
-    delta = measurement.new_timing - measurement.old_timing
-    percentage = ratio_change(measurement.ratio)
+    old_timing, old_range = timing_parts(measurement.old_timing, measurement.old_min, measurement.old_max)
+    new_timing, new_range = timing_parts(measurement.new_timing, measurement.new_min, measurement.new_max)
     return BenchmarkRow(
-        result=result,
-        display_name=display_name,
-        old_timing=format_seconds(measurement.old_timing),
-        new_timing=format_seconds(measurement.new_timing),
-        delta=format_delta_seconds(delta),
-        change=format_percentage(percentage),
-        confidence_interval=format_ratio_interval(measurement.ratio_interval),
-        confidence=result_confidence(result),
-        runs=format_run_count(result),
-        bucket=bucket,
-        percentage=percentage,
+        display_name,
+        old_timing,
+        old_range,
+        new_timing,
+        new_range,
+        delta_text(measurement),
+        format_run_count(result),
+        bucket,
+        ratio_change(measurement.ratio),
     )
-
-
-def color_change(bucket: str, value: str) -> str:
-    if bucket in (BUCKET_REGRESSION, BUCKET_SLOWER, BUCKET_FAILURE):
-        return f"{ANSI_RED}{value}{ANSI_RESET}"
-    if bucket == BUCKET_UNCONFIRMED:
-        return f"{ANSI_YELLOW}{value}{ANSI_RESET}"
-    if bucket == BUCKET_FASTER:
-        return f"{ANSI_GREEN}{value}{ANSI_RESET}"
-    return f"{ANSI_GRAY}{value}{ANSI_RESET}"
-
-
-def gray(value: str) -> str:
-    return f"{ANSI_GRAY}{value}{ANSI_RESET}"
-
-
-def color_result(result_text: str) -> str:
-    if result_text == "no regressions":
-        color = ANSI_GREEN
-    elif result_text == "uncertain regressions":
-        color = ANSI_YELLOW
-    else:
-        color = ANSI_RED
-    return f"{color}{result_text}{ANSI_RESET}"
-
-
-def color_geomean_change(percentage: float) -> str:
-    value = format_percentage(percentage)
-    if percentage < 0:
-        return f"{ANSI_GREEN}{value}{ANSI_RESET}"
-    if percentage > 0:
-        return f"{ANSI_RED}{value}{ANSI_RESET}"
-    return value
 
 
 def row_sort_key(row: BenchmarkRow):
@@ -501,32 +436,36 @@ def row_sort_key(row: BenchmarkRow):
         BUCKET_UNCHANGED: 0,
         BUCKET_FASTER: 1,
         BUCKET_SLOWER: 2,
-        BUCKET_UNCONFIRMED: 3,
-        BUCKET_REGRESSION: 4,
-        BUCKET_FAILURE: 5,
+        BUCKET_REGRESSION: 3,
+        BUCKET_FAILURE: 4,
     }
     if row.bucket == BUCKET_FASTER:
         bucket_value = -row.percentage
-    elif row.bucket in (BUCKET_SLOWER, BUCKET_UNCONFIRMED, BUCKET_REGRESSION):
+    elif row.bucket in (BUCKET_SLOWER, BUCKET_REGRESSION):
         bucket_value = row.percentage
     else:
         bucket_value = 0
     return bucket_order[row.bucket], bucket_value, row.display_name
 
 
+def plain_timing_cell(timing: str, timing_range: str) -> str:
+    return f"{timing} {timing_range}" if timing_range else timing
+
+
+def styled_timing_cell(timing: str, timing_range: str) -> str:
+    return f"{timing} {gray(timing_range)}" if timing_range else timing
+
+
 def render_table(rows: List[BenchmarkRow]):
     if not rows:
         return
-    headers = ["benchmark", "base", "PR", "delta", "median change", "95% CI", "confidence", "runs"]
+    headers = ["benchmark", "base median", "PR median", "delta median", "runs"]
     plain_rows = [
         [
             row.display_name,
-            row.old_timing,
-            row.new_timing,
+            plain_timing_cell(row.old_timing, row.old_range),
+            plain_timing_cell(row.new_timing, row.new_range),
             row.delta,
-            row.change,
-            row.confidence_interval,
-            row.confidence,
             row.runs,
         ]
         for row in rows
@@ -539,12 +478,16 @@ def render_table(rows: List[BenchmarkRow]):
     print("  ".join(headers[index].ljust(widths[index]) for index in range(len(headers))))
     print("  ".join("-" * widths[index] for index in range(len(headers))))
     for row, plain_row in zip(rows, plain_rows):
+        styled_row = [
+            row.display_name,
+            styled_timing_cell(row.old_timing, row.old_range),
+            styled_timing_cell(row.new_timing, row.new_range),
+            color_change(row.bucket, row.delta),
+            row.runs,
+        ]
         cells = []
-        for index, value in enumerate(plain_row):
-            padded = value.ljust(widths[index])
-            if headers[index] == "median change":
-                padded = color_change(row.bucket, padded)
-            cells.append(padded)
+        for index, value in enumerate(styled_row):
+            cells.append(value + " " * (widths[index] - len(plain_row[index])))
         print("  ".join(cells))
 
 
@@ -569,54 +512,143 @@ def geomean(values: List[float]) -> Optional[float]:
     return math.exp(math.fsum(math.log(value) for value in values) / len(values))
 
 
-def print_geomean_summary(old_geomean: Optional[float], new_geomean: Optional[float]):
-    print("")
-    sample_text = gray(f"(initial {INITIAL_RUNS} samples)")
+def geomean_regressed(old_geomean: Optional[float], new_geomean: Optional[float]) -> bool:
     if old_geomean is None or new_geomean is None:
-        print(f"geomean: unavailable  {sample_text}")
+        return False
+    return new_geomean / old_geomean >= REGRESSION_LIMIT or new_geomean - old_geomean >= GEOMEAN_REGRESSION_SECONDS
+
+
+def print_geomean_summary(old_geomean: Optional[float], new_geomean: Optional[float], sample_text: str):
+    print("")
+    if old_geomean is None or new_geomean is None:
+        print(f"geomean: unavailable  {gray(sample_text)}")
         return
-    percentage = ((new_geomean / old_geomean) - 1.0) * 100.0
-    change = color_geomean_change(percentage)
-    print(f"geomean: {format_seconds(old_geomean)} -> {format_seconds(new_geomean)}  " f"{change}  {sample_text}")
+    old_text = format_duration(old_geomean)
+    new_text = format_duration(new_geomean)
+    measurement = BenchmarkMeasurement(
+        old_timing=old_geomean,
+        old_min=old_geomean,
+        old_max=old_geomean,
+        new_timing=new_geomean,
+        new_min=new_geomean,
+        new_max=new_geomean,
+        ratio=new_geomean / old_geomean,
+        runs=0,
+    )
+    if new_geomean > old_geomean:
+        bucket = BUCKET_SLOWER
+    elif new_geomean < old_geomean:
+        bucket = BUCKET_FASTER
+    else:
+        bucket = BUCKET_UNCHANGED
+    print(f"geomean: {old_text} -> {new_text}  {color_change(bucket, delta_text(measurement))}  {gray(sample_text)}")
+
+
+def sampling_description(samples: Optional[int], rounded_samples: Optional[int], early_stop: bool) -> str:
+    if samples is None:
+        description = (
+            f"sampling: adaptive; {INITIAL_RUNS} initial pairs, then "
+            f"{MIN_CONFIRMATION_RUNS}–{MAX_CONFIRMATION_RUNS} confirmation pairs outside ±2%"
+        )
+    else:
+        assert rounded_samples is not None
+        description = f"sampling: fixed; {rounded_samples} samples per binary"
+        if rounded_samples != samples:
+            description += f" (--samples={samples} rounded up)"
+        else:
+            description += f" (--samples={samples})"
+    if early_stop:
+        description += "; median early stop"
+    return description
 
 
 def print_benchmark_report(
     rows: List[BenchmarkRow],
     common_prefix: str,
+    samples: Optional[int],
+    rounded_samples: Optional[int],
+    early_stop: bool,
 ):
     buckets = {
         bucket: [row for row in rows if row.bucket == bucket]
-        for bucket in (
-            BUCKET_UNCHANGED,
-            BUCKET_FASTER,
-            BUCKET_SLOWER,
-            BUCKET_UNCONFIRMED,
-            BUCKET_REGRESSION,
-            BUCKET_FAILURE,
-        )
+        for bucket in (BUCKET_UNCHANGED, BUCKET_FASTER, BUCKET_SLOWER, BUCKET_REGRESSION, BUCKET_FAILURE)
     }
-
     print("")
     suite_text = f"{common_prefix} ({len(rows)} benchmarks)" if common_prefix else f"{len(rows)} benchmarks"
     print(gray(f"suite: {suite_text}"))
-    print(
-        gray(
-            f"sampling: {INITIAL_RUNS} initial pairs; {MIN_CONFIRMATION_RUNS}–{MAX_CONFIRMATION_RUNS} "
-            f"confirmation pairs outside ±{NOISE_THRESHOLD * 100:.0f}%, with early noise stop"
-        )
-    )
-    print(
-        gray(
-            f"regression: fail when the {CONFIDENCE_PERCENTAGE}% CI is above "
-            f"{format_ratio_change(REGRESSION_LIMIT)}"
-        )
-    )
+    print(gray(sampling_description(samples, rounded_samples, early_stop)))
+    print(gray("query regression: median change ≥ +10.0% (warning)"))
+    print(gray("CI failure: geomean change ≥ +10.0% or ≥ +50.0ms"))
     print_bucket("UNCHANGED (±2%)", buckets[BUCKET_UNCHANGED], len(buckets[BUCKET_UNCHANGED]))
     print_bucket("FASTER", buckets[BUCKET_FASTER])
-    print_bucket("SLOWER (+2%…+10%)", buckets[BUCKET_SLOWER])
-    print_bucket("UNCERTAIN REGRESSIONS", buckets[BUCKET_UNCONFIRMED])
-    print_bucket("REGRESSIONS", buckets[BUCKET_REGRESSION])
+    print_bucket("SLOWER (+2%…<+10%)", buckets[BUCKET_SLOWER])
+    print_bucket("REGRESSIONS (≥+10%)", buckets[BUCKET_REGRESSION])
     print_bucket("FAILURES", buckets[BUCKET_FAILURE])
+
+
+def markdown_row(result: BenchmarkResult) -> str:
+    measurement = result.measurement
+    if measurement is None:
+        return f"| `{result.benchmark}` | failed | failed | failed | `{format_run_count(result)}` |"
+    old_timing, old_range = timing_parts(measurement.old_timing, measurement.old_min, measurement.old_max)
+    new_timing, new_range = timing_parts(measurement.new_timing, measurement.new_min, measurement.new_max)
+    return (
+        f"| `{result.benchmark}` | `{old_timing} {old_range}` | `{new_timing} {new_range}` | "
+        f"`{delta_text(measurement)}` | `{format_run_count(result)}` |"
+    )
+
+
+def report_query_regressions(results: List[BenchmarkResult], suite: str):
+    if not results:
+        return
+    summary_lines = [
+        f"## Query Regressions: `{suite}`",
+        "",
+        "| Benchmark | Base median | PR median | Delta median | Runs |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+    for result in results:
+        measurement = result.measurement
+        assert measurement is not None
+        emit_github_warning(
+            "Benchmark query regression",
+            f"{suite}: {result.benchmark} median changed by {format_ratio_change(measurement.ratio)} "
+            f"({format_duration(measurement.old_timing)} to {format_duration(measurement.new_timing)})",
+        )
+        summary_lines.append(markdown_row(result))
+    append_step_summary(summary_lines + [""])
+
+
+def report_failures(results: List[BenchmarkResult], suite: str):
+    if not results:
+        return
+    summary_lines = [
+        f"## Benchmark Failures: `{suite}`",
+        "",
+        "| Benchmark | Base median | PR median | Delta median | Runs |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+    for result in results:
+        emit_github_error(
+            "Regression benchmark failure",
+            f"{suite}: {result.benchmark} failed while comparing base and PR benchmark runs",
+        )
+        summary_lines.append(markdown_row(result))
+    append_step_summary(summary_lines + [""])
+
+
+def report_geomean_regression(old_geomean: float, new_geomean: float, nofail: bool):
+    delta = new_geomean - old_geomean
+    ratio = new_geomean / old_geomean
+    message = (
+        f"geomean changed from {format_duration(old_geomean)} to {format_duration(new_geomean)}; "
+        f"{format_duration(delta, signed=True)} ({format_ratio_change(ratio)})"
+    )
+    if nofail:
+        emit_github_warning("Geomean benchmark regression", message)
+    else:
+        emit_github_error("Geomean benchmark regression", message)
+    append_step_summary(["## Geomean Regression", "", message, ""])
 
 
 def print_failure_summary(failures: List[BenchmarkResult]):
@@ -630,14 +662,41 @@ def print_failure_summary(failures: List[BenchmarkResult]):
 """
     )
     for index, result in enumerate(failures, start=1):
-        prefix = "::error::" if in_ci() else ""
-        print(f"{prefix}{index}: {result.benchmark}")
+        print(f"{index}: {result.benchmark}")
         if result.old_failure != result.new_failure:
             print("Base:\n", result.old_failure)
             print("PR:\n", result.new_failure)
         else:
             print(result.old_failure)
         print("-", 52)
+
+
+def query_regression_text(count: int) -> str:
+    if count == 0:
+        return "no query regressions"
+    if count == 1:
+        return "1 query regression"
+    return f"{count} query regressions"
+
+
+def print_result(execution_failed: bool, gate_failed: bool, nofail: bool, query_regressions: int):
+    query_text = query_regression_text(query_regressions)
+    colored_query_text = (
+        f"{ANSI_YELLOW}{query_text}{ANSI_RESET}" if query_regressions else f"{ANSI_GRAY}{query_text}{ANSI_RESET}"
+    )
+    if execution_failed:
+        print(f"result: {ANSI_RED}failed; benchmark failure{ANSI_RESET}; {colored_query_text}")
+    elif gate_failed and nofail:
+        print(
+            f"result: {ANSI_GREEN}passed (--nofail){ANSI_RESET}; "
+            f"{ANSI_RED}geomean regression{ANSI_RESET}; {colored_query_text}"
+        )
+    elif gate_failed:
+        print(f"result: {ANSI_RED}failed; geomean regression{ANSI_RESET}; {colored_query_text}")
+    elif query_regressions:
+        print(f"result: {ANSI_GREEN}passed{ANSI_RESET}; {colored_query_text}")
+    else:
+        print(f"result: {ANSI_GREEN}passed; no query regressions{ANSI_RESET}")
 
 
 def main() -> int:
@@ -658,60 +717,60 @@ def main() -> int:
     suite = Path(args.benchmarks).stem
     old_runner = BenchmarkRunner(args.old, "base", args.threads, args.memory_limit, args.verbose, args.disable_timeout)
     new_runner = BenchmarkRunner(args.new, "PR", args.threads, args.memory_limit, args.verbose, args.disable_timeout)
-    results = [run_paired_benchmark(old_runner, new_runner, benchmark, args.verbose) for benchmark in benchmarks]
-
-    failing_results = [
-        result
-        for result in results
-        if result.outcome == OUTCOME_FAILURE or (result.outcome == OUTCOME_CONFIRMED_REGRESSION and not args.nofail)
-    ]
-    inconclusive_results = [result for result in results if result.outcome == OUTCOME_UNCONFIRMED_REGRESSION]
-    failure_summary = []
-    if failing_results:
-        summary_lines = [
-            f"## Regression Suite: `{suite}`",
-            "",
-            "| Benchmark | Base | PR | Delta | Median change | 95% CI | Runs |",
-            "| --- | --- | --- | --- | --- | --- | --- |",
+    rounded_samples = sum(sampling_batch_sizes(args.samples)) if args.samples is not None else None
+    if args.samples is None:
+        results = [
+            run_adaptive_benchmark(old_runner, new_runner, benchmark, args.early_stop, args.verbose)
+            for benchmark in benchmarks
         ]
-        for result in failing_results:
-            report_regression(result, suite, failure_summary, summary_lines)
-        append_step_summary(summary_lines + [""])
-
-    if inconclusive_results:
-        summary_lines = [
-            f"## Inconclusive Regression Candidates: `{suite}`",
-            "",
-            "| Benchmark | Base | PR | Delta | Median change | 95% CI | Runs |",
-            "| --- | --- | --- | --- | --- | --- | --- |",
+    else:
+        results = [
+            run_fixed_benchmark(old_runner, new_runner, benchmark, args.samples, args.early_stop, args.verbose)
+            for benchmark in benchmarks
         ]
-        for result in inconclusive_results:
-            report_unconfirmed(result, suite, summary_lines)
-        append_step_summary(summary_lines + [""])
+
+    execution_failures = [result for result in results if result.outcome == OUTCOME_FAILURE]
+    query_regressions = [result for result in results if result.outcome == OUTCOME_REGRESSION]
+    report_failures(execution_failures, suite)
+    report_query_regressions(query_regressions, suite)
 
     display_names = benchmark_display_names([result.benchmark for result in results])
     rows = [benchmark_row(result, display_names[result.benchmark]) for result in results]
     rows.sort(key=row_sort_key)
-    if any(result.outcome == OUTCOME_FAILURE for result in results):
-        result_text = "benchmark failure"
-    elif any(result.outcome == OUTCOME_CONFIRMED_REGRESSION for result in results):
-        result_text = "regression detected"
-    elif inconclusive_results:
-        result_text = "uncertain regressions"
-    else:
-        result_text = "no regressions"
+    geomean_measurements = [
+        result.initial_measurement if args.samples is None else result.measurement
+        for result in results
+        if (result.initial_measurement if args.samples is None else result.measurement) is not None
+    ]
+    old_geomean = geomean([measurement.old_timing for measurement in geomean_measurements])
+    new_geomean = geomean([measurement.new_timing for measurement in geomean_measurements])
+    gate_failed = geomean_regressed(old_geomean, new_geomean)
+    if gate_failed:
+        assert old_geomean is not None and new_geomean is not None
+        report_geomean_regression(old_geomean, new_geomean, args.nofail)
 
-    initial_measurements = [result.initial_measurement for result in results if result.initial_measurement]
-    old_geomean = geomean([measurement.old_timing for measurement in initial_measurements])
-    new_geomean = geomean([measurement.new_timing for measurement in initial_measurements])
     print_benchmark_report(
         rows,
         benchmark_common_prefix([result.benchmark for result in results]),
+        args.samples,
+        rounded_samples,
+        args.early_stop,
     )
-    print_failure_summary(failure_summary)
-    print_geomean_summary(old_geomean, new_geomean)
-    print(f"result: {color_result(result_text)}")
-    return 1 if failing_results else 0
+    print_failure_summary(execution_failures)
+    if args.samples is None:
+        sample_text = f"(initial {INITIAL_RUNS} samples)"
+    elif args.early_stop:
+        sample_text = f"(up to {rounded_samples} samples)"
+    else:
+        sample_text = f"({rounded_samples} samples)"
+    print_geomean_summary(old_geomean, new_geomean, sample_text)
+    print_result(bool(execution_failures), gate_failed, args.nofail, len(query_regressions))
+
+    if execution_failures:
+        return 1
+    if gate_failed and not args.nofail:
+        return 1
+    return 0
 
 
 if __name__ == "__main__":

--- a/scripts/regression/test_runner.py
+++ b/scripts/regression/test_runner.py
@@ -487,6 +487,15 @@ def color_result(result_text: str) -> str:
     return f"{color}{result_text}{ANSI_RESET}"
 
 
+def color_geomean_change(percentage: float) -> str:
+    value = format_percentage(percentage)
+    if percentage < 0:
+        return f"{ANSI_GREEN}{value}{ANSI_RESET}"
+    if percentage > 0:
+        return f"{ANSI_RED}{value}{ANSI_RESET}"
+    return value
+
+
 def row_sort_key(row: BenchmarkRow):
     bucket_order = {
         BUCKET_UNCHANGED: 0,
@@ -546,10 +555,11 @@ def print_bucket(title: str, rows: List[BenchmarkRow], unchanged_count: int = 0)
     elif not rows:
         return
     print("")
-    print(title)
     if title == "UNCHANGED (±2%)":
-        print(f"{unchanged_count} benchmarks")
+        print(gray(title))
+        print(gray(f"{unchanged_count} benchmarks"))
     else:
+        print(title)
         render_table(rows)
 
 
@@ -566,22 +576,13 @@ def print_geomean_summary(old_geomean: Optional[float], new_geomean: Optional[fl
         print(f"geomean: unavailable  {sample_text}")
         return
     percentage = ((new_geomean / old_geomean) - 1.0) * 100.0
-    if percentage > NOISE_THRESHOLD * 100.0:
-        bucket = BUCKET_SLOWER
-    elif percentage < -NOISE_THRESHOLD * 100.0:
-        bucket = BUCKET_FASTER
-    else:
-        bucket = BUCKET_UNCHANGED
-    change = color_change(bucket, format_percentage(percentage))
+    change = color_geomean_change(percentage)
     print(f"geomean: {format_seconds(old_geomean)} -> {format_seconds(new_geomean)}  " f"{change}  {sample_text}")
 
 
 def print_benchmark_report(
     rows: List[BenchmarkRow],
     common_prefix: str,
-    result_text: str,
-    old_geomean: Optional[float],
-    new_geomean: Optional[float],
 ):
     buckets = {
         bucket: [row for row in rows if row.bucket == bucket]
@@ -610,8 +611,6 @@ def print_benchmark_report(
             f"{format_ratio_change(REGRESSION_LIMIT)}"
         )
     )
-    print_geomean_summary(old_geomean, new_geomean)
-    print(f"result: {color_result(result_text)}")
     print_bucket("UNCHANGED (±2%)", buckets[BUCKET_UNCHANGED], len(buckets[BUCKET_UNCHANGED]))
     print_bucket("FASTER", buckets[BUCKET_FASTER])
     print_bucket("SLOWER (+2%…+10%)", buckets[BUCKET_SLOWER])
@@ -708,11 +707,10 @@ def main() -> int:
     print_benchmark_report(
         rows,
         benchmark_common_prefix([result.benchmark for result in results]),
-        result_text,
-        old_geomean,
-        new_geomean,
     )
     print_failure_summary(failure_summary)
+    print_geomean_summary(old_geomean, new_geomean)
+    print(f"result: {color_result(result_text)}")
     return 1 if failing_results else 0
 
 

--- a/scripts/regression/test_runner.py
+++ b/scripts/regression/test_runner.py
@@ -1,142 +1,30 @@
-import os
-import math
+import argparse
 import functools
+import math
+import os
 import shutil
-from benchmark import BenchmarkRunner, BenchmarkRunnerConfig
-from comparison import (
-    confirmation_run_count,
-    paired_measurement,
-    regression_measurement,
-)
 from dataclasses import dataclass
-from typing import Optional, List, Union, Dict, Tuple
 from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+from benchmark import BenchmarkRunner
+from comparison import (
+    CONFIRMATION_TARGET_SECONDS,
+    MAX_CONFIRMATION_RUNS,
+    MIN_CONFIRMATION_RUNS,
+    BenchmarkMeasurement,
+    benchmark_measurement,
+    confirmation_run_count,
+)
+
 
 print = functools.partial(print, flush=True)
 
-
-def is_number(s):
-    try:
-        float(s)
-        return True
-    except ValueError:
-        return False
-
-
-# Geometric mean of an array of numbers
-def geomean(xs):
-    if len(xs) == 0:
-        return "EMPTY"
-    for entry in xs:
-        if not is_number(entry):
-            return entry
-    return math.exp(math.fsum(math.log(float(x)) for x in xs) / len(xs))
-
-
-import argparse
-
-# Set up the argument parser
-parser = argparse.ArgumentParser(description="Benchmark script with old and new runners.")
-
-# Define the arguments
-parser.add_argument("--old", type=str, help="Path to the old runner.", required=True)
-parser.add_argument("--new", type=str, help="Path to the new runner.", required=True)
-parser.add_argument("--benchmarks", type=str, help="Path to the benchmark file.", required=True)
-parser.add_argument("--verbose", action="store_true", help="Enable verbose output.")
-parser.add_argument("--threads", type=int, help="Number of threads to use.")
-parser.add_argument("--memory_limit", type=str, help="Memory limit to use.")
-parser.add_argument("--nofail", action="store_true", help="Do not fail on regression.")
-parser.add_argument("--disable-timeout", action="store_true", help="Disable timeout.")
-parser.add_argument(
-    "--max-timeout",
-    type=int,
-    default=3600,
-    help="Set maximum timeout in seconds (default: 3600).",
-)
-parser.add_argument("--root-dir", type=str, default="", help="Root directory.")
-parser.add_argument("--no-summary", type=str, default=False, help="No summary in the end.")
-parser.add_argument(
-    "--initial-runs",
-    type=int,
-    default=10,
-    help="Number of initial paired timed runs for each benchmark (default: 10).",
-)
-parser.add_argument(
-    "--confirmation-time-seconds",
-    type=float,
-    default=3.0,
-    help="Target measured time per runner when confirming a regression (default: 3 seconds).",
-)
-parser.add_argument(
-    "--min-confirmation-runs",
-    type=int,
-    default=15,
-    help="Minimum paired timed runs used to confirm a regression (default: 15).",
-)
-parser.add_argument(
-    "--max-confirmation-runs",
-    type=int,
-    default=100,
-    help="Maximum paired timed runs used to confirm a regression (default: 100).",
-)
-parser.add_argument(
-    "--clear-benchmark-cache",
-    action="store_true",
-    help="Clear benchmark caches prior to running",
-    default=False,
-)
-parser.add_argument(
-    "--keep-benchmark-data",
-    action="store_true",
-    help="Benchmark data will not be deleted between tests",
-    default=False,
-)
-parser.add_argument(
-    "--regression-threshold-seconds",
-    type=float,
-    default=0.05,
-    help="REGRESSION_THRESHOLD_SECONDS value for large benchmarks.",
-)
-
-# Parse the arguments
-args = parser.parse_args()
-
-# Assign parsed arguments to variables
-old_runner_path = args.old
-new_runner_path = args.new
-benchmark_file = args.benchmarks
-verbose = args.verbose
-threads = args.threads
-memory_limit = args.memory_limit
-no_regression_fail = args.nofail
-disable_timeout = args.disable_timeout
-max_timeout = args.max_timeout
-root_dir = args.root_dir
-no_summary = args.no_summary
-clear_benchmark_cache = args.clear_benchmark_cache
-keep_benchmark_data = args.keep_benchmark_data
-regression_threshold_seconds = args.regression_threshold_seconds
-initial_runs = args.initial_runs
-confirmation_time_seconds = args.confirmation_time_seconds
-min_confirmation_runs = args.min_confirmation_runs
-max_confirmation_runs = args.max_confirmation_runs
-
-if initial_runs <= 0:
-    parser.error("--initial-runs must be greater than zero")
-if confirmation_time_seconds <= 0:
-    parser.error("--confirmation-time-seconds must be greater than zero")
-if min_confirmation_runs < 6:
-    parser.error("--min-confirmation-runs must be at least 6")
-if max_confirmation_runs < min_confirmation_runs:
-    parser.error("--max-confirmation-runs must be greater than or equal to --min-confirmation-runs")
-
-
-# the threshold at which we consider something a regression (percentage)
-REGRESSION_THRESHOLD_PERCENTAGE = 0.1
-# minimal seconds diff for something to be a regression (for very fast benchmarks)
-REGRESSION_THRESHOLD_SECONDS = regression_threshold_seconds
-# hide benchmark changes that are below the noise floor in the final report
-DISPLAY_THRESHOLD_PERCENTAGE = 2.0
+INITIAL_BATCH_SIZE = 5
+INITIAL_RUNS = 2 * INITIAL_BATCH_SIZE
+REGRESSION_LIMIT = 1.10
+NOISE_THRESHOLD = 0.02
+CONFIDENCE_PERCENTAGE = 95
 
 ANSI_RED = "\033[31m"
 ANSI_GREEN = "\033[32m"
@@ -156,26 +44,206 @@ OUTCOME_UNCONFIRMED_REGRESSION = "unconfirmed_regression"
 OUTCOME_FAILURE = "failure"
 
 
-def in_ci():
+@dataclass
+class BenchmarkResult:
+    benchmark: str
+    initial_measurement: Optional[BenchmarkMeasurement] = None
+    measurement: Optional[BenchmarkMeasurement] = None
+    old_failure: Optional[str] = None
+    new_failure: Optional[str] = None
+    initial_runs: int = 0
+    confirmation_runs: int = 0
+    outcome: str = OUTCOME_NO_REGRESSION
+
+    @property
+    def runs(self) -> int:
+        return self.initial_runs + self.confirmation_runs
+
+
+@dataclass
+class BenchmarkRow:
+    result: Optional[BenchmarkResult]
+    display_name: str
+    old_timing: str
+    new_timing: str
+    delta: str
+    change: str
+    runs: str
+    bucket: str
+    percentage: float = 0
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(description="Compare benchmarks from base and PR benchmark runners.")
+    parser.add_argument("--old", required=True, help="Path to the base benchmark runner.")
+    parser.add_argument("--new", required=True, help="Path to the PR benchmark runner.")
+    parser.add_argument("--benchmarks", required=True, help="Path to the benchmark list.")
+    parser.add_argument("--threads", type=int, help="Number of threads used by each benchmark runner.")
+    parser.add_argument("--memory-limit", help="Memory limit used by each benchmark runner.")
+    parser.add_argument("--verbose", action="store_true", help="Print raw benchmark runner output.")
+    parser.add_argument("--nofail", action="store_true", help="Report confirmed regressions without failing.")
+    parser.add_argument("--disable-timeout", action="store_true", help="Disable the benchmark runner timeout.")
+    parser.add_argument(
+        "--benchmark-cache",
+        choices=("keep", "clear"),
+        default="keep",
+        help="Keep benchmark data or clear runner caches before running (default: keep).",
+    )
+    return parser.parse_args()
+
+
+def clear_benchmark_caches(runner_paths: List[str]):
+    cache_paths = {
+        os.path.abspath(os.path.join(os.path.dirname(runner_path), "..", "..", "..", "duckdb_benchmark_data"))
+        for runner_path in runner_paths
+    }
+    for cache_path in cache_paths:
+        shutil.rmtree(cache_path, ignore_errors=True)
+
+
+def run_paired_samples(
+    old_runner: BenchmarkRunner,
+    new_runner: BenchmarkRunner,
+    benchmark: str,
+    requested_runs: int,
+    initial_batch_index: int,
+):
+    old_timings = []
+    new_timings = []
+    batch_index = initial_batch_index
+    batch_sizes = [(requested_runs + 1) // 2, requested_runs // 2]
+
+    for batch_size in batch_sizes:
+        if batch_index % 2 == 0:
+            old_batch, old_failure = old_runner.run(benchmark, batch_size)
+            new_batch, new_failure = new_runner.run(benchmark, batch_size)
+        else:
+            new_batch, new_failure = new_runner.run(benchmark, batch_size)
+            old_batch, old_failure = old_runner.run(benchmark, batch_size)
+
+        old_batch = old_batch or []
+        new_batch = new_batch or []
+        if old_failure or new_failure:
+            return old_timings, new_timings, old_failure, new_failure, batch_index
+        if len(old_batch) != len(new_batch):
+            failure = f"Paired benchmark batches produced different run counts: {len(old_batch)} and {len(new_batch)}"
+            return old_timings, new_timings, failure, failure, batch_index
+
+        old_timings.extend(old_batch)
+        new_timings.extend(new_batch)
+        batch_index += 1
+
+    return old_timings, new_timings, None, None, batch_index
+
+
+def failed_benchmark_result(
+    benchmark: str,
+    old_failure: Optional[str],
+    new_failure: Optional[str],
+    initial_measurement: Optional[BenchmarkMeasurement],
+    initial_runs: int,
+    confirmation_runs: int,
+) -> BenchmarkResult:
+    return BenchmarkResult(
+        benchmark=benchmark,
+        initial_measurement=initial_measurement,
+        old_failure=old_failure,
+        new_failure=new_failure,
+        initial_runs=initial_runs,
+        confirmation_runs=confirmation_runs,
+        outcome=OUTCOME_FAILURE,
+    )
+
+
+def run_paired_benchmark(
+    old_runner: BenchmarkRunner, new_runner: BenchmarkRunner, benchmark: str, verbose: bool
+) -> BenchmarkResult:
+    old_initial, new_initial, old_failure, new_failure, batch_index = run_paired_samples(
+        old_runner, new_runner, benchmark, INITIAL_RUNS, 0
+    )
+    initial_count = min(len(old_initial), len(new_initial))
+    if old_failure or new_failure:
+        return failed_benchmark_result(benchmark, old_failure, new_failure, None, initial_count, 0)
+
+    initial_measurement = benchmark_measurement(old_initial, new_initial)
+    is_candidate = initial_measurement.ratio > REGRESSION_LIMIT
+    if verbose:
+        decision = "regression candidate" if is_candidate else "initial sampling complete"
+        print(
+            f"initial sampling: {benchmark}: {initial_count} paired runs, "
+            f"median PR/base {initial_measurement.ratio:.3f}x ({decision})"
+        )
+
+    if not is_candidate:
+        return BenchmarkResult(
+            benchmark=benchmark,
+            initial_measurement=initial_measurement,
+            measurement=initial_measurement,
+            initial_runs=initial_count,
+        )
+
+    requested_confirmation_runs = confirmation_run_count(initial_measurement)
+    old_confirmation, new_confirmation, old_failure, new_failure, _ = run_paired_samples(
+        old_runner,
+        new_runner,
+        benchmark,
+        requested_confirmation_runs,
+        batch_index,
+    )
+    confirmation_count = min(len(old_confirmation), len(new_confirmation))
+    if old_failure or new_failure:
+        return failed_benchmark_result(
+            benchmark,
+            old_failure,
+            new_failure,
+            initial_measurement,
+            initial_count,
+            confirmation_count,
+        )
+
+    confirmation_measurement = benchmark_measurement(old_confirmation, new_confirmation)
+    lower_bound, upper_bound = confirmation_measurement.ratio_interval
+    if lower_bound > REGRESSION_LIMIT:
+        outcome = OUTCOME_CONFIRMED_REGRESSION
+        decision = "confirmed regression"
+    elif upper_bound <= REGRESSION_LIMIT:
+        outcome = OUTCOME_NO_REGRESSION
+        decision = "regression rejected"
+    else:
+        outcome = OUTCOME_UNCONFIRMED_REGRESSION
+        decision = "regression inconclusive"
+
+    if verbose:
+        print(
+            f"regression confirmation: {benchmark}: {confirmation_count} paired runs, "
+            f"{CONFIDENCE_PERCENTAGE}% CI for PR/base median ratio: {lower_bound:.3f}x to {upper_bound:.3f}x; "
+            f"regression limit: {REGRESSION_LIMIT:.3f}x ({decision})"
+        )
+
+    return BenchmarkResult(
+        benchmark=benchmark,
+        initial_measurement=initial_measurement,
+        measurement=confirmation_measurement,
+        initial_runs=initial_count,
+        confirmation_runs=confirmation_count,
+        outcome=outcome,
+    )
+
+
+def in_ci() -> bool:
     return os.getenv("CI") == "true"
-
-
-def suite_name():
-    return Path(benchmark_file).stem
 
 
 def append_step_summary(lines: List[str]):
     summary_path = os.getenv("GITHUB_STEP_SUMMARY")
     if not summary_path:
         return
-    with open(summary_path, "a", encoding="utf-8") as f:
-        f.write("\n".join(lines))
-        f.write("\n")
+    with open(summary_path, "a", encoding="utf-8") as summary_file:
+        summary_file.write("\n".join(lines))
+        summary_file.write("\n")
 
 
-def format_seconds(value: Union[float, str]) -> str:
-    if isinstance(value, str):
-        return value
+def format_seconds(value: float) -> str:
     return f"{value:.3f}s"
 
 
@@ -183,24 +251,25 @@ def format_delta_seconds(delta: float) -> str:
     if delta == 0:
         return "0.000s"
     if abs(delta) < 0.001:
-        if delta < 0:
-            return "-<0.001s"
-        return "<0.001s"
+        return "-<0.001s" if delta < 0 else "<0.001s"
     return f"{delta:+.3f}s"
 
 
 def format_percentage(value: float) -> str:
-    if math.isfinite(value):
-        return f"{value:+.1f}%"
-    return "+inf%"
+    return f"{value:+.1f}%" if math.isfinite(value) else "+inf%"
 
 
-def regression_delta(old_value: float, new_value: float) -> str:
-    delta_sec = new_value - old_value
-    delta_pct = ((new_value / old_value) - 1.0) * 100.0 if old_value > 0 else math.inf
-    if math.isfinite(delta_pct):
-        return f"{format_delta_seconds(delta_sec)} ({format_percentage(delta_pct)})"
-    return format_delta_seconds(delta_sec)
+def regression_delta(measurement: BenchmarkMeasurement) -> str:
+    delta_seconds = measurement.new_timing - measurement.old_timing
+    delta_percentage = ((measurement.new_timing / measurement.old_timing) - 1.0) * 100.0
+    return f"{format_delta_seconds(delta_seconds)} ({format_percentage(delta_percentage)})"
+
+
+def confidence_text(result: BenchmarkResult) -> str:
+    if result.measurement is None:
+        return "unavailable"
+    lower_bound, upper_bound = result.measurement.ratio_interval
+    return f"{lower_bound:.3f}x to {upper_bound:.3f}x"
 
 
 def emit_github_error(title: str, message: str):
@@ -213,64 +282,49 @@ def emit_github_warning(title: str, message: str):
         print(f"::warning title={title}::{message}")
 
 
-def benchmark_timing_summary(regression: "BenchmarkResult"):
-    old_timing = format_seconds(regression.old_result)
-    new_timing = format_seconds(regression.new_result)
-    return old_timing, new_timing
-
-
-def report_regression(regression: "BenchmarkResult", summary: List[dict], summary_lines: List[str]):
-    old_timing, new_timing = benchmark_timing_summary(regression)
-    error_title = "Regression benchmark"
-    if not isinstance(regression.old_result, str) and not isinstance(regression.new_result, str):
-        delta = regression_delta(regression.old_result, regression.new_result)
-        message = f"{suite_name()}: {regression.benchmark} regressed from {old_timing} to {new_timing} ({delta})"
-        summary_delta = delta
-    else:
-        message = f"{suite_name()}: {regression.benchmark} failed while comparing base and PR benchmark runs"
+def report_regression(
+    result: BenchmarkResult, suite: str, failure_summary: List[BenchmarkResult], summary_lines: List[str]
+):
+    if result.outcome == OUTCOME_FAILURE:
+        message = f"{suite}: {result.benchmark} failed while comparing base and PR benchmark runs"
+        old_timing = "failed"
+        new_timing = "failed"
         summary_delta = "benchmark run failed"
-    emit_github_error(error_title, message)
+        failure_summary.append(result)
+    else:
+        measurement = result.measurement
+        assert measurement is not None
+        old_timing = format_seconds(measurement.old_timing)
+        new_timing = format_seconds(measurement.new_timing)
+        summary_delta = regression_delta(measurement)
+        message = (
+            f"{suite}: {result.benchmark} regressed from {old_timing} to {new_timing} ({summary_delta}); "
+            f"{CONFIDENCE_PERCENTAGE}% CI for PR/base median ratio {confidence_text(result)}, "
+            f"regression limit {REGRESSION_LIMIT:.3f}x"
+        )
+    emit_github_error("Regression benchmark", message)
     summary_lines.append(
-        f"| `{regression.benchmark}` | `{old_timing}` | `{new_timing}` | `{summary_delta}` | `{regression.runs}` |"
+        f"| `{result.benchmark}` | `{old_timing}` | `{new_timing}` | `{summary_delta}` | `{format_run_count(result)}` |"
     )
-    if regression.old_failure or regression.new_failure:
-        new_data = {
-            "benchmark": regression.benchmark,
-            "old_failure": regression.old_failure,
-            "new_failure": regression.new_failure,
-        }
-        summary.append(new_data)
 
 
-def report_unconfirmed(result: "BenchmarkResult", summary_lines: List[str]):
-    if isinstance(result.old_result, str) or isinstance(result.new_result, str):
-        raise ValueError("An unconfirmed regression must have benchmark timings")
-    old_timing, new_timing = benchmark_timing_summary(result)
-    delta = regression_delta(result.old_result, result.new_result)
-    lower_bound, upper_bound = result.confirmation_interval
-    confidence = f"{lower_bound:.3f}x to {upper_bound:.3f}x"
+def report_unconfirmed(result: BenchmarkResult, suite: str, summary_lines: List[str]):
+    measurement = result.measurement
+    assert measurement is not None
+    old_timing = format_seconds(measurement.old_timing)
+    new_timing = format_seconds(measurement.new_timing)
+    delta = regression_delta(measurement)
+    confidence = confidence_text(result)
     message = (
-        f"{suite_name()}: {result.benchmark} looked regressive during initial sampling but was not confirmed "
-        f"({delta}, confirmation interval {confidence})"
+        f"{suite}: {result.benchmark} looked regressive during initial sampling but remains inconclusive "
+        f"({delta}); {CONFIDENCE_PERCENTAGE}% CI for PR/base median ratio {confidence}, "
+        f"regression limit {REGRESSION_LIMIT:.3f}x"
     )
-    emit_github_warning("Unconfirmed regression benchmark", message)
+    emit_github_warning("Inconclusive regression benchmark", message)
     summary_lines.append(
         f"| `{result.benchmark}` | `{old_timing}` | `{new_timing}` | `{delta}` | "
-        f"`{result.initial_runs}+{result.confirmation_runs}` | `{confidence}` |"
+        f"`{format_run_count(result)}` | `{confidence}` |"
     )
-
-
-@dataclass
-class BenchmarkRow:
-    result: "BenchmarkResult"
-    display_name: str
-    old_timing: str
-    new_timing: str
-    delta: str
-    change: str
-    runs: str
-    bucket: str
-    percentage: float = 0
 
 
 def benchmark_common_prefix(benchmarks: List[str]) -> str:
@@ -287,79 +341,68 @@ def benchmark_display_names(benchmarks: List[str]) -> Dict[str, str]:
     common_prefix = benchmark_common_prefix(benchmarks)
     display_names = {}
     for benchmark in benchmarks:
-        display_name = benchmark
-        if common_prefix and benchmark.startswith(common_prefix):
-            display_name = benchmark[len(common_prefix) :]
+        display_name = (
+            benchmark[len(common_prefix) :] if common_prefix and benchmark.startswith(common_prefix) else benchmark
+        )
         if display_name.endswith(".benchmark"):
             display_name = display_name[: -len(".benchmark")]
         display_names[benchmark] = display_name
     return display_names
 
 
-def classify_result(result: "BenchmarkResult") -> str:
-    if isinstance(result.old_result, str) or isinstance(result.new_result, str):
+def classify_result(result: BenchmarkResult) -> str:
+    if result.outcome == OUTCOME_FAILURE:
         return BUCKET_FAILURE
     if result.outcome == OUTCOME_CONFIRMED_REGRESSION:
         return BUCKET_REGRESSION
     if result.outcome == OUTCOME_UNCONFIRMED_REGRESSION:
         return BUCKET_UNCONFIRMED
 
-    display_ratio = DISPLAY_THRESHOLD_PERCENTAGE / 100.0
-    lower_ratio, upper_ratio = result.ratio_interval
-    if lower_ratio > 1.0 + display_ratio:
+    assert result.measurement is not None
+    lower_ratio, upper_ratio = result.measurement.ratio_interval
+    if lower_ratio > 1.0 + NOISE_THRESHOLD:
         return BUCKET_SLOWER
-    if upper_ratio < 1.0 - display_ratio:
+    if upper_ratio < 1.0 - NOISE_THRESHOLD:
         return BUCKET_FASTER
     return BUCKET_UNCHANGED
 
 
-def format_run_count(result: "BenchmarkResult") -> str:
-    if result.confirmation_runs > 0:
+def format_run_count(result: BenchmarkResult) -> str:
+    if result.confirmation_runs:
         return f"{result.initial_runs}+{result.confirmation_runs}"
     return str(result.initial_runs)
 
 
-def benchmark_row(result: "BenchmarkResult", display_name: str) -> BenchmarkRow:
-    if isinstance(result.old_result, str) or isinstance(result.new_result, str):
+def benchmark_row(result: BenchmarkResult, display_name: str) -> BenchmarkRow:
+    bucket = classify_result(result)
+    if result.outcome == OUTCOME_FAILURE:
         return BenchmarkRow(
-            result=result,
-            display_name=display_name,
-            old_timing=format_seconds(result.old_result),
-            new_timing=format_seconds(result.new_result),
-            delta="failed",
-            change="failed",
-            runs=format_run_count(result),
-            bucket=BUCKET_FAILURE,
+            result, display_name, "failed", "failed", "failed", "failed", format_run_count(result), bucket
         )
-    delta = result.new_result - result.old_result
-    percentage = ((result.new_result / result.old_result) - 1.0) * 100.0 if result.old_result > 0 else math.inf
+
+    measurement = result.measurement
+    assert measurement is not None
+    delta = measurement.new_timing - measurement.old_timing
+    percentage = ((measurement.new_timing / measurement.old_timing) - 1.0) * 100.0
     return BenchmarkRow(
         result=result,
         display_name=display_name,
-        old_timing=format_seconds(result.old_result),
-        new_timing=format_seconds(result.new_result),
+        old_timing=format_seconds(measurement.old_timing),
+        new_timing=format_seconds(measurement.new_timing),
         delta=format_delta_seconds(delta),
         change=format_percentage(percentage),
         runs=format_run_count(result),
-        bucket=classify_result(result),
+        bucket=bucket,
         percentage=percentage,
     )
 
 
-def show_in_report(row: BenchmarkRow) -> bool:
-    if row.bucket in (BUCKET_REGRESSION, BUCKET_UNCONFIRMED, BUCKET_FAILURE):
-        return True
-    if not math.isfinite(row.percentage):
-        return True
-    return abs(row.percentage) >= DISPLAY_THRESHOLD_PERCENTAGE
-
-
-def color_change(row: BenchmarkRow, value: str) -> str:
-    if row.bucket in (BUCKET_REGRESSION, BUCKET_SLOWER, BUCKET_FAILURE):
+def color_change(bucket: str, value: str) -> str:
+    if bucket in (BUCKET_REGRESSION, BUCKET_SLOWER, BUCKET_FAILURE):
         return f"{ANSI_RED}{value}{ANSI_RESET}"
-    if row.bucket == BUCKET_UNCONFIRMED:
+    if bucket == BUCKET_UNCONFIRMED:
         return f"{ANSI_YELLOW}{value}{ANSI_RESET}"
-    if row.bucket == BUCKET_FASTER:
+    if bucket == BUCKET_FASTER:
         return f"{ANSI_GREEN}{value}{ANSI_RESET}"
     return value
 
@@ -383,418 +426,202 @@ def row_sort_key(row: BenchmarkRow):
 
 
 def render_table(rows: List[BenchmarkRow]):
-    if len(rows) == 0:
+    if not rows:
         return
-    headers = ["benchmark", "old", "new", "delta", "change", "runs"]
-    plain_rows = [
-        [
-            row.display_name,
-            row.old_timing,
-            row.new_timing,
-            row.delta,
-            row.change,
-            row.runs,
-        ]
-        for row in rows
-    ]
+    headers = ["benchmark", "base", "PR", "delta", "change", "runs"]
+    plain_rows = [[row.display_name, row.old_timing, row.new_timing, row.delta, row.change, row.runs] for row in rows]
     widths = [len(header) for header in headers]
     for plain_row in plain_rows:
         for index, value in enumerate(plain_row):
             widths[index] = max(widths[index], len(value))
 
-    header = "  ".join(headers[index].ljust(widths[index]) for index in range(len(headers)))
-    separator = "  ".join("-" * widths[index] for index in range(len(headers)))
-    print(header)
-    print(separator)
+    print("  ".join(headers[index].ljust(widths[index]) for index in range(len(headers))))
+    print("  ".join("-" * widths[index] for index in range(len(headers))))
     for row, plain_row in zip(rows, plain_rows):
         cells = []
         for index, value in enumerate(plain_row):
             padded = value.ljust(widths[index])
             if headers[index] == "change":
-                padded = color_change(row, padded)
+                padded = color_change(row.bucket, padded)
             cells.append(padded)
         print("  ".join(cells))
 
 
-def print_banner(title: str):
-    print("====================================================")
-    print(f"==============  {title.center(26)}  =============")
-    print("====================================================")
+def print_bucket(title: str, rows: List[BenchmarkRow], unchanged_count: int = 0):
     print("")
+    print(title)
+    if title == "UNCHANGED / NOISE":
+        print(f"{unchanged_count} benchmarks whose {CONFIDENCE_PERCENTAGE}% interval overlaps +/-2%")
+    elif rows:
+        render_table(rows)
+    else:
+        print("0 benchmarks")
+
+
+def geomean(values: List[float]) -> Optional[float]:
+    if not values:
+        return None
+    return math.exp(math.fsum(math.log(value) for value in values) / len(values))
+
+
+def print_geomean_summary(old_geomean: Optional[float], new_geomean: Optional[float]):
+    print("")
+    if old_geomean is None or new_geomean is None:
+        print(f"geomean (initial {INITIAL_RUNS} samples): unavailable")
+        return
+    percentage = ((new_geomean / old_geomean) - 1.0) * 100.0
+    if percentage > NOISE_THRESHOLD * 100.0:
+        bucket = BUCKET_SLOWER
+    elif percentage < -NOISE_THRESHOLD * 100.0:
+        bucket = BUCKET_FASTER
+    else:
+        bucket = BUCKET_UNCHANGED
+    change = color_change(bucket, format_percentage(percentage))
+    print(
+        f"geomean (initial {INITIAL_RUNS} samples): "
+        f"{format_seconds(old_geomean)} -> {format_seconds(new_geomean)}  {change}"
+    )
 
 
 def print_benchmark_report(
     rows: List[BenchmarkRow],
     common_prefix: str,
     result_text: str,
-    total_count: int,
-    hidden_noise_count: int,
-    time_a: Union[float, str],
-    time_b: Union[float, str],
+    old_geomean: Optional[float],
+    new_geomean: Optional[float],
 ):
     buckets = {
-        BUCKET_UNCHANGED: [row for row in rows if row.bucket == BUCKET_UNCHANGED],
-        BUCKET_FASTER: [row for row in rows if row.bucket == BUCKET_FASTER],
-        BUCKET_SLOWER: [row for row in rows if row.bucket == BUCKET_SLOWER],
-        BUCKET_UNCONFIRMED: [row for row in rows if row.bucket == BUCKET_UNCONFIRMED],
-        BUCKET_REGRESSION: [row for row in rows if row.bucket == BUCKET_REGRESSION],
-        BUCKET_FAILURE: [row for row in rows if row.bucket == BUCKET_FAILURE],
+        bucket: [row for row in rows if row.bucket == bucket]
+        for bucket in (
+            BUCKET_UNCHANGED,
+            BUCKET_FASTER,
+            BUCKET_SLOWER,
+            BUCKET_UNCONFIRMED,
+            BUCKET_REGRESSION,
+            BUCKET_FAILURE,
+        )
     }
 
-    print_banner("BENCHMARK QUERY AGGREGATES")
-    print(f"suite: {suite_name()}")
+    print("====================================================")
+    print("==============  BENCHMARK QUERY RESULTS  ===========")
+    print("====================================================")
+    print("")
     if common_prefix:
         print(f"common prefix: {common_prefix}")
-    print(f"benchmarks: {total_count}")
-    print(f"timing: {initial_runs} initial runs; regression confirmation targets {confirmation_time_seconds:g}s")
-    print(f"confirmation runs: {min_confirmation_runs}-{max_confirmation_runs}")
-    print(f"threshold: +{REGRESSION_THRESHOLD_PERCENTAGE * 100.0:.1f}% and +{REGRESSION_THRESHOLD_SECONDS:.3f}s")
-    print(f"display threshold: +/-{DISPLAY_THRESHOLD_PERCENTAGE:.1f}%")
-    print(f"hidden noise: {hidden_noise_count} benchmarks below +/-{DISPLAY_THRESHOLD_PERCENTAGE:.1f}%")
+    print(f"benchmarks: {len(rows)}")
+    print(f"initial sampling: {INITIAL_RUNS} runs per binary in 2 batches of {INITIAL_BATCH_SIZE}")
+    print(
+        f"confirmation sampling: ceil({CONFIRMATION_TARGET_SECONDS:g}s / faster-side median), "
+        f"clamped to {MIN_CONFIRMATION_RUNS}-{MAX_CONFIRMATION_RUNS} runs per binary"
+    )
+    print(f"regression limit: {REGRESSION_LIMIT:.3f}x (+{(REGRESSION_LIMIT - 1.0) * 100:.0f}%)")
+    print(f"confidence: {CONFIDENCE_PERCENTAGE}%; noise threshold: +/-{NOISE_THRESHOLD * 100:.0f}%")
     print(f"result: {result_text}")
-    print_geomean_summary(time_a, time_b)
-    print_bucket("UNCHANGED / NOISE", buckets[BUCKET_UNCHANGED], hidden_noise_count)
+    print_geomean_summary(old_geomean, new_geomean)
+    print_bucket("UNCHANGED / NOISE", buckets[BUCKET_UNCHANGED], len(buckets[BUCKET_UNCHANGED]))
     print_bucket("FASTER", buckets[BUCKET_FASTER])
-    print_bucket("SLOWER BELOW THRESHOLD", buckets[BUCKET_SLOWER])
-    print_bucket("UNCONFIRMED REGRESSION CANDIDATES", buckets[BUCKET_UNCONFIRMED])
+    print_bucket("SLOWER BELOW REGRESSION LIMIT", buckets[BUCKET_SLOWER])
+    print_bucket("INCONCLUSIVE REGRESSION CANDIDATES", buckets[BUCKET_UNCONFIRMED])
     print_bucket("REGRESSIONS", buckets[BUCKET_REGRESSION])
-    if len(buckets[BUCKET_FAILURE]) > 0:
+    if buckets[BUCKET_FAILURE]:
         print_bucket("FAILURES", buckets[BUCKET_FAILURE])
 
 
-def print_bucket(title: str, rows: List[BenchmarkRow], hidden_noise_count: int = 0):
-    print("")
-    print(title)
-    if title == "UNCHANGED / NOISE":
-        print(f"{hidden_noise_count} benchmarks below +/-{DISPLAY_THRESHOLD_PERCENTAGE:.1f}%")
+def print_failure_summary(failures: List[BenchmarkResult]):
+    if not failures:
         return
-    if len(rows) == 0:
-        print("0 benchmarks")
-        return
-    render_table(rows)
-
-
-def print_geomean_summary(time_a: Union[float, str], time_b: Union[float, str]):
-    print("")
-    if isinstance(time_a, str) or isinstance(time_b, str):
-        print(f"geomean old: {time_a}")
-        print(f"geomean new: {time_b}")
-        return
-    delta_pct = ((time_b / time_a) - 1.0) * 100.0 if time_a > 0 else math.inf
-    row = BenchmarkRow(
-        result=BenchmarkResult("geomean", time_a, time_b),
-        display_name="geomean",
-        old_timing=format_seconds(time_a),
-        new_timing=format_seconds(time_b),
-        delta=format_delta_seconds(time_b - time_a),
-        change=format_percentage(delta_pct),
-        runs="",
-        bucket=(BUCKET_SLOWER if delta_pct > 0 else BUCKET_FASTER if delta_pct < 0 else BUCKET_UNCHANGED),
-        percentage=delta_pct,
-    )
-    print(f"geomean: {format_seconds(time_a)} -> {format_seconds(time_b)}  {color_change(row, row.change)}")
-
-
-if not os.path.isfile(old_runner_path):
-    print(f"Failed to find old runner {old_runner_path}")
-    exit(1)
-
-if not os.path.isfile(new_runner_path):
-    print(f"Failed to find new runner {new_runner_path}")
-    exit(1)
-
-if clear_benchmark_cache:
-    old_cache_path = os.path.join(os.path.dirname(old_runner_path), "..", "..", "..", "duckdb_benchmark_data")
-    new_cache_path = os.path.join(os.path.dirname(new_runner_path), "..", "..", "..", "duckdb_benchmark_data")
-    try:
-        shutil.rmtree(old_cache_path)
-    except:
-        pass
-    try:
-        shutil.rmtree(new_cache_path)
-    except:
-        pass
-
-config_dict = vars(args)
-old_runner = BenchmarkRunner(
-    BenchmarkRunnerConfig.from_params(old_runner_path, benchmark_file, runner_label="old", **config_dict)
-)
-new_runner = BenchmarkRunner(
-    BenchmarkRunnerConfig.from_params(new_runner_path, benchmark_file, runner_label="new", **config_dict)
-)
-
-benchmark_list = old_runner.benchmark_list
-
-summary = []
-
-
-@dataclass
-class BenchmarkResult:
-    benchmark: str
-    old_result: Union[float, str]
-    new_result: Union[float, str]
-    old_failure: Optional[str] = None
-    new_failure: Optional[str] = None
-    runs: int = 0
-    initial_runs: int = 0
-    confirmation_runs: int = 0
-    outcome: str = OUTCOME_NO_REGRESSION
-    ratio_interval: Tuple[float, float] = (-math.inf, math.inf)
-    confirmation_interval: Tuple[float, float] = (-math.inf, math.inf)
-
-
-def run_paired_samples(
-    old_runner: BenchmarkRunner,
-    new_runner: BenchmarkRunner,
-    benchmark: str,
-    requested_runs: int,
-    initial_batch_index: int,
-):
-    old_timings = []
-    new_timings = []
-    batch_index = initial_batch_index
-
-    batch_sizes = [(requested_runs + 1) // 2, requested_runs // 2]
-    for batch_size in batch_sizes:
-        if batch_size == 0:
-            continue
-        if batch_index % 2 == 0:
-            old_batch, old_failure = old_runner.run_benchmark_once(benchmark, batch_size)
-            new_batch, new_failure = new_runner.run_benchmark_once(benchmark, batch_size)
-        else:
-            new_batch, new_failure = new_runner.run_benchmark_once(benchmark, batch_size)
-            old_batch, old_failure = old_runner.run_benchmark_once(benchmark, batch_size)
-
-        old_batch = old_batch or []
-        new_batch = new_batch or []
-        if old_failure or new_failure:
-            return old_timings, new_timings, old_failure, new_failure, batch_index
-        if not old_batch or not new_batch:
-            failure = "Benchmark did not produce any timings"
-            return (
-                old_timings,
-                new_timings,
-                failure if not old_batch else None,
-                failure if not new_batch else None,
-                batch_index,
-            )
-        if len(old_batch) != len(new_batch):
-            failure = f"Paired benchmark batches produced different run counts: {len(old_batch)} and {len(new_batch)}"
-            return old_timings, new_timings, failure, failure, batch_index
-
-        old_timings.extend(old_batch)
-        new_timings.extend(new_batch)
-        batch_index += 1
-
-    return old_timings, new_timings, None, None, batch_index
-
-
-def failed_benchmark_result(
-    benchmark: str,
-    old_failure: Optional[str],
-    new_failure: Optional[str],
-    initial_count: int,
-    confirmation_count: int,
-) -> BenchmarkResult:
-    failure_result = "Failed to run benchmark " + benchmark
-    return BenchmarkResult(
-        benchmark,
-        failure_result,
-        failure_result,
-        old_failure,
-        new_failure,
-        initial_count + confirmation_count,
-        initial_count,
-        confirmation_count,
-        OUTCOME_FAILURE,
-    )
-
-
-def run_paired_benchmark(old_runner: BenchmarkRunner, new_runner: BenchmarkRunner, benchmark: str) -> BenchmarkResult:
-    old_initial, new_initial, old_failure, new_failure, batch_index = run_paired_samples(
-        old_runner, new_runner, benchmark, initial_runs, 0
-    )
-    initial_count = min(len(old_initial), len(new_initial))
-    if old_failure or new_failure:
-        return failed_benchmark_result(benchmark, old_failure, new_failure, initial_count, 0)
-
-    initial_measurement = paired_measurement(old_initial, new_initial)
-    initial_regression = regression_measurement(
-        old_initial,
-        new_initial,
-        REGRESSION_THRESHOLD_PERCENTAGE,
-        REGRESSION_THRESHOLD_SECONDS,
-    )
-    is_candidate = initial_regression.ratio > 1.0
-    if verbose:
-        decision = "regression candidate" if is_candidate else "initial sampling complete"
-        print(
-            f"initial sampling: {benchmark}: {initial_count} paired runs, "
-            f"{(initial_measurement.ratio - 1.0) * 100.0:+.1f}% ({decision})"
-        )
-
-    if not is_candidate:
-        return BenchmarkResult(
-            benchmark,
-            initial_measurement.old_timing,
-            initial_measurement.new_timing,
-            runs=initial_count,
-            initial_runs=initial_count,
-            ratio_interval=initial_measurement.ratio_interval,
-        )
-
-    requested_confirmation_runs = confirmation_run_count(
-        initial_measurement,
-        confirmation_time_seconds,
-        min_confirmation_runs,
-        max_confirmation_runs,
-    )
-    old_confirmation, new_confirmation, old_failure, new_failure, _ = run_paired_samples(
-        old_runner,
-        new_runner,
-        benchmark,
-        requested_confirmation_runs,
-        batch_index,
-    )
-    confirmation_count = min(len(old_confirmation), len(new_confirmation))
-    if old_failure or new_failure:
-        return failed_benchmark_result(benchmark, old_failure, new_failure, initial_count, confirmation_count)
-
-    confirmation_regression = regression_measurement(
-        old_confirmation,
-        new_confirmation,
-        REGRESSION_THRESHOLD_PERCENTAGE,
-        REGRESSION_THRESHOLD_SECONDS,
-    )
-    lower_bound, upper_bound = confirmation_regression.ratio_interval
-    if lower_bound > 1.0:
-        outcome = OUTCOME_CONFIRMED_REGRESSION
-        decision = "confirmed regression"
-    elif upper_bound <= 1.0:
-        outcome = OUTCOME_NO_REGRESSION
-        decision = "regression rejected"
-    else:
-        outcome = OUTCOME_UNCONFIRMED_REGRESSION
-        decision = "regression inconclusive"
-    all_old_timings = old_initial + old_confirmation
-    all_new_timings = new_initial + new_confirmation
-    combined_measurement = paired_measurement(all_old_timings, all_new_timings)
-    if verbose:
-        print(
-            f"regression confirmation: {benchmark}: {confirmation_count} paired runs, "
-            f"threshold interval {lower_bound:.3f}x to {upper_bound:.3f}x ({decision})"
-        )
-
-    return BenchmarkResult(
-        benchmark,
-        combined_measurement.old_timing,
-        combined_measurement.new_timing,
-        runs=initial_count + confirmation_count,
-        initial_runs=initial_count,
-        confirmation_runs=confirmation_count,
-        outcome=outcome,
-        ratio_interval=combined_measurement.ratio_interval,
-        confirmation_interval=confirmation_regression.ratio_interval,
-    )
-
-
-if not old_runner.supports_timed_runs or not new_runner.supports_timed_runs:
-    print("Paired benchmark sampling requires both benchmark runners to support --timed-runs")
-    exit(1)
-
-all_results = [run_paired_benchmark(old_runner, new_runner, benchmark) for benchmark in benchmark_list]
-
-final_regression_results = [
-    result
-    for result in all_results
-    if isinstance(result.old_result, str)
-    or isinstance(result.new_result, str)
-    or ((not no_regression_fail) and result.outcome == OUTCOME_CONFIRMED_REGRESSION)
-]
-unconfirmed_results = [result for result in all_results if result.outcome == OUTCOME_UNCONFIRMED_REGRESSION]
-display_names = benchmark_display_names([result.benchmark for result in all_results])
-rows = [benchmark_row(result, display_names[result.benchmark]) for result in all_results]
-rows.sort(key=row_sort_key)
-visible_rows = [row for row in rows if show_in_report(row)]
-hidden_noise_count = len(rows) - len(visible_rows)
-
-exit_code = 0
-summary = []
-if len(final_regression_results) > 0:
-    exit_code = 1
-    summary_lines = [
-        f"## Regression Suite: `{suite_name()}`",
-        "",
-        "| Benchmark | Base | PR | Delta | Runs |",
-        "| --- | --- | --- | --- | --- |",
-    ]
-    for regression in final_regression_results:
-        report_regression(regression, summary, summary_lines)
-    append_step_summary(summary_lines + [""])
-
-if len(unconfirmed_results) > 0:
-    summary_lines = [
-        f"## Unconfirmed Regression Candidates: `{suite_name()}`",
-        "",
-        "| Benchmark | Base | PR | Delta | Runs | Confirmation interval |",
-        "| --- | --- | --- | --- | --- | --- |",
-    ]
-    for result in unconfirmed_results:
-        report_unconfirmed(result, summary_lines)
-    append_step_summary(summary_lines + [""])
-
-has_failures = any(row.bucket == BUCKET_FAILURE for row in rows)
-has_regressions = any(row.bucket == BUCKET_REGRESSION for row in rows)
-has_unconfirmed = any(row.bucket == BUCKET_UNCONFIRMED for row in rows)
-if has_failures:
-    result_text = "benchmark failure detected"
-elif has_regressions:
-    result_text = "regression detected"
-elif has_unconfirmed:
-    result_text = "no confirmed regressions; noisy candidates reported"
-else:
-    result_text = "no regressions detected"
-
-common_prefix = benchmark_common_prefix([result.benchmark for result in all_results])
-successful_results = [
-    result
-    for result in all_results
-    if not isinstance(result.old_result, str) and not isinstance(result.new_result, str)
-]
-time_a = geomean([result.old_result for result in successful_results])
-time_b = geomean([result.new_result for result in successful_results])
-print_benchmark_report(
-    visible_rows,
-    common_prefix,
-    result_text,
-    len(rows),
-    hidden_noise_count,
-    time_a,
-    time_b,
-)
-
-# nuke cached benchmark data between runs
-if not keep_benchmark_data:
-    if os.path.isdir("duckdb_benchmark_data"):
-        shutil.rmtree("duckdb_benchmark_data")
-
-if summary and not no_summary:
     print(
-        """\n\n====================================================
+        """\n
+====================================================
 ================  FAILURES SUMMARY  ================
 ====================================================
 """
     )
-    # check the value is "true" otherwise you'll see the prefix in local run outputs
-    prefix = "::error::" if in_ci() else ""
-    for i, failure_message in enumerate(summary, start=1):
-        prefix_str = f"{prefix}{i}" if len(prefix) > 0 else f"{i}"
-        print(f"{prefix_str}: ", failure_message["benchmark"])
-        if failure_message["old_failure"] != failure_message["new_failure"]:
-            print("Old:\n", failure_message["old_failure"])
-            print("New:\n", failure_message["new_failure"])
+    for index, result in enumerate(failures, start=1):
+        prefix = "::error::" if in_ci() else ""
+        print(f"{prefix}{index}: {result.benchmark}")
+        if result.old_failure != result.new_failure:
+            print("Base:\n", result.old_failure)
+            print("PR:\n", result.new_failure)
         else:
-            print(failure_message["old_failure"])
+            print(result.old_failure)
         print("-", 52)
 
-exit(exit_code)
+
+def main() -> int:
+    args = parse_arguments()
+    for label, path in (("base", args.old), ("PR", args.new)):
+        if not os.path.isfile(path):
+            print(f"Failed to find {label} runner {path}")
+            return 1
+    if not os.path.isfile(args.benchmarks):
+        print(f"Failed to find benchmark list {args.benchmarks}")
+        return 1
+
+    if args.benchmark_cache == "clear":
+        clear_benchmark_caches([args.old, args.new])
+
+    with open(args.benchmarks, "r", encoding="utf-8") as benchmark_file:
+        benchmarks = [line.strip() for line in benchmark_file if line.strip()]
+    suite = Path(args.benchmarks).stem
+    old_runner = BenchmarkRunner(args.old, "base", args.threads, args.memory_limit, args.verbose, args.disable_timeout)
+    new_runner = BenchmarkRunner(args.new, "PR", args.threads, args.memory_limit, args.verbose, args.disable_timeout)
+    results = [run_paired_benchmark(old_runner, new_runner, benchmark, args.verbose) for benchmark in benchmarks]
+
+    failing_results = [
+        result
+        for result in results
+        if result.outcome == OUTCOME_FAILURE or (result.outcome == OUTCOME_CONFIRMED_REGRESSION and not args.nofail)
+    ]
+    inconclusive_results = [result for result in results if result.outcome == OUTCOME_UNCONFIRMED_REGRESSION]
+    failure_summary = []
+    if failing_results:
+        summary_lines = [
+            f"## Regression Suite: `{suite}`",
+            "",
+            "| Benchmark | Base | PR | Delta | Runs |",
+            "| --- | --- | --- | --- | --- |",
+        ]
+        for result in failing_results:
+            report_regression(result, suite, failure_summary, summary_lines)
+        append_step_summary(summary_lines + [""])
+
+    if inconclusive_results:
+        summary_lines = [
+            f"## Inconclusive Regression Candidates: `{suite}`",
+            "",
+            "| Benchmark | Base | PR | Delta | Runs | 95% PR/base median ratio interval |",
+            "| --- | --- | --- | --- | --- | --- |",
+        ]
+        for result in inconclusive_results:
+            report_unconfirmed(result, suite, summary_lines)
+        append_step_summary(summary_lines + [""])
+
+    display_names = benchmark_display_names([result.benchmark for result in results])
+    rows = [benchmark_row(result, display_names[result.benchmark]) for result in results]
+    rows.sort(key=row_sort_key)
+    if any(result.outcome == OUTCOME_FAILURE for result in results):
+        result_text = "benchmark failure detected"
+    elif any(result.outcome == OUTCOME_CONFIRMED_REGRESSION for result in results):
+        result_text = "regression detected"
+    elif inconclusive_results:
+        result_text = "no confirmed regressions; inconclusive candidates reported"
+    else:
+        result_text = "no regressions detected"
+
+    initial_measurements = [result.initial_measurement for result in results if result.initial_measurement]
+    old_geomean = geomean([measurement.old_timing for measurement in initial_measurements])
+    new_geomean = geomean([measurement.new_timing for measurement in initial_measurements])
+    print_benchmark_report(
+        rows,
+        benchmark_common_prefix([result.benchmark for result in results]),
+        result_text,
+        old_geomean,
+        new_geomean,
+    )
+    print_failure_summary(failure_summary)
+    return 1 if failing_results else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/regression/test_runner.py
+++ b/scripts/regression/test_runner.py
@@ -9,7 +9,6 @@ from typing import Dict, List, Optional, Tuple
 
 from benchmark import BenchmarkRunner
 from comparison import (
-    CONFIRMATION_TARGET_SECONDS,
     MAX_CONFIRMATION_RUNS,
     MIN_CONFIRMATION_RUNS,
     SAMPLE_BATCH_SIZE,
@@ -31,6 +30,7 @@ CONFIDENCE_PERCENTAGE = 95
 ANSI_RED = "\033[31m"
 ANSI_GREEN = "\033[32m"
 ANSI_YELLOW = "\033[33m"
+ANSI_GRAY = "\033[90m"
 ANSI_RESET = "\033[0m"
 
 BUCKET_UNCHANGED = "unchanged"
@@ -110,32 +110,34 @@ def run_paired_samples(
     new_runner: BenchmarkRunner,
     benchmark: str,
     requested_runs: int,
-    initial_batch_index: int,
+    stop_on_confident_noise: bool = False,
 ):
     old_timings = []
     new_timings = []
-    batch_index = initial_batch_index
-    for batch_size in sampling_batch_sizes(requested_runs):
-        if batch_index % 2 == 0:
-            old_batch, old_failure = old_runner.run(benchmark, batch_size)
-            new_batch, new_failure = new_runner.run(benchmark, batch_size)
-        else:
-            new_batch, new_failure = new_runner.run(benchmark, batch_size)
-            old_batch, old_failure = old_runner.run(benchmark, batch_size)
+    batch_sizes = sampling_batch_sizes(requested_runs)
+    planned_runs = sum(batch_sizes)
+    for batch_size in batch_sizes:
+        old_batch, old_failure = old_runner.run(benchmark, batch_size)
+        new_batch, new_failure = new_runner.run(benchmark, batch_size)
 
         old_batch = old_batch or []
         new_batch = new_batch or []
         if old_failure or new_failure:
-            return old_timings, new_timings, old_failure, new_failure, batch_index
+            return old_timings, new_timings, old_failure, new_failure, False
         if len(old_batch) != len(new_batch):
             failure = f"Paired benchmark batches produced different run counts: {len(old_batch)} and {len(new_batch)}"
-            return old_timings, new_timings, failure, failure, batch_index
+            return old_timings, new_timings, failure, failure, False
 
         old_timings.extend(old_batch)
         new_timings.extend(new_batch)
-        batch_index += 1
+        completed_runs = len(old_timings)
+        if stop_on_confident_noise and completed_runs < planned_runs and completed_runs % (2 * SAMPLE_BATCH_SIZE) == 0:
+            measurement = benchmark_measurement(old_timings, new_timings)
+            lower_bound, upper_bound = measurement.ratio_interval
+            if lower_bound >= 1.0 - NOISE_THRESHOLD and upper_bound <= 1.0 + NOISE_THRESHOLD:
+                return old_timings, new_timings, None, None, True
 
-    return old_timings, new_timings, None, None, batch_index
+    return old_timings, new_timings, None, None, False
 
 
 def failed_benchmark_result(
@@ -160,8 +162,8 @@ def failed_benchmark_result(
 def run_paired_benchmark(
     old_runner: BenchmarkRunner, new_runner: BenchmarkRunner, benchmark: str, verbose: bool
 ) -> BenchmarkResult:
-    old_initial, new_initial, old_failure, new_failure, batch_index = run_paired_samples(
-        old_runner, new_runner, benchmark, INITIAL_RUNS, 0
+    old_initial, new_initial, old_failure, new_failure, _ = run_paired_samples(
+        old_runner, new_runner, benchmark, INITIAL_RUNS
     )
     initial_count = min(len(old_initial), len(new_initial))
     if old_failure or new_failure:
@@ -187,12 +189,12 @@ def run_paired_benchmark(
             initial_runs=initial_count,
         )
 
-    old_confirmation, new_confirmation, old_failure, new_failure, _ = run_paired_samples(
+    old_confirmation, new_confirmation, old_failure, new_failure, stopped_early = run_paired_samples(
         old_runner,
         new_runner,
         benchmark,
         requested_confirmation_runs,
-        batch_index,
+        stop_on_confident_noise=True,
     )
     confirmation_count = min(len(old_confirmation), len(new_confirmation))
     if old_failure or new_failure:
@@ -217,10 +219,10 @@ def run_paired_benchmark(
 
     if verbose:
         print(
-            f"confirmation: {benchmark}: {confirmation_count} pairs | "
+            f"confirm: {benchmark}: {confirmation_count} pairs | "
             f"median change {format_ratio_change(confirmation_measurement.ratio)} | "
             f"{CONFIDENCE_PERCENTAGE}% CI {format_ratio_interval((lower_bound, upper_bound))} | "
-            f"{measurement_status(confirmation_measurement, outcome)}"
+            f"{measurement_status(confirmation_measurement, outcome, stopped_early)}"
         )
 
     return BenchmarkResult(
@@ -286,7 +288,9 @@ def direction_confidence(measurement: BenchmarkMeasurement) -> str:
     return "within noise"
 
 
-def measurement_status(measurement: BenchmarkMeasurement, outcome: str) -> str:
+def measurement_status(measurement: BenchmarkMeasurement, outcome: str, stopped_early: bool = False) -> str:
+    if stopped_early:
+        return "within ±2% (confident; stopped early)"
     if outcome == OUTCOME_CONFIRMED_REGRESSION:
         return "regression (confirmed)"
     if outcome == OUTCOME_UNCONFIRMED_REGRESSION:
@@ -466,7 +470,21 @@ def color_change(bucket: str, value: str) -> str:
         return f"{ANSI_YELLOW}{value}{ANSI_RESET}"
     if bucket == BUCKET_FASTER:
         return f"{ANSI_GREEN}{value}{ANSI_RESET}"
-    return value
+    return f"{ANSI_GRAY}{value}{ANSI_RESET}"
+
+
+def gray(value: str) -> str:
+    return f"{ANSI_GRAY}{value}{ANSI_RESET}"
+
+
+def color_result(result_text: str) -> str:
+    if result_text == "no regressions":
+        color = ANSI_GREEN
+    elif result_text == "uncertain regressions":
+        color = ANSI_YELLOW
+    else:
+        color = ANSI_RED
+    return f"{color}{result_text}{ANSI_RESET}"
 
 
 def row_sort_key(row: BenchmarkRow):
@@ -522,14 +540,17 @@ def render_table(rows: List[BenchmarkRow]):
 
 
 def print_bucket(title: str, rows: List[BenchmarkRow], unchanged_count: int = 0):
+    if title == "UNCHANGED (±2%)":
+        if not unchanged_count:
+            return
+    elif not rows:
+        return
     print("")
     print(title)
-    if title == "UNCHANGED / NOISE":
-        print(f"{unchanged_count} benchmarks whose median change is within ±2%")
-    elif rows:
-        render_table(rows)
+    if title == "UNCHANGED (±2%)":
+        print(f"{unchanged_count} benchmarks")
     else:
-        print("0 benchmarks")
+        render_table(rows)
 
 
 def geomean(values: List[float]) -> Optional[float]:
@@ -540,8 +561,9 @@ def geomean(values: List[float]) -> Optional[float]:
 
 def print_geomean_summary(old_geomean: Optional[float], new_geomean: Optional[float]):
     print("")
+    sample_text = gray(f"(initial {INITIAL_RUNS} samples)")
     if old_geomean is None or new_geomean is None:
-        print(f"geomean (initial {INITIAL_RUNS} samples): unavailable")
+        print(f"geomean: unavailable  {sample_text}")
         return
     percentage = ((new_geomean / old_geomean) - 1.0) * 100.0
     if percentage > NOISE_THRESHOLD * 100.0:
@@ -551,10 +573,7 @@ def print_geomean_summary(old_geomean: Optional[float], new_geomean: Optional[fl
     else:
         bucket = BUCKET_UNCHANGED
     change = color_change(bucket, format_percentage(percentage))
-    print(
-        f"geomean (initial {INITIAL_RUNS} samples): "
-        f"{format_seconds(old_geomean)} -> {format_seconds(new_geomean)}  {change}"
-    )
+    print(f"geomean: {format_seconds(old_geomean)} -> {format_seconds(new_geomean)}  " f"{change}  {sample_text}")
 
 
 def print_benchmark_report(
@@ -576,34 +595,29 @@ def print_benchmark_report(
         )
     }
 
-    print("====================================================")
-    print("==============  BENCHMARK QUERY RESULTS  ===========")
-    print("====================================================")
     print("")
-    if common_prefix:
-        print(f"common prefix: {common_prefix}")
-    print(f"benchmarks: {len(rows)}")
-    print(f"initial sampling: {INITIAL_RUNS} runs per binary in 2 batches of {INITIAL_BATCH_SIZE}")
+    suite_text = f"{common_prefix} ({len(rows)} benchmarks)" if common_prefix else f"{len(rows)} benchmarks"
+    print(gray(f"suite: {suite_text}"))
     print(
-        f"confirmation sampling: ceil({CONFIRMATION_TARGET_SECONDS:g}s / faster-side median), "
-        f"clamped to {MIN_CONFIRMATION_RUNS}-{MAX_CONFIRMATION_RUNS} runs per binary in batches of "
-        f"{SAMPLE_BATCH_SIZE}"
+        gray(
+            f"sampling: {INITIAL_RUNS} initial pairs; {MIN_CONFIRMATION_RUNS}–{MAX_CONFIRMATION_RUNS} "
+            f"confirmation pairs outside ±{NOISE_THRESHOLD * 100:.0f}%, with early noise stop"
+        )
     )
-    print(f"confirmation candidates: initial median change outside ±{NOISE_THRESHOLD * 100:.0f}%")
-    print(f"regression limit: {format_ratio_change(REGRESSION_LIMIT)}")
     print(
-        f"reporting: confirmation median with ±{NOISE_THRESHOLD * 100:.0f}% noise threshold; "
-        f"regressions require {CONFIDENCE_PERCENTAGE}% confidence"
+        gray(
+            f"regression: fail when the {CONFIDENCE_PERCENTAGE}% CI is above "
+            f"{format_ratio_change(REGRESSION_LIMIT)}"
+        )
     )
-    print(f"result: {result_text}")
     print_geomean_summary(old_geomean, new_geomean)
-    print_bucket("UNCHANGED / NOISE", buckets[BUCKET_UNCHANGED], len(buckets[BUCKET_UNCHANGED]))
+    print(f"result: {color_result(result_text)}")
+    print_bucket("UNCHANGED (±2%)", buckets[BUCKET_UNCHANGED], len(buckets[BUCKET_UNCHANGED]))
     print_bucket("FASTER", buckets[BUCKET_FASTER])
-    print_bucket("SLOWER BELOW REGRESSION LIMIT", buckets[BUCKET_SLOWER])
-    print_bucket("INCONCLUSIVE REGRESSION CANDIDATES", buckets[BUCKET_UNCONFIRMED])
+    print_bucket("SLOWER (+2%…+10%)", buckets[BUCKET_SLOWER])
+    print_bucket("UNCERTAIN REGRESSIONS", buckets[BUCKET_UNCONFIRMED])
     print_bucket("REGRESSIONS", buckets[BUCKET_REGRESSION])
-    if buckets[BUCKET_FAILURE]:
-        print_bucket("FAILURES", buckets[BUCKET_FAILURE])
+    print_bucket("FAILURES", buckets[BUCKET_FAILURE])
 
 
 def print_failure_summary(failures: List[BenchmarkResult]):
@@ -680,13 +694,13 @@ def main() -> int:
     rows = [benchmark_row(result, display_names[result.benchmark]) for result in results]
     rows.sort(key=row_sort_key)
     if any(result.outcome == OUTCOME_FAILURE for result in results):
-        result_text = "benchmark failure detected"
+        result_text = "benchmark failure"
     elif any(result.outcome == OUTCOME_CONFIRMED_REGRESSION for result in results):
         result_text = "regression detected"
     elif inconclusive_results:
-        result_text = "no confirmed regressions; inconclusive candidates reported"
+        result_text = "uncertain regressions"
     else:
-        result_text = "no regressions detected"
+        result_text = "no regressions"
 
     initial_measurements = [result.initial_measurement for result in results if result.initial_measurement]
     old_geomean = geomean([measurement.old_timing for measurement in initial_measurements])

--- a/scripts/regression/test_runner.py
+++ b/scripts/regression/test_runner.py
@@ -2,7 +2,8 @@ import os
 import math
 import functools
 import shutil
-from benchmark import BenchmarkRunner, BenchmarkRunnerConfig, DEFAULT_TIMED_RUNS
+from benchmark import BenchmarkRunner, BenchmarkRunnerConfig
+from comparison import paired_measurement, sampling_decision
 from dataclasses import dataclass
 from typing import Optional, List, Union, Dict
 from pathlib import Path
@@ -48,8 +49,20 @@ parser.add_argument("--no-summary", type=str, default=False, help="No summary in
 parser.add_argument(
     "--timed-runs",
     type=int,
-    default=DEFAULT_TIMED_RUNS,
-    help=f"Number of timed runs per benchmark (default: {DEFAULT_TIMED_RUNS}).",
+    default=20,
+    help="Minimum number of timed runs per benchmark (default: 20).",
+)
+parser.add_argument(
+    "--max-timed-runs",
+    type=int,
+    default=100,
+    help="Maximum number of timed runs per benchmark (default: 100).",
+)
+parser.add_argument(
+    "--max-adaptive-time-seconds",
+    type=float,
+    default=10.0,
+    help="Maximum combined measured time before adaptive sampling stops (default: 10 seconds).",
 )
 parser.add_argument(
     "--clear-benchmark-cache", action="store_true", help="Clear benchmark caches prior to running", default=False
@@ -83,9 +96,18 @@ clear_benchmark_cache = args.clear_benchmark_cache
 keep_benchmark_data = args.keep_benchmark_data
 regression_threshold_seconds = args.regression_threshold_seconds
 timed_runs = args.timed_runs
+max_timed_runs = args.max_timed_runs
+max_adaptive_time_seconds = args.max_adaptive_time_seconds
+
+if timed_runs <= 0:
+    parser.error("--timed-runs must be greater than zero")
+if max_timed_runs < timed_runs:
+    parser.error("--max-timed-runs must be greater than or equal to --timed-runs")
+if max_adaptive_time_seconds <= 0:
+    parser.error("--max-adaptive-time-seconds must be greater than zero")
 
 
-# how many times we will run the experiment, to be sure of the regression
+# Legacy runners without --timed-runs support retain the old confirmation loop.
 NUMBER_REPETITIONS = 5
 # the threshold at which we consider something a regression (percentage)
 REGRESSION_THRESHOLD_PERCENTAGE = 0.1
@@ -175,7 +197,9 @@ def report_regression(regression: "BenchmarkResult", summary: List[dict], summar
         message = f"{suite_name()}: {regression.benchmark} failed while comparing base and PR benchmark runs"
         summary_delta = "benchmark run failed"
     emit_github_error(error_title, message)
-    summary_lines.append(f"| `{regression.benchmark}` | `{old_timing}` | `{new_timing}` | `{summary_delta}` |")
+    summary_lines.append(
+        f"| `{regression.benchmark}` | `{old_timing}` | `{new_timing}` | `{summary_delta}` | `{regression.runs}` |"
+    )
     if regression.old_failure or regression.new_failure:
         new_data = {
             "benchmark": regression.benchmark,
@@ -193,6 +217,7 @@ class BenchmarkRow:
     new_timing: str
     delta: str
     change: str
+    runs: str
     bucket: str
     percentage: float = 0
 
@@ -245,6 +270,7 @@ def benchmark_row(result: "BenchmarkResult", display_name: str) -> BenchmarkRow:
             new_timing=format_seconds(result.new_result),
             delta="failed",
             change="failed",
+            runs=str(result.runs),
             bucket=BUCKET_FAILURE,
         )
     delta = result.new_result - result.old_result
@@ -256,6 +282,7 @@ def benchmark_row(result: "BenchmarkResult", display_name: str) -> BenchmarkRow:
         new_timing=format_seconds(result.new_result),
         delta=format_delta_seconds(delta),
         change=format_percentage(percentage),
+        runs=str(result.runs),
         bucket=classify_result(result),
         percentage=percentage,
     )
@@ -297,8 +324,8 @@ def row_sort_key(row: BenchmarkRow):
 def render_table(rows: List[BenchmarkRow]):
     if len(rows) == 0:
         return
-    headers = ["benchmark", "old", "new", "delta", "change"]
-    plain_rows = [[row.display_name, row.old_timing, row.new_timing, row.delta, row.change] for row in rows]
+    headers = ["benchmark", "old", "new", "delta", "change", "runs"]
+    plain_rows = [[row.display_name, row.old_timing, row.new_timing, row.delta, row.change, row.runs] for row in rows]
     widths = [len(header) for header in headers]
     for plain_row in plain_rows:
         for index, value in enumerate(plain_row):
@@ -347,10 +374,13 @@ def print_benchmark_report(
     if common_prefix:
         print(f"common prefix: {common_prefix}")
     print(f"benchmarks: {total_count}")
-    if timed_runs:
-        print(f"timing: median of {timed_runs} timed runs")
+    if adaptive_sampling:
+        print(
+            f"timing: paired median, {timed_runs}-{max_timed_runs} timed runs, "
+            f"{max_adaptive_time_seconds:g}s adaptive budget"
+        )
     else:
-        print("timing: median")
+        print(f"timing: median of {timed_runs} timed runs")
     print(f"threshold: +{REGRESSION_THRESHOLD_PERCENTAGE * 100.0:.1f}% and +{REGRESSION_THRESHOLD_SECONDS:.3f}s")
     print(f"display threshold: +/-{DISPLAY_THRESHOLD_PERCENTAGE:.1f}%")
     print(f"hidden noise: {hidden_noise_count} benchmarks below +/-{DISPLAY_THRESHOLD_PERCENTAGE:.1f}%")
@@ -390,6 +420,7 @@ def print_geomean_summary(time_a: Union[float, str], time_b: Union[float, str]):
         new_timing=format_seconds(time_b),
         delta=format_delta_seconds(time_b - time_a),
         change=format_percentage(delta_pct),
+        runs="",
         bucket=BUCKET_SLOWER if delta_pct > 0 else BUCKET_FASTER if delta_pct < 0 else BUCKET_UNCHANGED,
         percentage=delta_pct,
     )
@@ -436,13 +467,15 @@ class BenchmarkResult:
     new_result: Union[float, str]
     old_failure: Optional[str] = None
     new_failure: Optional[str] = None
+    runs: int = 0
 
 
-def run_benchmarks_alternating(old_runner: BenchmarkRunner, new_runner: BenchmarkRunner, benchmark_list: List[str]):
+def run_benchmarks_legacy(old_runner: BenchmarkRunner, new_runner: BenchmarkRunner, benchmark_list: List[str]):
     old_results = {}
     new_results = {}
     old_failures = {}
     new_failures = {}
+    run_counts = {}
     requested_runs = max(timed_runs, 1) if timed_runs is not None else 1
 
     for benchmark in benchmark_list:
@@ -488,49 +521,128 @@ def run_benchmarks_alternating(old_runner: BenchmarkRunner, new_runner: Benchmar
             new_failures[benchmark] = new_failure
         else:
             new_results[benchmark], new_failures[benchmark] = new_runner.complete_benchmark(benchmark, new_timings)
+        run_counts[benchmark] = min(len(old_timings), len(new_timings))
 
-    return old_results, old_failures, new_results, new_failures
+    return old_results, old_failures, new_results, new_failures, run_counts
+
+
+def run_paired_benchmark(old_runner: BenchmarkRunner, new_runner: BenchmarkRunner, benchmark: str) -> BenchmarkResult:
+    old_timings = []
+    new_timings = []
+    batch_index = 0
+
+    while len(old_timings) < max_timed_runs:
+        batch_size = min(TIMED_RUN_BATCH_SIZE, max_timed_runs - len(old_timings))
+        if batch_index % 2 == 0:
+            old_batch, old_failure = old_runner.run_benchmark_once(benchmark, batch_size)
+            new_batch, new_failure = new_runner.run_benchmark_once(benchmark, batch_size)
+        else:
+            new_batch, new_failure = new_runner.run_benchmark_once(benchmark, batch_size)
+            old_batch, old_failure = old_runner.run_benchmark_once(benchmark, batch_size)
+
+        old_batch = old_batch or []
+        new_batch = new_batch or []
+        if old_failure or new_failure:
+            failure_result = 'Failed to run benchmark ' + benchmark
+            return BenchmarkResult(
+                benchmark,
+                failure_result,
+                failure_result,
+                old_failure,
+                new_failure,
+                min(len(old_timings), len(new_timings)),
+            )
+        if not old_batch or not new_batch:
+            failure = "Benchmark did not produce any timings"
+            failure_result = 'Failed to run benchmark ' + benchmark
+            return BenchmarkResult(
+                benchmark,
+                failure_result,
+                failure_result,
+                failure if not old_batch else None,
+                failure if not new_batch else None,
+                min(len(old_timings), len(new_timings)),
+            )
+        if len(old_batch) != len(new_batch):
+            failure = f"Paired benchmark batches produced different run counts: {len(old_batch)} and {len(new_batch)}"
+            failure_result = 'Failed to run benchmark ' + benchmark
+            return BenchmarkResult(benchmark, failure_result, failure_result, failure, failure, len(old_timings))
+
+        old_timings.extend(old_batch)
+        new_timings.extend(new_batch)
+        batch_index += 1
+
+        measurement = paired_measurement(old_timings, new_timings)
+        measured_seconds = math.fsum(old_timings) + math.fsum(new_timings)
+        decision = sampling_decision(
+            measurement,
+            measured_seconds,
+            timed_runs,
+            max_timed_runs,
+            max_adaptive_time_seconds,
+            DISPLAY_THRESHOLD_PERCENTAGE,
+            REGRESSION_THRESHOLD_PERCENTAGE,
+            REGRESSION_THRESHOLD_SECONDS,
+        )
+        if verbose:
+            print(
+                f"adaptive sampling: {benchmark}: {measurement.runs} paired runs, "
+                f"{(measurement.ratio - 1.0) * 100.0:+.1f}% ({decision.reason})"
+            )
+        if not decision.collect_more:
+            return BenchmarkResult(benchmark, measurement.old_timing, measurement.new_timing, runs=measurement.runs)
+
+    raise RuntimeError("Adaptive benchmark loop exceeded its configured run limit")
 
 
 multiply_percentage = 1.0 + REGRESSION_THRESHOLD_PERCENTAGE
-other_results: List[BenchmarkResult] = []
-error_list: List[BenchmarkResult] = []
-for i in range(NUMBER_REPETITIONS):
-    regression_list: List[BenchmarkResult] = []
-    if len(benchmark_list) == 0:
-        break
-    print(
-        f'''====================================================
+adaptive_sampling = old_runner.supports_timed_runs and new_runner.supports_timed_runs
+if adaptive_sampling:
+    all_results = [run_paired_benchmark(old_runner, new_runner, benchmark) for benchmark in benchmark_list]
+else:
+    print("Adaptive paired sampling disabled because a benchmark runner does not support --timed-runs")
+    other_results: List[BenchmarkResult] = []
+    error_list: List[BenchmarkResult] = []
+    for i in range(NUMBER_REPETITIONS):
+        regression_list: List[BenchmarkResult] = []
+        if len(benchmark_list) == 0:
+            break
+        print(
+            f'''====================================================
 ==============      ITERATION {i}        =============
 ==============      REMAINING {len(benchmark_list)}        =============
 ====================================================
 '''
-    )
+        )
 
-    old_results, old_failures, new_results, new_failures = run_benchmarks_alternating(
-        old_runner, new_runner, benchmark_list
-    )
+        old_results, old_failures, new_results, new_failures, run_counts = run_benchmarks_legacy(
+            old_runner, new_runner, benchmark_list
+        )
 
-    for benchmark in benchmark_list:
-        old_res = old_results[benchmark]
-        new_res = new_results[benchmark]
+        for benchmark in benchmark_list:
+            old_res = old_results[benchmark]
+            new_res = new_results[benchmark]
+            old_fail = old_failures[benchmark]
+            new_fail = new_failures[benchmark]
+            runs = run_counts[benchmark]
 
-        old_fail = old_failures[benchmark]
-        new_fail = new_failures[benchmark]
+            if isinstance(old_res, str) or isinstance(new_res, str):
+                error_list.append(BenchmarkResult(benchmark, old_res, new_res, old_fail, new_fail, runs))
+            elif (not no_regression_fail) and is_regression(old_res, new_res):
+                regression_list.append(BenchmarkResult(benchmark, old_res, new_res, runs=runs))
+            else:
+                other_results.append(BenchmarkResult(benchmark, old_res, new_res, runs=runs))
+        benchmark_list = [res.benchmark for res in regression_list]
 
-        if isinstance(old_res, str) or isinstance(new_res, str):
-            # benchmark failed to run - always a regression
-            error_list.append(BenchmarkResult(benchmark, old_res, new_res, old_fail, new_fail))
-        elif (no_regression_fail == False) and (
-            (old_res + REGRESSION_THRESHOLD_SECONDS) * multiply_percentage < new_res
-        ):
-            regression_list.append(BenchmarkResult(benchmark, old_res, new_res))
-        else:
-            other_results.append(BenchmarkResult(benchmark, old_res, new_res))
-    benchmark_list = [res.benchmark for res in regression_list]
+    all_results = other_results + regression_list + error_list
 
-final_regression_results = regression_list + error_list
-all_results = other_results + final_regression_results
+final_regression_results = [
+    result
+    for result in all_results
+    if isinstance(result.old_result, str)
+    or isinstance(result.new_result, str)
+    or ((not no_regression_fail) and is_regression(result.old_result, result.new_result))
+]
 display_names = benchmark_display_names([result.benchmark for result in all_results])
 rows = [benchmark_row(result, display_names[result.benchmark]) for result in all_results]
 rows.sort(key=row_sort_key)
@@ -544,8 +656,8 @@ if len(final_regression_results) > 0:
     summary_lines = [
         f"## Regression Suite: `{suite_name()}`",
         "",
-        "| Benchmark | Base | PR | Delta |",
-        "| --- | --- | --- | --- |",
+        "| Benchmark | Base | PR | Delta | Runs |",
+        "| --- | --- | --- | --- | --- |",
     ]
     for regression in final_regression_results:
         report_regression(regression, summary, summary_lines)
@@ -561,8 +673,13 @@ else:
     result_text = "no regressions detected"
 
 common_prefix = benchmark_common_prefix([result.benchmark for result in all_results])
-time_a = geomean(old_runner.complete_timings)
-time_b = geomean(new_runner.complete_timings)
+successful_results = [
+    result
+    for result in all_results
+    if not isinstance(result.old_result, str) and not isinstance(result.new_result, str)
+]
+time_a = geomean([result.old_result for result in successful_results])
+time_b = geomean([result.new_result for result in successful_results])
 print_benchmark_report(visible_rows, common_prefix, result_text, len(rows), hidden_noise_count, time_a, time_b)
 
 # nuke cached benchmark data between runs


### PR DESCRIPTION
<details>
<summary>Original approach</summary>

### Adaptive sampling

Initially, collect 10 samples (2 times a batch of 5 samples) for every query per binary.

For regression candidates, choose an independent confirmation sample size from the observed runtime:

```python
confirmation_runs =
    clamp(5 × ceil((3 seconds / faster_side_median) / 5), 30, 100)
```

Approximate confirmation sizes:

| Query runtime       | Confirmation runs |
|---------------------|------------------:|
| 20 ms               | 100 (capped) |
| 50 ms               | 60 |
| 100 ms              | 30 |
| 300 ms              | 30 |
| 500 ms – a few sec  | 30 (minimum) |

This combines [Hyperfine](https://github.com/sharkdp/hyperfine#basic-benchmarks)’s 10-run/3-second acquisition model with [Criterion](https://bheisler.github.io/criterion.rs/book/user_guide/command_line_output.html)’s 95% confidence and ±2% noise principles.

### Simplify bench report

No regressions detected:

<img width="762" height="335" alt="Screenshot 2026-08-06 at 08 55 03" src="https://github.com/user-attachments/assets/40071932-e8b1-4b31-92bf-397bcb822c8b" />

A few slower and faster (but not exceeding regressions):

<img width="804" height="460" alt="Screenshot 2026-08-06 at 08 55 20" src="https://github.com/user-attachments/assets/0e9908bf-b02c-4d7f-b500-992880b36662" />
</details>

### Easier to understand benchmark report
- Median/min/max measurements and compact gray ranges (like [hyperfine](https://github.com/sharkdp/hyperfine)).
- Five-column report with median delta and run counts.

No regressions found:

<img width="796" height="274" alt="Screenshot 2026-08-06 at 13 31 01" src="https://github.com/user-attachments/assets/adefa11a-4cbc-4067-add3-b04ee609c0f7" />

Some faster/slower, but no regressions:

<img width="803" height="495" alt="Screenshot 2026-08-06 at 13 31 45" src="https://github.com/user-attachments/assets/bb1c1e96-92d7-4f23-b8b2-0f521eda5ab1" />

Since benchmarks use fewer samples (CI time for TPC-DS went from 8min to 4 min), we can increase TPC-DS sf3 to sf10, like TPC-H. With lower scale factor, some query are very fast (`q32` takes `3ms`?!) and those make the bench report too noisy (see previous screenshot).

### Samples
- Alternating `base → PR`, then `PR → base` batches.
- Added `--samples` for local usage (rounded up to five samples).
- Added median-based `--early-stop`: reduce CI runtime if median is in noise range (±2%). 
  - Enabled `--early-stop` in Regression workflow jobs.

### What is a failing regression?
- Individual query regressions at `≥10%` emit CI warnings but do not fail CI.
- CI fails when geomean increases by `≥10%` or `≥50ms`. Same as what CI currently checks.
- `--nofail` suppresses only the geomean gate.