### PR TITLE
Propagate Parquet expression reader statistics

### DIFF
--- a/extension/parquet/include/reader/expression_column_reader.hpp
+++ b/extension/parquet/include/reader/expression_column_reader.hpp
@@ -42,9 +42,9 @@ public:
 	static constexpr const PhysicalType TYPE = PhysicalType::INVALID;
 
 public:
-	ExpressionColumnReader(ClientContext &context, vector<unique_ptr<ColumnReader>> child_readers,
+	ExpressionColumnReader(ClientContext &context_p, vector<unique_ptr<ColumnReader>> child_readers,
 	                       unique_ptr<Expression> expr, const ParquetColumnSchema &schema);
-	ExpressionColumnReader(ClientContext &context, vector<unique_ptr<ColumnReader>> child_readers,
+	ExpressionColumnReader(ClientContext &context_p, vector<unique_ptr<ColumnReader>> child_readers,
 	                       unique_ptr<Expression> expr, unique_ptr<ParquetColumnSchema> owned_schema);
 
 	//! Reader(s) to produce the input(s) for the expression
@@ -61,6 +61,7 @@ public:
 	                    TProtocol &protocol_p) override;
 
 	idx_t Read(ColumnReaderInput &input, Vector &result) override;
+	unique_ptr<BaseStatistics> Stats(idx_t row_group_idx_p, const vector<ColumnChunk> &columns) override;
 
 	void Select(ColumnReaderInput &input, Vector &result, const SelectionVector &sel,
 	            idx_t approved_tuple_count) override;
@@ -87,6 +88,7 @@ public:
 	}
 
 private:
+	ClientContext &context;
 	void InitializeChunk();
 };
 

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1677,13 +1677,10 @@ void ParquetReader::PrepareRowGroupBuffer(ClientContext &context, ParquetReaderS
 					has_min_max = group.columns[schema_column_index].meta_data.statistics.__isset.min_value &&
 					              group.columns[schema_column_index].meta_data.statistics.__isset.max_value;
 				}
-				if (is_expression) {
-					// no pruning possible for expressions
-					prune_result = FilterPropagateResult::NO_PRUNING_POSSIBLE;
-				} else if (!is_generated_column && has_min_max &&
-				           (column_reader.Type().id() == LogicalTypeId::FLOAT ||
-				            column_reader.Type().id() == LogicalTypeId::DOUBLE) &&
-				           parquet_options.can_have_nan) {
+				if (!is_expression && !is_generated_column && has_min_max &&
+				    (column_reader.Type().id() == LogicalTypeId::FLOAT ||
+				     column_reader.Type().id() == LogicalTypeId::DOUBLE) &&
+				    parquet_options.can_have_nan) {
 					// floating point columns can have NaN values in addition to the min/max bounds defined in the file
 					// in order to do optimal pruning - we prune based on the [min, max] of the file followed by pruning
 					// based on nan

--- a/extension/parquet/reader/expression_column_reader.cpp
+++ b/extension/parquet/reader/expression_column_reader.cpp
@@ -5,6 +5,7 @@
 #include "parquet_reader.hpp"
 #include "duckdb/common/types/vector.hpp"
 #include "duckdb/common/vector/flat_vector.hpp"
+#include "duckdb/planner/filter/expression_filter.hpp"
 
 namespace duckdb_apache {
 namespace thrift {
@@ -23,10 +24,11 @@ class ClientContext;
 //===--------------------------------------------------------------------===//
 // Expression Column Reader
 //===--------------------------------------------------------------------===//
-ExpressionColumnReader::ExpressionColumnReader(ClientContext &context, vector<unique_ptr<ColumnReader>> child_readers_p,
+ExpressionColumnReader::ExpressionColumnReader(ClientContext &context_p,
+                                               vector<unique_ptr<ColumnReader>> child_readers_p,
                                                unique_ptr<Expression> expr_p, const ParquetColumnSchema &schema_p)
     : ColumnReader(child_readers_p[0]->Reader(), schema_p), child_readers(std::move(child_readers_p)),
-      expr(std::move(expr_p)), executor(context, expr.get()) {
+      expr(std::move(expr_p)), executor(context_p, expr.get()), context(context_p) {
 	if (child_readers.empty()) {
 		throw InternalException("Can't instantiate an ExpressionColumnReader with 0 children");
 	}
@@ -38,11 +40,13 @@ ExpressionColumnReader::ExpressionColumnReader(ClientContext &context, vector<un
 	InitializeChunk();
 }
 
-ExpressionColumnReader::ExpressionColumnReader(ClientContext &context, vector<unique_ptr<ColumnReader>> child_readers_p,
+ExpressionColumnReader::ExpressionColumnReader(ClientContext &context_p,
+                                               vector<unique_ptr<ColumnReader>> child_readers_p,
                                                unique_ptr<Expression> expr_p,
                                                unique_ptr<ParquetColumnSchema> owned_schema_p)
     : ColumnReader(child_readers_p[0]->Reader(), *owned_schema_p), child_readers(std::move(child_readers_p)),
-      expr(std::move(expr_p)), executor(context, expr.get()), owned_schema(std::move(owned_schema_p)) {
+      expr(std::move(expr_p)), executor(context_p, expr.get()), owned_schema(std::move(owned_schema_p)),
+      context(context_p) {
 	if (child_readers.empty()) {
 		throw InternalException("Can't instantiate an ExpressionColumnReader with 0 children");
 	}
@@ -67,6 +71,23 @@ void ExpressionColumnReader::InitializeRead(idx_t row_group_idx_p, idx_t row_gro
 	for (auto &child_reader : child_readers) {
 		child_reader->InitializeRead(row_group_idx_p, row_group_num_rows, columns, protocol_p);
 	}
+}
+
+unique_ptr<BaseStatistics> ExpressionColumnReader::Stats(idx_t row_group_idx_p, const vector<ColumnChunk> &columns) {
+	if (Schema().schema_type != ParquetColumnSchemaType::EXPRESSION) {
+		return ColumnReader::Stats(row_group_idx_p, columns);
+	}
+	vector<BaseStatistics> input_stats;
+	input_stats.reserve(child_readers.size());
+	for (auto &child_reader : child_readers) {
+		auto child_stats = child_reader->Stats(row_group_idx_p, columns);
+		if (!child_stats) {
+			return nullptr;
+		}
+		input_stats.push_back(child_stats->Copy());
+	}
+	return ExpressionFilter::TryGetExpressionStatistics(
+	    context, *expr, array_ptr<const BaseStatistics>(input_stats.data(), input_stats.size()));
 }
 
 static void ReverseSelectionVector(const SelectionVector &input, SelectionVector &output, idx_t input_count,

--- a/src/include/duckdb/planner/filter/expression_filter.hpp
+++ b/src/include/duckdb/planner/filter/expression_filter.hpp
@@ -8,11 +8,12 @@
 
 #pragma once
 
-#include "duckdb/planner/table_filter.hpp"
+#include "duckdb/common/array_ptr.hpp"
 #include "duckdb/planner/expression.hpp"
 #include "duckdb/planner/expression/bound_comparison_expression.hpp"
-#include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression/bound_conjunction_expression.hpp"
+#include "duckdb/planner/expression/bound_constant_expression.hpp"
+#include "duckdb/planner/table_filter.hpp"
 
 namespace duckdb {
 class ExpressionExecutor;
@@ -51,6 +52,9 @@ public:
 	static FilterPropagateResult CheckExpressionStatistics(const Expression &expr, const BaseStatistics &stats);
 	static FilterPropagateResult CheckExpressionStatistics(optional_ptr<ClientContext> context_p,
 	                                                       const Expression &expr, const BaseStatistics &stats);
+	//! Derive statistics for an expression over one or more input columns
+	static unique_ptr<BaseStatistics> TryGetExpressionStatistics(ClientContext &context, const Expression &expr,
+	                                                             array_ptr<const BaseStatistics> input_stats);
 	//! Check if an expression tree contains an internal function with the given name
 	static bool ContainsInternalFunction(const Expression &expr, const string &func_name);
 	//! Check if an expression tree is entirely optional filter semantics

--- a/src/planner/filter/expression_filter.cpp
+++ b/src/planner/filter/expression_filter.cpp
@@ -201,12 +201,18 @@ static FilterPropagateResult CheckZonemapAgainstConstants(const BaseStatistics &
 	}
 }
 
-static optional_ptr<const BaseStatistics> TryGetFilterStats(optional_ptr<ClientContext> context_p,
-                                                            const Expression &expr, const BaseStatistics &stats,
-                                                            vector<unique_ptr<BaseStatistics>> &owned_stats) {
+static optional_ptr<const BaseStatistics> TryGetExpressionStats(optional_ptr<ClientContext> context_p,
+                                                                const Expression &expr,
+                                                                array_ptr<const BaseStatistics> input_stats,
+                                                                vector<unique_ptr<BaseStatistics>> &owned_stats) {
 	switch (expr.GetExpressionClass()) {
-	case ExpressionClass::BOUND_REF:
-		return &stats;
+	case ExpressionClass::BOUND_REF: {
+		auto index = expr.Cast<BoundReferenceExpression>().Index();
+		if (index >= input_stats.size()) {
+			return nullptr;
+		}
+		return &input_stats[index];
+	}
 	case ExpressionClass::BOUND_CONSTANT: {
 		auto &constant = expr.Cast<BoundConstantExpression>().GetValue();
 		owned_stats.push_back(BaseStatistics::FromConstant(constant).ToUnique());
@@ -217,7 +223,7 @@ static optional_ptr<const BaseStatistics> TryGetFilterStats(optional_ptr<ClientC
 
 		if (BoundCastExpression::IsCast(func)) {
 			auto &cast_child = BoundCastExpression::Child(func);
-			auto child_stats = TryGetFilterStats(context_p, cast_child, stats, owned_stats);
+			auto child_stats = TryGetExpressionStats(context_p, cast_child, input_stats, owned_stats);
 			if (!child_stats) {
 				return nullptr;
 			}
@@ -237,7 +243,7 @@ static optional_ptr<const BaseStatistics> TryGetFilterStats(optional_ptr<ClientC
 			// Since statistics callback need context, so this path is the fallback
 			idx_t child_idx;
 			if (TryGetStructExtractChildIndex(func, child_idx) && !func.GetChildren().empty()) {
-				auto child_stats = TryGetFilterStats(context_p, *func.GetChildren()[0], stats, owned_stats);
+				auto child_stats = TryGetExpressionStats(context_p, *func.GetChildren()[0], input_stats, owned_stats);
 				if (!child_stats || child_stats->GetType().id() != LogicalTypeId::STRUCT) {
 					return nullptr;
 				}
@@ -251,7 +257,7 @@ static optional_ptr<const BaseStatistics> TryGetFilterStats(optional_ptr<ClientC
 			vector<BaseStatistics> child_stats;
 			child_stats.reserve(func.GetChildren().size());
 			for (auto &child_expr : func.GetChildren()) {
-				auto child_stat = TryGetFilterStats(context_p, *child_expr, stats, owned_stats);
+				auto child_stat = TryGetExpressionStats(context_p, *child_expr, input_stats, owned_stats);
 				if (!child_stat) {
 					return nullptr;
 				}
@@ -273,7 +279,7 @@ static optional_ptr<const BaseStatistics> TryGetFilterStats(optional_ptr<ClientC
 			vector<BaseStatistics> child_stats;
 			child_stats.reserve(func.GetChildren().size());
 			for (auto &child_expr : func.GetChildren()) {
-				auto child_stat = TryGetFilterStats(context_p, *child_expr, stats, owned_stats);
+				auto child_stat = TryGetExpressionStats(context_p, *child_expr, input_stats, owned_stats);
 				child_stats.push_back(child_stat ? child_stat->Copy()
 				                                 : BaseStatistics::CreateUnknown(child_expr->GetReturnType()));
 			}
@@ -289,6 +295,19 @@ static optional_ptr<const BaseStatistics> TryGetFilterStats(optional_ptr<ClientC
 	default:
 		return nullptr;
 	}
+}
+
+static optional_ptr<const BaseStatistics> TryGetFilterStats(optional_ptr<ClientContext> context_p,
+                                                            const Expression &expr, const BaseStatistics &stats,
+                                                            vector<unique_ptr<BaseStatistics>> &owned_stats) {
+	return TryGetExpressionStats(context_p, expr, array_ptr<const BaseStatistics>(stats), owned_stats);
+}
+
+unique_ptr<BaseStatistics> ExpressionFilter::TryGetExpressionStatistics(ClientContext &context, const Expression &expr,
+                                                                        array_ptr<const BaseStatistics> input_stats) {
+	vector<unique_ptr<BaseStatistics>> owned_stats;
+	auto result = TryGetExpressionStats(&context, expr, input_stats, owned_stats);
+	return result ? result->ToUnique() : nullptr;
 }
 
 static bool TryGetVariantComparisonStatsType(const LogicalType &typed_type, const LogicalType &constant_type,

--- a/test/sql/copy/parquet/variant_array_row_group_pruning.test
+++ b/test/sql/copy/parquet/variant_array_row_group_pruning.test
@@ -1,0 +1,25 @@
+# name: test/sql/copy/parquet/variant_array_row_group_pruning.test
+# description: Test row-group pruning for VARIANT array element filters
+# group: [parquet]
+
+require parquet
+
+statement ok
+COPY (
+	SELECT [i::INTEGER]::VARIANT AS v
+	FROM range(8192) t(i)
+) TO '{TEST_DIR}/variant_array_row_group_pruning.parquet' (ROW_GROUP_SIZE 2048)
+
+query I
+SELECT count(*)
+FROM '{TEST_DIR}/variant_array_row_group_pruning.parquet'
+WHERE v[1]::INTEGER BETWEEN 4096 AND 4100
+----
+5
+
+query II
+EXPLAIN ANALYZE SELECT count(*)
+FROM '{TEST_DIR}/variant_array_row_group_pruning.parquet'
+WHERE v[1]::INTEGER BETWEEN 4096 AND 4100
+----
+analyzed_plan	<REGEX>:(?s).*Row Groups Scanned: 1 / 4.*


### PR DESCRIPTION
## Summary

Resolves #24339

Parquet expression readers can materialize derived values, but previously did not expose statistics, so filters on derived columns such as VARIANT array elements had to scan every row group even when statistics for the underlying columns were available. This change collects statistics from the child readers and uses DuckDB's existing cast, function, and monotonicity propagation to derive statistics for the expression output.

## Results

```sql
COPY (
    SELECT [i::INTEGER]::VARIANT AS v
    FROM range(8192) t(i)
) TO '/tmp/variant_array_rg.parquet' (ROW_GROUP_SIZE 2048);

EXPLAIN ANALYZE SELECT count(*)
FROM '/tmp/variant_array_rg.parquet'
WHERE v[1]::INTEGER BETWEEN 4096 AND 4100;
```

### Before

```sql
╭─ Ungrouped Aggregate ────────────────────────────╮
│ Aggregates: count_star()                         │
│ 1 row                                        0µs │
╰─────────────────────────┒┎───────────────────────╯
╭─ Table Scan ────────────┚┖───────────────────────╮
│ Function: PARQUET_SCAN                           │
│ Filters:                                         │
│ CAST(variant_extract(v, 1) AS INTEGER) BETWEEN   │
│ 4096 AND 4100                                    │
│ Total Files Read: 1                              │
│ Filename(s):                                     │
│ /tmp/variant_array_rg.parquet                    │
│ Row Groups Scanned: 4 / 4                        │
│ 5 rows                                       0µs │
╰──────────────────────────────────────────────────╯
```

### After

```sql
╭─ Ungrouped Aggregate ────────────────────────────╮
│ Aggregates: count_star()                         │
│ 1 row                                        0µs │
╰─────────────────────────┒┎───────────────────────╯
╭─ Table Scan ────────────┚┖───────────────────────╮
│ Function: PARQUET_SCAN                           │
│ Filters:                                         │
│ CAST(variant_extract(v, 1) AS INTEGER) BETWEEN   │
│ 4096 AND 4100                                    │
│ Total Files Read: 1                              │
│ Filename(s):                                     │
│ /tmp/variant_array_rg.parquet                    │
│ Row Groups Scanned: 1 / 4                        │
│ 5 rows                                       0µs │
╰──────────────────────────────────────────────────╯
```
