### PR TITLE
Use configured filename column in multi-file filter pushdown

### DIFF
--- a/src/common/hive_partitioning.cpp
+++ b/src/common/hive_partitioning.cpp
@@ -28,7 +28,7 @@ GetKnownColumnValues(const string &filename, const HivePartitioningFilterInfo &f
 
 	auto &column_map = filter_info.column_map;
 	if (filter_info.filename_enabled) {
-		auto lookup_column_id = column_map.find("filename");
+		auto lookup_column_id = column_map.find(filter_info.filename_column);
 		if (lookup_column_id != column_map.end()) {
 			result.insert(make_pair(lookup_column_id->second, PartitioningColumnValue(filename)));
 		}

--- a/src/common/multi_file/multi_file_list.cpp
+++ b/src/common/multi_file/multi_file_list.cpp
@@ -42,6 +42,7 @@ bool PushdownInternal(ClientContext &context, const MultiFileOptions &options, M
 	}
 	filter_info.hive_enabled = options.hive_partitioning;
 	filter_info.filename_enabled = options.filename;
+	filter_info.filename_column = options.filename_column;
 
 	auto start_files = expanded_files.size();
 	HivePartitioning::ApplyFiltersToFileList(context, expanded_files, filters, filter_info, info);

--- a/src/include/duckdb/common/hive_partitioning.hpp
+++ b/src/include/duckdb/common/hive_partitioning.hpp
@@ -19,6 +19,7 @@ struct MultiFilePushdownInfo;
 
 struct HivePartitioningFilterInfo {
 	unordered_map<string, column_t> column_map;
+	string filename_column;
 	bool hive_enabled;
 	bool filename_enabled;
 };

--- a/test/issues/general/test_24204.test
+++ b/test/issues/general/test_24204.test
@@ -1,0 +1,90 @@
+# name: test/issues/general/test_24204.test
+# description: Test filters on a physical filename column when the virtual filename column is renamed
+# group: [general]
+
+require parquet
+
+statement ok
+COPY (
+	SELECT 'foo' AS name, 42 AS number, '/physical/thing1' AS filename
+) TO '{TEST_DIR}/issue_24204_parquet_1.parquet';
+
+statement ok
+COPY (
+	SELECT 'bar' AS name, 101 AS number, '/physical/thing2' AS filename
+) TO '{TEST_DIR}/issue_24204_parquet_2.parquet';
+
+statement ok
+CREATE VIEW issue_24204_parquet AS
+SELECT *
+FROM read_parquet(
+	'{TEST_DIR}/issue_24204_parquet_*.parquet',
+	filename = 'source_file'
+);
+
+query I
+SELECT name
+FROM issue_24204_parquet
+WHERE filename = '/physical/thing1';
+----
+foo
+
+query I
+SELECT name
+FROM issue_24204_parquet
+WHERE source_file = '{TEST_DIR}/issue_24204_parquet_1.parquet';
+----
+foo
+
+query II
+EXPLAIN SELECT name
+FROM issue_24204_parquet
+WHERE filename = '/physical/thing1';
+----
+physical_plan	<!REGEX>:.*File Filters:.*
+
+query II
+EXPLAIN SELECT name
+FROM issue_24204_parquet
+WHERE source_file = '{TEST_DIR}/issue_24204_parquet_1.parquet';
+----
+physical_plan	<REGEX>:.*File Filters:.*source_file.*Scanning Files:.*1/2.*
+
+statement ok
+CREATE TABLE issue_24204_table AS
+SELECT name
+FROM read_parquet(
+	'{TEST_DIR}/issue_24204_parquet_*.parquet',
+	filename = 'source_file'
+)
+WHERE filename = '/physical/thing1';
+
+query I
+SELECT count(*) FROM issue_24204_table;
+----
+1
+
+statement ok
+COPY (
+	SELECT 'foo' AS name, '/physical/thing1' AS filename
+) TO '{TEST_DIR}/issue_24204_csv_1.csv' (HEADER);
+
+statement ok
+COPY (
+	SELECT 'bar' AS name, '/physical/thing2' AS filename
+) TO '{TEST_DIR}/issue_24204_csv_2.csv' (HEADER);
+
+statement ok
+CREATE VIEW issue_24204_csv AS
+SELECT *
+FROM read_csv_auto(
+	'{TEST_DIR}/issue_24204_csv_*.csv',
+	filename = 'source_file'
+);
+
+query I
+SELECT name
+FROM issue_24204_csv
+WHERE filename = '/physical/thing1';
+----
+foo


### PR DESCRIPTION
Fixes #24204.

When `read_parquet(..., filename = 'source_file')` reads files that contain a physical column named `filename`, complex file filter pushdown still looks up the hard-coded column name `"filename"`.

As a result, predicates on the physical `filename` column can be evaluated against the file path instead of the Parquet column, silently returning incorrect results. Predicates on the renamed generated filename column also fail to prune the file list correctly.

**Fix**

Pass the configured `MultiFileOptions::filename_column` through `HivePartitioningFilterInfo` and use it when resolving the known filename value during complex filter pushdown.

This ensures that:

- predicates on the physical `filename` column return the correct results.
- predicates on the renamed generated filename column correctly prune the file list.

**Testing**

Added regression coverage for both Parquet and CSV, since the affected filter pushdown logic is shared by the MultiFile implementation. The tests verify query correctness, filter pushdown, file pruning, and materialized results when the generated filename column is renamed.