### PR TITLE
Fix projected types for missing columns

### DIFF
--- a/src/common/multi_file/multi_file_reader.cpp
+++ b/src/common/multi_file/multi_file_reader.cpp
@@ -382,7 +382,8 @@ void MultiFileReader::FinalizeBind(MultiFileReaderData &reader_data, const Multi
 			if (not_present_in_file) {
 				// we need to project a column with name \"global_name\" - but it does not exist in the current file
 				// push a NULL value of the specified type
-				reader_data.constant_map.Add(global_idx, Value(type));
+				auto &constant_type = col_id.HasType() ? col_id.GetScanType() : type;
+				reader_data.constant_map.Add(global_idx, Value(constant_type));
 				continue;
 			}
 		}

--- a/test/sql/copy/parquet/union_by_name_struct_projection.test
+++ b/test/sql/copy/parquet/union_by_name_struct_projection.test
@@ -1,0 +1,37 @@
+# name: test/sql/copy/parquet/union_by_name_struct_projection.test
+# description: Test projecting a struct field missing from a unioned Parquet file
+# group: [parquet]
+
+require parquet
+
+statement ok
+COPY (SELECT {'a': 1, 'b': 2}::STRUCT(a INT, b INT) AS s, 1 AS id)
+TO '{TEST_DIR}/struct.parquet' (FORMAT PARQUET);
+
+statement ok
+COPY (SELECT 2 AS id)
+TO '{TEST_DIR}/no_struct.parquet' (FORMAT PARQUET);
+
+query II
+SELECT id, s.a
+FROM read_parquet(['{TEST_DIR}/struct.parquet', '{TEST_DIR}/no_struct.parquet'], union_by_name = true)
+ORDER BY id;
+----
+1	1
+2	NULL
+
+query I
+SELECT id
+FROM read_parquet(['{TEST_DIR}/struct.parquet', '{TEST_DIR}/no_struct.parquet'], union_by_name = true)
+WHERE s.a IS NULL
+ORDER BY id;
+----
+2
+
+query I
+SELECT id
+FROM read_parquet(['{TEST_DIR}/struct.parquet', '{TEST_DIR}/no_struct.parquet'], union_by_name = true)
+WHERE s.a = 1
+ORDER BY id;
+----
+1


### PR DESCRIPTION
## Summary

Resolves #24253

When `union_by_name` fills a column missing from an input file, it creates a NULL value for that column. Nested projection pushdown can make the scan output a child type instead of the full global column type, which previously caused a type mismatch and an INTERNAL error. This change uses the projected scan type for the generated NULL when available, ensuring it matches the scan output.
