### PR TITLE
Fix dedimal width overflow

### DIFF
--- a/extension/parquet/reader/variant/parquet_variant_iterator.cpp
+++ b/extension/parquet/reader/variant/parquet_variant_iterator.cpp
@@ -234,9 +234,13 @@ uint32_t ComputeDecimalWidth(T value) {
 	if (value == 0) {
 		return 1;
 	}
-	auto abs_val = value;
-	if (abs_val < 0) {
-		abs_val = -abs_val;
+	// |min| might not fit in signed T; use unsigned wrap.
+	using unsigned_t = std::make_unsigned_t<T>;
+	unsigned_t abs_val = 0;
+	if (value < 0) {
+		abs_val = static_cast<unsigned_t>(0) - static_cast<unsigned_t>(value);
+	} else {
+		abs_val = static_cast<unsigned_t>(value);
 	}
 	return static_cast<uint32_t>(floor(log10(static_cast<double>(abs_val))) + 1);
 }

--- a/test/parquet/variant/variant_bytes_to_variant.test
+++ b/test/parquet/variant/variant_bytes_to_variant.test
@@ -102,3 +102,18 @@ query I
 select variant_bytes_to_variant(NULL::BLOB);
 ----
 NULL
+
+# ---------- DECIMAL min signed values (INT32_MIN / INT64_MIN) ----------
+# Metadata: version=1, empty dictionary. Value: DECIMAL4/8, scale=0, little-endian min int.
+
+query II
+SELECT variant_typeof(v), v
+FROM (SELECT variant_bytes_to_variant('\x01\x00\x00\x20\x00\x00\x00\x00\x80'::BLOB) AS v);
+----
+DECIMAL(10, 0)	-2147483648
+
+query II
+SELECT variant_typeof(v), v
+FROM (SELECT variant_bytes_to_variant('\x01\x00\x00\x24\x00\x00\x00\x00\x00\x00\x00\x00\x80'::BLOB) AS v);
+----
+DECIMAL(19, 0)	-9223372036854775808


### PR DESCRIPTION
Closes https://github.com/duckdb/duckdb/issues/24460

Error message points out the location, obviously we could suffer overflow for the minimal possible value for a signed type.
```sql
memory D SELECT variant_bytes_to_variant('\x01\x00\x00\x20\x00\x00\x00\x00\x80'::BLOB);
/Users/haojiang/Desktop/duckdb/build/debug/extension/parquet/reader/variant/../../../../../../extension/parquet/reader/variant/parquet_variant_iterator.cpp:239:13: runtime error: negation of -2147483648 cannot be represented in type 'int'; cast to an unsigned type to negate this value to itself
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /Users/haojiang/Desktop/duckdb/build/debug/extension/parquet/reader/variant/../../../../../../extension/parquet/reader/variant/parquet_variant_iterator.cpp:239:13 
zsh: abort      ./build/debug/duckdb
```