### PR TITLE
Split linux test configs in more CI jobs

### DIFF
--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -1308,12 +1308,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - group: Verification
-            target: test_configs_verification
-          - group: Storage
-            target: test_configs_storage
+          - group: Query Verification
+            target: test_configs_query_verification
           - group: Execution
             target: test_configs_execution
+          - group: Persistence
+            target: test_configs_persistence
+          - group: Storage Engine
+            target: test_configs_storage_engine
 
     steps:
     - name: "Checkout"
@@ -1347,7 +1349,7 @@ jobs:
         make ${{ matrix.target }}
 
     - name: Test Storage Compatibility
-      if: ${{ (success() || failure()) && matrix.group == 'Storage' }}
+      if: ${{ (success() || failure()) && matrix.group == 'Persistence' }}
       run: |
         make test_storage
 

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -1298,12 +1298,22 @@ jobs:
  # TODO: Consider bringing back fts
  # TODO: DEBUG_STACKTRACE: 1 + reldebug ?
  linux-configs:
-    name: Tests a release build with different configurations
+    name: Linux Config (${{ matrix.group }})
     if: ${{ contains(fromJson(needs.prepare.outputs.enabled_jobs), 'linux-configs') }}
     runs-on: ${{ needs.prepare.outputs.runner_linux_x64 }}
     needs:
       - prepare
       - linux-release
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - group: Verification
+            target: test_configs_verification
+          - group: Storage
+            target: test_configs_storage
+          - group: Execution
+            target: test_configs_execution
 
     steps:
     - name: "Checkout"
@@ -1334,22 +1344,22 @@ jobs:
     - name: Test Configurations
       if: success() || failure()
       run: |
-        make test_configs
+        make ${{ matrix.target }}
+
+    - name: Test Storage Compatibility
+      if: ${{ (success() || failure()) && matrix.group == 'Storage' }}
+      run: |
+        make test_storage
 
     - name: Test Vector Verification
-      if: success() || failure()
+      if: ${{ (success() || failure()) && matrix.group == 'Execution' }}
       run: |
         make test_vector
 
     - name: Test Synchronous Table Scan
-      if: success() || failure()
+      if: ${{ (success() || failure()) && matrix.group == 'Execution' }}
       run: |
         make test_table_scan
-
-    - name: Test Storage Compatibility
-      if: success() || failure()
-      run: |
-        make test_storage
 
  summary:
     name: Summary

--- a/Makefile
+++ b/Makefile
@@ -517,31 +517,41 @@ endif
 unittest_release:
 	build/release/test/run $(T)
 
-TEST_CONFIGS := \
+TEST_CONFIGS_VERIFICATION := \
 	test/configs/verify_statement_copy.json \
 	test/configs/verify_statement_to_string.json \
 	test/configs/verify_statement_explain.json \
 	test/configs/verify_statement_prepare.json \
 	test/configs/verify_serializer.json \
-	test/configs/verify_compression.json \
 	test/configs/verify_stats.json \
 	test/configs/verify_statement_serialization.json \
+	test/configs/disable_optimizer.json \
+	test/configs/internal_vector_serialization.json \
+	test/configs/internal_vector_verification.json \
+	test/configs/verify_fetch_row.json \
+	test/configs/disable_caching_operators.json \
+	test/configs/verification_projection.json \
+	test/configs/verify_column_bindings.json \
+	test/configs/verify_aggregate_state_export.json \
+	test/configs/verify_functions.json \
+	test/configs/transformer_trampoline_style.json
+
+TEST_CONFIGS_STORAGE := \
 	test/configs/force_storage.json \
 	test/configs/force_storage_restart.json \
 	test/configs/latest_storage.json \
 	test/configs/block_verification.json \
 	test/configs/block_verification_latest.json \
-	test/configs/disable_optimizer.json \
-	test/configs/internal_vector_serialization.json \
-	test/configs/internal_vector_verification.json \
-	test/configs/force_external.json \
-	test/configs/verify_fetch_row.json \
-	test/configs/disable_caching_operators.json \
 	test/configs/wal_verification.json \
 	test/configs/vacuum_rebuild_indexes_force_storage.json \
-	test/configs/verification_projection.json \
-	test/configs/verify_column_bindings.json \
 	test/configs/no_local_filesystem.json \
+	test/configs/v1_storage.json \
+	test/configs/v1_storage_block_size_16kB.json \
+	test/configs/force_storage_mmap.json
+
+TEST_CONFIGS_EXECUTION := \
+	test/configs/verify_compression.json \
+	test/configs/force_external.json \
 	test/configs/block_size_16kB.json \
 	test/configs/latest_storage_block_size_16kB.json \
 	test/configs/block_allocator_100mib.json \
@@ -549,16 +559,23 @@ TEST_CONFIGS := \
 	test/configs/compressed_in_memory.json \
 	test/configs/prefetch_all_storage.json \
 	test/configs/encryption.json \
-	test/configs/v1_storage.json \
-	test/configs/v1_storage_block_size_16kB.json \
-	test/configs/force_storage_mmap.json \
-	test/configs/verify_aggregate_state_export.json \
-	test/configs/verify_functions.json \
-	test/configs/shredded_vector.json \
-	test/configs/transformer_trampoline_style.json
+	test/configs/shredded_vector.json
+
+TEST_CONFIGS := $(TEST_CONFIGS_VERIFICATION) $(TEST_CONFIGS_STORAGE) $(TEST_CONFIGS_EXECUTION)
+
+.PHONY: test_configs test_configs_verification test_configs_storage test_configs_execution
 
 test_configs:
 	./build/release/test/run $(foreach cfg,$(TEST_CONFIGS),--test-config=$(cfg))
+
+test_configs_verification:
+	./build/release/test/run $(foreach cfg,$(TEST_CONFIGS_VERIFICATION),--test-config=$(cfg))
+
+test_configs_storage:
+	./build/release/test/run $(foreach cfg,$(TEST_CONFIGS_STORAGE),--test-config=$(cfg))
+
+test_configs_execution:
+	./build/release/test/run $(foreach cfg,$(TEST_CONFIGS_EXECUTION),--test-config=$(cfg))
 
 test_vector:
 	./build/release/test/run --test-flags="--verify-vector dictionary_expression --skip-compiled"

--- a/Makefile
+++ b/Makefile
@@ -517,7 +517,7 @@ endif
 unittest_release:
 	build/release/test/run $(T)
 
-TEST_CONFIGS_VERIFICATION := \
+TEST_CONFIGS_QUERY_VERIFICATION := \
 	test/configs/verify_statement_copy.json \
 	test/configs/verify_statement_to_string.json \
 	test/configs/verify_statement_explain.json \
@@ -526,56 +526,63 @@ TEST_CONFIGS_VERIFICATION := \
 	test/configs/verify_stats.json \
 	test/configs/verify_statement_serialization.json \
 	test/configs/disable_optimizer.json \
-	test/configs/internal_vector_serialization.json \
-	test/configs/internal_vector_verification.json \
-	test/configs/verify_fetch_row.json \
-	test/configs/disable_caching_operators.json \
 	test/configs/verification_projection.json \
 	test/configs/verify_column_bindings.json \
-	test/configs/verify_aggregate_state_export.json \
-	test/configs/verify_functions.json \
 	test/configs/transformer_trampoline_style.json
 
-TEST_CONFIGS_STORAGE := \
+TEST_CONFIGS_EXECUTION := \
+	test/configs/internal_vector_serialization.json \
+	test/configs/internal_vector_verification.json \
+	test/configs/force_external.json \
+	test/configs/verify_fetch_row.json \
+	test/configs/disable_caching_operators.json \
+	test/configs/variant_vector.json \
+	test/configs/verify_aggregate_state_export.json \
+	test/configs/verify_functions.json \
+	test/configs/shredded_vector.json
+
+TEST_CONFIGS_PERSISTENCE := \
 	test/configs/force_storage.json \
 	test/configs/force_storage_restart.json \
 	test/configs/latest_storage.json \
-	test/configs/block_verification.json \
-	test/configs/block_verification_latest.json \
 	test/configs/wal_verification.json \
 	test/configs/vacuum_rebuild_indexes_force_storage.json \
 	test/configs/no_local_filesystem.json \
+	test/configs/encryption.json \
 	test/configs/v1_storage.json \
-	test/configs/v1_storage_block_size_16kB.json \
-	test/configs/force_storage_mmap.json
+	test/configs/v1_storage_block_size_16kB.json
 
-TEST_CONFIGS_EXECUTION := \
+TEST_CONFIGS_STORAGE_ENGINE := \
 	test/configs/verify_compression.json \
-	test/configs/force_external.json \
+	test/configs/block_verification.json \
+	test/configs/block_verification_latest.json \
 	test/configs/block_size_16kB.json \
 	test/configs/latest_storage_block_size_16kB.json \
 	test/configs/block_allocator_100mib.json \
-	test/configs/variant_vector.json \
 	test/configs/compressed_in_memory.json \
 	test/configs/prefetch_all_storage.json \
-	test/configs/encryption.json \
-	test/configs/shredded_vector.json
+	test/configs/force_storage_mmap.json
 
-TEST_CONFIGS := $(TEST_CONFIGS_VERIFICATION) $(TEST_CONFIGS_STORAGE) $(TEST_CONFIGS_EXECUTION)
+TEST_CONFIGS := $(TEST_CONFIGS_QUERY_VERIFICATION) $(TEST_CONFIGS_EXECUTION) $(TEST_CONFIGS_PERSISTENCE) \
+	$(TEST_CONFIGS_STORAGE_ENGINE)
 
-.PHONY: test_configs test_configs_verification test_configs_storage test_configs_execution
+.PHONY: test_configs test_configs_query_verification test_configs_execution test_configs_persistence \
+	test_configs_storage_engine
 
 test_configs:
 	./build/release/test/run $(foreach cfg,$(TEST_CONFIGS),--test-config=$(cfg))
 
-test_configs_verification:
-	./build/release/test/run $(foreach cfg,$(TEST_CONFIGS_VERIFICATION),--test-config=$(cfg))
-
-test_configs_storage:
-	./build/release/test/run $(foreach cfg,$(TEST_CONFIGS_STORAGE),--test-config=$(cfg))
+test_configs_query_verification:
+	./build/release/test/run $(foreach cfg,$(TEST_CONFIGS_QUERY_VERIFICATION),--test-config=$(cfg))
 
 test_configs_execution:
 	./build/release/test/run $(foreach cfg,$(TEST_CONFIGS_EXECUTION),--test-config=$(cfg))
+
+test_configs_persistence:
+	./build/release/test/run $(foreach cfg,$(TEST_CONFIGS_PERSISTENCE),--test-config=$(cfg))
+
+test_configs_storage_engine:
+	./build/release/test/run $(foreach cfg,$(TEST_CONFIGS_STORAGE_ENGINE),--test-config=$(cfg))
 
 test_vector:
 	./build/release/test/run --test-flags="--verify-vector dictionary_expression --skip-compiled"


### PR DESCRIPTION
### Context
Currently, we run all tests configs in one CI job taking 43 min(!).

I want to split the job so each job takes roughly ~10-15 minutes, and balance the number of "related test config groups" with their estimated CI compute time.
 
### Groups

- **Query Verification (9 min):** Statement transformations, parser trampoline, plan serialization, statistics, optimizer, projections, and column bindings.
- **Execution (14 min):** Vector verification, fetch-row, external execution, operator caching, aggregate/function verification, variant/shredded vectors, and table scans.
- **Persistence (12 min):** Persistent databases, restarts, WAL, vacuum, encryption, storage versions, filesystem restrictions, and compatibility testing.
- **Storage Engine (9 min):** Compression, block verification and sizes, allocator settings, mmap, prefetching, and compressed in-memory storage.

### Easily run the groups locally 
I added make targets so engineers/agents can run test config (groups) locally:
- `make test_configs`: run all test configs (locally).
- `make test_configs_query_verification`: run query verification test configs.
- `make test_configs_execution`: run (vector) execution test configs.
- `make test_configs_persistence`: run persistence test configs.
- `make test_configs_storage_engine`: run storage test configs.