### PR TITLE
Moved thread-local work outside the global lock in `PhysicalInsert::Combine`

### DIFF
--- a/src/execution/operator/persistent/physical_insert.cpp
+++ b/src/execution/operator/persistent/physical_insert.cpp
@@ -692,7 +692,13 @@ SinkCombineResultType PhysicalInsert::Combine(ExecutionContext &context, Operato
 	auto &collection = *optimistic_collection.collection;
 	collection.FinalizeAppend(tdata, lstate.local_append_state);
 
-	auto append_count = collection.GetTotalRows();
+	const auto append_count = collection.GetTotalRows();
+
+	if (append_count >= row_group_size) {
+		// flush thread-local optimistic data
+		lstate.optimistic_writer->WriteUnflushedRowGroups(optimistic_collection);
+		lstate.optimistic_writer->FinalFlush();
+	}
 
 	lock_guard<mutex> lock(gstate.lock);
 	gstate.insert_count += append_count;
@@ -707,8 +713,6 @@ SinkCombineResultType PhysicalInsert::Combine(ExecutionContext &context, Operato
 		storage.FinalizeLocalAppend(append_state);
 	} else {
 		// we have written rows to disk optimistically - merge directly into the transaction-local storage
-		lstate.optimistic_writer->WriteUnflushedRowGroups(optimistic_collection);
-		lstate.optimistic_writer->FinalFlush();
 		gstate.table.GetStorage().LocalMerge(context.client, optimistic_collection);
 		auto &optimistic_writer = gstate.table.GetStorage().GetOptimisticWriter(context.client);
 		optimistic_writer.Merge(*lstate.optimistic_writer);

--- a/test/sql/parallelism/intraquery/test_persistent_parallelism.test
+++ b/test/sql/parallelism/intraquery/test_persistent_parallelism.test
@@ -43,6 +43,14 @@ PRAGMA threads=4
 statement ok
 PRAGMA verify_parallelism
 
+statement ok
+CREATE TABLE large_integers AS SELECT * FROM range(1000000) tbl(i)
+
+query III
+SELECT COUNT(*), MIN(i), MAX(i) FROM large_integers
+----
+1000000	0	999999
+
 query II
 SELECT MIN(i), MAX(i) FROM integers
 ----


### PR DESCRIPTION
Resolves https://github.com/duckdblabs/duckdb-internal/issues/10165.

Previously `WriteUnflushedRowGroups` and `FinalFlush` were being executed under the global lock of `InsertGlobalState` during `PhysicalInsert::Combine`. These functions operate either over thread-local state or are concurrency safe themselves, so moving them outside of the global lock increases parallel performance.

### Results

Used source:
```sql
CREATE TABLE src AS
SELECT i, i % 512 k,
       ('a' || hash(i))::VARCHAR s1, ('b' || hash(i * 2))::VARCHAR s2,
       ('c' || hash(i * 3))::VARCHAR s3,
       (hash(i * 4) % 1000000)::DECIMAL(38, 5) d1,
       (hash(i * 5) % 1000000)::DECIMAL(38, 5) d2,
       (hash(i * 6) % 1000000)::DECIMAL(38, 5) d3
FROM range(8000000) t(i);
CREATE TABLE keys AS SELECT range k FROM range(512);
```

Measured query:
```sql
CREATE OR REPLACE TABLE o AS SELECT s.* FROM src s JOIN keys USING (k);
```

Based on `v1.5-variegata`, with the only difference the change in this PR. Total 10 repetitions per configuration:

| Threads | Before (median) | After (median) |
|---------|-----------------|----------------|
| 4       | 1.810s          | 1.480s         |
| 14      | 4.525s          | 1.010s         |