### PR TITLE
Fix escape strings being incorrectly tokenized

### DIFF
--- a/src/parser/peg/tokenizer/base_tokenizer.cpp
+++ b/src/parser/peg/tokenizer/base_tokenizer.cpp
@@ -236,6 +236,7 @@ void BaseTokenizer::TokenizeInput() {
 bool BaseTokenizer::TokenizeInputInternal() {
 	auto state = TokenizeState::STANDARD;
 	idx_t last_pos = 0;
+	bool escape_string = false;
 	string dollar_quote_marker;
 	idx_t dollar_marker_start = 0;
 	for (idx_t i = 0; i < sql.size(); i++) {
@@ -245,6 +246,7 @@ bool BaseTokenizer::TokenizeInputInternal() {
 			if (c == '\'') {
 				state = TokenizeState::STRING_LITERAL;
 				last_pos = i;
+				escape_string = false;
 				break;
 			}
 			if (c == '"') {
@@ -337,6 +339,9 @@ bool BaseTokenizer::TokenizeInputInternal() {
 				if (i + 1 < sql.size() && sql[i + 1] == '\'') {
 					state = TokenizeState::STRING_LITERAL;
 					last_pos = i;
+					if (c == 'E' || c == 'e') {
+						escape_string = true;
+					}
 					i++;
 					break;
 				}
@@ -436,6 +441,10 @@ bool BaseTokenizer::TokenizeInputInternal() {
 			}
 			break;
 		case TokenizeState::STRING_LITERAL:
+			if (escape_string && c == '\\' && i + 1 < sql.size()) {
+				i++;
+				break;
+			}
 			if (c == '\'') {
 				if (i + 1 < sql.size() && sql[i + 1] == '\'') {
 					// escaped - skip escape
@@ -443,6 +452,7 @@ bool BaseTokenizer::TokenizeInputInternal() {
 				} else {
 					PushToken(last_pos, i + 1, TokenType::STRING_LITERAL);
 					last_pos = i + 1;
+					escape_string = false;
 					state = TokenizeState::STANDARD;
 				}
 			}

--- a/test/sql/peg_parser/escape_string.test
+++ b/test/sql/peg_parser/escape_string.test
@@ -3,6 +3,31 @@
 # group: [peg_parser]
 
 query I
+SELECT E'it\'s a test' = 'it''s a test';
+----
+true
+
+query I
+SELECT e'it\'s a test' = 'it''s a test';
+----
+true
+
+query I
+SELECT E'a\'b\'c' = 'a''b''c';
+----
+true
+
+query I
+SELECT E'\\' = '\';
+----
+true
+
+query I
+SELECT E'\\\\' = '\\';
+----
+true
+
+query I
 SELECT e'\033' = chr(27);
 ----
 true
@@ -61,4 +86,3 @@ statement error
 SELECT e'\000';
 ----
 Parser Error: Null character not permitted in escape string literal
-


### PR DESCRIPTION
Part of: https://github.com/duckdblabs/duckdb-internal/issues/9093

The query: `SELECT E'it\'s a test';` was improperly tokenized and would result in untermined string literal. This was a regression compared to `v1.5.5.`. 

With E'...', backslash escapes should be respected while finding the end of the string token. In particular, \' should be treated as part of the literal, not as the closing quote. This is now something we track in the tokenizer. Regular string literals are not changed. 

```sql
./build/release/duckdb -c "SELECT E'it\'s a test';"
Parser Error:
unterminated string literal

LINE 1: SELECT E'it\'s a test';
                             ^
```

This is now corrected: 
```sql
./build/release/duckdb -c "SELECT E'it\'s a test';"
┌────────────────┐
│ 'it''s a test' │
│    varchar     │
├────────────────┤
│ it's a test    │
└────────────────┘
```