### PR TITLE
Prune row groups when an IN-list covers the whole zonemap rangend add

### DIFF
--- a/src/include/duckdb/storage/statistics/numeric_stats.hpp
+++ b/src/include/duckdb/storage/statistics/numeric_stats.hpp
@@ -73,6 +73,9 @@ struct NumericStats {
 	DUCKDB_API static FilterPropagateResult CheckZonemap(const BaseStatistics &stats, ExpressionType comparison_type,
 	                                                     array_ptr<const Value> constants);
 
+	//! Whether the constants cover every value in [min, max] - only meaningful for integral types
+	static bool ConstantsCoverRange(const BaseStatistics &stats, array_ptr<const Value> constants);
+
 	DUCKDB_API static void Merge(BaseStatistics &stats, const BaseStatistics &other_p);
 
 	DUCKDB_API static void Serialize(const BaseStatistics &stats, Serializer &serializer);

--- a/src/planner/filter/expression_filter.cpp
+++ b/src/planner/filter/expression_filter.cpp
@@ -553,23 +553,38 @@ static FilterPropagateResult CheckInOperatorStatistics(optional_ptr<ClientContex
 	if (!filter_stats->CanHaveNoNull()) {
 		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
 	}
-	auto result = CheckZonemapAgainstConstants(*filter_stats, ExpressionType::COMPARE_EQUAL,
-	                                           array_ptr<const Value>(values.data(), values.size()));
+	array_ptr<const Value> constants(values.data(), values.size());
+	auto result = CheckZonemapAgainstConstants(*filter_stats, ExpressionType::COMPARE_EQUAL, constants);
+	if (result == FilterPropagateResult::NO_PRUNING_POSSIBLE &&
+	    NumericStats::ConstantsCoverRange(*filter_stats, constants)) {
+		// an integral column whose whole [min, max] range is listed always matches
+		result = FilterPropagateResult::FILTER_ALWAYS_TRUE;
+	}
 	if (result == FilterPropagateResult::FILTER_ALWAYS_TRUE && filter_stats->CanHaveNull()) {
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 	}
 	return result;
 }
 
-static FilterPropagateResult CheckNotOperatorStatistics(const BoundOperatorExpression &op_expr) {
-	if (op_expr.GetChildren().size() != 1 ||
-	    op_expr.GetChildren()[0]->GetExpressionType() != ExpressionType::COMPARE_IN) {
+static FilterPropagateResult CheckNotOperatorStatistics(optional_ptr<ClientContext> context_p,
+                                                        const BoundOperatorExpression &op_expr,
+                                                        const BaseStatistics &stats) {
+	if (op_expr.GetChildren().size() != 1) {
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 	}
-	auto &children = op_expr.GetChildren()[0]->Cast<BoundOperatorExpression>().GetChildren();
-	if (children.size() == 2 && children[1]->GetExpressionType() == ExpressionType::VALUE_CONSTANT &&
-	    children[1]->Cast<BoundConstantExpression>().GetValue().IsNull()) {
-		return FilterPropagateResult::FILTER_FALSE_OR_NULL;
+	auto &child = *op_expr.GetChildren()[0];
+	if (child.GetExpressionType() == ExpressionType::COMPARE_IN) {
+		auto &children = child.Cast<BoundOperatorExpression>().GetChildren();
+		if (children.size() == 2 && children[1]->GetExpressionType() == ExpressionType::VALUE_CONSTANT &&
+		    children[1]->Cast<BoundConstantExpression>().GetValue().IsNull()) {
+			return FilterPropagateResult::FILTER_FALSE_OR_NULL;
+		}
+	}
+	// a child matching every row makes NOT match no row - the converse does not hold, since a child
+	// that matches no row may be NULL rather than false, and NOT NULL does not match either
+	if (ExpressionFilter::CheckExpressionStatistics(context_p, child, stats) ==
+	    FilterPropagateResult::FILTER_ALWAYS_TRUE) {
+		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
 	}
 	return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 }
@@ -584,7 +599,7 @@ static FilterPropagateResult CheckOperatorStatistics(optional_ptr<ClientContext>
 	case ExpressionType::COMPARE_IN:
 		return CheckInOperatorStatistics(context_p, op_expr, stats);
 	case ExpressionType::OPERATOR_NOT:
-		return CheckNotOperatorStatistics(op_expr);
+		return CheckNotOperatorStatistics(context_p, op_expr, stats);
 	default:
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 	}

--- a/src/storage/statistics/numeric_stats.cpp
+++ b/src/storage/statistics/numeric_stats.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/storage/statistics/numeric_stats.hpp"
 
 #include "duckdb/common/algorithm.hpp"
+#include "duckdb/common/numeric_utils.hpp"
 #include "duckdb/common/operator/comparison_operators.hpp"
 #include "duckdb/common/serializer/deserializer.hpp"
 #include "duckdb/common/serializer/serializer.hpp"
@@ -285,14 +286,16 @@ FilterPropagateResult NumericStats::CheckZonemap(const BaseStatistics &stats, Ex
 
 bool NumericStats::ConstantsCoverRange(const BaseStatistics &stats, array_ptr<const Value> constants) {
 	auto &type = stats.GetType();
-	auto physical_type = type.InternalType();
-	// hugeint_t holds every integral type exactly, except the 128-bit ones
-	if (!type.IsIntegral() || physical_type == PhysicalType::INT128 || physical_type == PhysicalType::UINT128 ||
-	    !NumericStats::HasMinMax(stats)) {
+	// values are compared as hugeint_t, which cannot hold large UINT128 values
+	if (!type.IsIntegral() || type.InternalType() == PhysicalType::UINT128 || !NumericStats::HasMinMax(stats)) {
 		return false;
 	}
 	auto min_value = NumericStats::Min(stats).GetValue<hugeint_t>();
 	auto max_value = NumericStats::Max(stats).GetValue<hugeint_t>();
+	// covering [min, max] requires at least max - min + 1 constants
+	if (max_value - min_value >= NumericCast<int64_t>(constants.size())) {
+		return false;
+	}
 	vector<hugeint_t> values;
 	for (auto &constant_value : constants) {
 		if (constant_value.type() != type) {

--- a/src/storage/statistics/numeric_stats.cpp
+++ b/src/storage/statistics/numeric_stats.cpp
@@ -3,6 +3,7 @@
 #include "duckdb/common/algorithm.hpp"
 #include "duckdb/common/numeric_utils.hpp"
 #include "duckdb/common/operator/comparison_operators.hpp"
+#include "duckdb/common/operator/subtract.hpp"
 #include "duckdb/common/serializer/deserializer.hpp"
 #include "duckdb/common/serializer/serializer.hpp"
 #include "duckdb/common/types/vector.hpp"
@@ -293,7 +294,9 @@ bool NumericStats::ConstantsCoverRange(const BaseStatistics &stats, array_ptr<co
 	auto min_value = NumericStats::Min(stats).GetValue<hugeint_t>();
 	auto max_value = NumericStats::Max(stats).GetValue<hugeint_t>();
 	// covering [min, max] requires at least max - min + 1 constants
-	if (max_value - min_value >= NumericCast<int64_t>(constants.size())) {
+	hugeint_t range;
+	if (!TrySubtractOperator::Operation(max_value, min_value, range) ||
+	    range >= NumericCast<int64_t>(constants.size())) {
 		return false;
 	}
 	vector<hugeint_t> values;

--- a/src/storage/statistics/numeric_stats.cpp
+++ b/src/storage/statistics/numeric_stats.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/storage/statistics/numeric_stats.hpp"
 
+#include "duckdb/common/algorithm.hpp"
 #include "duckdb/common/operator/comparison_operators.hpp"
 #include "duckdb/common/serializer/deserializer.hpp"
 #include "duckdb/common/serializer/serializer.hpp"
@@ -280,6 +281,38 @@ FilterPropagateResult NumericStats::CheckZonemap(const BaseStatistics &stats, Ex
 	default:
 		throw InternalException("Unsupported type for NumericStats::CheckZonemap");
 	}
+}
+
+bool NumericStats::ConstantsCoverRange(const BaseStatistics &stats, array_ptr<const Value> constants) {
+	auto &type = stats.GetType();
+	auto physical_type = type.InternalType();
+	// hugeint_t holds every integral type exactly, except the 128-bit ones
+	if (!type.IsIntegral() || physical_type == PhysicalType::INT128 || physical_type == PhysicalType::UINT128 ||
+	    !NumericStats::HasMinMax(stats)) {
+		return false;
+	}
+	auto min_value = NumericStats::Min(stats).GetValue<hugeint_t>();
+	auto max_value = NumericStats::Max(stats).GetValue<hugeint_t>();
+	vector<hugeint_t> values;
+	for (auto &constant_value : constants) {
+		if (constant_value.type() != type) {
+			return false;
+		}
+		auto constant = constant_value.GetValue<hugeint_t>();
+		if (constant >= min_value && constant <= max_value) {
+			values.push_back(constant);
+		}
+	}
+	std::sort(values.begin(), values.end());
+	if (values.empty() || values.front() != min_value || values.back() != max_value) {
+		return false;
+	}
+	for (idx_t i = 1; i < values.size(); i++) {
+		if (values[i - 1] != values[i] && values[i - 1] + 1 != values[i]) {
+			return false;
+		}
+	}
+	return true;
 }
 
 bool NumericStats::IsConstant(const BaseStatistics &stats) {

--- a/test/sql/optimizer/in_list_row_group_pruning.test
+++ b/test/sql/optimizer/in_list_row_group_pruning.test
@@ -1,0 +1,43 @@
+# name: test/sql/optimizer/in_list_row_group_pruning.test
+# description: Prune row groups for NOT IN when the IN-list covers the whole zonemap range
+# group: [optimizer]
+
+statement ok
+ATTACH '{TEST_DIR}/in_list_prune.duckdb' AS db (ROW_GROUP_SIZE 2048);
+
+statement ok
+USE db;
+
+# 3 row groups, each with zonemap [1, 3] fully covered by the IN-list
+statement ok
+CREATE TABLE covered AS SELECT (range % 3 + 1)::INTEGER AS i FROM range(6144);
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM covered WHERE i NOT IN (1, 2, 3);
+----
+analyzed_plan	<REGEX>:.*Empty Result.*
+
+# only the first row group is [1, 3]; the other two are [4, 5] and must survive
+statement ok
+CREATE TABLE mixed AS
+    SELECT CASE WHEN range < 2048 THEN (range % 3 + 1) ELSE (range % 2 + 4) END::INTEGER AS i
+    FROM range(6144);
+
+query I
+SELECT count(*) FROM mixed WHERE i NOT IN (1, 2, 3);
+----
+4096
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM mixed WHERE i NOT IN (1, 2, 3);
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 2 / 3.*
+
+# a DOUBLE zonemap of [1, 3] still holds 1.5, so the range is never covered
+statement ok
+CREATE TABLE doubles AS SELECT unnest([1.0, 1.5, 3.0])::DOUBLE AS i;
+
+query I
+SELECT count(*) FROM doubles WHERE i NOT IN (1, 2, 3);
+----
+1


### PR DESCRIPTION
Resolves #24414

### Problem

A NOT IN predicate whose list covers a row group's entire zonemap range still scans that row group:
```CREATE TABLE t(i INTEGER CHECK (i IN (1, 2, 3)));
INSERT INTO t SELECT (range % 3 + 1)::INTEGER FROM range(6144);

EXPLAIN ANALYZE SELECT count(*) FROM t WHERE i NOT IN (1, 2, 3);
```

The zonemap is [1, 3] and i is an integer, so every value the row group can hold is listed. i IN (1, 2, 3) is therefore always true and its negation always false — no row can match, and nothing needs to be read.

### Before

```text
╭─ Ungrouped Aggregate ─────────╮
│ Aggregates: count_star()      │
│ 1 row                     0µs │
╰───────────────┬───────────────╯
╭─ Table Scan ──┴───────────────╮
│ Table: memory.main.t          │
│ Type: Sequential Scan         │
│ Filters: NOT (i IN (1, 2, 3)) │
│ Row Groups Scanned: 1 / 1     │
│ 0 rows                    0µs │
╰───────────────────────────────╯
```
### After
```text
╭─ Ungrouped Aggregate ────╮
│ Aggregates: count_star() │
│ 1 row                0µs │
╰─────────────┬────────────╯
╭─ Empty Result ───────────╮
│ 0 rows               0µs │
╰──────────────────────────╯
```


### Tests covered

New file `test/sql/optimizer/in_list_row_group_pruning.test`. It fails on main at the first assertion. Three cases:

- The fix. Three row groups, each with `zonemap [1, 3]`. `WHERE i NOT IN (1, 2, 3)` becomes Empty Result.
- Don't prune too much. Only the first row group is `[1, 3]`; the other two are `[4, 5]` and must be read. Row Groups Scanned: 2 / 3, answer 4096.
- Don't prune the wrong type. `A DOUBLE `column with` zonemap [1, 3]` holding 1.5. That row is not in the list, so `count(*)` is 1.