### PR TITLE
Improved tokenization for nested comments

### DIFF
--- a/src/parser/peg/tokenizer/base_tokenizer.cpp
+++ b/src/parser/peg/tokenizer/base_tokenizer.cpp
@@ -238,6 +238,7 @@ bool BaseTokenizer::TokenizeInputInternal() {
 	idx_t last_pos = 0;
 	string dollar_quote_marker;
 	idx_t dollar_marker_start = 0;
+	idx_t multi_line_comment_depth = 0;
 	for (idx_t i = 0; i < sql.size(); i++) {
 		auto c = sql[i];
 		switch (state) {
@@ -305,6 +306,7 @@ bool BaseTokenizer::TokenizeInputInternal() {
 			if (c == '/' && i + 1 < sql.size() && sql[i + 1] == '*') {
 				i++;
 				state = TokenizeState::MULTI_LINE_COMMENT;
+				multi_line_comment_depth = 1;
 				break;
 			}
 			if (StringUtil::CharacterIsSpace(c)) {
@@ -467,11 +469,17 @@ bool BaseTokenizer::TokenizeInputInternal() {
 			}
 			break;
 		case TokenizeState::MULTI_LINE_COMMENT:
-			if (c == '*' && i + 1 < sql.size() && sql[i + 1] == '/') {
+			if (c == '/' && i + 1 < sql.size() && sql[i + 1] == '*') {
 				i++;
-				PushToken(last_pos, i + 1, TokenType::COMMENT);
-				last_pos = i + 1;
-				state = TokenizeState::STANDARD;
+				multi_line_comment_depth++;
+			} else if (c == '*' && i + 1 < sql.size() && sql[i + 1] == '/') {
+				i++;
+				multi_line_comment_depth--;
+				if (multi_line_comment_depth == 0) {
+					PushToken(last_pos, i + 1, TokenType::COMMENT);
+					last_pos = i + 1;
+					state = TokenizeState::STANDARD;
+				}
 			}
 			break;
 		case TokenizeState::DOLLAR_QUOTED_STRING: {

--- a/test/sql/function/tokenize/simple_tokenize.test
+++ b/test/sql/function/tokenize/simple_tokenize.test
@@ -75,6 +75,16 @@ select start, token_type, word from sql_tokenize($$select 1; -- this is a commen
 10	COMMENT	-- this is a comment
 
 query III
+select start, token_type, word from sql_tokenize($$SELECT 1 /* I /* love */ comments */ + 2;$$);
+----
+0	KEYWORD	SELECT
+7	NUMBER_LITERAL	1
+9	COMMENT	/* I /* love */ comments */
+38	OPERATOR	+
+40	NUMBER_LITERAL	2
+41	TERMINATOR	;
+
+query III
 select start, token_type, word from sql_tokenize($$select * fro$$);
 ----
 0	KEYWORD	select

--- a/test/sql/function/tokenize/simple_tokenize.test
+++ b/test/sql/function/tokenize/simple_tokenize.test
@@ -80,9 +80,16 @@ select start, token_type, word from sql_tokenize($$SELECT 1 /* I /* love */ comm
 0	KEYWORD	SELECT
 7	NUMBER_LITERAL	1
 9	COMMENT	/* I /* love */ comments */
-38	OPERATOR	+
-40	NUMBER_LITERAL	2
-41	TERMINATOR	;
+37	OPERATOR	+
+39	NUMBER_LITERAL	2
+40	TERMINATOR	;
+
+query III
+select start, token_type, word from sql_tokenize($$SELECT 1 -- /* not a block */ rest$$);
+----
+0	KEYWORD	SELECT
+7	NUMBER_LITERAL	1
+9	COMMENT	-- /* not a block */ rest
 
 query III
 select start, token_type, word from sql_tokenize($$select * fro$$);

--- a/test/sql/peg_parser/parser/comments.test
+++ b/test/sql/peg_parser/parser/comments.test
@@ -1,0 +1,19 @@
+# name: test/sql/peg_parser/parser/comments.test
+# description: Test comment handling in the PEG parser
+# group: [parser]
+
+require autocomplete
+
+query I
+SELECT 1 /* I /* love */ comments */ + 2;
+----
+3
+
+statement ok
+CALL check_peg_parser($TEST_PEG_PARSER$SELECT 1 /* outer /* inner */ rest */ + 2;$TEST_PEG_PARSER$);
+
+statement ok
+CALL check_peg_parser($TEST_PEG_PARSER$SELECT 10 /* a /* b /* c */ b */ a */ + 5;$TEST_PEG_PARSER$);
+
+statement ok
+CALL check_peg_parser($TEST_PEG_PARSER$SELECT 1/**//* second */+2;$TEST_PEG_PARSER$);

--- a/test/sql/peg_parser/parser/comments.test
+++ b/test/sql/peg_parser/parser/comments.test
@@ -9,6 +9,12 @@ SELECT 1 /* I /* love */ comments */ + 2;
 ----
 3
 
+query I
+SELECT 1 -- /* not a block */ rest
++ 2;
+----
+3
+
 statement ok
 CALL check_peg_parser($TEST_PEG_PARSER$SELECT 1 /* outer /* inner */ rest */ + 2;$TEST_PEG_PARSER$);
 


### PR DESCRIPTION
Part of: https://github.com/duckdblabs/duckdb-internal/issues/9093

The old lexer handled multiple nested comments, but the new tokenizer only kept track of a single multi-line comment. So if you have multiple nested comments this would go wrong. We now keep track of the number of nested comments that we encounter during tokenization. 

Example query: 
```sql
SELECT 1 /* I /* love */ comments */ + 2;
```
(Side note, Github's markdown highlighting doesn't seem to handle nested comments as well as DuckDB now)

The highlighting in the CLI works as well: 
<img width="486" height="180" alt="afbeelding" src="https://github.com/user-attachments/assets/a5892f86-56e1-4987-8773-eb4aa873c22a" />

