### PR TITLE
Kill process group when retrying hanged command in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -684,7 +684,7 @@ define ensure_apt_packages
 	fi
 endef
 
-APT_TIMEOUT_OPTS=-o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30
+APT_TIMEOUT_OPTS=-o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o DPkg::Lock::Timeout=30
 
 .PHONY: toolsci
 

--- a/scripts/ci/retry.py
+++ b/scripts/ci/retry.py
@@ -1,11 +1,14 @@
 import argparse
-import re
 import os
+import re
+import signal
 import subprocess
 import sys
 import time
 
 RETRY_DELAY_SECONDS = 15.0
+TERMINATE_GRACE_SECONDS = 10.0
+PROCESS_GROUP_POLL_SECONDS = 0.1
 
 
 def parse_timeout(timeout: str) -> float:
@@ -65,10 +68,86 @@ def format_command(command):
     return subprocess.list2cmdline(command) if os.name == "nt" else " ".join(command)
 
 
-def run_command(command, command_text, timeout):
+def process_group_exists(process_group_id):
+    try:
+        os.killpg(process_group_id, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def wait_for_process_group_exit(process, process_group_id):
+    deadline = time.monotonic() + TERMINATE_GRACE_SECONDS
+    while process_group_exists(process_group_id):
+        process.poll()
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return False
+        time.sleep(min(PROCESS_GROUP_POLL_SECONDS, remaining))
+    return True
+
+
+def terminate_posix_process_group(process):
+    process_group_id = process.pid
+    try:
+        os.killpg(process_group_id, signal.SIGTERM)
+    except ProcessLookupError:
+        process.wait()
+        return
+
+    if not wait_for_process_group_exit(process, process_group_id):
+        try:
+            os.killpg(process_group_id, signal.SIGKILL)
+        except (PermissionError, ProcessLookupError):
+            pass
+        wait_for_process_group_exit(process, process_group_id)
+    process.wait()
+
+
+def terminate_windows_process_tree(process):
+    try:
+        completed = subprocess.run(
+            ["taskkill", "/PID", str(process.pid), "/T", "/F"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except OSError:
+        completed = None
+    if completed is None or (completed.returncode != 0 and process.poll() is None):
+        process.kill()
+    process.wait()
+
+
+def terminate_process_tree(process):
     if os.name == "nt":
-        return subprocess.run(command_text, timeout=timeout, shell=True)
-    return subprocess.run(command, timeout=timeout)
+        terminate_windows_process_tree(process)
+    else:
+        terminate_posix_process_group(process)
+
+
+def run_command(command, command_text, timeout):
+    if timeout is None:
+        if os.name == "nt":
+            return subprocess.run(command_text, shell=True)
+        return subprocess.run(command)
+
+    if os.name == "nt":
+        process = subprocess.Popen(
+            command_text,
+            shell=True,
+            creationflags=subprocess.CREATE_NEW_PROCESS_GROUP,
+        )
+    else:
+        process = subprocess.Popen(command, start_new_session=True)
+
+    try:
+        return_code = process.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        terminate_process_tree(process)
+        raise
+    return subprocess.CompletedProcess(command, return_code)
 
 
 def main() -> int:

--- a/scripts/ci/test_retry.py
+++ b/scripts/ci/test_retry.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+import os
+import subprocess
+import sys
+import tempfile
+import textwrap
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.ci import retry
+
+
+class RetryScriptTest(unittest.TestCase):
+    def test_parse_timeout(self):
+        self.assertEqual(retry.parse_timeout("30"), 30)
+        self.assertEqual(retry.parse_timeout("45s"), 45)
+        self.assertEqual(retry.parse_timeout("2m"), 120)
+        self.assertEqual(retry.parse_timeout("1.5h"), 5400)
+
+    def test_parse_timeout_rejects_invalid_values(self):
+        for value in ["", "0", "-1", "1d", "seconds"]:
+            with self.subTest(value=value):
+                with self.assertRaises(ValueError):
+                    retry.parse_timeout(value)
+
+    def test_run_command_without_timeout_preserves_completed_status(self):
+        completed = retry.run_command([sys.executable, "-c", "raise SystemExit(7)"], "unused", None)
+        self.assertEqual(completed.returncode, 7)
+
+    def test_run_command_without_timeout_succeeds(self):
+        completed = retry.run_command([sys.executable, "-c", "pass"], "unused", None)
+        self.assertEqual(completed.returncode, 0)
+
+    def test_main_returns_124_after_timeout(self):
+        args = mock.Mock(
+            retries=0,
+            timeout="1s",
+            timeout_seconds=1,
+            command=[sys.executable, "-c", "pass"],
+        )
+        timeout = subprocess.TimeoutExpired(args.command, 1)
+        with (
+            mock.patch.object(retry, "parse_args", return_value=args),
+            mock.patch.object(retry, "run_command", side_effect=timeout),
+            mock.patch("builtins.print"),
+        ):
+            self.assertEqual(retry.main(), 124)
+
+    def test_run_command_timeout_terminates_process_tree_before_reraising(self):
+        command = [sys.executable, "-c", "pass"]
+        process = mock.Mock()
+        timeout = subprocess.TimeoutExpired(command, 1)
+        process.wait.side_effect = timeout
+        with (
+            mock.patch.object(retry.os, "name", "posix"),
+            mock.patch.object(retry.subprocess, "Popen", return_value=process) as popen,
+            mock.patch.object(retry, "terminate_process_tree") as terminate_process_tree,
+        ):
+            with self.assertRaises(subprocess.TimeoutExpired):
+                retry.run_command(command, retry.format_command(command), 1)
+
+        popen.assert_called_once_with(command, start_new_session=True)
+        terminate_process_tree.assert_called_once_with(process)
+
+    @unittest.skipIf(os.name == "nt", "POSIX process groups are not available on Windows")
+    def test_process_group_cleanup_terminates_descendants_that_ignore_sigterm(self):
+        import fcntl
+        import signal
+
+        child_code = textwrap.dedent(
+            """
+            import fcntl
+            import signal
+            import sys
+            import time
+            from pathlib import Path
+
+            with open(sys.argv[1], "w") as lock_file:
+                fcntl.flock(lock_file, fcntl.LOCK_EX)
+                signal.signal(signal.SIGTERM, signal.SIG_IGN)
+                Path(sys.argv[2]).touch()
+                time.sleep(60)
+            """
+        )
+        parent_code = textwrap.dedent(
+            """
+            import subprocess
+            import sys
+            import time
+
+            subprocess.Popen([sys.executable, "-c", sys.argv[1], sys.argv[2], sys.argv[3]])
+            time.sleep(60)
+            """
+        )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            lock_path = Path(temp_dir) / "held.lock"
+            ready_path = Path(temp_dir) / "ready"
+            command = [sys.executable, "-c", parent_code, child_code, str(lock_path), str(ready_path)]
+            process = subprocess.Popen(command, start_new_session=True)
+            try:
+                deadline = time.monotonic() + 5
+                while not ready_path.exists():
+                    self.assertIsNone(process.poll(), "process group exited before acquiring the lock")
+                    self.assertLess(time.monotonic(), deadline, "process group did not acquire the lock")
+                    time.sleep(0.005)
+
+                with (
+                    mock.patch.object(retry, "TERMINATE_GRACE_SECONDS", 0.05),
+                    mock.patch.object(retry, "PROCESS_GROUP_POLL_SECONDS", 0.005),
+                ):
+                    retry.terminate_posix_process_group(process)
+            finally:
+                if retry.process_group_exists(process.pid):
+                    os.killpg(process.pid, signal.SIGKILL)
+                process.wait()
+
+            with lock_path.open("w") as lock_file:
+                try:
+                    fcntl.flock(lock_file, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                except BlockingIOError:
+                    self.fail("timed-out descendant still holds the lock")
+
+    def test_windows_timeout_uses_shell_and_new_process_group(self):
+        process = mock.Mock()
+        process.wait.return_value = 0
+        with (
+            mock.patch.object(retry.os, "name", "nt"),
+            mock.patch.object(retry.subprocess, "CREATE_NEW_PROCESS_GROUP", 512, create=True),
+            mock.patch.object(retry.subprocess, "Popen", return_value=process) as popen,
+        ):
+            completed = retry.run_command(["where", "cmake"], "where cmake", 1)
+
+        self.assertEqual(completed.returncode, 0)
+        popen.assert_called_once_with("where cmake", shell=True, creationflags=512)
+
+    def test_windows_cleanup_terminates_process_tree(self):
+        process = mock.Mock(pid=123)
+        taskkill_result = subprocess.CompletedProcess([], 0)
+        with mock.patch.object(retry.subprocess, "run", return_value=taskkill_result) as run:
+            retry.terminate_windows_process_tree(process)
+
+        run.assert_called_once_with(
+            ["taskkill", "/PID", "123", "/T", "/F"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        process.wait.assert_called_once_with()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Retrying a hanged command (like `apt install`) can result in a different failure:
```
...
0 upgraded, 27 newly installed, 0 to remove and 83 not upgraded.
Need to get 162 MB of archives.
After this operation, 1130 MB of additional disk space will be used.
Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist [144 B]
Get:2 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libhiredis1.1.0 amd64 1.2.0-6ubuntu3 [41.4 kB]
Get:3 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 ccache amd64 4.9.1-1 [592 kB]
Get:4 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 libclang-cpp20 amd64 1:20.1.2-0ubuntu1~24.04.3 [14.2 MB]
Get:5 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 libclang-common-20-dev amd64 1:20.1.2-0ubuntu1~24.04.3 [782 kB]
Get:6 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 llvm-20-linker-tools amd64 1:20.1.2-0ubuntu1~24.04.3 [1338 kB]
Get:7 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 libclang1-20 amd64 1:20.1.2-0ubuntu1~24.04.3 [8318 kB]
Get:8 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 clang-20 amd64 1:20.1.2-0ubuntu1~24.04.3 [77.7 kB]
Get:9 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 fonts-mathjax all 2.7.9+dfsg-1 [2208 kB]
Get:10 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libjs-mathjax all 2.7.9+dfsg-1 [5665 kB]
Get:11 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 clang-20-doc all 1:20.1.2-0ubuntu1~24.04.3 [1701 kB]
[retry] attempt 1/3 timed out after 2m
[retry] attempt 1/3 failed (exit code: 124) for: make toolsci
[retry] sleeping for 15 seconds before retry
missing=0; for cmd in ninja mold ccache pkg-config pigz clang++-20 clangd-20; do command -v $cmd >/dev/null 2>&1 || missing=1; done; if [ $missing -eq 1 ]; then sudo apt-get -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 update -y -q && sudo apt-get -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 install -y -q ninja-build mold ccache pkg-config pigz clang++-20 clangd-20; fi
Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist [144 B]
Hit:2 http://azure.archive.ubuntu.com/ubuntu noble InRelease
Hit:6 https://packages.microsoft.com/repos/azure-cli noble InRelease
Hit:7 https://packages.microsoft.com/ubuntu/24.04/prod noble InRelease
Hit:3 http://azure.archive.ubuntu.com/ubuntu noble-updates InRelease
Hit:4 http://azure.archive.ubuntu.com/ubuntu noble-backports InRelease
Hit:5 http://azure.archive.ubuntu.com/ubuntu noble-security InRelease
Hit:8 https://dl.google.com/linux/chrome-stable/deb stable InRelease
Reading package lists...
E: Could not get lock /var/lib/dpkg/lock-frontend. It is held by process 2685 (apt-get)
E: Unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend), is another process using it?
make: *** [Makefile:692: toolsci] Error 100
[retry] attempt 2/3 failed (exit code: 2) for: make toolsci
...
```
because the apt process is still running and acquired the lock.

Instead, we can kill the process group, wait a little, and then retry the command.

<details>
<summary>I asked codex to confirm Apt release the lock</summary>

Confirmed—with one precise qualification: APT releases the lock when the signal terminates the process, not merely when the signal is delivered.

- Ubuntu Noble currently uses APT 2.8.3. APT acquires `lock-frontend` using an `fcntl(F_SETLK)` write lock held by an open file descriptor. [APT source](https://github.com/Debian/apt/blob/main/apt-pkg/deb/debsystem.cc), [lock implementation](https://github.com/Debian/apt/blob/main/apt-pkg/contrib/fileutl.cc)
- Linux automatically releases all such record locks when the owning process terminates—even after `SIGKILL`. [Linux `fcntl` documentation](https://www.man7.org/linux/man-pages/man2/fcntl_locking.2.html)
- Noble’s `sudo` forwards `SIGTERM` to the root-owned `apt-get` child. [Ubuntu Noble `sudo` documentation](https://manpages.ubuntu.com/manpages/noble/man8/sudo.8.html)
- [retry.py](/Users/sander/dev/duckdb/duckdb/scripts/ci/retry.py:89) sends `SIGTERM` to the timed attempt’s process group, escalates to `SIGKILL`, and waits for the group to exit before retrying.

Therefore the specific stale lock from timed-out process `2685 (apt-get)` should no longer survive into attempt 2.

The same error could still occur if an unrelated APT process acquires the lock concurrently. `DPkg::Lock::Timeout=30` now handles those shorter overlaps. The only exceptional case is an uninterruptible kernel sleep (`D` state), where even `SIGKILL` cannot complete until the kernel operation returns.
</details>