### PR TITLE
Remove a redundant DISTINCT on the existence-only side of a semi join

### DIFF
--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -3958,19 +3958,20 @@ const StringUtil::EnumStringLiteral *GetOptimizerTypeValues() {
 		{ static_cast<uint32_t>(OptimizerType::GROUPING_SETS), "GROUPING_SETS" },
 		{ static_cast<uint32_t>(OptimizerType::TYPE_PUSHDOWN), "TYPE_PUSHDOWN" },
 		{ static_cast<uint32_t>(OptimizerType::SCALAR_FN_PUSHDOWN), "SCALAR_FN_PUSHDOWN" },
-		{ static_cast<uint32_t>(OptimizerType::DISTINCT_AGGREGATE_REWRITE), "DISTINCT_AGGREGATE_REWRITE" }
+		{ static_cast<uint32_t>(OptimizerType::DISTINCT_AGGREGATE_REWRITE), "DISTINCT_AGGREGATE_REWRITE" },
+		{ static_cast<uint32_t>(OptimizerType::SEMI_ANTI_DISTINCT_REMOVAL), "SEMI_ANTI_DISTINCT_REMOVAL" }
 	};
 	return values;
 }
 
 template<>
 const char* EnumUtil::ToChars<OptimizerType>(OptimizerType value) {
-	return StringUtil::EnumToString(GetOptimizerTypeValues(), 44, "OptimizerType", static_cast<uint32_t>(value));
+	return StringUtil::EnumToString(GetOptimizerTypeValues(), 45, "OptimizerType", static_cast<uint32_t>(value));
 }
 
 template<>
 OptimizerType EnumUtil::FromString<OptimizerType>(const char *value) {
-	return static_cast<OptimizerType>(StringUtil::StringToEnum(GetOptimizerTypeValues(), 44, "OptimizerType", value));
+	return static_cast<OptimizerType>(StringUtil::StringToEnum(GetOptimizerTypeValues(), 45, "OptimizerType", value));
 }
 
 const StringUtil::EnumStringLiteral *GetOrderByColumnTypeValues() {

--- a/src/common/enums/optimizer_type.cpp
+++ b/src/common/enums/optimizer_type.cpp
@@ -56,6 +56,7 @@ static const DefaultOptimizerType internal_optimizer_types[] = {
     {"type_pushdown", OptimizerType::TYPE_PUSHDOWN},
     {"scalar_fn_pushdown", OptimizerType::SCALAR_FN_PUSHDOWN},
     {"distinct_aggregate_rewrite", OptimizerType::DISTINCT_AGGREGATE_REWRITE},
+    {"semi_anti_distinct_removal", OptimizerType::SEMI_ANTI_DISTINCT_REMOVAL},
     {nullptr, OptimizerType::INVALID}};
 
 string OptimizerTypeToString(OptimizerType type) {

--- a/src/include/duckdb/common/enums/optimizer_type.hpp
+++ b/src/include/duckdb/common/enums/optimizer_type.hpp
@@ -57,7 +57,8 @@ enum class OptimizerType : uint32_t {
 	GROUPING_SETS = 40,
 	TYPE_PUSHDOWN = 41,
 	SCALAR_FN_PUSHDOWN = 42,
-	DISTINCT_AGGREGATE_REWRITE = 43
+	DISTINCT_AGGREGATE_REWRITE = 43,
+	SEMI_ANTI_DISTINCT_REMOVAL = 44
 };
 
 string OptimizerTypeToString(OptimizerType type);

--- a/src/include/duckdb/optimizer/semi_anti_distinct_removal.hpp
+++ b/src/include/duckdb/optimizer/semi_anti_distinct_removal.hpp
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/optimizer/semi_anti_distinct_removal.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/constants.hpp"
+
+namespace duckdb {
+class LogicalOperator;
+class Optimizer;
+
+//! Removes a DISTINCT that sits directly on the existence-only side of a semi,
+//! anti or mark join. Those joins only ask whether a match exists, so duplicates
+//! on that side cannot change the result.
+class SemiAntiDistinctRemoval {
+public:
+	unique_ptr<LogicalOperator> Optimize(unique_ptr<LogicalOperator> op);
+	//! Whether the DISTINCT below this join can be removed
+	static bool CanOptimize(LogicalOperator &op);
+};
+
+} // namespace duckdb

--- a/src/optimizer/CMakeLists.txt
+++ b/src/optimizer/CMakeLists.txt
@@ -45,6 +45,7 @@ add_library_unity(
   row_group_pruner.cpp
   statistics_propagator.cpp
   limit_pushdown.cpp
+  semi_anti_distinct_removal.cpp
   topn_optimizer.cpp
   topn_window_elimination.cpp
   unnest_rewriter.cpp

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -35,6 +35,7 @@
 #include "duckdb/optimizer/rule/list.hpp"
 #include "duckdb/optimizer/sampling_pushdown.hpp"
 #include "duckdb/optimizer/scalar_fn_pushdown.hpp"
+#include "duckdb/optimizer/semi_anti_distinct_removal.hpp"
 #include "duckdb/optimizer/statistics_propagator.hpp"
 #include "duckdb/optimizer/aggregate_function_rewriter.hpp"
 #include "duckdb/optimizer/topn_optimizer.hpp"
@@ -317,6 +318,13 @@ void Optimizer::RunBuiltInOptimizers() {
 	RunOptimizer(OptimizerType::PARTIAL_AGGREGATE_PUSHDOWN, [&]() {
 		PartialAggregatePushdown partial_aggregate_pushdown(*this);
 		partial_aggregate_pushdown.VisitOperator(plan);
+	});
+
+	// a semi, anti or mark join only checks whether a match exists, so a DISTINCT
+	// on the side that is probed for existence cannot change the result
+	RunOptimizer(OptimizerType::SEMI_ANTI_DISTINCT_REMOVAL, [&]() {
+		SemiAntiDistinctRemoval semi_anti_distinct_removal;
+		plan = semi_anti_distinct_removal.Optimize(std::move(plan));
 	});
 
 	RunOptimizer(OptimizerType::JOIN_ELIMINATION, [&]() {

--- a/src/optimizer/semi_anti_distinct_removal.cpp
+++ b/src/optimizer/semi_anti_distinct_removal.cpp
@@ -1,0 +1,88 @@
+#include "duckdb/optimizer/semi_anti_distinct_removal.hpp"
+
+#include "duckdb/common/enums/join_type.hpp"
+#include "duckdb/planner/operator/logical_comparison_join.hpp"
+#include "duckdb/planner/operator/logical_distinct.hpp"
+
+namespace duckdb {
+
+//! Returns whether this join type only probes one of its children for existence,
+//! and if so which child that is.
+static bool GetExistenceOnlyChild(JoinType type, idx_t &result) {
+	switch (type) {
+	case JoinType::SEMI:
+	case JoinType::ANTI:
+	case JoinType::MARK:
+		// these emit rows from the left and only ask whether the right matches
+		result = 1;
+		return true;
+	case JoinType::RIGHT_SEMI:
+	case JoinType::RIGHT_ANTI:
+		// the optimizer swapped the children, so the left side is the one that
+		// is only probed for existence
+		result = 0;
+		return true;
+	default:
+		return false;
+	}
+}
+
+//! Walks down from an existence-only join child looking for a DISTINCT that can be
+//! removed. A projection maps every input row to exactly one output row, so it
+//! cannot turn a duplicate-insensitive consumer into a sensitive one and we can
+//! keep descending through it.
+static optional_ptr<unique_ptr<LogicalOperator>> FindRemovableDistinct(unique_ptr<LogicalOperator> &start) {
+	auto current = &start;
+	while (true) {
+		auto &op = **current;
+		if (op.type == LogicalOperatorType::LOGICAL_DISTINCT) {
+			auto &distinct = op.Cast<LogicalDistinct>();
+			// DISTINCT ON keeps one row per group and an ORDER BY decides which one,
+			// so removing it can change which values reach the join condition. Only a
+			// plain DISTINCT is a pure de-duplication.
+			if (distinct.distinct_type != DistinctType::DISTINCT) {
+				return nullptr;
+			}
+			return current;
+		}
+		if (op.type == LogicalOperatorType::LOGICAL_PROJECTION && op.children.size() == 1) {
+			current = &op.children[0];
+			continue;
+		}
+		return nullptr;
+	}
+}
+
+bool SemiAntiDistinctRemoval::CanOptimize(LogicalOperator &op) {
+	if (op.type != LogicalOperatorType::LOGICAL_COMPARISON_JOIN) {
+		return false;
+	}
+	auto &join = op.Cast<LogicalComparisonJoin>();
+	idx_t child_idx;
+	if (!GetExistenceOnlyChild(join.join_type, child_idx)) {
+		return false;
+	}
+	return FindRemovableDistinct(op.children[child_idx]) != nullptr;
+}
+
+unique_ptr<LogicalOperator> SemiAntiDistinctRemoval::Optimize(unique_ptr<LogicalOperator> op) {
+	if (op->type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN) {
+		auto &join = op->Cast<LogicalComparisonJoin>();
+		idx_t child_idx;
+		if (GetExistenceOnlyChild(join.join_type, child_idx)) {
+			auto slot = FindRemovableDistinct(op->children[child_idx]);
+			if (slot) {
+				// LogicalDistinct forwards both the column bindings and the types of
+				// its child, so it can be spliced out without rebinding anything above
+				auto distinct = std::move(*slot);
+				*slot = std::move(distinct->children[0]);
+			}
+		}
+	}
+	for (auto &child : op->children) {
+		child = Optimize(std::move(child));
+	}
+	return op;
+}
+
+} // namespace duckdb

--- a/test/sql/optimizer/semi_anti_distinct_removal.test
+++ b/test/sql/optimizer/semi_anti_distinct_removal.test
@@ -1,0 +1,113 @@
+# name: test/sql/optimizer/semi_anti_distinct_removal.test
+# description: Remove a DISTINCT on the existence-only side of a semi, anti or mark join
+# group: [optimizer]
+
+# assert on the logical plan, which is what this rule rewrites
+statement ok
+SET explain_output='optimized_only';
+
+statement ok
+CREATE TABLE probe(k INTEGER);
+
+statement ok
+INSERT INTO probe VALUES (0), (1), (2), (99), (NULL);
+
+statement ok
+CREATE TABLE build(k INTEGER);
+
+statement ok
+INSERT INTO build VALUES (1), (1), (2), (2), (2), (3);
+
+statement ok
+CREATE TABLE with_null(k INTEGER);
+
+statement ok
+INSERT INTO with_null VALUES (1), (NULL);
+
+# the DISTINCT is dropped: a semi join only asks whether a match exists
+query II
+EXPLAIN SELECT k FROM probe WHERE k IN (SELECT DISTINCT k FROM build);
+----
+logical_opt	<!REGEX>:.*Distinct.*
+
+# and it is kept when the optimizer is switched off
+statement ok
+SET disabled_optimizers='semi_anti_distinct_removal';
+
+query II
+EXPLAIN SELECT k FROM probe WHERE k IN (SELECT DISTINCT k FROM build);
+----
+logical_opt	<REGEX>:.*Distinct.*
+
+statement ok
+RESET disabled_optimizers;
+
+# results are unchanged
+query I
+SELECT k FROM probe WHERE k IN (SELECT DISTINCT k FROM build) ORDER BY 1;
+----
+1
+2
+
+query I
+SELECT k FROM probe WHERE k NOT IN (SELECT DISTINCT k FROM build) ORDER BY 1;
+----
+0
+99
+
+# NULL on the inner side: IN yields NULL rather than false when there is no match,
+# and collapsing duplicate NULLs must not change that
+query I
+SELECT k FROM probe WHERE k IN (SELECT DISTINCT k FROM with_null) ORDER BY 1;
+----
+1
+
+query I
+SELECT k FROM probe WHERE k NOT IN (SELECT DISTINCT k FROM with_null) ORDER BY 1;
+----
+
+query II
+SELECT k, k IN (SELECT DISTINCT k FROM with_null) AS m FROM probe ORDER BY 1;
+----
+0	NULL
+1	true
+2	NULL
+99	NULL
+NULL	NULL
+
+# EXISTS and NOT EXISTS take the same paths
+query I
+SELECT k FROM probe p WHERE EXISTS (SELECT DISTINCT k FROM build b WHERE b.k = p.k) ORDER BY 1;
+----
+1
+2
+
+query I
+SELECT k FROM probe p WHERE NOT EXISTS (SELECT DISTINCT k FROM build b WHERE b.k = p.k) ORDER BY 1;
+----
+0
+99
+NULL
+
+# DISTINCT ON is not a pure de-duplication: an ORDER BY decides which row survives,
+# so it must be left alone
+query II
+EXPLAIN SELECT k FROM probe WHERE k IN (SELECT DISTINCT ON (k) k FROM build ORDER BY k);
+----
+logical_opt	<REGEX>:.*Distinct.*
+
+# a DISTINCT whose consumer does care about duplicates must be kept
+query II
+EXPLAIN SELECT count(*) FROM (SELECT DISTINCT k FROM build) s;
+----
+logical_opt	<REGEX>:.*Distinct.*
+
+query I
+SELECT count(*) FROM (SELECT DISTINCT k FROM build) s;
+----
+3
+
+query II
+EXPLAIN SELECT count(*) FROM probe JOIN (SELECT DISTINCT k FROM build) s ON probe.k = s.k;
+----
+logical_opt	<REGEX>:.*Distinct.*


### PR DESCRIPTION
Fixes #24143.

A semi, anti or mark join only asks whether a matching row exists on the side it probes. Duplicates on that side cannot change the answer, so a `DISTINCT` there is pure overhead. DuckDB currently keeps it, which for the query in the issue means a blocking aggregation over ten million values feeding a join that never needed them de-duplicated.

## The rewrite does not need the primary key

The issue frames this as a schema question: `build.k` is a `PRIMARY KEY`, so `SELECT DISTINCT k FROM build` is provably the same as `SELECT k FROM build`. That is true, but it is a narrower justification than the situation allows, and acting on it would mean teaching the optimizer to reason about uniqueness constraints, which it does not do today.

Uniqueness is irrelevant here. What matters is the consumer: a semi join asks an existence question, and existence is unaffected by how many times a value appears. So the rewrite is valid whether or not the column is unique, and it also fires for subqueries over columns with no constraint at all.

## What it does

A new optimizer pass, `SEMI_ANTI_DISTINCT_REMOVAL`, which for `SEMI`, `ANTI`, `MARK`, `RIGHT_SEMI` and `RIGHT_ANTI` joins removes a `LogicalDistinct` sitting on the existence-only child. `RIGHT_SEMI` and `RIGHT_ANTI` have their children swapped by the optimizer, so for those the existence-only side is the left child.

Two details worth calling out:

**It descends through projections.** In practice the `DISTINCT` is not the direct child of the join, there is a projection in between. A `LogicalProjection` maps every input row to exactly one output row, so it cannot turn a duplicate-insensitive consumer into a sensitive one, and it is safe to keep looking below it.

**`DISTINCT ON` is left alone.** It keeps one row per group and an `ORDER BY` decides which one, so removing it can change which values reach the join condition. Only a plain `DISTINCT` is a pure de-duplication.

The splice itself is trivial because `LogicalDistinct` forwards both the column bindings and the types of its child, so nothing above it needs rebinding.

The pass runs just before `JOIN_ELIMINATION` and can be switched off with `SET disabled_optimizers='semi_anti_distinct_removal'`.

## Result

The plan for the query in the issue loses the aggregation entirely:

```
before:  COMPARISON_JOIN (RIGHT_SEMI) -> PROJECTION -> DISTINCT -> PROJECTION -> SEQ_SCAN build
after:   COMPARISON_JOIN (RIGHT_SEMI) -> PROJECTION -> PROJECTION -> SEQ_SCAN build
```

At the scale in the issue, ten million rows, one thread, same binary with the optimizer toggled so nothing else differs:

| Query | before | after |
| --- | ---: | ---: |
| `k IN (SELECT DISTINCT k FROM build)` | 334 ms | **1 ms** |
| `k IN (SELECT k FROM build)` | 1 ms | 1 ms |

Both return `1`. The two spellings now produce equivalent plans and equivalent times, which is what the issue asked for. The issue measured 31.7x on its hardware; the gap is larger here because once the aggregation is gone the join short-circuits against a single probe row.

## Correctness

The risk with an optimizer rule is a wrong answer rather than a slow one, and the exposed area is three-valued logic: `IN` builds a mark join and `NOT IN` an anti join, both of which have to distinguish false from NULL.

I ran every query below twice against the same binary, once with the pass enabled and once disabled, and compared results exactly. 22 of 22 match:

- `IN` and `NOT IN` against inner tables with duplicates, with NULLs, and empty
- the mark result selected directly, so NULL versus false is visible rather than collapsed by a filter
- `EXISTS` and `NOT EXISTS`
- multi-column `DISTINCT`
- nested and correlated subqueries
- cases where the `DISTINCT` must be kept: feeding `COUNT`, feeding `SUM`, and feeding an inner join
- `DISTINCT ON`, which must not be removed

Added `test/sql/optimizer/semi_anti_distinct_removal.test`, covering the plan change in both directions (present with the optimizer disabled, absent with it enabled), the NULL cases, and the cases that must be preserved. 41 assertions. It fails without the change.

`make unittest` is clean: `All tests passed (420 skipped tests, 971346 assertions in 4876 test cases)`.

## One caveat on formatting

`make format-fix` could not run here. It pins `clang_format==11.0.1`, which has no arm64 build, and the machine has no Rosetta. I checked the two new files against the repository's own `.clang-format` with a current clang-format and it reports no changes, and they were written against `limit_pushdown.cpp` as a model, but I have not been able to run the exact pinned version. Happy to apply whatever the CI formatter produces.
