### PR TITLE
Fix index scans past generated columns

### DIFF
--- a/src/function/table/table_scan.cpp
+++ b/src/function/table/table_scan.cpp
@@ -698,7 +698,7 @@ bool TryScanIndex(ART &art, IndexEntry &entry, const ColumnList &column_list, Ta
 	}
 
 	// Get ART column.
-	auto &col = column_list.GetColumn(LogicalIndex(indexed_columns[0]));
+	auto &col = column_list.GetColumn(PhysicalIndex(indexed_columns[0]));
 
 	// The indexes of the filters match input.column_indexes, which are: i -> column_index.
 	// Try to find a filter on the ART column.

--- a/test/issues/general/test_24246.test
+++ b/test/issues/general/test_24246.test
@@ -1,0 +1,64 @@
+# name: test/issues/general/test_24246.test
+# description: Index scans map physical column IDs past generated columns correctly
+# group: [general]
+
+# An index after a generated column must not be mistaken for the preceding
+# logical column.
+statement ok
+CREATE TABLE indexed_strings(a INTEGER, g AS (a + b), b INTEGER, c INTEGER UNIQUE)
+
+statement ok
+INSERT INTO indexed_strings(a, b, c) VALUES (1, 10, 100001), (2, 42, 100002)
+
+query I
+SELECT a FROM indexed_strings WHERE b = 10 ORDER BY a
+----
+1
+
+query I
+SELECT a FROM indexed_strings WHERE b = 42 ORDER BY a
+----
+2
+
+query I
+SELECT a FROM indexed_strings WHERE b >= 42 ORDER BY a
+----
+2
+
+# The index remains usable for its actual column.
+query I
+SELECT a FROM indexed_strings WHERE c = 100002
+----
+2
+
+# Original issue reproducer: updating the indexed column through an UPSERT
+# must not change how filters on the preceding physical column are planned.
+statement ok
+CREATE TABLE up(
+    a INTEGER PRIMARY KEY,
+    g INTEGER AS (a + b),
+    b INTEGER DEFAULT 10,
+    c INTEGER UNIQUE
+)
+
+statement ok
+INSERT INTO up(a, c) SELECT i, i + 100000 FROM range(0, 64) r(i)
+
+statement ok
+INSERT INTO up(a, b, c) VALUES (1, 42, 200001)
+ON CONFLICT(a) DO UPDATE SET b = excluded.b, c = excluded.c
+
+query I
+SELECT count(*) FROM up WHERE b = 10
+----
+63
+
+query I
+SELECT count(*) FROM up WHERE b = 42
+----
+1
+
+query I
+SELECT count(*) FROM up WHERE b >= 42
+----
+1


### PR DESCRIPTION
DuckDB stores an index's column IDs as physical IDs, excluding virtual generated columns, but `TryScanIndex` passed such an ID to `ColumnList::GetColumn` as a logical ID. When a generated column shifted the two ID spaces, an ART index on one column could be matched to a filter on another column, and DuckDB silently returned rows from the wrong index. The issue's UPSERT is not required to trigger the defect: a table with a generated column between an ordinary filtered column and a later unique column reproduces it immediately after insertion.

The lookup now uses `PhysicalIndex`, and the selected `ColumnDefinition` supplies the logical ID for the following filter lookup, preserving each ID space at its API boundary.

A new regression in `test/issues/general/test_24246.test` covers the minimal reproducer, the actual indexed column, and the original UPSERT scenario. Fixes #24246.
