### PR TITLE
Do not cache encrypted Parquet metadata in the plaintext cache

### DIFF
--- a/extension/parquet/include/parquet_file_metadata_cache.hpp
+++ b/extension/parquet/include/parquet_file_metadata_cache.hpp
@@ -55,6 +55,7 @@ public:
 	bool IsValid(CachingFileHandle &new_handle) const;
 	//! Return if a cache entry is valid.
 	ParquetCacheValidity IsValid(const OpenFileInfo &info, ClientContext &context) const;
+	bool IsEncrypted() const;
 
 private:
 	timestamp_t last_modified;

--- a/extension/parquet/parquet_file_metadata_cache.cpp
+++ b/extension/parquet/parquet_file_metadata_cache.cpp
@@ -93,4 +93,9 @@ ParquetCacheValidity ParquetFileMetadataCache::IsValid(const OpenFileInfo &info,
 	return ParquetCacheValidity::INVALID;
 }
 
+bool ParquetFileMetadataCache::IsEncrypted() const {
+	return crypto_metadata && (crypto_metadata->encryption_algorithm.__isset.AES_GCM_V1 ||
+	                           crypto_metadata->encryption_algorithm.__isset.AES_GCM_CTR_V1);
+}
+
 } // namespace duckdb

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1274,11 +1274,14 @@ ParquetReader::ParquetReader(ClientContext &context_p, OpenFileInfo file_p, Parq
 			metadata = LoadMetadata(context_p, allocator, *file_handle, parquet_options.encryption_config,
 			                        encryption_util, footer_size);
 		} else {
-			metadata = ObjectCache::GetObjectCache(context_p).GetWithTypePrefix<ParquetFileMetadataCache>(file.path);
+			metadata = GetMetadataCacheEntry(context_p, file);
 			if (!metadata || !metadata->IsValid(*file_handle)) {
 				metadata = LoadMetadata(context_p, allocator, *file_handle, parquet_options.encryption_config,
 				                        encryption_util, footer_size);
-				ObjectCache::GetObjectCache(context_p).PutWithTypePrefix<ParquetFileMetadataCache>(file.path, metadata);
+				if (!metadata->IsEncrypted()) {
+					ObjectCache::GetObjectCache(context_p).PutWithTypePrefix<ParquetFileMetadataCache>(file.path,
+					                                                                                   metadata);
+				}
 			}
 		}
 	} else {
@@ -1308,7 +1311,11 @@ bool ParquetReader::MetadataCacheEnabled(ClientContext &context) {
 
 shared_ptr<ParquetFileMetadataCache> ParquetReader::GetMetadataCacheEntry(ClientContext &context,
                                                                           const OpenFileInfo &file) {
-	return ObjectCache::GetObjectCache(context).GetWithTypePrefix<ParquetFileMetadataCache>(file.path);
+	auto metadata = ObjectCache::GetObjectCache(context).GetWithTypePrefix<ParquetFileMetadataCache>(file.path);
+	if (metadata && metadata->IsEncrypted()) {
+		return nullptr;
+	}
+	return metadata;
 }
 
 ParquetUnionData::~ParquetUnionData() {

--- a/test/issues/general/test_24317.test
+++ b/test/issues/general/test_24317.test
@@ -1,0 +1,53 @@
+# name: test/issues/general/test_24317.test
+# description: Encrypted Parquet metadata must not be reused without authenticating the footer key
+# group: [parquet]
+
+require parquet
+
+require noforcestorage
+
+statement ok
+SET force_mbedtls_unsafe = true;
+
+statement ok
+SET parquet_metadata_cache = true;
+
+statement ok
+PRAGMA add_parquet_key('key256', '01234567891123450123456789112345');
+
+statement ok
+PRAGMA add_parquet_key('key192', '012345678911234501234567');
+
+statement ok
+COPY (SELECT i::INTEGER AS i FROM range(10) t(i))
+TO '{TEST_DIR}/encrypted_metadata_cache_auth.parquet' (
+	FORMAT PARQUET,
+	ENCRYPTION_CONFIG {footer_key: 'key256'}
+);
+
+query III
+SELECT count(*), min(i), max(i)
+FROM read_parquet('{TEST_DIR}/encrypted_metadata_cache_auth.parquet',
+	encryption_config = {footer_key: 'key256'});
+----
+10	0	9
+
+statement error
+SELECT count(*), min(i), max(i)
+FROM read_parquet('{TEST_DIR}/encrypted_metadata_cache_auth.parquet');
+----
+Invalid Input Error: File '{TEST_DIR}/encrypted_metadata_cache_auth.parquet' is encrypted, but 'encryption_config' was not set
+
+statement error
+SELECT count(*), min(i), max(i)
+FROM read_parquet('{TEST_DIR}/encrypted_metadata_cache_auth.parquet',
+	encryption_config = {footer_key: 'key192'});
+----
+Invalid Input Error: Computed AES tag differs from read AES tag, are you using the right key?
+
+query I
+SELECT sum(i)
+FROM read_parquet('{TEST_DIR}/encrypted_metadata_cache_auth.parquet',
+	encryption_config = {footer_key: 'key256'});
+----
+45


### PR DESCRIPTION

Closes #24317.

DuckDB's database-global Parquet metadata cache keyed entries only by file
path. After one read with the correct encryption configuration cached a
decrypted encrypted footer, later metadata-only queries on the same file —
without the encryption configuration, or with a wrong key — could reuse the
cached plaintext schema, cardinality, and statistics without the footer being
authenticated again.

Exclude encrypted footers from the plaintext metadata cache. Caching of
unencrypted files is unchanged.

The regression test fails against an unchanged build and passes 11 assertions
on the patched Debug ASan/UBSan build. Four ordinary metadata-cache suites
pass another 205 assertions. Rebased onto current `main` (`a82e24d90b`)
without conflicts.

Verified: `test/issues/general/test_24317.test` fails on main `aedb56e5c1`
(unauthenticated metadata read of the encrypted file returns `10 0 9` from
the plaintext cache instead of the expected encryption error), passes with
this branch (11 assertions).