### PR TITLE
Only cast selected LIST child values

### DIFF
--- a/src/function/cast/list_casts.cpp
+++ b/src/function/cast/list_casts.cpp
@@ -41,27 +41,76 @@ unique_ptr<FunctionLocalState> ListBoundCastData::InitListLocalState(CastLocalSt
 bool ListCast::ListToListCast(Vector &source, Vector &result, idx_t count, CastParameters &parameters) {
 	auto &cast_data = parameters.cast_data->Cast<ListBoundCastData>();
 
-	// only handle constant and flat vectors here for now
-	auto source_data = source.Values<list_entry_t>();
-	auto result_data = FlatVector::Writer<list_entry_t>(result, count);
+	auto &source_cc = ListVector::GetChildMutable(source);
+	auto &append_vector = ListVector::GetChildMutable(result);
+	CastParameters child_parameters(parameters, cast_data.child_cast_info.GetCastData(), parameters.local_state);
+
+	if (source.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+		auto source_data = ConstantVector::GetData<list_entry_t>(source);
+		auto result_data = FlatVector::Writer<list_entry_t>(result, count);
+		for (idx_t r = 0; r < count; r++) {
+			if (ConstantVector::IsNull(source)) {
+				result_data.WriteNull();
+			} else {
+				result_data.WriteValue(source_data[0]);
+			}
+		}
+		auto source_size = ListVector::GetListSize(source);
+		ListVector::Reserve(result, source_size);
+		bool all_succeeded = cast_data.child_cast_info.Cast(source_cc, append_vector, source_size, child_parameters);
+		ListVector::SetListSize(result, source_size);
+		return all_succeeded;
+	}
+
+	source.Flatten();
+	auto source_data = FlatVector::GetData<list_entry_t>(source);
+	idx_t child_count = 0;
 	for (idx_t r = 0; r < count; r++) {
-		auto source_list = source_data[r];
-		if (!source_list.IsValid()) {
+		if (FlatVector::IsNull(source, r)) {
+			continue;
+		}
+		child_count += source_data[r].length;
+	}
+
+	bool cast_child_directly = child_count == ListVector::GetListSize(source);
+	idx_t expected_offset = 0;
+	for (idx_t r = 0; cast_child_directly && r < count; r++) {
+		if (FlatVector::IsNull(source, r)) {
+			continue;
+		}
+		if (source_data[r].offset != expected_offset) {
+			cast_child_directly = false;
+		}
+		expected_offset += source_data[r].length;
+	}
+
+	SelectionVector child_sel(cast_child_directly ? 0 : child_count);
+	auto result_data = FlatVector::Writer<list_entry_t>(result, count);
+	idx_t child_offset = 0;
+	for (idx_t r = 0; r < count; r++) {
+		if (FlatVector::IsNull(source, r)) {
 			result_data.WriteNull();
 			continue;
 		}
-		result_data.WriteValue(source_list.GetValue());
+		auto &source_list = source_data[r];
+		result_data.WriteValue(list_entry_t(child_offset, source_list.length));
+		for (idx_t child_idx = 0; child_idx < source_list.length; child_idx++) {
+			if (!cast_child_directly) {
+				child_sel.set_index(child_offset, source_list.offset + child_idx);
+			}
+			child_offset++;
+		}
 	}
-	auto &source_cc = ListVector::GetChildMutable(source);
-	auto source_size = ListVector::GetListSize(source);
 
-	ListVector::Reserve(result, source_size);
-	auto &append_vector = ListVector::GetChildMutable(result);
-
-	CastParameters child_parameters(parameters, cast_data.child_cast_info.GetCastData(), parameters.local_state);
-	bool all_succeeded = cast_data.child_cast_info.Cast(source_cc, append_vector, source_size, child_parameters);
-	ListVector::SetListSize(result, source_size);
-	D_ASSERT(ListVector::GetListSize(result) == source_size);
+	ListVector::Reserve(result, child_count);
+	if (cast_child_directly) {
+		bool all_succeeded = cast_data.child_cast_info.Cast(source_cc, append_vector, child_count, child_parameters);
+		ListVector::SetListSize(result, child_count);
+		return all_succeeded;
+	}
+	Vector source_slice(source_cc, child_sel, child_count);
+	bool all_succeeded = cast_data.child_cast_info.Cast(source_slice, append_vector, child_count, child_parameters);
+	ListVector::SetListSize(result, child_count);
 	return all_succeeded;
 }
 

--- a/test/sql/types/list/list_cast_selection.test
+++ b/test/sql/types/list/list_cast_selection.test
@@ -1,0 +1,73 @@
+# name: test/sql/types/list/list_cast_selection.test
+# description: LIST casts only convert child values referenced by selected rows
+# group: [list]
+
+statement ok
+CREATE TABLE list_casts(id INTEGER, values VARCHAR[]);
+
+statement ok
+INSERT INTO list_casts VALUES (1, ['invalid']), (2, ['1', '2']), (3, NULL), (4, []), (5, ['3', NULL]);
+
+query II
+SELECT id, values::INTEGER[] FROM list_casts WHERE id > 1 ORDER BY id;
+----
+2	[1, 2]
+3	NULL
+4	[]
+5	[3, NULL]
+
+# A selection containing no child values still produces valid NULL and empty lists
+query II
+SELECT id, values::INTEGER[] FROM list_casts WHERE id BETWEEN 3 AND 4 ORDER BY id;
+----
+3	NULL
+4	[]
+
+# Dictionary selections can reference the same list more than once
+query I
+SELECT values::INTEGER[] FROM list_casts, range(3) WHERE id=2;
+----
+[1, 2]
+[1, 2]
+[1, 2]
+
+# Selected conversion errors still follow TRY_CAST's element-wise semantics
+query I
+SELECT TRY_CAST(values AS INTEGER[]) FROM list_casts WHERE id IN (1, 2) ORDER BY id;
+----
+[NULL]
+[1, 2]
+
+# Pack disjoint child ranges with different lengths
+query II
+SELECT id, values::INTEGER[] FROM list_casts WHERE id IN (2, 4, 5) ORDER BY id;
+----
+2	[1, 2]
+4	[]
+5	[3, NULL]
+
+statement ok
+CREATE TABLE nested_list_casts(id INTEGER, values VARCHAR[][]);
+
+statement ok
+INSERT INTO nested_list_casts VALUES (1, [['invalid']]), (2, [['1', '2'], [], NULL]), (3, NULL);
+
+query II
+SELECT id, values::INTEGER[][] FROM nested_list_casts WHERE id > 1 ORDER BY id;
+----
+2	[[1, 2], [], NULL]
+3	NULL
+
+# Constant lists can share their child data between result rows
+query I
+SELECT ['1', '2']::INTEGER[] FROM range(3);
+----
+[1, 2]
+[1, 2]
+[1, 2]
+
+query I
+SELECT NULL::VARCHAR[]::INTEGER[] FROM range(2);
+----
+NULL
+NULL

--- a/test/sql/types/list/list_cast_selection.test
+++ b/test/sql/types/list/list_cast_selection.test
@@ -58,6 +58,44 @@ SELECT id, values::INTEGER[][] FROM nested_list_casts WHERE id > 1 ORDER BY id;
 2	[[1, 2], [], NULL]
 3	NULL
 
+# Selected STRUCT children must be materialised before the recursive cast
+statement ok
+CREATE TABLE struct_list_casts(id INTEGER, values STRUCT(a VARCHAR)[]);
+
+statement ok
+INSERT INTO struct_list_casts VALUES (1, [{'a': 'invalid'}]), (2, [{'a': '3'}]);
+
+query I
+SELECT ((values::STRUCT(a INTEGER)[])[1]).a FROM struct_list_casts WHERE id=2;
+----
+3
+
+# MAP is represented as a LIST of key/value STRUCTs and takes the same path
+statement ok
+CREATE TABLE map_casts(id INTEGER, values MAP(VARCHAR, VARCHAR));
+
+statement ok
+INSERT INTO map_casts VALUES (1, map(['invalid'], ['invalid'])), (2, map(['4'], ['5']));
+
+query I
+SELECT map_extract_value(values::MAP(INTEGER, INTEGER), 4) FROM map_casts WHERE id=2;
+----
+5
+
+# ARRAY children also propagate the packed parent selection to their children
+statement ok
+CREATE TABLE array_list_casts(id INTEGER, values VARCHAR[2][]);
+
+statement ok
+INSERT INTO array_list_casts VALUES
+    (1, [array_value('invalid', 'invalid')]),
+    (2, [array_value('6', '7')]);
+
+query I
+SELECT ((values::INTEGER[2][])[1])[2] FROM array_list_casts WHERE id=2;
+----
+7
+
 # Constant lists can share their child data between result rows
 query I
 SELECT ['1', '2']::INTEGER[] FROM range(3);


### PR DESCRIPTION
Casting a LIST after filtering rows can fail on a value the filter removed: a query that filters to rows whose list values all cast successfully can still raise a conversion error on a value from a filtered-out row. The filtered LIST vector retains its original child storage and selects parent entries through a dictionary, and `ListCast::ListToListCast` copied the selected parent entries but then cast every value in the underlying child vector.

For non-constant inputs the fix flattens the selected parent entries, packs the child ranges they actually reference, and casts a dictionary slice containing only those child values, rewriting output list offsets to the packed layout. A fast path keeps casting the child directly when the selected non-NULL ranges already cover it contiguously, avoiding a large selection allocation for ordinary unfiltered lists, and constant-list behaviour is preserved.

The new regression in `test/sql/types/list/list_cast_selection.test` covers NULL and empty lists, disjoint and repeated dictionary selections, nested LIST casts, filtered LIST children containing STRUCT, MAP and ARRAY values, constant and constant-NULL lists, and selected `TRY_CAST` failures. Fixes #23720.
