### PR TITLE
Preserve GROUPING() bindings in the ordered-list aggregate rewrite

### DIFF
--- a/src/optimizer/aggregate_function_rewriter.cpp
+++ b/src/optimizer/aggregate_function_rewriter.cpp
@@ -392,6 +392,16 @@ private:
 			projection_expressions.push_back(std::move(final_result));
 		}
 
+		// Pass grouping-function bindings through after the original aggregates. Any helper aggregates added by the
+		// rewrite remain private to this projection.
+		for (idx_t grouping_idx = 0; grouping_idx < aggr.grouping_functions.size(); grouping_idx++) {
+			ColumnBinding grouping_binding(aggr.groupings_index, ProjectionIndex(grouping_idx));
+			aggregate_map[grouping_binding] =
+			    ColumnBinding(proj_index, ProjectionIndex(group_count + aggr_count + grouping_idx));
+			projection_expressions.push_back(
+			    make_uniq<BoundColumnRefExpression>(LogicalType::BIGINT, grouping_binding));
+		}
+
 		auto proj = make_uniq<LogicalProjection>(proj_index, std::move(projection_expressions));
 		if (op->has_estimated_cardinality) {
 			proj->SetEstimatedCardinality(op->estimated_cardinality);

--- a/test/issues/general/test_23940.test
+++ b/test/issues/general/test_23940.test
@@ -27,3 +27,13 @@ FROM (VALUES (1, 10, 3), (1, 10, 1)) t(g, h, v)
 GROUP BY g, h;
 ----
 0	0	[1, 3]	[3, 1]	2
+
+# GROUPING bindings used only above the rewrite projection must also be remapped.
+query I
+SELECT list(v ORDER BY v)
+FROM (VALUES (1, 3), (1, 1), (2, 2)) t(g, v)
+GROUP BY ROLLUP(g)
+HAVING GROUPING(g) = 1
+ORDER BY GROUPING(g);
+----
+[1, 2, 3]

--- a/test/issues/general/test_23940.test
+++ b/test/issues/general/test_23940.test
@@ -1,0 +1,29 @@
+# name: test/issues/general/test_23940.test
+# description: Issue 23940 - ordered list rewrite must preserve GROUPING bindings
+# group: [general]
+
+query II
+SELECT GROUPING(g), list(v ORDER BY v)
+FROM (VALUES (1, 3), (1, 1)) t(g, v)
+GROUP BY g;
+----
+0	[1, 3]
+
+# Preserve both the value and position of the GROUPING result when grouping sets are present.
+query III
+SELECT GROUPING(g), g, list(v ORDER BY v)
+FROM (VALUES (1, 3), (1, 1), (2, 2)) t(g, v)
+GROUP BY ROLLUP(g)
+ORDER BY GROUPING(g), g;
+----
+0	1	[1, 3]
+0	2	[2]
+1	NULL	[1, 2, 3]
+
+# Multiple rewritten aggregates add private helpers, while every GROUPING result remains externally visible.
+query IIIII
+SELECT GROUPING(g), GROUPING(h), list(v ORDER BY v), list(v ORDER BY v DESC), count(*)
+FROM (VALUES (1, 10, 3), (1, 10, 1)) t(g, h, v)
+GROUP BY g, h;
+----
+0	0	[1, 3]	[3, 1]	2


### PR DESCRIPTION
An ordered `list()` whose argument is also its ordering key makes the aggregate-function rewriter insert a projection that cannot resolve the query's `GROUPING()` column, failing with `INTERNAL Error: Failed to bind column reference "GROUPING(t.g)"`.

`AggregateFunctionRewriter` rewrites `list(x ORDER BY x)` into `list_sort(list(x), ...)`: its generic rewrite path adds private helper aggregates and inserts a projection exposing the original groups and aggregates, but `LogicalAggregate` exposes `GROUPING()` results through a third binding family, `groupings_index`, which that projection neither forwarded nor remapped — so the parent retained a binding its child no longer exposed. The fix appends each real grouping-function result to the projection after the original aggregates and maps its old `groupings_index` binding to the new position; the offset uses the aggregate count captured before rewriting, so helper aggregates remain private.

The new issue test covers ordinary grouping, `ROLLUP` with a non-zero grouping result, two simultaneous `GROUPING()` outputs, two rewritten ordered lists with separate private helpers, and a `GROUPING()` binding referenced only by `HAVING` or `ORDER BY` above the rewrite projection. Fixes #23940.
