### PR TITLE
Fix internal error for MERGE NOT MATCHED BY SOURCE UPDATE RETURNING

### DIFF
--- a/src/planner/binder/statement/bind_merge_into.cpp
+++ b/src/planner/binder/statement/bind_merge_into.cpp
@@ -274,6 +274,7 @@ BoundStatement Binder::BindNode(MergeQueryNode &node) {
 	// bind the WHEN NOT MATCHED BY SOURCE / TARGET merge actions
 	auto &get = bound_table.plan->Cast<LogicalGet>();
 	auto merge_into = make_uniq<LogicalMergeInto>(table);
+	merge_into->return_chunk = !node.returning_list.empty();
 	merge_into->table_index = GenerateTableIndex();
 	auto proj_index = GenerateTableIndex();
 	vector<unique_ptr<Expression>> projection_expressions;
@@ -340,10 +341,6 @@ BoundStatement Binder::BindNode(MergeQueryNode &node) {
 	// kind of hacky, CreatePlan turns a RIGHT join into a LEFT join so the children get reversed from what we need
 	bool inverted = join.type == JoinType::RIGHT;
 	auto &source = join_ref.get().children[inverted ? 1 : 0];
-
-	if (!node.returning_list.empty()) {
-		merge_into->return_chunk = true;
-	}
 
 	// bind WHEN_MATCHED merge actions (can contain references to both source and target)
 	for (auto &entry : node.actions) {

--- a/test/issues/general/test_24212.test
+++ b/test/issues/general/test_24212.test
@@ -1,0 +1,79 @@
+# name: test/issues/general/test_24212.test
+# description: MERGE NOT MATCHED BY SOURCE UPDATE returns complete rows
+# group: [general]
+
+statement ok
+CREATE TABLE t(i INTEGER, j INTEGER);
+
+statement ok
+INSERT INTO t VALUES (1, 10), (2, 20);
+
+statement ok
+SET debug_verify_serializer = true;
+
+query II
+MERGE INTO t
+USING (VALUES (1, 100)) s(i, j)
+ON t.i = s.i
+WHEN NOT MATCHED BY SOURCE THEN UPDATE SET j = t.j + 1
+RETURNING merge_action, j;
+----
+UPDATE	21
+
+statement ok
+SET debug_verify_serializer = false;
+
+query II
+SELECT * FROM t ORDER BY i;
+----
+1	10
+2	21
+
+statement ok
+CREATE TABLE generated(i INTEGER, j INTEGER, k INTEGER GENERATED ALWAYS AS (j * 2));
+
+statement ok
+INSERT INTO generated(i, j) VALUES (1, 10), (2, 20);
+
+query IIII
+MERGE INTO generated
+USING (VALUES (1, 100)) s(i, j)
+ON generated.i = s.i
+WHEN NOT MATCHED BY SOURCE THEN UPDATE SET j = generated.j + 1
+RETURNING merge_action, i, j, k;
+----
+UPDATE	2	21	42
+
+statement ok
+CREATE TABLE indexed(i INTEGER PRIMARY KEY, j INTEGER);
+
+statement ok
+INSERT INTO indexed VALUES (1, 10), (2, 20);
+
+query III
+MERGE INTO indexed
+USING (VALUES (1)) s(i)
+ON indexed.i = s.i
+WHEN NOT MATCHED BY SOURCE THEN UPDATE SET i = indexed.i + 10
+RETURNING merge_action, i, j;
+----
+UPDATE	12	20
+
+statement ok
+CREATE TABLE combined(i INTEGER, j INTEGER);
+
+statement ok
+INSERT INTO combined VALUES (1, 10), (2, 20);
+
+query III rowsort
+MERGE INTO combined
+USING (VALUES (1, 100), (3, 300)) s(i, j)
+ON combined.i = s.i
+WHEN MATCHED THEN UPDATE SET j = s.j
+WHEN NOT MATCHED BY TARGET THEN INSERT VALUES (s.i, s.j)
+WHEN NOT MATCHED BY SOURCE THEN UPDATE SET j = combined.j + 1
+RETURNING merge_action, i, j;
+----
+INSERT	3	300
+UPDATE	1	100
+UPDATE	2	21


### PR DESCRIPTION
A `WHEN NOT MATCHED BY SOURCE` update combined with `RETURNING` raises an internal `DataChunk::CheckCardinality` error. DuckDB binds `WHEN NOT MATCHED BY SOURCE` and `WHEN NOT MATCHED BY TARGET` actions before constructing the join, but did not set the logical MERGE node's `return_chunk` flag until afterwards, so the dummy logical UPDATE used while binding an early update action behaved as if there were no `RETURNING` clause and did not retain unchanged table columns. At execution, the physical update tried to assemble a complete returned row from a chunk with missing vectors.

The fix initialises `return_chunk` immediately after creating the logical MERGE node, before binding any action; statements without `RETURNING` are unaffected.

The new regression covers the reported update, the resulting table contents, unchanged returned columns, a generated column, an indexed-column update using delete-and-insert execution, and a MERGE exercising matched, source-only and target-only actions together. Fixes #24212.
