### PR TITLE
Fix infinite loop in equi_width_bins with more bins than boundaries

### DIFF
--- a/extension/core_functions/scalar/generic/binning.cpp
+++ b/extension/core_functions/scalar/generic/binning.cpp
@@ -23,6 +23,9 @@ hugeint_t GetPreviousPowerOfTen(hugeint_t input) {
 enum class NiceRounding { CEILING, ROUND };
 
 hugeint_t RoundToNumber(hugeint_t input, hugeint_t num, NiceRounding rounding) {
+	if (num == 0) {
+		return input;
+	}
 	if (rounding == NiceRounding::ROUND) {
 		return (input + (num / 2)) / num * num;
 	} else {
@@ -130,6 +133,10 @@ struct EquiWidthBinsInteger {
 
 		const hugeint_t span = max - min;
 		hugeint_t step = span / Hugeint::Convert(bin_count);
+		if (step == 0) {
+			// the bin count exceeds the number of boundaries in the range - clamp to the smallest possible step
+			step = 1;
+		}
 		if (nice_rounding) {
 			// when doing nice rounding we try to make the max/step values nicer
 			hugeint_t new_step = MakeNumberNice(step, step, NiceRounding::ROUND);
@@ -187,7 +194,9 @@ struct EquiWidthBinsDouble {
 			bin_count *= 2;
 		}
 		if (step == 0) {
-			throw InternalException("step is 0!?");
+			// the span is too small to compute a step size - return only the max boundary
+			result.push_back(max);
+			return result;
 		}
 
 		const double round_multiplication = 10 / step_power_of_ten;

--- a/test/sql/aggregate/aggregates/binning.test
+++ b/test/sql/aggregate/aggregates/binning.test
@@ -315,6 +315,43 @@ SELECT EQUI_WIDTH_BINS(0, 10, 5999, false)
 ----
 [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 
+# more bins than boundaries in the range used to hang forever (issue #24282)
+query I
+SELECT equi_width_bins(1::BIGINT, 2::BIGINT, 1000000, false)
+----
+[1, 2]
+
+query I
+SELECT equi_width_bins(1::BIGINT, 2::BIGINT, 1000000, true)
+----
+[1, 2]
+
+query I
+SELECT equi_width_bins(0::BIGINT, 10::BIGINT, 1000000, false)
+----
+[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+
+query I
+SELECT equi_width_bins(-2::BIGINT, -1::BIGINT, 1000000, false)
+----
+[-1]
+
+query I
+SELECT equi_width_bins(TIMESTAMP '2000-01-01', TIMESTAMP '2000-01-01 00:00:00.000001', 1000000, false)
+----
+['2000-01-01 00:00:00', '2000-01-01 00:00:00.000001']
+
+# a span too small to compute a step size returns a single bucket
+query I
+SELECT equi_width_bins(0.0, 5e-324, 1000000, false)
+----
+[5e-324]
+
+query I
+SELECT equi_width_bins(0.0, 5e-324, 1000000, true)
+----
+[5e-324]
+
 statement error
 SELECT equi_width_bins(-0.0, -1.0, 5, true);
 ----


### PR DESCRIPTION
When the requested bin count exceeds the number of boundaries in the range, the integer step size truncates to zero and the boundary loop in EquiWidthBinsInteger::Operation never terminates, pinning a CPU core. This affected both the nice_rounding and plain paths.

Clamp the integer step to the smallest possible step when it truncates to zero.
Make the hugeint RoundToNumber return its input when the rounding number is zero instead of relying on hugeint division by zero returning zero, mirroring the double implementation.
Return a single bucket from EquiWidthBinsDouble::Operation when the span is too small to compute a step size, instead of throwing an InternalException that was reachable from user input (e.g. equi_width_bins(0.0, 5e-324, 1000000, false)).

Fixes duckdb/duckdb#24282