### PR TITLE
Terminate the dead end chain when the build side uses dictionary emission

### DIFF
--- a/src/execution/join_hashtable.cpp
+++ b/src/execution/join_hashtable.cpp
@@ -2878,11 +2878,16 @@ void JoinHashTable::BuildDictionaryArrays(const PhysicalHashJoin &op) {
 		dict_arrays.emplace_back(std::move(dict_entry));
 	}
 
-	// save chain pointers before overwriting NEXT_PTR; GetNextPointer reads them back
+	// save chain pointers before overwriting NEXT_PTR; GetNextPointer reads them back.
+	// One extra slot is reserved at the end and left null so that `dead_end` has an index
+	// that terminates a chain. Without it, `dead_end` is zeroed and therefore resolves to
+	// index 0, which belongs to a real row, and following it walks an unrelated chain.
 	const auto has_chains = chains_longer_than_one.load(std::memory_order_relaxed);
 	if (has_chains) {
-		aux_next_ptrs = buffer_manager.GetBufferAllocator().Allocate(build_count * sizeof(data_ptr_t));
+		aux_next_ptrs = buffer_manager.GetBufferAllocator().Allocate((build_count + 1) * sizeof(data_ptr_t));
 		aux_next_ptrs_data = reinterpret_cast<data_ptr_t *>(aux_next_ptrs.get());
+		aux_next_ptrs_data[build_count] = nullptr;
+		Store<uint32_t>(static_cast<uint32_t>(build_count), dead_end.get() + pointer_offset);
 	}
 
 	// save the original NEXT_PTR into aux_next_ptrs (if chains exist) and embed the dict index

--- a/test/sql/join/inner/right_semi_dict_emission_dead_end.test
+++ b/test/sql/join/inner/right_semi_dict_emission_dead_end.test
@@ -1,0 +1,58 @@
+# name: test/sql/join/inner/right_semi_dict_emission_dead_end.test
+# description: Test RIGHT_SEMI hash join over a window aggregate with dictionary emission
+# group: [inner]
+
+statement ok
+CREATE TABLE big (f BOOLEAN, s VARCHAR);
+
+statement ok
+INSERT INTO big SELECT (i % 3) = 0, ['a', '', 'dup', 'zzz'][(i % 4) + 1] FROM generate_series(1, 30) t(i);
+
+statement ok
+CREATE VIEW v AS SELECT MAX(f) OVER (PARTITION BY s) AS f, s FROM big;
+
+statement ok
+CREATE TABLE p (pb BOOLEAN);
+
+statement ok
+INSERT INTO p VALUES (TRUE), (TRUE), (NULL);
+
+# The build side is emitted as dictionary vectors, so the chain pointer of each row holds
+# an index rather than a pointer. Marking a chain as found parks the probe pointer on the
+# dead end row, whose chain field is zero, and index zero belongs to a real row. Following
+# it walked an unrelated chain and segfaulted.
+query I
+SELECT COUNT(*) FROM p WHERE p.pb IN (SELECT x.f FROM v x JOIN v y ON x.s = y.s CROSS JOIN v z);
+----
+2
+
+# same query without the join reordering that produces RIGHT_SEMI
+statement ok
+SET disabled_optimizers='build_side_probe_side';
+
+query I
+SELECT COUNT(*) FROM p WHERE p.pb IN (SELECT x.f FROM v x JOIN v y ON x.s = y.s CROSS JOIN v z);
+----
+2
+
+statement ok
+RESET disabled_optimizers;
+
+# related shapes over the same view
+statement ok
+INSERT INTO p VALUES (FALSE);
+
+query I
+SELECT COUNT(*) FROM p WHERE p.pb NOT IN (SELECT x.f FROM v x JOIN v y ON x.s = y.s);
+----
+1
+
+query I
+SELECT COUNT(*) FROM p WHERE EXISTS (SELECT 1 FROM v x WHERE x.f = p.pb);
+----
+2
+
+query I
+SELECT COUNT(*) FROM p WHERE p.pb IN (SELECT f FROM v);
+----
+2


### PR DESCRIPTION
Fixes #24485.

The reported query segfaults on `main`. It does not on 1.5.5, so this is a regression in unreleased code.

```
AddressSanitizer: SEGV join_hashtable.cpp:1942
  in duckdb::JoinHashTable::ScanStructure::NextRightSemiOrAntiJoin(DataChunk&, DataChunk&)
```

## Cause

`BuildDictionaryArrays` changes what a row's chain field means. Instead of holding a pointer to the next row, it holds a `uint32` index into `aux_next_ptrs`, and `GetNextPointer` resolves the chain through that array:

```cpp
if (USE_DICT_EMISSION) {
    if (!chains_longer_than_one.load(...)) {
        return nullptr;
    }
    return aux_next_ptrs_data[Load<uint32_t>(row_ptr + pointer_offset)];
}
return cast_uint64_to_pointer(Load<uint64_t>(row_ptr + pointer_offset));
```

Separately, `MarkChainsAsFoundLoop` parks a probe pointer on the `dead_end` row once a chain has been fully marked, so that the next `AdvancePointers` ends the scan:

```cpp
if (Load<bool>(ptr + ht.tuple_size)) { // Early out: chain has been fully marked as found before
    ptr = dead_end_ptr;
    continue;
}
```

`dead_end` is a zeroed row. Under the pointer layout that zero reads back as a null pointer and the chain ends, which is what the early out relies on. Under dictionary emission the same zero reads back as **index 0**, and index 0 belongs to a real row, because `aux_next_ptrs` is allocated with exactly `build_count` entries and every index in it is a live row:

```cpp
aux_next_ptrs = ...Allocate(build_count * sizeof(data_ptr_t));
for (idx_t i = 0; i < build_count; i++) {
    aux_next_ptrs_data[i] = LoadPointer(next_ptr_location);
    Store<uint32_t>(static_cast<uint32_t>(i), next_ptr_location);
}
```

So instead of terminating, the scan resumes down an unrelated chain and eventually dereferences a value that is not a row pointer. The sentinel silently assumed a layout that dictionary emission had replaced.

That also explains the workaround in the issue. Disabling `build_side_probe_side` avoids the join being flipped to `RIGHT_SEMI`, so `NextRightSemiOrAntiJoin` never runs.

## Fix

Reserve one slot past the end of `aux_next_ptrs`, leave it null, and store its index in `dead_end`. The early out then terminates correctly under both layouts, rather than having to be disabled for one of them.

Both `GetNextPointer` call sites dispatch on `use_dict_emission`, and `AdvancePointers` returns early on the same `chains_longer_than_one` condition that guards the allocation, so the pointer layout never reads the index written here.

## Verification

| | |
| --- | --- |
| `main` | exit 139, ASan reports SEGV at `join_hashtable.cpp:1942` |
| 1.5.5 | no crash, returns `2` |
| with this change | no crash, returns `2` |

Results are restored rather than merely un-crashed. Four shapes over the same view, compared against 1.5.5:

| Query | 1.5.5 | this branch |
| --- | ---: | ---: |
| `IN` with the triple cross join from the issue | 2 | 2 |
| `NOT IN` over the self join | 1 | 1 |
| `EXISTS` | 2 | 2 |
| plain `IN` over the view | 2 | 2 |

Added `test/sql/join/inner/right_semi_dict_emission_dead_end.test`. Reverting the change makes it abort with the same SEGV, so it fails for the right reason.

Full suite on a build with assertions and AddressSanitizer:

```
All tests passed (420 skipped tests, 1026534 assertions in 4876 test cases)
```

with no sanitizer reports.

## Note on formatting

`make format-fix` could not run here: it pins `clang_format==11.0.1`, which has no arm64 build, and this machine has no Rosetta. The changed file reports clean against the repository's `.clang-format` with a current clang-format, but I have not been able to run the pinned version. Happy to apply whatever CI produces.
