### PR TITLE
Fix filter pushdown with collated set operations

### DIFF
--- a/src/include/duckdb/optimizer/filter_pushdown.hpp
+++ b/src/include/duckdb/optimizer/filter_pushdown.hpp
@@ -114,6 +114,8 @@ private:
 	//! Extract filter bindings to compare them with expressions in an operator and determine if the filter
 	//! can be pushed down
 	void ExtractFilterBindings(const Expression &expr, vector<ColumnBinding> &bindings);
+	//! Whether the filter can distinguish values represented by a collation key
+	bool FilterUsesCollation(const Filter &filter);
 	//! Generate filters from the current set of filters stored in the FilterCombiner
 	void GenerateFilters();
 	//! if there are filters in this FilterPushdown node, push them into the combiner. Returns

--- a/src/optimizer/filter_pushdown.cpp
+++ b/src/optimizer/filter_pushdown.cpp
@@ -8,6 +8,8 @@
 #include "duckdb/planner/operator/logical_empty_result.hpp"
 #include "duckdb/planner/operator/logical_window.hpp"
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
+#include "duckdb/planner/expression/bound_reference_expression.hpp"
+#include "duckdb/planner/collation_binding.hpp"
 #include "duckdb/planner/logical_operator_visitor.hpp"
 
 namespace duckdb {
@@ -323,6 +325,20 @@ unique_ptr<LogicalOperator> FilterPushdown::FinishPushdown(unique_ptr<LogicalOpe
 void FilterPushdown::Filter::ExtractBindings() {
 	bindings.clear();
 	LogicalJoin::GetExpressionBindings(*filter, bindings);
+}
+
+bool FilterPushdown::FilterUsesCollation(const Filter &filter) {
+	bool uses_collation = false;
+	ExpressionIterator::VisitExpression<BoundColumnRefExpression>(
+	    *filter.filter, [&](const BoundColumnRefExpression &colref) {
+		    unique_ptr<Expression> reference =
+		        make_uniq<BoundReferenceExpression>(colref.GetReturnType(), colref.Binding().column_index);
+		    if (CollationBinding::Get(optimizer.context)
+		            .PushCollation(optimizer.context, reference, colref.GetReturnType(), CollationType::ALL_COLLATIONS)) {
+			    uses_collation = true;
+		    }
+	    });
+	return uses_collation;
 }
 
 } // namespace duckdb

--- a/src/optimizer/pushdown/pushdown_distinct.cpp
+++ b/src/optimizer/pushdown/pushdown_distinct.cpp
@@ -8,9 +8,20 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownDistinct(unique_ptr<LogicalO
 	D_ASSERT(op->type == LogicalOperatorType::LOGICAL_DISTINCT);
 	auto &distinct = op->Cast<LogicalDistinct>();
 	if (!distinct.order_by) {
-		// regular DISTINCT - can just push down
-		op->children[0] = Rewrite(std::move(op->children[0]));
-		return op;
+		// A predicate may distinguish values that DISTINCT considers equal under a collation, changing which
+		// representative survives. Keep those filters above DISTINCT and push the remaining filters normally.
+		FilterPushdown pushdown(optimizer, convert_mark_joins, projection_mode);
+		vector<unique_ptr<Filter>> remaining_filters;
+		for (auto &filter : filters) {
+			if (FilterUsesCollation(*filter)) {
+				remaining_filters.push_back(std::move(filter));
+			} else {
+				pushdown.filters.push_back(std::move(filter));
+			}
+		}
+		filters = std::move(remaining_filters);
+		op->children[0] = pushdown.Rewrite(std::move(op->children[0]));
+		return PushFinalFilters(std::move(op));
 	}
 	// no pushdown through DISTINCT ON (yet?)
 	return FinishPushdown(std::move(op));

--- a/src/optimizer/pushdown/pushdown_set_operation.cpp
+++ b/src/optimizer/pushdown/pushdown_set_operation.cpp
@@ -28,12 +28,24 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownSetOperation(unique_ptr<Logi
 	D_ASSERT(op->type == LogicalOperatorType::LOGICAL_UNION || op->type == LogicalOperatorType::LOGICAL_EXCEPT ||
 	         op->type == LogicalOperatorType::LOGICAL_INTERSECT);
 	auto &setop = op->Cast<LogicalSetOperation>();
+	vector<unique_ptr<Filter>> pushdown_filters;
+	vector<unique_ptr<Filter>> remaining_filters;
+	for (auto &filter : filters) {
+		// A predicate may distinguish values that the set operation considers equal. Pushing such a predicate into the
+		// inputs can remove a match from EXCEPT/INTERSECT. UNION ALL performs no equality comparison.
+		if ((setop.type == LogicalOperatorType::LOGICAL_UNION && setop.setop_all) || !FilterUsesCollation(*filter)) {
+			pushdown_filters.push_back(std::move(filter));
+		} else {
+			remaining_filters.push_back(std::move(filter));
+		}
+	}
+	filters = std::move(remaining_filters);
 
 	for (auto &child : op->children) {
 		auto child_bindings = child->GetColumnBindings();
 
 		FilterPushdown child_pushdown(optimizer, convert_mark_joins, projection_mode);
-		for (auto &original_filter : filters) {
+		for (auto &original_filter : pushdown_filters) {
 			// first create a copy of the filter
 			auto filter = make_uniq<Filter>();
 			filter->filter = original_filter->filter->Copy();
@@ -69,7 +81,7 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownSetOperation(unique_ptr<Logi
 				i--;
 			}
 		}
-		return op;
+		return PushFinalFilters(std::move(op));
 	}
 	bool left_empty = op->children[0]->type == LogicalOperatorType::LOGICAL_EMPTY_RESULT;
 	bool right_empty = op->children[1]->type == LogicalOperatorType::LOGICAL_EMPTY_RESULT;
@@ -92,7 +104,7 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownSetOperation(unique_ptr<Logi
 				// union or except with empty right child: return left child
 				auto &projection = op->children[0]->Cast<LogicalProjection>();
 				projection.table_index = setop.table_index;
-				return std::move(op->children[0]);
+				return PushFinalFilters(std::move(op->children[0]));
 			}
 			break;
 		case LogicalOperatorType::LOGICAL_INTERSECT:
@@ -102,7 +114,7 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownSetOperation(unique_ptr<Logi
 			throw InternalException("Unsupported set operation");
 		}
 	}
-	return op;
+	return PushFinalFilters(std::move(op));
 }
 
 } // namespace duckdb

--- a/test/sql/optimizer/plan/setop_collation_filter_pushdown.test
+++ b/test/sql/optimizer/plan/setop_collation_filter_pushdown.test
@@ -1,0 +1,86 @@
+# name: test/sql/optimizer/plan/setop_collation_filter_pushdown.test
+# description: Do not push representation-sensitive filters through collated set operations
+# group: [plan]
+
+statement ok
+SET default_collation = 'nocase'
+
+# A filter on either input must not remove a collation-equivalent match.
+query T
+SELECT x FROM (SELECT 'A' x EXCEPT SELECT 'a' x) q WHERE ascii(x) = 65
+----
+
+query T
+SELECT x FROM (SELECT 'A' x INTERSECT SELECT 'a' x) q WHERE ascii(x) = 65
+----
+A
+
+# Bag set operations use the same collated equality for their row-number partitions.
+query T
+SELECT x FROM (SELECT 'A' x EXCEPT ALL SELECT 'a' x) q WHERE ascii(x) = 65
+----
+
+query T
+SELECT x FROM (SELECT 'A' x INTERSECT ALL SELECT 'a' x) q WHERE ascii(x) = 65
+----
+A
+
+# Nested string values also use their child collation during set equality.
+query T
+SELECT x FROM (SELECT ['A'] x EXCEPT SELECT ['a'] x) q WHERE ascii(x[1]) = 65
+----
+
+statement ok
+SET default_collation = ''
+
+# Explicit collations must follow the same rule without a default collation.
+query T
+SELECT x FROM (SELECT 'A' COLLATE nocase x EXCEPT SELECT 'a' x) q WHERE ascii(x) = 65
+----
+
+# Simplifying EXCEPT ALL with an empty right side must retain the outer filter.
+query T
+SELECT x FROM (SELECT 'a' COLLATE nocase x EXCEPT ALL SELECT 'z' WHERE false) q WHERE ascii(x) = 65
+----
+
+# UNION ALL performs no set equality, so its filters remain safe to push down.
+query T
+SELECT x FROM (SELECT 'a' COLLATE nocase x UNION ALL SELECT 'A' x) q WHERE ascii(x) = 65
+----
+A
+
+statement ok
+CREATE TABLE fp_left(s VARCHAR COLLATE nocase, n INTEGER)
+
+statement ok
+CREATE TABLE fp_right(s VARCHAR COLLATE nocase, n INTEGER)
+
+statement ok
+INSERT INTO fp_left VALUES ('a', 1), ('b', 2)
+
+statement ok
+INSERT INTO fp_right VALUES ('a', 1), ('c', 3)
+
+statement ok
+SET profiling_renderer_settings = MAP {'operator_casing': 'upper'}
+
+statement ok
+SET explain_output = 'optimized_only'
+
+# A filter that only references an uncollated column still pushes into both inputs.
+query II
+EXPLAIN SELECT * FROM (SELECT * FROM fp_left EXCEPT SELECT * FROM fp_right) q WHERE n = 1
+----
+logical_opt	<REGEX>:.*EXCEPT.*Filters: n = 1.*Filters: n = 1.*
+
+# A collated filter stays above both duplicate elimination and the set operation.
+query II
+EXPLAIN SELECT * FROM (SELECT * FROM fp_left EXCEPT SELECT * FROM fp_right) q WHERE ascii(s) = 65
+----
+logical_opt	<REGEX>:.*FILTER.*DISTINCT.*EXCEPT.*
+
+# UNION ALL has no equality boundary, so collated filters still reach its scans.
+query II
+EXPLAIN SELECT * FROM (SELECT * FROM fp_left UNION ALL SELECT * FROM fp_right) q WHERE ascii(s) = 65
+----
+logical_opt	<REGEX>:.*UNION.*Filters: ascii\(s\) = 65.*Filters: ascii\(s\) = 65.*

--- a/test/sql/optimizer/plan/setop_collation_filter_pushdown.test
+++ b/test/sql/optimizer/plan/setop_collation_filter_pushdown.test
@@ -49,6 +49,23 @@ SELECT x FROM (SELECT 'a' COLLATE nocase x UNION ALL SELECT 'A' x) q WHERE ascii
 ----
 A
 
+# Non-string types whose set equality is not byte equality follow the same rule.
+# INTERVAL: 30 days and 1 month are set-equal but extract() distinguishes them.
+query T
+SELECT i FROM (SELECT INTERVAL '30 days' i EXCEPT SELECT INTERVAL '1 month' i) q WHERE extract(day from i) = 30
+----
+
+# VARIANT: 1 and 1.0 are set-equal but their string representations distinguish them.
+query T
+SELECT v FROM (SELECT 1::VARIANT v EXCEPT SELECT 1.0::VARIANT v) q WHERE v::VARCHAR = '1'
+----
+
+# Mixed conjuncts split per conjunct: the collation-sensitive half stays above the
+# set operation while the uncollated half still pushes into both inputs.
+query TI
+SELECT x, n FROM (SELECT 'A' COLLATE nocase x, 1 n EXCEPT SELECT 'a' x, 1 n) q WHERE ascii(x) = 65 AND n = 1
+----
+
 statement ok
 CREATE TABLE fp_left(s VARCHAR COLLATE nocase, n INTEGER)
 
@@ -84,3 +101,16 @@ query II
 EXPLAIN SELECT * FROM (SELECT * FROM fp_left UNION ALL SELECT * FROM fp_right) q WHERE ascii(s) = 65
 ----
 logical_opt	<REGEX>:.*UNION.*Filters: ascii\(s\) = 65.*Filters: ascii\(s\) = 65.*
+
+# Conjunct splitting: the collated conjunct stays above the set operation while the
+# uncollated conjunct still pushes into both inputs.
+query II
+EXPLAIN SELECT * FROM (SELECT * FROM fp_left EXCEPT SELECT * FROM fp_right) q WHERE ascii(s) = 65 AND n = 1
+----
+logical_opt	<REGEX>:.*FILTER.*DISTINCT.*EXCEPT.*Filters: n = 1.*Filters: n = 1.*
+
+# An INTERVAL filter that can distinguish set-equal values stays above the set operation.
+query II
+EXPLAIN SELECT i FROM (SELECT INTERVAL '30 days' i EXCEPT SELECT INTERVAL '1 month' i) q WHERE extract(day from i) = 30
+----
+logical_opt	<REGEX>:.*FILTER.*EXCEPT.*


### PR DESCRIPTION
Pushing a filter through a set operation whose equality is not byte equality can change semantics: the predicate can distinguish values the set operation considers equal, removing a match from `EXCEPT` or `INTERSECT` inputs, or changing which representative survives `DISTINCT` and non-ALL `UNION`. This is not specific to string collations — `INTERVAL`, `VARIANT`, `TIME_TZ` and `BIT` columns also compare through collation functions, and for `INTERVAL` (`30 days` vs `1 month`) and `VARIANT` (`1` vs `1.0`) byte-different values are genuinely set-equal, reproducing the same wrong result.

The fix keeps any filter that references a collation-bearing column above the set operation (and above plain `DISTINCT`), so it is evaluated under the same comparison regime as the surrounding query; conjuncts that only reference non-collated columns still push down, and `UNION ALL` is unaffected since it performs no set equality. For `TIME_TZ` and `BIT` the guard is conservative, with no known byte-different, set-equal pairs.

The new regression in `test/sql/optimizer/plan/setop_collation_filter_pushdown.test` covers the `EXCEPT` cases over `COLLATE NOCASE`, `INTERVAL` and `VARIANT` values and a mixed conjunct, confirming only the uncollated conjunct pushes. Fixes #24321.
