### PR TITLE
Fix `UPDATE OF` triggers after column rename

### DIFF
--- a/src/catalog/catalog_entry/duck_table_entry.cpp
+++ b/src/catalog/catalog_entry/duck_table_entry.cpp
@@ -484,6 +484,32 @@ unique_ptr<CatalogEntry> DuckTableEntry::RenameColumn(ClientContext &context, Re
 	auto binder = Binder::CreateBinder(context);
 	auto bound_create_info = binder->BindCreateTableInfo(std::move(create_info), schema, info.bind_mode);
 	SetAlterDependencies(*bound_create_info, info);
+
+	// UPDATE OF trigger columns are stored by name. Keep them aligned with the
+	// table schema when a referenced column is renamed.
+	auto transaction = catalog.GetCatalogTransaction(context);
+	vector<unique_ptr<CreateTriggerInfo>> renamed_triggers;
+	ScanTriggers(transaction, [&](CatalogEntry &entry) {
+		auto &trigger = entry.Cast<TriggerCatalogEntry>();
+		if (trigger.event_type != TriggerEventType::UPDATE_EVENT) {
+			return;
+		}
+		auto trigger_info = unique_ptr_cast<CreateInfo, CreateTriggerInfo>(trigger.GetInfo());
+		bool renamed = false;
+		for (auto &column : trigger_info->columns) {
+			if (column == info.old_name) {
+				column = info.new_name;
+				renamed = true;
+			}
+		}
+		if (renamed) {
+			trigger_info->on_conflict = OnCreateConflict::REPLACE_ON_CONFLICT;
+			renamed_triggers.push_back(std::move(trigger_info));
+		}
+	});
+	for (auto &trigger_info : renamed_triggers) {
+		CreateTrigger(transaction, *trigger_info);
+	}
 	return make_uniq<DuckTableEntry>(catalog, schema, *bound_create_info, storage, triggers);
 }
 

--- a/test/sql/trigger/create_trigger_wal.test
+++ b/test/sql/trigger/create_trigger_wal.test
@@ -32,6 +32,9 @@ CREATE TRIGGER del_trigger BEFORE DELETE ON t1 DELETE FROM log_table WHERE log_t
 statement ok
 CREATE TRIGGER upd_trigger AFTER UPDATE OF id ON t1 UPDATE log_table SET id = 99 WHERE log_table.id = 1;
 
+statement ok
+ALTER TABLE t1 RENAME COLUMN id TO renamed_id;
+
 query I
 SELECT COUNT(*) FROM duckdb_triggers() WHERE table_name = 't1';
 ----
@@ -58,7 +61,56 @@ upd_trigger	t1	AFTER	UPDATE
 query TTT
 SELECT trigger_name, for_each, columns FROM duckdb_triggers() WHERE trigger_name = 'upd_trigger';
 ----
-upd_trigger	STATEMENT	[id]
+upd_trigger	STATEMENT	[renamed_id]
+
+statement ok
+USE triggerdb;
+
+statement ok
+INSERT INTO log_table VALUES (1);
+
+statement ok
+UPDATE t1 SET renamed_id = 1;
+
+query I
+SELECT id FROM log_table;
+----
+99
+
+# The renamed trigger also survives checkpoint serialization
+statement ok
+CHECKPOINT triggerdb;
+
+statement ok
+USE memory;
+
+statement ok
+DETACH triggerdb;
+
+statement ok
+ATTACH '{TEST_DIR}/create_trigger_wal.db' AS triggerdb;
+
+query T
+SELECT columns FROM duckdb_triggers() WHERE trigger_name = 'upd_trigger';
+----
+[renamed_id]
+
+statement ok
+USE triggerdb;
+
+statement ok
+DELETE FROM log_table;
+
+statement ok
+INSERT INTO log_table VALUES (1);
+
+statement ok
+UPDATE t1 SET renamed_id = 2;
+
+query I
+SELECT id FROM log_table;
+----
+99
 
 statement ok
 USE memory;

--- a/test/sql/trigger/trigger_alter_table.test
+++ b/test/sql/trigger/trigger_alter_table.test
@@ -18,16 +18,151 @@ statement ok
 ALTER TABLE t ADD COLUMN j INTEGER;
 
 query I
-SELECT COUNT(*) FROM duckdb_triggers();
+SELECT COUNT(*) FROM duckdb_triggers() WHERE table_name = 't';
 ----
 1
+
+# RENAME COLUMN updates the column list of UPDATE OF triggers
+statement ok
+CREATE TABLE rename_target(i INTEGER, j INTEGER, other INTEGER);
+
+statement ok
+CREATE TABLE rename_audit(trigger_name VARCHAR);
+
+statement ok
+CREATE TRIGGER rename_one AFTER UPDATE OF j ON rename_target
+    INSERT INTO rename_audit VALUES ('one');
+
+statement ok
+CREATE TRIGGER rename_many BEFORE UPDATE OF i, j ON rename_target
+    INSERT INTO rename_audit VALUES ('many');
+
+statement ok
+CREATE TRIGGER rename_unqualified AFTER UPDATE ON rename_target
+    INSERT INTO rename_audit VALUES ('all');
+
+statement ok
+ALTER TABLE rename_target RENAME COLUMN j TO k;
+
+query TT rowsort
+SELECT trigger_name, columns FROM duckdb_triggers()
+WHERE trigger_name IN ('rename_many', 'rename_one', 'rename_unqualified');
+----
+rename_many	[i, k]
+rename_one	[k]
+rename_unqualified	[]
+
+statement ok
+UPDATE rename_target SET k = 1;
+
+query T rowsort
+SELECT trigger_name FROM rename_audit;
+----
+all
+many
+one
+
+# Identifier matching is case-insensitive, while catalogue output keeps the
+# spelling of the new column name
+statement ok
+CREATE TABLE rename_case("OldName" INTEGER);
+
+statement ok
+CREATE TRIGGER rename_case_trigger AFTER UPDATE OF oldname ON rename_case
+    INSERT INTO rename_audit VALUES ('case');
+
+statement ok
+ALTER TABLE rename_case RENAME COLUMN OLDNAME TO "NewName";
+
+query TT
+SELECT columns, sql LIKE '%UPDATE OF NewName%'
+FROM duckdb_triggers() WHERE trigger_name = 'rename_case_trigger';
+----
+[NewName]	true
+
+statement ok
+UPDATE rename_case SET newname = 1;
+
+query I
+SELECT count(*) FROM rename_audit WHERE trigger_name = 'case';
+----
+1
+
+statement ok
+DELETE FROM rename_audit;
+
+# An unrelated column rename leaves UPDATE OF lists unchanged
+statement ok
+ALTER TABLE rename_target RENAME COLUMN other TO extra;
+
+query TT rowsort
+SELECT trigger_name, columns FROM duckdb_triggers()
+WHERE trigger_name IN ('rename_many', 'rename_one', 'rename_unqualified');
+----
+rename_many	[i, k]
+rename_one	[k]
+rename_unqualified	[]
+
+statement ok
+UPDATE rename_target SET extra = 1;
+
+query T
+SELECT trigger_name FROM rename_audit;
+----
+all
+
+statement ok
+DELETE FROM rename_audit;
+
+# The untouched member of a multi-column UPDATE OF list still fires
+statement ok
+UPDATE rename_target SET i = 1;
+
+query T rowsort
+SELECT trigger_name FROM rename_audit;
+----
+all
+many
+
+statement ok
+DELETE FROM rename_audit;
+
+# Rolling back the rename also rolls back the trigger-catalogue replacement
+statement ok
+BEGIN TRANSACTION;
+
+statement ok
+ALTER TABLE rename_target RENAME COLUMN k TO j;
+
+query T
+SELECT columns FROM duckdb_triggers() WHERE trigger_name = 'rename_one';
+----
+[j]
+
+statement ok
+ROLLBACK;
+
+query T
+SELECT columns FROM duckdb_triggers() WHERE trigger_name = 'rename_one';
+----
+[k]
+
+statement ok
+UPDATE rename_target SET k = 2;
+
+query T rowsort
+SELECT trigger_name FROM rename_audit;
+----
+all
+many
+one
 
 # DROP COLUMN takes the physical-column rebuild path
 statement ok
 ALTER TABLE t DROP COLUMN j;
 
 query I
-SELECT COUNT(*) FROM duckdb_triggers();
+SELECT COUNT(*) FROM duckdb_triggers() WHERE table_name = 't';
 ----
 1
 
@@ -36,7 +171,7 @@ statement ok
 ALTER TABLE t ALTER COLUMN i SET NOT NULL;
 
 query I
-SELECT COUNT(*) FROM duckdb_triggers();
+SELECT COUNT(*) FROM duckdb_triggers() WHERE table_name = 't';
 ----
 1
 
@@ -45,7 +180,7 @@ statement ok
 ALTER TABLE t ALTER COLUMN i TYPE BIGINT;
 
 query I
-SELECT COUNT(*) FROM duckdb_triggers();
+SELECT COUNT(*) FROM duckdb_triggers() WHERE table_name = 't';
 ----
 1
 
@@ -54,6 +189,6 @@ statement ok
 ALTER TABLE t ADD PRIMARY KEY(i);
 
 query I
-SELECT COUNT(*) FROM duckdb_triggers();
+SELECT COUNT(*) FROM duckdb_triggers() WHERE table_name = 't';
 ----
 1


### PR DESCRIPTION
Renaming a column left `TriggerCatalogEntry::columns` referring to the old name. Since trigger expansion intersects those identifiers with the columns in an `UPDATE`'s SET list, an `UPDATE OF` trigger silently stopped firing once any of its columns was renamed.

`DuckTableEntry::RenameColumn` now finds every `UPDATE OF` trigger on the table whose column list mentions the old name and transactionally replaces the catalog entry with a deep copy containing the new identifier. Trigger CREATE replay uses shallow copies of `CreateTriggerInfo`, so the replacement clones the info and its dependencies rather than mutating shared state, and the swap happens outside `ScanTriggers`' iteration because `CatalogSet::Scan` holds a lock for the scan's duration.

Extended `trigger_alter_table.test` and `create_trigger_wal.test` cover a rename firing on the new name and not the old, rollback of a transaction that renamed a column, and WAL replay and checkpoint recovery of renamed trigger columns. Fixes #24209.
