### PR TITLE
Fix NUL escape handling in `LIKE`/`ILIKE` operators

### DIFF
--- a/src/function/scalar/string/like.cpp
+++ b/src/function/scalar/string/like.cpp
@@ -397,7 +397,8 @@ struct LikeEscapeOperator {
 	template <class TA, class TB, class TC>
 	static inline bool Operation(TA str, TB pattern, TC escape) {
 		char escape_char = GetEscapeChar(escape);
-		return LikeOperatorFunction(str.GetData(), str.GetSize(), pattern.GetData(), pattern.GetSize(), escape_char);
+		return escape.GetSize() == 0 ? LikeOperatorFunction(str, pattern)
+		                             : LikeOperatorFunction(str, pattern, escape_char);
 	}
 };
 
@@ -415,7 +416,8 @@ struct LikeOperator {
 	}
 };
 
-bool ILikeOperatorFunction(string_t &str, string_t &pattern, char escape = '\0') {
+template <bool HAS_ESCAPE>
+bool ILikeOperatorFunctionInternal(string_t &str, string_t &pattern, char escape) {
 	auto str_data = str.GetData();
 	auto str_size = str.GetSize();
 	auto pat_data = pattern.GetData();
@@ -431,18 +433,26 @@ bool ILikeOperatorFunction(string_t &str, string_t &pattern, char escape = '\0')
 	LowerCase(pat_data, pat_size, pat_ldata.get());
 	string_t str_lcase(str_ldata.get(), UnsafeNumericCast<uint32_t>(str_llength));
 	string_t pat_lcase(pat_ldata.get(), UnsafeNumericCast<uint32_t>(pat_llength));
-	// '\0' is the "no escape" sentinel: use the non-escape matcher so embedded NUL bytes are matched literally
-	if (escape == '\0') {
+	if (!HAS_ESCAPE) {
 		return LikeOperatorFunction(str_lcase, pat_lcase);
 	}
 	return LikeOperatorFunction(str_lcase, pat_lcase, escape);
+}
+
+bool ILikeOperatorFunction(string_t &str, string_t &pattern) {
+	return ILikeOperatorFunctionInternal<false>(str, pattern, '\0');
+}
+
+bool ILikeOperatorFunction(string_t &str, string_t &pattern, char escape) {
+	return ILikeOperatorFunctionInternal<true>(str, pattern, escape);
 }
 
 struct ILikeEscapeOperator {
 	template <class TA, class TB, class TC>
 	static inline bool Operation(TA str, TB pattern, TC escape) {
 		char escape_char = GetEscapeChar(escape);
-		return ILikeOperatorFunction(str, pattern, escape_char);
+		return escape.GetSize() == 0 ? ILikeOperatorFunction(str, pattern)
+		                             : ILikeOperatorFunction(str, pattern, escape_char);
 	}
 };
 
@@ -523,6 +533,7 @@ void ILikeEscapeFunction(DataChunk &args, ExpressionState &state, Vector &result
 		auto pattern = *ConstantVector::GetData<string_t>(pattern_vec);
 		auto escape = *ConstantVector::GetData<string_t>(escape_vec);
 		char escape_char = GetEscapeChar(escape);
+		bool has_escape = escape.GetSize() != 0;
 
 		// lowercase the pattern exactly once, up front
 		idx_t pat_llength = LowerLength(pattern.GetData(), pattern.GetSize());
@@ -533,8 +544,7 @@ void ILikeEscapeFunction(DataChunk &args, ExpressionState &state, Vector &result
 		// the matcher cannot honor escape semantics, so only use it when the escape char never appears in the
 		// (lowercased) pattern, in which case escape is irrelevant and the pattern is a plain LIKE pattern
 		unique_ptr<LikeMatcher> matcher;
-		bool escape_active =
-		    escape_char != '\0' && memchr(pat_lcase.GetData(), escape_char, pat_lcase.GetSize()) != nullptr;
+		bool escape_active = has_escape && memchr(pat_lcase.GetData(), escape_char, pat_lcase.GetSize()) != nullptr;
 		if (!escape_active) {
 			matcher = LikeMatcher::CreateLikeMatcher(string(pat_lcase.GetData(), pat_lcase.GetSize()));
 		}
@@ -550,10 +560,9 @@ void ILikeEscapeFunction(DataChunk &args, ExpressionState &state, Vector &result
 			}
 			LowerCase(str.GetData(), str.GetSize(), scratch.get());
 			string_t str_lcase(scratch.get(), UnsafeNumericCast<uint32_t>(str_llength));
-			// '\0' escape means no escape: use the non-escape matcher so embedded NUL bytes are matched literally
 			bool match = matcher ? matcher->Match(str_lcase)
-			                     : (escape_char == '\0' ? LikeOperatorFunction(str_lcase, pat_lcase)
-			                                            : LikeOperatorFunction(str_lcase, pat_lcase, escape_char));
+			                     : (has_escape ? LikeOperatorFunction(str_lcase, pat_lcase, escape_char)
+			                                   : LikeOperatorFunction(str_lcase, pat_lcase));
 			return INVERT ? !match : match;
 		});
 		return;

--- a/test/sql/function/string/test_ilike_escape.test
+++ b/test/sql/function/string/test_ilike_escape.test
@@ -77,3 +77,43 @@ statement error
 SELECT str ILIKE pat ESCAPE str FROM tbl
 ----
 <REGEX>:.*Syntax Error: Invalid escape string.*
+
+# An embedded NUL is a valid escape character and must not be confused with
+# the empty escape string, which disables escaping.
+query IIII
+SELECT '%' ILIKE (chr(0) || '%') ESCAPE chr(0),
+       '%' NOT ILIKE (chr(0) || '%') ESCAPE chr(0),
+       '%' ILIKE (chr(0) || '%') ESCAPE '',
+       (chr(0) || '%') ILIKE (chr(0) || '%') ESCAPE ''
+----
+true	false	false	true
+
+# Exercise the non-constant ternary path as well as case folding around a NUL escape.
+statement ok
+CREATE TABLE nul_escapes(str VARCHAR, pat VARCHAR, esc VARCHAR);
+
+statement ok
+INSERT INTO nul_escapes VALUES
+	('A%', 'a' || chr(0) || '%', chr(0)),
+	('A%', 'a' || chr(0) || '%', '');
+
+query I
+SELECT str ILIKE pat ESCAPE esc FROM nul_escapes ORDER BY esc
+----
+false
+true
+
+# Constant pattern/escape over a vector takes the specialised fast path.
+query II
+SELECT str ILIKE ('a' || chr(0) || '%') ESCAPE chr(0),
+       str ILIKE ('a' || chr(0) || '%') ESCAPE ''
+FROM (VALUES ('A%'), ('🦆')) t(str)
+ORDER BY str
+----
+true	false
+false	false
+
+statement error
+SELECT 'ab' ILIKE ('a' || chr(0)) ESCAPE chr(0)
+----
+<REGEX>:.*Syntax Error: Like pattern must not end with escape character.*

--- a/test/sql/function/string/test_like_escape.test
+++ b/test/sql/function/string/test_like_escape.test
@@ -112,3 +112,10 @@ select 'a' like 'a' escape NULL;
 ----
 NULL
 
+# Empty ESCAPE disables escaping; it must be distinct from a NUL escape byte.
+query III
+SELECT '%' LIKE (chr(0) || '%') ESCAPE chr(0),
+       '%' LIKE (chr(0) || '%') ESCAPE '',
+       (chr(0) || 'abc') LIKE (chr(0) || '%') ESCAPE ''
+----
+true	false	true


### PR DESCRIPTION
Fixes #24387.

Commit `169f23eaac` corrected plain `ILIKE` with embedded NUL bytes by
treating the byte value `\0` as a sentinel for "no escape". That made an
actual one-byte NUL escape indistinguishable from the empty escape string, so
`ESCAPE chr(0)` used the no-escape matcher and failed to quote `%` or `_`:

```sql
-- should be true: chr(0) escapes the '%'
SELECT '%' ILIKE (chr(0) || '%') ESCAPE chr(0);  -- returned false
```

Ordinary `LIKE` had the inverse bug: `ESCAPE ''` (which should disable escape
processing entirely) still treated NUL bytes as escape markers:

```sql
-- empty escape disables escaping, so the pattern is a literal NUL + wildcard
SELECT '%' LIKE (chr(0) || '%') ESCAPE '';  -- returned true, should be false
```

The fix represents escape presence separately from the escape byte value in
`src/function/scalar/string/like.cpp`, so an empty escape disables escape
processing while a NUL escape works like any other one-byte escape. Note that
per this contract `SELECT '%' ILIKE (chr(0) || '%') ESCAPE '';` is correctly
false, even though #24387 described the older true result as correct.

### Tests

Extended `test/sql/function/string/test_ilike_escape.test` and
`test/sql/function/string/test_like_escape.test` cover constant and
non-constant `ILIKE`, `NOT ILIKE`, Unicode case-folding, the specialised
constant-pattern path, actual NUL escapes, empty escapes, and ordinary `LIKE`.

The complete `test/sql/function/string/*` SQLLogicTest group passes: 82 test
cases and 4,417 assertions (one Windows-only skip).

Two pre-existing matcher defects found during review are deliberately **not**
part of this narrow fix (escape bytes vs. case-folded pattern comparison, and
trailing-escape validation on exhausted input); they can be follow-up issues.

---
Verified (2026-08-05): `test/sql/function/string/test_ilike_escape.test` and
`test/sql/function/string/test_like_escape.test` fail on unpatched duckdb main
`033322be14` (`ESCAPE chr(0)` fails to quote `%`; `ESCAPE ''` still treats NUL
as an escape) and pass with this branch (28 and 31 assertions, debug build).
