### PR TITLE
Fix Top-N window elimination for nullable ordering expressions

### DIFF
--- a/src/include/duckdb/planner/expression_nullability.hpp
+++ b/src/include/duckdb/planner/expression_nullability.hpp
@@ -1,0 +1,37 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/planner/expression_nullability.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/optional_ptr.hpp"
+#include "duckdb/common/vector.hpp"
+
+namespace duckdb {
+
+class ClientContext;
+class Expression;
+class LogicalCTE;
+class LogicalOperator;
+
+//! Conservatively proves that an expression cannot be NULL at a logical operator's output.
+class NotNullExpressionAnalyzer {
+public:
+	explicit NotNullExpressionAnalyzer(ClientContext &context, optional_ptr<LogicalOperator> plan_root = nullptr);
+
+	bool IsNotNull(LogicalOperator &op, const Expression &expr);
+
+private:
+	bool IsNotNull(LogicalOperator &op, const Expression &expr, vector<idx_t> &seen_ctes);
+	optional_ptr<LogicalCTE> FindCTE(idx_t cte_index);
+
+private:
+	ClientContext &context;
+	optional_ptr<LogicalOperator> plan_root;
+};
+
+} // namespace duckdb

--- a/src/optimizer/topn_window_elimination.cpp
+++ b/src/optimizer/topn_window_elimination.cpp
@@ -9,6 +9,7 @@
 #include "duckdb/common/unique_ptr.hpp"
 #include "duckdb/optimizer/late_materialization_helper.hpp"
 #include "duckdb/planner/binder.hpp"
+#include "duckdb/planner/expression_nullability.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/planner/operator/logical_aggregate.hpp"
 #include "duckdb/planner/operator/logical_comparison_join.hpp"
@@ -864,22 +865,11 @@ TopNWindowElimination::ExtractOptimizerParameters(const LogicalWindow &window, c
 	params.partition_count = window_expr.partitions.size();
 	params.order_type = window_expr.orders[0].type;
 
-	VisitExpression(&window_expr.orders[0].expression);
-	if (params.payload_type == TopNPayloadType::SINGLE_COLUMN && !aggregate_payload.empty()) {
-		VisitExpression(&aggregate_payload[0]);
+	NotNullExpressionAnalyzer nullability(context);
+	params.can_be_null = !nullability.IsNotNull(*window.children[0], *window_expr.orders[0].expression);
+	if (!params.can_be_null && params.payload_type == TopNPayloadType::SINGLE_COLUMN && !aggregate_payload.empty()) {
+		params.can_be_null = !nullability.IsNotNull(*window.children[0], *aggregate_payload[0]);
 	}
-	if (column_references.empty()) {
-		params.can_be_null = true;
-	} else {
-		for (const auto &column_ref : column_references) {
-			const auto &column_stats = stats->find(column_ref.first);
-			if (column_stats == stats->end() || column_stats->second->CanHaveNull()) {
-				params.can_be_null = true;
-				break;
-			}
-		}
-	}
-	column_references.clear();
 
 	return params;
 }

--- a/src/optimizer/topn_window_elimination.cpp
+++ b/src/optimizer/topn_window_elimination.cpp
@@ -25,6 +25,7 @@
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression/bound_unnest_expression.hpp"
 #include "duckdb/planner/expression/bound_window_expression.hpp"
+#include "duckdb/planner/expression_nullability.hpp"
 #include "duckdb/function/function_binder.hpp"
 #include "duckdb/main/database.hpp"
 #include "duckdb/common/enums/order_type.hpp"
@@ -883,18 +884,11 @@ TopNWindowElimination::ExtractOptimizerParameters(const LogicalWindow &window, c
 	params.partition_count = window_expr.Partitions().size();
 	params.order_type = window_expr.OrderBy()[0].type;
 
-	VisitExpression(&window_expr.OrderByMutable()[0].expression);
-	if (params.payload_type == TopNPayloadType::SINGLE_COLUMN && !aggregate_payload.empty()) {
-		VisitExpression(&aggregate_payload[0]);
+	NotNullExpressionAnalyzer nullability(context);
+	params.can_be_null = !nullability.IsNotNull(*window.children[0], *window_expr.OrderBy()[0].expression);
+	if (!params.can_be_null && params.payload_type == TopNPayloadType::SINGLE_COLUMN && !aggregate_payload.empty()) {
+		params.can_be_null = !nullability.IsNotNull(*window.children[0], *aggregate_payload[0]);
 	}
-	for (const auto &column_ref : column_references) {
-		const auto &column_stats = stats->find(column_ref.first);
-		if (column_stats == stats->end() || column_stats->second->CanHaveNull()) {
-			params.can_be_null = true;
-			break;
-		}
-	}
-	column_references.clear();
 
 	return params;
 }

--- a/src/planner/CMakeLists.txt
+++ b/src/planner/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library_unity(
   bound_parameter_map.cpp
   collation_binding.cpp
   expression_iterator.cpp
+  expression_nullability.cpp
   expression.cpp
   table_binding.cpp
   expression_binder.cpp

--- a/src/planner/expression_nullability.cpp
+++ b/src/planner/expression_nullability.cpp
@@ -1,0 +1,233 @@
+#include "duckdb/planner/expression_nullability.hpp"
+
+#include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
+#include "duckdb/planner/expression/bound_columnref_expression.hpp"
+#include "duckdb/planner/expression/bound_comparison_expression.hpp"
+#include "duckdb/planner/expression/bound_conjunction_expression.hpp"
+#include "duckdb/planner/expression/bound_operator_expression.hpp"
+#include "duckdb/planner/filter/expression_filter.hpp"
+#include "duckdb/planner/operator/list.hpp"
+#include "duckdb/storage/statistics/base_statistics.hpp"
+
+#include <algorithm>
+
+namespace duckdb {
+
+NotNullExpressionAnalyzer::NotNullExpressionAnalyzer(ClientContext &context_p,
+                                                     optional_ptr<LogicalOperator> plan_root_p)
+    : context(context_p), plan_root(plan_root_p) {
+}
+
+static bool GetColumnRefBinding(const Expression &expr, ColumnBinding &binding) {
+	if (expr.GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
+		return false;
+	}
+	auto &colref = expr.Cast<BoundColumnRefExpression>();
+	if (colref.depth != 0) {
+		return false;
+	}
+	binding = colref.binding;
+	return true;
+}
+
+static bool IsComparisonType(ExpressionType type) {
+	return type >= ExpressionType::COMPARE_EQUAL && type <= ExpressionType::COMPARE_NOT_DISTINCT_FROM;
+}
+
+static bool FilterRejectsNull(const Expression &filter, const Expression &expr) {
+	if (filter.GetExpressionType() == ExpressionType::CONJUNCTION_AND) {
+		auto &conjunction = filter.Cast<BoundConjunctionExpression>();
+		for (auto &child : conjunction.children) {
+			if (FilterRejectsNull(*child, expr)) {
+				return true;
+			}
+		}
+		return false;
+	}
+	if (filter.GetExpressionType() == ExpressionType::CONJUNCTION_OR) {
+		auto &conjunction = filter.Cast<BoundConjunctionExpression>();
+		if (conjunction.children.empty()) {
+			return false;
+		}
+		for (auto &child : conjunction.children) {
+			if (!FilterRejectsNull(*child, expr)) {
+				return false;
+			}
+		}
+		return true;
+	}
+	if (filter.GetExpressionType() == ExpressionType::OPERATOR_IS_NOT_NULL) {
+		auto &op = filter.Cast<BoundOperatorExpression>();
+		return !op.children.empty() && Expression::Equals(*op.children[0], expr);
+	}
+	if (!IsComparisonType(filter.GetExpressionType()) ||
+	    filter.GetExpressionType() == ExpressionType::COMPARE_DISTINCT_FROM ||
+	    filter.GetExpressionType() == ExpressionType::COMPARE_NOT_DISTINCT_FROM) {
+		return false;
+	}
+	auto &comparison = filter.Cast<BoundComparisonExpression>();
+	return Expression::Equals(*comparison.left, expr) || Expression::Equals(*comparison.right, expr);
+}
+
+static bool JoinOutputPreservesChildNonNullability(JoinType join_type, idx_t child_idx) {
+	switch (join_type) {
+	case JoinType::INNER:
+		return child_idx < 2;
+	case JoinType::LEFT:
+	case JoinType::SEMI:
+	case JoinType::ANTI:
+	case JoinType::MARK:
+	case JoinType::SINGLE:
+		return child_idx == 0;
+	case JoinType::RIGHT:
+	case JoinType::RIGHT_SEMI:
+	case JoinType::RIGHT_ANTI:
+		return child_idx == 1;
+	case JoinType::OUTER:
+	case JoinType::INVALID:
+		return false;
+	}
+	return false;
+}
+
+optional_ptr<LogicalCTE> NotNullExpressionAnalyzer::FindCTE(idx_t cte_index) {
+	if (!plan_root) {
+		return nullptr;
+	}
+	vector<reference<LogicalOperator>> operators;
+	operators.push_back(*plan_root);
+	while (!operators.empty()) {
+		auto &op = operators.back().get();
+		operators.pop_back();
+		if (op.type == LogicalOperatorType::LOGICAL_MATERIALIZED_CTE &&
+		    op.Cast<LogicalCTE>().table_index == cte_index) {
+			return op.Cast<LogicalCTE>();
+		}
+		for (auto &child : op.children) {
+			operators.push_back(*child);
+		}
+	}
+	return nullptr;
+}
+
+bool NotNullExpressionAnalyzer::IsNotNull(LogicalOperator &op, const Expression &expr, vector<idx_t> &seen_ctes) {
+	switch (op.type) {
+	case LogicalOperatorType::LOGICAL_PROJECTION: {
+		auto &projection = op.Cast<LogicalProjection>();
+		if (projection.children.size() != 1) {
+			return false;
+		}
+		ColumnBinding binding;
+		if (!GetColumnRefBinding(expr, binding)) {
+			return false;
+		}
+		auto projection_bindings = projection.GetColumnBindings();
+		for (idx_t idx = 0; idx < projection_bindings.size(); idx++) {
+			if (projection_bindings[idx] == binding) {
+				return IsNotNull(*projection.children[0], *projection.expressions[idx], seen_ctes);
+			}
+		}
+		return false;
+	}
+	case LogicalOperatorType::LOGICAL_FILTER: {
+		auto &filter = op.Cast<LogicalFilter>();
+		for (auto &filter_expr : filter.expressions) {
+			if (FilterRejectsNull(*filter_expr, expr)) {
+				return true;
+			}
+		}
+		return filter.children.size() == 1 && IsNotNull(*filter.children[0], expr, seen_ctes);
+	}
+	case LogicalOperatorType::LOGICAL_COMPARISON_JOIN: {
+		auto &join = op.Cast<LogicalComparisonJoin>();
+		if (join.children.size() != 2) {
+			return false;
+		}
+		ColumnBinding binding;
+		if (!GetColumnRefBinding(expr, binding)) {
+			return false;
+		}
+		auto output_bindings = join.GetColumnBindings();
+		if (std::find(output_bindings.begin(), output_bindings.end(), binding) == output_bindings.end()) {
+			return false;
+		}
+		optional_idx binding_child;
+		for (idx_t child_idx = 0; child_idx < join.children.size(); child_idx++) {
+			auto child_bindings = join.children[child_idx]->GetColumnBindings();
+			if (std::find(child_bindings.begin(), child_bindings.end(), binding) == child_bindings.end()) {
+				continue;
+			}
+			if (binding_child.IsValid()) {
+				return false;
+			}
+			binding_child = child_idx;
+		}
+		if (!binding_child.IsValid() ||
+		    !JoinOutputPreservesChildNonNullability(join.join_type, binding_child.GetIndex())) {
+			return false;
+		}
+		return IsNotNull(*join.children[binding_child.GetIndex()], expr, seen_ctes);
+	}
+	case LogicalOperatorType::LOGICAL_GET: {
+		ColumnBinding binding;
+		if (!GetColumnRefBinding(expr, binding)) {
+			return false;
+		}
+		auto &get = op.Cast<LogicalGet>();
+		if (binding.table_index != get.table_index) {
+			return false;
+		}
+		auto &column_ids = get.GetColumnIds();
+		if (binding.column_index >= column_ids.size()) {
+			return false;
+		}
+		auto &column_index = column_ids[binding.column_index];
+		if (!column_index.HasPrimaryIndex() || column_index.HasChildren() ||
+		    column_index.GetPrimaryIndex() == DConstants::INVALID_INDEX) {
+			return false;
+		}
+		auto table = get.GetTable();
+		if (!table) {
+			return false;
+		}
+		auto stats = table->GetStatistics(context, column_index.GetPrimaryIndex());
+		//! Unknown statistics must not count as proof of non-nullability
+		return stats && stats->CanHaveNoNull() && !stats->CanHaveNull();
+	}
+	case LogicalOperatorType::LOGICAL_CTE_REF: {
+		ColumnBinding binding;
+		if (!GetColumnRefBinding(expr, binding)) {
+			return false;
+		}
+		auto &cte_ref = op.Cast<LogicalCTERef>();
+		if (binding.table_index != cte_ref.table_index ||
+		    std::find(seen_ctes.begin(), seen_ctes.end(), cte_ref.cte_index) != seen_ctes.end()) {
+			return false;
+		}
+		auto cte = FindCTE(cte_ref.cte_index);
+		if (!cte || cte->children.empty()) {
+			return false;
+		}
+		auto column_index = binding.column_index;
+		auto &cte_source = *cte->children[0];
+		auto source_bindings = cte_source.GetColumnBindings();
+		if (column_index >= source_bindings.size() || column_index >= cte_source.types.size()) {
+			return false;
+		}
+		seen_ctes.push_back(cte_ref.cte_index);
+		auto source_expr = BoundColumnRefExpression(cte_source.types[column_index], source_bindings[column_index]);
+		auto result = IsNotNull(cte_source, source_expr, seen_ctes);
+		seen_ctes.pop_back();
+		return result;
+	}
+	default:
+		return false;
+	}
+}
+
+bool NotNullExpressionAnalyzer::IsNotNull(LogicalOperator &op, const Expression &expr) {
+	vector<idx_t> seen_ctes;
+	return IsNotNull(op, expr, seen_ctes);
+}
+
+} // namespace duckdb

--- a/src/planner/expression_nullability.cpp
+++ b/src/planner/expression_nullability.cpp
@@ -215,8 +215,9 @@ bool NotNullExpressionAnalyzer::IsNotNull(LogicalOperator &op, const Expression 
 			return false;
 		}
 		seen_ctes.push_back(cte_ref.cte_index);
-		auto source_expr = BoundColumnRefExpression(cte_source.types[column_index], source_bindings[column_index]);
-		auto result = IsNotNull(cte_source, source_expr, seen_ctes);
+		auto source_expr =
+		    make_uniq<BoundColumnRefExpression>(cte_source.types[column_index], source_bindings[column_index]);
+		auto result = IsNotNull(cte_source, *source_expr, seen_ctes);
 		seen_ctes.pop_back();
 		return result;
 	}

--- a/test/optimizer/topn_window_elimination.test_slow
+++ b/test/optimizer/topn_window_elimination.test_slow
@@ -24,6 +24,56 @@ INSERT INTO tbl2 VALUES (0, 'a'), (1, 'b'), (null, 'c')
 statement ok
 CREATE TABLE empty_topn(s INTEGER, p INTEGER)
 
+# Ordering expressions can introduce NULLs even when their input columns cannot
+statement ok
+CREATE TABLE expression_nulls(id INTEGER PRIMARY KEY)
+
+statement ok
+INSERT INTO expression_nulls VALUES (1), (2), (3)
+
+query II
+SELECT id, row_number() OVER (ORDER BY NULLIF(id % 3, 0) DESC NULLS LAST) AS rn
+FROM expression_nulls
+QUALIFY rn <= 3
+ORDER BY rn
+----
+2	1
+1	2
+3	3
+
+# Exercise the min_n/max_n rewrite without a payload column
+query I
+SELECT row_number() OVER (ORDER BY NULLIF(id % 3, 0) DESC NULLS LAST) AS rn
+FROM expression_nulls
+QUALIFY rn <= 3
+ORDER BY rn
+----
+1
+2
+3
+
+# An expression whose ordering key is always NULL must not fabricate a NULL payload
+query II
+SELECT count(*), count(id)
+FROM (
+	SELECT id
+	FROM expression_nulls
+	QUALIFY row_number() OVER (ORDER BY NULLIF(id, id) NULLS LAST) = 1
+)
+----
+1	1
+
+# This is not specific to NULLIF: TRY_CAST can also introduce NULLs
+query IIII
+SELECT count(*), count(id), min(rn), max(rn)
+FROM (
+	SELECT id, row_number() OVER (ORDER BY TRY_CAST(id::VARCHAR || 'x' AS INTEGER) NULLS LAST) AS rn
+	FROM expression_nulls
+	QUALIFY rn <= 3
+)
+----
+3	3	1	3
+
 query I
 SELECT p
 FROM empty_topn

--- a/test/optimizer/topn_window_elimination.test_slow
+++ b/test/optimizer/topn_window_elimination.test_slow
@@ -74,6 +74,76 @@ WHERE s < random()
 QUALIFY row_number() OVER (ORDER BY s) <= 1
 ----
 
+# Ordering expressions can introduce NULLs even when their input columns cannot
+statement ok
+CREATE TABLE expression_nulls(id INTEGER PRIMARY KEY)
+
+statement ok
+INSERT INTO expression_nulls VALUES (1), (2), (3)
+
+query II
+SELECT id, row_number() OVER (ORDER BY NULLIF(id % 3, 0) DESC NULLS LAST) AS rn
+FROM expression_nulls
+QUALIFY rn <= 3
+ORDER BY rn
+----
+2	1
+1	2
+3	3
+
+# Exercise the min_n/max_n rewrite without a payload column
+query I
+SELECT row_number() OVER (ORDER BY NULLIF(id % 3, 0) DESC NULLS LAST) AS rn
+FROM expression_nulls
+QUALIFY rn <= 3
+ORDER BY rn
+----
+1
+2
+3
+
+# An expression whose ordering key is always NULL must not fabricate a NULL payload
+query II
+SELECT count(*), count(id)
+FROM (
+	SELECT id
+	FROM expression_nulls
+	QUALIFY row_number() OVER (ORDER BY NULLIF(id, id) NULLS LAST) = 1
+)
+----
+1	1
+
+# This is not specific to NULLIF: TRY_CAST can also introduce NULLs
+query IIII
+SELECT count(*), count(id), min(rn), max(rn)
+FROM (
+	SELECT id, row_number() OVER (ORDER BY TRY_CAST(id::VARCHAR || 'x' AS INTEGER) NULLS LAST) AS rn
+	FROM expression_nulls
+	QUALIFY rn <= 3
+)
+----
+3	3	1	3
+
+# Preserve nullable ordering keys through the partitioned, multi-payload path
+statement ok
+CREATE TABLE expression_null_payload(id INTEGER PRIMARY KEY, payload VARCHAR NOT NULL, grp INTEGER NOT NULL)
+
+statement ok
+INSERT INTO expression_null_payload VALUES (1, 'a', 1), (2, 'b', 1), (3, 'c', 1), (4, 'd', 2)
+
+query IIII
+SELECT id, payload, grp, row_number() OVER (
+	PARTITION BY grp ORDER BY NULLIF(id % 3, 0) DESC NULLS LAST
+) AS rn
+FROM expression_null_payload
+QUALIFY rn <= 3
+ORDER BY grp, rn;
+----
+2	b	1	1
+1	a	1	2
+3	c	1	3
+4	d	2	1
+
 # NaN sorts after all finite floating-point values
 query II
 WITH floating_values(id, val) AS (

--- a/test/optimizer/topn_window_elimination.test_slow
+++ b/test/optimizer/topn_window_elimination.test_slow
@@ -74,6 +74,26 @@ FROM (
 ----
 3	3	1	3
 
+# Preserve nullable ordering keys through the partitioned, multi-payload path
+statement ok
+CREATE TABLE expression_null_payload(id INTEGER PRIMARY KEY, payload VARCHAR NOT NULL, grp INTEGER NOT NULL)
+
+statement ok
+INSERT INTO expression_null_payload VALUES (1, 'a', 1), (2, 'b', 1), (3, 'c', 1), (4, 'd', 2)
+
+query IIII
+SELECT id, payload, grp, row_number() OVER (
+	PARTITION BY grp ORDER BY NULLIF(id % 3, 0) DESC NULLS LAST
+) AS rn
+FROM expression_null_payload
+QUALIFY rn <= 3
+ORDER BY grp, rn;
+----
+2	b	1	1
+1	a	1	2
+3	c	1	3
+4	d	2	1
+
 query I
 SELECT p
 FROM empty_topn


### PR DESCRIPTION
`TopNWindowElimination::ExtractOptimizerParameters` inferred the nullability of a `ROW_NUMBER()` ordering expression from the statistics of its referenced columns, but a non-null column does not imply a non-null expression — `NULLIF`, `TRY_CAST` and similar constructs can introduce NULL values. The rewrite's `min_n`/`arg_max` aggregate path ignores NULL keys, so rows whose ordering expression evaluates to NULL were silently discarded, returning fewer rows than the query should.

The fix runs `NotNullExpressionAnalyzer` over the complete ordering and payload expressions and selects the existing null-preserving aggregate path when it cannot prove both non-null. The analyser is deliberately conservative, so uncertainty costs only an optimisation opportunity, never rows.

Extended `test/optimizer/topn_window_elimination.test_slow` covers payload and payload-free rewrites, an entirely NULL ordering expression, a `TRY_CAST` expression that introduces NULLs, partitions, and the multi-payload struct-packing path. Fixes #23677.
