### PR TITLE
Avoid shredding colliding VARIANT keys

### DIFF
--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -39,6 +39,7 @@
 #include "duckdb/logging/logger.hpp"
 #include "duckdb/logging/log_manager.hpp"
 #include "duckdb/common/type_visitor.hpp"
+#include "duckdb/common/case_insensitive_map.hpp"
 #include "duckdb/function/variant/variant_shredding.hpp"
 #include "duckdb/storage/block_allocator.hpp"
 
@@ -673,6 +674,19 @@ void ForceVariantShredding::SetGlobal(DatabaseInstance *_, DBConfig &config, con
 			}
 			if (type.id() == LogicalTypeId::STRUCT && StructType::IsUnnamed(type)) {
 				throw InvalidInputException("STRUCT types in the shredding can not be empty");
+			}
+			if (type.id() == LogicalTypeId::STRUCT) {
+				//! STRUCT field names are case-insensitive, but VARIANT object keys are case-sensitive;
+				//! colliding fields would shred distinct keys into the same STRUCT field.
+				case_insensitive_set_t field_names;
+				for (auto &child : StructType::GetChildTypes(type)) {
+					if (!field_names.insert(child.first.GetIdentifierName()).second) {
+						throw InvalidInputException(
+						    "STRUCT field names in the shredding must be unique, but field \"%s\" collides with "
+						    "another field when compared case-insensitively",
+						    child.first.GetIdentifierName());
+					}
+				}
 			}
 			return false;
 		}

--- a/src/storage/table/variant/variant_shredding.cpp
+++ b/src/storage/table/variant/variant_shredding.cpp
@@ -439,11 +439,16 @@ bool VariantShreddingStats::GetShreddedTypeInternal(const VariantColumnStatsData
 	bool fully_consistent = !force_partial && max_count == total_value_count;
 	if (type_index == static_cast<uint8_t>(VariantLogicalType::OBJECT)) {
 		child_list_t<LogicalType> child_types;
+		case_insensitive_string_set_t field_names;
 		for (auto &entry : column.field_stats) {
 			auto &child_column = GetColumnStats(entry.second);
 			if (entry.first.empty()) {
 				//! Do not include empty field names in the shredded type!
 				continue;
+			}
+			if (!field_names.emplace(entry.first).second) {
+				//! STRUCT field names are case-insensitive, but VARIANT object keys are case-sensitive.
+				return false;
 			}
 			LogicalType child_type;
 			if (GetShreddedTypeInternal(child_column, child_type, total_value_count, force_partial)) {

--- a/test/configs/shredded_vector.json
+++ b/test/configs/shredded_vector.json
@@ -11,6 +11,12 @@
 				"test/sql/types/variant/tpch_test_through_json.test",
 				"test/sql/function/variant/variant_typeof.test"
 			]
+		},
+		{
+			"reason": "Asserts that a non-shreddable VARIANT overlay is scanned as a FLAT_VECTOR; this config forces all vectors to be shredded",
+			"paths": [
+				"test/issues/general/test_24298.test"
+			]
 		}
 	]
 }

--- a/test/configs/stats_dependent_tests.json
+++ b/test/configs/stats_dependent_tests.json
@@ -52,7 +52,8 @@
         "test/sql/copy/parquet/parquet_prefetch_strategy_option.test",
         "test/sql/copy/parquet/read_ahead/readahead_depth_learning.test",
         "test/sql/copy/parquet/read_ahead/readahead_io_budget.test_slow",
-        "test/sql/types/geo/geometry_vertex_extract.test"
+        "test/sql/types/geo/geometry_vertex_extract.test",
+        "test/issues/general/test_24298.test"
       ]
     }
     ]

--- a/test/issues/general/test_24298.test
+++ b/test/issues/general/test_24298.test
@@ -66,3 +66,25 @@ FROM nested
 ----
 [A]	NULL	2
 [a]	1	NULL
+
+# Forcing a shredding type whose STRUCT fields collide case-insensitively
+# would build the same colliding STRUCT the inference guard prevents:
+# extraction resolves both spellings to the first matching field, returning
+# wrong values and losing the other spelling.  The setting must reject it.
+statement error
+SET force_variant_shredding = 'STRUCT("a" INTEGER, "A" INTEGER)'
+----
+collides with another field
+
+# The check applies to nested STRUCTs as well.
+statement error
+SET force_variant_shredding = 'STRUCT(obj STRUCT("a" INTEGER, "A" INTEGER))'
+----
+collides with another field
+
+# A forced shredding type without colliding fields is still accepted.
+statement ok
+SET force_variant_shredding = 'STRUCT("a" INTEGER, "b" INTEGER)'
+
+statement ok
+RESET force_variant_shredding

--- a/test/issues/general/test_24298.test
+++ b/test/issues/general/test_24298.test
@@ -2,7 +2,7 @@
 # description: Case-sensitive VARIANT keys that collide as STRUCT fields remain unshredded
 # group: [general]
 
-load {TEST_DIR}/variant_case_insensitive_field_collision.db readwrite
+load {TEST_DIR}/variant_case_insensitive_field_collision.db readwrite v1.5.0
 
 statement ok
 SET variant_minimum_shredding_size = 0

--- a/test/issues/general/test_24298.test
+++ b/test/issues/general/test_24298.test
@@ -1,0 +1,68 @@
+# name: test/issues/general/test_24298.test
+# description: Case-sensitive VARIANT keys that collide as STRUCT fields remain unshredded
+# group: [general]
+
+load {TEST_DIR}/variant_case_insensitive_field_collision.db readwrite
+
+statement ok
+SET variant_minimum_shredding_size = 0
+
+statement ok
+CREATE TABLE top_level(v VARIANT)
+
+statement ok
+INSERT INTO top_level VALUES ({'a': 1}::VARIANT), ({'A': 2}::VARIANT)
+
+statement ok
+FORCE CHECKPOINT
+
+query I
+SELECT stats(v)::VARCHAR FROM top_level LIMIT 1
+----
+{'has_no_null': true, 'has_null': false, 'shredding_state': UNINITIALIZED}
+
+query I
+SELECT DISTINCT vector_type(v) FROM top_level
+----
+FLAT_VECTOR
+
+query III rowsort
+SELECT variant_keys(v), variant_extract(v, 'a')::INTEGER, variant_extract(v, 'A')::INTEGER
+FROM top_level
+----
+[A]	NULL	2
+[a]	1	NULL
+
+# A collision in a nested object must not prevent unrelated fields from being
+# shredded, and both spellings must survive in the unshredded overlay.
+statement ok
+CREATE TABLE nested(v VARIANT)
+
+statement ok
+INSERT INTO nested VALUES
+    ({'outer': {'a': 1}, 'other': 10}::VARIANT),
+    ({'outer': {'A': 2}, 'other': 20}::VARIANT)
+
+statement ok
+FORCE CHECKPOINT
+
+query I
+SELECT stats(v).shredding_state FROM nested LIMIT 1
+----
+SHREDDED
+
+query II
+SELECT stats(v).fully_shredded.other.stats.min,
+       stats(v).fully_shredded.other.stats.max
+FROM nested LIMIT 1
+----
+10	20
+
+query III rowsort
+SELECT variant_keys(variant_extract(v, 'outer')),
+       variant_extract(variant_extract(v, 'outer'), 'a')::INTEGER,
+       variant_extract(variant_extract(v, 'outer'), 'A')::INTEGER
+FROM nested
+----
+[A]	NULL	2
+[a]	1	NULL

--- a/test/issues/general/test_24298.test
+++ b/test/issues/general/test_24298.test
@@ -17,9 +17,9 @@ statement ok
 FORCE CHECKPOINT
 
 query I
-SELECT stats(v)::VARCHAR FROM top_level LIMIT 1
+SELECT stats(v).fully_shredded IS NULL FROM top_level LIMIT 1
 ----
-{'has_no_null': true, 'has_null': false, 'shredding_state': UNINITIALIZED}
+true
 
 query I
 SELECT DISTINCT vector_type(v) FROM top_level


### PR DESCRIPTION
Fixes #24298.

VARIANT object keys are case-sensitive, but STRUCT field identifiers are
case-insensitive. Automatic shredding inferred separate fields for keys such
as `a` and `A`, then attempted to represent both in a STRUCT; reading the
column's statistics consequently failed with a duplicate-field error.

Detect case-insensitive key collisions while inferring an object's shredded
type and decline to shred that object. For a nested collision, that whole
nested object — including its non-colliding sibling fields — remains in the
overlay, while unrelated parent fields outside it can still be shredded.
Neither key spelling is merged or discarded. `force_variant_shredding`
bypasses inference, so its validator now rejects shredding types whose
STRUCT fields collide case-insensitively at any nesting depth.

The regression covers statistics, vector shape, case-sensitive extraction
and keys after a checkpoint, nested fallback with an unrelated parent field
that stays shredded, and rejection of colliding forced types.
