### PR TITLE
Produce valid JSON for fractional VARIANT decimals

### DIFF
--- a/src/function/cast/variant/to_json.cpp
+++ b/src/function/cast/variant/to_json.cpp
@@ -142,6 +142,11 @@ struct JSONConverter {
 		} else {
 			throw InternalException("Unhandled decimal type");
 		}
+		if (width == scale) {
+			// Decimal::ToString omits the zero before the decimal point when all digits are fractional.
+			// JSON numbers require an integer component.
+			val_str.insert(val_str[0] == '-' ? 1 : 0, 1, '0');
+		}
 		return yyjson_mut_rawncpy(doc, val_str.c_str(), val_str.size());
 	}
 

--- a/test/sql/types/variant/json_cast.test
+++ b/test/sql/types/variant/json_cast.test
@@ -96,6 +96,37 @@ select '{"hello": [1,2,true, false, null], "test": [1, {"test": false}, ["blob",
 {"hello":[1,2,true,false,null],"test":[1,{"test":false},["blob","this is a long string",123]]}
 {"hello":[1,2,true,false,null],"test":[1,{"test":false},["blob","this is a long string",123]]}
 
+# Issue #23996: DECIMALs with no integer digit still produce valid JSON numbers
+query II
+SELECT 0.5::DECIMAL(1,1)::VARIANT::JSON, (-0.5::DECIMAL(1,1))::VARIANT::JSON;
+----
+0.5	-0.5
+
+query IIII
+SELECT 0.5::DECIMAL(4,4)::VARIANT::JSON,
+       0.5::DECIMAL(9,9)::VARIANT::JSON,
+       0.5::DECIMAL(18,18)::VARIANT::JSON,
+       0.5::DECIMAL(38,38)::VARIANT::JSON;
+----
+0.5000	0.500000000	0.500000000000000000	0.50000000000000000000000000000000000000
+
+query I
+SELECT [0.5::DECIMAL(1,1), -0.5::DECIMAL(1,1)]::VARIANT::JSON;
+----
+[0.5,-0.5]
+
+query I
+SELECT {'positive': 0.5::DECIMAL(1,1), 'negative': -0.5::DECIMAL(1,1)}::VARIANT::JSON;
+----
+{"negative":-0.5,"positive":0.5}
+
+query III
+SELECT json_valid(0.5::DECIMAL(1,1)::VARIANT::JSON),
+       json_valid([0.5::DECIMAL(1,1)]::VARIANT::JSON),
+       json_valid({'value': -0.5::DECIMAL(1,1)}::VARIANT::JSON);
+----
+true	true	true
+
 statement ok
 create table tbl(var JSON);
 


### PR DESCRIPTION
Fixes #23996.

Casting a DECIMAL whose width equals its scale through VARIANT and then to
JSON emits a fractional number without an integer component:

```sql
SELECT 0.5::DECIMAL(1,1)::VARIANT::JSON;
-- .5 (invalid JSON)
```

The same applies to negative values (`-.5`) and to nested values, making
arrays and objects containing them invalid JSON too. It reproduces for all
four physical DECIMAL representations.

### Cause and fix

`JSONConverter::VisitDecimal` passes `Decimal::ToString` output directly to
yyjson as a raw number. DuckDB's general DECIMAL display deliberately omits
the major part when `width == scale`, because every value of that type has a
zero integer part; JSON's number grammar does not permit that shorthand.

The general DECIMAL formatter is unchanged. In the VARIANT-to-JSON converter
only, insert `0` before the decimal point (after an optional minus sign) when
`width == scale`, then pass the valid number to yyjson.

### Tests

- The focused JSON-cast test passes 61 assertions: positive and negative
  scalars, all four physical DECIMAL widths, arrays, objects, `json_valid`,
  zero, boundary `DECIMAL(1,1)` values, ordinary DECIMALs, and NULL.
- The complete `test/sql/types/variant/*` selection passes 823 assertions.
- With the fix removed but the regression retained, the suite fails at the
  first new assertion with actual `.5`/`-.5` (negative control).

Verified: `test/sql/types/variant/json_cast.test` fails on main `033322be14` emitting invalid JSON `.5`/`-.5`, passes with this branch (61 assertions).
