### PR TITLE
Reject filename and Hive partition collisions

### DIFF
--- a/src/common/multi_file/multi_file_reader.cpp
+++ b/src/common/multi_file/multi_file_reader.cpp
@@ -282,8 +282,14 @@ void MultiFileReader::BindOptions(MultiFileOptions &options, MultiFileList &file
 			auto lookup = std::find_if(names.begin(), names.end(),
 			                           [&](const Identifier &col_name) { return col_name == part.first; });
 			if (lookup != names.end()) {
-				// hive partitioning column also exists in file - override
 				auto idx = NumericCast<idx_t>(lookup - names.begin());
+				if (bind_data.filename_idx == idx) {
+					throw BinderException(
+					    "Option filename adds column \"%s\", but a hive partition column with this "
+					    "name also exists. Try setting a different name: filename='<filename column name>'",
+					    options.filename_column);
+				}
+				// hive partitioning column also exists in file - override
 				hive_partitioning_index = idx;
 				return_types[idx] = options.GetHiveLogicalType(part.first);
 			} else {

--- a/test/issues/general/test_24310.test
+++ b/test/issues/general/test_24310.test
@@ -1,0 +1,29 @@
+# name: test/issues/general/test_24310.test
+# description: Hive partition column colliding with the generated filename column
+# group: [parquet]
+
+require parquet
+
+statement ok
+CREATE TABLE source AS SELECT * FROM (VALUES ('part_a', 1), ('part_b', 2)) v(filename, id);
+
+statement ok
+COPY source TO '{TEST_DIR}/partition_filename_collision' (
+	FORMAT PARQUET,
+	PARTITION_BY (filename)
+);
+
+statement error
+SELECT filename, id
+FROM read_parquet('{TEST_DIR}/partition_filename_collision/**/*.parquet',
+	hive_partitioning = true, filename = true);
+----
+Option filename adds column "filename", but a hive partition column with this name also exists. Try setting a different name: filename='<filename column name>'
+
+query III rowsort
+SELECT filename, parse_filename(file_path), id
+FROM read_parquet('{TEST_DIR}/partition_filename_collision/**/*.parquet',
+	hive_partitioning = true, filename = 'file_path');
+----
+part_a	data_0.parquet	1
+part_b	data_0.parquet	2

--- a/test/issues/general/test_24310.test
+++ b/test/issues/general/test_24310.test
@@ -1,6 +1,6 @@
 # name: test/issues/general/test_24310.test
 # description: Hive partition column colliding with the generated filename column
-# group: [parquet]
+# group: [general]
 
 require parquet
 


### PR DESCRIPTION
Fixes <https://github.com/duckdb/duckdb/issues/24310>.

When `filename = true` and Hive partitioning both produce a column called `filename`, `MultiFileReader::BindOptions` assigns both generated constants the same output index. The Hive partition constant then silently overwrites the filename column, and queries return partition values where file paths were expected (or vice versa) with no error.

### Fix

At bind time, detect that the matched Hive partition column index is the generated filename column index and throw a `BinderException` telling the caller to pick a different generated name:

```
Option filename adds column "filename", but a hive partition column with this
name also exists. Try setting a different name: filename='<filename column name>'
```

This matches the existing behaviour for a physical filename-column conflict, which is already rejected. Renaming the generated column (`filename = 'file_path'`) keeps both columns working.

### Testing

- New regression `test/issues/general/test_24310.test` (9 assertions): the default generated name now raises the explicit binder error, and `filename = 'file_path'` exposes partition values, file names, and row ids correctly. Against an unchanged build the error assertion fails because the query silently succeeds with wrong values.
- Four adjacent suites pass 229 assertions (filename-column naming and physical filename collision, Parquet Hive override behaviour, shared CSV Hive/filename handling), re-verified on the prep build 2026-08-05 (`test/parquet/test_filename_column.test` 18, `test/sql/copy/parquet/parquet_hive.test` 106, `test/sql/copy/parquet/parquet_filename.test` 44, `test/sql/copy/csv/csv_hive_filename_union.test` 61).
- An independent read-only review traced pre-open constant resolution and filter pushdown and confirmed the patch rejects only the generated-column collision, not user data columns.

Verified: `test/issues/general/test_24310.test` fails on main `033322be14` with the colliding `filename = true` query silently succeeding and returning file paths, passes with this branch (9 assertions).
