### PR TITLE
Handle collations in map_contains and map_extract

### DIFF
--- a/extension/core_functions/scalar/map/map_extract.cpp
+++ b/extension/core_functions/scalar/map/map_extract.cpp
@@ -1,9 +1,16 @@
 #include "duckdb/common/vector/map_vector.hpp"
 #include "core_functions/scalar/map_functions.hpp"
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/catalog/catalog_entry/scalar_function_catalog_entry.hpp"
 #include "duckdb/common/types/data_chunk.hpp"
+#include "duckdb/function/function_binder.hpp"
 #include "duckdb/function/scalar/list/contains_or_position.hpp"
 #include "duckdb/function/scalar/nested_functions.hpp"
+#include "duckdb/planner/expression/bound_case_expression.hpp"
+#include "duckdb/planner/expression/bound_cast_expression.hpp"
+#include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "duckdb/planner/expression/bound_operator_expression.hpp"
 
 namespace duckdb {
 
@@ -95,12 +102,171 @@ static void MapExtractListFunc(DataChunk &args, ExpressionState &state, Vector &
 	}
 }
 
+static bool TypeHasCollation(const LogicalType &type) {
+	switch (type.id()) {
+	case LogicalTypeId::VARCHAR:
+		return !type.HasAlias() && !StringType::GetCollation(type).empty();
+	case LogicalTypeId::LIST:
+		return TypeHasCollation(ListType::GetChildType(type));
+	case LogicalTypeId::ARRAY:
+		return TypeHasCollation(ArrayType::GetChildType(type));
+	default:
+		return false;
+	}
+}
+
+static unique_ptr<Expression> BindSiblingFunction(FunctionBindExpressionInput &input, const char *name,
+                                                  vector<unique_ptr<Expression>> children) {
+	auto &catalog = Catalog::GetSystemCatalog(input.context);
+	auto &function_entry = catalog.GetEntry<ScalarFunctionCatalogEntry>(
+	    input.context, QualifiedName(catalog.GetName(), Identifier::DefaultSchema(), Identifier(name)));
+	FunctionBinder function_binder(input.context);
+	ErrorData error;
+	auto function = function_binder.BindScalarFunction(function_entry, std::move(children), error);
+	if (!function) {
+		error.Throw();
+	}
+	return function;
+}
+
+static unique_ptr<Expression> IsNull(unique_ptr<Expression> expression) {
+	auto result = make_uniq<BoundOperatorExpression>(ExpressionType::OPERATOR_IS_NULL, LogicalType::BOOLEAN);
+	result->GetChildrenMutable().push_back(std::move(expression));
+	return result;
+}
+
+static unique_ptr<Expression> CastToResultType(FunctionBindExpressionInput &input, unique_ptr<Expression> expression) {
+	const auto &result_type = input.bound_function.GetReturnType();
+	if (expression->GetReturnType() == result_type) {
+		return expression;
+	}
+	return BoundCastExpression::AddCastToType(input.context, std::move(expression), result_type);
+}
+
+//! Binds map_values(map), list_position(map_keys(map), key) and friends for the collated rewrites below.
+struct MapSearchRewrite {
+	unique_ptr<Expression> values;
+	unique_ptr<Expression> position;
+	unique_ptr<Expression> key_is_null;
+};
+
+static MapSearchRewrite BindMapSearch(FunctionBindExpressionInput &input) {
+	MapSearchRewrite rewrite;
+
+	vector<unique_ptr<Expression>> keys_children;
+	keys_children.push_back(input.children[0]->Copy());
+	auto keys = BindSiblingFunction(input, "map_keys", std::move(keys_children));
+
+	vector<unique_ptr<Expression>> values_children;
+	values_children.push_back(std::move(input.children[0]));
+	rewrite.values = BindSiblingFunction(input, "map_values", std::move(values_children));
+
+	rewrite.key_is_null = IsNull(input.children[1]->Copy());
+
+	vector<unique_ptr<Expression>> position_children;
+	position_children.push_back(std::move(keys));
+	position_children.push_back(std::move(input.children[1]));
+	rewrite.position = BindSiblingFunction(input, "list_position", std::move(position_children));
+
+	return rewrite;
+}
+
+static unique_ptr<Expression> BindMapExtractValueExpression(FunctionBindExpressionInput &input) {
+	// Untyped NULL maps are left to the direct implementation (they evaluate to NULL).
+	if (input.children[0]->GetReturnType().id() == LogicalTypeId::SQLNULL) {
+		return nullptr;
+	}
+	// Check both key types: template "K" unifies the map-key and search-key types, but the
+	// binder does not insert casts for types that only differ in their collation annotation,
+	// so the collation shows up on whichever side originally carried it.
+	if (!TypeHasCollation(input.children[1]->GetReturnType()) &&
+	    !TypeHasCollation(MapType::KeyType(input.children[0]->GetReturnType()))) {
+		return nullptr;
+	}
+
+	// Rebind a collated lookup through the collation-aware list search:
+	//
+	//   map_extract_value(m, k) == list_extract(map_values(m), list_position(map_keys(m), k))
+	//
+	// Map keys are unique, so the first match is the only match. NULL propagation is preserved:
+	// a NULL map yields NULL through map_keys/map_values, and a missing key yields a NULL
+	// position, which list_extract turns into NULL.
+	auto rewrite = BindMapSearch(input);
+
+	vector<unique_ptr<Expression>> extract_children;
+	extract_children.push_back(std::move(rewrite.values));
+	extract_children.push_back(std::move(rewrite.position));
+	auto extract = CastToResultType(input, BindSiblingFunction(input, "list_extract", std::move(extract_children)));
+
+	// A NULL search key never matches because map keys are never NULL; the guard keeps the
+	// rewrite exact even for maps carrying NULL keys, e.g. read from a file that skips
+	// validation.
+	const auto &result_type = input.bound_function.GetReturnType();
+	auto null_result = make_uniq<BoundConstantExpression>(Value(result_type));
+	return make_uniq<BoundCaseExpression>(std::move(rewrite.key_is_null), std::move(null_result), std::move(extract));
+}
+
+static unique_ptr<Expression> BindMapExtractExpression(FunctionBindExpressionInput &input) {
+	// Untyped NULL maps are left to the direct implementation (they evaluate to NULL).
+	if (input.children[0]->GetReturnType().id() == LogicalTypeId::SQLNULL) {
+		return nullptr;
+	}
+	// Check both key types: template "K" unifies the map-key and search-key types, but the
+	// binder does not insert casts for types that only differ in their collation annotation,
+	// so the collation shows up on whichever side originally carried it.
+	if (!TypeHasCollation(input.children[1]->GetReturnType()) &&
+	    !TypeHasCollation(MapType::KeyType(input.children[0]->GetReturnType()))) {
+		return nullptr;
+	}
+
+	// Rebind a collated lookup through the collation-aware list search:
+	//
+	//   map_extract(m, k) == CASE WHEN m IS NULL THEN NULL
+	//                             WHEN k IS NULL THEN []
+	//                             WHEN pos IS NULL THEN []
+	//                             ELSE [list_extract(map_values(m), pos)] END
+	//
+	//   with pos = list_position(map_keys(m), k)
+	//
+	// Map keys are unique, so the first match is the only match. The explicit NULL guards
+	// preserve the direct implementation's NULL handling: a NULL map yields NULL, and a NULL
+	// or missing search key yields an empty list (a NULL key can never match because map keys
+	// are never NULL).
+	const auto &result_type = input.bound_function.GetReturnType();
+	const auto &value_type = ListType::GetChildType(result_type);
+
+	auto map_is_null = IsNull(input.children[0]->Copy());
+	auto rewrite = BindMapSearch(input);
+	auto position_is_null = IsNull(rewrite.position->Copy());
+
+	vector<unique_ptr<Expression>> extract_children;
+	extract_children.push_back(std::move(rewrite.values));
+	extract_children.push_back(std::move(rewrite.position));
+	auto extract = BindSiblingFunction(input, "list_extract", std::move(extract_children));
+
+	vector<unique_ptr<Expression>> pack_children;
+	pack_children.push_back(std::move(extract));
+	auto packed = CastToResultType(input, BindSiblingFunction(input, "list_pack", std::move(pack_children)));
+
+	auto missing_result = make_uniq<BoundConstantExpression>(Value::LIST(value_type, {}));
+	auto found_case =
+	    make_uniq<BoundCaseExpression>(std::move(position_is_null), std::move(missing_result), std::move(packed));
+
+	auto null_key_result = make_uniq<BoundConstantExpression>(Value::LIST(value_type, {}));
+	auto key_case = make_uniq<BoundCaseExpression>(std::move(rewrite.key_is_null), std::move(null_key_result),
+	                                               std::move(found_case));
+
+	auto null_map_result = make_uniq<BoundConstantExpression>(Value(result_type));
+	return make_uniq<BoundCaseExpression>(std::move(map_is_null), std::move(null_map_result), std::move(key_case));
+}
+
 ScalarFunction MapExtractValueFun::GetFunction() {
 	auto key_type = LogicalType::TEMPLATE("K");
 	auto val_type = LogicalType::TEMPLATE("V");
 
 	ScalarFunction fun({LogicalType::MAP(key_type, val_type), key_type}, val_type, MapExtractValueFunc);
 	fun.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
+	fun.SetBindExpressionCallback(BindMapExtractValueExpression);
 	return fun;
 }
 
@@ -111,6 +277,7 @@ ScalarFunction MapExtractFun::GetFunction() {
 	ScalarFunction fun({LogicalType::MAP(key_type, val_type), key_type}, LogicalType::LIST(val_type),
 	                   MapExtractListFunc);
 	fun.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
+	fun.SetBindExpressionCallback(BindMapExtractExpression);
 	return fun;
 }
 

--- a/extension/core_functions/scalar/map/map_extract.cpp
+++ b/extension/core_functions/scalar/map/map_extract.cpp
@@ -143,7 +143,7 @@ static unique_ptr<Expression> CastToResultType(FunctionBindExpressionInput &inpu
 	return BoundCastExpression::AddCastToType(input.context, std::move(expression), result_type);
 }
 
-//! Binds map_values(map), list_position(map_keys(map), key) and friends for the collated rewrites below.
+//! Shared sub-expressions for collated map-search rewrites.
 struct MapSearchRewrite {
 	unique_ptr<Expression> values;
 	unique_ptr<Expression> position;
@@ -172,25 +172,17 @@ static MapSearchRewrite BindMapSearch(FunctionBindExpressionInput &input) {
 }
 
 static unique_ptr<Expression> BindMapExtractValueExpression(FunctionBindExpressionInput &input) {
-	// Untyped NULL maps are left to the direct implementation (they evaluate to NULL).
+	// Untyped NULL maps evaluate to NULL in the direct path.
 	if (input.children[0]->GetReturnType().id() == LogicalTypeId::SQLNULL) {
 		return nullptr;
 	}
-	// Check both key types: template "K" unifies the map-key and search-key types, but the
-	// binder does not insert casts for types that only differ in their collation annotation,
-	// so the collation shows up on whichever side originally carried it.
+	// Collation remains on whichever unified key type originally carried it.
 	if (!TypeHasCollation(input.children[1]->GetReturnType()) &&
 	    !TypeHasCollation(MapType::KeyType(input.children[0]->GetReturnType()))) {
 		return nullptr;
 	}
 
-	// Rebind a collated lookup through the collation-aware list search:
-	//
-	//   map_extract_value(m, k) == list_extract(map_values(m), list_position(map_keys(m), k))
-	//
-	// Map keys are unique, so the first match is the only match. NULL propagation is preserved:
-	// a NULL map yields NULL through map_keys/map_values, and a missing key yields a NULL
-	// position, which list_extract turns into NULL.
+	// Rebind through list_extract(map_values(m), list_position(map_keys(m), k)).
 	auto rewrite = BindMapSearch(input);
 
 	vector<unique_ptr<Expression>> extract_children;
@@ -198,40 +190,25 @@ static unique_ptr<Expression> BindMapExtractValueExpression(FunctionBindExpressi
 	extract_children.push_back(std::move(rewrite.position));
 	auto extract = CastToResultType(input, BindSiblingFunction(input, "list_extract", std::move(extract_children)));
 
-	// A NULL search key never matches because map keys are never NULL; the guard keeps the
-	// rewrite exact even for maps carrying NULL keys, e.g. read from a file that skips
-	// validation.
+		// list_position matches NULL elements; the direct map search does not, so
+		// the key_is_null guard preserves behaviour for NULL keys in unvalidated maps.
 	const auto &result_type = input.bound_function.GetReturnType();
 	auto null_result = make_uniq<BoundConstantExpression>(Value(result_type));
 	return make_uniq<BoundCaseExpression>(std::move(rewrite.key_is_null), std::move(null_result), std::move(extract));
 }
 
 static unique_ptr<Expression> BindMapExtractExpression(FunctionBindExpressionInput &input) {
-	// Untyped NULL maps are left to the direct implementation (they evaluate to NULL).
+	// Untyped NULL maps evaluate to NULL in the direct path.
 	if (input.children[0]->GetReturnType().id() == LogicalTypeId::SQLNULL) {
 		return nullptr;
 	}
-	// Check both key types: template "K" unifies the map-key and search-key types, but the
-	// binder does not insert casts for types that only differ in their collation annotation,
-	// so the collation shows up on whichever side originally carried it.
+	// Collation remains on whichever unified key type originally carried it.
 	if (!TypeHasCollation(input.children[1]->GetReturnType()) &&
 	    !TypeHasCollation(MapType::KeyType(input.children[0]->GetReturnType()))) {
 		return nullptr;
 	}
 
-	// Rebind a collated lookup through the collation-aware list search:
-	//
-	//   map_extract(m, k) == CASE WHEN m IS NULL THEN NULL
-	//                             WHEN k IS NULL THEN []
-	//                             WHEN pos IS NULL THEN []
-	//                             ELSE [list_extract(map_values(m), pos)] END
-	//
-	//   with pos = list_position(map_keys(m), k)
-	//
-	// Map keys are unique, so the first match is the only match. The explicit NULL guards
-	// preserve the direct implementation's NULL handling: a NULL map yields NULL, and a NULL
-	// or missing search key yields an empty list (a NULL key can never match because map keys
-	// are never NULL).
+	// Rebind through a CASE over list_extract(map_values(m), list_position(map_keys(m), k)).
 	const auto &result_type = input.bound_function.GetReturnType();
 	const auto &value_type = ListType::GetChildType(result_type);
 
@@ -252,6 +229,7 @@ static unique_ptr<Expression> BindMapExtractExpression(FunctionBindExpressionInp
 	auto found_case =
 	    make_uniq<BoundCaseExpression>(std::move(position_is_null), std::move(missing_result), std::move(packed));
 
+		// list_position matches NULL elements; the direct map search does not.
 	auto null_key_result = make_uniq<BoundConstantExpression>(Value::LIST(value_type, {}));
 	auto key_case = make_uniq<BoundCaseExpression>(std::move(rewrite.key_is_null), std::move(null_key_result),
 	                                               std::move(found_case));

--- a/extension/core_functions/scalar/map/map_extract.cpp
+++ b/extension/core_functions/scalar/map/map_extract.cpp
@@ -132,7 +132,7 @@ static unique_ptr<Expression> BindSiblingFunction(FunctionBindExpressionInput &i
 static unique_ptr<Expression> IsNull(unique_ptr<Expression> expression) {
 	auto result = make_uniq<BoundOperatorExpression>(ExpressionType::OPERATOR_IS_NULL, LogicalType::BOOLEAN);
 	result->GetChildrenMutable().push_back(std::move(expression));
-	return result;
+	return std::move(result);
 }
 
 static unique_ptr<Expression> CastToResultType(FunctionBindExpressionInput &input, unique_ptr<Expression> expression) {

--- a/src/function/scalar/map/map_contains.cpp
+++ b/src/function/scalar/map/map_contains.cpp
@@ -32,6 +32,9 @@ static bool TypeHasCollation(const LogicalType &type) {
 }
 
 static unique_ptr<Expression> BindMapContainsExpression(FunctionBindExpressionInput &input) {
+	// Check both key types: template "K" unifies the map-key and search-key types, but the
+	// binder does not insert casts for types that only differ in their collation annotation,
+	// so the collation shows up on whichever side originally carried it.
 	auto &key_type = input.children[1]->GetReturnType();
 	auto &map_key_type = MapType::KeyType(input.children[0]->GetReturnType());
 	if (!TypeHasCollation(key_type) && !TypeHasCollation(map_key_type)) {

--- a/src/function/scalar/map/map_contains.cpp
+++ b/src/function/scalar/map/map_contains.cpp
@@ -1,5 +1,8 @@
 #include "duckdb/common/vector/map_vector.hpp"
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/catalog/catalog_entry/scalar_function_catalog_entry.hpp"
 #include "duckdb/function/scalar/list/contains_or_position.hpp"
+#include "duckdb/function/function_binder.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/function/scalar/map_functions.hpp"
 
@@ -15,12 +18,49 @@ static void MapContainsFunction(DataChunk &input, ExpressionState &state, Vector
 	ListSearchOp<bool>(map_vec, key_vec, arg_vec, result, count);
 }
 
+static unique_ptr<Expression> BindMapContainsExpression(FunctionBindExpressionInput &input) {
+	auto &key_type = input.children[1]->GetReturnType();
+	auto &map_key_type = MapType::KeyType(input.children[0]->GetReturnType());
+	auto key_collation = key_type.id() == LogicalTypeId::VARCHAR ? StringType::GetCollation(key_type) : string();
+	auto map_collation =
+	    map_key_type.id() == LogicalTypeId::VARCHAR ? StringType::GetCollation(map_key_type) : string();
+	if (key_collation.empty() && map_collation.empty()) {
+		return nullptr;
+	}
+
+	// Rebind collated map searches through the existing collation-aware list search.
+	auto &catalog = Catalog::GetSystemCatalog(input.context);
+	auto &map_keys = catalog.GetEntry<ScalarFunctionCatalogEntry>(
+	    input.context, QualifiedName(catalog.GetName(), Identifier::DefaultSchema(), "map_keys"));
+	auto &list_contains = catalog.GetEntry<ScalarFunctionCatalogEntry>(
+	    input.context, QualifiedName(catalog.GetName(), Identifier::DefaultSchema(), "list_contains"));
+
+	FunctionBinder function_binder(input.context);
+	ErrorData error;
+	vector<unique_ptr<Expression>> map_children;
+	map_children.push_back(std::move(input.children[0]));
+	auto keys = function_binder.BindScalarFunction(map_keys, std::move(map_children), error);
+	if (!keys) {
+		error.Throw();
+	}
+
+	vector<unique_ptr<Expression>> contains_children;
+	contains_children.push_back(std::move(keys));
+	contains_children.push_back(std::move(input.children[1]));
+	auto result = function_binder.BindScalarFunction(list_contains, std::move(contains_children), error);
+	if (!result) {
+		error.Throw();
+	}
+	return result;
+}
+
 ScalarFunction MapContainsFun::GetFunction() {
 	auto key_type = LogicalType::TEMPLATE("K");
 	auto val_type = LogicalType::TEMPLATE("V");
 
 	ScalarFunction fun("map_contains", {LogicalType::MAP(key_type, val_type), key_type}, LogicalType::BOOLEAN,
 	                   MapContainsFunction);
+	fun.SetBindExpressionCallback(BindMapContainsExpression);
 	return fun;
 }
 

--- a/src/function/scalar/map/map_contains.cpp
+++ b/src/function/scalar/map/map_contains.cpp
@@ -18,13 +18,23 @@ static void MapContainsFunction(DataChunk &input, ExpressionState &state, Vector
 	ListSearchOp<bool>(map_vec, key_vec, arg_vec, result, count);
 }
 
+static bool TypeHasCollation(const LogicalType &type) {
+	switch (type.id()) {
+	case LogicalTypeId::VARCHAR:
+		return !type.HasAlias() && !StringType::GetCollation(type).empty();
+	case LogicalTypeId::LIST:
+		return TypeHasCollation(ListType::GetChildType(type));
+	case LogicalTypeId::ARRAY:
+		return TypeHasCollation(ArrayType::GetChildType(type));
+	default:
+		return false;
+	}
+}
+
 static unique_ptr<Expression> BindMapContainsExpression(FunctionBindExpressionInput &input) {
 	auto &key_type = input.children[1]->GetReturnType();
 	auto &map_key_type = MapType::KeyType(input.children[0]->GetReturnType());
-	auto key_collation = key_type.id() == LogicalTypeId::VARCHAR ? StringType::GetCollation(key_type) : string();
-	auto map_collation =
-	    map_key_type.id() == LogicalTypeId::VARCHAR ? StringType::GetCollation(map_key_type) : string();
-	if (key_collation.empty() && map_collation.empty()) {
+	if (!TypeHasCollation(key_type) && !TypeHasCollation(map_key_type)) {
 		return nullptr;
 	}
 

--- a/src/function/scalar/map/map_contains.cpp
+++ b/src/function/scalar/map/map_contains.cpp
@@ -32,16 +32,14 @@ static bool TypeHasCollation(const LogicalType &type) {
 }
 
 static unique_ptr<Expression> BindMapContainsExpression(FunctionBindExpressionInput &input) {
-	// Check both key types: template "K" unifies the map-key and search-key types, but the
-	// binder does not insert casts for types that only differ in their collation annotation,
-	// so the collation shows up on whichever side originally carried it.
+	// Collation remains on whichever unified key type originally carried it.
 	auto &key_type = input.children[1]->GetReturnType();
 	auto &map_key_type = MapType::KeyType(input.children[0]->GetReturnType());
 	if (!TypeHasCollation(key_type) && !TypeHasCollation(map_key_type)) {
 		return nullptr;
 	}
 
-	// Rebind collated map searches through the existing collation-aware list search.
+	// Rebind through list_contains(map_keys(map), key), which already handles collations.
 	auto &catalog = Catalog::GetSystemCatalog(input.context);
 	auto &map_keys = catalog.GetEntry<ScalarFunctionCatalogEntry>(
 	    input.context, QualifiedName(catalog.GetName(), Identifier::DefaultSchema(), "map_keys"));

--- a/test/issues/general/test_24328.test
+++ b/test/issues/general/test_24328.test
@@ -13,6 +13,19 @@ SELECT map_contains(MAP {'Apple': 1}, 'apple' COLLATE NOCASE),
 ----
 true	true	true	false
 
+query I
+SELECT map_contains(map([['Apple']], [1]), ['apple' COLLATE NOCASE]);
+----
+true
+
+statement error
+SELECT map_contains(
+    map([['Résumé' COLLATE NOACCENT]], [1]),
+    ['résumé' COLLATE NOCASE]
+);
+----
+Cannot combine types with different collation!
+
 statement ok
 SET debug_verify_serializer = false;
 
@@ -54,3 +67,12 @@ statement error
 SELECT map_contains(map(['Résumé' COLLATE NOACCENT], [1]), 'résumé' COLLATE NOCASE);
 ----
 Cannot combine types with different collation!
+
+# Collation propagation descends through nested LIST/ARRAY key types.
+query IIII
+SELECT map_contains(map([['Apple' COLLATE NOCASE]], [1]), ['apple']),
+       map_contains(map([[['Apple' COLLATE NOCASE]]], [1]), [['apple']]),
+       map_contains(map([array_value('Apple' COLLATE NOCASE)], [1]), array_value('apple')),
+       map_contains(map([['Apple' COLLATE NOCASE]], [1]), ['pear']);
+----
+true	true	true	false

--- a/test/issues/general/test_24328.test
+++ b/test/issues/general/test_24328.test
@@ -1,0 +1,56 @@
+# name: test/issues/general/test_24328.test
+# description: map_contains respects collations on map keys
+# group: [general]
+
+statement ok
+SET debug_verify_serializer = true;
+
+query IIII
+SELECT map_contains(MAP {'Apple': 1}, 'apple' COLLATE NOCASE),
+       contains(MAP {'Apple': 1}, 'apple' COLLATE NOCASE),
+       map_contains(map(['Apple' COLLATE NOCASE], [1]), 'apple'),
+       map_contains(MAP {'Apple': 1}, 'banana' COLLATE NOCASE);
+----
+true	true	true	false
+
+statement ok
+SET debug_verify_serializer = false;
+
+query I
+WITH data(m, key) AS (
+    VALUES (MAP {'Apple': 1}, 'APPLE'),
+           (MAP {'Banana': 2}, 'banana'),
+           (MAP {'Cherry': 3}, 'pear')
+)
+SELECT map_contains(m, key COLLATE NOCASE)
+FROM data;
+----
+true
+true
+false
+
+query II
+SELECT map_contains(MAP {'hello': 1}, 'héllo' COLLATE NOACCENT),
+       map_contains(MAP {'Hello': 1}, 'HÉLLO' COLLATE NOCASE.NOACCENT);
+----
+true	true
+
+statement ok
+CREATE TABLE collated_maps AS SELECT map(['Apple' COLLATE NOCASE], [1]) AS m;
+
+query I
+SELECT map_contains(m, 'apple')
+FROM collated_maps;
+----
+true
+
+query II
+SELECT map_contains(NULL::MAP(VARCHAR, INTEGER), 'apple' COLLATE NOCASE),
+       map_contains(MAP {'Apple': 1}, NULL::VARCHAR COLLATE NOCASE);
+----
+NULL	NULL
+
+statement error
+SELECT map_contains(map(['Résumé' COLLATE NOACCENT], [1]), 'résumé' COLLATE NOCASE);
+----
+Cannot combine types with different collation!

--- a/test/issues/general/test_24328.test
+++ b/test/issues/general/test_24328.test
@@ -26,9 +26,6 @@ SELECT map_contains(
 ----
 Cannot combine types with different collation!
 
-statement ok
-SET debug_verify_serializer = false;
-
 query I
 WITH data(m, key) AS (
     VALUES (MAP {'Apple': 1}, 'APPLE'),

--- a/test/sql/types/nested/map/test_map_extract_collation.test
+++ b/test/sql/types/nested/map/test_map_extract_collation.test
@@ -1,0 +1,119 @@
+# name: test/sql/types/nested/map/test_map_extract_collation.test
+# description: map_extract/map_extract_value respect collations on map keys
+# group: [map]
+
+statement ok
+SET debug_verify_serializer = true;
+
+# Collated search key against an uncollated map. element_at is an alias of map_extract.
+query III
+SELECT map_extract(MAP {'Apple': 1}, 'apple' COLLATE NOCASE),
+       element_at(MAP {'Apple': 1}, 'apple' COLLATE NOCASE),
+       map_extract(MAP {'Apple': 1}, 'pear' COLLATE NOCASE);
+----
+[1]	[1]	[]
+
+# map_extract_value and the [] subscript.
+query III
+SELECT map_extract_value(MAP {'Apple': 1}, 'apple' COLLATE NOCASE),
+       (MAP {'Apple': 1})['apple' COLLATE NOCASE],
+       map_extract_value(MAP {'Apple': 1}, 'pear' COLLATE NOCASE);
+----
+1	1	NULL
+
+# Collated map-key type against an uncollated search key.
+query II
+SELECT map_extract(map(['Apple' COLLATE NOCASE], [1]), 'apple'),
+       map_extract_value(map(['Apple' COLLATE NOCASE], [1]), 'apple');
+----
+[1]	1
+
+# Row-varying map and search-key inputs.
+query II
+WITH data(m, key) AS (
+    VALUES (MAP {'Apple': 1}, 'APPLE'),
+           (MAP {'Banana': 2}, 'banana'),
+           (MAP {'Cherry': 3}, 'pear')
+)
+SELECT map_extract(m, key COLLATE NOCASE), map_extract_value(m, key COLLATE NOCASE)
+FROM data;
+----
+[1]	1
+[2]	2
+[]	NULL
+
+# NULL propagation: a NULL map yields NULL, a NULL search key never matches.
+query IIII
+SELECT map_extract(NULL::MAP(VARCHAR, INTEGER), 'apple' COLLATE NOCASE),
+       map_extract(MAP {'Apple': 1}, NULL::VARCHAR COLLATE NOCASE),
+       map_extract_value(NULL::MAP(VARCHAR, INTEGER), 'apple' COLLATE NOCASE),
+       map_extract_value(MAP {'Apple': 1}, NULL::VARCHAR COLLATE NOCASE);
+----
+NULL	[]	NULL	NULL
+
+# Untyped NULL maps.
+query II
+SELECT map_extract(NULL, 'apple' COLLATE NOCASE),
+       map_extract_value(NULL, 'apple' COLLATE NOCASE);
+----
+NULL	NULL
+
+# A matched NULL value is [NULL]/NULL, distinct from a missing key.
+query II
+SELECT map_extract(map(['Apple' COLLATE NOCASE], [NULL::INTEGER]), 'apple'),
+       map_extract_value(map(['Apple' COLLATE NOCASE], [NULL::INTEGER]), 'apple');
+----
+[NULL]	NULL
+
+# NOACCENT and combined collations.
+query IIII
+SELECT map_extract(MAP {'hello': 1}, 'héllo' COLLATE NOACCENT),
+       map_extract_value(MAP {'hello': 1}, 'héllo' COLLATE NOACCENT),
+       map_extract(MAP {'Hello': 1}, 'HÉLLO' COLLATE NOCASE.NOACCENT),
+       map_extract_value(MAP {'Hello': 1}, 'HÉLLO' COLLATE NOCASE.NOACCENT);
+----
+[1]	1	[1]	1
+
+# Collations nested through LIST, doubly nested LIST, and ARRAY key types.
+query IIII
+SELECT map_extract(map([['Apple' COLLATE NOCASE]], [1]), ['apple']),
+       map_extract(map([[['Apple' COLLATE NOCASE]]], [1]), [['apple']]),
+       map_extract(map([array_value('Apple' COLLATE NOCASE)], [1]), array_value('apple')),
+       map_extract(map([['Apple' COLLATE NOCASE]], [1]), ['pear']);
+----
+[1]	[1]	[1]	[]
+
+# Collated VARCHAR values keep working.
+query II
+SELECT map_extract(MAP {'Apple': 'x'}, 'apple' COLLATE NOCASE),
+       map_extract_value(MAP {'Apple': 'x'}, 'apple' COLLATE NOCASE);
+----
+[x]	x
+
+# Collated map-key column.
+statement ok
+CREATE TABLE collated_extracts AS SELECT map(['Apple' COLLATE NOCASE], [1]) AS m;
+
+query II
+SELECT map_extract(m, 'apple'), map_extract_value(m, 'apple')
+FROM collated_extracts;
+----
+[1]	1
+
+# Uncollated lookups stay case-sensitive.
+query II
+SELECT map_extract(MAP {'Apple': 1}, 'apple'),
+       map_extract_value(MAP {'Apple': 1}, 'apple');
+----
+[]	NULL
+
+# Incompatible collations are rejected by the template unification, as before.
+statement error
+SELECT map_extract(map(['Résumé' COLLATE NOACCENT], [1]), 'résumé' COLLATE NOCASE);
+----
+Cannot combine types with different collation!
+
+statement error
+SELECT map_extract_value(map([['Résumé' COLLATE NOACCENT]], [1]), ['résumé' COLLATE NOCASE]);
+----
+Cannot combine types with different collation!


### PR DESCRIPTION
Fixes #24328.

`map_contains`, `map_extract`, and `map_extract_value` (with its `map[key]`
subscript and `element_at` alias) search the map's key vector with the same
primitive as `list_contains`, but their bound functions ignore collations. A
case-insensitive search can return `false`/`[]`/`NULL` where the equivalent
search through `map_keys` finds the key.

The generic binder's `PUSH_COMBINABLE_COLLATIONS` policy descends through LIST
and ARRAY arguments but not MAP keys, so merely selecting it is not enough.
When either the map-key type or the search key carries a collation (including
collations nested through LIST or ARRAY), the fix rebinds through the existing
collation-aware list functions: `map_contains` becomes `list_contains(map_keys(map),
key)`, `map_extract_value` becomes `list_extract(map_values(m),
list_position(map_keys(m), k))`, and `map_extract` the equivalent CASE.
Multiple collation-equivalent keys match the first, as in the direct path.
Uncollated calls retain the direct implementations.

Two new regression tests cover `NOCASE`, `NOACCENT`, combined collations,
nested collations through LIST/ARRAY, NULL propagation, row-varying inputs,
and incompatible collations (which now raise the expected binder error instead
of silently running an uncollated comparison).