### PR TITLE
Resolve partition columns for non-pushdown table functions

### DIFF
--- a/src/execution/physical_plan/plan_aggregate.cpp
+++ b/src/execution/physical_plan/plan_aggregate.cpp
@@ -96,16 +96,26 @@ bool PhysicalPlanGenerator::HasSingleValuePartitions(ClientContext &context,
 		return false;
 	}
 	// get the base columns by projecting over the projection_ids/column_ids
-	if (!table_scan.projection_ids.empty()) {
-		for (auto &partition_col : partition_columns) {
-			partition_col = table_scan.projection_ids[partition_col];
-		}
-	}
 	vector<column_t> base_columns;
-	for (const auto &partition_idx : partition_columns) {
-		auto col_idx = partition_idx;
-		col_idx = table_scan.column_ids[col_idx].GetPrimaryIndex();
-		base_columns.push_back(col_idx);
+	if (!table_scan.function.projection_pushdown) {
+		// Non-pushdown scans output every base column in order. Any projection above the scan already maps references
+		// into that base-column space.
+		base_columns = partition_columns;
+	} else {
+		if (!table_scan.projection_ids.empty()) {
+			for (auto &partition_col : partition_columns) {
+				if (partition_col >= table_scan.projection_ids.size()) {
+					return false;
+				}
+				partition_col = table_scan.projection_ids[partition_col];
+			}
+		}
+		for (const auto &partition_idx : partition_columns) {
+			if (partition_idx >= table_scan.column_ids.size()) {
+				return false;
+			}
+			base_columns.push_back(table_scan.column_ids[partition_idx].GetPrimaryIndex());
+		}
 	}
 	// check if the source operator is partitioned by the grouping columns
 	TableFunctionPartitionInput input(table_scan.bind_data.get(), base_columns);

--- a/test/sql/function/table/CMakeLists.txt
+++ b/test/sql/function/table/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library_unity(test_table_function OBJECT table_in_out.cpp
-                  table_bind_replace.cpp)
+                  table_bind_replace.cpp table_partition_info.cpp)
 set(UNITTEST_OBJECT_FILES
     ${UNITTEST_OBJECT_FILES} $<TARGET_OBJECTS:test_table_function>
     PARENT_SCOPE)

--- a/test/sql/function/table/table_partition_info.cpp
+++ b/test/sql/function/table/table_partition_info.cpp
@@ -1,0 +1,76 @@
+#include "catch.hpp"
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/function/partition_stats.hpp"
+#include "duckdb/parser/parsed_data/create_table_function_info.hpp"
+#include "test_helpers.hpp"
+
+using namespace duckdb;
+
+namespace {
+
+struct NonPushdownPartitionFunction {
+	struct BindData : public TableFunctionData {
+		vector<column_t> expected_partition_ids;
+	};
+
+	static unique_ptr<FunctionData> Bind(ClientContext &, TableFunctionBindInput &input,
+	                                     vector<LogicalType> &return_types, vector<string> &names) {
+		return_types = {LogicalType::VARCHAR, LogicalType::BIGINT, LogicalType::DOUBLE};
+		names = {"region", "year", "value"};
+		auto result = make_uniq<BindData>();
+		result->expected_partition_ids.push_back(UnsafeNumericCast<column_t>(input.inputs[0].GetValue<int64_t>()));
+		auto second_id = input.inputs[1].GetValue<int64_t>();
+		if (second_id >= 0) {
+			result->expected_partition_ids.push_back(UnsafeNumericCast<column_t>(second_id));
+		}
+		return std::move(result);
+	}
+
+	static void Scan(ClientContext &, TableFunctionInput &, DataChunk &output) {
+		output.SetChildCardinality(0);
+	}
+
+	static TablePartitionInfo GetPartitionInfo(ClientContext &, TableFunctionPartitionInput &input) {
+		auto &bind_data = input.bind_data->Cast<BindData>();
+		if (input.partition_ids != bind_data.expected_partition_ids) {
+			throw InternalException("Partition columns did not resolve to the expected base columns");
+		}
+		return TablePartitionInfo::SINGLE_VALUE_PARTITIONS;
+	}
+
+	static void Register(Connection &con) {
+		con.BeginTransaction();
+		auto &catalog = Catalog::GetSystemCatalog(*con.context);
+		TableFunction function("non_pushdown_partitions", {LogicalType::BIGINT, LogicalType::BIGINT}, Scan, Bind);
+		function.projection_pushdown = false;
+		function.get_partition_info = GetPartitionInfo;
+		CreateTableFunctionInfo info(function);
+		catalog.CreateTableFunction(*con.context, info);
+		con.Commit();
+	}
+};
+
+} // namespace
+
+TEST_CASE("Resolve partition columns for table functions without projection pushdown", "[tablefunction]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	NonPushdownPartitionFunction::Register(con);
+
+	auto result = con.Query("EXPLAIN SELECT year, COUNT(*) FROM non_pushdown_partitions(1, -1) GROUP BY year");
+	REQUIRE(!result->HasError());
+	REQUIRE(StringUtil::Contains(result->ToString(), "Partitioned Aggregate"));
+
+	result = con.Query("EXPLAIN SELECT year, COUNT(*) FROM (SELECT year FROM non_pushdown_partitions(1, -1) "
+	                   "WHERE region = 'x') GROUP BY year");
+	REQUIRE(!result->HasError());
+	REQUIRE(StringUtil::Contains(result->ToString(), "Partitioned Aggregate"));
+
+	result = con.Query("EXPLAIN SELECT year, region, COUNT(*) FROM non_pushdown_partitions(1, 0) "
+	                   "GROUP BY year, region");
+	REQUIRE(!result->HasError());
+	REQUIRE(StringUtil::Contains(result->ToString(), "Partitioned Aggregate"));
+
+	result = con.Query("EXPLAIN SELECT COUNT(*) OVER (PARTITION BY year) FROM non_pushdown_partitions(1, -1)");
+	REQUIRE(!result->HasError());
+}

--- a/test/sql/function/table/table_partition_info.cpp
+++ b/test/sql/function/table/table_partition_info.cpp
@@ -14,7 +14,7 @@ struct NonPushdownPartitionFunction {
 	};
 
 	static unique_ptr<FunctionData> Bind(ClientContext &, TableFunctionBindInput &input,
-	                                     vector<LogicalType> &return_types, vector<string> &names) {
+	                                     vector<LogicalType> &return_types, vector<Identifier> &names) {
 		return_types = {LogicalType::VARCHAR, LogicalType::BIGINT, LogicalType::DOUBLE};
 		names = {"region", "year", "value"};
 		auto result = make_uniq<BindData>();


### PR DESCRIPTION
`PhysicalPlanGenerator::HasSingleValuePartitions` walks projections and filters to map aggregate and window partition expressions to a table scan, mapping scan output positions through `projection_ids` and `column_ids` for functions with projection pushdown. A function with `projection_pushdown = false` has a different physical shape: the scan outputs every base column in schema order, and `plan_get.cpp` adds a projection whose bound references already contain base-column indices. The helper nevertheless indexed the narrowed `column_ids` with those base indices a second time, silently querying partition information for the wrong column or throwing an internal out-of-range exception during planning.

The fix uses the already-resolved indices directly for non-pushdown scans, retains the existing mapping for pushdown scans, and adds defensive bounds checks before indexing the projection vectors.

A new C++ table function deliberately disables projection pushdown and makes its partition callback reject any column mapping other than the expected base indices; its regression covers a narrowed `GROUP BY`, an intervening filter and projection, reordered two-column grouping, and the window-planner caller. Fixes #24327.
