### PR TITLE
Preserve regex semantics for collated strings

### DIFF
--- a/src/optimizer/rule/regex_optimizations.cpp
+++ b/src/optimizer/rule/regex_optimizations.cpp
@@ -154,6 +154,12 @@ unique_ptr<Expression> RegexOptimizationRule::Apply(LogicalOperator &op, vector<
 	auto &root = bindings[0].get().Cast<BoundFunctionExpression>();
 	auto &constant_expr = bindings[2].get().Cast<BoundConstantExpression>();
 	D_ASSERT(root.GetChildrenMutable().size() == 2 || root.GetChildrenMutable().size() == 3);
+	for (idx_t i = 0; i < 2; i++) {
+		const auto &type = root.GetChildren()[i]->GetReturnType();
+		if (type.id() == LogicalTypeId::VARCHAR && !StringType::GetCollation(type).empty()) {
+			return nullptr;
+		}
+	}
 	auto regexp_bind_data = root.BindInfo().get()->Cast<RegexpMatchesBindData>();
 
 	auto constant_value = ExpressionExecutor::EvaluateScalar(GetContext(), constant_expr);

--- a/test/issues/general/test_24245.test
+++ b/test/issues/general/test_24245.test
@@ -1,0 +1,117 @@
+# name: test/issues/general/test_24245.test
+# description: Regex optimizations preserve collation-independent matching
+# group: [general]
+
+statement ok
+PRAGMA explain_output = OPTIMIZED_ONLY
+
+statement ok
+CREATE TABLE nocase_strings(s VARCHAR COLLATE NOCASE)
+
+statement ok
+INSERT INTO nocase_strings VALUES ('Abc'), ('abc'), ('xA'), ('xa'), ('Axxc')
+
+query I
+SELECT s
+FROM nocase_strings
+WHERE regexp_matches(s, 'A')
+ORDER BY s, s COLLATE C
+----
+Abc
+Axxc
+xA
+
+query I
+SELECT string_agg(s, ',' ORDER BY s COLLATE C)
+FROM nocase_strings
+WHERE regexp_matches(s, 'A', 'l')
+----
+Abc,Axxc,xA
+
+# Regex case-insensitivity remains controlled by regex options, not SQL collations
+query I
+SELECT string_agg(s, ',' ORDER BY s COLLATE C)
+FROM nocase_strings
+WHERE regexp_matches(s, 'a', 'i')
+----
+Abc,Axxc,abc,xA,xa
+
+query II
+EXPLAIN SELECT s FROM nocase_strings WHERE regexp_matches(s, 'A')
+----
+logical_opt	<REGEX>:.*regexp_matches\(s, 'A'\).*
+
+# LIKE-compatible rewrites must also retain the regex's case-sensitive semantics
+query I
+SELECT s
+FROM nocase_strings
+WHERE regexp_matches(s, 'A.*c', 's')
+ORDER BY s COLLATE C
+----
+Abc
+Axxc
+
+# Subsequent LIKE rewrites to prefix, suffix, equality, and contains are unsafe too
+query I
+SELECT string_agg(s, ',' ORDER BY s COLLATE C)
+FROM nocase_strings
+WHERE regexp_matches(s, '^A')
+----
+Abc,Axxc
+
+query I
+SELECT string_agg(s, ',' ORDER BY s COLLATE C)
+FROM nocase_strings
+WHERE regexp_matches(s, 'A$')
+----
+xA
+
+query I
+SELECT string_agg(s, ',' ORDER BY s COLLATE C)
+FROM nocase_strings
+WHERE regexp_matches(s, '^Abc$')
+----
+Abc
+
+query I
+SELECT string_agg(s, ',' ORDER BY s COLLATE C)
+FROM nocase_strings
+WHERE regexp_matches(s, '.*A.*', 's')
+----
+Abc,Axxc,xA
+
+# A collation attached to the pattern is likewise irrelevant to regex matching
+statement ok
+CREATE TABLE plain_strings(s VARCHAR)
+
+statement ok
+INSERT INTO plain_strings VALUES ('A'), ('a'), ('É'), ('é'), ('e')
+
+query I
+SELECT s
+FROM plain_strings
+WHERE regexp_matches(s, 'A' COLLATE NOCASE)
+ORDER BY s
+----
+A
+
+statement ok
+CREATE TABLE noaccent_strings(s VARCHAR COLLATE NOACCENT)
+
+statement ok
+INSERT INTO noaccent_strings VALUES ('resume'), ('résumé'), ('é'), ('e')
+
+query I
+SELECT s
+FROM noaccent_strings
+WHERE regexp_matches(s, 'é')
+ORDER BY s COLLATE C
+----
+résumé
+é
+
+# Keep optimizing ordinary uncollated inputs
+query II
+EXPLAIN SELECT s FROM plain_strings WHERE regexp_matches(s, 'A')
+----
+logical_opt	<REGEX>:.*contains\(s, 'A'\).*


### PR DESCRIPTION

Closes #24245.

`regexp_matches` is independent of SQL string collations, but the expression
rewriter replaced simple regular expressions with collation-aware operations
such as `contains`, `prefix`, `suffix`, and equality. On a `NOCASE` input the
replacement could therefore return a different answer from the original
regular expression. A collation on the pattern caused the same problem.
Skipping only the first rewrite to `LIKE` is insufficient, because later LIKE
optimisation again produces collation-aware operations.

The optimiser now conservatively skips regex optimisation when either string
argument has an explicit collation. Ordinary uncollated calls retain their
existing optimisation.

Negative control: with the guard removed, the new regression fails immediately
(a query expecting `Abc`, `Axxc`, and `xA` returns no rows). With the fix the
focused suite passes 25 assertions, and adjacent optimiser suites pass
(82 regex-optimiser, 15 coverage, and 18 regex-to-LIKE assertions). Tests
cover literal/LIKE-compatible regexes, downstream prefix, suffix, equality and
contains rewrites, regex flags, collated patterns, `NOCASE`, `NOACCENT`, and
preservation of the ordinary uncollated optimisation. Rebased onto current
`main` without conflicts.

Verified: `test/issues/general/test_24245.test` fails on main `aedb56e5c1`
(`regexp_matches(s, 'A')` on a `NOCASE` column returns 0 rows instead of
`Abc`, `Axxc`, `xA`), passes with this branch (25 assertions).
