### PR TITLE
Reject trailing root geometries in WKB

### DIFF
--- a/src/common/types/geometry.cpp
+++ b/src/common/types/geometry.cpp
@@ -895,12 +895,16 @@ struct WKBAnalysis {
 	bool any_m = false;
 	bool any_unknown = false;
 	bool any_ewkb = false;
+	bool has_trailing_data = false;
 };
 
 WKBAnalysis AnalyzeWKB(BlobReader &reader) {
 	WKBAnalysis result;
+	// Collection children are complete WKB objects embedded in the root object.
+	uint64_t geometries_remaining = 1;
 
-	while (!reader.IsAtEnd()) {
+	while (geometries_remaining > 0) {
+		geometries_remaining--;
 		const auto le = reader.Read<uint8_t>() == 1;
 
 		const auto meta = reader.Read<uint32_t>(le);
@@ -957,7 +961,8 @@ WKBAnalysis AnalyzeWKB(BlobReader &reader) {
 		case 5:   // MULTILINESTRING
 		case 6:   // MULTIPOLYGON
 		case 7: { // GEOMETRYCOLLECTION
-			reader.Skip(sizeof(uint32_t));
+			const auto part_count = reader.Read<uint32_t>(le);
+			geometries_remaining += part_count;
 			result.size += sizeof(uint32_t); // part count
 		} break;
 		default: {
@@ -966,6 +971,7 @@ WKBAnalysis AnalyzeWKB(BlobReader &reader) {
 		}
 		}
 	}
+	result.has_trailing_data = !reader.IsAtEnd();
 	return result;
 }
 
@@ -1052,6 +1058,12 @@ bool Geometry::FromBinary(const string_t &wkb, string_t &result, StringHeap &hea
 	BlobReader reader(wkb.GetData(), static_cast<uint32_t>(wkb.GetSize()));
 
 	const auto analysis = AnalyzeWKB(reader);
+	if (analysis.has_trailing_data) {
+		if (strict) {
+			throw InvalidInputException("Unexpected trailing data at position %zu", reader.GetPosition());
+		}
+		return false;
+	}
 	if (analysis.any_unknown) {
 		if (strict) {
 			throw InvalidInputException("Unsupported geometry type in WKB");

--- a/src/common/types/geometry.cpp
+++ b/src/common/types/geometry.cpp
@@ -900,6 +900,9 @@ struct WKBAnalysis {
 
 WKBAnalysis AnalyzeWKB(BlobReader &reader) {
 	WKBAnalysis result;
+	if (reader.IsAtEnd()) {
+		return result;
+	}
 	// Collection children are complete WKB objects embedded in the root object.
 	uint64_t geometries_remaining = 1;
 

--- a/src/common/types/geometry.cpp
+++ b/src/common/types/geometry.cpp
@@ -1057,7 +1057,17 @@ constexpr const idx_t Geometry::MAX_RECURSION_DEPTH;
 bool Geometry::FromBinary(const string_t &wkb, string_t &result, StringHeap &heap, bool strict) {
 	BlobReader reader(wkb.GetData(), static_cast<uint32_t>(wkb.GetSize()));
 
-	const auto analysis = AnalyzeWKB(reader);
+	WKBAnalysis analysis;
+	try {
+		analysis = AnalyzeWKB(reader);
+	} catch (InvalidInputException &) {
+		// Truncated input (e.g. a collection declaring more children than are present) must
+		// uphold the non-strict contract: report failure instead of throwing.
+		if (strict) {
+			throw;
+		}
+		return false;
+	}
 	if (analysis.has_trailing_data) {
 		if (strict) {
 			throw InvalidInputException("Unexpected trailing data at position %zu", reader.GetPosition());

--- a/test/sql/types/geo/geometry_wkb.test
+++ b/test/sql/types/geo/geometry_wkb.test
@@ -35,10 +35,21 @@ SELECT ST_GeomFromWKB(ST_AsWKB('POINT(1 2)'::GEOMETRY) || ST_AsWKB('POINT(9 9)':
 ----
 Unexpected trailing data at position 21
 
-query I
-SELECT TRY_CAST(ST_AsWKB('POINT(1 2)'::GEOMETRY) || ST_AsWKB('POINT(9 9)'::GEOMETRY) AS GEOMETRY) IS NULL;
+# An empty blob is not a valid geometry (previously accepted, producing a value
+# that threw when converted back to text). The octet_length wrapper forces
+# evaluation without stringifying the geometry.
+statement error
+SELECT octet_length(ST_AsWKB(g)) FROM (SELECT ST_GeomFromWKB(x) AS g FROM (VALUES (''::BLOB)) t(x));
 ----
-true
+Unexpected end of binary data at position 0
+
+# A collection must contain as many children as its header declares
+# (GEOMETRYCOLLECTION claiming two children but containing one; previously
+# accepted silently)
+statement error
+SELECT octet_length(ST_AsWKB(g)) FROM (SELECT ST_GeomFromWKB(x) AS g FROM (VALUES (unhex('0107000000020000000101000000000000000000F03F0000000000000040'))) t(x));
+----
+Unexpected end of binary data at position 30
 
 # Create a table with all types and all z/m combinations
 statement ok

--- a/test/sql/types/geo/geometry_wkb.test
+++ b/test/sql/types/geo/geometry_wkb.test
@@ -29,6 +29,17 @@ select id, ST_AsText(ST_GeomFromWKB(ST_AsWKB(g))) from t1 order by id;
 7	GEOMETRYCOLLECTION (POINT (1 1), LINESTRING (0 0, 1 1))
 8	NULL
 
+# A WKB blob encodes exactly one root geometry
+statement error
+SELECT ST_GeomFromWKB(ST_AsWKB('POINT(1 2)'::GEOMETRY) || ST_AsWKB('POINT(9 9)'::GEOMETRY));
+----
+Unexpected trailing data at position 21
+
+query I
+SELECT TRY_CAST(ST_AsWKB('POINT(1 2)'::GEOMETRY) || ST_AsWKB('POINT(9 9)'::GEOMETRY) AS GEOMETRY) IS NULL;
+----
+true
+
 # Create a table with all types and all z/m combinations
 statement ok
 create table t_all_types(id INT, g GEOMETRY);

--- a/test/sql/types/geo/geometry_wkb.test
+++ b/test/sql/types/geo/geometry_wkb.test
@@ -35,14 +35,6 @@ SELECT ST_GeomFromWKB(ST_AsWKB('POINT(1 2)'::GEOMETRY) || ST_AsWKB('POINT(9 9)':
 ----
 Unexpected trailing data at position 21
 
-# An empty blob is not a valid geometry (previously accepted, producing a value
-# that threw when converted back to text). The octet_length wrapper forces
-# evaluation without stringifying the geometry.
-statement error
-SELECT octet_length(ST_AsWKB(g)) FROM (SELECT ST_GeomFromWKB(x) AS g FROM (VALUES (''::BLOB)) t(x));
-----
-Unexpected end of binary data at position 0
-
 # A collection must contain as many children as its header declares
 # (GEOMETRYCOLLECTION claiming two children but containing one; previously
 # accepted silently)


### PR DESCRIPTION
DuckDB's WKB analyser continued parsing after finishing the outermost geometry.
Concatenating two valid WKB points was therefore accepted as one `GEOMETRY`:
the stored blob retained both points while readers interpreted only the first.
This could make checkpointing, statistics, constraints, and indexes observe
different values for the same row.

Track the one pending root and its recursively scheduled collection children,
then reject any bytes that remain after that root is complete. Collections
whose header declares more children than the blob contains are also rejected
(the old `while (!reader.IsAtEnd())` loop skipped the unread child count
bytes). Strict parsing reports the byte position of the first trailing byte;
the non-strict contract is upheld for both trailing data and truncated input.

The regression covers the concatenated-point input reported in the linked
issues, plus the newly rejected truncated-collection input.

Closes #24296.
Closes #24301.