### PR TITLE
Fix overflowing FOLLOWING and reject negative `ROWS` window frame offsets

### DIFF
--- a/src/function/window/window_boundaries_state.cpp
+++ b/src/function/window/window_boundaries_state.cpp
@@ -727,7 +727,7 @@ void WindowBoundariesState::FrameBegin(idx_t row_idx, const idx_t count, WindowI
 			int64_t computed_start;
 			if (!TryAddOperator::Operation(static_cast<int64_t>(row_idx), boundary_begin.GetCell<int64_t>(chunk_idx),
 			                               computed_start)) {
-				window_start = partition_begin_data[chunk_idx];
+				window_start = partition_end_data[chunk_idx];
 			} else {
 				window_start = UnsafeNumericCast<idx_t>(MaxValue<int64_t>(computed_start, 0));
 			}

--- a/src/function/window/window_boundaries_state.cpp
+++ b/src/function/window/window_boundaries_state.cpp
@@ -712,9 +712,12 @@ void WindowBoundariesState::FrameBegin(idx_t row_idx, const idx_t count, WindowI
 		break;
 	case WindowBoundary::EXPR_PRECEDING_ROWS:
 		for (idx_t chunk_idx = 0; chunk_idx < count; ++chunk_idx, ++row_idx) {
+			const auto boundary = boundary_begin.CellIsNull(chunk_idx) ? 0 : boundary_begin.GetCell<int64_t>(chunk_idx);
+			if (boundary < 0) {
+				throw OutOfRangeException("Invalid ROWS PRECEDING value");
+			}
 			int64_t computed_start;
-			if (!TrySubtractOperator::Operation(static_cast<int64_t>(row_idx),
-			                                    boundary_begin.GetCell<int64_t>(chunk_idx), computed_start)) {
+			if (!TrySubtractOperator::Operation(static_cast<int64_t>(row_idx), boundary, computed_start)) {
 				window_start = partition_begin_data[chunk_idx];
 			} else {
 				window_start = UnsafeNumericCast<idx_t>(MaxValue<int64_t>(computed_start, 0));
@@ -724,9 +727,12 @@ void WindowBoundariesState::FrameBegin(idx_t row_idx, const idx_t count, WindowI
 		break;
 	case WindowBoundary::EXPR_FOLLOWING_ROWS:
 		for (idx_t chunk_idx = 0; chunk_idx < count; ++chunk_idx, ++row_idx) {
+			const auto boundary = boundary_begin.CellIsNull(chunk_idx) ? 0 : boundary_begin.GetCell<int64_t>(chunk_idx);
+			if (boundary < 0) {
+				throw OutOfRangeException("Invalid ROWS FOLLOWING value");
+			}
 			int64_t computed_start;
-			if (!TryAddOperator::Operation(static_cast<int64_t>(row_idx), boundary_begin.GetCell<int64_t>(chunk_idx),
-			                               computed_start)) {
+			if (!TryAddOperator::Operation(static_cast<int64_t>(row_idx), boundary, computed_start)) {
 				window_start = partition_end_data[chunk_idx];
 			} else {
 				window_start = UnsafeNumericCast<idx_t>(MaxValue<int64_t>(computed_start, 0));
@@ -867,9 +873,12 @@ void WindowBoundariesState::FrameEnd(idx_t row_idx, const idx_t count, WindowInp
 		return;
 	case WindowBoundary::EXPR_PRECEDING_ROWS: {
 		for (idx_t chunk_idx = 0; chunk_idx < count; ++chunk_idx, ++row_idx) {
+			const auto boundary = boundary_end.CellIsNull(chunk_idx) ? 0 : boundary_end.GetCell<int64_t>(chunk_idx);
+			if (boundary < 0) {
+				throw OutOfRangeException("Invalid ROWS PRECEDING value");
+			}
 			int64_t computed_start;
-			if (!TrySubtractOperator::Operation(int64_t(row_idx + 1), boundary_end.GetCell<int64_t>(chunk_idx),
-			                                    computed_start)) {
+			if (!TrySubtractOperator::Operation(int64_t(row_idx + 1), boundary, computed_start)) {
 				window_end = partition_end_data[chunk_idx];
 			} else {
 				window_end = UnsafeNumericCast<idx_t>(MaxValue<int64_t>(computed_start, 0));
@@ -880,9 +889,12 @@ void WindowBoundariesState::FrameEnd(idx_t row_idx, const idx_t count, WindowInp
 	}
 	case WindowBoundary::EXPR_FOLLOWING_ROWS:
 		for (idx_t chunk_idx = 0; chunk_idx < count; ++chunk_idx, ++row_idx) {
+			const auto boundary = boundary_end.CellIsNull(chunk_idx) ? 0 : boundary_end.GetCell<int64_t>(chunk_idx);
+			if (boundary < 0) {
+				throw OutOfRangeException("Invalid ROWS FOLLOWING value");
+			}
 			int64_t computed_start;
-			if (!TryAddOperator::Operation(int64_t(row_idx + 1), boundary_end.GetCell<int64_t>(chunk_idx),
-			                               computed_start)) {
+			if (!TryAddOperator::Operation(int64_t(row_idx + 1), boundary, computed_start)) {
 				window_end = partition_end_data[chunk_idx];
 			} else {
 				window_end = UnsafeNumericCast<idx_t>(MaxValue<int64_t>(computed_start, 0));

--- a/test/fuzzer/duckfuzz/window_negate_stats.test
+++ b/test/fuzzer/duckfuzz/window_negate_stats.test
@@ -6,7 +6,7 @@ statement ok
 create table all_types as select * exclude(small_enum, medium_enum, large_enum) from test_all_types();
 
 query I
-SELECT max(c34) FILTER (WHERE c26) OVER (PARTITION BY c23 ROWS BETWEEN c5 PRECEDING AND CURRENT ROW)
+SELECT max(c34) FILTER (WHERE c26) OVER (PARTITION BY c23 ROWS BETWEEN greatest(c5, 0) PRECEDING AND CURRENT ROW)
 FROM all_types AS t43(c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19, c20, c21, c22, c23, c24, c25, c26, c27, c28, c29, c30, c31, c32, c33, c34, c35, c36, c37, c38, c39, c40, c41, c42, c43)
 ORDER BY ALL NULLS LAST
 ----

--- a/test/fuzzer/sqlsmith/window-list-value.test
+++ b/test/fuzzer/sqlsmith/window-list-value.test
@@ -7,7 +7,7 @@ create table all_types as select * exclude(small_enum, medium_enum, large_enum)
 from test_all_types();
 
 query I
-SELECT first_value(c40) OVER (PARTITION BY c42 ROWS BETWEEN #4 FOLLOWING AND UNBOUNDED FOLLOWING)
+SELECT first_value(c40) OVER (PARTITION BY c42 ROWS BETWEEN greatest(#4, 0) FOLLOWING AND UNBOUNDED FOLLOWING)
 FROM all_types AS t42(c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19, c20, c21, c22, c23, c24, c25, c26, c27, c28, c29, c30, c31, c32, c33, c34, c35, c36, c37, c38, c39, c40, c41, c42)
 ORDER BY ALL
 ----

--- a/test/fuzzer/sqlsmith/window-rows-overflow.test
+++ b/test/fuzzer/sqlsmith/window-rows-overflow.test
@@ -15,7 +15,7 @@ query I
 SELECT nth_value(1929, 42) OVER (
 	PARTITION BY (
 		"usmallint" > "smallint"
-	), 747 ROWS BETWEEN "bigint" PRECEDING AND CURRENT ROW
+	), 747 ROWS BETWEEN greatest("bigint", 0) PRECEDING AND CURRENT ROW
 )
 FROM all_types;
 ----

--- a/test/fuzzer/sqlsmith/window-rows-overflow.test
+++ b/test/fuzzer/sqlsmith/window-rows-overflow.test
@@ -27,7 +27,7 @@ query I
 SELECT nth_value(1929, 42) OVER (
 	PARTITION BY (
 		"usmallint" > "smallint"
-	), 747 ROWS BETWEEN 1 PRECEDING AND "bigint" PRECEDING
+	), 747 ROWS BETWEEN 1 PRECEDING AND greatest("bigint", 0) PRECEDING
 )
 FROM all_types;
 ----
@@ -39,7 +39,7 @@ query I
 SELECT nth_value(1929, 42) OVER (
 	PARTITION BY (
 		"usmallint" > "smallint"
-	), 747 ROWS BETWEEN "bigint" FOLLOWING AND 1 FOLLOWING
+	), 747 ROWS BETWEEN greatest("bigint", 0) FOLLOWING AND 1 FOLLOWING
 )
 FROM all_types;
 ----
@@ -51,7 +51,7 @@ query I
 SELECT nth_value(1929, 42) OVER (
 	PARTITION BY (
 		"usmallint" > "smallint"
-	), 747 ROWS BETWEEN CURRENT ROW AND "bigint" FOLLOWING
+	), 747 ROWS BETWEEN CURRENT ROW AND greatest("bigint", 0) FOLLOWING
 )
 FROM all_types;
 ----

--- a/test/issues/general/test_24307.test
+++ b/test/issues/general/test_24307.test
@@ -1,0 +1,82 @@
+# name: test/issues/general/test_24307.test
+# description: ROWS FOLLOWING offsets that overflow produce empty frames
+# group: [general]
+
+query III
+SELECT i,
+       count(*) OVER (
+           ORDER BY i
+           ROWS BETWEEN 9223372036854775807 FOLLOWING AND 9223372036854775807 FOLLOWING
+       ),
+       list(i) OVER (
+           ORDER BY i
+           ROWS BETWEEN 9223372036854775807 FOLLOWING AND 9223372036854775807 FOLLOWING
+       )
+FROM range(3) t(i);
+----
+0	0	NULL
+1	0	NULL
+2	0	NULL
+
+query II
+SELECT i,
+       count(*) OVER (
+           ORDER BY i
+           ROWS BETWEEN 9223372036854775807 FOLLOWING AND UNBOUNDED FOLLOWING
+       )
+FROM range(3) t(i);
+----
+0	0
+1	0
+2	0
+
+query II
+SELECT i,
+       count(*) OVER (
+           ORDER BY i
+           ROWS BETWEEN 9223372036854775807 FOLLOWING AND CURRENT ROW
+       )
+FROM range(3) t(i);
+----
+0	0
+1	0
+2	0
+
+query II
+WITH data(i, off) AS (
+    SELECT i, CASE WHEN i % 2 = 0 THEN 9223372036854775807 ELSE 1 END::BIGINT
+    FROM range(10) t(i)
+)
+SELECT i,
+       count(*) OVER (ORDER BY i ROWS BETWEEN off FOLLOWING AND off FOLLOWING)
+FROM data;
+----
+0	0
+1	1
+2	0
+3	1
+4	0
+5	1
+6	0
+7	1
+8	0
+9	0
+
+query III
+WITH data(p, i) AS (
+    VALUES (0, 0), (0, 1), (1, 0), (1, 1), (1, 2)
+)
+SELECT p, i,
+       count(*) OVER (
+           PARTITION BY p
+           ORDER BY i
+           ROWS BETWEEN 9223372036854775807 FOLLOWING AND 9223372036854775807 FOLLOWING
+       )
+FROM data
+ORDER BY p, i;
+----
+0	0	0
+0	1	0
+1	0	0
+1	1	0
+1	2	0

--- a/test/sql/window/test_negative_rows.test
+++ b/test/sql/window/test_negative_rows.test
@@ -1,0 +1,82 @@
+# name: test/sql/window/test_negative_rows.test
+# description: ROWS frame offsets must be non-negative
+# group: [window]
+
+statement error
+SELECT count(*) OVER (
+    ORDER BY i ROWS BETWEEN -1 PRECEDING AND UNBOUNDED FOLLOWING
+) FROM range(3) t(i);
+----
+Invalid ROWS PRECEDING value
+
+statement error
+SELECT count(*) OVER (
+    ORDER BY i ROWS BETWEEN -1 FOLLOWING AND UNBOUNDED FOLLOWING
+) FROM range(3) t(i);
+----
+Invalid ROWS FOLLOWING value
+
+statement error
+SELECT count(*) OVER (
+    ORDER BY i ROWS BETWEEN UNBOUNDED PRECEDING AND -1 PRECEDING
+) FROM range(3) t(i);
+----
+Invalid ROWS PRECEDING value
+
+statement error
+SELECT count(*) OVER (
+    ORDER BY i ROWS BETWEEN UNBOUNDED PRECEDING AND -1 FOLLOWING
+) FROM range(3) t(i);
+----
+Invalid ROWS FOLLOWING value
+
+# Dynamic offsets are validated row by row, including INT64_MIN.
+statement error
+WITH data(i, off) AS (
+    VALUES (0, 0::BIGINT), (1, (-9223372036854775807 - 1)::BIGINT)
+)
+SELECT count(*) OVER (
+    ORDER BY i ROWS BETWEEN off PRECEDING AND UNBOUNDED FOLLOWING
+) FROM data;
+----
+Invalid ROWS PRECEDING value
+
+statement error
+WITH data(p, i, off) AS (
+    VALUES (0, 0, 0::BIGINT), (0, 1, -1::BIGINT), (1, 0, 0::BIGINT)
+)
+SELECT count(*) OVER (
+    PARTITION BY p ORDER BY i ROWS BETWEEN UNBOUNDED PRECEDING AND off FOLLOWING
+) FROM data;
+----
+Invalid ROWS FOLLOWING value
+
+# NULL and non-negative offsets retain their existing behaviour.
+query III
+WITH data(i, off) AS (
+    VALUES (0, NULL::BIGINT), (1, 0::BIGINT), (2, 1::BIGINT)
+)
+SELECT i,
+       count(*) OVER (ORDER BY i ROWS BETWEEN off PRECEDING AND CURRENT ROW),
+       count(*) OVER (ORDER BY i ROWS BETWEEN CURRENT ROW AND off FOLLOWING)
+FROM data;
+----
+0	1	1
+1	1	1
+2	2	1
+
+# Do not inspect the unspecified payload beneath a NULL validity bit. The
+# NULLIF input is negative for the first row but every result is NULL.
+query III
+SELECT i,
+       count(*) OVER (
+           ORDER BY i ROWS BETWEEN NULLIF(i - 1, i - 1) PRECEDING AND CURRENT ROW
+       ),
+       count(*) OVER (
+           ORDER BY i ROWS BETWEEN CURRENT ROW AND NULLIF(i - 1, i - 1) FOLLOWING
+       )
+FROM range(3) t(i);
+----
+0	1	1
+1	1	1
+2	1	1

--- a/test/sql/window/test_quantile_window.test_slow
+++ b/test/sql/window/test_quantile_window.test_slow
@@ -25,7 +25,7 @@ select sum(m)
 from (
     select median(a) over (
         order by b asc
-        rows between mod(b * 47, 521) preceding and 100 - mod(b * 47, 521) following) as m
+        rows between mod(b * 47, 521) preceding and greatest(0, 100 - mod(b * 47, 521)) following) as m
     from rank100
     ) q;
 ----
@@ -73,7 +73,7 @@ select sum(m)
 from (
     select mad(a) over (
         order by b asc
-        rows between mod(b * 47, 521) preceding and 100 - mod(b * 47, 521) following) as m
+        rows between mod(b * 47, 521) preceding and greatest(0, 100 - mod(b * 47, 521)) following) as m
     from rank100
     ) q;
 ----


### PR DESCRIPTION
This PR bundles two related `ROWS` window-frame offset fixes: the overflow fallback fixed by the first is reachable through the negative offsets rejected by the second.

An extremely large `ROWS ... FOLLOWING` offset produces incorrect non-empty frames. A frame start of `n FOLLOWING` is the current global row index plus `n`, clamped to the current partition; when that signed addition overflows, `WindowBoundariesState`'s fallback chose the partition beginning, so the frame covered the whole partition. The fix changes the fallback to the current partition end — the saturated result in the offset's direction — so the frame is empty.

DuckDB rejects negative `RANGE` and `GROUPS` offsets but accepted negative `ROWS` offsets, which can silently reverse direction and create unexpected frames. The fix follows the `RANGE` and `GROUPS` contract, rejecting negative values at runtime in all four `ROWS` boundary paths. NULL offsets keep the existing zero/current-row semantics; each path checks the validity bit before reading vector storage, so payload bits beneath a NULL cannot spuriously trigger the error.

New regressions `test/issues/general/test_24307.test` and `test/sql/window/test_negative_rows.test` cover overflowing frames and negative-offset rejections. Fixes #24307.
