### PR TITLE
Fix infinite loop in `equi_width_bins` via zero step size

### DIFF
--- a/extension/core_functions/scalar/generic/binning.cpp
+++ b/extension/core_functions/scalar/generic/binning.cpp
@@ -130,6 +130,11 @@ struct EquiWidthBinsInteger {
 
 		const hugeint_t span = max - min;
 		hugeint_t step = span / Hugeint::Convert(bin_count);
+		if (step == 0) {
+			throw InvalidInputException(expr,
+			                            "Invalid input for equi_width_bins - the bin count is too large for the given "
+			                            "range, resulting in a step size of 0");
+		}
 		if (nice_rounding) {
 			// when doing nice rounding we try to make the max/step values nicer
 			hugeint_t new_step = MakeNumberNice(step, step, NiceRounding::ROUND);
@@ -178,6 +183,11 @@ struct EquiWidthBinsDouble {
 		} else {
 			step = span / static_cast<double>(bin_count);
 		}
+		if (step == 0) {
+			throw InvalidInputException(expr,
+			                            "Invalid input for equi_width_bins - the bin count is too large for the given "
+			                            "range, resulting in a step size of 0");
+		}
 		const double step_power_of_ten = GetPreviousPowerOfTen(step);
 		if (nice_rounding) {
 			// when doing nice rounding we try to make the max/step values nicer
@@ -185,9 +195,6 @@ struct EquiWidthBinsDouble {
 			max = RoundToNumber(input_max, step, NiceRounding::CEILING);
 			// we allow for more bins when doing nice rounding since the bin count is approximate
 			bin_count *= 2;
-		}
-		if (step == 0) {
-			throw InternalException("step is 0!?");
 		}
 
 		const double round_multiplication = 10 / step_power_of_ten;

--- a/test/sql/aggregate/aggregates/binning.test
+++ b/test/sql/aggregate/aggregates/binning.test
@@ -344,3 +344,27 @@ statement error
 SELECT equi_width_bins('a'::VARCHAR, 'z'::VARCHAR, 2, true)
 ----
 Unsupported type "VARCHAR"
+
+# equi_width_bins: reject bin_count that truncates integer step to zero
+statement error
+SELECT equi_width_bins(1::BIGINT, 2::BIGINT, 1000000, false);
+----
+the bin count is too large for the given range
+
+# same input must fail before nice_rounding arithmetic (MakeNumberNice(0) divides by zero)
+statement error
+SELECT equi_width_bins(1::BIGINT, 2::BIGINT, 1000000, true);
+----
+the bin count is too large for the given range
+
+# double variant: subnormal span underflows to step=0.0 (min==max is intercepted by wrapper)
+statement error
+SELECT equi_width_bins(0.0, 5e-324, 2, false);
+----
+the bin count is too large for the given range
+
+# existing valid behavior must remain unaffected
+query I
+SELECT equi_width_bins(1::BIGINT, 2::BIGINT, 5, false);
+----
+[1, 2]


### PR DESCRIPTION
Fixes #24282

This PR fixes multiple vulnerabilities in `equi_width_bins` caused by a calculated step size of zero, which previously led to an infinite loop (CPU exhaustion) or division-by-zero crashes.

1. Integer Variant: Added a `step == 0` guard in `EquiWidthBinsInteger`. I chose to throw an `InvalidInputException` instead of artificially clamping the step to `1`.

2. Double Variant: Moved the existing `step == 0` guard in `EquiWidthBinsDouble` to the top of the function (before `GetPreviousPowerOfTen` and `MakeNumberNice`) to catch subnormal floating-point underflows earlier. I also reclassified it from `InternalException` to `InvalidInputException`, as this is caused by mathematically impossible user input, not an internal engine logic failure.

3. Nice Rounding Crash: By placing the integer guard before the `nice_rounding` block, this PR also fixes a secondary bug where `MakeNumberNice(0, 0)` would trigger a hard SIGFPE division-by-zero crash if `nice_rounding` was set to true.

After the fix:
```
-- Integer Bug: Massive bin count safely rejected before hanging the engine
memory D SELECT equi_width_bins(1::BIGINT, 2::BIGINT, 1000000, false);
Invalid Input Error:
Invalid input for equi_width_bins - the bin count is too large for the given range, resulting in a step size of 0

LINE 1: SELECT equi_width_bins(1::BIGINT, 2::BIGINT, 1000000, false);
               ^
-- Double Bug: Subnormal float underflow safely rejected instead of causing internal crash
memory D SELECT equi_width_bins(0.0::DOUBLE, 5e-324::DOUBLE, 2, false);
Invalid Input Error:
Invalid input for equi_width_bins - the bin count is too large for the given range, resulting in a step size of 0

LINE 1: SELECT equi_width_bins(0.0::DOUBLE, 5e-324::DOUBLE, 2, false);
               ^
```