### PR TITLE
Unify and optimize scalar executor infrastructure

### DIFF
--- a/benchmark/micro/CMakeLists.txt
+++ b/benchmark/micro/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(
   append_mix.cpp
   bulkupdate.cpp
   cast.cpp
+  executor.cpp
   in.cpp
   storage.cpp
   string_serialize.cpp)

--- a/benchmark/micro/executor.cpp
+++ b/benchmark/micro/executor.cpp
@@ -18,6 +18,7 @@ enum class ExecutorBenchmarkType : uint8_t {
 	TERNARY_OPTIONAL_EXECUTE,
 	VARIADIC_EXECUTE,
 	BINARY_SELECT,
+	BINARY_SELECT_GREATER_THAN_EQUALS,
 	TERNARY_SELECT
 };
 
@@ -200,6 +201,15 @@ public:
 			}
 			break;
 		}
+		case ExecutorBenchmarkType::BINARY_SELECT_GREATER_THAN_EQUALS: {
+			auto true_sel = selection_output == ExecutorSelectionOutput::FALSE_ONLY ? nullptr : &state.true_sel;
+			auto false_sel = selection_output == ExecutorSelectionOutput::TRUE_ONLY ? nullptr : &state.false_sel;
+			for (idx_t i = 0; i < iterations; i++) {
+				state.selected_count = BinaryExecutor::Select<int64_t, int64_t, GreaterThanEquals>(
+				    state.a, state.b, nullptr, EXECUTOR_BENCHMARK_COUNT, true_sel, false_sel);
+			}
+			break;
+		}
 		case ExecutorBenchmarkType::TERNARY_SELECT:
 			for (idx_t i = 0; i < iterations; i++) {
 				state.selected_count = TernaryExecutor::Select<int64_t, int64_t, int64_t, ExecutorBetweenOperator>(
@@ -207,7 +217,9 @@ public:
 			}
 			break;
 		}
-		if (type == ExecutorBenchmarkType::BINARY_SELECT || type == ExecutorBenchmarkType::TERNARY_SELECT) {
+		if (type == ExecutorBenchmarkType::BINARY_SELECT ||
+		    type == ExecutorBenchmarkType::BINARY_SELECT_GREATER_THAN_EQUALS ||
+		    type == ExecutorBenchmarkType::TERNARY_SELECT) {
 			state.checksum = NumericCast<int64_t>(state.selected_count + 1);
 		} else {
 			auto value = state.result.GetValue(EXECUTOR_BENCHMARK_COUNT - 1);
@@ -235,6 +247,7 @@ private:
 			return constant_mask == 0x1 ? EXECUTOR_CONSTANT_BENCHMARK_ITERATIONS : EXECUTOR_BENCHMARK_ITERATIONS;
 		case ExecutorBenchmarkType::BINARY_EXECUTE:
 		case ExecutorBenchmarkType::BINARY_SELECT:
+		case ExecutorBenchmarkType::BINARY_SELECT_GREATER_THAN_EQUALS:
 		case ExecutorBenchmarkType::TERNARY_SELECT:
 			return constant_mask == 0x3 ? EXECUTOR_CONSTANT_BENCHMARK_ITERATIONS : EXECUTOR_BENCHMARK_ITERATIONS;
 		case ExecutorBenchmarkType::TERNARY_EXECUTE:
@@ -272,6 +285,14 @@ ExecutorBenchmark binary_dictionary_dictionary("ScalarExecutorBinaryDictionaryDi
 ExecutorBenchmark binary_select_flat_flat("ScalarExecutorBinarySelectFlatFlat", ExecutorBenchmarkType::BINARY_SELECT);
 ExecutorBenchmark binary_select_flat_constant("ScalarExecutorBinarySelectFlatConstant",
                                               ExecutorBenchmarkType::BINARY_SELECT, 0x2);
+ExecutorBenchmark binary_select_dictionary_constant("ScalarExecutorBinarySelectDictionaryConstant",
+                                                    ExecutorBenchmarkType::BINARY_SELECT, 0x2, 0x1);
+ExecutorBenchmark binary_select_constant_dictionary("ScalarExecutorBinarySelectConstantDictionary",
+                                                    ExecutorBenchmarkType::BINARY_SELECT, 0x1, 0x2);
+ExecutorBenchmark
+    binary_select_greater_equals_dictionary_constant("ScalarExecutorBinarySelectGreaterEqualsDictionaryConstant",
+                                                     ExecutorBenchmarkType::BINARY_SELECT_GREATER_THAN_EQUALS, 0x2,
+                                                     0x1);
 ExecutorBenchmark ternary_select_flat("ScalarExecutorTernarySelectFlat", ExecutorBenchmarkType::TERNARY_SELECT);
 
 ExecutorBenchmark ternary_fff("ScalarExecutorTernaryFFF", ExecutorBenchmarkType::TERNARY_EXECUTE, 0x0);

--- a/benchmark/micro/executor.cpp
+++ b/benchmark/micro/executor.cpp
@@ -49,7 +49,12 @@ struct ExecutorBenchmarkState : public DuckDBBenchmarkState {
 		InitializeInput(b, 3, 1);
 		InitializeInput(c, 5, 2);
 		InitializeInput(d, 7, 3);
-		if (selection_percent <= 100 && !(constant_mask & 0x3)) {
+		if (selection_percent <= 100 && constant_mask == 0x5) {
+			auto b_data = FlatVector::GetDataMutable<int64_t>(b);
+			for (idx_t i = 0; i < EXECUTOR_BENCHMARK_COUNT; i++) {
+				b_data[i] = i % 100 < selection_percent ? 1 : 3;
+			}
+		} else if (selection_percent <= 100 && !(constant_mask & 0x3)) {
 			auto a_data = FlatVector::GetData<int64_t>(a);
 			auto b_data = FlatVector::GetDataMutable<int64_t>(b);
 			for (idx_t i = 0; i < EXECUTOR_BENCHMARK_COUNT; i++) {
@@ -210,12 +215,15 @@ public:
 			}
 			break;
 		}
-		case ExecutorBenchmarkType::TERNARY_SELECT:
+		case ExecutorBenchmarkType::TERNARY_SELECT: {
+			auto true_sel = selection_output == ExecutorSelectionOutput::FALSE_ONLY ? nullptr : &state.true_sel;
+			auto false_sel = selection_output == ExecutorSelectionOutput::TRUE_ONLY ? nullptr : &state.false_sel;
 			for (idx_t i = 0; i < iterations; i++) {
 				state.selected_count = TernaryExecutor::Select<int64_t, int64_t, int64_t, ExecutorBetweenOperator>(
-				    state.b, state.a, state.c, nullptr, EXECUTOR_BENCHMARK_COUNT, &state.true_sel, &state.false_sel);
+				    state.b, state.a, state.c, nullptr, EXECUTOR_BENCHMARK_COUNT, true_sel, false_sel);
 			}
 			break;
+		}
 		}
 		if (type == ExecutorBenchmarkType::BINARY_SELECT ||
 		    type == ExecutorBenchmarkType::BINARY_SELECT_GREATER_THAN_EQUALS ||
@@ -303,6 +311,13 @@ ExecutorBenchmark
                                                      ExecutorBenchmarkType::BINARY_SELECT_GREATER_THAN_EQUALS, 0x2,
                                                      0x1);
 ExecutorBenchmark ternary_select_flat("ScalarExecutorTernarySelectFlat", ExecutorBenchmarkType::TERNARY_SELECT);
+ExecutorBenchmark ternary_select_fcc_true("ScalarExecutorTernarySelectFlatConstantConstantTrueOnly50",
+                                          ExecutorBenchmarkType::TERNARY_SELECT, 0x5, 0, ExecutorNullProfile::NONE, 50,
+                                          ExecutorSelectionOutput::TRUE_ONLY);
+ExecutorBenchmark ternary_select_fcc_true_sparse_null("ScalarExecutorTernarySelectFlatConstantConstantTrueOnlyNull01",
+                                                      ExecutorBenchmarkType::TERNARY_SELECT, 0x5, 0,
+                                                      ExecutorNullProfile::SPARSE, 50,
+                                                      ExecutorSelectionOutput::TRUE_ONLY);
 
 ExecutorBenchmark ternary_fff("ScalarExecutorTernaryFFF", ExecutorBenchmarkType::TERNARY_EXECUTE, 0x0);
 ExecutorBenchmark ternary_cff("ScalarExecutorTernaryCFF", ExecutorBenchmarkType::TERNARY_EXECUTE, 0x1);

--- a/benchmark/micro/executor.cpp
+++ b/benchmark/micro/executor.cpp
@@ -282,6 +282,15 @@ ExecutorBenchmark binary_flat_dictionary("ScalarExecutorBinaryFlatDictionary", E
                                          0x2);
 ExecutorBenchmark binary_dictionary_dictionary("ScalarExecutorBinaryDictionaryDictionary",
                                                ExecutorBenchmarkType::BINARY_EXECUTE, 0, 0x3);
+ExecutorBenchmark binary_dictionary_flat_sparse_null("ScalarExecutorBinaryDictionaryFlatNull01",
+                                                     ExecutorBenchmarkType::BINARY_EXECUTE, 0, 0x1,
+                                                     ExecutorNullProfile::SPARSE);
+ExecutorBenchmark binary_flat_dictionary_sparse_null("ScalarExecutorBinaryFlatDictionaryNull01",
+                                                     ExecutorBenchmarkType::BINARY_EXECUTE, 0, 0x2,
+                                                     ExecutorNullProfile::SPARSE);
+ExecutorBenchmark binary_dictionary_dictionary_sparse_null("ScalarExecutorBinaryDictionaryDictionaryNull01",
+                                                           ExecutorBenchmarkType::BINARY_EXECUTE, 0, 0x3,
+                                                           ExecutorNullProfile::SPARSE);
 ExecutorBenchmark binary_select_flat_flat("ScalarExecutorBinarySelectFlatFlat", ExecutorBenchmarkType::BINARY_SELECT);
 ExecutorBenchmark binary_select_flat_constant("ScalarExecutorBinarySelectFlatConstant",
                                               ExecutorBenchmarkType::BINARY_SELECT, 0x2);

--- a/benchmark/micro/executor.cpp
+++ b/benchmark/micro/executor.cpp
@@ -1,0 +1,323 @@
+#include "benchmark_runner.hpp"
+#include "duckdb_benchmark.hpp"
+#include "duckdb/common/operator/comparison_operators.hpp"
+#include "duckdb/common/vector/flat_vector.hpp"
+#include "duckdb/common/vector_operations/binary_executor.hpp"
+#include "duckdb/common/vector_operations/ternary_executor.hpp"
+#include "duckdb/common/vector_operations/unary_executor.hpp"
+#include "duckdb/common/vector_operations/variadic_executor.hpp"
+
+using namespace duckdb;
+
+namespace {
+
+enum class ExecutorBenchmarkType : uint8_t {
+	UNARY_EXECUTE,
+	BINARY_EXECUTE,
+	TERNARY_EXECUTE,
+	TERNARY_OPTIONAL_EXECUTE,
+	VARIADIC_EXECUTE,
+	BINARY_SELECT,
+	TERNARY_SELECT
+};
+
+enum class ExecutorNullProfile : uint8_t { NONE, SPARSE, DENSE, MOSTLY_NULL, CLUSTERED };
+
+enum class ExecutorSelectionOutput : uint8_t { BOTH, TRUE_ONLY, FALSE_ONLY };
+
+static constexpr idx_t EXECUTOR_BENCHMARK_COUNT = STANDARD_VECTOR_SIZE;
+static constexpr idx_t EXECUTOR_BENCHMARK_ITERATIONS = 1000000;
+static constexpr idx_t EXECUTOR_CONSTANT_BENCHMARK_ITERATIONS = 20000000;
+
+struct ExecutorBetweenOperator {
+	template <class T>
+	static bool Operation(T input, T lower, T upper) {
+		return input >= lower && input <= upper;
+	}
+};
+
+struct ExecutorBenchmarkState : public DuckDBBenchmarkState {
+	ExecutorBenchmarkState(uint8_t constant_mask_p, uint8_t dictionary_mask_p, ExecutorNullProfile null_profile_p,
+	                       idx_t selection_percent_p)
+	    : DuckDBBenchmarkState(string()), a(LogicalType::BIGINT, EXECUTOR_BENCHMARK_COUNT),
+	      b(LogicalType::BIGINT, EXECUTOR_BENCHMARK_COUNT), c(LogicalType::BIGINT, EXECUTOR_BENCHMARK_COUNT),
+	      d(LogicalType::BIGINT, EXECUTOR_BENCHMARK_COUNT), result(LogicalType::BIGINT, EXECUTOR_BENCHMARK_COUNT),
+	      true_sel(EXECUTOR_BENCHMARK_COUNT), false_sel(EXECUTOR_BENCHMARK_COUNT), constant_mask(constant_mask_p),
+	      dictionary_mask(dictionary_mask_p), null_profile(null_profile_p), selection_percent(selection_percent_p) {
+		InitializeInput(a, 1, 0);
+		InitializeInput(b, 3, 1);
+		InitializeInput(c, 5, 2);
+		InitializeInput(d, 7, 3);
+		if (selection_percent <= 100 && !(constant_mask & 0x3)) {
+			auto a_data = FlatVector::GetData<int64_t>(a);
+			auto b_data = FlatVector::GetDataMutable<int64_t>(b);
+			for (idx_t i = 0; i < EXECUTOR_BENCHMARK_COUNT; i++) {
+				b_data[i] = a_data[i] + (i % 100 < selection_percent ? 1 : -1);
+			}
+		}
+	}
+
+	void InitializeInput(Vector &input, int64_t multiplier, idx_t input_index) {
+		auto data = FlatVector::GetDataMutable<int64_t>(input);
+		for (idx_t i = 0; i < EXECUTOR_BENCHMARK_COUNT; i++) {
+			data[i] = NumericCast<int64_t>(i * multiplier + input_index);
+		}
+		FlatVector::SetSize(input, EXECUTOR_BENCHMARK_COUNT);
+		ApplyNullProfile(input, input_index);
+		if (constant_mask & (uint8_t(1) << input_index)) {
+			input.Reference(Value::BIGINT(data[0]), count_t(EXECUTOR_BENCHMARK_COUNT));
+		} else if (dictionary_mask & (uint8_t(1) << input_index)) {
+			SelectionVector sel(EXECUTOR_BENCHMARK_COUNT);
+			for (idx_t i = 0; i < EXECUTOR_BENCHMARK_COUNT; i++) {
+				sel.set_index(i, i % 128);
+			}
+			input.Slice(sel, EXECUTOR_BENCHMARK_COUNT);
+		}
+	}
+
+	void ApplyNullProfile(Vector &input, idx_t input_index) {
+		if (null_profile == ExecutorNullProfile::NONE) {
+			return;
+		}
+		auto &validity = FlatVector::ValidityMutable(input);
+		for (idx_t row = 0; row < EXECUTOR_BENCHMARK_COUNT; row++) {
+			auto shifted_row = row + input_index * 17;
+			bool is_null = false;
+			switch (null_profile) {
+			case ExecutorNullProfile::NONE:
+				break;
+			case ExecutorNullProfile::SPARSE:
+				is_null = shifted_row % 100 == 0;
+				break;
+			case ExecutorNullProfile::DENSE:
+				is_null = shifted_row % 2 == 0;
+				break;
+			case ExecutorNullProfile::MOSTLY_NULL:
+				is_null = shifted_row % 100 != 0;
+				break;
+			case ExecutorNullProfile::CLUSTERED:
+				is_null = (shifted_row / ValidityMask::BITS_PER_VALUE) % 2 == 0;
+				break;
+			}
+			if (is_null) {
+				validity.SetInvalid(row);
+			}
+		}
+	}
+
+	Vector a;
+	Vector b;
+	Vector c;
+	Vector d;
+	Vector result;
+	SelectionVector true_sel;
+	SelectionVector false_sel;
+	uint8_t constant_mask;
+	uint8_t dictionary_mask;
+	ExecutorNullProfile null_profile;
+	idx_t selection_percent;
+	idx_t selected_count = 0;
+	int64_t checksum = 0;
+};
+
+class ExecutorBenchmark : public DuckDBBenchmark {
+public:
+	ExecutorBenchmark(const string &name, ExecutorBenchmarkType type_p, uint8_t constant_mask_p = 0,
+	                  uint8_t dictionary_mask_p = 0, ExecutorNullProfile null_profile_p = ExecutorNullProfile::NONE,
+	                  idx_t selection_percent_p = 101,
+	                  ExecutorSelectionOutput selection_output_p = ExecutorSelectionOutput::BOTH)
+	    : DuckDBBenchmark(true, name, "[scalar_executor]"), type(type_p), constant_mask(constant_mask_p),
+	      dictionary_mask(dictionary_mask_p), null_profile(null_profile_p), selection_percent(selection_percent_p),
+	      selection_output(selection_output_p) {
+	}
+
+	unique_ptr<DuckDBBenchmarkState> CreateBenchmarkState() override {
+		return make_uniq<ExecutorBenchmarkState>(constant_mask, dictionary_mask, null_profile, selection_percent);
+	}
+
+	void Load(DuckDBBenchmarkState *state) override {
+	}
+
+	void RunBenchmark(DuckDBBenchmarkState *state_p) override {
+		auto &state = static_cast<ExecutorBenchmarkState &>(*state_p);
+		const auto iterations = Iterations();
+		switch (type) {
+		case ExecutorBenchmarkType::UNARY_EXECUTE: {
+			auto fun = [](int64_t value) {
+				return value + 1;
+			};
+			for (idx_t i = 0; i < iterations; i++) {
+				UnaryExecutor::Execute<int64_t, int64_t>(state.a, state.result, fun, FunctionErrors::CANNOT_ERROR);
+			}
+			break;
+		}
+		case ExecutorBenchmarkType::BINARY_EXECUTE: {
+			auto fun = [](int64_t left, int64_t right) {
+				return left + right;
+			};
+			for (idx_t i = 0; i < iterations; i++) {
+				BinaryExecutor::Execute<int64_t, int64_t, int64_t>(state.a, state.b, state.result, fun);
+			}
+			break;
+		}
+		case ExecutorBenchmarkType::TERNARY_EXECUTE: {
+			auto fun = [](int64_t a, int64_t b, int64_t c) {
+				return a + b * c;
+			};
+			for (idx_t i = 0; i < iterations; i++) {
+				TernaryExecutor::Execute<int64_t, int64_t, int64_t, int64_t>(state.a, state.b, state.c, state.result,
+				                                                             fun);
+			}
+			break;
+		}
+		case ExecutorBenchmarkType::TERNARY_OPTIONAL_EXECUTE: {
+			auto fun = [](int64_t a, int64_t b, int64_t c) -> optional<int64_t> {
+				auto value = a + b * c;
+				return value % 101 == 0 ? optional<int64_t>() : optional<int64_t>(value);
+			};
+			for (idx_t i = 0; i < iterations; i++) {
+				TernaryExecutor::Execute<int64_t, int64_t, int64_t, int64_t>(state.a, state.b, state.c, state.result,
+				                                                             fun);
+			}
+			break;
+		}
+		case ExecutorBenchmarkType::VARIADIC_EXECUTE: {
+			auto fun = [](int64_t a, int64_t b, int64_t c, int64_t d) {
+				return a + b * c - d;
+			};
+			std::array<VariadicExecutor::VectorRef, 4> inputs = {{state.a, state.b, state.c, state.d}};
+			for (idx_t i = 0; i < iterations; i++) {
+				VariadicExecutor::Execute<int64_t, int64_t, int64_t, int64_t, int64_t>(inputs, state.result, fun);
+			}
+			break;
+		}
+		case ExecutorBenchmarkType::BINARY_SELECT: {
+			auto true_sel = selection_output == ExecutorSelectionOutput::FALSE_ONLY ? nullptr : &state.true_sel;
+			auto false_sel = selection_output == ExecutorSelectionOutput::TRUE_ONLY ? nullptr : &state.false_sel;
+			for (idx_t i = 0; i < iterations; i++) {
+				state.selected_count = BinaryExecutor::Select<int64_t, int64_t, LessThan>(
+				    state.a, state.b, nullptr, EXECUTOR_BENCHMARK_COUNT, true_sel, false_sel);
+			}
+			break;
+		}
+		case ExecutorBenchmarkType::TERNARY_SELECT:
+			for (idx_t i = 0; i < iterations; i++) {
+				state.selected_count = TernaryExecutor::Select<int64_t, int64_t, int64_t, ExecutorBetweenOperator>(
+				    state.b, state.a, state.c, nullptr, EXECUTOR_BENCHMARK_COUNT, &state.true_sel, &state.false_sel);
+			}
+			break;
+		}
+		if (type == ExecutorBenchmarkType::BINARY_SELECT || type == ExecutorBenchmarkType::TERNARY_SELECT) {
+			state.checksum = NumericCast<int64_t>(state.selected_count + 1);
+		} else {
+			auto value = state.result.GetValue(EXECUTOR_BENCHMARK_COUNT - 1);
+			state.checksum = value.IsNull() ? 1 : value.GetValue<int64_t>();
+		}
+	}
+
+	string VerifyResult(QueryResult *result) override {
+		return string();
+	}
+
+	string Verify(BenchmarkState *state_p) override {
+		auto &state = static_cast<ExecutorBenchmarkState &>(*state_p);
+		return state.checksum == 0 ? "Executor benchmark produced an empty checksum" : string();
+	}
+
+	string BenchmarkInfo() override {
+		return "Direct scalar executor microbenchmark over a standard-size vector";
+	}
+
+private:
+	idx_t Iterations() const {
+		switch (type) {
+		case ExecutorBenchmarkType::UNARY_EXECUTE:
+			return constant_mask == 0x1 ? EXECUTOR_CONSTANT_BENCHMARK_ITERATIONS : EXECUTOR_BENCHMARK_ITERATIONS;
+		case ExecutorBenchmarkType::BINARY_EXECUTE:
+		case ExecutorBenchmarkType::BINARY_SELECT:
+		case ExecutorBenchmarkType::TERNARY_SELECT:
+			return constant_mask == 0x3 ? EXECUTOR_CONSTANT_BENCHMARK_ITERATIONS : EXECUTOR_BENCHMARK_ITERATIONS;
+		case ExecutorBenchmarkType::TERNARY_EXECUTE:
+		case ExecutorBenchmarkType::TERNARY_OPTIONAL_EXECUTE:
+			return constant_mask == 0x7 ? EXECUTOR_CONSTANT_BENCHMARK_ITERATIONS : EXECUTOR_BENCHMARK_ITERATIONS;
+		case ExecutorBenchmarkType::VARIADIC_EXECUTE:
+			return constant_mask == 0xF ? EXECUTOR_CONSTANT_BENCHMARK_ITERATIONS : EXECUTOR_BENCHMARK_ITERATIONS;
+		}
+		throw InternalException("Unknown executor benchmark type");
+	}
+
+	ExecutorBenchmarkType type;
+	uint8_t constant_mask;
+	uint8_t dictionary_mask;
+	ExecutorNullProfile null_profile;
+	idx_t selection_percent;
+	ExecutorSelectionOutput selection_output;
+};
+
+ExecutorBenchmark unary_flat("ScalarExecutorUnaryFlat", ExecutorBenchmarkType::UNARY_EXECUTE);
+ExecutorBenchmark unary_constant("ScalarExecutorUnaryConstant", ExecutorBenchmarkType::UNARY_EXECUTE, 0x1);
+ExecutorBenchmark unary_dictionary("ScalarExecutorUnaryDictionary", ExecutorBenchmarkType::UNARY_EXECUTE, 0, true);
+
+ExecutorBenchmark binary_flat_flat("ScalarExecutorBinaryFlatFlat", ExecutorBenchmarkType::BINARY_EXECUTE);
+ExecutorBenchmark binary_constant_flat("ScalarExecutorBinaryConstantFlat", ExecutorBenchmarkType::BINARY_EXECUTE, 0x1);
+ExecutorBenchmark binary_flat_constant("ScalarExecutorBinaryFlatConstant", ExecutorBenchmarkType::BINARY_EXECUTE, 0x2);
+ExecutorBenchmark binary_constant_constant("ScalarExecutorBinaryConstantConstant",
+                                           ExecutorBenchmarkType::BINARY_EXECUTE, 0x3);
+ExecutorBenchmark binary_dictionary_flat("ScalarExecutorBinaryDictionaryFlat", ExecutorBenchmarkType::BINARY_EXECUTE, 0,
+                                         0x1);
+ExecutorBenchmark binary_flat_dictionary("ScalarExecutorBinaryFlatDictionary", ExecutorBenchmarkType::BINARY_EXECUTE, 0,
+                                         0x2);
+ExecutorBenchmark binary_dictionary_dictionary("ScalarExecutorBinaryDictionaryDictionary",
+                                               ExecutorBenchmarkType::BINARY_EXECUTE, 0, 0x3);
+ExecutorBenchmark binary_select_flat_flat("ScalarExecutorBinarySelectFlatFlat", ExecutorBenchmarkType::BINARY_SELECT);
+ExecutorBenchmark binary_select_flat_constant("ScalarExecutorBinarySelectFlatConstant",
+                                              ExecutorBenchmarkType::BINARY_SELECT, 0x2);
+ExecutorBenchmark ternary_select_flat("ScalarExecutorTernarySelectFlat", ExecutorBenchmarkType::TERNARY_SELECT);
+
+ExecutorBenchmark ternary_fff("ScalarExecutorTernaryFFF", ExecutorBenchmarkType::TERNARY_EXECUTE, 0x0);
+ExecutorBenchmark ternary_cff("ScalarExecutorTernaryCFF", ExecutorBenchmarkType::TERNARY_EXECUTE, 0x1);
+ExecutorBenchmark ternary_fcf("ScalarExecutorTernaryFCF", ExecutorBenchmarkType::TERNARY_EXECUTE, 0x2);
+ExecutorBenchmark ternary_ccf("ScalarExecutorTernaryCCF", ExecutorBenchmarkType::TERNARY_EXECUTE, 0x3);
+ExecutorBenchmark ternary_ffc("ScalarExecutorTernaryFFC", ExecutorBenchmarkType::TERNARY_EXECUTE, 0x4);
+ExecutorBenchmark ternary_cfc("ScalarExecutorTernaryCFC", ExecutorBenchmarkType::TERNARY_EXECUTE, 0x5);
+ExecutorBenchmark ternary_fcc("ScalarExecutorTernaryFCC", ExecutorBenchmarkType::TERNARY_EXECUTE, 0x6);
+ExecutorBenchmark ternary_ccc("ScalarExecutorTernaryCCC", ExecutorBenchmarkType::TERNARY_EXECUTE, 0x7);
+
+ExecutorBenchmark unary_sparse_null("ScalarExecutorUnaryFlatNull01", ExecutorBenchmarkType::UNARY_EXECUTE, 0, false,
+                                    ExecutorNullProfile::SPARSE);
+ExecutorBenchmark unary_dense_null("ScalarExecutorUnaryFlatNull50", ExecutorBenchmarkType::UNARY_EXECUTE, 0, false,
+                                   ExecutorNullProfile::DENSE);
+ExecutorBenchmark binary_sparse_null("ScalarExecutorBinaryFlatFlatNull01", ExecutorBenchmarkType::BINARY_EXECUTE, 0,
+                                     false, ExecutorNullProfile::SPARSE);
+ExecutorBenchmark binary_clustered_null("ScalarExecutorBinaryFlatFlatNullClustered",
+                                        ExecutorBenchmarkType::BINARY_EXECUTE, 0, false,
+                                        ExecutorNullProfile::CLUSTERED);
+ExecutorBenchmark ternary_sparse_null("ScalarExecutorTernaryFFFNull01", ExecutorBenchmarkType::TERNARY_EXECUTE, 0,
+                                      false, ExecutorNullProfile::SPARSE);
+ExecutorBenchmark ternary_dense_null("ScalarExecutorTernaryFFFNull50", ExecutorBenchmarkType::TERNARY_EXECUTE, 0, false,
+                                     ExecutorNullProfile::DENSE);
+ExecutorBenchmark ternary_mostly_null("ScalarExecutorTernaryFFFNull99", ExecutorBenchmarkType::TERNARY_EXECUTE, 0,
+                                      false, ExecutorNullProfile::MOSTLY_NULL);
+ExecutorBenchmark ternary_clustered_null("ScalarExecutorTernaryFFFNullClustered",
+                                         ExecutorBenchmarkType::TERNARY_EXECUTE, 0, false,
+                                         ExecutorNullProfile::CLUSTERED);
+ExecutorBenchmark ternary_optional("ScalarExecutorTernaryOptional", ExecutorBenchmarkType::TERNARY_OPTIONAL_EXECUTE);
+
+ExecutorBenchmark select_none("ScalarExecutorBinarySelectRate00", ExecutorBenchmarkType::BINARY_SELECT, 0, false,
+                              ExecutorNullProfile::NONE, 0);
+ExecutorBenchmark select_sparse("ScalarExecutorBinarySelectRate01", ExecutorBenchmarkType::BINARY_SELECT, 0, false,
+                                ExecutorNullProfile::NONE, 1);
+ExecutorBenchmark select_half("ScalarExecutorBinarySelectRate50", ExecutorBenchmarkType::BINARY_SELECT, 0, false,
+                              ExecutorNullProfile::NONE, 50);
+ExecutorBenchmark select_most("ScalarExecutorBinarySelectRate99", ExecutorBenchmarkType::BINARY_SELECT, 0, false,
+                              ExecutorNullProfile::NONE, 99);
+ExecutorBenchmark select_half_true("ScalarExecutorBinarySelectRate50True", ExecutorBenchmarkType::BINARY_SELECT, 0,
+                                   false, ExecutorNullProfile::NONE, 50, ExecutorSelectionOutput::TRUE_ONLY);
+ExecutorBenchmark select_half_false("ScalarExecutorBinarySelectRate50False", ExecutorBenchmarkType::BINARY_SELECT, 0,
+                                    false, ExecutorNullProfile::NONE, 50, ExecutorSelectionOutput::FALSE_ONLY);
+
+ExecutorBenchmark variadic_flat("ScalarExecutorVariadicFlat", ExecutorBenchmarkType::VARIADIC_EXECUTE);
+ExecutorBenchmark variadic_dictionary("ScalarExecutorVariadicDictionary", ExecutorBenchmarkType::VARIADIC_EXECUTE, 0,
+                                      true);
+
+} // namespace

--- a/src/common/vector_operations/CMakeLists.txt
+++ b/src/common/vector_operations/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(
   duckdb_vector_operations OBJECT
   boolean_operators.cpp
+  scalar_executor.cpp
   vector_cast.cpp
   comparison_operators.cpp
   vector_copy.cpp

--- a/src/common/vector_operations/scalar_executor.cpp
+++ b/src/common/vector_operations/scalar_executor.cpp
@@ -4,32 +4,23 @@ namespace duckdb {
 
 bool ScalarExecutor::PrepareGenericResultValidity(const UnifiedVectorFormat *formats, idx_t format_count,
                                                   Vector &result, idx_t count, bool preserve_result_validity,
-                                                  bool adds_nulls, ValidityMask &input_validity) {
-	bool initialized = false;
+                                                  bool adds_nulls) {
+	bool inputs_can_have_null = false;
 	for (idx_t input_idx = 0; input_idx < format_count; input_idx++) {
-		if (formats[input_idx].validity.CannotHaveNull()) {
-			continue;
-		}
-		ValidityMask mapped(count);
-		mapped.CopySel(formats[input_idx].validity, *formats[input_idx].sel, 0, 0, count);
-		if (!initialized) {
-			input_validity.Initialize(mapped);
-			initialized = true;
-		} else {
-			input_validity.Combine(mapped, count);
+		if (formats[input_idx].validity.CanHaveNull()) {
+			inputs_can_have_null = true;
+			break;
 		}
 	}
 
 	auto &result_validity = FlatVector::ValidityMutable(result);
-	if (initialized) {
-		result_validity.Initialize(input_validity);
-	} else if (!preserve_result_validity) {
+	if (inputs_can_have_null || !preserve_result_validity) {
 		result_validity.Reset(count);
 	} else if (adds_nulls && result_validity.CanHaveNull()) {
 		ValidityMask preserved(result_validity, count);
 		result_validity.Initialize(preserved);
 	}
-	return initialized;
+	return inputs_can_have_null;
 }
 
 } // namespace duckdb

--- a/src/common/vector_operations/scalar_executor.cpp
+++ b/src/common/vector_operations/scalar_executor.cpp
@@ -1,0 +1,35 @@
+#include "duckdb/common/vector_operations/scalar_executor.hpp"
+
+namespace duckdb {
+
+bool ScalarExecutor::PrepareGenericResultValidity(const UnifiedVectorFormat *formats, idx_t format_count,
+                                                  Vector &result, idx_t count, bool preserve_result_validity,
+                                                  bool adds_nulls, ValidityMask &input_validity) {
+	bool initialized = false;
+	for (idx_t input_idx = 0; input_idx < format_count; input_idx++) {
+		if (formats[input_idx].validity.CannotHaveNull()) {
+			continue;
+		}
+		ValidityMask mapped(count);
+		mapped.CopySel(formats[input_idx].validity, *formats[input_idx].sel, 0, 0, count);
+		if (!initialized) {
+			input_validity.Initialize(mapped);
+			initialized = true;
+		} else {
+			input_validity.Combine(mapped, count);
+		}
+	}
+
+	auto &result_validity = FlatVector::ValidityMutable(result);
+	if (initialized) {
+		result_validity.Initialize(input_validity);
+	} else if (!preserve_result_validity) {
+		result_validity.Reset(count);
+	} else if (adds_nulls && result_validity.CanHaveNull()) {
+		ValidityMask preserved(result_validity, count);
+		result_validity.Initialize(preserved);
+	}
+	return initialized;
+}
+
+} // namespace duckdb

--- a/src/include/duckdb/common/smaller_binary.hpp
+++ b/src/include/duckdb/common/smaller_binary.hpp
@@ -64,6 +64,14 @@
 #define DUCKDB_SB_FEATURE_binary_executor_select_flags DUCKDB_SB_DEFAULT // group: vector_specialization
 #endif
 
+#ifndef DUCKDB_SB_FEATURE_binary_executor_generic_no_null
+#define DUCKDB_SB_FEATURE_binary_executor_generic_no_null DUCKDB_SB_DEFAULT // group: vector_specialization
+#endif
+
+#ifndef DUCKDB_SB_FEATURE_variadic_executor_select_flat
+#define DUCKDB_SB_FEATURE_variadic_executor_select_flat DUCKDB_SB_DEFAULT // group: vector_specialization
+#endif
+
 #ifndef DUCKDB_SB_FEATURE_aggregate_executor_flat
 #define DUCKDB_SB_FEATURE_aggregate_executor_flat DUCKDB_SB_DEFAULT // group: vector_specialization
 #endif

--- a/src/include/duckdb/common/smaller_binary.hpp
+++ b/src/include/duckdb/common/smaller_binary.hpp
@@ -64,12 +64,16 @@
 #define DUCKDB_SB_FEATURE_binary_executor_select_flags DUCKDB_SB_DEFAULT // group: vector_specialization
 #endif
 
-#ifndef DUCKDB_SB_FEATURE_binary_executor_generic_no_null
-#define DUCKDB_SB_FEATURE_binary_executor_generic_no_null DUCKDB_SB_DEFAULT // group: vector_specialization
+#ifndef DUCKDB_SB_FEATURE_binary_executor_generic_nullable
+#define DUCKDB_SB_FEATURE_binary_executor_generic_nullable DUCKDB_SB_DEFAULT // group: vector_specialization
 #endif
 
 #ifndef DUCKDB_SB_FEATURE_variadic_executor_select_flat
 #define DUCKDB_SB_FEATURE_variadic_executor_select_flat DUCKDB_SB_DEFAULT // group: vector_specialization
+#endif
+
+#ifndef DUCKDB_SB_FEATURE_variadic_executor_select_flags
+#define DUCKDB_SB_FEATURE_variadic_executor_select_flags DUCKDB_SB_DEFAULT // group: vector_specialization
 #endif
 
 #ifndef DUCKDB_SB_FEATURE_aggregate_executor_flat

--- a/src/include/duckdb/common/smaller_binary.hpp
+++ b/src/include/duckdb/common/smaller_binary.hpp
@@ -52,6 +52,14 @@
 #define DUCKDB_SB_FEATURE_unary_executor_flat DUCKDB_SB_DEFAULT // group: vector_specialization
 #endif
 
+#ifndef DUCKDB_SB_FEATURE_unary_executor_select_flat
+#define DUCKDB_SB_FEATURE_unary_executor_select_flat DUCKDB_SB_DEFAULT // group: vector_specialization
+#endif
+
+#ifndef DUCKDB_SB_FEATURE_unary_executor_select_flags
+#define DUCKDB_SB_FEATURE_unary_executor_select_flags DUCKDB_SB_DEFAULT // group: vector_specialization
+#endif
+
 #ifndef DUCKDB_SB_FEATURE_binary_executor_flat
 #define DUCKDB_SB_FEATURE_binary_executor_flat DUCKDB_SB_DEFAULT // group: vector_specialization
 #endif
@@ -70,6 +78,10 @@
 
 #ifndef DUCKDB_SB_FEATURE_variadic_executor_select_flat
 #define DUCKDB_SB_FEATURE_variadic_executor_select_flat DUCKDB_SB_DEFAULT // group: vector_specialization
+#endif
+
+#ifndef DUCKDB_SB_FEATURE_variadic_executor_flat
+#define DUCKDB_SB_FEATURE_variadic_executor_flat DUCKDB_SB_DEFAULT // group: vector_specialization
 #endif
 
 #ifndef DUCKDB_SB_FEATURE_variadic_executor_select_flags

--- a/src/include/duckdb/common/vector_operations/binary_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/binary_executor.hpp
@@ -140,10 +140,10 @@ private:
 	struct SelectPolicy {
 #if !DUCKDB_SMALLER_BINARY(binary_executor_select_flat)
 		static constexpr uint64_t SPECIALIZED_MASKS = 0x7;
-		static constexpr bool DIRECT_TRUE_FLAT = true;
+		static constexpr uint64_t DIRECT_TRUE_FLAT_MASKS = 0x7;
 #else
 		static constexpr uint64_t SPECIALIZED_MASKS = 0;
-		static constexpr bool DIRECT_TRUE_FLAT = false;
+		static constexpr uint64_t DIRECT_TRUE_FLAT_MASKS = 0;
 #endif
 #if !DUCKDB_SMALLER_BINARY(binary_executor_select_flags)
 		static constexpr bool SPECIALIZE_OUTPUTS = true;

--- a/src/include/duckdb/common/vector_operations/binary_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/binary_executor.hpp
@@ -123,82 +123,42 @@ struct BinarySelectAdapter {
 
 struct BinaryExecutor {
 private:
-#if !DUCKDB_SMALLER_BINARY(binary_executor_select_flat)
-	template <class LEFT_TYPE, class RIGHT_TYPE, class OP, bool LEFT_CONSTANT, bool RIGHT_CONSTANT>
-	static idx_t SelectTrueFlatLoop(const LEFT_TYPE *__restrict left_data, const RIGHT_TYPE *__restrict right_data,
-	                                const SelectionVector &sel, idx_t count, const ValidityMask &validity,
-	                                SelectionVector &true_sel) {
-		idx_t true_count = 0;
-		idx_t base_idx = 0;
-		auto entry_count = ValidityMask::EntryCount(count);
-		for (idx_t entry_idx = 0; entry_idx < entry_count; entry_idx++) {
-			auto validity_entry = validity.GetValidityEntry(entry_idx);
-			auto next = MinValue<idx_t>(base_idx + ValidityMask::BITS_PER_VALUE, count);
-			if (ValidityMask::AllValid(validity_entry)) {
-				for (; base_idx < next; base_idx++) {
-					auto result_idx = sel.get_index(base_idx);
-					bool comparison_result = OP::Operation(left_data[LEFT_CONSTANT ? 0 : base_idx],
-					                                       right_data[RIGHT_CONSTANT ? 0 : base_idx]);
-					true_sel.set_index(true_count, result_idx);
-					true_count += comparison_result;
-				}
-			} else if (ValidityMask::NoneValid(validity_entry)) {
-				base_idx = next;
-			} else {
-				auto start = base_idx;
-				for (; base_idx < next; base_idx++) {
-					auto result_idx = sel.get_index(base_idx);
-					bool comparison_result = ValidityMask::RowIsValid(validity_entry, base_idx - start) &&
-					                         OP::Operation(left_data[LEFT_CONSTANT ? 0 : base_idx],
-					                                       right_data[RIGHT_CONSTANT ? 0 : base_idx]);
-					true_sel.set_index(true_count, result_idx);
-					true_count += comparison_result;
-				}
-			}
-		}
-		return true_count;
-	}
-
-	template <class LEFT_TYPE, class RIGHT_TYPE, class OP, bool LEFT_CONSTANT, bool RIGHT_CONSTANT>
-	static idx_t SelectTrueFlat(const Vector &left, const Vector &right, const SelectionVector &sel, idx_t count,
-	                            SelectionVector &true_sel) {
-		if ((LEFT_CONSTANT && ConstantVector::IsNull(left)) || (RIGHT_CONSTANT && ConstantVector::IsNull(right))) {
-			return 0;
-		}
-		auto left_data = FlatVector::GetData<LEFT_TYPE>(left);
-		auto right_data = FlatVector::GetData<RIGHT_TYPE>(right);
-		if constexpr (LEFT_CONSTANT) {
-			return SelectTrueFlatLoop<LEFT_TYPE, RIGHT_TYPE, OP, LEFT_CONSTANT, RIGHT_CONSTANT>(
-			    left_data, right_data, sel, count, FlatVector::Validity(right), true_sel);
-		} else if constexpr (RIGHT_CONSTANT) {
-			return SelectTrueFlatLoop<LEFT_TYPE, RIGHT_TYPE, OP, LEFT_CONSTANT, RIGHT_CONSTANT>(
-			    left_data, right_data, sel, count, FlatVector::Validity(left), true_sel);
-		} else {
-			ValidityMask combined_validity = FlatVector::Validity(left);
-			combined_validity.Combine(FlatVector::Validity(right), count);
-			return SelectTrueFlatLoop<LEFT_TYPE, RIGHT_TYPE, OP, LEFT_CONSTANT, RIGHT_CONSTANT>(
-			    left_data, right_data, sel, count, combined_validity, true_sel);
-		}
-	}
+	struct ExecutePolicy {
+#if !DUCKDB_SMALLER_BINARY(binary_executor_flat)
+		static constexpr bool SPECIALIZE_FLAT = true;
+#else
+		static constexpr bool SPECIALIZE_FLAT = false;
 #endif
+#if !DUCKDB_SMALLER_BINARY(binary_executor_generic_nullable)
+		static constexpr bool SPECIALIZE_NULLABLE_GENERIC_SELECTIONS = true;
+#else
+		static constexpr bool SPECIALIZE_NULLABLE_GENERIC_SELECTIONS = false;
+#endif
+		static constexpr bool PRESERVE_RESULT_VALIDITY = false;
+	};
+
+	struct SelectPolicy {
+#if !DUCKDB_SMALLER_BINARY(binary_executor_select_flat)
+		static constexpr uint64_t SPECIALIZED_MASKS = 0x7;
+		static constexpr bool DIRECT_TRUE_FLAT = true;
+#else
+		static constexpr uint64_t SPECIALIZED_MASKS = 0;
+		static constexpr bool DIRECT_TRUE_FLAT = false;
+#endif
+#if !DUCKDB_SMALLER_BINARY(binary_executor_select_flags)
+		static constexpr bool SPECIALIZE_OUTPUTS = true;
+#else
+		static constexpr bool SPECIALIZE_OUTPUTS = false;
+#endif
+	};
 
 	template <bool ADDS_NULLS, class LEFT_TYPE, class RIGHT_TYPE, class RESULT_TYPE, class OPWRAPPER, class OP,
 	          class FUNC>
 	static void ExecuteSwitchInternal(const Vector &left, const Vector &right, Vector &result, idx_t count, FUNC &fun) {
 		std::array<ScalarExecutor::VectorRef, 2> inputs = {{left, right}};
 		BinaryScalarAdapter<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, OPWRAPPER, OP, FUNC, ADDS_NULLS> adapter(fun);
-#if !DUCKDB_SMALLER_BINARY(binary_executor_generic_nullable)
-		static constexpr bool SPECIALIZE_NULLABLE_GENERIC_SELECTIONS = true;
-#else
-		static constexpr bool SPECIALIZE_NULLABLE_GENERIC_SELECTIONS = false;
-#endif
-#if !DUCKDB_SMALLER_BINARY(binary_executor_flat)
-		ScalarExecutor::Execute<true, SPECIALIZE_NULLABLE_GENERIC_SELECTIONS, false, RESULT_TYPE, decltype(adapter),
-		                        LEFT_TYPE, RIGHT_TYPE>(inputs, result, count, adapter);
-#else
-		ScalarExecutor::Execute<false, SPECIALIZE_NULLABLE_GENERIC_SELECTIONS, false, RESULT_TYPE, decltype(adapter),
-		                        LEFT_TYPE, RIGHT_TYPE>(inputs, result, count, adapter);
-#endif
+		ScalarExecutor::Execute<ExecutePolicy, RESULT_TYPE, decltype(adapter), LEFT_TYPE, RIGHT_TYPE>(inputs, result,
+		                                                                                              count, adapter);
 	}
 
 	template <class LEFT_TYPE, class RIGHT_TYPE, class RESULT_TYPE, class OPWRAPPER, class OP, class FUNC>
@@ -225,17 +185,7 @@ private:
 	static idx_t SelectShared(const std::array<ScalarExecutor::VectorRef, 2> &inputs, const SelectionVector *sel,
 	                          idx_t count, SelectionVector *true_sel, SelectionVector *false_sel) {
 		BinarySelectAdapter<LEFT_TYPE, RIGHT_TYPE, OP> adapter;
-#if !DUCKDB_SMALLER_BINARY(binary_executor_select_flat)
-		static constexpr uint64_t SPECIALIZED_MASKS = 0x7;
-#else
-		static constexpr uint64_t SPECIALIZED_MASKS = 0;
-#endif
-#if !DUCKDB_SMALLER_BINARY(binary_executor_select_flags)
-		static constexpr bool SPECIALIZE_OUTPUTS = true;
-#else
-		static constexpr bool SPECIALIZE_OUTPUTS = false;
-#endif
-		return ScalarExecutor::Select<SPECIALIZED_MASKS, SPECIALIZE_OUTPUTS, decltype(adapter), LEFT_TYPE, RIGHT_TYPE>(
+		return ScalarExecutor::Select<SelectPolicy, decltype(adapter), LEFT_TYPE, RIGHT_TYPE>(
 		    inputs, sel, count, true_sel, false_sel, adapter);
 	}
 
@@ -284,22 +234,6 @@ public:
 	static idx_t Select(const Vector &left, const Vector &right, const SelectionVector *sel, idx_t count,
 	                    SelectionVector *true_sel, SelectionVector *false_sel) {
 		std::array<ScalarExecutor::VectorRef, 2> inputs = {{left, right}};
-#if !DUCKDB_SMALLER_BINARY(binary_executor_select_flat)
-		if (true_sel && !false_sel) {
-			if (!sel) {
-				sel = FlatVector::IncrementalSelectionVector();
-			}
-			auto left_type = left.GetVectorType();
-			auto right_type = right.GetVectorType();
-			if (left_type == VectorType::FLAT_VECTOR && right_type == VectorType::FLAT_VECTOR) {
-				return SelectTrueFlat<LEFT_TYPE, RIGHT_TYPE, OP, false, false>(left, right, *sel, count, *true_sel);
-			} else if (left_type == VectorType::FLAT_VECTOR && right_type == VectorType::CONSTANT_VECTOR) {
-				return SelectTrueFlat<LEFT_TYPE, RIGHT_TYPE, OP, false, true>(left, right, *sel, count, *true_sel);
-			} else if (left_type == VectorType::CONSTANT_VECTOR && right_type == VectorType::FLAT_VECTOR) {
-				return SelectTrueFlat<LEFT_TYPE, RIGHT_TYPE, OP, true, false>(left, right, *sel, count, *true_sel);
-			}
-		}
-#endif
 		return SelectShared<LEFT_TYPE, RIGHT_TYPE, OP>(inputs, sel, count, true_sel, false_sel);
 	}
 };

--- a/src/include/duckdb/common/vector_operations/binary_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/binary_executor.hpp
@@ -107,6 +107,18 @@ struct BinarySelectAdapter {
 	inline bool Operation(LEFT_TYPE left, RIGHT_TYPE right) {
 		return OP::Operation(left, right);
 	}
+
+	inline bool OperationNoNull(LEFT_TYPE left, RIGHT_TYPE right) {
+		if constexpr (ComparisonSelectComplement<OP>::FOLD) {
+			using FOLDED = ComparisonSelectComplement<OP>;
+			using COMPLEMENT = typename FOLDED::COMPLEMENT;
+			if constexpr (FOLDED::SWAP_OPERANDS) {
+				return !COMPLEMENT::Operation(right, left);
+			}
+			return !COMPLEMENT::Operation(left, right);
+		}
+		return Operation(left, right);
+	}
 };
 
 struct BinaryExecutor {
@@ -285,24 +297,6 @@ public:
 				return SelectTrueFlat<LEFT_TYPE, RIGHT_TYPE, OP, false, true>(left, right, *sel, count, *true_sel);
 			} else if (left_type == VectorType::CONSTANT_VECTOR && right_type == VectorType::FLAT_VECTOR) {
 				return SelectTrueFlat<LEFT_TYPE, RIGHT_TYPE, OP, true, false>(left, right, *sel, count, *true_sel);
-			}
-		}
-#endif
-#if !DUCKDB_SMALLER_BINARY(binary_executor_select_flags)
-		if constexpr (ComparisonSelectComplement<OP>::FOLD) {
-			auto left_type = left.GetVectorType();
-			auto right_type = right.GetVectorType();
-			bool flat_profile = (left_type == VectorType::FLAT_VECTOR || left_type == VectorType::CONSTANT_VECTOR) &&
-			                    (right_type == VectorType::FLAT_VECTOR || right_type == VectorType::CONSTANT_VECTOR);
-			if (!flat_profile && !ScalarExecutor::InputsCanHaveNull<LEFT_TYPE, RIGHT_TYPE>(inputs)) {
-				using FOLDED = ComparisonSelectComplement<OP>;
-				if constexpr (FOLDED::SWAP_OPERANDS) {
-					std::array<ScalarExecutor::VectorRef, 2> swapped = {{right, left}};
-					return count - SelectShared<RIGHT_TYPE, LEFT_TYPE, typename FOLDED::COMPLEMENT>(
-					                   swapped, sel, count, false_sel, true_sel);
-				}
-				return count - SelectShared<LEFT_TYPE, RIGHT_TYPE, typename FOLDED::COMPLEMENT>(inputs, sel, count,
-				                                                                                false_sel, true_sel);
 			}
 		}
 #endif

--- a/src/include/duckdb/common/vector_operations/binary_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/binary_executor.hpp
@@ -187,17 +187,17 @@ private:
 	static void ExecuteSwitchInternal(const Vector &left, const Vector &right, Vector &result, idx_t count, FUNC &fun) {
 		std::array<ScalarExecutor::VectorRef, 2> inputs = {{left, right}};
 		BinaryScalarAdapter<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, OPWRAPPER, OP, FUNC, ADDS_NULLS> adapter(fun);
-#if !DUCKDB_SMALLER_BINARY(binary_executor_generic_no_null)
-		static constexpr bool SPECIALIZE_GENERIC_SELECTIONS = true;
+#if !DUCKDB_SMALLER_BINARY(binary_executor_generic_nullable)
+		static constexpr bool SPECIALIZE_NULLABLE_GENERIC_SELECTIONS = true;
 #else
-		static constexpr bool SPECIALIZE_GENERIC_SELECTIONS = false;
+		static constexpr bool SPECIALIZE_NULLABLE_GENERIC_SELECTIONS = false;
 #endif
 #if !DUCKDB_SMALLER_BINARY(binary_executor_flat)
-		ScalarExecutor::Execute<true, SPECIALIZE_GENERIC_SELECTIONS, false, RESULT_TYPE, decltype(adapter), LEFT_TYPE,
-		                        RIGHT_TYPE>(inputs, result, count, adapter);
+		ScalarExecutor::Execute<true, SPECIALIZE_NULLABLE_GENERIC_SELECTIONS, false, RESULT_TYPE, decltype(adapter),
+		                        LEFT_TYPE, RIGHT_TYPE>(inputs, result, count, adapter);
 #else
-		ScalarExecutor::Execute<false, SPECIALIZE_GENERIC_SELECTIONS, false, RESULT_TYPE, decltype(adapter), LEFT_TYPE,
-		                        RIGHT_TYPE>(inputs, result, count, adapter);
+		ScalarExecutor::Execute<false, SPECIALIZE_NULLABLE_GENERIC_SELECTIONS, false, RESULT_TYPE, decltype(adapter),
+		                        LEFT_TYPE, RIGHT_TYPE>(inputs, result, count, adapter);
 #endif
 	}
 

--- a/src/include/duckdb/common/vector_operations/binary_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/binary_executor.hpp
@@ -3,43 +3,38 @@
 //
 // duckdb/common/vector_operations/binary_executor.hpp
 //
-//
 //===----------------------------------------------------------------------===//
 
 #pragma once
 
-#include "duckdb/common/exception.hpp"
 #include "duckdb/common/operator/comparison_operators.hpp"
 #include "duckdb/common/optional.hpp"
-#include "duckdb/common/types/vector.hpp"
-#include "duckdb/common/vector/constant_vector.hpp"
-#include "duckdb/common/vector/flat_vector.hpp"
+#include "duckdb/common/smaller_binary.hpp"
+#include "duckdb/common/vector_operations/scalar_executor.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 
-#include "duckdb/common/smaller_binary.hpp"
 #include <functional>
+#include <type_traits>
 
 namespace duckdb {
 
-//! Complement-fold trait for comparison selection. On the NO_NULL path a comparison op's selection
-//! is the exact complement of its complement op's selection (no NULL third bucket).
-//! Note LessThanEquals is not handled since that's done upstream in the general case (see
-//! VectorOperations::LessThan[Equals])
 template <class OP>
 struct ComparisonSelectComplement {
 	static constexpr bool FOLD = false;
 };
+
 template <>
 struct ComparisonSelectComplement<NotEquals> {
 	static constexpr bool FOLD = true;
 	using COMPLEMENT = Equals;
 	static constexpr bool SWAP_OPERANDS = false;
 };
+
 template <>
 struct ComparisonSelectComplement<GreaterThanEquals> {
 	static constexpr bool FOLD = true;
 	using COMPLEMENT = GreaterThan;
-	static constexpr bool SWAP_OPERANDS = true; // GreaterThanEquals(a,b) == !GreaterThan(b,a)
+	static constexpr bool SWAP_OPERANDS = true;
 };
 
 struct DefaultNullCheckOperator {
@@ -51,22 +46,22 @@ struct DefaultNullCheckOperator {
 
 struct BinaryStandardOperatorWrapper {
 	template <class FUNC, class OP, class LEFT_TYPE, class RIGHT_TYPE, class RESULT_TYPE>
-	static inline RESULT_TYPE Operation(FUNC fun, LEFT_TYPE left, RIGHT_TYPE right, ValidityMask &mask, idx_t idx) {
+	static inline RESULT_TYPE Operation(FUNC &fun, LEFT_TYPE left, RIGHT_TYPE right, ValidityMask &mask, idx_t idx) {
 		return OP::template Operation<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE>(left, right);
 	}
 
-	static bool AddsNulls() {
+	static constexpr bool AddsNulls() {
 		return false;
 	}
 };
 
 struct BinarySingleArgumentOperatorWrapper {
 	template <class FUNC, class OP, class LEFT_TYPE, class RIGHT_TYPE, class RESULT_TYPE>
-	static inline RESULT_TYPE Operation(FUNC fun, LEFT_TYPE left, RIGHT_TYPE right, ValidityMask &mask, idx_t idx) {
+	static inline RESULT_TYPE Operation(FUNC &fun, LEFT_TYPE left, RIGHT_TYPE right, ValidityMask &mask, idx_t idx) {
 		return OP::template Operation<LEFT_TYPE>(left, right);
 	}
 
-	static bool AddsNulls() {
+	static constexpr bool AddsNulls() {
 		return false;
 	}
 };
@@ -74,7 +69,7 @@ struct BinarySingleArgumentOperatorWrapper {
 template <bool ADDS_NULLS>
 struct BinaryLambdaWrapper {
 	template <class FUNC, class OP, class LEFT_TYPE, class RIGHT_TYPE, class RESULT_TYPE>
-	static inline RESULT_TYPE Operation(FUNC fun, LEFT_TYPE left, RIGHT_TYPE right, ValidityMask &mask, idx_t idx) {
+	static inline RESULT_TYPE Operation(FUNC &fun, LEFT_TYPE left, RIGHT_TYPE right, ValidityMask &mask, idx_t idx) {
 		if constexpr (ADDS_NULLS) {
 			auto result = fun(left, right);
 			if (!result.has_value()) {
@@ -87,228 +82,124 @@ struct BinaryLambdaWrapper {
 		}
 	}
 
-	static bool AddsNulls() {
+	static constexpr bool AddsNulls() {
 		return ADDS_NULLS;
 	}
 };
 
+template <class LEFT_TYPE, class RIGHT_TYPE, class RESULT_TYPE, class OPWRAPPER, class OP, class FUNC,
+          bool CAN_ADD_NULLS>
+struct BinaryScalarAdapter {
+	static constexpr bool ADDS_NULLS = CAN_ADD_NULLS;
+
+	explicit BinaryScalarAdapter(FUNC &fun_p) : fun(fun_p) {
+	}
+
+	inline RESULT_TYPE Operation(ValidityMask &mask, idx_t idx, LEFT_TYPE left, RIGHT_TYPE right) {
+		return OPWRAPPER::template Operation<FUNC, OP, LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE>(fun, left, right, mask, idx);
+	}
+
+	FUNC &fun;
+};
+
+template <class LEFT_TYPE, class RIGHT_TYPE, class OP>
+struct BinarySelectAdapter {
+	inline bool Operation(LEFT_TYPE left, RIGHT_TYPE right) {
+		return OP::Operation(left, right);
+	}
+};
+
 struct BinaryExecutor {
-#if !DUCKDB_SMALLER_BINARY(binary_executor_flat)
-	template <class LEFT_TYPE, class RIGHT_TYPE, class RESULT_TYPE, class OPWRAPPER, class OP, class FUNC,
-	          bool LEFT_CONSTANT, bool RIGHT_CONSTANT>
-	static void ExecuteFlatLoop(const LEFT_TYPE *__restrict ldata, const RIGHT_TYPE *__restrict rdata,
-	                            RESULT_TYPE *__restrict result_data, idx_t count, ValidityMask &mask, FUNC fun) {
-		if (!LEFT_CONSTANT) {
-			ASSERT_RESTRICT(ldata, ldata + count, result_data, result_data + count);
-		}
-		if (!RIGHT_CONSTANT) {
-			ASSERT_RESTRICT(rdata, rdata + count, result_data, result_data + count);
-		}
-
-		if (mask.CanHaveNull()) {
-			idx_t base_idx = 0;
-			auto entry_count = ValidityMask::EntryCount(count);
-			for (idx_t entry_idx = 0; entry_idx < entry_count; entry_idx++) {
-				auto validity_entry = mask.GetValidityEntry(entry_idx);
-				idx_t next = MinValue<idx_t>(base_idx + ValidityMask::BITS_PER_VALUE, count);
-				if (ValidityMask::AllValid(validity_entry)) {
-					// all valid: perform operation
-					for (; base_idx < next; base_idx++) {
-						auto lentry = ldata[LEFT_CONSTANT ? 0 : base_idx];
-						auto rentry = rdata[RIGHT_CONSTANT ? 0 : base_idx];
-						result_data[base_idx] =
-						    OPWRAPPER::template Operation<FUNC, OP, LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE>(
-						        fun, lentry, rentry, mask, base_idx);
-					}
-				} else if (ValidityMask::NoneValid(validity_entry)) {
-					// nothing valid: skip all
-					base_idx = next;
-					continue;
-				} else {
-					// partially valid: need to check individual elements for validity
-					idx_t start = base_idx;
-					for (; base_idx < next; base_idx++) {
-						if (ValidityMask::RowIsValid(validity_entry, base_idx - start)) {
-							auto lentry = ldata[LEFT_CONSTANT ? 0 : base_idx];
-							auto rentry = rdata[RIGHT_CONSTANT ? 0 : base_idx];
-							result_data[base_idx] =
-							    OPWRAPPER::template Operation<FUNC, OP, LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE>(
-							        fun, lentry, rentry, mask, base_idx);
-						}
-					}
-				}
-			}
-		} else {
-			for (idx_t i = 0; i < count; i++) {
-				auto lentry = ldata[LEFT_CONSTANT ? 0 : i];
-				auto rentry = rdata[RIGHT_CONSTANT ? 0 : i];
-				result_data[i] = OPWRAPPER::template Operation<FUNC, OP, LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE>(
-				    fun, lentry, rentry, mask, i);
-			}
-		}
-	}
-#endif
-
-	template <class LEFT_TYPE, class RIGHT_TYPE, class RESULT_TYPE, class OPWRAPPER, class OP, class FUNC>
-	static void ExecuteConstant(const Vector &left, const Vector &right, Vector &result, idx_t count, FUNC fun) {
-		result.SetVectorType(VectorType::CONSTANT_VECTOR);
-		if (result.size() != count) {
-			FlatVector::SetSize(result, count);
-		}
-
-		auto ldata = ConstantVector::GetData<LEFT_TYPE>(left);
-		auto rdata = ConstantVector::GetData<RIGHT_TYPE>(right);
-		auto result_data = ConstantVector::GetData<RESULT_TYPE>(result);
-
-		if (ConstantVector::IsNull(left) || ConstantVector::IsNull(right)) {
-			ConstantVector::SetNull(result, count_t(count));
-			return;
-		}
-		*result_data = OPWRAPPER::template Operation<FUNC, OP, LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE>(
-		    fun, *ldata, *rdata, ConstantVector::Validity(result), 0);
-	}
-
-#if !DUCKDB_SMALLER_BINARY(binary_executor_flat)
-	template <class LEFT_TYPE, class RIGHT_TYPE, class RESULT_TYPE, class OPWRAPPER, class OP, class FUNC,
-	          bool LEFT_CONSTANT, bool RIGHT_CONSTANT>
-	static void ExecuteFlat(const Vector &left, const Vector &right, Vector &result, idx_t count, FUNC fun) {
-		auto ldata = LEFT_CONSTANT ? ConstantVector::GetData<LEFT_TYPE>(left) : FlatVector::GetData<LEFT_TYPE>(left);
-		auto rdata =
-		    RIGHT_CONSTANT ? ConstantVector::GetData<RIGHT_TYPE>(right) : FlatVector::GetData<RIGHT_TYPE>(right);
-
-		if ((LEFT_CONSTANT && ConstantVector::IsNull(left)) || (RIGHT_CONSTANT && ConstantVector::IsNull(right))) {
-			// either left or right is constant NULL: result is constant NULL
-			ConstantVector::SetNull(result, count_t(count));
-			return;
-		}
-
-		result.SetVectorType(VectorType::FLAT_VECTOR);
-		if (result.size() != count) {
-			FlatVector::SetSize(result, count);
-		}
-		auto result_data = FlatVector::GetDataMutable<RESULT_TYPE>(result);
-		auto &result_validity = FlatVector::ValidityMutable(result);
-		if (LEFT_CONSTANT) {
-			if (OPWRAPPER::AddsNulls()) {
-				result_validity.Copy(FlatVector::Validity(right), count);
-			} else {
-				FlatVector::SetValidity(result, FlatVector::Validity(right));
-			}
-		} else if (RIGHT_CONSTANT) {
-			if (OPWRAPPER::AddsNulls()) {
-				result_validity.Copy(FlatVector::Validity(left), count);
-			} else {
-				FlatVector::SetValidity(result, FlatVector::Validity(left));
-			}
-		} else {
-			if (OPWRAPPER::AddsNulls()) {
-				result_validity.Copy(FlatVector::Validity(left), count);
-				if (result_validity.CannotHaveNull()) {
-					result_validity.Copy(FlatVector::Validity(right), count);
-				} else {
-					result_validity.Combine(FlatVector::Validity(right), count);
-				}
-			} else {
-				FlatVector::SetValidity(result, FlatVector::Validity(left));
-				result_validity.Combine(FlatVector::Validity(right), count);
-			}
-		}
-		ExecuteFlatLoop<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, OPWRAPPER, OP, FUNC, LEFT_CONSTANT, RIGHT_CONSTANT>(
-		    ldata, rdata, result_data, count, result_validity, fun);
-	}
-#endif
-
-	template <class LEFT_TYPE, class RIGHT_TYPE, class RESULT_TYPE, class OPWRAPPER, class OP, class FUNC>
-	static void ExecuteGenericLoop(const LEFT_TYPE *__restrict ldata, const RIGHT_TYPE *__restrict rdata,
-	                               RESULT_TYPE *__restrict result_data, const SelectionVector *__restrict lsel,
-	                               const SelectionVector *__restrict rsel, idx_t count, const ValidityMask &lvalidity,
-	                               const ValidityMask &rvalidity, ValidityMask &result_validity, FUNC fun) {
-		if (lvalidity.CanHaveNull() || rvalidity.CanHaveNull()) {
-			for (idx_t i = 0; i < count; i++) {
-				auto lindex = lsel->get_index(i);
-				auto rindex = rsel->get_index(i);
-				if (lvalidity.RowIsValid(lindex) && rvalidity.RowIsValid(rindex)) {
-					auto lentry = ldata[lindex];
-					auto rentry = rdata[rindex];
-					result_data[i] = OPWRAPPER::template Operation<FUNC, OP, LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE>(
-					    fun, lentry, rentry, result_validity, i);
-				} else {
-					result_validity.SetInvalid(i);
-				}
-			}
-		} else {
-			for (idx_t i = 0; i < count; i++) {
-				auto lentry = ldata[lsel->get_index(i)];
-				auto rentry = rdata[rsel->get_index(i)];
-				result_data[i] = OPWRAPPER::template Operation<FUNC, OP, LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE>(
-				    fun, lentry, rentry, result_validity, i);
-			}
-		}
-	}
-
-	template <class LEFT_TYPE, class RIGHT_TYPE, class RESULT_TYPE, class OPWRAPPER, class OP, class FUNC>
-	static void ExecuteGeneric(const Vector &left, const Vector &right, Vector &result, idx_t count, FUNC fun) {
-		UnifiedVectorFormat ldata, rdata;
-
-		left.ToUnifiedFormat(ldata);
-		right.ToUnifiedFormat(rdata);
-
-		result.SetVectorType(VectorType::FLAT_VECTOR);
-		if (result.size() != count) {
-			FlatVector::SetSize(result, count);
-		}
-		auto result_data = FlatVector::GetDataMutable<RESULT_TYPE>(result);
-		ExecuteGenericLoop<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, OPWRAPPER, OP, FUNC>(
-		    UnifiedVectorFormat::GetData<LEFT_TYPE>(ldata), UnifiedVectorFormat::GetData<RIGHT_TYPE>(rdata),
-		    result_data, ldata.sel, rdata.sel, count, ldata.validity, rdata.validity,
-		    FlatVector::ValidityMutable(result), fun);
-	}
-
-	template <class LEFT_TYPE, class RIGHT_TYPE, class RESULT_TYPE, class OPWRAPPER, class OP, class FUNC>
-	static void ExecuteSwitch(const Vector &left, const Vector &right, Vector &result, idx_t count, FUNC fun) {
-		auto left_vector_type = left.GetVectorType();
-		auto right_vector_type = right.GetVectorType();
-		if (left_vector_type == VectorType::CONSTANT_VECTOR && right_vector_type == VectorType::CONSTANT_VECTOR) {
-			ExecuteConstant<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, OPWRAPPER, OP, FUNC>(left, right, result, count, fun);
-#if !DUCKDB_SMALLER_BINARY(binary_executor_flat)
-		} else if (left_vector_type == VectorType::FLAT_VECTOR && right_vector_type == VectorType::CONSTANT_VECTOR) {
-			ExecuteFlat<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, OPWRAPPER, OP, FUNC, false, true>(left, right, result,
-			                                                                                  count, fun);
-		} else if (left_vector_type == VectorType::CONSTANT_VECTOR && right_vector_type == VectorType::FLAT_VECTOR) {
-			ExecuteFlat<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, OPWRAPPER, OP, FUNC, true, false>(left, right, result,
-			                                                                                  count, fun);
-		} else if (left_vector_type == VectorType::FLAT_VECTOR && right_vector_type == VectorType::FLAT_VECTOR) {
-			ExecuteFlat<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, OPWRAPPER, OP, FUNC, false, false>(left, right, result,
-			                                                                                   count, fun);
-#endif
-		} else {
-			ExecuteGeneric<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, OPWRAPPER, OP, FUNC>(left, right, result, count, fun);
-		}
-	}
-
-public:
-	template <class LEFT_TYPE, class RIGHT_TYPE, class RESULT_TYPE,
-	          class FUNC = std::function<RESULT_TYPE(LEFT_TYPE, RIGHT_TYPE)>>
-	static void Execute(const Vector &left, const Vector &right, Vector &result, idx_t count, FUNC fun) {
-		constexpr bool adds_nulls = std::is_same<decltype(fun(std::declval<LEFT_TYPE>(), std::declval<RIGHT_TYPE>())),
-		                                         optional<RESULT_TYPE>>::value;
-		ExecuteSwitch<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, BinaryLambdaWrapper<adds_nulls>, bool, FUNC>(
-		    left, right, result, count, fun);
-	}
-
-	template <class LEFT_TYPE, class RIGHT_TYPE, class RESULT_TYPE, class OP,
-	          class OPWRAPPER = BinarySingleArgumentOperatorWrapper>
-	static void Execute(const Vector &left, const Vector &right, Vector &result, idx_t count) {
-		ExecuteSwitch<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, OPWRAPPER, OP, bool>(left, right, result, count, false);
-	}
-
-	template <class LEFT_TYPE, class RIGHT_TYPE, class RESULT_TYPE, class OP>
-	static void ExecuteStandard(const Vector &left, const Vector &right, Vector &result, idx_t count) {
-		ExecuteSwitch<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, BinaryStandardOperatorWrapper, OP, bool>(left, right, result,
-		                                                                                           count, false);
-	}
-
 private:
+#if !DUCKDB_SMALLER_BINARY(binary_executor_select_flat)
+	template <class LEFT_TYPE, class RIGHT_TYPE, class OP, bool LEFT_CONSTANT, bool RIGHT_CONSTANT>
+	static idx_t SelectTrueFlatLoop(const LEFT_TYPE *__restrict left_data, const RIGHT_TYPE *__restrict right_data,
+	                                const SelectionVector &sel, idx_t count, const ValidityMask &validity,
+	                                SelectionVector &true_sel) {
+		idx_t true_count = 0;
+		idx_t base_idx = 0;
+		auto entry_count = ValidityMask::EntryCount(count);
+		for (idx_t entry_idx = 0; entry_idx < entry_count; entry_idx++) {
+			auto validity_entry = validity.GetValidityEntry(entry_idx);
+			auto next = MinValue<idx_t>(base_idx + ValidityMask::BITS_PER_VALUE, count);
+			if (ValidityMask::AllValid(validity_entry)) {
+				for (; base_idx < next; base_idx++) {
+					auto result_idx = sel.get_index(base_idx);
+					bool comparison_result = OP::Operation(left_data[LEFT_CONSTANT ? 0 : base_idx],
+					                                       right_data[RIGHT_CONSTANT ? 0 : base_idx]);
+					true_sel.set_index(true_count, result_idx);
+					true_count += comparison_result;
+				}
+			} else if (ValidityMask::NoneValid(validity_entry)) {
+				base_idx = next;
+			} else {
+				auto start = base_idx;
+				for (; base_idx < next; base_idx++) {
+					auto result_idx = sel.get_index(base_idx);
+					bool comparison_result = ValidityMask::RowIsValid(validity_entry, base_idx - start) &&
+					                         OP::Operation(left_data[LEFT_CONSTANT ? 0 : base_idx],
+					                                       right_data[RIGHT_CONSTANT ? 0 : base_idx]);
+					true_sel.set_index(true_count, result_idx);
+					true_count += comparison_result;
+				}
+			}
+		}
+		return true_count;
+	}
+
+	template <class LEFT_TYPE, class RIGHT_TYPE, class OP, bool LEFT_CONSTANT, bool RIGHT_CONSTANT>
+	static idx_t SelectTrueFlat(const Vector &left, const Vector &right, const SelectionVector &sel, idx_t count,
+	                            SelectionVector &true_sel) {
+		if ((LEFT_CONSTANT && ConstantVector::IsNull(left)) || (RIGHT_CONSTANT && ConstantVector::IsNull(right))) {
+			return 0;
+		}
+		auto left_data = FlatVector::GetData<LEFT_TYPE>(left);
+		auto right_data = FlatVector::GetData<RIGHT_TYPE>(right);
+		if constexpr (LEFT_CONSTANT) {
+			return SelectTrueFlatLoop<LEFT_TYPE, RIGHT_TYPE, OP, LEFT_CONSTANT, RIGHT_CONSTANT>(
+			    left_data, right_data, sel, count, FlatVector::Validity(right), true_sel);
+		} else if constexpr (RIGHT_CONSTANT) {
+			return SelectTrueFlatLoop<LEFT_TYPE, RIGHT_TYPE, OP, LEFT_CONSTANT, RIGHT_CONSTANT>(
+			    left_data, right_data, sel, count, FlatVector::Validity(left), true_sel);
+		} else {
+			ValidityMask combined_validity = FlatVector::Validity(left);
+			combined_validity.Combine(FlatVector::Validity(right), count);
+			return SelectTrueFlatLoop<LEFT_TYPE, RIGHT_TYPE, OP, LEFT_CONSTANT, RIGHT_CONSTANT>(
+			    left_data, right_data, sel, count, combined_validity, true_sel);
+		}
+	}
+#endif
+
+	template <bool ADDS_NULLS, class LEFT_TYPE, class RIGHT_TYPE, class RESULT_TYPE, class OPWRAPPER, class OP,
+	          class FUNC>
+	static void ExecuteSwitchInternal(const Vector &left, const Vector &right, Vector &result, idx_t count, FUNC &fun) {
+		std::array<ScalarExecutor::VectorRef, 2> inputs = {{left, right}};
+		BinaryScalarAdapter<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, OPWRAPPER, OP, FUNC, ADDS_NULLS> adapter(fun);
+#if !DUCKDB_SMALLER_BINARY(binary_executor_generic_no_null)
+		static constexpr bool SPECIALIZE_GENERIC_SELECTIONS = true;
+#else
+		static constexpr bool SPECIALIZE_GENERIC_SELECTIONS = false;
+#endif
+#if !DUCKDB_SMALLER_BINARY(binary_executor_flat)
+		ScalarExecutor::Execute<true, SPECIALIZE_GENERIC_SELECTIONS, false, RESULT_TYPE, decltype(adapter), LEFT_TYPE,
+		                        RIGHT_TYPE>(inputs, result, count, adapter);
+#else
+		ScalarExecutor::Execute<false, SPECIALIZE_GENERIC_SELECTIONS, false, RESULT_TYPE, decltype(adapter), LEFT_TYPE,
+		                        RIGHT_TYPE>(inputs, result, count, adapter);
+#endif
+	}
+
+	template <class LEFT_TYPE, class RIGHT_TYPE, class RESULT_TYPE, class OPWRAPPER, class OP, class FUNC>
+	static void ExecuteSwitch(const Vector &left, const Vector &right, Vector &result, idx_t count, FUNC &fun) {
+		if (OPWRAPPER::AddsNulls()) {
+			ExecuteSwitchInternal<true, LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, OPWRAPPER, OP>(left, right, result, count,
+			                                                                               fun);
+		} else {
+			ExecuteSwitchInternal<false, LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, OPWRAPPER, OP>(left, right, result, count,
+			                                                                                fun);
+		}
+	}
+
 	static idx_t CheckExecuteCount(const Vector &left, const Vector &right) {
 		if (left.size() != right.size()) {
 			throw InternalException(
@@ -318,8 +209,48 @@ private:
 		return left.size();
 	}
 
+	template <class LEFT_TYPE, class RIGHT_TYPE, class OP>
+	static idx_t SelectShared(const std::array<ScalarExecutor::VectorRef, 2> &inputs, const SelectionVector *sel,
+	                          idx_t count, SelectionVector *true_sel, SelectionVector *false_sel) {
+		BinarySelectAdapter<LEFT_TYPE, RIGHT_TYPE, OP> adapter;
+#if !DUCKDB_SMALLER_BINARY(binary_executor_select_flat)
+		static constexpr uint64_t SPECIALIZED_MASKS = 0x7;
+#else
+		static constexpr uint64_t SPECIALIZED_MASKS = 0;
+#endif
+#if !DUCKDB_SMALLER_BINARY(binary_executor_select_flags)
+		static constexpr bool SPECIALIZE_OUTPUTS = true;
+#else
+		static constexpr bool SPECIALIZE_OUTPUTS = false;
+#endif
+		return ScalarExecutor::Select<SPECIALIZED_MASKS, SPECIALIZE_OUTPUTS, decltype(adapter), LEFT_TYPE, RIGHT_TYPE>(
+		    inputs, sel, count, true_sel, false_sel, adapter);
+	}
+
 public:
-	//! Convenience overloads without explicit count - count is derived from the input vectors.
+	template <class LEFT_TYPE, class RIGHT_TYPE, class RESULT_TYPE,
+	          class FUNC = std::function<RESULT_TYPE(LEFT_TYPE, RIGHT_TYPE)>>
+	static void Execute(const Vector &left, const Vector &right, Vector &result, idx_t count, FUNC fun) {
+		constexpr bool adds_nulls =
+		    std::is_same<std::invoke_result_t<FUNC &, LEFT_TYPE, RIGHT_TYPE>, optional<RESULT_TYPE>>::value;
+		ExecuteSwitch<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, BinaryLambdaWrapper<adds_nulls>, bool>(left, right, result,
+		                                                                                         count, fun);
+	}
+
+	template <class LEFT_TYPE, class RIGHT_TYPE, class RESULT_TYPE, class OP,
+	          class OPWRAPPER = BinarySingleArgumentOperatorWrapper>
+	static void Execute(const Vector &left, const Vector &right, Vector &result, idx_t count) {
+		bool dummy = false;
+		ExecuteSwitch<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, OPWRAPPER, OP>(left, right, result, count, dummy);
+	}
+
+	template <class LEFT_TYPE, class RIGHT_TYPE, class RESULT_TYPE, class OP>
+	static void ExecuteStandard(const Vector &left, const Vector &right, Vector &result, idx_t count) {
+		bool dummy = false;
+		ExecuteSwitch<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, BinaryStandardOperatorWrapper, OP>(left, right, result, count,
+		                                                                                     dummy);
+	}
+
 	template <class LEFT_TYPE, class RIGHT_TYPE, class RESULT_TYPE,
 	          class FUNC = std::function<RESULT_TYPE(LEFT_TYPE, RIGHT_TYPE)>>
 	static void Execute(const Vector &left, const Vector &right, Vector &result, FUNC fun) {
@@ -337,408 +268,45 @@ public:
 		ExecuteStandard<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, OP>(left, right, result, CheckExecuteCount(left, right));
 	}
 
-public:
-	template <class LEFT_TYPE, class RIGHT_TYPE, class OP>
-	static idx_t SelectConstant(const Vector &left, const Vector &right, const SelectionVector &sel, idx_t count,
-	                            SelectionVector *true_sel, SelectionVector *false_sel) {
-		auto ldata = ConstantVector::GetData<LEFT_TYPE>(left);
-		auto rdata = ConstantVector::GetData<RIGHT_TYPE>(right);
-
-		// both sides are constant, return either 0 or the count
-		// in this case we do not fill in the result selection vector at all
-		if (ConstantVector::IsNull(left) || ConstantVector::IsNull(right) || !OP::Operation(*ldata, *rdata)) {
-			if (false_sel) {
-				for (idx_t i = 0; i < count; i++) {
-					false_sel->set_index(i, sel.get_index(i));
-				}
-			}
-			return 0;
-		} else {
-			if (true_sel) {
-				for (idx_t i = 0; i < count; i++) {
-					true_sel->set_index(i, sel.get_index(i));
-				}
-			}
-			return count;
-		}
-	}
-
-// NOTE: the flat path is intentionally NOT covered by the ComparisonSelectComplement fold (unlike
-// the generic and constant paths above). It is null-unified — there is no NO_NULL template split;
-#if !DUCKDB_SMALLER_BINARY(binary_executor_select_flat)
-	template <class LEFT_TYPE, class RIGHT_TYPE, class OP, bool LEFT_CONSTANT, bool RIGHT_CONSTANT, bool HAS_TRUE_SEL,
-	          bool HAS_FALSE_SEL>
-	static inline idx_t SelectFlatLoop(const LEFT_TYPE *__restrict ldata, const RIGHT_TYPE *__restrict rdata,
-	                                   const SelectionVector &sel, idx_t count, const ValidityMask &validity_mask,
-	                                   SelectionVector *true_sel, SelectionVector *false_sel) {
-		idx_t true_count = 0, false_count = 0;
-		idx_t base_idx = 0;
-		auto entry_count = ValidityMask::EntryCount(count);
-		for (idx_t entry_idx = 0; entry_idx < entry_count; entry_idx++) {
-			auto validity_entry = validity_mask.GetValidityEntry(entry_idx);
-			idx_t next = MinValue<idx_t>(base_idx + ValidityMask::BITS_PER_VALUE, count);
-			if (ValidityMask::AllValid(validity_entry)) {
-				// all valid: perform operation
-				for (; base_idx < next; base_idx++) {
-					idx_t result_idx = sel.get_index(base_idx);
-					idx_t lidx = LEFT_CONSTANT ? 0 : base_idx;
-					idx_t ridx = RIGHT_CONSTANT ? 0 : base_idx;
-					bool comparison_result = OP::Operation(ldata[lidx], rdata[ridx]);
-					if (HAS_TRUE_SEL) {
-						true_sel->set_index(true_count, result_idx);
-						true_count += comparison_result;
-					}
-					if (HAS_FALSE_SEL) {
-						false_sel->set_index(false_count, result_idx);
-						false_count += !comparison_result;
-					}
-				}
-			} else if (ValidityMask::NoneValid(validity_entry)) {
-				// nothing valid: skip all
-				if (HAS_FALSE_SEL) {
-					for (; base_idx < next; base_idx++) {
-						idx_t result_idx = sel.get_index(base_idx);
-						false_sel->set_index(false_count, result_idx);
-						false_count++;
-					}
-				}
-				base_idx = next;
-				continue;
-			} else {
-				// partially valid: need to check individual elements for validity
-				idx_t start = base_idx;
-				for (; base_idx < next; base_idx++) {
-					idx_t result_idx = sel.get_index(base_idx);
-					idx_t lidx = LEFT_CONSTANT ? 0 : base_idx;
-					idx_t ridx = RIGHT_CONSTANT ? 0 : base_idx;
-					bool comparison_result = ValidityMask::RowIsValid(validity_entry, base_idx - start) &&
-					                         OP::Operation(ldata[lidx], rdata[ridx]);
-					if (HAS_TRUE_SEL) {
-						true_sel->set_index(true_count, result_idx);
-						true_count += comparison_result;
-					}
-					if (HAS_FALSE_SEL) {
-						false_sel->set_index(false_count, result_idx);
-						false_count += !comparison_result;
-					}
-				}
-			}
-		}
-		if (HAS_TRUE_SEL) {
-			return true_count;
-		} else {
-			return count - false_count;
-		}
-	}
-
-	template <class LEFT_TYPE, class RIGHT_TYPE, class OP, bool LEFT_CONSTANT, bool RIGHT_CONSTANT>
-	static inline idx_t SelectFlatLoopSwitch(const LEFT_TYPE *__restrict ldata, const RIGHT_TYPE *__restrict rdata,
-	                                         const SelectionVector &sel, idx_t count, const ValidityMask &mask,
-	                                         SelectionVector *true_sel, SelectionVector *false_sel) {
-		if (true_sel && false_sel) {
-			return SelectFlatLoop<LEFT_TYPE, RIGHT_TYPE, OP, LEFT_CONSTANT, RIGHT_CONSTANT, true, true>(
-			    ldata, rdata, sel, count, mask, true_sel, false_sel);
-		} else if (true_sel) {
-			return SelectFlatLoop<LEFT_TYPE, RIGHT_TYPE, OP, LEFT_CONSTANT, RIGHT_CONSTANT, true, false>(
-			    ldata, rdata, sel, count, mask, true_sel, false_sel);
-		} else {
-			D_ASSERT(false_sel);
-			return SelectFlatLoop<LEFT_TYPE, RIGHT_TYPE, OP, LEFT_CONSTANT, RIGHT_CONSTANT, false, true>(
-			    ldata, rdata, sel, count, mask, true_sel, false_sel);
-		}
-	}
-
-	template <class LEFT_TYPE, class RIGHT_TYPE, class OP, bool LEFT_CONSTANT, bool RIGHT_CONSTANT>
-	static idx_t SelectFlat(const Vector &left, const Vector &right, const SelectionVector &sel, idx_t count,
-	                        SelectionVector *true_sel, SelectionVector *false_sel) {
-		auto ldata = LEFT_CONSTANT ? ConstantVector::GetData<LEFT_TYPE>(left) : FlatVector::GetData<LEFT_TYPE>(left);
-		auto rdata =
-		    RIGHT_CONSTANT ? ConstantVector::GetData<RIGHT_TYPE>(right) : FlatVector::GetData<RIGHT_TYPE>(right);
-
-		if (LEFT_CONSTANT && ConstantVector::IsNull(left)) {
-			if (false_sel) {
-				for (idx_t i = 0; i < count; i++) {
-					false_sel->set_index(i, sel.get_index(i));
-				}
-			}
-			return 0;
-		}
-		if (RIGHT_CONSTANT && ConstantVector::IsNull(right)) {
-			if (false_sel) {
-				for (idx_t i = 0; i < count; i++) {
-					false_sel->set_index(i, sel.get_index(i));
-				}
-			}
-			return 0;
-		}
-
-		if (LEFT_CONSTANT) {
-			return SelectFlatLoopSwitch<LEFT_TYPE, RIGHT_TYPE, OP, LEFT_CONSTANT, RIGHT_CONSTANT>(
-			    ldata, rdata, sel, count, FlatVector::Validity(right), true_sel, false_sel);
-		} else if (RIGHT_CONSTANT) {
-			return SelectFlatLoopSwitch<LEFT_TYPE, RIGHT_TYPE, OP, LEFT_CONSTANT, RIGHT_CONSTANT>(
-			    ldata, rdata, sel, count, FlatVector::Validity(left), true_sel, false_sel);
-		} else {
-			ValidityMask combined_mask = FlatVector::Validity(left);
-			combined_mask.Combine(FlatVector::Validity(right), count);
-			return SelectFlatLoopSwitch<LEFT_TYPE, RIGHT_TYPE, OP, LEFT_CONSTANT, RIGHT_CONSTANT>(
-			    ldata, rdata, sel, count, combined_mask, true_sel, false_sel);
-		}
-	}
-
-	template <class CONSTANT_TYPE, class GENERIC_TYPE, class OP, bool RIGHT_CONSTANT, bool CAN_HAVE_NULL,
-	          bool HAS_TRUE_SEL, bool HAS_FALSE_SEL>
-	static idx_t SelectGenericConstant(CONSTANT_TYPE constant, const GENERIC_TYPE *__restrict data,
-	                                   const SelectionVector &generic_sel, const ValidityMask &mask,
-	                                   const SelectionVector &result_sel, idx_t count, SelectionVector *true_sel,
-	                                   SelectionVector *false_sel) {
-		idx_t true_count = 0, false_count = 0;
-		for (idx_t r = 0; r < count; r++) {
-			auto result_idx = result_sel.get_index(r);
-			auto idx = generic_sel.get_index(r);
-			bool comparison_result = (!CAN_HAVE_NULL || mask.RowIsValid(idx));
-			if constexpr (RIGHT_CONSTANT) {
-				comparison_result = comparison_result && OP::Operation(data[idx], constant);
-			} else {
-				comparison_result = comparison_result && OP::Operation(constant, data[idx]);
-			}
-			if constexpr (HAS_TRUE_SEL) {
-				true_sel->set_index(true_count, result_idx);
-				true_count += comparison_result;
-			}
-			if constexpr (HAS_FALSE_SEL) {
-				false_sel->set_index(false_count, result_idx);
-				false_count += !comparison_result;
-			}
-		}
-		if constexpr (HAS_TRUE_SEL) {
-			return true_count;
-		} else {
-			return count - false_count;
-		}
-	}
-
-	template <class CONSTANT_TYPE, class GENERIC_TYPE, class OP, bool RIGHT_CONSTANT, bool CAN_HAVE_NULL>
-	static idx_t SelectGenericConstant(CONSTANT_TYPE constant, const GENERIC_TYPE *__restrict data,
-	                                   const SelectionVector &generic_sel, const ValidityMask &mask,
-	                                   const SelectionVector &result_sel, idx_t count, SelectionVector *true_sel,
-	                                   SelectionVector *false_sel) {
-		// NO_NULL complement fold: NotEquals/GreaterThanEquals are exactly the complement of
-		// Equals/GreaterThan when there are no NULLs
-		if constexpr (!CAN_HAVE_NULL && ComparisonSelectComplement<OP>::FOLD) {
-			using FOLDED = ComparisonSelectComplement<OP>;
-			constexpr bool FOLDED_RIGHT_CONSTANT = FOLDED::SWAP_OPERANDS ? !RIGHT_CONSTANT : RIGHT_CONSTANT;
-			return count - SelectGenericConstant<CONSTANT_TYPE, GENERIC_TYPE, typename FOLDED::COMPLEMENT,
-			                                     FOLDED_RIGHT_CONSTANT, CAN_HAVE_NULL>(
-			                   constant, data, generic_sel, mask, result_sel, count, false_sel, true_sel);
-		}
-		if (true_sel && false_sel) {
-			return SelectGenericConstant<CONSTANT_TYPE, GENERIC_TYPE, OP, RIGHT_CONSTANT, CAN_HAVE_NULL, true, true>(
-			    constant, data, generic_sel, mask, result_sel, count, true_sel, false_sel);
-		} else if (true_sel) {
-			return SelectGenericConstant<CONSTANT_TYPE, GENERIC_TYPE, OP, RIGHT_CONSTANT, CAN_HAVE_NULL, true, false>(
-			    constant, data, generic_sel, mask, result_sel, count, true_sel, false_sel);
-		} else if (false_sel) {
-			return SelectGenericConstant<CONSTANT_TYPE, GENERIC_TYPE, OP, RIGHT_CONSTANT, CAN_HAVE_NULL, false, true>(
-			    constant, data, generic_sel, mask, result_sel, count, true_sel, false_sel);
-		} else {
-			throw InternalException("Either true or false sel must be set");
-		}
-	}
-
-	template <class CONSTANT_TYPE, class GENERIC_TYPE, class OP, bool RIGHT_CONSTANT>
-	static idx_t SelectGenericConstant(CONSTANT_TYPE constant, const GENERIC_TYPE *__restrict data,
-	                                   const SelectionVector &generic_sel, const ValidityMask &mask,
-	                                   const SelectionVector &sel, idx_t count, SelectionVector *true_sel,
-	                                   SelectionVector *false_sel) {
-		if (mask.CanHaveNull()) {
-			return SelectGenericConstant<CONSTANT_TYPE, GENERIC_TYPE, OP, RIGHT_CONSTANT, true>(
-			    constant, data, generic_sel, mask, sel, count, true_sel, false_sel);
-		} else {
-			return SelectGenericConstant<CONSTANT_TYPE, GENERIC_TYPE, OP, RIGHT_CONSTANT, false>(
-			    constant, data, generic_sel, mask, sel, count, true_sel, false_sel);
-		}
-	}
-
-	template <class LEFT_TYPE, class RIGHT_TYPE, class OP, bool RIGHT_CONSTANT>
-	static idx_t SelectGenericConstant(const Vector &left, const Vector &right, const SelectionVector &sel, idx_t count,
-	                                   SelectionVector *true_sel, SelectionVector *false_sel) {
-		constexpr bool LEFT_CONSTANT = !RIGHT_CONSTANT;
-		if (LEFT_CONSTANT && ConstantVector::IsNull(left)) {
-			if (false_sel) {
-				for (idx_t i = 0; i < count; i++) {
-					false_sel->set_index(i, sel.get_index(i));
-				}
-			}
-			return 0;
-		}
-		if (RIGHT_CONSTANT && ConstantVector::IsNull(right)) {
-			if (false_sel) {
-				for (idx_t i = 0; i < count; i++) {
-					false_sel->set_index(i, sel.get_index(i));
-				}
-			}
-			return 0;
-		}
-
-		UnifiedVectorFormat format;
-		if (LEFT_CONSTANT) {
-		} else {
-			right.ToUnifiedFormat(format);
-		}
-
-		if (LEFT_CONSTANT) {
-			right.ToUnifiedFormat(format);
-			auto data = UnifiedVectorFormat::GetData<RIGHT_TYPE>(format);
-			return SelectGenericConstant<LEFT_TYPE, RIGHT_TYPE, OP, RIGHT_CONSTANT>(
-			    *ConstantVector::GetData<LEFT_TYPE>(left), data, *format.sel, format.validity, sel, count, true_sel,
-			    false_sel);
-		} else {
-			left.ToUnifiedFormat(format);
-			auto data = UnifiedVectorFormat::GetData<LEFT_TYPE>(format);
-			return SelectGenericConstant<RIGHT_TYPE, LEFT_TYPE, OP, RIGHT_CONSTANT>(
-			    *ConstantVector::GetData<RIGHT_TYPE>(right), data, *format.sel, format.validity, sel, count, true_sel,
-			    false_sel);
-		}
-	}
-#endif
-
-#if !DUCKDB_SMALLER_BINARY(binary_executor_select_flags)
-	template <class LEFT_TYPE, class RIGHT_TYPE, class OP, bool NO_NULL, bool HAS_TRUE_SEL, bool HAS_FALSE_SEL>
-#else
-	template <class LEFT_TYPE, class RIGHT_TYPE, class OP>
-#endif
-	static inline idx_t SelectGenericLoop(const LEFT_TYPE *__restrict ldata, const RIGHT_TYPE *__restrict rdata,
-	                                      const SelectionVector *__restrict lsel,
-	                                      const SelectionVector *__restrict rsel, const SelectionVector &result_sel,
-	                                      idx_t count, const ValidityMask &lvalidity, const ValidityMask &rvalidity,
-	                                      SelectionVector *true_sel, SelectionVector *false_sel) {
-		idx_t true_count = 0, false_count = 0;
-#if DUCKDB_SMALLER_BINARY(binary_executor_select_flags)
-		const bool HAS_TRUE_SEL = true_sel;
-		const bool HAS_FALSE_SEL = false_sel;
-		const bool NO_NULL = false;
-#endif
-		for (idx_t i = 0; i < count; i++) {
-			auto result_idx = result_sel.get_index(i);
-			auto lindex = lsel->get_index(i);
-			auto rindex = rsel->get_index(i);
-			const bool comparison_result =
-			    (NO_NULL || (lvalidity.RowIsValid(lindex) && rvalidity.RowIsValid(rindex))) &&
-			    OP::Operation(ldata[lindex], rdata[rindex]);
-			if (HAS_TRUE_SEL) {
-				true_sel->set_index(true_count, result_idx);
-				true_count += comparison_result;
-			}
-			if (HAS_FALSE_SEL) {
-				false_sel->set_index(false_count, result_idx);
-				false_count += !comparison_result;
-			}
-		}
-		if (HAS_TRUE_SEL) {
-			return true_count;
-		} else {
-			return count - false_count;
-		}
-	}
-
-#if !DUCKDB_SMALLER_BINARY(binary_executor_select_flags)
-	template <class LEFT_TYPE, class RIGHT_TYPE, class OP, bool NO_NULL>
-	static inline idx_t
-	SelectGenericLoopSelSwitch(const LEFT_TYPE *__restrict ldata, const RIGHT_TYPE *__restrict rdata,
-	                           const SelectionVector *__restrict lsel, const SelectionVector *__restrict rsel,
-	                           const SelectionVector &result_sel, idx_t count, const ValidityMask &lvalidity,
-	                           const ValidityMask &rvalidity, SelectionVector *true_sel, SelectionVector *false_sel) {
-		// NO_NULL complement fold: NotEquals/GreaterThanEquals are exactly the complement of
-		// Equals/GreaterThan when there are no NULLs
-		if constexpr (NO_NULL && ComparisonSelectComplement<OP>::FOLD) {
-			using FOLDED = ComparisonSelectComplement<OP>;
-			if constexpr (FOLDED::SWAP_OPERANDS) {
-				return count -
-				       SelectGenericLoopSelSwitch<RIGHT_TYPE, LEFT_TYPE, typename FOLDED::COMPLEMENT, NO_NULL>(
-				           rdata, ldata, rsel, lsel, result_sel, count, rvalidity, lvalidity, false_sel, true_sel);
-			} else {
-				return count -
-				       SelectGenericLoopSelSwitch<LEFT_TYPE, RIGHT_TYPE, typename FOLDED::COMPLEMENT, NO_NULL>(
-				           ldata, rdata, lsel, rsel, result_sel, count, lvalidity, rvalidity, false_sel, true_sel);
-			}
-		}
-		if (true_sel && false_sel) {
-			return SelectGenericLoop<LEFT_TYPE, RIGHT_TYPE, OP, NO_NULL, true, true>(
-			    ldata, rdata, lsel, rsel, result_sel, count, lvalidity, rvalidity, true_sel, false_sel);
-		} else if (true_sel) {
-			return SelectGenericLoop<LEFT_TYPE, RIGHT_TYPE, OP, NO_NULL, true, false>(
-			    ldata, rdata, lsel, rsel, result_sel, count, lvalidity, rvalidity, true_sel, false_sel);
-		} else {
-			D_ASSERT(false_sel);
-			return SelectGenericLoop<LEFT_TYPE, RIGHT_TYPE, OP, NO_NULL, false, true>(
-			    ldata, rdata, lsel, rsel, result_sel, count, lvalidity, rvalidity, true_sel, false_sel);
-		}
-	}
-#endif
-
-	template <class LEFT_TYPE, class RIGHT_TYPE, class OP>
-	static inline idx_t
-	SelectGenericLoopSwitch(const LEFT_TYPE *__restrict ldata, const RIGHT_TYPE *__restrict rdata,
-	                        const SelectionVector *__restrict lsel, const SelectionVector *__restrict rsel,
-	                        const SelectionVector &result_sel, idx_t count, const ValidityMask &lvalidity,
-	                        const ValidityMask &rvalidity, SelectionVector *true_sel, SelectionVector *false_sel) {
-#if !DUCKDB_SMALLER_BINARY(binary_executor_select_flags)
-		if (lvalidity.CanHaveNull() || rvalidity.CanHaveNull()) {
-			return SelectGenericLoopSelSwitch<LEFT_TYPE, RIGHT_TYPE, OP, false>(
-			    ldata, rdata, lsel, rsel, result_sel, count, lvalidity, rvalidity, true_sel, false_sel);
-		} else {
-			return SelectGenericLoopSelSwitch<LEFT_TYPE, RIGHT_TYPE, OP, true>(
-			    ldata, rdata, lsel, rsel, result_sel, count, lvalidity, rvalidity, true_sel, false_sel);
-		}
-#else
-		return SelectGenericLoop<LEFT_TYPE, RIGHT_TYPE, OP>(ldata, rdata, lsel, rsel, result_sel, count, lvalidity,
-		                                                    rvalidity, true_sel, false_sel);
-#endif
-	}
-
-	template <class LEFT_TYPE, class RIGHT_TYPE, class OP>
-	static idx_t SelectGeneric(const Vector &left, const Vector &right, const SelectionVector &sel, idx_t count,
-	                           SelectionVector *true_sel, SelectionVector *false_sel) {
-		UnifiedVectorFormat ldata, rdata;
-
-		left.ToUnifiedFormat(ldata);
-		right.ToUnifiedFormat(rdata);
-
-		return SelectGenericLoopSwitch<LEFT_TYPE, RIGHT_TYPE, OP>(
-		    UnifiedVectorFormat::GetData<LEFT_TYPE>(ldata), UnifiedVectorFormat::GetData<RIGHT_TYPE>(rdata), ldata.sel,
-		    rdata.sel, sel, count, ldata.validity, rdata.validity, true_sel, false_sel);
-	}
-
 	template <class LEFT_TYPE, class RIGHT_TYPE, class OP>
 	static idx_t Select(const Vector &left, const Vector &right, const SelectionVector *sel, idx_t count,
 	                    SelectionVector *true_sel, SelectionVector *false_sel) {
-		if (!sel) {
-			sel = FlatVector::IncrementalSelectionVector();
-		}
-		if (left.GetVectorType() == VectorType::CONSTANT_VECTOR &&
-		    right.GetVectorType() == VectorType::CONSTANT_VECTOR) {
-			return SelectConstant<LEFT_TYPE, RIGHT_TYPE, OP>(left, right, *sel, count, true_sel, false_sel);
+		std::array<ScalarExecutor::VectorRef, 2> inputs = {{left, right}};
 #if !DUCKDB_SMALLER_BINARY(binary_executor_select_flat)
-		} else if (left.GetVectorType() == VectorType::CONSTANT_VECTOR &&
-		           right.GetVectorType() == VectorType::FLAT_VECTOR) {
-			return SelectFlat<LEFT_TYPE, RIGHT_TYPE, OP, true, false>(left, right, *sel, count, true_sel, false_sel);
-		} else if (left.GetVectorType() == VectorType::FLAT_VECTOR &&
-		           right.GetVectorType() == VectorType::CONSTANT_VECTOR) {
-			return SelectFlat<LEFT_TYPE, RIGHT_TYPE, OP, false, true>(left, right, *sel, count, true_sel, false_sel);
-		} else if (left.GetVectorType() == VectorType::FLAT_VECTOR &&
-		           right.GetVectorType() == VectorType::FLAT_VECTOR) {
-			return SelectFlat<LEFT_TYPE, RIGHT_TYPE, OP, false, false>(left, right, *sel, count, true_sel, false_sel);
-		} else if (left.GetVectorType() == VectorType::CONSTANT_VECTOR) {
-			return SelectGenericConstant<LEFT_TYPE, RIGHT_TYPE, OP, false>(left, right, *sel, count, true_sel,
-			                                                               false_sel);
-		} else if (right.GetVectorType() == VectorType::CONSTANT_VECTOR) {
-			return SelectGenericConstant<LEFT_TYPE, RIGHT_TYPE, OP, true>(left, right, *sel, count, true_sel,
-			                                                              false_sel);
-#endif
-		} else {
-			return SelectGeneric<LEFT_TYPE, RIGHT_TYPE, OP>(left, right, *sel, count, true_sel, false_sel);
+		if (true_sel && !false_sel) {
+			if (!sel) {
+				sel = FlatVector::IncrementalSelectionVector();
+			}
+			auto left_type = left.GetVectorType();
+			auto right_type = right.GetVectorType();
+			if (left_type == VectorType::FLAT_VECTOR && right_type == VectorType::FLAT_VECTOR) {
+				return SelectTrueFlat<LEFT_TYPE, RIGHT_TYPE, OP, false, false>(left, right, *sel, count, *true_sel);
+			} else if (left_type == VectorType::FLAT_VECTOR && right_type == VectorType::CONSTANT_VECTOR) {
+				return SelectTrueFlat<LEFT_TYPE, RIGHT_TYPE, OP, false, true>(left, right, *sel, count, *true_sel);
+			} else if (left_type == VectorType::CONSTANT_VECTOR && right_type == VectorType::FLAT_VECTOR) {
+				return SelectTrueFlat<LEFT_TYPE, RIGHT_TYPE, OP, true, false>(left, right, *sel, count, *true_sel);
+			}
 		}
+#endif
+#if !DUCKDB_SMALLER_BINARY(binary_executor_select_flags)
+		if constexpr (ComparisonSelectComplement<OP>::FOLD) {
+			auto left_type = left.GetVectorType();
+			auto right_type = right.GetVectorType();
+			bool flat_profile = (left_type == VectorType::FLAT_VECTOR || left_type == VectorType::CONSTANT_VECTOR) &&
+			                    (right_type == VectorType::FLAT_VECTOR || right_type == VectorType::CONSTANT_VECTOR);
+			if (!flat_profile && !ScalarExecutor::InputsCanHaveNull<LEFT_TYPE, RIGHT_TYPE>(inputs)) {
+				using FOLDED = ComparisonSelectComplement<OP>;
+				if constexpr (FOLDED::SWAP_OPERANDS) {
+					std::array<ScalarExecutor::VectorRef, 2> swapped = {{right, left}};
+					return count - SelectShared<RIGHT_TYPE, LEFT_TYPE, typename FOLDED::COMPLEMENT>(
+					                   swapped, sel, count, false_sel, true_sel);
+				}
+				return count - SelectShared<LEFT_TYPE, RIGHT_TYPE, typename FOLDED::COMPLEMENT>(inputs, sel, count,
+				                                                                                false_sel, true_sel);
+			}
+		}
+#endif
+		return SelectShared<LEFT_TYPE, RIGHT_TYPE, OP>(inputs, sel, count, true_sel, false_sel);
 	}
 };
 

--- a/src/include/duckdb/common/vector_operations/scalar_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/scalar_executor.hpp
@@ -298,8 +298,7 @@ private:
 		}
 	}
 
-	template <bool SPECIALIZE_FLAT, bool SPECIALIZE_NULLABLE_GENERIC_SELECTIONS, bool PRESERVE_RESULT_VALIDITY,
-	          class RESULT_TYPE, class ADAPTER, class... ARGS, size_t... Is>
+	template <class POLICY, class RESULT_TYPE, class ADAPTER, class... ARGS, size_t... Is>
 	static void ExecuteInternal(const std::array<VectorRef, sizeof...(ARGS)> &inputs, Vector &result, idx_t count,
 	                            ADAPTER &adapter, std::index_sequence<Is...> indices) {
 		constexpr idx_t N = sizeof...(ARGS);
@@ -310,7 +309,7 @@ private:
 			                                               indices);
 			return;
 		}
-		if constexpr (SPECIALIZE_FLAT && N <= 3) {
+		if constexpr (POLICY::SPECIALIZE_FLAT && N <= 3) {
 			if (profile.all_flat_or_constant) {
 				if (profile.any_constant_null) {
 					result.SetVectorType(VectorType::CONSTANT_VECTOR);
@@ -322,48 +321,48 @@ private:
 				}
 				switch (profile.constant_mask) {
 				case 0:
-					ExecuteFlat<PRESERVE_RESULT_VALIDITY, 0, RESULT_TYPE, ADAPTER, ARGS...>(inputs, result, count,
-					                                                                        adapter, indices);
+					ExecuteFlat<POLICY::PRESERVE_RESULT_VALIDITY, 0, RESULT_TYPE, ADAPTER, ARGS...>(
+					    inputs, result, count, adapter, indices);
 					return;
 				case 1:
 					if constexpr (N >= 2) {
-						ExecuteFlat<PRESERVE_RESULT_VALIDITY, 1, RESULT_TYPE, ADAPTER, ARGS...>(inputs, result, count,
-						                                                                        adapter, indices);
+						ExecuteFlat<POLICY::PRESERVE_RESULT_VALIDITY, 1, RESULT_TYPE, ADAPTER, ARGS...>(
+						    inputs, result, count, adapter, indices);
 						return;
 					}
 					break;
 				case 2:
 					if constexpr (N >= 2) {
-						ExecuteFlat<PRESERVE_RESULT_VALIDITY, 2, RESULT_TYPE, ADAPTER, ARGS...>(inputs, result, count,
-						                                                                        adapter, indices);
+						ExecuteFlat<POLICY::PRESERVE_RESULT_VALIDITY, 2, RESULT_TYPE, ADAPTER, ARGS...>(
+						    inputs, result, count, adapter, indices);
 						return;
 					}
 					break;
 				case 3:
 					if constexpr (N >= 3) {
-						ExecuteFlat<PRESERVE_RESULT_VALIDITY, 3, RESULT_TYPE, ADAPTER, ARGS...>(inputs, result, count,
-						                                                                        adapter, indices);
+						ExecuteFlat<POLICY::PRESERVE_RESULT_VALIDITY, 3, RESULT_TYPE, ADAPTER, ARGS...>(
+						    inputs, result, count, adapter, indices);
 						return;
 					}
 					break;
 				case 4:
 					if constexpr (N >= 3) {
-						ExecuteFlat<PRESERVE_RESULT_VALIDITY, 4, RESULT_TYPE, ADAPTER, ARGS...>(inputs, result, count,
-						                                                                        adapter, indices);
+						ExecuteFlat<POLICY::PRESERVE_RESULT_VALIDITY, 4, RESULT_TYPE, ADAPTER, ARGS...>(
+						    inputs, result, count, adapter, indices);
 						return;
 					}
 					break;
 				case 5:
 					if constexpr (N >= 3) {
-						ExecuteFlat<PRESERVE_RESULT_VALIDITY, 5, RESULT_TYPE, ADAPTER, ARGS...>(inputs, result, count,
-						                                                                        adapter, indices);
+						ExecuteFlat<POLICY::PRESERVE_RESULT_VALIDITY, 5, RESULT_TYPE, ADAPTER, ARGS...>(
+						    inputs, result, count, adapter, indices);
 						return;
 					}
 					break;
 				case 6:
 					if constexpr (N >= 3) {
-						ExecuteFlat<PRESERVE_RESULT_VALIDITY, 6, RESULT_TYPE, ADAPTER, ARGS...>(inputs, result, count,
-						                                                                        adapter, indices);
+						ExecuteFlat<POLICY::PRESERVE_RESULT_VALIDITY, 6, RESULT_TYPE, ADAPTER, ARGS...>(
+						    inputs, result, count, adapter, indices);
 						return;
 					}
 					break;
@@ -372,33 +371,120 @@ private:
 				}
 			}
 		}
-		ExecuteGeneric<SPECIALIZE_NULLABLE_GENERIC_SELECTIONS, PRESERVE_RESULT_VALIDITY, RESULT_TYPE, ADAPTER, ARGS...>(
-		    inputs, result, count, adapter, indices);
+		ExecuteGeneric<POLICY::SPECIALIZE_NULLABLE_GENERIC_SELECTIONS, POLICY::PRESERVE_RESULT_VALIDITY, RESULT_TYPE,
+		               ADAPTER, ARGS...>(inputs, result, count, adapter, indices);
 	}
 
-	template <bool SPECIALIZE_OUTPUTS, bool HAS_TRUE_SEL, bool HAS_FALSE_SEL>
-	static inline void StoreSelection(bool comparison_result, idx_t result_idx, SelectionVector *true_sel,
-	                                  SelectionVector *false_sel, idx_t &true_count, idx_t &false_count) {
-		if constexpr (SPECIALIZE_OUTPUTS) {
-			if constexpr (HAS_TRUE_SEL) {
-				true_sel->set_index(true_count, result_idx);
+	template <bool HAS_TRUE_SELECTION, bool HAS_FALSE_SELECTION>
+	struct StaticSelectionSink {
+		static_assert(HAS_TRUE_SELECTION || HAS_FALSE_SELECTION, "A selection sink requires an output");
+
+		StaticSelectionSink(SelectionVector *true_selection_p, SelectionVector *false_selection_p)
+		    : true_selection(true_selection_p ? true_selection_p->data() : nullptr),
+		      false_selection(false_selection_p ? false_selection_p->data() : nullptr) {
+			D_ASSERT(!HAS_TRUE_SELECTION || true_selection);
+			D_ASSERT(!HAS_FALSE_SELECTION || false_selection);
+		}
+
+		inline void Append(bool comparison_result, idx_t result_idx) {
+			if constexpr (HAS_TRUE_SELECTION) {
+				true_selection[true_count] = UnsafeNumericCast<sel_t>(result_idx);
 				true_count += comparison_result;
 			}
-			if constexpr (HAS_FALSE_SEL) {
-				false_sel->set_index(false_count, result_idx);
-				false_count += !comparison_result;
-			}
-		} else {
-			if (true_sel) {
-				true_sel->set_index(true_count, result_idx);
-				true_count += comparison_result;
-			}
-			if (false_sel) {
-				false_sel->set_index(false_count, result_idx);
+			if constexpr (HAS_FALSE_SELECTION) {
+				false_selection[false_count] = UnsafeNumericCast<sel_t>(result_idx);
 				false_count += !comparison_result;
 			}
 		}
-	}
+
+		inline void AppendInvalidRange(const SelectionVector &sel, idx_t start, idx_t end) {
+			if constexpr (HAS_FALSE_SELECTION) {
+				for (idx_t row = start; row < end; row++) {
+					false_selection[false_count++] = UnsafeNumericCast<sel_t>(sel.get_index(row));
+				}
+			}
+		}
+
+		idx_t FillConstant(bool comparison_result, const SelectionVector &sel, idx_t count) {
+			if (comparison_result) {
+				if constexpr (HAS_TRUE_SELECTION) {
+					for (idx_t row = 0; row < count; row++) {
+						true_selection[row] = UnsafeNumericCast<sel_t>(sel.get_index(row));
+					}
+					true_count = count;
+				}
+			} else if constexpr (HAS_FALSE_SELECTION) {
+				for (idx_t row = 0; row < count; row++) {
+					false_selection[row] = UnsafeNumericCast<sel_t>(sel.get_index(row));
+				}
+				false_count = count;
+			}
+			return Result(count);
+		}
+
+		inline idx_t Result(idx_t count) const {
+			if constexpr (HAS_TRUE_SELECTION) {
+				return true_count;
+			}
+			return count - false_count;
+		}
+
+		sel_t *true_selection;
+		sel_t *false_selection;
+		idx_t true_count = 0;
+		idx_t false_count = 0;
+	};
+
+	struct RuntimeSelectionSink {
+		RuntimeSelectionSink(SelectionVector *true_selection_p, SelectionVector *false_selection_p)
+		    : true_selection(true_selection_p), false_selection(false_selection_p) {
+		}
+
+		inline void Append(bool comparison_result, idx_t result_idx) {
+			if (true_selection) {
+				true_selection->set_index(true_count, result_idx);
+				true_count += comparison_result;
+			}
+			if (false_selection) {
+				false_selection->set_index(false_count, result_idx);
+				false_count += !comparison_result;
+			}
+		}
+
+		inline void AppendInvalidRange(const SelectionVector &sel, idx_t start, idx_t end) {
+			if (false_selection) {
+				for (idx_t row = start; row < end; row++) {
+					false_selection->set_index(false_count++, sel.get_index(row));
+				}
+			}
+		}
+
+		idx_t FillConstant(bool comparison_result, const SelectionVector &sel, idx_t count) {
+			if (comparison_result) {
+				if (true_selection) {
+					for (idx_t row = 0; row < count; row++) {
+						true_selection->set_index(row, sel.get_index(row));
+					}
+					true_count = count;
+				}
+			} else if (false_selection) {
+				for (idx_t row = 0; row < count; row++) {
+					false_selection->set_index(row, sel.get_index(row));
+				}
+				false_count = count;
+			}
+			return Result(count);
+		}
+
+		inline idx_t Result(idx_t count) const {
+			return true_selection ? true_count : count - false_count;
+		}
+
+		SelectionVector *true_selection;
+		SelectionVector *false_selection;
+		idx_t true_count = 0;
+		idx_t false_count = 0;
+	};
 
 	template <bool NO_NULL, class ADAPTER, class... ARGS>
 	static inline bool SelectOperation(ADAPTER &adapter, ARGS... args) {
@@ -408,39 +494,19 @@ private:
 		return adapter.Operation(args...);
 	}
 
-	static idx_t FillConstantSelection(bool comparison_result, const SelectionVector &sel, idx_t count,
-	                                   SelectionVector *true_sel, SelectionVector *false_sel) {
-		if (comparison_result) {
-			if (true_sel) {
-				for (idx_t i = 0; i < count; i++) {
-					true_sel->set_index(i, sel.get_index(i));
-				}
-			}
-			return count;
-		}
-		if (false_sel) {
-			for (idx_t i = 0; i < count; i++) {
-				false_sel->set_index(i, sel.get_index(i));
-			}
-		}
-		return 0;
-	}
-
-	template <class ADAPTER, class... ARGS, size_t... Is>
+	template <class SINK, class ADAPTER, class... ARGS, size_t... Is>
 	static idx_t SelectConstant(const std::array<VectorRef, sizeof...(ARGS)> &inputs, const SelectionVector &sel,
-	                            idx_t count, SelectionVector *true_sel, SelectionVector *false_sel, ADAPTER &adapter,
-	                            std::index_sequence<Is...>) {
+	                            idx_t count, const SINK &sink, ADAPTER &adapter, std::index_sequence<Is...>) {
+		auto local_sink = sink;
 		bool comparison_result = adapter.Operation(*ConstantVector::GetData<ARGS>(inputs[Is].get())...);
-		return FillConstantSelection(comparison_result, sel, count, true_sel, false_sel);
+		return local_sink.FillConstant(comparison_result, sel, count);
 	}
 
-	template <uint64_t CONSTANT_MASK, bool SPECIALIZE_OUTPUTS, bool HAS_TRUE_SEL, bool HAS_FALSE_SEL, class ADAPTER,
-	          class... ARGS, size_t... Is>
+	template <uint64_t CONSTANT_MASK, class SINK, class ADAPTER, class... ARGS, size_t... Is>
 	static idx_t SelectFlatLoop(const std::tuple<const ARGS *...> &input_data, const ValidityMask &input_validity,
-	                            const SelectionVector &sel, idx_t count, SelectionVector *true_sel,
-	                            SelectionVector *false_sel, ADAPTER &adapter, std::index_sequence<Is...>) {
-		idx_t true_count = 0;
-		idx_t false_count = 0;
+	                            const SelectionVector &sel, idx_t count, const SINK &sink, ADAPTER &adapter,
+	                            std::index_sequence<Is...>) {
+		auto local_sink = sink;
 		idx_t base_idx = 0;
 		auto entry_count = ValidityMask::EntryCount(count);
 		for (idx_t entry_idx = 0; entry_idx < entry_count; entry_idx++) {
@@ -451,27 +517,11 @@ private:
 					auto result_idx = sel.get_index(base_idx);
 					bool comparison_result =
 					    adapter.Operation(std::get<Is>(input_data)[InputIndex<Is, CONSTANT_MASK>(base_idx)]...);
-					StoreSelection<SPECIALIZE_OUTPUTS, HAS_TRUE_SEL, HAS_FALSE_SEL>(
-					    comparison_result, result_idx, true_sel, false_sel, true_count, false_count);
+					local_sink.Append(comparison_result, result_idx);
 				}
 			} else if (ValidityMask::NoneValid(validity_entry)) {
-				if constexpr (SPECIALIZE_OUTPUTS) {
-					if constexpr (HAS_FALSE_SEL) {
-						for (; base_idx < next; base_idx++) {
-							false_sel->set_index(false_count++, sel.get_index(base_idx));
-						}
-					} else {
-						base_idx = next;
-					}
-				} else {
-					if (false_sel) {
-						for (; base_idx < next; base_idx++) {
-							false_sel->set_index(false_count++, sel.get_index(base_idx));
-						}
-					} else {
-						base_idx = next;
-					}
-				}
+				local_sink.AppendInvalidRange(sel, base_idx, next);
+				base_idx = next;
 			} else {
 				auto start = base_idx;
 				for (; base_idx < next; base_idx++) {
@@ -479,55 +529,29 @@ private:
 					bool comparison_result =
 					    ValidityMask::RowIsValid(validity_entry, base_idx - start) &&
 					    adapter.Operation(std::get<Is>(input_data)[InputIndex<Is, CONSTANT_MASK>(base_idx)]...);
-					StoreSelection<SPECIALIZE_OUTPUTS, HAS_TRUE_SEL, HAS_FALSE_SEL>(
-					    comparison_result, result_idx, true_sel, false_sel, true_count, false_count);
+					local_sink.Append(comparison_result, result_idx);
 				}
 			}
 		}
-		if constexpr (SPECIALIZE_OUTPUTS && HAS_TRUE_SEL) {
-			return true_count;
-		}
-		return true_sel ? true_count : count - false_count;
+		return local_sink.Result(count);
 	}
 
-	template <uint64_t CONSTANT_MASK, bool SPECIALIZE_OUTPUTS, bool HAS_TRUE_SEL, bool HAS_FALSE_SEL, class ADAPTER,
-	          class... ARGS, size_t... Is>
+	template <uint64_t CONSTANT_MASK, class SINK, class ADAPTER, class... ARGS, size_t... Is>
 	static idx_t SelectFlat(const std::array<VectorRef, sizeof...(ARGS)> &inputs, const SelectionVector &sel,
-	                        idx_t count, SelectionVector *true_sel, SelectionVector *false_sel, ADAPTER &adapter,
-	                        std::index_sequence<Is...> indices) {
+	                        idx_t count, const SINK &sink, ADAPTER &adapter, std::index_sequence<Is...> indices) {
 		auto input_data = std::make_tuple(FlatVector::GetData<ARGS>(inputs[Is].get())...);
 		auto input_validity = PrepareFlatInputValidity<CONSTANT_MASK>(inputs, count, indices);
-		return SelectFlatLoop<CONSTANT_MASK, SPECIALIZE_OUTPUTS, HAS_TRUE_SEL, HAS_FALSE_SEL>(
-		    input_data, input_validity, sel, count, true_sel, false_sel, adapter, indices);
+		return SelectFlatLoop<CONSTANT_MASK, SINK, ADAPTER, ARGS...>(input_data, input_validity, sel, count, sink,
+		                                                             adapter, indices);
 	}
 
-	template <uint64_t CONSTANT_MASK, bool SPECIALIZE_OUTPUTS, class ADAPTER, class... ARGS, size_t... Is>
-	static idx_t SelectFlatSwitch(const std::array<VectorRef, sizeof...(ARGS)> &inputs, const SelectionVector &sel,
-	                              idx_t count, SelectionVector *true_sel, SelectionVector *false_sel, ADAPTER &adapter,
-	                              std::index_sequence<Is...> indices) {
-		if constexpr (SPECIALIZE_OUTPUTS) {
-			if (true_sel && false_sel) {
-				return SelectFlat<CONSTANT_MASK, true, true, true, ADAPTER, ARGS...>(inputs, sel, count, true_sel,
-				                                                                     false_sel, adapter, indices);
-			} else if (true_sel) {
-				return SelectFlat<CONSTANT_MASK, true, true, false, ADAPTER, ARGS...>(inputs, sel, count, true_sel,
-				                                                                      false_sel, adapter, indices);
-			}
-			return SelectFlat<CONSTANT_MASK, true, false, true, ADAPTER, ARGS...>(inputs, sel, count, true_sel,
-			                                                                      false_sel, adapter, indices);
-		}
-		return SelectFlat<CONSTANT_MASK, false, false, false, ADAPTER, ARGS...>(inputs, sel, count, true_sel, false_sel,
-		                                                                        adapter, indices);
-	}
-
-	template <bool RIGHT_CONSTANT, bool CAN_HAVE_NULL, bool SPECIALIZE_OUTPUTS, bool HAS_TRUE_SEL, bool HAS_FALSE_SEL,
-	          class CONSTANT_TYPE, class GENERIC_TYPE, class ADAPTER>
+	template <bool RIGHT_CONSTANT, bool CAN_HAVE_NULL, class SINK, class CONSTANT_TYPE, class GENERIC_TYPE,
+	          class ADAPTER>
 	static idx_t SelectGenericConstantLoop(CONSTANT_TYPE constant, const GENERIC_TYPE *__restrict data,
 	                                       const SelectionVector &generic_sel, const ValidityMask &validity,
-	                                       const SelectionVector &sel, idx_t count, SelectionVector *true_sel,
-	                                       SelectionVector *false_sel, ADAPTER &adapter) {
-		idx_t true_count = 0;
-		idx_t false_count = 0;
+	                                       const SelectionVector &sel, idx_t count, const SINK &sink,
+	                                       ADAPTER &adapter) {
+		auto local_sink = sink;
 		for (idx_t row = 0; row < count; row++) {
 			auto result_idx = sel.get_index(row);
 			auto generic_index = generic_sel.get_index(row);
@@ -541,39 +565,14 @@ private:
 					                                  : adapter.OperationNoNull(constant, data[generic_index]);
 				}
 			}
-			StoreSelection<SPECIALIZE_OUTPUTS, HAS_TRUE_SEL, HAS_FALSE_SEL>(comparison_result, result_idx, true_sel,
-			                                                                false_sel, true_count, false_count);
+			local_sink.Append(comparison_result, result_idx);
 		}
-		if constexpr (SPECIALIZE_OUTPUTS && HAS_TRUE_SEL) {
-			return true_count;
-		}
-		return true_sel ? true_count : count - false_count;
+		return local_sink.Result(count);
 	}
 
-	template <bool RIGHT_CONSTANT, bool CAN_HAVE_NULL, bool SPECIALIZE_OUTPUTS, class CONSTANT_TYPE, class GENERIC_TYPE,
-	          class ADAPTER>
-	static idx_t SelectGenericConstantSwitch(CONSTANT_TYPE constant, const GENERIC_TYPE *__restrict data,
-	                                         const SelectionVector &generic_sel, const ValidityMask &validity,
-	                                         const SelectionVector &sel, idx_t count, SelectionVector *true_sel,
-	                                         SelectionVector *false_sel, ADAPTER &adapter) {
-		if constexpr (SPECIALIZE_OUTPUTS) {
-			if (true_sel && false_sel) {
-				return SelectGenericConstantLoop<RIGHT_CONSTANT, CAN_HAVE_NULL, true, true, true>(
-				    constant, data, generic_sel, validity, sel, count, true_sel, false_sel, adapter);
-			} else if (true_sel) {
-				return SelectGenericConstantLoop<RIGHT_CONSTANT, CAN_HAVE_NULL, true, true, false>(
-				    constant, data, generic_sel, validity, sel, count, true_sel, false_sel, adapter);
-			}
-			return SelectGenericConstantLoop<RIGHT_CONSTANT, CAN_HAVE_NULL, true, false, true>(
-			    constant, data, generic_sel, validity, sel, count, true_sel, false_sel, adapter);
-		}
-		return SelectGenericConstantLoop<RIGHT_CONSTANT, CAN_HAVE_NULL, false, false, false>(
-		    constant, data, generic_sel, validity, sel, count, true_sel, false_sel, adapter);
-	}
-
-	template <uint64_t CONSTANT_MASK, bool SPECIALIZE_OUTPUTS, class ADAPTER, class LEFT_TYPE, class RIGHT_TYPE>
+	template <uint64_t CONSTANT_MASK, class SINK, class ADAPTER, class LEFT_TYPE, class RIGHT_TYPE>
 	static idx_t SelectGenericConstant(const std::array<VectorRef, 2> &inputs, const SelectionVector &sel, idx_t count,
-	                                   SelectionVector *true_sel, SelectionVector *false_sel, ADAPTER &adapter) {
+	                                   const SINK &sink, ADAPTER &adapter) {
 		static_assert(CONSTANT_MASK == 1 || CONSTANT_MASK == 2, "Exactly one binary input must be constant");
 		constexpr idx_t GENERIC_INDEX = CONSTANT_MASK == 1 ? 1 : 0;
 		UnifiedVectorFormat generic_format;
@@ -583,141 +582,106 @@ private:
 			auto constant = *ConstantVector::GetData<LEFT_TYPE>(inputs[0].get());
 			auto data = UnifiedVectorFormat::GetData<RIGHT_TYPE>(generic_format);
 			if (can_have_null) {
-				return SelectGenericConstantSwitch<false, true, SPECIALIZE_OUTPUTS>(constant, data, *generic_format.sel,
-				                                                                    generic_format.validity, sel, count,
-				                                                                    true_sel, false_sel, adapter);
+				return SelectGenericConstantLoop<false, true>(constant, data, *generic_format.sel,
+				                                              generic_format.validity, sel, count, sink, adapter);
 			}
-			return SelectGenericConstantSwitch<false, false, SPECIALIZE_OUTPUTS>(
-			    constant, data, *generic_format.sel, generic_format.validity, sel, count, true_sel, false_sel, adapter);
+			return SelectGenericConstantLoop<false, false>(constant, data, *generic_format.sel, generic_format.validity,
+			                                               sel, count, sink, adapter);
 		}
 		auto constant = *ConstantVector::GetData<RIGHT_TYPE>(inputs[1].get());
 		auto data = UnifiedVectorFormat::GetData<LEFT_TYPE>(generic_format);
 		if (can_have_null) {
-			return SelectGenericConstantSwitch<true, true, SPECIALIZE_OUTPUTS>(
-			    constant, data, *generic_format.sel, generic_format.validity, sel, count, true_sel, false_sel, adapter);
+			return SelectGenericConstantLoop<true, true>(constant, data, *generic_format.sel, generic_format.validity,
+			                                             sel, count, sink, adapter);
 		}
-		return SelectGenericConstantSwitch<true, false, SPECIALIZE_OUTPUTS>(
-		    constant, data, *generic_format.sel, generic_format.validity, sel, count, true_sel, false_sel, adapter);
+		return SelectGenericConstantLoop<true, false>(constant, data, *generic_format.sel, generic_format.validity, sel,
+		                                              count, sink, adapter);
 	}
 
-	template <bool NO_NULL, bool SPECIALIZE_OUTPUTS, bool HAS_TRUE_SEL, bool HAS_FALSE_SEL, class ADAPTER,
-	          class... ARGS, size_t... Is>
+	template <bool NO_NULL, class SINK, class ADAPTER, class... ARGS, size_t... Is>
 	static idx_t SelectGenericLoop(std::tuple<const ARGS *...> &input_data,
 	                               std::array<UnifiedVectorFormat, sizeof...(ARGS)> &formats,
-	                               const SelectionVector &sel, idx_t count, SelectionVector *true_sel,
-	                               SelectionVector *false_sel, ADAPTER &adapter, std::index_sequence<Is...>) {
+	                               const SelectionVector &sel, idx_t count, const SINK &sink, ADAPTER &adapter,
+	                               std::index_sequence<Is...>) {
+		auto local_sink = sink;
 		constexpr idx_t N = sizeof...(ARGS);
-		idx_t true_count = 0;
-		idx_t false_count = 0;
 		for (idx_t row = 0; row < count; row++) {
 			auto result_idx = sel.get_index(row);
 			std::array<idx_t, N> input_indices = {{formats[Is].sel->get_index(row)...}};
 			bool comparison_result = (NO_NULL || (... && formats[Is].validity.RowIsValid(input_indices[Is]))) &&
 			                         SelectOperation<NO_NULL>(adapter, std::get<Is>(input_data)[input_indices[Is]]...);
-			StoreSelection<SPECIALIZE_OUTPUTS, HAS_TRUE_SEL, HAS_FALSE_SEL>(comparison_result, result_idx, true_sel,
-			                                                                false_sel, true_count, false_count);
+			local_sink.Append(comparison_result, result_idx);
 		}
-		if constexpr (SPECIALIZE_OUTPUTS && HAS_TRUE_SEL) {
-			return true_count;
-		}
-		return true_sel ? true_count : count - false_count;
+		return local_sink.Result(count);
 	}
 
-	template <bool NO_NULL, bool SPECIALIZE_OUTPUTS, class ADAPTER, class... ARGS, size_t... Is>
-	static idx_t SelectGenericSwitch(std::tuple<const ARGS *...> &input_data,
-	                                 std::array<UnifiedVectorFormat, sizeof...(ARGS)> &formats,
-	                                 const SelectionVector &sel, idx_t count, SelectionVector *true_sel,
-	                                 SelectionVector *false_sel, ADAPTER &adapter, std::index_sequence<Is...> indices) {
-		if constexpr (SPECIALIZE_OUTPUTS) {
-			if (true_sel && false_sel) {
-				return SelectGenericLoop<NO_NULL, true, true, true>(input_data, formats, sel, count, true_sel,
-				                                                    false_sel, adapter, indices);
-			} else if (true_sel) {
-				return SelectGenericLoop<NO_NULL, true, true, false>(input_data, formats, sel, count, true_sel,
-				                                                     false_sel, adapter, indices);
-			}
-			return SelectGenericLoop<NO_NULL, true, false, true>(input_data, formats, sel, count, true_sel, false_sel,
-			                                                     adapter, indices);
-		}
-		return SelectGenericLoop<NO_NULL, false, false, false>(input_data, formats, sel, count, true_sel, false_sel,
-		                                                       adapter, indices);
-	}
-
-	template <bool SPECIALIZE_OUTPUTS, class ADAPTER, class... ARGS, size_t... Is>
+	template <class SINK, class ADAPTER, class... ARGS, size_t... Is>
 	static idx_t SelectGeneric(const std::array<VectorRef, sizeof...(ARGS)> &inputs, const SelectionVector &sel,
-	                           idx_t count, SelectionVector *true_sel, SelectionVector *false_sel, ADAPTER &adapter,
-	                           std::index_sequence<Is...> indices) {
+	                           idx_t count, const SINK &sink, ADAPTER &adapter, std::index_sequence<Is...> indices) {
 		std::array<UnifiedVectorFormat, sizeof...(ARGS)> formats;
 		for (idx_t i = 0; i < sizeof...(ARGS); i++) {
 			inputs[i].get().ToUnifiedFormat(formats[i]);
 		}
 		auto input_data = std::make_tuple(UnifiedVectorFormat::GetData<ARGS>(formats[Is])...);
 		if ((... || formats[Is].validity.CanHaveNull())) {
-			return SelectGenericSwitch<false, SPECIALIZE_OUTPUTS>(input_data, formats, sel, count, true_sel, false_sel,
-			                                                      adapter, indices);
+			return SelectGenericLoop<false, SINK, ADAPTER, ARGS...>(input_data, formats, sel, count, sink, adapter,
+			                                                        indices);
 		}
-		return SelectGenericSwitch<true, SPECIALIZE_OUTPUTS>(input_data, formats, sel, count, true_sel, false_sel,
-		                                                     adapter, indices);
+		return SelectGenericLoop<true, SINK, ADAPTER, ARGS...>(input_data, formats, sel, count, sink, adapter, indices);
 	}
 
-	template <uint64_t SPECIALIZED_MASKS, bool SPECIALIZE_OUTPUTS, class ADAPTER, class... ARGS, size_t... Is>
+	template <class POLICY, class SINK, class ADAPTER, class... ARGS, size_t... Is>
 	static idx_t SelectInternal(const std::array<VectorRef, sizeof...(ARGS)> &inputs, const SelectionVector &sel,
-	                            idx_t count, SelectionVector *true_sel, SelectionVector *false_sel, ADAPTER &adapter,
+	                            idx_t count, const InputProfile &profile, const SINK &sink, ADAPTER &adapter,
 	                            std::index_sequence<Is...> indices) {
 		constexpr idx_t N = sizeof...(ARGS);
-		auto profile = GetInputProfile(inputs, indices);
 		if (profile.all_constant) {
 			if (profile.any_constant_null) {
-				return FillConstantSelection(false, sel, count, true_sel, false_sel);
+				auto local_sink = sink;
+				return local_sink.FillConstant(false, sel, count);
 			}
-			return SelectConstant<ADAPTER, ARGS...>(inputs, sel, count, true_sel, false_sel, adapter, indices);
+			return SelectConstant<SINK, ADAPTER, ARGS...>(inputs, sel, count, sink, adapter, indices);
 		}
-		if constexpr (SPECIALIZED_MASKS != 0 && N <= 3) {
+		if constexpr (POLICY::SPECIALIZED_MASKS != 0 && N <= 3) {
 			if (profile.all_flat_or_constant) {
 				if (profile.any_constant_null) {
-					return FillConstantSelection(false, sel, count, true_sel, false_sel);
+					auto local_sink = sink;
+					return local_sink.FillConstant(false, sel, count);
 				}
 				switch (profile.constant_mask) {
 				case 0:
-					if constexpr (SPECIALIZED_MASKS & (uint64_t(1) << 0)) {
-						return SelectFlatSwitch<0, SPECIALIZE_OUTPUTS, ADAPTER, ARGS...>(inputs, sel, count, true_sel,
-						                                                                 false_sel, adapter, indices);
+					if constexpr (POLICY::SPECIALIZED_MASKS & (uint64_t(1) << 0)) {
+						return SelectFlat<0, SINK, ADAPTER, ARGS...>(inputs, sel, count, sink, adapter, indices);
 					}
 					break;
 				case 1:
-					if constexpr (N >= 2 && (SPECIALIZED_MASKS & (uint64_t(1) << 1))) {
-						return SelectFlatSwitch<1, SPECIALIZE_OUTPUTS, ADAPTER, ARGS...>(inputs, sel, count, true_sel,
-						                                                                 false_sel, adapter, indices);
+					if constexpr (N >= 2 && (POLICY::SPECIALIZED_MASKS & (uint64_t(1) << 1))) {
+						return SelectFlat<1, SINK, ADAPTER, ARGS...>(inputs, sel, count, sink, adapter, indices);
 					}
 					break;
 				case 2:
-					if constexpr (N >= 2 && (SPECIALIZED_MASKS & (uint64_t(1) << 2))) {
-						return SelectFlatSwitch<2, SPECIALIZE_OUTPUTS, ADAPTER, ARGS...>(inputs, sel, count, true_sel,
-						                                                                 false_sel, adapter, indices);
+					if constexpr (N >= 2 && (POLICY::SPECIALIZED_MASKS & (uint64_t(1) << 2))) {
+						return SelectFlat<2, SINK, ADAPTER, ARGS...>(inputs, sel, count, sink, adapter, indices);
 					}
 					break;
 				case 3:
-					if constexpr (N >= 3 && (SPECIALIZED_MASKS & (uint64_t(1) << 3))) {
-						return SelectFlatSwitch<3, SPECIALIZE_OUTPUTS, ADAPTER, ARGS...>(inputs, sel, count, true_sel,
-						                                                                 false_sel, adapter, indices);
+					if constexpr (N >= 3 && (POLICY::SPECIALIZED_MASKS & (uint64_t(1) << 3))) {
+						return SelectFlat<3, SINK, ADAPTER, ARGS...>(inputs, sel, count, sink, adapter, indices);
 					}
 					break;
 				case 4:
-					if constexpr (N >= 3 && (SPECIALIZED_MASKS & (uint64_t(1) << 4))) {
-						return SelectFlatSwitch<4, SPECIALIZE_OUTPUTS, ADAPTER, ARGS...>(inputs, sel, count, true_sel,
-						                                                                 false_sel, adapter, indices);
+					if constexpr (N >= 3 && (POLICY::SPECIALIZED_MASKS & (uint64_t(1) << 4))) {
+						return SelectFlat<4, SINK, ADAPTER, ARGS...>(inputs, sel, count, sink, adapter, indices);
 					}
 					break;
 				case 5:
-					if constexpr (N >= 3 && (SPECIALIZED_MASKS & (uint64_t(1) << 5))) {
-						return SelectFlatSwitch<5, SPECIALIZE_OUTPUTS, ADAPTER, ARGS...>(inputs, sel, count, true_sel,
-						                                                                 false_sel, adapter, indices);
+					if constexpr (N >= 3 && (POLICY::SPECIALIZED_MASKS & (uint64_t(1) << 5))) {
+						return SelectFlat<5, SINK, ADAPTER, ARGS...>(inputs, sel, count, sink, adapter, indices);
 					}
 					break;
 				case 6:
-					if constexpr (N >= 3 && (SPECIALIZED_MASKS & (uint64_t(1) << 6))) {
-						return SelectFlatSwitch<6, SPECIALIZE_OUTPUTS, ADAPTER, ARGS...>(inputs, sel, count, true_sel,
-						                                                                 false_sel, adapter, indices);
+					if constexpr (N >= 3 && (POLICY::SPECIALIZED_MASKS & (uint64_t(1) << 6))) {
+						return SelectFlat<6, SINK, ADAPTER, ARGS...>(inputs, sel, count, sink, adapter, indices);
 					}
 					break;
 				default:
@@ -725,34 +689,30 @@ private:
 				}
 			}
 		}
-		if constexpr (SPECIALIZED_MASKS != 0 && N == 2) {
+		if constexpr (POLICY::SPECIALIZED_MASKS != 0 && N == 2) {
 			if (!profile.any_constant_null) {
 				switch (profile.constant_mask) {
 				case 1:
-					return SelectGenericConstant<1, SPECIALIZE_OUTPUTS, ADAPTER, ARGS...>(inputs, sel, count, true_sel,
-					                                                                      false_sel, adapter);
+					return SelectGenericConstant<1, SINK, ADAPTER, ARGS...>(inputs, sel, count, sink, adapter);
 				case 2:
-					return SelectGenericConstant<2, SPECIALIZE_OUTPUTS, ADAPTER, ARGS...>(inputs, sel, count, true_sel,
-					                                                                      false_sel, adapter);
+					return SelectGenericConstant<2, SINK, ADAPTER, ARGS...>(inputs, sel, count, sink, adapter);
 				default:
 					break;
 				}
 			}
 		}
-		return SelectGeneric<SPECIALIZE_OUTPUTS, ADAPTER, ARGS...>(inputs, sel, count, true_sel, false_sel, adapter,
-		                                                           indices);
+		return SelectGeneric<SINK, ADAPTER, ARGS...>(inputs, sel, count, sink, adapter, indices);
 	}
 
 public:
-	template <bool SPECIALIZE_FLAT, bool SPECIALIZE_NULLABLE_GENERIC_SELECTIONS, bool PRESERVE_RESULT_VALIDITY,
-	          class RESULT_TYPE, class ADAPTER, class... ARGS>
+	template <class POLICY, class RESULT_TYPE, class ADAPTER, class... ARGS>
 	static void Execute(const std::array<VectorRef, sizeof...(ARGS)> &inputs, Vector &result, idx_t count,
 	                    ADAPTER &adapter) {
-		ExecuteInternal<SPECIALIZE_FLAT, SPECIALIZE_NULLABLE_GENERIC_SELECTIONS, PRESERVE_RESULT_VALIDITY, RESULT_TYPE,
-		                ADAPTER, ARGS...>(inputs, result, count, adapter, std::index_sequence_for<ARGS...> {});
+		ExecuteInternal<POLICY, RESULT_TYPE, ADAPTER, ARGS...>(inputs, result, count, adapter,
+		                                                       std::index_sequence_for<ARGS...> {});
 	}
 
-	template <uint64_t SPECIALIZED_MASKS, bool SPECIALIZE_OUTPUTS, class ADAPTER, class... ARGS>
+	template <class POLICY, class ADAPTER, class... ARGS>
 	static idx_t Select(const std::array<VectorRef, sizeof...(ARGS)> &inputs, const SelectionVector *sel, idx_t count,
 	                    SelectionVector *true_sel, SelectionVector *false_sel, ADAPTER &adapter) {
 		if (!true_sel && !false_sel) {
@@ -761,8 +721,40 @@ public:
 		if (!sel) {
 			sel = FlatVector::IncrementalSelectionVector();
 		}
-		return SelectInternal<SPECIALIZED_MASKS, SPECIALIZE_OUTPUTS, ADAPTER, ARGS...>(
-		    inputs, *sel, count, true_sel, false_sel, adapter, std::index_sequence_for<ARGS...> {});
+		auto indices = std::index_sequence_for<ARGS...> {};
+		if constexpr (POLICY::DIRECT_TRUE_FLAT) {
+			static_assert(sizeof...(ARGS) == 2, "Direct true-only selection requires two inputs");
+			if (true_sel && !false_sel) {
+				StaticSelectionSink<true, false> sink(true_sel, false_sel);
+				auto left_type = inputs[0].get().GetVectorType();
+				auto right_type = inputs[1].get().GetVectorType();
+				if (left_type == VectorType::FLAT_VECTOR && right_type == VectorType::FLAT_VECTOR) {
+					return SelectFlat<0, decltype(sink), ADAPTER, ARGS...>(inputs, *sel, count, sink, adapter, indices);
+				} else if (left_type == VectorType::FLAT_VECTOR && right_type == VectorType::CONSTANT_VECTOR) {
+					return SelectFlat<2, decltype(sink), ADAPTER, ARGS...>(inputs, *sel, count, sink, adapter, indices);
+				} else if (left_type == VectorType::CONSTANT_VECTOR && right_type == VectorType::FLAT_VECTOR) {
+					return SelectFlat<1, decltype(sink), ADAPTER, ARGS...>(inputs, *sel, count, sink, adapter, indices);
+				}
+			}
+		}
+		auto profile = GetInputProfile(inputs, indices);
+		if constexpr (POLICY::SPECIALIZE_OUTPUTS) {
+			if (true_sel && false_sel) {
+				StaticSelectionSink<true, true> sink(true_sel, false_sel);
+				return SelectInternal<POLICY, decltype(sink), ADAPTER, ARGS...>(inputs, *sel, count, profile, sink,
+				                                                                adapter, indices);
+			} else if (true_sel) {
+				StaticSelectionSink<true, false> sink(true_sel, false_sel);
+				return SelectInternal<POLICY, decltype(sink), ADAPTER, ARGS...>(inputs, *sel, count, profile, sink,
+				                                                                adapter, indices);
+			}
+			StaticSelectionSink<false, true> sink(true_sel, false_sel);
+			return SelectInternal<POLICY, decltype(sink), ADAPTER, ARGS...>(inputs, *sel, count, profile, sink, adapter,
+			                                                                indices);
+		}
+		RuntimeSelectionSink sink(true_sel, false_sel);
+		return SelectInternal<POLICY, decltype(sink), ADAPTER, ARGS...>(inputs, *sel, count, profile, sink, adapter,
+		                                                                indices);
 	}
 };
 

--- a/src/include/duckdb/common/vector_operations/scalar_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/scalar_executor.hpp
@@ -545,6 +545,60 @@ private:
 		                                                             adapter, indices);
 	}
 
+	template <uint64_t SPECIALIZED_MASKS, class SINK, class ADAPTER, class... ARGS, size_t... Is>
+	static bool TrySelectFlat(const std::array<VectorRef, sizeof...(ARGS)> &inputs, const SelectionVector &sel,
+	                          idx_t count, uint64_t constant_mask, const SINK &sink, ADAPTER &adapter,
+	                          std::index_sequence<Is...> indices, idx_t &result) {
+		constexpr idx_t N = sizeof...(ARGS);
+		switch (constant_mask) {
+		case 0:
+			if constexpr (SPECIALIZED_MASKS & (uint64_t(1) << 0)) {
+				result = SelectFlat<0, SINK, ADAPTER, ARGS...>(inputs, sel, count, sink, adapter, indices);
+				return true;
+			}
+			break;
+		case 1:
+			if constexpr (N >= 2 && (SPECIALIZED_MASKS & (uint64_t(1) << 1))) {
+				result = SelectFlat<1, SINK, ADAPTER, ARGS...>(inputs, sel, count, sink, adapter, indices);
+				return true;
+			}
+			break;
+		case 2:
+			if constexpr (N >= 2 && (SPECIALIZED_MASKS & (uint64_t(1) << 2))) {
+				result = SelectFlat<2, SINK, ADAPTER, ARGS...>(inputs, sel, count, sink, adapter, indices);
+				return true;
+			}
+			break;
+		case 3:
+			if constexpr (N >= 3 && (SPECIALIZED_MASKS & (uint64_t(1) << 3))) {
+				result = SelectFlat<3, SINK, ADAPTER, ARGS...>(inputs, sel, count, sink, adapter, indices);
+				return true;
+			}
+			break;
+		case 4:
+			if constexpr (N >= 3 && (SPECIALIZED_MASKS & (uint64_t(1) << 4))) {
+				result = SelectFlat<4, SINK, ADAPTER, ARGS...>(inputs, sel, count, sink, adapter, indices);
+				return true;
+			}
+			break;
+		case 5:
+			if constexpr (N >= 3 && (SPECIALIZED_MASKS & (uint64_t(1) << 5))) {
+				result = SelectFlat<5, SINK, ADAPTER, ARGS...>(inputs, sel, count, sink, adapter, indices);
+				return true;
+			}
+			break;
+		case 6:
+			if constexpr (N >= 3 && (SPECIALIZED_MASKS & (uint64_t(1) << 6))) {
+				result = SelectFlat<6, SINK, ADAPTER, ARGS...>(inputs, sel, count, sink, adapter, indices);
+				return true;
+			}
+			break;
+		default:
+			break;
+		}
+		return false;
+	}
+
 	template <bool RIGHT_CONSTANT, bool CAN_HAVE_NULL, class SINK, class CONSTANT_TYPE, class GENERIC_TYPE,
 	          class ADAPTER>
 	static idx_t SelectGenericConstantLoop(CONSTANT_TYPE constant, const GENERIC_TYPE *__restrict data,
@@ -648,44 +702,10 @@ private:
 					auto local_sink = sink;
 					return local_sink.FillConstant(false, sel, count);
 				}
-				switch (profile.constant_mask) {
-				case 0:
-					if constexpr (POLICY::SPECIALIZED_MASKS & (uint64_t(1) << 0)) {
-						return SelectFlat<0, SINK, ADAPTER, ARGS...>(inputs, sel, count, sink, adapter, indices);
-					}
-					break;
-				case 1:
-					if constexpr (N >= 2 && (POLICY::SPECIALIZED_MASKS & (uint64_t(1) << 1))) {
-						return SelectFlat<1, SINK, ADAPTER, ARGS...>(inputs, sel, count, sink, adapter, indices);
-					}
-					break;
-				case 2:
-					if constexpr (N >= 2 && (POLICY::SPECIALIZED_MASKS & (uint64_t(1) << 2))) {
-						return SelectFlat<2, SINK, ADAPTER, ARGS...>(inputs, sel, count, sink, adapter, indices);
-					}
-					break;
-				case 3:
-					if constexpr (N >= 3 && (POLICY::SPECIALIZED_MASKS & (uint64_t(1) << 3))) {
-						return SelectFlat<3, SINK, ADAPTER, ARGS...>(inputs, sel, count, sink, adapter, indices);
-					}
-					break;
-				case 4:
-					if constexpr (N >= 3 && (POLICY::SPECIALIZED_MASKS & (uint64_t(1) << 4))) {
-						return SelectFlat<4, SINK, ADAPTER, ARGS...>(inputs, sel, count, sink, adapter, indices);
-					}
-					break;
-				case 5:
-					if constexpr (N >= 3 && (POLICY::SPECIALIZED_MASKS & (uint64_t(1) << 5))) {
-						return SelectFlat<5, SINK, ADAPTER, ARGS...>(inputs, sel, count, sink, adapter, indices);
-					}
-					break;
-				case 6:
-					if constexpr (N >= 3 && (POLICY::SPECIALIZED_MASKS & (uint64_t(1) << 6))) {
-						return SelectFlat<6, SINK, ADAPTER, ARGS...>(inputs, sel, count, sink, adapter, indices);
-					}
-					break;
-				default:
-					throw InternalException("Invalid flat/constant scalar selection profile");
+				idx_t result;
+				if (TrySelectFlat<POLICY::SPECIALIZED_MASKS, SINK, ADAPTER, ARGS...>(
+				        inputs, sel, count, profile.constant_mask, sink, adapter, indices, result)) {
+					return result;
 				}
 			}
 		}
@@ -722,22 +742,22 @@ public:
 			sel = FlatVector::IncrementalSelectionVector();
 		}
 		auto indices = std::index_sequence_for<ARGS...> {};
-		if constexpr (POLICY::DIRECT_TRUE_FLAT) {
-			static_assert(sizeof...(ARGS) == 2, "Direct true-only selection requires two inputs");
-			if (true_sel && !false_sel) {
+		auto profile = GetInputProfile(inputs, indices);
+		if constexpr (POLICY::DIRECT_TRUE_FLAT_MASKS != 0) {
+			static_assert(sizeof...(ARGS) <= 3, "Direct true-only selection supports up to three inputs");
+			if (true_sel && !false_sel && profile.all_flat_or_constant &&
+			    (POLICY::DIRECT_TRUE_FLAT_MASKS & (uint64_t(1) << profile.constant_mask))) {
 				StaticSelectionSink<true, false> sink(true_sel, false_sel);
-				auto left_type = inputs[0].get().GetVectorType();
-				auto right_type = inputs[1].get().GetVectorType();
-				if (left_type == VectorType::FLAT_VECTOR && right_type == VectorType::FLAT_VECTOR) {
-					return SelectFlat<0, decltype(sink), ADAPTER, ARGS...>(inputs, *sel, count, sink, adapter, indices);
-				} else if (left_type == VectorType::FLAT_VECTOR && right_type == VectorType::CONSTANT_VECTOR) {
-					return SelectFlat<2, decltype(sink), ADAPTER, ARGS...>(inputs, *sel, count, sink, adapter, indices);
-				} else if (left_type == VectorType::CONSTANT_VECTOR && right_type == VectorType::FLAT_VECTOR) {
-					return SelectFlat<1, decltype(sink), ADAPTER, ARGS...>(inputs, *sel, count, sink, adapter, indices);
+				if (profile.any_constant_null) {
+					return sink.FillConstant(false, *sel, count);
+				}
+				idx_t result;
+				if (TrySelectFlat<POLICY::DIRECT_TRUE_FLAT_MASKS, decltype(sink), ADAPTER, ARGS...>(
+				        inputs, *sel, count, profile.constant_mask, sink, adapter, indices, result)) {
+					return result;
 				}
 			}
 		}
-		auto profile = GetInputProfile(inputs, indices);
 		if constexpr (POLICY::SPECIALIZE_OUTPUTS) {
 			if (true_sel && false_sel) {
 				StaticSelectionSink<true, true> sink(true_sel, false_sel);

--- a/src/include/duckdb/common/vector_operations/scalar_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/scalar_executor.hpp
@@ -120,7 +120,7 @@ private:
 
 	DUCKDB_API static bool PrepareGenericResultValidity(const UnifiedVectorFormat *formats, idx_t format_count,
 	                                                    Vector &result, idx_t count, bool preserve_result_validity,
-	                                                    bool adds_nulls, ValidityMask &input_validity);
+	                                                    bool adds_nulls);
 
 	template <bool PRESERVE_RESULT_VALIDITY, uint64_t CONSTANT_MASK, class RESULT_TYPE, class ADAPTER, class... ARGS,
 	          size_t... Is>
@@ -204,52 +204,60 @@ private:
 		return row;
 	}
 
-	template <uint64_t SELECTION_MASK, class RESULT_TYPE, class ADAPTER, class... ARGS, size_t... Is>
-	static void ExecuteGenericNoNullLoop(const std::tuple<const ARGS *...> &input_data,
-	                                     const std::array<const sel_t *, 2> &selections, RESULT_TYPE *result_data,
-	                                     idx_t count, ValidityMask &result_validity, ADAPTER &adapter,
-	                                     std::index_sequence<Is...>) {
-		auto result_ptr = result_data;
-		auto result_end = result_data + count;
-		idx_t result_idx = 0;
-		while (result_ptr != result_end) {
-			*result_ptr = adapter.Operation(
-			    result_validity, result_idx,
-			    std::get<Is>(input_data)[GenericInputIndex<Is, SELECTION_MASK>(selections, result_idx)]...);
-			result_ptr++;
-			result_idx++;
+	template <uint64_t SELECTION_MASK, class RESULT_TYPE, class ADAPTER, class LEFT_TYPE, class RIGHT_TYPE>
+	static void
+	ExecuteGenericBinaryNullable(const LEFT_TYPE *__restrict left_data, const RIGHT_TYPE *__restrict right_data,
+	                             const std::array<UnifiedVectorFormat, 2> &formats,
+	                             const std::array<const sel_t *, 2> &selections, RESULT_TYPE *__restrict result_data,
+	                             idx_t count, ValidityMask &result_validity, ADAPTER &adapter) {
+		auto &left_validity = formats[0].validity;
+		auto &right_validity = formats[1].validity;
+		for (idx_t row = 0; row < count; row++) {
+			auto left_index = GenericInputIndex<0, SELECTION_MASK>(selections, row);
+			auto right_index = GenericInputIndex<1, SELECTION_MASK>(selections, row);
+			if (left_validity.RowIsValid(left_index) && right_validity.RowIsValid(right_index)) {
+				result_data[row] =
+				    adapter.Operation(result_validity, row, left_data[left_index], right_data[right_index]);
+			} else {
+				result_validity.SetInvalid(row);
+			}
 		}
 	}
 
-	template <class RESULT_TYPE, class ADAPTER, class... ARGS, size_t... Is>
-	static void ExecuteGenericNoNullSwitch(const std::tuple<const ARGS *...> &input_data,
-	                                       const std::array<UnifiedVectorFormat, 2> &formats, RESULT_TYPE *result_data,
-	                                       idx_t count, ValidityMask &result_validity, ADAPTER &adapter,
-	                                       std::index_sequence<Is...> indices) {
+	template <class RESULT_TYPE, class ADAPTER, class LEFT_TYPE, class RIGHT_TYPE>
+	static void ExecuteGenericBinaryNullableSwitch(const LEFT_TYPE *__restrict left_data,
+	                                               const RIGHT_TYPE *__restrict right_data,
+	                                               const std::array<UnifiedVectorFormat, 2> &formats,
+	                                               RESULT_TYPE *__restrict result_data, idx_t count,
+	                                               ValidityMask &result_validity, ADAPTER &adapter) {
 		std::array<const sel_t *, 2> selections = {{formats[0].sel->data(), formats[1].sel->data()}};
 		uint64_t selection_mask = 0;
 		selection_mask |= selections[0] ? 1 : 0;
 		selection_mask |= selections[1] ? 2 : 0;
 		switch (selection_mask) {
 		case 0:
-			ExecuteGenericNoNullLoop<0>(input_data, selections, result_data, count, result_validity, adapter, indices);
+			ExecuteGenericBinaryNullable<0>(left_data, right_data, formats, selections, result_data, count,
+			                                result_validity, adapter);
 			return;
 		case 1:
-			ExecuteGenericNoNullLoop<1>(input_data, selections, result_data, count, result_validity, adapter, indices);
+			ExecuteGenericBinaryNullable<1>(left_data, right_data, formats, selections, result_data, count,
+			                                result_validity, adapter);
 			return;
 		case 2:
-			ExecuteGenericNoNullLoop<2>(input_data, selections, result_data, count, result_validity, adapter, indices);
+			ExecuteGenericBinaryNullable<2>(left_data, right_data, formats, selections, result_data, count,
+			                                result_validity, adapter);
 			return;
 		case 3:
-			ExecuteGenericNoNullLoop<3>(input_data, selections, result_data, count, result_validity, adapter, indices);
+			ExecuteGenericBinaryNullable<3>(left_data, right_data, formats, selections, result_data, count,
+			                                result_validity, adapter);
 			return;
 		default:
-			throw InternalException("Invalid generic scalar executor selection profile");
+			throw InternalException("Invalid nullable generic scalar executor selection profile");
 		}
 	}
 
-	template <bool SPECIALIZE_GENERIC_SELECTIONS, bool PRESERVE_RESULT_VALIDITY, class RESULT_TYPE, class ADAPTER,
-	          class... ARGS, size_t... Is>
+	template <bool SPECIALIZE_NULLABLE_GENERIC_SELECTIONS, bool PRESERVE_RESULT_VALIDITY, class RESULT_TYPE,
+	          class ADAPTER, class... ARGS, size_t... Is>
 	static void ExecuteGeneric(const std::array<VectorRef, sizeof...(ARGS)> &inputs, Vector &result, idx_t count,
 	                           ADAPTER &adapter, std::index_sequence<Is...>) {
 		constexpr idx_t N = sizeof...(ARGS);
@@ -264,23 +272,24 @@ private:
 		}
 		auto result_data = FlatVector::GetDataMutable<RESULT_TYPE>(result);
 		auto &result_validity = FlatVector::ValidityMutable(result);
-		ValidityMask input_validity(count);
-		auto inputs_can_have_null = PrepareGenericResultValidity(
-		    formats.data(), N, result, count, PRESERVE_RESULT_VALIDITY, ADAPTER::ADDS_NULLS, input_validity);
+		auto inputs_can_have_null = PrepareGenericResultValidity(formats.data(), N, result, count,
+		                                                         PRESERVE_RESULT_VALIDITY, ADAPTER::ADDS_NULLS);
 
 		if (inputs_can_have_null) {
-			for (idx_t row = 0; row < count; row++) {
-				std::array<idx_t, N> input_indices = {{formats[Is].sel->get_index(row)...}};
-				if (input_validity.RowIsValid(row)) {
-					result_data[row] =
-					    adapter.Operation(result_validity, row, std::get<Is>(input_data)[input_indices[Is]]...);
-				} else {
-					result_validity.SetInvalid(row);
+			if constexpr (SPECIALIZE_NULLABLE_GENERIC_SELECTIONS && N == 2) {
+				ExecuteGenericBinaryNullableSwitch(std::get<0>(input_data), std::get<1>(input_data), formats,
+				                                   result_data, count, result_validity, adapter);
+			} else {
+				for (idx_t row = 0; row < count; row++) {
+					std::array<idx_t, N> input_indices = {{formats[Is].sel->get_index(row)...}};
+					if ((... && formats[Is].validity.RowIsValid(input_indices[Is]))) {
+						result_data[row] =
+						    adapter.Operation(result_validity, row, std::get<Is>(input_data)[input_indices[Is]]...);
+					} else {
+						result_validity.SetInvalid(row);
+					}
 				}
 			}
-		} else if constexpr (SPECIALIZE_GENERIC_SELECTIONS && N == 2) {
-			ExecuteGenericNoNullSwitch(input_data, formats, result_data, count, result_validity, adapter,
-			                           std::index_sequence_for<ARGS...> {});
 		} else {
 			for (idx_t row = 0; row < count; row++) {
 				result_data[row] = adapter.Operation(result_validity, row,
@@ -289,7 +298,7 @@ private:
 		}
 	}
 
-	template <bool SPECIALIZE_FLAT, bool SPECIALIZE_GENERIC_SELECTIONS, bool PRESERVE_RESULT_VALIDITY,
+	template <bool SPECIALIZE_FLAT, bool SPECIALIZE_NULLABLE_GENERIC_SELECTIONS, bool PRESERVE_RESULT_VALIDITY,
 	          class RESULT_TYPE, class ADAPTER, class... ARGS, size_t... Is>
 	static void ExecuteInternal(const std::array<VectorRef, sizeof...(ARGS)> &inputs, Vector &result, idx_t count,
 	                            ADAPTER &adapter, std::index_sequence<Is...> indices) {
@@ -363,7 +372,7 @@ private:
 				}
 			}
 		}
-		ExecuteGeneric<SPECIALIZE_GENERIC_SELECTIONS, PRESERVE_RESULT_VALIDITY, RESULT_TYPE, ADAPTER, ARGS...>(
+		ExecuteGeneric<SPECIALIZE_NULLABLE_GENERIC_SELECTIONS, PRESERVE_RESULT_VALIDITY, RESULT_TYPE, ADAPTER, ARGS...>(
 		    inputs, result, count, adapter, indices);
 	}
 
@@ -511,21 +520,26 @@ private:
 		                                                                        adapter, indices);
 	}
 
-	template <bool RIGHT_CONSTANT, bool SPECIALIZE_OUTPUTS, bool HAS_TRUE_SEL, bool HAS_FALSE_SEL, class CONSTANT_TYPE,
-	          class GENERIC_TYPE, class ADAPTER>
+	template <bool RIGHT_CONSTANT, bool CAN_HAVE_NULL, bool SPECIALIZE_OUTPUTS, bool HAS_TRUE_SEL, bool HAS_FALSE_SEL,
+	          class CONSTANT_TYPE, class GENERIC_TYPE, class ADAPTER>
 	static idx_t SelectGenericConstantLoop(CONSTANT_TYPE constant, const GENERIC_TYPE *__restrict data,
-	                                       const SelectionVector &generic_sel, const SelectionVector &sel, idx_t count,
-	                                       SelectionVector *true_sel, SelectionVector *false_sel, ADAPTER &adapter) {
+	                                       const SelectionVector &generic_sel, const ValidityMask &validity,
+	                                       const SelectionVector &sel, idx_t count, SelectionVector *true_sel,
+	                                       SelectionVector *false_sel, ADAPTER &adapter) {
 		idx_t true_count = 0;
 		idx_t false_count = 0;
 		for (idx_t row = 0; row < count; row++) {
 			auto result_idx = sel.get_index(row);
 			auto generic_index = generic_sel.get_index(row);
-			bool comparison_result;
-			if constexpr (RIGHT_CONSTANT) {
-				comparison_result = adapter.OperationNoNull(data[generic_index], constant);
-			} else {
-				comparison_result = adapter.OperationNoNull(constant, data[generic_index]);
+			bool comparison_result = !CAN_HAVE_NULL || validity.RowIsValid(generic_index);
+			if (comparison_result) {
+				if constexpr (RIGHT_CONSTANT) {
+					comparison_result = CAN_HAVE_NULL ? adapter.Operation(data[generic_index], constant)
+					                                  : adapter.OperationNoNull(data[generic_index], constant);
+				} else {
+					comparison_result = CAN_HAVE_NULL ? adapter.Operation(constant, data[generic_index])
+					                                  : adapter.OperationNoNull(constant, data[generic_index]);
+				}
 			}
 			StoreSelection<SPECIALIZE_OUTPUTS, HAS_TRUE_SEL, HAS_FALSE_SEL>(comparison_result, result_idx, true_sel,
 			                                                                false_sel, true_count, false_count);
@@ -536,24 +550,25 @@ private:
 		return true_sel ? true_count : count - false_count;
 	}
 
-	template <bool RIGHT_CONSTANT, bool SPECIALIZE_OUTPUTS, class CONSTANT_TYPE, class GENERIC_TYPE, class ADAPTER>
+	template <bool RIGHT_CONSTANT, bool CAN_HAVE_NULL, bool SPECIALIZE_OUTPUTS, class CONSTANT_TYPE, class GENERIC_TYPE,
+	          class ADAPTER>
 	static idx_t SelectGenericConstantSwitch(CONSTANT_TYPE constant, const GENERIC_TYPE *__restrict data,
-	                                         const SelectionVector &generic_sel, const SelectionVector &sel,
-	                                         idx_t count, SelectionVector *true_sel, SelectionVector *false_sel,
-	                                         ADAPTER &adapter) {
+	                                         const SelectionVector &generic_sel, const ValidityMask &validity,
+	                                         const SelectionVector &sel, idx_t count, SelectionVector *true_sel,
+	                                         SelectionVector *false_sel, ADAPTER &adapter) {
 		if constexpr (SPECIALIZE_OUTPUTS) {
 			if (true_sel && false_sel) {
-				return SelectGenericConstantLoop<RIGHT_CONSTANT, true, true, true>(constant, data, generic_sel, sel,
-				                                                                   count, true_sel, false_sel, adapter);
+				return SelectGenericConstantLoop<RIGHT_CONSTANT, CAN_HAVE_NULL, true, true, true>(
+				    constant, data, generic_sel, validity, sel, count, true_sel, false_sel, adapter);
 			} else if (true_sel) {
-				return SelectGenericConstantLoop<RIGHT_CONSTANT, true, true, false>(
-				    constant, data, generic_sel, sel, count, true_sel, false_sel, adapter);
+				return SelectGenericConstantLoop<RIGHT_CONSTANT, CAN_HAVE_NULL, true, true, false>(
+				    constant, data, generic_sel, validity, sel, count, true_sel, false_sel, adapter);
 			}
-			return SelectGenericConstantLoop<RIGHT_CONSTANT, true, false, true>(constant, data, generic_sel, sel, count,
-			                                                                    true_sel, false_sel, adapter);
+			return SelectGenericConstantLoop<RIGHT_CONSTANT, CAN_HAVE_NULL, true, false, true>(
+			    constant, data, generic_sel, validity, sel, count, true_sel, false_sel, adapter);
 		}
-		return SelectGenericConstantLoop<RIGHT_CONSTANT, false, false, false>(constant, data, generic_sel, sel, count,
-		                                                                      true_sel, false_sel, adapter);
+		return SelectGenericConstantLoop<RIGHT_CONSTANT, CAN_HAVE_NULL, false, false, false>(
+		    constant, data, generic_sel, validity, sel, count, true_sel, false_sel, adapter);
 	}
 
 	template <uint64_t CONSTANT_MASK, bool SPECIALIZE_OUTPUTS, class ADAPTER, class LEFT_TYPE, class RIGHT_TYPE>
@@ -561,27 +576,28 @@ private:
 	                                   SelectionVector *true_sel, SelectionVector *false_sel, ADAPTER &adapter) {
 		static_assert(CONSTANT_MASK == 1 || CONSTANT_MASK == 2, "Exactly one binary input must be constant");
 		constexpr idx_t GENERIC_INDEX = CONSTANT_MASK == 1 ? 1 : 0;
-		constexpr idx_t CONSTANT_INDEX = CONSTANT_MASK == 1 ? 0 : 1;
-		std::array<UnifiedVectorFormat, 2> formats;
-		auto &generic_format = formats[GENERIC_INDEX];
+		UnifiedVectorFormat generic_format;
 		inputs[GENERIC_INDEX].get().ToUnifiedFormat(generic_format);
-		if (generic_format.validity.CanHaveNull()) {
-			inputs[CONSTANT_INDEX].get().ToUnifiedFormat(formats[CONSTANT_INDEX]);
-			auto input_data = std::make_tuple(UnifiedVectorFormat::GetData<LEFT_TYPE>(formats[0]),
-			                                  UnifiedVectorFormat::GetData<RIGHT_TYPE>(formats[1]));
-			return SelectGenericSwitch<false, SPECIALIZE_OUTPUTS>(input_data, formats, sel, count, true_sel, false_sel,
-			                                                      adapter, std::index_sequence<0, 1> {});
-		}
+		auto can_have_null = generic_format.validity.CanHaveNull();
 		if constexpr (CONSTANT_MASK == 1) {
 			auto constant = *ConstantVector::GetData<LEFT_TYPE>(inputs[0].get());
 			auto data = UnifiedVectorFormat::GetData<RIGHT_TYPE>(generic_format);
-			return SelectGenericConstantSwitch<false, SPECIALIZE_OUTPUTS>(constant, data, *generic_format.sel, sel,
-			                                                              count, true_sel, false_sel, adapter);
+			if (can_have_null) {
+				return SelectGenericConstantSwitch<false, true, SPECIALIZE_OUTPUTS>(constant, data, *generic_format.sel,
+				                                                                    generic_format.validity, sel, count,
+				                                                                    true_sel, false_sel, adapter);
+			}
+			return SelectGenericConstantSwitch<false, false, SPECIALIZE_OUTPUTS>(
+			    constant, data, *generic_format.sel, generic_format.validity, sel, count, true_sel, false_sel, adapter);
 		}
 		auto constant = *ConstantVector::GetData<RIGHT_TYPE>(inputs[1].get());
 		auto data = UnifiedVectorFormat::GetData<LEFT_TYPE>(generic_format);
-		return SelectGenericConstantSwitch<true, SPECIALIZE_OUTPUTS>(constant, data, *generic_format.sel, sel, count,
-		                                                             true_sel, false_sel, adapter);
+		if (can_have_null) {
+			return SelectGenericConstantSwitch<true, true, SPECIALIZE_OUTPUTS>(
+			    constant, data, *generic_format.sel, generic_format.validity, sel, count, true_sel, false_sel, adapter);
+		}
+		return SelectGenericConstantSwitch<true, false, SPECIALIZE_OUTPUTS>(
+		    constant, data, *generic_format.sel, generic_format.validity, sel, count, true_sel, false_sel, adapter);
 	}
 
 	template <bool NO_NULL, bool SPECIALIZE_OUTPUTS, bool HAS_TRUE_SEL, bool HAS_FALSE_SEL, class ADAPTER,
@@ -728,12 +744,12 @@ private:
 	}
 
 public:
-	template <bool SPECIALIZE_FLAT, bool SPECIALIZE_GENERIC_SELECTIONS, bool PRESERVE_RESULT_VALIDITY,
+	template <bool SPECIALIZE_FLAT, bool SPECIALIZE_NULLABLE_GENERIC_SELECTIONS, bool PRESERVE_RESULT_VALIDITY,
 	          class RESULT_TYPE, class ADAPTER, class... ARGS>
 	static void Execute(const std::array<VectorRef, sizeof...(ARGS)> &inputs, Vector &result, idx_t count,
 	                    ADAPTER &adapter) {
-		ExecuteInternal<SPECIALIZE_FLAT, SPECIALIZE_GENERIC_SELECTIONS, PRESERVE_RESULT_VALIDITY, RESULT_TYPE, ADAPTER,
-		                ARGS...>(inputs, result, count, adapter, std::index_sequence_for<ARGS...> {});
+		ExecuteInternal<SPECIALIZE_FLAT, SPECIALIZE_NULLABLE_GENERIC_SELECTIONS, PRESERVE_RESULT_VALIDITY, RESULT_TYPE,
+		                ADAPTER, ARGS...>(inputs, result, count, adapter, std::index_sequence_for<ARGS...> {});
 	}
 
 	template <uint64_t SPECIALIZED_MASKS, bool SPECIALIZE_OUTPUTS, class ADAPTER, class... ARGS>

--- a/src/include/duckdb/common/vector_operations/scalar_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/scalar_executor.hpp
@@ -1,0 +1,672 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/vector_operations/scalar_executor.hpp
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/types/vector.hpp"
+#include "duckdb/common/vector/constant_vector.hpp"
+#include "duckdb/common/vector/flat_vector.hpp"
+
+#include <array>
+#include <functional>
+#include <tuple>
+#include <type_traits>
+
+namespace duckdb {
+
+//! Internal execution engine shared by the named scalar executor facades.
+struct ScalarExecutor {
+	using VectorRef = std::reference_wrapper<const Vector>;
+
+private:
+	struct InputProfile {
+		uint64_t constant_mask = 0;
+		bool all_constant = true;
+		bool all_flat_or_constant = true;
+		bool any_constant_null = false;
+	};
+
+	template <size_t N, size_t... Is>
+	static inline InputProfile GetInputProfile(const std::array<VectorRef, N> &inputs, std::index_sequence<Is...>) {
+		InputProfile result;
+		auto classify = [&](auto input_index) {
+			constexpr idx_t INPUT_INDEX = decltype(input_index)::value;
+			auto vector_type = inputs[INPUT_INDEX].get().GetVectorType();
+			if (vector_type == VectorType::CONSTANT_VECTOR) {
+				if constexpr (INPUT_INDEX < 64) {
+					result.constant_mask |= uint64_t(1) << INPUT_INDEX;
+				}
+				result.any_constant_null |= ConstantVector::IsNull(inputs[INPUT_INDEX].get());
+			} else {
+				result.all_constant = false;
+				result.all_flat_or_constant &= vector_type == VectorType::FLAT_VECTOR;
+			}
+		};
+		(classify(std::integral_constant<idx_t, Is> {}), ...);
+		return result;
+	}
+
+	template <idx_t INPUT_INDEX, uint64_t CONSTANT_MASK>
+	static inline idx_t InputIndex(idx_t row) {
+		if constexpr (CONSTANT_MASK & (uint64_t(1) << INPUT_INDEX)) {
+			return 0;
+		} else {
+			return row;
+		}
+	}
+
+	template <bool ADDS_NULLS, bool PRESERVE_RESULT_VALIDITY, uint64_t CONSTANT_MASK, size_t N, size_t... Is>
+	static inline ValidityMask &PrepareFlatResultValidity(const std::array<VectorRef, N> &inputs, Vector &result,
+	                                                      idx_t count, std::index_sequence<Is...>) {
+		auto &result_validity = FlatVector::ValidityMutable(result);
+		bool initialized = false;
+		auto combine = [&](auto input_index) {
+			constexpr idx_t INPUT_INDEX = decltype(input_index)::value;
+			if constexpr (!(CONSTANT_MASK & (uint64_t(1) << INPUT_INDEX))) {
+				auto &input_validity = FlatVector::Validity(inputs[INPUT_INDEX].get());
+				if (input_validity.CanHaveNull()) {
+					if (!initialized) {
+						if constexpr (ADDS_NULLS) {
+							result_validity.Copy(input_validity, count);
+						} else {
+							result_validity.Initialize(input_validity);
+						}
+						initialized = true;
+					} else {
+						result_validity.Combine(input_validity, count);
+					}
+				}
+			}
+		};
+		(combine(std::integral_constant<idx_t, Is> {}), ...);
+		if (!initialized) {
+			if constexpr (PRESERVE_RESULT_VALIDITY) {
+				if constexpr (ADDS_NULLS) {
+					ValidityMask preserved(result_validity, count);
+					result_validity.Initialize(preserved);
+				}
+			} else {
+				result_validity.Reset(count);
+			}
+		}
+		return result_validity;
+	}
+
+	template <uint64_t CONSTANT_MASK, size_t N, size_t... Is>
+	static inline ValidityMask PrepareFlatInputValidity(const std::array<VectorRef, N> &inputs, idx_t count,
+	                                                    std::index_sequence<Is...>) {
+		ValidityMask result(count);
+		bool initialized = false;
+		auto combine = [&](auto input_index) {
+			constexpr idx_t INPUT_INDEX = decltype(input_index)::value;
+			if constexpr (!(CONSTANT_MASK & (uint64_t(1) << INPUT_INDEX))) {
+				auto &input_validity = FlatVector::Validity(inputs[INPUT_INDEX].get());
+				if (!initialized) {
+					result.Initialize(input_validity);
+					initialized = true;
+				} else {
+					result.Combine(input_validity, count);
+				}
+			}
+		};
+		(combine(std::integral_constant<idx_t, Is> {}), ...);
+		return result;
+	}
+
+	DUCKDB_API static bool PrepareGenericResultValidity(const UnifiedVectorFormat *formats, idx_t format_count,
+	                                                    Vector &result, idx_t count, bool preserve_result_validity,
+	                                                    bool adds_nulls, ValidityMask &input_validity);
+
+	template <bool PRESERVE_RESULT_VALIDITY, uint64_t CONSTANT_MASK, class RESULT_TYPE, class ADAPTER, class... ARGS,
+	          size_t... Is>
+	static void ExecuteFlat(const std::array<VectorRef, sizeof...(ARGS)> &inputs, Vector &result, idx_t count,
+	                        ADAPTER &adapter, std::index_sequence<Is...> indices) {
+		result.SetVectorType(VectorType::FLAT_VECTOR);
+		if (result.size() != count) {
+			FlatVector::SetSize(result, count);
+		}
+		auto result_data = FlatVector::GetDataMutable<RESULT_TYPE>(result);
+		auto input_data = std::make_tuple(FlatVector::GetData<ARGS>(inputs[Is].get())...);
+		auto &result_validity = PrepareFlatResultValidity<ADAPTER::ADDS_NULLS, PRESERVE_RESULT_VALIDITY, CONSTANT_MASK>(
+		    inputs, result, count, indices);
+
+#ifdef DEBUG
+		auto assert_restrict = [&](auto input_index) {
+			constexpr idx_t INPUT_INDEX = decltype(input_index)::value;
+			if constexpr (!(CONSTANT_MASK & (uint64_t(1) << INPUT_INDEX))) {
+				auto data = std::get<INPUT_INDEX>(input_data);
+				ASSERT_RESTRICT(data, data + count, result_data, result_data + count);
+			}
+		};
+		(assert_restrict(std::integral_constant<idx_t, Is> {}), ...);
+#endif
+
+		if (result_validity.CanHaveNull()) {
+			idx_t base_idx = 0;
+			auto entry_count = ValidityMask::EntryCount(count);
+			for (idx_t entry_idx = 0; entry_idx < entry_count; entry_idx++) {
+				auto validity_entry = result_validity.GetValidityEntry(entry_idx);
+				auto next = MinValue<idx_t>(base_idx + ValidityMask::BITS_PER_VALUE, count);
+				if (ValidityMask::AllValid(validity_entry)) {
+					for (; base_idx < next; base_idx++) {
+						result_data[base_idx] =
+						    adapter.Operation(result_validity, base_idx,
+						                      std::get<Is>(input_data)[InputIndex<Is, CONSTANT_MASK>(base_idx)]...);
+					}
+				} else if (ValidityMask::NoneValid(validity_entry)) {
+					base_idx = next;
+				} else {
+					auto start = base_idx;
+					for (; base_idx < next; base_idx++) {
+						if (ValidityMask::RowIsValid(validity_entry, base_idx - start)) {
+							result_data[base_idx] =
+							    adapter.Operation(result_validity, base_idx,
+							                      std::get<Is>(input_data)[InputIndex<Is, CONSTANT_MASK>(base_idx)]...);
+						}
+					}
+				}
+			}
+		} else {
+			for (idx_t row = 0; row < count; row++) {
+				result_data[row] = adapter.Operation(result_validity, row,
+				                                     std::get<Is>(input_data)[InputIndex<Is, CONSTANT_MASK>(row)]...);
+			}
+		}
+	}
+
+	template <class RESULT_TYPE, class ADAPTER, class... ARGS, size_t... Is>
+	static void ExecuteConstant(const std::array<VectorRef, sizeof...(ARGS)> &inputs, Vector &result, idx_t count,
+	                            bool input_is_null, ADAPTER &adapter, std::index_sequence<Is...>) {
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+		if (result.size() != count) {
+			FlatVector::SetSize(result, count);
+		}
+		if (input_is_null) {
+			ConstantVector::SetNull(result, true);
+			return;
+		}
+		auto &result_validity = ConstantVector::Validity(result);
+		result_validity.SetValid(0);
+		auto result_data = ConstantVector::GetData<RESULT_TYPE>(result);
+		result_data[0] = adapter.Operation(result_validity, 0, *ConstantVector::GetData<ARGS>(inputs[Is].get())...);
+	}
+
+	template <idx_t INPUT_INDEX, uint64_t SELECTION_MASK>
+	static inline idx_t GenericInputIndex(const std::array<const sel_t *, 2> &selections, idx_t row) {
+		if constexpr (SELECTION_MASK & (uint64_t(1) << INPUT_INDEX)) {
+			return selections[INPUT_INDEX][row];
+		}
+		return row;
+	}
+
+	template <uint64_t SELECTION_MASK, class RESULT_TYPE, class ADAPTER, class... ARGS, size_t... Is>
+	static void ExecuteGenericNoNullLoop(const std::tuple<const ARGS *...> &input_data,
+	                                     const std::array<const sel_t *, 2> &selections, RESULT_TYPE *result_data,
+	                                     idx_t count, ValidityMask &result_validity, ADAPTER &adapter,
+	                                     std::index_sequence<Is...>) {
+		auto result_ptr = result_data;
+		auto result_end = result_data + count;
+		idx_t result_idx = 0;
+		while (result_ptr != result_end) {
+			*result_ptr = adapter.Operation(
+			    result_validity, result_idx,
+			    std::get<Is>(input_data)[GenericInputIndex<Is, SELECTION_MASK>(selections, result_idx)]...);
+			result_ptr++;
+			result_idx++;
+		}
+	}
+
+	template <class RESULT_TYPE, class ADAPTER, class... ARGS, size_t... Is>
+	static void ExecuteGenericNoNullSwitch(const std::tuple<const ARGS *...> &input_data,
+	                                       const std::array<UnifiedVectorFormat, 2> &formats, RESULT_TYPE *result_data,
+	                                       idx_t count, ValidityMask &result_validity, ADAPTER &adapter,
+	                                       std::index_sequence<Is...> indices) {
+		std::array<const sel_t *, 2> selections = {{formats[0].sel->data(), formats[1].sel->data()}};
+		uint64_t selection_mask = 0;
+		selection_mask |= selections[0] ? 1 : 0;
+		selection_mask |= selections[1] ? 2 : 0;
+		switch (selection_mask) {
+		case 0:
+			ExecuteGenericNoNullLoop<0>(input_data, selections, result_data, count, result_validity, adapter, indices);
+			return;
+		case 1:
+			ExecuteGenericNoNullLoop<1>(input_data, selections, result_data, count, result_validity, adapter, indices);
+			return;
+		case 2:
+			ExecuteGenericNoNullLoop<2>(input_data, selections, result_data, count, result_validity, adapter, indices);
+			return;
+		case 3:
+			ExecuteGenericNoNullLoop<3>(input_data, selections, result_data, count, result_validity, adapter, indices);
+			return;
+		default:
+			throw InternalException("Invalid generic scalar executor selection profile");
+		}
+	}
+
+	template <bool SPECIALIZE_GENERIC_SELECTIONS, bool PRESERVE_RESULT_VALIDITY, class RESULT_TYPE, class ADAPTER,
+	          class... ARGS, size_t... Is>
+	static void ExecuteGeneric(const std::array<VectorRef, sizeof...(ARGS)> &inputs, Vector &result, idx_t count,
+	                           ADAPTER &adapter, std::index_sequence<Is...>) {
+		constexpr idx_t N = sizeof...(ARGS);
+		std::array<UnifiedVectorFormat, N> formats;
+		for (idx_t i = 0; i < N; i++) {
+			inputs[i].get().ToUnifiedFormat(formats[i]);
+		}
+		auto input_data = std::make_tuple(UnifiedVectorFormat::GetData<ARGS>(formats[Is])...);
+		result.SetVectorType(VectorType::FLAT_VECTOR);
+		if (result.size() != count) {
+			FlatVector::SetSize(result, count);
+		}
+		auto result_data = FlatVector::GetDataMutable<RESULT_TYPE>(result);
+		auto &result_validity = FlatVector::ValidityMutable(result);
+		ValidityMask input_validity(count);
+		auto inputs_can_have_null = PrepareGenericResultValidity(
+		    formats.data(), N, result, count, PRESERVE_RESULT_VALIDITY, ADAPTER::ADDS_NULLS, input_validity);
+
+		if (inputs_can_have_null) {
+			for (idx_t row = 0; row < count; row++) {
+				std::array<idx_t, N> input_indices = {{formats[Is].sel->get_index(row)...}};
+				if (input_validity.RowIsValid(row)) {
+					result_data[row] =
+					    adapter.Operation(result_validity, row, std::get<Is>(input_data)[input_indices[Is]]...);
+				} else {
+					result_validity.SetInvalid(row);
+				}
+			}
+		} else if constexpr (SPECIALIZE_GENERIC_SELECTIONS && N == 2) {
+			ExecuteGenericNoNullSwitch(input_data, formats, result_data, count, result_validity, adapter,
+			                           std::index_sequence_for<ARGS...> {});
+		} else {
+			for (idx_t row = 0; row < count; row++) {
+				result_data[row] = adapter.Operation(result_validity, row,
+				                                     std::get<Is>(input_data)[formats[Is].sel->get_index(row)]...);
+			}
+		}
+	}
+
+	template <bool SPECIALIZE_FLAT, bool SPECIALIZE_GENERIC_SELECTIONS, bool PRESERVE_RESULT_VALIDITY,
+	          class RESULT_TYPE, class ADAPTER, class... ARGS, size_t... Is>
+	static void ExecuteInternal(const std::array<VectorRef, sizeof...(ARGS)> &inputs, Vector &result, idx_t count,
+	                            ADAPTER &adapter, std::index_sequence<Is...> indices) {
+		constexpr idx_t N = sizeof...(ARGS);
+		static_assert(N > 0, "ScalarExecutor requires at least one input");
+		auto profile = GetInputProfile(inputs, indices);
+		if (profile.all_constant) {
+			ExecuteConstant<RESULT_TYPE, ADAPTER, ARGS...>(inputs, result, count, profile.any_constant_null, adapter,
+			                                               indices);
+			return;
+		}
+		if constexpr (SPECIALIZE_FLAT && N <= 3) {
+			if (profile.all_flat_or_constant) {
+				if (profile.any_constant_null) {
+					result.SetVectorType(VectorType::CONSTANT_VECTOR);
+					if (result.size() != count) {
+						FlatVector::SetSize(result, count);
+					}
+					ConstantVector::SetNull(result, true);
+					return;
+				}
+				switch (profile.constant_mask) {
+				case 0:
+					ExecuteFlat<PRESERVE_RESULT_VALIDITY, 0, RESULT_TYPE, ADAPTER, ARGS...>(inputs, result, count,
+					                                                                        adapter, indices);
+					return;
+				case 1:
+					if constexpr (N >= 2) {
+						ExecuteFlat<PRESERVE_RESULT_VALIDITY, 1, RESULT_TYPE, ADAPTER, ARGS...>(inputs, result, count,
+						                                                                        adapter, indices);
+						return;
+					}
+					break;
+				case 2:
+					if constexpr (N >= 2) {
+						ExecuteFlat<PRESERVE_RESULT_VALIDITY, 2, RESULT_TYPE, ADAPTER, ARGS...>(inputs, result, count,
+						                                                                        adapter, indices);
+						return;
+					}
+					break;
+				case 3:
+					if constexpr (N >= 3) {
+						ExecuteFlat<PRESERVE_RESULT_VALIDITY, 3, RESULT_TYPE, ADAPTER, ARGS...>(inputs, result, count,
+						                                                                        adapter, indices);
+						return;
+					}
+					break;
+				case 4:
+					if constexpr (N >= 3) {
+						ExecuteFlat<PRESERVE_RESULT_VALIDITY, 4, RESULT_TYPE, ADAPTER, ARGS...>(inputs, result, count,
+						                                                                        adapter, indices);
+						return;
+					}
+					break;
+				case 5:
+					if constexpr (N >= 3) {
+						ExecuteFlat<PRESERVE_RESULT_VALIDITY, 5, RESULT_TYPE, ADAPTER, ARGS...>(inputs, result, count,
+						                                                                        adapter, indices);
+						return;
+					}
+					break;
+				case 6:
+					if constexpr (N >= 3) {
+						ExecuteFlat<PRESERVE_RESULT_VALIDITY, 6, RESULT_TYPE, ADAPTER, ARGS...>(inputs, result, count,
+						                                                                        adapter, indices);
+						return;
+					}
+					break;
+				default:
+					throw InternalException("Invalid flat/constant scalar executor profile");
+				}
+			}
+		}
+		ExecuteGeneric<SPECIALIZE_GENERIC_SELECTIONS, PRESERVE_RESULT_VALIDITY, RESULT_TYPE, ADAPTER, ARGS...>(
+		    inputs, result, count, adapter, indices);
+	}
+
+	template <bool SPECIALIZE_OUTPUTS, bool HAS_TRUE_SEL, bool HAS_FALSE_SEL>
+	static inline void StoreSelection(bool comparison_result, idx_t result_idx, SelectionVector *true_sel,
+	                                  SelectionVector *false_sel, idx_t &true_count, idx_t &false_count) {
+		if constexpr (SPECIALIZE_OUTPUTS) {
+			if constexpr (HAS_TRUE_SEL) {
+				true_sel->set_index(true_count, result_idx);
+				true_count += comparison_result;
+			}
+			if constexpr (HAS_FALSE_SEL) {
+				false_sel->set_index(false_count, result_idx);
+				false_count += !comparison_result;
+			}
+		} else {
+			if (true_sel) {
+				true_sel->set_index(true_count, result_idx);
+				true_count += comparison_result;
+			}
+			if (false_sel) {
+				false_sel->set_index(false_count, result_idx);
+				false_count += !comparison_result;
+			}
+		}
+	}
+
+	static idx_t FillConstantSelection(bool comparison_result, const SelectionVector &sel, idx_t count,
+	                                   SelectionVector *true_sel, SelectionVector *false_sel) {
+		if (comparison_result) {
+			if (true_sel) {
+				for (idx_t i = 0; i < count; i++) {
+					true_sel->set_index(i, sel.get_index(i));
+				}
+			}
+			return count;
+		}
+		if (false_sel) {
+			for (idx_t i = 0; i < count; i++) {
+				false_sel->set_index(i, sel.get_index(i));
+			}
+		}
+		return 0;
+	}
+
+	template <class ADAPTER, class... ARGS, size_t... Is>
+	static idx_t SelectConstant(const std::array<VectorRef, sizeof...(ARGS)> &inputs, const SelectionVector &sel,
+	                            idx_t count, SelectionVector *true_sel, SelectionVector *false_sel, ADAPTER &adapter,
+	                            std::index_sequence<Is...>) {
+		bool comparison_result = adapter.Operation(*ConstantVector::GetData<ARGS>(inputs[Is].get())...);
+		return FillConstantSelection(comparison_result, sel, count, true_sel, false_sel);
+	}
+
+	template <uint64_t CONSTANT_MASK, bool SPECIALIZE_OUTPUTS, bool HAS_TRUE_SEL, bool HAS_FALSE_SEL, class ADAPTER,
+	          class... ARGS, size_t... Is>
+	static idx_t SelectFlatLoop(const std::tuple<const ARGS *...> &input_data, const ValidityMask &input_validity,
+	                            const SelectionVector &sel, idx_t count, SelectionVector *true_sel,
+	                            SelectionVector *false_sel, ADAPTER &adapter, std::index_sequence<Is...>) {
+		idx_t true_count = 0;
+		idx_t false_count = 0;
+		idx_t base_idx = 0;
+		auto entry_count = ValidityMask::EntryCount(count);
+		for (idx_t entry_idx = 0; entry_idx < entry_count; entry_idx++) {
+			auto validity_entry = input_validity.GetValidityEntry(entry_idx);
+			auto next = MinValue<idx_t>(base_idx + ValidityMask::BITS_PER_VALUE, count);
+			if (ValidityMask::AllValid(validity_entry)) {
+				for (; base_idx < next; base_idx++) {
+					auto result_idx = sel.get_index(base_idx);
+					bool comparison_result =
+					    adapter.Operation(std::get<Is>(input_data)[InputIndex<Is, CONSTANT_MASK>(base_idx)]...);
+					StoreSelection<SPECIALIZE_OUTPUTS, HAS_TRUE_SEL, HAS_FALSE_SEL>(
+					    comparison_result, result_idx, true_sel, false_sel, true_count, false_count);
+				}
+			} else if (ValidityMask::NoneValid(validity_entry)) {
+				if constexpr (SPECIALIZE_OUTPUTS) {
+					if constexpr (HAS_FALSE_SEL) {
+						for (; base_idx < next; base_idx++) {
+							false_sel->set_index(false_count++, sel.get_index(base_idx));
+						}
+					} else {
+						base_idx = next;
+					}
+				} else {
+					if (false_sel) {
+						for (; base_idx < next; base_idx++) {
+							false_sel->set_index(false_count++, sel.get_index(base_idx));
+						}
+					} else {
+						base_idx = next;
+					}
+				}
+			} else {
+				auto start = base_idx;
+				for (; base_idx < next; base_idx++) {
+					auto result_idx = sel.get_index(base_idx);
+					bool comparison_result =
+					    ValidityMask::RowIsValid(validity_entry, base_idx - start) &&
+					    adapter.Operation(std::get<Is>(input_data)[InputIndex<Is, CONSTANT_MASK>(base_idx)]...);
+					StoreSelection<SPECIALIZE_OUTPUTS, HAS_TRUE_SEL, HAS_FALSE_SEL>(
+					    comparison_result, result_idx, true_sel, false_sel, true_count, false_count);
+				}
+			}
+		}
+		if constexpr (SPECIALIZE_OUTPUTS && HAS_TRUE_SEL) {
+			return true_count;
+		}
+		return true_sel ? true_count : count - false_count;
+	}
+
+	template <uint64_t CONSTANT_MASK, bool SPECIALIZE_OUTPUTS, bool HAS_TRUE_SEL, bool HAS_FALSE_SEL, class ADAPTER,
+	          class... ARGS, size_t... Is>
+	static idx_t SelectFlat(const std::array<VectorRef, sizeof...(ARGS)> &inputs, const SelectionVector &sel,
+	                        idx_t count, SelectionVector *true_sel, SelectionVector *false_sel, ADAPTER &adapter,
+	                        std::index_sequence<Is...> indices) {
+		auto input_data = std::make_tuple(FlatVector::GetData<ARGS>(inputs[Is].get())...);
+		auto input_validity = PrepareFlatInputValidity<CONSTANT_MASK>(inputs, count, indices);
+		return SelectFlatLoop<CONSTANT_MASK, SPECIALIZE_OUTPUTS, HAS_TRUE_SEL, HAS_FALSE_SEL>(
+		    input_data, input_validity, sel, count, true_sel, false_sel, adapter, indices);
+	}
+
+	template <uint64_t CONSTANT_MASK, bool SPECIALIZE_OUTPUTS, class ADAPTER, class... ARGS, size_t... Is>
+	static idx_t SelectFlatSwitch(const std::array<VectorRef, sizeof...(ARGS)> &inputs, const SelectionVector &sel,
+	                              idx_t count, SelectionVector *true_sel, SelectionVector *false_sel, ADAPTER &adapter,
+	                              std::index_sequence<Is...> indices) {
+		if constexpr (SPECIALIZE_OUTPUTS) {
+			if (true_sel && false_sel) {
+				return SelectFlat<CONSTANT_MASK, true, true, true, ADAPTER, ARGS...>(inputs, sel, count, true_sel,
+				                                                                     false_sel, adapter, indices);
+			} else if (true_sel) {
+				return SelectFlat<CONSTANT_MASK, true, true, false, ADAPTER, ARGS...>(inputs, sel, count, true_sel,
+				                                                                      false_sel, adapter, indices);
+			}
+			return SelectFlat<CONSTANT_MASK, true, false, true, ADAPTER, ARGS...>(inputs, sel, count, true_sel,
+			                                                                      false_sel, adapter, indices);
+		}
+		return SelectFlat<CONSTANT_MASK, false, false, false, ADAPTER, ARGS...>(inputs, sel, count, true_sel, false_sel,
+		                                                                        adapter, indices);
+	}
+
+	template <bool NO_NULL, bool SPECIALIZE_OUTPUTS, bool HAS_TRUE_SEL, bool HAS_FALSE_SEL, class ADAPTER,
+	          class... ARGS, size_t... Is>
+	static idx_t SelectGenericLoop(std::tuple<const ARGS *...> &input_data,
+	                               std::array<UnifiedVectorFormat, sizeof...(ARGS)> &formats,
+	                               const SelectionVector &sel, idx_t count, SelectionVector *true_sel,
+	                               SelectionVector *false_sel, ADAPTER &adapter, std::index_sequence<Is...>) {
+		constexpr idx_t N = sizeof...(ARGS);
+		idx_t true_count = 0;
+		idx_t false_count = 0;
+		for (idx_t row = 0; row < count; row++) {
+			auto result_idx = sel.get_index(row);
+			std::array<idx_t, N> input_indices = {{formats[Is].sel->get_index(row)...}};
+			bool comparison_result = (NO_NULL || (... && formats[Is].validity.RowIsValid(input_indices[Is]))) &&
+			                         adapter.Operation(std::get<Is>(input_data)[input_indices[Is]]...);
+			StoreSelection<SPECIALIZE_OUTPUTS, HAS_TRUE_SEL, HAS_FALSE_SEL>(comparison_result, result_idx, true_sel,
+			                                                                false_sel, true_count, false_count);
+		}
+		if constexpr (SPECIALIZE_OUTPUTS && HAS_TRUE_SEL) {
+			return true_count;
+		}
+		return true_sel ? true_count : count - false_count;
+	}
+
+	template <bool NO_NULL, bool SPECIALIZE_OUTPUTS, class ADAPTER, class... ARGS, size_t... Is>
+	static idx_t SelectGenericSwitch(std::tuple<const ARGS *...> &input_data,
+	                                 std::array<UnifiedVectorFormat, sizeof...(ARGS)> &formats,
+	                                 const SelectionVector &sel, idx_t count, SelectionVector *true_sel,
+	                                 SelectionVector *false_sel, ADAPTER &adapter, std::index_sequence<Is...> indices) {
+		if constexpr (SPECIALIZE_OUTPUTS) {
+			if (true_sel && false_sel) {
+				return SelectGenericLoop<NO_NULL, true, true, true>(input_data, formats, sel, count, true_sel,
+				                                                    false_sel, adapter, indices);
+			} else if (true_sel) {
+				return SelectGenericLoop<NO_NULL, true, true, false>(input_data, formats, sel, count, true_sel,
+				                                                     false_sel, adapter, indices);
+			}
+			return SelectGenericLoop<NO_NULL, true, false, true>(input_data, formats, sel, count, true_sel, false_sel,
+			                                                     adapter, indices);
+		}
+		return SelectGenericLoop<NO_NULL, false, false, false>(input_data, formats, sel, count, true_sel, false_sel,
+		                                                       adapter, indices);
+	}
+
+	template <bool SPECIALIZE_OUTPUTS, class ADAPTER, class... ARGS, size_t... Is>
+	static idx_t SelectGeneric(const std::array<VectorRef, sizeof...(ARGS)> &inputs, const SelectionVector &sel,
+	                           idx_t count, SelectionVector *true_sel, SelectionVector *false_sel, ADAPTER &adapter,
+	                           std::index_sequence<Is...> indices) {
+		std::array<UnifiedVectorFormat, sizeof...(ARGS)> formats;
+		for (idx_t i = 0; i < sizeof...(ARGS); i++) {
+			inputs[i].get().ToUnifiedFormat(formats[i]);
+		}
+		auto input_data = std::make_tuple(UnifiedVectorFormat::GetData<ARGS>(formats[Is])...);
+		if ((... || formats[Is].validity.CanHaveNull())) {
+			return SelectGenericSwitch<false, SPECIALIZE_OUTPUTS>(input_data, formats, sel, count, true_sel, false_sel,
+			                                                      adapter, indices);
+		}
+		return SelectGenericSwitch<true, SPECIALIZE_OUTPUTS>(input_data, formats, sel, count, true_sel, false_sel,
+		                                                     adapter, indices);
+	}
+
+	template <uint64_t SPECIALIZED_MASKS, bool SPECIALIZE_OUTPUTS, class ADAPTER, class... ARGS, size_t... Is>
+	static idx_t SelectInternal(const std::array<VectorRef, sizeof...(ARGS)> &inputs, const SelectionVector &sel,
+	                            idx_t count, SelectionVector *true_sel, SelectionVector *false_sel, ADAPTER &adapter,
+	                            std::index_sequence<Is...> indices) {
+		constexpr idx_t N = sizeof...(ARGS);
+		auto profile = GetInputProfile(inputs, indices);
+		if (profile.all_constant) {
+			if (profile.any_constant_null) {
+				return FillConstantSelection(false, sel, count, true_sel, false_sel);
+			}
+			return SelectConstant<ADAPTER, ARGS...>(inputs, sel, count, true_sel, false_sel, adapter, indices);
+		}
+		if constexpr (SPECIALIZED_MASKS != 0 && N <= 3) {
+			if (profile.all_flat_or_constant) {
+				if (profile.any_constant_null) {
+					return FillConstantSelection(false, sel, count, true_sel, false_sel);
+				}
+				switch (profile.constant_mask) {
+				case 0:
+					if constexpr (SPECIALIZED_MASKS & (uint64_t(1) << 0)) {
+						return SelectFlatSwitch<0, SPECIALIZE_OUTPUTS, ADAPTER, ARGS...>(inputs, sel, count, true_sel,
+						                                                                 false_sel, adapter, indices);
+					}
+					break;
+				case 1:
+					if constexpr (N >= 2 && (SPECIALIZED_MASKS & (uint64_t(1) << 1))) {
+						return SelectFlatSwitch<1, SPECIALIZE_OUTPUTS, ADAPTER, ARGS...>(inputs, sel, count, true_sel,
+						                                                                 false_sel, adapter, indices);
+					}
+					break;
+				case 2:
+					if constexpr (N >= 2 && (SPECIALIZED_MASKS & (uint64_t(1) << 2))) {
+						return SelectFlatSwitch<2, SPECIALIZE_OUTPUTS, ADAPTER, ARGS...>(inputs, sel, count, true_sel,
+						                                                                 false_sel, adapter, indices);
+					}
+					break;
+				case 3:
+					if constexpr (N >= 3 && (SPECIALIZED_MASKS & (uint64_t(1) << 3))) {
+						return SelectFlatSwitch<3, SPECIALIZE_OUTPUTS, ADAPTER, ARGS...>(inputs, sel, count, true_sel,
+						                                                                 false_sel, adapter, indices);
+					}
+					break;
+				case 4:
+					if constexpr (N >= 3 && (SPECIALIZED_MASKS & (uint64_t(1) << 4))) {
+						return SelectFlatSwitch<4, SPECIALIZE_OUTPUTS, ADAPTER, ARGS...>(inputs, sel, count, true_sel,
+						                                                                 false_sel, adapter, indices);
+					}
+					break;
+				case 5:
+					if constexpr (N >= 3 && (SPECIALIZED_MASKS & (uint64_t(1) << 5))) {
+						return SelectFlatSwitch<5, SPECIALIZE_OUTPUTS, ADAPTER, ARGS...>(inputs, sel, count, true_sel,
+						                                                                 false_sel, adapter, indices);
+					}
+					break;
+				case 6:
+					if constexpr (N >= 3 && (SPECIALIZED_MASKS & (uint64_t(1) << 6))) {
+						return SelectFlatSwitch<6, SPECIALIZE_OUTPUTS, ADAPTER, ARGS...>(inputs, sel, count, true_sel,
+						                                                                 false_sel, adapter, indices);
+					}
+					break;
+				default:
+					throw InternalException("Invalid flat/constant scalar selection profile");
+				}
+			}
+		}
+		return SelectGeneric<SPECIALIZE_OUTPUTS, ADAPTER, ARGS...>(inputs, sel, count, true_sel, false_sel, adapter,
+		                                                           indices);
+	}
+
+public:
+	template <bool SPECIALIZE_FLAT, bool SPECIALIZE_GENERIC_SELECTIONS, bool PRESERVE_RESULT_VALIDITY,
+	          class RESULT_TYPE, class ADAPTER, class... ARGS>
+	static void Execute(const std::array<VectorRef, sizeof...(ARGS)> &inputs, Vector &result, idx_t count,
+	                    ADAPTER &adapter) {
+		ExecuteInternal<SPECIALIZE_FLAT, SPECIALIZE_GENERIC_SELECTIONS, PRESERVE_RESULT_VALIDITY, RESULT_TYPE, ADAPTER,
+		                ARGS...>(inputs, result, count, adapter, std::index_sequence_for<ARGS...> {});
+	}
+
+	template <uint64_t SPECIALIZED_MASKS, bool SPECIALIZE_OUTPUTS, class ADAPTER, class... ARGS>
+	static idx_t Select(const std::array<VectorRef, sizeof...(ARGS)> &inputs, const SelectionVector *sel, idx_t count,
+	                    SelectionVector *true_sel, SelectionVector *false_sel, ADAPTER &adapter) {
+		if (!true_sel && !false_sel) {
+			throw InternalException("Either true or false sel must be set");
+		}
+		if (!sel) {
+			sel = FlatVector::IncrementalSelectionVector();
+		}
+		return SelectInternal<SPECIALIZED_MASKS, SPECIALIZE_OUTPUTS, ADAPTER, ARGS...>(
+		    inputs, *sel, count, true_sel, false_sel, adapter, std::index_sequence_for<ARGS...> {});
+	}
+
+	template <class... ARGS, size_t... Is>
+	static bool InputsCanHaveNull(const std::array<VectorRef, sizeof...(ARGS)> &inputs, std::index_sequence<Is...>) {
+		std::array<UnifiedVectorFormat, sizeof...(ARGS)> formats;
+		for (idx_t i = 0; i < sizeof...(ARGS); i++) {
+			inputs[i].get().ToUnifiedFormat(formats[i]);
+		}
+		return (... || formats[Is].validity.CanHaveNull());
+	}
+
+	template <class... ARGS>
+	static bool InputsCanHaveNull(const std::array<VectorRef, sizeof...(ARGS)> &inputs) {
+		return InputsCanHaveNull<ARGS...>(inputs, std::index_sequence_for<ARGS...> {});
+	}
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/common/vector_operations/scalar_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/scalar_executor.hpp
@@ -17,6 +17,14 @@
 #include <tuple>
 #include <type_traits>
 
+#if defined(_MSC_VER)
+#define DUCKDB_SCALAR_EXECUTOR_NOINLINE __declspec(noinline)
+#elif defined(__GNUC__)
+#define DUCKDB_SCALAR_EXECUTOR_NOINLINE __attribute__((noinline))
+#else
+#define DUCKDB_SCALAR_EXECUTOR_NOINLINE
+#endif
+
 namespace duckdb {
 
 //! Internal execution engine shared by the named scalar executor facades.
@@ -724,6 +732,39 @@ private:
 		return SelectGeneric<SINK, ADAPTER, ARGS...>(inputs, sel, count, sink, adapter, indices);
 	}
 
+	template <class POLICY, class ADAPTER, class... ARGS, size_t... Is>
+	static idx_t SelectOutputDispatch(const std::array<VectorRef, sizeof...(ARGS)> &inputs, const SelectionVector &sel,
+	                                  idx_t count, SelectionVector *true_sel, SelectionVector *false_sel,
+	                                  const InputProfile &profile, ADAPTER &adapter,
+	                                  std::index_sequence<Is...> indices) {
+		if constexpr (POLICY::SPECIALIZE_OUTPUTS) {
+			if (true_sel && false_sel) {
+				StaticSelectionSink<true, true> sink(true_sel, false_sel);
+				return SelectInternal<POLICY, decltype(sink), ADAPTER, ARGS...>(inputs, sel, count, profile, sink,
+				                                                                adapter, indices);
+			} else if (true_sel) {
+				StaticSelectionSink<true, false> sink(true_sel, false_sel);
+				return SelectInternal<POLICY, decltype(sink), ADAPTER, ARGS...>(inputs, sel, count, profile, sink,
+				                                                                adapter, indices);
+			}
+			StaticSelectionSink<false, true> sink(true_sel, false_sel);
+			return SelectInternal<POLICY, decltype(sink), ADAPTER, ARGS...>(inputs, sel, count, profile, sink, adapter,
+			                                                                indices);
+		}
+		RuntimeSelectionSink sink(true_sel, false_sel);
+		return SelectInternal<POLICY, decltype(sink), ADAPTER, ARGS...>(inputs, sel, count, profile, sink, adapter,
+		                                                                indices);
+	}
+
+	template <class POLICY, class ADAPTER, class... ARGS, size_t... Is>
+	DUCKDB_SCALAR_EXECUTOR_NOINLINE static idx_t
+	SelectFallback(const std::array<VectorRef, sizeof...(ARGS)> &inputs, const SelectionVector &sel, idx_t count,
+	               SelectionVector *true_sel, SelectionVector *false_sel, const InputProfile &profile, ADAPTER &adapter,
+	               std::index_sequence<Is...> indices) {
+		return SelectOutputDispatch<POLICY, ADAPTER, ARGS...>(inputs, sel, count, true_sel, false_sel, profile, adapter,
+		                                                      indices);
+	}
+
 public:
 	template <class POLICY, class RESULT_TYPE, class ADAPTER, class... ARGS>
 	static void Execute(const std::array<VectorRef, sizeof...(ARGS)> &inputs, Vector &result, idx_t count,
@@ -745,37 +786,28 @@ public:
 		auto profile = GetInputProfile(inputs, indices);
 		if constexpr (POLICY::DIRECT_TRUE_FLAT_MASKS != 0) {
 			static_assert(sizeof...(ARGS) <= 3, "Direct true-only selection supports up to three inputs");
-			if (true_sel && !false_sel && profile.all_flat_or_constant &&
-			    (POLICY::DIRECT_TRUE_FLAT_MASKS & (uint64_t(1) << profile.constant_mask))) {
-				StaticSelectionSink<true, false> sink(true_sel, false_sel);
-				if (profile.any_constant_null) {
-					return sink.FillConstant(false, *sel, count);
+			if (true_sel && !false_sel) {
+				if (profile.all_flat_or_constant &&
+				    (POLICY::DIRECT_TRUE_FLAT_MASKS & (uint64_t(1) << profile.constant_mask))) {
+					StaticSelectionSink<true, false> sink(true_sel, false_sel);
+					if (profile.any_constant_null) {
+						return sink.FillConstant(false, *sel, count);
+					}
+					idx_t result;
+					if (TrySelectFlat<POLICY::DIRECT_TRUE_FLAT_MASKS, decltype(sink), ADAPTER, ARGS...>(
+					        inputs, *sel, count, profile.constant_mask, sink, adapter, indices, result)) {
+						return result;
+					}
 				}
-				idx_t result;
-				if (TrySelectFlat<POLICY::DIRECT_TRUE_FLAT_MASKS, decltype(sink), ADAPTER, ARGS...>(
-				        inputs, *sel, count, profile.constant_mask, sink, adapter, indices, result)) {
-					return result;
-				}
+				return SelectFallback<POLICY, ADAPTER, ARGS...>(inputs, *sel, count, true_sel, false_sel, profile,
+				                                                adapter, indices);
 			}
 		}
-		if constexpr (POLICY::SPECIALIZE_OUTPUTS) {
-			if (true_sel && false_sel) {
-				StaticSelectionSink<true, true> sink(true_sel, false_sel);
-				return SelectInternal<POLICY, decltype(sink), ADAPTER, ARGS...>(inputs, *sel, count, profile, sink,
-				                                                                adapter, indices);
-			} else if (true_sel) {
-				StaticSelectionSink<true, false> sink(true_sel, false_sel);
-				return SelectInternal<POLICY, decltype(sink), ADAPTER, ARGS...>(inputs, *sel, count, profile, sink,
-				                                                                adapter, indices);
-			}
-			StaticSelectionSink<false, true> sink(true_sel, false_sel);
-			return SelectInternal<POLICY, decltype(sink), ADAPTER, ARGS...>(inputs, *sel, count, profile, sink, adapter,
-			                                                                indices);
-		}
-		RuntimeSelectionSink sink(true_sel, false_sel);
-		return SelectInternal<POLICY, decltype(sink), ADAPTER, ARGS...>(inputs, *sel, count, profile, sink, adapter,
-		                                                                indices);
+		return SelectOutputDispatch<POLICY, ADAPTER, ARGS...>(inputs, *sel, count, true_sel, false_sel, profile,
+		                                                      adapter, indices);
 	}
 };
 
 } // namespace duckdb
+
+#undef DUCKDB_SCALAR_EXECUTOR_NOINLINE

--- a/src/include/duckdb/common/vector_operations/scalar_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/scalar_executor.hpp
@@ -391,6 +391,14 @@ private:
 		}
 	}
 
+	template <bool NO_NULL, class ADAPTER, class... ARGS>
+	static inline bool SelectOperation(ADAPTER &adapter, ARGS... args) {
+		if constexpr (NO_NULL) {
+			return adapter.OperationNoNull(args...);
+		}
+		return adapter.Operation(args...);
+	}
+
 	static idx_t FillConstantSelection(bool comparison_result, const SelectionVector &sel, idx_t count,
 	                                   SelectionVector *true_sel, SelectionVector *false_sel) {
 		if (comparison_result) {
@@ -503,6 +511,79 @@ private:
 		                                                                        adapter, indices);
 	}
 
+	template <bool RIGHT_CONSTANT, bool SPECIALIZE_OUTPUTS, bool HAS_TRUE_SEL, bool HAS_FALSE_SEL, class CONSTANT_TYPE,
+	          class GENERIC_TYPE, class ADAPTER>
+	static idx_t SelectGenericConstantLoop(CONSTANT_TYPE constant, const GENERIC_TYPE *__restrict data,
+	                                       const SelectionVector &generic_sel, const SelectionVector &sel, idx_t count,
+	                                       SelectionVector *true_sel, SelectionVector *false_sel, ADAPTER &adapter) {
+		idx_t true_count = 0;
+		idx_t false_count = 0;
+		for (idx_t row = 0; row < count; row++) {
+			auto result_idx = sel.get_index(row);
+			auto generic_index = generic_sel.get_index(row);
+			bool comparison_result;
+			if constexpr (RIGHT_CONSTANT) {
+				comparison_result = adapter.OperationNoNull(data[generic_index], constant);
+			} else {
+				comparison_result = adapter.OperationNoNull(constant, data[generic_index]);
+			}
+			StoreSelection<SPECIALIZE_OUTPUTS, HAS_TRUE_SEL, HAS_FALSE_SEL>(comparison_result, result_idx, true_sel,
+			                                                                false_sel, true_count, false_count);
+		}
+		if constexpr (SPECIALIZE_OUTPUTS && HAS_TRUE_SEL) {
+			return true_count;
+		}
+		return true_sel ? true_count : count - false_count;
+	}
+
+	template <bool RIGHT_CONSTANT, bool SPECIALIZE_OUTPUTS, class CONSTANT_TYPE, class GENERIC_TYPE, class ADAPTER>
+	static idx_t SelectGenericConstantSwitch(CONSTANT_TYPE constant, const GENERIC_TYPE *__restrict data,
+	                                         const SelectionVector &generic_sel, const SelectionVector &sel,
+	                                         idx_t count, SelectionVector *true_sel, SelectionVector *false_sel,
+	                                         ADAPTER &adapter) {
+		if constexpr (SPECIALIZE_OUTPUTS) {
+			if (true_sel && false_sel) {
+				return SelectGenericConstantLoop<RIGHT_CONSTANT, true, true, true>(constant, data, generic_sel, sel,
+				                                                                   count, true_sel, false_sel, adapter);
+			} else if (true_sel) {
+				return SelectGenericConstantLoop<RIGHT_CONSTANT, true, true, false>(
+				    constant, data, generic_sel, sel, count, true_sel, false_sel, adapter);
+			}
+			return SelectGenericConstantLoop<RIGHT_CONSTANT, true, false, true>(constant, data, generic_sel, sel, count,
+			                                                                    true_sel, false_sel, adapter);
+		}
+		return SelectGenericConstantLoop<RIGHT_CONSTANT, false, false, false>(constant, data, generic_sel, sel, count,
+		                                                                      true_sel, false_sel, adapter);
+	}
+
+	template <uint64_t CONSTANT_MASK, bool SPECIALIZE_OUTPUTS, class ADAPTER, class LEFT_TYPE, class RIGHT_TYPE>
+	static idx_t SelectGenericConstant(const std::array<VectorRef, 2> &inputs, const SelectionVector &sel, idx_t count,
+	                                   SelectionVector *true_sel, SelectionVector *false_sel, ADAPTER &adapter) {
+		static_assert(CONSTANT_MASK == 1 || CONSTANT_MASK == 2, "Exactly one binary input must be constant");
+		constexpr idx_t GENERIC_INDEX = CONSTANT_MASK == 1 ? 1 : 0;
+		constexpr idx_t CONSTANT_INDEX = CONSTANT_MASK == 1 ? 0 : 1;
+		std::array<UnifiedVectorFormat, 2> formats;
+		auto &generic_format = formats[GENERIC_INDEX];
+		inputs[GENERIC_INDEX].get().ToUnifiedFormat(generic_format);
+		if (generic_format.validity.CanHaveNull()) {
+			inputs[CONSTANT_INDEX].get().ToUnifiedFormat(formats[CONSTANT_INDEX]);
+			auto input_data = std::make_tuple(UnifiedVectorFormat::GetData<LEFT_TYPE>(formats[0]),
+			                                  UnifiedVectorFormat::GetData<RIGHT_TYPE>(formats[1]));
+			return SelectGenericSwitch<false, SPECIALIZE_OUTPUTS>(input_data, formats, sel, count, true_sel, false_sel,
+			                                                      adapter, std::index_sequence<0, 1> {});
+		}
+		if constexpr (CONSTANT_MASK == 1) {
+			auto constant = *ConstantVector::GetData<LEFT_TYPE>(inputs[0].get());
+			auto data = UnifiedVectorFormat::GetData<RIGHT_TYPE>(generic_format);
+			return SelectGenericConstantSwitch<false, SPECIALIZE_OUTPUTS>(constant, data, *generic_format.sel, sel,
+			                                                              count, true_sel, false_sel, adapter);
+		}
+		auto constant = *ConstantVector::GetData<RIGHT_TYPE>(inputs[1].get());
+		auto data = UnifiedVectorFormat::GetData<LEFT_TYPE>(generic_format);
+		return SelectGenericConstantSwitch<true, SPECIALIZE_OUTPUTS>(constant, data, *generic_format.sel, sel, count,
+		                                                             true_sel, false_sel, adapter);
+	}
+
 	template <bool NO_NULL, bool SPECIALIZE_OUTPUTS, bool HAS_TRUE_SEL, bool HAS_FALSE_SEL, class ADAPTER,
 	          class... ARGS, size_t... Is>
 	static idx_t SelectGenericLoop(std::tuple<const ARGS *...> &input_data,
@@ -516,7 +597,7 @@ private:
 			auto result_idx = sel.get_index(row);
 			std::array<idx_t, N> input_indices = {{formats[Is].sel->get_index(row)...}};
 			bool comparison_result = (NO_NULL || (... && formats[Is].validity.RowIsValid(input_indices[Is]))) &&
-			                         adapter.Operation(std::get<Is>(input_data)[input_indices[Is]]...);
+			                         SelectOperation<NO_NULL>(adapter, std::get<Is>(input_data)[input_indices[Is]]...);
 			StoreSelection<SPECIALIZE_OUTPUTS, HAS_TRUE_SEL, HAS_FALSE_SEL>(comparison_result, result_idx, true_sel,
 			                                                                false_sel, true_count, false_count);
 		}
@@ -628,6 +709,20 @@ private:
 				}
 			}
 		}
+		if constexpr (SPECIALIZED_MASKS != 0 && N == 2) {
+			if (!profile.any_constant_null) {
+				switch (profile.constant_mask) {
+				case 1:
+					return SelectGenericConstant<1, SPECIALIZE_OUTPUTS, ADAPTER, ARGS...>(inputs, sel, count, true_sel,
+					                                                                      false_sel, adapter);
+				case 2:
+					return SelectGenericConstant<2, SPECIALIZE_OUTPUTS, ADAPTER, ARGS...>(inputs, sel, count, true_sel,
+					                                                                      false_sel, adapter);
+				default:
+					break;
+				}
+			}
+		}
 		return SelectGeneric<SPECIALIZE_OUTPUTS, ADAPTER, ARGS...>(inputs, sel, count, true_sel, false_sel, adapter,
 		                                                           indices);
 	}
@@ -652,20 +747,6 @@ public:
 		}
 		return SelectInternal<SPECIALIZED_MASKS, SPECIALIZE_OUTPUTS, ADAPTER, ARGS...>(
 		    inputs, *sel, count, true_sel, false_sel, adapter, std::index_sequence_for<ARGS...> {});
-	}
-
-	template <class... ARGS, size_t... Is>
-	static bool InputsCanHaveNull(const std::array<VectorRef, sizeof...(ARGS)> &inputs, std::index_sequence<Is...>) {
-		std::array<UnifiedVectorFormat, sizeof...(ARGS)> formats;
-		for (idx_t i = 0; i < sizeof...(ARGS); i++) {
-			inputs[i].get().ToUnifiedFormat(formats[i]);
-		}
-		return (... || formats[Is].validity.CanHaveNull());
-	}
-
-	template <class... ARGS>
-	static bool InputsCanHaveNull(const std::array<VectorRef, sizeof...(ARGS)> &inputs) {
-		return InputsCanHaveNull<ARGS...>(inputs, std::index_sequence_for<ARGS...> {});
 	}
 };
 

--- a/src/include/duckdb/common/vector_operations/unary_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/unary_executor.hpp
@@ -81,6 +81,10 @@ struct UnarySelectAdapter {
 		return fun(input);
 	}
 
+	inline bool OperationNoNull(INPUT_TYPE input) {
+		return Operation(input);
+	}
+
 	FUNC &fun;
 };
 

--- a/src/include/duckdb/common/vector_operations/unary_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/unary_executor.hpp
@@ -3,23 +3,20 @@
 //
 // duckdb/common/vector_operations/unary_executor.hpp
 //
-//
 //===----------------------------------------------------------------------===//
 
 #pragma once
 
-#include "duckdb/common/exception.hpp"
+#include "duckdb/common/enums/function_errors.hpp"
 #include "duckdb/common/optional.hpp"
 #include "duckdb/common/smaller_binary.hpp"
-#include "duckdb/common/types/vector.hpp"
-#include "duckdb/common/vector/constant_vector.hpp"
 #include "duckdb/common/vector/dictionary_vector.hpp"
-#include "duckdb/common/vector/flat_vector.hpp"
 #include "duckdb/common/vector/string_vector.hpp"
+#include "duckdb/common/vector_operations/scalar_executor.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
-#include "duckdb/common/enums/function_errors.hpp"
 
 #include <functional>
+#include <type_traits>
 
 namespace duckdb {
 
@@ -61,170 +58,76 @@ struct UnaryStringOperator {
 	}
 };
 
+template <class INPUT_TYPE, class RESULT_TYPE, class OPWRAPPER, class OP, class DATA_TYPE, bool CAN_ADD_NULLS>
+struct UnaryScalarAdapter {
+	static constexpr bool ADDS_NULLS = CAN_ADD_NULLS;
+
+	explicit UnaryScalarAdapter(DATA_TYPE &data_p) : data(data_p) {
+	}
+
+	inline RESULT_TYPE Operation(ValidityMask &mask, idx_t idx, INPUT_TYPE input) {
+		return OPWRAPPER::template Operation<OP, INPUT_TYPE, RESULT_TYPE>(input, mask, idx, data);
+	}
+
+	DATA_TYPE &data;
+};
+
+template <class INPUT_TYPE, class FUNC>
+struct UnarySelectAdapter {
+	explicit UnarySelectAdapter(FUNC &fun_p) : fun(fun_p) {
+	}
+
+	inline bool Operation(INPUT_TYPE input) {
+		return fun(input);
+	}
+
+	FUNC &fun;
+};
+
 struct UnaryExecutor {
 private:
-	template <class INPUT_TYPE, class RESULT_TYPE, class OPWRAPPER, class OP, class DATA_TYPE>
-	static inline void ExecuteLoop(const INPUT_TYPE *__restrict ldata, RESULT_TYPE *__restrict result_data, idx_t count,
-	                               const SelectionVector *__restrict sel_vector, const ValidityMask &mask,
-	                               ValidityMask &result_mask, DATA_TYPE &data, bool adds_nulls) {
-#ifdef DEBUG
-		// ldata may point to a compressed dictionary buffer which can be smaller than ldata + count
-		idx_t max_index = 0;
-		for (idx_t i = 0; i < count; i++) {
-			auto idx = sel_vector->get_index(i);
-			max_index = MaxValue(max_index, idx);
-		}
-		ASSERT_RESTRICT(ldata, ldata + max_index, result_data, result_data + count);
-#endif
-
-		if (mask.CanHaveNull()) {
-			for (idx_t i = 0; i < count; i++) {
-				auto idx = sel_vector->get_index(i);
-				if (mask.RowIsValidUnsafe(idx)) {
-					result_data[i] =
-					    OPWRAPPER::template Operation<OP, INPUT_TYPE, RESULT_TYPE>(ldata[idx], result_mask, i, data);
-				} else {
-					result_mask.SetInvalid(i);
-				}
-			}
-		} else {
-			for (idx_t i = 0; i < count; i++) {
-				auto idx = sel_vector->get_index(i);
-				result_data[i] =
-				    OPWRAPPER::template Operation<OP, INPUT_TYPE, RESULT_TYPE>(ldata[idx], result_mask, i, data);
-			}
-		}
-	}
+	template <bool ADDS_NULLS, class INPUT_TYPE, class RESULT_TYPE, class OPWRAPPER, class OP, class DATA_TYPE>
+	static inline void ExecuteInternal(const Vector &input, Vector &result, idx_t count, DATA_TYPE &data,
+	                                   FunctionErrors errors) {
+		UnaryScalarAdapter<INPUT_TYPE, RESULT_TYPE, OPWRAPPER, OP, DATA_TYPE, ADDS_NULLS> adapter(data);
 
 #if !DUCKDB_SMALLER_BINARY(unary_executor_flat)
-	template <class INPUT_TYPE, class RESULT_TYPE, class OPWRAPPER, class OP, class DATA_TYPE>
-	static inline void ExecuteFlat(const INPUT_TYPE *__restrict ldata, RESULT_TYPE *__restrict result_data, idx_t count,
-	                               const ValidityMask &mask, ValidityMask &result_mask, DATA_TYPE &data,
-	                               bool adds_nulls) {
-		ASSERT_RESTRICT(ldata, ldata + count, result_data, result_data + count);
-
-		if (mask.CanHaveNull()) {
-			if (!adds_nulls) {
-				result_mask.Initialize(mask);
-			} else {
-				result_mask.Copy(mask, count);
-			}
-			idx_t base_idx = 0;
-			auto entry_count = ValidityMask::EntryCount(count);
-			for (idx_t entry_idx = 0; entry_idx < entry_count; entry_idx++) {
-				auto validity_entry = mask.GetValidityEntry(entry_idx);
-				idx_t next = MinValue<idx_t>(base_idx + ValidityMask::BITS_PER_VALUE, count);
-				if (ValidityMask::AllValid(validity_entry)) {
-					// all valid: perform operation
-					for (; base_idx < next; base_idx++) {
-						result_data[base_idx] = OPWRAPPER::template Operation<OP, INPUT_TYPE, RESULT_TYPE>(
-						    ldata[base_idx], result_mask, base_idx, data);
-					}
-				} else if (ValidityMask::NoneValid(validity_entry)) {
-					// nothing valid: skip all
-					base_idx = next;
-					continue;
-				} else {
-					// partially valid: need to check individual elements for validity
-					idx_t start = base_idx;
-					for (; base_idx < next; base_idx++) {
-						if (ValidityMask::RowIsValid(validity_entry, base_idx - start)) {
-							D_ASSERT(mask.RowIsValid(base_idx));
-							result_data[base_idx] = OPWRAPPER::template Operation<OP, INPUT_TYPE, RESULT_TYPE>(
-							    ldata[base_idx], result_mask, base_idx, data);
-						}
-					}
+		if (input.GetVectorType() == VectorType::DICTIONARY_VECTOR && errors == FunctionErrors::CANNOT_ERROR) {
+			static constexpr idx_t DICTIONARY_THRESHOLD = 2;
+			auto dictionary_size = DictionaryVector::DictionarySize(input);
+			if (dictionary_size.IsValid() && dictionary_size.GetIndex() * DICTIONARY_THRESHOLD <= count) {
+				auto &dictionary_values = DictionaryVector::Child(input);
+				if (dictionary_values.GetVectorType() == VectorType::FLAT_VECTOR) {
+					std::array<ScalarExecutor::VectorRef, 1> dictionary_input = {{dictionary_values}};
+					ScalarExecutor::Execute<true, false, true, RESULT_TYPE, decltype(adapter), INPUT_TYPE>(
+					    dictionary_input, result, dictionary_size.GetIndex(), adapter);
+					auto &offsets = DictionaryVector::SelVector(input);
+					FlatVector::SetSize(result, dictionary_size.GetIndex());
+					result.Dictionary(result, dictionary_size.GetIndex(), offsets, count);
+					return;
 				}
 			}
-		} else {
-			for (idx_t i = 0; i < count; i++) {
-				result_data[i] =
-				    OPWRAPPER::template Operation<OP, INPUT_TYPE, RESULT_TYPE>(ldata[i], result_mask, i, data);
-			}
 		}
-	}
 #endif
+
+		std::array<ScalarExecutor::VectorRef, 1> inputs = {{input}};
+#if !DUCKDB_SMALLER_BINARY(unary_executor_flat)
+		ScalarExecutor::Execute<true, false, true, RESULT_TYPE, decltype(adapter), INPUT_TYPE>(inputs, result, count,
+		                                                                                       adapter);
+#else
+		ScalarExecutor::Execute<false, false, true, RESULT_TYPE, decltype(adapter), INPUT_TYPE>(inputs, result, count,
+		                                                                                        adapter);
+#endif
+	}
 
 	template <class INPUT_TYPE, class RESULT_TYPE, class OPWRAPPER, class OP, class DATA_TYPE>
 	static inline void ExecuteStandard(const Vector &input, Vector &result, idx_t count, DATA_TYPE &data,
 	                                   bool adds_nulls,
 	                                   FunctionErrors errors = FunctionErrors::CAN_THROW_RUNTIME_ERROR) {
-		switch (input.GetVectorType()) {
-		case VectorType::CONSTANT_VECTOR: {
-			result.SetVectorType(VectorType::CONSTANT_VECTOR);
-			if (result.size() != count) {
-				FlatVector::SetSize(result, count);
-			}
-			auto result_data = ConstantVector::GetData<RESULT_TYPE>(result);
-			auto ldata = ConstantVector::GetData<INPUT_TYPE>(input);
-
-			if (ConstantVector::IsNull(input)) {
-				ConstantVector::SetNull(result, count_t(count));
-			} else {
-				ConstantVector::SetNull(result, false);
-				*result_data = OPWRAPPER::template Operation<OP, INPUT_TYPE, RESULT_TYPE>(
-				    *ldata, ConstantVector::Validity(result), 0, data);
-			}
-			break;
-		}
-#if !DUCKDB_SMALLER_BINARY(unary_executor_flat)
-		case VectorType::FLAT_VECTOR: {
-			result.SetVectorType(VectorType::FLAT_VECTOR);
-			if (result.size() != count) {
-				FlatVector::SetSize(result, count);
-			}
-			auto result_data = FlatVector::GetDataMutable<RESULT_TYPE>(result);
-			auto ldata = FlatVector::GetData<INPUT_TYPE>(input);
-
-			ExecuteFlat<INPUT_TYPE, RESULT_TYPE, OPWRAPPER, OP>(ldata, result_data, count, FlatVector::Validity(input),
-			                                                    FlatVector::ValidityMutable(result), data, adds_nulls);
-			break;
-		}
-		case VectorType::DICTIONARY_VECTOR: {
-			// dictionary vector - we can run the function ONLY on the dictionary in some cases
-			// we can only do this if the function does not throw errors
-			// we can execute the function on a value that is in the dictionary but that is not referenced
-			// if the function can throw errors - this will result in us (incorrectly) throwing an error
-			if (errors == FunctionErrors::CANNOT_ERROR) {
-				static constexpr idx_t DICTIONARY_THRESHOLD = 2;
-				auto dict_size = DictionaryVector::DictionarySize(input);
-				if (dict_size.IsValid() && dict_size.GetIndex() * DICTIONARY_THRESHOLD <= count) {
-					// we can operate directly on the dictionary if we have a dictionary size
-					// but this only makes sense if the dictionary size is smaller than the count by some factor
-					auto &dictionary_values = DictionaryVector::Child(input);
-					if (dictionary_values.GetVectorType() == VectorType::FLAT_VECTOR) {
-						// execute the function over the dictionary
-						auto result_data = FlatVector::GetDataMutable<RESULT_TYPE>(result);
-						auto ldata = FlatVector::GetData<INPUT_TYPE>(dictionary_values);
-						ExecuteFlat<INPUT_TYPE, RESULT_TYPE, OPWRAPPER, OP>(
-						    ldata, result_data, dict_size.GetIndex(), FlatVector::Validity(dictionary_values),
-						    FlatVector::ValidityMutable(result), data, adds_nulls);
-						// slice the result with the original offsets
-						auto &offsets = DictionaryVector::SelVector(input);
-						FlatVector::SetSize(result, dict_size.GetIndex());
-						result.Dictionary(result, dict_size.GetIndex(), offsets, count);
-						break;
-					}
-				}
-			}
-			DUCKDB_EXPLICIT_FALLTHROUGH;
-		}
-#endif
-		default: {
-			UnifiedVectorFormat vdata;
-			input.ToUnifiedFormat(vdata);
-
-			result.SetVectorType(VectorType::FLAT_VECTOR);
-			if (result.size() != count) {
-				FlatVector::SetSize(result, count);
-			}
-			auto result_data = FlatVector::GetDataMutable<RESULT_TYPE>(result);
-			auto ldata = UnifiedVectorFormat::GetData<INPUT_TYPE>(vdata);
-
-			ExecuteLoop<INPUT_TYPE, RESULT_TYPE, OPWRAPPER, OP>(ldata, result_data, count, vdata.sel, vdata.validity,
-			                                                    FlatVector::ValidityMutable(result), data, adds_nulls);
-			break;
-		}
+		if (adds_nulls) {
+			ExecuteInternal<true, INPUT_TYPE, RESULT_TYPE, OPWRAPPER, OP>(input, result, count, data, errors);
+		} else {
+			ExecuteInternal<false, INPUT_TYPE, RESULT_TYPE, OPWRAPPER, OP>(input, result, count, data, errors);
 		}
 	}
 
@@ -232,31 +135,32 @@ public:
 	template <class INPUT_TYPE, class RESULT_TYPE, class OP>
 	static void Execute(const Vector &input, Vector &result, idx_t count) {
 		std::nullptr_t no_data = nullptr;
-		ExecuteStandard<INPUT_TYPE, RESULT_TYPE, UnaryOperatorWrapper, OP>(input, result, count, no_data, false);
+		ExecuteInternal<false, INPUT_TYPE, RESULT_TYPE, UnaryOperatorWrapper, OP>(
+		    input, result, count, no_data, FunctionErrors::CAN_THROW_RUNTIME_ERROR);
 	}
 
 	template <class INPUT_TYPE, class RESULT_TYPE, class FUNC = std::function<RESULT_TYPE(INPUT_TYPE)>>
 	static void Execute(const Vector &input, Vector &result, idx_t count, FUNC fun,
 	                    FunctionErrors errors = FunctionErrors::CAN_THROW_RUNTIME_ERROR) {
 		constexpr bool adds_nulls =
-		    std::is_same<decltype(fun(std::declval<INPUT_TYPE>())), optional<RESULT_TYPE>>::value;
-		ExecuteStandard<INPUT_TYPE, RESULT_TYPE, UnaryLambdaWrapper, FUNC>(input, result, count, fun, adds_nulls,
-		                                                                   errors);
+		    std::is_same<std::invoke_result_t<FUNC &, INPUT_TYPE>, optional<RESULT_TYPE>>::value;
+		ExecuteInternal<adds_nulls, INPUT_TYPE, RESULT_TYPE, UnaryLambdaWrapper, FUNC>(input, result, count, fun,
+		                                                                               errors);
 	}
 
 	template <class INPUT_TYPE, class RESULT_TYPE, class OP, class DATA_TYPE>
-	static void GenericExecute(const Vector &input, Vector &result, idx_t count, DATA_TYPE &data,
-	                           bool adds_nulls = false) {
-		ExecuteStandard<INPUT_TYPE, RESULT_TYPE, GenericUnaryWrapper, OP>(input, result, count, data, adds_nulls);
+	static void GenericExecute(const Vector &input, Vector &result, idx_t count, DATA_TYPE &data, bool = false) {
+		// Generic operations own the result mask so they can invalidate rows at runtime.
+		ExecuteInternal<true, INPUT_TYPE, RESULT_TYPE, GenericUnaryWrapper, OP>(
+		    input, result, count, data, FunctionErrors::CAN_THROW_RUNTIME_ERROR);
 	}
 
 	template <class INPUT_TYPE, class RESULT_TYPE, class OP>
 	static void ExecuteString(const Vector &input, Vector &result, idx_t count) {
 		auto &heap = StringVector::GetStringHeap(result);
-		UnaryExecutor::GenericExecute<INPUT_TYPE, RESULT_TYPE, UnaryStringOperator<OP>>(input, result, count, heap);
+		GenericExecute<INPUT_TYPE, RESULT_TYPE, UnaryStringOperator<OP>>(input, result, count, heap);
 	}
 
-	//! Convenience overloads without explicit count - count is derived from input.size().
 	template <class INPUT_TYPE, class RESULT_TYPE, class OP>
 	static void Execute(const Vector &input, Vector &result) {
 		Execute<INPUT_TYPE, RESULT_TYPE, OP>(input, result, input.size());
@@ -278,76 +182,13 @@ public:
 		ExecuteString<INPUT_TYPE, RESULT_TYPE, OP>(input, result, input.size());
 	}
 
-private:
-	// Select logic copied from TernaryExecutor, but with a lambda instead of a static functor
-	template <class INPUT_TYPE, class FUNC = std::function<bool(INPUT_TYPE)>, bool NO_NULL, bool HAS_TRUE_SEL,
-	          bool HAS_FALSE_SEL>
-	static inline idx_t SelectLoop(const INPUT_TYPE *__restrict input_data, const SelectionVector *result_sel,
-	                               const idx_t count, FUNC fun, const SelectionVector &input_sel,
-	                               const ValidityMask &input_validity, SelectionVector *true_sel,
-	                               SelectionVector *false_sel) {
-		idx_t true_count = 0, false_count = 0;
-		for (idx_t i = 0; i < count; i++) {
-			const auto result_idx = result_sel->get_index(i);
-			const auto idx = input_sel.get_index(i);
-			const bool comparison_result = (NO_NULL || input_validity.RowIsValid(idx)) && fun(input_data[idx]);
-			if (HAS_TRUE_SEL) {
-				true_sel->set_index(true_count, result_idx);
-				true_count += comparison_result;
-			}
-			if (HAS_FALSE_SEL) {
-				false_sel->set_index(false_count, result_idx);
-				false_count += !comparison_result;
-			}
-		}
-		if (HAS_TRUE_SEL) {
-			return true_count;
-		} else {
-			return count - false_count;
-		}
-	}
-
-	template <class INPUT_TYPE, class FUNC = std::function<bool(INPUT_TYPE)>, bool NO_NULL>
-	static inline idx_t SelectLoopSelSwitch(UnifiedVectorFormat &input_data, const SelectionVector *sel,
-	                                        const idx_t count, FUNC fun, SelectionVector *true_sel,
-	                                        SelectionVector *false_sel) {
-		if (true_sel && false_sel) {
-			return SelectLoop<INPUT_TYPE, FUNC, NO_NULL, true, true>(
-			    UnifiedVectorFormat::GetData<INPUT_TYPE>(input_data), sel, count, fun, *input_data.sel,
-			    input_data.validity, true_sel, false_sel);
-		} else if (true_sel) {
-			return SelectLoop<INPUT_TYPE, FUNC, NO_NULL, true, false>(
-			    UnifiedVectorFormat::GetData<INPUT_TYPE>(input_data), sel, count, fun, *input_data.sel,
-			    input_data.validity, true_sel, false_sel);
-		} else {
-			D_ASSERT(false_sel);
-			return SelectLoop<INPUT_TYPE, FUNC, NO_NULL, false, true>(
-			    UnifiedVectorFormat::GetData<INPUT_TYPE>(input_data), sel, count, fun, *input_data.sel,
-			    input_data.validity, true_sel, false_sel);
-		}
-	}
-
 	template <class INPUT_TYPE, class FUNC = std::function<bool(INPUT_TYPE)>>
-	static inline idx_t SelectLoopSwitch(UnifiedVectorFormat &input_data, const SelectionVector *sel, const idx_t count,
-	                                     FUNC fun, SelectionVector *true_sel, SelectionVector *false_sel) {
-		if (input_data.validity.CanHaveNull()) {
-			return SelectLoopSelSwitch<INPUT_TYPE, FUNC, false>(input_data, sel, count, fun, true_sel, false_sel);
-		} else {
-			return SelectLoopSelSwitch<INPUT_TYPE, FUNC, true>(input_data, sel, count, fun, true_sel, false_sel);
-		}
-	}
-
-public:
-	template <class INPUT_TYPE, class FUNC = std::function<bool(INPUT_TYPE)>>
-	static idx_t Select(const Vector &input, const SelectionVector *sel, const idx_t count, FUNC fun,
+	static idx_t Select(const Vector &input, const SelectionVector *sel, idx_t count, FUNC fun,
 	                    SelectionVector *true_sel, SelectionVector *false_sel) {
-		if (!sel) {
-			sel = FlatVector::IncrementalSelectionVector();
-		}
-		UnifiedVectorFormat input_data;
-		input.ToUnifiedFormat(input_data);
-
-		return SelectLoopSwitch<INPUT_TYPE, FUNC>(input_data, sel, count, fun, true_sel, false_sel);
+		std::array<ScalarExecutor::VectorRef, 1> inputs = {{input}};
+		UnarySelectAdapter<INPUT_TYPE, FUNC> adapter(fun);
+		return ScalarExecutor::Select<1, true, decltype(adapter), INPUT_TYPE>(inputs, sel, count, true_sel, false_sel,
+		                                                                      adapter);
 	}
 };
 

--- a/src/include/duckdb/common/vector_operations/unary_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/unary_executor.hpp
@@ -90,6 +90,30 @@ struct UnarySelectAdapter {
 
 struct UnaryExecutor {
 private:
+	struct ExecutePolicy {
+#if !DUCKDB_SMALLER_BINARY(unary_executor_flat)
+		static constexpr bool SPECIALIZE_FLAT = true;
+#else
+		static constexpr bool SPECIALIZE_FLAT = false;
+#endif
+		static constexpr bool SPECIALIZE_NULLABLE_GENERIC_SELECTIONS = false;
+		static constexpr bool PRESERVE_RESULT_VALIDITY = true;
+	};
+
+	struct SelectPolicy {
+#if !DUCKDB_SMALLER_BINARY(unary_executor_select_flat)
+		static constexpr uint64_t SPECIALIZED_MASKS = 1;
+#else
+		static constexpr uint64_t SPECIALIZED_MASKS = 0;
+#endif
+#if !DUCKDB_SMALLER_BINARY(unary_executor_select_flags)
+		static constexpr bool SPECIALIZE_OUTPUTS = true;
+#else
+		static constexpr bool SPECIALIZE_OUTPUTS = false;
+#endif
+		static constexpr bool DIRECT_TRUE_FLAT = false;
+	};
+
 	template <bool ADDS_NULLS, class INPUT_TYPE, class RESULT_TYPE, class OPWRAPPER, class OP, class DATA_TYPE>
 	static inline void ExecuteInternal(const Vector &input, Vector &result, idx_t count, DATA_TYPE &data,
 	                                   FunctionErrors errors) {
@@ -103,7 +127,7 @@ private:
 				auto &dictionary_values = DictionaryVector::Child(input);
 				if (dictionary_values.GetVectorType() == VectorType::FLAT_VECTOR) {
 					std::array<ScalarExecutor::VectorRef, 1> dictionary_input = {{dictionary_values}};
-					ScalarExecutor::Execute<true, false, true, RESULT_TYPE, decltype(adapter), INPUT_TYPE>(
+					ScalarExecutor::Execute<ExecutePolicy, RESULT_TYPE, decltype(adapter), INPUT_TYPE>(
 					    dictionary_input, result, dictionary_size.GetIndex(), adapter);
 					auto &offsets = DictionaryVector::SelVector(input);
 					FlatVector::SetSize(result, dictionary_size.GetIndex());
@@ -115,24 +139,8 @@ private:
 #endif
 
 		std::array<ScalarExecutor::VectorRef, 1> inputs = {{input}};
-#if !DUCKDB_SMALLER_BINARY(unary_executor_flat)
-		ScalarExecutor::Execute<true, false, true, RESULT_TYPE, decltype(adapter), INPUT_TYPE>(inputs, result, count,
-		                                                                                       adapter);
-#else
-		ScalarExecutor::Execute<false, false, true, RESULT_TYPE, decltype(adapter), INPUT_TYPE>(inputs, result, count,
-		                                                                                        adapter);
-#endif
-	}
-
-	template <class INPUT_TYPE, class RESULT_TYPE, class OPWRAPPER, class OP, class DATA_TYPE>
-	static inline void ExecuteStandard(const Vector &input, Vector &result, idx_t count, DATA_TYPE &data,
-	                                   bool adds_nulls,
-	                                   FunctionErrors errors = FunctionErrors::CAN_THROW_RUNTIME_ERROR) {
-		if (adds_nulls) {
-			ExecuteInternal<true, INPUT_TYPE, RESULT_TYPE, OPWRAPPER, OP>(input, result, count, data, errors);
-		} else {
-			ExecuteInternal<false, INPUT_TYPE, RESULT_TYPE, OPWRAPPER, OP>(input, result, count, data, errors);
-		}
+		ScalarExecutor::Execute<ExecutePolicy, RESULT_TYPE, decltype(adapter), INPUT_TYPE>(inputs, result, count,
+		                                                                                   adapter);
 	}
 
 public:
@@ -191,8 +199,8 @@ public:
 	                    SelectionVector *true_sel, SelectionVector *false_sel) {
 		std::array<ScalarExecutor::VectorRef, 1> inputs = {{input}};
 		UnarySelectAdapter<INPUT_TYPE, FUNC> adapter(fun);
-		return ScalarExecutor::Select<1, true, decltype(adapter), INPUT_TYPE>(inputs, sel, count, true_sel, false_sel,
-		                                                                      adapter);
+		return ScalarExecutor::Select<SelectPolicy, decltype(adapter), INPUT_TYPE>(inputs, sel, count, true_sel,
+		                                                                           false_sel, adapter);
 	}
 };
 

--- a/src/include/duckdb/common/vector_operations/unary_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/unary_executor.hpp
@@ -111,7 +111,7 @@ private:
 #else
 		static constexpr bool SPECIALIZE_OUTPUTS = false;
 #endif
-		static constexpr bool DIRECT_TRUE_FLAT = false;
+		static constexpr uint64_t DIRECT_TRUE_FLAT_MASKS = 0;
 	};
 
 	template <bool ADDS_NULLS, class INPUT_TYPE, class RESULT_TYPE, class OPWRAPPER, class OP, class DATA_TYPE>

--- a/src/include/duckdb/common/vector_operations/variadic_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/variadic_executor.hpp
@@ -153,7 +153,12 @@ public:
 #else
 		static constexpr uint64_t SPECIALIZED_MASKS = 0;
 #endif
-		return ScalarExecutor::Select<SPECIALIZED_MASKS, false, decltype(adapter), ARGS...>(
+#if !DUCKDB_SMALLER_BINARY(variadic_executor_select_flags)
+		static constexpr bool SPECIALIZE_OUTPUTS = true;
+#else
+		static constexpr bool SPECIALIZE_OUTPUTS = false;
+#endif
+		return ScalarExecutor::Select<SPECIALIZED_MASKS, SPECIALIZE_OUTPUTS, decltype(adapter), ARGS...>(
 		    inputs, sel, count, true_sel, false_sel, adapter);
 	}
 };

--- a/src/include/duckdb/common/vector_operations/variadic_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/variadic_executor.hpp
@@ -106,15 +106,17 @@ private:
 	struct SelectPolicy {
 #if !DUCKDB_SMALLER_BINARY(variadic_executor_select_flat)
 		static constexpr uint64_t SPECIALIZED_MASKS = SpecializeFlat<ARGS...>() ? 1 : 0;
+		static constexpr uint64_t DIRECT_TRUE_FLAT_MASKS =
+		    sizeof...(ARGS) == 3 && SpecializeFlat<ARGS...>() ? uint64_t(1) << 6 : 0;
 #else
 		static constexpr uint64_t SPECIALIZED_MASKS = 0;
+		static constexpr uint64_t DIRECT_TRUE_FLAT_MASKS = 0;
 #endif
 #if !DUCKDB_SMALLER_BINARY(variadic_executor_select_flags)
 		static constexpr bool SPECIALIZE_OUTPUTS = true;
 #else
 		static constexpr bool SPECIALIZE_OUTPUTS = false;
 #endif
-		static constexpr bool DIRECT_TRUE_FLAT = false;
 	};
 
 	template <size_t N, size_t... Is>

--- a/src/include/duckdb/common/vector_operations/variadic_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/variadic_executor.hpp
@@ -64,12 +64,9 @@ template <class RESULT_TYPE, class OP, class... ARGS>
 struct VariadicStandardAdapter {
 	static constexpr bool ADDS_NULLS = false;
 
-	inline RESULT_TYPE Operation(ValidityMask &mask, idx_t idx, ARGS... args) {
-		return VariadicStandardOperatorWrapper<OP>::template Operation<bool, RESULT_TYPE, ARGS...>(dummy, mask, idx,
-		                                                                                           args...);
+	inline RESULT_TYPE Operation(ValidityMask &, idx_t, ARGS... args) {
+		return OP::template Operation<ARGS..., RESULT_TYPE>(args...);
 	}
-
-	bool dummy = false;
 };
 
 template <class OP, class... ARGS>
@@ -93,6 +90,32 @@ private:
 	static constexpr bool SpecializeFlat() {
 		return sizeof...(ARGS) <= 3 && (... && std::is_arithmetic<ARGS>::value);
 	}
+
+	template <class... ARGS>
+	struct ExecutePolicy {
+#if !DUCKDB_SMALLER_BINARY(variadic_executor_flat)
+		static constexpr bool SPECIALIZE_FLAT = SpecializeFlat<ARGS...>();
+#else
+		static constexpr bool SPECIALIZE_FLAT = false;
+#endif
+		static constexpr bool SPECIALIZE_NULLABLE_GENERIC_SELECTIONS = false;
+		static constexpr bool PRESERVE_RESULT_VALIDITY = false;
+	};
+
+	template <class... ARGS>
+	struct SelectPolicy {
+#if !DUCKDB_SMALLER_BINARY(variadic_executor_select_flat)
+		static constexpr uint64_t SPECIALIZED_MASKS = SpecializeFlat<ARGS...>() ? 1 : 0;
+#else
+		static constexpr uint64_t SPECIALIZED_MASKS = 0;
+#endif
+#if !DUCKDB_SMALLER_BINARY(variadic_executor_select_flags)
+		static constexpr bool SPECIALIZE_OUTPUTS = true;
+#else
+		static constexpr bool SPECIALIZE_OUTPUTS = false;
+#endif
+		static constexpr bool DIRECT_TRUE_FLAT = false;
+	};
 
 	template <size_t N, size_t... Is>
 	static std::array<VectorRef, N> MakeInputArrayImpl(DataChunk &input, std::index_sequence<Is...>) {
@@ -124,42 +147,32 @@ public:
 	static void Execute(std::array<VectorRef, sizeof...(ARGS)> inputs, Vector &result, FUN fun) {
 		auto count = CheckExecuteCount(inputs);
 		VariadicLambdaAdapter<RESULT_TYPE, FUN, ARGS...> adapter(fun);
-		ScalarExecutor::Execute<SpecializeFlat<ARGS...>(), false, false, RESULT_TYPE, decltype(adapter), ARGS...>(
-		    inputs, result, count, adapter);
+		ScalarExecutor::Execute<ExecutePolicy<ARGS...>, RESULT_TYPE, decltype(adapter), ARGS...>(inputs, result, count,
+		                                                                                         adapter);
 	}
 
 	template <class RESULT_TYPE, class... ARGS, class FUN>
 	static void Execute(DataChunk &input, Vector &result, FUN fun) {
 		auto inputs = MakeInputArray<sizeof...(ARGS)>(input);
 		VariadicLambdaAdapter<RESULT_TYPE, FUN, ARGS...> adapter(fun);
-		ScalarExecutor::Execute<SpecializeFlat<ARGS...>(), false, false, RESULT_TYPE, decltype(adapter), ARGS...>(
-		    inputs, result, input.size(), adapter);
+		ScalarExecutor::Execute<ExecutePolicy<ARGS...>, RESULT_TYPE, decltype(adapter), ARGS...>(inputs, result,
+		                                                                                         input.size(), adapter);
 	}
 
 	template <class RESULT_TYPE, class OP, class... ARGS>
 	static void ExecuteStandard(std::array<VectorRef, sizeof...(ARGS)> inputs, Vector &result) {
 		auto count = CheckExecuteCount(inputs);
 		VariadicStandardAdapter<RESULT_TYPE, OP, ARGS...> adapter;
-		ScalarExecutor::Execute<SpecializeFlat<ARGS...>(), false, false, RESULT_TYPE, decltype(adapter), ARGS...>(
-		    inputs, result, count, adapter);
+		ScalarExecutor::Execute<ExecutePolicy<ARGS...>, RESULT_TYPE, decltype(adapter), ARGS...>(inputs, result, count,
+		                                                                                         adapter);
 	}
 
 	template <class OP, class... ARGS>
 	static idx_t Select(std::array<VectorRef, sizeof...(ARGS)> inputs, const SelectionVector *sel, idx_t count,
 	                    SelectionVector *true_sel, SelectionVector *false_sel) {
 		VariadicSelectAdapter<OP, ARGS...> adapter;
-#if !DUCKDB_SMALLER_BINARY(variadic_executor_select_flat)
-		static constexpr uint64_t SPECIALIZED_MASKS = SpecializeFlat<ARGS...>() ? 1 : 0;
-#else
-		static constexpr uint64_t SPECIALIZED_MASKS = 0;
-#endif
-#if !DUCKDB_SMALLER_BINARY(variadic_executor_select_flags)
-		static constexpr bool SPECIALIZE_OUTPUTS = true;
-#else
-		static constexpr bool SPECIALIZE_OUTPUTS = false;
-#endif
-		return ScalarExecutor::Select<SPECIALIZED_MASKS, SPECIALIZE_OUTPUTS, decltype(adapter), ARGS...>(
-		    inputs, sel, count, true_sel, false_sel, adapter);
+		return ScalarExecutor::Select<SelectPolicy<ARGS...>, decltype(adapter), ARGS...>(inputs, sel, count, true_sel,
+		                                                                                 false_sel, adapter);
 	}
 };
 

--- a/src/include/duckdb/common/vector_operations/variadic_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/variadic_executor.hpp
@@ -3,26 +3,24 @@
 //
 // duckdb/common/vector_operations/variadic_executor.hpp
 //
-//
 //===----------------------------------------------------------------------===//
 
 #pragma once
 
 #include "duckdb/common/optional.hpp"
+#include "duckdb/common/smaller_binary.hpp"
 #include "duckdb/common/types/data_chunk.hpp"
-#include "duckdb/common/types/vector.hpp"
-#include "duckdb/common/vector/constant_vector.hpp"
-#include "duckdb/common/vector/flat_vector.hpp"
+#include "duckdb/common/vector_operations/scalar_executor.hpp"
 
 #include <array>
 #include <functional>
 #include <tuple>
+#include <type_traits>
 
 namespace duckdb {
 
 //! Wrappers that adapt different calling conventions to a uniform interface.
 //! Each wrapper's Operation method takes: (FUN, ValidityMask&, idx_t, ARGS...)
-
 struct VariadicLambdaWrapper {
 	template <class FUN, class RESULT_TYPE, class... ARGS>
 	static inline RESULT_TYPE Operation(FUN &fun, ValidityMask &mask, idx_t idx, ARGS... args) {
@@ -47,18 +45,51 @@ struct VariadicStandardOperatorWrapper {
 	}
 };
 
-//! VariadicExecutor: a unified executor for any number of input vectors.
-//! Uses C++17 fold expressions and std::index_sequence to generalize the
-//! pattern shared by TernaryExecutor, SenaryExecutor, and SeptenaryExecutor.
-//!
-//! Template parameter ordering: <RESULT_TYPE, INPUT_TYPES...>
-//! This differs from TernaryExecutor's <INPUT_TYPES..., RESULT_TYPE> because
-//! a parameter pack must be last (or followed only by deducible params).
-//! The named executors (TernaryExecutor, etc.) provide backward-compatible APIs.
+template <class RESULT_TYPE, class FUN, class... ARGS>
+struct VariadicLambdaAdapter {
+	static constexpr bool ADDS_NULLS =
+	    std::is_same<std::invoke_result_t<FUN &, ARGS &...>, optional<RESULT_TYPE>>::value;
+
+	explicit VariadicLambdaAdapter(FUN &fun_p) : fun(fun_p) {
+	}
+
+	inline RESULT_TYPE Operation(ValidityMask &mask, idx_t idx, ARGS... args) {
+		return VariadicLambdaWrapper::template Operation<FUN, RESULT_TYPE, ARGS...>(fun, mask, idx, args...);
+	}
+
+	FUN &fun;
+};
+
+template <class RESULT_TYPE, class OP, class... ARGS>
+struct VariadicStandardAdapter {
+	static constexpr bool ADDS_NULLS = false;
+
+	inline RESULT_TYPE Operation(ValidityMask &mask, idx_t idx, ARGS... args) {
+		return VariadicStandardOperatorWrapper<OP>::template Operation<bool, RESULT_TYPE, ARGS...>(dummy, mask, idx,
+		                                                                                           args...);
+	}
+
+	bool dummy = false;
+};
+
+template <class OP, class... ARGS>
+struct VariadicSelectAdapter {
+	inline bool Operation(ARGS... args) {
+		return OP::Operation(args...);
+	}
+};
+
+//! VariadicExecutor is the generic public facade over ScalarExecutor.
+//! Template parameter ordering remains <RESULT_TYPE, INPUT_TYPES...>.
 struct VariadicExecutor {
-	using VectorRef = std::reference_wrapper<const Vector>;
+	using VectorRef = ScalarExecutor::VectorRef;
 
 private:
+	template <class... ARGS>
+	static constexpr bool SpecializeFlat() {
+		return sizeof...(ARGS) <= 3 && (... && std::is_arithmetic<ARGS>::value);
+	}
+
 	template <size_t N, size_t... Is>
 	static std::array<VectorRef, N> MakeInputArrayImpl(DataChunk &input, std::index_sequence<Is...>) {
 		return {{std::cref(input.data[Is])...}};
@@ -71,155 +102,10 @@ private:
 	}
 
 	template <size_t N>
-	static bool AllConstant(const std::array<VectorRef, N> &inputs) {
-		for (size_t i = 0; i < N; i++) {
-			if (inputs[i].get().GetVectorType() != VectorType::CONSTANT_VECTOR) {
-				return false;
-			}
-		}
-		return true;
-	}
-
-	template <size_t N>
-	static bool AnyConstantNull(const std::array<VectorRef, N> &inputs) {
-		for (size_t i = 0; i < N; i++) {
-			if (ConstantVector::IsNull(inputs[i].get())) {
-				return true;
-			}
-		}
-		return false;
-	}
-
-	//-------------------------------------------------------------------
-	// Execute implementation
-	//-------------------------------------------------------------------
-	template <class RESULT_TYPE, class OPWRAPPER, class FUN, class... ARGS, size_t... Is>
-	static void ExecuteImplWithIndices(std::array<VectorRef, sizeof...(ARGS)> &inputs, Vector &result, idx_t count,
-	                                   FUN fun, std::index_sequence<Is...>) {
-		constexpr size_t N = sizeof...(ARGS);
-
-		if (AllConstant<N>(inputs)) {
-			result.SetVectorType(VectorType::CONSTANT_VECTOR);
-			FlatVector::SetSize(result, count);
-			if (AnyConstantNull<N>(inputs)) {
-				ConstantVector::SetNull(result, true);
-			} else {
-				auto result_data = ConstantVector::GetData<RESULT_TYPE>(result);
-				result_data[0] = OPWRAPPER::template Operation<FUN, RESULT_TYPE, ARGS...>(
-				    fun, ConstantVector::Validity(result), 0, *ConstantVector::GetData<ARGS>(inputs[Is].get())...);
-			}
-		} else {
-			result.SetVectorType(VectorType::FLAT_VECTOR);
-			auto result_data = FlatVector::GetDataMutable<RESULT_TYPE>(result);
-			auto &result_validity = FlatVector::ValidityMutable(result);
-
-			std::array<UnifiedVectorFormat, N> vdata;
-			for (size_t i = 0; i < N; i++) {
-				inputs[i].get().ToUnifiedFormat(vdata[i]);
-			}
-
-			auto data_ptrs = std::make_tuple(UnifiedVectorFormat::GetData<ARGS>(vdata[Is])...);
-
-			if ((... || vdata[Is].validity.CanHaveNull())) {
-				for (idx_t i = 0; i < count; i++) {
-					std::array<idx_t, N> idxs = {{vdata[Is].sel->get_index(i)...}};
-					if ((... && vdata[Is].validity.RowIsValid(idxs[Is]))) {
-						result_data[i] = OPWRAPPER::template Operation<FUN, RESULT_TYPE, ARGS...>(
-						    fun, result_validity, i, std::get<Is>(data_ptrs)[idxs[Is]]...);
-					} else {
-						result_validity.SetInvalid(i);
-					}
-				}
-			} else {
-				for (idx_t i = 0; i < count; i++) {
-					result_data[i] = OPWRAPPER::template Operation<FUN, RESULT_TYPE, ARGS...>(
-					    fun, result_validity, i, std::get<Is>(data_ptrs)[vdata[Is].sel->get_index(i)]...);
-				}
-			}
-			FlatVector::SetSize(result, count);
-		}
-	}
-
-	//-------------------------------------------------------------------
-	// Select implementation
-	//-------------------------------------------------------------------
-	template <class OP, bool NO_NULL, bool HAS_TRUE_SEL, bool HAS_FALSE_SEL, class... ARGS, size_t... Is>
-	static idx_t SelectLoopImpl(std::tuple<const ARGS *...> &data_ptrs,
-	                            std::array<UnifiedVectorFormat, sizeof...(ARGS)> &vdata,
-	                            const SelectionVector *result_sel, idx_t count, SelectionVector *true_sel,
-	                            SelectionVector *false_sel, std::index_sequence<Is...>) {
-		constexpr size_t N = sizeof...(ARGS);
-		idx_t true_count = 0, false_count = 0;
-		for (idx_t i = 0; i < count; i++) {
-			auto result_idx = result_sel->get_index(i);
-			std::array<idx_t, N> idxs = {{vdata[Is].sel->get_index(i)...}};
-			bool comparison_result = (NO_NULL || (... && vdata[Is].validity.RowIsValid(idxs[Is]))) &&
-			                         OP::Operation(std::get<Is>(data_ptrs)[idxs[Is]]...);
-			if (HAS_TRUE_SEL) {
-				true_sel->set_index(true_count, result_idx);
-				true_count += comparison_result;
-			}
-			if (HAS_FALSE_SEL) {
-				false_sel->set_index(false_count, result_idx);
-				false_count += !comparison_result;
-			}
-		}
-		if (HAS_TRUE_SEL) {
-			return true_count;
-		}
-		return count - false_count;
-	}
-
-	template <class OP, bool NO_NULL, class... ARGS, size_t... Is>
-	static idx_t SelectLoopSelSwitch(std::tuple<const ARGS *...> &data_ptrs,
-	                                 std::array<UnifiedVectorFormat, sizeof...(ARGS)> &vdata,
-	                                 const SelectionVector *sel, idx_t count, SelectionVector *true_sel,
-	                                 SelectionVector *false_sel, std::index_sequence<Is...> indices) {
-		if (true_sel && false_sel) {
-			return SelectLoopImpl<OP, NO_NULL, true, true, ARGS...>(data_ptrs, vdata, sel, count, true_sel, false_sel,
-			                                                        indices);
-		} else if (true_sel) {
-			return SelectLoopImpl<OP, NO_NULL, true, false, ARGS...>(data_ptrs, vdata, sel, count, true_sel, false_sel,
-			                                                         indices);
-		} else {
-			D_ASSERT(false_sel);
-			return SelectLoopImpl<OP, NO_NULL, false, true, ARGS...>(data_ptrs, vdata, sel, count, true_sel, false_sel,
-			                                                         indices);
-		}
-	}
-
-	template <class OP, class... ARGS, size_t... Is>
-	static idx_t SelectImplWithIndices(std::array<VectorRef, sizeof...(ARGS)> &inputs, const SelectionVector *sel,
-	                                   idx_t count, SelectionVector *true_sel, SelectionVector *false_sel,
-	                                   std::index_sequence<Is...> indices) {
-		constexpr size_t N = sizeof...(ARGS);
-		if (!sel) {
-			sel = FlatVector::IncrementalSelectionVector();
-		}
-
-		std::array<UnifiedVectorFormat, N> vdata;
-		for (size_t i = 0; i < N; i++) {
-			inputs[i].get().ToUnifiedFormat(vdata[i]);
-		}
-
-		auto data_ptrs = std::make_tuple(UnifiedVectorFormat::GetData<ARGS>(vdata[Is])...);
-
-		if ((... || vdata[Is].validity.CanHaveNull())) {
-			return SelectLoopSelSwitch<OP, false, ARGS...>(data_ptrs, vdata, sel, count, true_sel, false_sel, indices);
-		} else {
-			return SelectLoopSelSwitch<OP, true, ARGS...>(data_ptrs, vdata, sel, count, true_sel, false_sel, indices);
-		}
-	}
-
-private:
-	//-------------------------------------------------------------------
-	// Verify all inputs have the same size and return that size.
-	//-------------------------------------------------------------------
-	template <size_t N>
 	static idx_t CheckExecuteCount(const std::array<VectorRef, N> &inputs) {
 		static_assert(N > 0, "VariadicExecutor requires at least one input");
 		idx_t count = inputs[0].get().size();
-		for (size_t i = 1; i < N; i++) {
+		for (idx_t i = 1; i < N; i++) {
 			if (inputs[i].get().size() != count) {
 				throw InternalException(
 				    "Mismatch in input vector sizes for VariadicExecutor - expected %d rows but got %d", count,
@@ -230,47 +116,41 @@ private:
 	}
 
 public:
-	//-------------------------------------------------------------------
-	// Execute: lambda-based, with Vector array
-	//-------------------------------------------------------------------
 	template <class RESULT_TYPE, class... ARGS, class FUN>
 	static void Execute(std::array<VectorRef, sizeof...(ARGS)> inputs, Vector &result, FUN fun) {
-		constexpr size_t N = sizeof...(ARGS);
-		const idx_t count = CheckExecuteCount<N>(inputs);
-		ExecuteImplWithIndices<RESULT_TYPE, VariadicLambdaWrapper, FUN, ARGS...>(inputs, result, count, fun,
-		                                                                         std::index_sequence_for<ARGS...> {});
+		auto count = CheckExecuteCount(inputs);
+		VariadicLambdaAdapter<RESULT_TYPE, FUN, ARGS...> adapter(fun);
+		ScalarExecutor::Execute<SpecializeFlat<ARGS...>(), false, false, RESULT_TYPE, decltype(adapter), ARGS...>(
+		    inputs, result, count, adapter);
 	}
 
-	//-------------------------------------------------------------------
-	// Execute: lambda-based, with DataChunk
-	//-------------------------------------------------------------------
 	template <class RESULT_TYPE, class... ARGS, class FUN>
 	static void Execute(DataChunk &input, Vector &result, FUN fun) {
 		auto inputs = MakeInputArray<sizeof...(ARGS)>(input);
-		ExecuteImplWithIndices<RESULT_TYPE, VariadicLambdaWrapper, FUN, ARGS...>(inputs, result, input.size(), fun,
-		                                                                         std::index_sequence_for<ARGS...> {});
+		VariadicLambdaAdapter<RESULT_TYPE, FUN, ARGS...> adapter(fun);
+		ScalarExecutor::Execute<SpecializeFlat<ARGS...>(), false, false, RESULT_TYPE, decltype(adapter), ARGS...>(
+		    inputs, result, input.size(), adapter);
 	}
 
-	//-------------------------------------------------------------------
-	// ExecuteStandard: static OP::Operation, with Vector array
-	//-------------------------------------------------------------------
 	template <class RESULT_TYPE, class OP, class... ARGS>
 	static void ExecuteStandard(std::array<VectorRef, sizeof...(ARGS)> inputs, Vector &result) {
-		constexpr size_t N = sizeof...(ARGS);
-		const idx_t count = CheckExecuteCount<N>(inputs);
-		bool dummy = false;
-		ExecuteImplWithIndices<RESULT_TYPE, VariadicStandardOperatorWrapper<OP>, bool, ARGS...>(
-		    inputs, result, count, dummy, std::index_sequence_for<ARGS...> {});
+		auto count = CheckExecuteCount(inputs);
+		VariadicStandardAdapter<RESULT_TYPE, OP, ARGS...> adapter;
+		ScalarExecutor::Execute<SpecializeFlat<ARGS...>(), false, false, RESULT_TYPE, decltype(adapter), ARGS...>(
+		    inputs, result, count, adapter);
 	}
 
-	//-------------------------------------------------------------------
-	// Select: OP::Operation returns bool, with Vector array
-	//-------------------------------------------------------------------
 	template <class OP, class... ARGS>
 	static idx_t Select(std::array<VectorRef, sizeof...(ARGS)> inputs, const SelectionVector *sel, idx_t count,
 	                    SelectionVector *true_sel, SelectionVector *false_sel) {
-		return SelectImplWithIndices<OP, ARGS...>(inputs, sel, count, true_sel, false_sel,
-		                                          std::index_sequence_for<ARGS...> {});
+		VariadicSelectAdapter<OP, ARGS...> adapter;
+#if !DUCKDB_SMALLER_BINARY(variadic_executor_select_flat)
+		static constexpr uint64_t SPECIALIZED_MASKS = SpecializeFlat<ARGS...>() ? 1 : 0;
+#else
+		static constexpr uint64_t SPECIALIZED_MASKS = 0;
+#endif
+		return ScalarExecutor::Select<SPECIALIZED_MASKS, false, decltype(adapter), ARGS...>(
+		    inputs, sel, count, true_sel, false_sel, adapter);
 	}
 };
 

--- a/src/include/duckdb/common/vector_operations/variadic_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/variadic_executor.hpp
@@ -77,6 +77,10 @@ struct VariadicSelectAdapter {
 	inline bool Operation(ARGS... args) {
 		return OP::Operation(args...);
 	}
+
+	inline bool OperationNoNull(ARGS... args) {
+		return Operation(args...);
+	}
 };
 
 //! VariadicExecutor is the generic public facade over ScalarExecutor.

--- a/test/common/CMakeLists.txt
+++ b/test/common/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library_unity(
   test_parse_load_statement.cpp
   test_parse_logical_type.cpp
   test_recursive_cte_metrics.cpp
+  test_scalar_executor.cpp
   test_logical_type_is_complete.cpp
   test_utf.cpp
   test_allocator_debug_info.cpp

--- a/test/common/CMakeLists.txt
+++ b/test/common/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library_unity(
   test_parse_expression.cpp
   test_parse_load_statement.cpp
   test_parse_logical_type.cpp
+  test_scalar_executor.cpp
   test_logical_type_is_complete.cpp
   test_utf.cpp
   test_allocator_debug_info.cpp

--- a/test/common/test_scalar_executor.cpp
+++ b/test/common/test_scalar_executor.cpp
@@ -501,6 +501,10 @@ TEST_CASE("Scalar selection preserves result mappings and NULL semantics", "[sca
 	for (idx_t row = 0; row < COUNT; row++) {
 		REQUIRE(false_sel.get_index(row) == input_sel.get_index(row));
 	}
+	REQUIRE(BinaryExecutor::Select<int64_t, int64_t, LessThan>(constant_null, right, &input_sel, COUNT, &true_sel,
+	                                                           nullptr) == 0);
+	REQUIRE(BinaryExecutor::Select<int64_t, int64_t, LessThan>(left, constant_null, &input_sel, COUNT, &true_sel,
+	                                                           nullptr) == 0);
 
 	REQUIRE(BinaryExecutor::Select<int64_t, int64_t, LessThan>(left, right, nullptr, 0, &true_sel, &false_sel) == 0);
 #ifndef DUCKDB_CRASH_ON_ASSERT
@@ -533,6 +537,14 @@ TEST_CASE("Scalar selection preserves result mappings and NULL semantics", "[sca
 			}
 		}
 	}
+
+	auto null_bound = MakeNullConstantVector(COUNT);
+	std::array<VariadicExecutor::VectorRef, 3> null_lower_inputs = {{left, null_bound, right_constant}};
+	std::array<VariadicExecutor::VectorRef, 3> null_upper_inputs = {{left, middle, null_bound}};
+	REQUIRE(VariadicExecutor::Select<TernaryLessThanSum, int64_t, int64_t, int64_t>(null_lower_inputs, &input_sel,
+	                                                                                COUNT, &true_sel, nullptr) == 0);
+	REQUIRE(VariadicExecutor::Select<TernaryLessThanSum, int64_t, int64_t, int64_t>(null_upper_inputs, &input_sel,
+	                                                                                COUNT, &true_sel, nullptr) == 0);
 }
 
 TEST_CASE("Binary comparison folding remains correct on dictionaries", "[scalar_executor]") {

--- a/test/common/test_scalar_executor.cpp
+++ b/test/common/test_scalar_executor.cpp
@@ -545,6 +545,9 @@ TEST_CASE("Executor facade operation conventions remain compatible", "[scalar_ex
 }
 
 TEST_CASE("Executor facades preserve vector-size errors", "[scalar_executor]") {
+#ifdef DUCKDB_CRASH_ON_ASSERT
+	return;
+#endif
 	auto short_vector = MakeFlatVector(3);
 	auto long_vector = MakeFlatVector(4);
 	Vector result(LogicalType::BIGINT, 4);

--- a/test/common/test_scalar_executor.cpp
+++ b/test/common/test_scalar_executor.cpp
@@ -497,6 +497,65 @@ TEST_CASE("Binary comparison folding remains correct on dictionaries", "[scalar_
 	}
 }
 
+TEST_CASE("Binary generic-constant selection preserves comparison folding", "[scalar_executor]") {
+	static constexpr idx_t COUNT = 12;
+	auto child = MakeFlatVector(COUNT, 0);
+	SelectionVector dictionary_sel(COUNT);
+	SelectionVector input_sel(COUNT);
+	for (idx_t row = 0; row < COUNT; row++) {
+		dictionary_sel.set_index(row, COUNT - row - 1);
+		input_sel.set_index(row, row * 3 + 1);
+	}
+	Vector dictionary(LogicalType::BIGINT, COUNT);
+	dictionary.Slice(child, dictionary_sel, COUNT);
+	auto constant = MakeConstantVector(COUNT, 5);
+	auto null_constant = MakeConstantVector(COUNT, 5);
+	ConstantVector::SetNull(null_constant, true);
+
+	for (bool nullable : {false, true}) {
+		if (nullable) {
+			FlatVector::ValidityMutable(child).SetInvalid(3);
+			dictionary.Slice(child, dictionary_sel, COUNT);
+		}
+		for (bool constant_is_null : {false, true}) {
+			auto &constant_input = constant_is_null ? null_constant : constant;
+			for (bool constant_left : {false, true}) {
+				for (idx_t output_mode = 0; output_mode < 3; output_mode++) {
+					SelectionVector true_sel(COUNT);
+					SelectionVector false_sel(COUNT);
+					auto true_ptr = output_mode == 1 ? nullptr : &true_sel;
+					auto false_ptr = output_mode == 0 ? nullptr : &false_sel;
+					auto true_count = constant_left
+					                      ? BinaryExecutor::Select<int64_t, int64_t, GreaterThanEquals>(
+					                            constant_input, dictionary, &input_sel, COUNT, true_ptr, false_ptr)
+					                      : BinaryExecutor::Select<int64_t, int64_t, GreaterThanEquals>(
+					                            dictionary, constant_input, &input_sel, COUNT, true_ptr, false_ptr);
+					idx_t expected_true_count = 0;
+					idx_t expected_false_count = 0;
+					for (idx_t row = 0; row < COUNT; row++) {
+						auto child_index = dictionary_sel.get_index(row);
+						bool valid = !constant_is_null && (!nullable || child_index != 3);
+						bool selected = valid && (constant_left ? 5 >= child_index : child_index >= 5);
+						if (selected) {
+							if (true_ptr) {
+								REQUIRE(true_sel.get_index(expected_true_count) == input_sel.get_index(row));
+							}
+							expected_true_count++;
+						} else {
+							if (false_ptr) {
+								REQUIRE(false_sel.get_index(expected_false_count) == input_sel.get_index(row));
+							}
+							expected_false_count++;
+						}
+					}
+					REQUIRE(true_count == expected_true_count);
+					REQUIRE(expected_true_count + expected_false_count == COUNT);
+				}
+			}
+		}
+	}
+}
+
 TEST_CASE("Executor facade operation conventions remain compatible", "[scalar_executor]") {
 	static constexpr idx_t COUNT = 4;
 	auto a = MakeFlatVector(COUNT, 1);

--- a/test/common/test_scalar_executor.cpp
+++ b/test/common/test_scalar_executor.cpp
@@ -449,6 +449,29 @@ TEST_CASE("Scalar selection preserves result mappings and NULL semantics", "[sca
 	}
 	SelectionVector true_sel(COUNT);
 	SelectionVector false_sel(COUNT);
+	for (idx_t output_mode = 0; output_mode < 3; output_mode++) {
+		auto true_ptr = output_mode == 1 ? nullptr : &true_sel;
+		auto false_ptr = output_mode == 0 ? nullptr : &false_sel;
+		auto unary_true_count = UnaryExecutor::Select<int64_t>(
+		    left, &input_sel, COUNT, [](int64_t value) { return value < 5; }, true_ptr, false_ptr);
+		REQUIRE(unary_true_count == 4);
+		idx_t true_index = 0;
+		idx_t false_index = 0;
+		for (idx_t row = 0; row < COUNT; row++) {
+			bool selected = row < 5 && row != 2;
+			if (selected) {
+				if (true_ptr) {
+					REQUIRE(true_sel.get_index(true_index) == input_sel.get_index(row));
+				}
+				true_index++;
+			} else {
+				if (false_ptr) {
+					REQUIRE(false_sel.get_index(false_index) == input_sel.get_index(row));
+				}
+				false_index++;
+			}
+		}
+	}
 
 	auto true_count =
 	    BinaryExecutor::Select<int64_t, int64_t, LessThan>(left, right, &input_sel, COUNT, &true_sel, &false_sel);

--- a/test/common/test_scalar_executor.cpp
+++ b/test/common/test_scalar_executor.cpp
@@ -443,7 +443,9 @@ TEST_CASE("Scalar selection preserves result mappings and NULL semantics", "[sca
 	}
 
 	REQUIRE(BinaryExecutor::Select<int64_t, int64_t, LessThan>(left, right, nullptr, 0, &true_sel, &false_sel) == 0);
+#ifndef DUCKDB_CRASH_ON_ASSERT
 	REQUIRE_THROWS(BinaryExecutor::Select<int64_t, int64_t, LessThan>(left, right, nullptr, COUNT, nullptr, nullptr));
+#endif
 
 	auto middle = MakeFlatVector(COUNT, 10);
 	auto right_flat = MakeFlatVector(COUNT, 1);

--- a/test/common/test_scalar_executor.cpp
+++ b/test/common/test_scalar_executor.cpp
@@ -259,6 +259,43 @@ TEST_CASE("Scalar executor preserves pre-seeded and aliased unary validity", "[s
 	RequireValue(result, 2, 13);
 }
 
+TEST_CASE("Scalar executor generic validity stays isolated across mapped result reuse", "[scalar_executor]") {
+	static constexpr idx_t COUNT = 12;
+	auto child = MakeFlatVector(COUNT, 10);
+	FlatVector::ValidityMutable(child).SetInvalid(4);
+	SelectionVector sel(COUNT);
+	for (idx_t row = 0; row < COUNT; row++) {
+		sel.set_index(row, (row * 5 + 3) % COUNT);
+	}
+	Vector dictionary(LogicalType::BIGINT, COUNT);
+	dictionary.Slice(child, sel, COUNT);
+	auto other = MakeFlatVector(COUNT, 100);
+	Vector result(LogicalType::BIGINT, COUNT);
+	FlatVector::ValidityMutable(result).Initialize(FlatVector::Validity(child));
+
+	BinaryExecutor::Execute<int64_t, int64_t, int64_t>(dictionary, other, result,
+	                                                   [](int64_t left, int64_t right) { return left + right; });
+	RequireNull(result, 5);
+	RequireValue(result, 0, 113);
+	FlatVector::ValidityMutable(result).SetInvalid(0);
+	RequireValue(child, 0, 10);
+
+	FlatVector::ValidityMutable(child).SetValid(4);
+	BinaryExecutor::Execute<int64_t, int64_t, int64_t>(dictionary, other, result,
+	                                                   [](int64_t left, int64_t right) { return left + right; });
+	RequireValue(result, 0, 113);
+	RequireValue(result, 5, 119);
+
+	FlatVector::ValidityMutable(child).SetInvalid(4);
+	FlatVector::ValidityMutable(result).Initialize(FlatVector::Validity(child));
+	UnaryExecutor::Execute<int64_t, int64_t>(dictionary, result, [](int64_t input) -> optional<int64_t> {
+		return input == 17 ? optional<int64_t>() : input + 1;
+	});
+	RequireNull(result, 5);
+	RequireNull(result, 8);
+	RequireValue(child, 7, 17);
+}
+
 TEST_CASE("Scalar executor generic fallback preserves dictionary mappings", "[scalar_executor]") {
 	static constexpr idx_t COUNT = 12;
 	auto left_base = MakeFlatVector(COUNT, 20);
@@ -447,16 +484,31 @@ TEST_CASE("Scalar selection preserves result mappings and NULL semantics", "[sca
 	REQUIRE_THROWS(BinaryExecutor::Select<int64_t, int64_t, LessThan>(left, right, nullptr, COUNT, nullptr, nullptr));
 #endif
 
-	auto middle = MakeFlatVector(COUNT, 10);
-	auto right_flat = MakeFlatVector(COUNT, 1);
-	for (idx_t row = 0; row < COUNT; row++) {
-		FlatVector::ValidityMutable(left).SetInvalid(row);
-	}
-	std::array<VariadicExecutor::VectorRef, 3> ternary_inputs = {{left, middle, right_flat}};
-	REQUIRE(VariadicExecutor::Select<TernaryLessThanSum, int64_t, int64_t, int64_t>(ternary_inputs, &input_sel, COUNT,
-	                                                                                &true_sel, &false_sel) == 0);
-	for (idx_t row = 0; row < COUNT; row++) {
-		REQUIRE(false_sel.get_index(row) == input_sel.get_index(row));
+	auto middle = MakeConstantVector(COUNT, 5);
+	auto right_constant = MakeConstantVector(COUNT, 0);
+	std::array<VariadicExecutor::VectorRef, 3> ternary_inputs = {{left, middle, right_constant}};
+	for (idx_t output_mode = 0; output_mode < 3; output_mode++) {
+		auto true_ptr = output_mode == 1 ? nullptr : &true_sel;
+		auto false_ptr = output_mode == 0 ? nullptr : &false_sel;
+		auto ternary_true_count = VariadicExecutor::Select<TernaryLessThanSum, int64_t, int64_t, int64_t>(
+		    ternary_inputs, &input_sel, COUNT, true_ptr, false_ptr);
+		REQUIRE(ternary_true_count == 4);
+		idx_t true_index = 0;
+		idx_t false_index = 0;
+		for (idx_t row = 0; row < COUNT; row++) {
+			bool selected = row < 5 && row != 2;
+			if (selected) {
+				if (true_ptr) {
+					REQUIRE(true_sel.get_index(true_index) == input_sel.get_index(row));
+				}
+				true_index++;
+			} else {
+				if (false_ptr) {
+					REQUIRE(false_sel.get_index(false_index) == input_sel.get_index(row));
+				}
+				false_index++;
+			}
+		}
 	}
 }
 

--- a/test/common/test_scalar_executor.cpp
+++ b/test/common/test_scalar_executor.cpp
@@ -1,0 +1,559 @@
+#include "catch.hpp"
+#include "duckdb/common/operator/comparison_operators.hpp"
+#include "duckdb/common/types/string_heap.hpp"
+#include "duckdb/common/vector/flat_vector.hpp"
+#include "duckdb/common/vector_operations/binary_executor.hpp"
+#include "duckdb/common/vector_operations/ternary_executor.hpp"
+#include "duckdb/common/vector_operations/unary_executor.hpp"
+#include "duckdb/common/vector_operations/variadic_executor.hpp"
+
+using namespace duckdb; // NOLINT
+
+namespace {
+
+static Vector MakeFlatVector(idx_t count, int64_t offset = 0) {
+	Vector result(LogicalType::BIGINT, count);
+	auto data = FlatVector::GetDataMutable<int64_t>(result);
+	for (idx_t i = 0; i < count; i++) {
+		data[i] = NumericCast<int64_t>(i) + offset;
+	}
+	FlatVector::SetSize(result, count);
+	return result;
+}
+
+static Vector MakeConstantVector(idx_t count, int64_t value) {
+	return Vector(Value::BIGINT(value), count_t(count));
+}
+
+static Vector MakeNullConstantVector(idx_t count) {
+	return Vector(Value(LogicalType::BIGINT), count_t(count));
+}
+
+static void RequireValue(const Vector &vector, idx_t row, int64_t expected) {
+	auto value = vector.GetValue(row);
+	REQUIRE(!value.IsNull());
+	REQUIRE(value.GetValue<int64_t>() == expected);
+}
+
+static void RequireNull(const Vector &vector, idx_t row) {
+	REQUIRE(vector.GetValue(row).IsNull());
+}
+
+struct UnaryAddOne {
+	template <class INPUT_TYPE, class RESULT_TYPE>
+	static RESULT_TYPE Operation(INPUT_TYPE input) {
+		return input + 1;
+	}
+};
+
+struct UnaryGenericAdd {
+	template <class INPUT_TYPE, class RESULT_TYPE, class DATA_TYPE>
+	static RESULT_TYPE Operation(INPUT_TYPE input, ValidityMask &mask, idx_t row, DATA_TYPE &state) {
+		if (input == state.null_value) {
+			mask.SetInvalid(row);
+			return RESULT_TYPE();
+		}
+		return input + state.offset;
+	}
+};
+
+struct UnaryGenericState {
+	int64_t offset;
+	int64_t null_value;
+};
+
+struct UnaryStringCopy {
+	template <class INPUT_TYPE, class RESULT_TYPE>
+	static RESULT_TYPE Operation(INPUT_TYPE input, StringHeap &heap) {
+		return heap.AddString(input);
+	}
+};
+
+struct BinaryAdd {
+	template <class INPUT_TYPE>
+	static INPUT_TYPE Operation(INPUT_TYPE left, INPUT_TYPE right) {
+		return left + right;
+	}
+};
+
+struct BinaryTypedAdd {
+	template <class LEFT_TYPE, class RIGHT_TYPE, class RESULT_TYPE>
+	static RESULT_TYPE Operation(LEFT_TYPE left, RIGHT_TYPE right) {
+		return left + right;
+	}
+};
+
+struct RuntimeNullBinaryWrapper {
+	template <class FUNC, class OP, class LEFT_TYPE, class RIGHT_TYPE, class RESULT_TYPE>
+	static RESULT_TYPE Operation(FUNC &fun, LEFT_TYPE left, RIGHT_TYPE right, ValidityMask &mask, idx_t row) {
+		if (right == 2) {
+			mask.SetInvalid(row);
+			return RESULT_TYPE();
+		}
+		return left + right;
+	}
+
+	static bool AddsNulls() {
+		return true;
+	}
+};
+
+struct TernaryAdd {
+	template <class A_TYPE, class B_TYPE, class C_TYPE, class RESULT_TYPE>
+	static RESULT_TYPE Operation(A_TYPE a, B_TYPE b, C_TYPE c) {
+		return a + b + c;
+	}
+};
+
+struct TernaryLessThanSum {
+	template <class A_TYPE, class B_TYPE, class C_TYPE>
+	static bool Operation(A_TYPE a, B_TYPE b, C_TYPE c) {
+		return a < b + c;
+	}
+};
+
+struct QuaternaryAdd {
+	template <class A_TYPE, class B_TYPE, class C_TYPE, class D_TYPE, class RESULT_TYPE>
+	static RESULT_TYPE Operation(A_TYPE a, B_TYPE b, C_TYPE c, D_TYPE d) {
+		return a + b + c + d;
+	}
+};
+
+static bool Contains(const SelectionVector &sel, idx_t count, idx_t value) {
+	for (idx_t i = 0; i < count; i++) {
+		if (sel.get_index(i) == value) {
+			return true;
+		}
+	}
+	return false;
+}
+
+} // namespace
+
+TEST_CASE("Scalar executor handles every ternary flat and constant profile", "[scalar_executor]") {
+	static constexpr idx_t COUNT = 131;
+	for (uint8_t constant_mask = 0; constant_mask < 8; constant_mask++) {
+		auto a = (constant_mask & 1) ? MakeConstantVector(COUNT, 3) : MakeFlatVector(COUNT, 1);
+		auto b = (constant_mask & 2) ? MakeConstantVector(COUNT, 5) : MakeFlatVector(COUNT, 2);
+		auto c = (constant_mask & 4) ? MakeConstantVector(COUNT, 7) : MakeFlatVector(COUNT, 3);
+		Vector result(LogicalType::BIGINT, COUNT);
+
+		if (!(constant_mask & 1)) {
+			auto &validity = FlatVector::ValidityMutable(a);
+			validity.SetInvalid(0);
+			validity.SetInvalid(63);
+			validity.SetInvalid(65);
+			validity.SetInvalid(129);
+		}
+		if (!(constant_mask & 2)) {
+			auto &validity = FlatVector::ValidityMutable(b);
+			validity.SetInvalid(64);
+			validity.SetInvalid(65);
+			validity.SetInvalid(130);
+		}
+		if (!(constant_mask & 4)) {
+			auto &validity = FlatVector::ValidityMutable(c);
+			validity.SetInvalid(1);
+			validity.SetInvalid(128);
+		}
+
+		idx_t invocation_count = 0;
+		TernaryExecutor::Execute<int64_t, int64_t, int64_t, int64_t>(a, b, c, result,
+		                                                             [&](int64_t left, int64_t middle, int64_t right) {
+			                                                             invocation_count++;
+			                                                             return left + middle * right;
+		                                                             });
+
+		idx_t expected_invocations = 0;
+		for (idx_t row = 0; row < COUNT; row++) {
+			bool valid = ((constant_mask & 1) || (row != 0 && row != 63 && row != 65 && row != 129)) &&
+			             ((constant_mask & 2) || (row != 64 && row != 65 && row != 130)) &&
+			             ((constant_mask & 4) || (row != 1 && row != 128));
+			if (!valid) {
+				RequireNull(result, row);
+				continue;
+			}
+			expected_invocations++;
+			auto left = (constant_mask & 1) ? 3 : NumericCast<int64_t>(row) + 1;
+			auto middle = (constant_mask & 2) ? 5 : NumericCast<int64_t>(row) + 2;
+			auto right = (constant_mask & 4) ? 7 : NumericCast<int64_t>(row) + 3;
+			RequireValue(result, row, left + middle * right);
+		}
+		REQUIRE(invocation_count == (constant_mask == 7 ? 1 : expected_invocations));
+		REQUIRE(result.size() == COUNT);
+		REQUIRE(result.GetVectorType() == (constant_mask == 7 ? VectorType::CONSTANT_VECTOR : VectorType::FLAT_VECTOR));
+	}
+}
+
+TEST_CASE("Scalar executor clears stale validity in reused results", "[scalar_executor]") {
+	static constexpr idx_t COUNT = 130;
+	auto valid = MakeConstantVector(COUNT, 4);
+	auto null = MakeNullConstantVector(COUNT);
+	Vector result(LogicalType::BIGINT, COUNT);
+	idx_t invocation_count = 0;
+	auto operation = [&](int64_t input) {
+		invocation_count++;
+		return input + 1;
+	};
+
+	UnaryExecutor::Execute<int64_t, int64_t>(valid, result, operation);
+	RequireValue(result, 0, 5);
+	UnaryExecutor::Execute<int64_t, int64_t>(null, result, operation);
+	RequireNull(result, 0);
+	UnaryExecutor::Execute<int64_t, int64_t>(valid, result, operation);
+	RequireValue(result, 0, 5);
+	REQUIRE(invocation_count == 2);
+
+	auto flat = MakeFlatVector(COUNT, 10);
+	FlatVector::ValidityMutable(flat).SetInvalid(64);
+	UnaryExecutor::Execute<int64_t, int64_t>(flat, result, [](int64_t input) { return input; });
+	RequireNull(result, 64);
+	FlatVector::ValidityMutable(flat).SetValid(64);
+	UnaryExecutor::Execute<int64_t, int64_t>(flat, result, [](int64_t input) { return input; });
+	RequireValue(result, 64, 74);
+
+	UnaryExecutor::Execute<int64_t, int64_t>(flat, result, [](int64_t input) -> optional<int64_t> {
+		if (input == 75) {
+			return optional<int64_t>();
+		}
+		return input;
+	});
+	RequireNull(result, 65);
+	RequireValue(flat, 65, 75);
+	UnaryExecutor::Execute<int64_t, int64_t>(flat, result, [](int64_t input) -> optional<int64_t> { return input; });
+	RequireValue(result, 65, 75);
+}
+
+TEST_CASE("Scalar executor preserves pre-seeded and aliased unary validity", "[scalar_executor]") {
+	static constexpr idx_t COUNT = 8;
+	auto flat_input = MakeFlatVector(COUNT, 20);
+	Vector preseeded_result(LogicalType::BIGINT, COUNT);
+	FlatVector::ValidityMutable(preseeded_result).SetInvalid(4);
+	UnaryExecutor::Execute<int64_t, int64_t>(flat_input, preseeded_result, [](int64_t value) { return value + 1; });
+	RequireNull(preseeded_result, 4);
+	RequireValue(preseeded_result, 3, 24);
+	auto validity_owner = MakeFlatVector(COUNT);
+	FlatVector::ValidityMutable(validity_owner).SetInvalid(4);
+	FlatVector::ValidityMutable(preseeded_result).Initialize(FlatVector::Validity(validity_owner));
+	UnaryExecutor::Execute<int64_t, int64_t>(flat_input, preseeded_result, [](int64_t value) -> optional<int64_t> {
+		return value == 22 ? optional<int64_t>() : value;
+	});
+	REQUIRE(!validity_owner.GetValue(2).IsNull());
+	RequireNull(preseeded_result, 2);
+	RequireNull(preseeded_result, 4);
+
+	auto child = MakeFlatVector(COUNT, 10);
+	FlatVector::ValidityMutable(child).SetInvalid(3);
+	SelectionVector sel(COUNT);
+	for (idx_t row = 0; row < COUNT; row++) {
+		sel.set_index(row, row);
+	}
+	Vector input(LogicalType::BIGINT, COUNT);
+	input.Slice(child, sel, COUNT);
+	Vector result(LogicalType::BIGINT, COUNT);
+	FlatVector::ValidityMutable(result).Initialize(FlatVector::Validity(child));
+
+	UnaryExecutor::Execute<int64_t, int64_t>(input, result, [](int64_t value) { return value + 1; });
+	RequireNull(input, 3);
+	RequireNull(result, 3);
+	RequireValue(result, 2, 13);
+}
+
+TEST_CASE("Scalar executor generic fallback preserves dictionary mappings", "[scalar_executor]") {
+	static constexpr idx_t COUNT = 12;
+	auto left_base = MakeFlatVector(COUNT, 20);
+	auto right_base = MakeFlatVector(COUNT, 200);
+	SelectionVector left_sel(COUNT);
+	SelectionVector right_sel(COUNT);
+	for (idx_t row = 0; row < COUNT; row++) {
+		left_sel.set_index(row, (row * 5 + 3) % COUNT);
+		right_sel.set_index(row, COUNT - row - 1);
+	}
+	Vector left_dictionary(LogicalType::BIGINT, COUNT);
+	Vector right_dictionary(LogicalType::BIGINT, COUNT);
+	left_dictionary.Slice(left_base, left_sel, COUNT);
+	right_dictionary.Slice(right_base, right_sel, COUNT);
+	Vector result(LogicalType::BIGINT, COUNT);
+	auto add = [](int64_t left, int64_t right) {
+		return left + right;
+	};
+
+	BinaryExecutor::Execute<int64_t, int64_t, int64_t>(left_dictionary, right_base, result, add);
+	for (idx_t row = 0; row < COUNT; row++) {
+		RequireValue(result, row, NumericCast<int64_t>(left_sel.get_index(row)) + 20 + NumericCast<int64_t>(row) + 200);
+	}
+	BinaryExecutor::Execute<int64_t, int64_t, int64_t>(left_base, right_dictionary, result, add);
+	for (idx_t row = 0; row < COUNT; row++) {
+		RequireValue(result, row,
+		             NumericCast<int64_t>(row) + 20 + NumericCast<int64_t>(right_sel.get_index(row)) + 200);
+	}
+	BinaryExecutor::Execute<int64_t, int64_t, int64_t>(left_dictionary, right_dictionary, result, add);
+	for (idx_t row = 0; row < COUNT; row++) {
+		RequireValue(result, row,
+		             NumericCast<int64_t>(left_sel.get_index(row)) + 20 +
+		                 NumericCast<int64_t>(right_sel.get_index(row)) + 200);
+	}
+
+	auto base = MakeFlatVector(COUNT, 10);
+	FlatVector::ValidityMutable(base).SetInvalid(4);
+	SelectionVector first_sel(COUNT);
+	for (idx_t row = 0; row < COUNT; row++) {
+		first_sel.set_index(row, (row * 5 + 3) % COUNT);
+	}
+	Vector dictionary(LogicalType::BIGINT, COUNT);
+	dictionary.Slice(base, first_sel, COUNT);
+
+	SelectionVector second_sel(COUNT);
+	for (idx_t row = 0; row < COUNT; row++) {
+		second_sel.set_index(row, COUNT - row - 1);
+	}
+	dictionary.Slice(second_sel, COUNT);
+
+	auto other = MakeFlatVector(COUNT, 100);
+	BinaryExecutor::Execute<int64_t, int64_t, int64_t>(dictionary, other, result,
+	                                                   [](int64_t left, int64_t right) { return left + right; });
+	for (idx_t row = 0; row < COUNT; row++) {
+		auto first_row = COUNT - row - 1;
+		auto base_row = (first_row * 5 + 3) % COUNT;
+		if (base_row == 4) {
+			RequireNull(result, row);
+		} else {
+			RequireValue(result, row, NumericCast<int64_t>(base_row) + 10 + NumericCast<int64_t>(row) + 100);
+		}
+	}
+
+	std::array<VariadicExecutor::VectorRef, 4> inputs = {{dictionary, other, base, other}};
+	VariadicExecutor::Execute<int64_t, int64_t, int64_t, int64_t, int64_t>(
+	    inputs, result, [](int64_t a, int64_t b, int64_t c, int64_t d) { return a + b + c + d; });
+	for (idx_t row = 0; row < COUNT; row++) {
+		auto base_row = ((COUNT - row - 1) * 5 + 3) % COUNT;
+		if (base_row == 4 || row == 4) {
+			RequireNull(result, row);
+		} else {
+			RequireValue(result, row,
+			             NumericCast<int64_t>(base_row) + 10 + 2 * (NumericCast<int64_t>(row) + 100) +
+			                 NumericCast<int64_t>(row) + 10);
+		}
+	}
+}
+
+TEST_CASE("Unary dictionary execution respects error and reuse guards", "[scalar_executor]") {
+	static constexpr idx_t DICTIONARY_SIZE = 8;
+	static constexpr idx_t COUNT = 32;
+	auto child = MakeFlatVector(DICTIONARY_SIZE, 1);
+	auto child_data = FlatVector::GetDataMutable<int64_t>(child);
+	child_data[7] = -1;
+	FlatVector::ValidityMutable(child).SetInvalid(6);
+	SelectionVector sel(COUNT);
+	for (idx_t row = 0; row < COUNT; row++) {
+		sel.set_index(row, row % 3);
+	}
+	Vector dictionary(LogicalType::BIGINT, COUNT);
+	dictionary.Slice(child, sel, COUNT);
+	Vector result(LogicalType::BIGINT, COUNT);
+
+	idx_t domain_invocations = 0;
+	UnaryExecutor::Execute<int64_t, int64_t>(
+	    dictionary, result,
+	    [&](int64_t input) {
+		    domain_invocations++;
+		    return input * 2;
+	    },
+	    FunctionErrors::CANNOT_ERROR);
+#if !DUCKDB_SMALLER_BINARY(unary_executor_flat)
+	REQUIRE(domain_invocations == DICTIONARY_SIZE - 1);
+	REQUIRE(result.GetVectorType() == VectorType::DICTIONARY_VECTOR);
+#else
+	REQUIRE(domain_invocations == COUNT);
+	REQUIRE(result.GetVectorType() == VectorType::FLAT_VECTOR);
+#endif
+	for (idx_t row = 0; row < COUNT; row++) {
+		RequireValue(result, row, NumericCast<int64_t>((row % 3) + 1) * 2);
+	}
+
+	idx_t throwing_invocations = 0;
+	Vector throwing_result(LogicalType::BIGINT, COUNT);
+	REQUIRE_NOTHROW(UnaryExecutor::Execute<int64_t, int64_t>(dictionary, throwing_result, [&](int64_t input) {
+		throwing_invocations++;
+		if (input < 0) {
+			throw InvalidInputException("unreferenced dictionary value");
+		}
+		return input;
+	}));
+	REQUIRE(throwing_invocations == COUNT);
+
+	Vector optional_result(LogicalType::BIGINT, COUNT);
+	UnaryExecutor::Execute<int64_t, int64_t>(
+	    dictionary, optional_result,
+	    [](int64_t input) -> optional<int64_t> {
+		    if (input == 2) {
+			    return optional<int64_t>();
+		    }
+		    return input;
+	    },
+	    FunctionErrors::CANNOT_ERROR);
+	for (idx_t row = 0; row < COUNT; row++) {
+		if (row % 3 == 1) {
+			RequireNull(optional_result, row);
+		} else {
+			RequireValue(optional_result, row, NumericCast<int64_t>((row % 3) + 1));
+		}
+	}
+}
+
+TEST_CASE("Scalar selection preserves result mappings and NULL semantics", "[scalar_executor]") {
+	static constexpr idx_t COUNT = 10;
+	auto left = MakeFlatVector(COUNT, 0);
+	auto right = MakeConstantVector(COUNT, 5);
+	FlatVector::ValidityMutable(left).SetInvalid(2);
+	SelectionVector input_sel(COUNT);
+	for (idx_t row = 0; row < COUNT; row++) {
+		input_sel.set_index(row, 100 + ((row * 7) % COUNT));
+	}
+	SelectionVector true_sel(COUNT);
+	SelectionVector false_sel(COUNT);
+
+	auto true_count =
+	    BinaryExecutor::Select<int64_t, int64_t, LessThan>(left, right, &input_sel, COUNT, &true_sel, &false_sel);
+	REQUIRE(true_count == 4);
+	REQUIRE(Contains(true_sel, true_count, input_sel.get_index(0)));
+	REQUIRE(Contains(true_sel, true_count, input_sel.get_index(4)));
+	REQUIRE(Contains(false_sel, COUNT - true_count, input_sel.get_index(2)));
+	REQUIRE(Contains(false_sel, COUNT - true_count, input_sel.get_index(9)));
+
+	SelectionVector true_only(COUNT);
+	REQUIRE(BinaryExecutor::Select<int64_t, int64_t, LessThan>(left, right, &input_sel, COUNT, &true_only, nullptr) ==
+	        true_count);
+	for (idx_t row = 0; row < true_count; row++) {
+		REQUIRE(true_only.get_index(row) == true_sel.get_index(row));
+	}
+
+	SelectionVector false_only(COUNT);
+	REQUIRE(BinaryExecutor::Select<int64_t, int64_t, LessThan>(left, right, &input_sel, COUNT, nullptr, &false_only) ==
+	        true_count);
+	for (idx_t row = 0; row < COUNT - true_count; row++) {
+		REQUIRE(false_only.get_index(row) == false_sel.get_index(row));
+	}
+
+	auto constant_null = MakeNullConstantVector(COUNT);
+	REQUIRE(BinaryExecutor::Select<int64_t, int64_t, LessThan>(constant_null, right, &input_sel, COUNT, &true_sel,
+	                                                           &false_sel) == 0);
+	for (idx_t row = 0; row < COUNT; row++) {
+		REQUIRE(false_sel.get_index(row) == input_sel.get_index(row));
+	}
+
+	REQUIRE(BinaryExecutor::Select<int64_t, int64_t, LessThan>(left, right, nullptr, 0, &true_sel, &false_sel) == 0);
+	REQUIRE_THROWS(BinaryExecutor::Select<int64_t, int64_t, LessThan>(left, right, nullptr, COUNT, nullptr, nullptr));
+
+	auto middle = MakeFlatVector(COUNT, 10);
+	auto right_flat = MakeFlatVector(COUNT, 1);
+	for (idx_t row = 0; row < COUNT; row++) {
+		FlatVector::ValidityMutable(left).SetInvalid(row);
+	}
+	std::array<VariadicExecutor::VectorRef, 3> ternary_inputs = {{left, middle, right_flat}};
+	REQUIRE(VariadicExecutor::Select<TernaryLessThanSum, int64_t, int64_t, int64_t>(ternary_inputs, &input_sel, COUNT,
+	                                                                                &true_sel, &false_sel) == 0);
+	for (idx_t row = 0; row < COUNT; row++) {
+		REQUIRE(false_sel.get_index(row) == input_sel.get_index(row));
+	}
+}
+
+TEST_CASE("Binary comparison folding remains correct on dictionaries", "[scalar_executor]") {
+	static constexpr idx_t COUNT = 12;
+	auto left_child = MakeFlatVector(COUNT, 0);
+	auto right_child = MakeFlatVector(COUNT, 5);
+	SelectionVector dictionary_sel(COUNT);
+	for (idx_t row = 0; row < COUNT; row++) {
+		dictionary_sel.set_index(row, COUNT - row - 1);
+	}
+	Vector left(LogicalType::BIGINT, COUNT);
+	Vector right(LogicalType::BIGINT, COUNT);
+	left.Slice(left_child, dictionary_sel, COUNT);
+	right.Slice(right_child, dictionary_sel, COUNT);
+	SelectionVector input_sel(COUNT);
+	for (idx_t row = 0; row < COUNT; row++) {
+		input_sel.set_index(row, row * 3 + 1);
+	}
+
+	for (bool nullable : {false, true}) {
+		if (nullable) {
+			FlatVector::ValidityMutable(left_child).SetInvalid(3);
+			left.Slice(left_child, dictionary_sel, COUNT);
+		}
+		for (idx_t output_mode = 0; output_mode < 3; output_mode++) {
+			SelectionVector true_sel(COUNT);
+			SelectionVector false_sel(COUNT);
+			auto true_ptr = output_mode == 1 ? nullptr : &true_sel;
+			auto false_ptr = output_mode == 0 ? nullptr : &false_sel;
+			auto not_equal_count = BinaryExecutor::Select<int64_t, int64_t, NotEquals>(left, right, &input_sel, COUNT,
+			                                                                           true_ptr, false_ptr);
+			auto greater_equal_count = BinaryExecutor::Select<int64_t, int64_t, GreaterThanEquals>(
+			    left, right, &input_sel, COUNT, true_ptr, false_ptr);
+			REQUIRE(not_equal_count == COUNT - (nullable ? 1 : 0));
+			REQUIRE(greater_equal_count == 0);
+		}
+	}
+}
+
+TEST_CASE("Executor facade operation conventions remain compatible", "[scalar_executor]") {
+	static constexpr idx_t COUNT = 4;
+	auto a = MakeFlatVector(COUNT, 1);
+	auto b = MakeFlatVector(COUNT, 2);
+	auto c = MakeFlatVector(COUNT, 3);
+	auto d = MakeFlatVector(COUNT, 4);
+	Vector result(LogicalType::BIGINT, COUNT);
+
+	UnaryExecutor::Execute<int64_t, int64_t, UnaryAddOne>(a, result);
+	RequireValue(result, 0, 2);
+	UnaryGenericState state {10, 3};
+	UnaryExecutor::GenericExecute<int64_t, int64_t, UnaryGenericAdd>(a, result, state, true);
+	RequireValue(result, 0, 11);
+	RequireNull(result, 2);
+
+	Vector string_input(Value("executor"), count_t(COUNT));
+	Vector string_result(LogicalType::VARCHAR, COUNT);
+	UnaryExecutor::ExecuteString<string_t, string_t, UnaryStringCopy>(string_input, string_result);
+	REQUIRE(string_result.GetValue(0).ToString() == "executor");
+
+	BinaryExecutor::Execute<int64_t, int64_t, int64_t, BinaryAdd>(a, b, result);
+	RequireValue(result, 0, 3);
+	BinaryExecutor::ExecuteStandard<int64_t, int64_t, int64_t, BinaryTypedAdd>(a, b, result);
+	RequireValue(result, 0, 3);
+	BinaryExecutor::Execute<int64_t, int64_t, int64_t, BinaryAdd, RuntimeNullBinaryWrapper>(a, b, result);
+	RequireNull(result, 0);
+	RequireValue(result, 1, 5);
+
+	TernaryExecutor::ExecuteStandard<int64_t, int64_t, int64_t, int64_t, TernaryAdd>(a, b, c, result);
+	RequireValue(result, 0, 6);
+	TernaryExecutor::Execute<int64_t, int64_t, int64_t, int64_t>(
+	    a, b, c, result, [](int64_t left, int64_t middle, int64_t right) -> optional<int64_t> {
+		    if (left == 2) {
+			    return optional<int64_t>();
+		    }
+		    return left + middle + right;
+	    });
+	RequireNull(result, 1);
+
+	std::array<VariadicExecutor::VectorRef, 4> inputs = {{a, b, c, d}};
+	VariadicExecutor::ExecuteStandard<int64_t, QuaternaryAdd, int64_t, int64_t, int64_t, int64_t>(inputs, result);
+	RequireValue(result, 0, 10);
+	VariadicExecutor::Execute<int64_t, int64_t, int64_t, int64_t, int64_t>(
+	    inputs, result, [](int64_t w, int64_t x, int64_t y, int64_t z) { return w + x + y + z; });
+	RequireValue(result, 3, 22);
+}
+
+TEST_CASE("Executor facades preserve vector-size errors", "[scalar_executor]") {
+	auto short_vector = MakeFlatVector(3);
+	auto long_vector = MakeFlatVector(4);
+	Vector result(LogicalType::BIGINT, 4);
+	REQUIRE_THROWS(BinaryExecutor::Execute<int64_t, int64_t, int64_t>(
+	    short_vector, long_vector, result, [](int64_t left, int64_t right) { return left + right; }));
+
+	auto third = MakeFlatVector(3);
+	REQUIRE_THROWS(TernaryExecutor::Execute<int64_t, int64_t, int64_t, int64_t>(
+	    short_vector, long_vector, third, result, [](int64_t a, int64_t b, int64_t c) { return a + b + c; }));
+
+	std::array<VariadicExecutor::VectorRef, 4> inputs = {{short_vector, third, long_vector, third}};
+	REQUIRE_THROWS(VariadicExecutor::Execute<int64_t, int64_t, int64_t, int64_t, int64_t>(
+	    inputs, result, [](int64_t a, int64_t b, int64_t c, int64_t d) { return a + b + c + d; }));
+}

--- a/test/sql/function/test_scalar_executor.test
+++ b/test/sql/function/test_scalar_executor.test
@@ -1,0 +1,48 @@
+# name: test/sql/function/test_scalar_executor.test
+# description: Exercise scalar executor facades through representative SQL functions
+# group: [function]
+
+statement ok
+CREATE TABLE executor_input(i INTEGER, s VARCHAR);
+
+statement ok
+INSERT INTO executor_input VALUES (-3, 'aardvark'), (2, 'beta'), (NULL, NULL), (5, 'gamma');
+
+# Unary numeric/string execution and binary arithmetic over flat vectors.
+query ITI
+SELECT abs(i), upper(s), i + 10 FROM executor_input ORDER BY rowid;
+----
+3	AARDVARK	7
+2	BETA	12
+NULL	NULL	NULL
+5	GAMMA	15
+
+# The filter produces a dictionary input for the projection.
+query IT
+SELECT abs(i), upper(s) FROM executor_input WHERE i > 0 ORDER BY i;
+----
+2	BETA
+5	GAMMA
+
+# Ternary string execution, including NULL propagation.
+query T
+SELECT replace(s, 'a', 'x') FROM executor_input ORDER BY rowid;
+----
+xxrdvxrk
+betx
+NULL
+gxmmx
+
+# Unary optional-return execution.
+query T
+SELECT try_strptime(s, '%Y-%m-%d') FROM (VALUES ('2024-01-02'), ('invalid'), (NULL)) input(s);
+----
+2024-01-02 00:00:00
+NULL
+NULL
+
+# Variadic execution with six inputs.
+query T
+SELECT make_timestamp(2024, 1, 2, 3, 4, 5);
+----
+2024-01-02 03:04:05


### PR DESCRIPTION
I ran into a split in DuckDB's scalar executor infrastructure: unary and binary execution had carefully specialized flat and constant paths, while ternary and higher-arity execution went through the generic unified-vector loop. The implementations solved the same representation, validity, and selection problems independently. That made the hot paths difficult to improve consistently, and it meant a cheap ternary operation still paid selection-vector and per-input validity overhead when every input was flat or constant.

The violated invariant was in the vector executor layer. Arity should determine how arguments are expanded and how an operation is called; it should not determine which representation and validity optimizations are available. I moved that common work into an internal `ScalarExecutor` and kept `UnaryExecutor`, `BinaryExecutor`, `TernaryExecutor`, and `VariadicExecutor` as compatibility facades. Their existing entry points and operation conventions remain intact.

The shared engine classifies every input as constant, flat, or generic. It evaluates all-constant inputs once, specializes flat/constant masks through arity three, combines validity a machine word at a time, and falls back to `UnifiedVectorFormat` for other representations. Small adapters preserve lambda, optional-return, unary generic/state, unary string, binary single-type, binary fully typed, and variadic static-operation conventions. The unary facade retains dictionary-domain evaluation and its `FunctionErrors::CANNOT_ERROR` guard, while the binary facade retains comparison-complement folding.

There are two deliberate exceptions to a completely uniform facade. First, the initial shared binary true-only selection loop regressed a measured hot path, so I retained a narrow binary-specific flat loop for that output mode. Second, unary execution preserves a pre-seeded result validity mask when all explicit inputs are valid. Arrow extension conversion relies on this existing contract: it places the Arrow NULL mask on the result before converting an all-valid temporary storage vector. Operations that can add NULLs copy that mask before mutating it. Ternary and variadic execution do not preserve an old result mask, so reused results still clear stale NULLs there. The all-constant path also explicitly clears valid/NULL/valid reuse state.

I bounded specialization because instantiating every mask and every selection-output combination quickly outweighed the runtime benefit. Execution specializes arithmetic inputs through arity three. Variadic selection specializes only the all-flat input mask; adding all ternary input masks increased text by more than 1 MiB without a corresponding measured gain. It does retain compile-time true-only, false-only, and dual-output loops. I initially dispatched output presence at runtime, but profiling the Recursive CTE `game_of_life` regression showed that the resulting pointer checks made the shared BETWEEN loop substantially slower. `DUCKDB_SMALLER_BINARY` can remove these two dimensions independently through `variadic_executor_select_flat` and `variadic_executor_select_flags` in the existing `vector_specialization` group.

The follow-up review also surfaced the small binary-executor change in [duckdb/duckdb#24391](https://github.com/duckdb/duckdb/pull/24391). I evaluated the same four input-selection masks at the shared-engine boundary. The generated code looked cleaner, but direct all-valid measurements on this arm64 host were within noise and exact TPC-H Q1 was reproducibly about 4% slower. I therefore did not retain the all-valid specialization here. The ordinary all-valid path stays compact, while the facade uses the selection masks only for nullable generic binary execution, where they have a measured benefit. This is controlled by `binary_executor_generic_nullable` in the `vector_specialization` smaller-binary group.

I measured the change against `daa81697e31a3dc97a93f11220037cd2213af6cd` on arm64 macOS 26.5 with Apple Clang 21, release optimization, and isolated baseline/candidate builds with compiler launchers disabled. The direct executor benchmark uses a standard-size vector and one million in-process iterations for nonconstant profiles. Paired process-level measurements kept unary flat (923.3 ms versus 919.0 ms), unary dictionary (3.116 s versus 3.128 s), binary flat/flat (1.248 s versus 1.262 s), and binary flat/constant and constant/flat at parity or slightly faster. The retained binary true-only selection path measured about 1% faster than the pinned implementation across eight in-process samples.

I added direct nullable dictionary/flat, flat/dictionary, and dictionary/dictionary binary cases to make that distinction measurable. Dispatching the selection profile once per vector improved them from 10.523 s to 7.477 s, 10.101 s to 8.297 s, and 10.447 s to 8.747 s respectively, or 29%, 18%, and 16%. The row loop tests each validity mask at the selected source index and avoids materializing a mapped validity mask before doing any useful work.

The advisory end-to-end jobs later showed a smaller caveat that those direct benchmarks missed. Against the exact CI base, TPC-H SF10 moved by +1.7% and TPC-DS SF3 by +2.0%; neither crossed the benchmark runner's regression threshold. The largest TPC-H movement, Q15 at +26.8%, came from a host slowdown phase landing on opposite sides of the two ordered medians rather than from the branch. Repeating Q15 and the largest TPC-DS movements locally with exact base/candidate Release builds and both process orders reduced the selected-query geometric-mean difference to roughly +0.5%. TPC-DS Q85 nevertheless retained a small signal: four 100-run processes put the candidate 2.28% behind using the mean of the per-process medians.

Sampling Q85 pointed to binary generic-constant selection. The pinned implementation loaded only the dictionary operand's selection index. The first shared implementation loaded an index for both operands, including the constant operand's zero selection, and generic comparison-complement folding materialized both unified formats once to inspect nullability and then again for execution. In comparable ten-second profiles, the old specialized loop had 1,020 self samples while the candidate's two shared generic-loop variants had 1,389 combined self samples, plus a separate `InputsCanHaveNull` pass.

I fixed that at the shared-engine boundary rather than putting representation loops back into `BinaryExecutor`. For a generic/constant pair, `ScalarExecutor` prepares only the generic operand, passes the constant by value, keeps the generic data pointer restricted, and loads one selection index per row. Separate nullable and no-NULL instantiations preserve NULL semantics without sending nullable comparisons through the full two-input generic loop. A small adapter hook still performs comparison-complement folding after the engine knows the inputs cannot contain NULLs, which removes the duplicate facade preflight.

The direct profiles are back at parity. Across six final alternating process pairs, dictionary/constant selection moved by +0.40%, constant/dictionary by +0.27%, and folded `>=` dictionary/constant by +0.16% using the median paired delta. A final Q85 gate with 16 alternating process pairs and 30 in-process samples per binary had a -0.02% median paired delta, a +0.07% two-pair-trimmed mean, and pooled medians of 14.274 ms versus 14.311 ms (+0.26%). Repeating the five-query advisory TPC subset in both binary orders produced +0.2% in base-to-fixed order and -0.0% in fixed-to-base order, with no regressions. The final Q85 sample puts the two no-NULL generic-constant loops at 840 combined self samples, down from 1,389 in the unfixed candidate, and the duplicate nullability-preflight frame is gone.

A later CI run exposed another cost in nullable generic execution. The first shared implementation mapped every input validity mask into result-row space with `ValidityMask::CopySel` before entering the operation loop. In a ten-second TPC-DS Q15 sample, that prepass took 217 self samples; the old binary executor's complete generic string loop took only 181 inclusive samples. The invariant belongs at the row being produced, so I removed the eager materialization. The shared loop now checks each input validity mask at its selected source index, after unified formats have been captured and result validity has been safely detached. A focused non-identity dictionary test covers result/input validity aliasing, stale-mask clearing, and reuse.

I compared the final source as an exact merge over CI base `76dd1e7d6f` against that same base, using Apple Clang 21, arm64 macOS 26.5, Release, the `tpch`, `tpcds`, `core_functions`, and `parquet` extensions, and two execution threads. TPC-H Q1 is 228 ms versus 229 ms (+0.6%, 50 samples), after removing the all-valid mask specialization reduced its earlier roughly 4% regression. Full TPC-H SF10 is +0.9% over 15 samples with no query regressions; the independent Linux CI result is +0.6%, with Q14 and Q15 slightly faster. Full TPC-DS SF3 is 27.5 ms versus 27.5 ms (+0.0%, 10 samples), also with no query regressions.

I also checked the Recursive CTE job because its CI distribution reported three 12-15% warnings. Native sampling found one separate refactor regression: variadic selection had lost compile-time output-presence dispatch, making the shared BETWEEN loop in `game_of_life` take 560 self samples versus 374 in the old variadic loop. Restoring that dispatch in `ScalarExecutor` brought `game_of_life` and `aoc2022_day11` back within 2%. The final 57-case suite is +0.4% by geometric mean with no query regressions. A consolidated 50-sample run of `direct_probe_sparse`, `asql_cyk_using_key`, and `aoc2022_day12_using_key` puts all three within 2% (+0.5% geometric mean); the bimodal Day 12 case alone is -0.5% over 100 samples.

Cheap ternary execution is where the consolidation pays off. The six mixed flat/constant profiles improved by 21% to 69%, while flat/flat/flat improved by about 2%. All-flat ternary selection improved from 7.060 s to 4.894 s, or 1.44x. Word-at-a-time validity handling also materially improved the NULL-heavy ternary cases: the 50% NULL profile went from 1.957 s to 0.076 s, the 99% NULL profile from 1.833 s to 0.076 s, and validity-word-sized clusters from 2.838 s to 0.355 s. Sampling and flamegraphs identified an initially non-inlined unary validity helper; after fixing that, the 50% NULL unary case was at parity (3.152 s versus 3.132 s).

The one visible microbenchmark trade-off is the all-constant binary case. It is roughly 3.3% slower because the new path clears stale constant validity before producing a valid result, which the pinned implementation omitted. This is one operation per vector rather than a row loop, and I chose the deterministic valid/NULL/valid behavior over preserving that small constant-dispatch difference.

The final specializations make an intentional binary-size trade-off. In the standard release configuration, local-symbol-stripped `libduckdb` grows from 45,252,216 to 46,132,680 bytes (+1.95%), and `__text` grows from 34,349,184 to 35,131,196 bytes (+2.28%). Most of that is the four nullable binary selection profiles instantiated for each operation: trimming only `binary_executor_generic_nullable` removes about 381 KiB from the stripped library, but direct nullable dictionary execution falls back from the 16-29% improvement to baseline performance. I kept the specialization because the runtime gain is substantial and the feature remains independently removable through `DUCKDB_SMALLER_BINARY`.

The fully smaller build strips all executor specializations and grows from 37,010,320 to 37,359,024 bytes (+0.94%), with `__text` growing from 26,560,980 to 26,867,080 bytes (+1.15%). That remaining fixed cost is the generic shared engine and the row-local validity handling. I did not duplicate the old executors behind preprocessor branches merely to hide it. Fully smaller builds retain the runtime-output fallback for variadic selection.