### PR TITLE
Do not push NULL constraints through row-reducing operators or NULL e…

### DIFF
--- a/src/include/duckdb/optimizer/outer_join_simplification.hpp
+++ b/src/include/duckdb/optimizer/outer_join_simplification.hpp
@@ -22,7 +22,6 @@ class LogicalFilter;
 class LogicalJoin;
 class LogicalOrder;
 class LogicalProjection;
-class LogicalTopN;
 
 //! Simplifies outer joins if NULL-extended rows are filtered in a way that changes the join semantics
 class OuterJoinSimplification : public LogicalOperatorVisitor {
@@ -63,10 +62,10 @@ private:
 	void VisitComparisonJoin(LogicalComparisonJoin &join, LogicalOperator &op);
 	void VisitInnerOrSemiJoin(LogicalComparisonJoin &join, LogicalOperator &op);
 	void VisitOuterJoin(LogicalComparisonJoin &join, LogicalOperator &op);
+	void VisitJoinChildren(LogicalComparisonJoin &join, LogicalOperator &op);
 	void VisitProjection(LogicalProjection &projection, LogicalOperator &op);
 	void VisitFilter(LogicalFilter &filter, LogicalOperator &op);
 	void VisitOrder(LogicalOrder &order, LogicalOperator &op);
-	void VisitTopN(LogicalTopN &top_n, LogicalOperator &op);
 	void VisitAggregate(LogicalAggregate &aggregate, LogicalOperator &op);
 	void VisitUnsupportedOperator(LogicalOperator &op);
 

--- a/src/optimizer/outer_join_simplification.cpp
+++ b/src/optimizer/outer_join_simplification.cpp
@@ -297,7 +297,7 @@ void OuterJoinSimplification::VisitInnerOrSemiJoin(LogicalComparisonJoin &join, 
 void OuterJoinSimplification::VisitOuterJoin(LogicalComparisonJoin &join, LogicalOperator &op) {
 	if (TryConvertLeftToAntiJoin(join)) {
 		AddRequiredColumns(join.conditions);
-		VisitOperatorChildren(op);
+		VisitJoinChildren(join, op);
 		return;
 	}
 
@@ -308,7 +308,27 @@ void OuterJoinSimplification::VisitOuterJoin(LogicalComparisonJoin &join, Logica
 	}
 
 	AddRequiredColumns(join.conditions);
-	VisitOperatorChildren(op);
+	VisitJoinChildren(join, op);
+}
+
+void OuterJoinSimplification::VisitJoinChildren(LogicalComparisonJoin &join, LogicalOperator &op) {
+	// this join NULL-extends the columns of these children
+	D_ASSERT(op.children.size() == 2);
+	const bool null_extended[2] = {join.join_type == JoinType::RIGHT || join.join_type == JoinType::OUTER,
+	                               join.join_type == JoinType::LEFT || join.join_type == JoinType::OUTER ||
+	                                   join.join_type == JoinType::ANTI};
+	for (idx_t child_idx = 0; child_idx < 2; child_idx++) {
+		if (!null_extended[child_idx]) {
+			VisitOperator(*op.children[child_idx]);
+			continue;
+		}
+		// a NULL requirement from above can be satisfied by the NULL extension this join performs, so it does not
+		// necessarily hold within the child itself
+		auto parent_null_required_columns = std::move(null_required_columns);
+		null_required_columns.clear();
+		VisitOperator(*op.children[child_idx]);
+		null_required_columns = std::move(parent_null_required_columns);
+	}
 }
 
 void OuterJoinSimplification::VisitProjection(LogicalProjection &projection, LogicalOperator &op) {
@@ -372,13 +392,6 @@ void OuterJoinSimplification::VisitOrder(LogicalOrder &order, LogicalOperator &o
 	VisitOperatorChildren(op);
 }
 
-void OuterJoinSimplification::VisitTopN(LogicalTopN &top_n, LogicalOperator &op) {
-	for (const auto &order_node : top_n.orders) {
-		AddRequiredColumns(*order_node.expression);
-	}
-	VisitOperatorChildren(op);
-}
-
 void OuterJoinSimplification::VisitAggregate(LogicalAggregate &aggregate, LogicalOperator &op) {
 	column_binding_set_t child_required_columns;
 	for (const auto &expr : aggregate.groups) {
@@ -426,14 +439,11 @@ void OuterJoinSimplification::VisitOperator(LogicalOperator &op) {
 		VisitOrder(order, op);
 		return;
 	}
-	case LogicalOperatorType::LOGICAL_TOP_N: {
-		auto &top_n = op.Cast<LogicalTopN>();
-		VisitTopN(top_n, op);
-		return;
-	}
+	case LogicalOperatorType::LOGICAL_TOP_N:
 	case LogicalOperatorType::LOGICAL_LIMIT:
-		VisitOperatorChildren(op);
-		return;
+		// these operators emit a subset of their input rows - constraints collected above them are applied after the
+		// rows have been selected, so they do not hold for the children
+		break;
 	case LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY: {
 		auto &aggregate = op.Cast<LogicalAggregate>();
 		VisitAggregate(aggregate, op);

--- a/test/optimizer/outer_join_simplification.test
+++ b/test/optimizer/outer_join_simplification.test
@@ -314,6 +314,87 @@ ORDER BY 1;
 0	0
 1	1
 
+# a filter above a LIMIT is applied after the rows have been selected, so it cannot simplify the join below it
+statement ok
+CREATE TABLE l2(a BIGINT, ak VARCHAR);
+
+statement ok
+CREATE TABLE r2(b BIGINT, bk VARCHAR);
+
+statement ok
+INSERT INTO l2 VALUES (1, 'x'), (2, 'y'), (3, 'p');
+
+statement ok
+INSERT INTO r2 VALUES (10, 'p'), (11, 'q');
+
+query II
+EXPLAIN SELECT * FROM (
+    SELECT l2.a AS a, l2.ak AS ak, r2.b AS b
+    FROM l2 LEFT JOIN r2 ON l2.ak = r2.bk
+    ORDER BY b DESC NULLS FIRST, a ASC NULLS LAST
+    LIMIT 2
+) s
+WHERE s.b <= 20;
+----
+logical_opt	<REGEX>:.*LEFT.*
+
+query III
+SELECT * FROM (
+    SELECT l2.a AS a, l2.ak AS ak, r2.b AS b
+    FROM l2 LEFT JOIN r2 ON l2.ak = r2.bk
+    ORDER BY b DESC NULLS FIRST, a ASC NULLS LAST
+    LIMIT 2
+) s
+WHERE s.b <= 20;
+----
+
+# the same for a plain LIMIT, which is not collapsed into a TOP_N
+query II
+EXPLAIN SELECT * FROM (
+    SELECT l2.a AS a, l2.ak AS ak, r2.b AS b
+    FROM l2 LEFT JOIN r2 ON l2.ak = r2.bk
+    LIMIT 2
+) s
+WHERE s.b IS NULL;
+----
+logical_opt	<!REGEX>:.*ANTI.*
+
+# an IS NULL filter above an outer join can be satisfied by the NULL extension of that join,
+# so it cannot be pushed into the NULL-extended side
+query III
+SELECT * FROM (VALUES (1), (2), (NULL)) AS a(x)
+LEFT JOIN (
+    SELECT p.y AS y, q.z AS z
+    FROM (VALUES (2), (3), (NULL)) AS p(y)
+    LEFT JOIN (VALUES (1), (3), (NULL)) AS q(z) ON p.y <> q.z
+) AS s
+ON a.x <> s.y
+WHERE s.z IS NULL;
+----
+NULL	NULL	NULL
+
+query II
+EXPLAIN SELECT * FROM (VALUES (1), (2), (NULL)) AS a(x)
+LEFT JOIN (
+    SELECT p.y AS y, q.z AS z
+    FROM (VALUES (2), (3), (NULL)) AS p(y)
+    LEFT JOIN (VALUES (1), (3), (NULL)) AS q(z) ON p.y <> q.z
+) AS s
+ON a.x <> s.y
+WHERE s.z IS NULL;
+----
+logical_opt	<!REGEX>:.*ANTI.*
+
+# the ANTI rewrite is still applied when the IS NULL filter sits directly above the LEFT join
+query I
+SELECT l.i
+FROM range(3) l(i)
+LEFT JOIN range(2) r(i) ON l.i = r.i
+WHERE r.i IS NULL
+ORDER BY 1;
+----
+2
+
 require tpcds
 
 statement ok


### PR DESCRIPTION
…xtension

OuterJoinSimplification collects NULL constraints from filters while descending the plan and uses them to simplify the joins below. Two of the paths it descends through do not preserve those constraints, which produced wrong results.

  LIMIT and TOP_N emit a subset of their input rows, so a filter above
  them is applied only after the rows have been selected. Using such a
  filter to simplify a join below changes which rows the limit sees.
  Both operators now act as barriers instead of passing the collected
  constraints on to their children.

  An IS NULL filter above an outer join can be satisfied by the NULL
  extension that join performs, so the requirement does not necessarily
  hold within the NULL-extended child. Dropping child rows there can
  leave a row of the preserved side unmatched, which then passes the
  filter as a NULL-extended row that should not be in the result.
  null_required_columns is now cleared when descending into a child whose
  columns this join can NULL-extend. Columns whose NULLs are rejected by
  a filter above still propagate, since a NULL-extended row is discarded
  by that filter as well.

Fixes duckdb/duckdb#24540
Fixes duckdb/duckdb#24542