### PR TITLE
fix: avoid int64 overflow in generic InterpolateOperator for fill()

### DIFF
--- a/src/include/duckdb/common/operator/interpolate.hpp
+++ b/src/include/duckdb/common/operator/interpolate.hpp
@@ -18,8 +18,8 @@ namespace duckdb {
 struct InterpolateOperator {
 	template <typename TARGET_TYPE>
 	static inline TARGET_TYPE Operation(const TARGET_TYPE &lo, const double d, const TARGET_TYPE &hi) {
-		const auto delta = static_cast<double>(hi - lo);
-		return LossyNumericCast<TARGET_TYPE>(lo + static_cast<TARGET_TYPE>(delta * d));
+		const auto delta = static_cast<double>(hi) - static_cast<double>(lo);
+		return LossyNumericCast<TARGET_TYPE>(static_cast<double>(lo) + delta * d);
 	}
 };
 

--- a/test/sql/window/test_fill_orderby.test
+++ b/test/sql/window/test_fill_orderby.test
@@ -336,3 +336,16 @@ endloop
 
 endloop
 
+# Regression (#23986): BIGINT value span overflows int64 arithmetic in generic InterpolateOperator
+query III
+SELECT x, y, fill(y ORDER BY x) OVER () AS filled
+FROM (VALUES
+    (0::BIGINT,  9223372036854775807::BIGINT),
+    (1::BIGINT,  NULL),
+    (2::BIGINT, -9223372036854775807::BIGINT)) t(x, y)
+ORDER BY x;
+----
+0	9223372036854775807	9223372036854775807
+1	NULL	0
+2	-9223372036854775807	-9223372036854775807
+


### PR DESCRIPTION
This is made to fix #23986

When lo and hi are large int64 values with opposite signs, computing hi - lo in integer space overflows before the cast to double, producing a garbage delta and a wrong interpolated result (INT64_MIN instead of 0).

Fixed it by casting both operands to double before subtracting, matching the approach already used in the hugeint_t specialization. Also fixes the same overflow for int32 and smaller signed integer types, and for DECIMAL columns backed by int64 physical storage in quantile_cont. 

Also added a test.
