### PR TITLE
Internal #10187: Volatile Window Inputs

### DIFF
--- a/src/optimizer/window_self_join.cpp
+++ b/src/optimizer/window_self_join.cpp
@@ -13,6 +13,25 @@
 
 namespace duckdb {
 
+class VolatileExpressionCounter : public LogicalOperatorVisitor {
+public:
+	static idx_t HasVolatiles(LogicalOperator &op) {
+		VolatileExpressionCounter counter;
+		counter.VisitOperator(op);
+		return counter.volatiles;
+	}
+
+	VolatileExpressionCounter() {
+	}
+
+	void VisitExpression(unique_ptr<Expression> *expression) override {
+		volatiles += (*expression)->IsVolatile();
+		LogicalOperatorVisitor::VisitExpression(expression);
+	}
+
+	idx_t volatiles = 0;
+};
+
 static bool IsOrderableDistinctAggregate(const BoundWindowExpression &w_expr) {
 	//	If the aggregate is order-sensitive and distinct,
 	//	then the ORDER BYs need to be functional dependencies of the arguments.
@@ -179,6 +198,11 @@ unique_ptr<LogicalOperator> WindowSelfJoinOptimizer::OptimizeInternal(unique_ptr
 
 		// Check recursively
 		window.children[0] = OptimizeInternal(std::move(window.children[0]), replacer);
+
+		//	We cannot perform self-join when there are volatile functions below us.
+		if (VolatileExpressionCounter::HasVolatiles(window)) {
+			return op;
+		}
 
 		if (!CanOptimize(*window.children[0])) {
 			return op;

--- a/test/sql/optimizer/test_window_self_join.test
+++ b/test/sql/optimizer/test_window_self_join.test
@@ -319,3 +319,24 @@ FROM (
 ) AS b;
 ----
 1	10.0
+
+statement ok 
+CREATE OR REPLACE SEQUENCE seq;
+
+statement ok 
+CREATE OR REPLACE TABLE t AS SELECT * FROM range(6) tt(i);
+
+query III
+SELECT g, n, sum(n) OVER (PARTITION BY g) s 
+FROM (
+	SELECT nextval('seq') g, i n 
+	FROM t
+) 
+ORDER BY n;
+----
+1	0	0
+2	1	1
+3	2	2
+4	3	3
+5	4	4
+6	5	5


### PR DESCRIPTION
* Don't apply the self-join optimisation when there are volatile inputs.