### PR TITLE
Fix heap overflow in `string_agg`

### DIFF
--- a/extension/core_functions/aggregate/distributive/string_agg.cpp
+++ b/extension/core_functions/aggregate/distributive/string_agg.cpp
@@ -64,7 +64,7 @@ struct StringAggFunction {
 			if (new_size > NumericLimits<uint32_t>::Maximum()) {
 				throw InvalidInputException("string_agg string size exceeds maximum string size");
 			}
-			state.alloc_size = NextPowerOfTwo(new_size);
+			state.alloc_size = MinValue<idx_t>(NextPowerOfTwo(new_size), string_t::MAX_STRING_SIZE);
 			target_data = char_ptr_cast(allocator.Allocate(state.alloc_size));
 			if (current_size > 0) {
 				// copy over the current data

--- a/test/sql/aggregate/aggregates/test_string_agg_overflow.test_slow
+++ b/test/sql/aggregate/aggregates/test_string_agg_overflow.test_slow
@@ -1,5 +1,5 @@
 # name: test/sql/aggregate/aggregates/test_string_agg_overflow.test_slow
-# description: Issue #24188: STRING_AGG allocation size overflow
+# description: STRING_AGG allocation size overflow
 # group: [aggregates]
 
 statement ok

--- a/test/sql/aggregate/aggregates/test_string_agg_overflow.test_slow
+++ b/test/sql/aggregate/aggregates/test_string_agg_overflow.test_slow
@@ -1,0 +1,12 @@
+# name: test/sql/aggregate/aggregates/test_string_agg_overflow.test_slow
+# description: Issue #24188: STRING_AGG allocation size overflow
+# group: [aggregates]
+
+statement ok
+SET threads=1;
+
+query I
+SELECT length(string_agg(s, ''))
+FROM (SELECT repeat('A', 100000000) AS s FROM range(30)) t;
+----
+3000000000


### PR DESCRIPTION
Resolves https://github.com/duckdb/duckdb/issues/24188 by clamping the maximum allocation size.