### PR TITLE
Fix external file cache seek when uncache read

### DIFF
--- a/src/storage/external_file_cache/caching_file_system.cpp
+++ b/src/storage/external_file_cache/caching_file_system.cpp
@@ -364,10 +364,14 @@ FileBufferHandleGroup CachingFileHandle::Read(idx_t &nr_bytes) {
 	if (!external_file_cache.IsEnabled() || !CanSeek() || no_validation_metadata) {
 		auto buf = AllocateUncachedReadBuffer(external_file_cache.GetBufferManager(), nr_bytes);
 		auto file_handle = GetFileHandle();
+		// Do positional read if handle can seek, otherwise have to fallback to sequential read.
 		if (file_handle->CanSeek()) {
-			file_handle->Seek(position);
+			const auto file_size = file_handle->GetFileSize();
+			nr_bytes = position >= file_size ? 0 : MinValue(nr_bytes, file_size - position);
+			file_handle->Read(context, buf.GetDataMutable(), nr_bytes, position);
+		} else {
+			nr_bytes = NumericCast<idx_t>(file_handle->Read(context, buf.GetDataMutable(), nr_bytes));
 		}
-		nr_bytes = NumericCast<idx_t>(file_handle->Read(context, buf.GetDataMutable(), nr_bytes));
 		vector<FileBufferHandleGroup::MemoryHandle> mem_handles;
 		mem_handles.push_back({std::move(buf), 0, nr_bytes});
 		position += nr_bytes;

--- a/src/storage/external_file_cache/caching_file_system.cpp
+++ b/src/storage/external_file_cache/caching_file_system.cpp
@@ -364,6 +364,9 @@ FileBufferHandleGroup CachingFileHandle::Read(idx_t &nr_bytes) {
 	if (!external_file_cache.IsEnabled() || !CanSeek() || no_validation_metadata) {
 		auto buf = AllocateUncachedReadBuffer(external_file_cache.GetBufferManager(), nr_bytes);
 		auto file_handle = GetFileHandle();
+		if (file_handle->CanSeek()) {
+			file_handle->Seek(position);
+		}
 		nr_bytes = NumericCast<idx_t>(file_handle->Read(context, buf.GetDataMutable(), nr_bytes));
 		vector<FileBufferHandleGroup::MemoryHandle> mem_handles;
 		mem_handles.push_back({std::move(buf), 0, nr_bytes});

--- a/test/common/test_external_file_cache.cpp
+++ b/test/common/test_external_file_cache.cpp
@@ -48,6 +48,14 @@ string ReadFull(CachingFileHandle &handle, idx_t size, idx_t offset = 0) {
 	return result;
 }
 
+string ReadSequential(CachingFileHandle &handle, idx_t size) {
+	auto read_size = size;
+	auto group = handle.Read(read_size);
+	string result(read_size, '\0');
+	group.CopyTo(reinterpret_cast<data_ptr_t>(&result[0]), read_size);
+	return result;
+}
+
 void WriteTestContent(const string &path, const string &content) {
 	auto local_fs = FileSystem::CreateLocal();
 	auto handle = local_fs->OpenFile(path, FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE);
@@ -290,6 +298,25 @@ TEST_CASE("Disabled external file cache does not insert into ObjectCache", "[ext
 		REQUIRE(ReadFull(*handle, FILE_SIZE) == content);
 	}
 	REQUIRE(cache.GetCachedFileCount() == 1);
+}
+
+TEST_CASE("Sequential read preserves its position when the cache is disabled", "[external_file_cache]") {
+	DuckDB db = MakeCacheLocalFilesDB();
+	auto &cache = db.instance->GetExternalFileCache();
+	auto tracking_fs = make_uniq<EFCTrackingFileSystem>();
+
+	const idx_t block_size = cache.GetCacheBlockSize(TestDirectoryPath());
+	const string first_block(block_size, 'A');
+	const string second_block(block_size, 'B');
+	EFCTestFileGuard test_file("test_efc_disabled_sequential_position.bin", first_block + second_block);
+
+	CachingFileSystem cfs(*tracking_fs, *db.instance);
+	auto handle = cfs.OpenFile(MakeTestOpenFileInfo(test_file.GetPath()), FileFlags::FILE_FLAGS_READ);
+	REQUIRE(ReadSequential(*handle, block_size) == first_block);
+	REQUIRE(CountCachedBlocks(cache) == 1);
+
+	cache.SetEnabled(false);
+	REQUIRE(ReadSequential(*handle, block_size) == second_block);
 }
 
 TEST_CASE("Re-enabled external file cache refreshes live handle metadata", "[external_file_cache]") {


### PR DESCRIPTION
The bug is
- When serving uncached read, currently internal file handle directly reads from the current position, whatever the requested position is
- It doesn't reproduces usually because if we're (1) always doing cached read or uncached read; and (2) cached content serves requests properly well

In this PR, I seek to the requested position for internal file handle; don't think it matters for non-seekable file handle (i.e., pipe-based).