### PR TITLE
Optimize boolean identity `CASE` at filter root

### DIFF
--- a/src/include/duckdb/optimizer/rule/case_simplification.hpp
+++ b/src/include/duckdb/optimizer/rule/case_simplification.hpp
@@ -12,7 +12,8 @@
 
 namespace duckdb {
 
-// The Case Simplification rule rewrites cases with a constant check (i.e. [CASE WHEN 1=1 THEN x ELSE y END] => x)
+// The Case Simplification rule rewrites cases with a constant check (i.e. [CASE WHEN 1=1 THEN x ELSE y END] => x),
+// and boolean identity cases at filter roots (i.e. WHERE CASE WHEN p THEN true ELSE false END => WHERE p).
 class CaseSimplificationRule : public Rule {
 public:
 	explicit CaseSimplificationRule(ExpressionRewriter &rewriter);

--- a/src/optimizer/rule/case_simplification.cpp
+++ b/src/optimizer/rule/case_simplification.cpp
@@ -2,8 +2,19 @@
 
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/planner/expression/bound_case_expression.hpp"
+#include "duckdb/planner/expression/bound_constant_expression.hpp"
 
 namespace duckdb {
+
+static bool IsBooleanConstant(const Expression &expr, bool expected_value) {
+	if (expr.GetExpressionClass() != ExpressionClass::BOUND_CONSTANT) {
+		return false;
+	}
+
+	const auto &constant = expr.Cast<BoundConstantExpression>().GetValue();
+	return !constant.IsNull() && constant.type() == LogicalType::BOOLEAN &&
+	       BooleanValue::Get(constant) == expected_value;
+}
 
 CaseSimplificationRule::CaseSimplificationRule(ExpressionRewriter &rewriter) : Rule(rewriter) {
 	// match on a CaseExpression that has a ConstantExpression as a check
@@ -42,7 +53,23 @@ unique_ptr<Expression> CaseSimplificationRule::Apply(LogicalOperator &op, vector
 		// no case checks left: return the ELSE expression
 		return std::move(root.ElseMutable());
 	}
-	return nullptr;
+
+	// This rewrite is only valid at a filter root, where FALSE and NULL both reject the row.
+	if (!is_root || op.type != LogicalOperatorType::LOGICAL_FILTER) {
+		return nullptr;
+	}
+
+	if (root.CaseChecks().size() != 1) {
+		return nullptr;
+	}
+
+	auto &case_check = root.CaseChecksMutable()[0];
+	if (!IsBooleanConstant(*case_check.then_expr, true) || !IsBooleanConstant(root.Else(), false)) {
+		return nullptr;
+	}
+
+	// CASE WHEN predicate THEN true ELSE false END -> predicate
+	return std::move(case_check.when_expr);
 }
 
 } // namespace duckdb

--- a/test/optimizer/case_simplification.test
+++ b/test/optimizer/case_simplification.test
@@ -32,3 +32,26 @@ query I nosort casenorm3
 EXPLAIN SELECT X+2 FROM test
 ----
 
+query I nosort case_boolean_filter_identity
+EXPLAIN SELECT *
+FROM test
+WHERE CASE WHEN X > 0 THEN TRUE ELSE FALSE END
+----
+
+query I nosort case_boolean_filter_identity
+EXPLAIN SELECT *
+FROM test
+WHERE X > 0
+----
+
+statement ok
+CREATE TABLE nullable_test(x INTEGER);
+
+statement ok
+INSERT INTO nullable_test VALUES (NULL);
+
+query T
+SELECT CASE WHEN x > 0 THEN TRUE ELSE FALSE END
+FROM nullable_test
+----
+false


### PR DESCRIPTION
Fixes #24112

This PR adds an optimization rule to `CaseSimplificationRule` to simplify `CASE WHEN p THEN TRUE ELSE FALSE END` down to `p` when the expression is the root of a `LogicalFilter`. Because `LogicalFilter` discards both `FALSE` and `NULL`, it prevents semantic changes in contexts where `FALSE` and `NULL` behave differently (e.g., projections, `CHECK` constraints, or inside a `NOT(...)`).

Also added regression tests verifying the query plan optimization, and a control test ensuring `NULL` semantics are perfectly preserved in a projection context.