### PR TITLE
Make configs and secrets use Identifiers

### DIFF
--- a/.github/config/extensions/azure.cmake
+++ b/.github/config/extensions/azure.cmake
@@ -3,5 +3,6 @@ if (NOT MINGW AND NOT ${WASM_ENABLED})
         LOAD_TESTS
         GIT_URL https://github.com/duckdb/duckdb-azure
         GIT_TAG 4bc09038f6cf5609375464a8ed7e9e2ed2d66517
+        APPLY_PATCHES
   )
 endif()

--- a/.github/config/extensions/httpfs.cmake
+++ b/.github/config/extensions/httpfs.cmake
@@ -2,4 +2,5 @@ duckdb_extension_load(httpfs
     LOAD_TESTS
     GIT_URL https://github.com/duckdb/duckdb-httpfs
     GIT_TAG a7b3862d86808ea7a8baa89391c96c5ca2141a53
+    APPLY_PATCHES
 )

--- a/.github/patches/extensions/aws/0002-secret-provider-error-message.patch
+++ b/.github/patches/extensions/aws/0002-secret-provider-error-message.patch
@@ -1,0 +1,11 @@
+--- a/test/sql/aws_errors.test
++++ b/test/sql/aws_errors.test
+@@ -8,7 +8,7 @@ require no_extension_autoloading "EXPECTED: Test relies on explicit INSTALL and
+ statement error
+ create secret s1 (type s3, provider 'credential_chain');
+ ----
+-Invalid Input Error: Secret provider 'credential_chain' for type 's3' does not exist, but it exists in the aws extension.
++Invalid Input Error: Secret provider credential_chain for type s3 does not exist, but it exists in the aws extension.
+
+ # Require statement will ensure this test is run with this extension loaded
+ require aws

--- a/.github/patches/extensions/azure/0001-setting-name-identifier.patch
+++ b/.github/patches/extensions/azure/0001-setting-name-identifier.patch
@@ -1,0 +1,12 @@
+diff --git a/src/azure_storage_account_client.cpp b/src/azure_storage_account_client.cpp
+--- a/src/azure_storage_account_client.cpp
++++ b/src/azure_storage_account_client.cpp
+@@ -38,7 +38,7 @@
+ const static std::string DEFAULT_BLOB_ENDPOINT = "blob.core.windows.net";
+ const static std::string DEFAULT_DFS_ENDPOINT = "dfs.core.windows.net";
+ 
+-static std::string TryGetCurrentSetting(optional_ptr<FileOpener> opener, const std::string &name) {
++static std::string TryGetCurrentSetting(optional_ptr<FileOpener> opener, const Identifier &name) {
+ 	Value val;
+ 	if (FileOpener::TryGetCurrentSetting(opener, name, val)) {
+ 		return val.ToString();

--- a/.github/patches/extensions/ducklake/0006-setting-name-identifier.patch
+++ b/.github/patches/extensions/ducklake/0006-setting-name-identifier.patch
@@ -1,0 +1,33 @@
+diff --git a/src/include/storage/ducklake_scan.hpp b/src/include/storage/ducklake_scan.hpp
+--- a/src/include/storage/ducklake_scan.hpp
++++ b/src/include/storage/ducklake_scan.hpp
+@@ -29,7 +29,7 @@
+ 
+ 	static unique_ptr<FunctionData> BindDuckLakeScan(ClientContext &context, TableFunction &function);
+ 
+-	static CopyFunctionCatalogEntry &GetCopyFunction(ClientContext &context, const string &name);
++	static CopyFunctionCatalogEntry &GetCopyFunction(ClientContext &context, const Identifier &name);
+ };
+ 
+ //! Serialize/Deserialize callbacks for DuckLakeScan (used by table macro Copy)
+diff --git a/src/storage/ducklake_insert.cpp b/src/storage/ducklake_insert.cpp
+--- a/src/storage/ducklake_insert.cpp
++++ b/src/storage/ducklake_insert.cpp
+@@ -284,7 +284,7 @@
+ //===--------------------------------------------------------------------===//
+ // Plan
+ //===--------------------------------------------------------------------===//
+-CopyFunctionCatalogEntry &DuckLakeFunctions::GetCopyFunction(ClientContext &context, const string &name) {
++CopyFunctionCatalogEntry &DuckLakeFunctions::GetCopyFunction(ClientContext &context, const Identifier &name) {
+ 	// Logic is partially duplicated from Catalog::AutoLoadExtensionByCatalogEntry(db, CatalogType::COPY_FUNCTION_ENTRY,
+ 	// name), but that do not offer enough control
+ 	auto &db = *context.db;
+@@ -298,7 +298,7 @@
+ 	auto &system_catalog = Catalog::GetSystemCatalog(db);
+ 
+ 	auto entry = system_catalog.GetEntry<CopyFunctionCatalogEntry>(
+-	    context, QualifiedName(system_catalog.GetName(), Identifier::DefaultSchema(), Identifier(name)),
++	    context, QualifiedName(system_catalog.GetName(), Identifier::DefaultSchema(), name),
+ 	    OnEntryNotFound::RETURN_NULL);
+ 	if (!entry) {
+ 		throw MissingExtensionException(

--- a/.github/patches/extensions/httpfs/0001-setting-name-identifier.patch
+++ b/.github/patches/extensions/httpfs/0001-setting-name-identifier.patch
@@ -1,0 +1,109 @@
+diff --git a/src/http/httpfs.cpp b/src/http/httpfs.cpp
+--- a/src/http/httpfs.cpp
++++ b/src/http/httpfs.cpp
+@@ -87,7 +87,7 @@
+ 		}
+ 	}
+ 
+-	SettingLookupResult TryGetSetting(const string &key, Value &value) {
++	SettingLookupResult TryGetSetting(const Identifier &key, Value &value) {
+ 		if (info) {
+ 			return FileOpener::TryGetCurrentSetting(opener, key, value, *info);
+ 		}
+diff --git a/src/include/s3/s3_auth.hpp b/src/include/s3/s3_auth.hpp
+--- a/src/include/s3/s3_auth.hpp
++++ b/src/include/s3/s3_auth.hpp
+@@ -13,7 +13,8 @@
+ 	explicit S3KeyValueReader(const KeyValueSecretReader &reader);
+ 
+ 	template <class TYPE>
+-	SettingLookupResult TryGetSecretKeyOrSetting(const string &secret_key, const string &setting_name, TYPE &result) {
++	SettingLookupResult TryGetSecretKeyOrSetting(const Identifier &secret_key, const Identifier &setting_name,
++	                                             TYPE &result) {
+ 		Value temp_result;
+ 		auto setting_scope = reader.TryGetSecretKeyOrSetting(secret_key, setting_name, temp_result);
+ 		if (!temp_result.IsNull() && !(setting_scope && setting_scope.GetScope() == SettingScope::GLOBAL &&
+@@ -24,7 +25,7 @@
+ 	}
+ 
+ 	template <class TYPE>
+-	SettingLookupResult TryGetSecretKey(const string &secret_key, TYPE &value_out) {
++	SettingLookupResult TryGetSecretKey(const Identifier &secret_key, TYPE &value_out) {
+ 		return reader.TryGetSecretKey(secret_key, value_out);
+ 	}
+ 
+@@ -70,7 +71,7 @@
+ 
+ 	DBConfig &config;
+ 
+-	void SetExtensionOptionValue(string key, const char *env_var);
++	void SetExtensionOptionValue(const Identifier &key, const char *env_var);
+ 	void SetAll();
+ };
+ 
+diff --git a/src/s3/s3_auth.cpp b/src/s3/s3_auth.cpp
+--- a/src/s3/s3_auth.cpp
++++ b/src/s3/s3_auth.cpp
+@@ -6,7 +6,7 @@
+ 
+ namespace duckdb {
+ 
+-void AWSEnvironmentCredentialsProvider::SetExtensionOptionValue(string key, const char *env_var_name) {
++void AWSEnvironmentCredentialsProvider::SetExtensionOptionValue(const Identifier &key, const char *env_var_name) {
+ 	const auto env_value = std::getenv(env_var_name);
+ 	if (env_value) {
+ 		if (StringUtil::Lower(env_value) == "false") {
+diff --git a/test/extension/autoloading_base.test b/test/extension/autoloading_base.test
+--- a/test/extension/autoloading_base.test
++++ b/test/extension/autoloading_base.test
+@@ -33,12 +33,12 @@
+ statement error
+ SET s3_region='eu-west-1';
+ ----
+-<REGEX>:.*Catalog Error.*Setting with name "s3_region" is not in the catalog.*
++<REGEX>:.*Catalog Error.*Setting with name s3_region is not in the catalog.*
+ 
+ statement error
+ select * from read_json_auto('data/json/example_n.ndjson');
+ ----
+-<REGEX>:.*Catalog Error.*Table Function with name "read_json_auto" is not in the catalog.*
++<REGEX>:.*Catalog Error.*Table Function with name read_json_auto is not in the catalog.*
+ 
+ statement error
+ select * from thistablefunctionwillnotexistfosho();
+diff --git a/test/extension/autoloading_load_only.test b/test/extension/autoloading_load_only.test
+--- a/test/extension/autoloading_load_only.test
++++ b/test/extension/autoloading_load_only.test
+@@ -22,7 +22,7 @@
+ statement error
+ SET s3_region='eu-west-1';
+ ----
+-<REGEX>:.*Catalog Error.*Setting with name "s3_region" is not in the catalog.*
++<REGEX>:.*Catalog Error.*Setting with name s3_region is not in the catalog.*
+ 
+ ### Autoloading but not autoinstall, while the extension is not installed: still not working
+ statement ok
+diff --git a/test/extension/autoloading_reset_setting.test b/test/extension/autoloading_reset_setting.test
+--- a/test/extension/autoloading_reset_setting.test
++++ b/test/extension/autoloading_reset_setting.test
+@@ -22,7 +22,7 @@
+ statement error
+ RESET s3_region;
+ ----
+-Catalog Error: Setting with name "s3_region" is not in the catalog, but it exists in the httpfs extension.
++Catalog Error: Setting with name s3_region is not in the catalog, but it exists in the httpfs extension.
+ 
+ ### Autoloading, but no auto install
+ statement ok
+diff --git a/test/extension/autoloading_current_setting.test b/test/extension/autoloading_current_setting.test
+--- a/test/extension/autoloading_current_setting.test
++++ b/test/extension/autoloading_current_setting.test
+@@ -21,7 +21,7 @@
+ statement error
+ select current_setting('s3_region');
+ ----
+-<REGEX>:.*Catalog Error.*Setting with name "s3_region" is not in the catalog.*
++<REGEX>:.*Catalog Error.*Setting with name s3_region is not in the catalog.*
+ 
+ ### Autoloading, but but not autoinstall
+ statement ok

--- a/.github/patches/extensions/iceberg/0006-setting-name-identifier.patch
+++ b/.github/patches/extensions/iceberg/0006-setting-name-identifier.patch
@@ -1,0 +1,80 @@
+diff --git a/src/include/iceberg_options.hpp b/src/include/iceberg_options.hpp
+--- a/src/include/iceberg_options.hpp
++++ b/src/include/iceberg_options.hpp
+@@ -7,23 +7,25 @@
+ 
+ namespace duckdb {
+ 
+-static string VERSION_GUESSING_CONFIG_VARIABLE = "unsafe_enable_version_guessing";
++static constexpr const char *VERSION_GUESSING_CONFIG_VARIABLE = "unsafe_enable_version_guessing";
+ 
+ // The Iceberg format version used when creating a new table without an explicit
+ // 'format-version' property. Valid values are 2 and 3. Version 1 is not supported
+ // for writing (NotImplementedException); anything outside [2, 3] is rejected
+ // (InvalidConfigurationException).
+-static string DEFAULT_FORMAT_VERSION_CONFIG_VARIABLE = "iceberg_default_format_version";
++static constexpr const char *DEFAULT_FORMAT_VERSION_CONFIG_VARIABLE = "iceberg_default_format_version";
+ static constexpr uint64_t DEFAULT_ICEBERG_FORMAT_VERSION = 2;
+ 
+ // Compatibility escape hatch for deletion-vector files written by DuckDB Iceberg 1.5.3,
+ // which contain only the deletion-vector blob rather than a valid Puffin container.
+-static string SKIP_PUFFIN_VERIFICATION_CONFIG_VARIABLE = "iceberg_unsafe_skip_puffin_verification";
++static constexpr const char *SKIP_PUFFIN_VERIFICATION_CONFIG_VARIABLE =
++    "iceberg_unsafe_skip_puffin_verification";
+ 
+ // When this is true, a DELETE on a v2 Iceberg table whose WHERE clause is a pure
+ // conjunction of equality predicates writes an Iceberg equality-delete file instead
+ // of a positional delete. This exists only to exercise the equality-delete read path.
+-static string ENABLE_EQUALITY_DELETES_CONFIG_VARIABLE = "unsafe_and_disabled_for_iceberg_v3_enable_equality_deletes";
++static constexpr const char *ENABLE_EQUALITY_DELETES_CONFIG_VARIABLE =
++    "unsafe_and_disabled_for_iceberg_v3_enable_equality_deletes";
+ 
+ static constexpr const char *UNSAFE_STRUCT_NULL_DEFAULT_INTERP_CONFIG_VARIABLE =
+     "__iceberg_unsafe_struct_null_default_interp";
+diff --git a/src/include/common/iceberg_utils.hpp b/src/include/common/iceberg_utils.hpp
+--- a/src/include/common/iceberg_utils.hpp
++++ b/src/include/common/iceberg_utils.hpp
+@@ -43,7 +43,7 @@
+ 	static optional_ptr<CatalogEntry> GetTableEntry(ClientContext &context, string &input_string);
+ 	static optional_ptr<SchemaCatalogEntry> GetSchemaEntry(ClientContext &context, string &input_string);
+ 	static idx_t CountOccurrences(const string &input, const string &to_find);
+-	static CopyFunctionCatalogEntry &GetCopyFunction(ClientContext &context, const string &name);
++	static CopyFunctionCatalogEntry &GetCopyFunction(ClientContext &context, const Identifier &name);
+ 	static idx_t ParseByteSizeOptionallyFormatted(const string &input);
+ 	static int64_t AddFileSizeChecked(int64_t total, int64_t file_size_in_bytes);
+ 	static timestamp_ms_t GetTransactionStartTimeMS(ClientContext &context);
+diff --git a/src/common/iceberg_utils.cpp b/src/common/iceberg_utils.cpp
+--- a/src/common/iceberg_utils.cpp
++++ b/src/common/iceberg_utils.cpp
+@@ -51,7 +51,7 @@
+ 	}
+ }
+ 
+-CopyFunctionCatalogEntry &IcebergUtils::GetCopyFunction(ClientContext &context, const string &name) {
++CopyFunctionCatalogEntry &IcebergUtils::GetCopyFunction(ClientContext &context, const Identifier &name) {
+ 	// Logic is partially duplicated from Catalog::AutoLoadExtensionByCatalogEntry(db, CatalogType::COPY_FUNCTION_ENTRY,
+ 	// name), but that do not offer enough control
+ 	auto &db = *context.db;
+@@ -64,8 +64,8 @@
+ 	D_ASSERT(!name.empty());
+ 	auto &system_catalog = Catalog::GetSystemCatalog(db);
+ 
+-	auto entry = system_catalog.GetEntry<CopyFunctionCatalogEntry>(context, Identifier::DefaultSchema(),
+-	                                                               Identifier(name), OnEntryNotFound::RETURN_NULL);
++	auto entry = system_catalog.GetEntry<CopyFunctionCatalogEntry>(context, Identifier::DefaultSchema(), name,
++	                                                               OnEntryNotFound::RETURN_NULL);
+ 	if (!entry) {
+ 		throw MissingExtensionException(
+ 		    "Could not load the copy function for \"%s\". Try explicitly loading the \"%s\" extension", name, name);
+diff --git a/src/execution/operator/iceberg_insert.cpp b/src/execution/operator/iceberg_insert.cpp
+--- a/src/execution/operator/iceberg_insert.cpp
++++ b/src/execution/operator/iceberg_insert.cpp
+@@ -672,7 +672,7 @@
+ 	copy_input.schema.GetColumnNamesAndTypes(names_to_write, types_to_write);
+ 
+ 	// Get Parquet Copy function
+-	auto &copy_fun = IcebergUtils::GetCopyFunction(context, file_format);
++	auto &copy_fun = IcebergUtils::GetCopyFunction(context, Identifier(file_format));
+ 	IcebergCopyOptions result(std::move(info), copy_fun.function);
+ 	GenerateSortOrderExpressions(context, copy_input, result);
+ 

--- a/.github/patches/extensions/postgres_scanner/0003-setting-name-identifier.patch
+++ b/.github/patches/extensions/postgres_scanner/0003-setting-name-identifier.patch
@@ -1,0 +1,50 @@
+diff --git a/database-connector/src/include/dbconnector/optimizer/aggregate_optimizer.hpp b/database-connector/src/include/dbconnector/optimizer/aggregate_optimizer.hpp
+--- a/database-connector/src/include/dbconnector/optimizer/aggregate_optimizer.hpp
++++ b/database-connector/src/include/dbconnector/optimizer/aggregate_optimizer.hpp
+@@ -22,7 +22,8 @@
+ 		should_push_aggregate_t should_push_aggregate = nullptr;
+ 	};
+ 
+-	static Config CreateConfig(duckdb::ClientContext &ctx, const std::string &enabled_option, char identifier_quote,
++	static Config CreateConfig(duckdb::ClientContext &ctx, const duckdb::Identifier &enabled_option,
++	                           char identifier_quote,
+ 	                           query::QuoteEscapeStyle escape_style, std::string table_scan_name,
+ 	                           should_push_aggregate_t should_push_aggregate = nullptr);
+ 
+diff --git a/database-connector/src/include/dbconnector/optimizer/order_by_and_limit_optimizer.hpp b/database-connector/src/include/dbconnector/optimizer/order_by_and_limit_optimizer.hpp
+--- a/database-connector/src/include/dbconnector/optimizer/order_by_and_limit_optimizer.hpp
++++ b/database-connector/src/include/dbconnector/optimizer/order_by_and_limit_optimizer.hpp
+@@ -19,7 +19,8 @@
+ 		std::string table_scan_name;
+ 	};
+ 
+-	static Config CreateConfig(duckdb::ClientContext &ctx, const std::string &enabled_option, char identifier_quote,
++	static Config CreateConfig(duckdb::ClientContext &ctx, const duckdb::Identifier &enabled_option,
++	                           char identifier_quote,
+ 	                           query::QuoteEscapeStyle escape_style, std::string table_scan_name);
+ 
+ 	static void Optimize(const Config &config, duckdb::OptimizerExtensionInput &input,
+diff --git a/database-connector/src/optimizer/aggregate_optimizer.cpp b/database-connector/src/optimizer/aggregate_optimizer.cpp
+--- a/database-connector/src/optimizer/aggregate_optimizer.cpp
++++ b/database-connector/src/optimizer/aggregate_optimizer.cpp
+@@ -25,7 +25,7 @@
+ 
+ using namespace duckdb;
+ 
+-AggregateOptimizer::Config AggregateOptimizer::CreateConfig(ClientContext &ctx, const std::string &enabled_option,
++AggregateOptimizer::Config AggregateOptimizer::CreateConfig(ClientContext &ctx, const Identifier &enabled_option,
+                                                             char identifier_quote, query::QuoteEscapeStyle escape_style,
+                                                             std::string table_scan_name,
+                                                             should_push_aggregate_t should_push_aggregate) {
+diff --git a/database-connector/src/optimizer/order_by_and_limit_optimizer.cpp b/database-connector/src/optimizer/order_by_and_limit_optimizer.cpp
+--- a/database-connector/src/optimizer/order_by_and_limit_optimizer.cpp
++++ b/database-connector/src/optimizer/order_by_and_limit_optimizer.cpp
+@@ -19,7 +19,7 @@
+ using namespace duckdb;
+ 
+ OrderByAndLimitOptimizer::Config
+-OrderByAndLimitOptimizer::CreateConfig(ClientContext &ctx, const std::string &enabled_option, char identifier_quote,
++OrderByAndLimitOptimizer::CreateConfig(ClientContext &ctx, const Identifier &enabled_option, char identifier_quote,
+                                        query::QuoteEscapeStyle escape_style, std::string table_scan_name) {
+ 	Config res;
+ 

--- a/.github/patches/extensions/quack/0003-setting-name-identifier.patch
+++ b/.github/patches/extensions/quack/0003-setting-name-identifier.patch
@@ -1,0 +1,24 @@
+diff --git a/src/quack_server.cpp b/src/quack_server.cpp
+--- a/src/quack_server.cpp
++++ b/src/quack_server.cpp
+@@ -73,7 +73,7 @@
+ 	return true;
+ }
+ 
+-static string GetSettingString(DatabaseInstance &db, const string &setting_name) {
++static string GetSettingString(DatabaseInstance &db, const Identifier &setting_name) {
+ 	Value setting_val;
+ 	auto &config = DBConfig::GetConfig(db);
+ 
+diff --git a/src/quack_extension.cpp b/src/quack_extension.cpp
+--- a/src/quack_extension.cpp
++++ b/src/quack_extension.cpp
+@@ -93,7 +93,7 @@
+ 		if (kv.second.IsNull()) {
+ 			continue;
+ 		}
+-		db_config.SetOptionByName("whoami_" + kv.first, kv.second);
++		db_config.SetOptionByName(Identifier("whoami_" + kv.first), kv.second);
+ 	}
+ 	return_types.emplace_back(LogicalType::BOOLEAN);
+ 	names.emplace_back("ok");

--- a/extension/core_functions/scalar/generic/current_setting.cpp
+++ b/extension/core_functions/scalar/generic/current_setting.cpp
@@ -37,11 +37,11 @@ unique_ptr<FunctionData> CurrentSettingBind(BindScalarFunctionInput &input) {
 	auto &bound_function = input.GetBoundFunction();
 
 	auto key_val = input.GetNonNullConstant(0);
-	if (StringValue::Get(key_val).empty()) {
+	auto key = key_val.GetValue<Identifier>();
+	if (key.empty()) {
 		throw ParserException("Key name for current_setting must not be empty");
 	}
 
-	auto key = StringUtil::Lower(StringValue::Get(key_val));
 	Value val;
 	if (!context.TryGetCurrentSetting(key, val)) {
 		auto extension_name = Catalog::AutoloadExtensionByConfigName(context, key);

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -658,11 +658,10 @@ bool Catalog::TryAutoLoad(ClientContext &context, const string &original_name) n
 	return false;
 }
 
-String Catalog::AutoloadExtensionByConfigName(ClientContext &context, const String &configuration_name) {
+String Catalog::AutoloadExtensionByConfigName(ClientContext &context, const Identifier &configuration_name) {
 #ifndef DUCKDB_DISABLE_EXTENSION_LOAD
 	if (Settings::Get<AutoloadKnownExtensionsSetting>(context)) {
-		auto extension_name =
-		    ExtensionHelper::FindExtensionInEntries(configuration_name.ToStdString(), EXTENSION_SETTINGS);
+		auto extension_name = ExtensionHelper::FindExtensionInEntries(configuration_name, EXTENSION_SETTINGS);
 		if (ExtensionHelper::CanAutoloadExtension(extension_name)) {
 			ExtensionHelper::AutoLoadExtension(context, extension_name);
 			return extension_name;
@@ -670,7 +669,7 @@ String Catalog::AutoloadExtensionByConfigName(ClientContext &context, const Stri
 	}
 #endif
 
-	throw Catalog::UnrecognizedConfigurationError(context, configuration_name.ToStdString());
+	throw Catalog::UnrecognizedConfigurationError(context, configuration_name);
 }
 
 static bool IsAutoloadableFunction(CatalogType type) {
@@ -714,7 +713,7 @@ static bool CompareCatalogTypes(CatalogType type_a, CatalogType type_b) {
 	return false;
 }
 
-bool Catalog::AutoLoadExtensionByCatalogEntry(DatabaseInstance &db, CatalogType type, const string &entry_name) {
+bool Catalog::AutoLoadExtensionByCatalogEntry(DatabaseInstance &db, CatalogType type, const Identifier &entry_name) {
 #ifndef DUCKDB_DISABLE_EXTENSION_LOAD
 	if (Settings::Get<AutoloadKnownExtensionsSetting>(db)) {
 		string extension_name;
@@ -749,12 +748,12 @@ bool Catalog::AutoLoadExtensionByCatalogEntry(DatabaseInstance &db, CatalogType 
 	return false;
 }
 
-CatalogException Catalog::UnrecognizedConfigurationError(ClientContext &context, const string &name) {
+CatalogException Catalog::UnrecognizedConfigurationError(ClientContext &context, const Identifier &name) {
 	// check if the setting exists in any extensions
 	auto extension_name = ExtensionHelper::FindExtensionInEntries(name, EXTENSION_SETTINGS);
 	if (!extension_name.empty()) {
-		auto error_message = "Setting with name \"" + name + "\" is not in the catalog, but it exists in the " +
-		                     extension_name + " extension.";
+		auto error_message = StringUtil::Format(
+		    "Setting with name %s is not in the catalog, but it exists in the %s extension.", name, extension_name);
 		error_message = ExtensionHelper::AddExtensionInstallHintToErrorMsg(context, error_message, extension_name);
 		return CatalogException(error_message);
 	}
@@ -762,9 +761,9 @@ CatalogException Catalog::UnrecognizedConfigurationError(ClientContext &context,
 	// get a list of all options
 	vector<string> potential_names = DBConfig::GetOptionNames();
 	for (auto &entry : DBConfig::GetConfig(context).GetExtensionSettings()) {
-		potential_names.push_back(entry.first);
+		potential_names.push_back(entry.first.GetIdentifierName());
 	}
-	throw CatalogException::MissingEntry("configuration parameter", Identifier(name), potential_names);
+	throw CatalogException::MissingEntry("configuration parameter", name, potential_names);
 }
 
 CatalogException Catalog::CreateMissingEntryException(CatalogEntryRetriever &retriever,
@@ -795,7 +794,7 @@ CatalogException Catalog::CreateMissingEntryException(CatalogEntryRetriever &ret
 	// Check if the entry exists in any extension.
 	string extension_name;
 	auto type = lookup_info.GetCatalogType();
-	auto &entry_name = lookup_info.GetEntryName();
+	auto &entry_name = lookup_info.GetEntryIdentifier();
 	if (type == CatalogType::TABLE_FUNCTION_ENTRY || type == CatalogType::SCALAR_FUNCTION_ENTRY ||
 	    type == CatalogType::AGGREGATE_FUNCTION_ENTRY || type == CatalogType::PRAGMA_FUNCTION_ENTRY) {
 		auto lookup_result = ExtensionHelper::FindExtensionInFunctionEntries(entry_name, EXTENSION_FUNCTIONS);
@@ -820,7 +819,7 @@ CatalogException Catalog::CreateMissingEntryException(CatalogEntryRetriever &ret
 			if (other_types.size() == 1) {
 				auto &function_type = other_types[0];
 				auto error =
-				    CatalogException("%s with name \"%s\" is not in the catalog, a function by this name exists "
+				    CatalogException("%s with name %s is not in the catalog, a function by this name exists "
 				                     "in the %s extension, but it's of a different type, namely %s",
 				                     CatalogTypeToString(type), entry_name, extension_for_error, function_type);
 				return error;
@@ -828,7 +827,7 @@ CatalogException Catalog::CreateMissingEntryException(CatalogEntryRetriever &ret
 				D_ASSERT(!other_types.empty());
 				auto list_of_types = StringUtil::Join(other_types, ", ");
 				auto error =
-				    CatalogException("%s with name \"%s\" is not in the catalog, functions with this name exist "
+				    CatalogException("%s with name %s is not in the catalog, functions with this name exist "
 				                     "in the %s extension, but they are of different types, namely %s",
 				                     CatalogTypeToString(type), entry_name, extension_for_error, list_of_types);
 				return error;
@@ -844,8 +843,9 @@ CatalogException Catalog::CreateMissingEntryException(CatalogEntryRetriever &ret
 
 	// if we found an extension that can handle this catalog entry, create an error hinting the user
 	if (!extension_name.empty()) {
-		auto error_message = CatalogTypeToString(type) + " with name \"" + entry_name +
-		                     "\" is not in the catalog, but it exists in the " + extension_name + " extension.";
+		auto error_message =
+		    StringUtil::Format("%s with name %s is not in the catalog, but it exists in the %s extension.",
+		                       CatalogTypeToString(type), entry_name, extension_name);
 		error_message = ExtensionHelper::AddExtensionInstallHintToErrorMsg(context, error_message, extension_name);
 		return CatalogException(error_message);
 	}
@@ -1203,7 +1203,7 @@ optional_ptr<CatalogEntry> Catalog::GetEntry(CatalogEntryRetriever &retriever, c
 	// Try autoloading extension to resolve lookup
 	if (!result.Found()) {
 		if (AutoLoadExtensionByCatalogEntry(*retriever.GetContext().db, lookup_info.GetCatalogType(),
-		                                    lookup_info.GetEntryName())) {
+		                                    lookup_info.GetEntryIdentifier())) {
 			result = TryLookupEntryAcrossCatalogs(retriever, lookup_info, if_not_found);
 		}
 	}
@@ -1260,7 +1260,7 @@ optional_ptr<CatalogEntry> Catalog::GetEntry(CatalogEntryRetriever &retriever, c
 	// Try autoloading extension to resolve lookup
 	if (!result.Found()) {
 		if (AutoLoadExtensionByCatalogEntry(*retriever.GetContext().db, lookup_info.GetCatalogType(),
-		                                    lookup_info.GetEntryName())) {
+		                                    lookup_info.GetEntryIdentifier())) {
 			result = TryLookupEntry(retriever, qualified, if_not_found);
 		}
 	}

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -759,9 +759,9 @@ CatalogException Catalog::UnrecognizedConfigurationError(ClientContext &context,
 	}
 	// the setting is not in an extension
 	// get a list of all options
-	vector<string> potential_names = DBConfig::GetOptionNames();
+	vector<Identifier> potential_names = DBConfig::GetOptionNames();
 	for (auto &entry : DBConfig::GetConfig(context).GetExtensionSettings()) {
-		potential_names.push_back(entry.first.GetIdentifierName());
+		potential_names.push_back(entry.first);
 	}
 	throw CatalogException::MissingEntry("configuration parameter", name, potential_names);
 }

--- a/src/common/exception/catalog_exception.cpp
+++ b/src/common/exception/catalog_exception.cpp
@@ -49,7 +49,7 @@ CatalogException CatalogException::MissingEntry(CatalogType type, const Identifi
 }
 
 CatalogException CatalogException::MissingEntry(const string &type, const Identifier &name,
-                                                const vector<string> &suggestions, QueryErrorContext context) {
+                                                const vector<Identifier> &suggestions, QueryErrorContext context) {
 	auto extra_info = Exception::InitializeExtraInfo("MISSING_ENTRY", context.query_location);
 	extra_info["error_subtype"] = "MISSING_ENTRY";
 	extra_info["name"] = name.GetIdentifierName();
@@ -57,9 +57,11 @@ CatalogException CatalogException::MissingEntry(const string &type, const Identi
 	if (!suggestions.empty()) {
 		extra_info["candidates"] = StringUtil::Join(suggestions, ", ");
 	}
-	return CatalogException(extra_info, StringUtil::Format("unrecognized %s \"%s\"\n%s", type, name,
-	                                                       StringUtil::CandidatesErrorMessage(
-	                                                           suggestions, name.GetIdentifierName(), "Did you mean")));
+	return CatalogException(extra_info,
+	                        StringUtil::Format("unrecognized %s \"%s\"\n%s", type, name,
+	                                           StringUtil::CandidatesErrorMessage(IdentifiersToStrings(suggestions),
+	                                                                             name.GetIdentifierName(),
+	                                                                             "Did you mean")));
 }
 
 CatalogException CatalogException::EntryAlreadyExists(CatalogType type, const Identifier &name,

--- a/src/common/exception/catalog_exception.cpp
+++ b/src/common/exception/catalog_exception.cpp
@@ -57,11 +57,10 @@ CatalogException CatalogException::MissingEntry(const string &type, const Identi
 	if (!suggestions.empty()) {
 		extra_info["candidates"] = StringUtil::Join(suggestions, ", ");
 	}
-	return CatalogException(extra_info,
-	                        StringUtil::Format("unrecognized %s \"%s\"\n%s", type, name,
-	                                           StringUtil::CandidatesErrorMessage(IdentifiersToStrings(suggestions),
-	                                                                             name.GetIdentifierName(),
-	                                                                             "Did you mean")));
+	return CatalogException(
+	    extra_info, StringUtil::Format("unrecognized %s \"%s\"\n%s", type, name,
+	                                   StringUtil::CandidatesErrorMessage(IdentifiersToStrings(suggestions),
+	                                                                      name.GetIdentifierName(), "Did you mean")));
 }
 
 CatalogException CatalogException::EntryAlreadyExists(CatalogType type, const Identifier &name,

--- a/src/execution/operator/helper/physical_reset.cpp
+++ b/src/execution/operator/helper/physical_reset.cpp
@@ -30,14 +30,15 @@ SourceResultType PhysicalReset::GetDataInternal(ExecutionContext &context, DataC
 		return SourceResultType::FINISHED;
 	}
 	auto &config = DBConfig::GetConfig(context.client);
-	config.CheckLock(name);
-	auto option = DBConfig::GetOptionByName(name);
+	Identifier option_name(name.ToStdString());
+	config.CheckLock(option_name);
+	auto option = DBConfig::GetOptionByName(option_name);
 	if (!option) {
 		// check if this is an extra extension variable
 		ExtensionOption extension_option;
-		if (!config.TryGetExtensionOption(name, extension_option)) {
-			auto extension_name = Catalog::AutoloadExtensionByConfigName(context.client, name);
-			if (!config.TryGetExtensionOption(name, extension_option)) {
+		if (!config.TryGetExtensionOption(option_name, extension_option)) {
+			auto extension_name = Catalog::AutoloadExtensionByConfigName(context.client, option_name);
+			if (!config.TryGetExtensionOption(option_name, extension_option)) {
 				throw InvalidInputException("Extension parameter %s was not found after autoloading", name);
 			}
 		}

--- a/src/execution/operator/helper/physical_set.cpp
+++ b/src/execution/operator/helper/physical_set.cpp
@@ -11,8 +11,8 @@ void PhysicalSet::SetGenericVariable(ClientContext &context, idx_t setting_index
 	Settings::Set(context, setting_index, scope, std::move(target_value));
 }
 
-void PhysicalSet::SetExtensionVariable(ClientContext &context, ExtensionOption &extension_option, const String &name,
-                                       SetScope scope, const Value &value) {
+void PhysicalSet::SetExtensionVariable(ClientContext &context, ExtensionOption &extension_option, SetScope scope,
+                                       const Value &value) {
 	auto &target_type = extension_option.type;
 	Value target_value = value.CastAs(context, target_type);
 	if (extension_option.set_function) {
@@ -59,19 +59,20 @@ SetScope PhysicalSet::GetSettingScope(const ConfigurationOption &option, SetScop
 SourceResultType PhysicalSet::GetDataInternal(ExecutionContext &context, DataChunk &chunk,
                                               OperatorSourceInput &input) const {
 	auto &config = DBConfig::GetConfig(context.client);
+	Identifier option_name(name.ToStdString());
 	// check if we are allowed to change the configuration option
-	config.CheckLock(name);
-	auto option = DBConfig::GetOptionByName(name);
+	config.CheckLock(option_name);
+	auto option = DBConfig::GetOptionByName(option_name);
 	if (!option) {
 		ExtensionOption extension_option;
 		// check if this is an extra extension variable
-		if (!config.TryGetExtensionOption(name, extension_option)) {
-			auto extension_name = Catalog::AutoloadExtensionByConfigName(context.client, name);
-			if (!config.TryGetExtensionOption(name, extension_option)) {
+		if (!config.TryGetExtensionOption(option_name, extension_option)) {
+			auto extension_name = Catalog::AutoloadExtensionByConfigName(context.client, option_name);
+			if (!config.TryGetExtensionOption(option_name, extension_option)) {
 				throw InvalidInputException("Extension parameter %s was not found after autoloading", name);
 			}
 		}
-		SetExtensionVariable(context.client, extension_option, name, scope, value);
+		SetExtensionVariable(context.client, extension_option, scope, value);
 		return SourceResultType::FINISHED;
 	}
 	SetScope variable_scope = GetSettingScope(*option, scope);

--- a/src/function/table/system/duckdb_settings.cpp
+++ b/src/function/table/system/duckdb_settings.cpp
@@ -6,7 +6,7 @@
 namespace duckdb {
 
 struct DuckDBSettingValue {
-	string name;
+	Identifier name;
 	Value value;
 	string description;
 	string input_type;
@@ -85,7 +85,7 @@ unique_ptr<GlobalTableFunctionState> DuckDBSettingsInit(ClientContext &context, 
 		}
 		for (auto &alias : value.aliases) {
 			DuckDBSettingValue alias_value = value;
-			alias_value.name = StringValue::Get(alias);
+			alias_value.name = alias.GetValue<Identifier>();
 			alias_value.aliases.clear();
 			result->settings.push_back(std::move(alias_value));
 		}

--- a/src/include/duckdb/catalog/catalog.hpp
+++ b/src/include/duckdb/catalog/catalog.hpp
@@ -471,12 +471,12 @@ public:
 
 	virtual void Verify();
 
-	static CatalogException UnrecognizedConfigurationError(ClientContext &context, const string &name);
+	static CatalogException UnrecognizedConfigurationError(ClientContext &context, const Identifier &name);
 
 	//! Autoload the extension required for `configuration_name` or throw a CatalogException
-	static String AutoloadExtensionByConfigName(ClientContext &context, const String &configuration_name);
+	static String AutoloadExtensionByConfigName(ClientContext &context, const Identifier &configuration_name);
 	//! Autoload the extension required for `function_name` or throw a CatalogException
-	static bool AutoLoadExtensionByCatalogEntry(DatabaseInstance &db, CatalogType type, const string &entry_name);
+	static bool AutoLoadExtensionByCatalogEntry(DatabaseInstance &db, CatalogType type, const Identifier &entry_name);
 	DUCKDB_API static bool TryAutoLoad(ClientContext &context, const string &extension_name) noexcept;
 
 	//! Called when the catalog is detached

--- a/src/include/duckdb/common/exception/catalog_exception.hpp
+++ b/src/include/duckdb/common/exception/catalog_exception.hpp
@@ -38,7 +38,8 @@ public:
 	static CatalogException MissingEntry(const EntryLookupInfo &lookup_info, const string &suggestion);
 	static CatalogException MissingEntry(CatalogType type, const Identifier &name, const string &suggestion,
 	                                     QueryErrorContext context = QueryErrorContext());
-	static CatalogException MissingEntry(const string &type, const Identifier &name, const vector<string> &suggestions,
+	static CatalogException MissingEntry(const string &type, const Identifier &name,
+	                                     const vector<Identifier> &suggestions,
 	                                     QueryErrorContext context = QueryErrorContext());
 	static CatalogException EntryAlreadyExists(CatalogType type, const Identifier &name,
 	                                           QueryErrorContext context = QueryErrorContext());

--- a/src/include/duckdb/common/file_opener.hpp
+++ b/src/include/duckdb/common/file_opener.hpp
@@ -32,8 +32,8 @@ public:
 	}
 	virtual ~FileOpener() {};
 
-	virtual SettingLookupResult TryGetCurrentSetting(const string &key, Value &result, FileOpenerInfo &info);
-	virtual SettingLookupResult TryGetCurrentSetting(const string &key, Value &result) = 0;
+	virtual SettingLookupResult TryGetCurrentSetting(const Identifier &key, Value &result, FileOpenerInfo &info);
+	virtual SettingLookupResult TryGetCurrentSetting(const Identifier &key, Value &result) = 0;
 	virtual optional_ptr<ClientContext> TryGetClientContext() = 0;
 	virtual optional_ptr<DatabaseInstance> TryGetDatabase() = 0;
 	virtual HTTPUtil &GetHTTPUtil() = 0;
@@ -43,14 +43,14 @@ public:
 	DUCKDB_API static optional_ptr<ClientContext> TryGetClientContext(optional_ptr<FileOpener> opener);
 	DUCKDB_API static optional_ptr<DatabaseInstance> TryGetDatabase(optional_ptr<FileOpener> opener);
 	DUCKDB_API static optional_ptr<SecretManager> TryGetSecretManager(optional_ptr<FileOpener> opener);
-	DUCKDB_API static SettingLookupResult TryGetCurrentSetting(optional_ptr<FileOpener> opener, const string &key,
+	DUCKDB_API static SettingLookupResult TryGetCurrentSetting(optional_ptr<FileOpener> opener, const Identifier &key,
 	                                                           Value &result);
-	DUCKDB_API static SettingLookupResult TryGetCurrentSetting(optional_ptr<FileOpener> opener, const string &key,
+	DUCKDB_API static SettingLookupResult TryGetCurrentSetting(optional_ptr<FileOpener> opener, const Identifier &key,
 	                                                           Value &result, FileOpenerInfo &info);
 
 	template <class TYPE>
-	static SettingLookupResult TryGetCurrentSetting(optional_ptr<FileOpener> opener, const string &key, TYPE &result,
-	                                                optional_ptr<FileOpenerInfo> info) {
+	static SettingLookupResult TryGetCurrentSetting(optional_ptr<FileOpener> opener, const Identifier &key,
+	                                                TYPE &result, optional_ptr<FileOpenerInfo> info) {
 		Value output;
 		SettingLookupResult lookup_result;
 

--- a/src/include/duckdb/execution/operator/helper/physical_set.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_set.hpp
@@ -41,8 +41,8 @@ public:
 		return true;
 	}
 
-	static void SetExtensionVariable(ClientContext &context, ExtensionOption &extension_option, const String &name,
-	                                 SetScope scope, const Value &value);
+	static void SetExtensionVariable(ClientContext &context, ExtensionOption &extension_option, SetScope scope,
+	                                 const Value &value);
 
 	static void SetGenericVariable(ClientContext &context, idx_t setting_index, SetScope scope, Value target_value);
 	static SetScope GetSettingScope(const ConfigurationOption &option, SetScope variable_scope);

--- a/src/include/duckdb/main/client_context.hpp
+++ b/src/include/duckdb/main/client_context.hpp
@@ -244,7 +244,7 @@ public:
 	                                                 bool requires_valid_transaction = true);
 
 	//! Equivalent to CURRENT_SETTING(key) SQL function.
-	DUCKDB_API SettingLookupResult TryGetCurrentSetting(const string &key, Value &result) const;
+	DUCKDB_API SettingLookupResult TryGetCurrentSetting(const Identifier &key, Value &result) const;
 	//! Returns the value of the current setting set by the user - if the user has set it.
 	DUCKDB_API SettingLookupResult TryGetCurrentUserSetting(idx_t setting_index, Value &result) const;
 

--- a/src/include/duckdb/main/client_context_file_opener.hpp
+++ b/src/include/duckdb/main/client_context_file_opener.hpp
@@ -22,8 +22,8 @@ public:
 	}
 
 	Logger &GetLogger() const override;
-	SettingLookupResult TryGetCurrentSetting(const string &key, Value &result, FileOpenerInfo &info) override;
-	SettingLookupResult TryGetCurrentSetting(const string &key, Value &result) override;
+	SettingLookupResult TryGetCurrentSetting(const Identifier &key, Value &result, FileOpenerInfo &info) override;
+	SettingLookupResult TryGetCurrentSetting(const Identifier &key, Value &result) override;
 
 	optional_ptr<ClientContext> TryGetClientContext() override {
 		return &context;

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -123,9 +123,9 @@ struct DBConfigOptions {
 	//! Debug setting - how to verify ORDER BY results (e.g. by rewriting ORDER BY into create_sort_key)
 	DebugOrderVerification debug_order_verification = DebugOrderVerification::NONE;
 	//! The set of user-provided options
-	case_insensitive_map_t<Value> user_options;
+	identifier_map_t<Value> user_options;
 	//! The set of unrecognized (other) options
-	case_insensitive_map_t<Value> unrecognized_options;
+	identifier_map_t<Value> unrecognized_options;
 	//! If bulk deallocation larger than this occurs, flush outstanding allocations (1 << 30, ~1GB)
 	idx_t allocator_bulk_deallocation_flush_threshold = 536870912ULL;
 	//! Delta Only! - Fall back to recognizing Variant columns structurally
@@ -165,7 +165,7 @@ struct DBConfig {
 public:
 	DUCKDB_API DBConfig();
 	explicit DUCKDB_API DBConfig(bool read_only);
-	DUCKDB_API DBConfig(const case_insensitive_map_t<Value> &config_dict, bool read_only);
+	DUCKDB_API DBConfig(const identifier_map_t<Value> &config_dict, bool read_only);
 	DUCKDB_API ~DBConfig();
 
 	//! Replacement table scans are automatically attempted when a table name cannot be found in the schema
@@ -212,32 +212,32 @@ public:
 	DUCKDB_API static vector<string> GetOptionNames();
 	DUCKDB_API static bool IsInMemoryDatabase(const char *database_path);
 
-	DUCKDB_API void AddExtensionOption(const string &name, string description, LogicalType parameter,
+	DUCKDB_API void AddExtensionOption(const Identifier &name, string description, LogicalType parameter,
 	                                   const Value &default_value = Value(), set_option_callback_t function = nullptr,
 	                                   SetScope default_scope = SetScope::SESSION);
-	DUCKDB_API bool HasExtensionOption(const string &name) const;
-	DUCKDB_API case_insensitive_map_t<ExtensionOption> GetExtensionSettings() const;
-	DUCKDB_API bool TryGetExtensionOption(const String &name, ExtensionOption &result) const;
+	DUCKDB_API bool HasExtensionOption(const Identifier &name) const;
+	DUCKDB_API identifier_map_t<ExtensionOption> GetExtensionSettings() const;
+	DUCKDB_API bool TryGetExtensionOption(const Identifier &name, ExtensionOption &result) const;
 	//! Fetch an option by index. Returns a pointer to the option, or nullptr if out of range
 	DUCKDB_API static optional_ptr<const ConfigurationOption> GetOptionByIndex(idx_t index);
 	//! Fetcha n alias by index, or nullptr if out of range
 	DUCKDB_API static optional_ptr<const ConfigurationAlias> GetAliasByIndex(idx_t index);
 	//! Fetch an option by name. Returns a pointer to the option, or nullptr if none exists.
-	DUCKDB_API static optional_ptr<const ConfigurationOption> GetOptionByName(const String &name);
+	DUCKDB_API static optional_ptr<const ConfigurationOption> GetOptionByName(const Identifier &name);
 	DUCKDB_API void SetOption(const ConfigurationOption &option, const Value &value);
 	DUCKDB_API void SetOption(optional_ptr<DatabaseInstance> db, const ConfigurationOption &option, const Value &value);
-	DUCKDB_API void SetOption(const string &name, Value value);
+	DUCKDB_API void SetOption(const Identifier &name, Value value);
 	DUCKDB_API void SetOption(idx_t setting_index, Value value);
-	DUCKDB_API void SetOptionByName(const string &name, const Value &value);
-	DUCKDB_API void SetOptionsByName(const case_insensitive_map_t<Value> &values);
+	DUCKDB_API void SetOptionByName(const Identifier &name, const Value &value);
+	DUCKDB_API void SetOptionsByName(const identifier_map_t<Value> &values);
 	DUCKDB_API void ResetOption(optional_ptr<DatabaseInstance> db, const ConfigurationOption &option);
 	DUCKDB_API void ResetOption(const ExtensionOption &extension_option);
 	DUCKDB_API void ResetGenericOption(idx_t setting_index);
-	DUCKDB_API optional_idx TryGetSettingIndex(const String &name,
+	DUCKDB_API optional_idx TryGetSettingIndex(const Identifier &name,
 	                                           optional_ptr<const ConfigurationOption> &option) const;
 	static LogicalType ParseLogicalType(const string &type);
 
-	DUCKDB_API void CheckLock(const String &name);
+	DUCKDB_API void CheckLock(const Identifier &name);
 
 	DUCKDB_API static idx_t ParseMemoryLimit(const string &arg);
 
@@ -286,14 +286,14 @@ public:
 	const string UserAgent() const;
 
 	//! Returns the value of a setting currently. If the setting is not set by the user, returns the default value.
-	SettingLookupResult TryGetCurrentSetting(const string &key, Value &result) const;
+	SettingLookupResult TryGetCurrentSetting(const Identifier &key, Value &result) const;
 	//! Returns the value of a setting set by the user currently
 	SettingLookupResult TryGetCurrentUserSetting(idx_t setting_index, Value &result) const;
 	//! Returns the default value of an option
 	static SettingLookupResult TryGetDefaultValue(optional_ptr<const ConfigurationOption> option, Value &result);
 
 	bool CanAccessFile(const string &path, FileType type);
-	void AddAllowedConfig(const string &config_name);
+	void AddAllowedConfig(const Identifier &config_name);
 	void AddAllowedDirectory(const string &path);
 	void AddAllowedPath(const string &path);
 	string SanitizeAllowedPath(const string &path) const;

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -209,7 +209,7 @@ public:
 	DUCKDB_API static vector<ConfigurationAlias> GetAliases();
 	DUCKDB_API static idx_t GetOptionCount();
 	DUCKDB_API static idx_t GetAliasCount();
-	DUCKDB_API static vector<string> GetOptionNames();
+	DUCKDB_API static vector<Identifier> GetOptionNames();
 	DUCKDB_API static bool IsInMemoryDatabase(const char *database_path);
 
 	DUCKDB_API void AddExtensionOption(const Identifier &name, string description, LogicalType parameter,

--- a/src/include/duckdb/main/database.hpp
+++ b/src/include/duckdb/main/database.hpp
@@ -80,7 +80,7 @@ public:
 
 	DUCKDB_API bool ExtensionIsLoaded(const string &name);
 
-	DUCKDB_API SettingLookupResult TryGetCurrentSetting(const string &key, Value &result) const;
+	DUCKDB_API SettingLookupResult TryGetCurrentSetting(const Identifier &key, Value &result) const;
 
 	DUCKDB_API shared_ptr<EncryptionUtil> GetEncryptionUtil(bool read_only = false);
 	shared_ptr<EncryptionUtil> GetMbedTLSUtil(bool force_mbedtls) const;

--- a/src/include/duckdb/main/database_file_opener.hpp
+++ b/src/include/duckdb/main/database_file_opener.hpp
@@ -28,11 +28,11 @@ public:
 		return Logger::Get(db);
 	}
 
-	SettingLookupResult TryGetCurrentSetting(const string &key, Value &result) override {
+	SettingLookupResult TryGetCurrentSetting(const Identifier &key, Value &result) override {
 		return db.TryGetCurrentSetting(key, result);
 	}
 
-	SettingLookupResult TryGetCurrentSetting(const string &key, Value &result, FileOpenerInfo &) override {
+	SettingLookupResult TryGetCurrentSetting(const Identifier &key, Value &result, FileOpenerInfo &) override {
 		return db.TryGetCurrentSetting(key, result);
 	}
 

--- a/src/include/duckdb/main/extension_helper.hpp
+++ b/src/include/duckdb/main/extension_helper.hpp
@@ -178,13 +178,11 @@ public:
 	//! Lookup a name + type in an ExtensionFunctionEntry list
 	template <size_t N>
 	static vector<pair<string, CatalogType>>
-	FindExtensionInFunctionEntries(const string &name, const ExtensionFunctionEntry (&entries)[N]) {
-		auto lcase = StringUtil::Lower(name);
-
+	FindExtensionInFunctionEntries(const Identifier &name, const ExtensionFunctionEntry (&entries)[N]) {
 		vector<pair<string, CatalogType>> result;
 		for (idx_t i = 0; i < N; i++) {
 			auto &element = entries[i];
-			if (element.name == lcase) {
+			if (element.name == name) {
 				result.push_back(make_pair(element.extension, element.type));
 			}
 		}
@@ -206,13 +204,11 @@ public:
 
 	//! Lookup a name in an ExtensionEntry list
 	template <idx_t N>
-	static string FindExtensionInEntries(const string &name, const ExtensionEntry (&entries)[N]) {
-		auto lcase = StringUtil::Lower(name);
-
+	static string FindExtensionInEntries(const Identifier &name, const ExtensionEntry (&entries)[N]) {
 		auto it =
-		    std::find_if(entries, entries + N, [&](const ExtensionEntry &element) { return element.name == lcase; });
+		    std::find_if(entries, entries + N, [&](const ExtensionEntry &element) { return element.name == name; });
 
-		if (it != entries + N && it->name == lcase) {
+		if (it != entries + N) {
 			return it->extension;
 		}
 		return "";
@@ -220,7 +216,8 @@ public:
 
 	//! Lookup a name in an extension entry and try to autoload it
 	template <idx_t N>
-	static void TryAutoloadFromEntry(DatabaseInstance &db, const string &entry, const ExtensionEntry (&entries)[N]) {
+	static void TryAutoloadFromEntry(DatabaseInstance &db, const Identifier &entry,
+	                                 const ExtensionEntry (&entries)[N]) {
 #ifndef DUCKDB_DISABLE_EXTENSION_LOAD
 		if (Settings::Get<AutoloadKnownExtensionsSetting>(db)) {
 			auto extension_name = ExtensionHelper::FindExtensionInEntries(entry, entries);

--- a/src/include/duckdb/main/secret/secret.hpp
+++ b/src/include/duckdb/main/secret/secret.hpp
@@ -285,17 +285,18 @@ public:
 	~KeyValueSecretReader();
 
 	//! Lookup a KeyValueSecret value
-	SettingLookupResult TryGetSecretKey(const string &secret_key, Value &result);
+	SettingLookupResult TryGetSecretKey(const Identifier &secret_key, Value &result);
 	//! Lookup a KeyValueSecret value or a setting
-	SettingLookupResult TryGetSecretKeyOrSetting(const string &secret_key, const string &setting_name, Value &result);
+	SettingLookupResult TryGetSecretKeyOrSetting(const Identifier &secret_key, const Identifier &setting_name,
+	                                             Value &result);
 	//! Lookup a KeyValueSecret value or a setting, throws InvalidInputException on not found
-	Value GetSecretKey(const string &secret_key);
+	Value GetSecretKey(const Identifier &secret_key);
 	//! Lookup a KeyValueSecret value or a setting, throws InvalidInputException on not found
-	Value GetSecretKeyOrSetting(const string &secret_key, const string &setting_name);
+	Value GetSecretKeyOrSetting(const Identifier &secret_key, const Identifier &setting_name);
 
 	//! Templating around TryGetSecretKey
 	template <class TYPE>
-	SettingLookupResult TryGetSecretKey(const string &secret_key, TYPE &value_out) {
+	SettingLookupResult TryGetSecretKey(const Identifier &secret_key, TYPE &value_out) {
 		Value result;
 		auto lookup_result = TryGetSecretKey(secret_key, result);
 		if (lookup_result) {
@@ -306,7 +307,7 @@ public:
 
 	//! Templating around TryGetSecretOrSetting
 	template <class TYPE>
-	SettingLookupResult TryGetSecretKeyOrSetting(const string &secret_key, const string &setting_name,
+	SettingLookupResult TryGetSecretKeyOrSetting(const Identifier &secret_key, const Identifier &setting_name,
 	                                             TYPE &value_out) {
 		Value result;
 		auto lookup_result = TryGetSecretKeyOrSetting(secret_key, setting_name, result);
@@ -320,7 +321,8 @@ public:
 
 	// Like a templated GetSecretOrSetting but instead of throwing on not found, return the default value
 	template <class TYPE>
-	TYPE GetSecretKeyOrSettingOrDefault(const string &secret_key, const string &setting_name, TYPE default_value) {
+	TYPE GetSecretKeyOrSettingOrDefault(const Identifier &secret_key, const Identifier &setting_name,
+	                                    TYPE default_value) {
 		TYPE result;
 		if (TryGetSecretKeyOrSetting(secret_key, setting_name, result)) {
 			return result;
@@ -331,8 +333,8 @@ public:
 protected:
 	void Initialize(const char **secret_types, idx_t secret_types_len);
 
-	[[noreturn]] void ThrowNotFoundError(const string &secret_key);
-	[[noreturn]] void ThrowNotFoundError(const string &secret_key, const string &setting_name);
+	[[noreturn]] void ThrowNotFoundError(const Identifier &secret_key);
+	[[noreturn]] void ThrowNotFoundError(const Identifier &secret_key, const Identifier &setting_name);
 
 	//! Fetching the secret
 	optional_ptr<const KeyValueSecret> secret;

--- a/src/include/duckdb/main/secret/secret_manager.hpp
+++ b/src/include/duckdb/main/secret/secret_manager.hpp
@@ -166,7 +166,7 @@ private:
 	//! Lookup a SecretType, throws if not found
 	SecretType LookupTypeInternal(const Identifier &type);
 	//! Try to lookup a SecretType
-	bool TryLookupTypeInternal(const string &type, SecretType &type_out);
+	bool TryLookupTypeInternal(const Identifier &type, SecretType &type_out);
 	//! Register a secret provider
 	void RegisterSecretFunctionInternal(CreateSecretFunction function, OnCreateConflict on_conflict);
 	//! Lookup a CreateSecretFunction
@@ -181,13 +181,14 @@ private:
 	void LoadSecretStorageInternal(unique_ptr<SecretStorage> storage);
 
 	//! Autoload extension for specific secret type
-	void AutoloadExtensionForType(const string &type);
+	void AutoloadExtensionForType(const Identifier &type);
 	//! Autoload extension for specific secret function
-	void AutoloadExtensionForFunction(const string &type, const string &provider);
+	void AutoloadExtensionForFunction(const Identifier &type, const Identifier &provider);
 
 	//! Will throw appropriate error message when type not found
 	[[noreturn]] void ThrowTypeNotFoundError(const Identifier &type, const string &secret_path = "");
-	[[noreturn]] void ThrowProviderNotFoundError(const string &type, const string &provider, bool was_default = false);
+	[[noreturn]] void ThrowProviderNotFoundError(const Identifier &type, const Identifier &provider,
+	                                             bool was_default = false);
 
 	//! Thread-safe accessors for secret_storages
 	vector<reference<SecretStorage>> GetSecretStorages();

--- a/src/include/duckdb/main/user_settings.hpp
+++ b/src/include/duckdb/main/user_settings.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "duckdb/common/common.hpp"
+#include "duckdb/common/identifier.hpp"
 #include "duckdb/common/mutex.hpp"
 #include "duckdb/common/types/value.hpp"
 #include "duckdb/main/setting_info.hpp"
@@ -60,10 +61,10 @@ public:
 	void ClearSetting(idx_t setting_index);
 	bool IsSet(idx_t setting_index) const;
 	SettingLookupResult TryGetSetting(idx_t setting_index, Value &result_value) const;
-	bool HasExtensionOption(const string &name) const;
-	idx_t AddExtensionOption(const string &name, ExtensionOption extension_option);
-	case_insensitive_map_t<ExtensionOption> GetExtensionSettings() const;
-	bool TryGetExtensionOption(const String &name, ExtensionOption &result) const;
+	bool HasExtensionOption(const Identifier &name) const;
+	idx_t AddExtensionOption(const Identifier &name, ExtensionOption extension_option);
+	identifier_map_t<ExtensionOption> GetExtensionSettings() const;
+	bool TryGetExtensionOption(const Identifier &name, ExtensionOption &result) const;
 	hugeint_t GetUUID() const;
 
 #ifndef __MINGW32__
@@ -75,7 +76,7 @@ private:
 	//! Database-global settings
 	UserSettingsMap settings_map;
 	//! Extra parameters that can be SET for loaded extensions
-	case_insensitive_map_t<ExtensionOption> extension_parameters;
+	identifier_map_t<ExtensionOption> extension_parameters;
 	//! Current version of the settings - incremented when settings are modified
 	atomic<idx_t> settings_version;
 	//! Settings uuid

--- a/src/main/capi/config_options-c.cpp
+++ b/src/main/capi/config_options-c.cpp
@@ -110,11 +110,12 @@ duckdb_state duckdb_register_config_option(duckdb_connection connection, duckdb_
 
 	// TODO: This is not transactional... but theres no easy way to make it so currently.
 	try {
-		if (conn->context->db->config.HasExtensionOption(coption->name)) {
+		duckdb::Identifier option_name(coption->name);
+		if (conn->context->db->config.HasExtensionOption(option_name)) {
 			// Option already exists
 			return DuckDBError;
 		}
-		conn->context->db->config.AddExtensionOption(coption->name, coption->description, coption->type,
+		conn->context->db->config.AddExtensionOption(option_name, coption->description, coption->type,
 		                                             coption->default_value, nullptr, coption->default_scope);
 	} catch (...) {
 		return DuckDBError;

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -1566,7 +1566,7 @@ unique_ptr<QueryResult> ClientContext::Execute(const shared_ptr<Relation> &relat
 	return ErrorResult<MaterializedQueryResult>(ErrorData(err_str));
 }
 
-SettingLookupResult ClientContext::TryGetCurrentSetting(const string &key, Value &result) const {
+SettingLookupResult ClientContext::TryGetCurrentSetting(const Identifier &key, Value &result) const {
 	optional_ptr<const ConfigurationOption> option;
 	// try to get the setting index
 	auto &db_config = DBConfig::GetConfig(*this);

--- a/src/main/client_context_file_opener.cpp
+++ b/src/main/client_context_file_opener.cpp
@@ -9,7 +9,7 @@
 
 namespace duckdb {
 
-SettingLookupResult ClientContextFileOpener::TryGetCurrentSetting(const string &key, Value &result) {
+SettingLookupResult ClientContextFileOpener::TryGetCurrentSetting(const Identifier &key, Value &result) {
 	return context.TryGetCurrentSetting(key, result);
 }
 
@@ -18,7 +18,8 @@ Logger &ClientContextFileOpener::GetLogger() const {
 }
 
 // LCOV_EXCL_START
-SettingLookupResult ClientContextFileOpener::TryGetCurrentSetting(const string &key, Value &result, FileOpenerInfo &) {
+SettingLookupResult ClientContextFileOpener::TryGetCurrentSetting(const Identifier &key, Value &result,
+                                                                  FileOpenerInfo &) {
 	return context.TryGetCurrentSetting(key, result);
 }
 
@@ -73,7 +74,7 @@ optional_ptr<SecretManager> FileOpener::TryGetSecretManager(optional_ptr<FileOpe
 	return &db->GetSecretManager();
 }
 
-SettingLookupResult FileOpener::TryGetCurrentSetting(optional_ptr<FileOpener> opener, const string &key,
+SettingLookupResult FileOpener::TryGetCurrentSetting(optional_ptr<FileOpener> opener, const Identifier &key,
                                                      Value &result) {
 	if (!opener) {
 		return SettingLookupResult();
@@ -81,15 +82,15 @@ SettingLookupResult FileOpener::TryGetCurrentSetting(optional_ptr<FileOpener> op
 	return opener->TryGetCurrentSetting(key, result);
 }
 
-SettingLookupResult FileOpener::TryGetCurrentSetting(optional_ptr<FileOpener> opener, const string &key, Value &result,
-                                                     FileOpenerInfo &info) {
+SettingLookupResult FileOpener::TryGetCurrentSetting(optional_ptr<FileOpener> opener, const Identifier &key,
+                                                     Value &result, FileOpenerInfo &info) {
 	if (!opener) {
 		return SettingLookupResult();
 	}
 	return opener->TryGetCurrentSetting(key, result, info);
 }
 
-SettingLookupResult FileOpener::TryGetCurrentSetting(const string &key, Value &result, FileOpenerInfo &info) {
+SettingLookupResult FileOpener::TryGetCurrentSetting(const Identifier &key, Value &result, FileOpenerInfo &info) {
 	return TryGetCurrentSetting(key, result);
 }
 // LCOV_EXCL_STOP

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -290,8 +290,8 @@ idx_t DBConfig::GetAliasCount() {
 	return sizeof(setting_aliases) / sizeof(ConfigurationAlias) - 1;
 }
 
-vector<string> DBConfig::GetOptionNames() {
-	vector<string> names;
+vector<Identifier> DBConfig::GetOptionNames() {
+	vector<Identifier> names;
 	for (idx_t index = 0; internal_options[index].name; index++) {
 		names.emplace_back(internal_options[index].name);
 	}

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -317,13 +317,11 @@ optional_ptr<const ConfigurationAlias> DBConfig::GetAliasByIndex(idx_t target_in
 
 optional_ptr<const ConfigurationOption> DBConfig::GetOptionByName(const Identifier &name) {
 	for (idx_t index = 0; internal_options[index].name; index++) {
-		D_ASSERT(StringUtil::Lower(internal_options[index].name) == string(internal_options[index].name));
 		if (internal_options[index].name == name) {
 			return internal_options + index;
 		}
 	}
 	for (idx_t index = 0; setting_aliases[index].alias; index++) {
-		D_ASSERT(StringUtil::Lower(internal_options[index].name) == string(internal_options[index].name));
 		if (setting_aliases[index].alias == name) {
 			return GetOptionByIndex(setting_aliases[index].option_index);
 		}

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -315,17 +315,16 @@ optional_ptr<const ConfigurationAlias> DBConfig::GetAliasByIndex(idx_t target_in
 	return setting_aliases + target_index;
 }
 
-optional_ptr<const ConfigurationOption> DBConfig::GetOptionByName(const String &name) {
-	auto lname = name.Lower();
+optional_ptr<const ConfigurationOption> DBConfig::GetOptionByName(const Identifier &name) {
 	for (idx_t index = 0; internal_options[index].name; index++) {
 		D_ASSERT(StringUtil::Lower(internal_options[index].name) == string(internal_options[index].name));
-		if (internal_options[index].name == lname) {
+		if (internal_options[index].name == name) {
 			return internal_options + index;
 		}
 	}
 	for (idx_t index = 0; setting_aliases[index].alias; index++) {
 		D_ASSERT(StringUtil::Lower(internal_options[index].name) == string(internal_options[index].name));
-		if (setting_aliases[index].alias == lname) {
+		if (setting_aliases[index].alias == name) {
 			return GetOptionByIndex(setting_aliases[index].option_index);
 		}
 	}
@@ -336,7 +335,7 @@ void DBConfig::SetOption(const ConfigurationOption &option, const Value &value) 
 	SetOption(nullptr, option, value);
 }
 
-void DBConfig::SetOptionByName(const string &name, const Value &value) {
+void DBConfig::SetOptionByName(const Identifier &name, const Value &value) {
 	if (is_user_config) {
 		// for user config we just set the option in the `user_options`
 		options.user_options[name] = value;
@@ -356,7 +355,7 @@ void DBConfig::SetOptionByName(const string &name, const Value &value) {
 	}
 }
 
-void DBConfig::SetOptionsByName(const case_insensitive_map_t<Value> &values) {
+void DBConfig::SetOptionsByName(const identifier_map_t<Value> &values) {
 	for (auto &kv : values) {
 		auto &name = kv.first;
 		auto &value = kv.second;
@@ -401,7 +400,7 @@ void DBConfig::SetOption(idx_t setting_index, Value value) {
 	user_settings.SetUserSetting(setting_index, std::move(value));
 }
 
-void DBConfig::SetOption(const string &name, Value value) {
+void DBConfig::SetOption(const Identifier &name, Value value) {
 	optional_ptr<const ConfigurationOption> option;
 	auto setting_index = TryGetSettingIndex(name, option);
 	if (!setting_index.IsValid()) {
@@ -521,15 +520,15 @@ LogicalType DBConfig::ParseLogicalType(const string &type) {
 	return type_id;
 }
 
-bool DBConfig::HasExtensionOption(const string &name) const {
+bool DBConfig::HasExtensionOption(const Identifier &name) const {
 	return user_settings.HasExtensionOption(name);
 }
 
-bool DBConfig::TryGetExtensionOption(const String &name, ExtensionOption &result) const {
+bool DBConfig::TryGetExtensionOption(const Identifier &name, ExtensionOption &result) const {
 	return user_settings.TryGetExtensionOption(name, result);
 }
 
-void DBConfig::AddExtensionOption(const string &name, string description, LogicalType parameter,
+void DBConfig::AddExtensionOption(const Identifier &name, string description, LogicalType parameter,
                                   const Value &default_value, set_option_callback_t function, SetScope default_scope) {
 	ExtensionOption extension_option(std::move(description), std::move(parameter), function, default_value,
 	                                 default_scope);
@@ -546,7 +545,7 @@ void DBConfig::AddExtensionOption(const string &name, string description, Logica
 	}
 }
 
-case_insensitive_map_t<ExtensionOption> DBConfig::GetExtensionSettings() const {
+identifier_map_t<ExtensionOption> DBConfig::GetExtensionSettings() const {
 	return user_settings.GetExtensionSettings();
 }
 
@@ -602,20 +601,20 @@ void DBConfig::SetDefaultTempDirectory() {
 	}
 }
 
-void DBConfig::CheckLock(const String &name) {
+void DBConfig::CheckLock(const Identifier &name) {
 	if (!Settings::Get<LockConfigurationSetting>(*this)) {
 		// not locked
 		return;
 	}
 	identifier_set_t allowed_settings {"schema", "search_path"};
-	if (allowed_settings.find(Identifier(name.ToStdString())) != allowed_settings.end()) {
+	if (allowed_settings.find(name) != allowed_settings.end()) {
 		// we are always allowed to change these settings
 		return;
 	}
 	if (!options.allowed_configs.empty()) {
 		auto option = GetOptionByName(name);
-		auto canonical_name = option ? string(option->name) : name.ToStdString();
-		if (options.allowed_configs.find(Identifier(canonical_name)) != options.allowed_configs.end()) {
+		auto canonical_name = option ? Identifier(option->name) : name;
+		if (options.allowed_configs.find(canonical_name) != options.allowed_configs.end()) {
 			// settings that are allowed through allowed_configs
 			return;
 		}
@@ -777,7 +776,7 @@ SettingLookupResult DBConfig::TryGetDefaultValue(optional_ptr<const Configuratio
 	return SettingLookupResult(SettingScope::GLOBAL);
 }
 
-SettingLookupResult DBConfig::TryGetCurrentSetting(const string &key, Value &result) const {
+SettingLookupResult DBConfig::TryGetCurrentSetting(const Identifier &key, Value &result) const {
 	optional_ptr<const ConfigurationOption> option;
 	auto setting_index = TryGetSettingIndex(key, option);
 	if (setting_index.IsValid()) {
@@ -789,7 +788,8 @@ SettingLookupResult DBConfig::TryGetCurrentSetting(const string &key, Value &res
 	return TryGetDefaultValue(option, result);
 }
 
-optional_idx DBConfig::TryGetSettingIndex(const String &name, optional_ptr<const ConfigurationOption> &option) const {
+optional_idx DBConfig::TryGetSettingIndex(const Identifier &name,
+                                          optional_ptr<const ConfigurationOption> &option) const {
 	ExtensionOption extension_option;
 	if (TryGetExtensionOption(name, extension_option)) {
 		// extension setting
@@ -860,12 +860,12 @@ string DBConfig::SanitizeAllowedPath(const string &path_p) const {
 	return result;
 }
 
-void DBConfig::AddAllowedConfig(const string &config_name) {
+void DBConfig::AddAllowedConfig(const Identifier &config_name) {
 	if (config_name.empty()) {
 		throw InvalidInputException("Cannot provide an empty string for allowed_configs");
 	}
 	duckdb::identifier_set_t always_disallowed_config {"allowed_configs", "lock_configuration"};
-	if (always_disallowed_config.find(Identifier(config_name)) != always_disallowed_config.end()) {
+	if (always_disallowed_config.find(config_name) != always_disallowed_config.end()) {
 		throw InvalidInputException("Cannot include '%s' in allowed_configs", config_name);
 	}
 	// Validate that the config name refers to a known setting (built-in or extension)
@@ -878,14 +878,14 @@ void DBConfig::AddAllowedConfig(const string &config_name) {
 	}
 	ExtensionOption extension_option;
 	if (TryGetExtensionOption(config_name, extension_option)) {
-		options.allowed_configs.insert(Identifier(config_name));
+		options.allowed_configs.insert(config_name);
 		return;
 	}
 	// Check if the setting belongs to a known extension (even if not yet loaded)
 	auto extension_name = ExtensionHelper::FindExtensionInEntries(config_name, EXTENSION_SETTINGS);
 	if (!extension_name.empty()) {
 		// Accept the setting - the extension may be autoloaded later when the setting is used
-		options.allowed_configs.insert(Identifier(config_name));
+		options.allowed_configs.insert(config_name);
 		return;
 	}
 	throw InvalidInputException("Unknown configuration option '%s' in allowed_configs", config_name);

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -70,7 +70,7 @@ DBConfig::DBConfig(bool read_only) : DBConfig::DBConfig() {
 	}
 }
 
-DBConfig::DBConfig(const case_insensitive_map_t<Value> &config_dict, bool read_only) : DBConfig::DBConfig(read_only) {
+DBConfig::DBConfig(const identifier_map_t<Value> &config_dict, bool read_only) : DBConfig::DBConfig(read_only) {
 	SetOptionsByName(config_dict);
 }
 
@@ -236,10 +236,10 @@ void DatabaseInstance::CreateMainDatabase() {
 	con.Commit();
 }
 
-static void ThrowExtensionSetUnrecognizedOptions(const case_insensitive_map_t<Value> &unrecognized_options) {
+static void ThrowExtensionSetUnrecognizedOptions(const identifier_map_t<Value> &unrecognized_options) {
 	D_ASSERT(!unrecognized_options.empty());
 
-	vector<string> options;
+	vector<duckdb::Identifier> options;
 	for (auto &kv : unrecognized_options) {
 		options.push_back(kv.first);
 	}
@@ -260,7 +260,6 @@ void DatabaseInstance::LoadExtensionSettings() {
 		Connection con(*this);
 		con.BeginTransaction();
 
-		vector<string> extension_options;
 		for (auto &option : unrecognized_options_copy) {
 			auto &name = option.first;
 			auto &value = option.second;
@@ -281,8 +280,7 @@ void DatabaseInstance::LoadExtensionSettings() {
 			// if the extension provided the option, it should no longer be unrecognized.
 			D_ASSERT(config.options.unrecognized_options.find(name) == config.options.unrecognized_options.end());
 			auto &context = *con.context;
-			PhysicalSet::SetExtensionVariable(context, extension_option, name, SetScope::GLOBAL, value);
-			extension_options.push_back(name);
+			PhysicalSet::SetExtensionVariable(context, extension_option, SetScope::GLOBAL, value);
 		}
 
 		con.Commit();
@@ -588,7 +586,7 @@ bool DuckDB::ExtensionIsLoaded(const std::string &name) {
 	return instance->ExtensionIsLoaded(name);
 }
 
-SettingLookupResult DatabaseInstance::TryGetCurrentSetting(const string &key, Value &result) const {
+SettingLookupResult DatabaseInstance::TryGetCurrentSetting(const Identifier &key, Value &result) const {
 	// check the session values
 	auto &db_config = DBConfig::GetConfig(*this);
 	return db_config.TryGetCurrentSetting(key, result);

--- a/src/main/secret/secret.cpp
+++ b/src/main/secret/secret.cpp
@@ -184,16 +184,16 @@ KeyValueSecretReader::KeyValueSecretReader(FileOpener &opener_p, optional_ptr<Fi
 KeyValueSecretReader::~KeyValueSecretReader() {
 }
 
-SettingLookupResult KeyValueSecretReader::TryGetSecretKey(const string &secret_key, Value &result) {
-	if (secret && secret->TryGetValue(Identifier(secret_key), result)) {
+SettingLookupResult KeyValueSecretReader::TryGetSecretKey(const Identifier &secret_key, Value &result) {
+	if (secret && secret->TryGetValue(secret_key, result)) {
 		return SettingLookupResult(SettingScope::SECRET);
 	}
 	return SettingLookupResult();
 }
 
-SettingLookupResult KeyValueSecretReader::TryGetSecretKeyOrSetting(const string &secret_key, const string &setting_name,
-                                                                   Value &result) {
-	if (secret && secret->TryGetValue(Identifier(secret_key), result)) {
+SettingLookupResult KeyValueSecretReader::TryGetSecretKeyOrSetting(const Identifier &secret_key,
+                                                                   const Identifier &setting_name, Value &result) {
+	if (secret && secret->TryGetValue(secret_key, result)) {
 		return SettingLookupResult(SettingScope::SECRET);
 	}
 	if (context) {
@@ -208,7 +208,7 @@ SettingLookupResult KeyValueSecretReader::TryGetSecretKeyOrSetting(const string 
 	return SettingLookupResult();
 }
 
-Value KeyValueSecretReader::GetSecretKey(const string &secret_key) {
+Value KeyValueSecretReader::GetSecretKey(const Identifier &secret_key) {
 	Value result;
 	if (TryGetSecretKey(secret_key, result)) {
 		return result;
@@ -216,7 +216,7 @@ Value KeyValueSecretReader::GetSecretKey(const string &secret_key) {
 	ThrowNotFoundError(secret_key);
 }
 
-Value KeyValueSecretReader::GetSecretKeyOrSetting(const string &secret_key, const string &setting_name) {
+Value KeyValueSecretReader::GetSecretKeyOrSetting(const Identifier &secret_key, const Identifier &setting_name) {
 	Value result;
 	if (TryGetSecretKeyOrSetting(secret_key, setting_name, result)) {
 		return result;
@@ -224,8 +224,8 @@ Value KeyValueSecretReader::GetSecretKeyOrSetting(const string &secret_key, cons
 	ThrowNotFoundError(secret_key, setting_name);
 }
 
-void KeyValueSecretReader::ThrowNotFoundError(const string &secret_key) {
-	string base_message = "Failed to fetch required secret key '%s' from secret";
+void KeyValueSecretReader::ThrowNotFoundError(const Identifier &secret_key) {
+	string base_message = "Failed to fetch required secret key %s from secret";
 
 	if (!secret) {
 		string secret_scope = path;
@@ -234,11 +234,11 @@ void KeyValueSecretReader::ThrowNotFoundError(const string &secret_key) {
 		                                    secret_scope_hint_message);
 	}
 
-	throw InvalidConfigurationException(base_message + " '%s'.", secret_key, secret->GetName());
+	throw InvalidConfigurationException(base_message + " %s.", secret_key, secret->GetName());
 }
 
-void KeyValueSecretReader::ThrowNotFoundError(const string &secret_key, const string &setting_name) {
-	string base_message = "Failed to fetch a parameter from either the secret key '%s' or the setting '%s'";
+void KeyValueSecretReader::ThrowNotFoundError(const Identifier &secret_key, const Identifier &setting_name) {
+	string base_message = "Failed to fetch a parameter from either the secret key %s or the setting %s";
 
 	if (!secret) {
 		string secret_scope = path;
@@ -248,7 +248,7 @@ void KeyValueSecretReader::ThrowNotFoundError(const string &secret_key, const st
 	}
 
 	throw InvalidConfigurationException(base_message +
-	                                        ": secret '%s' did not contain the key, also the setting was not found.",
+	                                        ": secret %s did not contain the key, also the setting was not found.",
 	                                    secret_key, setting_name, secret->GetName());
 }
 

--- a/src/main/secret/secret_manager.cpp
+++ b/src/main/secret/secret_manager.cpp
@@ -101,9 +101,9 @@ void SecretManager::LoadSecretStorageInternal(unique_ptr<SecretStorage> storage)
 
 // FIXME: use serialization scripts?
 unique_ptr<BaseSecret> SecretManager::DeserializeSecret(Deserializer &deserializer, const string &secret_path) {
-	auto type = deserializer.ReadProperty<string>(100, "type");
-	auto provider = deserializer.ReadProperty<string>(101, "provider");
-	auto name = deserializer.ReadProperty<string>(102, "name");
+	auto type = deserializer.ReadProperty<Identifier>(100, "type");
+	auto provider = deserializer.ReadProperty<Identifier>(101, "provider");
+	auto name = deserializer.ReadProperty<Identifier>(102, "name");
 	vector<string> scope;
 	deserializer.ReadList(103, "scope",
 	                      [&](Deserializer::List &list, idx_t i) { scope.push_back(list.ReadElement<string>()); });
@@ -113,8 +113,7 @@ unique_ptr<BaseSecret> SecretManager::DeserializeSecret(Deserializer &deserializ
 	switch (serialization_type) {
 	// This allows us to skip looking up the secret type for deserialization altogether
 	case SecretSerializationType::KEY_VALUE_SECRET:
-		return KeyValueSecret::Deserialize<KeyValueSecret>(
-		    deserializer, BaseSecret(scope, Identifier(type), Identifier(provider), Identifier(name)));
+		return KeyValueSecret::Deserialize<KeyValueSecret>(deserializer, BaseSecret(scope, type, provider, name));
 	// Continues below: we need to do a type lookup to find the secret deserialize method
 	case SecretSerializationType::CUSTOM:
 		break;
@@ -125,7 +124,7 @@ unique_ptr<BaseSecret> SecretManager::DeserializeSecret(Deserializer &deserializ
 
 	SecretType deserialized_type;
 	if (!TryLookupTypeInternal(type, deserialized_type)) {
-		ThrowTypeNotFoundError(Identifier(type), secret_path);
+		ThrowTypeNotFoundError(type, secret_path);
 	}
 
 	if (!deserialized_type.deserializer) {
@@ -133,8 +132,7 @@ unique_ptr<BaseSecret> SecretManager::DeserializeSecret(Deserializer &deserializ
 		    "Attempted to deserialize secret type '%s' which does not have a deserialization method", type);
 	}
 
-	return deserialized_type.deserializer(deserializer,
-	                                      BaseSecret(scope, Identifier(type), Identifier(provider), Identifier(name)));
+	return deserialized_type.deserializer(deserializer, BaseSecret(scope, type, provider, name));
 }
 
 void SecretManager::RegisterSecretType(SecretType &type) {
@@ -232,7 +230,7 @@ optional_ptr<CreateSecretFunction> SecretManager::LookupFunctionInternal(const I
 
 	// Try autoloading
 	lck.unlock();
-	AutoloadExtensionForFunction(type.GetIdentifierName(), provider.GetIdentifierName());
+	AutoloadExtensionForFunction(type, provider);
 	lck.lock();
 
 	lookup = secret_functions.find(type);
@@ -261,7 +259,7 @@ unique_ptr<SecretEntry> SecretManager::CreateSecret(ClientContext &context, cons
 	// Lookup function
 	auto function_lookup = LookupFunctionInternal(function_input.type, function_input.provider);
 	if (!function_lookup) {
-		ThrowProviderNotFoundError(input.type.GetIdentifierName(), input.provider.GetIdentifierName());
+		ThrowProviderNotFoundError(input.type, input.provider);
 	}
 
 	// Call the function
@@ -298,7 +296,7 @@ BoundStatement SecretManager::BindCreateSecret(CatalogTransaction transaction, C
 	auto function = LookupFunctionInternal(type, provider);
 
 	if (!function) {
-		ThrowProviderNotFoundError(info.type.GetIdentifierName(), info.provider.GetIdentifierName(), default_provider);
+		ThrowProviderNotFoundError(info.type, info.provider, default_provider);
 	}
 
 	auto bound_info = info;
@@ -488,9 +486,9 @@ void SecretManager::RegisterSecretTypeInternal(SecretType &type) {
 	secret_types[type.name] = type;
 }
 
-bool SecretManager::TryLookupTypeInternal(const string &type, SecretType &type_out) {
+bool SecretManager::TryLookupTypeInternal(const Identifier &type, SecretType &type_out) {
 	unique_lock<mutex> lck(manager_lock);
-	auto lookup = secret_types.find(Identifier(type));
+	auto lookup = secret_types.find(type);
 	if (lookup != secret_types.end()) {
 		type_out = lookup->second;
 		return true;
@@ -501,7 +499,7 @@ bool SecretManager::TryLookupTypeInternal(const string &type, SecretType &type_o
 	AutoloadExtensionForType(type);
 	lck.lock();
 
-	lookup = secret_types.find(Identifier(type));
+	lookup = secret_types.find(type);
 	if (lookup != secret_types.end()) {
 		type_out = lookup->second;
 		return true;
@@ -512,7 +510,7 @@ bool SecretManager::TryLookupTypeInternal(const string &type, SecretType &type_o
 
 SecretType SecretManager::LookupTypeInternal(const Identifier &type) {
 	SecretType return_value;
-	if (!TryLookupTypeInternal(type.GetIdentifierName(), return_value)) {
+	if (!TryLookupTypeInternal(type, return_value)) {
 		ThrowTypeNotFoundError(type);
 	}
 	return return_value;
@@ -630,13 +628,17 @@ void SecretManager::InitializeSecrets(CatalogTransaction transaction) {
 	}
 }
 
-void SecretManager::AutoloadExtensionForType(const string &type) {
-	ExtensionHelper::TryAutoloadFromEntry(*db, StringUtil::Lower(type), EXTENSION_SECRET_TYPES);
+//! EXTENSION_SECRET_PROVIDERS is keyed on the composite "type/provider" name
+static Identifier SecretProviderKey(const Identifier &type, const Identifier &provider) {
+	return Identifier(type + "/" + provider);
+}
+
+void SecretManager::AutoloadExtensionForType(const Identifier &type) {
+	ExtensionHelper::TryAutoloadFromEntry(*db, type, EXTENSION_SECRET_TYPES);
 }
 
 void SecretManager::ThrowTypeNotFoundError(const Identifier &type, const string &secret_path) {
-	auto entry =
-	    ExtensionHelper::FindExtensionInEntries(StringUtil::Lower(type.GetIdentifierName()), EXTENSION_SECRET_TYPES);
+	auto entry = ExtensionHelper::FindExtensionInEntries(type, EXTENSION_SECRET_TYPES);
 	string error_message;
 
 	if (!entry.empty() && db) {
@@ -661,23 +663,21 @@ void SecretManager::ThrowTypeNotFoundError(const Identifier &type, const string 
 	throw InvalidInputException(error_message);
 }
 
-void SecretManager::AutoloadExtensionForFunction(const string &type, const string &provider) {
-	ExtensionHelper::TryAutoloadFromEntry(*db, StringUtil::Lower(type) + "/" + StringUtil::Lower(provider),
-	                                      EXTENSION_SECRET_PROVIDERS);
+void SecretManager::AutoloadExtensionForFunction(const Identifier &type, const Identifier &provider) {
+	ExtensionHelper::TryAutoloadFromEntry(*db, SecretProviderKey(type, provider), EXTENSION_SECRET_PROVIDERS);
 }
 
-void SecretManager::ThrowProviderNotFoundError(const string &type, const string &provider, bool was_default) {
-	auto entry = ExtensionHelper::FindExtensionInEntries(StringUtil::Lower(type) + "/" + StringUtil::Lower(provider),
-	                                                     EXTENSION_SECRET_PROVIDERS);
+void SecretManager::ThrowProviderNotFoundError(const Identifier &type, const Identifier &provider, bool was_default) {
+	auto entry = ExtensionHelper::FindExtensionInEntries(SecretProviderKey(type, provider), EXTENSION_SECRET_PROVIDERS);
 	if (!entry.empty() && db) {
 		string error_message = was_default ? "Default secret provider" : "Secret provider";
-		error_message +=
-		    " '" + provider + "' for type '" + type + "' does not exist, but it exists in the " + entry + " extension.";
+		error_message += StringUtil::Format(" %s for type %s does not exist, but it exists in the %s extension.",
+		                                    provider, type, entry);
 		error_message = ExtensionHelper::AddExtensionInstallHintToErrorMsg(*db, error_message, entry);
 
 		throw InvalidInputException(error_message);
 	}
-	throw InvalidInputException("Secret provider '%s' not found for type '%s'", provider, type);
+	throw InvalidInputException("Secret provider %s not found for type %s", provider, type);
 }
 
 optional_ptr<SecretStorage> SecretManager::GetSecretStorage(const Identifier &name) {

--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -193,7 +193,7 @@ void AllowedConfigsSetting::SetGlobal(DatabaseInstance *db, DBConfig &config, co
 	config.options.allowed_configs.clear();
 	auto &list = ListValue::GetChildren(input);
 	for (auto &val : list) {
-		config.AddAllowedConfig(val.GetValue<string>());
+		config.AddAllowedConfig(val.GetValue<Identifier>());
 	}
 }
 

--- a/src/main/user_settings.cpp
+++ b/src/main/user_settings.cpp
@@ -100,12 +100,12 @@ SettingLookupResult GlobalUserSettings::TryGetSetting(idx_t setting_index, Value
 	return SettingLookupResult();
 }
 
-bool GlobalUserSettings::HasExtensionOption(const string &name) const {
+bool GlobalUserSettings::HasExtensionOption(const Identifier &name) const {
 	lock_guard<mutex> l(lock);
 	return extension_parameters.find(name) != extension_parameters.end();
 }
 
-idx_t GlobalUserSettings::AddExtensionOption(const string &name, ExtensionOption extension_option) {
+idx_t GlobalUserSettings::AddExtensionOption(const Identifier &name, ExtensionOption extension_option) {
 	lock_guard<mutex> l(lock);
 	const auto new_option = extension_parameters.emplace(make_pair(name, std::move(extension_option)));
 	const auto did_insert = new_option.second;
@@ -121,14 +121,14 @@ idx_t GlobalUserSettings::AddExtensionOption(const string &name, ExtensionOption
 	return setting_index;
 }
 
-case_insensitive_map_t<ExtensionOption> GlobalUserSettings::GetExtensionSettings() const {
+identifier_map_t<ExtensionOption> GlobalUserSettings::GetExtensionSettings() const {
 	lock_guard<mutex> l(lock);
 	return extension_parameters;
 }
 
-bool GlobalUserSettings::TryGetExtensionOption(const String &name, ExtensionOption &result) const {
+bool GlobalUserSettings::TryGetExtensionOption(const Identifier &name, ExtensionOption &result) const {
 	lock_guard<mutex> l(lock);
-	auto entry = extension_parameters.find(name.ToStdString());
+	auto entry = extension_parameters.find(name);
 	if (entry == extension_parameters.end()) {
 		return false;
 	}

--- a/test/api/test_config.cpp
+++ b/test/api/test_config.cpp
@@ -56,7 +56,7 @@ TEST_CASE("Test DB config configuration", "[api]") {
 }
 
 TEST_CASE("Test allowed options", "[api]") {
-	case_insensitive_map_t<Value> config_dict;
+	identifier_map_t<Value> config_dict;
 	string option;
 
 	SECTION("allowed_directories") {

--- a/test/extension/autoloading_copy_function.test
+++ b/test/extension/autoloading_copy_function.test
@@ -22,7 +22,7 @@ set autoinstall_known_extensions=false
 statement maybe
 copy (select 1337 as edgy_hacker_number) TO '{TEST_DIR}/test1337.parquet'
 ----
-Catalog Error: Copy Function with name parquet is not in the catalog, but it exists in the parquet extension.
+Catalog Error: Copy Function with name "parquet" is not in the catalog, but it exists in the parquet extension.
 
 ### With autoloading, install and correct repo
 statement ok

--- a/test/extension/autoloading_copy_function.test
+++ b/test/extension/autoloading_copy_function.test
@@ -22,7 +22,7 @@ set autoinstall_known_extensions=false
 statement maybe
 copy (select 1337 as edgy_hacker_number) TO '{TEST_DIR}/test1337.parquet'
 ----
-Catalog Error: Copy Function with name "parquet" is not in the catalog, but it exists in the parquet extension.
+Catalog Error: Copy Function with name parquet is not in the catalog, but it exists in the parquet extension.
 
 ### With autoloading, install and correct repo
 statement ok

--- a/test/extension/wrong_function_type.test
+++ b/test/extension/wrong_function_type.test
@@ -12,10 +12,10 @@ require no_extension_autoloading "EXPECTED: Test relies on autoloading being dis
 statement error
 select json_execute_serialized_sql(42) from range(5);
 ----
-Catalog Error: Scalar Function with name "json_execute_serialized_sql" is not in the catalog, functions with this name exist in the json extension, but they are of different types, namely Pragma Function, Table Function
+Catalog Error: Scalar Function with name json_execute_serialized_sql is not in the catalog, functions with this name exist in the json extension, but they are of different types, namely Pragma Function, Table Function
 
 # One of the two options is Table Function
 statement error
 CALL json_execute_serialized_sql('test');
 ----
-Catalog Error: Table Function with name "json_execute_serialized_sql" is not in the catalog, but it exists in the json extension.
+Catalog Error: Table Function with name json_execute_serialized_sql is not in the catalog, but it exists in the json extension.

--- a/test/helpers/test_config.cpp
+++ b/test/helpers/test_config.cpp
@@ -769,7 +769,7 @@ vector<ConfigSetting> TestConfiguration::GetConfigSettings() {
 		for (const auto &value : list_children) {
 			auto &struct_children = StructValue::GetChildren(value);
 			ConfigSetting config_setting;
-			config_setting.name = StringValue::Get(struct_children[0]);
+			config_setting.name = struct_children[0].GetValue<Identifier>();
 			config_setting.value = StringValue::Get(struct_children[1]);
 			result.push_back(std::move(config_setting));
 		}

--- a/test/include/test_config.hpp
+++ b/test/include/test_config.hpp
@@ -24,7 +24,7 @@ namespace duckdb {
 enum class SortStyle : uint8_t { NO_SORT, ROW_SORT, VALUE_SORT };
 
 struct ConfigSetting {
-	string name;
+	Identifier name;
 	Value value;
 };
 

--- a/test/sql/catalog/test_extension_suggestion.test
+++ b/test/sql/catalog/test_extension_suggestion.test
@@ -9,4 +9,4 @@ require no_extension_autoloading "EXPECTED: This tests what happens when extensi
 statement error
 SELECT from_json('{DATA_DIR}/json/array_of_empty_arrays.json');
 ----
-Catalog Error: Scalar Function with name "from_json" is not in the catalog, but it exists in the json extension.
+Catalog Error: Scalar Function with name from_json is not in the catalog, but it exists in the json extension.

--- a/test/sql/secrets/create_secret_hffs_autoload.test
+++ b/test/sql/secrets/create_secret_hffs_autoload.test
@@ -22,7 +22,7 @@ CREATE SECRET hf1 (
     TOKEN 'bla'
 )
 ----
-Secret provider 'config' for type 'huggingface' does not exist, but it exists in the httfps extension.
+Secret provider config for type huggingface does not exist, but it exists in the httfps extension.
 
 # Cache provider will automatically try to fetch the token from the cache
 statement error
@@ -31,4 +31,4 @@ CREATE SECRET hf2 (
     PROVIDER 'credential_chain'
 )
 ----
-Secret provider 'credential_chain' for type 'huggingface' does not exist, but it exists in the httpfs extension.
+Secret provider credential_chain for type huggingface does not exist, but it exists in the httpfs extension.

--- a/test/sql/secrets/secret_autoloading_errors.test
+++ b/test/sql/secrets/secret_autoloading_errors.test
@@ -12,12 +12,12 @@ Secret type 's3' does not exist, but it exists in the httpfs extension.
 statement error
 CREATE SECRET (TYPE S3, PROVIDER CONFIG)
 ----
-Secret provider 'config' for type 's3' does not exist, but it exists in the httpfs extension.
+Secret provider config for type s3 does not exist, but it exists in the httpfs extension.
 
 statement error
 CREATE SECRET (TYPE S3, PROVIDER CREDENTIAL_CHAIN)
 ----
-Secret provider 'credential_chain' for type 's3' does not exist, but it exists in the aws extension.
+Secret provider credential_chain for type s3 does not exist, but it exists in the aws extension.
 
 statement error
 CREATE SECRET (TYPE AZURE)
@@ -27,9 +27,9 @@ Secret type 'azure' does not exist, but it exists in the azure extension.
 statement error
 CREATE SECRET (TYPE AZURE, PROVIDER CONFIG)
 ----
-Secret provider 'config' for type 'azure' does not exist, but it exists in the azure extension.
+Secret provider config for type azure does not exist, but it exists in the azure extension.
 
 statement error
 CREATE SECRET (TYPE AZURE, PROVIDER CREDENTIAL_CHAIN)
 ----
-Secret provider 'credential_chain' for type 'azure' does not exist, but it exists in the azure extension.
+Secret provider credential_chain for type azure does not exist, but it exists in the azure extension.


### PR DESCRIPTION
Config names and secret names/types/providers are now changed throughout the code to work with `Identifier`.
