### PR TITLE
Fix join projection map bug in TopNWindowElimination

### DIFF
--- a/src/optimizer/topn_window_elimination.cpp
+++ b/src/optimizer/topn_window_elimination.cpp
@@ -1148,8 +1148,11 @@ unique_ptr<LogicalOperator> TopNWindowElimination::TryPrepareLateMaterialization
 
 				auto &projection_map = RefersToSameObject(op_child, *join.children[0]) ? join.left_projection_map
 				                                                                       : join.right_projection_map;
-				for (const auto rowid_idx : rhs_rowid_idxs) {
-					projection_map.push_back(rowid_idx);
+				// An empty map already projects every column, including the newly added row ID.
+				if (!projection_map.empty()) {
+					for (const auto rowid_idx : rhs_rowid_idxs) {
+						projection_map.push_back(rowid_idx);
+					}
 				}
 			}
 			break;

--- a/test/optimizer/topn_window_elimination.test_slow
+++ b/test/optimizer/topn_window_elimination.test_slow
@@ -20,6 +20,38 @@ CREATE TABLE tbl2(generated_col AS (x + 1), x INTEGER, y VARCHAR)
 statement ok
 INSERT INTO tbl2 VALUES (0, 'a'), (1, 'b'), (null, 'c')
 
+# Regression test: adding row IDs must preserve an empty projection map on the selected join side.
+# An empty map projects all columns, including the newly added row ID.
+statement ok
+CREATE TABLE topn_filter_l(id INTEGER, k INTEGER, x DOUBLE, y DOUBLE)
+
+statement ok
+CREATE TABLE topn_filter_r(id INTEGER, z DOUBLE)
+
+statement ok
+INSERT INTO topn_filter_l VALUES (1, 0, 5, 5), (1, 1, 1, 1), (1, 2, 2, 2), (2, 0, 9, 9)
+
+statement ok
+INSERT INTO topn_filter_r VALUES (1, 3), (2, 3)
+
+query IRR
+SELECT c.id, c.x, c.y
+FROM topn_filter_l c
+JOIN topn_filter_r p USING (id)
+WHERE greatest(c.x, p.z) = p.z
+QUALIFY row_number() OVER (PARTITION BY c.id ORDER BY c.k) = 1
+----
+1	1.0	1.0
+
+query II
+EXPLAIN SELECT c.id, c.x, c.y
+FROM topn_filter_l c
+JOIN topn_filter_r p USING (id)
+WHERE greatest(c.x, p.z) = p.z
+QUALIFY row_number() OVER (PARTITION BY c.id ORDER BY c.k) = 1
+----
+logical_opt	<REGEX>:.*COMPARISON_JOIN.*rowid = rowid.*AGGREGATE.*
+
 # An unpartitioned top-1 window must not turn empty input into a NULL row
 statement ok
 CREATE TABLE empty_topn(s INTEGER, p INTEGER)


### PR DESCRIPTION
fixes https://github.com/duckdblabs/duckdb-internal/issues/10059
fixes https://github.com/duckdb/duckdb/issues/23925
supersedes https://github.com/duckdb/duckdb/pull/23943

This PR fixes a bug that would pull the rowid through a join by adding it to its projection map, even if that map is empty.  As an empty map projects all columns, we would then only project the rowid and lose everything else.