### PR TITLE
Inject markers, network, memory, and http requests into a Samply profile

### DIFF
--- a/scripts/samply_profile.py
+++ b/scripts/samply_profile.py
@@ -529,7 +529,14 @@ def duckdb_arguments(arguments: list[str], launcher_path: str | Path) -> list[st
     else:
         wrapper_arguments = []
         command_arguments = arguments
-    return [*wrapper_arguments, "--", str(duckdb), *command_arguments]
+    return [
+        *wrapper_arguments,
+        "--",
+        str(duckdb),
+        "-cmd",
+        "SET samply_tracks='all';",
+        *command_arguments,
+    ]
 
 
 def duckdb_main(arguments: list[str] | None = None, *, launcher_path: str | Path) -> int:

--- a/scripts/samply_profile.py
+++ b/scripts/samply_profile.py
@@ -1,0 +1,400 @@
+#!/usr/bin/env python3
+"""Record DuckDB with stock Samply and inject DuckDB resource counters."""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import json
+import math
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from typing import Any, Iterable
+
+
+class ProfileInjectionError(RuntimeError):
+    pass
+
+
+def _finite_number(value: Any, field: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(value):
+        raise ProfileInjectionError(f"profile field {field} must be a finite number")
+    return float(value)
+
+
+def load_profile(path: Path) -> dict[str, Any]:
+    try:
+        with path.open("rb") as raw_file:
+            is_gzip = raw_file.read(2) == b"\x1f\x8b"
+        opener = gzip.open if is_gzip else open
+        with opener(path, "rt", encoding="utf-8") as profile_file:
+            profile = json.load(profile_file)
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise ProfileInjectionError(f"could not read Samply profile {path}: {error}") from error
+    if not isinstance(profile, dict):
+        raise ProfileInjectionError("Samply profile root must be an object")
+    return profile
+
+
+def write_profile_atomic(profile: dict[str, Any], output: Path) -> None:
+    output = output.absolute()
+    if not output.parent.is_dir():
+        raise ProfileInjectionError(f"output directory does not exist: {output.parent}")
+    temporary_path: Path | None = None
+    try:
+        descriptor, temporary_name = tempfile.mkstemp(prefix=f".{output.name}.", dir=output.parent)
+        temporary_path = Path(temporary_name)
+        with os.fdopen(descriptor, "wb") as raw_file:
+            with gzip.GzipFile(filename="", mode="wb", fileobj=raw_file, mtime=0) as gzip_file:
+                payload = json.dumps(profile, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+                gzip_file.write(payload)
+            raw_file.flush()
+            os.fsync(raw_file.fileno())
+        os.replace(temporary_path, output)
+        temporary_path = None
+    except OSError as error:
+        raise ProfileInjectionError(f"could not atomically write {output}: {error}") from error
+    finally:
+        if temporary_path is not None:
+            try:
+                temporary_path.unlink()
+            except OSError:
+                pass
+
+
+def read_sidecar(path: Path) -> tuple[int, int, dict[str, list[tuple[int, int]]]]:
+    calibration: tuple[int, int] | None = None
+    samples: dict[str, list[tuple[int, int]]] = {"rss": [], "network-rx": [], "network-tx": []}
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeError) as error:
+        raise ProfileInjectionError(f"could not read counter sidecar {path}: {error}") from error
+    for line_number, line in enumerate(lines, 1):
+        fields = line.split()
+        if not fields:
+            continue
+        try:
+            if fields[0] == "clock":
+                if len(fields) != 3 or calibration is not None:
+                    raise ValueError("expected one 'clock MONOTONIC_NS UNIX_NS' record")
+                calibration = (int(fields[1]), int(fields[2]))
+                if calibration[0] < 0 or calibration[1] < 0:
+                    raise ValueError("clock timestamps cannot be negative")
+            else:
+                if len(fields) != 3 or fields[1] not in samples:
+                    raise ValueError("invalid counter sample")
+                monotonic_ns = int(fields[0])
+                value = int(fields[2])
+                if monotonic_ns < 0 or value < 0:
+                    raise ValueError("counter samples cannot be negative")
+                samples[fields[1]].append((monotonic_ns, value))
+        except ValueError as error:
+            raise ProfileInjectionError(f"malformed {path}:{line_number}: {error}") from error
+    if calibration is None:
+        raise ProfileInjectionError(f"counter sidecar {path} has no clock calibration")
+    for name, track_samples in samples.items():
+        if any(current[0] < previous[0] for previous, current in zip(track_samples, track_samples[1:])):
+            raise ProfileInjectionError(f"counter sidecar {path} has out-of-order {name} samples")
+    return calibration[0], calibration[1], samples
+
+
+def _time_deltas(times: list[float]) -> list[float]:
+    if not times:
+        return []
+    return [times[0], *(current - previous for previous, current in zip(times, times[1:]))]
+
+
+def _memory_display() -> dict[str, Any]:
+    return {
+        "graphType": "line-accumulated",
+        "unit": "bytes",
+        "color": "red",
+        "markerSchemaLocation": "timeline-memory",
+        "sortWeight": 0,
+        "label": "Memory usage (RSS)",
+        "tooltipRows": [
+            {
+                "type": "value",
+                "source": "accumulated",
+                "format": {"unit": "bytes"},
+                "label": "Resident memory",
+            }
+        ],
+    }
+
+
+def _network_display(label: str, color: str, sort_weight: int) -> dict[str, Any]:
+    return {
+        "graphType": "line-rate",
+        "unit": "bytes-per-second",
+        "color": color,
+        "markerSchemaLocation": None,
+        "sortWeight": sort_weight,
+        "label": label,
+        "tooltipRows": [
+            {
+                "type": "value",
+                "source": "rate",
+                "format": {"unit": "bytes-per-second"},
+                "label": "Rate",
+            },
+            {
+                "type": "value",
+                "source": "selection-total",
+                "format": {"unit": "bytes"},
+                "label": "Transferred",
+                "requiresPreviewSelection": True,
+            },
+        ],
+    }
+
+
+def _make_counter(
+    *,
+    name: str,
+    category: str,
+    description: str,
+    pid: Any,
+    main_thread_index: int,
+    times: list[float],
+    counts: list[int],
+    display: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "name": name,
+        "category": category,
+        "description": description,
+        "pid": pid,
+        "mainThreadIndex": main_thread_index,
+        "samples": {"timeDeltas": _time_deltas(times), "count": counts, "length": len(times)},
+        "display": display,
+    }
+
+
+def _matching_thread(profile: dict[str, Any], pid: int) -> tuple[int, dict[str, Any]] | None:
+    for index, thread in enumerate(profile["threads"]):
+        if not isinstance(thread, dict) or "pid" not in thread:
+            raise ProfileInjectionError(f"profile thread {index} is missing its pid")
+        try:
+            matches = int(thread["pid"]) == pid
+        except (TypeError, ValueError):
+            matches = False
+        if matches:
+            return index, thread
+    return None
+
+
+def inject_counters(profile: dict[str, Any], sidecars: Iterable[Path]) -> int:
+    meta = profile.get("meta")
+    threads = profile.get("threads")
+    counters = profile.get("counters")
+    if not isinstance(meta, dict):
+        raise ProfileInjectionError("profile is missing its meta object")
+    start_time = _finite_number(meta.get("startTime"), "meta.startTime")
+    if not isinstance(threads, list) or not threads:
+        raise ProfileInjectionError("profile threads must be a non-empty array")
+    if not isinstance(counters, list):
+        raise ProfileInjectionError("profile counters must be an array")
+
+    added = 0
+    for sidecar in sidecars:
+        match = re.fullmatch(r"counter-(\d+)\.txt", sidecar.name)
+        if not match:
+            continue
+        pid = int(match.group(1))
+        thread_match = _matching_thread(profile, pid)
+        if thread_match is None:
+            continue
+        main_thread_index, thread = thread_match
+        process_start = _finite_number(
+            thread.get("processStartupTime"), f"threads[{main_thread_index}].processStartupTime"
+        )
+        process_end_value = thread.get("processShutdownTime")
+        process_end = (
+            math.inf
+            if process_end_value is None
+            else _finite_number(process_end_value, f"threads[{main_thread_index}].processShutdownTime")
+        )
+        calibration_monotonic, calibration_unix, samples = read_sidecar(sidecar)
+
+        def converted(track: str) -> tuple[list[float], list[int]]:
+            converted_samples: list[tuple[float, int]] = []
+            for monotonic_ns, value in samples[track]:
+                unix_ns = calibration_unix + monotonic_ns - calibration_monotonic
+                profile_ms = unix_ns / 1_000_000 - start_time
+                if profile_ms < 0 or profile_ms < process_start or profile_ms > process_end:
+                    continue
+                converted_samples.append((profile_ms, value))
+            return ([sample[0] for sample in converted_samples], [sample[1] for sample in converted_samples])
+
+        rss_times, rss_values = converted("rss")
+        if rss_times:
+            rss_deltas = [
+                rss_values[0],
+                *(current - previous for previous, current in zip(rss_values, rss_values[1:])),
+            ]
+            counters.append(
+                _make_counter(
+                    name="Memory usage (RSS)",
+                    category="Memory",
+                    description="Resident memory used by the DuckDB process",
+                    pid=thread["pid"],
+                    main_thread_index=main_thread_index,
+                    times=rss_times,
+                    counts=rss_deltas,
+                    display=_memory_display(),
+                )
+            )
+            added += 1
+
+        for track, name, color, sort_weight in (
+            ("network-rx", "System network RX", "blue", 10),
+            ("network-tx", "System network TX", "green", 11),
+        ):
+            times, values = converted(track)
+            if times:
+                counters.append(
+                    _make_counter(
+                        name=name,
+                        category="Network",
+                        description="Bytes transferred across system non-loopback interfaces",
+                        pid=thread["pid"],
+                        main_thread_index=main_thread_index,
+                        times=times,
+                        counts=values,
+                        display=_network_display(name, color, sort_weight),
+                    )
+                )
+                added += 1
+    return added
+
+
+def inject_profile(raw_profile: Path, sidecar_directory: Path, output: Path) -> int:
+    profile = load_profile(raw_profile)
+    added = inject_counters(profile, sorted(sidecar_directory.glob("counter-*.txt")))
+    write_profile_atomic(profile, output)
+    return added
+
+
+def resolve_samply(argument: str | None) -> str:
+    candidate = argument or os.environ.get("SAMPLY") or "samply"
+    resolved = shutil.which(candidate)
+    if resolved is None:
+        raise ProfileInjectionError(f"could not find Samply executable: {candidate}")
+    return resolved
+
+
+def resolve_duckdb(launcher_path: str | Path) -> Path:
+    duckdb = Path(launcher_path).resolve().with_name("duckdb")
+    if not duckdb.is_file():
+        raise ProfileInjectionError(f"could not find DuckDB executable next to profile launcher: {duckdb}")
+    return duckdb
+
+
+def duckdb_arguments(arguments: list[str], launcher_path: str | Path) -> list[str]:
+    duckdb = resolve_duckdb(launcher_path)
+    if "--" in arguments:
+        separator = arguments.index("--")
+        wrapper_arguments = arguments[:separator]
+        command_arguments = arguments[separator + 1 :]
+    else:
+        wrapper_arguments = []
+        command_arguments = arguments
+    return [*wrapper_arguments, "--", str(duckdb), *command_arguments]
+
+
+def duckdb_main(arguments: list[str] | None = None, *, launcher_path: str | Path) -> int:
+    if arguments is None:
+        arguments = sys.argv[1:]
+    try:
+        return main(duckdb_arguments(arguments, launcher_path))
+    except ProfileInjectionError as error:
+        print(f"samply_profile.py: {error}", file=sys.stderr)
+        return 1
+
+
+def parse_arguments(arguments: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--samply", help="path to the Samply executable (then SAMPLY, then PATH)")
+    parser.add_argument("--output", default="profile.json.gz", help="final injected gzip profile")
+    parser.add_argument("--rate", type=float, help="Samply sampling rate in Hz")
+    parser.add_argument("--duration", type=float, help="recording duration in seconds")
+    parser.add_argument("--profile-name", help="custom profile name")
+    parser.add_argument("--no-open", action="store_true", help="do not open the final profile")
+    parser.add_argument("--keep-temp", action="store_true", help="preserve raw profile and sidecars")
+    parser.add_argument("command", nargs=argparse.REMAINDER, help="command to profile, preceded by --")
+    result = parser.parse_args(arguments)
+    if not result.command:
+        parser.error("a command is required after --")
+    if result.command[0] == "--":
+        result.command = result.command[1:]
+    if not result.command:
+        parser.error("a command is required after --")
+    if result.rate is not None and (not math.isfinite(result.rate) or result.rate <= 0):
+        parser.error("--rate must be positive")
+    if result.duration is not None and (not math.isfinite(result.duration) or result.duration <= 0):
+        parser.error("--duration must be positive")
+    return result
+
+
+def _format_option(value: float) -> str:
+    return format(value, "g")
+
+
+def main(arguments: list[str] | None = None) -> int:
+    options = parse_arguments(arguments)
+    temporary_directory = Path(tempfile.mkdtemp(prefix="duckdb-samply-profile-"))
+    raw_profile = temporary_directory / "raw-profile.json.gz"
+    output = Path(options.output).absolute()
+    preserve = options.keep_temp
+    try:
+        samply = resolve_samply(options.samply)
+        record_command = [samply, "record", "--save-only", "--output", str(raw_profile)]
+        if options.rate is not None:
+            record_command.extend(["--rate", _format_option(options.rate)])
+        if options.duration is not None:
+            record_command.extend(["--duration", _format_option(options.duration)])
+        if options.profile_name is not None:
+            record_command.extend(["--profile-name", options.profile_name])
+        record_command.extend(["--", *options.command])
+        environment = os.environ.copy()
+        environment["DUCKDB_SAMPLY_DIR"] = str(temporary_directory)
+        record_result = subprocess.run(record_command, env=environment, check=False)
+        if not raw_profile.is_file():
+            preserve = True
+            raise ProfileInjectionError(f"Samply did not create the raw profile {raw_profile}")
+
+        added = inject_profile(raw_profile, temporary_directory, output)
+        print(f"Injected {added} DuckDB resource counter(s) into {output}", file=sys.stderr)
+
+        load_status = 0
+        if not options.no_open:
+            load_status = subprocess.run([samply, "load", str(output)], check=False).returncode
+        if record_result.returncode != 0:
+            preserve = True
+            return record_result.returncode
+        if load_status != 0:
+            preserve = True
+            print(f"samply load failed with exit status {load_status}", file=sys.stderr)
+            return load_status
+        return 0
+    except (OSError, ProfileInjectionError) as error:
+        preserve = True
+        print(f"samply_profile.py: {error}", file=sys.stderr)
+        return 1
+    finally:
+        if preserve:
+            print(f"Raw profile and DuckDB sidecars preserved in {temporary_directory}", file=sys.stderr)
+            if raw_profile.exists():
+                print(f"Raw profile: {raw_profile}", file=sys.stderr)
+        else:
+            shutil.rmtree(temporary_directory, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/samply_profile.py
+++ b/scripts/samply_profile.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
-"""Record DuckDB with stock Samply and inject DuckDB resource counters."""
+"""Record DuckDB with stock Samply and inject DuckDB counters and HTTP requests."""
 
 from __future__ import annotations
 
 import argparse
+import base64
+import binascii
 import gzip
 import json
 import math
@@ -103,6 +105,58 @@ def read_sidecar(path: Path) -> tuple[int, int, dict[str, list[tuple[int, int]]]
     return calibration[0], calibration[1], samples
 
 
+def _decode_http_field(value: str) -> str:
+    try:
+        return base64.b64decode(value, validate=True).decode("utf-8")
+    except (binascii.Error, UnicodeError) as error:
+        raise ValueError("invalid base64-encoded UTF-8 field") from error
+
+
+def read_http_sidecar(path: Path) -> list[dict[str, Any]]:
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeError) as error:
+        raise ProfileInjectionError(f"could not read HTTP sidecar {path}: {error}") from error
+    requests = []
+    for line_number, line in enumerate(lines, 1):
+        if not line:
+            continue
+        fields = line.split("\t")
+        try:
+            if len(fields) != 10 or fields[0] != "1":
+                raise ValueError("expected a version 1 HTTP record with 10 fields")
+            start_unix_ns = int(fields[1])
+            duration_ns = int(fields[2])
+            status_code = int(fields[3])
+            bytes_received = int(fields[4])
+            time_to_first_byte_ns = int(fields[5])
+            method = fields[6]
+            if start_unix_ns < 0 or duration_ns < 0 or bytes_received < 0:
+                raise ValueError("timestamps, durations, and byte counts cannot be negative")
+            if status_code < -1 or status_code > 999:
+                raise ValueError("invalid HTTP status code")
+            if time_to_first_byte_ns < -1 or time_to_first_byte_ns > duration_ns:
+                raise ValueError("invalid time to first byte")
+            if not method or any(character.isspace() for character in method):
+                raise ValueError("invalid HTTP method")
+            requests.append(
+                {
+                    "start_unix_ns": start_unix_ns,
+                    "duration_ns": duration_ns,
+                    "status_code": status_code,
+                    "bytes_received": bytes_received,
+                    "time_to_first_byte_ns": time_to_first_byte_ns,
+                    "method": method,
+                    "url": _decode_http_field(fields[7]),
+                    "request_range": _decode_http_field(fields[8]),
+                    "response_content_range": _decode_http_field(fields[9]),
+                }
+            )
+        except ValueError as error:
+            raise ProfileInjectionError(f"malformed {path}:{line_number}: {error}") from error
+    return requests
+
+
 def _time_deltas(times: list[float]) -> list[float]:
     if not times:
         return []
@@ -177,6 +231,7 @@ def _make_counter(
 
 
 def _matching_thread(profile: dict[str, Any], pid: int) -> tuple[int, dict[str, Any]] | None:
+    first_match = None
     for index, thread in enumerate(profile["threads"]):
         if not isinstance(thread, dict) or "pid" not in thread:
             raise ProfileInjectionError(f"profile thread {index} is missing its pid")
@@ -185,8 +240,11 @@ def _matching_thread(profile: dict[str, Any], pid: int) -> tuple[int, dict[str, 
         except (TypeError, ValueError):
             matches = False
         if matches:
-            return index, thread
-    return None
+            if first_match is None:
+                first_match = (index, thread)
+            if thread.get("isMainThread") is True:
+                return index, thread
+    return first_match
 
 
 def inject_counters(profile: dict[str, Any], sidecars: Iterable[Path]) -> int:
@@ -274,11 +332,177 @@ def inject_counters(profile: dict[str, Any], sidecars: Iterable[Path]) -> int:
     return added
 
 
-def inject_profile(raw_profile: Path, sidecar_directory: Path, output: Path) -> int:
-    profile = load_profile(raw_profile)
-    added = inject_counters(profile, sorted(sidecar_directory.glob("counter-*.txt")))
-    write_profile_atomic(profile, output)
+def _network_category(profile: dict[str, Any]) -> int:
+    meta = profile.get("meta")
+    if not isinstance(meta, dict):
+        raise ProfileInjectionError("profile is missing its meta object")
+    categories = meta.get("categories")
+    if not isinstance(categories, list):
+        raise ProfileInjectionError("profile meta.categories must be an array")
+    for index, category in enumerate(categories):
+        if isinstance(category, dict) and category.get("name") == "Network":
+            return index
+    categories.append({"name": "Network", "color": "lightblue", "subcategories": ["Other"]})
+    return len(categories) - 1
+
+
+def _marker_table(thread: dict[str, Any], thread_index: int) -> dict[str, Any]:
+    markers = thread.get("markers")
+    if not isinstance(markers, dict):
+        raise ProfileInjectionError(f"profile thread {thread_index} is missing its marker table")
+    length = markers.get("length")
+    if isinstance(length, bool) or not isinstance(length, int) or length < 0:
+        raise ProfileInjectionError(f"profile thread {thread_index} has an invalid marker table length")
+    for column in ("category", "data", "endTime", "name", "phase", "startTime"):
+        values = markers.get(column)
+        if not isinstance(values, list) or len(values) != length:
+            raise ProfileInjectionError(f"profile thread {thread_index} has an invalid marker column {column}")
+    string_array = thread.get("stringArray")
+    if not isinstance(string_array, list) or not all(isinstance(value, str) for value in string_array):
+        raise ProfileInjectionError(f"profile thread {thread_index} has an invalid string array")
+    return markers
+
+
+def _next_network_marker_id(profile: dict[str, Any]) -> int:
+    used_ids = set()
+    for thread in profile["threads"]:
+        if not isinstance(thread, dict):
+            continue
+        markers = thread.get("markers")
+        if not isinstance(markers, dict) or not isinstance(markers.get("data"), list):
+            continue
+        for payload in markers["data"]:
+            if not isinstance(payload, dict) or payload.get("type") != "Network":
+                continue
+            marker_id = payload.get("id")
+            if isinstance(marker_id, int) and not isinstance(marker_id, bool) and marker_id >= 0:
+                used_ids.add(marker_id)
+    return max(used_ids, default=0) + 1
+
+
+def _append_raw_marker(
+    markers: dict[str, Any], *, category: int, data: dict[str, Any], end_time: float, name: int, start_time: float
+) -> None:
+    markers["category"].append(category)
+    markers["data"].append(data)
+    markers["endTime"].append(end_time)
+    markers["name"].append(name)
+    markers["phase"].append(1)
+    markers["startTime"].append(start_time)
+    markers["length"] += 1
+
+
+def inject_http_requests(profile: dict[str, Any], sidecars: Iterable[Path]) -> int:
+    meta = profile.get("meta")
+    threads = profile.get("threads")
+    if not isinstance(meta, dict):
+        raise ProfileInjectionError("profile is missing its meta object")
+    start_time = _finite_number(meta.get("startTime"), "meta.startTime")
+    if not isinstance(threads, list) or not threads:
+        raise ProfileInjectionError("profile threads must be a non-empty array")
+
+    requests_by_pid: dict[int, list[dict[str, Any]]] = {}
+    for sidecar in sidecars:
+        match = re.fullmatch(r"http-(\d+)-(\d+)\.txt", sidecar.name)
+        if not match:
+            continue
+        requests_by_pid.setdefault(int(match.group(1)), []).extend(read_http_sidecar(sidecar))
+    if not requests_by_pid:
+        return 0
+
+    category = _network_category(profile)
+    marker_id = _next_network_marker_id(profile)
+    added = 0
+    for pid, requests in requests_by_pid.items():
+        thread_match = _matching_thread(profile, pid)
+        if thread_match is None:
+            continue
+        thread_index, thread = thread_match
+        process_start = _finite_number(thread.get("processStartupTime"), f"threads[{thread_index}].processStartupTime")
+        process_end_value = thread.get("processShutdownTime")
+        process_end = (
+            math.inf
+            if process_end_value is None
+            else _finite_number(process_end_value, f"threads[{thread_index}].processShutdownTime")
+        )
+        markers = _marker_table(thread, thread_index)
+        string_array = thread["stringArray"]
+
+        requests.sort(key=lambda request: (request["start_unix_ns"], request["duration_ns"]))
+        for request in requests:
+            request_start = request["start_unix_ns"] / 1_000_000 - start_time
+            request_end = request_start + request["duration_ns"] / 1_000_000
+            if request_start < 0 or request_start < process_start or request_start > process_end:
+                continue
+            request_end = min(request_end, process_end)
+            request_end = max(request_start, request_end)
+
+            title = f"Load {marker_id} {request['method']}"
+            if request["request_range"]:
+                title += f" [Range={request['request_range']}]"
+            title += f": {request['url']}"
+            name_index = len(string_array)
+            string_array.append(title)
+
+            start_payload = {
+                "type": "Network",
+                "URI": request["url"],
+                "id": marker_id,
+                "pri": 0,
+                "status": "STATUS_START",
+                "startTime": request_start,
+                "endTime": request_start,
+                "method": request["method"],
+            }
+            if request["request_range"]:
+                start_payload["requestRange"] = request["request_range"]
+
+            response_start = request_end
+            if request["time_to_first_byte_ns"] >= 0:
+                response_start = min(request_end, request_start + request["time_to_first_byte_ns"] / 1_000_000)
+            stop_payload = {
+                **start_payload,
+                "status": "STATUS_STOP" if request["status_code"] > 0 else "STATUS_CANCEL",
+                "startTime": request_start,
+                "endTime": request_end,
+                "requestStart": request_start,
+                "responseStart": response_start,
+                "responseEnd": request_end,
+            }
+            if request["status_code"] > 0:
+                stop_payload["responseStatus"] = request["status_code"]
+            if request["bytes_received"] > 0:
+                stop_payload["count"] = request["bytes_received"]
+            if request["response_content_range"]:
+                stop_payload["responseContentRange"] = request["response_content_range"]
+
+            _append_raw_marker(
+                markers,
+                category=category,
+                data=start_payload,
+                end_time=request_start,
+                name=name_index,
+                start_time=request_start,
+            )
+            _append_raw_marker(
+                markers,
+                category=category,
+                data=stop_payload,
+                end_time=request_end,
+                name=name_index,
+                start_time=request_start,
+            )
+            marker_id += 1
+            added += 1
     return added
+
+
+def inject_profile(raw_profile: Path, sidecar_directory: Path, output: Path) -> tuple[int, int]:
+    profile = load_profile(raw_profile)
+    added_counters = inject_counters(profile, sorted(sidecar_directory.glob("counter-*.txt")))
+    added_http_requests = inject_http_requests(profile, sorted(sidecar_directory.glob("http-*.txt")))
+    write_profile_atomic(profile, output)
+    return added_counters, added_http_requests
 
 
 def resolve_samply(argument: str | None) -> str:
@@ -369,8 +593,12 @@ def main(arguments: list[str] | None = None) -> int:
             preserve = True
             raise ProfileInjectionError(f"Samply did not create the raw profile {raw_profile}")
 
-        added = inject_profile(raw_profile, temporary_directory, output)
-        print(f"Injected {added} DuckDB resource counter(s) into {output}", file=sys.stderr)
+        added_counters, added_http_requests = inject_profile(raw_profile, temporary_directory, output)
+        print(
+            f"Injected {added_counters} DuckDB resource counter(s) and "
+            f"{added_http_requests} HTTP request(s) into {output}",
+            file=sys.stderr,
+        )
 
         load_status = 0
         if not options.no_open:

--- a/scripts/samply_profile.py
+++ b/scripts/samply_profile.py
@@ -71,7 +71,11 @@ def write_profile_atomic(profile: dict[str, Any], output: Path) -> None:
 
 def read_sidecar(path: Path) -> tuple[int, int, dict[str, list[tuple[int, int]]]]:
     calibration: tuple[int, int] | None = None
-    samples: dict[str, list[tuple[int, int]]] = {"rss": [], "network-rx": [], "network-tx": []}
+    samples: dict[str, list[tuple[int, int]]] = {
+        "tracked-memory": [],
+        "http-download": [],
+        "http-upload": [],
+    }
     try:
         lines = path.read_text(encoding="utf-8").splitlines()
     except (OSError, UnicodeError) as error:
@@ -157,6 +161,38 @@ def read_http_sidecar(path: Path) -> list[dict[str, Any]]:
     return requests
 
 
+def read_query_sidecar(path: Path) -> list[dict[str, Any]]:
+    records = []
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeError) as error:
+        raise ProfileInjectionError(f"could not read query sidecar {path}: {error}") from error
+    for line_number, line in enumerate(lines, 1):
+        if not line:
+            continue
+        try:
+            record = json.loads(line)
+            if not isinstance(record, dict) or record.get("version") != 1:
+                raise ValueError("expected a version 1 query profile record")
+            start_unix_ns = record.get("start_unix_ns")
+            duration_ns = record.get("duration_ns")
+            profile = record.get("profile")
+            if (
+                isinstance(start_unix_ns, bool)
+                or not isinstance(start_unix_ns, int)
+                or start_unix_ns < 0
+                or isinstance(duration_ns, bool)
+                or not isinstance(duration_ns, int)
+                or duration_ns < 0
+                or not isinstance(profile, dict)
+            ):
+                raise ValueError("invalid query timestamps or profile")
+            records.append(record)
+        except (json.JSONDecodeError, ValueError) as error:
+            raise ProfileInjectionError(f"malformed {path}:{line_number}: {error}") from error
+    return records
+
+
 def _time_deltas(times: list[float]) -> list[float]:
     if not times:
         return []
@@ -170,13 +206,13 @@ def _memory_display() -> dict[str, Any]:
         "color": "red",
         "markerSchemaLocation": "timeline-memory",
         "sortWeight": 0,
-        "label": "Memory usage (RSS)",
+        "label": "Tracked Memory",
         "tooltipRows": [
             {
                 "type": "value",
                 "source": "accumulated",
                 "format": {"unit": "bytes"},
-                "label": "Resident memory",
+                "label": "Tracked memory",
             }
         ],
     }
@@ -290,29 +326,29 @@ def inject_counters(profile: dict[str, Any], sidecars: Iterable[Path]) -> int:
                 converted_samples.append((profile_ms, value))
             return ([sample[0] for sample in converted_samples], [sample[1] for sample in converted_samples])
 
-        rss_times, rss_values = converted("rss")
-        if rss_times:
-            rss_deltas = [
-                rss_values[0],
-                *(current - previous for previous, current in zip(rss_values, rss_values[1:])),
+        memory_times, memory_values = converted("tracked-memory")
+        if memory_times:
+            memory_deltas = [
+                memory_values[0],
+                *(current - previous for previous, current in zip(memory_values, memory_values[1:])),
             ]
             counters.append(
                 _make_counter(
-                    name="Memory usage (RSS)",
+                    name="Tracked Memory",
                     category="Memory",
-                    description="Resident memory used by the DuckDB process",
+                    description="Live bytes requested through DuckDB memory allocators",
                     pid=thread["pid"],
                     main_thread_index=main_thread_index,
-                    times=rss_times,
-                    counts=rss_deltas,
+                    times=memory_times,
+                    counts=memory_deltas,
                     display=_memory_display(),
                 )
             )
             added += 1
 
         for track, name, color, sort_weight in (
-            ("network-rx", "System network RX", "blue", 10),
-            ("network-tx", "System network TX", "green", 11),
+            ("http-download", "HTTP Download", "blue", 10),
+            ("http-upload", "HTTP Upload", "green", 11),
         ):
             times, values = converted(track)
             if times:
@@ -320,7 +356,7 @@ def inject_counters(profile: dict[str, Any], sidecars: Iterable[Path]) -> int:
                     _make_counter(
                         name=name,
                         category="Network",
-                        description="Bytes transferred across system non-loopback interfaces",
+                        description="HTTP payload bytes transferred by DuckDB",
                         pid=thread["pid"],
                         main_thread_index=main_thread_index,
                         times=times,
@@ -390,6 +426,219 @@ def _append_raw_marker(
     markers["phase"].append(1)
     markers["startTime"].append(start_time)
     markers["length"] += 1
+
+
+def _duckdb_category(profile: dict[str, Any]) -> int:
+    categories = profile["meta"].get("categories")
+    if not isinstance(categories, list):
+        categories = []
+        profile["meta"]["categories"] = categories
+    for index, category in enumerate(categories):
+        if isinstance(category, dict) and category.get("name") == "DuckDB":
+            return index
+    categories.append({"name": "DuckDB", "color": "purple", "subcategories": ["Other"]})
+    return len(categories) - 1
+
+
+def _ensure_duckdb_marker_schema(profile: dict[str, Any]) -> None:
+    schemas = profile["meta"].get("markerSchema")
+    if schemas is None:
+        schemas = []
+        profile["meta"]["markerSchema"] = schemas
+    elif not isinstance(schemas, list):
+        raise ProfileInjectionError("profile meta.markerSchema must be an array")
+    if any(isinstance(schema, dict) and schema.get("name") == "DuckDBProfile" for schema in schemas):
+        return
+    schemas.append(
+        {
+            "name": "DuckDBProfile",
+            "display": ["marker-chart", "marker-table"],
+            "chartLabel": "{marker.data.name}",
+            "tooltipLabel": "{marker.data.name}",
+            "tableLabel": "{marker.data.name}",
+            "data": [
+                {"key": "name", "label": "Name", "format": "unique-string", "searchable": True},
+                {"key": "kind", "label": "Kind", "format": "unique-string", "searchable": True},
+                {"key": "metric", "label": "Metric", "format": "unique-string", "searchable": True},
+                {"key": "activeDuration", "label": "Active time", "format": "duration"},
+                {"key": "path", "label": "Operator path", "format": "unique-string", "searchable": True},
+                {"key": "details", "label": "Details", "format": "unique-string", "searchable": True},
+            ],
+        }
+    )
+
+
+def _query_marker_name(sql: Any) -> str:
+    if not isinstance(sql, str):
+        return "Query: <unknown>"
+    normalized = " ".join(sql.split()).replace("\x00", "?") or "<empty>"
+    prefix = "Query: "
+    maximum_bytes = 900 - len(prefix.encode("utf-8"))
+    encoded = normalized.encode("utf-8")
+    if len(encoded) <= maximum_bytes:
+        return prefix + normalized
+    ellipsis = "…"
+    normalized = normalized[:500]
+    while len((normalized + ellipsis).encode("utf-8")) > maximum_bytes:
+        normalized = normalized[:-1]
+    return prefix + normalized + ellipsis
+
+
+def _metric_title(metric: str) -> str:
+    return metric.rsplit(".", 1)[-1].replace("_", " ").title()
+
+
+def inject_query_profiles(profile: dict[str, Any], sidecars: Iterable[Path]) -> int:
+    meta = profile.get("meta")
+    threads = profile.get("threads")
+    if not isinstance(meta, dict):
+        raise ProfileInjectionError("profile is missing its meta object")
+    start_time = _finite_number(meta.get("startTime"), "meta.startTime")
+    if not isinstance(threads, list) or not threads:
+        raise ProfileInjectionError("profile threads must be a non-empty array")
+
+    records_by_pid: dict[int, list[dict[str, Any]]] = {}
+    for sidecar in sidecars:
+        match = re.fullmatch(r"query-(\d+)-(\d+)\.jsonl", sidecar.name)
+        if match:
+            records_by_pid.setdefault(int(match.group(1)), []).extend(read_query_sidecar(sidecar))
+    if not records_by_pid:
+        return 0
+
+    category = _duckdb_category(profile)
+    _ensure_duckdb_marker_schema(profile)
+    added = 0
+    for pid, records in records_by_pid.items():
+        thread_match = _matching_thread(profile, pid)
+        if thread_match is None:
+            continue
+        thread_index, thread = thread_match
+        process_start = _finite_number(thread.get("processStartupTime"), f"threads[{thread_index}].processStartupTime")
+        process_end_value = thread.get("processShutdownTime")
+        process_end = (
+            math.inf
+            if process_end_value is None
+            else _finite_number(process_end_value, f"threads[{thread_index}].processShutdownTime")
+        )
+        markers = _marker_table(thread, thread_index)
+        string_array = thread["stringArray"]
+
+        for record in sorted(records, key=lambda item: item["start_unix_ns"]):
+            query_start = record["start_unix_ns"] / 1_000_000 - start_time
+            query_end = query_start + record["duration_ns"] / 1_000_000
+            if query_start < 0 or query_start < process_start or query_start > process_end:
+                continue
+            query_end = max(query_start, min(query_end, process_end))
+            query_profile = record["profile"]
+            candidates: list[tuple[float, float, str, dict[str, Any]]] = []
+
+            def add_marker(start: float, end: float, title: str, data: dict[str, Any]) -> None:
+                start = max(query_start, start)
+                end = min(query_end, max(start, end))
+                candidates.append((start, end, title, {"type": "DuckDBProfile", "name": title, **data}))
+
+            query = query_profile.get("query")
+            sql = query.get("sql") if isinstance(query, dict) else None
+            add_marker(query_start, query_end, _query_marker_name(sql), {"kind": "query"})
+
+            bounds_by_name = {}
+            timing_bounds = query_profile.get("timing_bounds")
+            if isinstance(timing_bounds, list):
+                for bounds in timing_bounds:
+                    if not isinstance(bounds, dict) or not isinstance(bounds.get("name"), str):
+                        continue
+                    start_ns = bounds.get("start_ns")
+                    end_ns = bounds.get("end_ns")
+                    if isinstance(start_ns, int) and isinstance(end_ns, int) and 0 <= start_ns <= end_ns:
+                        bounds_by_name[bounds["name"]] = (start_ns, end_ns)
+
+            planning_metrics = {
+                "parser.total_time": "Parser",
+                "planner.total_time": "Planner",
+                "optimizer.total_time": "Optimizer",
+                "physical_planner.total_time": "Physical Planner",
+            }
+            planning_spans = []
+            for metric, title in planning_metrics.items():
+                bounds = bounds_by_name.get(metric)
+                if bounds is None:
+                    continue
+                phase_start = query_start + bounds[0] / 1_000_000
+                phase_end = query_start + bounds[1] / 1_000_000
+                planning_spans.append((phase_start, phase_end))
+                add_marker(phase_start, phase_end, title, {"kind": "phase", "metric": metric})
+
+            if planning_spans:
+                planning_start = min(span[0] for span in planning_spans)
+                planning_end = max(span[1] for span in planning_spans)
+                add_marker(planning_start, planning_end, "Planning", {"kind": "phase"})
+            else:
+                planning_end = query_start
+            add_marker(planning_end, query_end, "Execution", {"kind": "phase"})
+
+            for metric, bounds in bounds_by_name.items():
+                if metric in planning_metrics or metric == "query.total_time":
+                    continue
+                if not metric.startswith(("planner.", "optimizer.", "physical_planner.")):
+                    continue
+                phase_start = query_start + bounds[0] / 1_000_000
+                phase_end = query_start + bounds[1] / 1_000_000
+                add_marker(
+                    phase_start,
+                    phase_end,
+                    _metric_title(metric),
+                    {"kind": "phase detail", "metric": metric},
+                )
+
+            def add_operators(nodes: Any, path: list[str]) -> None:
+                if not isinstance(nodes, list):
+                    return
+                for node in nodes:
+                    if not isinstance(node, dict):
+                        continue
+                    operator_type = node.get("type")
+                    operator_type = operator_type if isinstance(operator_type, str) else "UNKNOWN"
+                    operator_path = [*path, operator_type]
+                    bounds = node.get("timing_bounds")
+                    if isinstance(bounds, dict):
+                        start_ns = bounds.get("start_ns")
+                        end_ns = bounds.get("end_ns")
+                        if isinstance(start_ns, int) and isinstance(end_ns, int) and 0 <= start_ns <= end_ns:
+                            details = node.get("extra_info")
+                            payload: dict[str, Any] = {
+                                "kind": "operator",
+                                "path": " → ".join(operator_path),
+                                "details": (
+                                    json.dumps(details, separators=(",", ":"), ensure_ascii=False)
+                                    if isinstance(details, dict)
+                                    else ""
+                                ),
+                            }
+                            timing = node.get("timing")
+                            if isinstance(timing, (int, float)) and not isinstance(timing, bool):
+                                payload["activeDuration"] = timing * 1000
+                            add_marker(
+                                query_start + start_ns / 1_000_000,
+                                query_start + end_ns / 1_000_000,
+                                f"Operator: {operator_type}",
+                                payload,
+                            )
+                    add_operators(node.get("children"), operator_path)
+
+            add_operators(query_profile.get("operator"), [])
+            for marker_start, marker_end, title, data in sorted(candidates, key=lambda item: (item[0], -item[1])):
+                name_index = len(string_array)
+                string_array.append(title)
+                _append_raw_marker(
+                    markers,
+                    category=category,
+                    data=data,
+                    end_time=marker_end,
+                    name=name_index,
+                    start_time=marker_start,
+                )
+                added += 1
+    return added
 
 
 def inject_http_requests(profile: dict[str, Any], sidecars: Iterable[Path]) -> int:
@@ -497,12 +746,13 @@ def inject_http_requests(profile: dict[str, Any], sidecars: Iterable[Path]) -> i
     return added
 
 
-def inject_profile(raw_profile: Path, sidecar_directory: Path, output: Path) -> tuple[int, int]:
+def inject_profile(raw_profile: Path, sidecar_directory: Path, output: Path) -> tuple[int, int, int]:
     profile = load_profile(raw_profile)
     added_counters = inject_counters(profile, sorted(sidecar_directory.glob("counter-*.txt")))
     added_http_requests = inject_http_requests(profile, sorted(sidecar_directory.glob("http-*.txt")))
+    added_query_markers = inject_query_profiles(profile, sorted(sidecar_directory.glob("query-*.jsonl")))
     write_profile_atomic(profile, output)
-    return added_counters, added_http_requests
+    return added_counters, added_http_requests, added_query_markers
 
 
 def resolve_samply(argument: str | None) -> str:
@@ -600,10 +850,12 @@ def main(arguments: list[str] | None = None) -> int:
             preserve = True
             raise ProfileInjectionError(f"Samply did not create the raw profile {raw_profile}")
 
-        added_counters, added_http_requests = inject_profile(raw_profile, temporary_directory, output)
+        added_counters, added_http_requests, added_query_markers = inject_profile(
+            raw_profile, temporary_directory, output
+        )
         print(
             f"Injected {added_counters} DuckDB resource counter(s) and "
-            f"{added_http_requests} HTTP request(s) into {output}",
+            f"{added_http_requests} HTTP request(s), and {added_query_markers} query marker(s) into {output}",
             file=sys.stderr,
         )
 

--- a/scripts/samply_profile_launcher.py.in
+++ b/scripts/samply_profile_launcher.py.in
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+import sys
+
+SOURCE_ROOT = r"@PROJECT_SOURCE_DIR@"
+if SOURCE_ROOT not in sys.path:
+    sys.path.insert(0, SOURCE_ROOT)
+
+from scripts.samply_profile import duckdb_main
+
+
+if __name__ == "__main__":
+    raise SystemExit(duckdb_main(sys.argv[1:], launcher_path=__file__))

--- a/scripts/test_samply_profile.py
+++ b/scripts/test_samply_profile.py
@@ -1,0 +1,278 @@
+import gzip
+import json
+import os
+from pathlib import Path
+import shutil
+import stat
+import tempfile
+import textwrap
+import unittest
+from unittest import mock
+
+from scripts import samply_profile
+
+
+def synthetic_profile():
+    return {
+        "meta": {"startTime": 1000.0},
+        "threads": [
+            {"pid": 7, "processStartupTime": 0.0, "processShutdownTime": None},
+            {"pid": 42, "processStartupTime": 50.0, "processShutdownTime": 300.0},
+            {"pid": 42, "processStartupTime": 0.0, "processShutdownTime": None},
+        ],
+        "counters": [{"name": "existing"}],
+    }
+
+
+class SamplyInjectionTests(unittest.TestCase):
+    def test_injects_all_counters_with_pid_and_lifetime_filtering(self):
+        with tempfile.TemporaryDirectory() as directory_name:
+            sidecar = Path(directory_name) / "counter-42.txt"
+            sidecar.write_text(
+                "\n".join(
+                    [
+                        "clock 1000000000 1000000000",
+                        "1000000000 rss 800",
+                        "1100000000 rss 1000",
+                        "1200000000 rss 1200",
+                        "1400000000 rss 9999",
+                        "1100000000 network-rx 25",
+                        "1200000000 network-rx 50",
+                        "1100000000 network-tx 10",
+                        "1200000000 network-tx 20",
+                    ]
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            profile = synthetic_profile()
+            self.assertEqual(samply_profile.inject_counters(profile, [sidecar]), 3)
+
+        self.assertEqual(profile["counters"][0], {"name": "existing"})
+        memory, network_rx, network_tx = profile["counters"][1:]
+        self.assertEqual(memory["mainThreadIndex"], 1)
+        self.assertEqual(memory["samples"], {"timeDeltas": [100.0, 100.0], "count": [1000, 200], "length": 2})
+        self.assertEqual(network_rx["samples"]["count"], [25, 50])
+        self.assertNotIn("number", network_rx["samples"])
+        self.assertEqual(network_rx["display"]["graphType"], "line-rate")
+        self.assertEqual(network_rx["display"]["color"], "blue")
+        self.assertEqual(network_tx["display"]["color"], "green")
+        self.assertEqual(
+            [row["format"]["unit"] for row in network_rx["display"]["tooltipRows"]],
+            ["bytes-per-second", "bytes"],
+        )
+
+    def test_ignores_sidecar_for_pid_not_in_profile(self):
+        with tempfile.TemporaryDirectory() as directory_name:
+            sidecar = Path(directory_name) / "counter-99.txt"
+            sidecar.write_text("clock 1 1\n2 rss 10\n", encoding="utf-8")
+            profile = synthetic_profile()
+            self.assertEqual(samply_profile.inject_counters(profile, [sidecar]), 0)
+            self.assertEqual(profile["counters"], [{"name": "existing"}])
+
+    def test_rejects_malformed_inputs_and_profiles(self):
+        with tempfile.TemporaryDirectory() as directory_name:
+            sidecar = Path(directory_name) / "counter-42.txt"
+            sidecar.write_text("1 rss 10\n", encoding="utf-8")
+            with self.assertRaisesRegex(samply_profile.ProfileInjectionError, "no clock calibration"):
+                samply_profile.inject_counters(synthetic_profile(), [sidecar])
+            sidecar.write_text("clock 1 1\n2 mystery 10\n", encoding="utf-8")
+            with self.assertRaisesRegex(samply_profile.ProfileInjectionError, "malformed"):
+                samply_profile.inject_counters(synthetic_profile(), [sidecar])
+
+        with self.assertRaisesRegex(samply_profile.ProfileInjectionError, "meta"):
+            samply_profile.inject_counters({"threads": [], "counters": []}, [])
+        with self.assertRaisesRegex(samply_profile.ProfileInjectionError, "threads"):
+            samply_profile.inject_counters({"meta": {"startTime": 0}, "threads": [], "counters": []}, [])
+
+    def test_reads_gzip_and_plain_json_and_writes_gzip_atomically(self):
+        with tempfile.TemporaryDirectory() as directory_name:
+            directory = Path(directory_name)
+            plain = directory / "plain.json"
+            compressed = directory / "compressed.json.gz"
+            output = directory / "output.json.gz"
+            profile = synthetic_profile()
+            plain.write_text(json.dumps(profile), encoding="utf-8")
+            with gzip.open(compressed, "wt", encoding="utf-8") as profile_file:
+                json.dump(profile, profile_file)
+            self.assertEqual(samply_profile.load_profile(plain), profile)
+            self.assertEqual(samply_profile.load_profile(compressed), profile)
+            samply_profile.write_profile_atomic(profile, output)
+            with gzip.open(output, "rt", encoding="utf-8") as profile_file:
+                self.assertEqual(json.load(profile_file), profile)
+            self.assertEqual(list(directory.glob(f".{output.name}.*")), [])
+
+
+FAKE_SAMPLY = r"""
+#!/usr/bin/env python3
+import json
+import os
+from pathlib import Path
+import sys
+
+log = Path(os.environ["FAKE_SAMPLY_LOG"])
+with log.open("a", encoding="utf-8") as log_file:
+    log_file.write(json.dumps({"argv": sys.argv[1:], "sidecar": os.environ.get("DUCKDB_SAMPLY_DIR")}) + "\n")
+
+if sys.argv[1] == "load":
+    raise SystemExit(int(os.environ.get("FAKE_LOAD_STATUS", "0")))
+
+output = Path(sys.argv[sys.argv.index("--output") + 1])
+if os.environ.get("FAKE_MALFORMED_PROFILE") == "1":
+    output.write_text("not json", encoding="utf-8")
+else:
+    profile = {
+        "meta": {"startTime": 1000.0},
+        "threads": [{"pid": 42, "processStartupTime": 0.0, "processShutdownTime": 500.0}],
+        "counters": [],
+    }
+    output.write_text(json.dumps(profile), encoding="utf-8")
+    sidecar = Path(os.environ["DUCKDB_SAMPLY_DIR"]) / "counter-42.txt"
+    sidecar.write_text("clock 1000000000 1000000000\n1100000000 rss 1000\n", encoding="utf-8")
+raise SystemExit(int(os.environ.get("FAKE_RECORD_STATUS", "0")))
+"""
+
+
+class SamplyWrapperTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.directory = Path(self.temporary_directory.name)
+        self.fake_samply = self.directory / "fake samply"
+        self.fake_samply.write_text(textwrap.dedent(FAKE_SAMPLY).lstrip(), encoding="utf-8")
+        self.fake_samply.chmod(self.fake_samply.stat().st_mode | stat.S_IXUSR)
+        self.log = self.directory / "fake.log"
+        self.output = self.directory / "final profile.json.gz"
+
+    def tearDown(self):
+        self.temporary_directory.cleanup()
+
+    def environment(self, **extra):
+        return mock.patch.dict(os.environ, {"FAKE_SAMPLY_LOG": str(self.log), **extra}, clear=False)
+
+    def log_entries(self):
+        return [json.loads(line) for line in self.log.read_text(encoding="utf-8").splitlines()]
+
+    def test_record_arguments_environment_and_cleanup(self):
+        with self.environment():
+            status = samply_profile.main(
+                [
+                    "--samply",
+                    str(self.fake_samply),
+                    "--output",
+                    str(self.output),
+                    "--rate",
+                    "250",
+                    "--duration",
+                    "2.5",
+                    "--profile-name",
+                    "demo",
+                    "--no-open",
+                    "--",
+                    "/bin/echo",
+                    "; not shell syntax",
+                ]
+            )
+        self.assertEqual(status, 0)
+        entry = self.log_entries()[0]
+        self.assertEqual(entry["argv"][0:2], ["record", "--save-only"])
+        self.assertIn("250", entry["argv"])
+        self.assertEqual(entry["argv"][-3:], ["--", "/bin/echo", "; not shell syntax"])
+        self.assertFalse(Path(entry["sidecar"]).exists())
+        with gzip.open(self.output, "rt", encoding="utf-8") as profile_file:
+            self.assertEqual(json.load(profile_file)["counters"][0]["name"], "Memory usage (RSS)")
+
+    def test_load_is_run_and_failure_is_reported(self):
+        with self.environment(FAKE_LOAD_STATUS="9"):
+            status = samply_profile.main(
+                ["--samply", str(self.fake_samply), "--output", str(self.output), "--", "/bin/true"]
+            )
+        self.assertEqual(status, 9)
+        entries = self.log_entries()
+        self.assertEqual(entries[1]["argv"], ["load", str(self.output)])
+        sidecar_directory = Path(entries[0]["sidecar"])
+        self.assertTrue(sidecar_directory.exists())
+        shutil.rmtree(sidecar_directory)
+
+    def test_record_status_is_preserved(self):
+        with self.environment(FAKE_RECORD_STATUS="7"):
+            status = samply_profile.main(
+                ["--samply", str(self.fake_samply), "--output", str(self.output), "--no-open", "--", "/bin/false"]
+            )
+        self.assertEqual(status, 7)
+        sidecar_directory = Path(self.log_entries()[0]["sidecar"])
+        self.assertTrue(sidecar_directory.exists())
+        shutil.rmtree(sidecar_directory)
+
+    def test_injection_failure_preserves_raw_profile_and_sidecars(self):
+        with self.environment(FAKE_MALFORMED_PROFILE="1"):
+            status = samply_profile.main(
+                ["--samply", str(self.fake_samply), "--output", str(self.output), "--no-open", "--", "/bin/true"]
+            )
+        self.assertEqual(status, 1)
+        sidecar_directory = Path(self.log_entries()[0]["sidecar"])
+        self.assertTrue((sidecar_directory / "raw-profile.json.gz").exists())
+        shutil.rmtree(sidecar_directory)
+
+
+class DuckDBLauncherTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.directory = Path(self.temporary_directory.name)
+        self.launcher = self.directory / "profile"
+        self.duckdb = self.directory / "duckdb"
+        self.duckdb.touch()
+        self.resolved_duckdb = self.duckdb.resolve()
+
+    def tearDown(self):
+        self.temporary_directory.cleanup()
+
+    def test_constructs_default_command(self):
+        self.assertEqual(
+            samply_profile.duckdb_arguments([], self.launcher),
+            ["--", str(self.resolved_duckdb)],
+        )
+
+    def test_forwards_all_arguments_to_duckdb_without_separator(self):
+        self.assertEqual(
+            samply_profile.duckdb_arguments(["database.db", "-c", "SELECT 42"], self.launcher),
+            ["--", str(self.resolved_duckdb), "database.db", "-c", "SELECT 42"],
+        )
+
+    def test_splits_wrapper_options_from_duckdb_arguments(self):
+        self.assertEqual(
+            samply_profile.duckdb_arguments(
+                ["--no-open", "--rate", "100", "--", "database.db", "-c", "SELECT 42"], self.launcher
+            ),
+            [
+                "--no-open",
+                "--rate",
+                "100",
+                "--",
+                str(self.resolved_duckdb),
+                "database.db",
+                "-c",
+                "SELECT 42",
+            ],
+        )
+
+    def test_preserves_option_like_duckdb_arguments(self):
+        self.assertEqual(
+            samply_profile.duckdb_arguments(["--no-open", "--output", "query.csv"], self.launcher),
+            ["--", str(self.resolved_duckdb), "--no-open", "--output", "query.csv"],
+        )
+
+    def test_resolves_duckdb_next_to_launcher(self):
+        nested_launcher = self.directory / "nested" / ".." / "profile"
+        self.assertEqual(samply_profile.resolve_duckdb(nested_launcher), self.resolved_duckdb)
+
+    def test_reports_missing_duckdb(self):
+        self.duckdb.unlink()
+        with self.assertRaisesRegex(
+            samply_profile.ProfileInjectionError,
+            "could not find DuckDB executable next to profile launcher",
+        ):
+            samply_profile.resolve_duckdb(self.launcher)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_samply_profile.py
+++ b/scripts/test_samply_profile.py
@@ -15,7 +15,11 @@ from scripts import samply_profile
 
 def synthetic_profile():
     return {
-        "meta": {"startTime": 1000.0, "categories": [{"name": "Other", "color": "grey"}]},
+        "meta": {
+            "startTime": 1000.0,
+            "categories": [{"name": "Other", "color": "grey"}],
+            "markerSchema": [],
+        },
         "threads": [
             {"pid": 7, "processStartupTime": 0.0, "processShutdownTime": None},
             {"pid": 42, "processStartupTime": 50.0, "processShutdownTime": 300.0},
@@ -79,14 +83,14 @@ class SamplyInjectionTests(unittest.TestCase):
                 "\n".join(
                     [
                         "clock 1000000000 1000000000",
-                        "1000000000 rss 800",
-                        "1100000000 rss 1000",
-                        "1200000000 rss 1200",
-                        "1400000000 rss 9999",
-                        "1100000000 network-rx 25",
-                        "1200000000 network-rx 50",
-                        "1100000000 network-tx 10",
-                        "1200000000 network-tx 20",
+                        "1000000000 tracked-memory 800",
+                        "1100000000 tracked-memory 1000",
+                        "1200000000 tracked-memory 1200",
+                        "1400000000 tracked-memory 9999",
+                        "1100000000 http-download 25",
+                        "1200000000 http-download 50",
+                        "1100000000 http-upload 10",
+                        "1200000000 http-upload 20",
                     ]
                 )
                 + "\n",
@@ -112,7 +116,7 @@ class SamplyInjectionTests(unittest.TestCase):
     def test_ignores_sidecar_for_pid_not_in_profile(self):
         with tempfile.TemporaryDirectory() as directory_name:
             sidecar = Path(directory_name) / "counter-99.txt"
-            sidecar.write_text("clock 1 1\n2 rss 10\n", encoding="utf-8")
+            sidecar.write_text("clock 1 1\n2 tracked-memory 10\n", encoding="utf-8")
             profile = synthetic_profile()
             self.assertEqual(samply_profile.inject_counters(profile, [sidecar]), 0)
             self.assertEqual(profile["counters"], [{"name": "existing"}])
@@ -120,7 +124,7 @@ class SamplyInjectionTests(unittest.TestCase):
     def test_rejects_malformed_inputs_and_profiles(self):
         with tempfile.TemporaryDirectory() as directory_name:
             sidecar = Path(directory_name) / "counter-42.txt"
-            sidecar.write_text("1 rss 10\n", encoding="utf-8")
+            sidecar.write_text("1 tracked-memory 10\n", encoding="utf-8")
             with self.assertRaisesRegex(samply_profile.ProfileInjectionError, "no clock calibration"):
                 samply_profile.inject_counters(synthetic_profile(), [sidecar])
             sidecar.write_text("clock 1 1\n2 mystery 10\n", encoding="utf-8")
@@ -230,6 +234,66 @@ class SamplyInjectionTests(unittest.TestCase):
             with self.assertRaisesRegex(samply_profile.ProfileInjectionError, "malformed"):
                 samply_profile.read_http_sidecar(sidecar)
 
+    def test_injects_query_phase_and_operator_markers_from_profiler_output(self):
+        with tempfile.TemporaryDirectory() as directory_name:
+            sidecar = Path(directory_name) / "query-42-100.jsonl"
+            query_profile = {
+                "query": {"sql": "  SELECT\n42  "},
+                "timing_bounds": [
+                    {"name": "parser.total_time", "start_ns": 1_000_000, "end_ns": 3_000_000},
+                    {"name": "planner.total_time", "start_ns": 3_000_000, "end_ns": 7_000_000},
+                    {"name": "optimizer.total_time", "start_ns": 7_000_000, "end_ns": 9_000_000},
+                    {"name": "physical_planner.total_time", "start_ns": 9_000_000, "end_ns": 10_000_000},
+                ],
+                "operator": [
+                    {
+                        "type": "TABLE_SCAN",
+                        "timing": 0.004,
+                        "timing_bounds": {"start_ns": 12_000_000, "end_ns": 30_000_000},
+                        "extra_info": {"Table": "integers"},
+                        "children": [],
+                    }
+                ],
+            }
+            sidecar.write_text(
+                json.dumps(
+                    {
+                        "version": 1,
+                        "start_unix_ns": 1_100_000_000,
+                        "duration_ns": 50_000_000,
+                        "profile": query_profile,
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            profile = synthetic_profile()
+            _add_marker_table(profile["threads"][1], main=True)
+            _add_marker_table(profile["threads"][2])
+            self.assertEqual(samply_profile.inject_query_profiles(profile, [sidecar]), 8)
+
+        thread = profile["threads"][1]
+        self.assertEqual(thread["markers"]["length"], 9)
+        self.assertEqual(
+            thread["stringArray"][1:],
+            [
+                "Query: SELECT 42",
+                "Planning",
+                "Parser",
+                "Planner",
+                "Optimizer",
+                "Physical Planner",
+                "Execution",
+                "Operator: TABLE_SCAN",
+            ],
+        )
+        operator = thread["markers"]["data"][-1]
+        self.assertEqual(operator["path"], "TABLE_SCAN")
+        self.assertEqual(operator["activeDuration"], 4.0)
+        self.assertEqual(thread["markers"]["startTime"][-1], 112.0)
+        self.assertEqual(thread["markers"]["endTime"][-1], 130.0)
+        self.assertEqual(profile["meta"]["markerSchema"][-1]["name"], "DuckDBProfile")
+
 
 FAKE_SAMPLY = r"""
 #!/usr/bin/env python3
@@ -250,13 +314,13 @@ if os.environ.get("FAKE_MALFORMED_PROFILE") == "1":
     output.write_text("not json", encoding="utf-8")
 else:
     profile = {
-        "meta": {"startTime": 1000.0},
+        "meta": {"startTime": 1000.0, "categories": [], "markerSchema": []},
         "threads": [{"pid": 42, "processStartupTime": 0.0, "processShutdownTime": 500.0}],
         "counters": [],
     }
     output.write_text(json.dumps(profile), encoding="utf-8")
     sidecar = Path(os.environ["DUCKDB_SAMPLY_DIR"]) / "counter-42.txt"
-    sidecar.write_text("clock 1000000000 1000000000\n1100000000 rss 1000\n", encoding="utf-8")
+    sidecar.write_text("clock 1000000000 1000000000\n1100000000 tracked-memory 1000\n", encoding="utf-8")
 raise SystemExit(int(os.environ.get("FAKE_RECORD_STATUS", "0")))
 """
 
@@ -307,7 +371,7 @@ class SamplyWrapperTests(unittest.TestCase):
         self.assertEqual(entry["argv"][-3:], ["--", "/bin/echo", "; not shell syntax"])
         self.assertFalse(Path(entry["sidecar"]).exists())
         with gzip.open(self.output, "rt", encoding="utf-8") as profile_file:
-            self.assertEqual(json.load(profile_file)["counters"][0]["name"], "Memory usage (RSS)")
+            self.assertEqual(json.load(profile_file)["counters"][0]["name"], "Tracked Memory")
 
     def test_load_is_run_and_failure_is_reported(self):
         with self.environment(FAKE_LOAD_STATUS="9"):

--- a/scripts/test_samply_profile.py
+++ b/scripts/test_samply_profile.py
@@ -357,13 +357,21 @@ class DuckDBLauncherTests(unittest.TestCase):
     def test_constructs_default_command(self):
         self.assertEqual(
             samply_profile.duckdb_arguments([], self.launcher),
-            ["--", str(self.resolved_duckdb)],
+            ["--", str(self.resolved_duckdb), "-cmd", "SET samply_tracks='all';"],
         )
 
     def test_forwards_all_arguments_to_duckdb_without_separator(self):
         self.assertEqual(
             samply_profile.duckdb_arguments(["database.db", "-c", "SELECT 42"], self.launcher),
-            ["--", str(self.resolved_duckdb), "database.db", "-c", "SELECT 42"],
+            [
+                "--",
+                str(self.resolved_duckdb),
+                "-cmd",
+                "SET samply_tracks='all';",
+                "database.db",
+                "-c",
+                "SELECT 42",
+            ],
         )
 
     def test_splits_wrapper_options_from_duckdb_arguments(self):
@@ -377,6 +385,8 @@ class DuckDBLauncherTests(unittest.TestCase):
                 "100",
                 "--",
                 str(self.resolved_duckdb),
+                "-cmd",
+                "SET samply_tracks='all';",
                 "database.db",
                 "-c",
                 "SELECT 42",
@@ -386,7 +396,30 @@ class DuckDBLauncherTests(unittest.TestCase):
     def test_preserves_option_like_duckdb_arguments(self):
         self.assertEqual(
             samply_profile.duckdb_arguments(["--no-open", "--output", "query.csv"], self.launcher),
-            ["--", str(self.resolved_duckdb), "--no-open", "--output", "query.csv"],
+            [
+                "--",
+                str(self.resolved_duckdb),
+                "-cmd",
+                "SET samply_tracks='all';",
+                "--no-open",
+                "--output",
+                "query.csv",
+            ],
+        )
+
+    def test_explicit_track_setting_can_override_default(self):
+        self.assertEqual(
+            samply_profile.duckdb_arguments(["-cmd", "SET samply_tracks='http';", "-f", "query.sql"], self.launcher),
+            [
+                "--",
+                str(self.resolved_duckdb),
+                "-cmd",
+                "SET samply_tracks='all';",
+                "-cmd",
+                "SET samply_tracks='http';",
+                "-f",
+                "query.sql",
+            ],
         )
 
     def test_resolves_duckdb_next_to_launcher(self):

--- a/scripts/test_samply_profile.py
+++ b/scripts/test_samply_profile.py
@@ -1,3 +1,4 @@
+import base64
 import gzip
 import json
 import os
@@ -14,13 +15,59 @@ from scripts import samply_profile
 
 def synthetic_profile():
     return {
-        "meta": {"startTime": 1000.0},
+        "meta": {"startTime": 1000.0, "categories": [{"name": "Other", "color": "grey"}]},
         "threads": [
             {"pid": 7, "processStartupTime": 0.0, "processShutdownTime": None},
             {"pid": 42, "processStartupTime": 50.0, "processShutdownTime": 300.0},
             {"pid": 42, "processStartupTime": 0.0, "processShutdownTime": None},
         ],
         "counters": [{"name": "existing"}],
+    }
+
+
+def _http_record(
+    start_unix_ns,
+    duration_ns,
+    status_code,
+    bytes_received,
+    time_to_first_byte_ns,
+    method,
+    url,
+    request_range="",
+    response_content_range="",
+):
+    encoded = [
+        base64.b64encode(value.encode("utf-8")).decode("ascii")
+        for value in (url, request_range, response_content_range)
+    ]
+    return "\t".join(
+        map(
+            str,
+            [
+                1,
+                start_unix_ns,
+                duration_ns,
+                status_code,
+                bytes_received,
+                time_to_first_byte_ns,
+                method,
+                *encoded,
+            ],
+        )
+    )
+
+
+def _add_marker_table(thread, *, main=False):
+    thread["isMainThread"] = main
+    thread["stringArray"] = ["Existing marker"]
+    thread["markers"] = {
+        "category": [0],
+        "data": [None],
+        "endTime": [60.0],
+        "length": 1,
+        "name": [0],
+        "phase": [0],
+        "startTime": [60.0],
     }
 
 
@@ -101,6 +148,87 @@ class SamplyInjectionTests(unittest.TestCase):
             with gzip.open(output, "rt", encoding="utf-8") as profile_file:
                 self.assertEqual(json.load(profile_file), profile)
             self.assertEqual(list(directory.glob(f".{output.name}.*")), [])
+
+    def test_injects_parallel_http_attempts_as_firefox_network_markers(self):
+        with tempfile.TemporaryDirectory() as directory_name:
+            directory = Path(directory_name)
+            first_sidecar = directory / "http-42-100.txt"
+            second_sidecar = directory / "http-42-200.txt"
+            first_sidecar.write_text(
+                _http_record(
+                    1100000000,
+                    100000000,
+                    206,
+                    4096,
+                    25000000,
+                    "GET",
+                    "https://example.com/part-1.parquet",
+                    "bytes=0-4095",
+                    "bytes 0-4095/8192",
+                )
+                + "\n"
+                + _http_record(
+                    1250000000,
+                    10000000,
+                    -1,
+                    0,
+                    -1,
+                    "GET",
+                    "https://example.com/retry.parquet",
+                    "bytes=4096-8191",
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            second_sidecar.write_text(
+                _http_record(
+                    1150000000,
+                    100000000,
+                    200,
+                    2048,
+                    50000000,
+                    "HEAD",
+                    "https://example.com/part-2.parquet",
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            profile = synthetic_profile()
+            _add_marker_table(profile["threads"][1], main=True)
+            _add_marker_table(profile["threads"][2])
+
+            self.assertEqual(samply_profile.inject_http_requests(profile, [first_sidecar, second_sidecar]), 3)
+
+        self.assertEqual(profile["meta"]["categories"][-1]["name"], "Network")
+        self.assertEqual(profile["threads"][2]["markers"]["length"], 1)
+        thread = profile["threads"][1]
+        self.assertEqual(thread["markers"]["length"], 7)
+        self.assertEqual(
+            thread["stringArray"][1:],
+            [
+                "Load 1 GET [Range=bytes=0-4095]: https://example.com/part-1.parquet",
+                "Load 2 HEAD: https://example.com/part-2.parquet",
+                "Load 3 GET [Range=bytes=4096-8191]: https://example.com/retry.parquet",
+            ],
+        )
+        start, stop = thread["markers"]["data"][1:3]
+        self.assertEqual(start["status"], "STATUS_START")
+        self.assertEqual(stop["status"], "STATUS_STOP")
+        self.assertEqual(stop["responseStatus"], 206)
+        self.assertEqual(stop["count"], 4096)
+        self.assertEqual(stop["requestRange"], "bytes=0-4095")
+        self.assertEqual(stop["responseContentRange"], "bytes 0-4095/8192")
+        self.assertEqual(stop["requestStart"], 100.0)
+        self.assertEqual(stop["responseStart"], 125.0)
+        self.assertEqual(stop["responseEnd"], 200.0)
+        self.assertEqual(thread["markers"]["data"][6]["status"], "STATUS_CANCEL")
+
+    def test_rejects_malformed_http_sidecar(self):
+        with tempfile.TemporaryDirectory() as directory_name:
+            sidecar = Path(directory_name) / "http-42-1.txt"
+            sidecar.write_text("1\t2\t3\n", encoding="utf-8")
+            with self.assertRaisesRegex(samply_profile.ProfileInjectionError, "malformed"):
+                samply_profile.read_http_sidecar(sidecar)
 
 
 FAKE_SAMPLY = r"""

--- a/src/common/allocator/allocator.cpp
+++ b/src/common/allocator/allocator.cpp
@@ -25,6 +25,11 @@ namespace duckdb {
 
 constexpr const idx_t Allocator::MAXIMUM_ALLOC_SIZE;
 
+static atomic<idx_t> &TrackedMemory() {
+	static atomic<idx_t> tracked_memory {0};
+	return tracked_memory;
+}
+
 AllocatedData::AllocatedData() : allocator(nullptr), pointer(nullptr), allocated_size(0) {
 }
 
@@ -132,6 +137,9 @@ data_ptr_t Allocator::AllocateData(idx_t size) {
 	if (!result) {
 		throw OutOfMemoryException("Failed to allocate block of %llu bytes (bad allocation)", size);
 	}
+	if (ShouldTrackAllocations()) {
+		AddTrackedMemory(size);
+	}
 	return result;
 }
 
@@ -145,6 +153,9 @@ void Allocator::FreeData(data_ptr_t pointer, idx_t size) {
 		private_data->debug_info->FreeData(pointer, size);
 	}
 #endif
+	if (ShouldTrackAllocations()) {
+		RemoveTrackedMemory(size);
+	}
 	free_function(private_data.get(), pointer, size);
 }
 
@@ -167,7 +178,30 @@ data_ptr_t Allocator::ReallocateData(data_ptr_t pointer, idx_t old_size, idx_t s
 	if (!new_pointer) {
 		throw OutOfMemoryException("Failed to re-allocate block of %llu bytes (bad allocation)", size);
 	}
+	if (ShouldTrackAllocations()) {
+		if (size >= old_size) {
+			AddTrackedMemory(size - old_size);
+		} else {
+			RemoveTrackedMemory(old_size - size);
+		}
+	}
 	return new_pointer;
+}
+
+idx_t Allocator::GetTrackedMemory() {
+	return TrackedMemory().load(std::memory_order_relaxed);
+}
+
+void Allocator::AddTrackedMemory(idx_t size) {
+	TrackedMemory().fetch_add(size, std::memory_order_relaxed);
+}
+
+void Allocator::RemoveTrackedMemory(idx_t size) {
+	auto &tracked_memory = TrackedMemory();
+	auto current = tracked_memory.load(std::memory_order_relaxed);
+	while (!tracked_memory.compare_exchange_weak(current, current >= size ? current - size : 0,
+	                                             std::memory_order_relaxed)) {
+	}
 }
 shared_ptr<Allocator> &Allocator::DefaultAllocatorReference() {
 	static shared_ptr<Allocator> DEFAULT_ALLOCATOR = make_shared_ptr<Allocator>();

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -159,6 +159,7 @@
 #include "duckdb/main/extension_helper.hpp"
 #include "duckdb/main/extension_install_info.hpp"
 #include "duckdb/main/profiler/gathered_metrics.hpp"
+#include "duckdb/main/profiler/samply.hpp"
 #include "duckdb/main/query_result.hpp"
 #include "duckdb/main/secret/secret.hpp"
 #include "duckdb/main/setting_info.hpp"
@@ -5153,6 +5154,26 @@ const char* EnumUtil::ToChars<SamplingState>(SamplingState value) {
 template<>
 SamplingState EnumUtil::FromString<SamplingState>(const char *value) {
 	return static_cast<SamplingState>(StringUtil::StringToEnum(GetSamplingStateValues(), 2, "SamplingState", value));
+}
+
+const StringUtil::EnumStringLiteral *GetSamplyTrackValues() {
+	static constexpr StringUtil::EnumStringLiteral values[] {
+		{ static_cast<uint32_t>(SamplyTrack::QUERY), "QUERY" },
+		{ static_cast<uint32_t>(SamplyTrack::MEMORY), "MEMORY" },
+		{ static_cast<uint32_t>(SamplyTrack::NETWORK), "NETWORK" },
+		{ static_cast<uint32_t>(SamplyTrack::HTTP), "HTTP" }
+	};
+	return values;
+}
+
+template<>
+const char* EnumUtil::ToChars<SamplyTrack>(SamplyTrack value) {
+	return StringUtil::EnumToString(GetSamplyTrackValues(), 4, "SamplyTrack", static_cast<uint32_t>(value));
+}
+
+template<>
+SamplyTrack EnumUtil::FromString<SamplyTrack>(const char *value) {
+	return static_cast<SamplyTrack>(StringUtil::StringToEnum(GetSamplyTrackValues(), 4, "SamplyTrack", value));
 }
 
 const StringUtil::EnumStringLiteral *GetScanTypeValues() {

--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -1239,6 +1239,13 @@
         "default_value": "partial"
     },
     {
+        "name": "samply_tracks",
+        "description": "Samply tracks to collect: query, memory, network, http, none, or all",
+        "type": "VARCHAR",
+        "scope": "local",
+        "custom_implementation": true
+    },
+    {
         "name": "scalar_subquery_error_on_multiple_rows",
         "description": "When a scalar subquery returns multiple rows - return a random row instead of returning an error.",
         "type": "BOOLEAN",

--- a/src/common/time_point.cpp
+++ b/src/common/time_point.cpp
@@ -14,6 +14,10 @@ int64_t TimePoint::GetTickMs() {
 	return std::chrono::duration_cast<std::chrono::milliseconds>(steady_clock::now().time_since_epoch()).count();
 }
 
+int64_t TimePoint::GetTickNanos() {
+	return std::chrono::duration_cast<std::chrono::nanoseconds>(steady_clock::now().time_since_epoch()).count();
+}
+
 double TimePoint::ElapsedSeconds(const TimePoint &start, const TimePoint &end) {
 	D_ASSERT(start.value <= end.value);
 	return std::chrono::duration_cast<std::chrono::duration<double>>(end.value - start.value).count();

--- a/src/function/pragma/pragma_functions.cpp
+++ b/src/function/pragma/pragma_functions.cpp
@@ -37,14 +37,6 @@ static void PragmaDisableProfiling(ClientContext &context, const FunctionParamet
 	config.enable_profiler = false;
 }
 
-static void PragmaEnableSamplyMarkers(ClientContext &context, const FunctionParameters &parameters) {
-	EnableSamplyMarkersSetting::SetLocal(context, Value::BOOLEAN(true));
-}
-
-static void PragmaDisableSamplyMarkers(ClientContext &context, const FunctionParameters &parameters) {
-	EnableSamplyMarkersSetting::SetLocal(context, Value::BOOLEAN(false));
-}
-
 static void PragmaEnableProgressBar(ClientContext &context, const FunctionParameters &parameters) {
 	ClientConfig::GetConfig(context).enable_progress_bar = true;
 }
@@ -111,9 +103,6 @@ void PragmaFunctions::RegisterFunction(BuiltinFunctions &set) {
 
 	set.AddFunction(PragmaFunction::PragmaStatement("disable_profile", PragmaDisableProfiling));
 	set.AddFunction(PragmaFunction::PragmaStatement("disable_profiling", PragmaDisableProfiling));
-	set.AddFunction(PragmaFunction::PragmaStatement("enable_samply_markers", PragmaEnableSamplyMarkers));
-	set.AddFunction(PragmaFunction::PragmaStatement("disable_samply_markers", PragmaDisableSamplyMarkers));
-
 	set.AddFunction(PragmaFunction::PragmaStatement("enable_verification", PragmaEnableVerification));
 	set.AddFunction(PragmaFunction::PragmaStatement("disable_verification", PragmaDisableVerification));
 

--- a/src/function/pragma/pragma_functions.cpp
+++ b/src/function/pragma/pragma_functions.cpp
@@ -37,6 +37,14 @@ static void PragmaDisableProfiling(ClientContext &context, const FunctionParamet
 	config.enable_profiler = false;
 }
 
+static void PragmaEnableSamplyMarkers(ClientContext &context, const FunctionParameters &parameters) {
+	EnableSamplyMarkersSetting::SetLocal(context, Value::BOOLEAN(true));
+}
+
+static void PragmaDisableSamplyMarkers(ClientContext &context, const FunctionParameters &parameters) {
+	EnableSamplyMarkersSetting::SetLocal(context, Value::BOOLEAN(false));
+}
+
 static void PragmaEnableProgressBar(ClientContext &context, const FunctionParameters &parameters) {
 	ClientConfig::GetConfig(context).enable_progress_bar = true;
 }
@@ -103,6 +111,8 @@ void PragmaFunctions::RegisterFunction(BuiltinFunctions &set) {
 
 	set.AddFunction(PragmaFunction::PragmaStatement("disable_profile", PragmaDisableProfiling));
 	set.AddFunction(PragmaFunction::PragmaStatement("disable_profiling", PragmaDisableProfiling));
+	set.AddFunction(PragmaFunction::PragmaStatement("enable_samply_markers", PragmaEnableSamplyMarkers));
+	set.AddFunction(PragmaFunction::PragmaStatement("disable_samply_markers", PragmaDisableSamplyMarkers));
 
 	set.AddFunction(PragmaFunction::PragmaStatement("enable_verification", PragmaEnableVerification));
 	set.AddFunction(PragmaFunction::PragmaStatement("disable_verification", PragmaDisableVerification));

--- a/src/include/duckdb/common/allocator.hpp
+++ b/src/include/duckdb/common/allocator.hpp
@@ -31,6 +31,8 @@ struct PrivateAllocatorData {
 	virtual ~PrivateAllocatorData();
 
 	AllocatorFreeType free_type = AllocatorFreeType::REQUIRES_FREE;
+	//! Whether this allocator owns backing allocations rather than forwarding to another allocator.
+	bool track_allocations = true;
 	//! Debug info for tracking allocations. Only initialized when the Allocator is constructed in a DEBUG build.
 	//! Code accessing this must check for nullptr because e.g. statically-linked extensions may have a different
 	//! DEBUG/release configuration than the host binary.
@@ -121,6 +123,9 @@ public:
 
 	DUCKDB_API static Allocator &DefaultAllocator();
 	DUCKDB_API static shared_ptr<Allocator> &DefaultAllocatorReference();
+	DUCKDB_API static idx_t GetTrackedMemory();
+	DUCKDB_API static void AddTrackedMemory(idx_t size);
+	DUCKDB_API static void RemoveTrackedMemory(idx_t size);
 
 	static bool SupportsFlush();
 	static optional_idx DecayDelay();
@@ -142,6 +147,9 @@ private:
 	bool ShouldUseDebugInfo() const {
 		return private_data && private_data->free_type != AllocatorFreeType::DOES_NOT_REQUIRE_FREE &&
 		       private_data->debug_info;
+	}
+	bool ShouldTrackAllocations() const {
+		return !private_data || private_data->track_allocations;
 	}
 };
 

--- a/src/include/duckdb/common/enum_util.hpp
+++ b/src/include/duckdb/common/enum_util.hpp
@@ -470,6 +470,8 @@ enum class SampleType : uint8_t;
 
 enum class SamplingState : uint8_t;
 
+enum class SamplyTrack : uint8_t;
+
 enum class ScanType : uint8_t;
 
 enum class SecretDisplayType : uint8_t;
@@ -1273,6 +1275,9 @@ const char* EnumUtil::ToChars<SampleType>(SampleType value);
 
 template<>
 const char* EnumUtil::ToChars<SamplingState>(SamplingState value);
+
+template<>
+const char* EnumUtil::ToChars<SamplyTrack>(SamplyTrack value);
 
 template<>
 const char* EnumUtil::ToChars<ScanType>(ScanType value);
@@ -2150,6 +2155,9 @@ SampleType EnumUtil::FromString<SampleType>(const char *value);
 
 template<>
 SamplingState EnumUtil::FromString<SamplingState>(const char *value);
+
+template<>
+SamplyTrack EnumUtil::FromString<SamplyTrack>(const char *value);
 
 template<>
 ScanType EnumUtil::FromString<ScanType>(const char *value);

--- a/src/include/duckdb/common/http_util.hpp
+++ b/src/include/duckdb/common/http_util.hpp
@@ -326,6 +326,8 @@ public:
 
 	//! Whether replaying this request is safe. POST is the only method we cannot assume is idempotent.
 	DUCKDB_API static bool IsIdempotent(RequestType type);
+	DUCKDB_API static idx_t GetTotalBytesReceived();
+	DUCKDB_API static idx_t GetTotalBytesSent();
 
 	static void ParseHTTPProxyHost(string &proxy_value, string &hostname_out, idx_t &port_out, idx_t default_port = 80);
 	static void DecomposeURL(const string &url, string &path_out, string &proto_host_port_out);

--- a/src/include/duckdb/common/time_point.hpp
+++ b/src/include/duckdb/common/time_point.hpp
@@ -22,6 +22,7 @@ public:
 
 	// Get current monotonic clock time in milliseconds.
 	static int64_t GetTickMs();
+	static int64_t GetTickNanos();
 	// Get two timepoints difference in different units
 	static double ElapsedSeconds(const TimePoint &start, const TimePoint &end);
 	static int64_t ElapsedMillis(const TimePoint &start, const TimePoint &end);

--- a/src/include/duckdb/execution/executor.hpp
+++ b/src/include/duckdb/execution/executor.hpp
@@ -157,8 +157,6 @@ private:
 	unique_ptr<PipelineExecutor> root_executor;
 	//! The current root pipeline index
 	idx_t root_pipeline_idx;
-	//! The next query-local pipeline marker identifier
-	idx_t next_pipeline_id = 0;
 	//! The producer of this query
 	unique_ptr<ProducerToken> producer;
 	//! List of events

--- a/src/include/duckdb/execution/executor.hpp
+++ b/src/include/duckdb/execution/executor.hpp
@@ -157,6 +157,8 @@ private:
 	unique_ptr<PipelineExecutor> root_executor;
 	//! The current root pipeline index
 	idx_t root_pipeline_idx;
+	//! The next query-local pipeline marker identifier
+	idx_t next_pipeline_id = 0;
 	//! The producer of this query
 	unique_ptr<ProducerToken> producer;
 	//! List of events

--- a/src/include/duckdb/main/client_config.hpp
+++ b/src/include/duckdb/main/client_config.hpp
@@ -23,6 +23,7 @@ namespace duckdb {
 class ClientContext;
 class PhysicalResultCollector;
 class PreparedStatementData;
+class SamplyResourceSubscription;
 
 typedef std::function<unique_ptr<PhysicalOperator>(ClientContext &context, PreparedStatementData &data)>
     get_result_collector_t;
@@ -30,8 +31,10 @@ typedef std::function<unique_ptr<PhysicalOperator>(ClientContext &context, Prepa
 struct ClientConfig {
 	//! If the query profiler is enabled or not.
 	bool enable_profiler = false;
-	//! If query profiler scopes are emitted as Samply marker spans.
-	bool enable_samply_markers = false;
+	//! Bitmask of query and resource tracks emitted for Samply.
+	uint8_t samply_tracks = 0;
+	//! Keeps this connection's process-wide resource sampler request active.
+	shared_ptr<SamplyResourceSubscription> samply_resource_subscription;
 	//! The format to print query profiling information in (default: query_tree), if enabled.
 	//! This is the profiler format name passed to QueryProfiler::CreateProfiler.
 	string profiler_print_format = "query_tree";

--- a/src/include/duckdb/main/client_config.hpp
+++ b/src/include/duckdb/main/client_config.hpp
@@ -30,6 +30,8 @@ typedef std::function<unique_ptr<PhysicalOperator>(ClientContext &context, Prepa
 struct ClientConfig {
 	//! If the query profiler is enabled or not.
 	bool enable_profiler = false;
+	//! If query profiler scopes are emitted as Samply marker spans.
+	bool enable_samply_markers = false;
 	//! The format to print query profiling information in (default: query_tree), if enabled.
 	//! This is the profiler format name passed to QueryProfiler::CreateProfiler.
 	string profiler_print_format = "query_tree";

--- a/src/include/duckdb/main/profiler/profiling_node.hpp
+++ b/src/include/duckdb/main/profiler/profiling_node.hpp
@@ -29,6 +29,8 @@ struct OperatorMetrics {
 	idx_t rows_scanned;
 	idx_t row_groups_scanned;
 	idx_t total_row_groups_to_scan;
+	idx_t timing_start_ns;
+	idx_t timing_end_ns;
 
 	profiler_metrics_t GetMetrics(const GatheredMetrics &info) const;
 	void ResetMetrics() {
@@ -40,6 +42,8 @@ struct OperatorMetrics {
 		rows_scanned = 0;
 		row_groups_scanned = 0;
 		total_row_groups_to_scan = 0;
+		timing_start_ns = DConstants::INVALID_INDEX;
+		timing_end_ns = 0;
 		operator_type = PhysicalOperatorType::INVALID;
 		extra_info.clear();
 	}
@@ -53,6 +57,7 @@ struct OperatorMetrics {
 		return extra_info;
 	}
 	void GatherMetrics(ClientContext &context, double elapsed_time, optional_ptr<DataChunk> chunk);
+	void UpdateTimingBounds(idx_t start_ns, idx_t end_ns);
 	void Merge(const OperatorMetrics &other);
 	void Accumulate(const OperatorMetrics &other);
 
@@ -90,6 +95,7 @@ private:
 	bool enabled;
 	//! The timer used to time the execution time of the individual Physical Operators
 	Profiler op;
+	idx_t active_start_ns = 0;
 	//! The stack of Physical Operators that are currently active
 	optional_ptr<const PhysicalOperator> active_operator;
 	//! A mapping of physical operators to profiled operator information.

--- a/src/include/duckdb/main/profiler/profiling_utils.hpp
+++ b/src/include/duckdb/main/profiler/profiling_utils.hpp
@@ -12,6 +12,7 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/main/profiler/gathered_metrics.hpp"
 #include "duckdb/main/profiler/profiling_node.hpp"
+#include "duckdb/main/profiler/samply.hpp"
 #include "duckdb/common/profiler.hpp"
 
 namespace duckdb_yyjson {
@@ -142,8 +143,10 @@ struct MetricsTimer {
 public:
 	MetricsTimer() : metric_name(""), is_active(false) {
 	}
-	MetricsTimer(QueryMetrics &query_metrics, string key, const bool is_active = true)
-	    : query_metrics(query_metrics), metric_name(std::move(key)), is_active(is_active) {
+	MetricsTimer(QueryMetrics &query_metrics, string key, const bool is_active = true,
+	             const bool samply_markers_enabled = false)
+	    : query_metrics(query_metrics), metric_name(std::move(key)), samply_marker(samply_markers_enabled),
+	      is_active(is_active) {
 		if (!is_active) {
 			return;
 		}
@@ -162,12 +165,14 @@ public:
 		std::swap(query_metrics, other.query_metrics);
 		std::swap(metric_name, other.metric_name);
 		std::swap(profiler, other.profiler);
+		std::swap(samply_marker, other.samply_marker);
 		std::swap(is_active, other.is_active);
 	}
 	MetricsTimer &operator=(MetricsTimer &&other) noexcept {
 		std::swap(query_metrics, other.query_metrics);
 		std::swap(metric_name, other.metric_name);
 		std::swap(profiler, other.profiler);
+		std::swap(samply_marker, other.samply_marker);
 		std::swap(is_active, other.is_active);
 		return *this;
 	}
@@ -179,6 +184,7 @@ public:
 		}
 		is_active = false;
 		profiler.End();
+		samply_marker.End(metric_name.c_str());
 		query_metrics->UpdateMetric(metric_name, profiler.ElapsedNanos());
 	}
 
@@ -187,6 +193,7 @@ public:
 			return;
 		}
 		profiler.Reset();
+		samply_marker.Reset();
 		is_active = false;
 	}
 
@@ -194,6 +201,7 @@ private:
 	optional_ptr<QueryMetrics> query_metrics;
 	string metric_name;
 	Profiler profiler;
+	SamplyMarker samply_marker;
 	bool is_active;
 };
 

--- a/src/include/duckdb/main/profiler/profiling_utils.hpp
+++ b/src/include/duckdb/main/profiler/profiling_utils.hpp
@@ -144,8 +144,9 @@ public:
 	MetricsTimer() : metric_name(""), is_active(false) {
 	}
 	MetricsTimer(QueryMetrics &query_metrics, string key, const bool is_active = true,
-	             const bool samply_markers_enabled = false)
-	    : query_metrics(query_metrics), metric_name(std::move(key)), samply_marker(samply_markers_enabled),
+	             const bool samply_markers_enabled = false, string samply_marker_name_p = string())
+	    : query_metrics(query_metrics), metric_name(std::move(key)),
+	      samply_marker_name(std::move(samply_marker_name_p)), samply_marker(samply_markers_enabled),
 	      is_active(is_active) {
 		if (!is_active) {
 			return;
@@ -164,6 +165,7 @@ public:
 	MetricsTimer(MetricsTimer &&other) noexcept : is_active(false) {
 		std::swap(query_metrics, other.query_metrics);
 		std::swap(metric_name, other.metric_name);
+		std::swap(samply_marker_name, other.samply_marker_name);
 		std::swap(profiler, other.profiler);
 		std::swap(samply_marker, other.samply_marker);
 		std::swap(is_active, other.is_active);
@@ -171,6 +173,7 @@ public:
 	MetricsTimer &operator=(MetricsTimer &&other) noexcept {
 		std::swap(query_metrics, other.query_metrics);
 		std::swap(metric_name, other.metric_name);
+		std::swap(samply_marker_name, other.samply_marker_name);
 		std::swap(profiler, other.profiler);
 		std::swap(samply_marker, other.samply_marker);
 		std::swap(is_active, other.is_active);
@@ -184,7 +187,7 @@ public:
 		}
 		is_active = false;
 		profiler.End();
-		samply_marker.End(metric_name.c_str());
+		samply_marker.End(samply_marker_name.empty() ? metric_name.c_str() : samply_marker_name.c_str());
 		query_metrics->UpdateMetric(metric_name, profiler.ElapsedNanos());
 	}
 
@@ -200,6 +203,7 @@ public:
 private:
 	optional_ptr<QueryMetrics> query_metrics;
 	string metric_name;
+	string samply_marker_name;
 	Profiler profiler;
 	SamplyMarker samply_marker;
 	bool is_active;

--- a/src/include/duckdb/main/profiler/profiling_utils.hpp
+++ b/src/include/duckdb/main/profiler/profiling_utils.hpp
@@ -12,7 +12,6 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/main/profiler/gathered_metrics.hpp"
 #include "duckdb/main/profiler/profiling_node.hpp"
-#include "duckdb/main/profiler/samply.hpp"
 #include "duckdb/common/profiler.hpp"
 
 namespace duckdb_yyjson {
@@ -23,6 +22,15 @@ struct yyjson_mut_val;
 namespace duckdb {
 
 struct MetricsTimer;
+
+struct TimingBounds {
+	idx_t start_ns = DConstants::INVALID_INDEX;
+	idx_t end_ns = 0;
+
+	bool IsSet() const {
+		return start_ns != DConstants::INVALID_INDEX;
+	}
+};
 
 // Top level query metrics
 struct QueryMetrics {
@@ -45,6 +53,18 @@ public:
 public:
 	void UpdateMetric(const string &key, idx_t addition) {
 		string_timings[key] += addition;
+	}
+	void UpdateTimingBounds(const string &key, idx_t start_ns, idx_t end_ns) {
+		auto &bounds = timing_bounds[key];
+		bounds.start_ns = bounds.IsSet() ? MinValue(bounds.start_ns, start_ns) : start_ns;
+		bounds.end_ns = MaxValue(bounds.end_ns, end_ns);
+	}
+	idx_t GetElapsedNanos() const {
+		if (query_start_tick_ns == 0) {
+			return 0;
+		}
+		auto now = TimePoint::GetTickNanos();
+		return static_cast<idx_t>(now >= query_start_tick_ns ? now - query_start_tick_ns : 0);
 	}
 
 	void UpdateMetricCounter(const string &key, idx_t addition) {
@@ -98,10 +118,18 @@ public:
 	const unordered_map<string, idx_t> &GetMetricCounters() const {
 		return string_counters;
 	}
+	const unordered_map<string, TimingBounds> &GetTimingBounds() const {
+		return timing_bounds;
+	}
+	idx_t GetMetricTimingNanos(const string &key) const {
+		auto entry = string_timings.find(key);
+		return entry == string_timings.end() ? 0 : entry->second;
+	}
 
 	void Reset() {
 		string_timings.clear();
 		string_counters.clear();
+		timing_bounds.clear();
 		bytes_read = 0;
 		bytes_written = 0;
 		total_memory_allocated = 0;
@@ -111,6 +139,8 @@ public:
 		system_peak_buffer_memory = 0;
 		system_peak_temp_dir_size = 0;
 		blocked_thread_time = 0;
+		query_start_tick_ns = 0;
+		query_start_unix_ns = 0;
 	}
 
 	//! Write all query-level metrics into the given GatheredMetrics.
@@ -131,26 +161,27 @@ public:
 private:
 	// String-keyed timings for optimizer, storage and phase timing metrics
 	unordered_map<string, idx_t> string_timings;
+	unordered_map<string, TimingBounds> timing_bounds;
 	// String-keyed counters for storage counter metrics (e.g. "storage.wal_replay_entry_count")
 	unordered_map<string, idx_t> string_counters;
 
 public:
+	int64_t query_start_tick_ns = 0;
+	uint64_t query_start_unix_ns = 0;
 	// Declared after string_timings so it is destroyed first; its destructor writes to string_timings.
 	unique_ptr<MetricsTimer> latency_timer;
 };
 
 struct MetricsTimer {
 public:
-	MetricsTimer() : metric_name(""), is_active(false) {
+	MetricsTimer() : metric_name(""), start_ns(0), is_active(false) {
 	}
-	MetricsTimer(QueryMetrics &query_metrics, string key, const bool is_active = true,
-	             const bool samply_markers_enabled = false, string samply_marker_name_p = string())
-	    : query_metrics(query_metrics), metric_name(std::move(key)),
-	      samply_marker_name(std::move(samply_marker_name_p)), samply_marker(samply_markers_enabled),
-	      is_active(is_active) {
+	MetricsTimer(QueryMetrics &query_metrics, string key, const bool is_active = true)
+	    : query_metrics(query_metrics), metric_name(std::move(key)), start_ns(0), is_active(is_active) {
 		if (!is_active) {
 			return;
 		}
+		start_ns = query_metrics.GetElapsedNanos();
 		profiler.Start();
 	}
 	~MetricsTimer() {
@@ -162,20 +193,18 @@ public:
 	MetricsTimer(const MetricsTimer &other) = delete;
 	MetricsTimer &operator=(const MetricsTimer &) = delete;
 	//! enable move constructors
-	MetricsTimer(MetricsTimer &&other) noexcept : is_active(false) {
+	MetricsTimer(MetricsTimer &&other) noexcept : start_ns(0), is_active(false) {
 		std::swap(query_metrics, other.query_metrics);
 		std::swap(metric_name, other.metric_name);
-		std::swap(samply_marker_name, other.samply_marker_name);
 		std::swap(profiler, other.profiler);
-		std::swap(samply_marker, other.samply_marker);
+		std::swap(start_ns, other.start_ns);
 		std::swap(is_active, other.is_active);
 	}
 	MetricsTimer &operator=(MetricsTimer &&other) noexcept {
 		std::swap(query_metrics, other.query_metrics);
 		std::swap(metric_name, other.metric_name);
-		std::swap(samply_marker_name, other.samply_marker_name);
 		std::swap(profiler, other.profiler);
-		std::swap(samply_marker, other.samply_marker);
+		std::swap(start_ns, other.start_ns);
 		std::swap(is_active, other.is_active);
 		return *this;
 	}
@@ -187,8 +216,9 @@ public:
 		}
 		is_active = false;
 		profiler.End();
-		samply_marker.End(samply_marker_name.empty() ? metric_name.c_str() : samply_marker_name.c_str());
+		auto end_ns = query_metrics->GetElapsedNanos();
 		query_metrics->UpdateMetric(metric_name, profiler.ElapsedNanos());
+		query_metrics->UpdateTimingBounds(metric_name, start_ns, end_ns);
 	}
 
 	void Reset() {
@@ -196,16 +226,14 @@ public:
 			return;
 		}
 		profiler.Reset();
-		samply_marker.Reset();
 		is_active = false;
 	}
 
 private:
 	optional_ptr<QueryMetrics> query_metrics;
 	string metric_name;
-	string samply_marker_name;
 	Profiler profiler;
-	SamplyMarker samply_marker;
+	idx_t start_ns;
 	bool is_active;
 };
 

--- a/src/include/duckdb/main/profiler/samply.hpp
+++ b/src/include/duckdb/main/profiler/samply.hpp
@@ -41,19 +41,18 @@ void WriteSamplyHTTPAttempt(uint64_t start_unix_ns, uint64_t duration_ns, const 
                             int32_t status_code, uint64_t bytes_received, int64_t time_to_first_byte_ns,
                             const string &request_range, const string &response_content_range) noexcept;
 
-//! Creates a single-line query label that fits in a Samply marker record.
-string SamplyQueryMarkerName(const string &query);
+//! Writes one completed query profile to the sidecar consumed by scripts/samply_profile.py.
+void WriteSamplyQueryProfile(uint64_t start_unix_ns, uint64_t duration_ns, const string &profile_json) noexcept;
 
-//! Writes the marker-file format consumed by Samply. This is public only for unit testing.
-class SamplyMarkerWriter {
+class SamplyQueryWriter {
 public:
-	explicit SamplyMarkerWriter(const char *directory = nullptr) noexcept;
-	~SamplyMarkerWriter();
+	explicit SamplyQueryWriter(const char *directory = nullptr) noexcept;
+	~SamplyQueryWriter();
 
-	SamplyMarkerWriter(const SamplyMarkerWriter &) = delete;
-	SamplyMarkerWriter &operator=(const SamplyMarkerWriter &) = delete;
+	SamplyQueryWriter(const SamplyQueryWriter &) = delete;
+	SamplyQueryWriter &operator=(const SamplyQueryWriter &) = delete;
 
-	bool WriteMarker(uint64_t start_ns, uint64_t end_ns, const char *name) noexcept;
+	bool WriteProfile(uint64_t start_unix_ns, uint64_t duration_ns, const string &profile_json) noexcept;
 	const char *GetPath() const noexcept;
 
 private:
@@ -117,41 +116,6 @@ private:
 	int file_descriptor;
 	bool failed;
 	char path[4096];
-};
-
-//! A movable timer whose completed span can be written as a named marker.
-class SamplyMarker {
-public:
-	SamplyMarker() noexcept;
-	explicit SamplyMarker(bool enabled) noexcept;
-	SamplyMarker(SamplyMarker &&other) noexcept;
-	SamplyMarker &operator=(SamplyMarker &&other) noexcept;
-
-	SamplyMarker(const SamplyMarker &) = delete;
-	SamplyMarker &operator=(const SamplyMarker &) = delete;
-
-	void End(const char *name) noexcept;
-	void Reset() noexcept;
-
-private:
-	uint64_t start_ns;
-	bool active;
-};
-
-class SamplyMarkerScope {
-public:
-	explicit SamplyMarkerScope(const char *name_p) noexcept : marker(name_p && name_p[0] != '\0'), name(name_p) {
-	}
-	~SamplyMarkerScope() {
-		marker.End(name);
-	}
-
-	SamplyMarkerScope(const SamplyMarkerScope &) = delete;
-	SamplyMarkerScope &operator=(const SamplyMarkerScope &) = delete;
-
-private:
-	SamplyMarker marker;
-	const char *name;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/main/profiler/samply.hpp
+++ b/src/include/duckdb/main/profiler/samply.hpp
@@ -12,6 +12,9 @@
 
 namespace duckdb {
 
+//! Creates a single-line query label that fits in a Samply marker record.
+string SamplyQueryMarkerName(const string &query);
+
 //! Writes the marker-file format consumed by Samply. This is public only for unit testing.
 class SamplyMarkerWriter {
 public:

--- a/src/include/duckdb/main/profiler/samply.hpp
+++ b/src/include/duckdb/main/profiler/samply.hpp
@@ -17,6 +17,7 @@ enum class SamplyTrack : uint8_t {
 	QUERY = 1,
 	MEMORY = 2,
 	NETWORK = 4,
+	HTTP = 8,
 };
 
 static inline bool SamplyTrackEnabled(uint8_t tracks, SamplyTrack track) {
@@ -31,6 +32,14 @@ shared_ptr<SamplyResourceSubscription> StartSamplyResourceSampling(uint8_t track
 //! Starts an isolated resource sampler without periodic sampling. Public only for unit testing.
 shared_ptr<SamplyResourceSubscription> StartSamplyResourceSamplingForTesting(uint8_t tracks,
                                                                              const char *directory) noexcept;
+
+//! Returns whether process-wide HTTP request tracking is currently active.
+bool SamplyHTTPTrackEnabled() noexcept;
+
+//! Writes one HTTP request attempt to the sidecar consumed by scripts/samply_profile.py.
+void WriteSamplyHTTPAttempt(uint64_t start_unix_ns, uint64_t duration_ns, const char *method, const string &url,
+                            int32_t status_code, uint64_t bytes_received, int64_t time_to_first_byte_ns,
+                            const string &request_range, const string &response_content_range) noexcept;
 
 //! Creates a single-line query label that fits in a Samply marker record.
 string SamplyQueryMarkerName(const string &query);
@@ -82,6 +91,31 @@ private:
 	bool failed;
 	bool wrote_clock;
 	string buffer;
+	char path[4096];
+};
+
+//! Writes the HTTP sidecar format used by scripts/samply_profile.py. Public only for unit testing.
+class SamplyHTTPWriter {
+public:
+	explicit SamplyHTTPWriter(const char *directory = nullptr) noexcept;
+	~SamplyHTTPWriter();
+
+	SamplyHTTPWriter(const SamplyHTTPWriter &) = delete;
+	SamplyHTTPWriter &operator=(const SamplyHTTPWriter &) = delete;
+
+	bool WriteAttempt(uint64_t start_unix_ns, uint64_t duration_ns, const char *method, const string &url,
+	                  int32_t status_code, uint64_t bytes_received, int64_t time_to_first_byte_ns,
+	                  const string &request_range, const string &response_content_range) noexcept;
+	const char *GetPath() const noexcept;
+
+private:
+	bool Initialize() noexcept;
+	bool Write(const char *data, idx_t size) noexcept;
+
+private:
+	const char *directory;
+	int file_descriptor;
+	bool failed;
 	char path[4096];
 };
 

--- a/src/include/duckdb/main/profiler/samply.hpp
+++ b/src/include/duckdb/main/profiler/samply.hpp
@@ -9,8 +9,28 @@
 #pragma once
 
 #include "duckdb/common/constants.hpp"
+#include "duckdb/common/shared_ptr.hpp"
 
 namespace duckdb {
+
+enum class SamplyTrack : uint8_t {
+	QUERY = 1,
+	MEMORY = 2,
+	NETWORK = 4,
+};
+
+static inline bool SamplyTrackEnabled(uint8_t tracks, SamplyTrack track) {
+	return (tracks & static_cast<uint8_t>(track)) != 0;
+}
+
+class SamplyResourceSubscription;
+
+//! Starts process-wide resource sampling for the requested resource bits.
+shared_ptr<SamplyResourceSubscription> StartSamplyResourceSampling(uint8_t tracks) noexcept;
+
+//! Starts an isolated resource sampler without periodic sampling. Public only for unit testing.
+shared_ptr<SamplyResourceSubscription> StartSamplyResourceSamplingForTesting(uint8_t tracks,
+                                                                             const char *directory) noexcept;
 
 //! Creates a single-line query label that fits in a Samply marker record.
 string SamplyQueryMarkerName(const string &query);
@@ -35,6 +55,33 @@ private:
 	const char *directory;
 	int file_descriptor;
 	bool failed;
+	char path[4096];
+};
+
+//! Writes the counter sidecar format used by scripts/samply_profile.py. Public only for unit testing.
+class SamplyCounterWriter {
+public:
+	explicit SamplyCounterWriter(const char *directory = nullptr) noexcept;
+	~SamplyCounterWriter();
+
+	SamplyCounterWriter(const SamplyCounterWriter &) = delete;
+	SamplyCounterWriter &operator=(const SamplyCounterWriter &) = delete;
+
+	bool WriteClock(uint64_t monotonic_ns, uint64_t unix_ns) noexcept;
+	bool WriteSample(uint64_t monotonic_ns, const char *name, int64_t value) noexcept;
+	bool Flush() noexcept;
+	const char *GetPath() const noexcept;
+
+private:
+	bool Initialize() noexcept;
+	bool Append(const char *data, idx_t size) noexcept;
+
+private:
+	const char *directory;
+	int file_descriptor;
+	bool failed;
+	bool wrote_clock;
+	string buffer;
 	char path[4096];
 };
 

--- a/src/include/duckdb/main/profiler/samply.hpp
+++ b/src/include/duckdb/main/profiler/samply.hpp
@@ -1,0 +1,73 @@
+//===----------------------------------------------------------------------===//
+//
+//                         DuckDB
+//
+// duckdb/main/profiler/samply.hpp
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/constants.hpp"
+
+namespace duckdb {
+
+//! Writes the marker-file format consumed by Samply. This is public only for unit testing.
+class SamplyMarkerWriter {
+public:
+	explicit SamplyMarkerWriter(const char *directory = nullptr) noexcept;
+	~SamplyMarkerWriter();
+
+	SamplyMarkerWriter(const SamplyMarkerWriter &) = delete;
+	SamplyMarkerWriter &operator=(const SamplyMarkerWriter &) = delete;
+
+	bool WriteMarker(uint64_t start_ns, uint64_t end_ns, const char *name) noexcept;
+	const char *GetPath() const noexcept;
+
+private:
+	bool Initialize() noexcept;
+	bool Write(const char *data, idx_t size) noexcept;
+
+private:
+	const char *directory;
+	int file_descriptor;
+	bool failed;
+	char path[4096];
+};
+
+//! A movable timer whose completed span can be written as a named marker.
+class SamplyMarker {
+public:
+	SamplyMarker() noexcept;
+	explicit SamplyMarker(bool enabled) noexcept;
+	SamplyMarker(SamplyMarker &&other) noexcept;
+	SamplyMarker &operator=(SamplyMarker &&other) noexcept;
+
+	SamplyMarker(const SamplyMarker &) = delete;
+	SamplyMarker &operator=(const SamplyMarker &) = delete;
+
+	void End(const char *name) noexcept;
+	void Reset() noexcept;
+
+private:
+	uint64_t start_ns;
+	bool active;
+};
+
+class SamplyMarkerScope {
+public:
+	explicit SamplyMarkerScope(const char *name_p) noexcept : marker(name_p && name_p[0] != '\0'), name(name_p) {
+	}
+	~SamplyMarkerScope() {
+		marker.End(name);
+	}
+
+	SamplyMarkerScope(const SamplyMarkerScope &) = delete;
+	SamplyMarkerScope &operator=(const SamplyMarkerScope &) = delete;
+
+private:
+	SamplyMarker marker;
+	const char *name;
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/main/query_profiler.hpp
+++ b/src/include/duckdb/main/query_profiler.hpp
@@ -158,6 +158,7 @@ public:
 	static string DrawPadded(const string &str, idx_t width);
 	DUCKDB_API void ToLog() const;
 	DUCKDB_API string ToJSON() const;
+	DUCKDB_API string ToSamplyJSON() const;
 	DUCKDB_API void WriteToFile(const char *path, string &info) const;
 	DUCKDB_API idx_t GetBytesRead() const;
 	DUCKDB_API idx_t GetBytesWritten() const;
@@ -166,6 +167,9 @@ public:
 	QueryProfileResult &GetResult();
 	//! Returns true if the last query produced a profiling tree (i.e. profiling was enabled and the query succeeded)
 	bool HasRoot() const;
+	idx_t GetElapsedNanos() const {
+		return query_metrics.GetElapsedNanos();
+	}
 
 private:
 	unique_ptr<ProfilingNode> CreateTree(const PhysicalOperator &root, const idx_t depth = 0);
@@ -226,7 +230,7 @@ private:
 	//! Write metrics to log without acquiring the lock (must be called with lock held).
 	void ToLogInternal() const;
 
-	unique_ptr<QueryProfileResult> ToResultTree() const;
+	unique_ptr<QueryProfileResult> ToResultTree(bool include_timing_bounds = false) const;
 	unique_ptr<QueryProfileResult> ToLegacyResultTree() const;
 
 	//! Check whether or not an operator type requires query profiling. If none of the ops in a query require profiling

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -1827,6 +1827,16 @@ struct RegexMatchOperatorSemanticsSetting {
 	static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
+struct SamplyTracksSetting {
+	using RETURN_TYPE = string;
+	static constexpr const char *Name = "samply_tracks";
+	static constexpr const char *Description = "Samply tracks to collect: query, memory, network, http, none, or all";
+	static constexpr const char *InputType = "VARCHAR";
+	static void SetLocal(ClientContext &context, const Value &parameter);
+	static void ResetLocal(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
+};
+
 struct ScalarSubqueryErrorOnMultipleRowsSetting {
 	using RETURN_TYPE = bool;
 	static constexpr const char *Name = "scalar_subquery_error_on_multiple_rows";

--- a/src/include/duckdb/parallel/pipeline.hpp
+++ b/src/include/duckdb/parallel/pipeline.hpp
@@ -136,10 +136,6 @@ public:
 	vector<reference<PhysicalOperator>> GetOperators();
 	vector<const_reference<PhysicalOperator>> GetOperators() const;
 	const vector<reference<PhysicalOperator>> &GetIntermediateOperators() const;
-	const string &GetSamplyMarkerName() const {
-		return samply_marker_name;
-	}
-
 	optional_ptr<PhysicalOperator> GetSink() {
 		return sink;
 	}
@@ -174,9 +170,6 @@ public:
 	//! Updates the batch index of a pipeline (and returns the new minimum batch index)
 	idx_t UpdateBatchIndex(idx_t old_index, idx_t new_index);
 
-private:
-	void InitializeSamplyMarkerName();
-
 	//! Whether or not the pipeline has been readied
 	bool ready;
 	//! Whether or not the pipeline has been initialized
@@ -187,11 +180,6 @@ private:
 	vector<reference<PhysicalOperator>> operators;
 	//! The sink (i.e. destination) for data; this is e.g. a hash table to-be-built
 	optional_ptr<PhysicalOperator> sink;
-	//! A stable query-local identifier used in Samply marker labels
-	idx_t samply_pipeline_id;
-	//! The precomputed Samply marker label; empty when markers are disabled
-	string samply_marker_name;
-
 	//! The global source state
 	shared_ptr<GlobalSourceState> source_state DUCKDB_GUARDED_BY(source_state_lock);
 	//! Lock for resetting or inspecting the global source state pointer

--- a/src/include/duckdb/parallel/pipeline.hpp
+++ b/src/include/duckdb/parallel/pipeline.hpp
@@ -175,6 +175,8 @@ public:
 	idx_t UpdateBatchIndex(idx_t old_index, idx_t new_index);
 
 private:
+	void InitializeSamplyMarkerName();
+
 	//! Whether or not the pipeline has been readied
 	bool ready;
 	//! Whether or not the pipeline has been initialized

--- a/src/include/duckdb/parallel/pipeline.hpp
+++ b/src/include/duckdb/parallel/pipeline.hpp
@@ -136,6 +136,9 @@ public:
 	vector<reference<PhysicalOperator>> GetOperators();
 	vector<const_reference<PhysicalOperator>> GetOperators() const;
 	const vector<reference<PhysicalOperator>> &GetIntermediateOperators() const;
+	const string &GetSamplyMarkerName() const {
+		return samply_marker_name;
+	}
 
 	optional_ptr<PhysicalOperator> GetSink() {
 		return sink;
@@ -182,6 +185,10 @@ private:
 	vector<reference<PhysicalOperator>> operators;
 	//! The sink (i.e. destination) for data; this is e.g. a hash table to-be-built
 	optional_ptr<PhysicalOperator> sink;
+	//! A stable query-local identifier used in Samply marker labels
+	idx_t samply_pipeline_id;
+	//! The precomputed Samply marker label; empty when markers are disabled
+	string samply_marker_name;
 
 	//! The global source state
 	shared_ptr<GlobalSourceState> source_state DUCKDB_GUARDED_BY(source_state_lock);

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -53,6 +53,7 @@ add_library_unity(
   prepared_statement.cpp
   prepared_statement_data.cpp
   relation.cpp
+  samply.cpp
   query_profiler.cpp
   query_result.cpp
   result_set_manager.cpp

--- a/src/main/client_verify.cpp
+++ b/src/main/client_verify.cpp
@@ -256,9 +256,17 @@ void ClientContext::StatementVerification(ClientContextLock &lock, unique_ptr<SQ
 		// overwriting the profiling output file with the EXPLAIN's profiling data.
 		auto &client_config = ClientConfig::GetConfig(*this);
 		bool saved_profiler = client_config.enable_profiler;
+		bool saved_samply_markers = client_config.enable_samply_markers;
 		ScopedConfigSetting suppress_profiling(
-		    client_config, [](ClientConfig &config) { config.enable_profiler = false; },
-		    [saved_profiler](ClientConfig &config) { config.enable_profiler = saved_profiler; });
+		    client_config,
+		    [](ClientConfig &config) {
+			    config.enable_profiler = false;
+			    config.enable_samply_markers = false;
+		    },
+		    [saved_profiler, saved_samply_markers](ClientConfig &config) {
+			    config.enable_profiler = saved_profiler;
+			    config.enable_samply_markers = saved_samply_markers;
+		    });
 		auto explain_result = RunStatementInternal(lock, std::move(explain_stmt), query_parameters);
 		if (explain_result->HasError()) {
 			explain_result->ThrowError();

--- a/src/main/client_verify.cpp
+++ b/src/main/client_verify.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/main/database.hpp"
 #include "duckdb/common/enums/debug_statement_verification.hpp"
 #include "duckdb/main/settings.hpp"
+#include "duckdb/main/profiler/samply.hpp"
 #include "duckdb/parser/parser.hpp"
 #include "duckdb/parser/statement/delete_statement.hpp"
 #include "duckdb/parser/statement/insert_statement.hpp"
@@ -256,16 +257,16 @@ void ClientContext::StatementVerification(ClientContextLock &lock, unique_ptr<SQ
 		// overwriting the profiling output file with the EXPLAIN's profiling data.
 		auto &client_config = ClientConfig::GetConfig(*this);
 		bool saved_profiler = client_config.enable_profiler;
-		bool saved_samply_markers = client_config.enable_samply_markers;
+		auto saved_samply_tracks = client_config.samply_tracks;
 		ScopedConfigSetting suppress_profiling(
 		    client_config,
 		    [](ClientConfig &config) {
 			    config.enable_profiler = false;
-			    config.enable_samply_markers = false;
+			    config.samply_tracks &= ~static_cast<uint8_t>(SamplyTrack::QUERY);
 		    },
-		    [saved_profiler, saved_samply_markers](ClientConfig &config) {
+		    [saved_profiler, saved_samply_tracks](ClientConfig &config) {
 			    config.enable_profiler = saved_profiler;
-			    config.enable_samply_markers = saved_samply_markers;
+			    config.samply_tracks = saved_samply_tracks;
 		    });
 		auto explain_result = RunStatementInternal(lock, std::move(explain_stmt), query_parameters);
 		if (explain_result->HasError()) {

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -223,6 +223,7 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_LOCAL(ProgressBarTimeSetting),
     DUCKDB_SETTING_CALLBACK(ReadAheadDepthSetting),
     DUCKDB_SETTING_CALLBACK(RegexMatchOperatorSemanticsSetting),
+    DUCKDB_LOCAL(SamplyTracksSetting),
     DUCKDB_SETTING(ScalarSubqueryErrorOnMultipleRowsSetting),
     DUCKDB_SETTING(SchedulerProcessPartialSetting),
     DUCKDB_LOCAL(SchemaSetting),
@@ -253,9 +254,9 @@ static const ConfigurationAlias setting_aliases[] = {DUCKDB_SETTING_ALIAS("confi
                                                      DUCKDB_SETTING_ALIAS("memory_limit", 129),
                                                      DUCKDB_SETTING_ALIAS("null_order", 61),
                                                      DUCKDB_SETTING_ALIAS("profile_output", 152),
-                                                     DUCKDB_SETTING_ALIAS("user", 171),
+                                                     DUCKDB_SETTING_ALIAS("user", 172),
                                                      DUCKDB_SETTING_ALIAS("wal_autocheckpoint", 29),
-                                                     DUCKDB_SETTING_ALIAS("worker_threads", 169),
+                                                     DUCKDB_SETTING_ALIAS("worker_threads", 170),
                                                      FINAL_ALIAS};
 
 vector<ConfigurationOption> DBConfig::GetOptions() {

--- a/src/main/http/http_util.cpp
+++ b/src/main/http/http_util.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/common/http_util.hpp"
 
 #include "duckdb/common/error_data.hpp"
+#include "duckdb/common/enum_util.hpp"
 #include "duckdb/common/exception/http_exception.hpp"
 #include "duckdb/common/limits.hpp"
 #include "duckdb/common/operator/cast_operators.hpp"
@@ -12,6 +13,9 @@
 #include "duckdb/main/database.hpp"
 #include "duckdb/main/database_file_opener.hpp"
 #include "duckdb/main/settings.hpp"
+#include "duckdb/main/profiler/samply.hpp"
+
+#include <cmath>
 
 #ifdef DISABLE_DUCKDB_REMOTE_INSTALL
 #define DUCKDB_DISABLE_BUILTIN_HTTPLIB
@@ -283,11 +287,52 @@ unique_ptr<HTTPResponse> HTTPUtil::SendRequest(BaseRequest &request, unique_ptr<
 
 	std::function<unique_ptr<HTTPResponse>(void)> on_request([&]() {
 		unique_ptr<HTTPResponse> response;
+		const bool track_samply_http = SamplyHTTPTrackEnabled();
 
 		// When logging is enabled, we collect request timings
 		if (request.params.logger) {
 			request.have_request_timing = request.params.logger->ShouldLog(HTTPLogType::NAME, HTTPLogType::LEVEL);
 		}
+		request.have_time_to_fst_byte = false;
+		request.time_to_fst_byte_sec = 0;
+		request.bytes_received = 0;
+
+		auto write_samply_attempt = [&](optional_ptr<HTTPResponse> http_response) noexcept {
+			if (!track_samply_http || request.request_system_start.value < 0) {
+				return;
+			}
+			try {
+				string request_range;
+				if (request.headers.HasHeader("Range")) {
+					request_range = request.headers.GetHeaderValue("Range");
+				}
+				string response_content_range;
+				int32_t status_code = -1;
+				if (http_response) {
+					status_code = static_cast<int32_t>(http_response->status);
+					if (http_response->HasHeader("Content-Range")) {
+						response_content_range = http_response->GetHeaderValue("Content-Range");
+					}
+				}
+				int64_t time_to_first_byte_ns = -1;
+				if (request.have_time_to_fst_byte && std::isfinite(request.time_to_fst_byte_sec) &&
+				    request.time_to_fst_byte_sec >= 0 &&
+				    request.time_to_fst_byte_sec <=
+				        static_cast<double>(NumericLimits<int64_t>::Maximum()) / 1000000000.0) {
+					time_to_first_byte_ns = static_cast<int64_t>(request.time_to_fst_byte_sec * 1000000000.0);
+				}
+				auto duration_ns =
+				    TimePoint::ElapsedNanos(request.request_monotonic_start, request.request_monotonic_end);
+				if (duration_ns < 0) {
+					return;
+				}
+				WriteSamplyHTTPAttempt(static_cast<uint64_t>(request.request_system_start.value) * 1000,
+				                       static_cast<uint64_t>(duration_ns), EnumUtil::ToChars(request.type), request.url,
+				                       status_code, request.bytes_received, time_to_first_byte_ns, request_range,
+				                       response_content_range);
+			} catch (...) {
+			}
+		};
 
 		try {
 			request.request_system_start = Timestamp::GetCurrentTimestamp();
@@ -295,10 +340,12 @@ unique_ptr<HTTPResponse> HTTPUtil::SendRequest(BaseRequest &request, unique_ptr<
 			response = client->Request(request);
 		} catch (...) {
 			request.request_monotonic_end = TimePoint::Tick();
+			write_samply_attempt(nullptr);
 			LogRequest(request, nullptr);
 			throw;
 		}
 		request.request_monotonic_end = TimePoint::Tick();
+		write_samply_attempt(response ? response.get() : nullptr);
 		LogRequest(request, response ? response.get() : nullptr);
 		return response;
 	});

--- a/src/main/http/http_util.cpp
+++ b/src/main/http/http_util.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/common/http_util.hpp"
 
 #include "duckdb/common/error_data.hpp"
+#include "duckdb/common/atomic.hpp"
 #include "duckdb/common/enum_util.hpp"
 #include "duckdb/common/exception/http_exception.hpp"
 #include "duckdb/common/limits.hpp"
@@ -34,6 +35,16 @@
 #endif
 
 namespace duckdb {
+
+static atomic<idx_t> &TotalBytesReceived() {
+	static atomic<idx_t> total_bytes_received {0};
+	return total_bytes_received;
+}
+
+static atomic<idx_t> &TotalBytesSent() {
+	static atomic<idx_t> total_bytes_sent {0};
+	return total_bytes_sent;
+}
 
 HTTPParams::~HTTPParams() {
 }
@@ -141,6 +152,14 @@ bool HTTPUtil::IsIdempotent(RequestType type) {
 	return type != RequestType::POST_REQUEST;
 }
 
+idx_t HTTPUtil::GetTotalBytesReceived() {
+	return TotalBytesReceived().load(std::memory_order_relaxed);
+}
+
+idx_t HTTPUtil::GetTotalBytesSent() {
+	return TotalBytesSent().load(std::memory_order_relaxed);
+}
+
 bool HTTPUtil::ShouldRetry(const BaseRequest &request, const HTTPResponse &response) {
 	return response.ShouldRetry();
 }
@@ -196,8 +215,11 @@ public:
 	unique_ptr<HTTPResponse> Get(GetRequestInfo &info) override {
 		auto headers = TransformHeaders(info.headers, info.params);
 		if (!info.response_handler && !info.content_handler) {
-			return TransformResult(client->Get(info.path, headers));
+			auto result = TransformResult(client->Get(info.path, headers));
+			info.bytes_received = result->body.size();
+			return result;
 		} else {
+			idx_t bytes_received = 0;
 			return TransformResult(client->Get(
 			    info.path, headers,
 			    [&](const duckdb_httplib::Response &response) {
@@ -205,7 +227,9 @@ public:
 				    return info.response_handler(*http_response);
 			    },
 			    [&](const char *data, size_t data_length) {
-				    return info.content_handler(const_data_ptr_cast(data), data_length);
+				    bytes_received += data_length;
+				    info.bytes_received = bytes_received;
+				    return !info.content_handler || info.content_handler(const_data_ptr_cast(data), data_length);
 			    }));
 		}
 	}
@@ -333,6 +357,10 @@ unique_ptr<HTTPResponse> HTTPUtil::SendRequest(BaseRequest &request, unique_ptr<
 			} catch (...) {
 			}
 		};
+		auto record_network_bytes = [&]() noexcept {
+			TotalBytesReceived().fetch_add(request.bytes_received, std::memory_order_relaxed);
+			TotalBytesSent().fetch_add(request.request_body_length, std::memory_order_relaxed);
+		};
 
 		try {
 			request.request_system_start = Timestamp::GetCurrentTimestamp();
@@ -340,11 +368,13 @@ unique_ptr<HTTPResponse> HTTPUtil::SendRequest(BaseRequest &request, unique_ptr<
 			response = client->Request(request);
 		} catch (...) {
 			request.request_monotonic_end = TimePoint::Tick();
+			record_network_bytes();
 			write_samply_attempt(nullptr);
 			LogRequest(request, nullptr);
 			throw;
 		}
 		request.request_monotonic_end = TimePoint::Tick();
+		record_network_bytes();
 		write_samply_attempt(response ? response.get() : nullptr);
 		LogRequest(request, response ? response.get() : nullptr);
 		return response;

--- a/src/main/query_profiler.cpp
+++ b/src/main/query_profiler.cpp
@@ -79,7 +79,7 @@ QueryProfiler::QueryProfiler(ClientContext &context_p)
 
 bool QueryProfiler::IsEnabled() const {
 	auto &config = ClientConfig::GetConfig(context);
-	return is_explain_analyze || config.enable_profiler || config.enable_samply_markers;
+	return is_explain_analyze || config.enable_profiler || SamplyTrackEnabled(config.samply_tracks, SamplyTrack::QUERY);
 }
 
 unique_ptr<TreeRenderer> QueryProfiler::CreateProfiler(const string &name) const {
@@ -125,11 +125,12 @@ void QueryProfiler::Start(const string &query) {
 	query_metrics.query_sql = query;
 	auto &config = ClientConfig::GetConfig(context);
 	string samply_marker_name;
-	if (config.enable_samply_markers) {
+	const auto samply_query_enabled = SamplyTrackEnabled(config.samply_tracks, SamplyTrack::QUERY);
+	if (samply_query_enabled) {
 		samply_marker_name = SamplyQueryMarkerName(query);
 	}
 	query_metrics.latency_timer = make_uniq<MetricsTimer>(query_metrics, MetricQueryTotalTime::Name, IsEnabled(),
-	                                                      config.enable_samply_markers, std::move(samply_marker_name));
+	                                                      samply_query_enabled, std::move(samply_marker_name));
 }
 
 void QueryProfiler::Reset() {
@@ -300,7 +301,7 @@ idx_t QueryProfiler::GetBytesWritten() const {
 
 MetricsTimer QueryProfiler::StartTimerInternal(const string &key) {
 	auto &config = ClientConfig::GetConfig(context);
-	return MetricsTimer(query_metrics, key, IsEnabled(), config.enable_samply_markers);
+	return MetricsTimer(query_metrics, key, IsEnabled(), SamplyTrackEnabled(config.samply_tracks, SamplyTrack::QUERY));
 }
 
 string QueryProfiler::ToString(const ProfilerPrintFormat &format) const {

--- a/src/main/query_profiler.cpp
+++ b/src/main/query_profiler.cpp
@@ -21,6 +21,8 @@
 #include "duckdb/main/settings.hpp"
 #include "duckdb/storage/buffer/buffer_pool.hpp"
 #include "duckdb/common/json_document.hpp"
+#include "duckdb/common/types/timestamp.hpp"
+#include "duckdb/main/profiler/samply.hpp"
 
 #include <utility>
 
@@ -122,15 +124,10 @@ QueryProfiler &QueryProfiler::Get(ClientContext &context) {
 void QueryProfiler::Start(const string &query) {
 	Reset();
 	running = true;
+	query_metrics.query_start_tick_ns = TimePoint::GetTickNanos();
+	query_metrics.query_start_unix_ns = NumericCast<uint64_t>(Timestamp::GetCurrentTimestamp().value) * 1000;
 	query_metrics.query_sql = query;
-	auto &config = ClientConfig::GetConfig(context);
-	string samply_marker_name;
-	const auto samply_query_enabled = SamplyTrackEnabled(config.samply_tracks, SamplyTrack::QUERY);
-	if (samply_query_enabled) {
-		samply_marker_name = SamplyQueryMarkerName(query);
-	}
-	query_metrics.latency_timer = make_uniq<MetricsTimer>(query_metrics, MetricQueryTotalTime::Name, IsEnabled(),
-	                                                      samply_query_enabled, std::move(samply_marker_name));
+	query_metrics.latency_timer = make_uniq<MetricsTimer>(query_metrics, MetricQueryTotalTime::Name, IsEnabled());
 }
 
 void QueryProfiler::Reset() {
@@ -225,11 +222,16 @@ void QueryProfiler::EndQuery() {
 
 	FinalizeMetricsInternal();
 	running = false;
+	auto &config = ClientConfig::GetConfig(context);
+	const bool emit_samply_profile =
+	    !is_explain_analyze && root && SamplyTrackEnabled(config.samply_tracks, SamplyTrack::QUERY);
+	const auto query_start_unix_ns = query_metrics.query_start_unix_ns;
+	const auto query_duration_ns = query_metrics.GetMetricTimingNanos(MetricQueryTotalTime::Name);
 	bool emit_output = false;
 
 	// Print or output the query profiling after query termination.
 	// EXPLAIN ANALYZE output is not written by the profiler, and the "no_output" format emits no output.
-	if (!is_explain_analyze && ClientConfig::GetConfig(context).profiler_print_format != "no_output") {
+	if (!is_explain_analyze && config.enable_profiler && config.profiler_print_format != "no_output") {
 		emit_output = true;
 	}
 
@@ -239,6 +241,9 @@ void QueryProfiler::EndQuery() {
 	ToLogInternal();
 
 	guard.unlock();
+	if (emit_samply_profile) {
+		WriteSamplyQueryProfile(query_start_unix_ns, query_duration_ns, ToSamplyJSON());
+	}
 
 	if (emit_output) {
 		auto save_location = GetSaveLocation();
@@ -300,8 +305,7 @@ idx_t QueryProfiler::GetBytesWritten() const {
 }
 
 MetricsTimer QueryProfiler::StartTimerInternal(const string &key) {
-	auto &config = ClientConfig::GetConfig(context);
-	return MetricsTimer(query_metrics, key, IsEnabled(), SamplyTrackEnabled(config.samply_tracks, SamplyTrack::QUERY));
+	return MetricsTimer(query_metrics, key, IsEnabled() && running);
 }
 
 string QueryProfiler::ToString(const ProfilerPrintFormat &format) const {
@@ -429,7 +433,13 @@ void OperatorProfiler::StartOperator(optional_ptr<const PhysicalOperator> phys_o
 	}
 
 	// Start the timing of the current operator.
+	active_start_ns = QueryProfiler::Get(context).GetElapsedNanos();
 	op.Start();
+}
+
+void OperatorMetrics::UpdateTimingBounds(idx_t start_ns, idx_t end_ns) {
+	timing_start_ns = timing_start_ns == DConstants::INVALID_INDEX ? start_ns : MinValue(timing_start_ns, start_ns);
+	timing_end_ns = MaxValue(timing_end_ns, end_ns);
 }
 
 void OperatorMetrics::GatherMetrics(ClientContext &context, double elapsed_time, optional_ptr<DataChunk> chunk) {
@@ -455,6 +465,9 @@ void OperatorMetrics::MergeInternal(const OperatorMetrics &other) {
 	intermediate_size_bytes += other.intermediate_size_bytes;
 	rows_scanned += other.rows_scanned;
 	row_groups_scanned += other.row_groups_scanned;
+	if (other.timing_start_ns != DConstants::INVALID_INDEX) {
+		UpdateTimingBounds(other.timing_start_ns, other.timing_end_ns);
+	}
 	if (other.system_peak_buffer_manager_memory > system_peak_buffer_manager_memory) {
 		system_peak_buffer_manager_memory = other.system_peak_buffer_manager_memory;
 	}
@@ -483,6 +496,7 @@ void OperatorProfiler::EndOperator(optional_ptr<DataChunk> chunk) {
 
 	auto &info = GetOperatorMetrics(*active_operator);
 	op.End();
+	info.UpdateTimingBounds(active_start_ns, QueryProfiler::Get(context).GetElapsedNanos());
 	info.GatherMetrics(context, op.Elapsed(), chunk);
 	active_operator = nullptr;
 }
@@ -827,16 +841,23 @@ void QueryProfiler::ToLog() const {
 	ToLogInternal();
 }
 
-static void OperatorToResultTree(const GatheredMetrics &settings, ProfilingNode &node, QueryProfileResult &result) {
+static void OperatorToResultTree(const GatheredMetrics &settings, ProfilingNode &node, QueryProfileResult &result,
+                                 bool include_timing_bounds) {
 	auto operator_metrics = node.GetOperatorMetrics().GetMetrics(settings);
 	for (auto &entry : operator_metrics) {
 		result.AddValue(entry.first, std::move(entry.second));
+	}
+	const auto &metrics = node.GetOperatorMetrics();
+	if (include_timing_bounds && metrics.timing_start_ns != DConstants::INVALID_INDEX) {
+		auto &bounds = result.AddObject("timing_bounds");
+		bounds.AddValue("start_ns", Value::UBIGINT(metrics.timing_start_ns));
+		bounds.AddValue("end_ns", Value::UBIGINT(metrics.timing_end_ns));
 	}
 	if (node.GetChildCount() > 0) {
 		auto &children_list = result.AddList("children");
 		for (idx_t i = 0; i < node.GetChildCount(); i++) {
 			auto &child_result = children_list.AppendObject();
-			OperatorToResultTree(settings, *node.GetChild(i), child_result);
+			OperatorToResultTree(settings, *node.GetChild(i), child_result, include_timing_bounds);
 		}
 	}
 }
@@ -956,8 +977,8 @@ unique_ptr<QueryProfileResult> QueryProfiler::ToLegacyResultTree() const {
 	return result;
 }
 
-unique_ptr<QueryProfileResult> QueryProfiler::ToResultTree() const {
-	if (Settings::Get<LegacyMetricsFormatSetting>(context)) {
+unique_ptr<QueryProfileResult> QueryProfiler::ToResultTree(bool include_timing_bounds) const {
+	if (!include_timing_bounds && Settings::Get<LegacyMetricsFormatSetting>(context)) {
 		return ToLegacyResultTree();
 	}
 	auto result = make_uniq<QueryProfileResult>();
@@ -966,10 +987,25 @@ unique_ptr<QueryProfileResult> QueryProfiler::ToResultTree() const {
 		return result;
 	}
 	metrics->MetricsToProfileResult(*result);
+	if (include_timing_bounds && !query_metrics.GetTimingBounds().empty()) {
+		auto &bounds_list = result->AddList("timing_bounds");
+		vector<string> names;
+		for (const auto &entry : query_metrics.GetTimingBounds()) {
+			names.push_back(entry.first);
+		}
+		std::sort(names.begin(), names.end());
+		for (const auto &name : names) {
+			const auto &timing = query_metrics.GetTimingBounds().at(name);
+			auto &bounds = bounds_list.AppendObject();
+			bounds.AddValue("name", Value(name));
+			bounds.AddValue("start_ns", Value::UBIGINT(timing.start_ns));
+			bounds.AddValue("end_ns", Value::UBIGINT(timing.end_ns));
+		}
+	}
 	if (metrics->AnyOperatorMetricTracked()) {
 		auto &op_list = result->AddList("operator");
 		auto &op_node = op_list.AppendObject();
-		OperatorToResultTree(*metrics, *root, op_node);
+		OperatorToResultTree(*metrics, *root, op_node, include_timing_bounds);
 	}
 	return result;
 }
@@ -992,6 +1028,14 @@ string QueryProfiler::ToJSON() const {
 	auto result = ToResultTree();
 	writer.SetRoot(QueryProfileResultToJSON(writer, *result));
 	return writer.ToString(JSONWriteFlags::ALLOW_INF_AND_NAN | JSONWriteFlags::PRETTY);
+}
+
+string QueryProfiler::ToSamplyJSON() const {
+	lock_guard<std::mutex> guard(lock);
+	JSONWriter writer;
+	auto result = ToResultTree(true);
+	writer.SetRoot(QueryProfileResultToJSON(writer, *result));
+	return writer.ToString(JSONWriteFlags::ALLOW_INF_AND_NAN);
 }
 
 void QueryProfiler::WriteToFile(const char *path, string &info) const {

--- a/src/main/query_profiler.cpp
+++ b/src/main/query_profiler.cpp
@@ -78,7 +78,8 @@ QueryProfiler::QueryProfiler(ClientContext &context_p)
 }
 
 bool QueryProfiler::IsEnabled() const {
-	return is_explain_analyze || ClientConfig::GetConfig(context).enable_profiler;
+	auto &config = ClientConfig::GetConfig(context);
+	return is_explain_analyze || config.enable_profiler || config.enable_samply_markers;
 }
 
 unique_ptr<TreeRenderer> QueryProfiler::CreateProfiler(const string &name) const {
@@ -292,7 +293,8 @@ idx_t QueryProfiler::GetBytesWritten() const {
 }
 
 MetricsTimer QueryProfiler::StartTimerInternal(const string &key) {
-	return MetricsTimer(query_metrics, key, IsEnabled());
+	auto &config = ClientConfig::GetConfig(context);
+	return MetricsTimer(query_metrics, key, IsEnabled(), config.enable_samply_markers);
 }
 
 string QueryProfiler::ToString(const ProfilerPrintFormat &format) const {

--- a/src/main/query_profiler.cpp
+++ b/src/main/query_profiler.cpp
@@ -123,7 +123,13 @@ void QueryProfiler::Start(const string &query) {
 	Reset();
 	running = true;
 	query_metrics.query_sql = query;
-	query_metrics.latency_timer = make_uniq<MetricsTimer>(StartTimer<MetricQueryTotalTime>());
+	auto &config = ClientConfig::GetConfig(context);
+	string samply_marker_name;
+	if (config.enable_samply_markers) {
+		samply_marker_name = SamplyQueryMarkerName(query);
+	}
+	query_metrics.latency_timer = make_uniq<MetricsTimer>(query_metrics, MetricQueryTotalTime::Name, IsEnabled(),
+	                                                      config.enable_samply_markers, std::move(samply_marker_name));
 }
 
 void QueryProfiler::Reset() {

--- a/src/main/samply.cpp
+++ b/src/main/samply.cpp
@@ -1,5 +1,8 @@
 #include "duckdb/main/profiler/samply.hpp"
 
+#include "duckdb/common/string_util.hpp"
+#include "utf8proc_wrapper.hpp"
+
 #include <cerrno>
 #include <cstdio>
 
@@ -23,6 +26,57 @@
 #endif
 
 namespace duckdb {
+
+string SamplyQueryMarkerName(const string &query) {
+	static constexpr idx_t MAX_QUERY_CHARACTERS = 500;
+	static constexpr idx_t MAX_MARKER_NAME_BYTES = 900;
+	const string prefix = "Query: ";
+	const string ellipsis = "…";
+
+	string normalized_query;
+	normalized_query.reserve(MinValue<idx_t>(query.size(), MAX_MARKER_NAME_BYTES));
+	bool pending_space = false;
+	for (const auto character : query) {
+		if (StringUtil::CharacterIsSpace(character)) {
+			pending_space = !normalized_query.empty();
+			continue;
+		}
+		if (pending_space) {
+			normalized_query += ' ';
+			pending_space = false;
+		}
+		normalized_query += character == '\0' ? '?' : character;
+	}
+	if (normalized_query.empty()) {
+		return prefix + "<empty>";
+	}
+	if (!Utf8Proc::IsValid(normalized_query.c_str(), normalized_query.size())) {
+		Utf8Proc::MakeValid(&normalized_query[0], normalized_query.size());
+	}
+
+	idx_t character_count = 0;
+	idx_t query_bytes = 0;
+	while (query_bytes < normalized_query.size() && character_count < MAX_QUERY_CHARACTERS) {
+		auto next_position =
+		    Utf8Proc::NextGraphemeCluster(normalized_query.c_str(), normalized_query.size(), query_bytes);
+		if (prefix.size() + next_position > MAX_MARKER_NAME_BYTES) {
+			break;
+		}
+		query_bytes = next_position;
+		character_count++;
+	}
+
+	if (query_bytes == normalized_query.size()) {
+		return prefix + normalized_query;
+	}
+	if (character_count == MAX_QUERY_CHARACTERS) {
+		query_bytes = Utf8Proc::PreviousGraphemeCluster(normalized_query.c_str(), normalized_query.size(), query_bytes);
+	}
+	while (prefix.size() + query_bytes + ellipsis.size() > MAX_MARKER_NAME_BYTES) {
+		query_bytes = Utf8Proc::PreviousGraphemeCluster(normalized_query.c_str(), normalized_query.size(), query_bytes);
+	}
+	return prefix + normalized_query.substr(0, query_bytes) + ellipsis;
+}
 
 #if defined(__linux__) || defined(__APPLE__)
 

--- a/src/main/samply.cpp
+++ b/src/main/samply.cpp
@@ -4,11 +4,20 @@
 #include "utf8proc_wrapper.hpp"
 
 #include <cerrno>
+#include <chrono>
+#include <condition_variable>
 #include <cstdio>
+#include <cstring>
+#include <limits>
+#include <mutex>
+#include <thread>
+#include <unordered_map>
+#include <vector>
 
 #if defined(__linux__) || defined(__APPLE__)
 #include <cstdlib>
 #include <fcntl.h>
+#include <sys/resource.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <time.h>
@@ -21,8 +30,12 @@
 #endif
 
 #ifdef __APPLE__
+#include <mach/mach.h>
 #include <mach/mach_time.h>
+#include <net/if.h>
+#include <net/route.h>
 #include <pthread.h>
+#include <sys/sysctl.h>
 #endif
 
 namespace duckdb {
@@ -113,6 +126,14 @@ static uint64_t SamplyThreadId() noexcept {
 
 struct SamplyDirectoryState {
 	SamplyDirectoryState() noexcept : path {0} {
+		const char *configured_directory = getenv("DUCKDB_SAMPLY_DIR");
+		if (configured_directory && configured_directory[0] != '\0') {
+			auto length = snprintf(path, sizeof(path), "%s", configured_directory);
+			if (length <= 0 || static_cast<idx_t>(length) >= sizeof(path)) {
+				path[0] = '\0';
+			}
+			return;
+		}
 		const char *temporary_directory = getenv("TMPDIR");
 		if (!temporary_directory || temporary_directory[0] == '\0') {
 			temporary_directory = "/tmp";
@@ -133,6 +154,515 @@ static const char *SamplyDirectory() noexcept {
 }
 
 #endif
+
+SamplyCounterWriter::SamplyCounterWriter(const char *directory_p) noexcept
+    : directory(directory_p), file_descriptor(-1), failed(false), wrote_clock(false), path {0} {
+	try {
+		buffer.reserve(64 * 1024);
+	} catch (...) {
+		failed = true;
+	}
+}
+
+SamplyCounterWriter::~SamplyCounterWriter() {
+	Flush();
+#if defined(__linux__) || defined(__APPLE__)
+	if (file_descriptor >= 0) {
+		close(file_descriptor);
+	}
+#endif
+}
+
+bool SamplyCounterWriter::Initialize() noexcept {
+#if defined(__linux__) || defined(__APPLE__)
+	if (failed) {
+		return false;
+	}
+	if (file_descriptor >= 0) {
+		return true;
+	}
+	if (!directory) {
+		directory = SamplyDirectory();
+	}
+	if (!directory) {
+		failed = true;
+		return false;
+	}
+	auto length =
+	    snprintf(path, sizeof(path), "%s/counter-%llu.txt", directory, static_cast<unsigned long long>(getpid()));
+	if (length <= 0 || static_cast<idx_t>(length) >= sizeof(path)) {
+		failed = true;
+		return false;
+	}
+	file_descriptor = open(path, O_WRONLY | O_CREAT | O_APPEND | O_CLOEXEC, S_IRUSR | S_IWUSR);
+	if (file_descriptor < 0) {
+		failed = true;
+		return false;
+	}
+	return true;
+#else
+	failed = true;
+	return false;
+#endif
+}
+
+bool SamplyCounterWriter::Append(const char *data, idx_t size) noexcept {
+	if (!Initialize()) {
+		return false;
+	}
+	try {
+		buffer.append(data, size);
+		return true;
+	} catch (...) {
+		failed = true;
+		return false;
+	}
+}
+
+bool SamplyCounterWriter::WriteClock(uint64_t monotonic_ns, uint64_t unix_ns) noexcept {
+	if (wrote_clock) {
+		return true;
+	}
+	char record[96];
+	auto length = snprintf(record, sizeof(record), "clock %llu %llu\n", static_cast<unsigned long long>(monotonic_ns),
+	                       static_cast<unsigned long long>(unix_ns));
+	if (length <= 0 || static_cast<idx_t>(length) >= sizeof(record)) {
+		failed = true;
+		return false;
+	}
+	if (!Append(record, static_cast<idx_t>(length))) {
+		return false;
+	}
+	wrote_clock = true;
+	return true;
+}
+
+bool SamplyCounterWriter::WriteSample(uint64_t monotonic_ns, const char *name, int64_t value) noexcept {
+	char record[128];
+	auto length = snprintf(record, sizeof(record), "%llu %s %lld\n", static_cast<unsigned long long>(monotonic_ns),
+	                       name, static_cast<long long>(value));
+	if (length <= 0 || static_cast<idx_t>(length) >= sizeof(record)) {
+		failed = true;
+		return false;
+	}
+	return Append(record, static_cast<idx_t>(length));
+}
+
+bool SamplyCounterWriter::Flush() noexcept {
+#if defined(__linux__) || defined(__APPLE__)
+	if (buffer.empty()) {
+		return !failed;
+	}
+	if (!Initialize()) {
+		return false;
+	}
+	idx_t offset = 0;
+	while (offset < buffer.size()) {
+		auto written = write(file_descriptor, buffer.data() + offset, buffer.size() - offset);
+		if (written < 0 && errno == EINTR) {
+			continue;
+		}
+		if (written <= 0) {
+			failed = true;
+			return false;
+		}
+		offset += static_cast<idx_t>(written);
+	}
+	buffer.clear();
+	return true;
+#else
+	return false;
+#endif
+}
+
+const char *SamplyCounterWriter::GetPath() const noexcept {
+	return path;
+}
+
+#if defined(__linux__) || defined(__APPLE__)
+
+static uint64_t SamplyUnixTimestamp() noexcept {
+	struct timespec timestamp;
+	if (clock_gettime(CLOCK_REALTIME, &timestamp) != 0) {
+		return 0;
+	}
+	return static_cast<uint64_t>(timestamp.tv_sec) * 1000000000ULL + static_cast<uint64_t>(timestamp.tv_nsec);
+}
+
+struct SamplyNetworkInterface {
+	string name;
+	uint64_t received;
+	uint64_t transmitted;
+};
+
+static bool SamplyReadRSS(uint64_t &rss) noexcept {
+#ifdef __linux__
+	FILE *file = fopen("/proc/self/statm", "r");
+	if (!file) {
+		return false;
+	}
+	unsigned long long resident_pages = 0;
+	auto result = fscanf(file, "%*llu %llu", &resident_pages);
+	fclose(file);
+	if (result != 1) {
+		return false;
+	}
+	auto page_size = sysconf(_SC_PAGESIZE);
+	if (page_size <= 0 || resident_pages > std::numeric_limits<uint64_t>::max() / static_cast<uint64_t>(page_size)) {
+		return false;
+	}
+	rss = resident_pages * static_cast<uint64_t>(page_size);
+	return true;
+#else
+	mach_task_basic_info_data_t info;
+	mach_msg_type_number_t count = MACH_TASK_BASIC_INFO_COUNT;
+	if (task_info(mach_task_self(), MACH_TASK_BASIC_INFO, reinterpret_cast<task_info_t>(&info), &count) !=
+	    KERN_SUCCESS) {
+		return false;
+	}
+	rss = info.resident_size;
+	return true;
+#endif
+}
+
+class SamplyResourceSampler {
+public:
+	static shared_ptr<SamplyResourceSampler> Get() {
+		static auto sampler = make_shared_ptr<SamplyResourceSampler>(nullptr, true);
+		return sampler;
+	}
+
+	SamplyResourceSampler(const char *directory_p, bool periodic_sampling_p)
+	    : memory_references(0), network_references(0), pending_final_tracks(0), completed_final_tracks(0),
+	      stopping(false), periodic_sampling(periodic_sampling_p), directory(directory_p ? directory_p : ""),
+	      writer(directory_p ? directory.c_str() : nullptr), network_buffer() {
+		try {
+			network_interfaces.reserve(32);
+			network_buffer.reserve(16 * 1024);
+		} catch (...) {
+		}
+	}
+
+	~SamplyResourceSampler() {
+		std::lock_guard<std::mutex> control_guard(control_mutex);
+		{
+			std::lock_guard<std::mutex> guard(lock);
+			stopping = true;
+			condition.notify_all();
+		}
+		if (worker.joinable()) {
+			worker.join();
+		}
+	}
+
+	void Add(uint8_t tracks) noexcept {
+		std::lock_guard<std::mutex> control_guard(control_mutex);
+		std::lock_guard<std::mutex> guard(lock);
+		if (SamplyTrackEnabled(tracks, SamplyTrack::MEMORY)) {
+			memory_references++;
+		}
+		if (SamplyTrackEnabled(tracks, SamplyTrack::NETWORK)) {
+			network_references++;
+		}
+		if (!worker.joinable()) {
+			stopping = false;
+			try {
+				worker = std::thread(&SamplyResourceSampler::Run, this);
+			} catch (...) {
+			}
+		}
+		condition.notify_all();
+	}
+
+	void Remove(uint8_t tracks) noexcept {
+		std::lock_guard<std::mutex> control_guard(control_mutex);
+		bool should_join;
+		uint8_t final_tracks = 0;
+		{
+			std::lock_guard<std::mutex> guard(lock);
+			if (SamplyTrackEnabled(tracks, SamplyTrack::MEMORY) && memory_references > 0) {
+				memory_references--;
+				if (memory_references == 0) {
+					final_tracks |= static_cast<uint8_t>(SamplyTrack::MEMORY);
+				}
+			}
+			if (SamplyTrackEnabled(tracks, SamplyTrack::NETWORK) && network_references > 0) {
+				network_references--;
+				if (network_references == 0) {
+					final_tracks |= static_cast<uint8_t>(SamplyTrack::NETWORK);
+				}
+			}
+			pending_final_tracks |= final_tracks;
+			completed_final_tracks &= ~final_tracks;
+			stopping = memory_references == 0 && network_references == 0;
+			should_join = stopping;
+			condition.notify_all();
+		}
+		if (should_join && worker.joinable()) {
+			worker.join();
+		} else if (final_tracks != 0 && worker.joinable()) {
+			std::unique_lock<std::mutex> guard(lock);
+			condition.wait(guard,
+			               [this, final_tracks] { return (completed_final_tracks & final_tracks) == final_tracks; });
+			completed_final_tracks &= ~final_tracks;
+		}
+	}
+
+private:
+	void SetLowPriority() noexcept {
+#ifdef __APPLE__
+		pthread_set_qos_class_self_np(QOS_CLASS_UTILITY, 0);
+#else
+		setpriority(PRIO_PROCESS, static_cast<id_t>(SamplyThreadId()), 10);
+#endif
+	}
+
+	bool ReadNetwork() noexcept {
+		network_interfaces.clear();
+#ifdef __linux__
+		FILE *file = fopen("/proc/net/dev", "r");
+		if (!file) {
+			return false;
+		}
+		char line[1024];
+		while (fgets(line, sizeof(line), file)) {
+			char name[64];
+			unsigned long long received;
+			unsigned long long transmitted;
+			if (sscanf(line, " %63[^:]: %llu %*llu %*llu %*llu %*llu %*llu %*llu %*llu %llu", name, &received,
+			           &transmitted) != 3 ||
+			    strcmp(name, "lo") == 0) {
+				continue;
+			}
+			try {
+				network_interfaces.push_back({name, received, transmitted});
+			} catch (...) {
+				fclose(file);
+				return false;
+			}
+		}
+		fclose(file);
+		return true;
+#else
+		int mib[6] = {CTL_NET, PF_ROUTE, 0, 0, NET_RT_IFLIST2, 0};
+		size_t needed = 0;
+		if (sysctl(mib, 6, nullptr, &needed, nullptr, 0) != 0) {
+			return false;
+		}
+		try {
+			if (network_buffer.size() < needed) {
+				network_buffer.resize(needed);
+			}
+		} catch (...) {
+			return false;
+		}
+		if (sysctl(mib, 6, network_buffer.data(), &needed, nullptr, 0) != 0) {
+			return false;
+		}
+		char *current = network_buffer.data();
+		char *end = current + needed;
+		while (current + sizeof(if_msghdr) <= end) {
+			auto message = reinterpret_cast<if_msghdr *>(current);
+			if (message->ifm_msglen == 0 || current + message->ifm_msglen > end) {
+				return false;
+			}
+			if (message->ifm_type == RTM_IFINFO2 && message->ifm_msglen >= sizeof(if_msghdr2)) {
+				auto info = reinterpret_cast<if_msghdr2 *>(current);
+				if ((info->ifm_flags & IFF_LOOPBACK) == 0) {
+					char name[IF_NAMESIZE];
+					if (if_indextoname(info->ifm_index, name)) {
+						try {
+							network_interfaces.push_back({name, info->ifm_data.ifi_ibytes, info->ifm_data.ifi_obytes});
+						} catch (...) {
+							return false;
+						}
+					}
+				}
+			}
+			current += message->ifm_msglen;
+		}
+		return true;
+#endif
+	}
+
+	void SampleNetwork(uint64_t timestamp) noexcept {
+		if (!ReadNetwork()) {
+			return;
+		}
+		uint64_t received_delta = 0;
+		uint64_t transmitted_delta = 0;
+		std::unordered_map<string, std::pair<uint64_t, uint64_t>> next_baselines;
+		try {
+			next_baselines.reserve(network_interfaces.size());
+			for (const auto &interface : network_interfaces) {
+				auto previous = network_baselines.find(interface.name);
+				if (previous != network_baselines.end()) {
+					if (interface.received >= previous->second.first) {
+						received_delta += interface.received - previous->second.first;
+					}
+					if (interface.transmitted >= previous->second.second) {
+						transmitted_delta += interface.transmitted - previous->second.second;
+					}
+				}
+				next_baselines.emplace(interface.name, std::make_pair(interface.received, interface.transmitted));
+			}
+			network_baselines.swap(next_baselines);
+		} catch (...) {
+			return;
+		}
+		if (received_delta <= static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
+			writer.WriteSample(timestamp, "network-rx", static_cast<int64_t>(received_delta));
+		}
+		if (transmitted_delta <= static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
+			writer.WriteSample(timestamp, "network-tx", static_cast<int64_t>(transmitted_delta));
+		}
+	}
+
+	void Sample(uint8_t tracks) noexcept {
+		auto timestamp = SamplyTimestamp();
+		if (SamplyTrackEnabled(tracks, SamplyTrack::MEMORY)) {
+			uint64_t rss;
+			if (SamplyReadRSS(rss) && rss <= static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
+				writer.WriteSample(timestamp, "rss", static_cast<int64_t>(rss));
+			}
+		}
+		if (SamplyTrackEnabled(tracks, SamplyTrack::NETWORK)) {
+			SampleNetwork(timestamp);
+		}
+	}
+
+	void Run() noexcept {
+		SetLowPriority();
+		writer.WriteClock(SamplyTimestamp(), SamplyUnixTimestamp());
+		auto next_sample = std::chrono::steady_clock::now();
+		auto last_flush = next_sample;
+		while (true) {
+			uint8_t tracks;
+			uint8_t final_tracks;
+			{
+				std::unique_lock<std::mutex> guard(lock);
+				if (periodic_sampling) {
+					condition.wait_until(guard, next_sample, [this] { return stopping || pending_final_tracks != 0; });
+				} else {
+					condition.wait(guard, [this] { return stopping || pending_final_tracks != 0; });
+				}
+				final_tracks = pending_final_tracks;
+				pending_final_tracks = 0;
+				if (final_tracks == 0 && stopping) {
+					break;
+				}
+				tracks = final_tracks;
+				if (tracks == 0) {
+					if (memory_references > 0) {
+						tracks |= static_cast<uint8_t>(SamplyTrack::MEMORY);
+					}
+					if (network_references > 0) {
+						tracks |= static_cast<uint8_t>(SamplyTrack::NETWORK);
+					}
+				}
+			}
+
+			Sample(tracks);
+			if (SamplyTrackEnabled(final_tracks, SamplyTrack::NETWORK)) {
+				network_baselines.clear();
+			}
+			if (final_tracks != 0) {
+				writer.Flush();
+				std::lock_guard<std::mutex> guard(lock);
+				completed_final_tracks |= final_tracks;
+				condition.notify_all();
+				continue;
+			}
+
+			auto now = std::chrono::steady_clock::now();
+			if (now - last_flush >= std::chrono::seconds(1)) {
+				writer.Flush();
+				last_flush = now;
+			}
+			next_sample += std::chrono::milliseconds(5);
+			while (next_sample <= now) {
+				next_sample += std::chrono::milliseconds(5);
+			}
+		}
+		writer.Flush();
+	}
+
+private:
+	std::mutex control_mutex;
+	std::mutex lock;
+	std::condition_variable condition;
+	idx_t memory_references;
+	idx_t network_references;
+	uint8_t pending_final_tracks;
+	uint8_t completed_final_tracks;
+	bool stopping;
+	bool periodic_sampling;
+	std::thread worker;
+	string directory;
+	SamplyCounterWriter writer;
+	vector<SamplyNetworkInterface> network_interfaces;
+	vector<char> network_buffer;
+	std::unordered_map<string, std::pair<uint64_t, uint64_t>> network_baselines;
+};
+
+#endif
+
+class SamplyResourceSubscription {
+public:
+#if defined(__linux__) || defined(__APPLE__)
+	explicit SamplyResourceSubscription(uint8_t tracks_p)
+	    : SamplyResourceSubscription(tracks_p, SamplyResourceSampler::Get()) {
+	}
+
+	SamplyResourceSubscription(uint8_t tracks_p, shared_ptr<SamplyResourceSampler> sampler_p) noexcept
+	    : tracks(tracks_p), sampler(std::move(sampler_p)) {
+		sampler->Add(tracks);
+	}
+#else
+	explicit SamplyResourceSubscription(uint8_t tracks_p) noexcept : tracks(tracks_p) {
+	}
+#endif
+
+	~SamplyResourceSubscription() {
+#if defined(__linux__) || defined(__APPLE__)
+		sampler->Remove(tracks);
+#endif
+	}
+
+private:
+	uint8_t tracks;
+#if defined(__linux__) || defined(__APPLE__)
+	shared_ptr<SamplyResourceSampler> sampler;
+#endif
+};
+
+shared_ptr<SamplyResourceSubscription> StartSamplyResourceSampling(uint8_t tracks) noexcept {
+	if (tracks == 0) {
+		return nullptr;
+	}
+	try {
+		return make_shared_ptr<SamplyResourceSubscription>(tracks);
+	} catch (...) {
+		return nullptr;
+	}
+}
+
+shared_ptr<SamplyResourceSubscription> StartSamplyResourceSamplingForTesting(uint8_t tracks,
+                                                                             const char *directory) noexcept {
+#if defined(__linux__) || defined(__APPLE__)
+	if (tracks == 0) {
+		return nullptr;
+	}
+	try {
+		auto sampler = make_shared_ptr<SamplyResourceSampler>(directory, false);
+		return make_shared_ptr<SamplyResourceSubscription>(tracks, std::move(sampler));
+	} catch (...) {
+		return nullptr;
+	}
+#else
+	return nullptr;
+#endif
+}
 
 SamplyMarkerWriter::SamplyMarkerWriter(const char *directory_p) noexcept
     : directory(directory_p), file_descriptor(-1), failed(false), path {0} {

--- a/src/main/samply.cpp
+++ b/src/main/samply.cpp
@@ -5,6 +5,7 @@
 #include "utf8proc_wrapper.hpp"
 
 #include <cerrno>
+#include <cinttypes>
 #include <chrono>
 #include <condition_variable>
 #include <cstdio>
@@ -159,7 +160,7 @@ static const char *SamplyDirectory() noexcept {
 SamplyCounterWriter::SamplyCounterWriter(const char *directory_p) noexcept
     : directory(directory_p), file_descriptor(-1), failed(false), wrote_clock(false), path {0} {
 	try {
-		buffer.reserve(64 * 1024);
+		buffer.reserve(idx_t(64) * 1024);
 	} catch (...) {
 		failed = true;
 	}
@@ -302,8 +303,9 @@ static bool SamplyReadRSS(uint64_t &rss) noexcept {
 	if (!file) {
 		return false;
 	}
-	unsigned long long resident_pages = 0;
-	auto result = fscanf(file, "%*llu %llu", &resident_pages);
+	uint64_t total_pages = 0;
+	uint64_t resident_pages = 0;
+	auto result = fscanf(file, "%" SCNu64 " %" SCNu64, &total_pages, &resident_pages);
 	fclose(file);
 	if (result != 1) {
 		return false;
@@ -340,7 +342,7 @@ public:
 	      network_buffer() {
 		try {
 			network_interfaces.reserve(32);
-			network_buffer.reserve(16 * 1024);
+			network_buffer.reserve(idx_t(16) * 1024);
 		} catch (...) {
 		}
 	}
@@ -440,15 +442,17 @@ private:
 		char line[1024];
 		while (fgets(line, sizeof(line), file)) {
 			char name[64];
-			unsigned long long received;
-			unsigned long long transmitted;
-			if (sscanf(line, " %63[^:]: %llu %*llu %*llu %*llu %*llu %*llu %*llu %*llu %llu", name, &received,
-			           &transmitted) != 3 ||
+			uint64_t counters[9];
+			if (sscanf(line,
+			           " %63[^:]: %" SCNu64 " %" SCNu64 " %" SCNu64 " %" SCNu64 " %" SCNu64 " %" SCNu64 " %" SCNu64
+			           " %" SCNu64 " %" SCNu64,
+			           name, &counters[0], &counters[1], &counters[2], &counters[3], &counters[4], &counters[5],
+			           &counters[6], &counters[7], &counters[8]) != 10 ||
 			    strcmp(name, "lo") == 0) {
 				continue;
 			}
 			try {
-				network_interfaces.push_back({name, received, transmitted});
+				network_interfaces.push_back({name, counters[0], counters[8]});
 			} catch (...) {
 				fclose(file);
 				return false;
@@ -760,11 +764,10 @@ bool SamplyHTTPWriter::WriteAttempt(uint64_t start_unix_ns, uint64_t duration_ns
                                     const string &request_range, const string &response_content_range) noexcept {
 #if defined(__linux__) || defined(__APPLE__)
 	try {
-		auto record = StringUtil::Format(
-		    "1\t%llu\t%llu\t%d\t%llu\t%lld\t%s\t%s\t%s\t%s\n", static_cast<unsigned long long>(start_unix_ns),
-		    static_cast<unsigned long long>(duration_ns), status_code, static_cast<unsigned long long>(bytes_received),
-		    static_cast<long long>(time_to_first_byte_ns), method, Blob::ToBase64(url), Blob::ToBase64(request_range),
-		    Blob::ToBase64(response_content_range));
+		auto record = StringUtil::Format("1\t%llu\t%llu\t%d\t%llu\t%lld\t%s\t%s\t%s\t%s\n", start_unix_ns, duration_ns,
+		                                 status_code, bytes_received, time_to_first_byte_ns, method,
+		                                 Blob::ToBase64(string_t(url)), Blob::ToBase64(string_t(request_range)),
+		                                 Blob::ToBase64(string_t(response_content_range)));
 		return Write(record.data(), record.size());
 	} catch (...) {
 		failed = true;

--- a/src/main/samply.cpp
+++ b/src/main/samply.cpp
@@ -1,12 +1,13 @@
 #include "duckdb/main/profiler/samply.hpp"
 
+#include "duckdb/common/allocator.hpp"
+#include "duckdb/common/atomic.hpp"
+#include "duckdb/common/http_util.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/types/blob.hpp"
 #include "duckdb/common/types/string_type.hpp"
-#include "utf8proc_wrapper.hpp"
 
 #include <cerrno>
-#include <cinttypes>
 #include <chrono>
 #include <condition_variable>
 #include <cstdio>
@@ -14,8 +15,6 @@
 #include <limits>
 #include <mutex>
 #include <thread>
-#include <unordered_map>
-#include <vector>
 
 #if defined(__linux__) || defined(__APPLE__)
 #include <cstdlib>
@@ -28,71 +27,15 @@
 #endif
 
 #ifdef __linux__
-#include <sys/mman.h>
 #include <sys/syscall.h>
 #endif
 
 #ifdef __APPLE__
-#include <mach/mach.h>
 #include <mach/mach_time.h>
-#include <net/if.h>
-#include <net/route.h>
 #include <pthread.h>
-#include <sys/sysctl.h>
 #endif
 
 namespace duckdb {
-
-string SamplyQueryMarkerName(const string &query) {
-	static constexpr idx_t MAX_QUERY_CHARACTERS = 500;
-	static constexpr idx_t MAX_MARKER_NAME_BYTES = 900;
-	const string prefix = "Query: ";
-	const string ellipsis = "…";
-
-	string normalized_query;
-	normalized_query.reserve(MinValue<idx_t>(query.size(), MAX_MARKER_NAME_BYTES));
-	bool pending_space = false;
-	for (const auto character : query) {
-		if (StringUtil::CharacterIsSpace(character)) {
-			pending_space = !normalized_query.empty();
-			continue;
-		}
-		if (pending_space) {
-			normalized_query += ' ';
-			pending_space = false;
-		}
-		normalized_query += character == '\0' ? '?' : character;
-	}
-	if (normalized_query.empty()) {
-		return prefix + "<empty>";
-	}
-	if (!Utf8Proc::IsValid(normalized_query.c_str(), normalized_query.size())) {
-		Utf8Proc::MakeValid(&normalized_query[0], normalized_query.size());
-	}
-
-	idx_t character_count = 0;
-	idx_t query_bytes = 0;
-	while (query_bytes < normalized_query.size() && character_count < MAX_QUERY_CHARACTERS) {
-		auto next_position =
-		    Utf8Proc::NextGraphemeCluster(normalized_query.c_str(), normalized_query.size(), query_bytes);
-		if (prefix.size() + next_position > MAX_MARKER_NAME_BYTES) {
-			break;
-		}
-		query_bytes = next_position;
-		character_count++;
-	}
-
-	if (query_bytes == normalized_query.size()) {
-		return prefix + normalized_query;
-	}
-	if (character_count == MAX_QUERY_CHARACTERS) {
-		query_bytes = Utf8Proc::PreviousGraphemeCluster(normalized_query.c_str(), normalized_query.size(), query_bytes);
-	}
-	while (prefix.size() + query_bytes + ellipsis.size() > MAX_MARKER_NAME_BYTES) {
-		query_bytes = Utf8Proc::PreviousGraphemeCluster(normalized_query.c_str(), normalized_query.size(), query_bytes);
-	}
-	return prefix + normalized_query.substr(0, query_bytes) + ellipsis;
-}
 
 #if defined(__linux__) || defined(__APPLE__)
 
@@ -292,43 +235,6 @@ static uint64_t SamplyUnixTimestamp() noexcept {
 	return static_cast<uint64_t>(timestamp.tv_sec) * 1000000000ULL + static_cast<uint64_t>(timestamp.tv_nsec);
 }
 
-struct SamplyNetworkInterface {
-	string name;
-	uint64_t received;
-	uint64_t transmitted;
-};
-
-static bool SamplyReadRSS(uint64_t &rss) noexcept {
-#ifdef __linux__
-	FILE *file = fopen("/proc/self/statm", "r");
-	if (!file) {
-		return false;
-	}
-	uint64_t total_pages = 0;
-	uint64_t resident_pages = 0;
-	auto result = fscanf(file, "%" SCNu64 " %" SCNu64, &total_pages, &resident_pages);
-	fclose(file);
-	if (result != 2) {
-		return false;
-	}
-	auto page_size = sysconf(_SC_PAGESIZE);
-	if (page_size <= 0 || resident_pages > std::numeric_limits<uint64_t>::max() / static_cast<uint64_t>(page_size)) {
-		return false;
-	}
-	rss = resident_pages * static_cast<uint64_t>(page_size);
-	return true;
-#else
-	mach_task_basic_info_data_t info;
-	mach_msg_type_number_t count = MACH_TASK_BASIC_INFO_COUNT;
-	if (task_info(mach_task_self(), MACH_TASK_BASIC_INFO, reinterpret_cast<task_info_t>(&info), &count) !=
-	    KERN_SUCCESS) {
-		return false;
-	}
-	rss = info.resident_size;
-	return true;
-#endif
-}
-
 class SamplyResourceSampler {
 public:
 	static shared_ptr<SamplyResourceSampler> Get() {
@@ -340,12 +246,7 @@ public:
 	    : memory_references(0), network_references(0), http_references(0), pending_final_tracks(0),
 	      completed_final_tracks(0), stopping(false), periodic_sampling(periodic_sampling_p),
 	      directory(directory_p ? directory_p : ""), writer(directory_p ? directory.c_str() : nullptr),
-	      network_buffer() {
-		try {
-			network_interfaces.reserve(32);
-			network_buffer.reserve(idx_t(16) * 1024);
-		} catch (...) {
-		}
+	      received_baseline(HTTPUtil::GetTotalBytesReceived()), sent_baseline(HTTPUtil::GetTotalBytesSent()) {
 	}
 
 	~SamplyResourceSampler() {
@@ -367,6 +268,10 @@ public:
 			memory_references++;
 		}
 		if (SamplyTrackEnabled(tracks, SamplyTrack::NETWORK)) {
+			if (network_references == 0) {
+				received_baseline.store(HTTPUtil::GetTotalBytesReceived(), std::memory_order_relaxed);
+				sent_baseline.store(HTTPUtil::GetTotalBytesSent(), std::memory_order_relaxed);
+			}
 			network_references++;
 		}
 		if (SamplyTrackEnabled(tracks, SamplyTrack::HTTP)) {
@@ -433,115 +338,23 @@ private:
 #endif
 	}
 
-	bool ReadNetwork() noexcept {
-		network_interfaces.clear();
-#ifdef __linux__
-		FILE *file = fopen("/proc/net/dev", "r");
-		if (!file) {
-			return false;
-		}
-		char line[1024];
-		while (fgets(line, sizeof(line), file)) {
-			char name[64];
-			uint64_t counters[9];
-			if (sscanf(line,
-			           " %63[^:]: %" SCNu64 " %" SCNu64 " %" SCNu64 " %" SCNu64 " %" SCNu64 " %" SCNu64 " %" SCNu64
-			           " %" SCNu64 " %" SCNu64,
-			           name, &counters[0], &counters[1], &counters[2], &counters[3], &counters[4], &counters[5],
-			           &counters[6], &counters[7], &counters[8]) != 10 ||
-			    strcmp(name, "lo") == 0) {
-				continue;
-			}
-			try {
-				network_interfaces.push_back({name, counters[0], counters[8]});
-			} catch (...) {
-				fclose(file);
-				return false;
-			}
-		}
-		fclose(file);
-		return true;
-#else
-		int mib[6] = {CTL_NET, PF_ROUTE, 0, 0, NET_RT_IFLIST2, 0};
-		size_t needed = 0;
-		if (sysctl(mib, 6, nullptr, &needed, nullptr, 0) != 0) {
-			return false;
-		}
-		try {
-			if (network_buffer.size() < needed) {
-				network_buffer.resize(needed);
-			}
-		} catch (...) {
-			return false;
-		}
-		if (sysctl(mib, 6, network_buffer.data(), &needed, nullptr, 0) != 0) {
-			return false;
-		}
-		char *current = network_buffer.data();
-		char *end = current + needed;
-		while (current + sizeof(if_msghdr) <= end) {
-			auto message = reinterpret_cast<if_msghdr *>(current);
-			if (message->ifm_msglen == 0 || current + message->ifm_msglen > end) {
-				return false;
-			}
-			if (message->ifm_type == RTM_IFINFO2 && message->ifm_msglen >= sizeof(if_msghdr2)) {
-				auto info = reinterpret_cast<if_msghdr2 *>(current);
-				if ((info->ifm_flags & IFF_LOOPBACK) == 0) {
-					char name[IF_NAMESIZE];
-					if (if_indextoname(info->ifm_index, name)) {
-						try {
-							network_interfaces.push_back({name, info->ifm_data.ifi_ibytes, info->ifm_data.ifi_obytes});
-						} catch (...) {
-							return false;
-						}
-					}
-				}
-			}
-			current += message->ifm_msglen;
-		}
-		return true;
-#endif
-	}
-
 	void SampleNetwork(uint64_t timestamp) noexcept {
-		if (!ReadNetwork()) {
-			return;
-		}
-		uint64_t received_delta = 0;
-		uint64_t transmitted_delta = 0;
-		std::unordered_map<string, std::pair<uint64_t, uint64_t>> next_baselines;
-		try {
-			next_baselines.reserve(network_interfaces.size());
-			for (const auto &interface : network_interfaces) {
-				auto previous = network_baselines.find(interface.name);
-				if (previous != network_baselines.end()) {
-					if (interface.received >= previous->second.first) {
-						received_delta += interface.received - previous->second.first;
-					}
-					if (interface.transmitted >= previous->second.second) {
-						transmitted_delta += interface.transmitted - previous->second.second;
-					}
-				}
-				next_baselines.emplace(interface.name, std::make_pair(interface.received, interface.transmitted));
-			}
-			network_baselines.swap(next_baselines);
-		} catch (...) {
-			return;
-		}
-		if (received_delta <= static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
-			writer.WriteSample(timestamp, "network-rx", static_cast<int64_t>(received_delta));
-		}
-		if (transmitted_delta <= static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
-			writer.WriteSample(timestamp, "network-tx", static_cast<int64_t>(transmitted_delta));
-		}
+		auto received = HTTPUtil::GetTotalBytesReceived();
+		auto sent = HTTPUtil::GetTotalBytesSent();
+		auto previous_received = received_baseline.exchange(received, std::memory_order_relaxed);
+		auto previous_sent = sent_baseline.exchange(sent, std::memory_order_relaxed);
+		writer.WriteSample(timestamp, "http-download",
+		                   static_cast<int64_t>(received >= previous_received ? received - previous_received : 0));
+		writer.WriteSample(timestamp, "http-upload",
+		                   static_cast<int64_t>(sent >= previous_sent ? sent - previous_sent : 0));
 	}
 
 	void Sample(uint8_t tracks) noexcept {
 		auto timestamp = SamplyTimestamp();
 		if (SamplyTrackEnabled(tracks, SamplyTrack::MEMORY)) {
-			uint64_t rss;
-			if (SamplyReadRSS(rss) && rss <= static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
-				writer.WriteSample(timestamp, "rss", static_cast<int64_t>(rss));
+			auto memory = Allocator::GetTrackedMemory();
+			if (memory <= static_cast<idx_t>(std::numeric_limits<int64_t>::max())) {
+				writer.WriteSample(timestamp, "tracked-memory", static_cast<int64_t>(memory));
 			}
 		}
 		if (SamplyTrackEnabled(tracks, SamplyTrack::NETWORK)) {
@@ -581,9 +394,6 @@ private:
 			}
 
 			Sample(tracks);
-			if (SamplyTrackEnabled(final_tracks, SamplyTrack::NETWORK)) {
-				network_baselines.clear();
-			}
 			if (final_tracks != 0) {
 				writer.Flush();
 				std::lock_guard<std::mutex> guard(lock);
@@ -619,9 +429,8 @@ private:
 	std::thread worker;
 	string directory;
 	SamplyCounterWriter writer;
-	vector<SamplyNetworkInterface> network_interfaces;
-	vector<char> network_buffer;
-	std::unordered_map<string, std::pair<uint64_t, uint64_t>> network_baselines;
+	atomic<idx_t> received_baseline;
+	atomic<idx_t> sent_baseline;
 };
 
 #endif
@@ -795,11 +604,11 @@ void WriteSamplyHTTPAttempt(uint64_t start_unix_ns, uint64_t duration_ns, const 
 	                                time_to_first_byte_ns, request_range, response_content_range);
 }
 
-SamplyMarkerWriter::SamplyMarkerWriter(const char *directory_p) noexcept
+SamplyQueryWriter::SamplyQueryWriter(const char *directory_p) noexcept
     : directory(directory_p), file_descriptor(-1), failed(false), path {0} {
 }
 
-SamplyMarkerWriter::~SamplyMarkerWriter() {
+SamplyQueryWriter::~SamplyQueryWriter() {
 #if defined(__linux__) || defined(__APPLE__)
 	if (file_descriptor >= 0) {
 		close(file_descriptor);
@@ -807,7 +616,7 @@ SamplyMarkerWriter::~SamplyMarkerWriter() {
 #endif
 }
 
-bool SamplyMarkerWriter::Initialize() noexcept {
+bool SamplyQueryWriter::Initialize() noexcept {
 #if defined(__linux__) || defined(__APPLE__)
 	if (failed) {
 		return false;
@@ -823,33 +632,17 @@ bool SamplyMarkerWriter::Initialize() noexcept {
 		return false;
 	}
 	auto length =
-	    snprintf(path, sizeof(path), "%s/marker-%llu-%llu.txt", directory, static_cast<unsigned long long>(getpid()),
+	    snprintf(path, sizeof(path), "%s/query-%llu-%llu.jsonl", directory, static_cast<unsigned long long>(getpid()),
 	             static_cast<unsigned long long>(SamplyThreadId()));
 	if (length <= 0 || static_cast<idx_t>(length) >= sizeof(path)) {
 		failed = true;
 		return false;
 	}
-	file_descriptor = open(path, O_RDWR | O_CREAT | O_APPEND | O_CLOEXEC, S_IRUSR | S_IWUSR);
+	file_descriptor = open(path, O_WRONLY | O_CREAT | O_APPEND | O_CLOEXEC, S_IRUSR | S_IWUSR);
 	if (file_descriptor < 0) {
 		failed = true;
 		return false;
 	}
-#ifdef __linux__
-	if (ftruncate(file_descriptor, 1) != 0) {
-		failed = true;
-		return false;
-	}
-	auto mapping = mmap(nullptr, 1, PROT_READ | PROT_EXEC, MAP_PRIVATE, file_descriptor, 0);
-	if (mapping == MAP_FAILED) {
-		failed = true;
-		return false;
-	}
-	munmap(mapping, 1);
-	if (ftruncate(file_descriptor, 0) != 0) {
-		failed = true;
-		return false;
-	}
-#endif
 	return true;
 #else
 	failed = true;
@@ -857,7 +650,7 @@ bool SamplyMarkerWriter::Initialize() noexcept {
 #endif
 }
 
-bool SamplyMarkerWriter::Write(const char *data, idx_t size) noexcept {
+bool SamplyQueryWriter::Write(const char *data, idx_t size) noexcept {
 #if defined(__linux__) || defined(__APPLE__)
 	if (!Initialize()) {
 		return false;
@@ -880,68 +673,31 @@ bool SamplyMarkerWriter::Write(const char *data, idx_t size) noexcept {
 #endif
 }
 
-bool SamplyMarkerWriter::WriteMarker(uint64_t start_ns, uint64_t end_ns, const char *name) noexcept {
-#if defined(__linux__) || defined(__APPLE__)
-	char marker[1024];
-	auto length = snprintf(marker, sizeof(marker), "%llu %llu %s\n", static_cast<unsigned long long>(start_ns),
-	                       static_cast<unsigned long long>(end_ns), name);
-	if (length <= 0 || static_cast<idx_t>(length) >= sizeof(marker)) {
+bool SamplyQueryWriter::WriteProfile(uint64_t start_unix_ns, uint64_t duration_ns,
+                                     const string &profile_json) noexcept {
+	try {
+		auto record = StringUtil::Format(
+		    "{\"version\":1,\"start_unix_ns\":%llu,\"duration_ns\":%llu,\"profile\":", start_unix_ns, duration_ns);
+		record += profile_json;
+		record += "}\n";
+		return Write(record.data(), record.size());
+	} catch (...) {
 		failed = true;
 		return false;
 	}
-	return Write(marker, static_cast<idx_t>(length));
-#else
-	return false;
-#endif
 }
 
-const char *SamplyMarkerWriter::GetPath() const noexcept {
+const char *SamplyQueryWriter::GetPath() const noexcept {
 	return path;
 }
 
-static SamplyMarkerWriter &ThreadMarkerWriter() noexcept {
-	thread_local SamplyMarkerWriter writer;
+static SamplyQueryWriter &ThreadQueryWriter() noexcept {
+	thread_local SamplyQueryWriter writer;
 	return writer;
 }
 
-SamplyMarker::SamplyMarker() noexcept : start_ns(0), active(false) {
-}
-
-SamplyMarker::SamplyMarker(bool enabled) noexcept : start_ns(0), active(false) {
-#if defined(__linux__) || defined(__APPLE__)
-	if (enabled) {
-		start_ns = SamplyTimestamp();
-		active = start_ns != 0;
-	}
-#else
-	(void)enabled;
-#endif
-}
-
-SamplyMarker::SamplyMarker(SamplyMarker &&other) noexcept : start_ns(other.start_ns), active(other.active) {
-	other.active = false;
-}
-
-SamplyMarker &SamplyMarker::operator=(SamplyMarker &&other) noexcept {
-	start_ns = other.start_ns;
-	active = other.active;
-	other.active = false;
-	return *this;
-}
-
-void SamplyMarker::End(const char *name) noexcept {
-#if defined(__linux__) || defined(__APPLE__)
-	if (active) {
-		active = false;
-		ThreadMarkerWriter().WriteMarker(start_ns, SamplyTimestamp(), name);
-	}
-#else
-	(void)name;
-#endif
-}
-
-void SamplyMarker::Reset() noexcept {
-	active = false;
+void WriteSamplyQueryProfile(uint64_t start_unix_ns, uint64_t duration_ns, const string &profile_json) noexcept {
+	ThreadQueryWriter().WriteProfile(start_unix_ns, duration_ns, profile_json);
 }
 
 } // namespace duckdb

--- a/src/main/samply.cpp
+++ b/src/main/samply.cpp
@@ -2,6 +2,7 @@
 
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/types/blob.hpp"
+#include "duckdb/common/types/string_type.hpp"
 #include "utf8proc_wrapper.hpp"
 
 #include <cerrno>
@@ -307,7 +308,7 @@ static bool SamplyReadRSS(uint64_t &rss) noexcept {
 	uint64_t resident_pages = 0;
 	auto result = fscanf(file, "%" SCNu64 " %" SCNu64, &total_pages, &resident_pages);
 	fclose(file);
-	if (result != 1) {
+	if (result != 2) {
 		return false;
 	}
 	auto page_size = sysconf(_SC_PAGESIZE);

--- a/src/main/samply.cpp
+++ b/src/main/samply.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/main/profiler/samply.hpp"
 
 #include "duckdb/common/string_util.hpp"
+#include "duckdb/common/types/blob.hpp"
 #include "utf8proc_wrapper.hpp"
 
 #include <cerrno>
@@ -333,9 +334,10 @@ public:
 	}
 
 	SamplyResourceSampler(const char *directory_p, bool periodic_sampling_p)
-	    : memory_references(0), network_references(0), pending_final_tracks(0), completed_final_tracks(0),
-	      stopping(false), periodic_sampling(periodic_sampling_p), directory(directory_p ? directory_p : ""),
-	      writer(directory_p ? directory.c_str() : nullptr), network_buffer() {
+	    : memory_references(0), network_references(0), http_references(0), pending_final_tracks(0),
+	      completed_final_tracks(0), stopping(false), periodic_sampling(periodic_sampling_p),
+	      directory(directory_p ? directory_p : ""), writer(directory_p ? directory.c_str() : nullptr),
+	      network_buffer() {
 		try {
 			network_interfaces.reserve(32);
 			network_buffer.reserve(16 * 1024);
@@ -364,7 +366,10 @@ public:
 		if (SamplyTrackEnabled(tracks, SamplyTrack::NETWORK)) {
 			network_references++;
 		}
-		if (!worker.joinable()) {
+		if (SamplyTrackEnabled(tracks, SamplyTrack::HTTP)) {
+			http_references++;
+		}
+		if ((memory_references > 0 || network_references > 0) && !worker.joinable()) {
 			stopping = false;
 			try {
 				worker = std::thread(&SamplyResourceSampler::Run, this);
@@ -392,6 +397,9 @@ public:
 					final_tracks |= static_cast<uint8_t>(SamplyTrack::NETWORK);
 				}
 			}
+			if (SamplyTrackEnabled(tracks, SamplyTrack::HTTP) && http_references > 0) {
+				http_references--;
+			}
 			pending_final_tracks |= final_tracks;
 			completed_final_tracks &= ~final_tracks;
 			stopping = memory_references == 0 && network_references == 0;
@@ -406,6 +414,11 @@ public:
 			               [this, final_tracks] { return (completed_final_tracks & final_tracks) == final_tracks; });
 			completed_final_tracks &= ~final_tracks;
 		}
+	}
+
+	bool HTTPEnabled() noexcept {
+		std::lock_guard<std::mutex> guard(lock);
+		return http_references > 0;
 	}
 
 private:
@@ -593,6 +606,7 @@ private:
 	std::condition_variable condition;
 	idx_t memory_references;
 	idx_t network_references;
+	idx_t http_references;
 	uint8_t pending_final_tracks;
 	uint8_t completed_final_tracks;
 	bool stopping;
@@ -662,6 +676,119 @@ shared_ptr<SamplyResourceSubscription> StartSamplyResourceSamplingForTesting(uin
 #else
 	return nullptr;
 #endif
+}
+
+bool SamplyHTTPTrackEnabled() noexcept {
+#if defined(__linux__) || defined(__APPLE__)
+	return SamplyResourceSampler::Get()->HTTPEnabled();
+#else
+	return false;
+#endif
+}
+
+SamplyHTTPWriter::SamplyHTTPWriter(const char *directory_p) noexcept
+    : directory(directory_p), file_descriptor(-1), failed(false), path {0} {
+}
+
+SamplyHTTPWriter::~SamplyHTTPWriter() {
+#if defined(__linux__) || defined(__APPLE__)
+	if (file_descriptor >= 0) {
+		close(file_descriptor);
+	}
+#endif
+}
+
+bool SamplyHTTPWriter::Initialize() noexcept {
+#if defined(__linux__) || defined(__APPLE__)
+	if (failed) {
+		return false;
+	}
+	if (file_descriptor >= 0) {
+		return true;
+	}
+	if (!directory) {
+		directory = SamplyDirectory();
+	}
+	if (!directory) {
+		failed = true;
+		return false;
+	}
+	auto length =
+	    snprintf(path, sizeof(path), "%s/http-%llu-%llu.txt", directory, static_cast<unsigned long long>(getpid()),
+	             static_cast<unsigned long long>(SamplyThreadId()));
+	if (length <= 0 || static_cast<idx_t>(length) >= sizeof(path)) {
+		failed = true;
+		return false;
+	}
+	file_descriptor = open(path, O_WRONLY | O_CREAT | O_APPEND | O_CLOEXEC, S_IRUSR | S_IWUSR);
+	if (file_descriptor < 0) {
+		failed = true;
+		return false;
+	}
+	return true;
+#else
+	failed = true;
+	return false;
+#endif
+}
+
+bool SamplyHTTPWriter::Write(const char *data, idx_t size) noexcept {
+#if defined(__linux__) || defined(__APPLE__)
+	if (!Initialize()) {
+		return false;
+	}
+	idx_t offset = 0;
+	while (offset < size) {
+		auto written = write(file_descriptor, data + offset, size - offset);
+		if (written < 0 && errno == EINTR) {
+			continue;
+		}
+		if (written <= 0) {
+			failed = true;
+			return false;
+		}
+		offset += static_cast<idx_t>(written);
+	}
+	return true;
+#else
+	return false;
+#endif
+}
+
+bool SamplyHTTPWriter::WriteAttempt(uint64_t start_unix_ns, uint64_t duration_ns, const char *method, const string &url,
+                                    int32_t status_code, uint64_t bytes_received, int64_t time_to_first_byte_ns,
+                                    const string &request_range, const string &response_content_range) noexcept {
+#if defined(__linux__) || defined(__APPLE__)
+	try {
+		auto record = StringUtil::Format(
+		    "1\t%llu\t%llu\t%d\t%llu\t%lld\t%s\t%s\t%s\t%s\n", static_cast<unsigned long long>(start_unix_ns),
+		    static_cast<unsigned long long>(duration_ns), status_code, static_cast<unsigned long long>(bytes_received),
+		    static_cast<long long>(time_to_first_byte_ns), method, Blob::ToBase64(url), Blob::ToBase64(request_range),
+		    Blob::ToBase64(response_content_range));
+		return Write(record.data(), record.size());
+	} catch (...) {
+		failed = true;
+		return false;
+	}
+#else
+	return false;
+#endif
+}
+
+const char *SamplyHTTPWriter::GetPath() const noexcept {
+	return path;
+}
+
+static SamplyHTTPWriter &ThreadHTTPWriter() noexcept {
+	thread_local SamplyHTTPWriter writer;
+	return writer;
+}
+
+void WriteSamplyHTTPAttempt(uint64_t start_unix_ns, uint64_t duration_ns, const char *method, const string &url,
+                            int32_t status_code, uint64_t bytes_received, int64_t time_to_first_byte_ns,
+                            const string &request_range, const string &response_content_range) noexcept {
+	ThreadHTTPWriter().WriteAttempt(start_unix_ns, duration_ns, method, url, status_code, bytes_received,
+	                                time_to_first_byte_ns, request_range, response_content_range);
 }
 
 SamplyMarkerWriter::SamplyMarkerWriter(const char *directory_p) noexcept

--- a/src/main/samply.cpp
+++ b/src/main/samply.cpp
@@ -1,0 +1,232 @@
+#include "duckdb/main/profiler/samply.hpp"
+
+#include <cerrno>
+#include <cstdio>
+
+#if defined(__linux__) || defined(__APPLE__)
+#include <cstdlib>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <time.h>
+#include <unistd.h>
+#endif
+
+#ifdef __linux__
+#include <sys/mman.h>
+#include <sys/syscall.h>
+#endif
+
+#ifdef __APPLE__
+#include <mach/mach_time.h>
+#include <pthread.h>
+#endif
+
+namespace duckdb {
+
+#if defined(__linux__) || defined(__APPLE__)
+
+static uint64_t SamplyTimestamp() noexcept {
+#ifdef __APPLE__
+	static mach_timebase_info_data_t timebase = [] {
+		mach_timebase_info_data_t result;
+		mach_timebase_info(&result);
+		return result;
+	}();
+	auto ticks = mach_absolute_time();
+	auto scale = reinterpret_cast<const uint32_t *>(&timebase);
+	return static_cast<uint64_t>((static_cast<__uint128_t>(ticks) * scale[0]) / scale[1]);
+#else
+	struct timespec timestamp;
+	if (clock_gettime(CLOCK_MONOTONIC, &timestamp) != 0) {
+		return 0;
+	}
+	return static_cast<uint64_t>(timestamp.tv_sec) * 1000000000ULL + static_cast<uint64_t>(timestamp.tv_nsec);
+#endif
+}
+
+static uint64_t SamplyThreadId() noexcept {
+#ifdef __APPLE__
+	uint64_t thread_id = 0;
+	if (pthread_threadid_np(nullptr, &thread_id) != 0) {
+		return 0;
+	}
+	return static_cast<uint32_t>(thread_id);
+#else
+	return static_cast<uint64_t>(syscall(SYS_gettid));
+#endif
+}
+
+struct SamplyDirectoryState {
+	SamplyDirectoryState() noexcept : path {0} {
+		const char *temporary_directory = getenv("TMPDIR");
+		if (!temporary_directory || temporary_directory[0] == '\0') {
+			temporary_directory = "/tmp";
+		}
+		auto length = snprintf(path, sizeof(path), "%s/duckdb-samply-%llu-XXXXXX", temporary_directory,
+		                       static_cast<unsigned long long>(getpid()));
+		if (length <= 0 || static_cast<idx_t>(length) >= sizeof(path) || !mkdtemp(path)) {
+			path[0] = '\0';
+		}
+	}
+
+	char path[4096];
+};
+
+static const char *SamplyDirectory() noexcept {
+	static SamplyDirectoryState directory;
+	return directory.path[0] == '\0' ? nullptr : directory.path;
+}
+
+#endif
+
+SamplyMarkerWriter::SamplyMarkerWriter(const char *directory_p) noexcept
+    : directory(directory_p), file_descriptor(-1), failed(false), path {0} {
+}
+
+SamplyMarkerWriter::~SamplyMarkerWriter() {
+#if defined(__linux__) || defined(__APPLE__)
+	if (file_descriptor >= 0) {
+		close(file_descriptor);
+	}
+#endif
+}
+
+bool SamplyMarkerWriter::Initialize() noexcept {
+#if defined(__linux__) || defined(__APPLE__)
+	if (failed) {
+		return false;
+	}
+	if (file_descriptor >= 0) {
+		return true;
+	}
+	if (!directory) {
+		directory = SamplyDirectory();
+	}
+	if (!directory) {
+		failed = true;
+		return false;
+	}
+	auto length =
+	    snprintf(path, sizeof(path), "%s/marker-%llu-%llu.txt", directory, static_cast<unsigned long long>(getpid()),
+	             static_cast<unsigned long long>(SamplyThreadId()));
+	if (length <= 0 || static_cast<idx_t>(length) >= sizeof(path)) {
+		failed = true;
+		return false;
+	}
+	file_descriptor = open(path, O_RDWR | O_CREAT | O_APPEND | O_CLOEXEC, S_IRUSR | S_IWUSR);
+	if (file_descriptor < 0) {
+		failed = true;
+		return false;
+	}
+#ifdef __linux__
+	if (ftruncate(file_descriptor, 1) != 0) {
+		failed = true;
+		return false;
+	}
+	auto mapping = mmap(nullptr, 1, PROT_READ | PROT_EXEC, MAP_PRIVATE, file_descriptor, 0);
+	if (mapping == MAP_FAILED) {
+		failed = true;
+		return false;
+	}
+	munmap(mapping, 1);
+	if (ftruncate(file_descriptor, 0) != 0) {
+		failed = true;
+		return false;
+	}
+#endif
+	return true;
+#else
+	failed = true;
+	return false;
+#endif
+}
+
+bool SamplyMarkerWriter::Write(const char *data, idx_t size) noexcept {
+#if defined(__linux__) || defined(__APPLE__)
+	if (!Initialize()) {
+		return false;
+	}
+	idx_t offset = 0;
+	while (offset < size) {
+		auto written = write(file_descriptor, data + offset, size - offset);
+		if (written < 0 && errno == EINTR) {
+			continue;
+		}
+		if (written <= 0) {
+			failed = true;
+			return false;
+		}
+		offset += static_cast<idx_t>(written);
+	}
+	return true;
+#else
+	return false;
+#endif
+}
+
+bool SamplyMarkerWriter::WriteMarker(uint64_t start_ns, uint64_t end_ns, const char *name) noexcept {
+#if defined(__linux__) || defined(__APPLE__)
+	char marker[1024];
+	auto length = snprintf(marker, sizeof(marker), "%llu %llu %s\n", static_cast<unsigned long long>(start_ns),
+	                       static_cast<unsigned long long>(end_ns), name);
+	if (length <= 0 || static_cast<idx_t>(length) >= sizeof(marker)) {
+		failed = true;
+		return false;
+	}
+	return Write(marker, static_cast<idx_t>(length));
+#else
+	return false;
+#endif
+}
+
+const char *SamplyMarkerWriter::GetPath() const noexcept {
+	return path;
+}
+
+static SamplyMarkerWriter &ThreadMarkerWriter() noexcept {
+	thread_local SamplyMarkerWriter writer;
+	return writer;
+}
+
+SamplyMarker::SamplyMarker() noexcept : start_ns(0), active(false) {
+}
+
+SamplyMarker::SamplyMarker(bool enabled) noexcept : start_ns(0), active(false) {
+#if defined(__linux__) || defined(__APPLE__)
+	if (enabled) {
+		start_ns = SamplyTimestamp();
+		active = start_ns != 0;
+	}
+#else
+	(void)enabled;
+#endif
+}
+
+SamplyMarker::SamplyMarker(SamplyMarker &&other) noexcept : start_ns(other.start_ns), active(other.active) {
+	other.active = false;
+}
+
+SamplyMarker &SamplyMarker::operator=(SamplyMarker &&other) noexcept {
+	start_ns = other.start_ns;
+	active = other.active;
+	other.active = false;
+	return *this;
+}
+
+void SamplyMarker::End(const char *name) noexcept {
+#if defined(__linux__) || defined(__APPLE__)
+	if (active) {
+		active = false;
+		ThreadMarkerWriter().WriteMarker(start_ns, SamplyTimestamp(), name);
+	}
+#else
+	(void)name;
+#endif
+}
+
+void SamplyMarker::Reset() noexcept {
+	active = false;
+}
+
+} // namespace duckdb

--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -937,9 +937,11 @@ void SamplyTracksSetting::SetLocal(ClientContext &context, const Value &input) {
 			tracks |= static_cast<uint8_t>(SamplyTrack::MEMORY);
 		} else if (value == "network") {
 			tracks |= static_cast<uint8_t>(SamplyTrack::NETWORK);
+		} else if (value == "http") {
+			tracks |= static_cast<uint8_t>(SamplyTrack::HTTP);
 		} else {
-			throw InvalidInputException("Unknown Samply track '%s'; expected query, memory, network, none, or all",
-			                            value);
+			throw InvalidInputException(
+			    "Unknown Samply track '%s'; expected query, memory, network, http, none, or all", value);
 		}
 	}
 	if ((has_none || has_all) && (values.size() != 1 || has_none == has_all)) {
@@ -947,7 +949,7 @@ void SamplyTracksSetting::SetLocal(ClientContext &context, const Value &input) {
 	}
 	if (has_all) {
 		tracks = static_cast<uint8_t>(SamplyTrack::QUERY) | static_cast<uint8_t>(SamplyTrack::MEMORY) |
-		         static_cast<uint8_t>(SamplyTrack::NETWORK);
+		         static_cast<uint8_t>(SamplyTrack::NETWORK) | static_cast<uint8_t>(SamplyTrack::HTTP);
 	}
 #if !defined(__linux__) && !defined(__APPLE__)
 	if (tracks != 0) {
@@ -956,7 +958,8 @@ void SamplyTracksSetting::SetLocal(ClientContext &context, const Value &input) {
 #endif
 	auto &config = ClientConfig::GetConfig(context);
 	auto resource_tracks =
-	    tracks & (static_cast<uint8_t>(SamplyTrack::MEMORY) | static_cast<uint8_t>(SamplyTrack::NETWORK));
+	    tracks & (static_cast<uint8_t>(SamplyTrack::MEMORY) | static_cast<uint8_t>(SamplyTrack::NETWORK) |
+	              static_cast<uint8_t>(SamplyTrack::HTTP));
 	auto subscription = StartSamplyResourceSampling(resource_tracks);
 	config.samply_tracks = tracks;
 	config.samply_resource_subscription = std::move(subscription);
@@ -974,7 +977,7 @@ Value SamplyTracksSetting::GetSetting(const ClientContext &context) {
 		return Value("none");
 	}
 	auto all = static_cast<uint8_t>(SamplyTrack::QUERY) | static_cast<uint8_t>(SamplyTrack::MEMORY) |
-	           static_cast<uint8_t>(SamplyTrack::NETWORK);
+	           static_cast<uint8_t>(SamplyTrack::NETWORK) | static_cast<uint8_t>(SamplyTrack::HTTP);
 	if (tracks == all) {
 		return Value("all");
 	}
@@ -987,6 +990,9 @@ Value SamplyTracksSetting::GetSetting(const ClientContext &context) {
 	}
 	if (SamplyTrackEnabled(tracks, SamplyTrack::NETWORK)) {
 		result.emplace_back("network");
+	}
+	if (SamplyTrackEnabled(tracks, SamplyTrack::HTTP)) {
+		result.emplace_back("http");
 	}
 	return Value(StringUtil::Join(result, ","));
 }

--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -28,6 +28,7 @@
 #include "duckdb/common/tree_renderer.hpp"
 #include "duckdb/main/extension_helper.hpp"
 #include "duckdb/main/query_profiler.hpp"
+#include "duckdb/main/profiler/samply.hpp"
 #include "duckdb/main/secret/secret_manager.hpp"
 #include "duckdb/parallel/task_scheduler.hpp"
 #include "duckdb/parser/parser.hpp"
@@ -899,24 +900,95 @@ Value EnableProfilingSetting::GetSetting(const ClientContext &context) {
 }
 
 //===----------------------------------------------------------------------===//
-// Enable Samply Markers
+// Samply Tracks
 //===----------------------------------------------------------------------===//
-void EnableSamplyMarkersSetting::SetLocal(ClientContext &context, const Value &input) {
-	auto enabled = input.GetValue<bool>();
+void SamplyTracksSetting::SetLocal(ClientContext &context, const Value &input) {
+	auto input_string = input.GetValue<string>();
+	auto trimmed_input = input_string;
+	StringUtil::Trim(trimmed_input);
+	if (trimmed_input.empty()) {
+		input_string = "all";
+	}
+	vector<string> values;
+	idx_t start = 0;
+	while (true) {
+		auto separator = input_string.find(',', start);
+		values.push_back(input_string.substr(start, separator - start));
+		if (separator == string::npos) {
+			break;
+		}
+		start = separator + 1;
+	}
+	uint8_t tracks = 0;
+	bool has_none = false;
+	bool has_all = false;
+	for (auto &value : values) {
+		StringUtil::Trim(value);
+		value = StringUtil::Lower(value);
+		if (value.empty()) {
+			throw InvalidInputException("samply_tracks contains an empty track");
+		} else if (value == "none") {
+			has_none = true;
+		} else if (value == "all") {
+			has_all = true;
+		} else if (value == "query") {
+			tracks |= static_cast<uint8_t>(SamplyTrack::QUERY);
+		} else if (value == "memory") {
+			tracks |= static_cast<uint8_t>(SamplyTrack::MEMORY);
+		} else if (value == "network") {
+			tracks |= static_cast<uint8_t>(SamplyTrack::NETWORK);
+		} else {
+			throw InvalidInputException("Unknown Samply track '%s'; expected query, memory, network, none, or all",
+			                            value);
+		}
+	}
+	if ((has_none || has_all) && (values.size() != 1 || has_none == has_all)) {
+		throw InvalidInputException("Samply tracks 'none' and 'all' cannot be combined with other values");
+	}
+	if (has_all) {
+		tracks = static_cast<uint8_t>(SamplyTrack::QUERY) | static_cast<uint8_t>(SamplyTrack::MEMORY) |
+		         static_cast<uint8_t>(SamplyTrack::NETWORK);
+	}
 #if !defined(__linux__) && !defined(__APPLE__)
-	if (enabled) {
-		throw NotImplementedException("Samply markers are only supported on Linux and macOS");
+	if (tracks != 0) {
+		throw NotImplementedException("Samply tracks are only supported on Linux and macOS");
 	}
 #endif
-	ClientConfig::GetConfig(context).enable_samply_markers = enabled;
+	auto &config = ClientConfig::GetConfig(context);
+	auto resource_tracks =
+	    tracks & (static_cast<uint8_t>(SamplyTrack::MEMORY) | static_cast<uint8_t>(SamplyTrack::NETWORK));
+	auto subscription = StartSamplyResourceSampling(resource_tracks);
+	config.samply_tracks = tracks;
+	config.samply_resource_subscription = std::move(subscription);
 }
 
-void EnableSamplyMarkersSetting::ResetLocal(ClientContext &context) {
-	ClientConfig::GetConfig(context).enable_samply_markers = ClientConfig().enable_samply_markers;
+void SamplyTracksSetting::ResetLocal(ClientContext &context) {
+	auto &config = ClientConfig::GetConfig(context);
+	config.samply_tracks = 0;
+	config.samply_resource_subscription.reset();
 }
 
-Value EnableSamplyMarkersSetting::GetSetting(const ClientContext &context) {
-	return Value::BOOLEAN(ClientConfig::GetConfig(context).enable_samply_markers);
+Value SamplyTracksSetting::GetSetting(const ClientContext &context) {
+	auto tracks = ClientConfig::GetConfig(context).samply_tracks;
+	if (tracks == 0) {
+		return Value("none");
+	}
+	auto all = static_cast<uint8_t>(SamplyTrack::QUERY) | static_cast<uint8_t>(SamplyTrack::MEMORY) |
+	           static_cast<uint8_t>(SamplyTrack::NETWORK);
+	if (tracks == all) {
+		return Value("all");
+	}
+	vector<string> result;
+	if (SamplyTrackEnabled(tracks, SamplyTrack::QUERY)) {
+		result.emplace_back("query");
+	}
+	if (SamplyTrackEnabled(tracks, SamplyTrack::MEMORY)) {
+		result.emplace_back("memory");
+	}
+	if (SamplyTrackEnabled(tracks, SamplyTrack::NETWORK)) {
+		result.emplace_back("network");
+	}
+	return Value(StringUtil::Join(result, ","));
 }
 
 //===----------------------------------------------------------------------===//

--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -899,6 +899,27 @@ Value EnableProfilingSetting::GetSetting(const ClientContext &context) {
 }
 
 //===----------------------------------------------------------------------===//
+// Enable Samply Markers
+//===----------------------------------------------------------------------===//
+void EnableSamplyMarkersSetting::SetLocal(ClientContext &context, const Value &input) {
+	auto enabled = input.GetValue<bool>();
+#if !defined(__linux__) && !defined(__APPLE__)
+	if (enabled) {
+		throw NotImplementedException("Samply markers are only supported on Linux and macOS");
+	}
+#endif
+	ClientConfig::GetConfig(context).enable_samply_markers = enabled;
+}
+
+void EnableSamplyMarkersSetting::ResetLocal(ClientContext &context) {
+	ClientConfig::GetConfig(context).enable_samply_markers = ClientConfig().enable_samply_markers;
+}
+
+Value EnableSamplyMarkersSetting::GetSetting(const ClientContext &context) {
+	return Value::BOOLEAN(ClientConfig::GetConfig(context).enable_samply_markers);
+}
+
+//===----------------------------------------------------------------------===//
 // Enable Progress Bar Print
 //===----------------------------------------------------------------------===//
 void EnableProgressBarPrintSetting::SetLocal(ClientContext &context, const Value &input) {

--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -497,7 +497,6 @@ void Executor::Reset() {
 	root_executor.reset();
 	root_pipelines.clear();
 	root_pipeline_idx = 0;
-	next_pipeline_id = 0;
 	completed_pipelines = 0;
 	total_pipelines = 0;
 	error_manager.Reset();

--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -497,6 +497,7 @@ void Executor::Reset() {
 	root_executor.reset();
 	root_pipelines.clear();
 	root_pipeline_idx = 0;
+	next_pipeline_id = 0;
 	completed_pipelines = 0;
 	total_pipelines = 0;
 	error_manager.Reset();

--- a/src/parallel/pipeline.cpp
+++ b/src/parallel/pipeline.cpp
@@ -10,6 +10,7 @@
 #include "duckdb/execution/operator/set/physical_recursive_cte.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/database.hpp"
+#include "duckdb/main/profiler/samply.hpp"
 #include "duckdb/parallel/pipeline_event.hpp"
 #include "duckdb/parallel/pipeline_executor.hpp"
 #include "duckdb/parallel/task_scheduler.hpp"
@@ -561,7 +562,7 @@ void Pipeline::Ready() {
 	ready = true;
 	std::reverse(operators.begin(), operators.end());
 
-	if (!ClientConfig::GetConfig(GetClientContext()).enable_samply_markers) {
+	if (!SamplyTrackEnabled(ClientConfig::GetConfig(GetClientContext()).samply_tracks, SamplyTrack::QUERY)) {
 		return;
 	}
 

--- a/src/parallel/pipeline.cpp
+++ b/src/parallel/pipeline.cpp
@@ -10,12 +10,10 @@
 #include "duckdb/execution/operator/set/physical_recursive_cte.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/database.hpp"
-#include "duckdb/main/profiler/samply.hpp"
+#include "duckdb/main/settings.hpp"
 #include "duckdb/parallel/pipeline_event.hpp"
 #include "duckdb/parallel/pipeline_executor.hpp"
 #include "duckdb/parallel/task_scheduler.hpp"
-#include "duckdb/main/settings.hpp"
-#include "duckdb/common/enum_util.hpp"
 
 namespace duckdb {
 
@@ -76,8 +74,7 @@ TaskExecutionResult PipelineTask::ExecuteTask(TaskExecutionMode mode) {
 }
 
 Pipeline::Pipeline(Executor &executor_p)
-    : executor(executor_p), ready(false), initialized(false), source(nullptr), sink(nullptr),
-      samply_pipeline_id(++executor_p.next_pipeline_id) {
+    : executor(executor_p), ready(false), initialized(false), source(nullptr), sink(nullptr) {
 }
 
 ClientContext &Pipeline::GetClientContext() {
@@ -561,43 +558,6 @@ void Pipeline::Ready() {
 	}
 	ready = true;
 	std::reverse(operators.begin(), operators.end());
-	InitializeSamplyMarkerName();
-}
-
-void Pipeline::InitializeSamplyMarkerName() {
-	if (!SamplyTrackEnabled(ClientConfig::GetConfig(GetClientContext()).samply_tracks, SamplyTrack::QUERY)) {
-		return;
-	}
-
-	samply_marker_name = "Pipeline " + std::to_string(samply_pipeline_id) + ": ";
-	auto pipeline_operators = GetOperators();
-	for (idx_t operator_idx = 0; operator_idx < pipeline_operators.size(); operator_idx++) {
-		auto &op = pipeline_operators[operator_idx].get();
-		string operator_name = EnumUtil::ToChars(op.type);
-
-		const bool is_source = operator_idx == 0;
-		const bool is_sink = sink && operator_idx + 1 == pipeline_operators.size();
-		if (op.type == PhysicalOperatorType::HASH_JOIN) {
-			if (is_sink) {
-				operator_name += "[build]";
-			} else if (is_source) {
-				operator_name += "[scan]";
-			} else {
-				operator_name += "[probe]";
-			}
-		} else if (is_sink) {
-			operator_name += "[sink]";
-		} else if (is_source) {
-			operator_name += "[source]";
-		}
-
-		const string separator = operator_idx == 0 ? "" : " → ";
-		if (samply_marker_name.size() + separator.size() + operator_name.size() > 900) {
-			samply_marker_name += " → …";
-			break;
-		}
-		samply_marker_name += separator + operator_name;
-	}
 }
 
 void Pipeline::AddDependency(shared_ptr<Pipeline> &pipeline) {

--- a/src/parallel/pipeline.cpp
+++ b/src/parallel/pipeline.cpp
@@ -14,6 +14,7 @@
 #include "duckdb/parallel/pipeline_executor.hpp"
 #include "duckdb/parallel/task_scheduler.hpp"
 #include "duckdb/main/settings.hpp"
+#include "duckdb/common/enum_util.hpp"
 
 namespace duckdb {
 
@@ -74,7 +75,8 @@ TaskExecutionResult PipelineTask::ExecuteTask(TaskExecutionMode mode) {
 }
 
 Pipeline::Pipeline(Executor &executor_p)
-    : executor(executor_p), ready(false), initialized(false), source(nullptr), sink(nullptr) {
+    : executor(executor_p), ready(false), initialized(false), source(nullptr), sink(nullptr),
+      samply_pipeline_id(++executor_p.next_pipeline_id) {
 }
 
 ClientContext &Pipeline::GetClientContext() {
@@ -558,6 +560,40 @@ void Pipeline::Ready() {
 	}
 	ready = true;
 	std::reverse(operators.begin(), operators.end());
+
+	if (!ClientConfig::GetConfig(GetClientContext()).enable_samply_markers) {
+		return;
+	}
+
+	samply_marker_name = "Pipeline " + std::to_string(samply_pipeline_id) + ": ";
+	auto pipeline_operators = GetOperators();
+	for (idx_t operator_idx = 0; operator_idx < pipeline_operators.size(); operator_idx++) {
+		auto &op = pipeline_operators[operator_idx].get();
+		string operator_name = EnumUtil::ToChars(op.type);
+
+		const bool is_source = operator_idx == 0;
+		const bool is_sink = sink && operator_idx + 1 == pipeline_operators.size();
+		if (op.type == PhysicalOperatorType::HASH_JOIN) {
+			if (is_sink) {
+				operator_name += "[build]";
+			} else if (is_source) {
+				operator_name += "[scan]";
+			} else {
+				operator_name += "[probe]";
+			}
+		} else if (is_sink) {
+			operator_name += "[sink]";
+		} else if (is_source) {
+			operator_name += "[source]";
+		}
+
+		const string separator = operator_idx == 0 ? "" : " → ";
+		if (samply_marker_name.size() + separator.size() + operator_name.size() > 900) {
+			samply_marker_name += " → …";
+			break;
+		}
+		samply_marker_name += separator + operator_name;
+	}
 }
 
 void Pipeline::AddDependency(shared_ptr<Pipeline> &pipeline) {

--- a/src/parallel/pipeline.cpp
+++ b/src/parallel/pipeline.cpp
@@ -561,7 +561,10 @@ void Pipeline::Ready() {
 	}
 	ready = true;
 	std::reverse(operators.begin(), operators.end());
+	InitializeSamplyMarkerName();
+}
 
+void Pipeline::InitializeSamplyMarkerName() {
 	if (!SamplyTrackEnabled(ClientConfig::GetConfig(GetClientContext()).samply_tracks, SamplyTrack::QUERY)) {
 		return;
 	}

--- a/src/parallel/pipeline_executor.cpp
+++ b/src/parallel/pipeline_executor.cpp
@@ -3,8 +3,6 @@
 #include "duckdb/common/limits.hpp"
 #include "duckdb/common/mutex.hpp"
 #include "duckdb/main/client_context.hpp"
-#include "duckdb/main/profiler/samply.hpp"
-
 #include "duckdb/main/settings.hpp"
 
 #ifdef DUCKDB_DEBUG_ASYNC_SINK_SOURCE
@@ -332,7 +330,6 @@ SinkNextBatchType PipelineExecutor::NextBatch(OperatorPartitionData next_data, b
 }
 
 PipelineExecuteResult PipelineExecutor::Execute(idx_t max_chunks) {
-	SamplyMarkerScope samply_marker(pipeline.GetSamplyMarkerName().c_str());
 	D_ASSERT(pipeline.sink);
 	auto &source_chunk = pipeline.operators.empty() ? final_chunk : *intermediate_chunks[0];
 	ExecutionBudget chunk_budget(max_chunks);

--- a/src/parallel/pipeline_executor.cpp
+++ b/src/parallel/pipeline_executor.cpp
@@ -3,6 +3,7 @@
 #include "duckdb/common/limits.hpp"
 #include "duckdb/common/mutex.hpp"
 #include "duckdb/main/client_context.hpp"
+#include "duckdb/main/profiler/samply.hpp"
 
 #include "duckdb/main/settings.hpp"
 
@@ -331,6 +332,7 @@ SinkNextBatchType PipelineExecutor::NextBatch(OperatorPartitionData next_data, b
 }
 
 PipelineExecuteResult PipelineExecutor::Execute(idx_t max_chunks) {
+	SamplyMarkerScope samply_marker(pipeline.GetSamplyMarkerName().c_str());
 	D_ASSERT(pipeline.sink);
 	auto &source_chunk = pipeline.operators.empty() ? final_chunk : *intermediate_chunks[0];
 	ExecutionBudget chunk_budget(max_chunks);

--- a/src/storage/arena_allocator.cpp
+++ b/src/storage/arena_allocator.cpp
@@ -27,6 +27,7 @@ ArenaChunk::~ArenaChunk() {
 struct ArenaAllocatorData : public PrivateAllocatorData {
 	explicit ArenaAllocatorData(ArenaAllocator &allocator) : allocator(allocator) {
 		free_type = AllocatorFreeType::DOES_NOT_REQUIRE_FREE;
+		track_allocations = false;
 	}
 
 	ArenaAllocator &allocator;

--- a/src/storage/block_allocator.cpp
+++ b/src/storage/block_allocator.cpp
@@ -325,7 +325,9 @@ data_ptr_t BlockAllocator::AllocateData(const idx_t size) const {
 	if (!IsActive() || !IsEnabled() || size != block_size) {
 		return allocator.AllocateData(size);
 	}
-	return GetBlockAllocatorThreadLocalState(*this).Allocate();
+	auto result = GetBlockAllocatorThreadLocalState(*this).Allocate();
+	Allocator::AddTrackedMemory(size);
+	return result;
 }
 
 void BlockAllocator::FreeData(const data_ptr_t pointer, const idx_t size) const {
@@ -333,6 +335,7 @@ void BlockAllocator::FreeData(const data_ptr_t pointer, const idx_t size) const 
 		return allocator.FreeData(pointer, size);
 	}
 	D_ASSERT(size == block_size);
+	Allocator::RemoveTrackedMemory(size);
 	GetBlockAllocatorThreadLocalState(*this).Free(pointer);
 }
 

--- a/src/storage/standard_buffer_manager.cpp
+++ b/src/storage/standard_buffer_manager.cpp
@@ -36,6 +36,7 @@ static void WriteGarbageIntoBuffer(BlockHandle &block) {
 
 struct BufferAllocatorData : PrivateAllocatorData {
 	explicit BufferAllocatorData(StandardBufferManager &manager) : manager(manager) {
+		track_allocations = false;
 	}
 
 	StandardBufferManager &manager;

--- a/test/api/CMakeLists.txt
+++ b/test/api/CMakeLists.txt
@@ -49,7 +49,7 @@ set(TEST_API_OBJECTS
     test_block_allocator_tls.cpp)
 
 if(NOT WIN32)
-  set(TEST_API_OBJECTS ${TEST_API_OBJECTS} test_read_only.cpp)
+  set(TEST_API_OBJECTS ${TEST_API_OBJECTS} test_read_only.cpp test_samply.cpp)
 endif()
 
 if(DUCKDB_EXTENSION_TPCH_SHOULD_LINK)

--- a/test/api/test_reset.cpp
+++ b/test/api/test_reset.cpp
@@ -214,6 +214,7 @@ bool OptionIsExcludedFromTest(const string &name) {
 	    "index_scan_percentage",
 	    "scheduler_process_partial",
 	    "enable_profiling",
+	    "enable_samply_markers", // platform-specific setting
 	    "enable_progress_bar",
 	    "enable_progress_bar_print",
 	    "extension_directories",

--- a/test/api/test_reset.cpp
+++ b/test/api/test_reset.cpp
@@ -214,7 +214,7 @@ bool OptionIsExcludedFromTest(const string &name) {
 	    "index_scan_percentage",
 	    "scheduler_process_partial",
 	    "enable_profiling",
-	    "enable_samply_markers", // platform-specific setting
+	    "samply_tracks", // platform-specific setting
 	    "enable_progress_bar",
 	    "enable_progress_bar_print",
 	    "extension_directories",

--- a/test/api/test_samply.cpp
+++ b/test/api/test_samply.cpp
@@ -1,37 +1,30 @@
 #include "catch.hpp"
+#include "duckdb/common/allocator.hpp"
 #include "duckdb/common/types/blob.hpp"
 #include "duckdb/main/profiler/samply.hpp"
 #include "test_helpers.hpp"
-#include "utf8proc_wrapper.hpp"
 
 #include <fstream>
 
 using namespace duckdb;
 
-TEST_CASE("Samply markers are written in marker-file format", "[api][samply]") {
-	REQUIRE(SamplyQueryMarkerName("  SELECT\n  42;\t") == "Query: SELECT 42;");
-	REQUIRE(SamplyQueryMarkerName(" \n\t ") == "Query: <empty>");
-
-	auto long_query = StringUtil::Repeat("x", 501);
-	REQUIRE(SamplyQueryMarkerName(long_query) == "Query: " + StringUtil::Repeat("x", 499) + "…");
-	auto unicode_query_name = SamplyQueryMarkerName(StringUtil::Repeat("é", 450));
-	REQUIRE(Utf8Proc::IsValid(unicode_query_name.c_str(), unicode_query_name.size()));
-	REQUIRE(StringUtil::EndsWith(unicode_query_name, "…"));
-
-	auto directory = TestCreatePath("samply_markers");
+TEST_CASE("Samply query profiles are written in query sidecar format", "[api][samply]") {
+	auto directory = TestCreatePath("samply_query_profiles");
 	TestCreateDirectory(directory);
+	string path;
+	{
+		SamplyQueryWriter writer(directory.c_str());
+		REQUIRE(writer.WriteProfile(1000, 250, "{\"query\":{\"sql\":\"SELECT 42\"}}"));
+		path = writer.GetPath();
+	}
 
-	SamplyMarkerWriter writer(directory.c_str());
-	REQUIRE(writer.WriteMarker(10, 20, SamplyQueryMarkerName("SELECT 42;").c_str()));
-	REQUIRE(writer.WriteMarker(30, 40, "Pipeline 2: TABLE_SCAN[source] → HASH_JOIN[build]"));
-
-	string path = writer.GetPath();
-	REQUIRE(StringUtil::Contains(path, "/marker-"));
-	REQUIRE(StringUtil::EndsWith(path, ".txt"));
-
-	std::ifstream marker_file(path);
-	string contents((std::istreambuf_iterator<char>(marker_file)), std::istreambuf_iterator<char>());
-	REQUIRE(contents == "10 20 Query: SELECT 42;\n30 40 Pipeline 2: TABLE_SCAN[source] → HASH_JOIN[build]\n");
+	REQUIRE(StringUtil::Contains(path, "/query-"));
+	REQUIRE(StringUtil::EndsWith(path, ".jsonl"));
+	std::ifstream query_file(path);
+	string contents((std::istreambuf_iterator<char>(query_file)), std::istreambuf_iterator<char>());
+	REQUIRE(
+	    contents ==
+	    "{\"version\":1,\"start_unix_ns\":1000,\"duration_ns\":250,\"profile\":{\"query\":{\"sql\":\"SELECT 42\"}}}\n");
 }
 
 TEST_CASE("Samply counters are buffered and flushed in counter-file format", "[api][samply]") {
@@ -42,9 +35,9 @@ TEST_CASE("Samply counters are buffered and flushed in counter-file format", "[a
 		SamplyCounterWriter writer(directory.c_str());
 		REQUIRE(writer.WriteClock(100, 1000));
 		REQUIRE(writer.WriteClock(200, 2000));
-		REQUIRE(writer.WriteSample(110, "rss", 4096));
-		REQUIRE(writer.WriteSample(120, "network-rx", 50));
-		REQUIRE(writer.WriteSample(120, "network-tx", 25));
+		REQUIRE(writer.WriteSample(110, "tracked-memory", 4096));
+		REQUIRE(writer.WriteSample(120, "http-download", 50));
+		REQUIRE(writer.WriteSample(120, "http-upload", 25));
 		path = writer.GetPath();
 
 		std::ifstream before_flush(path);
@@ -54,7 +47,18 @@ TEST_CASE("Samply counters are buffered and flushed in counter-file format", "[a
 
 	std::ifstream counter_file(path);
 	string contents((std::istreambuf_iterator<char>(counter_file)), std::istreambuf_iterator<char>());
-	REQUIRE(contents == "clock 100 1000\n110 rss 4096\n120 network-rx 50\n120 network-tx 25\n");
+	REQUIRE(contents == "clock 100 1000\n110 tracked-memory 4096\n120 http-download 50\n120 http-upload 25\n");
+}
+
+TEST_CASE("DuckDB allocator reports tracked memory", "[api][samply]") {
+	Allocator allocator;
+	auto baseline = Allocator::GetTrackedMemory();
+	auto pointer = allocator.AllocateData(64);
+	REQUIRE(Allocator::GetTrackedMemory() == baseline + 64);
+	pointer = allocator.ReallocateData(pointer, 64, 96);
+	REQUIRE(Allocator::GetTrackedMemory() == baseline + 96);
+	allocator.FreeData(pointer, 96);
+	REQUIRE(Allocator::GetTrackedMemory() == baseline);
 }
 
 TEST_CASE("Samply HTTP attempts are written in HTTP sidecar format", "[api][samply]") {
@@ -119,8 +123,8 @@ TEST_CASE("Samply resources receive a final sample when deactivated", "[api][sam
 	auto lines = StringUtil::Split(contents, '\n');
 	REQUIRE(lines.size() == 4);
 	REQUIRE(StringUtil::StartsWith(lines[0], "clock "));
-	REQUIRE(StringUtil::Contains(lines[1], " rss "));
-	REQUIRE(StringUtil::Contains(lines[2], " network-rx "));
-	REQUIRE(StringUtil::Contains(lines[3], " network-tx "));
+	REQUIRE(StringUtil::Contains(lines[1], " tracked-memory "));
+	REQUIRE(StringUtil::Contains(lines[2], " http-download "));
+	REQUIRE(StringUtil::Contains(lines[3], " http-upload "));
 }
 #endif

--- a/test/api/test_samply.cpp
+++ b/test/api/test_samply.cpp
@@ -1,4 +1,5 @@
 #include "catch.hpp"
+#include "duckdb/common/types/blob.hpp"
 #include "duckdb/main/profiler/samply.hpp"
 #include "test_helpers.hpp"
 #include "utf8proc_wrapper.hpp"
@@ -56,7 +57,46 @@ TEST_CASE("Samply counters are buffered and flushed in counter-file format", "[a
 	REQUIRE(contents == "clock 100 1000\n110 rss 4096\n120 network-rx 50\n120 network-tx 25\n");
 }
 
+TEST_CASE("Samply HTTP attempts are written in HTTP sidecar format", "[api][samply]") {
+	auto directory = TestCreatePath("samply_http");
+	TestCreateDirectory(directory);
+	string path;
+	{
+		SamplyHTTPWriter writer(directory.c_str());
+		REQUIRE(writer.WriteAttempt(1000000000, 25000000, "GET", "https://example.com/file.parquet", 206, 4096, 5000000,
+		                            "bytes=100-4195", "bytes 100-4195/10000"));
+		path = writer.GetPath();
+	}
+
+	REQUIRE(StringUtil::Contains(path, "/http-"));
+	REQUIRE(StringUtil::EndsWith(path, ".txt"));
+	std::ifstream http_file(path);
+	string contents((std::istreambuf_iterator<char>(http_file)), std::istreambuf_iterator<char>());
+	StringUtil::RTrim(contents);
+	auto fields = StringUtil::Split(contents, '\t');
+	REQUIRE(fields.size() == 10);
+	REQUIRE(fields[0] == "1");
+	REQUIRE(fields[1] == "1000000000");
+	REQUIRE(fields[2] == "25000000");
+	REQUIRE(fields[3] == "206");
+	REQUIRE(fields[4] == "4096");
+	REQUIRE(fields[5] == "5000000");
+	REQUIRE(fields[6] == "GET");
+	REQUIRE(fields[7] == Blob::ToBase64("https://example.com/file.parquet"));
+	REQUIRE(fields[8] == Blob::ToBase64("bytes=100-4195"));
+	REQUIRE(fields[9] == Blob::ToBase64("bytes 100-4195/10000"));
+}
+
 #if defined(__linux__) || defined(__APPLE__)
+TEST_CASE("Samply HTTP tracking follows subscription lifetime", "[api][samply]") {
+	REQUIRE_FALSE(SamplyHTTPTrackEnabled());
+	auto subscription = StartSamplyResourceSampling(static_cast<uint8_t>(SamplyTrack::HTTP));
+	REQUIRE(subscription);
+	REQUIRE(SamplyHTTPTrackEnabled());
+	subscription.reset();
+	REQUIRE_FALSE(SamplyHTTPTrackEnabled());
+}
+
 TEST_CASE("Samply resources receive a final sample when deactivated", "[api][samply]") {
 	auto directory = TestCreatePath("samply_final_resources");
 	TestCreateDirectory(directory);

--- a/test/api/test_samply.cpp
+++ b/test/api/test_samply.cpp
@@ -1,17 +1,27 @@
 #include "catch.hpp"
 #include "duckdb/main/profiler/samply.hpp"
 #include "test_helpers.hpp"
+#include "utf8proc_wrapper.hpp"
 
 #include <fstream>
 
 using namespace duckdb;
 
 TEST_CASE("Samply markers are written in marker-file format", "[api][samply]") {
+	REQUIRE(SamplyQueryMarkerName("  SELECT\n  42;\t") == "Query: SELECT 42;");
+	REQUIRE(SamplyQueryMarkerName(" \n\t ") == "Query: <empty>");
+
+	auto long_query = StringUtil::Repeat("x", 501);
+	REQUIRE(SamplyQueryMarkerName(long_query) == "Query: " + StringUtil::Repeat("x", 499) + "…");
+	auto unicode_query_name = SamplyQueryMarkerName(StringUtil::Repeat("é", 450));
+	REQUIRE(Utf8Proc::IsValid(unicode_query_name.c_str(), unicode_query_name.size()));
+	REQUIRE(StringUtil::EndsWith(unicode_query_name, "…"));
+
 	auto directory = TestCreatePath("samply_markers");
 	TestCreateDirectory(directory);
 
 	SamplyMarkerWriter writer(directory.c_str());
-	REQUIRE(writer.WriteMarker(10, 20, "query.total_time"));
+	REQUIRE(writer.WriteMarker(10, 20, SamplyQueryMarkerName("SELECT 42;").c_str()));
 	REQUIRE(writer.WriteMarker(30, 40, "Pipeline 2: TABLE_SCAN[source] → HASH_JOIN[build]"));
 
 	string path = writer.GetPath();
@@ -20,5 +30,5 @@ TEST_CASE("Samply markers are written in marker-file format", "[api][samply]") {
 
 	std::ifstream marker_file(path);
 	string contents((std::istreambuf_iterator<char>(marker_file)), std::istreambuf_iterator<char>());
-	REQUIRE(contents == "10 20 query.total_time\n30 40 Pipeline 2: TABLE_SCAN[source] → HASH_JOIN[build]\n");
+	REQUIRE(contents == "10 20 Query: SELECT 42;\n30 40 Pipeline 2: TABLE_SCAN[source] → HASH_JOIN[build]\n");
 }

--- a/test/api/test_samply.cpp
+++ b/test/api/test_samply.cpp
@@ -1,0 +1,24 @@
+#include "catch.hpp"
+#include "duckdb/main/profiler/samply.hpp"
+#include "test_helpers.hpp"
+
+#include <fstream>
+
+using namespace duckdb;
+
+TEST_CASE("Samply markers are written in marker-file format", "[api][samply]") {
+	auto directory = TestCreatePath("samply_markers");
+	TestCreateDirectory(directory);
+
+	SamplyMarkerWriter writer(directory.c_str());
+	REQUIRE(writer.WriteMarker(10, 20, "query.total_time"));
+	REQUIRE(writer.WriteMarker(30, 40, "Pipeline 2: TABLE_SCAN[source] → HASH_JOIN[build]"));
+
+	string path = writer.GetPath();
+	REQUIRE(StringUtil::Contains(path, "/marker-"));
+	REQUIRE(StringUtil::EndsWith(path, ".txt"));
+
+	std::ifstream marker_file(path);
+	string contents((std::istreambuf_iterator<char>(marker_file)), std::istreambuf_iterator<char>());
+	REQUIRE(contents == "10 20 query.total_time\n30 40 Pipeline 2: TABLE_SCAN[source] → HASH_JOIN[build]\n");
+}

--- a/test/api/test_samply.cpp
+++ b/test/api/test_samply.cpp
@@ -32,3 +32,55 @@ TEST_CASE("Samply markers are written in marker-file format", "[api][samply]") {
 	string contents((std::istreambuf_iterator<char>(marker_file)), std::istreambuf_iterator<char>());
 	REQUIRE(contents == "10 20 Query: SELECT 42;\n30 40 Pipeline 2: TABLE_SCAN[source] → HASH_JOIN[build]\n");
 }
+
+TEST_CASE("Samply counters are buffered and flushed in counter-file format", "[api][samply]") {
+	auto directory = TestCreatePath("samply_counters");
+	TestCreateDirectory(directory);
+	string path;
+	{
+		SamplyCounterWriter writer(directory.c_str());
+		REQUIRE(writer.WriteClock(100, 1000));
+		REQUIRE(writer.WriteClock(200, 2000));
+		REQUIRE(writer.WriteSample(110, "rss", 4096));
+		REQUIRE(writer.WriteSample(120, "network-rx", 50));
+		REQUIRE(writer.WriteSample(120, "network-tx", 25));
+		path = writer.GetPath();
+
+		std::ifstream before_flush(path);
+		string buffered_contents((std::istreambuf_iterator<char>(before_flush)), std::istreambuf_iterator<char>());
+		REQUIRE(buffered_contents.empty());
+	}
+
+	std::ifstream counter_file(path);
+	string contents((std::istreambuf_iterator<char>(counter_file)), std::istreambuf_iterator<char>());
+	REQUIRE(contents == "clock 100 1000\n110 rss 4096\n120 network-rx 50\n120 network-tx 25\n");
+}
+
+#if defined(__linux__) || defined(__APPLE__)
+TEST_CASE("Samply resources receive a final sample when deactivated", "[api][samply]") {
+	auto directory = TestCreatePath("samply_final_resources");
+	TestCreateDirectory(directory);
+	auto tracks = static_cast<uint8_t>(SamplyTrack::MEMORY) | static_cast<uint8_t>(SamplyTrack::NETWORK);
+	auto subscription = StartSamplyResourceSamplingForTesting(tracks, directory.c_str());
+	REQUIRE(subscription);
+	subscription.reset();
+
+	auto file_system = FileSystem::CreateLocal();
+	string counter_path;
+	file_system->ListFiles(directory, [&](const string &path, bool is_directory) {
+		if (!is_directory && StringUtil::StartsWith(path, "counter-") && StringUtil::EndsWith(path, ".txt")) {
+			counter_path = file_system->JoinPath(directory, path);
+		}
+	});
+	REQUIRE(!counter_path.empty());
+
+	std::ifstream counter_file(counter_path);
+	string contents((std::istreambuf_iterator<char>(counter_file)), std::istreambuf_iterator<char>());
+	auto lines = StringUtil::Split(contents, '\n');
+	REQUIRE(lines.size() == 4);
+	REQUIRE(StringUtil::StartsWith(lines[0], "clock "));
+	REQUIRE(StringUtil::Contains(lines[1], " rss "));
+	REQUIRE(StringUtil::Contains(lines[2], " network-rx "));
+	REQUIRE(StringUtil::Contains(lines[3], " network-tx "));
+}
+#endif

--- a/test/sql/pragma/profiling/test_samply_markers.test
+++ b/test/sql/pragma/profiling/test_samply_markers.test
@@ -133,12 +133,14 @@ SET samply_tracks = 'query,';
 ----
 empty track
 
-# Query tracking retains the existing query profiler and marker behavior.
-statement ok
-PRAGMA profiling_output = '{TEST_DIR}/samply_profile.txt';
-
+# Query tracking gathers internal profile data without enabling normal profiler output.
 statement ok
 SET samply_tracks = 'query';
+
+query II
+SELECT current_setting('samply_tracks'), current_setting('enable_profiling');
+----
+query	NULL
 
 statement ok
 CREATE TABLE build_side AS SELECT i FROM range(10) t(i);
@@ -153,11 +155,6 @@ SELECT count(*) FROM probe_side JOIN build_side USING (i);
 
 statement ok
 SET samply_tracks = 'none';
-
-query I
-SELECT contains(content, 'Hash Join') FROM read_text('{TEST_DIR}/samply_profile.txt');
-----
-true
 
 statement ok
 SET enable_profiling = 'json';

--- a/test/sql/pragma/profiling/test_samply_markers.test
+++ b/test/sql/pragma/profiling/test_samply_markers.test
@@ -1,0 +1,63 @@
+# name: test/sql/pragma/profiling/test_samply_markers.test
+# description: Test Samply marker profiling setting
+# group: [profiling]
+
+require notwindows
+
+statement ok
+PRAGMA profiling_output = '{TEST_DIR}/samply_profile.txt';
+
+query I
+SELECT current_setting('enable_samply_markers');
+----
+false
+
+statement ok
+PRAGMA enable_samply_markers;
+
+query I
+SELECT current_setting('enable_samply_markers');
+----
+true
+
+statement ok
+CREATE TABLE build_side AS SELECT i FROM range(10) t(i);
+
+statement ok
+CREATE TABLE probe_side AS SELECT i FROM range(20) t(i);
+
+query I
+SELECT count(*) FROM probe_side JOIN build_side USING (i);
+----
+10
+
+statement ok
+PRAGMA disable_samply_markers;
+
+query I
+SELECT current_setting('enable_samply_markers');
+----
+false
+
+# Enabling Samply markers also produced the normal query profile for the join.
+query I
+SELECT contains(content, 'Hash Join') FROM read_text('{TEST_DIR}/samply_profile.txt');
+----
+true
+
+statement ok
+SET enable_profiling = 'json';
+
+statement ok
+SET enable_samply_markers = true;
+
+statement ok
+RESET enable_samply_markers;
+
+query II
+SELECT current_setting('enable_samply_markers'), current_setting('enable_profiling');
+----
+false	json
+
+statement ok
+RESET enable_profiling;

--- a/test/sql/pragma/profiling/test_samply_markers.test
+++ b/test/sql/pragma/profiling/test_samply_markers.test
@@ -1,24 +1,128 @@
 # name: test/sql/pragma/profiling/test_samply_markers.test
-# description: Test Samply marker profiling setting
+# description: Test Samply query and resource track settings
 # group: [profiling]
 
 require notwindows
 
+query I
+SELECT current_setting('samply_tracks');
+----
+none
+
+statement ok
+SET samply_tracks = '';
+
+query I
+SELECT current_setting('samply_tracks');
+----
+all
+
+statement ok
+SET samply_tracks = '   ';
+
+query I
+SELECT current_setting('samply_tracks');
+----
+all
+
+statement ok
+SET samply_tracks = 'query';
+
+query I
+SELECT current_setting('samply_tracks');
+----
+query
+
+statement ok
+SET samply_tracks = 'memory';
+
+query II
+SELECT current_setting('samply_tracks'), current_setting('enable_profiling');
+----
+memory	NULL
+
+statement ok
+SET samply_tracks = 'network';
+
+query I
+SELECT current_setting('samply_tracks');
+----
+network
+
+statement ok
+SET samply_tracks = ' NETWORK , QUERY , memory ';
+
+query I
+SELECT current_setting('samply_tracks');
+----
+all
+
+statement ok
+SET samply_tracks = 'network,query';
+
+query I
+SELECT current_setting('samply_tracks');
+----
+query,network
+
+statement ok
+SET samply_tracks = 'memory,query';
+
+query I
+SELECT current_setting('samply_tracks');
+----
+query,memory
+
+statement ok
+SET samply_tracks = 'memory,network';
+
+query I
+SELECT current_setting('samply_tracks');
+----
+memory,network
+
+statement ok
+SET samply_tracks = 'all';
+
+query I
+SELECT current_setting('samply_tracks');
+----
+all
+
+statement ok
+SET samply_tracks = 'none';
+
+query I
+SELECT current_setting('samply_tracks');
+----
+none
+
+statement error
+SET samply_tracks = 'cpu';
+----
+Unknown Samply track
+
+statement error
+SET samply_tracks = 'none,query';
+----
+cannot be combined
+
+statement error
+SET samply_tracks = 'all,memory';
+----
+cannot be combined
+
+statement error
+SET samply_tracks = 'query,';
+----
+empty track
+
+# Query tracking retains the existing query profiler and marker behavior.
 statement ok
 PRAGMA profiling_output = '{TEST_DIR}/samply_profile.txt';
 
-query I
-SELECT current_setting('enable_samply_markers');
-----
-false
-
 statement ok
-PRAGMA enable_samply_markers;
-
-query I
-SELECT current_setting('enable_samply_markers');
-----
-true
+SET samply_tracks = 'query';
 
 statement ok
 CREATE TABLE build_side AS SELECT i FROM range(10) t(i);
@@ -32,14 +136,8 @@ SELECT count(*) FROM probe_side JOIN build_side USING (i);
 10
 
 statement ok
-PRAGMA disable_samply_markers;
+SET samply_tracks = 'none';
 
-query I
-SELECT current_setting('enable_samply_markers');
-----
-false
-
-# Enabling Samply markers also produced the normal query profile for the join.
 query I
 SELECT contains(content, 'Hash Join') FROM read_text('{TEST_DIR}/samply_profile.txt');
 ----
@@ -49,15 +147,15 @@ statement ok
 SET enable_profiling = 'json';
 
 statement ok
-SET enable_samply_markers = true;
+SET samply_tracks = 'all';
 
 statement ok
-RESET enable_samply_markers;
+RESET samply_tracks;
 
 query II
-SELECT current_setting('enable_samply_markers'), current_setting('enable_profiling');
+SELECT current_setting('samply_tracks'), current_setting('enable_profiling');
 ----
-false	json
+none	json
 
 statement ok
 RESET enable_profiling;

--- a/test/sql/pragma/profiling/test_samply_markers.test
+++ b/test/sql/pragma/profiling/test_samply_markers.test
@@ -50,7 +50,15 @@ SELECT current_setting('samply_tracks');
 network
 
 statement ok
-SET samply_tracks = ' NETWORK , QUERY , memory ';
+SET samply_tracks = 'http';
+
+query I
+SELECT current_setting('samply_tracks');
+----
+http
+
+statement ok
+SET samply_tracks = ' NETWORK , QUERY , memory, HTTP ';
 
 query I
 SELECT current_setting('samply_tracks');
@@ -80,6 +88,14 @@ query I
 SELECT current_setting('samply_tracks');
 ----
 memory,network
+
+statement ok
+SET samply_tracks = 'http,network';
+
+query I
+SELECT current_setting('samply_tracks');
+----
+network,http
 
 statement ok
 SET samply_tracks = 'all';

--- a/tools/shell/CMakeLists.txt
+++ b/tools/shell/CMakeLists.txt
@@ -85,6 +85,22 @@ set_target_properties(shell PROPERTIES OUTPUT_NAME duckdb)
 set_target_properties(shell PROPERTIES RUNTIME_OUTPUT_DIRECTORY
                                        ${PROJECT_BINARY_DIR})
 
+if(NOT WIN32)
+  configure_file("${PROJECT_SOURCE_DIR}/scripts/samply_profile_launcher.py.in"
+                 "${PROJECT_BINARY_DIR}/profile" @ONLY)
+  file(
+    CHMOD
+    "${PROJECT_BINARY_DIR}/profile"
+    PERMISSIONS
+    OWNER_READ
+    OWNER_WRITE
+    OWNER_EXECUTE
+    GROUP_READ
+    GROUP_EXECUTE
+    WORLD_READ
+    WORLD_EXECUTE)
+endif()
+
 duckdb_codesign_for_debugging(shell)
 
 install(TARGETS shell RUNTIME DESTINATION "${INSTALL_BIN_DIR}")


### PR DESCRIPTION
### Context

I added network throughput, memory usage (RSS), and individual HTTP requests to samply's profiler output so we can interactively explore how duckdb uses system resources.

<img width="1490" height="826" alt="Screenshot 2026-08-07 at 16 13 42" src="https://github.com/user-attachments/assets/cdaf645e-4dde-42ea-9f62-039707ea4d79" />

I used this sql:
```sql
SET samply_tracks = 'all';

SELECT count(*)
FROM 'https://blobs.duckdb.org/data/taxi_2019_04.parquet'
WHERE pickup_at BETWEEN '2019-04-15' AND '2019-04-20';
```
for that screenshot, and the profile can be viewed online: https://share.firefox.dev/4waiAr9

the data is injected into the profile after samply is done. There is no "dependency" on samply to make this work in duckdb core.

i've also added "markers" for the queries, their plan/execute phases and pipelines (based on the existing duckdb profiler data),  and the network requests.

<img width="1483" height="598" alt="image" src="https://github.com/user-attachments/assets/561a6907-9132-4aa2-8fe6-046663a5648d" />

### Usage

```shell
build/release/profile -f taxi.sql
```

### TODO
- [ ] Rebase and resolve conflicts.
- [ ] Verify network and memory track values.
- [ ] Verify http requests timeline.