### PR TITLE
Use foreign keys to prune NOT IN joins

### DIFF
--- a/src/optimizer/pushdown/pushdown_mark_join.cpp
+++ b/src/optimizer/pushdown/pushdown_mark_join.cpp
@@ -1,11 +1,159 @@
 #include "duckdb/optimizer/filter_pushdown.hpp"
+
+#include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
+#include "duckdb/parser/constraints/foreign_key_constraint.hpp"
+#include "duckdb/planner/expression/bound_columnref_expression.hpp"
+#include "duckdb/planner/expression/bound_conjunction_expression.hpp"
 #include "duckdb/planner/expression/bound_operator_expression.hpp"
 #include "duckdb/planner/expression_nullability.hpp"
 #include "duckdb/planner/operator/logical_comparison_join.hpp"
+#include "duckdb/planner/operator/logical_get.hpp"
+#include "duckdb/planner/operator/logical_projection.hpp"
 
 namespace duckdb {
 
 using Filter = FilterPushdown::Filter;
+
+struct BaseTableColumn {
+	optional_ptr<LogicalGet> get;
+	idx_t physical_index;
+};
+
+struct ForeignKeyJoinColumn {
+	ForeignKeyJoinColumn(idx_t foreign_key_index_p, idx_t primary_key_index_p)
+	    : foreign_key_index(foreign_key_index_p), primary_key_index(primary_key_index_p) {
+	}
+
+	idx_t foreign_key_index;
+	idx_t primary_key_index;
+};
+
+static bool GetBaseTableColumn(LogicalOperator &op, const Expression &expr, BaseTableColumn &result) {
+	if (expr.GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
+		return false;
+	}
+	auto &column_ref = expr.Cast<BoundColumnRefExpression>();
+	switch (op.type) {
+	case LogicalOperatorType::LOGICAL_PROJECTION: {
+		auto &projection = op.Cast<LogicalProjection>();
+		if (column_ref.Binding().table_index != projection.table_index) {
+			return false;
+		}
+		return GetBaseTableColumn(*projection.children[0], projection.GetExpression(column_ref.Binding()), result);
+	}
+	case LogicalOperatorType::LOGICAL_GET: {
+		auto &get = op.Cast<LogicalGet>();
+		if (column_ref.Binding().table_index != get.table_index) {
+			return false;
+		}
+		auto table = get.GetTable();
+		if (!table) {
+			return false;
+		}
+		auto &column_index = get.GetColumnIndex(column_ref.Binding());
+		if (!column_index.HasPrimaryIndex() || column_index.HasChildren() || column_index.IsVirtualColumn()) {
+			return false;
+		}
+		result.get = get;
+		result.physical_index = table->GetColumn(column_index.ToLogical()).Physical().index;
+		return true;
+	}
+	default:
+		return false;
+	}
+}
+
+static bool MatchesForeignKey(const ForeignKeyInfo &info, const TableCatalogEntry &fk_table,
+                              const TableCatalogEntry &pk_table, const vector<ForeignKeyJoinColumn> &join_columns) {
+	if (info.type != ForeignKeyType::FK_TYPE_FOREIGN_KEY_TABLE &&
+	    info.type != ForeignKeyType::FK_TYPE_SELF_REFERENCE_TABLE) {
+		return false;
+	}
+	if (&fk_table.ParentCatalog() != &pk_table.ParentCatalog() ||
+	    &fk_table.ParentSchema() != &pk_table.ParentSchema() || info.table != pk_table.name) {
+		return false;
+	}
+	if (info.fk_keys.size() != join_columns.size() || info.pk_keys.size() != join_columns.size()) {
+		return false;
+	}
+	vector<bool> matched(join_columns.size(), false);
+	for (idx_t key_idx = 0; key_idx < info.fk_keys.size(); ++key_idx) {
+		bool found = false;
+		for (idx_t join_idx = 0; join_idx < join_columns.size(); ++join_idx) {
+			if (matched[join_idx] || join_columns[join_idx].foreign_key_index != info.fk_keys[key_idx].index ||
+			    join_columns[join_idx].primary_key_index != info.pk_keys[key_idx].index) {
+				continue;
+			}
+			matched[join_idx] = true;
+			found = true;
+			break;
+		}
+		if (!found) {
+			return false;
+		}
+	}
+	return true;
+}
+
+static unique_ptr<Expression> CreateForeignKeyNullFilter(LogicalComparisonJoin &join) {
+	if (join.type != LogicalOperatorType::LOGICAL_COMPARISON_JOIN || join.conditions.empty()) {
+		return nullptr;
+	}
+	optional_ptr<LogicalGet> fk_get;
+	optional_ptr<LogicalGet> pk_get;
+	vector<ForeignKeyJoinColumn> join_columns;
+	join_columns.reserve(join.conditions.size());
+	for (const auto &condition : join.conditions) {
+		if (!condition.IsComparison() || condition.GetComparisonType() != ExpressionType::COMPARE_EQUAL) {
+			return nullptr;
+		}
+		BaseTableColumn fk_column;
+		BaseTableColumn pk_column;
+		if (!GetBaseTableColumn(*join.children[0], condition.GetLHS(), fk_column) ||
+		    !GetBaseTableColumn(*join.children[1], condition.GetRHS(), pk_column)) {
+			return nullptr;
+		}
+		if ((fk_get && fk_get != fk_column.get) || (pk_get && pk_get != pk_column.get)) {
+			return nullptr;
+		}
+		fk_get = fk_column.get;
+		pk_get = pk_column.get;
+		join_columns.emplace_back(/*foreign_key_index=*/fk_column.physical_index,
+		                          /*primary_key_index=*/pk_column.physical_index);
+	}
+	D_ASSERT(fk_get);
+	D_ASSERT(pk_get);
+	auto fk_table = fk_get->GetTable();
+	auto pk_table = pk_get->GetTable();
+	D_ASSERT(fk_table);
+	D_ASSERT(pk_table);
+	if (pk_get->table_filters.HasFilters()) {
+		return nullptr;
+	}
+	for (const auto &constraint : fk_table->GetConstraints()) {
+		if (constraint->type != ConstraintType::FOREIGN_KEY) {
+			continue;
+		}
+		const auto &foreign_key = constraint->Cast<ForeignKeyConstraint>();
+		if (!MatchesForeignKey(foreign_key.info, *fk_table, *pk_table, join_columns)) {
+			continue;
+		}
+		unique_ptr<Expression> result;
+		for (const auto &condition : join.conditions) {
+			auto is_null = make_uniq<BoundOperatorExpression>(ExpressionType::OPERATOR_IS_NULL,
+			                                                  LogicalType {LogicalTypeId::BOOLEAN});
+			is_null->GetChildrenMutable().push_back(condition.GetLHS().Copy());
+			if (!result) {
+				result = std::move(is_null);
+			} else {
+				result = make_uniq<BoundConjunctionExpression>(ExpressionType::CONJUNCTION_OR, std::move(result),
+				                                               std::move(is_null));
+			}
+		}
+		return result;
+	}
+	return nullptr;
+}
 
 static void SimplifyNullSafeSemiJoinConditions(ClientContext &context, LogicalComparisonJoin &join) {
 	D_ASSERT(join.join_type == JoinType::SEMI);
@@ -41,6 +189,7 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownMarkJoin(unique_ptr<LogicalO
 #ifdef DEBUG
 	bool simplified_mark_join = false;
 #endif
+	bool added_foreign_key_filter = false;
 	// now check the set of filters
 	for (idx_t i = 0; i < filters.size(); i++) {
 		auto side = JoinSide::GetJoinSide(filters[i]->bindings, left_bindings, right_bindings);
@@ -74,6 +223,16 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownMarkJoin(unique_ptr<LogicalO
 			if (filters[i]->filter->GetExpressionType() == ExpressionType::OPERATOR_NOT) {
 				auto &op_expr = filters[i]->filter->Cast<BoundOperatorExpression>();
 				if (op_expr.GetChildren()[0]->GetExpressionType() == ExpressionType::BOUND_COLUMN_REF) {
+					auto &marker = op_expr.GetChildren()[0]->Cast<BoundColumnRefExpression>();
+					if (!added_foreign_key_filter && marker.Binding().table_index == comp_join.mark_index) {
+						auto null_filter = CreateForeignKeyNullFilter(comp_join);
+						if (null_filter) {
+							auto filter = make_uniq<Filter>(std::move(null_filter));
+							filter->ExtractBindings();
+							left_pushdown.filters.push_back(std::move(filter));
+							added_foreign_key_filter = true;
+						}
+					}
 					// the filter is NOT(marker), check the join conditions
 					bool all_null_values_are_equal = true;
 					for (auto &cond : comp_join.conditions) {

--- a/src/optimizer/statistics/operator/propagate_join.cpp
+++ b/src/optimizer/statistics/operator/propagate_join.cpp
@@ -217,6 +217,10 @@ unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalJoin
 			MultiplyCardinalities(node_stats, *child_stats);
 		}
 	}
+	if (join.join_type == JoinType::MARK && join.children[0]->type == LogicalOperatorType::LOGICAL_EMPTY_RESULT) {
+		ReplaceWithEmptyResult(node_ptr);
+		return make_uniq<NodeStatistics>(0U, 0U);
+	}
 
 	auto join_type = join.join_type;
 	// depending on the join type, we might need to alter the statistics

--- a/test/sql/optimizer/foreign_key_not_in_pruning.test
+++ b/test/sql/optimizer/foreign_key_not_in_pruning.test
@@ -1,0 +1,116 @@
+# name: test/sql/optimizer/foreign_key_not_in_pruning.test
+# description: Use foreign keys to prune NOT IN probe rows
+# group: [optimizer]
+
+statement ok
+ATTACH '{TEST_DIR}/foreign_key_not_in.duckdb' AS db (ROW_GROUP_SIZE 2048);
+
+statement ok
+USE db;
+
+statement ok
+CREATE TABLE parent(id INTEGER PRIMARY KEY);
+
+statement ok
+CREATE TABLE child(pid INTEGER REFERENCES parent(id));
+
+statement ok
+INSERT INTO parent SELECT range::INTEGER FROM range(6144);
+
+statement ok
+INSERT INTO child SELECT range::INTEGER FROM range(6144);
+
+statement ok
+CHECKPOINT;
+
+query I
+SELECT count(*) FROM child WHERE pid NOT IN (SELECT id FROM parent);
+----
+0
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM child WHERE pid NOT IN (SELECT id FROM parent);
+----
+analyzed_plan	<REGEX>:.*Empty Result.*
+
+# A filtered or transformed referenced side does not preserve the foreign key guarantee
+query I
+SELECT count(*) FROM child WHERE pid NOT IN (SELECT id FROM parent WHERE id < 10);
+----
+6134
+
+query I
+SELECT count(*) FROM child WHERE pid NOT IN (SELECT id + 1 FROM parent);
+----
+1
+
+# A NULL foreign key passes NOT IN when the referenced table is empty
+statement ok
+CREATE TABLE empty_parent(id INTEGER PRIMARY KEY);
+
+statement ok
+CREATE TABLE nullable_child(pid INTEGER REFERENCES empty_parent(id));
+
+statement ok
+INSERT INTO nullable_child VALUES (NULL), (NULL);
+
+query I
+SELECT count(*) FROM nullable_child WHERE pid NOT IN (SELECT id FROM empty_parent);
+----
+2
+
+statement ok
+INSERT INTO empty_parent VALUES (1);
+
+query I
+SELECT count(*) FROM nullable_child WHERE pid NOT IN (SELECT id FROM empty_parent);
+----
+0
+
+# Without a foreign key, non-matching values must remain visible
+statement ok
+CREATE TABLE unrelated_parent(id INTEGER PRIMARY KEY);
+
+statement ok
+CREATE TABLE unrelated_child(pid INTEGER);
+
+statement ok
+INSERT INTO unrelated_parent VALUES (1);
+
+statement ok
+INSERT INTO unrelated_child VALUES (2);
+
+query I
+SELECT count(*) FROM unrelated_child WHERE pid NOT IN (SELECT id FROM unrelated_parent);
+----
+1
+
+# Composite foreign keys derive a disjunction of NULL checks
+statement ok
+CREATE TABLE composite_parent(a INTEGER, b INTEGER, PRIMARY KEY (a, b));
+
+statement ok
+CREATE TABLE composite_child(x INTEGER, y INTEGER, FOREIGN KEY (x, y) REFERENCES composite_parent(a, b));
+
+statement ok
+INSERT INTO composite_parent SELECT range::INTEGER, range::INTEGER FROM range(6144);
+
+statement ok
+INSERT INTO composite_child SELECT range::INTEGER, range::INTEGER FROM range(6144);
+
+statement ok
+CHECKPOINT;
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM composite_child
+WHERE (x, y) NOT IN (SELECT a, b FROM composite_parent);
+----
+analyzed_plan	<REGEX>:.*Empty Result.*
+
+statement ok
+INSERT INTO composite_child VALUES (NULL, -1);
+
+query I
+SELECT count(*) FROM composite_child WHERE (x, y) NOT IN (SELECT a, b FROM composite_parent);
+----
+1


### PR DESCRIPTION
## Summary

Resolves #24415

Queries such as `child.pid NOT IN (SELECT parent.id FROM parent)` are planned as MARK joins and currently scan both tables even when an enforced foreign key guarantees that every non-NULL probe key exists on the referenced side. This change detects equality MARK joins that exactly cover a foreign key whose referenced-side scan is unfiltered and derives an `IS NULL` probe filter, while retaining the original MARK join to preserve SQL NULL semantics. Statistics can then prune non-NULL row groups; if the probe side becomes empty, the optimizer collapses the MARK join so the referenced table is not scanned.

## Results

```sql
CREATE TABLE parent(id INTEGER PRIMARY KEY);
CREATE TABLE child(pid INTEGER REFERENCES parent(id));
INSERT INTO parent SELECT range::INTEGER FROM range(6144);
INSERT INTO child SELECT range::INTEGER FROM range(6144);
CHECKPOINT;

EXPLAIN ANALYZE
SELECT count(*)
FROM child
WHERE pid NOT IN (SELECT id FROM parent);
```

### Before

```SQL
╭─ Summary ───────────╮
│ Total Time: 0.0009s │
╰─────────────────────╯
╭─ Ungrouped Aggregate ─────╮
│ Aggregates: count_star()  │
│ 1 row                 0µs │
╰─────────────┬─────────────╯
╭─ Filter ────┴─────────────╮
│ Expression: NOT SUBQUERY  │
│ 0 rows                0µs │
╰─────────────┒┎────────────╯
╭─ Hash Join ─┚┖────────────╮
│ Join Type: MARK           │
│ Conditions: pid = #0      │
│ 6,144 rows            0µs │
╰─────────────┰┰────────────╯
              ┃┠─────────────────────────────┰┒
╭─ Table Scan ┚┖────────────╮  ╭─ Table Scan ┚┖────────────╮
│ Table: memory.main.child  │  │ Table: memory.main.parent │
│ Type: Sequential Scan     │  │ Type: Sequential Scan     │
│ Projections: pid          │  │ Projections: id           │
│ Row Groups Scanned: 1 / 1 │  │ Row Groups Scanned: 1 / 1 │
│ 6,144 rows            0µs │  │ 6,144 rows            0µs │
╰───────────────────────────╯  ╰───────────────────────────╯
```

### After

```SQL
╭─ Summary ───────────╮
│ Total Time: 0.0006s │
╰─────────────────────╯
╭─ Ungrouped Aggregate ────╮
│ Aggregates: count_star() │
│ 1 row                0µs │
╰─────────────┬────────────╯
╭─ Empty Result ───────────╮
│ 0 rows               0µs │
╰──────────────────────────╯
```
