### PR TITLE
Clean up orphaned temp spill files on startup after a crash

### DIFF
--- a/src/include/duckdb/storage/temporary_file_manager.hpp
+++ b/src/include/duckdb/storage/temporary_file_manager.hpp
@@ -263,7 +263,8 @@ class TemporaryFileManager {
 	friend class TemporaryFileHandle;
 
 public:
-	TemporaryFileManager(DatabaseInstance &db, const string &temp_directory_p, atomic<idx_t> &size_on_disk);
+	TemporaryFileManager(DatabaseInstance &db, const string &temp_directory_p, const string &temporary_file_identifier_p,
+	                     atomic<idx_t> &size_on_disk);
 	~TemporaryFileManager();
 
 private:
@@ -291,6 +292,8 @@ public:
 
 	//! Get the list of temporary files and their sizes
 	vector<TemporaryFileInformation> GetTemporaryFiles();
+	//! Create the path for a variable-size temporary block
+	string CreateTemporaryBlockFileName(block_id_t id) const;
 
 	//! Get/set maximum swap space
 	optional_idx GetMaxSwapSpace() const;
@@ -326,6 +329,8 @@ private:
 	DatabaseInstance &db;
 	//! The temporary directory
 	string temp_directory;
+	//! Identifier shared by all temporary files owned by this instance
+	string temporary_file_identifier;
 	//! Lock for parallel access
 	mutex manager_lock;
 	//! The set of active temporary file handles
@@ -359,7 +364,9 @@ public:
 private:
 	DatabaseInstance &db;
 	string temp_directory;
+	string temporary_file_identifier;
 	bool created_directory = false;
+	unique_ptr<FileHandle> ownership_lock;
 	unique_ptr<TemporaryFileManager> temp_file;
 };
 

--- a/src/include/duckdb/storage/temporary_file_manager.hpp
+++ b/src/include/duckdb/storage/temporary_file_manager.hpp
@@ -263,8 +263,8 @@ class TemporaryFileManager {
 	friend class TemporaryFileHandle;
 
 public:
-	TemporaryFileManager(DatabaseInstance &db, const string &temp_directory_p, const string &temporary_file_identifier_p,
-	                     atomic<idx_t> &size_on_disk);
+	TemporaryFileManager(DatabaseInstance &db, const string &temp_directory_p,
+	                     const string &temporary_file_identifier_p, atomic<idx_t> &size_on_disk);
 	~TemporaryFileManager();
 
 private:

--- a/src/storage/standard_buffer_manager.cpp
+++ b/src/storage/standard_buffer_manager.cpp
@@ -477,8 +477,8 @@ vector<MemoryInformation> StandardBufferManager::GetMemoryUsageInfo() const {
 }
 
 string StandardBufferManager::GetTemporaryPath(block_id_t id) {
-	auto &fs = FileSystem::GetFileSystem(db);
-	return fs.JoinPath(temporary_directory.path, "duckdb_temp_block-" + to_string(id) + ".block");
+	D_ASSERT(temporary_directory.handle);
+	return temporary_directory.handle->GetTempFile().CreateTemporaryBlockFileName(id);
 }
 
 void StandardBufferManager::RequireTemporaryDirectory() {

--- a/src/storage/temporary_file_manager.cpp
+++ b/src/storage/temporary_file_manager.cpp
@@ -744,6 +744,25 @@ TemporaryDirectoryHandle::TemporaryDirectoryHandle(DatabaseInstance &db, string 
 	if (!fs.DirectoryExists(temp_directory)) {
 		fs.CreateDirectory(temp_directory);
 		created_directory = true;
+	} else {
+		// the directory already existed. This can happen if a previous DuckDB process using this
+		// temp directory crashed (e.g. kill -9, OOM kill, power loss) without running its destructors.
+		// any duckdb_temp_* files left behind are orphaned: no live process holds them open, and the
+		// block ids they reference are meaningless to this new process. Remove them before we start
+		// writing new files of our own, so garbage doesn't accumulate indefinitely across crashes.
+		vector<string> orphaned_files;
+		fs.ListFiles(temp_directory, [&](const string &path, bool isdir) {
+			if (isdir) {
+				return;
+			}
+			if (!StringUtil::StartsWith(path, "duckdb_temp_")) {
+				return;
+			}
+			orphaned_files.push_back(fs.JoinPath(temp_directory, path));
+		});
+		if (!orphaned_files.empty()) {
+			fs.RemoveFiles(orphaned_files);
+		}
 	}
 	temp_file->SetMaxSwapSpace(max_swap_space);
 }

--- a/src/storage/temporary_file_manager.cpp
+++ b/src/storage/temporary_file_manager.cpp
@@ -10,7 +10,18 @@
 #include "duckdb/common/encryption_functions.hpp"
 #include "zstd.h"
 
+#include <algorithm>
+
 namespace duckdb {
+
+static mutex temporary_file_ownership_lock;
+static vector<string> live_temporary_file_identifiers;
+
+static bool IsLiveTemporaryFileIdentifier(const string &identifier) {
+	lock_guard<mutex> guard(temporary_file_ownership_lock);
+	return std::find(live_temporary_file_identifiers.begin(), live_temporary_file_identifiers.end(), identifier) !=
+	       live_temporary_file_identifiers.end();
+}
 
 //===--------------------------------------------------------------------===//
 // TemporaryBufferSize
@@ -492,8 +503,9 @@ void TemporaryFileCompressionAdaptivity::Update(const TemporaryCompressionLevel 
 // TemporaryFileManager
 //===--------------------------------------------------------------------===//
 TemporaryFileManager::TemporaryFileManager(DatabaseInstance &db, const string &temp_directory_p,
-                                           atomic<idx_t> &size_on_disk_p)
-    : db(db), temp_directory(temp_directory_p), files(*this), size_on_disk(size_on_disk_p), max_swap_space(0) {
+                                           const string &temporary_file_identifier_p, atomic<idx_t> &size_on_disk_p)
+    : db(db), temp_directory(temp_directory_p), temporary_file_identifier(temporary_file_identifier_p), files(*this),
+      size_on_disk(size_on_disk_p), max_swap_space(0) {
 }
 
 TemporaryFileManager::~TemporaryFileManager() {
@@ -711,8 +723,13 @@ void TemporaryFileManager::EraseUsedBlock(TemporaryFileManagerLock &lock, block_
 
 string TemporaryFileManager::CreateTemporaryFileName(const TemporaryFileIdentifier &identifier) const {
 	return FileSystem::GetFileSystem(db).JoinPath(
-	    temp_directory, StringUtil::Format("duckdb_temp_storage_%s-%llu.tmp", EnumUtil::ToString(identifier.size),
-	                                       identifier.file_index.GetIndex()));
+	    temp_directory, StringUtil::Format("duckdb_temp_storage_%s_%s-%llu.tmp", temporary_file_identifier,
+	                                       EnumUtil::ToString(identifier.size), identifier.file_index.GetIndex()));
+}
+
+string TemporaryFileManager::CreateTemporaryBlockFileName(block_id_t id) const {
+	return FileSystem::GetFileSystem(db).JoinPath(
+	    temp_directory, StringUtil::Format("duckdb_temp_block_%s-%lld.block", temporary_file_identifier, id));
 }
 
 optional_ptr<TemporaryFileHandle> TemporaryFileManager::GetFileHandle(TemporaryFileManagerLock &,
@@ -737,70 +754,74 @@ void TemporaryFileManager::EraseFileHandle(TemporaryFileManagerLock &, const Tem
 //===--------------------------------------------------------------------===//
 TemporaryDirectoryHandle::TemporaryDirectoryHandle(DatabaseInstance &db, string path_p, atomic<idx_t> &size_on_disk,
                                                    optional_idx max_swap_space)
-    : db(db), temp_directory(std::move(path_p)),
-      temp_file(make_uniq<TemporaryFileManager>(db, temp_directory, size_on_disk)) {
+    : db(db), temp_directory(std::move(path_p)), temporary_file_identifier(StringUtil::GenerateRandomName()),
+      temp_file(make_uniq<TemporaryFileManager>(db, temp_directory, temporary_file_identifier, size_on_disk)) {
 	auto &fs = FileSystem::GetFileSystem(db);
 	D_ASSERT(!temp_directory.empty());
 	if (!fs.DirectoryExists(temp_directory)) {
 		fs.CreateDirectory(temp_directory);
 		created_directory = true;
-	} else {
-		// the directory already existed. This can happen if a previous DuckDB process using this
-		// temp directory crashed (e.g. kill -9, OOM kill, power loss) without running its destructors.
-		// any duckdb_temp_* files left behind are orphaned: no live process holds them open, and the
-		// block ids they reference are meaningless to this new process. Remove them before we start
-		// writing new files of our own, so garbage doesn't accumulate indefinitely across crashes.
-		vector<string> orphaned_files;
-		fs.ListFiles(temp_directory, [&](const string &path, bool isdir) {
-			if (isdir) {
-				return;
-			}
-			if (!StringUtil::StartsWith(path, "duckdb_temp_")) {
-				return;
-			}
-			orphaned_files.push_back(fs.JoinPath(temp_directory, path));
-		});
-		if (!orphaned_files.empty()) {
-			fs.RemoveFiles(orphaned_files);
-		}
 	}
+	const auto lock_name = "duckdb_temp_" + temporary_file_identifier + ".lock";
+	const auto lock_path = fs.JoinPath(temp_directory, lock_name);
+	ownership_lock = fs.OpenFile(lock_path, FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_WRITE |
+	                                            FileFlags::FILE_FLAGS_FILE_CREATE | FileLockType::WRITE_LOCK);
+	{
+		lock_guard<mutex> guard(temporary_file_ownership_lock);
+		live_temporary_file_identifiers.push_back(temporary_file_identifier);
+	}
+	fs.ListFiles(temp_directory, [&](const string &path, bool isdir) {
+		if (isdir || !StringUtil::StartsWith(path, "duckdb_temp_") || !StringUtil::EndsWith(path, ".lock") ||
+		    path == lock_name) {
+			return;
+		}
+		const auto identifier = path.substr(string("duckdb_temp_").size(),
+		                                    path.size() - string("duckdb_temp_").size() - string(".lock").size());
+		if (IsLiveTemporaryFileIdentifier(identifier)) {
+			return;
+		}
+		unique_ptr<FileHandle> lock;
+		try {
+			lock = fs.OpenFile(fs.JoinPath(temp_directory, path),
+			                   FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_WRITE | FileLockType::WRITE_LOCK);
+		} catch (const IOException &) {
+			return;
+		}
+		vector<string> files_to_delete;
+		const auto prefix = "duckdb_temp_" + identifier;
+		fs.ListFiles(temp_directory, [&](const string &candidate, bool candidate_isdir) {
+			if (!candidate_isdir && StringUtil::StartsWith(candidate, prefix)) {
+				files_to_delete.push_back(fs.JoinPath(temp_directory, candidate));
+			}
+		});
+		fs.RemoveFiles(files_to_delete);
+	});
 	temp_file->SetMaxSwapSpace(max_swap_space);
 }
 
 TemporaryDirectoryHandle::~TemporaryDirectoryHandle() {
-	// first release any temporary files
+	// First release any temporary files, then remove only this instance's files.
 	temp_file.reset();
-	// then delete the temporary file directory
 	auto &fs = FileSystem::GetFileSystem(db);
 	if (!temp_directory.empty()) {
-		bool delete_directory = created_directory;
 		vector<string> files_to_delete;
-		if (!created_directory) {
-			bool deleted_everything = true;
-			fs.ListFiles(temp_directory, [&](const string &path, bool isdir) {
-				if (isdir) {
-					deleted_everything = false;
-					return;
-				}
-				if (!StringUtil::StartsWith(path, "duckdb_temp_")) {
-					deleted_everything = false;
-					return;
-				}
-				files_to_delete.push_back(path);
-			});
-		}
-		if (delete_directory) {
-			// we want to remove all files in the directory
-			fs.RemoveDirectory(temp_directory);
-		} else {
-			vector<string> full_path_files_to_delete;
-			full_path_files_to_delete.reserve(files_to_delete.size());
-			for (auto &file : files_to_delete) {
-				full_path_files_to_delete.push_back(fs.JoinPath(temp_directory, file));
+		const auto prefix = "duckdb_temp_" + temporary_file_identifier;
+		fs.ListFiles(temp_directory, [&](const string &path, bool isdir) {
+			if (!isdir && StringUtil::StartsWith(path, prefix)) {
+				files_to_delete.push_back(fs.JoinPath(temp_directory, path));
 			}
-			fs.RemoveFiles(full_path_files_to_delete);
+		});
+		ownership_lock.reset();
+		fs.RemoveFiles(files_to_delete);
+		if (created_directory) {
+			fs.RemoveDirectoryExtended(temp_directory, {RemoveDirectoryMode::SINGLE});
 		}
 	}
+	lock_guard<mutex> guard(temporary_file_ownership_lock);
+	auto entry = std::find(live_temporary_file_identifiers.begin(), live_temporary_file_identifiers.end(),
+	                       temporary_file_identifier);
+	D_ASSERT(entry != live_temporary_file_identifiers.end());
+	live_temporary_file_identifiers.erase(entry);
 }
 
 TemporaryFileManager &TemporaryDirectoryHandle::GetTempFile() const {

--- a/test/api/CMakeLists.txt
+++ b/test/api/CMakeLists.txt
@@ -28,6 +28,7 @@ set(TEST_API_OBJECTS
     test_get_table_names.cpp
     test_prepared_api.cpp
     test_table_info.cpp
+    test_temp_directory_crash_recovery.cpp
     test_appender_api.cpp
     test_lifecycle_hooks.cpp
     test_extension_schema_api.cpp

--- a/test/api/test_temp_directory_crash_recovery.cpp
+++ b/test/api/test_temp_directory_crash_recovery.cpp
@@ -1,0 +1,52 @@
+#include "catch.hpp"
+#include "duckdb/common/file_system.hpp"
+#include "test_helpers.hpp"
+
+using namespace duckdb;
+
+TEST_CASE("Orphaned temp files from a crashed process are cleaned up on startup",
+          "[temp_directory]") {
+	auto temp_dir = TestCreatePath("temp_dir_crash_recovery");
+
+	auto fs = FileSystem::CreateLocal();
+	if (fs->DirectoryExists(temp_dir)) {
+		fs->RemoveDirectory(temp_dir);
+	}
+	fs->CreateDirectory(temp_dir);
+
+	// simulate files left behind by a process that was killed (kill -9 / OOM / power loss)
+	auto orphan1 = fs->JoinPath(temp_dir, "duckdb_temp_storage_DEFAULT-0.tmp");
+	auto orphan2 = fs->JoinPath(temp_dir, "duckdb_temp_storage_S96K-0.tmp");
+	auto unrelated = fs->JoinPath(temp_dir, "not_a_temp_file.txt");
+
+	auto WriteDummyFile = [&](const string &path) {
+		auto handle = fs->OpenFile(path, FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE);
+		string data = "dummy";
+		fs->Write(*handle, (void *)data.c_str(), data.size(), 0);
+	};
+	WriteDummyFile(orphan1);
+	WriteDummyFile(orphan2);
+	WriteDummyFile(unrelated);
+
+	REQUIRE(fs->FileExists(orphan1));
+	REQUIRE(fs->FileExists(orphan2));
+	REQUIRE(fs->FileExists(unrelated));
+
+	// open a new DB pointed at the same temp_directory and force a spill,
+	// which lazily constructs TemporaryDirectoryHandle
+	auto db = make_uniq<DuckDB>(nullptr);
+	auto con = make_uniq<Connection>(*db);
+	REQUIRE_NO_FAIL(con->Query("SET temp_directory='" + temp_dir + "'"));
+	REQUIRE_NO_FAIL(con->Query("SET memory_limit='4MB'"));
+	REQUIRE_NO_FAIL(con->Query("CREATE OR REPLACE TABLE t2 AS SELECT random() FROM range(200000)"));
+
+	// orphaned duckdb_temp_* files should have been swept away on startup
+	REQUIRE_FALSE(fs->FileExists(orphan1));
+	REQUIRE_FALSE(fs->FileExists(orphan2));
+	// but anything not matching the prefix must be left alone
+	REQUIRE(fs->FileExists(unrelated));
+
+	con.reset();
+	db.reset();
+	fs->RemoveDirectory(temp_dir);
+}

--- a/test/api/test_temp_directory_crash_recovery.cpp
+++ b/test/api/test_temp_directory_crash_recovery.cpp
@@ -5,8 +5,7 @@
 
 using namespace duckdb;
 
-TEST_CASE("Orphaned temp files from a crashed process are cleaned up on startup",
-          "[temp_directory]") {
+TEST_CASE("Orphaned temp files from a crashed process are cleaned up on startup", "[temp_directory]") {
 	auto temp_dir = TestCreatePath("temp_dir_crash_recovery");
 
 	auto fs = FileSystem::CreateLocal();

--- a/test/api/test_temp_directory_crash_recovery.cpp
+++ b/test/api/test_temp_directory_crash_recovery.cpp
@@ -1,5 +1,6 @@
 #include "catch.hpp"
 #include "duckdb/common/file_system.hpp"
+#include "duckdb/common/string_util.hpp"
 #include "test_helpers.hpp"
 
 using namespace duckdb;
@@ -15,8 +16,10 @@ TEST_CASE("Orphaned temp files from a crashed process are cleaned up on startup"
 	fs->CreateDirectory(temp_dir);
 
 	// simulate files left behind by a process that was killed (kill -9 / OOM / power loss)
-	auto orphan1 = fs->JoinPath(temp_dir, "duckdb_temp_storage_DEFAULT-0.tmp");
-	auto orphan2 = fs->JoinPath(temp_dir, "duckdb_temp_storage_S96K-0.tmp");
+	const string orphan_identifier = "dead_instance";
+	auto orphan_lock = fs->JoinPath(temp_dir, "duckdb_temp_" + orphan_identifier + ".lock");
+	auto orphan1 = fs->JoinPath(temp_dir, "duckdb_temp_storage_" + orphan_identifier + "_DEFAULT-0.tmp");
+	auto orphan2 = fs->JoinPath(temp_dir, "duckdb_temp_block_" + orphan_identifier + "-0.block");
 	auto unrelated = fs->JoinPath(temp_dir, "not_a_temp_file.txt");
 
 	auto WriteDummyFile = [&](const string &path) {
@@ -24,10 +27,12 @@ TEST_CASE("Orphaned temp files from a crashed process are cleaned up on startup"
 		string data = "dummy";
 		fs->Write(*handle, (void *)data.c_str(), data.size(), 0);
 	};
+	WriteDummyFile(orphan_lock);
 	WriteDummyFile(orphan1);
 	WriteDummyFile(orphan2);
 	WriteDummyFile(unrelated);
 
+	REQUIRE(fs->FileExists(orphan_lock));
 	REQUIRE(fs->FileExists(orphan1));
 	REQUIRE(fs->FileExists(orphan2));
 	REQUIRE(fs->FileExists(unrelated));
@@ -40,7 +45,8 @@ TEST_CASE("Orphaned temp files from a crashed process are cleaned up on startup"
 	REQUIRE_NO_FAIL(con->Query("SET memory_limit='4MB'"));
 	REQUIRE_NO_FAIL(con->Query("CREATE OR REPLACE TABLE t2 AS SELECT random() FROM range(200000)"));
 
-	// orphaned duckdb_temp_* files should have been swept away on startup
+	// The unlocked ownership marker identifies this group as belonging to a dead instance.
+	REQUIRE_FALSE(fs->FileExists(orphan_lock));
 	REQUIRE_FALSE(fs->FileExists(orphan1));
 	REQUIRE_FALSE(fs->FileExists(orphan2));
 	// but anything not matching the prefix must be left alone
@@ -48,5 +54,43 @@ TEST_CASE("Orphaned temp files from a crashed process are cleaned up on startup"
 
 	con.reset();
 	db.reset();
+	fs->RemoveDirectory(temp_dir);
+}
+
+TEST_CASE("Temporary files owned by a live instance are not reclaimed", "[temp_directory]") {
+	auto temp_dir = TestCreatePath("temp_dir_live_owner");
+	auto fs = FileSystem::CreateLocal();
+	if (fs->DirectoryExists(temp_dir)) {
+		fs->RemoveDirectory(temp_dir);
+	}
+
+	auto db1 = make_uniq<DuckDB>(nullptr);
+	auto con1 = make_uniq<Connection>(*db1);
+	REQUIRE_NO_FAIL(con1->Query("SET temp_directory='" + temp_dir + "'"));
+	REQUIRE_NO_FAIL(con1->Query("SET memory_limit='4MB'"));
+	REQUIRE_NO_FAIL(con1->Query("CREATE TEMP TABLE t AS SELECT random() FROM range(200000)"));
+
+	vector<string> live_files;
+	fs->ListFiles(temp_dir, [&](const string &path, bool isdir) {
+		if (!isdir && StringUtil::StartsWith(path, "duckdb_temp_")) {
+			live_files.push_back(fs->JoinPath(temp_dir, path));
+		}
+	});
+	REQUIRE_FALSE(live_files.empty());
+
+	auto db2 = make_uniq<DuckDB>(nullptr);
+	auto con2 = make_uniq<Connection>(*db2);
+	REQUIRE_NO_FAIL(con2->Query("SET temp_directory='" + temp_dir + "'"));
+	REQUIRE_NO_FAIL(con2->Query("SET memory_limit='4MB'"));
+	REQUIRE_NO_FAIL(con2->Query("CREATE TEMP TABLE t AS SELECT random() FROM range(200000)"));
+
+	for (const auto &path : live_files) {
+		REQUIRE(fs->FileExists(path));
+	}
+
+	con2.reset();
+	db2.reset();
+	con1.reset();
+	db1.reset();
 	fs->RemoveDirectory(temp_dir);
 }


### PR DESCRIPTION
Fixes #24576 

## Problem

DuckDB spills data to disk under memory pressure, creating files like
`duckdb_temp_storage_DEFAULT-0.tmp` in `temp_directory`. On a clean shutdown,
these are deleted in `TemporaryDirectoryHandle`'s destructor. On an unclean
shutdown (`kill -9`, OOM kill, power loss), no destructors run, so the files
are orphaned — the process that created them no longer exists, and DuckDB
never revisits them. The temp directory accumulates garbage indefinitely.

## Fix

`TemporaryDirectoryHandle`'s constructor already checks whether
`temp_directory` exists. If it doesn't, it creates it (fresh start, nothing
to clean). This adds an `else` branch: if the directory *does* already
exist, it may contain orphans from a previous crash, so we scan for files
matching the `duckdb_temp_` prefix and remove them before this process
writes anything of its own. This mirrors the scan/delete logic the
destructor already uses on clean shutdown — just moved to also run on the
"directory already existed" startup path.

## Caveats (by design)

- **Cleanup is lazy.** `TemporaryDirectoryHandle` is only constructed the
  first time this process needs to spill (`RequireTemporaryDirectory`). A
  process that opens `temp_directory` but never hits memory pressure won't
  trigger cleanup — orphans persist until some future process actually
  spills into that directory.
- **Assumes `temp_directory` is not shared by concurrent live DuckDB
  processes.** This isn't a new risk from this change: temp file names
  (`duckdb_temp_storage_<size>-<index>.tmp`) contain no per-process
  identifier, so two processes sharing a directory would already collide
  on filenames during normal operation, independent of cleanup. The
  existing destructor cleanup makes the same assumption.

## Testing

Added a regression test that:
- creates orphaned `duckdb_temp_*` files alongside an unrelated file
- opens a new database using the same `temp_directory`
- forces creation of `TemporaryDirectoryHandle` via a spilling query
- verifies orphaned files are removed while the unrelated file remains

Also manually reproduced the original issue: forced a spill, `kill -9`'d
the process, restarted, confirmed orphaned files are now cleaned up on the
next spill (previously they persisted indefinitely).