### PR TITLE
Propagate stats in materialized CTEs and array distance/similarity functions

### DIFF
--- a/extension/core_functions/scalar/array/array_functions.cpp
+++ b/extension/core_functions/scalar/array/array_functions.cpp
@@ -2,6 +2,7 @@
 #include "core_functions/scalar/array_functions.hpp"
 #include "core_functions/array_kernels.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "duckdb/storage/statistics/array_stats.hpp"
 
 namespace duckdb {
 
@@ -208,7 +209,23 @@ static auto ArrayGenericFoldStats(ClientContext &context, FunctionStatisticsInpu
 	const auto &lhs_stats = input.child_stats[0];
 	const auto &rhs_stats = input.child_stats[1];
 	auto new_stats = NumericStats::CreateUnknown(input.expr.GetReturnType());
+
+	auto &lhs_child_stats = ArrayStats::GetChildStats(lhs_stats);
+	auto &rhs_child_stats = ArrayStats::GetChildStats(rhs_stats);
+
+	const auto has_any_nulls = lhs_child_stats.CanHaveNull() || rhs_child_stats.CanHaveNull();
+
+	if (has_any_nulls) {
+		// We will throw an error if the child arrays have nulls, so don't propagate any stats
+		return new_stats.ToUnique();
+	}
+
+	// If the child has no nulls, we won't throw.
+	input.expr.FunctionMutable().GetProperties().SetErrorMode(FunctionErrors::CANNOT_ERROR);
+
+	// Forward the validity
 	new_stats.CombineValidity(lhs_stats, rhs_stats);
+
 	return new_stats.ToUnique();
 }
 

--- a/extension/core_functions/scalar/array/array_functions.cpp
+++ b/extension/core_functions/scalar/array/array_functions.cpp
@@ -202,6 +202,16 @@ static void ArrayGenericFold(DataChunk &args, ExpressionState &state, Vector &re
 	}
 }
 
+static auto ArrayGenericFoldStats(ClientContext &context, FunctionStatisticsInput &input)
+    -> unique_ptr<BaseStatistics> {
+	// Propagate validity
+	const auto &lhs_stats = input.child_stats[0];
+	const auto &rhs_stats = input.child_stats[1];
+	auto new_stats = NumericStats::CreateUnknown(input.expr.GetReturnType());
+	new_stats.CombineValidity(lhs_stats, rhs_stats);
+	return new_stats.ToUnique();
+}
+
 //------------------------------------------------------------------------------
 // Function Registration
 //------------------------------------------------------------------------------
@@ -213,11 +223,13 @@ template <class OP>
 static void AddArrayFoldFunction(ScalarFunctionSet &set, const LogicalType &type) {
 	const auto array = LogicalType::ARRAY(type, optional_idx());
 	if (type.id() == LogicalTypeId::FLOAT) {
-		ScalarFunction function({array, array}, type, ArrayGenericFold<float, OP>, ArrayGenericBinaryBind);
+		ScalarFunction function({array, array}, type, ArrayGenericFold<float, OP>, ArrayGenericBinaryBind,
+		                        ArrayGenericFoldStats);
 		function.SetFallible();
 		set.AddFunction(function);
 	} else if (type.id() == LogicalTypeId::DOUBLE) {
-		ScalarFunction function({array, array}, type, ArrayGenericFold<double, OP>, ArrayGenericBinaryBind);
+		ScalarFunction function({array, array}, type, ArrayGenericFold<double, OP>, ArrayGenericBinaryBind,
+		                        ArrayGenericFoldStats);
 		function.SetFallible();
 		set.AddFunction(function);
 	} else {

--- a/src/include/duckdb/optimizer/statistics_propagator.hpp
+++ b/src/include/duckdb/optimizer/statistics_propagator.hpp
@@ -135,8 +135,15 @@ private:
 	optional_ptr<LogicalOperator> root;
 	//! The map of ColumnBinding -> statistics for the various nodes
 	column_binding_map_t<unique_ptr<BaseStatistics>> statistics_map;
-	//! The map of CTE index -> statistics of the columns emitted by the CTE definition
-	unordered_map<TableIndex, vector<unique_ptr<BaseStatistics>>> cte_stats_map;
+	//! The statistics of a materialized CTE definition, which hold for every reference to it
+	struct CTEStatistics {
+		//! Statistics of the columns emitted by the definition, by position
+		vector<unique_ptr<BaseStatistics>> column_stats;
+		//! Cardinality of the definition
+		unique_ptr<NodeStatistics> node_stats;
+	};
+	//! The map of CTE index -> statistics of its definition
+	unordered_map<TableIndex, CTEStatistics> cte_stats_map;
 	//! Node stats for the current node
 	unique_ptr<NodeStatistics> node_stats;
 };

--- a/src/include/duckdb/optimizer/statistics_propagator.hpp
+++ b/src/include/duckdb/optimizer/statistics_propagator.hpp
@@ -10,7 +10,9 @@
 
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/enums/filter_propagate_result.hpp"
+#include "duckdb/common/table_index.hpp"
 #include "duckdb/common/types/value.hpp"
+#include "duckdb/common/unordered_map.hpp"
 #include "duckdb/planner/bound_tokens.hpp"
 #include "duckdb/planner/column_binding_map.hpp"
 #include "duckdb/planner/logical_tokens.hpp"
@@ -50,6 +52,8 @@ private:
 	unique_ptr<NodeStatistics> PropagateStatistics(LogicalOperator &node, unique_ptr<LogicalOperator> &node_ptr);
 
 	unique_ptr<NodeStatistics> PropagateStatistics(LogicalCopyToFile &op, unique_ptr<LogicalOperator> &node_ptr);
+	unique_ptr<NodeStatistics> PropagateStatistics(LogicalCTERef &op, unique_ptr<LogicalOperator> &node_ptr);
+	unique_ptr<NodeStatistics> PropagateStatistics(LogicalMaterializedCTE &op, unique_ptr<LogicalOperator> &node_ptr);
 	unique_ptr<NodeStatistics> PropagateStatistics(LogicalFilter &op, unique_ptr<LogicalOperator> &node_ptr);
 	unique_ptr<NodeStatistics> PropagateStatistics(LogicalGet &op, unique_ptr<LogicalOperator> &node_ptr);
 	unique_ptr<NodeStatistics> PropagateStatistics(LogicalJoin &op, unique_ptr<LogicalOperator> &node_ptr);
@@ -131,6 +135,8 @@ private:
 	optional_ptr<LogicalOperator> root;
 	//! The map of ColumnBinding -> statistics for the various nodes
 	column_binding_map_t<unique_ptr<BaseStatistics>> statistics_map;
+	//! The map of CTE index -> statistics of the columns emitted by the CTE definition
+	unordered_map<TableIndex, vector<unique_ptr<BaseStatistics>>> cte_stats_map;
 	//! Node stats for the current node
 	unique_ptr<NodeStatistics> node_stats;
 };

--- a/src/optimizer/statistics/operator/CMakeLists.txt
+++ b/src/optimizer/statistics/operator/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library_unity(
   OBJECT
   propagate_aggregate.cpp
   propagate_cross_product.cpp
+  propagate_cte.cpp
   propagate_filter.cpp
   propagate_get.cpp
   propagate_limit.cpp

--- a/src/optimizer/statistics/operator/propagate_cte.cpp
+++ b/src/optimizer/statistics/operator/propagate_cte.cpp
@@ -7,20 +7,25 @@ namespace duckdb {
 unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalMaterializedCTE &op,
                                                                      unique_ptr<LogicalOperator> &node_ptr) {
 	// the CTE is evaluated once, so the statistics of its definition hold for every reference to it
-	PropagateStatistics(op.children[0]);
+	auto definition_node_stats = PropagateStatistics(op.children[0]);
 
 	auto definition_bindings = op.children[0]->GetColumnBindings();
-	vector<unique_ptr<BaseStatistics>> definition_stats;
-	definition_stats.reserve(definition_bindings.size());
-	for (auto &binding : definition_bindings) {
-		auto entry = statistics_map.find(binding);
+	auto column_count = MinValue<idx_t>(op.column_count, definition_bindings.size());
+
+	CTEStatistics cte_stats;
+	cte_stats.column_stats.reserve(column_count);
+	for (idx_t i = 0; i < column_count; i++) {
+		auto entry = statistics_map.find(definition_bindings[i]);
 		if (entry == statistics_map.end() || !entry->second) {
-			definition_stats.push_back(nullptr);
+			cte_stats.column_stats.push_back(nullptr);
 			continue;
 		}
-		definition_stats.push_back(entry->second->ToUnique());
+		cte_stats.column_stats.push_back(entry->second->ToUnique());
 	}
-	cte_stats_map[op.table_index] = std::move(definition_stats);
+	if (definition_node_stats) {
+		cte_stats.node_stats = make_uniq<NodeStatistics>(*definition_node_stats);
+	}
+	cte_stats_map[op.table_index] = std::move(cte_stats);
 
 	// the operator emits whatever the query referencing the CTE emits
 	return PropagateStatistics(op.children[1]);
@@ -39,14 +44,20 @@ unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalCTER
 	auto &cte_stats = entry->second;
 
 	auto bindings = op.GetColumnBindings();
-	auto column_count = MinValue<idx_t>(bindings.size(), cte_stats.size());
+	auto column_count = MinValue<idx_t>(bindings.size(), cte_stats.column_stats.size());
 	for (idx_t i = 0; i < column_count; i++) {
-		if (!cte_stats[i] || cte_stats[i]->GetType() != op.chunk_types[i]) {
+		auto &column_stats = cte_stats.column_stats[i];
+		if (!column_stats || column_stats->GetType() != op.chunk_types[i]) {
 			continue;
 		}
-		statistics_map[bindings[i]] = cte_stats[i]->ToUnique();
+		statistics_map[bindings[i]] = column_stats->ToUnique();
 	}
-	return nullptr;
+
+	// a reference scans the whole CTE, so it emits exactly as many rows as the definition
+	if (!cte_stats.node_stats) {
+		return nullptr;
+	}
+	return make_uniq<NodeStatistics>(*cte_stats.node_stats);
 }
 
 } // namespace duckdb

--- a/src/optimizer/statistics/operator/propagate_cte.cpp
+++ b/src/optimizer/statistics/operator/propagate_cte.cpp
@@ -1,0 +1,52 @@
+#include "duckdb/optimizer/statistics_propagator.hpp"
+#include "duckdb/planner/operator/logical_cteref.hpp"
+#include "duckdb/planner/operator/logical_materialized_cte.hpp"
+
+namespace duckdb {
+
+unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalMaterializedCTE &op,
+                                                                     unique_ptr<LogicalOperator> &node_ptr) {
+	// the CTE is evaluated once, so the statistics of its definition hold for every reference to it
+	PropagateStatistics(op.children[0]);
+
+	auto definition_bindings = op.children[0]->GetColumnBindings();
+	vector<unique_ptr<BaseStatistics>> definition_stats;
+	definition_stats.reserve(definition_bindings.size());
+	for (auto &binding : definition_bindings) {
+		auto entry = statistics_map.find(binding);
+		if (entry == statistics_map.end() || !entry->second) {
+			definition_stats.push_back(nullptr);
+			continue;
+		}
+		definition_stats.push_back(entry->second->ToUnique());
+	}
+	cte_stats_map[op.table_index] = std::move(definition_stats);
+
+	// the operator emits whatever the query referencing the CTE emits
+	return PropagateStatistics(op.children[1]);
+}
+
+unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalCTERef &op,
+                                                                     unique_ptr<LogicalOperator> &node_ptr) {
+	if (op.is_recurring) {
+		// the recurring table is filled during execution - the definition does not describe it
+		return nullptr;
+	}
+	auto entry = cte_stats_map.find(op.cte_index);
+	if (entry == cte_stats_map.end()) {
+		return nullptr;
+	}
+	auto &cte_stats = entry->second;
+
+	auto bindings = op.GetColumnBindings();
+	auto column_count = MinValue<idx_t>(bindings.size(), cte_stats.size());
+	for (idx_t i = 0; i < column_count; i++) {
+		if (!cte_stats[i] || cte_stats[i]->GetType() != op.chunk_types[i]) {
+			continue;
+		}
+		statistics_map[bindings[i]] = cte_stats[i]->ToUnique();
+	}
+	return nullptr;
+}
+
+} // namespace duckdb

--- a/src/optimizer/statistics_propagator.cpp
+++ b/src/optimizer/statistics_propagator.cpp
@@ -10,10 +10,12 @@
 #include "duckdb/planner/operator/logical_aggregate.hpp"
 #include "duckdb/planner/operator/logical_copy_to_file.hpp"
 #include "duckdb/planner/operator/logical_cross_product.hpp"
+#include "duckdb/planner/operator/logical_cteref.hpp"
 #include "duckdb/planner/operator/logical_empty_result.hpp"
 #include "duckdb/planner/operator/logical_filter.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/planner/operator/logical_join.hpp"
+#include "duckdb/planner/operator/logical_materialized_cte.hpp"
 #include "duckdb/planner/operator/logical_order.hpp"
 #include "duckdb/planner/operator/logical_positional_join.hpp"
 #include "duckdb/planner/operator/logical_projection.hpp"
@@ -51,6 +53,12 @@ unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalOper
 		break;
 	case LogicalOperatorType::LOGICAL_CROSS_PRODUCT:
 		result = PropagateStatistics(node.Cast<LogicalCrossProduct>(), node_ptr);
+		break;
+	case LogicalOperatorType::LOGICAL_CTE_REF:
+		result = PropagateStatistics(node.Cast<LogicalCTERef>(), node_ptr);
+		break;
+	case LogicalOperatorType::LOGICAL_MATERIALIZED_CTE:
+		result = PropagateStatistics(node.Cast<LogicalMaterializedCTE>(), node_ptr);
 		break;
 	case LogicalOperatorType::LOGICAL_FILTER:
 		result = PropagateStatistics(node.Cast<LogicalFilter>(), node_ptr);

--- a/src/optimizer/topn_window_elimination.cpp
+++ b/src/optimizer/topn_window_elimination.cpp
@@ -363,18 +363,16 @@ TopNWindowElimination::CreateAggregateOperator(LogicalWindow &window, vector<uni
 	aggregate->children.push_back(std::move(window.children[0]));
 	aggregate->ResolveOperatorTypes();
 
-	// Add group statistics to allow for perfect hash aggregation if applicable
+	// Add group statistics to allow for perfect hash aggregation if applicable.
+	// The partition statistics describe the window input, i.e. exactly what this aggregate reads.
+	// The global statistics map cannot be used here: its entries are narrowed by operators above the window.
+	auto &partitions_stats = window_expr.PartitionsStats();
 	aggregate->group_stats.resize(aggregate->groups.size());
-	for (idx_t i = 0; i < aggregate->groups.size(); i++) {
-		auto &group = aggregate->groups[i];
-		if (group->GetExpressionType() == ExpressionType::BOUND_COLUMN_REF) {
-			auto &column_ref = group->Cast<BoundColumnRefExpression>();
-			auto group_stats = stats->find(column_ref.Binding());
-			if (group_stats == stats->end()) {
-				continue;
-			}
-			aggregate->group_stats[i] = group_stats->second->ToUnique();
+	for (idx_t i = 0; i < MinValue<idx_t>(aggregate->groups.size(), partitions_stats.size()); i++) {
+		if (!partitions_stats[i]) {
+			continue;
 		}
+		aggregate->group_stats[i] = partitions_stats[i]->ToUnique();
 	}
 
 	return unique_ptr<LogicalOperator>(std::move(aggregate));

--- a/test/optimizer/cte_statistics_propagation.test
+++ b/test/optimizer/cte_statistics_propagation.test
@@ -1,0 +1,74 @@
+# name: test/optimizer/cte_statistics_propagation.test
+# description: Statistics of a materialized CTE definition are propagated to references to it
+# group: [optimizer]
+
+statement ok
+CREATE TABLE t(i INTEGER, j INTEGER);
+
+statement ok
+INSERT INTO t VALUES (1, 10), (2, 20), (3, 30);
+
+statement ok
+CREATE TABLE nullable(i INTEGER, j INTEGER);
+
+statement ok
+INSERT INTO nullable VALUES (1, 10), (NULL, 20);
+
+statement ok
+PRAGMA explain_output = OPTIMIZED_ONLY
+
+# the CTE definition cannot produce NULL, so the join condition is always true
+query II
+EXPLAIN WITH c AS MATERIALIZED (SELECT * FROM t) SELECT * FROM t l JOIN c ON l.i + c.i IS NOT NULL
+----
+logical_opt	<!REGEX>:.*IS NOT NULL.*
+
+# ... but only if it really cannot produce NULL
+query II
+EXPLAIN WITH c AS MATERIALIZED (SELECT * FROM nullable) SELECT * FROM t l JOIN c ON l.i + c.i IS NOT NULL
+----
+logical_opt	<REGEX>:.*IS NOT NULL.*
+
+# min/max are propagated as well: no row can match, so the comparison folds to false
+query II
+EXPLAIN WITH c AS MATERIALIZED (SELECT * FROM t) SELECT * FROM t l JOIN c ON l.i + c.i > 1000
+----
+logical_opt	<!REGEX>:.*1000.*
+
+query I
+WITH c AS MATERIALIZED (SELECT * FROM t) SELECT count(*) FROM t l JOIN c ON l.i + c.i > 1000
+----
+0
+
+# the same holds for the duplicate-eliminated CTE that decorrelation generates for a lateral join
+query II
+EXPLAIN SELECT * FROM t l, LATERAL (SELECT * FROM t r WHERE r.i + l.i IS NOT NULL ORDER BY r.i + l.i LIMIT 2)
+----
+logical_opt	<!REGEX>:.*IS NOT NULL.*
+
+query III
+SELECT l.i, r.i, r.j FROM t l, LATERAL (SELECT * FROM t r WHERE r.i + l.i IS NOT NULL ORDER BY r.i + l.i LIMIT 2) r
+ORDER BY l.i, r.i
+----
+1	1	10
+1	2	20
+2	1	10
+2	2	20
+3	1	10
+3	2	20
+
+# the recurring table of a recursive CTE grows during execution, so the anchor statistics do not describe it
+query I
+WITH RECURSIVE r(i) AS (SELECT 1 UNION ALL SELECT i + 1 FROM r WHERE i < 10) SELECT i FROM r WHERE i > 5 ORDER BY i
+----
+6
+7
+8
+9
+10
+
+query I
+WITH RECURSIVE r(i) AS (SELECT 1 UNION ALL SELECT i + 1 FROM r WHERE i < 10)
+SELECT count(*) FROM r WHERE i IS NOT NULL
+----
+10

--- a/test/optimizer/cte_statistics_propagation.test
+++ b/test/optimizer/cte_statistics_propagation.test
@@ -40,6 +40,41 @@ WITH c AS MATERIALIZED (SELECT * FROM t) SELECT count(*) FROM t l JOIN c ON l.i 
 ----
 0
 
+# the cardinality of the definition reaches the reference, which is what lets sum() prove it cannot
+# overflow an int64 and switch to sum_no_overflow
+statement ok
+CREATE TABLE small_vals(v BIGINT);
+
+statement ok
+INSERT INTO small_vals SELECT (i * 1000000000)::BIGINT FROM range(1000) s(i);
+
+query II
+EXPLAIN WITH c AS MATERIALIZED (SELECT v FROM small_vals) SELECT sum(v) FROM c
+----
+logical_opt	<REGEX>:.*sum_no_overflow\(v\).*
+
+query I
+WITH c AS MATERIALIZED (SELECT v FROM small_vals) SELECT sum(v) FROM c
+----
+499500000000000
+
+# ... and declines to when the sum could exceed an int64
+statement ok
+CREATE TABLE big_vals(v BIGINT);
+
+statement ok
+INSERT INTO big_vals SELECT 4000000000000000000::BIGINT FROM range(5) s(i);
+
+query II
+EXPLAIN WITH c AS MATERIALIZED (SELECT v FROM big_vals) SELECT sum(v) FROM c
+----
+logical_opt	<!REGEX>:.*sum_no_overflow.*
+
+query I
+WITH c AS MATERIALIZED (SELECT v FROM big_vals) SELECT sum(v) FROM c
+----
+20000000000000000000
+
 # the same holds for the duplicate-eliminated CTE that decorrelation generates for a lateral join
 query II
 EXPLAIN SELECT * FROM t l, LATERAL (SELECT * FROM t r WHERE r.i + l.i IS NOT NULL ORDER BY r.i + l.i LIMIT 2)

--- a/test/optimizer/cte_statistics_propagation.test
+++ b/test/optimizer/cte_statistics_propagation.test
@@ -41,34 +41,25 @@ WITH c AS MATERIALIZED (SELECT * FROM t) SELECT count(*) FROM t l JOIN c ON l.i 
 0
 
 # the cardinality of the definition reaches the reference, which is what lets sum() prove it cannot
-# overflow an int64 and switch to sum_no_overflow
+# overflow an int64 and switch to sum_no_overflow. The plan assertions for that rewrite live in
+# test/optimizer/test_aggregate_function_rewrite.test; here we only check that the results stay correct
+# on either side of the overflow boundary.
 statement ok
 CREATE TABLE small_vals(v BIGINT);
 
 statement ok
 INSERT INTO small_vals SELECT (i * 1000000000)::BIGINT FROM range(1000) s(i);
 
-query II
-EXPLAIN WITH c AS MATERIALIZED (SELECT v FROM small_vals) SELECT sum(v) FROM c
-----
-logical_opt	<REGEX>:.*sum_no_overflow\(v\).*
-
 query I
 WITH c AS MATERIALIZED (SELECT v FROM small_vals) SELECT sum(v) FROM c
 ----
 499500000000000
 
-# ... and declines to when the sum could exceed an int64
 statement ok
 CREATE TABLE big_vals(v BIGINT);
 
 statement ok
 INSERT INTO big_vals SELECT 4000000000000000000::BIGINT FROM range(5) s(i);
-
-query II
-EXPLAIN WITH c AS MATERIALIZED (SELECT v FROM big_vals) SELECT sum(v) FROM c
-----
-logical_opt	<!REGEX>:.*sum_no_overflow.*
 
 query I
 WITH c AS MATERIALIZED (SELECT v FROM big_vals) SELECT sum(v) FROM c

--- a/test/optimizer/test_aggregate_function_rewrite.test
+++ b/test/optimizer/test_aggregate_function_rewrite.test
@@ -50,6 +50,16 @@ EXPLAIN SELECT SUM(i + 1), SUM(2 + i), SUM(i + 3), SUM(4 + i) FROM integers
 ----
 logical_opt	<REGEX>:.*sum_no_overflow\(i\).*
 
+query II
+EXPLAIN WITH d AS MATERIALIZED (SELECT i FROM integers) SELECT SUM(i) FROM d
+----
+logical_opt	<REGEX>:.*sum_no_overflow\(i\).*
+
+query II
+EXPLAIN WITH d AS MATERIALIZED (SELECT i FROM integers) SELECT COUNT(i) FROM d
+----
+logical_opt	<REGEX>:.*count_star\(\).*
+
 # test rewrite with HUGEINT
 statement ok
 CREATE TABLE T(a HUGEINT);

--- a/test/optimizer/test_aggregate_function_rewrite.test
+++ b/test/optimizer/test_aggregate_function_rewrite.test
@@ -60,6 +60,30 @@ EXPLAIN WITH d AS MATERIALIZED (SELECT i FROM integers) SELECT COUNT(i) FROM d
 ----
 logical_opt	<REGEX>:.*count_star\(\).*
 
+# the rewrite needs the cardinality of the CTE definition, so it only fires when the sum provably
+# fits in an int64
+statement ok
+CREATE TABLE small_vals(v BIGINT);
+
+statement ok
+INSERT INTO small_vals SELECT (i * 1000000000)::BIGINT FROM range(1000) s(i);
+
+query II
+EXPLAIN WITH c AS MATERIALIZED (SELECT v FROM small_vals) SELECT sum(v) FROM c
+----
+logical_opt	<REGEX>:.*sum_no_overflow\(v\).*
+
+statement ok
+CREATE TABLE big_vals(v BIGINT);
+
+statement ok
+INSERT INTO big_vals SELECT 4000000000000000000::BIGINT FROM range(5) s(i);
+
+query II
+EXPLAIN WITH c AS MATERIALIZED (SELECT v FROM big_vals) SELECT sum(v) FROM c
+----
+logical_opt	<!REGEX>:.*sum_no_overflow.*
+
 # test rewrite with HUGEINT
 statement ok
 CREATE TABLE T(a HUGEINT);

--- a/test/optimizer/topn_window_elimination_group_stats.test
+++ b/test/optimizer/topn_window_elimination_group_stats.test
@@ -1,0 +1,34 @@
+# name: test/optimizer/topn_window_elimination_group_stats.test
+# description: The aggregate replacing a top-N window must use statistics of the window input
+# group: [optimizer]
+
+statement ok
+CREATE TABLE w(g INTEGER, v INTEGER);
+
+statement ok
+INSERT INTO w SELECT (range * 7) % 40, range FROM range(400);
+
+statement ok
+CREATE TABLE k(k INTEGER);
+
+statement ok
+INSERT INTO k VALUES (0), (1), (2), (3);
+
+# The join above the window narrows the statistics of g to [0, 3], but the aggregate that replaces
+# the window sits below the join and still sees all 40 partitions
+query I
+SELECT count(*) FROM (
+	SELECT g, v, row_number() OVER (PARTITION BY g ORDER BY v) AS rn FROM w
+) t JOIN k ON t.g = k.k WHERE t.rn = 1
+----
+4
+
+query II
+SELECT t.g, t.v FROM (
+	SELECT g, v, row_number() OVER (PARTITION BY g ORDER BY v) AS rn FROM w
+) t JOIN k ON t.g = k.k WHERE t.rn = 1 ORDER BY t.g
+----
+0	0
+1	23
+2	6
+3	29

--- a/test/sql/optimizer/test_fd_derived_groups.test
+++ b/test/sql/optimizer/test_fd_derived_groups.test
@@ -115,11 +115,11 @@ logical_opt	<REGEX>:.*"Groups":\s*\[\s*"[^"]*"\s*,\s*".*
 
 # Multiple grouping sets: positional groups must not collapse. This can appear either as a
 # single aggregate with two positional groups, or as a grouping-sets rewrite with separate
-# singleton aggregate branches.
+# singleton aggregate branches. The singleton groups may be wrapped by compressed materialization.
 query II
 EXPLAIN (FORMAT JSON) SELECT x, x-1, count(*) FROM t GROUP BY GROUPING SETS ((x), (x-1));
 ----
-logical_opt	<REGEX>:.*("Groups":\s*\[\s*"[^"]*"\s*,\s*"|CTE.*UNION.*"Groups":\s*"x".*"Groups":\s*"\(x - 1\)").*
+logical_opt	<REGEX>:.*("Groups":\s*\[\s*"[^"]*"\s*,\s*"|CTE.*UNION.*"Groups":\s*"[^"]*x[^"]*".*"Groups":\s*"[^"]*\(x - 1\)[^"]*").*
 
 # No raw-column base: synthesising one would need an injectivity proof per derived.
 query II


### PR DESCRIPTION
When looking at the plans produced by the new `NEAREST BY` join (introduced in #24137) I realized that since the `<ranking expression> IS NOT NULL` is correlated, decorrelation lifts it into a ANY join condition, causing to be evaluated twice, both as part of a `BLOCKWISE_NL_JOIN`, and as part of the actual `TOP-K` further up in the plan. 

Since the ranking expressions in both vss and spatial workloads can be quite expensive to compute, this seems not ideal, especially considering that there are no nulls in either table. 

Fixing this required two changes:

1. Propagating the validity statistics in the array distance functions. This works by just combining the validity of the input arguments, as these functions don't return `NULL` on their own, but rather throw on invalid input (high-five past max for making that decision ✋). In theory we could also derive min/max bounds for some of the variants, but I don't think that would be very useful in practice and I know float-stats propagation can be prickly due to non-commutativity of floating-point ops so I left it out of this PR.

I had hoped this would let the optimizer just remove the filter entirely. However, I also had to add support to...

2. Propagate stats across materialized CTE's (which is what the delim-join now turns into). Im not super confident working with CTE's yet, but this seems like a pretty straightforward and safe thing to do, as long as the CTE is materialized and non-recursive? Would love some feedback of `src/optimizer/statistics/operator/propagate_cte.cpp` from @kryonix! As a bonus this also triggers other stats-based optimizations when scanning materialized CTE's, e.g. compressed-materialization.

Adding 2. also exposed a pre-existing issue with the `TopNWindowElimination`, which read the final `statistics_map` to set `group_stats` on the aggregate it substitutes for a top-N window. Those stats are narrowed by operators above the window, but the aggregate sits below them, so the perfect hash aggregate gets sized too small. This reproducible on main even when no CTEs are involved:

```sql
CREATE TABLE w(g INT, v INT);
INSERT INTO w SELECT (range*7)%40, range FROM range(400);
CREATE TABLE s(k INT); INSERT INTO s VALUES (0),(1),(2),(3);

SELECT count(*) FROM (SELECT g, v, row_number() OVER (PARTITION BY g ORDER BY v) rn FROM w) t
  JOIN s ON t.g = s.k WHERE t.rn = 1;
----
Invalid Input Error: Perfect hash aggregate: aggregate group 8 exceeded total groups 8
```

The join narrows g to [0,3] while the aggregate below still sees all 40 partitions. The fix is to use the `window_expr.PartitionsStats()` instead, which is contain the stats for the aggregates actual input.

There are a lot of other open PRs making various adjustments to the `TopNWindowElimination` code, e.g. https://github.com/duckdb/duckdb/pull/24551, https://github.com/duckdb/duckdb/pull/24346, https://github.com/duckdb/duckdb/pull/23943, https://github.com/duckdb/duckdb/pull/23702. I'm not sure if the fix in this PR overlaps or can be generalized, but it does seem like a sane fix in isolation.

---------------------

With these changes, the join condition now folds into a `BlockwiseNLJoin: true` - basically a cross product - eliminating e.g. a duplicate `array_cosine_similarity` evaluation per row pair. Here's a quick benchmark result:

```
128 users × 16,384 products (2.1M pairs), APPROX NEAREST 5 BY SIMILARITY, threads=4.

┌───────────────┬─────────┬─────────┬────────────────┐
│ Embedding dim │ Before  │  After  │    Speedup     │
├───────────────┼─────────┼─────────┼────────────────┤
│ 256           │ 0.851 s │ 0.529 s │ 1.61x (−37.8%) │
├───────────────┼─────────┼─────────┼────────────────┤
│ 16            │ 0.046 s │ 0.035 s │   1.31x (−24%) │
└───────────────┴─────────┴─────────┴────────────────┘
```

I want to investigate folding `BLOCKWISE_NL_JOIN`s on `true` into cross-products next, to hopefully shave of some minor execution overhead, and make it even easier for optimizers to target this plan shape. We should also be able to do the opposite and turn e.g. inner `BLOCKWISE_NL_JOIN` on `false` into `EMPTY_RESULT`.