### PR TITLE
Fix grouped printf formats for signed integer arguments

### DIFF
--- a/test/sql/function/string/test_format_extensions.test
+++ b/test/sql/function/string/test_format_extensions.test
@@ -97,6 +97,30 @@ select printf('%,.3f', 123456.789::DOUBLE)
 ----
 123,456.789
 
+# preserve the sign when grouped float-family formats receive signed integers
+query IIIII
+select printf('%+,.0f', -5::TINYINT), printf('%+,.0f', -5::SMALLINT), printf('%+,.0f', -5::INTEGER), printf('%+,.0f', -5::BIGINT), printf('%+,.0f', -5::HUGEINT)
+----
+-5	-5	-5	-5	-5
+
+# grouped integer formatting remains exact above the double precision limit
+query II
+select printf('%,.0f', 9007199254740993::BIGINT), printf('%,.0f', 18446744073709551615::UBIGINT)
+----
+9,007,199,254,740,993	18,446,744,073,709,551,615
+
+# all grouped float-family specifiers preserve signed integer arguments
+query IIII
+select printf('%,.0e', -5::BIGINT), printf('%,.0f', -5::BIGINT), printf('%,.3g', -5::BIGINT), printf('%,.0a', -5::BIGINT)
+----
+-5	-5	-005	-5
+
+# conversions are applied independently in multi-argument calls
+query I
+select printf('%+,.0f / %,.0f / %,.0f', -5::BIGINT, 9007199254740993::BIGINT, 5::UBIGINT)
+----
+-5 / 9,007,199,254,740,993 / 5
+
 foreach val 1.724e12 1.7e12 1.72456e12 1.723456e11 1.724567e12 1.234e4
 
 query I

--- a/third_party/fmt/include/fmt/printf.h
+++ b/third_party/fmt/include/fmt/printf.h
@@ -116,7 +116,10 @@ template <typename T, typename Context> class arg_converter {
 
   template <typename U, FMT_ENABLE_IF(is_integral<U>::value)>
   void operator()(U value) {
-    bool is_signed = type_ == 'd' || type_ == 'i';
+    bool is_signed = type_ == 'd' || type_ == 'i' ||
+                     ((type_ == 'a' || type_ == 'A' || type_ == 'e' || type_ == 'E' ||
+                       type_ == 'f' || type_ == 'F' || type_ == 'g' || type_ == 'G') &&
+                      (std::numeric_limits<U>::is_signed || std::is_same<U, int128_t>::value));
     using target_type = conditional_t<std::is_same<T, void>::value, U, T>;
     if (const_check(sizeof(target_type) <= sizeof(int))) {
       // Extra casts are used to silence warnings.
@@ -147,9 +150,9 @@ template <typename T, typename Context> class arg_converter {
 };
 
 // Converts an integer argument to T for printf, if T is an integral type.
-// If T is void, the argument is converted to corresponding signed or unsigned
-// type depending on the type specifier: 'd' and 'i' - signed, other -
-// unsigned).
+// If T is void, the argument is converted to the signedness expected by the
+// type specifier. 'd' and 'i' are signed, floating-point specifiers preserve
+// the argument's signedness, and other specifiers are unsigned.
 template <typename T, typename Context, typename Char>
 void convert_arg(basic_format_arg<Context>& arg, Char type) {
   visit_format_arg(arg_converter<T, Context>(arg, type), arg);


### PR DESCRIPTION
## Summary

Grouped float-family `printf` formats reinterpret negative signed integers as unsigned values before DuckDB applies its integer-preserving formatting path. For example:

```sql
SELECT printf('%,.0f', -5::BIGINT);
-- before: 18,446,744,073,709,551,611
-- after:  -5
```

Preserve the source integer's signedness for `a`, `e`, `f`, and `g` conversions. Unsigned values retain the existing unsigned path, including exact formatting above the double-precision limit.

## Tests

Added SQLLogicTest coverage for:

- signed `TINYINT`, `SMALLINT`, `INTEGER`, `BIGINT`, and `HUGEINT`
- all grouped float-family conversion types
- `BIGINT` and `UBIGINT` values above `2^53`
- multiple converted arguments in one call

Built DuckDB from current `main` and ran:

```text
build/upstream-review/test/unittest test/sql/function/string/test_format_extensions.test
All tests passed (43 assertions in 1 test case)
```