### PR TITLE
Fix `DECIMAL` syntax silently accepting non-integral parameters

### DIFF
--- a/src/catalog/default/default_types.cpp
+++ b/src/catalog/default/default_types.cpp
@@ -31,6 +31,9 @@ LogicalType BindDecimalType(BindLogicalTypeInput &input) {
 		if (width_value.IsNull()) {
 			throw BinderException("DECIMAL type width cannot be NULL");
 		}
+		if (!width_value.type().IsIntegral()) {
+			throw BinderException("DECIMAL type width must be an integral type");
+		}
 		if (width_value.DefaultTryCastAs(LogicalTypeId::UTINYINT)) {
 			width = width_value.GetValueUnsafe<uint8_t>();
 			scale = 0; // reset scale to 0 if only width is provided
@@ -43,6 +46,9 @@ LogicalType BindDecimalType(BindLogicalTypeInput &input) {
 		auto scale_value = modifiers[1].GetValue();
 		if (scale_value.IsNull()) {
 			throw BinderException("DECIMAL type scale cannot be NULL");
+		}
+		if (!scale_value.type().IsIntegral()) {
+			throw BinderException("DECIMAL type scale must be an integral type");
 		}
 		if (scale_value.DefaultTryCastAs(LogicalTypeId::UTINYINT)) {
 			scale = scale_value.GetValueUnsafe<uint8_t>();

--- a/test/sql/types/decimal/test_decimal.test
+++ b/test/sql/types/decimal/test_decimal.test
@@ -141,7 +141,7 @@ SELECT '0.1'::DECIMAL(3, 4);
 statement error
 SELECT '0.1'::DECIMAL('hello');
 ----
-<REGEX>:Binder Error.*DECIMAL type width must be between 1 and 38.*
+<REGEX>:Binder Error.*DECIMAL type width must be an integral type.*
 
 # ...or negative numbers
 statement error
@@ -164,3 +164,34 @@ statement error
 SELECT '1'::INTEGER(1000);
 ----
 <REGEX>:Parser Error.*syntax error.*
+
+# non-integral type parameters
+statement error
+SELECT 1::DECIMAL(3.2);
+----
+<REGEX>:Binder Error.*DECIMAL type width must be an integral type.*
+
+statement error
+SELECT 1::DECIMAL(3.0);
+----
+<REGEX>:Binder Error.*DECIMAL type width must be an integral type.*
+
+statement error
+SELECT 1::DECIMAL('32');
+----
+<REGEX>:Binder Error.*DECIMAL type width must be an integral type.*
+
+statement error
+SELECT 1::DECIMAL(18, 2.5);
+----
+<REGEX>:Binder Error.*DECIMAL type scale must be an integral type.*
+
+statement error
+SELECT 1::DECIMAL(18, '2');
+----
+<REGEX>:Binder Error.*DECIMAL type scale must be an integral type.*
+
+statement error
+SELECT 1::DECIMAL(TRUE);
+----
+<REGEX>:Binder Error.*DECIMAL type width must be an integral type.*


### PR DESCRIPTION
Fixes #24570.

Previously, `BindDecimalType` only validated metadata parameters using a permissive `DefaultTryCastAs(LogicalTypeId::UTINYINT)` check. This meant DuckDB would silently accept and cast non-integral types like `DECIMAL(3.2)`, effectively rounding the float down to `3` instead of rejecting the user's typo.

Taking direct inspiration from how `ARRAY` enforces its size modifiers in the exact same file (`BindArrayType`), this PR adds a strict `!value.type().IsIntegral()` check before the cast attempt to ensure only pure integers are allowed through.

So currently only actual DuckDB integer types (e.g., `DECIMAL(3, 2)`) are accepted.
Floats (`3.2`), whole floats (`3.0`), string literals (`'3'`), and booleans (`TRUE`) are now immediately caught and rejected with a `Binder Error: DECIMAL type width/scale must be an integral type`.