### PR TITLE
Fix COUNT(x) still reading the counted column after the COUNT(*) rewrite

### DIFF
--- a/.github/regression/micro.csv
+++ b/.github/regression/micro.csv
@@ -34,5 +34,6 @@ benchmark/micro/logger/storage/file/log_message_size/huge_string.benchmark
 benchmark/micro/logger/storage/file/log_message_size/small_string.benchmark
 benchmark/micro/filter/choose_correct_filter_function.benchmark
 benchmark/micro/optimizer/topn_window_elimination.benchmark
+benchmark/micro/optimizer/count_not_null_column_prune.benchmark
 benchmark/micro/aggregate/group_two_string_dictionaries.benchmark
 benchmark/micro/functions/nested_macros.benchmark

--- a/benchmark/micro/optimizer/count_not_null_column_prune.benchmark
+++ b/benchmark/micro/optimizer/count_not_null_column_prune.benchmark
@@ -1,0 +1,27 @@
+# name: benchmark/micro/optimizer/count_not_null_column_prune.benchmark
+# description: Benchmark of column pruning after the COUNT(x) to COUNT(*) rewrite
+# group: [optimizer]
+
+name Count Not Null Column Prune
+group micro
+subgroup optimizer
+storage persistent
+
+load
+CREATE TABLE events AS
+    SELECT 'd' || (i % 8) AS device_type,
+           md5(i::VARCHAR) AS uuid
+    FROM range(5000000) t(i);
+
+run
+SELECT device_type, count(uuid) FROM events GROUP BY device_type ORDER BY device_type;
+
+result II
+d0	625000
+d1	625000
+d2	625000
+d3	625000
+d4	625000
+d5	625000
+d6	625000
+d7	625000

--- a/src/include/duckdb/optimizer/statistics_propagator.hpp
+++ b/src/include/duckdb/optimizer/statistics_propagator.hpp
@@ -42,6 +42,9 @@ public:
 	bool FilterBindingsChanged() const {
 		return filter_bindings_changed;
 	}
+	bool HasRemovedAggregateChildren() const {
+		return removed_aggregate_children;
+	}
 
 	//! Derive output statistics of a monotone function by evaluating it at the corners of its
 	//! argument ranges (see ArgProperties). Returns nullptr when the bounds cannot be derived.
@@ -155,6 +158,8 @@ private:
 	};
 	//! The map of CTE index -> statistics of its definition
 	unordered_map<TableIndex, CTEStatistics> cte_stats_map;
+	//! Whether a statistics callback removed aggregate children, leaving columns that may now be unused
+	bool removed_aggregate_children = false;
 	//! Node stats for the current node
 	unique_ptr<NodeStatistics> node_stats;
 	//! Whether statistics changed which relations a filter depends on

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -151,6 +151,17 @@ void Optimizer::Verify(LogicalOperator &op) {
 	ColumnBindingResolver::Verify(context, op);
 }
 
+// RemoveUnusedColumns renumbers bindings, so RemapProjectionMap can match a stale binding to a
+// different column rather than dropping it
+static void ClearProjectionMaps(LogicalOperator &op) {
+	for (idx_t child_index = 0; child_index < op.children.size(); child_index++) {
+		if (auto projection_map = LogicalOperatorVisitor::GetProjectionMap(op, child_index)) {
+			projection_map->clear();
+		}
+		ClearProjectionMaps(*op.children[child_index]);
+	}
+}
+
 static bool ContainsDML(const LogicalOperator &op) {
 	switch (op.type) {
 	case LogicalOperatorType::LOGICAL_INSERT:
@@ -434,12 +445,14 @@ void Optimizer::RunBuiltInOptimizers() {
 	// DML CTEs can invalidate the table statistics captured during planning.
 	column_binding_map_t<unique_ptr<BaseStatistics>> statistics_map;
 	bool propagated_statistics = false;
+	bool removed_aggregate_children = false;
 	if (!CTEContainsDML(*plan)) {
 		RunOptimizer(OptimizerType::STATISTICS_PROPAGATION, [&]() {
 			StatisticsPropagator propagator(*this, *plan);
 			propagator.PropagateStatistics(plan);
 			statistics_map = propagator.GetStatisticsMap();
 			propagated_statistics = true;
+			removed_aggregate_children = propagator.HasRemovedAggregateChildren();
 		});
 	}
 	if (propagated_statistics) {
@@ -449,6 +462,7 @@ void Optimizer::RunBuiltInOptimizers() {
 			StatisticsPropagator propagator(*this, *plan);
 			propagator.PropagateStatistics(plan);
 			statistics_map = propagator.GetStatisticsMap();
+			removed_aggregate_children |= propagator.HasRemovedAggregateChildren();
 		}
 	}
 
@@ -463,6 +477,15 @@ void Optimizer::RunBuiltInOptimizers() {
 		CommonAggregateOptimizer common_aggregate;
 		common_aggregate.VisitOperator(*plan);
 	});
+
+	// COUNT(x) becomes COUNT(*) during statistics propagation, leaving unreferenced columns in the scan
+	if (removed_aggregate_children) {
+		RunOptimizer(OptimizerType::UNUSED_COLUMNS, [&]() {
+			ClearProjectionMaps(*plan);
+			RemoveUnusedColumns unused(*this);
+			unused.VisitOperator(plan);
+		});
+	}
 
 	// creates projection maps so unused columns are projected out early
 	RunOptimizer(OptimizerType::COLUMN_LIFETIME, [&]() {

--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -683,7 +683,9 @@ void RemoveUnusedColumns::VisitOperator(unique_ptr<LogicalOperator> &op_ref) {
 			throw InternalException("CTE pruning did not traverse the entire plan. This is a bug in the optimizer.");
 		}
 
-		if (cte_map_entry.everything_referenced) {
+		// Distinct column indexes here, unlike the per-reader map, so comparing sizes is a valid width check.
+		if (cte_map_entry.everything_referenced ||
+		    referenced_columns_in_rhs.size() == cte.children[0]->GetColumnBindings().size()) {
 			if (!analyze) {
 				everything_referenced = true;
 			}
@@ -772,10 +774,8 @@ void RemoveUnusedColumns::VisitOperator(unique_ptr<LogicalOperator> &op_ref) {
 			}
 		}
 
-		// The flag is shared by all readers, so only ever turn it on: an unaccounted reader needs every column
-		if (everything_referenced || cte_ref.chunk_types.size() == referenced_columns.size()) {
-			cte_entry.everything_referenced = true;
-		}
+		// Keyed per reader, so its size counts reader-column pairs, not columns. Coverage is decided at the CTE.
+		cte_entry.everything_referenced |= everything_referenced;
 		break;
 	}
 	case LogicalOperatorType::LOGICAL_COPY_TO_FILE:

--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -683,8 +683,19 @@ void RemoveUnusedColumns::VisitOperator(unique_ptr<LogicalOperator> &op_ref) {
 			throw InternalException("CTE pruning did not traverse the entire plan. This is a bug in the optimizer.");
 		}
 
+		// A CTE whose own output exposes its readers' bindings has no projection above the RHS. Operators above
+		// the CTE may then reference those readers directly, and the rewrite below only covers the RHS, so
+		// pruning here could leave those references stale.
+		bool readers_visible_in_output = false;
+		for (auto &binding : cte.GetColumnBindings()) {
+			if (cte_map_entry.expected_readers.find(binding.table_index) != cte_map_entry.expected_readers.end()) {
+				readers_visible_in_output = true;
+				break;
+			}
+		}
+
 		// Distinct column indexes here, unlike the per-reader map, so comparing sizes is a valid width check.
-		if (cte_map_entry.everything_referenced ||
+		if (cte_map_entry.everything_referenced || readers_visible_in_output ||
 		    referenced_columns_in_rhs.size() == cte.children[0]->GetColumnBindings().size()) {
 			if (!analyze) {
 				everything_referenced = true;

--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -772,7 +772,10 @@ void RemoveUnusedColumns::VisitOperator(unique_ptr<LogicalOperator> &op_ref) {
 			}
 		}
 
-		cte_entry.everything_referenced = cte_ref.chunk_types.size() == referenced_columns.size();
+		// The flag is shared by all readers, so only ever turn it on: an unaccounted reader needs every column
+		if (everything_referenced || cte_ref.chunk_types.size() == referenced_columns.size()) {
+			cte_entry.everything_referenced = true;
+		}
 		break;
 	}
 	case LogicalOperatorType::LOGICAL_COPY_TO_FILE:

--- a/src/optimizer/statistics/expression/propagate_aggregate.cpp
+++ b/src/optimizer/statistics/expression/propagate_aggregate.cpp
@@ -19,7 +19,10 @@ unique_ptr<BaseStatistics> StatisticsPropagator::PropagateExpression(BoundAggreg
 		return nullptr;
 	}
 	AggregateStatisticsInput input(aggr.BindInfo(), stats, node_stats.get());
-	return aggr.Function().GetCallbacks().GetStatisticsCallback()(context, aggr, input);
+	const idx_t child_count = aggr.GetChildren().size();
+	auto result = aggr.Function().GetCallbacks().GetStatisticsCallback()(context, aggr, input);
+	removed_aggregate_children |= aggr.GetChildren().size() < child_count;
+	return result;
 }
 
 } // namespace duckdb

--- a/src/optimizer/statistics/operator/propagate_aggregate.cpp
+++ b/src/optimizer/statistics/operator/propagate_aggregate.cpp
@@ -7,9 +7,7 @@
 #include "duckdb/common/types/value.hpp"
 #include "duckdb/common/unique_ptr.hpp"
 #include "duckdb/common/vector.hpp"
-#include "duckdb/function/function_binder.hpp"
 #include "duckdb/function/partition_stats.hpp"
-#include "duckdb/function/aggregate/distributive_functions.hpp"
 #include "duckdb/optimizer/optimizer.hpp"
 #include "duckdb/optimizer/column_binding_replacer.hpp"
 #include "duckdb/planner/binder.hpp"
@@ -28,7 +26,6 @@
 #include "duckdb/storage/statistics/base_statistics.hpp"
 #include "duckdb/storage/statistics/string_stats.hpp"
 #include "duckdb/storage/storage_index.hpp"
-#include "duckdb/optimizer/matcher/expression_matcher.hpp"
 
 namespace duckdb {
 
@@ -495,27 +492,9 @@ unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalAggr
 		statistics_map[group_binding] = std::move(stats);
 	}
 
-	// Set up an expression matcher that detects COUNT(x)
-	FunctionBinder function_binder(context);
-	const auto count_fun = CountStarFun::GetFunction();
-	const auto count_matcher = make_uniq<AggregateExpressionMatcher>();
-	count_matcher->function = make_uniq<SpecificFunctionMatcher>("count");
-	count_matcher->policy = SetMatcher::Policy::ORDERED;
-	count_matcher->matchers.push_back(make_uniq<ExpressionMatcher>());
-
 	// propagate statistics in the aggregates
 	for (idx_t aggregate_idx = 0; aggregate_idx < aggr.expressions.size(); aggregate_idx++) {
 		auto &expr = aggr.expressions[aggregate_idx];
-
-		// Rewrite COUNT(x) to COUNT(*) if x cannot be NULL
-		vector<reference<Expression>> bindings;
-		if (count_matcher->Match(*expr, bindings)) {
-			auto &aggr_expr = expr->Cast<BoundAggregateExpression>();
-			const auto child_stats = PropagateExpression(aggr_expr.GetChildrenMutable()[0]);
-			if (child_stats && !child_stats->CanHaveNull()) {
-				expr = function_binder.BindAggregateFunction(count_fun, {}, nullptr, AggregateType::NON_DISTINCT);
-			}
-		}
 
 		auto stats = PropagateExpression(expr);
 		if (!stats) {

--- a/test/configs/verify_aggregate_state_export.json
+++ b/test/configs/verify_aggregate_state_export.json
@@ -12,6 +12,8 @@
         "test/optimizer/eager_aggregate_execution_parquet.test",
         "test/optimizer/partial_aggregate_precomputation.test",
         "test/optimizer/partition_stats_exactness.test",
+        "test/optimizer/statistics/statistics_count_not_null_join_pruning.test",
+        "test/optimizer/statistics/statistics_count_not_null_pruning.test",
         "test/optimizer/test_aggregate_function_rewrite.test",
         "test/optimizer/ordered_aggregate.test",
         "test/sql/copy/parquet/parquet_encryption.test",

--- a/test/optimizer/common_subplan_nested_cte.test
+++ b/test/optimizer/common_subplan_nested_cte.test
@@ -22,6 +22,16 @@ INSERT INTO person_knows VALUES (1, 10), (2, 10);
 
 # Extracting a nested common subplan creates new CTE reader bindings. A later
 # common subplan must retain the canonical identities of those generated bindings.
+# The first COLUMN_LIFETIME pass narrows the extracted subplan to live columns, so this shape does not
+# form by default. Disabling it exposes the defect, and per-pass verification reports the pass at fault.
+statement ok
+SET debug_verify_column_bindings = true;
+
+foreach do '' 'column_lifetime'
+
+statement ok
+SET disabled_optimizers TO {do};
+
 query III
 WITH RECURSIVE
 interest_source AS (
@@ -71,3 +81,11 @@ LIMIT 20;
 ----
 1	2	1
 2	1	1
+
+endloop
+
+statement ok
+RESET disabled_optimizers;
+
+statement ok
+RESET debug_verify_column_bindings;

--- a/test/optimizer/compressed_materialization.test_slow
+++ b/test/optimizer/compressed_materialization.test_slow
@@ -108,7 +108,7 @@ from range(10)
 # and if we see it more than twice we're likely compressing and decompressing twice (once for each ORDER BY)
 # but we can compress once, then do both ORDER BYs, then decompress
 query II
-explain select count(i), count(j) from (select i, j from (select i, j from test order by j offset 1) order by j offset 1)
+explain select sum(i), sum(j) from (select i, j from (select i, j from test order by j offset 1) order by j offset 1)
 ----
 logical_opt	<REGEX>:(.*CAST.*){4}
 
@@ -121,7 +121,7 @@ logical_opt	<REGEX>:(.*CAST.*){3}
 
 # We can't deal with duplicate projections (yet) so this should see 3 compresses instead of 1
 query II
-explain select count(j1), count(j2) from (select j j1, j j2 from (select j from test order by j offset 1) order by j1, j2 offset 1)
+explain select sum(j1), sum(j2) from (select j j1, j j2 from (select j from test order by j offset 1) order by j1, j2 offset 1)
 ----
 logical_opt	<REGEX>:(.*CAST.*){6}
 

--- a/test/optimizer/statistics/statistics_count_not_null_join_pruning.test
+++ b/test/optimizer/statistics/statistics_count_not_null_join_pruning.test
@@ -1,0 +1,95 @@
+# name: test/optimizer/statistics/statistics_count_not_null_join_pruning.test
+# description: Statistics propagation column pruning with joins and projection maps
+# group: [statistics]
+
+# the second pruning pass runs on a plan that already carries projection maps
+statement ok
+SET debug_verify_column_bindings=true;
+
+# same two-fact-and-dimension fixture as test/optimizer/partial_aggregate_pushdown.test
+
+statement ok
+CREATE TABLE de_dim AS SELECT i AS k, (i % 7) AS g FROM range(50) _(i);
+
+statement ok
+CREATE TABLE de_a AS SELECT (i % 50) AS k FROM range(5000) _(i);
+
+statement ok
+CREATE TABLE de_b AS SELECT (i % 50) AS k, ((i * 13) % 100)::BIGINT AS metric FROM range(5000) _(i);
+
+# keeping the aggregate above the join exposes the stale bindings
+statement ok
+SET disabled_optimizers='partial_aggregate_pushdown';
+
+# metric cannot be NULL: count becomes count_star, but min keeps the column alive
+query III
+SELECT g, count(b.metric), min(b.metric)
+FROM de_a a JOIN de_dim d USING (k) JOIN de_b b USING (k)
+GROUP BY g
+ORDER BY g
+----
+0	80000	0
+1	70000	4
+2	70000	8
+3	70000	3
+4	70000	2
+5	70000	6
+6	70000	1
+
+statement ok
+RESET disabled_optimizers
+
+# nothing else needs metric, so the scan should not project it
+query II
+EXPLAIN SELECT count(b.metric) FROM de_a a JOIN de_dim d USING (k) JOIN de_b b USING (k)
+----
+physical_plan	<!REGEX>:.*metric.*
+
+# counted on the preserving side of an outer join, so it is still non-null and is pruned
+query II
+EXPLAIN SELECT count(b.metric) FROM de_b b LEFT JOIN de_a a USING (k)
+----
+physical_plan	<!REGEX>:.*metric.*
+
+query I
+SELECT count(b.metric) FROM de_b b LEFT JOIN de_a a USING (k)
+----
+500000
+
+# a semi join reaches the scan through the mark index rather than the projection map
+query II
+EXPLAIN SELECT count(b.metric) FROM de_b b WHERE b.k IN (SELECT k FROM de_a)
+----
+physical_plan	<!REGEX>:.*metric.*
+
+query I
+SELECT count(b.metric) FROM de_b b WHERE b.k IN (SELECT k FROM de_a)
+----
+5000
+
+# a cross product is an unconditional join and has no projection map at all
+query II
+EXPLAIN SELECT count(b.metric) FROM de_b b, de_dim d WHERE d.g = 0
+----
+physical_plan	<!REGEX>:.*metric.*
+
+query I
+SELECT count(b.metric) FROM de_b b, de_dim d WHERE d.g = 0
+----
+40000
+
+# partial aggregate pushdown runs before statistics propagation and splits the aggregate, so the
+# partial count below the join is created after the rewrite and keeps the column: results stay correct
+query II
+SELECT d.g, count(b.metric) FROM de_b b JOIN de_dim d USING (k) GROUP BY d.g ORDER BY d.g
+----
+0	800
+1	700
+2	700
+3	700
+4	700
+5	700
+6	700
+
+statement ok
+SET debug_verify_column_bindings=false;

--- a/test/optimizer/statistics/statistics_count_not_null_join_pruning.test
+++ b/test/optimizer/statistics/statistics_count_not_null_join_pruning.test
@@ -37,7 +37,7 @@ ORDER BY g
 6	70000	1
 
 statement ok
-RESET disabled_optimizers
+RESET disabled_optimizers;
 
 # nothing else needs metric, so the scan should not project it
 query II
@@ -92,4 +92,4 @@ SELECT d.g, count(b.metric) FROM de_b b JOIN de_dim d USING (k) GROUP BY d.g ORD
 6	700
 
 statement ok
-SET debug_verify_column_bindings=false;
+RESET debug_verify_column_bindings;

--- a/test/optimizer/statistics/statistics_count_not_null_pruning.test
+++ b/test/optimizer/statistics/statistics_count_not_null_pruning.test
@@ -173,4 +173,3 @@ SELECT grp, count(maybe_null) FROM filtered WHERE maybe_null > 0 GROUP BY grp OR
 g0	8
 g1	8
 g2	8
-

--- a/test/optimizer/statistics/statistics_count_not_null_pruning.test
+++ b/test/optimizer/statistics/statistics_count_not_null_pruning.test
@@ -1,0 +1,176 @@
+# name: test/optimizer/statistics/statistics_count_not_null_pruning.test
+# description: Statistics propagation prunes non-null COUNT arguments from scans
+# group: [statistics]
+
+statement ok
+PRAGMA explain_output = PHYSICAL_ONLY;
+
+statement ok
+CREATE TABLE events(user_id INTEGER NOT NULL, session_id INTEGER, device_type VARCHAR, event_type VARCHAR);
+
+statement ok
+INSERT INTO events VALUES (1, NULL, 'Desktop', 'action'), (2, 2, 'Mobile', 'view');
+
+# user_id cannot be NULL, so the aggregate becomes count_star() and the column is no longer read
+query II
+EXPLAIN SELECT device_type, count(user_id) FROM events GROUP BY device_type;
+----
+physical_plan	<!REGEX>:.*user_id.*
+
+# a nullable argument keeps the real count and the column
+query II
+EXPLAIN SELECT device_type, count(session_id) FROM events GROUP BY device_type;
+----
+physical_plan	<!REGEX>:.*count_star.*
+
+query TII
+SELECT device_type, count(user_id), count(session_id) FROM events GROUP BY device_type ORDER BY device_type;
+----
+Desktop	1	0
+Mobile	1	1
+
+# FILTER over a different column: rewritten, only the filter column survives
+query II
+EXPLAIN SELECT device_type, count(user_id) FILTER (WHERE event_type = 'action') FROM events GROUP BY device_type;
+----
+physical_plan	<!REGEX>:.*user_id.*
+
+query TI
+SELECT device_type, count(user_id) FILTER (WHERE event_type = 'action') FROM events GROUP BY device_type ORDER BY device_type;
+----
+Desktop	1
+Mobile	0
+
+# FILTER over the counted column: rewritten, but the column is still referenced
+query II
+EXPLAIN SELECT device_type, count(user_id) FILTER (WHERE user_id = 2) FROM events GROUP BY device_type;
+----
+physical_plan	<REGEX>:.*user_id.*
+
+query TI
+SELECT device_type, count(user_id) FILTER (WHERE user_id = 2) FROM events GROUP BY device_type ORDER BY device_type;
+----
+Desktop	0
+Mobile	1
+
+# count is not order dependent, so ORDER BY inside the aggregate is rewritten too
+query II
+EXPLAIN SELECT device_type, count(user_id ORDER BY event_type) FROM events GROUP BY device_type;
+----
+physical_plan	<!REGEX>:.*user_id.*
+
+query TI
+SELECT device_type, count(user_id ORDER BY event_type) FROM events GROUP BY device_type ORDER BY device_type;
+----
+Desktop	1
+Mobile	1
+
+# the rewrite must not change results, with any of the passes it depends on disabled
+# column_lifetime is the interesting one: the rerun is skipped so the cleared maps are not regenerated
+foreach disabled_opt 'statistics_propagation' 'unused_columns' 'column_lifetime'
+
+statement ok
+SET disabled_optimizers to {disabled_opt}
+
+query TII
+SELECT device_type, count(user_id), count(session_id) FROM events GROUP BY device_type ORDER BY device_type;
+----
+Desktop	1	0
+Mobile	1	1
+
+query TI
+SELECT device_type, count(user_id) FILTER (WHERE user_id = 2) FROM events GROUP BY device_type ORDER BY device_type;
+----
+Desktop	0
+Mobile	1
+
+statement ok
+RESET disabled_optimizers;
+
+endloop
+
+# the counted column is pruned from a join too, where the projection maps live
+statement ok
+CREATE TABLE devices(device_type VARCHAR, vendor VARCHAR);
+
+statement ok
+INSERT INTO devices VALUES ('Desktop', 'Acme'), ('Mobile', 'Globex');
+
+query II
+EXPLAIN SELECT d.vendor, count(e.user_id) FROM events e JOIN devices d USING (device_type) GROUP BY d.vendor;
+----
+physical_plan	<!REGEX>:.*user_id.*
+
+query TI
+SELECT d.vendor, count(e.user_id) FROM events e JOIN devices d USING (device_type) GROUP BY d.vendor ORDER BY d.vendor;
+----
+Acme	1
+Globex	1
+
+# a materialized CTE referenced twice also goes through the common subplan optimizer
+statement ok
+CREATE TABLE wide_events AS SELECT i AS user_id, 'd' || (i % 4) AS device_type FROM range(20) t(i);
+
+# DISTINCT must not be rewritten: 4 distinct values over 20 non-null rows
+query I
+SELECT count(DISTINCT device_type) FROM wide_events
+----
+4
+
+query II
+EXPLAIN WITH cte AS MATERIALIZED (SELECT device_type FROM wide_events)
+SELECT w.device_type, count(w.user_id) FROM wide_events w
+WHERE w.device_type IN (SELECT device_type FROM cte UNION ALL SELECT device_type FROM cte)
+GROUP BY w.device_type;
+----
+physical_plan	<!REGEX>:.*user_id.*
+
+query TI
+WITH cte AS MATERIALIZED (SELECT device_type FROM wide_events)
+SELECT w.device_type, count(w.user_id) FROM wide_events w
+WHERE w.device_type IN (SELECT device_type FROM cte UNION ALL SELECT device_type FROM cte)
+GROUP BY w.device_type ORDER BY w.device_type;
+----
+d0	5
+d1	5
+d2	5
+d3	5
+
+# identical union branches become one common subplan CTE, which the rerun then sees for the first time
+statement ok
+CREATE TABLE cs(a INTEGER, b INTEGER NOT NULL);
+
+statement ok
+INSERT INTO cs SELECT i, i FROM range(3) t(i);
+
+query II
+SELECT * FROM (
+    SELECT a, (SELECT count(b) FROM cs) AS c FROM cs
+    UNION ALL
+    SELECT a, (SELECT count(b) FROM cs) AS c FROM cs
+) ORDER BY 1, 2;
+----
+0	3
+0	3
+1	3
+1	3
+2	3
+2	3
+
+# non-nullness can come from a pushed-down filter rather than the column itself
+statement ok
+CREATE TABLE filtered AS SELECT CASE WHEN i % 5 = 0 THEN NULL ELSE i END AS maybe_null, 'g' || (i % 3) AS grp FROM range(30) t(i);
+
+# the filter still references the column, but the scan no longer projects it
+query II
+EXPLAIN SELECT grp, count(maybe_null) FROM filtered WHERE maybe_null > 0 GROUP BY grp;
+----
+physical_plan	<!REGEX>:.*Projections: maybe_null.*
+
+query TI
+SELECT grp, count(maybe_null) FROM filtered WHERE maybe_null > 0 GROUP BY grp ORDER BY grp;
+----
+g0	8
+g1	8
+g2	8
+

--- a/test/optimizer/unused_columns/cte_unused_columns.test
+++ b/test/optimizer/unused_columns/cte_unused_columns.test
@@ -29,3 +29,48 @@ WITH test AS MATERIALIZED (SELECT * FROM o_order)
 SELECT col0, col6, t2.* FROM test, (SELECT col1 FROM test) t2;
 ----
 logical_opt	<!REGEX>:.*col[2-5].*
+
+statement ok
+CREATE TABLE cte_fanout(source_key INTEGER, unused_payload VARCHAR);
+
+statement ok
+INSERT INTO cte_fanout VALUES (1, 'wide'), (2, 'column');
+
+query II
+EXPLAIN
+WITH c AS MATERIALIZED (SELECT * FROM cte_fanout)
+SELECT sum(source_key)
+FROM (
+    SELECT source_key FROM c
+    UNION ALL
+    SELECT source_key FROM c
+);
+----
+logical_opt	<!REGEX>:.*unused_payload.*
+
+query II
+EXPLAIN
+WITH c AS MATERIALIZED (SELECT * FROM cte_fanout)
+SELECT sum(source_key)
+FROM (
+    SELECT source_key FROM c
+    UNION ALL
+    SELECT source_key FROM c
+    UNION ALL
+    SELECT source_key FROM c
+);
+----
+logical_opt	<!REGEX>:.*unused_payload.*
+
+query I
+WITH c AS MATERIALIZED (SELECT * FROM cte_fanout)
+SELECT sum(source_key)
+FROM (
+    SELECT source_key FROM c
+    UNION ALL
+    SELECT source_key FROM c
+    UNION ALL
+    SELECT source_key FROM c
+);
+----
+9

--- a/test/sql/cte/materialized/test_cte_hash_join_exchange.test
+++ b/test/sql/cte/materialized/test_cte_hash_join_exchange.test
@@ -337,12 +337,14 @@ EXPLAIN ANALYZE
 WITH c AS MATERIALIZED (
   SELECT i, repeat('x', 32) payload FROM range(10000) t(i)
 )
-SELECT count(*)
+SELECT branch, count(*), sum(v)
 FROM (
-  SELECT c.i FROM c JOIN range(10000) r(i) USING (i)
+  SELECT 1 branch, length(c.payload) v FROM c JOIN range(10000) r(i) USING (i)
   UNION ALL
-  SELECT c.i FROM c JOIN range(10000) r(i) USING (i)
-);
+  SELECT 2 branch, length(c.payload) v FROM c JOIN range(10000) r(i) USING (i)
+)
+GROUP BY branch
+ORDER BY branch;
 ----
 analyzed_plan	<REGEX>:.*Execution Mode: STREAMING_FANOUT.*Direct Consumers: 2.*CTE Mode: DIRECT.*
 


### PR DESCRIPTION
Fixes #24593.

When statistics prove a column cannot be `NULL`, DuckDB rewrites `count(x)` into `count_star()`. The aggregate no longer needs the column, but the scan keeps reading it. 
The same query written as `count(*)` reads one column fewer. On a wide string column and with large tables, that difference could be most of the query.

It comes down to ordering: column pruning runs before statistics propagation, so it decides what to read while the plan still says `count(x)`.

Reproduce with:
```sql
CREATE TABLE events(app INTEGER, device_type VARCHAR, uuid VARCHAR NOT NULL);
INSERT INTO events SELECT (i%5), 'd'||(i%8), md5(i::VARCHAR) FROM range(5000000) t(i);
EXPLAIN SELECT device_type, count(uuid) FROM events WHERE app < 4 GROUP BY device_type;
```

## The fix
Statistics propagation now records when a callback drops an aggregate's arguments, and column pruning runs again when it did. Recording it at the expression level covers any aggregate that drops arguments, rather than matching `count` by name, thereby removing the separate `count` matcher in `PropagateStatistics`. Queries where nothing was rewritten are untouched.

The rerun clears projection maps first. Joins, filters, and orders address their input the pruner renumbers those positions, and the existing remapping only notices a column disappearing, not moving. `COLUMN_LIFETIME` rebuilds them.

Common subplan materialization runs before statistics propagation, so the rerun is the first time the pruner meets those CTEs, and it reached two pre-existing bugs there. A materialized CTE keeps one "everything is referenced" flag shared by all readers, but it was overwritten rather than accumulated, so a reader contributing no references could clear it and drop columns another reader still needed. It is now only ever set. A CTE whose own output exposes its readers' bindings is no longer pruned either, since the rewrite only covers the RHS and operators above the CTE would keep stale references.

## Tests
* `statistics_count_not_null_pruning.test`: the rewrite and the pruning, `FILTER` over the counted column and over another, `ORDER BY` inside the aggregate, `count(DISTINCT)` which must not be rewritten, a materialized CTE read twice, and non-nullness that comes from a pushed-down filter rather than the column definition. Every result is re-asserted with `statistics_propagation`, `unused_columns` and `column_lifetime` disabled in turn. It also covers the CTE flag: identical union branches that carry a scalar subquery `count` become a single common subplan CTE, and without the fix, that query fails to bind.
* `statistics_count_not_null_join_pruning.test`: the same pruning across inner and left joins, a semi join, and a cross product, under `debug_verify_column_bindings`. One boundary is pinned rather than left implicit: partial aggregate pushdown runs before statistics propagation, so when it splits the aggregate, the partial `count` below the join keeps the column. 
* `common_subplan_nested_cte.test`: its existing nested common subplan query, now with and without `column_lifetime`, under `debug_verify_column_bindings`. Disabling that pass is important because it rewrites the stale bindings afterward and masks the defect; without the fix, the query fails to bind to `interested_id`.
* `compressed_materialization.test_slow` counted a column it also expects to see in the scan projection, so it was relying on the behavior being fixed here. Those two aggregates become `sum`, which genuinely reads its argument. 
* `test_cte_hash_join_exchange.test`: its `STREAMING_FANOUT` expectation relied on the pruning bug keeping the unread `payload` column wide enough to exceed the materialization budget: the `EXPLAIN ANALYZE` now asserts the executed sibling query, which reads `payload`, since pruning unused materialized CTE columns intentionally narrows the width the fanout cost model sees.

## Benchmark
It's starting to be observable around 5M, but the use case is much worse with a table around 20B.
`benchmark/micro/optimizer/count_not_null_column_prune.benchmark`, registered in `.github/regression/micro.csv`: 5M rows, a 32-character `uuid`, persistent storage. 

Running exactly that on the base commit and on this branch:
```
base         Projections: device_type, uuid     0.12 / 0.11 / 0.12 s
this branch  Projections: device_type           0.02 / 0.02 / 0.03 s
```
