### PR TITLE
Honour FILE_FLAGS_EXCLUSIVE_CREATE on Windows

### DIFF
--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -1280,7 +1280,13 @@ unique_ptr<FileHandle> LocalFileSystem::OpenFile(const string &path_p, FileOpenF
 	share_mode |= FILE_SHARE_DELETE;
 
 	if (open_write) {
-		if (flags.CreateFileIfNotExists()) {
+		// EXCLUSIVE_CREATE is tested FIRST: FileOpenFlags::Verify requires it to be combined with
+		// FILE_CREATE/FILE_CREATE_NEW, so every legal caller also sets one of those and testing them first
+		// would swallow it. CREATE_NEW fails with ERROR_FILE_EXISTS instead of opening the existing file,
+		// which is what O_EXCL gives the POSIX branch above.
+		if (flags.ExclusiveCreate()) {
+			creation_disposition = CREATE_NEW;
+		} else if (flags.CreateFileIfNotExists()) {
 			creation_disposition = OPEN_ALWAYS;
 		} else if (flags.OverwriteExistingFile()) {
 			creation_disposition = CREATE_ALWAYS;
@@ -1292,7 +1298,15 @@ unique_ptr<FileHandle> LocalFileSystem::OpenFile(const string &path_p, FileOpenF
 	HANDLE hFile = CreateFileW(unicode_path.c_str(), desired_access, share_mode, NULL, creation_disposition,
 	                           flags_and_attributes, NULL);
 	if (hFile == INVALID_HANDLE_VALUE) {
-		if (flags.ReturnNullIfNotExists() && GetLastError() == ERROR_FILE_NOT_FOUND) {
+		auto last_error = GetLastError();
+		if (flags.ReturnNullIfNotExists() && last_error == ERROR_FILE_NOT_FOUND) {
+			return nullptr;
+		}
+		// Mirrors the EEXIST case in the POSIX branch: FILE_FLAGS_NULL_IF_EXISTS may only be set together
+		// with EXCLUSIVE_CREATE, so this reports a lost race as a null handle rather than a throw.
+		// ERROR_ALREADY_EXISTS is accepted alongside ERROR_FILE_EXISTS because CreateFileW reports that
+		// one for some existing entries.
+		if (flags.ReturnNullIfExists() && (last_error == ERROR_FILE_EXISTS || last_error == ERROR_ALREADY_EXISTS)) {
 			return nullptr;
 		}
 		auto error = LocalFileSystem::GetLastErrorAsString();

--- a/test/common/test_file_system.cpp
+++ b/test/common/test_file_system.cpp
@@ -479,6 +479,53 @@ TEST_CASE("filesystem concurrent access and deletion", "[file_system]") {
 	REQUIRE(!fs->FileExists(fname));
 }
 
+TEST_CASE("exclusive create fails when the file exists", "[file_system]") {
+	auto fs = FileSystem::CreateLocal();
+
+	auto fname = TestCreatePath("exclusive_create_test_file");
+	fs->TryRemoveFile(fname);
+
+	const string payload = "EXCLUSIVE_CREATE_ORIGINAL_CONTENT";
+	auto exclusive_flags =
+	    FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE | FileFlags::FILE_FLAGS_EXCLUSIVE_CREATE;
+
+	// On a path that does not exist yet the exclusive create succeeds, and hands back an ordinary
+	// writable handle.
+	auto handle = fs->OpenFile(fname, exclusive_flags);
+	REQUIRE(handle != nullptr);
+	handle->Write(QueryContext(), static_cast<void *>(const_cast<char *>(payload.c_str())), payload.size(),
+	              /*location=*/0);
+	handle->Sync();
+	handle.reset();
+	REQUIRE(fs->FileExists(fname));
+
+	// The file exists now, so the identical open must FAIL rather than hand out a handle to it. That is the
+	// whole point of the flag: it lets a caller create a file only if nobody else got there first.
+	REQUIRE_THROWS(fs->OpenFile(fname, exclusive_flags));
+
+	// ... and with NULL_IF_EXISTS the same collision is reported as a null handle instead of a throw.
+	auto null_handle = fs->OpenFile(fname, exclusive_flags | FileFlags::FILE_FLAGS_NULL_IF_EXISTS);
+	REQUIRE(null_handle == nullptr);
+
+	// A rejected exclusive create must leave the existing file completely alone; in particular it must not
+	// have truncated it on the way to failing.
+	string read_back(payload.size(), '\0');
+	auto read_handle = fs->OpenFile(fname, FileFlags::FILE_FLAGS_READ);
+	read_handle->Read(QueryContext(), static_cast<void *>(const_cast<char *>(read_back.data())), payload.size(),
+	                  /*location=*/0);
+	REQUIRE(read_back == payload);
+	read_handle.reset();
+
+	// Control: without the exclusive flag the very same path opens fine. Without this the two failures above
+	// would pass equally if the file had simply become unopenable.
+	auto reopen = fs->OpenFile(fname, FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE);
+	REQUIRE(reopen != nullptr);
+	reopen.reset();
+
+	fs->RemoveFile(fname);
+	REQUIRE(!fs->FileExists(fname));
+}
+
 // ------------------------------------------------------------------------------------------------
 // Path struct tests
 // ------------------------------------------------------------------------------------------------


### PR DESCRIPTION
closes https://github.com/duckdb/duckdb/issues/24610
FileOpenFlags::ExclusiveCreate() is read in exactly one place in the tree: the POSIX branch of LocalFileSystem::OpenFile, where it maps to O_EXCL. The Windows branch never consults it, so the flag is silently dropped and the open falls through to OPEN_ALWAYS ("open, creating if absent"), which happily returns a handle to the already-existing file. CREATE_NEW -- the Win32 disposition that fails with ERROR_FILE_EXISTS, i.e. exactly this primitive -- appears nowhere in the file.

Consequence: a caller using the flag to create a file only if nobody else got there first silently races on Windows.

FILE_FLAGS_NULL_IF_EXISTS is dead on Windows for the same reason: it may only be set together with EXCLUSIVE_CREATE (see FileOpenFlags::Verify), and since the create never failed it could never return null. The error branch now mirrors the POSIX one, which already handles EEXIST.

Both flags arrived in #13123, which added them, added their combination rules to FileOpenFlags::Verify, and implemented them in the POSIX branch only; the Windows disposition block in the same function dates from 2021 and was not revisited. Neither flag has an in-tree caller, so no existing test could reach the Windows path -- they are used by extensions and over the C API, where DUCKDB_FILE_FLAG_CREATE_NEW has exposed the flag publicly since d4f7b546.

The new test is platform-agnostic: it passes on POSIX before and after this change, and fails on Windows without it.