### PR TITLE
Fix CREATE SEQUENCE throwing INTERNAL error on NULL option values

### DIFF
--- a/src/parser/peg/transformer/transform_create_sequence.cpp
+++ b/src/parser/peg/transformer/transform_create_sequence.cpp
@@ -45,6 +45,9 @@ unique_ptr<CreateStatement> PEGTransformerFactory::TransformCreateSequenceStmt(
 	for (auto &option : sequence_options) {
 		if (option.first == "increment") {
 			auto seq_val_option = unique_ptr_cast<SequenceOption, ValueSequenceOption>(std::move(option.second));
+			if (seq_val_option->value.IsNull()) {
+				throw ParserException("INCREMENT must not be NULL");
+			}
 			info->increment = seq_val_option->value.GetValue<int64_t>();
 			if (info->increment == 0) {
 				throw ParserException("Increment must not be zero");
@@ -68,6 +71,9 @@ unique_ptr<CreateStatement> PEGTransformerFactory::TransformCreateSequenceStmt(
 				continue;
 			}
 			auto seq_val_option = unique_ptr_cast<SequenceOption, ValueSequenceOption>(std::move(option.second));
+			if (seq_val_option->value.IsNull()) {
+				throw ParserException("MINVALUE must not be NULL");
+			}
 			info->min_value = seq_val_option->value.GetValue<int64_t>();
 			min_value_set = true;
 		} else if (option.first == "maxvalue") {
@@ -75,10 +81,16 @@ unique_ptr<CreateStatement> PEGTransformerFactory::TransformCreateSequenceStmt(
 				continue;
 			}
 			auto seq_val_option = unique_ptr_cast<SequenceOption, ValueSequenceOption>(std::move(option.second));
+			if (seq_val_option->value.IsNull()) {
+				throw ParserException("MAXVALUE must not be NULL");
+			}
 			info->max_value = seq_val_option->value.GetValue<int64_t>();
 			max_value_set = true;
 		} else if (option.first == "start") {
 			auto seq_val_option = unique_ptr_cast<SequenceOption, ValueSequenceOption>(std::move(option.second));
+			if (seq_val_option->value.IsNull()) {
+				throw ParserException("START value must not be NULL");
+			}
 			info->start_value = seq_val_option->value.GetValue<int64_t>();
 			has_start_value = true;
 		} else if (option.first == "cycle") {

--- a/test/sql/catalog/sequence/test_sequence.test
+++ b/test/sql/catalog/sequence/test_sequence.test
@@ -558,3 +558,34 @@ statement error
 CREATE SEQUENCE wrongseq INCREMENT 2 INCREMENT BY -1;
 ----
 Parser Error: Increment should be passed at most once
+
+# NULL is not a valid value for sequence options
+statement error
+CREATE SEQUENCE wrongseq START NULL;
+----
+<REGEX>:.*Parser Error.*START value must not be NULL.*
+
+statement error
+CREATE SEQUENCE wrongseq START WITH NULL;
+----
+<REGEX>:.*Parser Error.*START value must not be NULL.*
+
+statement error
+CREATE SEQUENCE wrongseq MINVALUE NULL;
+----
+<REGEX>:.*Parser Error.*MINVALUE must not be NULL.*
+
+statement error
+CREATE SEQUENCE wrongseq MAXVALUE NULL;
+----
+<REGEX>:.*Parser Error.*MAXVALUE must not be NULL.*
+
+statement error
+CREATE SEQUENCE wrongseq INCREMENT BY NULL;
+----
+<REGEX>:.*Parser Error.*INCREMENT must not be NULL.*
+
+statement error
+CREATE SEQUENCE wrongseq CYCLE START NULL;
+----
+<REGEX>:.*Parser Error.*START value must not be NULL.*


### PR DESCRIPTION
## Description
CREATE SEQUENCE with a NULL option value (START / MINVALUE / MAXVALUE / INCREMENT BY)
threw an INTERNAL error. This rejects NULL with a clean Parser Error naming the option.

## What was happening
`CREATE SEQUENCE s START NULL;` (and the other numeric options) surfaced
`INTERNAL Error: Calling GetValue on a value that is NULL`.

## What should happen
A user-facing Parser Error, e.g. `Parser Error: START value must not be NULL`.

## Root cause
`TransformCreateSequenceStmt` called `Value::GetValue<int64_t>()` on each option's
parsed constant without checking `IsNull()`. NULL is a legal literal at that grammar
position, so it reached the assert in `Value::GetValue`.

## Changes
- Add `IsNull()` guards for INCREMENT, MINVALUE, MAXVALUE, START in
  `transform_create_sequence.cpp`, throwing `ParserException` naming the option.
- Add regression tests covering all four options, the `START WITH` alias, and a
  combined `CYCLE START NULL` case.

## Testing
- Focused: `test/sql/catalog/sequence/test_sequence.test` (fails before, passes after)
- Related: `test/sql/catalog/sequence/*`, `test/issues/fuzz/sequence_overflow.test`
- Broader: `test/sql/catalog/*`, `test/sql/parser/*`, `test/sql/create/*`
All pass.

## Related Issue
Fixes #24602