### PR TITLE
Prevent unsafe narrowing-cast rewrite in comparison simplification

### DIFF
--- a/src/optimizer/rule/comparison_simplification.cpp
+++ b/src/optimizer/rule/comparison_simplification.cpp
@@ -172,6 +172,14 @@ unique_ptr<Expression> ComparisonSimplificationRule::Apply(LogicalOperator &op, 
 		if (!BoundCastExpression::CastIsInvertible(target_type, cast_expression.GetReturnType())) {
 			return nullptr;
 		}
+		// Narrowing between integer types loses information even when CastIsInvertible allows it
+		// (e.g. INTEGER -> TINYINT: not every INTEGER value fits in a TINYINT).
+		if (target_type.IsIntegral() && cast_expression.GetReturnType().IsIntegral()) {
+			if (Value::MinimumValue(target_type) < Value::MinimumValue(cast_expression.GetReturnType()) ||
+				Value::MaximumValue(target_type) > Value::MaximumValue(cast_expression.GetReturnType())) {
+        		return nullptr;
+			}
+		}
 
 		// Can we cast the constant at all?
 		string error_message;

--- a/src/optimizer/rule/comparison_simplification.cpp
+++ b/src/optimizer/rule/comparison_simplification.cpp
@@ -172,13 +172,12 @@ unique_ptr<Expression> ComparisonSimplificationRule::Apply(LogicalOperator &op, 
 		if (!BoundCastExpression::CastIsInvertible(target_type, cast_expression.GetReturnType())) {
 			return nullptr;
 		}
-		// Narrowing between integer types loses information even when CastIsInvertible allows it
-		// (e.g. INTEGER -> TINYINT: not every INTEGER value fits in a TINYINT).
-		if (target_type.IsIntegral() && cast_expression.GetReturnType().IsIntegral()) {
-			if (Value::MinimumValue(target_type) < Value::MinimumValue(cast_expression.GetReturnType()) ||
-				Value::MaximumValue(target_type) > Value::MaximumValue(cast_expression.GetReturnType())) {
-        		return nullptr;
-			}
+		// Narrowing casts can lose information even when CastIsInvertible allows it
+		// (e.g. INTEGER -> TINYINT). Pass try_cast=false regardless of whether this
+		// expression is a TRY_CAST: we're asking whether the type pair itself can
+		// lose information, not whether this particular cast throws at runtime.
+		if (BoundCastExpression::CastCanThrow(target_type, cast_expression.GetReturnType(), false)) {
+    		return nullptr;
 		}
 
 		// Can we cast the constant at all?

--- a/test/optimizer/comparison_simplification_narrowing_cast.test
+++ b/test/optimizer/comparison_simplification_narrowing_cast.test
@@ -1,0 +1,27 @@
+# name: test/optimizer/comparison_simplification_narrowing_cast.test
+# description: Ensure narrowing integer casts are not incorrectly rewritten away in comparisons
+# group: [optimizer]
+
+statement ok
+CREATE TABLE t(a INT);
+
+statement ok
+INSERT INTO t VALUES (51), (127), (128), (200), (300), (-200);
+
+# Values outside TINYINT's range must not be silently included -
+# TRY_CAST(a AS TINYINT) should evaluate to NULL for those, failing the '> 50' filter.
+query I
+SELECT a FROM t WHERE TRY_CAST(a AS TINYINT) > 50 ORDER BY a
+----
+51
+127
+
+# Confirm the optimizer isn't stripping the cast from the filter expression -
+# it must still appear in the optimized plan, not get simplified down to 'a > 50'.
+statement ok
+PRAGMA explain_output = OPTIMIZED_ONLY;
+
+query II
+EXPLAIN SELECT a FROM t WHERE TRY_CAST(a AS TINYINT) > 50
+----
+logical_opt	<REGEX>:.*TRY_CAST.*


### PR DESCRIPTION
Fixes #23687. ComparisonSimplificationRule was stripping casts like TRY_CAST(a AS TINYINT) when rewriting comparisons, using CastIsInvertible as the sole guard. That function has no awareness of integer-narrowing casts (e.g. INTEGER -> TINYINT), so it incorrectly allowed the rewrite even when source values fall outside the target type's range, silently changing query results.

Added an explicit range check: for integer-to-integer casts, only allow the rewrite if the source type's full range fits inside the target type's range. Includes a regression test.