### PR TITLE
Fix Windows static-extension builds with MSVC-targeting Clang

### DIFF
--- a/extension/extension_build_tools.cmake
+++ b/extension/extension_build_tools.cmake
@@ -138,7 +138,9 @@ function(build_loadable_extension_directory NAME ABI_TYPE OUTPUT_DIRECTORY EXTEN
     elseif(${ABI_TYPE} STREQUAL "C_STRUCT" OR ${ABI_TYPE} STREQUAL "C_STRUCT_UNSTABLE")
         # TODO strip all symbols except the capi init
     elseif (EXTENSION_STATIC_BUILD)
-        if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+        if (WIN32 AND NOT MINGW)
+            target_link_libraries(${TARGET_NAME} duckdb_static dummy_static_extension_loader ${DUCKDB_EXTRA_LINK_FLAGS})
+        elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
             if (APPLE)
                 set_target_properties(${TARGET_NAME} PROPERTIES CXX_VISIBILITY_PRESET hidden)
                 # Note that on MacOS we need to use the -exported_symbol whitelist feature due to a lack of -exclude-libs flag in mac's ld variant

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,7 +28,7 @@ endif()
 
 set(DUCKDB_SYSTEM_LIBS ${CMAKE_DL_LIBS})
 
-if(MSVC OR MINGW)
+if(WIN32)
   set(DUCKDB_SYSTEM_LIBS ${DUCKDB_SYSTEM_LIBS} ws2_32 rstrtmgr)
 endif()
 if(MSVC)


### PR DESCRIPTION
We should give some leeway to windows builds using clang.
Clang builds the project under windows just fine, and we don't really need to make big changes to support it

The tiny problem is:
```cmake
if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
```

This is checking whether we use clang, and erroneously pass the `-Wl,--gc-sections -Wl,--exclude-libs,ALL` to the compiler, even when we are building under windows with clang

It is an easy fix, we just need to reorder the checks, so that we check whether we are in a native-ish windows build first and deal with it appropriately. These options are appropriate for the GNU/MinGW-style linker path, but not for a native Windows Clang build.


And again,
```cmake
if(MSVC OR MINGW)
```

can be just simplified to 

```
if(WIN32)
```

We are gonna be linking `ws2_32` and `rstrtmgr` under windows regardless of the compiler anyways.


