### PR TITLE
fix issue 24616

### DIFF
--- a/extension/core_functions/scalar/list/list_reduce.cpp
+++ b/extension/core_functions/scalar/list/list_reduce.cpp
@@ -333,6 +333,8 @@ ScalarFunctionSet ListReduceFun::GetFunctions() {
 	fun.SetSerializeCallback(ListLambdaBindData::Serialize);
 	fun.SetDeserializeCallback(ListLambdaBindData::Deserialize);
 	fun.SetBindLambdaCallback(ListReduceBindLambda);
+	// the lambda expression that is executed for every element can throw
+	fun.SetFallible();
 
 	ScalarFunctionSet set;
 	set.AddFunction(fun);

--- a/test/sql/function/list/list_reduce_fallible.test
+++ b/test/sql/function/list/list_reduce_fallible.test
@@ -1,0 +1,42 @@
+# name: test/sql/function/list/list_reduce_fallible.test
+# description: Test that list_reduce returns clean errors (not INTERNAL errors) when lambda throws
+# group: [list]
+
+# integer overflow in subtraction should give a clean Out of Range Error
+statement error
+SELECT list_reduce([10, -2147483648]::INTEGER[], lambda x, y: x - y);
+----
+Out of Range Error
+
+# bigint overflow in multiplication should give a clean Out of Range Error
+statement error
+SELECT list_reduce([9223372036854775807, 2]::BIGINT[], lambda x, y: x * y);
+----
+Out of Range Error
+
+# list_reduce with initial value should also return clean errors
+statement error
+SELECT list_reduce([2147483647]::INTEGER[], lambda x, y: x + y, 2147483647);
+----
+Out of Range Error
+
+# verify that valid list_reduce calls still work correctly
+query I
+SELECT list_reduce([1, 2, 3, 4], lambda x, y: x + y);
+----
+10
+
+query I
+SELECT list_reduce([1, 2, 3], lambda x, y: x * y);
+----
+6
+
+query I
+SELECT list_reduce([10, 3, 2], lambda x, y: x - y);
+----
+5
+
+query I
+SELECT list_reduce([1, 2, 3], lambda x, y: x + y, 100);
+----
+106


### PR DESCRIPTION
Description
This PR fixes an issue where the list_reduce function returns an INTERNAL Error instead of a clean, user-facing error when its lambda expression throws an error (e.g., during arithmetic overflow).

What happens?
The list_reduce scalar function wasn't marked as fallible, meaning any exception thrown during evaluation surfaced as an INTERNAL Error pointing to an assertion failure within DuckDB. This was because it was missing a SetFallible() call in its registration, unlike its siblings list_transform and list_filter.

Fix
Added the missing fun.SetFallible(); to ListReduceFun::GetFunctions() in extension/core_functions/scalar/list/list_reduce.cpp.

Now, when a lambda inside list_reduce causes an exception, it propagates the clean error (e.g., Out of Range Error: Overflow) matching the existing behavior of list_transform and list_filter.

Testing
Added regression tests in test/sql/function/list/list_reduce_fallible.test to ensure overflows and other clean exceptions are handled and reported properly by list_reduce.
Closes #24616