### PR TITLE
Avoid WindowSegmentTree aggregation for dynamic min/max N windows

### DIFF
--- a/src/function/window/window_segment_tree.cpp
+++ b/src/function/window/window_segment_tree.cpp
@@ -10,6 +10,30 @@ namespace duckdb {
 //===--------------------------------------------------------------------===//
 // WindowSegmentTree
 //===--------------------------------------------------------------------===//
+
+// min/max style functions with an N argument store N as the aggregate heap
+// capacity. The segment tree builds range states from leaves and recursively
+// combines them into higher levels, so varying N values inside those ranges can
+// create incompatible non-leaf states. Only allow the segment tree when N is
+// constant/foldable.
+static bool HasFoldableMinMaxNArgument(const BoundWindowExpression &wexpr) {
+	const auto &aggr = *wexpr.AggregateFunction();
+	const auto &children = wexpr.GetChildren();
+	const auto &name = aggr.GetName();
+
+	if ((name == "min" || name == "max") && children.size() == 2) {
+		return !children[1]->HasParameter() && children[1]->IsFoldable();
+	}
+
+	if ((name == "arg_min" || name == "arg_max" || name == "argmin" || name == "argmax" || name == "min_by" ||
+	     name == "max_by" || name == "arg_min_nulls_last" || name == "arg_max_nulls_last") &&
+	    children.size() == 3) {
+		return !children[2]->HasParameter() && children[2]->IsFoldable();
+	}
+
+	return true;
+}
+
 bool WindowSegmentTree::CanAggregate(const BoundWindowExpression &wexpr) {
 	if (!wexpr.AggregateFunction()) {
 		return false;
@@ -21,6 +45,10 @@ bool WindowSegmentTree::CanAggregate(const BoundWindowExpression &wexpr) {
 
 	//	Don't use segment trees for custom windowing
 	if (wexpr.AggregateFunction()->CanWindow()) {
+		return false;
+	}
+
+	if (!HasFoldableMinMaxNArgument(wexpr)) {
 		return false;
 	}
 

--- a/test/sql/window/test_minmax_n_dynamic_window.test
+++ b/test/sql/window/test_minmax_n_dynamic_window.test
@@ -1,0 +1,59 @@
+# name: test/sql/window/test_minmax_n_dynamic_window.test
+# description: Test windowed min/max N aggregates with dynamic N arguments
+# group: [window]
+
+foreach FUNC min max
+
+query I
+SELECT {FUNC}(i, CASE WHEN i < 16 THEN 1 ELSE 2 END) OVER (
+	ROWS BETWEEN CURRENT ROW AND CURRENT ROW
+) AS window_result
+FROM range(17) AS t(i);
+----
+[0]
+[1]
+[2]
+[3]
+[4]
+[5]
+[6]
+[7]
+[8]
+[9]
+[10]
+[11]
+[12]
+[13]
+[14]
+[15]
+[16]
+
+endloop
+
+foreach FUNC arg_min arg_max argmin argmax min_by max_by arg_min_nulls_last arg_max_nulls_last
+
+query I
+SELECT {FUNC}(i, i, CASE WHEN i < 16 THEN 1 ELSE 2 END) OVER (
+	ROWS BETWEEN CURRENT ROW AND CURRENT ROW
+) AS window_result
+FROM range(17) AS t(i);
+----
+[0]
+[1]
+[2]
+[3]
+[4]
+[5]
+[6]
+[7]
+[8]
+[9]
+[10]
+[11]
+[12]
+[13]
+[14]
+[15]
+[16]
+
+endloop


### PR DESCRIPTION
Fixes #24449                                                                                                                                                                                 
                                                                                                                                                                                               
Window segment trees combine aggregate states while building higher levels. The min/max and arg_min/arg_max N variants store N as heap capacity, so dynamic N values can create incompatible states during combine.

This falls back to the naive window aggregator when the N argument is not foldable, and adds regression coverage for the affected N-variant aggregates.

Tested with:
```bash
./build/debug/test/unittest test/sql/window/test_minmax_n_dynamic_window.test
```