### PR TITLE
Fix histogram with row-dependent window bins

### DIFF
--- a/extension/core_functions/aggregate/nested/binned_histogram.cpp
+++ b/extension/core_functions/aggregate/nested/binned_histogram.cpp
@@ -391,6 +391,9 @@ unique_ptr<FunctionData> HistogramBinBindFunction(BindAggregateFunctionInput &in
 	}
 
 	function.ReplaceImplementation(GetHistogramBinFunction<HIST>(arguments[0]->GetReturnType()));
+	if (!arguments[1]->IsFoldable()) {
+		function.SetFallible();
+	}
 	return nullptr;
 }
 

--- a/src/function/window/window_segment_tree.cpp
+++ b/src/function/window/window_segment_tree.cpp
@@ -24,6 +24,13 @@ bool WindowSegmentTree::CanAggregate(const BoundWindowExpression &wexpr) {
 		return false;
 	}
 
+	// Fallible aggregates with multiple arguments may have row-dependent parameters. The segment tree
+	// combines states outside individual frames, which can trigger errors for otherwise valid frames.
+	if (wexpr.AggregateFunction()->GetErrorMode() == FunctionErrors::CAN_THROW_RUNTIME_ERROR &&
+	    wexpr.GetChildren().size() > 1) {
+		return false;
+	}
+
 	//	We can't handle DISTINCT, ORDER BY args or () args (COUNT(*))
 	return !wexpr.Distinct() && wexpr.ArgOrders().empty() && !wexpr.GetChildren().empty();
 }

--- a/test/sql/aggregate/aggregates/histogram_exact.test
+++ b/test/sql/aggregate/aggregates/histogram_exact.test
@@ -105,3 +105,16 @@ query I
 SELECT is_histogram_other_bin({'i': NULL::INT[][]})
 ----
 true
+
+# Row-dependent bins in a singleton window frame should not be combined outside the frame
+query III
+SELECT count(*), sum(window_result[0]), sum(window_result[2147483647])
+FROM (
+  SELECT histogram_exact(0, CASE WHEN i < 16 THEN [0] ELSE [1] END) OVER (
+    ORDER BY i
+    ROWS BETWEEN CURRENT ROW AND CURRENT ROW
+  ) AS window_result
+  FROM range(17) AS t(i)
+) windowed
+----
+17	16	1


### PR DESCRIPTION
Fixes #24451

`histogram_exact` with row-dependent bin expressions failed for singleton window frames because the segment tree combined intermediate states with different bin boundaries, even though those rows were never part of the same frame.

This change marks binned histograms with row-dependent bins as fallible and avoids the segment-tree path for these multi-argument aggregates. Constant-bin histograms continue using the optimized path.

A regression test covering the reported query has been added.

Tests:
- `histogram_exact.test`
- `test_binned_histogram.test`
- `test_naive_aggregation.test`
- `test_kurtosis.test`