### PR TITLE
Fix UB for ALP

### DIFF
--- a/src/include/duckdb/storage/compression/alp/algorithm/alp.hpp
+++ b/src/include/duckdb/storage/compression/alp/algorithm/alp.hpp
@@ -121,6 +121,9 @@ struct AlpCompression {
 			return ExactNumericCast<int64_t>(AlpConstants::ENCODING_UPPER_LIMIT);
 		}
 		n = n + AlpTypedConstants<T>::MAGIC_NUMBER - AlpTypedConstants<T>::MAGIC_NUMBER;
+		if (IsImpossibleToEncode(n)) {
+			return ExactNumericCast<int64_t>(AlpConstants::ENCODING_UPPER_LIMIT);
+		}
 		return LossyNumericCast<int64_t>(n);
 	}
 

--- a/test/sql/storage/compression/alp/alp_out_of_range.test
+++ b/test/sql/storage/compression/alp/alp_out_of_range.test
@@ -1,0 +1,19 @@
+# name: test/sql/storage/compression/alp/alp_out_of_range.test
+# description: Test ALP compression of values outside the int64 range
+# group: [alp]
+
+load {TEST_DIR}/test_alp_out_of_range.db
+
+statement ok
+CREATE TABLE integers(v DOUBLE);
+
+statement ok
+INSERT INTO integers SELECT 9223372036854775807.0 FROM range(3000);
+
+statement ok
+CHECKPOINT;
+
+query II
+SELECT count(*), count(*) FILTER (WHERE v != 9223372036854775807.0) FROM integers;
+----
+3000	0


### PR DESCRIPTION
Closes https://github.com/duckdb/duckdb/issues/24634

The issue magic-number rounding moves a valid double outside the int64_t range, so we need to echeck the rounded value before casting. The UB error message clearly indicates the code location.