### PR TITLE
Require 16GB RAM for string_agg overflow test

### DIFF
--- a/test/sql/aggregate/aggregates/test_string_agg_overflow.test_slow
+++ b/test/sql/aggregate/aggregates/test_string_agg_overflow.test_slow
@@ -2,6 +2,8 @@
 # description: STRING_AGG allocation size overflow
 # group: [aggregates]
 
+require ram 16gb
+
 statement ok
 SET threads=1;
 


### PR DESCRIPTION
Fixes #24642.

`test_string_agg_overflow.test_slow` requires approximately 7.8 GiB of peak memory because previous arena allocations remain alive when the final 4 GiB allocation is made. This causes the test to fail on low-memory macOS CI runners.

**Fix**
Add a 16 GB RAM requirement so the test is skipped on low-memory runners while continuing to run on higher-memory CI runners.