### PR TITLE
Add data_page_size_limit option to Parquet COPY

### DIFF
--- a/extension/parquet/include/parquet_writer.hpp
+++ b/extension/parquet/include/parquet_writer.hpp
@@ -167,6 +167,8 @@ struct ParquetWriterOptions {
 	optional_idx dictionary_size_limit;
 	//! The maximum bytes of string-data to put into the dictionary, per column/field
 	idx_t string_dictionary_page_size_limit;
+	//! The maximum uncompressed size of a data page
+	idx_t data_page_size_limit;
 	//! Whether to use bloom filters or not
 	bool enable_bloom_filters;
 	//! Maximum ratio of false-positives to allow in the written bloom filter
@@ -230,6 +232,9 @@ public:
 	}
 	idx_t StringDictionaryPageSizeLimit() const {
 		return options.string_dictionary_page_size_limit;
+	}
+	idx_t DataPageSizeLimit() const {
+		return options.data_page_size_limit;
 	}
 	bool EnableBloomFilters() const {
 		return options.enable_bloom_filters;

--- a/extension/parquet/parquet_extension.cpp
+++ b/extension/parquet/parquet_extension.cpp
@@ -105,6 +105,9 @@ struct ParquetWriteBindData : public TableFunctionData {
 	//! This is huge but we grow it starting from 1 MB
 	idx_t string_dictionary_page_size_limit = PrimitiveColumnWriter::MAX_UNCOMPRESSED_DICT_PAGE_SIZE;
 
+	//! The maximum uncompressed size of a data page
+	idx_t data_page_size_limit = PrimitiveColumnWriter::MAX_UNCOMPRESSED_PAGE_SIZE;
+
 	bool enable_bloom_filters = true;
 	//! What false positive rate are we willing to accept for bloom filters
 	double bloom_filter_false_positive_ratio = 0.01;
@@ -147,6 +150,7 @@ static void ParquetListCopyOptions(ClientContext &context, CopyOptionsInput &inp
 	copy_options["encryption_config"] = CopyOption(LogicalType::ANY, CopyOptionMode::READ_WRITE);
 	copy_options["dictionary_size_limit"] = CopyOption(LogicalType::BIGINT, CopyOptionMode::WRITE_ONLY);
 	copy_options["string_dictionary_page_size_limit"] = CopyOption(LogicalType::UBIGINT, CopyOptionMode::WRITE_ONLY);
+	copy_options["data_page_size_limit"] = CopyOption(LogicalType::UBIGINT, CopyOptionMode::WRITE_ONLY);
 	copy_options["bloom_filter_false_positive_ratio"] = CopyOption(LogicalType::DOUBLE, CopyOptionMode::WRITE_ONLY);
 	copy_options["debug_use_openssl"] = CopyOption(LogicalType::BOOLEAN, CopyOptionMode::READ_WRITE);
 	copy_options["write_bloom_filter"] = CopyOption(LogicalType::BOOLEAN, CopyOptionMode::WRITE_ONLY);
@@ -305,6 +309,13 @@ static unique_ptr<FunctionData> ParquetWriteBind(ClientContext &context, CopyFun
 				    PrimitiveColumnWriter::MAX_UNCOMPRESSED_DICT_PAGE_SIZE);
 			}
 			bind_data->string_dictionary_page_size_limit = val;
+		} else if (option_name == "data_page_size_limit") {
+			auto val = option_values[0].GetValue<uint64_t>();
+			if (val > PrimitiveColumnWriter::MAX_UNCOMPRESSED_PAGE_SIZE || val == 0) {
+				throw BinderException("data_page_size_limit cannot be 0 and must be less than or equal to %llu",
+				                      PrimitiveColumnWriter::MAX_UNCOMPRESSED_PAGE_SIZE);
+			}
+			bind_data->data_page_size_limit = val;
 		} else if (option_name == "write_bloom_filter") {
 			bind_data->enable_bloom_filters = BooleanValue::Get(option_values[0].DefaultCastAs(LogicalType::BOOLEAN));
 		} else if (option_name == "bloom_filter_false_positive_ratio") {
@@ -395,6 +406,7 @@ static unique_ptr<GlobalFunctionData> ParquetWriteInitializeGlobal(ClientContext
 	options.encryption_config = parquet_bind.encryption_config;
 	options.dictionary_size_limit = parquet_bind.dictionary_size_limit,
 	options.string_dictionary_page_size_limit = parquet_bind.string_dictionary_page_size_limit;
+	options.data_page_size_limit = parquet_bind.data_page_size_limit;
 	options.enable_bloom_filters = parquet_bind.enable_bloom_filters,
 	options.bloom_filter_false_positive_ratio = parquet_bind.bloom_filter_false_positive_ratio;
 	options.compression_level = parquet_bind.compression_level;
@@ -733,6 +745,8 @@ static void ParquetCopySerialize(Serializer &serializer, const FunctionData &bin
 	                                    default_value.write_timestamp_as_int96);
 	serializer.WritePropertyWithDefault<vector<bool>>(120, "not_null_columns", bind_data.not_null_columns,
 	                                                  default_value.not_null_columns);
+	serializer.WritePropertyWithDefault(121, "data_page_size_limit", bind_data.data_page_size_limit,
+	                                    default_value.data_page_size_limit);
 }
 
 static unique_ptr<FunctionData> ParquetCopyDeserialize(Deserializer &deserializer, CopyFunction &function) {
@@ -773,6 +787,8 @@ static unique_ptr<FunctionData> ParquetCopyDeserialize(Deserializer &deserialize
 	    119, "write_timestamp_as_int96", default_value.write_timestamp_as_int96);
 	data->not_null_columns =
 	    deserializer.ReadPropertyWithExplicitDefault<vector<bool>>(120, "not_null_columns", vector<bool>());
+	data->data_page_size_limit =
+	    deserializer.ReadPropertyWithExplicitDefault(121, "data_page_size_limit", default_value.data_page_size_limit);
 
 	return std::move(data);
 }

--- a/extension/parquet/writer/primitive_column_writer.cpp
+++ b/extension/parquet/writer/primitive_column_writer.cpp
@@ -118,8 +118,7 @@ void PrimitiveColumnWriter::Prepare(ColumnWriterState &state_p, ColumnWriterStat
 	const idx_t page_size_limit = writer.DataPageSizeLimit();
 	const bool check_parent_empty = parent && !parent->is_empty.empty();
 	if (!check_parent_empty && validity.CannotHaveNull() && TypeIsConstantSize(vector.GetType().InternalType()) &&
-	    page_info_ref.get().estimated_page_size + GetRowSize(vector, vector_index, state) * vcount <
-	        page_size_limit) {
+	    page_info_ref.get().estimated_page_size + GetRowSize(vector, vector_index, state) * vcount < page_size_limit) {
 		// Fast path: fixed-size type, all valid, and it fits on the current page
 		auto &page_info = page_info_ref.get();
 		page_info.row_count += vcount;

--- a/extension/parquet/writer/primitive_column_writer.cpp
+++ b/extension/parquet/writer/primitive_column_writer.cpp
@@ -115,10 +115,11 @@ void PrimitiveColumnWriter::Prepare(ColumnWriterState &state_p, ColumnWriterStat
 	reference<PageInformation> page_info_ref = state.page_info.back();
 	col_chunk.meta_data.num_values += NumericCast<int64_t>(vcount);
 
+	const idx_t page_size_limit = writer.DataPageSizeLimit();
 	const bool check_parent_empty = parent && !parent->is_empty.empty();
 	if (!check_parent_empty && validity.CannotHaveNull() && TypeIsConstantSize(vector.GetType().InternalType()) &&
 	    page_info_ref.get().estimated_page_size + GetRowSize(vector, vector_index, state) * vcount <
-	        MAX_UNCOMPRESSED_PAGE_SIZE) {
+	        page_size_limit) {
 		// Fast path: fixed-size type, all valid, and it fits on the current page
 		auto &page_info = page_info_ref.get();
 		page_info.row_count += vcount;
@@ -133,7 +134,7 @@ void PrimitiveColumnWriter::Prepare(ColumnWriterState &state_p, ColumnWriterStat
 			}
 			if (validity.RowIsValid(vector_index)) {
 				page_info.estimated_page_size += GetRowSize(vector, vector_index, state);
-				if (page_info.estimated_page_size >= MAX_UNCOMPRESSED_PAGE_SIZE) {
+				if (page_info.estimated_page_size >= page_size_limit) {
 					if (!vector_can_span_multiple_pages && i != 0) {
 						// Vector is not allowed to span multiple pages, and we already started writing it
 						continue;

--- a/test/sql/copy/parquet/writer/parquet_write_data_page_size.test
+++ b/test/sql/copy/parquet/writer/parquet_write_data_page_size.test
@@ -1,0 +1,44 @@
+# name: test/sql/copy/parquet/writer/parquet_write_data_page_size.test
+# description: Test the data_page_size_limit COPY option
+# group: [writer]
+
+require parquet
+
+# write with a small data page size limit, forcing many data pages
+statement ok
+copy (select range i, 'val_' || (range % 400) s from range(100_000)) to '{TEST_DIR}/small_pages.parquet' (format parquet, data_page_size_limit 4096, compression uncompressed);
+
+# round-trip: contents must be identical
+query II
+select count(*), sum(i) from '{TEST_DIR}/small_pages.parquet';
+----
+100000	4999950000
+
+query I
+select count(*) from '{TEST_DIR}/small_pages.parquet' where s <> 'val_' || (i % 400);
+----
+0
+
+# same data with the default (100MB) limit, i.e., a single page per column chunk
+statement ok
+copy (select range i, 'val_' || (range % 400) s from range(100_000)) to '{TEST_DIR}/big_pages.parquet' (format parquet, compression uncompressed);
+
+# more pages means more page headers, so the same uncompressed data must occupy more bytes
+query I
+select small.total_size > big.total_size
+from (select sum(total_compressed_size) total_size from parquet_metadata('{TEST_DIR}/small_pages.parquet')) small,
+     (select sum(total_compressed_size) total_size from parquet_metadata('{TEST_DIR}/big_pages.parquet')) big;
+----
+true
+
+# cannot be 0
+statement error
+copy (select 42) to '{TEST_DIR}/zero.parquet' (format parquet, data_page_size_limit 0);
+----
+Binder Error
+
+# cannot exceed the 100MB maximum
+statement error
+copy (select 42) to '{TEST_DIR}/too_big.parquet' (format parquet, data_page_size_limit 104857601);
+----
+Binder Error


### PR DESCRIPTION
Fixes #24507

Adds a `data_page_size_limit` COPY option so data pages can be split below the hardcoded 100 MB threshold, which currently yields one huge page per column chunk. Today I write through DuckDB + delta-rs just to get normal-sized pages, which adds overhead; I'd like to write with DuckDB alone, but the huge pages are very problematic for downstream readers (Power BI in my case).

```sql
COPY tbl TO 'f.parquet' (FORMAT parquet, DATA_PAGE_SIZE_LIMIT 1048576);
```

Mirrors `string_dictionary_page_size_limit` end-to-end; default unchanged (100 MB, still the upper bound); limit is best-effort at vector granularity. Includes a sqllogictest.

Written with Claude Code; reviewed and submitted by me, To be clear: I understand the problem well (it's my daily workflow), but the C++ was AI-written
