### PR TITLE
Fix ALTER TABLE RENAME leaving stale table names in foreign keys

### DIFF
--- a/src/catalog/catalog_entry/duck_schema_entry.cpp
+++ b/src/catalog/catalog_entry/duck_schema_entry.cpp
@@ -69,6 +69,30 @@ static void FindForeignKeyInformation(TableCatalogEntry &table, AlterForeignKeyT
 	}
 }
 
+//! Collects the alters that rewrite the name that referenced tables hold for a table that is being renamed. Every
+//! referenced table stores the name of the referencing table in a FK_TYPE_PRIMARY_KEY_TABLE constraint, and that is
+//! the name the foreign key verification looks up when the referenced table is modified.
+static void FindForeignKeyRenameInformation(TableCatalogEntry &table, const Identifier &new_name,
+                                            vector<unique_ptr<AlterForeignKeyInfo>> &fk_arrays) {
+	for (auto &cond : table.GetConstraints()) {
+		if (cond->type != ConstraintType::FOREIGN_KEY) {
+			continue;
+		}
+		auto &fk = cond->Cast<ForeignKeyConstraint>();
+		if (fk.info.type != ForeignKeyType::FK_TYPE_FOREIGN_KEY_TABLE) {
+			continue;
+		}
+		// the referenced table lives in the same (possibly nested) schema as this table
+		AlterEntryData alter_data(table.schema.GetQualifiedName(fk.info.table), OnEntryNotFound::THROW_EXCEPTION);
+		fk_arrays.push_back(make_uniq<AlterForeignKeyInfo>(alter_data, table.name, fk.pk_columns, fk.fk_columns,
+		                                                   fk.info.pk_keys, fk.info.fk_keys,
+		                                                   AlterForeignKeyType::AFT_DELETE));
+		fk_arrays.push_back(make_uniq<AlterForeignKeyInfo>(std::move(alter_data), new_name, fk.pk_columns,
+		                                                   fk.fk_columns, fk.info.pk_keys, fk.info.fk_keys,
+		                                                   AlterForeignKeyType::AFT_ADD));
+	}
+}
+
 DuckSchemaEntry::DuckSchemaEntry(Catalog &catalog, CreateSchemaInfo &info,
                                  optional_ptr<SchemaCatalogEntry> parent_schema_p)
     : SchemaCatalogEntry(catalog, info), parent_schema(parent_schema_p), schemas(catalog),
@@ -345,8 +369,28 @@ void DuckSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) {
 		}
 	} else {
 		auto &name = info.GetQualifiedName().Name();
+
+		// a table rename has to rewrite the name that referenced tables hold for this table. The nested alters below
+		// are FOREIGN_KEY_CONSTRAINT alters, so they do not collect anything themselves.
+		vector<unique_ptr<AlterForeignKeyInfo>> fk_arrays;
+		if (info.type == AlterType::ALTER_TABLE &&
+		    info.Cast<AlterTableInfo>().alter_table_type == AlterTableType::RENAME_TABLE) {
+			auto &rename_info = info.Cast<RenameTableInfo>();
+			auto existing_entry = set.GetEntry(transaction, name);
+			if (existing_entry && existing_entry->type == CatalogType::TABLE_ENTRY &&
+			    rename_info.new_table_name != name) {
+				FindForeignKeyRenameInformation(existing_entry->Cast<TableCatalogEntry>(), rename_info.new_table_name,
+				                                fk_arrays);
+			}
+		}
+
 		if (!set.AlterEntry(transaction, name, info)) {
 			throw CatalogException::MissingEntry(type, name, string());
+		}
+
+		// the rename succeeded - point the referenced tables at the new name
+		for (auto &fk_info : fk_arrays) {
+			Alter(transaction, *fk_info);
 		}
 	}
 }

--- a/src/catalog/catalog_entry/duck_table_entry.cpp
+++ b/src/catalog/catalog_entry/duck_table_entry.cpp
@@ -307,10 +307,7 @@ unique_ptr<CatalogEntry> DuckTableEntry::AlterEntry(ClientContext &context, Alte
 	}
 	case AlterTableType::RENAME_TABLE: {
 		auto &rename_info = table_info.Cast<RenameTableInfo>();
-		auto copied_table = Copy(context);
-		copied_table->name = rename_info.new_table_name;
-		storage->SetTableName(rename_info.new_table_name);
-		return copied_table;
+		return RenameTable(context, rename_info);
 	}
 	case AlterTableType::ADD_COLUMN: {
 		auto &add_info = table_info.Cast<AddColumnInfo>();
@@ -413,6 +410,27 @@ static const Value &GetRemapStructMapping(ChangeColumnTypeInfo &info) {
 	auto &mapping = arguments[2].GetExpression();
 	D_ASSERT(mapping.GetExpressionClass() == ExpressionClass::CONSTANT);
 	return mapping.Cast<ConstantExpression>().GetValue();
+}
+
+unique_ptr<CatalogEntry> DuckTableEntry::RenameTable(ClientContext &context, RenameTableInfo &info) {
+	auto create_info = GetInfo();
+	// a self-referencing foreign key stores the name of this table, so it has to be rewritten
+	for (auto &constraint : create_info->Cast<CreateTableInfo>().constraints) {
+		if (constraint->type != ConstraintType::FOREIGN_KEY) {
+			continue;
+		}
+		auto &fk = constraint->Cast<ForeignKeyConstraint>();
+		if (fk.info.type == ForeignKeyType::FK_TYPE_SELF_REFERENCE_TABLE) {
+			fk.info.table = info.new_table_name;
+		}
+	}
+
+	auto binder = Binder::CreateBinder(context);
+	auto bound_create_info = binder->BindCreateTableCheckpoint(std::move(create_info), schema);
+	auto renamed_table = make_uniq<DuckTableEntry>(catalog, schema, *bound_create_info, storage, triggers);
+	renamed_table->name = info.new_table_name;
+	storage->SetTableName(info.new_table_name);
+	return std::move(renamed_table);
 }
 
 unique_ptr<CatalogEntry> DuckTableEntry::RenameColumn(ClientContext &context, RenameColumnInfo &info) {

--- a/src/include/duckdb/catalog/catalog_entry/duck_table_entry.hpp
+++ b/src/include/duckdb/catalog/catalog_entry/duck_table_entry.hpp
@@ -78,6 +78,7 @@ public:
 	bool DropTrigger(CatalogTransaction transaction, const Identifier &name, bool cascade);
 
 private:
+	unique_ptr<CatalogEntry> RenameTable(ClientContext &context, RenameTableInfo &info);
 	unique_ptr<CatalogEntry> RenameColumn(ClientContext &context, RenameColumnInfo &info);
 	unique_ptr<CatalogEntry> RenameField(ClientContext &context, RenameFieldInfo &info);
 	unique_ptr<CatalogEntry> AddColumn(ClientContext &context, AddColumnInfo &info);

--- a/test/sql/constraints/foreignkey/test_fk_alter.test
+++ b/test/sql/constraints/foreignkey/test_fk_alter.test
@@ -19,8 +19,8 @@ drop table departments
 ----
 Catalog Error: Could not drop the table because this table is main key table of the table "employees"
 
-# FIXME: we would need to update the foreign key constraint of the tables that are referencing 'employees'
-# to fix this, propagating an alter down.
+# FIXME: renaming a referenced table would need to update the foreign key constraint of the tables
+# that reference it, for which there is no alter yet (renaming a referencing table is propagated).
 # (or use Postgres's solution of using oids to add a layer of indirection so we dont need to do cleanup whenever a rename is done)
 statement error
 ALTER TABLE departments RENAME TO old_departments

--- a/test/sql/constraints/foreignkey/test_fk_rename_table.test
+++ b/test/sql/constraints/foreignkey/test_fk_rename_table.test
@@ -1,0 +1,68 @@
+# name: test/sql/constraints/foreignkey/test_fk_rename_table.test
+# description: Test ALTER TABLE ... RENAME TO on tables involved in a foreign key
+# group: [foreignkey]
+
+# the referenced table stores the name of the referencing table, so a rename has to rewrite it
+
+statement ok
+CREATE TABLE pk_tbl (i INTEGER PRIMARY KEY);
+
+statement ok
+INSERT INTO pk_tbl VALUES (1), (2);
+
+statement ok
+CREATE TABLE fk_tbl (j INTEGER REFERENCES pk_tbl(i));
+
+statement ok
+INSERT INTO fk_tbl VALUES (1);
+
+statement ok
+ALTER TABLE fk_tbl RENAME TO fk_renamed;
+
+statement error
+DELETE FROM pk_tbl WHERE i = 1;
+----
+<REGEX>:Constraint Error.*is still referenced by a foreign key.*
+
+# rows that nothing references can still be removed
+
+statement ok
+DELETE FROM pk_tbl WHERE i = 2;
+
+statement error
+INSERT INTO fk_renamed VALUES (99);
+----
+<REGEX>:Constraint Error.*does not exist in the referenced table.*
+
+statement error
+DROP TABLE pk_tbl;
+----
+<REGEX>:Catalog Error.*main key table of the table "fk_renamed".*
+
+statement ok
+DROP TABLE fk_renamed;
+
+statement ok
+DROP TABLE pk_tbl;
+
+# a self-referencing foreign key stores this table's own name
+
+statement ok
+CREATE TABLE self_tbl (i INTEGER PRIMARY KEY, parent INTEGER REFERENCES self_tbl(i));
+
+statement ok
+INSERT INTO self_tbl VALUES (1, NULL);
+
+statement ok
+INSERT INTO self_tbl VALUES (2, 1);
+
+statement ok
+ALTER TABLE self_tbl RENAME TO self_renamed;
+
+statement error
+DELETE FROM self_renamed WHERE i = 1;
+----
+<REGEX>:Constraint Error.*is still referenced by a foreign key.*
+
+statement ok
+INSERT INTO self_renamed VALUES (3, 2);


### PR DESCRIPTION
Fixes #24648.

A `REFERENCES` clause freezes a table name on both sides: the referencing table gets a `FK_TYPE_FOREIGN_KEY_TABLE` constraint naming the referenced table, and `CREATE TABLE` adds a `FK_TYPE_PRIMARY_KEY_TABLE` constraint to the referenced table naming the referencing table. Foreign key verification resolves the sibling table through that frozen name (`data_table.cpp:696`). `CREATE TABLE` and `DROP TABLE` keep both sides in sync through nested alters, but `ALTER TABLE ... RENAME` does not, so renaming the referencing table leaves the referenced table holding a name that no longer resolves, and the stale name reaches the catalog rather than staying in memory. A self-referencing foreign key stores the table's own name and goes stale the same way.

The stale name lives in two places, so it is rewritten in two: the constraints that other tables hold for this one, and the constraint that a self-referencing table holds for itself. `DuckSchemaEntry::Alter` now collects the referenced tables before applying a table rename and, once the rename succeeds, rewrites the frozen name on each of them with the same `AFT_DELETE` plus `AFT_ADD` nested alters that `CREATE TABLE` and `DROP TABLE` already use. Collecting first keeps the pre-rename constraint list available, and applying afterwards leaves the referenced tables untouched if the rename fails. The `RENAME_TABLE` branch of `DuckTableEntry::AlterEntry` moves into a new `DuckTableEntry::RenameTable`, which rewrites the name stored by a `FK_TYPE_SELF_REFERENCE_TABLE` constraint; the entry is rebuilt from `CreateInfo` because `Copy()` carries constraints that are already bound.

Renaming the referenced table is still refused by the dependency manager and is not part of this fix.

### Tests

`test/sql/constraints/foreignkey/test_fk_rename_table.test` covers renaming a referencing table and renaming a self-referencing table, and the FIXME in `test_fk_alter.test` is narrowed to the direction that is still refused. Three of its assertions fail on `main` and now hold: deleting a row of the referenced table that nothing references succeeds instead of reporting a catalog error, the referenced table can be dropped once the renamed table is gone, and inserting a valid row into the renamed self-referencing table succeeds. Enforcement is asserted alongside them, so a referenced row still reports a `Constraint Error` and a value missing from the referenced table is still rejected. The `test/sql/constraints/foreignkey/*` group passes: 26 test cases and 661 assertions. Restoring the three source files to their `main` versions makes the new test fail where a `Constraint Error` is expected and `Catalog Error: Table with name fk_tbl does not exist!` is reported instead.

Written with AI assistance; I reviewed every line and stand behind the change.