### PR TITLE
Keep the DISTINCT modifier on last()

### DIFF
--- a/src/function/aggregate/distributive/first_last_any.cpp
+++ b/src/function/aggregate/distributive/first_last_any.cpp
@@ -434,7 +434,9 @@ unique_ptr<FunctionData> BindDecimalFirst(BindAggregateFunctionInput &input) {
 	auto name = function.GetName();
 	function.ReplaceImplementation(GetFirstFunction<LAST, SKIP_NULLS>(decimal_type));
 	function.SetName(std::move(name));
-	function.SetDistinctDependent(AggregateDistinctDependent::NOT_DISTINCT_DEPENDENT);
+	// the last distinct value is not the last row's value, so last() is distinct-dependent
+	function.SetDistinctDependent(LAST ? AggregateDistinctDependent::DISTINCT_DEPENDENT
+	                                   : AggregateDistinctDependent::NOT_DISTINCT_DEPENDENT);
 	function.SetReturnType(decimal_type);
 	return nullptr;
 }
@@ -456,7 +458,9 @@ unique_ptr<FunctionData> BindFirst(BindAggregateFunctionInput &input) {
 	auto name = function.GetName();
 	function.ReplaceImplementation(GetFirstOperator<LAST, SKIP_NULLS>(input_type));
 	function.SetName(std::move(name));
-	function.SetDistinctDependent(AggregateDistinctDependent::NOT_DISTINCT_DEPENDENT);
+	// the last distinct value is not the last row's value, so last() is distinct-dependent
+	function.SetDistinctDependent(LAST ? AggregateDistinctDependent::DISTINCT_DEPENDENT
+	                                   : AggregateDistinctDependent::NOT_DISTINCT_DEPENDENT);
 	return nullptr;
 }
 

--- a/test/sql/aggregate/distinct/rewrite/distinct_aggregate_rewrite.test
+++ b/test/sql/aggregate/distinct/rewrite/distinct_aggregate_rewrite.test
@@ -349,6 +349,24 @@ NULL	P	3	1	0
 NULL	NULL	6	1	1
 
 statement ok
+CREATE TABLE distinct_rewrite_last(id INTEGER, x INTEGER);
+
+statement ok
+INSERT INTO distinct_rewrite_last VALUES (1, 1), (2, 2), (3, 1);
+
+# the last distinct value differs from the last row's value, so the DISTINCT modifier is kept
+query I
+SELECT last(DISTINCT x) FROM distinct_rewrite_last;
+----
+2
+
+# first()/any_value() return the same value with or without DISTINCT, so the rewrite still applies
+query II
+SELECT first(DISTINCT x), any_value(DISTINCT x) FROM distinct_rewrite_last;
+----
+1	1
+
+statement ok
 PRAGMA disable_verification
 
 statement ok


### PR DESCRIPTION
Fixes #24625.

`DistinctAggregateOptimizer` removes the `DISTINCT` modifier from aggregates marked `NOT_DISTINCT_DEPENDENT`. `first()`, `last()` and `any_value()` share the same two bind functions (`BindFirst`, `BindDecimalFirst`) and were all marked that way unconditionally.

The rewrite is sound for `first()` and `any_value()`. It is not for `last()`: the last distinct value is not the last row's value, so whether the optimizer ran changes the result.

On current main:

```sql
CREATE TABLE t(id INTEGER, x INTEGER);
INSERT INTO t VALUES (1, 1), (2, 2), (3, 1);

SELECT last(DISTINCT x) FROM t;                    -- 1
SET disabled_optimizers='expression_rewriter';
SELECT last(DISTINCT x) FROM t;                    -- 2
```

## Changes

- `first_last_any.cpp`: mark `last()` as `DISTINCT_DEPENDENT`; `first()` and `any_value()` keep the existing behaviour.
- Adds a regression case to the existing `distinct_aggregate_rewrite.test`, placed before `PRAGMA disable_verification` so it runs with verification enabled.

## Validation

- [x] `test/sql/aggregate/distinct/rewrite/distinct_aggregate_rewrite.test` — fails on unpatched main (actual 1, expected 2), passes with this change
- [x] `test/sql/aggregate/*` — 180/181. The one failure is `test_string_agg_overflow.test_slow`, which needs a 4 GiB allocation and runs out of memory on the 7.8 GiB machine I used; unrelated to this change
- [x] `test/sql/window/*` — 77 cases, 96228 assertions, all passing (`DistinctWindowedOptimizer` reads the same flag)
- [x] `clang-format --dry-run -Werror` on the changed source file
- [ ] `make allunit` / `test_configs` / `test_vector` — not run, too slow on the machine available to me

## Notes for reviewers

`first()` is deliberately left alone. On main the deduplication happens to iterate in first-seen order, so `first(DISTINCT x)` agrees with `first(x)` and I could not produce a failing case. On the v1.5.5 release binary the iteration order differs and `first()` is the one that disagrees, so the same class of problem applies to it. I did not change it because there is no reproducible failure on main — happy to cover both if you would rather have it handled in one go.

This does not give DISTINCT aggregates an ordering guarantee. Both functions are documented as "affected by ordering", and with a `VALUES` source `last(DISTINCT x)` still varies between runs after this change. The fix only removes the discrepancy between the optimized and unoptimized plans for the reproducible case.

Heads-up: #24647 touches the immediate neighbourhood of the same two lines (it adds `SetSingleValueIdentity` directly below them). Whichever lands first, the other is a trivial rebase.
