### PR TITLE
Add UUID to temporary file names

### DIFF
--- a/src/common/types/uuid.cpp
+++ b/src/common/types/uuid.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/common/types/uuid.hpp"
+#include "duckdb/common/atomic.hpp"
 #include "duckdb/common/chrono.hpp"
 #include "duckdb/common/random_engine.hpp"
 
@@ -167,6 +168,15 @@ hugeint_t UUIDv4::GenerateRandomUUID(RandomEngine &engine) {
 hugeint_t UUIDv4::GenerateRandomUUID() {
 	RandomEngine engine;
 	return GenerateRandomUUID(engine);
+}
+
+hugeint_t UUIDv4::GenerateUniqueUUID() {
+	static const hugeint_t PROCESS_BASE = GenerateRandomUUID();
+	static atomic<uint64_t> counter(0);
+	auto result = PROCESS_BASE;
+	// the variant bits live in the top byte of the lower half, so a counter below 2^56 keeps this a valid v4
+	result.lower ^= counter++;
+	return result;
 }
 
 //////////////////

--- a/src/include/duckdb/common/types/uuid.hpp
+++ b/src/include/duckdb/common/types/uuid.hpp
@@ -63,6 +63,10 @@ public:
 	//! Generate a random UUID v4 value.
 	static hugeint_t GenerateRandomUUID(RandomEngine &engine);
 	static hugeint_t GenerateRandomUUID();
+	//! Generate a UUID v4 value that no other call in this process returns, and that is distinct across
+	//! processes. Distinctness within the process is guaranteed rather than probabilistic, and does not
+	//! depend on the entropy source, which is drawn once per process instead of once per call.
+	static hugeint_t GenerateUniqueUUID();
 };
 
 using UUIDv4 = UUID;

--- a/src/include/duckdb/main/database.hpp
+++ b/src/include/duckdb/main/database.hpp
@@ -73,6 +73,13 @@ public:
 
 	DUCKDB_API const duckdb_ext_api_v1 GetExtensionAPIV1();
 
+	//! Identifies this instance for the lifetime of the process. Distinct for every DatabaseInstance,
+	//! including two instances in the same process, so it can name resources that instances must not
+	//! share. Attached databases belong to one instance and therefore share its id.
+	const string &GetInstanceId() const {
+		return instance_id;
+	}
+
 	idx_t NumberOfThreads();
 
 	DUCKDB_API static DatabaseInstance &GetDatabase(ClientContext &context);
@@ -96,6 +103,7 @@ private:
 	void Configure(DBConfig &config, const char *path);
 
 private:
+	string instance_id;
 	shared_ptr<BufferManager> buffer_manager;
 	unique_ptr<DatabaseManager> db_manager;
 	unique_ptr<ExternalResourceTypeRegistry> external_resource_type_registry;

--- a/src/include/duckdb/storage/temporary_file_manager.hpp
+++ b/src/include/duckdb/storage/temporary_file_manager.hpp
@@ -41,6 +41,14 @@ enum class TemporaryBufferSize : uint64_t {
 	DEFAULT = DEFAULT_BLOCK_ALLOC_SIZE,
 };
 
+//! Prefix shared by every temporary file this instance creates: "duckdb_temp_<instance id>_".
+//! The instance id is what keeps two DatabaseInstances that resolve to the same temp_directory -
+//! two in-memory instances in one working directory, two readers of one database file, or two
+//! instances inside a single process - from ever choosing the same path and writing over each
+//! other. The "duckdb_temp_" part is kept so that the cleanup in ~TemporaryDirectoryHandle, and
+//! that of other duckdb versions sharing the directory, still recognises these files.
+DUCKDB_API string TemporaryFilePrefix(DatabaseInstance &db);
+
 //===--------------------------------------------------------------------===//
 // TemporaryFileIdentifier/TemporaryFileIndex
 //===--------------------------------------------------------------------===//

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -1,3 +1,4 @@
+#include "duckdb/common/types/uuid.hpp"
 #include "duckdb/main/database.hpp"
 #include "duckdb/common/arrow/arrow_type_extension.hpp"
 #include "duckdb/main/profiler/metrics_manager.hpp"
@@ -77,7 +78,7 @@ DBConfig::DBConfig(const identifier_map_t<Value> &config_dict, bool read_only) :
 DBConfig::~DBConfig() {
 }
 
-DatabaseInstance::DatabaseInstance() : db_validity(*this) {
+DatabaseInstance::DatabaseInstance() : instance_id(UUID::ToString(UUIDv4::GenerateRandomUUID())), db_validity(*this) {
 	config.is_user_config = false;
 	create_api_v1 = nullptr;
 	parser_cache = make_uniq<ParserCache>();

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -78,7 +78,7 @@ DBConfig::DBConfig(const identifier_map_t<Value> &config_dict, bool read_only) :
 DBConfig::~DBConfig() {
 }
 
-DatabaseInstance::DatabaseInstance() : instance_id(UUID::ToString(UUIDv4::GenerateRandomUUID())), db_validity(*this) {
+DatabaseInstance::DatabaseInstance() : instance_id(UUID::ToString(UUIDv4::GenerateUniqueUUID())), db_validity(*this) {
 	config.is_user_config = false;
 	create_api_v1 = nullptr;
 	parser_cache = make_uniq<ParserCache>();

--- a/src/storage/standard_buffer_manager.cpp
+++ b/src/storage/standard_buffer_manager.cpp
@@ -463,7 +463,7 @@ vector<MemoryInformation> StandardBufferManager::GetMemoryUsageInfo() const {
 
 string StandardBufferManager::GetTemporaryPath(block_id_t id) {
 	auto &fs = FileSystem::GetFileSystem(db);
-	return fs.JoinPath(temporary_directory.path, "duckdb_temp_block-" + to_string(id) + ".block");
+	return fs.JoinPath(temporary_directory.path, TemporaryFilePrefix(db) + "block-" + to_string(id) + ".block");
 }
 
 void StandardBufferManager::RequireTemporaryDirectory() {

--- a/src/storage/temporary_file_manager.cpp
+++ b/src/storage/temporary_file_manager.cpp
@@ -703,10 +703,14 @@ void TemporaryFileManager::EraseUsedBlock(TemporaryFileManagerLock &lock, block_
 	}
 }
 
+string TemporaryFilePrefix(DatabaseInstance &db) {
+	return "duckdb_temp_" + db.GetInstanceId() + "_";
+}
+
 string TemporaryFileManager::CreateTemporaryFileName(const TemporaryFileIdentifier &identifier) const {
 	return FileSystem::GetFileSystem(db).JoinPath(
-	    temp_directory, StringUtil::Format("duckdb_temp_storage_%s-%llu.tmp", EnumUtil::ToString(identifier.size),
-	                                       identifier.file_index.GetIndex()));
+	    temp_directory, StringUtil::Format("%sstorage_%s-%llu.tmp", TemporaryFilePrefix(db),
+	                                       EnumUtil::ToString(identifier.size), identifier.file_index.GetIndex()));
 }
 
 optional_ptr<TemporaryFileHandle> TemporaryFileManager::GetFileHandle(TemporaryFileManagerLock &,

--- a/test/api/CMakeLists.txt
+++ b/test/api/CMakeLists.txt
@@ -10,6 +10,7 @@ add_subdirectory(capi)
 
 set(TEST_API_OBJECTS
     test_api.cpp
+    test_instance_id.cpp
     test_bind_statement.cpp
     test_scalar_function_decimal_return.cpp
     test_aggregate_state_bind_data.cpp

--- a/test/api/test_instance_id.cpp
+++ b/test/api/test_instance_id.cpp
@@ -1,0 +1,42 @@
+#include "catch.hpp"
+#include "test_helpers.hpp"
+#include "duckdb/common/set.hpp"
+#include "duckdb/common/types/uuid.hpp"
+#include "duckdb/main/database.hpp"
+
+using namespace duckdb;
+
+TEST_CASE("Test that every DatabaseInstance has its own id", "[api]") {
+	SECTION("the id is a well-formed UUID and is stable for the instance") {
+		DuckDB db(nullptr);
+		auto &id = db.instance->GetInstanceId();
+		REQUIRE(id.size() == UUID::STRING_SIZE);
+		// asking again returns the same id
+		REQUIRE(id == db.instance->GetInstanceId());
+	}
+	SECTION("two instances in the same process do not share an id") {
+		// this is the case a process identifier cannot distinguish
+		DuckDB db1(nullptr);
+		DuckDB db2(nullptr);
+		REQUIRE(db1.instance->GetInstanceId() != db2.instance->GetInstanceId());
+	}
+	SECTION("many instances are all distinct") {
+		set<string> ids;
+		for (idx_t i = 0; i < 32; i++) {
+			DuckDB db(nullptr);
+			ids.insert(db.instance->GetInstanceId());
+		}
+		REQUIRE(ids.size() == 32);
+	}
+	SECTION("seeding the session RNG does not make instances share an id") {
+		// the id is drawn from its own RandomEngine, so it must not be reproducible from a seeded
+		// session - otherwise two instances could name the same resources
+		DuckDB db1(nullptr);
+		Connection con1(db1);
+		REQUIRE_NO_FAIL(con1.Query("SELECT setseed(0.42)"));
+		DuckDB db2(nullptr);
+		Connection con2(db2);
+		REQUIRE_NO_FAIL(con2.Query("SELECT setseed(0.42)"));
+		REQUIRE(db1.instance->GetInstanceId() != db2.instance->GetInstanceId());
+	}
+}

--- a/test/api/test_instance_id.cpp
+++ b/test/api/test_instance_id.cpp
@@ -21,6 +21,7 @@ TEST_CASE("Test that every DatabaseInstance has its own id", "[api]") {
 		REQUIRE(db1.instance->GetInstanceId() != db2.instance->GetInstanceId());
 	}
 	SECTION("many instances are all distinct") {
+		// UUID::GenerateUniqueUUID counts within the process, so this holds regardless of the entropy source
 		set<string> ids;
 		for (idx_t i = 0; i < 32; i++) {
 			DuckDB db(nullptr);

--- a/test/api/test_uuid.cpp
+++ b/test/api/test_uuid.cpp
@@ -1,8 +1,21 @@
 #include "test_helpers.hpp"
+#include "duckdb/common/set.hpp"
+#include "duckdb/common/thread.hpp"
 #include "duckdb/common/types/uuid.hpp"
 #include "catch.hpp"
 
 using namespace duckdb;
+
+namespace {
+
+bool IsWellFormedV4(hugeint_t uuid) {
+	// version nibble lives in byte 6 (the lower half of `upper`), variant bits in byte 8 (top of `lower`)
+	auto version = (static_cast<uint64_t>(uuid.upper) >> 8) & 0xF0;
+	auto variant = (uuid.lower >> 56) & 0xC0;
+	return version == 0x40 && variant == 0x80;
+}
+
+} // namespace
 
 TEST_CASE("Test UUID API", "[api]") {
 	REQUIRE(UUID::ToString(UUID::FromUHugeint(uhugeint_t(0))) == "00000000-0000-0000-0000-000000000000");
@@ -40,4 +53,41 @@ TEST_CASE("Test UUID API", "[api]") {
 	             Catch::Predicate<uhugeint_t>([&](const uhugeint_t &input) {
 		             return input.upper == 0x8000000000000000 && input.lower == 0x0000000000000000;
 	             }));
+}
+
+TEST_CASE("Test UUID::GenerateUniqueUUID", "[api]") {
+	SECTION("no two calls return the same value") {
+		// distinctness here is a guarantee, not a probability - callers name resources with it
+		set<hugeint_t> uuids;
+		for (idx_t i = 0; i < 10000; i++) {
+			uuids.insert(UUID::GenerateUniqueUUID());
+		}
+		REQUIRE(uuids.size() == 10000);
+	}
+	SECTION("the result stays a well-formed v4 UUID") {
+		for (idx_t i = 0; i < 10000; i++) {
+			REQUIRE(IsWellFormedV4(UUID::GenerateUniqueUUID()));
+		}
+	}
+	SECTION("concurrent callers do not collide") {
+		constexpr idx_t THREAD_COUNT = 4;
+		constexpr idx_t PER_THREAD = 2000;
+		vector<vector<hugeint_t>> per_thread(THREAD_COUNT);
+		vector<thread> threads;
+		for (idx_t t = 0; t < THREAD_COUNT; t++) {
+			threads.emplace_back([&per_thread, t]() {
+				for (idx_t i = 0; i < PER_THREAD; i++) {
+					per_thread[t].push_back(UUID::GenerateUniqueUUID());
+				}
+			});
+		}
+		for (auto &t : threads) {
+			t.join();
+		}
+		set<hugeint_t> uuids;
+		for (auto &results : per_thread) {
+			uuids.insert(results.begin(), results.end());
+		}
+		REQUIRE(uuids.size() == THREAD_COUNT * PER_THREAD);
+	}
 }

--- a/test/api/test_uuid.cpp
+++ b/test/api/test_uuid.cpp
@@ -8,6 +8,9 @@ using namespace duckdb;
 
 namespace {
 
+constexpr idx_t THREAD_COUNT = 4;
+constexpr idx_t PER_THREAD = 2000;
+
 bool IsWellFormedV4(hugeint_t uuid) {
 	// version nibble lives in byte 6 (the lower half of `upper`), variant bits in byte 8 (top of `lower`)
 	auto version = (static_cast<uint64_t>(uuid.upper) >> 8) & 0xF0;
@@ -70,8 +73,6 @@ TEST_CASE("Test UUID::GenerateUniqueUUID", "[api]") {
 		}
 	}
 	SECTION("concurrent callers do not collide") {
-		constexpr idx_t THREAD_COUNT = 4;
-		constexpr idx_t PER_THREAD = 2000;
 		vector<vector<hugeint_t>> per_thread(THREAD_COUNT);
 		vector<thread> threads;
 		for (idx_t t = 0; t < THREAD_COUNT; t++) {

--- a/test/api/test_uuid.cpp
+++ b/test/api/test_uuid.cpp
@@ -8,8 +8,10 @@ using namespace duckdb;
 
 namespace {
 
+#ifndef DUCKDB_NO_THREADS
 constexpr idx_t THREAD_COUNT = 4;
 constexpr idx_t PER_THREAD = 2000;
+#endif
 
 bool IsWellFormedV4(hugeint_t uuid) {
 	// version nibble lives in byte 6 (the lower half of `upper`), variant bits in byte 8 (top of `lower`)
@@ -72,6 +74,7 @@ TEST_CASE("Test UUID::GenerateUniqueUUID", "[api]") {
 			REQUIRE(IsWellFormedV4(UUID::GenerateUniqueUUID()));
 		}
 	}
+#ifndef DUCKDB_NO_THREADS
 	SECTION("concurrent callers do not collide") {
 		vector<vector<hugeint_t>> per_thread(THREAD_COUNT);
 		vector<thread> threads;
@@ -91,4 +94,5 @@ TEST_CASE("Test UUID::GenerateUniqueUUID", "[api]") {
 		}
 		REQUIRE(uuids.size() == THREAD_COUNT * PER_THREAD);
 	}
+#endif
 }


### PR DESCRIPTION
Currently temporary files (used by duckdb to spill to disk) might collide between different DatabaseInstances, both same process and different co-existing processes. I think it would be cleaner to mark them as different via an UUID each `DatabaseInstance` is stamped with.

This do not properly solves all issues (like the first instance to close down will delete the other instance folder), but this at least turns silent failures into either working situation or a clear throw (that a file has been invalidated).

Possible follow ups to be considered:
1. fold `GenerateUniqueUUID` into a SystemUtils style utility, that could also allow re-initializing this multiple times.
2. add a lock file of sort, and on non-crashing code-paths an instance can avoid clean-up of folders that still have active in-use lock files
3. shortening of the names, currently they might be like:
```
.tmp/
 -> duckdb_temp_3f2a1c8e-7b4d-4a19-9c05-6e8f0d2b7a31_storage_DEFAULT-0.tmp   (70 chars)
 -> duckdb_temp_3f2a1c8e-7b4d-4a19-9c05-6e8f0d2b7a31_block-12345.block
```
vs previous:
```
.tmp/
 -> duckdb_temp_storage_DEFAULT-0.tmp   (34 chars)
 -> duckdb_temp_block-12345.block
```
that on file-systems that limit file length might be an issue we could now run into.

Bumped into this while running multiple unittester side-by-side, current workaround is explicit temporary folder, but we should have a solution that works by default for these cases.