### PR TITLE
Do not push down an extract on an already extracted column

### DIFF
--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -903,6 +903,11 @@ void RemoveUnusedColumns::CheckPushdownExtract(LogicalOperator &op) {
 				continue;
 			}
 			auto &column_id = get.GetColumnIndex(column_binding);
+			if (column_id.IsPushdownExtract()) {
+				//! We already pushed down an extract for this column, so a new path is relative to that
+				col.supports_pushdown_extract = PushdownExtractSupport::DISABLED;
+				continue;
+			}
 			auto logical_column_index = LogicalIndex(column_id.GetPrimaryIndex());
 			if (!get.function.supports_pushdown_extract || get.function.statistics) {
 				//! Either 'statistics_extended' needs to be set or 'statistics' needs to be NULL
@@ -1042,7 +1047,8 @@ void RemoveUnusedColumns::RemoveColumnsFromLogicalGet(LogicalGet &get, unique_pt
 			if (logical_column_id.IsPushdownExtract()) {
 				//! RemoveUnusedColumns is also used by other optimizers,
 				//! so we have to deal with this case and preserve the PushdownExtract we created earlier
-				D_ASSERT(entry->second.child_columns.empty());
+				D_ASSERT(entry->second.child_columns.empty() ||
+				         entry->second.supports_pushdown_extract == PushdownExtractSupport::DISABLED);
 				new_column_ids.emplace_back(logical_column_id);
 			} else {
 				ColumnIndex new_index(logical_column_id.GetPrimaryIndex(), entry->second.child_columns);

--- a/test/configs/storage_compatibility.json
+++ b/test/configs/storage_compatibility.json
@@ -148,6 +148,7 @@
         "test/sql/storage/types/variant/variant_stats_merging.test_slow",
         "test/parquet/variant/variant_legacy_encoding.test",
         "test/sql/types/variant/tpch_test.test",
+        "test/sql/optimizer/pushdown_extract_reapplied.test",
         "test/sql/storage/compression/default_storage_dict_fsst.test",
         "test/sql/storage/compression/roaring/roaring_bool_array_simple.test",
         "test/sql/storage/compression/roaring/roaring_bool_array_simple_w_null.test",

--- a/test/sql/optimizer/pushdown_extract_reapplied.test
+++ b/test/sql/optimizer/pushdown_extract_reapplied.test
@@ -1,0 +1,110 @@
+# name: test/sql/optimizer/pushdown_extract_reapplied.test
+# description: A pushdown-extract column must not be narrowed a second time by a later pruner run
+# group: [optimizer]
+
+statement ok
+SET late_materialization_max_rows = 100;
+
+# Every field holds a distinct value, so reading the wrong one cannot produce the expected result
+statement ok
+CREATE TABLE nested_extract AS SELECT
+    {'id': k + 1000, 'ms': {'a': k + 200, 'b': k + 30, 'c': {'d': k + 7}}} AS v
+FROM range(3) t(k);
+
+# A cast between the two extracts stops the pushdown at v.ms and leaves a struct_extract above the
+# scan. Late materialization runs the pruner again, and that extract is pushed down a second time
+# against the column, so the two fields below resolve to v.id and to v.ms instead.
+query II
+SELECT (v.ms::STRUCT(b VARCHAR, a VARCHAR)).b, (v.ms::STRUCT(b VARCHAR, a VARCHAR)).a
+FROM nested_extract ORDER BY v.id LIMIT 1
+----
+30	200
+
+# Deeper nesting threw from the statistics propagator instead of returning the wrong field
+query I
+SELECT (v.ms::STRUCT(c STRUCT(d VARCHAR), b VARCHAR, a VARCHAR)).c.d
+FROM nested_extract ORDER BY v.id LIMIT 1
+----
+7
+
+# The pruner pushes down variant extracts the same way, but there the second push returned NULL
+statement ok
+CREATE TABLE nested_variant AS
+SELECT {'id': k + 1000, 'ms': {'a': k + 200, 'b': k + 30}}::VARIANT AS v
+FROM range(3) t(k);
+
+query I
+SELECT (v.ms::STRUCT(b VARCHAR, a VARCHAR)).b FROM nested_variant ORDER BY v.id::BIGINT LIMIT 1
+----
+30
+
+# TopNWindowElimination runs the pruner a second time as well. The residual extract has to sit in the
+# window ORDER BY, because a full reference to the column anywhere else clears the child columns.
+# The WHERE clause also exercises table-filter remapping on that scan.
+statement ok
+CREATE TABLE windowed AS SELECT
+    k % 2 AS grp, {'id': k + 1000, 'ms': {'a': k + 200, 'b': 50 - k}} AS v
+FROM range(6) t(k);
+
+query II
+SELECT grp, v.id FROM windowed
+WHERE v.id > 1000
+QUALIFY row_number() OVER (PARTITION BY grp ORDER BY (v.ms::STRUCT(b VARCHAR, a VARCHAR)).b) = 1
+ORDER BY grp
+----
+0	1004
+1	1005
+
+# Pushing the extract down also dropped the sibling field, and with it the cast error it raises
+statement ok
+CREATE TABLE unconvertible AS SELECT
+    {'id': k + 1000, 'ms': {'a': 'xyz', 'b': k + 30}} AS v
+FROM range(3) t(k);
+
+statement error
+SELECT (v.ms::STRUCT(a INTEGER, b VARCHAR)).b FROM unconvertible ORDER BY v.id LIMIT 1
+----
+Conversion Error
+
+# With late materialization disabled this query prunes once, so it was always correct
+statement ok
+SET disabled_optimizers = 'LATE_MATERIALIZATION';
+
+query I
+SELECT (v.ms::STRUCT(b VARCHAR, a VARCHAR)).b FROM nested_extract ORDER BY v.id LIMIT 1
+----
+30
+
+statement ok
+SET disabled_optimizers = '';
+
+# This query only gets a second pruner run when it is planned as a late materialization
+statement ok
+PRAGMA explain_output = OPTIMIZED_ONLY
+
+query II
+EXPLAIN SELECT (v.ms::STRUCT(b VARCHAR, a VARCHAR)).b FROM nested_extract ORDER BY v.id LIMIT 1
+----
+logical_opt	<REGEX>:.*rowid = rowid.*
+
+statement ok
+PRAGMA explain_output = PHYSICAL_ONLY
+
+# Without a cast there is nothing to re-push, so the extract still reaches the leaf. A guard that is
+# too broad would keep every result correct, so only the scan projection can show it.
+query II
+EXPLAIN SELECT v.ms.b FROM nested_extract ORDER BY v.id LIMIT 1
+----
+physical_plan	<REGEX>:.*Projections: v\.ms\.b.*
+
+require parquet
+
+# The same over parquet, where the second push is resolved by the multi file column mapper
+statement ok
+COPY nested_extract TO '{TEST_DIR}/nested_extract.parquet' (FORMAT PARQUET)
+
+query I
+SELECT (v.ms::STRUCT(b VARCHAR, a VARCHAR)).b
+FROM '{TEST_DIR}/nested_extract.parquet' ORDER BY v.id LIMIT 1
+----
+30


### PR DESCRIPTION
Fixes #24657.

Reading a field out of a nested struct through a `CAST` returns a different field:
```sql
CREATE TABLE nested AS SELECT
    {'id': k + 1000, 'ms': {'a': k + 200, 'b': k + 30}} AS v
FROM range(3) t(k);

SELECT (v.ms::STRUCT(b VARCHAR, a VARCHAR)).b FROM nested ORDER BY v.id LIMIT 1;
-- 1000, expected 30
```

It comes down to the pruner running twice:`LateMaterialization` and `TopNWindowElimination` run `RemoveUnusedColumns` again on a plan it has already rewritten. 
The extract walk stops at the cast, so the first run pushes the `v.ms` prefix into the scan and leaves a `struct_extract` above it. The second run treats that leftover as fresh, and `CheckPushdownExtract` reads `column_id.GetPrimaryIndex()`, which is still the root column. 
`b` is ordinal 0 of the cast type, and ordinal 0 of `v` is `id`, so the scan reads `id`.

`EXPLAIN ... PHYSICAL_ONLY` shows it without reasoning about values:
```
│ Expressions: v, v         │
│ Projections: v.id, v.id   │
```

After, the scan stays narrowed to `v.ms` and the leftover extract stays above it:
```
│ Expressions: struct_extract(v, 'b'), v │
│ Projections: v.ms, v.id                │
```

## The fix
Pushdown extract is disabled for a column that is already a `PushdownExtract`. The narrowed column stays in place, and the projection above does the remaining extraction, which is what already happens for every other shape that cannot be pushed.

This gives up no pushdown: running the pruner once, with `SET disabled_optimizers = 'LATE_MATERIALIZATION'`, already produces that same plan.

## Tests
- `test/sql/optimizer/pushdown_extract_reapplied.test`: every field of the fixture holds a distinct value so that reading the wrong one cannot produce the expected result, which is how the plain `1000` in the reproducer names the field it misread.