### PR TITLE
Fix PRAGMA tpch/tpcds throwing INTERNAL error on NULL argument

### DIFF
--- a/extension/tpcds/tpcds_extension.cpp
+++ b/extension/tpcds/tpcds_extension.cpp
@@ -239,6 +239,9 @@ static void TPCDSQueryAnswerFunction(ClientContext &context, TableFunctionInput 
 }
 
 static string PragmaTpcdsQuery(ClientContext &context, const FunctionParameters &parameters) {
+	if (parameters.values[0].IsNull()) {
+		throw BinderException("TPC-DS query number must not be NULL");
+	}
 	auto index = parameters.values[0].GetValue<int32_t>();
 	return tpcds::DSDGenWrapper::GetQuery(index);
 }

--- a/extension/tpch/tpch_extension.cpp
+++ b/extension/tpch/tpch_extension.cpp
@@ -238,6 +238,9 @@ static void TPCHQueryAnswerFunction(ClientContext &context, TableFunctionInput &
 }
 
 static string PragmaTpchQuery(ClientContext &context, const FunctionParameters &parameters) {
+	if (parameters.values[0].IsNull()) {
+		throw BinderException("TPC-H query number must not be NULL");
+	}
 	auto index = parameters.values[0].GetValue<int32_t>();
 	return tpch::DBGenWrapper::GetQuery(index);
 }

--- a/test/sql/tpcds/tpcds_null_arg.test
+++ b/test/sql/tpcds/tpcds_null_arg.test
@@ -1,0 +1,10 @@
+# name: test/sql/tpcds/tpcds_null_arg.test
+# description: PRAGMA tpcds rejects a NULL query number instead of throwing an INTERNAL error
+# group: [tpcds]
+
+require tpcds
+
+statement error
+PRAGMA tpcds(NULL);
+----
+<REGEX>:.*Binder Error.*TPC-DS query number must not be NULL.*

--- a/test/sql/tpch/tpch_null_arg.test
+++ b/test/sql/tpch/tpch_null_arg.test
@@ -1,0 +1,10 @@
+# name: test/sql/tpch/tpch_null_arg.test
+# description: PRAGMA tpch rejects a NULL query number instead of throwing an INTERNAL error
+# group: [tpch]
+
+require tpch
+
+statement error
+PRAGMA tpch(NULL);
+----
+<REGEX>:.*Binder Error.*TPC-H query number must not be NULL.*


### PR DESCRIPTION
Fixes #24603

`PRAGMA tpch(NULL)` and `PRAGMA tpcds(NULL)` reached `Value::GetValue<int32_t>()` on a NULL constant, asserting with `INTERNAL Error: Calling GetValueInternal on a value that is NULL`.

This adds `IsNull()` guards in `PragmaTpchQuery` and `PragmaTpcdsQuery`, throwing a `BinderException` naming the argument — matching the existing `CALL dbgen(sf=NULL)` behavior in the same files (`Binder Error: Cannot use NULL as function argument`).

I kept the guard per-site rather than at the pragma-binding layer (which would also cover the assignment-form issue #18448) to keep the change minimal; happy to move it if a general fix is preferred.

Regression tests: `test/sql/tpch/tpch_null_arg.test` and `test/sql/tpcds/tpcds_null_arg.test`. Full tpch (25 cases) and tpcds (13 cases) suites pass.