### PR TITLE
Add one-way settings gating the EXTERNAL RESOURCE feature

### DIFF
--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -38,6 +38,7 @@
 #include "duckdb/common/enums/destroy_buffer_upon.hpp"
 #include "duckdb/common/enums/dialect_compatibility_mode.hpp"
 #include "duckdb/common/enums/expression_type.hpp"
+#include "duckdb/common/enums/external_resources_mode.hpp"
 #include "duckdb/common/enums/file_compression_type.hpp"
 #include "duckdb/common/enums/file_glob_options.hpp"
 #include "duckdb/common/enums/file_write_mode.hpp"
@@ -158,6 +159,7 @@
 #include "duckdb/main/extension.hpp"
 #include "duckdb/main/extension_helper.hpp"
 #include "duckdb/main/extension_install_info.hpp"
+#include "duckdb/main/external_resources_manager.hpp"
 #include "duckdb/main/profiler/gathered_metrics.hpp"
 #include "duckdb/main/query_result.hpp"
 #include "duckdb/main/secret/secret.hpp"
@@ -2332,6 +2334,25 @@ ExtensionUpdateResultTag EnumUtil::FromString<ExtensionUpdateResultTag>(const ch
 	return static_cast<ExtensionUpdateResultTag>(StringUtil::StringToEnum(GetExtensionUpdateResultTagValues(), 8, "ExtensionUpdateResultTag", value));
 }
 
+const StringUtil::EnumStringLiteral *GetExternalResourceCapabilityValues() {
+	static constexpr StringUtil::EnumStringLiteral values[] {
+		{ static_cast<uint32_t>(ExternalResourceCapability::LISTING), "LISTING" },
+		{ static_cast<uint32_t>(ExternalResourceCapability::MANAGEMENT), "MANAGEMENT" },
+		{ static_cast<uint32_t>(ExternalResourceCapability::TYPE_REGISTRATION), "TYPE_REGISTRATION" }
+	};
+	return values;
+}
+
+template<>
+const char* EnumUtil::ToChars<ExternalResourceCapability>(ExternalResourceCapability value) {
+	return StringUtil::EnumToString(GetExternalResourceCapabilityValues(), 3, "ExternalResourceCapability", static_cast<uint32_t>(value));
+}
+
+template<>
+ExternalResourceCapability EnumUtil::FromString<ExternalResourceCapability>(const char *value) {
+	return static_cast<ExternalResourceCapability>(StringUtil::StringToEnum(GetExternalResourceCapabilityValues(), 3, "ExternalResourceCapability", value));
+}
+
 const StringUtil::EnumStringLiteral *GetExternalResourceOperationValues() {
 	static constexpr StringUtil::EnumStringLiteral values[] {
 		{ static_cast<uint32_t>(ExternalResourceOperation::CREATE), "CREATE" },
@@ -2350,6 +2371,25 @@ const char* EnumUtil::ToChars<ExternalResourceOperation>(ExternalResourceOperati
 template<>
 ExternalResourceOperation EnumUtil::FromString<ExternalResourceOperation>(const char *value) {
 	return static_cast<ExternalResourceOperation>(StringUtil::StringToEnum(GetExternalResourceOperationValues(), 4, "ExternalResourceOperation", value));
+}
+
+const StringUtil::EnumStringLiteral *GetExternalResourcesModeValues() {
+	static constexpr StringUtil::EnumStringLiteral values[] {
+		{ static_cast<uint32_t>(ExternalResourcesMode::AVAILABLE), "AVAILABLE" },
+		{ static_cast<uint32_t>(ExternalResourcesMode::LISTING), "LISTING" },
+		{ static_cast<uint32_t>(ExternalResourcesMode::OFF), "OFF" }
+	};
+	return values;
+}
+
+template<>
+const char* EnumUtil::ToChars<ExternalResourcesMode>(ExternalResourcesMode value) {
+	return StringUtil::EnumToString(GetExternalResourcesModeValues(), 3, "ExternalResourcesMode", static_cast<uint32_t>(value));
+}
+
+template<>
+ExternalResourcesMode EnumUtil::FromString<ExternalResourcesMode>(const char *value) {
+	return static_cast<ExternalResourcesMode>(StringUtil::StringToEnum(GetExternalResourcesModeValues(), 3, "ExternalResourcesMode", value));
 }
 
 const StringUtil::EnumStringLiteral *GetExtraDropInfoTypeValues() {

--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -782,6 +782,26 @@
         ]
     },
     {
+        "name": "external_resources_mode",
+        "description": "Which external resource operations are permitted: AVAILABLE (everything), LISTING (listing and discovery only) or OFF (nothing). Degrades one way only - the mode can be made more restrictive, never less",
+        "type": "ENUM<ExternalResourcesMode>",
+        "scope": "global",
+        "custom_implementation": [
+            "set",
+            "reset"
+        ]
+    },
+    {
+        "name": "external_resources_type_registration",
+        "description": "Whether new external resource types can be registered. Degrades one way only - it can be disabled, but not re-enabled",
+        "type": "BOOLEAN",
+        "scope": "global",
+        "custom_implementation": [
+            "set",
+            "reset"
+        ]
+    },
+    {
         "name": "external_threads",
         "description": "The number of external threads that work on DuckDB tasks.",
         "type": "UBIGINT",

--- a/src/execution/operator/helper/physical_external_resource.cpp
+++ b/src/execution/operator/helper/physical_external_resource.cpp
@@ -54,6 +54,7 @@ static void DestroyExternalResource(ClientContext &client, const BoundExternalRe
 
 SourceResultType PhysicalExternalResource::GetDataInternal(ExecutionContext &context, DataChunk &chunk,
                                                            OperatorSourceInput &input) const {
+	ExternalResources::RequireCapability(context.client, ExternalResourceCapability::MANAGEMENT);
 	switch (data.operation) {
 	case ExternalResourceOperation::CREATE:
 	case ExternalResourceOperation::REGISTER:

--- a/src/function/table/system/create_external_resource.cpp
+++ b/src/function/table/system/create_external_resource.cpp
@@ -110,6 +110,7 @@ struct CreateExternalResourceState : public GlobalTableFunctionState {
 static unique_ptr<FunctionData> CreateExternalResourceBind(ClientContext &context, TableFunctionBindInput &input,
                                                            vector<LogicalType> &return_types,
                                                            vector<Identifier> &names) {
+	ExternalResources::RequireCapability(context, ExternalResourceCapability::MANAGEMENT);
 	auto result = make_uniq<CreateExternalResourceBindData>();
 	if (input.inputs[0].IsNull()) {
 		throw InvalidInputException("create_external_resource: the type name must not be NULL");
@@ -158,6 +159,7 @@ static unique_ptr<GlobalTableFunctionState> CreateExternalResourceInit(ClientCon
 }
 
 static void CreateExternalResourceFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	ExternalResources::RequireCapability(context, ExternalResourceCapability::MANAGEMENT);
 	auto &state = data_p.global_state->Cast<CreateExternalResourceState>();
 	if (state.done) {
 		return;
@@ -392,6 +394,7 @@ struct DestroyExternalResourceState : public GlobalTableFunctionState {
 static unique_ptr<FunctionData> DestroyExternalResourceBind(ClientContext &context, TableFunctionBindInput &input,
                                                             vector<LogicalType> &return_types,
                                                             vector<Identifier> &names) {
+	ExternalResources::RequireCapability(context, ExternalResourceCapability::MANAGEMENT);
 	auto result = make_uniq<DestroyExternalResourceBindData>();
 	if (input.inputs[0].IsNull() || StringValue::Get(input.inputs[0]).empty()) {
 		throw InvalidInputException("destroy_external_resource: the deleter function must not be NULL or empty");
@@ -410,6 +413,7 @@ static unique_ptr<GlobalTableFunctionState> DestroyExternalResourceInit(ClientCo
 }
 
 static void DestroyExternalResourceFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	ExternalResources::RequireCapability(context, ExternalResourceCapability::MANAGEMENT);
 	auto &state = data_p.global_state->Cast<DestroyExternalResourceState>();
 	if (state.done) {
 		return;

--- a/src/function/table/system/external_resource_types.cpp
+++ b/src/function/table/system/external_resource_types.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/client_data.hpp"
 #include "duckdb/main/external_resource_type_registry.hpp"
+#include "duckdb/main/external_resources_manager.hpp"
 
 namespace duckdb {
 
@@ -23,6 +24,7 @@ struct RegisterExternalResourceTypeState : public GlobalTableFunctionState {
 static unique_ptr<FunctionData> RegisterExternalResourceTypeBind(ClientContext &context, TableFunctionBindInput &input,
                                                                  vector<LogicalType> &return_types,
                                                                  vector<Identifier> &names) {
+	ExternalResources::RequireCapability(context, ExternalResourceCapability::TYPE_REGISTRATION);
 	auto result = make_uniq<RegisterExternalResourceTypeBindData>();
 	auto &type = result->type;
 
@@ -68,6 +70,7 @@ static unique_ptr<GlobalTableFunctionState> RegisterExternalResourceTypeInit(Cli
 
 static void RegisterExternalResourceTypeFunction(ClientContext &context, TableFunctionInput &data_p,
                                                  DataChunk &output) {
+	ExternalResources::RequireCapability(context, ExternalResourceCapability::TYPE_REGISTRATION);
 	auto &state = data_p.global_state->Cast<RegisterExternalResourceTypeState>();
 	if (state.done) {
 		return;
@@ -93,6 +96,7 @@ struct ExternalResourceTypesData : public GlobalTableFunctionState {
 static unique_ptr<FunctionData> ExternalResourceTypesBind(ClientContext &context, TableFunctionBindInput &input,
                                                           vector<LogicalType> &return_types,
                                                           vector<Identifier> &names) {
+	ExternalResources::RequireCapability(context, ExternalResourceCapability::LISTING);
 	names.emplace_back("name");
 	return_types.emplace_back(LogicalType::VARCHAR);
 	names.emplace_back("kind");
@@ -114,6 +118,7 @@ static unique_ptr<FunctionData> ExternalResourceTypesBind(ClientContext &context
 
 static unique_ptr<GlobalTableFunctionState> ExternalResourceTypesInit(ClientContext &context,
                                                                       TableFunctionInitInput &input) {
+	ExternalResources::RequireCapability(context, ExternalResourceCapability::LISTING);
 	auto result = make_uniq<ExternalResourceTypesData>();
 	result->types = ExternalResourceTypeRegistry::Get(context).List();
 	return std::move(result);

--- a/src/function/table/system/external_resources.cpp
+++ b/src/function/table/system/external_resources.cpp
@@ -47,6 +47,7 @@ struct ExternalResourcesGlobalState : public GlobalTableFunctionState {
 
 static unique_ptr<FunctionData> ExternalResourcesBind(ClientContext &context, TableFunctionBindInput &input,
                                                       vector<LogicalType> &return_types, vector<Identifier> &names) {
+	ExternalResources::RequireCapability(context, ExternalResourceCapability::LISTING);
 	auto result = make_uniq<ExternalResourcesBindData>();
 	for (auto &np : input.named_parameters) {
 		if (StringUtil::Lower(np.first.GetIdentifierName()) == "discover" && !np.second.IsNull()) {
@@ -155,6 +156,7 @@ static void DiscoverExternalResources(ClientContext &context, const ExternalReso
 
 static unique_ptr<GlobalTableFunctionState> ExternalResourcesInit(ClientContext &context,
                                                                   TableFunctionInitInput &input) {
+	ExternalResources::RequireCapability(context, ExternalResourceCapability::LISTING);
 	auto &bind_data = input.bind_data->Cast<ExternalResourcesBindData>();
 	auto result = make_uniq<ExternalResourcesGlobalState>();
 
@@ -235,6 +237,7 @@ struct RegisterExternalResourceState : public GlobalTableFunctionState {
 static unique_ptr<FunctionData> RegisterExternalResourceBind(ClientContext &context, TableFunctionBindInput &input,
                                                              vector<LogicalType> &return_types,
                                                              vector<Identifier> &names) {
+	ExternalResources::RequireCapability(context, ExternalResourceCapability::MANAGEMENT);
 	auto result = make_uniq<RegisterExternalResourceBindData>();
 	auto &resource = result->resource;
 	if (input.inputs[0].IsNull() || input.inputs[1].IsNull()) {
@@ -274,6 +277,7 @@ static unique_ptr<GlobalTableFunctionState> RegisterExternalResourceInit(ClientC
 }
 
 static void RegisterExternalResourceFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	ExternalResources::RequireCapability(context, ExternalResourceCapability::MANAGEMENT);
 	auto &state = data_p.global_state->Cast<RegisterExternalResourceState>();
 	if (state.done) {
 		return;
@@ -314,6 +318,7 @@ struct DeregisterExternalResourceState : public GlobalTableFunctionState {
 static unique_ptr<FunctionData> DeregisterExternalResourceBind(ClientContext &context, TableFunctionBindInput &input,
                                                                vector<LogicalType> &return_types,
                                                                vector<Identifier> &names) {
+	ExternalResources::RequireCapability(context, ExternalResourceCapability::MANAGEMENT);
 	auto result = make_uniq<DeregisterExternalResourceBindData>();
 	if (input.inputs[0].IsNull() || StringValue::Get(input.inputs[0]).empty()) {
 		throw InvalidInputException("deregister_external_resource: the name must not be NULL or empty");
@@ -330,6 +335,7 @@ static unique_ptr<GlobalTableFunctionState> DeregisterExternalResourceInit(Clien
 }
 
 static void DeregisterExternalResourceFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	ExternalResources::RequireCapability(context, ExternalResourceCapability::MANAGEMENT);
 	auto &state = data_p.global_state->Cast<DeregisterExternalResourceState>();
 	if (state.done) {
 		return;

--- a/src/include/duckdb/common/enum_util.hpp
+++ b/src/include/duckdb/common/enum_util.hpp
@@ -224,7 +224,11 @@ enum class ExtensionLoadResult : uint8_t;
 
 enum class ExtensionUpdateResultTag : uint8_t;
 
+enum class ExternalResourceCapability : uint8_t;
+
 enum class ExternalResourceOperation : uint8_t;
+
+enum class ExternalResourcesMode : uint8_t;
 
 enum class ExtraDropInfoType : uint8_t;
 
@@ -906,7 +910,13 @@ template<>
 const char* EnumUtil::ToChars<ExtensionUpdateResultTag>(ExtensionUpdateResultTag value);
 
 template<>
+const char* EnumUtil::ToChars<ExternalResourceCapability>(ExternalResourceCapability value);
+
+template<>
 const char* EnumUtil::ToChars<ExternalResourceOperation>(ExternalResourceOperation value);
+
+template<>
+const char* EnumUtil::ToChars<ExternalResourcesMode>(ExternalResourcesMode value);
 
 template<>
 const char* EnumUtil::ToChars<ExtraDropInfoType>(ExtraDropInfoType value);
@@ -1783,7 +1793,13 @@ template<>
 ExtensionUpdateResultTag EnumUtil::FromString<ExtensionUpdateResultTag>(const char *value);
 
 template<>
+ExternalResourceCapability EnumUtil::FromString<ExternalResourceCapability>(const char *value);
+
+template<>
 ExternalResourceOperation EnumUtil::FromString<ExternalResourceOperation>(const char *value);
+
+template<>
+ExternalResourcesMode EnumUtil::FromString<ExternalResourcesMode>(const char *value);
 
 template<>
 ExtraDropInfoType EnumUtil::FromString<ExtraDropInfoType>(const char *value);

--- a/src/include/duckdb/common/enums/external_resources_mode.hpp
+++ b/src/include/duckdb/common/enums/external_resources_mode.hpp
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/enums/external_resources_mode.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/constants.hpp"
+
+namespace duckdb {
+
+//! How much of the external resource feature is available. Ordered by increasing restriction: the mode
+//! degrades one way only, so a new mode is accepted only when it compares greater than the current one.
+enum class ExternalResourcesMode : uint8_t {
+	//! Everything: provisioning, teardown, type registration and listing.
+	AVAILABLE = 0,
+	//! Read-only: listing and discovery, but no create, destroy or type registration.
+	LISTING = 1,
+	//! Nothing: every external resource operation is rejected.
+	OFF = 2
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -15,6 +15,7 @@
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/enums/access_mode.hpp"
 #include "duckdb/common/enums/cache_validation_mode.hpp"
+#include "duckdb/common/enums/external_resources_mode.hpp"
 #include "duckdb/common/enums/thread_pin_mode.hpp"
 #include "duckdb/common/enums/compression_type.hpp"
 #include "duckdb/common/enums/optimizer_type.hpp"
@@ -144,6 +145,10 @@ struct DBConfigOptions {
 	set<string> allowed_directories;
 	//! Additional configuration options that are allowed to be changed even when the configuration is locked
 	identifier_set_t allowed_configs;
+	//! Which external resource operations are permitted - degrades one way only
+	ExternalResourcesMode external_resources_mode = ExternalResourcesMode::AVAILABLE;
+	//! Whether new external resource types can be registered - degrades one way only
+	bool external_resources_type_registration = true;
 	//! The log configuration
 	LogConfig log_config = LogConfig();
 	//! Physical memory that the block allocator is allowed to use (this memory is never freed and cannot be reduced)

--- a/src/include/duckdb/main/external_resources_manager.hpp
+++ b/src/include/duckdb/main/external_resources_manager.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "duckdb/common/enums/external_resources_mode.hpp"
 #include "duckdb/common/mutex.hpp"
 #include "duckdb/common/types/value.hpp"
 #include "duckdb/common/vector.hpp"
@@ -15,6 +16,30 @@
 namespace duckdb {
 class DatabaseInstance;
 class ClientContext;
+struct DBConfig;
+
+//! What a caller wants to do with the external resource feature. Every user-facing entry point names one,
+//! and `ExternalResources::RequireCapability` maps it to the settings that govern it — this enum plus that
+//! mapping is the extension point: a new capability is added here, not by adding checks at the callsites.
+enum class ExternalResourceCapability : uint8_t {
+	//! Reading what exists: duckdb_external_resources(), duckdb_external_resource_types(), SHOW EXTERNAL RESOURCES.
+	LISTING,
+	//! Provisioning and teardown: CREATE / REGISTER / DESTROY EXTERNAL RESOURCE and their table functions.
+	MANAGEMENT,
+	//! Registering a new external resource type.
+	TYPE_REGISTRATION
+};
+
+//! The configuration gate for the external resource feature. The C++ APIs below (the manager, the type
+//! registry) stay ungated on purpose: internal paths such as teardown must keep working, and an extension
+//! that is already loaded is inside the trust boundary. Only the SQL entry points are gated - each of them
+//! twice: at bind time so the failure is early and clear, and again where the work happens, because a
+//! statement prepared before the setting was lowered would otherwise still run.
+struct ExternalResources {
+	//! Throws a PermissionException unless the configuration permits `capability`.
+	static void RequireCapability(const DBConfig &config, ExternalResourceCapability capability);
+	static void RequireCapability(ClientContext &context, ExternalResourceCapability capability);
+};
 
 //! An external resource this instance tracks, registered under a local name (from CREATE/REGISTER EXTERNAL
 //! RESOURCE). `name` is the local alias and the only key enforced here: `(type, handle)` identifies the

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -1182,6 +1182,29 @@ struct ExternalFileCacheRemoteBlockSizeSetting {
 	static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
+struct ExternalResourcesModeSetting {
+	using RETURN_TYPE = ExternalResourcesMode;
+	static constexpr const char *Name = "external_resources_mode";
+	static constexpr const char *Description =
+	    "Which external resource operations are permitted: AVAILABLE (everything), LISTING (listing and discovery "
+	    "only) or OFF (nothing). Degrades one way only - the mode can be made more restrictive, never less";
+	static constexpr const char *InputType = "VARCHAR";
+	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
+	static Value GetSetting(const ClientContext &context);
+};
+
+struct ExternalResourcesTypeRegistrationSetting {
+	using RETURN_TYPE = bool;
+	static constexpr const char *Name = "external_resources_type_registration";
+	static constexpr const char *Description = "Whether new external resource types can be registered. Degrades one "
+	                                           "way only - it can be disabled, but not re-enabled";
+	static constexpr const char *InputType = "BOOLEAN";
+	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
+	static Value GetSetting(const ClientContext &context);
+};
+
 struct ExternalThreadsSetting {
 	using RETURN_TYPE = idx_t;
 	static constexpr const char *Name = "external_threads";

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -164,6 +164,8 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_SETTING(ExtensionDirectorySetting),
     DUCKDB_SETTING_CALLBACK(ExternalFileCacheLocalBlockSizeSetting),
     DUCKDB_SETTING_CALLBACK(ExternalFileCacheRemoteBlockSizeSetting),
+    DUCKDB_GLOBAL(ExternalResourcesModeSetting),
+    DUCKDB_GLOBAL(ExternalResourcesTypeRegistrationSetting),
     DUCKDB_SETTING_CALLBACK(ExternalThreadsSetting),
     DUCKDB_SETTING(FileSearchPathSetting),
     DUCKDB_SETTING_CALLBACK(ForceBitpackingModeSetting),
@@ -250,12 +252,12 @@ static const ConfigurationOption internal_options[] = {
 
 static const ConfigurationAlias setting_aliases[] = {DUCKDB_SETTING_ALIAS("configure_metrics", 30),
                                                      DUCKDB_SETTING_ALIAS("custom_profiling_settings", 30),
-                                                     DUCKDB_SETTING_ALIAS("memory_limit", 129),
+                                                     DUCKDB_SETTING_ALIAS("memory_limit", 131),
                                                      DUCKDB_SETTING_ALIAS("null_order", 61),
-                                                     DUCKDB_SETTING_ALIAS("profile_output", 152),
-                                                     DUCKDB_SETTING_ALIAS("user", 171),
+                                                     DUCKDB_SETTING_ALIAS("profile_output", 154),
+                                                     DUCKDB_SETTING_ALIAS("user", 173),
                                                      DUCKDB_SETTING_ALIAS("wal_autocheckpoint", 29),
-                                                     DUCKDB_SETTING_ALIAS("worker_threads", 169),
+                                                     DUCKDB_SETTING_ALIAS("worker_threads", 171),
                                                      FINAL_ALIAS};
 
 vector<ConfigurationOption> DBConfig::GetOptions() {

--- a/src/main/external_resources_manager.cpp
+++ b/src/main/external_resources_manager.cpp
@@ -4,16 +4,65 @@
 #include "duckdb/catalog/catalog_entry/schema_catalog_entry.hpp"
 #include "duckdb/catalog/entry_lookup_info.hpp"
 #include "duckdb/common/enums/on_entry_not_found.hpp"
+#include "duckdb/common/enum_util.hpp"
 #include "duckdb/common/error_data.hpp"
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/string_util.hpp"
 #include "duckdb/logging/log_type.hpp"
 #include "duckdb/logging/logger.hpp"
 #include "duckdb/main/client_context.hpp"
+#include "duckdb/main/config.hpp"
 #include "duckdb/main/connection.hpp"
 #include "duckdb/main/database.hpp"
 #include "duckdb/parser/qualified_name.hpp"
 
 namespace duckdb {
+
+//! The minimum mode a capability needs. Modes are ordered by increasing restriction, so a capability is
+//! permitted while the configured mode is no stricter than this.
+static ExternalResourcesMode RequiredMode(ExternalResourceCapability capability) {
+	switch (capability) {
+	case ExternalResourceCapability::LISTING:
+		return ExternalResourcesMode::LISTING;
+	case ExternalResourceCapability::MANAGEMENT:
+	case ExternalResourceCapability::TYPE_REGISTRATION:
+		// Registering a type needs the full mode too, not just LISTING: a type's `list` callback is invoked
+		// by discovery, which LISTING still allows, so a new type would be a way to get a function called.
+		return ExternalResourcesMode::AVAILABLE;
+	default:
+		throw InternalException("Unsupported external resource capability");
+	}
+}
+
+static const char *CapabilityDescription(ExternalResourceCapability capability) {
+	switch (capability) {
+	case ExternalResourceCapability::LISTING:
+		return "listing external resources";
+	case ExternalResourceCapability::MANAGEMENT:
+		return "creating or destroying external resources";
+	case ExternalResourceCapability::TYPE_REGISTRATION:
+		return "registering external resource types";
+	default:
+		throw InternalException("Unsupported external resource capability");
+	}
+}
+
+void ExternalResources::RequireCapability(const DBConfig &config, ExternalResourceCapability capability) {
+	auto mode = config.options.external_resources_mode;
+	if (mode > RequiredMode(capability)) {
+		throw PermissionException("%s is disabled because external_resources_mode is set to \"%s\"",
+		                          CapabilityDescription(capability), StringUtil::Lower(EnumUtil::ToString(mode)));
+	}
+	if (capability == ExternalResourceCapability::TYPE_REGISTRATION &&
+	    !config.options.external_resources_type_registration) {
+		throw PermissionException("%s is disabled because external_resources_type_registration is set to false",
+		                          CapabilityDescription(capability));
+	}
+}
+
+void ExternalResources::RequireCapability(ClientContext &context, ExternalResourceCapability capability) {
+	RequireCapability(DBConfig::GetConfig(context), capability);
+}
 
 ResourceDeleter::ResourceDeleter(DatabaseInstance &db, string deleter_function_p, Value deleter_payload_p,
                                  string resource_type_p, string resource_name_p)

--- a/src/main/settings/autogenerated_settings.cpp
+++ b/src/main/settings/autogenerated_settings.cpp
@@ -220,6 +220,22 @@ void ExplainOutputSetting::OnSet(SettingCallbackInfo &info, Value &parameter) {
 }
 
 //===----------------------------------------------------------------------===//
+// External Resources Mode
+//===----------------------------------------------------------------------===//
+Value ExternalResourcesModeSetting::GetSetting(const ClientContext &context) {
+	auto &config = DBConfig::GetConfig(context);
+	return Value(StringUtil::Lower(EnumUtil::ToString(config.options.external_resources_mode)));
+}
+
+//===----------------------------------------------------------------------===//
+// External Resources Type Registration
+//===----------------------------------------------------------------------===//
+Value ExternalResourcesTypeRegistrationSetting::GetSetting(const ClientContext &context) {
+	auto &config = DBConfig::GetConfig(context);
+	return Value::BOOLEAN(config.options.external_resources_type_registration);
+}
+
+//===----------------------------------------------------------------------===//
 // Force Bitpacking Mode
 //===----------------------------------------------------------------------===//
 void ForceBitpackingModeSetting::OnSet(SettingCallbackInfo &info, Value &parameter) {

--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -933,6 +933,69 @@ bool EnableProgressBarSetting::OnLocalReset(ClientContext &context) {
 }
 
 //===----------------------------------------------------------------------===//
+// External Resources Mode
+//===----------------------------------------------------------------------===//
+//! Accepted spellings on top of the enum names: `on` for AVAILABLE and `none` for OFF.
+static ExternalResourcesMode ParseExternalResourcesMode(const Value &input) {
+	if (input.IsNull()) {
+		throw InvalidInputException("external_resources_mode setting cannot be NULL");
+	}
+	auto parameter = StringUtil::Upper(input.ToString());
+	if (parameter == "ON") {
+		return ExternalResourcesMode::AVAILABLE;
+	}
+	if (parameter == "NONE") {
+		return ExternalResourcesMode::OFF;
+	}
+	return EnumUtil::FromString<ExternalResourcesMode>(parameter);
+}
+
+static string ExternalResourcesModeName(ExternalResourcesMode mode) {
+	return StringUtil::Lower(EnumUtil::ToString(mode));
+}
+
+void ExternalResourcesModeSetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {
+	auto requested = ParseExternalResourcesMode(input);
+	auto &current_mode = config.options.external_resources_mode;
+	// The modes are ordered by increasing restriction, so degrading never decreases the value.
+	if (requested < current_mode) {
+		throw InvalidInputException(
+		    "Cannot set external_resources_mode to \"%s\" while it is \"%s\" - it can only be made more restrictive",
+		    ExternalResourcesModeName(requested), ExternalResourcesModeName(current_mode));
+	}
+	current_mode = requested;
+}
+
+void ExternalResourcesModeSetting::ResetGlobal(DatabaseInstance *db, DBConfig &config) {
+	auto default_mode = DBConfigOptions().external_resources_mode;
+	if (config.options.external_resources_mode != default_mode) {
+		throw InvalidInputException(
+		    "Cannot reset external_resources_mode - it is \"%s\" and can only be made more restrictive",
+		    ExternalResourcesModeName(config.options.external_resources_mode));
+	}
+}
+
+//===----------------------------------------------------------------------===//
+// External Resources Type Registration
+//===----------------------------------------------------------------------===//
+void ExternalResourcesTypeRegistrationSetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {
+	auto requested = input.GetValue<bool>();
+	if (requested && !config.options.external_resources_type_registration) {
+		throw InvalidInputException(
+		    "Cannot enable external_resources_type_registration - it can only be disabled, not re-enabled");
+	}
+	config.options.external_resources_type_registration = requested;
+}
+
+void ExternalResourcesTypeRegistrationSetting::ResetGlobal(DatabaseInstance *db, DBConfig &config) {
+	auto default_value = DBConfigOptions().external_resources_type_registration;
+	if (config.options.external_resources_type_registration != default_value) {
+		throw InvalidInputException(
+		    "Cannot reset external_resources_type_registration - it is disabled and can only be disabled");
+	}
+}
+
+//===----------------------------------------------------------------------===//
 // External Threads
 //===----------------------------------------------------------------------===//
 void ExternalThreadsSetting::OnSet(SettingCallbackInfo &info, Value &input) {

--- a/src/planner/binder/statement/bind_external_resource.cpp
+++ b/src/planner/binder/statement/bind_external_resource.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/execution/expression_executor.hpp"
+#include "duckdb/main/external_resources_manager.hpp"
 #include "duckdb/parser/expression/constant_expression.hpp"
 #include "duckdb/parser/expression/function_expression.hpp"
 #include "duckdb/parser/expression/star_expression.hpp"
@@ -13,6 +14,9 @@
 namespace duckdb {
 
 BoundStatement Binder::Bind(ExternalResourceStatement &stmt) {
+	ExternalResources::RequireCapability(context, stmt.operation == ExternalResourceOperation::SHOW
+	                                                  ? ExternalResourceCapability::LISTING
+	                                                  : ExternalResourceCapability::MANAGEMENT);
 	if (stmt.operation == ExternalResourceOperation::SHOW) {
 		// SHOW [ALL] EXTERNAL RESOURCES desugars to `SELECT * FROM duckdb_external_resources(all := <all>)`.
 		vector<unique_ptr<ParsedExpression>> children;

--- a/test/api/test_reset.cpp
+++ b/test/api/test_reset.cpp
@@ -186,14 +186,16 @@ bool OptionIsExcludedFromTest(const string &name) {
 	    "search_path",
 	    "debug_window_mode",
 	    "experimental_parallel_csv",
-	    "lock_configuration",            // cant change this while db is running
-	    "disabled_filesystems",          // cant change this while db is running
-	    "enable_external_access",        // cant change this while db is running
-	    "allow_unsigned_extensions",     // cant change this while db is running
-	    "allow_community_extensions",    // cant change this while db is running
-	    "allow_unredacted_secrets",      // cant change this while db is running
-	    "disable_database_invalidation", // cant change this while db is running
-	    "vacuum_rebuild_indexes",        // cant change this while db is running
+	    "lock_configuration",                   // cant change this while db is running
+	    "disabled_filesystems",                 // cant change this while db is running
+	    "enable_external_access",               // cant change this while db is running
+	    "allow_unsigned_extensions",            // cant change this while db is running
+	    "allow_community_extensions",           // cant change this while db is running
+	    "allow_unredacted_secrets",             // cant change this while db is running
+	    "disable_database_invalidation",        // cant change this while db is running
+	    "external_resources_mode",              // one-way setting - cannot be reset once lowered
+	    "external_resources_type_registration", // one-way setting - cannot be reset once disabled
+	    "vacuum_rebuild_indexes",               // cant change this while db is running
 	    "temp_file_encryption",
 	    "enable_object_cache",
 	    "force_variant_shredding",

--- a/test/configs/force_storage_restart.json
+++ b/test/configs/force_storage_restart.json
@@ -14,7 +14,9 @@
         "test/sql/table_function/external_resource_logging.test",
         "test/sql/table_function/external_resource_discovery.test",
         "test/sql/table_function/external_resource_discovery_error.test",
-        "test/sql/attach/external_resource_discovery.test"
+        "test/sql/attach/external_resource_discovery.test",
+        "test/sql/settings/external_resources_mode.test",
+        "test/sql/settings/external_resources_type_registration.test"
       ]
     },
     {

--- a/test/sql/settings/external_resources_mode.test
+++ b/test/sql/settings/external_resources_mode.test
@@ -1,0 +1,169 @@
+# name: test/sql/settings/external_resources_mode.test
+# description: external_resources_mode gates the EXTERNAL RESOURCE feature and degrades one way only
+# group: [settings]
+
+# The feature is fully available by default.
+query T
+SELECT current_setting('external_resources_mode');
+----
+available
+
+# At the default nothing is gated: these fail on their own merits, not on the gate.
+statement ok
+CALL register_external_resource_type('quack@aws:ec2', kind := 'catalog', create_function := 'quack_create');
+
+query I
+SELECT count(*) FROM duckdb_external_resources();
+----
+0
+
+statement error
+DESTROY EXTERNAL RESOURCE nope;
+----
+<REGEX>:.*not registered.*
+
+# `on` is accepted as a spelling of AVAILABLE, and the canonical name is reported back.
+statement ok
+SET external_resources_mode = 'on';
+
+query T
+SELECT current_setting('external_resources_mode');
+----
+available
+
+# Unknown values are rejected.
+statement error
+SET external_resources_mode = 'sometimes';
+----
+<REGEX>:.*unrecognized value.*
+
+# ---------------------------------------------------------------------------
+# listing: create and destroy are blocked, listing still works
+# ---------------------------------------------------------------------------
+statement ok
+SET external_resources_mode = 'listing';
+
+query T
+SELECT current_setting('external_resources_mode');
+----
+listing
+
+query I
+SELECT count(*) FROM duckdb_external_resources();
+----
+0
+
+query I
+SELECT count(*) FROM duckdb_external_resource_types();
+----
+1
+
+statement ok
+SHOW EXTERNAL RESOURCES;
+
+statement error
+CREATE EXTERNAL RESOURCE 'quack@aws:ec2' AS x;
+----
+<REGEX>:.*creating or destroying external resources is disabled.*external_resources_mode.*listing.*
+
+statement error
+REGISTER EXTERNAL RESOURCE 'quack@aws:ec2' AS x FROM MAP {'id': 'i-123'};
+----
+<REGEX>:.*creating or destroying external resources is disabled.*
+
+statement error
+DESTROY EXTERNAL RESOURCE nope;
+----
+<REGEX>:.*creating or destroying external resources is disabled.*
+
+statement error
+SELECT * FROM create_external_resource('quack@aws:ec2');
+----
+<REGEX>:.*creating or destroying external resources is disabled.*
+
+statement error
+CALL destroy_external_resource('quack_destroy', MAP {'id': 'i-123'});
+----
+<REGEX>:.*creating or destroying external resources is disabled.*
+
+statement error
+CALL register_external_resource('quack@aws:ec2', 'x', MAP {'id': 'i-123'});
+----
+<REGEX>:.*creating or destroying external resources is disabled.*
+
+statement error
+CALL deregister_external_resource('x');
+----
+<REGEX>:.*creating or destroying external resources is disabled.*
+
+# Registering a type needs the full mode, not just listing: a type's `list` callback is invoked by
+# discovery, which listing still allows.
+statement error
+CALL register_external_resource_type('pg@aws:rds', kind := 'catalog', create_function := 'pg_create');
+----
+<REGEX>:.*registering external resource types is disabled.*external_resources_mode.*listing.*
+
+# ---------------------------------------------------------------------------
+# One way only: the mode can never be relaxed again
+# ---------------------------------------------------------------------------
+statement error
+SET external_resources_mode = 'available';
+----
+<REGEX>:.*Cannot set external_resources_mode to "available" while it is "listing".*
+
+statement error
+SET external_resources_mode = 'on';
+----
+<REGEX>:.*only be made more restrictive.*
+
+# ... and RESET cannot smuggle the default back in.
+statement error
+RESET external_resources_mode;
+----
+<REGEX>:.*Cannot reset external_resources_mode.*
+
+query T
+SELECT current_setting('external_resources_mode');
+----
+listing
+
+# Re-applying the current mode is a no-op, not an error.
+statement ok
+SET external_resources_mode = 'listing';
+
+# ---------------------------------------------------------------------------
+# off (spelled `none` here): listing is blocked too
+# ---------------------------------------------------------------------------
+statement ok
+SET external_resources_mode = 'none';
+
+query T
+SELECT current_setting('external_resources_mode');
+----
+off
+
+statement error
+SELECT count(*) FROM duckdb_external_resources();
+----
+<REGEX>:.*listing external resources is disabled.*external_resources_mode.*off.*
+
+statement error
+SELECT count(*) FROM duckdb_external_resource_types();
+----
+<REGEX>:.*listing external resources is disabled.*
+
+statement error
+SHOW EXTERNAL RESOURCES;
+----
+<REGEX>:.*listing external resources is disabled.*
+
+statement error
+CREATE EXTERNAL RESOURCE 'quack@aws:ec2' AS x;
+----
+<REGEX>:.*creating or destroying external resources is disabled.*
+
+# The setting is global, so a connection made after it was lowered is gated too.
+statement error con1
+SELECT count(*) FROM duckdb_external_resources();
+----
+<REGEX>:.*listing external resources is disabled.*

--- a/test/sql/settings/external_resources_mode_off.test
+++ b/test/sql/settings/external_resources_mode_off.test
@@ -1,0 +1,48 @@
+# name: test/sql/settings/external_resources_mode_off.test
+# description: external_resources_mode = off, reached in one step from the default
+# group: [settings]
+
+statement ok
+CALL register_external_resource_type('quack@aws:ec2', kind := 'catalog', create_function := 'quack_create');
+
+# The ladder can be descended more than one rung at a time.
+statement ok
+SET external_resources_mode = 'off';
+
+query T
+SELECT current_setting('external_resources_mode');
+----
+off
+
+statement error
+SELECT count(*) FROM duckdb_external_resource_types();
+----
+<REGEX>:.*listing external resources is disabled.*external_resources_mode.*off.*
+
+statement error
+CALL register_external_resource_type('pg@aws:rds', kind := 'catalog', create_function := 'pg_create');
+----
+<REGEX>:.*registering external resource types is disabled.*
+
+# `listing` is less restrictive than `off`, so it is refused just like `available` is.
+statement error
+SET external_resources_mode = 'listing';
+----
+<REGEX>:.*Cannot set external_resources_mode to "listing" while it is "off".*
+
+statement error
+SET external_resources_mode = 'on';
+----
+<REGEX>:.*only be made more restrictive.*
+
+query T
+SELECT current_setting('external_resources_mode');
+----
+off
+
+# Re-applying `off` is a no-op, under either spelling.
+statement ok
+SET external_resources_mode = 'off';
+
+statement ok
+SET external_resources_mode = 'none';

--- a/test/sql/settings/external_resources_type_registration.test
+++ b/test/sql/settings/external_resources_type_registration.test
@@ -1,0 +1,67 @@
+# name: test/sql/settings/external_resources_type_registration.test
+# description: external_resources_type_registration blocks new external resource types, one way only
+# group: [settings]
+
+# Type registration is allowed by default.
+query T
+SELECT current_setting('external_resources_type_registration');
+----
+true
+
+statement ok
+CALL register_external_resource_type('quack@aws:ec2', kind := 'catalog', create_function := 'quack_create');
+
+statement ok
+SET external_resources_type_registration = false;
+
+query T
+SELECT current_setting('external_resources_type_registration');
+----
+false
+
+statement error
+CALL register_external_resource_type('pg@aws:rds', kind := 'catalog', create_function := 'pg_create');
+----
+<REGEX>:.*registering external resource types is disabled.*external_resources_type_registration.*
+
+# It is the only thing gated: the types registered before it are still usable and listable.
+query I
+SELECT count(*) FROM duckdb_external_resource_types();
+----
+1
+
+query I
+SELECT count(*) FROM duckdb_external_resources();
+----
+0
+
+statement error
+DESTROY EXTERNAL RESOURCE nope;
+----
+<REGEX>:.*not registered.*
+
+# One way only.
+statement error
+SET external_resources_type_registration = true;
+----
+<REGEX>:.*Cannot enable external_resources_type_registration.*
+
+statement error
+RESET external_resources_type_registration;
+----
+<REGEX>:.*Cannot reset external_resources_type_registration.*
+
+query T
+SELECT current_setting('external_resources_type_registration');
+----
+false
+
+# Re-applying the current value is a no-op, not an error.
+statement ok
+SET external_resources_type_registration = false;
+
+# The setting is global, so a connection made after it was disabled is gated too.
+statement error con1
+CALL register_external_resource_type('pg@aws:rds', kind := 'catalog', create_function := 'pg_create');
+----
+<REGEX>:.*registering external resource types is disabled.*


### PR DESCRIPTION
Two global settings, both of which can only ever be made more restrictive:

```sql
SET external_resources_mode = 'available' | 'on'   -- the default, nothing gated
SET external_resources_mode = 'listing'            -- no create/register/destroy
SET external_resources_mode = 'off' | 'none'       -- no listing either
SET external_resources_type_registration = false   -- no new resource types
```

Raising either of them errors, and RESET is refused once lowered, so an operator can hand a session to less-trusted code without it being able to undo the restriction. Both are non-generic settings for that reason: a setting with a `default_value` lives in DBConfig::user_settings, where RESET is a bare ClearSetting with no callback and would restore the default.

The modes are an ENUM<ExternalResourcesMode> ordered by increasing restriction, so "degrade only" is simply "the new value must not compare less than the current one".

Callers name a capability rather than a setting: ExternalResources::RequireCapability maps LISTING / MANAGEMENT / TYPE_REGISTRATION onto the settings that govern them, so a future knob is added there instead of at the call sites. TYPE_REGISTRATION requires the full mode, not just LISTING: a type's `list` callback is invoked by discovery, which LISTING still allows, so registering a type would otherwise be a way to get an arbitrary function called under a read-only mode.

Every SQL entry point is gated twice - at bind time, so the failure is early and clear, and again where the work happens, because a statement prepared before the setting was lowered would otherwise still run. The in-process C++ APIs (the manager, the type registry) stay ungated so internal teardown keeps working.