### PR TITLE
Fix list_reduce raising INTERNAL error when its lambda throws

### DIFF
--- a/extension/core_functions/scalar/list/list_reduce.cpp
+++ b/extension/core_functions/scalar/list/list_reduce.cpp
@@ -333,6 +333,7 @@ ScalarFunctionSet ListReduceFun::GetFunctions() {
 	fun.SetSerializeCallback(ListLambdaBindData::Serialize);
 	fun.SetDeserializeCallback(ListLambdaBindData::Deserialize);
 	fun.SetBindLambdaCallback(ListReduceBindLambda);
+	fun.SetFallible();
 
 	ScalarFunctionSet set;
 	set.AddFunction(fun);

--- a/test/sql/function/list/lambdas/reduce.test
+++ b/test/sql/function/list/lambdas/reduce.test
@@ -441,3 +441,14 @@ list_reduce(
 )
 ----
 {'a': 2, 'b': 2}
+
+# errors thrown by the reduce lambda propagate as clean errors, not INTERNAL errors (#24616)
+statement error
+SELECT list_reduce([1, 2], lambda x, y: error('test error'));
+----
+Invalid Input Error: test error
+
+statement error
+SELECT list_reduce(['1', 'a'], lambda x, y: (x::INT + y::INT)::VARCHAR);
+----
+Conversion Error


### PR DESCRIPTION
Fixes #24616

`list_reduce` never called `SetFallible()`, so any error raised while evaluating the reduce lambda (e.g. arithmetic overflow) surfaced as `INTERNAL Error: Scalar function "list_reduce" threw an execution error, but the function is not marked as fallible` instead of the clean user-facing error.

This adds the missing `fun.SetFallible()` call in `ListReduceFun::GetFunctions()`, matching the sibling list-lambda functions `list_transform` and `list_filter` which already mark themselves fallible.

Regression tests added to `test/sql/function/list/lambdas/reduce.test` covering both overflow repros from the issue. Full lambdas suite (34 cases) and list function suite (110 cases) pass.