### PR TITLE
Remove patches to see bugprone-exception-escape fail in CI

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -37,7 +37,6 @@ Checks: >-
   cppcoreguidelines-rvalue-reference-param-not-moved,
   cppcoreguidelines-virtual-class-destructor,
   -readability-identifier-naming,
-  -bugprone-exception-escape,
   -bugprone-unused-local-non-trivial-variable,
   -bugprone-empty-catch,
   -misc-use-internal-linkage,


### PR DESCRIPTION
Try to see clang tidy fail in CI because https://github.com/duckdb/duckdb/pull/24659/ adds changes that should fail and be detected.