### PR TITLE
fix: MERGE `RETURNING` returning zeroed rows on `WHEN NOT MATCHED BY SOURCE` UPDATE

### DIFF
--- a/src/planner/binder/statement/bind_merge_into.cpp
+++ b/src/planner/binder/statement/bind_merge_into.cpp
@@ -286,6 +286,13 @@ BoundStatement Binder::BindNode(MergeQueryNode &node) {
 
 	merge_into->bound_constraints = BindConstraints(table);
 
+	// Set return_chunk before binding any actions: the update binding uses it to expand to a full-row update so
+	// RETURNING can report the whole row. It must be set before the WHEN NOT MATCHED (BY SOURCE) actions below are
+	// bound, otherwise those updates only carry their SET columns and RETURNING reports zeroed values for the rest.
+	if (!node.returning_list.empty()) {
+		merge_into->return_chunk = true;
+	}
+
 	for (auto &entry : node.actions) {
 		if (entry.first == MergeActionCondition::WHEN_MATCHED) {
 			continue;
@@ -340,10 +347,6 @@ BoundStatement Binder::BindNode(MergeQueryNode &node) {
 	// kind of hacky, CreatePlan turns a RIGHT join into a LEFT join so the children get reversed from what we need
 	bool inverted = join.type == JoinType::RIGHT;
 	auto &source = join_ref.get().children[inverted ? 1 : 0];
-
-	if (!node.returning_list.empty()) {
-		merge_into->return_chunk = true;
-	}
 
 	// bind WHEN_MATCHED merge actions (can contain references to both source and target)
 	for (auto &entry : node.actions) {

--- a/src/planner/binder/statement/bind_merge_into.cpp
+++ b/src/planner/binder/statement/bind_merge_into.cpp
@@ -286,9 +286,7 @@ BoundStatement Binder::BindNode(MergeQueryNode &node) {
 
 	merge_into->bound_constraints = BindConstraints(table);
 
-	// Set return_chunk before binding any actions: the update binding uses it to expand to a full-row update so
-	// RETURNING can report the whole row. It must be set before the WHEN NOT MATCHED (BY SOURCE) actions below are
-	// bound, otherwise those updates only carry their SET columns and RETURNING reports zeroed values for the rest.
+	// Set return_chunk before binding any actions
 	if (!node.returning_list.empty()) {
 		merge_into->return_chunk = true;
 	}

--- a/test/sql/merge/merge_into_returning.test
+++ b/test/sql/merge/merge_into_returning.test
@@ -72,3 +72,25 @@ WHEN MATCHED THEN DELETE
 RETURNING *, merge_action;
 ----
 30	300	DELETE
+
+# NOT MATCHED BY SOURCE UPDATE must return the full (new) row, not zeroed values
+statement ok
+CREATE TABLE arch(item_id int, balance int, is_current boolean);
+
+statement ok
+INSERT INTO arch VALUES (1, 100, true), (2, 200, true), (3, 300, true);
+
+statement ok
+CREATE TABLE live(item_id int);
+
+statement ok
+INSERT INTO live VALUES (1);
+
+query IIII rowsort
+MERGE INTO arch USING live ON arch.item_id = live.item_id
+WHEN NOT MATCHED BY SOURCE AND arch.is_current = true
+THEN UPDATE SET is_current = false
+RETURNING merge_action, *;
+----
+UPDATE	2	200	false
+UPDATE	3	300	false


### PR DESCRIPTION
Close #24666 

A `MERGE INTO` statement with `RETURNING merge_action, *` and a `WHEN NOT MATCHED BY SOURCE THEN UPDATE` clause returns **zeroed / garbage values** for every column not in the `SET` list, instead of the actual row.

The garbage is **uninitialized memory**, so the observed values are nondeterministic, depending on what was left in the buffer.

The table itself was always updated correctly, only `RETURNING` was wrong.

---

Before (1.5.5)

<img width="927" height="436" alt="image" src="https://github.com/user-attachments/assets/f3efdbbc-ac9c-4d12-9d49-064ec94bbd67" />

After (This PR)

<img width="946" height="555" alt="image" src="https://github.com/user-attachments/assets/07a59de3-6494-469e-a7b1-be9340a4f391" />
