### PR TITLE
Handle infinite dates in timestamp comparison optimization

### DIFF
--- a/src/optimizer/rule/timestamp_comparison.cpp
+++ b/src/optimizer/rule/timestamp_comparison.cpp
@@ -53,6 +53,15 @@ static optional_ptr<BoundFunctionExpression> GetTimestampCast(Expression &expr) 
 	return &cast_expr;
 }
 
+static Value DateToTimestampValue(date_t date, dtime_t time) {
+	if (date == date_t::infinity()) {
+		return Value::TIMESTAMP(timestamp_t::infinity());
+	} else if (date == date_t::ninfinity()) {
+		return Value::TIMESTAMP(timestamp_t::ninfinity());
+	}
+	return Value::TIMESTAMP(date, time);
+}
+
 unique_ptr<Expression> TimeStampComparison::Apply(LogicalOperator &op, vector<reference<Expression>> &bindings,
                                                   bool &changes_made, bool is_root) {
 	auto &comparison = bindings[0].get().Cast<BoundFunctionExpression>();
@@ -82,8 +91,16 @@ unique_ptr<Expression> TimeStampComparison::Apply(LogicalOperator &op, vector<re
 		auto no_seconds = dtime_t(0);
 
 		// original date as timestamp with no seconds
-		auto original_val_ts = Value::TIMESTAMP(original_val, no_seconds);
+		auto original_val_ts = DateToTimestampValue(original_val, no_seconds);
 		auto original_val_for_comparison = make_uniq<BoundConstantExpression>(original_val_ts);
+
+		if (!original_val.IsFinite()) {
+			auto column_copy = cast_columnref->Copy();
+			auto eq_expr = BoundComparisonExpression::Create(ExpressionType::COMPARE_EQUAL, std::move(column_copy),
+			                                                 std::move(original_val_for_comparison));
+			new_expr->GetChildrenMutable().push_back(std::move(eq_expr));
+			return std::move(new_expr);
+		}
 
 		// add one day and validate the new date
 		// code is inspired by AddOperator::Operation(date_t left, int32_t right). The function wasn't used directly

--- a/test/optimizer/pushdown/timestamp_to_date_infinity_pushdown.test
+++ b/test/optimizer/pushdown/timestamp_to_date_infinity_pushdown.test
@@ -1,0 +1,29 @@
+# name: test/optimizer/pushdown/timestamp_to_date_infinity_pushdown.test
+# description: Test timestamp to date filter pushdown with infinite date constants
+# group: [pushdown]
+
+statement ok
+create table ts_inf(t timestamp);
+
+statement ok
+insert into ts_inf values (timestamp '-infinity'), (timestamp '2025-01-01'), (timestamp 'infinity'), (NULL);
+
+query I
+select count(*) from ts_inf where cast(t as date) = date 'infinity';
+----
+1
+
+query I
+select count(*) from ts_inf where date 'infinity' = cast(t as date);
+----
+1
+
+query I
+select count(*) from ts_inf where cast(t as date) = date '-infinity';
+----
+1
+
+query I
+select count(*) from ts_inf where date '-infinity' = cast(t as date);
+----
+1


### PR DESCRIPTION
Fixes #24306

The timestamp-to-date equality rewrite converts date constants into timestamp bounds. For DATE infinity and -infinity, the finite date-to-timestamp construction using Timestamp::FromDatetime can overflow, which is correctly detected and results in an exception.

This change rewrites infinite DATE comparisons to direct TIMESTAMP equality, and adds regression coverage for both operand orders.

Tested with:

```bash
  ./build/debug/test/unittest test/optimizer/pushdown/timestamp_to_date_infinity_pushdown.test
```

**Run after the fix**

```bash
memory D CREATE TABLE ts_inf(t TIMESTAMP);
memory D INSERT INTO ts_inf VALUES (TIMESTAMP '-infinity'), (TIMESTAMP '2025-01-01'), (TIMESTAMP 'infinity');
memory D SELECT count(*) FROM ts_inf WHERE CAST(t AS DATE) = DATE 'infinity';
┌──────────────┐
│ count_star() │
│    int64     │
├──────────────┤
│            1 │
└──────────────┘
memory D PRAGMA disable_optimizer;
┌─────────┐
│ Success │
│ boolean │
└─────────┘
  0 rows 
memory D SELECT count(*) FROM ts_inf WHERE CAST(t AS DATE) = DATE 'infinity';
┌──────────────┐
│ count_star() │
│    int64     │
├──────────────┤
│            1 │
└──────────────┘

```