### PR TITLE
Fixup test_not_distinct_index_scan.test to actually be forced to be a Sequence Scan (vs optimized after checkpoint Column Data Scan)

### DIFF
--- a/test/sql/index/art/scan/test_not_distinct_index_scan.test
+++ b/test/sql/index/art/scan/test_not_distinct_index_scan.test
@@ -29,7 +29,7 @@ statement ok
 INSERT INTO tbl VALUES (NULL);
 
 query II
-EXPLAIN ANALYZE SELECT count(*) FROM tbl WHERE i IS NOT DISTINCT FROM NULL;
+EXPLAIN ANALYZE SELECT i FROM tbl WHERE i IS NOT DISTINCT FROM NULL;
 ----
 analyzed_plan	<REGEX>:.*Sequential Scan.*
 


### PR DESCRIPTION
Bumped on various PRs in failures to configurations, this should fix at least some of them.

Issue is that once DB is written do disk and checkpointed, a Sequence Scan is not guaranteed.