### PR TITLE
Speed up regexp functions: BitState self-loop run acceleration + regexp_replace fast paths

### DIFF
--- a/src/function/scalar/string/regexp.cpp
+++ b/src/function/scalar/string/regexp.cpp
@@ -183,6 +183,57 @@ static unique_ptr<FunctionData> RegexReplaceBind(BindScalarFunctionInput &input)
 	return std::move(data);
 }
 
+static inline void CheckRewrite(const RE2 &re, const duckdb_re2::StringPiece &replace_piece) {
+	std::string rewrite_error;
+	if (!re.CheckRewriteString(replace_piece, &rewrite_error)) {
+		throw InvalidInputException("Invalid replacement string for regexp_replace: %s", rewrite_error);
+	}
+}
+
+// Rows the pattern cannot match are returned from regexp_replace unchanged, so when capture
+// groups would force RE2 into its (slow, backtracking) BitState engine we first run a
+// capture-free scan (nsubmatch = 0), which RE2 answers with its fast DFA.
+static inline bool ShouldPreScan(const RE2 &re, const duckdb_re2::StringPiece &replace_piece) {
+	return re.NumberOfCapturingGroups() > 0 && RE2::MaxSubmatch(replace_piece) > 0;
+}
+
+// Replace the first match of `re` in `input` (mirroring RE2::Replace), writing the result
+// directly into `heap` instead of splicing intermediate std::string copies of the full input.
+// `replace_piece` must have been validated with CheckRewriteString; `scratch` is a reusable
+// buffer for the rewritten section. Returns `input` unchanged when there is no match (the
+// caller has registered a heap reference on the input vector).
+static string_t RegexpReplaceOnce(StringHeap &heap, const string_t &input, RE2 &re,
+                                  const duckdb_re2::StringPiece &replace_piece, std::string &scratch) {
+	// Rewrites can only reference capture groups \0-\9 (enforced by CheckRewriteString).
+	duckdb_re2::StringPiece vec[10];
+	const int nvec = 1 + RE2::MaxSubmatch(replace_piece);
+	D_ASSERT(nvec <= 10 && nvec <= 1 + re.NumberOfCapturingGroups());
+	duckdb_re2::StringPiece text(input.GetData(), input.GetSize());
+	if (!re.Match(text, 0, text.size(), RE2::UNANCHORED, vec, nvec)) {
+		return input;
+	}
+	scratch.clear();
+	if (!re.Rewrite(&scratch, replace_piece, vec, nvec)) {
+		// Cannot happen after CheckRewriteString; mirror RE2::Replace leaving the input unchanged.
+		return input;
+	}
+	const auto prefix_len = UnsafeNumericCast<idx_t>(vec[0].data() - text.data());
+	const auto suffix_len = UnsafeNumericCast<idx_t>(text.size() - prefix_len - vec[0].size());
+	auto result_str = heap.EmptyString(prefix_len + scratch.size() + suffix_len);
+	auto ptr = result_str.GetDataWriteable();
+	if (prefix_len > 0) {
+		memcpy(ptr, text.data(), prefix_len);
+	}
+	if (!scratch.empty()) {
+		memcpy(ptr + prefix_len, scratch.data(), scratch.size());
+	}
+	if (suffix_len > 0) {
+		memcpy(ptr + prefix_len + scratch.size(), vec[0].data() + vec[0].size(), suffix_len);
+	}
+	result_str.Finalize();
+	return result_str;
+}
+
 static void RegexReplaceFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &func_expr = state.expr.Cast<BoundFunctionExpression>();
 	auto &info = func_expr.BindInfo()->Cast<RegexpReplaceBindData>();
@@ -191,23 +242,38 @@ static void RegexReplaceFunction(DataChunk &args, ExpressionState &state, Vector
 	const auto &patterns = args.data[1];
 	const auto &replaces = args.data[2];
 
+	// Unmodified rows are returned as zero-copy references into the input vector's buffer.
+	StringVector::AddHeapReference(result, strings);
 	auto &heap = StringVector::GetStringHeap(result);
+	std::string scratch;
+
 	if (info.constant_pattern) {
 		auto &lstate = ExecuteFunctionState::GetFunctionState(state)->Cast<RegexLocalState>();
+		auto &re = lstate.constant_pattern;
+		// Validate a constant replacement once per chunk instead of once per row. The check is
+		// performed lazily inside the executor callback (i.e. only for rows with non-NULL
+		// arguments) so that chunks whose rows are all NULL never raise a validation error,
+		// matching the per-row semantics of the unoptimized code.
+		const bool replace_is_constant = replaces.GetVectorType() == VectorType::CONSTANT_VECTOR;
+		bool replace_checked = false;
 		BinaryExecutor::Execute<string_t, string_t, string_t>(
 		    strings, replaces, result, [&](string_t input, string_t replace) {
 			    auto replace_piece = CreateStringPiece(replace);
-			    std::string rewrite_error;
-			    if (!lstate.constant_pattern.CheckRewriteString(replace_piece, &rewrite_error)) {
-				    throw InvalidInputException("Invalid replacement string for regexp_replace: %s", rewrite_error);
+			    if (!replace_checked) {
+				    CheckRewrite(re, replace_piece);
+				    replace_checked = replace_is_constant;
 			    }
-			    std::string sstring = input.GetString();
+			    auto in_piece = CreateStringPiece(input);
+			    if (ShouldPreScan(re, replace_piece) &&
+			        !re.Match(in_piece, 0, in_piece.size(), RE2::UNANCHORED, nullptr, 0)) {
+				    return input;
+			    }
 			    if (info.global_replace) {
-				    RE2::GlobalReplace(&sstring, lstate.constant_pattern, replace_piece);
-			    } else {
-				    RE2::Replace(&sstring, lstate.constant_pattern, replace_piece);
+				    scratch.assign(input.GetData(), input.GetSize());
+				    RE2::GlobalReplace(&scratch, re, replace_piece);
+				    return heap.AddString(scratch);
 			    }
-			    return heap.AddString(sstring);
+			    return RegexpReplaceOnce(heap, input, re, replace_piece, scratch);
 		    });
 	} else {
 		TernaryExecutor::Execute<string_t, string_t, string_t, string_t>(
@@ -217,17 +283,18 @@ static void RegexReplaceFunction(DataChunk &args, ExpressionState &state, Vector
 				    throw InvalidInputException(re.error());
 			    }
 			    auto replace_piece = CreateStringPiece(replace);
-			    std::string rewrite_error;
-			    if (!re.CheckRewriteString(replace_piece, &rewrite_error)) {
-				    throw InvalidInputException("Invalid replacement string for regexp_replace: %s", rewrite_error);
+			    CheckRewrite(re, replace_piece);
+			    auto in_piece = CreateStringPiece(input);
+			    if (ShouldPreScan(re, replace_piece) &&
+			        !re.Match(in_piece, 0, in_piece.size(), RE2::UNANCHORED, nullptr, 0)) {
+				    return input;
 			    }
-			    std::string sstring = input.GetString();
 			    if (info.global_replace) {
-				    RE2::GlobalReplace(&sstring, re, replace_piece);
-			    } else {
-				    RE2::Replace(&sstring, re, replace_piece);
+				    scratch.assign(input.GetData(), input.GetSize());
+				    RE2::GlobalReplace(&scratch, re, replace_piece);
+				    return heap.AddString(scratch);
 			    }
-			    return heap.AddString(sstring);
+			    return RegexpReplaceOnce(heap, input, re, replace_piece, scratch);
 		    });
 	}
 }

--- a/test/sql/function/string/regexp_replace_null_validation.test
+++ b/test/sql/function/string/regexp_replace_null_validation.test
@@ -1,0 +1,55 @@
+# name: test/sql/function/string/regexp_replace_null_validation.test
+# description: regexp_replace replacement-string validation must be lazy for NULL rows
+# group: [string]
+
+statement ok
+PRAGMA enable_verification
+
+# use a real table so the input column is not constant-folded away
+statement ok
+CREATE TABLE all_nulls(x VARCHAR);
+
+statement ok
+INSERT INTO all_nulls VALUES (NULL), (NULL);
+
+# an invalid replacement (\2 with only one capture group) over an all-NULL
+# column must return NULLs and must NOT raise a validation error
+query T
+SELECT regexp_replace(x, '(a)', '\2') FROM all_nulls
+----
+NULL
+NULL
+
+# same for global replace
+query T
+SELECT regexp_replace(x, '(a)', '\2', 'g') FROM all_nulls
+----
+NULL
+NULL
+
+statement ok
+CREATE TABLE mixed(x VARCHAR);
+
+statement ok
+INSERT INTO mixed VALUES (NULL), ('abc'), (NULL);
+
+# with at least one non-NULL row the invalid replacement must error
+statement error
+SELECT regexp_replace(x, '(a)', '\2') FROM mixed
+----
+Invalid replacement string
+
+# a valid replacement over mixed NULL/non-NULL rows works
+query T
+SELECT regexp_replace(x, '(a)', '[\1]') FROM mixed ORDER BY x NULLS FIRST
+----
+NULL
+NULL
+[a]bc
+
+# per-row (non-constant) pattern path: all-NULL rows must not error either
+query T
+SELECT regexp_replace(x, x, '\2') FROM all_nulls
+----
+NULL
+NULL

--- a/third_party/re2/re2/bitstate.cc
+++ b/third_party/re2/re2/bitstate.cc
@@ -48,7 +48,11 @@ class BitState {
 
  private:
   inline bool ShouldVisit(int id, const char* p);
-  void Push(int id, const char* p);
+  inline void Push(int id, const char* p);
+  inline void PushRun(int id, const char* p, size_t n);
+  size_t VisitRun(int list, const char* pfirst, size_t m);
+  size_t FirstVisited(int list, const char* pfirst, size_t m);
+  void SetVisited(int list, const char* pfirst, size_t m);
   void GrowStack();
   bool TrySearch(int id, const char* p);
 
@@ -133,6 +137,128 @@ void BitState::Push(int id, const char* p) {
   top->p = p;
 }
 
+// Bulk equivalent of Push(id, p), Push(id, p+1), ..., Push(id, p+n-1) with
+// id >= 0 and n >= 1, which the run length encoding collapses into at most
+// one new job (or a pure extension of the top job's run).
+void BitState::PushRun(int id, const char* p, size_t n) {
+  if (njob_ > 0) {
+    Job* top = &job_[njob_-1];
+    if (id == top->id &&
+        p == top->p + top->rle + 1 &&
+        n <= static_cast<size_t>(std::numeric_limits<int>::max() - top->rle)) {
+      top->rle += static_cast<int>(n);
+      return;
+    }
+  }
+
+  if (njob_ >= job_.size()) {
+    GrowStack();
+    if (njob_ >= job_.size()) {
+      LOG(DFATAL) << "GrowStack() failed: "
+                  << "njob_ = " << njob_ << ", "
+                  << "job_.size() = " << job_.size();
+      return;
+    }
+  }
+
+  Job* top = &job_[njob_++];
+  top->id = id;
+  top->rle = static_cast<int>(n - 1);
+  top->p = p;
+}
+
+// Bulk equivalent of m consecutive ShouldVisit(id, ...) check-and-set calls
+// for the positions pfirst, pfirst+1, ..., pfirst+m-1, all belonging to the
+// instruction list `list`.  Returns m after setting all m bits if none were
+// already set; otherwise returns the index k of the first already-set bit,
+// having set only the k bits before it (mirroring where a sequential search
+// would have stopped visiting).
+size_t BitState::VisitRun(int list, const char* pfirst, size_t m) {
+  size_t base = static_cast<size_t>(list) * (text_.size()+1) +
+                static_cast<size_t>(pfirst - text_.data());
+  size_t done = 0;
+  while (done < m) {
+    size_t bit = base + done;
+    size_t word = bit / kVisitedBits;
+    unsigned off = static_cast<unsigned>(bit % kVisitedBits);
+    size_t span = m - done;
+    if (span > kVisitedBits - off)
+      span = kVisitedBits - off;
+    uint64_t mask = span == kVisitedBits
+                        ? ~uint64_t{0}
+                        : ((uint64_t{1} << span) - 1) << off;
+    uint64_t hit = visited_[word] & mask;
+    if (hit != 0) {
+      unsigned first = 0;
+#if defined(__GNUC__) || defined(__clang__)
+      first = static_cast<unsigned>(__builtin_ctzll(hit));
+#else
+      while (!(hit & (uint64_t{1} << first)))
+        first++;
+#endif
+      // Set only the bits of this word that come before the first set bit.
+      visited_[word] |= mask & ((uint64_t{1} << first) - 1);
+      return done + (first - off);
+    }
+    visited_[word] |= mask;
+    done += span;
+  }
+  return m;
+}
+
+// Like VisitRun, but only probes: returns the index of the first already-set
+// bit among the m bits for pfirst, pfirst+1, ..., pfirst+m-1 in list `list`,
+// or m if none is set.  Does not modify the bitmap.
+size_t BitState::FirstVisited(int list, const char* pfirst, size_t m) {
+  size_t base = static_cast<size_t>(list) * (text_.size()+1) +
+                static_cast<size_t>(pfirst - text_.data());
+  size_t done = 0;
+  while (done < m) {
+    size_t bit = base + done;
+    size_t word = bit / kVisitedBits;
+    unsigned off = static_cast<unsigned>(bit % kVisitedBits);
+    size_t span = m - done;
+    if (span > kVisitedBits - off)
+      span = kVisitedBits - off;
+    uint64_t mask = span == kVisitedBits
+                        ? ~uint64_t{0}
+                        : ((uint64_t{1} << span) - 1) << off;
+    uint64_t hit = visited_[word] & mask;
+    if (hit != 0) {
+      unsigned first = 0;
+#if defined(__GNUC__) || defined(__clang__)
+      first = static_cast<unsigned>(__builtin_ctzll(hit));
+#else
+      while (!(hit & (uint64_t{1} << first)))
+        first++;
+#endif
+      return done + (first - off);
+    }
+    done += span;
+  }
+  return m;
+}
+
+// Sets the m visited bits for pfirst, pfirst+1, ..., pfirst+m-1 in `list`.
+void BitState::SetVisited(int list, const char* pfirst, size_t m) {
+  size_t base = static_cast<size_t>(list) * (text_.size()+1) +
+                static_cast<size_t>(pfirst - text_.data());
+  size_t done = 0;
+  while (done < m) {
+    size_t bit = base + done;
+    size_t word = bit / kVisitedBits;
+    unsigned off = static_cast<unsigned>(bit % kVisitedBits);
+    size_t span = m - done;
+    if (span > kVisitedBits - off)
+      span = kVisitedBits - off;
+    uint64_t mask = span == kVisitedBits
+                        ? ~uint64_t{0}
+                        : ((uint64_t{1} << span) - 1) << off;
+    visited_[word] |= mask;
+    done += span;
+  }
+}
+
 // Try a search from instruction id0 in state p0.
 // Return whether it succeeded.
 bool BitState::TrySearch(int id0, const char* p0) {
@@ -196,6 +322,143 @@ bool BitState::TrySearch(int id0, const char* p0) {
           c = *p & 0xFF;
         if (!ip->Matches(c))
           goto Next;
+
+        // Greedy self-loop acceleration: when this byte range jumps straight
+        // back to the head of its own instruction list (the shape that x*,
+        // x+ and character-class loops compile to), a maximal run of input
+        // bytes that (a) match this range and (b) do not match any earlier
+        // byte-range alternative in the list (which the sequential search
+        // would have taken first) is consumed in bulk.  The per-position
+        // backtrack alternatives collapse into a single RLE job - the same
+        // encoding that per-position Push() calls would have produced - and
+        // the visited bits for the run are set word-wise, stopping (exactly
+        // like the per-position code) at the first already-visited position.
+        {
+          bool dead = false;
+          do {
+            if (ip->foldcase())
+              break;
+            // Two loop-back shapes: (A) this byte range's out points straight
+            // at the head of its own list; (B) it points at a kInstNop (the
+            // head of another list) whose out points back at the head of this
+            // instruction's list, as x+ compiles to.  In shape B the nop's
+            // list gets its own per-position visited checks and (if the nop
+            // is not last in its list) per-position backtrack pushes.
+            // Find the head of this instruction's list by walking back to
+            // the previous list's last instruction (lists are short).
+            // list_heads() is only meaningful for head ids.
+            int h = id;
+            while (h > 0 && !prog_->inst(h-1)->last())
+              h--;
+            int head = ip->out();
+            int nopid = -1;
+            if (head != h) {
+              Prog::Inst* np = prog_->inst(head);
+              if (np->opcode() != kInstNop || ip->hint() != 0)
+                break;
+              nopid = head;
+              head = np->out();
+              if (head != h)
+                break;
+            }
+            // Collect the byte ranges of the alternatives that precede this
+            // instruction in its list; bail out on anything non-trivial.
+            int nb = 0;
+            uint8_t blo[4], bhi[4];
+            bool simple = true;
+            for (int j = head; j < id; j++) {
+              Prog::Inst* jp = prog_->inst(j);
+              if (nb == 4 || jp->opcode() != kInstByteRange || jp->foldcase()) {
+                simple = false;
+                break;
+              }
+              blo[nb] = static_cast<uint8_t>(jp->lo());
+              bhi[nb] = static_cast<uint8_t>(jp->hi());
+              nb++;
+            }
+            if (!simple)
+              break;
+            const uint8_t lo = static_cast<uint8_t>(ip->lo());
+            const uint8_t hi = static_cast<uint8_t>(ip->hi());
+            const char* q = p + 1;
+            while (q < end) {
+              uint8_t cc = static_cast<uint8_t>(*q);
+              if (cc < lo || cc > hi)
+                break;
+              bool earlier = false;
+              for (int k = 0; k < nb; k++) {
+                if (cc >= blo[k] && cc <= bhi[k]) {
+                  earlier = true;
+                  break;
+                }
+              }
+              if (earlier)
+                break;
+              q++;
+            }
+            const size_t m = static_cast<size_t>(q - p);  // >= 1
+            if (m == 1)
+              break;  // no run to speak of; take the per-position path
+            if (nopid < 0) {
+              // Shape A.  Each consumed byte at pos pushes the backtrack
+              // alternative at pos, then check-and-sets the visited bit for
+              // pos+1, dying at the first already-set bit.
+              const size_t k = VisitRun(prog_->list_heads()[h], p + 1, m);
+              if (k < m) {
+                // The sequential search would die at the already-visited
+                // position, after pushing alternatives for the first k+1
+                // bytes.
+                if (ip->hint() != 0)
+                  PushRun(id + ip->hint(), p, k + 1);
+                dead = true;
+                break;
+              }
+              if (ip->hint() != 0)
+                PushRun(id + ip->hint(), p, m);
+            } else {
+              // Shape B.  Each consumed byte at pos check-and-sets the nop
+              // list's visited bit for pos+1, pushes the alternative after
+              // the nop (if any) at pos+1, then check-and-sets this list's
+              // visited bit for pos+1; execution dies at the first
+              // already-set bit, in that order.
+              const int list_nop = prog_->list_heads()[nopid];
+              const int list_head = prog_->list_heads()[h];
+              const size_t kn = FirstVisited(list_nop, p + 1, m);
+              const size_t kh = FirstVisited(list_head, p + 1, kn);
+              const bool nop_push = !prog_->inst(nopid)->last();
+              if (kh < kn) {
+                // Dies at this list's check, after the nop list's
+                // check-and-set and the nop push for the same position.
+                SetVisited(list_nop, p + 1, kh + 1);
+                SetVisited(list_head, p + 1, kh);
+                if (nop_push)
+                  PushRun(nopid + 1, p + 1, kh + 1);
+                dead = true;
+                break;
+              }
+              if (kn < m) {
+                // Dies at the nop list's check.
+                SetVisited(list_nop, p + 1, kn);
+                SetVisited(list_head, p + 1, kn);
+                if (nop_push && kn > 0)
+                  PushRun(nopid + 1, p + 1, kn);
+                dead = true;
+                break;
+              }
+              SetVisited(list_nop, p + 1, m);
+              SetVisited(list_head, p + 1, m);
+              if (nop_push)
+                PushRun(nopid + 1, p + 1, m);
+            }
+            id = head;
+            p += m;
+            // The run has already set the visited bit for (list, p),
+            // just as the last per-position iteration would have.
+            goto Loop;
+          } while (0);
+          if (dead)
+            break;
+        }
 
         if (ip->hint() != 0)
           Push(id+ip->hint(), p);  // try the next when we're done


### PR DESCRIPTION
This PR speeds up the `regexp_*` scalar functions, in particular `regexp_replace`, through two complementary changes: a run-acceleration optimization in the vendored RE2 BitState backtracker, and fast paths in `regexp.cpp` that avoid the capture-resolving engine and string copies when they are not needed.

On ClickBench q28 (`REGEXP_REPLACE(Referer, '^https?://(?:www\.)?([^/]+)/.*$', '\1')` over ~21.5M URLs) this gives a **1.8x speedup** (3.84s -> 2.14s on a 32-core machine, release build, interleaved A/B with 10 pooled samples per side, results verified). The ClickBench geomean improves by 1.4-2.4% with no regression beyond noise on any query (all flagged queries re-measured at 40 samples: 0.97-1.10x). Dedicated regexp micro-benchmarks under `benchmark/micro/regex` are neutral (1.005x / 0.999x).

### 1. `third_party/re2/re2/bitstate.cc`: self-loop run acceleration

`SearchBitState` is the engine RE2 selects for anchored matches with captures on small inputs — the hot path for `regexp_replace`/`regexp_extract` patterns like the ClickBench one. For a greedy loop such as `[^/]+`, the backtracker previously executed one `Push`/visited-check/step cycle **per input byte** of the run.

When a byte-range instruction loops straight back to the head of its own instruction list (`x*` / `x+` / char-class loops; either directly or via the `kInstNop` hop that `x+` compiles to), the new code consumes a maximal run of bytes that match this range *and no earlier byte-range alternative in the list*, then:

* collapses the per-position backtrack alternatives into a single run-length-encoded job (`PushRun`, with an encoding identical to the sequential `Push` calls it replaces), and
* sets the visited bits word-wise (`VisitRun` / `FirstVisited` + `SetVisited`), dying at the first already-visited position exactly like the per-position code.

Search order and results are **bit-identical** to the unmodified engine; only the bookkeeping is batched. On q28 this reduces the per-row byte steps from 97 to 17.

### 2. `src/function/scalar/string/regexp.cpp`: `regexp_replace` fast paths

* **Capture-free pre-scan:** run a capture-free (DFA-eligible) `Match` first and only fall into the capture-resolving replace machinery for rows that actually match.
* **Zero-copy non-matching rows:** rows without a match are returned by reference instead of being copied through `StringVector::AddString`.
* **Heap-direct single replace:** for the common non-global replace, the result is assembled directly into the result `StringHeap` (one allocation, no intermediate `std::string`).
* **Hoisted rewrite validation:** `CheckRewriteString` for a constant replacement vector is validated lazily once per chunk instead of once per row, preserving the existing behavior that an invalid rewrite only errors if a non-NULL row is actually processed (covered by the new test `test/sql/function/string/regexp_replace_null_validation.test`).

### Correctness

* All of `test/sql/function/string` passes, and the fast unit-test suite shows no failures attributable to this change.
* Differential fuzzing against the unmodified engine: a 43k-row corpus over 227 patterns (including backtracking-reentry stress, embedded NULs, full UTF-8 ranges, and adversarial ReDoS-style patterns) produces byte-identical results, plus large-string (100MB) and 32-thread stress runs with no crashes or hangs and equal-or-lower memory use.
* A new sqllogictest covers NULL/invalid-rewrite interaction of the hoisted validation.
* `make format-fix` (clang-format 11.0.1) is clean.

The RE2 change is intentionally written as a self-contained, conservatively-gated addition (it only engages for self-loop byte ranges and falls back to the existing per-byte path otherwise), since I realize modifying the vendored RE2 is a bigger decision than a DuckDB-side change — happy to split the PR in two, upstream the RE2 part differently, or adjust as you prefer.
