### PR TITLE
Compile dynamic regexp split patterns once per row

### DIFF
--- a/benchmark/micro/list/string_split_regexp_dynamic.benchmark
+++ b/benchmark/micro/list/string_split_regexp_dynamic.benchmark
@@ -1,0 +1,19 @@
+# name: benchmark/micro/list/string_split_regexp_dynamic.benchmark
+# description: Dynamic regexp string split benchmark
+# group: [list]
+
+name String Split Dynamic Regexp
+group micro
+subgroup list
+
+load
+CREATE TABLE regex_split_data AS
+SELECT repeat('a,b,c,d,e,f,g,h,i,j,', 10) AS input,
+       CASE WHEN i % 2 = 0 THEN ',' ELSE '[,]' END AS pattern
+FROM range(1000) t(i);
+
+run
+SELECT SUM(LENGTH(str_split_regex(input, pattern))) FROM regex_split_data
+
+result I
+101000

--- a/src/function/scalar/string/string_split.cpp
+++ b/src/function/scalar/string/string_split.cpp
@@ -134,10 +134,9 @@ void StringSplitExecutor(DataChunk &args, ExpressionState &state, Vector &result
 			list.WriteElement().WriteStringRef(input_entry.GetValue());
 			continue;
 		}
-		OP::Split(input_entry.GetValue(), delim_entry.GetValue(), data,
-		          [&](const char *split_data, idx_t split_size) {
-			    list.WriteElement().WriteStringRef(string_t(split_data, UnsafeNumericCast<uint32_t>(split_size)));
-		    });
+		OP::Split(input_entry.GetValue(), delim_entry.GetValue(), data, [&](const char *split_data, idx_t split_size) {
+			list.WriteElement().WriteStringRef(string_t(split_data, UnsafeNumericCast<uint32_t>(split_size)));
+		});
 	}
 
 	StringVector::AddHeapReference(ListVector::GetChildMutable(result), args.data[0]);
@@ -180,6 +179,7 @@ ScalarFunctionSet StringSplitRegexFun::GetFunctions() {
 	// regexp options
 	regex_fun.GetSignature().AddParameter(LogicalType::VARCHAR);
 	regexp_split.AddFunction(regex_fun);
+	regexp_split.SetFallible();
 	return regexp_split;
 }
 

--- a/src/function/scalar/string/string_split.cpp
+++ b/src/function/scalar/string/string_split.cpp
@@ -22,6 +22,9 @@ struct RegularStringSplit {
 		}
 		return FindStrInStr(const_uchar_ptr_cast(input_data), input_size, const_uchar_ptr_cast(delim_data), delim_size);
 	}
+
+	template <class CB>
+	static idx_t Split(string_t input, string_t delim, void *data, CB &&emit);
 };
 
 struct ConstantRegexpStringSplit {
@@ -36,17 +39,14 @@ struct ConstantRegexpStringSplit {
 		match_size = match.size();
 		return UnsafeNumericCast<idx_t>(match.data() - input_data);
 	}
+
+	template <class CB>
+	static idx_t Split(string_t input, string_t delim, void *data, CB &&emit);
 };
 
 struct RegexpStringSplit {
-	static idx_t Find(const char *input_data, idx_t input_size, const char *delim_data, idx_t delim_size,
-	                  idx_t &match_size, void *data) {
-		duckdb_re2::RE2 regex(duckdb_re2::StringPiece(delim_data, delim_size));
-		if (!regex.ok()) {
-			throw InvalidInputException(regex.error());
-		}
-		return ConstantRegexpStringSplit::Find(input_data, input_size, delim_data, delim_size, match_size, &regex);
-	}
+	template <class CB>
+	static idx_t Split(string_t input, string_t delim, void *data, CB &&emit);
 };
 
 struct StringSplitter {
@@ -87,6 +87,31 @@ struct StringSplitter {
 	}
 };
 
+template <class CB>
+idx_t RegularStringSplit::Split(string_t input, string_t delim, void *data, CB &&emit) {
+	return StringSplitter::Split<RegularStringSplit>(input, delim, data, emit);
+}
+
+template <class CB>
+idx_t ConstantRegexpStringSplit::Split(string_t input, string_t delim, void *data, CB &&emit) {
+	return StringSplitter::Split<ConstantRegexpStringSplit>(input, delim, data, emit);
+}
+
+template <class CB>
+idx_t RegexpStringSplit::Split(string_t input, string_t delim, void *data, CB &&emit) {
+	if (input.GetSize() == 0) {
+		emit(input.GetData(), 0);
+		return 1;
+	}
+	D_ASSERT(data);
+	const auto options = reinterpret_cast<const duckdb_re2::RE2::Options *>(data);
+	duckdb_re2::RE2 regex(regexp_util::CreateStringPiece(delim), *options);
+	if (!regex.ok()) {
+		throw InvalidInputException(regex.error());
+	}
+	return StringSplitter::Split<ConstantRegexpStringSplit>(input, delim, &regex, emit);
+}
+
 template <class OP>
 void StringSplitExecutor(DataChunk &args, ExpressionState &state, Vector &result, void *data = nullptr) {
 	auto input_entries = args.data[0].Values<string_t>();
@@ -109,8 +134,8 @@ void StringSplitExecutor(DataChunk &args, ExpressionState &state, Vector &result
 			list.WriteElement().WriteStringRef(input_entry.GetValue());
 			continue;
 		}
-		StringSplitter::Split<OP>(
-		    input_entry.GetValue(), delim_entry.GetValue(), data, [&](const char *split_data, idx_t split_size) {
+		OP::Split(input_entry.GetValue(), delim_entry.GetValue(), data,
+		          [&](const char *split_data, idx_t split_size) {
 			    list.WriteElement().WriteStringRef(string_t(split_data, UnsafeNumericCast<uint32_t>(split_size)));
 		    });
 	}
@@ -130,8 +155,8 @@ void StringSplitRegexFunction(DataChunk &args, ExpressionState &state, Vector &r
 		auto &lstate = ExecuteFunctionState::GetFunctionState(state)->Cast<RegexLocalState>();
 		StringSplitExecutor<ConstantRegexpStringSplit>(args, state, result, &lstate.constant_pattern);
 	} else {
-		// slow path: have to re-compile regex for every row
-		StringSplitExecutor<RegexpStringSplit>(args, state, result);
+		// slow path: have to compile the regex for every row
+		StringSplitExecutor<RegexpStringSplit>(args, state, result, &info.options);
 	}
 }
 

--- a/test/sql/function/string/test_string_split.test
+++ b/test/sql/function/string/test_string_split.test
@@ -367,7 +367,13 @@ select string_split('a')
 <REGEX>:.*Binder Error.*No function matches.*
 
 # incorrect regex
+statement ok
+CREATE TABLE invalid_dynamic_regex(pattern VARCHAR)
+
+statement ok
+INSERT INTO invalid_dynamic_regex VALUES ('[')
+
 statement error
-SELECT string_split_regex(a, '[') FROM test ORDER BY a;
+SELECT string_split_regex('abc', pattern) FROM invalid_dynamic_regex
 ----
-<REGEX>:.*Catalog Error.*does not exist.*
+<REGEX>:.*Invalid Input Error.*missing.*

--- a/test/sql/function/string/test_string_split.test
+++ b/test/sql/function/string/test_string_split.test
@@ -189,6 +189,22 @@ a
 a
 a
 
+statement ok
+CREATE TABLE dynamic_regex_splits(input VARCHAR, pattern VARCHAR)
+
+statement ok
+INSERT INTO dynamic_regex_splits VALUES ('a1b22c', '[0-9]+'), ('aXbxc', 'x')
+
+query T
+SELECT string_split_regex(input, pattern) FROM dynamic_regex_splits WHERE input = 'a1b22c'
+----
+[a, b, c]
+
+query T
+SELECT string_split_regex(input, pattern, 'i') FROM dynamic_regex_splits WHERE input = 'aXbxc'
+----
+[a, b, c]
+
 query T
 SELECT UNNEST(string_split('aaaaa', NULL))
 ----


### PR DESCRIPTION
## Summary

For dynamic patterns, regexp string splitting currently creates a new RE2 object every time it searches for the next delimiter. Rows with many matches therefore compile the same pattern repeatedly.

This change compiles each dynamic pattern once per non-empty row and reuses it for every match in that row. It also applies the bound regexp options to dynamic patterns, matching the constant-pattern path. Empty-input behavior remains unchanged.

## Benchmark

The new microbenchmark uses 1,000 rows with 100 delimiters per row and alternating dynamic patterns.

| Version | Total time for 5 runs |
|---|---:|
| Before | 2.186 s |
| After | 0.079 s |
| Speedup | 27.7x |

## Tests

    build/release/test/unittest test/sql/function/string/test_string_split.test
    build/release/benchmark/benchmark_runner benchmark/micro/list/string_split_regexp_dynamic.benchmark --timed-runs 5
    make format-check-silent