### PR TITLE
Fix correlation detection for nested dependent joins

### DIFF
--- a/src/planner/subquery/flatten_dependent_join.cpp
+++ b/src/planner/subquery/flatten_dependent_join.cpp
@@ -95,6 +95,15 @@ FlattenDependentJoins::SubtreeAccess FlattenDependentJoins::GetSubtreeAccess(Log
 		return entry->second;
 	}
 	SubtreeAccess result;
+	if (op.type == LogicalOperatorType::LOGICAL_DEPENDENT_JOIN) {
+		auto &dependent_join = op.Cast<LogicalDependentJoin>();
+		for (auto &column : dependent_join.correlated_columns) {
+			if (correlated_aliases.find(column.binding) != correlated_aliases.end()) {
+				result.correlated = true;
+				break;
+			}
+		}
+	}
 	if (op.type == LogicalOperatorType::LOGICAL_CTE_REF) {
 		auto &cteref = op.Cast<LogicalCTERef>();
 		if (cteref.correlated_columns > 0) {

--- a/test/issues/general/test_23860.test
+++ b/test/issues/general/test_23860.test
@@ -1,0 +1,114 @@
+# name: test/issues/general/test_23860.test
+# description: Issue 23860 - Failed binding for correlations hidden in nested dependent joins
+# group: [general]
+
+statement ok
+CREATE TABLE integers(i INTEGER);
+
+statement ok
+INSERT INTO integers VALUES (0), (1), (1), (NULL);
+
+# Direct correlation provides the expected-result baseline.
+query II
+SELECT ref_0.i,
+       (SELECT 1 WHERE EXISTS (SELECT 1 WHERE NULL::INTEGER | ref_0.i)) AS result
+FROM integers ref_0
+ORDER BY ref_0.i NULLS LAST;
+----
+0	NULL
+1	NULL
+1	NULL
+NULL	NULL
+
+# A nested scalar subquery hides the correlation in dependent-join metadata.
+statement ok
+SET debug_verify_column_bindings = true;
+
+query II
+SELECT ref_0.i,
+       (SELECT 1 WHERE EXISTS (SELECT 1 WHERE NULL::INTEGER | (SELECT ref_0.i))) AS result
+FROM integers ref_0
+ORDER BY ref_0.i NULLS LAST;
+----
+0	NULL
+1	NULL
+1	NULL
+NULL	NULL
+
+# The same plan must bind without rewriting delim joins to CTEs.
+statement ok
+SET delim_join_as_cte = false;
+
+query II
+SELECT ref_0.i,
+       (SELECT 1 WHERE EXISTS (SELECT 1 WHERE NULL::INTEGER | (SELECT ref_0.i))) AS result
+FROM integers ref_0
+ORDER BY ref_0.i NULLS LAST;
+----
+0	NULL
+1	NULL
+1	NULL
+NULL	NULL
+
+# The decorrelator must also work without optimizer assistance.
+statement ok
+PRAGMA disable_optimizer;
+
+query II
+SELECT ref_0.i,
+       (SELECT 1 WHERE EXISTS (SELECT 1 WHERE NULL::INTEGER | (SELECT ref_0.i))) AS result
+FROM integers ref_0
+ORDER BY ref_0.i NULLS LAST;
+----
+0	NULL
+1	NULL
+1	NULL
+NULL	NULL
+
+statement ok
+PRAGMA enable_optimizer;
+
+statement ok
+SET delim_join_as_cte = true;
+
+# Preserve the original LATERAL, UNION, and UNION ALL structure.
+query II
+SELECT ref_0.i,
+       (SELECT 1
+        WHERE EXISTS (
+            SELECT 1
+            WHERE NULL::INTEGER | (
+                ((SELECT NULL::INTEGER)
+                 UNION
+                 (SELECT NULL::INTEGER
+                  FROM LATERAL (SELECT ref_0.i AS c2) subq))
+                UNION ALL
+                (SELECT NULL::INTEGER WHERE false)
+            )
+        )) AS result
+FROM integers ref_0
+ORDER BY ref_0.i NULLS LAST;
+----
+0	NULL
+1	NULL
+1	NULL
+NULL	NULL
+
+# EXISTS creates a MARK dependent join whose hidden correlation also needs the domain.
+query II
+SELECT ref_0.i,
+       (SELECT 1
+        WHERE EXISTS (
+            SELECT 1
+            WHERE NULL::INTEGER | CAST(EXISTS (SELECT ref_0.i) AS INTEGER)
+        )) AS result
+FROM integers ref_0
+ORDER BY ref_0.i NULLS LAST;
+----
+0	NULL
+1	NULL
+1	NULL
+NULL	NULL
+
+statement ok
+SET debug_verify_column_bindings = false;


### PR DESCRIPTION
Fixes #23860.
Fixes https://github.com/duckdblabs/duckdb-internal/issues/10058.

The reported query fails during planning because a nested dependent join references an outer column, but that correlation is no longer visible as a bound column expression. It only exists in the nested `LogicalDependentJoin::correlated_columns` metadata.

`FlattenDependentJoins::GetSubtreeAccess` uses correlation information to decide whether a subtree must be evaluated with the active outer domain. It previously inspected expressions and correlated CTE metadata, but not dependent-join metadata. As a result, the nested join was classified as independent, its left-hand side did not receive the outer domain, and the finalized join referenced a column binding that was unavailable from that side.

I now inspect `LogicalDependentJoin::correlated_columns` when determining subtree access. A subtree is marked as correlated only when this metadata references one of the current flattener’s active aliases, so unrelated nested correlations remain independent.

I added regression coverage for the reduced scalar and MARK join cases, as well as the original combination of `LATERAL`, `UNION`, and `UNION ALL`. The tests also cover NULLs, duplicate outer values, optimizer-disabled planning, both `delim_join_as_cte` settings, and explicit column-binding verification.