### PR TITLE
Reuse unchanged persistent segments during checkpoint

### DIFF
--- a/src/include/duckdb/storage/table/column_checkpoint_state.hpp
+++ b/src/include/duckdb/storage/table/column_checkpoint_state.hpp
@@ -45,6 +45,8 @@ public:
 	virtual shared_ptr<ColumnData> GetFinalResult();
 
 	virtual unique_ptr<BaseStatistics> GetStatistics();
+	//! Incorporate a persistent Segment and its metadata into the checkpoint result
+	void AppendReferencedSegment(shared_ptr<ColumnSegment> segment, idx_t row_start);
 
 	virtual void FlushSegmentInternal(unique_ptr<ColumnSegment> segment, idx_t segment_size);
 	virtual void FlushSegment(unique_ptr<ColumnSegment> segment, BufferHandle handle, idx_t segment_size);

--- a/src/include/duckdb/storage/table/column_data_checkpointer.hpp
+++ b/src/include/duckdb/storage/table/column_data_checkpointer.hpp
@@ -68,14 +68,29 @@ public:
 	void FinalizeCheckpoint();
 
 private:
-	void ScanSegments(const std::function<void(Vector &)> &callback);
-	vector<CheckpointAnalyzeResult> DetectBestCompressionMethod();
+	struct SegmentReusePlan;
+
+	void ScanSegments(const ColumnData &column_data, const std::function<void(Vector &)> &callback);
+	void ScanSegment(const ColumnData &column_data, SegmentNode<ColumnSegment> &segment,
+	                 const std::function<void(Vector &)> &callback);
+	vector<CompressionType> PrepareCompressionMethods();
+	vector<unique_ptr<AnalyzeState>> InitAnalyze(idx_t checkpoint_state_idx);
+	void AnalyzeVector(idx_t checkpoint_state_idx, vector<unique_ptr<AnalyzeState>> &states, Vector &scan_vector);
+	CheckpointAnalyzeResult FinalizeAnalyze(idx_t checkpoint_state_idx, vector<unique_ptr<AnalyzeState>> states,
+	                                        CompressionType forced_method);
+	unique_ptr<SegmentReusePlan> TryBuildSegmentReusePlan(const vector<CompressionType> &forced_methods);
+	vector<CheckpointAnalyzeResult> AnalyzeFullColumn(const vector<CompressionType> &forced_methods);
+	void AnalyzeRewriteRanges(SegmentReusePlan &plan, const vector<CompressionType> &forced_methods);
+	bool TryWriteReusedSegments(const vector<CompressionType> &forced_methods);
 	void WriteToDisk();
+	void WriteFullColumn(vector<CheckpointAnalyzeResult> analyze_result);
+	void WriteRewriteRanges(SegmentReusePlan &plan);
+	void WriteValidity(CheckpointAnalyzeResult &analyze_result);
 	void WritePersistentSegments(ColumnCheckpointState &state);
-	bool HasChanges(ColumnData &col_data);
-	void InitAnalyze();
-	void DropSegments();
-	bool ValidityCoveredByBasedata(vector<CheckpointAnalyzeResult> &result);
+	void PreserveUnchangedValidity();
+	void MarkAllSourceBlocksModified();
+	void MarkRewrittenSourceBlocksModified(const SegmentReusePlan &plan);
+	bool ValidityCoveredByBasedata(const vector<CheckpointAnalyzeResult> &result);
 
 private:
 	vector<reference<ColumnCheckpointState>> &checkpoint_states;
@@ -87,8 +102,6 @@ private:
 	bool has_changes = false;
 	//! For every column data that is being checkpointed, the applicable functions
 	vector<vector<optional_ptr<const CompressionFunction>>> compression_functions;
-	//! For every column data that is being checkpointed, the analyze state of functions being tried
-	vector<vector<unique_ptr<AnalyzeState>>> analyze_states;
 };
 
 } // namespace duckdb

--- a/src/storage/table/column_checkpoint_state.cpp
+++ b/src/storage/table/column_checkpoint_state.cpp
@@ -7,6 +7,17 @@
 
 namespace duckdb {
 
+struct PersistentSegmentBlockMarker : public BlockIdVisitor {
+	explicit PersistentSegmentBlockMarker(BlockManager &manager) : manager(manager) {
+	}
+
+	void Visit(block_id_t block_id) override {
+		manager.MarkBlockAsCheckpointed(block_id);
+	}
+
+	BlockManager &manager;
+};
+
 ColumnCheckpointState::ColumnCheckpointState(const RowGroup &row_group, ColumnData &original_column,
                                              PartialBlockManager &partial_block_manager)
     : row_group(row_group), original_column(original_column), partial_block_manager(partial_block_manager),
@@ -19,6 +30,22 @@ ColumnCheckpointState::~ColumnCheckpointState() {
 unique_ptr<BaseStatistics> ColumnCheckpointState::GetStatistics() {
 	D_ASSERT(global_stats);
 	return std::move(global_stats);
+}
+
+void ColumnCheckpointState::AppendReferencedSegment(shared_ptr<ColumnSegment> segment, idx_t row_start) {
+	D_ASSERT(segment);
+	if (segment->GetSegmentType() != ColumnSegmentType::PERSISTENT) {
+		throw InternalException("Cannot reference a transient segment from a checkpoint");
+	}
+
+	auto &result = GetResultColumn();
+	auto &result_tree = result.GetSegmentTree();
+	auto result_lock = result_tree.Lock();
+	PersistentSegmentBlockMarker marker(partial_block_manager.GetBlockManager());
+	segment->VisitBlockIds(marker);
+	global_stats->Merge(segment->GetStats());
+	data_pointers.push_back(segment->GetDataPointer(row_start));
+	result_tree.AppendSegment(result_lock, std::move(segment), row_start);
 }
 
 shared_ptr<ColumnData> ColumnCheckpointState::CreateEmptyColumnData() {

--- a/src/storage/table/column_data_checkpointer.cpp
+++ b/src/storage/table/column_data_checkpointer.cpp
@@ -48,6 +48,119 @@ StorageManager &ColumnDataCheckpointData::GetStorageManager() {
 
 //! ColumnDataCheckpointer
 
+static bool CanReuseBaseSegment(ColumnSegment &segment) {
+	auto &function = segment.GetCompressionFunction();
+	return segment.GetSegmentType() == ColumnSegmentType::PERSISTENT &&
+	       function.validity == CompressionValidity::REQUIRES_VALIDITY;
+}
+
+struct ColumnDataCheckpointer::SegmentReusePlan {
+	//! Minimum unchanged tuple ratio; higher values favor full rewrites
+	static constexpr double MINIMUM_REUSED_TUPLE_RATIO = 0.125;
+
+	//! Maximum number of independent analyze/compression pipelines allowed in a local rewrite
+	static constexpr idx_t MAX_LOCAL_REWRITE_RANGES = 4;
+
+	//! More dirty ranges incur higher analyze/compression costs.
+	//! Higher values require more reused tuples and favor full rewrites for fragmented updates.
+	static constexpr idx_t MINIMUM_REUSED_VECTORS_PER_EXTRA_DIRTY_RANGE = 5;
+
+	//! Maximum estimated Segment-count overhead; higher values tolerate more fragmented block layouts
+	static constexpr double MAXIMUM_PROJECTED_SEGMENT_OVERHEAD_RATIO = 0.25;
+
+	enum class Action : uint8_t { REUSE, REWRITE };
+
+	struct Range {
+		Range(idx_t first_segment_p, idx_t tuple_count_p, Action action_p)
+		    : first_segment(first_segment_p), segment_count(1), tuple_count(tuple_count_p), action(action_p) {
+		}
+
+		bool ReusesSegments() const {
+			return action == Action::REUSE;
+		}
+
+		idx_t first_segment;
+		idx_t segment_count;
+		idx_t tuple_count;
+		Action action;
+		CheckpointAnalyzeResult analyze_result;
+	};
+
+	SegmentReusePlan(vector<Range> ranges_p, idx_t segment_count_p, idx_t total_tuple_count_p,
+	                 idx_t largest_segment_tuple_count_p)
+	    : ranges(std::move(ranges_p)), segment_count(segment_count_p), total_tuple_count(total_tuple_count_p),
+	      largest_segment_tuple_count(largest_segment_tuple_count_p) {
+	}
+
+	template <class FUNC>
+	void ForEachSegment(const ColumnData &column_data, const Range &range, FUNC &&callback) const {
+		D_ASSERT(column_data.data.GetSegmentCount() == segment_count);
+		D_ASSERT(range.first_segment + range.segment_count <= segment_count);
+		auto segment_node = column_data.data.GetSegmentByIndex(UnsafeNumericCast<int64_t>(range.first_segment));
+		D_ASSERT(segment_node);
+		for (idx_t i = 0; i < range.segment_count; i++) {
+			callback(*segment_node);
+			if (i + 1 < range.segment_count) {
+				segment_node = segment_node->Next();
+				D_ASSERT(segment_node);
+			}
+		}
+	}
+
+	bool IsProfitable() const {
+		idx_t reused_tuple_count = 0;
+		for (auto &range : ranges) {
+			if (range.ReusesSegments()) {
+				reused_tuple_count += range.tuple_count;
+			}
+		}
+
+		auto minimum_reused_tuple_count =
+		    LossyNumericCast<idx_t>(static_cast<double>(total_tuple_count) * MINIMUM_REUSED_TUPLE_RATIO);
+		if (reused_tuple_count == 0 || reused_tuple_count < minimum_reused_tuple_count) {
+			return false;
+		}
+
+		idx_t dirty_range_count = 0;
+		idx_t projected_segment_count = 0;
+		for (auto &range : ranges) {
+			if (range.ReusesSegments()) {
+				projected_segment_count += range.segment_count;
+				continue;
+			}
+
+			dirty_range_count++;
+			auto estimated_dirty_segment_count = (range.tuple_count - 1) / largest_segment_tuple_count + 1;
+			// Codec output boundaries are unknown before compression, so reserve one extra Segment per dirty range.
+			projected_segment_count += estimated_dirty_segment_count + 1;
+		}
+		if (dirty_range_count > MAX_LOCAL_REWRITE_RANGES) {
+			return false;
+		}
+
+		auto extra_dirty_range_count = dirty_range_count > 0 ? dirty_range_count - 1 : 0;
+		auto range_reuse_requirement =
+		    extra_dirty_range_count * MINIMUM_REUSED_VECTORS_PER_EXTRA_DIRTY_RANGE * STANDARD_VECTOR_SIZE;
+		auto required_reused_tuple_count = MaxValue(minimum_reused_tuple_count, range_reuse_requirement);
+		if (reused_tuple_count < required_reused_tuple_count) {
+			return false;
+		}
+
+		auto estimated_compact_segment_count = (total_tuple_count - 1) / largest_segment_tuple_count + 1;
+		auto projected_segment_overhead = LossyNumericCast<idx_t>(static_cast<double>(estimated_compact_segment_count) *
+		                                                          MAXIMUM_PROJECTED_SEGMENT_OVERHEAD_RATIO);
+		auto maximum_projected_segment_count =
+		    estimated_compact_segment_count + MaxValue<idx_t>(1, projected_segment_overhead);
+
+		return projected_segment_count <= maximum_projected_segment_count;
+	}
+
+	vector<Range> ranges;
+	idx_t segment_count;
+	idx_t total_tuple_count;
+	idx_t largest_segment_tuple_count;
+};
+
 static void CreateIntermediateVector(vector<reference<ColumnCheckpointState>> &states, DataChunk &chunk) {
 	D_ASSERT(!states.empty());
 
@@ -89,28 +202,30 @@ ColumnDataCheckpointer::ColumnDataCheckpointer(vector<reference<ColumnCheckpoint
 	CreateIntermediateVector(checkpoint_states, intermediate);
 }
 
-void ColumnDataCheckpointer::ScanSegments(const std::function<void(Vector &)> &callback) {
-	auto &first_state = checkpoint_states[0];
-	auto &col_data = first_state.get().original_column;
+void ColumnDataCheckpointer::ScanSegment(const ColumnData &col_data, SegmentNode<ColumnSegment> &segment_node,
+                                         const std::function<void(Vector &)> &callback) {
+	auto &segment = segment_node.GetNode();
+	ColumnScanState scan_state(nullptr);
+	scan_state.current = segment_node;
+	segment.InitializeScan(scan_state);
 
+	auto &scan_vector = intermediate.data[0];
+	for (idx_t base_row_index = 0; base_row_index < segment.count; base_row_index += STANDARD_VECTOR_SIZE) {
+		intermediate.Reset();
+
+		idx_t count = MinValue<idx_t>(segment.count - base_row_index, STANDARD_VECTOR_SIZE);
+		scan_state.offset_in_column = segment_node.GetRowStart() + base_row_index;
+
+		col_data.CheckpointScan(segment, scan_state, count, scan_vector);
+		scan_vector.BufferMutable().SetVectorSize(count);
+		callback(scan_vector);
+	}
+}
+
+void ColumnDataCheckpointer::ScanSegments(const ColumnData &col_data, const std::function<void(Vector &)> &callback) {
 	// TODO: scan all the nodes from all segments, no need for CheckpointScan to virtualize this I think..
 	for (auto &segment_node : col_data.data.SegmentNodes()) {
-		auto &segment = segment_node.GetNode();
-		ColumnScanState scan_state(nullptr);
-		scan_state.current = segment_node;
-		segment.InitializeScan(scan_state);
-
-		auto &scan_vector = intermediate.data[0];
-		for (idx_t base_row_index = 0; base_row_index < segment.count; base_row_index += STANDARD_VECTOR_SIZE) {
-			intermediate.Reset();
-
-			idx_t count = MinValue<idx_t>(segment.count - base_row_index, STANDARD_VECTOR_SIZE);
-			scan_state.offset_in_column = segment_node.GetRowStart() + base_row_index;
-
-			col_data.CheckpointScan(segment, scan_state, count, scan_vector);
-			scan_vector.BufferMutable().SetVectorSize(count);
-			callback(scan_vector);
-		}
+		ScanSegment(col_data, segment_node, callback);
 	}
 }
 
@@ -151,28 +266,9 @@ CompressionType ForceCompression(StorageManager &storage_manager,
 	return compression_type;
 }
 
-void ColumnDataCheckpointer::InitAnalyze() {
-	analyze_states.resize(checkpoint_states.size());
-	for (idx_t i = 0; i < checkpoint_states.size(); i++) {
-		auto &functions = compression_functions[i];
-		auto &states = analyze_states[i];
-		auto &checkpoint_state = checkpoint_states[i];
-		auto &coldata = checkpoint_state.get().GetResultColumn();
-		states.resize(functions.size());
-		for (idx_t j = 0; j < functions.size(); j++) {
-			auto &func = functions[j];
-			if (!func) {
-				continue;
-			}
-			states[j] = func->init_analyze(coldata, coldata.type.InternalType());
-		}
-	}
-}
-
-vector<CheckpointAnalyzeResult> ColumnDataCheckpointer::DetectBestCompressionMethod() {
+vector<CompressionType> ColumnDataCheckpointer::PrepareCompressionMethods() {
 	D_ASSERT(!compression_functions.empty());
-	auto &db = storage_manager.GetDatabase();
-	auto &config = DBConfig::GetConfig(db);
+	auto &config = DBConfig::GetConfig(storage_manager.GetDatabase());
 	vector<CompressionType> forced_methods(checkpoint_states.size(), CompressionType::COMPRESSION_AUTO);
 
 	auto compression_type = checkpoint_info.GetCompressionType();
@@ -180,98 +276,209 @@ vector<CheckpointAnalyzeResult> ColumnDataCheckpointer::DetectBestCompressionMet
 		auto &functions = compression_functions[i];
 		if (compression_type != CompressionType::COMPRESSION_AUTO) {
 			forced_methods[i] = ForceCompression(storage_manager, functions, compression_type);
+			continue;
 		}
-		if (compression_type == CompressionType::COMPRESSION_AUTO) {
-			auto force_compression = Settings::Get<ForceCompressionSetting>(config);
-			if (force_compression != CompressionType::COMPRESSION_AUTO) {
-				forced_methods[i] = ForceCompression(storage_manager, functions, force_compression);
-			}
+		auto force_compression = Settings::Get<ForceCompressionSetting>(config);
+		if (force_compression != CompressionType::COMPRESSION_AUTO) {
+			forced_methods[i] = ForceCompression(storage_manager, functions, force_compression);
+		}
+	}
+	return forced_methods;
+}
+
+vector<unique_ptr<AnalyzeState>> ColumnDataCheckpointer::InitAnalyze(idx_t checkpoint_state_idx) {
+	auto &functions = compression_functions[checkpoint_state_idx];
+	auto &checkpoint_state = checkpoint_states[checkpoint_state_idx].get();
+	auto &coldata = checkpoint_state.GetResultColumn();
+	vector<unique_ptr<AnalyzeState>> states(functions.size());
+	for (idx_t j = 0; j < functions.size(); j++) {
+		auto &func = functions[j];
+		if (func) {
+			states[j] = func->init_analyze(coldata, coldata.type.InternalType());
+		}
+	}
+	return states;
+}
+
+void ColumnDataCheckpointer::AnalyzeVector(idx_t checkpoint_state_idx, vector<unique_ptr<AnalyzeState>> &states,
+                                           Vector &scan_vector) {
+	auto &functions = compression_functions[checkpoint_state_idx];
+	for (idx_t j = 0; j < functions.size(); j++) {
+		auto &state = states[j];
+		auto &func = functions[j];
+		if (!state) {
+			continue;
+		}
+		if (!func->analyze(*state, scan_vector)) {
+			// Analyze states are range-local; keep the function available for later ranges.
+			state = nullptr;
+		}
+	}
+}
+
+CheckpointAnalyzeResult ColumnDataCheckpointer::FinalizeAnalyze(idx_t checkpoint_state_idx,
+                                                                vector<unique_ptr<AnalyzeState>> states,
+                                                                CompressionType forced_method) {
+	auto &functions = compression_functions[checkpoint_state_idx];
+	unique_ptr<AnalyzeState> chosen_state;
+	idx_t best_score = NumericLimits<idx_t>::Maximum();
+	idx_t compression_idx = DConstants::INVALID_INDEX;
+
+	D_ASSERT(functions.size() == states.size());
+	for (idx_t j = 0; j < functions.size(); j++) {
+		auto &function = functions[j];
+		auto &state = states[j];
+		if (!state) {
+			continue;
+		}
+
+		bool forced_method_found = function->type == forced_method;
+		auto score = function->final_analyze(*state);
+		if (score == DConstants::INVALID_INDEX) {
+			continue;
+		}
+		if (score < best_score || forced_method_found) {
+			compression_idx = j;
+			best_score = score;
+			chosen_state = std::move(state);
+		}
+		if (forced_method_found) {
+			break;
 		}
 	}
 
-	InitAnalyze();
-	// scan over all the segments and run the analyze step
-	ScanSegments([&](Vector &scan_vector) {
-		for (idx_t i = 0; i < checkpoint_states.size(); i++) {
-			auto &functions = compression_functions[i];
-			auto &states = analyze_states[i];
-			for (idx_t j = 0; j < functions.size(); j++) {
-				auto &state = states[j];
-				auto &func = functions[j];
+	auto &col_data = checkpoint_states[checkpoint_state_idx].get().GetResultColumn();
+	if (!chosen_state) {
+		throw FatalException("No suitable compression/storage method found to store column of type %s",
+		                     col_data.type.ToString());
+	}
+	D_ASSERT(compression_idx != DConstants::INVALID_INDEX);
 
-				if (!state) {
-					continue;
-				}
-				if (!func->analyze(*state, scan_vector)) {
-					state = nullptr;
-					func = nullptr;
-				}
-			}
+	auto &best_function = *functions[compression_idx];
+	auto &db = storage_manager.GetDatabase();
+	DUCKDB_LOG_TRACE(db, "ColumnDataCheckpointer FinalAnalyze(%s) result for %s.%s.%d(%s): %d",
+	                 EnumUtil::ToString(best_function.type), col_data.info.GetSchemaName(),
+	                 col_data.info.GetTableName(), col_data.column_index, col_data.type.ToString(), best_score);
+	return CheckpointAnalyzeResult(std::move(chosen_state), best_function);
+}
+
+unique_ptr<ColumnDataCheckpointer::SegmentReusePlan>
+ColumnDataCheckpointer::TryBuildSegmentReusePlan(const vector<CompressionType> &forced_methods) {
+	D_ASSERT(forced_methods.size() == checkpoint_states.size());
+	auto compression_type = checkpoint_info.GetCompressionType();
+	if (checkpoint_states.size() != 2) {
+		return nullptr;
+	}
+	auto auto_compression = compression_type == CompressionType::COMPRESSION_AUTO;
+	if (auto_compression) {
+		auto &config = DBConfig::GetConfig(storage_manager.GetDatabase());
+		if (Settings::Get<ForceCompressionSetting>(config) != CompressionType::COMPRESSION_AUTO) {
+			return nullptr;
+		}
+	} else if (forced_methods[0] != compression_type) {
+		return nullptr;
+	}
+
+	auto &base_data = checkpoint_states[0].get().original_column;
+	auto &validity_data = checkpoint_states[1].get().original_column;
+	if (base_data.HasParent() || base_data.type.IsNested() || validity_data.type.InternalType() != PhysicalType::BIT ||
+	    !validity_data.data.GetRootSegment()) {
+		return nullptr;
+	}
+	auto total_tuple_count = base_data.count.load();
+	for (auto &function : compression_functions[0]) {
+		if (!function) {
+			continue;
+		}
+		if (!auto_compression && function->validity != CompressionValidity::REQUIRES_VALIDITY) {
+			return nullptr;
+		}
+	}
+	for (auto &segment : validity_data.data.Segments()) {
+		if (segment.GetSegmentType() != ColumnSegmentType::PERSISTENT ||
+		    segment.GetCompressionFunction().type == CompressionType::COMPRESSION_EMPTY) {
+			return nullptr;
+		}
+	}
+	// Row-remapping checkpoints cannot reuse source Segment ranges.
+	if (total_tuple_count != row_group.count.load()) {
+		return nullptr;
+	}
+
+	idx_t current_row = 0;
+	idx_t segment_index = 0;
+	idx_t largest_segment_tuple_count = 0;
+	vector<SegmentReusePlan::Range> ranges;
+	for (auto &segment_node : base_data.data.SegmentNodes()) {
+		auto segment_start = segment_node.GetRowStart();
+		auto segment_end = segment_node.GetRowEnd();
+		auto segment_tuple_count = segment_node.GetNode().count.load();
+		if (segment_start != current_row || segment_tuple_count == 0) {
+			return nullptr;
+		}
+		auto &segment = segment_node.GetNode();
+		auto reuse = CanReuseBaseSegment(segment) && !base_data.HasChanges(segment_start, segment_end);
+		auto action = reuse ? SegmentReusePlan::Action::REUSE : SegmentReusePlan::Action::REWRITE;
+		if (ranges.empty() || ranges.back().action != action) {
+			ranges.emplace_back(segment_index, segment_tuple_count, action);
+		} else {
+			ranges.back().segment_count++;
+			ranges.back().tuple_count += segment_tuple_count;
+		}
+		largest_segment_tuple_count = MaxValue(largest_segment_tuple_count, segment_tuple_count);
+		current_row = segment_end;
+		segment_index++;
+	}
+	if (current_row != total_tuple_count) {
+		return nullptr;
+	}
+
+	auto plan =
+	    make_uniq<SegmentReusePlan>(std::move(ranges), segment_index, total_tuple_count, largest_segment_tuple_count);
+	if (!plan->IsProfitable()) {
+		return nullptr;
+	}
+	return plan;
+}
+
+vector<CheckpointAnalyzeResult>
+ColumnDataCheckpointer::AnalyzeFullColumn(const vector<CompressionType> &forced_methods) {
+	D_ASSERT(forced_methods.size() == checkpoint_states.size());
+	vector<CheckpointAnalyzeResult> result(checkpoint_states.size());
+	auto &base_data = checkpoint_states[0].get().original_column;
+	vector<vector<unique_ptr<AnalyzeState>>> analyze_states(checkpoint_states.size());
+	for (idx_t i = 0; i < checkpoint_states.size(); i++) {
+		analyze_states[i] = InitAnalyze(i);
+	}
+	ScanSegments(base_data, [&](Vector &scan_vector) {
+		for (idx_t i = 0; i < checkpoint_states.size(); i++) {
+			AnalyzeVector(i, analyze_states[i], scan_vector);
 		}
 	});
-
-	vector<CheckpointAnalyzeResult> result;
-	result.resize(checkpoint_states.size());
-
 	for (idx_t i = 0; i < checkpoint_states.size(); i++) {
-		auto &functions = compression_functions[i];
-		auto &states = analyze_states[i];
-		auto &forced_method = forced_methods[i];
-
-		unique_ptr<AnalyzeState> chosen_state;
-		idx_t best_score = NumericLimits<idx_t>::Maximum();
-		idx_t compression_idx = DConstants::INVALID_INDEX;
-
-		D_ASSERT(functions.size() == states.size());
-		for (idx_t j = 0; j < functions.size(); j++) {
-			auto &function = functions[j];
-			auto &state = states[j];
-
-			if (!state) {
-				continue;
-			}
-
-			//! Check if the method type is the forced method (if forced is used)
-			bool forced_method_found = function->type == forced_method;
-			// now that we have passed over all the data, we need to figure out the best method
-			// we do this using the final_analyze method
-			auto score = function->final_analyze(*state);
-
-			//! The finalize method can return this value from final_analyze to indicate it should not be used.
-			if (score == DConstants::INVALID_INDEX) {
-				continue;
-			}
-
-			if (score < best_score || forced_method_found) {
-				compression_idx = j;
-				best_score = score;
-				chosen_state = std::move(state);
-			}
-			//! If we have found the forced method, we're done
-			if (forced_method_found) {
-				break;
-			}
-		}
-
-		auto &checkpoint_state = checkpoint_states[i];
-		auto &col_data = checkpoint_state.get().GetResultColumn();
-		if (!chosen_state) {
-			throw FatalException("No suitable compression/storage method found to store column of type %s",
-			                     col_data.type.ToString());
-		}
-		D_ASSERT(compression_idx != DConstants::INVALID_INDEX);
-
-		auto &best_function = *functions[compression_idx];
-		DUCKDB_LOG_TRACE(db, "ColumnDataCheckpointer FinalAnalyze(%s) result for %s.%s.%d(%s): %d",
-		                 EnumUtil::ToString(best_function.type), col_data.info.GetSchemaName(),
-		                 col_data.info.GetTableName(), col_data.column_index, col_data.type.ToString(), best_score);
-		result[i] = CheckpointAnalyzeResult(std::move(chosen_state), best_function);
+		result[i] = FinalizeAnalyze(i, std::move(analyze_states[i]), forced_methods[i]);
 	}
 	return result;
 }
 
-struct CheckpointBlockIdDropper : public BlockIdVisitor {
-	explicit CheckpointBlockIdDropper(BlockManager &manager) : manager(manager) {
+void ColumnDataCheckpointer::AnalyzeRewriteRanges(SegmentReusePlan &plan,
+                                                  const vector<CompressionType> &forced_methods) {
+	D_ASSERT(forced_methods.size() == checkpoint_states.size());
+	auto &base_data = checkpoint_states[0].get().original_column;
+	for (auto &range : plan.ranges) {
+		if (range.ReusesSegments()) {
+			continue;
+		}
+		auto states = InitAnalyze(0);
+		plan.ForEachSegment(base_data, range, [&](auto &segment_node) {
+			ScanSegment(base_data, segment_node, [&](Vector &scan_vector) { AnalyzeVector(0, states, scan_vector); });
+		});
+		range.analyze_result = FinalizeAnalyze(0, std::move(states), forced_methods[0]);
+	}
+}
+
+struct ModifiedBlockMarker : public BlockIdVisitor {
+	explicit ModifiedBlockMarker(BlockManager &manager) : manager(manager) {
 	}
 
 	void Visit(block_id_t block_id) override {
@@ -281,24 +488,7 @@ struct CheckpointBlockIdDropper : public BlockIdVisitor {
 	BlockManager &manager;
 };
 
-void ColumnDataCheckpointer::DropSegments() {
-	// first we check the current segments
-	// if there are any persistent segments, we will mark their old block ids as modified
-	// since the segments will be rewritten their old on disk data is no longer required
-
-	for (idx_t i = 0; i < checkpoint_states.size(); i++) {
-		auto &state = checkpoint_states[i];
-		auto &col_data = state.get().original_column;
-
-		// Drop the segments, as we'll be replacing them with new ones, because there are changes
-		CheckpointBlockIdDropper dropper(storage_manager.GetBlockManager());
-		for (auto &segment : col_data.data.Segments()) {
-			segment.VisitBlockIds(dropper);
-		}
-	}
-}
-
-bool ColumnDataCheckpointer::ValidityCoveredByBasedata(vector<CheckpointAnalyzeResult> &result) {
+bool ColumnDataCheckpointer::ValidityCoveredByBasedata(const vector<CheckpointAnalyzeResult> &result) {
 	if (result.size() != 2) {
 		return false;
 	}
@@ -307,9 +497,40 @@ bool ColumnDataCheckpointer::ValidityCoveredByBasedata(vector<CheckpointAnalyzeR
 	return base.function->validity == CompressionValidity::NO_VALIDITY_REQUIRED;
 }
 
-void ColumnDataCheckpointer::WriteToDisk() { // Analyze the candidate functions to select one of them to use for
-	                                         // compression
-	auto analyze_result = DetectBestCompressionMethod();
+void ColumnDataCheckpointer::WriteToDisk() {
+	auto forced_methods = PrepareCompressionMethods();
+	if (TryWriteReusedSegments(forced_methods)) {
+		return;
+	}
+	WriteFullColumn(AnalyzeFullColumn(forced_methods));
+}
+
+bool ColumnDataCheckpointer::TryWriteReusedSegments(const vector<CompressionType> &forced_methods) {
+	auto plan = TryBuildSegmentReusePlan(forced_methods);
+	if (!plan) {
+		return false;
+	}
+
+	AnalyzeRewriteRanges(*plan, forced_methods);
+	CheckpointAnalyzeResult validity_result;
+	auto &validity_data = checkpoint_states[1].get().original_column;
+	if (validity_data.HasChanges()) {
+		auto states = InitAnalyze(1);
+		ScanSegments(validity_data, [&](Vector &scan_vector) { AnalyzeVector(1, states, scan_vector); });
+		validity_result = FinalizeAnalyze(1, std::move(states), forced_methods[1]);
+	}
+
+	WriteRewriteRanges(*plan);
+	if (validity_data.HasChanges()) {
+		WriteValidity(validity_result);
+	} else {
+		PreserveUnchangedValidity();
+	}
+	MarkRewrittenSourceBlocksModified(*plan);
+	return true;
+}
+
+void ColumnDataCheckpointer::WriteFullColumn(vector<CheckpointAnalyzeResult> analyze_result) {
 	if (ValidityCoveredByBasedata(analyze_result)) {
 		D_ASSERT(analyze_result.size() == 2);
 		auto &validity = analyze_result[1];
@@ -319,7 +540,6 @@ void ColumnDataCheckpointer::WriteToDisk() { // Analyze the candidate functions 
 		// turning the compression+final compress steps into a no-op, saving a single empty segment
 		validity.function = config.GetCompressionFunction(CompressionType::COMPRESSION_EMPTY, PhysicalType::BIT).get();
 	}
-
 	// Initialize the compression for the selected function
 	D_ASSERT(analyze_result.size() == checkpoint_states.size());
 	vector<ColumnDataCheckpointData> checkpoint_data(checkpoint_states.size());
@@ -337,7 +557,8 @@ void ColumnDataCheckpointer::WriteToDisk() { // Analyze the candidate functions 
 	}
 
 	// Scan over the existing segment + changes and compress the data
-	ScanSegments([&](Vector &scan_vector) {
+	auto &base_data = checkpoint_states[0].get().original_column;
+	ScanSegments(base_data, [&](Vector &scan_vector) {
 		for (idx_t i = 0; i < checkpoint_states.size(); i++) {
 			auto &function = analyze_result[i].function;
 			auto &compression_state = compression_states[i];
@@ -351,13 +572,79 @@ void ColumnDataCheckpointer::WriteToDisk() { // Analyze the candidate functions 
 		auto &compression_state = compression_states[i];
 		function->compress_finalize(*compression_state);
 	}
-
-	// after we finish checkpointing we can drop this segment
-	DropSegments();
+	MarkAllSourceBlocksModified();
 }
 
-bool ColumnDataCheckpointer::HasChanges(ColumnData &col_data) {
-	return col_data.HasAnyChanges();
+void ColumnDataCheckpointer::WriteRewriteRanges(SegmentReusePlan &plan) {
+	auto &checkpoint_state = checkpoint_states[0].get();
+	auto &original_column = checkpoint_state.original_column;
+	auto &result_column = checkpoint_state.GetResultColumn();
+	ColumnDataCheckpointData checkpoint_data(checkpoint_state, result_column, result_column.GetDatabase(), row_group,
+	                                         storage_manager);
+	for (auto &range : plan.ranges) {
+		if (range.ReusesSegments()) {
+			plan.ForEachSegment(original_column, range, [&](auto &segment_node) {
+				checkpoint_state.AppendReferencedSegment(segment_node.ReferenceNode(), segment_node.GetRowStart());
+			});
+			continue;
+		}
+
+		auto &analyze_result = range.analyze_result;
+		if (!analyze_result.function) {
+			throw InternalException("Missing compression method for a checkpoint rewrite range");
+		}
+		auto &rewrite_function = *analyze_result.function;
+		auto compression_state =
+		    rewrite_function.init_compression(checkpoint_data, std::move(analyze_result.analyze_state));
+		plan.ForEachSegment(original_column, range, [&](auto &segment_node) {
+			ScanSegment(original_column, segment_node,
+			            [&](Vector &scan_vector) { rewrite_function.compress(*compression_state, scan_vector); });
+		});
+		rewrite_function.compress_finalize(*compression_state);
+	}
+}
+
+void ColumnDataCheckpointer::WriteValidity(CheckpointAnalyzeResult &analyze_result) {
+	D_ASSERT(analyze_result.function);
+	auto &checkpoint_state = checkpoint_states[1].get();
+	auto &original_column = checkpoint_state.original_column;
+	auto &result_column = checkpoint_state.GetResultColumn();
+	ColumnDataCheckpointData checkpoint_data(checkpoint_state, result_column, result_column.GetDatabase(), row_group,
+	                                         storage_manager);
+	auto &function = *analyze_result.function;
+	auto compression_state = function.init_compression(checkpoint_data, std::move(analyze_result.analyze_state));
+	ScanSegments(original_column, [&](Vector &scan_vector) { function.compress(*compression_state, scan_vector); });
+	function.compress_finalize(*compression_state);
+}
+
+void ColumnDataCheckpointer::MarkAllSourceBlocksModified() {
+	ModifiedBlockMarker marker(storage_manager.GetBlockManager());
+	for (auto &state : checkpoint_states) {
+		for (auto &segment : state.get().original_column.data.Segments()) {
+			segment.VisitBlockIds(marker);
+		}
+	}
+}
+
+void ColumnDataCheckpointer::MarkRewrittenSourceBlocksModified(const SegmentReusePlan &plan) {
+	D_ASSERT(checkpoint_states.size() == 2);
+	ModifiedBlockMarker marker(storage_manager.GetBlockManager());
+	auto &base_data = checkpoint_states[0].get().original_column;
+	for (auto &range : plan.ranges) {
+		if (range.ReusesSegments()) {
+			continue;
+		}
+		plan.ForEachSegment(base_data, range,
+		                    [&](auto &segment_node) { segment_node.GetNode().VisitBlockIds(marker); });
+	}
+
+	auto &validity_data = checkpoint_states[1].get().original_column;
+	if (!validity_data.HasChanges()) {
+		return;
+	}
+	for (auto &segment : validity_data.data.Segments()) {
+		segment.VisitBlockIds(marker);
+	}
 }
 
 void ColumnDataCheckpointer::WritePersistentSegments(ColumnCheckpointState &state) {
@@ -408,6 +695,14 @@ struct CheckpointBlockIdMarker : public BlockIdVisitor {
 	BlockManager &manager;
 };
 
+void ColumnDataCheckpointer::PreserveUnchangedValidity() {
+	auto &state = checkpoint_states[1].get();
+	D_ASSERT(!state.original_column.HasChanges());
+	CheckpointBlockIdMarker marker(storage_manager.GetBlockManager());
+	state.original_column.VisitBlockIds(marker);
+	WritePersistentSegments(state);
+}
+
 void ColumnDataCheckpointer::Checkpoint() {
 	for (idx_t i = 0; i < checkpoint_states.size(); i++) {
 		auto &state = checkpoint_states[i];
@@ -436,8 +731,7 @@ void ColumnDataCheckpointer::Checkpoint() {
 
 void ColumnDataCheckpointer::FinalizeCheckpoint() {
 	if (has_changes) {
-		// something has undergone changes, we rewrote everything
-		// write the new data - not the old data
+		// Changed columns were finalized by WriteToDisk
 		return;
 	}
 	// no changes - copy over the original columns

--- a/src/storage/table/update_segment.cpp
+++ b/src/storage/table/update_segment.cpp
@@ -1561,14 +1561,25 @@ bool UpdateSegment::HasUncommittedUpdates(idx_t vector_index) {
 
 bool UpdateSegment::HasUpdates(idx_t start_row_index, idx_t end_row_index) {
 	auto read_lock = lock.GetSharedLock();
-	if (!root) {
+	if (!root || start_row_index >= end_row_index) {
 		return false;
 	}
 	idx_t base_vector_index = start_row_index / STANDARD_VECTOR_SIZE;
-	idx_t end_vector_index = end_row_index / STANDARD_VECTOR_SIZE;
+	idx_t end_vector_index = (end_row_index - 1) / STANDARD_VECTOR_SIZE;
+	auto start_offset = start_row_index % STANDARD_VECTOR_SIZE;
+	auto end_offset = (end_row_index - 1) % STANDARD_VECTOR_SIZE + 1;
 	for (idx_t i = base_vector_index; i <= end_vector_index; i++) {
 		auto entry = GetUpdateNode(*read_lock, i);
-		if (entry.IsSet()) {
+		if (!entry.IsSet()) {
+			continue;
+		}
+		auto pin = entry.Pin();
+		auto &info = UpdateInfo::Get(pin);
+		auto start_in_vector = i == base_vector_index ? start_offset : 0;
+		auto end_in_vector = i == end_vector_index ? end_offset : STANDARD_VECTOR_SIZE;
+		auto tuples = info.GetTuples();
+		auto tuple = std::lower_bound(tuples, tuples + info.N, start_in_vector);
+		if (tuple != tuples + info.N && *tuple < end_in_vector) {
 			return true;
 		}
 	}

--- a/test/sql/storage/compression/reuse_explicit_compression_segments.test
+++ b/test/sql/storage/compression/reuse_explicit_compression_segments.test
@@ -1,0 +1,944 @@
+# name: test/sql/storage/compression/reuse_explicit_compression_segments.test
+# description: Test persistent base segment reuse across checkpoint rewrites
+# group: [compression]
+
+require noforcestorage
+
+require no_alternative_verify
+
+require vector_size 2048
+
+load {TEST_DIR}/reuse_explicit_compression_segments.db readwrite v1.2.0
+
+statement ok
+SET threads=1
+
+statement ok
+SET checkpoint_threshold='9999GB'
+
+statement ok
+SET debug_verify_blocks=true
+
+statement ok
+CALL enable_logging(storage='memory', level='trace')
+
+# Exercise the tuple/Vector amortization policy on deterministic 16 KiB fixed-size Segments.
+statement ok
+ATTACH '{TEST_DIR}/reuse_range_gate.db' AS range_gate_db (STORAGE_VERSION 'v1.2.0', BLOCK_SIZE 16384)
+
+statement ok
+CREATE TABLE range_gate_db.reuse_pipeline_gate_t(
+    id BIGINT,
+    v BIGINT USING COMPRESSION UNCOMPRESSED)
+
+statement ok
+INSERT INTO range_gate_db.reuse_pipeline_gate_t
+SELECT i, i FROM range(860160) t(i)
+
+statement ok
+FORCE CHECKPOINT range_gate_db
+
+statement ok
+CREATE TEMP TABLE reuse_pipeline_gate_cases(
+    row_group_id BIGINT,
+    expected_local BOOLEAN)
+
+statement ok
+INSERT INTO reuse_pipeline_gate_cases VALUES
+    (0, true),
+    (1, true),
+    (2, true),
+    (3, true),
+    (4, false),
+    (5, false),
+    (6, false)
+
+statement ok
+CREATE TABLE range_gate_db.reuse_pipeline_gate_targets AS
+WITH segments AS (
+    SELECT row_group_id, start, count,
+           row_number() OVER (PARTITION BY row_group_id ORDER BY start) AS segment_no
+    FROM pragma_storage_info('range_gate_db.reuse_pipeline_gate_t')
+    WHERE column_name='v' AND segment_type='BIGINT'
+)
+SELECT row_group_id, start AS segment_start,
+       row_group_id*122880+start+count//2 AS id
+FROM segments
+WHERE CASE row_group_id
+    WHEN 0 THEN segment_no>=9
+    WHEN 1 THEN segment_no BETWEEN 11 AND 35 OR segment_no>=37
+    WHEN 2 THEN segment_no BETWEEN 12 AND 35 OR segment_no>=37
+    WHEN 3 THEN segment_no BETWEEN 5 AND 10 OR segment_no BETWEEN 20 AND 25
+                 OR segment_no BETWEEN 35 AND 40 OR segment_no BETWEEN 50 AND 55
+    WHEN 4 THEN segment_no NOT IN (1,2,3,4,5,6,7,8,20,40,60)
+    WHEN 5 THEN segment_no IN (5,15,25,35,45)
+    WHEN 6 THEN segment_no>=8
+    ELSE false
+END
+
+statement ok
+CREATE TEMP TABLE reuse_pipeline_gate_before AS
+SELECT row_group_id, start, count, block_id, block_offset,
+       row_number() OVER (PARTITION BY row_group_id ORDER BY start) AS segment_no,
+       EXISTS (SELECT 1 FROM range_gate_db.reuse_pipeline_gate_targets target
+               WHERE target.row_group_id=storage.row_group_id
+                 AND target.segment_start=storage.start) AS dirty
+FROM pragma_storage_info('range_gate_db.reuse_pipeline_gate_t') storage
+WHERE column_name='v' AND segment_type='BIGINT'
+
+# The selected RowGroups cover one, four, and five dirty ranges as well as
+# insufficient reuse and an over-fragmented projected layout.
+statement ok
+SET threads=32
+
+statement ok
+UPDATE range_gate_db.reuse_pipeline_gate_t AS target
+SET v=-target.id-1
+FROM range_gate_db.reuse_pipeline_gate_targets AS changes
+WHERE target.id=changes.id
+
+statement ok
+FORCE CHECKPOINT range_gate_db
+
+query II rowsort
+WITH after_segments AS (
+    SELECT row_group_id, start, count, block_id, block_offset
+    FROM pragma_storage_info('range_gate_db.reuse_pipeline_gate_t')
+    WHERE column_name='v' AND segment_type='BIGINT'
+), matches AS (
+    SELECT before.row_group_id,
+           count(*) FILTER (WHERE NOT before.dirty) AS clean_segments,
+           count(*) FILTER (WHERE NOT before.dirty AND before.block_id=after.block_id
+                                                   AND before.block_offset=after.block_offset) AS reused_clean_segments,
+           count(*) FILTER (WHERE before.block_id=after.block_id
+                              AND before.block_offset=after.block_offset) AS retained_segments
+    FROM reuse_pipeline_gate_before before
+    LEFT JOIN after_segments after USING (row_group_id, start, count)
+    GROUP BY before.row_group_id
+)
+SELECT matches.row_group_id,
+       CASE WHEN cases.expected_local THEN reused_clean_segments=clean_segments AND clean_segments>0
+            ELSE retained_segments=0 END::INTEGER
+FROM matches
+JOIN reuse_pipeline_gate_cases cases USING (row_group_id)
+ORDER BY row_group_id
+----
+0	1
+1	1
+2	1
+3	1
+4	1
+5	1
+6	1
+
+query I
+SELECT count(*) FROM range_gate_db.reuse_pipeline_gate_t
+WHERE v IS DISTINCT FROM CASE
+    WHEN id IN (SELECT id FROM range_gate_db.reuse_pipeline_gate_targets) THEN -id-1
+    ELSE id END
+----
+0
+
+statement ok
+SET threads=1
+
+# One dirty range passes tuple amortization but an already sparse layout exceeds the Segment budget.
+statement ok
+CREATE TABLE range_gate_db.reuse_layout_gate_t(
+    id BIGINT,
+    v VARCHAR USING COMPRESSION UNCOMPRESSED)
+
+statement ok
+INSERT INTO range_gate_db.reuse_layout_gate_t
+SELECT i, CASE WHEN i<32768 THEN 'x' ELSE repeat('y',64) END
+FROM range(122880) t(i)
+
+statement ok
+FORCE CHECKPOINT range_gate_db
+
+statement ok
+CREATE TABLE range_gate_db.reuse_layout_gate_target AS
+SELECT start+count//2 AS id
+FROM pragma_storage_info('range_gate_db.reuse_layout_gate_t')
+WHERE column_name='v' AND segment_type='VARCHAR'
+ORDER BY start
+LIMIT 1
+
+statement ok
+CREATE TEMP TABLE reuse_layout_gate_before AS
+SELECT start, count, block_id, block_offset,
+       (SELECT id FROM range_gate_db.reuse_layout_gate_target)>=start
+         AND (SELECT id FROM range_gate_db.reuse_layout_gate_target)<start+count AS dirty
+FROM pragma_storage_info('range_gate_db.reuse_layout_gate_t')
+WHERE column_name='v' AND segment_type='VARCHAR'
+
+statement ok
+UPDATE range_gate_db.reuse_layout_gate_t
+SET v=repeat('z',64)
+WHERE id=(SELECT id FROM range_gate_db.reuse_layout_gate_target)
+
+statement ok
+FORCE CHECKPOINT range_gate_db
+
+query II
+SELECT (SELECT count(*)
+        FROM reuse_layout_gate_before before
+        JOIN pragma_storage_info('range_gate_db.reuse_layout_gate_t') after USING (block_id, block_offset)
+        WHERE after.column_name='v' AND after.segment_type='VARCHAR'),
+       (SELECT count(*) FROM range_gate_db.reuse_layout_gate_t
+        WHERE v IS DISTINCT FROM CASE
+            WHEN id=(SELECT id FROM range_gate_db.reuse_layout_gate_target) THEN repeat('z',64)
+            WHEN id<32768 THEN 'x' ELSE repeat('y',64) END)
+----
+0	0
+
+# Analyze candidates are initialized independently for every dirty range.
+statement ok
+CREATE TABLE range_gate_db.reuse_range_analyze_t(
+    id BIGINT,
+    v VARCHAR USING COMPRESSION DICTIONARY)
+
+statement ok
+INSERT INTO range_gate_db.reuse_range_analyze_t
+SELECT i, concat('dictionary-', i::VARCHAR, '-', repeat(md5(i::VARCHAR), 2))
+FROM range(122880) t(i)
+
+statement ok
+FORCE CHECKPOINT range_gate_db
+
+statement ok
+CREATE TABLE range_gate_db.reuse_range_analyze_targets AS
+WITH segments AS (
+    SELECT start, count, row_number() OVER (ORDER BY start) AS segment_no,
+           count(*) OVER () AS segment_count
+    FROM pragma_storage_info('range_gate_db.reuse_range_analyze_t')
+    WHERE column_name='v' AND segment_type='VARCHAR'
+)
+SELECT start+count//2 AS id, segment_no=2 AS use_large_string
+FROM segments
+WHERE segment_no=2 OR segment_no=segment_count-1
+
+query I
+SELECT (count(*)=2 AND count(*) FILTER (WHERE use_large_string)=1)::INTEGER
+FROM range_gate_db.reuse_range_analyze_targets
+----
+1
+
+statement ok
+CREATE TEMP TABLE reuse_range_analyze_before AS
+SELECT start, count, block_id, block_offset,
+       EXISTS (SELECT 1 FROM range_gate_db.reuse_range_analyze_targets target
+               WHERE target.id>=storage.start AND target.id<storage.start+storage.count) AS dirty
+FROM pragma_storage_info('range_gate_db.reuse_range_analyze_t') storage
+WHERE column_name='v' AND segment_type='VARCHAR'
+
+statement ok
+CALL truncate_duckdb_logs()
+
+statement ok
+UPDATE range_gate_db.reuse_range_analyze_t AS target
+SET v=CASE WHEN changes.use_large_string THEN repeat('L',300000) ELSE 'dictionary-after-failure' END
+FROM range_gate_db.reuse_range_analyze_targets AS changes
+WHERE target.id=changes.id
+
+statement ok
+FORCE CHECKPOINT range_gate_db
+
+query IIIII
+WITH after_segments AS (
+    SELECT start, count, block_id, block_offset
+    FROM pragma_storage_info('range_gate_db.reuse_range_analyze_t')
+    WHERE column_name='v' AND segment_type='VARCHAR'
+)
+SELECT (count(*) FILTER (WHERE NOT before.dirty AND before.block_id=after.block_id
+                                          AND before.block_offset=after.block_offset)
+            = count(*) FILTER (WHERE NOT before.dirty)
+        AND count(*) FILTER (WHERE NOT before.dirty)>0)::INTEGER,
+       (SELECT count(*) FROM duckdb_logs
+        WHERE contains(message, 'reuse_range_analyze_t')
+          AND contains(message, '.1(VARCHAR)')
+          AND starts_with(message, 'ColumnDataCheckpointer FinalAnalyze(UNCOMPRESSED)')),
+       (SELECT count(*) FROM duckdb_logs
+        WHERE contains(message, 'reuse_range_analyze_t')
+          AND contains(message, '.1(VARCHAR)')
+          AND starts_with(message, 'ColumnDataCheckpointer FinalAnalyze(DICTIONARY)')),
+       (SELECT count(*) FROM range_gate_db.reuse_range_analyze_t data
+        JOIN range_gate_db.reuse_range_analyze_targets target USING (id)
+        WHERE target.use_large_string AND data.v!=repeat('L',300000)),
+       (SELECT count(*) FROM range_gate_db.reuse_range_analyze_t data
+        JOIN range_gate_db.reuse_range_analyze_targets target USING (id)
+        WHERE NOT target.use_large_string AND data.v!='dictionary-after-failure')
+FROM reuse_range_analyze_before before
+LEFT JOIN after_segments after USING (start, count)
+----
+1	1	1	0	0
+
+statement ok
+ATTACH '{TEST_DIR}/reuse_fragment_guard.db' AS fragment_db (STORAGE_VERSION 'v1.2.0', BLOCK_SIZE 262144)
+
+statement ok
+CREATE TABLE fragment_db.reuse_fragment_guard_t(
+    id BIGINT,
+    v VARCHAR USING COMPRESSION FSST)
+
+statement ok
+INSERT INTO fragment_db.reuse_fragment_guard_t
+SELECT i, md5(i::VARCHAR) || md5((i+1)::VARCHAR)
+FROM range(122880) t(i)
+
+statement ok
+FORCE CHECKPOINT fragment_db
+
+# Alternating dirty segments exceed the budget and rewrite the complete base column.
+statement ok
+CREATE TABLE fragment_db.reuse_fragment_guarded_targets AS
+WITH segments AS (
+    SELECT start, count, row_number() OVER (ORDER BY start) AS segment_no
+    FROM pragma_storage_info('fragment_db.reuse_fragment_guard_t')
+    WHERE column_name='v' AND segment_type='VARCHAR'
+)
+SELECT start+count//2 AS id
+FROM segments
+WHERE segment_no%2=1
+
+statement ok
+CREATE TEMP TABLE reuse_fragment_guarded_before AS
+SELECT start, count, block_id, block_offset,
+       EXISTS (SELECT 1 FROM fragment_db.reuse_fragment_guarded_targets targets
+               WHERE targets.id>=start AND targets.id<start+count) AS dirty
+FROM pragma_storage_info('fragment_db.reuse_fragment_guard_t')
+WHERE column_name='v' AND segment_type='VARCHAR'
+
+statement ok
+UPDATE fragment_db.reuse_fragment_guard_t AS target
+SET v=md5(concat('guarded-', target.id::VARCHAR))
+   || md5(concat('guarded-tail-', target.id::VARCHAR))
+FROM fragment_db.reuse_fragment_guarded_targets AS changes
+WHERE target.id=changes.id
+
+statement ok
+FORCE CHECKPOINT fragment_db
+
+query III
+WITH layout AS (
+    SELECT count(*) AS segments, sum(count) AS tuples, max(count) AS max_count
+    FROM pragma_storage_info('fragment_db.reuse_fragment_guard_t')
+    WHERE column_name='v' AND segment_type='VARCHAR'
+)
+SELECT (SELECT count(*)
+        FROM reuse_fragment_guarded_before before
+        JOIN pragma_storage_info('fragment_db.reuse_fragment_guard_t') after USING (block_id, block_offset)
+        WHERE after.column_name='v' AND after.segment_type='VARCHAR'),
+       (SELECT (segments <= (tuples+max_count-1)//max_count
+                           + greatest(1, ((tuples+max_count-1)//max_count)//8))::INTEGER
+        FROM layout),
+       (SELECT count(*) FROM fragment_db.reuse_fragment_guard_t
+        WHERE v IS DISTINCT FROM CASE
+            WHEN id IN (SELECT id FROM fragment_db.reuse_fragment_guarded_targets)
+                THEN md5(concat('guarded-', id::VARCHAR))
+                  || md5(concat('guarded-tail-', id::VARCHAR))
+            ELSE md5(id::VARCHAR) || md5((id+1)::VARCHAR) END)
+----
+0	1	0
+
+# Once compacted, one dirty segment is again eligible for local rewriting.
+statement ok
+CREATE TABLE fragment_db.reuse_fragment_post_target AS
+SELECT start+count//2 AS id
+FROM pragma_storage_info('fragment_db.reuse_fragment_guard_t')
+WHERE column_name='v' AND segment_type='VARCHAR'
+ORDER BY start
+LIMIT 1
+
+statement ok
+CREATE TEMP TABLE reuse_fragment_compacted_before AS
+SELECT start, count, block_id, block_offset,
+       EXISTS (SELECT 1 FROM fragment_db.reuse_fragment_post_target target
+               WHERE target.id>=start AND target.id<start+count) AS dirty
+FROM pragma_storage_info('fragment_db.reuse_fragment_guard_t')
+WHERE column_name='v' AND segment_type='VARCHAR'
+
+statement ok
+UPDATE fragment_db.reuse_fragment_guard_t AS target
+SET v=md5(concat('post-', target.id::VARCHAR))
+   || md5(concat('post-tail-', target.id::VARCHAR))
+FROM fragment_db.reuse_fragment_post_target AS changes
+WHERE target.id=changes.id
+
+statement ok
+FORCE CHECKPOINT fragment_db
+
+query II
+WITH after_segments AS (
+    SELECT start, count, block_id, block_offset
+    FROM pragma_storage_info('fragment_db.reuse_fragment_guard_t')
+    WHERE column_name='v' AND segment_type='VARCHAR'
+)
+SELECT (count(*) FILTER (WHERE NOT before.dirty AND before.block_id=after.block_id
+                                          AND before.block_offset=after.block_offset)
+            = count(*) FILTER (WHERE NOT before.dirty)
+        AND count(*) FILTER (WHERE NOT before.dirty)>0)::INTEGER,
+       (SELECT count(*) FROM fragment_db.reuse_fragment_guard_t
+        WHERE v IS DISTINCT FROM CASE
+            WHEN id IN (SELECT id FROM fragment_db.reuse_fragment_post_target)
+                THEN md5(concat('post-', id::VARCHAR))
+                  || md5(concat('post-tail-', id::VARCHAR))
+            WHEN id IN (SELECT id FROM fragment_db.reuse_fragment_guarded_targets)
+                THEN md5(concat('guarded-', id::VARCHAR))
+                  || md5(concat('guarded-tail-', id::VARCHAR))
+            ELSE md5(id::VARCHAR) || md5((id+1)::VARCHAR) END)
+FROM reuse_fragment_compacted_before before
+LEFT JOIN after_segments after USING (start, count)
+----
+1	0
+
+statement ok
+SET threads=1
+
+# An explicit codec rewrites the dirty segment and reuses every unchanged segment.
+statement ok
+CREATE TABLE reuse_numeric_t(
+    id BIGINT,
+    v BIGINT USING COMPRESSION UNCOMPRESSED)
+
+statement ok
+INSERT INTO reuse_numeric_t SELECT i, i FROM range(122880) t(i)
+
+statement ok
+FORCE CHECKPOINT
+
+statement ok
+CREATE TEMP TABLE reuse_numeric_before AS
+SELECT start, count, block_id, block_offset,
+       start<=60000 AND start+count>60000 AS dirty
+FROM pragma_storage_info('reuse_numeric_t')
+WHERE column_name='v' AND segment_type='BIGINT'
+
+statement ok
+UPDATE reuse_numeric_t SET v=v+1 WHERE id=60000
+
+statement ok
+FORCE CHECKPOINT
+
+query II
+WITH after_segments AS (
+    SELECT start, count, block_id, block_offset
+    FROM pragma_storage_info('reuse_numeric_t')
+    WHERE column_name='v' AND segment_type='BIGINT'
+)
+SELECT (count(*) FILTER (WHERE NOT before.dirty AND before.block_id=after.block_id
+                                          AND before.block_offset=after.block_offset)
+            = count(*) FILTER (WHERE NOT before.dirty)
+        AND count(*) FILTER (WHERE NOT before.dirty)>0)::INTEGER,
+       (SELECT count(*) FROM reuse_numeric_t
+        WHERE v IS DISTINCT FROM CASE WHEN id=60000 THEN id+1 ELSE id END)
+FROM reuse_numeric_before before
+LEFT JOIN after_segments after USING (start, count)
+----
+1	0
+
+# A partial RowGroup with no reusable tuples takes the whole-column path.
+statement ok
+CREATE TABLE reuse_tiny_row_group_t(
+    id BIGINT,
+    v BIGINT USING COMPRESSION UNCOMPRESSED)
+
+statement ok
+INSERT INTO reuse_tiny_row_group_t VALUES
+    (0, NULL),
+    (1, 10),
+    (2, 20),
+    (3, 30)
+
+statement ok
+FORCE CHECKPOINT
+
+query II
+SELECT (count(*)=1)::INTEGER, max(count)//8
+FROM pragma_storage_info('reuse_tiny_row_group_t')
+WHERE column_name='v' AND segment_type='BIGINT'
+----
+1	0
+
+statement ok
+UPDATE reuse_tiny_row_group_t SET v=v+1 WHERE id=1
+
+statement ok
+FORCE CHECKPOINT
+
+query I
+SELECT (SELECT count(*) FROM reuse_tiny_row_group_t
+        WHERE v IS DISTINCT FROM CASE id
+            WHEN 0 THEN NULL WHEN 1 THEN 11 WHEN 2 THEN 20 ELSE 30 END)
+----
+0
+
+# A validity-only change can reuse the base of a tiny partial RowGroup.
+statement ok
+CREATE TEMP TABLE reuse_tiny_validity_before AS
+SELECT start, count, block_id, block_offset
+FROM pragma_storage_info('reuse_tiny_row_group_t')
+WHERE column_name='v' AND segment_type='BIGINT'
+
+statement ok
+UPDATE reuse_tiny_row_group_t SET v=NULL WHERE id=2
+
+statement ok
+FORCE CHECKPOINT
+
+query II
+WITH after_segments AS (
+    SELECT start, count, block_id, block_offset
+    FROM pragma_storage_info('reuse_tiny_row_group_t')
+    WHERE column_name='v' AND segment_type='BIGINT'
+)
+SELECT (count(*) FILTER (WHERE before.block_id=after.block_id
+                           AND before.block_offset=after.block_offset)=1)::INTEGER,
+       (SELECT count(*) FROM reuse_tiny_row_group_t
+        WHERE v IS DISTINCT FROM CASE id
+            WHEN 0 THEN NULL WHEN 1 THEN 11 WHEN 2 THEN NULL ELSE 30 END)
+FROM reuse_tiny_validity_before before
+LEFT JOIN after_segments after USING (start, count)
+----
+1	0
+
+# A fresh compact layout keeps two separated dirty segments as independent rewrite ranges.
+statement ok
+CREATE TABLE reuse_auto_disjoint_t(id BIGINT, v VARCHAR)
+
+statement ok
+INSERT INTO reuse_auto_disjoint_t
+SELECT i, concat('value-', i::VARCHAR, '-', repeat(md5(i::VARCHAR), 2))
+FROM range(122880) t(i)
+
+statement ok
+FORCE CHECKPOINT
+
+statement ok
+CREATE TABLE reuse_auto_disjoint_targets AS
+WITH segments AS (
+    SELECT start, count, row_number() OVER (ORDER BY start) AS segment_no,
+           count(*) OVER () AS segment_count
+    FROM pragma_storage_info('reuse_auto_disjoint_t')
+    WHERE column_name='v' AND segment_type='VARCHAR'
+)
+SELECT start+count//2 AS id, segment_count
+FROM segments
+WHERE segment_no=1 OR segment_no=segment_count
+
+query I
+SELECT (count(*)=2 AND min(segment_count)>=3)::INTEGER
+FROM reuse_auto_disjoint_targets
+----
+1
+
+statement ok
+CREATE TEMP TABLE reuse_auto_disjoint_before AS
+SELECT start, count, block_id, block_offset,
+       EXISTS (SELECT 1 FROM reuse_auto_disjoint_targets targets
+               WHERE targets.id>=start AND targets.id<start+count) AS dirty
+FROM pragma_storage_info('reuse_auto_disjoint_t')
+WHERE column_name='v' AND segment_type='VARCHAR'
+
+statement ok
+UPDATE reuse_auto_disjoint_t AS target
+SET v=concat('point-', target.id::VARCHAR)
+FROM reuse_auto_disjoint_targets changes
+WHERE target.id=changes.id
+
+statement ok
+FORCE CHECKPOINT
+
+query II
+WITH after_segments AS (
+    SELECT start, count, block_id, block_offset
+    FROM pragma_storage_info('reuse_auto_disjoint_t')
+    WHERE column_name='v' AND segment_type='VARCHAR'
+)
+SELECT (count(*) FILTER (WHERE NOT before.dirty AND before.block_id=after.block_id
+                                          AND before.block_offset=after.block_offset)
+            = count(*) FILTER (WHERE NOT before.dirty)
+        AND count(*) FILTER (WHERE NOT before.dirty)>0)::INTEGER,
+       (SELECT count(*) FROM reuse_auto_disjoint_t
+        WHERE v IS DISTINCT FROM CASE
+            WHEN id IN (SELECT id FROM reuse_auto_disjoint_targets) THEN concat('point-', id::VARCHAR)
+            ELSE concat('value-', id::VARCHAR, '-', repeat(md5(id::VARCHAR), 2)) END)
+FROM reuse_auto_disjoint_before before
+LEFT JOIN after_segments after USING (start, count)
+----
+1	0
+
+# AUTO can retain and rewrite ranges with different physical codecs.
+statement ok
+CREATE TABLE reuse_mixed_codec_t(id BIGINT, v UBIGINT)
+
+statement ok
+INSERT INTO reuse_mixed_codec_t SELECT i, hash(i) FROM range(122880) t(i)
+
+statement ok
+FORCE CHECKPOINT
+
+statement ok
+CREATE TABLE reuse_mixed_codec_target AS
+SELECT start, count
+FROM pragma_storage_info('reuse_mixed_codec_t')
+WHERE column_name='v' AND segment_type='UBIGINT'
+ORDER BY start
+LIMIT 1
+
+query I
+SELECT (count(*)>1 AND count(DISTINCT compression)=1)::INTEGER
+FROM pragma_storage_info('reuse_mixed_codec_t')
+WHERE column_name='v' AND segment_type='UBIGINT'
+----
+1
+
+statement ok
+CREATE TEMP TABLE reuse_mixed_codec_before AS
+SELECT start, count, block_id, block_offset,
+       start=(SELECT start FROM reuse_mixed_codec_target) AS dirty
+FROM pragma_storage_info('reuse_mixed_codec_t')
+WHERE column_name='v' AND segment_type='UBIGINT'
+
+statement ok
+UPDATE reuse_mixed_codec_t
+SET v=7
+WHERE id>=(SELECT start FROM reuse_mixed_codec_target)
+  AND id<(SELECT start+count FROM reuse_mixed_codec_target)
+
+statement ok
+FORCE CHECKPOINT
+
+query IIII
+WITH after_segments AS (
+    SELECT start, count, block_id, block_offset, compression
+    FROM pragma_storage_info('reuse_mixed_codec_t')
+    WHERE column_name='v' AND segment_type='UBIGINT'
+)
+SELECT (count(*) FILTER (WHERE NOT before.dirty AND before.block_id=after.block_id
+                                          AND before.block_offset=after.block_offset)
+            = count(*) FILTER (WHERE NOT before.dirty)
+        AND count(*) FILTER (WHERE NOT before.dirty)>0)::INTEGER,
+       (SELECT count(DISTINCT compression) FROM after_segments),
+       (SELECT count(*) FROM after_segments WHERE compression='Constant'),
+       (SELECT count(*) FROM reuse_mixed_codec_t
+        WHERE v IS DISTINCT FROM CASE
+            WHEN id>=(SELECT start FROM reuse_mixed_codec_target)
+             AND id<(SELECT start+count FROM reuse_mixed_codec_target) THEN 7::UBIGINT
+            ELSE hash(id) END)
+FROM reuse_mixed_codec_before before
+LEFT JOIN after_segments after USING (start, count)
+----
+1	2	1	0
+
+# Use stable multi-segment data to cover both sides of the local rewrite threshold.
+statement ok
+CREATE TABLE reuse_threshold_t(
+    id BIGINT,
+    v VARCHAR USING COMPRESSION UNCOMPRESSED)
+
+statement ok
+INSERT INTO reuse_threshold_t
+SELECT i, concat('threshold-', i::VARCHAR, '-', repeat(md5(i::VARCHAR), 2))
+FROM range(122880) t(i)
+
+statement ok
+FORCE CHECKPOINT
+
+# A dense rewrite remains local while at least one eighth of the tuples can be reused.
+statement ok
+CREATE TEMP TABLE reuse_threshold_dense_boundary AS
+SELECT max(start) AS boundary
+FROM pragma_storage_info('reuse_threshold_t')
+WHERE column_name='v' AND segment_type='VARCHAR' AND start<=98304
+
+query I
+SELECT ((SELECT boundary FROM reuse_threshold_dense_boundary)>=61440
+        AND 122880-(SELECT boundary FROM reuse_threshold_dense_boundary)>=122880//8)::INTEGER
+----
+1
+
+statement ok
+CREATE TEMP TABLE reuse_threshold_dense_before AS
+SELECT start, count, block_id, block_offset,
+       start<(SELECT boundary FROM reuse_threshold_dense_boundary) AS dirty
+FROM pragma_storage_info('reuse_threshold_t')
+WHERE column_name='v' AND segment_type='VARCHAR'
+
+statement ok
+UPDATE reuse_threshold_t
+SET v=concat('dense-profit-', id::VARCHAR)
+WHERE id<(SELECT boundary FROM reuse_threshold_dense_boundary)
+
+statement ok
+FORCE CHECKPOINT
+
+query II
+WITH after_segments AS (
+    SELECT start, count, block_id, block_offset
+    FROM pragma_storage_info('reuse_threshold_t')
+    WHERE column_name='v' AND segment_type='VARCHAR'
+)
+SELECT (count(*) FILTER (WHERE NOT before.dirty AND before.block_id=after.block_id
+                                          AND before.block_offset=after.block_offset)
+            = count(*) FILTER (WHERE NOT before.dirty)
+        AND count(*) FILTER (WHERE NOT before.dirty)>0)::INTEGER,
+       (SELECT count(*) FROM reuse_threshold_t
+        WHERE v IS DISTINCT FROM CASE
+            WHEN id<(SELECT boundary FROM reuse_threshold_dense_boundary)
+                THEN concat('dense-profit-', id::VARCHAR)
+            ELSE concat('threshold-', id::VARCHAR, '-', repeat(md5(id::VARCHAR), 2)) END)
+FROM reuse_threshold_dense_before before
+LEFT JOIN after_segments after USING (start, count)
+----
+1	0
+
+# Rewriting all but a suffix smaller than one eighth takes the whole-column path.
+statement ok
+CREATE TEMP TABLE reuse_threshold_small_suffix_boundary AS
+SELECT max(start) AS boundary
+FROM pragma_storage_info('reuse_threshold_t')
+WHERE column_name='v' AND segment_type='VARCHAR'
+
+query I
+SELECT ((SELECT boundary FROM reuse_threshold_small_suffix_boundary)<122880
+        AND 122880-(SELECT boundary FROM reuse_threshold_small_suffix_boundary)<122880//8)::INTEGER
+----
+1
+
+statement ok
+CREATE TEMP TABLE reuse_threshold_small_suffix_before AS
+SELECT block_id, block_offset
+FROM pragma_storage_info('reuse_threshold_t')
+WHERE column_name='v' AND segment_type='VARCHAR'
+
+statement ok
+UPDATE reuse_threshold_t
+SET v=concat('dense-fallback-', id::VARCHAR)
+WHERE id<(SELECT boundary FROM reuse_threshold_small_suffix_boundary)
+
+statement ok
+FORCE CHECKPOINT
+
+query II
+SELECT (SELECT count(*)
+        FROM reuse_threshold_small_suffix_before before
+        JOIN pragma_storage_info('reuse_threshold_t') after USING (block_id, block_offset)
+        WHERE after.column_name='v' AND after.segment_type='VARCHAR'),
+       (SELECT count(*) FROM reuse_threshold_t
+        WHERE v IS DISTINCT FROM CASE
+            WHEN id<(SELECT boundary FROM reuse_threshold_small_suffix_boundary)
+                THEN concat('dense-fallback-', id::VARCHAR)
+            ELSE concat('threshold-', id::VARCHAR, '-', repeat(md5(id::VARCHAR), 2)) END)
+----
+0	0
+
+# A validity-only update preserves the complete base and independently rewrites validity.
+statement ok
+CREATE TABLE reuse_validity_t(id BIGINT, v VARCHAR)
+
+statement ok
+INSERT INTO reuse_validity_t
+SELECT i, CASE WHEN i=60000 THEN repeat('x', 300000) ELSE concat('base-', i::VARCHAR) END
+FROM range(122880) t(i)
+
+statement ok
+FORCE CHECKPOINT
+
+statement ok
+CREATE TEMP TABLE reuse_validity_only_before AS
+SELECT start, count, block_id, block_offset
+FROM pragma_storage_info('reuse_validity_t')
+WHERE column_name='v' AND segment_type='VARCHAR'
+
+statement ok
+UPDATE reuse_validity_t SET v=NULL WHERE id<30720
+
+statement ok
+FORCE CHECKPOINT
+
+query III
+WITH after_segments AS (
+    SELECT start, count, block_id, block_offset
+    FROM pragma_storage_info('reuse_validity_t')
+    WHERE column_name='v' AND segment_type='VARCHAR'
+)
+SELECT (count(*) FILTER (WHERE before.block_id=after.block_id
+                           AND before.block_offset=after.block_offset)
+            = (SELECT count(*) FROM reuse_validity_only_before))::INTEGER,
+       (SELECT count(*) FROM reuse_validity_t WHERE v IS NULL),
+       (SELECT count(*) FROM reuse_validity_t
+        WHERE v IS DISTINCT FROM CASE WHEN id<30720 THEN NULL
+            WHEN id=60000 THEN repeat('x', 300000) ELSE concat('base-', id::VARCHAR) END)
+FROM reuse_validity_only_before before
+LEFT JOIN after_segments after USING (start, count)
+----
+1	30720	0
+
+# NULL-to-value updates rewrite the affected base range and retain its clean suffix.
+statement ok
+CREATE TEMP TABLE reuse_validity_restore_before AS
+SELECT start, count, block_id, block_offset, start<30720 AS dirty
+FROM pragma_storage_info('reuse_validity_t')
+WHERE column_name='v' AND segment_type='VARCHAR'
+
+statement ok
+UPDATE reuse_validity_t SET v=concat('restored-', id::VARCHAR) WHERE v IS NULL
+
+statement ok
+FORCE CHECKPOINT
+
+query II
+WITH after_segments AS (
+    SELECT start, count, block_id, block_offset
+    FROM pragma_storage_info('reuse_validity_t')
+    WHERE column_name='v' AND segment_type='VARCHAR'
+)
+SELECT (count(*) FILTER (WHERE NOT before.dirty AND before.block_id=after.block_id
+                                          AND before.block_offset=after.block_offset)
+            = count(*) FILTER (WHERE NOT before.dirty)
+        AND count(*) FILTER (WHERE NOT before.dirty)>0)::INTEGER,
+       (SELECT count(*) FROM reuse_validity_t
+        WHERE v IS DISTINCT FROM CASE WHEN id<30720 THEN concat('restored-', id::VARCHAR)
+            WHEN id=60000 THEN repeat('x', 300000) ELSE concat('base-', id::VARCHAR) END)
+FROM reuse_validity_restore_before before
+LEFT JOIN after_segments after USING (start, count)
+----
+1	0
+
+# A global force setting retains the original whole-column behavior.
+statement ok
+CREATE TABLE reuse_force_t(id BIGINT, v BIGINT)
+
+statement ok
+INSERT INTO reuse_force_t SELECT i, i//64 FROM range(122880) t(i)
+
+statement ok
+FORCE CHECKPOINT
+
+statement ok
+CREATE TEMP TABLE reuse_force_before AS
+SELECT block_id, block_offset
+FROM pragma_storage_info('reuse_force_t')
+WHERE column_name='v' AND segment_type='BIGINT'
+
+statement ok
+SET force_compression='rle'
+
+statement ok
+UPDATE reuse_force_t SET v=-1 WHERE id=60000
+
+statement ok
+FORCE CHECKPOINT
+
+query II
+SELECT (SELECT count(*)
+        FROM reuse_force_before before
+        JOIN pragma_storage_info('reuse_force_t') after USING (block_id, block_offset)
+        WHERE after.column_name='v' AND after.segment_type='BIGINT'),
+       (SELECT count(*) FROM reuse_force_t
+        WHERE v IS DISTINCT FROM CASE WHEN id=60000 THEN -1 ELSE id//64 END)
+----
+0	0
+
+statement ok
+RESET force_compression
+
+# Empty validity means the base owns NULL information and disables reuse.
+statement ok
+ATTACH '{TEST_DIR}/reuse_empty_validity.db' AS empty_db (STORAGE_VERSION 'v1.3.0', BLOCK_SIZE 16384)
+
+statement ok
+SET force_compression='dict_fsst'
+
+statement ok
+CREATE TABLE empty_db.reuse_empty_t(id BIGINT, v VARCHAR)
+
+statement ok
+INSERT INTO empty_db.reuse_empty_t
+SELECT i, CASE WHEN i=1000 THEN NULL ELSE concat('value-', (i%4)::VARCHAR) END
+FROM range(122880) t(i)
+
+statement ok
+FORCE CHECKPOINT empty_db
+
+statement ok
+RESET force_compression
+
+query II
+SELECT (count(*) FILTER (WHERE segment_type='VARCHAR' AND compression='DICT_FSST')
+            = count(*) FILTER (WHERE segment_type='VARCHAR')
+        AND count(*) FILTER (WHERE segment_type='VARCHAR')>0)::INTEGER,
+       count(*) FILTER (WHERE segment_type='VALIDITY' AND compression='Empty Validity')
+FROM pragma_storage_info('empty_db.reuse_empty_t')
+----
+1	1
+
+statement ok
+CREATE TEMP TABLE reuse_empty_before AS
+SELECT block_id, block_offset
+FROM pragma_storage_info('empty_db.reuse_empty_t')
+WHERE column_name='v' AND segment_type='VARCHAR'
+
+statement ok
+UPDATE empty_db.reuse_empty_t SET v=NULL WHERE id=1
+
+statement ok
+FORCE CHECKPOINT empty_db
+
+query III
+SELECT (SELECT count(*)
+        FROM reuse_empty_before before
+        JOIN pragma_storage_info('empty_db.reuse_empty_t') after USING (block_id, block_offset)
+        WHERE after.column_name='v' AND after.segment_type='VARCHAR'),
+       (SELECT count(*) FROM empty_db.reuse_empty_t WHERE v IS NULL),
+       (SELECT count(*) FROM empty_db.reuse_empty_t
+        WHERE v IS DISTINCT FROM CASE WHEN id IN (1, 1000) THEN NULL
+                                      ELSE concat('value-', (id%4)::VARCHAR) END)
+----
+0	2	0
+
+# Parallel RowGroups keep base and validity decisions local to each checkpoint task.
+statement ok
+SET threads=8
+
+statement ok
+CREATE TABLE reuse_parallel_t(id BIGINT, v VARCHAR)
+
+statement ok
+INSERT INTO reuse_parallel_t
+SELECT i, concat('parallel-', i::VARCHAR, '-', repeat(md5(i::VARCHAR), 2))
+FROM range(983040) t(i)
+
+statement ok
+FORCE CHECKPOINT
+
+statement ok
+CREATE TEMP TABLE reuse_parallel_validity_before AS
+SELECT row_group_id, start, count, block_id, block_offset
+FROM pragma_storage_info('reuse_parallel_t')
+WHERE column_name='v' AND segment_type='VARCHAR'
+
+statement ok
+UPDATE reuse_parallel_t SET v=NULL WHERE id%122880=1
+
+statement ok
+FORCE CHECKPOINT
+
+query III
+WITH after_segments AS (
+    SELECT row_group_id, start, count, block_id, block_offset
+    FROM pragma_storage_info('reuse_parallel_t')
+    WHERE column_name='v' AND segment_type='VARCHAR'
+)
+SELECT (count(*) FILTER (WHERE before.block_id=after.block_id
+                           AND before.block_offset=after.block_offset)
+            = (SELECT count(*) FROM reuse_parallel_validity_before))::INTEGER,
+       (SELECT count(*) FROM reuse_parallel_t WHERE v IS NULL),
+       (SELECT count(*) FROM reuse_parallel_t
+        WHERE v IS DISTINCT FROM CASE WHEN id%122880=1 THEN NULL
+            ELSE concat('parallel-', id::VARCHAR, '-', repeat(md5(id::VARCHAR), 2)) END)
+FROM reuse_parallel_validity_before before
+LEFT JOIN after_segments after USING (row_group_id, start, count)
+----
+1	8	0

--- a/test/sql/storage/compression/reuse_explicit_compression_segments_edge_cases.test
+++ b/test/sql/storage/compression/reuse_explicit_compression_segments_edge_cases.test
@@ -1,0 +1,412 @@
+# name: test/sql/storage/compression/reuse_explicit_compression_segments_edge_cases.test
+# description: Test update and statistics edge cases for persistent segment reuse
+# group: [compression]
+
+require noforcestorage
+
+require no_alternative_verify
+
+require vector_size 2048
+
+load {TEST_DIR}/reuse_explicit_compression_segments_edge_cases.db readwrite v1.2.0
+
+statement ok
+SET checkpoint_threshold='9999GB'
+
+statement ok
+SET debug_verify_blocks=true
+
+# A 16 KiB Uncompressed BIGINT segment holds 2047 rows, so its second Segment
+# contains both the last tuple of vector 0 and the first tuple of vector 1.
+statement ok
+ATTACH '{TEST_DIR}/reuse_vector_boundary.db' AS boundary_db
+    (STORAGE_VERSION 'v1.2.0', BLOCK_SIZE 16384)
+
+statement ok
+CREATE TABLE boundary_db.vector_boundary_t(
+    id BIGINT,
+    v BIGINT USING COMPRESSION UNCOMPRESSED)
+
+statement ok
+INSERT INTO boundary_db.vector_boundary_t SELECT i, i FROM range(122880) t(i)
+
+statement ok
+FORCE CHECKPOINT boundary_db
+
+query I
+SELECT count(*)
+FROM pragma_storage_info('boundary_db.vector_boundary_t')
+WHERE column_name='v' AND segment_type='BIGINT' AND start=2047 AND count=2047
+----
+1
+
+# Updating the right Segment at rows 2047/2048 covers both sides of a vector boundary.
+statement ok
+CREATE TEMP TABLE vector_start_before AS
+SELECT start, count, block_id, block_offset
+FROM pragma_storage_info('boundary_db.vector_boundary_t')
+WHERE column_name='v' AND segment_type='BIGINT' AND start IN (0, 2047)
+
+statement ok
+UPDATE boundary_db.vector_boundary_t SET v=-id WHERE id IN (2047, 2048)
+
+statement ok
+FORCE CHECKPOINT boundary_db
+
+query III
+WITH after_segments AS (
+    SELECT start, count, block_id, block_offset
+    FROM pragma_storage_info('boundary_db.vector_boundary_t')
+    WHERE column_name='v' AND segment_type='BIGINT' AND start IN (0, 2047)
+)
+SELECT count(*) FILTER (WHERE before.start=0
+                         AND before.block_id=after.block_id
+                         AND before.block_offset=after.block_offset),
+	       count(*) FILTER (WHERE before.start=2047
+                         AND (before.block_id!=after.block_id
+                              OR before.block_offset!=after.block_offset)),
+       (SELECT count(*) FROM boundary_db.vector_boundary_t
+	        WHERE v IS DISTINCT FROM CASE WHEN id IN (2047, 2048) THEN -id ELSE id END)
+FROM vector_start_before before
+JOIN after_segments after USING (start, count)
+----
+1	1	0
+
+# Updating the last tuple of the left Segment must not dirty the right Segment.
+statement ok
+CREATE TEMP TABLE vector_end_before AS
+SELECT start, count, block_id, block_offset
+FROM pragma_storage_info('boundary_db.vector_boundary_t')
+WHERE column_name='v' AND segment_type='BIGINT' AND start IN (0, 2047)
+
+statement ok
+UPDATE boundary_db.vector_boundary_t SET v=-id WHERE id=2046
+
+statement ok
+FORCE CHECKPOINT boundary_db
+
+query III
+WITH after_segments AS (
+    SELECT start, count, block_id, block_offset
+    FROM pragma_storage_info('boundary_db.vector_boundary_t')
+    WHERE column_name='v' AND segment_type='BIGINT' AND start IN (0, 2047)
+)
+SELECT count(*) FILTER (WHERE before.start=0
+                         AND (before.block_id!=after.block_id
+                              OR before.block_offset!=after.block_offset)),
+	       count(*) FILTER (WHERE before.start=2047
+                         AND before.block_id=after.block_id
+                         AND before.block_offset=after.block_offset),
+       (SELECT count(*) FROM boundary_db.vector_boundary_t
+	        WHERE v IS DISTINCT FROM CASE WHEN id IN (2046, 2047, 2048) THEN -id ELSE id END)
+FROM vector_end_before before
+JOIN after_segments after USING (start, count)
+----
+1	1	0
+
+# A first no-op update does not create an UpdateSegment entry.
+statement ok
+CREATE TEMP TABLE noop_before AS
+SELECT start, count, block_id, block_offset
+FROM pragma_storage_info('boundary_db.vector_boundary_t')
+WHERE column_name='v' AND segment_type='BIGINT'
+
+statement ok
+UPDATE boundary_db.vector_boundary_t SET v=v WHERE id=4096
+
+statement ok
+FORCE CHECKPOINT boundary_db
+
+query II
+WITH after_segments AS (
+    SELECT start, count, block_id, block_offset
+    FROM pragma_storage_info('boundary_db.vector_boundary_t')
+    WHERE column_name='v' AND segment_type='BIGINT'
+)
+SELECT count(*) FILTER (WHERE before.block_id=after.block_id
+                         AND before.block_offset=after.block_offset)=count(*),
+	       (SELECT count(*) FROM boundary_db.vector_boundary_t
+	        WHERE v IS DISTINCT FROM CASE WHEN id IN (2046, 2047, 2048) THEN -id ELSE id END)
+FROM noop_before before
+LEFT JOIN after_segments after USING (start, count)
+----
+true	0
+
+# Rollback may leave a conservative dirty marker, but it must never publish the rolled-back value.
+statement ok
+BEGIN TRANSACTION
+
+statement ok
+UPDATE boundary_db.vector_boundary_t SET v=-6145 WHERE id=6144
+
+statement ok
+ROLLBACK
+
+statement ok
+FORCE CHECKPOINT boundary_db
+
+query I
+SELECT count(*) FROM boundary_db.vector_boundary_t
+WHERE v IS DISTINCT FROM CASE WHEN id IN (2046, 2047, 2048) THEN -id ELSE id END
+----
+0
+
+# Multiple updates of one tuple keep one sorted tuple id and checkpoint the latest value.
+statement ok
+BEGIN TRANSACTION
+
+statement ok
+UPDATE boundary_db.vector_boundary_t SET v=-4096 WHERE id=4096
+
+statement ok
+UPDATE boundary_db.vector_boundary_t SET v=-4097 WHERE id=4096
+
+statement ok
+UPDATE boundary_db.vector_boundary_t SET v=-4097 WHERE id=4096
+
+statement ok
+COMMIT
+
+statement ok
+FORCE CHECKPOINT boundary_db
+
+query I
+SELECT count(*) FROM boundary_db.vector_boundary_t
+WHERE v IS DISTINCT FROM CASE
+	    WHEN id IN (2046, 2047, 2048) THEN -id
+    WHEN id=4096 THEN -4097
+    ELSE id END
+----
+0
+
+# The root UpdateInfo keeps the sorted union of tuple ids across committed
+# versions. Exact range checks must find both sides of a Segment boundary.
+statement ok
+CREATE TABLE boundary_db.version_chain_t(
+    id BIGINT,
+    v BIGINT USING COMPRESSION UNCOMPRESSED)
+
+statement ok
+INSERT INTO boundary_db.version_chain_t SELECT i, i FROM range(122880) t(i)
+
+statement ok
+FORCE CHECKPOINT boundary_db
+
+statement ok
+CREATE TEMP TABLE version_chain_before AS
+SELECT start, count, block_id, block_offset
+FROM pragma_storage_info('boundary_db.version_chain_t')
+WHERE column_name='v' AND segment_type='BIGINT' AND start IN (0, 2047)
+
+statement ok
+BEGIN TRANSACTION
+
+statement ok
+UPDATE boundary_db.version_chain_t SET v=-12046 WHERE id=2046
+
+statement ok
+COMMIT
+
+statement ok
+BEGIN TRANSACTION
+
+statement ok
+UPDATE boundary_db.version_chain_t SET v=-12047 WHERE id=2047
+
+statement ok
+COMMIT
+
+statement ok
+FORCE CHECKPOINT boundary_db
+
+query III
+WITH after_segments AS (
+    SELECT start, count, block_id, block_offset
+    FROM pragma_storage_info('boundary_db.version_chain_t')
+    WHERE column_name='v' AND segment_type='BIGINT' AND start IN (0, 2047)
+)
+SELECT count(*) FILTER (WHERE before.block_id!=after.block_id
+                         OR before.block_offset!=after.block_offset),
+       count(*),
+       (SELECT count(*) FROM boundary_db.version_chain_t
+        WHERE v IS DISTINCT FROM CASE
+            WHEN id=2046 THEN -12046
+            WHEN id=2047 THEN -12047
+            ELSE id END)
+FROM version_chain_before before
+JOIN after_segments after USING (start, count)
+----
+2	2	0
+
+# Hiding the old minimum and maximum only changes validity; every base Segment is reusable.
+statement ok
+CREATE TABLE validity_stats_t(
+    id BIGINT,
+    v BIGINT USING COMPRESSION UNCOMPRESSED)
+
+statement ok
+INSERT INTO validity_stats_t SELECT i, i FROM range(122880) t(i)
+
+statement ok
+FORCE CHECKPOINT
+
+statement ok
+CREATE TEMP TABLE validity_stats_before AS
+SELECT start, count, block_id, block_offset
+FROM pragma_storage_info('validity_stats_t')
+WHERE column_name='v' AND segment_type='BIGINT'
+
+statement ok
+UPDATE validity_stats_t SET v=NULL WHERE id IN (0, 122879)
+
+statement ok
+FORCE CHECKPOINT
+
+query I
+WITH after_segments AS (
+    SELECT start, count, block_id, block_offset
+    FROM pragma_storage_info('validity_stats_t')
+    WHERE column_name='v' AND segment_type='BIGINT'
+)
+SELECT (count(*) FILTER (WHERE before.block_id=after.block_id
+                          AND before.block_offset=after.block_offset)=count(*))::INTEGER
+FROM validity_stats_before before
+LEFT JOIN after_segments after USING (start, count)
+----
+1
+
+query IIII
+SELECT min(v), max(v), count(*) FILTER (WHERE v IS NULL), count(*) FILTER (WHERE v IS NOT NULL)
+FROM validity_stats_t
+----
+1	122878	2	122878
+
+query IIIII
+SELECT count(*) FILTER (WHERE v=0),
+       count(*) FILTER (WHERE v=1),
+       count(*) FILTER (WHERE v=122879),
+       count(*) FILTER (WHERE v<2),
+       count(*) FILTER (WHERE v>=122878)
+FROM validity_stats_t
+----
+0	1	0	1	1
+
+# Restoring NULLs outside the old range rewrites only the affected base Segments.
+statement ok
+CREATE TEMP TABLE validity_restore_before AS
+SELECT start, count, block_id, block_offset,
+	       start=0 AS dirty
+FROM pragma_storage_info('validity_stats_t')
+WHERE column_name='v' AND segment_type='BIGINT'
+
+statement ok
+UPDATE validity_stats_t SET v=-1000 WHERE id=0
+
+statement ok
+FORCE CHECKPOINT
+
+query II
+WITH after_segments AS (
+    SELECT start, count, block_id, block_offset
+    FROM pragma_storage_info('validity_stats_t')
+    WHERE column_name='v' AND segment_type='BIGINT'
+)
+SELECT (count(*) FILTER (WHERE NOT before.dirty
+                          AND before.block_id=after.block_id
+                          AND before.block_offset=after.block_offset)
+            = count(*) FILTER (WHERE NOT before.dirty))::INTEGER,
+       (count(*) FILTER (WHERE before.dirty
+                          AND before.block_id=after.block_id
+                          AND before.block_offset=after.block_offset)=0)::INTEGER
+FROM validity_restore_before before
+LEFT JOIN after_segments after USING (start, count)
+----
+1	1
+
+statement ok
+CREATE TEMP TABLE validity_restore_max_before AS
+SELECT start, count, block_id, block_offset,
+	       start+count=122880 AS dirty
+FROM pragma_storage_info('validity_stats_t')
+WHERE column_name='v' AND segment_type='BIGINT'
+
+statement ok
+UPDATE validity_stats_t SET v=999999 WHERE id=122879
+
+statement ok
+FORCE CHECKPOINT
+
+query II
+WITH after_segments AS (
+	SELECT start, count, block_id, block_offset
+	FROM pragma_storage_info('validity_stats_t')
+	WHERE column_name='v' AND segment_type='BIGINT'
+)
+SELECT (count(*) FILTER (WHERE NOT before.dirty
+	                      AND before.block_id=after.block_id
+	                      AND before.block_offset=after.block_offset)
+	        = count(*) FILTER (WHERE NOT before.dirty))::INTEGER,
+	   (count(*) FILTER (WHERE before.dirty
+	                      AND before.block_id=after.block_id
+	                      AND before.block_offset=after.block_offset)=0)::INTEGER
+FROM validity_restore_max_before before
+LEFT JOIN after_segments after USING (start, count)
+----
+1	1
+
+query IIIIII
+SELECT min(v), max(v),
+       count(*) FILTER (WHERE v=-1000),
+       count(*) FILTER (WHERE v=999999),
+       count(*) FILTER (WHERE v<0),
+       count(*) FILTER (WHERE v>122879)
+FROM validity_stats_t
+----
+-1000	999999	1	1	1	1
+
+restart
+
+statement ok
+ATTACH '{TEST_DIR}/reuse_vector_boundary.db' AS boundary_db
+
+statement ok
+SET debug_verify_blocks=true
+
+statement ok
+FORCE CHECKPOINT
+
+statement ok
+FORCE CHECKPOINT boundary_db
+
+query II
+SELECT (SELECT count(*) FROM boundary_db.vector_boundary_t
+        WHERE v IS DISTINCT FROM CASE
+	            WHEN id IN (2046, 2047, 2048) THEN -id
+            WHEN id=4096 THEN -4097
+            ELSE id END),
+       (SELECT count(*) FROM validity_stats_t
+        WHERE v IS DISTINCT FROM CASE
+            WHEN id=0 THEN -1000
+            WHEN id=122879 THEN 999999
+            ELSE id END)
+----
+0	0
+
+query I
+SELECT count(*) FROM boundary_db.version_chain_t
+WHERE v IS DISTINCT FROM CASE
+    WHEN id=2046 THEN -12046
+    WHEN id=2047 THEN -12047
+    ELSE id END
+----
+0
+
+query IIIIII
+SELECT min(v), max(v),
+       count(*) FILTER (WHERE v=-1000),
+       count(*) FILTER (WHERE v=999999),
+       count(*) FILTER (WHERE v BETWEEN 1 AND 2),
+       count(*) FILTER (WHERE v IS NULL)
+FROM validity_stats_t
+----
+-1000	999999	1	1	2	0

--- a/test/sql/storage/compression/reuse_explicit_compression_segments_recovery.test_slow
+++ b/test/sql/storage/compression/reuse_explicit_compression_segments_recovery.test_slow
@@ -1,0 +1,491 @@
+# name: test/sql/storage/compression/reuse_explicit_compression_segments_recovery.test_slow
+# description: Test auxiliary blocks, checkpoint recovery, and concurrent updates with segment reuse
+# group: [compression]
+
+require noforcestorage
+
+require no_alternative_verify
+
+require vector_size 2048
+
+load {TEST_DIR}/reuse_explicit_compression_segments_recovery.db readwrite v1.2.0
+
+statement ok
+SET checkpoint_threshold='9999GB'
+
+statement ok
+SET debug_verify_blocks=true
+
+statement ok
+SET threads=8
+
+# ZSTD owns additional pages through its ColumnSegment state. A validity-only
+# update must retain both the main Block and every additional Block.
+statement ok
+SET force_compression='zstd'
+
+statement ok
+CREATE TABLE zstd_aux_t(
+    id BIGINT,
+    v VARCHAR)
+
+statement ok
+INSERT INTO zstd_aux_t
+SELECT i, md5(i::VARCHAR)
+       || md5((i+16384)::VARCHAR)
+       || md5((i+32768)::VARCHAR)
+       || md5((i+49152)::VARCHAR)
+FROM range(16384) t(i)
+
+statement ok
+FORCE CHECKPOINT
+
+statement ok
+RESET force_compression
+
+query II
+SELECT count(*), count(*) FILTER (WHERE len(additional_block_ids)>0)
+FROM pragma_storage_info('zstd_aux_t')
+WHERE column_name='v' AND segment_type='VARCHAR' AND compression='ZSTD'
+----
+1	1
+
+statement ok
+CREATE TEMP TABLE zstd_aux_before AS
+SELECT start, count, block_id, block_offset, additional_block_ids
+FROM pragma_storage_info('zstd_aux_t')
+WHERE column_name='v' AND segment_type='VARCHAR' AND compression='ZSTD'
+
+statement ok
+UPDATE zstd_aux_t SET v=NULL WHERE id=0
+
+statement ok
+FORCE CHECKPOINT
+
+query III
+WITH after_segment AS (
+    SELECT start, count, block_id, block_offset, additional_block_ids
+    FROM pragma_storage_info('zstd_aux_t')
+    WHERE column_name='v' AND segment_type='VARCHAR' AND compression='ZSTD'
+)
+SELECT count(*) FILTER (WHERE before.block_id=after.block_id
+                         AND before.block_offset=after.block_offset),
+       count(*) FILTER (WHERE before.additional_block_ids=after.additional_block_ids),
+       (SELECT count(*) FROM zstd_aux_t WHERE v IS NULL)
+FROM zstd_aux_before before
+JOIN after_segment after USING (start, count)
+----
+1	1	1
+
+# A data update rewrites the ZSTD Segment and replaces its auxiliary Block set.
+statement ok
+CREATE TEMP TABLE zstd_rewrite_before AS
+SELECT start, count, block_id, block_offset, additional_block_ids
+FROM pragma_storage_info('zstd_aux_t')
+WHERE column_name='v' AND segment_type='VARCHAR' AND compression='ZSTD'
+
+statement ok
+SET force_compression='zstd'
+
+statement ok
+UPDATE zstd_aux_t SET v='zstd-restored-0' WHERE id=0
+
+statement ok
+FORCE CHECKPOINT
+
+statement ok
+RESET force_compression
+
+query IIII
+WITH after_segment AS (
+    SELECT start, count, block_id, block_offset, additional_block_ids
+    FROM pragma_storage_info('zstd_aux_t')
+    WHERE column_name='v' AND segment_type='VARCHAR' AND compression='ZSTD'
+)
+SELECT count(*) FILTER (WHERE before.block_id!=after.block_id
+                         OR before.block_offset!=after.block_offset),
+       count(*) FILTER (WHERE before.additional_block_ids!=after.additional_block_ids),
+       count(*) FILTER (WHERE len(after.additional_block_ids)>0),
+       (SELECT count(*) FROM zstd_aux_t
+        WHERE v IS DISTINCT FROM CASE WHEN id=0 THEN 'zstd-restored-0'
+            ELSE md5(id::VARCHAR)
+              || md5((id+16384)::VARCHAR)
+              || md5((id+32768)::VARCHAR)
+              || md5((id+49152)::VARCHAR) END)
+FROM zstd_rewrite_before before
+JOIN after_segment after USING (start, count)
+----
+1	1	1	0
+
+# FORCE CHECKPOINT waits for an updater that already owns the shared checkpoint
+# lock, then includes the committed update in the checkpoint it writes.
+statement ok
+CREATE TABLE snapshot_reuse_t(
+    id BIGINT,
+    v BIGINT USING COMPRESSION UNCOMPRESSED)
+
+statement ok
+INSERT INTO snapshot_reuse_t SELECT i, i FROM range(122880) t(i)
+
+statement ok
+FORCE CHECKPOINT
+
+statement ok
+CREATE TEMP TABLE snapshot_wait_before AS
+SELECT start, count, block_id, block_offset,
+       start<=60000 AND start+count>60000 AS dirty
+FROM pragma_storage_info('snapshot_reuse_t')
+WHERE column_name='v' AND segment_type='BIGINT'
+
+concurrentloop threadid 0 2
+
+onlyif threadid=1
+statement ok
+BEGIN TRANSACTION
+
+onlyif threadid=1
+statement ok
+UPDATE snapshot_reuse_t SET v=-60000 WHERE id=60000
+
+onlyif threadid=0
+statement ok
+SELECT sleep_ms(100)
+
+onlyif threadid=0
+statement ok
+FORCE CHECKPOINT
+
+onlyif threadid=1
+statement ok
+SELECT sleep_ms(300)
+
+onlyif threadid=1
+statement ok
+COMMIT
+
+endloop
+
+query III
+WITH after_segments AS (
+    SELECT start, count, block_id, block_offset
+    FROM pragma_storage_info('snapshot_reuse_t')
+    WHERE column_name='v' AND segment_type='BIGINT'
+)
+SELECT (count(*) FILTER (WHERE NOT before.dirty
+                          AND before.block_id=after.block_id
+                          AND before.block_offset=after.block_offset)
+            = count(*) FILTER (WHERE NOT before.dirty))::INTEGER,
+       (count(*) FILTER (WHERE before.dirty
+                          AND before.block_id=after.block_id
+                          AND before.block_offset=after.block_offset)=0)::INTEGER,
+       (SELECT count(*) FROM snapshot_reuse_t
+        WHERE v IS DISTINCT FROM CASE WHEN id=60000 THEN -60000 ELSE id END)
+FROM snapshot_wait_before before
+LEFT JOIN after_segments after USING (start, count)
+----
+1	1	0
+
+# Once checkpoint holds the exclusive lock, a newly-started transaction may
+# begin but its update waits until this checkpoint's snapshot is complete.
+statement ok
+CREATE TEMP TABLE snapshot_during_before AS
+SELECT start, count, block_id, block_offset,
+       start<=90000 AND start+count>90000 AS dirty
+FROM pragma_storage_info('snapshot_reuse_t')
+WHERE column_name='v' AND segment_type='BIGINT'
+
+statement ok
+SET debug_checkpoint_sleep_ms=500
+
+concurrentloop threadid 0 2
+
+onlyif threadid=0
+statement ok
+FORCE CHECKPOINT
+
+onlyif threadid=1
+statement ok
+SELECT sleep_ms(100)
+
+onlyif threadid=1
+statement ok
+BEGIN TRANSACTION
+
+onlyif threadid=1
+statement ok
+UPDATE snapshot_reuse_t SET v=-90000 WHERE id=90000
+
+onlyif threadid=1
+statement ok
+COMMIT
+
+endloop
+
+statement ok
+SET debug_checkpoint_sleep_ms=0
+
+query II
+WITH after_segments AS (
+    SELECT start, count, block_id, block_offset
+    FROM pragma_storage_info('snapshot_reuse_t')
+    WHERE column_name='v' AND segment_type='BIGINT'
+)
+SELECT (count(*) FILTER (WHERE before.block_id=after.block_id
+                          AND before.block_offset=after.block_offset)=count(*))::INTEGER,
+       (SELECT count(*) FROM snapshot_reuse_t
+        WHERE v IS DISTINCT FROM CASE
+            WHEN id=60000 THEN -60000
+            WHEN id=90000 THEN -90000
+            ELSE id END)
+FROM snapshot_during_before before
+LEFT JOIN after_segments after USING (start, count)
+----
+1	0
+
+statement ok
+FORCE CHECKPOINT
+
+query II
+WITH after_segments AS (
+    SELECT start, count, block_id, block_offset
+    FROM pragma_storage_info('snapshot_reuse_t')
+    WHERE column_name='v' AND segment_type='BIGINT'
+)
+SELECT (count(*) FILTER (WHERE NOT before.dirty
+                          AND before.block_id=after.block_id
+                          AND before.block_offset=after.block_offset)
+            = count(*) FILTER (WHERE NOT before.dirty))::INTEGER,
+       (count(*) FILTER (WHERE before.dirty
+                          AND before.block_id=after.block_id
+                          AND before.block_offset=after.block_offset)=0)::INTEGER
+FROM snapshot_during_before before
+LEFT JOIN after_segments after USING (start, count)
+----
+1	1
+
+restart
+
+statement ok
+SET checkpoint_threshold='9999GB'
+
+statement ok
+SET debug_verify_blocks=true
+
+statement ok
+FORCE CHECKPOINT
+
+query II
+SELECT count(*) FILTER (WHERE v IS DISTINCT FROM CASE
+           WHEN id=60000 THEN -60000
+           WHEN id=90000 THEN -90000
+           ELSE id END),
+       (bit_xor(hash(id, v))=bit_xor(hash(id, CASE
+           WHEN id=60000 THEN -60000
+           WHEN id=90000 THEN -90000
+           ELSE id END)))::INTEGER
+FROM snapshot_reuse_t
+----
+0	1
+
+# Select one RLE tail from a main Block shared by multiple RowGroups.
+statement ok
+CREATE TABLE shared_abort_t(
+    id BIGINT,
+    v INTEGER USING COMPRESSION RLE)
+
+statement ok
+INSERT INTO shared_abort_t
+SELECT i, (((i%122880)*100000)//122880)::INTEGER
+FROM range(491520) t(i)
+
+statement ok
+FORCE CHECKPOINT
+
+statement ok
+CREATE TABLE shared_abort_targets AS
+WITH segments AS (
+    SELECT row_group_id, start, count, block_id, block_offset,
+           min(start) OVER (PARTITION BY row_group_id) AS first_start,
+           row_number() OVER (PARTITION BY row_group_id ORDER BY start DESC) AS tail_no
+    FROM pragma_storage_info('shared_abort_t')
+    WHERE column_name='v' AND segment_type='INTEGER' AND block_id>=0
+), tails AS (
+    SELECT *, count(*) OVER (PARTITION BY block_id) AS peer_count,
+           row_number() OVER (PARTITION BY block_id ORDER BY row_group_id) AS peer_no
+    FROM segments
+    WHERE tail_no=1
+), selected_block AS (
+    SELECT min(block_id) AS block_id FROM tails WHERE peer_count>1
+)
+SELECT row_group_id, start, count, tails.block_id, block_offset,
+       row_group_id*122880+(start-first_start)+count//2 AS id,
+       peer_no=1 AS dirty
+FROM tails, selected_block
+WHERE tails.block_id=selected_block.block_id
+
+query III
+SELECT (count(*)>1)::INTEGER,
+       (count(*) FILTER (WHERE dirty)=1)::INTEGER,
+       (count(*) FILTER (WHERE NOT dirty)>0)::INTEGER
+FROM shared_abort_targets
+----
+1	1	1
+
+statement ok
+CREATE TABLE shared_abort_before AS
+SELECT storage.row_group_id, storage.start, storage.count,
+       storage.block_id, storage.block_offset,
+       EXISTS (SELECT 1 FROM shared_abort_targets target
+               WHERE target.row_group_id=storage.row_group_id
+                 AND target.start=storage.start AND target.dirty) AS dirty
+FROM pragma_storage_info('shared_abort_t') storage
+WHERE column_name='v' AND segment_type='INTEGER'
+
+statement ok
+FORCE CHECKPOINT
+
+# The old header and free list must remain usable after an abort that occurs
+# after the new free list is written but before the header is switched.
+loop abort_round 0 3
+
+statement ok
+SET checkpoint_threshold='9999GB'
+
+statement ok
+PRAGMA disable_checkpoint_on_shutdown
+
+statement ok
+UPDATE shared_abort_t
+SET v=-({abort_round}+1)
+WHERE id=(SELECT id FROM shared_abort_targets WHERE dirty)
+
+statement ok
+PRAGMA debug_checkpoint_abort='after_free_list_write'
+
+statement error
+FORCE CHECKPOINT
+----
+Checkpoint aborted after free list write
+
+restart
+
+statement ok
+PRAGMA debug_checkpoint_abort='none'
+
+statement ok
+SET checkpoint_threshold='9999GB'
+
+statement ok
+SET debug_verify_blocks=true
+
+statement ok
+FORCE CHECKPOINT
+
+query I
+SELECT count(*) FROM shared_abort_t
+WHERE v IS DISTINCT FROM CASE
+    WHEN id=(SELECT id FROM shared_abort_targets WHERE dirty) THEN -({abort_round}+1)
+    ELSE (((id%122880)*100000)//122880)::INTEGER END
+----
+0
+
+endloop
+
+query II
+WITH after_segments AS (
+    SELECT row_group_id, start, count, block_id, block_offset
+    FROM pragma_storage_info('shared_abort_t')
+    WHERE column_name='v' AND segment_type='INTEGER'
+)
+SELECT (count(*) FILTER (WHERE NOT before.dirty
+                          AND before.block_id=after.block_id
+                          AND before.block_offset=after.block_offset)
+            = count(*) FILTER (WHERE NOT before.dirty))::INTEGER,
+       (SELECT count(*) FROM shared_abort_before before
+        JOIN pragma_storage_info('shared_abort_t') after
+          ON before.block_id=after.block_id AND before.block_offset=after.block_offset
+        WHERE before.dirty AND after.column_name='v' AND after.segment_type='INTEGER')
+FROM shared_abort_before before
+LEFT JOIN after_segments after USING (row_group_id, start, count)
+----
+1	0
+
+# Updates in open transactions and FORCE CHECKPOINT serialize on the checkpoint
+# lock. The final hash must include every committed update exactly once.
+statement ok
+CREATE TABLE concurrent_reuse_t(
+    id BIGINT,
+    v BIGINT USING COMPRESSION UNCOMPRESSED)
+
+statement ok
+INSERT INTO concurrent_reuse_t SELECT i, i FROM range(491520) t(i)
+
+statement ok
+FORCE CHECKPOINT
+
+statement ok
+SET debug_checkpoint_sleep_ms=25
+
+concurrentloop threadid 0 5
+
+loop update_round 0 20
+
+onlyif threadid=0
+statement ok
+FORCE CHECKPOINT
+
+onlyif threadid>0
+statement ok
+BEGIN TRANSACTION
+
+onlyif threadid>0
+statement ok
+UPDATE concurrent_reuse_t
+SET v=v+1
+WHERE id=({threadid}-1)*122880+2048
+
+onlyif threadid>0
+statement ok
+COMMIT
+
+endloop
+
+endloop
+
+statement ok
+SET debug_checkpoint_sleep_ms=0
+
+statement ok
+FORCE CHECKPOINT
+
+query II
+SELECT count(*) FILTER (WHERE v IS DISTINCT FROM
+           CASE WHEN id%122880=2048 THEN id+20 ELSE id END),
+       (bit_xor(hash(id, v))=bit_xor(hash(id,
+           CASE WHEN id%122880=2048 THEN id+20 ELSE id END)))::INTEGER
+FROM concurrent_reuse_t
+----
+0	1
+
+restart
+
+statement ok
+SET debug_verify_blocks=true
+
+statement ok
+FORCE CHECKPOINT
+
+query III
+SELECT count(*) FILTER (WHERE v IS DISTINCT FROM
+           CASE WHEN id%122880=2048 THEN id+20 ELSE id END),
+       (bit_xor(hash(id, v))=bit_xor(hash(id,
+           CASE WHEN id%122880=2048 THEN id+20 ELSE id END)))::INTEGER,
+       (SELECT count(*) FROM zstd_aux_t
+        WHERE v IS DISTINCT FROM CASE WHEN id=0 THEN 'zstd-restored-0'
+            ELSE md5(id::VARCHAR)
+              || md5((id+16384)::VARCHAR)
+              || md5((id+32768)::VARCHAR)
+              || md5((id+49152)::VARCHAR) END)
+FROM concurrent_reuse_t
+----
+0	1	0


### PR DESCRIPTION
Hi DuckDB team,

Motivated by a workload we encounter in AliSQL DuckDB, we noticed that checkpointing can introduce significant latency on instances that replicate data from InnoDB into DuckDB. We therefore looked into reducing work during checkpoint. It would be nice to discuss it with you for further improvements.

## Motivation

Updating any value in a persistent base column currently makes checkpoint decode, analyze, recompress, and write the entire column of that RowGroup. Sparse updates therefore repeat work for persistent Segments whose payload has not changed. A validity-only update also rewrites the unchanged base payload.

This patch lets checkpoint reference eligible unchanged persistent Segments and only rewrite contiguous ranges that contain changes. It preserves the existing whole-column path whenever the layout is unsupported or the expected benefit is too small.

## Design

Adjacent dirty Segments are combined into maximal contiguous ranges. Each dirty range uses one range-local
Analyze/compression pipeline, while each eligible clean Segment is referenced without decoding or rewriting its
payload. 

Multiple ranges add pipeline setup, finalization, and codec-specific Analyze work. Recompression can also produce
more or smaller Segments than a whole-column rewrite, making the persistent layout less compact over time. The local path is therefore selected only when all of these conditions hold:

- at least 12.5% of tuples can be reused;
- there are no more than four dirty ranges;
- total reuse satisfies both one eighth of the column and five Vectors per additional Analyze/compression pipeline;
- the estimated Segment count is at most 25% above an estimated compact layout.

The admission checks run before Analyze, Block marking, or result-tree writes. Failure therefore returns to the
existing whole-column rewrite without local-path side effects. Nested columns, row-remapping checkpoints, unavailable or globally forced compression layouts, and unsupported validity layouts also retain the original path.

The local path also requires an independently persisted validity layout. Some codecs encode NULL information in the
base Segment, while `COMPRESSION_EMPTY` validity layouts have no independent persistent NULL bitmap. A rewritten range may select a codec that requires separate validity, so both layouts conservatively use whole-column rewriting.

## Evaluation

All values are medians. The matrix contains 10 cases and 120 timed checkpoints; all 60 Candidate samples selected
the local path.

| Codec | Actual reuse | Baseline wall (ms) | Candidate wall (ms) | Wall speedup |
|---|---:|---:|---:|---:|
| FSST | 25.4% | 157.5 | 116.5 | 1.352x |
| FSST | 49.3% | 161.0 | 81.5 | 1.975x |
| FSST | 74.7% | 163.5 | 42.0 | 3.893x |
| FSST | 90.6% | 160.5 | 19.0 | 8.447x |
| FSST | 98.6% | 162.0 | 7.0 | 23.143x |
| Uncompressed | 25.4% | 51.5 | 36.0 | 1.431x |
| Uncompressed | 49.7% | 55.0 | 24.0 | 2.292x |
| Uncompressed | 75.1% | 59.0 | 13.0 | 4.538x |
| Uncompressed | 89.7% | 61.0 | 6.0 | 10.167x |
| Uncompressed | 99.4% | 63.0 | 1.0 | 63.000x |
| **Overall** | **25.4%-99.4%** | | | **5.354x geometric mean** |

| Codec | Actual reuse | CPU speedup | Write reduction | Baseline peak RSS (MiB) | Candidate peak RSS (MiB) |
|---|---:|---:|---:|---:|---:|
| FSST | 25.4% | 1.358x | 25.0% | 95.5 | 83.4 |
| FSST | 49.3% | 1.982x | 48.4% | 98.6 | 69.9 |
| FSST | 74.7% | 3.907x | 73.4% | 98.3 | 52.8 |
| FSST | 90.6% | 8.528x | 89.0% | 93.8 | 43.6 |
| FSST | 98.6% | 23.743x | 95.3% | 91.5 | 37.2 |
| Uncompressed | 25.4% | 1.447x | 25.0% | 76.8 | 65.9 |
| Uncompressed | 49.7% | 2.280x | 48.8% | 76.5 | 55.7 |
| Uncompressed | 75.1% | 4.685x | 73.8% | 76.3 | 44.8 |
| Uncompressed | 89.7% | 9.943x | 88.1% | 76.2 | 38.6 |
| Uncompressed | 99.4% | 36.558x | 97.6% | 74.8 | 33.6 |
| **Overall** | **25.4%-99.4%** | | **25.0%-97.6%** |  | **Lower in 10/10 cases** |


## Limitations

- Projected Segment count is a pre-compression estimate, not a strict bound on codec output.
- Segment count does not directly measure stranded space inside shared Blocks.
