### PR TITLE
Fix: `RANK/PERCENT_RANK/CUME_DIST` peers when the argument `ORDER BY` is a prefix of the window `ORDER BY`

### DIFF
--- a/src/function/window/window_rank_function.cpp
+++ b/src/function/window/window_rank_function.cpp
@@ -20,12 +20,15 @@ public:
 		if (!executor.arg_order_idx.empty()) {
 			use_framing = true;
 
-			//	If the argument order is a prefix of the partition ordering
+			//	If the argument order is the entire partition ordering
 			//	(and the optimizer is enabled), then we can just use the partition ordering.
+			//	A prefix is not sufficient because peer boundaries use all of the ordering keys.
 			auto &wexpr = executor.wexpr;
 			auto &arg_orders = executor.wexpr.ArgOrders();
+			auto &orders = wexpr.OrderBy();
 			const auto optimize = Settings::Get<EnableOptimizerSetting>(client);
-			if (!optimize || BoundWindowExpression::GetSharedOrders(wexpr.OrderBy(), arg_orders) != arg_orders.size()) {
+			const auto shared = BoundWindowExpression::GetSharedOrders(orders, arg_orders);
+			if (!optimize || shared != arg_orders.size() || arg_orders.size() != orders.size()) {
 				token_tree = make_uniq<WindowTokenTree>(client, arg_orders, executor.arg_order_idx, payload_count);
 			}
 		}

--- a/test/sql/window/test_cume_dist_orderby.test
+++ b/test/sql/window/test_cume_dist_orderby.test
@@ -67,3 +67,20 @@ ORDER BY id;
 1	0.0	0.0
 2	0.0	0.0
 3	0.0	0.0
+
+# Argument ordering that is only a prefix of the window ordering must not split peers
+query III
+SELECT
+	id,
+	k,
+	cume_dist(ORDER BY k) OVER w AS cd,
+FROM (VALUES (1, 1), (2, 1), (3, 2)) tbl(id, k)
+WINDOW w AS (
+	ORDER BY k, id
+	ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+)
+ORDER BY id
+----
+1	1	0.6666666666666666
+2	1	0.6666666666666666
+3	2	1.0

--- a/test/sql/window/test_rank_orderby.test
+++ b/test/sql/window/test_rank_orderby.test
@@ -72,3 +72,31 @@ ORDER BY 1
 7	3	3	0.4
 8	4	4	0.75
 9	4	3	0.6666666666666666
+
+# Argument ordering that is only a prefix of the window ordering must not split peers
+query III
+SELECT
+	id,
+	k,
+	percent_rank(ORDER BY k) OVER (ORDER BY k, id) AS arg_percent_rank,
+FROM (VALUES (1, 1), (2, 1)) tbl(id, k)
+ORDER BY id
+----
+1	1	0.0
+2	1	0.0
+
+query IIII
+SELECT
+	id,
+	k,
+	rank(ORDER BY k) OVER w,
+	percent_rank(ORDER BY k) OVER w,
+FROM (VALUES (1, 1), (2, 1), (3, 2)) tbl(id, k)
+WINDOW w AS (
+	ORDER BY k, id
+)
+ORDER BY id
+----
+1	1	1	0.0
+2	1	1	0.0
+3	2	3	1.0


### PR DESCRIPTION
Fixes #24628.

### Problem

`WindowPeerGlobalState` - shared by `rank`, `percent_rank` and `cume_dist` - skips building the
`WindowTokenTree` for a function's argument `ORDER BY` when that order is a *prefix* of the window
`ORDER BY`, and instead reuses the `PEER_BEGIN`/`PEER_END` boundaries the window operator has
already computed.

Those boundaries are derived from *all* the window ordering keys, so reusing them is only valid
when the argument order covers the whole window order. For a strict prefix the extra trailing keys
split peer groups that the argument order considers equal:

```sql
SELECT id, k, percent_rank(ORDER BY k) OVER (ORDER BY k, id)
FROM (VALUES (1, 1), (2, 1)) t(id, k)
ORDER BY id;
```

`id` makes each row its own peer, so the second row got `1.0` instead of `0.0`. Because the guard
is conditional on the optimizer being enabled, `SET enable_optimizer=false` returned the correct
`0.0` for both rows.

### Solution

Require the argument order to match the entire window `ORDER BY`, not just a prefix; otherwise
build the token tree as before.

The same prefix test in `window_rownumber_function.cpp`, `window_value_function.cpp` (`lead`/`lag`,
`fill`) and `window_aggregate_function.cpp` is correct as-is: those functions are positional or
insensitive to how ties are broken, so a prefix genuinely suffices. Only the peer-based ranking
functions depend on peer group identity.

### Tests

`cume_dist` was affected by the same bug and is covered as well - it is only visible with an
explicit frame, since the default `RANGE UNBOUNDED PRECEDING` frame yields `1.0` on both paths:

| query | before | after / `enable_optimizer=false` |
| --- | --- | --- |
| `percent_rank(ORDER BY k) OVER (ORDER BY k, id)` | `0.0, 1.0` | `0.0, 0.0` |
| `rank(ORDER BY k) OVER (ORDER BY k, id)` | `1, 2` | `1, 1` |
| `cume_dist(ORDER BY k) OVER (ORDER BY k, id ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)` | `0.33, 0.67, 1.0` | `0.67, 0.67, 1.0` |

Regression cases added to `test/sql/window/test_rank_orderby.test` and
`test/sql/window/test_cume_dist_orderby.test`. The full `test/sql/window/*` suite passes
(77 cases, 96237 assertions).
