### PR TITLE
Exempt the buffer manager's temporary files from disabled_filesystems when the temp directory is locked

### DIFF
--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -980,6 +980,13 @@
         "default_value": "false"
     },
     {
+        "name": "lock_temp_directory",
+        "description": "Fix the temp directory in place: 'temp_directory' can no longer be modified, and the temporary files written by the buffer manager bypass 'disabled_filesystems'",
+        "type": "BOOLEAN",
+        "scope": "global",
+        "custom_implementation": true
+    },
+    {
         "name": "log_query_path",
         "description": "Specifies the path to which queries should be logged (default: NULL, queries are not logged)",
         "type": "VARCHAR",

--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -164,6 +164,10 @@ public:
 	DUCKDB_API static FileSystem &GetFileSystem(ClientContext &context);
 	DUCKDB_API static FileSystem &GetFileSystem(DatabaseInstance &db);
 	DUCKDB_API static FileSystem &GetLocal(DatabaseInstance &db);
+	//! File system through which the buffer manager reaches its temporary files. This is the regular file system
+	//! unless the temp directory has been locked, in which case it is the local one - see
+	//! DBConfigOptions::lock_temp_directory.
+	DUCKDB_API static FileSystem &GetTemporaryFileSystem(DatabaseInstance &db);
 	DUCKDB_API static FileSystem &Get(AttachedDatabase &db);
 
 	DUCKDB_API virtual unique_ptr<FileHandle> OpenFile(const string &path, FileOpenFlags flags,

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -103,6 +103,12 @@ struct DBConfigOptions {
 	bool force_checkpoint = false;
 	//! Run a checkpoint on successful shutdown and delete the WAL, to leave only a single database file behind
 	bool checkpoint_on_shutdown = true;
+	//! Whether the temporary directory is fixed in place. Once set this cannot be unset: 'temporary_directory' can no
+	//! longer be modified, and in exchange the buffer manager reaches its temporary files through the local file
+	//! system rather than the virtual one, so 'disabled_filesystems' no longer applies to them. Declared at the end of
+	//! the bool run so it takes a padding byte the struct already had: extensions are compiled against this layout,
+	//! and every member above keeps the offset it has in a release without this one.
+	bool lock_temp_directory = false;
 	//! Serialize the metadata on checkpoint with compatibility for a given DuckDB version.
 	StorageCompatibility storage_compatibility = StorageCompatibility::Default();
 	//! Initialize the database with the standard set of DuckDB functions

--- a/src/include/duckdb/main/database.hpp
+++ b/src/include/duckdb/main/database.hpp
@@ -60,6 +60,7 @@ public:
 	DUCKDB_API ExternalResourcesManager &GetExternalResourcesManager();
 	DUCKDB_API FileSystem &GetFileSystem();
 	DUCKDB_API FileSystem &GetLocalFileSystem();
+	DUCKDB_API FileSystem &GetTemporaryFileSystem();
 	DUCKDB_API ExternalFileCache &GetExternalFileCache();
 	DUCKDB_API ResultSetManager &GetResultSetManager();
 	DUCKDB_API TaskScheduler &GetScheduler();
@@ -114,6 +115,12 @@ private:
 	unique_ptr<ParserCache> parser_cache;
 
 	duckdb_ext_api_v1 (*create_api_v1)();
+
+	//! The same local file system as `local_db_file_system`, minus the `disabled_filesystems` check. Only ever
+	//! reached for the buffer manager's temporary files, and only once the temp directory is locked - see
+	//! DBConfigOptions::lock_temp_directory. Declared last on purpose: extensions are built against this class, so
+	//! everything above it keeps the offset it has in a release without this member.
+	unique_ptr<LocalDatabaseFileSystem> temporary_db_file_system;
 };
 
 //! The database object. This object holds the catalog and all the

--- a/src/include/duckdb/main/database_file_opener.hpp
+++ b/src/include/duckdb/main/database_file_opener.hpp
@@ -71,7 +71,9 @@ private:
 
 class LocalDatabaseFileSystem : public OpenerFileSystem {
 public:
-	explicit LocalDatabaseFileSystem(DatabaseInstance &db_p);
+	//! `apply_disabled_file_systems` may only be false where the paths reached are engine-internal and not
+	//! user-controllable, since it is what makes `disabled_filesystems` bite on a local path.
+	explicit LocalDatabaseFileSystem(DatabaseInstance &db_p, bool apply_disabled_file_systems = true);
 
 	FileSystem &GetFileSystem() const override;
 	optional_ptr<FileOpener> GetOpener() const override {
@@ -82,6 +84,7 @@ private:
 	DatabaseInstance &db;
 	unique_ptr<FileSystem> owned_file_system;
 	FileSystem &local_fs;
+	bool apply_disabled_file_systems;
 	mutable DatabaseFileOpener database_opener;
 };
 

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -1460,6 +1460,18 @@ struct LockConfigurationSetting {
 	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
+struct LockTempDirectorySetting {
+	using RETURN_TYPE = bool;
+	static constexpr const char *Name = "lock_temp_directory";
+	static constexpr const char *Description =
+	    "Fix the temp directory in place: 'temp_directory' can no longer be modified, and the temporary files written "
+	    "by the buffer manager bypass 'disabled_filesystems'";
+	static constexpr const char *InputType = "BOOLEAN";
+	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
+	static Value GetSetting(const ClientContext &context);
+};
+
 struct LogQueryPathSetting {
 	using RETURN_TYPE = string;
 	static constexpr const char *Name = "log_query_path";

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -189,6 +189,7 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_SETTING(LegacyDisableNullTypeSetting),
     DUCKDB_SETTING(LegacyMetricsFormatSetting),
     DUCKDB_SETTING(LockConfigurationSetting),
+    DUCKDB_GLOBAL(LockTempDirectorySetting),
     DUCKDB_SETTING_CALLBACK(LogQueryPathSetting),
     DUCKDB_GLOBAL(LoggingLevel),
     DUCKDB_GLOBAL(LoggingMode),
@@ -250,12 +251,12 @@ static const ConfigurationOption internal_options[] = {
 
 static const ConfigurationAlias setting_aliases[] = {DUCKDB_SETTING_ALIAS("configure_metrics", 30),
                                                      DUCKDB_SETTING_ALIAS("custom_profiling_settings", 30),
-                                                     DUCKDB_SETTING_ALIAS("memory_limit", 129),
+                                                     DUCKDB_SETTING_ALIAS("memory_limit", 130),
                                                      DUCKDB_SETTING_ALIAS("null_order", 61),
-                                                     DUCKDB_SETTING_ALIAS("profile_output", 152),
-                                                     DUCKDB_SETTING_ALIAS("user", 171),
+                                                     DUCKDB_SETTING_ALIAS("profile_output", 153),
+                                                     DUCKDB_SETTING_ALIAS("user", 172),
                                                      DUCKDB_SETTING_ALIAS("wal_autocheckpoint", 29),
-                                                     DUCKDB_SETTING_ALIAS("worker_threads", 169),
+                                                     DUCKDB_SETTING_ALIAS("worker_threads", 170),
                                                      FINAL_ALIAS};
 
 vector<ConfigurationOption> DBConfig::GetOptions() {

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -158,6 +158,17 @@ FileSystem &FileSystem::GetLocal(DatabaseInstance &db) {
 	return db.GetLocalFileSystem();
 }
 
+FileSystem &FileSystem::GetTemporaryFileSystem(DatabaseInstance &db) {
+	if (db.config.options.lock_temp_directory) {
+		// The temp directory can no longer be redirected, so the files the buffer manager writes there are
+		// engine-internal state rather than user-directed file access. Exempting them from
+		// 'disabled_filesystems' lets an embedder fence off user file access without also giving up
+		// out-of-core execution. 'allowed_directories' still applies.
+		return db.GetTemporaryFileSystem();
+	}
+	return GetFileSystem(db);
+}
+
 FileSystem &FileSystem::Get(AttachedDatabase &db) {
 	return FileSystem::GetFileSystem(db.GetDatabase());
 }
@@ -307,6 +318,7 @@ void DatabaseInstance::Initialize(const char *database_path, DBConfig *user_conf
 
 	db_file_system = make_uniq<DatabaseFileSystem>(*this);
 	local_db_file_system = make_uniq<LocalDatabaseFileSystem>(*this);
+	temporary_db_file_system = make_uniq<LocalDatabaseFileSystem>(*this, false);
 	db_manager = make_uniq<DatabaseManager>(*this);
 	external_resource_type_registry = make_uniq<ExternalResourceTypeRegistry>();
 	external_resources_manager = make_uniq<ExternalResourcesManager>();
@@ -421,6 +433,10 @@ FileSystem &DatabaseInstance::GetLocalFileSystem() {
 	return *local_db_file_system;
 }
 
+FileSystem &DatabaseInstance::GetTemporaryFileSystem() {
+	return *temporary_db_file_system;
+}
+
 static FileSystem &ResolveLocalFileSystem(DatabaseInstance &db, unique_ptr<FileSystem> &owned) {
 	auto &vfs = static_cast<VirtualFileSystem &>(*db.config.file_system);
 	auto &default_fs = vfs.GetDefaultFileSystem();
@@ -431,12 +447,13 @@ static FileSystem &ResolveLocalFileSystem(DatabaseInstance &db, unique_ptr<FileS
 	return *owned;
 }
 
-LocalDatabaseFileSystem::LocalDatabaseFileSystem(DatabaseInstance &db_p)
-    : db(db_p), local_fs(ResolveLocalFileSystem(db_p, owned_file_system)), database_opener(db_p) {
+LocalDatabaseFileSystem::LocalDatabaseFileSystem(DatabaseInstance &db_p, bool apply_disabled_file_systems_p)
+    : db(db_p), local_fs(ResolveLocalFileSystem(db_p, owned_file_system)),
+      apply_disabled_file_systems(apply_disabled_file_systems_p), database_opener(db_p) {
 }
 
 FileSystem &LocalDatabaseFileSystem::GetFileSystem() const {
-	if (db.config.file_system->SubSystemIsDisabled(local_fs.GetName())) {
+	if (apply_disabled_file_systems && db.config.file_system->SubSystemIsDisabled(local_fs.GetName())) {
 		throw PermissionException("File system %s has been disabled by configuration", local_fs.GetName());
 	}
 	return local_fs;

--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -1471,9 +1471,37 @@ Value StreamingBufferSizeSetting::GetSetting(const ClientContext &context) {
 }
 
 //===----------------------------------------------------------------------===//
+// Lock Temp Directory
+//===----------------------------------------------------------------------===//
+static void CheckTempDirectoryNotLocked(const DBConfig &config) {
+	if (config.options.lock_temp_directory) {
+		throw PermissionException("Modifying the temp_directory is disabled - the temp directory has been locked");
+	}
+}
+
+void LockTempDirectorySetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {
+	if (!input.GetValue<bool>()) {
+		// Unlocking would hand back the ability to point the exempted temp directory somewhere else.
+		CheckTempDirectoryNotLocked(config);
+		return;
+	}
+	config.options.lock_temp_directory = true;
+}
+
+void LockTempDirectorySetting::ResetGlobal(DatabaseInstance *db, DBConfig &config) {
+	CheckTempDirectoryNotLocked(config);
+}
+
+Value LockTempDirectorySetting::GetSetting(const ClientContext &context) {
+	auto &config = DBConfig::GetConfig(context);
+	return Value::BOOLEAN(config.options.lock_temp_directory);
+}
+
+//===----------------------------------------------------------------------===//
 // Temp Directory
 //===----------------------------------------------------------------------===//
 void TempDirectorySetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {
+	CheckTempDirectoryNotLocked(config);
 	if (!Settings::Get<EnableExternalAccessSetting>(config)) {
 		throw PermissionException("Modifying the temp_directory has been disabled by configuration");
 	}
@@ -1486,6 +1514,7 @@ void TempDirectorySetting::SetGlobal(DatabaseInstance *db, DBConfig &config, con
 }
 
 void TempDirectorySetting::ResetGlobal(DatabaseInstance *db, DBConfig &config) {
+	CheckTempDirectoryNotLocked(config);
 	if (!Settings::Get<EnableExternalAccessSetting>(config)) {
 		throw PermissionException("Modifying the temp_directory has been disabled by configuration");
 	}

--- a/src/storage/standard_buffer_manager.cpp
+++ b/src/storage/standard_buffer_manager.cpp
@@ -462,7 +462,7 @@ vector<MemoryInformation> StandardBufferManager::GetMemoryUsageInfo() const {
 }
 
 string StandardBufferManager::GetTemporaryPath(block_id_t id) {
-	auto &fs = FileSystem::GetFileSystem(db);
+	auto &fs = FileSystem::GetTemporaryFileSystem(db);
 	return fs.JoinPath(temporary_directory.path, "duckdb_temp_block-" + to_string(id) + ".block");
 }
 
@@ -508,7 +508,7 @@ void StandardBufferManager::WriteTemporaryBuffer(QueryContext context, MemoryTag
 	evicted_data_per_tag[uint8_t(tag)] += buffer.AllocSize();
 
 	// Create the file and write the size followed by the buffer contents.
-	auto &fs = FileSystem::GetFileSystem(db);
+	auto &fs = FileSystem::GetTemporaryFileSystem(db);
 	auto handle = fs.OpenFile(path, FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE);
 	temporary_directory.handle->GetTempFile().IncreaseSizeOnDisk(buffer.AllocSize() + header_size);
 	//! for very large buffers, we store the size of the buffer in plaintext.
@@ -555,7 +555,7 @@ unique_ptr<FileBuffer> StandardBufferManager::ReadTemporaryBuffer(QueryContext c
 	idx_t block_size;
 	idx_t block_header_size;
 	auto path = GetTemporaryPath(id);
-	auto &fs = FileSystem::GetFileSystem(db);
+	auto &fs = FileSystem::GetTemporaryFileSystem(db);
 	auto handle = fs.OpenFile(path, FileFlags::FILE_FLAGS_READ);
 	handle->Read(context, &block_size, sizeof(idx_t), 0);
 	handle->Read(context, &block_header_size, sizeof(idx_t), sizeof(idx_t));
@@ -615,7 +615,7 @@ void StandardBufferManager::DeleteTemporaryFile(BlockMemory &memory) {
 	}
 
 	// The file is not in the shared pool of files.
-	auto &fs = FileSystem::GetFileSystem(db);
+	auto &fs = FileSystem::GetTemporaryFileSystem(db);
 	auto path = GetTemporaryPath(id);
 	if (fs.FileExists(path)) {
 		evicted_data_per_tag[uint8_t(memory.GetMemoryTag())] -= memory.GetMemoryUsage();
@@ -636,7 +636,7 @@ bool StandardBufferManager::HasFilesInTemporaryDirectory() const {
 		return false;
 	}
 
-	auto &fs = FileSystem::GetFileSystem(db);
+	auto &fs = FileSystem::GetTemporaryFileSystem(db);
 	bool found = false;
 	fs.ListFiles(temporary_directory.path, [&](const string &name, bool is_dir) {
 		if (is_dir) {
@@ -664,7 +664,7 @@ vector<TemporaryFileInformation> StandardBufferManager::GetTemporaryFiles() {
 			result = temporary_directory.handle->GetTempFile().GetTemporaryFiles();
 		}
 	}
-	auto &fs = FileSystem::GetFileSystem(db);
+	auto &fs = FileSystem::GetTemporaryFileSystem(db);
 	fs.ListFiles(temporary_directory.path, [&](const string &name, bool is_dir) {
 		if (is_dir) {
 			return;

--- a/src/storage/temporary_file_manager.cpp
+++ b/src/storage/temporary_file_manager.cpp
@@ -310,7 +310,7 @@ bool TemporaryFileHandle::DeleteIfEmpty() {
 	}
 	// the file is empty: delete it
 	handle.reset();
-	auto &fs = FileSystem::GetFileSystem(db);
+	auto &fs = FileSystem::GetTemporaryFileSystem(db);
 	fs.RemoveFile(path);
 	return true;
 }
@@ -331,7 +331,7 @@ void TemporaryFileHandle::CreateFileIfNotExists(TemporaryFileLock &) {
 	if (handle) {
 		return;
 	}
-	auto &fs = FileSystem::GetFileSystem(db);
+	auto &fs = FileSystem::GetTemporaryFileSystem(db);
 	auto open_flags = FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE;
 	// Temp files have no per-file IO_MODE; they follow the global default_io_mode setting.
 	if (Settings::Get<DefaultIoModeSetting>(db) == FileIOMode::DIRECT_IO) {
@@ -347,7 +347,7 @@ void TemporaryFileHandle::RemoveTempBlockIndex(TemporaryFileLock &, idx_t index)
 		// as a result we can truncate the file
 #ifndef WIN32 // this ended up causing issues when sorting
 		auto max_index = index_manager.GetMaxIndex();
-		auto &fs = FileSystem::GetFileSystem(db);
+		auto &fs = FileSystem::GetTemporaryFileSystem(db);
 		fs.Truncate(*handle, NumericCast<int64_t>(GetPositionInFile(max_index + 1)));
 #endif
 	}
@@ -704,7 +704,7 @@ void TemporaryFileManager::EraseUsedBlock(TemporaryFileManagerLock &lock, block_
 }
 
 string TemporaryFileManager::CreateTemporaryFileName(const TemporaryFileIdentifier &identifier) const {
-	return FileSystem::GetFileSystem(db).JoinPath(
+	return FileSystem::GetTemporaryFileSystem(db).JoinPath(
 	    temp_directory, StringUtil::Format("duckdb_temp_storage_%s-%llu.tmp", EnumUtil::ToString(identifier.size),
 	                                       identifier.file_index.GetIndex()));
 }
@@ -733,7 +733,7 @@ TemporaryDirectoryHandle::TemporaryDirectoryHandle(DatabaseInstance &db, string 
                                                    optional_idx max_swap_space)
     : db(db), temp_directory(std::move(path_p)),
       temp_file(make_uniq<TemporaryFileManager>(db, temp_directory, size_on_disk)) {
-	auto &fs = FileSystem::GetFileSystem(db);
+	auto &fs = FileSystem::GetTemporaryFileSystem(db);
 	D_ASSERT(!temp_directory.empty());
 	if (!fs.DirectoryExists(temp_directory)) {
 		fs.CreateDirectory(temp_directory);
@@ -746,7 +746,7 @@ TemporaryDirectoryHandle::~TemporaryDirectoryHandle() {
 	// first release any temporary files
 	temp_file.reset();
 	// then delete the temporary file directory
-	auto &fs = FileSystem::GetFileSystem(db);
+	auto &fs = FileSystem::GetTemporaryFileSystem(db);
 	if (!temp_directory.empty()) {
 		bool delete_directory = created_directory;
 		vector<string> files_to_delete;

--- a/test/api/test_reset.cpp
+++ b/test/api/test_reset.cpp
@@ -188,6 +188,7 @@ bool OptionIsExcludedFromTest(const string &name) {
 	    "experimental_parallel_csv",
 	    "lock_configuration",            // cant change this while db is running
 	    "disabled_filesystems",          // cant change this while db is running
+	    "lock_temp_directory",           // cant be unset once set
 	    "enable_external_access",        // cant change this while db is running
 	    "allow_unsigned_extensions",     // cant change this while db is running
 	    "allow_community_extensions",    // cant change this while db is running

--- a/test/sql/settings/lock_temp_directory.test
+++ b/test/sql/settings/lock_temp_directory.test
@@ -1,0 +1,70 @@
+# name: test/sql/settings/lock_temp_directory.test
+# description: Test lock_temp_directory - the buffer manager keeps spilling when the local file system is disabled
+# group: [settings]
+
+require vector_size 2048
+
+require noforcestorage
+
+require skip_reload
+
+statement ok
+PRAGMA temp_directory='{TEST_DIR}/lock_temp_directory'
+
+statement ok
+PRAGMA memory_limit='2MB'
+
+query I
+SELECT current_setting('lock_temp_directory')
+----
+false
+
+statement ok
+SET lock_temp_directory=true
+
+query I
+SELECT current_setting('lock_temp_directory')
+----
+true
+
+# the exempted directory can no longer be pointed somewhere else
+statement error
+PRAGMA temp_directory='{TEST_DIR}/lock_temp_directory_elsewhere'
+----
+the temp directory has been locked
+
+statement error
+RESET temp_directory
+----
+the temp directory has been locked
+
+# ...and the lock cannot be lifted to get that ability back
+statement error
+SET lock_temp_directory=false
+----
+the temp directory has been locked
+
+statement error
+RESET lock_temp_directory
+----
+the temp directory has been locked
+
+statement ok
+SET disabled_filesystems='LocalFileSystem'
+
+# reading a local file is still refused
+statement error
+SELECT * FROM read_csv_auto('{DATA_DIR}/csv/auto/skip_row.csv')
+----
+File system LocalFileSystem has been disabled by configuration
+
+# ...but this does not fit in memory_limit and still spills to the locked temp directory.
+# A TEMP table on purpose: a persistent one would have to commit through the file system
+# this test has just disabled, which is not what is under test here.
+statement ok
+CREATE TEMP TABLE t2 AS SELECT * FROM range(1000000);
+
+query I
+SELECT count(*) FROM t2
+----
+1000000

--- a/test/sql/settings/lock_temp_directory_unset.test
+++ b/test/sql/settings/lock_temp_directory_unset.test
@@ -1,0 +1,23 @@
+# name: test/sql/settings/lock_temp_directory_unset.test
+# description: Without lock_temp_directory, disabling the local file system also stops the buffer manager spilling
+# group: [settings]
+
+require vector_size 2048
+
+require noforcestorage
+
+require skip_reload
+
+statement ok
+PRAGMA temp_directory='{TEST_DIR}/lock_temp_directory_unset'
+
+statement ok
+PRAGMA memory_limit='2MB'
+
+statement ok
+SET disabled_filesystems='LocalFileSystem'
+
+statement error
+CREATE TEMP TABLE t2 AS SELECT * FROM range(1000000);
+----
+File system LocalFileSystem has been disabled by configuration


### PR DESCRIPTION
## The problem

An embedded engine that runs **untrusted SQL in-process** has no way to say "you may spill to
disk, but you may not touch the filesystem for anything else".

`disabled_filesystems='LocalFileSystem'` is the natural fence, and it works well for user file
access. But the buffer manager's temporary files reach the disk through the same virtual file
system, so the fence takes out-of-core execution with it: any query whose working set outgrows
`memory_limit` fails with a permission error instead of spilling. The sandbox and the ability
to run large queries become mutually exclusive.

Nothing in the existing configuration bridges that gap:

- `allowed_directories` / `allowed_paths` enforce nothing while `enable_external_access` is
  true — `DBConfig::CanAccessFile` returns early.
- Turning `enable_external_access` off *does* preserve spilling (startup adds the temp
  directory to `allowed_directories`), but it makes the postgres and mysql extensions refuse
  to `ATTACH` unconditionally, with no allowlist entry able to re-permit it.
- `FileSystem::GetLocal` is not an escape hatch either: `LocalDatabaseFileSystem::GetFileSystem`
  re-applies the `disabled_filesystems` check by hand.
- A remote `temp_directory` is not usable — DuckDB cannot open a remote file for both reading
  and writing.

### Where this comes from

[Windmill](https://github.com/windmill-labs/windmill) runs DuckDB **in-process** in its job
workers, through an FFI cdylib. Every other language runtime it supports is confined by
nsjail/unshare; DuckDB cannot be, because there is no child process to jail. So the worker
mirrors that policy at the connection level instead, splicing `disabled_filesystems` (plus an
INSTALL/LOAD allowlist) ahead of the user's SQL.

That fence is what makes it safe to run untrusted DuckDB scripts at all — but with it in place,
every DuckDB feature that depends on going out-of-core is crippled: large sorts, aggregations,
joins and `CREATE TABLE AS` all fail as soon as they exceed `memory_limit`, on precisely the
worker class that exists because the tenants are not trusted. Spilling is the one filesystem
capability such a deployment needs to keep, and it is the one it cannot express today.

## The change

`lock_temp_directory` (BOOLEAN, global, default `false`, irreversible). Setting it:

1. fixes `temp_directory` in place — it can no longer be modified, and the setting itself
   cannot be unset or reset;
2. routes the buffer manager's temporary files through a local file system that
   `disabled_filesystems` does not apply to (`FileSystem::GetTemporaryFileSystem`).

The two halves are only safe as a pair, and that is the crux of the design: the exemption is
sound **because** the directory can no longer be redirected. Without (1), a user could point
`temp_directory` at an arbitrary path and turn the exemption into a blind write primitive.
With it, the exempted location is fixed by the embedder before any untrusted SQL runs.

`allowed_directories` still applies either way, since the new file system is still an
`OpenerFileSystem` — so an embedder that also restricts paths keeps that restriction.

The temp directory was already treated as a protected resource, which is the precedent this
follows: `TempDirectorySetting` refuses to modify it when `enable_external_access` is false,
and the startup path adds it to `allowed_directories` so that spilling survives that lockdown.

## Notes for review

**No struct member changes offset.** Both new fields are placed in space the structs already
had — `lock_temp_directory` at the end of `DBConfigOptions`' run of bools, where it occupies
an existing padding byte, and `temporary_db_file_system` last in `DatabaseInstance`. Verified
with `clang++ -Xclang -fdump-record-layouts` against the unpatched tree: the only difference is
added lines. This matters for extensions built against the current layout — during development
an earlier revision declared the `DatabaseInstance` member next to `local_db_file_system`,
which pushed `create_api_v1` 8 bytes along, and every prebuilt extension `LOAD` then hung
rather than failing.

**`test_reset.cpp`.** `lock_temp_directory` joins the excluded-options list next to
`disabled_filesystems`, `lock_configuration` and `enable_external_access`: that test requires
every setting to survive a `RESET`, which an irreversible one cannot.

**Generated files.** `src/common/settings.json` regenerated with
`scripts/generate_settings.py`; formatted with clang-format 11.0.1.

## Tests

Two sqllogictests:

- `test/sql/settings/lock_temp_directory.test` — the lock takes effect, `temp_directory` can no
  longer be set or reset, the setting cannot be unset, a local read is still refused, and a
  query that outgrows `memory_limit` still spills and completes.
- `test/sql/settings/lock_temp_directory_unset.test` — without the lock, the fence stops the
  spill. This is what keeps the first test honest: it fails on a build where the query never
  needed to spill in the first place.

Full fast suite on this branch: **974 376 assertions across 4900 test cases, all passing**
(420 skipped for missing optional extensions).

### CI on my fork

Run per CONTRIBUTING before opening. Everything passed except three tests, none of which this
change touches — I chased each one down rather than assume:

- `test/sql/index/art/scan/test_not_distinct_index_scan.test` — fails under the alternate
  storage configs (`compressed_in_memory`, `force_storage`, `latest_storage` and others).
  **Reproduces on an unmodified `main` build**:
  `./build/release/test/run --test-config=test/configs/compressed_in_memory.json test/sql/index/art/scan/test_not_distinct_index_scan.test`
  It passes on the default config, which is presumably why it is not more visible.
- `test/sql/storage/compression/fsst/fsst_greedy_long_strings.test` — flaky on `main`. It
  asserts an exact storage-segment count and returns 2 instead of 1 roughly 8% of the time:
  **16 failures in 200 consecutive runs of that test alone, on an unmodified `main` build**.
- `test/sql/parallelism/interquery/concurrent_checkpoint_insert.test` on Windows — CI's own
  retry logic attempted it twice before failing.

Happy to open any of those separately if useful; I did not want to bundle unrelated fixes here.

Two rounds of that CI also caught genuine problems in *my* tests, both since fixed: they
created a persistent table (which cannot commit once the test has disabled the file system, so
it is now a `TEMP` table), and they lacked `require vector_size 2048`, which the
`STANDARD_VECTOR_SIZE=2` build needs.

---

*Disclosure: this patch was written with AI assistance. I have reviewed it, run the test suite
and the layout verification described above, and I am submitting it under my own name. I am
aware of the note in CONTRIBUTING.md and am flagging it up front rather than leaving you to
infer it — close it on those grounds if you prefer, and I will not take it personally.*
