### PR TITLE
Fix stale table statistics in prepared statements

### DIFF
--- a/src/execution/physical_plan/plan_prepare.cpp
+++ b/src/execution/physical_plan/plan_prepare.cpp
@@ -9,7 +9,8 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalPrepare &op) {
 	// Generate the physical plan only if all parameters are bound.
 	// Otherwise, the physical plan is never used.
 	D_ASSERT(op.children.size() <= 1);
-	if (op.prepared->properties.bound_all_parameters && !op.children.empty()) {
+	if (op.prepared->properties.bound_all_parameters && !op.prepared->properties.always_require_rebind &&
+	    !op.children.empty()) {
 		PhysicalPlanGenerator inner_planner(context);
 		op.prepared->physical_plan = inner_planner.PlanInternal(*op.children[0]);
 		op.prepared->types = op.prepared->physical_plan->Root().types;

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -55,6 +55,7 @@
 #include "duckdb/optimizer/rule/predicate_factoring.hpp"
 #include "duckdb/planner/binder.hpp"
 #include "duckdb/planner/planner.hpp"
+#include "duckdb/planner/operator/logical_prepare.hpp"
 #include "duckdb/optimizer/remote_pushdown_optimizer.hpp"
 #include "duckdb/main/database_manager.hpp"
 #include "duckdb/main/settings.hpp"
@@ -163,6 +164,18 @@ static bool ContainsDML(const LogicalOperator &op) {
 	return false;
 }
 
+static bool ContainsDataSource(const LogicalOperator &op) {
+	if (op.type == LogicalOperatorType::LOGICAL_GET) {
+		return true;
+	}
+	for (auto &child : op.children) {
+		if (ContainsDataSource(*child)) {
+			return true;
+		}
+	}
+	return false;
+}
+
 // Returns true if the plan contains a DML statement inside a CTE body. A top-level
 // DML statement is not flagged. COPY TO is side-effecting, but does not invalidate
 // table statistics and is deliberately excluded here.
@@ -195,7 +208,6 @@ void Optimizer::OptimizeStatement(unique_ptr<SQLStatement> &statement) {
 }
 
 void Optimizer::RunBuiltInOptimizers() {
-	const bool reusable_prepared_plan = plan->type == LogicalOperatorType::LOGICAL_PREPARE;
 	switch (plan->type) {
 	case LogicalOperatorType::LOGICAL_TRANSACTION:
 	case LogicalOperatorType::LOGICAL_PRAGMA:
@@ -402,9 +414,9 @@ void Optimizer::RunBuiltInOptimizers() {
 	});
 
 	// perform statistics propagation
-	// Cached plans and DML CTEs can outlive the table statistics captured during planning.
+	// DML CTEs can invalidate the table statistics captured during planning.
 	column_binding_map_t<unique_ptr<BaseStatistics>> statistics_map;
-	if (!reusable_prepared_plan && !CTEContainsDML(*plan)) {
+	if (!CTEContainsDML(*plan)) {
 		RunOptimizer(OptimizerType::STATISTICS_PROPAGATION, [&]() {
 			StatisticsPropagator propagator(*this, *plan);
 			propagator.PropagateStatistics(plan);
@@ -474,6 +486,13 @@ unique_ptr<LogicalOperator> Optimizer::Optimize(unique_ptr<LogicalOperator> plan
 	Verify(*plan_p);
 
 	this->plan = std::move(plan_p);
+	if (plan->type == LogicalOperatorType::LOGICAL_PREPARE) {
+		auto &prepared = plan->Cast<LogicalPrepare>().prepared;
+		// Optimizers can embed the current database state in the executable plan.
+		if (!prepared->properties.read_databases.empty() && ContainsDataSource(*plan)) {
+			prepared->properties.always_require_rebind = true;
+		}
+	}
 
 	for (auto &pre_optimizer_extension : OptimizerExtension::Iterate(context)) {
 		RunOptimizer(OptimizerType::EXTENSION, [&]() {

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -195,6 +195,7 @@ void Optimizer::OptimizeStatement(unique_ptr<SQLStatement> &statement) {
 }
 
 void Optimizer::RunBuiltInOptimizers() {
+	const bool reusable_prepared_plan = plan->type == LogicalOperatorType::LOGICAL_PREPARE;
 	switch (plan->type) {
 	case LogicalOperatorType::LOGICAL_TRANSACTION:
 	case LogicalOperatorType::LOGICAL_PRAGMA:
@@ -401,12 +402,9 @@ void Optimizer::RunBuiltInOptimizers() {
 	});
 
 	// perform statistics propagation
-	// Skip when the plan contains a DML CTE: statistics are captured at plan time
-	// and do not reflect the table state after the DML executes.  Propagating them
-	// can cause filters or scans to be incorrectly eliminated (e.g. replaced with
-	// EMPTY_RESULT because an empty table has no statistics for a given predicate).
+	// Cached plans and DML CTEs can outlive the table statistics captured during planning.
 	column_binding_map_t<unique_ptr<BaseStatistics>> statistics_map;
-	if (!CTEContainsDML(*plan)) {
+	if (!reusable_prepared_plan && !CTEContainsDML(*plan)) {
 		RunOptimizer(OptimizerType::STATISTICS_PROPAGATION, [&]() {
 			StatisticsPropagator propagator(*this, *plan);
 			propagator.PropagateStatistics(plan);

--- a/test/configs/stats_dependent_tests.json
+++ b/test/configs/stats_dependent_tests.json
@@ -43,6 +43,7 @@
         "test/sql/types/geo/geometry_stats.test",
         "test/sql/types/geo/geometry_compatability.test",
         "test/sql/function/numeric/test_random.test",
+        "test/sql/prepared/prepared_statistics_optimization.test",
         "test/sql/copy/parquet/bloom_filters.test",
         "test/sql/copy/parquet/parquet_filename_filter.test",
         "test/sql/copy/parquet/union_by_name_hive_partitioning.test",

--- a/test/configs/verify_aggregate_state_export.json
+++ b/test/configs/verify_aggregate_state_export.json
@@ -49,6 +49,7 @@
         "test/sql/aggregate/aggregates/test_ordered_aggregates.test",
         "test/sql/function/list/aggregates/histogram_decimal.test",
         "test/sql/pivot/pivot_operator_expression.test",
+        "test/sql/prepared/prepared_statistics_optimization.test",
         "test/sql/types/struct/struct_equality_bug.test",
         "test/sql/types/timestamp/test_infinite_time.test",
         "test/sql/variant/variant_comparator.test"

--- a/test/sql/prepared/prepared_stale_statistics.test
+++ b/test/sql/prepared/prepared_stale_statistics.test
@@ -1,0 +1,170 @@
+# name: test/sql/prepared/prepared_stale_statistics.test
+# description: Prepared statements must not reuse plan-time table statistics after data changes
+# group: [prepared]
+
+statement ok
+PRAGMA threads=1;
+
+# A one-shot query can safely use the current table statistics.
+statement ok
+CREATE TABLE filter_t(i INTEGER);
+
+statement ok
+INSERT INTO filter_t SELECT range FROM range(100);
+
+query II
+EXPLAIN SELECT count(*) FROM filter_t WHERE i = 200;
+----
+physical_plan	<REGEX>:.*Empty Result.*
+
+# A prepared plan must not retain the resulting EMPTY_RESULT after the table changes.
+statement ok
+PREPARE stale_filter AS SELECT count(*) FROM filter_t WHERE i = 200;
+
+query I
+EXECUTE stale_filter;
+----
+0
+
+statement ok
+INSERT INTO filter_t VALUES (200);
+
+query I
+EXECUTE stale_filter;
+----
+1
+
+query I
+SELECT count(*) FROM filter_t WHERE i = 200;
+----
+1
+
+query II
+EXPLAIN EXECUTE stale_filter;
+----
+physical_plan	<!REGEX>:.*Empty Result.*
+
+# Join statistics must not become static probe filters in a reusable plan.
+statement ok
+CREATE TABLE probe AS SELECT i::BIGINT AS k FROM range(0, 6144) t(i);
+
+statement ok
+CREATE TABLE build(k BIGINT);
+
+statement ok
+INSERT INTO build VALUES (3000), (5000);
+
+statement ok
+CHECKPOINT;
+
+statement ok
+PREPARE stale_join AS
+SELECT count(*)::BIGINT AS c, coalesce(sum(probe.k), 0)::BIGINT AS s
+FROM probe
+JOIN build USING (k);
+
+query II
+EXECUTE stale_join;
+----
+2	8000
+
+statement ok
+DELETE FROM build;
+
+statement ok
+INSERT INTO build VALUES (1), (2);
+
+query II
+EXECUTE stale_join;
+----
+2	3
+
+query II
+SELECT count(*)::BIGINT AS c, coalesce(sum(probe.k), 0)::BIGINT AS s
+FROM probe
+JOIN build USING (k);
+----
+2	3
+
+# Runtime join filters should remain enabled for prepared plans.
+query II
+EXPLAIN EXECUTE stale_join;
+----
+physical_plan	<REGEX>:.*Dynamic Filters:.*
+
+# Repeated execution must refresh correctly with duplicate and NULL build keys.
+statement ok
+DELETE FROM build;
+
+statement ok
+INSERT INTO build VALUES (1), (1), (2), (NULL);
+
+query II
+EXECUTE stale_join;
+----
+3	4
+
+query II
+SELECT count(*)::BIGINT AS c, coalesce(sum(probe.k), 0)::BIGINT AS s
+FROM probe
+JOIN build USING (k);
+----
+3	4
+
+# The same invariant applies to SEMI joins, where build duplicates do not duplicate probe rows.
+statement ok
+PREPARE stale_semi AS
+SELECT count(*)::BIGINT AS c, coalesce(sum(k), 0)::BIGINT AS s
+FROM probe
+WHERE k IN (SELECT k FROM build);
+
+query II
+EXECUTE stale_semi;
+----
+2	3
+
+statement ok
+DELETE FROM build;
+
+statement ok
+INSERT INTO build VALUES (3000), (3000), (5000), (NULL);
+
+query II
+EXECUTE stale_semi;
+----
+2	8000
+
+query II
+SELECT count(*)::BIGINT AS c, coalesce(sum(k), 0)::BIGINT AS s
+FROM probe
+WHERE k IN (SELECT k FROM build);
+----
+2	8000
+
+# Metadata-only aggregate rewrites must also observe post-prepare changes.
+statement ok
+CREATE TABLE aggregate_t AS SELECT i::INTEGER AS i FROM range(100) t(i);
+
+statement ok
+CHECKPOINT;
+
+statement ok
+PREPARE stale_aggregate AS SELECT min(i), max(i), count(*) FROM aggregate_t;
+
+query III
+EXECUTE stale_aggregate;
+----
+0	99	100
+
+statement ok
+INSERT INTO aggregate_t VALUES (-1), (200);
+
+query III
+EXECUTE stale_aggregate;
+----
+-1	200	102
+
+query III
+SELECT min(i), max(i), count(*) FROM aggregate_t;
+----
+-1	200	102

--- a/test/sql/prepared/prepared_stale_statistics.test
+++ b/test/sql/prepared/prepared_stale_statistics.test
@@ -5,19 +5,12 @@
 statement ok
 PRAGMA threads=1;
 
-# A one-shot query can safely use the current table statistics.
 statement ok
 CREATE TABLE filter_t(i INTEGER);
 
 statement ok
 INSERT INTO filter_t SELECT range FROM range(100);
 
-query II
-EXPLAIN SELECT count(*) FROM filter_t WHERE i = 200;
-----
-physical_plan	<REGEX>:.*Empty Result.*
-
-# A prepared plan must not retain the resulting EMPTY_RESULT after the table changes.
 statement ok
 PREPARE stale_filter AS SELECT count(*) FROM filter_t WHERE i = 200;
 
@@ -39,10 +32,44 @@ SELECT count(*) FROM filter_t WHERE i = 200;
 ----
 1
 
-query II
-EXPLAIN EXECUTE stale_filter;
+# Transaction-local changes and rollbacks must use the current transaction snapshot.
+statement ok
+BEGIN TRANSACTION;
+
+statement ok
+INSERT INTO filter_t VALUES (200);
+
+query I
+EXECUTE stale_filter;
 ----
-physical_plan	<!REGEX>:.*Empty Result.*
+2
+
+statement ok
+ROLLBACK;
+
+query I
+EXECUTE stale_filter;
+----
+1
+
+# The same dependency can be nested below a materialization boundary.
+statement ok
+PREPARE stale_cte AS
+WITH filtered AS MATERIALIZED (SELECT * FROM filter_t WHERE i = 201)
+SELECT count(*) FROM filtered;
+
+query I
+EXECUTE stale_cte;
+----
+0
+
+statement ok
+INSERT INTO filter_t VALUES (201);
+
+query I
+EXECUTE stale_cte;
+----
+1
 
 # Join statistics must not become static probe filters in a reusable plan.
 statement ok
@@ -85,12 +112,6 @@ FROM probe
 JOIN build USING (k);
 ----
 2	3
-
-# Runtime join filters should remain enabled for prepared plans.
-query II
-EXPLAIN EXECUTE stale_join;
-----
-physical_plan	<REGEX>:.*Dynamic Filters:.*
 
 # Repeated execution must refresh correctly with duplicate and NULL build keys.
 statement ok
@@ -168,3 +189,51 @@ query III
 SELECT min(i), max(i), count(*) FROM aggregate_t;
 ----
 -1	200	102
+
+# COUNT rewrites based on nullability statistics must be refreshed.
+statement ok
+CREATE TABLE count_t(i INTEGER);
+
+statement ok
+INSERT INTO count_t VALUES (1), (2);
+
+statement ok
+PREPARE stale_count AS SELECT count(i), count(*) FROM count_t;
+
+query II
+EXECUTE stale_count;
+----
+2	2
+
+statement ok
+INSERT INTO count_t VALUES (NULL);
+
+query II
+EXECUTE stale_count;
+----
+2	3
+
+# Statistics-pruned filters in modifying statements must also be refreshed.
+statement ok
+CREATE TABLE delete_t(i INTEGER);
+
+statement ok
+PREPARE stale_delete AS DELETE FROM delete_t WHERE i = 42;
+
+query I
+EXECUTE stale_delete;
+----
+0
+
+statement ok
+INSERT INTO delete_t VALUES (42);
+
+query I
+EXECUTE stale_delete;
+----
+1
+
+query I
+SELECT count(*) FROM delete_t;
+----
+0

--- a/test/sql/prepared/prepared_statistics_optimization.test
+++ b/test/sql/prepared/prepared_statistics_optimization.test
@@ -1,0 +1,232 @@
+# name: test/sql/prepared/prepared_statistics_optimization.test
+# description: Data-dependent optimizations are retained while prepared plans are rebound
+# group: [prepared]
+
+statement ok
+PRAGMA threads=1;
+
+# Plans without mutable database inputs remain cached.
+statement ok
+PREPARE cached_constant AS SELECT 42;
+
+query I
+SELECT result_types IS NULL FROM duckdb_prepared_statements() WHERE name = 'cached_constant';
+----
+false
+
+# Modifying statements without a database read can also retain their physical plan.
+statement ok
+CREATE TABLE insert_t(i INTEGER);
+
+statement ok
+PREPARE cached_insert AS INSERT INTO insert_t VALUES (42) RETURNING i;
+
+query I
+SELECT result_types IS NULL FROM duckdb_prepared_statements() WHERE name = 'cached_insert';
+----
+false
+
+query I
+EXECUTE cached_insert;
+----
+42
+
+query I
+SELECT count(*) FROM insert_t;
+----
+1
+
+# Temporary modification targets have a catalog read dependency but no data source.
+statement ok
+CREATE TEMP TABLE temp_insert_t(i INTEGER);
+
+statement ok
+PREPARE cached_temp_insert AS INSERT INTO temp_insert_t VALUES (84) RETURNING i;
+
+query I
+SELECT result_types IS NULL FROM duckdb_prepared_statements() WHERE name = 'cached_temp_insert';
+----
+false
+
+query I
+EXECUTE cached_temp_insert;
+----
+84
+
+statement ok
+CREATE TABLE filter_t(i INTEGER);
+
+statement ok
+INSERT INTO filter_t SELECT range FROM range(100);
+
+statement ok
+PREPARE cached_scan AS SELECT i FROM filter_t;
+
+query I
+SELECT result_types IS NULL FROM duckdb_prepared_statements() WHERE name = 'cached_scan';
+----
+true
+
+# Statistics can still eliminate a prepared query while the statistics are current.
+statement ok
+PREPARE stale_filter AS SELECT count(*) FROM filter_t WHERE i = 200;
+
+query II
+EXPLAIN EXECUTE stale_filter;
+----
+physical_plan	<REGEX>:.*Empty Result.*
+
+query I
+SELECT result_types IS NULL FROM duckdb_prepared_statements() WHERE name = 'stale_filter';
+----
+true
+
+statement ok
+INSERT INTO filter_t VALUES (200);
+
+query II
+EXPLAIN EXECUTE stale_filter;
+----
+physical_plan	<!REGEX>:.*Empty Result.*
+
+# Join-derived range filters are regenerated from the current build-side statistics.
+statement ok
+CREATE TABLE probe AS SELECT i::BIGINT AS k FROM range(0, 6144) t(i);
+
+statement ok
+CREATE TABLE build(k BIGINT);
+
+statement ok
+INSERT INTO build VALUES (3000), (5000);
+
+statement ok
+CHECKPOINT;
+
+statement ok
+PREPARE stale_join AS
+SELECT count(*)::BIGINT AS c, coalesce(sum(probe.k), 0)::BIGINT AS s
+FROM probe
+JOIN build USING (k);
+
+query II
+EXPLAIN EXECUTE stale_join;
+----
+physical_plan	<REGEX>:.*Filters: \(k >= 3000\) AND \(k <= 5000\).*
+
+query II
+EXPLAIN ANALYZE EXECUTE stale_join;
+----
+analyzed_plan	<REGEX>:.*Dynamic Filters:.*
+
+statement ok
+DELETE FROM build;
+
+statement ok
+INSERT INTO build VALUES (1), (2);
+
+query II
+EXPLAIN EXECUTE stale_join;
+----
+physical_plan	<REGEX>:.*Filters: \(k >= 1\).*
+
+query II
+EXPLAIN EXECUTE stale_join;
+----
+physical_plan	<!REGEX>:.*Filters: \(k >= 3000\).*
+
+# Metadata aggregate execution remains available and also triggers rebinding.
+statement ok
+CREATE TABLE aggregate_t AS SELECT i::INTEGER AS i FROM range(100) t(i);
+
+statement ok
+CHECKPOINT;
+
+statement ok
+PREPARE stale_aggregate AS SELECT min(i), max(i), count(*) FROM aggregate_t;
+
+query I
+SELECT result_types IS NULL FROM duckdb_prepared_statements() WHERE name = 'stale_aggregate';
+----
+true
+
+# Statistics callbacks that populate aggregate bind data must also be refreshed.
+statement ok
+CREATE TABLE bitstring_t(i INTEGER);
+
+statement ok
+INSERT INTO bitstring_t VALUES (1), (2);
+
+statement ok
+PREPARE stale_bitstring AS SELECT bit_count(bitstring_agg(i)) FROM bitstring_t;
+
+query I
+EXECUTE stale_bitstring;
+----
+2
+
+statement ok
+INSERT INTO bitstring_t VALUES (4);
+
+query I
+EXECUTE stale_bitstring;
+----
+3
+
+# Scalar statistics callbacks can also materialize current statistics in bind data.
+statement ok
+CREATE TABLE stats_t(i INTEGER);
+
+statement ok
+INSERT INTO stats_t VALUES (1), (2);
+
+statement ok
+PREPARE stale_stats AS
+SELECT s.min, s.max, s.has_null
+FROM (SELECT stats(i) AS s FROM stats_t LIMIT 1);
+
+query III
+EXECUTE stale_stats;
+----
+1	2	false
+
+statement ok
+INSERT INTO stats_t VALUES (5), (NULL);
+
+query III
+EXECUTE stale_stats;
+----
+1	5	true
+
+# Other data-dependent optimizers must also trigger rebinding independently of statistics propagation.
+statement ok
+SET disabled_optimizers = 'statistics_propagation';
+
+statement ok
+CREATE TABLE row_group_t AS SELECT i::INTEGER AS i FROM range(245760) t(i);
+
+statement ok
+CHECKPOINT;
+
+statement ok
+PREPARE stale_row_group AS SELECT i FROM row_group_t ORDER BY i LIMIT 1 OFFSET 122880;
+
+query I
+EXECUTE stale_row_group;
+----
+122880
+
+statement ok
+INSERT INTO row_group_t VALUES (-1);
+
+query I
+EXECUTE stale_row_group;
+----
+122879
+
+query I
+SELECT i FROM row_group_t ORDER BY i LIMIT 1 OFFSET 122880;
+----
+122879
+
+statement ok
+SET disabled_optimizers = '';


### PR DESCRIPTION
Prepared statements currently run statistics propagation while their reusable plan is created. This allows statistics from the current table contents to become semantic changes in a plan that may execute after those contents have changed.

This causes both #23704 and #24182. In #23704, statistics replace a filtered scan with an `EMPTY_RESULT`, so rows inserted after preparation remain invisible. In #24182, join statistics add a static min/max range to the probe side. The runtime dynamic filter is refreshed on each execution, but the stale static range can still discard valid matches after the build side changes.

A reusable plan must not depend on mutable storage statistics. I enforce that invariant at the optimizer boundary by skipping statistics propagation for `LOGICAL_PREPARE` plans. One-shot queries continue to use statistics, and prepared joins still receive runtime dynamic filters.

This deliberately gives up statistics-driven rewrites for prepared statements, including metadata aggregate rewrites and statistics-based physical operator selection. I prefer that conservative trade-off over blocking only the two transformations observed here, since other statistics-driven rewrites could violate the same plan-lifetime invariant.

A possible follow-up would be to make prepared plans track the mutable statistics sources they depend on and rebind only when a relevant data version changes. That would preserve these rewrites while the underlying data remains unchanged. DuckDB currently tracks catalog changes for prepared-plan invalidation but does not have an equivalent MVCC-aware data version, so handling transaction-local writes, commits, rollbacks, concurrent snapshots, and external table functions belongs in a separate change.

Fixes #23704.
Fixes #24182.
Fixes https://github.com/duckdblabs/duckdb-internal/issues/10231.