### PR TITLE
Push down ungrouped aggregates into file readers

### DIFF
--- a/extension/parquet/include/parquet_multi_file_info.hpp
+++ b/extension/parquet/include/parquet_multi_file_info.hpp
@@ -72,9 +72,7 @@ struct ParquetMultiFileInfo : MultiFileReaderInterface {
 	                                                           MultiFileGlobalState &global_state) override;
 	unique_ptr<LocalTableFunctionState> InitializeLocalState(ClientContext &, GlobalTableFunctionState &) override;
 
-	bool SupportsReadAhead(const MultiFileBindData &bind_data) const override {
-		return true;
-	}
+	bool SupportsReadAhead(const MultiFileBindData &bind_data) const override;
 	shared_ptr<BaseFileReader> CreateReader(ClientContext &context, GlobalTableFunctionState &gstate,
 	                                        BaseUnionData &union_data, const MultiFileBindData &bind_data_p) override;
 	shared_ptr<BaseFileReader> CreateReader(ClientContext &context, GlobalTableFunctionState &gstate,
@@ -88,6 +86,9 @@ struct ParquetMultiFileInfo : MultiFileReaderInterface {
 	void GetVirtualColumns(ClientContext &context, MultiFileBindData &bind_data, virtual_column_map_t &result) override;
 	unique_ptr<MultiFileReaderInterface> Copy() override;
 	FileGlobInput GetGlobInput() override;
+	bool TryPushdownAggregates(ClientContext &context, MultiFileBindData &bind_data,
+	                           const TableFunctionAggregateInput &input) override;
+	bool FinalizeScan(ClientContext &context, GlobalTableFunctionState &global_state, DataChunk &output) override;
 };
 
 class ParquetScanFunction {

--- a/extension/parquet/parquet_multi_file_info.cpp
+++ b/extension/parquet/parquet_multi_file_info.cpp
@@ -61,6 +61,8 @@ struct ParquetReadBindData : public TableFunctionData {
 	idx_t explicit_cardinality = 0; // can be set to inject exterior cardinality knowledge (e.g. from a data lake)
 	unique_ptr<ParquetFileReaderOptions> options;
 	unordered_map<idx_t, ParquetReaderProjectionExpression> projection_expressions;
+	//! Every aggregate pushed into this scan is a count(*):
+	bool count_star_pushdown = false;
 
 	ParquetOptions &GetParquetOptions() {
 		return options->options;
@@ -78,6 +80,7 @@ struct ParquetReadBindData : public TableFunctionData {
 		result->explicit_cardinality = explicit_cardinality;
 		result->options = make_uniq<ParquetFileReaderOptions>(options->options);
 		result->projection_expressions = projection_expressions;
+		result->count_star_pushdown = count_star_pushdown;
 		return std::move(result);
 	}
 
@@ -99,6 +102,9 @@ struct ParquetReadGlobalState : public GlobalTableFunctionState {
 	atomic<idx_t> row_groups_scanned_unreported {0};
 	//! Total considered, across all scan states
 	atomic<idx_t> total_row_groups_to_scan {0};
+	bool count_star_pushdown = false;
+	atomic<idx_t> count_star {0};
+	atomic<bool> count_star_written {false};
 };
 
 struct ParquetReadLocalState : public LocalTableFunctionState {
@@ -299,6 +305,7 @@ static void ParquetScanSerialize(Serializer &serializer, const optional_ptr<Func
 	// don't push this field. If projection expression worked,
 	// it modified "types" which we serialize ultimately
 	serializer.WriteProperty(105, "projection_expressions", parquet_data.projection_expressions);
+	serializer.WritePropertyWithDefault(106, "count_star_pushdown", parquet_data.count_star_pushdown, false);
 }
 
 static unique_ptr<FunctionData> ParquetScanDeserialize(Deserializer &deserializer, TableFunction &function) {
@@ -312,6 +319,7 @@ static unique_ptr<FunctionData> ParquetScanDeserialize(Deserializer &deserialize
 	auto projection_expressions =
 	    deserializer.ReadPropertyWithExplicitDefault<unordered_map<idx_t, ParquetReaderProjectionExpression>>(
 	        105, "projection_expressions", unordered_map<idx_t, ParquetReaderProjectionExpression> {});
+	auto count_star_pushdown = deserializer.ReadPropertyWithExplicitDefault<bool>(106, "count_star_pushdown", false);
 
 	vector<Value> file_path;
 	for (auto &path : files) {
@@ -333,6 +341,8 @@ static unique_ptr<FunctionData> ParquetScanDeserialize(Deserializer &deserialize
 	inner_bind_data.table_columns = std::move(table_columns);
 	auto &parquet_bind_data = inner_bind_data.bind_data->Cast<ParquetReadBindData>();
 	parquet_bind_data.projection_expressions = std::move(projection_expressions);
+	parquet_bind_data.count_star_pushdown = count_star_pushdown;
+	inner_bind_data.aggregates_pushed = count_star_pushdown;
 
 	for (const auto &[idx, expr] : parquet_bind_data.projection_expressions) {
 		if (idx < inner_bind_data.columns.size()) {
@@ -380,6 +390,41 @@ static void ParquetScanGetMetrics(TableFunctionGetMetricsInput &input) {
 	// each local state drains the not-yet-reported count
 	input.operator_metrics.row_groups_scanned = parquet_gstate.row_groups_scanned_unreported.exchange(0);
 	input.operator_metrics.total_row_groups_to_scan = parquet_gstate.total_row_groups_to_scan.load();
+}
+
+bool ParquetMultiFileInfo::TryPushdownAggregates(ClientContext &context, MultiFileBindData &bind_data,
+                                                 const TableFunctionAggregateInput &input) {
+	// Don't do pushdown on custom schema users like Ducklake.
+	// We may support it and UNION readers in the future
+	if (!bind_data.reader_bind.schema.empty() || !bind_data.union_readers.empty()) {
+		return false;
+	}
+	for (const auto &[column_index, expr] : input.projections) {
+		if (column_index.IsValid()) { // only count(*) is supported
+			return false;
+		}
+	}
+	bind_data.bind_data->Cast<ParquetReadBindData>().count_star_pushdown = true;
+	return true;
+}
+
+bool ParquetMultiFileInfo::SupportsReadAhead(const MultiFileBindData &bind_data) const {
+	// count(*) is answered from footer metadata, there is no column IO
+	return !bind_data.bind_data->Cast<ParquetReadBindData>().count_star_pushdown;
+}
+
+bool ParquetMultiFileInfo::FinalizeScan(ClientContext &context, GlobalTableFunctionState &global_state,
+                                        DataChunk &output) {
+	auto &gstate = global_state.Cast<ParquetReadGlobalState>();
+	if (!gstate.count_star_pushdown || gstate.count_star_written.exchange(true)) {
+		return false;
+	}
+	const auto count = Value::BIGINT(NumericCast<int64_t>(gstate.count_star.load()));
+	for (idx_t col_idx = 0; col_idx < output.ColumnCount(); col_idx++) {
+		output.data[col_idx].Append(count);
+	}
+	output.CheckCardinality(1);
+	return true;
 }
 
 static bool ParquetProjectionExpressionPushdown(ClientContext &context,
@@ -895,9 +940,12 @@ shared_ptr<BaseUnionData> ParquetReader::GetUnionData(idx_t file_idx) {
 	return std::move(result);
 }
 
-unique_ptr<GlobalTableFunctionState> ParquetMultiFileInfo::InitializeGlobalState(ClientContext &, MultiFileBindData &,
+unique_ptr<GlobalTableFunctionState> ParquetMultiFileInfo::InitializeGlobalState(ClientContext &,
+                                                                                 MultiFileBindData &bind_data,
                                                                                  MultiFileGlobalState &global_state) {
-	return make_uniq<ParquetReadGlobalState>(global_state.op);
+	auto result = make_uniq<ParquetReadGlobalState>(global_state.op);
+	result->count_star_pushdown = bind_data.bind_data->Cast<ParquetReadBindData>().count_star_pushdown;
+	return std::move(result);
 }
 
 unique_ptr<LocalTableFunctionState> ParquetMultiFileInfo::InitializeLocalState(ClientContext &,
@@ -909,6 +957,9 @@ bool ParquetReader::TryInitializeScan(ClientContext &context, GlobalTableFunctio
                                       LocalTableFunctionState &lstate_p) {
 	auto &gstate = gstate_p.Cast<ParquetReadGlobalState>();
 	auto &lstate = lstate_p.Cast<ParquetReadLocalState>();
+	if (gstate.count_star_pushdown) {
+		return false; // count(*) is taken from metadata, don't read row groups
+	}
 	if (gstate.row_group_index >= NumRowGroups()) {
 		// scanned all row groups in this file
 		return false;
@@ -944,6 +995,9 @@ AsyncResult ParquetReader::ScheduleIO(ClientContext &context, GlobalTableFunctio
 
 void ParquetReader::FinishFile(ClientContext &context, GlobalTableFunctionState &gstate_p) {
 	auto &gstate = gstate_p.Cast<ParquetReadGlobalState>();
+	if (gstate.count_star_pushdown) {
+		gstate.count_star += NumericCast<idx_t>(GetFileMetadata()->num_rows);
+	}
 	gstate.row_group_index = 0;
 }
 

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -3964,19 +3964,20 @@ const StringUtil::EnumStringLiteral *GetOptimizerTypeValues() {
 		{ static_cast<uint32_t>(OptimizerType::TYPE_PUSHDOWN), "TYPE_PUSHDOWN" },
 		{ static_cast<uint32_t>(OptimizerType::SCALAR_FN_PUSHDOWN), "SCALAR_FN_PUSHDOWN" },
 		{ static_cast<uint32_t>(OptimizerType::DISTINCT_AGGREGATE_REWRITE), "DISTINCT_AGGREGATE_REWRITE" },
-		{ static_cast<uint32_t>(OptimizerType::AGGREGATE_REUSE), "AGGREGATE_REUSE" }
+		{ static_cast<uint32_t>(OptimizerType::AGGREGATE_REUSE), "AGGREGATE_REUSE" },
+		{ static_cast<uint32_t>(OptimizerType::AGGREGATE_FN_PUSHDOWN), "AGGREGATE_FN_PUSHDOWN" }
 	};
 	return values;
 }
 
 template<>
 const char* EnumUtil::ToChars<OptimizerType>(OptimizerType value) {
-	return StringUtil::EnumToString(GetOptimizerTypeValues(), 45, "OptimizerType", static_cast<uint32_t>(value));
+	return StringUtil::EnumToString(GetOptimizerTypeValues(), 46, "OptimizerType", static_cast<uint32_t>(value));
 }
 
 template<>
 OptimizerType EnumUtil::FromString<OptimizerType>(const char *value) {
-	return static_cast<OptimizerType>(StringUtil::StringToEnum(GetOptimizerTypeValues(), 45, "OptimizerType", value));
+	return static_cast<OptimizerType>(StringUtil::StringToEnum(GetOptimizerTypeValues(), 46, "OptimizerType", value));
 }
 
 const StringUtil::EnumStringLiteral *GetOrderByColumnTypeValues() {

--- a/src/common/enums/optimizer_type.cpp
+++ b/src/common/enums/optimizer_type.cpp
@@ -57,6 +57,7 @@ static const DefaultOptimizerType internal_optimizer_types[] = {
     {"scalar_fn_pushdown", OptimizerType::SCALAR_FN_PUSHDOWN},
     {"distinct_aggregate_rewrite", OptimizerType::DISTINCT_AGGREGATE_REWRITE},
     {"aggregate_reuse", OptimizerType::AGGREGATE_REUSE},
+    {"aggregate_fn_pushdown", OptimizerType::AGGREGATE_FN_PUSHDOWN},
     {nullptr, OptimizerType::INVALID}};
 
 string OptimizerTypeToString(OptimizerType type) {

--- a/src/common/multi_file/multi_file_reader.cpp
+++ b/src/common/multi_file/multi_file_reader.cpp
@@ -68,6 +68,7 @@ unique_ptr<FunctionData> MultiFileBindData::Copy() const {
 	result->names = names;
 	result->virtual_columns = virtual_columns;
 	result->table_columns = table_columns;
+	result->aggregates_pushed = aggregates_pushed;
 	return std::move(result);
 }
 

--- a/src/function/table_function.cpp
+++ b/src/function/table_function.cpp
@@ -23,9 +23,9 @@ TableFunction::TableFunction(Identifier name, const vector<LogicalType> &argumen
       in_out_function(nullptr), in_out_function_final(nullptr), statistics(nullptr), statistics_extended(nullptr),
       dependency(nullptr), cardinality(nullptr), get_metrics(nullptr), pushdown_complex_filter(nullptr),
       pushdown_expression(nullptr), to_string(nullptr), table_scan_progress(nullptr), get_partition_data(nullptr),
-      get_bind_info(nullptr), projection_expression_pushdown(nullptr), get_multi_file_reader(nullptr),
-      supports_pushdown_type(nullptr), supports_pushdown_extract(nullptr), is_repeatable(nullptr),
-      get_partition_info(nullptr), get_partition_stats(nullptr), get_virtual_columns(nullptr),
+      get_bind_info(nullptr), projection_expression_pushdown(nullptr), aggregate_pushdown(nullptr),
+      get_multi_file_reader(nullptr), supports_pushdown_type(nullptr), supports_pushdown_extract(nullptr),
+      is_repeatable(nullptr), get_partition_info(nullptr), get_partition_stats(nullptr), get_virtual_columns(nullptr),
       get_row_id_columns(nullptr), set_scan_order(nullptr), serialize(nullptr), deserialize(nullptr),
       projection_pushdown(false), filter_pushdown(false), filter_prune(false), sampling_pushdown(false),
       late_materialization(false), return_type(TableFunctionReturnType::TABLE_RETURNING_FUNCTION) {
@@ -39,9 +39,9 @@ TableFunction::TableFunction(Identifier name, const vector<LogicalType> &argumen
       in_out_function(nullptr), in_out_function_final(nullptr), statistics(nullptr), statistics_extended(nullptr),
       dependency(nullptr), cardinality(nullptr), get_metrics(nullptr), pushdown_complex_filter(nullptr),
       pushdown_expression(nullptr), to_string(nullptr), table_scan_progress(nullptr), get_partition_data(nullptr),
-      get_bind_info(nullptr), projection_expression_pushdown(nullptr), get_multi_file_reader(nullptr),
-      supports_pushdown_type(nullptr), supports_pushdown_extract(nullptr), is_repeatable(nullptr),
-      get_partition_info(nullptr), get_partition_stats(nullptr), get_virtual_columns(nullptr),
+      get_bind_info(nullptr), projection_expression_pushdown(nullptr), aggregate_pushdown(nullptr),
+      get_multi_file_reader(nullptr), supports_pushdown_type(nullptr), supports_pushdown_extract(nullptr),
+      is_repeatable(nullptr), get_partition_info(nullptr), get_partition_stats(nullptr), get_virtual_columns(nullptr),
       get_row_id_columns(nullptr), set_scan_order(nullptr), serialize(nullptr), deserialize(nullptr),
       projection_pushdown(false), filter_pushdown(false), filter_prune(false), sampling_pushdown(false),
       late_materialization(false), return_type(TableFunctionReturnType::TABLE_RETURNING_FUNCTION) {
@@ -71,15 +71,15 @@ bool TableFunction::operator==(const TableFunction &rhs) const {
 	       to_string == rhs.to_string && table_scan_progress == rhs.table_scan_progress &&
 	       get_partition_data == rhs.get_partition_data && get_bind_info == rhs.get_bind_info &&
 	       projection_expression_pushdown == rhs.projection_expression_pushdown &&
-	       get_multi_file_reader == rhs.get_multi_file_reader && supports_pushdown_type == rhs.supports_pushdown_type &&
-	       is_repeatable == rhs.is_repeatable && get_partition_info == rhs.get_partition_info &&
-	       get_partition_stats == rhs.get_partition_stats && get_virtual_columns == rhs.get_virtual_columns &&
-	       get_row_id_columns == rhs.get_row_id_columns && serialize == rhs.serialize &&
-	       deserialize == rhs.deserialize && verify_serialization == rhs.verify_serialization &&
-	       projection_pushdown == rhs.projection_pushdown && filter_pushdown == rhs.filter_pushdown &&
-	       filter_prune == rhs.filter_prune && sampling_pushdown == rhs.sampling_pushdown &&
-	       late_materialization == rhs.late_materialization && return_type == rhs.return_type &&
-	       global_initialization == rhs.global_initialization;
+	       aggregate_pushdown == rhs.aggregate_pushdown && get_multi_file_reader == rhs.get_multi_file_reader &&
+	       supports_pushdown_type == rhs.supports_pushdown_type && is_repeatable == rhs.is_repeatable &&
+	       get_partition_info == rhs.get_partition_info && get_partition_stats == rhs.get_partition_stats &&
+	       get_virtual_columns == rhs.get_virtual_columns && get_row_id_columns == rhs.get_row_id_columns &&
+	       serialize == rhs.serialize && deserialize == rhs.deserialize &&
+	       verify_serialization == rhs.verify_serialization && projection_pushdown == rhs.projection_pushdown &&
+	       filter_pushdown == rhs.filter_pushdown && filter_prune == rhs.filter_prune &&
+	       sampling_pushdown == rhs.sampling_pushdown && late_materialization == rhs.late_materialization &&
+	       return_type == rhs.return_type && global_initialization == rhs.global_initialization;
 }
 
 bool TableFunction::operator!=(const TableFunction &rhs) const {

--- a/src/include/duckdb/common/enums/optimizer_type.hpp
+++ b/src/include/duckdb/common/enums/optimizer_type.hpp
@@ -58,7 +58,8 @@ enum class OptimizerType : uint32_t {
 	TYPE_PUSHDOWN = 41,
 	SCALAR_FN_PUSHDOWN = 42,
 	DISTINCT_AGGREGATE_REWRITE = 43,
-	AGGREGATE_REUSE = 44
+	AGGREGATE_REUSE = 44,
+	AGGREGATE_FN_PUSHDOWN = 45
 };
 
 string OptimizerTypeToString(OptimizerType type);

--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -64,6 +64,11 @@ struct MultiFileReaderInterface {
 	                                                const MultiFileOptions &file_options);
 	virtual void FinishReading(ClientContext &context, GlobalTableFunctionState &global_state,
 	                           LocalTableFunctionState &local_state);
+	//! Emit one chunk after every file has been read. Implementations must sync inside this function so
+	//! chunk is produced once per scan
+	virtual bool FinalizeScan(ClientContext &context, GlobalTableFunctionState &global_state, DataChunk &output) {
+		return false;
+	}
 	virtual unique_ptr<NodeStatistics> GetCardinality(const MultiFileBindData &bind_data, idx_t file_count) {
 		return nullptr;
 	}
@@ -74,6 +79,11 @@ struct MultiFileReaderInterface {
 	virtual void GetVirtualColumns(ClientContext &context, MultiFileBindData &bind_data, virtual_column_map_t &result);
 	virtual unique_ptr<MultiFileReaderInterface> Copy();
 	virtual FileGlobInput GetGlobInput();
+	//! True if reader can compute all aggregates in "input".
+	virtual bool TryPushdownAggregates(ClientContext &context, MultiFileBindData &bind_data,
+	                                   const TableFunctionAggregateInput &input) {
+		return false;
+	}
 };
 
 template <class OP>
@@ -91,6 +101,7 @@ public:
 		get_partition_info = MultiFileGetPartitionInfo;
 		get_virtual_columns = MultiFileGetVirtualColumns;
 		get_metrics = MultiFileGetMetrics;
+		aggregate_pushdown = MultiFileAggregatePushdown;
 		MultiFileReader::AddParameters(*this);
 	}
 
@@ -264,6 +275,24 @@ public:
 		                                    names, std::move(file_options), std::move(options), std::move(interface));
 		expected_names = IdentifiersToStrings(names);
 		return result;
+	}
+
+	static bool MultiFileAggregatePushdown(ClientContext &context, const TableFunctionAggregateInput &input) {
+		auto &bind_data = input.get.bind_data->CastNoConst<MultiFileBindData>();
+		if (IsEmptyResult(bind_data)) {
+			return false;
+		}
+		if (input.get.table_filters.HasFilters()) {
+			return false;
+		}
+		if (input.get.extra_info.sample_options) {
+			return false;
+		}
+		if (!bind_data.interface->TryPushdownAggregates(context, bind_data, input)) {
+			return false;
+		}
+		bind_data.aggregates_pushed = true;
+		return true;
 	}
 
 	static unique_ptr<MultiFileList> MultiFileFilterPushdown(ClientContext &context, const MultiFileBindData &data,
@@ -633,6 +662,13 @@ public:
 			return std::move(result);
 		}
 
+		if (bind_data.aggregates_pushed) {
+			// column ids refer to aggregates GET was rewritten to return and not
+			// bind_data.columns
+			input.column_ids.clear();
+			input.column_indexes.clear();
+		}
+
 		// before instantiating a scan trigger a dynamic filter pushdown if possible
 		auto new_list = MultiFileFilterPushdown(context, bind_data, input.column_indexes, input.filters);
 		if (new_list) {
@@ -734,8 +770,11 @@ public:
 	static OperatorPartitionData MultiFileGetPartitionData(ClientContext &context,
 	                                                       TableFunctionGetPartitionInput &input) {
 		auto &bind_data = input.bind_data->CastNoConst<MultiFileBindData>();
-		auto &data = input.local_state->Cast<MultiFileLocalState>();
 		auto &gstate = input.global_state->Cast<MultiFileGlobalState>();
+		if (!input.local_state || bind_data.aggregates_pushed) {
+			return OperatorPartitionData(gstate.batch_index);
+		}
+		auto &data = input.local_state->Cast<MultiFileLocalState>();
 		OperatorPartitionData partition_data(data.job.batch_index);
 		bind_data.multi_file_reader->GetPartitionData(context, bind_data.reader_bind, *data.job.reader_data,
 		                                              gstate.multi_file_reader_state, input.partition_info,
@@ -881,6 +920,13 @@ public:
 
 	static void MultiFileScan(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
 		if (!data_p.local_state) {
+			auto &gstate = data_p.global_state->Cast<MultiFileGlobalState>();
+			auto &bind_data = data_p.bind_data->CastNoConst<MultiFileBindData>();
+			if (gstate.global_state && bind_data.interface &&
+			    bind_data.interface->FinalizeScan(context, *gstate.global_state, output)) {
+				data_p.async_result = SourceResultType::HAVE_MORE_OUTPUT;
+				return;
+			}
 			data_p.async_result = SourceResultType::FINISHED;
 			return;
 		}
@@ -897,6 +943,10 @@ public:
 				case MultiFileAcquireResult::PARKED:
 					return;
 				case MultiFileAcquireResult::EXHAUSTED:
+					if (bind_data.interface->FinalizeScan(context, *gstate.global_state, output)) {
+						data_p.async_result = SourceResultType::HAVE_MORE_OUTPUT;
+						return;
+					}
 					data_p.async_result = SourceResultType::FINISHED;
 					return;
 				case MultiFileAcquireResult::ACQUIRED:

--- a/src/include/duckdb/common/multi_file/multi_file_states.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_states.hpp
@@ -89,6 +89,7 @@ struct MultiFileBindData : public TableFunctionData {
 	shared_ptr<BaseFileReader> initial_reader;
 	// The union readers are created (when the union_by_name option is on) during binding
 	vector<shared_ptr<BaseUnionData>> union_readers;
+	bool aggregates_pushed = false;
 
 	void Initialize(shared_ptr<BaseFileReader> reader) {
 		initial_reader = std::move(reader);

--- a/src/include/duckdb/function/table_function.hpp
+++ b/src/include/duckdb/function/table_function.hpp
@@ -211,6 +211,13 @@ struct TableFunctionProjectionExpressionInput {
 	ProjectionIndex column_index;
 };
 
+struct TableFunctionAggregateInput {
+	const LogicalGet &get;
+	//! Column scan index -> aggregate expression
+	//! For count_star() ProjectionIndex is default-constructed
+	const vector<pair<ProjectionIndex, reference<const Expression>>> &projections;
+};
+
 struct TableFunctionToStringInput {
 	TableFunctionToStringInput(const TableFunction &table_function_p, optional_ptr<const FunctionData> bind_data_p)
 	    : table_function(table_function_p), bind_data(bind_data_p) {
@@ -368,6 +375,7 @@ typedef unique_ptr<FunctionData> (*table_function_deserialize_t)(Deserializer &d
 
 typedef bool (*table_function_projection_expression_pushdown_t)(ClientContext &context,
                                                                 const TableFunctionProjectionExpressionInput &input);
+typedef bool (*table_function_aggregate_pushdown_t)(ClientContext &context, const TableFunctionAggregateInput &input);
 typedef TablePartitionInfo (*table_function_get_partition_info_t)(ClientContext &context,
                                                                   TableFunctionPartitionInput &input);
 
@@ -492,6 +500,9 @@ public:
 	//! casts like "col as UINTEGER" in "SELECT col::UINTEGER" to scanner.
 	//! Returns true if pushdown was successful
 	table_function_projection_expression_pushdown_t projection_expression_pushdown;
+	//! (Optional) pushes aggregates like count_star() in "SELECT count(*)" to scanner.
+	//! Returns true if pushdown was successful
+	table_function_aggregate_pushdown_t aggregate_pushdown;
 	//! (Optional) allows injecting a custom MultiFileReader implementation
 	table_function_get_multi_file_reader_t get_multi_file_reader;
 	//! (Optional) If this scanner supports filter pushdown, but not to all data types

--- a/src/include/duckdb/optimizer/aggregate_fn_pushdown.hpp
+++ b/src/include/duckdb/optimizer/aggregate_fn_pushdown.hpp
@@ -1,0 +1,37 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/optimizer/aggregate_fn_pushdown.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+#include "duckdb/optimizer/type_pushdown.hpp"
+
+namespace duckdb {
+class LogicalAggregate;
+
+unique_ptr<LogicalOperator> TryPushdownAggregateFunctions(ClientContext &context, unique_ptr<LogicalOperator> plan);
+
+unique_ptr<LogicalOperator> RewriteAggregates(ClientContext &context, unique_ptr<LogicalOperator> op,
+                                              Analyses &analyses, const Projections &projections);
+
+unique_ptr<LogicalOperator> TryReplaceAggregate(ClientContext &context, unique_ptr<LogicalOperator> op,
+                                                Analyses &analyses, const Projections &projections);
+
+// return GET for UNGROUPED_AGGREGATE -> [GET] or for UNGROUPED_AGGREGATE ->
+// PROJECTION -> [GET], nullptr if not found.
+LogicalGet *GetChildGet(const LogicalAggregate &agg);
+
+// Push UNGROUPED_AGGREGATE's of form agg(T) and count_star() into GET.
+class AggregateFnPushdown {
+public:
+	explicit inline AggregateFnPushdown(ClientContext &context) : context(context) {
+	}
+	unique_ptr<LogicalOperator> Optimize(unique_ptr<LogicalOperator> op);
+
+private:
+	ClientContext &context;
+};
+} // namespace duckdb

--- a/src/include/duckdb/optimizer/type_pushdown.hpp
+++ b/src/include/duckdb/optimizer/type_pushdown.hpp
@@ -112,6 +112,9 @@ unique_ptr<LogicalOperator> PushdownOptimize(ClientContext &context, unique_ptr<
 
 	bool any_pushed = false;
 	for (auto &[_, analysis] : analyses) {
+		if (analysis.get.function.projection_expression_pushdown == nullptr) {
+			continue;
+		}
 		for (auto &[column_index, expr] : analysis.col_to_expr) {
 			if (expr == nullptr) { // Conflict for column
 				continue;

--- a/src/optimizer/CMakeLists.txt
+++ b/src/optimizer/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library_unity(
   duckdb_optimizer
   OBJECT
   aggregate_rewrite.cpp
+  aggregate_fn_pushdown.cpp
   aggregate_function_rewriter.cpp
   aggregate_reuse.cpp
   materialized_aggregate_reuse.cpp

--- a/src/optimizer/aggregate_fn_pushdown.cpp
+++ b/src/optimizer/aggregate_fn_pushdown.cpp
@@ -1,0 +1,134 @@
+#include "duckdb/optimizer/aggregate_fn_pushdown.hpp"
+#include "duckdb/planner/expression/bound_aggregate_expression.hpp"
+#include "duckdb/planner/expression/bound_columnref_expression.hpp"
+#include "duckdb/planner/operator/logical_aggregate.hpp"
+
+namespace duckdb {
+
+unique_ptr<LogicalOperator> AggregateFnPushdown::Optimize(unique_ptr<LogicalOperator> op) {
+	Analyses analyses;
+	Projections projections;
+	FindGetsAndProjections(*op, analyses, projections);
+	if (analyses.empty()) {
+		return op;
+	}
+	return RewriteAggregates(context, std::move(op), analyses, projections);
+}
+
+unique_ptr<LogicalOperator> RewriteAggregates(ClientContext &context, unique_ptr<LogicalOperator> op,
+                                              Analyses &analyses, const Projections &projections) {
+	for (auto &child : op->children) {
+		child = RewriteAggregates(context, std::move(child), analyses, projections);
+	}
+	if (op->type == LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY) {
+		return TryReplaceAggregate(context, std::move(op), analyses, projections);
+	}
+	return op;
+}
+
+static bool IsUngrouped(const LogicalAggregate &agg) {
+	return agg.groups.empty() && agg.grouping_sets.empty() && agg.grouping_functions.empty() &&
+	       !agg.expressions.empty();
+}
+
+static const ProjectionIndex COUNT_STAR_PROJ_IDX = ProjectionIndex();
+
+unique_ptr<LogicalOperator> TryReplaceAggregate(ClientContext &context, unique_ptr<LogicalOperator> op,
+                                                Analyses &analyses, const Projections &projections) {
+	LogicalAggregate &agg = op->Cast<LogicalAggregate>();
+	if (!IsUngrouped(agg)) {
+		return op;
+	}
+
+	LogicalGet *const get = GetChildGet(agg);
+	if (get == nullptr) {
+		return op;
+	}
+
+	vector<pair<ProjectionIndex, reference<const Expression>>> input;
+	const idx_t aggregates_len = agg.expressions.size();
+	input.reserve(aggregates_len);
+
+	for (const auto &expr : agg.expressions) {
+		if (expr->GetExpressionClass() != ExpressionClass::BOUND_AGGREGATE) {
+			return op;
+		}
+		const auto &bound_aggr = expr->Cast<BoundAggregateExpression>();
+		if (bound_aggr.IsDistinct() || bound_aggr.GetFilter() != nullptr || bound_aggr.GetOrderBys() != nullptr) {
+			return op;
+		}
+
+		if (bound_aggr.Function().GetName() == "count_star") {
+			input.emplace_back(COUNT_STAR_PROJ_IDX, *expr);
+			continue;
+		}
+
+		if (bound_aggr.GetChildren().size() != 1 ||
+		    bound_aggr.GetChildren()[0]->GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
+			return op;
+		}
+		const auto &bound_col = bound_aggr.GetChildren()[0]->Cast<BoundColumnRefExpression>();
+		const auto binding = Resolve(bound_col.Binding(), analyses, projections);
+		if (!binding || &binding->analysis.get != get) {
+			return op;
+		}
+		input.emplace_back(binding->column_index, *expr);
+	}
+
+	TableFunctionAggregateInput pushdown_input {*get, input};
+	if (!get->function.aggregate_pushdown(context, pushdown_input)) {
+		return op;
+	}
+
+	// GET now returns one column per aggregate. Expand existing columns
+	auto &column_ids = get->GetMutableColumnIds();
+	get->types.resize(aggregates_len);
+	get->returned_types.resize(aggregates_len);
+	column_ids.resize(aggregates_len);
+
+	vector<Identifier> names(aggregates_len); // need a copy because we reference original names
+
+	for (idx_t i = 0; i < aggregates_len; i++) {
+		const auto &[column_index, expr] = input[i];
+		if (column_index == COUNT_STAR_PROJ_IDX) {
+			names[i] = "count_star()";
+		} else {
+			const idx_t storage_index = get->GetColumnIds()[column_index].GetPrimaryIndex();
+			names[i] = get->names[storage_index];
+		}
+		get->types[i] = expr.get().GetReturnType();
+		get->returned_types[i] = expr.get().GetReturnType();
+		column_ids[i] = ColumnIndex(i);
+	}
+	get->names = std::move(names);
+	get->projection_ids.clear();
+	get->table_index = agg.aggregate_index;
+
+	unique_ptr<LogicalOperator> &child = agg.children[0];
+	if (child->type == LogicalOperatorType::LOGICAL_GET) {
+		return std::move(child);
+	}
+	D_ASSERT(child->type == LogicalOperatorType::LOGICAL_PROJECTION);
+	D_ASSERT(child->children.size() == 1);
+	D_ASSERT(child->children[0]->type == LogicalOperatorType::LOGICAL_GET);
+	return std::move(child->children[0]);
+}
+
+LogicalGet *GetChildGet(const LogicalAggregate &agg) {
+	if (agg.children.size() != 1) {
+		return nullptr;
+	}
+	LogicalOperator &child = *agg.children[0];
+	LogicalOperator *op;
+	if (child.type == LogicalOperatorType::LOGICAL_GET) {
+		op = &child;
+	} else if (child.type == LogicalOperatorType::LOGICAL_PROJECTION && child.children.size() == 1 &&
+	           child.children[0]->type == LogicalOperatorType::LOGICAL_GET) {
+		op = child.children[0].get();
+	} else {
+		return nullptr;
+	}
+	LogicalGet &get = op->Cast<LogicalGet>();
+	return get.function.aggregate_pushdown != nullptr ? &get : nullptr;
+}
+} // namespace duckdb

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -34,6 +34,7 @@
 #include "duckdb/optimizer/rule/join_dependent_filter.hpp"
 #include "duckdb/optimizer/rule/list.hpp"
 #include "duckdb/optimizer/sampling_pushdown.hpp"
+#include "duckdb/optimizer/aggregate_fn_pushdown.hpp"
 #include "duckdb/optimizer/scalar_fn_pushdown.hpp"
 #include "duckdb/optimizer/statistics_propagator.hpp"
 #include "duckdb/optimizer/aggregate_function_rewriter.hpp"
@@ -496,6 +497,12 @@ void Optimizer::RunBuiltInOptimizers() {
 	RunOptimizer(OptimizerType::SCALAR_FN_PUSHDOWN, [&] {
 		ScalarFnPushdown fn_pushdown(context);
 		plan = fn_pushdown.Optimize(std::move(plan));
+	});
+
+	// Push UNGROUPED_AGGREGATE's of form agg(T) and count_star() into GET.
+	RunOptimizer(OptimizerType::AGGREGATE_FN_PUSHDOWN, [&] {
+		AggregateFnPushdown aggregate_fn_pushdown(context);
+		plan = aggregate_fn_pushdown.Optimize(std::move(plan));
 	});
 }
 

--- a/src/optimizer/type_pushdown.cpp
+++ b/src/optimizer/type_pushdown.cpp
@@ -47,7 +47,8 @@ static bool IsPassthrough(const LogicalProjection &projection) {
 void FindGetsAndProjections(LogicalOperator &op, Analyses &analyses, Projections &projections) {
 	switch (op.type) {
 	case LogicalOperatorType::LOGICAL_GET: {
-		if (auto &get = op.Cast<LogicalGet>(); get.function.projection_expression_pushdown != nullptr) {
+		if (auto &get = op.Cast<LogicalGet>();
+		    get.function.projection_expression_pushdown != nullptr || get.function.aggregate_pushdown != nullptr) {
 			analyses.emplace(get.table_index, GetAnalysis {get, {}});
 		}
 		break;
@@ -73,7 +74,8 @@ void FindGetsAndProjections(LogicalOperator &op, Analyses &analyses, Projections
 			get = &child.Cast<LogicalGet>();
 		}
 
-		if (get != nullptr && get->function.projection_expression_pushdown != nullptr) {
+		if (get != nullptr &&
+		    (get->function.projection_expression_pushdown != nullptr || get->function.aggregate_pushdown != nullptr)) {
 			projections.emplace(projection.table_index, projection);
 		}
 		break;

--- a/test/configs/verify_aggregate_state_export.json
+++ b/test/configs/verify_aggregate_state_export.json
@@ -12,6 +12,7 @@
         "test/optimizer/eager_aggregate_execution_parquet.test",
         "test/optimizer/partial_aggregate_precomputation.test",
         "test/optimizer/partition_stats_exactness.test",
+        "test/optimizer/pushdown/parquet_count_star_pushdown.test",
         "test/optimizer/test_aggregate_function_rewrite.test",
         "test/optimizer/ordered_aggregate.test",
         "test/sql/copy/parquet/parquet_encryption.test",

--- a/test/optimizer/pushdown/parquet_count_star_pushdown.test
+++ b/test/optimizer/pushdown/parquet_count_star_pushdown.test
@@ -1,0 +1,52 @@
+# name: test/optimizer/pushdown/parquet_count_star_pushdown.test
+# description: Test count(*) pushdown into Parquet
+# group: [pushdown]
+
+require parquet
+
+statement ok
+COPY (SELECT range i FROM range(100)) TO '{TEST_DIR}/count_star_1.parquet';
+
+statement ok
+COPY (SELECT range i FROM range(50)) TO '{TEST_DIR}/count_star_2.parquet';
+
+query II
+EXPLAIN SELECT count(*) FROM '{TEST_DIR}/count_star_*.parquet';
+----
+physical_plan	<!REGEX>:(?i).*aggregate.*
+
+query I
+SELECT count(*) FROM '{TEST_DIR}/count_star_*.parquet';
+----
+150
+
+query II
+SELECT count(*), count(*) FROM '{TEST_DIR}/count_star_*.parquet';
+----
+150	150
+
+query I
+SELECT count(*) FROM '{TEST_DIR}/count_star_1.parquet';
+----
+100
+
+query I
+SELECT count(*) FROM '{TEST_DIR}/count_star_*.parquet' WHERE i >= 10;
+----
+130
+
+query II
+EXPLAIN SELECT count(i) FROM '{TEST_DIR}/count_star_*.parquet';
+----
+physical_plan	<REGEX>:(?i).*aggregate.*
+
+query I
+SELECT count(i) FROM '{TEST_DIR}/count_star_*.parquet';
+----
+150
+
+query II
+SELECT i % 2 AS g, count(*) FROM '{TEST_DIR}/count_star_*.parquet' GROUP BY g ORDER BY g;
+----
+0	75
+1	75


### PR DESCRIPTION
- Add AggregateFnPushdown optimizer which pushes ungrouped single-argument aggregates (sum(x), min(x), etc.) and count(*) into file readers.
- Support count(*) pushdown in Parquet. This lowers down CPU usage significantly (3-4x) on files with large row group count.
- Add FinalizeScan and TryPushdownAggregates to MultiFileReader interface so implementors like Vortex can make use of it.
- Add `aggregate_pushdown` callback to TableFunction. This currently pushes down only ungrouped aggregates of specific form, but in the future we may push more with the same signature, so comment doesn't specify what exactly we will push. It will be caller's responsibility to check the input.