### PR TITLE
Fix `INTERNAL Error`: Mark `regexp_full_match` as fallible

### DIFF
--- a/src/function/scalar/string/regexp.cpp
+++ b/src/function/scalar/string/regexp.cpp
@@ -412,6 +412,9 @@ ScalarFunctionSet RegexpFun::GetFunctions() {
 	    {{"string", LogicalType::VARCHAR}, {"regex", LogicalType::VARCHAR}, {"options", LogicalType::VARCHAR}},
 	    LogicalType::BOOLEAN, RegexpMatchesFunction<RegexFullMatch>, RegexpMatchesBind, nullptr, RegexInitLocalState,
 	    LogicalType::INVALID, FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING));
+	for (auto &func : regexp_full_match.functions) {
+		func.SetFallible();
+	}
 	return (regexp_full_match);
 }
 

--- a/test/sql/function/string/regex_search.test
+++ b/test/sql/function/string/regex_search.test
@@ -200,3 +200,13 @@ statement error
 SELECT regexp_matches(s, p) FROM regex
 ----
 <REGEX>:.*Invalid Input Error.*missing.*
+
+statement error
+SELECT regexp_full_match(s, p) FROM regex
+----
+<REGEX>:.*Invalid Input Error.*missing.*
+
+statement error
+SELECT regexp_full_match(s, p, 'c') FROM regex
+----
+<REGEX>:.*Invalid Input Error.*missing.*


### PR DESCRIPTION
Fixes #24622

Adds the missing `SetFallible()` call to the `regexp_full_match` function registrations and regression tests to verify that invalid non-constant patterns now safely throw a standard `Invalid Input Error` instead of an `INTERNAL Error`.