### PR TITLE
Fix interval comparison when carrying left leaves a negative field

### DIFF
--- a/src/include/duckdb/common/types/interval.hpp
+++ b/src/include/duckdb/common/types/interval.hpp
@@ -181,15 +181,24 @@ public:
 void interval_t::Normalize(int64_t &months, int64_t &days, int64_t &micros) const {
 	auto &input = *this;
 
-	//  Carry left
+	//  Carry left, borrowing so that the remainders are never negative.
+	//  Truncating division would leave e.g. 1 month -4 days unnormalized, which then compares above 26 days.
 	micros = input.micros;
 	int64_t carry_days = micros / Interval::MICROS_PER_DAY;
 	micros -= carry_days * Interval::MICROS_PER_DAY;
+	if (micros < 0) {
+		--carry_days;
+		micros += Interval::MICROS_PER_DAY;
+	}
 
 	days = input.days;
 	days += carry_days;
 	int64_t carry_months = days / Interval::DAYS_PER_MONTH;
 	days -= carry_months * Interval::DAYS_PER_MONTH;
+	if (days < 0) {
+		--carry_months;
+		days += Interval::DAYS_PER_MONTH;
+	}
 
 	months = input.months;
 	months += carry_months;
@@ -198,12 +207,23 @@ void interval_t::Normalize(int64_t &months, int64_t &days, int64_t &micros) cons
 void interval_t::Borrow(const int64_t msf, int64_t &lsf, int32_t &f, const int64_t scale) {
 	if (msf > NumericLimits<int32_t>::Maximum()) {
 		f = NumericLimits<int32_t>::Maximum();
-		lsf += (msf - f) * scale;
 	} else if (msf < NumericLimits<int32_t>::Minimum()) {
 		f = NumericLimits<int32_t>::Minimum();
-		lsf += (msf - f) * scale;
 	} else {
 		f = UnsafeNumericCast<int32_t>(msf);
+		return;
+	}
+
+	//	The borrowed amount is not always representable, so saturate instead of overflowing.
+	//	Normalize leaves lsf in [0, scale), so the headroom below keeps the addition in range as well.
+	const int64_t remainder = msf - f;
+	const int64_t max_units = NumericLimits<int64_t>::Maximum() / scale - 1;
+	if (remainder > max_units) {
+		lsf = NumericLimits<int64_t>::Maximum();
+	} else if (remainder < -max_units) {
+		lsf = NumericLimits<int64_t>::Minimum();
+	} else {
+		lsf += remainder * scale;
 	}
 }
 

--- a/test/sql/types/interval/test_interval_comparison.test
+++ b/test/sql/types/interval/test_interval_comparison.test
@@ -49,6 +49,43 @@ select interval '28 days 432000 seconds' = interval '1 month 3 days';
 ----
 True
 
+# Borrow left when carrying leaves a negative field
+query I
+select interval '1 month' - interval '4 days' = interval '26 days';
+----
+True
+
+query I
+select interval '26 days' < (interval '1 month' - interval '4 days');
+----
+False
+
+query I
+select interval '1 day' - interval '1 hour' = interval '23 hours';
+----
+True
+
+query I
+select interval '2 months' - interval '40 days' = interval '20 days';
+----
+True
+
+query I
+select interval '-1 month' + interval '4 days' = interval '-26 days';
+----
+True
+
+# Normalising the extremes saturates instead of overflowing the borrowed field
+query I
+select normalized_interval(interval '-2147483648 months -2147483648 days -9223372036854775807 microseconds');
+----
+-178956970 years -8 months -2147483648 days -2562047788:00:54.775808
+
+query I
+select normalized_interval(interval '2147483647 months 2147483647 days 9223372036854775807 microseconds');
+----
+178956970 years 7 months 2147483647 days 2562047788:00:54.775807
+
 # Sorting with normalisation
 statement ok
 CREATE TABLE issue14384(i INTERVAL);

--- a/test/sql/window/test_window_interval.test
+++ b/test/sql/window/test_window_interval.test
@@ -29,3 +29,12 @@ select j, i, sum(i) over (partition by j order by i) from a order by 1,2
 1 year	4	6
 2 years	1	1
 2 years	3	4
+
+# RANGE PRECEDING must include the lower endpoint when the order key normalises to whole months
+query III
+with src(id, k, x) as (values (1, interval '26' day, 10), (2, interval '30' day, 1))
+select id, k, sum(x) over (order by k range between interval '4' day preceding and current row)
+from src order by id
+----
+1	26 days	10
+2	30 days	11


### PR DESCRIPTION
Fixes #24631.

### The bug

`RANGE PRECEDING` over an `INTERVAL` order key excludes the inclusive lower endpoint once the current row's value reaches 30 days:

```sql
WITH src(id, k, x) AS (VALUES (1, INTERVAL 26 DAY, 10), (2, INTERVAL 30 DAY, 1))
SELECT id, SUM(x) OVER (ORDER BY k RANGE BETWEEN INTERVAL 4 DAY PRECEDING AND CURRENT ROW)
FROM src ORDER BY id;
-- id 2 returns 1, expected 11
```

The window is only where it surfaces. The defect is in interval comparison and reproduces with no window at all:

```sql
SELECT INTERVAL 1 MONTH = INTERVAL 30 DAY;                      -- true
SELECT (INTERVAL 1 MONTH - INTERVAL 4 DAY) = INTERVAL 26 DAY;   -- false, expected true
SELECT (INTERVAL 1 DAY  - INTERVAL 1 HOUR) = INTERVAL 23 HOUR;  -- false, expected true
SELECT (INTERVAL 2 MONTH - INTERVAL 40 DAY) = INTERVAL 20 DAY;  -- false, expected true
```

If `1 month == 30 days`, then `1 month - 4 days` has to equal `26 days`.

### Root cause

`interval_t::Normalize` carries micros into days and days into months with truncating division, so a negative remainder is never borrowed. `1 month -4 days` stays unnormalized, and the month-major comparison then ranks it above `26 days`.

The binder rewrites a RANGE boundary as `normalized_interval(k) - offset`. For `k = 30 days` that boundary becomes `1 month -4 days` instead of `26 days`, so the frame start lands past the row that should be included.

### The fix

Borrow after each carry so the remainders are never negative. `Normalize` now yields a genuine canonical form — `months`, `days ∈ [0,30)`, `micros ∈ [0, 1 day)` — which is what the lexicographic comparison already assumed. Equality, ordering, hashing and VARIANT comparison encoding all route through it, so they agree with each other.

`Borrow()` multiplied the out-of-range amount by the field scale with no overflow check. That product only just fitted for the extreme interval, and the extra borrow above pushed it past `INT64_MIN`; UBSan caught it. It now saturates.

Display is unaffected — it prints the raw fields, so `1 month -4 days` still renders as written. It just no longer compares greater than `26 days`.

### Testing

Added to `test_interval_comparison.test`: borrow cases in both signs, plus the saturated extremes covering the `Borrow` path. Added the reported query to `test_window_interval.test`.

Also property-tested locally — 540,225 pairs built from explicit `(months, days, micros)` components across negative and mixed signs, checking `<`, `=`, `>`, `<=` against the true total computed in `HUGEINT`. Zero mismatches. Confirmed hashing agrees with equality: differently-written equal intervals collapse to a single group under `GROUP BY` and `COUNT(DISTINCT)`.

### CI

86 jobs pass on my fork, including Relassert/UBSan, Thread Sanitizer and Vector Sizes. Three failures look unrelated:

- `Linux Config (Execution)` — `duckdb_eviction_queues.test` times out under `verify_fetch_row`; the test uses no intervals and reproduces as a timeout on a clean checkout
- `windows / MinGW (64 Bit)` — the known flaky `concurrent_checkpoint_insert.test` (#24333); the MSVC 64-bit job passes
- `extensions / Main (search) / osx_amd64` — vcpkg failed to fetch zlib (`curl: (60) SSL certificate problem`)