### PR TITLE
Issue #24617: ICU TRY_CAST Throws

### DIFF
--- a/extension/icu/icu-timezone.cpp
+++ b/extension/icu/icu-timezone.cpp
@@ -145,11 +145,18 @@ struct ICUFromNaiveTimestamp : public ICUDateFunc {
 		auto &info = cast_data.info->Cast<BindData>();
 		CalendarPtr calendar(info.calendar->Copy());
 
-		UnaryExecutor::Execute<SRC, DST>(source, result, count, [&](SRC input) {
+		bool all_converted = true;
+		UnaryExecutor::Execute<SRC, DST>(source, result, count, [&](SRC input) -> optional<DST> {
 			using NAIVE = timestamp_base_t<DST::PRECISION, false>;
-			return Operation(calendar.get(), Cast::Operation<SRC, NAIVE>(input));
+			NAIVE naive;
+			if (!TryCast::Operation(input, naive)) {
+				HandleCastError::AssignError(CastExceptionText<SRC, NAIVE>(input), parameters);
+				all_converted = false;
+				return nullopt;
+			}
+			return Operation(calendar.get(), naive);
 		});
-		return true;
+		return all_converted;
 	}
 
 	template <typename SRC>
@@ -260,11 +267,19 @@ struct ICUToNaiveTimestamp : public ICUDateFunc {
 		auto &info = cast_data.info->Cast<BindData>();
 		CalendarPtr calendar(info.calendar->Copy());
 
-		UnaryExecutor::Execute<SRC, DST>(source, result, count, [&](SRC input) {
+		bool all_converted = true;
+		UnaryExecutor::Execute<SRC, DST>(source, result, count, [&](SRC input) -> optional<DST> {
 			using NAIVE = timestamp_base_t<SRC::PRECISION, false>;
-			return Cast::Operation<NAIVE, DST>(Operation(calendar.get(), input));
+			const NAIVE naive(Operation(calendar.get(), input));
+			DST output;
+			if (!TryCast::Operation(naive, output)) {
+				HandleCastError::AssignError("Could not convert Timestamp to higher precision.", parameters);
+				all_converted = false;
+				return nullopt;
+			}
+			return output;
 		});
-		return true;
+		return all_converted;
 	}
 
 	static BoundCastInfo BindCastToNaive(BindCastInput &input, const LogicalType &source, const LogicalType &target) {

--- a/test/sql/timezone/test_icu_casts.test
+++ b/test/sql/timezone/test_icu_casts.test
@@ -53,3 +53,43 @@ query I
 select t::DATE from tstzs;
 ----
 2026-04-09
+
+# Issue #24617: TRY_CAST through the ICU casts must return NULL on overflow instead of raising
+
+statement ok
+SET TimeZone = 'UTC';
+
+query I
+SELECT TRY_CAST(TIMESTAMPTZ '2262-04-11 23:47:16.854776+00' AS TIMESTAMP_NS);
+----
+NULL
+
+statement error
+SELECT CAST(TIMESTAMPTZ '2262-04-11 23:47:16.854776+00' AS TIMESTAMP_NS);
+----
+Conversion Error: Could not convert Timestamp to higher precision.
+
+# The overflow check applies to the local time, so use values that overflow in any time zone
+statement ok
+SET TimeZone = 'America/Los_Angeles';
+
+query I
+SELECT TRY_CAST(TIMESTAMPTZ '9999-01-01 00:00:00+00' AS TIMESTAMP_NS);
+----
+NULL
+
+query I
+SELECT TRY_CAST(TIMESTAMPTZ '2026-04-09 11:48:07.123456-07' AS TIMESTAMP_NS);
+----
+2026-04-09 11:48:07.123456
+
+# Widening the naive source before attaching the time zone can also overflow
+query I
+SELECT TRY_CAST(DATE '5877642-06-25' AS TIMESTAMPTZ);
+----
+NULL
+
+statement error
+SELECT CAST(DATE '5877642-06-25' AS TIMESTAMPTZ);
+----
+Conversion Error

--- a/test/sql/timezone/test_icu_timezone.test
+++ b/test/sql/timezone/test_icu_timezone.test
@@ -134,12 +134,12 @@ SELECT '-infinity'::DATE::TIMESTAMPTZ AS dttz;
 statement error
 select '5877642-06-25 (BC)'::DATE::TIMESTAMPTZ AS dttz;
 ----
-Invalid Input Error
+Conversion Error
 
 statement error
 select '5881580-07-10'::DATE::TIMESTAMPTZ AS dttz;
 ----
-Invalid Input Error
+Conversion Error
 
 # Table
 statement ok


### PR DESCRIPTION
Route the ICU CastToNaive and CastFromNaive vectorized casts through TryCast::Operation and HandleCastError::AssignError so TRY_CAST yields NULL on overflow instead of raising an internal error, while plain CAST still raises a Conversion Error.

fixes: duckdb#24617