### PR TITLE
Simplify filters when entire enum domain is present in IN clause

### DIFF
--- a/src/include/duckdb/optimizer/constant_or_null_simplification.hpp
+++ b/src/include/duckdb/optimizer/constant_or_null_simplification.hpp
@@ -1,0 +1,32 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/optimizer/constant_or_null_simplification.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/planner/logical_operator.hpp"
+
+namespace duckdb {
+class ClientContext;
+class NotNullExpressionAnalyzer;
+
+class ConstantOrNullSimplification {
+public:
+	explicit ConstantOrNullSimplification(ClientContext &context);
+
+	unique_ptr<LogicalOperator> Optimize(unique_ptr<LogicalOperator> op);
+
+private:
+	unique_ptr<Expression> SimplifyExpression(LogicalOperator &input, unique_ptr<Expression> expr,
+	                                          NotNullExpressionAnalyzer &analyzer);
+	unique_ptr<LogicalOperator> OptimizeFilter(unique_ptr<LogicalOperator> op);
+
+private:
+	ClientContext &context;
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/optimizer/constant_or_null_simplification.hpp
+++ b/src/include/duckdb/optimizer/constant_or_null_simplification.hpp
@@ -21,9 +21,10 @@ public:
 	unique_ptr<LogicalOperator> Optimize(unique_ptr<LogicalOperator> op);
 
 private:
+	unique_ptr<LogicalOperator> OptimizeInternal(unique_ptr<LogicalOperator> op, bool plan_has_side_effects);
 	unique_ptr<Expression> SimplifyExpression(LogicalOperator &input, unique_ptr<Expression> expr,
-	                                          NotNullExpressionAnalyzer &analyzer);
-	unique_ptr<LogicalOperator> OptimizeFilter(unique_ptr<LogicalOperator> op);
+	                                          NotNullExpressionAnalyzer &analyzer, bool allow_folding);
+	unique_ptr<LogicalOperator> OptimizeFilter(unique_ptr<LogicalOperator> op, bool plan_has_side_effects);
 
 private:
 	ClientContext &context;

--- a/src/optimizer/CMakeLists.txt
+++ b/src/optimizer/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library_unity(
   builtin_function_lookup.cpp
   column_binding_replacer.cpp
   column_lifetime_analyzer.cpp
+  constant_or_null_simplification.cpp
   empty_result_pullup.cpp
   common_aggregate_optimizer.cpp
   common_subplan_optimizer.cpp

--- a/src/optimizer/constant_or_null_simplification.cpp
+++ b/src/optimizer/constant_or_null_simplification.cpp
@@ -1,0 +1,167 @@
+#include "duckdb/optimizer/constant_or_null_simplification.hpp"
+
+#include "duckdb/function/scalar/generic_common.hpp"
+#include "duckdb/optimizer/expression_rewriter.hpp"
+#include "duckdb/planner/expression/bound_constant_expression.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "duckdb/planner/expression/bound_operator_expression.hpp"
+#include "duckdb/planner/expression_iterator.hpp"
+#include "duckdb/planner/expression_nullability.hpp"
+#include "duckdb/planner/operator/logical_empty_result.hpp"
+#include "duckdb/planner/operator/logical_filter.hpp"
+
+namespace duckdb {
+
+ConstantOrNullSimplification::ConstantOrNullSimplification(ClientContext &context_p) : context(context_p) {
+}
+
+static optional<bool> GetBooleanConstant(const Expression &expr) {
+	if (expr.GetExpressionClass() != ExpressionClass::BOUND_CONSTANT) {
+		return optional<bool>();
+	}
+
+	auto &constant = expr.Cast<BoundConstantExpression>().GetValue();
+	if (constant.IsNull() || constant.type().id() != LogicalTypeId::BOOLEAN) {
+		return optional<bool>();
+	}
+
+	return BooleanValue::Get(constant);
+}
+
+static optional<bool> GetConstantOrNullBoolean(Expression &expr) {
+	if (expr.GetExpressionClass() != ExpressionClass::BOUND_FUNCTION ||
+	    expr.GetReturnType().id() != LogicalTypeId::BOOLEAN) {
+		return optional<bool>();
+	}
+
+	auto &func = expr.Cast<BoundFunctionExpression>();
+	if (ConstantOrNull::IsConstantOrNull(func, Value::BOOLEAN(true))) {
+		return true;
+	}
+
+	if (ConstantOrNull::IsConstantOrNull(func, Value::BOOLEAN(false))) {
+		return false;
+	}
+
+	return optional<bool>();
+}
+
+static bool ConstantOrNullInputsAreNotNull(LogicalOperator &input, BoundFunctionExpression &func,
+                                           NotNullExpressionAnalyzer &analyzer) {
+	auto &children = func.GetChildren();
+	D_ASSERT(children.size() >= 2);
+
+	for (idx_t child_idx = 1; child_idx < children.size(); ++child_idx) {
+		if (children[child_idx]->GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
+			auto &constant = children[child_idx]->Cast<BoundConstantExpression>().GetValue();
+			if (!constant.IsNull()) {
+				continue;
+			}
+		}
+
+		if (!analyzer.IsNotNull(input, *children[child_idx])) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+unique_ptr<Expression> ConstantOrNullSimplification::SimplifyExpression(LogicalOperator &input,
+                                                                        unique_ptr<Expression> expr,
+                                                                        NotNullExpressionAnalyzer &analyzer) {
+	ExpressionIterator::EnumerateChildren(*expr, [&](unique_ptr<Expression> &child) {
+		child = SimplifyExpression(input, std::move(child), analyzer);
+	});
+
+	if (expr->GetExpressionClass() == ExpressionClass::BOUND_FUNCTION) {
+		auto value = GetConstantOrNullBoolean(*expr);
+		if (!value.has_value()) {
+			return expr;
+		}
+
+		auto &func = expr->Cast<BoundFunctionExpression>();
+		if (ConstantOrNullInputsAreNotNull(input, func, analyzer)) {
+			return make_uniq<BoundConstantExpression>(Value::BOOLEAN(value.value()));
+		}
+
+		return expr;
+	}
+
+	if (expr->GetExpressionType() != ExpressionType::OPERATOR_NOT) {
+		return expr;
+	}
+
+	auto &not_expr = expr->Cast<BoundOperatorExpression>();
+	D_ASSERT(not_expr.GetChildren().size() == 1);
+
+	auto value = GetBooleanConstant(*not_expr.GetChildren()[0]);
+	if (value.has_value()) {
+		return make_uniq<BoundConstantExpression>(Value::BOOLEAN(!value.value()));
+	}
+
+	value = GetConstantOrNullBoolean(*not_expr.GetChildren()[0]);
+	if (!value.has_value()) {
+		return expr;
+	}
+
+	auto &func = not_expr.GetChildren()[0]->Cast<BoundFunctionExpression>();
+	auto &func_children = func.GetChildrenMutable();
+	D_ASSERT(func_children.size() >= 2);
+
+	vector<unique_ptr<Expression>> children;
+	children.reserve(func_children.size());
+	children.push_back(make_uniq<BoundConstantExpression>(Value::BOOLEAN(!value.value())));
+	for (idx_t child_idx = 1; child_idx < func_children.size(); ++child_idx) {
+		children.push_back(std::move(func_children[child_idx]));
+	}
+
+	return ExpressionRewriter::ConstantOrNull(std::move(children), Value::BOOLEAN(!value.value()));
+}
+
+unique_ptr<LogicalOperator> ConstantOrNullSimplification::OptimizeFilter(unique_ptr<LogicalOperator> op) {
+	auto &filter = op->Cast<LogicalFilter>();
+	if (filter.children.size() != 1) {
+		return op;
+	}
+
+	NotNullExpressionAnalyzer analyzer(context);
+	vector<unique_ptr<Expression>> remaining_expressions;
+	remaining_expressions.reserve(filter.expressions.size());
+	for (auto &expr : filter.expressions) {
+		expr = SimplifyExpression(*filter.children[0], std::move(expr), analyzer);
+		auto value = GetBooleanConstant(*expr);
+		if (!value.has_value()) {
+			remaining_expressions.push_back(std::move(expr));
+		} else if (!value.value()) {
+			return make_uniq<LogicalEmptyResult>(std::move(op));
+		}
+	}
+
+	if (!remaining_expressions.empty()) {
+		filter.expressions = std::move(remaining_expressions);
+		return op;
+	}
+
+	if (filter.projection_map.empty()) {
+		return std::move(filter.children[0]);
+	}
+
+	remaining_expressions.push_back(make_uniq<BoundConstantExpression>(Value::BOOLEAN(true)));
+	filter.expressions = std::move(remaining_expressions);
+	return op;
+}
+
+unique_ptr<LogicalOperator> ConstantOrNullSimplification::Optimize(unique_ptr<LogicalOperator> op) {
+	for (auto &child : op->children) {
+		child = Optimize(std::move(child));
+	}
+
+	if (op->type == LogicalOperatorType::LOGICAL_FILTER) {
+		return OptimizeFilter(std::move(op));
+	}
+
+	return op;
+}
+
+} // namespace duckdb

--- a/src/optimizer/constant_or_null_simplification.cpp
+++ b/src/optimizer/constant_or_null_simplification.cpp
@@ -46,11 +46,13 @@ static optional<bool> GetConstantOrNullBoolean(Expression &expr) {
 	return optional<bool>();
 }
 
+//! Whether every input that can still turn the result into NULL is provably NOT NULL.
 static bool ConstantOrNullInputsAreNotNull(LogicalOperator &input, BoundFunctionExpression &func,
                                            NotNullExpressionAnalyzer &analyzer) {
 	auto &children = func.GetChildren();
 	D_ASSERT(children.size() >= 2);
 
+	// Folding is only valid when the NULL-preserving inputs cannot be NULL.
 	for (idx_t child_idx = 1; child_idx < children.size(); ++child_idx) {
 		if (children[child_idx]->GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
 			auto &constant = children[child_idx]->Cast<BoundConstantExpression>().GetValue();
@@ -67,21 +69,35 @@ static bool ConstantOrNullInputsAreNotNull(LogicalOperator &input, BoundFunction
 	return true;
 }
 
+static bool ConstantOrNullInputsAreVolatile(BoundFunctionExpression &func) {
+	auto &children = func.GetChildren();
+	for (idx_t child_idx = 1; child_idx < children.size(); ++child_idx) {
+		if (children[child_idx]->IsVolatile()) {
+			return true;
+		}
+	}
+	return false;
+}
+
 unique_ptr<Expression> ConstantOrNullSimplification::SimplifyExpression(LogicalOperator &input,
                                                                         unique_ptr<Expression> expr,
-                                                                        NotNullExpressionAnalyzer &analyzer) {
+                                                                        NotNullExpressionAnalyzer &analyzer,
+                                                                        bool allow_folding) {
 	ExpressionIterator::EnumerateChildren(*expr, [&](unique_ptr<Expression> &child) {
-		child = SimplifyExpression(input, std::move(child), analyzer);
+		child = SimplifyExpression(input, std::move(child), analyzer, allow_folding);
 	});
 
 	if (expr->GetExpressionClass() == ExpressionClass::BOUND_FUNCTION) {
+		if (!allow_folding) {
+			return expr;
+		}
 		auto value = GetConstantOrNullBoolean(*expr);
 		if (!value.has_value()) {
 			return expr;
 		}
 
 		auto &func = expr->Cast<BoundFunctionExpression>();
-		if (ConstantOrNullInputsAreNotNull(input, func, analyzer)) {
+		if (!ConstantOrNullInputsAreVolatile(func) && ConstantOrNullInputsAreNotNull(input, func, analyzer)) {
 			return make_uniq<BoundConstantExpression>(Value::BOOLEAN(value.value()));
 		}
 
@@ -92,6 +108,7 @@ unique_ptr<Expression> ConstantOrNullSimplification::SimplifyExpression(LogicalO
 		return expr;
 	}
 
+	// Push NOT into constant_or_null without dropping per-row NULL checks.
 	auto &not_expr = expr->Cast<BoundOperatorExpression>();
 	D_ASSERT(not_expr.GetChildren().size() == 1);
 
@@ -119,17 +136,22 @@ unique_ptr<Expression> ConstantOrNullSimplification::SimplifyExpression(LogicalO
 	return ExpressionRewriter::ConstantOrNull(std::move(children), Value::BOOLEAN(!value.value()));
 }
 
-unique_ptr<LogicalOperator> ConstantOrNullSimplification::OptimizeFilter(unique_ptr<LogicalOperator> op) {
+unique_ptr<LogicalOperator> ConstantOrNullSimplification::OptimizeFilter(unique_ptr<LogicalOperator> op,
+                                                                         bool plan_has_side_effects) {
 	auto &filter = op->Cast<LogicalFilter>();
 	if (filter.children.size() != 1) {
 		return op;
 	}
 
+	// Folding removes the NULL check, so disable it for plans with side effects.
+	// Same-statement DML can add NULLs after statistics-based nullability analysis.
+	const bool allow_folding = !plan_has_side_effects;
+
 	NotNullExpressionAnalyzer analyzer(context);
 	vector<unique_ptr<Expression>> remaining_expressions;
 	remaining_expressions.reserve(filter.expressions.size());
 	for (auto &expr : filter.expressions) {
-		expr = SimplifyExpression(*filter.children[0], std::move(expr), analyzer);
+		expr = SimplifyExpression(*filter.children[0], std::move(expr), analyzer, allow_folding);
 		auto value = GetBooleanConstant(*expr);
 		if (!value.has_value()) {
 			remaining_expressions.push_back(std::move(expr));
@@ -153,12 +175,18 @@ unique_ptr<LogicalOperator> ConstantOrNullSimplification::OptimizeFilter(unique_
 }
 
 unique_ptr<LogicalOperator> ConstantOrNullSimplification::Optimize(unique_ptr<LogicalOperator> op) {
+	const bool has_side_effects = op->HasSideEffects();
+	return OptimizeInternal(std::move(op), has_side_effects);
+}
+
+unique_ptr<LogicalOperator> ConstantOrNullSimplification::OptimizeInternal(unique_ptr<LogicalOperator> op,
+                                                                           bool plan_has_side_effects) {
 	for (auto &child : op->children) {
-		child = Optimize(std::move(child));
+		child = OptimizeInternal(std::move(child), plan_has_side_effects);
 	}
 
 	if (op->type == LogicalOperatorType::LOGICAL_FILTER) {
-		return OptimizeFilter(std::move(op));
+		return OptimizeFilter(std::move(op), plan_has_side_effects);
 	}
 
 	return op;

--- a/src/optimizer/constant_or_null_simplification.cpp
+++ b/src/optimizer/constant_or_null_simplification.cpp
@@ -133,7 +133,7 @@ unique_ptr<Expression> ConstantOrNullSimplification::SimplifyExpression(LogicalO
 		children.push_back(std::move(func_children[child_idx]));
 	}
 
-	return ExpressionRewriter::ConstantOrNull(std::move(children), Value::BOOLEAN(!value.value()));
+	return ExpressionRewriter::ConstantOrNull(this->context, std::move(children), Value::BOOLEAN(!value.value()));
 }
 
 unique_ptr<LogicalOperator> ConstantOrNullSimplification::OptimizeFilter(unique_ptr<LogicalOperator> op,

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -8,6 +8,7 @@
 #include "duckdb/optimizer/build_probe_side_optimizer.hpp"
 #include "duckdb/optimizer/column_lifetime_analyzer.hpp"
 #include "duckdb/optimizer/common_aggregate_optimizer.hpp"
+#include "duckdb/optimizer/constant_or_null_simplification.hpp"
 #include "duckdb/optimizer/cse_optimizer.hpp"
 #include "duckdb/optimizer/cte_inlining.hpp"
 #include "duckdb/optimizer/cte_filter_pusher.hpp"
@@ -244,7 +245,13 @@ void Optimizer::RunBuiltInOptimizers() {
 	}
 	// first we perform expression rewrites using the ExpressionRewriter
 	// this does not change the logical plan structure, but only simplifies the expression trees
-	RunOptimizer(OptimizerType::EXPRESSION_REWRITER, [&]() { rewriter.VisitOperator(*plan); });
+	RunOptimizer(OptimizerType::EXPRESSION_REWRITER, [&]() {
+		rewriter.VisitOperator(*plan);
+		if (!plan->HasSideEffects()) {
+			ConstantOrNullSimplification constant_or_null_simplification(context);
+			plan = constant_or_null_simplification.Optimize(std::move(plan));
+		}
+	});
 
 	// try to inline CTEs instead of materialization
 	RunOptimizer(OptimizerType::CTE_INLINING, [&]() {

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -247,10 +247,8 @@ void Optimizer::RunBuiltInOptimizers() {
 	// this does not change the logical plan structure, but only simplifies the expression trees
 	RunOptimizer(OptimizerType::EXPRESSION_REWRITER, [&]() {
 		rewriter.VisitOperator(*plan);
-		if (!plan->HasSideEffects()) {
-			ConstantOrNullSimplification constant_or_null_simplification(context);
-			plan = constant_or_null_simplification.Optimize(std::move(plan));
-		}
+		ConstantOrNullSimplification constant_or_null_simplification(context);
+		plan = constant_or_null_simplification.Optimize(std::move(plan));
 	});
 
 	// try to inline CTEs instead of materialization

--- a/src/optimizer/rule/in_clause_simplification_rule.cpp
+++ b/src/optimizer/rule/in_clause_simplification_rule.cpp
@@ -6,6 +6,7 @@
 #include "duckdb/planner/expression/list.hpp"
 #include "duckdb/planner/expression/bound_operator_expression.hpp"
 #include "duckdb/common/string_map_set.hpp"
+#include "duckdb/common/unordered_set.hpp"
 
 namespace duckdb {
 
@@ -101,6 +102,7 @@ unique_ptr<Expression> InEnumSimplificationRule::Apply(LogicalOperator &op, vect
 	vector<unique_ptr<Expression>> in_children;
 	in_children.emplace_back(enum_expr.Copy());
 
+	unordered_set<uint64_t> matched_enum_values{};
 	for (idx_t i = 1; i < children.size(); ++i) {
 		auto &child = *children[i];
 		auto &v = child.Cast<BoundConstantExpression>().GetValue();
@@ -113,15 +115,18 @@ unique_ptr<Expression> InEnumSimplificationRule::Apply(LogicalOperator &op, vect
 			if (it != enum_domain.end()) {
 				//	The literal is in the ENUM domain, so translate it
 				in_children.emplace_back(make_uniq<BoundConstantExpression>(Value::ENUM(it->second, enum_type)));
+				matched_enum_values.insert(it->second);
 			}
 			// Not in the domain, so ignore it.
 		}
 	}
 
-	//	If ALL the children are string constants being matched against an ENUM (NOT) IN,
-	//	and SOME of them are in the domain
-	//	then swap out the children for the valid ENUM values
-	if (in_children.size() > 1) {
+	//	If all ENUM values are present, replace with a constant for non-NULL inputs.
+	//	If SOME of them are in the domain, swap out the children for the valid ENUM values.
+	if (matched_enum_values.size() == EnumType::GetSize(enum_type)) {
+		const bool in_clause = (expr.GetExpressionType() == ExpressionType::COMPARE_IN);
+		return rewriter.ConstantOrNull(in_children[0]->Copy(), Value::BOOLEAN(in_clause));
+	} else if (in_children.size() > 1) {
 		children.swap(in_children);
 	} else {
 		// constant_or_null(not_in, child[0])

--- a/src/optimizer/rule/in_clause_simplification_rule.cpp
+++ b/src/optimizer/rule/in_clause_simplification_rule.cpp
@@ -102,7 +102,7 @@ unique_ptr<Expression> InEnumSimplificationRule::Apply(LogicalOperator &op, vect
 	vector<unique_ptr<Expression>> in_children;
 	in_children.emplace_back(enum_expr.Copy());
 
-	unordered_set<uint64_t> matched_enum_values{};
+	unordered_set<uint64_t> matched_enum_values {};
 	for (idx_t i = 1; i < children.size(); ++i) {
 		auto &child = *children[i];
 		auto &v = child.Cast<BoundConstantExpression>().GetValue();

--- a/src/optimizer/rule/in_clause_simplification_rule.cpp
+++ b/src/optimizer/rule/in_clause_simplification_rule.cpp
@@ -65,32 +65,82 @@ unique_ptr<Expression> InClauseSimplificationRule::Apply(LogicalOperator &op, ve
 	return nullptr;
 }
 
+class EnumInProbeMatcher : public ExpressionMatcher {
+public:
+	EnumInProbeMatcher() : ExpressionMatcher() {
+	}
+
+	bool Match(Expression &expr, vector<reference<Expression>> &bindings) override {
+		// Support both enum_col IN (...) and enum_col::VARCHAR IN (...).
+		if (expr.GetReturnType().id() == LogicalTypeId::ENUM) {
+			bindings.push_back(expr);
+			return true;
+		}
+		if (!BoundCastExpression::IsCast(expr) || expr.GetReturnType() != LogicalType::VARCHAR) {
+			return false;
+		}
+		auto &cast_expr = expr.Cast<BoundFunctionExpression>();
+		if (BoundCastExpression::Child(cast_expr).GetReturnType().id() != LogicalTypeId::ENUM) {
+			return false;
+		}
+		bindings.push_back(expr);
+		return true;
+	}
+};
+
+class EnumInConstantMatcher : public ExpressionMatcher {
+public:
+	EnumInConstantMatcher() : ExpressionMatcher(ExpressionClass::BOUND_CONSTANT) {
+	}
+
+	bool Match(Expression &expr, vector<reference<Expression>> &bindings) override {
+		if (!ExpressionMatcher::Match(expr, bindings)) {
+			return false;
+		}
+		auto &constant = expr.Cast<BoundConstantExpression>().GetValue();
+		if (constant.IsNull() || constant.type().id() == LogicalTypeId::VARCHAR ||
+		    constant.type().id() == LogicalTypeId::ENUM) {
+			return true;
+		}
+		bindings.pop_back();
+		return false;
+	}
+};
+
 InEnumSimplificationRule::InEnumSimplificationRule(ExpressionRewriter &rewriter) : Rule(rewriter) {
-	// match enum::VARCHAR IN (string literals)
+	// match enum IN constants and enum::VARCHAR IN constants
 	auto op = make_uniq<InUniformExpressionMatcher>();
 
-	//	Probe must be enum::VARCHAR
-	auto cast_matcher = make_uniq<CastExpressionMatcher>();
-	cast_matcher->type = make_uniq<SpecificTypeMatcher>(LogicalType::VARCHAR);
-	auto enum_matcher = make_uniq<ExpressionMatcher>();
-	enum_matcher->type = make_uniq<TypeMatcherId>(LogicalTypeId::ENUM);
-	cast_matcher->matcher = std::move(enum_matcher);
-	op->probe_matcher = std::move(cast_matcher);
-
-	//	Children must be constant strings
-	op->child_matcher = make_uniq<ExpressionMatcher>(ExpressionClass::BOUND_CONSTANT);
-	op->child_matcher->type = make_uniq<SpecificTypeMatcher>(LogicalType::VARCHAR);
+	op->probe_matcher = make_uniq<EnumInProbeMatcher>();
+	op->child_matcher = make_uniq<EnumInConstantMatcher>();
 
 	root = std::move(op);
+}
+
+static optional_ptr<const Expression> GetEnumInProbe(const Expression &expr) {
+	if (expr.GetReturnType().id() == LogicalTypeId::ENUM) {
+		return expr;
+	}
+	if (!BoundCastExpression::IsCast(expr) || expr.GetReturnType() != LogicalType::VARCHAR) {
+		return nullptr;
+	}
+	auto &cast_expr = expr.Cast<BoundFunctionExpression>();
+	auto &child = BoundCastExpression::Child(cast_expr);
+	if (child.GetReturnType().id() != LogicalTypeId::ENUM) {
+		return nullptr;
+	}
+	return child;
 }
 
 unique_ptr<Expression> InEnumSimplificationRule::Apply(LogicalOperator &op, vector<reference<Expression>> &bindings,
                                                        bool &changes_made, bool is_root) {
 	auto &expr = bindings[0].get().Cast<BoundOperatorExpression>();
 	auto &children = expr.GetChildrenMutable();
-	auto &cast_expr = children[0]->Cast<BoundFunctionExpression>();
-	auto &enum_expr = BoundCastExpression::Child(cast_expr);
-	auto &enum_type = enum_expr.GetReturnType();
+	auto enum_expr = GetEnumInProbe(*children[0]);
+	if (enum_expr == nullptr) {
+		return nullptr;
+	}
+	auto &enum_type = enum_expr->GetReturnType();
 
 	// Look up the domain for the original ENUM
 	string_map_t<uint64_t> enum_domain;
@@ -100,7 +150,7 @@ unique_ptr<Expression> InEnumSimplificationRule::Apply(LogicalOperator &op, vect
 	}
 
 	vector<unique_ptr<Expression>> in_children;
-	in_children.emplace_back(enum_expr.Copy());
+	in_children.emplace_back(enum_expr->Copy());
 
 	unordered_set<uint64_t> matched_enum_values {};
 	for (idx_t i = 1; i < children.size(); ++i) {
@@ -110,6 +160,10 @@ unique_ptr<Expression> InEnumSimplificationRule::Apply(LogicalOperator &op, vect
 			//	Keep NULLs
 			in_children.emplace_back(make_uniq<BoundConstantExpression>(Value(enum_type)));
 		} else {
+			if (v.type().id() != LogicalTypeId::VARCHAR && v.type().id() != LogicalTypeId::ENUM) {
+				return nullptr;
+			}
+			// Check values against the probe enum domain before rebuilding typed enum constants.
 			auto s = v.ToString();
 			auto it = enum_domain.find(s);
 			if (it != enum_domain.end()) {
@@ -125,7 +179,7 @@ unique_ptr<Expression> InEnumSimplificationRule::Apply(LogicalOperator &op, vect
 	//	If SOME of them are in the domain, swap out the children for the valid ENUM values.
 	if (matched_enum_values.size() == EnumType::GetSize(enum_type)) {
 		const bool in_clause = (expr.GetExpressionType() == ExpressionType::COMPARE_IN);
-		return rewriter.ConstantOrNull(in_children[0]->Copy(), Value::BOOLEAN(in_clause));
+		return rewriter.ConstantOrNull(GetContext(), in_children[0]->Copy(), Value::BOOLEAN(in_clause));
 	} else if (in_children.size() > 1) {
 		children.swap(in_children);
 	} else {

--- a/test/sql/optimizer/expression/enum_full_domain_behavior.test
+++ b/test/sql/optimizer/expression/enum_full_domain_behavior.test
@@ -1,0 +1,144 @@
+# name: test/sql/optimizer/expression/enum_full_domain_behavior.test
+# description: Baseline plan behavior of full-domain ENUM (NOT) IN predicates across nullable, side-effect, DML and stats-free contexts
+# group: [expression]
+
+statement ok
+SET profiling_renderer_settings = MAP {'operator_casing': 'upper'};
+
+statement ok
+CREATE TYPE mood AS ENUM('sad', 'ok', 'happy');
+
+# column with provably no NULLs
+statement ok
+CREATE TABLE covered AS SELECT ['sad', 'ok', 'happy'][1 + (range % 3)]::mood AS m FROM range(6144);
+
+# column that can contain NULLs
+statement ok
+CREATE TABLE nullables(m mood);
+
+statement ok
+INSERT INTO nullables SELECT ['sad', 'ok', 'happy'][1 + (range % 3)]::mood FROM range(6144);
+
+statement ok
+INSERT INTO nullables VALUES (NULL);
+
+# 1. clean query + non-NULL column: NOT IN over the full domain collapses to a constant false
+#    and the whole filter becomes an empty result
+query II
+explain
+SELECT count(*) FROM covered WHERE m NOT IN ('sad', 'ok', 'happy');
+----
+physical_plan	<REGEX>:.*EMPTY.*
+
+query I
+SELECT count(*) FROM covered WHERE m NOT IN ('sad', 'ok', 'happy');
+----
+0
+
+# 2. nullable column: the input nullability check fails, so the new expression-rewrite
+#    pass leaves the filter alone - but constant_or_null(false, ...) evaluates to false
+#    for every non-NULL row and to NULL for NULL rows, so the statistics pass prunes it
+#    to an empty result unconditionally (false-or-null semantics: no row can pass)
+query II
+explain
+SELECT count(*) FROM nullables WHERE m NOT IN ('sad', 'ok', 'happy');
+----
+physical_plan	<REGEX>:.*EMPTY.*
+
+query I
+SELECT count(*) FROM nullables WHERE m NOT IN ('sad', 'ok', 'happy');
+----
+0
+
+# 3. volatile expressions in a projection do NOT gate the simplification pass
+#    (HasSideEffects only covers DML operators): the non-NULL column still collapses
+query II
+explain
+SELECT random() FROM covered WHERE m NOT IN ('sad', 'ok', 'happy');
+----
+physical_plan	<REGEX>:.*EMPTY.*
+
+# 3b. the same query on a nullable column: again no expression-rewrite collapse, but
+#     the constant_or_null(false, ...) filter still prunes to an empty result via the
+#     statistics pass - no row can pass it regardless of nullability
+query II
+explain
+SELECT random() FROM nullables WHERE m NOT IN ('sad', 'ok', 'happy');
+----
+physical_plan	<REGEX>:.*EMPTY.*
+
+# 4. DML plans no longer gate the pass as a whole: the NOT(constant_or_null(true, m))
+#    shape rewrite is a pure transformation that keeps evaluating m, so the filter
+#    collapses to an empty result here as well (false-or-null semantics)
+query II
+explain
+DELETE FROM covered WHERE m NOT IN ('sad', 'ok', 'happy');
+----
+physical_plan	<REGEX>:.*EMPTY.*
+
+statement ok
+DELETE FROM covered WHERE m NOT IN ('sad', 'ok', 'happy');
+
+query I
+SELECT count(*) FROM covered;
+----
+6144
+
+# 5. positive IN over the full domain on a non-NULL column: the filter is removed
+#    entirely (no constant_or_null left in the plan)
+query II
+explain
+SELECT count(*) FROM covered WHERE m IN ('sad', 'ok', 'happy');
+----
+physical_plan	<!REGEX>:.*constant_or_null.*
+
+query I
+SELECT count(*) FROM covered WHERE m IN ('sad', 'ok', 'happy');
+----
+6144
+
+# 6. stats-free input (VALUES): the rewrite still happens and nullability cannot be
+#    proven, but the constant false-or-null semantics prune the filter to an empty
+#    result anyway (no stats needed - the condition itself is constant per row)
+query II
+explain
+SELECT count(*) FROM (VALUES ('sad'::mood), ('ok'::mood), ('happy'::mood)) v(m) WHERE m NOT IN ('sad', 'ok', 'happy');
+----
+physical_plan	<REGEX>:.*EMPTY.*
+
+query I
+SELECT count(*) FROM (VALUES ('sad'::mood), ('ok'::mood), ('happy'::mood)) v(m) WHERE m NOT IN ('sad', 'ok', 'happy');
+----
+0
+
+# 7. DML CTE stale statistics: the CTE inserts a NULL that the statement's statistics
+#    snapshot (taken before execution) does not see. Folding constant_or_null into a
+#    plain constant relies on that snapshot to prove m non-NULL, so it must stay
+#    disabled on side-effecting plans - otherwise the freshly inserted NULL row would
+#    slip through the IN filter
+statement ok
+CREATE TABLE guard_check(m mood);
+
+statement ok
+INSERT INTO guard_check VALUES ('sad'), ('ok'), ('happy');
+
+# the filter is NOT folded away: the scan keeps evaluating constant_or_null per row
+query II
+explain
+WITH ins AS (INSERT INTO guard_check VALUES (NULL) RETURNING *) SELECT count(*) FROM guard_check WHERE m IN ('sad', 'ok', 'happy');
+----
+physical_plan	<REGEX>:.*constant_or_null.*
+
+# the CTE-inserted NULL row is visible to the main query but must be filtered out
+query I
+WITH ins AS (INSERT INTO guard_check VALUES (NULL) RETURNING *) SELECT count(*) FROM guard_check WHERE m IN ('sad', 'ok', 'happy');
+----
+3
+
+# pin the premise: the count above is only meaningful if the CTE really ran and its NULL row
+# is visible here - without this check a planner bug that dropped the side-effecting CTE
+# would also yield 3
+query I
+SELECT count(*) FROM guard_check WHERE m IS NULL;
+----
+1

--- a/test/sql/optimizer/expression/enum_full_domain_behavior.test
+++ b/test/sql/optimizer/expression/enum_full_domain_behavior.test
@@ -97,6 +97,40 @@ SELECT count(*) FROM covered WHERE m IN ('sad', 'ok', 'happy');
 ----
 6144
 
+# 5b. typed ENUM constants cover the same full domain and should simplify too
+query II
+explain
+SELECT count(*) FROM covered WHERE m NOT IN ('sad'::mood, 'ok'::mood, 'happy'::mood);
+----
+physical_plan	<REGEX>:.*EMPTY.*
+
+query I
+SELECT count(*) FROM covered WHERE m NOT IN ('sad'::mood, 'ok'::mood, 'happy'::mood);
+----
+0
+
+query II
+explain
+SELECT count(*) FROM covered WHERE m IN ('sad'::mood, 'ok'::mood, 'happy'::mood);
+----
+physical_plan	<!REGEX>:.*constant_or_null.*
+
+query I
+SELECT count(*) FROM covered WHERE m IN ('sad'::mood, 'ok'::mood, 'happy'::mood);
+----
+6144
+
+query III
+SELECT
+	m IS NULL,
+	m NOT IN ('sad'::mood, 'ok'::mood, 'happy'::mood),
+	NOT (m IN ('sad'::mood, 'ok'::mood, 'happy'::mood))
+FROM (VALUES ('sad'::mood), (NULL::mood)) v(m)
+ORDER BY m IS NULL
+----
+false	false	false
+true	NULL	NULL
+
 # 6. stats-free input (VALUES): the rewrite still happens and nullability cannot be
 #    proven, but the constant false-or-null semantics prune the filter to an empty
 #    result anyway (no stats needed - the condition itself is constant per row)

--- a/test/sql/optimizer/expression/enum_full_domain_fold_guard.test
+++ b/test/sql/optimizer/expression/enum_full_domain_fold_guard.test
@@ -1,0 +1,144 @@
+# name: test/sql/optimizer/expression/enum_full_domain_fold_guard.test
+# description: Folding guard of ConstantOrNullSimplification over DML plans and non-ENUM constant_or_null producers
+# group: [expression]
+
+statement ok
+CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy');
+
+# The folding half of ConstantOrNullSimplification rewrites constant_or_null(c, x) into the plain
+# constant c, which drops the per-row NULL handling. That rewrite is only valid if x cannot be
+# NULL, and the proof comes from table statistics - a snapshot that does not see rows appended by
+# DML running in the same statement. On side-effecting plans folding stays disabled, so the filter
+# keeps its per-row constant_or_null evaluation and rows inserted by a DML CTE are filtered by
+# their own NULL semantics.
+
+statement ok
+CREATE TABLE t_enum(m mood);
+
+statement ok
+INSERT INTO t_enum VALUES ('sad'), ('ok'), ('happy');
+
+# the CTE inserts a NULL that the optimizer's statistics snapshot does not see; that row is
+# visible to the main query, but NULL IN (...) is NULL, so it must not be counted
+query I
+WITH ins AS (INSERT INTO t_enum VALUES (NULL) RETURNING *) SELECT count(*) FROM t_enum WHERE m IN ('sad', 'ok', 'happy');
+----
+3
+
+# pin the premise: the inserted row really is visible in the same statement
+query I
+SELECT count(*) FROM t_enum WHERE m IS NULL;
+----
+1
+
+# the same hazard is not ENUM specific: move_constants rewrites i * 2 <> 5 into
+# constant_or_null(TRUE, i), and the fold would delete that filter as well
+statement ok
+CREATE TABLE t_int(i INTEGER);
+
+statement ok
+INSERT INTO t_int VALUES (1), (2), (3);
+
+query I
+WITH ins AS (INSERT INTO t_int VALUES (NULL) RETURNING *) SELECT count(*) FROM t_int WHERE i * 2 <> 5;
+----
+3
+
+query I
+SELECT count(*) FROM t_int WHERE i IS NULL;
+----
+1
+
+# UPDATE: a folded filter would also update the CTE-inserted NULL row
+statement ok
+CREATE TABLE t_upd(m mood, x INTEGER);
+
+statement ok
+INSERT INTO t_upd VALUES ('sad', 0), ('ok', 0), ('happy', 0);
+
+statement ok
+WITH ins AS (INSERT INTO t_upd VALUES (NULL, 0) RETURNING *) UPDATE t_upd SET x = 1 WHERE m IN ('sad', 'ok', 'happy');
+
+query I
+SELECT count(*) FROM t_upd WHERE x = 1;
+----
+3
+
+query I
+SELECT count(*) FROM t_upd;
+----
+4
+
+# the guard is plan-wide: DML on one table also disables folding for an unrelated table.
+# Correct, but conservative - this is the part the reviewer on #25133 asked to narrow down.
+statement ok
+CREATE TABLE t_a(i INTEGER);
+
+statement ok
+CREATE TABLE t_b(i INTEGER);
+
+statement ok
+INSERT INTO t_b VALUES (1), (2), (3);
+
+query I
+WITH ins AS (INSERT INTO t_a VALUES (NULL) RETURNING *) SELECT count(*) FROM t_b WHERE i * 2 <> 5;
+----
+3
+
+# once the append is committed the statistics see the NULL row, so the plain query filters it
+query I
+SELECT count(*) FROM t_int WHERE i * 2 <> 5;
+----
+3
+
+# prepared statements re-plan, so a plan folded against older statistics is not reused
+statement ok
+CREATE TABLE t_prep(i INTEGER);
+
+statement ok
+INSERT INTO t_prep VALUES (1), (2), (3);
+
+statement ok
+PREPARE p AS SELECT count(*) FROM t_prep WHERE i * 2 <> 5;
+
+query I
+EXECUTE p;
+----
+3
+
+statement ok
+INSERT INTO t_prep VALUES (NULL);
+
+query I
+EXECUTE p;
+----
+3
+
+# volatility does NOT gate the fold: folding constant_or_null(c, x) drops only the per-row
+# evaluation of x, and the nullability proof can establish x only as a column reference or a
+# non-NULL constant - never as a volatile expression. A volatile sibling conjunct (random()
+# here), or a volatile expression in an operator below the filter, keeps being evaluated and
+# must not disable the fold.
+statement ok
+CREATE TABLE t_vol(m mood);
+
+statement ok
+INSERT INTO t_vol SELECT ['sad', 'ok', 'happy'][1 + (range % 3)]::mood FROM range(1024);
+
+query II
+explain
+SELECT count(*) FROM t_vol WHERE m IN ('sad', 'ok', 'happy') AND random() > 0.5;
+----
+physical_plan	<!REGEX>:.*IS NOT NULL.*
+
+query II
+explain
+SELECT count(*) FROM (SELECT m, random() AS r FROM t_vol) t WHERE m IN ('sad', 'ok', 'happy') AND r > 0.5;
+----
+physical_plan	<!REGEX>:.*IS NOT NULL.*
+
+query I
+SELECT count(*) FROM t_vol WHERE m IN ('sad', 'ok', 'happy');
+----
+1024
+

--- a/test/sql/optimizer/expression/test_enum_in_simplification.test
+++ b/test/sql/optimizer/expression/test_enum_in_simplification.test
@@ -130,7 +130,129 @@ WHERE sym NOT IN (
 GROUP BY sym 
 ORDER BY sym;
 ----
-physical_plan	<REGEX>:.*NOT constant_or_null.*
+physical_plan	<!REGEX>:.*constant_or_null.*
+
+#
+# Test full ENUM domain
+#
+query II
+explain
+SELECT count(*)
+FROM quote
+WHERE sym IN (
+	'0',
+	'1',
+	'2',
+	'3',
+	'4',
+	'5',
+	'6',
+	'7',
+	'8',
+	'9'
+)
+----
+physical_plan	<!REGEX>:.*constant_or_null.*
+
+query II
+explain
+SELECT count(*)
+FROM quote
+WHERE sym NOT IN (
+	'0',
+	'1',
+	'2',
+	'3',
+	'4',
+	'5',
+	'6',
+	'7',
+	'8',
+	'9'
+)
+----
+physical_plan	<REGEX>:.*EMPTY_RESULT.*
+
+query II
+explain
+SELECT count(*)
+FROM quote
+WHERE NOT (sym IN (
+	'0',
+	'1',
+	'2',
+	'3',
+	'4',
+	'5',
+	'6',
+	'7',
+	'8',
+	'9'
+))
+----
+physical_plan	<REGEX>:.*EMPTY_RESULT.*
+
+query II
+SELECT
+	sym NOT IN (
+		'0',
+		'1',
+		'2',
+		'3',
+		'4',
+		'5',
+		'6',
+		'7',
+		'8',
+		'9'
+	),
+	NOT (sym IN (
+		'0',
+		'1',
+		'2',
+		'3',
+		'4',
+		'5',
+		'6',
+		'7',
+		'8',
+		'9'
+	))
+FROM (VALUES ('0'::sym_enum), ('1'::sym_enum)) tbl(sym)
+ORDER BY sym
+----
+false	false
+false	false
+
+#
+# Test full ENUM domain with DML CTE
+#
+statement ok
+CREATE TABLE dml_quote(sym sym_enum);
+
+statement ok
+INSERT INTO dml_quote VALUES ('0'), ('1');
+
+query I
+WITH ins AS (
+	INSERT INTO dml_quote VALUES (NULL) RETURNING *
+)
+SELECT count(*)
+FROM dml_quote
+WHERE sym IN (
+	'0',
+	'1',
+	'2',
+	'3',
+	'4',
+	'5',
+	'6',
+	'7',
+	'8',
+	'9'
+)
+----
+2
 
 #
 # Test no valid strings and NULL
@@ -170,7 +292,7 @@ FROM (
 	WHERE n IS NOT NULL
 ) tbl;
 ----
-physical_plan	<REGEX>:.*NOT.*constant_or_null.*IS.*NOT.*NULL.*
+physical_plan	<REGEX>:.*constant_or_null.*IS.*NOT.*NULL.*
 
 query II
 SELECT count(*), max(n) 
@@ -181,6 +303,190 @@ FROM (
 ) tbl;
 ----
 100	true
+
+query I
+SELECT count(*)
+FROM quote
+WHERE (NOT constant_or_null(true, sym)) IS NULL
+----
+1
+
+query I
+SELECT count(*)
+FROM quote
+WHERE sym IN (
+	'0',
+	'1',
+	'2',
+	'3',
+	'4',
+	'5',
+	'6',
+	'7',
+	'8',
+	'9'
+)
+----
+100
+
+query II
+explain
+SELECT count(*)
+FROM quote
+WHERE sym IN (
+	'0',
+	'1',
+	'2',
+	'3',
+	'4',
+	'5',
+	'6',
+	'7',
+	'8',
+	'9'
+)
+----
+physical_plan	<REGEX>:.*IS NOT NULL.*
+
+query II
+explain
+SELECT count(*)
+FROM quote
+WHERE sym NOT IN (
+	'0',
+	'1',
+	'2',
+	'3',
+	'4',
+	'5',
+	'6',
+	'7',
+	'8',
+	'9'
+)
+----
+physical_plan	<REGEX>:.*EMPTY_RESULT.*
+
+query I
+SELECT count(*)
+FROM quote
+WHERE sym NOT IN (
+	'0',
+	'1',
+	'2',
+	'3',
+	'4',
+	'5',
+	'6',
+	'7',
+	'8',
+	'9'
+)
+----
+0
+
+query III
+SELECT
+	sym IS NULL,
+	sym NOT IN (
+		'0',
+		'1',
+		'2',
+		'3',
+		'4',
+		'5',
+		'6',
+		'7',
+		'8',
+		'9'
+	),
+	NOT (sym IN (
+		'0',
+		'1',
+		'2',
+		'3',
+		'4',
+		'5',
+		'6',
+		'7',
+		'8',
+		'9'
+	))
+FROM (VALUES ('0'::sym_enum), (NULL::sym_enum)) tbl(sym)
+ORDER BY sym IS NULL
+----
+false	false	false
+true	NULL	NULL
+
+query III
+SELECT
+	sym IS NULL,
+	sym IN (
+		NULL,
+		'0',
+		'1',
+		'2',
+		'3',
+		'4',
+		'5',
+		'6',
+		'7',
+		'8',
+		'9'
+	),
+	sym NOT IN (
+		NULL,
+		'0',
+		'1',
+		'2',
+		'3',
+		'4',
+		'5',
+		'6',
+		'7',
+		'8',
+		'9'
+	)
+FROM (VALUES ('0'::sym_enum), (NULL::sym_enum)) tbl(sym)
+ORDER BY sym IS NULL
+----
+false	true	false
+true	NULL	NULL
+
+query III
+SELECT
+	sym IS NULL,
+	sym NOT IN (
+		NULL,
+		'0',
+		'1',
+		'2',
+		'3',
+		'4',
+		'5',
+		'6',
+		'7',
+		'8',
+		'9'
+	),
+	NOT (sym IN (
+		NULL,
+		'0',
+		'1',
+		'2',
+		'3',
+		'4',
+		'5',
+		'6',
+		'7',
+		'8',
+		'9'
+	))
+FROM (VALUES ('0'::sym_enum), (NULL::sym_enum)) tbl(sym)
+ORDER BY sym IS NULL
+----
+false	false	false
+true	NULL	NULL
 
 # Test comparisons
 query II

--- a/test/sql/optimizer/expression/uncommitted_appends_fold_guard.test
+++ b/test/sql/optimizer/expression/uncommitted_appends_fold_guard.test
@@ -1,0 +1,65 @@
+# name: test/sql/optimizer/expression/uncommitted_appends_fold_guard.test
+# description: Folding guard against uncommitted appends that committed-only statistics do not see
+# group: [expression]
+
+statement ok
+CREATE TABLE t(i INTEGER);
+
+statement ok
+BEGIN;
+
+statement ok
+INSERT INTO t VALUES (1), (2), (3);
+
+statement ok
+INSERT INTO t VALUES (NULL);
+
+# i * 2 <> 5 becomes constant_or_null(TRUE, i) via move_constants
+query I
+SELECT count(*) FROM t WHERE i * 2 <> 5;
+----
+3
+
+# the NULL row is visible, it just must not pass the predicate
+query I
+SELECT count(*) FROM t WHERE i IS NULL;
+----
+1
+
+statement ok
+COMMIT;
+
+# same query after the append is committed - statistics are up to date, result is correct
+query I
+SELECT count(*) FROM t WHERE i * 2 <> 5;
+----
+3
+
+statement ok
+CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy');
+
+statement ok
+CREATE TABLE m1(m mood);
+
+statement ok
+BEGIN;
+
+statement ok
+INSERT INTO m1 VALUES ('sad'), ('ok'), ('happy');
+
+statement ok
+INSERT INTO m1 VALUES (NULL);
+
+# full-domain ENUM IN rewrites to constant_or_null(TRUE, m)
+query I
+SELECT count(*) FROM m1 WHERE m IN ('sad', 'ok', 'happy');
+----
+3
+
+statement ok
+COMMIT;
+
+query I
+SELECT count(*) FROM m1 WHERE m IN ('sad', 'ok', 'happy');
+----
+3


### PR DESCRIPTION
Fixes <https://github.com/duckdb/duckdb/issues/24417>

Enum IN simplification can map VARCHAR literals back to ENUM constants. When the valid literals cover the full ENUM domain, rewrite the predicate to constant_or_null so filters can be simplified to true or false when the input is known non-null.

Add changes to detect enum domain exhaustion in InEnumSimplificationRule::Apply. Add ConstantOrNullSimplification to eliminate the entire filter in cases where the condition boils down to "true" or "false". This elimination is only done when the query has no side effects.

Add regression coverage for full-domain ENUM IN and NOT IN filters, nullable inputs, and DML CTE null handling.