### PR TITLE
Prune out of range fixed size array extracts via statistics callback

### DIFF
--- a/src/function/scalar/list/list_extract.cpp
+++ b/src/function/scalar/list/list_extract.cpp
@@ -123,13 +123,36 @@ static void ListExtractFunction(DataChunk &args, ExpressionState &state, Vector 
 	}
 }
 
+struct ListExtractBindData : public FunctionData {
+	ListExtractBindData(optional_idx array_size, optional<Value> index)
+	    : array_size(array_size), index(std::move(index)) {
+	}
+	optional_idx array_size;
+	optional<Value> index;
+
+	unique_ptr<FunctionData> Copy() const override {
+		return make_uniq<ListExtractBindData>(array_size, index);
+	}
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = other_p.Cast<ListExtractBindData>();
+		return array_size == other.array_size && index == other.index;
+	}
+};
+
 static unique_ptr<FunctionData> ListExtractBind(BindScalarFunctionInput &input) {
 	auto &context = input.GetClientContext();
 	auto &bound_function = input.GetBoundFunction();
 	auto &arguments = input.GetArguments();
 	D_ASSERT(bound_function.GetArguments().size() == 2);
+
+	optional_idx array_size;
+	optional<Value> index;
+	if (arguments[0]->GetReturnType().id() == LogicalTypeId::ARRAY) {
+		array_size = ArrayType::GetSize(arguments[0]->GetReturnType());
+		index = input.TryGetConstant(1);
+	}
 	arguments[0] = BoundCastExpression::AddArrayCastToList(context, std::move(arguments[0]));
-	return nullptr;
+	return make_uniq<ListExtractBindData>(array_size, std::move(index));
 }
 
 //! Extracting from a string throws if the index is outside of the range supported by substring - if the index is a
@@ -158,6 +181,16 @@ static unique_ptr<BaseStatistics> ListExtractStats(ClientContext &context, Funct
 	auto &child_stats = input.child_stats;
 	auto &list_child_stats = ListStats::GetChildStats(child_stats[0]);
 	auto child_copy = list_child_stats.Copy();
+
+	auto &bind_data = input.bind_data->Cast<ListExtractBindData>();
+	if (bind_data.array_size.IsValid() && bind_data.index && !bind_data.index->IsNull()) {
+		auto index_num = bind_data.index->GetValue<int64_t>();
+		list_entry_t bounds(0, bind_data.array_size.GetIndex());
+		if (!TryGetChildOffset(bounds, index_num).IsValid()) {
+			child_copy.Set(StatsInfo::CANNOT_HAVE_VALID_VALUES);
+		}
+	}
+
 	// list_extract always pushes a NULL, since if the offset is out of range for a list it inserts a null
 	child_copy.Set(StatsInfo::CAN_HAVE_NULL_VALUES);
 	return child_copy.ToUnique();

--- a/test/sql/optimizer/array_extract_out_of_bounds_pruning.test
+++ b/test/sql/optimizer/array_extract_out_of_bounds_pruning.test
@@ -1,0 +1,94 @@
+# name: test/sql/optimizer/array_extract_out_of_bounds_pruning.test
+# description: Out-of-bounds fixed-size array extract is simplified to NULL, enabling full row-group pruning
+# group: [optimizer]
+
+statement ok
+ATTACH '{TEST_DIR}/array_extract_simplification.duckdb' AS db (ROW_GROUP_SIZE 2048);
+
+statement ok
+USE db;
+
+statement ok
+CREATE TABLE arrays AS
+    SELECT [i::INTEGER, (i + 1)::INTEGER, (i + 2)::INTEGER]::INTEGER[3] AS a
+    FROM range(6144) tbl(i);
+
+# Out-of-bounds positive index: always NULL, filter is always false, plan eliminates the scan
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM arrays WHERE a[4] IS NOT NULL;
+----
+analyzed_plan	<REGEX>:.*Empty Result.*
+
+query I
+SELECT count(*) FROM arrays WHERE a[4] IS NOT NULL;
+----
+0
+
+# Out-of-bounds negative index: same
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM arrays WHERE a[-4] IS NOT NULL;
+----
+analyzed_plan	<REGEX>:.*Empty Result.*
+
+query I
+SELECT count(*) FROM arrays WHERE a[-4] IS NOT NULL;
+----
+0
+
+# In-bounds access: not simplified, normal scan
+query I
+SELECT count(*) FROM arrays WHERE a[1] IS NOT NULL;
+----
+6144
+
+# NULL index: result is NULL
+query I
+SELECT a[NULL] FROM arrays LIMIT 1;
+----
+NULL
+
+# Zero index: always NULL in 1-based indexing, filter is always false, plan eliminates the scan
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM arrays WHERE a[0] IS NOT NULL;
+----
+analyzed_plan	<REGEX>:.*Empty Result.*
+
+query I
+SELECT count(*) FROM arrays WHERE a[0] IS NOT NULL;
+----
+0
+
+query I
+SELECT a[0] FROM arrays LIMIT 1;
+----
+NULL
+
+# Boundary valid positive index (a[3] is in-bounds for INTEGER[3]): not simplified
+query I
+SELECT count(*) FROM arrays WHERE a[3] IS NOT NULL;
+----
+6144
+
+# Boundary valid negative indices: not simplified
+query I
+SELECT count(*) FROM arrays WHERE a[-1] IS NOT NULL;
+----
+6144
+
+query I
+SELECT count(*) FROM arrays WHERE a[-3] IS NOT NULL;
+----
+6144
+
+# Two out-of-bounds extracts on the same array column: the shared ARRAY -> LIST
+# cast is a candidate for common-subexpression elimination, which must not
+# prevent the out-of-bounds detection from firing on either extract
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM arrays WHERE a[4] IS NOT NULL OR a[5] IS NOT NULL;
+----
+analyzed_plan	<REGEX>:.*Empty Result.*
+
+query I
+SELECT count(*) FROM arrays WHERE a[4] IS NOT NULL OR a[5] IS NOT NULL;
+----
+0


### PR DESCRIPTION
Fixes: https://github.com/duckdb/duckdb/issues/24376

Previously, fixed sized array extracts that were out of range evaluate to null but the optimizer still performs a full table scan despite this.

- Prune out of range fixed sized array extracts via statistics callback `ListExtractStats`
- Added `ListExtractBindData` to contain the array size and index
- In `ListExtractBind` produce the data with the necessary information