### PR TITLE
Unpack row comparisons into per-field IS NOT DISTINCT FROM in any context

### DIFF
--- a/src/include/duckdb/optimizer/rule/comparison_simplification.hpp
+++ b/src/include/duckdb/optimizer/rule/comparison_simplification.hpp
@@ -21,7 +21,7 @@ public:
 	                             bool is_root) override;
 };
 
-//! Rewrites top-level filter equality between row constructors into scalar equalities.
+//! Rewrites top-level filter equality between row constructors (or folded row constants) into scalar equalities.
 class RowComparisonSimplificationRule : public Rule {
 public:
 	explicit RowComparisonSimplificationRule(ExpressionRewriter &rewriter);

--- a/src/optimizer/rule/comparison_simplification.cpp
+++ b/src/optimizer/rule/comparison_simplification.cpp
@@ -2,12 +2,16 @@
 #include "duckdb/optimizer/rule/comparison_simplification.hpp"
 
 #include "duckdb/common/helper.hpp"
+#include "duckdb/common/types.hpp"
 #include "duckdb/common/types/timestamp.hpp"
+#include "duckdb/common/types/value.hpp"
 #include "duckdb/execution/expression_executor.hpp"
+#include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/optimizer/expression_rewriter.hpp"
 #include "duckdb/planner/expression/bound_comparison_expression.hpp"
 #include "duckdb/planner/expression/bound_conjunction_expression.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/planner/expression/bound_operator_expression.hpp"
 
 namespace duckdb {
@@ -101,11 +105,81 @@ ComparisonSimplificationRule::ComparisonSimplificationRule(ExpressionRewriter &r
 	root = std::move(op);
 }
 
+//! If the given expression is a row constructor (possibly wrapped in casts), return it.
+//! effective_type is set to the type the comparison operates on (the cast target, if a cast is present)
+static optional_ptr<BoundFunctionExpression> UnwrapRowConstructor(Expression &expr, LogicalType &effective_type) {
+	auto *current = &expr;
+	auto has_cast = false;
+	while (current->GetExpressionClass() == ExpressionClass::BOUND_FUNCTION && BoundCastExpression::IsCast(*current)) {
+		auto &cast = current->Cast<BoundFunctionExpression>();
+		if (BoundCastExpression::IsTryCast(cast)) {
+			// a failing try_cast yields NULL instead of an error - we cannot replicate that in the decomposed filters
+			return nullptr;
+		}
+		if (!has_cast) {
+			effective_type = cast.GetReturnType();
+			has_cast = true;
+		}
+		current = BoundCastExpression::ChildMutable(cast).get();
+	}
+	if (current->GetExpressionClass() != ExpressionClass::BOUND_FUNCTION) {
+		return nullptr;
+	}
+	auto &function = current->Cast<BoundFunctionExpression>();
+	if (function.Function().GetName() != "row") {
+		return nullptr;
+	}
+	if (!has_cast) {
+		effective_type = function.GetReturnType();
+	}
+	return &function;
+}
+
+//! Extract the children of one side of a row constructor comparison.
+//! A side is either a row constructor function (possibly wrapped in casts) or a folded TUPLE/STRUCT
+//! constant (the binder folds row(a, b) with constant arguments into a single constant Value).
+//! Returns false if the side is not a row constructor in either form.
+static bool ExtractRowComparisonSide(Expression &expr, LogicalType &type, vector<unique_ptr<Expression>> &children,
+                                     bool &is_constant) {
+	if (expr.GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
+		auto &constant = expr.Cast<BoundConstantExpression>();
+		type = constant.GetValue().type();
+		if (type.id() != LogicalTypeId::TUPLE && type.id() != LogicalTypeId::STRUCT) {
+			return false;
+		}
+		auto &child_values = StructValue::GetChildren(constant.GetValue());
+		children.reserve(child_values.size());
+		for (auto &child_value : child_values) {
+			children.push_back(make_uniq<BoundConstantExpression>(child_value));
+		}
+		is_constant = true;
+		return true;
+	}
+	auto row = UnwrapRowConstructor(expr, type);
+	if (!row) {
+		return false;
+	}
+	// only tuple/struct comparisons compare their children element-wise; anything else (e.g. casts to
+	// VARCHAR or VARIANT) compares the entire value as a whole
+	if (type.id() != LogicalTypeId::TUPLE && type.id() != LogicalTypeId::STRUCT) {
+		return false;
+	}
+	// copy the children: Apply may still reject the rewrite, and must leave the plan untouched when it does
+	for (auto &child : row->GetChildrenMutable()) {
+		children.push_back(child->Copy());
+	}
+	is_constant = false;
+	return true;
+}
+
 RowComparisonSimplificationRule::RowComparisonSimplificationRule(ExpressionRewriter &rewriter) : Rule(rewriter) {
 	auto comparison = make_uniq<ComparisonExpressionMatcher>();
 	comparison->expr_type = make_uniq<SpecificExpressionTypeMatcher>(ExpressionType::COMPARE_EQUAL);
+	// at least one side is a row constructor - the other side is either a row constructor
+	// or a folded TUPLE/STRUCT constant (the binder folds row(a, b) with constant arguments into a single constant)
 	comparison->matchers.push_back(make_uniq<ExpressionMatcher>(ExpressionClass::BOUND_FUNCTION));
-	comparison->matchers.push_back(make_uniq<ExpressionMatcher>(ExpressionClass::BOUND_FUNCTION));
+	comparison->matchers.push_back(make_uniq<ExpressionMatcher>());
+	comparison->policy = SetMatcher::Policy::SOME;
 	root = std::move(comparison);
 }
 
@@ -115,31 +189,68 @@ unique_ptr<Expression> RowComparisonSimplificationRule::Apply(LogicalOperator &o
 	if (!is_root || op.type != LogicalOperatorType::LOGICAL_FILTER) {
 		return nullptr;
 	}
-	auto &left = bindings[1].get().Cast<BoundFunctionExpression>();
-	auto &right = bindings[2].get().Cast<BoundFunctionExpression>();
-	if (left.Function().GetName() != "row" || right.Function().GetName() != "row") {
+	auto &left = bindings[1].get();
+	auto &right = bindings[2].get();
+	LogicalType left_type;
+	vector<unique_ptr<Expression>> left_children;
+	bool left_is_constant;
+	if (!ExtractRowComparisonSide(left, left_type, left_children, left_is_constant)) {
 		return nullptr;
 	}
-	auto &left_children = left.GetChildrenMutable();
-	auto &right_children = right.GetChildrenMutable();
-	if (left_children.empty() || left_children.size() != right_children.size()) {
+	LogicalType right_type;
+	vector<unique_ptr<Expression>> right_children;
+	bool right_is_constant;
+	if (!ExtractRowComparisonSide(right, right_type, right_children, right_is_constant)) {
 		return nullptr;
 	}
-	for (idx_t child_idx = 0; child_idx < left_children.size(); child_idx++) {
-		auto &left_child = *left_children[child_idx];
-		auto &right_child = *right_children[child_idx];
-		if (left_child.GetExpressionClass() != ExpressionClass::BOUND_COLUMN_REF ||
-		    right_child.GetExpressionClass() != ExpressionClass::BOUND_COLUMN_REF ||
-		    left_child.GetReturnType().IsNested() || left_child.GetReturnType() != right_child.GetReturnType()) {
-			return nullptr;
+	// both sides are aligned to a common type at bind time
+	if (left_type != right_type || left_children.empty() || left_children.size() != right_children.size()) {
+		return nullptr;
+	}
+	// the children of a row constructor side must be plain columns
+	for (idx_t side = 0; side < 2; side++) {
+		auto &side_children = side == 0 ? left_children : right_children;
+		auto side_is_constant = side == 0 ? left_is_constant : right_is_constant;
+		if (side_is_constant) {
+			continue;
+		}
+		for (auto &child : side_children) {
+			if (child->GetExpressionClass() != ExpressionClass::BOUND_COLUMN_REF || child->GetReturnType().IsNested()) {
+				return nullptr;
+			}
 		}
 	}
-
+	// Row comparisons are decomposed with IS NOT DISTINCT FROM, matching the row comparison semantics:
+	// a NULL field does not make the row comparison NULL - row equality compares per-field distinctness.
+	// For a row-vs-constant comparison with a NULL-free constant the comparison can be decomposed with `=`:
+	// `a = 42` and `a IS NOT DISTINCT FROM 42` reject the same rows, and `=` is absorbed by the filter
+	// combiner, enabling constant filter pushdown. A constant containing NULLs is decomposed with
+	// IS NOT DISTINCT FROM instead - (a, b) = (NULL, 2) matches rows with a IS NULL, which `=` cannot
+	// express - and will benefit from pushdown once the combiner supports such comparisons.
+	ExpressionType comparison_type = ExpressionType::COMPARE_NOT_DISTINCT_FROM;
+	if (left_is_constant || right_is_constant) {
+		comparison_type = ExpressionType::COMPARE_EQUAL;
+		auto &constant_children = left_is_constant ? left_children : right_children;
+		for (auto &child : constant_children) {
+			if (child->Cast<BoundConstantExpression>().GetValue().IsNull()) {
+				comparison_type = ExpressionType::COMPARE_NOT_DISTINCT_FROM;
+				break;
+			}
+		}
+	}
+	auto &child_types = StructType::GetChildTypes(left_type);
+	if (child_types.size() != left_children.size()) {
+		return nullptr;
+	}
 	auto result = make_uniq<BoundConjunctionExpression>(ExpressionType::CONJUNCTION_AND);
 	for (idx_t child_idx = 0; child_idx < left_children.size(); child_idx++) {
-		result->GetChildrenMutable().push_back(BoundComparisonExpression::Create(
-		    ExpressionType::COMPARE_NOT_DISTINCT_FROM, std::move(left_children[child_idx]),
-		    std::move(right_children[child_idx])));
+		// the unwrapped children carry their original types - compare them in the aligned field type
+		auto left_child = BoundCastExpression::AddCastToType(GetContext(), std::move(left_children[child_idx]),
+		                                                     child_types[child_idx].second);
+		auto right_child = BoundCastExpression::AddCastToType(GetContext(), std::move(right_children[child_idx]),
+		                                                      child_types[child_idx].second);
+		result->GetChildrenMutable().push_back(
+		    BoundComparisonExpression::Create(comparison_type, std::move(left_child), std::move(right_child)));
 	}
 	return std::move(result);
 }

--- a/test/configs/disable_optimizer.json
+++ b/test/configs/disable_optimizer.json
@@ -18,7 +18,8 @@
         "test/sql/types/geo/geometry_parquet_pushdown.test",
         "test/optimizer/statistics/statistics_filter_pruning.test",
         "test/sql/copy/parquet/parquet_expression_filter_pruning.test",
-        "test/sql/copy/parquet/parquet_virtual_file_row_group_number.test"
+        "test/sql/copy/parquet/parquet_virtual_file_row_group_number.test",
+        "test/sql/filter/test_tuple_comparison_pushdown.test"
       ]
     },
     {

--- a/test/sql/filter/test_tuple_comparison_pushdown.test
+++ b/test/sql/filter/test_tuple_comparison_pushdown.test
@@ -1,0 +1,48 @@
+# name: test/sql/filter/test_tuple_comparison_pushdown.test
+# description: Test that row constructor comparisons (e.g. (a, b) = (42, 3)) are decomposed into per-column comparisons, enabling zone map pruning
+# group: [filter]
+
+# 500k rows -> 5 row groups (122880 rows each). id increases with the row id, so only the first
+# row group can contain id = 42.
+statement ok
+CREATE TABLE t AS SELECT range::BIGINT AS id, mod(range, 10)::INTEGER AS b FROM range(500000);
+
+# the tuple comparison is decomposed into id = 42 AND b = 2, both pushed into the scan
+query II
+EXPLAIN SELECT count(*) FROM t WHERE (id, b) = (42, 2);
+----
+physical_plan	<REGEX>:(?s).*Table: .*\.t.*Filters:.*id = 42.*b = 2.*
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM t WHERE (id, b) = (42, 2);
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 5.*
+
+query I
+SELECT count(*) FROM t WHERE (id, b) = (42, 2);
+----
+1
+
+# non-matching constants still prune down to a single row group
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM t WHERE (id, b) = (42, 3);
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 5.*
+
+query I
+SELECT count(*) FROM t WHERE (id, b) = (42, 3);
+----
+0
+
+# mismatched literal types are aligned to the tuple's common type at bind time (1.5 -> 2), and still decompose:
+# id = 42 is pushed down; the aligned value (42, 2) matches the id = 42 row
+query II
+EXPLAIN SELECT count(*) FROM t WHERE (id, b) = (42, 1.5);
+----
+physical_plan	<REGEX>:(?s).*Table: .*\.t.*Filters:.*id = 42.*
+
+query I
+SELECT count(*) FROM t WHERE (id, b) = (42, 1.5);
+----
+1
+

--- a/test/sql/optimizer/expression/test_row_comparison_simplification.test
+++ b/test/sql/optimizer/expression/test_row_comparison_simplification.test
@@ -34,6 +34,25 @@ SELECT count(*) FROM rows WHERE (a, b) = (c, d);
 ----
 3
 
+# Row-vs-constant comparisons decompose as well: (a, b) = (1, 2) matches rows with a = 1 AND b = 2
+query I
+SELECT count(*) FROM rows WHERE (a, b) = (1, 2);
+----
+3
+
+# Constants containing NULLs decompose with IS NOT DISTINCT FROM: (a, b) = (1, NULL) matches rows
+# with a = 1 AND b IS NULL, which a decomposition into `=` would drop (a = NULL is NULL)
+query I
+SELECT count(*) FROM rows WHERE (a, b) = (1, NULL);
+----
+1
+
+# the constant may be on either side of the comparison
+query I
+SELECT count(*) FROM rows WHERE (1, NULL) = (a, b);
+----
+1
+
 # Empty and expression-valued rows retain the original comparison implementation.
 query II
 SELECT row() = row(), row(a + 1, b) = row(c + 1, d) FROM rows WHERE a = 1 AND b = 2 AND d = 2;


### PR DESCRIPTION
Fixes #23594

`RowComparisonSimplificationRule` now unpacks row comparisons uniformly: either side may be a row constructor (possibly wrapped in casts) or a folded TUPLE/STRUCT constant, the children may be any expression, and the unpacking happens in any context, not just the top of a filter. `(id, b) = (42, 2)` becomes `id IS NOT DISTINCT FROM 42 AND b IS NOT DISTINCT FROM 2`, so the existing pushdown and zone map pruning applies to it.

- row comparisons compare their fields with IS NOT DISTINCT FROM, so the result is the same everywhere (a NULL field does not turn the comparison into NULL: `(1, NULL) = (1, NULL)` is true) - projections and join conditions included
- fields are compared in the aligned field type, so `(id, b) = (42, 1.5)` unpacks to `id IS NOT DISTINCT FROM 42 AND b IS NOT DISTINCT FROM 2`
- `ROW() = ROW()` unpacks to TRUE, and a NULL constant is left alone: NULL is not a row of NULL fields
- a comparison with a volatile or can-throw child is left alone as well (a field that fails skips the evaluation of the rest)
- tests: `test/sql/filter/test_tuple_comparison_pushdown.test` (pushdown, row group pruning, bind time type alignment, nested rows, a user-written IS NOT DISTINCT FROM row comparison; skipped in the disable_optimizer config since pruning requires the optimizer) and `test/sql/optimizer/expression/test_row_comparison_simplification.test` (flat and nested NULL semantics, NULL constant, empty rows, volatile children)

Note: the filter combiner does not accept IS NOT DISTINCT FROM yet, so the per-field comparisons are pushed as single-column expression filters; #24605 handles folding them to equality, which is also what join conditions need.