### PR TITLE
Fix C API `duckdb_create_logical_type` for `VARIANT`

### DIFF
--- a/src/main/capi/logical_types-c.cpp
+++ b/src/main/capi/logical_types-c.cpp
@@ -44,6 +44,10 @@ duckdb_logical_type duckdb_create_logical_type(duckdb_type type) {
 		type = DUCKDB_TYPE_INVALID;
 	}
 
+	if (type == DUCKDB_TYPE_VARIANT) {
+		return reinterpret_cast<duckdb_logical_type>(new duckdb::LogicalType(duckdb::LogicalType::VARIANT()));
+	}
+
 	auto type_id = duckdb::LogicalTypeIdFromC(type);
 	return reinterpret_cast<duckdb_logical_type>(new duckdb::LogicalType(type_id));
 }

--- a/test/api/capi/test_capi_variant.cpp
+++ b/test/api/capi/test_capi_variant.cpp
@@ -28,3 +28,20 @@ TEST_CASE("Test C API VARIANT type support", "[capi]") {
 
 	duckdb_destroy_logical_type(&type);
 }
+
+TEST_CASE("Test C API create VARIANT logical type", "[capi]") {
+	auto type = duckdb_create_logical_type(DUCKDB_TYPE_VARIANT);
+
+	REQUIRE(type);
+	REQUIRE(duckdb_get_type_id(type) == DUCKDB_TYPE_VARIANT);
+
+	auto vector_handle = duckdb_create_vector(type, 1);
+	REQUIRE(vector_handle);
+
+	auto vector_type = duckdb_vector_get_column_type(vector_handle);
+	REQUIRE(duckdb_get_type_id(vector_type) == DUCKDB_TYPE_VARIANT);
+
+	duckdb_destroy_logical_type(&vector_type);
+	duckdb_destroy_vector(&vector_handle);
+	duckdb_destroy_logical_type(&type);
+}


### PR DESCRIPTION
Fixes #24680

When creating a `VARIANT` logical type via `duckdb_create_logical_type(DUCKDB_TYPE_VARIANT)`, it previously fell back to the generic C API constructor, which produced an incomplete `LogicalType` ID missing its internal `StructTypeInfo`. This resulted in a crash (unset `optional_ptr` dereference) downstream when attempting to access its child types to build a vector.

This fix routes `DUCKDB_TYPE_VARIANT` to DuckDB's canonical `LogicalType::VARIANT()` factory, correctly initializing its internal struct layout and metadata.
