### PR TITLE
Preserve case-sensitive VARIANT fields during shredding

### DIFF
--- a/extension/parquet/writer/variant/convert_variant.cpp
+++ b/extension/parquet/writer/variant/convert_variant.cpp
@@ -230,14 +230,13 @@ vector<idx_t> GetChildIndices(const UnifiedVariantVectorData &variant, idx_t row
 		}
 		return child_indices;
 	}
-	//! FIXME: The variant spec says that field names should be case-sensitive, not insensitive
-	case_insensitive_string_set_t shredded_fields = shredding_state->ObjectFields();
+	auto shredded_fields = shredding_state->ObjectFields();
 
 	for (idx_t i = 0; i < nested_data.child_count; i++) {
 		auto keys_index = variant.GetKeysIndex(row, i + nested_data.children_idx);
 		auto &key = variant.GetKey(row, keys_index);
 
-		if (shredded_fields.count(key)) {
+		if (shredded_fields.count(key.GetString())) {
 			//! This field is shredded on, omit it from the value
 			continue;
 		}

--- a/src/function/variant/variant_shredding.cpp
+++ b/src/function/variant/variant_shredding.cpp
@@ -356,13 +356,12 @@ void VariantShreddingState::SetShredded(uint32_t row, uint32_t values_index, uin
 	count++;
 }
 
-case_insensitive_string_set_t VariantShreddingState::ObjectFields() {
+unordered_set<string> VariantShreddingState::ObjectFields() const {
 	D_ASSERT(type.id() == LogicalTypeId::STRUCT);
-	case_insensitive_string_set_t res;
+	unordered_set<string> res;
 	auto &child_types = StructType::GetChildTypes(type);
 	for (auto &entry : child_types) {
-		auto &type = entry.first;
-		res.emplace(type.c_str(), static_cast<uint32_t>(type.size()));
+		res.emplace(entry.first.GetIdentifierName());
 	}
 	return res;
 }

--- a/src/include/duckdb/function/variant/variant_shredding.hpp
+++ b/src/include/duckdb/function/variant/variant_shredding.hpp
@@ -5,7 +5,7 @@
 #include "duckdb/common/types/selection_vector.hpp"
 #include "duckdb/common/types/decimal.hpp"
 #include "duckdb/common/types/uuid.hpp"
-#include "duckdb/common/string_map_set.hpp"
+#include "duckdb/common/unordered_set.hpp"
 #include "duckdb/function/scalar/variant_utils.hpp"
 
 namespace duckdb {
@@ -106,7 +106,7 @@ public:
 public:
 	bool ValueIsShredded(UnifiedVariantVectorData &variant, idx_t row, uint32_t values_index);
 	void SetShredded(uint32_t row, uint32_t values_index, uint32_t result_idx);
-	case_insensitive_string_set_t ObjectFields();
+	unordered_set<string> ObjectFields() const;
 	virtual const unordered_set<VariantLogicalType> &GetVariantTypes() = 0;
 
 public:

--- a/src/storage/statistics/variant_stats.cpp
+++ b/src/storage/statistics/variant_stats.cpp
@@ -558,6 +558,20 @@ unique_ptr<BaseStatistics> VariantStats::WrapExtractedFieldAsVariant(const BaseS
 	copy.Copy(base_variant);
 	copy.child_stats[1] = BaseStatistics::CreateUnknown(extracted_field.GetType());
 	copy.child_stats[1].Copy(extracted_field);
+	// The extraction can produce NULL when the field's typed value is NULL, even if the input
+	// variant is not - descend through the shredding STRUCTs to the typed value.
+	const BaseStatistics *effective = &extracted_field;
+	bool can_have_null = false;
+	while (true) {
+		can_have_null |= effective->CanHaveNull();
+		if (effective->GetType().id() != LogicalTypeId::STRUCT) {
+			break;
+		}
+		effective = &VariantStats::GetTypedStats(*effective);
+	}
+	if (can_have_null) {
+		copy.Set(StatsInfo::CAN_HAVE_NULL_VALUES);
+	}
 	return copy.ToUnique();
 }
 

--- a/src/storage/table/variant/variant_shredding.cpp
+++ b/src/storage/table/variant/variant_shredding.cpp
@@ -555,7 +555,7 @@ static vector<uint32_t> UnshreddedObjectChildren(UnifiedVariantVectorData &varia
 	for (uint32_t i = 0; i < nested_data.child_count; i++) {
 		auto keys_index = variant.GetKeysIndex(row, nested_data.children_idx + i);
 		auto &key = variant.GetKey(row, keys_index);
-		if (shredded_fields.count(key)) {
+		if (shredded_fields.count(key.GetString())) {
 			continue;
 		}
 		unshredded_children.emplace_back(i);

--- a/src/storage/table/variant_column_data.cpp
+++ b/src/storage/table/variant_column_data.cpp
@@ -82,7 +82,7 @@ bool FindShreddedColumnInternal(const ColumnData &shredded, reference<const Base
 	auto &object_children = StructType::GetChildTypes(typed_value.type);
 	optional_idx opt_index;
 	for (idx_t i = 0; i < object_children.size(); i++) {
-		if (field_name == object_children[i].first) {
+		if (field_name == object_children[i].first.GetIdentifierName()) {
 			opt_index = i;
 			break;
 		}

--- a/test/parquet/variant/pushdown/variant_case_sensitivity.test
+++ b/test/parquet/variant/pushdown/variant_case_sensitivity.test
@@ -39,6 +39,40 @@ WHERE v.Foo = 3;
 ----
 1
 
+# A differently cased field is not the field named by the explicit shredding
+# schema and must remain in the untyped overlay.
+
+statement ok
+CREATE OR REPLACE VIEW vw AS SELECT {'foo': 2::INTEGER}::VARIANT AS v;
+
+statement ok
+COPY vw TO '{TEST_DIR}/variant_case_mismatch.parquet' (
+	SHREDDING {'v': 'STRUCT("Foo" INTEGER)'}
+);
+
+query III
+SELECT v::VARCHAR, variant_extract(v, 'foo')::VARCHAR, variant_extract(v, 'Foo')::VARCHAR
+FROM '{TEST_DIR}/variant_case_mismatch.parquet';
+----
+{'foo': 2}	2	NULL
+
+# Apply the same exact matching recursively.
+
+statement ok
+CREATE OR REPLACE VIEW vw AS SELECT {'outer': {'foo': 3::INTEGER}}::VARIANT AS v;
+
+statement ok
+COPY vw TO '{TEST_DIR}/variant_nested_case_mismatch.parquet' (
+	SHREDDING {'v': 'STRUCT("outer" STRUCT("Foo" INTEGER))'}
+);
+
+query II
+SELECT variant_extract(variant_extract(v, 'outer'), 'foo')::VARCHAR,
+	variant_extract(variant_extract(v, 'outer'), 'Foo')::VARCHAR
+FROM '{TEST_DIR}/variant_nested_case_mismatch.parquet';
+----
+3	NULL
+
 # Shred "Foo" on a different type, causing the values to not land in 'typed_value'
 
 statement ok

--- a/test/sql/storage/types/variant/variant_case_sensitive_fields_shredded.test
+++ b/test/sql/storage/types/variant/variant_case_sensitive_fields_shredded.test
@@ -76,3 +76,11 @@ select v::varchar,
 from forced_case;
 ----
 {'foo': 2}	2	NULL
+
+# The same field must be reachable through an isolated pushdown (exercises
+# FindShreddedColumnInternal's exact field-name match).
+query I
+select count(*) from forced_case where v.foo = 2
+----
+1
+

--- a/test/sql/storage/types/variant/variant_case_sensitive_fields_shredded.test
+++ b/test/sql/storage/types/variant/variant_case_sensitive_fields_shredded.test
@@ -48,3 +48,31 @@ restart
 
 statement ok
 checkpoint;
+
+# A differently cased field is not the field named by a forced shredding schema
+# and must remain in the untyped overlay.
+
+statement ok
+drop table test_structs;
+
+statement ok
+set force_variant_shredding = 'STRUCT("Foo" INTEGER)';
+
+statement ok
+create table forced_case(v variant);
+
+statement ok
+insert into forced_case values ({'foo': 2}::variant);
+
+statement ok
+checkpoint;
+
+restart
+
+query III
+select v::varchar,
+       variant_extract(v, 'foo')::varchar,
+       variant_extract(v, 'Foo')::varchar
+from forced_case;
+----
+{'foo': 2}	2	NULL


### PR DESCRIPTION
Fixes #24379. Fixes #24297.

VARIANT object keys are case-sensitive, but DuckDB STRUCT field identifiers are case-insensitive. When a shredding schema contains a key spelled `Foo` and the actual data uses `foo`, the untyped-overlay omission set was case-insensitive and silently discarded the value. The separate issue of schemas that themselves contain both `a` and `A` is handled by #24553; this PR fixes the remaining case where the schema and data differ in spelling alone.

The Parquet and internal-storage writers now use exact matching for the omission set, so a field spelled differently from the shredded schema is retained in the overlay rather than dropped. The read-side lookup in `FindShreddedColumnInternal` also switches from the STRUCT field-name equality operator (case-insensitive) to `GetIdentifierName()` for exact comparison.

The regression covers top-level and nested mismatches in both Parquet and internal storage, forced shredding, and an isolated pushdown through the read path.
