### PR TITLE
Fix: Don't rewrite timestamp-to-date comparisons for infinite dates

### DIFF
--- a/src/optimizer/rule/timestamp_comparison.cpp
+++ b/src/optimizer/rule/timestamp_comparison.cpp
@@ -81,6 +81,9 @@ unique_ptr<Expression> TimeStampComparison::Apply(LogicalOperator &op, vector<re
 		auto original_val = result.GetValue<duckdb::date_t>();
 		auto no_seconds = dtime_t(0);
 
+		if (!original_val.IsFinite()) {
+			return nullptr;
+		}
 		// original date as timestamp with no seconds
 		auto original_val_ts = Value::TIMESTAMP(original_val, no_seconds);
 		auto original_val_for_comparison = make_uniq<BoundConstantExpression>(original_val_ts);

--- a/test/optimizer/pushdown/timestamp_to_date_pushdown.test
+++ b/test/optimizer/pushdown/timestamp_to_date_pushdown.test
@@ -5,6 +5,17 @@
 statement ok
 SET profiling_renderer_settings = MAP {'operator_casing': 'upper'};
 
+statement ok
+create table tbl1(t timestamp);
+
+statement ok
+insert into tbl1 values (timestamp '-infinity'), (timestamp '2025-01-01'), (timestamp 'infinity'), (NULL);
+
+query I
+select count(*) from tbl1 where t::date == date 'infinity';
+----
+1
+
 require icu
 
 foreach timezone UTC ECT


### PR DESCRIPTION
Bail out and let the comparison be evaluated as-is instead.

Fixes: https://github.com/duckdb/duckdb/issues/24306