### PR TITLE
Fix clang tidy errors in json variant cast file

### DIFF
--- a/src/function/cast/variant/to_json.cpp
+++ b/src/function/cast/variant/to_json.cpp
@@ -1,15 +1,10 @@
-#include "duckdb/function/scalar/variant_utils.hpp"
-#include "duckdb/function/cast/default_casts.hpp"
 #include "yyjson.hpp"
-#include "duckdb/common/serializer/memory_stream.hpp"
-#include "duckdb/common/serializer/varint.hpp"
 #include "duckdb/common/typedefs.hpp"
-#include "duckdb/common/optional_idx.hpp"
-#include "duckdb/common/string_map_set.hpp"
-#include "duckdb/common/types/selection_vector.hpp"
 #include "duckdb/common/types/decimal.hpp"
 #include "duckdb/common/types/time.hpp"
 #include "duckdb/common/types/timestamp.hpp"
+#include "duckdb/common/types/variant.hpp"
+#include "duckdb/common/types/variant_iterator.hpp"
 #include "duckdb/common/types/variant_visitor.hpp"
 
 using namespace duckdb_yyjson; // NOLINT


### PR DESCRIPTION
Fix clang tidy [errors](https://github.com/duckdb/duckdb/actions/runs/31550893085/job/93973298054#step:6:63) on main:
```c++
src/function/cast/variant/to_json.cpp:202:42: Error: Member access into incomplete type 'const VariantNode' [incomplete_member_access]
  200 |  	static yyjson_mut_val *VisitObject(const VariantNode &variant, yyjson_mut_doc *doc) {
  201 |  		const auto obj = yyjson_mut_obj(doc);
  202 |  		for (const auto &[key, value] : variant.GetObjectChildren(OBJECT_ORDER)) {
      |                                           ^
  203 |  			const auto key_value = yyjson_mut_strncpy(doc, key.GetData(), key.GetSize());
  204 |  			const auto json_value = VariantVisitor<NodeJSONConverter<OBJECT_ORDER>>::Visit(value, doc);
src/function/cast/variant/to_json.cpp:24:7: Note:  
   24 |  	using result_type = yyjson_mut_val *;
      |        ^

src/function/cast/variant/to_json.cpp:215:31: Error: Out-of-line definition of 'ConvertVariantToJSON' does not match any declaration in 'duckdb::VariantCasts' [member_decl_does_not_match]
  213 |  } // namespace
  214 |  
  215 |  yyjson_mut_val *VariantCasts::ConvertVariantToJSON(yyjson_mut_doc *doc, const VariantNode &variant,
      |                                ^~~~~~~~~~~~~~~~~~~~
  216 |                                                     bool sort_object_keys) {
  217 |  	if (sort_object_keys) {
src/function/cast/variant/to_json.cpp:209:8: Note:  
  209 |  		return obj;
      |         ^

src/function/cast/variant/to_json.cpp:218:66: Error: No member named 'LEXICOGRAPHIC' in 'duckdb::VariantIterationOrder' [no_member]
  216 |                                                     bool sort_object_keys) {
  217 |  	if (sort_object_keys) {
  218 |  		return VariantVisitor<NodeJSONConverter<VariantIterationOrder::LEXICOGRAPHIC>>::Visit(variant, doc);
      |                                                                   ^~~~~~~~~~~~~
  219 |  	}
  220 |  	return VariantVisitor<NodeJSONConverter<VariantIterationOrder::INTERNAL>>::Visit(variant, doc);

src/function/cast/variant/to_json.cpp:220:65: Error: No member named 'INTERNAL' in 'duckdb::VariantIterationOrder' [no_member]
  218 |  		return VariantVisitor<NodeJSONConverter<VariantIterationOrder::LEXICOGRAPHIC>>::Visit(variant, doc);
  219 |  	}
  220 |  	return VariantVisitor<NodeJSONConverter<VariantIterationOrder::INTERNAL>>::Visit(variant, doc);
      |                                                                  ^~~~~~~~
  221 |  }
  222 |

src/function/cast/variant/to_json.cpp:223:31: Error: Out-of-line definition of 'ConvertVariantToJSON' does not match any declaration in 'duckdb::VariantCasts' [member_decl_does_not_match]
  221 |  }
  222 |  
  223 |  yyjson_mut_val *VariantCasts::ConvertVariantToJSON(yyjson_mut_doc *doc, const UnifiedVariantVectorData &variant,
      |                                ^~~~~~~~~~~~~~~~~~~~
  224 |                                                     idx_t row, uint32_t values_idx) {
  225 |  	return VariantVisitor<JSONConverter>::Visit(variant, row, values_idx, doc);
src/function/cast/variant/to_json.cpp:209:8: Note:  
  209 |  		return obj;
      |         ^

```