### PR TITLE
[Sequence] Disable parallel insert for tables with column(s) with `nextval(...)` in them

### DIFF
--- a/src/execution/operator/projection/physical_projection.cpp
+++ b/src/execution/operator/projection/physical_projection.cpp
@@ -1,6 +1,8 @@
 #include "duckdb/execution/operator/projection/physical_projection.hpp"
 #include "duckdb/parallel/thread_context.hpp"
 #include "duckdb/execution/expression_executor.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "duckdb/planner/expression_iterator.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 
 namespace duckdb {
@@ -38,6 +40,21 @@ OperatorResultType PhysicalProjection::Execute(ExecutionContext &context, DataCh
 
 unique_ptr<OperatorState> PhysicalProjection::GetOperatorState(ExecutionContext &context) const {
 	return make_uniq<ProjectionState>(context, select_list);
+}
+
+bool PhysicalProjection::ParallelOperator() const {
+	for (auto &expression : select_list) {
+		bool requires_ordered_execution = false;
+		ExpressionIterator::VisitExpression<BoundFunctionExpression>(*expression, [&](const auto &function) {
+			if (function.RequiresOrderedExecution()) {
+				requires_ordered_execution = true;
+			}
+		});
+		if (requires_ordered_execution) {
+			return false;
+		}
+	}
+	return true;
 }
 
 InsertionOrderPreservingMap<string> PhysicalProjection::ParamsToString() const {

--- a/src/function/function.cpp
+++ b/src/function/function.cpp
@@ -11,7 +11,8 @@ namespace duckdb {
 
 bool FunctionProperties::operator==(const FunctionProperties &rhs) const {
 	return stability == rhs.stability && null_handling == rhs.null_handling && errors == rhs.errors &&
-	       collation_handling == rhs.collation_handling && capture_argument_aliases == rhs.capture_argument_aliases;
+	       collation_handling == rhs.collation_handling && capture_argument_aliases == rhs.capture_argument_aliases &&
+	       requires_ordered_execution == rhs.requires_ordered_execution;
 }
 
 bool FunctionProperties::operator!=(const FunctionProperties &rhs) const {

--- a/src/function/scalar/sequence/nextval.cpp
+++ b/src/function/scalar/sequence/nextval.cpp
@@ -164,6 +164,7 @@ ScalarFunction NextvalFun::GetFunction() {
 	next_val.SetInitStateCallback(NextValLocalFunction);
 	next_val.SetVolatile();
 	next_val.SetFallible();
+	next_val.SetRequiresOrderedExecution(true);
 	return next_val;
 }
 
@@ -189,6 +190,7 @@ ScalarFunctionSet SetvalFun::GetFunctions() {
 	set_val.SetInitStateCallback(NextValLocalFunction);
 	set_val.SetVolatile();
 	set_val.SetFallible();
+	set_val.SetRequiresOrderedExecution(true);
 
 	ScalarFunctionSet set_val_set;
 	set_val_set.AddFunction(set_val);

--- a/src/include/duckdb/execution/operator/projection/physical_projection.hpp
+++ b/src/include/duckdb/execution/operator/projection/physical_projection.hpp
@@ -28,9 +28,7 @@ public:
 	OperatorResultType Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
 	                           GlobalOperatorState &gstate, OperatorState &state) const override;
 
-	bool ParallelOperator() const override {
-		return true;
-	}
+	bool ParallelOperator() const override;
 	PipelineExternalInputSupport GetExternalInputSupport() const override {
 		return PipelineExternalInputSupport::SUPPORTED;
 	}

--- a/src/include/duckdb/function/function.hpp
+++ b/src/include/duckdb/function/function.hpp
@@ -473,6 +473,13 @@ public:
 		capture_argument_aliases = value;
 	}
 
+	auto RequiresOrderedExecution() const -> bool {
+		return requires_ordered_execution;
+	}
+	auto SetRequiresOrderedExecution(bool value) -> void {
+		requires_ordered_execution = value;
+	}
+
 	// Helpers
 	auto SetFallible() -> void {
 		errors = FunctionErrors::CAN_THROW_RUNTIME_ERROR;
@@ -496,6 +503,8 @@ public:
 	//! function. This preserves the legacy behavior of functions such as struct_pack/row, which derived their
 	//! (struct field) names from argument aliases and therefore allowed positional arguments after named ones.
 	bool capture_argument_aliases = false;
+	//! Whether calls to this function must follow input order
+	bool requires_ordered_execution = false;
 };
 
 class BoundSimpleFunction {

--- a/src/include/duckdb/function/scalar_function.hpp
+++ b/src/include/duckdb/function/scalar_function.hpp
@@ -242,6 +242,9 @@ public: // Properties
 	auto GetCaptureArgumentAliases() const -> bool { return properties.capture_argument_aliases; }
 	auto SetCaptureArgumentAliases(bool value) -> void { properties.capture_argument_aliases = value; }
 
+	auto RequiresOrderedExecution() const -> bool { return properties.requires_ordered_execution; }
+	auto SetRequiresOrderedExecution(bool value) -> void { properties.requires_ordered_execution = value; }
+
 	//! Set this functions error-mode as fallible (can throw runtime errors)
 	void SetFallible() { properties.errors = FunctionErrors::CAN_THROW_RUNTIME_ERROR; }
 	//! Set this functions stability as volatile (can not be cached per row)

--- a/src/include/duckdb/planner/expression/bound_function_expression.hpp
+++ b/src/include/duckdb/planner/expression/bound_function_expression.hpp
@@ -48,6 +48,7 @@ public:
 	bool &IsOperatorMutable() {
 		return is_operator;
 	}
+	bool RequiresOrderedExecution() const;
 
 	bool IsVolatile() const override;
 	bool IsConsistent() const override;

--- a/src/planner/expression/bound_function_expression.cpp
+++ b/src/planner/expression/bound_function_expression.cpp
@@ -6,6 +6,7 @@
 #include "duckdb/common/serializer/serializer.hpp"
 #include "duckdb/common/serializer/deserializer.hpp"
 #include "duckdb/function/lambda_functions.hpp"
+#include "duckdb/planner/expression_iterator.hpp"
 
 namespace duckdb {
 
@@ -24,6 +25,21 @@ ExpressionType BoundFunctionExpression::GetFunctionExpressionType(const BoundSca
                                                                   optional_ptr<FunctionData> bind_info_p) {
 	FunctionToStringInput input(bound_function, bind_info_p.get(), arguments);
 	return bound_function.GetExpressionType(input);
+}
+
+bool BoundFunctionExpression::RequiresOrderedExecution() const {
+	if (function.RequiresOrderedExecution()) {
+		return true;
+	}
+	bool has_value = false;
+	ExpressionIterator::EnumerateChildren(*this, [&](const Expression &child) {
+		if (child.GetExpressionType() != ExpressionType::BOUND_FUNCTION) {
+			return;
+		}
+		auto &child_function = child.Cast<BoundFunctionExpression>().Function();
+		has_value |= child_function.RequiresOrderedExecution();
+	});
+	return has_value;
 }
 
 bool BoundFunctionExpression::IsVolatile() const {

--- a/test/sql/catalog/table/test_default.test
+++ b/test/sql/catalog/table/test_default.test
@@ -87,10 +87,18 @@ statement ok
 CREATE SEQUENCE seq;
 
 statement ok
-CREATE TABLE test (a INTEGER DEFAULT nextval('seq'), b INTEGER);
+CREATE TABLE test (
+	a INTEGER DEFAULT nextval('seq'),
+	b INTEGER
+);
 
 statement ok
-INSERT INTO test (b) VALUES (2), (4), (6), (2), (4);
+INSERT INTO test (b) VALUES
+	(2),
+	(4),
+	(6),
+	(2),
+	(4);
 
 query II
 SELECT * FROM test ORDER BY 1


### PR DESCRIPTION
This PR fixes https://github.com/duckdblabs/duckdb-internal/issues/10309

I believe this became an issue once https://github.com/duckdb/duckdb/pull/24084 was merged.