### PR TITLE
Prune struct segment

### DIFF
--- a/src/include/duckdb/storage/table/array_column_data.hpp
+++ b/src/include/duckdb/storage/table/array_column_data.hpp
@@ -21,7 +21,8 @@ public:
 
 public:
 	void SetDataType(ColumnDataType data_type) override;
-	FilterPropagateResult CheckZonemap(ColumnScanState &state, TableFilter &filter) override;
+	FilterPropagateResult CheckZonemap(ColumnScanState &state, TableFilter &filter,
+	                                   optional_ptr<SegmentNode<ColumnSegment>> &checked_segment) override;
 
 	void InitializePrefetch(PrefetchState &prefetch_state, ColumnScanState &scan_state, idx_t rows) override;
 	void InitializeScan(ColumnScanState &state) override;

--- a/src/include/duckdb/storage/table/column_data.hpp
+++ b/src/include/duckdb/storage/table/column_data.hpp
@@ -81,7 +81,8 @@ public:
 	LogicalType type;
 
 public:
-	virtual FilterPropagateResult CheckZonemap(ColumnScanState &state, TableFilter &filter);
+	virtual FilterPropagateResult CheckZonemap(ColumnScanState &state, TableFilter &filter,
+	                                           optional_ptr<SegmentNode<ColumnSegment>> &checked_segment);
 
 	BlockManager &GetBlockManager() const {
 		return block_manager;

--- a/src/include/duckdb/storage/table/list_column_data.hpp
+++ b/src/include/duckdb/storage/table/list_column_data.hpp
@@ -21,7 +21,8 @@ public:
 
 public:
 	void SetDataType(ColumnDataType data_type) override;
-	FilterPropagateResult CheckZonemap(ColumnScanState &state, TableFilter &filter) override;
+	FilterPropagateResult CheckZonemap(ColumnScanState &state, TableFilter &filter,
+	                                   optional_ptr<SegmentNode<ColumnSegment>> &checked_segment) override;
 
 	void InitializePrefetch(PrefetchState &prefetch_state, ColumnScanState &scan_state, idx_t rows) override;
 	void InitializeScan(ColumnScanState &state) override;

--- a/src/include/duckdb/storage/table/row_id_column_data.hpp
+++ b/src/include/duckdb/storage/table/row_id_column_data.hpp
@@ -38,7 +38,8 @@ public:
 
 	void Skip(ColumnScanState &state, idx_t count = STANDARD_VECTOR_SIZE) override;
 
-	FilterPropagateResult CheckZonemap(ColumnScanState &state, TableFilter &filter) override;
+	FilterPropagateResult CheckZonemap(ColumnScanState &state, TableFilter &filter,
+	                                   optional_ptr<SegmentNode<ColumnSegment>> &checked_segment) override;
 
 	void InitializeAppend(ColumnAppendState &state) override;
 	void Append(ColumnAppendState &state, const Vector &vector, idx_t count) override;

--- a/src/include/duckdb/storage/table/row_number_column_data.hpp
+++ b/src/include/duckdb/storage/table/row_number_column_data.hpp
@@ -36,7 +36,8 @@ public:
 
 	void Skip(ColumnScanState &state, idx_t count = STANDARD_VECTOR_SIZE) override;
 
-	FilterPropagateResult CheckZonemap(ColumnScanState &state, TableFilter &filter) override;
+	FilterPropagateResult CheckZonemap(ColumnScanState &state, TableFilter &filter,
+	                                   optional_ptr<SegmentNode<ColumnSegment>> &checked_segment) override;
 
 	void InitializeAppend(ColumnAppendState &state) override;
 	void Append(ColumnAppendState &state, const Vector &vector, idx_t count) override;

--- a/src/include/duckdb/storage/table/struct_column_data.hpp
+++ b/src/include/duckdb/storage/table/struct_column_data.hpp
@@ -36,6 +36,8 @@ public:
 public:
 	void SetDataType(ColumnDataType data_type) override;
 	idx_t GetMaxEntry() override;
+	FilterPropagateResult CheckZonemap(ColumnScanState &state, TableFilter &filter,
+	                                   optional_ptr<SegmentNode<ColumnSegment>> &checked_segment) override;
 
 	void InitializePrefetch(PrefetchState &prefetch_state, ColumnScanState &scan_state, idx_t rows) override;
 	void InitializeScan(ColumnScanState &state) override;

--- a/src/include/duckdb/storage/table/validity_column_data.hpp
+++ b/src/include/duckdb/storage/table/validity_column_data.hpp
@@ -22,7 +22,8 @@ public:
 	                   optional_ptr<ColumnData> parent);
 
 public:
-	FilterPropagateResult CheckZonemap(ColumnScanState &state, TableFilter &filter) override;
+	FilterPropagateResult CheckZonemap(ColumnScanState &state, TableFilter &filter,
+	                                   optional_ptr<SegmentNode<ColumnSegment>> &checked_segment) override;
 	void AppendData(ColumnAppendState &state, UnifiedVectorFormat &vdata, idx_t count) override;
 	unique_ptr<ColumnCheckpointState> CreateCheckpointState(const RowGroup &row_group,
 	                                                        PartialBlockManager &partial_block_manager) override;

--- a/src/storage/table/array_column_data.cpp
+++ b/src/storage/table/array_column_data.cpp
@@ -27,9 +27,8 @@ void ArrayColumnData::SetDataType(ColumnDataType data_type) {
 	validity->SetDataType(data_type);
 }
 
-FilterPropagateResult
-ArrayColumnData::CheckZonemap(ColumnScanState &state, TableFilter &filter,
-                              optional_ptr<SegmentNode<ColumnSegment>> &checked_segment) {
+FilterPropagateResult ArrayColumnData::CheckZonemap(ColumnScanState &state, TableFilter &filter,
+                                                    optional_ptr<SegmentNode<ColumnSegment>> &checked_segment) {
 	// FIXME: There is nothing preventing us from supporting this, but it's not implemented yet.
 	// table filters are not supported yet for fixed size list columns
 	checked_segment = nullptr;

--- a/src/storage/table/array_column_data.cpp
+++ b/src/storage/table/array_column_data.cpp
@@ -27,9 +27,12 @@ void ArrayColumnData::SetDataType(ColumnDataType data_type) {
 	validity->SetDataType(data_type);
 }
 
-FilterPropagateResult ArrayColumnData::CheckZonemap(ColumnScanState &state, TableFilter &filter) {
+FilterPropagateResult
+ArrayColumnData::CheckZonemap(ColumnScanState &state, TableFilter &filter,
+                              optional_ptr<SegmentNode<ColumnSegment>> &checked_segment) {
 	// FIXME: There is nothing preventing us from supporting this, but it's not implemented yet.
 	// table filters are not supported yet for fixed size list columns
+	checked_segment = nullptr;
 	return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 }
 

--- a/src/storage/table/column_data.cpp
+++ b/src/storage/table/column_data.cpp
@@ -420,7 +420,9 @@ void ColumnData::FinalizeAppendLocked(ColumnDataFinalizeAppendState &finalize_st
 	FinalizeAppend(finalize_state, state);
 }
 
-FilterPropagateResult ColumnData::CheckZonemap(ColumnScanState &state, TableFilter &filter) {
+FilterPropagateResult ColumnData::CheckZonemap(ColumnScanState &state, TableFilter &filter,
+                                               optional_ptr<SegmentNode<ColumnSegment>> &checked_segment) {
+	checked_segment = nullptr;
 	if (state.segment_checked) {
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 	}
@@ -431,13 +433,14 @@ FilterPropagateResult ColumnData::CheckZonemap(ColumnScanState &state, TableFilt
 	auto &expr_filter = ExpressionFilter::GetExpressionFilter(filter, "ColumnData::CheckZonemap");
 	bool is_dynamic = ExpressionFilter::ContainsInternalFunction(*expr_filter.expr, DynamicFilterScalarFun::NAME);
 	state.segment_checked = !is_dynamic;
+	checked_segment =
+	    IsDirectNullCheckFilter(filter) && !state.child_states.empty() && state.child_states[0].current
+	        ? state.child_states[0].current
+	        : state.current;
 	FilterPropagateResult prune_result;
 	{
 		lock_guard<mutex> l(stats_lock);
-		auto &segment_stats =
-		    IsDirectNullCheckFilter(filter) && !state.child_states.empty() && state.child_states[0].current
-		        ? state.child_states[0].current->GetNode().GetStatsMutable()
-		        : state.current->GetNode().GetStatsMutable();
+		auto &segment_stats = checked_segment->GetNode().GetStatsMutable();
 		auto context = state.context.GetClientContext();
 		prune_result =
 		    context ? expr_filter.CheckStatistics(*context, segment_stats) : expr_filter.CheckStatistics(segment_stats);

--- a/src/storage/table/column_data.cpp
+++ b/src/storage/table/column_data.cpp
@@ -433,10 +433,9 @@ FilterPropagateResult ColumnData::CheckZonemap(ColumnScanState &state, TableFilt
 	auto &expr_filter = ExpressionFilter::GetExpressionFilter(filter, "ColumnData::CheckZonemap");
 	bool is_dynamic = ExpressionFilter::ContainsInternalFunction(*expr_filter.expr, DynamicFilterScalarFun::NAME);
 	state.segment_checked = !is_dynamic;
-	checked_segment =
-	    IsDirectNullCheckFilter(filter) && !state.child_states.empty() && state.child_states[0].current
-	        ? state.child_states[0].current
-	        : state.current;
+	checked_segment = IsDirectNullCheckFilter(filter) && !state.child_states.empty() && state.child_states[0].current
+	                      ? state.child_states[0].current
+	                      : state.current;
 	FilterPropagateResult prune_result;
 	{
 		lock_guard<mutex> l(stats_lock);

--- a/src/storage/table/list_column_data.cpp
+++ b/src/storage/table/list_column_data.cpp
@@ -27,9 +27,8 @@ void ListColumnData::SetDataType(ColumnDataType data_type) {
 	validity->SetDataType(data_type);
 }
 
-FilterPropagateResult
-ListColumnData::CheckZonemap(ColumnScanState &state, TableFilter &filter,
-                             optional_ptr<SegmentNode<ColumnSegment>> &checked_segment) {
+FilterPropagateResult ListColumnData::CheckZonemap(ColumnScanState &state, TableFilter &filter,
+                                                   optional_ptr<SegmentNode<ColumnSegment>> &checked_segment) {
 	// table filters are not supported yet for list columns
 	checked_segment = nullptr;
 	return FilterPropagateResult::NO_PRUNING_POSSIBLE;

--- a/src/storage/table/list_column_data.cpp
+++ b/src/storage/table/list_column_data.cpp
@@ -27,8 +27,11 @@ void ListColumnData::SetDataType(ColumnDataType data_type) {
 	validity->SetDataType(data_type);
 }
 
-FilterPropagateResult ListColumnData::CheckZonemap(ColumnScanState &state, TableFilter &filter) {
+FilterPropagateResult
+ListColumnData::CheckZonemap(ColumnScanState &state, TableFilter &filter,
+                             optional_ptr<SegmentNode<ColumnSegment>> &checked_segment) {
 	// table filters are not supported yet for list columns
+	checked_segment = nullptr;
 	return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 }
 

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -754,15 +754,15 @@ bool RowGroup::CheckZonemapSegments(CollectionScanState &state) {
 		auto column_idx = entry.scan_column_index;
 		auto base_column_idx = entry.table_column_index;
 		auto &filter = entry.filter;
+		auto &column_data = GetColumn(base_column_idx);
 
-		auto prune_result = GetColumn(base_column_idx).CheckZonemap(state.column_scans[column_idx], filter);
+		optional_ptr<SegmentNode<ColumnSegment>> current_segment;
+		auto prune_result = column_data.CheckZonemap(state.column_scans[column_idx], filter, current_segment);
 		if (prune_result != FilterPropagateResult::FILTER_ALWAYS_FALSE) {
 			continue;
 		}
 
 		// check zone map segment.
-		auto &column_scan_state = state.column_scans[column_idx];
-		auto current_segment = column_scan_state.current;
 		if (!current_segment) {
 			// no segment to skip
 			continue;

--- a/src/storage/table/row_id_column_data.cpp
+++ b/src/storage/table/row_id_column_data.cpp
@@ -15,7 +15,10 @@ idx_t RowIdColumnData::GetRowStart(ColumnScanState &state) {
 	return state.parent->row_group->GetRowStart();
 }
 
-FilterPropagateResult RowIdColumnData::CheckZonemap(ColumnScanState &state, TableFilter &filter) {
+FilterPropagateResult
+RowIdColumnData::CheckZonemap(ColumnScanState &state, TableFilter &filter,
+                              optional_ptr<SegmentNode<ColumnSegment>> &checked_segment) {
+	checked_segment = nullptr;
 	auto row_start = GetRowStart(state);
 	return RowGroup::CheckRowIdFilter(filter, row_start, row_start + count);
 }

--- a/src/storage/table/row_id_column_data.cpp
+++ b/src/storage/table/row_id_column_data.cpp
@@ -15,9 +15,8 @@ idx_t RowIdColumnData::GetRowStart(ColumnScanState &state) {
 	return state.parent->row_group->GetRowStart();
 }
 
-FilterPropagateResult
-RowIdColumnData::CheckZonemap(ColumnScanState &state, TableFilter &filter,
-                              optional_ptr<SegmentNode<ColumnSegment>> &checked_segment) {
+FilterPropagateResult RowIdColumnData::CheckZonemap(ColumnScanState &state, TableFilter &filter,
+                                                    optional_ptr<SegmentNode<ColumnSegment>> &checked_segment) {
 	checked_segment = nullptr;
 	auto row_start = GetRowStart(state);
 	return RowGroup::CheckRowIdFilter(filter, row_start, row_start + count);

--- a/src/storage/table/row_number_column_data.cpp
+++ b/src/storage/table/row_number_column_data.cpp
@@ -13,8 +13,11 @@ idx_t RowNumberColumnData::GetRowNumberBase(ColumnScanState &state) {
 	return state.parent->row_number_base.GetIndex();
 }
 
-FilterPropagateResult RowNumberColumnData::CheckZonemap(ColumnScanState &state, TableFilter &filter) {
+FilterPropagateResult
+RowNumberColumnData::CheckZonemap(ColumnScanState &state, TableFilter &filter,
+                                  optional_ptr<SegmentNode<ColumnSegment>> &checked_segment) {
 	// row_number columns don't have zonemaps - we cannot prune based on row number
+	checked_segment = nullptr;
 	return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 }
 

--- a/src/storage/table/row_number_column_data.cpp
+++ b/src/storage/table/row_number_column_data.cpp
@@ -13,9 +13,8 @@ idx_t RowNumberColumnData::GetRowNumberBase(ColumnScanState &state) {
 	return state.parent->row_number_base.GetIndex();
 }
 
-FilterPropagateResult
-RowNumberColumnData::CheckZonemap(ColumnScanState &state, TableFilter &filter,
-                                  optional_ptr<SegmentNode<ColumnSegment>> &checked_segment) {
+FilterPropagateResult RowNumberColumnData::CheckZonemap(ColumnScanState &state, TableFilter &filter,
+                                                        optional_ptr<SegmentNode<ColumnSegment>> &checked_segment) {
 	// row_number columns don't have zonemaps - we cannot prune based on row number
 	checked_segment = nullptr;
 	return FilterPropagateResult::NO_PRUNING_POSSIBLE;

--- a/src/storage/table/struct_column_data.cpp
+++ b/src/storage/table/struct_column_data.cpp
@@ -48,9 +48,8 @@ idx_t StructColumnData::GetMaxEntry() {
 	return sub_columns[0]->GetMaxEntry();
 }
 
-FilterPropagateResult
-StructColumnData::CheckZonemap(ColumnScanState &state, TableFilter &filter,
-                               optional_ptr<SegmentNode<ColumnSegment>> &checked_segment) {
+FilterPropagateResult StructColumnData::CheckZonemap(ColumnScanState &state, TableFilter &filter,
+                                                     optional_ptr<SegmentNode<ColumnSegment>> &checked_segment) {
 	if (!state.storage_index.IsPushdownExtract() || state.expression_state) {
 		checked_segment = nullptr;
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;

--- a/src/storage/table/struct_column_data.cpp
+++ b/src/storage/table/struct_column_data.cpp
@@ -48,6 +48,18 @@ idx_t StructColumnData::GetMaxEntry() {
 	return sub_columns[0]->GetMaxEntry();
 }
 
+FilterPropagateResult
+StructColumnData::CheckZonemap(ColumnScanState &state, TableFilter &filter,
+                               optional_ptr<SegmentNode<ColumnSegment>> &checked_segment) {
+	if (!state.storage_index.IsPushdownExtract() || state.expression_state) {
+		checked_segment = nullptr;
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+	auto children = GetStructChildren(state);
+	D_ASSERT(children.size() == 1);
+	return children[0].col.CheckZonemap(children[0].state, filter, checked_segment);
+}
+
 vector<StructColumnData::StructColumnDataChild> StructColumnData::GetStructChildren(ColumnScanState &state) const {
 	vector<StructColumnData::StructColumnDataChild> res;
 	if (state.storage_index.IsPushdownExtract()) {

--- a/src/storage/table/validity_column_data.cpp
+++ b/src/storage/table/validity_column_data.cpp
@@ -14,7 +14,10 @@ ValidityColumnData::ValidityColumnData(BlockManager &block_manager, DataTableInf
     : ValidityColumnData(block_manager, info, column_index, parent.GetDataType(), parent) {
 }
 
-FilterPropagateResult ValidityColumnData::CheckZonemap(ColumnScanState &state, TableFilter &filter) {
+FilterPropagateResult
+ValidityColumnData::CheckZonemap(ColumnScanState &state, TableFilter &filter,
+                                 optional_ptr<SegmentNode<ColumnSegment>> &checked_segment) {
+	checked_segment = nullptr;
 	return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 }
 

--- a/src/storage/table/validity_column_data.cpp
+++ b/src/storage/table/validity_column_data.cpp
@@ -14,9 +14,8 @@ ValidityColumnData::ValidityColumnData(BlockManager &block_manager, DataTableInf
     : ValidityColumnData(block_manager, info, column_index, parent.GetDataType(), parent) {
 }
 
-FilterPropagateResult
-ValidityColumnData::CheckZonemap(ColumnScanState &state, TableFilter &filter,
-                                 optional_ptr<SegmentNode<ColumnSegment>> &checked_segment) {
+FilterPropagateResult ValidityColumnData::CheckZonemap(ColumnScanState &state, TableFilter &filter,
+                                                       optional_ptr<SegmentNode<ColumnSegment>> &checked_segment) {
 	checked_segment = nullptr;
 	return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 }

--- a/test/configs/disable_optimizer.json
+++ b/test/configs/disable_optimizer.json
@@ -13,6 +13,7 @@
     {
       "reason": "Zone map pruning requires filter pushdown from optimizer.",
       "paths": [
+        "test/sql/optimizer/struct_segment_pruning.test",
         "test/sql/pragma/profiling/test_custom_profiling_row_group_metrics_local_storage.test",
         "test/sql/types/geo/geometry_parquet_pushdown.test",
         "test/optimizer/statistics/statistics_filter_pruning.test",

--- a/test/sql/optimizer/struct_segment_pruning.test
+++ b/test/sql/optimizer/struct_segment_pruning.test
@@ -1,0 +1,65 @@
+# name: test/sql/optimizer/struct_segment_pruning.test
+# description: Segment pruning for pushed-down STRUCT fields
+# group: [optimizer]
+
+require json
+
+require no_force_storage
+
+require vector_size 2048
+
+statement ok
+SET threads = 1
+
+statement ok
+SET initial_column_segment_size = 2048
+
+statement ok
+SET wal_autocheckpoint = '1TB'
+
+statement ok
+CREATE TABLE events AS
+SELECT i,
+       CASE WHEN i = 50000 THEN NULL
+            ELSE {'meta': {'ts': CASE WHEN i = 50001 THEN NULL
+                                      WHEN i = 99999 THEN TIMESTAMP '2100-01-01'
+                                      ELSE TIMESTAMP '2020-01-01' + i * INTERVAL 1 SECOND
+                                 END}}
+       END AS payload
+FROM range(100000) t(i)
+
+query I
+SELECT count(*) FROM events WHERE payload.meta.ts IS NULL
+----
+2
+
+statement ok
+PRAGMA enable_profiling = 'json'
+
+statement ok
+PRAGMA profiling_output = '{TEST_DIR}/struct_segment_pruning_profile.json'
+
+statement ok
+SET tracked_metrics = ['query.total_rows_scanned']
+
+query I
+SELECT count(*) FROM events WHERE payload.meta.ts >= TIMESTAMP '2099-01-01'
+----
+1
+
+statement ok
+PRAGMA disable_profiling
+
+query I
+SELECT query.total_rows_scanned BETWEEN 1 AND 99999
+FROM '{TEST_DIR}/struct_segment_pruning_profile.json'
+----
+true
+
+statement ok
+UPDATE events SET payload = NULL WHERE i = 1
+
+query I
+SELECT count(*) FROM events WHERE payload.meta.ts IS NULL
+----
+3


### PR DESCRIPTION
Hi team, I found in the current implementation, scalar column segment prunes fine, but struct column never prunes.
```sql
-- scalar column prunes segment fine
memory D CREATE TABLE flat AS SELECT i::BIGINT AS v FROM range(100000) t(i);
memory D SET tracked_metrics = ['query.total_rows_scanned'];
memory D PRAGMA enable_profiling = 'json';
memory D SELECT count(*) FROM flat WHERE v >= 99999;
{
    "query": {
        "total_rows_scanned": 16032
    }
}

-- struct column doesn't prune segments
memory D CREATE TABLE nested AS SELECT {'v': i::BIGINT} AS s FROM range(100000) t(i);
memory D SET tracked_metrics = ['query.total_rows_scanned'];
memory D PRAGMA enable_profiling = 'json';
memory D SELECT count(*) FROM nested WHERE s.v >= 99999;
{
    "query": {
        "total_rows_scanned": 100000
    }
}
```

The reason is
- `StructColumnData` doesn't implement its own `CheckZonemap`, which calls the base class's `ColumnData::CheckZonemap`
- But because struct doesn't have segment at top level (all segment lives at leaf nodes), zonemap check early returns [here](https://github.com/duckdb/duckdb/blob/7e14bd24e03f5b5c30b8f3af79a8fbb15dce8320/src/storage/table/column_data.cpp#L427-L429); in this PR I add the missing zonemap check function