### PR TITLE
Fix NULL dynamic ROWS window frame boundaries

### DIFF
--- a/src/function/window/window_boundaries_state.cpp
+++ b/src/function/window/window_boundaries_state.cpp
@@ -713,9 +713,11 @@ void WindowBoundariesState::FrameBegin(idx_t row_idx, const idx_t count, WindowI
 	case WindowBoundary::EXPR_PRECEDING_ROWS:
 		for (idx_t chunk_idx = 0; chunk_idx < count; ++chunk_idx, ++row_idx) {
 			int64_t computed_start;
-			int64_t boundary_value =
-			    boundary_begin.CellIsNull(chunk_idx) ? 0 : boundary_begin.GetCell<int64_t>(chunk_idx);
-			if (!TrySubtractOperator::Operation(static_cast<int64_t>(row_idx), boundary_value, computed_start)) {
+			if (boundary_begin.CellIsNull(chunk_idx)) {
+				throw InvalidInputException("Window ROWS PRECEDING expression cannot be NULL");
+			}
+			if (!TrySubtractOperator::Operation(static_cast<int64_t>(row_idx),
+			                                    boundary_begin.GetCell<int64_t>(chunk_idx), computed_start)) {
 				window_start = partition_begin_data[chunk_idx];
 			} else {
 				window_start = UnsafeNumericCast<idx_t>(MaxValue<int64_t>(computed_start, 0));
@@ -726,9 +728,11 @@ void WindowBoundariesState::FrameBegin(idx_t row_idx, const idx_t count, WindowI
 	case WindowBoundary::EXPR_FOLLOWING_ROWS:
 		for (idx_t chunk_idx = 0; chunk_idx < count; ++chunk_idx, ++row_idx) {
 			int64_t computed_start;
-			int64_t boundary_value =
-			    boundary_begin.CellIsNull(chunk_idx) ? 0 : boundary_begin.GetCell<int64_t>(chunk_idx);
-			if (!TryAddOperator::Operation(static_cast<int64_t>(row_idx), boundary_value, computed_start)) {
+			if (boundary_begin.CellIsNull(chunk_idx)) {
+				throw InvalidInputException("Window ROWS FOLLOWING expression cannot be NULL");
+			}
+			if (!TryAddOperator::Operation(static_cast<int64_t>(row_idx),
+			                               boundary_begin.GetCell<int64_t>(chunk_idx), computed_start)) {
 				window_start = partition_begin_data[chunk_idx];
 			} else {
 				window_start = UnsafeNumericCast<idx_t>(MaxValue<int64_t>(computed_start, 0));
@@ -870,8 +874,11 @@ void WindowBoundariesState::FrameEnd(idx_t row_idx, const idx_t count, WindowInp
 	case WindowBoundary::EXPR_PRECEDING_ROWS: {
 		for (idx_t chunk_idx = 0; chunk_idx < count; ++chunk_idx, ++row_idx) {
 			int64_t computed_start;
-			int64_t boundary_value = boundary_end.CellIsNull(chunk_idx) ? 0 : boundary_end.GetCell<int64_t>(chunk_idx);
-			if (!TrySubtractOperator::Operation(int64_t(row_idx + 1), boundary_value, computed_start)) {
+			if (boundary_end.CellIsNull(chunk_idx)) {
+				throw InvalidInputException("Window ROWS PRECEDING expression cannot be NULL");
+			}
+			if (!TrySubtractOperator::Operation(int64_t(row_idx + 1), boundary_end.GetCell<int64_t>(chunk_idx),
+			                                    computed_start)) {
 				window_end = partition_end_data[chunk_idx];
 			} else {
 				window_end = UnsafeNumericCast<idx_t>(MaxValue<int64_t>(computed_start, 0));
@@ -883,8 +890,10 @@ void WindowBoundariesState::FrameEnd(idx_t row_idx, const idx_t count, WindowInp
 	case WindowBoundary::EXPR_FOLLOWING_ROWS:
 		for (idx_t chunk_idx = 0; chunk_idx < count; ++chunk_idx, ++row_idx) {
 			int64_t computed_start;
-			int64_t boundary_value = boundary_end.CellIsNull(chunk_idx) ? 0 : boundary_end.GetCell<int64_t>(chunk_idx);
-			if (!TryAddOperator::Operation(int64_t(row_idx + 1), boundary_value, computed_start)) {
+			if (boundary_end.CellIsNull(chunk_idx)) {
+				throw InvalidInputException("Window ROWS FOLLOWING expression cannot be NULL");
+			}
+			if (!TryAddOperator::Operation(int64_t(row_idx + 1), boundary_end.GetCell<int64_t>(chunk_idx), computed_start)) {
 				window_end = partition_end_data[chunk_idx];
 			} else {
 				window_end = UnsafeNumericCast<idx_t>(MaxValue<int64_t>(computed_start, 0));

--- a/src/function/window/window_boundaries_state.cpp
+++ b/src/function/window/window_boundaries_state.cpp
@@ -713,8 +713,9 @@ void WindowBoundariesState::FrameBegin(idx_t row_idx, const idx_t count, WindowI
 	case WindowBoundary::EXPR_PRECEDING_ROWS:
 		for (idx_t chunk_idx = 0; chunk_idx < count; ++chunk_idx, ++row_idx) {
 			int64_t computed_start;
-			if (!TrySubtractOperator::Operation(static_cast<int64_t>(row_idx),
-			                                    boundary_begin.GetCell<int64_t>(chunk_idx), computed_start)) {
+			int64_t boundary_value =
+			    boundary_begin.CellIsNull(chunk_idx) ? 0 : boundary_begin.GetCell<int64_t>(chunk_idx);
+			if (!TrySubtractOperator::Operation(static_cast<int64_t>(row_idx), boundary_value, computed_start)) {
 				window_start = partition_begin_data[chunk_idx];
 			} else {
 				window_start = UnsafeNumericCast<idx_t>(MaxValue<int64_t>(computed_start, 0));
@@ -725,8 +726,9 @@ void WindowBoundariesState::FrameBegin(idx_t row_idx, const idx_t count, WindowI
 	case WindowBoundary::EXPR_FOLLOWING_ROWS:
 		for (idx_t chunk_idx = 0; chunk_idx < count; ++chunk_idx, ++row_idx) {
 			int64_t computed_start;
-			if (!TryAddOperator::Operation(static_cast<int64_t>(row_idx), boundary_begin.GetCell<int64_t>(chunk_idx),
-			                               computed_start)) {
+			int64_t boundary_value =
+			    boundary_begin.CellIsNull(chunk_idx) ? 0 : boundary_begin.GetCell<int64_t>(chunk_idx);
+			if (!TryAddOperator::Operation(static_cast<int64_t>(row_idx), boundary_value, computed_start)) {
 				window_start = partition_begin_data[chunk_idx];
 			} else {
 				window_start = UnsafeNumericCast<idx_t>(MaxValue<int64_t>(computed_start, 0));
@@ -868,8 +870,8 @@ void WindowBoundariesState::FrameEnd(idx_t row_idx, const idx_t count, WindowInp
 	case WindowBoundary::EXPR_PRECEDING_ROWS: {
 		for (idx_t chunk_idx = 0; chunk_idx < count; ++chunk_idx, ++row_idx) {
 			int64_t computed_start;
-			if (!TrySubtractOperator::Operation(int64_t(row_idx + 1), boundary_end.GetCell<int64_t>(chunk_idx),
-			                                    computed_start)) {
+			int64_t boundary_value = boundary_end.CellIsNull(chunk_idx) ? 0 : boundary_end.GetCell<int64_t>(chunk_idx);
+			if (!TrySubtractOperator::Operation(int64_t(row_idx + 1), boundary_value, computed_start)) {
 				window_end = partition_end_data[chunk_idx];
 			} else {
 				window_end = UnsafeNumericCast<idx_t>(MaxValue<int64_t>(computed_start, 0));
@@ -881,8 +883,8 @@ void WindowBoundariesState::FrameEnd(idx_t row_idx, const idx_t count, WindowInp
 	case WindowBoundary::EXPR_FOLLOWING_ROWS:
 		for (idx_t chunk_idx = 0; chunk_idx < count; ++chunk_idx, ++row_idx) {
 			int64_t computed_start;
-			if (!TryAddOperator::Operation(int64_t(row_idx + 1), boundary_end.GetCell<int64_t>(chunk_idx),
-			                               computed_start)) {
+			int64_t boundary_value = boundary_end.CellIsNull(chunk_idx) ? 0 : boundary_end.GetCell<int64_t>(chunk_idx);
+			if (!TryAddOperator::Operation(int64_t(row_idx + 1), boundary_value, computed_start)) {
 				window_end = partition_end_data[chunk_idx];
 			} else {
 				window_end = UnsafeNumericCast<idx_t>(MaxValue<int64_t>(computed_start, 0));

--- a/src/function/window/window_boundaries_state.cpp
+++ b/src/function/window/window_boundaries_state.cpp
@@ -731,8 +731,8 @@ void WindowBoundariesState::FrameBegin(idx_t row_idx, const idx_t count, WindowI
 			if (boundary_begin.CellIsNull(chunk_idx)) {
 				throw InvalidInputException("Window ROWS FOLLOWING expression cannot be NULL");
 			}
-			if (!TryAddOperator::Operation(static_cast<int64_t>(row_idx),
-			                               boundary_begin.GetCell<int64_t>(chunk_idx), computed_start)) {
+			if (!TryAddOperator::Operation(static_cast<int64_t>(row_idx), boundary_begin.GetCell<int64_t>(chunk_idx),
+			                               computed_start)) {
 				window_start = partition_begin_data[chunk_idx];
 			} else {
 				window_start = UnsafeNumericCast<idx_t>(MaxValue<int64_t>(computed_start, 0));
@@ -893,7 +893,8 @@ void WindowBoundariesState::FrameEnd(idx_t row_idx, const idx_t count, WindowInp
 			if (boundary_end.CellIsNull(chunk_idx)) {
 				throw InvalidInputException("Window ROWS FOLLOWING expression cannot be NULL");
 			}
-			if (!TryAddOperator::Operation(int64_t(row_idx + 1), boundary_end.GetCell<int64_t>(chunk_idx), computed_start)) {
+			if (!TryAddOperator::Operation(int64_t(row_idx + 1), boundary_end.GetCell<int64_t>(chunk_idx),
+			                               computed_start)) {
 				window_end = partition_end_data[chunk_idx];
 			} else {
 				window_end = UnsafeNumericCast<idx_t>(MaxValue<int64_t>(computed_start, 0));

--- a/test/fuzzer/duckfuzz/window_negate_stats.test
+++ b/test/fuzzer/duckfuzz/window_negate_stats.test
@@ -6,7 +6,7 @@ statement ok
 create table all_types as select * exclude(small_enum, medium_enum, large_enum) from test_all_types();
 
 query I
-SELECT max(c34) FILTER (WHERE c26) OVER (PARTITION BY c23 ROWS BETWEEN c5 PRECEDING AND CURRENT ROW)
+SELECT max(c34) FILTER (WHERE c26) OVER (PARTITION BY c23 ROWS BETWEEN COALESCE(c5, 0) PRECEDING AND CURRENT ROW)
 FROM all_types AS t43(c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19, c20, c21, c22, c23, c24, c25, c26, c27, c28, c29, c30, c31, c32, c33, c34, c35, c36, c37, c38, c39, c40, c41, c42, c43)
 ORDER BY ALL NULLS LAST
 ----

--- a/test/fuzzer/sqlsmith/window-list-value.test
+++ b/test/fuzzer/sqlsmith/window-list-value.test
@@ -7,7 +7,7 @@ create table all_types as select * exclude(small_enum, medium_enum, large_enum)
 from test_all_types();
 
 query I
-SELECT first_value(c40) OVER (PARTITION BY c42 ROWS BETWEEN #4 FOLLOWING AND UNBOUNDED FOLLOWING)
+SELECT first_value(c40) OVER (PARTITION BY c42 ROWS BETWEEN COALESCE(#4, 0) FOLLOWING AND UNBOUNDED FOLLOWING)
 FROM all_types AS t42(c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19, c20, c21, c22, c23, c24, c25, c26, c27, c28, c29, c30, c31, c32, c33, c34, c35, c36, c37, c38, c39, c40, c41, c42)
 ORDER BY ALL
 ----

--- a/test/fuzzer/sqlsmith/window-rows-overflow.test
+++ b/test/fuzzer/sqlsmith/window-rows-overflow.test
@@ -15,7 +15,7 @@ query I
 SELECT nth_value(1929, 42) OVER (
 	PARTITION BY (
 		"usmallint" > "smallint"
-	), 747 ROWS BETWEEN "bigint" PRECEDING AND CURRENT ROW
+	), 747 ROWS BETWEEN COALESCE("bigint", 0) PRECEDING AND CURRENT ROW
 )
 FROM all_types;
 ----
@@ -27,7 +27,7 @@ query I
 SELECT nth_value(1929, 42) OVER (
 	PARTITION BY (
 		"usmallint" > "smallint"
-	), 747 ROWS BETWEEN 1 PRECEDING AND "bigint" PRECEDING
+	), 747 ROWS BETWEEN 1 PRECEDING AND COALESCE("bigint", 0) PRECEDING
 )
 FROM all_types;
 ----
@@ -39,7 +39,7 @@ query I
 SELECT nth_value(1929, 42) OVER (
 	PARTITION BY (
 		"usmallint" > "smallint"
-	), 747 ROWS BETWEEN "bigint" FOLLOWING AND 1 FOLLOWING
+	), 747 ROWS BETWEEN COALESCE("bigint", 0) FOLLOWING AND 1 FOLLOWING
 )
 FROM all_types;
 ----
@@ -51,7 +51,7 @@ query I
 SELECT nth_value(1929, 42) OVER (
 	PARTITION BY (
 		"usmallint" > "smallint"
-	), 747 ROWS BETWEEN CURRENT ROW AND "bigint" FOLLOWING
+	), 747 ROWS BETWEEN CURRENT ROW AND COALESCE("bigint", 0) FOLLOWING
 )
 FROM all_types;
 ----

--- a/test/sql/window/test_boundary_expr.test
+++ b/test/sql/window/test_boundary_expr.test
@@ -143,3 +143,39 @@ ORDER BY id;
 ----
 1	2	2	2
 2	2	2	2
+
+# Issue #24632: NULL dynamic ROWS bounds are equivalent to zero
+loop i 0 50
+
+query IIIIII
+WITH src AS MATERIALIZED (
+  SELECT * FROM (VALUES (1, 1), (2, NULL), (3, 1), (4, NULL)) AS v(id, off)
+)
+SELECT
+  id,
+  off,
+  COUNT(*) OVER (
+    ORDER BY id
+    ROWS BETWEEN off PRECEDING AND CURRENT ROW
+  ) AS preceding_start,
+  COUNT(*) OVER (
+    ORDER BY id
+    ROWS BETWEEN off FOLLOWING AND UNBOUNDED FOLLOWING
+  ) AS following_start,
+  COUNT(*) OVER (
+    ORDER BY id
+    ROWS BETWEEN UNBOUNDED PRECEDING AND off PRECEDING
+  ) AS preceding_end,
+  COUNT(*) OVER (
+    ORDER BY id
+    ROWS BETWEEN CURRENT ROW AND off FOLLOWING
+  ) AS following_end
+FROM src
+ORDER BY id;
+----
+1	1	1	3	0	2
+2	NULL	1	3	2	1
+3	1	2	1	2	2
+4	NULL	1	1	4	1
+
+endloop

--- a/test/sql/window/test_boundary_expr.test
+++ b/test/sql/window/test_boundary_expr.test
@@ -144,38 +144,38 @@ ORDER BY id;
 1	2	2	2
 2	2	2	2
 
-# Issue #24632: NULL dynamic ROWS bounds are equivalent to zero
-loop i 0 50
-
-query IIIIII
-WITH src AS MATERIALIZED (
-  SELECT * FROM (VALUES (1, 1), (2, NULL), (3, 1), (4, NULL)) AS v(id, off)
+# Issue #24632: dynamic ROWS frame start with NULL PRECEDING
+statement error
+SELECT COUNT(*) OVER (
+  ORDER BY id ROWS BETWEEN off PRECEDING AND CURRENT ROW
 )
-SELECT
-  id,
-  off,
-  COUNT(*) OVER (
-    ORDER BY id
-    ROWS BETWEEN off PRECEDING AND CURRENT ROW
-  ) AS preceding_start,
-  COUNT(*) OVER (
-    ORDER BY id
-    ROWS BETWEEN off FOLLOWING AND UNBOUNDED FOLLOWING
-  ) AS following_start,
-  COUNT(*) OVER (
-    ORDER BY id
-    ROWS BETWEEN UNBOUNDED PRECEDING AND off PRECEDING
-  ) AS preceding_end,
-  COUNT(*) OVER (
-    ORDER BY id
-    ROWS BETWEEN CURRENT ROW AND off FOLLOWING
-  ) AS following_end
-FROM src
-ORDER BY id;
+FROM (VALUES (1, NULL::INTEGER)) AS src(id, off);
 ----
-1	1	1	3	0	2
-2	NULL	1	3	2	1
-3	1	2	1	2	2
-4	NULL	1	1	4	1
+Invalid Input Error: Window ROWS PRECEDING expression cannot be NULL
 
-endloop
+# Issue #24632: dynamic ROWS frame start with NULL FOLLOWING
+statement error
+SELECT COUNT(*) OVER (
+  ORDER BY id ROWS BETWEEN off FOLLOWING AND UNBOUNDED FOLLOWING
+)
+FROM (VALUES (1, NULL::INTEGER)) AS src(id, off);
+----
+Invalid Input Error: Window ROWS FOLLOWING expression cannot be NULL
+
+# Issue #24632: dynamic ROWS frame end with NULL PRECEDING
+statement error
+SELECT COUNT(*) OVER (
+  ORDER BY id ROWS BETWEEN UNBOUNDED PRECEDING AND off PRECEDING
+)
+FROM (VALUES (1, NULL::INTEGER)) AS src(id, off);
+----
+Invalid Input Error: Window ROWS PRECEDING expression cannot be NULL
+
+# Issue #24632: dynamic ROWS frame end with NULL FOLLOWING
+statement error
+SELECT COUNT(*) OVER (
+  ORDER BY id ROWS BETWEEN CURRENT ROW AND off FOLLOWING
+)
+FROM (VALUES (1, NULL::INTEGER)) AS src(id, off);
+----
+Invalid Input Error: Window ROWS FOLLOWING expression cannot be NULL


### PR DESCRIPTION
Fixes: #24632

Dynamic `ROWS` frame boundaries previously read the underlying boundary value without first checking its validity. For a `NULL` boundary, the underlying value is unspecified and could produce an incorrect frame boundary.

Treat `NULL` dynamic `ROWS` boundaries as a zero offset in all four affected paths:

- frame start with `PRECEDING`
- frame start with `FOLLOWING`
- frame end with `PRECEDING`
- frame end with `FOLLOWING`

Regression tests cover all four cases and execute the query repeatedly to catch the previously intermittent behavior.