### PR TITLE
Fix race condition in reclaiming file cache blocks

### DIFF
--- a/src/include/duckdb/storage/external_file_cache/external_file_cache.hpp
+++ b/src/include/duckdb/storage/external_file_cache/external_file_cache.hpp
@@ -81,6 +81,9 @@ public:
 	//! Return the blocks cached for the given range.
 	vector<shared_ptr<CacheBlock>> ReindexAndAcquireBlocks(CachedFile &cached_file, idx_t current_block_size,
 	                                                       idx_t first_block, idx_t num_blocks);
+	//! Remove an acquired block range from the cache without mutating blocks that may still be used by readers.
+	//! A block is only removed when it is still the current entry for its index.
+	void RetireBlocks(CachedFile &cached_file, idx_t first_block, const vector<shared_ptr<CacheBlock>> &blocks);
 
 	BufferManager &GetBufferManager() const;
 	//! Gets the shared cached file for the given path, creating it if not yet present.

--- a/src/storage/external_file_cache/caching_file_system.cpp
+++ b/src/storage/external_file_cache/caching_file_system.cpp
@@ -342,9 +342,10 @@ FileBufferHandleGroup CachingFileHandle::Read(const idx_t nr_bytes, const idx_t 
 		const annotated_lock_guard<annotated_mutex> meta_guard(current_cached_file->meta_lock);
 		if (!ExternalFileCache::IsValid(true, current_cached_file->version_tag, current_cached_file->last_modified,
 		                                current_version_tag, current_last_modified)) {
-			for (auto &block : blocks) {
-				block->Reinit();
-			}
+			// Do not reset blocks in place: another reader may already have pinned the same blocks and still need their
+			// byte counts. Removing only the matching map entries preserves those readers while forcing future reads
+			// to fetch fresh blocks.
+			external_file_cache.RetireBlocks(*current_cached_file, first_block, blocks);
 		}
 	}
 

--- a/src/storage/external_file_cache/external_file_cache.cpp
+++ b/src/storage/external_file_cache/external_file_cache.cpp
@@ -199,6 +199,19 @@ vector<shared_ptr<CacheBlock>> ExternalFileCache::ReindexAndAcquireBlocks(Cached
 	return blocks;
 }
 
+void ExternalFileCache::RetireBlocks(CachedFile &cached_file, idx_t first_block,
+                                     const vector<shared_ptr<CacheBlock>> &blocks) {
+	const annotated_lock_guard<annotated_mutex> map_guard(cached_file.map_lock);
+	for (idx_t idx = 0; idx < blocks.size(); idx++) {
+		const auto block_idx = first_block + idx;
+		auto entry = cached_file.blocks.find(block_idx);
+		if (entry == cached_file.blocks.end() || entry->second != blocks[idx]) {
+			continue;
+		}
+		cached_file.blocks.erase(entry);
+	}
+}
+
 ExternalFileCache::CachedFile::CachedFile(string path_p, idx_t generation_p)
     : path(std::move(path_p)), generation(generation_p) {
 }

--- a/test/common/test_external_file_cache.cpp
+++ b/test/common/test_external_file_cache.cpp
@@ -554,4 +554,49 @@ TEST_CASE("No-metadata file is not cached and always returns fresh content", "[e
 	REQUIRE(CountCachedBlocks(cache) == 0);
 }
 
+TEST_CASE("Retiring cache blocks preserves existing readers and cannot erase replacements", "[external_file_cache]") {
+	DuckDB db = MakeCacheLocalFilesDB();
+	auto &cache = db.instance->GetExternalFileCache();
+	auto cached_file = cache.GetOrCreateCachedFile("retire-blocks-test");
+
+	constexpr idx_t BLOCK_SIZE = 4096;
+	constexpr idx_t FIRST_BLOCK = 7;
+	auto acquired = cache.ReindexAndAcquireBlocks(*cached_file, BLOCK_SIZE, FIRST_BLOCK, 2);
+	{
+		const annotated_lock_guard<annotated_mutex> guard(acquired[0]->mtx);
+		acquired[0]->state = CacheBlockState::LOADED;
+		acquired[0]->nr_bytes = BLOCK_SIZE;
+	}
+	{
+		const annotated_lock_guard<annotated_mutex> guard(acquired[1]->mtx);
+		acquired[1]->state = CacheBlockState::LOADED;
+		acquired[1]->nr_bytes = 123;
+	}
+
+	cache.RetireBlocks(*cached_file, FIRST_BLOCK, acquired);
+
+	// Existing readers retain the immutable block metadata needed to finish their reads.
+	{
+		const annotated_lock_guard<annotated_mutex> guard(acquired[0]->mtx);
+		REQUIRE(acquired[0]->state == CacheBlockState::LOADED);
+		REQUIRE(acquired[0]->nr_bytes == BLOCK_SIZE);
+	}
+	{
+		const annotated_lock_guard<annotated_mutex> guard(acquired[1]->mtx);
+		REQUIRE(acquired[1]->state == CacheBlockState::LOADED);
+		REQUIRE(acquired[1]->nr_bytes == 123);
+	}
+
+	// Future readers receive fresh cache blocks.
+	auto replacements = cache.ReindexAndAcquireBlocks(*cached_file, BLOCK_SIZE, FIRST_BLOCK, 2);
+	REQUIRE(replacements[0] != acquired[0]);
+	REQUIRE(replacements[1] != acquired[1]);
+
+	// A delayed retirement of the old range must not erase its replacements.
+	cache.RetireBlocks(*cached_file, FIRST_BLOCK, acquired);
+	auto reacquired = cache.ReindexAndAcquireBlocks(*cached_file, BLOCK_SIZE, FIRST_BLOCK, 2);
+	REQUIRE(reacquired[0] == replacements[0]);
+	REQUIRE(reacquired[1] == replacements[1]);
+}
+
 } // namespace duckdb


### PR DESCRIPTION
There is race condition in reclaiming external file cache blocks.

Repro:
```shell
python3 -m http.server 8018 /tmp/httpfs_plan_server/ &
build/release/duckdb -unsigned :memory: -c "LOAD 'build/release/extension/httpfs/httpfs.duckdb_extension'; COPY (SELECT i, repeat('x', 80) AS payload FROM
    range(2000000) t(i)) TO '/tmp/httpfs_plan_server/cache_repro.csv' (HEADER); SELECT count(*) FROM read_csv('http://localhost:8018/cache_repro.csv',
    auto_detect=false, header=true, columns={'i':'BIGINT','payload':'VARCHAR'});"
```
results in:
```
INTERNAL Error: FileBufferHandleGroup::CopyTo: handles contain 31457280 bytes but 32000000 were requested
 
Stack Trace:
0        duckdb::Exception::ToJSON(duckdb::ExceptionType, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) + 48
1        duckdb::InternalException::InternalException(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) + 32
2        duckdb::InternalException::InternalException<unsigned long long&, unsigned long long&>(std::__1::basic_string<char, std::__1::char_traits<char>,
std::__1::allocator<char>> const&, unsigned long long&, unsigned long long&) + 136
3        duckdb::FileBufferHandleGroup::CopyTo(unsigned char*, unsigned long long) const + 228
4        duckdb::CachingFileSystemWrapper::Read(duckdb::FileHandle&, void*, long long, unsigned long long) + 268
5        duckdb::CSVBuffer::Pin(duckdb::CSVFileHandle&, bool&) + 168
6        duckdb::CSVRandomAccessBufferManager::GetBuffer(unsigned long long) + 580
7        std::__1::__function::__func<duckdb::BufferLoadTask(duckdb::shared_ptr<duckdb::CSVBufferManager, true> const&, unsigned long long)::$_0, void
()>::operator()() + 48
8        duckdb::AsyncExecutionTask::ExecuteTask(duckdb::TaskExecutionMode) + 36
9        duckdb::ExecutorTask::Execute(duckdb::TaskExecutionMode) + 284
```