### PR TITLE
Make `LogicalType` immutable

### DIFF
--- a/.github/patches/extensions/inet/0008-immutable-logical-type.patch
+++ b/.github/patches/extensions/inet/0008-immutable-logical-type.patch
@@ -1,0 +1,15 @@
+diff --git a/src/inet_extension.cpp b/src/inet_extension.cpp
+index 46d916c..5c45e96 100644
+--- a/src/inet_extension.cpp
++++ b/src/inet_extension.cpp
+@@ -24,8 +24,8 @@ static void LoadInternal(ExtensionLoader &loader) {
+   // versions.
+   children.emplace_back(make_pair("address", LogicalType::HUGEINT));
+   children.emplace_back(make_pair("mask", LogicalType::USMALLINT));
+-  auto inet_type = LogicalType::STRUCT(std::move(children));
+-  inet_type.SetAlias(INET_TYPE_NAME);
++  auto inet_type =
++      LogicalType::STRUCT(std::move(children)).WithAlias(INET_TYPE_NAME);
+   loader.RegisterType(INET_TYPE_NAME, inet_type);
+ 
+   // add the casts to and from INET type

--- a/.github/patches/extensions/postgres_scanner/0004-immutable-logical-type.patch
+++ b/.github/patches/extensions/postgres_scanner/0004-immutable-logical-type.patch
@@ -1,0 +1,48 @@
+diff --git a/src/postgres_utils.cpp b/src/postgres_utils.cpp
+index de683b6..f3d405d 100644
+--- a/src/postgres_utils.cpp
++++ b/src/postgres_utils.cpp
+@@ -371,9 +371,7 @@ LogicalType PostgresUtils::ToPostgresType(const LogicalType &input) {
+ 			auto &type = StructType::GetChildType(input, c);
+ 			new_types.push_back(make_pair(name, ToPostgresType(type)));
+ 		}
+-		auto result = LogicalType::STRUCT(std::move(new_types));
+-		result.SetAlias(input.GetAlias());
+-		return result;
++		return LogicalType::STRUCT(std::move(new_types)).WithAlias(input.GetAlias());
+ 	}
+ 	case LogicalTypeId::TIMESTAMP_SEC:
+ 	case LogicalTypeId::TIMESTAMP_MS:
+diff --git a/src/storage/postgres_type_set.cpp b/src/storage/postgres_type_set.cpp
+index c92f25c..3d5105d 100644
+--- a/src/storage/postgres_type_set.cpp
++++ b/src/storage/postgres_type_set.cpp
+@@ -60,8 +60,7 @@ void PostgresTypeSet::CreateEnum(PostgresTransaction &transaction, PostgresResul
+ 	for (idx_t enum_idx = 0; enum_idx < enum_count; enum_idx++) {
+ 		duckdb_levels.SetValue(enum_idx, result.GetString(start_row + enum_idx, 3));
+ 	}
+-	info.type = LogicalType::ENUM(duckdb_levels, enum_count);
+-	info.type.SetAlias(info.GetTypeName().GetIdentifierName());
++	info.type = LogicalType::ENUM(duckdb_levels, enum_count).WithAlias(info.GetTypeName().GetIdentifierName());
+ 	auto type_entry = make_shared_ptr<PostgresTypeEntry>(catalog, schema, info, postgres_type);
+ 	CreateEntry(transaction, std::move(type_entry));
+ }
+@@ -128,8 +127,7 @@ void PostgresTypeSet::CreateCompositeType(PostgresTransaction &transaction, Post
+ 		    Identifier(type_name), PostgresUtils::TypeToLogicalType(&transaction, &schema, type_data, child_type)));
+ 		postgres_type.children.push_back(std::move(child_type));
+ 	}
+-	info.type = LogicalType::STRUCT(std::move(child_types));
+-	info.type.SetAlias(info.GetTypeName().GetIdentifierName());
++	info.type = LogicalType::STRUCT(std::move(child_types)).WithAlias(info.GetTypeName().GetIdentifierName());
+ 	auto type_entry = make_shared_ptr<PostgresTypeEntry>(catalog, schema, info, postgres_type);
+ 	CreateEntry(transaction, std::move(type_entry));
+ }
+@@ -207,7 +205,7 @@ optional_ptr<CatalogEntry> PostgresTypeSet::CreateType(PostgresTransaction &tran
+ 
+ 	auto create_sql = GetCreateTypeSQL(info);
+ 	conn.Execute(transaction.GetContext(), create_sql);
+-	info.type.SetAlias(info.GetTypeName().GetIdentifierName());
++	info.type = info.type.WithAlias(info.GetTypeName().GetIdentifierName());
+ 	auto pg_type = PostgresUtils::CreateEmptyPostgresType(info.type);
+ 	auto type_entry = make_shared_ptr<PostgresTypeEntry>(catalog, schema, info, pg_type);
+ 	return CreateEntry(transaction, std::move(type_entry));

--- a/.github/patches/extensions/spatial/0005-immutable-logical-type.patch
+++ b/.github/patches/extensions/spatial/0005-immutable-logical-type.patch
@@ -1,0 +1,145 @@
+diff --git a/src/spatial/modules/shapefile/shapefile_module.cpp b/src/spatial/modules/shapefile/shapefile_module.cpp
+index f12d1eb..6ef8fb5 100644
+--- a/src/spatial/modules/shapefile/shapefile_module.cpp
++++ b/src/spatial/modules/shapefile/shapefile_module.cpp
+@@ -966,8 +966,8 @@ struct Shapefile_Meta {
+ 			auto str = string_t(shape_type_map[i].shp_name);
+ 			varchar_data[i] = str.IsInlined() ? str : StringVector::AddString(varchar_vector, str);
+ 		}
+-		auto shape_type_enum = LogicalType::ENUM("SHAPE_TYPE", varchar_vector, shape_type_count);
+-		shape_type_enum.SetAlias("SHAPE_TYPE");
++		auto shape_type_enum =
++		    LogicalType::ENUM("SHAPE_TYPE", varchar_vector, shape_type_count).WithAlias("SHAPE_TYPE");
+ 
+ 		return_types.push_back(LogicalType::VARCHAR);
+ 		return_types.push_back(shape_type_enum);
+diff --git a/src/spatial/modules/wkb/wkb_module.cpp b/src/spatial/modules/wkb/wkb_module.cpp
+index 43e7d1a..5395fca 100644
+--- a/src/spatial/modules/wkb/wkb_module.cpp
++++ b/src/spatial/modules/wkb/wkb_module.cpp
+@@ -11,9 +11,7 @@ namespace {
+ struct WKBTypes {
+ 
+ 	static LogicalType WKB_BLOB() {
+-		auto blob_type = LogicalType(LogicalTypeId::BLOB);
+-		blob_type.SetAlias("WKB_BLOB");
+-		return blob_type;
++		return LogicalType(LogicalTypeId::BLOB).WithAlias("WKB_BLOB");
+ 	}
+ 
+ 	static bool ToWKBCast(Vector &source, Vector &result, idx_t count, CastParameters &) {
+diff --git a/src/spatial/spatial_types.cpp b/src/spatial/spatial_types.cpp
+index d98b266..e4ee52f 100644
+--- a/src/spatial/spatial_types.cpp
++++ b/src/spatial/spatial_types.cpp
+@@ -7,70 +7,59 @@
+ namespace duckdb {
+ 
+ LogicalType GeoTypes::POINT_2D() {
+-	auto type = LogicalType::STRUCT({{"x", LogicalType::DOUBLE}, {"y", LogicalType::DOUBLE}});
+-	type.SetAlias("POINT_2D");
+-	return type;
++	return LogicalType::STRUCT({{"x", LogicalType::DOUBLE}, {"y", LogicalType::DOUBLE}}).WithAlias("POINT_2D");
+ }
+ 
+ LogicalType GeoTypes::POINT_3D() {
+-	auto type =
+-	    LogicalType::STRUCT({{"x", LogicalType::DOUBLE}, {"y", LogicalType::DOUBLE}, {"z", LogicalType::DOUBLE}});
+-	type.SetAlias("POINT_3D");
+-	return type;
++	return LogicalType::STRUCT({{"x", LogicalType::DOUBLE}, {"y", LogicalType::DOUBLE}, {"z", LogicalType::DOUBLE}})
++	    .WithAlias("POINT_3D");
+ }
+ 
+ LogicalType GeoTypes::POINT_4D() {
+-	auto type = LogicalType::STRUCT({{"x", LogicalType::DOUBLE},
+-	                                 {"y", LogicalType::DOUBLE},
+-	                                 {"z", LogicalType::DOUBLE},
+-	                                 {"m", LogicalType::DOUBLE}});
+-	type.SetAlias("POINT_4D");
+-	return type;
++	return LogicalType::STRUCT({{"x", LogicalType::DOUBLE},
++	                            {"y", LogicalType::DOUBLE},
++	                            {"z", LogicalType::DOUBLE},
++	                            {"m", LogicalType::DOUBLE}})
++	    .WithAlias("POINT_4D");
+ }
+ 
+ LogicalType GeoTypes::BOX_2D() {
+-	auto type = LogicalType::STRUCT({{"min_x", LogicalType::DOUBLE},
+-	                                 {"min_y", LogicalType::DOUBLE},
+-	                                 {"max_x", LogicalType::DOUBLE},
+-	                                 {"max_y", LogicalType::DOUBLE}});
+-	type.SetAlias("BOX_2D");
+-	return type;
++	return LogicalType::STRUCT({{"min_x", LogicalType::DOUBLE},
++	                            {"min_y", LogicalType::DOUBLE},
++	                            {"max_x", LogicalType::DOUBLE},
++	                            {"max_y", LogicalType::DOUBLE}})
++	    .WithAlias("BOX_2D");
+ }
+ 
+ LogicalType GeoTypes::BOX_2DF() {
+-	auto type = LogicalType::STRUCT({{"min_x", LogicalType::FLOAT},
+-	                                 {"min_y", LogicalType::FLOAT},
+-	                                 {"max_x", LogicalType::FLOAT},
+-	                                 {"max_y", LogicalType::FLOAT}});
+-	type.SetAlias("BOX_2DF");
+-	return type;
++	return LogicalType::STRUCT({{"min_x", LogicalType::FLOAT},
++	                            {"min_y", LogicalType::FLOAT},
++	                            {"max_x", LogicalType::FLOAT},
++	                            {"max_y", LogicalType::FLOAT}})
++	    .WithAlias("BOX_2DF");
+ }
+ 
+ LogicalType GeoTypes::LINESTRING_2D() {
+-	auto type = LogicalType::LIST(LogicalType::STRUCT({{"x", LogicalType::DOUBLE}, {"y", LogicalType::DOUBLE}}));
+-	type.SetAlias("LINESTRING_2D");
+-	return type;
++	return LogicalType::LIST(LogicalType::STRUCT({{"x", LogicalType::DOUBLE}, {"y", LogicalType::DOUBLE}}))
++	    .WithAlias("LINESTRING_2D");
+ }
+ 
+ LogicalType GeoTypes::LINESTRING_3D() {
+-	auto type = LogicalType::LIST(
+-	    LogicalType::STRUCT({{"x", LogicalType::DOUBLE}, {"y", LogicalType::DOUBLE}, {"z", LogicalType::DOUBLE}}));
+-	type.SetAlias("LINESTRING_3D");
+-	return type;
++	return LogicalType::LIST(LogicalType::STRUCT(
++	                             {{"x", LogicalType::DOUBLE}, {"y", LogicalType::DOUBLE}, {"z", LogicalType::DOUBLE}}))
++	    .WithAlias("LINESTRING_3D");
+ }
+ 
+ LogicalType GeoTypes::POLYGON_2D() {
+-	auto type = LogicalType::LIST(
+-	    LogicalType::LIST(LogicalType::STRUCT({{"x", LogicalType::DOUBLE}, {"y", LogicalType::DOUBLE}})));
+-	type.SetAlias("POLYGON_2D");
+-	return type;
++	return LogicalType::LIST(
++	           LogicalType::LIST(LogicalType::STRUCT({{"x", LogicalType::DOUBLE}, {"y", LogicalType::DOUBLE}})))
++	    .WithAlias("POLYGON_2D");
+ }
+ 
+ LogicalType GeoTypes::POLYGON_3D() {
+-	auto type = LogicalType::LIST(LogicalType::LIST(
+-	    LogicalType::STRUCT({{"x", LogicalType::DOUBLE}, {"y", LogicalType::DOUBLE}, {"z", LogicalType::DOUBLE}})));
+-	type.SetAlias("POLYGON_3D");
+-	return type;
++	return LogicalType::LIST(LogicalType::LIST(LogicalType::STRUCT(
++	                             {{"x", LogicalType::DOUBLE}, {"y", LogicalType::DOUBLE}, {"z", LogicalType::DOUBLE}})))
++	    .WithAlias("POLYGON_3D");
+ }
+ 
+ LogicalType GeoTypes::CreateEnumType(const string &name, const vector<string> &members) {
+@@ -80,9 +69,7 @@ LogicalType GeoTypes::CreateEnumType(const string &name, const vector<string> &m
+ 		auto str = string_t(members[i]);
+ 		varchar_data[i] = str.IsInlined() ? str : StringVector::AddString(varchar_vector, str);
+ 	}
+-	auto enum_type = LogicalType::ENUM(name, varchar_vector, members.size());
+-	enum_type.SetAlias(name);
+-	return enum_type;
++	return LogicalType::ENUM(name, varchar_vector, members.size()).WithAlias(name);
+ }
+ 
+ static unique_ptr<FunctionData> PropagateTypesInternal(ClientContext &context, BoundSimpleFunction &bound_function,

--- a/extension/parquet/writer/variant/convert_variant.cpp
+++ b/extension/parquet/writer/variant/convert_variant.cpp
@@ -999,9 +999,7 @@ static LogicalType GetParquetVariantType(optional_ptr<LogicalType> shredding = n
 	if (shredding && shredding->id() != LogicalTypeId::VARIANT) {
 		children.emplace_back("typed_value", VariantColumnWriter::TransformTypedValueRecursive(*shredding));
 	}
-	auto res = LogicalType::STRUCT(std::move(children));
-	res.SetAlias("PARQUET_VARIANT");
-	return res;
+	return LogicalType::STRUCT(std::move(children)).WithAlias("PARQUET_VARIANT");
 }
 
 static unique_ptr<FunctionData> BindTransform(BindScalarFunctionInput &input) {

--- a/src/catalog/catalog_entry/type_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/type_catalog_entry.cpp
@@ -47,10 +47,8 @@ string TypeCatalogEntry::ToSQL() const {
 	ss << SQLIdentifier(name);
 	ss << " AS ";
 
-	auto user_type_copy = user_type;
-
 	// Strip off the potential alias so ToString doesn't just output the alias
-	user_type_copy.SetAlias("");
+	auto user_type_copy = user_type.WithAlias("");
 	D_ASSERT(user_type_copy.GetAlias().empty());
 
 	ss << user_type_copy.ToString();

--- a/src/common/extra_type_info.cpp
+++ b/src/common/extra_type_info.cpp
@@ -116,7 +116,7 @@ void ExtraTypeInfo::CopyBaseInfo(ExtraTypeInfo &target) const {
 	}
 }
 
-bool ExtraTypeInfo::Equals(ExtraTypeInfo *other_p) const {
+bool ExtraTypeInfo::Equals(const ExtraTypeInfo *other_p) const {
 	if (type == ExtraTypeInfoType::INVALID_TYPE_INFO || type == ExtraTypeInfoType::STRING_TYPE_INFO ||
 	    type == ExtraTypeInfoType::GENERIC_TYPE_INFO) {
 		if (!other_p) {
@@ -152,7 +152,7 @@ bool ExtraTypeInfo::Equals(ExtraTypeInfo *other_p) const {
 	return EqualsInternal(other_p);
 }
 
-bool ExtraTypeInfo::EqualsInternal(ExtraTypeInfo *other_p) const {
+bool ExtraTypeInfo::EqualsInternal(const ExtraTypeInfo *other_p) const {
 	// Do nothing
 	return true;
 }
@@ -168,7 +168,7 @@ DecimalTypeInfo::DecimalTypeInfo(uint8_t width_p, uint8_t scale_p)
 	D_ASSERT(width_p >= scale_p);
 }
 
-bool DecimalTypeInfo::EqualsInternal(ExtraTypeInfo *other_p) const {
+bool DecimalTypeInfo::EqualsInternal(const ExtraTypeInfo *other_p) const {
 	auto &other = other_p->Cast<DecimalTypeInfo>();
 	return width == other.width && scale == other.scale;
 }
@@ -187,7 +187,7 @@ StringTypeInfo::StringTypeInfo(string collation_p)
     : ExtraTypeInfo(ExtraTypeInfoType::STRING_TYPE_INFO), collation(std::move(collation_p)) {
 }
 
-bool StringTypeInfo::EqualsInternal(ExtraTypeInfo *other_p) const {
+bool StringTypeInfo::EqualsInternal(const ExtraTypeInfo *other_p) const {
 	// collation info has no impact on equality
 	return true;
 }
@@ -206,7 +206,7 @@ ListTypeInfo::ListTypeInfo(LogicalType child_type_p)
     : ExtraTypeInfo(ExtraTypeInfoType::LIST_TYPE_INFO), child_type(std::move(child_type_p)) {
 }
 
-bool ListTypeInfo::EqualsInternal(ExtraTypeInfo *other_p) const {
+bool ListTypeInfo::EqualsInternal(const ExtraTypeInfo *other_p) const {
 	auto &other = other_p->Cast<ListTypeInfo>();
 	return child_type == other.child_type;
 }
@@ -235,7 +235,7 @@ StructTypeInfo::StructTypeInfo(child_list_t<LogicalType> child_types_p)
     : ExtraTypeInfo(ExtraTypeInfoType::STRUCT_TYPE_INFO), child_types(std::move(child_types_p)) {
 }
 
-bool StructTypeInfo::EqualsInternal(ExtraTypeInfo *other_p) const {
+bool StructTypeInfo::EqualsInternal(const ExtraTypeInfo *other_p) const {
 	auto &other = other_p->Cast<StructTypeInfo>();
 	return child_types == other.child_types;
 }
@@ -328,7 +328,7 @@ LegacyAggregateStateTypeInfo::LegacyAggregateStateTypeInfo()
 	throw InternalException("LegacyAggregateStateTypeInfo should no longer be getting constructed");
 }
 
-bool LegacyAggregateStateTypeInfo::EqualsInternal(ExtraTypeInfo *other_p) const {
+bool LegacyAggregateStateTypeInfo::EqualsInternal(const ExtraTypeInfo *other_p) const {
 	throw InternalException("LegacyAggregateStateTypeInfo should no longer be getting constructed");
 }
 
@@ -430,7 +430,7 @@ shared_ptr<ExtraTypeInfo> EnumTypeInfo::Deserialize(Deserializer &deserializer) 
 }
 
 // Equalities are only used in enums with different catalog entries
-bool EnumTypeInfo::EqualsInternal(ExtraTypeInfo *other_p) const {
+bool EnumTypeInfo::EqualsInternal(const ExtraTypeInfo *other_p) const {
 	auto &other = other_p->Cast<EnumTypeInfo>();
 	if (dict_type != other.dict_type) {
 		return false;
@@ -477,7 +477,7 @@ ArrayTypeInfo::ArrayTypeInfo(LogicalType child_type_p, uint32_t size_p)
     : ExtraTypeInfo(ExtraTypeInfoType::ARRAY_TYPE_INFO), child_type(std::move(child_type_p)), size(size_p) {
 }
 
-bool ArrayTypeInfo::EqualsInternal(ExtraTypeInfo *other_p) const {
+bool ArrayTypeInfo::EqualsInternal(const ExtraTypeInfo *other_p) const {
 	auto &other = other_p->Cast<ArrayTypeInfo>();
 	return child_type == other.child_type && size == other.size;
 }
@@ -502,7 +502,7 @@ AnyTypeInfo::AnyTypeInfo(LogicalType target_type_p, idx_t cast_score_p)
     : ExtraTypeInfo(ExtraTypeInfoType::ANY_TYPE_INFO), target_type(std::move(target_type_p)), cast_score(cast_score_p) {
 }
 
-bool AnyTypeInfo::EqualsInternal(ExtraTypeInfo *other_p) const {
+bool AnyTypeInfo::EqualsInternal(const ExtraTypeInfo *other_p) const {
 	auto &other = other_p->Cast<AnyTypeInfo>();
 	return target_type == other.target_type && cast_score == other.cast_score;
 }
@@ -530,7 +530,7 @@ IntegerLiteralTypeInfo::IntegerLiteralTypeInfo(Value constant_value_p)
 	}
 }
 
-bool IntegerLiteralTypeInfo::EqualsInternal(ExtraTypeInfo *other_p) const {
+bool IntegerLiteralTypeInfo::EqualsInternal(const ExtraTypeInfo *other_p) const {
 	auto &other = other_p->Cast<IntegerLiteralTypeInfo>();
 	return constant_value == other.constant_value;
 }
@@ -549,7 +549,7 @@ TemplateTypeInfo::TemplateTypeInfo(string name_p)
     : ExtraTypeInfo(ExtraTypeInfoType::TEMPLATE_TYPE_INFO), name(std::move(name_p)) {
 }
 
-bool TemplateTypeInfo::EqualsInternal(ExtraTypeInfo *other_p) const {
+bool TemplateTypeInfo::EqualsInternal(const ExtraTypeInfo *other_p) const {
 	auto &other = other_p->Cast<TemplateTypeInfo>();
 	return name == other.name;
 }
@@ -564,7 +564,7 @@ shared_ptr<ExtraTypeInfo> TemplateTypeInfo::Copy() const {
 GeoTypeInfo::GeoTypeInfo() : ExtraTypeInfo(ExtraTypeInfoType::GEO_TYPE_INFO) {
 }
 
-bool GeoTypeInfo::EqualsInternal(ExtraTypeInfo *other_p) const {
+bool GeoTypeInfo::EqualsInternal(const ExtraTypeInfo *other_p) const {
 	// No additional info to compare
 	const auto &other = other_p->Cast<GeoTypeInfo>();
 	return other.crs.Equals(crs);
@@ -584,7 +584,7 @@ UnboundTypeInfo::UnboundTypeInfo(unique_ptr<ParsedExpression> expr_p)
     : ExtraTypeInfo(ExtraTypeInfoType::UNBOUND_TYPE_INFO), expr(std::move(expr_p)) {
 }
 
-bool UnboundTypeInfo::EqualsInternal(ExtraTypeInfo *other_p) const {
+bool UnboundTypeInfo::EqualsInternal(const ExtraTypeInfo *other_p) const {
 	auto &other = other_p->Cast<UnboundTypeInfo>();
 	if (!expr->Equals(*other.expr)) {
 		return false;
@@ -593,7 +593,9 @@ bool UnboundTypeInfo::EqualsInternal(ExtraTypeInfo *other_p) const {
 }
 
 shared_ptr<ExtraTypeInfo> UnboundTypeInfo::Copy() const {
-	return make_shared_ptr<UnboundTypeInfo>(expr->Copy());
+	auto result = make_shared_ptr<UnboundTypeInfo>(expr->Copy());
+	CopyBaseInfo(*result);
+	return result;
 }
 
 } // namespace duckdb

--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -43,7 +43,7 @@ LogicalType::LogicalType() : LogicalType(LogicalTypeId::INVALID) {
 LogicalType::LogicalType(LogicalTypeId id) : id_(id) {
 	physical_type_ = GetInternalType();
 }
-LogicalType::LogicalType(LogicalTypeId id, shared_ptr<ExtraTypeInfo> type_info_p)
+LogicalType::LogicalType(LogicalTypeId id, shared_ptr<const ExtraTypeInfo> type_info_p)
     : id_(id), type_info_(std::move(type_info_p)) {
 	physical_type_ = GetInternalType();
 }
@@ -1288,7 +1288,7 @@ void LogicalType::Serialize(Serializer &serializer) const {
 		serialized_id = LogicalTypeId::STRUCT;
 	}
 	serializer.WriteProperty<LogicalTypeId>(100, "id", serialized_id);
-	serializer.WritePropertyWithDefault<shared_ptr<ExtraTypeInfo>>(101, "type_info", type_info_);
+	serializer.WritePropertyWithDefault<shared_ptr<const ExtraTypeInfo>>(101, "type_info", type_info_);
 }
 
 LogicalType LogicalType::Deserialize(Deserializer &deserializer) {
@@ -1335,12 +1335,25 @@ LogicalType LogicalType::DeepCopy() const {
 	return copy;
 }
 
-void LogicalType::SetAlias(string alias) {
+LogicalType LogicalType::WithAlias(string alias) const {
 	if (!type_info_) {
-		type_info_ = make_shared_ptr<ExtraTypeInfo>(ExtraTypeInfoType::GENERIC_TYPE_INFO, std::move(alias));
-	} else {
-		type_info_->alias = std::move(alias);
+		if (alias.empty()) {
+			// a type without type info is equivalent to a generic type info with an empty alias
+			return *this;
+		}
+		LogicalType result = *this;
+		result.type_info_ = make_shared_ptr<ExtraTypeInfo>(ExtraTypeInfoType::GENERIC_TYPE_INFO, std::move(alias));
+		return result;
 	}
+	if (type_info_->alias == alias) {
+		// avoid copying the (potentially expensive) type info if the alias does not change
+		return *this;
+	}
+	auto new_info = type_info_->Copy();
+	new_info->alias = std::move(alias);
+	LogicalType result = *this;
+	result.type_info_ = std::move(new_info);
+	return result;
 }
 
 string LogicalType::GetAlias() const {
@@ -1371,18 +1384,13 @@ optional_ptr<const ExtensionTypeInfo> LogicalType::GetExtensionInfo() const {
 	return nullptr;
 }
 
-optional_ptr<ExtensionTypeInfo> LogicalType::GetExtensionInfo() {
-	if (type_info_ && type_info_->extension_info) {
-		return type_info_->extension_info.get();
-	}
-	return nullptr;
-}
-
-void LogicalType::SetExtensionInfo(unique_ptr<ExtensionTypeInfo> info) {
-	if (!type_info_) {
-		type_info_ = make_shared_ptr<ExtraTypeInfo>(ExtraTypeInfoType::GENERIC_TYPE_INFO);
-	}
-	type_info_->extension_info = std::move(info);
+LogicalType LogicalType::WithExtensionInfo(unique_ptr<ExtensionTypeInfo> info) const {
+	auto new_info =
+	    type_info_ ? type_info_->Copy() : make_shared_ptr<ExtraTypeInfo>(ExtraTypeInfoType::GENERIC_TYPE_INFO);
+	new_info->extension_info = std::move(info);
+	LogicalType result = *this;
+	result.type_info_ = std::move(new_info);
+	return result;
 }
 
 //===--------------------------------------------------------------------===//
@@ -1679,9 +1687,7 @@ PhysicalType EnumType::GetPhysicalType(const LogicalType &type) {
 // JSON Type
 //===--------------------------------------------------------------------===//
 LogicalType LogicalType::JSON() {
-	auto json_type = LogicalType(LogicalTypeId::VARCHAR);
-	json_type.SetAlias(JSON_TYPE_NAME);
-	return json_type;
+	return LogicalType(LogicalTypeId::VARCHAR).WithAlias(JSON_TYPE_NAME);
 }
 
 bool LogicalType::IsJSONType() const {
@@ -1885,7 +1891,7 @@ bool GeoType::HasCRS(const LogicalType &type) {
 	auto info = type.AuxInfo();
 	if (!info || info->type != ExtraTypeInfoType::GEO_TYPE_INFO) {
 		// a GEOMETRY type without geo type info has no CRS - this can happen when an alias is set on a geometry
-		// type that was created without a CRS (SetAlias attaches a generic type info)
+		// type that was created without a CRS (WithAlias attaches a generic type info)
 		return false;
 	}
 	const auto &geo_info = info->Cast<GeoTypeInfo>();

--- a/src/common/types/geometry.cpp
+++ b/src/common/types/geometry.cpp
@@ -2429,9 +2429,7 @@ void Geometry::FromVectorizedFormat(const Vector &source, Vector &target, idx_t 
 }
 
 LogicalType Geometry::GetSpatialGeometryType() {
-	auto blob_type = LogicalType(LogicalTypeId::BLOB);
-	blob_type.SetAlias("GEOMETRY");
-	return blob_type;
+	return LogicalType(LogicalTypeId::BLOB).WithAlias("GEOMETRY");
 }
 
 bool Geometry::IsSpatialGeometryType(const LogicalType &type) {

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -357,9 +357,9 @@ Value Vector::GetValueInternal(const Vector &v_p, idx_t index_p) {
 
 Value Vector::GetValue(const Vector &v_p, idx_t index_p) {
 	auto value = GetValueInternal(v_p, index_p);
-	// set the alias of the type to the correct value, if there is a type alias
+	// the value's type is reconstructed from the data - restore the source type so that the alias survives
 	if (v_p.GetType().HasAlias()) {
-		value.GetTypeMutable().CopyAuxInfo(v_p.GetType());
+		value.GetTypeMutable() = v_p.GetType();
 	}
 	if (v_p.GetType().id() != LogicalTypeId::LEGACY_AGGREGATE_STATE &&
 	    value.type().id() != LogicalTypeId::LEGACY_AGGREGATE_STATE) {

--- a/src/function/scalar/system/aggregate_export.cpp
+++ b/src/function/scalar/system/aggregate_export.cpp
@@ -863,14 +863,9 @@ string OrderModifierToString(OrderType order_type, OrderByNullType null_order) {
 LogicalType CreateAggregateStateType(const BoundAggregateFunction &bound_function,
                                      optional_ptr<FunctionData> bind_data) {
 	auto layout = bound_function.GetStateType(bind_data);
-	// deep copy the type before modifying it - SetAlias/SetExtensionInfo modify the (shared) extra type info in
-	// place, and the state layout type can share its type info with e.g. the aggregate's input expressions
-	LogicalType state_layout = layout.type.DeepCopy();
-	state_layout.SetAlias("AGGREGATE_STATE");
 	auto ext_info = make_uniq<ExtensionTypeInfo>();
 	EncodeStateParameters(*ext_info, bound_function, layout);
-	state_layout.SetExtensionInfo(std::move(ext_info));
-	return state_layout;
+	return layout.type.WithAlias("AGGREGATE_STATE").WithExtensionInfo(std::move(ext_info));
 }
 
 // constructs the AGGREGATE_STATE type for an ordered aggregate - the state is the buffer of values
@@ -879,7 +874,6 @@ LogicalType CreateSortedAggregateStateType(const BoundAggregateFunction &inner_f
                                            optional_ptr<FunctionData> inner_bind_data, const LogicalType &buffer_struct,
                                            const vector<SortedAggregateStateOrder> &orders) {
 	LogicalType state_layout = LogicalType::LIST(buffer_struct);
-	state_layout.SetAlias("AGGREGATE_STATE");
 	auto ext_info = make_uniq<ExtensionTypeInfo>();
 	EncodeStateParameters(*ext_info, inner_function, inner_function.GetStateType(inner_bind_data));
 	// per key: the buffered column it sorts on and the modifier string (the argument count is re-derived on re-bind)
@@ -891,8 +885,7 @@ LogicalType CreateSortedAggregateStateType(const BoundAggregateFunction &inner_f
 		order_values.push_back(Value::STRUCT(std::move(children)));
 	}
 	ext_info->properties.emplace("order_bys", Value::LIST(OrderByEntryType(), std::move(order_values)));
-	state_layout.SetExtensionInfo(std::move(ext_info));
-	return state_layout;
+	return state_layout.WithAlias("AGGREGATE_STATE").WithExtensionInfo(std::move(ext_info));
 }
 
 // parses a single entry of the to_aggregate_state signature list - either a TYPE value (e.g. make_type('VARCHAR'))

--- a/src/include/duckdb/common/extra_type_info.hpp
+++ b/src/include/duckdb/common/extra_type_info.hpp
@@ -50,7 +50,7 @@ protected:
 	ExtraTypeInfo &operator=(const ExtraTypeInfo &other);
 
 public:
-	bool Equals(ExtraTypeInfo *other_p) const;
+	bool Equals(const ExtraTypeInfo *other_p) const;
 
 	virtual void Serialize(Serializer &serializer) const;
 	static shared_ptr<ExtraTypeInfo> Deserialize(Deserializer &source);
@@ -72,7 +72,7 @@ public:
 	}
 
 protected:
-	virtual bool EqualsInternal(ExtraTypeInfo *other_p) const;
+	virtual bool EqualsInternal(const ExtraTypeInfo *other_p) const;
 };
 
 struct DecimalTypeInfo : public ExtraTypeInfo {
@@ -87,7 +87,7 @@ public:
 	shared_ptr<ExtraTypeInfo> Copy() const override;
 
 protected:
-	bool EqualsInternal(ExtraTypeInfo *other_p) const override;
+	bool EqualsInternal(const ExtraTypeInfo *other_p) const override;
 
 private:
 	DecimalTypeInfo();
@@ -104,7 +104,7 @@ public:
 	shared_ptr<ExtraTypeInfo> Copy() const override;
 
 protected:
-	bool EqualsInternal(ExtraTypeInfo *other_p) const override;
+	bool EqualsInternal(const ExtraTypeInfo *other_p) const override;
 
 private:
 	StringTypeInfo();
@@ -122,7 +122,7 @@ public:
 	shared_ptr<ExtraTypeInfo> DeepCopy() const override;
 
 protected:
-	bool EqualsInternal(ExtraTypeInfo *other_p) const override;
+	bool EqualsInternal(const ExtraTypeInfo *other_p) const override;
 
 private:
 	ListTypeInfo();
@@ -141,7 +141,7 @@ public:
 	shared_ptr<ExtraTypeInfo> DeepCopy() const override;
 
 protected:
-	bool EqualsInternal(ExtraTypeInfo *other_p) const override;
+	bool EqualsInternal(const ExtraTypeInfo *other_p) const override;
 
 private:
 	StructTypeInfo();
@@ -156,7 +156,7 @@ public:
 	static shared_ptr<ExtraTypeInfo> LegacyDeserialize();
 
 protected:
-	bool EqualsInternal(ExtraTypeInfo *other_p) const override;
+	bool EqualsInternal(const ExtraTypeInfo *other_p) const override;
 
 private:
 	LegacyAggregateStateTypeInfo();
@@ -185,7 +185,7 @@ public:
 
 protected:
 	// Equalities are only used in enums with different catalog entries
-	bool EqualsInternal(ExtraTypeInfo *other_p) const override;
+	bool EqualsInternal(const ExtraTypeInfo *other_p) const override;
 
 	Vector values_insert_order;
 
@@ -206,7 +206,7 @@ public:
 	shared_ptr<ExtraTypeInfo> DeepCopy() const override;
 
 protected:
-	bool EqualsInternal(ExtraTypeInfo *other_p) const override;
+	bool EqualsInternal(const ExtraTypeInfo *other_p) const override;
 };
 
 struct AnyTypeInfo : public ExtraTypeInfo {
@@ -222,7 +222,7 @@ public:
 	shared_ptr<ExtraTypeInfo> DeepCopy() const override;
 
 protected:
-	bool EqualsInternal(ExtraTypeInfo *other_p) const override;
+	bool EqualsInternal(const ExtraTypeInfo *other_p) const override;
 
 private:
 	AnyTypeInfo();
@@ -239,7 +239,7 @@ public:
 	shared_ptr<ExtraTypeInfo> Copy() const override;
 
 protected:
-	bool EqualsInternal(ExtraTypeInfo *other_p) const override;
+	bool EqualsInternal(const ExtraTypeInfo *other_p) const override;
 
 private:
 	IntegerLiteralTypeInfo();
@@ -258,7 +258,7 @@ public:
 	shared_ptr<ExtraTypeInfo> Copy() const override;
 
 protected:
-	bool EqualsInternal(ExtraTypeInfo *other_p) const override;
+	bool EqualsInternal(const ExtraTypeInfo *other_p) const override;
 	TemplateTypeInfo();
 };
 
@@ -274,7 +274,7 @@ public:
 	CoordinateReferenceSystem crs;
 
 protected:
-	bool EqualsInternal(ExtraTypeInfo *other_p) const override;
+	bool EqualsInternal(const ExtraTypeInfo *other_p) const override;
 };
 
 struct UnboundTypeInfo : public ExtraTypeInfo {
@@ -287,7 +287,7 @@ struct UnboundTypeInfo : public ExtraTypeInfo {
 	shared_ptr<ExtraTypeInfo> Copy() const override;
 
 protected:
-	bool EqualsInternal(ExtraTypeInfo *other_p) const override;
+	bool EqualsInternal(const ExtraTypeInfo *other_p) const override;
 
 private:
 	UnboundTypeInfo();

--- a/src/include/duckdb/common/types.hpp
+++ b/src/include/duckdb/common/types.hpp
@@ -263,7 +263,7 @@ struct ExtensionTypeInfo;
 struct LogicalType {
 	DUCKDB_API LogicalType();
 	DUCKDB_API LogicalType(LogicalTypeId id); // NOLINT: Allow implicit conversion from `LogicalTypeId`
-	DUCKDB_API LogicalType(LogicalTypeId id, shared_ptr<ExtraTypeInfo> type_info);
+	DUCKDB_API LogicalType(LogicalTypeId id, shared_ptr<const ExtraTypeInfo> type_info);
 	DUCKDB_API LogicalType(const LogicalType &other);
 	DUCKDB_API LogicalType(LogicalType &&other) noexcept;
 
@@ -275,7 +275,7 @@ struct LogicalType {
 	inline PhysicalType InternalType() const {
 		return physical_type_;
 	}
-	inline const optional_ptr<ExtraTypeInfo> AuxInfo() const {
+	inline optional_ptr<const ExtraTypeInfo> AuxInfo() const {
 		return type_info_.get();
 	}
 	inline bool IsNested() const {
@@ -298,18 +298,11 @@ struct LogicalType {
 		return id_ == LogicalTypeId::UNBOUND;
 	}
 
-	inline shared_ptr<ExtraTypeInfo> GetAuxInfoShrPtr() const {
-		return type_info_;
-	}
-
 	//! Copies the logical type, making a new ExtraTypeInfo
 	LogicalType Copy() const;
 	//! DeepCopy() will make a unique copy of any nested ExtraTypeInfo as well
 	LogicalType DeepCopy() const;
 
-	inline void CopyAuxInfo(const LogicalType &other) {
-		type_info_ = other.type_info_;
-	}
 	bool EqualTypeInfo(const LogicalType &rhs) const;
 
 	// copy assignment
@@ -353,14 +346,15 @@ struct LogicalType {
 	DUCKDB_API static bool IsNumeric(LogicalTypeId type);
 	DUCKDB_API bool IsTemporal() const;
 	DUCKDB_API hash_t Hash() const;
-	DUCKDB_API void SetAlias(string alias);
+	//! Returns a copy of this type with "alias" as its alias - never modifies types that share our type info
+	DUCKDB_API LogicalType WithAlias(string alias) const;
 	DUCKDB_API bool HasAlias() const;
 	DUCKDB_API string GetAlias() const;
 
 	DUCKDB_API bool HasExtensionInfo() const;
 	DUCKDB_API optional_ptr<const ExtensionTypeInfo> GetExtensionInfo() const;
-	DUCKDB_API optional_ptr<ExtensionTypeInfo> GetExtensionInfo();
-	DUCKDB_API void SetExtensionInfo(unique_ptr<ExtensionTypeInfo> info);
+	//! Returns a copy of this type with "info" as its extension info - never modifies types that share our type info
+	DUCKDB_API LogicalType WithExtensionInfo(unique_ptr<ExtensionTypeInfo> info) const;
 
 	//! Returns the maximum logical type when combining the two types - or throws an exception if combining is not
 	//! possible
@@ -400,9 +394,9 @@ struct LogicalType {
 	bool SupportsRegularUpdate() const;
 
 private:
-	LogicalTypeId id_;                    // NOLINT: allow this naming for legacy reasons
-	PhysicalType physical_type_;          // NOLINT: allow this naming for legacy reasons
-	shared_ptr<ExtraTypeInfo> type_info_; // NOLINT: allow this naming for legacy reasons
+	LogicalTypeId id_;                          // NOLINT: allow this naming for legacy reasons
+	PhysicalType physical_type_;                // NOLINT: allow this naming for legacy reasons
+	shared_ptr<const ExtraTypeInfo> type_info_; // NOLINT: allow this naming for legacy reasons
 
 private:
 	PhysicalType GetInternalType();

--- a/src/main/capi/logical_types-c.cpp
+++ b/src/main/capi/logical_types-c.cpp
@@ -373,7 +373,7 @@ char *duckdb_logical_type_get_alias(duckdb_logical_type type) {
 
 void duckdb_logical_type_set_alias(duckdb_logical_type type, const char *alias) {
 	auto &logical_type = *(reinterpret_cast<duckdb::LogicalType *>(type));
-	logical_type.SetAlias(alias);
+	logical_type = logical_type.WithAlias(alias);
 }
 
 duckdb_logical_type duckdb_struct_type_child_type(duckdb_logical_type type, idx_t index) {

--- a/src/optimizer/statistics/operator/propagate_aggregate.cpp
+++ b/src/optimizer/statistics/operator/propagate_aggregate.cpp
@@ -368,7 +368,7 @@ void StatisticsPropagator::TryExecuteAggregates(LogicalAggregate &aggr, unique_p
 					agg_result = rhs;
 				}
 			}
-			types.push_back(agg_result.GetTypeMutable());
+			types.push_back(agg_result.type());
 			auto expr = make_uniq<BoundConstantExpression>(agg_result);
 			agg_results.push_back(std::move(expr));
 		}

--- a/test/api/capi/test_capi_complex_types.cpp
+++ b/test/api/capi/test_capi_complex_types.cpp
@@ -292,9 +292,8 @@ TEST_CASE("Logical types with aliases", "[capi]") {
 	connection->BeginTransaction();
 
 	child_list_t<LogicalType> children = {{"hello", LogicalType::VARCHAR}};
-	auto id = LogicalType::STRUCT(children);
 	auto type_name = "test_type";
-	id.SetAlias(type_name);
+	auto id = LogicalType::STRUCT(children).WithAlias(type_name);
 	CreateTypeInfo info(type_name, id);
 
 	auto catalog_name = DatabaseManager::GetDefaultDatabase(*connection->context);
@@ -323,6 +322,33 @@ TEST_CASE("Logical types with aliases", "[capi]") {
 
 		duckdb_destroy_logical_type(&logical_type);
 	}
+}
+
+TEST_CASE("duckdb_logical_type_set_alias does not affect other types", "[capi]") {
+	CAPITester tester;
+	REQUIRE(tester.OpenDatabase(nullptr));
+
+	// a LIST type has extra type info - the two logical types below are copies that share it
+	auto result = tester.Query("SELECT [1, 2, 3] AS l");
+	REQUIRE(NO_FAIL(*result));
+
+	auto first = duckdb_column_logical_type(&result->InternalResult(), 0);
+	auto second = duckdb_column_logical_type(&result->InternalResult(), 0);
+	REQUIRE(first);
+	REQUIRE(second);
+
+	duckdb_logical_type_set_alias(first, "MY_ALIAS");
+
+	auto alias = duckdb_logical_type_get_alias(first);
+	REQUIRE(alias);
+	REQUIRE(string(alias) == "MY_ALIAS");
+	duckdb_free(alias);
+
+	// setting the alias on "first" must not have modified "second"
+	REQUIRE(duckdb_logical_type_get_alias(second) == nullptr);
+
+	duckdb_destroy_logical_type(&first);
+	duckdb_destroy_logical_type(&second);
 }
 
 TEST_CASE("duckdb_create_value", "[capi]") {

--- a/test/common/CMakeLists.txt
+++ b/test/common/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library_unity(
   test_parse_logical_type.cpp
   test_recursive_cte_metrics.cpp
   test_logical_type_is_complete.cpp
+  test_logical_type_immutable.cpp
   test_utf.cpp
   test_allocator_debug_info.cpp
   test_buffer_pool_reservation.cpp

--- a/test/common/test_logical_type_immutable.cpp
+++ b/test/common/test_logical_type_immutable.cpp
@@ -1,0 +1,68 @@
+#include "catch.hpp"
+#include "duckdb/common/types.hpp"
+#include "duckdb/common/extension_type_info.hpp"
+#include "duckdb/common/vector/flat_vector.hpp"
+#include "duckdb/common/vector/string_vector.hpp"
+
+using namespace duckdb;
+
+TEST_CASE("Test that LogicalType::WithAlias does not modify shared type info", "[logical_type_immutable]") {
+	SECTION("nested types share their extra type info") {
+		auto base = LogicalType::LIST(LogicalType::INTEGER);
+		auto shared = base;
+
+		auto aliased = base.WithAlias("MY_LIST");
+		REQUIRE(!base.HasAlias());
+		REQUIRE(!shared.HasAlias());
+		REQUIRE(aliased.GetAlias() == "MY_LIST");
+		REQUIRE(aliased.InternalType() == base.InternalType());
+		REQUIRE(ListType::GetChildType(aliased) == LogicalType::INTEGER);
+	}
+
+	SECTION("re-aliasing does not modify the previous alias") {
+		auto first = LogicalType::LIST(LogicalType::INTEGER).WithAlias("FIRST");
+		auto second = first.WithAlias("SECOND");
+		REQUIRE(first.GetAlias() == "FIRST");
+		REQUIRE(second.GetAlias() == "SECOND");
+	}
+
+	SECTION("enums are unshared and keep a working dictionary") {
+		Vector values(LogicalType::VARCHAR, 2);
+		auto data = FlatVector::GetDataMutable<string_t>(values);
+		data[0] = StringVector::AddString(values, "a");
+		data[1] = StringVector::AddString(values, "b");
+
+		auto base = LogicalType::ENUM(values, 2);
+		auto shared = base;
+		auto aliased = base.WithAlias("MOOD");
+
+		REQUIRE(!base.HasAlias());
+		REQUIRE(!shared.HasAlias());
+		REQUIRE(aliased.GetAlias() == "MOOD");
+		REQUIRE(EnumType::GetSize(aliased) == 2);
+		REQUIRE(EnumType::GetPos(aliased, string_t("b")) == 1);
+		REQUIRE(EnumType::GetPos(aliased, string_t("c")) == -1);
+	}
+
+	SECTION("an empty alias does not allocate extra type info") {
+		auto type = LogicalType(LogicalTypeId::INTEGER);
+		REQUIRE(!type.WithAlias("").AuxInfo());
+		REQUIRE(type.WithAlias("") == type);
+		// a generic type info with an empty alias compares equal to a type without type info
+		REQUIRE(type.WithAlias("x").WithAlias("") == type);
+	}
+}
+
+TEST_CASE("Test that LogicalType::WithExtensionInfo does not modify shared type info", "[logical_type_immutable]") {
+	auto base = LogicalType::LIST(LogicalType::INTEGER);
+	auto shared = base;
+
+	auto info = make_uniq<ExtensionTypeInfo>();
+	info->modifiers.emplace_back(Value::INTEGER(42));
+	auto extended = base.WithExtensionInfo(std::move(info));
+
+	REQUIRE(!base.HasExtensionInfo());
+	REQUIRE(!shared.HasExtensionInfo());
+	REQUIRE(extended.HasExtensionInfo());
+	REQUIRE(extended.GetExtensionInfo()->modifiers[0].value.GetValue<int32_t>() == 42);
+}

--- a/test/extension/loadable_extension_demo.cpp
+++ b/test/extension/loadable_extension_demo.cpp
@@ -520,18 +520,13 @@ struct BoundedType {
 	}
 
 	static LogicalType Get(int32_t max_val) {
-		auto type = LogicalType(LogicalTypeId::INTEGER);
-		type.SetAlias("BOUNDED");
 		auto info = make_uniq<ExtensionTypeInfo>();
 		info->modifiers.emplace_back(Value::INTEGER(max_val));
-		type.SetExtensionInfo(std::move(info));
-		return type;
+		return LogicalType(LogicalTypeId::INTEGER).WithAlias("BOUNDED").WithExtensionInfo(std::move(info));
 	}
 
 	static LogicalType GetDefault() {
-		auto type = LogicalType(LogicalTypeId::INTEGER);
-		type.SetAlias("BOUNDED");
-		return type;
+		return LogicalType(LogicalTypeId::INTEGER).WithAlias("BOUNDED");
 	}
 
 	static int32_t GetMaxValue(const LogicalType &type) {
@@ -695,13 +690,10 @@ struct MinMaxType {
 			throw BinderException("MINMAX type min value must be less than max value");
 		}
 
-		auto type = LogicalType(LogicalTypeId::INTEGER);
-		type.SetAlias("MINMAX");
 		auto info = make_uniq<ExtensionTypeInfo>();
 		info->modifiers.emplace_back(Value::INTEGER(min_val));
 		info->modifiers.emplace_back(Value::INTEGER(max_val));
-		type.SetExtensionInfo(std::move(info));
-		return type;
+		return LogicalType(LogicalTypeId::INTEGER).WithAlias("MINMAX").WithExtensionInfo(std::move(info));
 	}
 
 	static int32_t GetMinValue(const LogicalType &type) {
@@ -717,19 +709,14 @@ struct MinMaxType {
 	}
 
 	static LogicalType Get(int32_t min_val, int32_t max_val) {
-		auto type = LogicalType(LogicalTypeId::INTEGER);
-		type.SetAlias("MINMAX");
 		auto info = make_uniq<ExtensionTypeInfo>();
 		info->modifiers.emplace_back(Value::INTEGER(min_val));
 		info->modifiers.emplace_back(Value::INTEGER(max_val));
-		type.SetExtensionInfo(std::move(info));
-		return type;
+		return LogicalType(LogicalTypeId::INTEGER).WithAlias("MINMAX").WithExtensionInfo(std::move(info));
 	}
 
 	static LogicalType GetDefault() {
-		auto type = LogicalType(LogicalTypeId::INTEGER);
-		type.SetAlias("MINMAX");
-		return type;
+		return LogicalType(LogicalTypeId::INTEGER).WithAlias("MINMAX");
 	}
 };
 
@@ -1193,8 +1180,7 @@ DUCKDB_CPP_EXTENSION_ENTRY(loadable_extension_demo, loader) {
 	auto alias_info = make_uniq<CreateTypeInfo>();
 	alias_info->internal = true;
 	alias_info->SetTypeName(Identifier(alias_name));
-	LogicalType target_type = LogicalType::STRUCT(child_types);
-	target_type.SetAlias(alias_name);
+	LogicalType target_type = LogicalType::STRUCT(child_types).WithAlias(alias_name);
 	alias_info->type = target_type;
 
 	auto type_entry = catalog.CreateType(client_context, *alias_info);


### PR DESCRIPTION
This is a long overdue cleanup to make `LogicalType` actually entirely immutable.

`LogicalType`s contain shared pointers internally, and so having them be mutable is very risky. Thankfully they were almost entirely immutable already, with the exception of "aliases" and "ExtensionTypeInfo" set by extension types. These mutable accessors are now const and return "new" types instead.

This will also unlock further optimizations for `LogicalType`s and `Value`s down the line.

Most of the diff is additional regression test coverage.