### PR TITLE
Allow duplicates in index in ReplayRowGroupData

### DIFF
--- a/src/storage/wal_replay.cpp
+++ b/src/storage/wal_replay.cpp
@@ -1165,7 +1165,14 @@ void WriteAheadLogDeserializer::ReplayRowGroupData() {
 					continue;
 				}
 				auto &bound_index = index.Cast<BoundIndex>();
-				bound_index.Append(chunk, row_id_vector);
+				// Deleted index entries are removed when the replay transaction commits. Duplicates can temporarily
+				// exist, similar to tuple WAL replay.
+				IndexAppendInfo append_info(IndexAppendMode::INSERT_DUPLICATES, nullptr);
+				auto error = bound_index.Append(chunk, row_id_vector, append_info);
+				if (error.HasError()) {
+					throw InternalException("Failed to append to index '%s' during ROW_GROUP_DATA WAL replay: %s",
+					                        bound_index.GetIndexName(), error.Message());
+				}
 			}
 		}
 	}

--- a/test/sql/storage/optimistic_write/optimistic_write_unique_index_wal_replay.test
+++ b/test/sql/storage/optimistic_write/optimistic_write_unique_index_wal_replay.test
@@ -1,0 +1,80 @@
+# name: test/sql/storage/optimistic_write/optimistic_write_unique_index_wal_replay.test
+# description: Replay optimistic row groups for replacements on a table with a unique index
+# group: [optimistic_write]
+
+require noforcestorage
+
+require skip_reload
+
+load __TEST_DIR__/optimistic_write_unique_index_wal_replay.db
+
+statement ok
+PRAGMA disable_checkpoint_on_shutdown;
+
+statement ok
+SET threads = 1;
+
+statement ok
+CREATE TABLE t (id BIGINT PRIMARY KEY, payload INTEGER);
+
+statement ok
+INSERT INTO t SELECT i, 0 FROM range(0, 260000) r(i);
+
+statement ok
+CHECKPOINT;
+
+statement ok
+SET checkpoint_threshold = '1TB';
+
+statement ok
+SET wal_autocheckpoint = '1TB';
+
+statement ok
+SET write_buffer_row_group_count = 1;
+
+statement ok
+BEGIN;
+
+statement ok
+DELETE FROM t WHERE id >= 0 AND id < 130000;
+
+statement ok
+INSERT INTO t SELECT i, 1 FROM range(0, 130000) r(i);
+
+statement ok
+COMMIT;
+
+statement ok
+BEGIN;
+
+statement ok
+DELETE FROM t WHERE id >= 10000 AND id < 140000;
+
+statement ok
+INSERT INTO t SELECT i, 2 FROM range(10000, 140000) r(i);
+
+statement ok
+COMMIT;
+
+restart
+
+query II
+SELECT COUNT(*), COUNT(DISTINCT id) FROM t;
+----
+260000	260000
+
+query II
+SELECT id, payload FROM t WHERE id IN (0, 9999, 10000, 129999, 130000, 139999, 140000) ORDER BY id;
+----
+0	1
+9999	1
+10000	2
+129999	2
+130000	2
+139999	2
+140000	0
+
+statement error
+INSERT INTO t VALUES (0, 99);
+----
+<REGEX>:Constraint Error.*violates primary key constraint.*

--- a/test/sql/storage/optimistic_write/optimistic_write_unique_index_wal_replay_desync.test
+++ b/test/sql/storage/optimistic_write/optimistic_write_unique_index_wal_replay_desync.test
@@ -1,0 +1,71 @@
+# name: test/sql/storage/optimistic_write/optimistic_write_unique_index_wal_replay_desync.test
+# description: Replayed optimistic row groups remain reachable through their unique index
+# group: [optimistic_write]
+
+require noforcestorage
+
+require skip_reload
+
+load __TEST_DIR__/optimistic_write_unique_index_wal_replay_desync.db
+
+statement ok
+PRAGMA disable_checkpoint_on_shutdown;
+
+statement ok
+SET threads = 1;
+
+statement ok
+CREATE TABLE t (id BIGINT PRIMARY KEY, payload INTEGER);
+
+statement ok
+INSERT INTO t SELECT i, 0 FROM range(0, 260000) r(i);
+
+statement ok
+CHECKPOINT;
+
+statement ok
+SET checkpoint_threshold = '1TB';
+
+statement ok
+SET wal_autocheckpoint = '1TB';
+
+statement ok
+SET write_buffer_row_group_count = 1;
+
+statement ok
+BEGIN;
+
+statement ok
+DELETE FROM t WHERE id >= 0 AND id < 130000;
+
+statement ok
+INSERT INTO t SELECT i, 1 FROM range(0, 130000) r(i);
+
+statement ok
+COMMIT;
+
+restart
+
+# First force a table scan. The replacement row is present in the recovered row groups.
+statement ok
+SET index_scan_percentage = 0;
+
+statement ok
+SET index_scan_max_count = 0;
+
+query II
+SELECT id, payload FROM t WHERE id = 10000;
+----
+10000	1
+
+# Now force an index scan. It must find the same replacement row.
+statement ok
+SET index_scan_percentage = 1;
+
+statement ok
+SET index_scan_max_count = 999999999;
+
+query II
+SELECT id, payload FROM t WHERE id = 10000;
+----
+10000	1


### PR DESCRIPTION
fixes the bug for: https://github.com/duckdblabs/duckdb-internal/issues/10157

ReplayRowGroupData (replaying WAL entry for an optimistic write) was not allowing temporary duplicates in primary key indexes during WAL replay. This was causing the insert to fail, and no error was being propagated. The deletes would later still be applied upon transaction commit (as they should be), but the inserts that should have been in the index weren't there, hence the index was corrupted. 

Duplicates should be temporarily allowed, e.g. for replaying tuple inserts we do the same thing: if there is a delete + insert tuple, the index temporarily retains duplicate rowid's until transaction commit, at which point the old rowid is deleted. 