### PR TITLE
Make `Value` immutable

### DIFF
--- a/.github/config/extensions/delta.cmake
+++ b/.github/config/extensions/delta.cmake
@@ -3,5 +3,6 @@ if(NOT MINGW AND NOT ${WASM_ENABLED})
             GIT_URL https://github.com/duckdb/duckdb-delta
             GIT_TAG 10a49159f8e65674474b3bf34b92440f2399850d
             SUBMODULES extension-ci-tools
+            APPLY_PATCHES
   )
 endif()

--- a/.github/patches/extensions/delta/0001-value-optional-trycast.patch
+++ b/.github/patches/extensions/delta/0001-value-optional-trycast.patch
@@ -1,0 +1,20 @@
+diff --git a/src/storage/delta_catalog.cpp b/src/storage/delta_catalog.cpp
+index a3413f5..883d3c8 100644
+--- a/src/storage/delta_catalog.cpp
++++ b/src/storage/delta_catalog.cpp
+@@ -15,12 +15,12 @@ idx_t ParseDeltaVersionFromAtClause(const BoundAtClause &at_clause) {
+ 	if (at_clause.Unit() != "version") {
+ 		throw InvalidConfigurationException("Delta tables only support at_clause with unit 'version'");
+ 	}
+-	Value version_value = at_clause.GetValue();
+-	if (!version_value.DefaultTryCastAs(LogicalType::UBIGINT, false)) {
++	auto version_value = at_clause.GetValue().DefaultTryCastAs(LogicalType::UBIGINT);
++	if (!version_value) {
+ 		throw InvalidInputException("Failed to parse version number '%s' into a valid version",
+ 		                            at_clause.GetValue().ToString().c_str());
+ 	}
+-	return version_value.GetValue<idx_t>();
++	return version_value->GetValue<idx_t>();
+ }
+ 
+ DeltaCatalog::DeltaCatalog(AttachedDatabase &db_p, const string &path, AccessMode access_mode)

--- a/.github/patches/extensions/ducklake/0007-value-optional-trycast.patch
+++ b/.github/patches/extensions/ducklake/0007-value-optional-trycast.patch
@@ -23,12 +23,12 @@ index 6399814d..020063ba 100644
  	}
 -	Value casted;
 -	if (!constant.DefaultTryCastAs(col_type, casted, nullptr)) {
-+	auto casted = constant.DefaultTryCastAs(col_type);
-+	if (!casted) {
++	auto cast = constant.DefaultTryCastAs(col_type);
++	if (!cast) {
  		return optional_idx();
  	}
 -	auto const_expr = make_uniq<BoundConstantExpression>(std::move(casted));
-+	auto const_expr = make_uniq<BoundConstantExpression>(std::move(*casted));
++	auto const_expr = make_uniq<BoundConstantExpression>(std::move(*cast));
  	auto bucket_expr = DuckLakePartitionUtils::ApplyBucketTransform(context, std::move(const_expr), bucket_count);
  	Value result;
  	if (!ExpressionExecutor::TryEvaluateScalar(context, *bucket_expr, result)) {
@@ -42,11 +42,11 @@ index a485317f..f43b1c42 100644
  		// if casts fail, just skip pruning
 -		Value casted_constant;
 -		if (!constant.DefaultTryCastAs(col_filter.column_type, casted_constant, nullptr)) {
-+		auto casted_constant_opt = constant.DefaultTryCastAs(col_filter.column_type);
-+		if (!casted_constant_opt) {
++		auto cast_constant_opt = constant.DefaultTryCastAs(col_filter.column_type);
++		if (!cast_constant_opt) {
  			continue;
  		}
-+		auto &casted_constant = *casted_constant_opt;
++		auto &cast_constant = *cast_constant_opt;
  
  		switch (comparison_type) {
  		case ExpressionType::COMPARE_GREATERTHAN:
@@ -62,10 +62,10 @@ index a485317f..f43b1c42 100644
  			}
  			if (comparison_type == ExpressionType::COMPARE_GREATERTHAN) {
 -				return !(file_max > casted_constant);
-+				return !(*file_max > casted_constant);
++				return !(*file_max > cast_constant);
  			}
 -			return !(file_max >= casted_constant);
-+			return !(*file_max >= casted_constant);
++			return !(*file_max >= cast_constant);
  		}
  		case ExpressionType::COMPARE_LESSTHAN:
  		case ExpressionType::COMPARE_LESSTHANOREQUALTO: {
@@ -81,10 +81,10 @@ index a485317f..f43b1c42 100644
  			}
  			if (comparison_type == ExpressionType::COMPARE_LESSTHAN) {
 -				return !(file_min < casted_constant);
-+				return !(*file_min < casted_constant);
++				return !(*file_min < cast_constant);
  			}
 -			return !(file_min <= casted_constant);
-+			return !(*file_min <= casted_constant);
++			return !(*file_min <= cast_constant);
  		}
  		default:
  			// nothing to prune

--- a/.github/patches/extensions/ducklake/0007-value-optional-trycast.patch
+++ b/.github/patches/extensions/ducklake/0007-value-optional-trycast.patch
@@ -1,0 +1,109 @@
+diff --git a/src/functions/ducklake_add_data_files.cpp b/src/functions/ducklake_add_data_files.cpp
+index 23c37db3..69fa6da0 100644
+--- a/src/functions/ducklake_add_data_files.cpp
++++ b/src/functions/ducklake_add_data_files.cpp
+@@ -973,8 +973,8 @@ unique_ptr<DuckLakeNameMapEntry> DuckLakeFileProcessor::MapHiveColumn(ParquetFil
+ 	}
+ 
+ 	string error;
+-	Value cast_result;
+-	if (!hive_value.DefaultTryCastAs(target_type, cast_result, &error)) {
++	auto cast_result = hive_value.DefaultTryCastAs(target_type, &error);
++	if (!cast_result) {
+ 		throw InvalidInputException("Column \"%s\" exists as a hive partition with value \"%s\", but this value cannot "
+ 		                            "be cast to the column type \"%s\"",
+ 		                            field_id.Name(), hive_value.ToString(), field_id.Type());
+diff --git a/src/storage/ducklake_metadata_manager.cpp b/src/storage/ducklake_metadata_manager.cpp
+index 6399814d..020063ba 100644
+--- a/src/storage/ducklake_metadata_manager.cpp
++++ b/src/storage/ducklake_metadata_manager.cpp
+@@ -1611,11 +1611,11 @@ static optional_idx FoldBucketValue(ClientContext &context, const Value &constan
+ 	if (constant.IsNull()) {
+ 		return optional_idx();
+ 	}
+-	Value casted;
+-	if (!constant.DefaultTryCastAs(col_type, casted, nullptr)) {
++	auto casted = constant.DefaultTryCastAs(col_type);
++	if (!casted) {
+ 		return optional_idx();
+ 	}
+-	auto const_expr = make_uniq<BoundConstantExpression>(std::move(casted));
++	auto const_expr = make_uniq<BoundConstantExpression>(std::move(*casted));
+ 	auto bucket_expr = DuckLakePartitionUtils::ApplyBucketTransform(context, std::move(const_expr), bucket_count);
+ 	Value result;
+ 	if (!ExpressionExecutor::TryEvaluateScalar(context, *bucket_expr, result)) {
+diff --git a/src/storage/ducklake_multi_file_reader.cpp b/src/storage/ducklake_multi_file_reader.cpp
+index a485317f..f43b1c42 100644
+--- a/src/storage/ducklake_multi_file_reader.cpp
++++ b/src/storage/ducklake_multi_file_reader.cpp
+@@ -109,10 +109,11 @@ static bool CanSkipFileByTopNDynamicFilter(const DuckLakeFileListEntry &file_ent
+ 
+ 		// from here we'll try to cast and compare with the dynamic filter values
+ 		// if casts fail, just skip pruning
+-		Value casted_constant;
+-		if (!constant.DefaultTryCastAs(col_filter.column_type, casted_constant, nullptr)) {
++		auto casted_constant_opt = constant.DefaultTryCastAs(col_filter.column_type);
++		if (!casted_constant_opt) {
+ 			continue;
+ 		}
++		auto &casted_constant = *casted_constant_opt;
+ 
+ 		switch (comparison_type) {
+ 		case ExpressionType::COMPARE_GREATERTHAN:
+@@ -121,14 +122,14 @@ static bool CanSkipFileByTopNDynamicFilter(const DuckLakeFileListEntry &file_ent
+ 			if (max_str.empty()) {
+ 				continue;
+ 			}
+-			Value file_max;
+-			if (!Value(max_str).DefaultTryCastAs(col_filter.column_type, file_max, nullptr)) {
++			auto file_max = Value(max_str).DefaultTryCastAs(col_filter.column_type);
++			if (!file_max) {
+ 				continue;
+ 			}
+ 			if (comparison_type == ExpressionType::COMPARE_GREATERTHAN) {
+-				return !(file_max > casted_constant);
++				return !(*file_max > casted_constant);
+ 			}
+-			return !(file_max >= casted_constant);
++			return !(*file_max >= casted_constant);
+ 		}
+ 		case ExpressionType::COMPARE_LESSTHAN:
+ 		case ExpressionType::COMPARE_LESSTHANOREQUALTO: {
+@@ -136,14 +137,14 @@ static bool CanSkipFileByTopNDynamicFilter(const DuckLakeFileListEntry &file_ent
+ 			if (min_str.empty()) {
+ 				continue;
+ 			}
+-			Value file_min;
+-			if (!Value(min_str).DefaultTryCastAs(col_filter.column_type, file_min, nullptr)) {
++			auto file_min = Value(min_str).DefaultTryCastAs(col_filter.column_type);
++			if (!file_min) {
+ 				continue;
+ 			}
+ 			if (comparison_type == ExpressionType::COMPARE_LESSTHAN) {
+-				return !(file_min < casted_constant);
++				return !(*file_min < casted_constant);
+ 			}
+-			return !(file_min <= casted_constant);
++			return !(*file_min <= casted_constant);
+ 		}
+ 		default:
+ 			// nothing to prune
+diff --git a/src/storage/ducklake_table_entry.cpp b/src/storage/ducklake_table_entry.cpp
+index 2f75aeb7..d9eaf3a4 100644
+--- a/src/storage/ducklake_table_entry.cpp
++++ b/src/storage/ducklake_table_entry.cpp
+@@ -554,11 +554,11 @@ DuckLakePartitionField GetPartitionField(DuckLakeTableEntry &table, ParsedExpres
+ 			}
+ 
+ 			auto &bucket_expr = args[0].GetExpressionMutable()->Cast<ConstantExpression>();
+-			auto bucket_value = bucket_expr.GetValue();
+-			if (!bucket_value.DefaultTryCastAs(LogicalType::BIGINT)) {
++			auto bucket_value = bucket_expr.GetValue().DefaultTryCastAs(LogicalType::BIGINT);
++			if (!bucket_value) {
+ 				throw InvalidInputException("Bucket count must be an integer");
+ 			}
+-			auto bucket_count = bucket_value.GetValue<int64_t>();
++			auto bucket_count = bucket_value->GetValue<int64_t>();
+ 			if (bucket_count <= 0) {
+ 				throw InvalidInputException("Bucket count must be positive");
+ 			}

--- a/.github/patches/extensions/excel/0007-value-optional-trycast.patch
+++ b/.github/patches/extensions/excel/0007-value-optional-trycast.patch
@@ -1,0 +1,42 @@
+diff --git a/src/excel/xlsx/copy_xlsx.cpp b/src/excel/xlsx/copy_xlsx.cpp
+index 324c9ba..7d2415a 100644
+--- a/src/excel/xlsx/copy_xlsx.cpp
++++ b/src/excel/xlsx/copy_xlsx.cpp
+@@ -95,14 +95,14 @@ static void ParseCopyToOptions(const unique_ptr<WriteXLSXData> &data,
+ 			throw BinderException("Header option must be a single boolean value");
+ 		}
+ 		string error_msg;
+-		Value bool_val;
+-		if (!header_opt->second.back().DefaultTryCastAs(LogicalType::BOOLEAN, bool_val, &error_msg)) {
++		auto bool_val = header_opt->second.back().DefaultTryCastAs(LogicalType::BOOLEAN, &error_msg);
++		if (!bool_val) {
+ 			throw BinderException("Header option must be a single boolean value");
+ 		}
+-		if (bool_val.IsNull()) {
++		if (bool_val->IsNull()) {
+ 			throw BinderException("Header option must be a single boolean value");
+ 		}
+-		data->header = BooleanValue::Get(bool_val);
++		data->header = BooleanValue::Get(*bool_val);
+ 	} else {
+ 		data->header = false;
+ 	}
+@@ -131,14 +131,14 @@ static void ParseCopyToOptions(const unique_ptr<WriteXLSXData> &data,
+ 			throw BinderException("Sheet row limit option must be a single integer value");
+ 		}
+ 		string error_msg;
+-		Value int_val;
+-		if (!sheet_row_limit_opt->second.back().DefaultTryCastAs(LogicalType::INTEGER, int_val, &error_msg)) {
++		auto int_val = sheet_row_limit_opt->second.back().DefaultTryCastAs(LogicalType::INTEGER, &error_msg);
++		if (!int_val) {
+ 			throw BinderException("Sheet row limit option must be a single integer value");
+ 		}
+-		if (int_val.IsNull()) {
++		if (int_val->IsNull()) {
+ 			throw BinderException("Sheet row limit option must be a single integer value");
+ 		}
+-		data->sheet_row_limit = IntegerValue::Get(int_val);
++		data->sheet_row_limit = IntegerValue::Get(*int_val);
+ 	} else {
+ 		data->sheet_row_limit = XLSX_MAX_CELL_ROWS;
+ 	}

--- a/.github/patches/extensions/iceberg/0007-value-optional-trycast.patch
+++ b/.github/patches/extensions/iceberg/0007-value-optional-trycast.patch
@@ -7,20 +7,20 @@ index 50de71c7..3e312551 100644
  
  			if (StringUtil::CIEquals(key, "format-version")) {
 -				if (!val.DefaultTryCastAs(LogicalType::INTEGER, true)) {
-+				auto casted_val = val.DefaultTryCastAs(LogicalType::INTEGER, nullptr, true);
-+				if (!casted_val) {
++				auto cast_val = val.DefaultTryCastAs(LogicalType::INTEGER, nullptr, true);
++				if (!cast_val) {
  					throw InvalidInputException("Can't cast 'format-version' property (%s) to INTEGER", val.ToString());
  				}
 -				new_format_version = val.GetValue<int32_t>();
-+				new_format_version = casted_val->GetValue<int32_t>();
++				new_format_version = cast_val->GetValue<int32_t>();
  			} else {
 -				if (!val.DefaultTryCastAs(LogicalType::VARCHAR, true)) {
-+				auto casted_val = val.DefaultTryCastAs(LogicalType::VARCHAR, nullptr, true);
-+				if (!casted_val) {
++				auto cast_val = val.DefaultTryCastAs(LogicalType::VARCHAR, nullptr, true);
++				if (!cast_val) {
  					throw InvalidInputException("Can't cast '%s' property (%s) to VARCHAR", key, val.ToString());
  				}
 -				new_properties[key] = val.GetValue<string>();
-+				new_properties[key] = casted_val->GetValue<string>();
++				new_properties[key] = cast_val->GetValue<string>();
  			}
  		}
  
@@ -33,13 +33,13 @@ index df426e28..6fc1cd26 100644
  		throw BinderException("NULL is not supported as a valid option for '%s'", property_name);
  	}
 -	if (!val.DefaultTryCastAs(type, true)) {
-+	auto casted_val = val.DefaultTryCastAs(type, nullptr, true);
-+	if (!casted_val) {
++	auto cast_val = val.DefaultTryCastAs(type, nullptr, true);
++	if (!cast_val) {
  		throw InvalidInputException("Can't cast '%s' property (%s) to %s", property_name, val.ToString(),
  		                            type.ToString());
  	}
 -	return val;
-+	return std::move(*casted_val);
++	return std::move(*cast_val);
  }
  
  shared_ptr<IcebergTableInformation>

--- a/.github/patches/extensions/iceberg/0007-value-optional-trycast.patch
+++ b/.github/patches/extensions/iceberg/0007-value-optional-trycast.patch
@@ -7,20 +7,20 @@ index 50de71c7..3e312551 100644
  
  			if (StringUtil::CIEquals(key, "format-version")) {
 -				if (!val.DefaultTryCastAs(LogicalType::INTEGER, true)) {
-+				auto cast_val = val.DefaultTryCastAs(LogicalType::INTEGER, nullptr, true);
-+				if (!cast_val) {
++				auto casted_val = val.DefaultTryCastAs(LogicalType::INTEGER, nullptr, true);
++				if (!casted_val) {
  					throw InvalidInputException("Can't cast 'format-version' property (%s) to INTEGER", val.ToString());
  				}
 -				new_format_version = val.GetValue<int32_t>();
-+				new_format_version = cast_val->GetValue<int32_t>();
++				new_format_version = casted_val->GetValue<int32_t>();
  			} else {
 -				if (!val.DefaultTryCastAs(LogicalType::VARCHAR, true)) {
-+				auto cast_val = val.DefaultTryCastAs(LogicalType::VARCHAR, nullptr, true);
-+				if (!cast_val) {
++				auto casted_val = val.DefaultTryCastAs(LogicalType::VARCHAR, nullptr, true);
++				if (!casted_val) {
  					throw InvalidInputException("Can't cast '%s' property (%s) to VARCHAR", key, val.ToString());
  				}
 -				new_properties[key] = val.GetValue<string>();
-+				new_properties[key] = cast_val->GetValue<string>();
++				new_properties[key] = casted_val->GetValue<string>();
  			}
  		}
  
@@ -33,16 +33,30 @@ index df426e28..6fc1cd26 100644
  		throw BinderException("NULL is not supported as a valid option for '%s'", property_name);
  	}
 -	if (!val.DefaultTryCastAs(type, true)) {
-+	auto cast_val = val.DefaultTryCastAs(type, nullptr, true);
-+	if (!cast_val) {
++	auto casted_val = val.DefaultTryCastAs(type, nullptr, true);
++	if (!casted_val) {
  		throw InvalidInputException("Can't cast '%s' property (%s) to %s", property_name, val.ToString(),
  		                            type.ToString());
  	}
 -	return val;
-+	return std::move(*cast_val);
++	return std::move(*casted_val);
  }
  
  shared_ptr<IcebergTableInformation>
+diff --git a/src/core/expression/iceberg_hash.cpp b/src/core/expression/iceberg_hash.cpp
+index b9ca3811..985cc289 100644
+--- a/src/core/expression/iceberg_hash.cpp
++++ b/src/core/expression/iceberg_hash.cpp
+@@ -324,8 +324,7 @@ Value IcebergHash::TruncateValue(const Value &v, idx_t width) {
+ 	}
+ 	case LogicalTypeId::DECIMAL: {
+ 		// Truncate the unscaled integer value, preserving type (scale/precision)
+-		auto scaled = v.Copy();
+-		scaled.Reinterpret(LogicalType::BIGINT);
++		auto scaled = v.WithType(LogicalType::BIGINT);
+ 		auto val = scaled.GetValue<int64_t>();
+ 		auto result = val - (((val % W) + W) % W);
+ 		return Value::DECIMAL(result, DecimalType::GetWidth(v.type()), DecimalType::GetScale(v.type()));
 diff --git a/src/core/metadata/manifest/iceberg_manifest.cpp b/src/core/metadata/manifest/iceberg_manifest.cpp
 index 5e30a09a..3c5468a2 100644
 --- a/src/core/metadata/manifest/iceberg_manifest.cpp

--- a/.github/patches/extensions/iceberg/0007-value-optional-trycast.patch
+++ b/.github/patches/extensions/iceberg/0007-value-optional-trycast.patch
@@ -1,0 +1,144 @@
+diff --git a/src/catalog/rest/catalog_entry/schema/iceberg_schema_entry.cpp b/src/catalog/rest/catalog_entry/schema/iceberg_schema_entry.cpp
+index 50de71c7..3e312551 100644
+--- a/src/catalog/rest/catalog_entry/schema/iceberg_schema_entry.cpp
++++ b/src/catalog/rest/catalog_entry/schema/iceberg_schema_entry.cpp
+@@ -600,15 +600,17 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info)
+ 			}
+ 
+ 			if (StringUtil::CIEquals(key, "format-version")) {
+-				if (!val.DefaultTryCastAs(LogicalType::INTEGER, true)) {
++				auto casted_val = val.DefaultTryCastAs(LogicalType::INTEGER, nullptr, true);
++				if (!casted_val) {
+ 					throw InvalidInputException("Can't cast 'format-version' property (%s) to INTEGER", val.ToString());
+ 				}
+-				new_format_version = val.GetValue<int32_t>();
++				new_format_version = casted_val->GetValue<int32_t>();
+ 			} else {
+-				if (!val.DefaultTryCastAs(LogicalType::VARCHAR, true)) {
++				auto casted_val = val.DefaultTryCastAs(LogicalType::VARCHAR, nullptr, true);
++				if (!casted_val) {
+ 					throw InvalidInputException("Can't cast '%s' property (%s) to VARCHAR", key, val.ToString());
+ 				}
+-				new_properties[key] = val.GetValue<string>();
++				new_properties[key] = casted_val->GetValue<string>();
+ 			}
+ 		}
+ 
+diff --git a/src/catalog/rest/iceberg_table_set.cpp b/src/catalog/rest/iceberg_table_set.cpp
+index df426e28..6fc1cd26 100644
+--- a/src/catalog/rest/iceberg_table_set.cpp
++++ b/src/catalog/rest/iceberg_table_set.cpp
+@@ -160,11 +160,12 @@ static Value ParseTableProperty(TableFunctionBinder &binder, ClientContext &cont
+ 	if (val.IsNull()) {
+ 		throw BinderException("NULL is not supported as a valid option for '%s'", property_name);
+ 	}
+-	if (!val.DefaultTryCastAs(type, true)) {
++	auto casted_val = val.DefaultTryCastAs(type, nullptr, true);
++	if (!casted_val) {
+ 		throw InvalidInputException("Can't cast '%s' property (%s) to %s", property_name, val.ToString(),
+ 		                            type.ToString());
+ 	}
+-	return val;
++	return std::move(*casted_val);
+ }
+ 
+ shared_ptr<IcebergTableInformation>
+diff --git a/src/core/metadata/manifest/iceberg_manifest.cpp b/src/core/metadata/manifest/iceberg_manifest.cpp
+index 5e30a09a..3c5468a2 100644
+--- a/src/core/metadata/manifest/iceberg_manifest.cpp
++++ b/src/core/metadata/manifest/iceberg_manifest.cpp
+@@ -505,13 +505,13 @@ static void WritePartitionValue(Vector &vector, idx_t row_idx, const Value &valu
+ 		FlatVector::SetNull(vector, row_idx, true);
+ 		return;
+ 	}
+-	Value cast_value;
+ 	string error_message;
+-	if (!value.DefaultTryCastAs(vector.GetType(), cast_value, &error_message, true)) {
++	auto cast_value = value.DefaultTryCastAs(vector.GetType(), &error_message, true);
++	if (!cast_value) {
+ 		throw InvalidInputException("Could not cast partition value %s to %s", value.type().ToString(),
+ 		                            vector.GetType().ToString());
+ 	}
+-	vector.SetValue(row_idx, cast_value);
++	vector.SetValue(row_idx, *cast_value);
+ }
+ 
+ static void WritePartitionStructRow(Vector &partition_vector, idx_t row_idx, const IcebergDataFile &data_file,
+diff --git a/src/execution/helpers/equality_delete_helpers.cpp b/src/execution/helpers/equality_delete_helpers.cpp
+index 2f09c1d0..6a8f1d43 100644
+--- a/src/execution/helpers/equality_delete_helpers.cpp
++++ b/src/execution/helpers/equality_delete_helpers.cpp
+@@ -321,12 +321,12 @@ bool IcebergDelete::TryGetEqualityDeletePredicates(ClientContext &context, Icebe
+ 		predicate.column_name = column_definition->name;
+ 		predicate.type = column_definition->type;
+ 		for (auto &raw_value : raw_values) {
+-			Value delete_value;
+ 			string error_message;
+-			if (!raw_value.DefaultTryCastAs(column_definition->type, delete_value, &error_message, true)) {
++			auto delete_value = raw_value.DefaultTryCastAs(column_definition->type, &error_message, true);
++			if (!delete_value) {
+ 				return false;
+ 			}
+-			predicate.values.push_back(std::move(delete_value));
++			predicate.values.push_back(std::move(*delete_value));
+ 		}
+ 		equality_predicates.push_back(std::move(predicate));
+ 	}
+diff --git a/src/storage/statistics/iceberg_variant_statistics.cpp b/src/storage/statistics/iceberg_variant_statistics.cpp
+index 8f14976c..50fc11c7 100644
+--- a/src/storage/statistics/iceberg_variant_statistics.cpp
++++ b/src/storage/statistics/iceberg_variant_statistics.cpp
+@@ -96,13 +96,13 @@ static string BuildJsonPath(const vector<string> &field_names) {
+ //! Serialize a bounds object (a struct keyed by JSON path) to the parquet-variant encoding by casting
+ //! it to VARIANT and calling variant_to_parquet_variant, then concatenating the metadata and value blobs.
+ static optional<string> SerializeBoundsVariant(ClientContext &context, Value bounds_struct) {
+-	Value variant_value;
+-	if (!bounds_struct.DefaultTryCastAs(LogicalType::VARIANT(), variant_value, nullptr)) {
++	auto variant_value = bounds_struct.DefaultTryCastAs(LogicalType::VARIANT());
++	if (!variant_value) {
+ 		return std::nullopt;
+ 	}
+ 
+ 	vector<unique_ptr<Expression>> children;
+-	children.push_back(make_uniq<BoundConstantExpression>(std::move(variant_value)));
++	children.push_back(make_uniq<BoundConstantExpression>(std::move(*variant_value)));
+ 
+ 	ErrorData error;
+ 	FunctionBinder binder(context);
+@@ -232,15 +232,15 @@ bool IcebergVariantBounds::Finalize(ClientContext &context, optional<string> &lo
+ 			continue;
+ 		}
+ 		if (field.min_value) {
+-			Value typed;
+-			if (Value(*field.min_value).DefaultTryCastAs(leaf_type, typed, nullptr)) {
+-				lower_children.emplace_back(json_path, std::move(typed));
++			auto typed = Value(*field.min_value).DefaultTryCastAs(leaf_type);
++			if (typed) {
++				lower_children.emplace_back(json_path, std::move(*typed));
+ 			}
+ 		}
+ 		if (field.max_value) {
+-			Value typed;
+-			if (Value(*field.max_value).DefaultTryCastAs(leaf_type, typed, nullptr)) {
+-				upper_children.emplace_back(json_path, std::move(typed));
++			auto typed = Value(*field.max_value).DefaultTryCastAs(leaf_type);
++			if (typed) {
++				upper_children.emplace_back(json_path, std::move(*typed));
+ 			}
+ 		}
+ 	}
+@@ -381,11 +381,11 @@ bool IcebergVariantBoundsReader::RekeyBoundsVariant(const Value &bounds_variant,
+ 	}
+ 
+ 	Value nested_struct = NodeToValue(root);
+-	Value variant_result;
+-	if (!nested_struct.DefaultTryCastAs(LogicalType::VARIANT(), variant_result, nullptr)) {
++	auto variant_result = nested_struct.DefaultTryCastAs(LogicalType::VARIANT());
++	if (!variant_result) {
+ 		return false;
+ 	}
+-	result = std::move(variant_result);
++	result = std::move(*variant_result);
+ 	return true;
+ }
+ 

--- a/.github/patches/extensions/inet/0008-immutable-logical-type.patch
+++ b/.github/patches/extensions/inet/0008-immutable-logical-type.patch
@@ -1,0 +1,15 @@
+diff --git a/src/inet_extension.cpp b/src/inet_extension.cpp
+index 46d916c..5c45e96 100644
+--- a/src/inet_extension.cpp
++++ b/src/inet_extension.cpp
+@@ -24,8 +24,8 @@ static void LoadInternal(ExtensionLoader &loader) {
+   // versions.
+   children.emplace_back(make_pair("address", LogicalType::HUGEINT));
+   children.emplace_back(make_pair("mask", LogicalType::USMALLINT));
+-  auto inet_type = LogicalType::STRUCT(std::move(children));
+-  inet_type.SetAlias(INET_TYPE_NAME);
++  auto inet_type =
++      LogicalType::STRUCT(std::move(children)).WithAlias(INET_TYPE_NAME);
+   loader.RegisterType(INET_TYPE_NAME, inet_type);
+ 
+   // add the casts to and from INET type

--- a/.github/patches/extensions/mysql_scanner/0016-value-optional-trycast.patch
+++ b/.github/patches/extensions/mysql_scanner/0016-value-optional-trycast.patch
@@ -1,0 +1,108 @@
+diff --git a/src/mysql_sql_writer.cpp b/src/mysql_sql_writer.cpp
+index 867aa85..70233b2 100644
+--- a/src/mysql_sql_writer.cpp
++++ b/src/mysql_sql_writer.cpp
+@@ -483,13 +483,13 @@ string MySQLSQLWriter::WriteExpression(const ParsedExpression &expr) {
+ 			if (target_type.id() == LogicalTypeId::UNBOUND) {
+ 				target_type = UnboundType::TryDefaultBind(target_type);
+ 			}
+-			Value cast_result;
+ 			string error;
+-			if (!value.DefaultTryCastAs(target_type, cast_result, &error)) {
++			auto cast_result = value.DefaultTryCastAs(target_type, &error);
++			if (!cast_result) {
+ 				throw InternalException("MySQLSQLWriter: cast of literal failed - should have been blocked by "
+ 				                        "SupportsPushdown");
+ 			}
+-			return WriteConstant(cast_result);
++			return WriteConstant(*cast_result);
+ 		}
+ 		return "CAST(" + WriteExpression(cast_expr.Child()) + " AS " + WriteCastType(cast_expr.TargetType()) + ")";
+ 	}
+@@ -602,10 +602,10 @@ string MySQLSQLWriter::WriteOrderList(const vector<OrderByNode> &orders,
+ 			if (val.type().IsIntegral() && !val.IsNull() && select_list) {
+ 				// positional reference (e.g. ORDER BY 1) - resolve it against the select list
+ 				// SupportsPushdown verifies that this resolution is possible
+-				Value bigint_value;
+ 				string error;
+-				if (val.DefaultTryCastAs(LogicalType::BIGINT, bigint_value, &error) && !bigint_value.IsNull()) {
+-					auto index = BigIntValue::Get(bigint_value);
++				auto bigint_value = val.DefaultTryCastAs(LogicalType::BIGINT, &error);
++				if (bigint_value && !bigint_value->IsNull()) {
++					auto index = BigIntValue::Get(*bigint_value);
+ 					if (index >= 1 && idx_t(index) <= select_list->size()) {
+ 						auto &target = *(*select_list)[idx_t(index) - 1];
+ 						// reference the output column by its alias where possible - expressions over
+diff --git a/src/storage/mysql_catalog.cpp b/src/storage/mysql_catalog.cpp
+index 4f825a0..1b11f54 100644
+--- a/src/storage/mysql_catalog.cpp
++++ b/src/storage/mysql_catalog.cpp
+@@ -972,12 +972,12 @@ static bool MySQLSupportsOrderEntries(const vector<OrderByNode> &orders,
+ 				if (!select_list || val.IsNull()) {
+ 					return false;
+ 				}
+-				Value bigint_value;
+ 				string error;
+-				if (!val.DefaultTryCastAs(LogicalType::BIGINT, bigint_value, &error) || bigint_value.IsNull()) {
++				auto bigint_value = val.DefaultTryCastAs(LogicalType::BIGINT, &error);
++				if (!bigint_value || bigint_value->IsNull()) {
+ 					return false;
+ 				}
+-				auto index = BigIntValue::Get(bigint_value);
++				auto index = BigIntValue::Get(*bigint_value);
+ 				if (index < 1 || idx_t(index) > select_list->size()) {
+ 					return false;
+ 				}
+@@ -1006,12 +1006,12 @@ static bool MySQLIsIntegerLiteralAtLeast(const ParsedExpression &expr, int64_t m
+ 		return false;
+ 	}
+ 	auto &val = expr.Cast<ConstantExpression>().GetValue();
+-	Value bigint_value;
+ 	string error;
+-	if (!val.DefaultTryCastAs(LogicalType::BIGINT, bigint_value, &error) || bigint_value.IsNull()) {
++	auto bigint_value = val.DefaultTryCastAs(LogicalType::BIGINT, &error);
++	if (!bigint_value || bigint_value->IsNull()) {
+ 		return false;
+ 	}
+-	return BigIntValue::Get(bigint_value) >= minimum_value;
++	return BigIntValue::Get(*bigint_value) >= minimum_value;
+ }
+ 
+ static bool MySQLIsIntegerLiteralAtMost(const ParsedExpression &expr, int64_t maximum_value) {
+@@ -1019,12 +1019,12 @@ static bool MySQLIsIntegerLiteralAtMost(const ParsedExpression &expr, int64_t ma
+ 		return false;
+ 	}
+ 	auto &val = expr.Cast<ConstantExpression>().GetValue();
+-	Value bigint_value;
+ 	string error;
+-	if (!val.DefaultTryCastAs(LogicalType::BIGINT, bigint_value, &error) || bigint_value.IsNull()) {
++	auto bigint_value = val.DefaultTryCastAs(LogicalType::BIGINT, &error);
++	if (!bigint_value || bigint_value->IsNull()) {
+ 		return false;
+ 	}
+-	return BigIntValue::Get(bigint_value) <= maximum_value;
++	return BigIntValue::Get(*bigint_value) <= maximum_value;
+ }
+ 
+ static bool MySQLSupportsResultModifiers(const QueryNode &node,
+@@ -1218,16 +1218,16 @@ bool MySQLCatalog::SupportsPushdown(const ParsedExpression &expr) {
+ 			if (target_type.id() == LogicalTypeId::UNBOUND) {
+ 				target_type = UnboundType::TryDefaultBind(target_type);
+ 			}
+-			Value cast_result;
+ 			string error;
+-			if (!value.DefaultTryCastAs(target_type, cast_result, &error)) {
++			auto cast_result = value.DefaultTryCastAs(target_type, &error);
++			if (!cast_result) {
+ 				return false;
+ 			}
+ 			// the cast result must also be representable in MySQL
+-			if (!MySQLSupportsValue(cast_result)) {
++			if (!MySQLSupportsValue(*cast_result)) {
+ 				return false;
+ 			}
+-			if (cast_result.type().id() == LogicalTypeId::VARCHAR && version.GetBinaryCollation().empty()) {
++			if (cast_result->type().id() == LogicalTypeId::VARCHAR && version.GetBinaryCollation().empty()) {
+ 				// the folded result is serialized as a string literal, which requires a binary collation
+ 				return false;
+ 			}

--- a/.github/patches/extensions/postgres_scanner/0004-immutable-logical-type.patch
+++ b/.github/patches/extensions/postgres_scanner/0004-immutable-logical-type.patch
@@ -1,0 +1,48 @@
+diff --git a/src/postgres_utils.cpp b/src/postgres_utils.cpp
+index de683b6..f3d405d 100644
+--- a/src/postgres_utils.cpp
++++ b/src/postgres_utils.cpp
+@@ -371,9 +371,7 @@ LogicalType PostgresUtils::ToPostgresType(const LogicalType &input) {
+ 			auto &type = StructType::GetChildType(input, c);
+ 			new_types.push_back(make_pair(name, ToPostgresType(type)));
+ 		}
+-		auto result = LogicalType::STRUCT(std::move(new_types));
+-		result.SetAlias(input.GetAlias());
+-		return result;
++		return LogicalType::STRUCT(std::move(new_types)).WithAlias(input.GetAlias());
+ 	}
+ 	case LogicalTypeId::TIMESTAMP_SEC:
+ 	case LogicalTypeId::TIMESTAMP_MS:
+diff --git a/src/storage/postgres_type_set.cpp b/src/storage/postgres_type_set.cpp
+index c92f25c..3d5105d 100644
+--- a/src/storage/postgres_type_set.cpp
++++ b/src/storage/postgres_type_set.cpp
+@@ -60,8 +60,7 @@ void PostgresTypeSet::CreateEnum(PostgresTransaction &transaction, PostgresResul
+ 	for (idx_t enum_idx = 0; enum_idx < enum_count; enum_idx++) {
+ 		duckdb_levels.SetValue(enum_idx, result.GetString(start_row + enum_idx, 3));
+ 	}
+-	info.type = LogicalType::ENUM(duckdb_levels, enum_count);
+-	info.type.SetAlias(info.GetTypeName().GetIdentifierName());
++	info.type = LogicalType::ENUM(duckdb_levels, enum_count).WithAlias(info.GetTypeName().GetIdentifierName());
+ 	auto type_entry = make_shared_ptr<PostgresTypeEntry>(catalog, schema, info, postgres_type);
+ 	CreateEntry(transaction, std::move(type_entry));
+ }
+@@ -128,8 +127,7 @@ void PostgresTypeSet::CreateCompositeType(PostgresTransaction &transaction, Post
+ 		    Identifier(type_name), PostgresUtils::TypeToLogicalType(&transaction, &schema, type_data, child_type)));
+ 		postgres_type.children.push_back(std::move(child_type));
+ 	}
+-	info.type = LogicalType::STRUCT(std::move(child_types));
+-	info.type.SetAlias(info.GetTypeName().GetIdentifierName());
++	info.type = LogicalType::STRUCT(std::move(child_types)).WithAlias(info.GetTypeName().GetIdentifierName());
+ 	auto type_entry = make_shared_ptr<PostgresTypeEntry>(catalog, schema, info, postgres_type);
+ 	CreateEntry(transaction, std::move(type_entry));
+ }
+@@ -207,7 +205,7 @@ optional_ptr<CatalogEntry> PostgresTypeSet::CreateType(PostgresTransaction &tran
+ 
+ 	auto create_sql = GetCreateTypeSQL(info);
+ 	conn.Execute(transaction.GetContext(), create_sql);
+-	info.type.SetAlias(info.GetTypeName().GetIdentifierName());
++	info.type = info.type.WithAlias(info.GetTypeName().GetIdentifierName());
+ 	auto pg_type = PostgresUtils::CreateEmptyPostgresType(info.type);
+ 	auto type_entry = make_shared_ptr<PostgresTypeEntry>(catalog, schema, info, pg_type);
+ 	return CreateEntry(transaction, std::move(type_entry));

--- a/.github/patches/extensions/spatial/0005-immutable-logical-type.patch
+++ b/.github/patches/extensions/spatial/0005-immutable-logical-type.patch
@@ -1,0 +1,145 @@
+diff --git a/src/spatial/modules/shapefile/shapefile_module.cpp b/src/spatial/modules/shapefile/shapefile_module.cpp
+index f12d1eb..6ef8fb5 100644
+--- a/src/spatial/modules/shapefile/shapefile_module.cpp
++++ b/src/spatial/modules/shapefile/shapefile_module.cpp
+@@ -966,8 +966,8 @@ struct Shapefile_Meta {
+ 			auto str = string_t(shape_type_map[i].shp_name);
+ 			varchar_data[i] = str.IsInlined() ? str : StringVector::AddString(varchar_vector, str);
+ 		}
+-		auto shape_type_enum = LogicalType::ENUM("SHAPE_TYPE", varchar_vector, shape_type_count);
+-		shape_type_enum.SetAlias("SHAPE_TYPE");
++		auto shape_type_enum =
++		    LogicalType::ENUM("SHAPE_TYPE", varchar_vector, shape_type_count).WithAlias("SHAPE_TYPE");
+ 
+ 		return_types.push_back(LogicalType::VARCHAR);
+ 		return_types.push_back(shape_type_enum);
+diff --git a/src/spatial/modules/wkb/wkb_module.cpp b/src/spatial/modules/wkb/wkb_module.cpp
+index 43e7d1a..5395fca 100644
+--- a/src/spatial/modules/wkb/wkb_module.cpp
++++ b/src/spatial/modules/wkb/wkb_module.cpp
+@@ -11,9 +11,7 @@ namespace {
+ struct WKBTypes {
+ 
+ 	static LogicalType WKB_BLOB() {
+-		auto blob_type = LogicalType(LogicalTypeId::BLOB);
+-		blob_type.SetAlias("WKB_BLOB");
+-		return blob_type;
++		return LogicalType(LogicalTypeId::BLOB).WithAlias("WKB_BLOB");
+ 	}
+ 
+ 	static bool ToWKBCast(Vector &source, Vector &result, idx_t count, CastParameters &) {
+diff --git a/src/spatial/spatial_types.cpp b/src/spatial/spatial_types.cpp
+index d98b266..e4ee52f 100644
+--- a/src/spatial/spatial_types.cpp
++++ b/src/spatial/spatial_types.cpp
+@@ -7,70 +7,59 @@
+ namespace duckdb {
+ 
+ LogicalType GeoTypes::POINT_2D() {
+-	auto type = LogicalType::STRUCT({{"x", LogicalType::DOUBLE}, {"y", LogicalType::DOUBLE}});
+-	type.SetAlias("POINT_2D");
+-	return type;
++	return LogicalType::STRUCT({{"x", LogicalType::DOUBLE}, {"y", LogicalType::DOUBLE}}).WithAlias("POINT_2D");
+ }
+ 
+ LogicalType GeoTypes::POINT_3D() {
+-	auto type =
+-	    LogicalType::STRUCT({{"x", LogicalType::DOUBLE}, {"y", LogicalType::DOUBLE}, {"z", LogicalType::DOUBLE}});
+-	type.SetAlias("POINT_3D");
+-	return type;
++	return LogicalType::STRUCT({{"x", LogicalType::DOUBLE}, {"y", LogicalType::DOUBLE}, {"z", LogicalType::DOUBLE}})
++	    .WithAlias("POINT_3D");
+ }
+ 
+ LogicalType GeoTypes::POINT_4D() {
+-	auto type = LogicalType::STRUCT({{"x", LogicalType::DOUBLE},
+-	                                 {"y", LogicalType::DOUBLE},
+-	                                 {"z", LogicalType::DOUBLE},
+-	                                 {"m", LogicalType::DOUBLE}});
+-	type.SetAlias("POINT_4D");
+-	return type;
++	return LogicalType::STRUCT({{"x", LogicalType::DOUBLE},
++	                            {"y", LogicalType::DOUBLE},
++	                            {"z", LogicalType::DOUBLE},
++	                            {"m", LogicalType::DOUBLE}})
++	    .WithAlias("POINT_4D");
+ }
+ 
+ LogicalType GeoTypes::BOX_2D() {
+-	auto type = LogicalType::STRUCT({{"min_x", LogicalType::DOUBLE},
+-	                                 {"min_y", LogicalType::DOUBLE},
+-	                                 {"max_x", LogicalType::DOUBLE},
+-	                                 {"max_y", LogicalType::DOUBLE}});
+-	type.SetAlias("BOX_2D");
+-	return type;
++	return LogicalType::STRUCT({{"min_x", LogicalType::DOUBLE},
++	                            {"min_y", LogicalType::DOUBLE},
++	                            {"max_x", LogicalType::DOUBLE},
++	                            {"max_y", LogicalType::DOUBLE}})
++	    .WithAlias("BOX_2D");
+ }
+ 
+ LogicalType GeoTypes::BOX_2DF() {
+-	auto type = LogicalType::STRUCT({{"min_x", LogicalType::FLOAT},
+-	                                 {"min_y", LogicalType::FLOAT},
+-	                                 {"max_x", LogicalType::FLOAT},
+-	                                 {"max_y", LogicalType::FLOAT}});
+-	type.SetAlias("BOX_2DF");
+-	return type;
++	return LogicalType::STRUCT({{"min_x", LogicalType::FLOAT},
++	                            {"min_y", LogicalType::FLOAT},
++	                            {"max_x", LogicalType::FLOAT},
++	                            {"max_y", LogicalType::FLOAT}})
++	    .WithAlias("BOX_2DF");
+ }
+ 
+ LogicalType GeoTypes::LINESTRING_2D() {
+-	auto type = LogicalType::LIST(LogicalType::STRUCT({{"x", LogicalType::DOUBLE}, {"y", LogicalType::DOUBLE}}));
+-	type.SetAlias("LINESTRING_2D");
+-	return type;
++	return LogicalType::LIST(LogicalType::STRUCT({{"x", LogicalType::DOUBLE}, {"y", LogicalType::DOUBLE}}))
++	    .WithAlias("LINESTRING_2D");
+ }
+ 
+ LogicalType GeoTypes::LINESTRING_3D() {
+-	auto type = LogicalType::LIST(
+-	    LogicalType::STRUCT({{"x", LogicalType::DOUBLE}, {"y", LogicalType::DOUBLE}, {"z", LogicalType::DOUBLE}}));
+-	type.SetAlias("LINESTRING_3D");
+-	return type;
++	return LogicalType::LIST(LogicalType::STRUCT(
++	                             {{"x", LogicalType::DOUBLE}, {"y", LogicalType::DOUBLE}, {"z", LogicalType::DOUBLE}}))
++	    .WithAlias("LINESTRING_3D");
+ }
+ 
+ LogicalType GeoTypes::POLYGON_2D() {
+-	auto type = LogicalType::LIST(
+-	    LogicalType::LIST(LogicalType::STRUCT({{"x", LogicalType::DOUBLE}, {"y", LogicalType::DOUBLE}})));
+-	type.SetAlias("POLYGON_2D");
+-	return type;
++	return LogicalType::LIST(
++	           LogicalType::LIST(LogicalType::STRUCT({{"x", LogicalType::DOUBLE}, {"y", LogicalType::DOUBLE}})))
++	    .WithAlias("POLYGON_2D");
+ }
+ 
+ LogicalType GeoTypes::POLYGON_3D() {
+-	auto type = LogicalType::LIST(LogicalType::LIST(
+-	    LogicalType::STRUCT({{"x", LogicalType::DOUBLE}, {"y", LogicalType::DOUBLE}, {"z", LogicalType::DOUBLE}})));
+-	type.SetAlias("POLYGON_3D");
+-	return type;
++	return LogicalType::LIST(LogicalType::LIST(LogicalType::STRUCT(
++	                             {{"x", LogicalType::DOUBLE}, {"y", LogicalType::DOUBLE}, {"z", LogicalType::DOUBLE}})))
++	    .WithAlias("POLYGON_3D");
+ }
+ 
+ LogicalType GeoTypes::CreateEnumType(const string &name, const vector<string> &members) {
+@@ -80,9 +69,7 @@ LogicalType GeoTypes::CreateEnumType(const string &name, const vector<string> &m
+ 		auto str = string_t(members[i]);
+ 		varchar_data[i] = str.IsInlined() ? str : StringVector::AddString(varchar_vector, str);
+ 	}
+-	auto enum_type = LogicalType::ENUM(name, varchar_vector, members.size());
+-	enum_type.SetAlias(name);
+-	return enum_type;
++	return LogicalType::ENUM(name, varchar_vector, members.size()).WithAlias(name);
+ }
+ 
+ static unique_ptr<FunctionData> PropagateTypesInternal(ClientContext &context, BoundSimpleFunction &bound_function,

--- a/.github/patches/extensions/unity_catalog/0003-value-optional-trycast.patch
+++ b/.github/patches/extensions/unity_catalog/0003-value-optional-trycast.patch
@@ -1,0 +1,20 @@
+diff --git a/src/storage/uc_table_set.cpp b/src/storage/uc_table_set.cpp
+index ccd4229..a8bdd46 100644
+--- a/src/storage/uc_table_set.cpp
++++ b/src/storage/uc_table_set.cpp
+@@ -27,12 +27,12 @@ static idx_t ParseDeltaVersionFromAtClause(const BoundAtClause &at_clause) {
+ 	if (at_clause.Unit() != "version") {
+ 		throw InvalidConfigurationException("Delta tables only support at_clause with unit 'version'");
+ 	}
+-	Value version_value = at_clause.GetValue();
+-	if (!version_value.DefaultTryCastAs(LogicalType::UBIGINT, false)) {
++	auto version_value = at_clause.GetValue().DefaultTryCastAs(LogicalType::UBIGINT);
++	if (!version_value) {
+ 		throw InvalidInputException("Failed to parse version number '%s' into a valid version",
+ 		                            at_clause.GetValue().ToString().c_str());
+ 	}
+-	return version_value.GetValue<idx_t>();
++	return version_value->GetValue<idx_t>();
+ }
+ 
+ UCTableSet::UCTableSet(UCSchemaEntry &schema) : catalog(schema.ParentCatalog().Cast<UnityCatalog>()), schema(schema) {

--- a/extension/json/json_functions/json_transform.cpp
+++ b/extension/json/json_functions/json_transform.cpp
@@ -83,10 +83,11 @@ static unique_ptr<FunctionData> JSONTransformBind(BindScalarFunctionInput &input
 	if (structure_val.IsNull() || arguments[1]->GetReturnType() == LogicalTypeId::SQLNULL) {
 		bound_function.SetReturnType(LogicalTypeId::SQLNULL);
 	} else {
-		if (!structure_val.DefaultTryCastAs(LogicalType::JSON())) {
+		auto json_structure_val = structure_val.DefaultTryCastAs(LogicalType::JSON());
+		if (!json_structure_val) {
 			throw BinderException("Cannot cast JSON structure to string");
 		}
-		auto structure_string = structure_val.GetValueUnsafe<string_t>();
+		auto structure_string = json_structure_val->GetValueUnsafe<string_t>();
 		JSONAllocator json_allocator(Allocator::DefaultAllocator());
 		auto doc = JSONCommon::ReadDocument(structure_string, JSONCommon::READ_FLAG, json_allocator.GetYYAlc());
 		bound_function.SetReturnType(StructureStringToType(doc->root, context));

--- a/extension/parquet/parquet_multi_file_info.cpp
+++ b/extension/parquet/parquet_multi_file_info.cpp
@@ -209,13 +209,13 @@ static bool GetBooleanArgument(const Identifier &key, const vector<Value> &optio
 	if (option_values.empty()) {
 		return true;
 	}
-	Value boolean_value;
 	string error_message;
-	if (!option_values[0].DefaultTryCastAs(LogicalType::BOOLEAN, boolean_value, &error_message)) {
+	auto boolean_value = option_values[0].DefaultTryCastAs(LogicalType::BOOLEAN, &error_message);
+	if (!boolean_value) {
 		throw InvalidInputException("Unable to cast \"%s\" to BOOLEAN for Parquet option %s",
 		                            option_values[0].ToString(), key);
 	}
-	return BooleanValue::Get(boolean_value);
+	return BooleanValue::Get(*boolean_value);
 }
 
 static bool ParquetScanPushdownExpression(ClientContext &context, const LogicalGet &get, Expression &expr) {

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1231,10 +1231,12 @@ ParquetColumnDefinition ParquetColumnDefinition::FromSchemaValue(ClientContext &
 	result.name = StringValue::Get(children[0]);
 	result.type = TransformStringToLogicalType(StringValue::Get(children[1]), context);
 	string error_message;
-	if (!children[2].TryCastAs(context, result.type, result.default_value, &error_message)) {
+	auto default_value = children[2].TryCastAs(context, result.type, &error_message);
+	if (!default_value) {
 		throw BinderException("Unable to cast Parquet schema default_value \"%s\" to %s", children[2].ToString(),
 		                      result.type.ToString());
 	}
+	result.default_value = std::move(*default_value);
 
 	return result;
 }

--- a/extension/parquet/parquet_statistics.cpp
+++ b/extension/parquet/parquet_statistics.cpp
@@ -113,13 +113,13 @@ static unique_ptr<BaseStatistics> CreateFloatingPointStats(const LogicalType &ty
 
 Value ParquetStatisticsUtils::ConvertValue(const LogicalType &type, const ParquetColumnSchema &schema_ele,
                                            const std::string &stats) {
-	Value result;
 	string error;
 	auto stats_val = ConvertValueInternal(type, schema_ele, stats);
-	if (!stats_val.DefaultTryCastAs(type, result, &error)) {
+	auto result = stats_val.DefaultTryCastAs(type, &error);
+	if (!result) {
 		return Value(type);
 	}
-	return result;
+	return std::move(*result);
 }
 Value ParquetStatisticsUtils::ConvertValueInternal(const LogicalType &type, const ParquetColumnSchema &schema_ele,
                                                    const std::string &stats) {

--- a/extension/parquet/writer/variant/convert_variant.cpp
+++ b/extension/parquet/writer/variant/convert_variant.cpp
@@ -999,9 +999,7 @@ static LogicalType GetParquetVariantType(optional_ptr<LogicalType> shredding = n
 	if (shredding && shredding->id() != LogicalTypeId::VARIANT) {
 		children.emplace_back("typed_value", VariantColumnWriter::TransformTypedValueRecursive(*shredding));
 	}
-	auto res = LogicalType::STRUCT(std::move(children));
-	res.SetAlias("PARQUET_VARIANT");
-	return res;
+	return LogicalType::STRUCT(std::move(children)).WithAlias("PARQUET_VARIANT");
 }
 
 static unique_ptr<FunctionData> BindTransform(BindScalarFunctionInput &input) {

--- a/src/catalog/catalog_entry/type_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/type_catalog_entry.cpp
@@ -47,10 +47,8 @@ string TypeCatalogEntry::ToSQL() const {
 	ss << SQLIdentifier(name);
 	ss << " AS ";
 
-	auto user_type_copy = user_type;
-
 	// Strip off the potential alias so ToString doesn't just output the alias
-	user_type_copy.SetAlias("");
+	auto user_type_copy = user_type.WithAlias("");
 	D_ASSERT(user_type_copy.GetAlias().empty());
 
 	ss << user_type_copy.ToString();

--- a/src/catalog/default/default_types.cpp
+++ b/src/catalog/default/default_types.cpp
@@ -34,9 +34,9 @@ LogicalType BindDecimalType(BindLogicalTypeInput &input) {
 		if (!width_value.type().IsIntegral()) {
 			throw BinderException("DECIMAL type width must be an integral type");
 		}
-		auto casted_width = width_value.DefaultTryCastAs(LogicalTypeId::UTINYINT);
-		if (casted_width) {
-			width = casted_width->GetValueUnsafe<uint8_t>();
+		auto cast_width = width_value.DefaultTryCastAs(LogicalTypeId::UTINYINT);
+		if (cast_width) {
+			width = cast_width->GetValueUnsafe<uint8_t>();
 			scale = 0; // reset scale to 0 if only width is provided
 		} else {
 			throw BinderException("DECIMAL type width must be between 1 and %d", Decimal::MAX_WIDTH_DECIMAL);
@@ -51,9 +51,9 @@ LogicalType BindDecimalType(BindLogicalTypeInput &input) {
 		if (!scale_value.type().IsIntegral()) {
 			throw BinderException("DECIMAL type scale must be an integral type");
 		}
-		auto casted_scale = scale_value.DefaultTryCastAs(LogicalTypeId::UTINYINT);
-		if (casted_scale) {
-			scale = casted_scale->GetValueUnsafe<uint8_t>();
+		auto cast_scale = scale_value.DefaultTryCastAs(LogicalTypeId::UTINYINT);
+		if (cast_scale) {
+			scale = cast_scale->GetValueUnsafe<uint8_t>();
 		} else {
 			throw BinderException("DECIMAL type scale must be between 0 and %d", Decimal::MAX_WIDTH_DECIMAL);
 		}
@@ -92,9 +92,9 @@ LogicalType BindTimestampType(BindLogicalTypeInput &input) {
 		throw BinderException("TIMESTAMP type precision cannot be NULL");
 	}
 	uint8_t precision;
-	auto casted_precision = precision_value.DefaultTryCastAs(LogicalTypeId::UTINYINT);
-	if (casted_precision) {
-		precision = casted_precision->GetValueUnsafe<uint8_t>();
+	auto cast_precision = precision_value.DefaultTryCastAs(LogicalTypeId::UTINYINT);
+	if (cast_precision) {
+		precision = cast_precision->GetValueUnsafe<uint8_t>();
 	} else {
 		throw BinderException("TIMESTAMP type precision must be between 0 and 9");
 	}
@@ -247,12 +247,12 @@ LogicalType BindArrayType(BindLogicalTypeInput &input) {
 	if (!size_val.type().IsIntegral()) {
 		throw BinderException("ARRAY type size modifier must be an integral type");
 	}
-	auto casted_size = size_val.DefaultTryCastAs(LogicalTypeId::BIGINT);
-	if (!casted_size) {
+	auto cast_size = size_val.DefaultTryCastAs(LogicalTypeId::BIGINT);
+	if (!cast_size) {
 		throw BinderException("ARRAY type size modifier must be a BIGINT");
 	}
 
-	auto array_size = casted_size->GetValueUnsafe<int64_t>();
+	auto array_size = cast_size->GetValueUnsafe<int64_t>();
 
 	if (array_size < 1) {
 		throw BinderException("ARRAY type size must be at least 1");

--- a/src/catalog/default/default_types.cpp
+++ b/src/catalog/default/default_types.cpp
@@ -34,8 +34,9 @@ LogicalType BindDecimalType(BindLogicalTypeInput &input) {
 		if (!width_value.type().IsIntegral()) {
 			throw BinderException("DECIMAL type width must be an integral type");
 		}
-		if (width_value.DefaultTryCastAs(LogicalTypeId::UTINYINT)) {
-			width = width_value.GetValueUnsafe<uint8_t>();
+		auto casted_width = width_value.DefaultTryCastAs(LogicalTypeId::UTINYINT);
+		if (casted_width) {
+			width = casted_width->GetValueUnsafe<uint8_t>();
 			scale = 0; // reset scale to 0 if only width is provided
 		} else {
 			throw BinderException("DECIMAL type width must be between 1 and %d", Decimal::MAX_WIDTH_DECIMAL);
@@ -50,8 +51,9 @@ LogicalType BindDecimalType(BindLogicalTypeInput &input) {
 		if (!scale_value.type().IsIntegral()) {
 			throw BinderException("DECIMAL type scale must be an integral type");
 		}
-		if (scale_value.DefaultTryCastAs(LogicalTypeId::UTINYINT)) {
-			scale = scale_value.GetValueUnsafe<uint8_t>();
+		auto casted_scale = scale_value.DefaultTryCastAs(LogicalTypeId::UTINYINT);
+		if (casted_scale) {
+			scale = casted_scale->GetValueUnsafe<uint8_t>();
 		} else {
 			throw BinderException("DECIMAL type scale must be between 0 and %d", Decimal::MAX_WIDTH_DECIMAL);
 		}
@@ -90,8 +92,9 @@ LogicalType BindTimestampType(BindLogicalTypeInput &input) {
 		throw BinderException("TIMESTAMP type precision cannot be NULL");
 	}
 	uint8_t precision;
-	if (precision_value.DefaultTryCastAs(LogicalTypeId::UTINYINT)) {
-		precision = precision_value.GetValueUnsafe<uint8_t>();
+	auto casted_precision = precision_value.DefaultTryCastAs(LogicalTypeId::UTINYINT);
+	if (casted_precision) {
+		precision = casted_precision->GetValueUnsafe<uint8_t>();
 	} else {
 		throw BinderException("TIMESTAMP type precision must be between 0 and 9");
 	}
@@ -244,11 +247,12 @@ LogicalType BindArrayType(BindLogicalTypeInput &input) {
 	if (!size_val.type().IsIntegral()) {
 		throw BinderException("ARRAY type size modifier must be an integral type");
 	}
-	if (!size_val.DefaultTryCastAs(LogicalTypeId::BIGINT)) {
+	auto casted_size = size_val.DefaultTryCastAs(LogicalTypeId::BIGINT);
+	if (!casted_size) {
 		throw BinderException("ARRAY type size modifier must be a BIGINT");
 	}
 
-	auto array_size = size_val.GetValueUnsafe<int64_t>();
+	auto array_size = casted_size->GetValueUnsafe<int64_t>();
 
 	if (array_size < 1) {
 		throw BinderException("ARRAY type size must be at least 1");

--- a/src/common/extra_type_info.cpp
+++ b/src/common/extra_type_info.cpp
@@ -116,7 +116,7 @@ void ExtraTypeInfo::CopyBaseInfo(ExtraTypeInfo &target) const {
 	}
 }
 
-bool ExtraTypeInfo::Equals(ExtraTypeInfo *other_p) const {
+bool ExtraTypeInfo::Equals(const ExtraTypeInfo *other_p) const {
 	if (type == ExtraTypeInfoType::INVALID_TYPE_INFO || type == ExtraTypeInfoType::STRING_TYPE_INFO ||
 	    type == ExtraTypeInfoType::GENERIC_TYPE_INFO) {
 		if (!other_p) {
@@ -152,7 +152,7 @@ bool ExtraTypeInfo::Equals(ExtraTypeInfo *other_p) const {
 	return EqualsInternal(other_p);
 }
 
-bool ExtraTypeInfo::EqualsInternal(ExtraTypeInfo *other_p) const {
+bool ExtraTypeInfo::EqualsInternal(const ExtraTypeInfo *other_p) const {
 	// Do nothing
 	return true;
 }
@@ -168,7 +168,7 @@ DecimalTypeInfo::DecimalTypeInfo(uint8_t width_p, uint8_t scale_p)
 	D_ASSERT(width_p >= scale_p);
 }
 
-bool DecimalTypeInfo::EqualsInternal(ExtraTypeInfo *other_p) const {
+bool DecimalTypeInfo::EqualsInternal(const ExtraTypeInfo *other_p) const {
 	auto &other = other_p->Cast<DecimalTypeInfo>();
 	return width == other.width && scale == other.scale;
 }
@@ -187,7 +187,7 @@ StringTypeInfo::StringTypeInfo(string collation_p)
     : ExtraTypeInfo(ExtraTypeInfoType::STRING_TYPE_INFO), collation(std::move(collation_p)) {
 }
 
-bool StringTypeInfo::EqualsInternal(ExtraTypeInfo *other_p) const {
+bool StringTypeInfo::EqualsInternal(const ExtraTypeInfo *other_p) const {
 	// collation info has no impact on equality
 	return true;
 }
@@ -206,7 +206,7 @@ ListTypeInfo::ListTypeInfo(LogicalType child_type_p)
     : ExtraTypeInfo(ExtraTypeInfoType::LIST_TYPE_INFO), child_type(std::move(child_type_p)) {
 }
 
-bool ListTypeInfo::EqualsInternal(ExtraTypeInfo *other_p) const {
+bool ListTypeInfo::EqualsInternal(const ExtraTypeInfo *other_p) const {
 	auto &other = other_p->Cast<ListTypeInfo>();
 	return child_type == other.child_type;
 }
@@ -235,7 +235,7 @@ StructTypeInfo::StructTypeInfo(child_list_t<LogicalType> child_types_p)
     : ExtraTypeInfo(ExtraTypeInfoType::STRUCT_TYPE_INFO), child_types(std::move(child_types_p)) {
 }
 
-bool StructTypeInfo::EqualsInternal(ExtraTypeInfo *other_p) const {
+bool StructTypeInfo::EqualsInternal(const ExtraTypeInfo *other_p) const {
 	auto &other = other_p->Cast<StructTypeInfo>();
 	return child_types == other.child_types;
 }
@@ -328,7 +328,7 @@ LegacyAggregateStateTypeInfo::LegacyAggregateStateTypeInfo()
 	throw InternalException("LegacyAggregateStateTypeInfo should no longer be getting constructed");
 }
 
-bool LegacyAggregateStateTypeInfo::EqualsInternal(ExtraTypeInfo *other_p) const {
+bool LegacyAggregateStateTypeInfo::EqualsInternal(const ExtraTypeInfo *other_p) const {
 	throw InternalException("LegacyAggregateStateTypeInfo should no longer be getting constructed");
 }
 
@@ -430,7 +430,7 @@ shared_ptr<ExtraTypeInfo> EnumTypeInfo::Deserialize(Deserializer &deserializer) 
 }
 
 // Equalities are only used in enums with different catalog entries
-bool EnumTypeInfo::EqualsInternal(ExtraTypeInfo *other_p) const {
+bool EnumTypeInfo::EqualsInternal(const ExtraTypeInfo *other_p) const {
 	auto &other = other_p->Cast<EnumTypeInfo>();
 	if (dict_type != other.dict_type) {
 		return false;
@@ -477,7 +477,7 @@ ArrayTypeInfo::ArrayTypeInfo(LogicalType child_type_p, uint32_t size_p)
     : ExtraTypeInfo(ExtraTypeInfoType::ARRAY_TYPE_INFO), child_type(std::move(child_type_p)), size(size_p) {
 }
 
-bool ArrayTypeInfo::EqualsInternal(ExtraTypeInfo *other_p) const {
+bool ArrayTypeInfo::EqualsInternal(const ExtraTypeInfo *other_p) const {
 	auto &other = other_p->Cast<ArrayTypeInfo>();
 	return child_type == other.child_type && size == other.size;
 }
@@ -502,7 +502,7 @@ AnyTypeInfo::AnyTypeInfo(LogicalType target_type_p, idx_t cast_score_p)
     : ExtraTypeInfo(ExtraTypeInfoType::ANY_TYPE_INFO), target_type(std::move(target_type_p)), cast_score(cast_score_p) {
 }
 
-bool AnyTypeInfo::EqualsInternal(ExtraTypeInfo *other_p) const {
+bool AnyTypeInfo::EqualsInternal(const ExtraTypeInfo *other_p) const {
 	auto &other = other_p->Cast<AnyTypeInfo>();
 	return target_type == other.target_type && cast_score == other.cast_score;
 }
@@ -530,7 +530,7 @@ IntegerLiteralTypeInfo::IntegerLiteralTypeInfo(Value constant_value_p)
 	}
 }
 
-bool IntegerLiteralTypeInfo::EqualsInternal(ExtraTypeInfo *other_p) const {
+bool IntegerLiteralTypeInfo::EqualsInternal(const ExtraTypeInfo *other_p) const {
 	auto &other = other_p->Cast<IntegerLiteralTypeInfo>();
 	return constant_value == other.constant_value;
 }
@@ -549,7 +549,7 @@ TemplateTypeInfo::TemplateTypeInfo(string name_p)
     : ExtraTypeInfo(ExtraTypeInfoType::TEMPLATE_TYPE_INFO), name(std::move(name_p)) {
 }
 
-bool TemplateTypeInfo::EqualsInternal(ExtraTypeInfo *other_p) const {
+bool TemplateTypeInfo::EqualsInternal(const ExtraTypeInfo *other_p) const {
 	auto &other = other_p->Cast<TemplateTypeInfo>();
 	return name == other.name;
 }
@@ -564,7 +564,7 @@ shared_ptr<ExtraTypeInfo> TemplateTypeInfo::Copy() const {
 GeoTypeInfo::GeoTypeInfo() : ExtraTypeInfo(ExtraTypeInfoType::GEO_TYPE_INFO) {
 }
 
-bool GeoTypeInfo::EqualsInternal(ExtraTypeInfo *other_p) const {
+bool GeoTypeInfo::EqualsInternal(const ExtraTypeInfo *other_p) const {
 	// No additional info to compare
 	const auto &other = other_p->Cast<GeoTypeInfo>();
 	return other.crs.Equals(crs);
@@ -584,7 +584,7 @@ UnboundTypeInfo::UnboundTypeInfo(unique_ptr<ParsedExpression> expr_p)
     : ExtraTypeInfo(ExtraTypeInfoType::UNBOUND_TYPE_INFO), expr(std::move(expr_p)) {
 }
 
-bool UnboundTypeInfo::EqualsInternal(ExtraTypeInfo *other_p) const {
+bool UnboundTypeInfo::EqualsInternal(const ExtraTypeInfo *other_p) const {
 	auto &other = other_p->Cast<UnboundTypeInfo>();
 	if (!expr->Equals(*other.expr)) {
 		return false;
@@ -593,7 +593,9 @@ bool UnboundTypeInfo::EqualsInternal(ExtraTypeInfo *other_p) const {
 }
 
 shared_ptr<ExtraTypeInfo> UnboundTypeInfo::Copy() const {
-	return make_shared_ptr<UnboundTypeInfo>(expr->Copy());
+	auto result = make_shared_ptr<UnboundTypeInfo>(expr->Copy());
+	CopyBaseInfo(*result);
+	return result;
 }
 
 } // namespace duckdb

--- a/src/common/hive_partitioning.cpp
+++ b/src/common/hive_partitioning.cpp
@@ -150,12 +150,12 @@ Value HivePartitioning::GetValue(ClientContext &context, const string &key, cons
 
 	// cast to the target type
 	Value value(Unescape(str_val));
-	auto casted = value.TryCastAs(context, type);
-	if (!casted) {
+	auto cast = value.TryCastAs(context, type);
+	if (!cast) {
 		throw InvalidInputException("Unable to cast '%s' (from hive partition column '%s') to: '%s'", value.ToString(),
 		                            StringUtil::Upper(key), type.ToString());
 	}
-	return std::move(*casted);
+	return std::move(*cast);
 }
 
 // TODO: this can still be improved by removing the parts of filter expressions that are true for all remaining files.

--- a/src/common/hive_partitioning.cpp
+++ b/src/common/hive_partitioning.cpp
@@ -150,11 +150,12 @@ Value HivePartitioning::GetValue(ClientContext &context, const string &key, cons
 
 	// cast to the target type
 	Value value(Unescape(str_val));
-	if (!value.TryCastAs(context, type)) {
+	auto casted = value.TryCastAs(context, type);
+	if (!casted) {
 		throw InvalidInputException("Unable to cast '%s' (from hive partition column '%s') to: '%s'", value.ToString(),
 		                            StringUtil::Upper(key), type.ToString());
 	}
-	return value;
+	return std::move(*casted);
 }
 
 // TODO: this can still be improved by removing the parts of filter expressions that are true for all remaining files.
@@ -231,15 +232,11 @@ static inline Value GetHiveKeyValue(const T &val) {
 
 template <class T>
 static inline Value GetHiveKeyValue(const T &val, const LogicalType &type) {
-	auto result = GetHiveKeyValue(val);
-	result.Reinterpret(type);
-	return result;
+	return GetHiveKeyValue(val).WithType(type);
 }
 
 static inline Value GetHiveKeyNullValue(const LogicalType &type) {
-	Value result;
-	result.Reinterpret(type);
-	return result;
+	return Value().WithType(type);
 }
 
 template <class T>

--- a/src/common/multi_file/multi_file_column_mapper.cpp
+++ b/src/common/multi_file/multi_file_column_mapper.cpp
@@ -887,7 +887,12 @@ static bool TryCastConstant(Value &constant, const LogicalType &target_type) {
 	if (!StatisticsPropagator::CanPropagateCast(constant.type(), target_type)) {
 		return false;
 	}
-	return constant.DefaultTryCastAs(target_type);
+	auto casted = constant.DefaultTryCastAs(target_type);
+	if (!casted) {
+		return false;
+	}
+	constant = std::move(*casted);
+	return true;
 }
 
 struct RewrittenMappedExpression {

--- a/src/common/multi_file/multi_file_column_mapper.cpp
+++ b/src/common/multi_file/multi_file_column_mapper.cpp
@@ -887,11 +887,11 @@ static bool TryCastConstant(Value &constant, const LogicalType &target_type) {
 	if (!StatisticsPropagator::CanPropagateCast(constant.type(), target_type)) {
 		return false;
 	}
-	auto casted = constant.DefaultTryCastAs(target_type);
-	if (!casted) {
+	auto cast = constant.DefaultTryCastAs(target_type);
+	if (!cast) {
 		return false;
 	}
-	constant = std::move(*casted);
+	constant = std::move(*cast);
 	return true;
 }
 

--- a/src/common/multi_file/multi_file_reader.cpp
+++ b/src/common/multi_file/multi_file_reader.cpp
@@ -144,11 +144,11 @@ bool MultiFileReader::ParseOption(const Identifier &key, const Value &val, Multi
 			options.filename = true;
 			options.filename_column = StringValue::Get(val);
 		} else {
-			Value boolean_value;
 			string error_message;
-			if (val.DefaultTryCastAs(LogicalType::BOOLEAN, boolean_value, &error_message)) {
+			auto boolean_value = val.DefaultTryCastAs(LogicalType::BOOLEAN, &error_message);
+			if (boolean_value) {
 				// If the argument can be cast to boolean, we just interpret it as a boolean
-				options.filename = BooleanValue::Get(boolean_value);
+				options.filename = BooleanValue::Get(*boolean_value);
 			}
 		}
 	} else if (key == "hive_partitioning") {
@@ -789,7 +789,7 @@ void MultiFileOptions::AutoDetectHiveTypesInternal(MultiFileList &files, ClientC
 			LogicalType detected_type = LogicalType::VARCHAR;
 			Value value(part.second);
 			for (auto &candidate : candidates) {
-				const bool success = value.TryCastAs(context, candidate, true);
+				const bool success = value.TryCastAs(context, candidate, nullptr, true).has_value();
 				if (success) {
 					detected_type = candidate;
 					break;

--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -1813,8 +1813,7 @@ bool IntegerLiteral::FitsInType(const LogicalType &type, const LogicalType &targ
 	auto info = type.AuxInfo();
 	D_ASSERT(info->type == ExtraTypeInfoType::INTEGER_LITERAL_TYPE_INFO);
 	auto &literal_info = info->Cast<IntegerLiteralTypeInfo>();
-	Value copy = literal_info.constant_value;
-	return copy.DefaultTryCastAs(target);
+	return literal_info.constant_value.DefaultTryCastAs(target).has_value();
 }
 
 LogicalType LogicalType::INTEGER_LITERAL(const Value &constant) { // NOLINT

--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -43,7 +43,7 @@ LogicalType::LogicalType() : LogicalType(LogicalTypeId::INVALID) {
 LogicalType::LogicalType(LogicalTypeId id) : id_(id) {
 	physical_type_ = GetInternalType();
 }
-LogicalType::LogicalType(LogicalTypeId id, shared_ptr<ExtraTypeInfo> type_info_p)
+LogicalType::LogicalType(LogicalTypeId id, shared_ptr<const ExtraTypeInfo> type_info_p)
     : id_(id), type_info_(std::move(type_info_p)) {
 	physical_type_ = GetInternalType();
 }
@@ -1288,7 +1288,7 @@ void LogicalType::Serialize(Serializer &serializer) const {
 		serialized_id = LogicalTypeId::STRUCT;
 	}
 	serializer.WriteProperty<LogicalTypeId>(100, "id", serialized_id);
-	serializer.WritePropertyWithDefault<shared_ptr<ExtraTypeInfo>>(101, "type_info", type_info_);
+	serializer.WritePropertyWithDefault<shared_ptr<const ExtraTypeInfo>>(101, "type_info", type_info_);
 }
 
 LogicalType LogicalType::Deserialize(Deserializer &deserializer) {
@@ -1335,12 +1335,25 @@ LogicalType LogicalType::DeepCopy() const {
 	return copy;
 }
 
-void LogicalType::SetAlias(string alias) {
+LogicalType LogicalType::WithAlias(string alias) const {
 	if (!type_info_) {
-		type_info_ = make_shared_ptr<ExtraTypeInfo>(ExtraTypeInfoType::GENERIC_TYPE_INFO, std::move(alias));
-	} else {
-		type_info_->alias = std::move(alias);
+		if (alias.empty()) {
+			// a type without type info is equivalent to a generic type info with an empty alias
+			return *this;
+		}
+		LogicalType result = *this;
+		result.type_info_ = make_shared_ptr<ExtraTypeInfo>(ExtraTypeInfoType::GENERIC_TYPE_INFO, std::move(alias));
+		return result;
 	}
+	if (type_info_->alias == alias) {
+		// avoid copying the (potentially expensive) type info if the alias does not change
+		return *this;
+	}
+	auto new_info = type_info_->Copy();
+	new_info->alias = std::move(alias);
+	LogicalType result = *this;
+	result.type_info_ = std::move(new_info);
+	return result;
 }
 
 string LogicalType::GetAlias() const {
@@ -1371,18 +1384,13 @@ optional_ptr<const ExtensionTypeInfo> LogicalType::GetExtensionInfo() const {
 	return nullptr;
 }
 
-optional_ptr<ExtensionTypeInfo> LogicalType::GetExtensionInfo() {
-	if (type_info_ && type_info_->extension_info) {
-		return type_info_->extension_info.get();
-	}
-	return nullptr;
-}
-
-void LogicalType::SetExtensionInfo(unique_ptr<ExtensionTypeInfo> info) {
-	if (!type_info_) {
-		type_info_ = make_shared_ptr<ExtraTypeInfo>(ExtraTypeInfoType::GENERIC_TYPE_INFO);
-	}
-	type_info_->extension_info = std::move(info);
+LogicalType LogicalType::WithExtensionInfo(unique_ptr<ExtensionTypeInfo> info) const {
+	auto new_info =
+	    type_info_ ? type_info_->Copy() : make_shared_ptr<ExtraTypeInfo>(ExtraTypeInfoType::GENERIC_TYPE_INFO);
+	new_info->extension_info = std::move(info);
+	LogicalType result = *this;
+	result.type_info_ = std::move(new_info);
+	return result;
 }
 
 //===--------------------------------------------------------------------===//
@@ -1679,9 +1687,7 @@ PhysicalType EnumType::GetPhysicalType(const LogicalType &type) {
 // JSON Type
 //===--------------------------------------------------------------------===//
 LogicalType LogicalType::JSON() {
-	auto json_type = LogicalType(LogicalTypeId::VARCHAR);
-	json_type.SetAlias(JSON_TYPE_NAME);
-	return json_type;
+	return LogicalType(LogicalTypeId::VARCHAR).WithAlias(JSON_TYPE_NAME);
 }
 
 bool LogicalType::IsJSONType() const {
@@ -1885,7 +1891,7 @@ bool GeoType::HasCRS(const LogicalType &type) {
 	auto info = type.AuxInfo();
 	if (!info || info->type != ExtraTypeInfoType::GEO_TYPE_INFO) {
 		// a GEOMETRY type without geo type info has no CRS - this can happen when an alias is set on a geometry
-		// type that was created without a CRS (SetAlias attaches a generic type info)
+		// type that was created without a CRS (WithAlias attaches a generic type info)
 		return false;
 	}
 	const auto &geo_info = info->Cast<GeoTypeInfo>();

--- a/src/common/types/geometry.cpp
+++ b/src/common/types/geometry.cpp
@@ -2429,9 +2429,7 @@ void Geometry::FromVectorizedFormat(const Vector &source, Vector &target, idx_t 
 }
 
 LogicalType Geometry::GetSpatialGeometryType() {
-	auto blob_type = LogicalType(LogicalTypeId::BLOB);
-	blob_type.SetAlias("GEOMETRY");
-	return blob_type;
+	return LogicalType(LogicalTypeId::BLOB).WithAlias("GEOMETRY");
 }
 
 bool Geometry::IsSpatialGeometryType(const LogicalType &type) {

--- a/src/common/types/value.cpp
+++ b/src/common/types/value.cpp
@@ -2110,32 +2110,32 @@ bool Value::operator>=(const int64_t &rhs) const {
 	return *this >= Value::Numeric(type_, rhs);
 }
 
-bool Value::TryCastAs(CastFunctionSet &set, GetCastFunctionInput &get_input, const LogicalType &target_type,
-                      Value &new_value, string *error_message, bool strict) const {
+optional<Value> Value::TryCastAs(CastFunctionSet &set, GetCastFunctionInput &get_input, const LogicalType &target_type,
+                                 string *error_message, bool strict) const {
 	if (type_ == target_type) {
-		new_value = Copy();
-		return true;
+		return Copy();
 	}
 	Vector input(*this, count_t(1));
 	Vector result(target_type);
-	if (!VectorOperations::TryCast(set, get_input, input, result, 1, error_message, strict)) {
-		return false;
+	// always pass an error string - VectorOperations::TryCast throws instead of returning false without one
+	string local_error;
+	if (!VectorOperations::TryCast(set, get_input, input, result, 1, error_message ? error_message : &local_error,
+	                               strict)) {
+		return nullopt;
 	}
-	new_value = result.GetValue(0);
-	return true;
+	return result.GetValue(0);
 }
 
-bool Value::TryCastAs(ClientContext &context, const LogicalType &target_type, Value &new_value, string *error_message,
-                      bool strict) const {
+optional<Value> Value::TryCastAs(ClientContext &context, const LogicalType &target_type, string *error_message,
+                                 bool strict) const {
 	GetCastFunctionInput get_input(context);
-	return TryCastAs(CastFunctionSet::Get(context), get_input, target_type, new_value, error_message, strict);
+	return TryCastAs(CastFunctionSet::Get(context), get_input, target_type, error_message, strict);
 }
 
-bool Value::DefaultTryCastAs(const LogicalType &target_type, Value &new_value, string *error_message,
-                             bool strict) const {
+optional<Value> Value::DefaultTryCastAs(const LogicalType &target_type, string *error_message, bool strict) const {
 	CastFunctionSet set;
 	GetCastFunctionInput get_input;
-	return TryCastAs(set, get_input, target_type, new_value, error_message, strict);
+	return TryCastAs(set, get_input, target_type, error_message, strict);
 }
 
 Value Value::CastAs(CastFunctionSet &set, GetCastFunctionInput &get_input, const LogicalType &target_type,
@@ -2143,12 +2143,12 @@ Value Value::CastAs(CastFunctionSet &set, GetCastFunctionInput &get_input, const
 	if (target_type.id() == LogicalTypeId::ANY) {
 		return *this;
 	}
-	Value new_value;
 	string error_message;
-	if (!TryCastAs(set, get_input, target_type, new_value, &error_message, strict)) {
+	auto new_value = TryCastAs(set, get_input, target_type, &error_message, strict);
+	if (!new_value) {
 		throw InvalidInputException("Failed to cast value: %s", error_message);
 	}
-	return new_value;
+	return std::move(*new_value);
 }
 
 Value Value::CastAs(ClientContext &context, const LogicalType &target_type, bool strict) const {
@@ -2162,33 +2162,10 @@ Value Value::DefaultCastAs(const LogicalType &target_type, bool strict) const {
 	return CastAs(set, get_input, target_type, strict);
 }
 
-bool Value::TryCastAs(CastFunctionSet &set, GetCastFunctionInput &get_input, const LogicalType &target_type,
-                      bool strict) {
-	Value new_value;
-	string error_message;
-	if (!TryCastAs(set, get_input, target_type, new_value, &error_message, strict)) {
-		return false;
-	}
-	type_ = target_type;
-	is_null = new_value.is_null;
-	value_ = new_value.value_;
-	value_info_ = std::move(new_value.value_info_);
-	return true;
-}
-
-bool Value::TryCastAs(ClientContext &context, const LogicalType &target_type, bool strict) {
-	GetCastFunctionInput get_input(context);
-	return TryCastAs(CastFunctionSet::Get(context), get_input, target_type, strict);
-}
-
-bool Value::DefaultTryCastAs(const LogicalType &target_type, bool strict) {
-	CastFunctionSet set;
-	GetCastFunctionInput get_input;
-	return TryCastAs(set, get_input, target_type, strict);
-}
-
-void Value::Reinterpret(LogicalType new_type) {
-	this->type_ = std::move(new_type);
+Value Value::WithType(LogicalType new_type) const {
+	Value result = *this;
+	result.type_ = std::move(new_type);
+	return result;
 }
 
 static const LogicalType &GetChildType(const LogicalType &parent_type, idx_t i) {

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -357,9 +357,9 @@ Value Vector::GetValueInternal(const Vector &v_p, idx_t index_p) {
 
 Value Vector::GetValue(const Vector &v_p, idx_t index_p) {
 	auto value = GetValueInternal(v_p, index_p);
-	// set the alias of the type to the correct value, if there is a type alias
+	// the value's type is reconstructed from the data - restore the source type so that the alias survives
 	if (v_p.GetType().HasAlias()) {
-		value.GetTypeMutable().CopyAuxInfo(v_p.GetType());
+		value.GetTypeMutable() = v_p.GetType();
 	}
 	if (v_p.GetType().id() != LogicalTypeId::LEGACY_AGGREGATE_STATE &&
 	    value.type().id() != LogicalTypeId::LEGACY_AGGREGATE_STATE) {

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -359,7 +359,7 @@ Value Vector::GetValue(const Vector &v_p, idx_t index_p) {
 	auto value = GetValueInternal(v_p, index_p);
 	// the value's type is reconstructed from the data - restore the source type so that the alias survives
 	if (v_p.GetType().HasAlias()) {
-		value.GetTypeMutable() = v_p.GetType();
+		value = value.WithType(v_p.GetType());
 	}
 	if (v_p.GetType().id() != LogicalTypeId::LEGACY_AGGREGATE_STATE &&
 	    value.type().id() != LogicalTypeId::LEGACY_AGGREGATE_STATE) {

--- a/src/common/value_operations/comparison_operations.cpp
+++ b/src/common/value_operations/comparison_operations.cpp
@@ -77,15 +77,14 @@ static bool TemplatedBooleanOperation(const Value &left, const Value &right) {
 	const auto &left_type = left.type();
 	const auto &right_type = right.type();
 	if (left_type != right_type) {
-		Value left_copy = left;
-		Value right_copy = right;
-
 		auto comparison_type = LogicalType::DefaultForceMaxLogicalType(left_type, right_type);
-		if (!left_copy.DefaultTryCastAs(comparison_type) || !right_copy.DefaultTryCastAs(comparison_type)) {
+		auto left_copy = left.DefaultTryCastAs(comparison_type);
+		auto right_copy = right.DefaultTryCastAs(comparison_type);
+		if (!left_copy || !right_copy) {
 			return false;
 		}
-		D_ASSERT(left_copy.type() == right_copy.type());
-		return TemplatedBooleanOperation<OP>(left_copy, right_copy);
+		D_ASSERT(left_copy->type() == right_copy->type());
+		return TemplatedBooleanOperation<OP>(*left_copy, *right_copy);
 	}
 	switch (left_type.InternalType()) {
 	case PhysicalType::BOOL:

--- a/src/execution/operator/csv_scanner/sniffer/type_detection.cpp
+++ b/src/execution/operator/csv_scanner/sniffer/type_detection.cpp
@@ -309,11 +309,10 @@ bool CSVSniffer::CanYouCastIt(ClientContext &context, const string_t value, cons
 		return true;
 	default: {
 		// We do Value Try Cast for non-basic types.
-		Value new_value;
 		string error_message;
 		Value str_value(value);
-		bool success = str_value.TryCastAs(context, type, new_value, &error_message, true);
-		return success && error_message.empty();
+		auto new_value = str_value.TryCastAs(context, type, &error_message, true);
+		return new_value.has_value() && error_message.empty();
 	}
 	}
 }

--- a/src/execution/operator/join/perfect_hash_join_executor.cpp
+++ b/src/execution/operator/join/perfect_hash_join_executor.cpp
@@ -61,11 +61,11 @@ bool ExtractNumericValue(const Value &val, hugeint_t &result) {
 			return false;
 		}
 	} else {
-		auto casted = val.DefaultTryCastAs(LogicalType::HUGEINT);
-		if (!casted) {
+		auto cast = val.DefaultTryCastAs(LogicalType::HUGEINT);
+		if (!cast) {
 			return false;
 		}
-		result = casted->GetValue<hugeint_t>();
+		result = cast->GetValue<hugeint_t>();
 	}
 	return true;
 }

--- a/src/execution/operator/join/perfect_hash_join_executor.cpp
+++ b/src/execution/operator/join/perfect_hash_join_executor.cpp
@@ -18,7 +18,7 @@ const LogicalType &PerfectHashJoinExecutor::GetKeyType() const {
 //===--------------------------------------------------------------------===//
 // Initialize
 //===--------------------------------------------------------------------===//
-bool ExtractNumericValue(Value val, hugeint_t &result) {
+bool ExtractNumericValue(const Value &val, hugeint_t &result) {
 	if (!val.type().IsIntegral()) {
 		switch (val.type().InternalType()) {
 		case PhysicalType::INT8:
@@ -61,10 +61,11 @@ bool ExtractNumericValue(Value val, hugeint_t &result) {
 			return false;
 		}
 	} else {
-		if (!val.DefaultTryCastAs(LogicalType::HUGEINT)) {
+		auto casted = val.DefaultTryCastAs(LogicalType::HUGEINT);
+		if (!casted) {
 			return false;
 		}
-		result = val.GetValue<hugeint_t>();
+		result = casted->GetValue<hugeint_t>();
 	}
 	return true;
 }

--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -1791,13 +1791,13 @@ unique_ptr<DataChunk> JoinFilterPushdownInfo::FinalizeFilters(ClientContext &con
 
 			// Cast to storage type, skip if fails
 			if (pushdown_column.storage_type.IsValid() && !reconstruct_filter_expression) {
-				auto casted_min = min_val.DefaultTryCastAs(pushdown_column.storage_type);
-				auto casted_max = max_val.DefaultTryCastAs(pushdown_column.storage_type);
-				if (!casted_min || !casted_max) {
+				auto cast_min = min_val.DefaultTryCastAs(pushdown_column.storage_type);
+				auto cast_max = max_val.DefaultTryCastAs(pushdown_column.storage_type);
+				if (!cast_min || !cast_max) {
 					continue;
 				}
-				min_val = std::move(*casted_min);
-				max_val = std::move(*casted_max);
+				min_val = std::move(*cast_min);
+				max_val = std::move(*cast_max);
 			}
 
 			if (min_val.IsNull() || max_val.IsNull()) {

--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -1635,12 +1635,12 @@ static void CreateDynamicMinMaxFilter(const PhysicalComparisonJoin &op, const Jo
 static unique_ptr<Expression> CreateComparisonExpressionFilter(ExpressionType comparison_type,
                                                                unique_ptr<Expression> input, const Value &constant,
                                                                const LogicalType &comparison_logical_type) {
-	auto constant_value = constant;
-	if (!constant_value.DefaultTryCastAs(comparison_logical_type)) {
+	auto constant_value = constant.DefaultTryCastAs(comparison_logical_type);
+	if (!constant_value) {
 		return nullptr;
 	}
 	return BoundComparisonExpression::Create(comparison_type, std::move(input),
-	                                         make_uniq<BoundConstantExpression>(std::move(constant_value)));
+	                                         make_uniq<BoundConstantExpression>(std::move(*constant_value)));
 }
 
 static unique_ptr<Expression> CreateComparisonExpressionFilter(ExpressionType comparison_type, const Value &constant,
@@ -1701,11 +1701,11 @@ bool JoinFilterPushdownInfo::PushInFilter(ClientContext &context, const JoinFilt
 
 	value_set_t unique_ht_values;
 	for (idx_t k = 0; k < key_count; k++) {
-		auto value = build_vector.GetValue(k);
-		if (!value.DefaultTryCastAs(filter_input_type)) {
+		auto value = build_vector.GetValue(k).DefaultTryCastAs(filter_input_type);
+		if (!value) {
 			return false;
 		}
-		unique_ht_values.insert(std::move(value));
+		unique_ht_values.insert(std::move(*value));
 	}
 	vector<Value> in_list(unique_ht_values.begin(), unique_ht_values.end());
 
@@ -1791,12 +1791,13 @@ unique_ptr<DataChunk> JoinFilterPushdownInfo::FinalizeFilters(ClientContext &con
 
 			// Cast to storage type, skip if fails
 			if (pushdown_column.storage_type.IsValid() && !reconstruct_filter_expression) {
-				if (!min_val.DefaultTryCastAs(pushdown_column.storage_type)) {
+				auto casted_min = min_val.DefaultTryCastAs(pushdown_column.storage_type);
+				auto casted_max = max_val.DefaultTryCastAs(pushdown_column.storage_type);
+				if (!casted_min || !casted_max) {
 					continue;
 				}
-				if (!max_val.DefaultTryCastAs(pushdown_column.storage_type)) {
-					continue;
-				}
+				min_val = std::move(*casted_min);
+				max_val = std::move(*casted_max);
 			}
 
 			if (min_val.IsNull() || max_val.IsNull()) {

--- a/src/function/cast/variant/from_variant.cpp
+++ b/src/function/cast/variant/from_variant.cpp
@@ -182,13 +182,14 @@ static bool CastVariantToPrimitive(FromVariantConversionData &conversion_data, V
 		}
 		if (!converted) {
 			auto value = VariantUtils::ConvertVariantToValue(conversion_data.variant, row_index, sel[i]);
-			if (!value.DefaultTryCastAs(target_type, true)) {
+			auto casted_value = value.DefaultTryCastAs(target_type, nullptr, true);
+			if (!casted_value) {
 				conversion_data.error = StringUtil::Format("Can't convert VARIANT(%s) value '%s'",
 				                                           EnumUtil::ToString(type_id), value.ToString());
-				value = Value(target_type);
+				casted_value = Value(target_type);
 				all_valid = false;
 			}
-			result.SetValue(i + offset, value);
+			result.SetValue(i + offset, *casted_value);
 		}
 	}
 	return all_valid;
@@ -575,11 +576,12 @@ static bool CastVariant(FromVariantConversionData &conversion_data, Vector &resu
 			uint32_t value_index = sel[i];
 			auto value = VariantUtils::ConvertVariantToValue(conversion_data.variant, row_index, value_index);
 			try {
-				if (!value.DefaultTryCastAs(target_type, true)) {
-					value = Value(target_type);
+				auto casted_value = value.DefaultTryCastAs(target_type, nullptr, true);
+				if (!casted_value) {
+					casted_value = Value(target_type);
 					all_valid = false;
 				}
-				result.SetValue(i + offset, value);
+				result.SetValue(i + offset, *casted_value);
 			} catch (const BinderException &) {
 				// Bind-time exceptions (e.g., incompatible struct layouts) should be treated as conversion failures
 				// Set the value to NULL and mark as failed

--- a/src/function/cast/variant/from_variant.cpp
+++ b/src/function/cast/variant/from_variant.cpp
@@ -182,14 +182,14 @@ static bool CastVariantToPrimitive(FromVariantConversionData &conversion_data, V
 		}
 		if (!converted) {
 			auto value = VariantUtils::ConvertVariantToValue(conversion_data.variant, row_index, sel[i]);
-			auto casted_value = value.DefaultTryCastAs(target_type, nullptr, true);
-			if (!casted_value) {
+			auto cast_value = value.DefaultTryCastAs(target_type, nullptr, true);
+			if (!cast_value) {
 				conversion_data.error = StringUtil::Format("Can't convert VARIANT(%s) value '%s'",
 				                                           EnumUtil::ToString(type_id), value.ToString());
-				casted_value = Value(target_type);
+				cast_value = Value(target_type);
 				all_valid = false;
 			}
-			result.SetValue(i + offset, *casted_value);
+			result.SetValue(i + offset, *cast_value);
 		}
 	}
 	return all_valid;
@@ -576,12 +576,12 @@ static bool CastVariant(FromVariantConversionData &conversion_data, Vector &resu
 			uint32_t value_index = sel[i];
 			auto value = VariantUtils::ConvertVariantToValue(conversion_data.variant, row_index, value_index);
 			try {
-				auto casted_value = value.DefaultTryCastAs(target_type, nullptr, true);
-				if (!casted_value) {
-					casted_value = Value(target_type);
+				auto cast_value = value.DefaultTryCastAs(target_type, nullptr, true);
+				if (!cast_value) {
+					cast_value = Value(target_type);
 					all_valid = false;
 				}
-				result.SetValue(i + offset, *casted_value);
+				result.SetValue(i + offset, *cast_value);
 			} catch (const BinderException &) {
 				// Bind-time exceptions (e.g., incompatible struct layouts) should be treated as conversion failures
 				// Set the value to NULL and mark as failed

--- a/src/function/scalar/list/list_extract.cpp
+++ b/src/function/scalar/list/list_extract.cpp
@@ -137,9 +137,8 @@ static unique_ptr<FunctionData> ListExtractBind(BindScalarFunctionInput &input) 
 static unique_ptr<FunctionData> StringExtractBind(BindScalarFunctionInput &input) {
 	auto &bound_function = input.GetBoundFunction();
 	auto index = input.TryGetConstant(1);
-	Value index_value;
-	if (!index || !index->DefaultTryCastAs(LogicalType::BIGINT, index_value, nullptr) || index_value.IsNull() ||
-	    !SubstringInSupportedRange(BigIntValue::Get(index_value), 1)) {
+	auto index_value = index ? index->DefaultTryCastAs(LogicalType::BIGINT) : nullopt;
+	if (!index_value || index_value->IsNull() || !SubstringInSupportedRange(BigIntValue::Get(*index_value), 1)) {
 		bound_function.SetFallible();
 	}
 	return nullptr;

--- a/src/function/scalar/list/list_extract.cpp
+++ b/src/function/scalar/list/list_extract.cpp
@@ -1,3 +1,4 @@
+#include "duckdb/common/exception/conversion_exception.hpp"
 #include "duckdb/common/pair.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/types/data_chunk.hpp"
@@ -137,8 +138,17 @@ static unique_ptr<FunctionData> ListExtractBind(BindScalarFunctionInput &input) 
 static unique_ptr<FunctionData> StringExtractBind(BindScalarFunctionInput &input) {
 	auto &bound_function = input.GetBoundFunction();
 	auto index = input.TryGetConstant(1);
-	auto index_value = index ? index->DefaultTryCastAs(LogicalType::BIGINT) : nullopt;
-	if (!index_value || index_value->IsNull() || !SubstringInSupportedRange(BigIntValue::Get(*index_value), 1)) {
+	if (!index) {
+		bound_function.SetFallible();
+		return nullptr;
+	}
+	string error;
+	auto index_value = index->DefaultTryCastAs(LogicalType::BIGINT, &error);
+	if (!index_value) {
+		// the index is a constant that cannot be converted to an integer at all - report that directly
+		throw ConversionException(error);
+	}
+	if (index_value->IsNull() || !SubstringInSupportedRange(BigIntValue::Get(*index_value), 1)) {
 		bound_function.SetFallible();
 	}
 	return nullptr;

--- a/src/function/scalar/system/aggregate_export.cpp
+++ b/src/function/scalar/system/aggregate_export.cpp
@@ -863,14 +863,9 @@ string OrderModifierToString(OrderType order_type, OrderByNullType null_order) {
 LogicalType CreateAggregateStateType(const BoundAggregateFunction &bound_function,
                                      optional_ptr<FunctionData> bind_data) {
 	auto layout = bound_function.GetStateType(bind_data);
-	// deep copy the type before modifying it - SetAlias/SetExtensionInfo modify the (shared) extra type info in
-	// place, and the state layout type can share its type info with e.g. the aggregate's input expressions
-	LogicalType state_layout = layout.type.DeepCopy();
-	state_layout.SetAlias("AGGREGATE_STATE");
 	auto ext_info = make_uniq<ExtensionTypeInfo>();
 	EncodeStateParameters(*ext_info, bound_function, layout);
-	state_layout.SetExtensionInfo(std::move(ext_info));
-	return state_layout;
+	return layout.type.WithAlias("AGGREGATE_STATE").WithExtensionInfo(std::move(ext_info));
 }
 
 // constructs the AGGREGATE_STATE type for an ordered aggregate - the state is the buffer of values
@@ -879,7 +874,6 @@ LogicalType CreateSortedAggregateStateType(const BoundAggregateFunction &inner_f
                                            optional_ptr<FunctionData> inner_bind_data, const LogicalType &buffer_struct,
                                            const vector<SortedAggregateStateOrder> &orders) {
 	LogicalType state_layout = LogicalType::LIST(buffer_struct);
-	state_layout.SetAlias("AGGREGATE_STATE");
 	auto ext_info = make_uniq<ExtensionTypeInfo>();
 	EncodeStateParameters(*ext_info, inner_function, inner_function.GetStateType(inner_bind_data));
 	// per key: the buffered column it sorts on and the modifier string (the argument count is re-derived on re-bind)
@@ -891,8 +885,7 @@ LogicalType CreateSortedAggregateStateType(const BoundAggregateFunction &inner_f
 		order_values.push_back(Value::STRUCT(std::move(children)));
 	}
 	ext_info->properties.emplace("order_bys", Value::LIST(OrderByEntryType(), std::move(order_values)));
-	state_layout.SetExtensionInfo(std::move(ext_info));
-	return state_layout;
+	return state_layout.WithAlias("AGGREGATE_STATE").WithExtensionInfo(std::move(ext_info));
 }
 
 // parses a single entry of the to_aggregate_state signature list - either a TYPE value (e.g. make_type('VARCHAR'))

--- a/src/function/scalar/variant/variant_comparator.cpp
+++ b/src/function/scalar/variant/variant_comparator.cpp
@@ -264,15 +264,15 @@ bool TryEncodeBoundKey(ClientContext &context, const Value &bound, string &resul
 	if (bound.IsNull()) {
 		return false;
 	}
-	Value variant_value;
-	if (!bound.TryCastAs(context, LogicalType::VARIANT(), variant_value, nullptr)) {
+	auto variant_value = bound.TryCastAs(context, LogicalType::VARIANT());
+	if (!variant_value) {
 		return false;
 	}
-	if (variant_value.IsNull()) {
+	if (variant_value->IsNull()) {
 		return false;
 	}
 	Vector input(LogicalType::VARIANT(), 1);
-	input.SetValue(0, variant_value);
+	input.SetValue(0, *variant_value);
 	Vector sort_key(LogicalType::BLOB, 1);
 	CreateVariantComparator(input, 1, sort_key);
 	auto key = sort_key.GetValue(0);

--- a/src/function/window/window_value_function.cpp
+++ b/src/function/window/window_value_function.cpp
@@ -357,11 +357,11 @@ public:
 			if (offset_value.IsNull()) {
 				return false;
 			}
-			Value bigint_value;
-			if (!offset_value.DefaultTryCastAs(LogicalType::BIGINT, bigint_value, nullptr, false)) {
+			auto bigint_value = offset_value.DefaultTryCastAs(LogicalType::BIGINT);
+			if (!bigint_value) {
 				return false;
 			}
-			offset = bigint_value.GetValue<int64_t>();
+			offset = bigint_value->GetValue<int64_t>();
 		}
 
 		//	We can only support LEAD and LAG values within one standard vector
@@ -382,7 +382,12 @@ public:
 			return false;
 		}
 		auto dflt_value = ExpressionExecutor::EvaluateScalar(client, *default_expr);
-		return dflt_value.DefaultTryCastAs(wexpr.GetReturnType(), result, nullptr, false);
+		auto casted_value = dflt_value.DefaultTryCastAs(wexpr.GetReturnType());
+		if (!casted_value) {
+			return false;
+		}
+		result = std::move(*casted_value);
+		return true;
 	}
 
 	WindowLeadLagStreamingState(ClientContext &context, const BoundWindowExpression &wexpr)
@@ -1041,13 +1046,13 @@ public:
 		if (nth_value.IsNull()) {
 			return false;
 		}
-		Value bigint_value;
-		if (!nth_value.DefaultTryCastAs(LogicalType::BIGINT, bigint_value, nullptr, false)) {
+		auto bigint_value = nth_value.DefaultTryCastAs(LogicalType::BIGINT);
+		if (!bigint_value) {
 			return false;
 		}
 		//	Unlike PG we are currently accepting negative indices and mapping them to 0.
 		//	Streaming this will have the same behaviour if we use a 0 index.
-		const auto bigint = bigint_value.GetValue<int64_t>();
+		const auto bigint = bigint_value->GetValue<int64_t>();
 		nth_index = bigint > 0 ? UnsafeNumericCast<idx_t>(bigint) : 0;
 		return true;
 	}

--- a/src/function/window/window_value_function.cpp
+++ b/src/function/window/window_value_function.cpp
@@ -382,11 +382,11 @@ public:
 			return false;
 		}
 		auto dflt_value = ExpressionExecutor::EvaluateScalar(client, *default_expr);
-		auto casted_value = dflt_value.DefaultTryCastAs(wexpr.GetReturnType());
-		if (!casted_value) {
+		auto cast_value = dflt_value.DefaultTryCastAs(wexpr.GetReturnType());
+		if (!cast_value) {
 			return false;
 		}
-		result = std::move(*casted_value);
+		result = std::move(*cast_value);
 		return true;
 	}
 

--- a/src/include/duckdb/common/extra_type_info.hpp
+++ b/src/include/duckdb/common/extra_type_info.hpp
@@ -50,7 +50,7 @@ protected:
 	ExtraTypeInfo &operator=(const ExtraTypeInfo &other);
 
 public:
-	bool Equals(ExtraTypeInfo *other_p) const;
+	bool Equals(const ExtraTypeInfo *other_p) const;
 
 	virtual void Serialize(Serializer &serializer) const;
 	static shared_ptr<ExtraTypeInfo> Deserialize(Deserializer &source);
@@ -72,7 +72,7 @@ public:
 	}
 
 protected:
-	virtual bool EqualsInternal(ExtraTypeInfo *other_p) const;
+	virtual bool EqualsInternal(const ExtraTypeInfo *other_p) const;
 };
 
 struct DecimalTypeInfo : public ExtraTypeInfo {
@@ -87,7 +87,7 @@ public:
 	shared_ptr<ExtraTypeInfo> Copy() const override;
 
 protected:
-	bool EqualsInternal(ExtraTypeInfo *other_p) const override;
+	bool EqualsInternal(const ExtraTypeInfo *other_p) const override;
 
 private:
 	DecimalTypeInfo();
@@ -104,7 +104,7 @@ public:
 	shared_ptr<ExtraTypeInfo> Copy() const override;
 
 protected:
-	bool EqualsInternal(ExtraTypeInfo *other_p) const override;
+	bool EqualsInternal(const ExtraTypeInfo *other_p) const override;
 
 private:
 	StringTypeInfo();
@@ -122,7 +122,7 @@ public:
 	shared_ptr<ExtraTypeInfo> DeepCopy() const override;
 
 protected:
-	bool EqualsInternal(ExtraTypeInfo *other_p) const override;
+	bool EqualsInternal(const ExtraTypeInfo *other_p) const override;
 
 private:
 	ListTypeInfo();
@@ -141,7 +141,7 @@ public:
 	shared_ptr<ExtraTypeInfo> DeepCopy() const override;
 
 protected:
-	bool EqualsInternal(ExtraTypeInfo *other_p) const override;
+	bool EqualsInternal(const ExtraTypeInfo *other_p) const override;
 
 private:
 	StructTypeInfo();
@@ -156,7 +156,7 @@ public:
 	static shared_ptr<ExtraTypeInfo> LegacyDeserialize();
 
 protected:
-	bool EqualsInternal(ExtraTypeInfo *other_p) const override;
+	bool EqualsInternal(const ExtraTypeInfo *other_p) const override;
 
 private:
 	LegacyAggregateStateTypeInfo();
@@ -185,7 +185,7 @@ public:
 
 protected:
 	// Equalities are only used in enums with different catalog entries
-	bool EqualsInternal(ExtraTypeInfo *other_p) const override;
+	bool EqualsInternal(const ExtraTypeInfo *other_p) const override;
 
 	Vector values_insert_order;
 
@@ -206,7 +206,7 @@ public:
 	shared_ptr<ExtraTypeInfo> DeepCopy() const override;
 
 protected:
-	bool EqualsInternal(ExtraTypeInfo *other_p) const override;
+	bool EqualsInternal(const ExtraTypeInfo *other_p) const override;
 };
 
 struct AnyTypeInfo : public ExtraTypeInfo {
@@ -222,7 +222,7 @@ public:
 	shared_ptr<ExtraTypeInfo> DeepCopy() const override;
 
 protected:
-	bool EqualsInternal(ExtraTypeInfo *other_p) const override;
+	bool EqualsInternal(const ExtraTypeInfo *other_p) const override;
 
 private:
 	AnyTypeInfo();
@@ -239,7 +239,7 @@ public:
 	shared_ptr<ExtraTypeInfo> Copy() const override;
 
 protected:
-	bool EqualsInternal(ExtraTypeInfo *other_p) const override;
+	bool EqualsInternal(const ExtraTypeInfo *other_p) const override;
 
 private:
 	IntegerLiteralTypeInfo();
@@ -258,7 +258,7 @@ public:
 	shared_ptr<ExtraTypeInfo> Copy() const override;
 
 protected:
-	bool EqualsInternal(ExtraTypeInfo *other_p) const override;
+	bool EqualsInternal(const ExtraTypeInfo *other_p) const override;
 	TemplateTypeInfo();
 };
 
@@ -274,7 +274,7 @@ public:
 	CoordinateReferenceSystem crs;
 
 protected:
-	bool EqualsInternal(ExtraTypeInfo *other_p) const override;
+	bool EqualsInternal(const ExtraTypeInfo *other_p) const override;
 };
 
 struct UnboundTypeInfo : public ExtraTypeInfo {
@@ -287,7 +287,7 @@ struct UnboundTypeInfo : public ExtraTypeInfo {
 	shared_ptr<ExtraTypeInfo> Copy() const override;
 
 protected:
-	bool EqualsInternal(ExtraTypeInfo *other_p) const override;
+	bool EqualsInternal(const ExtraTypeInfo *other_p) const override;
 
 private:
 	UnboundTypeInfo();

--- a/src/include/duckdb/common/types.hpp
+++ b/src/include/duckdb/common/types.hpp
@@ -263,7 +263,7 @@ struct ExtensionTypeInfo;
 struct LogicalType {
 	DUCKDB_API LogicalType();
 	DUCKDB_API LogicalType(LogicalTypeId id); // NOLINT: Allow implicit conversion from `LogicalTypeId`
-	DUCKDB_API LogicalType(LogicalTypeId id, shared_ptr<ExtraTypeInfo> type_info);
+	DUCKDB_API LogicalType(LogicalTypeId id, shared_ptr<const ExtraTypeInfo> type_info);
 	DUCKDB_API LogicalType(const LogicalType &other);
 	DUCKDB_API LogicalType(LogicalType &&other) noexcept;
 
@@ -275,7 +275,7 @@ struct LogicalType {
 	inline PhysicalType InternalType() const {
 		return physical_type_;
 	}
-	inline const optional_ptr<ExtraTypeInfo> AuxInfo() const {
+	inline optional_ptr<const ExtraTypeInfo> AuxInfo() const {
 		return type_info_.get();
 	}
 	inline bool IsNested() const {
@@ -298,18 +298,11 @@ struct LogicalType {
 		return id_ == LogicalTypeId::UNBOUND;
 	}
 
-	inline shared_ptr<ExtraTypeInfo> GetAuxInfoShrPtr() const {
-		return type_info_;
-	}
-
 	//! Copies the logical type, making a new ExtraTypeInfo
 	LogicalType Copy() const;
 	//! DeepCopy() will make a unique copy of any nested ExtraTypeInfo as well
 	LogicalType DeepCopy() const;
 
-	inline void CopyAuxInfo(const LogicalType &other) {
-		type_info_ = other.type_info_;
-	}
 	bool EqualTypeInfo(const LogicalType &rhs) const;
 
 	// copy assignment
@@ -353,14 +346,15 @@ struct LogicalType {
 	DUCKDB_API static bool IsNumeric(LogicalTypeId type);
 	DUCKDB_API bool IsTemporal() const;
 	DUCKDB_API hash_t Hash() const;
-	DUCKDB_API void SetAlias(string alias);
+	//! Returns a copy of this type with "alias" as its alias - never modifies types that share our type info
+	DUCKDB_API LogicalType WithAlias(string alias) const;
 	DUCKDB_API bool HasAlias() const;
 	DUCKDB_API string GetAlias() const;
 
 	DUCKDB_API bool HasExtensionInfo() const;
 	DUCKDB_API optional_ptr<const ExtensionTypeInfo> GetExtensionInfo() const;
-	DUCKDB_API optional_ptr<ExtensionTypeInfo> GetExtensionInfo();
-	DUCKDB_API void SetExtensionInfo(unique_ptr<ExtensionTypeInfo> info);
+	//! Returns a copy of this type with "info" as its extension info - never modifies types that share our type info
+	DUCKDB_API LogicalType WithExtensionInfo(unique_ptr<ExtensionTypeInfo> info) const;
 
 	//! Returns the maximum logical type when combining the two types - or throws an exception if combining is not
 	//! possible
@@ -400,9 +394,9 @@ struct LogicalType {
 	bool SupportsRegularUpdate() const;
 
 private:
-	LogicalTypeId id_;                    // NOLINT: allow this naming for legacy reasons
-	PhysicalType physical_type_;          // NOLINT: allow this naming for legacy reasons
-	shared_ptr<ExtraTypeInfo> type_info_; // NOLINT: allow this naming for legacy reasons
+	LogicalTypeId id_;                          // NOLINT: allow this naming for legacy reasons
+	PhysicalType physical_type_;                // NOLINT: allow this naming for legacy reasons
+	shared_ptr<const ExtraTypeInfo> type_info_; // NOLINT: allow this naming for legacy reasons
 
 private:
 	PhysicalType GetInternalType();

--- a/src/include/duckdb/common/types/value.hpp
+++ b/src/include/duckdb/common/types/value.hpp
@@ -18,6 +18,7 @@
 #include "duckdb/common/types/datetime.hpp"
 #include "duckdb/common/types/interval.hpp"
 #include "duckdb/common/shared_ptr.hpp"
+#include "duckdb/common/optional.hpp"
 #include "duckdb/common/insertion_order_preserving_map.hpp"
 
 #include <cmath>
@@ -76,9 +77,6 @@ public:
 	// move assignment
 	DUCKDB_API Value &operator=(Value &&other) noexcept;
 
-	inline LogicalType &GetTypeMutable() {
-		return type_;
-	}
 	inline const LogicalType &type() const { // NOLINT
 		return type_;
 	}
@@ -250,20 +248,18 @@ public:
 	                        bool strict = false) const;
 	DUCKDB_API Value CastAs(ClientContext &context, const LogicalType &target_type, bool strict = false) const;
 	DUCKDB_API Value DefaultCastAs(const LogicalType &target_type, bool strict = false) const;
-	//! Tries to cast this value to another type, and stores the result in "new_value"
-	DUCKDB_API bool TryCastAs(CastFunctionSet &set, GetCastFunctionInput &get_input, const LogicalType &target_type,
-	                          Value &new_value, string *error_message, bool strict = false) const;
-	DUCKDB_API bool TryCastAs(ClientContext &context, const LogicalType &target_type, Value &new_value,
-	                          string *error_message, bool strict = false) const;
-	DUCKDB_API bool DefaultTryCastAs(const LogicalType &target_type, Value &new_value, string *error_message,
-	                                 bool strict = false) const;
-	//! Tries to cast this value to another type, and stores the result in THIS value again
-	DUCKDB_API bool TryCastAs(CastFunctionSet &set, GetCastFunctionInput &get_input, const LogicalType &target_type,
-	                          bool strict = false);
-	DUCKDB_API bool TryCastAs(ClientContext &context, const LogicalType &target_type, bool strict = false);
-	DUCKDB_API bool DefaultTryCastAs(const LogicalType &target_type, bool strict = false);
+	//! Tries to cast this value to another type - returns the result, or nullopt if the cast is not possible.
+	//! Never throws on a failed cast; pass "error_message" to obtain the reason for the failure
+	DUCKDB_API optional<Value> TryCastAs(CastFunctionSet &set, GetCastFunctionInput &get_input,
+	                                     const LogicalType &target_type, string *error_message = nullptr,
+	                                     bool strict = false) const;
+	DUCKDB_API optional<Value> TryCastAs(ClientContext &context, const LogicalType &target_type,
+	                                     string *error_message = nullptr, bool strict = false) const;
+	DUCKDB_API optional<Value> DefaultTryCastAs(const LogicalType &target_type, string *error_message = nullptr,
+	                                            bool strict = false) const;
 
-	DUCKDB_API void Reinterpret(LogicalType new_type);
+	//! Returns a copy of this value with its type replaced - the underlying value is reinterpreted, not cast
+	DUCKDB_API Value WithType(LogicalType new_type) const;
 
 	//! Serializes a Value to a stand-alone binary blob
 	DUCKDB_API void Serialize(Serializer &serializer) const;

--- a/src/main/appender.cpp
+++ b/src/main/appender.cpp
@@ -321,10 +321,10 @@ void duckdb::BaseAppender::Append(DataChunk &target, const Value &value, idx_t c
 	if (value.type() == target.GetTypes()[col]) {
 		target.data[col].SetValue(row, value);
 	} else {
-		Value new_value;
 		string error_msg;
-		if (value.DefaultTryCastAs(target.GetTypes()[col], new_value, &error_msg)) {
-			target.data[col].SetValue(row, new_value);
+		auto new_value = value.DefaultTryCastAs(target.GetTypes()[col], &error_msg);
+		if (new_value) {
+			target.data[col].SetValue(row, *new_value);
 		} else {
 			throw InvalidInputException("type mismatch in Append, expected %s, got %s for column %d",
 			                            target.GetTypes()[col], value.type(), col);

--- a/src/main/capi/duckdb_value-c.cpp
+++ b/src/main/capi/duckdb_value-c.cpp
@@ -50,11 +50,11 @@ static duckdb_value CAPICreateValue(T input) {
 template <class T, LogicalTypeId TYPE_ID>
 static T CAPIGetValue(duckdb_value val) {
 	auto &v = UnwrapValue(val);
-	auto casted = v.DefaultTryCastAs(TYPE_ID);
-	if (!casted) {
+	auto cast = v.DefaultTryCastAs(TYPE_ID);
+	if (!cast) {
 		return duckdb::NullValue<T>();
 	}
-	return casted->template GetValue<T>();
+	return cast->template GetValue<T>();
 }
 
 duckdb_value duckdb_create_bool(bool input) {

--- a/src/main/capi/duckdb_value-c.cpp
+++ b/src/main/capi/duckdb_value-c.cpp
@@ -50,10 +50,11 @@ static duckdb_value CAPICreateValue(T input) {
 template <class T, LogicalTypeId TYPE_ID>
 static T CAPIGetValue(duckdb_value val) {
 	auto &v = UnwrapValue(val);
-	if (!v.DefaultTryCastAs(TYPE_ID)) {
+	auto casted = v.DefaultTryCastAs(TYPE_ID);
+	if (!casted) {
 		return duckdb::NullValue<T>();
 	}
-	return v.GetValue<T>();
+	return casted->template GetValue<T>();
 }
 
 duckdb_value duckdb_create_bool(bool input) {

--- a/src/main/capi/logical_types-c.cpp
+++ b/src/main/capi/logical_types-c.cpp
@@ -373,7 +373,7 @@ char *duckdb_logical_type_get_alias(duckdb_logical_type type) {
 
 void duckdb_logical_type_set_alias(duckdb_logical_type type, const char *alias) {
 	auto &logical_type = *(reinterpret_cast<duckdb::LogicalType *>(type));
-	logical_type.SetAlias(alias);
+	logical_type = logical_type.WithAlias(alias);
 }
 
 duckdb_logical_type duckdb_struct_type_child_type(duckdb_logical_type type, idx_t index) {

--- a/src/main/capi/result-c.cpp
+++ b/src/main/capi/result-c.cpp
@@ -374,8 +374,11 @@ bool DeprecatedMaterializeResult(duckdb_result *result) {
 	    materialized.GetStatementProperties().return_type == StatementReturnType::CHANGED_ROWS) {
 		// update total changes
 		auto row_changes = materialized.GetValue(0, 0);
-		if (!row_changes.IsNull() && row_changes.DefaultTryCastAs(LogicalType::BIGINT)) {
-			result->deprecated_rows_changed = NumericCast<idx_t>(row_changes.GetValue<int64_t>());
+		if (!row_changes.IsNull()) {
+			auto casted_row_changes = row_changes.DefaultTryCastAs(LogicalType::BIGINT);
+			if (casted_row_changes) {
+				result->deprecated_rows_changed = NumericCast<idx_t>(casted_row_changes->GetValue<int64_t>());
+			}
 		}
 	}
 

--- a/src/main/capi/result-c.cpp
+++ b/src/main/capi/result-c.cpp
@@ -375,9 +375,9 @@ bool DeprecatedMaterializeResult(duckdb_result *result) {
 		// update total changes
 		auto row_changes = materialized.GetValue(0, 0);
 		if (!row_changes.IsNull()) {
-			auto casted_row_changes = row_changes.DefaultTryCastAs(LogicalType::BIGINT);
-			if (casted_row_changes) {
-				result->deprecated_rows_changed = NumericCast<idx_t>(casted_row_changes->GetValue<int64_t>());
+			auto cast_row_changes = row_changes.DefaultTryCastAs(LogicalType::BIGINT);
+			if (cast_row_changes) {
+				result->deprecated_rows_changed = NumericCast<idx_t>(cast_row_changes->GetValue<int64_t>());
 			}
 		}
 	}

--- a/src/main/prepared_statement_data.cpp
+++ b/src/main/prepared_statement_data.cpp
@@ -156,13 +156,13 @@ void PreparedStatementData::Bind(ClientContext &context, const identifier_map_t<
 		auto parameter_value = GetParameterValue(context, values, it.first, can_read_user_variable);
 		D_ASSERT(it.second);
 		const auto &value = parameter_value.GetValue();
-		auto casted_value = value.DefaultTryCastAs(it.second->return_type);
-		if (!casted_value) {
+		auto cast_value = value.DefaultTryCastAs(it.second->return_type);
+		if (!cast_value) {
 			throw BinderException(
 			    "Type mismatch for binding parameter with identifier %s, expected type %s but got type %s", identifier,
 			    it.second->return_type.ToString().c_str(), value.type().ToString().c_str());
 		}
-		it.second->SetValue(std::move(*casted_value));
+		it.second->SetValue(std::move(*cast_value));
 	}
 }
 

--- a/src/main/prepared_statement_data.cpp
+++ b/src/main/prepared_statement_data.cpp
@@ -155,13 +155,14 @@ void PreparedStatementData::Bind(ClientContext &context, const identifier_map_t<
 		    allow_user_variables && PreparedStatement::AllowsUserVariableFallback(it.first);
 		auto parameter_value = GetParameterValue(context, values, it.first, can_read_user_variable);
 		D_ASSERT(it.second);
-		auto value = parameter_value.GetValue();
-		if (!value.DefaultTryCastAs(it.second->return_type)) {
+		const auto &value = parameter_value.GetValue();
+		auto casted_value = value.DefaultTryCastAs(it.second->return_type);
+		if (!casted_value) {
 			throw BinderException(
 			    "Type mismatch for binding parameter with identifier %s, expected type %s but got type %s", identifier,
 			    it.second->return_type.ToString().c_str(), value.type().ToString().c_str());
 		}
-		it.second->SetValue(std::move(value));
+		it.second->SetValue(std::move(*casted_value));
 	}
 }
 

--- a/src/main/secret/secret_manager.cpp
+++ b/src/main/secret/secret_manager.cpp
@@ -312,13 +312,13 @@ BoundStatement SecretManager::BindCreateSecret(CatalogTransaction transaction, C
 
 		// Cast the provided value to the expected type
 		string error_msg;
-		Value cast_value;
-		if (!param.second.DefaultTryCastAs(matched_param->second, cast_value, &error_msg)) {
+		auto cast_value = param.second.DefaultTryCastAs(matched_param->second, &error_msg);
+		if (!cast_value) {
 			throw BinderException("Failed to cast option '%s' to type '%s': '%s'", matched_param->first,
 			                      matched_param->second.ToString(), error_msg);
 		}
 
-		bound_info.options[Identifier(matched_param->first.GetIdentifierName()).GetIdentifierName()] = {cast_value};
+		bound_info.options[Identifier(matched_param->first.GetIdentifierName()).GetIdentifierName()] = {*cast_value};
 	}
 
 	BoundStatement result;

--- a/src/optimizer/compressed_materialization.cpp
+++ b/src/optimizer/compressed_materialization.cpp
@@ -202,9 +202,11 @@ bool CMHelper::GetIntegralOffsetCompressInfo(ClientContext &context, const Logic
 
 	// Get range and cast to UBIGINT (might fail for HUGEINT, in which case we just return)
 	range_value = GetIntegralRangeValue(context, type, stats);
-	if (!range_value.DefaultTryCastAs(LogicalType::UBIGINT)) {
+	auto range_ubigint = range_value.DefaultTryCastAs(LogicalType::UBIGINT);
+	if (!range_ubigint) {
 		return false;
 	}
+	range_value = std::move(*range_ubigint);
 	offset_type = GetIntegralOffsetType(UBigIntValue::Get(range_value));
 	min = NumericStats::Min(stats);
 	return true;
@@ -227,19 +229,20 @@ LogicalType CMHelper::GetSameWidthIntegralType(const LogicalType &type, const bo
 
 bool CMHelper::ValuePreservingCastFits(const Value &value, const LogicalType &source_type,
                                        const LogicalType &target_type) {
-	Value cast_value;
-	Value roundtrip_value;
+	optional<Value> roundtrip_value;
 	try {
-		if (!value.DefaultTryCastAs(target_type, cast_value, nullptr, true)) {
+		auto cast_value = value.DefaultTryCastAs(target_type, nullptr, true);
+		if (!cast_value) {
 			return false;
 		}
-		if (!cast_value.DefaultTryCastAs(source_type, roundtrip_value, nullptr, true)) {
+		roundtrip_value = cast_value->DefaultTryCastAs(source_type, nullptr, true);
+		if (!roundtrip_value) {
 			return false;
 		}
 	} catch (ConversionException &) {
 		return false;
 	}
-	return value == roundtrip_value;
+	return value == *roundtrip_value;
 }
 
 LogicalType CMHelper::GetIntegralCastType(const LogicalType &source_type, const LogicalType &offset_type,
@@ -276,15 +279,13 @@ unique_ptr<BaseStatistics> CMHelper::CreateIntegralCastStats(const LogicalType &
 	auto compress_stats = BaseStatistics::CreateEmpty(target_type);
 	compress_stats.CopyBase(stats);
 	if (NumericStats::HasMinMax(stats)) {
-		Value cast_min;
-		Value cast_max;
-		const auto min_success = NumericStats::Min(stats).DefaultTryCastAs(target_type, cast_min, nullptr, true);
-		const auto max_success = NumericStats::Max(stats).DefaultTryCastAs(target_type, cast_max, nullptr, true);
-		if (!min_success || !max_success) {
+		auto cast_min = NumericStats::Min(stats).DefaultTryCastAs(target_type, nullptr, true);
+		auto cast_max = NumericStats::Max(stats).DefaultTryCastAs(target_type, nullptr, true);
+		if (!cast_min || !cast_max) {
 			throw InternalException("Casting failure in CMHelper::CreateIntegralCastStats");
 		}
-		NumericStats::SetMin(compress_stats, cast_min);
-		NumericStats::SetMax(compress_stats, cast_max);
+		NumericStats::SetMin(compress_stats, *cast_min);
+		NumericStats::SetMax(compress_stats, *cast_max);
 	}
 	return compress_stats.ToUnique();
 }

--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -905,7 +905,7 @@ FilterPushdownResult FilterCombiner::TryPushdownTemporalCastFilter(TableFilterSe
 	if (!cast_result) {
 		return FilterPushdownResult::NO_PUSHDOWN;
 	}
-	auto casted_value = std::move(*cast_result);
+	auto cast_value = std::move(*cast_result);
 
 	auto push_optional = [&](ExpressionType filter_type, Value filter_val) {
 		auto filter_expr =
@@ -916,14 +916,14 @@ FilterPushdownResult FilterCombiner::TryPushdownTemporalCastFilter(TableFilterSe
 	// push relaxed filter(s) as OptionalFilter
 	auto comparison_type = invert ? FlipComparisonExpression(comp.GetExpressionType()) : comp.GetExpressionType();
 	if (IsGreaterThan(comparison_type) || comparison_type == ExpressionType::COMPARE_EQUAL) {
-		Value lower = casted_value;
+		Value lower = cast_value;
 		if (!AdjustTemporalValue(lower, -margin)) {
 			return FilterPushdownResult::NO_PUSHDOWN;
 		}
 		push_optional(ExpressionType::COMPARE_GREATERTHANOREQUALTO, std::move(lower));
 	}
 	if (IsLessThan(comparison_type) || comparison_type == ExpressionType::COMPARE_EQUAL) {
-		Value upper = casted_value;
+		Value upper = cast_value;
 		if (!AdjustTemporalValue(upper, margin)) {
 			return FilterPushdownResult::NO_PUSHDOWN;
 		}

--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -893,7 +893,7 @@ FilterPushdownResult FilterCombiner::TryPushdownTemporalCastFilter(TableFilterSe
 	}
 
 	// evaluate the constant side
-	Value constant_value, casted_value;
+	Value constant_value;
 	string error_msg;
 	if (!ExpressionExecutor::TryEvaluateScalar(context, const_side, constant_value)) {
 		return FilterPushdownResult::NO_PUSHDOWN;
@@ -901,9 +901,11 @@ FilterPushdownResult FilterCombiner::TryPushdownTemporalCastFilter(TableFilterSe
 	if (constant_value.IsNull()) {
 		return FilterPushdownResult::NO_PUSHDOWN;
 	}
-	if (!constant_value.TryCastAs(context, source_type, casted_value, &error_msg)) {
+	auto cast_result = constant_value.TryCastAs(context, source_type, &error_msg);
+	if (!cast_result) {
 		return FilterPushdownResult::NO_PUSHDOWN;
 	}
+	auto casted_value = std::move(*cast_result);
 
 	auto push_optional = [&](ExpressionType filter_type, Value filter_val) {
 		auto filter_expr =

--- a/src/optimizer/rule/comparison_simplification.cpp
+++ b/src/optimizer/rule/comparison_simplification.cpp
@@ -194,12 +194,11 @@ unique_ptr<Expression> ComparisonSimplificationRule::Apply(LogicalOperator &op, 
 
 		// Can we cast the constant at all?
 		string error_message;
-		Value cast_constant;
-		auto new_constant =
-		    constant_value.TryCastAs(rewriter.context, target_type, cast_constant, &error_message, true);
+		auto new_constant = constant_value.TryCastAs(rewriter.context, target_type, &error_message, true);
 		if (!new_constant) {
 			return nullptr;
 		}
+		auto &cast_constant = *new_constant;
 
 		// Is the constant cast invertible?
 		unique_ptr<Expression> replacement;

--- a/src/optimizer/rule/in_clause_simplification_rule.cpp
+++ b/src/optimizer/rule/in_clause_simplification_rule.cpp
@@ -49,7 +49,7 @@ unique_ptr<Expression> InClauseSimplificationRule::Apply(LogicalOperator &op, ve
 		if (!new_constant) {
 			return nullptr;
 		} else {
-			auto new_constant_expr = make_uniq<BoundConstantExpression>(constant_value);
+			auto new_constant_expr = make_uniq<BoundConstantExpression>(std::move(*new_constant));
 			cast_list.push_back(std::move(new_constant_expr));
 		}
 	}

--- a/src/optimizer/rule/monotone_preimage.cpp
+++ b/src/optimizer/rule/monotone_preimage.cpp
@@ -188,11 +188,11 @@ unique_ptr<Expression> MonotonePreimageRule::Apply(LogicalOperator &op, vector<r
 		return nullptr;
 	}
 	if (c.type() != func.GetReturnType()) {
-		auto casted = c.DefaultTryCastAs(func.GetReturnType());
-		if (!casted) {
+		auto cast = c.DefaultTryCastAs(func.GetReturnType());
+		if (!cast) {
 			return nullptr;
 		}
-		c = std::move(*casted);
+		c = std::move(*cast);
 	}
 
 	// normalize the comparison so the function is on the left: f(col) OP c

--- a/src/optimizer/rule/monotone_preimage.cpp
+++ b/src/optimizer/rule/monotone_preimage.cpp
@@ -187,8 +187,12 @@ unique_ptr<Expression> MonotonePreimageRule::Apply(LogicalOperator &op, vector<r
 	if (!ExpressionExecutor::TryEvaluateScalar(GetContext(), constant_expr, c) || c.IsNull()) {
 		return nullptr;
 	}
-	if (c.type() != func.GetReturnType() && !c.DefaultTryCastAs(func.GetReturnType())) {
-		return nullptr;
+	if (c.type() != func.GetReturnType()) {
+		auto casted = c.DefaultTryCastAs(func.GetReturnType());
+		if (!casted) {
+			return nullptr;
+		}
+		c = std::move(*casted);
 	}
 
 	// normalize the comparison so the function is on the left: f(col) OP c

--- a/src/optimizer/rule/move_constants.cpp
+++ b/src/optimizer/rule/move_constants.cpp
@@ -65,8 +65,8 @@ unique_ptr<Expression> MoveConstantsRule::Apply(LogicalOperator &op, vector<refe
 		if (!Hugeint::TrySubtractInPlace(outer_value, inner_value)) {
 			return nullptr;
 		}
-		auto result_value = Value::HUGEINT(outer_value);
-		if (!result_value.DefaultTryCastAs(constant_type)) {
+		auto result_value = Value::HUGEINT(outer_value).DefaultTryCastAs(constant_type);
+		if (!result_value) {
 			if (comparison.GetExpressionType() != ExpressionType::COMPARE_EQUAL) {
 				return nullptr;
 			}
@@ -76,7 +76,7 @@ unique_ptr<Expression> MoveConstantsRule::Apply(LogicalOperator &op, vector<refe
 			return ExpressionRewriter::ConstantOrNull(
 			    std::move(arithmetic.GetChildrenMutable()[arithmetic_child_index]), Value::BOOLEAN(false));
 		}
-		outer_constant.GetValueMutable() = std::move(result_value);
+		outer_constant.GetValueMutable() = std::move(*result_value);
 	} else if (op_type == "-") {
 		// [x - 1 COMP 10] O R [1 - x COMP 10]
 		// order matters in subtraction:
@@ -86,8 +86,8 @@ unique_ptr<Expression> MoveConstantsRule::Apply(LogicalOperator &op, vector<refe
 			if (!Hugeint::TryAddInPlace(outer_value, inner_value)) {
 				return nullptr;
 			}
-			auto result_value = Value::HUGEINT(outer_value);
-			if (!result_value.DefaultTryCastAs(constant_type)) {
+			auto result_value = Value::HUGEINT(outer_value).DefaultTryCastAs(constant_type);
+			if (!result_value) {
 				// if the cast is not possible then an equality comparison is not possible
 				if (comparison.GetExpressionType() != ExpressionType::COMPARE_EQUAL) {
 					return nullptr;
@@ -95,15 +95,15 @@ unique_ptr<Expression> MoveConstantsRule::Apply(LogicalOperator &op, vector<refe
 				return ExpressionRewriter::ConstantOrNull(
 				    std::move(arithmetic.GetChildrenMutable()[arithmetic_child_index]), Value::BOOLEAN(false));
 			}
-			outer_constant.GetValueMutable() = std::move(result_value);
+			outer_constant.GetValueMutable() = std::move(*result_value);
 		} else {
 			// [1 - x COMP 10]
 			// change right side to 1-10=-9
 			if (!Hugeint::TrySubtractInPlace(inner_value, outer_value)) {
 				return nullptr;
 			}
-			auto result_value = Value::HUGEINT(inner_value);
-			if (!result_value.DefaultTryCastAs(constant_type)) {
+			auto result_value = Value::HUGEINT(inner_value).DefaultTryCastAs(constant_type);
+			if (!result_value) {
 				// if the cast is not possible then an equality comparison is not possible
 				if (comparison.GetExpressionType() != ExpressionType::COMPARE_EQUAL) {
 					return nullptr;
@@ -111,7 +111,7 @@ unique_ptr<Expression> MoveConstantsRule::Apply(LogicalOperator &op, vector<refe
 				return ExpressionRewriter::ConstantOrNull(
 				    std::move(arithmetic.GetChildrenMutable()[arithmetic_child_index]), Value::BOOLEAN(false));
 			}
-			outer_constant.GetValueMutable() = std::move(result_value);
+			outer_constant.GetValueMutable() = std::move(*result_value);
 			// in this case, we should also flip the comparison
 			// e.g. if we have [4 - x < 2] then we should have [x > 2]
 			BoundComparisonExpression::FlipType(comparison);
@@ -151,12 +151,12 @@ unique_ptr<Expression> MoveConstantsRule::Apply(LogicalOperator &op, vector<refe
 		// else divide the RHS by the LHS
 		// we need to do a range check on the cast even though we do a division
 		// because e.g. -128 / -1 = 128, which is out of range
-		auto result_value = Value::HUGEINT(outer_value / inner_value);
-		if (!result_value.DefaultTryCastAs(constant_type)) {
+		auto result_value = Value::HUGEINT(outer_value / inner_value).DefaultTryCastAs(constant_type);
+		if (!result_value) {
 			return ExpressionRewriter::ConstantOrNull(
 			    std::move(arithmetic.GetChildrenMutable()[arithmetic_child_index]), Value::BOOLEAN(false));
 		}
-		outer_constant.GetValueMutable() = std::move(result_value);
+		outer_constant.GetValueMutable() = std::move(*result_value);
 	}
 	// replace left side with x
 	// first extract x from the arithmetic expression
@@ -289,11 +289,11 @@ unique_ptr<Expression> MoveUnaryMinusRule::Apply(LogicalOperator &op, vector<ref
 		} else {
 			val = DoubleValue::Get(outer_constant.GetValue());
 		}
-		auto result_value = Value::DOUBLE(-val);
-		if (!result_value.DefaultTryCastAs(constant_type)) {
+		auto result_value = Value::DOUBLE(-val).DefaultTryCastAs(constant_type);
+		if (!result_value) {
 			return nullptr;
 		}
-		outer_constant.GetValueMutable() = std::move(result_value);
+		outer_constant.GetValueMutable() = std::move(*result_value);
 	} else if (constant_type.id() == LogicalTypeId::DECIMAL) {
 		// negate the unscaled integer and reconstruct with the same width/scale
 		hugeint_t negated_value;
@@ -327,8 +327,8 @@ unique_ptr<Expression> MoveUnaryMinusRule::Apply(LogicalOperator &op, vector<ref
 		if (!Hugeint::TryNegate(IntegralValue::Get(outer_constant.GetValue()), negated_value)) {
 			return nullptr;
 		}
-		auto result_value = Value::HUGEINT(negated_value);
-		if (!result_value.DefaultTryCastAs(constant_type)) {
+		auto result_value = Value::HUGEINT(negated_value).DefaultTryCastAs(constant_type);
+		if (!result_value) {
 			bool comparison_result;
 			if (!TryOutOfRangeComparisonResult(comparison.GetExpressionType(), comparison_result)) {
 				return nullptr;
@@ -336,7 +336,7 @@ unique_ptr<Expression> MoveUnaryMinusRule::Apply(LogicalOperator &op, vector<ref
 			return ExpressionRewriter::ConstantOrNull(std::move(negation.GetChildrenMutable()[0]),
 			                                          Value::BOOLEAN(comparison_result));
 		}
-		outer_constant.GetValueMutable() = std::move(result_value);
+		outer_constant.GetValueMutable() = std::move(*result_value);
 	}
 	// [-x COMP c] => [x FLIPPED_COMP -c]
 	auto inner_expr = std::move(negation.GetChildrenMutable()[0]);

--- a/src/optimizer/statistics/expression/propagate_cast.cpp
+++ b/src/optimizer/statistics/expression/propagate_cast.cpp
@@ -16,16 +16,16 @@ static unique_ptr<BaseStatistics> StatisticsOperationsNumericNumericCast(const B
 	if (!NumericStats::HasMinMax(input)) {
 		return nullptr;
 	}
-	Value min = NumericStats::Min(input);
-	Value max = NumericStats::Max(input);
-	if (!min.DefaultTryCastAs(target) || !max.DefaultTryCastAs(target)) {
+	auto min = NumericStats::Min(input).DefaultTryCastAs(target);
+	auto max = NumericStats::Max(input).DefaultTryCastAs(target);
+	if (!min || !max) {
 		// overflow in cast: bailout
 		return nullptr;
 	}
 	auto result = NumericStats::CreateEmpty(target);
 	result.CopyBase(input);
-	NumericStats::SetMin(result, min);
-	NumericStats::SetMax(result, max);
+	NumericStats::SetMin(result, *min);
+	NumericStats::SetMax(result, *max);
 	return result.ToUnique();
 }
 

--- a/src/optimizer/statistics/operator/propagate_aggregate.cpp
+++ b/src/optimizer/statistics/operator/propagate_aggregate.cpp
@@ -368,7 +368,7 @@ void StatisticsPropagator::TryExecuteAggregates(LogicalAggregate &aggr, unique_p
 					agg_result = rhs;
 				}
 			}
-			types.push_back(agg_result.GetTypeMutable());
+			types.push_back(agg_result.type());
 			auto expr = make_uniq<BoundConstantExpression>(agg_result);
 			agg_results.push_back(std::move(expr));
 		}

--- a/src/optimizer/statistics/operator/propagate_aggregate.cpp
+++ b/src/optimizer/statistics/operator/propagate_aggregate.cpp
@@ -150,9 +150,14 @@ bool TryGetValueFromStats(const PartitionStatistics &stats, const StorageIndex &
 		}
 	}
 	result = comparator.GetVal(*column_stats);
-	if (result.type() != result_type && !result.DefaultTryCastAs(result_type)) {
+	if (result.type() == result_type) {
+		return true;
+	}
+	auto casted = result.DefaultTryCastAs(result_type);
+	if (!casted) {
 		return false;
 	}
+	result = std::move(*casted);
 	return true;
 }
 

--- a/src/optimizer/statistics/operator/propagate_aggregate.cpp
+++ b/src/optimizer/statistics/operator/propagate_aggregate.cpp
@@ -153,11 +153,11 @@ bool TryGetValueFromStats(const PartitionStatistics &stats, const StorageIndex &
 	if (result.type() == result_type) {
 		return true;
 	}
-	auto casted = result.DefaultTryCastAs(result_type);
-	if (!casted) {
+	auto cast = result.DefaultTryCastAs(result_type);
+	if (!cast) {
 		return false;
 	}
-	result = std::move(*casted);
+	result = std::move(*cast);
 	return true;
 }
 

--- a/src/parser/peg/transformer/peg_transformer_factory.cpp
+++ b/src/parser/peg/transformer/peg_transformer_factory.cpp
@@ -372,12 +372,12 @@ bool PEGTransformerFactory::ConstructConstantFromExpression(const ParsedExpressi
 		}
 
 		string error_message;
-		auto casted_value = dummy_value.DefaultTryCastAs(cast_type, &error_message);
-		if (!casted_value) {
+		auto cast_value = dummy_value.DefaultTryCastAs(cast_type, &error_message);
+		if (!cast_value) {
 			throw ConversionException("Unable to cast %s to %s", dummy_value.ToString(),
 			                          EnumUtil::ToString(cast_type.id()));
 		}
-		value = std::move(*casted_value);
+		value = std::move(*cast_value);
 		return true;
 	}
 	default:

--- a/src/parser/peg/transformer/peg_transformer_factory.cpp
+++ b/src/parser/peg/transformer/peg_transformer_factory.cpp
@@ -372,10 +372,12 @@ bool PEGTransformerFactory::ConstructConstantFromExpression(const ParsedExpressi
 		}
 
 		string error_message;
-		if (!dummy_value.DefaultTryCastAs(cast_type, value, &error_message)) {
+		auto casted_value = dummy_value.DefaultTryCastAs(cast_type, &error_message);
+		if (!casted_value) {
 			throw ConversionException("Unable to cast %s to %s", dummy_value.ToString(),
 			                          EnumUtil::ToString(cast_type.id()));
 		}
+		value = std::move(*casted_value);
 		return true;
 	}
 	default:

--- a/src/parser/peg/transformer/transform_expression.cpp
+++ b/src/parser/peg/transformer/transform_expression.cpp
@@ -496,10 +496,10 @@ PEGTransformerFactory::TransformArrayParensSelect(PEGTransformer &transformer,
 		for (auto &order : aggr->OrderByMutable()->orders) {
 			if (order.expression->GetExpressionType() == ExpressionType::VALUE_CONSTANT) {
 				auto &constant_expr = order.expression->Cast<ConstantExpression>();
-				Value bigint_value;
 				string error;
-				if (constant_expr.GetValue().DefaultTryCastAs(LogicalType::BIGINT, bigint_value, &error)) {
-					int64_t order_index = BigIntValue::Get(bigint_value);
+				auto bigint_value = constant_expr.GetValue().DefaultTryCastAs(LogicalType::BIGINT, &error);
+				if (bigint_value) {
+					int64_t order_index = BigIntValue::Get(*bigint_value);
 					idx_t positional_index = order_index < 0 ? NumericLimits<idx_t>::Maximum() : idx_t(order_index);
 					order.expression = make_uniq<PositionalReferenceExpression>(positional_index);
 				}

--- a/src/parser/peg/transformer/transform_select.cpp
+++ b/src/parser/peg/transformer/transform_select.cpp
@@ -714,8 +714,11 @@ static unique_ptr<TableRef> BuildNearestJoin(const optional<JoinType> &join_type
 		auto value = (*number_literal)->Cast<ConstantExpression>().GetValue();
 		auto literal_text = value.ToString();
 		int64_t count = 0;
-		if (value.type().IsIntegral() && value.DefaultTryCastAs(LogicalType::BIGINT)) {
-			count = value.GetValue<int64_t>();
+		if (value.type().IsIntegral()) {
+			auto bigint_value = value.DefaultTryCastAs(LogicalType::BIGINT);
+			if (bigint_value) {
+				count = bigint_value->GetValue<int64_t>();
+			}
 		}
 		if (count < 1) {
 			throw ParserException("NEAREST expects a positive integer literal, got \"%s\"", literal_text);

--- a/src/parser/tableref/pivotref.cpp
+++ b/src/parser/tableref/pivotref.cpp
@@ -219,9 +219,11 @@ static bool TryFoldConstantForBackwardsCompatibility(const ParsedExpression &exp
 		}
 
 		string error_message;
-		if (!dummy_value.DefaultTryCastAs(cast_type, value, &error_message)) {
+		auto casted_value = dummy_value.DefaultTryCastAs(cast_type, &error_message);
+		if (!casted_value) {
 			return false;
 		}
+		value = std::move(*casted_value);
 		return true;
 	}
 	default:

--- a/src/parser/tableref/pivotref.cpp
+++ b/src/parser/tableref/pivotref.cpp
@@ -219,11 +219,11 @@ static bool TryFoldConstantForBackwardsCompatibility(const ParsedExpression &exp
 		}
 
 		string error_message;
-		auto casted_value = dummy_value.DefaultTryCastAs(cast_type, &error_message);
-		if (!casted_value) {
+		auto cast_value = dummy_value.DefaultTryCastAs(cast_type, &error_message);
+		if (!cast_value) {
 			return false;
 		}
-		value = std::move(*casted_value);
+		value = std::move(*cast_value);
 		return true;
 	}
 	default:

--- a/src/planner/binder/expression/bind_operator_expression.cpp
+++ b/src/planner/binder/expression/bind_operator_expression.cpp
@@ -133,9 +133,10 @@ BindResult ExpressionBinder::BindExpression(OperatorExpression &op, idx_t depth)
 			if (i_exp->GetExpressionClass() == ExpressionClass::BOUND_CONSTANT &&
 			    !i_exp->Cast<BoundConstantExpression>().GetValue().IsNull()) {
 				auto &const_exp = i_exp->Cast<BoundConstantExpression>();
-				if (const_exp.GetValueMutable().TryCastAs(context, LogicalType::UINTEGER)) {
+				auto uinteger_value = const_exp.GetValue().TryCastAs(context, LogicalType::UINTEGER);
+				if (uinteger_value) {
 					// Array extraction: if the cast fails it's definitely out-of-bounds for a JSON array
-					auto index = UIntegerValue::Get(const_exp.GetValueMutable());
+					auto index = UIntegerValue::Get(*uinteger_value);
 					const_exp.GetValueMutable() = StringUtil::Format("$[%lld]", index);
 					const_exp.SetReturnType(LogicalType::VARCHAR);
 				} else if (const_exp.GetReturnType().id() == LogicalType::VARCHAR) {

--- a/src/planner/binder/statement/bind_copy.cpp
+++ b/src/planner/binder/statement/bind_copy.cpp
@@ -103,12 +103,12 @@ static idx_t ParseBytesArg(const Identifier &name, Value &arg) {
 	if (arg.type().id() == LogicalTypeId::VARCHAR) {
 		return DBConfig::ParseMemoryLimit(arg.ToString());
 	}
-	auto casted_arg = arg.DefaultTryCastAs(LogicalType::UBIGINT);
-	if (!casted_arg) {
+	auto cast_arg = arg.DefaultTryCastAs(LogicalType::UBIGINT);
+	if (!cast_arg) {
 		throw BinderException("Unable to parse bytes from \"%s\" for copy option \"%s\" ", arg.ToString(),
 		                      StringUtil::Upper(name.GetIdentifierName()));
 	}
-	return casted_arg->GetValue<idx_t>();
+	return cast_arg->GetValue<idx_t>();
 }
 
 struct CopyToParsedOptions {

--- a/src/planner/binder/statement/bind_copy.cpp
+++ b/src/planner/binder/statement/bind_copy.cpp
@@ -103,11 +103,12 @@ static idx_t ParseBytesArg(const Identifier &name, Value &arg) {
 	if (arg.type().id() == LogicalTypeId::VARCHAR) {
 		return DBConfig::ParseMemoryLimit(arg.ToString());
 	}
-	if (!arg.DefaultTryCastAs(LogicalType::UBIGINT)) {
+	auto casted_arg = arg.DefaultTryCastAs(LogicalType::UBIGINT);
+	if (!casted_arg) {
 		throw BinderException("Unable to parse bytes from \"%s\" for copy option \"%s\" ", arg.ToString(),
 		                      StringUtil::Upper(name.GetIdentifierName()));
 	}
-	return arg.GetValue<idx_t>();
+	return casted_arg->GetValue<idx_t>();
 }
 
 struct CopyToParsedOptions {
@@ -771,14 +772,14 @@ BoundStatement Binder::Bind(CopyStatement &stmt, CopyToType copy_to_type) {
 					}
 				}
 
-				Value new_value;
-				if (!can_cast || !original_value.TryCastAs(context, copy_option.type, new_value, nullptr)) {
+				auto new_value = can_cast ? original_value.TryCastAs(context, copy_option.type) : nullopt;
+				if (!new_value) {
 					throw InvalidInputException("Copy option %s expected an argument of type %s - the argument "
 					                            "\"%s\" of type %s could not be cast as this type",
 					                            provided_option, copy_option.type, original_value.ToString(),
 					                            original_value.type());
 				}
-				original_value = std::move(new_value);
+				original_value = std::move(*new_value);
 			}
 		}
 	}

--- a/src/planner/filter/expression_filter.cpp
+++ b/src/planner/filter/expression_filter.cpp
@@ -355,9 +355,11 @@ TryPrepareVariantComparisonStats(const BaseStatistics &stats, Value &constant,
 	if (!TryGetVariantComparisonStatsType(typed_type, constant.type(), comparison_type)) {
 		return nullptr;
 	}
-	if (!constant.DefaultTryCastAs(comparison_type)) {
+	auto casted_constant = constant.DefaultTryCastAs(comparison_type);
+	if (!casted_constant) {
 		return nullptr;
 	}
+	constant = std::move(*casted_constant);
 	if (typed_type == comparison_type) {
 		return &typed_stats;
 	}

--- a/src/planner/filter/expression_filter.cpp
+++ b/src/planner/filter/expression_filter.cpp
@@ -355,11 +355,11 @@ TryPrepareVariantComparisonStats(const BaseStatistics &stats, Value &constant,
 	if (!TryGetVariantComparisonStatsType(typed_type, constant.type(), comparison_type)) {
 		return nullptr;
 	}
-	auto casted_constant = constant.DefaultTryCastAs(comparison_type);
-	if (!casted_constant) {
+	auto cast_constant = constant.DefaultTryCastAs(comparison_type);
+	if (!cast_constant) {
 		return nullptr;
 	}
-	constant = std::move(*casted_constant);
+	constant = std::move(*cast_constant);
 	if (typed_type == comparison_type) {
 		return &typed_stats;
 	}

--- a/src/storage/statistics/numeric_stats.cpp
+++ b/src/storage/statistics/numeric_stats.cpp
@@ -389,9 +389,7 @@ Value NumericValueUnionToValueInternal(const LogicalType &type, const NumericVal
 }
 
 Value NumericValueUnionToValue(const LogicalType &type, const NumericValueUnion &val) {
-	Value result = NumericValueUnionToValueInternal(type, val);
-	result.GetTypeMutable() = type;
-	return result;
+	return NumericValueUnionToValueInternal(type, val).WithType(type);
 }
 
 bool NumericStats::HasMinMax(const BaseStatistics &stats) {

--- a/test/api/capi/test_capi_complex_types.cpp
+++ b/test/api/capi/test_capi_complex_types.cpp
@@ -292,9 +292,8 @@ TEST_CASE("Logical types with aliases", "[capi]") {
 	connection->BeginTransaction();
 
 	child_list_t<LogicalType> children = {{"hello", LogicalType::VARCHAR}};
-	auto id = LogicalType::STRUCT(children);
 	auto type_name = "test_type";
-	id.SetAlias(type_name);
+	auto id = LogicalType::STRUCT(children).WithAlias(type_name);
 	CreateTypeInfo info(type_name, id);
 
 	auto catalog_name = DatabaseManager::GetDefaultDatabase(*connection->context);
@@ -323,6 +322,33 @@ TEST_CASE("Logical types with aliases", "[capi]") {
 
 		duckdb_destroy_logical_type(&logical_type);
 	}
+}
+
+TEST_CASE("duckdb_logical_type_set_alias does not affect other types", "[capi]") {
+	CAPITester tester;
+	REQUIRE(tester.OpenDatabase(nullptr));
+
+	// a LIST type has extra type info - the two logical types below are copies that share it
+	auto result = tester.Query("SELECT [1, 2, 3] AS l");
+	REQUIRE(NO_FAIL(*result));
+
+	auto first = duckdb_column_logical_type(&result->InternalResult(), 0);
+	auto second = duckdb_column_logical_type(&result->InternalResult(), 0);
+	REQUIRE(first);
+	REQUIRE(second);
+
+	duckdb_logical_type_set_alias(first, "MY_ALIAS");
+
+	auto alias = duckdb_logical_type_get_alias(first);
+	REQUIRE(alias);
+	REQUIRE(string(alias) == "MY_ALIAS");
+	duckdb_free(alias);
+
+	// setting the alias on "first" must not have modified "second"
+	REQUIRE(duckdb_logical_type_get_alias(second) == nullptr);
+
+	duckdb_destroy_logical_type(&first);
+	duckdb_destroy_logical_type(&second);
 }
 
 TEST_CASE("duckdb_create_value", "[capi]") {

--- a/test/common/CMakeLists.txt
+++ b/test/common/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library_unity(
   test_parse_logical_type.cpp
   test_recursive_cte_metrics.cpp
   test_logical_type_is_complete.cpp
+  test_logical_type_immutable.cpp
   test_utf.cpp
   test_allocator_debug_info.cpp
   test_buffer_pool_reservation.cpp

--- a/test/common/test_logical_type_immutable.cpp
+++ b/test/common/test_logical_type_immutable.cpp
@@ -1,0 +1,68 @@
+#include "catch.hpp"
+#include "duckdb/common/types.hpp"
+#include "duckdb/common/extension_type_info.hpp"
+#include "duckdb/common/vector/flat_vector.hpp"
+#include "duckdb/common/vector/string_vector.hpp"
+
+using namespace duckdb;
+
+TEST_CASE("Test that LogicalType::WithAlias does not modify shared type info", "[logical_type_immutable]") {
+	SECTION("nested types share their extra type info") {
+		auto base = LogicalType::LIST(LogicalType::INTEGER);
+		auto shared = base;
+
+		auto aliased = base.WithAlias("MY_LIST");
+		REQUIRE(!base.HasAlias());
+		REQUIRE(!shared.HasAlias());
+		REQUIRE(aliased.GetAlias() == "MY_LIST");
+		REQUIRE(aliased.InternalType() == base.InternalType());
+		REQUIRE(ListType::GetChildType(aliased) == LogicalType::INTEGER);
+	}
+
+	SECTION("re-aliasing does not modify the previous alias") {
+		auto first = LogicalType::LIST(LogicalType::INTEGER).WithAlias("FIRST");
+		auto second = first.WithAlias("SECOND");
+		REQUIRE(first.GetAlias() == "FIRST");
+		REQUIRE(second.GetAlias() == "SECOND");
+	}
+
+	SECTION("enums are unshared and keep a working dictionary") {
+		Vector values(LogicalType::VARCHAR, 2);
+		auto data = FlatVector::GetDataMutable<string_t>(values);
+		data[0] = StringVector::AddString(values, "a");
+		data[1] = StringVector::AddString(values, "b");
+
+		auto base = LogicalType::ENUM(values, 2);
+		auto shared = base;
+		auto aliased = base.WithAlias("MOOD");
+
+		REQUIRE(!base.HasAlias());
+		REQUIRE(!shared.HasAlias());
+		REQUIRE(aliased.GetAlias() == "MOOD");
+		REQUIRE(EnumType::GetSize(aliased) == 2);
+		REQUIRE(EnumType::GetPos(aliased, string_t("b")) == 1);
+		REQUIRE(EnumType::GetPos(aliased, string_t("c")) == -1);
+	}
+
+	SECTION("an empty alias does not allocate extra type info") {
+		auto type = LogicalType(LogicalTypeId::INTEGER);
+		REQUIRE(!type.WithAlias("").AuxInfo());
+		REQUIRE(type.WithAlias("") == type);
+		// a generic type info with an empty alias compares equal to a type without type info
+		REQUIRE(type.WithAlias("x").WithAlias("") == type);
+	}
+}
+
+TEST_CASE("Test that LogicalType::WithExtensionInfo does not modify shared type info", "[logical_type_immutable]") {
+	auto base = LogicalType::LIST(LogicalType::INTEGER);
+	auto shared = base;
+
+	auto info = make_uniq<ExtensionTypeInfo>();
+	info->modifiers.emplace_back(Value::INTEGER(42));
+	auto extended = base.WithExtensionInfo(std::move(info));
+
+	REQUIRE(!base.HasExtensionInfo());
+	REQUIRE(!shared.HasExtensionInfo());
+	REQUIRE(extended.HasExtensionInfo());
+	REQUIRE(extended.GetExtensionInfo()->modifiers[0].value.GetValue<int32_t>() == 42);
+}

--- a/test/extension/loadable_extension_demo.cpp
+++ b/test/extension/loadable_extension_demo.cpp
@@ -520,18 +520,13 @@ struct BoundedType {
 	}
 
 	static LogicalType Get(int32_t max_val) {
-		auto type = LogicalType(LogicalTypeId::INTEGER);
-		type.SetAlias("BOUNDED");
 		auto info = make_uniq<ExtensionTypeInfo>();
 		info->modifiers.emplace_back(Value::INTEGER(max_val));
-		type.SetExtensionInfo(std::move(info));
-		return type;
+		return LogicalType(LogicalTypeId::INTEGER).WithAlias("BOUNDED").WithExtensionInfo(std::move(info));
 	}
 
 	static LogicalType GetDefault() {
-		auto type = LogicalType(LogicalTypeId::INTEGER);
-		type.SetAlias("BOUNDED");
-		return type;
+		return LogicalType(LogicalTypeId::INTEGER).WithAlias("BOUNDED");
 	}
 
 	static int32_t GetMaxValue(const LogicalType &type) {
@@ -695,13 +690,10 @@ struct MinMaxType {
 			throw BinderException("MINMAX type min value must be less than max value");
 		}
 
-		auto type = LogicalType(LogicalTypeId::INTEGER);
-		type.SetAlias("MINMAX");
 		auto info = make_uniq<ExtensionTypeInfo>();
 		info->modifiers.emplace_back(Value::INTEGER(min_val));
 		info->modifiers.emplace_back(Value::INTEGER(max_val));
-		type.SetExtensionInfo(std::move(info));
-		return type;
+		return LogicalType(LogicalTypeId::INTEGER).WithAlias("MINMAX").WithExtensionInfo(std::move(info));
 	}
 
 	static int32_t GetMinValue(const LogicalType &type) {
@@ -717,19 +709,14 @@ struct MinMaxType {
 	}
 
 	static LogicalType Get(int32_t min_val, int32_t max_val) {
-		auto type = LogicalType(LogicalTypeId::INTEGER);
-		type.SetAlias("MINMAX");
 		auto info = make_uniq<ExtensionTypeInfo>();
 		info->modifiers.emplace_back(Value::INTEGER(min_val));
 		info->modifiers.emplace_back(Value::INTEGER(max_val));
-		type.SetExtensionInfo(std::move(info));
-		return type;
+		return LogicalType(LogicalTypeId::INTEGER).WithAlias("MINMAX").WithExtensionInfo(std::move(info));
 	}
 
 	static LogicalType GetDefault() {
-		auto type = LogicalType(LogicalTypeId::INTEGER);
-		type.SetAlias("MINMAX");
-		return type;
+		return LogicalType(LogicalTypeId::INTEGER).WithAlias("MINMAX");
 	}
 };
 
@@ -1193,8 +1180,7 @@ DUCKDB_CPP_EXTENSION_ENTRY(loadable_extension_demo, loader) {
 	auto alias_info = make_uniq<CreateTypeInfo>();
 	alias_info->internal = true;
 	alias_info->SetTypeName(Identifier(alias_name));
-	LogicalType target_type = LogicalType::STRUCT(child_types);
-	target_type.SetAlias(alias_name);
+	LogicalType target_type = LogicalType::STRUCT(child_types).WithAlias(alias_name);
 	alias_info->type = target_type;
 
 	auto type_entry = catalog.CreateType(client_context, *alias_info);

--- a/test/sqlite/result_helper.cpp
+++ b/test/sqlite/result_helper.cpp
@@ -521,18 +521,24 @@ bool TestResultHelper::CompareValues(SQLLogicTestLogger &logger, MaterializedQue
 			lvalue = Value(sql_type);
 			converted_lvalue = true;
 		} else {
-			lvalue = Value(lvalue_str);
-			if (lvalue.TryCastAs(*runner.con->context, sql_type)) {
+			auto casted_lvalue = Value(lvalue_str).TryCastAs(*runner.con->context, sql_type);
+			if (casted_lvalue) {
+				lvalue = std::move(*casted_lvalue);
 				converted_lvalue = true;
+			} else {
+				lvalue = Value(lvalue_str);
 			}
 		}
 		if (rvalue_str == "NULL") {
 			rvalue = Value(sql_type);
 			converted_rvalue = true;
 		} else {
-			rvalue = Value(rvalue_str);
-			if (rvalue.TryCastAs(*runner.con->context, sql_type)) {
+			auto casted_rvalue = Value(rvalue_str).TryCastAs(*runner.con->context, sql_type);
+			if (casted_rvalue) {
+				rvalue = std::move(*casted_rvalue);
 				converted_rvalue = true;
+			} else {
+				rvalue = Value(rvalue_str);
 			}
 		}
 		if (converted_lvalue && converted_rvalue) {

--- a/test/sqlite/result_helper.cpp
+++ b/test/sqlite/result_helper.cpp
@@ -521,9 +521,9 @@ bool TestResultHelper::CompareValues(SQLLogicTestLogger &logger, MaterializedQue
 			lvalue = Value(sql_type);
 			converted_lvalue = true;
 		} else {
-			auto casted_lvalue = Value(lvalue_str).TryCastAs(*runner.con->context, sql_type);
-			if (casted_lvalue) {
-				lvalue = std::move(*casted_lvalue);
+			auto cast_lvalue = Value(lvalue_str).TryCastAs(*runner.con->context, sql_type);
+			if (cast_lvalue) {
+				lvalue = std::move(*cast_lvalue);
 				converted_lvalue = true;
 			} else {
 				lvalue = Value(lvalue_str);
@@ -533,9 +533,9 @@ bool TestResultHelper::CompareValues(SQLLogicTestLogger &logger, MaterializedQue
 			rvalue = Value(sql_type);
 			converted_rvalue = true;
 		} else {
-			auto casted_rvalue = Value(rvalue_str).TryCastAs(*runner.con->context, sql_type);
-			if (casted_rvalue) {
-				rvalue = std::move(*casted_rvalue);
+			auto cast_rvalue = Value(rvalue_str).TryCastAs(*runner.con->context, sql_type);
+			if (cast_rvalue) {
+				rvalue = std::move(*cast_rvalue);
 				converted_rvalue = true;
 			} else {
 				rvalue = Value(rvalue_str);

--- a/test/sqlite/sqllogic_test_runner.cpp
+++ b/test/sqlite/sqllogic_test_runner.cpp
@@ -1103,11 +1103,11 @@ void SQLLogicTestRunner::ExecuteScript(SQLLogicParser &parser, const string &scr
 				if (token.parameters.size() != 2) {
 					parser.Fail("set seed requires a single seed value");
 				}
-				Value seed(token.parameters[1]);
-				if (!seed.DefaultTryCastAs(LogicalType::DOUBLE)) {
+				auto seed = Value(token.parameters[1]).DefaultTryCastAs(LogicalType::DOUBLE);
+				if (!seed) {
 					parser.Fail("set seed requires a floating point parameter");
 				}
-				auto res = con->Query("SELECT SETSEED(" + seed.ToString() + ")");
+				auto res = con->Query("SELECT SETSEED(" + seed->ToString() + ")");
 				if (res->HasError()) {
 					parser.Fail("Failed to set seed: %s", res->GetError());
 				}

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -966,9 +966,12 @@ SuccessState ShellState::ExecuteStatement(unique_ptr<duckdb::SQLStatement> state
 		if (result_chunk && result_chunk->size() == 1) {
 			// update total changes
 			auto row_changes = result_chunk->GetValue(0, 0);
-			if (!row_changes.IsNull() && row_changes.DefaultTryCastAs(duckdb::LogicalType::BIGINT)) {
-				last_changes = row_changes.GetValue<int64_t>();
-				total_changes += last_changes;
+			if (!row_changes.IsNull()) {
+				auto casted_row_changes = row_changes.DefaultTryCastAs(duckdb::LogicalType::BIGINT);
+				if (casted_row_changes) {
+					last_changes = casted_row_changes->GetValue<int64_t>();
+					total_changes += last_changes;
+				}
 			}
 		}
 	}

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -967,9 +967,9 @@ SuccessState ShellState::ExecuteStatement(unique_ptr<duckdb::SQLStatement> state
 			// update total changes
 			auto row_changes = result_chunk->GetValue(0, 0);
 			if (!row_changes.IsNull()) {
-				auto casted_row_changes = row_changes.DefaultTryCastAs(duckdb::LogicalType::BIGINT);
-				if (casted_row_changes) {
-					last_changes = casted_row_changes->GetValue<int64_t>();
+				auto cast_row_changes = row_changes.DefaultTryCastAs(duckdb::LogicalType::BIGINT);
+				if (cast_row_changes) {
+					last_changes = cast_row_changes->GetValue<int64_t>();
 					total_changes += last_changes;
 				}
 			}


### PR DESCRIPTION
This PR is stacked upon https://github.com/duckdb/duckdb/pull/24738.

The idea is the same: `duckdb::Value` is commonly part of shared pointer structures, and should therefore be immutable.

The main change is removing `Value::GetTypeMutable()` and making the mutable versions of `Value::TryCastAs` and `Value::Reinterpret` now return a new `optional<Value>` instead of modifying the value in place. 

Also `TryCastAs` used to throw or return false depending on whether you passed an error string, but it now never throw.