### PR TITLE
Use `CHECK` constraints to prune contradicting filters

### DIFF
--- a/src/include/duckdb/optimizer/filter_pushdown.hpp
+++ b/src/include/duckdb/optimizer/filter_pushdown.hpp
@@ -14,6 +14,7 @@
 
 namespace duckdb {
 
+class LogicalGet;
 class Optimizer;
 
 class FilterPushdown {
@@ -70,6 +71,8 @@ private:
 	unique_ptr<LogicalOperator> PushdownSetOperation(unique_ptr<LogicalOperator> op);
 	//! Push down a LogicalGet op
 	unique_ptr<LogicalOperator> PushdownGet(unique_ptr<LogicalOperator> op);
+	//! Whether or not any of the filters contradicts a CHECK constraint of the scanned table
+	bool CheckConstraintsUnsatisfiable(const LogicalGet &get);
 	//! Push down a LogicalLimit op
 	unique_ptr<LogicalOperator> PushdownLimit(unique_ptr<LogicalOperator> op);
 	//! Push down a LogicalWindow op

--- a/src/optimizer/pushdown/pushdown_get.cpp
+++ b/src/optimizer/pushdown/pushdown_get.cpp
@@ -1,12 +1,19 @@
+#include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
 #include "duckdb/optimizer/filter_pushdown.hpp"
 #include "duckdb/optimizer/in_clause_rewriter.hpp"
 #include "duckdb/optimizer/optimizer.hpp"
+#include "duckdb/planner/binder.hpp"
+#include "duckdb/planner/constraints/bound_check_constraint.hpp"
+#include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
+#include "duckdb/planner/expression/bound_comparison_expression.hpp"
 #include "duckdb/planner/expression/bound_operator_expression.hpp"
 #include "duckdb/planner/expression/bound_parameter_expression.hpp"
+#include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/planner/expression_iterator.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/planner/operator/logical_empty_result.hpp"
+#include "duckdb/storage/storage_index.hpp"
 
 namespace duckdb {
 
@@ -41,12 +48,93 @@ static void NormalizeColumnRefAliases(unique_ptr<Expression> &expr, const Logica
 	});
 }
 
+//! Rewrite the column references of a bound CHECK expression (which are storage indexes) into bindings of the get
+static bool RewriteCheckExpression(unique_ptr<Expression> &expr, const LogicalGet &get) {
+	unordered_map<idx_t, idx_t> storage_to_binding;
+	auto &column_ids = get.GetColumnIds();
+	for (idx_t i = 0; i < column_ids.size(); i++) {
+		StorageIndex storage_index;
+		if (column_ids[i].HasChildren() || !get.TryGetStorageIndex(column_ids[i], storage_index)) {
+			continue;
+		}
+		storage_to_binding[storage_index.GetPrimaryIndex()] = i;
+	}
+	bool success = true;
+	ExpressionIterator::VisitExpressionMutable<BoundReferenceExpression>(
+	    expr, [&](BoundReferenceExpression &ref, unique_ptr<Expression> &child) {
+		    auto entry = storage_to_binding.find(ref.Index());
+		    if (entry == storage_to_binding.end()) {
+			    // the column is not scanned by the get
+			    success = false;
+			    return;
+		    }
+		    child = make_uniq<BoundColumnRefExpression>(ref.GetReturnType(),
+		                                                ColumnBinding(get.table_index, ProjectionIndex(entry->second)));
+	    });
+	return success;
+}
+
+//! A CHECK constraint guarantees that its expression never evaluates to FALSE for any row in the table
+//! a filter that is the negation of a CHECK expression can therefore never be satisfied
+static bool IsNegation(const Expression &filter, const Expression &check) {
+	if (filter.GetExpressionType() == ExpressionType::OPERATOR_NOT) {
+		return filter.Cast<BoundOperatorExpression>().GetChildren()[0]->Equals(check);
+	}
+	if (!BoundComparisonExpression::IsComparison(filter) || !BoundComparisonExpression::IsComparison(check) ||
+	    NegateComparisonExpression(filter.GetExpressionType()) != check.GetExpressionType()) {
+		return false;
+	}
+	auto &filter_comparison = filter.Cast<BoundFunctionExpression>();
+	auto &check_comparison = check.Cast<BoundFunctionExpression>();
+	return BoundComparisonExpression::Left(filter_comparison)
+	           .Equals(BoundComparisonExpression::Left(check_comparison)) &&
+	       BoundComparisonExpression::Right(filter_comparison)
+	           .Equals(BoundComparisonExpression::Right(check_comparison));
+}
+
+//! Check if any of the filters contradicts a CHECK constraint of the scanned table
+bool FilterPushdown::CheckConstraintsUnsatisfiable(const LogicalGet &get) {
+	auto table = get.GetTable();
+	if (filters.empty() || !table) {
+		return false;
+	}
+	shared_ptr<Binder> binder;
+	for (auto &constraint : table->GetConstraints()) {
+		if (constraint->type != ConstraintType::CHECK) {
+			continue;
+		}
+		if (!binder) {
+			binder = Binder::CreateBinder(optimizer.context);
+		}
+		auto bound_constraint = binder->BindConstraint(*constraint, table->name, table->GetColumns());
+		auto check_expression = std::move(bound_constraint->Cast<BoundCheckConstraint>().expression);
+		if (check_expression->IsVolatile() || !check_expression->IsConsistent()) {
+			continue;
+		}
+		// the CheckBinder casts the CHECK expression to INTEGER - strip the cast to get back the predicate
+		if (!BoundCastExpression::IsCast(*check_expression) || !RewriteCheckExpression(check_expression, get)) {
+			continue;
+		}
+		auto &check_predicate = BoundCastExpression::Child(check_expression->Cast<BoundFunctionExpression>());
+		for (auto &filter : filters) {
+			if (IsNegation(*filter->filter, check_predicate)) {
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
 unique_ptr<LogicalOperator> FilterPushdown::PushdownGet(unique_ptr<LogicalOperator> op) {
 	D_ASSERT(op->type == LogicalOperatorType::LOGICAL_GET);
 	auto &get = op->Cast<LogicalGet>();
 
 	for (auto &filter : filters) {
 		NormalizeColumnRefAliases(filter->filter, get);
+	}
+
+	if (CheckConstraintsUnsatisfiable(get)) {
+		return make_uniq<LogicalEmptyResult>(std::move(op));
 	}
 
 	if (get.function.pushdown_complex_filter || get.function.filter_pushdown) {

--- a/test/sql/constraints/check/test_check_filter_contradiction.test
+++ b/test/sql/constraints/check/test_check_filter_contradiction.test
@@ -1,0 +1,135 @@
+# name: test/sql/constraints/check/test_check_filter_contradiction.test
+# description: Filters that contradict a CHECK constraint are pruned
+# group: [check]
+
+statement ok
+CREATE TABLE t(a INTEGER, b INTEGER, CHECK (b = a + 1));
+
+statement ok
+INSERT INTO t SELECT range::INTEGER, (range + 1)::INTEGER FROM range(6144);
+
+# the filter is the negation of the CHECK constraint - the scan can be skipped entirely
+query II
+EXPLAIN SELECT count(*) FROM t WHERE b <> a + 1;
+----
+physical_plan	<REGEX>:(?s).*Empty Result.*
+
+query II
+EXPLAIN SELECT count(*) FROM t WHERE NOT (b = a + 1);
+----
+physical_plan	<REGEX>:(?s).*Empty Result.*
+
+query I
+SELECT count(*) FROM t WHERE b <> a + 1;
+----
+0
+
+# the filter must match the CHECK constraint exactly
+query II
+EXPLAIN SELECT count(*) FROM t WHERE b <> a + 2;
+----
+physical_plan	<!REGEX>:(?s).*Empty Result.*
+
+query I
+SELECT count(*) FROM t WHERE b <> a + 2;
+----
+6144
+
+# a CHECK constraint is satisfied by NULL, so the filter itself cannot be removed
+statement ok
+INSERT INTO t VALUES (NULL, 42);
+
+query I
+SELECT count(*) FROM t WHERE b = a + 1;
+----
+6144
+
+query I
+SELECT count(*) FROM t WHERE b <> a + 1;
+----
+0
+
+# inequality CHECK constraints
+statement ok
+CREATE TABLE ineq(a INTEGER, b INTEGER, CHECK (a < b));
+
+statement ok
+INSERT INTO ineq VALUES (1, 2), (3, 4);
+
+query II
+EXPLAIN SELECT * FROM ineq WHERE a >= b;
+----
+physical_plan	<REGEX>:(?s).*Empty Result.*
+
+query I
+SELECT count(*) FROM ineq WHERE a >= b;
+----
+0
+
+query II
+EXPLAIN SELECT * FROM ineq WHERE a <= b;
+----
+physical_plan	<!REGEX>:(?s).*Empty Result.*
+
+# the contradicting filter may be one of many conjuncts
+query II
+EXPLAIN SELECT * FROM ineq WHERE a > 0 AND a >= b;
+----
+physical_plan	<REGEX>:(?s).*Empty Result.*
+
+# CHECK constraints over a function call
+statement ok
+CREATE TABLE fun(s VARCHAR, CHECK (length(s) < 10));
+
+statement ok
+INSERT INTO fun VALUES ('hello');
+
+query II
+EXPLAIN SELECT * FROM fun WHERE length(s) >= 10;
+----
+physical_plan	<REGEX>:(?s).*Empty Result.*
+
+query I
+SELECT count(*) FROM fun WHERE length(s) >= 10;
+----
+0
+
+# columns that are not scanned do not trigger the rewrite
+query II
+EXPLAIN SELECT a FROM t WHERE a > 0;
+----
+physical_plan	<!REGEX>:(?s).*Empty Result.*
+
+# a boolean CHECK constraint negated with NOT
+statement ok
+CREATE TABLE bl(f BOOLEAN, CHECK (f));
+
+statement ok
+INSERT INTO bl VALUES (true), (NULL);
+
+query II
+EXPLAIN SELECT * FROM bl WHERE NOT f;
+----
+physical_plan	<REGEX>:(?s).*Empty Result.*
+
+query I
+SELECT count(*) FROM bl WHERE NOT f;
+----
+0
+
+query I
+SELECT count(*) FROM bl WHERE f;
+----
+1
+
+# volatile CHECK constraints hold at insertion time only - they cannot be used
+statement ok
+CREATE TABLE vol(a DOUBLE, CHECK (a < random()));
+
+statement ok
+INSERT INTO vol VALUES (0.0);
+
+query II
+EXPLAIN SELECT * FROM vol WHERE a >= random();
+----
+physical_plan	<!REGEX>:(?s).*Empty Result.*


### PR DESCRIPTION
Fixes #24416

### Problem

CHECK constraints are never consulted by the optimizer - nothing in `src/optimizer/` reads constraints at all, they are only used for insert/update validation in `DataTable::VerifyAppendConstraints`. So a provably unsatisfiable predicate still scans the whole table:

```sql
CREATE TABLE t(a INTEGER, b INTEGER, CHECK (b = a + 1));
INSERT INTO t SELECT range::INTEGER, (range + 1)::INTEGER FROM range(6144);

EXPLAIN ANALYZE SELECT count(*) FROM t WHERE b <> a + 1;
-- Filter: b != (a + 1)  ->  Table Scan: 6,144 rows
```

Single-column cases such as `CHECK (a > 0)` with `WHERE a <= 0` appear to work today, but that is zonemap statistics rather than the constraint. Multi-column and expression relationships have no statistics representation, hence the gap.

### Fix

A `CHECK (X)` constraint guarantees no stored row has `X = FALSE`. A filter that is the negation of `X` is therefore satisfied by no row, and the scan can be replaced with an empty result. This holds with NULLs in both directions, since a filter rejects rows where the predicate is NULL.

Implemented in `FilterPushdown::PushdownGet`, where the filters and the table entry are both already available:

1. Skip unless there are filters and the table has a CHECK constraint.
2. Bind the constraint; skip volatile or inconsistent expressions, whose guarantee
   only held at insertion time.
3. Rewrite the bound expression's storage indexes into the bindings of the get.
4. Strip the `CAST(... AS INTEGER)` that `CheckBinder` wraps the predicate in.
5. If a filter is `NOT X`, or the negated comparison of `X` with equal operands,
   return a `LogicalEmptyResult`.

The converse rewrite is **not** valid and is deliberately not done: a CHECK constraint is also satisfied when its expression evaluates to NULL, so `INSERT INTO t VALUES (NULL, 5)` is accepted and `WHERE b = a + 1` must still filter that row out.

No new optimizer type, so this is covered by `SET disabled_optimizers='filter_pushdown'` and needs no enum or serialization regeneration.

### Testing

New test `test/sql/constraints/check/test_check_filter_contradiction.test` opens with the issue's repro verbatim and covers negated comparisons, `NOT`, boolean CHECK constraints, function calls in constraints, one conjunct among many, near-miss filters, unscanned columns, and volatile constraints.

Also verified: dropped columns (logical ≠ physical index), DELETE/UPDATE plans, and self-joins.

Suites run locally: fast suite, `allunit`, `test_configs` (38/38), `test_vector` (5/5), and the full suite under `FORCE_DEBUG=1 FORCE_ASSERT=1` - all clean.

### Follow-ups

- Bound constraints are not cached anywhere, so they are re-bound per scan on tables that have CHECK constraints. Caching them on the table entry would remove  that cost.
- This handles direct negation only. General constraint propagation - using `b = a + 1` to rewrite predicates on `b` into predicates on `a` - is a much larger piece of work.