### PR TITLE
Preserve HUGEINT precision in quantile interpolation

### DIFF
--- a/src/function/scalar/operator/arithmetic.cpp
+++ b/src/function/scalar/operator/arithmetic.cpp
@@ -1362,9 +1362,8 @@ static hugeint_t ShiftRight192(uint64_t lower, uint64_t middle, uint64_t upper, 
 }
 
 // Computes floor(delta * weight) exactly for a non-negative HUGEINT delta and a finite double weight in [0, 1].
-// The caller uses the result as an offset from one endpoint, retaining the truncation-towards-zero behaviour of the
-// previous floating-point conversion without first rounding the delta to double precision.
 static hugeint_t MultiplyHugeintByDoubleFraction(const hugeint_t &delta, const double weight) {
+	D_ASSERT(delta >= 0);
 	if (weight == 0) {
 		return hugeint_t(0);
 	}
@@ -1404,9 +1403,7 @@ hugeint_t InterpolateOperator::Operation(const hugeint_t &lo, const double d, co
 		if (lower >= 0 || upper <= 0) {
 			auto delta = upper;
 			if (Hugeint::TrySubtractInPlace(delta, lower)) {
-				// Preserve truncation towards zero by interpolating up from a non-negative lower bound or down from a
-				// non-positive upper bound. Calculating the offset from the delta retains precision for nearby large
-				// values.
+				// Interpolate from the endpoint with the matching sign to truncate towards zero.
 				const bool non_negative = lower >= 0;
 				const auto weight = non_negative ? (ascending ? d : 1 - d) : (ascending ? 1 - d : d);
 				const auto offset = MultiplyHugeintByDoubleFraction(delta, weight);
@@ -1419,7 +1416,7 @@ hugeint_t InterpolateOperator::Operation(const hugeint_t &lo, const double d, co
 			}
 		}
 	}
-	// Opposite-sign and very wide endpoints can overflow a signed delta. Retain the overflow-safe fallback.
+	// Fall back when the endpoint range does not fit a signed delta.
 	return Hugeint::Convert(Operation(Hugeint::Cast<double>(lo), d, Hugeint::Cast<double>(hi)));
 }
 

--- a/src/function/scalar/operator/arithmetic.cpp
+++ b/src/function/scalar/operator/arithmetic.cpp
@@ -1326,16 +1326,100 @@ timestamp_t InterpolateOperator::Operation(const timestamp_t &lo, const double d
 	return timestamp_t(std::llround(static_cast<double>(lo.value) * (1.0 - d) + static_cast<double>(hi.value) * d));
 }
 
-template <>
-hugeint_t InterpolateOperator::Operation(const hugeint_t &lo, const double d, const hugeint_t &hi) {
-	hugeint_t delta_hugeint = hi;
-	if (Hugeint::TrySubtractInPlace(delta_hugeint, lo)) {
-		const auto delta = Hugeint::Cast<double>(delta_hugeint);
-		return lo + Hugeint::Convert(delta * d);
+static void MultiplyUint64(uint64_t lhs, uint64_t rhs, uint64_t &lower, uint64_t &upper) {
+	const auto lhs_lower = lhs & 0xffffffff;
+	const auto lhs_upper = lhs >> 32;
+	const auto rhs_lower = rhs & 0xffffffff;
+	const auto rhs_upper = rhs >> 32;
+
+	const auto product_lower = lhs_lower * rhs_lower;
+	const auto product_middle_left = lhs_lower * rhs_upper;
+	const auto product_middle_right = lhs_upper * rhs_lower;
+	const auto product_upper = lhs_upper * rhs_upper;
+	const auto middle = (product_lower >> 32) + static_cast<uint32_t>(product_middle_left) +
+	                    static_cast<uint32_t>(product_middle_right);
+
+	lower = (product_lower & 0xffffffff) | (middle << 32);
+	upper = product_upper + (product_middle_left >> 32) + (product_middle_right >> 32) + (middle >> 32);
+}
+
+static hugeint_t ShiftRight192(uint64_t lower, uint64_t middle, uint64_t upper, idx_t shift) {
+	if (shift < 64) {
+		return hugeint_t(static_cast<int64_t>((middle >> shift) | (upper << (64 - shift))),
+		                 (lower >> shift) | (middle << (64 - shift)));
+	}
+	if (shift == 64) {
+		return hugeint_t(static_cast<int64_t>(upper), middle);
+	}
+	if (shift < 128) {
+		return hugeint_t(static_cast<int64_t>(upper >> (shift - 64)),
+		                 (middle >> (shift - 64)) | (upper << (128 - shift)));
+	}
+	if (shift < 192) {
+		return hugeint_t(0, upper >> (shift - 128));
+	}
+	return hugeint_t(0);
+}
+
+// Computes floor(delta * weight) exactly for a non-negative HUGEINT delta and a finite double weight in [0, 1].
+// The caller uses the result as an offset from one endpoint, retaining the truncation-towards-zero behaviour of the
+// previous floating-point conversion without first rounding the delta to double precision.
+static hugeint_t MultiplyHugeintByDoubleFraction(const hugeint_t &delta, const double weight) {
+	if (weight == 0) {
+		return hugeint_t(0);
+	}
+	if (weight == 1) {
+		return delta;
 	}
 
-	// if delta overflows, we fall back to original subtraction to avoid UB
-	// only happens when lo and hi are so apart that their difference can't be stored in a hugeint
+	int exponent;
+	const auto fraction = std::frexp(weight, &exponent);
+	const auto mantissa = static_cast<uint64_t>(std::ldexp(fraction, 53));
+	const auto shift = static_cast<idx_t>(53 - exponent);
+
+	uint64_t lower_product;
+	uint64_t lower_carry;
+	MultiplyUint64(delta.lower, mantissa, lower_product, lower_carry);
+
+	uint64_t middle_product;
+	uint64_t upper_product;
+	MultiplyUint64(static_cast<uint64_t>(delta.upper), mantissa, middle_product, upper_product);
+	const auto middle = lower_carry + middle_product;
+	const auto carry = middle < lower_carry;
+	return ShiftRight192(lower_product, middle, upper_product + carry, shift);
+}
+
+template <>
+hugeint_t InterpolateOperator::Operation(const hugeint_t &lo, const double d, const hugeint_t &hi) {
+	if (d == 0 || lo == hi) {
+		return lo;
+	}
+	if (d == 1) {
+		return hi;
+	}
+	if (d > 0 && d < 1) {
+		const bool ascending = lo < hi;
+		const auto lower = ascending ? lo : hi;
+		const auto upper = ascending ? hi : lo;
+		if (lower >= 0 || upper <= 0) {
+			auto delta = upper;
+			if (Hugeint::TrySubtractInPlace(delta, lower)) {
+				// Preserve truncation towards zero by interpolating up from a non-negative lower bound or down from a
+				// non-positive upper bound. Calculating the offset from the delta retains precision for nearby large
+				// values.
+				const bool non_negative = lower >= 0;
+				const auto weight = non_negative ? (ascending ? d : 1 - d) : (ascending ? 1 - d : d);
+				const auto offset = MultiplyHugeintByDoubleFraction(delta, weight);
+				auto result = non_negative ? lower : upper;
+				const bool success =
+				    non_negative ? Hugeint::TryAddInPlace(result, offset) : Hugeint::TrySubtractInPlace(result, offset);
+				if (success) {
+					return result;
+				}
+			}
+		}
+	}
+	// Opposite-sign and very wide endpoints can overflow a signed delta. Retain the overflow-safe fallback.
 	return Hugeint::Convert(Operation(Hugeint::Cast<double>(lo), d, Hugeint::Cast<double>(hi)));
 }
 

--- a/test/issues/general/test_24314.test
+++ b/test/issues/general/test_24314.test
@@ -74,3 +74,30 @@ SELECT quantile_cont(v, 1::DECIMAL(38,0) / 4096)::VARCHAR
 FROM (VALUES (0::DECIMAL(38,0)), (99999999999999999999999999999999999999::DECIMAL(38,0))) t(v);
 ----
 24414062499999999999999999999999999
+
+# Negative quantile weights select the complementary weight through the same exact path.
+query I
+SELECT quantile_cont(-v, [0.25, 0.5, 0.75])::VARCHAR
+FROM (VALUES (0::DECIMAL(38,0)), (18014398509481986::DECIMAL(38,0))) t(v);
+----
+[-13510798882111489, -9007199254740993, -4503599627370496]
+
+# The interpolation is shared with the window fill() function.
+query I
+SELECT fill(v ORDER BY x) OVER () z
+FROM (VALUES (0.0::DOUBLE, 0::DECIMAL(38,0)),
+             (1.0, 18014398509481986::DECIMAL(38,0)),
+             (0.5, NULL::DECIMAL(38,0))) t(x, v)
+ORDER BY x;
+----
+0
+9007199254740993
+18014398509481986
+
+# An asymmetric opposite-sign span whose delta overflows signed INT128 retains the double fallback.
+query I
+SELECT quantile_cont(v, 0.25)::VARCHAR
+FROM (VALUES (-99999999999999999999999999999999999999::DECIMAL(38,0)),
+             (80000000000000000000000000000000000000::DECIMAL(38,0))) t(v);
+----
+-55000000000000001595265292622605844480

--- a/test/issues/general/test_24314.test
+++ b/test/issues/general/test_24314.test
@@ -1,0 +1,76 @@
+# name: test/issues/general/test_24314.test
+# description: Issue 24314 - preserve precision when interpolating nearby large decimals
+# group: [general]
+
+query II
+WITH t(v) AS (
+    VALUES (9999999999999999999999999999::DECIMAL(38,0)),
+           (9999999999999999999999999997::DECIMAL(38,0))
+)
+SELECT quantile_cont(v, 0.5), median(v) FROM t;
+----
+9999999999999999999999999998	9999999999999999999999999998
+
+# The sign-aware path retains the same precision for negative endpoints.
+query II
+SELECT quantile_cont(v, 0.5), median(v)
+FROM (VALUES (-9999999999999999999999999999::DECIMAL(38,0)),
+             (-9999999999999999999999999997::DECIMAL(38,0))) t(v);
+----
+-9999999999999999999999999998	-9999999999999999999999999998
+
+# Interpolation must not perturb equal values at large magnitudes.
+query II
+SELECT quantile_cont(v, 0.5), median(v)
+FROM (VALUES (9999999999999999999999999999::DECIMAL(38,0)),
+             (9999999999999999999999999999::DECIMAL(38,0))) t(v);
+----
+9999999999999999999999999999	9999999999999999999999999999
+
+# Fractional quantiles and decimal scales use the same physical INT128 path.
+query II
+SELECT quantile_cont(v, [0.25, 0.5, 0.75]), median(v)
+FROM (VALUES (99999999999999999999999999.99::DECIMAL(38,2)),
+             (99999999999999999999999999.95::DECIMAL(38,2))) t(v);
+----
+[99999999999999999999999999.96, 99999999999999999999999999.97, 99999999999999999999999999.98]	99999999999999999999999999.97
+
+# Keep final-value truncation towards zero regardless of interpolation direction.
+query IIII
+SELECT quantile_cont(v, [0.25, 0.5, 0.75]),
+       quantile_cont(v, [-0.25, -0.5, -0.75]),
+       quantile_cont(-v, [0.25, 0.5, 0.75]),
+       quantile_cont(-v, [-0.25, -0.5, -0.75])
+FROM (VALUES (0::DECIMAL(38,0)), (3::DECIMAL(38,0))) t(v);
+----
+[0, 1, 2]	[2, 1, 0]	[-2, -1, 0]	[0, -1, -2]
+
+# Preserve the overflow-safe path when the endpoint difference does not fit in a signed INT128.
+query II
+SELECT quantile_cont(v, 0.5), median(v)
+FROM (VALUES (-99999999999999999999999999999999999999::DECIMAL(38,0)),
+             (99999999999999999999999999999999999999::DECIMAL(38,0))) t(v);
+----
+0	0
+
+# Do not round an exactly representable HUGEINT delta to double before interpolation.
+query II
+SELECT quantile_cont(v, [0.25, 0.5, 0.75]), median(v)
+FROM (VALUES (0::DECIMAL(38,0)), (18014398509481986::DECIMAL(38,0))) t(v);
+----
+[4503599627370496, 9007199254740993, 13510798882111489]	9007199254740993
+
+# The same exact offset calculation preserves truncation towards zero below zero.
+query II
+SELECT quantile_cont(v, [0.25, 0.5, 0.75]), median(v)
+FROM (VALUES (-18014398509481986::DECIMAL(38,0)), (0::DECIMAL(38,0))) t(v);
+----
+[-13510798882111489, -9007199254740993, -4503599627370496]	-9007199254740993
+
+# A weight of 1/4096 shifts the 192-bit product right by exactly one limb; the limb-aligned
+# shift must retain the middle limb rather than shifting the upper limb by 64.
+query I
+SELECT quantile_cont(v, 1::DECIMAL(38,0) / 4096)::VARCHAR
+FROM (VALUES (0::DECIMAL(38,0)), (99999999999999999999999999999999999999::DECIMAL(38,0))) t(v);
+----
+24414062499999999999999999999999999


### PR DESCRIPTION
HUGEINT interpolation converts its overflow-safe delta to double, which loses low digits for DECIMAL(38,*) endpoints above 2^53: the median of 0 and 2^54+2 is 9007199254740992 instead of 9007199254740993, and quantile_cont at weight 1/4096 over 0 and 10^38−1 returns 24414062499999999450393023304695808 instead of 24414062499999999999999999999999999.

This PR interpolates same-sign endpoints exactly: the delta is multiplied by the exact 53-bit mantissa of the weight through a three-limb 192-bit product, then shifted right, so neither the endpoints nor the delta are rounded to double. The shift handles limb-aligned weights such as 1/4096 explicitly, opposite-sign and too-wide deltas keep the overflow-safe endpoint fallback, and truncation towards zero is preserved in both sort directions.

The regression extends the #24314 test with the above-2^53 midpoint, a limb-aligned 1/4096 weight, negative quantile weights, the shared window fill() path, and an asymmetric overflow-fallback span.
