### PR TITLE
Fix invoke function throwing INTERNAL error on lambda runtime errors

### DIFF
--- a/src/function/scalar/generic/invoke.cpp
+++ b/src/function/scalar/generic/invoke.cpp
@@ -138,6 +138,7 @@ ScalarFunction InvokeFun::GetFunction() {
 	fun.SetInitStateCallback(LambdaInvokeState::Init);
 	fun.SetSerializeCallback(LambdaInvokeData::Serialize);
 	fun.SetDeserializeCallback(LambdaInvokeData::Deserialize);
+	fun.SetFallible();
 	return fun;
 }
 

--- a/test/sql/function/generic/invoke.test
+++ b/test/sql/function/generic/invoke.test
@@ -143,3 +143,14 @@ statement error
 SELECT invoke(NULL, 1);
 ----
 Binder Error: Invalid lambda expression passed to 'invoke' function.
+
+# Issue #24644: invoke() lambda runtime error must propagate as ordinary runtime error (not INTERNAL Error)
+statement error
+SELECT invoke(lambda x: x::INTEGER, 'abc');
+----
+Conversion Error
+
+statement error
+SELECT invoke(lambda x: error('boom'), 1);
+----
+Invalid Input Error


### PR DESCRIPTION
Fixes #24644

### Summary
The `invoke` scalar function executes user-supplied lambda expressions via an `ExpressionExecutor`, but was missing `fun.SetFallible();` in `InvokeFun::GetFunction()`. Consequently, any runtime error thrown during lambda evaluation (e.g. failed cast, explicit `error()`) was caught by the scalar execution layer as an unhandled exception from a non-fallible function, wrapping it into an `INTERNAL Error` assertion failure instead of propagating as a standard runtime error.

### Changes Made
- Added `fun.SetFallible();` in `src/function/scalar/generic/invoke.cpp` (`InvokeFun::GetFunction()`).
- Added regression tests in `test/sql/function/generic/invoke.test` confirming that lambda evaluation runtime errors surface as ordinary runtime errors (`Conversion Error`, `Invalid Input Error`).