### PR TITLE
Do not use file statistics for overridden hive partitioning columns

### DIFF
--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -932,6 +932,14 @@ public:
 		auto primary_index = column_index.GetPrimaryIndex();
 		const auto &col_name = bind_data.names[primary_index];
 
+		// a hive partitioning column overrides any file column of the same name - the statistics stored in the
+		// file describe the overridden column and can even have a different type, so they cannot be used here
+		for (auto &hive_partitioning_index : bind_data.reader_bind.hive_partitioning_indexes) {
+			if (hive_partitioning_index.index == primary_index) {
+				return nullptr;
+			}
+		}
+
 		// NOTE: we do not want to parse the file metadata for the sole purpose of getting column statistics
 		if (bind_data.file_list->GetExpandResult() == FileExpandResult::MULTIPLE_FILES) {
 			if (!bind_data.file_options.union_by_name) {

--- a/test/sql/copy/parquet/parquet_hive_override_stats.test
+++ b/test/sql/copy/parquet/parquet_hive_override_stats.test
@@ -1,0 +1,67 @@
+# name: test/sql/copy/parquet/parquet_hive_override_stats.test
+# description: A hive partitioning column overrides the file column of the same name - do not use the file's statistics
+# group: [parquet]
+
+require parquet
+
+# both files keep a physical "part" column next to the hive path, but with a different type:
+# ubigint in one file, bigint in the other - the hive column overrides both with its own type
+statement ok
+COPY (SELECT 1::UBIGINT AS id, 42::UBIGINT AS part)
+TO '{TEST_DIR}/hive_override_u' (FORMAT parquet, PARTITION_BY (part), WRITE_PARTITION_COLUMNS true)
+
+statement ok
+COPY (SELECT 1::UBIGINT AS id, 42::BIGINT AS part)
+TO '{TEST_DIR}/hive_override_s' (FORMAT parquet, PARTITION_BY (part), WRITE_PARTITION_COLUMNS true)
+
+# the hive column wins, so both sides are bigint regardless of what the files contain
+query II
+SELECT typeof(part), part FROM read_parquet('{TEST_DIR}/hive_override_u/part=42/*.parquet')
+----
+BIGINT	42
+
+query II
+SELECT typeof(part), part FROM read_parquet('{TEST_DIR}/hive_override_s/part=42/*.parquet')
+----
+BIGINT	42
+
+# joining the two used to hand the optimizer ubigint statistics for a bigint column
+query I
+SELECT count(*)
+FROM read_parquet('{TEST_DIR}/hive_override_u/part=42/*.parquet') u
+JOIN read_parquet('{TEST_DIR}/hive_override_s/part=42/*.parquet') s ON u.part = s.part
+----
+1
+
+query I
+SELECT count(*)
+FROM read_parquet('{TEST_DIR}/hive_override_u/part=42/*.parquet') u
+SEMI JOIN (SELECT DISTINCT id, part FROM read_parquet('{TEST_DIR}/hive_override_s/part=42/*.parquet')) s
+ON u.id = s.id AND u.part = s.part
+----
+1
+
+# filters on the overridden column use the hive value, not the value stored in the file
+# (write a part=7 directory first, then drop a file into it that disagrees with the path)
+statement ok
+COPY (SELECT 1::UBIGINT AS id, 7::UBIGINT AS part)
+TO '{TEST_DIR}/hive_mismatch' (FORMAT parquet, PARTITION_BY (part), WRITE_PARTITION_COLUMNS false)
+
+statement ok
+COPY (SELECT 1::UBIGINT AS id, 999::UBIGINT AS part)
+TO '{TEST_DIR}/hive_mismatch/part=7/disagrees.parquet' (FORMAT parquet)
+
+query II
+SELECT part, count(*) FROM read_parquet('{TEST_DIR}/hive_mismatch/part=7/disagrees.parquet') GROUP BY part
+----
+7	1
+
+query I
+SELECT count(*) FROM read_parquet('{TEST_DIR}/hive_mismatch/part=7/disagrees.parquet') WHERE part = 7
+----
+1
+
+query I
+SELECT count(*) FROM read_parquet('{TEST_DIR}/hive_mismatch/part=7/disagrees.parquet') WHERE part = 999
+----
+0

--- a/test/sql/copy/parquet/parquet_hive_override_stats.test
+++ b/test/sql/copy/parquet/parquet_hive_override_stats.test
@@ -61,7 +61,9 @@ SELECT count(*) FROM read_parquet('{TEST_DIR}/hive_mismatch/part=7/disagrees.par
 ----
 1
 
-query I
-SELECT count(*) FROM read_parquet('{TEST_DIR}/hive_mismatch/part=7/disagrees.parquet') WHERE part = 999
+# the value stored in the file is only visible with hive partitioning turned off
+query II
+SELECT typeof(part), part
+FROM read_parquet('{TEST_DIR}/hive_mismatch/part=7/disagrees.parquet', hive_partitioning=false)
 ----
-0
+UBIGINT	999


### PR DESCRIPTION
# Do not use file statistics for overridden hive partitioning columns

Fixes #24736.

## Repro

Not S3-specific, and not a `UINT64` zonemap problem — it reproduces locally in
four lines. What matters is that a hive partitioning key has the same name as a
column stored in the file, and that the two files disagree on that column's
type:

```sql
COPY (SELECT 1::UBIGINT AS h8, 42::UBIGINT AS h0) TO 'a/h0=42/data_0.parquet' (FORMAT parquet);
COPY (SELECT 1::UBIGINT AS h8, 42::BIGINT  AS h0) TO 'b/h0=42/data_0.parquet' (FORMAT parquet);

SELECT count(*) FROM read_parquet('a/h0=42/data_0.parquet') a
JOIN read_parquet('b/h0=42/data_0.parquet') b ON a.h0 = b.h0;
-- INTERNAL Error: SetMin or SetMax called with Value that does not match statistics' column value
```

The reporter's files have exactly this shape: both carry a physical `h0`
alongside the `h0=...` path, `UINT_64` in the probe file and `INT_64` in the
build file.

## Cause

`MultiFileReader::BindOptions` overrides the file column when a hive key
collides with it:

```cpp
if (lookup != names.end()) {
    // hive partitioning column also exists in file - override
    hive_partitioning_index = idx;
    return_types[idx] = options.GetHiveLogicalType(part.first);
}
```

So the scan emits the value parsed from the path and the column takes the hive
type (`BIGINT` here). But `MultiFileScanStatsExtended` still resolved statistics
by name against the file reader, which returns the statistics of the *overridden*
file column. Those describe values that are never emitted, and carry the file's
type rather than the plan's:

```
[DBG] get col=h0 plan_type=BIGINT stats_type=UBIGINT   <<< MISMATCH
[DBG] get col=h0 plan_type=BIGINT stats_type=BIGINT
```

`StatisticsPropagator::PropagateStatistics(LogicalGet &)` stores whatever the
table function returns, so the join reached
`UpdateFilterStatistics(lstats, rstats, COMPARE_EQUAL)` holding one `UBIGINT` and
one `BIGINT` statistics object — the case its
`D_ASSERT(lstats.GetType() == rstats.GetType())` already documents — and
`NumericStats::SetMin` threw.

This also means the statistics were simply wrong whenever a file's values for
the column disagree with its path, which the added test pins down.

## Fix

Skip file statistics for columns that a hive partitioning key overrides.

Both the minimal repro and the reporter's original query now run; the latter
returns `33569`, matching what they reported with `statistics_propagation`
disabled.

## Notes

`disabled_optimizers='statistics_propagation'` worked around it because that is
the only consumer of these statistics.

The bisection in the issue points elsewhere, so for the record: S3 is
irrelevant (the local copies of the same bytes crash identically), and the
partially-overlapping build side is irrelevant — the crash happens during
optimization, before any zonemap is compared. Reading the files locally without
the `h0=.../` directory is what made it look S3-only, since that is what stops
hive partitioning from being auto-detected.

## Testing

* `test/sql/copy/parquet/parquet_hive_override_stats.test` — fails with the
  reported internal error without this change
* `test/sql/copy/*` and `test/optimizer/*` pass
* full `build/reldebug/test/unittest` passes (970775 assertions, 4842 cases)
