### PR TITLE
Fix ICU calendar differences across era boundaries

### DIFF
--- a/extension/icu/datetime/calendar.cpp
+++ b/extension/icu/datetime/calendar.cpp
@@ -832,6 +832,7 @@ void FieldCalendar::AddChecked(CalendarField field, int32_t amount) {
 	switch (field) {
 	case CAL_ERA: {
 		const auto era = GetChecked(CAL_ERA);
+		const auto year = GetChecked(CAL_YEAR);
 		if (failed) {
 			return;
 		}
@@ -842,18 +843,35 @@ void FieldCalendar::AddChecked(CalendarField field, int32_t amount) {
 		}
 		Set(CAL_ERA, sum);
 		PinField(CAL_ERA);
+		// keep the same year within the new era
+		Set(CAL_YEAR, year);
+		PinField(CAL_DATE);
 		return;
 	}
-	case CAL_YEAR:
-	case CAL_YEAR_WOY:
-		// in an era that counts backwards, later years have smaller numbers
-		if (GetChecked(CAL_ERA) == 0 && IsEra0CountingBackward()) {
-			if (!TryMultiply(amount, -1, amount)) {
-				Fail();
-				return;
-			}
+	case CAL_YEAR: {
+		// extended years continue across era boundaries
+		const auto year = GetChecked(CAL_EXTENDED_YEAR);
+		int32_t sum;
+		if (failed || !TryAdd(year, amount, sum)) {
+			Fail();
+			return;
 		}
-		DUCKDB_EXPLICIT_FALLTHROUGH;
+		Set(CAL_EXTENDED_YEAR, sum);
+		PinField(CAL_DATE);
+		return;
+	}
+	case CAL_YEAR_WOY: {
+		// week-based year numbers continue across era boundaries
+		const auto year = GetChecked(CAL_YEAR_WOY);
+		int32_t sum;
+		if (failed || !TryAdd(year, amount, sum)) {
+			Fail();
+			return;
+		}
+		Set(CAL_YEAR_WOY, sum);
+		PinField(CAL_DATE);
+		return;
+	}
 	case CAL_EXTENDED_YEAR:
 	case CAL_MONTH:
 	case CAL_ORDINAL_MONTH: {
@@ -1049,6 +1067,37 @@ int32_t FieldCalendar::FieldDifference(int64_t target, CalendarField field) {
 	failed = false;
 	int32_t min = 0;
 	const auto start = GetTimeChecked();
+	if (field == CAL_ERA) {
+		// eras can start partway through a year, so only count complete eras between the two dates
+		const auto start_era = GetChecked(CAL_ERA);
+		SetTimeChecked(target);
+		const auto target_era = GetChecked(CAL_ERA);
+		const auto difference = int64_t(target_era) - start_era;
+		if (failed) {
+			return 0;
+		}
+		if (difference < NumericLimits<int32_t>::Minimum() || difference > NumericLimits<int32_t>::Maximum()) {
+			Fail();
+			return 0;
+		}
+		// start by applying the difference between the two era numbers
+		auto result = int32_t(difference);
+		SetTimeChecked(start);
+		AddChecked(field, result);
+		const auto reached = GetTimeChecked();
+		if (failed) {
+			return 0;
+		}
+		// check whether applying the era number difference reaches the target without overshooting it
+		if (reached == target || (start < target ? reached < target : reached > target)) {
+			return result;
+		}
+		result += start < target ? -1 : 1;
+		// leave the calendar at the date reached by the returned difference
+		SetTimeChecked(start);
+		AddChecked(field, result);
+		return failed ? 0 : result;
+	}
 
 	// most differences are close to what the average length of the field predicts, which saves
 	// the search below from having to bracket the answer from scratch

--- a/extension/icu/datetime/gregorian.cpp
+++ b/extension/icu/datetime/gregorian.cpp
@@ -177,11 +177,7 @@ int32_t GregorianCalendar::HandleGetExtendedYear() {
 		return InternalGet(CAL_YEAR, EPOCH_YEAR);
 	}
 	case CAL_YEAR_WOY: {
-		auto year_woy = InternalGet(CAL_YEAR_WOY);
-		if (InternalGet(CAL_ERA, AD) == BC) {
-			year_woy = 1 - year_woy;
-		}
-		return HandleGetExtendedYearFromWeekFields(year_woy, InternalGet(CAL_WEEK_OF_YEAR));
+		return HandleGetExtendedYearFromWeekFields(InternalGet(CAL_YEAR_WOY), InternalGet(CAL_WEEK_OF_YEAR));
 	}
 	default:
 		return EPOCH_YEAR;

--- a/extension/icu/datetime/include/calendar.hpp
+++ b/extension/icu/datetime/include/calendar.hpp
@@ -125,11 +125,6 @@ public:
 	//! A table of groups, terminated by a null group
 	using ResolutionTable = const ResolutionGroup *;
 
-	//! Whether the years of the first era count backwards, as in the Gregorian BC era
-	virtual bool IsEra0CountingBackward() const {
-		return false;
-	}
-
 	const TimeZone &GetTimeZone() const {
 		return *zone;
 	}

--- a/extension/icu/datetime/include/coptic.hpp
+++ b/extension/icu/datetime/include/coptic.hpp
@@ -48,9 +48,6 @@ public:
 	const char *GetType() const override {
 		return "coptic";
 	}
-	bool IsEra0CountingBackward() const override {
-		return true;
-	}
 	unique_ptr<Calendar> Copy() const override {
 		return unique_ptr<Calendar>(new CopticCalendar(*this));
 	}

--- a/extension/icu/datetime/include/gregorian.hpp
+++ b/extension/icu/datetime/include/gregorian.hpp
@@ -39,9 +39,6 @@ public:
 	const char *GetType() const override {
 		return "gregorian";
 	}
-	bool IsEra0CountingBackward() const override {
-		return true;
-	}
 	unique_ptr<Calendar> Copy() const override {
 		return unique_ptr<Calendar>(new GregorianCalendar(*this));
 	}
@@ -85,9 +82,6 @@ public:
 
 	const char *GetType() const override {
 		return "buddhist";
-	}
-	bool IsEra0CountingBackward() const override {
-		return false;
 	}
 	unique_ptr<Calendar> Copy() const override {
 		return unique_ptr<Calendar>(new BuddhistCalendar(*this));
@@ -140,9 +134,6 @@ public:
 
 	const char *GetType() const override {
 		return "iso8601";
-	}
-	bool IsEra0CountingBackward() const override {
-		return false;
 	}
 	unique_ptr<Calendar> Copy() const override {
 		return unique_ptr<Calendar>(new ISO8601Calendar(*this));

--- a/extension/icu/datetime/include/japanese.hpp
+++ b/extension/icu/datetime/include/japanese.hpp
@@ -35,9 +35,6 @@ public:
 	const char *GetType() const override {
 		return "japanese";
 	}
-	bool IsEra0CountingBackward() const override {
-		return false;
-	}
 	unique_ptr<Calendar> Copy() const override {
 		return unique_ptr<Calendar>(new JapaneseCalendar(*this));
 	}

--- a/extension/icu/icu-datesub.cpp
+++ b/extension/icu/icu-datesub.cpp
@@ -8,6 +8,18 @@
 namespace duckdb {
 
 struct ICUCalendarSub : public ICUDateFunc {
+	static unique_ptr<FunctionData> Bind(BindScalarFunctionInput &input) {
+		auto part_value = input.TryGetConstant(0);
+		if (part_value && !part_value->IsNull()) {
+			DatePartSpecifier part;
+			if (TryGetDatePartSpecifier(part_value->GetValue<string>(), part) && part == DatePartSpecifier::ERA) {
+				// date_sub is not monotone for eras because era boundaries can occur partway through a year
+				input.GetBoundFunction().SetArgProperties({});
+			}
+		}
+		return ICUDateFunc::Bind(input);
+	}
+
 	//	ICU only has 32 bit precision for date parts, so it can overflow a high resolution.
 	//	Since there is no difference between ICU and the obvious calculations,
 	//	we make these using the DuckDB internal type.

--- a/extension/icu/icu-datesub.cpp
+++ b/extension/icu/icu-datesub.cpp
@@ -189,6 +189,20 @@ ICUDateFunc::part_sub_t ICUDateFunc::SubtractFactory(DatePartSpecifier type) {
 // MS-SQL differences can be computed using ICU by truncating both arguments
 // to the desired part precision and then applying ICU subtraction/difference
 struct ICUCalendarDiff : public ICUDateFunc {
+	static int64_t DifferenceEra(Calendar *calendar, timestamp_tz_t start_date, timestamp_tz_t end_date) {
+		SetTime(calendar, start_date);
+		const auto start_era = ExtractField(calendar, CAL_ERA);
+		SetTime(calendar, end_date);
+		return int64_t(ExtractField(calendar, CAL_ERA)) - start_era;
+	}
+
+	static int64_t DifferenceEra(Calendar *calendar, timestamp_tz_ns_t start_date, timestamp_tz_ns_t end_date) {
+		SetTimeNS(calendar, start_date);
+		const auto start_era = ExtractField(calendar, CAL_ERA);
+		SetTimeNS(calendar, end_date);
+		return int64_t(ExtractField(calendar, CAL_ERA)) - start_era;
+	}
+
 	static timestamp_tz_t TruncateForDiff(Calendar *calendar, timestamp_tz_t date, part_trunc_t trunc_func) {
 		auto micros = SetTime(calendar, date);
 		trunc_func(calendar, micros);
@@ -249,6 +263,9 @@ struct ICUCalendarDiff : public ICUDateFunc {
 				BinaryExecutor::Execute<T, T, int64_t>(
 				    startdate_arg, enddate_arg, result, [&](T start_date, T end_date) -> optional<int64_t> {
 					    if (start_date.IsFinite() && end_date.IsFinite()) {
+						    if (part == DatePartSpecifier::ERA) {
+							    return DifferenceEra(calendar, start_date, end_date);
+						    }
 						    return DifferenceFunc(calendar, start_date, end_date, trunc_func, sub_func);
 					    } else {
 						    return nullopt;
@@ -261,6 +278,9 @@ struct ICUCalendarDiff : public ICUDateFunc {
 			    [&](string_t specifier, T start_date, T end_date) -> optional<int64_t> {
 				    if (start_date.IsFinite() && end_date.IsFinite()) {
 					    const auto part = GetDatePartSpecifier(specifier.GetString());
+					    if (part == DatePartSpecifier::ERA) {
+						    return DifferenceEra(calendar, start_date, end_date);
+					    }
 					    auto trunc_func = DiffTruncationFactory(part);
 					    auto sub_func = SubtractFactory(part);
 					    return DifferenceFunc(calendar, start_date, end_date, trunc_func, sub_func);

--- a/test/sql/function/timestamp/test_icu_datediff.test
+++ b/test/sql/function/timestamp/test_icu_datediff.test
@@ -42,6 +42,24 @@ SELECT DATEDIFF('isoyear', '2022-01-01 00:00:00-08'::TIMESTAMPTZ, '2022-01-03 00
 ----
 1
 
+# Calendar boundaries across the BC/AD era transition
+query IIII
+SELECT
+	date_diff('isoyear', '1-01-01 (BC)'::TIMESTAMPTZ, '1-01-01'::TIMESTAMPTZ),
+	date_diff('isoyear', '1-01-01'::TIMESTAMPTZ, '1-01-01 (BC)'::TIMESTAMPTZ),
+	date_diff('era', '1-01-01 (BC)'::TIMESTAMPTZ, '1-01-01'::TIMESTAMPTZ),
+	date_diff('era', '1-01-01'::TIMESTAMPTZ, '1-01-01 (BC)'::TIMESTAMPTZ);
+----
+2	-2	1	-1
+
+# Unequal dates in the same era have no era boundaries between them
+query II
+SELECT
+	date_diff('era', '2000-01-01'::TIMESTAMPTZ, '2020-01-01'::TIMESTAMPTZ),
+	date_diff('era', '2020-01-01'::TIMESTAMPTZ, '2000-01-01'::TIMESTAMPTZ);
+----
+0	0
+
 #
 # TIMESTAMPTZ_NS
 #
@@ -69,9 +87,10 @@ endloop
 
 query II rowsort
 SELECT part, date_diff(part, startdate, enddate)
-FROM datetime_ns, (VALUES ('year'), ('month'), ('day'), ('hour')) parts(part)
+FROM datetime_ns, (VALUES ('era'), ('year'), ('month'), ('day'), ('hour')) parts(part)
 ----
 day	1
+era	0
 hour	1
 month	1
 year	1
@@ -280,3 +299,48 @@ query I
 select date_diff('day', '2022-01-04 19:00:00'::timestamptz, '2024-03-01'::date) as c1;
 ----
 787
+
+# Era differences count boundaries according to each calendar's era numbering
+statement ok
+SET TimeZone = 'UTC';
+
+statement ok
+SET Calendar = 'gregorian';
+
+statement ok
+CREATE TEMP TABLE era_boundaries(name VARCHAR, startdate TIMESTAMPTZ, enddate TIMESTAMPTZ);
+
+statement ok
+INSERT INTO era_boundaries VALUES
+	('coptic', '0283-08-29 12:00:00+00', '0284-08-29 12:00:00+00'),
+	('roc', '1911-12-31 12:00:00+00', '1912-01-01 12:00:00+00'),
+	('japanese', '1912-07-29 00:00:00+00', '2019-05-01 00:00:00+00');
+
+foreach calendar coptic roc
+
+statement ok
+SET Calendar = '{calendar}';
+
+query II
+SELECT date_diff('era', startdate, enddate), date_diff('era', enddate, startdate)
+FROM era_boundaries WHERE name = '{calendar}';
+----
+1	-1
+
+endloop
+
+statement ok
+SET TimeZone = 'Asia/Tokyo';
+
+statement ok
+SET Calendar = 'japanese';
+
+query IIII
+SELECT
+	date_diff('era', startdate, enddate),
+	date_diff('era', enddate, startdate),
+	date_diff('era', '1912-07-29 00:00:00+00'::TIMESTAMPTZ_NS, '2019-05-01 00:00:00+00'::TIMESTAMPTZ_NS),
+	date_diff('era', '2019-05-01 00:00:00+00'::TIMESTAMPTZ_NS, '1912-07-29 00:00:00+00'::TIMESTAMPTZ_NS)
+FROM era_boundaries WHERE name = 'japanese';
+----
+4	-4	4	-4

--- a/test/sql/function/timestamp/test_icu_datesub.test
+++ b/test/sql/function/timestamp/test_icu_datesub.test
@@ -51,6 +51,34 @@ select DATESUB('isoyear', '2004-02-29 12:00:00-08'::TIMESTAMPTZ, '2005-02-28 13:
 ----
 1
 
+# Complete ISO years and eras across BC/AD
+foreach datepart isoyear era
+
+query II
+SELECT
+	date_sub('{datepart}', '1-01-01 (BC)'::TIMESTAMPTZ, '1-01-01'::TIMESTAMPTZ),
+	date_sub('{datepart}', '1-01-01'::TIMESTAMPTZ, '1-01-01 (BC)'::TIMESTAMPTZ);
+----
+1	-1
+
+endloop
+
+# Years increase continuously across BC/AD
+query II
+SELECT
+	date_sub('year', '2-01-01 (BC)'::TIMESTAMPTZ, '2-01-01'::TIMESTAMPTZ),
+	date_sub('year', '2-01-01'::TIMESTAMPTZ, '2-01-01 (BC)'::TIMESTAMPTZ);
+----
+3	-3
+
+# Unequal dates in the same era have no era boundaries between them
+query II
+SELECT
+	date_sub('era', '2000-01-01'::TIMESTAMPTZ, '2020-01-01'::TIMESTAMPTZ),
+	date_sub('era', '2020-01-01'::TIMESTAMPTZ, '2000-01-01'::TIMESTAMPTZ);
+----
+0	0
+
 query I
 select DATESUB('decade', '1994-02-28 12:00:00-08'::TIMESTAMPTZ, '2004-02-29 13:00:00-08'::TIMESTAMPTZ);
 ----
@@ -299,3 +327,36 @@ FROM (
 1
 
 endloop
+
+# Era subtraction follows each calendar's era numbering
+statement ok
+SET TimeZone = 'UTC';
+
+statement ok
+SET Calendar = 'gregorian';
+
+statement ok
+CREATE TEMP TABLE era_subtraction(name VARCHAR, startdate TIMESTAMPTZ, enddate TIMESTAMPTZ);
+
+statement ok
+INSERT INTO era_subtraction VALUES
+	('coptic', '0283-08-30 12:00:00+00', '0284-08-29 12:00:00+00'),
+	('japanese', '1872-10-01 12:00:00+00', '2023-10-01 12:00:00+00');
+
+statement ok
+SET Calendar = 'coptic';
+
+query II
+SELECT date_sub('era', startdate, enddate), date_sub('era', enddate, startdate)
+FROM era_subtraction WHERE name = 'coptic';
+----
+1	-1
+
+statement ok
+SET Calendar = 'japanese';
+
+query II
+SELECT date_sub('era', startdate, enddate), date_sub('era', enddate, startdate)
+FROM era_subtraction WHERE name = 'japanese';
+----
+4	-4


### PR DESCRIPTION
This fixes `date_sub` and `date_diff` for years, ISO week-years, and eras across calendar era boundaries. Year arithmetic now uses continuous calendar years instead of assuming era 0 counts backward.

The tests also cover Gregorian BC/AD transitions, Coptic and Japanese era boundaries.

Fixes https://github.com/duckdb/duckdb/issues/24453
Fixes https://github.com/duckdblabs/duckdb-internal/issues/10246