### PR TITLE
fix: allow root path in HTTP proxy URL

### DIFF
--- a/src/main/http/http_util.cpp
+++ b/src/main/http/http_util.cpp
@@ -322,6 +322,16 @@ void HTTPUtil::ParseHTTPProxyHost(string &proxy_value, string &hostname_out, idx
 	if (StringUtil::StartsWith(proxy_value, "http://")) {
 		sanitized_proxy_value = proxy_value.substr(7);
 	}
+	auto path_pos = sanitized_proxy_value.find('/');
+	if (path_pos != string::npos) {
+		if (path_pos != sanitized_proxy_value.size() - 1) {
+			throw InvalidInputException("Failed to parse http_proxy '%s' into a host and port", proxy_value);
+		}
+		sanitized_proxy_value.pop_back();
+	}
+	if (sanitized_proxy_value.empty()) {
+		throw InvalidInputException("Failed to parse http_proxy '%s' into a host and port", proxy_value);
+	}
 	auto proxy_split = StringUtil::Split(sanitized_proxy_value, ":");
 	if (proxy_split.size() == 1) {
 		hostname_out = proxy_split[0];

--- a/test/common/CMakeLists.txt
+++ b/test/common/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library_unity(
   test_caching_file_system_wrapper.cpp
   test_external_file_cache.cpp
   test_hyperlog.cpp
+  test_http_util.cpp
   test_lru_cache.cpp
   test_numeric_cast.cpp
   test_parse_expression.cpp

--- a/test/common/test_http_util.cpp
+++ b/test/common/test_http_util.cpp
@@ -1,0 +1,26 @@
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/http_util.hpp"
+#include "catch.hpp"
+
+using namespace duckdb;
+
+TEST_CASE("Parse HTTP proxy host", "[http]") {
+	string hostname;
+	idx_t port;
+
+	string proxy = "http://proxy.example.com:3128/";
+	HTTPUtil::ParseHTTPProxyHost(proxy, hostname, port);
+	REQUIRE(hostname == "proxy.example.com");
+	REQUIRE(port == 3128);
+
+	proxy = "http://proxy.example.com/";
+	HTTPUtil::ParseHTTPProxyHost(proxy, hostname, port);
+	REQUIRE(hostname == "proxy.example.com");
+	REQUIRE(port == 80);
+
+	proxy = "http://proxy.example.com:3128/foo";
+	REQUIRE_THROWS_AS(HTTPUtil::ParseHTTPProxyHost(proxy, hostname, port), InvalidInputException);
+
+	proxy = "http://proxy.example.com:3128//";
+	REQUIRE_THROWS_AS(HTTPUtil::ParseHTTPProxyHost(proxy, hostname, port), InvalidInputException);
+}


### PR DESCRIPTION
> Proxy environment variables commonly contain a trailing slash. Treat the root path as equivalent to no path while continuing to reject non-root proxy paths.

AI disclosure: this code is generated with the assistance of an LLM/agent.

---

we have an environment which is running with `HTTP_PROXY=http://proxy-svc.ns.svc:3128/` which fails on duckdb with

```
_duckdb.InvalidInputException: Invalid Input Error: Failed to parse port from http_proxy 'http://proxy-svc.ns.svc:3128/'
```

such a proxy URL is perfectly fine with, say, curl.

i am not entirely sure how to handle the `http://proxy.example.com:3128/foo` case since curl supports it and only uses `(scheme, host, port)` out of it and ignores path. not sure if we should extend this to the general case¹

¹ in which case i don't really wanna sit and figure out URL parsing shenanigans here..
