### PR TITLE
Isolate temporary files per DuckDB instance

### DIFF
--- a/src/include/duckdb/storage/temporary_file_manager.hpp
+++ b/src/include/duckdb/storage/temporary_file_manager.hpp
@@ -263,7 +263,8 @@ class TemporaryFileManager {
 	friend class TemporaryFileHandle;
 
 public:
-	TemporaryFileManager(DatabaseInstance &db, const string &temp_directory_p, atomic<idx_t> &size_on_disk);
+	TemporaryFileManager(DatabaseInstance &db, const string &temp_directory_p, string instance_id_p,
+	                     atomic<idx_t> &size_on_disk);
 	~TemporaryFileManager();
 
 private:
@@ -326,6 +327,8 @@ private:
 	DatabaseInstance &db;
 	//! The temporary directory
 	string temp_directory;
+	//! The identifier of the DuckDB instance that owns these temporary files
+	string instance_id;
 	//! Lock for parallel access
 	mutex manager_lock;
 	//! The set of active temporary file handles
@@ -355,11 +358,22 @@ public:
 
 public:
 	TemporaryFileManager &GetTempFile() const;
+	string GetTempBlockPath(block_id_t id) const;
+
+private:
+	void InitializeOwnerFile(FileSystem &fs);
+	void CleanupOrphanedFiles(FileSystem &fs);
+	void RemoveOwnedTemporaryFiles(FileSystem &fs, const string &owner_id);
+	void UnregisterOwner();
+	void ReleaseOwnerFile(FileSystem &fs, bool remove_owner_file);
 
 private:
 	DatabaseInstance &db;
 	string temp_directory;
-	bool created_directory = false;
+	string instance_id;
+	string owner_file_path;
+	unique_ptr<FileHandle> owner_file_handle;
+	bool owner_registered = false;
 	unique_ptr<TemporaryFileManager> temp_file;
 };
 

--- a/src/storage/standard_buffer_manager.cpp
+++ b/src/storage/standard_buffer_manager.cpp
@@ -462,8 +462,8 @@ vector<MemoryInformation> StandardBufferManager::GetMemoryUsageInfo() const {
 }
 
 string StandardBufferManager::GetTemporaryPath(block_id_t id) {
-	auto &fs = FileSystem::GetFileSystem(db);
-	return fs.JoinPath(temporary_directory.path, "duckdb_temp_block-" + to_string(id) + ".block");
+	D_ASSERT(temporary_directory.handle);
+	return temporary_directory.handle->GetTempBlockPath(id);
 }
 
 void StandardBufferManager::RequireTemporaryDirectory() {

--- a/src/storage/temporary_file_manager.cpp
+++ b/src/storage/temporary_file_manager.cpp
@@ -1,6 +1,9 @@
 #include "duckdb/storage/temporary_file_manager.hpp"
 
 #include "duckdb/common/enum_util.hpp"
+#include "duckdb/common/types/uuid.hpp"
+#include "duckdb/common/unordered_map.hpp"
+#include "duckdb/common/unordered_set.hpp"
 #include "duckdb/parallel/task_scheduler.hpp"
 #include "duckdb/storage/buffer/temporary_file_information.hpp"
 #include "duckdb/main/database.hpp"
@@ -10,6 +13,166 @@
 #include "zstd.h"
 
 namespace duckdb {
+
+static constexpr const char *TEMPORARY_OWNER_FILE_PREFIX = "duckdb_temp_owner_v1_";
+static constexpr const char *TEMPORARY_OWNER_FILE_SUFFIX = ".lock";
+static constexpr const char *TEMPORARY_FILE_PREFIX = "duckdb_temp_v1_";
+static constexpr const char *TEMPORARY_OWNER_MAGIC = "DUCKDB_TEMP_OWNER";
+static constexpr idx_t TEMPORARY_OWNER_VERSION = 1;
+static constexpr idx_t TEMPORARY_OWNER_ID_LENGTH = 36;
+static constexpr idx_t TEMPORARY_OWNER_UUID_VERSION_INDEX = 14;
+static constexpr idx_t TEMPORARY_OWNER_UUID_VARIANT_INDEX = 19;
+static constexpr idx_t TEMPORARY_OWNER_CREATE_ATTEMPTS = 3;
+
+struct ActiveTemporaryOwnerRegistry {
+	// POSIX fcntl locks are process-scoped, so they cannot distinguish DuckDB instances in the same process.
+	mutex lock;
+	unordered_set<string> owners;
+};
+
+static ActiveTemporaryOwnerRegistry &GetActiveTemporaryOwnerRegistry() {
+	static ActiveTemporaryOwnerRegistry registry;
+	return registry;
+}
+
+static bool RegisterActiveTemporaryOwner(const string &owner_id) {
+	auto &registry = GetActiveTemporaryOwnerRegistry();
+	lock_guard<mutex> guard(registry.lock);
+	return registry.owners.insert(owner_id).second;
+}
+
+static void UnregisterActiveTemporaryOwner(const string &owner_id) {
+	auto &registry = GetActiveTemporaryOwnerRegistry();
+	lock_guard<mutex> guard(registry.lock);
+	registry.owners.erase(owner_id);
+}
+
+static bool IsActiveTemporaryOwner(const string &owner_id) {
+	auto &registry = GetActiveTemporaryOwnerRegistry();
+	lock_guard<mutex> guard(registry.lock);
+	return registry.owners.find(owner_id) != registry.owners.end();
+}
+
+static string TemporaryOwnerFileName(const string &owner_id) {
+	return string(TEMPORARY_OWNER_FILE_PREFIX) + owner_id + TEMPORARY_OWNER_FILE_SUFFIX;
+}
+
+static string TemporaryOwnerManifest(const string &owner_id) {
+	return StringUtil::Format("%s\n%llu\n%s\n", TEMPORARY_OWNER_MAGIC, TEMPORARY_OWNER_VERSION, owner_id);
+}
+
+static string OwnedTemporaryFilePrefix(const string &owner_id) {
+	return string(TEMPORARY_FILE_PREFIX) + owner_id + "_";
+}
+
+static bool IsTemporaryOwnerId(const string &candidate) {
+	if (candidate.size() != TEMPORARY_OWNER_ID_LENGTH) {
+		return false;
+	}
+	hugeint_t parsed_uuid;
+	return UUID::FromString(candidate, parsed_uuid, true) && UUID::ToString(parsed_uuid) == candidate &&
+	       candidate[TEMPORARY_OWNER_UUID_VERSION_INDEX] == '4' &&
+	       (candidate[TEMPORARY_OWNER_UUID_VARIANT_INDEX] == '8' ||
+	        candidate[TEMPORARY_OWNER_UUID_VARIANT_INDEX] == '9' ||
+	        candidate[TEMPORARY_OWNER_UUID_VARIANT_INDEX] == 'a' ||
+	        candidate[TEMPORARY_OWNER_UUID_VARIANT_INDEX] == 'b');
+}
+
+static bool TryParseTemporaryOwnerFile(const string &file_name, string &owner_id) {
+	if (!StringUtil::StartsWith(file_name, TEMPORARY_OWNER_FILE_PREFIX) ||
+	    !StringUtil::EndsWith(file_name, TEMPORARY_OWNER_FILE_SUFFIX)) {
+		return false;
+	}
+	const auto prefix_size = strlen(TEMPORARY_OWNER_FILE_PREFIX);
+	const auto suffix_size = strlen(TEMPORARY_OWNER_FILE_SUFFIX);
+	if (file_name.size() <= prefix_size + suffix_size) {
+		return false;
+	}
+	auto candidate = file_name.substr(prefix_size, file_name.size() - prefix_size - suffix_size);
+	if (!IsTemporaryOwnerId(candidate)) {
+		return false;
+	}
+	owner_id = std::move(candidate);
+	return true;
+}
+
+static bool IsUnsignedNumber(const string &value) {
+	if (value.empty()) {
+		return false;
+	}
+	for (const auto ch : value) {
+		if (ch < '0' || ch > '9') {
+			return false;
+		}
+	}
+	return true;
+}
+
+static bool IsTemporaryStorageSize(const string &value) {
+	return value == "S32K" || value == "S64K" || value == "S96K" || value == "S128K" || value == "S160K" ||
+	       value == "S192K" || value == "S224K" || value == "DEFAULT";
+}
+
+static bool TryParseOwnedTemporaryFile(const string &file_name, string &owner_id) {
+	if (!StringUtil::StartsWith(file_name, TEMPORARY_FILE_PREFIX)) {
+		return false;
+	}
+	const auto prefix_size = strlen(TEMPORARY_FILE_PREFIX);
+	if (file_name.size() <= prefix_size + TEMPORARY_OWNER_ID_LENGTH ||
+	    file_name[prefix_size + TEMPORARY_OWNER_ID_LENGTH] != '_') {
+		return false;
+	}
+	auto candidate = file_name.substr(prefix_size, TEMPORARY_OWNER_ID_LENGTH);
+	if (!IsTemporaryOwnerId(candidate)) {
+		return false;
+	}
+	const auto remainder = file_name.substr(prefix_size + TEMPORARY_OWNER_ID_LENGTH + 1);
+	if (StringUtil::StartsWith(remainder, "block-") && StringUtil::EndsWith(remainder, ".block")) {
+		const auto block_id =
+		    remainder.substr(strlen("block-"), remainder.size() - strlen("block-") - strlen(".block"));
+		if (!IsUnsignedNumber(block_id)) {
+			return false;
+		}
+		owner_id = std::move(candidate);
+		return true;
+	}
+	if (!StringUtil::StartsWith(remainder, "storage_") || !StringUtil::EndsWith(remainder, ".tmp")) {
+		return false;
+	}
+	const auto storage_id =
+	    remainder.substr(strlen("storage_"), remainder.size() - strlen("storage_") - strlen(".tmp"));
+	const auto separator = storage_id.rfind('-');
+	if (separator == string::npos) {
+		return false;
+	}
+	if (!IsTemporaryStorageSize(storage_id.substr(0, separator)) ||
+	    !IsUnsignedNumber(storage_id.substr(separator + 1))) {
+		return false;
+	}
+	owner_id = std::move(candidate);
+	return true;
+}
+
+static bool IsOwnedTemporaryFile(const string &file_name, const string &owner_id) {
+	string parsed_owner_id;
+	return TryParseOwnedTemporaryFile(file_name, parsed_owner_id) && parsed_owner_id == owner_id;
+}
+
+static bool TemporaryOwnerManifestMatches(FileHandle &handle, const string &owner_id) {
+	auto expected = TemporaryOwnerManifest(owner_id);
+	if (handle.GetFileSize() != expected.size()) {
+		return false;
+	}
+	string actual(expected.size(), '\0');
+	handle.Read(QueryContext(), data_ptr_cast(&actual[0]), actual.size(), 0);
+	return actual == expected;
+}
+
+struct LockedTemporaryOwner {
+	string owner_file_path;
+	unique_ptr<FileHandle> owner_file_handle;
+	vector<string> files;
+};
 
 //===--------------------------------------------------------------------===//
 // TemporaryBufferSize
@@ -485,9 +648,10 @@ void TemporaryFileCompressionAdaptivity::Update(const TemporaryCompressionLevel 
 //===--------------------------------------------------------------------===//
 // TemporaryFileManager
 //===--------------------------------------------------------------------===//
-TemporaryFileManager::TemporaryFileManager(DatabaseInstance &db, const string &temp_directory_p,
+TemporaryFileManager::TemporaryFileManager(DatabaseInstance &db, const string &temp_directory_p, string instance_id_p,
                                            atomic<idx_t> &size_on_disk_p)
-    : db(db), temp_directory(temp_directory_p), files(*this), size_on_disk(size_on_disk_p), max_swap_space(0) {
+    : db(db), temp_directory(temp_directory_p), instance_id(std::move(instance_id_p)), files(*this),
+      size_on_disk(size_on_disk_p), max_swap_space(0) {
 }
 
 TemporaryFileManager::~TemporaryFileManager() {
@@ -705,8 +869,9 @@ void TemporaryFileManager::EraseUsedBlock(TemporaryFileManagerLock &lock, block_
 
 string TemporaryFileManager::CreateTemporaryFileName(const TemporaryFileIdentifier &identifier) const {
 	return FileSystem::GetFileSystem(db).JoinPath(
-	    temp_directory, StringUtil::Format("duckdb_temp_storage_%s-%llu.tmp", EnumUtil::ToString(identifier.size),
-	                                       identifier.file_index.GetIndex()));
+	    temp_directory,
+	    StringUtil::Format("%sstorage_%s-%llu.tmp", OwnedTemporaryFilePrefix(instance_id),
+	                       EnumUtil::ToString(identifier.size), identifier.file_index.GetIndex()));
 }
 
 optional_ptr<TemporaryFileHandle> TemporaryFileManager::GetFileHandle(TemporaryFileManagerLock &,
@@ -731,55 +896,196 @@ void TemporaryFileManager::EraseFileHandle(TemporaryFileManagerLock &, const Tem
 //===--------------------------------------------------------------------===//
 TemporaryDirectoryHandle::TemporaryDirectoryHandle(DatabaseInstance &db, string path_p, atomic<idx_t> &size_on_disk,
                                                    optional_idx max_swap_space)
-    : db(db), temp_directory(std::move(path_p)),
-      temp_file(make_uniq<TemporaryFileManager>(db, temp_directory, size_on_disk)) {
+    : db(db), temp_directory(std::move(path_p)) {
 	auto &fs = FileSystem::GetFileSystem(db);
 	D_ASSERT(!temp_directory.empty());
 	if (!fs.DirectoryExists(temp_directory)) {
 		fs.CreateDirectory(temp_directory);
-		created_directory = true;
 	}
-	temp_file->SetMaxSwapSpace(max_swap_space);
+	try {
+		bool cleanup_orphaned_files = true;
+		try {
+			InitializeOwnerFile(fs);
+		} catch (...) {
+			// Establishing ownership is only required for orphan cleanup. Keep spilling in an unregistered UUID
+			// namespace if the file system cannot create, lock, write or sync the owner file.
+			ReleaseOwnerFile(fs, true);
+			instance_id = UUID::ToString(UUID::GenerateRandomUUID());
+			cleanup_orphaned_files = false;
+		}
+		if (cleanup_orphaned_files) {
+			CleanupOrphanedFiles(fs);
+		}
+		temp_file = make_uniq<TemporaryFileManager>(db, temp_directory, instance_id, size_on_disk);
+		temp_file->SetMaxSwapSpace(max_swap_space);
+	} catch (...) {
+		ReleaseOwnerFile(fs, true);
+		throw;
+	}
 }
 
 TemporaryDirectoryHandle::~TemporaryDirectoryHandle() {
-	// first release any temporary files
 	temp_file.reset();
-	// then delete the temporary file directory
 	auto &fs = FileSystem::GetFileSystem(db);
-	if (!temp_directory.empty()) {
-		bool delete_directory = created_directory;
-		vector<string> files_to_delete;
-		if (!created_directory) {
-			bool deleted_everything = true;
-			fs.ListFiles(temp_directory, [&](const string &path, bool isdir) {
-				if (isdir) {
-					deleted_everything = false;
-					return;
-				}
-				if (!StringUtil::StartsWith(path, "duckdb_temp_")) {
-					deleted_everything = false;
-					return;
-				}
-				files_to_delete.push_back(path);
-			});
+	bool remove_owner_file = true;
+	try {
+		RemoveOwnedTemporaryFiles(fs, instance_id);
+	} catch (...) {
+		remove_owner_file = false;
+	}
+	ReleaseOwnerFile(fs, remove_owner_file);
+}
+
+void TemporaryDirectoryHandle::InitializeOwnerFile(FileSystem &fs) {
+	const auto flags = FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE_NEW |
+	                   FileFlags::FILE_FLAGS_EXCLUSIVE_CREATE | FileFlags::FILE_FLAGS_NULL_IF_EXISTS |
+	                   FileFlags::FILE_FLAGS_DISABLE_LOGGING | FileLockType::WRITE_LOCK;
+	for (idx_t attempt = 0; attempt < TEMPORARY_OWNER_CREATE_ATTEMPTS; attempt++) {
+		auto candidate = UUID::ToString(UUID::GenerateRandomUUID());
+		if (!RegisterActiveTemporaryOwner(candidate)) {
+			continue;
 		}
-		if (delete_directory) {
-			// we want to remove all files in the directory
-			fs.RemoveDirectory(temp_directory);
-		} else {
-			vector<string> full_path_files_to_delete;
-			full_path_files_to_delete.reserve(files_to_delete.size());
-			for (auto &file : files_to_delete) {
-				full_path_files_to_delete.push_back(fs.JoinPath(temp_directory, file));
+		string candidate_path;
+		unique_ptr<FileHandle> candidate_handle;
+		try {
+			candidate_path = fs.JoinPath(temp_directory, TemporaryOwnerFileName(candidate));
+			candidate_handle = fs.OpenFile(candidate_path, flags);
+		} catch (...) {
+			UnregisterActiveTemporaryOwner(candidate);
+			if (!candidate_path.empty()) {
+				fs.TryRemoveFile(candidate_path);
 			}
-			fs.RemoveFiles(full_path_files_to_delete);
+			throw;
+		}
+		if (!candidate_handle) {
+			UnregisterActiveTemporaryOwner(candidate);
+			continue;
+		}
+
+		instance_id = std::move(candidate);
+		owner_file_path = std::move(candidate_path);
+		owner_file_handle = std::move(candidate_handle);
+		owner_registered = true;
+		auto manifest = TemporaryOwnerManifest(instance_id);
+		owner_file_handle->Write(QueryContext(), &manifest[0], manifest.size(), 0);
+		fs.FileSync(*owner_file_handle);
+		return;
+	}
+	throw IOException("Failed to create a unique owner file in temporary directory \"%s\"", temp_directory);
+}
+
+void TemporaryDirectoryHandle::CleanupOrphanedFiles(FileSystem &fs) {
+	vector<pair<string, string>> owner_files;
+	try {
+		fs.ListFiles(temp_directory, [&](const string &file_name, bool is_directory) {
+			if (is_directory) {
+				return;
+			}
+			string owner_id;
+			if (TryParseTemporaryOwnerFile(file_name, owner_id)) {
+				owner_files.emplace_back(std::move(file_name), std::move(owner_id));
+			}
+		});
+	} catch (IOException &) {
+		return;
+	}
+
+	vector<LockedTemporaryOwner> locked_owners;
+	unordered_map<string, idx_t> locked_owner_indexes;
+	for (const auto &entry : owner_files) {
+		const auto &owner_file_name = entry.first;
+		const auto &owner_id = entry.second;
+		if (IsActiveTemporaryOwner(owner_id)) {
+			continue;
+		}
+		auto path = fs.JoinPath(temp_directory, owner_file_name);
+		try {
+			auto cleanup_lock = fs.OpenFile(path, FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_WRITE |
+			                                          FileFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS |
+			                                          FileFlags::FILE_FLAGS_DISABLE_LOGGING |
+			                                          FileLockType::WRITE_LOCK);
+			if (!cleanup_lock || !TemporaryOwnerManifestMatches(*cleanup_lock, owner_id)) {
+				continue;
+			}
+			locked_owner_indexes.emplace(owner_id, locked_owners.size());
+			locked_owners.push_back({std::move(path), std::move(cleanup_lock), {}});
+		} catch (IOException &) {
+			// A lock failure means the owner is still alive. Other I/O errors leave the owner marker for a later retry.
+			continue;
+		}
+	}
+	if (locked_owners.empty()) {
+		return;
+	}
+
+	try {
+		fs.ListFiles(temp_directory, [&](const string &file_name, bool is_directory) {
+			if (is_directory) {
+				return;
+			}
+			string owner_id;
+			if (!TryParseOwnedTemporaryFile(file_name, owner_id)) {
+				return;
+			}
+			const auto entry = locked_owner_indexes.find(owner_id);
+			if (entry == locked_owner_indexes.end()) {
+				return;
+			}
+			locked_owners[entry->second].files.push_back(fs.JoinPath(temp_directory, file_name));
+		});
+	} catch (IOException &) {
+		return;
+	}
+
+	for (auto &owner : locked_owners) {
+		try {
+			fs.RemoveFiles(owner.files);
+			fs.TryRemoveFile(owner.owner_file_path);
+		} catch (IOException &) {
+			// Leave the owner marker behind so a later process can retry cleanup.
+			continue;
 		}
 	}
 }
 
+void TemporaryDirectoryHandle::RemoveOwnedTemporaryFiles(FileSystem &fs, const string &owner_id) {
+	if (owner_id.empty()) {
+		return;
+	}
+	vector<string> files_to_delete;
+	fs.ListFiles(temp_directory, [&](const string &file_name, bool is_directory) {
+		if (!is_directory && IsOwnedTemporaryFile(file_name, owner_id)) {
+			files_to_delete.push_back(fs.JoinPath(temp_directory, file_name));
+		}
+	});
+	fs.RemoveFiles(files_to_delete);
+}
+
+void TemporaryDirectoryHandle::UnregisterOwner() {
+	if (!owner_registered) {
+		return;
+	}
+	UnregisterActiveTemporaryOwner(instance_id);
+	owner_registered = false;
+}
+
+void TemporaryDirectoryHandle::ReleaseOwnerFile(FileSystem &fs, bool remove_owner_file) {
+	owner_file_handle.reset();
+	UnregisterOwner();
+	if (remove_owner_file && !owner_file_path.empty()) {
+		fs.TryRemoveFile(owner_file_path);
+	}
+	owner_file_path.clear();
+}
+
 TemporaryFileManager &TemporaryDirectoryHandle::GetTempFile() const {
+	D_ASSERT(temp_file);
 	return *temp_file;
+}
+
+string TemporaryDirectoryHandle::GetTempBlockPath(block_id_t id) const {
+	return FileSystem::GetFileSystem(db).JoinPath(
+	    temp_directory, StringUtil::Format("%sblock-%llu.block", OwnedTemporaryFilePrefix(instance_id), id));
 }
 
 } // namespace duckdb

--- a/test/sql/storage/test_buffer_manager.cpp
+++ b/test/sql/storage/test_buffer_manager.cpp
@@ -1,16 +1,290 @@
 #include <duckdb/main/settings.hpp>
 
 #include "catch.hpp"
+#include "duckdb/common/exception.hpp"
 #include "duckdb/common/file_system.hpp"
+#include "duckdb/common/local_file_system.hpp"
+#include "duckdb/function/scalar_function.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/settings.hpp"
+#include "duckdb/parser/parsed_data/create_scalar_function_info.hpp"
 #include "duckdb/storage/buffer/block_handle.hpp"
 #include "duckdb/storage/buffer_manager.hpp"
 #include "duckdb/storage/storage_info.hpp"
 #include "duckdb/common/enums/memory_tag.hpp"
 #include "test_helpers.hpp"
 
+#include <chrono>
+#include <condition_variable>
+#include <cstring>
+#include <mutex>
+#include <thread>
+
+#if !defined(_WIN32) && !defined(WIN32)
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
+
 using namespace duckdb;
+
+static constexpr const char *TEST_TEMP_OWNER_PREFIX = "duckdb_temp_owner_v1_";
+static constexpr const char *TEST_TEMP_OWNER_SUFFIX = ".lock";
+static constexpr const char *TEST_TEMP_FILE_PREFIX = "duckdb_temp_v1_";
+
+class TestNoLockFileSystem : public LocalFileSystem {
+public:
+	explicit TestNoLockFileSystem(string path_prefix_p) : path_prefix(std::move(path_prefix_p)) {
+	}
+
+public:
+	string GetName() const override {
+		return "TestNoLockFileSystem";
+	}
+
+	bool CanHandleFile(const string &path) override {
+		return StringUtil::StartsWith(path, path_prefix);
+	}
+
+	duckdb::unique_ptr<FileHandle> OpenFile(const string &path, FileOpenFlags flags,
+	                                        optional_ptr<FileOpener> opener = nullptr) override {
+		if (flags.Lock() == FileLockType::NO_LOCK) {
+			return LocalFileSystem::OpenFile(path, flags, opener);
+		}
+		auto unlocked_flags = FileOpenFlags(flags.GetFlagsInternal(), FileLockType::NO_LOCK, flags.Compression());
+		auto handle = LocalFileSystem::OpenFile(path, unlocked_flags, opener);
+		if (!handle) {
+			return nullptr;
+		}
+		handle.reset();
+		throw IOException("Test file system does not support file locks");
+	}
+
+private:
+	string path_prefix;
+};
+
+class TestCleanupFileSystem : public LocalFileSystem {
+public:
+	explicit TestCleanupFileSystem(string path_prefix_p, bool fail_next_list_p = false)
+	    : path_prefix(std::move(path_prefix_p)), fail_next_list(fail_next_list_p) {
+	}
+
+public:
+	string GetName() const override {
+		return "TestCleanupFileSystem";
+	}
+
+	bool CanHandleFile(const string &path) override {
+		return StringUtil::StartsWith(path, path_prefix);
+	}
+
+	bool ListFilesExtended(const string &directory, const std::function<void(OpenFileInfo &)> &callback,
+	                       optional_ptr<FileOpener> opener = nullptr) override {
+		list_count++;
+		if (fail_next_list) {
+			fail_next_list = false;
+			throw IOException("Injected orphan cleanup failure");
+		}
+		return LocalFileSystem::ListFilesExtended(directory, callback, opener);
+	}
+
+	idx_t GetListCount() const {
+		return list_count;
+	}
+
+private:
+	string path_prefix;
+	bool fail_next_list;
+	idx_t list_count = 0;
+};
+
+static string TestTempOwnerPath(FileSystem &fs, const string &directory, const string &owner_id) {
+	return fs.JoinPath(directory, string(TEST_TEMP_OWNER_PREFIX) + owner_id + TEST_TEMP_OWNER_SUFFIX);
+}
+
+static string TestTempOwnerManifest(const string &owner_id) {
+	return "DUCKDB_TEMP_OWNER\n1\n" + owner_id + "\n";
+}
+
+static string TestTempStoragePath(FileSystem &fs, const string &directory, const string &owner_id) {
+	return fs.JoinPath(directory, string(TEST_TEMP_FILE_PREFIX) + owner_id + "_storage_DEFAULT-0.tmp");
+}
+
+static string TestTempBlockPath(FileSystem &fs, const string &directory, const string &owner_id) {
+	return fs.JoinPath(directory, string(TEST_TEMP_FILE_PREFIX) + owner_id + "_block-1.block");
+}
+
+static void TestWriteFile(FileSystem &fs, const string &path, const string &contents = "dummy") {
+	auto handle = fs.OpenFile(path, FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE_NEW);
+	handle->Write(QueryContext(), const_cast<char *>(contents.data()), contents.size(), 0);
+}
+
+static duckdb::vector<string> TestGetTempOwnerIds(FileSystem &fs, const string &directory) {
+	duckdb::vector<string> result;
+	fs.ListFiles(directory, [&](const string &file_name, bool is_directory) {
+		if (is_directory || !StringUtil::StartsWith(file_name, TEST_TEMP_OWNER_PREFIX) ||
+		    !StringUtil::EndsWith(file_name, TEST_TEMP_OWNER_SUFFIX)) {
+			return;
+		}
+		auto prefix_size = strlen(TEST_TEMP_OWNER_PREFIX);
+		auto suffix_size = strlen(TEST_TEMP_OWNER_SUFFIX);
+		result.push_back(file_name.substr(prefix_size, file_name.size() - prefix_size - suffix_size));
+	});
+	return result;
+}
+
+static duckdb::vector<string> TestGetTempStorageFiles(FileSystem &fs, const string &directory,
+                                                      const string &owner_id) {
+	duckdb::vector<string> result;
+	auto prefix = string(TEST_TEMP_FILE_PREFIX) + owner_id + "_storage_";
+	fs.ListFiles(directory, [&](const string &file_name, bool is_directory) {
+		if (!is_directory && StringUtil::StartsWith(file_name, prefix) && StringUtil::EndsWith(file_name, ".tmp")) {
+			result.push_back(fs.JoinPath(directory, file_name));
+		}
+	});
+	return result;
+}
+
+static duckdb::vector<string> TestGetSpillFiles(FileSystem &fs, const string &directory) {
+	duckdb::vector<string> result;
+	fs.ListFiles(directory, [&](const string &file_name, bool is_directory) {
+		if (!is_directory && StringUtil::StartsWith(file_name, TEST_TEMP_FILE_PREFIX)) {
+			result.push_back(fs.JoinPath(directory, file_name));
+		}
+	});
+	return result;
+}
+
+static void TestSetTempDirectory(Connection &con, const string &temp_directory) {
+	auto result = con.Query("SET temp_directory='" + temp_directory + "'");
+	if (result->HasError()) {
+		result->ThrowError();
+	}
+}
+
+static duckdb::shared_ptr<BlockHandle> TestSpillLargeTemporaryBlock(BufferManager &buffer_manager, int fill_byte) {
+	auto pin = buffer_manager.Allocate(MemoryTag::EXTENSION, buffer_manager.GetBlockSize() + 1024, false);
+	memset(pin.Ptr(), fill_byte, pin.GetFileBuffer().AllocSize());
+	auto block = pin.GetBlockHandle();
+	pin.Destroy();
+
+	auto &memory = block->GetMemory();
+	auto lock = memory.GetLock();
+	memory.Unload(lock);
+	if (!memory.IsUnloaded()) {
+		throw InternalException("Expected the test temporary block to be unloaded");
+	}
+	return block;
+}
+
+static void TestAdvanceTemporaryBlockId(Connection &con) {
+	auto &buffer_manager = BufferManager::GetBufferManager(*con.context);
+	auto pin = buffer_manager.Allocate(MemoryTag::EXTENSION, buffer_manager.GetBlockSize() + 1024, true);
+	auto block = pin.GetBlockHandle();
+	pin.Destroy();
+	block.reset();
+}
+
+static void TestInitializeTempDirectory(DuckDB &db, const string &temp_directory) {
+	Connection con(db);
+	TestSetTempDirectory(con, temp_directory);
+	auto &buffer_manager = db.instance->GetBufferManager();
+	auto grouped_buffer = buffer_manager.ConstructManagedBuffer(buffer_manager.GetBlockSize(),
+	                                                            DEFAULT_BLOCK_HEADER_STORAGE_SIZE, nullptr);
+	buffer_manager.WriteTemporaryBuffer(MemoryTag::BASE_TABLE, 2, *grouped_buffer);
+	auto block_buffer = buffer_manager.ConstructManagedBuffer(buffer_manager.GetBlockAllocSize(),
+	                                                          DEFAULT_BLOCK_HEADER_STORAGE_SIZE, nullptr);
+	buffer_manager.WriteTemporaryBuffer(MemoryTag::BASE_TABLE, 1, *block_buffer);
+}
+
+struct RunningQueryTemporaryBlockState {
+	bool WaitUntilBlocked(chrono::seconds timeout) {
+		unique_lock<mutex> guard(lock);
+		return cv.wait_for(guard, timeout, [&]() { return blocked; });
+	}
+
+	void Release() {
+		lock_guard<mutex> guard(lock);
+		released = true;
+		cv.notify_all();
+	}
+
+	mutex lock;
+	condition_variable cv;
+	bool blocked = false;
+	bool released = false;
+	bool initialized = false;
+	duckdb::shared_ptr<BlockHandle> block;
+};
+
+static RunningQueryTemporaryBlockState *running_query_temp_block_state;
+
+struct RunningQueryStateGuard {
+	explicit RunningQueryStateGuard(RunningQueryTemporaryBlockState &state_p) : state(state_p) {
+		running_query_temp_block_state = &state;
+	}
+
+	~RunningQueryStateGuard() {
+		running_query_temp_block_state = nullptr;
+	}
+
+	RunningQueryTemporaryBlockState &state;
+};
+
+struct RunningQueryThreadGuard {
+	RunningQueryThreadGuard(RunningQueryTemporaryBlockState &state_p, thread &query_thread_p)
+	    : state(state_p), query_thread(query_thread_p) {
+	}
+
+	~RunningQueryThreadGuard() {
+		state.Release();
+		if (query_thread.joinable()) {
+			query_thread.join();
+		}
+		state.block.reset();
+	}
+
+	RunningQueryTemporaryBlockState &state;
+	thread &query_thread;
+};
+
+static void RunningQueryTemporaryBlockProbe(DataChunk &input, ExpressionState &state, Vector &result) {
+	result.Reference(input.data[0]);
+
+	auto probe_state = running_query_temp_block_state;
+	if (!probe_state) {
+		return;
+	}
+
+	{
+		lock_guard<mutex> guard(probe_state->lock);
+		if (probe_state->initialized) {
+			return;
+		}
+		probe_state->initialized = true;
+	}
+
+	auto &buffer_manager = BufferManager::GetBufferManager(state.GetContext());
+	auto block = TestSpillLargeTemporaryBlock(buffer_manager, 0x42);
+	{
+		unique_lock<mutex> guard(probe_state->lock);
+		probe_state->block = block;
+		probe_state->blocked = true;
+		probe_state->cv.notify_all();
+		probe_state->cv.wait(guard, [&]() { return probe_state->released; });
+	}
+
+	auto reloaded = buffer_manager.Pin(block);
+	reloaded.Destroy();
+}
+
+static void RegisterRunningQueryTemporaryBlockProbe(Connection &con) {
+	ScalarFunction function("running_query_temp_block_probe", {LogicalType::BIGINT}, LogicalType::BIGINT,
+	                        RunningQueryTemporaryBlockProbe, nullptr, nullptr, nullptr, nullptr, LogicalType::INVALID,
+	                        FunctionStability::VOLATILE);
+	CreateScalarFunctionInfo info(function);
+	con.context->RegisterFunction(info);
+}
 
 TEST_CASE("Test storing a big string that exceeds buffer manager size", "[storage][.]") {
 	duckdb::unique_ptr<MaterializedQueryResult> result;
@@ -77,6 +351,237 @@ TEST_CASE("Test storing a big string that exceeds buffer manager size", "[storag
 	}
 	DeleteDatabase(storage_database);
 }
+
+TEST_CASE("Test cleanup of orphaned temporary files", "[storage][temp_directory]") {
+	auto fs = FileSystem::CreateLocal();
+	auto temp_directory = TestCreatePath("orphaned_temp_files");
+	TestDeleteDirectory(temp_directory);
+	TestCreateDirectory(temp_directory);
+
+	const string stale_owner_id = "11111111-1111-4111-8111-111111111111";
+	const string second_stale_owner_id = "33333333-3333-4333-8333-333333333333";
+	const string invalid_owner_id = "22222222-2222-4222-8222-222222222222";
+	auto stale_owner_file = TestTempOwnerPath(*fs, temp_directory, stale_owner_id);
+	auto stale_storage_file = TestTempStoragePath(*fs, temp_directory, stale_owner_id);
+	auto stale_block_file = TestTempBlockPath(*fs, temp_directory, stale_owner_id);
+	auto second_stale_owner_file = TestTempOwnerPath(*fs, temp_directory, second_stale_owner_id);
+	auto second_stale_storage_file = TestTempStoragePath(*fs, temp_directory, second_stale_owner_id);
+	auto stale_unrecognized_file =
+	    fs->JoinPath(temp_directory, string(TEST_TEMP_FILE_PREFIX) + stale_owner_id + "_storage_DEFAULT-0.tmp.backup");
+	auto invalid_owner_file = TestTempOwnerPath(*fs, temp_directory, invalid_owner_id);
+	auto invalid_owned_file = TestTempStoragePath(*fs, temp_directory, invalid_owner_id);
+	auto legacy_storage_file = fs->JoinPath(temp_directory, "duckdb_temp_storage_orphan.tmp");
+	auto legacy_block_file = fs->JoinPath(temp_directory, "duckdb_temp_block-1.block");
+	auto unrelated_file = fs->JoinPath(temp_directory, "unrelated_file.tmp");
+	TestWriteFile(*fs, stale_owner_file, TestTempOwnerManifest(stale_owner_id));
+	TestWriteFile(*fs, second_stale_owner_file, TestTempOwnerManifest(second_stale_owner_id));
+	for (const auto &path : {stale_storage_file, stale_block_file, stale_unrecognized_file, invalid_owned_file,
+	                         second_stale_storage_file, legacy_storage_file, legacy_block_file, unrelated_file}) {
+		TestWriteFile(*fs, path);
+	}
+	TestWriteFile(*fs, invalid_owner_file, "DUCKDB_TEMP_OWNER\n2\n" + invalid_owner_id + "\n");
+
+	{
+		DuckDB db(nullptr);
+		auto cleanup_fs = make_uniq<TestCleanupFileSystem>(temp_directory);
+		auto cleanup_fs_ptr = cleanup_fs.get();
+		db.GetFileSystem().RegisterSubSystem(std::move(cleanup_fs));
+		TestInitializeTempDirectory(db, temp_directory);
+		const idx_t expected_cleanup_scans = 2;
+		REQUIRE(cleanup_fs_ptr->GetListCount() == expected_cleanup_scans);
+		REQUIRE(!fs->FileExists(stale_owner_file));
+		REQUIRE(!fs->FileExists(stale_storage_file));
+		REQUIRE(!fs->FileExists(stale_block_file));
+		REQUIRE(!fs->FileExists(second_stale_owner_file));
+		REQUIRE(!fs->FileExists(second_stale_storage_file));
+		REQUIRE(fs->FileExists(stale_unrecognized_file));
+		REQUIRE(fs->FileExists(invalid_owner_file));
+		REQUIRE(fs->FileExists(invalid_owned_file));
+		REQUIRE(fs->FileExists(legacy_storage_file));
+		REQUIRE(fs->FileExists(legacy_block_file));
+		REQUIRE(fs->FileExists(unrelated_file));
+	}
+
+	TestDeleteDirectory(temp_directory);
+}
+
+TEST_CASE("Test cleanup skips live temporary directory owners", "[storage][temp_directory]") {
+	auto fs = FileSystem::CreateLocal();
+	auto temp_directory = TestCreatePath("live_temp_file_owner");
+	TestDeleteDirectory(temp_directory);
+	TestCreateDirectory(temp_directory);
+
+	auto live_db = make_uniq<DuckDB>(nullptr);
+	TestInitializeTempDirectory(*live_db, temp_directory);
+	auto owner_ids = TestGetTempOwnerIds(*fs, temp_directory);
+	REQUIRE(owner_ids.size() == 1);
+	auto live_owner_file = TestTempOwnerPath(*fs, temp_directory, owner_ids[0]);
+	auto live_storage_files = TestGetTempStorageFiles(*fs, temp_directory, owner_ids[0]);
+	REQUIRE(live_storage_files.size() == 1);
+	auto live_storage_file = live_storage_files[0];
+	auto live_block_file = TestTempBlockPath(*fs, temp_directory, owner_ids[0]);
+	REQUIRE(fs->FileExists(live_block_file));
+
+	{
+		DuckDB cleanup_db(nullptr);
+		TestInitializeTempDirectory(cleanup_db, temp_directory);
+		REQUIRE(fs->FileExists(live_owner_file));
+		REQUIRE(fs->FileExists(live_storage_file));
+		REQUIRE(fs->FileExists(live_block_file));
+	}
+
+	REQUIRE(fs->FileExists(live_owner_file));
+	REQUIRE(fs->FileExists(live_storage_file));
+	REQUIRE(fs->FileExists(live_block_file));
+	live_db.reset();
+	REQUIRE(!fs->FileExists(live_owner_file));
+	REQUIRE(!fs->FileExists(live_storage_file));
+	REQUIRE(!fs->FileExists(live_block_file));
+
+	TestDeleteDirectory(temp_directory);
+}
+
+TEST_CASE("Test temporary files remain usable when owner locking is unavailable", "[storage][temp_directory]") {
+	auto local_fs = FileSystem::CreateLocal();
+	auto temp_directory = TestCreatePath("temp_file_owner_lock_unsupported");
+	TestDeleteDirectory(temp_directory);
+	TestCreateDirectory(temp_directory);
+
+	{
+		DuckDB db(nullptr);
+		db.GetFileSystem().RegisterSubSystem(make_uniq<TestNoLockFileSystem>(temp_directory));
+		TestInitializeTempDirectory(db, temp_directory);
+		REQUIRE(TestGetTempOwnerIds(*local_fs, temp_directory).empty());
+		REQUIRE(TestGetSpillFiles(*local_fs, temp_directory).size() == 2);
+	}
+
+	REQUIRE(TestGetTempOwnerIds(*local_fs, temp_directory).empty());
+	REQUIRE(TestGetSpillFiles(*local_fs, temp_directory).empty());
+	TestDeleteDirectory(temp_directory);
+}
+
+TEST_CASE("Test temporary files remain usable when orphan cleanup fails", "[storage][temp_directory]") {
+	auto local_fs = FileSystem::CreateLocal();
+	auto temp_directory = TestCreatePath("temp_file_cleanup_failure");
+	TestDeleteDirectory(temp_directory);
+	TestCreateDirectory(temp_directory);
+
+	{
+		DuckDB db(nullptr);
+		db.GetFileSystem().RegisterSubSystem(make_uniq<TestCleanupFileSystem>(temp_directory, true));
+		TestInitializeTempDirectory(db, temp_directory);
+		REQUIRE(TestGetTempOwnerIds(*local_fs, temp_directory).size() == 1);
+		REQUIRE(TestGetSpillFiles(*local_fs, temp_directory).size() == 2);
+	}
+
+	REQUIRE(TestGetTempOwnerIds(*local_fs, temp_directory).empty());
+	REQUIRE(TestGetSpillFiles(*local_fs, temp_directory).empty());
+	TestDeleteDirectory(temp_directory);
+}
+
+TEST_CASE("Running query keeps temporary files isolated from another DuckDB instance cleanup",
+          "[storage][temp_directory]") {
+	auto temp_directory = TestCreatePath("running_query_shared_temp_directory");
+	TestDeleteDirectory(temp_directory);
+	TestCreateDirectory(temp_directory);
+
+	{
+		RunningQueryTemporaryBlockState probe_state;
+		RunningQueryStateGuard state_guard(probe_state);
+
+		DuckDB db_a(nullptr);
+		Connection con_a(db_a);
+		TestSetTempDirectory(con_a, temp_directory);
+		RegisterRunningQueryTemporaryBlockProbe(con_a);
+
+		duckdb::unique_ptr<QueryResult> result;
+		thread query_thread(
+		    [&]() { result = con_a.Query("SELECT running_query_temp_block_probe(i) FROM range(1) t(i)"); });
+		RunningQueryThreadGuard query_guard(probe_state, query_thread);
+
+		if (!probe_state.WaitUntilBlocked(chrono::seconds(10))) {
+			FAIL("Timed out waiting for the running query to spill its temporary block");
+		}
+
+		{
+			DuckDB db_b(nullptr);
+			Connection con_b(db_b);
+			TestSetTempDirectory(con_b, temp_directory);
+			// Keep B's spilled file at a different name so this exercises directory cleanup, not same-name removal.
+			TestAdvanceTemporaryBlockId(con_b);
+			auto &buffer_manager = BufferManager::GetBufferManager(*con_b.context);
+			auto block_b = TestSpillLargeTemporaryBlock(buffer_manager, 0x5A);
+			block_b.reset();
+		}
+
+		probe_state.Release();
+		query_thread.join();
+
+		REQUIRE(result);
+		REQUIRE(NO_FAIL(*result));
+		REQUIRE(CHECK_COLUMN(result, 0, {Value::BIGINT(0)}));
+	}
+
+	TestDeleteDirectory(temp_directory);
+}
+
+#if !defined(_WIN32) && !defined(WIN32)
+TEST_CASE("Test cleanup skips temporary directory owners locked by another process",
+          "[storage][temp_directory][.]") {
+	auto fs = FileSystem::CreateLocal();
+	auto temp_directory = TestCreatePath("live_temp_file_owner_process");
+	TestDeleteDirectory(temp_directory);
+	TestCreateDirectory(temp_directory);
+
+	const string owner_id = "44444444-4444-4444-8444-444444444444";
+	auto owner_file = TestTempOwnerPath(*fs, temp_directory, owner_id);
+	auto storage_file = TestTempStoragePath(*fs, temp_directory, owner_id);
+	auto owner_flags = FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_WRITE |
+	                   FileFlags::FILE_FLAGS_FILE_CREATE_NEW | FileFlags::FILE_FLAGS_EXCLUSIVE_CREATE |
+	                   FileLockType::WRITE_LOCK;
+	auto owner_handle = fs->OpenFile(owner_file, owner_flags);
+	auto manifest = TestTempOwnerManifest(owner_id);
+	owner_handle->Write(QueryContext(), &manifest[0], manifest.size(), 0);
+	fs->FileSync(*owner_handle);
+	TestWriteFile(*fs, storage_file);
+
+	auto pid = fork();
+	REQUIRE(pid >= 0);
+	if (pid == 0) {
+		int exit_code = 0;
+		try {
+			{
+				DuckDB cleanup_db(nullptr);
+				TestInitializeTempDirectory(cleanup_db, temp_directory);
+				auto child_fs = FileSystem::CreateLocal();
+				if (!child_fs->FileExists(owner_file) || !child_fs->FileExists(storage_file)) {
+					exit_code = 1;
+				}
+			}
+		} catch (...) {
+			exit_code = 2;
+		}
+		_exit(exit_code);
+	}
+
+	int child_status = 0;
+	REQUIRE(waitpid(pid, &child_status, 0) == pid);
+	REQUIRE(WIFEXITED(child_status));
+	REQUIRE(WEXITSTATUS(child_status) == 0);
+	REQUIRE(fs->FileExists(owner_file));
+	REQUIRE(fs->FileExists(storage_file));
+
+	owner_handle.reset();
+	{
+		DuckDB cleanup_db(nullptr);
+		TestInitializeTempDirectory(cleanup_db, temp_directory);
+	}
+	REQUIRE(!fs->FileExists(owner_file));
+	REQUIRE(!fs->FileExists(storage_file));
+
+	TestDeleteDirectory(temp_directory);
+}
+#endif
 
 TEST_CASE("Modifying the buffer manager limit at runtime for an in-memory database", "[storage][.]") {
 	duckdb::unique_ptr<MaterializedQueryResult> result;


### PR DESCRIPTION
**Problem**
DuckDB allows multiple instances to share one temp_directory, but temporary files are not isolated per
 instance. This causes two problems:

-  A running query can fail when another instance sharing the same temp_directory is destroyed. TemporaryDirectoryHandle currently scans the directory on destruction and deletes every file with the
duckdb_temp_ prefix, without knowing which instance owns it. As a result, instance B can delete spill
files still being used by instance A.

- Crashed instances bypass destructor cleanup and leave orphaned temporary files behind (#24576).


**Fix**
The fix isolates temporary files per instance, cleans an instance’s own files on shutdown, and reclaims
 files belonging to confirmed dead owners on startup.

1. Isolate temporary files by UUID

Each instance generates a UUID and includes it in every temporary filename, using names such as
 duckdb_temp_v1__....
The same UUID is recorded in an owner file named duckdb_temp_owner_v1_.lock. The instance keeps
  this file under an exclusive write lock for its lifetime. On POSIX systems this uses fcntl; an in-
  process registry handles multiple instances in the same process, where fcntl locks alone cannot
  distinguish instances.
When an instance is destroyed, it only removes temporary files containing its own UUID.

2. Clean up dead owners on startup

On startup, an instance scans the owner files and attempts to acquire an exclusive write lock on each
 one.
If the lock is acquired and the owner file is valid, no active process owns that UUID. Its temporary
 files are therefore considered orphaned and are removed together with the owner file.
If the owner is active, or its state cannot be safely determined, cleanup skips it. Cleanup failures do
 not prevent temporary files from being used.