### PR TITLE
Fix ASOF join over EXCEPT ALL / INTERSECT ALL children

### DIFF
--- a/src/execution/physical_plan/plan_asof_join.cpp
+++ b/src/execution/physical_plan/plan_asof_join.cpp
@@ -59,8 +59,12 @@ PhysicalPlanGenerator::PlanAsOfLoopJoin(LogicalComparisonJoin &op, PhysicalOpera
 
 	LogicalComparisonJoin join_op(InverseJoinType(op.join_type));
 
-	join_op.types = op.children[1]->types;
-	const auto &probe_types = op.children[0]->types;
+	// Use the types of the planned children: planning a child can change the types of the logical operator
+	// (EXCEPT ALL/INTERSECT ALL append a ROW_NUMBER column to it)
+	const auto &probe_types = probe.GetTypes();
+	const auto &build_types = build.GetTypes();
+
+	join_op.types = build_types;
 	join_op.types.insert(join_op.types.end(), probe_types.begin(), probe_types.end());
 
 	// Project pk
@@ -72,14 +76,14 @@ PhysicalPlanGenerator::PlanAsOfLoopJoin(LogicalComparisonJoin &op, PhysicalOpera
 	//	we have to track this carefully...
 	join_op.left_projection_map = op.right_projection_map;
 	if (join_op.left_projection_map.empty()) {
-		for (idx_t i = 0; i < op.children[1]->types.size(); ++i) {
+		for (idx_t i = 0; i < build_types.size(); ++i) {
 			join_op.left_projection_map.emplace_back(i);
 		}
 	}
 
 	join_op.right_projection_map = op.left_projection_map;
 	if (join_op.right_projection_map.empty()) {
-		for (idx_t i = 0; i < op.children[0]->types.size(); ++i) {
+		for (idx_t i = 0; i < probe_types.size(); ++i) {
 			join_op.right_projection_map.emplace_back(i);
 		}
 	}
@@ -87,8 +91,8 @@ PhysicalPlanGenerator::PlanAsOfLoopJoin(LogicalComparisonJoin &op, PhysicalOpera
 	// Remap predicate column references.
 	auto predicate = CreatePredicateFromConditions(op.conditions);
 	if (predicate) {
-		const auto lhs_width = op.children[0]->types.size();
-		const auto rhs_width = op.children[1]->types.size();
+		const auto lhs_width = probe_types.size();
+		const auto rhs_width = build_types.size();
 
 		ExpressionIterator::EnumerateExpression(predicate, [&](Expression &child) {
 			if (child.GetExpressionClass() == ExpressionClass::BOUND_REF) {
@@ -191,7 +195,7 @@ PhysicalPlanGenerator::PlanAsOfLoopJoin(LogicalComparisonJoin &op, PhysicalOpera
 	// Wrap all the projected non-pk probe fields in `first` aggregates;
 	vector<unique_ptr<Expression>> aggregates;
 	for (const auto &right_proj : join_op.right_projection_map) {
-		const auto col_idx = op.children[1]->types.size() + right_proj;
+		const auto col_idx = build_types.size() + right_proj;
 		const auto col_type = join_op.types[col_idx];
 		aggr_types.emplace_back(col_type);
 
@@ -403,7 +407,8 @@ PhysicalOperator &PhysicalPlanGenerator::PlanAsOfJoin(LogicalComparisonJoin &op)
 	vector<unique_ptr<Expression>> window_select;
 	window_select.emplace_back(std::move(asof_end));
 
-	auto &window_types = op.children[1]->types;
+	// Copy the types of the planned child instead of mutating the logical operator's types.
+	auto window_types = right.GetTypes();
 	window_types.emplace_back(asof_type);
 
 	auto &window = Make<PhysicalWindow>(window_types, std::move(window_select), rhs_cardinality);

--- a/src/execution/physical_plan/plan_set_operation.cpp
+++ b/src/execution/physical_plan/plan_set_operation.cpp
@@ -100,6 +100,10 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalSetOperation &op) {
 
 		// For EXCEPT ALL / INTERSECT ALL we need to remove the row number column again
 		if (op.setop_all) {
+			// Restore the logical operator's types: the ROW_NUMBER column is an implementation detail of the physical
+			// plan.
+			op.types.pop_back();
+
 			vector<unique_ptr<Expression>> select_list;
 			for (idx_t i = 0; i < types.size(); i++) {
 				select_list.push_back(make_uniq<BoundReferenceExpression>(types[i], i));

--- a/test/sql/join/asof/test_asof_join_setops.test
+++ b/test/sql/join/asof/test_asof_join_setops.test
@@ -1,0 +1,94 @@
+# name: test/sql/join/asof/test_asof_join_setops.test
+# description: Test AsOf joins whose children are EXCEPT ALL / INTERSECT ALL (internal issue #24672)
+# group: [asof]
+
+statement ok
+CREATE TABLE a(d INTEGER);
+
+statement ok
+INSERT INTO a VALUES (1), (2);
+
+statement ok
+CREATE TABLE b(d INTEGER);
+
+statement ok
+CREATE TABLE r AS SELECT * FROM a;
+
+# Compare the NLJ optimisation to the AsOf operator
+foreach threshold 0 32
+
+statement ok
+PRAGMA asof_loop_join_threshold = {threshold};
+
+# EXCEPT ALL / INTERSECT ALL append a ROW_NUMBER column during physical planning. That column must not leak into the types of the AsOf join's children.
+
+# Set operation on the probe (LHS) side
+query II
+SELECT * FROM (SELECT * FROM a EXCEPT ALL SELECT * FROM b) t0
+ASOF LEFT JOIN r t1 ON t0.d >= t1.d
+ORDER BY ALL;
+----
+1	1
+2	2
+
+query II
+SELECT * FROM (SELECT * FROM a INTERSECT ALL SELECT * FROM a) t0
+ASOF LEFT JOIN r t1 ON t0.d >= t1.d
+ORDER BY ALL;
+----
+1	1
+2	2
+
+# Set operation on the build (RHS) side
+query II
+SELECT * FROM r t1
+ASOF LEFT JOIN (SELECT * FROM a EXCEPT ALL SELECT * FROM b) t0 ON t1.d >= t0.d
+ORDER BY ALL;
+----
+1	1
+2	2
+
+query II
+SELECT * FROM r t1
+ASOF LEFT JOIN (SELECT * FROM a INTERSECT ALL SELECT * FROM a) t0 ON t1.d >= t0.d
+ORDER BY ALL;
+----
+1	1
+2	2
+
+# Set operations on both sides
+query II
+SELECT * FROM (SELECT * FROM a EXCEPT ALL SELECT * FROM b) t0
+ASOF LEFT JOIN (SELECT * FROM a INTERSECT ALL SELECT * FROM a) t1 ON t0.d >= t1.d
+ORDER BY ALL;
+----
+1	1
+2	2
+
+# INNER AsOf join
+query II
+SELECT * FROM (SELECT * FROM a EXCEPT ALL SELECT * FROM b) t0
+ASOF JOIN r t1 ON t0.d >= t1.d
+ORDER BY ALL;
+----
+1	1
+2	2
+
+# Non-comparison predicate forces the NLJ path
+query II
+SELECT * FROM (SELECT * FROM a EXCEPT ALL SELECT * FROM b) t0
+ASOF LEFT JOIN r t1 ON t0.d >= t1.d AND (t0.d + t1.d) > 1
+ORDER BY ALL;
+----
+1	1
+2	2
+
+# EXCEPT ALL that actually removes rows
+query II
+SELECT * FROM (SELECT * FROM a EXCEPT ALL SELECT 1) t0
+ASOF LEFT JOIN r t1 ON t0.d >= t1.d
+ORDER BY ALL;
+----
+2	2
+
+endloop


### PR DESCRIPTION
Fixes #24672.

### Problem

`ASOF JOIN` fails with an internal error when one of its children is `EXCEPT ALL` / `INTERSECT ALL`:

```sql
CREATE TABLE a(d INTEGER); INSERT INTO a VALUES (1), (2);
CREATE TABLE b(d INTEGER);
CREATE TABLE r AS SELECT * FROM a;

SELECT * FROM (SELECT * FROM a EXCEPT ALL SELECT * FROM b) t0
ASOF LEFT JOIN r t1 ON t0.d >= t1.d;
-- INTERNAL Error: ExpressionExecutor::Execute called with a result vector of
--                 type INTEGER that does not match expression type BIGINT
-- (assertion build: expressions.size() == result.ColumnCount())
```

It also reproduces with the set operation on the build side, with a different symptom:

```sql
SELECT * FROM r t1
ASOF LEFT JOIN (SELECT * FROM a EXCEPT ALL SELECT * FROM b) t0 ON t1.d >= t0.d;
-- INTERNAL Error: Vector::Reference used on vector of different type
--                 (source BIGINT referenced INTEGER)
```

### Root cause

`EXCEPT ALL` / `INTERSECT ALL` get bag semantics from a `ROW_NUMBER` column added during physical planning. To make the ANTI/SEMI `PhysicalHashJoin` emit that column, `CreatePlan(LogicalSetOperation &)` appends a `BIGINT` to `op.types` and never restores it:

https://github.com/duckdb/duckdb/blob/c6f7f3e2502c0a5141f339cb208ba21f770d6661/src/execution/physical_plan/plan_set_operation.cpp#L92

The physical plan still ends in a projection that strips the column, so from that point on the `LogicalSetOperation`'s types no longer match the physical operator it was planned into.

`PlanAsOfLoopJoin()` then reads the **logical** children's types *after* they have been planned:

```cpp
auto &left  = CreatePlan(*op.children[0]);   // <- mutates children[0]->types
auto &right = CreatePlan(*op.children[1]);
...
join_op.types = op.children[1]->types;
const auto &probe_types = op.children[0]->types;   // one column too wide
```

Everything downstream shifts by one column: `join_op.types` declares 4 columns for a 3-column NLJ, `right_projection_map` gains a phantom entry, an extra `first(<row_number>)` aggregate is bound, and the final `PhysicalProjection` ends up with 3 expressions writing into a 2-column output chunk.

This is confined to the NLJ optimisation path: `SET asof_loop_join_threshold = 0` avoids it, and `EXCEPT` without `ALL` is fine because it never appends the column. Both match the workarounds reported in the issue.

### Fix

- `plan_asof_join.cpp`: `PlanAsOfLoopJoin()` builds operators on top of the planned children, so use `probe.GetTypes()` / `build.GetTypes()` instead of `op.children[i]->types`. The `debug_asof_iejoin` path had the same pattern (it held a reference to `op.children[1]->types` and appended to it in place), it now copies.
- `plan_set_operation.cpp`: restore `op.types` after the hash join has copied them, so the ROW_NUMBER column stays an implementation detail of the physical plan.

Either change alone fixes the issue. I kept both. The first makes ASOF planning robust against logical/physical type mismatches, the second removes the mismatch at its source.

### Tests

New `test/sql/join/asof/test_asof_join_setops.test`, run at `asof_loop_join_threshold` 0 and 32 so both the `PhysicalAsOfJoin` and the NLJ paths are covered: set operation on the probe side, on the build side, on both sides, `ASOF JOIN` as well as `ASOF LEFT JOIN`, with a non-comparison predicate, and a case where `EXCEPT ALL` actually removes rows so results are checked rather than just the absence of a crash.