### PR TITLE
Use IO exception for invalid variant input

### DIFF
--- a/extension/parquet/reader/variant/parquet_variant_iterator.cpp
+++ b/extension/parquet/reader/variant/parquet_variant_iterator.cpp
@@ -521,7 +521,7 @@ string_t ParquetVariantNode::GetString() const {
 			return str;
 		}
 		if (!Utf8Proc::IsValid(str.GetData(), str.GetSize())) {
-			throw InternalException("Can't decode Variant string, it isn't valid UTF8");
+			throw IOException("Can't decode Variant string, it isn't valid UTF8");
 		}
 		return str;
 	}
@@ -532,7 +532,7 @@ string_t ParquetVariantNode::GetString() const {
 		auto string_data = const_char_ptr_cast(payload);
 		CheckBinaryRead(payload, value_metadata.string_size, binary_end);
 		if (!Utf8Proc::IsValid(string_data, value_metadata.string_size)) {
-			throw InternalException("Can't decode Variant short-string, string isn't valid UTF8");
+			throw IOException("Can't decode Variant short-string, string isn't valid UTF8");
 		}
 		return string_t(string_data, value_metadata.string_size);
 	}
@@ -544,7 +544,7 @@ string_t ParquetVariantNode::GetString() const {
 		return string_t(string_data, size);
 	}
 	if (!Utf8Proc::IsValid(string_data, size)) {
-		throw InternalException("Can't decode Variant string, it isn't valid UTF8");
+		throw IOException("Can't decode Variant string, it isn't valid UTF8");
 	}
 	return string_t(string_data, size);
 }

--- a/test/parquet/variant/variant_malicious.test
+++ b/test/parquet/variant/variant_malicious.test
@@ -12,3 +12,9 @@ statement error
 SELECT variant_bytes_to_variant('\x01\x02\xC8\x05\x0A\x00\x00\x00\x00\x00'::BLOB);
 ----
 IO Error: Corrupted VARIANT 'metadata' buffer, the next dictionary offset is smaller than the last offset
+
+# Invalid UTF-8 in a short string is corrupted input, not an internal error
+statement error
+SELECT variant_bytes_to_variant('\x01\x00\x00\x05\xFF'::BLOB);
+----
+IO Error: Can't decode Variant short-string, string isn't valid UTF8


### PR DESCRIPTION
Closes https://github.com/duckdb/duckdb/issues/24762

In the latest v1.5.5 release, we actually use `IOException`
```sql
DuckDB v1.5.5 (Variegata)
Enter ".help" for usage hints.
memory D SELECT variant_bytes_to_variant('\x01\x00\x00\x05\xFF'::BLOB);
IO Error:
Can't decode Variant short-string, string isn't valid UTF8
```