### PR TITLE
Fix incorrect SEMI/ANTI join results with residual predicates

### DIFF
--- a/src/execution/operator/join/physical_nested_loop_join.cpp
+++ b/src/execution/operator/join/physical_nested_loop_join.cpp
@@ -339,6 +339,10 @@ public:
 		left_outer.Initialize(STANDARD_VECTOR_SIZE);
 
 		if (op.predicate) {
+			auto predicate_types = op.children[0].get().GetTypes();
+			auto &right_types = op.children[1].get().GetTypes();
+			predicate_types.insert(predicate_types.end(), right_types.begin(), right_types.end());
+			predicate_chunk.Initialize(allocator, predicate_types);
 			pred_executor.AddExpression(*op.predicate);
 			pred_matches.Initialize();
 		}
@@ -364,6 +368,7 @@ public:
 	//! Predicate
 	ExpressionExecutor pred_executor;
 	SelectionVector pred_matches;
+	DataChunk predicate_chunk;
 
 private:
 	void ResetState() {
@@ -378,6 +383,7 @@ private:
 		left_tuple = 0;
 		right_tuple = 0;
 		left_outer.Reset();
+		predicate_chunk.Reset();
 	}
 
 public:
@@ -443,8 +449,45 @@ void PhysicalNestedLoopJoin::ResolveSimpleJoin(ExecutionContext &context, DataCh
 	bool found_unknown[STANDARD_VECTOR_SIZE] = {false};
 	const bool track_unknown = join_type == JoinType::MARK && conditions.size() == 1 &&
 	                           conditions[0].GetLHS().GetReturnType().id() == LogicalTypeId::TUPLE;
-	NestedLoopJoinMark::Perform(state.left_condition, gstate.right_condition_data, found_match, conditions,
-	                            track_unknown ? optional_ptr<bool>(found_unknown) : nullptr);
+
+	if (!predicate || join_type == JoinType::MARK) {
+		NestedLoopJoinMark::Perform(state.left_condition, gstate.right_condition_data, found_match, conditions,
+		                            track_unknown ? optional_ptr<bool>(found_unknown) : nullptr);
+	} else {
+		D_ASSERT(join_type == JoinType::SEMI || join_type == JoinType::ANTI);
+		gstate.right_condition_data.InitializeScan(state.condition_scan_state);
+		gstate.right_payload_data.InitializeScan(state.payload_scan_state);
+		while (gstate.right_condition_data.Scan(state.condition_scan_state, state.right_condition)) {
+			if (!gstate.right_payload_data.Scan(state.payload_scan_state, state.right_payload) ||
+			    state.right_condition.size() != state.right_payload.size()) {
+				throw InternalException("Nested loop join: payload and conditions are unaligned!?");
+			}
+
+			state.left_tuple = 0;
+			state.right_tuple = 0;
+			while (state.right_tuple < state.right_condition.size()) {
+				SelectionVector lvector(STANDARD_VECTOR_SIZE), rvector(STANDARD_VECTOR_SIZE);
+				auto match_count =
+				    NestedLoopJoinInner::Perform(state.left_tuple, state.right_tuple, state.left_condition,
+				                                 state.right_condition, lvector, rvector, conditions);
+				if (match_count == 0) {
+					continue;
+				}
+
+				state.predicate_chunk.Reset();
+				state.predicate_chunk.Slice(input, lvector, match_count);
+				state.predicate_chunk.Slice(state.right_payload, rvector, match_count, input.ColumnCount());
+
+				auto predicate_count = state.pred_executor.SelectExpression(state.predicate_chunk, state.pred_matches);
+				for (idx_t i = 0; i < predicate_count; i++) {
+					auto candidate_index = state.pred_matches.get_index(i);
+					auto left_index = lvector.get_index(candidate_index);
+					found_match[left_index] = true;
+				}
+			}
+		}
+	}
+
 	switch (join_type) {
 	case JoinType::MARK:
 		// now construct the mark join result from the found matches

--- a/test/issues/general/test_24623.test
+++ b/test/issues/general/test_24623.test
@@ -1,0 +1,18 @@
+# name: test/issues/general/test_24623.test
+# description: Preserve unmatched rows when simplifying an outer join
+# group: [general]
+
+statement ok
+CREATE TABLE issue_24623(c1 BOOLEAN, c2 BOOLEAN);
+
+statement ok
+INSERT INTO issue_24623 VALUES (false, true);
+
+query I
+SELECT issue_24623.c1
+FROM issue_24623
+RIGHT JOIN (SELECT NOT c2 AS col0 FROM issue_24623) sub0
+ON sub0.col0 BETWEEN true AND issue_24623.c1
+WHERE issue_24623.c1 IS NULL;
+----
+NULL

--- a/test/sql/join/semianti/nested_loop_join_residual.test
+++ b/test/sql/join/semianti/nested_loop_join_residual.test
@@ -1,0 +1,55 @@
+# name: test/sql/join/semianti/nested_loop_join_residual.test
+# description: Test residual predicates in nested loop semi and anti joins
+# group: [semianti]
+
+statement ok
+SET profiling_renderer_settings = MAP {'operator_casing': 'upper'};
+
+statement ok
+PRAGMA explain_output = 'PHYSICAL_ONLY';
+
+statement ok
+CREATE TABLE nl_left(x INTEGER, v INTEGER);
+
+statement ok
+INSERT INTO nl_left VALUES (1, 1), (2, 2), (3, 3), (5, 5);
+
+statement ok
+CREATE TABLE nl_right(y INTEGER, v INTEGER);
+
+statement ok
+INSERT INTO nl_right VALUES (1, 2), (2, 2), (4, 4);
+
+query II
+EXPLAIN SELECT * FROM nl_left SEMI JOIN nl_right ON nl_left.x <= nl_right.y AND nl_left.x + nl_right.v = 3;
+----
+physical_plan	<REGEX>:.*NESTED_LOOP_JOIN.*
+
+query II rowsort
+SELECT * FROM nl_left SEMI JOIN nl_right ON nl_left.x <= nl_right.y AND nl_left.x + nl_right.v = 3;
+----
+1	1
+
+query II rowsort
+SELECT * FROM nl_left ANTI JOIN nl_right ON nl_left.x <= nl_right.y AND nl_left.x + nl_right.v = 3;
+----
+2	2
+3	3
+5	5
+
+# Scan more than one right-hand chunk and find the match in the final chunk
+statement ok
+CREATE TABLE nl_large_left AS SELECT i::INTEGER AS x FROM range(2) t(i);
+
+statement ok
+CREATE TABLE nl_large_right AS
+SELECT i::INTEGER AS y FROM range(current_setting('standard_vector_size')::BIGINT + 2) t(i);
+
+query I rowsort
+SELECT * FROM nl_large_left
+SEMI JOIN nl_large_right
+ON nl_large_left.x <= nl_large_right.y
+AND nl_large_left.x + nl_large_right.y = current_setting('standard_vector_size')::BIGINT + 1;
+----
+0
+1


### PR DESCRIPTION
Fixes #24623

When a join with a residual predicate is planned as a nested loop SEMI or ANTI join, the residual predicate is not evaluated, which can produce incorrect results.

**Fix**

Evaluate the residual predicate as part of match determination for nested loop SEMI and ANTI joins.

Falling back to `PhysicalBlockwiseNLJoin` would also fix the issue, similar to the fallback used for multiple comparison conditions in [#10190](https://github.com/duckdb/duckdb/pull/10190). However, residual predicates can coexist with a usable comparison condition, which can still be used to narrow down candidate pairs. This patch therefore uses `NestedLoopJoinInner::Perform` and evaluates the residual predicate on those candidates. This keeps comparison-based candidate pruning, but does not attempt to preserve the per-LHS early-out behavior of NestedLoopJoinMark. That optimization is left out of scope for this correctness fix

Extending `NestedLoopJoinMark::Perform` was also considered, but MARK joins need to preserve comparison-UNKNOWN pairs and evaluate the residual predicate for them as well. SEMI/ANTI joins do not need this extra work, since an UNKNOWN comparison can never make the full join condition TRUE. MARK residual support is therefore left out of scope for this targeted fix.

**Testing**

- Added direct regression coverage for nested loop `SEMI` and `ANTI` joins with residual predicates.
- Added a multi-chunk RHS case where matching rows occur only after the first vector boundary, verifying that condition and payload scans remain aligned across chunks.
- Added the original query from #24623 as a separate result-based regression test without depending on a specific optimizer rewrite or physical plan.