### PR TITLE
Prune segment for nested types on validity check

### DIFF
--- a/src/include/duckdb/storage/table/column_data.hpp
+++ b/src/include/duckdb/storage/table/column_data.hpp
@@ -258,6 +258,11 @@ protected:
 
 	idx_t GetVectorCount(idx_t vector_index) const;
 
+	static bool IsDirectNullCheckFilter(const TableFilter &filter);
+	FilterPropagateResult CheckValidityZonemap(ColumnScanState &state, TableFilter &filter,
+	                                           optional_ptr<SegmentNode<ColumnSegment>> &checked_segment,
+	                                           ColumnData &validity_column);
+
 private:
 	void UpdateCompressionFunction(SegmentLock &l, const CompressionFunction &function);
 

--- a/src/include/duckdb/storage/table/validity_column_data.hpp
+++ b/src/include/duckdb/storage/table/validity_column_data.hpp
@@ -22,8 +22,6 @@ public:
 	                   optional_ptr<ColumnData> parent);
 
 public:
-	FilterPropagateResult CheckZonemap(ColumnScanState &state, TableFilter &filter,
-	                                   optional_ptr<SegmentNode<ColumnSegment>> &checked_segment) override;
 	void AppendData(ColumnAppendState &state, UnifiedVectorFormat &vdata, idx_t count) override;
 	unique_ptr<ColumnCheckpointState> CreateCheckpointState(const RowGroup &row_group,
 	                                                        PartialBlockManager &partial_block_manager) override;

--- a/src/storage/table/array_column_data.cpp
+++ b/src/storage/table/array_column_data.cpp
@@ -29,10 +29,7 @@ void ArrayColumnData::SetDataType(ColumnDataType data_type) {
 
 FilterPropagateResult ArrayColumnData::CheckZonemap(ColumnScanState &state, TableFilter &filter,
                                                     optional_ptr<SegmentNode<ColumnSegment>> &checked_segment) {
-	// FIXME: There is nothing preventing us from supporting this, but it's not implemented yet.
-	// table filters are not supported yet for fixed size list columns
-	checked_segment = nullptr;
-	return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	return CheckValidityZonemap(state, filter, checked_segment, *validity);
 }
 
 void ArrayColumnData::InitializePrefetch(PrefetchState &prefetch_state, ColumnScanState &scan_state, idx_t rows) {

--- a/src/storage/table/column_data.cpp
+++ b/src/storage/table/column_data.cpp
@@ -33,7 +33,7 @@
 
 namespace duckdb {
 
-static bool IsDirectNullCheckFilter(const TableFilter &filter) {
+bool ColumnData::IsDirectNullCheckFilter(const TableFilter &filter) {
 	auto &expr = ExpressionFilter::GetExpressionFilter(filter, "ColumnData::IsDirectNullCheckFilter").expr;
 	if (expr->GetExpressionClass() != ExpressionClass::BOUND_OPERATOR) {
 		return false;
@@ -45,6 +45,16 @@ static bool IsDirectNullCheckFilter(const TableFilter &filter) {
 		return false;
 	}
 	return op.GetChildren()[0]->GetExpressionClass() == ExpressionClass::BOUND_REF;
+}
+
+FilterPropagateResult ColumnData::CheckValidityZonemap(ColumnScanState &state, TableFilter &filter,
+                                                       optional_ptr<SegmentNode<ColumnSegment>> &checked_segment,
+                                                       ColumnData &validity_column) {
+	if (!IsDirectNullCheckFilter(filter) || state.child_states.empty()) {
+		checked_segment = nullptr;
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+	return validity_column.CheckZonemap(state.child_states[0], filter, checked_segment);
 }
 
 ColumnData::ColumnData(BlockManager &block_manager, DataTableInfo &info, idx_t column_index, LogicalType type_p,

--- a/src/storage/table/list_column_data.cpp
+++ b/src/storage/table/list_column_data.cpp
@@ -29,9 +29,7 @@ void ListColumnData::SetDataType(ColumnDataType data_type) {
 
 FilterPropagateResult ListColumnData::CheckZonemap(ColumnScanState &state, TableFilter &filter,
                                                    optional_ptr<SegmentNode<ColumnSegment>> &checked_segment) {
-	// table filters are not supported yet for list columns
-	checked_segment = nullptr;
-	return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	return CheckValidityZonemap(state, filter, checked_segment, *validity);
 }
 
 void ListColumnData::InitializePrefetch(PrefetchState &prefetch_state, ColumnScanState &scan_state, idx_t rows) {

--- a/src/storage/table/struct_column_data.cpp
+++ b/src/storage/table/struct_column_data.cpp
@@ -50,13 +50,16 @@ idx_t StructColumnData::GetMaxEntry() {
 
 FilterPropagateResult StructColumnData::CheckZonemap(ColumnScanState &state, TableFilter &filter,
                                                      optional_ptr<SegmentNode<ColumnSegment>> &checked_segment) {
-	if (!state.storage_index.IsPushdownExtract() || state.expression_state) {
+	if (state.expression_state) {
 		checked_segment = nullptr;
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 	}
-	auto children = GetStructChildren(state);
-	D_ASSERT(children.size() == 1);
-	return children[0].col.CheckZonemap(children[0].state, filter, checked_segment);
+	if (state.storage_index.IsPushdownExtract()) {
+		auto children = GetStructChildren(state);
+		D_ASSERT(children.size() == 1);
+		return children[0].col.CheckZonemap(children[0].state, filter, checked_segment);
+	}
+	return CheckValidityZonemap(state, filter, checked_segment, *validity);
 }
 
 vector<StructColumnData::StructColumnDataChild> StructColumnData::GetStructChildren(ColumnScanState &state) const {

--- a/src/storage/table/validity_column_data.cpp
+++ b/src/storage/table/validity_column_data.cpp
@@ -14,12 +14,6 @@ ValidityColumnData::ValidityColumnData(BlockManager &block_manager, DataTableInf
     : ValidityColumnData(block_manager, info, column_index, parent.GetDataType(), parent) {
 }
 
-FilterPropagateResult ValidityColumnData::CheckZonemap(ColumnScanState &state, TableFilter &filter,
-                                                       optional_ptr<SegmentNode<ColumnSegment>> &checked_segment) {
-	checked_segment = nullptr;
-	return FilterPropagateResult::NO_PRUNING_POSSIBLE;
-}
-
 void ValidityColumnData::UpdateWithBase(TransactionData transaction, DuckTableEntry &table_entry, idx_t column_index,
                                         Vector &update_vector, row_t *row_ids, idx_t update_count, ColumnData &base,
                                         idx_t row_group_start) {

--- a/test/configs/compressed_in_memory.json
+++ b/test/configs/compressed_in_memory.json
@@ -27,6 +27,12 @@
         "test/sql/index/art/vacuum/test_art_vacuum_strings.test_slow",
         "test/sql/index/art/memory/test_art_varchar.test_slow"
       ]
+    },
+    {
+      "reason": "Compression packs validity into one segment, so zonemap pruning cannot skip rows.",
+      "paths": [
+        "test/sql/optimizer/nested_null_segment_pruning.test"
+      ]
     }
   ]
 }

--- a/test/configs/disable_optimizer.json
+++ b/test/configs/disable_optimizer.json
@@ -13,6 +13,7 @@
     {
       "reason": "Zone map pruning requires filter pushdown from optimizer.",
       "paths": [
+        "test/sql/optimizer/nested_null_segment_pruning.test",
         "test/sql/optimizer/struct_segment_pruning.test",
         "test/sql/pragma/profiling/test_custom_profiling_row_group_metrics_local_storage.test",
         "test/sql/types/geo/geometry_parquet_pushdown.test",

--- a/test/configs/encryption.json
+++ b/test/configs/encryption.json
@@ -97,6 +97,12 @@
       "paths": [
         "test/fuzzer/duckfuzz/vector_type.test"
       ]
+    },
+    {
+      "reason": "Encrypted persistent storage packs validity into one segment, so zonemap pruning cannot skip rows.",
+      "paths": [
+        "test/sql/optimizer/nested_null_segment_pruning.test"
+      ]
     }
   ]
 }

--- a/test/configs/no_local_filesystem.json
+++ b/test/configs/no_local_filesystem.json
@@ -29,6 +29,12 @@
       "paths": [
         "test/sql/json/test_json_copy_serialize_plan.test"
       ]
+    },
+    {
+      "reason": "Writes and reads a local profiling JSON file.",
+      "paths": [
+        "test/sql/optimizer/nested_null_segment_pruning.test"
+      ]
     }
   ]
 }

--- a/test/sql/optimizer/nested_null_segment_pruning.test
+++ b/test/sql/optimizer/nested_null_segment_pruning.test
@@ -1,0 +1,86 @@
+# name: test/sql/optimizer/nested_null_segment_pruning.test
+# description: Segment pruning for IS NULL on STRUCT/LIST/ARRAY columns
+# group: [optimizer]
+
+require json
+
+require no_force_storage
+
+require vector_size 2048
+
+statement ok
+SET initial_column_segment_size = 2048
+
+statement ok
+SET wal_autocheckpoint = '1TB'
+
+statement ok
+CREATE TABLE nested_nulls AS
+SELECT CASE WHEN i >= 99999 THEN NULL ELSE {'v': i} END AS s,
+       CASE WHEN i >= 99999 THEN NULL ELSE [i] END AS l
+FROM range(100000) t(i)
+
+statement ok
+CREATE TABLE array_nulls AS
+SELECT [i, i, i]::INTEGER[3] AS a
+FROM range(99999) t(i)
+
+statement ok
+INSERT INTO array_nulls VALUES (NULL)
+
+statement ok
+PRAGMA enable_profiling = 'json'
+
+statement ok
+PRAGMA profiling_output = '{TEST_DIR}/nested_null_profile.json'
+
+statement ok
+SET tracked_metrics = ['query.total_rows_scanned']
+
+query I
+SELECT count(*) FROM nested_nulls WHERE s IS NULL
+----
+1
+
+statement ok
+PRAGMA disable_profiling
+
+query I
+SELECT query.total_rows_scanned BETWEEN 1 AND 99999
+FROM '{TEST_DIR}/nested_null_profile.json'
+----
+true
+
+statement ok
+PRAGMA enable_profiling = 'json'
+
+query I
+SELECT count(*) FROM nested_nulls WHERE l IS NULL
+----
+1
+
+statement ok
+PRAGMA disable_profiling
+
+query I
+SELECT query.total_rows_scanned BETWEEN 1 AND 99999
+FROM '{TEST_DIR}/nested_null_profile.json'
+----
+true
+
+statement ok
+PRAGMA enable_profiling = 'json'
+
+query I
+SELECT count(*) FROM array_nulls WHERE a IS NULL
+----
+1
+
+statement ok
+PRAGMA disable_profiling
+
+query I
+SELECT query.total_rows_scanned BETWEEN 1 AND 99999
+FROM '{TEST_DIR}/nested_null_profile.json'
+----
+true

--- a/test/sql/optimizer/nested_null_segment_pruning.test
+++ b/test/sql/optimizer/nested_null_segment_pruning.test
@@ -6,6 +6,8 @@ require json
 
 require no_force_storage
 
+require vector_size 2048
+
 statement ok
 CREATE TABLE nested_nulls AS
 SELECT CASE WHEN i >= 99999 THEN NULL ELSE {'v': i} END AS s,
@@ -19,6 +21,12 @@ FROM range(99999) t(i)
 
 statement ok
 INSERT INTO array_nulls VALUES (NULL)
+
+query II
+SELECT (SELECT count(*) FROM nested_nulls WHERE l IS NULL),
+       (SELECT count(*) FROM array_nulls WHERE a IS NULL)
+----
+1	1
 
 statement ok
 PRAGMA enable_profiling = 'json'
@@ -37,42 +45,9 @@ SELECT count(*) FROM nested_nulls WHERE s IS NULL
 statement ok
 PRAGMA disable_profiling
 
+# Last validity segment is 54944 rows. A full scan is 100000.
 query I
-SELECT query.total_rows_scanned BETWEEN 1 AND 99999
+SELECT query.total_rows_scanned
 FROM '{TEST_DIR}/nested_null_profile.json'
 ----
-true
-
-statement ok
-PRAGMA enable_profiling = 'json'
-
-query I
-SELECT count(*) FROM nested_nulls WHERE l IS NULL
-----
-1
-
-statement ok
-PRAGMA disable_profiling
-
-query I
-SELECT query.total_rows_scanned BETWEEN 1 AND 99999
-FROM '{TEST_DIR}/nested_null_profile.json'
-----
-true
-
-statement ok
-PRAGMA enable_profiling = 'json'
-
-query I
-SELECT count(*) FROM array_nulls WHERE a IS NULL
-----
-1
-
-statement ok
-PRAGMA disable_profiling
-
-query I
-SELECT query.total_rows_scanned BETWEEN 1 AND 99999
-FROM '{TEST_DIR}/nested_null_profile.json'
-----
-true
+54944

--- a/test/sql/optimizer/nested_null_segment_pruning.test
+++ b/test/sql/optimizer/nested_null_segment_pruning.test
@@ -6,14 +6,6 @@ require json
 
 require no_force_storage
 
-require vector_size 2048
-
-statement ok
-SET initial_column_segment_size = 2048
-
-statement ok
-SET wal_autocheckpoint = '1TB'
-
 statement ok
 CREATE TABLE nested_nulls AS
 SELECT CASE WHEN i >= 99999 THEN NULL ELSE {'v': i} END AS s,


### PR DESCRIPTION
Hi team, I found for `IS NULL` predicate, not all the types prune segment well. For example
```sql
memory D PRAGMA enable_profiling = 'json';
memory D SET tracked_metrics = ['query.total_rows_scanned'];

-- scalar types prune as expected
memory D CREATE TABLE scalar_null AS
         SELECT CASE WHEN i >= 99999 THEN NULL ELSE i END AS v
         FROM range(100000) t(i);
memory D SELECT count(*) FROM scalar_null WHERE v IS NULL;
{
    "query": {
        "total_rows_scanned": 54944
    }
}

-- struct doesn't prune segment
memory D CREATE TABLE struct_null AS
         SELECT CASE WHEN i >= 99999 THEN NULL ELSE {'v': i} END AS s
         FROM range(100000) t(i);
memory D SELECT count(*) FROM struct_null WHERE s IS NULL;
{
    "query": {
        "total_rows_scanned": 100000
    }
}

-- list doesn't prune segment
memory D CREATE TABLE list_null AS
         SELECT CASE WHEN i >= 99999 THEN NULL ELSE [i] END AS l
         FROM range(100000) t(i);
memory D SELECT count(*) FROM list_null WHERE l IS NULL;
{
    "query": {
        "total_rows_scanned": 100000
    }
}
```
This PR consults validity zonemap for these nested types, after change segment prunes correctly.
```sql
memory D CREATE TABLE struct_null AS
                  SELECT CASE WHEN i >= 99999 THEN NULL ELSE {'v': i} END AS s
                  FROM range(100000) t(i);
memory D SELECT count(*) FROM struct_null WHERE s IS NULL;
{
    "query": {
        "total_rows_scanned": 54944
    }
}

memory D CREATE TABLE list_null AS
                  SELECT CASE WHEN i >= 99999 THEN NULL ELSE [i] END AS l
                  FROM range(100000) t(i);
memory D SELECT count(*) FROM list_null WHERE l IS NULL;
{
    "query": {
        "total_rows_scanned": 54944
    }
}
```
