### PR TITLE
[Dev] Refactor `BaseTokenizer`, and rename to `Tokenizer`

### DIFF
--- a/extension/autocomplete/autocomplete_extension.cpp
+++ b/extension/autocomplete/autocomplete_extension.cpp
@@ -16,7 +16,7 @@
 #include "duckdb/parser/peg/matcher.hpp"
 #include "duckdb/parser/peg/autocomplete_catalog_provider.hpp"
 #include "duckdb/main/attached_database.hpp"
-#include "duckdb/parser/peg/tokenizer/base_tokenizer.hpp"
+#include "duckdb/parser/peg/tokenizer/tokenizer.hpp"
 #include "duckdb/catalog/catalog_entry/pragma_function_catalog_entry.hpp"
 #include "duckdb/catalog/catalog_entry/scalar_function_catalog_entry.hpp"
 #include "duckdb/catalog/catalog_entry/table_function_catalog_entry.hpp"
@@ -457,19 +457,21 @@ void SQLAutoCompleteFunction(ClientContext &context, TableFunctionInput &data_p,
 }
 
 static unique_ptr<SQLTokenizeFunctionData> GenerateTokens(ClientContext &context, const string &sql) {
-	HighlightTokenizer tokenizer(sql);
+	vector<MatcherToken> tokens;
+	HighlightTokenizerBehavior behavior(sql, tokens);
+	Tokenizer tokenizer(behavior);
 	tokenizer.TokenizeInput();
 
 	// use the parser to annotate any tokens
 	vector<MatcherSuggestion> suggestions;
 	ParseResultAllocator parse_allocator;
 	idx_t max_token_index = 0;
-	MatchState state(tokenizer.tokens, suggestions, parse_allocator, max_token_index);
+	MatchState state(tokens, suggestions, parse_allocator, max_token_index);
 
 	auto peg_matcher = PEGMatcher::Get(context);
 	peg_matcher->ProgramMatcher().Match(state);
 
-	return make_uniq<SQLTokenizeFunctionData>(tokenizer.tokens);
+	return make_uniq<SQLTokenizeFunctionData>(std::move(tokens));
 }
 
 unique_ptr<GlobalTableFunctionState> SQLTokenizeInit(ClientContext &context, TableFunctionInitInput &input) {
@@ -540,7 +542,8 @@ static duckdb::unique_ptr<FunctionData> CheckPEGParserBind(ClientContext &contex
 	vector<MatcherToken> root_tokens;
 	string clean_sql;
 	const string &sql_ref = Parser::StripUnicodeSpaces(sql, clean_sql) ? clean_sql : sql;
-	ParserTokenizer tokenizer(sql_ref, root_tokens);
+	ParserTokenizerBehavior behavior(sql_ref, root_tokens);
+	Tokenizer tokenizer(behavior);
 
 	tokenizer.TokenizeInput();
 	if (!tokenizer.CanAutocomplete()) {

--- a/src/include/duckdb/parser/peg/tokenizer/highlight_tokenizer.hpp
+++ b/src/include/duckdb/parser/peg/tokenizer/highlight_tokenizer.hpp
@@ -1,18 +1,16 @@
 #pragma once
-#include "duckdb/parser/peg/tokenizer/base_tokenizer.hpp"
+#include "duckdb/parser/peg/tokenizer/tokenizer.hpp"
 
 namespace duckdb {
 struct MatcherToken;
 
-class HighlightTokenizer : public BaseTokenizer {
+class HighlightTokenizerBehavior : public TokenizerBehavior {
 public:
-	explicit HighlightTokenizer(const string &sql);
-	~HighlightTokenizer() override = default;
+	HighlightTokenizerBehavior(const string &sql, vector<MatcherToken> &tokens);
+	~HighlightTokenizerBehavior() override = default;
 
 	void PushToken(idx_t start, idx_t end, TokenType type, bool unterminated) override;
 	void OnStatementEnd(idx_t pos) override;
-
-	vector<MatcherToken> tokens;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/parser/peg/tokenizer/parser_tokenizer.hpp
+++ b/src/include/duckdb/parser/peg/tokenizer/parser_tokenizer.hpp
@@ -1,13 +1,13 @@
 #pragma once
-#include "duckdb/parser/peg/tokenizer/base_tokenizer.hpp"
+#include "duckdb/parser/peg/tokenizer/tokenizer.hpp"
 
 namespace duckdb {
 struct MatcherToken;
 
-class ParserTokenizer : public BaseTokenizer {
+class ParserTokenizerBehavior : public TokenizerBehavior {
 public:
-	ParserTokenizer(const string &sql, vector<MatcherToken> &tokens);
-	~ParserTokenizer() override = default;
+	ParserTokenizerBehavior(const string &sql, vector<MatcherToken> &tokens);
+	~ParserTokenizerBehavior() override = default;
 
 	void PushToken(idx_t start, idx_t end, TokenType type, bool unterminated = false) override;
 	void OnStatementEnd(idx_t pos) override;

--- a/src/include/duckdb/parser/peg/tokenizer/tokenizer.hpp
+++ b/src/include/duckdb/parser/peg/tokenizer/tokenizer.hpp
@@ -1,7 +1,7 @@
 //===----------------------------------------------------------------------===//
 //                         DuckDB
 //
-// include/parser/tokenizer/tokenizer.hpp
+// duckdb/parser/peg/tokenizer/tokenizer.hpp
 //
 //
 //===----------------------------------------------------------------------===//
@@ -25,18 +25,45 @@ enum class TokenizeState {
 	DOLLAR_QUOTED_STRING
 };
 
-class BaseTokenizer {
+class Tokenizer;
+
+class TokenizerBehavior {
 public:
-	BaseTokenizer(const string &sql, vector<MatcherToken> &tokens);
-	virtual ~BaseTokenizer() = default;
+	TokenizerBehavior(const string &sql, vector<MatcherToken> &tokens);
+	virtual ~TokenizerBehavior() = default;
 
 public:
-	void TokenizeInput();
+	virtual void PushToken(idx_t start, idx_t end, TokenType type, bool unterminated = false);
+	virtual void OnStatementEnd(idx_t pos);
+	virtual void OnLastToken(TokenizeState state, string last_word, idx_t last_pos);
+
+	//! Sentinel appended at the end of the token vector on a clean exit. Override to return
+	//! `END_OF_INPUT_AUTOCOMPLETE` for autocomplete behavior. Dirty exits (unterminated comment /
+	//! dollar-quote) always append `END_OF_INPUT` regardless of this hook.
+	virtual TokenType GetTerminator() const {
+		return TokenType::END_OF_INPUT;
+	}
+
+protected:
+	const string &sql;
+	vector<MatcherToken> &tokens;
+	PEGKeywordHelper keyword_helper;
+
+	friend class Tokenizer;
+};
+
+class Tokenizer {
+public:
+	explicit Tokenizer(TokenizerBehavior &behavior);
+	virtual ~Tokenizer() = default;
+
+public:
+	virtual void TokenizeInput();
 
 	//! True iff `TokenizeInput()` finished in a state where autocomplete could be offered (the
 	//! input wasn't truncated mid-comment / mid-dollar-quoted-string). Derived by inspecting the
 	//! trailing sentinel: the clean-exit paths append `GetTerminator()` (which becomes
-	//! `END_OF_INPUT_AUTOCOMPLETE` for autocomplete tokenizers); the dirty-exit paths always append
+	//! `END_OF_INPUT_AUTOCOMPLETE` for autocomplete behavior); the dirty-exit paths always append
 	//! `END_OF_INPUT`.
 	bool CanAutocomplete() const;
 
@@ -48,17 +75,6 @@ private:
 	bool TokenizeInputInternal();
 
 public:
-	virtual void PushToken(idx_t start, idx_t end, TokenType type, bool unterminated = false);
-	virtual void OnStatementEnd(idx_t pos);
-	virtual void OnLastToken(TokenizeState state, string last_word, idx_t last_pos);
-
-	//! Sentinel appended at the end of the token vector on a clean exit. Override to return
-	//! `END_OF_INPUT_AUTOCOMPLETE` in autocomplete tokenizers. Dirty exits (unterminated comment /
-	//! dollar-quote) always append `END_OF_INPUT` regardless of this hook.
-	virtual TokenType GetTerminator() const {
-		return TokenType::END_OF_INPUT;
-	}
-
 	bool IsSpecialOperator(idx_t pos, idx_t &op_len) const;
 	static bool IsSingleByteOperator(char c);
 	static bool CharacterIsInitialNumber(char c);
@@ -69,13 +85,14 @@ public:
 	static bool CharacterIsOperator(char c);
 	static bool CharacterIsSpecialStringCharacter(char c);
 	bool IsValidDollarTagCharacter(char c);
-	TokenType TokenizeStateToType(TokenizeState state);
+	static TokenType TokenizeStateToType(TokenizeState state);
 	static bool IsUnterminatedState(TokenizeState state);
 
 protected:
 	const string &sql;
 	vector<MatcherToken> &tokens;
 	PEGKeywordHelper keyword_helper;
+	TokenizerBehavior &behavior;
 };
 
 } // namespace duckdb

--- a/src/main/parse_iterator.cpp
+++ b/src/main/parse_iterator.cpp
@@ -141,7 +141,8 @@ void ParseIterator::EnsureTokenized() {
 		// Tokenize the full input once. Subsequent Peek/HasMore calls walk through `tokens` via
 		// `token_cursor`; we never re-tokenize. Tokenization is grammar-free.
 		tokens = make_uniq<vector<MatcherToken>>();
-		ParserTokenizer tokenizer(sql, *tokens);
+		ParserTokenizerBehavior behavior(sql, *tokens);
+		Tokenizer tokenizer(behavior);
 		tokenizer.TokenizeInput();
 	}
 }

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -267,7 +267,8 @@ void Parser::ParseQuery(const string &query_p) {
 	// failure, hand the rest of the query to parse_function extensions; the extension reports
 	// how many bytes it consumed and we advance the token cursor past them.
 	vector<MatcherToken> tokens;
-	ParserTokenizer tokenizer(query, tokens);
+	ParserTokenizerBehavior behavior(query, tokens);
+	Tokenizer tokenizer(behavior);
 	tokenizer.TokenizeInput();
 	idx_t token_cursor = 0;
 	while (token_cursor < tokens.size()) {
@@ -361,12 +362,14 @@ unique_ptr<SQLStatement> Parser::ParseTopLevelStatement(vector<MatcherToken> &to
 }
 
 vector<SimplifiedToken> Parser::Tokenize(const string &query) {
-	HighlightTokenizer tokenizer(query);
+	vector<MatcherToken> tokens;
+	HighlightTokenizerBehavior behavior(query, tokens);
+	Tokenizer tokenizer(behavior);
 	tokenizer.TokenizeInput();
 
 	vector<SimplifiedToken> result;
-	result.reserve(tokenizer.tokens.size());
-	for (auto &token : tokenizer.tokens) {
+	result.reserve(tokens.size());
+	for (auto &token : tokens) {
 		SimplifiedToken simplified;
 		simplified.start = token.offset;
 		switch (token.type) {

--- a/src/parser/peg/autocomplete_core.cpp
+++ b/src/parser/peg/autocomplete_core.cpp
@@ -3,7 +3,7 @@
 #include "duckdb/common/case_insensitive_map.hpp"
 #include "duckdb/parser/keyword_helper.hpp"
 #include "duckdb/parser/parser.hpp"
-#include "duckdb/parser/peg/tokenizer/base_tokenizer.hpp"
+#include "duckdb/parser/peg/tokenizer/tokenizer.hpp"
 
 namespace duckdb {
 
@@ -161,10 +161,10 @@ bool ReplaceUnicodeSpaces(const string &query, string &new_query, const vector<U
 	return true;
 }
 
-class AutoCompleteTokenizer : public BaseTokenizer {
+class AutoCompleteTokenizerBehavior : public TokenizerBehavior {
 public:
-	AutoCompleteTokenizer(const string &sql, MatchState &state)
-	    : BaseTokenizer(sql, state.tokens), suggestions(state.suggestions) {
+	AutoCompleteTokenizerBehavior(const string &sql, MatchState &state)
+	    : TokenizerBehavior(sql, state.tokens), suggestions(state.suggestions) {
 		last_pos = 0;
 	}
 
@@ -173,7 +173,7 @@ public:
 	}
 
 	void OnLastToken(TokenizeState state, string last_word_p, idx_t last_pos_p) override {
-		if (TokenizeStateToType(state) == TokenType::STRING_LITERAL) {
+		if (Tokenizer::TokenizeStateToType(state) == TokenType::STRING_LITERAL) {
 			suggestions.emplace_back(SuggestionState::SUGGEST_FILE_NAME);
 		}
 		if (StringUtil::StartsWith(last_word_p, "'")) {
@@ -204,7 +204,8 @@ vector<AutoCompleteSuggestion> GenerateAutoCompleteSuggestions(AutoCompleteCatal
 	vector<UnicodeSpace> unicode_spaces;
 	string clean_sql;
 	const string &sql_ref = Parser::StripUnicodeSpaces(sql, clean_sql) ? clean_sql : sql;
-	AutoCompleteTokenizer tokenizer(sql_ref, state);
+	AutoCompleteTokenizerBehavior behavior(sql_ref, state);
+	Tokenizer tokenizer(behavior);
 	tokenizer.TokenizeInput();
 	if (!tokenizer.CanAutocomplete()) {
 		return {};
@@ -220,7 +221,7 @@ vector<AutoCompleteSuggestion> GenerateAutoCompleteSuggestions(AutoCompleteCatal
 	}
 	vector<AutoCompleteCandidate> available_suggestions;
 	for (auto &suggestion : suggestions) {
-		idx_t suggestion_pos = tokenizer.last_pos;
+		idx_t suggestion_pos = behavior.last_pos;
 		// run the suggestions
 		vector<AutoCompleteCandidate> new_suggestions;
 		switch (suggestion.type) {
@@ -247,7 +248,7 @@ vector<AutoCompleteSuggestion> GenerateAutoCompleteSuggestions(AutoCompleteCatal
 			break;
 		case SuggestionState::SUGGEST_FILE_NAME:
 			if (parameters.max_file_suggestion_count > 0) {
-				new_suggestions = provider.SuggestFileName(tokenizer.last_word, suggestion_pos);
+				new_suggestions = provider.SuggestFileName(behavior.last_word, suggestion_pos);
 				parameters.suggestion_contains_files = true;
 			}
 			break;
@@ -274,7 +275,7 @@ vector<AutoCompleteSuggestion> GenerateAutoCompleteSuggestions(AutoCompleteCatal
 			available_suggestions.push_back(std::move(new_suggestion));
 		}
 	}
-	return ComputeSuggestions(available_suggestions, tokenizer.last_word, parameters);
+	return ComputeSuggestions(available_suggestions, behavior.last_word, parameters);
 }
 
 } // namespace duckdb

--- a/src/parser/peg/matcher.cpp
+++ b/src/parser/peg/matcher.cpp
@@ -11,7 +11,7 @@
 #include "duckdb/parser/peg/keyword_helper.hpp"
 #include "duckdb/common/case_insensitive_map.hpp"
 #include "duckdb/common/exception/parser_exception.hpp"
-#include "duckdb/parser/peg/tokenizer/base_tokenizer.hpp"
+#include "duckdb/parser/peg/tokenizer/tokenizer.hpp"
 #include "duckdb/parser/peg/peg_parser.hpp"
 #include "duckdb/parser/peg/transformer/parse_result.hpp"
 #ifdef PEG_PARSER_SOURCE_FILE
@@ -507,10 +507,10 @@ public:
 		if (IsQuoted(text)) {
 			return true;
 		}
-		if (BaseTokenizer::CharacterIsInitialNumber(text[0])) {
+		if (Tokenizer::CharacterIsInitialNumber(text[0])) {
 			return false;
 		}
-		return BaseTokenizer::CharacterIsKeyword(text[0]);
+		return Tokenizer::CharacterIsKeyword(text[0]);
 	}
 
 	MatchResultType Match(MatchState &state) const override {
@@ -858,7 +858,7 @@ private:
 			return false;
 		}
 		auto &token_text = state.tokens[state.token_index].text;
-		if (token_text.empty() || !BaseTokenizer::CharacterIsInitialNumber(token_text[0])) {
+		if (token_text.empty() || !Tokenizer::CharacterIsInitialNumber(token_text[0])) {
 			return false;
 		}
 		// A lone '.' is a dot operator, not a number literal (e.g., '?.method()' should not consume '.')
@@ -867,7 +867,7 @@ private:
 		}
 		bool scientific_notation = false;
 		for (idx_t i = 1; i < token_text.size(); i++) {
-			if (BaseTokenizer::CharacterIsScientific(token_text[i])) {
+			if (Tokenizer::CharacterIsScientific(token_text[i])) {
 				if (scientific_notation) {
 					throw ParserException("Already found scientific notation");
 				}
@@ -876,7 +876,7 @@ private:
 			if (scientific_notation && (token_text[i] == '+' || token_text[i] == '-')) {
 				continue;
 			}
-			if (!BaseTokenizer::CharacterIsNumber(token_text[i])) {
+			if (!Tokenizer::CharacterIsNumber(token_text[i])) {
 				return false;
 			}
 		}

--- a/src/parser/peg/sql_formatter.cpp
+++ b/src/parser/peg/sql_formatter.cpp
@@ -87,15 +87,16 @@ SQLFormatter::SQLFormatter(const FormatterConfig &config) : config(config) {
 }
 
 string SQLFormatter::Format(const string &sql) {
-	HighlightTokenizer tokenizer(sql);
+	vector<MatcherToken> tokens;
+	HighlightTokenizerBehavior behavior(sql, tokens);
+	Tokenizer tokenizer(behavior);
 	tokenizer.TokenizeInput();
-	if (!tokenizer.tokens.empty()) {
-		auto back_type = tokenizer.tokens.back().type;
+	if (!tokens.empty()) {
+		auto back_type = tokens.back().type;
 		if (back_type == TokenType::END_OF_INPUT || back_type == TokenType::END_OF_INPUT_AUTOCOMPLETE) {
-			tokenizer.tokens.pop_back();
+			tokens.pop_back();
 		}
 	}
-	const auto &tokens = tokenizer.tokens;
 
 	if (tokens.empty()) {
 		return sql;

--- a/src/parser/peg/tokenizer/base_tokenizer.cpp
+++ b/src/parser/peg/tokenizer/base_tokenizer.cpp
@@ -1,11 +1,15 @@
 #include "duckdb/common/string_util.hpp"
-#include "duckdb/parser/peg/tokenizer/base_tokenizer.hpp"
+#include "duckdb/parser/peg/tokenizer/tokenizer.hpp"
 #include "duckdb/parser/peg/keyword_helper.hpp"
 
 namespace duckdb {
 
-BaseTokenizer::BaseTokenizer(const string &sql, vector<MatcherToken> &tokens)
+TokenizerBehavior::TokenizerBehavior(const string &sql, vector<MatcherToken> &tokens)
     : sql(sql), tokens(tokens), keyword_helper(PEGKeywordHelper::Instance()) {
+}
+
+Tokenizer::Tokenizer(TokenizerBehavior &behavior)
+    : sql(behavior.sql), tokens(behavior.tokens), keyword_helper(PEGKeywordHelper::Instance()), behavior(behavior) {
 }
 
 static bool OperatorEquals(const char *str, const char *op, idx_t len, idx_t &op_len) {
@@ -18,7 +22,7 @@ static bool OperatorEquals(const char *str, const char *op, idx_t len, idx_t &op
 	return true;
 }
 
-bool BaseTokenizer::IsSpecialOperator(idx_t pos, idx_t &op_len) const {
+bool Tokenizer::IsSpecialOperator(idx_t pos, idx_t &op_len) const {
 	const char *op_start = sql.c_str() + pos;
 	if (pos + 2 < sql.size()) {
 		if (OperatorEquals(op_start, "->>", 3, op_len)) {
@@ -47,7 +51,7 @@ bool BaseTokenizer::IsSpecialOperator(idx_t pos, idx_t &op_len) const {
 	return false;
 }
 
-bool BaseTokenizer::IsSingleByteOperator(char c) {
+bool Tokenizer::IsSingleByteOperator(char c) {
 	switch (c) {
 	case '(':
 	case ')':
@@ -66,14 +70,14 @@ bool BaseTokenizer::IsSingleByteOperator(char c) {
 	}
 }
 
-bool BaseTokenizer::CharacterIsInitialNumber(char c) {
+bool Tokenizer::CharacterIsInitialNumber(char c) {
 	if (c >= '0' && c <= '9') {
 		return true;
 	}
 	return c == '.';
 }
 
-bool BaseTokenizer::CharacterIsSpecialStringCharacter(char c) {
+bool Tokenizer::CharacterIsSpecialStringCharacter(char c) {
 	if (c == 'N' || c == 'n') {
 		return true;
 	}
@@ -89,7 +93,7 @@ bool BaseTokenizer::CharacterIsSpecialStringCharacter(char c) {
 	return false;
 }
 
-bool BaseTokenizer::CharacterIsNumber(char c) {
+bool Tokenizer::CharacterIsNumber(char c) {
 	if (CharacterIsInitialNumber(c)) {
 		return true;
 	}
@@ -103,7 +107,7 @@ bool BaseTokenizer::CharacterIsNumber(char c) {
 	}
 }
 
-bool BaseTokenizer::CharacterIsScientific(char c) {
+bool Tokenizer::CharacterIsScientific(char c) {
 	switch (c) {
 	case 'e':
 	case 'E':
@@ -113,7 +117,7 @@ bool BaseTokenizer::CharacterIsScientific(char c) {
 	}
 }
 
-bool BaseTokenizer::CharacterIsControlFlow(char c) {
+bool Tokenizer::CharacterIsControlFlow(char c) {
 	switch (c) {
 	case '\'':
 	case '-':
@@ -126,7 +130,7 @@ bool BaseTokenizer::CharacterIsControlFlow(char c) {
 	}
 }
 
-bool BaseTokenizer::CharacterIsKeyword(char c) {
+bool Tokenizer::CharacterIsKeyword(char c) {
 	if (IsSingleByteOperator(c)) {
 		return false;
 	}
@@ -142,7 +146,7 @@ bool BaseTokenizer::CharacterIsKeyword(char c) {
 	return true;
 }
 
-bool BaseTokenizer::CharacterIsOperator(char c) {
+bool Tokenizer::CharacterIsOperator(char c) {
 	if (IsSingleByteOperator(c)) {
 		return false;
 	}
@@ -152,7 +156,7 @@ bool BaseTokenizer::CharacterIsOperator(char c) {
 	return StringUtil::CharacterIsOperator(c);
 }
 
-TokenType BaseTokenizer::TokenizeStateToType(TokenizeState state) {
+TokenType Tokenizer::TokenizeStateToType(TokenizeState state) {
 	switch (state) {
 	case TokenizeState::STANDARD:
 		return TokenType::IDENTIFIER;
@@ -177,7 +181,7 @@ TokenType BaseTokenizer::TokenizeStateToType(TokenizeState state) {
 	}
 }
 
-void BaseTokenizer::PushToken(idx_t start, idx_t end, TokenType type, bool unterminated) {
+void TokenizerBehavior::PushToken(idx_t start, idx_t end, TokenType type, bool unterminated) {
 	if (type == TokenType::COMMENT) {
 		return;
 	}
@@ -191,7 +195,7 @@ void BaseTokenizer::PushToken(idx_t start, idx_t end, TokenType type, bool unter
 // Valid characters can be between A-Z, a-z, 0-9, underscore, or \200 - \377
 // Note: 0-9 are only valid after the first character. Callers are expected to validate that before calling this
 // function.
-bool BaseTokenizer::IsValidDollarTagCharacter(char c) {
+bool Tokenizer::IsValidDollarTagCharacter(char c) {
 	if (c >= 'A' && c <= 'Z') {
 		return true;
 	}
@@ -210,7 +214,7 @@ bool BaseTokenizer::IsValidDollarTagCharacter(char c) {
 	return false;
 }
 
-bool BaseTokenizer::IsUnterminatedState(TokenizeState state) {
+bool Tokenizer::IsUnterminatedState(TokenizeState state) {
 	switch (state) {
 	case TokenizeState::STRING_LITERAL:
 	case TokenizeState::QUOTED_IDENTIFIER:
@@ -221,19 +225,19 @@ bool BaseTokenizer::IsUnterminatedState(TokenizeState state) {
 	}
 }
 
-bool BaseTokenizer::CanAutocomplete() const {
+bool Tokenizer::CanAutocomplete() const {
 	return !tokens.empty() && tokens.back().type == TokenType::END_OF_INPUT_AUTOCOMPLETE;
 }
 
-void BaseTokenizer::TokenizeInput() {
+void Tokenizer::TokenizeInput() {
 	if (TokenizeInputInternal()) {
-		tokens.emplace_back("", sql.size(), GetTerminator());
+		tokens.emplace_back("", sql.size(), behavior.GetTerminator());
 	} else {
 		tokens.emplace_back("", sql.size(), TokenType::END_OF_INPUT);
 	}
 }
 
-bool BaseTokenizer::TokenizeInputInternal() {
+bool Tokenizer::TokenizeInputInternal() {
 	auto state = TokenizeState::STANDARD;
 	idx_t last_pos = 0;
 	bool escape_string = false;
@@ -257,7 +261,7 @@ bool BaseTokenizer::TokenizeInputInternal() {
 			}
 			if (c == ';') {
 				// end of statement
-				OnStatementEnd(i);
+				behavior.OnStatementEnd(i);
 				last_pos = i + 1;
 				break;
 			}
@@ -394,7 +398,7 @@ bool BaseTokenizer::TokenizeInputInternal() {
 			while (!CharacterIsInitialNumber(sql[i - 1])) {
 				i--;
 			}
-			PushToken(last_pos, i, TokenType::NUMBER_LITERAL);
+			behavior.PushToken(last_pos, i, TokenType::NUMBER_LITERAL);
 			state = TokenizeState::STANDARD;
 			last_pos = i;
 			i--;
@@ -419,7 +423,7 @@ bool BaseTokenizer::TokenizeInputInternal() {
 						end_pos--;
 					}
 				}
-				PushToken(last_pos, end_pos, TokenType::OPERATOR);
+				behavior.PushToken(last_pos, end_pos, TokenType::OPERATOR);
 				// Push any trimmed '+' characters as individual tokens
 				for (idx_t j = end_pos; j < i; j++) {
 					tokens.emplace_back(string(1, sql[j]), j, TokenType::OPERATOR);
@@ -436,7 +440,7 @@ bool BaseTokenizer::TokenizeInputInternal() {
 				// not a keyword - return to standard state
 				auto word = sql.substr(last_pos, i - last_pos);
 				auto token_type = keyword_helper.IsKeyword(word) ? TokenType::KEYWORD : TokenType::IDENTIFIER;
-				PushToken(last_pos, i, token_type);
+				behavior.PushToken(last_pos, i, token_type);
 				state = TokenizeState::STANDARD;
 				last_pos = i;
 				i--;
@@ -452,7 +456,7 @@ bool BaseTokenizer::TokenizeInputInternal() {
 					// escaped - skip escape
 					i++;
 				} else {
-					PushToken(last_pos, i + 1, TokenType::STRING_LITERAL);
+					behavior.PushToken(last_pos, i + 1, TokenType::STRING_LITERAL);
 					last_pos = i + 1;
 					escape_string = false;
 					state = TokenizeState::STANDARD;
@@ -465,7 +469,7 @@ bool BaseTokenizer::TokenizeInputInternal() {
 					// escaped - skip escape
 					i++;
 				} else {
-					PushToken(last_pos, i + 1, TokenType::IDENTIFIER);
+					behavior.PushToken(last_pos, i + 1, TokenType::IDENTIFIER);
 					last_pos = i + 1;
 					state = TokenizeState::STANDARD;
 				}
@@ -473,7 +477,7 @@ bool BaseTokenizer::TokenizeInputInternal() {
 			break;
 		case TokenizeState::SINGLE_LINE_COMMENT:
 			if (c == '\n' || c == '\r') {
-				PushToken(last_pos, i + 1, TokenType::COMMENT);
+				behavior.PushToken(last_pos, i + 1, TokenType::COMMENT);
 				last_pos = i + 1;
 				state = TokenizeState::STANDARD;
 			}
@@ -486,7 +490,7 @@ bool BaseTokenizer::TokenizeInputInternal() {
 				i++;
 				multi_line_comment_depth--;
 				if (multi_line_comment_depth == 0) {
-					PushToken(last_pos, i + 1, TokenType::COMMENT);
+					behavior.PushToken(last_pos, i + 1, TokenType::COMMENT);
 					last_pos = i + 1;
 					state = TokenizeState::STANDARD;
 				}
@@ -540,24 +544,24 @@ bool BaseTokenizer::TokenizeInputInternal() {
 	switch (state) {
 	case TokenizeState::SINGLE_LINE_COMMENT:
 	case TokenizeState::MULTI_LINE_COMMENT:
-		PushToken(last_pos, sql.size(), TokenType::COMMENT);
+		behavior.PushToken(last_pos, sql.size(), TokenType::COMMENT);
 		return false;
 	case TokenizeState::DOLLAR_QUOTED_STRING:
-		PushToken(last_pos, sql.size(), TokenType::STRING_LITERAL, true);
+		behavior.PushToken(last_pos, sql.size(), TokenType::STRING_LITERAL, true);
 		return false;
 	default:
 		break;
 	}
 	string last_word = sql.substr(last_pos, sql.size() - last_pos);
-	OnLastToken(state, std::move(last_word), last_pos);
+	behavior.OnLastToken(state, std::move(last_word), last_pos);
 	return true;
 }
 
-void BaseTokenizer::OnStatementEnd(idx_t pos) {
+void TokenizerBehavior::OnStatementEnd(idx_t pos) {
 	// Default: Do nothing
 }
 
-void BaseTokenizer::OnLastToken(TokenizeState state, string last_word, idx_t last_pos) {
+void TokenizerBehavior::OnLastToken(TokenizeState state, string last_word, idx_t last_pos) {
 	if (last_word.empty()) {
 		return;
 	}
@@ -565,8 +569,8 @@ void BaseTokenizer::OnLastToken(TokenizeState state, string last_word, idx_t las
 		state = keyword_helper.IsKeyword(last_word) ? TokenizeState::KEYWORD : TokenizeState::STANDARD;
 	}
 
-	bool is_unterminated = IsUnterminatedState(state);
-	tokens.emplace_back(std::move(last_word), last_pos, TokenizeStateToType(state), is_unterminated);
+	bool is_unterminated = Tokenizer::IsUnterminatedState(state);
+	tokens.emplace_back(std::move(last_word), last_pos, Tokenizer::TokenizeStateToType(state), is_unterminated);
 }
 
 } // namespace duckdb

--- a/src/parser/peg/tokenizer/highlight_tokenizer.cpp
+++ b/src/parser/peg/tokenizer/highlight_tokenizer.cpp
@@ -2,10 +2,11 @@
 
 namespace duckdb {
 
-HighlightTokenizer::HighlightTokenizer(const string &sql) : BaseTokenizer(sql, tokens) {
+HighlightTokenizerBehavior::HighlightTokenizerBehavior(const string &sql, vector<MatcherToken> &tokens)
+    : TokenizerBehavior(sql, tokens) {
 }
 
-void HighlightTokenizer::PushToken(idx_t start, idx_t end, TokenType type, bool unterminated) {
+void HighlightTokenizerBehavior::PushToken(idx_t start, idx_t end, TokenType type, bool unterminated) {
 	if (start >= end) {
 		return;
 	}
@@ -13,7 +14,7 @@ void HighlightTokenizer::PushToken(idx_t start, idx_t end, TokenType type, bool 
 	tokens.emplace_back(std::move(last_token), start, type, unterminated);
 }
 
-void HighlightTokenizer::OnStatementEnd(idx_t pos) {
+void HighlightTokenizerBehavior::OnStatementEnd(idx_t pos) {
 	tokens.emplace_back(";", pos, TokenType::TERMINATOR);
 }
 } // namespace duckdb

--- a/src/parser/peg/tokenizer/parser_tokenizer.cpp
+++ b/src/parser/peg/tokenizer/parser_tokenizer.cpp
@@ -7,23 +7,24 @@ static bool IsEmptyQuotedIdentifier(const string &sql, idx_t start, idx_t end, T
 	return type == TokenType::IDENTIFIER && end == start + 2 && sql.substr(start, 2) == "\"\"";
 }
 
-ParserTokenizer::ParserTokenizer(const string &sql, vector<MatcherToken> &tokens) : BaseTokenizer(sql, tokens) {
+ParserTokenizerBehavior::ParserTokenizerBehavior(const string &sql, vector<MatcherToken> &tokens)
+    : TokenizerBehavior(sql, tokens) {
 }
 
-void ParserTokenizer::PushToken(idx_t start, idx_t end, TokenType type, bool unterminated) {
+void ParserTokenizerBehavior::PushToken(idx_t start, idx_t end, TokenType type, bool unterminated) {
 	if (IsEmptyQuotedIdentifier(sql, start, end, type)) {
 		throw ParserException::SyntaxError(sql, "zero-length delimited identifier", optional_idx(start));
 	}
-	BaseTokenizer::PushToken(start, end, type, unterminated);
+	TokenizerBehavior::PushToken(start, end, type, unterminated);
 }
 
-void ParserTokenizer::OnStatementEnd(idx_t pos) {
+void ParserTokenizerBehavior::OnStatementEnd(idx_t pos) {
 	// Always emit ';' as a TERMINATOR token so the grammar can consume it.
 	// Statement boundaries are determined by the PEG grammar (Program rule), not the tokenizer.
 	tokens.emplace_back(";", pos, TokenType::TERMINATOR);
 }
 
-void ParserTokenizer::OnLastToken(TokenizeState state, string last_word, idx_t last_pos) {
+void ParserTokenizerBehavior::OnLastToken(TokenizeState state, string last_word, idx_t last_pos) {
 	switch (state) {
 	case TokenizeState::STRING_LITERAL:
 		throw ParserException::SyntaxError(sql, "unterminated string literal", optional_idx(last_pos));
@@ -32,7 +33,7 @@ void ParserTokenizer::OnLastToken(TokenizeState state, string last_word, idx_t l
 	default:
 		break;
 	}
-	BaseTokenizer::OnLastToken(state, std::move(last_word), last_pos);
+	TokenizerBehavior::OnLastToken(state, std::move(last_word), last_pos);
 }
 
 } // namespace duckdb

--- a/tools/shell/linenoise/highlighting.cpp
+++ b/tools/shell/linenoise/highlighting.cpp
@@ -41,11 +41,13 @@ static tokenType convertToken(TokenType token_type) {
 static vector<highlightToken> GetParseTokens(char *buf, size_t len) {
 	string sql(buf, len);
 	vector<highlightToken> tokens;
-	HighlightTokenizer tokenizer(sql);
+	vector<MatcherToken> matcher_tokens;
+	HighlightTokenizerBehavior behavior(sql, matcher_tokens);
+	Tokenizer tokenizer(behavior);
 	tokenizer.TokenizeInput();
 	vector<SimplifiedToken> result;
-	result.reserve(tokenizer.tokens.size());
-	for (auto &token : tokenizer.tokens) {
+	result.reserve(matcher_tokens.size());
+	for (auto &token : matcher_tokens) {
 		highlightToken new_token;
 		if (token.unterminated) {
 			new_token.type = tokenType::TOKEN_ERROR;


### PR DESCRIPTION
This PR is part of https://github.com/duckdblabs/duckdb-internal/issues/10346

Pull out behavior-changing derived classes and rework them into a dependency-injected interface instead.