### PR TITLE
Use compressed tarballs for CLI and shared libraries

### DIFF
--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -706,18 +706,19 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.S3_DUCKDB_STAGING_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DUCKDB_STAGING_KEY }}
       run: |
-        zip -j duckdb_cli-linux-${{ matrix.config.arch }}.zip build/release/duckdb
-        gzip -9 -k -n -c build/release/duckdb > duckdb_cli-linux-${{ matrix.config.arch }}.gz
-        zip -j libduckdb-linux-${{ matrix.config.arch }}.zip build/release/src/libduckdb*.* src/include/duckdb.h src/include/duckdb_extension.h
-        ./scripts/upload-assets-to-staging.sh github_release libduckdb-linux-${{ matrix.config.arch }}.zip duckdb_cli-linux-${{ matrix.config.arch }}.zip duckdb_cli-linux-${{ matrix.config.arch }}.gz
+        make cli-release-artifact ARTIFACT_SUFFIX=linux-${{ matrix.config.arch }} CLI_BINARY=build/release/duckdb
+        make shared-libs-release-artifact ARTIFACT_SUFFIX=linux-${{ matrix.config.arch }} SHARED_LIBRARIES="build/release/src/libduckdb.so*"
+        ./scripts/upload-assets-to-staging.sh github_release duckdb-cli-linux-${{ matrix.config.arch }}.tar.gz duckdb-shared-libs-linux-${{ matrix.config.arch }}.tar.gz
 
     - uses: actions/upload-artifact@v7
       with:
-        name: duckdb-binaries-linux-${{ matrix.config.arch }}
-        path: |
-          libduckdb-linux-${{ matrix.config.arch }}.zip
-          duckdb_cli-linux-${{ matrix.config.arch }}.zip
-          duckdb_cli-linux-${{ matrix.config.arch }}.gz
+        path: duckdb-cli-linux-${{ matrix.config.arch }}.tar.gz
+        archive: false
+
+    - uses: actions/upload-artifact@v7
+      with:
+        path: duckdb-shared-libs-linux-${{ matrix.config.arch }}.tar.gz
+        archive: false
 
     - name: Release tests
       if: ${{ !fromJson(needs.prepare.outputs.skip_tests) }}
@@ -834,18 +835,19 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.S3_DUCKDB_STAGING_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DUCKDB_STAGING_KEY }}
       run: |
-        zip -j duckdb_cli-linux-${{ matrix.config.arch }}-musl.zip build/release/duckdb
-        gzip -9 -k -n -c build/release/duckdb > duckdb_cli-linux-${{ matrix.config.arch }}-musl.gz
-        zip -j libduckdb-linux-${{ matrix.config.arch }}-musl.zip build/release/src/libduckdb*.* src/include/duckdb.h src/include/duckdb_extension.h
-        ./scripts/upload-assets-to-staging.sh github_release libduckdb-linux-${{ matrix.config.arch }}-musl.zip duckdb_cli-linux-${{ matrix.config.arch }}-musl.zip duckdb_cli-linux-${{ matrix.config.arch }}-musl.gz
+        make cli-release-artifact ARTIFACT_SUFFIX=linux-${{ matrix.config.arch }}-musl CLI_BINARY=build/release/duckdb
+        make shared-libs-release-artifact ARTIFACT_SUFFIX=linux-${{ matrix.config.arch }}-musl SHARED_LIBRARIES="build/release/src/libduckdb.so*"
+        ./scripts/upload-assets-to-staging.sh github_release duckdb-cli-linux-${{ matrix.config.arch }}-musl.tar.gz duckdb-shared-libs-linux-${{ matrix.config.arch }}-musl.tar.gz
 
     - uses: actions/upload-artifact@v7
       with:
-        name: duckdb-binaries-linux-${{ matrix.config.arch }}-musl
-        path: |
-          libduckdb-linux-${{ matrix.config.arch }}-musl.zip
-          duckdb_cli-linux-${{ matrix.config.arch }}-musl.zip
-          duckdb_cli-linux-${{ matrix.config.arch }}-musl.gz
+        path: duckdb-cli-linux-${{ matrix.config.arch }}-musl.tar.gz
+        archive: false
+
+    - uses: actions/upload-artifact@v7
+      with:
+        path: duckdb-shared-libs-linux-${{ matrix.config.arch }}-musl.tar.gz
+        archive: false
 
     - name: Test
       if: ${{ !fromJson(needs.prepare.outputs.skip_tests) }}

--- a/.github/workflows/OSX.yml
+++ b/.github/workflows/OSX.yml
@@ -154,28 +154,36 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.S3_DUCKDB_STAGING_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DUCKDB_STAGING_KEY }}
         run: |
-          zip -j -y libduckdb-osx-universal.zip build/release/src/libduckdb*.dylib src/include/duckdb.h src/include/duckdb_extension.h
-
           mkdir build/release_arm64 build/release_amd64
           lipo -extract arm64 -output build/release_arm64/duckdb build/release/duckdb
           lipo -extract x86_64 -output build/release_amd64/duckdb build/release/duckdb
 
-          zip -j duckdb_cli-osx-universal.zip build/release/duckdb
-          zip -j duckdb_cli-osx-arm64.zip build/release_arm64/duckdb
-          zip -j duckdb_cli-osx-amd64.zip build/release_amd64/duckdb
+          make cli-release-artifact ARTIFACT_SUFFIX=osx-universal CLI_BINARY=build/release/duckdb
+          make cli-release-artifact ARTIFACT_SUFFIX=osx-arm64 CLI_BINARY=build/release_arm64/duckdb
+          make cli-release-artifact ARTIFACT_SUFFIX=osx-amd64 CLI_BINARY=build/release_amd64/duckdb
+          make shared-libs-release-artifact ARTIFACT_SUFFIX=osx-universal SHARED_LIBRARIES="build/release/src/libduckdb*.dylib"
 
-          gzip -9 -k -n -c build/release/duckdb > duckdb_cli-osx-universal.gz
-          gzip -9 -k -n -c build/release_arm64/duckdb > duckdb_cli-osx-arm64.gz
-          gzip -9 -k -n -c build/release_amd64/duckdb > duckdb_cli-osx-amd64.gz
-
-          ./scripts/upload-assets-to-staging.sh github_release libduckdb-osx-universal.zip duckdb_cli-osx-universal.zip duckdb_cli-osx-universal.gz duckdb_cli-osx-arm64.zip duckdb_cli-osx-arm64.gz duckdb_cli-osx-amd64.zip duckdb_cli-osx-amd64.gz
+          ./scripts/upload-assets-to-staging.sh github_release duckdb-cli-osx-universal.tar.gz duckdb-cli-osx-arm64.tar.gz duckdb-cli-osx-amd64.tar.gz duckdb-shared-libs-osx-universal.tar.gz
 
       - uses: actions/upload-artifact@v7
         with:
-          name: duckdb-binaries-osx
-          path: |
-            libduckdb-osx-universal.zip
-            duckdb_cli-osx-universal.zip
+          path: duckdb-cli-osx-universal.tar.gz
+          archive: false
+
+      - uses: actions/upload-artifact@v7
+        with:
+          path: duckdb-cli-osx-arm64.tar.gz
+          archive: false
+
+      - uses: actions/upload-artifact@v7
+        with:
+          path: duckdb-cli-osx-amd64.tar.gz
+          archive: false
+
+      - uses: actions/upload-artifact@v7
+        with:
+          path: duckdb-shared-libs-osx-universal.tar.gz
+          archive: false
 
       - name: Unit Test
         shell: bash

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -118,20 +118,19 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.S3_DUCKDB_STAGING_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DUCKDB_STAGING_KEY }}
       run: |
-        "/c/Program Files/7-Zip/7z.exe" a -tzip duckdb_cli-windows-amd64.zip duckdb.exe
-        tmp_zip_dir="$(mktemp -d)"
-        lib_archive_path="$(pwd)/libduckdb-windows-amd64.zip"
-        cp src/duckdb.dll src/duckdb.lib src/include/duckdb.h src/include/duckdb_extension.h "${tmp_zip_dir}/"
-        (cd "${tmp_zip_dir}" && "/c/Program Files/7-Zip/7z.exe" a -tzip "${lib_archive_path}" ./*)
-        rm -rf "${tmp_zip_dir}"
-        ./scripts/upload-assets-to-staging.sh github_release libduckdb-windows-amd64.zip duckdb_cli-windows-amd64.zip
+        make cli-release-artifact ARTIFACT_SUFFIX=windows-amd64 CLI_BINARY=duckdb.exe
+        make shared-libs-release-artifact ARTIFACT_SUFFIX=windows-amd64 SHARED_LIBRARIES="src/duckdb.dll src/duckdb.lib"
+        ./scripts/upload-assets-to-staging.sh github_release duckdb-cli-windows-amd64.tar.gz duckdb-shared-libs-windows-amd64.tar.gz
 
     - uses: actions/upload-artifact@v7
       with:
-        name: duckdb-binaries-windows-amd64
-        path: |
-          libduckdb-windows-amd64.zip
-          duckdb_cli-windows-amd64.zip
+        path: duckdb-cli-windows-amd64.tar.gz
+        archive: false
+
+    - uses: actions/upload-artifact@v7
+      with:
+        path: duckdb-shared-libs-windows-amd64.tar.gz
+        archive: false
 
  win-release-32:
     name: Windows (32 Bit)
@@ -233,20 +232,19 @@ jobs:
          AWS_ACCESS_KEY_ID: ${{ secrets.S3_DUCKDB_STAGING_ID }}
          AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DUCKDB_STAGING_KEY }}
        run: |
-         "/c/Program Files/7-Zip/7z.exe" a -tzip duckdb_cli-windows-arm64.zip duckdb.exe
-         tmp_zip_dir="$(mktemp -d)"
-         lib_archive_path="$(pwd)/libduckdb-windows-arm64.zip"
-         cp src/duckdb.dll src/duckdb.lib src/include/duckdb.h src/include/duckdb_extension.h "${tmp_zip_dir}/"
-         (cd "${tmp_zip_dir}" && "/c/Program Files/7-Zip/7z.exe" a -tzip "${lib_archive_path}" ./*)
-         rm -rf "${tmp_zip_dir}"
-         ./scripts/upload-assets-to-staging.sh github_release libduckdb-windows-arm64.zip duckdb_cli-windows-arm64.zip
+         make cli-release-artifact ARTIFACT_SUFFIX=windows-arm64 CLI_BINARY=duckdb.exe
+         make shared-libs-release-artifact ARTIFACT_SUFFIX=windows-arm64 SHARED_LIBRARIES="src/duckdb.dll src/duckdb.lib"
+         ./scripts/upload-assets-to-staging.sh github_release duckdb-cli-windows-arm64.tar.gz duckdb-shared-libs-windows-arm64.tar.gz
 
      - uses: actions/upload-artifact@v7
        with:
-         name: duckdb-binaries-windows-arm64
-         path: |
-           libduckdb-windows-arm64.zip
-           duckdb_cli-windows-arm64.zip
+         path: duckdb-cli-windows-arm64.tar.gz
+         archive: false
+
+     - uses: actions/upload-artifact@v7
+       with:
+         path: duckdb-shared-libs-windows-arm64.tar.gz
+         archive: false
 
  mingw:
      name: MinGW (64 Bit)
@@ -328,26 +326,3 @@ jobs:
 
        - name: Test
          run: python build/release/test/run.py
-
- win-packaged-upload:
-   runs-on: ${{ fromJSON(inputs.runners).linux_slim || 'ubuntu-latest' }}
-   needs:
-     - win-release-64
-     - win-release-arm64
-   steps:
-    - uses: actions/download-artifact@v8
-      with:
-        name: duckdb-binaries-windows-arm64
-
-    - uses: actions/download-artifact@v8
-      with:
-        name: duckdb-binaries-windows-amd64
-
-    - uses: actions/upload-artifact@v7
-      with:
-        name: duckdb-binaries-windows
-        path: |
-          libduckdb-windows-amd64.zip
-          duckdb_cli-windows-amd64.zip
-          libduckdb-windows-arm64.zip
-          duckdb_cli-windows-arm64.zip

--- a/Makefile
+++ b/Makefile
@@ -652,6 +652,16 @@ relassert-artifact:
 release-artifact:
 	bash scripts/prepare_build_artifact.sh release
 
+.PHONY: cli-release-artifact
+
+cli-release-artifact:
+	bash scripts/package_release_artifact.sh cli "$(ARTIFACT_SUFFIX)" "$(CLI_BINARY)"
+
+.PHONY: shared-libs-release-artifact
+
+shared-libs-release-artifact:
+	bash scripts/package_release_artifact.sh shared-libs "$(ARTIFACT_SUFFIX)" $(SHARED_LIBRARIES)
+
 .PHONY: symbol-checks symbol-leakage-check banned-symbol-check
 
 symbol-checks: symbol-leakage-check banned-symbol-check

--- a/scripts/ci/check_staged_extensions.py
+++ b/scripts/ci/check_staged_extensions.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 
 import argparse
-import gzip
+import io
 import os
 import platform
 import subprocess
 import sys
+import tarfile
 import tempfile
 import time
 import urllib.error
@@ -34,9 +35,9 @@ def cli_asset_name(system: str | None = None, machine: str | None = None) -> str
     arch = normalize_arch(machine or platform.machine())
 
     if system == "linux" and arch in {"amd64", "arm64"}:
-        return f"duckdb_cli-linux-{arch}.gz"
+        return f"duckdb-cli-linux-{arch}.tar.gz"
     if system == "darwin" and arch in {"amd64", "arm64"}:
-        return f"duckdb_cli-osx-{arch}.gz"
+        return f"duckdb-cli-osx-{arch}.tar.gz"
 
     raise RuntimeError(f"unsupported staged CLI platform: {system}/{arch}")
 
@@ -63,6 +64,21 @@ def cli_asset_url(asset_base_url: str, git_sha: str, version: str) -> str:
     return f"{base}/{short_sha}/duckdb/duckdb/github_release/{asset_name}"
 
 
+def extract_cli(archive_bytes: bytes, target: Path) -> None:
+    with tarfile.open(fileobj=io.BytesIO(archive_bytes), mode="r:gz") as archive:
+        members = archive.getmembers()
+        if len(members) != 1 or members[0].name != "duckdb" or not members[0].isfile():
+            raise ValueError("staged CLI archive must contain only a top-level duckdb file")
+
+        source = archive.extractfile(members[0])
+        if source is None:
+            raise ValueError("failed to read duckdb from staged CLI archive")
+        with source, target.open("wb") as destination:
+            destination.write(source.read())
+
+    target.chmod(0o755)
+
+
 def download_cli(url: str, target: Path) -> None:
     last_error: Exception | None = None
     for attempt in range(1, DOWNLOAD_RETRIES + 1):
@@ -70,11 +86,10 @@ def download_cli(url: str, target: Path) -> None:
             print(f"Downloading staged CLI ({attempt}/{DOWNLOAD_RETRIES}): {url}", flush=True)
             request = urllib.request.Request(url, headers={"User-Agent": DOWNLOAD_USER_AGENT})
             with urllib.request.urlopen(request, timeout=60) as response:
-                compressed = response.read()
-            target.write_bytes(gzip.decompress(compressed))
-            target.chmod(0o755)
+                archive_bytes = response.read()
+            extract_cli(archive_bytes, target)
             return
-        except (OSError, urllib.error.URLError, urllib.error.HTTPError) as error:
+        except (OSError, ValueError, tarfile.TarError, urllib.error.URLError, urllib.error.HTTPError) as error:
             last_error = error
             if attempt == DOWNLOAD_RETRIES:
                 break

--- a/scripts/ci/test_check_staged_extensions.py
+++ b/scripts/ci/test_check_staged_extensions.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+
+import io
+import stat
+import sys
+import tarfile
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.ci import check_staged_extensions
+
+
+def create_tarball(members: list[tuple[str, bytes, int]]) -> bytes:
+    archive_buffer = io.BytesIO()
+    with tarfile.open(fileobj=archive_buffer, mode="w:gz") as archive:
+        for name, contents, mode in members:
+            member = tarfile.TarInfo(name)
+            member.size = len(contents)
+            member.mode = mode
+            archive.addfile(member, io.BytesIO(contents))
+    return archive_buffer.getvalue()
+
+
+class CheckStagedExtensionsTest(unittest.TestCase):
+    def test_cli_asset_names(self):
+        self.assertEqual(
+            check_staged_extensions.cli_asset_name("Linux", "x86_64"),
+            "duckdb-cli-linux-amd64.tar.gz",
+        )
+        self.assertEqual(
+            check_staged_extensions.cli_asset_name("Darwin", "arm64"),
+            "duckdb-cli-osx-arm64.tar.gz",
+        )
+
+    def test_extract_cli(self):
+        archive = create_tarball([("duckdb", b"binary", 0o755)])
+        with tempfile.TemporaryDirectory() as temp_dir:
+            target = Path(temp_dir) / "duckdb"
+            check_staged_extensions.extract_cli(archive, target)
+
+            self.assertEqual(target.read_bytes(), b"binary")
+            self.assertTrue(target.stat().st_mode & stat.S_IXUSR)
+
+    def test_extract_cli_rejects_nested_member(self):
+        archive = create_tarball([("directory/duckdb", b"binary", 0o755)])
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with self.assertRaisesRegex(ValueError, "only a top-level duckdb file"):
+                check_staged_extensions.extract_cli(archive, Path(temp_dir) / "duckdb")
+
+    def test_extract_cli_rejects_additional_members(self):
+        archive = create_tarball(
+            [
+                ("duckdb", b"binary", 0o755),
+                ("unexpected", b"contents", 0o644),
+            ]
+        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with self.assertRaisesRegex(ValueError, "only a top-level duckdb file"):
+                check_staged_extensions.extract_cli(archive, Path(temp_dir) / "duckdb")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/test_package_release_artifact.py
+++ b/scripts/ci/test_package_release_artifact.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+
+import os
+import stat
+import subprocess
+import tarfile
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+class PackageReleaseArtifactTest(unittest.TestCase):
+    def run_make(self, target: str, output_dir: Path, **variables: str) -> None:
+        environment = os.environ.copy()
+        environment["ARTIFACT_OUTPUT_DIR"] = str(output_dir)
+        command = ["make", target]
+        command.extend(f"{name}={value}" for name, value in variables.items())
+        subprocess.run(command, cwd=REPO_ROOT, env=environment, check=True, capture_output=True, text=True)
+
+    def test_cli_release_artifact(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            cli = root / "duckdb"
+            cli.write_bytes(b"binary")
+            cli.chmod(0o755)
+
+            self.run_make(
+                "cli-release-artifact",
+                root,
+                ARTIFACT_SUFFIX="linux-amd64",
+                CLI_BINARY=str(cli),
+            )
+
+            archive_path = root / "duckdb-cli-linux-amd64.tar.gz"
+            with tarfile.open(archive_path, mode="r:gz") as archive:
+                members = archive.getmembers()
+                self.assertEqual([member.name for member in members], ["duckdb"])
+                self.assertTrue(members[0].mode & stat.S_IXUSR)
+                self.assertEqual(archive.extractfile(members[0]).read(), b"binary")
+
+    def test_shared_libraries_release_artifact(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            versioned_library = root / "libduckdb.so.1"
+            versioned_library.write_bytes(b"library")
+            library_link = root / "libduckdb.so"
+            library_link.symlink_to(versioned_library.name)
+
+            self.run_make(
+                "shared-libs-release-artifact",
+                root,
+                ARTIFACT_SUFFIX="linux-amd64",
+                SHARED_LIBRARIES=f"{library_link} {versioned_library}",
+            )
+
+            archive_path = root / "duckdb-shared-libs-linux-amd64.tar.gz"
+            with tarfile.open(archive_path, mode="r:gz") as archive:
+                members = {member.name: member for member in archive.getmembers()}
+                self.assertEqual(
+                    set(members),
+                    {"libduckdb.so", "libduckdb.so.1", "duckdb.h", "duckdb_extension.h"},
+                )
+                self.assertTrue(members["libduckdb.so"].issym())
+                self.assertEqual(members["libduckdb.so"].linkname, "libduckdb.so.1")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/package_release_artifact.sh
+++ b/scripts/package_release_artifact.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+	echo "Usage: $0 <cli|shared-libs> <artifact-suffix> <input> [...]" >&2
+	exit 1
+}
+
+if [[ $# -lt 3 ]]; then
+	usage
+fi
+
+artifact_kind="$1"
+artifact_suffix="$2"
+shift 2
+
+if [[ ! "$artifact_suffix" =~ ^[a-z0-9][a-z0-9._-]*$ ]]; then
+	echo "Invalid artifact suffix: $artifact_suffix" >&2
+	exit 1
+fi
+
+case "$artifact_kind" in
+cli)
+	artifact_name="duckdb-cli-${artifact_suffix}.tar.gz"
+	if [[ $# -ne 1 ]]; then
+		usage
+	fi
+	;;
+shared-libs)
+	artifact_name="duckdb-shared-libs-${artifact_suffix}.tar.gz"
+	;;
+*)
+	usage
+	;;
+esac
+
+output_dir="${ARTIFACT_OUTPUT_DIR:-.}"
+if [[ ! -d "$output_dir" ]]; then
+	echo "Artifact output directory does not exist: $output_dir" >&2
+	exit 1
+fi
+
+staging_dir="$(mktemp -d "${TMPDIR:-/tmp}/duckdb-release-artifact.XXXXXX")"
+temporary_archive="$(mktemp "${output_dir}/.duckdb-release-artifact.XXXXXX")"
+cleanup() {
+	rm -rf "$staging_dir"
+	rm -f "$temporary_archive"
+}
+trap cleanup EXIT
+
+members=()
+stage_file() {
+	local source_path="$1"
+	local member_name
+	member_name="$(basename "$source_path")"
+
+	if [[ ! -e "$source_path" && ! -L "$source_path" ]]; then
+		echo "Release artifact input does not exist: $source_path" >&2
+		exit 1
+	fi
+	if [[ -e "$staging_dir/$member_name" || -L "$staging_dir/$member_name" ]]; then
+		echo "Duplicate release artifact member: $member_name" >&2
+		exit 1
+	fi
+
+	cp -Pp "$source_path" "$staging_dir/$member_name"
+	members+=("$member_name")
+}
+
+if [[ "$artifact_kind" == "cli" ]]; then
+	cli_name="$(basename "$1")"
+	if [[ "$cli_name" != "duckdb" && "$cli_name" != "duckdb.exe" ]]; then
+		echo "CLI input must be named duckdb or duckdb.exe: $1" >&2
+		exit 1
+	fi
+	stage_file "$1"
+else
+	for library in "$@"; do
+		stage_file "$library"
+	done
+
+	script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+	repository_root="$(cd "$script_dir/.." && pwd)"
+	stage_file "$repository_root/src/include/duckdb.h"
+	stage_file "$repository_root/src/include/duckdb_extension.h"
+fi
+
+tar -C "$staging_dir" -czf "$temporary_archive" "${members[@]}"
+mv "$temporary_archive" "$output_dir/$artifact_name"
+
+echo "Created $output_dir/$artifact_name"
+tar -tzf "$output_dir/$artifact_name"


### PR DESCRIPTION
### Context

Currently we have to perform multiple steps:
```shell
curl -fsSL https://artifacts.duckdb.org/latest/duckdb-binaries-linux-amd64.zip -o /tmp/o.zip
unzip -p /tmp/o.zip duckdb_cli-linux-amd64.zip > /tmp/inner.zip
unzip -p /tmp/inner.zip duckdb > /tmp/duckdb
chmod +x /tmp/duckdb
```
to get a duckdb CLI from a github artifacts file.

I would like to do something like:
```
curl -fsSL https://artifacts.duckdb.org/latest/duckdb-cli-linux-amd64.tar.gz -o- | tar xf -
```
and get the CLI with execute permissions in the work directory.

Fixes: https://github.com/duckdblabs/duckdb-internal/issues/9512.

### Changes

- Upload an already compressed tarball as github artifact (without wrapping it in a zip file using `archive: false`).
- Split CLI and shared libraries into two tarballs (`cli` and `shared-libs`).

### After merging:
- [x] Update links in [duckdb-web/install/preview.md](https://github.com/duckdb/duckdb-web/blob/37c18d765599fe17126c94816e0fe3c39615189a/install/preview.md?plain=1#L34).
- [ ] Update docker and nightly [workflows](https://github.com/search?q=org%3Aduckdblabs+duckdb-binaries&type=code).
- [ ] Verify that [staged](https://github.com/duckdb/duckdb/blob/46f811a4300b60ab6c69169cd1fbd2632df92f3d/.github/workflows/StagedUpload.yml#L57) upload still works (`duckdb_cli....gz`, instead of `duckdb-cli-....gz`).
- [x] [Announce](https://discord.com/channels/1129399131933261865/1473711238591545435/1539295504989421588) breaking change on Discord.