### PR TITLE
Add typed_value column to duckdb_settings()

### DIFF
--- a/src/catalog/default/default_table_functions.cpp
+++ b/src/catalog/default/default_table_functions.cpp
@@ -74,7 +74,7 @@ FROM duckdb_logs(denormalized_table=1)
 WHERE type ILIKE log_type
 )"},
 	{DEFAULT_SCHEMA, "duckdb_profiling_settings", {}, {}, R"(
-SELECT * EXCLUDE(input_type, scope, aliases)
+SELECT * EXCLUDE(input_type, scope, aliases, typed_value)
   FROM duckdb_settings()
   WHERE name IN (
       'enable_profiling',

--- a/src/function/table/system/duckdb_settings.cpp
+++ b/src/function/table/system/duckdb_settings.cpp
@@ -34,9 +34,6 @@ static unique_ptr<FunctionData> DuckDBSettingsBind(ClientContext &context, Table
 	names.emplace_back("value");
 	return_types.emplace_back(LogicalType::VARCHAR);
 
-	names.emplace_back("typed_value");
-	return_types.emplace_back(LogicalType::VARIANT());
-
 	names.emplace_back("description");
 	return_types.emplace_back(LogicalType::VARCHAR);
 
@@ -48,6 +45,9 @@ static unique_ptr<FunctionData> DuckDBSettingsBind(ClientContext &context, Table
 
 	names.emplace_back("aliases");
 	return_types.emplace_back(LogicalType::LIST(LogicalType::VARCHAR));
+
+	names.emplace_back("typed_value");
+	return_types.emplace_back(LogicalType::VARIANT());
 
 	return nullptr;
 }

--- a/src/function/table/system/duckdb_settings.cpp
+++ b/src/function/table/system/duckdb_settings.cpp
@@ -138,7 +138,6 @@ void DuckDBSettingsFunction(ClientContext &context, TableFunctionInput &data_p, 
 	auto &aliases = output.data[5];
 	// value, LogicalType::VARIANT
 	auto &typed_value = output.data[6];
-	
 
 	while (data.offset < data.settings.size() && count < STANDARD_VECTOR_SIZE) {
 		auto &entry = data.settings[data.offset++];

--- a/src/function/table/system/duckdb_settings.cpp
+++ b/src/function/table/system/duckdb_settings.cpp
@@ -34,6 +34,9 @@ static unique_ptr<FunctionData> DuckDBSettingsBind(ClientContext &context, Table
 	names.emplace_back("value");
 	return_types.emplace_back(LogicalType::VARCHAR);
 
+	names.emplace_back("typed_value");
+	return_types.emplace_back(LogicalType::VARIANT());
+
 	names.emplace_back("description");
 	return_types.emplace_back(LogicalType::VARCHAR);
 
@@ -125,20 +128,23 @@ void DuckDBSettingsFunction(ClientContext &context, TableFunctionInput &data_p, 
 	auto &name = output.data[0];
 	// value, LogicalType::VARCHAR
 	auto &value = output.data[1];
+	// value, LogicalType::VARIANT
+	auto &typed_value = output.data[2];
 	// description, LogicalType::VARCHAR
-	auto &description = output.data[2];
+	auto &description = output.data[3];
 	// input_type, LogicalType::VARCHAR
-	auto &input_type = output.data[3];
+	auto &input_type = output.data[4];
 	// scope, LogicalType::VARCHAR
-	auto &scope = output.data[4];
+	auto &scope = output.data[5];
 	// aliases, LogicalType::VARCHAR[]
-	auto &aliases = output.data[5];
+	auto &aliases = output.data[6];
 
 	while (data.offset < data.settings.size() && count < STANDARD_VECTOR_SIZE) {
 		auto &entry = data.settings[data.offset++];
 
 		name.Append(Value(entry.name));
 		value.Append(entry.value.CastAs(context, LogicalType::VARCHAR));
+		typed_value.Append(entry.value.CastAs(context, LogicalType::VARIANT()));
 		description.Append(Value(entry.description));
 		input_type.Append(Value(entry.input_type));
 		scope.Append(Value(entry.scope));

--- a/src/function/table/system/duckdb_settings.cpp
+++ b/src/function/table/system/duckdb_settings.cpp
@@ -128,27 +128,28 @@ void DuckDBSettingsFunction(ClientContext &context, TableFunctionInput &data_p, 
 	auto &name = output.data[0];
 	// value, LogicalType::VARCHAR
 	auto &value = output.data[1];
-	// value, LogicalType::VARIANT
-	auto &typed_value = output.data[2];
 	// description, LogicalType::VARCHAR
-	auto &description = output.data[3];
+	auto &description = output.data[2];
 	// input_type, LogicalType::VARCHAR
-	auto &input_type = output.data[4];
+	auto &input_type = output.data[3];
 	// scope, LogicalType::VARCHAR
-	auto &scope = output.data[5];
+	auto &scope = output.data[4];
 	// aliases, LogicalType::VARCHAR[]
-	auto &aliases = output.data[6];
+	auto &aliases = output.data[5];
+	// value, LogicalType::VARIANT
+	auto &typed_value = output.data[6];
+	
 
 	while (data.offset < data.settings.size() && count < STANDARD_VECTOR_SIZE) {
 		auto &entry = data.settings[data.offset++];
 
 		name.Append(Value(entry.name));
 		value.Append(entry.value.CastAs(context, LogicalType::VARCHAR));
-		typed_value.Append(entry.value.CastAs(context, LogicalType::VARIANT()));
 		description.Append(Value(entry.description));
 		input_type.Append(Value(entry.input_type));
 		scope.Append(Value(entry.scope));
 		aliases.Append(Value::LIST(LogicalType::VARCHAR, std::move(entry.aliases)));
+		typed_value.Append(entry.value.CastAs(context, LogicalType::VARIANT()));
 		count++;
 	}
 }

--- a/test/sql/pragma/profiling/test_duckdb_profiling_settings_function.test
+++ b/test/sql/pragma/profiling/test_duckdb_profiling_settings_function.test
@@ -3,7 +3,7 @@
 # group: [profiling]
 
 query I
-SELECT * EXCLUDE(value, description) FROM duckdb_profiling_settings();
+SELECT * EXCLUDE(value, typed_value, description) FROM duckdb_profiling_settings();
 ----
 enable_profiling
 profiling_coverage

--- a/test/sql/pragma/profiling/test_duckdb_profiling_settings_function.test
+++ b/test/sql/pragma/profiling/test_duckdb_profiling_settings_function.test
@@ -3,7 +3,7 @@
 # group: [profiling]
 
 query I
-SELECT * EXCLUDE(value, typed_value, description) FROM duckdb_profiling_settings();
+SELECT * EXCLUDE(value, description) FROM duckdb_profiling_settings();
 ----
 enable_profiling
 profiling_coverage

--- a/test/sql/table_function/duckdb_settings.test
+++ b/test/sql/table_function/duckdb_settings.test
@@ -20,3 +20,8 @@ query II
 SELECT name, value FROM duckdb_settings() WHERE name='default_null_order';
 ----
 default_null_order	NULLS_LAST
+
+query I
+SELECT COUNT(DISTINCT variant_typeof(typed_value)) > 1 FROM duckdb_settings();
+----
+true

--- a/test/sql/table_function/duckdb_settings.test
+++ b/test/sql/table_function/duckdb_settings.test
@@ -25,3 +25,23 @@ query I
 SELECT COUNT(DISTINCT variant_typeof(typed_value)) > 1 FROM duckdb_settings();
 ----
 true
+
+query III
+SELECT
+    typeof(value),
+    typeof(typed_value),
+    variant_typeof(typed_value)
+FROM duckdb_settings()
+WHERE name = 'standard_vector_size';
+----
+VARCHAR	VARIANT	UINT64
+
+query III
+SELECT
+    typeof(value),
+    typeof(typed_value),
+    variant_typeof(typed_value)
+FROM duckdb_settings()
+WHERE name = 'logging_level';
+----
+VARCHAR	VARIANT	VARCHAR


### PR DESCRIPTION
Added an extra **typed_value** column to output of **duckdb_settings()** with column type variant (issue [#6949](https://github.com/duckdblabs/duckdb-internal/issues/6949)) + test.