### PR TITLE
Fix case restoration for mismatched case column references

### DIFF
--- a/src/planner/bind_context.cpp
+++ b/src/planner/bind_context.cpp
@@ -244,7 +244,7 @@ unique_ptr<ParsedExpression> BindContext::CreateColumnReference(const BindingAli
 		return ExpandGeneratedColumn(binding->Cast<TableBinding>(), column_name);
 	}
 	auto &registered_name = binding->GetRegisteredColumnName(column_name);
-	if (registered_name != column_name) {
+	if (registered_name.GetIdentifierName() != column_name.GetIdentifierName()) {
 		// because of case insensitivity in the binder we rename the column to the original name
 		// as it appears in the binding itself
 		result->SetAlias(registered_name);
@@ -286,7 +286,7 @@ unique_ptr<ParsedExpression> BindContext::CreateColumnReference(const Identifier
 		return ExpandGeneratedColumn(binding->Cast<TableBinding>(), column_name);
 	}
 	auto &registered_name = binding->GetRegisteredColumnName(column_name);
-	if (registered_name != column_name) {
+	if (registered_name.GetIdentifierName() != column_name.GetIdentifierName()) {
 		// because of case insensitivity in the binder we rename the column to the original name
 		// as it appears in the binding itself
 		result->SetAlias(registered_name);

--- a/test/sql/binder/test_case_insensitive_binding.test
+++ b/test/sql/binder/test_case_insensitive_binding.test
@@ -138,3 +138,30 @@ query I
 SELECT hello FROM (SELECT 42) tbl("HeLlO")
 ----
 42
+
+statement ok
+CREATE TABLE case_test(MixedCase INTEGER);
+
+statement ok
+CREATE TABLE case_output AS
+SELECT mixedcase
+FROM case_test;
+
+query I
+SELECT column_name
+FROM duckdb_columns()
+WHERE table_name = 'case_output';
+----
+MixedCase
+
+statement ok
+CREATE TABLE case_alias_output AS
+SELECT mixedcase AS custom_name
+FROM case_test;
+
+query I
+SELECT column_name
+FROM duckdb_columns()
+WHERE table_name = 'case_alias_output';
+----
+custom_name


### PR DESCRIPTION
Fixes #24759.

Since the `Identifier` class was recently refactored to use case-insensitive equality, `registered_name != column_name` no longer detects identifiers that differ only by case. This skipped the alias-restoration logic for non-aliased column references, causing output schemas to use the user's typed case instead of the catalog spelling.

This PR uses a strict string comparison, `registered_name.GetIdentifierName() != column_name.GetIdentifierName()`, for this  specific output-name check while preserving case-insensitive identifier lookup behavior.