### PR TITLE
Fix #24781: do not merge common subplans of scans that cannot serialize their identity

### DIFF
--- a/src/optimizer/common_subplan_optimizer.cpp
+++ b/src/optimizer/common_subplan_optimizer.cpp
@@ -568,7 +568,6 @@ private:
 		case LogicalOperatorType::LOGICAL_TOP_N:
 		case LogicalOperatorType::LOGICAL_DISTINCT:
 		case LogicalOperatorType::LOGICAL_PIVOT:
-		case LogicalOperatorType::LOGICAL_GET:
 		case LogicalOperatorType::LOGICAL_EXPRESSION_GET:
 		case LogicalOperatorType::LOGICAL_DUMMY_SCAN:
 		case LogicalOperatorType::LOGICAL_COMPARISON_JOIN:
@@ -580,6 +579,18 @@ private:
 		case LogicalOperatorType::LOGICAL_EXCEPT:
 		case LogicalOperatorType::LOGICAL_INTERSECT:
 			return true;
+		case LogicalOperatorType::LOGICAL_GET: {
+			auto &get = op.Cast<LogicalGet>();
+			if (get.bind_data && !get.function.HasSerializationCallbacks() && get.parameters.empty() &&
+			    get.named_parameters.empty()) {
+				// Without serialization callbacks, the serialized form carries only the call parameters
+				// (see LogicalGet::Serialize). A parameter-less scan - e.g., one created through an
+				// attached catalog - keeps its identity solely in the bind data, so equal serialized
+				// bytes cannot prove that two scans read the same table.
+				return false;
+			}
+			return true;
+		}
 		case LogicalOperatorType::LOGICAL_CHUNK_GET:
 			// Avoid serializing massive amounts of data (this is here because of the "Test TPCH arrow roundtrip" test)
 			return op.Cast<LogicalColumnDataGet>().collection->Count() < 1000;


### PR DESCRIPTION
Fixes #24781 (silent wrong results: scans of different attached-SQLite tables with identical column layouts merged into one subplan).

## Root cause

`CommonSubplanOptimizer` compares subplans by serialized bytes (`PlanSignature`). For a table function **without serialization callbacks**, `LogicalGet::Serialize` falls back to writing the call `parameters` / `named_parameters` "for rebinding purposes", and `FunctionSerializer::Serialize` writes only the function name and argument types. A **parameter-less** scan — e.g. one created through an attached catalog via `TableCatalogEntry::GetScanFunction` — therefore serializes nothing that identifies *what* it scans: the file and table name live solely in the bind data. Two such scans over same-shape tables produce identical bytes and are merged, and the query silently returns one table's rows for both.

The gate that was supposed to catch this, `LogicalGet::SupportSerialization()`, answers a different question: its no-callback arm (`function.bind && bind_data->SupportStatementCache()`) is a *rebinding* contract, and `FunctionData::SupportStatementCache()` defaults to `true` — so "serializable enough to rebind" was being used as "serialized bytes capture identity", which does not hold when there are no parameters to rebind from.

This also explains the observed boundaries in #24781: column *names* discriminate (they are serialized), the source *file* does not (bind-data-only), direct `sqlite_scan('file','table')` calls are unaffected (parameters serialize), and native tables are unaffected (serialization callbacks present).

## Fix

`OperatorIsSupported` refuses merge-eligibility for a `LogicalGet` that carries bind data, has no serialization callbacks, and has no parameters — the exact case where equal bytes cannot prove equal scans. Strictly conservative: it only declines an optimization, and in-tree functions (which carry serialization callbacks) keep merging — verified that e.g. two `duckdb_tables()` subqueries still merge, while two attached-SQLite scans no longer do.

## Testing

- Built against `duckdb-sqlite` (the extension statically linked): the issue's repro flips from `f=2, v=2` / both subqueries returning the flows' ids to the correct `f=2, v=3` / per-table ids, and `EXPLAIN` shows two distinct `SQLITE_SCAN`s instead of one scan behind a shared materialized CTE.
- Full fast suite on the patched build: **all tests passed, 242,686 assertions in 4,074 test cases** (skips only for absent extensions/env).
- `test/optimizer/pullup_filters.test`, `test/optimizer/projection_pullup.test`, `test/sql/optimizer/test_common_subplan_cte_binding_order.test`, `test/sql/optimizer/test_common_subplan_projection_maps.test` pass on this branch's build.
- The sqlite extension's `test/sql/storage/*` (906 assertions) and `test/sql/scanner/*` (1,908 assertions) suites pass against the patched core.
- A sqllogictest covering the collision shapes (scalar-subquery pair, `string_agg` contents, `UNION ALL` arms) is proposed to `duckdb-sqlite`, since the trigger needs an extension catalog: duckdb/duckdb-sqlite — companion PR referenced there.

An alternative, less conservative fix would be to serialize the catalog identity (`GetTable()`) in the no-callback fallback of `LogicalGet::Serialize`, which would preserve merging for genuinely-identical catalog scans — I avoided it here because it changes the serialized plan format. Happy to rework in that direction if preferred.