### PR TITLE
Fix unused residual collection consuming must-apply cost predicates

### DIFF
--- a/src/optimizer/join_order/query_graph_manager.cpp
+++ b/src/optimizer/join_order/query_graph_manager.cpp
@@ -716,11 +716,14 @@ GenerateJoinRelation QueryGraphManager::GenerateJoins(vector<unique_ptr<LogicalO
 	result_operator->has_estimated_cardinality = true;
 
 	// Collect unused residual predicates that belong to this join. Semantic non-inner joins own their complete
-	// condition directly, so only ordinary (notably INNER) residual predicates reach this path.
+	// condition directly, so only ordinary (notably INNER) residual predicates reach this path. Predicates that
+	// belong to a must-apply operator occurrence are consumed by that occurrence during reconstruction, instead
+	// of being added to unused_residual_predicates.
 	vector<unique_ptr<Expression>> unused_residual_predicates;
 	for (auto &filter_info : filters_and_bindings) {
 		if (filter_info->from_residual_predicate && filters_and_bindings[filter_info->filter_index]->filter &&
-		    filter_info->set.get().count > 0 && JoinRelationSet::IsSubset(*result_relation, filter_info->set)) {
+		    !operator_costing_predicates.count(filter_info->filter_index) && filter_info->set.get().count > 0 &&
+		    JoinRelationSet::IsSubset(*result_relation, filter_info->set)) {
 			unused_residual_predicates.push_back(std::move(filters_and_bindings[filter_info->filter_index]->filter));
 		}
 	}

--- a/test/optimizer/joins/test_must_apply_residual_predicate.test
+++ b/test/optimizer/joins/test_must_apply_residual_predicate.test
@@ -1,0 +1,67 @@
+# name: test/optimizer/joins/test_must_apply_residual_predicate.test
+# description: Residual predicate belonging to a must-apply join operator must not be consumed as an unused residual (issue 24690)
+# group: [joins]
+
+statement ok
+CREATE TABLE e1(x INTEGER)
+
+statement ok
+CREATE TABLE e2(x INTEGER)
+
+statement ok
+CREATE TABLE e3(x INTEGER)
+
+statement ok
+CREATE TABLE e4(x INTEGER)
+
+query I
+SELECT count(*)
+FROM e1 LEFT JOIN e2 ON (e1.x = e2.x)
+        RIGHT JOIN e3 ON (e1.x = e3.x AND e3.x > 0), e4
+WHERE e4.x = e1.x
+----
+0
+
+query I
+SELECT count(*)
+FROM e1 LEFT JOIN e2 ON (e1.x = e2.x)
+        RIGHT JOIN e3 ON (e1.x = e3.x AND e3.x IS NOT NULL), e4
+WHERE e4.x = e1.x
+----
+0
+
+query I
+SELECT count(*)
+FROM e4, e1 LEFT JOIN e2 ON (e1.x = e2.x)
+        RIGHT JOIN e3 ON (e1.x = e3.x AND e3.x > 0)
+WHERE e4.x = e1.x
+----
+0
+
+query I
+SELECT count(*)
+FROM e1 LEFT JOIN e2 ON (e1.x = e2.x)
+        RIGHT JOIN e3 ON (e1.x = e3.x AND e3.x > 0), e4
+WHERE e4.x < e1.x
+----
+0
+
+statement ok
+CREATE TABLE t1 AS SELECT i AS x FROM range(4) s(i)
+
+statement ok
+CREATE TABLE t2 AS SELECT i AS x FROM range(9) s(i)
+
+statement ok
+CREATE TABLE t3 AS SELECT i AS x FROM range(7) s(i)
+
+statement ok
+CREATE TABLE t4 AS SELECT i AS x FROM range(3) s(i)
+
+query I
+SELECT count(*)
+FROM t1 LEFT JOIN t2 ON (t1.x = t2.x)
+        RIGHT JOIN t3 ON (t1.x = t3.x AND t3.x > 1), t4
+WHERE t4.x = t1.x
+----
+1


### PR DESCRIPTION
fixes: #24690

The unused-residual collection in `GenerateJoins` also collected residual predicates that belong
to a must-apply operator occurrence (its cost predicates), so the occurrence could no longer
consume them during reconstruction, failing with `INTERNAL Error: Cost predicate 2 was consumed
before operator occurrence 1`.

The collection now skips predicates registered in `operator_costing_predicates`.

Test: new `test/sql/join/test_must_apply_residual_predicate.test` with the issue's repro, the
variants from the issue that trigger the same error (non-comparison single-sided term, correlated
relation listed first, non-equality correlation), and the populated-data case (expected 1).