### PR TITLE
Fix join order reconstruction for cross products spanning three or more relations

### DIFF
--- a/src/optimizer/join_order/query_graph_manager.cpp
+++ b/src/optimizer/join_order/query_graph_manager.cpp
@@ -620,7 +620,8 @@ GenerateJoinRelation QueryGraphManager::GenerateJoins(vector<unique_ptr<LogicalO
 				throw InternalException("Could not orient operator occurrence %llu in reconstructed join tree",
 				                        descriptor->index);
 			}
-			if (!reconstructed_operators.insert(descriptor->index).second) {
+			if (descriptor->type != JoinOrderOperatorType::CROSS_PRODUCT &&
+			    !reconstructed_operators.insert(descriptor->index).second) {
 				throw InternalException("Operator occurrence %llu was reconstructed more than once", descriptor->index);
 			}
 

--- a/test/optimizer/joins/single_sided_predicate_reconstruction.test
+++ b/test/optimizer/joins/single_sided_predicate_reconstruction.test
@@ -1,0 +1,51 @@
+# name: test/optimizer/joins/single_sided_predicate_reconstruction.test
+# description: Join-order reconstruction must not fail when a cross-product spans more than two relations
+# group: [joins]
+
+statement ok
+CREATE TABLE a1 AS SELECT i AS x FROM range(8) s(i);
+
+statement ok
+CREATE TABLE b1 AS SELECT i AS x FROM range(8) s(i);
+
+statement ok
+CREATE TABLE c1 AS SELECT i AS x FROM range(16) s(i);
+
+statement ok
+CREATE TABLE d1 AS SELECT i AS x FROM range(8) s(i);
+
+# c1's join predicate only references c1, not d1, so the join is really an
+# unfiltered cross product between {a1,b1} and {c1,d1}.
+query I
+SELECT count(*) FROM a1, b1, c1 INNER JOIN d1 ON (c1.x > 0);
+----
+7680
+
+statement ok
+CREATE TABLE a2 AS SELECT i AS x FROM range(5) s(i);
+
+statement ok
+CREATE TABLE b2 AS SELECT i AS x FROM range(7) s(i);
+
+statement ok
+CREATE TABLE c2 AS SELECT i AS x FROM range(10) s(i);
+
+statement ok
+CREATE TABLE d2 AS SELECT i AS x FROM range(6) s(i);
+
+# Same shape with different, asymmetric cardinalities so the optimizer's cost
+# model is free to pick a different bushy plan than the first case.
+query I
+SELECT count(*) FROM a2, b2, c2 INNER JOIN d2 ON (c2.x > 3);
+----
+1260
+
+statement ok
+CREATE TABLE e3 AS SELECT i AS x FROM range(4) s(i);
+
+# A fifth relation widens the cross product further, stressing the same
+# reconstruction path with a larger connected component.
+query I
+SELECT count(*) FROM a2, b2, e3, c2 INNER JOIN d2 ON (c2.x >= 4);
+----
+5040


### PR DESCRIPTION
## Problem

A query whose INNER JOIN ON predicate only references one side of the join produces a cross product in the join graph rather than a comparison join. When that cross product's hyperedges connect a group of three or more relations, the dynamic programming search in the join order optimizer can legitimately place more than one join in the reconstructed plan tree under the same JoinOrderOperator descriptor. The existing reconstruction check assumed every descriptor is used exactly once and raised "Operator occurrence N was reconstructed more than once" for these queries.

Reproduction:

```sql
CREATE TABLE a AS SELECT i AS x FROM range(8) s(i);
CREATE TABLE b AS SELECT i AS x FROM range(8) s(i);
CREATE TABLE c AS SELECT i AS x FROM range(16) s(i);
CREATE TABLE d AS SELECT i AS x FROM range(8) s(i);

SELECT 1 FROM a, b, c INNER JOIN d ON (c.x > 0);
```

## Fix

The uniqueness check in QueryGraphManager::GenerateJoins now only applies to descriptors that must appear exactly once in the reconstructed tree (LEFT/SEMI/ANTI/constrained INNER joins). CROSS_PRODUCT descriptors are exempted, since query graph construction can fan a single cross product descriptor out across several relation pair edges, and the DP search can legitimately reuse it more than once when reconstructing a bushy plan.

## Testing

Added test/optimizer/joins/single_sided_predicate_reconstruction.test, covering the original repro, a variant with different relation cardinalities, and a five relation variant, so the fix holds across cross products of varying width rather than one specific shape.

Fixes #24615