### PR TITLE
Implement VACUUM FULL using COPY FROM DATABASE

### DIFF
--- a/src/function/table/CMakeLists.txt
+++ b/src/function/table/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library_unity(
   arrow.cpp
   arrow_conversion.cpp
   checkpoint.cpp
+  vacuum_full.cpp
   direct_file_reader.cpp
   glob.cpp
   query_function.cpp

--- a/src/function/table/range.cpp
+++ b/src/function/table/range.cpp
@@ -438,6 +438,7 @@ void RangeTableFunction::RegisterFunction(BuiltinFunctions &set) {
 
 void BuiltinFunctions::RegisterTableFunctions() {
 	CheckpointFunction::RegisterFunction(*this);
+	VacuumFullFunction::RegisterFunction(*this);
 	GlobTableFunction::RegisterFunction(*this);
 	RangeTableFunction::RegisterFunction(*this);
 	RepeatTableFunction::RegisterFunction(*this);

--- a/src/function/table/vacuum_full.cpp
+++ b/src/function/table/vacuum_full.cpp
@@ -1,0 +1,246 @@
+#include "duckdb/function/table/range.hpp"
+
+#include "duckdb/catalog/catalog_search_path.hpp"
+#include "duckdb/common/enums/on_entry_not_found.hpp"
+#include "duckdb/common/error_data.hpp"
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/file_system.hpp"
+#include "duckdb/common/sql_identifier.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/common/types/uuid.hpp"
+#include "duckdb/function/function_set.hpp"
+#include "duckdb/main/attached_database.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/main/client_data.hpp"
+#include "duckdb/main/config.hpp"
+#include "duckdb/main/connection.hpp"
+#include "duckdb/main/database.hpp"
+#include "duckdb/main/database_manager.hpp"
+#include "duckdb/parser/parsed_data/attach_info.hpp"
+#include "duckdb/storage/storage_manager.hpp"
+
+namespace duckdb {
+
+struct VacuumFullBindData : public FunctionData {
+	explicit VacuumFullBindData(Identifier db_name_p) : db_name(std::move(db_name_p)) {
+	}
+
+	Identifier db_name;
+
+public:
+	unique_ptr<FunctionData> Copy() const override {
+		return make_uniq<VacuumFullBindData>(db_name);
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = other_p.Cast<VacuumFullBindData>();
+		return db_name == other.db_name;
+	}
+};
+
+static Identifier ResolveVacuumFullTarget(ClientContext &context, DatabaseManager &db_manager) {
+	auto current_name = DatabaseManager::GetDefaultDatabase(context);
+	auto current = db_manager.GetDatabase(current_name);
+	if (current && current->HasStorageManager() && !current->GetStorageManager().InMemory()) {
+		return current_name;
+	}
+	Identifier found;
+	idx_t persistent_count = 0;
+	for (auto &db : db_manager.GetDatabases()) {
+		if (db->IsSystem() || db->IsTemporary()) {
+			continue;
+		}
+		if (!db->HasStorageManager() || db->GetStorageManager().InMemory()) {
+			continue;
+		}
+		found = db->GetName();
+		persistent_count++;
+	}
+	if (persistent_count == 1) {
+		return found;
+	}
+	if (persistent_count > 1) {
+		throw InvalidInputException(
+		    "VACUUM FULL requires the current database to be persistent, or exactly one persistent database to be "
+		    "attached");
+	}
+	throw NotImplementedException("VACUUM FULL is only supported for persistent databases");
+}
+
+static unique_ptr<FunctionData> VacuumFullBind(ClientContext &context, TableFunctionBindInput &input,
+                                               vector<LogicalType> &return_types, vector<Identifier> &names) {
+	return_types.emplace_back(LogicalType::BOOLEAN);
+	names.emplace_back("Success");
+	auto &db_manager = DatabaseManager::Get(context);
+	return make_uniq<VacuumFullBindData>(ResolveVacuumFullTarget(context, db_manager));
+}
+
+static Identifier UniqueAttachedName(DatabaseManager &db_manager, const string &prefix) {
+	Identifier candidate(prefix);
+	if (!db_manager.GetDatabase(candidate)) {
+		return candidate;
+	}
+	return Identifier(prefix + "_" + UUID::ToString(UUID::GenerateRandomUUID()));
+}
+
+static void RunVacuumFullSQL(DatabaseInstance &instance, const string &sql) {
+	Connection con(instance);
+	auto result = con.Query(sql);
+	if (result->HasError()) {
+		result->ThrowError();
+	}
+}
+
+static void RestoreSearchPath(CatalogSearchPath &search_path, const vector<CatalogSearchEntry> &previous_paths) {
+	if (previous_paths.empty()) {
+		search_path.Reset();
+	} else {
+		search_path.Set(previous_paths, CatalogSetPathType::SET_DIRECTLY);
+	}
+}
+
+static void AttachFileDatabase(ClientContext &context, DatabaseManager &db_manager, const Identifier &name,
+                               const string &path) {
+	AttachInfo info;
+	info.name = name;
+	info.path = path;
+	AttachOptions options(DBConfig::GetConfig(context).options);
+	options.access_mode = AccessMode::READ_WRITE;
+	db_manager.AttachDatabase(context, info, options);
+}
+
+static void TryDetach(ClientContext &context, DatabaseManager &db_manager, const Identifier &name) {
+	if (name.empty()) {
+		return;
+	}
+	db_manager.DetachDatabase(context, name, OnEntryNotFound::RETURN_NULL);
+}
+
+static void TryRemoveDBFiles(FileSystem &fs, const string &path) {
+	fs.TryRemoveFile(path);
+	fs.TryRemoveFile(path + ".wal");
+}
+
+static void VacuumFullFunctionInternal(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &bind_data = data_p.bind_data->Cast<VacuumFullBindData>();
+	auto &db_manager = DatabaseManager::Get(context);
+	auto attached = db_manager.GetDatabase(bind_data.db_name);
+	if (!attached) {
+		throw BinderException("Database \"%s\" not found", bind_data.db_name);
+	}
+	if (!attached->HasStorageManager() || attached->GetStorageManager().InMemory()) {
+		throw NotImplementedException("VACUUM FULL is only supported for persistent databases");
+	}
+	if (attached->IsReadOnly()) {
+		throw InvalidInputException("Cannot run VACUUM FULL on a read-only database");
+	}
+	if (attached->GetStorageManager().IsEncrypted()) {
+		throw NotImplementedException("VACUUM FULL is not yet implemented for encrypted databases");
+	}
+
+	const auto path = attached->GetStorageManager().GetDBPath();
+	const auto wal_path = attached->GetStorageManager().GetWALPath();
+	const auto checkpoint_wal_path = attached->GetStorageManager().GetCheckpointWALPath();
+	const auto recovery_wal_path = attached->GetStorageManager().GetRecoveryWALPath();
+	attached.reset();
+
+	auto tmp_alias = UniqueAttachedName(db_manager, "__vacuum_full_target");
+	auto tmp_path = path + ".vacuum_full.tmp";
+	auto backup_path = path + ".vacuum_full.bak";
+	auto &fs = FileSystem::GetFileSystem(context);
+	TryRemoveDBFiles(fs, tmp_path);
+	TryRemoveDBFiles(fs, backup_path);
+
+	Identifier fallback;
+	for (auto &db : db_manager.GetDatabases()) {
+		if (db->IsSystem() || db->IsTemporary()) {
+			continue;
+		}
+		if (db->GetName() == bind_data.db_name) {
+			continue;
+		}
+		fallback = db->GetName();
+		break;
+	}
+
+	string copy_sql;
+	copy_sql += "CHECKPOINT " + SQLIdentifier(bind_data.db_name) + ";\n";
+	copy_sql += "ATTACH " + SQLString(tmp_path) + " AS " + SQLIdentifier(tmp_alias) + ";\n";
+	copy_sql += "COPY FROM DATABASE " + SQLIdentifier(bind_data.db_name) + " TO " + SQLIdentifier(tmp_alias) + ";\n";
+	copy_sql += "DETACH " + SQLIdentifier(tmp_alias) + ";";
+	try {
+		RunVacuumFullSQL(DatabaseInstance::GetDatabase(context), copy_sql);
+	} catch (...) {
+		TryDetach(context, db_manager, tmp_alias);
+		TryRemoveDBFiles(fs, tmp_path);
+		throw;
+	}
+
+	bool created_fallback = false;
+	if (fallback.empty()) {
+		fallback = UniqueAttachedName(db_manager, "__vacuum_full_switch");
+		AttachInfo mem_info;
+		mem_info.name = fallback;
+		mem_info.path = ":memory:";
+		AttachOptions mem_options(DBConfig::GetConfig(context).options);
+		db_manager.AttachDatabase(context, mem_info, mem_options);
+		created_fallback = true;
+	}
+
+	auto &search_path = *ClientData::Get(context).catalog_search_path;
+	auto previous_paths = search_path.GetSetPaths();
+	search_path.Set(CatalogSearchEntry(fallback, Identifier::DefaultSchema()), CatalogSetPathType::SET_DIRECTLY);
+
+	ErrorData error;
+	try {
+		db_manager.DetachDatabase(context, bind_data.db_name, OnEntryNotFound::THROW_EXCEPTION);
+		if (fs.FileExists(path)) {
+			fs.MoveFile(path, backup_path);
+		}
+		fs.MoveFile(tmp_path, path);
+		fs.TryRemoveFile(tmp_path + ".wal");
+		fs.TryRemoveFile(wal_path);
+		fs.TryRemoveFile(checkpoint_wal_path);
+		fs.TryRemoveFile(recovery_wal_path);
+		AttachFileDatabase(context, db_manager, bind_data.db_name, path);
+	} catch (const std::exception &ex) {
+		error = ErrorData(ex);
+	}
+
+	if (error.HasError()) {
+		if (fs.FileExists(path) && fs.FileExists(backup_path)) {
+			TryRemoveDBFiles(fs, path);
+		}
+		if (!fs.FileExists(path) && fs.FileExists(backup_path)) {
+			fs.MoveFile(backup_path, path);
+		}
+		TryRemoveDBFiles(fs, tmp_path);
+		if (!db_manager.GetDatabase(bind_data.db_name) && fs.FileExists(path)) {
+			try {
+				AttachFileDatabase(context, db_manager, bind_data.db_name, path);
+			} catch (...) {
+			}
+		}
+		RestoreSearchPath(search_path, previous_paths);
+		if (created_fallback) {
+			TryDetach(context, db_manager, fallback);
+		}
+		error.Throw();
+	}
+
+	try {
+		TryRemoveDBFiles(fs, backup_path);
+	} catch (...) {
+	}
+	RestoreSearchPath(search_path, previous_paths);
+	if (created_fallback) {
+		TryDetach(context, db_manager, fallback);
+	}
+}
+
+void VacuumFullFunction::RegisterFunction(BuiltinFunctions &set) {
+	TableFunction vacuum_full("vacuum_full", {}, VacuumFullFunctionInternal, VacuumFullBind);
+	set.AddFunction(vacuum_full);
+}
+
+} // namespace duckdb

--- a/src/include/duckdb/function/table/range.hpp
+++ b/src/include/duckdb/function/table/range.hpp
@@ -17,6 +17,10 @@ struct CheckpointFunction {
 	static void RegisterFunction(BuiltinFunctions &set);
 };
 
+struct VacuumFullFunction {
+	static void RegisterFunction(BuiltinFunctions &set);
+};
+
 struct GlobTableFunction {
 	static void RegisterFunction(BuiltinFunctions &set);
 };

--- a/src/include/duckdb/parser/parsed_data/vacuum_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/vacuum_info.hpp
@@ -17,11 +17,12 @@ class Serializer;
 class Deserializer;
 
 struct VacuumOptions {
-	VacuumOptions() : vacuum(false), analyze(false) {
+	VacuumOptions() : vacuum(false), analyze(false), full(false) {
 	}
 
 	bool vacuum;
 	bool analyze;
+	bool full;
 
 	void Serialize(Serializer &serializer) const;
 	static VacuumOptions Deserialize(Deserializer &deserializer);

--- a/src/parser/peg/transformer/transform_vacuum.cpp
+++ b/src/parser/peg/transformer/transform_vacuum.cpp
@@ -1,7 +1,19 @@
 #include "duckdb/parser/peg/transformer/peg_transformer.hpp"
+#include "duckdb/parser/expression/function_expression.hpp"
+#include "duckdb/parser/statement/call_statement.hpp"
 #include "duckdb/parser/statement/vacuum_statement.hpp"
 
 namespace duckdb {
+
+static unique_ptr<SQLStatement> TransformVacuumFullCall() {
+	auto result = make_uniq<CallStatement>();
+	vector<unique_ptr<ParsedExpression>> children;
+	auto function = make_uniq<FunctionExpression>("vacuum_full", std::move(children));
+	function->SetQualifiedName(
+	    QualifiedName(Identifier(SYSTEM_CATALOG), Identifier(DEFAULT_SCHEMA), function->GetQualifiedName().Name()));
+	result->function = std::move(function);
+	return std::move(result);
+}
 
 unique_ptr<SQLStatement> PEGTransformerFactory::TransformVacuumStatement(PEGTransformer &transformer,
                                                                          const optional<VacuumOptions> &vacuum_options,
@@ -9,6 +21,15 @@ unique_ptr<SQLStatement> PEGTransformerFactory::TransformVacuumStatement(PEGTran
 	VacuumOptions options;
 	if (vacuum_options) {
 		options = *vacuum_options;
+	}
+	if (options.full) {
+		if (options.analyze) {
+			throw NotImplementedException("VACUUM FULL ANALYZE is not yet implemented");
+		}
+		if (analyze_target && analyze_target->ref) {
+			throw NotImplementedException("VACUUM FULL with a table name is not yet implemented");
+		}
+		return TransformVacuumFullCall();
 	}
 	auto result = make_uniq<VacuumStatement>(options);
 	if (analyze_target && analyze_target->ref) {
@@ -28,7 +49,7 @@ VacuumOptions PEGTransformerFactory::TransformVacuumLegacyOptions(PEGTransformer
 	options.vacuum = true;
 	options.analyze = opt_analyze.has_value();
 	if (opt_full) {
-		throw NotImplementedException("FULL is not yet implemented");
+		options.full = true;
 	}
 	if (opt_freeze) {
 		throw NotImplementedException("FREEZE is not yet implemented");
@@ -51,7 +72,8 @@ VacuumOptions PEGTransformerFactory::TransformVacuumParensOptions(PEGTransformer
 			throw NotImplementedException("FREEZE is not yet implemented");
 		}
 		if (StringUtil::CIEquals(option, "full")) {
-			throw NotImplementedException("FULL is not yet implemented");
+			options.full = true;
+			continue;
 		}
 		if (StringUtil::CIEquals(option, "verbose")) {
 			throw NotImplementedException("VERBOSE is not yet implemented");

--- a/test/sql/vacuum/vacuum_full.test
+++ b/test/sql/vacuum/vacuum_full.test
@@ -1,0 +1,110 @@
+# name: test/sql/vacuum/vacuum_full.test
+# description: VACUUM FULL reclaims file space via COPY FROM DATABASE on a table without FKs
+# group: [vacuum]
+
+# in-memory databases have no file to compact
+statement error
+VACUUM FULL
+----
+persistent
+
+statement ok
+ATTACH '{TEST_DIR}/vacuum_full_a.db' AS a
+
+statement ok
+ATTACH '{TEST_DIR}/vacuum_full_b.db' AS b
+
+statement error
+VACUUM FULL
+----
+exactly one
+
+statement ok
+DETACH a
+
+statement ok
+DETACH b
+
+statement ok
+ATTACH '{TEST_DIR}/vacuum_full.db' AS src
+
+statement ok
+CREATE TABLE src.t AS SELECT range AS i, md5(range::VARCHAR) AS s FROM range(200000)
+
+statement ok
+CHECKPOINT src
+
+statement ok
+DELETE FROM src.t WHERE i >= 20
+
+statement ok
+CHECKPOINT src
+
+statement ok
+CREATE TABLE sizes AS SELECT total_blocks AS before_blocks FROM pragma_database_size() WHERE database_name = 'src'
+
+query I
+SELECT before_blocks > 5 FROM sizes
+----
+true
+
+# Stay on memory so the current transaction does not pin src; FULL targets the only persistent DB.
+statement ok
+VACUUM FULL
+
+query I
+SELECT count(*) FROM src.t
+----
+20
+
+query II
+SELECT min(i), max(i) FROM src.t
+----
+0	19
+
+query I
+SELECT total_blocks < (SELECT before_blocks FROM sizes) FROM pragma_database_size() WHERE database_name = 'src'
+----
+true
+
+# already-compact databases still accept FULL / parenthesized FULL
+statement ok
+VACUUM (FULL)
+
+statement error
+VACUUM FULL t
+----
+table name
+
+statement error
+VACUUM FULL ANALYZE
+----
+ANALYZE
+
+statement error
+VACUUM (FULL, ANALYZE)
+----
+ANALYZE
+
+# compacting an encrypted catalog would write plaintext; reject before attaching a temp file
+statement ok
+DETACH src
+
+statement ok
+SET force_mbedtls_unsafe = true
+
+statement ok
+ATTACH '{TEST_DIR}/vacuum_full_enc.db' AS enc (ENCRYPTION_KEY 'asdf')
+
+statement ok
+CREATE TABLE enc.t(i INT)
+
+statement error
+VACUUM FULL
+----
+encrypted
+
+query I
+SELECT count(*) FROM glob('{TEST_DIR}/vacuum_full_enc.db.vacuum_full.tmp')
+----
+0


### PR DESCRIPTION
## Summary

Implements `VACUUM FULL` for #21154 by rewriting it to `CALL vacuum_full()`, which checkpoints the target file database, copies it with `COPY FROM DATABASE`, and replaces the original file with the compacted copy. That matches the approach suggested on the issue (do not do in-place index vacuum).

The target is the current database when it is persistent, or the only attached file database when the session is still on `memory`. Encrypted catalogs, `VACUUM FULL ANALYZE`, and `VACUUM FULL <table>` are rejected. If more than one file database is attached and the current database is not a file, FULL errors instead of picking one at random. Foreign-key catalogs still go through `COPY FROM DATABASE`, including the existing `copy_database_fk.test` hole.

## Test plan

```bash
GEN=ninja make reldebug
build/reldebug/test/unittest test/sql/vacuum/vacuum_full.test
build/reldebug/test/unittest "test/sql/copy_database/*"
build/reldebug/test/unittest "test/sql/vacuum/*"
```

Local reldebug run: `vacuum_full.test` 28 assertions pass; `test/sql/vacuum/*` 64 assertions pass; `test/sql/copy_database/*` 10 cases pass (`copy_database_fk.test` remains `mode skip instable`).
