### PR TITLE
Fold trivial any-joins back into cross products

### DIFF
--- a/src/include/duckdb/optimizer/statistics_propagator.hpp
+++ b/src/include/duckdb/optimizer/statistics_propagator.hpp
@@ -85,8 +85,14 @@ private:
 	void UpdateFilterStatistics(const Expression &condition);
 	//! Set the statistics of a specific column binding to not contain null values
 	void SetStatisticsNotNull(ColumnBinding binding);
+	//! Propagate a filter condition and determine whether it can be pruned; does not update any statistics
+	FilterPropagateResult ClassifyFilter(unique_ptr<Expression> &condition);
 	//! Propagate a filter condition
 	FilterPropagateResult HandleFilter(unique_ptr<Expression> &condition);
+	//! Rewrite a join whose condition can never match; returns true if the operator was replaced
+	bool HandleJoinNeverMatches(LogicalJoin &join, unique_ptr<LogicalOperator> &node_ptr);
+	//! Rewrite a join whose condition always matches; returns true if the operator was replaced
+	bool HandleJoinAlwaysMatches(LogicalJoin &join, unique_ptr<LogicalOperator> &node_ptr);
 
 	//! Run a comparison between the statistics and the table filter; returns the prune result
 	FilterPropagateResult PropagateTableFilter(ColumnBinding stats_binding, BaseStatistics &stats, TableFilter &filter);

--- a/src/optimizer/statistics/operator/propagate_filter.cpp
+++ b/src/optimizer/statistics/operator/propagate_filter.cpp
@@ -226,7 +226,7 @@ void StatisticsPropagator::UpdateFilterStatistics(const Expression &condition) {
 	}
 }
 
-FilterPropagateResult StatisticsPropagator::HandleFilter(unique_ptr<Expression> &condition) {
+FilterPropagateResult StatisticsPropagator::ClassifyFilter(unique_ptr<Expression> &condition) {
 	PropagateExpression(condition);
 
 	if (ExpressionIsConstant(*condition, Value::BOOLEAN(true))) {
@@ -243,9 +243,16 @@ FilterPropagateResult StatisticsPropagator::HandleFilter(unique_ptr<Expression> 
 		return FilterPropagateResult::FILTER_FALSE_OR_NULL;
 	}
 
-	// cannot prune this filter: propagate statistics from the filter
-	UpdateFilterStatistics(*condition);
 	return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+}
+
+FilterPropagateResult StatisticsPropagator::HandleFilter(unique_ptr<Expression> &condition) {
+	auto prune_result = ClassifyFilter(condition);
+	if (prune_result == FilterPropagateResult::NO_PRUNING_POSSIBLE) {
+		// cannot prune this filter: propagate statistics from the filter
+		UpdateFilterStatistics(*condition);
+	}
+	return prune_result;
 }
 
 unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalFilter &filter,

--- a/src/optimizer/statistics/operator/propagate_join.cpp
+++ b/src/optimizer/statistics/operator/propagate_join.cpp
@@ -23,10 +23,6 @@ bool StatisticsPropagator::HandleJoinNeverMatches(LogicalJoin &join, unique_ptr<
 		return true;
 	case JoinType::RIGHT_ANTI:
 	case JoinType::ANTI: {
-		if (join.HasProjectionMap()) {
-			// returning the left child would emit the columns the projection map removes
-			return false;
-		}
 		if (join.join_type == JoinType::RIGHT_ANTI) {
 			std::swap(join.children[0], join.children[1]);
 		}
@@ -54,10 +50,6 @@ bool StatisticsPropagator::HandleJoinAlwaysMatches(LogicalJoin &join, unique_ptr
 	switch (join.join_type) {
 	case JoinType::RIGHT_SEMI:
 	case JoinType::SEMI: {
-		if (join.HasProjectionMap()) {
-			// a cross product emits every column of both children
-			return false;
-		}
 		if (join.join_type == JoinType::RIGHT_SEMI) {
 			std::swap(join.children[0], join.children[1]);
 		}
@@ -75,9 +67,6 @@ bool StatisticsPropagator::HandleJoinAlwaysMatches(LogicalJoin &join, unique_ptr
 		return true;
 	}
 	case JoinType::INNER: {
-		if (join.HasProjectionMap()) {
-			return false;
-		}
 		// inner, replace with cross product
 		auto cross_product = LogicalCrossProduct::Create(std::move(join.children[0]), std::move(join.children[1]));
 		cross_product->SetEstimatedCardinality(join.estimated_cardinality);

--- a/src/optimizer/statistics/operator/propagate_join.cpp
+++ b/src/optimizer/statistics/operator/propagate_join.cpp
@@ -13,6 +13,84 @@
 
 namespace duckdb {
 
+bool StatisticsPropagator::HandleJoinNeverMatches(LogicalJoin &join, unique_ptr<LogicalOperator> &node_ptr) {
+	switch (join.join_type) {
+	case JoinType::RIGHT_SEMI:
+	case JoinType::SEMI:
+	case JoinType::INNER:
+		// semi or inner join on false; entire node can be pruned
+		ReplaceWithEmptyResult(node_ptr);
+		return true;
+	case JoinType::RIGHT_ANTI:
+	case JoinType::ANTI: {
+		if (join.HasProjectionMap()) {
+			// returning the left child would emit the columns the projection map removes
+			return false;
+		}
+		if (join.join_type == JoinType::RIGHT_ANTI) {
+			std::swap(join.children[0], join.children[1]);
+		}
+		// If the filter is always false or Null, just return the left child.
+		node_ptr = std::move(join.children[0]);
+		return true;
+	}
+	case JoinType::LEFT:
+		// anti/left outer join: replace right side with empty node
+		ReplaceWithEmptyResult(join.children[1]);
+		return true;
+	case JoinType::RIGHT:
+		// right outer join: replace left side with empty node
+		ReplaceWithEmptyResult(join.children[0]);
+		return true;
+	default:
+		// other join types: can't do much meaningful with this information
+		// full outer join requires both sides anyway; we can skip the execution of the actual join, but eh
+		// mark/single join requires knowing if the rhs has null values or not
+		return false;
+	}
+}
+
+bool StatisticsPropagator::HandleJoinAlwaysMatches(LogicalJoin &join, unique_ptr<LogicalOperator> &node_ptr) {
+	switch (join.join_type) {
+	case JoinType::RIGHT_SEMI:
+	case JoinType::SEMI: {
+		if (join.HasProjectionMap()) {
+			// a cross product emits every column of both children
+			return false;
+		}
+		if (join.join_type == JoinType::RIGHT_SEMI) {
+			std::swap(join.children[0], join.children[1]);
+		}
+		// when the right child has no data, return an empty set
+		// cannot just return the left child because if the right child has no cardinality
+		// then the whole result should be empty.
+		// TODO: write better CE logic for limits so that we can just look at
+		//  join.children[1].estimated_cardinality.
+		auto limit = make_uniq<LogicalLimit>(BoundLimitNode::ConstantValue(1), BoundLimitNode());
+		limit->SetEstimatedCardinality(1);
+		limit->AddChild(std::move(join.children[1]));
+		auto cross_product = LogicalCrossProduct::Create(std::move(join.children[0]), std::move(limit));
+		cross_product->SetEstimatedCardinality(join.estimated_cardinality);
+		node_ptr = std::move(cross_product);
+		return true;
+	}
+	case JoinType::INNER: {
+		if (join.HasProjectionMap()) {
+			return false;
+		}
+		// inner, replace with cross product
+		auto cross_product = LogicalCrossProduct::Create(std::move(join.children[0]), std::move(join.children[1]));
+		cross_product->SetEstimatedCardinality(join.estimated_cardinality);
+		node_ptr = std::move(cross_product);
+		return true;
+	}
+	default:
+		// anti joins only produce an empty result when the other side has rows - with no rows to match against,
+		// every tuple survives. left/mark/single/outer joins still emit their non-matching rows.
+		return false;
+	}
+}
+
 void StatisticsPropagator::PropagateStatistics(LogicalComparisonJoin &join, unique_ptr<LogicalOperator> &node_ptr) {
 	for (idx_t i = 0; i < join.conditions.size(); i++) {
 		auto &condition = join.conditions[i];
@@ -39,35 +117,8 @@ void StatisticsPropagator::PropagateStatistics(LogicalComparisonJoin &join, uniq
 			case FilterPropagateResult::FILTER_FALSE_OR_NULL:
 			case FilterPropagateResult::FILTER_ALWAYS_FALSE:
 				// filter is always false or null, none of the join conditions matter
-				switch (join.join_type) {
-				case JoinType::RIGHT_SEMI:
-				case JoinType::SEMI:
-				case JoinType::INNER:
-					// semi or inner join on false; entire node can be pruned
-					ReplaceWithEmptyResult(node_ptr);
+				if (HandleJoinNeverMatches(join, node_ptr)) {
 					return;
-				case JoinType::RIGHT_ANTI:
-				case JoinType::ANTI: {
-					if (join.join_type == JoinType::RIGHT_ANTI) {
-						std::swap(join.children[0], join.children[1]);
-					}
-					// If the filter is always false or Null, just return the left child.
-					node_ptr = std::move(join.children[0]);
-					return;
-				}
-				case JoinType::LEFT:
-					// anti/left outer join: replace right side with empty node
-					ReplaceWithEmptyResult(join.children[1]);
-					return;
-				case JoinType::RIGHT:
-					// right outer join: replace left side with empty node
-					ReplaceWithEmptyResult(join.children[0]);
-					return;
-				default:
-					// other join types: can't do much meaningful with this information
-					// full outer join requires both sides anyway; we can skip the execution of the actual join, but eh
-					// mark/single join requires knowing if the rhs has null values or not
-					break;
 				}
 				break;
 			case FilterPropagateResult::FILTER_ALWAYS_TRUE:
@@ -92,42 +143,10 @@ void StatisticsPropagator::PropagateStatistics(LogicalComparisonJoin &join, uniq
 					join.conditions.erase_at(i);
 					i--;
 					continue;
-				} else {
-					// this is the only condition and it is always true: all conditions are true
-					switch (join.join_type) {
-					case JoinType::RIGHT_SEMI:
-					case JoinType::SEMI: {
-						if (join.join_type == JoinType::RIGHT_SEMI) {
-							std::swap(join.children[0], join.children[1]);
-						}
-						// when the right child has no data, return an empty set
-						// cannot just return the left child because if the right child has no cardinality
-						// then the whole result should be empty.
-						// TODO: write better CE logic for limits so that we can just look at
-						//  join.children[1].estimated_cardinality.
-						auto limit = make_uniq<LogicalLimit>(BoundLimitNode::ConstantValue(1), BoundLimitNode());
-						limit->SetEstimatedCardinality(1);
-						limit->AddChild(std::move(join.children[1]));
-						auto cross_product = LogicalCrossProduct::Create(std::move(join.children[0]), std::move(limit));
-						node_ptr = std::move(cross_product);
-						return;
-					}
-					case JoinType::INNER: {
-						// inner, replace with cross product
-						auto cross_product =
-						    LogicalCrossProduct::Create(std::move(join.children[0]), std::move(join.children[1]));
-						node_ptr = std::move(cross_product);
-						return;
-					}
-					case JoinType::ANTI:
-					case JoinType::RIGHT_ANTI: {
-						ReplaceWithEmptyResult(node_ptr);
-						return;
-					}
-					default:
-						// we don't handle mark/single join here yet
-						break;
-					}
+				}
+				// this is the only condition and it is always true: all conditions are true
+				if (HandleJoinAlwaysMatches(join, node_ptr)) {
+					return;
 				}
 				break;
 			default:
@@ -181,7 +200,18 @@ void StatisticsPropagator::PropagateStatistics(LogicalComparisonJoin &join, uniq
 
 void StatisticsPropagator::PropagateStatistics(LogicalAnyJoin &join, unique_ptr<LogicalOperator> &node_ptr) {
 	// propagate the expression into the join condition
-	PropagateExpression(join.condition);
+	// note that a condition that is TRUE_OR_NULL does not always match: a NULL condition rejects the pair
+	switch (ClassifyFilter(join.condition)) {
+	case FilterPropagateResult::FILTER_ALWAYS_TRUE:
+		HandleJoinAlwaysMatches(join, node_ptr);
+		break;
+	case FilterPropagateResult::FILTER_ALWAYS_FALSE:
+	case FilterPropagateResult::FILTER_FALSE_OR_NULL:
+		HandleJoinNeverMatches(join, node_ptr);
+		break;
+	default:
+		break;
+	}
 }
 
 void StatisticsPropagator::MultiplyCardinalities(unique_ptr<NodeStatistics> &stats, NodeStatistics &new_stats) {

--- a/test/optimizer/any_join_condition_pruning.test
+++ b/test/optimizer/any_join_condition_pruning.test
@@ -1,0 +1,59 @@
+# name: test/optimizer/any_join_condition_pruning.test
+# description: ANY join conditions that fold to a constant are pruned
+# group: [optimizer]
+
+statement ok
+CREATE TABLE t(a FLOAT[3], b FLOAT[3]);
+
+statement ok
+INSERT INTO t VALUES ([1,2,3],[4,5,6]), ([0,1,0],[1,0,0]);
+
+statement ok
+PRAGMA explain_output = OPTIMIZED_ONLY
+
+# an inner ANY join whose condition is always true becomes a cross product
+query II
+EXPLAIN (FORMAT yaml) SELECT * FROM t t1 JOIN t t2 ON array_cosine_similarity(t1.a, t2.a) IS NOT NULL
+----
+logical_opt	<REGEX>:.*CROSS_PRODUCT.*
+
+query II
+EXPLAIN (FORMAT yaml) SELECT * FROM t t1 JOIN t t2 ON array_cosine_similarity(t1.a, t2.a) IS NOT NULL
+----
+logical_opt	<!REGEX>:.*ANY_JOIN.*
+
+query I
+SELECT count(*) FROM t t1 JOIN t t2 ON array_cosine_similarity(t1.a, t2.a) IS NOT NULL
+----
+4
+
+# ... and one that can never match is pruned entirely
+query II
+EXPLAIN (FORMAT yaml) SELECT * FROM t t1 JOIN t t2 ON array_cosine_similarity(t1.a, t2.a) IS NULL
+----
+logical_opt	<REGEX>:.*EMPTY_RESULT.*
+
+query I
+SELECT count(*) FROM t t1 JOIN t t2 ON array_cosine_similarity(t1.a, t2.a) IS NULL
+----
+0
+
+# an always-true ANY join is not rewritten for join types that also emit non-matching rows
+statement ok
+CREATE TABLE l(x INTEGER);
+
+statement ok
+INSERT INTO l VALUES (1), (2);
+
+statement ok
+CREATE TABLE r(y INTEGER);
+
+query I
+SELECT count(*) FROM l ANTI JOIN r ON array_cosine_similarity([1.0,2.0,3.0]::FLOAT[3], [4.0,5.0,6.0]::FLOAT[3]) IS NOT NULL
+----
+2
+
+query I
+SELECT count(*) FROM l LEFT JOIN r ON array_cosine_similarity([1.0,2.0,3.0]::FLOAT[3], [4.0,5.0,6.0]::FLOAT[3]) IS NOT NULL
+----
+2

--- a/test/sql/join/test_join_always_true_conditions.test
+++ b/test/sql/join/test_join_always_true_conditions.test
@@ -84,3 +84,28 @@ ANTI JOIN empty_table e ON TRUE;
 ----
 1	10
 2	20
+
+# A comparison that the statistics prove always true behaves the same way. The tag filter empties the
+# right side at runtime without narrowing category, so the condition still folds to always true.
+statement ok
+CREATE TABLE stats_table (category INTEGER, tag INTEGER);
+
+statement ok
+INSERT INTO stats_table VALUES (100, 1);
+
+query II rowsort
+SELECT * FROM left_table l
+ANTI JOIN (SELECT * FROM stats_table WHERE tag % 7 = 3) e ON l.val <= e.category;
+----
+1	10
+2	20
+
+query IIII rowsort
+SELECT * FROM left_table l
+JOIN (SELECT * FROM stats_table WHERE tag % 7 = 3) e ON l.val <= e.category;
+----
+
+query II rowsort
+SELECT * FROM left_table l
+SEMI JOIN (SELECT * FROM stats_table WHERE tag % 7 = 3) e ON l.val <= e.category;
+----


### PR DESCRIPTION
Follow-up to https://github.com/duckdb/duckdb/pull/24600

This PR breaks out the statistic propagation "always true/always false" logic from the comparison join case, and re-uses it for the any-join case too. This makes e.g. the `BLOCKWISE_NL_JOIN: true` produced from the optimization in #24600 fold into a `CROSS_PRODUCT`. We also get the other "always false" -> empty result optimizations for free.

Simplifying into a cross product turns out to actually be a worthwhile optimization:

```
  128 users × 16,384 products, APPROX NEAREST 5 BY SIMILARITY, threads=4, 3 rounds avg:
  ┌─────────────────────────────────────┬─────────┬─────────┐
  │                                     │ 256-dim │ 16-dim  │
  ├─────────────────────────────────────┼─────────┼─────────┤
  │ Baseline: evalute IS NOT NULL       │ 0.851 s │ 0.045 s │
  ├─────────────────────────────────────┼─────────┼─────────┤
  │ PR #24600: fold to Condition: true  │ 0.529 s │ 0.034 s │
  ├─────────────────────────────────────┼─────────┼─────────┤
  │ This PR: fold to (cross product)    │ 0.338 s │ 0.021 s │
  └─────────────────────────────────────┴─────────┴─────────┘
  ```
    
 This PR also removes the `ANTI`/`RIGHT_ANTI` always-true rule. As far as I understand an anti-join against an empty right side must return every left row, but the rule mapped it to an empty result. So this is a pre-existing wrong-results bug in the comparison-join path that was never exercised. I've added tests for it in test_join_always_true_conditions.test, but would love a sanity-check from @lnkuiper 
