### PR TITLE
Add column_keys support for Parquet modular encryption

### DIFF
--- a/extension/parquet/column_reader.cpp
+++ b/extension/parquet/column_reader.cpp
@@ -35,6 +35,7 @@
 #include "duckdb/common/enums/vector_type.hpp"
 #include "duckdb/common/limits.hpp"
 #include "duckdb/common/string.hpp"
+#include "duckdb/common/string_util.hpp"
 #include "duckdb/common/types/date.hpp"
 #include "duckdb/common/types/datetime.hpp"
 #include "duckdb/common/types/timestamp.hpp"
@@ -272,12 +273,26 @@ void ColumnReader::InitializeRead(idx_t row_group_idx_p, idx_t row_group_num_row
 	ValidateColumnMetadata(row_group_num_rows, *chunk);
 	group_rows_available = NumericCast<idx_t>(chunk->meta_data.num_values);
 
-	// Determine per-column decryption key
 	if (reader.parquet_options.encryption_config) {
 		auto &enc_config = *reader.parquet_options.encryption_config;
 		if (chunk->__isset.crypto_metadata && chunk->crypto_metadata.__isset.ENCRYPTION_WITH_COLUMN_KEY) {
-			auto &path = chunk->crypto_metadata.ENCRYPTION_WITH_COLUMN_KEY.path_in_schema;
-			string col_name = path.empty() ? column_schema.name : path[0];
+			auto &column_key_metadata = chunk->crypto_metadata.ENCRYPTION_WITH_COLUMN_KEY;
+			auto &path = column_key_metadata.path_in_schema;
+			auto column_path = path.empty() ? column_schema.name : StringUtil::Join(path, ".");
+			auto col_name = path.empty() ? column_schema.name : path[0];
+			if (!enc_config.HasColumnKey(col_name)) {
+				throw InvalidInputException("No column key was provided for encrypted Parquet column \"%s\"",
+				                            column_path);
+			}
+			if (column_key_metadata.__isset.key_metadata) {
+				auto &expected_key_name = column_key_metadata.key_metadata;
+				auto &provided_key_name = enc_config.GetColumnKeyName(col_name);
+				if (expected_key_name != provided_key_name) {
+					throw InvalidInputException(
+					    "Encrypted Parquet column \"%s\" requires key \"%s\", but encryption_config assigns key \"%s\"",
+					    column_path, expected_key_name, provided_key_name);
+				}
+			}
 			column_encryption_key = enc_config.GetColumnKey(col_name);
 		} else {
 			column_encryption_key = enc_config.GetFooterKey();

--- a/extension/parquet/column_reader.cpp
+++ b/extension/parquet/column_reader.cpp
@@ -271,6 +271,18 @@ void ColumnReader::InitializeRead(idx_t row_group_idx_p, idx_t row_group_num_row
 	}
 	ValidateColumnMetadata(row_group_num_rows, *chunk);
 	group_rows_available = NumericCast<idx_t>(chunk->meta_data.num_values);
+
+	// Determine per-column decryption key
+	if (reader.parquet_options.encryption_config) {
+		auto &enc_config = *reader.parquet_options.encryption_config;
+		if (chunk->__isset.crypto_metadata && chunk->crypto_metadata.__isset.ENCRYPTION_WITH_COLUMN_KEY) {
+			auto &path = chunk->crypto_metadata.ENCRYPTION_WITH_COLUMN_KEY.path_in_schema;
+			string col_name = path.empty() ? column_schema.name : path[0];
+			column_encryption_key = enc_config.GetColumnKey(col_name);
+		} else {
+			column_encryption_key = enc_config.GetFooterKey();
+		}
+	}
 }
 
 bool ColumnReader::PageIsFilteredOut(PageHeader &page_hdr, optional_ptr<const TableFilter> filter) {
@@ -324,14 +336,22 @@ void ColumnReader::ReadEncrypted(duckdb_apache::thrift::TBase &object) {
 	aad_crypto_metadata.module = ParquetCrypto::GetModuleHeader(*chunk, aad_crypto_metadata.page_ordinal);
 	aad_crypto_metadata.page_ordinal =
 	    ParquetCrypto::GetFinalPageOrdinal(*chunk, aad_crypto_metadata.module, aad_crypto_metadata.page_ordinal);
-	reader.ReadEncrypted(object, *protocol, aad_crypto_metadata);
+	if (!column_encryption_key.empty()) {
+		reader.ReadEncrypted(object, *protocol, aad_crypto_metadata, column_encryption_key);
+	} else {
+		reader.ReadEncrypted(object, *protocol, aad_crypto_metadata);
+	}
 }
 
 void ColumnReader::ReadDataEncrypted(const data_ptr_t buffer, const uint32_t buffer_size, PageType::type page_type) {
 	aad_crypto_metadata.module = ParquetCrypto::GetModule(*chunk, page_type, aad_crypto_metadata.page_ordinal);
 	aad_crypto_metadata.page_ordinal =
 	    ParquetCrypto::GetFinalPageOrdinal(*chunk, aad_crypto_metadata.module, aad_crypto_metadata.page_ordinal);
-	reader.ReadDataEncrypted(*protocol, buffer, buffer_size, aad_crypto_metadata);
+	if (!column_encryption_key.empty()) {
+		reader.ReadDataEncrypted(*protocol, buffer, buffer_size, aad_crypto_metadata, column_encryption_key);
+	} else {
+		reader.ReadDataEncrypted(*protocol, buffer, buffer_size, aad_crypto_metadata);
+	}
 }
 
 void ColumnReader::Read(PageHeader &page_hdr) {

--- a/extension/parquet/include/column_reader.hpp
+++ b/extension/parquet/include/column_reader.hpp
@@ -405,6 +405,8 @@ private:
 	DeltaByteArrayDecoder delta_byte_array_decoder;
 	ByteStreamSplitDecoder byte_stream_split_decoder;
 	CryptoMetaData aad_crypto_metadata;
+	//! Per-column decryption key (set during InitializeRead if the column has a dedicated key)
+	string column_encryption_key;
 
 	//! Resizeable buffers used for the various encodings above
 	ResizeableBuffer encoding_buffers[2];

--- a/extension/parquet/include/parquet.json
+++ b/extension/parquet/include/parquet.json
@@ -68,6 +68,11 @@
         "id": 101,
         "name": "column_keys",
         "type": "unordered_map<string, string>"
+      },
+      {
+        "id": 102,
+        "name": "column_key_names",
+        "type": "unordered_map<string, string>"
       }
     ],
     "pointer_type": "shared_ptr"

--- a/extension/parquet/include/parquet_crypto.hpp
+++ b/extension/parquet/include/parquet_crypto.hpp
@@ -115,6 +115,9 @@ public:
 public:
 	static shared_ptr<ParquetEncryptionConfig> Create(ClientContext &context, const Value &arg);
 	const string &GetFooterKey() const;
+	const string &GetColumnKey(const string &column_name) const;
+	bool HasColumnKey(const string &column_name) const;
+	void ValidateColumnNames(const vector<string> &column_names) const;
 
 public:
 	void Serialize(Serializer &serializer) const;

--- a/extension/parquet/include/parquet_crypto.hpp
+++ b/extension/parquet/include/parquet_crypto.hpp
@@ -116,8 +116,9 @@ public:
 	static shared_ptr<ParquetEncryptionConfig> Create(ClientContext &context, const Value &arg);
 	const string &GetFooterKey() const;
 	const string &GetColumnKey(const string &column_name) const;
+	const string &GetColumnKeyName(const string &column_name) const;
 	bool HasColumnKey(const string &column_name) const;
-	void ValidateColumnNames(const vector<string> &column_names) const;
+	void ValidateColumnNames(const vector<string> &column_names);
 
 public:
 	void Serialize(Serializer &serializer) const;
@@ -126,8 +127,10 @@ public:
 private:
 	//! The encryption key used for the footer
 	string footer_key;
-	//! Mapping from column name to key name
+	//! Mapping from normalized top-level column name to key bytes
 	unordered_map<string, string> column_keys;
+	//! Mapping from normalized top-level column name to key name
+	unordered_map<string, string> column_key_names;
 };
 
 class ParquetCrypto {

--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -378,10 +378,15 @@ public:
 	uint32_t Read(duckdb_apache::thrift::TBase &object, TProtocol &iprot) const;
 	uint32_t ReadEncrypted(duckdb_apache::thrift::TBase &object, TProtocol &iprot,
 	                       CryptoMetaData &aad_crypto_metadata) const;
+	uint32_t ReadEncrypted(duckdb_apache::thrift::TBase &object, TProtocol &iprot, CryptoMetaData &aad_crypto_metadata,
+	                       const string &key) const;
 	uint32_t ReadData(duckdb_apache::thrift::protocol::TProtocol &iprot, const data_ptr_t buffer,
 	                  const uint32_t buffer_size) const;
 	uint32_t ReadDataEncrypted(duckdb_apache::thrift::protocol::TProtocol &iprot, const data_ptr_t buffer,
 	                           const uint32_t buffer_size, CryptoMetaData &aad_crypto_metadata) const;
+	uint32_t ReadDataEncrypted(duckdb_apache::thrift::protocol::TProtocol &iprot, const data_ptr_t buffer,
+	                           const uint32_t buffer_size, CryptoMetaData &aad_crypto_metadata,
+	                           const string &key) const;
 
 	unique_ptr<BaseStatistics> ReadStatistics(const Identifier &name);
 

--- a/extension/parquet/include/parquet_writer.hpp
+++ b/extension/parquet/include/parquet_writer.hpp
@@ -271,6 +271,12 @@ public:
 	unique_ptr<AsyncWriteBuffer> PrepareWriteData(unique_ptr<AsyncWriteBuffer> buffer);
 	uint32_t WriteData(unique_ptr<AsyncWriteBuffer> buffer);
 
+	unique_ptr<AsyncWriteBuffer> PrepareWrite(const duckdb_apache::thrift::TBase &object, const string &key);
+	unique_ptr<AsyncWriteBuffer> PrepareWriteData(unique_ptr<AsyncWriteBuffer> buffer, const string &key);
+
+	bool HasEncryption() const;
+	const ParquetEncryptionConfig &GetEncryptionConfig() const;
+
 	GeoParquetFileMetadata &GetGeoParquetData();
 
 	static bool TryGetParquetType(const LogicalType &duckdb_type,

--- a/extension/parquet/parquet_crypto.cpp
+++ b/extension/parquet/parquet_crypto.cpp
@@ -160,7 +160,34 @@ ParquetEncryptionConfig::ParquetEncryptionConfig(ClientContext &context, const V
 		} else if (struct_key == "footer_key_value") {
 			footer_key = StringValue::Get(children[i].DefaultCastAs(LogicalType::BLOB));
 		} else if (struct_key == "column_keys") {
-			throw NotImplementedException("Parquet encryption_config column_keys not yet implemented");
+			auto &ck_val = children[i];
+			if (ck_val.type().id() != LogicalTypeId::STRUCT) {
+				throw BinderException("column_keys must be a STRUCT of {key_name: [column_names]}");
+			}
+			auto &ck_child_types = StructType::GetChildTypes(ck_val.type());
+			auto &ck_children = StructValue::GetChildren(ck_val);
+			for (idx_t j = 0; j < StructType::GetChildCount(ck_val.type()); j++) {
+				auto key_name = ck_child_types[j].first.GetIdentifierName();
+				if (!keys.HasKey(key_name)) {
+					throw BinderException(
+					    "No key with name \"%s\" exists. Add it with PRAGMA add_parquet_key('<key_name>','<key>');",
+					    key_name);
+				}
+				auto &key_bytes = keys.GetKey(key_name);
+
+				auto &col_list = ck_children[j];
+				if (col_list.type().id() != LogicalTypeId::LIST) {
+					throw BinderException("column_keys values must be lists of column names");
+				}
+				auto &list_children = ListValue::GetChildren(col_list);
+				for (auto &col_val : list_children) {
+					auto col_name = StringValue::Get(col_val.DefaultCastAs(LogicalType::VARCHAR));
+					if (column_keys.count(col_name)) {
+						throw BinderException("Column \"%s\" is assigned to multiple keys", col_name);
+					}
+					column_keys[col_name] = key_bytes;
+				}
+			}
 		} else {
 			throw BinderException("Unknown key in encryption_config \"%s\"", struct_key);
 		}
@@ -173,6 +200,33 @@ shared_ptr<ParquetEncryptionConfig> ParquetEncryptionConfig::Create(ClientContex
 
 const string &ParquetEncryptionConfig::GetFooterKey() const {
 	return footer_key;
+}
+
+const string &ParquetEncryptionConfig::GetColumnKey(const string &column_name) const {
+	auto it = column_keys.find(column_name);
+	if (it != column_keys.end()) {
+		return it->second;
+	}
+	return footer_key;
+}
+
+bool ParquetEncryptionConfig::HasColumnKey(const string &column_name) const {
+	return column_keys.count(column_name) > 0;
+}
+
+void ParquetEncryptionConfig::ValidateColumnNames(const vector<string> &column_names) const {
+	for (auto &entry : column_keys) {
+		bool found = false;
+		for (auto &name : column_names) {
+			if (StringUtil::CIEquals(entry.first, name)) {
+				found = true;
+				break;
+			}
+		}
+		if (!found) {
+			throw BinderException("Column \"%s\" in column_keys does not exist in the table", entry.first);
+		}
+	}
 }
 
 using duckdb_apache::thrift::protocol::TCompactProtocolFactoryT;

--- a/extension/parquet/parquet_crypto.cpp
+++ b/extension/parquet/parquet_crypto.cpp
@@ -159,8 +159,6 @@ ParquetEncryptionConfig::ParquetEncryptionConfig(ClientContext &context, const V
 				    "No key with name \"%s\" exists. Add it with PRAGMA add_parquet_key('<key_name>','<key>');",
 				    footer_key_name);
 			}
-			// footer key name provided - read the key from the config
-			const auto &keys = ParquetKeys::Get(context);
 			footer_key = keys.GetKey(footer_key_name);
 		} else if (normalized_struct_key == "footer_key_value") {
 			footer_key = StringValue::Get(children[i].DefaultCastAs(LogicalType::BLOB));
@@ -198,6 +196,9 @@ ParquetEncryptionConfig::ParquetEncryptionConfig(ClientContext &context, const V
 		} else {
 			throw BinderException("Unknown key in encryption_config \"%s\"", struct_key);
 		}
+	}
+	if (!column_keys.empty() && footer_key.empty()) {
+		throw BinderException("encryption_config specifies column_keys but no footer_key");
 	}
 }
 

--- a/extension/parquet/parquet_crypto.cpp
+++ b/extension/parquet/parquet_crypto.cpp
@@ -138,6 +138,10 @@ ParquetEncryptionConfig::ParquetEncryptionConfig() {
 ParquetEncryptionConfig::ParquetEncryptionConfig(string footer_key_p) : footer_key(std::move(footer_key_p)) {
 }
 
+static string NormalizeColumnKey(const string &column_name) {
+	return StringUtil::Lower(column_name);
+}
+
 ParquetEncryptionConfig::ParquetEncryptionConfig(ClientContext &context, const Value &arg) {
 	if (arg.type().id() != LogicalTypeId::STRUCT) {
 		throw BinderException("Parquet encryption_config must be of type STRUCT");
@@ -147,7 +151,8 @@ ParquetEncryptionConfig::ParquetEncryptionConfig(ClientContext &context, const V
 	const auto &keys = ParquetKeys::Get(context);
 	for (idx_t i = 0; i < StructType::GetChildCount(arg.type()); i++) {
 		auto &struct_key = child_types[i].first;
-		if (struct_key == "footer_key") {
+		auto normalized_struct_key = StringUtil::Lower(struct_key.GetIdentifierName());
+		if (normalized_struct_key == "footer_key") {
 			const auto footer_key_name = StringValue::Get(children[i].DefaultCastAs(LogicalType::VARCHAR));
 			if (!keys.HasKey(footer_key_name)) {
 				throw BinderException(
@@ -157,9 +162,9 @@ ParquetEncryptionConfig::ParquetEncryptionConfig(ClientContext &context, const V
 			// footer key name provided - read the key from the config
 			const auto &keys = ParquetKeys::Get(context);
 			footer_key = keys.GetKey(footer_key_name);
-		} else if (struct_key == "footer_key_value") {
+		} else if (normalized_struct_key == "footer_key_value") {
 			footer_key = StringValue::Get(children[i].DefaultCastAs(LogicalType::BLOB));
-		} else if (struct_key == "column_keys") {
+		} else if (normalized_struct_key == "column_keys") {
 			auto &ck_val = children[i];
 			if (ck_val.type().id() != LogicalTypeId::STRUCT) {
 				throw BinderException("column_keys must be a STRUCT of {key_name: [column_names]}");
@@ -182,10 +187,12 @@ ParquetEncryptionConfig::ParquetEncryptionConfig(ClientContext &context, const V
 				auto &list_children = ListValue::GetChildren(col_list);
 				for (auto &col_val : list_children) {
 					auto col_name = StringValue::Get(col_val.DefaultCastAs(LogicalType::VARCHAR));
-					if (column_keys.count(col_name)) {
+					auto normalized_col_name = NormalizeColumnKey(col_name);
+					if (column_keys.count(normalized_col_name)) {
 						throw BinderException("Column \"%s\" is assigned to multiple keys", col_name);
 					}
-					column_keys[col_name] = key_bytes;
+					column_keys[normalized_col_name] = key_bytes;
+					column_key_names[normalized_col_name] = key_name;
 				}
 			}
 		} else {
@@ -203,30 +210,51 @@ const string &ParquetEncryptionConfig::GetFooterKey() const {
 }
 
 const string &ParquetEncryptionConfig::GetColumnKey(const string &column_name) const {
-	auto it = column_keys.find(column_name);
+	auto it = column_keys.find(NormalizeColumnKey(column_name));
 	if (it != column_keys.end()) {
 		return it->second;
 	}
-	return footer_key;
+	throw InvalidInputException("No column key was provided for encrypted Parquet column \"%s\"", column_name);
+}
+
+const string &ParquetEncryptionConfig::GetColumnKeyName(const string &column_name) const {
+	auto it = column_key_names.find(NormalizeColumnKey(column_name));
+	if (it != column_key_names.end()) {
+		return it->second;
+	}
+	throw InvalidInputException("No column key was provided for encrypted Parquet column \"%s\"", column_name);
 }
 
 bool ParquetEncryptionConfig::HasColumnKey(const string &column_name) const {
-	return column_keys.count(column_name) > 0;
+	return column_keys.count(NormalizeColumnKey(column_name)) > 0;
 }
 
-void ParquetEncryptionConfig::ValidateColumnNames(const vector<string> &column_names) const {
+void ParquetEncryptionConfig::ValidateColumnNames(const vector<string> &column_names) {
+	unordered_map<string, string> validated_column_keys;
+	unordered_map<string, string> validated_column_key_names;
+
 	for (auto &entry : column_keys) {
 		bool found = false;
+		string normalized_name;
 		for (auto &name : column_names) {
 			if (StringUtil::CIEquals(entry.first, name)) {
 				found = true;
+				normalized_name = NormalizeColumnKey(name);
 				break;
 			}
 		}
 		if (!found) {
 			throw BinderException("Column \"%s\" in column_keys does not exist in the table", entry.first);
 		}
+		validated_column_keys[normalized_name] = entry.second;
+		auto key_name_entry = column_key_names.find(entry.first);
+		if (key_name_entry != column_key_names.end()) {
+			validated_column_key_names[normalized_name] = key_name_entry->second;
+		}
 	}
+
+	column_keys = std::move(validated_column_keys);
+	column_key_names = std::move(validated_column_key_names);
 }
 
 using duckdb_apache::thrift::protocol::TCompactProtocolFactoryT;

--- a/extension/parquet/parquet_extension.cpp
+++ b/extension/parquet/parquet_extension.cpp
@@ -373,6 +373,10 @@ static unique_ptr<FunctionData> ParquetWriteBind(ClientContext &context, CopyFun
 	bind_data->sql_types = sql_types;
 	bind_data->column_names = IdentifiersToStrings(names);
 
+	if (bind_data->encryption_config) {
+		bind_data->encryption_config->ValidateColumnNames(bind_data->column_names);
+	}
+
 	return std::move(bind_data);
 }
 

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1383,6 +1383,19 @@ uint32_t ParquetReader::ReadDataEncrypted(duckdb_apache::thrift::protocol::TProt
 	                               *encryption_util, aad_crypto_metadata);
 }
 
+uint32_t ParquetReader::ReadEncrypted(duckdb_apache::thrift::TBase &object, TProtocol &iprot,
+                                      CryptoMetaData &aad_crypto_metadata, const string &key) const {
+	ParquetCrypto::GenerateAdditionalAuthenticatedData(allocator, aad_crypto_metadata);
+	return ParquetCrypto::Read(object, iprot, key, *encryption_util, aad_crypto_metadata);
+}
+
+uint32_t ParquetReader::ReadDataEncrypted(duckdb_apache::thrift::protocol::TProtocol &iprot, const data_ptr_t buffer,
+                                          const uint32_t buffer_size, CryptoMetaData &aad_crypto_metadata,
+                                          const string &key) const {
+	ParquetCrypto::GenerateAdditionalAuthenticatedData(allocator, aad_crypto_metadata);
+	return ParquetCrypto::ReadData(iprot, buffer, buffer_size, key, *encryption_util, aad_crypto_metadata);
+}
+
 static idx_t GetRowGroupOffset(const ParquetReader &reader, idx_t group_idx) {
 	idx_t row_group_offset = 0;
 	auto &row_groups = reader.GetFileMetadata()->row_groups;

--- a/extension/parquet/parquet_writer.cpp
+++ b/extension/parquet/parquet_writer.cpp
@@ -433,6 +433,43 @@ uint32_t ParquetWriter::WriteData(unique_ptr<AsyncWriteBuffer> buffer) {
 	return buffer_size;
 }
 
+unique_ptr<AsyncWriteBuffer> ParquetWriter::PrepareWrite(const duckdb_apache::thrift::TBase &object,
+                                                         const string &key) {
+	auto stream = make_uniq<MemoryStream>(BufferAllocator::Get(context));
+	TCompactProtocolFactoryT<MyTransport> tproto_factory;
+	auto stream_protocol = tproto_factory.getProtocol(duckdb_base_std::make_shared<MyTransport>(*stream));
+	if (options.encryption_config) {
+		ParquetCrypto::Write(object, *stream_protocol, key, *encryption_util);
+	} else {
+		object.write(stream_protocol.get());
+	}
+	return make_uniq<ParquetPreparedWriteBuffer>(std::move(stream));
+}
+
+unique_ptr<AsyncWriteBuffer> ParquetWriter::PrepareWriteData(unique_ptr<AsyncWriteBuffer> buffer, const string &key) {
+	if (!options.encryption_config) {
+		return buffer;
+	}
+
+	auto required_capacity =
+	    buffer->Size() + ParquetCrypto::LENGTH_BYTES + ParquetCrypto::NONCE_BYTES + ParquetCrypto::TAG_BYTES;
+	auto stream = make_uniq<MemoryStream>(BufferAllocator::Get(context), NextPowerOfTwo(required_capacity));
+	TCompactProtocolFactoryT<MyTransport> tproto_factory;
+	auto stream_protocol = tproto_factory.getProtocol(duckdb_base_std::make_shared<MyTransport>(*stream));
+	ParquetCrypto::WriteData(*stream_protocol, buffer->Ptr(), NumericCast<uint32_t>(buffer->Size()), key,
+	                         *encryption_util);
+	return make_uniq<ParquetPreparedWriteBuffer>(std::move(stream));
+}
+
+bool ParquetWriter::HasEncryption() const {
+	return options.encryption_config != nullptr;
+}
+
+const ParquetEncryptionConfig &ParquetWriter::GetEncryptionConfig() const {
+	D_ASSERT(options.encryption_config);
+	return *options.encryption_config;
+}
+
 static void VerifyUniqueNames(const vector<string> &names) {
 #ifdef DEBUG
 	unordered_set<string> name_set;

--- a/extension/parquet/serialize_parquet.cpp
+++ b/extension/parquet/serialize_parquet.cpp
@@ -67,12 +67,14 @@ ParquetColumnDefinition ParquetColumnDefinition::Deserialize(Deserializer &deser
 void ParquetEncryptionConfig::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<string>(100, "footer_key", footer_key);
 	serializer.WritePropertyWithDefault<unordered_map<string, string>>(101, "column_keys", column_keys);
+	serializer.WritePropertyWithDefault<unordered_map<string, string>>(102, "column_key_names", column_key_names);
 }
 
 shared_ptr<ParquetEncryptionConfig> ParquetEncryptionConfig::Deserialize(Deserializer &deserializer) {
 	auto result = duckdb::shared_ptr<ParquetEncryptionConfig>(new ParquetEncryptionConfig());
 	deserializer.ReadPropertyWithDefault<string>(100, "footer_key", result->footer_key);
 	deserializer.ReadPropertyWithDefault<unordered_map<string, string>>(101, "column_keys", result->column_keys);
+	deserializer.ReadPropertyWithDefault<unordered_map<string, string>>(102, "column_key_names", result->column_key_names);
 	return result;
 }
 

--- a/extension/parquet/writer/primitive_column_writer.cpp
+++ b/extension/parquet/writer/primitive_column_writer.cpp
@@ -430,7 +430,7 @@ void PrimitiveColumnWriter::PrepareWrite(ColumnWriterState &state_p) {
 	string top_level_name = schema_path.empty() ? string() : schema_path[0].GetIdentifierName();
 	bool use_column_key =
 	    writer.HasEncryption() && !top_level_name.empty() && writer.GetEncryptionConfig().HasColumnKey(top_level_name);
-	const string *column_key = nullptr;
+	optional_ptr<const string> column_key;
 	if (use_column_key) {
 		column_key = &writer.GetEncryptionConfig().GetColumnKey(top_level_name);
 	}

--- a/extension/parquet/writer/primitive_column_writer.cpp
+++ b/extension/parquet/writer/primitive_column_writer.cpp
@@ -427,26 +427,26 @@ void PrimitiveColumnWriter::PrepareWrite(ColumnWriterState &state_p) {
 		FlushDictionary(state, state.stats_state.get());
 	}
 
-	// Determine the encryption key for this column
 	string top_level_name = schema_path.empty() ? string() : schema_path[0].GetIdentifierName();
 	bool use_column_key =
 	    writer.HasEncryption() && !top_level_name.empty() && writer.GetEncryptionConfig().HasColumnKey(top_level_name);
+	const string *column_key = nullptr;
+	if (use_column_key) {
+		column_key = &writer.GetEncryptionConfig().GetColumnKey(top_level_name);
+	}
 
 	for (auto &write_info : state.write_info) {
 		D_ASSERT(write_info.page_header.uncompressed_page_size > 0);
 		D_ASSERT(!write_info.prepared_header);
 		D_ASSERT(!write_info.prepared_payload);
 
-		if (use_column_key) {
-			auto &col_key = writer.GetEncryptionConfig().GetColumnKey(top_level_name);
-			write_info.prepared_header = writer.PrepareWrite(write_info.page_header, col_key);
-			auto payload_buffer = make_uniq<ParquetPagePayloadBuffer>(
-			    write_info.compressed_size, std::move(write_info.temp_writer), std::move(write_info.compressed_buf));
-			write_info.prepared_payload = writer.PrepareWriteData(std::move(payload_buffer), col_key);
+		auto payload_buffer = make_uniq<ParquetPagePayloadBuffer>(
+		    write_info.compressed_size, std::move(write_info.temp_writer), std::move(write_info.compressed_buf));
+		if (column_key) {
+			write_info.prepared_header = writer.PrepareWrite(write_info.page_header, *column_key);
+			write_info.prepared_payload = writer.PrepareWriteData(std::move(payload_buffer), *column_key);
 		} else {
 			write_info.prepared_header = writer.PrepareWrite(write_info.page_header);
-			auto payload_buffer = make_uniq<ParquetPagePayloadBuffer>(
-			    write_info.compressed_size, std::move(write_info.temp_writer), std::move(write_info.compressed_buf));
 			write_info.prepared_payload = writer.PrepareWriteData(std::move(payload_buffer));
 		}
 	}
@@ -491,14 +491,15 @@ void PrimitiveColumnWriter::FinalizeWrite(ColumnWriterState &state_p) {
 	column_chunk.meta_data.total_uncompressed_size = UnsafeNumericCast<int64_t>(total_uncompressed_size);
 	state.row_group.total_byte_size += column_chunk.meta_data.total_uncompressed_size;
 
-	// Set crypto_metadata on the ColumnChunk when using per-column keys
 	if (writer.HasEncryption() && !schema_path.empty()) {
 		auto &enc_config = writer.GetEncryptionConfig();
 		auto col_name = schema_path[0].GetIdentifierName();
 		column_chunk.__isset.crypto_metadata = true;
 		if (enc_config.HasColumnKey(col_name)) {
 			duckdb_parquet::EncryptionWithColumnKey eck;
-			eck.path_in_schema.push_back(col_name);
+			eck.path_in_schema = IdentifiersToStrings(schema_path);
+			eck.__isset.key_metadata = true;
+			eck.key_metadata = enc_config.GetColumnKeyName(col_name);
 			column_chunk.crypto_metadata.__isset.ENCRYPTION_WITH_COLUMN_KEY = true;
 			column_chunk.crypto_metadata.ENCRYPTION_WITH_COLUMN_KEY = std::move(eck);
 		} else {

--- a/extension/parquet/writer/primitive_column_writer.cpp
+++ b/extension/parquet/writer/primitive_column_writer.cpp
@@ -6,6 +6,7 @@
 
 #include "parquet_rle_bp_decoder.hpp"
 #include "parquet_rle_bp_encoder.hpp"
+#include "parquet_crypto.hpp"
 #include "parquet_writer.hpp"
 #include "duckdb/common/assert.hpp"
 #include "duckdb/common/constants.hpp"
@@ -426,15 +427,28 @@ void PrimitiveColumnWriter::PrepareWrite(ColumnWriterState &state_p) {
 		FlushDictionary(state, state.stats_state.get());
 	}
 
+	// Determine the encryption key for this column
+	string top_level_name = schema_path.empty() ? string() : schema_path[0].GetIdentifierName();
+	bool use_column_key =
+	    writer.HasEncryption() && !top_level_name.empty() && writer.GetEncryptionConfig().HasColumnKey(top_level_name);
+
 	for (auto &write_info : state.write_info) {
 		D_ASSERT(write_info.page_header.uncompressed_page_size > 0);
 		D_ASSERT(!write_info.prepared_header);
 		D_ASSERT(!write_info.prepared_payload);
 
-		write_info.prepared_header = writer.PrepareWrite(write_info.page_header);
-		auto payload_buffer = make_uniq<ParquetPagePayloadBuffer>(
-		    write_info.compressed_size, std::move(write_info.temp_writer), std::move(write_info.compressed_buf));
-		write_info.prepared_payload = writer.PrepareWriteData(std::move(payload_buffer));
+		if (use_column_key) {
+			auto &col_key = writer.GetEncryptionConfig().GetColumnKey(top_level_name);
+			write_info.prepared_header = writer.PrepareWrite(write_info.page_header, col_key);
+			auto payload_buffer = make_uniq<ParquetPagePayloadBuffer>(
+			    write_info.compressed_size, std::move(write_info.temp_writer), std::move(write_info.compressed_buf));
+			write_info.prepared_payload = writer.PrepareWriteData(std::move(payload_buffer), col_key);
+		} else {
+			write_info.prepared_header = writer.PrepareWrite(write_info.page_header);
+			auto payload_buffer = make_uniq<ParquetPagePayloadBuffer>(
+			    write_info.compressed_size, std::move(write_info.temp_writer), std::move(write_info.compressed_buf));
+			write_info.prepared_payload = writer.PrepareWriteData(std::move(payload_buffer));
+		}
 	}
 }
 
@@ -476,6 +490,21 @@ void PrimitiveColumnWriter::FinalizeWrite(ColumnWriterState &state_p) {
 	    UnsafeNumericCast<int64_t>(column_writer.GetTotalWritten() - start_offset);
 	column_chunk.meta_data.total_uncompressed_size = UnsafeNumericCast<int64_t>(total_uncompressed_size);
 	state.row_group.total_byte_size += column_chunk.meta_data.total_uncompressed_size;
+
+	// Set crypto_metadata on the ColumnChunk when using per-column keys
+	if (writer.HasEncryption() && !schema_path.empty()) {
+		auto &enc_config = writer.GetEncryptionConfig();
+		auto col_name = schema_path[0].GetIdentifierName();
+		column_chunk.__isset.crypto_metadata = true;
+		if (enc_config.HasColumnKey(col_name)) {
+			duckdb_parquet::EncryptionWithColumnKey eck;
+			eck.path_in_schema.push_back(col_name);
+			column_chunk.crypto_metadata.__isset.ENCRYPTION_WITH_COLUMN_KEY = true;
+			column_chunk.crypto_metadata.ENCRYPTION_WITH_COLUMN_KEY = std::move(eck);
+		} else {
+			column_chunk.crypto_metadata.__isset.ENCRYPTION_WITH_FOOTER_KEY = true;
+		}
+	}
 
 	if (state.bloom_filter) {
 		writer.BufferBloomFilter(state.col_idx, std::move(state.bloom_filter));

--- a/test/sql/copy/parquet/parquet_encryption.test
+++ b/test/sql/copy/parquet/parquet_encryption.test
@@ -132,6 +132,12 @@ PRAGMA add_parquet_key('ck1', 'aabbccddeeff00112233445566778899');
 statement ok
 PRAGMA add_parquet_key('ck2', '99887766554433221100ffeeddccbbaa');
 
+# column_keys without footer_key should fail
+statement error
+COPY (SELECT 42 i) to '{TEST_DIR}/no_footer.parquet' (ENCRYPTION_CONFIG {column_keys: {ck1: [i]}});
+----
+Binder Error: encryption_config specifies column_keys but no footer_key
+
 # Create test table
 statement ok
 CREATE TABLE t1 AS SELECT i AS id, 'name_' || i AS name, i * 100 AS secret FROM range(100) t(i);

--- a/test/sql/copy/parquet/parquet_encryption.test
+++ b/test/sql/copy/parquet/parquet_encryption.test
@@ -148,18 +148,18 @@ SELECT * FROM read_parquet('{TEST_DIR}/col_keys.parquet', encryption_config = {f
 1	name_1	100
 2	name_2	200
 
-# Read with wrong column key — should fail with tag mismatch
+# Read with swapped column mapping - should fail before decrypting pages
 statement error
 SELECT * FROM read_parquet('{TEST_DIR}/col_keys.parquet', encryption_config = {footer_key: 'fk', column_keys: {ck2: [name], ck1: [secret]}});
 ----
-Computed AES tag differs from read AES tag
+requires key "ck1", but encryption_config assigns key "ck2"
 
 # Read with only footer key (no column_keys) — columns using footer key work,
 # but columns with dedicated keys should fail
 statement error
 SELECT * FROM read_parquet('{TEST_DIR}/col_keys.parquet', encryption_config = {footer_key: 'fk'});
 ----
-Computed AES tag differs from read AES tag
+No column key was provided for encrypted Parquet column "name"
 
 # Read only footer-keyed column — should work (projection pushdown skips column-keyed pages)
 query I
@@ -174,6 +174,23 @@ statement error
 COPY t1 TO '{TEST_DIR}/dup.parquet' (ENCRYPTION_CONFIG {footer_key: 'fk', column_keys: {ck1: [name], ck2: [name]}});
 ----
 assigned to multiple keys
+
+# Duplicate column in column_keys with different casing should fail
+statement error
+COPY t1 TO '{TEST_DIR}/dup_case.parquet' (ENCRYPTION_CONFIG {footer_key: 'fk', column_keys: {ck1: [name], ck2: [NAME]}});
+----
+assigned to multiple keys
+
+# Column names in column_keys are matched case-insensitively, but still use the column key
+statement ok
+COPY t1 TO '{TEST_DIR}/col_keys_case.parquet' (ENCRYPTION_CONFIG {footer_key: 'fk', column_keys: {ck1: [NAME]}});
+
+query II
+SELECT id, name FROM read_parquet('{TEST_DIR}/col_keys_case.parquet', encryption_config = {footer_key: 'fk', column_keys: {ck1: [name]}}) ORDER BY id LIMIT 3;
+----
+0	name_0
+1	name_1
+2	name_2
 
 # Non-existent column in column_keys — should fail
 statement error
@@ -192,3 +209,29 @@ query I
 SELECT * FROM read_parquet('{TEST_DIR}/encrypted256.parquet', encryption_config={footer_key: 'key256'})
 ----
 42
+
+# Nested top-level columns use full Parquet paths in crypto metadata
+statement ok
+CREATE TABLE t_nested AS SELECT i AS id, {'name': 'nested_' || i, 'secret': i * 10}::STRUCT(name VARCHAR, secret BIGINT) AS info FROM range(3) t(i);
+
+statement ok
+COPY t_nested TO '{TEST_DIR}/col_keys_nested.parquet' (ENCRYPTION_CONFIG {footer_key: 'fk', column_keys: {ck1: [info]}});
+
+query II
+SELECT id, info.name FROM read_parquet('{TEST_DIR}/col_keys_nested.parquet', encryption_config = {footer_key: 'fk', column_keys: {ck1: [info]}}) ORDER BY id;
+----
+0	nested_0
+1	nested_1
+2	nested_2
+
+query I
+SELECT id FROM read_parquet('{TEST_DIR}/col_keys_nested.parquet', encryption_config = {footer_key: 'fk'}) ORDER BY id;
+----
+0
+1
+2
+
+statement error
+SELECT info.name FROM read_parquet('{TEST_DIR}/col_keys_nested.parquet', encryption_config = {footer_key: 'fk'});
+----
+No column key was provided for encrypted Parquet column "info.name"

--- a/test/sql/copy/parquet/parquet_encryption.test
+++ b/test/sql/copy/parquet/parquet_encryption.test
@@ -22,11 +22,11 @@ PRAGMA add_parquet_key('my_invalid_duck_key', 'ZHVjaw==')
 ----
 Invalid Input Error: Invalid AES key. Must have a length of 128, 192, or 256 bits (16, 24, or 32 bytes)
 
-# we dont support this yet
+# unknown key name in column_keys should fail
 statement error
 COPY (SELECT 42 i) to '{TEST_DIR}/encrypted.parquet' (ENCRYPTION_CONFIG {column_keys: {key_name: ['col0', 'col1']}})
 ----
-Not implemented Error: Parquet encryption_config column_keys not yet implemented
+Binder Error: No key with name "key_name" exists
 
 statement error
 COPY (SELECT 42 i) to '{TEST_DIR}/encrypted.parquet' (ENCRYPTION_CONFIG {footer_key: 'nonexistant'})
@@ -118,3 +118,77 @@ statement error
 SELECT * FROM read_parquet('{TEST_DIR}/encrypted_metadata_cache.parquet', encryption_config={footer_key: 'key192'})
 ----
 Invalid Input Error: Computed AES tag differs from read AES tag, are you using the right key?
+
+# ============================================================
+# column_keys tests
+# ============================================================
+
+statement ok
+PRAGMA add_parquet_key('fk', '01234567891123450123456789112345');
+
+statement ok
+PRAGMA add_parquet_key('ck1', 'aabbccddeeff00112233445566778899');
+
+statement ok
+PRAGMA add_parquet_key('ck2', '99887766554433221100ffeeddccbbaa');
+
+# Create test table
+statement ok
+CREATE TABLE t1 AS SELECT i AS id, 'name_' || i AS name, i * 100 AS secret FROM range(100) t(i);
+
+# Write with column_keys
+statement ok
+COPY t1 TO '{TEST_DIR}/col_keys.parquet' (ENCRYPTION_CONFIG {footer_key: 'fk', column_keys: {ck1: [name], ck2: [secret]}});
+
+# Read with all keys — should return all data
+query III
+SELECT * FROM read_parquet('{TEST_DIR}/col_keys.parquet', encryption_config = {footer_key: 'fk', column_keys: {ck1: [name], ck2: [secret]}}) ORDER BY id LIMIT 3;
+----
+0	name_0	0
+1	name_1	100
+2	name_2	200
+
+# Read with wrong column key — should fail with tag mismatch
+statement error
+SELECT * FROM read_parquet('{TEST_DIR}/col_keys.parquet', encryption_config = {footer_key: 'fk', column_keys: {ck2: [name], ck1: [secret]}});
+----
+Computed AES tag differs from read AES tag
+
+# Read with only footer key (no column_keys) — columns using footer key work,
+# but columns with dedicated keys should fail
+statement error
+SELECT * FROM read_parquet('{TEST_DIR}/col_keys.parquet', encryption_config = {footer_key: 'fk'});
+----
+Computed AES tag differs from read AES tag
+
+# Read only footer-keyed column — should work (projection pushdown skips column-keyed pages)
+query I
+SELECT id FROM read_parquet('{TEST_DIR}/col_keys.parquet', encryption_config = {footer_key: 'fk'}) ORDER BY id LIMIT 3;
+----
+0
+1
+2
+
+# Duplicate column in column_keys — should fail
+statement error
+COPY t1 TO '{TEST_DIR}/dup.parquet' (ENCRYPTION_CONFIG {footer_key: 'fk', column_keys: {ck1: [name], ck2: [name]}});
+----
+assigned to multiple keys
+
+# Non-existent column in column_keys — should fail
+statement error
+COPY t1 TO '{TEST_DIR}/bad_col.parquet' (ENCRYPTION_CONFIG {footer_key: 'fk', column_keys: {ck1: [nonexistent]}});
+----
+does not exist
+
+# Non-existent key name in column_keys — should fail
+statement error
+COPY t1 TO '{TEST_DIR}/bad_key.parquet' (ENCRYPTION_CONFIG {footer_key: 'fk', column_keys: {no_such_key: [name]}});
+----
+No key with name
+
+# Backward compat: files written with only footer_key still work
+query I
+SELECT * FROM read_parquet('{TEST_DIR}/encrypted256.parquet', encryption_config={footer_key: 'key256'})
+----
+42


### PR DESCRIPTION
Implements the `column_keys` option for Parquet modular encryption. Previously this threw `NotImplementedException`. Now different columns can be encrypted with different AES keys, with unassigned columns defaulting to the footer key.

```sql
PRAGMA add_parquet_key('footer_key', '01234567891123450123456789112345');
PRAGMA add_parquet_key('pii_key',    'aabbccddeeff00112233445566778899');

COPY patients TO 'patients.parquet' (ENCRYPTION_CONFIG {
    footer_key: 'footer_key',
    column_keys: {pii_key: [name, email, phone]}
});

SELECT id, diagnosis FROM read_parquet('patients.parquet',
    encryption_config = {footer_key: 'footer_key'});
-- works: id and diagnosis use the footer key, pii columns are never decrypted
```

Closes https://github.com/duckdb/duckdb/discussions/19222

### Design decisions

**Key routing is top-level only.** Keys are assigned to top-level column names, and nested children (struct fields, list elements) inherit. This matches how `ColumnChunk.crypto_metadata` works in the Parquet spec: metadata lives on the chunk, and chunks correspond to leaf columns grouped under a top-level schema node.

**Column names are normalized to lowercase** in the `column_keys` map since DuckDB identifiers are case-insensitive. `ValidateColumnNames` re-normalizes against the actual table schema at bind time, so `column_keys: {ck1: [NAME]}` matches a column called `name` and stores the mapping under the canonical form.

**`GetColumnKey` throws instead of falling back to the footer key.** If a `ColumnChunk` is marked `ENCRYPTION_WITH_COLUMN_KEY` and no matching key was provided, we fail immediately with a message naming the column and the expected key. Otherwise you'd get a confusing AES tag mismatch deep in the decryption stack.

**We write `key_metadata` into `EncryptionWithColumnKey`** so readers can validate key assignments before attempting decryption. On read, if `key_metadata` is present, we check it against the key name in the user's `encryption_config` and throw a clear error on mismatch (e.g. swapped column mappings). This catches misconfiguration upfront instead of producing a generic "wrong key" error.

**Projection pushdown is the access-control mechanism.** If you only provide the footer key, you can still read footer-keyed columns. Column-keyed columns are simply never read, so partial access works without any special reader logic.

### Limitations

- Keys are assigned at top-level column granularity only. You can't encrypt `info.name` with a different key than `info.secret` if they're both fields in a `STRUCT` column `info`.
- No key wrapping or KMS integration. Keys are raw AES bytes provided via `PRAGMA add_parquet_key`. Envelope encryption would need to sit above this.
- Only encrypted-footer mode (`PARE` magic bytes). Plaintext footer with encrypted columns is not supported (pre-existing limitation, not new to this PR).