### PR TITLE
Fix Parser::Tokenize by emitting trailing token past input end

### DIFF
--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -370,6 +370,9 @@ vector<SimplifiedToken> Parser::Tokenize(const string &query) {
 	vector<SimplifiedToken> result;
 	result.reserve(tokens.size());
 	for (auto &token : tokens) {
+		if (token.type == TokenType::END_OF_INPUT || token.type == TokenType::END_OF_INPUT_AUTOCOMPLETE) {
+			continue;
+		}
 		SimplifiedToken simplified;
 		simplified.start = token.offset;
 		switch (token.type) {

--- a/test/common/test_parse_expression.cpp
+++ b/test/common/test_parse_expression.cpp
@@ -99,6 +99,16 @@ TEST_CASE("Parser::Tokenize does not emit trailing token beyond input", "[parse_
 	REQUIRE(tokens[1].start == 7);
 	REQUIRE(tokens[1].type == SimplifiedTokenType::SIMPLIFIED_TOKEN_NUMERIC_CONSTANT);
 
+	// "select 1;" has 9 chars -> 3 tokens: "select" (start index 0), "1" (start index 7), ";" (start index 8)
+	tokens = Parser::Tokenize("select 1;");
+	REQUIRE(tokens.size() == 3);
+	REQUIRE(tokens[0].start == 0);
+	REQUIRE(tokens[0].type == SimplifiedTokenType::SIMPLIFIED_TOKEN_KEYWORD);
+	REQUIRE(tokens[1].start == 7);
+	REQUIRE(tokens[1].type == SimplifiedTokenType::SIMPLIFIED_TOKEN_NUMERIC_CONSTANT);
+	REQUIRE(tokens[2].start == 8);
+	REQUIRE(tokens[2].type == SimplifiedTokenType::SIMPLIFIED_TOKEN_OPERATOR);
+
 	// empty input produces 0 tokens
 	tokens = Parser::Tokenize("");
 	REQUIRE(tokens.empty());

--- a/test/common/test_parse_expression.cpp
+++ b/test/common/test_parse_expression.cpp
@@ -82,3 +82,28 @@ TEST_CASE("Parse Expression List rejects invalid clauses", "[parse_expression]")
 	REQUIRE_THROWS_AS(Parser::ParseExpressionList("first(x) AS x ORDER BY x"), ParserException);
 	REQUIRE_THROWS_AS(Parser::ParseExpressionList("x LIMIT 1"), ParserException);
 }
+
+TEST_CASE("Parser::Tokenize does not emit trailing token beyond input", "[parse_expression]") {
+	std::vector<string> test_queries = {"select 1", "select 1;", "create table zebra (bar varchar);", "", "  "};
+	for (const auto &sql : test_queries) {
+		auto tokens = Parser::Tokenize(sql);
+		for (const auto &token : tokens) {
+			REQUIRE(token.start < sql.size());
+		}
+	}
+	// "select 1" has 8 chars -> 2 tokens: "select" (start index 0) and "1" (start index 7)
+	auto tokens = Parser::Tokenize("select 1");
+	REQUIRE(tokens.size() == 2);
+	REQUIRE(tokens[0].start == 0);
+	REQUIRE(tokens[0].type == SimplifiedTokenType::SIMPLIFIED_TOKEN_KEYWORD);
+	REQUIRE(tokens[1].start == 7);
+	REQUIRE(tokens[1].type == SimplifiedTokenType::SIMPLIFIED_TOKEN_NUMERIC_CONSTANT);
+
+	// empty input produces 0 tokens
+	tokens = Parser::Tokenize("");
+	REQUIRE(tokens.empty());
+
+	// whitespace-only input produces 0 tokens
+	tokens = Parser::Tokenize("  ");
+	REQUIRE(tokens.empty());
+}


### PR DESCRIPTION
Fixes #24742

### The problem
`Parser::Tokenize` converts tokens produced by `HighlightTokenizer` without skipping the internal sentinel tokens:
- `TokenType::END_OF_INPUT`
- `TokenType::END_OF_INPUT_AUTOCOMPLETE`

These tokens are appended by `BaseTokenizer::TokenizeInput()`. 

Since these sentinel tokens aren't explicitly handled by the switch statement, they fall to the default case, and are emitted as `SIMPLIFIED_TOKEN_IDENTIFIER` tokens with `start == query.size()`.

### The solution
Just skip these sentinel tokens at the beginning of the for loop in `Parser::Tokenize`

### Adding a unit test
Added a unit test in `test/common/test_parse_expression.cpp` verifying no token start positions are greater than or equal to the input length. This is tested across regular queries, trailing semicolons, empty strings, and whitespace.
