### PR TITLE
Dispatch CLI dot-commands through shell_dot_command_ catalog functions

### DIFF
--- a/tools/shell/include/shell_state.hpp
+++ b/tools/shell/include/shell_state.hpp
@@ -426,6 +426,8 @@ public:
 #endif
 	optional_ptr<const CommandLineOption> FindCommandLineOption(const string &option, string &error_msg) const;
 	optional_ptr<const MetadataCommand> FindMetadataCommand(const string &option, string &error_msg) const;
+	//! Dispatch .cmd to catalog function shell_dot_command_cmd. Returns -1 if none exists.
+	int TryCatalogDotCommand(const vector<string> &args);
 	static vector<string> GetMetadataCompletions(const char *zLine, idx_t nLine);
 
 	//! Execute a SQL query

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -2671,13 +2671,26 @@ int ShellState::DoMetaCommand(const string &zLine) {
 	ClearTempFile();
 
 	string error_msg;
-	auto metadata_command = FindMetadataCommand(args[0], error_msg);
+	optional_ptr<const MetadataCommand> metadata_command;
+	try {
+		metadata_command = FindMetadataCommand(args[0], error_msg);
+	} catch (std::exception &ex) {
+		ErrorData error(ex);
+		PrintDatabaseError(error.Message());
+		return 1;
+	}
 	if (!metadata_command) {
-		int catalog_rc = TryCatalogDotCommand(args);
-		if (catalog_rc >= 0) {
-			rc = catalog_rc;
-		} else {
-			PrintDatabaseError(error_msg);
+		try {
+			int catalog_rc = TryCatalogDotCommand(args);
+			if (catalog_rc >= 0) {
+				rc = catalog_rc;
+			} else {
+				PrintDatabaseError(error_msg);
+				rc = 1;
+			}
+		} catch (std::exception &ex) {
+			ErrorData error(ex);
+			PrintDatabaseError(error.Message());
 			rc = 1;
 		}
 	} else {

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -2673,9 +2673,13 @@ int ShellState::DoMetaCommand(const string &zLine) {
 	string error_msg;
 	auto metadata_command = FindMetadataCommand(args[0], error_msg);
 	if (!metadata_command) {
-		// command not found
-		PrintDatabaseError(error_msg);
-		rc = 1;
+		int catalog_rc = TryCatalogDotCommand(args);
+		if (catalog_rc >= 0) {
+			rc = catalog_rc;
+		} else {
+			PrintDatabaseError(error_msg);
+			rc = 1;
+		}
 	} else {
 		auto &command = *metadata_command;
 		MetadataResult result = MetadataResult::PRINT_USAGE;

--- a/tools/shell/shell_extension.cpp
+++ b/tools/shell/shell_extension.cpp
@@ -8,6 +8,7 @@
 #include "duckdb/planner/operator/logical_get.hpp"
 #include "shell_state.hpp"
 #include "duckdb/parser/tableref/column_data_ref.hpp"
+#include "duckdb/parser/parsed_data/create_table_function_info.hpp"
 #include "shell_renderer.hpp"
 #ifdef HAVE_LINENOISE
 #include "history.hpp"
@@ -116,6 +117,59 @@ static void ShellHistoryFunction(ClientContext &context, TableFunctionInput &dat
 	data.offset += chunk_count;
 }
 
+#define CTIMEOPT_VAL_(opt) #opt
+#define CTIMEOPT_VAL(opt)  CTIMEOPT_VAL_(opt)
+
+static string GetShellCompilerVersion() {
+#if defined(__clang__) && defined(__clang_major__)
+	return "clang-" CTIMEOPT_VAL(__clang_major__) "." CTIMEOPT_VAL(__clang_minor__) "." CTIMEOPT_VAL(
+	    __clang_patchlevel__);
+#elif defined(_MSC_VER)
+	return "msvc-" CTIMEOPT_VAL(_MSC_VER);
+#elif defined(__GNUC__) && defined(__VERSION__)
+	return string("gcc-") + __VERSION__;
+#else
+	return string();
+#endif
+}
+
+struct ShellDotCommandVersionData : public GlobalTableFunctionState {
+	idx_t offset = 0;
+	vector<string> lines;
+};
+
+static unique_ptr<FunctionData> ShellDotCommandVersionBind(ClientContext &context, TableFunctionBindInput &input,
+                                                           vector<LogicalType> &return_types,
+                                                           vector<Identifier> &names) {
+	names.emplace_back("command");
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("input");
+	return_types.emplace_back(LogicalType::VARCHAR);
+	return nullptr;
+}
+
+static unique_ptr<GlobalTableFunctionState> ShellDotCommandVersionInit(ClientContext &context,
+                                                                       TableFunctionInitInput &input) {
+	auto result = make_uniq<ShellDotCommandVersionData>();
+	result->lines.push_back(StringUtil::Format("DuckDB %s (%s) %s", DuckDB::LibraryVersion(), DuckDB::ReleaseCodename(),
+	                                           DuckDB::SourceID()));
+	auto compiler = GetShellCompilerVersion();
+	if (!compiler.empty()) {
+		result->lines.push_back(std::move(compiler));
+	}
+	return result;
+}
+
+static void ShellDotCommandVersionFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &data = data_p.global_state->Cast<ShellDotCommandVersionData>();
+	idx_t chunk_count = MinValue<idx_t>(STANDARD_VECTOR_SIZE, data.lines.size() - data.offset);
+	for (idx_t i = 0; i < chunk_count; i++) {
+		output.data[0].Append(Value("print"));
+		output.data[1].Append(Value(data.lines[data.offset + i]));
+	}
+	data.offset += chunk_count;
+}
+
 void ShellExtension::Load(ExtensionLoader &loader) {
 	loader.SetDescription("Adds CLI-specific support and functionalities");
 	loader.RegisterFunction(
@@ -123,6 +177,17 @@ void ShellExtension::Load(ExtensionLoader &loader) {
 
 	TableFunction shell_history("shell_history", {}, ShellHistoryFunction, ShellHistoryBind, ShellHistoryInit);
 	loader.RegisterFunction(shell_history);
+
+	TableFunction shell_dot_command_version("shell_dot_command_version", {LogicalType::VARCHAR, LogicalType::VARCHAR},
+	                                        ShellDotCommandVersionFunction, ShellDotCommandVersionBind,
+	                                        ShellDotCommandVersionInit);
+	CreateTableFunctionInfo version_info(std::move(shell_dot_command_version));
+	FunctionDescription version_description;
+	version_description.description = "Show the version";
+	version_description.parameter_types = {LogicalType::VARCHAR, LogicalType::VARCHAR};
+	version_description.parameter_names = {"user_input", "extra_info"};
+	version_info.descriptions.push_back(std::move(version_description));
+	loader.RegisterFunction(std::move(version_info));
 
 	auto &config = duckdb::DBConfig::GetConfig(loader.GetDatabaseInstance());
 	config.SetOptionByName("duckdb_api", DUCKDB_API_CLI);

--- a/tools/shell/shell_extension.cpp
+++ b/tools/shell/shell_extension.cpp
@@ -157,7 +157,7 @@ static unique_ptr<GlobalTableFunctionState> ShellDotCommandVersionInit(ClientCon
 	if (!compiler.empty()) {
 		result->lines.push_back(std::move(compiler));
 	}
-	return result;
+	return std::move(result);
 }
 
 static void ShellDotCommandVersionFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {

--- a/tools/shell/shell_metadata_command.cpp
+++ b/tools/shell/shell_metadata_command.cpp
@@ -1053,10 +1053,15 @@ static vector<CatalogDotCommandInfo> ListCatalogDotCommands(const ShellState &st
 			});
 		}
 	};
-	context.RunFunctionInTransaction([&]() {
-		collect(duckdb::CatalogType::TABLE_FUNCTION_ENTRY);
-		collect(duckdb::CatalogType::TABLE_MACRO_ENTRY);
-	});
+	try {
+		context.RunFunctionInTransaction([&]() {
+			collect(duckdb::CatalogType::TABLE_FUNCTION_ENTRY);
+			collect(duckdb::CatalogType::TABLE_MACRO_ENTRY);
+		});
+	} catch (std::exception &) {
+		// Listing must not abort the CLI (e.g. an invalidated transaction).
+		return {};
+	}
 	return result;
 }
 
@@ -1093,8 +1098,15 @@ static bool ResolveCatalogDotCommand(const ShellState &state, const string &opti
 	return false;
 }
 
-static MetadataResult ExecuteCatalogDotCommand(ShellState &state, const string &function_name,
-                                               const vector<string> &args) {
+enum class CatalogDotExecuteResult : uint8_t { SUCCESS = 0, FAIL = 1, NOT_FOUND = 2 };
+
+static bool CatalogFunctionMissingError(const string &error, const string &function_name) {
+	return StringUtil::Contains(error, function_name) &&
+	       (StringUtil::Contains(error, "is not in the catalog") || StringUtil::Contains(error, "does not exist"));
+}
+
+static CatalogDotExecuteResult ExecuteCatalogDotCommand(ShellState &state, const string &function_name,
+                                                        const vector<string> &args) {
 	string user_input;
 	for (idx_t i = 1; i < args.size(); i++) {
 		if (i > 1) {
@@ -1107,18 +1119,21 @@ static MetadataResult ExecuteCatalogDotCommand(ShellState &state, const string &
 	    StringUtil::Format("CALL %s(%s, %s)", SQLIdentifier(function_name), SQLString(user_input), SQLString(""));
 	auto result = state.conn->Query(sql);
 	if (result->HasError()) {
+		if (CatalogFunctionMissingError(result->GetError(), function_name)) {
+			return CatalogDotExecuteResult::NOT_FOUND;
+		}
 		state.PrintDatabaseError(result->GetError());
-		return MetadataResult::FAIL;
+		return CatalogDotExecuteResult::FAIL;
 	}
 	if (result->ColumnCount() < 2) {
 		state.PrintDatabaseError("Catalog dot-command must return columns \"command\" and \"input\"");
-		return MetadataResult::FAIL;
+		return CatalogDotExecuteResult::FAIL;
 	}
 	try {
 		for (auto &row : *result) {
 			if (row.IsNull(0)) {
 				state.PrintDatabaseError("Catalog dot-command returned a NULL command");
-				return MetadataResult::FAIL;
+				return CatalogDotExecuteResult::FAIL;
 			}
 			auto command = row.GetValue<string>(0);
 			string input;
@@ -1130,31 +1145,49 @@ static MetadataResult ExecuteCatalogDotCommand(ShellState &state, const string &
 				state.Print("\n");
 			} else {
 				state.PrintDatabaseError(StringUtil::Format("Unsupported catalog dot-command \"%s\"", command));
-				return MetadataResult::FAIL;
+				return CatalogDotExecuteResult::FAIL;
 			}
 		}
 	} catch (std::exception &ex) {
 		duckdb::ErrorData error(ex);
 		state.PrintDatabaseError(error.Message());
-		return MetadataResult::FAIL;
+		return CatalogDotExecuteResult::FAIL;
 	}
-	return MetadataResult::SUCCESS;
+	return CatalogDotExecuteResult::SUCCESS;
 }
 
 int ShellState::TryCatalogDotCommand(const vector<string> &args) {
 	if (!conn || !conn->context) {
 		return -1;
 	}
-	string function_name;
-	string resolve_error;
-	if (!ResolveCatalogDotCommand(*this, args[0], function_name, resolve_error)) {
+	try {
+		string function_name;
+		string resolve_error;
+		if (ResolveCatalogDotCommand(*this, args[0], function_name, resolve_error)) {
+			auto executed = ExecuteCatalogDotCommand(*this, function_name, args);
+			if (executed == CatalogDotExecuteResult::NOT_FOUND) {
+				return -1;
+			}
+			return int(executed);
+		}
 		if (!resolve_error.empty()) {
 			PrintDatabaseError(resolve_error);
 			return int(MetadataResult::FAIL);
 		}
-		return -1;
+		// Listing can fail (invalidated transaction) or miss prefixes. Still try the exact name
+		// so .version reports a query error instead of looking unrecognized, and so the CLI
+		// does not unwind to "Exited due to error".
+		function_name = string(SHELL_DOT_COMMAND_PREFIX) + args[0];
+		auto executed = ExecuteCatalogDotCommand(*this, function_name, args);
+		if (executed == CatalogDotExecuteResult::NOT_FOUND) {
+			return -1;
+		}
+		return int(executed);
+	} catch (std::exception &ex) {
+		duckdb::ErrorData error(ex);
+		PrintDatabaseError(error.Message());
+		return int(MetadataResult::FAIL);
 	}
-	return int(ExecuteCatalogDotCommand(*this, function_name, args));
 }
 
 bool ShouldPrintCommand(const MetadataCommand &command, const string &glob_pattern) {

--- a/tools/shell/shell_metadata_command.cpp
+++ b/tools/shell/shell_metadata_command.cpp
@@ -3,6 +3,11 @@
 #include "shell_prompt.hpp"
 #include "shell_progress_bar.hpp"
 #include "shell_renderer.hpp"
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/catalog/catalog_entry/function_entry.hpp"
+#include "duckdb/catalog/catalog_entry/schema_catalog_entry.hpp"
+#include "duckdb/common/case_insensitive_map.hpp"
+#include "duckdb/main/client_context.hpp"
 
 #ifdef HAVE_LINENOISE
 #include "linenoise.h"
@@ -546,22 +551,6 @@ MetadataResult SetStartupText(ShellState &state, const vector<string> &args) {
 	return MetadataResult::SUCCESS;
 }
 
-MetadataResult ShowVersion(ShellState &state, const vector<string> &args) {
-	state.PrintF("DuckDB %s (%s) %s\n" /*extra-version-info*/, duckdb::DuckDB::LibraryVersion(),
-	             duckdb::DuckDB::ReleaseCodename(), duckdb::DuckDB::SourceID());
-#define CTIMEOPT_VAL_(opt) #opt
-#define CTIMEOPT_VAL(opt)  CTIMEOPT_VAL_(opt)
-#if defined(__clang__) && defined(__clang_major__)
-	state.PrintF("clang-" CTIMEOPT_VAL(__clang_major__) "." CTIMEOPT_VAL(__clang_minor__) "." CTIMEOPT_VAL(
-	    __clang_patchlevel__) "\n");
-#elif defined(_MSC_VER)
-	state.PrintF("msvc-" CTIMEOPT_VAL(_MSC_VER) "\n");
-#elif defined(__GNUC__) && defined(__VERSION__)
-	state.PrintF("gcc-" __VERSION__ "\n");
-#endif
-	return MetadataResult::SUCCESS;
-}
-
 MetadataResult SetWidths(ShellState &state, const vector<string> &args) {
 	state.colWidth.clear();
 	for (idx_t j = 1; j < args.size(); j++) {
@@ -1007,7 +996,6 @@ static const MetadataCommand metadata_commands[] = {
      "Sets the thousand separator used when rendering numbers. Only for duckbox mode.", 4, ""},
     {"timer", 2, ShellState::ToggleTimer, "on|off", "Turn SQL timer on or off", 0, ""},
     {"ui_command", 0, SetUICommand, "[command]", "Set the UI command", 0, ""},
-    {"version", 1, ShowVersion, "", "Show the version", 0, ""},
     {"web", 1, OpenProfileWeb, "", "Open the last query profile (EXPLAIN ANALYZE) in a web browser", 0, ""},
     {"width", 0, SetWidths, "NUM1 NUM2 ...", "Set minimum column widths for columnar output", 0,
      "Negative values right-justify"},
@@ -1016,6 +1004,158 @@ static const MetadataCommand metadata_commands[] = {
      "Deprecated. This option is accepted for compatibility but has no effect.", 0, ""},
 #endif
     {nullptr, 0, nullptr, 0, nullptr}};
+
+static constexpr const char *SHELL_DOT_COMMAND_PREFIX = "shell_dot_command_";
+
+struct CatalogDotCommandInfo {
+	string command;
+	string function_name;
+	string description;
+};
+
+static bool IsStaticMetadataCommand(const string &command) {
+	for (idx_t i = 0; metadata_commands[i].command; i++) {
+		if (StringUtil::CIEquals(metadata_commands[i].command, command)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+static vector<CatalogDotCommandInfo> ListCatalogDotCommands(const ShellState &state) {
+	vector<CatalogDotCommandInfo> result;
+	if (!state.conn || !state.conn->context) {
+		return result;
+	}
+	auto &context = *state.conn->context;
+	duckdb::case_insensitive_set_t seen;
+	auto collect = [&](duckdb::CatalogType type) {
+		auto schemas = duckdb::Catalog::GetAllSchemas(context);
+		for (auto &schema : schemas) {
+			schema.get().Scan(context, type, [&](duckdb::CatalogEntry &entry) {
+				if (!entry.name.StartsWith(SHELL_DOT_COMMAND_PREFIX)) {
+					return;
+				}
+				string full_name = entry.name.GetIdentifierName();
+				string suffix = full_name.substr(strlen(SHELL_DOT_COMMAND_PREFIX));
+				if (suffix.empty() || seen.find(suffix) != seen.end()) {
+					return;
+				}
+				seen.insert(suffix);
+				CatalogDotCommandInfo info;
+				info.command = suffix;
+				info.function_name = std::move(full_name);
+				auto &function_entry = entry.Cast<duckdb::FunctionEntry>();
+				if (!function_entry.descriptions.empty()) {
+					info.description = function_entry.descriptions[0].description;
+				}
+				result.push_back(std::move(info));
+			});
+		}
+	};
+	context.RunFunctionInTransaction([&]() {
+		collect(duckdb::CatalogType::TABLE_FUNCTION_ENTRY);
+		collect(duckdb::CatalogType::TABLE_MACRO_ENTRY);
+	});
+	return result;
+}
+
+static bool ResolveCatalogDotCommand(const ShellState &state, const string &option, string &function_name,
+                                     string &error_msg) {
+	auto commands = ListCatalogDotCommands(state);
+	for (auto &command : commands) {
+		if (StringUtil::CIEquals(command.command, option)) {
+			function_name = command.function_name;
+			return true;
+		}
+	}
+	vector<const CatalogDotCommandInfo *> matches;
+	idx_t n = option.size();
+	for (auto &command : commands) {
+		if (n <= command.command.size() && strncmp(option.c_str(), command.command.c_str(), n) == 0) {
+			matches.push_back(&command);
+		}
+	}
+	if (matches.size() == 1) {
+		function_name = matches[0]->function_name;
+		return true;
+	}
+	if (matches.size() > 1) {
+		vector<string> names;
+		for (auto *match : matches) {
+			names.push_back(string(".") + match->command);
+		}
+		error_msg = StringUtil::Format("Ambiguous Command Error: '.%s' matches multiple catalog commands\n", option);
+		error_msg += StringUtil::CandidatesErrorMessage(names, option, "Did you mean");
+		error_msg += "\n";
+		return false;
+	}
+	return false;
+}
+
+static MetadataResult ExecuteCatalogDotCommand(ShellState &state, const string &function_name,
+                                               const vector<string> &args) {
+	string user_input;
+	for (idx_t i = 1; i < args.size(); i++) {
+		if (i > 1) {
+			user_input += " ";
+		}
+		user_input += args[i];
+	}
+	// Later slices can stream this result instead of materializing.
+	auto sql =
+	    StringUtil::Format("CALL %s(%s, %s)", SQLIdentifier(function_name), SQLString(user_input), SQLString(""));
+	auto result = state.conn->Query(sql);
+	if (result->HasError()) {
+		state.PrintDatabaseError(result->GetError());
+		return MetadataResult::FAIL;
+	}
+	if (result->ColumnCount() < 2) {
+		state.PrintDatabaseError("Catalog dot-command must return columns \"command\" and \"input\"");
+		return MetadataResult::FAIL;
+	}
+	try {
+		for (auto &row : *result) {
+			if (row.IsNull(0)) {
+				state.PrintDatabaseError("Catalog dot-command returned a NULL command");
+				return MetadataResult::FAIL;
+			}
+			auto command = row.GetValue<string>(0);
+			string input;
+			if (!row.IsNull(1)) {
+				input = row.GetValue<string>(1);
+			}
+			if (StringUtil::CIEquals(command, "print")) {
+				state.Print(input);
+				state.Print("\n");
+			} else {
+				state.PrintDatabaseError(StringUtil::Format("Unsupported catalog dot-command \"%s\"", command));
+				return MetadataResult::FAIL;
+			}
+		}
+	} catch (std::exception &ex) {
+		duckdb::ErrorData error(ex);
+		state.PrintDatabaseError(error.Message());
+		return MetadataResult::FAIL;
+	}
+	return MetadataResult::SUCCESS;
+}
+
+int ShellState::TryCatalogDotCommand(const vector<string> &args) {
+	if (!conn || !conn->context) {
+		return -1;
+	}
+	string function_name;
+	string resolve_error;
+	if (!ResolveCatalogDotCommand(*this, args[0], function_name, resolve_error)) {
+		if (!resolve_error.empty()) {
+			PrintDatabaseError(resolve_error);
+			return int(MetadataResult::FAIL);
+		}
+		return -1;
+	}
+	return int(ExecuteCatalogDotCommand(*this, function_name, args));
+}
 
 bool ShouldPrintCommand(const MetadataCommand &command, const string &glob_pattern) {
 	if (!command.extra_description) {
@@ -1120,6 +1260,21 @@ idx_t ShellState::PrintHelp(const char *pattern) {
 			}
 		}
 	}
+	auto catalog_commands = ListCatalogDotCommands(*this);
+	for (auto &catalog_command : catalog_commands) {
+		if (IsStaticMetadataCommand(catalog_command.command)) {
+			continue;
+		}
+		if (!glob_pattern.empty() && !StringGlob(glob_pattern.c_str(), catalog_command.command.c_str())) {
+			continue;
+		}
+		PrintCommandInfo print_info;
+		print_info.command_name = StringUtil::Format(".%s", catalog_command.command);
+		print_info.first_part = " ";
+		print_info.second_part = catalog_command.description;
+		print_info.first_part_highlight = HighlightElementType::STRING_CONSTANT;
+		print_info_list.push_back(std::move(print_info));
+	}
 	// figure out alignment based on the total first part print size
 	idx_t max_lhs_size = 0;
 	for (auto &print_info : print_info_list) {
@@ -1179,6 +1334,29 @@ vector<string> ShellState::GetMetadataCompletions(const char *zLine, idx_t nLine
 			result.push_back(zBuf);
 		}
 	}
+	auto &state = ShellState::Get();
+	auto catalog_commands = ListCatalogDotCommands(state);
+	for (auto &catalog_command : catalog_commands) {
+		if (IsStaticMetadataCommand(catalog_command.command)) {
+			continue;
+		}
+		auto &line = catalog_command.command;
+		bool found_match = true;
+		idx_t line_pos;
+		zBuf[0] = '.';
+		for (line_pos = 0; line_pos < line.size() && !IsSpace(line[line_pos]) && line_pos + 2 < sizeof(zBuf);
+		     line_pos++) {
+			zBuf[line_pos + 1] = line[line_pos];
+			if (line_pos + 1 < nLine && line[line_pos] != zLine[line_pos + 1]) {
+				found_match = false;
+				break;
+			}
+		}
+		zBuf[line_pos + 1] = '\0';
+		if (found_match && line_pos + 1 >= nLine) {
+			result.push_back(zBuf);
+		}
+	}
 	return result;
 }
 
@@ -1199,6 +1377,12 @@ optional_ptr<const MetadataCommand> ShellState::FindMetadataCommand(const string
 	for (idx_t command_idx = 0; metadata_commands[command_idx].command; command_idx++) {
 		auto &command = metadata_commands[command_idx];
 		command_names.push_back(string(".") + command.command);
+	}
+	for (auto &catalog_command : ListCatalogDotCommands(*this)) {
+		if (IsStaticMetadataCommand(catalog_command.command)) {
+			continue;
+		}
+		command_names.push_back(string(".") + catalog_command.command);
 	}
 	auto candidates_msg = StringUtil::CandidatesErrorMessage(command_names, option, "Did you mean");
 	error_msg += candidates_msg + "\n";

--- a/tools/shell/tests/test_shell_dot_command.py
+++ b/tools/shell/tests/test_shell_dot_command.py
@@ -62,3 +62,19 @@ def test_help_lists_plugin_macro(shell):
     )
     result = test.run()
     result.check_stdout(".hello")
+
+
+def test_dot_commands_do_not_abort_after_failed_transaction(shell):
+    test = (
+        ShellTest(shell)
+        .statement(".bail off")
+        .statement("BEGIN")
+        .statement("SELECT * FROM this_table_does_not_exist")
+        .statement(".version")
+        .statement(".not_a_real_dot_command")
+        .statement(".help")
+    )
+    result = test.run()
+    assert "Exited due to error" not in result.stderr
+    result.check_stderr("Unrecognized command")
+    assert "Show help text for PATTERN" in result.stdout

--- a/tools/shell/tests/test_shell_dot_command.py
+++ b/tools/shell/tests/test_shell_dot_command.py
@@ -1,0 +1,64 @@
+# fmt: off
+
+from conftest import ShellTest
+
+
+def test_dot_version(shell):
+    test = ShellTest(shell).statement(".version")
+    result = test.run()
+    result.check_stdout("DuckDB")
+    result.check_stdout("v")
+    assert any(token in result.stdout for token in ("clang-", "gcc-", "msvc-"))
+
+
+def test_dot_version_prefix(shell):
+    test = ShellTest(shell).statement(".ver")
+    result = test.run()
+    result.check_stdout("DuckDB")
+    result.check_stdout("v")
+
+
+def test_call_shell_dot_command_version(shell):
+    test = ShellTest(shell).statement("CALL shell_dot_command_version('', '')")
+    result = test.run()
+    result.check_stdout("print")
+    result.check_stdout("DuckDB")
+
+
+def test_help_lists_catalog_version(shell):
+    test = ShellTest(shell).statement(".help")
+    result = test.run()
+    result.check_stdout(".version")
+    result.check_stdout("Show the version")
+
+
+def test_catalog_plugin_macro(shell):
+    test = (
+        ShellTest(shell)
+        .statement(
+            "CREATE MACRO shell_dot_command_hello(user_input, extra_info) AS TABLE "
+            "SELECT 'print' AS command, 'hello from plugin' AS input"
+        )
+        .statement(".hello")
+    )
+    result = test.run()
+    result.check_stdout("hello from plugin")
+
+
+def test_unknown_dot_command(shell):
+    test = ShellTest(shell).statement(".not_a_real_dot_command")
+    result = test.run()
+    result.check_stderr("Unrecognized command")
+
+
+def test_help_lists_plugin_macro(shell):
+    test = (
+        ShellTest(shell)
+        .statement(
+            "CREATE MACRO shell_dot_command_hello(user_input, extra_info) AS TABLE "
+            "SELECT 'print' AS command, 'hello from plugin' AS input"
+        )
+        .statement(".help hello")
+    )
+    result = test.run()
+    result.check_stdout(".hello")


### PR DESCRIPTION
## Summary

Restart of the first slice from #22079, as a new PR rather than a revival of that one.

Credit: @rustyconover opened #22079 with a C++ `ShellContext` / callback-manager approach for plugin `.` commands (including a video of the interaction model). @Mytherin reviewed that and asked not to take the C++ hook path, and instead sketched an incremental one: catalog functions named `shell_dot_command_<name>`, starting there because it does not conflict with the PEG-grammar work. This PR follows that catalog path only. It is not a port of the closed C++ hooks.

What this PR adds:

- Unknown `.cmd` looks up catalog table functions/macros named `shell_dot_command_<cmd>` and `CALL`s them with `(user_input, extra_info)`.
- Result protocol is `command` / `input` columns; only `print` is implemented (stdout + newline).
- Exact match first, then unique prefix among catalog suffixes (so `.ver` still hits `.version`). Ambiguous prefixes error instead of first-match.
- `.help`, tab-completion, and "Did you mean" include those catalog names (skipping names already in the static table). Description comes from `FunctionDescription`.
- `.version` is migrated off the static metadata table onto `shell_dot_command_version` in the shell extension. `-version` / `ShowVersionAndExit` are unchanged.
- Catalog listing runs in a transaction so `.` commands do not hit `ActiveTransaction` with no txn, and listing/dispatch failures do not unwind the CLI to `Exited due to error` after an aborted transaction.

Not in this PR: `~/.duckdb/shell_history.db`, PEG highlighting/autocomplete, streaming `clear_line` / MAP+VARIANT, or folding the rest of the static dot-commands into the grammar.

## Test plan

```
GEN=ninja make reldebug
python3 -m pytest tools/shell/tests/test_shell_dot_command.py --shell-binary build/reldebug/duckdb
python3 -m pytest tools/shell/tests --shell-binary build/reldebug/duckdb
```

Confirm `.version`, `.ver`, and `-version` still behave as before. The new file also covers a plugin `CREATE MACRO shell_dot_command_hello(...)`, unknown `.` commands, `.help` listing, and `.version` after an aborted transaction.

