### PR TITLE
Initial boilerplate for `DialectExtension`

### DIFF
--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -257,6 +257,18 @@
         ]
     },
     {
+        "name": "current_dialect",
+        "description": "The SQL dialect used by the parser",
+        "type": "VARCHAR",
+        "scope": "global",
+        "default_value": "duckdb",
+        "on_callbacks": [
+            "set",
+            "reset"
+        ],
+        "custom_implementation": true
+    },
+    {
         "name": "current_transaction_invalidation_policy",
         "description": "Which types of exceptions invalidate the database for the current transaction",
         "type": "VARCHAR",

--- a/src/function/table/system/CMakeLists.txt
+++ b/src/function/table/system/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library_unity(
   duckdb_coordinate_systems.cpp
   duckdb_databases.cpp
   duckdb_dependencies.cpp
+  duckdb_dialects.cpp
   create_external_resource.cpp
   duckdb_extensions.cpp
   duckdb_external_file_cache.cpp

--- a/src/function/table/system/duckdb_dialects.cpp
+++ b/src/function/table/system/duckdb_dialects.cpp
@@ -1,0 +1,44 @@
+#include "duckdb/function/table/system_functions.hpp"
+
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/main/extension_callback_manager.hpp"
+#include "duckdb/parser/dialect_extension.hpp"
+
+namespace duckdb {
+
+struct DuckDBDialectsData : public GlobalTableFunctionState {
+	vector<string> dialects;
+	idx_t offset = 0;
+};
+
+static unique_ptr<FunctionData> DuckDBDialectsBind(ClientContext &context, TableFunctionBindInput &input,
+                                                   vector<LogicalType> &return_types, vector<Identifier> &names) {
+	names.emplace_back("dialect_name");
+	return_types.emplace_back(LogicalType::VARCHAR);
+	return nullptr;
+}
+
+static unique_ptr<GlobalTableFunctionState> DuckDBDialectsInit(ClientContext &context, TableFunctionInitInput &input) {
+	auto result = make_uniq<DuckDBDialectsData>();
+	for (auto &dialect : ExtensionCallbackManager::Get(context).DialectExtensions()) {
+		result->dialects.push_back(dialect.name);
+	}
+	return std::move(result);
+}
+
+static void DuckDBDialectsFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &data = data_p.global_state->Cast<DuckDBDialectsData>();
+	auto &dialect_name = output.data[0];
+	idx_t count = 0;
+	while (data.offset < data.dialects.size() && count < STANDARD_VECTOR_SIZE) {
+		dialect_name.Append(Value(data.dialects[data.offset++]));
+		count++;
+	}
+}
+
+void DuckDBDialectsFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(
+	    TableFunction("duckdb_dialects", {}, DuckDBDialectsFunction, DuckDBDialectsBind, DuckDBDialectsInit));
+}
+
+} // namespace duckdb

--- a/src/function/table/system_functions.cpp
+++ b/src/function/table/system_functions.cpp
@@ -32,6 +32,7 @@ void BuiltinFunctions::RegisterSQLiteFunctions() {
 	DuckDBIndexesFun::RegisterFunction(*this);
 	DuckDBSchemasFun::RegisterFunction(*this);
 	DuckDBDependenciesFun::RegisterFunction(*this);
+	DuckDBDialectsFun::RegisterFunction(*this);
 	DuckDBExtensionsFun::RegisterFunction(*this);
 	RegisterExternalResourceTypeFun::RegisterFunction(*this);
 	CreateExternalResourceFun::RegisterFunction(*this);

--- a/src/include/duckdb/function/table/system_functions.hpp
+++ b/src/include/duckdb/function/table/system_functions.hpp
@@ -84,6 +84,10 @@ struct DuckDBDependenciesFun {
 	static void RegisterFunction(BuiltinFunctions &set);
 };
 
+struct DuckDBDialectsFun {
+	static void RegisterFunction(BuiltinFunctions &set);
+};
+
 struct DuckDBExtensionsFun {
 	static void RegisterFunction(BuiltinFunctions &set);
 };

--- a/src/include/duckdb/main/extension_callback_manager.hpp
+++ b/src/include/duckdb/main/extension_callback_manager.hpp
@@ -17,6 +17,7 @@ namespace duckdb {
 
 class ClientContext;
 class DatabaseInstance;
+class DialectExtension;
 class ExtensionCallback;
 class OperatorExtension;
 class OptimizerExtension;
@@ -42,6 +43,7 @@ public:
 	static const ExtensionCallbackManager &Get(const ClientContext &context);
 
 	void Register(ParserExtension extension);
+	void Register(DialectExtension extension);
 	void Register(PlannerExtension extension);
 	void Register(OptimizerExtension extension);
 	void Register(shared_ptr<OperatorExtension> extension);
@@ -52,11 +54,13 @@ public:
 	ExtensionCallbackIteratorHelper<shared_ptr<OperatorExtension>> OperatorExtensions() const;
 	ExtensionCallbackIteratorHelper<OptimizerExtension> OptimizerExtensions() const;
 	ExtensionCallbackIteratorHelper<ParserExtension> ParserExtensions() const;
+	ExtensionCallbackIteratorHelper<DialectExtension> DialectExtensions() const;
 	ExtensionCallbackIteratorHelper<PlannerExtension> PlannerExtensions() const;
 	ExtensionCallbackIteratorHelper<shared_ptr<ExtensionCallback>> ExtensionCallbacks() const;
 	optional_ptr<StorageExtension> FindStorageExtension(const string &name) const;
 	optional_ptr<ProfilerExtension> FindProfilerExtension(const string &name) const;
 	bool HasParserExtensions() const;
+	bool HasDialectExtension(const string &name) const;
 
 private:
 	mutex registry_lock;

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -457,6 +457,17 @@ struct ConfigureProfilingSetting {
 	static Value GetSetting(const ClientContext &context);
 };
 
+struct CurrentDialectSetting {
+	using RETURN_TYPE = string;
+	static constexpr const char *Name = "current_dialect";
+	static constexpr const char *Description = "The SQL dialect used by the parser";
+	static constexpr const char *InputType = "VARCHAR";
+	static constexpr const char *DefaultValue = "duckdb";
+	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
+	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+	static void OnSet(SettingCallbackInfo &info, Value &input);
+};
+
 struct CurrentTransactionInvalidationPolicySetting {
 	using RETURN_TYPE = string;
 	static constexpr const char *Name = "current_transaction_invalidation_policy";

--- a/src/include/duckdb/parser/dialect_extension.hpp
+++ b/src/include/duckdb/parser/dialect_extension.hpp
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/parser/dialect_extension.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/common.hpp"
+
+namespace duckdb {
+struct DBConfig;
+
+//! A named SQL dialect that can customize the PEG parser.
+class DialectExtension {
+public:
+	explicit DialectExtension(string name_p) : name(std::move(name_p)) {
+	}
+
+	string name;
+
+	static void Register(DBConfig &config, DialectExtension extension);
+};
+
+} // namespace duckdb

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -97,6 +97,7 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_SETTING_CALLBACK(CheckpointOnDetachSetting),
     DUCKDB_GLOBAL(CheckpointThresholdSetting),
     DUCKDB_LOCAL(ConfigureProfilingSetting),
+    DUCKDB_SETTING_CALLBACK(CurrentDialectSetting),
     DUCKDB_SETTING_CALLBACK(CurrentTransactionInvalidationPolicySetting),
     DUCKDB_SETTING(CustomExtensionRepositorySetting),
     DUCKDB_GLOBAL(CustomUserAgentSetting),
@@ -250,12 +251,12 @@ static const ConfigurationOption internal_options[] = {
 
 static const ConfigurationAlias setting_aliases[] = {DUCKDB_SETTING_ALIAS("configure_metrics", 30),
                                                      DUCKDB_SETTING_ALIAS("custom_profiling_settings", 30),
-                                                     DUCKDB_SETTING_ALIAS("memory_limit", 129),
-                                                     DUCKDB_SETTING_ALIAS("null_order", 61),
-                                                     DUCKDB_SETTING_ALIAS("profile_output", 152),
-                                                     DUCKDB_SETTING_ALIAS("user", 171),
+                                                     DUCKDB_SETTING_ALIAS("memory_limit", 130),
+                                                     DUCKDB_SETTING_ALIAS("null_order", 62),
+                                                     DUCKDB_SETTING_ALIAS("profile_output", 153),
+                                                     DUCKDB_SETTING_ALIAS("user", 172),
                                                      DUCKDB_SETTING_ALIAS("wal_autocheckpoint", 29),
-                                                     DUCKDB_SETTING_ALIAS("worker_threads", 169),
+                                                     DUCKDB_SETTING_ALIAS("worker_threads", 170),
                                                      FINAL_ALIAS};
 
 vector<ConfigurationOption> DBConfig::GetOptions() {

--- a/src/main/extension_callback_manager.cpp
+++ b/src/main/extension_callback_manager.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/main/extension_callback_manager.hpp"
 #include "duckdb/parser/parser_extension.hpp"
+#include "duckdb/parser/dialect_extension.hpp"
 #include "duckdb/optimizer/optimizer_extension.hpp"
 #include "duckdb/planner/operator_extension.hpp"
 #include "duckdb/planner/planner_extension.hpp"
@@ -11,6 +12,8 @@
 namespace duckdb {
 
 struct ExtensionCallbackRegistry {
+	//! SQL dialects made available to the PEG parser
+	vector<DialectExtension> dialect_extensions;
 	//! Extensions made to the parser
 	vector<ParserExtension> parser_extensions;
 	//! Extensions made to the planner
@@ -40,6 +43,7 @@ ExtensionCallbackManager &ExtensionCallbackManager::Get(DatabaseInstance &db) {
 }
 
 ExtensionCallbackManager::ExtensionCallbackManager() : callback_registry(make_shared_ptr<ExtensionCallbackRegistry>()) {
+	callback_registry->dialect_extensions.emplace_back("duckdb");
 }
 ExtensionCallbackManager::~ExtensionCallbackManager() {
 }
@@ -56,6 +60,21 @@ void ExtensionCallbackManager::Register(ParserExtension extension) {
 	lock_guard<mutex> guard(registry_lock);
 	auto new_registry = make_shared_ptr<ExtensionCallbackRegistry>(*callback_registry);
 	new_registry->parser_extensions.push_back(std::move(extension));
+	callback_registry.atomic_store(new_registry);
+}
+
+void ExtensionCallbackManager::Register(DialectExtension extension) {
+	if (extension.name.empty()) {
+		throw InvalidInputException("Dialect name cannot be empty");
+	}
+	lock_guard<mutex> guard(registry_lock);
+	auto new_registry = make_shared_ptr<ExtensionCallbackRegistry>(*callback_registry);
+	for (auto &existing : new_registry->dialect_extensions) {
+		if (StringUtil::CIEquals(existing.name, extension.name)) {
+			throw InvalidInputException("Dialect \"%s\" is already registered", extension.name);
+		}
+	}
+	new_registry->dialect_extensions.push_back(std::move(extension));
 	callback_registry.atomic_store(new_registry);
 }
 
@@ -129,6 +148,12 @@ ExtensionCallbackIteratorHelper<ParserExtension> ExtensionCallbackManager::Parse
 	return ExtensionCallbackIteratorHelper<ParserExtension>(parser_extensions, std::move(registry));
 }
 
+ExtensionCallbackIteratorHelper<DialectExtension> ExtensionCallbackManager::DialectExtensions() const {
+	auto registry = callback_registry.atomic_load();
+	auto &dialect_extensions = registry->dialect_extensions;
+	return ExtensionCallbackIteratorHelper<DialectExtension>(dialect_extensions, std::move(registry));
+}
+
 ExtensionCallbackIteratorHelper<PlannerExtension> ExtensionCallbackManager::PlannerExtensions() const {
 	auto registry = callback_registry.atomic_load();
 	auto &planner_extensions = registry->planner_extensions;
@@ -164,11 +189,25 @@ bool ExtensionCallbackManager::HasParserExtensions() const {
 	return !registry->parser_extensions.empty();
 }
 
+bool ExtensionCallbackManager::HasDialectExtension(const string &name) const {
+	auto registry = callback_registry.atomic_load();
+	for (auto &dialect : registry->dialect_extensions) {
+		if (StringUtil::CIEquals(dialect.name, name)) {
+			return true;
+		}
+	}
+	return false;
+}
+
 void OptimizerExtension::Register(DBConfig &config, OptimizerExtension extension) {
 	config.GetCallbackManager().Register(std::move(extension));
 }
 
 void ParserExtension::Register(DBConfig &config, ParserExtension extension) {
+	config.GetCallbackManager().Register(std::move(extension));
+}
+
+void DialectExtension::Register(DBConfig &config, DialectExtension extension) {
 	config.GetCallbackManager().Register(std::move(extension));
 }
 
@@ -205,6 +244,7 @@ template class ExtensionCallbackIteratorHelper<shared_ptr<ExtensionCallback>>;
 template class ExtensionCallbackIteratorHelper<shared_ptr<OperatorExtension>>;
 template class ExtensionCallbackIteratorHelper<OptimizerExtension>;
 template class ExtensionCallbackIteratorHelper<ParserExtension>;
+template class ExtensionCallbackIteratorHelper<DialectExtension>;
 template class ExtensionCallbackIteratorHelper<PlannerExtension>;
 
 } // namespace duckdb

--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -27,10 +27,12 @@
 #include "duckdb/main/database_manager.hpp"
 #include "duckdb/common/tree_renderer.hpp"
 #include "duckdb/main/extension_helper.hpp"
+#include "duckdb/main/extension_callback_manager.hpp"
 #include "duckdb/main/query_profiler.hpp"
 #include "duckdb/main/secret/secret_manager.hpp"
 #include "duckdb/parallel/task_scheduler.hpp"
 #include "duckdb/parser/parser.hpp"
+#include "duckdb/parser/peg/matcher.hpp"
 #include "duckdb/planner/expression_binder.hpp"
 #include "duckdb/storage/external_file_cache/external_file_cache.hpp"
 #include "duckdb/storage/buffer/buffer_pool.hpp"
@@ -1647,5 +1649,18 @@ void CurrentTransactionInvalidationPolicySetting::OnSet(SettingCallbackInfo &inf
 	}
 	info.context->transaction.SetInvalidationPolicy(
 	    EnumUtil::FromString<TransactionInvalidationPolicy>(input.GetValue<string>()));
+}
+
+void CurrentDialectSetting::OnSet(SettingCallbackInfo &info, Value &input) {
+	if (input.IsNull()) {
+		throw InvalidInputException("current_dialect setting cannot be NULL");
+	}
+	auto dialect_name = input.GetValue<string>();
+	if (!info.config.GetCallbackManager().HasDialectExtension(dialect_name)) {
+		throw InvalidInputException("Dialect \"%s\" is not installed", dialect_name);
+	}
+	if (info.db) {
+		info.db->GetParserCache().Invalidate();
+	}
 }
 } // namespace duckdb

--- a/test/api/test_reset.cpp
+++ b/test/api/test_reset.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/enums/deprecated_using_key_syntax.hpp"
 #include "duckdb/common/enums/dialect_compatibility_mode.hpp"
 #include "duckdb/common/enums/table_function_identifier_conversion.hpp"
+#include "duckdb/parser/dialect_extension.hpp"
 #include "test_helpers.hpp"
 
 #include <iostream>
@@ -143,6 +144,7 @@ OptionValueSet GetValueForOption(const string &name, const LogicalType &type) {
 	    {"storage_block_prefetch", {"always_prefetch"}},
 	    {"operator_memory_limit", {"4.0 GiB"}},
 	    {"pin_threads", {"off"}},
+	    {"current_dialect", {"test"}},
 	    {"current_transaction_invalidation_policy", {"SYNTACTIC_ERRORS_DO_NOT_INVALIDATE"}},
 	    {"default_transaction_invalidation_policy", {"SYNTACTIC_ERRORS_DO_NOT_INVALIDATE"}},
 	    {"checkpoint_on_detach", {"ENABLED"}},
@@ -260,6 +262,7 @@ TEST_CASE("Test RESET statement for ClientConfig options", "[api]") {
 	// Create a connection
 	DBConfig config;
 	config.options.load_extensions = false;
+	DialectExtension::Register(config, DialectExtension("test"));
 	DuckDB db(nullptr, &config);
 	Connection con(db);
 	con.Query("BEGIN TRANSACTION");

--- a/test/sql/table_function/duckdb_dialects.test
+++ b/test/sql/table_function/duckdb_dialects.test
@@ -1,0 +1,24 @@
+# name: test/sql/table_function/duckdb_dialects.test
+# description: Test the duckdb_dialects table function and current_dialect setting
+# group: [table_function]
+
+query I
+SELECT dialect_name FROM duckdb_dialects() ORDER BY dialect_name;
+----
+duckdb
+
+query I
+SELECT current_setting('current_dialect');
+----
+duckdb
+
+statement ok
+SET current_dialect = 'duckdb';
+
+statement error
+SET current_dialect = 'missing';
+----
+Dialect "missing" is not installed
+
+statement ok
+RESET current_dialect;


### PR DESCRIPTION
This PR is part of https://github.com/duckdblabs/duckdb-internal/issues/10346

It adds:
- `FROM duckdb_dialects()`
- `SELECT current_setting('current_dialect');`

For now the setting is an empty shell, to be populated by follow up PRs.
The only behavior that's tied to changing `current_dialect` for now is calling `Invalidate` on the parser cache.