### PR TITLE
Fix Go nightly workflow dispatch

### DIFF
--- a/.github/workflows/NotifyExternalRepositories.yml
+++ b/.github/workflows/NotifyExternalRepositories.yml
@@ -132,6 +132,6 @@ jobs:
       - name: Call /dispatch
         if: ${{ github.repository == 'duckdb/duckdb' && inputs.override-git-describe == '' }}
         run: |
-          export URL=https://api.github.com/repos/duckdb/duckdb-go-bindings/actions/workflows/nightly.yaml/dispatches
+          export URL=https://api.github.com/repos/duckdb/duckdb-go-bindings/actions/workflows/nightly.yml/dispatches
           export DATA='{"ref": "main", "inputs": {"duckdb-sha": "${{ inputs.duckdb-sha }}" }}'
           curl -v -XPOST -u "${PAT_USER}:${PAT_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" $URL --data "$DATA"


### PR DESCRIPTION
PR #24720 added the Go nightly dispatch with the wrong workflow extension. 🤦🏻‍♂️ 

Point it at `nightly.yml` so scheduled builds can start.

(I've considered renaming the extension in duckdb-go-bindings, but .yml is way more common in DuckDB land.)

refs https://github.com/duckdblabs/duckdb-internal/issues/7516
