### PR TITLE
Prune row groups with cross-column comparisons

### DIFF
--- a/src/execution/physical_plan/plan_get.cpp
+++ b/src/execution/physical_plan/plan_get.cpp
@@ -20,6 +20,9 @@ unique_ptr<TableFilterSet> MoveTableFilters(TableFilterSet &table_filters) {
 	for (auto &entry : table_filters) {
 		table_filter_set->SetFilterByColumnIndex(entry.GetIndex(), entry.TakeFilter());
 	}
+	for (const auto &filter : table_filters.GetRowGroupFilters()) {
+		table_filter_set->PushRowGroupFilter(filter.Copy());
+	}
 	return table_filter_set;
 }
 
@@ -76,7 +79,7 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalGet &op) {
 	}
 
 	unique_ptr<TableFilterSet> table_filters;
-	if (op.table_filters.HasFilters()) {
+	if (op.table_filters.HasFilters() || op.table_filters.HasRowGroupFilters()) {
 		table_filters = MoveTableFilters(op.table_filters);
 	}
 

--- a/src/execution/physical_plan/plan_get.cpp
+++ b/src/execution/physical_plan/plan_get.cpp
@@ -8,6 +8,7 @@
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
+#include "duckdb/planner/filter/expression_filter.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/planner/expression/bound_conjunction_expression.hpp"
 #include "duckdb/execution/operator/filter/physical_filter.hpp"
@@ -20,8 +21,9 @@ unique_ptr<TableFilterSet> MoveTableFilters(TableFilterSet &table_filters) {
 	for (auto &entry : table_filters) {
 		table_filter_set->SetFilterByColumnIndex(entry.GetIndex(), entry.TakeFilter());
 	}
-	for (const auto &filter : table_filters.GetRowGroupFilters()) {
-		table_filter_set->PushRowGroupFilter(filter.Copy());
+	for (const auto &filter : table_filters.GetMultiColumnFilters()) {
+		const auto &expression_filter = ExpressionFilter::GetExpressionFilter(*filter, "MoveTableFilters");
+		table_filter_set->PushMultiColumnFilter(expression_filter.Copy());
 	}
 	return table_filter_set;
 }
@@ -79,7 +81,7 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalGet &op) {
 	}
 
 	unique_ptr<TableFilterSet> table_filters;
-	if (op.table_filters.HasFilters() || op.table_filters.HasRowGroupFilters()) {
+	if (op.table_filters.HasFilters() || op.table_filters.HasMultiColumnFilters()) {
 		table_filters = MoveTableFilters(op.table_filters);
 	}
 

--- a/src/include/duckdb/optimizer/statistics_propagator.hpp
+++ b/src/include/duckdb/optimizer/statistics_propagator.hpp
@@ -46,6 +46,9 @@ public:
 	static unique_ptr<BaseStatistics> PropagateMonotoneBounds(ClientContext &context,
 	                                                          const BoundFunctionExpression &func,
 	                                                          const vector<BaseStatistics> &child_stats);
+	//! Compare two sets of statistics and return whether the comparison is always true or false
+	static FilterPropagateResult PropagateComparison(BaseStatistics &left, BaseStatistics &right,
+	                                                 ExpressionType comparison);
 
 private:
 	//! Propagate statistics through an operator
@@ -72,9 +75,6 @@ private:
 
 	//! Return statistics from a constant value
 	unique_ptr<BaseStatistics> StatisticsFromValue(const Value &input);
-	//! Run a comparison with two sets of statistics, returns if the comparison will always returns true/false or not
-	FilterPropagateResult PropagateComparison(BaseStatistics &left, BaseStatistics &right, ExpressionType comparison);
-
 	//! Update filter statistics from a filter with a constant
 	void UpdateFilterStatistics(BaseStatistics &input, ExpressionType comparison_type, const Value &constant);
 	//! Update statistics from a filter between two stats

--- a/src/include/duckdb/optimizer/statistics_propagator.hpp
+++ b/src/include/duckdb/optimizer/statistics_propagator.hpp
@@ -47,7 +47,7 @@ public:
 	                                                          const BoundFunctionExpression &func,
 	                                                          const vector<BaseStatistics> &child_stats);
 	//! Compare two sets of statistics and return whether the comparison is always true or false
-	static FilterPropagateResult PropagateComparison(BaseStatistics &left, BaseStatistics &right,
+	static FilterPropagateResult PropagateComparison(const BaseStatistics &left, const BaseStatistics &right,
 	                                                 ExpressionType comparison);
 
 private:

--- a/src/include/duckdb/planner/filter/expression_filter.hpp
+++ b/src/include/duckdb/planner/filter/expression_filter.hpp
@@ -28,9 +28,12 @@ public:
 
 public:
 	explicit ExpressionFilter(unique_ptr<Expression> expr);
+	ExpressionFilter(unique_ptr<Expression> expr, vector<ProjectionIndex> column_indexes);
 
 	//! The expression to evaluate
 	unique_ptr<Expression> expr;
+	//! For multi-column filters, maps BoundReferenceExpression indexes to scan projection indexes
+	vector<ProjectionIndex> column_indexes;
 
 public:
 	bool EvaluateWithConstant(ClientContext &context, const Value &val) const;
@@ -52,6 +55,11 @@ public:
 	static FilterPropagateResult CheckExpressionStatistics(const Expression &expr, const BaseStatistics &stats);
 	static FilterPropagateResult CheckExpressionStatistics(optional_ptr<ClientContext> context_p,
 	                                                       const Expression &expr, const BaseStatistics &stats);
+	static FilterPropagateResult CheckExpressionStatistics(const Expression &expr,
+	                                                       array_ptr<const BaseStatistics> input_stats);
+	static FilterPropagateResult CheckExpressionStatistics(optional_ptr<ClientContext> context_p,
+	                                                       const Expression &expr,
+	                                                       array_ptr<const BaseStatistics> input_stats);
 	//! Derive statistics for an expression over one or more input columns
 	static unique_ptr<BaseStatistics> TryGetExpressionStatistics(ClientContext &context, const Expression &expr,
 	                                                             array_ptr<const BaseStatistics> input_stats);

--- a/src/include/duckdb/planner/table_filter_set.hpp
+++ b/src/include/duckdb/planner/table_filter_set.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "duckdb/planner/table_filter.hpp"
+#include "duckdb/planner/expression.hpp"
 #include "duckdb/common/mutex.hpp"
 #include "duckdb/common/reference_map.hpp"
 #include "duckdb/common/types.hpp"
@@ -16,13 +17,32 @@
 
 namespace duckdb {
 
-//! The filters in here are non-composite (only need a single column to be evaluated)
-//! Conditions like `A = 2 OR B = 4` are not pushed into a TableFilterSet.
+struct RowGroupExpressionFilter {
+	RowGroupExpressionFilter();
+	RowGroupExpressionFilter(vector<ProjectionIndex> column_indexes, unique_ptr<Expression> expression);
+
+	vector<ProjectionIndex> column_indexes;
+	unique_ptr<Expression> expression;
+
+	bool Equals(const RowGroupExpressionFilter &other) const;
+	bool operator==(const RowGroupExpressionFilter &other) const {
+		return Equals(other);
+	}
+	RowGroupExpressionFilter Copy() const;
+
+	void Serialize(Serializer &serializer) const;
+	static RowGroupExpressionFilter Deserialize(Deserializer &deserializer);
+};
+
+//! The regular filters in here only need a single column to be evaluated.
+//! Composite filters can be stored separately for row-group pruning.
 class TableFilterSet {
 public:
 	void PushFilter(ProjectionIndex col_idx, unique_ptr<TableFilter> filter);
+	void PushRowGroupFilter(RowGroupExpressionFilter filter);
 	bool HasFilters() const;
 	idx_t FilterCount() const;
+	bool HasRowGroupFilters() const;
 	bool HasFilter(ProjectionIndex col_idx) const;
 	TableFilter &GetFilterByColumnIndexMutable(ProjectionIndex col_idx);
 	optional_ptr<TableFilter> TryGetFilterByColumnIndexMutable(ProjectionIndex col_idx);
@@ -31,6 +51,7 @@ public:
 	void SetFilterByColumnIndex(ProjectionIndex col_idx, unique_ptr<TableFilter> filter);
 	void RemoveFilterByColumnIndex(ProjectionIndex col_idx);
 	void ClearFilters();
+	const vector<RowGroupExpressionFilter> &GetRowGroupFilters() const;
 
 	bool Equals(TableFilterSet &other);
 	static bool Equals(TableFilterSet *left, TableFilterSet *right);
@@ -109,6 +130,7 @@ public:
 
 private:
 	map<ProjectionIndex, unique_ptr<TableFilter>> filters;
+	vector<RowGroupExpressionFilter> row_group_filters;
 };
 
 class DynamicTableFilterSet {

--- a/src/include/duckdb/planner/table_filter_set.hpp
+++ b/src/include/duckdb/planner/table_filter_set.hpp
@@ -9,7 +9,6 @@
 #pragma once
 
 #include "duckdb/planner/table_filter.hpp"
-#include "duckdb/planner/expression.hpp"
 #include "duckdb/common/mutex.hpp"
 #include "duckdb/common/reference_map.hpp"
 #include "duckdb/common/types.hpp"
@@ -17,32 +16,13 @@
 
 namespace duckdb {
 
-struct RowGroupExpressionFilter {
-	RowGroupExpressionFilter();
-	RowGroupExpressionFilter(vector<ProjectionIndex> column_indexes, unique_ptr<Expression> expression);
-
-	vector<ProjectionIndex> column_indexes;
-	unique_ptr<Expression> expression;
-
-	bool Equals(const RowGroupExpressionFilter &other) const;
-	bool operator==(const RowGroupExpressionFilter &other) const {
-		return Equals(other);
-	}
-	RowGroupExpressionFilter Copy() const;
-
-	void Serialize(Serializer &serializer) const;
-	static RowGroupExpressionFilter Deserialize(Deserializer &deserializer);
-};
-
-//! The regular filters in here only need a single column to be evaluated.
-//! Composite filters can be stored separately for row-group pruning.
 class TableFilterSet {
 public:
 	void PushFilter(ProjectionIndex col_idx, unique_ptr<TableFilter> filter);
-	void PushRowGroupFilter(RowGroupExpressionFilter filter);
+	void PushMultiColumnFilter(unique_ptr<TableFilter> filter);
 	bool HasFilters() const;
 	idx_t FilterCount() const;
-	bool HasRowGroupFilters() const;
+	bool HasMultiColumnFilters() const;
 	bool HasFilter(ProjectionIndex col_idx) const;
 	TableFilter &GetFilterByColumnIndexMutable(ProjectionIndex col_idx);
 	optional_ptr<TableFilter> TryGetFilterByColumnIndexMutable(ProjectionIndex col_idx);
@@ -51,7 +31,7 @@ public:
 	void SetFilterByColumnIndex(ProjectionIndex col_idx, unique_ptr<TableFilter> filter);
 	void RemoveFilterByColumnIndex(ProjectionIndex col_idx);
 	void ClearFilters();
-	const vector<RowGroupExpressionFilter> &GetRowGroupFilters() const;
+	const vector<unique_ptr<TableFilter>> &GetMultiColumnFilters() const;
 
 	bool Equals(TableFilterSet &other);
 	static bool Equals(TableFilterSet *left, TableFilterSet *right);
@@ -130,7 +110,7 @@ public:
 
 private:
 	map<ProjectionIndex, unique_ptr<TableFilter>> filters;
-	vector<RowGroupExpressionFilter> row_group_filters;
+	vector<unique_ptr<TableFilter>> multi_column_filters;
 };
 
 class DynamicTableFilterSet {

--- a/src/include/duckdb/storage/serialization/nodes.json
+++ b/src/include/duckdb/storage/serialization/nodes.json
@@ -632,6 +632,25 @@
     "pointer_type": "none"
   },
   {
+    "class": "RowGroupExpressionFilter",
+    "includes": [
+      "duckdb/planner/table_filter_set.hpp"
+    ],
+    "members": [
+      {
+        "id": 100,
+        "name": "column_indexes",
+        "type": "vector<ProjectionIndex>"
+      },
+      {
+        "id": 101,
+        "name": "expression",
+        "type": "Expression*"
+      }
+    ],
+    "pointer_type": "none"
+  },
+  {
     "class": "TableFilterSet",
     "includes": [
       "duckdb/planner/table_filter.hpp",
@@ -644,6 +663,12 @@
         "type": "map<ProjectionIndex, TableFilter*>",
         "serialize_property": "GetTableFiltersForSerialization(serializer)",
         "deserialize_property": "GetTableFiltersForDeserialization(deserializer)"
+      },
+      {
+        "id": 101,
+        "name": "row_group_filters",
+        "type": "vector<RowGroupExpressionFilter>",
+        "default": "vector<RowGroupExpressionFilter>()"
       }
     ],
     "pointer_type": "none"

--- a/src/include/duckdb/storage/serialization/nodes.json
+++ b/src/include/duckdb/storage/serialization/nodes.json
@@ -632,25 +632,6 @@
     "pointer_type": "none"
   },
   {
-    "class": "RowGroupExpressionFilter",
-    "includes": [
-      "duckdb/planner/table_filter_set.hpp"
-    ],
-    "members": [
-      {
-        "id": 100,
-        "name": "column_indexes",
-        "type": "vector<ProjectionIndex>"
-      },
-      {
-        "id": 101,
-        "name": "expression",
-        "type": "Expression*"
-      }
-    ],
-    "pointer_type": "none"
-  },
-  {
     "class": "TableFilterSet",
     "includes": [
       "duckdb/planner/table_filter.hpp",
@@ -666,9 +647,9 @@
       },
       {
         "id": 101,
-        "name": "row_group_filters",
-        "type": "vector<RowGroupExpressionFilter>",
-        "default": "vector<RowGroupExpressionFilter>()"
+        "name": "multi_column_filters",
+        "type": "vector<TableFilter*>",
+        "default": "vector<unique_ptr<TableFilter>>()"
       }
     ],
     "pointer_type": "none"

--- a/src/include/duckdb/storage/serialization/table_filter.json
+++ b/src/include/duckdb/storage/serialization/table_filter.json
@@ -157,8 +157,14 @@
         "id": 200,
         "name": "expr",
         "type": "Expression*"
+      },
+      {
+        "id": 201,
+        "name": "column_indexes",
+        "type": "vector<ProjectionIndex>",
+        "default": "vector<ProjectionIndex>()"
       }
     ],
-    "constructor": ["expr"]
+    "constructor": ["expr", "column_indexes"]
   }
 ]

--- a/src/include/duckdb/storage/table/scan_state.hpp
+++ b/src/include/duckdb/storage/table/scan_state.hpp
@@ -194,6 +194,12 @@ public:
 	const vector<ScanFilter> &GetFilterList() const {
 		return filter_list;
 	}
+	optional_ptr<const TableFilterSet> GetTableFilters() const {
+		return table_filters.get();
+	}
+	optional_ptr<const vector<StorageIndex>> GetColumnIds() const {
+		return column_ids;
+	}
 
 	optional_ptr<AdaptiveFilter> GetAdaptiveFilter();
 	AdaptiveFilterState BeginFilter() const;
@@ -214,6 +220,8 @@ public:
 private:
 	//! The table filters (if any)
 	optional_ptr<TableFilterSet> table_filters;
+	//! Maps scan projection indexes to storage column indexes
+	optional_ptr<const vector<StorageIndex>> column_ids;
 	//! Adaptive filter info (if any)
 	unique_ptr<AdaptiveFilter> adaptive_filter;
 	//! The set of filters

--- a/src/optimizer/common_subplan_optimizer.cpp
+++ b/src/optimizer/common_subplan_optimizer.cpp
@@ -270,13 +270,24 @@ private:
 					}
 				}
 
+				auto register_filter_index = [&](ProjectionIndex filter_index) {
+					D_ASSERT(filter_index.GetIndex() < column_ids.size());
+					const auto canonical_index = ProjectionIndex(column_ids[filter_index.GetIndex()].GetPrimaryIndex());
+					auto entry = restore_original_table_filter_index.emplace(canonical_index, filter_index);
+					return entry.second || entry.first->second == filter_index;
+				};
 				for (auto &entry : get.table_filters) {
-					D_ASSERT(entry.GetIndex().GetIndex() < column_ids.size());
-					const auto canonical_index =
-					    ProjectionIndex(column_ids[entry.GetIndex().GetIndex()].GetPrimaryIndex());
-					if (!restore_original_table_filter_index.emplace(canonical_index, entry.GetIndex()).second) {
+					if (!register_filter_index(entry.GetIndex())) {
 						restore_original_table_filter_index.clear();
 						return false;
+					}
+				}
+				for (const auto &filter : get.table_filters.GetRowGroupFilters()) {
+					for (const auto &column_index : filter.column_indexes) {
+						if (!register_filter_index(column_index)) {
+							restore_original_table_filter_index.clear();
+							return false;
+						}
 					}
 				}
 				if (!restore_original_table_filter_index.empty()) {
@@ -285,6 +296,13 @@ private:
 						const auto canonical_index =
 						    ProjectionIndex(column_ids[entry.GetIndex().GetIndex()].GetPrimaryIndex());
 						remapped_filters.PushFilter(canonical_index, entry.TakeFilter());
+					}
+					for (const auto &filter : get.table_filters.GetRowGroupFilters()) {
+						auto remapped_filter = filter.Copy();
+						for (auto &column_index : remapped_filter.column_indexes) {
+							column_index = ProjectionIndex(column_ids[column_index.GetIndex()].GetPrimaryIndex());
+						}
+						remapped_filters.PushRowGroupFilter(std::move(remapped_filter));
 					}
 					get.table_filters = std::move(remapped_filters);
 				}
@@ -314,6 +332,13 @@ private:
 					for (auto &entry : get.table_filters) {
 						remapped_filters.PushFilter(restore_original_table_filter_index.at(entry.GetIndex()),
 						                            entry.TakeFilter());
+					}
+					for (const auto &filter : get.table_filters.GetRowGroupFilters()) {
+						auto remapped_filter = filter.Copy();
+						for (auto &column_index : remapped_filter.column_indexes) {
+							column_index = restore_original_table_filter_index.at(column_index);
+						}
+						remapped_filters.PushRowGroupFilter(std::move(remapped_filter));
 					}
 					get.table_filters = std::move(remapped_filters);
 				}

--- a/src/optimizer/common_subplan_optimizer.cpp
+++ b/src/optimizer/common_subplan_optimizer.cpp
@@ -282,8 +282,10 @@ private:
 						return false;
 					}
 				}
-				for (const auto &filter : get.table_filters.GetRowGroupFilters()) {
-					for (const auto &column_index : filter.column_indexes) {
+				for (const auto &filter : get.table_filters.GetMultiColumnFilters()) {
+					const auto &expression_filter =
+					    ExpressionFilter::GetExpressionFilter(*filter, "CommonSubplanOptimizer::ConvertTableIndex");
+					for (const auto &column_index : expression_filter.column_indexes) {
 						if (!register_filter_index(column_index)) {
 							restore_original_table_filter_index.clear();
 							return false;
@@ -297,12 +299,14 @@ private:
 						    ProjectionIndex(column_ids[entry.GetIndex().GetIndex()].GetPrimaryIndex());
 						remapped_filters.PushFilter(canonical_index, entry.TakeFilter());
 					}
-					for (const auto &filter : get.table_filters.GetRowGroupFilters()) {
-						auto remapped_filter = filter.Copy();
-						for (auto &column_index : remapped_filter.column_indexes) {
+					for (const auto &filter : get.table_filters.GetMultiColumnFilters()) {
+						auto remapped_filter =
+						    ExpressionFilter::GetExpressionFilter(*filter, "CommonSubplanOptimizer::ConvertTableIndex")
+						        .Copy();
+						for (auto &column_index : remapped_filter->column_indexes) {
 							column_index = ProjectionIndex(column_ids[column_index.GetIndex()].GetPrimaryIndex());
 						}
-						remapped_filters.PushRowGroupFilter(std::move(remapped_filter));
+						remapped_filters.PushMultiColumnFilter(std::move(remapped_filter));
 					}
 					get.table_filters = std::move(remapped_filters);
 				}
@@ -333,12 +337,14 @@ private:
 						remapped_filters.PushFilter(restore_original_table_filter_index.at(entry.GetIndex()),
 						                            entry.TakeFilter());
 					}
-					for (const auto &filter : get.table_filters.GetRowGroupFilters()) {
-						auto remapped_filter = filter.Copy();
-						for (auto &column_index : remapped_filter.column_indexes) {
+					for (const auto &filter : get.table_filters.GetMultiColumnFilters()) {
+						auto remapped_filter =
+						    ExpressionFilter::GetExpressionFilter(*filter, "CommonSubplanOptimizer::ConvertTableIndex")
+						        .Copy();
+						for (auto &column_index : remapped_filter->column_indexes) {
 							column_index = restore_original_table_filter_index.at(column_index);
 						}
-						remapped_filters.PushRowGroupFilter(std::move(remapped_filter));
+						remapped_filters.PushMultiColumnFilter(std::move(remapped_filter));
 					}
 					get.table_filters = std::move(remapped_filters);
 				}

--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -402,6 +402,41 @@ FilterPushdownResult FilterCombiner::TryPushdownGenericExpression(LogicalGet &ge
 	if (bindings.empty()) {
 		return FilterPushdownResult::NO_PUSHDOWN;
 	}
+	if (bindings.size() == 2 && bindings[0] != bindings[1] &&
+	    get.function.GetName().GetIdentifierName() == "seq_scan" && BoundComparisonExpression::IsComparison(expr)) {
+		const auto &comparison = expr.Cast<BoundFunctionExpression>();
+		const auto &left = BoundComparisonExpression::Left(comparison);
+		const auto &right = BoundComparisonExpression::Right(comparison);
+		const auto comparison_type = comparison.GetExpressionType();
+		const bool supported_comparison = comparison_type == ExpressionType::COMPARE_EQUAL ||
+		                                  comparison_type == ExpressionType::COMPARE_GREATERTHAN ||
+		                                  comparison_type == ExpressionType::COMPARE_GREATERTHANOREQUALTO ||
+		                                  comparison_type == ExpressionType::COMPARE_LESSTHAN ||
+		                                  comparison_type == ExpressionType::COMPARE_LESSTHANOREQUALTO;
+		if (!supported_comparison || left.GetExpressionClass() != ExpressionClass::BOUND_COLUMN_REF ||
+		    right.GetExpressionClass() != ExpressionClass::BOUND_COLUMN_REF || !left.GetReturnType().IsNumeric() ||
+		    !right.GetReturnType().IsNumeric()) {
+			return FilterPushdownResult::NO_PUSHDOWN;
+		}
+		const auto &left_ref = left.Cast<BoundColumnRefExpression>();
+		const auto &right_ref = right.Cast<BoundColumnRefExpression>();
+		if (left_ref.Binding().table_index != get.table_index || right_ref.Binding().table_index != get.table_index ||
+		    left_ref.Binding().column_index >= get.GetColumnIds().size() ||
+		    right_ref.Binding().column_index >= get.GetColumnIds().size() ||
+		    get.GetColumnIds()[left_ref.Binding().column_index].IsVirtualColumn() ||
+		    get.GetColumnIds()[right_ref.Binding().column_index].IsVirtualColumn()) {
+			return FilterPushdownResult::NO_PUSHDOWN;
+		}
+
+		auto left_bound_ref = make_uniq<BoundReferenceExpression>(left_ref.GetAlias(), left_ref.GetReturnType(), 0);
+		auto right_bound_ref = make_uniq<BoundReferenceExpression>(right_ref.GetAlias(), right_ref.GetReturnType(), 1);
+		auto filter_expr =
+		    BoundComparisonExpression::Create(comparison_type, std::move(left_bound_ref), std::move(right_bound_ref));
+		vector<ProjectionIndex> column_indexes {left_ref.Binding().column_index, right_ref.Binding().column_index};
+		get.table_filters.PushRowGroupFilter(
+		    RowGroupExpressionFilter(std::move(column_indexes), std::move(filter_expr)));
+		return FilterPushdownResult::PUSHED_DOWN_PARTIALLY;
+	}
 	// we can only pushdown expressions that refer to exactly one column
 	for (idx_t i = 1; i < bindings.size(); i++) {
 		if (bindings[i] != bindings[0]) {

--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/optimizer/filter_combiner.hpp"
 
+#include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
 #include "duckdb/common/enums/expression_type.hpp"
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/function/scalar/string_common.hpp"
@@ -402,8 +403,9 @@ FilterPushdownResult FilterCombiner::TryPushdownGenericExpression(LogicalGet &ge
 	if (bindings.empty()) {
 		return FilterPushdownResult::NO_PUSHDOWN;
 	}
-	if (bindings.size() == 2 && bindings[0] != bindings[1] &&
-	    get.function.GetName().GetIdentifierName() == "seq_scan" && BoundComparisonExpression::IsComparison(expr)) {
+	auto table = get.GetTable();
+	if (bindings.size() == 2 && bindings[0] != bindings[1] && table && table->IsDuckTable() &&
+	    BoundComparisonExpression::IsComparison(expr)) {
 		const auto &comparison = expr.Cast<BoundFunctionExpression>();
 		const auto &left = BoundComparisonExpression::Left(comparison);
 		const auto &right = BoundComparisonExpression::Right(comparison);

--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -433,8 +433,8 @@ FilterPushdownResult FilterCombiner::TryPushdownGenericExpression(LogicalGet &ge
 		auto filter_expr =
 		    BoundComparisonExpression::Create(comparison_type, std::move(left_bound_ref), std::move(right_bound_ref));
 		vector<ProjectionIndex> column_indexes {left_ref.Binding().column_index, right_ref.Binding().column_index};
-		get.table_filters.PushRowGroupFilter(
-		    RowGroupExpressionFilter(std::move(column_indexes), std::move(filter_expr)));
+		get.table_filters.PushMultiColumnFilter(
+		    make_uniq<ExpressionFilter>(std::move(filter_expr), std::move(column_indexes)));
 		return FilterPushdownResult::PUSHED_DOWN_PARTIALLY;
 	}
 	// we can only pushdown expressions that refer to exactly one column

--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -1020,8 +1020,9 @@ void RemoveUnusedColumns::RemoveColumnsFromLogicalGet(LogicalGet &get, unique_pt
 		//! Now visit the filter to add to the 'column_references'
 		VisitExpression(&filter_expressions.back());
 	}
-	for (const auto &filter : get.table_filters.GetRowGroupFilters()) {
-		for (const auto &filter_idx : filter.column_indexes) {
+	for (const auto &filter : get.table_filters.GetMultiColumnFilters()) {
+		const auto &expression_filter = ExpressionFilter::GetExpressionFilter(*filter, "RemoveUnusedColumns::VisitGet");
+		for (const auto &filter_idx : expression_filter.column_indexes) {
 			const auto &col_id = get.GetColumnIndex(filter_idx);
 			auto column_type = get.GetColumnType(col_id);
 			ColumnBinding filter_binding(get.table_index, filter_idx);
@@ -1094,7 +1095,7 @@ void RemoveUnusedColumns::RemoveColumnsFromLogicalGet(LogicalGet &get, unique_pt
 	get.SetColumnIds(std::move(new_column_ids));
 
 	// remap table filters so they point towards the new set of ids
-	if (get.table_filters.HasFilters() || get.table_filters.HasRowGroupFilters()) {
+	if (get.table_filters.HasFilters() || get.table_filters.HasMultiColumnFilters()) {
 		// Build a mapping from old ProjectionIndex -> new ProjectionIndex using original_ids
 		unordered_map<ProjectionIndex, ProjectionIndex> old_to_new_pos;
 		old_to_new_pos.reserve(original_ids.size());
@@ -1109,16 +1110,18 @@ void RemoveUnusedColumns::RemoveColumnsFromLogicalGet(LogicalGet &get, unique_pt
 			}
 			remapped_filters.PushFilter(it->second, entry.TakeFilter());
 		}
-		for (const auto &filter : get.table_filters.GetRowGroupFilters()) {
-			auto remapped_filter = filter.Copy();
-			for (auto &column_index : remapped_filter.column_indexes) {
+		for (const auto &filter : get.table_filters.GetMultiColumnFilters()) {
+			auto remapped_filter =
+			    ExpressionFilter::GetExpressionFilter(*filter, "RemoveUnusedColumns::RemoveColumnsFromLogicalGet")
+			        .Copy();
+			for (auto &column_index : remapped_filter->column_indexes) {
 				auto it = old_to_new_pos.find(column_index);
 				if (it == old_to_new_pos.end()) {
-					throw InternalException("RemoveUnusedColumns: removed a row-group filter column");
+					throw InternalException("RemoveUnusedColumns: removed a multi-column filter column");
 				}
 				column_index = it->second;
 			}
-			remapped_filters.PushRowGroupFilter(std::move(remapped_filter));
+			remapped_filters.PushMultiColumnFilter(std::move(remapped_filter));
 		}
 		get.table_filters = std::move(remapped_filters);
 	}

--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -1020,6 +1020,16 @@ void RemoveUnusedColumns::RemoveColumnsFromLogicalGet(LogicalGet &get, unique_pt
 		//! Now visit the filter to add to the 'column_references'
 		VisitExpression(&filter_expressions.back());
 	}
+	for (const auto &filter : get.table_filters.GetRowGroupFilters()) {
+		for (const auto &filter_idx : filter.column_indexes) {
+			const auto &col_id = get.GetColumnIndex(filter_idx);
+			auto column_type = get.GetColumnType(col_id);
+			ColumnBinding filter_binding(get.table_index, filter_idx);
+			unique_ptr<Expression> column_ref =
+			    make_uniq<BoundColumnRefExpression>(std::move(column_type), filter_binding);
+			VisitExpression(&column_ref);
+		}
+	}
 
 	//! Check with the LogicalGet whether pushdown-extract is supported
 	CheckPushdownExtract(get);
@@ -1084,7 +1094,7 @@ void RemoveUnusedColumns::RemoveColumnsFromLogicalGet(LogicalGet &get, unique_pt
 	get.SetColumnIds(std::move(new_column_ids));
 
 	// remap table filters so they point towards the new set of ids
-	if (get.table_filters.HasFilters()) {
+	if (get.table_filters.HasFilters() || get.table_filters.HasRowGroupFilters()) {
 		// Build a mapping from old ProjectionIndex -> new ProjectionIndex using original_ids
 		unordered_map<ProjectionIndex, ProjectionIndex> old_to_new_pos;
 		old_to_new_pos.reserve(original_ids.size());
@@ -1098,6 +1108,17 @@ void RemoveUnusedColumns::RemoveColumnsFromLogicalGet(LogicalGet &get, unique_pt
 				throw InternalException("RemoveUnusedColumns: removed a filter column");
 			}
 			remapped_filters.PushFilter(it->second, entry.TakeFilter());
+		}
+		for (const auto &filter : get.table_filters.GetRowGroupFilters()) {
+			auto remapped_filter = filter.Copy();
+			for (auto &column_index : remapped_filter.column_indexes) {
+				auto it = old_to_new_pos.find(column_index);
+				if (it == old_to_new_pos.end()) {
+					throw InternalException("RemoveUnusedColumns: removed a row-group filter column");
+				}
+				column_index = it->second;
+			}
+			remapped_filters.PushRowGroupFilter(std::move(remapped_filter));
 		}
 		get.table_filters = std::move(remapped_filters);
 	}

--- a/src/optimizer/statistics/expression/propagate_comparison.cpp
+++ b/src/optimizer/statistics/expression/propagate_comparison.cpp
@@ -6,7 +6,8 @@
 
 namespace duckdb {
 
-FilterPropagateResult StatisticsPropagator::PropagateComparison(BaseStatistics &lstats, BaseStatistics &rstats,
+FilterPropagateResult StatisticsPropagator::PropagateComparison(const BaseStatistics &lstats,
+                                                                const BaseStatistics &rstats,
                                                                 ExpressionType comparison) {
 	// only handle numerics for now
 	switch (lstats.GetType().InternalType()) {

--- a/src/planner/filter/expression_filter.cpp
+++ b/src/planner/filter/expression_filter.cpp
@@ -30,8 +30,12 @@
 
 namespace duckdb {
 
-ExpressionFilter::ExpressionFilter(unique_ptr<Expression> expr_p)
-    : TableFilter(TableFilterType::EXPRESSION_FILTER), expr(std::move(expr_p)) {
+ExpressionFilter::ExpressionFilter(unique_ptr<Expression> expr_p) : ExpressionFilter(std::move(expr_p), {}) {
+}
+
+ExpressionFilter::ExpressionFilter(unique_ptr<Expression> expr_p, vector<ProjectionIndex> column_indexes_p)
+    : TableFilter(TableFilterType::EXPRESSION_FILTER), expr(std::move(expr_p)),
+      column_indexes(std::move(column_indexes_p)) {
 }
 
 const ExpressionFilter &ExpressionFilter::GetExpressionFilter(const TableFilter &filter, const char *context) {
@@ -298,9 +302,10 @@ static optional_ptr<const BaseStatistics> TryGetExpressionStats(optional_ptr<Cli
 }
 
 static optional_ptr<const BaseStatistics> TryGetFilterStats(optional_ptr<ClientContext> context_p,
-                                                            const Expression &expr, const BaseStatistics &stats,
+                                                            const Expression &expr,
+                                                            array_ptr<const BaseStatistics> input_stats,
                                                             vector<unique_ptr<BaseStatistics>> &owned_stats) {
-	return TryGetExpressionStats(context_p, expr, array_ptr<const BaseStatistics>(stats), owned_stats);
+	return TryGetExpressionStats(context_p, expr, input_stats, owned_stats);
 }
 
 unique_ptr<BaseStatistics> ExpressionFilter::TryGetExpressionStatistics(ClientContext &context, const Expression &expr,
@@ -374,7 +379,7 @@ TryPrepareVariantComparisonStats(const BaseStatistics &stats, Value &constant,
 
 static FilterPropagateResult CheckComparisonStatistics(optional_ptr<ClientContext> context_p,
                                                        const BoundFunctionExpression &comp_expr,
-                                                       const BaseStatistics &stats) {
+                                                       array_ptr<const BaseStatistics> input_stats) {
 	vector<unique_ptr<BaseStatistics>> owned_stats;
 	optional_ptr<const BaseStatistics> filter_stats;
 	optional_ptr<const BoundConstantExpression> constant_expr;
@@ -382,14 +387,19 @@ static FilterPropagateResult CheckComparisonStatistics(optional_ptr<ClientContex
 	auto &left = BoundComparisonExpression::Left(comp_expr);
 	auto &right = BoundComparisonExpression::Right(comp_expr);
 	if (right.GetExpressionType() == ExpressionType::VALUE_CONSTANT) {
-		filter_stats = TryGetFilterStats(context_p, left, stats, owned_stats);
+		filter_stats = TryGetFilterStats(context_p, left, input_stats, owned_stats);
 		constant_expr = &right.Cast<BoundConstantExpression>();
 	} else if (left.GetExpressionType() == ExpressionType::VALUE_CONSTANT) {
-		filter_stats = TryGetFilterStats(context_p, right, stats, owned_stats);
+		filter_stats = TryGetFilterStats(context_p, right, input_stats, owned_stats);
 		constant_expr = &left.Cast<BoundConstantExpression>();
 		comparison_type = FlipComparisonExpression(comparison_type);
 	} else {
-		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+		auto left_stats = TryGetFilterStats(context_p, left, input_stats, owned_stats);
+		auto right_stats = TryGetFilterStats(context_p, right, input_stats, owned_stats);
+		if (!left_stats || !right_stats) {
+			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+		}
+		return StatisticsPropagator::PropagateComparison(*left_stats, *right_stats, comparison_type);
 	}
 	if (!filter_stats || !constant_expr) {
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
@@ -431,7 +441,7 @@ static FilterPropagateResult CheckComparisonStatistics(optional_ptr<ClientContex
 //! CheckComparisonStatistics. `input` may itself be a monotone function whose stats are derived.
 static FilterPropagateResult CheckBetweenStatistics(optional_ptr<ClientContext> context_p,
                                                     const BoundFunctionExpression &between,
-                                                    const BaseStatistics &stats) {
+                                                    array_ptr<const BaseStatistics> input_stats) {
 	auto &lower = BoundBetweenExpression::LowerBound(between);
 	auto &upper = BoundBetweenExpression::UpperBound(between);
 	if (lower.GetExpressionType() != ExpressionType::VALUE_CONSTANT ||
@@ -444,18 +454,18 @@ static FilterPropagateResult CheckBetweenStatistics(optional_ptr<ClientContext> 
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 	}
 	vector<unique_ptr<BaseStatistics>> owned_stats;
-	auto input_stats = TryGetFilterStats(context_p, BoundBetweenExpression::Input(between), stats, owned_stats);
-	if (!input_stats || input_stats->GetType().id() == LogicalTypeId::VARIANT) {
+	auto between_stats = TryGetFilterStats(context_p, BoundBetweenExpression::Input(between), input_stats, owned_stats);
+	if (!between_stats || between_stats->GetType().id() == LogicalTypeId::VARIANT) {
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 	}
-	if (!input_stats->CanHaveNoNull()) {
+	if (!between_stats->CanHaveNoNull()) {
 		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
 	}
-	auto lower_res = CheckZonemapAgainstConstants(*input_stats, BoundBetweenExpression::LowerComparisonType(between),
+	auto lower_res = CheckZonemapAgainstConstants(*between_stats, BoundBetweenExpression::LowerComparisonType(between),
 	                                              array_ptr<const Value>(&lower_val, 1));
-	auto upper_res = CheckZonemapAgainstConstants(*input_stats, BoundBetweenExpression::UpperComparisonType(between),
+	auto upper_res = CheckZonemapAgainstConstants(*between_stats, BoundBetweenExpression::UpperComparisonType(between),
 	                                              array_ptr<const Value>(&upper_val, 1));
-	if (input_stats->CanHaveNull()) {
+	if (between_stats->CanHaveNull()) {
 		if (lower_res == FilterPropagateResult::FILTER_ALWAYS_FALSE ||
 		    upper_res == FilterPropagateResult::FILTER_ALWAYS_FALSE) {
 			return FilterPropagateResult::FILTER_ALWAYS_FALSE;
@@ -475,12 +485,12 @@ static FilterPropagateResult CheckBetweenStatistics(optional_ptr<ClientContext> 
 
 static FilterPropagateResult CheckFunctionStatistics(optional_ptr<ClientContext> context_p,
                                                      const BoundFunctionExpression &func_expr,
-                                                     const BaseStatistics &stats) {
+                                                     array_ptr<const BaseStatistics> input_stats) {
 	if (func_expr.GetExpressionType() == ExpressionType::COMPARE_BETWEEN) {
-		return CheckBetweenStatistics(context_p, func_expr, stats);
+		return CheckBetweenStatistics(context_p, func_expr, input_stats);
 	}
 	if (BoundComparisonExpression::IsComparison(func_expr.GetExpressionType())) {
-		return CheckComparisonStatistics(context_p, func_expr, stats);
+		return CheckComparisonStatistics(context_p, func_expr, input_stats);
 	}
 	if (!func_expr.Function().HasFilterPruneCallback()) {
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
@@ -492,7 +502,7 @@ static FilterPropagateResult CheckFunctionStatistics(optional_ptr<ClientContext>
 	vector<optional_ptr<const BaseStatistics>> child_stats;
 	child_stats.reserve(func_expr.GetChildren().size());
 	for (auto &child : func_expr.GetChildren()) {
-		child_stats.push_back(TryGetFilterStats(context_p, *child, stats, owned_stats));
+		child_stats.push_back(TryGetFilterStats(context_p, *child, input_stats, owned_stats));
 	}
 	FunctionStatisticsPruneInput input(func_expr, func_expr.BindInfo().get(), child_stats);
 	return func_expr.Function().GetFilterPruneCallback()(input);
@@ -500,12 +510,13 @@ static FilterPropagateResult CheckFunctionStatistics(optional_ptr<ClientContext>
 
 static FilterPropagateResult CheckNullOperatorStatistics(optional_ptr<ClientContext> context_p,
                                                          const BoundOperatorExpression &op_expr,
-                                                         const BaseStatistics &stats, ExpressionType operator_type) {
+                                                         array_ptr<const BaseStatistics> input_stats,
+                                                         ExpressionType operator_type) {
 	if (op_expr.GetChildren().empty()) {
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 	}
 	vector<unique_ptr<BaseStatistics>> owned_stats;
-	auto filter_stats = TryGetFilterStats(context_p, *op_expr.GetChildren()[0], stats, owned_stats);
+	auto filter_stats = TryGetFilterStats(context_p, *op_expr.GetChildren()[0], input_stats, owned_stats);
 	if (!filter_stats) {
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 	}
@@ -529,12 +540,12 @@ static FilterPropagateResult CheckNullOperatorStatistics(optional_ptr<ClientCont
 
 static FilterPropagateResult CheckInOperatorStatistics(optional_ptr<ClientContext> context_p,
                                                        const BoundOperatorExpression &op_expr,
-                                                       const BaseStatistics &stats) {
+                                                       array_ptr<const BaseStatistics> input_stats) {
 	if (op_expr.GetChildren().size() <= 1) {
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 	}
 	vector<unique_ptr<BaseStatistics>> owned_stats;
-	auto filter_stats = TryGetFilterStats(context_p, *op_expr.GetChildren()[0], stats, owned_stats);
+	auto filter_stats = TryGetFilterStats(context_p, *op_expr.GetChildren()[0], input_stats, owned_stats);
 	if (!filter_stats) {
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 	}
@@ -570,7 +581,7 @@ static FilterPropagateResult CheckInOperatorStatistics(optional_ptr<ClientContex
 
 static FilterPropagateResult CheckNotOperatorStatistics(optional_ptr<ClientContext> context_p,
                                                         const BoundOperatorExpression &op_expr,
-                                                        const BaseStatistics &stats) {
+                                                        array_ptr<const BaseStatistics> input_stats) {
 	if (op_expr.GetChildren().size() != 1) {
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 	}
@@ -584,7 +595,7 @@ static FilterPropagateResult CheckNotOperatorStatistics(optional_ptr<ClientConte
 	}
 	// a child matching every row makes NOT match no row - the converse does not hold, since a child
 	// that matches no row may be NULL rather than false, and NOT NULL does not match either
-	if (ExpressionFilter::CheckExpressionStatistics(context_p, child, stats) ==
+	if (ExpressionFilter::CheckExpressionStatistics(context_p, child, input_stats) ==
 	    FilterPropagateResult::FILTER_ALWAYS_TRUE) {
 		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
 	}
@@ -593,15 +604,15 @@ static FilterPropagateResult CheckNotOperatorStatistics(optional_ptr<ClientConte
 
 static FilterPropagateResult CheckOperatorStatistics(optional_ptr<ClientContext> context_p,
                                                      const BoundOperatorExpression &op_expr,
-                                                     const BaseStatistics &stats) {
+                                                     array_ptr<const BaseStatistics> input_stats) {
 	switch (op_expr.GetExpressionType()) {
 	case ExpressionType::OPERATOR_IS_NULL:
 	case ExpressionType::OPERATOR_IS_NOT_NULL:
-		return CheckNullOperatorStatistics(context_p, op_expr, stats, op_expr.GetExpressionType());
+		return CheckNullOperatorStatistics(context_p, op_expr, input_stats, op_expr.GetExpressionType());
 	case ExpressionType::COMPARE_IN:
-		return CheckInOperatorStatistics(context_p, op_expr, stats);
+		return CheckInOperatorStatistics(context_p, op_expr, input_stats);
 	case ExpressionType::OPERATOR_NOT:
-		return CheckNotOperatorStatistics(context_p, op_expr, stats);
+		return CheckNotOperatorStatistics(context_p, op_expr, input_stats);
 	default:
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 	}
@@ -609,12 +620,12 @@ static FilterPropagateResult CheckOperatorStatistics(optional_ptr<ClientContext>
 
 static FilterPropagateResult CheckConjunctionStatistics(optional_ptr<ClientContext> context_p,
                                                         const BoundConjunctionExpression &conj,
-                                                        const BaseStatistics &stats) {
+                                                        array_ptr<const BaseStatistics> input_stats) {
 	switch (conj.GetExpressionType()) {
 	case ExpressionType::CONJUNCTION_AND: {
 		auto result = FilterPropagateResult::FILTER_ALWAYS_TRUE;
 		for (auto &child : conj.GetChildren()) {
-			auto prune_result = ExpressionFilter::CheckExpressionStatistics(context_p, *child, stats);
+			auto prune_result = ExpressionFilter::CheckExpressionStatistics(context_p, *child, input_stats);
 			if (prune_result == FilterPropagateResult::FILTER_ALWAYS_FALSE) {
 				return FilterPropagateResult::FILTER_ALWAYS_FALSE;
 			}
@@ -630,7 +641,7 @@ static FilterPropagateResult CheckConjunctionStatistics(optional_ptr<ClientConte
 	case ExpressionType::CONJUNCTION_OR:
 		D_ASSERT(!conj.GetChildren().empty());
 		for (auto &child : conj.GetChildren()) {
-			auto prune_result = ExpressionFilter::CheckExpressionStatistics(context_p, *child, stats);
+			auto prune_result = ExpressionFilter::CheckExpressionStatistics(context_p, *child, input_stats);
 			if (prune_result == FilterPropagateResult::NO_PRUNING_POSSIBLE) {
 				return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 			}
@@ -645,18 +656,29 @@ static FilterPropagateResult CheckConjunctionStatistics(optional_ptr<ClientConte
 }
 
 FilterPropagateResult ExpressionFilter::CheckExpressionStatistics(const Expression &expr, const BaseStatistics &stats) {
-	return CheckExpressionStatistics(nullptr, expr, stats);
+	return CheckExpressionStatistics(nullptr, expr, array_ptr<const BaseStatistics>(stats));
 }
 
 FilterPropagateResult ExpressionFilter::CheckExpressionStatistics(optional_ptr<ClientContext> context_p,
                                                                   const Expression &expr, const BaseStatistics &stats) {
+	return CheckExpressionStatistics(context_p, expr, array_ptr<const BaseStatistics>(stats));
+}
+
+FilterPropagateResult ExpressionFilter::CheckExpressionStatistics(const Expression &expr,
+                                                                  array_ptr<const BaseStatistics> input_stats) {
+	return CheckExpressionStatistics(nullptr, expr, input_stats);
+}
+
+FilterPropagateResult ExpressionFilter::CheckExpressionStatistics(optional_ptr<ClientContext> context_p,
+                                                                  const Expression &expr,
+                                                                  array_ptr<const BaseStatistics> input_stats) {
 	switch (expr.GetExpressionClass()) {
 	case ExpressionClass::BOUND_FUNCTION:
-		return CheckFunctionStatistics(context_p, expr.Cast<BoundFunctionExpression>(), stats);
+		return CheckFunctionStatistics(context_p, expr.Cast<BoundFunctionExpression>(), input_stats);
 	case ExpressionClass::BOUND_OPERATOR:
-		return CheckOperatorStatistics(context_p, expr.Cast<BoundOperatorExpression>(), stats);
+		return CheckOperatorStatistics(context_p, expr.Cast<BoundOperatorExpression>(), input_stats);
 	case ExpressionClass::BOUND_CONJUNCTION:
-		return CheckConjunctionStatistics(context_p, expr.Cast<BoundConjunctionExpression>(), stats);
+		return CheckConjunctionStatistics(context_p, expr.Cast<BoundConjunctionExpression>(), input_stats);
 	default:
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 	}
@@ -744,7 +766,7 @@ shared_ptr<DynamicFilterData> ExpressionFilter::GetRootOptionalDynamicFilterData
 unique_ptr<ExpressionFilter> ExpressionFilter::FromTableFilter(const TableFilter &filter, const LogicalType &col_type) {
 	if (filter.filter_type == TableFilterType::EXPRESSION_FILTER) {
 		auto &expr_filter = filter.Cast<ExpressionFilter>();
-		return make_uniq<ExpressionFilter>(expr_filter.expr->Copy());
+		return expr_filter.Copy();
 	}
 	if (col_type == LogicalType::ANY) {
 		throw InternalException("ExpressionFilter::FromTableFilter requires the actual column type");
@@ -837,6 +859,7 @@ void ExpressionFilter::ReplaceExpressionRecursive(unique_ptr<Expression> &expr, 
 }
 
 unique_ptr<Expression> ExpressionFilter::ToExpression(const Expression &column) const {
+	D_ASSERT(column_indexes.empty());
 	auto expr_copy = expr->Copy();
 	ReplaceExpressionRecursive(expr_copy, column);
 	return expr_copy;
@@ -844,11 +867,11 @@ unique_ptr<Expression> ExpressionFilter::ToExpression(const Expression &column) 
 
 bool ExpressionFilter::Equals(const ExpressionFilter &other_p) const {
 	auto &other = other_p.Cast<ExpressionFilter>();
-	return other.expr->Equals(*expr);
+	return column_indexes == other.column_indexes && other.expr->Equals(*expr);
 }
 
 unique_ptr<ExpressionFilter> ExpressionFilter::Copy() const {
-	return make_uniq<ExpressionFilter>(expr->Copy());
+	return make_uniq<ExpressionFilter>(expr->Copy(), column_indexes);
 }
 
 } // namespace duckdb

--- a/src/planner/table_filter_set.cpp
+++ b/src/planner/table_filter_set.cpp
@@ -24,6 +24,22 @@
 
 namespace duckdb {
 
+RowGroupExpressionFilter::RowGroupExpressionFilter() {
+}
+
+RowGroupExpressionFilter::RowGroupExpressionFilter(vector<ProjectionIndex> column_indexes_p,
+                                                   unique_ptr<Expression> expression_p)
+    : column_indexes(std::move(column_indexes_p)), expression(std::move(expression_p)) {
+}
+
+bool RowGroupExpressionFilter::Equals(const RowGroupExpressionFilter &other) const {
+	return column_indexes == other.column_indexes && expression->Equals(*other.expression);
+}
+
+RowGroupExpressionFilter RowGroupExpressionFilter::Copy() const {
+	return RowGroupExpressionFilter(column_indexes, expression->Copy());
+}
+
 struct LegacyStructPathEntry {
 	idx_t child_idx;
 	Identifier child_name;
@@ -342,6 +358,9 @@ bool TableFilterSet::HasFilters() const {
 idx_t TableFilterSet::FilterCount() const {
 	return filters.size();
 }
+bool TableFilterSet::HasRowGroupFilters() const {
+	return !row_group_filters.empty();
+}
 bool TableFilterSet::HasFilter(ProjectionIndex col_idx) const {
 	return filters.find(col_idx) != filters.end();
 }
@@ -391,10 +410,11 @@ void TableFilterSet::SetFilterByColumnIndex(ProjectionIndex col_idx, unique_ptr<
 
 void TableFilterSet::ClearFilters() {
 	filters.clear();
+	row_group_filters.clear();
 }
 
 bool TableFilterSet::Equals(TableFilterSet &other) {
-	if (filters.size() != other.filters.size()) {
+	if (filters.size() != other.filters.size() || row_group_filters.size() != other.row_group_filters.size()) {
 		return false;
 	}
 	for (auto &entry : filters) {
@@ -403,6 +423,11 @@ bool TableFilterSet::Equals(TableFilterSet &other) {
 			return false;
 		}
 		if (!entry.second->Cast<ExpressionFilter>().Equals(other_entry->second->Cast<ExpressionFilter>())) {
+			return false;
+		}
+	}
+	for (idx_t i = 0; i < row_group_filters.size(); i++) {
+		if (!row_group_filters[i].Equals(other.row_group_filters[i])) {
 			return false;
 		}
 	}
@@ -424,6 +449,9 @@ unique_ptr<TableFilterSet> TableFilterSet::Copy() const {
 	for (auto &it : filters) {
 		copy->filters.emplace(it.first, it.second->Cast<ExpressionFilter>().Copy());
 	}
+	for (auto &filter : row_group_filters) {
+		copy->row_group_filters.push_back(filter.Copy());
+	}
 	return copy;
 }
 
@@ -444,6 +472,27 @@ void TableFilterSet::PushFilter(ProjectionIndex col_idx, unique_ptr<TableFilter>
 		and_expr->GetChildrenMutable().push_back(std::move(new_filter.expr));
 		filters[col_idx] = make_uniq<ExpressionFilter>(std::move(and_expr));
 	}
+}
+
+void TableFilterSet::PushRowGroupFilter(RowGroupExpressionFilter filter) {
+	if (filter.column_indexes.empty() || !filter.expression) {
+		throw InternalException("Cannot push an empty row-group expression filter");
+	}
+	for (auto &column_index : filter.column_indexes) {
+		if (!column_index.IsValid()) {
+			throw InternalException("Cannot push a row-group filter over an invalid ProjectionIndex");
+		}
+	}
+	for (auto &existing_filter : row_group_filters) {
+		if (existing_filter.Equals(filter)) {
+			return;
+		}
+	}
+	row_group_filters.push_back(std::move(filter));
+}
+
+const vector<RowGroupExpressionFilter> &TableFilterSet::GetRowGroupFilters() const {
+	return row_group_filters;
 }
 
 void DynamicTableFilterSet::ClearFilters(const PhysicalOperator &op) {
@@ -481,13 +530,16 @@ DynamicTableFilterSet::GetFinalTableFilters(const PhysicalTableScan &scan,
 		for (auto &filter_entry : *existing_filters) {
 			result->PushFilter(filter_entry.GetIndex(), filter_entry.Filter().Cast<ExpressionFilter>().Copy());
 		}
+		for (auto &filter : existing_filters->GetRowGroupFilters()) {
+			result->PushRowGroupFilter(filter.Copy());
+		}
 	}
 	for (auto &entry : filters) {
 		for (auto &filter_entry : *entry.second) {
 			result->PushFilter(filter_entry.GetIndex(), filter_entry.Filter().Cast<ExpressionFilter>().Copy());
 		}
 	}
-	if (!result->HasFilters()) {
+	if (!result->HasFilters() && !result->HasRowGroupFilters()) {
 		return nullptr;
 	}
 	return result;

--- a/src/planner/table_filter_set.cpp
+++ b/src/planner/table_filter_set.cpp
@@ -24,22 +24,6 @@
 
 namespace duckdb {
 
-RowGroupExpressionFilter::RowGroupExpressionFilter() {
-}
-
-RowGroupExpressionFilter::RowGroupExpressionFilter(vector<ProjectionIndex> column_indexes_p,
-                                                   unique_ptr<Expression> expression_p)
-    : column_indexes(std::move(column_indexes_p)), expression(std::move(expression_p)) {
-}
-
-bool RowGroupExpressionFilter::Equals(const RowGroupExpressionFilter &other) const {
-	return column_indexes == other.column_indexes && expression->Equals(*other.expression);
-}
-
-RowGroupExpressionFilter RowGroupExpressionFilter::Copy() const {
-	return RowGroupExpressionFilter(column_indexes, expression->Copy());
-}
-
 struct LegacyStructPathEntry {
 	idx_t child_idx;
 	Identifier child_name;
@@ -358,8 +342,8 @@ bool TableFilterSet::HasFilters() const {
 idx_t TableFilterSet::FilterCount() const {
 	return filters.size();
 }
-bool TableFilterSet::HasRowGroupFilters() const {
-	return !row_group_filters.empty();
+bool TableFilterSet::HasMultiColumnFilters() const {
+	return !multi_column_filters.empty();
 }
 bool TableFilterSet::HasFilter(ProjectionIndex col_idx) const {
 	return filters.find(col_idx) != filters.end();
@@ -410,11 +394,11 @@ void TableFilterSet::SetFilterByColumnIndex(ProjectionIndex col_idx, unique_ptr<
 
 void TableFilterSet::ClearFilters() {
 	filters.clear();
-	row_group_filters.clear();
+	multi_column_filters.clear();
 }
 
 bool TableFilterSet::Equals(TableFilterSet &other) {
-	if (filters.size() != other.filters.size() || row_group_filters.size() != other.row_group_filters.size()) {
+	if (filters.size() != other.filters.size() || multi_column_filters.size() != other.multi_column_filters.size()) {
 		return false;
 	}
 	for (auto &entry : filters) {
@@ -426,8 +410,12 @@ bool TableFilterSet::Equals(TableFilterSet &other) {
 			return false;
 		}
 	}
-	for (idx_t i = 0; i < row_group_filters.size(); i++) {
-		if (!row_group_filters[i].Equals(other.row_group_filters[i])) {
+	for (idx_t filter_idx = 0; filter_idx < multi_column_filters.size(); ++filter_idx) {
+		const auto &filter =
+		    ExpressionFilter::GetExpressionFilter(*multi_column_filters[filter_idx], "TableFilterSet::Equals");
+		const auto &other_filter =
+		    ExpressionFilter::GetExpressionFilter(*other.multi_column_filters[filter_idx], "TableFilterSet::Equals");
+		if (!filter.Equals(other_filter)) {
 			return false;
 		}
 	}
@@ -449,8 +437,9 @@ unique_ptr<TableFilterSet> TableFilterSet::Copy() const {
 	for (auto &it : filters) {
 		copy->filters.emplace(it.first, it.second->Cast<ExpressionFilter>().Copy());
 	}
-	for (auto &filter : row_group_filters) {
-		copy->row_group_filters.push_back(filter.Copy());
+	for (const auto &filter : multi_column_filters) {
+		copy->multi_column_filters.push_back(
+		    ExpressionFilter::GetExpressionFilter(*filter, "TableFilterSet::Copy").Copy());
 	}
 	return copy;
 }
@@ -460,6 +449,9 @@ void TableFilterSet::PushFilter(ProjectionIndex col_idx, unique_ptr<TableFilter>
 		throw InternalException("Cannot push a filter over an invalid ProjectionIndex");
 	}
 	auto &new_filter = ExpressionFilter::GetExpressionFilter(*filter, "TableFilterSet::PushFilter");
+	if (!new_filter.column_indexes.empty()) {
+		throw InternalException("Cannot push a multi-column filter as a single-column filter");
+	}
 	auto entry = filters.find(col_idx);
 	if (entry == filters.end()) {
 		// no filter yet: push the filter directly
@@ -474,25 +466,28 @@ void TableFilterSet::PushFilter(ProjectionIndex col_idx, unique_ptr<TableFilter>
 	}
 }
 
-void TableFilterSet::PushRowGroupFilter(RowGroupExpressionFilter filter) {
-	if (filter.column_indexes.empty() || !filter.expression) {
-		throw InternalException("Cannot push an empty row-group expression filter");
+void TableFilterSet::PushMultiColumnFilter(unique_ptr<TableFilter> filter) {
+	const auto &expression_filter =
+	    ExpressionFilter::GetExpressionFilter(*filter, "TableFilterSet::PushMultiColumnFilter");
+	if (!expression_filter.expr || expression_filter.column_indexes.size() < 2) {
+		throw InternalException("Multi-column filter must reference at least two columns");
 	}
-	for (auto &column_index : filter.column_indexes) {
+	for (const auto &column_index : expression_filter.column_indexes) {
 		if (!column_index.IsValid()) {
-			throw InternalException("Cannot push a row-group filter over an invalid ProjectionIndex");
+			throw InternalException("Cannot push a multi-column filter over an invalid ProjectionIndex");
 		}
 	}
-	for (auto &existing_filter : row_group_filters) {
-		if (existing_filter.Equals(filter)) {
+	for (const auto &existing_filter : multi_column_filters) {
+		if (ExpressionFilter::GetExpressionFilter(*existing_filter, "TableFilterSet::PushMultiColumnFilter")
+		        .Equals(expression_filter)) {
 			return;
 		}
 	}
-	row_group_filters.push_back(std::move(filter));
+	multi_column_filters.push_back(std::move(filter));
 }
 
-const vector<RowGroupExpressionFilter> &TableFilterSet::GetRowGroupFilters() const {
-	return row_group_filters;
+const vector<unique_ptr<TableFilter>> &TableFilterSet::GetMultiColumnFilters() const {
+	return multi_column_filters;
 }
 
 void DynamicTableFilterSet::ClearFilters(const PhysicalOperator &op) {
@@ -530,8 +525,9 @@ DynamicTableFilterSet::GetFinalTableFilters(const PhysicalTableScan &scan,
 		for (auto &filter_entry : *existing_filters) {
 			result->PushFilter(filter_entry.GetIndex(), filter_entry.Filter().Cast<ExpressionFilter>().Copy());
 		}
-		for (auto &filter : existing_filters->GetRowGroupFilters()) {
-			result->PushRowGroupFilter(filter.Copy());
+		for (const auto &filter : existing_filters->GetMultiColumnFilters()) {
+			result->PushMultiColumnFilter(
+			    ExpressionFilter::GetExpressionFilter(*filter, "DynamicTableFilterSet::GetFinalTableFilters").Copy());
 		}
 	}
 	for (auto &entry : filters) {
@@ -539,7 +535,7 @@ DynamicTableFilterSet::GetFinalTableFilters(const PhysicalTableScan &scan,
 			result->PushFilter(filter_entry.GetIndex(), filter_entry.Filter().Cast<ExpressionFilter>().Copy());
 		}
 	}
-	if (!result->HasFilters() && !result->HasRowGroupFilters()) {
+	if (!result->HasFilters() && !result->HasMultiColumnFilters()) {
 		return nullptr;
 	}
 	return result;

--- a/src/storage/serialization/serialize_nodes.cpp
+++ b/src/storage/serialization/serialize_nodes.cpp
@@ -25,7 +25,6 @@
 #include "duckdb/planner/expression/bound_parameter_data.hpp"
 #include "duckdb/planner/joinside.hpp"
 #include "duckdb/parser/parsed_data/vacuum_info.hpp"
-#include "duckdb/planner/table_filter_set.hpp"
 #include "duckdb/planner/table_filter.hpp"
 #include "duckdb/planner/expression.hpp"
 #include "duckdb/common/multi_file/multi_file_options.hpp"
@@ -528,18 +527,6 @@ unique_ptr<BlockingSample> ReservoirSamplePercentage::Deserialize(Deserializer &
 	return std::move(result);
 }
 
-void RowGroupExpressionFilter::Serialize(Serializer &serializer) const {
-	serializer.WritePropertyWithDefault<vector<ProjectionIndex>>(100, "column_indexes", column_indexes);
-	serializer.WritePropertyWithDefault<unique_ptr<Expression>>(101, "expression", expression);
-}
-
-RowGroupExpressionFilter RowGroupExpressionFilter::Deserialize(Deserializer &deserializer) {
-	RowGroupExpressionFilter result;
-	deserializer.ReadPropertyWithDefault<vector<ProjectionIndex>>(100, "column_indexes", result.column_indexes);
-	deserializer.ReadPropertyWithDefault<unique_ptr<Expression>>(101, "expression", result.expression);
-	return result;
-}
-
 void RowGroupOrderOptions::Serialize(Serializer &serializer) const {
 	serializer.WriteProperty<StorageIndex>(100, "column_idx", column_idx);
 	serializer.WriteProperty<OrderByStatistics>(101, "order_by", order_by);
@@ -792,13 +779,13 @@ TableColumn TableColumn::Deserialize(Deserializer &deserializer) {
 
 void TableFilterSet::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<map<ProjectionIndex, unique_ptr<TableFilter>>>(100, "filters", GetTableFiltersForSerialization(serializer));
-	serializer.WritePropertyWithDefault<vector<RowGroupExpressionFilter>>(101, "row_group_filters", row_group_filters, vector<RowGroupExpressionFilter>());
+	serializer.WritePropertyWithDefault<vector<unique_ptr<TableFilter>>>(101, "multi_column_filters", multi_column_filters, vector<unique_ptr<TableFilter>>());
 }
 
 TableFilterSet TableFilterSet::Deserialize(Deserializer &deserializer) {
 	TableFilterSet result;
 	deserializer.ReadPropertyWithDefault<map<ProjectionIndex, unique_ptr<TableFilter>>>(100, "filters", result.GetTableFiltersForDeserialization(deserializer));
-	deserializer.ReadPropertyWithExplicitDefault<vector<RowGroupExpressionFilter>>(101, "row_group_filters", result.row_group_filters, vector<RowGroupExpressionFilter>());
+	deserializer.ReadPropertyWithExplicitDefault<vector<unique_ptr<TableFilter>>>(101, "multi_column_filters", result.multi_column_filters, vector<unique_ptr<TableFilter>>());
 	return result;
 }
 

--- a/src/storage/serialization/serialize_nodes.cpp
+++ b/src/storage/serialization/serialize_nodes.cpp
@@ -25,6 +25,7 @@
 #include "duckdb/planner/expression/bound_parameter_data.hpp"
 #include "duckdb/planner/joinside.hpp"
 #include "duckdb/parser/parsed_data/vacuum_info.hpp"
+#include "duckdb/planner/table_filter_set.hpp"
 #include "duckdb/planner/table_filter.hpp"
 #include "duckdb/planner/expression.hpp"
 #include "duckdb/common/multi_file/multi_file_options.hpp"
@@ -527,6 +528,18 @@ unique_ptr<BlockingSample> ReservoirSamplePercentage::Deserialize(Deserializer &
 	return std::move(result);
 }
 
+void RowGroupExpressionFilter::Serialize(Serializer &serializer) const {
+	serializer.WritePropertyWithDefault<vector<ProjectionIndex>>(100, "column_indexes", column_indexes);
+	serializer.WritePropertyWithDefault<unique_ptr<Expression>>(101, "expression", expression);
+}
+
+RowGroupExpressionFilter RowGroupExpressionFilter::Deserialize(Deserializer &deserializer) {
+	RowGroupExpressionFilter result;
+	deserializer.ReadPropertyWithDefault<vector<ProjectionIndex>>(100, "column_indexes", result.column_indexes);
+	deserializer.ReadPropertyWithDefault<unique_ptr<Expression>>(101, "expression", result.expression);
+	return result;
+}
+
 void RowGroupOrderOptions::Serialize(Serializer &serializer) const {
 	serializer.WriteProperty<StorageIndex>(100, "column_idx", column_idx);
 	serializer.WriteProperty<OrderByStatistics>(101, "order_by", order_by);
@@ -779,11 +792,13 @@ TableColumn TableColumn::Deserialize(Deserializer &deserializer) {
 
 void TableFilterSet::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<map<ProjectionIndex, unique_ptr<TableFilter>>>(100, "filters", GetTableFiltersForSerialization(serializer));
+	serializer.WritePropertyWithDefault<vector<RowGroupExpressionFilter>>(101, "row_group_filters", row_group_filters, vector<RowGroupExpressionFilter>());
 }
 
 TableFilterSet TableFilterSet::Deserialize(Deserializer &deserializer) {
 	TableFilterSet result;
 	deserializer.ReadPropertyWithDefault<map<ProjectionIndex, unique_ptr<TableFilter>>>(100, "filters", result.GetTableFiltersForDeserialization(deserializer));
+	deserializer.ReadPropertyWithExplicitDefault<vector<RowGroupExpressionFilter>>(101, "row_group_filters", result.row_group_filters, vector<RowGroupExpressionFilter>());
 	return result;
 }
 

--- a/src/storage/serialization/serialize_table_filter.cpp
+++ b/src/storage/serialization/serialize_table_filter.cpp
@@ -64,11 +64,13 @@ unique_ptr<TableFilter> TableFilter::Deserialize(Deserializer &deserializer) {
 void ExpressionFilter::Serialize(Serializer &serializer) const {
 	TableFilter::Serialize(serializer);
 	serializer.WritePropertyWithDefault<unique_ptr<Expression>>(200, "expr", expr);
+	serializer.WritePropertyWithDefault<vector<ProjectionIndex>>(201, "column_indexes", column_indexes, vector<ProjectionIndex>());
 }
 
 unique_ptr<TableFilter> ExpressionFilter::Deserialize(Deserializer &deserializer) {
 	auto expr = deserializer.ReadPropertyWithDefault<unique_ptr<Expression>>(200, "expr");
-	auto result = duckdb::unique_ptr<ExpressionFilter>(new ExpressionFilter(std::move(expr)));
+	auto column_indexes = deserializer.ReadPropertyWithExplicitDefault<vector<ProjectionIndex>>(201, "column_indexes", vector<ProjectionIndex>());
+	auto result = duckdb::unique_ptr<ExpressionFilter>(new ExpressionFilter(std::move(expr), std::move(column_indexes)));
 	return std::move(result);
 }
 

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -13,8 +13,6 @@
 #include "duckdb/common/vector/flat_vector.hpp"
 #include "duckdb/execution/adaptive_filter.hpp"
 #include "duckdb/execution/expression_executor.hpp"
-#include "duckdb/optimizer/statistics_propagator.hpp"
-#include "duckdb/planner/expression/bound_comparison_expression.hpp"
 #include "duckdb/planner/filter/expression_filter.hpp"
 #include "duckdb/planner/table_filter.hpp"
 #include "duckdb/storage/checkpoint/table_data_writer.hpp"
@@ -719,38 +717,28 @@ bool RowGroup::CheckZonemap(optional_ptr<ClientContext> context, ScanFilterInfo 
 	const auto table_filters = filters.GetTableFilters();
 	const auto column_ids = filters.GetColumnIds();
 	if (table_filters && column_ids) {
-		for (const auto &filter : table_filters->GetRowGroupFilters()) {
-			if (filter.column_indexes.size() != 2 || !filter.expression ||
-			    !BoundComparisonExpression::IsComparison(*filter.expression)) {
+		for (const auto &filter : table_filters->GetMultiColumnFilters()) {
+			const auto &expression_filter = ExpressionFilter::GetExpressionFilter(*filter, "RowGroup::CheckZonemap");
+			vector<BaseStatistics> input_stats;
+			input_stats.reserve(expression_filter.column_indexes.size());
+			bool supported = true;
+			for (const auto &column_index : expression_filter.column_indexes) {
+				if (column_index.GetIndex() >= column_ids->size()) {
+					throw InternalException("Multi-column filter column index out of range");
+				}
+				const auto &storage_index = (*column_ids)[column_index.GetIndex()];
+				if (storage_index.IsRowIdColumn() || storage_index.IsRowNumberColumn()) {
+					supported = false;
+					break;
+				}
+				input_stats.push_back(GetStatistics(storage_index)->Copy());
+			}
+			if (!supported) {
 				continue;
 			}
-			const auto &comparison = filter.expression->Cast<BoundFunctionExpression>();
-			const auto &left = BoundComparisonExpression::Left(comparison);
-			const auto &right = BoundComparisonExpression::Right(comparison);
-			if (left.GetExpressionClass() != ExpressionClass::BOUND_REF ||
-			    right.GetExpressionClass() != ExpressionClass::BOUND_REF) {
-				continue;
-			}
-			const auto left_index = left.Cast<BoundReferenceExpression>().Index();
-			const auto right_index = right.Cast<BoundReferenceExpression>().Index();
-			if (left_index >= filter.column_indexes.size() || right_index >= filter.column_indexes.size()) {
-				continue;
-			}
-			const auto left_column_index = filter.column_indexes[left_index].GetIndex();
-			const auto right_column_index = filter.column_indexes[right_index].GetIndex();
-			if (left_column_index >= column_ids->size() || right_column_index >= column_ids->size()) {
-				throw InternalException("Row-group filter column index out of range");
-			}
-			const auto &left_storage_index = (*column_ids)[left_column_index];
-			const auto &right_storage_index = (*column_ids)[right_column_index];
-			if (left_storage_index.IsRowIdColumn() || left_storage_index.IsRowNumberColumn() ||
-			    right_storage_index.IsRowIdColumn() || right_storage_index.IsRowNumberColumn()) {
-				continue;
-			}
-			auto left_stats = GetStatistics(left_storage_index);
-			auto right_stats = GetStatistics(right_storage_index);
-			const auto prune_result =
-			    StatisticsPropagator::PropagateComparison(*left_stats, *right_stats, comparison.GetExpressionType());
+			const auto prune_result = ExpressionFilter::CheckExpressionStatistics(
+			    context, *expression_filter.expr,
+			    array_ptr<const BaseStatistics>(input_stats.data(), input_stats.size()));
 			if (prune_result == FilterPropagateResult::FILTER_ALWAYS_FALSE ||
 			    prune_result == FilterPropagateResult::FILTER_FALSE_OR_NULL) {
 				return false;

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -13,6 +13,8 @@
 #include "duckdb/common/vector/flat_vector.hpp"
 #include "duckdb/execution/adaptive_filter.hpp"
 #include "duckdb/execution/expression_executor.hpp"
+#include "duckdb/optimizer/statistics_propagator.hpp"
+#include "duckdb/planner/expression/bound_comparison_expression.hpp"
 #include "duckdb/planner/filter/expression_filter.hpp"
 #include "duckdb/planner/table_filter.hpp"
 #include "duckdb/storage/checkpoint/table_data_writer.hpp"
@@ -714,6 +716,47 @@ FilterPropagateResult RowGroup::CheckRowIdFilter(const TableFilter &filter, idx_
 }
 
 bool RowGroup::CheckZonemap(optional_ptr<ClientContext> context, ScanFilterInfo &filters, idx_t row_start) {
+	const auto table_filters = filters.GetTableFilters();
+	const auto column_ids = filters.GetColumnIds();
+	if (table_filters && column_ids) {
+		for (const auto &filter : table_filters->GetRowGroupFilters()) {
+			if (filter.column_indexes.size() != 2 || !filter.expression ||
+			    !BoundComparisonExpression::IsComparison(*filter.expression)) {
+				continue;
+			}
+			const auto &comparison = filter.expression->Cast<BoundFunctionExpression>();
+			const auto &left = BoundComparisonExpression::Left(comparison);
+			const auto &right = BoundComparisonExpression::Right(comparison);
+			if (left.GetExpressionClass() != ExpressionClass::BOUND_REF ||
+			    right.GetExpressionClass() != ExpressionClass::BOUND_REF) {
+				continue;
+			}
+			const auto left_index = left.Cast<BoundReferenceExpression>().Index();
+			const auto right_index = right.Cast<BoundReferenceExpression>().Index();
+			if (left_index >= filter.column_indexes.size() || right_index >= filter.column_indexes.size()) {
+				continue;
+			}
+			const auto left_column_index = filter.column_indexes[left_index].GetIndex();
+			const auto right_column_index = filter.column_indexes[right_index].GetIndex();
+			if (left_column_index >= column_ids->size() || right_column_index >= column_ids->size()) {
+				throw InternalException("Row-group filter column index out of range");
+			}
+			const auto &left_storage_index = (*column_ids)[left_column_index];
+			const auto &right_storage_index = (*column_ids)[right_column_index];
+			if (left_storage_index.IsRowIdColumn() || left_storage_index.IsRowNumberColumn() ||
+			    right_storage_index.IsRowIdColumn() || right_storage_index.IsRowNumberColumn()) {
+				continue;
+			}
+			auto left_stats = GetStatistics(left_storage_index);
+			auto right_stats = GetStatistics(right_storage_index);
+			const auto prune_result =
+			    StatisticsPropagator::PropagateComparison(*left_stats, *right_stats, comparison.GetExpressionType());
+			if (prune_result == FilterPropagateResult::FILTER_ALWAYS_FALSE ||
+			    prune_result == FilterPropagateResult::FILTER_FALSE_OR_NULL) {
+				return false;
+			}
+		}
+	}
 	auto &filter_list = filters.GetFilterList();
 	// new row group - label all filters as up for grabs again
 	filters.CheckAllFilters();

--- a/src/storage/table/scan_state.cpp
+++ b/src/storage/table/scan_state.cpp
@@ -81,10 +81,13 @@ ScanFilter::ScanFilter(ClientContext &context, ProjectionIndex index, const vect
 
 void ScanFilterInfo::Initialize(ClientContext &context, TableFilterSet &filters,
                                 const vector<StorageIndex> &column_ids) {
-	D_ASSERT(filters.HasFilters());
+	D_ASSERT(filters.HasFilters() || filters.HasRowGroupFilters());
 	table_filters = &filters;
-	adaptive_filter = make_uniq<AdaptiveFilter>(filters);
-	adaptive_filter->SetLogger(context.logger);
+	this->column_ids = &column_ids;
+	if (filters.HasFilters()) {
+		adaptive_filter = make_uniq<AdaptiveFilter>(filters);
+		adaptive_filter->SetLogger(context.logger);
+	}
 	filter_list.reserve(filters.FilterCount());
 	for (auto &entry : filters) {
 		filter_list.emplace_back(context, entry.GetIndex(), column_ids, entry.Filter());

--- a/src/storage/table/scan_state.cpp
+++ b/src/storage/table/scan_state.cpp
@@ -81,7 +81,7 @@ ScanFilter::ScanFilter(ClientContext &context, ProjectionIndex index, const vect
 
 void ScanFilterInfo::Initialize(ClientContext &context, TableFilterSet &filters,
                                 const vector<StorageIndex> &column_ids) {
-	D_ASSERT(filters.HasFilters() || filters.HasRowGroupFilters());
+	D_ASSERT(filters.HasFilters() || filters.HasMultiColumnFilters());
 	table_filters = &filters;
 	this->column_ids = &column_ids;
 	if (filters.HasFilters()) {

--- a/test/sql/optimizer/multiple_column_stats_pruning.test
+++ b/test/sql/optimizer/multiple_column_stats_pruning.test
@@ -1,0 +1,80 @@
+# name: test/sql/optimizer/multiple_column_stats_pruning.test
+# description: Use row-group statistics for direct column comparisons
+# group: [optimizer]
+
+statement ok
+CREATE TABLE xy AS
+SELECT CASE WHEN range % 2 = 0 THEN NULL ELSE range END::BIGINT AS i, (range + 200000)::BIGINT AS j
+FROM range(400000);
+
+statement ok
+CHECKPOINT;
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM xy WHERE i > j;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 0 / 4.*
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM xy WHERE i >= j;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 0 / 4.*
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM xy WHERE i = j;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 0 / 4.*
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM xy WHERE j < i;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 0 / 4.*
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM xy WHERE j <= i;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 0 / 4.*
+
+query I
+SELECT count(*) FROM xy WHERE i > j;
+----
+0
+
+# Row-group filters survive common-subplan canonicalization alongside regular filters
+statement ok
+PRAGMA explain_output='optimized_only';
+
+query II
+EXPLAIN SELECT count(*) FROM xy WHERE i > j AND i >= 0
+UNION ALL
+SELECT count(*) FROM xy WHERE i > j AND i >= 0;
+----
+logical_opt	<REGEX>:.*CTE.*
+
+statement ok
+PRAGMA explain_output='all';
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM xy WHERE i > j AND i >= 0
+UNION ALL
+SELECT count(*) FROM xy WHERE i > j AND i >= 0;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 0 / 4.*
+
+statement ok
+CREATE TABLE partially_matching AS
+SELECT range::BIGINT AS i, 200000::BIGINT AS j
+FROM range(400000);
+
+statement ok
+CHECKPOINT;
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM partially_matching WHERE i > j;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 3 / 4.*
+
+query I
+SELECT count(*) FROM partially_matching WHERE i > j;
+----
+199999

--- a/test/sql/optimizer/multiple_column_stats_pruning.test
+++ b/test/sql/optimizer/multiple_column_stats_pruning.test
@@ -40,7 +40,7 @@ SELECT count(*) FROM xy WHERE i > j;
 ----
 0
 
-# Row-group filters survive common-subplan canonicalization alongside regular filters
+# Multi-column filters survive common-subplan canonicalization alongside regular filters
 statement ok
 PRAGMA explain_output='optimized_only';
 


### PR DESCRIPTION
## Summary

Resolves #23884

Currently, cross-column predicates are evaluated only after every row group has been scanned. This change introduces a new `RowGroupExpressionFilter` to store cross-column expressions. It enables direct numeric column comparisons to be propagated to row-group pruning, so row groups that cannot match can be skipped safely.

## Results

```sql
CREATE TABLE xy AS
SELECT range::BIGINT AS i, (range + 200000)::BIGINT AS j
FROM range(400000);

CHECKPOINT;

EXPLAIN ANALYZE SELECT count(*) FROM xy WHERE i > j;
```

### Before

```sql
╭─ Summary ───────────╮
│ Total Time: 0.0046s │
╰─────────────────────╯
╭─ Ungrouped Aggregate ─────╮
│ Aggregates: count_star()  │
│ 1 row                 0µs │
╰─────────────┬─────────────╯
╭─ Filter ────┴─────────────╮
│ Expression: i > j         │
│ 0 rows                0µs │
╰─────────────┒┎────────────╯
╭─ Table Scan ┚┖────────────╮
│ Table: memory.main.xy     │
│ Type: Sequential Scan     │
│ Projections: i, j         │
│ Row Groups Scanned: 4 / 4 │
│ 400,000 rows          0µs │
╰───────────────────────────╯
```

### After

```sql
╭─ Summary ───────────╮
│ Total Time: 0.0018s │
╰─────────────────────╯
╭─ Ungrouped Aggregate ─────╮
│ Aggregates: count_star()  │
│ 1 row                 0µs │
╰─────────────┬─────────────╯
╭─ Filter ────┴─────────────╮
│ Expression: i > j         │
│ 0 rows                0µs │
╰─────────────┬─────────────╯
╭─ Table Scan ┴─────────────╮
│ Table: memory.main.xy     │
│ Type: Sequential Scan     │
│ Projections: i, j         │
│ Row Groups Scanned: 0 / 4 │
│ 0 rows                0µs │
╰───────────────────────────╯
```

### Note

Once this PR is merged, I plan to open follow-up PRs that reuse the current `RowGroupExpressionFilter` structure to support more general cross-column expressions, including:

- Disjunctions such as `i > j OR k < l`
- Arithmetic expressions such as `i + 1 > j` or `i * 2 <= j`
- Monotonic casts or functions such as `CAST(i AS HUGEINT) > j`
