### PR TITLE
Replace trailing variadic functions with `*args` and `**kwargs`

### DIFF
--- a/extension/core_functions/scalar/array/array_value.cpp
+++ b/extension/core_functions/scalar/array/array_value.cpp
@@ -1,7 +1,10 @@
 #include "duckdb/common/vector/array_vector.hpp"
 #include "core_functions/scalar/array_functions.hpp"
 #include "duckdb/function/scalar/nested_functions.hpp"
+#include "duckdb/common/vector/struct_vector.hpp"
+#include "duckdb/planner/expression/bound_argument_pack.hpp"
 #include "duckdb/storage/statistics/array_stats.hpp"
+#include "duckdb/storage/statistics/struct_stats.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 
 namespace duckdb {
@@ -11,20 +14,22 @@ namespace {
 void ArrayValueFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto array_type = result.GetType();
 
+	auto &values = StructVector::GetEntries(args.data[0]);
+
 	D_ASSERT(array_type.id() == LogicalTypeId::ARRAY);
-	D_ASSERT(args.ColumnCount() == ArrayType::GetSize(array_type));
+	D_ASSERT(values.size() == ArrayType::GetSize(array_type));
 
 	auto &child_type = ArrayType::GetChildType(array_type);
 
 	result.SetVectorType(VectorType::CONSTANT_VECTOR);
-	for (idx_t i = 0; i < args.ColumnCount(); i++) {
-		if (args.data[i].GetVectorType() != VectorType::CONSTANT_VECTOR) {
+	for (auto &value : values) {
+		if (value.GetVectorType() != VectorType::CONSTANT_VECTOR) {
 			result.SetVectorType(VectorType::FLAT_VECTOR);
 		}
 	}
 
 	auto num_rows = args.size();
-	auto num_columns = args.ColumnCount();
+	auto num_columns = values.size();
 
 	auto &child = ArrayVector::GetChildMutable(result);
 
@@ -37,7 +42,7 @@ void ArrayValueFunction(DataChunk &args, ExpressionState &state, Vector &result)
 
 	for (idx_t i = 0; i < num_rows; i++) {
 		for (idx_t j = 0; j < num_columns; j++) {
-			auto val = args.GetValue(j, i).DefaultCastAs(child_type);
+			auto val = values[j].GetValue(i).DefaultCastAs(child_type);
 			child.SetValue((i * num_columns) + j, val);
 		}
 	}
@@ -49,29 +54,27 @@ unique_ptr<FunctionData> ArrayValueBind(BindScalarFunctionInput &input) {
 	auto &context = input.GetClientContext();
 	auto &bound_function = input.GetBoundFunction();
 	auto &arguments = input.GetArguments();
-	if (arguments.empty()) {
+	D_ASSERT(arguments.size() == 1);
+	auto &values = StructType::GetChildTypes(arguments[0]->GetReturnType());
+	if (values.empty()) {
 		throw InvalidInputException("array_value requires at least one argument");
 	}
 
 	// construct return type
-	LogicalType child_type = arguments[0]->GetReturnType();
-	for (idx_t i = 1; i < arguments.size(); i++) {
-		child_type = LogicalType::MaxLogicalType(context, child_type, arguments[i]->GetReturnType());
+	LogicalType child_type = values[0].second;
+	for (idx_t i = 1; i < values.size(); i++) {
+		child_type = LogicalType::MaxLogicalType(context, child_type, values[i].second);
 	}
 
-	if (arguments.size() > ArrayType::MAX_ARRAY_SIZE) {
+	if (values.size() > ArrayType::MAX_ARRAY_SIZE) {
 		throw OutOfRangeException("Array size exceeds maximum allowed size");
 	}
 
 	// Cast all arguments to the common child type so that execution and statistics see matching types.
-	auto &function_args = bound_function.GetArguments();
-	function_args.clear();
-	function_args.reserve(arguments.size());
-	for (idx_t i = 0; i < arguments.size(); i++) {
-		function_args.push_back(child_type);
-	}
+	const auto value_count = values.size();
+	bound_function.GetArguments()[0] = ArgumentPack::PositionalType(vector<LogicalType>(value_count, child_type));
 
-	bound_function.SetReturnType(LogicalType::ARRAY(child_type, arguments.size()));
+	bound_function.SetReturnType(LogicalType::ARRAY(child_type, value_count));
 	return make_uniq<VariableReturnBindData>(bound_function.GetReturnType());
 }
 
@@ -80,8 +83,11 @@ unique_ptr<BaseStatistics> ArrayValueStats(ClientContext &context, FunctionStati
 	auto &expr = input.expr;
 	auto list_stats = ArrayStats::CreateEmpty(expr.GetReturnType());
 	auto &list_child_stats = ArrayStats::GetChildStats(list_stats);
-	for (idx_t i = 0; i < child_stats.size(); i++) {
-		list_child_stats.Merge(child_stats[i]);
+	// the values are collected by a "*values" parameter, so their statistics are the pack's member statistics
+	D_ASSERT(child_stats.size() == 1);
+	const auto value_count = StructType::GetChildCount(expr.GetChildren()[0]->GetReturnType());
+	for (idx_t i = 0; i < value_count; i++) {
+		list_child_stats.Merge(StructStats::GetChildStats(child_stats[0], i));
 	}
 	list_stats.SetHasNoNullFast();
 	return list_stats.ToUnique();
@@ -91,8 +97,12 @@ unique_ptr<BaseStatistics> ArrayValueStats(ClientContext &context, FunctionStati
 
 ScalarFunction ArrayValueFun::GetFunction() {
 	// the arguments and return types are actually set in the binder function
-	ScalarFunction fun("array_value", {}, LogicalTypeId::ARRAY, ArrayValueFunction, ArrayValueBind, ArrayValueStats);
-	fun.SetVarArgs(LogicalType::ANY);
+	FunctionSignature signature;
+	signature.AddVarPositionalParameter("values", LogicalType::ANY);
+	signature.SetReturnType(LogicalTypeId::ARRAY);
+	ScalarFunction fun("array_value", std::move(signature), ArrayValueFunction);
+	fun.SetBindCallback(ArrayValueBind);
+	fun.SetStatisticsCallback(ArrayValueStats);
 	fun.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 	return fun;
 }

--- a/extension/core_functions/scalar/array/array_value.cpp
+++ b/extension/core_functions/scalar/array/array_value.cpp
@@ -11,7 +11,6 @@ namespace duckdb {
 namespace {
 
 void ArrayValueFunction(DataChunk &args, ExpressionState &state, Vector &result) {
-
 	const auto &head = args.data[0];
 	const auto &tail = ArgumentPack::GetInput(args.data[1]);
 
@@ -51,7 +50,6 @@ unique_ptr<FunctionData> ArrayValueBind(BindScalarFunctionInput &input) {
 }
 
 unique_ptr<BaseStatistics> ArrayValueStats(ClientContext &, FunctionStatisticsInput &input) {
-
 	const auto &head_stats = input.child_stats[0];
 	const auto &tail_stats = input.child_stats[1];
 	const auto tail_length = ArgumentPack::GetSize(tail_stats.GetType());
@@ -74,15 +72,15 @@ ScalarFunction ArrayValueFun::GetFunction() {
 	const auto element_type = LogicalType::TEMPLATE("T");
 
 	auto sig = FunctionSignature()
-		.AddParameter("head", element_type)
-		.AddVarPositionalParameter("tail", element_type)
-		.SetReturnType(LogicalType::ARRAY(element_type, optional_idx()));
+	               .AddParameter("head", element_type)
+	               .AddVarPositionalParameter("tail", element_type)
+	               .SetReturnType(LogicalType::ARRAY(element_type, optional_idx()));
 
 	auto fun = ScalarFunction("array_value", std::move(sig))
-		.SetFunctionCallback(ArrayValueFunction)
-		.SetBindCallback(ArrayValueBind)
-		.SetStatisticsCallback(ArrayValueStats)
-		.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
+	               .SetFunctionCallback(ArrayValueFunction)
+	               .SetBindCallback(ArrayValueBind)
+	               .SetStatisticsCallback(ArrayValueStats)
+	               .SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 
 	return fun;
 }

--- a/extension/core_functions/scalar/array/array_value.cpp
+++ b/extension/core_functions/scalar/array/array_value.cpp
@@ -1,7 +1,6 @@
 #include "duckdb/common/vector/array_vector.hpp"
 #include "core_functions/scalar/array_functions.hpp"
 #include "duckdb/function/scalar/nested_functions.hpp"
-#include "duckdb/common/vector/struct_vector.hpp"
 #include "duckdb/planner/expression/bound_argument_pack.hpp"
 #include "duckdb/storage/statistics/array_stats.hpp"
 #include "duckdb/storage/statistics/struct_stats.hpp"
@@ -12,38 +11,24 @@ namespace duckdb {
 namespace {
 
 void ArrayValueFunction(DataChunk &args, ExpressionState &state, Vector &result) {
-	auto array_type = result.GetType();
 
-	auto &values = StructVector::GetEntries(args.data[0]);
+	const auto &head = args.data[0];
+	const auto &tail = ArgumentPack::GetInput(args.data[1]);
 
-	D_ASSERT(array_type.id() == LogicalTypeId::ARRAY);
-	D_ASSERT(values.size() == ArrayType::GetSize(array_type));
-
-	auto &child_type = ArrayType::GetChildType(array_type);
-
-	result.SetVectorType(VectorType::CONSTANT_VECTOR);
-	for (auto &value : values) {
-		if (value.GetVectorType() != VectorType::CONSTANT_VECTOR) {
-			result.SetVectorType(VectorType::FLAT_VECTOR);
-		}
-	}
-
-	auto num_rows = args.size();
-	auto num_columns = values.size();
+	const auto num_rows = args.size();
+	const auto num_cols = 1 + tail.size();
 
 	auto &child = ArrayVector::GetChildMutable(result);
 
-	if (num_columns > 1) {
-		// Ensure that the child has a validity mask of the correct size
-		// The SetValue call below expects the validity mask to be initialized
-		auto &child_validity = FlatVector::ValidityMutable(child);
-		child_validity.Resize(num_rows * num_columns);
-	}
+	FlatVector::ValidityMutable(child).Resize(num_rows * num_cols);
 
 	for (idx_t i = 0; i < num_rows; i++) {
-		for (idx_t j = 0; j < num_columns; j++) {
-			auto val = values[j].GetValue(i).DefaultCastAs(child_type);
-			child.SetValue((i * num_columns) + j, val);
+		const auto &head_val = head.GetValue(i);
+		child.SetValue(i * num_cols, head_val);
+
+		for (idx_t j = 0; j < tail.size(); j++) {
+			const auto &tail_val = tail[j].GetValue(i);
+			child.SetValue((i * num_cols) + 1 + j, tail_val);
 		}
 	}
 
@@ -51,59 +36,54 @@ void ArrayValueFunction(DataChunk &args, ExpressionState &state, Vector &result)
 }
 
 unique_ptr<FunctionData> ArrayValueBind(BindScalarFunctionInput &input) {
-	auto &context = input.GetClientContext();
-	auto &bound_function = input.GetBoundFunction();
-	auto &arguments = input.GetArguments();
-	D_ASSERT(arguments.size() == 1);
-	auto &values = StructType::GetChildTypes(arguments[0]->GetReturnType());
-	if (values.empty()) {
-		throw InvalidInputException("array_value requires at least one argument");
-	}
+	auto &func = input.GetBoundFunction();
 
-	// construct return type
-	LogicalType child_type = values[0].second;
-	for (idx_t i = 1; i < values.size(); i++) {
-		child_type = LogicalType::MaxLogicalType(context, child_type, values[i].second);
-	}
+	const auto &args = input.GetArguments();
+	const auto &head = args[0]->GetReturnType();
+	const auto &tail = ArgumentPack::GetTypes(args[1]->GetReturnType());
 
-	if (values.size() > ArrayType::MAX_ARRAY_SIZE) {
+	if (tail.size() > ArrayType::MAX_ARRAY_SIZE) {
 		throw OutOfRangeException("Array size exceeds maximum allowed size");
 	}
 
-	// Cast all arguments to the common child type so that execution and statistics see matching types.
-	const auto value_count = values.size();
-	bound_function.GetArguments()[0] = ArgumentPack::PositionalType(vector<LogicalType>(value_count, child_type));
-
-	bound_function.SetReturnType(LogicalType::ARRAY(child_type, value_count));
-	return make_uniq<VariableReturnBindData>(bound_function.GetReturnType());
+	func.SetReturnType(LogicalType::ARRAY(head, 1 + tail.size()));
+	return make_uniq<VariableReturnBindData>(func.GetReturnType());
 }
 
-unique_ptr<BaseStatistics> ArrayValueStats(ClientContext &context, FunctionStatisticsInput &input) {
-	auto &child_stats = input.child_stats;
-	auto &expr = input.expr;
-	auto list_stats = ArrayStats::CreateEmpty(expr.GetReturnType());
-	auto &list_child_stats = ArrayStats::GetChildStats(list_stats);
-	// the values are collected by a "*values" parameter, so their statistics are the pack's member statistics
-	D_ASSERT(child_stats.size() == 1);
-	const auto value_count = StructType::GetChildCount(expr.GetChildren()[0]->GetReturnType());
-	for (idx_t i = 0; i < value_count; i++) {
-		list_child_stats.Merge(StructStats::GetChildStats(child_stats[0], i));
+unique_ptr<BaseStatistics> ArrayValueStats(ClientContext &, FunctionStatisticsInput &input) {
+
+	const auto &head_stats = input.child_stats[0];
+	const auto &tail_stats = input.child_stats[1];
+	const auto tail_length = ArgumentPack::GetSize(tail_stats.GetType());
+
+	auto array_stats = ArrayStats::CreateEmpty(input.expr.GetReturnType());
+	auto &elem_stats = ArrayStats::GetChildStats(array_stats);
+
+	elem_stats.Merge(head_stats);
+	for (idx_t i = 0; i < tail_length; i++) {
+		elem_stats.Merge(StructStats::GetChildStats(tail_stats, i));
 	}
-	list_stats.SetHasNoNullFast();
-	return list_stats.ToUnique();
+
+	array_stats.SetHasNoNullFast();
+	return array_stats.ToUnique();
 }
 
 } // namespace
 
 ScalarFunction ArrayValueFun::GetFunction() {
-	// the arguments and return types are actually set in the binder function
-	FunctionSignature signature;
-	signature.AddVarPositionalParameter("values", LogicalType::ANY);
-	signature.SetReturnType(LogicalTypeId::ARRAY);
-	ScalarFunction fun("array_value", std::move(signature), ArrayValueFunction);
-	fun.SetBindCallback(ArrayValueBind);
-	fun.SetStatisticsCallback(ArrayValueStats);
-	fun.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
+	const auto element_type = LogicalType::TEMPLATE("T");
+
+	auto sig = FunctionSignature()
+		.AddParameter("head", element_type)
+		.AddVarPositionalParameter("tail", element_type)
+		.SetReturnType(LogicalType::ARRAY(element_type, optional_idx()));
+
+	auto fun = ScalarFunction("array_value", std::move(sig))
+		.SetFunctionCallback(ArrayValueFunction)
+		.SetBindCallback(ArrayValueBind)
+		.SetStatisticsCallback(ArrayValueStats)
+		.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
+
 	return fun;
 }
 

--- a/extension/core_functions/scalar/array/array_value.cpp
+++ b/extension/core_functions/scalar/array/array_value.cpp
@@ -37,15 +37,15 @@ void ArrayValueFunction(DataChunk &args, ExpressionState &state, Vector &result)
 unique_ptr<FunctionData> ArrayValueBind(BindScalarFunctionInput &input) {
 	auto &func = input.GetBoundFunction();
 
-	const auto &args = input.GetArguments();
-	const auto &head = args[0]->GetReturnType();
-	const auto &tail = ArgumentPack::GetTypes(args[1]->GetReturnType());
+	// every argument is cast to the type the "T" parameter resolved to, which is the array's element type
+	const auto &element_type = func.GetArguments()[0];
+	const auto tail_size = ArgumentPack::GetSize(input.GetArguments()[1]->GetReturnType());
 
-	if (tail.size() > ArrayType::MAX_ARRAY_SIZE) {
+	if (tail_size > ArrayType::MAX_ARRAY_SIZE) {
 		throw OutOfRangeException("Array size exceeds maximum allowed size");
 	}
 
-	func.SetReturnType(LogicalType::ARRAY(head, 1 + tail.size()));
+	func.SetReturnType(LogicalType::ARRAY(element_type, 1 + tail_size));
 	return make_uniq<VariableReturnBindData>(func.GetReturnType());
 }
 

--- a/extension/core_functions/scalar/debug/index_key.cpp
+++ b/extension/core_functions/scalar/debug/index_key.cpp
@@ -9,7 +9,9 @@
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/execution/index/art/art.hpp"
 #include "duckdb/execution/index/art/art_key.hpp"
+#include "duckdb/common/vector/struct_vector.hpp"
 #include "duckdb/function/scalar_function.hpp"
+#include "duckdb/planner/expression/bound_argument_pack.hpp"
 #include "duckdb/main/table_description.hpp"
 #include "duckdb/parser/parsed_data/parse_info.hpp"
 #include "duckdb/planner/binder.hpp"
@@ -121,9 +123,7 @@ static unique_ptr<FunctionData> IndexKeyBind(BindScalarFunctionInput &input) {
 	auto &context = input.GetClientContext();
 	auto &bound_function = input.GetBoundFunction();
 	auto &arguments = input.GetArguments();
-	if (arguments.size() < INDEX_KEY_FIXED_ARGS) {
-		throw BinderException("index_key: requires at least two arguments - path (STRUCT), index_name");
-	}
+	D_ASSERT(arguments.size() == INDEX_KEY_FIXED_ARGS + 1);
 
 	auto path = EvaluateTableDescription(input.GetConstant(0));
 	auto index_name = GetStringArgument(input.GetConstant(1), "index_name");
@@ -161,7 +161,7 @@ static unique_ptr<FunctionData> IndexKeyBind(BindScalarFunctionInput &input) {
 
 	auto key_types = bound_index.logical_types;
 
-	idx_t num_key_args = arguments.size() - INDEX_KEY_FIXED_ARGS;
+	idx_t num_key_args = StructType::GetChildCount(arguments[INDEX_KEY_FIXED_ARGS]->GetReturnType());
 	if (num_key_args != key_types.size()) {
 		throw BinderException("index_key: index '%s' expects %llu key column(s), but %llu argument(s) provided",
 		                      index_name, key_types.size(), num_key_args);
@@ -172,12 +172,11 @@ static unique_ptr<FunctionData> IndexKeyBind(BindScalarFunctionInput &input) {
 	// for execution even though they are only required for binding. This requires us to create a key_chunk
 	// that only references the key columns during execution. We could erase the first two arguments here, but
 	// that also requires some (de)serialization boilerplate, so for now we don't do it.
+	// giving the pack the index's key types makes CastToFunctionArguments cast the key columns into place
 	bound_function.GetArguments().clear();
 	bound_function.GetArguments().push_back(arguments[0]->GetReturnType());
 	bound_function.GetArguments().push_back(arguments[1]->GetReturnType());
-	for (auto &key_type : key_types) {
-		bound_function.GetArguments().push_back(key_type);
-	}
+	bound_function.GetArguments().push_back(ArgumentPack::PositionalType(key_types));
 
 	return make_uniq<IndexKeyBindData>(art, std::move(key_types));
 }
@@ -191,8 +190,9 @@ static void IndexKeyFunction(DataChunk &args, ExpressionState &state, Vector &re
 	// Create a DataChunk referencing only the key columns (skip path and index_name).
 	DataChunk key_chunk;
 	key_chunk.InitializeEmpty(bind_data.key_types);
+	auto &key_columns = StructVector::GetEntries(args.data[INDEX_KEY_FIXED_ARGS]);
 	for (idx_t i = 0; i < bind_data.key_types.size(); i++) {
-		key_chunk.data[i].Reference(args.data[INDEX_KEY_FIXED_ARGS + i]);
+		key_chunk.data[i].Reference(key_columns[i]);
 	}
 
 	auto &art = bind_data.art;
@@ -218,9 +218,13 @@ static void IndexKeyFunction(DataChunk &args, ExpressionState &state, Vector &re
 } // namespace
 
 ScalarFunction IndexKeyFun::GetFunction() {
-	ScalarFunction fun("index_key", {{"path", LogicalTypeId::STRUCT}, {"name", LogicalType::VARCHAR}},
-	                   LogicalType::BLOB, IndexKeyFunction, IndexKeyBind);
-	fun.SetVarArgs(LogicalTypeId::ANY);
+	FunctionSignature signature;
+	signature.AddParameter("path", LogicalTypeId::STRUCT);
+	signature.AddParameter("name", LogicalType::VARCHAR);
+	signature.AddVarPositionalParameter("keys", LogicalTypeId::ANY);
+	signature.SetReturnType(LogicalType::BLOB);
+	ScalarFunction fun("index_key", std::move(signature), IndexKeyFunction);
+	fun.SetBindCallback(IndexKeyBind);
 	return fun;
 }
 

--- a/extension/core_functions/scalar/generic/hash.cpp
+++ b/extension/core_functions/scalar/generic/hash.cpp
@@ -14,13 +14,12 @@ static void HashFunction(DataChunk &args, ExpressionState &state, Vector &result
 }
 
 ScalarFunction HashFun::GetFunction() {
-	return ScalarFunction("hash",
-		FunctionSignature()
-			.AddParameter("arg", LogicalType::ANY)
-			.AddVarPositionalParameter("args", LogicalType::ANY)
-			.SetReturnType(LogicalType::HASH))
-		.SetFunctionCallback(HashFunction)
-		.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
+	return ScalarFunction("hash", FunctionSignature()
+	                                  .AddParameter("arg", LogicalType::ANY)
+	                                  .AddVarPositionalParameter("args", LogicalType::ANY)
+	                                  .SetReturnType(LogicalType::HASH))
+	    .SetFunctionCallback(HashFunction)
+	    .SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 }
 
 } // namespace duckdb

--- a/extension/core_functions/scalar/generic/hash.cpp
+++ b/extension/core_functions/scalar/generic/hash.cpp
@@ -1,14 +1,24 @@
 #include "core_functions/scalar/generic_functions.hpp"
+#include "duckdb/common/vector/struct_vector.hpp"
+#include "duckdb/common/vector_operations/vector_operations.hpp"
 
 namespace duckdb {
 
 static void HashFunction(DataChunk &args, ExpressionState &state, Vector &result) {
-	args.Hash(result);
+	// combine the hash of the first value with the hash of every value collected by "*values"
+	const auto count = args.size();
+	VectorOperations::Hash(args.data[0], result, count);
+	for (auto &value : StructVector::GetEntries(args.data[1])) {
+		VectorOperations::CombineHash(result, value, count);
+	}
 }
 
 ScalarFunction HashFun::GetFunction() {
-	auto hash_fun = ScalarFunction({LogicalType::ANY}, LogicalType::HASH, HashFunction);
-	hash_fun.SetVarArgs(LogicalType::ANY);
+	FunctionSignature signature;
+	signature.AddParameter("value", LogicalType::ANY);
+	signature.AddVarPositionalParameter("values", LogicalType::ANY);
+	signature.SetReturnType(LogicalType::HASH);
+	auto hash_fun = ScalarFunction("hash", std::move(signature), HashFunction);
 	hash_fun.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 	return hash_fun;
 }

--- a/extension/core_functions/scalar/generic/hash.cpp
+++ b/extension/core_functions/scalar/generic/hash.cpp
@@ -1,6 +1,6 @@
 #include "core_functions/scalar/generic_functions.hpp"
-#include "duckdb/common/vector/struct_vector.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
+#include "duckdb/planner/expression/bound_argument_pack.hpp"
 
 namespace duckdb {
 
@@ -8,19 +8,19 @@ static void HashFunction(DataChunk &args, ExpressionState &state, Vector &result
 	// combine the hash of the first value with the hash of every value collected by "*values"
 	const auto count = args.size();
 	VectorOperations::Hash(args.data[0], result, count);
-	for (auto &value : StructVector::GetEntries(args.data[1])) {
+	for (auto &value : ArgumentPack::GetInput(args.data[1])) {
 		VectorOperations::CombineHash(result, value, count);
 	}
 }
 
 ScalarFunction HashFun::GetFunction() {
-	FunctionSignature signature;
-	signature.AddParameter("value", LogicalType::ANY);
-	signature.AddVarPositionalParameter("values", LogicalType::ANY);
-	signature.SetReturnType(LogicalType::HASH);
-	auto hash_fun = ScalarFunction("hash", std::move(signature), HashFunction);
-	hash_fun.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
-	return hash_fun;
+	return ScalarFunction("hash",
+		FunctionSignature()
+			.AddParameter("arg", LogicalType::ANY)
+			.AddVarPositionalParameter("args", LogicalType::ANY)
+			.SetReturnType(LogicalType::HASH))
+		.SetFunctionCallback(HashFunction)
+		.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 }
 
 } // namespace duckdb

--- a/extension/core_functions/scalar/generic/least.cpp
+++ b/extension/core_functions/scalar/generic/least.cpp
@@ -2,10 +2,12 @@
 #include "duckdb/common/operator/comparison_operators.hpp"
 #include "duckdb/common/smaller_binary.hpp"
 #include "duckdb/function/create_sort_key.hpp"
+#include "duckdb/planner/expression/bound_argument_pack.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/planner/expression_binder.hpp"
 #include "duckdb/storage/statistics/base_statistics.hpp"
 #include "duckdb/storage/statistics/numeric_stats.hpp"
+#include "duckdb/storage/statistics/struct_stats.hpp"
 
 namespace duckdb {
 
@@ -50,18 +52,33 @@ struct LeastGreatestSortKeyState : public FunctionLocalState {
 	OrderModifiers modifiers;
 };
 
+//! least/greatest collects everything after its first argument into an "*args" pack
+idx_t GetInputCount(const LogicalType &pack_type) {
+	return 1 + ArgumentPack::GetSize(pack_type);
+}
+
+vector<reference<Vector>> GetInputVectors(DataChunk &args) {
+	vector<reference<Vector>> inputs;
+	inputs.emplace_back(args.data[0]);
+	for (auto &packed : ArgumentPack::GetInput(args.data[1])) {
+		inputs.emplace_back(packed);
+	}
+	return inputs;
+}
+
 template <class OP>
 unique_ptr<FunctionLocalState> LeastGreatestSortKeyInit(ExpressionState &state, const BoundFunctionExpression &expr,
                                                         FunctionData *bind_data) {
-	return make_uniq<LeastGreatestSortKeyState>(expr.GetChildren().size(), OP::NullOrdering());
+	return make_uniq<LeastGreatestSortKeyState>(GetInputCount(expr.GetChildren()[1]->GetReturnType()),
+	                                            OP::NullOrdering());
 }
 
 template <bool STRING>
 struct StandardLeastGreatest {
 	static constexpr bool IS_STRING = STRING;
 
-	static DataChunk &Prepare(DataChunk &args, ExpressionState &) {
-		return args;
+	static vector<reference<Vector>> Prepare(vector<reference<Vector>> inputs, ExpressionState &) {
+		return inputs;
 	}
 
 	static Vector &TargetVector(Vector &result, ExpressionState &) {
@@ -81,13 +98,15 @@ struct StandardLeastGreatest {
 struct SortKeyLeastGreatest {
 	static constexpr bool IS_STRING = false;
 
-	static DataChunk &Prepare(DataChunk &args, ExpressionState &state) {
+	static vector<reference<Vector>> Prepare(vector<reference<Vector>> inputs, ExpressionState &state) {
 		auto &lstate = ExecuteFunctionState::GetFunctionState(state)->Cast<LeastGreatestSortKeyState>();
 		lstate.sort_keys.Reset();
-		for (idx_t c_idx = 0; c_idx < args.ColumnCount(); c_idx++) {
-			CreateSortKeyHelpers::CreateSortKey(args.data[c_idx], lstate.modifiers, lstate.sort_keys.data[c_idx]);
+		vector<reference<Vector>> sort_keys;
+		for (idx_t c_idx = 0; c_idx < inputs.size(); c_idx++) {
+			CreateSortKeyHelpers::CreateSortKey(inputs[c_idx].get(), lstate.modifiers, lstate.sort_keys.data[c_idx]);
+			sort_keys.emplace_back(lstate.sort_keys.data[c_idx]);
 		}
-		return lstate.sort_keys;
+		return sort_keys;
 	}
 
 	static Vector &TargetVector(Vector &result, ExpressionState &state) {
@@ -111,41 +130,43 @@ struct SortKeyLeastGreatest {
 
 template <class T, class OP, class BASE_OP = StandardLeastGreatest<false>>
 void LeastGreatestFunction(DataChunk &args, ExpressionState &state, Vector &result) {
-	if (args.ColumnCount() == 1) {
+	auto arguments = GetInputVectors(args);
+	const auto count = args.size();
+	if (arguments.size() == 1) {
 		// single input: nop
-		result.Reference(args.data[0]);
+		result.Reference(arguments[0].get());
 		return;
 	}
-	auto &input = BASE_OP::Prepare(args, state);
+	auto input = BASE_OP::Prepare(arguments, state);
 	auto &result_vector = BASE_OP::TargetVector(result, state);
 
 	auto result_type = VectorType::CONSTANT_VECTOR;
-	for (idx_t col_idx = 0; col_idx < input.ColumnCount(); col_idx++) {
-		if (args.data[col_idx].GetVectorType() != VectorType::CONSTANT_VECTOR) {
+	for (idx_t col_idx = 0; col_idx < input.size(); col_idx++) {
+		if (arguments[col_idx].get().GetVectorType() != VectorType::CONSTANT_VECTOR) {
 			// non-constant input: result is not a constant vector
 			result_type = VectorType::FLAT_VECTOR;
 		}
 		if (BASE_OP::IS_STRING) {
 			// for string vectors we add a reference to the heap of the children
-			StringVector::AddHeapReference(result_vector, input.data[col_idx]);
+			StringVector::AddHeapReference(result_vector, input[col_idx].get());
 		}
 	}
 
 	auto result_data = FlatVector::ScatterWriter<T>(result_vector);
 	bool result_has_value[STANDARD_VECTOR_SIZE] {false};
 	// perform the operation column-by-column
-	for (idx_t col_idx = 0; col_idx < input.ColumnCount(); col_idx++) {
-		if (input.data[col_idx].GetVectorType() == VectorType::CONSTANT_VECTOR &&
-		    ConstantVector::IsNull(input.data[col_idx])) {
+	for (idx_t col_idx = 0; col_idx < input.size(); col_idx++) {
+		auto &column = input[col_idx].get();
+		if (column.GetVectorType() == VectorType::CONSTANT_VECTOR && ConstantVector::IsNull(column)) {
 			// ignore null vector
 			continue;
 		}
 
-		auto entries = input.data[col_idx].template Values<T>();
+		auto entries = column.template Values<T>();
 
 		if (entries.CanHaveNull()) {
 			// potential new null entries: have to check the null mask
-			for (idx_t i = 0; i < input.size(); i++) {
+			for (idx_t i = 0; i < count; i++) {
 				auto entry = entries[i];
 				if (entry.IsValid()) {
 					// not a null entry: perform the operation and add to new set
@@ -158,7 +179,7 @@ void LeastGreatestFunction(DataChunk &args, ExpressionState &state, Vector &resu
 			}
 		} else {
 			// no new null entries: only need to perform the operation
-			for (idx_t i = 0; i < input.size(); i++) {
+			for (idx_t i = 0; i < count; i++) {
 				auto ivalue = entries.GetValueUnsafe(i);
 				if (!result_has_value[i] || OP::template Operation<T>(ivalue, result_data[i])) {
 					result_has_value[i] = true;
@@ -167,7 +188,7 @@ void LeastGreatestFunction(DataChunk &args, ExpressionState &state, Vector &resu
 			}
 		}
 	}
-	BASE_OP::FinalizeResult(input.size(), result_has_value, result, state);
+	BASE_OP::FinalizeResult(count, result_has_value, result, state);
 	result.SetVectorType(result_type);
 }
 
@@ -202,7 +223,16 @@ unique_ptr<BaseStatistics> PropagateLeastGreatestStats(ClientContext &context, F
 	Value anchored;          // over non-null inputs only
 	Value anchored_fallback; // over all inputs; used only when every input is nullable
 	bool has_nonnull_input = false;
-	for (auto &cs : child_stats) {
+	vector<reference<const BaseStatistics>> input_stats;
+	input_stats.emplace_back(child_stats[0]);
+	if (child_stats[1].GetStatsType() != StatisticsType::STRUCT_STATS) {
+		return nullptr;
+	}
+	for (idx_t i = 0; i < StructType::GetChildCount(child_stats[1].GetType()); i++) {
+		input_stats.emplace_back(StructStats::GetChildStats(child_stats[1], i));
+	}
+	for (auto &stats_ref : input_stats) {
+		auto &cs = stats_ref.get();
 		if (cs.GetStatsType() != StatisticsType::NUMERIC_STATS || !NumericStats::HasMinMax(cs)) {
 			return nullptr;
 		}
@@ -239,10 +269,10 @@ unique_ptr<FunctionData> BindLeastGreatest(BindScalarFunctionInput &input) {
 	auto &bound_function = input.GetBoundFunction();
 	auto &arguments = input.GetArguments();
 	LogicalType child_type = ExpressionBinder::GetExpressionReturnType(*arguments[0]);
-	for (idx_t i = 1; i < arguments.size(); i++) {
-		auto arg_type = ExpressionBinder::GetExpressionReturnType(*arguments[i]);
+	for (auto &packed : ArgumentPack::GetPackedChildren(*arguments[1])) {
+		auto arg_type = ExpressionBinder::GetExpressionReturnType(*packed);
 		if (!LogicalType::TryGetMaxLogicalType(context, child_type, arg_type, child_type)) {
-			throw BinderException(arguments[i]->GetQueryLocation(),
+			throw BinderException(packed->GetQueryLocation(),
 			                      "Cannot combine types of %s and %s - an explicit cast is required",
 			                      child_type.ToString(), arg_type.ToString());
 		}
@@ -291,18 +321,24 @@ unique_ptr<FunctionData> BindLeastGreatest(BindScalarFunctionInput &input) {
 		bound_function.SetInitStateCallback(LeastGreatestSortKeyInit<LEAST_GREATER_OP>);
 		break;
 	}
-	for (auto &arg : bound_function.GetArguments()) {
-		arg = child_type;
-	}
+	// every argument is cast to the common type, including the ones the "*args" pack collected
+	auto &pack_type = bound_function.GetArguments()[1];
+	pack_type = ArgumentPack::PositionalType(vector<LogicalType>(ArgumentPack::GetSize(pack_type), child_type));
+	bound_function.GetArguments()[0] = child_type;
 	bound_function.SetReturnType(child_type);
 	return nullptr;
 }
 
 template <class OP>
 ScalarFunction GetLeastGreatestFunction() {
-	return ScalarFunction({LogicalType::ANY}, LogicalType::ANY, nullptr, BindLeastGreatest<OP>,
-	                      PropagateLeastGreatestStats<OP>, nullptr, LogicalType::ANY, FunctionStability::CONSISTENT,
-	                      FunctionNullHandling::SPECIAL_HANDLING);
+	auto sig = FunctionSignature()
+	               .AddParameter("arg", LogicalType::ANY)
+	               .AddVarPositionalParameter("args", LogicalType::ANY)
+	               .SetReturnType(LogicalType::ANY);
+	return ScalarFunction(Identifier(), std::move(sig))
+	    .SetBindCallback(BindLeastGreatest<OP>)
+	    .SetStatisticsCallback(PropagateLeastGreatestStats<OP>)
+	    .SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 }
 
 template <class OP>

--- a/extension/core_functions/scalar/generic/type_functions.cpp
+++ b/extension/core_functions/scalar/generic/type_functions.cpp
@@ -79,9 +79,25 @@ static void MakeTypeFunction(DataChunk &args, ExpressionState &state, Vector &re
 	throw InvalidInputException("make_type function can only be used in constant expressions");
 }
 
+//! Turn the arguments an "*args"/"**kwargs" pack collected into type arguments. A keyword pack keys them by name,
+//! a positional one leaves them unnamed - which is what tells apart LIST(INTEGER) from STRUCT(a INTEGER).
+static void AddTypeArguments(ClientContext &context, Expression &pack,
+                             vector<unique_ptr<ParsedExpression>> &type_args) {
+	if (!pack.IsFoldable()) {
+		throw BinderException("make_type function arguments must be constant expressions");
+	}
+	auto pack_value = ExpressionExecutor::EvaluateScalar(context, pack);
+	auto &pack_items = StructValue::GetChildren(pack_value);
+
+	for (idx_t i = 0; i < pack_items.size(); i++) {
+		auto type_arg = make_uniq<ConstantExpression>(pack_items[i]);
+		type_arg->SetAlias(StructType::GetChildName(pack_value.type(), i));
+		type_args.push_back(std::move(type_arg));
+	}
+}
+
 static unique_ptr<Expression> BindMakeTypeFunctionExpression(FunctionBindExpressionInput &input) {
 	auto &name_arg = input.children[0];
-	auto &pack_arg = input.children[1];
 
 	if (!name_arg->IsFoldable()) {
 		throw BinderException("make_type function arguments must be constant expressions");
@@ -92,23 +108,9 @@ static unique_ptr<Expression> BindMakeTypeFunctionExpression(FunctionBindExpress
 	}
 	auto &type_name = StringValue::Get(name_val);
 
-	if (!pack_arg->IsFoldable()) {
-		throw BinderException("make_type function arguments must be constant expressions");
-	}
-
-	auto pack_value = ExpressionExecutor::EvaluateScalar(input.context, *pack_arg);
-	auto &pack_items = StructValue::GetChildren(pack_value);
-
 	vector<unique_ptr<ParsedExpression>> type_args;
-	for (idx_t i = 0; i < pack_items.size(); i++) {
-		auto &item_name = StructType::GetChildName(pack_value.type(), i);
-		auto &item_value = pack_items[i];
-
-		auto result = make_uniq<ConstantExpression>(item_value);
-		result->SetAlias(Identifier(item_name));
-
-		type_args.push_back(std::move(result));
-	}
+	AddTypeArguments(input.context, *input.children[1], type_args);
+	AddTypeArguments(input.context, *input.children[2], type_args);
 
 	auto qualified_name = QualifiedName::Parse(type_name);
 
@@ -124,6 +126,7 @@ static unique_ptr<Expression> BindMakeTypeFunctionExpression(FunctionBindExpress
 ScalarFunction MakeTypeFun::GetFunction() {
 	auto sig = FunctionSignature()
 	               .AddParameter("type_name", LogicalType::VARCHAR)
+	               .AddVarPositionalParameter("args", LogicalTypeId::ANY)
 	               .AddVarKeywordParameter("kwargs", LogicalTypeId::ANY)
 	               .SetReturnType(LogicalType::TYPE());
 

--- a/extension/core_functions/scalar/generic/type_functions.cpp
+++ b/extension/core_functions/scalar/generic/type_functions.cpp
@@ -80,7 +80,6 @@ static void MakeTypeFunction(DataChunk &args, ExpressionState &state, Vector &re
 }
 
 static unique_ptr<Expression> BindMakeTypeFunctionExpression(FunctionBindExpressionInput &input) {
-
 	auto &name_arg = input.children[0];
 	auto &pack_arg = input.children[1];
 
@@ -124,14 +123,14 @@ static unique_ptr<Expression> BindMakeTypeFunctionExpression(FunctionBindExpress
 
 ScalarFunction MakeTypeFun::GetFunction() {
 	auto sig = FunctionSignature()
-		.AddParameter("type_name", LogicalType::VARCHAR)
-		.AddVarKeywordParameter("kwargs", LogicalTypeId::ANY)
-		.SetReturnType(LogicalType::TYPE());
+	               .AddParameter("type_name", LogicalType::VARCHAR)
+	               .AddVarKeywordParameter("kwargs", LogicalTypeId::ANY)
+	               .SetReturnType(LogicalType::TYPE());
 
 	auto fun = ScalarFunction("make_type", std::move(sig))
-		.SetFunctionCallback(MakeTypeFunction)
-		.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING)
-		.SetBindExpressionCallback(BindMakeTypeFunctionExpression);
+	               .SetFunctionCallback(MakeTypeFunction)
+	               .SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING)
+	               .SetBindExpressionCallback(BindMakeTypeFunctionExpression);
 
 	return fun;
 }

--- a/extension/core_functions/scalar/generic/type_functions.cpp
+++ b/extension/core_functions/scalar/generic/type_functions.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/planner/binder.hpp"
 #include "duckdb/parser/expression/type_expression.hpp"
 #include "duckdb/execution/expression_executor.hpp"
+#include "duckdb/planner/expression/bound_argument_pack.hpp"
 
 namespace duckdb {
 
@@ -79,36 +80,37 @@ static void MakeTypeFunction(DataChunk &args, ExpressionState &state, Vector &re
 }
 
 static unique_ptr<Expression> BindMakeTypeFunctionExpression(FunctionBindExpressionInput &input) {
-	vector<pair<string, Value>> args;
 
-	// Evaluate all arguments to constant values
-	for (auto &child : input.children) {
-		string name = child->GetAlias().GetIdentifierName();
-		if (!child->IsFoldable()) {
-			throw BinderException("make_type function arguments must be constant expressions");
-		}
-		auto val = ExpressionExecutor::EvaluateScalar(input.context, *child);
-		args.emplace_back(name, val);
+	auto &name_arg = input.children[0];
+	auto &pack_arg = input.children[1];
+
+	if (!name_arg->IsFoldable()) {
+		throw BinderException("make_type function arguments must be constant expressions");
+	}
+	auto name_val = ExpressionExecutor::EvaluateScalar(input.context, *name_arg);
+	if (name_val.IsNull()) {
+		throw BinderException("make_type function type_name argument must not be NULL");
+	}
+	auto &type_name = StringValue::Get(name_val);
+
+	if (!pack_arg->IsFoldable()) {
+		throw BinderException("make_type function arguments must be constant expressions");
 	}
 
-	if (args.empty()) {
-		throw BinderException("make_type function requires at least one argument");
-	}
-
-	if (args.front().second.type() != LogicalType::VARCHAR) {
-		throw BinderException("make_type function first argument must be the type name as VARCHAR");
-	}
+	auto pack_value = ExpressionExecutor::EvaluateScalar(input.context, *pack_arg);
+	auto &pack_items = StructValue::GetChildren(pack_value);
 
 	vector<unique_ptr<ParsedExpression>> type_args;
-	for (idx_t i = 1; i < args.size(); i++) {
-		auto &arg = args[i];
-		auto result = make_uniq<ConstantExpression>(arg.second);
-		result->SetAlias(Identifier(arg.first));
+	for (idx_t i = 0; i < pack_items.size(); i++) {
+		auto &item_name = StructType::GetChildName(pack_value.type(), i);
+		auto &item_value = pack_items[i];
+
+		auto result = make_uniq<ConstantExpression>(item_value);
+		result->SetAlias(Identifier(item_name));
 
 		type_args.push_back(std::move(result));
 	}
 
-	auto type_name = args.front().second.GetValue<string>();
 	auto qualified_name = QualifiedName::Parse(type_name);
 
 	auto unbound_type =
@@ -121,10 +123,16 @@ static unique_ptr<Expression> BindMakeTypeFunctionExpression(FunctionBindExpress
 }
 
 ScalarFunction MakeTypeFun::GetFunction() {
-	auto fun = ScalarFunction({LogicalType::VARCHAR}, LogicalType::TYPE(), MakeTypeFunction);
-	fun.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
-	fun.SetBindExpressionCallback(BindMakeTypeFunctionExpression);
-	fun.SetVarArgs(LogicalType::ANY);
+	auto sig = FunctionSignature()
+		.AddParameter("type_name", LogicalType::VARCHAR)
+		.AddVarKeywordParameter("kwargs", LogicalTypeId::ANY)
+		.SetReturnType(LogicalType::TYPE());
+
+	auto fun = ScalarFunction("make_type", std::move(sig))
+		.SetFunctionCallback(MakeTypeFunction)
+		.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING)
+		.SetBindExpressionCallback(BindMakeTypeFunctionExpression);
+
 	return fun;
 }
 

--- a/extension/core_functions/scalar/list/list_aggregates.cpp
+++ b/extension/core_functions/scalar/list/list_aggregates.cpp
@@ -390,12 +390,15 @@ unique_ptr<FunctionData> ListAggregatesBindFunction(ClientContext &context, Boun
 	vector<unique_ptr<Expression>> children;
 	auto expr = make_uniq<BoundConstantExpression>(Value(list_child_type));
 	children.push_back(std::move(expr));
-	// push the extra arguments the "*args" parameter collected into the list aggregate bind
+	// push the extra arguments the "*args" parameter collected into the list aggregate bind, leaving the pack empty
 	if (arguments.size() > 2) {
-		for (auto &extra : ArgumentPack::GetPackedChildren(*arguments[2])) {
+		auto &packed = ArgumentPack::GetPackedChildren(*arguments[2]);
+		for (auto &extra : packed) {
 			children.push_back(std::move(extra));
 		}
-		arguments.resize(2);
+		packed.clear();
+		ArgumentPack::RefreshType(*arguments[2]);
+		bound_function.GetArguments()[2] = arguments[2]->GetReturnType();
 	}
 
 	FunctionBinder function_binder(context);

--- a/extension/core_functions/scalar/list/list_aggregates.cpp
+++ b/extension/core_functions/scalar/list/list_aggregates.cpp
@@ -502,19 +502,18 @@ unique_ptr<FunctionData> ListAggregateBind(BindScalarFunctionInput &input) {
 } // namespace
 
 ScalarFunction ListAggregateFun::GetFunction() {
-	return ScalarFunction("list_aggregate",
-		FunctionSignature()
-				.AddParameter("list", LogicalType::LIST(LogicalType::ANY))
-				.AddParameter("name", LogicalType::VARCHAR)
-				.AddVarPositionalParameter("args", LogicalType::ANY)
-				.SetReturnType(LogicalType::ANY))
-		.SetFunctionCallback(ListAggregateFunction)
-		.SetBindCallback(ListAggregateBind)
-		.SetInitStateCallback(ListAggregatesInitLocalState)
-		.SetFallible()
-		.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING)
-		.SetSerializeCallback(ListAggregatesBindData::SerializeFunction)
-		.SetDeserializeCallback(ListAggregatesBindData::DeserializeFunction);
+	return ScalarFunction("list_aggregate", FunctionSignature()
+	                                            .AddParameter("list", LogicalType::LIST(LogicalType::ANY))
+	                                            .AddParameter("name", LogicalType::VARCHAR)
+	                                            .AddVarPositionalParameter("args", LogicalType::ANY)
+	                                            .SetReturnType(LogicalType::ANY))
+	    .SetFunctionCallback(ListAggregateFunction)
+	    .SetBindCallback(ListAggregateBind)
+	    .SetInitStateCallback(ListAggregatesInitLocalState)
+	    .SetFallible()
+	    .SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING)
+	    .SetSerializeCallback(ListAggregatesBindData::SerializeFunction)
+	    .SetDeserializeCallback(ListAggregatesBindData::DeserializeFunction);
 }
 
 ScalarFunction ListDistinctFun::GetFunction() {

--- a/extension/core_functions/scalar/list/list_aggregates.cpp
+++ b/extension/core_functions/scalar/list/list_aggregates.cpp
@@ -14,7 +14,6 @@
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/planner/expression_binder.hpp"
-
 #include "duckdb/planner/expression/bound_argument_pack.hpp"
 
 namespace duckdb {
@@ -503,19 +502,19 @@ unique_ptr<FunctionData> ListAggregateBind(BindScalarFunctionInput &input) {
 } // namespace
 
 ScalarFunction ListAggregateFun::GetFunction() {
-	FunctionSignature signature;
-	signature.AddParameter("list", LogicalType::LIST(LogicalType::ANY));
-	signature.AddParameter("name", LogicalType::VARCHAR);
-	signature.AddVarPositionalParameter("args", LogicalType::ANY);
-	signature.SetReturnType(LogicalType::ANY);
-	auto result = ScalarFunction("list_aggregate", std::move(signature), ListAggregateFunction);
-	result.SetBindCallback(ListAggregateBind);
-	result.SetInitStateCallback(ListAggregatesInitLocalState);
-	result.SetFallible();
-	result.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
-	result.SetSerializeCallback(ListAggregatesBindData::SerializeFunction);
-	result.SetDeserializeCallback(ListAggregatesBindData::DeserializeFunction);
-	return result;
+	return ScalarFunction("list_aggregate",
+		FunctionSignature()
+				.AddParameter("list", LogicalType::LIST(LogicalType::ANY))
+				.AddParameter("name", LogicalType::VARCHAR)
+				.AddVarPositionalParameter("args", LogicalType::ANY)
+				.SetReturnType(LogicalType::ANY))
+		.SetFunctionCallback(ListAggregateFunction)
+		.SetBindCallback(ListAggregateBind)
+		.SetInitStateCallback(ListAggregatesInitLocalState)
+		.SetFallible()
+		.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING)
+		.SetSerializeCallback(ListAggregatesBindData::SerializeFunction)
+		.SetDeserializeCallback(ListAggregatesBindData::DeserializeFunction);
 }
 
 ScalarFunction ListDistinctFun::GetFunction() {

--- a/extension/core_functions/scalar/list/list_aggregates.cpp
+++ b/extension/core_functions/scalar/list/list_aggregates.cpp
@@ -15,6 +15,8 @@
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/planner/expression_binder.hpp"
 
+#include "duckdb/planner/expression/bound_argument_pack.hpp"
+
 namespace duckdb {
 
 namespace {
@@ -389,10 +391,10 @@ unique_ptr<FunctionData> ListAggregatesBindFunction(ClientContext &context, Boun
 	vector<unique_ptr<Expression>> children;
 	auto expr = make_uniq<BoundConstantExpression>(Value(list_child_type));
 	children.push_back(std::move(expr));
-	// push any extra arguments into the list aggregate bind
+	// push the extra arguments the "*args" parameter collected into the list aggregate bind
 	if (arguments.size() > 2) {
-		for (idx_t i = 2; i < arguments.size(); i++) {
-			children.push_back(std::move(arguments[i]));
+		for (auto &extra : ArgumentPack::GetPackedChildren(*arguments[2])) {
+			children.push_back(std::move(extra));
 		}
 		arguments.resize(2);
 	}
@@ -458,9 +460,12 @@ unique_ptr<FunctionData> ListAggregatesBind(BindScalarFunctionInput &input) {
 	ErrorData error;
 	vector<LogicalType> types;
 	types.push_back(child_type);
-	// push any extra arguments into the type list
-	for (idx_t i = 2; i < arguments.size(); i++) {
-		types.push_back(arguments[i]->GetReturnType());
+	// push the extra arguments the "*args" parameter collected into the type list
+	if (arguments.size() > 2) {
+		auto &extra_type = arguments[2]->GetReturnType();
+		for (idx_t i = 0; i < StructType::GetChildCount(extra_type); i++) {
+			types.push_back(StructType::GetChildType(extra_type, i));
+		}
 	}
 
 	FunctionBinder function_binder(context);
@@ -498,11 +503,16 @@ unique_ptr<FunctionData> ListAggregateBind(BindScalarFunctionInput &input) {
 } // namespace
 
 ScalarFunction ListAggregateFun::GetFunction() {
-	auto result = ScalarFunction({LogicalType::LIST(LogicalType::ANY), LogicalType::VARCHAR}, LogicalType::ANY,
-	                             ListAggregateFunction, ListAggregateBind, nullptr, ListAggregatesInitLocalState);
+	FunctionSignature signature;
+	signature.AddParameter("list", LogicalType::LIST(LogicalType::ANY));
+	signature.AddParameter("name", LogicalType::VARCHAR);
+	signature.AddVarPositionalParameter("args", LogicalType::ANY);
+	signature.SetReturnType(LogicalType::ANY);
+	auto result = ScalarFunction("list_aggregate", std::move(signature), ListAggregateFunction);
+	result.SetBindCallback(ListAggregateBind);
+	result.SetInitStateCallback(ListAggregatesInitLocalState);
 	result.SetFallible();
 	result.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
-	result.SetVarArgs(LogicalType::ANY);
 	result.SetSerializeCallback(ListAggregatesBindData::SerializeFunction);
 	result.SetDeserializeCallback(ListAggregatesBindData::DeserializeFunction);
 	return result;

--- a/extension/core_functions/scalar/list/list_value.cpp
+++ b/extension/core_functions/scalar/list/list_value.cpp
@@ -8,7 +8,9 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/common/pair.hpp"
 #include "duckdb/function/cast/vector_cast_helpers.hpp"
+#include "duckdb/planner/expression/bound_argument_pack.hpp"
 #include "duckdb/storage/statistics/list_stats.hpp"
+#include "duckdb/storage/statistics/struct_stats.hpp"
 #include "duckdb/planner/expression_binder.hpp"
 #include "duckdb/function/scalar/nested_functions.hpp"
 #include "duckdb/parser/query_error_context.hpp"
@@ -211,8 +213,52 @@ bool StructFunction(DataChunk &args, Vector &result) {
 	return true;
 }
 
-void ListValueFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+//! The trailing list elements are collected by a "*values" parameter, i.e. they arrive as the members of a single
+//! pack. The helpers below all walk a DataChunk of individual values, so reference them into one.
+void UnpackValues(DataChunk &args, DataChunk &values) {
+	vector<reference<Vector>> unpacked;
+	for (auto &column : args.data) {
+		if (!ArgumentPack::IsPackType(column.GetType())) {
+			unpacked.push_back(column);
+			continue;
+		}
+		for (auto &value : StructVector::GetEntries(column)) {
+			unpacked.push_back(value);
+		}
+	}
+
+	vector<LogicalType> types;
+	types.reserve(unpacked.size());
+	for (auto &value : unpacked) {
+		types.push_back(value.get().GetType());
+	}
+	values.InitializeEmpty(types);
+	for (idx_t i = 0; i < unpacked.size(); i++) {
+		values.data[i].Reference(unpacked[i].get());
+	}
+	values.SetChildCardinality(args.size());
+}
+
+//! The same, for the argument expressions a bind callback sees
+vector<reference<Expression>> UnpackValueExpressions(vector<unique_ptr<Expression>> &arguments) {
+	vector<reference<Expression>> result;
+	for (auto &argument : arguments) {
+		if (!ArgumentPack::IsPackType(argument->GetReturnType())) {
+			result.push_back(*argument);
+			continue;
+		}
+		for (auto &value : ArgumentPack::GetPackedChildren(*argument)) {
+			result.push_back(*value);
+		}
+	}
+	return result;
+}
+
+void ListValueFunction(DataChunk &input, ExpressionState &state, Vector &result) {
 	D_ASSERT(result.GetType().id() == LogicalTypeId::LIST);
+
+	DataChunk args;
+	UnpackValues(input, args);
 
 	if (args.ColumnCount() == 0) {
 		// Early out because the result is a constant empty list.
@@ -241,27 +287,27 @@ void ListValueFunction(DataChunk &args, ExpressionState &state, Vector &result) 
 unique_ptr<FunctionData> UnpivotBind(BindScalarFunctionInput &input) {
 	auto &context = input.GetClientContext();
 	auto &bound_function = input.GetBoundFunction();
-	auto &arguments = input.GetArguments();
+	auto packed = UnpackValueExpressions(input.GetArguments());
 	// collect names and deconflict, construct return type
 	LogicalType child_type =
-	    arguments.empty() ? LogicalType::SQLNULL : ExpressionBinder::GetExpressionReturnType(*arguments[0]);
-	for (idx_t i = 1; i < arguments.size(); i++) {
-		auto arg_type = ExpressionBinder::GetExpressionReturnType(*arguments[i]);
+	    packed.empty() ? LogicalType::SQLNULL : ExpressionBinder::GetExpressionReturnType(packed[0]);
+	for (idx_t i = 1; i < packed.size(); i++) {
+		auto arg_type = ExpressionBinder::GetExpressionReturnType(packed[i]);
 		if (!LogicalType::TryGetMaxLogicalType(context, child_type, arg_type, child_type)) {
 			string list_arguments = "Full list: ";
 			idx_t error_index = list_arguments.size();
-			for (idx_t k = 0; k < arguments.size(); k++) {
+			for (idx_t k = 0; k < packed.size(); k++) {
 				if (k > 0) {
 					list_arguments += ", ";
 				}
 				if (k == i) {
 					error_index = list_arguments.size();
 				}
-				list_arguments += arguments[k]->ToString() + " " + arguments[k]->GetReturnType().ToString();
+				list_arguments += packed[k].get().ToString() + " " + packed[k].get().GetReturnType().ToString();
 			}
 			auto error = StringUtil::Format("Cannot unpivot columns of types %s and %s - an explicit cast is required",
 			                                child_type.ToString(), arg_type.ToString());
-			throw BinderException(arguments[i]->GetQueryLocation(),
+			throw BinderException(packed[i].get().GetQueryLocation(),
 			                      QueryErrorContext::Format(list_arguments, error, error_index, false));
 		}
 	}
@@ -277,7 +323,15 @@ unique_ptr<BaseStatistics> ListValueStats(ClientContext &context, FunctionStatis
 	auto list_stats = ListStats::CreateEmpty(expr.GetReturnType());
 	auto &list_child_stats = ListStats::GetChildStats(list_stats);
 	for (idx_t i = 0; i < child_stats.size(); i++) {
-		list_child_stats.Merge(child_stats[i]);
+		auto &child_type = expr.GetChildren()[i]->GetReturnType();
+		if (!ArgumentPack::IsPackType(child_type)) {
+			list_child_stats.Merge(child_stats[i]);
+			continue;
+		}
+		const auto member_count = StructType::GetChildCount(child_type);
+		for (idx_t member = 0; member < member_count; member++) {
+			list_child_stats.Merge(StructStats::GetChildStats(child_stats[i], member));
+		}
 	}
 	list_stats.SetHasNoNullFast();
 	return list_stats.ToUnique();
@@ -290,8 +344,8 @@ unique_ptr<BaseStatistics> ListValueStats(ClientContext &context, FunctionStatis
 unique_ptr<FunctionData> ListValueBind(BindScalarFunctionInput &input) {
 	auto &bound_function = input.GetBoundFunction();
 	auto &child_type = ListType::GetChildType(bound_function.GetReturnType());
-	for (auto &argument : input.GetArguments()) {
-		auto argument_type = ExpressionBinder::GetExpressionReturnType(*argument);
+	for (auto &argument : UnpackValueExpressions(input.GetArguments())) {
+		auto argument_type = ExpressionBinder::GetExpressionReturnType(argument);
 		if (BoundCastExpression::CastCanThrow(argument_type, child_type, false)) {
 			bound_function.SetFallible();
 			break;
@@ -309,9 +363,13 @@ ScalarFunctionSet ListValueFun::GetFunctions() {
 
 	// Overload for 1 + N arguments, which returns a list of the arguments.
 	auto element_type = LogicalType::TEMPLATE("T");
-	ScalarFunction value_fun({element_type}, LogicalType::LIST(element_type), ListValueFunction, ListValueBind,
-	                         ListValueStats);
-	value_fun.SetVarArgs(element_type);
+	FunctionSignature value_signature;
+	value_signature.AddParameter("value", element_type);
+	value_signature.AddVarPositionalParameter("values", element_type);
+	value_signature.SetReturnType(LogicalType::LIST(element_type));
+	ScalarFunction value_fun("list_value", std::move(value_signature), ListValueFunction);
+	value_fun.SetBindCallback(ListValueBind);
+	value_fun.SetStatisticsCallback(ListValueStats);
 	value_fun.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 	set.AddFunction(value_fun);
 
@@ -319,8 +377,12 @@ ScalarFunctionSet ListValueFun::GetFunctions() {
 }
 
 ScalarFunction UnpivotListFun::GetFunction() {
-	ScalarFunction fun("unpivot_list", {}, LogicalTypeId::LIST, ListValueFunction, UnpivotBind, ListValueStats);
-	fun.SetVarArgs(LogicalTypeId::ANY);
+	FunctionSignature signature;
+	signature.AddVarPositionalParameter("values", LogicalTypeId::ANY);
+	signature.SetReturnType(LogicalTypeId::LIST);
+	ScalarFunction fun("unpivot_list", std::move(signature), ListValueFunction);
+	fun.SetBindCallback(UnpivotBind);
+	fun.SetStatisticsCallback(ListValueStats);
 	fun.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 	return fun;
 }

--- a/extension/core_functions/scalar/list/list_value.cpp
+++ b/extension/core_functions/scalar/list/list_value.cpp
@@ -367,6 +367,7 @@ ScalarFunctionSet ListValueFun::GetFunctions() {
 	value_signature.AddParameter("value", element_type);
 	value_signature.AddVarPositionalParameter("values", element_type);
 	value_signature.SetReturnType(LogicalType::LIST(element_type));
+
 	ScalarFunction value_fun("list_value", std::move(value_signature), ListValueFunction);
 	value_fun.SetBindCallback(ListValueBind);
 	value_fun.SetStatisticsCallback(ListValueStats);

--- a/extension/core_functions/scalar/map/cardinality.cpp
+++ b/extension/core_functions/scalar/map/cardinality.cpp
@@ -25,7 +25,8 @@ static void CardinalityFunction(DataChunk &args, ExpressionState &state, Vector 
 static unique_ptr<FunctionData> CardinalityBind(BindScalarFunctionInput &input) {
 	auto &bound_function = input.GetBoundFunction();
 	auto &arguments = input.GetArguments();
-	if (arguments.size() != 1) {
+	D_ASSERT(arguments.size() == 2);
+	if (StructType::GetChildCount(arguments[1]->GetReturnType()) != 0) {
 		throw BinderException("Cardinality must have exactly one arguments");
 	}
 
@@ -38,8 +39,13 @@ static unique_ptr<FunctionData> CardinalityBind(BindScalarFunctionInput &input) 
 }
 
 ScalarFunction CardinalityFun::GetFunction() {
-	ScalarFunction fun({LogicalType::ANY}, LogicalType::UBIGINT, CardinalityFunction, CardinalityBind);
-	fun.SetVarArgs(LogicalType::ANY);
+	FunctionSignature signature;
+	signature.AddParameter("map", LogicalType::ANY);
+	// only declared so that a call with too many arguments is rejected by the bind rather than by overload resolution
+	signature.AddVarPositionalParameter("extra", LogicalType::ANY);
+	signature.SetReturnType(LogicalType::UBIGINT);
+	ScalarFunction fun("cardinality", std::move(signature), CardinalityFunction);
+	fun.SetBindCallback(CardinalityBind);
 	fun.SetNullHandling(FunctionNullHandling::DEFAULT_NULL_HANDLING);
 	return fun;
 }

--- a/extension/core_functions/scalar/map/cardinality.cpp
+++ b/extension/core_functions/scalar/map/cardinality.cpp
@@ -1,52 +1,28 @@
 #include "core_functions/scalar/map_functions.hpp"
-#include "duckdb/planner/expression/bound_function_expression.hpp"
-#include "duckdb/common/string_util.hpp"
-#include "duckdb/parser/expression/bound_expression.hpp"
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/scalar/nested_functions.hpp"
 
 namespace duckdb {
 
-static void CardinalityFunction(DataChunk &args, ExpressionState &state, Vector &result) {
-	const auto &map = args.data[0];
-	auto entries = map.Values<list_entry_t>();
-
-	auto result_data = FlatVector::Writer<uint64_t>(result, args.size());
-	for (idx_t row = 0; row < args.size(); row++) {
-		auto entry = entries[row];
-		if (!entry.IsValid()) {
-			result_data.WriteNull();
-			continue;
-		}
-		result_data.WriteValue(entries.GetValueUnsafe(row).length);
-	}
-}
-
-static unique_ptr<FunctionData> CardinalityBind(BindScalarFunctionInput &input) {
-	auto &bound_function = input.GetBoundFunction();
-	auto &arguments = input.GetArguments();
-	D_ASSERT(arguments.size() == 2);
-	if (StructType::GetChildCount(arguments[1]->GetReturnType()) != 0) {
-		throw BinderException("Cardinality must have exactly one arguments");
-	}
-
-	if (arguments[0]->GetReturnType().id() != LogicalTypeId::MAP) {
-		throw BinderException("Cardinality can only operate on MAPs");
-	}
-
-	bound_function.SetReturnType(LogicalType::UBIGINT);
-	return make_uniq<VariableReturnBindData>(bound_function.GetReturnType());
+static void CardinalityFunction(DataChunk &args, ExpressionState &, Vector &result) {
+	UnaryExecutor::Execute<list_entry_t, uint64_t>(args.data[0], result, args.size(),
+		[&](const list_entry_t &input) {
+		return input.length;
+	});
 }
 
 ScalarFunction CardinalityFun::GetFunction() {
-	FunctionSignature signature;
-	signature.AddParameter("map", LogicalType::ANY);
-	// only declared so that a call with too many arguments is rejected by the bind rather than by overload resolution
-	signature.AddVarPositionalParameter("extra", LogicalType::ANY);
-	signature.SetReturnType(LogicalType::UBIGINT);
-	ScalarFunction fun("cardinality", std::move(signature), CardinalityFunction);
-	fun.SetBindCallback(CardinalityBind);
-	fun.SetNullHandling(FunctionNullHandling::DEFAULT_NULL_HANDLING);
+
+	const auto key_type = LogicalType::TEMPLATE("K");
+	const auto val_type = LogicalType::TEMPLATE("V");
+	const auto map_type = LogicalType::MAP(key_type, val_type);
+
+	auto sig = FunctionSignature()
+		.AddParameter("map", map_type)
+		.SetReturnType(LogicalTypeId::UBIGINT);
+
+	auto fun = ScalarFunction("cardinality", std::move(sig), CardinalityFunction);
+
 	return fun;
 }
 

--- a/extension/core_functions/scalar/map/cardinality.cpp
+++ b/extension/core_functions/scalar/map/cardinality.cpp
@@ -6,20 +6,15 @@ namespace duckdb {
 
 static void CardinalityFunction(DataChunk &args, ExpressionState &, Vector &result) {
 	UnaryExecutor::Execute<list_entry_t, uint64_t>(args.data[0], result, args.size(),
-		[&](const list_entry_t &input) {
-		return input.length;
-	});
+	                                               [&](const list_entry_t &input) { return input.length; });
 }
 
 ScalarFunction CardinalityFun::GetFunction() {
-
 	const auto key_type = LogicalType::TEMPLATE("K");
 	const auto val_type = LogicalType::TEMPLATE("V");
 	const auto map_type = LogicalType::MAP(key_type, val_type);
 
-	auto sig = FunctionSignature()
-		.AddParameter("map", map_type)
-		.SetReturnType(LogicalTypeId::UBIGINT);
+	auto sig = FunctionSignature().AddParameter("map", map_type).SetReturnType(LogicalTypeId::UBIGINT);
 
 	auto fun = ScalarFunction("cardinality", std::move(sig), CardinalityFunction);
 

--- a/extension/core_functions/scalar/map/map_concat.cpp
+++ b/extension/core_functions/scalar/map/map_concat.cpp
@@ -35,13 +35,16 @@ vector<Value> GetListEntries(vector<Value> keys, vector<Value> values) {
 	return entries;
 }
 
-void MapConcatFunction(DataChunk &input, ExpressionState &state, Vector &result) {
-	const auto &head = input.data[0];
-	const auto &tail = ArgumentPack::GetInput(input.data[1]);
+unique_ptr<FunctionData> MapConcatBind(BindScalarFunctionInput &input) {
+	if (ArgumentPack::GetSize(input.GetArguments()[0]->GetReturnType()) < 2) {
+		throw InvalidInputException("The provided amount of arguments is incorrect, please provide 2 or more maps");
+	}
+	return nullptr;
+}
 
+void MapConcatFunction(DataChunk &input, ExpressionState &state, Vector &result) {
 	vector<const_reference<Vector>> args;
-	args.emplace_back(head);
-	for (auto &arg : tail) {
+	for (auto &arg : ArgumentPack::GetInput(input.data[0])) {
 		args.emplace_back(arg);
 	}
 
@@ -133,14 +136,12 @@ ScalarFunction MapConcatFun::GetFunction() {
 	const auto val_type = LogicalType::TEMPLATE("V");
 	const auto map_type = LogicalType::MAP(key_type, val_type);
 
-	// TODO: this should take a single map arg + varargs
-	auto sig = FunctionSignature()
-	               .AddParameter("arg", map_type)
-	               .AddVarPositionalParameter("args", map_type)
-	               .SetReturnType(map_type);
+	// every argument is a map - the bind rejects a call with fewer than two of them
+	auto sig = FunctionSignature().AddVarPositionalParameter("args", map_type).SetReturnType(map_type);
 
 	auto fun = ScalarFunction("map_concat", std::move(sig))
 	               .SetFunctionCallback(MapConcatFunction)
+	               .SetBindCallback(MapConcatBind)
 	               .SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING)
 	               .SetFallible();
 

--- a/extension/core_functions/scalar/map/map_concat.cpp
+++ b/extension/core_functions/scalar/map/map_concat.cpp
@@ -8,6 +8,7 @@
 #include "duckdb/common/types.hpp"
 #include "duckdb/common/unordered_map.hpp"
 #include "core_functions/scalar/map_functions.hpp"
+#include "duckdb/planner/expression/bound_argument_pack.hpp"
 
 namespace duckdb {
 
@@ -34,7 +35,18 @@ vector<Value> GetListEntries(vector<Value> keys, vector<Value> values) {
 	return entries;
 }
 
-void MapConcatFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+void MapConcatFunction(DataChunk &input, ExpressionState &state, Vector &result) {
+
+	const auto &head = input.data[0];
+	const auto &tail = ArgumentPack::GetInput(input.data[1]);
+
+	vector<const_reference<Vector>> args;
+	args.emplace_back(head);
+	for (auto &arg : tail) {
+		args.emplace_back(arg);
+	}
+
+
 	if (result.GetType().id() == LogicalTypeId::SQLNULL) {
 		// All inputs are NULL, just return NULL
 		auto &validity = FlatVector::ValidityMutable(result);
@@ -43,12 +55,12 @@ void MapConcatFunction(DataChunk &args, ExpressionState &state, Vector &result) 
 		return;
 	}
 	D_ASSERT(result.GetType().id() == LogicalTypeId::MAP);
-	auto count = args.size();
+	auto count = input.size();
 
-	auto map_count = args.ColumnCount();
+	auto map_count = args.size();
 	vector<UnifiedVectorFormat> map_formats(map_count);
 	for (idx_t i = 0; i < map_count; i++) {
-		const auto &map = args.data[i];
+		const auto &map = args[i].get();
 		map.ToUnifiedFormat(map_formats[i]);
 	}
 	auto result_data = FlatVector::Writer<list_entry_t>(result, count);
@@ -60,7 +72,7 @@ void MapConcatFunction(DataChunk &args, ExpressionState &state, Vector &result) 
 		vector<Value> keys_list;
 		bool all_null = true;
 		for (idx_t map_idx = 0; map_idx < map_count; map_idx++) {
-			if (args.data[map_idx].GetType().id() == LogicalTypeId::SQLNULL) {
+			if (args[map_idx].get().GetType().id() == LogicalTypeId::SQLNULL) {
 				continue;
 			}
 
@@ -71,7 +83,7 @@ void MapConcatFunction(DataChunk &args, ExpressionState &state, Vector &result) 
 			}
 
 			all_null = false;
-			const auto &keys = MapVector::GetKeys(args.data[map_idx]);
+			const auto &keys = MapVector::GetKeys(args[map_idx].get());
 			auto entry = UnifiedVectorFormat::GetData<list_entry_t>(map_format)[index];
 
 			// Update the list for this row
@@ -104,7 +116,7 @@ void MapConcatFunction(DataChunk &args, ExpressionState &state, Vector &result) 
 		D_ASSERT(keys_list.size() == index_to_map.size());
 		// Get the values from the mapping
 		for (auto &mapping : index_to_map) {
-			const auto &map = args.data[mapping.map_index];
+			const auto &map = args[mapping.map_index].get();
 			const auto &values = MapVector::GetValues(map);
 			values_list.push_back(values.GetValue(mapping.key_index));
 		}
@@ -116,77 +128,25 @@ void MapConcatFunction(DataChunk &args, ExpressionState &state, Vector &result) 
 	}
 }
 
-bool IsEmptyMap(const LogicalType &map) {
-	D_ASSERT(map.id() == LogicalTypeId::MAP);
-	auto &key_type = MapType::KeyType(map);
-	auto &value_type = MapType::ValueType(map);
-	return key_type.id() == LogicalType::SQLNULL && value_type.id() == LogicalType::SQLNULL;
-}
-
-unique_ptr<FunctionData> MapConcatBind(BindScalarFunctionInput &input) {
-	auto &bound_function = input.GetBoundFunction();
-	auto &arguments = input.GetArguments();
-	auto arg_count = arguments.size();
-	if (arg_count < 2) {
-		throw InvalidInputException("The provided amount of arguments is incorrect, please provide 2 or more maps");
-	}
-
-	if (arguments[0]->GetReturnType().id() == LogicalTypeId::UNKNOWN) {
-		// Prepared statement
-		bound_function.GetArguments().emplace_back(LogicalTypeId::UNKNOWN);
-		bound_function.SetReturnType(LogicalTypeId::SQLNULL);
-		return nullptr;
-	}
-
-	LogicalType expected = LogicalType::SQLNULL;
-
-	bool is_null = true;
-	// Check and verify that all the maps are of the same type
-	for (idx_t i = 0; i < arg_count; i++) {
-		auto &arg = arguments[i];
-		auto &map = arg->GetReturnType();
-		if (map.id() == LogicalTypeId::UNKNOWN) {
-			// Prepared statement
-			bound_function.GetArguments().emplace_back(LogicalTypeId::UNKNOWN);
-			bound_function.SetReturnType(LogicalTypeId::SQLNULL);
-			return nullptr;
-		}
-		if (map.id() == LogicalTypeId::SQLNULL) {
-			// The maps are allowed to be NULL
-			continue;
-		}
-		if (map.id() != LogicalTypeId::MAP) {
-			throw InvalidInputException("MAP_CONCAT only takes map arguments");
-		}
-		is_null = false;
-		if (IsEmptyMap(map)) {
-			// Map is allowed to be empty
-			continue;
-		}
-
-		if (expected.id() == LogicalTypeId::SQLNULL) {
-			expected = map;
-		} else if (map != expected) {
-			throw InvalidInputException(
-			    "'value' type of map differs between arguments, expected '%s', found '%s' instead", expected.ToString(),
-			    map.ToString());
-		}
-	}
-
-	if (expected.id() == LogicalTypeId::SQLNULL && is_null == false) {
-		expected = LogicalType::MAP(LogicalType::SQLNULL, LogicalType::SQLNULL);
-	}
-	bound_function.SetReturnType(expected);
-	return make_uniq<VariableReturnBindData>(bound_function.GetReturnType());
-}
-
 } // namespace
 
 ScalarFunction MapConcatFun::GetFunction() {
-	//! the arguments and return types are actually set in the binder function
-	ScalarFunction fun("map_concat", {}, LogicalTypeId::LIST, MapConcatFunction, MapConcatBind);
-	fun.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
-	fun.SetVarArgs(LogicalType::ANY);
+
+	const auto key_type = LogicalType::TEMPLATE("K");
+	const auto val_type = LogicalType::TEMPLATE("V");
+	const auto map_type = LogicalType::MAP(key_type, val_type);
+
+	// TODO: this should take a single map arg + varargs
+	auto sig = FunctionSignature()
+		.AddParameter("arg", map_type)
+		.AddVarPositionalParameter("args", map_type)
+		.SetReturnType(map_type);
+
+	auto fun = ScalarFunction("map_concat", std::move(sig))
+		.SetFunctionCallback(MapConcatFunction)
+		.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING)
+		.SetFallible();
+
 	return fun;
 }
 

--- a/extension/core_functions/scalar/map/map_concat.cpp
+++ b/extension/core_functions/scalar/map/map_concat.cpp
@@ -36,7 +36,6 @@ vector<Value> GetListEntries(vector<Value> keys, vector<Value> values) {
 }
 
 void MapConcatFunction(DataChunk &input, ExpressionState &state, Vector &result) {
-
 	const auto &head = input.data[0];
 	const auto &tail = ArgumentPack::GetInput(input.data[1]);
 
@@ -45,7 +44,6 @@ void MapConcatFunction(DataChunk &input, ExpressionState &state, Vector &result)
 	for (auto &arg : tail) {
 		args.emplace_back(arg);
 	}
-
 
 	if (result.GetType().id() == LogicalTypeId::SQLNULL) {
 		// All inputs are NULL, just return NULL
@@ -131,21 +129,20 @@ void MapConcatFunction(DataChunk &input, ExpressionState &state, Vector &result)
 } // namespace
 
 ScalarFunction MapConcatFun::GetFunction() {
-
 	const auto key_type = LogicalType::TEMPLATE("K");
 	const auto val_type = LogicalType::TEMPLATE("V");
 	const auto map_type = LogicalType::MAP(key_type, val_type);
 
 	// TODO: this should take a single map arg + varargs
 	auto sig = FunctionSignature()
-		.AddParameter("arg", map_type)
-		.AddVarPositionalParameter("args", map_type)
-		.SetReturnType(map_type);
+	               .AddParameter("arg", map_type)
+	               .AddVarPositionalParameter("args", map_type)
+	               .SetReturnType(map_type);
 
 	auto fun = ScalarFunction("map_concat", std::move(sig))
-		.SetFunctionCallback(MapConcatFunction)
-		.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING)
-		.SetFallible();
+	               .SetFunctionCallback(MapConcatFunction)
+	               .SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING)
+	               .SetFallible();
 
 	return fun;
 }

--- a/extension/core_functions/scalar/map/switch.cpp
+++ b/extension/core_functions/scalar/map/switch.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/planner/expression/bound_comparison_expression.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/execution/expression_executor.hpp"
+#include "duckdb/planner/expression/bound_argument_pack.hpp"
 
 namespace duckdb {
 namespace {
@@ -72,11 +73,22 @@ void ExtractConstantExprFromList(unique_ptr<Expression> &expr, vector<unique_ptr
 	if (list_function.GetChildren().empty()) {
 		throw BinderException("No values provided for SWITCH expression");
 	}
+	// list_value collects everything after its first element into an "*args" pack
+	vector<reference<unique_ptr<Expression>>> elements;
 	for (auto &list_child : list_function.GetChildrenMutable()) {
-		if (list_child->GetExpressionClass() != ExpressionClass::BOUND_CONSTANT) {
+		if (!ArgumentPack::IsPack(*list_child)) {
+			elements.push_back(list_child);
+			continue;
+		}
+		for (auto &packed : ArgumentPack::GetPackedChildren(*list_child)) {
+			elements.push_back(packed);
+		}
+	}
+	for (auto &element : elements) {
+		if (element.get()->GetExpressionClass() != ExpressionClass::BOUND_CONSTANT) {
 			throw NotImplementedException("Only constant expressions are supported for keys inside SWITCH");
 		}
-		result.push_back(std::move(list_child));
+		result.push_back(std::move(element.get()));
 	}
 }
 

--- a/extension/core_functions/scalar/string/parse_path.cpp
+++ b/extension/core_functions/scalar/string/parse_path.cpp
@@ -263,7 +263,7 @@ static void ParsePathFunction(DataChunk &args, ExpressionState &state, Vector &r
 ScalarFunctionSet ParseDirnameFun::GetFunctions() {
 	ScalarFunctionSet parse_dirname;
 	ScalarFunction func({LogicalType::VARCHAR}, LogicalType::VARCHAR, TrimPathFunction<true>, nullptr, nullptr, nullptr,
-	                    LogicalType::INVALID, FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING);
+	                    FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING);
 	parse_dirname.AddFunction(func);
 	// separator options
 	func.GetSignature().AddParameter(LogicalType::VARCHAR);
@@ -274,7 +274,7 @@ ScalarFunctionSet ParseDirnameFun::GetFunctions() {
 ScalarFunctionSet ParseDirpathFun::GetFunctions() {
 	ScalarFunctionSet parse_dirpath;
 	ScalarFunction func({LogicalType::VARCHAR}, LogicalType::VARCHAR, ParseDirpathFunction, nullptr, nullptr, nullptr,
-	                    LogicalType::INVALID, FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING);
+	                    FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING);
 	parse_dirpath.AddFunction(func);
 	// separator options
 	func.GetSignature().AddParameter(LogicalType::VARCHAR);
@@ -285,18 +285,17 @@ ScalarFunctionSet ParseDirpathFun::GetFunctions() {
 ScalarFunctionSet ParseFilenameFun::GetFunctions() {
 	ScalarFunctionSet parse_filename;
 	parse_filename.AddFunction(ScalarFunction({LogicalType::VARCHAR}, LogicalType::VARCHAR, TrimPathFunction<false>,
-	                                          nullptr, nullptr, nullptr, LogicalType::INVALID,
-	                                          FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING));
+	                                          nullptr, nullptr, nullptr, FunctionStability::CONSISTENT,
+	                                          FunctionNullHandling::SPECIAL_HANDLING));
 	parse_filename.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::VARCHAR,
-	                                          TrimPathFunction<false>, nullptr, nullptr, nullptr, LogicalType::INVALID,
+	                                          TrimPathFunction<false>, nullptr, nullptr, nullptr,
 	                                          FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING));
 	parse_filename.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::BOOLEAN}, LogicalType::VARCHAR,
-	                                          TrimPathFunction<false>, nullptr, nullptr, nullptr, LogicalType::INVALID,
+	                                          TrimPathFunction<false>, nullptr, nullptr, nullptr,
 	                                          FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING));
 	parse_filename.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::BOOLEAN, LogicalType::VARCHAR},
 	                                          LogicalType::VARCHAR, TrimPathFunction<false>, nullptr, nullptr, nullptr,
-	                                          LogicalType::INVALID, FunctionStability::CONSISTENT,
-	                                          FunctionNullHandling::SPECIAL_HANDLING));
+	                                          FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING));
 	return parse_filename;
 }
 
@@ -304,7 +303,7 @@ ScalarFunctionSet ParsePathFun::GetFunctions() {
 	auto varchar_list_type = LogicalType::LIST(LogicalType::VARCHAR);
 	ScalarFunctionSet parse_path;
 	ScalarFunction func({LogicalType::VARCHAR}, varchar_list_type, ParsePathFunction, nullptr, nullptr, nullptr,
-	                    LogicalType::INVALID, FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING);
+	                    FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING);
 	parse_path.AddFunction(func);
 	// separator options
 	func.GetSignature().AddParameter(LogicalType::VARCHAR);

--- a/extension/core_functions/scalar/string/printf.cpp
+++ b/extension/core_functions/scalar/string/printf.cpp
@@ -180,14 +180,14 @@ ScalarFunction PrintfFun::GetFunction() {
 	// duckdb_fmt::printf_context, duckdb_fmt::vsprintf
 
 	auto sig = FunctionSignature()
-		.AddParameter("format", LogicalType::VARCHAR)
-		.AddVarPositionalParameter("args", LogicalType::ANY)
-		.SetReturnType(LogicalType::VARCHAR);
+	               .AddParameter("format", LogicalType::VARCHAR)
+	               .AddVarPositionalParameter("args", LogicalType::ANY)
+	               .SetReturnType(LogicalType::VARCHAR);
 
 	auto fun = ScalarFunction("printf", std::move(sig))
-		.SetFunctionCallback(PrintfFunction<FMTPrintf, duckdb_fmt::printf_context>)
-		.SetBindCallback(BindPrintfFunction)
-		.SetFallible();
+	               .SetFunctionCallback(PrintfFunction<FMTPrintf, duckdb_fmt::printf_context>)
+	               .SetBindCallback(BindPrintfFunction)
+	               .SetFallible();
 
 	return fun;
 }
@@ -196,14 +196,14 @@ ScalarFunction FormatFun::GetFunction() {
 	// duckdb_fmt::format_context, duckdb_fmt::vformat
 
 	auto sig = FunctionSignature()
-		.AddParameter("format", LogicalType::VARCHAR)
-		.AddVarPositionalParameter("args", LogicalType::ANY)
-		.SetReturnType(LogicalType::VARCHAR);
+	               .AddParameter("format", LogicalType::VARCHAR)
+	               .AddVarPositionalParameter("args", LogicalType::ANY)
+	               .SetReturnType(LogicalType::VARCHAR);
 
 	auto fun = ScalarFunction("format", std::move(sig))
-		.SetFunctionCallback(PrintfFunction<FMTFormat, duckdb_fmt::format_context>)
-		.SetBindCallback(BindPrintfFunction)
-		.SetFallible();
+	               .SetFunctionCallback(PrintfFunction<FMTFormat, duckdb_fmt::format_context>)
+	               .SetBindCallback(BindPrintfFunction)
+	               .SetFallible();
 
 	return fun;
 }

--- a/extension/core_functions/scalar/string/printf.cpp
+++ b/extension/core_functions/scalar/string/printf.cpp
@@ -1,4 +1,6 @@
 #include "core_functions/scalar/string_functions.hpp"
+#include "duckdb/common/vector/struct_vector.hpp"
+#include "duckdb/planner/expression/bound_argument_pack.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/common/limits.hpp"
 #include "fmt/format.h"
@@ -22,53 +24,51 @@ struct FMTFormat {
 	}
 };
 
+//! The type printf formats a value of the given type as
+static LogicalType PrintfArgumentType(const LogicalType &type) {
+	switch (type.id()) {
+	case LogicalTypeId::BOOLEAN:
+		return LogicalType::BOOLEAN;
+	case LogicalTypeId::TINYINT:
+	case LogicalTypeId::SMALLINT:
+	case LogicalTypeId::INTEGER:
+	case LogicalTypeId::BIGINT:
+		return LogicalType::BIGINT;
+	case LogicalTypeId::UTINYINT:
+	case LogicalTypeId::USMALLINT:
+	case LogicalTypeId::UINTEGER:
+	case LogicalTypeId::UBIGINT:
+		return LogicalType::UBIGINT;
+	case LogicalTypeId::HUGEINT:
+		return LogicalType::HUGEINT;
+	case LogicalTypeId::UHUGEINT:
+		return LogicalType::UHUGEINT;
+	case LogicalTypeId::FLOAT:
+	case LogicalTypeId::DOUBLE:
+	case LogicalTypeId::DECIMAL:
+		// decimal type: add cast to double
+		return LogicalType::DOUBLE;
+	case LogicalTypeId::VARCHAR:
+		return LogicalType::VARCHAR;
+	case LogicalTypeId::UNKNOWN:
+		// parameter: accept any input and rebind later
+		return LogicalType::ANY;
+	default:
+		// all other types: add cast to string
+		return LogicalType::VARCHAR;
+	}
+}
+
 static unique_ptr<FunctionData> BindPrintfFunction(BindScalarFunctionInput &input) {
 	auto &bound_function = input.GetBoundFunction();
 	auto &arguments = input.GetArguments();
-	for (idx_t i = 1; i < arguments.size(); i++) {
-		switch (arguments[i]->GetReturnType().id()) {
-		case LogicalTypeId::BOOLEAN:
-			bound_function.GetArguments()[i] = LogicalType::BOOLEAN;
-			break;
-		case LogicalTypeId::TINYINT:
-		case LogicalTypeId::SMALLINT:
-		case LogicalTypeId::INTEGER:
-		case LogicalTypeId::BIGINT:
-			bound_function.GetArguments()[i] = LogicalType::BIGINT;
-			break;
-		case LogicalTypeId::UTINYINT:
-		case LogicalTypeId::USMALLINT:
-		case LogicalTypeId::UINTEGER:
-		case LogicalTypeId::UBIGINT:
-			bound_function.GetArguments()[i] = LogicalType::UBIGINT;
-			break;
-		case LogicalTypeId::HUGEINT:
-			bound_function.GetArguments()[i] = LogicalType::HUGEINT;
-			break;
-		case LogicalTypeId::UHUGEINT:
-			bound_function.GetArguments()[i] = LogicalType::UHUGEINT;
-			break;
-		case LogicalTypeId::FLOAT:
-		case LogicalTypeId::DOUBLE:
-			bound_function.GetArguments()[i] = LogicalType::DOUBLE;
-			break;
-		case LogicalTypeId::VARCHAR:
-			bound_function.GetArguments()[i] = LogicalType::VARCHAR;
-			break;
-		case LogicalTypeId::DECIMAL:
-			// decimal type: add cast to double
-			bound_function.GetArguments()[i] = LogicalType::DOUBLE;
-			break;
-		case LogicalTypeId::UNKNOWN:
-			// parameter: accept any input and rebind later
-			bound_function.GetArguments()[i] = LogicalType::ANY;
-			break;
-		default:
-			// all other types: add cast to string
-			bound_function.GetArguments()[i] = LogicalType::VARCHAR;
-			break;
-		}
+	D_ASSERT(arguments.size() == 2);
+
+	vector<LogicalType> value_types;
+	for (auto &value : StructType::GetChildTypes(arguments[1]->GetReturnType())) {
+		value_types.push_back(PrintfArgumentType(value.second));
 	}
+	bound_function.GetArguments()[1] = ArgumentPack::PositionalType(std::move(value_types));
 	return nullptr;
 }
 
@@ -116,8 +116,10 @@ static void PrintfFunction(DataChunk &args, ExpressionState &state, Vector &resu
 
 	auto format_data = args.data[0].Values<string_t>();
 
-	for (idx_t i = 1; i < args.ColumnCount(); i++) {
-		const auto &col = args.data[i];
+	auto &values = StructVector::GetEntries(args.data[1]);
+	for (idx_t value_idx = 0; value_idx < values.size(); value_idx++) {
+		const auto &col = values[value_idx];
+		const auto i = value_idx + 1;
 		switch (col.GetType().id()) {
 		case LogicalTypeId::BOOLEAN:
 			ConvertArguments<bool>(col, i, format_args);
@@ -162,7 +164,7 @@ static void PrintfFunction(DataChunk &args, ExpressionState &state, Vector &resu
 	for (idx_t idx = 0; idx < count; idx++) {
 		auto entry = format_data[idx];
 		auto &current_args = format_args[idx];
-		if (!entry.IsValid() || current_args.size() != args.ColumnCount() - 1) {
+		if (!entry.IsValid() || current_args.size() != values.size()) {
 			// either format string or one of the input arguments is NULL
 			result_data.WriteNull();
 			continue;
@@ -178,18 +180,24 @@ static void PrintfFunction(DataChunk &args, ExpressionState &state, Vector &resu
 
 ScalarFunction PrintfFun::GetFunction() {
 	// duckdb_fmt::printf_context, duckdb_fmt::vsprintf
-	ScalarFunction printf_fun({LogicalType::VARCHAR}, LogicalType::VARCHAR,
-	                          PrintfFunction<FMTPrintf, duckdb_fmt::printf_context>, BindPrintfFunction);
-	printf_fun.SetVarArgs(LogicalType::ANY);
+	FunctionSignature signature;
+	signature.AddParameter("format", LogicalType::VARCHAR);
+	signature.AddVarPositionalParameter("values", LogicalType::ANY);
+	signature.SetReturnType(LogicalType::VARCHAR);
+	ScalarFunction printf_fun("printf", std::move(signature), PrintfFunction<FMTPrintf, duckdb_fmt::printf_context>);
+	printf_fun.SetBindCallback(BindPrintfFunction);
 	printf_fun.SetFallible();
 	return printf_fun;
 }
 
 ScalarFunction FormatFun::GetFunction() {
 	// duckdb_fmt::format_context, duckdb_fmt::vformat
-	ScalarFunction format_fun({LogicalType::VARCHAR}, LogicalType::VARCHAR,
-	                          PrintfFunction<FMTFormat, duckdb_fmt::format_context>, BindPrintfFunction);
-	format_fun.SetVarArgs(LogicalType::ANY);
+	FunctionSignature signature;
+	signature.AddParameter("format", LogicalType::VARCHAR);
+	signature.AddVarPositionalParameter("values", LogicalType::ANY);
+	signature.SetReturnType(LogicalType::VARCHAR);
+	ScalarFunction format_fun("format", std::move(signature), PrintfFunction<FMTFormat, duckdb_fmt::format_context>);
+	format_fun.SetBindCallback(BindPrintfFunction);
 	format_fun.SetFallible();
 	return format_fun;
 }

--- a/extension/core_functions/scalar/string/printf.cpp
+++ b/extension/core_functions/scalar/string/printf.cpp
@@ -1,7 +1,5 @@
 #include "core_functions/scalar/string_functions.hpp"
-#include "duckdb/common/vector/struct_vector.hpp"
 #include "duckdb/planner/expression/bound_argument_pack.hpp"
-#include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/common/limits.hpp"
 #include "fmt/format.h"
 #include "fmt/printf.h"
@@ -65,7 +63,7 @@ static unique_ptr<FunctionData> BindPrintfFunction(BindScalarFunctionInput &inpu
 	D_ASSERT(arguments.size() == 2);
 
 	vector<LogicalType> value_types;
-	for (auto &value : StructType::GetChildTypes(arguments[1]->GetReturnType())) {
+	for (auto &value : ArgumentPack::GetTypes(arguments[1]->GetReturnType())) {
 		value_types.push_back(PrintfArgumentType(value.second));
 	}
 	bound_function.GetArguments()[1] = ArgumentPack::PositionalType(std::move(value_types));
@@ -116,7 +114,7 @@ static void PrintfFunction(DataChunk &args, ExpressionState &state, Vector &resu
 
 	auto format_data = args.data[0].Values<string_t>();
 
-	auto &values = StructVector::GetEntries(args.data[1]);
+	auto &values = ArgumentPack::GetInput(args.data[1]);
 	for (idx_t value_idx = 0; value_idx < values.size(); value_idx++) {
 		const auto &col = values[value_idx];
 		const auto i = value_idx + 1;
@@ -180,26 +178,34 @@ static void PrintfFunction(DataChunk &args, ExpressionState &state, Vector &resu
 
 ScalarFunction PrintfFun::GetFunction() {
 	// duckdb_fmt::printf_context, duckdb_fmt::vsprintf
-	FunctionSignature signature;
-	signature.AddParameter("format", LogicalType::VARCHAR);
-	signature.AddVarPositionalParameter("values", LogicalType::ANY);
-	signature.SetReturnType(LogicalType::VARCHAR);
-	ScalarFunction printf_fun("printf", std::move(signature), PrintfFunction<FMTPrintf, duckdb_fmt::printf_context>);
-	printf_fun.SetBindCallback(BindPrintfFunction);
-	printf_fun.SetFallible();
-	return printf_fun;
+
+	auto sig = FunctionSignature()
+		.AddParameter("format", LogicalType::VARCHAR)
+		.AddVarPositionalParameter("args", LogicalType::ANY)
+		.SetReturnType(LogicalType::VARCHAR);
+
+	auto fun = ScalarFunction("printf", std::move(sig))
+		.SetFunctionCallback(PrintfFunction<FMTPrintf, duckdb_fmt::printf_context>)
+		.SetBindCallback(BindPrintfFunction)
+		.SetFallible();
+
+	return fun;
 }
 
 ScalarFunction FormatFun::GetFunction() {
 	// duckdb_fmt::format_context, duckdb_fmt::vformat
-	FunctionSignature signature;
-	signature.AddParameter("format", LogicalType::VARCHAR);
-	signature.AddVarPositionalParameter("values", LogicalType::ANY);
-	signature.SetReturnType(LogicalType::VARCHAR);
-	ScalarFunction format_fun("format", std::move(signature), PrintfFunction<FMTFormat, duckdb_fmt::format_context>);
-	format_fun.SetBindCallback(BindPrintfFunction);
-	format_fun.SetFallible();
-	return format_fun;
+
+	auto sig = FunctionSignature()
+		.AddParameter("format", LogicalType::VARCHAR)
+		.AddVarPositionalParameter("args", LogicalType::ANY)
+		.SetReturnType(LogicalType::VARCHAR);
+
+	auto fun = ScalarFunction("format", std::move(sig))
+		.SetFunctionCallback(PrintfFunction<FMTFormat, duckdb_fmt::format_context>)
+		.SetBindCallback(BindPrintfFunction)
+		.SetFallible();
+
+	return fun;
 }
 
 } // namespace duckdb

--- a/extension/core_functions/scalar/struct/struct_insert.cpp
+++ b/extension/core_functions/scalar/struct/struct_insert.cpp
@@ -8,6 +8,7 @@
 #include "duckdb/common/case_insensitive_map.hpp"
 #include "duckdb/storage/statistics/struct_stats.hpp"
 #include "duckdb/planner/expression_binder.hpp"
+#include "duckdb/planner/expression/bound_argument_pack.hpp"
 
 namespace duckdb {
 
@@ -25,21 +26,19 @@ static void StructInsertFunction(DataChunk &args, ExpressionState &state, Vector
 	}
 
 	// Assign the new children to the result vector.
-	for (idx_t i = 1; i < args.ColumnCount(); i++) {
-		result_child_entries[starting_child_entries.size() + i - 1].Reference(args.data[i]);
+	auto &pack = ArgumentPack::GetInput(args.data[1]);
+	for (idx_t i = 0; i < pack.size(); i++) {
+		result_child_entries[starting_child_entries.size() + i].Reference(pack[i]);
 	}
 }
 
 static unique_ptr<FunctionData> StructInsertBind(BindScalarFunctionInput &input) {
 	auto &bound_function = input.GetBoundFunction();
 	auto &arguments = input.GetArguments();
-	if (arguments.empty()) {
-		throw InvalidInputException("Missing required arguments for struct_insert function.");
-	}
-	if (LogicalTypeId::STRUCT != arguments[0]->GetReturnType().id()) {
-		throw InvalidInputException("The first argument to struct_insert must be a STRUCT");
-	}
-	if (arguments.size() < 2) {
+
+	auto &pack = ArgumentPack::GetPackedChildren(*arguments[1]);
+
+	if (pack.empty()) {
 		throw InvalidInputException("Can't insert nothing into a STRUCT");
 	}
 
@@ -54,18 +53,18 @@ static unique_ptr<FunctionData> StructInsertBind(BindScalarFunctionInput &input)
 	}
 
 	// Loop through the additional arguments (name/value pairs)
-	for (idx_t i = 1; i < arguments.size(); i++) {
-		auto &child = arguments[i];
-		if (child->GetAlias().empty()) {
-			throw BinderException("Need named argument for struct insert, e.g., a := b");
+	for (idx_t i = 0; i < pack.size(); i++) {
+		auto &name = StructType::GetChildName(arguments[1]->GetReturnType(), i);
+
+		if (name_collision_set.find(name) != name_collision_set.end()) {
+			throw BinderException("Duplicate struct entry name \"%s\"", name);
 		}
-		if (name_collision_set.find(child->GetAlias()) != name_collision_set.end()) {
-			throw BinderException("Duplicate struct entry name \"%s\"", child->GetAlias());
-		}
-		name_collision_set.insert(child->GetAlias());
-		new_children.emplace_back(make_pair(child->GetAlias(), arguments[i]->GetReturnType()));
+
+		name_collision_set.insert(name);
+		new_children.emplace_back(make_pair(name, pack[i]->GetReturnType()));
 	}
 
+	bound_function.GetArguments()[0] = arguments[0]->GetReturnType();
 	bound_function.SetReturnType(LogicalType::STRUCT(new_children));
 	return make_uniq<VariableReturnBindData>(bound_function.GetReturnType());
 }
@@ -81,20 +80,29 @@ static unique_ptr<BaseStatistics> StructInsertStats(ClientContext &context, Func
 		StructStats::SetChildStats(new_stats, i, existing_stats[i]);
 	}
 
-	auto new_count = StructType::GetChildCount(expr.GetReturnType());
-	auto offset = new_count - child_stats.size();
-	for (idx_t i = 1; i < child_stats.size(); i++) {
-		StructStats::SetChildStats(new_stats, offset + i, child_stats[i]);
+	auto pack_stats = StructStats::GetChildStats(child_stats[1]);
+	auto pack_count = StructType::GetChildCount(child_stats[1].GetType());
+
+	for (idx_t i = 0; i < pack_count; i++) {
+		StructStats::SetChildStats(new_stats, existing_count + i, pack_stats[i]);
 	}
 	return new_stats.ToUnique();
 }
 
 ScalarFunction StructInsertFun::GetFunction() {
-	ScalarFunction fun({}, LogicalTypeId::STRUCT, StructInsertFunction, StructInsertBind, StructInsertStats);
-	fun.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
-	fun.SetVarArgs(LogicalType::ANY);
-	fun.SetSerializeCallback(VariableReturnBindData::Serialize);
-	fun.SetDeserializeCallback(VariableReturnBindData::Deserialize);
+	auto sig = FunctionSignature()
+	               .AddParameter("struct", LogicalTypeId::STRUCT)
+	               .AddVarKeywordParameter("kwargs", LogicalTypeId::ANY)
+	               .SetReturnType(LogicalTypeId::STRUCT);
+
+	auto fun = ScalarFunction("struct_insert", std::move(sig))
+	               .SetFunctionCallback(StructInsertFunction)
+	               .SetBindCallback(StructInsertBind)
+	               .SetStatisticsCallback(StructInsertStats)
+	               .SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING)
+	               .SetSerializeCallback(VariableReturnBindData::Serialize)
+	               .SetDeserializeCallback(VariableReturnBindData::Deserialize);
+
 	return fun;
 }
 

--- a/extension/core_functions/scalar/struct/struct_update.cpp
+++ b/extension/core_functions/scalar/struct/struct_update.cpp
@@ -8,6 +8,7 @@
 #include "duckdb/common/case_insensitive_map.hpp"
 #include "duckdb/storage/statistics/struct_stats.hpp"
 #include "duckdb/planner/expression_binder.hpp"
+#include "duckdb/planner/expression/bound_argument_pack.hpp"
 
 namespace duckdb {
 
@@ -20,35 +21,36 @@ static void StructUpdateFunction(DataChunk &args, ExpressionState &state, Vector
 
 	auto &starting_types = StructType::GetChildTypes(starting_vec.GetType());
 
-	auto &func_args = state.expr.Cast<BoundFunctionExpression>().GetChildren();
-	auto new_entries = identifier_tree_t<idx_t>();
-	auto is_new_field = vector<bool>(args.ColumnCount(), true);
+	auto &pack = ArgumentPack::GetInput(args.data[1]);
+	auto &pack_types = ArgumentPack::GetTypes(args.data[1].GetType());
 
-	for (idx_t arg_idx = 1; arg_idx < func_args.size(); arg_idx++) {
-		auto &new_child = func_args[arg_idx];
-		new_entries.emplace(new_child->GetAlias(), arg_idx);
+	auto new_entries = identifier_tree_t<idx_t>();
+	auto is_new_field = vector<bool>(pack.size(), true);
+
+	for (idx_t pack_idx = 0; pack_idx < pack.size(); pack_idx++) {
+		new_entries.emplace(pack_types[pack_idx].first, pack_idx);
 	}
 
 	// Assign the original child entries to the STRUCT.
 	for (idx_t field_idx = 0; field_idx < starting_child_entries.size(); field_idx++) {
 		auto &starting_child = starting_child_entries[field_idx];
-		auto update = new_entries.find(starting_types[field_idx].first.c_str());
+		auto update = new_entries.find(starting_types[field_idx].first);
 
 		if (update == new_entries.end()) {
 			// No update present, copy from source
 			result_child_entries[field_idx].Reference(starting_child);
 		} else {
 			// We found a replacement of the same name to update
-			auto arg_idx = update->second;
-			result_child_entries[field_idx].Reference(args.data[arg_idx]);
-			is_new_field[arg_idx] = false;
+			auto pack_idx = update->second;
+			result_child_entries[field_idx].Reference(pack[pack_idx]);
+			is_new_field[pack_idx] = false;
 		}
 	}
 
 	// Assign the new (not updated) children to the end of the result vector.
-	for (idx_t arg_idx = 1, field_idx = starting_child_entries.size(); arg_idx < args.ColumnCount(); arg_idx++) {
-		if (is_new_field[arg_idx]) {
-			result_child_entries[field_idx++].Reference(args.data[arg_idx]);
+	for (idx_t pack_idx = 0, field_idx = starting_child_entries.size(); pack_idx < pack.size(); pack_idx++) {
+		if (is_new_field[pack_idx]) {
+			result_child_entries[field_idx++].Reference(pack[pack_idx]);
 		}
 	}
 }
@@ -56,13 +58,10 @@ static void StructUpdateFunction(DataChunk &args, ExpressionState &state, Vector
 static unique_ptr<FunctionData> StructUpdateBind(BindScalarFunctionInput &input) {
 	auto &bound_function = input.GetBoundFunction();
 	auto &arguments = input.GetArguments();
-	if (arguments.empty()) {
-		throw InvalidInputException("Missing required arguments for struct_update function.");
-	}
-	if (LogicalTypeId::STRUCT != arguments[0]->GetReturnType().id()) {
-		throw InvalidInputException("The first argument to struct_update must be a STRUCT");
-	}
-	if (arguments.size() < 2) {
+
+	auto &pack = ArgumentPack::GetPackedChildren(*arguments[1]);
+
+	if (pack.empty()) {
 		throw InvalidInputException("Can't update nothing into a STRUCT");
 	}
 
@@ -70,17 +69,12 @@ static unique_ptr<FunctionData> StructUpdateBind(BindScalarFunctionInput &input)
 	auto &existing_children = StructType::GetChildTypes(arguments[0]->GetReturnType());
 
 	auto incoming_children = identifier_tree_t<idx_t>();
-	auto is_new_field = vector<bool>(arguments.size(), true);
+	auto is_new_field = vector<bool>(pack.size(), true);
 
-	// Validate incoming arguments and record names
-	for (idx_t arg_idx = 1; arg_idx < arguments.size(); arg_idx++) {
-		auto &child = arguments[arg_idx];
-		if (child->GetAlias().empty()) {
-			throw BinderException("Need named argument for struct update, e.g., a := b");
-		} else if (incoming_children.find(child->GetAlias()) != incoming_children.end()) {
-			throw InvalidInputException("Duplicate named argument provided for %s", child->GetAlias().c_str());
-		}
-		incoming_children.emplace(child->GetAlias(), arg_idx);
+	// Record the names of the incoming arguments (name/value pairs)
+	for (idx_t pack_idx = 0; pack_idx < pack.size(); pack_idx++) {
+		auto &name = StructType::GetChildName(arguments[1]->GetReturnType(), pack_idx);
+		incoming_children.emplace(name, pack_idx);
 	}
 
 	for (idx_t field_idx = 0; field_idx < existing_children.size(); field_idx++) {
@@ -91,21 +85,22 @@ static unique_ptr<FunctionData> StructUpdateBind(BindScalarFunctionInput &input)
 			new_children.push_back(make_pair(existing_child.first, existing_child.second));
 		} else {
 			// Update the struct with the new data of the same name
-			auto arg_idx = update->second;
-			auto &new_child = arguments[arg_idx];
-			new_children.emplace_back(make_pair(new_child->GetAlias(), new_child->GetReturnType()));
-			is_new_field[arg_idx] = false;
+			auto pack_idx = update->second;
+			auto &name = StructType::GetChildName(arguments[1]->GetReturnType(), pack_idx);
+			new_children.emplace_back(make_pair(name, pack[pack_idx]->GetReturnType()));
+			is_new_field[pack_idx] = false;
 		}
 	}
 
-	// Loop through the additional arguments (name/value pairs)
-	for (idx_t arg_idx = 1; arg_idx < arguments.size(); arg_idx++) {
-		if (is_new_field[arg_idx]) {
-			auto &child = arguments[arg_idx];
-			new_children.emplace_back(make_pair(child->GetAlias(), child->GetReturnType()));
+	// Append the arguments that did not update an existing entry
+	for (idx_t pack_idx = 0; pack_idx < pack.size(); pack_idx++) {
+		if (is_new_field[pack_idx]) {
+			auto &name = StructType::GetChildName(arguments[1]->GetReturnType(), pack_idx);
+			new_children.emplace_back(make_pair(name, pack[pack_idx]->GetReturnType()));
 		}
 	}
 
+	bound_function.GetArguments()[0] = arguments[0]->GetReturnType();
 	bound_function.SetReturnType(LogicalType::STRUCT(new_children));
 	return make_uniq<VariableReturnBindData>(bound_function.GetReturnType());
 }
@@ -113,14 +108,17 @@ static unique_ptr<FunctionData> StructUpdateBind(BindScalarFunctionInput &input)
 static unique_ptr<BaseStatistics> StructUpdateStats(ClientContext &context, FunctionStatisticsInput &input) {
 	auto &child_stats = input.child_stats;
 	auto &expr = input.expr;
-
-	auto incoming_children = identifier_tree_t<idx_t>();
-	auto is_new_field = vector<bool>(expr.GetChildren().size(), true);
 	auto new_stats = StructStats::CreateUnknown(expr.GetReturnType());
 
-	for (idx_t arg_idx = 1; arg_idx < expr.GetChildren().size(); arg_idx++) {
-		auto &new_child = expr.GetChildren()[arg_idx];
-		incoming_children.emplace(new_child->GetAlias(), arg_idx);
+	auto pack_type = child_stats[1].GetType();
+	auto pack_count = StructType::GetChildCount(pack_type);
+	auto pack_stats = StructStats::GetChildStats(child_stats[1]);
+
+	auto incoming_children = identifier_tree_t<idx_t>();
+	auto is_new_field = vector<bool>(pack_count, true);
+
+	for (idx_t pack_idx = 0; pack_idx < pack_count; pack_idx++) {
+		incoming_children.emplace(StructType::GetChildName(pack_type, pack_idx), pack_idx);
 	}
 
 	auto existing_type = child_stats[0].GetType();
@@ -132,15 +130,15 @@ static unique_ptr<BaseStatistics> StructUpdateStats(ClientContext &context, Func
 		if (update == incoming_children.end()) {
 			StructStats::SetChildStats(new_stats, field_idx, existing_child);
 		} else {
-			auto arg_idx = update->second;
-			StructStats::SetChildStats(new_stats, field_idx, child_stats[arg_idx]);
-			is_new_field[arg_idx] = false;
+			auto pack_idx = update->second;
+			StructStats::SetChildStats(new_stats, field_idx, pack_stats[pack_idx]);
+			is_new_field[pack_idx] = false;
 		}
 	}
 
-	for (idx_t arg_idx = 1, field_idx = existing_count; arg_idx < expr.GetChildren().size(); arg_idx++) {
-		if (is_new_field[arg_idx]) {
-			StructStats::SetChildStats(new_stats, field_idx++, child_stats[arg_idx]);
+	for (idx_t pack_idx = 0, field_idx = existing_count; pack_idx < pack_count; pack_idx++) {
+		if (is_new_field[pack_idx]) {
+			StructStats::SetChildStats(new_stats, field_idx++, pack_stats[pack_idx]);
 		}
 	}
 
@@ -148,11 +146,19 @@ static unique_ptr<BaseStatistics> StructUpdateStats(ClientContext &context, Func
 }
 
 ScalarFunction StructUpdateFun::GetFunction() {
-	ScalarFunction fun({}, LogicalTypeId::STRUCT, StructUpdateFunction, StructUpdateBind, StructUpdateStats);
-	fun.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
-	fun.SetVarArgs(LogicalType::ANY);
-	fun.SetSerializeCallback(VariableReturnBindData::Serialize);
-	fun.SetDeserializeCallback(VariableReturnBindData::Deserialize);
+	auto sig = FunctionSignature()
+	               .AddParameter("struct", LogicalTypeId::STRUCT)
+	               .AddVarKeywordParameter("kwargs", LogicalTypeId::ANY)
+	               .SetReturnType(LogicalTypeId::STRUCT);
+
+	auto fun = ScalarFunction("struct_update", std::move(sig))
+	               .SetFunctionCallback(StructUpdateFunction)
+	               .SetBindCallback(StructUpdateBind)
+	               .SetStatisticsCallback(StructUpdateStats)
+	               .SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING)
+	               .SetSerializeCallback(VariableReturnBindData::Serialize)
+	               .SetDeserializeCallback(VariableReturnBindData::Deserialize);
+
 	return fun;
 }
 

--- a/extension/core_functions/scalar/union/union_value.cpp
+++ b/extension/core_functions/scalar/union/union_value.cpp
@@ -40,16 +40,15 @@ unique_ptr<FunctionData> UnionValueBind(BindScalarFunctionInput &input) {
 } // namespace
 
 ScalarFunction UnionValueFun::GetFunction() {
-	auto sig = FunctionSignature()
-		.AddVarKeywordParameter("kwargs", LogicalType::ANY)
-		.SetReturnType(LogicalTypeId::UNION);
+	auto sig =
+	    FunctionSignature().AddVarKeywordParameter("kwargs", LogicalType::ANY).SetReturnType(LogicalTypeId::UNION);
 
 	auto fun = ScalarFunction("union_value", std::move(sig))
-		.SetFunctionCallback(UnionValueFunction)
-		.SetBindCallback(UnionValueBind)
-		.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING)
-		.SetSerializeCallback(VariableReturnBindData::Serialize)
-		.SetDeserializeCallback(VariableReturnBindData::Deserialize);
+	               .SetFunctionCallback(UnionValueFunction)
+	               .SetBindCallback(UnionValueBind)
+	               .SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING)
+	               .SetSerializeCallback(VariableReturnBindData::Serialize)
+	               .SetDeserializeCallback(VariableReturnBindData::Deserialize);
 
 	return fun;
 }

--- a/extension/core_functions/scalar/union/union_value.cpp
+++ b/extension/core_functions/scalar/union/union_value.cpp
@@ -3,6 +3,7 @@
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/function/scalar/nested_functions.hpp"
+#include "duckdb/planner/expression/bound_argument_pack.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/planner/expression/bound_parameter_expression.hpp"
 
@@ -10,22 +11,11 @@ namespace duckdb {
 
 namespace {
 
-struct UnionValueBindData : public FunctionData {
-	UnionValueBindData() {
-	}
-
-public:
-	unique_ptr<FunctionData> Copy() const override {
-		return make_uniq<UnionValueBindData>();
-	}
-	bool Equals(const FunctionData &other_p) const override {
-		return true;
-	}
-};
-
 void UnionValueFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	const auto &kwargs = ArgumentPack::GetInput(args.data[0]);
+
 	// Assign the new entries to the result vector
-	UnionVector::GetMember(result, 0).Reference(args.data[0]);
+	UnionVector::GetMember(result, 0).Reference(kwargs[0]);
 
 	// Set the result tag vector to a constant value
 	auto &tag_vector = UnionVector::GetTags(result);
@@ -34,33 +24,33 @@ void UnionValueFunction(DataChunk &args, ExpressionState &state, Vector &result)
 }
 
 unique_ptr<FunctionData> UnionValueBind(BindScalarFunctionInput &input) {
-	auto &bound_function = input.GetBoundFunction();
-	auto &arguments = input.GetArguments();
-	if (arguments.size() != 1) {
-		throw BinderException("union_value takes exactly one argument");
-	}
-	auto &child = arguments[0];
+	const auto &args = input.GetArguments();
 
-	if (child->GetAlias().empty()) {
-		throw BinderException("Need named argument for union tag, e.g. UNION_VALUE(a := b)");
+	const auto &kwargs = ArgumentPack::GetTypes(args[0]->GetReturnType());
+	if (kwargs.size() != 1) {
+		throw BinderException("union_value takes exactly one named argument");
 	}
 
-	child_list_t<LogicalType> union_members;
+	auto &fun = input.GetBoundFunction();
+	fun.SetReturnType(LogicalType::UNION(kwargs));
 
-	union_members.emplace_back(make_pair(child->GetAlias(), child->GetReturnType()));
-
-	bound_function.SetReturnType(LogicalType::UNION(std::move(union_members)));
-	return make_uniq<VariableReturnBindData>(bound_function.GetReturnType());
+	return make_uniq<VariableReturnBindData>(fun.GetReturnType());
 }
 
 } // namespace
 
 ScalarFunction UnionValueFun::GetFunction() {
-	ScalarFunction fun("union_value", {}, LogicalTypeId::UNION, UnionValueFunction, UnionValueBind, nullptr, nullptr);
-	fun.SetVarArgs(LogicalType::ANY);
-	fun.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
-	fun.SetSerializeCallback(VariableReturnBindData::Serialize);
-	fun.SetDeserializeCallback(VariableReturnBindData::Deserialize);
+	auto sig = FunctionSignature()
+		.AddVarKeywordParameter("kwargs", LogicalType::ANY)
+		.SetReturnType(LogicalTypeId::UNION);
+
+	auto fun = ScalarFunction("union_value", std::move(sig))
+		.SetFunctionCallback(UnionValueFunction)
+		.SetBindCallback(UnionValueBind)
+		.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING)
+		.SetSerializeCallback(VariableReturnBindData::Serialize)
+		.SetDeserializeCallback(VariableReturnBindData::Deserialize);
+
 	return fun;
 }
 

--- a/extension/json/json_functions/json_create.cpp
+++ b/extension/json/json_functions/json_create.cpp
@@ -21,6 +21,9 @@
 #include "json_functions.hpp"
 #include "json_geojson.hpp"
 
+#include "duckdb/common/vector/struct_vector.hpp"
+#include "duckdb/planner/expression/bound_argument_pack.hpp"
+
 namespace duckdb {
 
 static constexpr const char *JSON_COPY_TO_JSON_INTERNAL_NAME = "__internal_json_copy_to_json";
@@ -306,32 +309,34 @@ static LogicalType GetJSONType(StructNames &const_struct_names, const LogicalTyp
 }
 
 static unique_ptr<FunctionData> JSONCreateBindParams(BoundScalarFunction &bound_function,
-                                                     vector<unique_ptr<Expression>> &arguments, bool object) {
+                                                     const vector<reference<Expression>> &arguments, bool object) {
 	StructNames const_struct_names;
-	auto &bound_arguments = bound_function.GetArguments();
-	bound_arguments.clear();
-	bound_arguments.reserve(arguments.size());
+	vector<LogicalType> value_types;
+	value_types.reserve(arguments.size());
 	for (idx_t i = 0; i < arguments.size(); i++) {
-		auto &type = arguments[i]->GetReturnType();
-		if (arguments[i]->HasParameter()) {
+		auto &argument = arguments[i].get();
+		auto &type = argument.GetReturnType();
+		if (argument.HasParameter()) {
 			throw ParameterNotResolvedException();
 		} else if (object && i % 2 == 0) {
 			if (type != LogicalType::VARCHAR) {
 				throw BinderException("json_object() keys must be VARCHAR, add an explicit cast to argument \"%s\"",
-				                      arguments[i]->GetName());
+				                      argument.GetName());
 			}
-			bound_arguments.push_back(LogicalType::VARCHAR);
+			value_types.push_back(LogicalType::VARCHAR);
 		} else {
 			// Value, cast to types that we can put in JSON
-			bound_arguments.push_back(GetJSONType(const_struct_names, type));
+			value_types.push_back(GetJSONType(const_struct_names, type));
 		}
 	}
+	// the values are collected by a "*args" parameter, so they are cast into place through the pack
+	bound_function.GetArguments() = {ArgumentPack::PositionalType(std::move(value_types))};
 	return make_uniq<JSONCreateFunctionData>(std::move(const_struct_names));
 }
 
 static unique_ptr<FunctionData> JSONObjectBind(BindScalarFunctionInput &input) {
 	auto &bound_function = input.GetBoundFunction();
-	auto &arguments = input.GetArguments();
+	auto arguments = input.GetUnpackedArguments();
 	if (arguments.size() % 2 != 0) {
 		throw BinderException("json_object() requires an even number of arguments");
 	}
@@ -340,13 +345,13 @@ static unique_ptr<FunctionData> JSONObjectBind(BindScalarFunctionInput &input) {
 
 static unique_ptr<FunctionData> JSONArrayBind(BindScalarFunctionInput &input) {
 	auto &bound_function = input.GetBoundFunction();
-	auto &arguments = input.GetArguments();
+	auto arguments = input.GetUnpackedArguments();
 	return JSONCreateBindParams(bound_function, arguments, false);
 }
 
 static unique_ptr<FunctionData> ToJSONBind(BindScalarFunctionInput &input) {
 	auto &bound_function = input.GetBoundFunction();
-	auto &arguments = input.GetArguments();
+	auto arguments = input.GetUnpackedArguments();
 	if (arguments.size() != 1) {
 		throw BinderException("to_json() takes exactly one argument");
 	}
@@ -355,12 +360,12 @@ static unique_ptr<FunctionData> ToJSONBind(BindScalarFunctionInput &input) {
 
 static unique_ptr<FunctionData> ArrayToJSONBind(BindScalarFunctionInput &input) {
 	auto &bound_function = input.GetBoundFunction();
-	auto &arguments = input.GetArguments();
+	auto arguments = input.GetUnpackedArguments();
 	if (arguments.size() != 1) {
 		throw BinderException("array_to_json() takes exactly one argument");
 	}
-	auto arg_id = arguments[0]->GetReturnType().id();
-	if (arguments[0]->HasParameter()) {
+	auto arg_id = arguments[0].get().GetReturnType().id();
+	if (arguments[0].get().HasParameter()) {
 		throw ParameterNotResolvedException();
 	}
 	if (arg_id != LogicalTypeId::LIST && arg_id != LogicalTypeId::ARRAY && arg_id != LogicalTypeId::SQLNULL) {
@@ -371,15 +376,15 @@ static unique_ptr<FunctionData> ArrayToJSONBind(BindScalarFunctionInput &input) 
 
 static unique_ptr<FunctionData> RowToJSONBind(BindScalarFunctionInput &input) {
 	auto &bound_function = input.GetBoundFunction();
-	auto &arguments = input.GetArguments();
+	auto arguments = input.GetUnpackedArguments();
 	if (arguments.size() != 1) {
 		throw BinderException("row_to_json() takes exactly one argument");
 	}
-	auto arg_id = arguments[0]->GetReturnType().id();
-	if (arguments[0]->HasParameter()) {
+	auto arg_id = arguments[0].get().GetReturnType().id();
+	if (arguments[0].get().HasParameter()) {
 		throw ParameterNotResolvedException();
 	}
-	if (arguments[0]->GetReturnType().id() != LogicalTypeId::STRUCT && arg_id != LogicalTypeId::SQLNULL) {
+	if (arguments[0].get().GetReturnType().id() != LogicalTypeId::STRUCT && arg_id != LogicalTypeId::SQLNULL) {
 		throw BinderException("row_to_json() argument type must be STRUCT");
 	}
 	return JSONCreateBindParams(bound_function, arguments, false);
@@ -1098,9 +1103,10 @@ static void ObjectFunction(DataChunk &args, ExpressionState &state, Vector &resu
 	// Initialize a re-usable value array
 	auto vals = JSONCommon::AllocateArray<yyjson_mut_val *>(doc, count);
 	// Loop through key/value pairs
-	for (idx_t pair_idx = 0; pair_idx < args.data.size() / 2; pair_idx++) {
-		Vector &key_v = args.data[pair_idx * 2];
-		Vector &value_v = args.data[pair_idx * 2 + 1];
+	auto &values = StructVector::GetEntries(args.data[0]);
+	for (idx_t pair_idx = 0; pair_idx < values.size() / 2; pair_idx++) {
+		Vector &key_v = values[pair_idx * 2];
+		Vector &value_v = values[pair_idx * 2 + 1];
 		CreateKeyValuePairs(info.const_struct_names, doc, objs, vals, key_v, value_v, count, options);
 	}
 	// Write JSON values to string
@@ -1127,8 +1133,8 @@ static void ArrayFunction(DataChunk &args, ExpressionState &state, Vector &resul
 	}
 	// Initialize a re-usable value array
 	auto vals = JSONCommon::AllocateArray<yyjson_mut_val *>(doc, count);
-	// Loop through args
-	for (auto &v : args.data) {
+	// Loop through the values collected by the "*args" parameter
+	for (auto &v : StructVector::GetEntries(args.data[0])) {
 		CreateValues(info.const_struct_names, doc, vals, v, count, options);
 		for (idx_t i = 0; i < count; i++) {
 			yyjson_mut_arr_append(arrs[i], vals[i]);
@@ -1177,7 +1183,8 @@ static void ToJSONFunction(DataChunk &args, ExpressionState &state, Vector &resu
 	auto alc = lstate.json_allocator->GetYYAlc();
 	auto options = ClientFormatOptions(state.GetContext());
 
-	ToJSONFunctionInternal(info.const_struct_names, args.data[0], args.size(), result, alc, options);
+	ToJSONFunctionInternal(info.const_struct_names, StructVector::GetEntries(args.data[0])[0], args.size(), result, alc,
+	                       options);
 }
 
 static void JSONCopyToJSONFunction(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1187,7 +1194,8 @@ static void JSONCopyToJSONFunction(DataChunk &args, ExpressionState &state, Vect
 	auto alc = lstate.json_allocator->GetYYAlc();
 	auto options = info.GetFormatOptions(state.GetContext());
 
-	ToJSONFunctionInternal(info.const_struct_names, args.data[0], args.size(), result, alc, options);
+	ToJSONFunctionInternal(info.const_struct_names, StructVector::GetEntries(args.data[0])[0], args.size(), result, alc,
+	                       options);
 }
 
 //===--------------------------------------------------------------------===//
@@ -1480,9 +1488,12 @@ unique_ptr<Expression> JSONFunctions::CreateJSONCopyToJSONExpression(ClientConte
 }
 
 ScalarFunctionSet JSONFunctions::GetObjectFunction() {
-	ScalarFunction fun("json_object", {}, LogicalType::JSON(), ObjectFunction, JSONObjectBind, nullptr,
-	                   JSONFunctionLocalState::Init);
-	fun.SetVarArgs(LogicalType::ANY);
+	FunctionSignature signature;
+	signature.AddVarPositionalParameter("args", LogicalType::ANY);
+	signature.SetReturnType(LogicalType::JSON());
+	ScalarFunction fun("json_object", std::move(signature), ObjectFunction);
+	fun.SetBindCallback(JSONObjectBind);
+	fun.SetInitStateCallback(JSONFunctionLocalState::Init);
 	fun.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 	// throws if a key is NULL
 	fun.SetFallible();
@@ -1490,17 +1501,23 @@ ScalarFunctionSet JSONFunctions::GetObjectFunction() {
 }
 
 ScalarFunctionSet JSONFunctions::GetArrayFunction() {
-	ScalarFunction fun("json_array", {}, LogicalType::JSON(), ArrayFunction, JSONArrayBind, nullptr,
-	                   JSONFunctionLocalState::Init);
-	fun.SetVarArgs(LogicalType::ANY);
+	FunctionSignature signature;
+	signature.AddVarPositionalParameter("args", LogicalType::ANY);
+	signature.SetReturnType(LogicalType::JSON());
+	ScalarFunction fun("json_array", std::move(signature), ArrayFunction);
+	fun.SetBindCallback(JSONArrayBind);
+	fun.SetInitStateCallback(JSONFunctionLocalState::Init);
 	fun.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 	return ScalarFunctionSet(fun);
 }
 
 ScalarFunctionSet JSONFunctions::GetToJSONFunction() {
-	ScalarFunction fun("to_json", {}, LogicalType::JSON(), ToJSONFunction, ToJSONBind, nullptr,
-	                   JSONFunctionLocalState::Init);
-	fun.SetVarArgs(LogicalType::ANY);
+	FunctionSignature signature;
+	signature.AddVarPositionalParameter("args", LogicalType::ANY);
+	signature.SetReturnType(LogicalType::JSON());
+	ScalarFunction fun("to_json", std::move(signature), ToJSONFunction);
+	fun.SetBindCallback(ToJSONBind);
+	fun.SetInitStateCallback(JSONFunctionLocalState::Init);
 	return ScalarFunctionSet(fun);
 }
 
@@ -1525,16 +1542,22 @@ ScalarFunction JSONFunctions::GetJSONCopyToGeoJSONFunction() {
 }
 
 ScalarFunctionSet JSONFunctions::GetArrayToJSONFunction() {
-	ScalarFunction fun("array_to_json", {}, LogicalType::JSON(), ToJSONFunction, ArrayToJSONBind, nullptr,
-	                   JSONFunctionLocalState::Init);
-	fun.SetVarArgs(LogicalType::ANY);
+	FunctionSignature signature;
+	signature.AddVarPositionalParameter("args", LogicalType::ANY);
+	signature.SetReturnType(LogicalType::JSON());
+	ScalarFunction fun("array_to_json", std::move(signature), ToJSONFunction);
+	fun.SetBindCallback(ArrayToJSONBind);
+	fun.SetInitStateCallback(JSONFunctionLocalState::Init);
 	return ScalarFunctionSet(fun);
 }
 
 ScalarFunctionSet JSONFunctions::GetRowToJSONFunction() {
-	ScalarFunction fun("row_to_json", {}, LogicalType::JSON(), ToJSONFunction, RowToJSONBind, nullptr,
-	                   JSONFunctionLocalState::Init);
-	fun.SetVarArgs(LogicalType::ANY);
+	FunctionSignature signature;
+	signature.AddVarPositionalParameter("args", LogicalType::ANY);
+	signature.SetReturnType(LogicalType::JSON());
+	ScalarFunction fun("row_to_json", std::move(signature), ToJSONFunction);
+	fun.SetBindCallback(RowToJSONBind);
+	fun.SetInitStateCallback(JSONFunctionLocalState::Init);
 	return ScalarFunctionSet(fun);
 }
 

--- a/extension/json/json_functions/json_deep_merge.cpp
+++ b/extension/json/json_functions/json_deep_merge.cpp
@@ -1,6 +1,8 @@
 #include "json_common.hpp"
 #include "json_functions.hpp"
 
+#include "duckdb/common/vector/struct_vector.hpp"
+
 namespace duckdb {
 
 //! Coalescing deep merge: null in patch means "absent/unknown", keeps the original value.
@@ -82,8 +84,8 @@ static void DeepMergeFunction(DataChunk &args, ExpressionState &state, Vector &r
 	DeepMergeReadObjects(doc, args.data[0], origs);
 
 	auto patches = JSONCommon::AllocateArray<yyjson_mut_val *>(alc, count);
-	for (idx_t arg_idx = 1; arg_idx < args.data.size(); arg_idx++) {
-		DeepMergeReadObjects(doc, args.data[arg_idx], patches);
+	for (auto &patch : StructVector::GetEntries(args.data[1])) {
+		DeepMergeReadObjects(doc, patch, patches);
 		for (idx_t i = 0; i < count; i++) {
 			if (patches[i] == nullptr) {
 				origs[i] = nullptr;
@@ -108,9 +110,12 @@ static void DeepMergeFunction(DataChunk &args, ExpressionState &state, Vector &r
 }
 
 ScalarFunctionSet JSONFunctions::GetDeepMergeFunction() {
-	ScalarFunction fun("json_deep_merge", {LogicalType::JSON(), LogicalType::JSON()}, LogicalType::JSON(),
-	                   DeepMergeFunction, nullptr, nullptr, JSONFunctionLocalState::Init);
-	fun.SetVarArgs(LogicalType::JSON());
+	FunctionSignature signature;
+	signature.AddParameter("json", LogicalType::JSON());
+	signature.AddVarPositionalParameter("patches", LogicalType::JSON());
+	signature.SetReturnType(LogicalType::JSON());
+	ScalarFunction fun("json_deep_merge", std::move(signature), DeepMergeFunction);
+	fun.SetInitStateCallback(JSONFunctionLocalState::Init);
 	fun.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 
 	return ScalarFunctionSet(fun);

--- a/extension/json/json_functions/json_merge_patch.cpp
+++ b/extension/json/json_functions/json_merge_patch.cpp
@@ -1,6 +1,8 @@
 #include "json_common.hpp"
 #include "json_functions.hpp"
 
+#include "duckdb/common/vector/struct_vector.hpp"
+
 namespace duckdb {
 
 static inline yyjson_mut_val *MergePatch(yyjson_mut_doc *doc, yyjson_mut_val *orig, yyjson_mut_val *patch) {
@@ -43,8 +45,8 @@ static void MergePatchFunction(DataChunk &args, ExpressionState &state, Vector &
 
 	// Read the next json args one by one and merge them into the first json arg
 	auto patches = JSONCommon::AllocateArray<yyjson_mut_val *>(alc, count);
-	for (idx_t arg_idx = 1; arg_idx < args.data.size(); arg_idx++) {
-		ReadObjects(doc, args.data[arg_idx], patches);
+	for (auto &patch : StructVector::GetEntries(args.data[1])) {
+		ReadObjects(doc, patch, patches);
 		for (idx_t i = 0; i < count; i++) {
 			if (patches[i] == nullptr) {
 				// Next json arg is NULL, obj becomes NULL
@@ -72,9 +74,12 @@ static void MergePatchFunction(DataChunk &args, ExpressionState &state, Vector &
 }
 
 ScalarFunctionSet JSONFunctions::GetMergePatchFunction() {
-	ScalarFunction fun("json_merge_patch", {LogicalType::JSON(), LogicalType::JSON()}, LogicalType::JSON(),
-	                   MergePatchFunction, nullptr, nullptr, JSONFunctionLocalState::Init);
-	fun.SetVarArgs(LogicalType::JSON());
+	FunctionSignature signature;
+	signature.AddParameter("json", LogicalType::JSON());
+	signature.AddVarPositionalParameter("patches", LogicalType::JSON());
+	signature.SetReturnType(LogicalType::JSON());
+	ScalarFunction fun("json_merge_patch", std::move(signature), MergePatchFunction);
+	fun.SetInitStateCallback(JSONFunctionLocalState::Init);
 	fun.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 
 	return ScalarFunctionSet(fun);

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -2237,6 +2237,7 @@ const StringUtil::EnumStringLiteral *GetExpressionTypeValues() {
 		{ static_cast<uint32_t>(ExpressionType::ARRAY_CONSTRUCTOR), "ARRAY_CONSTRUCTOR" },
 		{ static_cast<uint32_t>(ExpressionType::ARROW), "ARROW" },
 		{ static_cast<uint32_t>(ExpressionType::OPERATOR_TRY), "OPERATOR_TRY" },
+		{ static_cast<uint32_t>(ExpressionType::ARGUMENT_PACK), "ARGUMENT_PACK" },
 		{ static_cast<uint32_t>(ExpressionType::SUBQUERY), "SUBQUERY" },
 		{ static_cast<uint32_t>(ExpressionType::STAR), "STAR" },
 		{ static_cast<uint32_t>(ExpressionType::TABLE_STAR), "TABLE_STAR" },
@@ -2261,12 +2262,12 @@ const StringUtil::EnumStringLiteral *GetExpressionTypeValues() {
 
 template<>
 const char* EnumUtil::ToChars<ExpressionType>(ExpressionType value) {
-	return StringUtil::EnumToString(GetExpressionTypeValues(), 74, "ExpressionType", static_cast<uint32_t>(value));
+	return StringUtil::EnumToString(GetExpressionTypeValues(), 75, "ExpressionType", static_cast<uint32_t>(value));
 }
 
 template<>
 ExpressionType EnumUtil::FromString<ExpressionType>(const char *value) {
-	return static_cast<ExpressionType>(StringUtil::StringToEnum(GetExpressionTypeValues(), 74, "ExpressionType", value));
+	return static_cast<ExpressionType>(StringUtil::StringToEnum(GetExpressionTypeValues(), 75, "ExpressionType", value));
 }
 
 const StringUtil::EnumStringLiteral *GetExtensionABITypeValues() {
@@ -2689,6 +2690,26 @@ const char* EnumUtil::ToChars<FunctionNullHandling>(FunctionNullHandling value) 
 template<>
 FunctionNullHandling EnumUtil::FromString<FunctionNullHandling>(const char *value) {
 	return static_cast<FunctionNullHandling>(StringUtil::StringToEnum(GetFunctionNullHandlingValues(), 2, "FunctionNullHandling", value));
+}
+
+const StringUtil::EnumStringLiteral *GetFunctionParameterKindValues() {
+	static constexpr StringUtil::EnumStringLiteral values[] {
+		{ static_cast<uint32_t>(FunctionParameterKind::STANDARD), "STANDARD" },
+		{ static_cast<uint32_t>(FunctionParameterKind::VAR_POSITIONAL), "VAR_POSITIONAL" },
+		{ static_cast<uint32_t>(FunctionParameterKind::VAR_KEYWORD), "VAR_KEYWORD" },
+		{ static_cast<uint32_t>(FunctionParameterKind::KEYWORD_ONLY), "KEYWORD_ONLY" }
+	};
+	return values;
+}
+
+template<>
+const char* EnumUtil::ToChars<FunctionParameterKind>(FunctionParameterKind value) {
+	return StringUtil::EnumToString(GetFunctionParameterKindValues(), 4, "FunctionParameterKind", static_cast<uint32_t>(value));
+}
+
+template<>
+FunctionParameterKind EnumUtil::FromString<FunctionParameterKind>(const char *value) {
+	return static_cast<FunctionParameterKind>(StringUtil::StringToEnum(GetFunctionParameterKindValues(), 4, "FunctionParameterKind", value));
 }
 
 const StringUtil::EnumStringLiteral *GetFunctionStabilityValues() {

--- a/src/common/enums/expression_type.cpp
+++ b/src/common/enums/expression_type.cpp
@@ -93,6 +93,8 @@ string ExpressionTypeToString(ExpressionType type) {
 		return "COALESCE";
 	case ExpressionType::OPERATOR_TRY:
 		return "TRY";
+	case ExpressionType::ARGUMENT_PACK:
+		return "ARGUMENT_PACK";
 	case ExpressionType::ARRAY_EXTRACT:
 		return "ARRAY_EXTRACT";
 	case ExpressionType::ARRAY_SLICE:

--- a/src/common/multi_file/multi_file_column_mapper.cpp
+++ b/src/common/multi_file/multi_file_column_mapper.cpp
@@ -10,6 +10,7 @@
 #include "duckdb/parser/expression/constant_expression.hpp"
 #include "duckdb/optimizer/statistics_propagator.hpp"
 #include "duckdb/planner/filter/list.hpp"
+#include "duckdb/function/function_binder.hpp"
 #include "duckdb/function/scalar/struct_functions.hpp"
 #include "duckdb/function/scalar/struct_utils.hpp"
 #include "duckdb/function/scalar/nested_functions.hpp"
@@ -70,6 +71,14 @@ public:
 		return !error.empty();
 	}
 };
+
+//! struct_pack takes its field names from its argument names, so the defaults are packed as keyword arguments
+static unique_ptr<Expression> PackDefaultValues(ClientContext &context,
+                                                vector<pair<Identifier, unique_ptr<Expression>>> fields) {
+	FunctionBinder function_binder(context);
+	return function_binder.BindScalarFunction(StructPackFun::GetFunction(), vector<unique_ptr<Expression>>(),
+	                                          std::move(fields));
+}
 
 struct ColumnMapResult {
 	//! Contains the name of the local column that corresponds to this field
@@ -304,12 +313,11 @@ static ColumnMapResult MapColumnList(ClientContext &context, const MultiFileColu
 	}
 	if (is_selected && child_map.default_value) {
 		// we have default values at a previous level wrap it in a "list"
-		vector<unique_ptr<Expression>> default_expressions;
-		child_map.default_value->SetAlias("list");
-		default_expressions.push_back(std::move(child_map.default_value));
+		vector<pair<Identifier, unique_ptr<Expression>>> default_expressions;
+		default_expressions.emplace_back("list", std::move(child_map.default_value));
 
 		// auto default_type = LogicalType::STRUCT(std::move(default_type_list));
-		result.default_value = StructPackFun::GetFunction().Bind(context, std::move(default_expressions));
+		result.default_value = PackDefaultValues(context, std::move(default_expressions));
 	}
 	result.column_index = make_uniq<ColumnIndex>(local_id.GetIndex(), std::move(child_indexes));
 	result.mapping = std::move(mapping);
@@ -373,7 +381,7 @@ static ColumnMapResult MapColumnMap(ClientContext &context, const MultiFileColum
 
 	auto nested_mapper = mapper.Create(local_key_value.children);
 	child_list_t<Value> column_mapping;
-	vector<unique_ptr<Expression>> default_expressions;
+	vector<pair<Identifier, unique_ptr<Expression>>> default_expressions;
 	unordered_map<idx_t, const_reference<ColumnIndex>> selected_children;
 	if (global_index.HasChildren()) {
 		//! FIXME: is this expected for maps??
@@ -410,8 +418,7 @@ static ColumnMapResult MapColumnMap(ClientContext &context, const MultiFileColum
 			column_mapping.emplace_back(name, std::move(map_result.column_map));
 		}
 		if (map_result.default_value) {
-			map_result.default_value->SetAlias(name);
-			default_expressions.push_back(std::move(map_result.default_value));
+			default_expressions.emplace_back(name, std::move(map_result.default_value));
 		}
 	}
 
@@ -430,7 +437,7 @@ static ColumnMapResult MapColumnMap(ClientContext &context, const MultiFileColum
 	}
 	if (!default_expressions.empty()) {
 		// we have default values at a previous level wrap it in a "list"
-		result.default_value = StructPackFun::GetFunction().Bind(context, std::move(default_expressions));
+		result.default_value = PackDefaultValues(context, std::move(default_expressions));
 	}
 	vector<ColumnIndex> map_indexes;
 	map_indexes.emplace_back(0, std::move(child_indexes));
@@ -471,7 +478,7 @@ static ColumnMapResult MapColumnStruct(ClientContext &context, const MultiFileCo
 	}
 
 	child_list_t<Value> column_mapping;
-	vector<unique_ptr<Expression>> default_expressions;
+	vector<pair<Identifier, unique_ptr<Expression>>> default_expressions;
 	unordered_map<idx_t, const_reference<ColumnIndex>> selected_children;
 	if (global_index.HasChildren()) {
 		for (auto &index : global_index.GetChildIndexes()) {
@@ -514,8 +521,7 @@ static ColumnMapResult MapColumnStruct(ClientContext &context, const MultiFileCo
 		//! FIXME: the 'default_value' should only be used if the STRUCT's default value is not NULL
 		if (child_map.default_value) {
 			// found a default value for this child - emplace it
-			child_map.default_value->SetAlias(Identifier(global_child.name));
-			default_expressions.push_back(std::move(child_map.default_value));
+			default_expressions.emplace_back(Identifier(global_child.name), std::move(child_map.default_value));
 		}
 	}
 
@@ -535,7 +541,7 @@ static ColumnMapResult MapColumnStruct(ClientContext &context, const MultiFileCo
 	}
 
 	if (!default_expressions.empty()) {
-		result.default_value = StructPackFun::GetFunction().Bind(context, std::move(default_expressions));
+		result.default_value = PackDefaultValues(context, std::move(default_expressions));
 	}
 	result.column_index = make_uniq<ColumnIndex>(local_id.GetIndex(), std::move(child_indexes));
 	if (global_index.HasType()) {

--- a/src/execution/expression_executor/execute_operator.cpp
+++ b/src/execution/expression_executor/execute_operator.cpp
@@ -3,6 +3,7 @@
 #include "duckdb/planner/expression/bound_operator_expression.hpp"
 #include "duckdb/common/error_data.hpp"
 #include "duckdb/common/vector/flat_vector.hpp"
+#include "duckdb/common/vector/struct_vector.hpp"
 
 namespace duckdb {
 
@@ -15,6 +16,41 @@ unique_ptr<ExpressionState> ExpressionExecutor::InitializeState(const BoundOpera
 
 	result->Finalize();
 	return result;
+}
+
+//! Build the TUPLE/STRUCT value that fills a "*args"/"**kwargs" parameter out of the packed arguments.
+//! The pack itself is never NULL - NULLs among the packed arguments stay visible as NULL members, and it is up to the
+//! function to decide what they mean. A constant NULL argument still short-circuits the call at bind time, as it does
+//! for a regular argument.
+void ExpressionExecutor::ExecuteArgumentPack(const BoundOperatorExpression &expr, ExpressionState *state,
+                                             const SelectionVector *sel, idx_t count, Vector &result) {
+	auto &children = expr.GetChildren();
+	if (children.empty()) {
+		// empty pack: no children to reference, the value is a single non-null constant
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+		ConstantVector::SetNull(result, false);
+		return;
+	}
+
+	state->intermediate_chunk.Reset();
+	auto &child_entries = StructVector::GetEntries(result);
+	D_ASSERT(child_entries.size() == children.size());
+
+	bool all_const = true;
+	idx_t children_size = 0;
+	for (idx_t i = 0; i < children.size(); i++) {
+		auto &intermediate = state->intermediate_chunk.data[i];
+		Execute(*children[i], state->child_states[i].get(), sel, count, intermediate);
+		if (intermediate.GetVectorType() != VectorType::CONSTANT_VECTOR) {
+			all_const = false;
+		}
+		child_entries[i].Reference(intermediate);
+		children_size = MaxValue<idx_t>(children_size, child_entries[i].size());
+	}
+
+	// only set the pack buffer's type/size - the children reference the intermediate vectors and must not be touched
+	result.BufferMutable().SetVectorTypeOnly(all_const ? VectorType::CONSTANT_VECTOR : VectorType::FLAT_VECTOR);
+	result.BufferMutable().SetVectorSizeOnly(children_size);
 }
 
 void ExpressionExecutor::Execute(const BoundOperatorExpression &expr, ExpressionState *state,
@@ -62,6 +98,8 @@ void ExpressionExecutor::Execute(const BoundOperatorExpression &expr, Expression
 			// directly use the result
 			result.Reference(intermediate);
 		}
+	} else if (expression_type == ExpressionType::ARGUMENT_PACK) {
+		ExecuteArgumentPack(expr, state, sel, count, result);
 	} else if (expression_type == ExpressionType::OPERATOR_COALESCE) {
 		SelectionVector sel_a(count);
 		SelectionVector sel_b(count);

--- a/src/function/function.cpp
+++ b/src/function/function.cpp
@@ -6,6 +6,7 @@
 #include "duckdb/function/built_in_functions.hpp"
 #include "duckdb/function/scalar/string_functions.hpp"
 #include "duckdb/function/scalar_function.hpp"
+#include "duckdb/planner/expression/bound_argument_pack.hpp"
 
 namespace duckdb {
 
@@ -70,16 +71,36 @@ static bool RequiresCatalogAndSchemaNamePrefix(const Identifier &catalog_name, c
 }
 
 string FunctionParameter::ToString() const {
-	if (default_value) {
-		return StringUtil::Format("%s %s := %s", name, type.ToString(), default_value->ToString());
+	string prefix;
+	switch (kind) {
+	case FunctionParameterKind::VAR_POSITIONAL:
+		prefix = "*";
+		break;
+	case FunctionParameterKind::VAR_KEYWORD:
+		prefix = "**";
+		break;
+	default:
+		break;
 	}
-	return StringUtil::Format("%s %s", name, type.ToString());
+	if (default_value) {
+		return StringUtil::Format("%s%s %s := %s", prefix, name, type.ToString(), default_value->ToString());
+	}
+	return StringUtil::Format("%s%s %s", prefix, name, type.ToString());
 }
 
 string FunctionSignature::ToString() const {
 	vector<string> params;
 	params.reserve(parameters.size());
+	bool emitted_keyword_only_marker = false;
 	for (auto &param : parameters) {
+		// keyword-only parameters that are not preceded by a "*args" parameter are introduced by a bare "*",
+		// matching Python's notation
+		if (param.GetKind() == FunctionParameterKind::KEYWORD_ONLY && !emitted_keyword_only_marker) {
+			emitted_keyword_only_marker = true;
+			if (!HasVarPositional()) {
+				params.push_back("*");
+			}
+		}
 		params.push_back(param.ToString());
 	}
 	if (varargs.IsValid()) {
@@ -139,6 +160,7 @@ hash_t FunctionSignature::Hash() const {
 	hash_t hash = return_type.Hash();
 	for (auto &param : parameters) {
 		hash = duckdb::CombineHash(hash, param.GetType().Hash());
+		hash = duckdb::CombineHash(hash, duckdb::Hash(static_cast<uint8_t>(param.GetKind())));
 	}
 	return hash;
 }
@@ -206,6 +228,10 @@ void Function::EraseArgument(BoundSimpleFunction &bound_function, vector<unique_
 	}
 	D_ASSERT(arguments.size() == bound_function.GetArguments().size());
 	D_ASSERT(argument_index < arguments.size());
+	if (ArgumentPack::IsPackType(bound_function.GetArguments()[argument_index])) {
+		throw InternalException("%s: cannot erase argument %llu - it holds a packed argument list",
+		                        bound_function.GetName(), argument_index);
+	}
 	arguments.erase_at(argument_index);
 	bound_function.GetArguments().erase_at(argument_index);
 }
@@ -223,7 +249,7 @@ string BoundSimpleFunction::ToString() const {
 }
 
 bool FunctionParameter::operator==(const FunctionParameter &other) const {
-	return type == other.type && name == other.name;
+	return type == other.type && name == other.name && kind == other.kind;
 }
 
 bool FunctionParameter::operator!=(const FunctionParameter &other) const {
@@ -244,6 +270,9 @@ bool FunctionSignature::Equal(const FunctionSignature &other) const {
 	}
 	for (idx_t i = 0; i < parameters.size(); i++) {
 		if (parameters[i].GetType() != other.parameters[i].GetType()) {
+			return false;
+		}
+		if (parameters[i].GetKind() != other.parameters[i].GetKind()) {
 			return false;
 		}
 	}

--- a/src/function/function.cpp
+++ b/src/function/function.cpp
@@ -56,9 +56,8 @@ SimpleFunction::SimpleFunction(Identifier name_p, FunctionSignature signature_p)
     : Function(std::move(name_p)), signature(std::move(signature_p)) {
 }
 
-SimpleFunction::SimpleFunction(Identifier name_p, vector<LogicalType> arguments_p, LogicalType return_type,
-                               LogicalType varargs_p)
-    : Function(std::move(name_p)), signature(std::move(arguments_p), std::move(varargs_p), std::move(return_type)) {
+SimpleFunction::SimpleFunction(Identifier name_p, vector<LogicalType> arguments_p, LogicalType return_type)
+    : Function(std::move(name_p)), signature(std::move(arguments_p), std::move(return_type)) {
 }
 
 SimpleFunction::~SimpleFunction() {
@@ -101,9 +100,6 @@ string FunctionSignature::ToString() const {
 			}
 		}
 		params.push_back(param.ToString());
-	}
-	if (varargs.IsValid()) {
-		params.push_back("[" + varargs.ToString() + "...]");
 	}
 	auto head = StringUtil::Format("(%s)", StringUtil::Join(params, ", "));
 	if (return_type.IsValid()) {
@@ -170,8 +166,7 @@ hash_t SimpleFunction::Hash() const {
 
 string Function::CallToString(const Identifier &catalog_name, const Identifier &schema_name, const Identifier &name,
                               const vector<LogicalType> &arguments,
-                              const vector<pair<Identifier, LogicalType>> &named_arguments,
-                              const LogicalType &varargs) {
+                              const vector<pair<Identifier, LogicalType>> &named_arguments) {
 	string result;
 	if (RequiresCatalogAndSchemaNamePrefix(catalog_name, schema_name)) {
 		result += catalog_name + "." + schema_name + ".";
@@ -186,18 +181,13 @@ string Function::CallToString(const Identifier &catalog_name, const Identifier &
 		string_arguments.push_back(StringUtil::Format("%s := %s", arg_name, arg_type.ToString()));
 	}
 
-	if (varargs.IsValid()) {
-		string_arguments.push_back("[" + varargs.ToString() + "...]");
-	}
 	result += StringUtil::Join(string_arguments, ", ");
 	return result + ")";
 }
 
 string Function::CallToString(const Identifier &catalog_name, const Identifier &schema_name, const Identifier &name,
-                              const vector<LogicalType> &arguments, const LogicalType &varargs,
-                              const LogicalType &return_type) {
-	string result =
-	    CallToString(catalog_name, schema_name, name, arguments, vector<pair<Identifier, LogicalType>> {}, varargs);
+                              const vector<LogicalType> &arguments, const LogicalType &return_type) {
+	string result = CallToString(catalog_name, schema_name, name, arguments, vector<pair<Identifier, LogicalType>> {});
 	result += " -> " + return_type.ToString();
 	return result;
 }
@@ -244,7 +234,7 @@ hash_t BoundSimpleFunction::Hash() const {
 }
 
 string BoundSimpleFunction::ToString() const {
-	return Function::CallToString(catalog_name, schema_name, name, arguments, LogicalTypeId::INVALID, return_type);
+	return Function::CallToString(catalog_name, schema_name, name, arguments, return_type);
 }
 
 bool FunctionParameter::operator==(const FunctionParameter &other) const {
@@ -256,7 +246,7 @@ bool FunctionParameter::operator!=(const FunctionParameter &other) const {
 }
 
 bool FunctionSignature::operator==(const FunctionSignature &other) const {
-	return parameters == other.parameters && varargs == other.varargs && return_type == other.return_type;
+	return parameters == other.parameters && return_type == other.return_type;
 }
 
 bool FunctionSignature::operator!=(const FunctionSignature &other) const {
@@ -274,9 +264,6 @@ bool FunctionSignature::Equal(const FunctionSignature &other) const {
 		if (parameters[i].GetKind() != other.parameters[i].GetKind()) {
 			return false;
 		}
-	}
-	if (varargs != other.varargs) {
-		return false;
 	}
 	if (return_type != other.return_type) {
 		return false;
@@ -363,8 +350,7 @@ optional_idx BindFunctionInput::GetArgumentIndex(const Identifier &name) const {
 		throw InternalException("Function '%s' was bound without argument names, cannot look up argument '%s' by name",
 		                        function.GetName(), name);
 	}
-	// The binder resolves every argument to a slot and reports its name: the signature parameter name for positional
-	// slots, or the name the caller used for named varargs.
+	// The binder resolves every argument to the slot of the parameter it fills, and reports that parameter's name.
 	for (idx_t arg_idx = 0; arg_idx < argument_names->size(); arg_idx++) {
 		if ((*argument_names)[arg_idx] == name) {
 			return optional_idx(arg_idx);

--- a/src/function/function.cpp
+++ b/src/function/function.cpp
@@ -288,6 +288,20 @@ bool FunctionSignature::Equal(const FunctionSignature &other) const {
 //----------------------------------------------------------------------------------------------------------------------
 // Bind Function Input
 //----------------------------------------------------------------------------------------------------------------------
+vector<reference<Expression>> BindFunctionInput::GetUnpackedArguments() const {
+	vector<reference<Expression>> result;
+	for (auto &argument : arguments) {
+		if (!ArgumentPack::IsPackType(argument->GetReturnType())) {
+			result.push_back(*argument);
+			continue;
+		}
+		for (auto &packed : ArgumentPack::GetPackedChildren(*argument)) {
+			result.push_back(*packed);
+		}
+	}
+	return result;
+}
+
 Value BindFunctionInput::GetConstant(idx_t arg_idx, bool accept_null) const {
 	if (arg_idx >= arguments.size()) {
 		throw InternalException("%s: Argument index %llu is out of range", function.GetName(), arg_idx);

--- a/src/function/function.cpp
+++ b/src/function/function.cpp
@@ -12,8 +12,7 @@ namespace duckdb {
 
 bool FunctionProperties::operator==(const FunctionProperties &rhs) const {
 	return stability == rhs.stability && null_handling == rhs.null_handling && errors == rhs.errors &&
-	       collation_handling == rhs.collation_handling && capture_argument_aliases == rhs.capture_argument_aliases &&
-	       requires_ordered_execution == rhs.requires_ordered_execution;
+	       collation_handling == rhs.collation_handling && requires_ordered_execution == rhs.requires_ordered_execution;
 }
 
 bool FunctionProperties::operator!=(const FunctionProperties &rhs) const {

--- a/src/function/function_binder.cpp
+++ b/src/function/function_binder.cpp
@@ -1061,35 +1061,26 @@ static bool ArgumentsAlreadyPacked(const FunctionSignature &sig, const vector<un
 	return true;
 }
 
-// Build the TUPLE/STRUCT value that fills a "*args"/"**kwargs" parameter. The parameter's declared type constrains
-// the individual arguments it collects, so they are cast to it here - the pack itself is then already of the exact
-// type the function expects and CastToFunctionArguments leaves it alone.
-static unique_ptr<Expression> BuildArgumentPack(ClientContext &context, const FunctionParameter &param,
-                                                vector<unique_ptr<Expression>> children,
+// Build the TUPLE/STRUCT value that fills a "*args"/"**kwargs" parameter. The pack describes the arguments as they
+// were passed - settling them on the type the parameter declares is left to CastToFunctionArguments, which runs
+// after the "bind" callback has had a chance to narrow that type down to a concrete one.
+static unique_ptr<Expression> BuildArgumentPack(const FunctionParameter &param, vector<unique_ptr<Expression>> children,
                                                 optional_ptr<const vector<Identifier>> names) {
-	auto element_type = param.GetType();
-	PrepareTypeForCast(element_type);
-	const auto cast_elements = element_type.id() != LogicalTypeId::ANY && element_type.id() != LogicalTypeId::TEMPLATE;
-
-	child_list_t<LogicalType> pack_children;
-	pack_children.reserve(children.size());
-	for (idx_t i = 0; i < children.size(); i++) {
-		if (cast_elements &&
-		    RequiresCast(children[i]->GetReturnType(), element_type) == LogicalTypeComparisonResult::DIFFERENT_TYPES) {
-			children[i] = BoundCastExpression::AddCastToType(context, std::move(children[i]), element_type);
-		}
-		pack_children.emplace_back(names ? (*names)[i] : Identifier(), children[i]->GetReturnType());
-	}
-
 	if (!names) {
 		vector<LogicalType> element_types;
-		element_types.reserve(pack_children.size());
-		for (auto &pack_child : pack_children) {
-			element_types.push_back(std::move(pack_child.second));
+		element_types.reserve(children.size());
+		for (auto &child : children) {
+			element_types.push_back(child->GetReturnType());
 		}
 		return ArgumentPack::Create(std::move(children), ArgumentPack::PositionalType(std::move(element_types)));
 	}
-	return ArgumentPack::Create(std::move(children), ArgumentPack::KeywordType(std::move(pack_children)));
+
+	child_list_t<LogicalType> value_types;
+	value_types.reserve(children.size());
+	for (idx_t i = 0; i < children.size(); i++) {
+		value_types.emplace_back((*names)[i], children[i]->GetReturnType());
+	}
+	return ArgumentPack::Create(std::move(children), ArgumentPack::KeywordType(std::move(value_types)));
 }
 
 // Resolve the arguments of a function whose signature declares a "*args" and/or "**kwargs" parameter. The trailing
@@ -1167,7 +1158,7 @@ static vector<Identifier> ResolveArgumentsWithPacks(ClientContext &context, cons
 		}
 		switch (param.GetKind()) {
 		case FunctionParameterKind::VAR_POSITIONAL:
-			arguments[i] = BuildArgumentPack(context, param, std::move(var_positional_args), nullptr);
+			arguments[i] = BuildArgumentPack(param, std::move(var_positional_args), nullptr);
 			break;
 		case FunctionParameterKind::VAR_KEYWORD: {
 			vector<Identifier> keyword_names;
@@ -1178,7 +1169,7 @@ static vector<Identifier> ResolveArgumentsWithPacks(ClientContext &context, cons
 				keyword_names.push_back(keyword_arg.first);
 				keyword_children.push_back(std::move(keyword_arg.second));
 			}
-			arguments[i] = BuildArgumentPack(context, param, std::move(keyword_children), &keyword_names);
+			arguments[i] = BuildArgumentPack(param, std::move(keyword_children), &keyword_names);
 			break;
 		}
 		default:

--- a/src/function/function_binder.cpp
+++ b/src/function/function_binder.cpp
@@ -81,8 +81,7 @@ optional_idx FunctionBinder::BindFunctionCost(const SimpleFunction &func, const 
 	const auto minimum_arg_count = sig.GetRequiredParameterCount();
 
 	// a "*args"/"**kwargs" parameter collects an unbounded number of arguments
-	const auto accepts_any_count = sig.HasVarArgs() || sig.HasArgumentPacks();
-	const auto maximum_arg_count = accepts_any_count ? NumericLimits<idx_t>::Maximum() : sig.GetParameterCount();
+	const auto maximum_arg_count = sig.HasArgumentPacks() ? NumericLimits<idx_t>::Maximum() : sig.GetParameterCount();
 
 	if (received_arg_count < minimum_arg_count) {
 		// We have fewer arguments than the function requires, so this function cannot be a match.
@@ -121,8 +120,6 @@ optional_idx FunctionBinder::BindFunctionCost(const SimpleFunction &func, const 
 		} else if (var_positional_index.IsValid()) {
 			// captured by "*args" - check against the element type it constrains its arguments to
 			arg_type = sig.GetParameter(var_positional_index.GetIndex()).GetType();
-		} else if (sig.HasVarArgs()) {
-			arg_type = sig.GetVarArgs();
 		} else {
 			// more positional arguments than the function can take
 			return optional_idx();
@@ -144,17 +141,14 @@ optional_idx FunctionBinder::BindFunctionCost(const SimpleFunction &func, const 
 		auto opt_param_idx = sig.GetParameterIndexByName(named_arg.first);
 
 		if (!opt_param_idx.IsValid()) {
-			if (!var_keyword_index.IsValid() && !sig.HasVarArgs()) {
+			if (!var_keyword_index.IsValid()) {
 				// no parameter with this name: continue
 				return optional_idx();
 			}
 
-			// This argument is captured by "**kwargs" (or by the legacy trailing varargs) - check it against the
-			// value type that parameter constrains its arguments to. Both are always at the end of the argument
-			// list, so no parameter index check is needed.
-			const auto &catch_all_type = var_keyword_index.IsValid()
-			                                 ? sig.GetParameter(var_keyword_index.GetIndex()).GetType()
-			                                 : sig.GetVarArgs();
+			// This argument is captured by "**kwargs" - check it against the value type that parameter constrains
+			// its arguments to
+			const auto &catch_all_type = sig.GetParameter(var_keyword_index.GetIndex()).GetType();
 			int64_t cast_cost = CastFunctionSet::ImplicitCastCost(context, named_arg.second, catch_all_type);
 			if (cast_cost >= 0) {
 				// we can implicitly cast, add the cost to the total cost
@@ -565,7 +559,7 @@ void FunctionBinder::CastToFunctionArguments(BoundSimpleFunction &function, vect
 		PrepareTypeForCast(arg);
 	}
 
-	// Varargs should be expanded by this point
+	// Every argument expression sits in the slot of the parameter it fills by this point.
 	// If not, the function has somehow added more argument expressions during binding, which is not allowed.
 	// There is one exception, count(*) which can be invoked internally with fewer arguments than the function
 	// definition. That should be fixed separately though.
@@ -1214,8 +1208,7 @@ static void ApplyArgumentPackTypes(const FunctionSignature &sig, BoundSimpleFunc
 
 // Drain all named argument and insert them in the correct position according to the function signature.
 // Also insert default arguments where needed.
-// Returns the resolved name of every argument slot: the signature parameter name for positional slots, the
-// caller-provided name for named varargs, and an empty identifier for unnamed varargs.
+// Returns the name of every argument slot the signature covers.
 static vector<Identifier> ResolveArguments(ClientContext &context, const SimpleFunction &function,
                                            vector<unique_ptr<Expression>> &arguments,
                                            vector<pair<Identifier, unique_ptr<Expression>>> &named_arguments) {
@@ -1244,11 +1237,8 @@ static vector<Identifier> ResolveArguments(ClientContext &context, const SimpleF
 
 	identifier_set_t seen_names;
 
-	vector<pair<Identifier, unique_ptr<Expression>>> trailing_kwargs;
-
-	// We now need to reorder them to match the function signature, before appending them to the argument list.
-	for (idx_t kwarg_idx = 0; kwarg_idx < named_arguments.size(); kwarg_idx++) {
-		auto &[name, arg] = named_arguments[kwarg_idx];
+	// We now need to reorder them to match the function signature.
+	for (auto &[name, arg] : named_arguments) {
 		const auto location = arg->GetQueryLocation();
 
 		if (name.empty()) {
@@ -1268,14 +1258,8 @@ static vector<Identifier> ResolveArguments(ClientContext &context, const SimpleF
 
 		const auto opt_param_idx = sig.GetParameterIndexByName(name);
 		if (!opt_param_idx.IsValid()) {
-			if (!sig.HasVarArgs()) {
-				throw BinderException(location, "Function '%s' does not have a parameter named '%s'",
-				                      function.GetName(), name);
-			}
-
-			// This is a named vararg argument, come back for it later
-			trailing_kwargs.emplace_back(name, std::move(arg));
-			continue;
+			throw BinderException(location, "Function '%s' does not have a parameter named '%s'", function.GetName(),
+			                      name);
 		}
 
 		const auto param_idx = opt_param_idx.GetIndex();
@@ -1314,26 +1298,6 @@ static vector<Identifier> ResolveArguments(ClientContext &context, const SimpleF
 	for (idx_t i = 0; i < MinValue<idx_t>(arguments.size(), sig.GetParameterCount()); i++) {
 		argument_names[i] = sig.GetParameter(i).GetName();
 	}
-
-	// Now spread out any trailing named vararg arguments into the remaining argument slots, wherever they may be
-	idx_t kwarg_idx = 0;
-	for (idx_t slot_idx = kwargs_offset; slot_idx < arguments.size(); slot_idx++) {
-		if (!arguments[slot_idx]) {
-			argument_names[slot_idx] = trailing_kwargs[kwarg_idx].first;
-			arguments[slot_idx] = std::move(trailing_kwargs[kwarg_idx].second);
-			kwarg_idx++;
-		}
-	}
-
-	// And if there are still some left, just append them to the end
-	idx_t kwargs_remaining = trailing_kwargs.size() - kwarg_idx;
-	while (kwargs_remaining) {
-		argument_names.push_back(trailing_kwargs[kwarg_idx].first);
-		arguments.push_back(std::move(trailing_kwargs[kwarg_idx].second));
-		kwarg_idx++;
-		kwargs_remaining--;
-	}
-
 	return argument_names;
 }
 
@@ -1345,14 +1309,6 @@ FunctionBinder::ResolveFunction(const ScalarFunction &function, vector<unique_pt
 
 	// Make a BoundScalarFunction out of the ScalarFunction, so we can store bind info and other properties in it.
 	BoundScalarFunction bound_function(function);
-
-	// Expand varargs if necessary
-	if (function.HasVarArgs()) {
-		const auto &varargs_type = function.GetVarArgs();
-		for (idx_t i = function.GetSignature().GetParameterCount(); i < arguments.size(); i++) {
-			bound_function.GetArguments().push_back(varargs_type);
-		}
-	}
 
 	// A "*args"/"**kwargs" parameter declares the type of the arguments it collects, not the type of the pack that
 	// is handed to the function - fill in the concrete pack type before the "bind" callback runs.
@@ -1425,14 +1381,6 @@ FunctionBinder::ResolveFunction(const AggregateFunction &function, vector<unique
 	// Make a BoundFunction out of the func
 	BoundAggregateFunction bound_function(function);
 
-	// Expand varargs if necessary
-	if (function.HasVarArgs()) {
-		const auto &varargs_type = function.GetVarArgs();
-		for (idx_t i = function.GetSignature().GetParameterCount(); i < children.size(); i++) {
-			bound_function.GetArguments().push_back(varargs_type);
-		}
-	}
-
 	// A "*args"/"**kwargs" parameter declares the type of the arguments it collects, not the type of the pack that
 	// is handed to the function - fill in the concrete pack type before the "bind" callback runs.
 	ResolveTemplateTypes(function.GetSignature(), bound_function, children);
@@ -1504,14 +1452,6 @@ FunctionBinder::ResolveFunction(const WindowFunction &function, vector<unique_pt
 	auto argument_names = ResolveArguments(context, function, children, named_arguments);
 
 	BoundWindowFunction bound_function(function);
-
-	// Expand varargs if necessary
-	if (function.HasVarArgs()) {
-		const auto &varargs_type = function.GetVarArgs();
-		for (idx_t i = function.GetSignature().GetParameterCount(); i < children.size(); i++) {
-			bound_function.GetArguments().push_back(varargs_type);
-		}
-	}
 
 	// A "*args"/"**kwargs" parameter declares the type of the arguments it collects, not the type of the pack that
 	// is handed to the function - fill in the concrete pack type before the "bind" callback runs.

--- a/src/function/function_binder.cpp
+++ b/src/function/function_binder.cpp
@@ -540,6 +540,36 @@ static void PrepareTypeForCast(LogicalType &type) {
 	type = PrepareTypeForCastRecursive(type);
 }
 
+//! Cast the arguments a "*args"/"**kwargs" parameter collected to the types the function settled on, and describe
+//! the pack by what it ends up holding: RequiresCast leaves some differences alone - an array of a different size,
+//! say - so the members keep the types they really have.
+void FunctionBinder::CastArgumentPack(Expression &pack, LogicalType &pack_type) {
+	auto &packed = ArgumentPack::GetPackedChildren(pack);
+	D_ASSERT(packed.size() == StructType::GetChildCount(pack_type));
+
+	child_list_t<LogicalType> members;
+	members.reserve(packed.size());
+	for (idx_t i = 0; i < packed.size(); i++) {
+		auto &member_type = StructType::GetChildType(pack_type, i);
+		if (RequiresCast(packed[i]->GetReturnType(), member_type) == LogicalTypeComparisonResult::DIFFERENT_TYPES) {
+			packed[i] = BoundCastExpression::AddCastToType(context, std::move(packed[i]), member_type);
+		}
+		members.emplace_back(StructType::GetChildName(pack_type, i), packed[i]->GetReturnType());
+	}
+
+	if (pack_type.id() == LogicalTypeId::TUPLE) {
+		vector<LogicalType> member_types;
+		member_types.reserve(members.size());
+		for (auto &member : members) {
+			member_types.push_back(member.second);
+		}
+		pack_type = ArgumentPack::PositionalType(std::move(member_types));
+	} else {
+		pack_type = ArgumentPack::KeywordType(std::move(members));
+	}
+	pack.SetReturnType(pack_type);
+}
+
 void FunctionBinder::CastToFunctionArguments(BoundSimpleFunction &function, vector<unique_ptr<Expression>> &children) {
 	for (auto &arg : function.GetArguments()) {
 		PrepareTypeForCast(arg);
@@ -568,9 +598,16 @@ void FunctionBinder::CastToFunctionArguments(BoundSimpleFunction &function, vect
 		auto cast_result = RequiresCast(children[i]->GetReturnType(), target_type);
 		// except for one special case: if the function accepts ANY argument
 		// in that case we don't add a cast
-		if (cast_result == LogicalTypeComparisonResult::DIFFERENT_TYPES) {
-			children[i] = BoundCastExpression::AddCastToType(context, std::move(children[i]), target_type);
+		if (cast_result != LogicalTypeComparisonResult::DIFFERENT_TYPES) {
+			continue;
 		}
+		if (ArgumentPack::IsPackType(target_type)) {
+			// cast the collected arguments individually - wrapping the pack itself in a cast would leave the slot
+			// holding something that is no longer recognisable as the pack it was built for
+			CastArgumentPack(*children[i], target_type);
+			continue;
+		}
+		children[i] = BoundCastExpression::AddCastToType(context, std::move(children[i]), target_type);
 	}
 }
 
@@ -927,7 +964,7 @@ static void SubstituteTemplateType(LogicalType &type, case_insensitive_map_t<vec
 	});
 }
 
-void FunctionBinder::ResolveTemplateTypes(BoundSimpleFunction &bound_function,
+void FunctionBinder::ResolveTemplateTypes(const FunctionSignature &sig, BoundSimpleFunction &bound_function,
                                           const vector<unique_ptr<Expression>> &children) {
 	case_insensitive_map_t<vector<LogicalType>> bindings;
 	vector<reference<LogicalType>> to_substitute;
@@ -937,12 +974,24 @@ void FunctionBinder::ResolveTemplateTypes(BoundSimpleFunction &bound_function,
 		auto &param = bound_function.GetArguments()[i];
 
 		// If the parameter is not templated, we can skip it.
-		if (param.IsTemplated()) {
-			auto actual = ExpressionBinder::GetExpressionReturnType(*children[i]);
-			InferTemplateType(context, param, actual, bindings, *children[i], bound_function);
-
-			to_substitute.emplace_back(param);
+		if (!param.IsTemplated()) {
+			continue;
 		}
+
+		if (i < sig.GetParameterCount() && sig.GetParameter(i).IsArgumentPack()) {
+			// the declared type constrains every argument the pack collected, so they all have to agree on it
+			for (auto &member : ArgumentPack::GetPackedChildren(*children[i])) {
+				auto actual = ExpressionBinder::GetExpressionReturnType(*member);
+				InferTemplateType(context, param, actual, bindings, *member, bound_function);
+			}
+			to_substitute.emplace_back(param);
+			continue;
+		}
+
+		auto actual = ExpressionBinder::GetExpressionReturnType(*children[i]);
+		InferTemplateType(context, param, actual, bindings, *children[i], bound_function);
+
+		to_substitute.emplace_back(param);
 	}
 
 	// If the return type is templated, we need to substitute it as well
@@ -973,6 +1022,22 @@ void FunctionBinder::CheckTemplateTypesResolved(const BoundSimpleFunction &bound
 		VerifyTemplateType(arg, bound_function.GetName());
 	}
 	VerifyTemplateType(bound_function.GetReturnType(), bound_function.GetName());
+}
+
+// The optimizer may fold a pack built entirely from constants into a single struct value. A bound call is
+// re-bound when it is deserialized, and the bind callback expects one expression per collected argument, so the
+// binder builds the pack back out of that value.
+static void UnpackFoldedArgumentPack(unique_ptr<Expression> &pack) {
+	if (pack->GetExpressionType() != ExpressionType::VALUE_CONSTANT) {
+		return;
+	}
+	auto &value = pack->Cast<BoundConstantExpression>().GetValue();
+	D_ASSERT(!value.IsNull());
+	vector<unique_ptr<Expression>> packed;
+	for (auto &packed_value : StructValue::GetChildren(value)) {
+		packed.push_back(make_uniq<BoundConstantExpression>(packed_value));
+	}
+	pack = ArgumentPack::Create(std::move(packed), pack->GetReturnType());
 }
 
 // Whether the argument list has already been resolved into its packed form. A bound function call is serialized
@@ -1139,9 +1204,30 @@ static void ApplyArgumentPackTypes(const FunctionSignature &sig, BoundSimpleFunc
 	}
 	auto &bound_arguments = bound_function.GetArguments();
 	for (idx_t i = 0; i < MinValue<idx_t>(arguments.size(), bound_arguments.size()); i++) {
-		if (sig.GetParameter(i).IsArgumentPack() && arguments[i]) {
-			bound_arguments[i] = arguments[i]->GetReturnType();
+		if (!sig.GetParameter(i).IsArgumentPack() || !arguments[i]) {
+			continue;
 		}
+		auto &pack_type = arguments[i]->GetReturnType();
+		auto &element_type = bound_arguments[i];
+
+		// the declared element type is the concrete type every collected argument has to have - unless it accepts
+		// anything, in which case they keep the types they were passed with. It is only concrete here once the
+		// template types have been resolved, which is why that happens first.
+		if (element_type.id() == LogicalTypeId::ANY || element_type.id() == LogicalTypeId::INVALID) {
+			bound_arguments[i] = pack_type;
+			continue;
+		}
+		const auto member_count = StructType::GetChildCount(pack_type);
+		if (sig.GetParameter(i).GetKind() == FunctionParameterKind::VAR_POSITIONAL) {
+			bound_arguments[i] = ArgumentPack::PositionalType(vector<LogicalType>(member_count, element_type));
+			continue;
+		}
+		child_list_t<LogicalType> members;
+		members.reserve(member_count);
+		for (idx_t member = 0; member < member_count; member++) {
+			members.emplace_back(StructType::GetChildName(pack_type, member), element_type);
+		}
+		bound_arguments[i] = ArgumentPack::KeywordType(std::move(members));
 	}
 }
 
@@ -1159,6 +1245,9 @@ static vector<Identifier> ResolveArguments(ClientContext &context, const SimpleF
 			vector<Identifier> argument_names(arguments.size());
 			for (idx_t i = 0; i < arguments.size(); i++) {
 				argument_names[i] = sig.GetParameter(i).GetName();
+				if (sig.GetParameter(i).IsArgumentPack()) {
+					UnpackFoldedArgumentPack(arguments[i]);
+				}
 			}
 			return argument_names;
 		}
@@ -1286,10 +1375,10 @@ FunctionBinder::ResolveFunction(const ScalarFunction &function, vector<unique_pt
 
 	// A "*args"/"**kwargs" parameter declares the type of the arguments it collects, not the type of the pack that
 	// is handed to the function - fill in the concrete pack type before the "bind" callback runs.
-	ApplyArgumentPackTypes(function.GetSignature(), bound_function, arguments);
-
 	// Attempt to resolve template types, before we call the "Bind" callback.
-	ResolveTemplateTypes(bound_function, arguments);
+	ResolveTemplateTypes(function.GetSignature(), bound_function, arguments);
+
+	ApplyArgumentPackTypes(function.GetSignature(), bound_function, arguments);
 
 	unique_ptr<FunctionData> bind_info;
 
@@ -1365,9 +1454,9 @@ FunctionBinder::ResolveFunction(const AggregateFunction &function, vector<unique
 
 	// A "*args"/"**kwargs" parameter declares the type of the arguments it collects, not the type of the pack that
 	// is handed to the function - fill in the concrete pack type before the "bind" callback runs.
-	ApplyArgumentPackTypes(function.GetSignature(), bound_function, children);
+	ResolveTemplateTypes(function.GetSignature(), bound_function, children);
 
-	ResolveTemplateTypes(bound_function, children);
+	ApplyArgumentPackTypes(function.GetSignature(), bound_function, children);
 
 	unique_ptr<FunctionData> bind_info;
 
@@ -1445,9 +1534,9 @@ FunctionBinder::ResolveFunction(const WindowFunction &function, vector<unique_pt
 
 	// A "*args"/"**kwargs" parameter declares the type of the arguments it collects, not the type of the pack that
 	// is handed to the function - fill in the concrete pack type before the "bind" callback runs.
-	ApplyArgumentPackTypes(function.GetSignature(), bound_function, children);
+	ResolveTemplateTypes(function.GetSignature(), bound_function, children);
 
-	ResolveTemplateTypes(bound_function, children);
+	ApplyArgumentPackTypes(function.GetSignature(), bound_function, children);
 
 	unique_ptr<FunctionData> bind_info;
 

--- a/src/function/function_binder.cpp
+++ b/src/function/function_binder.cpp
@@ -10,6 +10,7 @@
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/function/cast/cast_function_set.hpp"
 #include "duckdb/planner/expression/bound_aggregate_expression.hpp"
+#include "duckdb/planner/expression/bound_argument_pack.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
@@ -79,7 +80,9 @@ optional_idx FunctionBinder::BindFunctionCost(const SimpleFunction &func, const 
 	// And the minimum and maximum number of arguments the function can accept
 	const auto minimum_arg_count = sig.GetRequiredParameterCount();
 
-	const auto maximum_arg_count = sig.HasVarArgs() ? NumericLimits<idx_t>::Maximum() : sig.GetParameterCount();
+	// a "*args"/"**kwargs" parameter collects an unbounded number of arguments
+	const auto accepts_any_count = sig.HasVarArgs() || sig.HasArgumentPacks();
+	const auto maximum_arg_count = accepts_any_count ? NumericLimits<idx_t>::Maximum() : sig.GetParameterCount();
 
 	if (received_arg_count < minimum_arg_count) {
 		// We have fewer arguments than the function requires, so this function cannot be a match.
@@ -94,13 +97,36 @@ optional_idx FunctionBinder::BindFunctionCost(const SimpleFunction &func, const 
 	idx_t cost = 0;
 	bool has_parameter = false;
 
+	// the number of slots that can be filled positionally - everything beyond this is captured by "*args" (if any)
+	const auto positional_count = sig.GetPositionalParameterCount();
+	const auto var_positional_index = sig.GetVarPositionalIndex();
+	const auto var_keyword_index = sig.GetVarKeywordIndex();
+
 	for (idx_t i = 0; i < arguments.size(); i++) {
 		if (arguments[i].id() == LogicalTypeId::UNKNOWN) {
 			has_parameter = true;
 			continue;
 		}
 
-		auto arg_type = i < sig.GetParameterCount() ? sig.GetParameter(i).GetType() : sig.GetVarArgs();
+		if (ArgumentPack::IsPackType(arguments[i]) && i < sig.GetParameterCount() &&
+		    sig.GetParameter(i).IsArgumentPack()) {
+			// an already-packed argument, i.e. this call is being re-bound after deserialization - the pack lines up
+			// with its parameter as-is
+			continue;
+		}
+
+		LogicalType arg_type;
+		if (i < positional_count) {
+			arg_type = sig.GetParameter(i).GetType();
+		} else if (var_positional_index.IsValid()) {
+			// captured by "*args" - check against the element type it constrains its arguments to
+			arg_type = sig.GetParameter(var_positional_index.GetIndex()).GetType();
+		} else if (sig.HasVarArgs()) {
+			arg_type = sig.GetVarArgs();
+		} else {
+			// more positional arguments than the function can take
+			return optional_idx();
+		}
 
 		int64_t cast_cost = CastFunctionSet::ImplicitCastCost(context, arguments[i], arg_type);
 		if (cast_cost >= 0) {
@@ -118,15 +144,18 @@ optional_idx FunctionBinder::BindFunctionCost(const SimpleFunction &func, const 
 		auto opt_param_idx = sig.GetParameterIndexByName(named_arg.first);
 
 		if (!opt_param_idx.IsValid()) {
-			if (!sig.HasVarArgs()) {
+			if (!var_keyword_index.IsValid() && !sig.HasVarArgs()) {
 				// no parameter with this name: continue
 				return optional_idx();
 			}
 
-			// This is a named vararg argument, we can skip the parameter index check as varargs are always at the end
-			// of the argument list
-			auto &vararg_type = sig.GetVarArgs();
-			int64_t cast_cost = CastFunctionSet::ImplicitCastCost(context, named_arg.second, vararg_type);
+			// This argument is captured by "**kwargs" (or by the legacy trailing varargs) - check it against the
+			// value type that parameter constrains its arguments to. Both are always at the end of the argument
+			// list, so no parameter index check is needed.
+			const auto &catch_all_type = var_keyword_index.IsValid()
+			                                 ? sig.GetParameter(var_keyword_index.GetIndex()).GetType()
+			                                 : sig.GetVarArgs();
+			int64_t cast_cost = CastFunctionSet::ImplicitCastCost(context, named_arg.second, catch_all_type);
 			if (cast_cost >= 0) {
 				// we can implicitly cast, add the cost to the total cost
 				cost += static_cast<idx_t>(cast_cost);
@@ -141,7 +170,7 @@ optional_idx FunctionBinder::BindFunctionCost(const SimpleFunction &func, const 
 			// context so we can give a better error message.
 			const auto param_idx = opt_param_idx.GetIndex();
 
-			if (param_idx < arguments.size()) {
+			if (param_idx < MinValue<idx_t>(arguments.size(), positional_count)) {
 				// If already covered by a positional argument, skip the cost check here.
 				continue;
 			}
@@ -946,13 +975,195 @@ void FunctionBinder::CheckTemplateTypesResolved(const BoundSimpleFunction &bound
 	VerifyTemplateType(bound_function.GetReturnType(), bound_function.GetName());
 }
 
+// Whether the argument list has already been resolved into its packed form. A bound function call is serialized
+// as-is, so ResolveFunction is re-entered with the packs already built when it is deserialized, and they must not be
+// packed a second time. The decision is made on the argument type rather than on the expression, because by then the
+// optimizer may have replaced the pack expression with an equivalent one (a constant, a column reference) - only the
+// reserved pack alias survives all of that, and it is what tells a pack apart from a TUPLE/STRUCT the caller passed
+// as an ordinary argument.
+static bool ArgumentsAlreadyPacked(const FunctionSignature &sig, const vector<unique_ptr<Expression>> &arguments) {
+	if (arguments.size() != sig.GetParameterCount()) {
+		return false;
+	}
+	for (idx_t i = 0; i < arguments.size(); i++) {
+		if (!sig.GetParameter(i).IsArgumentPack()) {
+			continue;
+		}
+		if (!arguments[i] || !ArgumentPack::IsPackType(arguments[i]->GetReturnType())) {
+			return false;
+		}
+	}
+	return true;
+}
+
+// Build the TUPLE/STRUCT value that fills a "*args"/"**kwargs" parameter. The parameter's declared type constrains
+// the individual arguments it collects, so they are cast to it here - the pack itself is then already of the exact
+// type the function expects and CastToFunctionArguments leaves it alone.
+static unique_ptr<Expression> BuildArgumentPack(ClientContext &context, const FunctionParameter &param,
+                                                vector<unique_ptr<Expression>> children,
+                                                optional_ptr<const vector<Identifier>> names) {
+	auto element_type = param.GetType();
+	PrepareTypeForCast(element_type);
+	const auto cast_elements = element_type.id() != LogicalTypeId::ANY && element_type.id() != LogicalTypeId::TEMPLATE;
+
+	child_list_t<LogicalType> pack_children;
+	pack_children.reserve(children.size());
+	for (idx_t i = 0; i < children.size(); i++) {
+		if (cast_elements &&
+		    RequiresCast(children[i]->GetReturnType(), element_type) == LogicalTypeComparisonResult::DIFFERENT_TYPES) {
+			children[i] = BoundCastExpression::AddCastToType(context, std::move(children[i]), element_type);
+		}
+		pack_children.emplace_back(names ? (*names)[i] : Identifier(), children[i]->GetReturnType());
+	}
+
+	if (!names) {
+		vector<LogicalType> element_types;
+		element_types.reserve(pack_children.size());
+		for (auto &pack_child : pack_children) {
+			element_types.push_back(std::move(pack_child.second));
+		}
+		return ArgumentPack::Create(std::move(children), ArgumentPack::PositionalType(std::move(element_types)));
+	}
+	return ArgumentPack::Create(std::move(children), ArgumentPack::KeywordType(std::move(pack_children)));
+}
+
+// Resolve the arguments of a function whose signature declares a "*args" and/or "**kwargs" parameter. The trailing
+// positional arguments and the unmatched named arguments are collected into their respective packs, so that the
+// resulting argument list lines up one-to-one with the signature's parameters.
+static vector<Identifier> ResolveArgumentsWithPacks(ClientContext &context, const SimpleFunction &function,
+                                                    vector<unique_ptr<Expression>> &arguments,
+                                                    vector<pair<Identifier, unique_ptr<Expression>>> &named_arguments) {
+	const auto &sig = function.GetSignature();
+	const auto param_count = sig.GetParameterCount();
+	const auto positional_count = sig.GetPositionalParameterCount();
+	const auto var_positional_index = sig.GetVarPositionalIndex();
+	const auto var_keyword_index = sig.GetVarKeywordIndex();
+
+	// collect the trailing positional arguments captured by "*args"
+	vector<unique_ptr<Expression>> var_positional_args;
+	for (idx_t i = positional_count; i < arguments.size(); i++) {
+		if (!var_positional_index.IsValid()) {
+			throw BinderException(arguments[i]->GetQueryLocation(),
+			                      "Function '%s' takes at most %llu positional arguments, but %llu were provided",
+			                      function.GetName(), positional_count, arguments.size());
+		}
+		var_positional_args.push_back(std::move(arguments[i]));
+	}
+	// the slots covered by positional arguments - a named argument targeting one of these is a duplicate
+	const auto provided_positional = MinValue<idx_t>(arguments.size(), positional_count);
+	arguments.resize(param_count);
+
+	// place the named arguments, collecting the ones captured by "**kwargs"
+	vector<pair<Identifier, unique_ptr<Expression>>> var_keyword_args;
+	identifier_set_t seen_names;
+	for (auto &named_argument : named_arguments) {
+		auto &name = named_argument.first;
+		auto &arg = named_argument.second;
+		const auto location = arg->GetQueryLocation();
+
+		if (name.empty()) {
+			throw BinderException(location,
+			                      "Positional arguments cannot follow named arguments in a function call to '%s'",
+			                      function.GetName());
+		}
+		if (seen_names.count(name)) {
+			throw BinderException(location, "Duplicate named argument '%s' in function call to '%s'",
+			                      name.GetIdentifierName(), function.GetName());
+		}
+		seen_names.insert(name);
+
+		const auto opt_param_idx = sig.GetParameterIndexByName(name);
+		if (!opt_param_idx.IsValid()) {
+			if (!var_keyword_index.IsValid()) {
+				throw BinderException(location, "Function '%s' does not have a parameter named '%s'",
+				                      function.GetName(), name);
+			}
+			var_keyword_args.emplace_back(name, std::move(arg));
+			continue;
+		}
+
+		const auto param_idx = opt_param_idx.GetIndex();
+		if (param_idx < provided_positional) {
+			throw BinderException(location,
+			                      "Named argument '%s' cannot be used for parameter '%s' because it has already "
+			                      "been provided as a positional argument in function call to '%s'",
+			                      arg->ToString(), name, function.GetName());
+		}
+		arguments[param_idx] = std::move(arg);
+	}
+
+	// build the packs and fill the remaining slots with their default values
+	vector<Identifier> argument_names(param_count);
+	for (idx_t i = 0; i < param_count; i++) {
+		const auto &param = sig.GetParameter(i);
+		argument_names[i] = param.GetName();
+		if (arguments[i]) {
+			continue;
+		}
+		switch (param.GetKind()) {
+		case FunctionParameterKind::VAR_POSITIONAL:
+			arguments[i] = BuildArgumentPack(context, param, std::move(var_positional_args), nullptr);
+			break;
+		case FunctionParameterKind::VAR_KEYWORD: {
+			vector<Identifier> keyword_names;
+			vector<unique_ptr<Expression>> keyword_children;
+			keyword_names.reserve(var_keyword_args.size());
+			keyword_children.reserve(var_keyword_args.size());
+			for (auto &keyword_arg : var_keyword_args) {
+				keyword_names.push_back(keyword_arg.first);
+				keyword_children.push_back(std::move(keyword_arg.second));
+			}
+			arguments[i] = BuildArgumentPack(context, param, std::move(keyword_children), &keyword_names);
+			break;
+		}
+		default:
+			if (!param.HasDefaultValue()) {
+				throw BinderException("Missing value for parameter '%s' in function call to '%s'", param.GetName(),
+				                      function.GetName());
+			}
+			arguments[i] = make_uniq<BoundConstantExpression>(*param.GetDefaultValue());
+			arguments[i]->SetAlias(param.GetName());
+			break;
+		}
+	}
+	return argument_names;
+}
+
+// Replace the declared element/value type of every "*args"/"**kwargs" slot with the concrete type of the pack that
+// was built for it, so that the bind callback sees the type the function will actually be handed and
+// CastToFunctionArguments does not try to cast the pack to anything.
+static void ApplyArgumentPackTypes(const FunctionSignature &sig, BoundSimpleFunction &bound_function,
+                                   const vector<unique_ptr<Expression>> &arguments) {
+	if (!sig.HasArgumentPacks()) {
+		return;
+	}
+	auto &bound_arguments = bound_function.GetArguments();
+	for (idx_t i = 0; i < MinValue<idx_t>(arguments.size(), bound_arguments.size()); i++) {
+		if (sig.GetParameter(i).IsArgumentPack() && arguments[i]) {
+			bound_arguments[i] = arguments[i]->GetReturnType();
+		}
+	}
+}
+
 // Drain all named argument and insert them in the correct position according to the function signature.
 // Also insert default arguments where needed.
 // Returns the resolved name of every argument slot: the signature parameter name for positional slots, the
 // caller-provided name for named varargs, and an empty identifier for unnamed varargs.
-static vector<Identifier> ResolveArguments(const SimpleFunction &function, vector<unique_ptr<Expression>> &arguments,
+static vector<Identifier> ResolveArguments(ClientContext &context, const SimpleFunction &function,
+                                           vector<unique_ptr<Expression>> &arguments,
                                            vector<pair<Identifier, unique_ptr<Expression>>> &named_arguments) {
 	const auto &sig = function.GetSignature();
+
+	if (sig.HasArgumentPacks()) {
+		if (ArgumentsAlreadyPacked(sig, arguments) && named_arguments.empty()) {
+			vector<Identifier> argument_names(arguments.size());
+			for (idx_t i = 0; i < arguments.size(); i++) {
+				argument_names[i] = sig.GetParameter(i).GetName();
+			}
+			return argument_names;
+		}
+		return ResolveArgumentsWithPacks(context, function, arguments, named_arguments);
+	}
 
 	const auto kwargs_offset = arguments.size();
 
@@ -1060,7 +1271,7 @@ pair<BoundScalarFunction, unique_ptr<FunctionData>>
 FunctionBinder::ResolveFunction(const ScalarFunction &function, vector<unique_ptr<Expression>> &arguments,
                                 vector<pair<Identifier, unique_ptr<Expression>>> &named_arguments) {
 	// Reorder named args
-	auto argument_names = ResolveArguments(function, arguments, named_arguments);
+	auto argument_names = ResolveArguments(context, function, arguments, named_arguments);
 
 	// Make a BoundScalarFunction out of the ScalarFunction, so we can store bind info and other properties in it.
 	BoundScalarFunction bound_function(function);
@@ -1072,6 +1283,10 @@ FunctionBinder::ResolveFunction(const ScalarFunction &function, vector<unique_pt
 			bound_function.GetArguments().push_back(varargs_type);
 		}
 	}
+
+	// A "*args"/"**kwargs" parameter declares the type of the arguments it collects, not the type of the pack that
+	// is handed to the function - fill in the concrete pack type before the "bind" callback runs.
+	ApplyArgumentPackTypes(function.GetSignature(), bound_function, arguments);
 
 	// Attempt to resolve template types, before we call the "Bind" callback.
 	ResolveTemplateTypes(bound_function, arguments);
@@ -1135,7 +1350,7 @@ pair<BoundAggregateFunction, unique_ptr<FunctionData>>
 FunctionBinder::ResolveFunction(const AggregateFunction &function, vector<unique_ptr<Expression>> &children,
                                 vector<pair<Identifier, unique_ptr<Expression>>> &named_arguments) {
 	// Reorder named args
-	auto argument_names = ResolveArguments(function, children, named_arguments);
+	auto argument_names = ResolveArguments(context, function, children, named_arguments);
 
 	// Make a BoundFunction out of the func
 	BoundAggregateFunction bound_function(function);
@@ -1147,6 +1362,10 @@ FunctionBinder::ResolveFunction(const AggregateFunction &function, vector<unique
 			bound_function.GetArguments().push_back(varargs_type);
 		}
 	}
+
+	// A "*args"/"**kwargs" parameter declares the type of the arguments it collects, not the type of the pack that
+	// is handed to the function - fill in the concrete pack type before the "bind" callback runs.
+	ApplyArgumentPackTypes(function.GetSignature(), bound_function, children);
 
 	ResolveTemplateTypes(bound_function, children);
 
@@ -1212,7 +1431,7 @@ FunctionBinder::ResolveFunction(const WindowFunction &function, vector<unique_pt
                                 optional_ptr<vector<OrderByNode>> orders,
                                 optional_ptr<vector<OrderByNode>> arg_orders) {
 	// Reorder named args
-	auto argument_names = ResolveArguments(function, children, named_arguments);
+	auto argument_names = ResolveArguments(context, function, children, named_arguments);
 
 	BoundWindowFunction bound_function(function);
 
@@ -1223,6 +1442,10 @@ FunctionBinder::ResolveFunction(const WindowFunction &function, vector<unique_pt
 			bound_function.GetArguments().push_back(varargs_type);
 		}
 	}
+
+	// A "*args"/"**kwargs" parameter declares the type of the arguments it collects, not the type of the pack that
+	// is handed to the function - fill in the concrete pack type before the "bind" callback runs.
+	ApplyArgumentPackTypes(function.GetSignature(), bound_function, children);
 
 	ResolveTemplateTypes(bound_function, children);
 

--- a/src/function/function_binder.cpp
+++ b/src/function/function_binder.cpp
@@ -350,14 +350,20 @@ optional_idx FunctionBinder::BindFunctionFromArguments(const Identifier &name, c
 	return candidate_functions[0];
 }
 
-template <class T>
-static bool AnyOverloadSupportsImplicitArgumentNames(const FunctionSet<T> &functions) {
-	for (auto &func : functions.functions) {
-		if (func.GetProperties().GetCaptureArgumentAliases()) {
-			return true;
+// Named arguments identify a parameter, so the same name cannot be passed twice - regardless of which overload the
+// call ends up resolving to, or whether the name feeds a parameter or a "**kwargs" pack.
+static void VerifyUniqueArgumentNames(const Identifier &function_name,
+                                      const vector<pair<Identifier, unique_ptr<Expression>>> &arguments) {
+	identifier_set_t seen_names;
+	for (auto &[name, arg] : arguments) {
+		if (name.empty()) {
+			continue;
+		}
+		if (!seen_names.insert(name).second) {
+			throw BinderException(arg->GetQueryLocation(), "Duplicate named argument '%s' in function call to '%s'",
+			                      name.GetIdentifierName(), function_name);
 		}
 	}
-	return false;
 }
 
 static optional_idx PositionalAfterNamedArgumentError(const vector<pair<Identifier, unique_ptr<Expression>>> &arguments,
@@ -382,7 +388,9 @@ template <class T>
 optional_idx FunctionBinder::BindFunctionFromArguments(const Identifier &name, const FunctionSet<T> &functions,
                                                        vector<pair<Identifier, unique_ptr<Expression>>> &arguments,
                                                        ErrorData &error) {
-	// First, attempt a regular bind, splitting the arguments into positional + named just once for all overloads.
+	VerifyUniqueArgumentNames(name, arguments);
+
+	// Split the arguments into positional + named just once for all overloads.
 	vector<LogicalType> positional;
 	vector<pair<Identifier, LogicalType>> named;
 
@@ -391,24 +399,6 @@ optional_idx FunctionBinder::BindFunctionFromArguments(const Identifier &name, c
 	}
 
 	// The split failed because a positional argument follows a named one.
-	// Check if there is any overload that supports implicit argument names.
-	if (AnyOverloadSupportsImplicitArgumentNames(functions)) {
-		// If so, we can attempt to salvage the call by implicitly naming the positional arguments and retrying again
-		for (auto &[name, expr] : arguments) {
-			if (name.empty()) {
-				name = expr->GetAlias();
-			}
-		}
-
-		positional.clear();
-		named.clear();
-
-		if (TrySplitArgumentTypes(arguments, positional, named)) {
-			return BindFunctionFromArguments(name, functions, positional, named, error);
-		}
-	}
-
-	// No overload could rescue the positional-after-named call, give a clear error.
 	return PositionalAfterNamedArgumentError(arguments, error);
 }
 

--- a/src/function/scalar/create_sort_key.cpp
+++ b/src/function/scalar/create_sort_key.cpp
@@ -17,6 +17,9 @@
 #include "duckdb/planner/expression_binder.hpp"
 #include "duckdb/parser/parser.hpp"
 
+#include "duckdb/common/vector/struct_vector.hpp"
+#include "duckdb/planner/expression/bound_argument_pack.hpp"
+
 namespace duckdb {
 
 namespace {
@@ -36,8 +39,27 @@ struct SortKeyBindData : public FunctionData {
 	}
 };
 
+//! The sort specifiers a create_sort_key/decode_sort_key call collected have to be constants, but the keys they
+//! alternate with are ordinary data - so they are read out of the pack one by one rather than by parameter.
+static Value GetSortSpecifier(BindScalarFunctionInput &input, const Expression &expr, const char *what) {
+	if (expr.HasParameter() || expr.GetReturnType().id() == LogicalTypeId::UNKNOWN) {
+		throw ParameterNotResolvedException();
+	}
+	if (!expr.IsFoldable()) {
+		throw BinderException(expr, "The %s in function '%s' must be a constant expression", what,
+		                      input.GetBoundFunction().GetName());
+	}
+	auto value = ExpressionExecutor::EvaluateScalar(input.GetClientContext(), expr);
+	if (value.IsNull()) {
+		throw BinderException(expr, "The %s in function '%s' must not be NULL", what,
+		                      input.GetBoundFunction().GetName());
+	}
+	return value;
+}
+
 unique_ptr<FunctionData> CreateSortKeyBind(BindScalarFunctionInput &input) {
-	auto &arguments = input.GetArguments();
+	// the keys and sort specifiers alternate, and all but the first are collected by a "*args" parameter
+	auto arguments = input.GetUnpackedArguments();
 	auto &function = input.GetBoundFunction();
 
 	if (arguments.size() % 2 != 0) {
@@ -46,7 +68,7 @@ unique_ptr<FunctionData> CreateSortKeyBind(BindScalarFunctionInput &input) {
 	}
 	auto result = make_uniq<SortKeyBindData>();
 	for (idx_t i = 1; i < arguments.size(); i += 2) {
-		auto sort_specifier = input.GetNonNullConstant(i);
+		auto sort_specifier = GetSortSpecifier(input, arguments[i], "sort specifier");
 		auto sort_specifier_str = sort_specifier.ToString();
 		result->modifiers.push_back(OrderModifiers::Parse(sort_specifier_str));
 	}
@@ -54,7 +76,7 @@ unique_ptr<FunctionData> CreateSortKeyBind(BindScalarFunctionInput &input) {
 	bool all_constant = true;
 	idx_t constant_size = 0;
 	for (idx_t i = 0; i < arguments.size(); i += 2) {
-		auto physical_type = arguments[i]->GetReturnType().InternalType();
+		auto physical_type = arguments[i].get().GetReturnType().InternalType();
 		if (!TypeIsConstantSize(physical_type)) {
 			all_constant = false;
 		} else {
@@ -1027,9 +1049,20 @@ static void CreateSortKeyFunction(DataChunk &args, ExpressionState &state, Vecto
 	auto &bind_data = state.expr.Cast<BoundFunctionExpression>().BindInfo()->Cast<SortKeyBindData>();
 
 	// prepare the sort key data
+	vector<reference<Vector>> inputs;
+	for (auto &column : args.data) {
+		if (!ArgumentPack::IsPackType(column.GetType())) {
+			inputs.push_back(column);
+			continue;
+		}
+		for (auto &packed : StructVector::GetEntries(column)) {
+			inputs.push_back(packed);
+		}
+	}
+
 	vector<unique_ptr<SortKeyVectorData>> sort_key_data;
-	for (idx_t c = 0; c < args.ColumnCount(); c += 2) {
-		sort_key_data.push_back(make_uniq<SortKeyVectorData>(args.data[c], args.size(), bind_data.modifiers[c / 2]));
+	for (idx_t c = 0; c < inputs.size(); c += 2) {
+		sort_key_data.push_back(make_uniq<SortKeyVectorData>(inputs[c].get(), args.size(), bind_data.modifiers[c / 2]));
 	}
 	CreateSortKeyInternal(sort_key_data, bind_data.modifiers, bind_data.all_constant, result, args.size());
 #ifdef DEBUG
@@ -1044,7 +1077,9 @@ namespace {
 
 unique_ptr<FunctionData> DecodeSortKeyBind(BindScalarFunctionInput &input) {
 	auto &context = input.GetClientContext();
-	auto &arguments = input.GetArguments();
+	// the column definitions and sort specifiers alternate after the sort key, with the trailing ones collected by
+	// a "*args" parameter
+	auto arguments = input.GetUnpackedArguments();
 	auto &function = input.GetBoundFunction();
 
 	if ((arguments.size() - 1) % 2 != 0) {
@@ -1057,7 +1092,7 @@ unique_ptr<FunctionData> DecodeSortKeyBind(BindScalarFunctionInput &input) {
 	auto result = make_uniq<SortKeyBindData>();
 	for (idx_t i = 1; i < arguments.size(); i += 2) {
 		// Parse column definition
-		Value col = input.GetConstant(i);
+		Value col = GetSortSpecifier(input, arguments[i], "column definition");
 		const auto col_list = Parser::ParseColumnList(col.ToString());
 		if (col_list.LogicalColumnCount() != 1) {
 			throw BinderException("decode_sort_key col must contain exactly one column");
@@ -1079,12 +1114,12 @@ unique_ptr<FunctionData> DecodeSortKeyBind(BindScalarFunctionInput &input) {
 		children.emplace_back(col_name, col_type);
 
 		// Parse sort specifier
-		auto sort_specifier = input.GetNonNullConstant(i + 1);
+		auto sort_specifier = GetSortSpecifier(input, arguments[i + 1], "sort specifier");
 		const auto sort_specifier_str = sort_specifier.ToString();
 		result->modifiers.push_back(OrderModifiers::Parse(sort_specifier_str));
 	}
 
-	const auto &sort_key_arg = *arguments[0];
+	const auto &sort_key_arg = arguments[0].get();
 	if (sort_key_arg.GetReturnType() == LogicalType::BIGINT) {
 		if (!all_constant || constant_size > sizeof(int64_t)) {
 			throw BinderException("sort_key has type BIGINT but arguments require BLOB");
@@ -1512,19 +1547,25 @@ static void DecodeSortKeyFunction(DataChunk &args, ExpressionState &state, Vecto
 // Get Functions
 //===--------------------------------------------------------------------===//
 ScalarFunction CreateSortKeyFun::GetFunction() {
-	ScalarFunction sort_key_function("create_sort_key", {LogicalType::ANY}, LogicalType::BLOB, CreateSortKeyFunction,
-	                                 CreateSortKeyBind);
-	sort_key_function.SetVarArgs(LogicalType::ANY);
+	FunctionSignature signature;
+	signature.AddParameter("key", LogicalType::ANY);
+	signature.AddVarPositionalParameter("args", LogicalType::ANY);
+	signature.SetReturnType(LogicalType::BLOB);
+	ScalarFunction sort_key_function("create_sort_key", std::move(signature), CreateSortKeyFunction);
+	sort_key_function.SetBindCallback(CreateSortKeyBind);
 	sort_key_function.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 	return sort_key_function;
 }
 
 ScalarFunction DecodeSortKeyFun::GetFunction() {
-	ScalarFunction sort_key_function(
-	    "decode_sort_key",
-	    {{"sort_key", LogicalType::ANY}, {"col", LogicalType::VARCHAR}, {"sort_specifier", LogicalType::VARCHAR}},
-	    LogicalType::STRUCT({{"any", LogicalType::ANY}}), DecodeSortKeyFunction, DecodeSortKeyBind);
-	sort_key_function.SetVarArgs(LogicalType::VARCHAR);
+	FunctionSignature signature;
+	signature.AddParameter("sort_key", LogicalType::ANY);
+	signature.AddParameter("col", LogicalType::VARCHAR);
+	signature.AddParameter("sort_specifier", LogicalType::VARCHAR);
+	signature.AddVarPositionalParameter("args", LogicalType::VARCHAR);
+	signature.SetReturnType(LogicalType::STRUCT({{"any", LogicalType::ANY}}));
+	ScalarFunction sort_key_function("decode_sort_key", std::move(signature), DecodeSortKeyFunction);
+	sort_key_function.SetBindCallback(DecodeSortKeyBind);
 	return sort_key_function;
 }
 

--- a/src/function/scalar/generic/constant_or_null.cpp
+++ b/src/function/scalar/generic/constant_or_null.cpp
@@ -4,6 +4,8 @@
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 
+#include "duckdb/common/vector/struct_vector.hpp"
+
 namespace duckdb {
 
 namespace {
@@ -29,10 +31,19 @@ static void ConstantOrNullFunction(DataChunk &args, ExpressionState &state, Vect
 	auto &func_expr = state.expr.Cast<BoundFunctionExpression>();
 	auto &info = func_expr.BindInfo()->Cast<ConstantOrNullBindData>();
 	result.Reference(info.value, count_t(args.size()));
-	for (idx_t idx = 1; idx < args.ColumnCount(); idx++) {
-		switch (args.data[idx].GetVectorType()) {
+
+	// the first argument is the constant, the rest are only inspected for NULLs
+	vector<reference<Vector>> inputs;
+	inputs.push_back(args.data[1]);
+	for (auto &packed : StructVector::GetEntries(args.data[2])) {
+		inputs.push_back(packed);
+	}
+
+	for (auto &input_ref : inputs) {
+		auto &input = input_ref.get();
+		switch (input.GetVectorType()) {
 		case VectorType::FLAT_VECTOR: {
-			auto &input_mask = FlatVector::ValidityMutable(args.data[idx]);
+			auto &input_mask = FlatVector::ValidityMutable(input);
 			if (input_mask.CanHaveNull()) {
 				// there are null values: need to merge them into the result
 				result.Flatten();
@@ -43,10 +54,10 @@ static void ConstantOrNullFunction(DataChunk &args, ExpressionState &state, Vect
 			break;
 		}
 		case VectorType::CONSTANT_VECTOR: {
-			if (ConstantVector::IsNull(args.data[idx])) {
+			if (ConstantVector::IsNull(input)) {
 				// input is constant null, return constant null
 				auto &result_mask = ConstantVector::Validity(result);
-				auto &input_mask = ConstantVector::Validity(args.data[idx]);
+				auto &input_mask = ConstantVector::Validity(input);
 				result_mask.Initialize(input_mask);
 				ConstantVector::SetNull(result, count_t(args.size()));
 				return;
@@ -54,7 +65,7 @@ static void ConstantOrNullFunction(DataChunk &args, ExpressionState &state, Vect
 			break;
 		}
 		default: {
-			auto entries = args.data[idx].Validity();
+			auto entries = input.Validity();
 			if (entries.CanHaveNull()) {
 				result.Flatten();
 				auto &result_mask = FlatVector::ValidityMutable(result);
@@ -75,7 +86,7 @@ unique_ptr<FunctionData> ConstantOrNullBind(BindScalarFunctionInput &input) {
 	auto &function = input.GetBoundFunction();
 
 	auto value = input.GetConstant(0);
-	D_ASSERT(arguments.size() >= 2);
+	D_ASSERT(arguments.size() == 3);
 	function.SetReturnType(arguments[0]->GetReturnType());
 	return make_uniq<ConstantOrNullBindData>(std::move(value));
 }
@@ -97,10 +108,13 @@ bool ConstantOrNull::IsConstantOrNull(BoundFunctionExpression &expr, const Value
 }
 
 ScalarFunction ConstantOrNullFun::GetFunction() {
-	auto fun = ScalarFunction("constant_or_null", {{"arg1", LogicalType::ANY}, {"arg2", LogicalType::ANY}},
-	                          LogicalType::ANY, ConstantOrNullFunction);
+	FunctionSignature signature;
+	signature.AddParameter("arg1", LogicalType::ANY);
+	signature.AddParameter("arg2", LogicalType::ANY);
+	signature.AddVarPositionalParameter("args", LogicalType::ANY);
+	signature.SetReturnType(LogicalType::ANY);
+	ScalarFunction fun("constant_or_null", std::move(signature), ConstantOrNullFunction);
 	fun.SetBindCallback(ConstantOrNullBind);
-	fun.SetVarArgs(LogicalType::ANY);
 	return fun;
 }
 

--- a/src/function/scalar/generic/constant_or_null.cpp
+++ b/src/function/scalar/generic/constant_or_null.cpp
@@ -39,6 +39,16 @@ static void ConstantOrNullFunction(DataChunk &args, ExpressionState &state, Vect
 		inputs.push_back(packed);
 	}
 
+	// a constant NULL anywhere makes the whole result NULL - check for one up front, because merging the other
+	// inputs' validity flattens the result and it can no longer be turned into a constant
+	for (auto &input_ref : inputs) {
+		auto &input = input_ref.get();
+		if (input.GetVectorType() == VectorType::CONSTANT_VECTOR && ConstantVector::IsNull(input)) {
+			ConstantVector::SetNull(result, count_t(args.size()));
+			return;
+		}
+	}
+
 	for (auto &input_ref : inputs) {
 		auto &input = input_ref.get();
 		switch (input.GetVectorType()) {
@@ -53,17 +63,9 @@ static void ConstantOrNullFunction(DataChunk &args, ExpressionState &state, Vect
 			}
 			break;
 		}
-		case VectorType::CONSTANT_VECTOR: {
-			if (ConstantVector::IsNull(input)) {
-				// input is constant null, return constant null
-				auto &result_mask = ConstantVector::Validity(result);
-				auto &input_mask = ConstantVector::Validity(input);
-				result_mask.Initialize(input_mask);
-				ConstantVector::SetNull(result, count_t(args.size()));
-				return;
-			}
+		case VectorType::CONSTANT_VECTOR:
+			// a constant that is not NULL contributes nothing
 			break;
-		}
 		default: {
 			auto entries = input.Validity();
 			if (entries.CanHaveNull()) {

--- a/src/function/scalar/generic/invoke.cpp
+++ b/src/function/scalar/generic/invoke.cpp
@@ -5,6 +5,9 @@
 #include "duckdb/common/serializer/deserializer.hpp"
 #include "duckdb/planner/expression/bound_lambda_expression.hpp"
 
+#include "duckdb/common/vector/struct_vector.hpp"
+#include "duckdb/planner/expression/bound_argument_pack.hpp"
+
 namespace duckdb {
 
 namespace {
@@ -67,15 +70,29 @@ struct LambdaInvokeState final : public FunctionLocalState {
 		}
 		auto &bound_lambda_expr = bdata.lambda_expr->Cast<BoundLambdaExpression>();
 		const auto parameter_count = bound_lambda_expr.ParameterCount();
-		D_ASSERT(parameter_count <= expr.GetChildren().size());
+
+		// the trailing arguments are collected by a "*args" parameter, whose type says what it holds
+		vector<LogicalType> argument_types;
+		for (auto &child : expr.GetChildren()) {
+			auto &child_type = child->GetReturnType();
+			if (!ArgumentPack::IsPackType(child_type)) {
+				argument_types.push_back(child_type);
+				continue;
+			}
+			for (idx_t i = 0; i < StructType::GetChildCount(child_type); i++) {
+				argument_types.push_back(StructType::GetChildType(child_type, i));
+			}
+		}
+
+		D_ASSERT(parameter_count <= argument_types.size());
 
 		vector<LogicalType> input_types;
-		input_types.reserve(expr.GetChildren().size());
+		input_types.reserve(argument_types.size());
 		for (idx_t i = 0; i < parameter_count; i++) {
-			input_types.push_back(expr.GetChildren()[parameter_count - i - 1]->GetReturnType());
+			input_types.push_back(argument_types[parameter_count - i - 1]);
 		}
-		for (idx_t i = parameter_count; i < expr.GetChildren().size(); i++) {
-			input_types.push_back(expr.GetChildren()[i]->GetReturnType());
+		for (idx_t i = parameter_count; i < argument_types.size(); i++) {
+			input_types.push_back(argument_types[i]);
 		}
 
 		auto executor = make_uniq<ExpressionExecutor>(state.GetContext(), *bound_lambda_expr.LambdaExpr());
@@ -85,11 +102,23 @@ struct LambdaInvokeState final : public FunctionLocalState {
 
 void LambdaInvokeFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &lstate = ExecuteFunctionState::GetFunctionState(state)->Cast<LambdaInvokeState>();
-	for (idx_t i = 0; i < lstate.parameter_count; i++) {
-		lstate.input_chunk.data[i].Reference(args.data[lstate.parameter_count - i - 1]);
+
+	vector<reference<Vector>> inputs;
+	for (auto &column : args.data) {
+		if (!ArgumentPack::IsPackType(column.GetType())) {
+			inputs.push_back(column);
+			continue;
+		}
+		for (auto &packed : StructVector::GetEntries(column)) {
+			inputs.push_back(packed);
+		}
 	}
-	for (idx_t i = lstate.parameter_count; i < args.ColumnCount(); i++) {
-		lstate.input_chunk.data[i].Reference(args.data[i]);
+
+	for (idx_t i = 0; i < lstate.parameter_count; i++) {
+		lstate.input_chunk.data[i].Reference(inputs[lstate.parameter_count - i - 1].get());
+	}
+	for (idx_t i = lstate.parameter_count; i < inputs.size(); i++) {
+		lstate.input_chunk.data[i].Reference(inputs[i].get());
 	}
 	lstate.input_chunk.SetChildCardinality(args.size());
 	lstate.executor->ExecuteExpression(lstate.input_chunk, result);
@@ -97,13 +126,13 @@ void LambdaInvokeFunction(DataChunk &args, ExpressionState &state, Vector &resul
 
 unique_ptr<FunctionData> LambdaInvokeBind(BindScalarFunctionInput &input) {
 	auto &bound_function = input.GetBoundFunction();
-	auto &arguments = input.GetArguments();
+	auto arguments = input.GetUnpackedArguments();
 	// the list column and the bound lambda expression
-	if (arguments[0]->GetExpressionClass() != ExpressionClass::BOUND_LAMBDA) {
+	if (arguments[0].get().GetExpressionClass() != ExpressionClass::BOUND_LAMBDA) {
 		throw BinderException("Invalid lambda expression passed to 'invoke' function.");
 	}
 
-	auto &bound_lambda_expr = arguments[0]->Cast<BoundLambdaExpression>();
+	auto &bound_lambda_expr = arguments[0].get().Cast<BoundLambdaExpression>();
 	if (bound_lambda_expr.ParameterCount() != arguments.size() - 1) {
 		throw BinderException("The number of lambda parameters does not match the number of arguments passed to the "
 		                      "'invoke' function, expected %d, got %d.",
@@ -130,9 +159,13 @@ LogicalType LambdaInvokeBindParameters(ClientContext &context, const vector<Logi
 } // namespace
 
 ScalarFunction InvokeFun::GetFunction() {
-	ScalarFunction fun("invoke", {LogicalType::LAMBDA, LogicalType::ANY}, LogicalType::ANY, LambdaInvokeFunction);
+	FunctionSignature signature;
+	signature.AddParameter("lambda", LogicalType::LAMBDA);
+	signature.AddParameter("arg", LogicalType::ANY);
+	signature.AddVarPositionalParameter("args", LogicalType::ANY);
+	signature.SetReturnType(LogicalType::ANY);
+	ScalarFunction fun("invoke", std::move(signature), LambdaInvokeFunction);
 	fun.SetBindCallback(LambdaInvokeBind);
-	fun.SetVarArgs(LogicalType::ANY);
 	fun.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 	fun.SetBindLambdaCallback(LambdaInvokeBindParameters);
 	fun.SetInitStateCallback(LambdaInvokeState::Init);

--- a/src/function/scalar/list/list_zip.cpp
+++ b/src/function/scalar/list/list_zip.cpp
@@ -7,6 +7,8 @@
 #include "duckdb/function/scalar/nested_functions.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/planner/expression_binder.hpp"
+#include "duckdb/common/vector/struct_vector.hpp"
+#include "duckdb/planner/expression/bound_argument_pack.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/planner/expression/bound_parameter_expression.hpp"
 #include "duckdb/common/to_string.hpp"
@@ -15,13 +17,14 @@ namespace duckdb {
 
 static void ListZipFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	idx_t count = args.size();
+	auto &lists = StructVector::GetEntries(args.data[0]);
 	vector<optional<VectorIterator<list_entry_t>>> input_lists;
 	optional<VectorIterator<bool>> truncate_flag;
-	for (idx_t i = 0; i < args.ColumnCount(); i++) {
-		if (i + 1 == args.ColumnCount() && args.data[i].GetType().id() == LogicalTypeId::BOOLEAN) {
-			truncate_flag = args.data[i].Values<bool>();
-		} else if (args.data[i].GetType().id() == LogicalTypeId::LIST) {
-			input_lists.emplace_back(args.data[i].Values<list_entry_t>());
+	for (idx_t i = 0; i < lists.size(); i++) {
+		if (i + 1 == lists.size() && lists[i].GetType().id() == LogicalTypeId::BOOLEAN) {
+			truncate_flag = lists[i].Values<bool>();
+		} else if (lists[i].GetType().id() == LogicalTypeId::LIST) {
+			input_lists.emplace_back(lists[i].Values<list_entry_t>());
 		} else {
 			// SQLNULL — no list iterator possible; treated as always-null input
 			input_lists.emplace_back(nullopt);
@@ -46,7 +49,7 @@ static void ListZipFunction(DataChunk &args, ExpressionState &state, Vector &res
 		idx_t len = truncate_to_shortest ? NumericLimits<idx_t>::Maximum() : 0;
 		for (idx_t i = 0; i < args_size; i++) {
 			idx_t curr_size = 0;
-			if (input_lists[i].has_value() && ListVector::GetListSize(args.data[i]) > 0) {
+			if (input_lists[i].has_value() && ListVector::GetListSize(lists[i]) > 0) {
 				auto list_entry = (*input_lists[i])[row_idx];
 				if (list_entry.IsValid()) {
 					curr_size = list_entry.GetValue().length;
@@ -76,8 +79,8 @@ static void ListZipFunction(DataChunk &args, ExpressionState &state, Vector &res
 
 	// Ensure list children are flat so FlatVector::Validity can be used below
 	for (idx_t i = 0; i < args_size; i++) {
-		if (input_lists[i].has_value() && ListVector::GetListSize(args.data[i]) > 0) {
-			ListVector::GetChildMutable(args.data[i]).Flatten();
+		if (input_lists[i].has_value() && ListVector::GetListSize(lists[i]) > 0) {
+			ListVector::GetChildMutable(lists[i]).Flatten();
 		}
 	}
 
@@ -98,7 +101,7 @@ static void ListZipFunction(DataChunk &args, ExpressionState &state, Vector &res
 					auto copy_len = len < curr_len ? len : curr_len;
 					idx_t entry = offset;
 					for (idx_t k = 0; k < copy_len; k++) {
-						if (!FlatVector::Validity(ListVector::GetChild(args.data[i])).RowIsValid(curr_off + k)) {
+						if (!FlatVector::Validity(ListVector::GetChild(lists[i])).RowIsValid(curr_off + k)) {
 							masks[i].SetInvalid(entry + k);
 						}
 						selections[i].set_index(entry + k, curr_off + k);
@@ -121,13 +124,11 @@ static void ListZipFunction(DataChunk &args, ExpressionState &state, Vector &res
 		offset += len;
 	}
 	for (idx_t child_idx = 0; child_idx < args_size; child_idx++) {
-		if (args.data[child_idx].GetType() == LogicalType::SQLNULL ||
-		    ListVector::GetListSize(args.data[child_idx]) == 0) {
+		if (lists[child_idx].GetType() == LogicalType::SQLNULL || ListVector::GetListSize(lists[child_idx]) == 0) {
 			struct_entries[child_idx].SetVectorType(VectorType::CONSTANT_VECTOR);
 			ConstantVector::SetNull(struct_entries[child_idx], true);
 		} else {
-			struct_entries[child_idx].Slice(ListVector::GetChild(args.data[child_idx]), selections[child_idx],
-			                                result_size);
+			struct_entries[child_idx].Slice(ListVector::GetChild(lists[child_idx]), selections[child_idx], result_size);
 		}
 		struct_entries[child_idx].Flatten();
 		FlatVector::SetValidity((struct_entries[child_idx]), masks[child_idx]);
@@ -137,7 +138,8 @@ static void ListZipFunction(DataChunk &args, ExpressionState &state, Vector &res
 static unique_ptr<FunctionData> ListZipBind(BindScalarFunctionInput &input) {
 	auto &context = input.GetClientContext();
 	auto &bound_function = input.GetBoundFunction();
-	auto &arguments = input.GetArguments();
+	auto &pack = *input.GetArguments()[0];
+	auto &arguments = ArgumentPack::GetPackedChildren(pack);
 	child_list_t<LogicalType> struct_children;
 
 	// The last argument could be a flag to be set if we want a minimal list or a maximal list
@@ -169,13 +171,20 @@ static unique_ptr<FunctionData> ListZipBind(BindScalarFunctionInput &input) {
 			throw BinderException("Parameter type needs to be List");
 		}
 	}
+	// the loop above may have cast some of the collected arguments, so the pack has to describe them again
+	ArgumentPack::RefreshType(pack);
+	bound_function.GetArguments()[0] = pack.GetReturnType();
+
 	bound_function.SetReturnType(LogicalType::LIST(LogicalType::TUPLE(struct_children)));
 	return make_uniq<VariableReturnBindData>(bound_function.GetReturnType());
 }
 
 ScalarFunction ListZipFun::GetFunction() {
-	auto fun = ScalarFunction({}, LogicalType::LIST(LogicalTypeId::STRUCT), ListZipFunction, ListZipBind);
-	fun.SetVarArgs(LogicalType::ANY);
+	FunctionSignature signature;
+	signature.AddVarPositionalParameter("lists", LogicalType::ANY);
+	signature.SetReturnType(LogicalType::LIST(LogicalTypeId::STRUCT));
+	auto fun = ScalarFunction("list_zip", std::move(signature), ListZipFunction);
+	fun.SetBindCallback(ListZipBind);
 	fun.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 	return fun;
 }

--- a/src/function/scalar/string/concat.cpp
+++ b/src/function/scalar/string/concat.cpp
@@ -10,6 +10,10 @@
 
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 
+#include "duckdb/common/vector/struct_vector.hpp"
+#include "duckdb/planner/expression/bound_argument_pack.hpp"
+#include "duckdb/storage/statistics/struct_stats.hpp"
+
 namespace duckdb {
 
 namespace {
@@ -37,12 +41,44 @@ unique_ptr<FunctionData> ConcatFunctionData::Copy() const {
 	return make_uniq<ConcatFunctionData>(return_type, is_operator);
 }
 
+//! The values being concatenated: the concat functions collect theirs with a "*values" parameter, the concat
+//! operator takes two ordinary arguments.
+vector<reference<Vector>> ConcatInputs(DataChunk &args) {
+	vector<reference<Vector>> inputs;
+	for (auto &column : args.data) {
+		if (!ArgumentPack::IsPackType(column.GetType())) {
+			inputs.push_back(column);
+			continue;
+		}
+		for (auto &value : StructVector::GetEntries(column)) {
+			inputs.push_back(value);
+		}
+	}
+	return inputs;
+}
+
+//! The same, for the argument expressions a bind callback sees
+vector<reference<Expression>> ConcatValues(vector<unique_ptr<Expression>> &arguments) {
+	vector<reference<Expression>> values;
+	for (auto &argument : arguments) {
+		if (!ArgumentPack::IsPackType(argument->GetReturnType())) {
+			values.push_back(*argument);
+			continue;
+		}
+		for (auto &value : ArgumentPack::GetPackedChildren(*argument)) {
+			values.push_back(*value);
+		}
+	}
+	return values;
+}
+
 void StringConcatFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto inputs = ConcatInputs(args);
 	// iterate over the vectors to count how large the final string will be
 	idx_t constant_lengths = 0;
 	vector<idx_t> result_lengths(args.size(), 0);
-	for (idx_t col_idx = 0; col_idx < args.ColumnCount(); col_idx++) {
-		const auto &input = args.data[col_idx];
+	for (auto &input_ref : inputs) {
+		const auto &input = input_ref.get();
 		D_ASSERT(input.GetType().InternalType() == PhysicalType::VARCHAR);
 		if (input.GetVectorType() == VectorType::CONSTANT_VECTOR) {
 			if (ConstantVector::IsNull(input)) {
@@ -73,8 +109,8 @@ void StringConcatFunction(DataChunk &args, ExpressionState &state, Vector &resul
 	}
 
 	// now that the empty space for the strings has been allocated, perform the concatenation
-	for (idx_t col_idx = 0; col_idx < args.ColumnCount(); col_idx++) {
-		const auto &input = args.data[col_idx];
+	for (auto &input_ref : inputs) {
+		const auto &input = input_ref.get();
 
 		// loop over the vector and concat to all results
 		if (input.GetVectorType() == VectorType::CONSTANT_VECTOR) {
@@ -143,7 +179,8 @@ void ListConcatFunction(DataChunk &args, ExpressionState &state, Vector &result,
 	auto count = args.size();
 
 	vector<ListConcatInputData> input_data;
-	for (const auto &input : args.data) {
+	for (auto &input_ref : ConcatInputs(args)) {
+		const auto &input = input_ref.get();
 		if (!is_operator && input.GetType().id() == LogicalTypeId::SQLNULL) {
 			// LIST_CONCAT ignores NULL values
 			continue;
@@ -207,6 +244,10 @@ void SetArgumentType(BoundScalarFunction &bound_function, const LogicalType &typ
 	}
 
 	for (auto &arg : bound_function.GetArguments()) {
+		if (ArgumentPack::IsPackType(arg)) {
+			arg = ArgumentPack::PositionalType(vector<LogicalType>(StructType::GetChildCount(arg), type));
+			continue;
+		}
 		arg = type;
 	}
 	bound_function.SetReturnType(type);
@@ -216,8 +257,10 @@ unique_ptr<FunctionData> BindListConcat(ClientContext &context, BoundScalarFunct
                                         vector<unique_ptr<Expression>> &arguments, bool is_operator) {
 	LogicalType child_type = LogicalType::SQLNULL;
 	bool all_null = true;
-	for (auto &arg : arguments) {
-		auto &return_type = arg->GetReturnType();
+	auto values = ConcatValues(arguments);
+	for (auto &value : values) {
+		auto &arg = value.get();
+		auto &return_type = arg.GetReturnType();
 		if (return_type == LogicalTypeId::SQLNULL) {
 			// we mimic postgres behaviour: list_concat(NULL, my_list) = my_list
 			continue;
@@ -235,23 +278,22 @@ unique_ptr<FunctionData> BindListConcat(ClientContext &context, BoundScalarFunct
 			break;
 		default: {
 			string type_list;
-			for (idx_t arg_idx = 0; arg_idx < arguments.size(); arg_idx++) {
+			for (idx_t arg_idx = 0; arg_idx < values.size(); arg_idx++) {
 				if (!type_list.empty()) {
-					if (arg_idx + 1 == arguments.size()) {
+					if (arg_idx + 1 == values.size()) {
 						// last argument
 						type_list += " and ";
 					} else {
 						type_list += ", ";
 					}
 				}
-				type_list += arguments[arg_idx]->GetReturnType().ToString();
+				type_list += values[arg_idx].get().GetReturnType().ToString();
 			}
-			throw BinderException(*arg, "Cannot concatenate types %s - an explicit cast is required", type_list);
+			throw BinderException(arg, "Cannot concatenate types %s - an explicit cast is required", type_list);
 		}
 		}
 		if (!LogicalType::TryGetMaxLogicalType(context, child_type, next_type, child_type)) {
-			throw BinderException(*arg,
-			                      "Cannot concatenate lists of types %s[] and %s[] - an explicit cast is required",
+			throw BinderException(arg, "Cannot concatenate lists of types %s[] and %s[] - an explicit cast is required",
 			                      child_type.ToString(), next_type.ToString());
 		}
 	}
@@ -272,17 +314,18 @@ unique_ptr<FunctionData> BindConcatFunctionInternal(ClientContext &context, Boun
 	bool all_null = true;
 	// blob concat is only supported for the concat operator - regular concat converts to varchar
 	bool all_blob = is_operator ? true : false;
-	for (auto &arg : arguments) {
-		if (arg->GetReturnType().id() == LogicalTypeId::UNKNOWN) {
+	for (auto &value : ConcatValues(arguments)) {
+		auto &return_type = value.get().GetReturnType();
+		if (return_type.id() == LogicalTypeId::UNKNOWN) {
 			throw ParameterNotResolvedException();
 		}
-		if (arg->GetReturnType().id() == LogicalTypeId::LIST || arg->GetReturnType().id() == LogicalTypeId::ARRAY) {
+		if (return_type.id() == LogicalTypeId::LIST || return_type.id() == LogicalTypeId::ARRAY) {
 			list_concat = true;
 		}
-		if (arg->GetReturnType().id() != LogicalTypeId::BLOB) {
+		if (return_type.id() != LogicalTypeId::BLOB) {
 			all_blob = false;
 		}
-		if (arg->GetReturnType().id() != LogicalTypeId::SQLNULL) {
+		if (return_type.id() != LogicalTypeId::SQLNULL) {
 			all_null = false;
 		}
 	}
@@ -295,9 +338,16 @@ unique_ptr<FunctionData> BindConcatFunctionInternal(ClientContext &context, Boun
 			return make_uniq<ConcatFunctionData>(bound_function.GetReturnType(), is_operator);
 		}
 
+		// tell list_concat apart from concat by the type its parameter accepts - for list_concat that is the
+		// element type of the "*lists" parameter, which the pack carries for every value it collected
 		const auto &func_args = bound_function.GetArguments();
-		if (!func_args.empty() &&
-		    (func_args[0].id() == LogicalTypeId::LIST || func_args[0].id() == LogicalTypeId::ARRAY)) {
+		auto first_arg = LogicalType(LogicalTypeId::INVALID);
+		if (!func_args.empty()) {
+			first_arg = ArgumentPack::IsPackType(func_args[0]) && StructType::GetChildCount(func_args[0]) > 0
+			                ? StructType::GetChildType(func_args[0], 0)
+			                : func_args[0];
+		}
+		if (first_arg.id() == LogicalTypeId::LIST || first_arg.id() == LogicalTypeId::ARRAY) {
 			SetArgumentType(bound_function, LogicalTypeId::SQLNULL, is_operator);
 			return make_uniq<ConcatFunctionData>(bound_function.GetReturnType(), is_operator);
 		}
@@ -326,11 +376,30 @@ unique_ptr<FunctionData> BindConcatOperator(BindScalarFunctionInput &input) {
 	return BindConcatFunctionInternal(context, bound_function, arguments, true);
 }
 
+void MergeConcatStats(unique_ptr<BaseStatistics> &stats, const BaseStatistics &next) {
+	if (!stats) {
+		stats = next.ToUnique();
+		return;
+	}
+	stats->Merge(next);
+}
+
 unique_ptr<BaseStatistics> ListConcatStats(ClientContext &context, FunctionStatisticsInput &input) {
 	auto &child_stats = input.child_stats;
-	auto stats = child_stats[0].ToUnique();
-	for (idx_t i = 1; i < child_stats.size(); i++) {
-		stats->Merge(child_stats[i]);
+	auto &expr = input.expr;
+
+	// the lists are collected by a "*lists" parameter, so their statistics are the pack's member statistics
+	unique_ptr<BaseStatistics> stats;
+	for (idx_t i = 0; i < child_stats.size(); i++) {
+		auto &child_type = expr.GetChildren()[i]->GetReturnType();
+		if (!ArgumentPack::IsPackType(child_type)) {
+			MergeConcatStats(stats, child_stats[i]);
+			continue;
+		}
+		const auto member_count = StructType::GetChildCount(child_type);
+		for (idx_t member = 0; member < member_count; member++) {
+			MergeConcatStats(stats, StructStats::GetChildStats(child_stats[i], member));
+		}
 	}
 	return stats;
 }
@@ -339,9 +408,12 @@ unique_ptr<BaseStatistics> ListConcatStats(ClientContext &context, FunctionStati
 
 ScalarFunction ListConcatFun::GetFunction() {
 	// The arguments and return types are set in the binder function.
-	auto fun =
-	    ScalarFunction({}, LogicalType::LIST(LogicalType::ANY), ConcatFunction, BindConcatFunction, ListConcatStats);
-	fun.SetVarArgs(LogicalType::LIST(LogicalType::ANY));
+	FunctionSignature signature;
+	signature.AddVarPositionalParameter("lists", LogicalType::LIST(LogicalType::ANY));
+	signature.SetReturnType(LogicalType::LIST(LogicalType::ANY));
+	auto fun = ScalarFunction("list_concat", std::move(signature), ConcatFunction);
+	fun.SetBindCallback(BindConcatFunction);
+	fun.SetStatisticsCallback(ListConcatStats);
 	fun.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 	return fun;
 }
@@ -355,9 +427,12 @@ ScalarFunction ListConcatFun::GetFunction() {
 // the concat function, however, treats NULL values as an empty string
 // i.e. concat(NULL, 'hello') = 'hello'
 ScalarFunction ConcatFun::GetFunction() {
-	ScalarFunction concat =
-	    ScalarFunction("concat", {LogicalType::ANY}, LogicalType::ANY, ConcatFunction, BindConcatFunction);
-	concat.SetVarArgs(LogicalType::ANY);
+	FunctionSignature signature;
+	signature.AddParameter("value", LogicalType::ANY);
+	signature.AddVarPositionalParameter("values", LogicalType::ANY);
+	signature.SetReturnType(LogicalType::ANY);
+	ScalarFunction concat("concat", std::move(signature), ConcatFunction);
+	concat.SetBindCallback(BindConcatFunction);
 	concat.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 	return concat;
 }

--- a/src/function/scalar/string/concat_ws.cpp
+++ b/src/function/scalar/string/concat_ws.cpp
@@ -1,4 +1,6 @@
+#include "duckdb/common/vector/struct_vector.hpp"
 #include "duckdb/function/scalar/string_functions.hpp"
+#include "duckdb/planner/expression/bound_argument_pack.hpp"
 
 #include <string.h>
 
@@ -8,9 +10,11 @@ static void ConcatWSFunction(DataChunk &args, ExpressionState &state, Vector &re
 	auto count = args.size();
 	auto sep_data = args.data[0].Values<string_t>();
 	vector<VectorIterator<string_t>> iterators;
-	for (idx_t col_idx = 1; col_idx < args.ColumnCount(); col_idx++) {
-		iterators.emplace_back(args.data[col_idx].Values<string_t>());
+	iterators.emplace_back(args.data[1].Values<string_t>());
+	for (auto &value : StructVector::GetEntries(args.data[2])) {
+		iterators.emplace_back(value.Values<string_t>());
 	}
+	const auto value_count = iterators.size();
 
 	auto result_data = FlatVector::Writer<string_t>(result, count);
 	for (idx_t r = 0; r < count; r++) {
@@ -26,8 +30,8 @@ static void ConcatWSFunction(DataChunk &args, ExpressionState &state, Vector &re
 		// first figure out the length of the result string
 		idx_t result_length = 0;
 		bool has_result = false;
-		for (idx_t col_idx = 1; col_idx < args.ColumnCount(); col_idx++) {
-			auto &idata = iterators[col_idx - 1];
+		for (idx_t col_idx = 0; col_idx < value_count; col_idx++) {
+			auto &idata = iterators[col_idx];
 			auto input = idata[r];
 			if (!input.IsValid()) {
 				continue;
@@ -43,8 +47,8 @@ static void ConcatWSFunction(DataChunk &args, ExpressionState &state, Vector &re
 		// now write the result string
 		result_length = 0;
 		has_result = false;
-		for (idx_t col_idx = 1; col_idx < args.ColumnCount(); col_idx++) {
-			auto &idata = iterators[col_idx - 1];
+		for (idx_t col_idx = 0; col_idx < value_count; col_idx++) {
+			auto &idata = iterators[col_idx];
 			auto input = idata[r];
 			if (!input.IsValid()) {
 				continue;
@@ -64,9 +68,13 @@ static void ConcatWSFunction(DataChunk &args, ExpressionState &state, Vector &re
 
 static unique_ptr<FunctionData> BindConcatWSFunction(BindScalarFunctionInput &input) {
 	auto &bound_function = input.GetBoundFunction();
-	for (auto &arg : bound_function.GetArguments()) {
-		arg = LogicalType::VARCHAR;
-	}
+	auto &arguments = bound_function.GetArguments();
+	D_ASSERT(arguments.size() == 3);
+	// every value is concatenated as a string, including the ones collected by "*values"
+	arguments[0] = LogicalType::VARCHAR;
+	arguments[1] = LogicalType::VARCHAR;
+	const auto packed_count = StructType::GetChildCount(arguments[2]);
+	arguments[2] = ArgumentPack::PositionalType(vector<LogicalType>(packed_count, LogicalType::VARCHAR));
 	return nullptr;
 }
 
@@ -79,9 +87,13 @@ ScalarFunction ConcatWsFun::GetFunction() {
 	// concat_ws(',', NULL, NULL) = ""
 	// concat_ws(',', '', '') = ","
 
-	ScalarFunction concat_ws = ScalarFunction("concat_ws", {LogicalType::VARCHAR, LogicalType::ANY},
-	                                          LogicalType::VARCHAR, ConcatWSFunction, BindConcatWSFunction);
-	concat_ws.SetVarArgs(LogicalType::ANY);
+	FunctionSignature signature;
+	signature.AddParameter("separator", LogicalType::VARCHAR);
+	signature.AddParameter("value", LogicalType::ANY);
+	signature.AddVarPositionalParameter("values", LogicalType::ANY);
+	signature.SetReturnType(LogicalType::VARCHAR);
+	ScalarFunction concat_ws("concat_ws", std::move(signature), ConcatWSFunction);
+	concat_ws.SetBindCallback(BindConcatWSFunction);
 	concat_ws.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 	return ScalarFunction(concat_ws);
 }

--- a/src/function/scalar/string/concat_ws.cpp
+++ b/src/function/scalar/string/concat_ws.cpp
@@ -89,9 +89,10 @@ ScalarFunction ConcatWsFun::GetFunction() {
 
 	FunctionSignature signature;
 	signature.AddParameter("separator", LogicalType::VARCHAR);
-	signature.AddParameter("value", LogicalType::ANY);
-	signature.AddVarPositionalParameter("values", LogicalType::ANY);
+	signature.AddParameter("arg", LogicalType::ANY);
+	signature.AddVarPositionalParameter("args", LogicalType::ANY);
 	signature.SetReturnType(LogicalType::VARCHAR);
+
 	ScalarFunction concat_ws("concat_ws", std::move(signature), ConcatWSFunction);
 	concat_ws.SetBindCallback(BindConcatWSFunction);
 	concat_ws.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);

--- a/src/function/scalar/string/path_join.cpp
+++ b/src/function/scalar/string/path_join.cpp
@@ -1,7 +1,7 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/types/vector.hpp"
-#include "duckdb/common/vector/struct_vector.hpp"
+#include "duckdb/planner/expression/bound_argument_pack.hpp"
 #include "duckdb/function/scalar/string_functions.hpp"
 
 namespace duckdb {
@@ -26,7 +26,7 @@ public:
 };
 
 // Process one output row; returns false if any input is NULL.
-static bool ProcessRow(idx_t row_idx, const vector<VectorIterator<string_t>> &inputs, idx_t col_count,
+bool ProcessRow(idx_t row_idx, const vector<VectorIterator<string_t>> &inputs, idx_t col_count,
                        string &out_result) {
 	Path out_path;
 	for (idx_t col_idx = 0; col_idx < col_count; col_idx++) {
@@ -50,10 +50,10 @@ void PathJoinFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto count = args.size();
 	vector<VectorIterator<string_t>> inputs;
 	inputs.emplace_back(args.data[0].Values<string_t>());
-	for (auto &path : StructVector::GetEntries(args.data[1])) {
+	for (const auto &path : ArgumentPack::GetInput(args.data[1])) {
 		inputs.emplace_back(path.Values<string_t>());
 	}
-	auto col_count = inputs.size();
+	const auto col_count = inputs.size();
 
 	auto result_data = FlatVector::Writer<string_t>(result, count);
 	for (idx_t row_idx = 0; row_idx < count; row_idx++) {
@@ -69,15 +69,17 @@ void PathJoinFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 } // namespace
 
 ScalarFunction PathJoinFun::GetFunction() {
-	FunctionSignature signature;
-	signature.AddParameter("path", LogicalType::VARCHAR);
-	signature.AddVarPositionalParameter("paths", LogicalType::VARCHAR);
-	signature.SetReturnType(LogicalType::VARCHAR);
-	ScalarFunction path_join(PathJoinFun::Name, std::move(signature), PathJoinFunction);
-	path_join.SetNullHandling(FunctionNullHandling::DEFAULT_NULL_HANDLING);
-	// throws if the paths that are joined are incompatible
-	path_join.SetFallible();
-	return path_join;
+	auto sig = FunctionSignature()
+		.AddParameter("path", LogicalType::VARCHAR)
+		.AddVarPositionalParameter("paths", LogicalType::VARCHAR)
+		.SetReturnType(LogicalType::VARCHAR);
+
+	auto fun = ScalarFunction(PathJoinFun::Name, std::move(sig))
+		.SetFunctionCallback(PathJoinFunction)
+		.SetNullHandling(FunctionNullHandling::DEFAULT_NULL_HANDLING)
+		.SetFallible(); // throws if the paths that are joined are incompatible
+
+	return fun;
 }
 
 } // namespace duckdb

--- a/src/function/scalar/string/path_join.cpp
+++ b/src/function/scalar/string/path_join.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/types/vector.hpp"
+#include "duckdb/common/vector/struct_vector.hpp"
 #include "duckdb/function/scalar/string_functions.hpp"
 
 namespace duckdb {
@@ -47,11 +48,12 @@ static bool ProcessRow(idx_t row_idx, const vector<VectorIterator<string_t>> &in
 
 void PathJoinFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto count = args.size();
-	auto col_count = args.ColumnCount();
 	vector<VectorIterator<string_t>> inputs;
-	for (idx_t col_idx = 0; col_idx < args.ColumnCount(); col_idx++) {
-		inputs.emplace_back(args.data[col_idx].Values<string_t>());
+	inputs.emplace_back(args.data[0].Values<string_t>());
+	for (auto &path : StructVector::GetEntries(args.data[1])) {
+		inputs.emplace_back(path.Values<string_t>());
 	}
+	auto col_count = inputs.size();
 
 	auto result_data = FlatVector::Writer<string_t>(result, count);
 	for (idx_t row_idx = 0; row_idx < count; row_idx++) {
@@ -67,8 +69,11 @@ void PathJoinFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 } // namespace
 
 ScalarFunction PathJoinFun::GetFunction() {
-	ScalarFunction path_join(PathJoinFun::Name, {LogicalType::VARCHAR}, LogicalType::VARCHAR, PathJoinFunction);
-	path_join.SetVarArgs(LogicalType::VARCHAR);
+	FunctionSignature signature;
+	signature.AddParameter("path", LogicalType::VARCHAR);
+	signature.AddVarPositionalParameter("paths", LogicalType::VARCHAR);
+	signature.SetReturnType(LogicalType::VARCHAR);
+	ScalarFunction path_join(PathJoinFun::Name, std::move(signature), PathJoinFunction);
 	path_join.SetNullHandling(FunctionNullHandling::DEFAULT_NULL_HANDLING);
 	// throws if the paths that are joined are incompatible
 	path_join.SetFallible();

--- a/src/function/scalar/string/path_join.cpp
+++ b/src/function/scalar/string/path_join.cpp
@@ -26,8 +26,7 @@ public:
 };
 
 // Process one output row; returns false if any input is NULL.
-bool ProcessRow(idx_t row_idx, const vector<VectorIterator<string_t>> &inputs, idx_t col_count,
-                       string &out_result) {
+bool ProcessRow(idx_t row_idx, const vector<VectorIterator<string_t>> &inputs, idx_t col_count, string &out_result) {
 	Path out_path;
 	for (idx_t col_idx = 0; col_idx < col_count; col_idx++) {
 		auto &vdata = inputs[col_idx];
@@ -70,14 +69,14 @@ void PathJoinFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 
 ScalarFunction PathJoinFun::GetFunction() {
 	auto sig = FunctionSignature()
-		.AddParameter("path", LogicalType::VARCHAR)
-		.AddVarPositionalParameter("paths", LogicalType::VARCHAR)
-		.SetReturnType(LogicalType::VARCHAR);
+	               .AddParameter("path", LogicalType::VARCHAR)
+	               .AddVarPositionalParameter("paths", LogicalType::VARCHAR)
+	               .SetReturnType(LogicalType::VARCHAR);
 
 	auto fun = ScalarFunction(PathJoinFun::Name, std::move(sig))
-		.SetFunctionCallback(PathJoinFunction)
-		.SetNullHandling(FunctionNullHandling::DEFAULT_NULL_HANDLING)
-		.SetFallible(); // throws if the paths that are joined are incompatible
+	               .SetFunctionCallback(PathJoinFunction)
+	               .SetNullHandling(FunctionNullHandling::DEFAULT_NULL_HANDLING)
+	               .SetFallible(); // throws if the paths that are joined are incompatible
 
 	return fun;
 }

--- a/src/function/scalar/string/regexp.cpp
+++ b/src/function/scalar/string/regexp.cpp
@@ -407,11 +407,11 @@ ScalarFunctionSet RegexpFun::GetFunctions() {
 	regexp_full_match.AddFunction(
 	    ScalarFunction({{"string", LogicalType::VARCHAR}, {"regex", LogicalType::VARCHAR}}, LogicalType::BOOLEAN,
 	                   RegexpMatchesFunction<RegexFullMatch>, RegexpMatchesBind, nullptr, RegexInitLocalState,
-	                   LogicalType::INVALID, FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING));
+	                   FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING));
 	regexp_full_match.AddFunction(ScalarFunction(
 	    {{"string", LogicalType::VARCHAR}, {"regex", LogicalType::VARCHAR}, {"options", LogicalType::VARCHAR}},
 	    LogicalType::BOOLEAN, RegexpMatchesFunction<RegexFullMatch>, RegexpMatchesBind, nullptr, RegexInitLocalState,
-	    LogicalType::INVALID, FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING));
+	    FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING));
 	for (auto &func : regexp_full_match.functions) {
 		func.SetFallible();
 	}
@@ -423,11 +423,11 @@ ScalarFunctionSet RegexpMatchesFun::GetFunctions() {
 	regexp_partial_match.AddFunction(
 	    ScalarFunction({{"string", LogicalType::VARCHAR}, {"regex", LogicalType::VARCHAR}}, LogicalType::BOOLEAN,
 	                   RegexpMatchesFunction<RegexPartialMatch>, RegexpMatchesBind, nullptr, RegexInitLocalState,
-	                   LogicalType::INVALID, FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING));
+	                   FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING));
 	regexp_partial_match.AddFunction(ScalarFunction(
 	    {{"string", LogicalType::VARCHAR}, {"regex", LogicalType::VARCHAR}, {"options", LogicalType::VARCHAR}},
 	    LogicalType::BOOLEAN, RegexpMatchesFunction<RegexPartialMatch>, RegexpMatchesBind, nullptr, RegexInitLocalState,
-	    LogicalType::INVALID, FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING));
+	    FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING));
 	for (auto &func : regexp_partial_match.functions) {
 		func.SetFallible();
 	}
@@ -454,34 +454,34 @@ ScalarFunctionSet RegexpExtractFun::GetFunctions() {
 	ScalarFunctionSet regexp_extract("regexp_extract");
 	regexp_extract.AddFunction(ScalarFunction({{"string", LogicalType::VARCHAR}, {"regex", LogicalType::VARCHAR}},
 	                                          LogicalType::VARCHAR, RegexExtractFunction, RegexExtractBind, nullptr,
-	                                          RegexInitLocalState, LogicalType::INVALID, FunctionStability::CONSISTENT,
+	                                          RegexInitLocalState, FunctionStability::CONSISTENT,
 	                                          FunctionNullHandling::SPECIAL_HANDLING));
 	regexp_extract.AddFunction(ScalarFunction(
 	    {{"string", LogicalType::VARCHAR}, {"regex", LogicalType::VARCHAR}, {"group", LogicalType::INTEGER}},
 	    LogicalType::VARCHAR, RegexExtractFunction, RegexExtractBind, nullptr, RegexInitLocalState,
-	    LogicalType::INVALID, FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING));
+	    FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING));
 	regexp_extract.AddFunction(ScalarFunction({{"string", LogicalType::VARCHAR},
 	                                           {"regex", LogicalType::VARCHAR},
 	                                           {"group", LogicalType::INTEGER},
 	                                           {"options", LogicalType::VARCHAR}},
 	                                          LogicalType::VARCHAR, RegexExtractFunction, RegexExtractBind, nullptr,
-	                                          RegexInitLocalState, LogicalType::INVALID, FunctionStability::CONSISTENT,
+	                                          RegexInitLocalState, FunctionStability::CONSISTENT,
 	                                          FunctionNullHandling::SPECIAL_HANDLING));
 	// REGEXP_EXTRACT(<string>, <pattern>, [<group 1 name>[, <group n name>]...])
 	regexp_extract.AddFunction(ScalarFunction({{"string", LogicalType::VARCHAR},
 	                                           {"regex", LogicalType::VARCHAR},
 	                                           {"name_list", LogicalType::LIST(LogicalType::VARCHAR)}},
 	                                          LogicalType::VARCHAR, RegexExtractStructFunction, RegexExtractBind,
-	                                          nullptr, RegexInitLocalState, LogicalType::INVALID,
-	                                          FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING));
+	                                          nullptr, RegexInitLocalState, FunctionStability::CONSISTENT,
+	                                          FunctionNullHandling::SPECIAL_HANDLING));
 	// REGEXP_EXTRACT(<string>, <pattern>, [<group 1 name>[, <group n name>]...], <options>)
 	regexp_extract.AddFunction(ScalarFunction({{"string", LogicalType::VARCHAR},
 	                                           {"regex", LogicalType::VARCHAR},
 	                                           {"name_list", LogicalType::LIST(LogicalType::VARCHAR)},
 	                                           {"options", LogicalType::VARCHAR}},
 	                                          LogicalType::VARCHAR, RegexExtractStructFunction, RegexExtractBind,
-	                                          nullptr, RegexInitLocalState, LogicalType::INVALID,
-	                                          FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING));
+	                                          nullptr, RegexInitLocalState, FunctionStability::CONSISTENT,
+	                                          FunctionNullHandling::SPECIAL_HANDLING));
 	return (regexp_extract);
 }
 
@@ -490,20 +490,18 @@ ScalarFunctionSet RegexpExtractAllFun::GetFunctions() {
 	regexp_extract_all.AddFunction(ScalarFunction(
 	    {{"string", LogicalType::VARCHAR}, {"regex", LogicalType::VARCHAR}}, LogicalType::LIST(LogicalType::VARCHAR),
 	    RegexpExtractAll::Execute, RegexpExtractAll::Bind, nullptr, RegexpExtractAll::InitLocalState,
-	    LogicalType::INVALID, FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING));
+	    FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING));
 	regexp_extract_all.AddFunction(ScalarFunction(
 	    {{"string", LogicalType::VARCHAR}, {"regex", LogicalType::VARCHAR}, {"group", LogicalType::INTEGER}},
 	    LogicalType::LIST(LogicalType::VARCHAR), RegexpExtractAll::Execute, RegexpExtractAll::Bind, nullptr,
-	    RegexpExtractAll::InitLocalState, LogicalType::INVALID, FunctionStability::CONSISTENT,
-	    FunctionNullHandling::SPECIAL_HANDLING));
-	regexp_extract_all.AddFunction(ScalarFunction({{"string", LogicalType::VARCHAR},
-	                                               {"regex", LogicalType::VARCHAR},
-	                                               {"group", LogicalType::INTEGER},
-	                                               {"options", LogicalType::VARCHAR}},
-	                                              LogicalType::LIST(LogicalType::VARCHAR), RegexpExtractAll::Execute,
-	                                              RegexpExtractAll::Bind, nullptr, RegexpExtractAll::InitLocalState,
-	                                              LogicalType::INVALID, FunctionStability::CONSISTENT,
-	                                              FunctionNullHandling::SPECIAL_HANDLING));
+	    RegexpExtractAll::InitLocalState, FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING));
+	regexp_extract_all.AddFunction(ScalarFunction(
+	    {{"string", LogicalType::VARCHAR},
+	     {"regex", LogicalType::VARCHAR},
+	     {"group", LogicalType::INTEGER},
+	     {"options", LogicalType::VARCHAR}},
+	    LogicalType::LIST(LogicalType::VARCHAR), RegexpExtractAll::Execute, RegexpExtractAll::Bind, nullptr,
+	    RegexpExtractAll::InitLocalState, FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING));
 	// Struct multi-match variant(s): pattern must be constant due to bind-time struct shape inference
 	regexp_extract_all.AddFunction(ScalarFunction(
 	    {{"string", LogicalType::VARCHAR},
@@ -511,7 +509,7 @@ ScalarFunctionSet RegexpExtractAllFun::GetFunctions() {
 	     {"name_list", LogicalType::LIST(LogicalType::VARCHAR)}},
 	    LogicalType::LIST(LogicalType::VARCHAR), // temporary, replaced in bind
 	    RegexpExtractAllStruct::Execute, RegexpExtractAllStruct::Bind, nullptr, RegexpExtractAllStruct::InitLocalState,
-	    LogicalType::INVALID, FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING));
+	    FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING));
 	regexp_extract_all.AddFunction(ScalarFunction(
 	    {{"string", LogicalType::VARCHAR},
 	     {"regex", LogicalType::VARCHAR},
@@ -519,7 +517,7 @@ ScalarFunctionSet RegexpExtractAllFun::GetFunctions() {
 	     {"options", LogicalType::VARCHAR}},
 	    LogicalType::LIST(LogicalType::VARCHAR), // temporary, replaced in bind
 	    RegexpExtractAllStruct::Execute, RegexpExtractAllStruct::Bind, nullptr, RegexpExtractAllStruct::InitLocalState,
-	    LogicalType::INVALID, FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING));
+	    FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING));
 	// throws when accessing a group that the pattern does not have
 	regexp_extract_all.SetFallible();
 	return (regexp_extract_all);

--- a/src/function/scalar/string/string_split.cpp
+++ b/src/function/scalar/string/string_split.cpp
@@ -149,8 +149,8 @@ ScalarFunctionSet StringSplitRegexFun::GetFunctions() {
 	auto varchar_list_type = LogicalType::LIST(LogicalType::VARCHAR);
 	ScalarFunctionSet regexp_split;
 	ScalarFunction regex_fun({LogicalType::VARCHAR, LogicalType::VARCHAR}, varchar_list_type, StringSplitRegexFunction,
-	                         RegexpMatchesBind, nullptr, RegexInitLocalState, LogicalType::INVALID,
-	                         FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING);
+	                         RegexpMatchesBind, nullptr, RegexInitLocalState, FunctionStability::CONSISTENT,
+	                         FunctionNullHandling::SPECIAL_HANDLING);
 	regexp_split.AddFunction(regex_fun);
 	// regexp options
 	regex_fun.GetSignature().AddParameter(LogicalType::VARCHAR);

--- a/src/function/scalar/struct/struct_concat.cpp
+++ b/src/function/scalar/struct/struct_concat.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/function/scalar/struct_functions.hpp"
 #include "duckdb/common/case_insensitive_map.hpp"
 #include "duckdb/planner/expression_binder.hpp"
+#include "duckdb/planner/expression/bound_argument_pack.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/storage/statistics/struct_stats.hpp"
 
@@ -11,22 +12,36 @@ namespace duckdb {
 
 static void StructConcatFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &result_cols = StructVector::GetEntries(result);
+
+	const auto &head = args.data[0];
+	const auto &tail = ArgumentPack::GetInput(args.data[1]);
+
 	idx_t offset = 0;
-	for (const auto &arg : args.data) {
-		const auto &child_cols = StructVector::GetEntries(arg);
-		for (auto &child_col : child_cols) {
+
+	for (auto &child_col : StructVector::GetEntries(head)) {
+		result_cols[offset++].Reference(child_col);
+	}
+
+	for (const auto &arg : tail) {
+		for (auto &child_col : StructVector::GetEntries(arg)) {
 			result_cols[offset++].Reference(child_col);
 		}
 	}
+
 	D_ASSERT(offset == result_cols.size());
 }
 
 static unique_ptr<FunctionData> StructConcatBind(BindScalarFunctionInput &input) {
 	auto &bound_function = input.GetBoundFunction();
-	auto &arguments = input.GetArguments();
-	// collect names and deconflict, construct return type
-	if (arguments.empty()) {
-		throw InvalidInputException("struct_concat: At least one argument is required");
+
+	auto &raw_args = input.GetArguments();
+
+	bound_function.GetArguments()[0] = raw_args[0]->GetReturnType();
+
+	vector<reference<unique_ptr<Expression>>> arguments;
+	arguments.emplace_back(raw_args[0]);
+	for (auto &arg : ArgumentPack::GetPackedChildren(*raw_args[1])) {
+		arguments.emplace_back(arg);
 	}
 
 	child_list_t<LogicalType> combined_children;
@@ -37,15 +52,15 @@ static unique_ptr<FunctionData> StructConcatBind(BindScalarFunctionInput &input)
 	for (idx_t arg_idx = 0; arg_idx < arguments.size(); arg_idx++) {
 		const auto &arg = arguments[arg_idx];
 
-		if (arg->GetReturnType().id() == LogicalTypeId::UNKNOWN) {
+		if (arg.get()->GetReturnType().id() == LogicalTypeId::UNKNOWN) {
 			throw ParameterNotResolvedException();
 		}
 
-		if (!StructType::IsStruct(arg->GetReturnType())) {
+		if (!StructType::IsStruct(arg.get()->GetReturnType())) {
 			throw InvalidInputException("struct_concat: Argument at position \"%d\" is not a STRUCT", arg_idx + 1);
 		}
 
-		const auto &child_types = StructType::GetChildTypes(arg->GetReturnType());
+		const auto &child_types = StructType::GetChildTypes(arg.get()->GetReturnType());
 		for (const auto &child : child_types) {
 			if (!child.first.empty()) {
 				auto it = name_set.find(child.first);
@@ -82,28 +97,42 @@ static unique_ptr<FunctionData> StructConcatBind(BindScalarFunctionInput &input)
 static unique_ptr<BaseStatistics> StructConcatStats(ClientContext &context, FunctionStatisticsInput &input) {
 	const auto &expr = input.expr;
 
-	auto &arg_stats = input.child_stats;
-	auto &arg_exprs = input.expr.GetChildren();
+	const auto &head_stats = input.child_stats[0];
+	const auto &tail_stats = input.child_stats[1];
 
 	auto struct_stats = StructStats::CreateUnknown(expr.GetReturnType());
-	idx_t struct_index = 0;
 
-	for (idx_t arg_idx = 0; arg_idx < arg_exprs.size(); arg_idx++) {
-		auto &arg_stat = arg_stats[arg_idx];
-		auto &arg_type = arg_exprs[arg_idx]->GetReturnType();
-		for (idx_t child_idx = 0; child_idx < StructType::GetChildCount(arg_type); child_idx++) {
-			auto &child_stat = StructStats::GetChildStats(arg_stat, child_idx);
-			StructStats::SetChildStats(struct_stats, struct_index++, child_stat);
+	idx_t offset = 0;
+
+	for (idx_t child_idx = 0; child_idx < StructType::GetChildCount(head_stats.GetType()); child_idx++) {
+		auto &child_stat = StructStats::GetChildStats(head_stats, child_idx);
+		StructStats::SetChildStats(struct_stats, offset++, child_stat);
+	}
+
+	for (idx_t tail_idx = 0; tail_idx < StructType::GetChildCount(tail_stats.GetType()); tail_idx++) {
+		auto &tail_stat = StructStats::GetChildStats(tail_stats, tail_idx);
+
+		for (idx_t child_idx = 0; child_idx < StructType::GetChildCount(tail_stat.GetType()); child_idx++) {
+			auto &child_stat = StructStats::GetChildStats(tail_stat, child_idx);
+			StructStats::SetChildStats(struct_stats, offset++, child_stat);
 		}
 	}
+
 	return struct_stats.ToUnique();
 }
 
 ScalarFunction StructConcatFun::GetFunction() {
-	ScalarFunction fun("struct_concat", {}, LogicalTypeId::STRUCT, StructConcatFunction, StructConcatBind,
-	                   StructConcatStats);
-	fun.SetVarArgs(LogicalType::ANY);
-	fun.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
+	auto sig = FunctionSignature()
+		.AddParameter("arg", LogicalTypeId::STRUCT)
+		.AddVarPositionalParameter("args", LogicalType::ANY)
+		.SetReturnType(LogicalTypeId::STRUCT);
+
+	auto fun = ScalarFunction("struct_concat", std::move(sig))
+		.SetFunctionCallback(StructConcatFunction)
+		.SetBindCallback(StructConcatBind)
+		.SetStatisticsCallback(StructConcatStats)
+		.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
+
 	return fun;
 }
 

--- a/src/function/scalar/struct/struct_concat.cpp
+++ b/src/function/scalar/struct/struct_concat.cpp
@@ -123,15 +123,15 @@ static unique_ptr<BaseStatistics> StructConcatStats(ClientContext &context, Func
 
 ScalarFunction StructConcatFun::GetFunction() {
 	auto sig = FunctionSignature()
-		.AddParameter("arg", LogicalTypeId::STRUCT)
-		.AddVarPositionalParameter("args", LogicalType::ANY)
-		.SetReturnType(LogicalTypeId::STRUCT);
+	               .AddParameter("arg", LogicalTypeId::STRUCT)
+	               .AddVarPositionalParameter("args", LogicalType::ANY)
+	               .SetReturnType(LogicalTypeId::STRUCT);
 
 	auto fun = ScalarFunction("struct_concat", std::move(sig))
-		.SetFunctionCallback(StructConcatFunction)
-		.SetBindCallback(StructConcatBind)
-		.SetStatisticsCallback(StructConcatStats)
-		.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
+	               .SetFunctionCallback(StructConcatFunction)
+	               .SetBindCallback(StructConcatBind)
+	               .SetStatisticsCallback(StructConcatStats)
+	               .SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 
 	return fun;
 }

--- a/src/function/scalar/struct/struct_pack.cpp
+++ b/src/function/scalar/struct/struct_pack.cpp
@@ -2,23 +2,27 @@
 #include "duckdb/common/vector/struct_vector.hpp"
 #include "duckdb/function/scalar/nested_functions.hpp"
 #include "duckdb/function/scalar/struct_functions.hpp"
-#include "duckdb/common/case_insensitive_map.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/parser/expression/bound_expression.hpp"
+#include "duckdb/planner/expression/bound_argument_pack.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/planner/expression_binder.hpp"
 #include "duckdb/storage/statistics/struct_stats.hpp"
 
 namespace duckdb {
 
+// row(*args) collects its arguments positionally into an unnamed TUPLE, struct_pack(**fields) collects them by name
+// into a STRUCT - either way the pack is the function's only argument.
+
 static void StructPackFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &input = ArgumentPack::GetInput(args.data[0]);
 #ifdef DEBUG
 	auto &func_expr = state.expr.Cast<BoundFunctionExpression>();
 	auto &info = func_expr.BindInfo()->Cast<VariableReturnBindData>();
 	// this should never happen if the binder below is sane
-	D_ASSERT(args.ColumnCount() == StructType::GetChildTypes(info.stype).size());
+	D_ASSERT(input.size() == StructType::GetChildTypes(info.stype).size());
 #endif
-	if (args.ColumnCount() == 0) {
+	if (input.empty()) {
 		// empty struct: no children to reference, the value is a single non-null constant
 		result.SetVectorType(VectorType::CONSTANT_VECTOR);
 		ConstantVector::SetNull(result, false);
@@ -27,12 +31,12 @@ static void StructPackFunction(DataChunk &args, ExpressionState &state, Vector &
 	bool all_const = true;
 	auto &child_entries = StructVector::GetEntries(result);
 	idx_t children_size = 0;
-	for (idx_t i = 0; i < args.ColumnCount(); i++) {
-		if (args.data[i].GetVectorType() != VectorType::CONSTANT_VECTOR) {
+	for (idx_t i = 0; i < input.size(); i++) {
+		if (input[i].GetVectorType() != VectorType::CONSTANT_VECTOR) {
 			all_const = false;
 		}
 		// same holds for this
-		child_entries[i].Reference(args.data[i]);
+		child_entries[i].Reference(input[i]);
 		children_size = MaxValue<idx_t>(children_size, child_entries[i].size());
 	}
 	// set only the struct buffer's type/size - do not propagate to children
@@ -47,27 +51,12 @@ static void StructPackFunction(DataChunk &args, ExpressionState &state, Vector &
 template <bool IS_STRUCT_PACK>
 static unique_ptr<FunctionData> StructPackBind(BindScalarFunctionInput &input) {
 	auto &bound_function = input.GetBoundFunction();
-	auto &arguments = input.GetArguments();
-	identifier_set_t name_collision_set;
+	auto &pack_type = input.GetArguments()[0]->GetReturnType();
 
-	// collect names and deconflict, construct return type
+	// the pack already collected the arguments under the names they were passed with (the binder rejects duplicate
+	// names), so the struct is just the pack without its alias
 	// note: zero arguments is allowed, producing an empty struct
-	child_list_t<LogicalType> struct_children;
-	for (idx_t i = 0; i < arguments.size(); i++) {
-		auto &child = arguments[i];
-		string alias;
-		if (IS_STRUCT_PACK) {
-			if (child->GetAlias().empty()) {
-				throw BinderException("Need named argument for struct pack, e.g. STRUCT_PACK(a := b)");
-			}
-			alias = child->GetAlias().GetIdentifierName();
-			if (name_collision_set.find(Identifier(alias)) != name_collision_set.end()) {
-				throw BinderException("Duplicate struct entry name \"%s\"", alias);
-			}
-			name_collision_set.insert(Identifier(alias));
-		}
-		struct_children.emplace_back(make_pair(alias, arguments[i]->GetReturnType()));
-	}
+	child_list_t<LogicalType> struct_children = ArgumentPack::GetTypes(pack_type);
 
 	// this is more for completeness reasons
 	// row() produces an unnamed TUPLE, struct_pack() produces a named STRUCT
@@ -79,27 +68,35 @@ static unique_ptr<FunctionData> StructPackBind(BindScalarFunctionInput &input) {
 	return make_uniq<VariableReturnBindData>(bound_function.GetReturnType());
 }
 
+template <bool IS_STRUCT_PACK>
 static unique_ptr<BaseStatistics> StructPackStats(ClientContext &context, FunctionStatisticsInput &input) {
-	auto &child_stats = input.child_stats;
+	auto &pack_stats = input.child_stats[0];
 	auto &expr = input.expr;
+	if (pack_stats.GetStatsType() != StatisticsType::STRUCT_STATS) {
+		return nullptr;
+	}
 	auto struct_stats = StructStats::CreateUnknown(expr.GetReturnType());
-	for (idx_t i = 0; i < child_stats.size(); i++) {
-		StructStats::SetChildStats(struct_stats, i, child_stats[i]);
+	for (idx_t i = 0; i < StructType::GetChildCount(expr.GetReturnType()); i++) {
+		StructStats::SetChildStats(struct_stats, i, StructStats::GetChildStats(pack_stats, i));
 	}
 	return struct_stats.ToUnique();
 }
 
 template <bool IS_STRUCT_PACK>
 static ScalarFunction GetStructPackFunction() {
-	ScalarFunction fun(IS_STRUCT_PACK ? "struct_pack" : "row", {},
-	                   IS_STRUCT_PACK ? LogicalTypeId::STRUCT : LogicalTypeId::TUPLE, StructPackFunction,
-	                   StructPackBind<IS_STRUCT_PACK>, StructPackStats);
-	fun.SetVarArgs(LogicalType::ANY);
+	FunctionSignature signature;
+	if (IS_STRUCT_PACK) {
+		signature.AddVarKeywordParameter("fields", LogicalType::ANY);
+	} else {
+		signature.AddVarPositionalParameter("args", LogicalType::ANY);
+	}
+	signature.SetReturnType(IS_STRUCT_PACK ? LogicalTypeId::STRUCT : LogicalTypeId::TUPLE);
+
+	ScalarFunction fun(IS_STRUCT_PACK ? "struct_pack" : "row", std::move(signature));
+	fun.SetFunctionCallback(StructPackFunction);
+	fun.SetBindCallback(StructPackBind<IS_STRUCT_PACK>);
+	fun.SetStatisticsCallback(StructPackStats<IS_STRUCT_PACK>);
 	fun.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
-	// struct_pack/row derive their (struct field) names from argument aliases, so the binder must capture argument
-	// expression aliases as named-argument names. This also preserves the legacy behavior of allowing positional
-	// arguments after named ones (the positional arguments simply take their expression's name as the field name).
-	fun.SetCaptureArgumentAliases(true);
 	fun.SetSerializeCallback(VariableReturnBindData::Serialize);
 	fun.SetDeserializeCallback(VariableReturnBindData::Deserialize);
 	return fun;

--- a/src/function/scalar/system/current_connection_id.cpp
+++ b/src/function/scalar/system/current_connection_id.cpp
@@ -38,7 +38,7 @@ void CurrentConnectionIdFunction(DataChunk &args, ExpressionState &state, Vector
 
 ScalarFunction CurrentConnectionId::GetFunction() {
 	return ScalarFunction({}, LogicalType::UBIGINT, CurrentConnectionIdFunction, CurrentConnectionIdBind, nullptr,
-	                      nullptr, LogicalType(LogicalTypeId::INVALID), FunctionStability::VOLATILE);
+	                      nullptr, FunctionStability::VOLATILE);
 }
 
 } // namespace duckdb

--- a/src/function/scalar/system/current_query_id.cpp
+++ b/src/function/scalar/system/current_query_id.cpp
@@ -44,7 +44,7 @@ void CurrentQueryIdFunction(DataChunk &args, ExpressionState &state, Vector &res
 
 ScalarFunction CurrentQueryId::GetFunction() {
 	return ScalarFunction({}, LogicalType::UBIGINT, CurrentQueryIdFunction, CurrentQueryIdBind, nullptr, nullptr,
-	                      LogicalType(LogicalTypeId::INVALID), FunctionStability::VOLATILE);
+	                      FunctionStability::VOLATILE);
 }
 
 } // namespace duckdb

--- a/src/function/scalar/system/current_transaction_id.cpp
+++ b/src/function/scalar/system/current_transaction_id.cpp
@@ -46,7 +46,7 @@ void CurrentTransactionIdFunction(DataChunk &args, ExpressionState &state, Vecto
 
 ScalarFunction CurrentTransactionId::GetFunction() {
 	return ScalarFunction({}, LogicalType::UBIGINT, CurrentTransactionIdFunction, CurrentTransactionIdBind, nullptr,
-	                      nullptr, LogicalType(LogicalTypeId::INVALID), FunctionStability::VOLATILE);
+	                      nullptr, FunctionStability::VOLATILE);
 }
 
 } // namespace duckdb

--- a/src/function/scalar/system/parse_log_message.cpp
+++ b/src/function/scalar/system/parse_log_message.cpp
@@ -81,8 +81,7 @@ void ParseLogMessageFunction(DataChunk &args, ExpressionState &state, Vector &re
 
 ScalarFunction ParseLogMessage::GetFunction() {
 	auto fun = ScalarFunction({{"type", LogicalType::VARCHAR}, {"message", LogicalType::VARCHAR}}, LogicalType::ANY,
-	                          ParseLogMessageFunction, ParseLogMessageBind, nullptr, nullptr,
-	                          LogicalType(LogicalTypeId::INVALID));
+	                          ParseLogMessageFunction, ParseLogMessageBind);
 	fun.SetErrorMode(FunctionErrors::CAN_THROW_RUNTIME_ERROR);
 	return fun;
 }

--- a/src/function/scalar/system/write_log.cpp
+++ b/src/function/scalar/system/write_log.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/logging/log_manager.hpp"
 #include "utf8proc.hpp"
 #include "duckdb/main/client_context.hpp"
+#include "duckdb/planner/expression/bound_argument_pack.hpp"
 
 namespace duckdb {
 
@@ -46,18 +47,21 @@ public:
 	}
 };
 
+//! The value of one of the options collected by "**options", which must be a constant
+Value GetOptionConstant(ClientContext &context, Expression &option, const Identifier &name) {
+	if (option.HasParameter() || option.GetReturnType().id() == LogicalTypeId::UNKNOWN) {
+		throw ParameterNotResolvedException();
+	}
+	if (!option.IsFoldable()) {
+		throw BinderException(option, "write_log: '%s' argument must be a constant expression", name);
+	}
+	return ExpressionExecutor::EvaluateScalar(context, option);
+}
+
 unique_ptr<FunctionData> WriteLogBind(BindScalarFunctionInput &input) {
 	auto &context = input.GetClientContext();
 	auto &bound_function = input.GetBoundFunction();
-	auto &arguments = input.GetArguments();
-
-	if (arguments.empty()) {
-		throw BinderException("write_log takes at least one argument");
-	}
-
-	if (arguments[0]->GetReturnType() != LogicalType::VARCHAR) {
-		throw InvalidTypeException("write_log first argument must be a VARCHAR");
-	}
+	auto &options = *input.GetArguments()[1];
 
 	// Used to replace the actual log call with a nop: useful for benchmarking
 	auto result = make_uniq<WriteLogBindData>();
@@ -65,37 +69,37 @@ unique_ptr<FunctionData> WriteLogBind(BindScalarFunctionInput &input) {
 	// Default return type
 	bound_function.SetReturnType(LogicalType::VARCHAR);
 
-	for (idx_t i = 1; i < arguments.size(); i++) {
-		auto &arg = arguments[i];
-		if (arg->HasParameter()) {
-			throw ParameterNotResolvedException();
-		}
-		if (arg->GetAlias() == "disable_logging") {
-			if (arg->GetReturnType().id() != LogicalTypeId::BOOLEAN) {
+	auto &option_types = ArgumentPack::GetTypes(options.GetReturnType());
+	auto &option_args = ArgumentPack::GetPackedChildren(options);
+	for (idx_t i = 0; i < option_args.size(); i++) {
+		const auto &name = option_types[i].first;
+		auto &arg = *option_args[i];
+		if (name == "disable_logging") {
+			if (arg.GetReturnType().id() != LogicalTypeId::BOOLEAN) {
 				throw BinderException("write_log: 'disable_logging' argument must be a boolean");
 			}
-			result->disable_logging = BooleanValue::Get(input.GetConstant(i));
-		} else if (arg->GetAlias() == "scope") {
-			if (arg->GetReturnType().id() != LogicalTypeId::VARCHAR) {
+			result->disable_logging = BooleanValue::Get(GetOptionConstant(context, arg, name));
+		} else if (name == "scope") {
+			if (arg.GetReturnType().id() != LogicalTypeId::VARCHAR) {
 				throw BinderException("write_log: 'scope' argument must be a string");
 			}
-			result->scope = StringValue::Get(input.GetConstant(i));
-		} else if (arg->GetAlias() == "level") {
-			if (arg->GetReturnType().id() != LogicalTypeId::VARCHAR) {
+			result->scope = StringValue::Get(GetOptionConstant(context, arg, name));
+		} else if (name == "level") {
+			if (arg.GetReturnType().id() != LogicalTypeId::VARCHAR) {
 				throw BinderException("write_log: 'level' argument must be a string");
 			}
-			result->level = EnumUtil::FromString<LogLevel>(StringValue::Get(input.GetConstant(i)));
-		} else if (arg->GetAlias() == "log_type") {
-			if (arg->GetReturnType().id() != LogicalTypeId::VARCHAR) {
+			result->level = EnumUtil::FromString<LogLevel>(StringValue::Get(GetOptionConstant(context, arg, name)));
+		} else if (name == "log_type") {
+			if (arg.GetReturnType().id() != LogicalTypeId::VARCHAR) {
 				throw BinderException("write_log: 'log_type' argument must be a string");
 			}
-			result->type = StringValue::Get(input.GetConstant(i));
-		} else if (arg->GetAlias() == "return_value") {
-			result->return_type = arg->GetReturnType();
+			result->type = StringValue::Get(GetOptionConstant(context, arg, name));
+		} else if (name == "return_value") {
+			result->return_type = arg.GetReturnType();
 			result->output_col = i;
 			bound_function.SetReturnType(result->return_type);
 		} else {
-			throw BinderException(StringUtil::Format("write_log: Unknown argument '%s'", arg->GetAlias()));
+			throw BinderException(StringUtil::Format("write_log: Unknown argument '%s'", name));
 		}
 	}
 
@@ -113,7 +117,7 @@ void WriteLogValues(T &LogSource, LogLevel level, const string_t *data, const Se
 }
 
 void WriteLogFunction(DataChunk &args, ExpressionState &state, Vector &result) {
-	D_ASSERT(args.ColumnCount() >= 1);
+	D_ASSERT(args.ColumnCount() == 2);
 
 	auto &func_expr = state.expr.Cast<BoundFunctionExpression>();
 	const auto &info = func_expr.BindInfo()->Cast<WriteLogBindData>();
@@ -141,7 +145,7 @@ void WriteLogFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	}
 
 	if (info.output_col != DConstants::INVALID_INDEX) {
-		result.Reference(args.data[info.output_col]);
+		result.Reference(ArgumentPack::GetInput(args.data[1])[info.output_col]);
 	} else {
 		ConstantVector::SetNull(result, count_t(args.size()));
 	}
@@ -152,8 +156,14 @@ void WriteLogFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 ScalarFunctionSet WriteLogFun::GetFunctions() {
 	ScalarFunctionSet set("write_log");
 
-	set.AddFunction(ScalarFunction({{"string", LogicalType::VARCHAR}}, LogicalType::ANY, WriteLogFunction, WriteLogBind,
-	                               nullptr, nullptr, LogicalType::ANY, FunctionStability::VOLATILE));
+	auto sig = FunctionSignature()
+	               .AddParameter("string", LogicalType::VARCHAR)
+	               .AddVarKeywordParameter("options", LogicalType::ANY)
+	               .SetReturnType(LogicalType::ANY);
+	set.AddFunction(ScalarFunction("write_log", std::move(sig))
+	                    .SetFunctionCallback(WriteLogFunction)
+	                    .SetBindCallback(WriteLogBind)
+	                    .SetVolatile());
 
 	return set;
 }

--- a/src/function/scalar_function.cpp
+++ b/src/function/scalar_function.cpp
@@ -32,7 +32,6 @@ FunctionLocalState::~FunctionLocalState() {
 ScalarFunctionInfo::~ScalarFunctionInfo() {
 }
 
-
 ScalarFunction::ScalarFunction(Identifier name, FunctionSignature sig, scalar_function_t function)
     : SimpleFunction(std::move(name), std::move(sig)) {
 	callbacks.function = std::move(function);

--- a/src/function/scalar_function.cpp
+++ b/src/function/scalar_function.cpp
@@ -32,6 +32,7 @@ FunctionLocalState::~FunctionLocalState() {
 ScalarFunctionInfo::~ScalarFunctionInfo() {
 }
 
+
 ScalarFunction::ScalarFunction(Identifier name, FunctionSignature sig, scalar_function_t function)
     : SimpleFunction(std::move(name), std::move(sig)) {
 	callbacks.function = std::move(function);

--- a/src/function/scalar_function.cpp
+++ b/src/function/scalar_function.cpp
@@ -40,9 +40,9 @@ ScalarFunction::ScalarFunction(Identifier name, FunctionSignature sig, scalar_fu
 ScalarFunction::ScalarFunction(Identifier name, vector<LogicalType> arguments, LogicalType return_type,
                                scalar_function_t function, bind_scalar_function_t bind,
                                function_statistics_t statistics, init_local_state_t init_local_state,
-                               LogicalType varargs, FunctionStability side_effects, FunctionNullHandling null_handling,
+                               FunctionStability side_effects, FunctionNullHandling null_handling,
                                bind_lambda_function_t bind_lambda)
-    : SimpleFunction(std::move(name), std::move(arguments), std::move(return_type), std::move(varargs)) {
+    : SimpleFunction(std::move(name), std::move(arguments), std::move(return_type)) {
 	properties.stability = side_effects;
 	properties.null_handling = null_handling;
 
@@ -55,19 +55,19 @@ ScalarFunction::ScalarFunction(Identifier name, vector<LogicalType> arguments, L
 
 ScalarFunction::ScalarFunction(vector<LogicalType> arguments, LogicalType return_type, scalar_function_t function,
                                bind_scalar_function_t bind, function_statistics_t statistics,
-                               init_local_state_t init_local_state, LogicalType varargs, FunctionStability side_effects,
+                               init_local_state_t init_local_state, FunctionStability side_effects,
                                FunctionNullHandling null_handling, bind_lambda_function_t bind_lambda)
     : ScalarFunction(Identifier(), std::move(arguments), std::move(return_type), std::move(function), bind, statistics,
-                     init_local_state, std::move(varargs), side_effects, null_handling, bind_lambda) {
+                     init_local_state, side_effects, null_handling, bind_lambda) {
 }
 
 // (we take an initializer list to ensure that the function is not ambiguous with the other constructor)
 ScalarFunction::ScalarFunction(Identifier name, std::initializer_list<FunctionParameter> params,
                                LogicalType return_type, scalar_function_t function, bind_scalar_function_t bind,
                                function_statistics_t statistics, init_local_state_t init_local_state,
-                               LogicalType varargs, FunctionStability side_effects, FunctionNullHandling null_handling,
+                               FunctionStability side_effects, FunctionNullHandling null_handling,
                                bind_lambda_function_t bind_lambda)
-    : SimpleFunction(std::move(name), FunctionSignature(params, std::move(varargs), std::move(return_type))) {
+    : SimpleFunction(std::move(name), FunctionSignature(params, std::move(return_type))) {
 	properties.stability = side_effects;
 	properties.null_handling = null_handling;
 
@@ -81,10 +81,10 @@ ScalarFunction::ScalarFunction(Identifier name, std::initializer_list<FunctionPa
 ScalarFunction::ScalarFunction(std::initializer_list<FunctionParameter> params, LogicalType return_type,
                                scalar_function_t function, bind_scalar_function_t bind,
                                function_statistics_t statistics, init_local_state_t init_local_state,
-                               LogicalType varargs, FunctionStability side_effects, FunctionNullHandling null_handling,
+                               FunctionStability side_effects, FunctionNullHandling null_handling,
                                bind_lambda_function_t bind_lambda)
     : ScalarFunction(Identifier(), params, std::move(return_type), std::move(function), bind, statistics,
-                     init_local_state, std::move(varargs), side_effects, null_handling, bind_lambda) {
+                     init_local_state, side_effects, null_handling, bind_lambda) {
 }
 
 bool ScalarFunction::operator==(const ScalarFunction &rhs) const {

--- a/src/function/table/system/duckdb_functions.cpp
+++ b/src/function/table/system/duckdb_functions.cpp
@@ -71,6 +71,9 @@ static unique_ptr<FunctionData> DuckDBFunctionsBind(ClientContext &context, Tabl
 	names.emplace_back("varargs");
 	return_types.emplace_back(LogicalType::VARCHAR);
 
+	names.emplace_back("named_varargs");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
 	names.emplace_back("macro_definition");
 	return_types.emplace_back(LogicalType::VARCHAR);
 
@@ -137,6 +140,25 @@ Value FunctionStabilityToValue(FunctionStability stability) {
 	}
 }
 
+//! The "varargs" column reports the type a "*args" parameter constrains the arguments it collects to, which is what
+//! a trailing-varargs function used to declare
+static Value VarPositionalType(const FunctionSignature &signature) {
+	auto index = signature.GetVarPositionalIndex();
+	if (!index.IsValid()) {
+		return Value();
+	}
+	return Value(signature.GetParameter(index.GetIndex()).GetType().ToString());
+}
+
+//! The "named_varargs" column reports the type a "**kwargs" parameter constrains the named arguments it collects to
+static Value VarKeywordType(const FunctionSignature &signature) {
+	auto index = signature.GetVarKeywordIndex();
+	if (!index.IsValid()) {
+		return Value();
+	}
+	return Value(signature.GetParameter(index.GetIndex()).GetType().ToString());
+}
+
 struct ScalarFunctionExtractor {
 	static idx_t FunctionCount(ScalarFunctionCatalogEntry &entry) {
 		return entry.functions.Size();
@@ -177,8 +199,11 @@ struct ScalarFunctionExtractor {
 	}
 
 	static Value GetVarArgs(ScalarFunctionCatalogEntry &entry, idx_t offset) {
-		const auto &fun = entry.functions.GetFunctionByOffset(offset);
-		return !fun.HasVarArgs() ? Value() : Value(fun.GetVarArgs().ToString());
+		return VarPositionalType(entry.functions.GetFunctionByOffset(offset).GetSignature());
+	}
+
+	static Value GetNamedVarArgs(ScalarFunctionCatalogEntry &entry, idx_t offset) {
+		return VarKeywordType(entry.functions.GetFunctionByOffset(offset).GetSignature());
 	}
 
 	static Value GetMacroDefinition(ScalarFunctionCatalogEntry &entry, idx_t offset) {
@@ -235,7 +260,11 @@ struct WindowFunctionExtractor {
 	}
 
 	static Value GetVarArgs(WindowFunctionCatalogEntry &entry, idx_t offset) {
-		return Value();
+		return VarPositionalType(entry.functions.GetFunctionByOffset(offset).GetSignature());
+	}
+
+	static Value GetNamedVarArgs(WindowFunctionCatalogEntry &entry, idx_t offset) {
+		return VarKeywordType(entry.functions.GetFunctionByOffset(offset).GetSignature());
 	}
 
 	static Value GetMacroDefinition(WindowFunctionCatalogEntry &entry, idx_t offset) {
@@ -291,8 +320,11 @@ struct AggregateFunctionExtractor {
 	}
 
 	static Value GetVarArgs(AggregateFunctionCatalogEntry &entry, idx_t offset) {
-		const auto &fun = entry.functions.GetFunctionByOffset(offset);
-		return !fun.HasVarArgs() ? Value() : Value(fun.GetVarArgs().ToString());
+		return VarPositionalType(entry.functions.GetFunctionByOffset(offset).GetSignature());
+	}
+
+	static Value GetNamedVarArgs(AggregateFunctionCatalogEntry &entry, idx_t offset) {
+		return VarKeywordType(entry.functions.GetFunctionByOffset(offset).GetSignature());
 	}
 
 	static Value GetMacroDefinition(AggregateFunctionCatalogEntry &entry, idx_t offset) {
@@ -356,6 +388,10 @@ struct MacroExtractor {
 		return Value();
 	}
 
+	static Value GetNamedVarArgs(ScalarMacroCatalogEntry &entry, idx_t offset) {
+		return Value();
+	}
+
 	static Value GetMacroDefinition(ScalarMacroCatalogEntry &entry, idx_t offset) {
 		auto &macro_entry = *entry.macros[offset];
 		D_ASSERT(macro_entry.type == MacroType::SCALAR_MACRO);
@@ -416,6 +452,10 @@ struct TableMacroExtractor {
 	}
 
 	static Value GetVarArgs(TableMacroCatalogEntry &entry, idx_t offset) {
+		return Value();
+	}
+
+	static Value GetNamedVarArgs(TableMacroCatalogEntry &entry, idx_t offset) {
 		return Value();
 	}
 
@@ -485,6 +525,10 @@ struct TableFunctionExtractor {
 		return !fun.HasVarArgs() ? Value() : Value(fun.GetVarArgs().ToString());
 	}
 
+	static Value GetNamedVarArgs(TableFunctionCatalogEntry &entry, idx_t offset) {
+		return Value();
+	}
+
 	static Value GetMacroDefinition(TableFunctionCatalogEntry &entry, idx_t offset) {
 		return Value();
 	}
@@ -545,6 +589,10 @@ struct PragmaFunctionExtractor {
 	static Value GetVarArgs(PragmaFunctionCatalogEntry &entry, idx_t offset) {
 		const auto &fun = entry.functions.GetFunctionByOffset(offset);
 		return !fun.HasVarArgs() ? Value() : Value(fun.GetVarArgs().ToString());
+	}
+
+	static Value GetNamedVarArgs(PragmaFunctionCatalogEntry &entry, idx_t offset) {
+		return Value();
 	}
 
 	static Value GetMacroDefinition(PragmaFunctionCatalogEntry &entry, idx_t offset) {
@@ -689,6 +737,9 @@ bool ExtractFunctionData(CatalogEntry &entry, idx_t function_idx, DataChunk &out
 
 	// varargs, LogicalType::VARCHAR
 	output.data[col++].Append(OP::GetVarArgs(function, function_idx));
+
+	// named_varargs, LogicalType::VARCHAR
+	output.data[col++].Append(OP::GetNamedVarArgs(function, function_idx));
 
 	// macro_definition, LogicalType::VARCHAR
 	output.data[col++].Append(OP::GetMacroDefinition(function, function_idx));

--- a/src/include/duckdb/common/enum_util.hpp
+++ b/src/include/duckdb/common/enum_util.hpp
@@ -260,6 +260,8 @@ enum class FunctionErrors : uint8_t;
 
 enum class FunctionNullHandling : uint8_t;
 
+enum class FunctionParameterKind : uint8_t;
+
 enum class FunctionStability : uint8_t;
 
 enum class GateStatus : uint8_t;
@@ -964,6 +966,9 @@ const char* EnumUtil::ToChars<FunctionErrors>(FunctionErrors value);
 
 template<>
 const char* EnumUtil::ToChars<FunctionNullHandling>(FunctionNullHandling value);
+
+template<>
+const char* EnumUtil::ToChars<FunctionParameterKind>(FunctionParameterKind value);
 
 template<>
 const char* EnumUtil::ToChars<FunctionStability>(FunctionStability value);
@@ -1850,6 +1855,9 @@ FunctionErrors EnumUtil::FromString<FunctionErrors>(const char *value);
 
 template<>
 FunctionNullHandling EnumUtil::FromString<FunctionNullHandling>(const char *value);
+
+template<>
+FunctionParameterKind EnumUtil::FromString<FunctionParameterKind>(const char *value);
 
 template<>
 FunctionStability EnumUtil::FromString<FunctionStability>(const char *value);

--- a/src/include/duckdb/common/enums/expression_type.hpp
+++ b/src/include/duckdb/common/enums/expression_type.hpp
@@ -123,6 +123,9 @@ enum class ExpressionType : uint8_t {
 	ARRAY_CONSTRUCTOR = 156,
 	ARROW = 157,
 	OPERATOR_TRY = 158,
+	//! Packs its children into a TUPLE/STRUCT to fill a "*args"/"**kwargs" parameter of a function call.
+	//! Only ever produced by the FunctionBinder - it is not reachable from SQL.
+	ARGUMENT_PACK = 159,
 
 	// -----------------------------
 	// Subquery IN/EXISTS

--- a/src/include/duckdb/common/type_visitor.hpp
+++ b/src/include/duckdb/common/type_visitor.hpp
@@ -67,7 +67,9 @@ inline LogicalType TypeVisitor::VisitReplace(const LogicalType &type, F &&func) 
 			return func(type);
 		}
 		const auto &child = ArrayType::GetChildType(type);
-		return func(LogicalType::ARRAY(VisitReplace(child, func), ArrayType::GetSize(type)));
+		// an array whose size is not known yet stays that way
+		const auto size = ArrayType::IsAnySize(type) ? optional_idx() : optional_idx(ArrayType::GetSize(type));
+		return func(LogicalType::ARRAY(VisitReplace(child, func), size));
 	}
 	case LogicalTypeId::MAP: {
 		if (!type.AuxInfo()) {

--- a/src/include/duckdb/execution/expression_executor.hpp
+++ b/src/include/duckdb/execution/expression_executor.hpp
@@ -122,6 +122,8 @@ protected:
 	             Vector &result);
 	void Execute(const BoundFunctionExpression &expr, ExpressionState *state, const SelectionVector *sel, idx_t count,
 	             Vector &result);
+	void ExecuteArgumentPack(const BoundOperatorExpression &expr, ExpressionState *state, const SelectionVector *sel,
+	                         idx_t count, Vector &result);
 	void Execute(const BoundOperatorExpression &expr, ExpressionState *state, const SelectionVector *sel, idx_t count,
 	             Vector &result);
 	void Execute(const BoundParameterExpression &expr, ExpressionState *state, const SelectionVector *sel, idx_t count,

--- a/src/include/duckdb/function/function.hpp
+++ b/src/include/duckdb/function/function.hpp
@@ -761,7 +761,12 @@ public:
 		return argument_names;
 	}
 
-	//! Get the constant value of an argument.
+	//! The arguments as the call was written, with the arguments collected by a "*args"/"**kwargs" parameter
+	//! spread back out. Use this to walk the arguments of a function that has such a parameter positionally.
+	DUCKDB_API vector<reference<Expression>> GetUnpackedArguments() const;
+
+	//! Get the constant value of an argument, indexed by parameter. A function with a "*args"/"**kwargs" parameter
+	//! gets the pack itself here - reach into it with ArgumentPack if its individual arguments are wanted.
 	//! Throws ParameterNotResolvedException if unresolved, and BinderException for non-constant arguments.
 	//! When 'accept_null' is false, also throws if the (constant) value is NULL.
 	DUCKDB_API Value GetConstant(idx_t arg_idx, bool accept_null = true) const;

--- a/src/include/duckdb/function/function.hpp
+++ b/src/include/duckdb/function/function.hpp
@@ -638,13 +638,6 @@ public:
 		collation_handling = value;
 	}
 
-	auto GetCaptureArgumentAliases() const -> bool {
-		return capture_argument_aliases;
-	}
-	auto SetCaptureArgumentAliases(bool value) -> void {
-		capture_argument_aliases = value;
-	}
-
 	auto RequiresOrderedExecution() const -> bool {
 		return requires_ordered_execution;
 	}
@@ -671,10 +664,6 @@ public:
 	FunctionErrors errors = FunctionErrors::CANNOT_ERROR;
 	//! Collation handling of the function
 	FunctionCollationHandling collation_handling = FunctionCollationHandling::PROPAGATE_COLLATIONS;
-	//! Whether the binder should capture argument expression aliases as named-argument names when binding this
-	//! function. This preserves the legacy behavior of functions such as struct_pack/row, which derived their
-	//! (struct field) names from argument aliases and therefore allowed positional arguments after named ones.
-	bool capture_argument_aliases = false;
 	//! Whether calls to this function must follow input order
 	bool requires_ordered_execution = false;
 };

--- a/src/include/duckdb/function/function.hpp
+++ b/src/include/duckdb/function/function.hpp
@@ -195,20 +195,13 @@ class FunctionSignature {
 public:
 	FunctionSignature() = default;
 
-	FunctionSignature(vector<LogicalType> arguments, LogicalType varargs, LogicalType return_type)
-	    : varargs(std::move(varargs)), return_type(std::move(return_type)) {
+	FunctionSignature(vector<FunctionParameter> parameters, LogicalType return_type)
+	    : parameters(std::move(parameters)), return_type(std::move(return_type)) {
+	}
+	FunctionSignature(vector<LogicalType> arguments, LogicalType return_type) : return_type(std::move(return_type)) {
 		for (auto &arg : arguments) {
 			AddParameter(std::move(arg));
 		}
-	}
-	FunctionSignature(vector<FunctionParameter> parameters, LogicalType return_type)
-	    : parameters(std::move(parameters)), varargs(LogicalTypeId::INVALID), return_type(std::move(return_type)) {
-	}
-	FunctionSignature(vector<FunctionParameter> parameters, LogicalType varargs, LogicalType return_type)
-	    : parameters(std::move(parameters)), varargs(std::move(varargs)), return_type(std::move(return_type)) {
-	}
-	FunctionSignature(vector<LogicalType> arguments, LogicalType return_type)
-	    : FunctionSignature(std::move(arguments), LogicalType(LogicalTypeId::INVALID), std::move(return_type)) {
 	}
 
 	string ToString() const;
@@ -238,16 +231,6 @@ public:
 	auto SetReturnType(LogicalType return_type_p) -> FunctionSignature & {
 		return_type = std::move(return_type_p);
 		return *this;
-	}
-
-	auto HasVarArgs() const -> bool {
-		return varargs.id() != LogicalTypeId::INVALID;
-	}
-	auto GetVarArgs() const -> const LogicalType & {
-		return varargs;
-	}
-	auto SetVarArgs(LogicalType varargs_p) -> void {
-		varargs = std::move(varargs_p);
 	}
 
 	auto AddParameter(Identifier name, LogicalType type, Value default_value) -> FunctionSignature & {
@@ -435,11 +418,6 @@ public:
 				                            parameters[var_keyword.GetIndex()].GetName(), param.GetName());
 			}
 		}
-
-		if (HasVarArgs() && (var_positional.IsValid() || var_keyword.IsValid())) {
-			throw InvalidInputException("A function cannot combine trailing varargs with '*args'/'**kwargs' "
-			                            "parameters - use '*args' instead");
-		}
 	}
 
 	hash_t Hash() const;
@@ -456,7 +434,6 @@ private:
 
 private:
 	vector<FunctionParameter> parameters;
-	LogicalType varargs;
 	LogicalType return_type;
 };
 
@@ -495,12 +472,11 @@ public:
 	//! Returns the formatted string name(arg1, arg2, ...)
 	DUCKDB_API static string CallToString(const Identifier &catalog_name, const Identifier &schema_name,
 	                                      const Identifier &name, const vector<LogicalType> &arguments,
-	                                      const vector<pair<Identifier, LogicalType>> &named_arguments,
-	                                      const LogicalType &varargs = LogicalType::INVALID);
+	                                      const vector<pair<Identifier, LogicalType>> &named_arguments);
 	//! Returns the formatted string name(arg1, arg2..) -> return_type
 	DUCKDB_API static string CallToString(const Identifier &catalog_name, const Identifier &schema_name,
 	                                      const Identifier &name, const vector<LogicalType> &arguments,
-	                                      const LogicalType &varargs, const LogicalType &return_type);
+	                                      const LogicalType &return_type);
 	//! Returns the formatted string name(arg1, arg2.., np1=a, np2=b, ...)
 	DUCKDB_API static string CallToString(const Identifier &catalog_name, const Identifier &schema_name,
 	                                      const Identifier &name, const vector<LogicalType> &arguments,
@@ -519,8 +495,7 @@ private:
 class SimpleFunction : public Function {
 public:
 	DUCKDB_API SimpleFunction(Identifier name, FunctionSignature signature);
-	DUCKDB_API SimpleFunction(Identifier name, vector<LogicalType> arguments, LogicalType return_type,
-	                          LogicalType varargs = LogicalType(LogicalTypeId::INVALID));
+	DUCKDB_API SimpleFunction(Identifier name, vector<LogicalType> arguments, LogicalType return_type);
 	DUCKDB_API ~SimpleFunction() override;
 
 protected:
@@ -535,18 +510,6 @@ public:
 	}
 	const FunctionSignature &GetSignature() const {
 		return signature;
-	}
-
-	const LogicalType &GetVarArgs() const {
-		return signature.GetVarArgs();
-	}
-
-	void SetVarArgs(LogicalType varargs_p) {
-		signature.SetVarArgs(std::move(varargs_p));
-	}
-
-	DUCKDB_API bool HasVarArgs() const {
-		return signature.HasVarArgs();
 	}
 
 	void SetReturnType(LogicalType return_type_p) {

--- a/src/include/duckdb/function/function.hpp
+++ b/src/include/duckdb/function/function.hpp
@@ -117,6 +117,18 @@ struct FunctionParameters {
 	named_parameter_map_t named_parameters;
 };
 
+//! How a parameter may be supplied by the caller. Mirrors Python's parameter kinds.
+enum class FunctionParameterKind : uint8_t {
+	//! An ordinary parameter - may be supplied positionally or by name
+	STANDARD = 0,
+	//! A "*args" parameter - collects the trailing positional arguments into a TUPLE
+	VAR_POSITIONAL = 1,
+	//! A "**kwargs" parameter - collects the unmatched named arguments into a STRUCT
+	VAR_KEYWORD = 2,
+	//! A parameter that may only be supplied by name
+	KEYWORD_ONLY = 3,
+};
+
 class FunctionParameter {
 public:
 	FunctionParameter(Identifier name, LogicalType type)
@@ -125,6 +137,10 @@ public:
 
 	FunctionParameter(Identifier name, LogicalType type, Value value)
 	    : name(std::move(name)), type(std::move(type)), default_value(make_shared_ptr<Value>(std::move(value))) {
+	}
+
+	FunctionParameter(Identifier name, LogicalType type, FunctionParameterKind kind)
+	    : name(std::move(name)), type(std::move(type)), default_value(nullptr), kind(kind) {
 	}
 
 	string ToString() const;
@@ -156,10 +172,23 @@ public:
 		return default_value != nullptr;
 	}
 
+	auto GetKind() const -> FunctionParameterKind {
+		return kind;
+	}
+	auto SetKind(FunctionParameterKind kind_p) -> void {
+		kind = kind_p;
+	}
+	//! Whether this is a "*args" or "**kwargs" parameter, i.e. one that is presented to the function as a single
+	//! packed TUPLE/STRUCT value built from a variable number of arguments
+	auto IsArgumentPack() const -> bool {
+		return kind == FunctionParameterKind::VAR_POSITIONAL || kind == FunctionParameterKind::VAR_KEYWORD;
+	}
+
 private:
 	Identifier name;
 	LogicalType type;
 	shared_ptr<Value> default_value;
+	FunctionParameterKind kind = FunctionParameterKind::STANDARD;
 };
 
 class FunctionSignature {
@@ -236,9 +265,38 @@ public:
 		return *this;
 	}
 
+	//! Add a "*args" parameter. 'element_type' constrains the individual arguments collected into it (ANY for no
+	//! constraint) - the function itself is passed a single TUPLE of all of them.
+	auto AddVarPositionalParameter(Identifier name, LogicalType element_type) -> FunctionSignature & {
+		parameters.emplace_back(std::move(name), std::move(element_type), FunctionParameterKind::VAR_POSITIONAL);
+		return *this;
+	}
+
+	//! Add a "**kwargs" parameter. 'value_type' constrains the individual arguments collected into it (ANY for no
+	//! constraint) - the function itself is passed a single STRUCT keyed by the caller's argument names.
+	auto AddVarKeywordParameter(Identifier name, LogicalType value_type) -> FunctionSignature & {
+		parameters.emplace_back(std::move(name), std::move(value_type), FunctionParameterKind::VAR_KEYWORD);
+		return *this;
+	}
+
+	auto AddKeywordOnlyParameter(Identifier name, LogicalType type) -> FunctionSignature & {
+		parameters.emplace_back(std::move(name), std::move(type), FunctionParameterKind::KEYWORD_ONLY);
+		return *this;
+	}
+
+	auto AddKeywordOnlyParameter(Identifier name, LogicalType type, Value default_value) -> FunctionSignature & {
+		parameters.emplace_back(std::move(name), std::move(type), std::move(default_value));
+		parameters.back().SetKind(FunctionParameterKind::KEYWORD_ONLY);
+		return *this;
+	}
+
 	auto GetParameterIndexByName(const Identifier &name) const -> optional_idx {
 		// Parameter names are matched case-insensitively, consistent with SQL identifier semantics.
 		for (idx_t i = 0; i < parameters.size(); i++) {
+			if (parameters[i].IsArgumentPack()) {
+				// argument packs cannot be supplied by name - they are built from the arguments they collect
+				continue;
+			}
 			if (parameters[i].GetName() == name) {
 				return i;
 			}
@@ -246,10 +304,42 @@ public:
 		return optional_idx();
 	}
 
+	auto GetVarPositionalIndex() const -> optional_idx {
+		return GetParameterIndexByKind(FunctionParameterKind::VAR_POSITIONAL);
+	}
+
+	auto GetVarKeywordIndex() const -> optional_idx {
+		return GetParameterIndexByKind(FunctionParameterKind::VAR_KEYWORD);
+	}
+
+	auto HasVarPositional() const -> bool {
+		return GetVarPositionalIndex().IsValid();
+	}
+
+	auto HasVarKeyword() const -> bool {
+		return GetVarKeywordIndex().IsValid();
+	}
+
+	auto HasArgumentPacks() const -> bool {
+		return HasVarPositional() || HasVarKeyword();
+	}
+
+	//! The number of parameter slots that can be filled positionally, i.e. everything up to the first parameter that
+	//! is not STANDARD (*args, **kwargs or a keyword-only parameter).
+	auto GetPositionalParameterCount() const -> idx_t {
+		for (idx_t i = 0; i < parameters.size(); i++) {
+			if (parameters[i].GetKind() != FunctionParameterKind::STANDARD) {
+				return i;
+			}
+		}
+		return parameters.size();
+	}
+
 	auto GetRequiredParameterCount() const -> idx_t {
 		idx_t result = 0;
 		for (const auto &param : parameters) {
-			if (!param.HasDefaultValue()) {
+			// an argument pack is always optional - it may collect zero arguments
+			if (!param.HasDefaultValue() && !param.IsArgumentPack()) {
 				result++;
 			}
 		}
@@ -266,9 +356,13 @@ public:
 			seen_names.insert(param.GetName());
 		}
 
-		// Also check for default values that are not at the end of the parameter list
+		// Also check for default values that are not at the end of the positional parameter list. Keyword-only
+		// parameters are exempt: they are always supplied by name, so their order is irrelevant.
 		bool found_default_value = false;
 		for (const auto &param : parameters) {
+			if (param.GetKind() != FunctionParameterKind::STANDARD) {
+				continue;
+			}
 			if (param.HasDefaultValue()) {
 				found_default_value = true;
 			} else if (found_default_value) {
@@ -278,9 +372,86 @@ public:
 				    param.GetName());
 			}
 		}
+
+		VerifyArgumentPacks();
+	}
+
+	//! Verify the "*args" / "**kwargs" / keyword-only rules. Split out from Verify so that it can be enforced on
+	//! function registration without also enforcing the pre-existing rules on every function ever written.
+	void VerifyArgumentPacks() const {
+		optional_idx var_positional;
+		optional_idx var_keyword;
+		bool found_keyword_only = false;
+
+		for (idx_t i = 0; i < parameters.size(); i++) {
+			const auto &param = parameters[i];
+			switch (param.GetKind()) {
+			case FunctionParameterKind::VAR_POSITIONAL:
+				if (var_positional.IsValid()) {
+					throw InvalidInputException("A function can only have a single '*args' parameter, but both '%s' "
+					                            "and '%s' are declared as one",
+					                            parameters[var_positional.GetIndex()].GetName(), param.GetName());
+				}
+				if (found_keyword_only) {
+					throw InvalidInputException("The '*args' parameter '%s' cannot follow a keyword-only parameter",
+					                            param.GetName());
+				}
+				var_positional = i;
+				break;
+			case FunctionParameterKind::VAR_KEYWORD:
+				if (var_keyword.IsValid()) {
+					throw InvalidInputException("A function can only have a single '**kwargs' parameter, but both "
+					                            "'%s' and '%s' are declared as one",
+					                            parameters[var_keyword.GetIndex()].GetName(), param.GetName());
+				}
+				var_keyword = i;
+				break;
+			case FunctionParameterKind::KEYWORD_ONLY:
+				found_keyword_only = true;
+				break;
+			case FunctionParameterKind::STANDARD:
+				if (found_keyword_only) {
+					throw InvalidInputException(
+					    "Parameter '%s' can be supplied positionally but follows a keyword-only parameter",
+					    param.GetName());
+				}
+				if (var_positional.IsValid()) {
+					throw InvalidInputException(
+					    "Parameter '%s' follows the '*args' parameter '%s' and must therefore be keyword-only",
+					    param.GetName(), parameters[var_positional.GetIndex()].GetName());
+				}
+				break;
+			}
+
+			if (param.IsArgumentPack() && param.HasDefaultValue()) {
+				throw InvalidInputException("The '*args'/'**kwargs' parameter '%s' cannot have a default value - it "
+				                            "collects zero arguments when none are supplied",
+				                            param.GetName());
+			}
+			if (var_keyword.IsValid() && i > var_keyword.GetIndex()) {
+				throw InvalidInputException("The '**kwargs' parameter '%s' must be the last parameter, but '%s' "
+				                            "follows it",
+				                            parameters[var_keyword.GetIndex()].GetName(), param.GetName());
+			}
+		}
+
+		if (HasVarArgs() && (var_positional.IsValid() || var_keyword.IsValid())) {
+			throw InvalidInputException("A function cannot combine trailing varargs with '*args'/'**kwargs' "
+			                            "parameters - use '*args' instead");
+		}
 	}
 
 	hash_t Hash() const;
+
+private:
+	auto GetParameterIndexByKind(FunctionParameterKind kind) const -> optional_idx {
+		for (idx_t i = 0; i < parameters.size(); i++) {
+			if (parameters[i].GetKind() == kind) {
+				return i;
+			}
+		}
+		return optional_idx();
+	}
 
 private:
 	vector<FunctionParameter> parameters;

--- a/src/include/duckdb/function/function.hpp
+++ b/src/include/duckdb/function/function.hpp
@@ -235,8 +235,9 @@ public:
 	auto GetReturnType() const -> const LogicalType & {
 		return return_type;
 	}
-	auto SetReturnType(LogicalType return_type_p) -> void {
+	auto SetReturnType(LogicalType return_type_p) -> FunctionSignature & {
 		return_type = std::move(return_type_p);
+		return *this;
 	}
 
 	auto HasVarArgs() const -> bool {

--- a/src/include/duckdb/function/function_binder.hpp
+++ b/src/include/duckdb/function/function_binder.hpp
@@ -213,8 +213,11 @@ public:
 private:
 	//! Cast a set of expressions to the arguments of this function
 	void CastToFunctionArguments(BoundSimpleFunction &function, vector<unique_ptr<Expression>> &children);
+	//! Cast the arguments an argument pack collected to the types the function settled on
+	void CastArgumentPack(Expression &pack, LogicalType &pack_type);
 
-	void ResolveTemplateTypes(BoundSimpleFunction &bound_function, const vector<unique_ptr<Expression>> &children);
+	void ResolveTemplateTypes(const FunctionSignature &sig, BoundSimpleFunction &bound_function,
+	                          const vector<unique_ptr<Expression>> &children);
 	void CheckTemplateTypesResolved(const BoundSimpleFunction &bound_function);
 
 	optional_idx BindFunctionCost(const SimpleFunction &func, const vector<LogicalType> &arguments,

--- a/src/include/duckdb/function/function_binder.hpp
+++ b/src/include/duckdb/function/function_binder.hpp
@@ -114,8 +114,7 @@ public:
 	                                                     optional_ptr<Binder> binder = nullptr);
 
 	//! Bind a scalar function from a catalog entry given the full list of (maybe-named) bound arguments. The
-	//! positional/named split is resolved per candidate overload (overloads flagged to capture argument aliases
-	//! treat every argument as positional and keep its alias).
+	//! positional/named split is resolved per candidate overload.
 	DUCKDB_API unique_ptr<Expression> BindScalarFunction(const ScalarFunctionCatalogEntry &function,
 	                                                     vector<pair<Identifier, unique_ptr<Expression>>> arguments,
 	                                                     ErrorData &error, bool is_operator = false,

--- a/src/include/duckdb/function/function_serialization.hpp
+++ b/src/include/duckdb/function/function_serialization.hpp
@@ -14,6 +14,7 @@
 #include "duckdb/common/serializer/serializer.hpp"
 #include "duckdb/common/serializer/deserializer.hpp"
 #include "duckdb/function/function_binder.hpp"
+#include "duckdb/planner/expression/bound_argument_pack.hpp"
 
 namespace duckdb {
 class ClientContext;
@@ -21,10 +22,12 @@ class ClientContext;
 class FunctionSerializer {
 public:
 	template <class FUNC>
-	static void Serialize(Serializer &serializer, const FUNC &function, optional_ptr<FunctionData> bind_info) {
+	static void Serialize(Serializer &serializer, const FUNC &function, optional_ptr<FunctionData> bind_info,
+	                      optional_ptr<const vector<LogicalType>> arguments_override = nullptr) {
 		D_ASSERT(!function.GetName().empty());
 		serializer.WriteProperty(500, "name", function.GetName());
-		serializer.WriteProperty(501, "arguments", function.GetArguments());
+		// storage versions that predate argument packs get the unrolled argument list (see ArgumentPack::Unroll)
+		serializer.WriteProperty(501, "arguments", arguments_override ? *arguments_override : function.GetArguments());
 		serializer.WriteProperty(502, "original_arguments", function.GetOriginalArguments());
 		// These are optional fields that are written out of numeric order, older
 		// databases won't contain the fields, so the defaults will be used, but if

--- a/src/include/duckdb/function/function_serialization.hpp
+++ b/src/include/duckdb/function/function_serialization.hpp
@@ -65,6 +65,34 @@ public:
 		return function;
 	}
 
+	//! Argument packs are written to disk unrolled (see ArgumentPack::Unroll), so a call read back from disk has to
+	//! be rolled up again. Table/pragma functions have no FunctionSignature and never pack.
+	static bool TryReroll(const SimpleFunction &function, vector<unique_ptr<Expression>> &children,
+	                      vector<LogicalType> &arguments, bool keywords_only = false) {
+		auto &sig = function.GetSignature();
+		if (keywords_only && !sig.GetVarKeywordIndex().IsValid()) {
+			return false;
+		}
+		return ArgumentPack::Reroll(sig, children, arguments);
+	}
+	static bool TryReroll(const SimpleNamedParameterFunction &, vector<unique_ptr<Expression>> &, vector<LogicalType> &,
+	                      bool = false) {
+		return false;
+	}
+
+	//! A "**kwargs" call has to be rolled up before the overload lookup, because its arguments only match the
+	//! signature once they are packed - and only the pack carries their names, which the unrolled form left in the
+	//! expression aliases.
+	template <class CATALOG_ENTRY>
+	static void RerollKeywordArguments(const CATALOG_ENTRY &functions, vector<unique_ptr<Expression>> &children,
+	                                   vector<LogicalType> &arguments) {
+		for (auto &candidate : functions.functions.functions) {
+			if (TryReroll(candidate, children, arguments, true)) {
+				return;
+			}
+		}
+	}
+
 	template <class FUNC, class CATALOG_ENTRY>
 	static pair<FUNC, bool> DeserializeBase(Deserializer &deserializer, CatalogType catalog_type,
 	                                        optional_ptr<vector<unique_ptr<Expression>>> children = nullptr) {
@@ -91,10 +119,19 @@ public:
 			}
 		}
 
+		if (children && original_arguments.empty()) {
+			auto &pack_catalog =
+			    Catalog::GetEntry(context, catalog_type, QualifiedName(catalog_name, schema_name, name));
+			RerollKeywordArguments(pack_catalog.template Cast<CATALOG_ENTRY>(), *children, arguments);
+		}
 		auto function = DeserializeFunction<FUNC, CATALOG_ENTRY>(context, catalog_type, catalog_name, schema_name, name,
 		                                                         arguments, original_arguments);
 		auto has_serialize = deserializer.ReadProperty<bool>(503, "has_serialize");
 		if (has_serialize) {
+			// nothing re-binds this call, so its argument packs have to be rebuilt here
+			if (children) {
+				TryReroll(function, *children, arguments);
+			}
 			function.GetArguments() = std::move(arguments);
 			function.GetOriginalArguments() = std::move(original_arguments);
 		}
@@ -190,6 +227,9 @@ public:
 			                        name.GetIdentifierName());
 		}
 		auto &functions = func_catalog.Cast<CATALOG_ENTRY>();
+		if (original_arguments.empty()) {
+			RerollKeywordArguments(functions, children, arguments);
+		}
 		const auto &function = functions.functions.GetFunctionByArguments(
 		    context, original_arguments.empty() ? arguments : original_arguments);
 
@@ -213,7 +253,9 @@ public:
 			}
 		}
 
-		// Otherwise, construct the bound function from its parts
+		// Otherwise, construct the bound function from its parts - nothing re-binds this call, so its argument
+		// packs have to be rebuilt here
+		TryReroll(function, children, arguments);
 		FUNC bound_function(function);
 		bound_function.GetArguments() = std::move(arguments);
 		bound_function.GetOriginalArguments() = std::move(original_arguments);

--- a/src/include/duckdb/function/scalar_function.hpp
+++ b/src/include/duckdb/function/scalar_function.hpp
@@ -403,7 +403,6 @@ public:
 class ScalarFunction : public BaseScalarFunction<ScalarFunction>,
                        public SimpleFunction { // NOLINT: work-around bug in clang-tidy
 public:
-
 	DUCKDB_API ScalarFunction(Identifier name, FunctionSignature sig, scalar_function_t function = nullptr);
 	DUCKDB_API ScalarFunction(Identifier name, vector<LogicalType> arguments, LogicalType return_type,
 	                          scalar_function_t function, bind_scalar_function_t bind = nullptr,

--- a/src/include/duckdb/function/scalar_function.hpp
+++ b/src/include/duckdb/function/scalar_function.hpp
@@ -219,90 +219,90 @@ public:
 	// clang-format off
 	auto GetProperties() const -> const FunctionProperties & { return properties; }
 	auto GetProperties() -> FunctionProperties & { return properties; }
-	auto SetProperties(const FunctionProperties &properties_p) -> void { properties = properties_p; }
+	auto SetProperties(const FunctionProperties &properties_p) -> IMPL & { properties = properties_p; return static_cast<IMPL &>(*this); }
 
 	auto GetCallbacks() const -> const ScalarFunctionCallbacks & { return callbacks; }
 	auto GetCallbacks() -> ScalarFunctionCallbacks & { return callbacks; }
-	auto SetCallbacks(const ScalarFunctionCallbacks &callbacks_p) -> void { callbacks = callbacks_p; }
+	auto SetCallbacks(const ScalarFunctionCallbacks &callbacks_p) -> IMPL & { callbacks = callbacks_p; return static_cast<IMPL &>(*this); }
 
 public: // Properties
 
 	auto GetStability() const -> FunctionStability { return properties.stability; }
-	auto SetStability(FunctionStability value) -> void { properties.stability = value; }
+	auto SetStability(FunctionStability value) -> IMPL & { properties.stability = value; return static_cast<IMPL &>(*this); }
 
 	auto GetNullHandling() const -> FunctionNullHandling { return properties.null_handling; }
-	auto SetNullHandling(FunctionNullHandling value) -> void { properties.null_handling = value; }
+	auto SetNullHandling(FunctionNullHandling value) -> IMPL & { properties.null_handling = value; return static_cast<IMPL &>(*this); }
 
 	auto GetErrorMode() const -> FunctionErrors { return properties.errors; }
-	auto SetErrorMode(FunctionErrors value) -> void { properties.errors = value; }
+	auto SetErrorMode(FunctionErrors value) -> IMPL & { properties.errors = value; return static_cast<IMPL &>(*this); }
 
 	auto GetCollationHandling() const -> FunctionCollationHandling { return properties.collation_handling; }
-	auto SetCollationHandling(FunctionCollationHandling value) -> void { properties.collation_handling = value; }
+	auto SetCollationHandling(FunctionCollationHandling value) -> IMPL & { properties.collation_handling = value; return static_cast<IMPL &>(*this); }
 
 	auto GetCaptureArgumentAliases() const -> bool { return properties.capture_argument_aliases; }
-	auto SetCaptureArgumentAliases(bool value) -> void { properties.capture_argument_aliases = value; }
+	auto SetCaptureArgumentAliases(bool value) -> IMPL & { properties.capture_argument_aliases = value; return static_cast<IMPL &>(*this); }
 
 	auto RequiresOrderedExecution() const -> bool { return properties.requires_ordered_execution; }
-	auto SetRequiresOrderedExecution(bool value) -> void { properties.requires_ordered_execution = value; }
+	auto SetRequiresOrderedExecution(bool value) -> IMPL & { properties.requires_ordered_execution = value; return static_cast<IMPL &>(*this); }
 
 	//! Set this functions error-mode as fallible (can throw runtime errors)
-	void SetFallible() { properties.errors = FunctionErrors::CAN_THROW_RUNTIME_ERROR; }
+	auto SetFallible() -> IMPL & { properties.errors = FunctionErrors::CAN_THROW_RUNTIME_ERROR; return static_cast<IMPL &>(*this); }
 	//! Set this functions stability as volatile (can not be cached per row)
-	void SetVolatile() { properties.stability = FunctionStability::VOLATILE; }
+	auto SetVolatile() -> IMPL & { properties.stability = FunctionStability::VOLATILE; return static_cast<IMPL &>(*this); }
 
 public: // Callbacks
 
 	auto HasFunctionCallback() const -> bool { return callbacks.function != nullptr; }
 	auto GetFunctionCallback() const -> scalar_function_t { return callbacks.function; }
-	auto SetFunctionCallback(scalar_function_t callback) -> void { callbacks.function = std::move(callback); }
+	auto SetFunctionCallback(scalar_function_t callback) -> IMPL & { callbacks.function = std::move(callback); return static_cast<IMPL &>(*this); }
 
 	auto HasSelectCallback() const -> bool { return callbacks.select_function != nullptr; }
 	auto GetSelectCallback() const -> scalar_function_select_t { return callbacks.select_function; }
-	auto SetSelectCallback(scalar_function_select_t callback) -> void { callbacks.select_function = callback; }
+	auto SetSelectCallback(scalar_function_select_t callback) -> IMPL & { callbacks.select_function = callback; return static_cast<IMPL &>(*this); }
 
 	auto HasBindCallback() const -> bool { return callbacks.bind != nullptr; };
 	auto GetBindCallback() const -> bind_scalar_function_t { return callbacks.bind; };
-	auto SetBindCallback(bind_scalar_function_t callback) -> void { callbacks.bind = callback; }
+	auto SetBindCallback(bind_scalar_function_t callback) -> IMPL & { callbacks.bind = callback; return static_cast<IMPL &>(*this); }
 
 	auto HasBindLambdaCallback() const -> bool { return callbacks.bind_lambda != nullptr; }
 	auto GetBindLambdaCallback() const -> bind_lambda_function_t { return callbacks.bind_lambda; }
-	auto SetBindLambdaCallback(bind_lambda_function_t callback) -> void { callbacks.bind_lambda = callback; }
+	auto SetBindLambdaCallback(bind_lambda_function_t callback) -> IMPL & { callbacks.bind_lambda = callback; return static_cast<IMPL &>(*this); }
 
 	auto HasBindExpressionCallback() const -> bool { return callbacks.bind_expression != nullptr; }
 	auto GetBindExpressionCallback() const -> function_bind_expression_t { return callbacks.bind_expression; }
-	auto SetBindExpressionCallback(function_bind_expression_t callback) -> void { callbacks.bind_expression = callback; }
+	auto SetBindExpressionCallback(function_bind_expression_t callback) -> IMPL & { callbacks.bind_expression = callback; return static_cast<IMPL &>(*this); }
 
 	auto HasInitStateCallback() const -> bool { return callbacks.init_local_state != nullptr; }
 	auto GetInitStateCallback() const -> init_local_state_t { return callbacks.init_local_state; }
-	auto SetInitStateCallback(init_local_state_t callback) -> void { callbacks.init_local_state = callback; }
+	auto SetInitStateCallback(init_local_state_t callback) -> IMPL & { callbacks.init_local_state = callback; return static_cast<IMPL &>(*this); }
 
 	auto HasStatisticsCallback() const -> bool { return callbacks.statistics != nullptr; }
 	auto GetStatisticsCallback() const -> function_statistics_t { return callbacks.statistics; }
-	auto SetStatisticsCallback(function_statistics_t callback) -> void { callbacks.statistics = callback; }
+	auto SetStatisticsCallback(function_statistics_t callback) -> IMPL & { callbacks.statistics = callback; return static_cast<IMPL &>(*this); }
 
 	auto HasModifiedDatabasesCallback() const -> bool { return callbacks.get_modified_databases != nullptr; }
 	auto GetModifiedDatabasesCallback() const -> get_modified_databases_t { return callbacks.get_modified_databases; }
-	auto SetModifiedDatabasesCallback(get_modified_databases_t callback) -> void { callbacks.get_modified_databases = callback; }
+	auto SetModifiedDatabasesCallback(get_modified_databases_t callback) -> IMPL & { callbacks.get_modified_databases = callback; return static_cast<IMPL &>(*this); }
 
 	auto HasSerializationCallbacks() const -> bool { return callbacks.serialize != nullptr && callbacks.deserialize != nullptr; }
-	auto SetSerializeCallback(function_serialize_t callback) -> void { callbacks.serialize = callback; }
-	auto SetDeserializeCallback(function_deserialize_t callback) -> void { callbacks.deserialize = callback; }
+	auto SetSerializeCallback(function_serialize_t callback) -> IMPL & { callbacks.serialize = callback; return static_cast<IMPL &>(*this); }
+	auto SetDeserializeCallback(function_deserialize_t callback) -> IMPL & { callbacks.deserialize = callback; return static_cast<IMPL &>(*this); }
 	auto GetSerializeCallback() const -> function_serialize_t { return callbacks.serialize; }
 	auto GetDeserializeCallback() const -> function_deserialize_t { return callbacks.deserialize; }
 
 	auto HasFilterPruneCallback() const -> bool { return callbacks.filter_prune != nullptr; }
-	auto SetFilterPruneCallback(propagate_filter_t callback) -> void { callbacks.filter_prune = callback; }
+	auto SetFilterPruneCallback(propagate_filter_t callback) -> IMPL & { callbacks.filter_prune = callback; return static_cast<IMPL &>(*this); }
 	auto GetFilterPruneCallback() const -> propagate_filter_t { return callbacks.filter_prune; }
 
 	auto HasToStringCallback() const -> bool { return callbacks.to_string != nullptr; }
-	auto SetToStringCallback(function_to_string_t callback) -> void { callbacks.to_string = callback; }
+	auto SetToStringCallback(function_to_string_t callback) -> IMPL & { callbacks.to_string = callback; return static_cast<IMPL &>(*this); }
 	auto FunctionToString(FunctionToStringInput &input) const -> string { return callbacks.to_string(input); }
 
 	auto HasLegacySerializeCallback() const -> bool { return callbacks.legacy_serialize != nullptr; }
-	auto SetLegacySerializeCallback(function_legacy_serialize_t callback) -> void { callbacks.legacy_serialize = callback; }
+	auto SetLegacySerializeCallback(function_legacy_serialize_t callback) -> IMPL & { callbacks.legacy_serialize = callback; return static_cast<IMPL &>(*this); }
 	auto GetLegacySerializeCallback() const -> function_legacy_serialize_t { return callbacks.legacy_serialize; }
 
-	auto SetGetExpressionTypeCallback(function_get_expression_type_t callback) -> void { callbacks.get_expression_type = callback; }
+	auto SetGetExpressionTypeCallback(function_get_expression_type_t callback) -> IMPL & { callbacks.get_expression_type = callback; return static_cast<IMPL &>(*this); }
 	auto GetExpressionType(FunctionToStringInput &input) const -> ExpressionType {
 		if (callbacks.get_expression_type) {
 			return callbacks.get_expression_type(input);
@@ -346,12 +346,14 @@ public:
 		D_ASSERT(function_info.get());
 		return *function_info;
 	}
-	void SetExtraFunctionInfo(shared_ptr<ScalarFunctionInfo> info) {
+	IMPL &SetExtraFunctionInfo(shared_ptr<ScalarFunctionInfo> info) {
 		function_info = std::move(info);
+		return static_cast<IMPL &>(*this);
 	}
 	template <class T, class... ARGS>
-	void SetExtraFunctionInfo(ARGS &&... args) {
+	IMPL &SetExtraFunctionInfo(ARGS &&... args) {
 		function_info = make_shared_ptr<T>(std::forward<ARGS>(args)...);
+		return static_cast<IMPL &>(*this);
 	}
 	shared_ptr<ScalarFunctionInfo> GetFunctionInfo() const {
 		return function_info;
@@ -401,7 +403,8 @@ public:
 class ScalarFunction : public BaseScalarFunction<ScalarFunction>,
                        public SimpleFunction { // NOLINT: work-around bug in clang-tidy
 public:
-	DUCKDB_API ScalarFunction(Identifier name, FunctionSignature sig, scalar_function_t function);
+
+	DUCKDB_API ScalarFunction(Identifier name, FunctionSignature sig, scalar_function_t function = nullptr);
 	DUCKDB_API ScalarFunction(Identifier name, vector<LogicalType> arguments, LogicalType return_type,
 	                          scalar_function_t function, bind_scalar_function_t bind = nullptr,
 	                          function_statistics_t statistics = nullptr, init_local_state_t init_local_state = nullptr,

--- a/src/include/duckdb/function/scalar_function.hpp
+++ b/src/include/duckdb/function/scalar_function.hpp
@@ -239,9 +239,6 @@ public: // Properties
 	auto GetCollationHandling() const -> FunctionCollationHandling { return properties.collation_handling; }
 	auto SetCollationHandling(FunctionCollationHandling value) -> IMPL & { properties.collation_handling = value; return static_cast<IMPL &>(*this); }
 
-	auto GetCaptureArgumentAliases() const -> bool { return properties.capture_argument_aliases; }
-	auto SetCaptureArgumentAliases(bool value) -> IMPL & { properties.capture_argument_aliases = value; return static_cast<IMPL &>(*this); }
-
 	auto RequiresOrderedExecution() const -> bool { return properties.requires_ordered_execution; }
 	auto SetRequiresOrderedExecution(bool value) -> IMPL & { properties.requires_ordered_execution = value; return static_cast<IMPL &>(*this); }
 

--- a/src/include/duckdb/function/scalar_function.hpp
+++ b/src/include/duckdb/function/scalar_function.hpp
@@ -404,7 +404,6 @@ public:
 	DUCKDB_API ScalarFunction(Identifier name, vector<LogicalType> arguments, LogicalType return_type,
 	                          scalar_function_t function, bind_scalar_function_t bind = nullptr,
 	                          function_statistics_t statistics = nullptr, init_local_state_t init_local_state = nullptr,
-	                          LogicalType varargs = LogicalType(LogicalTypeId::INVALID),
 	                          FunctionStability stability = FunctionStability::CONSISTENT,
 	                          FunctionNullHandling null_handling = FunctionNullHandling::DEFAULT_NULL_HANDLING,
 	                          bind_lambda_function_t bind_lambda = nullptr);
@@ -412,7 +411,6 @@ public:
 	DUCKDB_API ScalarFunction(vector<LogicalType> arguments, LogicalType return_type, scalar_function_t function,
 	                          bind_scalar_function_t bind = nullptr, function_statistics_t statistics = nullptr,
 	                          init_local_state_t init_local_state = nullptr,
-	                          LogicalType varargs = LogicalType(LogicalTypeId::INVALID),
 	                          FunctionStability stability = FunctionStability::CONSISTENT,
 	                          FunctionNullHandling null_handling = FunctionNullHandling::DEFAULT_NULL_HANDLING,
 	                          bind_lambda_function_t bind_lambda = nullptr);
@@ -420,7 +418,6 @@ public:
 	DUCKDB_API ScalarFunction(Identifier name, std::initializer_list<FunctionParameter> params, LogicalType return_type,
 	                          scalar_function_t function, bind_scalar_function_t bind = nullptr,
 	                          function_statistics_t statistics = nullptr, init_local_state_t init_local_state = nullptr,
-	                          LogicalType varargs = LogicalType(LogicalTypeId::INVALID),
 	                          FunctionStability stability = FunctionStability::CONSISTENT,
 	                          FunctionNullHandling null_handling = FunctionNullHandling::DEFAULT_NULL_HANDLING,
 	                          bind_lambda_function_t bind_lambda = nullptr);
@@ -428,7 +425,6 @@ public:
 	DUCKDB_API ScalarFunction(std::initializer_list<FunctionParameter> params, LogicalType return_type,
 	                          scalar_function_t function, bind_scalar_function_t bind = nullptr,
 	                          function_statistics_t statistics = nullptr, init_local_state_t init_local_state = nullptr,
-	                          LogicalType varargs = LogicalType(LogicalTypeId::INVALID),
 	                          FunctionStability stability = FunctionStability::CONSISTENT,
 	                          FunctionNullHandling null_handling = FunctionNullHandling::DEFAULT_NULL_HANDLING,
 	                          bind_lambda_function_t bind_lambda = nullptr);

--- a/src/include/duckdb/parser/expression/function_expression.hpp
+++ b/src/include/duckdb/parser/expression/function_expression.hpp
@@ -37,6 +37,10 @@ public:
 		return !name.empty();
 	}
 
+	void SetName(Identifier name_p) {
+		name = std::move(name_p);
+	}
+
 	unique_ptr<ParsedExpression> &GetExpressionMutable() {
 		return expression;
 	}
@@ -162,6 +166,11 @@ public:
 
 	//! Returns a pointer to the lambda expression, if the function has a lambda expression as a child, else nullptr.
 	optional_ptr<ParsedExpression> IsLambdaFunction();
+
+	//! struct_pack takes its field names from its argument names. Name any argument that was written without one
+	//! after the column it references, so that struct_pack(a, b) means struct_pack(a := a, b := b). Does nothing
+	//! unless this is a call to struct_pack.
+	DUCKDB_API void ApplyImplicitFieldNames();
 
 	bool IsLegacyFunctionCall() const {
 		return is_legacy_function_call;

--- a/src/include/duckdb/planner/expression/bound_argument_pack.hpp
+++ b/src/include/duckdb/planner/expression/bound_argument_pack.hpp
@@ -24,6 +24,12 @@ struct ArgumentPack {
 	//! packed a second time.
 	static constexpr const char *TYPE_ALIAS = "__argument_pack";
 
+	static const vector<Vector> &GetInput(const Vector &pack);
+
+	static const child_list_t<LogicalType> &GetTypes(const LogicalType &pack);
+
+	static idx_t GetSize(const LogicalType &pack);
+
 	//! Whether the given type is the type of an argument pack
 	static bool IsPackType(const LogicalType &type);
 

--- a/src/include/duckdb/planner/expression/bound_argument_pack.hpp
+++ b/src/include/duckdb/planner/expression/bound_argument_pack.hpp
@@ -51,6 +51,9 @@ struct ArgumentPack {
 	//! callback.
 	static vector<unique_ptr<Expression>> &GetPackedChildren(Expression &pack);
 
+	//! Recompute the pack's type from the arguments it currently holds. A bind callback that rewrites them - by
+	//! casting one, say - has to call this so that the pack still describes what it holds.
+	static void RefreshType(Expression &pack);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/planner/expression/bound_argument_pack.hpp
+++ b/src/include/duckdb/planner/expression/bound_argument_pack.hpp
@@ -33,6 +33,10 @@ struct ArgumentPack {
 	//! Whether the given type is the type of an argument pack
 	static bool IsPackType(const LogicalType &type);
 
+	//! Whether the given expression is still a pack expression. A pack is built by the binder, but the optimizer
+	//! may replace it with an expression of the same type - a constant, say - that no longer holds the arguments.
+	static bool IsPack(const Expression &expr);
+
 	//! The type of a "*args" pack over the given element types: an unnamed TUPLE carrying the pack alias
 	static LogicalType PositionalType(vector<LogicalType> element_types);
 	//! The type of a "**kwargs" pack: a STRUCT keyed by the caller's argument names, carrying the pack alias
@@ -43,14 +47,21 @@ struct ArgumentPack {
 	//! NULL members, and it is up to the function to decide what they mean.
 	static unique_ptr<Expression> Create(vector<unique_ptr<Expression>> children, LogicalType pack_type);
 
-	//! Flatten a bound call's argument packs back into the plain argument list the call was written with, which is
-	//! how a call to the same function looked before it took *args/**kwargs. Used when serializing to a storage
-	//! format that predates argument packs - reading such a call back simply binds the trailing arguments into
-	//! packs again. Only a call shaped like a pre-pack variadic one (leading positional arguments followed by the
-	//! "*args" pack) can be put back together that way, so anything else throws. Returns false if the call has no
-	//! packs, leaving the outputs untouched.
-	static bool Unroll(const vector<unique_ptr<Expression>> &children, const vector<LogicalType> &arguments,
-	                   vector<unique_ptr<Expression>> &flat_children, vector<LogicalType> &flat_arguments);
+	//! Flatten a bound call's argument packs back into the plain argument list the call was written with, so that
+	//! packs never reach disk - Reroll builds them again when the call is read back. A "**kwargs" pack is
+	//! flattened with its field names in the expression aliases. Only a call with a single trailing pack can be
+	//! put back together that way: anything else is written as-is, unless the storage version predates argument
+	//! packs, in which case it cannot be represented at all and this throws. Returns false when nothing was
+	//! unrolled, leaving the outputs untouched.
+	static bool Unroll(Serializer &serializer, const vector<unique_ptr<Expression>> &children,
+	                   const vector<LogicalType> &arguments, vector<unique_ptr<Expression>> &flat_children,
+	                   vector<LogicalType> &flat_arguments);
+
+	//! The inverse of Unroll: collect the trailing arguments of a call read back from disk into the pack the
+	//! signature declares. A "**kwargs" pack is keyed by the expression aliases, which is where Unroll left the
+	//! field names. Returns false when there is nothing to roll up.
+	static bool Reroll(const FunctionSignature &sig, vector<unique_ptr<Expression>> &children,
+	                   vector<LogicalType> &arguments);
 
 	//! The collected arguments, in place. A pack is built by the binder and only replaced afterwards, by the
 	//! optimizer, which the binder undoes before re-binding a call - so this is always reachable from a bind

--- a/src/include/duckdb/planner/expression/bound_argument_pack.hpp
+++ b/src/include/duckdb/planner/expression/bound_argument_pack.hpp
@@ -36,6 +36,15 @@ struct ArgumentPack {
 	//! child per packed expression. A pack is never NULL itself: NULLs among the packed arguments stay visible as
 	//! NULL members, and it is up to the function to decide what they mean.
 	static unique_ptr<Expression> Create(vector<unique_ptr<Expression>> children, LogicalType pack_type);
+
+	//! Flatten a bound call's argument packs back into the plain argument list the call was written with, which is
+	//! how a call to the same function looked before it took *args/**kwargs. Used when serializing to a storage
+	//! format that predates argument packs - reading such a call back simply binds the trailing arguments into
+	//! packs again. Only a call shaped like a pre-pack variadic one (leading positional arguments followed by the
+	//! "*args" pack) can be put back together that way, so anything else throws. Returns false if the call has no
+	//! packs, leaving the outputs untouched.
+	static bool Unroll(const vector<unique_ptr<Expression>> &children, const vector<LogicalType> &arguments,
+	                   vector<unique_ptr<Expression>> &flat_children, vector<LogicalType> &flat_arguments);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/planner/expression/bound_argument_pack.hpp
+++ b/src/include/duckdb/planner/expression/bound_argument_pack.hpp
@@ -25,6 +25,7 @@ struct ArgumentPack {
 	static constexpr const char *TYPE_ALIAS = "__argument_pack";
 
 	static const vector<Vector> &GetInput(const Vector &pack);
+	static vector<Vector> &GetInput(Vector &pack);
 
 	static const child_list_t<LogicalType> &GetTypes(const LogicalType &pack);
 

--- a/src/include/duckdb/planner/expression/bound_argument_pack.hpp
+++ b/src/include/duckdb/planner/expression/bound_argument_pack.hpp
@@ -1,0 +1,43 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/planner/expression/bound_argument_pack.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/function/function.hpp"
+#include "duckdb/planner/expression/bound_operator_expression.hpp"
+
+namespace duckdb {
+
+//! An argument pack fills a "*args" or "**kwargs" parameter of a function call: it collects the arguments that the
+//! parameter captured and presents them to the function as a single TUPLE (for *args) or STRUCT (for **kwargs) value.
+//! It is a BoundOperatorExpression of type ARGUMENT_PACK - not a function call - so that variadic functions can be
+//! used to build one without the binder recursing. This struct is only a set of helper methods.
+struct ArgumentPack {
+	//! Argument pack types carry this reserved alias. Only the binder ever builds one, so the alias is what tells a
+	//! pack apart from a TUPLE/STRUCT the caller passed as an ordinary argument - which matters because a bound
+	//! function call is serialized as-is, and on deserialization the packs come back already built and must not be
+	//! packed a second time.
+	static constexpr const char *TYPE_ALIAS = "__argument_pack";
+
+	//! Whether the given expression is an argument pack
+	static bool IsPack(const Expression &expr);
+	//! Whether the given type is the type of an argument pack
+	static bool IsPackType(const LogicalType &type);
+
+	//! The type of a "*args" pack over the given element types: an unnamed TUPLE carrying the pack alias
+	static LogicalType PositionalType(vector<LogicalType> element_types);
+	//! The type of a "**kwargs" pack: a STRUCT keyed by the caller's argument names, carrying the pack alias
+	static LogicalType KeywordType(child_list_t<LogicalType> value_types);
+
+	//! Create an argument pack of the given type, which must have come from PositionalType/KeywordType and have one
+	//! child per packed expression. A pack is never NULL itself: NULLs among the packed arguments stay visible as
+	//! NULL members, and it is up to the function to decide what they mean.
+	static unique_ptr<Expression> Create(vector<unique_ptr<Expression>> children, LogicalType pack_type);
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/planner/expression/bound_argument_pack.hpp
+++ b/src/include/duckdb/planner/expression/bound_argument_pack.hpp
@@ -24,8 +24,6 @@ struct ArgumentPack {
 	//! packed a second time.
 	static constexpr const char *TYPE_ALIAS = "__argument_pack";
 
-	//! Whether the given expression is an argument pack
-	static bool IsPack(const Expression &expr);
 	//! Whether the given type is the type of an argument pack
 	static bool IsPackType(const LogicalType &type);
 

--- a/src/include/duckdb/planner/expression/bound_argument_pack.hpp
+++ b/src/include/duckdb/planner/expression/bound_argument_pack.hpp
@@ -45,6 +45,12 @@ struct ArgumentPack {
 	//! packs, leaving the outputs untouched.
 	static bool Unroll(const vector<unique_ptr<Expression>> &children, const vector<LogicalType> &arguments,
 	                   vector<unique_ptr<Expression>> &flat_children, vector<LogicalType> &flat_arguments);
+
+	//! The collected arguments, in place. A pack is built by the binder and only replaced afterwards, by the
+	//! optimizer, which the binder undoes before re-binding a call - so this is always reachable from a bind
+	//! callback.
+	static vector<unique_ptr<Expression>> &GetPackedChildren(Expression &pack);
+
 };
 
 } // namespace duckdb

--- a/src/main/capi/scalar_function-c.cpp
+++ b/src/main/capi/scalar_function-c.cpp
@@ -6,6 +6,9 @@
 #include "duckdb/main/capi/capi_internal.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/parser/parsed_data/create_scalar_function_info.hpp"
+#include "duckdb/common/vector/struct_vector.hpp"
+#include "duckdb/planner/expression/bound_argument_pack.hpp"
+#include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 
 namespace duckdb {
@@ -153,6 +156,91 @@ duckdb_function_info ToCScalarFunctionInfo(duckdb::CScalarFunctionInternalFuncti
 }
 
 //===--------------------------------------------------------------------===//
+// Argument packs
+//===--------------------------------------------------------------------===//
+// duckdb_scalar_function_set_varargs maps onto a "*args" parameter, which hands the function a single TUPLE of the
+// trailing arguments. The C API predates argument packs and is documented to pass one argument per value, so the
+// pack is spread back out before anything C-facing sees it.
+
+bool HasArgumentPack(const vector<unique_ptr<Expression>> &arguments) {
+	for (auto &argument : arguments) {
+		if (ArgumentPack::IsPackType(argument->GetReturnType())) {
+			return true;
+		}
+	}
+	return false;
+}
+
+vector<unique_ptr<Expression>> &UnpackArguments(const BoundScalarFunction &bound_function,
+                                                vector<unique_ptr<Expression>> &arguments,
+                                                vector<unique_ptr<Expression>> &unpacked) {
+	if (!HasArgumentPack(arguments)) {
+		return arguments;
+	}
+	for (auto &argument : arguments) {
+		if (!ArgumentPack::IsPackType(argument->GetReturnType())) {
+			unpacked.push_back(argument->Copy());
+			continue;
+		}
+		if (argument->GetExpressionType() == ExpressionType::VALUE_CONSTANT) {
+			// the pack collected only constants and was folded into a single struct value
+			auto &value = argument->Cast<BoundConstantExpression>().GetValue();
+			for (auto &packed_value : StructValue::GetChildren(value)) {
+				unpacked.push_back(make_uniq<BoundConstantExpression>(packed_value));
+			}
+			continue;
+		}
+		if (argument->GetExpressionClass() != ExpressionClass::BOUND_OPERATOR) {
+			throw BinderException("Cannot pass the arguments of %s to a C scalar function individually - its "
+			                      "argument pack was replaced by a %s expression",
+			                      bound_function.GetName(), ExpressionTypeToString(argument->GetExpressionType()));
+		}
+		for (auto &packed : argument->Cast<BoundOperatorExpression>().GetChildren()) {
+			unpacked.push_back(packed->Copy());
+		}
+	}
+	return unpacked;
+}
+
+DataChunk &UnpackChunk(DataChunk &input, DataChunk &unpacked) {
+	bool has_pack = false;
+	for (auto &column : input.data) {
+		if (ArgumentPack::IsPackType(column.GetType())) {
+			has_pack = true;
+			break;
+		}
+	}
+	if (!has_pack) {
+		return input;
+	}
+
+	vector<LogicalType> types;
+	for (auto &column : input.data) {
+		if (!ArgumentPack::IsPackType(column.GetType())) {
+			types.push_back(column.GetType());
+			continue;
+		}
+		for (auto &member : StructType::GetChildTypes(column.GetType())) {
+			types.push_back(member.second);
+		}
+	}
+
+	unpacked.InitializeEmpty(types);
+	idx_t index = 0;
+	for (auto &column : input.data) {
+		if (!ArgumentPack::IsPackType(column.GetType())) {
+			unpacked.data[index++].Reference(column);
+			continue;
+		}
+		for (auto &member : StructVector::GetEntries(column)) {
+			unpacked.data[index++].Reference(member);
+		}
+	}
+	unpacked.SetChildCardinality(input.size());
+	return unpacked;
+}
+
+//===--------------------------------------------------------------------===//
 // Scalar Function Callbacks
 //===--------------------------------------------------------------------===//
 
@@ -163,9 +251,14 @@ unique_ptr<FunctionData> CScalarFunctionBind(BindScalarFunctionInput &input) {
 	auto &info = bound_function.GetExtraFunctionInfo().Cast<CScalarFunctionInfo>();
 	D_ASSERT(info.function);
 
+	// a variadic C function is documented to receive one argument per value the call was written with, so the
+	// "*args" parameter its varargs map to is spread back out before the C bind callback sees it
+	vector<unique_ptr<Expression>> unpacked_arguments;
+	auto &bind_arguments = UnpackArguments(bound_function, arguments, unpacked_arguments);
+
 	auto result = make_uniq<CScalarFunctionBindData>(info);
 	if (info.bind) {
-		CScalarFunctionInternalBindInfo bind_info(context, bound_function, arguments, *result);
+		CScalarFunctionInternalBindInfo bind_info(context, bound_function, bind_arguments, *result);
 		info.bind(ToCScalarFunctionBindInfo(bind_info));
 		if (!bind_info.success) {
 			throw BinderException(bind_info.error);
@@ -201,7 +294,11 @@ void CAPIScalarFunction(DataChunk &input, ExpressionState &state, Vector &result
 	auto &c_local_state = ExecuteFunctionState::GetFunctionState(state)->Cast<CScalarFunctionLocalState>();
 
 	input.Flatten();
-	auto c_input = reinterpret_cast<duckdb_data_chunk>(&input);
+
+	// as in CScalarFunctionBind, the members of the "*args" pack are presented as columns of their own
+	DataChunk unpacked_input;
+	auto &c_chunk = UnpackChunk(input, unpacked_input);
+	auto c_input = reinterpret_cast<duckdb_data_chunk>(&c_chunk);
 	auto c_result = reinterpret_cast<duckdb_vector>(&result);
 
 	CScalarFunctionInternalFunctionInfo function_info(c_bind_info, c_local_state);
@@ -251,7 +348,7 @@ void duckdb_scalar_function_set_varargs(duckdb_scalar_function function, duckdb_
 	}
 	auto &scalar_function = GetCScalarFunction(function);
 	auto logical_type = reinterpret_cast<duckdb::LogicalType *>(type);
-	scalar_function.SetVarArgs(*logical_type);
+	scalar_function.GetSignature().AddVarPositionalParameter("varargs", *logical_type);
 }
 
 void duckdb_scalar_function_set_special_handling(duckdb_scalar_function function) {

--- a/src/main/capi/scalar_function-c.cpp
+++ b/src/main/capi/scalar_function-c.cpp
@@ -64,13 +64,13 @@ struct CScalarFunctionBindData : public FunctionData {
 
 struct CScalarFunctionInternalBindInfo {
 	CScalarFunctionInternalBindInfo(ClientContext &context, BoundScalarFunction &bound_function,
-	                                vector<unique_ptr<Expression>> &arguments, CScalarFunctionBindData &bind_data)
+	                                vector<reference<Expression>> &arguments, CScalarFunctionBindData &bind_data)
 	    : context(context), bound_function(bound_function), arguments(arguments), bind_data(bind_data) {
 	}
 
 	ClientContext &context;
 	BoundScalarFunction &bound_function;
-	vector<unique_ptr<Expression>> &arguments;
+	vector<reference<Expression>> &arguments;
 	CScalarFunctionBindData &bind_data;
 
 	bool success = true;
@@ -162,41 +162,15 @@ duckdb_function_info ToCScalarFunctionInfo(duckdb::CScalarFunctionInternalFuncti
 // trailing arguments. The C API predates argument packs and is documented to pass one argument per value, so the
 // pack is spread back out before anything C-facing sees it.
 
-bool HasArgumentPack(const vector<unique_ptr<Expression>> &arguments) {
-	for (auto &argument : arguments) {
-		if (ArgumentPack::IsPackType(argument->GetReturnType())) {
-			return true;
-		}
-	}
-	return false;
-}
-
-vector<unique_ptr<Expression>> &UnpackArguments(const BoundScalarFunction &bound_function,
-                                                vector<unique_ptr<Expression>> &arguments,
-                                                vector<unique_ptr<Expression>> &unpacked) {
-	if (!HasArgumentPack(arguments)) {
-		return arguments;
-	}
+vector<reference<Expression>> UnpackArguments(vector<unique_ptr<Expression>> &arguments) {
+	vector<reference<Expression>> unpacked;
 	for (auto &argument : arguments) {
 		if (!ArgumentPack::IsPackType(argument->GetReturnType())) {
-			unpacked.push_back(argument->Copy());
+			unpacked.push_back(*argument);
 			continue;
 		}
-		if (argument->GetExpressionType() == ExpressionType::VALUE_CONSTANT) {
-			// the pack collected only constants and was folded into a single struct value
-			auto &value = argument->Cast<BoundConstantExpression>().GetValue();
-			for (auto &packed_value : StructValue::GetChildren(value)) {
-				unpacked.push_back(make_uniq<BoundConstantExpression>(packed_value));
-			}
-			continue;
-		}
-		if (argument->GetExpressionClass() != ExpressionClass::BOUND_OPERATOR) {
-			throw BinderException("Cannot pass the arguments of %s to a C scalar function individually - its "
-			                      "argument pack was replaced by a %s expression",
-			                      bound_function.GetName(), ExpressionTypeToString(argument->GetExpressionType()));
-		}
-		for (auto &packed : argument->Cast<BoundOperatorExpression>().GetChildren()) {
-			unpacked.push_back(packed->Copy());
+		for (auto &member : ArgumentPack::GetPackedChildren(*argument)) {
+			unpacked.push_back(*member);
 		}
 	}
 	return unpacked;
@@ -253,8 +227,7 @@ unique_ptr<FunctionData> CScalarFunctionBind(BindScalarFunctionInput &input) {
 
 	// a variadic C function is documented to receive one argument per value the call was written with, so the
 	// "*args" parameter its varargs map to is spread back out before the C bind callback sees it
-	vector<unique_ptr<Expression>> unpacked_arguments;
-	auto &bind_arguments = UnpackArguments(bound_function, arguments, unpacked_arguments);
+	auto bind_arguments = UnpackArguments(arguments);
 
 	auto result = make_uniq<CScalarFunctionBindData>(info);
 	if (info.bind) {
@@ -451,7 +424,7 @@ duckdb_expression duckdb_scalar_function_bind_get_argument(duckdb_bind_info info
 	auto &bind_info = GetCScalarFunctionBindInfo(info);
 	try {
 		auto wrapper = duckdb::make_uniq<ExpressionWrapper>();
-		wrapper->expr = bind_info.arguments[index]->Copy();
+		wrapper->expr = bind_info.arguments[index].get().Copy();
 		return reinterpret_cast<duckdb_expression>(wrapper.release());
 	} catch (std::exception &e) {
 		duckdb_scalar_function_bind_set_error(info, e.what());

--- a/src/optimizer/cse_optimizer.cpp
+++ b/src/optimizer/cse_optimizer.cpp
@@ -56,7 +56,12 @@ void CommonSubExpressionOptimizer::CountExpressions(Expression &expr, CSEReplace
 	default:
 		break;
 	}
-	if (expr.GetExpressionClass() != ExpressionClass::BOUND_AGGREGATE && !expr.IsVolatile()) {
+	// an argument pack only makes sense in the argument slot it was built for: hoisting it into a projection would
+	// leave the call holding a column reference, which its "bind" callback cannot read the collected arguments out
+	// of. Nothing is lost by that - building a pack is just referencing the vectors of the arguments it collected,
+	// and those are still considered below.
+	const auto is_argument_pack = expr.GetExpressionType() == ExpressionType::ARGUMENT_PACK;
+	if (expr.GetExpressionClass() != ExpressionClass::BOUND_AGGREGATE && !expr.IsVolatile() && !is_argument_pack) {
 		// we can't move aggregates to a projection, so we only consider the children of the aggregate
 		auto node = state.expression_count.find(expr);
 		if (node == state.expression_count.end()) {

--- a/src/optimizer/expression_rewriter.cpp
+++ b/src/optimizer/expression_rewriter.cpp
@@ -8,6 +8,8 @@
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 
+#include "duckdb/planner/expression/bound_argument_pack.hpp"
+
 namespace duckdb {
 
 struct RewriteFrame {
@@ -87,15 +89,30 @@ unique_ptr<Expression> ExpressionRewriter::ConstantOrNull(unique_ptr<Expression>
 }
 
 unique_ptr<Expression> ExpressionRewriter::ConstantOrNull(vector<unique_ptr<Expression>> children, Value value) {
+	D_ASSERT(!children.empty());
 	auto type = value.type();
 	auto func = ConstantOrNullFun::GetFunction();
 	func.GetSignature().GetParameter(0).SetType(type);
 	func.SetReturnType(type);
-	children.insert(children.begin(), make_uniq<BoundConstantExpression>(value));
+
+	// this bypasses the binder, so the arguments the "*args" parameter collects are packed here
+	vector<unique_ptr<Expression>> packed;
+	vector<LogicalType> packed_types;
+	for (idx_t i = 1; i < children.size(); i++) {
+		packed_types.push_back(children[i]->GetReturnType());
+		packed.push_back(std::move(children[i]));
+	}
+	auto pack_type = ArgumentPack::PositionalType(std::move(packed_types));
+
+	vector<unique_ptr<Expression>> arguments;
+	arguments.push_back(make_uniq<BoundConstantExpression>(value));
+	arguments.push_back(std::move(children[0]));
+	arguments.push_back(ArgumentPack::Create(std::move(packed), pack_type));
 
 	BoundScalarFunction bound_func(func);
+	bound_func.GetArguments() = {type, arguments[1]->GetReturnType(), std::move(pack_type)};
 
-	return make_uniq<BoundFunctionExpression>(std::move(bound_func), std::move(children),
+	return make_uniq<BoundFunctionExpression>(std::move(bound_func), std::move(arguments),
 	                                          ConstantOrNull::Bind(std::move(value)));
 }
 

--- a/src/optimizer/rule/comparison_simplification.cpp
+++ b/src/optimizer/rule/comparison_simplification.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/helper.hpp"
 #include "duckdb/common/types/timestamp.hpp"
 #include "duckdb/execution/expression_executor.hpp"
+#include "duckdb/planner/expression/bound_argument_pack.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/optimizer/expression_rewriter.hpp"
 #include "duckdb/planner/expression/bound_comparison_expression.hpp"
@@ -120,8 +121,13 @@ unique_ptr<Expression> RowComparisonSimplificationRule::Apply(LogicalOperator &o
 	if (left.Function().GetName() != "row" || right.Function().GetName() != "row") {
 		return nullptr;
 	}
-	auto &left_children = left.GetChildrenMutable();
-	auto &right_children = right.GetChildrenMutable();
+	// "row" collects its arguments into an "*args" pack, so its elements are one level down
+	if (left.GetChildren().size() != 1 || right.GetChildren().size() != 1 ||
+	    !ArgumentPack::IsPack(*left.GetChildren()[0]) || !ArgumentPack::IsPack(*right.GetChildren()[0])) {
+		return nullptr;
+	}
+	auto &left_children = ArgumentPack::GetPackedChildren(*left.GetChildrenMutable()[0]);
+	auto &right_children = ArgumentPack::GetPackedChildren(*right.GetChildrenMutable()[0]);
 	if (left_children.empty() || left_children.size() != right_children.size()) {
 		return nullptr;
 	}

--- a/src/optimizer/rule/least_greatest_simplification.cpp
+++ b/src/optimizer/rule/least_greatest_simplification.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/optimizer/rule/least_greatest_simplification.hpp"
 
 #include "duckdb/optimizer/matcher/expression_matcher.hpp"
+#include "duckdb/planner/expression/bound_argument_pack.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 
 namespace duckdb {
@@ -20,7 +21,15 @@ unique_ptr<Expression> LeastGreatestSimplificationRule::Apply(LogicalOperator &o
 	auto &root = bindings[0].get().Cast<BoundFunctionExpression>();
 	auto &children = root.GetChildrenMutable();
 	D_ASSERT(children.size() == 2);
-	if (children[0]->IsVolatile() || !children[0]->Equals(*children[1])) {
+	// least/greatest collects everything after its first argument into an "*args" pack
+	if (!ArgumentPack::IsPack(*children[1])) {
+		return nullptr;
+	}
+	auto &packed = ArgumentPack::GetPackedChildren(*children[1]);
+	if (packed.size() != 1) {
+		return nullptr;
+	}
+	if (children[0]->IsVolatile() || !children[0]->Equals(*packed[0])) {
 		return nullptr;
 	}
 	return std::move(children[0]);

--- a/src/optimizer/rule/list_comprehension_rewrite.cpp
+++ b/src/optimizer/rule/list_comprehension_rewrite.cpp
@@ -7,6 +7,7 @@
 #include "duckdb/common/types.hpp"
 #include "duckdb/function/lambda_functions.hpp"
 #include "duckdb/planner/expression.hpp"
+#include "duckdb/planner/expression/bound_argument_pack.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
@@ -51,9 +52,17 @@ optional_ptr<Expression> UnwrapCasts(optional_ptr<Expression> expr) {
 
 optional_ptr<Expression> FindStructPackChildByName(BoundFunctionExpression &struct_pack, const string &name) {
 	D_ASSERT(struct_pack.GetReturnType().id() == LogicalTypeId::STRUCT);
-	for (auto &child : struct_pack.GetChildren()) {
-		if (child->GetAlias() == name) {
-			return child.get();
+	// struct_pack collects its fields into a "**kwargs" pack keyed by the field names
+	auto &pack = *struct_pack.GetChildrenMutable().back();
+	if (!ArgumentPack::IsPack(pack)) {
+		// the pack was folded away, so there are no field expressions left to lift out
+		return nullptr;
+	}
+	auto &fields = ArgumentPack::GetTypes(pack.GetReturnType());
+	auto &packed = ArgumentPack::GetPackedChildren(pack);
+	for (idx_t i = 0; i < fields.size(); i++) {
+		if (fields[i].first == name) {
+			return packed[i].get();
 		}
 	}
 	return nullptr;

--- a/src/optimizer/statistics/expression/propagate_operator.cpp
+++ b/src/optimizer/statistics/expression/propagate_operator.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/optimizer/statistics_propagator.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression/bound_operator_expression.hpp"
+#include "duckdb/storage/statistics/struct_stats.hpp"
 
 namespace duckdb {
 
@@ -15,6 +16,17 @@ unique_ptr<BaseStatistics> StatisticsPropagator::PropagateExpression(BoundOperat
 			all_have_stats = false;
 		}
 		child_stats.push_back(std::move(stats));
+	}
+	if (expr.GetExpressionType() == ExpressionType::ARGUMENT_PACK) {
+		// an argument pack is a struct of the arguments it collects, so its statistics are theirs
+		auto result = StructStats::CreateUnknown(expr.GetReturnType());
+		for (idx_t i = 0; i < child_stats.size(); i++) {
+			if (child_stats[i]) {
+				StructStats::SetChildStats(result, i, *child_stats[i]);
+			}
+		}
+		result.SetHasNoNullFast();
+		return result.ToUnique();
 	}
 	if (!all_have_stats) {
 		return nullptr;

--- a/src/optimizer/statistics/operator/propagate_get.cpp
+++ b/src/optimizer/statistics/operator/propagate_get.cpp
@@ -12,6 +12,8 @@
 #include "duckdb/function/scalar/generic_common.hpp"
 #include "duckdb/function/scalar/generic_functions.hpp"
 
+#include "duckdb/planner/expression/bound_argument_pack.hpp"
+
 namespace duckdb {
 
 static bool IsDirectFilterColumnRef(const Expression &expr) {
@@ -137,8 +139,28 @@ static bool CanReplaceConstantOrNull(const TableFilter &table_filter) {
 	auto &expr_filter = ExpressionFilter::GetExpressionFilter(table_filter, "CanReplaceConstantOrNull");
 	auto &func = expr_filter.expr->Cast<BoundFunctionExpression>();
 	if (ConstantOrNull::IsConstantOrNull(func, Value::BOOLEAN(true))) {
+		// everything after the constant is checked for NULLs, with the trailing arguments collected by a "*args"
+		// parameter - look through it at the arguments themselves
+		vector<reference<const Expression>> checked;
 		for (auto child = ++func.GetChildren().begin(); child != func.GetChildren().end(); child++) {
-			switch (child->get()->GetExpressionType()) {
+			auto &argument = *child->get();
+			if (!ArgumentPack::IsPackType(argument.GetReturnType())) {
+				checked.push_back(argument);
+				continue;
+			}
+			if (argument.GetExpressionType() == ExpressionType::VALUE_CONSTANT) {
+				// the pack collected only constants and was folded into a single value
+				continue;
+			}
+			if (argument.GetExpressionClass() != ExpressionClass::BOUND_OPERATOR) {
+				return false;
+			}
+			for (auto &packed : argument.Cast<BoundOperatorExpression>().GetChildren()) {
+				checked.push_back(*packed);
+			}
+		}
+		for (auto &child : checked) {
+			switch (child.get().GetExpressionType()) {
 			case ExpressionType::BOUND_REF:
 			case ExpressionType::VALUE_CONSTANT:
 				continue;

--- a/src/optimizer/topn_window_elimination.cpp
+++ b/src/optimizer/topn_window_elimination.cpp
@@ -1,5 +1,7 @@
 #include "duckdb/optimizer/topn_window_elimination.hpp"
 
+#include "duckdb/function/scalar/struct_functions.hpp"
+
 #include "duckdb/catalog/catalog_entry/aggregate_function_catalog_entry.hpp"
 #include "duckdb/catalog/catalog_entry/scalar_function_catalog_entry.hpp"
 #include "duckdb/common/assert.hpp"
@@ -331,14 +333,16 @@ TopNWindowElimination::CreateAggregateOperator(LogicalWindow &window, vector<uni
 	if (args.size() == 1) {
 		aggregate_params.push_back(std::move(args[0]));
 	} else if (args.size() > 1) {
-		// For more than one arg, we must use struct pack
-		auto &catalog = Catalog::GetSystemCatalog(context);
+		// For more than one arg, we must use struct pack - it names its fields after its argument names, and the
+		// projection below reads them back out under those same names
 		FunctionBinder function_binder(context);
-		auto &struct_pack_entry = catalog.GetEntry<ScalarFunctionCatalogEntry>(
-		    context, QualifiedName(catalog.GetName(), Identifier::DefaultSchema(), "struct_pack"));
-		const auto &struct_pack_fun =
-		    struct_pack_entry.functions.GetFunctionByArguments(context, ExtractReturnTypes(args));
-		auto struct_pack_expr = function_binder.BindScalarFunction(struct_pack_fun, std::move(args));
+		vector<pair<Identifier, unique_ptr<Expression>>> fields;
+		fields.reserve(args.size());
+		for (auto &arg : args) {
+			fields.emplace_back(arg->GetAlias(), std::move(arg));
+		}
+		auto struct_pack_expr = function_binder.BindScalarFunction(StructPackFun::GetFunction(),
+		                                                           vector<unique_ptr<Expression>>(), std::move(fields));
 		aggregate_params.push_back(std::move(struct_pack_expr));
 	}
 

--- a/src/parser/expression/function_expression.cpp
+++ b/src/parser/expression/function_expression.cpp
@@ -6,6 +6,7 @@
 #include "duckdb/common/types/hash.hpp"
 #include "duckdb/common/serializer/serializer.hpp"
 #include "duckdb/common/serializer/deserializer.hpp"
+#include "duckdb/parser/expression/columnref_expression.hpp"
 
 namespace duckdb {
 
@@ -135,6 +136,21 @@ optional_ptr<ParsedExpression> FunctionExpression::IsLambdaFunction() {
 	return nullptr;
 }
 
+void FunctionExpression::ApplyImplicitFieldNames() {
+	if (qualified_name.Name() != "struct_pack") {
+		return;
+	}
+	for (auto &argument : arguments) {
+		if (argument.HasName()) {
+			continue;
+		}
+		auto &expression = argument.GetExpression();
+		if (expression.GetExpressionClass() == ExpressionClass::COLUMN_REF) {
+			argument.SetName(expression.Cast<ColumnRefExpression>().GetColumnName());
+		}
+	}
+}
+
 void FunctionExpression::Serialize(Serializer &serializer) const {
 	ParsedExpression::Serialize(serializer);
 	serializer.WritePropertyWithDefault<Identifier>(200, "function_name", qualified_name.Name());
@@ -194,6 +210,12 @@ unique_ptr<ParsedExpression> FunctionExpression::Deserialize(Deserializer &deser
 	// New children deserialization
 	if (children.empty()) {
 		deserializer.ReadPropertyWithDefault<vector<FunctionArgument>>(209, "arguments", result->arguments);
+	}
+
+	// struct_pack takes its field names from its argument names, which a legacy call carried in the argument aliases
+	if (result->FunctionName() == "struct_pack") {
+		result->is_legacy_function_call = false;
+		result->ApplyImplicitFieldNames();
 	}
 
 	return std::move(result);

--- a/src/parser/parsed_data/create_aggregate_function_info.cpp
+++ b/src/parser/parsed_data/create_aggregate_function_info.cpp
@@ -5,6 +5,7 @@ namespace duckdb {
 CreateAggregateFunctionInfo::CreateAggregateFunctionInfo(AggregateFunction function)
     : CreateFunctionInfo(CatalogType::AGGREGATE_FUNCTION_ENTRY), functions(function.name) {
 	SetFunctionName(function.name);
+	function.GetSignature().VerifyArgumentPacks();
 	functions.AddFunction(std::move(function));
 	internal = true;
 }
@@ -14,6 +15,7 @@ CreateAggregateFunctionInfo::CreateAggregateFunctionInfo(AggregateFunctionSet se
 	SetFunctionName(functions.name);
 	for (auto &func : functions.functions) {
 		func.name = functions.name;
+		func.GetSignature().VerifyArgumentPacks();
 	}
 	internal = true;
 }

--- a/src/parser/parsed_data/create_scalar_function_info.cpp
+++ b/src/parser/parsed_data/create_scalar_function_info.cpp
@@ -6,6 +6,7 @@ namespace duckdb {
 CreateScalarFunctionInfo::CreateScalarFunctionInfo(ScalarFunction function)
     : CreateFunctionInfo(CatalogType::SCALAR_FUNCTION_ENTRY), functions(function.name) {
 	SetFunctionName(function.name);
+	function.GetSignature().VerifyArgumentPacks();
 	functions.AddFunction(std::move(function));
 	internal = true;
 }
@@ -14,6 +15,7 @@ CreateScalarFunctionInfo::CreateScalarFunctionInfo(ScalarFunctionSet set)
 	SetFunctionName(functions.name);
 	for (auto &func : functions.functions) {
 		func.name = functions.name;
+		func.GetSignature().VerifyArgumentPacks();
 	}
 	internal = true;
 }

--- a/src/parser/parsed_data/create_window_function_info.cpp
+++ b/src/parser/parsed_data/create_window_function_info.cpp
@@ -5,6 +5,7 @@ namespace duckdb {
 CreateWindowFunctionInfo::CreateWindowFunctionInfo(WindowFunction function)
     : CreateFunctionInfo(CatalogType::WINDOW_FUNCTION_ENTRY), functions(function.name) {
 	SetFunctionName(function.name);
+	function.GetSignature().VerifyArgumentPacks();
 	functions.AddFunction(std::move(function));
 	internal = true;
 }
@@ -14,6 +15,7 @@ CreateWindowFunctionInfo::CreateWindowFunctionInfo(WindowFunctionSet set)
 	SetFunctionName(functions.name);
 	for (auto &func : functions.functions) {
 		func.name = functions.name;
+		func.GetSignature().VerifyArgumentPacks();
 	}
 	internal = true;
 }

--- a/src/parser/peg/transformer/transform_expression.cpp
+++ b/src/parser/peg/transformer/transform_expression.cpp
@@ -330,6 +330,8 @@ unique_ptr<ParsedExpression> PEGTransformerFactory::TransformFunctionExpression(
 	    QualifiedName(qualified_function.Catalog(), qualified_function.Schema(), Identifier(lowercase_name)),
 	    std::move(function_children), std::move(filter_expr), std::move(order_modifier), distinct, false,
 	    export_clause);
+	// struct_pack(a, b) is shorthand for struct_pack(a := a, b := b)
+	result->ApplyImplicitFieldNames();
 
 	return std::move(result);
 }

--- a/src/planner/binder/expression/bind_function_expression.cpp
+++ b/src/planner/binder/expression/bind_function_expression.cpp
@@ -333,18 +333,17 @@ BindResult ExpressionBinder::BindFunction(FunctionExpression &function, ScalarFu
 	}
 
 	// all children bound successfully - collect them (with their explicit names, if any) into the full argument list.
-	// The positional/named split (and, for capturing functions, the alias capture) is resolved later per candidate
-	// overload.
+	// The positional/named split is resolved later per candidate overload.
 	vector<pair<Identifier, unique_ptr<Expression>>> arguments;
 	arguments.reserve(function.GetArguments().size());
 	for (auto &arg : function.GetArgumentsMutable()) {
 		auto &bound_arg = BoundExpression::GetExpression(*arg.GetExpressionMutable());
 
 		// legacy function calls cannot have named arguments, so we ignore the names of the arguments during binding
-		// and pass them all positionally. We do alias them by their name though, so that alias-capturing functions
-		// (e.g. struct_pack) still work and so that re-serializing to the old format can match arguments by name.
-		// Only override the alias when the argument actually carries a name, otherwise we would clobber the
-		// display alias the binding assigned (e.g. clearing a column reference's name to its raw binding).
+		// and pass them all positionally. We do alias them by their name though, so that re-serializing to the old
+		// format can match arguments by name. Only override the alias when the argument actually carries a name,
+		// otherwise we would clobber the display alias the binding assigned (e.g. clearing a column reference's
+		// name to its raw binding).
 		if (!arg.GetName().empty()) {
 			bound_arg->SetAlias(arg.GetName());
 		}

--- a/src/planner/binder/expression/bind_star_expression.cpp
+++ b/src/planner/binder/expression/bind_star_expression.cpp
@@ -111,6 +111,10 @@ void Binder::ReplaceStarExpression(unique_ptr<ParsedExpression> &expr, unique_pt
 	}
 	ParsedExpressionIterator::EnumerateChildren(
 	    *expr, [&](unique_ptr<ParsedExpression> &child_expr) { ReplaceStarExpression(child_expr, replacement); });
+	if (expr->GetExpressionClass() == ExpressionClass::FUNCTION) {
+		// the replacement may have turned an argument into a column reference struct_pack can name itself
+		expr->Cast<FunctionExpression>().ApplyImplicitFieldNames();
+	}
 }
 
 string Binder::ReplaceColumnsAlias(const string &alias, const string &column_name,

--- a/src/planner/binder/expression/bind_subquery_expression.cpp
+++ b/src/planner/binder/expression/bind_subquery_expression.cpp
@@ -2,6 +2,7 @@
 #include "duckdb/planner/binder.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "duckdb/planner/expression/bound_argument_pack.hpp"
 #include "duckdb/planner/expression/bound_subquery_expression.hpp"
 #include "duckdb/planner/expression_binder.hpp"
 #include "duckdb/common/string_util.hpp"
@@ -61,9 +62,14 @@ static void ExtractSubqueryChildren(unique_ptr<Expression> &child, vector<unique
 		// not "ROW"
 		return;
 	}
+	if (function.GetChildren().size() != 1 || !ArgumentPack::IsPack(*function.GetChildren()[0])) {
+		// "row" collects its arguments into an "*args" pack - without one there is nothing to extract
+		return;
+	}
+	auto &row_children = ArgumentPack::GetPackedChildren(*function.GetChildrenMutable()[0]);
 	// we found (a, b, ...) - we can extract all children of this function
 	// note that we don't always want to do this
-	if (types.size() == 1 && TypeIsTuple(types[0]) && function.GetChildrenMutable().size() != types.size()) {
+	if (types.size() == 1 && TypeIsTuple(types[0]) && row_children.size() != types.size()) {
 		// old case: we have an unnamed struct INSIDE the subquery as well
 		// i.e. (a, b) IN (SELECT (a, b) ...)
 		// unnesting the struct is guaranteed to throw an error - match the structs against each-other instead
@@ -81,7 +87,7 @@ static void ExtractSubqueryChildren(unique_ptr<Expression> &child, vector<unique
 		// Keep the struct intact for row-valued comparisons with non-element-wise semantics.
 		return;
 	}
-	for (auto &row_child : function.GetChildrenMutable()) {
+	for (auto &row_child : row_children) {
 		result.push_back(std::move(row_child));
 	}
 }

--- a/src/planner/binder/expression/bind_unpacked_star_expression.cpp
+++ b/src/planner/binder/expression/bind_unpacked_star_expression.cpp
@@ -44,16 +44,22 @@ static void ReplaceInFunction(unique_ptr<ParsedExpression> &expr, expression_lis
                               optional_ptr<duckdb_re2::RE2> regex) {
 	auto &function_expr = expr->Cast<FunctionExpression>();
 
-	// Replace children
-	expression_list_t new_children;
+	// Replace children, keeping the name of any argument that expanded into exactly one expression
+	vector<FunctionArgument> new_arguments;
 	for (auto &child : function_expr.GetArgumentsMutable()) {
-		AddChild(child.GetExpressionMutable(), new_children, star_list, star, regex);
+		expression_list_t expanded;
+		AddChild(child.GetExpressionMutable(), expanded, star_list, star, regex);
+		if (expanded.size() == 1) {
+			new_arguments.emplace_back(child.GetName(), std::move(expanded[0]));
+			continue;
+		}
+		for (auto &new_child : expanded) {
+			new_arguments.emplace_back(std::move(new_child));
+		}
 	}
-
-	function_expr.GetArgumentsMutable().clear();
-	for (auto &child : new_children) {
-		function_expr.GetArgumentsMutable().emplace_back(std::move(child));
-	}
+	function_expr.GetArgumentsMutable() = std::move(new_arguments);
+	// the expansion may have produced column references struct_pack can name itself
+	function_expr.ApplyImplicitFieldNames();
 
 	// Replace ORDER_BY
 	if (function_expr.OrderBy()) {

--- a/src/planner/binder/expression/bind_window_expression.cpp
+++ b/src/planner/binder/expression/bind_window_expression.cpp
@@ -207,10 +207,10 @@ BindResult BaseSelectBinder::BindWindowExpression(WindowExpression &window, idx_
 		auto &bound_arg = BoundExpression::GetExpression(*arg.GetExpressionMutable());
 
 		// legacy function calls cannot have named arguments, so we ignore the names of the arguments during binding
-		// and pass them all positionally. We do alias them by their name though, so that alias-capturing functions
-		// (e.g. struct_pack) still work and so that re-serializing to the old format can match arguments by name.
-		// Only override the alias when the argument actually carries a name, otherwise we would clobber the
-		// display alias the binding assigned (e.g. clearing a column reference's name to its raw binding).
+		// and pass them all positionally. We do alias them by their name though, so that re-serializing to the old
+		// format can match arguments by name. Only override the alias when the argument actually carries a name,
+		// otherwise we would clobber the display alias the binding assigned (e.g. clearing a column reference's
+		// name to its raw binding).
 		if (!arg.GetName().empty()) {
 			bound_arg->SetAlias(arg.GetName());
 		}

--- a/src/planner/expression/CMakeLists.txt
+++ b/src/planner/expression/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library_unity(
   OBJECT
   bound_expression.cpp
   bound_aggregate_expression.cpp
+  bound_argument_pack.cpp
   bound_case_expression.cpp
   bound_cast_expression.cpp
   bound_columnref_expression.cpp

--- a/src/planner/expression/bound_aggregate_expression.cpp
+++ b/src/planner/expression/bound_aggregate_expression.cpp
@@ -127,10 +127,16 @@ unique_ptr<Expression> BoundAggregateExpression::Copy() const {
 }
 
 void BoundAggregateExpression::Serialize(Serializer &serializer) const {
+	// see BoundFunctionExpression::Serialize - argument packs are unrolled for older storage versions
+	vector<unique_ptr<Expression>> flat_children;
+	vector<LogicalType> flat_arguments;
+	const auto unrolled = !serializer.ShouldSerialize(StorageVersion::V2_0_0) &&
+	                      ArgumentPack::Unroll(children, function.GetArguments(), flat_children, flat_arguments);
+
 	Expression::Serialize(serializer);
 	serializer.WriteProperty(200, "return_type", return_type);
-	serializer.WriteProperty(201, "children", children);
-	FunctionSerializer::Serialize(serializer, function, bind_info.get());
+	serializer.WriteProperty(201, "children", unrolled ? flat_children : children);
+	FunctionSerializer::Serialize(serializer, function, bind_info.get(), unrolled ? &flat_arguments : nullptr);
 	serializer.WriteProperty(203, "aggregate_type", aggr_type);
 	serializer.WritePropertyWithDefault(204, "filter", filter, unique_ptr<Expression>());
 	serializer.WritePropertyWithDefault(205, "order_bys", order_bys, unique_ptr<BoundOrderModifier>());

--- a/src/planner/expression/bound_aggregate_expression.cpp
+++ b/src/planner/expression/bound_aggregate_expression.cpp
@@ -127,11 +127,11 @@ unique_ptr<Expression> BoundAggregateExpression::Copy() const {
 }
 
 void BoundAggregateExpression::Serialize(Serializer &serializer) const {
-	// see BoundFunctionExpression::Serialize - argument packs are unrolled for older storage versions
+	// see BoundFunctionExpression::Serialize - argument packs are unrolled on the way out
 	vector<unique_ptr<Expression>> flat_children;
 	vector<LogicalType> flat_arguments;
-	const auto unrolled = !serializer.ShouldSerialize(StorageVersion::V2_0_0) &&
-	                      ArgumentPack::Unroll(children, function.GetArguments(), flat_children, flat_arguments);
+	const auto unrolled =
+	    ArgumentPack::Unroll(serializer, children, function.GetArguments(), flat_children, flat_arguments);
 
 	Expression::Serialize(serializer);
 	serializer.WriteProperty(200, "return_type", return_type);

--- a/src/planner/expression/bound_argument_pack.cpp
+++ b/src/planner/expression/bound_argument_pack.cpp
@@ -2,7 +2,6 @@
 
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 
-
 namespace duckdb {
 
 bool ArgumentPack::IsPackType(const LogicalType &type) {
@@ -29,6 +28,27 @@ vector<unique_ptr<Expression>> &ArgumentPack::GetPackedChildren(Expression &pack
 	D_ASSERT(IsPackType(pack.GetReturnType()));
 	D_ASSERT(pack.GetExpressionClass() == ExpressionClass::BOUND_OPERATOR);
 	return pack.Cast<BoundOperatorExpression>().GetChildrenMutable();
+}
+
+void ArgumentPack::RefreshType(Expression &pack) {
+	auto &packed = GetPackedChildren(pack);
+	auto &pack_type = pack.GetReturnType();
+
+	if (pack_type.id() == LogicalTypeId::TUPLE) {
+		vector<LogicalType> member_types;
+		member_types.reserve(packed.size());
+		for (auto &member : packed) {
+			member_types.push_back(member->GetReturnType());
+		}
+		pack.SetReturnType(PositionalType(std::move(member_types)));
+		return;
+	}
+	child_list_t<LogicalType> members;
+	members.reserve(packed.size());
+	for (idx_t i = 0; i < packed.size(); i++) {
+		members.emplace_back(StructType::GetChildName(pack_type, i), packed[i]->GetReturnType());
+	}
+	pack.SetReturnType(KeywordType(std::move(members)));
 }
 
 bool ArgumentPack::Unroll(const vector<unique_ptr<Expression>> &children, const vector<LogicalType> &arguments,

--- a/src/planner/expression/bound_argument_pack.cpp
+++ b/src/planner/expression/bound_argument_pack.cpp
@@ -10,7 +10,7 @@ const vector<Vector> &ArgumentPack::GetInput(const Vector &pack) {
 	return StructVector::GetEntries(pack);
 }
 
-const child_list_t<LogicalType>& ArgumentPack::GetTypes(const LogicalType &pack) {
+const child_list_t<LogicalType> &ArgumentPack::GetTypes(const LogicalType &pack) {
 	D_ASSERT(IsPackType(pack));
 	return StructType::GetChildTypes(pack);
 }

--- a/src/planner/expression/bound_argument_pack.cpp
+++ b/src/planner/expression/bound_argument_pack.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/planner/expression/bound_argument_pack.hpp"
 
+#include "duckdb/common/serializer/serializer.hpp"
 #include "duckdb/common/vector/struct_vector.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 
@@ -22,6 +23,10 @@ idx_t ArgumentPack::GetSize(const LogicalType &pack) {
 
 bool ArgumentPack::IsPackType(const LogicalType &type) {
 	return StructType::IsStruct(type) && type.GetAlias() == TYPE_ALIAS;
+}
+
+bool ArgumentPack::IsPack(const Expression &expr) {
+	return expr.GetExpressionType() == ExpressionType::ARGUMENT_PACK;
 }
 
 LogicalType ArgumentPack::PositionalType(vector<LogicalType> element_types) {
@@ -67,35 +72,49 @@ void ArgumentPack::RefreshType(Expression &pack) {
 	pack.SetReturnType(KeywordType(std::move(members)));
 }
 
-bool ArgumentPack::Unroll(const vector<unique_ptr<Expression>> &children, const vector<LogicalType> &arguments,
-                          vector<unique_ptr<Expression>> &flat_children, vector<LogicalType> &flat_arguments) {
-	bool found_pack = false;
-	for (auto &argument : arguments) {
-		if (IsPackType(argument)) {
-			found_pack = true;
-			break;
-		}
+// Whether the pack in argument slot 'index' can be flattened into the argument list and rolled back up from it,
+// and if not, why not. Returns nullptr when it can.
+static const char *UnrollBlocker(const vector<unique_ptr<Expression>> &children, const vector<LogicalType> &arguments,
+                                 idx_t index) {
+	if (index + 1 != arguments.size()) {
+		// an argument sitting behind the pack cannot be put back where it belongs
+		return "the function takes arguments after its '*args'/'**kwargs' parameter";
 	}
-	if (!found_pack) {
-		return false;
+	if (index >= children.size()) {
+		return "the argument pack has no expression";
 	}
+	auto &child = *children[index];
+	// the pack collected only constants and was folded into a single struct value, or it is still a pack
+	if (child.GetExpressionType() == ExpressionType::VALUE_CONSTANT ||
+	    child.GetExpressionClass() == ExpressionClass::BOUND_OPERATOR) {
+		return nullptr;
+	}
+	return "the argument pack was replaced by another expression";
+}
 
-	// Reading the unrolled list back binds every trailing argument into the "*args" pack, so the only calls that
-	// survive the round-trip are the ones that look like a pre-pack variadic call: leading positional arguments
-	// followed by the pack. A "**kwargs" pack or a keyword-only argument sitting behind the "*args" one cannot be
-	// put back where it belongs, so it is not representable in a storage version that predates argument packs.
+bool ArgumentPack::Unroll(Serializer &serializer, const vector<unique_ptr<Expression>> &children,
+                          const vector<LogicalType> &arguments, vector<unique_ptr<Expression>> &flat_children,
+                          vector<LogicalType> &flat_arguments) {
+	bool found_pack = false;
 	for (idx_t i = 0; i < arguments.size(); i++) {
 		if (!IsPackType(arguments[i])) {
 			continue;
 		}
-		if (arguments[i].id() == LogicalTypeId::STRUCT) {
-			throw SerializationException("Cannot serialize a call to a function with a '**kwargs' parameter to a "
-			                             "storage version that predates argument packs");
+		found_pack = true;
+		auto blocker = UnrollBlocker(children, arguments, i);
+		if (!blocker) {
+			continue;
 		}
-		if (i + 1 != arguments.size()) {
-			throw SerializationException("Cannot serialize a call to a function with arguments after its '*args' "
-			                             "parameter to a storage version that predates argument packs");
+		if (serializer.ShouldSerialize(StorageVersion::V2_0_0)) {
+			// the call keeps its packs - this storage version can represent them
+			return false;
 		}
+		throw SerializationException("Cannot serialize this call to a storage version that predates argument packs: "
+		                             "%s",
+		                             blocker);
+	}
+	if (!found_pack) {
+		return false;
 	}
 
 	for (idx_t i = 0; i < children.size(); i++) {
@@ -109,27 +128,69 @@ bool ArgumentPack::Unroll(const vector<unique_ptr<Expression>> &children, const 
 
 		vector<unique_ptr<Expression>> packed;
 		if (children[i]->GetExpressionType() == ExpressionType::VALUE_CONSTANT) {
-			// the pack collected only constants and was folded into a single struct value
 			auto &value = children[i]->Cast<BoundConstantExpression>().GetValue();
 			for (auto &packed_value : StructValue::GetChildren(value)) {
 				packed.push_back(make_uniq<BoundConstantExpression>(packed_value));
 			}
-		} else if (children[i]->GetExpressionClass() == ExpressionClass::BOUND_OPERATOR) {
+		} else {
 			for (auto &packed_child : children[i]->Cast<BoundOperatorExpression>().GetChildren()) {
 				packed.push_back(packed_child->Copy());
 			}
-		} else {
-			throw SerializationException(
-			    "Cannot serialize an argument pack that was replaced by a %s expression to this storage version",
-			    ExpressionTypeToString(children[i]->GetExpressionType()));
 		}
 		D_ASSERT(packed.size() == child_count);
 
+		// the flat encoding of a keyword argument keeps its name in the expression alias
+		const auto is_keyword_pack = pack_type.id() == LogicalTypeId::STRUCT;
 		for (idx_t child_idx = 0; child_idx < child_count; child_idx++) {
+			if (is_keyword_pack) {
+				packed[child_idx]->SetAlias(StructType::GetChildName(pack_type, child_idx));
+			}
 			flat_arguments.push_back(StructType::GetChildType(pack_type, child_idx));
 			flat_children.push_back(std::move(packed[child_idx]));
 		}
 	}
+	return true;
+}
+
+static vector<LogicalType> ExtractTypes(const child_list_t<LogicalType> &fields) {
+	vector<LogicalType> types;
+	types.reserve(fields.size());
+	for (auto &field : fields) {
+		types.push_back(field.second);
+	}
+	return types;
+}
+
+bool ArgumentPack::Reroll(const FunctionSignature &sig, vector<unique_ptr<Expression>> &children,
+                          vector<LogicalType> &arguments) {
+	auto keyword_index = sig.GetVarKeywordIndex();
+	auto positional_index = sig.GetVarPositionalIndex();
+	if (keyword_index.IsValid() == positional_index.IsValid()) {
+		// only the shape Unroll produces can be rolled back up: a single trailing pack
+		return false;
+	}
+	const auto is_keyword_pack = keyword_index.IsValid();
+	const auto leading = is_keyword_pack ? keyword_index.GetIndex() : positional_index.GetIndex();
+	if (leading + 1 != sig.GetParameterCount() || children.size() < leading) {
+		return false;
+	}
+	if (children.size() == sig.GetParameterCount() && IsPackType(children[leading]->GetReturnType())) {
+		// this call is already packed
+		return false;
+	}
+
+	vector<unique_ptr<Expression>> packed;
+	child_list_t<LogicalType> fields;
+	for (idx_t i = leading; i < children.size(); i++) {
+		fields.emplace_back(is_keyword_pack ? children[i]->GetAlias() : Identifier(), children[i]->GetReturnType());
+		packed.push_back(std::move(children[i]));
+	}
+	auto pack_type = is_keyword_pack ? KeywordType(std::move(fields)) : PositionalType(ExtractTypes(fields));
+
+	children.resize(leading);
+	arguments.resize(MinValue<idx_t>(arguments.size(), leading));
+	children.push_back(Create(std::move(packed), pack_type));
+	arguments.push_back(std::move(pack_type));
 	return true;
 }
 

--- a/src/planner/expression/bound_argument_pack.cpp
+++ b/src/planner/expression/bound_argument_pack.cpp
@@ -2,11 +2,6 @@
 
 namespace duckdb {
 
-bool ArgumentPack::IsPack(const Expression &expr) {
-	return expr.GetExpressionClass() == ExpressionClass::BOUND_OPERATOR &&
-	       expr.GetExpressionType() == ExpressionType::ARGUMENT_PACK;
-}
-
 bool ArgumentPack::IsPackType(const LogicalType &type) {
 	return StructType::IsStruct(type) && type.GetAlias() == TYPE_ALIAS;
 }

--- a/src/planner/expression/bound_argument_pack.cpp
+++ b/src/planner/expression/bound_argument_pack.cpp
@@ -11,6 +11,11 @@ const vector<Vector> &ArgumentPack::GetInput(const Vector &pack) {
 	return StructVector::GetEntries(pack);
 }
 
+vector<Vector> &ArgumentPack::GetInput(Vector &pack) {
+	D_ASSERT(IsPackType(pack.GetType()));
+	return StructVector::GetEntries(pack);
+}
+
 const child_list_t<LogicalType> &ArgumentPack::GetTypes(const LogicalType &pack) {
 	D_ASSERT(IsPackType(pack));
 	return StructType::GetChildTypes(pack);

--- a/src/planner/expression/bound_argument_pack.cpp
+++ b/src/planner/expression/bound_argument_pack.cpp
@@ -2,6 +2,7 @@
 
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 
+
 namespace duckdb {
 
 bool ArgumentPack::IsPackType(const LogicalType &type) {
@@ -22,6 +23,12 @@ unique_ptr<Expression> ArgumentPack::Create(vector<unique_ptr<Expression>> child
 	auto result = make_uniq<BoundOperatorExpression>(ExpressionType::ARGUMENT_PACK, std::move(pack_type));
 	result->GetChildrenMutable() = std::move(children);
 	return std::move(result);
+}
+
+vector<unique_ptr<Expression>> &ArgumentPack::GetPackedChildren(Expression &pack) {
+	D_ASSERT(IsPackType(pack.GetReturnType()));
+	D_ASSERT(pack.GetExpressionClass() == ExpressionClass::BOUND_OPERATOR);
+	return pack.Cast<BoundOperatorExpression>().GetChildrenMutable();
 }
 
 bool ArgumentPack::Unroll(const vector<unique_ptr<Expression>> &children, const vector<LogicalType> &arguments,

--- a/src/planner/expression/bound_argument_pack.cpp
+++ b/src/planner/expression/bound_argument_pack.cpp
@@ -1,5 +1,7 @@
 #include "duckdb/planner/expression/bound_argument_pack.hpp"
 
+#include "duckdb/planner/expression/bound_constant_expression.hpp"
+
 namespace duckdb {
 
 bool ArgumentPack::IsPackType(const LogicalType &type) {
@@ -20,6 +22,72 @@ unique_ptr<Expression> ArgumentPack::Create(vector<unique_ptr<Expression>> child
 	auto result = make_uniq<BoundOperatorExpression>(ExpressionType::ARGUMENT_PACK, std::move(pack_type));
 	result->GetChildrenMutable() = std::move(children);
 	return std::move(result);
+}
+
+bool ArgumentPack::Unroll(const vector<unique_ptr<Expression>> &children, const vector<LogicalType> &arguments,
+                          vector<unique_ptr<Expression>> &flat_children, vector<LogicalType> &flat_arguments) {
+	bool found_pack = false;
+	for (auto &argument : arguments) {
+		if (IsPackType(argument)) {
+			found_pack = true;
+			break;
+		}
+	}
+	if (!found_pack) {
+		return false;
+	}
+
+	// Reading the unrolled list back binds every trailing argument into the "*args" pack, so the only calls that
+	// survive the round-trip are the ones that look like a pre-pack variadic call: leading positional arguments
+	// followed by the pack. A "**kwargs" pack or a keyword-only argument sitting behind the "*args" one cannot be
+	// put back where it belongs, so it is not representable in a storage version that predates argument packs.
+	for (idx_t i = 0; i < arguments.size(); i++) {
+		if (!IsPackType(arguments[i])) {
+			continue;
+		}
+		if (arguments[i].id() == LogicalTypeId::STRUCT) {
+			throw SerializationException("Cannot serialize a call to a function with a '**kwargs' parameter to a "
+			                             "storage version that predates argument packs");
+		}
+		if (i + 1 != arguments.size()) {
+			throw SerializationException("Cannot serialize a call to a function with arguments after its '*args' "
+			                             "parameter to a storage version that predates argument packs");
+		}
+	}
+
+	for (idx_t i = 0; i < children.size(); i++) {
+		const auto &pack_type = i < arguments.size() ? arguments[i] : children[i]->GetReturnType();
+		if (!IsPackType(pack_type)) {
+			flat_children.push_back(children[i]->Copy());
+			flat_arguments.push_back(pack_type);
+			continue;
+		}
+		const auto child_count = StructType::GetChildCount(pack_type);
+
+		vector<unique_ptr<Expression>> packed;
+		if (children[i]->GetExpressionType() == ExpressionType::VALUE_CONSTANT) {
+			// the pack collected only constants and was folded into a single struct value
+			auto &value = children[i]->Cast<BoundConstantExpression>().GetValue();
+			for (auto &packed_value : StructValue::GetChildren(value)) {
+				packed.push_back(make_uniq<BoundConstantExpression>(packed_value));
+			}
+		} else if (children[i]->GetExpressionClass() == ExpressionClass::BOUND_OPERATOR) {
+			for (auto &packed_child : children[i]->Cast<BoundOperatorExpression>().GetChildren()) {
+				packed.push_back(packed_child->Copy());
+			}
+		} else {
+			throw SerializationException(
+			    "Cannot serialize an argument pack that was replaced by a %s expression to this storage version",
+			    ExpressionTypeToString(children[i]->GetExpressionType()));
+		}
+		D_ASSERT(packed.size() == child_count);
+
+		for (idx_t child_idx = 0; child_idx < child_count; child_idx++) {
+			flat_arguments.push_back(StructType::GetChildType(pack_type, child_idx));
+			flat_children.push_back(std::move(packed[child_idx]));
+		}
+	}
+	return true;
 }
 
 } // namespace duckdb

--- a/src/planner/expression/bound_argument_pack.cpp
+++ b/src/planner/expression/bound_argument_pack.cpp
@@ -1,0 +1,30 @@
+#include "duckdb/planner/expression/bound_argument_pack.hpp"
+
+namespace duckdb {
+
+bool ArgumentPack::IsPack(const Expression &expr) {
+	return expr.GetExpressionClass() == ExpressionClass::BOUND_OPERATOR &&
+	       expr.GetExpressionType() == ExpressionType::ARGUMENT_PACK;
+}
+
+bool ArgumentPack::IsPackType(const LogicalType &type) {
+	return StructType::IsStruct(type) && type.GetAlias() == TYPE_ALIAS;
+}
+
+LogicalType ArgumentPack::PositionalType(vector<LogicalType> element_types) {
+	return LogicalType::TUPLE(std::move(element_types)).WithAlias(TYPE_ALIAS);
+}
+
+LogicalType ArgumentPack::KeywordType(child_list_t<LogicalType> value_types) {
+	return LogicalType::STRUCT(std::move(value_types)).WithAlias(TYPE_ALIAS);
+}
+
+unique_ptr<Expression> ArgumentPack::Create(vector<unique_ptr<Expression>> children, LogicalType pack_type) {
+	D_ASSERT(IsPackType(pack_type));
+	D_ASSERT(StructType::GetChildCount(pack_type) == children.size());
+	auto result = make_uniq<BoundOperatorExpression>(ExpressionType::ARGUMENT_PACK, std::move(pack_type));
+	result->GetChildrenMutable() = std::move(children);
+	return std::move(result);
+}
+
+} // namespace duckdb

--- a/src/planner/expression/bound_argument_pack.cpp
+++ b/src/planner/expression/bound_argument_pack.cpp
@@ -1,8 +1,24 @@
 #include "duckdb/planner/expression/bound_argument_pack.hpp"
 
+#include "duckdb/common/vector/struct_vector.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 
 namespace duckdb {
+
+const vector<Vector> &ArgumentPack::GetInput(const Vector &pack) {
+	D_ASSERT(IsPackType(pack.GetType()));
+	return StructVector::GetEntries(pack);
+}
+
+const child_list_t<LogicalType>& ArgumentPack::GetTypes(const LogicalType &pack) {
+	D_ASSERT(IsPackType(pack));
+	return StructType::GetChildTypes(pack);
+}
+
+idx_t ArgumentPack::GetSize(const LogicalType &pack) {
+	D_ASSERT(IsPackType(pack));
+	return StructType::GetChildCount(pack);
+}
 
 bool ArgumentPack::IsPackType(const LogicalType &type) {
 	return StructType::IsStruct(type) && type.GetAlias() == TYPE_ALIAS;

--- a/src/planner/expression/bound_function_expression.cpp
+++ b/src/planner/expression/bound_function_expression.cpp
@@ -157,10 +157,17 @@ void BoundFunctionExpression::Serialize(Serializer &serializer) const {
 		return;
 	}
 
+	// storage versions that predate argument packs never saw a packed call - write the plain argument list the
+	// call was made with, which binds straight back into packs when it is read again
+	vector<unique_ptr<Expression>> flat_children;
+	vector<LogicalType> flat_arguments;
+	const auto unrolled = !serializer.ShouldSerialize(StorageVersion::V2_0_0) &&
+	                      ArgumentPack::Unroll(children, function.GetArguments(), flat_children, flat_arguments);
+
 	Expression::Serialize(serializer);
 	serializer.WriteProperty(200, "return_type", return_type);
-	serializer.WriteProperty(201, "children", children);
-	FunctionSerializer::Serialize(serializer, function, bind_info.get());
+	serializer.WriteProperty(201, "children", unrolled ? flat_children : children);
+	FunctionSerializer::Serialize(serializer, function, bind_info.get(), unrolled ? &flat_arguments : nullptr);
 	serializer.WriteProperty(202, "is_operator", is_operator);
 }
 

--- a/src/planner/expression/bound_function_expression.cpp
+++ b/src/planner/expression/bound_function_expression.cpp
@@ -157,12 +157,12 @@ void BoundFunctionExpression::Serialize(Serializer &serializer) const {
 		return;
 	}
 
-	// storage versions that predate argument packs never saw a packed call - write the plain argument list the
-	// call was made with, which binds straight back into packs when it is read again
+	// argument packs are never written to disk - write the plain argument list the call was made with, which is
+	// rolled back up into packs when it is read again
 	vector<unique_ptr<Expression>> flat_children;
 	vector<LogicalType> flat_arguments;
-	const auto unrolled = !serializer.ShouldSerialize(StorageVersion::V2_0_0) &&
-	                      ArgumentPack::Unroll(children, function.GetArguments(), flat_children, flat_arguments);
+	const auto unrolled =
+	    ArgumentPack::Unroll(serializer, children, function.GetArguments(), flat_children, flat_arguments);
 
 	Expression::Serialize(serializer);
 	serializer.WriteProperty(200, "return_type", return_type);

--- a/src/planner/expression/bound_operator_expression.cpp
+++ b/src/planner/expression/bound_operator_expression.cpp
@@ -9,6 +9,22 @@ BoundOperatorExpression::BoundOperatorExpression(ExpressionType type, LogicalTyp
 }
 
 string BoundOperatorExpression::ToString() const {
+	if (type == ExpressionType::ARGUMENT_PACK) {
+		// print the packed arguments as they were written in the call, so that the enclosing function call reads
+		// back the way the user wrote it. Keyword names live in the STRUCT return type.
+		const auto named = return_type.id() == LogicalTypeId::STRUCT;
+		string result;
+		for (idx_t i = 0; i < children.size(); i++) {
+			if (i > 0) {
+				result += ", ";
+			}
+			if (named) {
+				result += StructType::GetChildName(return_type, i).GetIdentifierName() + " := ";
+			}
+			result += children[i]->ToString();
+		}
+		return result;
+	}
 	return OperatorExpression::ToString<BoundOperatorExpression, Expression>(*this);
 }
 

--- a/src/planner/expression/bound_window_expression.cpp
+++ b/src/planner/expression/bound_window_expression.cpp
@@ -248,14 +248,14 @@ unique_ptr<Expression> BoundWindowExpression::SerializedDefault(Serializer &seri
 }
 
 void BoundWindowExpression::Serialize(Serializer &serializer) const {
-	// see BoundFunctionExpression::Serialize - argument packs are unrolled for older storage versions. Packs and
-	// the legacy lead/lag rewrite in SerializedChildren are mutually exclusive, so only one of the two applies.
+	// see BoundFunctionExpression::Serialize - argument packs are unrolled on the way out. Packs and the legacy
+	// lead/lag rewrite in SerializedChildren are mutually exclusive, so only one of the two applies.
 	vector<unique_ptr<Expression>> flat_children;
 	vector<LogicalType> flat_arguments;
 	bool unrolled = false;
-	if (!serializer.ShouldSerialize(StorageVersion::V2_0_0)) {
+	if (aggregate || window) {
 		const auto &arguments = aggregate ? aggregate->GetArguments() : window->GetArguments();
-		unrolled = ArgumentPack::Unroll(children, arguments, flat_children, flat_arguments);
+		unrolled = ArgumentPack::Unroll(serializer, children, arguments, flat_children, flat_arguments);
 	}
 	if (!unrolled) {
 		flat_children = SerializedChildren(serializer);

--- a/src/planner/expression/bound_window_expression.cpp
+++ b/src/planner/expression/bound_window_expression.cpp
@@ -248,16 +248,29 @@ unique_ptr<Expression> BoundWindowExpression::SerializedDefault(Serializer &seri
 }
 
 void BoundWindowExpression::Serialize(Serializer &serializer) const {
+	// see BoundFunctionExpression::Serialize - argument packs are unrolled for older storage versions. Packs and
+	// the legacy lead/lag rewrite in SerializedChildren are mutually exclusive, so only one of the two applies.
+	vector<unique_ptr<Expression>> flat_children;
+	vector<LogicalType> flat_arguments;
+	bool unrolled = false;
+	if (!serializer.ShouldSerialize(StorageVersion::V2_0_0)) {
+		const auto &arguments = aggregate ? aggregate->GetArguments() : window->GetArguments();
+		unrolled = ArgumentPack::Unroll(children, arguments, flat_children, flat_arguments);
+	}
+	if (!unrolled) {
+		flat_children = SerializedChildren(serializer);
+	}
+
 	Expression::Serialize(serializer);
 	serializer.WriteProperty(200, "return_type", return_type);
-	serializer.WriteProperty(201, "children", SerializedChildren(serializer));
+	serializer.WriteProperty(201, "children", flat_children);
 	if (type == ExpressionType::WINDOW_AGGREGATE) {
 		D_ASSERT(aggregate);
-		FunctionSerializer::Serialize(serializer, *aggregate, bind_info.get());
+		FunctionSerializer::Serialize(serializer, *aggregate, bind_info.get(), unrolled ? &flat_arguments : nullptr);
 	} else if (type == ExpressionType::WINDOW_FUNCTION) {
 		//	New window function. Older versions will treat it as an unknown aggregate.
 		D_ASSERT(window);
-		FunctionSerializer::Serialize(serializer, *window, bind_info.get());
+		FunctionSerializer::Serialize(serializer, *window, bind_info.get(), unrolled ? &flat_arguments : nullptr);
 	} // else the expression type is all we need as there is no binding info.
 	auto null_expr = unique_ptr<Expression>();
 	serializer.WriteProperty(202, "partitions", partitions);

--- a/test/api/CMakeLists.txt
+++ b/test/api/CMakeLists.txt
@@ -10,6 +10,7 @@ add_subdirectory(capi)
 
 set(TEST_API_OBJECTS
     test_api.cpp
+    test_argument_pack_serialization.cpp
     test_bind_statement.cpp
     test_scalar_function_decimal_return.cpp
     test_aggregate_state_bind_data.cpp

--- a/test/api/test_argument_pack_serialization.cpp
+++ b/test/api/test_argument_pack_serialization.cpp
@@ -1,0 +1,107 @@
+#include "catch.hpp"
+#include "duckdb/common/serializer/binary_deserializer.hpp"
+#include "duckdb/common/serializer/binary_serializer.hpp"
+#include "duckdb/common/serializer/memory_stream.hpp"
+#include "duckdb/parser/parser.hpp"
+#include "duckdb/parser/statement/logical_plan_statement.hpp"
+#include "duckdb/planner/expression/bound_argument_pack.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "duckdb/planner/planner.hpp"
+#include "test_helpers.hpp"
+
+using namespace duckdb;
+
+namespace {
+
+unique_ptr<LogicalOperator> PlanQuery(Connection &con, const string &query) {
+	Parser parser;
+	parser.ParseQuery(query);
+	Planner planner(*con.context);
+	planner.CreatePlan(std::move(parser.statements[0]));
+	return std::move(planner.plan);
+}
+
+//! Serialize a plan at the given storage version, returning the bytes it was written as
+vector<data_t> Serialize(LogicalOperator &plan, const StorageCompatibility &compatibility) {
+	MemoryStream stream(Allocator::DefaultAllocator());
+
+	SerializationOptions options;
+	options.storage_compatibility = compatibility;
+	BinarySerializer serializer(stream, options);
+	serializer.Begin();
+	plan.Serialize(serializer);
+	serializer.End();
+
+	vector<data_t> result(stream.GetPosition());
+	memcpy(result.data(), stream.GetData(), stream.GetPosition());
+	return result;
+}
+
+unique_ptr<LogicalOperator> Deserialize(Connection &con, const vector<data_t> &bytes) {
+	MemoryStream stream(Allocator::DefaultAllocator());
+	stream.WriteData(bytes.data(), bytes.size());
+	stream.Rewind();
+
+	BinaryDeserializer deserializer(stream);
+	deserializer.Set<ClientContext &>(*con.context);
+	deserializer.Begin();
+	auto result = LogicalOperator::Deserialize(deserializer);
+	deserializer.End();
+	result->ResolveOperatorTypes();
+	return result;
+}
+
+//! The "hash" function takes (value ANY, *values ANY), so a call to it always has exactly two arguments once bound:
+//! the first value and the pack holding the rest.
+void RequirePackedHashCall(LogicalOperator &plan) {
+	auto &expr = *plan.expressions[0];
+	REQUIRE(expr.GetExpressionClass() == ExpressionClass::BOUND_FUNCTION);
+	auto &function = expr.Cast<BoundFunctionExpression>();
+	REQUIRE(function.Function().GetName() == "hash");
+	REQUIRE(function.GetChildren().size() == 2);
+	REQUIRE(ArgumentPack::IsPackType(function.GetChildren()[1]->GetReturnType()));
+}
+
+} // namespace
+
+TEST_CASE("Argument packs survive plan serialization", "[api]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	con.BeginTransaction();
+
+	const string query = "SELECT hash(i, i + 1, 'x') FROM range(3) t(i)";
+	auto expected = con.Query(query);
+	REQUIRE_NO_FAIL(*expected);
+
+	auto plan = PlanQuery(con, query);
+	RequirePackedHashCall(*plan);
+
+	auto latest_bytes = Serialize(*plan, StorageCompatibility::Latest());
+	auto legacy_bytes = Serialize(*plan, StorageCompatibility::FromString("v1.2.0"));
+
+	// a storage version that predates argument packs gets a different encoding of the same call: the pack is
+	// unrolled into the plain argument list the call was written with
+	REQUIRE(latest_bytes != legacy_bytes);
+
+	SECTION("current storage version keeps the call packed") {
+		auto deserialized = Deserialize(con, latest_bytes);
+		RequirePackedHashCall(*deserialized);
+
+		auto result = con.context->Query(make_uniq<LogicalPlanStatement>(std::move(deserialized)), false);
+		REQUIRE_NO_FAIL(*result);
+		REQUIRE(result->Equals(*expected, false));
+	}
+
+	SECTION("an unrolled call binds its trailing arguments back into a pack") {
+		auto deserialized = Deserialize(con, legacy_bytes);
+
+		// this is also what happens when a plan written before argument packs existed is read back
+		RequirePackedHashCall(*deserialized);
+
+		auto result = con.context->Query(make_uniq<LogicalPlanStatement>(std::move(deserialized)), false);
+		REQUIRE_NO_FAIL(*result);
+		REQUIRE(result->Equals(*expected, false));
+	}
+
+	con.Rollback();
+}

--- a/test/api/test_argument_pack_serialization.cpp
+++ b/test/api/test_argument_pack_serialization.cpp
@@ -62,6 +62,22 @@ void RequirePackedHashCall(LogicalOperator &plan) {
 	REQUIRE(ArgumentPack::IsPackType(function.GetChildren()[1]->GetReturnType()));
 }
 
+//! "struct_pack" takes (**fields ANY), so a bound call always has exactly one argument: the keyword pack, whose
+//! field names are the names the arguments were passed under
+void RequirePackedStructPackCall(LogicalOperator &plan) {
+	auto &expr = *plan.expressions[0];
+	REQUIRE(expr.GetExpressionClass() == ExpressionClass::BOUND_FUNCTION);
+	auto &function = expr.Cast<BoundFunctionExpression>();
+	REQUIRE(function.Function().GetName() == "struct_pack");
+	REQUIRE(function.GetChildren().size() == 1);
+
+	auto &pack_type = function.GetChildren()[0]->GetReturnType();
+	REQUIRE(ArgumentPack::IsPackType(pack_type));
+	REQUIRE(StructType::GetChildCount(pack_type) == 2);
+	REQUIRE(StructType::GetChildName(pack_type, 0) == "a");
+	REQUIRE(StructType::GetChildName(pack_type, 1) == "b");
+}
+
 } // namespace
 
 TEST_CASE("Argument packs survive plan serialization", "[api]") {
@@ -79,11 +95,7 @@ TEST_CASE("Argument packs survive plan serialization", "[api]") {
 	auto latest_bytes = Serialize(*plan, StorageCompatibility::Latest());
 	auto legacy_bytes = Serialize(*plan, StorageCompatibility::FromString("v1.2.0"));
 
-	// a storage version that predates argument packs gets a different encoding of the same call: the pack is
-	// unrolled into the plain argument list the call was written with
-	REQUIRE(latest_bytes != legacy_bytes);
-
-	SECTION("current storage version keeps the call packed") {
+	SECTION("the current storage version writes the call unrolled and reads it back packed") {
 		auto deserialized = Deserialize(con, latest_bytes);
 		RequirePackedHashCall(*deserialized);
 
@@ -92,11 +104,38 @@ TEST_CASE("Argument packs survive plan serialization", "[api]") {
 		REQUIRE(result->Equals(*expected, false));
 	}
 
-	SECTION("an unrolled call binds its trailing arguments back into a pack") {
+	SECTION("so does a storage version that predates argument packs") {
 		auto deserialized = Deserialize(con, legacy_bytes);
 
 		// this is also what happens when a plan written before argument packs existed is read back
 		RequirePackedHashCall(*deserialized);
+
+		auto result = con.context->Query(make_uniq<LogicalPlanStatement>(std::move(deserialized)), false);
+		REQUIRE_NO_FAIL(*result);
+		fprintf(stderr, "GOT:\n%s\nEXPECTED:\n%s\n", result->ToString().c_str(), expected->ToString().c_str());
+		REQUIRE(result->Equals(*expected, false));
+	}
+
+	con.Rollback();
+}
+
+TEST_CASE("Keyword argument packs survive plan serialization", "[api]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	con.BeginTransaction();
+
+	const string query = "SELECT struct_pack(a := i, b := i + 1) FROM range(3) t(i)";
+	auto plan = PlanQuery(con, query);
+	RequirePackedStructPackCall(*plan);
+
+	// the keyword pack is unrolled with its field names in the argument aliases, which is how a call to a function
+	// that derived its names from argument aliases looked before argument packs existed
+	for (auto &compatibility : {StorageCompatibility::Latest(), StorageCompatibility::FromString("v1.2.0")}) {
+		auto expected = con.Query(query);
+		REQUIRE_NO_FAIL(*expected);
+
+		auto deserialized = Deserialize(con, Serialize(*plan, compatibility));
+		RequirePackedStructPackCall(*deserialized);
 
 		auto result = con.context->Query(make_uniq<LogicalPlanStatement>(std::move(deserialized)), false);
 		REQUIRE_NO_FAIL(*result);

--- a/test/extension/loadable_extension_demo.cpp
+++ b/test/extension/loadable_extension_demo.cpp
@@ -1117,6 +1117,7 @@ static void RegisterNamedArgumentFunction(ExtensionLoader &loader) {
 	}
 
 	// test_named_agg_inspect(a INTEGER, b INTEGER = 100, c INTEGER = 200) -> VARCHAR
+	// (see below RegisterArgumentPackFunctions for the "*args"/"**kwargs" counterparts)
 	// Aggregate counterpart of test_named_inspect. AggregateFunction has no FunctionSignature
 	// constructor, so we build it from positional types and then set parameter names + defaults on
 	// the signature. Exercises named-argument binding for aggregates (shared resolution path).
@@ -1138,6 +1139,171 @@ static void RegisterNamedArgumentFunction(ExtensionLoader &loader) {
 }
 
 //===--------------------------------------------------------------------===//
+// Test extension functions with python-style "*args" / "**kwargs" parameters
+//===--------------------------------------------------------------------===//
+// These reuse TestFunctionArgs above, so a call prints "<idx>|arg|arg|...". A "*args" parameter
+// shows up as a single TUPLE argument and a "**kwargs" parameter as a single STRUCT argument, which
+// makes both the packing itself and the resulting member names/types visible in the query result.
+
+// Aggregate counterpart: sums the values collected by its "*args" parameter and reports how many
+// there were, as count * 1000 + sum, so a test can see the pack arrive with the right arity.
+struct PackAggState {
+	int64_t sum;
+	idx_t arg_count;
+	bool initialized;
+};
+
+struct PackAggOp {
+	template <class STATE>
+	static void Initialize(STATE &state) {
+		state.sum = 0;
+		state.arg_count = 0;
+		state.initialized = false;
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
+		target.sum += source.sum;
+		if (source.initialized && !target.initialized) {
+			target.arg_count = source.arg_count;
+			target.initialized = true;
+		}
+	}
+
+	template <class T, class STATE>
+	static void Finalize(STATE &state, T &target, AggregateFinalizeData &) {
+		target = NumericCast<int64_t>(state.arg_count) * 1000 + state.sum;
+	}
+
+	static bool IgnoreNull() {
+		return false;
+	}
+};
+
+static void PackAggUpdate(Vector inputs[], AggregateInputData &, idx_t input_count, Vector &state_vector, idx_t count) {
+	D_ASSERT(input_count == 1);
+	UnifiedVectorFormat sdata;
+	state_vector.ToUnifiedFormat(sdata);
+	auto states = UnifiedVectorFormat::GetData<PackAggState *>(sdata);
+
+	// the single argument is the "*args" pack - its members are the values the call was written with
+	auto &packed = StructVector::GetEntries(inputs[0]);
+	vector<UnifiedVectorFormat> pdata(packed.size());
+	for (idx_t c = 0; c < packed.size(); c++) {
+		packed[c].ToUnifiedFormat(pdata[c]);
+	}
+
+	for (idx_t i = 0; i < count; i++) {
+		auto &state = *states[sdata.sel->get_index(i)];
+		state.arg_count = packed.size();
+		state.initialized = true;
+		for (idx_t c = 0; c < packed.size(); c++) {
+			const auto idx = pdata[c].sel->get_index(i);
+			if (pdata[c].validity.RowIsValid(idx)) {
+				state.sum += UnifiedVectorFormat::GetData<int32_t>(pdata[c])[idx];
+			}
+		}
+	}
+}
+
+static void RegisterArgumentPackFunctions(ExtensionLoader &loader) {
+	using NH = FunctionNullHandling;
+	using PK = FunctionParameterKind;
+
+	// test_pack_args(a INTEGER, *rest ANY) -> VARCHAR
+	// The trailing positional arguments are collected into a TUPLE, whatever their types.
+	{
+		FunctionSignature sig;
+		sig.AddParameter("a", LogicalType::INTEGER);
+		sig.AddVarPositionalParameter("rest", LogicalType::ANY);
+		sig.SetReturnType(LogicalType::VARCHAR);
+		ScalarFunction fn("test_pack_args", std::move(sig), TestFunctionArgs<20>);
+		fn.SetNullHandling(NH::SPECIAL_HANDLING);
+		loader.RegisterFunction(std::move(fn));
+	}
+
+	// test_pack_kwargs(a INTEGER, **opts ANY) -> VARCHAR
+	// The named arguments that match no parameter are collected into a STRUCT keyed by their names.
+	{
+		FunctionSignature sig;
+		sig.AddParameter("a", LogicalType::INTEGER);
+		sig.AddVarKeywordParameter("opts", LogicalType::ANY);
+		sig.SetReturnType(LogicalType::VARCHAR);
+		ScalarFunction fn("test_pack_kwargs", std::move(sig), TestFunctionArgs<21>);
+		fn.SetNullHandling(NH::SPECIAL_HANDLING);
+		loader.RegisterFunction(std::move(fn));
+	}
+
+	// test_pack_both(a INTEGER, *args INTEGER, b INTEGER := 7, **kwargs VARCHAR) -> VARCHAR
+	// Both packs at once, with a keyword-only parameter in between and element types that the
+	// collected arguments have to be cast to.
+	{
+		FunctionSignature sig;
+		sig.AddParameter("a", LogicalType::INTEGER);
+		sig.AddVarPositionalParameter("args", LogicalType::INTEGER);
+		sig.AddKeywordOnlyParameter("b", LogicalType::INTEGER, Value::INTEGER(7));
+		sig.AddVarKeywordParameter("kwargs", LogicalType::VARCHAR);
+		sig.SetReturnType(LogicalType::VARCHAR);
+		ScalarFunction fn("test_pack_both", std::move(sig), TestFunctionArgs<22>);
+		fn.SetNullHandling(NH::SPECIAL_HANDLING);
+		loader.RegisterFunction(std::move(fn));
+	}
+
+	// test_pack_overload: a "**kwargs" overload next to one that takes a plain STRUCT, to pin down
+	// that a struct passed as an ordinary argument is not mistaken for a pack.
+	//   <23> (a INTEGER, s STRUCT(v INTEGER))
+	//   <24> (a INTEGER, **opts ANY)
+	{
+		ScalarFunctionSet set("test_pack_overload");
+		{
+			FunctionSignature sig;
+			sig.AddParameter("a", LogicalType::INTEGER);
+			sig.AddParameter("s", LogicalType::STRUCT({{"v", LogicalType::INTEGER}}));
+			sig.SetReturnType(LogicalType::VARCHAR);
+			ScalarFunction fn("", std::move(sig), TestFunctionArgs<23>);
+			fn.SetNullHandling(NH::SPECIAL_HANDLING);
+			set.AddFunction(std::move(fn));
+		}
+		{
+			FunctionSignature sig;
+			sig.AddParameter("a", LogicalType::INTEGER);
+			sig.AddVarKeywordParameter("opts", LogicalType::ANY);
+			sig.SetReturnType(LogicalType::VARCHAR);
+			ScalarFunction fn("", std::move(sig), TestFunctionArgs<24>);
+			fn.SetNullHandling(NH::SPECIAL_HANDLING);
+			set.AddFunction(std::move(fn));
+		}
+		loader.RegisterFunction(set);
+	}
+
+	// test_pack_nullshort(a INTEGER, *rest ANY) -> VARCHAR
+	// DEFAULT_NULL_HANDLING: a constant NULL anywhere - including one destined for the pack - still
+	// short-circuits the whole call to NULL.
+	{
+		FunctionSignature sig;
+		sig.AddParameter("a", LogicalType::INTEGER);
+		sig.AddVarPositionalParameter("rest", LogicalType::ANY);
+		sig.SetReturnType(LogicalType::VARCHAR);
+		loader.RegisterFunction(ScalarFunction("test_pack_nullshort", std::move(sig), TestFunctionArgs<25>));
+	}
+
+	// test_pack_agg(*args INTEGER) -> BIGINT
+	// AggregateFunction has no FunctionSignature constructor, so build it positionally and then mark
+	// the parameter as a "*args" one.
+	{
+		AggregateFunction agg("test_pack_agg", {LogicalType::INTEGER}, LogicalType::BIGINT,
+		                      AggregateFunction::StateSize<PackAggState>,
+		                      AggregateFunction::StateInitialize<PackAggState, PackAggOp>, PackAggUpdate,
+		                      AggregateFunction::StateCombine<PackAggState, PackAggOp>,
+		                      AggregateFunction::StateFinalize<PackAggState, int64_t, PackAggOp>, NH::SPECIAL_HANDLING);
+		auto &sig = agg.GetSignature();
+		sig.GetParameter(0).SetName("args");
+		sig.GetParameter(0).SetKind(PK::VAR_POSITIONAL);
+		loader.RegisterFunction(std::move(agg));
+	}
+}
+
+//===--------------------------------------------------------------------===//
 // Extension load + setup
 //===--------------------------------------------------------------------===//
 extern "C" {
@@ -1146,6 +1312,7 @@ DUCKDB_CPP_EXTENSION_ENTRY(loadable_extension_demo, loader) {
 	    ScalarFunction("test_alias_hello", {}, LogicalType::VARCHAR, TestAliasHello));
 
 	RegisterNamedArgumentFunction(loader);
+	RegisterArgumentPackFunctions(loader);
 	AggregateFunction volatile_aggregate(
 	    "test_volatile_aggregate", {LogicalType::INTEGER}, LogicalType::BIGINT,
 	    AggregateFunction::StateSize<VolatileAggregateState>,

--- a/test/extension/loadable_extension_demo.cpp
+++ b/test/extension/loadable_extension_demo.cpp
@@ -1011,7 +1011,7 @@ static void InspectAggUpdate(Vector inputs[], AggregateInputData &, idx_t input_
 
 // The inspection functions below return VARCHAR and print "<idx>|arg|arg|..." (see
 // TestFunctionArgs) so that a single query result reveals both which overload was chosen
-// and the final positional argument list (after reordering/defaults/varargs). SPECIAL_HANDLING
+// and the final positional argument list (after reordering and defaults). SPECIAL_HANDLING
 // is used so that NULL arguments still reach the body and we can observe their final position.
 static void RegisterNamedArgumentFunction(ExtensionLoader &loader) {
 	using NH = FunctionNullHandling;
@@ -1025,19 +1025,6 @@ static void RegisterNamedArgumentFunction(ExtensionLoader &loader) {
 		sig.AddParameter("c", LogicalType::INTEGER, Value::INTEGER(200));
 		sig.SetReturnType(LogicalType::VARCHAR);
 		ScalarFunction fn("test_named_inspect", std::move(sig), TestFunctionArgs<1>);
-		fn.SetNullHandling(NH::SPECIAL_HANDLING);
-		loader.RegisterFunction(std::move(fn));
-	}
-
-	// test_named_varargs(a INTEGER, b INTEGER = 100, ... INTEGER) -> VARCHAR
-	// Varargs are appended trailing; named varargs have their names discarded but keep order.
-	{
-		FunctionSignature sig;
-		sig.AddParameter("a", LogicalType::INTEGER);
-		sig.AddParameter("b", LogicalType::INTEGER, Value::INTEGER(100));
-		sig.SetVarArgs(LogicalType::INTEGER);
-		sig.SetReturnType(LogicalType::VARCHAR);
-		ScalarFunction fn("test_named_varargs", std::move(sig), TestFunctionArgs<2>);
 		fn.SetNullHandling(NH::SPECIAL_HANDLING);
 		loader.RegisterFunction(std::move(fn));
 	}

--- a/test/extension/loadable_extension_demo.cpp
+++ b/test/extension/loadable_extension_demo.cpp
@@ -1249,6 +1249,20 @@ static void RegisterArgumentPackFunctions(ExtensionLoader &loader) {
 		loader.RegisterFunction(std::move(fn));
 	}
 
+	// test_pack_required_kw(a INTEGER, *args INTEGER, b INTEGER) -> VARCHAR
+	// A keyword-only parameter without a default: it can only be supplied by name, and omitting it
+	// is an error even though *args happily collects any number of positional arguments.
+	{
+		FunctionSignature sig;
+		sig.AddParameter("a", LogicalType::INTEGER);
+		sig.AddVarPositionalParameter("args", LogicalType::INTEGER);
+		sig.AddKeywordOnlyParameter("b", LogicalType::INTEGER);
+		sig.SetReturnType(LogicalType::VARCHAR);
+		ScalarFunction fn("test_pack_required_kw", std::move(sig), TestFunctionArgs<26>);
+		fn.SetNullHandling(NH::SPECIAL_HANDLING);
+		loader.RegisterFunction(std::move(fn));
+	}
+
 	// test_pack_overload: a "**kwargs" overload next to one that takes a plain STRUCT, to pin down
 	// that a struct passed as an ordinary argument is not mistaken for a pack.
 	//   <23> (a INTEGER, s STRUCT(v INTEGER))

--- a/test/extension/test_function_argument_packs.test
+++ b/test/extension/test_function_argument_packs.test
@@ -1,0 +1,276 @@
+# name: test/extension/test_function_argument_packs.test
+# description: Python-style *args / **kwargs function parameters - packing, overload resolution and errors
+# group: [extension]
+
+require skip_reload
+
+require notmingw
+
+require allow_unsigned_extensions
+
+statement ok
+LOAD '{BUILD_DIRECTORY}/test/extension/loadable_extension_demo.duckdb_extension';
+
+# The inspection functions return a string "<overload_idx>|arg|arg|..." that shows the final argument
+# list the function was called with. A "*args" parameter shows up as a single TUPLE argument and a
+# "**kwargs" parameter as a single STRUCT argument, so both the packing and the resulting member
+# names/types are visible in the result.
+
+statement ok
+CREATE TABLE t AS SELECT * FROM (VALUES (1), (2)) v(x);
+
+#===--------------------------------------------------------------------===#
+# *args - test_pack_args(a INTEGER, *rest ANY)
+#===--------------------------------------------------------------------===#
+
+# no trailing arguments at all - the pack is an empty tuple, not an error
+query I
+SELECT test_pack_args(1);
+----
+<20>|1|()|
+
+query I
+SELECT test_pack_args(1, 2);
+----
+<20>|1|(2,)|
+
+# the element type is ANY, so the collected arguments keep their own types
+query I
+SELECT test_pack_args(1, 2, 'a', 3.5);
+----
+<20>|1|(2, 'a', 3.5)|
+
+# a NULL is a value inside the pack, not a NULL argument (this overload has SPECIAL_HANDLING)
+query I
+SELECT test_pack_args(1, NULL, 2);
+----
+<20>|1|(NULL, 2)|
+
+# the pack is rebuilt per row - here from a mix of a column and constants
+query I
+SELECT test_pack_args(x, 1, 2) FROM t ORDER BY x;
+----
+<20>|1|(1, 2)|
+<20>|2|(1, 2)|
+
+# a fully constant call: the whole expression folds, and the packed arguments survive it
+query I
+SELECT test_pack_args(1, 2, 3) FROM t ORDER BY x;
+----
+<20>|1|(2, 3)|
+<20>|1|(2, 3)|
+
+#===--------------------------------------------------------------------===#
+# **kwargs - test_pack_kwargs(a INTEGER, **opts ANY)
+#===--------------------------------------------------------------------===#
+
+query I
+SELECT test_pack_kwargs(1);
+----
+<21>|1|{}|
+
+# the caller's names become the struct field names, in call order
+query I
+SELECT test_pack_kwargs(1, k := 'a', j := 5);
+----
+<21>|1|{'k': 'a', 'j': 5}|
+
+query I
+SELECT test_pack_kwargs(1, j := 5, k := 'a');
+----
+<21>|1|{'j': 5, 'k': 'a'}|
+
+# => works as well as :=
+query I
+SELECT test_pack_kwargs(1, k => 'a');
+----
+<21>|1|{'k': 'a'}|
+
+# the name of the **kwargs parameter itself is not reserved - it is just another keyword
+query I
+SELECT test_pack_kwargs(1, opts := 'a');
+----
+<21>|1|{'opts': 'a'}|
+
+#===--------------------------------------------------------------------===#
+# Both packs at once, with a keyword-only parameter in between
+# test_pack_both(a INTEGER, *args INTEGER, b INTEGER := 7, **kwargs VARCHAR)
+#===--------------------------------------------------------------------===#
+
+query I
+SELECT test_pack_both(1);
+----
+<22>|1|()|7|{}|
+
+query I
+SELECT test_pack_both(1, 2, 3);
+----
+<22>|1|(2, 3)|7|{}|
+
+# the keyword-only parameter can only be supplied by name - a fourth positional argument is
+# collected by *args and 'b' keeps its default
+query I
+SELECT test_pack_both(1, 2, 3, 9);
+----
+<22>|1|(2, 3, 9)|7|{}|
+
+query I
+SELECT test_pack_both(1, 2, 3, b := 9);
+----
+<22>|1|(2, 3)|9|{}|
+
+query I
+SELECT test_pack_both(1, 2, 3, b := 9, z := 'q', y := 'r');
+----
+<22>|1|(2, 3)|9|{'z': 'q', 'y': 'r'}|
+
+# the collected arguments are cast to the element type the parameter declares: here the string
+# literal '2' is cast to the INTEGER that *args collects
+query I
+SELECT test_pack_both(1, '2', 3, z := 'q');
+----
+<22>|1|(2, 3)|7|{'z': 'q'}|
+
+# ... and an argument that cannot be implicitly cast to it rules the overload out, exactly as it
+# would for a regular parameter (INTEGER does not implicitly cast to the VARCHAR **kwargs collects)
+statement error
+SELECT test_pack_both(1, 2, z := 4);
+----
+<REGEX>:Binder Error:.*No function matches.*
+
+#===--------------------------------------------------------------------===#
+# Overload resolution: a plain STRUCT argument is not a **kwargs pack
+#   <23> (a INTEGER, s STRUCT(v INTEGER))
+#   <24> (a INTEGER, **opts ANY)
+#===--------------------------------------------------------------------===#
+
+query I
+SELECT test_pack_overload(1, {'v': 1});
+----
+<23>|1|{'v': 1}|
+
+query I
+SELECT test_pack_overload(1, s := {'v': 1});
+----
+<23>|1|{'v': 1}|
+
+query I
+SELECT test_pack_overload(1, k := 'v');
+----
+<24>|1|{'k': 'v'}|
+
+query I
+SELECT test_pack_overload(1);
+----
+<24>|1|{}|
+
+#===--------------------------------------------------------------------===#
+# NULL handling - test_pack_nullshort(a INTEGER, *rest ANY) has DEFAULT_NULL_HANDLING
+#===--------------------------------------------------------------------===#
+
+# a constant NULL destined for the pack short-circuits the whole call, exactly as a constant NULL
+# passed to a regular argument does
+query I
+SELECT test_pack_nullshort(1, NULL, 2);
+----
+NULL
+
+query I
+SELECT test_pack_nullshort(NULL, 1, 2);
+----
+NULL
+
+query I
+SELECT test_pack_nullshort(1, 2);
+----
+<25>|1|(2,)|
+
+#===--------------------------------------------------------------------===#
+# Two call sites sharing an identical pack (the common subexpression optimizer may merge them)
+#===--------------------------------------------------------------------===#
+
+query II
+SELECT test_pack_args(x, 1, 2), test_pack_nullshort(x, 1, 2) FROM t ORDER BY x;
+----
+<20>|1|(1, 2)|	<25>|1|(1, 2)|
+<20>|2|(1, 2)|	<25>|2|(1, 2)|
+
+query II
+SELECT test_pack_args(x, 1, 2) AS a, test_pack_args(x, 1, 2) AS b FROM t ORDER BY x;
+----
+<20>|1|(1, 2)|	<20>|1|(1, 2)|
+<20>|2|(1, 2)|	<20>|2|(1, 2)|
+
+#===--------------------------------------------------------------------===#
+# Aggregates share the same resolution path - test_pack_agg(*args INTEGER)
+# returns <number of packed arguments> * 1000 + <sum of their values>
+#===--------------------------------------------------------------------===#
+
+query I
+SELECT test_pack_agg(x, 10) FROM t;
+----
+2023
+
+query I
+SELECT test_pack_agg(x) FROM t;
+----
+1003
+
+query I
+SELECT test_pack_agg() FROM t;
+----
+0
+
+#===--------------------------------------------------------------------===#
+# Errors
+#===--------------------------------------------------------------------===#
+
+# more positional arguments than a function without *args can take
+statement error
+SELECT test_named_inspect(1, 2, 3, 4);
+----
+<REGEX>:Binder Error:.*No function matches.*
+
+# only **kwargs, so there is nothing to collect a second positional argument
+statement error
+SELECT test_pack_kwargs(1, 2);
+----
+<REGEX>:Binder Error:.*No function matches.*
+
+# an argument pack parameter cannot be supplied by name - it is built from what it collects
+statement error
+SELECT test_pack_args(1, rest := 2);
+----
+<REGEX>:Binder Error:.*No function matches.*
+
+# a named argument that matches no parameter, with no **kwargs to collect it
+statement error
+SELECT test_named_inspect(1, nosuch := 2);
+----
+<REGEX>:Binder Error:.*No function matches.*
+
+statement error
+SELECT test_pack_kwargs(1, k := 1, k := 2);
+----
+<REGEX>:Binder Error:.*Duplicate named argument 'k'.*
+
+statement error
+SELECT test_pack_kwargs(1, a := 5);
+----
+<REGEX>:Binder Error:.*already been provided as a positional argument.*
+
+statement error
+SELECT test_pack_kwargs();
+----
+<REGEX>:Binder Error:.*No function matches.*
+
+# the collected arguments still have to be castable to the element type the parameter declares
+statement error
+SELECT test_pack_both(1, 'notanint');
+----
+<REGEX>:(Binder|Conversion) Error:.*
+
+statement error
+SELECT test_pack_both(1, 2, b := 'notanint');
+----
+<REGEX>:Conversion Error:.*

--- a/test/extension/test_function_argument_packs.test
+++ b/test/extension/test_function_argument_packs.test
@@ -302,3 +302,15 @@ statement error
 SELECT test_pack_both(1, 2, b := 'notanint');
 ----
 <REGEX>:Conversion Error:.*
+
+#===--------------------------------------------------------------------===#
+# duckdb_functions() reports the element/value type of each pack parameter
+#===--------------------------------------------------------------------===#
+
+query III
+SELECT function_name, varargs, named_varargs FROM duckdb_functions()
+WHERE function_name IN ('test_pack_args', 'test_pack_kwargs', 'test_pack_both') ORDER BY function_name;
+----
+test_pack_args	ANY	NULL
+test_pack_both	INTEGER	VARCHAR
+test_pack_kwargs	NULL	ANY

--- a/test/extension/test_function_argument_packs.test
+++ b/test/extension/test_function_argument_packs.test
@@ -139,6 +139,34 @@ SELECT test_pack_both(1, 2, z := 4);
 <REGEX>:Binder Error:.*No function matches.*
 
 #===--------------------------------------------------------------------===#
+# A keyword-only parameter without a default is required
+# test_pack_required_kw(a INTEGER, *args INTEGER, b INTEGER)
+#===--------------------------------------------------------------------===#
+
+query I
+SELECT test_pack_required_kw(1, b := 2);
+----
+<26>|1|()|2|
+
+query I
+SELECT test_pack_required_kw(1, 2, 3, b := 4);
+----
+<26>|1|(2, 3)|4|
+
+# omitting it is an error - *args collects the extra positional arguments instead of filling it
+statement error
+SELECT test_pack_required_kw(1, 2);
+----
+<REGEX>:Binder Error:.*Missing value for parameter 'b'.*
+
+# with too few arguments to cover it at all, the overload is ruled out on arity before its
+# parameters are matched up
+statement error
+SELECT test_pack_required_kw(1);
+----
+<REGEX>:Binder Error:.*No function matches.*
+
+#===--------------------------------------------------------------------===#
 # Overload resolution: a plain STRUCT argument is not a **kwargs pack
 #   <23> (a INTEGER, s STRUCT(v INTEGER))
 #   <24> (a INTEGER, **opts ANY)

--- a/test/extension/test_function_argument_packs_storage.test
+++ b/test/extension/test_function_argument_packs_storage.test
@@ -1,0 +1,54 @@
+# name: test/extension/test_function_argument_packs_storage.test
+# description: *args / **kwargs function calls survive a round-trip through storage
+# group: [extension]
+
+require skip_reload
+
+require notmingw
+
+require allow_unsigned_extensions
+
+load {TEST_DIR}/argument_packs.db
+
+statement ok
+LOAD '{BUILD_DIRECTORY}/test/extension/loadable_extension_demo.duckdb_extension';
+
+# A generated column and a CHECK constraint both store a bound expression in the catalog, so these
+# calls are serialized with their argument packs built and have to be re-bound on load without the
+# packs being packed a second time.
+
+statement ok
+CREATE TABLE tt(
+    x INTEGER CHECK (test_pack_args(x, 1, 2) IS NOT NULL),
+    g VARCHAR GENERATED ALWAYS AS (test_pack_both(x, 1, 2, b := 9, z := 'q')),
+    h VARCHAR GENERATED ALWAYS AS (test_pack_kwargs(x, k := 'a', j := 5))
+);
+
+statement ok
+INSERT INTO tt(x) VALUES (5);
+
+query III
+SELECT x, g, h FROM tt;
+----
+5	<22>|5|(1, 2)|9|{'z': 'q'}|	<21>|5|{'k': 'a', 'j': 5}|
+
+restart
+
+statement ok
+LOAD '{BUILD_DIRECTORY}/test/extension/loadable_extension_demo.duckdb_extension';
+
+# the stored expressions still evaluate to the same thing after being read back
+query III
+SELECT x, g, h FROM tt;
+----
+5	<22>|5|(1, 2)|9|{'z': 'q'}|	<21>|5|{'k': 'a', 'j': 5}|
+
+# ... and are still usable for new rows, which means they were re-bound into a working plan
+statement ok
+INSERT INTO tt(x) VALUES (6);
+
+query III
+SELECT x, g, h FROM tt ORDER BY x;
+----
+5	<22>|5|(1, 2)|9|{'z': 'q'}|	<21>|5|{'k': 'a', 'j': 5}|
+6	<22>|6|(1, 2)|9|{'z': 'q'}|	<21>|6|{'k': 'a', 'j': 5}|

--- a/test/extension/test_function_argument_packs_storage.test
+++ b/test/extension/test_function_argument_packs_storage.test
@@ -13,9 +13,10 @@ load {TEST_DIR}/argument_packs.db
 statement ok
 LOAD '{BUILD_DIRECTORY}/test/extension/loadable_extension_demo.duckdb_extension';
 
-# A generated column and a CHECK constraint both store a bound expression in the catalog, so these
-# calls are serialized with their argument packs built and have to be re-bound on load without the
-# packs being packed a second time.
+# Generated columns and CHECK constraints store the expression as written, so reopening the database
+# re-binds these calls from scratch. That covers the binding side of the round-trip; serialization of
+# the *bound* call, including how it is written for storage versions that predate argument packs, is
+# covered by the "Argument packs survive plan serialization" test in test/api.
 
 statement ok
 CREATE TABLE tt(

--- a/test/extension/test_function_named_args.test
+++ b/test/extension/test_function_named_args.test
@@ -164,60 +164,6 @@ SELECT test_named_nullshort(a := 1, b := NULL);
 NULL
 
 #===--------------------------------------------------------------------===#
-# Varargs (a INT, b INT = 100, ... INT) - varargs are appended trailing
-#===--------------------------------------------------------------------===#
-
-query I
-SELECT test_named_varargs(1);
-----
-<2>|1|100|
-
-query I
-SELECT test_named_varargs(1, 2);
-----
-<2>|1|2|
-
-query I
-SELECT test_named_varargs(1, 2, 3);
-----
-<2>|1|2|3|
-
-query I
-SELECT test_named_varargs(1, 2, 3, 4, 5);
-----
-<2>|1|2|3|4|5|
-
-# Named varargs: the names are discarded, the values are appended in call order
-query I
-SELECT test_named_varargs(1, 2, x := 3, y := 4);
-----
-<2>|1|2|3|4|
-
-# Order of multiple named varargs is preserved
-query I
-SELECT test_named_varargs(1, 2, z := 30, w := 40, m := 50);
-----
-<2>|1|2|30|40|50|
-
-# Defaults are filled before varargs are appended
-query I
-SELECT test_named_varargs(1, x := 10);
-----
-<2>|1|100|10|
-
-# Named non-vararg parameter + named vararg
-query I
-SELECT test_named_varargs(a := 1, b := 2, x := 3);
-----
-<2>|1|2|3|
-
-# A castable vararg value is cast to the vararg type
-query I
-SELECT test_named_varargs(1, 2, 3::SMALLINT);
-----
-<2>|1|2|3|
-
-#===--------------------------------------------------------------------===#
 # Overload resolution driven by types/arity, including via named arguments
 #   <10> (a INT, b INT)   <11> (a INT, b VARCHAR)   <12> (a INT)
 #===--------------------------------------------------------------------===#
@@ -289,12 +235,6 @@ SELECT test_named_inspect();
 # argument resolution rather than from "no matching function".
 statement error
 SELECT test_named_inspect(b := 2);
-----
-<REGEX>:Binder Error:.*Missing value for parameter 'a'.*
-
-# A named vararg cannot satisfy a required positional parameter
-statement error
-SELECT test_named_varargs(x := 5);
 ----
 <REGEX>:Binder Error:.*Missing value for parameter 'a'.*
 

--- a/test/sql/function/nested/test_struct_insert.test
+++ b/test/sql/function/nested/test_struct_insert.test
@@ -25,7 +25,7 @@ SELECT struct_insert({'a': 1, 'b': 'abc', 'c': true}, d := {'a': 'new stuff'});
 statement error
 SELECT struct_insert();
 ----
-<REGEX>:Invalid Input Error.*Missing required arguments for struct_insert function.*
+<REGEX>:Binder Error:.*No function matches the given name and argument types 'struct_insert\(\)'.*
 
 statement error
 SELECT struct_insert({a: 1, b: 2});
@@ -35,7 +35,7 @@ SELECT struct_insert({a: 1, b: 2});
 statement error
 SELECT struct_insert(123, a := 1);
 ----
-<REGEX>:Invalid Input Error.*The first argument to struct_insert must be a STRUCT.*
+<REGEX>:Binder Error:.*No function matches the given name and argument types 'struct_insert\(INTEGER_LITERAL, a := INTEGER_LITERAL\)'.*
 
 statement error
 SELECT struct_insert({a: 1, b: 2}, a := 2);

--- a/test/sql/function/nested/test_struct_update.test
+++ b/test/sql/function/nested/test_struct_update.test
@@ -25,7 +25,7 @@ SELECT struct_update({'a': 1, 'b': 'abc', 'c': true}, d := {'a': 'new stuff'});
 statement error
 SELECT struct_update();
 ----
-<REGEX>:Invalid Input Error.*Missing required arguments for struct_update function.*
+<REGEX>:Binder Error:.*No function matches the given name and argument types 'struct_update\(\)'.*
 
 statement error
 SELECT struct_update({a: 1, b: 2});
@@ -35,7 +35,7 @@ SELECT struct_update({a: 1, b: 2});
 statement error
 SELECT struct_update(123, a := 1);
 ----
-<REGEX>:Invalid Input Error.*The first argument to struct_update must be a STRUCT.*
+<REGEX>:Binder Error:.*No function matches the given name and argument types 'struct_update\(INTEGER_LITERAL, a := INTEGER_LITERAL\)'.*
 
 statement error
 SELECT struct_update({a: 1, b: 2}, a := 2, a := 3);

--- a/test/sql/types/nested/array/array_invalid.test
+++ b/test/sql/types/nested/array/array_invalid.test
@@ -25,11 +25,11 @@ CREATE TABLE t1(a INT, b INT[2147483647]);
 ----
 <REGEX>:.*Binder Error.*ARRAY type size must be at most 100000.*
 
-# Should not be able to create an array with 0 elements
+# Should not be able to create an array with 0 elements - array_value declares one required element
 statement error
 SELECT array_value();
 ----
-<REGEX>:.*Invalid Input Error.*array_value requires at least one argument.*
+<REGEX>:.*Binder Error.*No function matches.*array_value.*
 
 # Should not be able to create an array with a negative number of elements
 statement error

--- a/test/sql/types/struct/struct_concat.test
+++ b/test/sql/types/struct/struct_concat.test
@@ -44,7 +44,7 @@ SELECT struct_concat(s, {'a': 2, 'b': NULL}) FROM t1 WHERE s.i % 2 = 0;
 statement error
 SELECT struct_concat();
 ----
-Invalid Input Error: struct_concat: At least one argument is required
+<REGEX>:Binder Error:.*No function matches the given name and argument types 'struct_concat\(\)'.*
 
 statement error
 SELECT struct_concat(NULL::STRUCT(k INT), 'not a struct');

--- a/test/sql/types/struct/struct_pack_argument_names.test
+++ b/test/sql/types/struct/struct_pack_argument_names.test
@@ -1,0 +1,97 @@
+# name: test/sql/types/struct/struct_pack_argument_names.test
+# description: struct_pack takes its field names from its argument names
+# group: [struct]
+
+statement ok
+CREATE TABLE t AS SELECT 1 a, 'x' b
+
+# an argument written without a name takes the name of the column it references
+query I
+SELECT struct_pack(a, b) FROM t
+----
+{'a': 1, 'b': x}
+
+# the column name, not the qualification it was written with
+query I
+SELECT struct_pack(t.a, main.t.b) FROM t
+----
+{'a': 1, 'b': x}
+
+# explicit names win, and can be mixed with implicit ones
+query I
+SELECT struct_pack(a, c := b) FROM t
+----
+{'a': 1, 'c': x}
+
+query I
+SELECT struct_pack(c := b, a) FROM t
+----
+{'c': x, 'a': 1}
+
+# a *COLUMNS(...) expansion produces column references, which are named the same way
+query I
+SELECT struct_pack(*COLUMNS(*)) FROM t
+----
+{'a': 1, 'b': x}
+
+query I
+SELECT struct_pack(c := 42, *COLUMNS('a')) FROM t
+----
+{'c': 42, 'a': 1}
+
+# COLUMNS(...) replicates the whole expression instead
+query II
+SELECT struct_pack(COLUMNS(*)) FROM t
+----
+{'a': 1}	{'b': x}
+
+# an argument that is not a column reference has no name to take
+statement error
+SELECT struct_pack(a + 1) FROM t
+----
+<REGEX>:.*Binder Error.*No function matches.*struct_pack.*
+
+statement error
+SELECT struct_pack(1)
+----
+<REGEX>:.*Binder Error.*No function matches.*struct_pack.*
+
+# a struct literal without a field name is the same case
+statement error
+SELECT {'': 42}
+----
+<REGEX>:.*Binder Error.*No function matches.*struct_pack.*
+
+# duplicate field names are rejected
+statement error
+SELECT struct_pack(a := 1, a := 2)
+----
+<REGEX>:.*Binder Error.*Duplicate named argument 'a'.*
+
+statement error
+SELECT struct_pack(a, a := 2) FROM t
+----
+<REGEX>:.*Binder Error.*Duplicate named argument 'a'.*
+
+# row() is positional and keeps no names
+query II
+SELECT row(a, b), typeof(row(a, b)) FROM t
+----
+(1, x)	TUPLE(INTEGER, VARCHAR)
+
+statement error
+SELECT "row"(a := 1)
+----
+<REGEX>:.*Binder Error.*No function matches.*row.*
+
+# the packed call survives a rebind through storage
+statement ok
+CREATE TABLE packed(id INT, s STRUCT(a INT, b VARCHAR) DEFAULT struct_pack(a := 1, b := 'x'))
+
+statement ok
+INSERT INTO packed (id) VALUES (1)
+
+query II
+SELECT id, s FROM packed
+----
+1	{'a': 1, 'b': x}

--- a/test/sql/types/struct/unnest_column_names.test
+++ b/test/sql/types/struct/unnest_column_names.test
@@ -71,12 +71,12 @@ element1	TUPLE(INTEGER)
 statement error
 SELECT column_name, column_type FROM (DESCRIBE SELECT unnest([{'a': 12, 'b': {'': {'': 12}}}], max_depth := 3));
 ----
-<REGEX>:.*Binder Error.*Need named argument for struct pack.*
+<REGEX>:.*Binder Error.*No function matches.*struct_pack.*
 
 statement error
 SELECT column_name, column_type FROM (DESCRIBE SELECT unnest([{'': {'': 12}}], recursive := true, keep_parent_names := true));
 ----
-<REGEX>:.*Binder Error.*Need named argument for struct pack.*
+<REGEX>:.*Binder Error.*No function matches.*struct_pack.*
 
 # Test empty structs or lists
 


### PR DESCRIPTION
**This PR is a work-in-progress**, the functionality is there, but there's a lot of stuff to clean up before this is ready to be merged.

This PR (attempts) to remove support for "trailing" variadic arguments from function using the `FunctionSignature` (e.g. scalar/window/aggregates) and instead introduces support for positional and named _parameter pack_ parameters. In other words, Python-style `*args` and `**kwargs`. 

If a function signature contains a positional parameter pack (`*args`), any extraneous arguments will automatically be packed into an unnamed struct (`LogicalType::TUPLE`) and passed to the function at the same "position" as the positional pack is defined in the signature during execution.

Similarly, the binder will automatically pack any extraneous _named_ arguments into a `STRUCT` where the fields are the passed argument names - if the function signature has a named parameter pack (`**kwargs`).

This is implemented by introducing a new `ARGUMENT_PACK` `OperatorExpression`, which essentially just copies the implementation of the `struct_pack`/`row` functions. Unfortunately, we need a new operator type and can't just manufacture a `struct_pack`/`row` function expression, as they themselves are also variadic functions, and so would bundle their arguments into another pack, which would require another `struct_pack`/`row` call, etc. etc. - indefinite recursion.

This has the following benefits:
- Functions always know exactly what arguments will be given at which position.
- Functions can now distinguish between positional/keyword-varargs, and can _always_ access the name of a given argument by just checking the argument types, no need to know anything about expressions or access `expr->GetAlias()` (which may make it easier to remove expression aliases in the future)
- Functions can now define _keyword-only_ arguments (simply define a named argument _after_ a positional parameter pack in the signature, e.g. `foo(x, *args, this_arg_can_only_be_passed_by_name, **kwargs)`
- We can now support variadic used-defined macros (if we switch them over to also use the `FunctionSignature`
- We can now also move `TableFunction`/`PragmaFunction`s to use the `FunctionSignature` too as their "named parameter map" is essentially just a constant-folded `**kwargs`.
- We can now define `FunctionSignature`s for "type constructors", making the future binding/creation of both built-in and custom types have much nicer error messages and automatically generated documentation.
- We could support __both__ struct and array "spreading"/"unpacking" (i.e.`*`, `**`, or `...` syntax) in function calls, allowing for very expressive column/expression manipulation in SQL, narrowing the gap further between our SQL and various data frame APIs.
- Maps nicely to Python UDFs (which we want to support post v2.0 anyway), but also UDFs in other languages where trailing arguments are packed into lists/tuples (e.g. java/C#).

This PR is quite big cause it moves over all existing variadic scalar/window/aggregate functions to use parameter packs instead of trailing varargs.

Backwards compatibility is preserved by "unrolling" any bound parameter packs back into trailing arguments when serializing to an older storage version. We also unroll parameter packs in the V1-C-API so that c-api functions that support trailing varargs don't need any changes.

However, there is one function that still use trailing varargs, which is why this PR does not remove that functionality yet. That function is `struct_pack`

# We need to talk about `struct_pack`

`struct_pack` is a very different function. It takes an arbitrary list of _named arguments_, e.g. `struct_pack( x := 42, y := 'foo')` and returns a new `STRUCT` column containing the arguments as fields, with their passed names as field names, i.e. `{'x': 42, 'y': 'foo'}`. In theory we could just define its signature as `struct_pack(**kwargs)` - except that it also has the really odd behavior of _automatically naming unnamed arguments based if the argument expression alias_. Aliased expressions are in themselves kind of odd in that they are created very inconsistently, but it is basically what allows you to currently do:

```sql
select struct_pack(i) from range(0,1) as r(i);
----
┌──────────────────┐ -- wait, I never passed ` i := i`?
│  struct_pack(i)  │
│ struct(i bigint) │
├──────────────────┤
│ {'i': 0}         │
└──────────────────┘
```

I don't even know if this is intentional, but it is very annoying cause no other function really work this way (very few functions supported passing arguments by name to begin with), and it also e.g. allows you to pass a positional argument _after_ a named argument _if that argument comes from an aliased expression_. Again, no other language with named arguments support this (it should be a parser error IMO and not even reach the binder).

I actually discovered this back in https://github.com/duckdb/duckdb/pull/22941, and ended up writing a very hacky special binding mode for "implicit argument capture" - which only `struct_extract` uses. I no longer think this is the right way to go, we should just remove this capability from `struct_extract`, make it work like any other function, and reject positional-after-named arguments in the parser way before it reaches the binder (which will simplify a lot of binding code).

Now, I can see that being able to automatically wrap up a bunch of expression in a struct and have the field names be automatically generated could be useful. So my proposal would be that we preserve this behavior when creating structs through the _literal syntax_, i.e. `{'x' := 42, i} from range(0, 1) as r(i)`, by having the parser emit a new parsed `PackExpression`, which the binder turns into a `PACK_OPERATOR` `OperatorExpression`, without going through the function binder. The braced `{}` syntax would then essentially mirror the behavior of `SELECT`-lists, which I think is kinda neat. A table/relation is more or less just an unpacked struct after all?

This is however a minor user facing SQL change - but I would argue that it should be acceptable because it is a very niche, and essentially unintended behavior. We would then be able to unify function call semantics across all of our functions and function types.
