### PR TITLE
Verify foreign keys against the referenced table's local deletes

### DIFF
--- a/src/include/duckdb/storage/data_table.hpp
+++ b/src/include/duckdb/storage/data_table.hpp
@@ -312,14 +312,11 @@ private:
 	//! Rebuild all indexes after vacuuming changed rowid's (used with vacuum_rebuild_indexes setting).
 	void RebuildIndexes();
 
-	void VerifyForeignKeyConstraint(optional_ptr<LocalTableStorage> storage,
-	                                const BoundForeignKeyConstraint &bound_foreign_key, ClientContext &context,
+	void VerifyForeignKeyConstraint(const BoundForeignKeyConstraint &bound_foreign_key, ClientContext &context,
 	                                DataChunk &chunk, VerifyExistenceType type);
-	void VerifyAppendForeignKeyConstraint(optional_ptr<LocalTableStorage> storage,
-	                                      const BoundForeignKeyConstraint &bound_foreign_key, ClientContext &context,
+	void VerifyAppendForeignKeyConstraint(const BoundForeignKeyConstraint &bound_foreign_key, ClientContext &context,
 	                                      DataChunk &chunk);
-	void VerifyDeleteForeignKeyConstraint(optional_ptr<LocalTableStorage> storage,
-	                                      const BoundForeignKeyConstraint &bound_foreign_key, ClientContext &context,
+	void VerifyDeleteForeignKeyConstraint(const BoundForeignKeyConstraint &bound_foreign_key, ClientContext &context,
 	                                      DataChunk &chunk);
 
 private:

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -640,8 +640,7 @@ static bool IsAppend(VerifyExistenceType verify_type) {
 	return verify_type == VerifyExistenceType::APPEND_FK;
 }
 
-void DataTable::VerifyForeignKeyConstraint(optional_ptr<LocalTableStorage> storage,
-                                           const BoundForeignKeyConstraint &bound_foreign_key, ClientContext &context,
+void DataTable::VerifyForeignKeyConstraint(const BoundForeignKeyConstraint &bound_foreign_key, ClientContext &context,
                                            DataChunk &chunk, VerifyExistenceType verify_type) {
 	reference<const vector<PhysicalIndex>> src_keys_ptr = bound_foreign_key.info.fk_keys;
 	reference<const vector<PhysicalIndex>> dst_keys_ptr = bound_foreign_key.info.pk_keys;
@@ -687,19 +686,21 @@ void DataTable::VerifyForeignKeyConstraint(optional_ptr<LocalTableStorage> stora
 
 	// Global constraint verification.
 	auto &data_table = table_entry.GetStorage();
-	data_table.info->indexes.VerifyForeignKey(storage ? &storage->delete_indexes : nullptr, dst_keys_ptr, dst_chunk,
-	                                          global_conflict_manager);
+	auto &local_storage = LocalStorage::Get(context, db);
+	// The rows being looked up belong to the referenced table, so use its delete indexes.
+	auto referenced_storage = local_storage.GetStorage(data_table);
+	optional_ptr<const TableIndexList> referenced_deletes =
+	    referenced_storage ? &referenced_storage->delete_indexes : nullptr;
+	data_table.info->indexes.VerifyForeignKey(referenced_deletes, dst_keys_ptr, dst_chunk, global_conflict_manager);
 
 	// Check if we can insert the chunk into the local storage.
-	auto &local_storage = LocalStorage::Get(context, db);
 	bool local_error = false;
 	auto local_verification = local_storage.Find(data_table);
 
 	// Local constraint verification.
 	if (local_verification) {
 		auto &local_indexes = local_storage.GetIndexes(context, data_table);
-		local_indexes.VerifyForeignKey(storage ? &storage->delete_indexes : nullptr, dst_keys_ptr, dst_chunk,
-		                               local_conflict_manager);
+		local_indexes.VerifyForeignKey(referenced_deletes, dst_keys_ptr, dst_chunk, local_conflict_manager);
 		local_error = IsForeignKeyConstraintError(local_conflict_manager, is_append, count);
 	}
 	// Global constraint verification.
@@ -773,16 +774,14 @@ void DataTable::VerifyForeignKeyConstraint(optional_ptr<LocalTableStorage> stora
 	}
 }
 
-void DataTable::VerifyAppendForeignKeyConstraint(optional_ptr<LocalTableStorage> storage,
-                                                 const BoundForeignKeyConstraint &bound_foreign_key,
+void DataTable::VerifyAppendForeignKeyConstraint(const BoundForeignKeyConstraint &bound_foreign_key,
                                                  ClientContext &context, DataChunk &chunk) {
-	VerifyForeignKeyConstraint(storage, bound_foreign_key, context, chunk, VerifyExistenceType::APPEND_FK);
+	VerifyForeignKeyConstraint(bound_foreign_key, context, chunk, VerifyExistenceType::APPEND_FK);
 }
 
-void DataTable::VerifyDeleteForeignKeyConstraint(optional_ptr<LocalTableStorage> storage,
-                                                 const BoundForeignKeyConstraint &bound_foreign_key,
+void DataTable::VerifyDeleteForeignKeyConstraint(const BoundForeignKeyConstraint &bound_foreign_key,
                                                  ClientContext &context, DataChunk &chunk) {
-	VerifyForeignKeyConstraint(storage, bound_foreign_key, context, chunk, VerifyExistenceType::DELETE_FK);
+	VerifyForeignKeyConstraint(bound_foreign_key, context, chunk, VerifyExistenceType::DELETE_FK);
 }
 
 void DataTable::VerifyNewConstraint(LocalStorage &local_storage, DataTable &parent, const BoundConstraint &constraint) {
@@ -844,7 +843,7 @@ void DataTable::VerifyAppendConstraints(ConstraintState &constraint_state, Clien
 		case ConstraintType::FOREIGN_KEY: {
 			auto &bound_foreign_key = constraint->Cast<BoundForeignKeyConstraint>();
 			if (bound_foreign_key.info.IsAppendConstraint()) {
-				VerifyAppendForeignKeyConstraint(storage, bound_foreign_key, context, chunk);
+				VerifyAppendForeignKeyConstraint(bound_foreign_key, context, chunk);
 			}
 			break;
 		}
@@ -1288,7 +1287,7 @@ void DataTable::VerifyDeleteConstraints(optional_ptr<LocalTableStorage> storage,
 		case ConstraintType::FOREIGN_KEY: {
 			auto &bound_foreign_key = constraint->Cast<BoundForeignKeyConstraint>();
 			if (bound_foreign_key.info.IsDeleteConstraint()) {
-				VerifyDeleteForeignKeyConstraint(storage, bound_foreign_key, context, chunk);
+				VerifyDeleteForeignKeyConstraint(bound_foreign_key, context, chunk);
 			}
 			break;
 		}

--- a/test/sql/constraints/foreignkey/fk_19002.test
+++ b/test/sql/constraints/foreignkey/fk_19002.test
@@ -1,0 +1,168 @@
+# name: test/sql/constraints/foreignkey/fk_19002.test
+# description: Deleting a referenced key must be visible to foreign key checks in the same transaction
+# group: [foreignkey]
+
+statement ok
+CREATE TABLE primary_table (id INTEGER PRIMARY KEY)
+
+statement ok
+CREATE TABLE secondary_table (primary_id INTEGER, FOREIGN KEY (primary_id) REFERENCES primary_table(id))
+
+statement ok
+INSERT INTO primary_table VALUES (42)
+
+# Committing the delete and the reference together used to leave a dangling foreign key.
+
+statement ok
+BEGIN
+
+statement ok
+DELETE FROM primary_table WHERE id = 42
+
+statement error
+INSERT INTO secondary_table VALUES (42)
+----
+<REGEX>:Constraint Error.*Violates foreign key constraint.*
+
+statement ok
+ROLLBACK
+
+query II
+SELECT (SELECT count(*) FROM primary_table), (SELECT count(*) FROM secondary_table)
+----
+1	0
+
+# A read in the same transaction before the delete must not change the outcome.
+
+statement ok
+BEGIN
+
+statement ok
+SELECT id FROM primary_table LIMIT 1
+
+statement ok
+DELETE FROM primary_table WHERE id = 42
+
+statement error
+INSERT INTO secondary_table VALUES (42)
+----
+<REGEX>:Constraint Error.*Violates foreign key constraint.*
+
+statement ok
+ROLLBACK
+
+# The referenced key can still be re-inserted within the transaction.
+
+statement ok
+BEGIN
+
+statement ok
+DELETE FROM primary_table WHERE id = 42
+
+statement ok
+INSERT INTO primary_table VALUES (42)
+
+statement ok
+INSERT INTO secondary_table VALUES (42)
+
+statement ok
+COMMIT
+
+query II
+SELECT (SELECT count(*) FROM primary_table), (SELECT count(*) FROM secondary_table)
+----
+1	1
+
+# UUID keys, as in the original report.
+
+statement ok
+CREATE TABLE pk_uuid (id UUID PRIMARY KEY)
+
+statement ok
+CREATE TABLE fk_uuid (pk_id UUID, FOREIGN KEY (pk_id) REFERENCES pk_uuid(id))
+
+statement ok
+INSERT INTO pk_uuid VALUES ('11111111-1111-1111-1111-111111111111')
+
+statement ok
+BEGIN
+
+statement ok
+DELETE FROM pk_uuid WHERE id = '11111111-1111-1111-1111-111111111111'
+
+statement error
+INSERT INTO fk_uuid VALUES ('11111111-1111-1111-1111-111111111111')
+----
+<REGEX>:Constraint Error.*Violates foreign key constraint.*
+
+statement ok
+ROLLBACK
+
+# Self-referencing foreign keys resolve against the same table's deletes.
+
+statement ok
+CREATE TABLE node (id INTEGER PRIMARY KEY, parent INTEGER, FOREIGN KEY (parent) REFERENCES node(id))
+
+statement ok
+INSERT INTO node VALUES (1, NULL)
+
+statement ok
+BEGIN
+
+statement ok
+DELETE FROM node WHERE id = 1
+
+statement error
+INSERT INTO node VALUES (2, 1)
+----
+<REGEX>:Constraint Error.*Violates foreign key constraint.*
+
+statement ok
+ROLLBACK
+
+statement ok
+BEGIN
+
+statement ok
+INSERT INTO node VALUES (3, 1)
+
+statement ok
+COMMIT
+
+query I
+SELECT count(*) FROM node
+----
+2
+
+# Deleting only some of the referenced keys still rejects the missing one.
+
+statement ok
+CREATE TABLE pk_multi (id INTEGER PRIMARY KEY)
+
+statement ok
+CREATE TABLE fk_multi (pk_id INTEGER, FOREIGN KEY (pk_id) REFERENCES pk_multi(id))
+
+statement ok
+INSERT INTO pk_multi VALUES (1), (2), (3)
+
+statement ok
+BEGIN
+
+statement ok
+DELETE FROM pk_multi WHERE id = 2
+
+statement ok
+INSERT INTO fk_multi VALUES (1), (3)
+
+statement error
+INSERT INTO fk_multi VALUES (1), (2)
+----
+<REGEX>:Constraint Error.*Violates foreign key constraint.*
+
+statement ok
+COMMIT
+
+query II
+SELECT (SELECT count(*) FROM pk_multi), (SELECT count(*) FROM fk_multi)
+----
+3	0

--- a/test/sql/constraints/foreignkey/test_fk_transaction.test
+++ b/test/sql/constraints/foreignkey/test_fk_transaction.test
@@ -53,13 +53,32 @@ DELETE FROM pkt WHERE i = 1
 statement ok
 ROLLBACK
 
-# Delete a tuple in the referencing table and then delete that tuple in the main table.
+# Delete a tuple in the main table, then reference it from the referencing table.
 
 statement ok
 BEGIN TRANSACTION
 
 statement ok
 DELETE FROM pkt WHERE i = 1
+
+statement error
+INSERT INTO fkt VALUES (1)
+----
+<REGEX>:Constraint Error.*Violates foreign key constraint.*
+
+statement ok
+ROLLBACK
+
+# Re-inserting the tuple in the main table makes the reference valid again.
+
+statement ok
+BEGIN TRANSACTION
+
+statement ok
+DELETE FROM pkt WHERE i = 1
+
+statement ok
+INSERT INTO pkt VALUES (1)
 
 statement ok
 INSERT INTO fkt VALUES (1)
@@ -108,8 +127,10 @@ BEGIN TRANSACTION
 statement ok
 DELETE FROM pkt WHERE i = 3
 
-statement ok
+statement error
 INSERT INTO fkt VALUES (3)
+----
+<REGEX>:Constraint Error.*Violates foreign key constraint.*
 
 statement ok
 ROLLBACK


### PR DESCRIPTION
Fixes: #19002

`DataTable::VerifyForeignKeyConstraint` passed the `LocalTableStorage` of the referencing table to `TableIndexList::VerifyForeignKey`, even though the index being verified belongs to the referenced table. As a result, the referenced table's delete-ART was not found, so a key deleted earlier in the same transaction was incorrectly considered to still exist.

The fix looks up the local storage from the table owning the index being verified and removes the now-unused `storage` parameter from the FK verification helpers.

Tests: new `test/sql/constraints/foreignkey/fk_19002.test` covering the issue reproducer, read-before-delete, UUID keys, self-referencing foreign keys, multi-row inserts, and delete/re-insert cases. Updated existing transaction tests to expect immediate constraint errors. The relevant constraint/transaction/index/foreignkey/storage/catalog tests pass: 313 test cases, 81226 assertions.

The symmetric case where a referencing row is deleted before deleting the referenced row remains unchanged; this is covered by the existing `proper foreign key + delete ART support` FIXME.