### PR TITLE
Preserve GROUPING bindings in aggregate rewrites

### DIFF
--- a/src/optimizer/aggregate_function_rewriter.cpp
+++ b/src/optimizer/aggregate_function_rewriter.cpp
@@ -377,6 +377,7 @@ private:
 		auto proj_index = optimizer.binder.GenerateTableIndex();
 		const auto group_count = aggr.groups.size();
 		vector<unique_ptr<Expression>> projection_expressions;
+		projection_expressions.reserve(group_count + aggr_count + aggr.grouping_functions.size());
 
 		// Pass group bindings through and register them in the aggregate_map
 		for (idx_t group_idx = 0; group_idx < group_count; group_idx++) {
@@ -409,6 +410,16 @@ private:
 			auto final_result = rule.CreateProjectionExpression(aggr_type, std::move(aggr_ref),
 			                                                    std::move(rewrite_info.additional_expressions));
 			projection_expressions.push_back(std::move(final_result));
+		}
+
+		// Keep GROUPING() results in the output order defined by LogicalAggregate::GetColumnBindings().
+		// Without these mappings, the projection leaves stale grouping-function references in its parents.
+		for (idx_t grouping_idx = 0; grouping_idx < aggr.grouping_functions.size(); grouping_idx++) {
+			ColumnBinding grouping_binding(aggr.groupings_index, ProjectionIndex(grouping_idx));
+			auto projection_idx = ProjectionIndex(group_count + aggr_count + grouping_idx);
+			aggregate_map[grouping_binding] = ColumnBinding(proj_index, projection_idx);
+			projection_expressions.push_back(
+			    make_uniq<BoundColumnRefExpression>(LogicalType::BIGINT, grouping_binding));
 		}
 
 		auto proj = make_uniq<LogicalProjection>(proj_index, std::move(projection_expressions));

--- a/test/issues/general/test_24627.test
+++ b/test/issues/general/test_24627.test
@@ -1,0 +1,60 @@
+# name: test/issues/general/test_24627.test
+# description: Issue 24627 - Preserve GROUPING bindings through aggregate function rewrites
+# group: [general]
+
+statement ok
+CREATE TABLE t(g INTEGER, x INTEGER);
+
+statement ok
+INSERT INTO t VALUES (1, 1), (1, 2);
+
+statement ok
+SET debug_verify_column_bindings = true;
+
+# The ordered-list rewrite inserts a projection for list_sort. GROUPING results must remain visible above it.
+query III
+SELECT GROUPING(g) AS gr, g, list(x ORDER BY x) AS xs
+FROM t
+GROUP BY g
+ORDER BY ALL;
+----
+0	1	[1, 2]
+
+# Preserve GROUPING through the same rewrite when grouping sets are expanded.
+query III
+SELECT GROUPING(g) AS gr, g, list(x ORDER BY x) AS xs
+FROM t
+GROUP BY ROLLUP(g)
+ORDER BY gr, g NULLS FIRST;
+----
+0	1	[1, 2]
+1	NULL	[1, 2]
+
+statement ok
+CREATE TABLE multiple_groups(a INTEGER, b INTEGER, x INTEGER);
+
+statement ok
+INSERT INTO multiple_groups VALUES (1, 10, 2), (1, 10, 1);
+
+# Cover multiple grouping-function bindings and their projection offsets.
+query IIIIII
+SELECT GROUPING(a), GROUPING(b), GROUPING(a, b), a, b, list(x ORDER BY x)
+FROM multiple_groups
+GROUP BY ROLLUP(a, b)
+ORDER BY GROUPING(a, b), a NULLS FIRST, b NULLS FIRST;
+----
+0	0	0	1	10	[1, 2]
+0	1	1	1	NULL	[1, 2]
+1	1	3	NULL	NULL	[1, 2]
+
+# Verify that the fix preserves the ordered-list optimization rather than skipping it.
+statement ok
+PRAGMA explain_output = OPTIMIZED_ONLY;
+
+query II
+EXPLAIN SELECT GROUPING(g), g, list(x ORDER BY x) FROM t GROUP BY g;
+----
+logical_opt	<REGEX>:.*list_sort.*
+
+statement ok
+SET debug_verify_column_bindings = false;


### PR DESCRIPTION
Fixes #24627

### Problem

Combining `GROUPING()` with an ordered list() aggregate can produce an invalid logical plan when aggregate_function_rewriter is enabled.

A minimal example is:

```
CREATE TABLE t(g INTEGER, x INTEGER);
INSERT INTO t VALUES (1, 1), (1, 2);

SELECT GROUPING(g), g, list(x ORDER BY x) FROM t GROUP BY g;
```

Instead of returning the grouping value and the sorted list, physical plan generation fails with a Failed to bind column reference internal error. Disabling aggregate_function_rewriter makes the query succeed.

Although the original reproducer uses `ROLLUP`, a regular `GROUP BY` is sufficient to trigger the problem on the current main branch.

### Root cause

`BaseSelectBinder::BindGroupingFunction` binds every `GROUPING()` call to a separate `BIGINT` column: `ColumnBinding(node.groupings_index, grouping_idx)`.
`LogicalAggregate::ResolveTypes` and `LogicalAggregate::GetColumnBindings` define the aggregate output layout as: `groups | aggregate expressions | grouping functions`. Grouping-function results are therefore a third class of aggregate output. They are neither regular group columns nor aggregate expressions. `ListRewriteRule` does not skip grouped aggregates or aggregates containing grouping functions. It removes the internal `ORDER BY` from an aggregate such as `list(x ORDER BY x)`, and reconstructs the result above the aggregate as: `list_sort(list(x), direction, null_order)`.
The generic aggregate rewrite infrastructure also adds an auxiliary `count(*)` aggregate and inserts a `LogicalProjection` above the `LogicalAggregate` to reconstruct the original aggregate results.

Before this change, that projection only handled `aggr.groups | original aggr.expressions`. It did not: append `aggr.grouping_functions` to `projection_expressions`; or map the old `(groupings_index, grouping_idx)` bindings to the new projection bindings.

The resulting plan was logically equivalent to:

```
LogicalAggregate:
      g | list(x) | count(*) | GROUPING(g)

Inserted LogicalProjection:
      g | list_sort(list(x), direction, null_order)
```

The projection intentionally hides the `auxiliary count(*)`, but it also incorrectly removed the `GROUPING()` result. Expressions above the projection continued to reference that result even though it was no longer part of the projection's output.

During physical plan generation, `ColumnBindingResolver` could only see the bindings exposed by the inserted projection and failed to resolve the grouping-function binding. The exact table and column indexes in the error are dynamically allocated and may also have been remapped by the grouping-sets optimizer, but the missing projection output is the underlying cause.

When `aggregate_function_rewriter` is disabled, this projection is not inserted. `GroupingSetsOptimizer` correctly emits grouping-function values and remaps their bindings, so the query succeeds.

### Fix

The rewrite projection now preserves the complete public output schema defined by `LogicalAggregate::GetColumnBindings`: `groups | original aggregate results | grouping-function results`

For every grouping-function result, the rewrite:

1. creates a `BIGINT` column reference using: `ColumnBinding(aggr.groupings_index, grouping_idx)`
2. appends it after the visible groups and original aggregate results
3. registers the corresponding mapping in `aggregate_map`

The destination offset deliberately uses the original aggregate count rather than the size of `aggr.expressions` after rewriting. Auxiliary `COUNT` aggregates are implementation details and must remain hidden above the reconstruction projection. This fixes the binding invariant without disabling the ordered-list optimization. Optimized plans continue to contain `list_sort`.
