### PR TITLE
Fix partitioned COPY losing rows on __HIVE_DEFAULT_PARTITION__ collision

### DIFF
--- a/src/common/hive_partitioning.cpp
+++ b/src/common/hive_partitioning.cpp
@@ -88,11 +88,13 @@ string HivePartitioning::Escape(const string &input) {
 
 string HivePartitioning::EscapeValue(const string &input) {
 	auto result = Escape(input);
-	if (result != DEFAULT_PARTITION_NAME) {
+	// the comparison is case-insensitive because on a case-insensitive file system a value that differs only in
+	// case still lands in the directory that is reserved for NULL values
+	if (!StringUtil::CIEquals(result, DEFAULT_PARTITION_NAME)) {
 		return result;
 	}
-	// this value escapes to the directory name that is reserved for NULL values - percent-encode the first
-	// character so the value gets its own directory while still unescaping back to the original value
+	// percent-encode the first character so the value gets its own directory while still unescaping back to the
+	// original value
 	static constexpr const char *HEX_DIGIT = "0123456789ABCDEF";
 	const auto first = static_cast<unsigned char>(result[0]);
 	string escaped = "%";

--- a/src/common/hive_partitioning.cpp
+++ b/src/common/hive_partitioning.cpp
@@ -86,12 +86,28 @@ string HivePartitioning::Escape(const string &input) {
 	return StringUtil::URLEncode(input);
 }
 
+string HivePartitioning::EscapeValue(const string &input) {
+	auto result = Escape(input);
+	if (result != DEFAULT_PARTITION_NAME) {
+		return result;
+	}
+	// this value escapes to the directory name that is reserved for NULL values - percent-encode the first
+	// character so the value gets its own directory while still unescaping back to the original value
+	static constexpr const char *HEX_DIGIT = "0123456789ABCDEF";
+	const auto first = static_cast<unsigned char>(result[0]);
+	string escaped = "%";
+	escaped += HEX_DIGIT[first >> 4];
+	escaped += HEX_DIGIT[first & 15];
+	escaped += result.substr(1);
+	return escaped;
+}
+
 string HivePartitioning::Unescape(const string &input) {
 	return StringUtil::URLDecode(input);
 }
 
 bool HivePartitioning::IsNull(const string &input) {
-	return StringUtil::CIEquals(input, "NULL") || input == "__HIVE_DEFAULT_PARTITION__";
+	return StringUtil::CIEquals(input, "NULL") || input == DEFAULT_PARTITION_NAME;
 }
 
 // matches hive partitions in file name. For example:
@@ -132,7 +148,7 @@ std::map<string, string> HivePartitioning::Parse(const string &filename) {
 Value HivePartitioning::GetValue(ClientContext &context, const string &key, const string &str_val,
                                  const LogicalType &type) {
 	// On SQLNULL, DuckDB writes "__HIVE_DEFAULT_PARTITION__", instead of string version "NULL".
-	if (str_val == "__HIVE_DEFAULT_PARTITION__") {
+	if (str_val == DEFAULT_PARTITION_NAME) {
 		return Value(type);
 	}
 	if (type.id() == LogicalTypeId::VARCHAR) {

--- a/src/execution/operator/persistent/physical_copy_to_file.cpp
+++ b/src/execution/operator/persistent/physical_copy_to_file.cpp
@@ -2990,9 +2990,9 @@ PartitionDirectory PartitionFileRequestBuilder::BuildDirectory(string path) cons
 			p_dir += HivePartitioning::Escape(partition_col_name.GetIdentifierName());
 			p_dir += "=";
 			if (partition_value.IsNull()) {
-				p_dir += "__HIVE_DEFAULT_PARTITION__";
+				p_dir += HivePartitioning::DEFAULT_PARTITION_NAME;
 			} else {
-				p_dir += HivePartitioning::Escape(partition_value.ToString());
+				p_dir += HivePartitioning::EscapeValue(partition_value.ToString());
 			}
 			result.path = fs.JoinPath(result.path, p_dir);
 			result.directories.push_back(result.path);

--- a/src/include/duckdb/common/hive_partitioning.hpp
+++ b/src/include/duckdb/common/hive_partitioning.hpp
@@ -25,6 +25,10 @@ struct HivePartitioningFilterInfo {
 
 class HivePartitioning {
 public:
+	//! The directory name that is written for a NULL partition value
+	static constexpr const char *DEFAULT_PARTITION_NAME = "__HIVE_DEFAULT_PARTITION__";
+
+public:
 	//! Parse a filename that follows the hive partitioning scheme
 	DUCKDB_API static std::map<string, string> Parse(const string &filename);
 	//! Prunes a list of filenames based on a set of filters, can be used by TableFunctions in the
@@ -39,6 +43,8 @@ public:
 	                                 const LogicalType &type);
 	//! Escape a hive partition key or value using URL encoding
 	DUCKDB_API static string Escape(const string &input);
+	//! Escape a non-NULL hive partition value, avoiding a collision with the NULL partition directory
+	DUCKDB_API static string EscapeValue(const string &input);
 	//! Unescape a hive partition key or value encoded using URL encoding
 	DUCKDB_API static string Unescape(const string &input);
 	//! Whether the value is a null marker when detecting Hive partition types

--- a/test/sql/copy/parquet/parquet_hive_null.test
+++ b/test/sql/copy/parquet/parquet_hive_null.test
@@ -104,3 +104,52 @@ query I
 select count(*) from glob('{TEST_DIR}/hive-null-write-test/a=__HIVE_DEFAULT_PARTITION__/b=__HIVE_DEFAULT_PARTITION__/*.parquet');
 ----
 1
+
+# Test that a literal '__HIVE_DEFAULT_PARTITION__' value does not collide with the NULL partition directory
+statement ok
+CREATE TABLE test_hive_default_collision AS
+SELECT *
+FROM (VALUES ('__HIVE_DEFAULT_PARTITION__', 1), (NULL, 2), ('ok', 3)) v(p, id);
+
+statement ok
+COPY test_hive_default_collision TO '{TEST_DIR}/hive-default-collision'
+(FORMAT PARQUET, PARTITION_BY (p), OVERWRITE);
+
+query III
+SELECT (p IS NULL)::INTEGER AS is_null, p, id
+FROM parquet_scan('{TEST_DIR}/hive-default-collision/**/*.parquet', hive_partitioning=1)
+ORDER BY id
+----
+0	__HIVE_DEFAULT_PARTITION__	1
+1	NULL	2
+0	ok	3
+
+# the literal value is escaped so that it gets a directory of its own
+query I
+select count(*) from glob('{TEST_DIR}/hive-default-collision/p=%5F_HIVE_DEFAULT_PARTITION__/*.parquet');
+----
+1
+
+query I
+select count(*) from glob('{TEST_DIR}/hive-default-collision/p=__HIVE_DEFAULT_PARTITION__/*.parquet');
+----
+1
+
+# the same collision on a multi-column partition
+statement ok
+CREATE TABLE test_hive_default_collision_multi AS
+SELECT *
+FROM (VALUES ('__HIVE_DEFAULT_PARTITION__', 'x', 1), (NULL, 'x', 2), (NULL, NULL, 3)) v(a, b, id);
+
+statement ok
+COPY test_hive_default_collision_multi TO '{TEST_DIR}/hive-default-collision-multi'
+(FORMAT PARQUET, PARTITION_BY (a, b), OVERWRITE);
+
+query IIII
+SELECT (a IS NULL)::INTEGER AS a_is_null, a, b, id
+FROM parquet_scan('{TEST_DIR}/hive-default-collision-multi/**/*.parquet', hive_partitioning=1)
+ORDER BY id
+----
+0	__HIVE_DEFAULT_PARTITION__	x	1
+1	NULL	x	2
+1	NULL	NULL	3

--- a/test/sql/copy/parquet/parquet_hive_null.test
+++ b/test/sql/copy/parquet/parquet_hive_null.test
@@ -153,3 +153,30 @@ ORDER BY id
 0	__HIVE_DEFAULT_PARTITION__	x	1
 1	NULL	x	2
 1	NULL	NULL	3
+
+# a value that only differs in case still collides on a case-insensitive file system
+statement ok
+COPY (
+    SELECT * FROM (
+        VALUES ('__hive_default_partition__', 1), (NULL, 2)
+    ) v(p, id)
+) TO '{TEST_DIR}/hive-default-collision-case'
+(FORMAT PARQUET, PARTITION_BY (p), OVERWRITE);
+
+query III
+SELECT (p IS NULL)::INTEGER AS is_null, p, id
+FROM read_parquet('{TEST_DIR}/hive-default-collision-case/**/*.parquet', hive_partitioning=true)
+ORDER BY id
+----
+0	__hive_default_partition__	1
+1	NULL	2
+
+query I
+select count(*) from glob('{TEST_DIR}/hive-default-collision-case/p=%5F_hive_default_partition__/*.parquet');
+----
+1
+
+query I
+select count(*) from glob('{TEST_DIR}/hive-default-collision-case/p=__HIVE_DEFAULT_PARTITION__/*.parquet');
+----
+1


### PR DESCRIPTION
Fixes #24308.

A partitioned COPY writes NULL partition values to a directory named __HIVE_DEFAULT_PARTITION__, while non-NULL values are URL-encoded. URL encoding leaves '_' unreserved, so the literal string '__HIVE_DEFAULT_PARTITION__' encoded to itself and shared a directory with the NULL partition. Since the output file index is tracked per partition value, both partitions wrote data_0.parquet into that directory and the second write silently clobbered the first, losing rows.

Escape a non-NULL partition value that would collide with the NULL sentinel by percent-encoding its first character, which still unescapes back to the original value on read.