### PR TITLE
Add multiplicity-aware combine support and fix LIST state combination

### DIFF
--- a/src/function/scalar/system/aggregate_export.cpp
+++ b/src/function/scalar/system/aggregate_export.cpp
@@ -435,6 +435,7 @@ void CombineAggrStateCombine(Vector &source, Vector &target, AggregateInputData 
 	auto &bind_data = aggr_input_data.bind_data->Cast<ExportAggregateBindData>();
 	AggregateInputData combine_input(bind_data.aggr, bind_data.bind_data.get(), aggr_input_data.allocator,
 	                                 aggr_input_data.combine_type);
+	combine_input.combine_multiplicities = aggr_input_data.combine_multiplicities;
 	bind_data.aggr.GetStateCombineCallback()(source, target, combine_input, count);
 }
 

--- a/src/include/duckdb/function/aggregate/list_aggregate.hpp
+++ b/src/include/duckdb/function/aggregate/list_aggregate.hpp
@@ -99,6 +99,22 @@ inline void ListClusterUpdate(Vector inputs[], AggregateInputData &aggr_input_da
 	}
 }
 
+inline void ListAbsorbState(ListAggState &source, ListAggState &target) {
+	if (source.linked_list.total_capacity == 0) {
+		// NULL, no need to append. This can happen with a filtered aggregate.
+		return;
+	}
+	if (target.linked_list.total_capacity == 0) {
+		target.linked_list = source.linked_list;
+		return;
+	}
+
+	// Append the linked list.
+	target.linked_list.last_segment->next = source.linked_list.first_segment;
+	target.linked_list.last_segment = source.linked_list.last_segment;
+	target.linked_list.total_capacity += source.linked_list.total_capacity;
+}
+
 inline void ListAbsorbFunction(Vector &states_vector, Vector &combined, AggregateInputData &aggr_input_data,
                                idx_t count) {
 	D_ASSERT(aggr_input_data.combine_type == AggregateCombineType::ALLOW_DESTRUCTIVE);
@@ -106,23 +122,7 @@ inline void ListAbsorbFunction(Vector &states_vector, Vector &combined, Aggregat
 	auto states = states_vector.Values<ListAggState *>();
 	auto combined_ptr = FlatVector::GetDataMutable<ListAggState *>(combined);
 	for (idx_t i = 0; i < count; i++) {
-		auto &state = *states[i].GetValue();
-		if (state.linked_list.total_capacity == 0) {
-			// NULL, no need to append
-			// this can happen when adding a FILTER to the grouping, e.g.,
-			// LIST(i) FILTER (WHERE i <> 3)
-			continue;
-		}
-
-		if (combined_ptr[i]->linked_list.total_capacity == 0) {
-			combined_ptr[i]->linked_list = state.linked_list;
-			continue;
-		}
-
-		// append the linked list
-		combined_ptr[i]->linked_list.last_segment->next = state.linked_list.first_segment;
-		combined_ptr[i]->linked_list.last_segment = state.linked_list.last_segment;
-		combined_ptr[i]->linked_list.total_capacity += state.linked_list.total_capacity;
+		ListAbsorbState(*states[i].GetValue(), *combined_ptr[i]);
 	}
 }
 
@@ -130,7 +130,8 @@ inline void ListAbsorbFunction(Vector &states_vector, Vector &combined, Aggregat
 template <class OP>
 void ListCombineFunction(Vector &states_vector, Vector &combined, AggregateInputData &aggr_input_data, idx_t count) {
 	//	Can we use destructive combining?
-	if (aggr_input_data.combine_type == AggregateCombineType::ALLOW_DESTRUCTIVE) {
+	if (aggr_input_data.combine_type == AggregateCombineType::ALLOW_DESTRUCTIVE &&
+	    !aggr_input_data.combine_multiplicities) {
 		ListAbsorbFunction(states_vector, combined, aggr_input_data, count);
 		return;
 	}
@@ -141,10 +142,35 @@ void ListCombineFunction(Vector &states_vector, Vector &combined, AggregateInput
 	auto element_type = OP::GetElementType(aggr_input_data);
 	ListSegmentFunctions functions;
 	GetSegmentDataFunctions(functions, element_type);
+	UnifiedVectorFormat multiplicities;
+	const int64_t *multiplicity_data = nullptr;
+	if (aggr_input_data.combine_multiplicities) {
+		aggr_input_data.combine_multiplicities->ToUnifiedFormat(multiplicities);
+		multiplicity_data = UnifiedVectorFormat::GetData<int64_t>(multiplicities);
+	}
 
 	for (idx_t i = 0; i < count; i++) {
 		auto &source = *states[i].GetValue();
 		auto &target = *combined_ptr[i];
+		idx_t multiplicity = 1;
+		if (multiplicity_data) {
+			const auto multiplicity_idx = multiplicities.sel->get_index(i);
+			if (!multiplicities.validity.RowIsValid(multiplicity_idx)) {
+				continue;
+			}
+			const auto signed_multiplicity = multiplicity_data[multiplicity_idx];
+			if (signed_multiplicity < 0) {
+				throw InvalidInputException("combine_aggr multiplicity must be non-negative");
+			}
+			multiplicity = static_cast<idx_t>(signed_multiplicity);
+		}
+		if (multiplicity == 0 || source.linked_list.total_capacity == 0) {
+			continue;
+		}
+		if (multiplicity == 1 && aggr_input_data.combine_type == AggregateCombineType::ALLOW_DESTRUCTIVE) {
+			ListAbsorbState(source, target);
+			continue;
+		}
 
 		const auto entry_count = source.linked_list.total_capacity;
 		Vector input(element_type, entry_count);
@@ -153,8 +179,10 @@ void ListCombineFunction(Vector &states_vector, Vector &combined, AggregateInput
 		RecursiveUnifiedVectorFormat input_data;
 		Vector::RecursiveToUnifiedFormat(input, input_data);
 
-		functions.AppendListEntry(aggr_input_data.allocator, target.linked_list, input_data,
-		                          list_entry_t(0, entry_count));
+		for (idx_t repeat_idx = 0; repeat_idx < multiplicity; repeat_idx++) {
+			functions.AppendListEntry(aggr_input_data.allocator, target.linked_list, input_data,
+			                          list_entry_t(0, entry_count));
+		}
 	}
 }
 

--- a/test/issues/general/test_24806.test
+++ b/test/issues/general/test_24806.test
@@ -1,0 +1,74 @@
+# name: test/issues/general/test_24806.test
+# description: List-backed aggregate states preserve join multiplicity during partial aggregate pushdown
+# group: [general]
+
+# The original issue reproducer
+statement ok
+CREATE TABLE issue_24806(i INTEGER, g INTEGER, d INTEGER, txt INTEGER, chr INTEGER)
+
+statement ok
+INSERT INTO issue_24806 VALUES
+    (1, 1, 1, 1, 0),
+    (1, 1, 1, 1, 0),
+    (42, 1, 2, 3, 9),
+    (42, 1, 1, 2, 2),
+    (NULL, -7, 1, 0, 0),
+    (42, NULL, 3, NULL, 3)
+
+query IR rowsort
+SELECT t1.g, median(t3.i)
+FROM issue_24806 t1
+INNER JOIN issue_24806 t2 ON t1.d = t2.d
+INNER JOIN issue_24806 t3 ON t2.txt = t3.chr
+GROUP BY t1.g;
+----
+-7	1.0
+1	1.0
+
+# A two-table reduction exercises every list-backed aggregate affected by the same bug
+statement ok
+CREATE TABLE issue_24806_multiplicity(k INTEGER, g INTEGER)
+
+statement ok
+INSERT INTO issue_24806_multiplicity VALUES (1, 1), (1, 1), (1, 1), (2, 1), (2, 1)
+
+statement ok
+CREATE TABLE issue_24806_values(k INTEGER, v INTEGER)
+
+statement ok
+INSERT INTO issue_24806_values VALUES (1, 1), (1, 1), (2, 42), (2, 42)
+
+statement ok
+ANALYZE
+
+query IRRRT
+SELECT
+    m.g,
+    median(v.v),
+    quantile_cont(v.v, 0.5),
+    mad(v.v),
+    list_sort(list(v.v))
+FROM issue_24806_multiplicity m
+INNER JOIN issue_24806_values v USING (k)
+GROUP BY m.g;
+----
+1	1.0	1.0	0.0	[1, 1, 1, 1, 1, 1, 42, 42, 42, 42]
+
+statement ok
+SET disabled_optimizers = 'partial_aggregate_pushdown'
+
+query IRRRT
+SELECT
+    m.g,
+    median(v.v),
+    quantile_cont(v.v, 0.5),
+    mad(v.v),
+    list_sort(list(v.v))
+FROM issue_24806_multiplicity m
+INNER JOIN issue_24806_values v USING (k)
+GROUP BY m.g;
+----
+1	1.0	1.0	0.0	[1, 1, 1, 1, 1, 1, 42, 42, 42, 42]
+
+statement ok
+RESET disabled_optimizers

--- a/test/optimizer/partial_aggregate_pushdown.test
+++ b/test/optimizer/partial_aggregate_pushdown.test
@@ -513,6 +513,66 @@ GROUP BY g
 ----
 physical_plan	<REGEX>:.*combine_aggr.*
 
+# LIST-backed aggregate states must honor the other side's row count when double-eager aggregation combines them.
+# Keep the collapse ratio well above the cost threshold so this plan is stable across vector sizes. The two keys have
+# different multiplicities, making incorrect state repetition observable in median, LIST count, and LIST sum.
+statement ok
+CREATE TABLE de_list_multiplicity AS
+SELECT CASE WHEN i < 30 THEN 1 ELSE 2 END::INTEGER AS k, 1::INTEGER AS g
+FROM range(50) _(i)
+
+statement ok
+CREATE TABLE de_list_values AS
+SELECT CASE WHEN i < 20 THEN 1 ELSE 2 END::INTEGER AS k,
+       CASE WHEN i < 20 THEN 1 ELSE 42 END::INTEGER AS v
+FROM range(40) _(i)
+
+statement ok
+ANALYZE
+
+query II
+EXPLAIN
+SELECT m.g, median(v.v)
+FROM de_list_multiplicity m
+INNER JOIN de_list_values v USING (k)
+GROUP BY m.g
+----
+physical_plan	<REGEX>:.*combine_aggr.*
+
+query IRRRII
+SELECT
+    m.g,
+    median(v.v),
+    quantile_cont(v.v, 0.5),
+    mad(v.v),
+    list_count(list(v.v)),
+    list_sum(list(v.v))
+FROM de_list_multiplicity m
+INNER JOIN de_list_values v USING (k)
+GROUP BY m.g
+----
+1	1.0	1.0	0.0	1000	17400
+
+statement ok
+SET disabled_optimizers = 'partial_aggregate_pushdown'
+
+query IRRRII
+SELECT
+    m.g,
+    median(v.v),
+    quantile_cont(v.v, 0.5),
+    mad(v.v),
+    list_count(list(v.v)),
+    list_sum(list(v.v))
+FROM de_list_multiplicity m
+INNER JOIN de_list_values v USING (k)
+GROUP BY m.g
+----
+1	1.0	1.0	0.0	1000	17400
+
+statement ok
+RESET disabled_optimizers
+
 # Modest per-key collapse does not amortize two aggregate-state tables, their join, and the final combine.
 statement ok
 CREATE TABLE de_modest_dim AS SELECT i AS k, (i % 1000) AS g FROM range(5000) _(i)

--- a/test/sql/aggregate/aggregate_state_export/test_combine_aggr.test
+++ b/test/sql/aggregate/aggregate_state_export/test_combine_aggr.test
@@ -135,6 +135,48 @@ FROM states;
 ----
 18	2
 
+# List-backed aggregate states honor per-state multiplicities
+query TRRR
+WITH states AS (
+    SELECT
+        k,
+        list(v) EXPORT_STATE AS list_s,
+        median(v) EXPORT_STATE AS median_s,
+        quantile_cont(v, 0.5) EXPORT_STATE AS quantile_s,
+        mad(v) EXPORT_STATE AS mad_s
+    FROM (VALUES (1, 1), (1, 1), (2, 42), (2, 42)) t(k, v)
+    GROUP BY k
+)
+SELECT
+    list_sort(finalize(combine_aggr(list_s, CASE k WHEN 1 THEN 3 ELSE 2 END))),
+    finalize(combine_aggr(median_s, CASE k WHEN 1 THEN 3 ELSE 2 END)),
+    finalize(combine_aggr(quantile_s, CASE k WHEN 1 THEN 3 ELSE 2 END)),
+    finalize(combine_aggr(mad_s, CASE k WHEN 1 THEN 3 ELSE 2 END))
+FROM states;
+----
+[1, 1, 1, 1, 1, 1, 42, 42, 42, 42]	1.0	1.0	0.0
+
+# Zero and NULL multiplicities are also no-ops for list-backed states
+query II
+WITH states AS (
+    SELECT list(v) EXPORT_STATE AS s
+    FROM (VALUES (1), (2)) t(v)
+)
+SELECT
+    (finalize(combine_aggr(s, 0)) IS NULL)::INTEGER,
+    (finalize(combine_aggr(s, NULL::BIGINT)) IS NULL)::INTEGER
+FROM states;
+----
+1	1
+
+statement error
+WITH states AS (
+    SELECT list(v) EXPORT_STATE AS s FROM (VALUES (1), (2)) t(v)
+)
+SELECT finalize(combine_aggr(s, -1)) FROM states;
+----
+<REGEX>:.*combine_aggr multiplicity must be non-negative.*
+
 statement error
 WITH states AS (
     SELECT sum(v) EXPORT_STATE AS s FROM (VALUES (1), (2)) t(v)


### PR DESCRIPTION
Fix #24806 

### Problem

`PartialAggregatePushdown::TryDoubleEagerPushdown` rewrites aggregates over joins into partial aggregate states. It exports a state from one side of the join, counts matching rows on the other side, and then calls `combine_aggr(state, multiplicity)`.

This works for aggregates whose combine implementation honors the multiplicity. However, list-backed aggregates such as `LIST`, `MEDIAN`, `QUANTILE_CONT`, and `MAD` used a custom `ListCombineFunction` that appended each state only once and ignored the multiplicity.

As a result, join duplicates were lost. For example, a joined multiset containing six 1s and four 42s was effectively reduced to [1, 1, 42, 42], producing a median of `21.5` instead of `1.0`.

### Fix

The commit introduces an explicit multiplicity-aware state-combine capability:

- Aggregates must explicitly provide a multiplicity-aware combine callback before double-eager partial aggregate pushdown can use them.
- `combine_aggr(state, multiplicity)` dispatches to this callback and rejects aggregates that do not support multiplicities.
- `ListCombineFunction` now correctly handles multiplicities:
      - `NULL` and zero are no-ops.
      - Negative values raise an error.
      - A multiplicity of one can use the existing destructive merge.
      - Larger multiplicities copy the list state the required number of times.

- Existing executor-backed and list-backed aggregates are registered with the new capability.