### PR TITLE
Fix Parquet interval millisecond overflow

### DIFF
--- a/extension/parquet/include/parquet_interval.hpp
+++ b/extension/parquet/include/parquet_interval.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "duckdb/common/helper.hpp"
+#include "duckdb/common/numeric_utils.hpp"
 #include "duckdb/common/types/interval.hpp"
 #include "zstd/common/xxhash.hpp"
 
@@ -21,8 +22,8 @@ struct ParquetIntervalUtils {
 		const auto days = int64_t(interval.days) + interval.micros / Interval::MICROS_PER_DAY;
 		const auto micros = interval.micros % Interval::MICROS_PER_DAY;
 		Store<uint32_t>(static_cast<uint32_t>(interval.months), target);
-		Store<uint32_t>(static_cast<uint32_t>(days), target + sizeof(uint32_t));
-		Store<uint32_t>(static_cast<uint32_t>(micros / Interval::MICROS_PER_MSEC), target + sizeof(uint32_t) * 2);
+		Store<uint32_t>(NumericCast<uint32_t>(days), target + sizeof(uint32_t));
+		Store<uint32_t>(NumericCast<uint32_t>(micros / Interval::MICROS_PER_MSEC), target + sizeof(uint32_t) * 2);
 	}
 
 	static uint64_t HashNormalized(const interval_t &interval) {

--- a/extension/parquet/include/parquet_interval.hpp
+++ b/extension/parquet/include/parquet_interval.hpp
@@ -18,10 +18,11 @@ struct ParquetIntervalUtils {
 	static constexpr const idx_t PARQUET_INTERVAL_SIZE = 12;
 
 	static void Encode(const interval_t &interval, data_ptr_t target) {
+		const auto days = int64_t(interval.days) + interval.micros / Interval::MICROS_PER_DAY;
+		const auto micros = interval.micros % Interval::MICROS_PER_DAY;
 		Store<uint32_t>(static_cast<uint32_t>(interval.months), target);
-		Store<uint32_t>(static_cast<uint32_t>(interval.days), target + sizeof(uint32_t));
-		Store<uint32_t>(static_cast<uint32_t>(interval.micros / Interval::MICROS_PER_MSEC),
-		                target + sizeof(uint32_t) * 2);
+		Store<uint32_t>(static_cast<uint32_t>(days), target + sizeof(uint32_t));
+		Store<uint32_t>(static_cast<uint32_t>(micros / Interval::MICROS_PER_MSEC), target + sizeof(uint32_t) * 2);
 	}
 
 	static uint64_t HashNormalized(const interval_t &interval) {

--- a/test/sql/copy/parquet/writer/parquet_write_interval.test
+++ b/test/sql/copy/parquet/writer/parquet_write_interval.test
@@ -34,3 +34,18 @@ statement error
 COPY (SELECT -interval '1 day') TO '{TEST_DIR}/intervals.parquet'
 ----
 <REGEX>:.*IO Error.*do not support negative intervals.*
+
+# Store complete days from a large microseconds component in Parquet's days field.
+statement ok
+COPY (SELECT INTERVAL '580063 hours 44 minutes 54 seconds' AS i) TO '{TEST_DIR}/large_interval.parquet'
+
+query IIIIII
+SELECT i = INTERVAL '580063 hours 44 minutes 54 seconds',
+       datepart('month', i),
+       datepart('day', i),
+       datepart('hour', i),
+       datepart('minute', i),
+       datepart('second', i)
+FROM '{TEST_DIR}/large_interval.parquet'
+----
+true	0	24169	7	44	54


### PR DESCRIPTION
Fixes: #24810

Fix Parquet `INTERVAL` corruption by carrying complete days from the microseconds component before storing the remaining milliseconds as `uint32_t`.