### PR TITLE
Reset default database after detachment

### DIFF
--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -345,6 +345,9 @@ shared_ptr<AttachedDatabase> DatabaseManager::DetachInternal(const Identifier &n
 		}
 		attached_db = std::move(entry->second);
 		databases.erase(entry);
+		if (name == default_database) {
+			default_database = databases.empty() ? Identifier() : databases.begin()->first;
+		}
 	}
 	if (attached_db && attached_db->GetCatalog().Supports(RemoteCapability::IS_REMOTE)) {
 		--remote_catalog_count;

--- a/test/sql/attach/detach_manager_default_database.test
+++ b/test/sql/attach/detach_manager_default_database.test
@@ -1,0 +1,22 @@
+# name: test/sql/attach/detach_manager_default_database.test
+# description: Test detaching the database manager's default database
+# group: [attach]
+
+require skip_reload
+
+require noforcestorage
+
+statement ok con1
+ATTACH ':memory:' AS other;
+
+statement ok con1
+USE other;
+
+statement ok con1
+DETACH memory;
+
+# Connections without an explicit search path should use a remaining database
+query T con2
+SELECT database_name FROM duckdb_databases() WHERE database_name = 'other';
+----
+other

--- a/test/sql/attach/detach_manager_default_database.test
+++ b/test/sql/attach/detach_manager_default_database.test
@@ -2,21 +2,22 @@
 # description: Test detaching the database manager's default database
 # group: [attach]
 
-require skip_reload
-
 require noforcestorage
 
-statement ok con1
+statement ok
 ATTACH ':memory:' AS other;
 
-statement ok con1
+statement ok
 USE other;
 
-statement ok con1
+statement ok
 DETACH memory;
 
-# Connections without an explicit search path should use a remaining database
-query T con2
+statement ok
+RESET search_path;
+
+# An unset search path should use a remaining database
+query T
 SELECT database_name FROM duckdb_databases() WHERE database_name = 'other';
 ----
 other


### PR DESCRIPTION
Closes https://github.com/duckdb/duckdb/issues/24783

In the current impl, default database becomes dangling reference after its detachment; this PR resets default if there're still valid databases.