### PR TITLE
Publish linked extensions on the config, so an extension can load them too

### DIFF
--- a/extension/CMakeLists.txt
+++ b/extension/CMakeLists.txt
@@ -44,7 +44,7 @@ configure_file(
 
 # generated_extension_loader.hpp
 set(EXT_LOADER_NAME_LIST "")
-set(EXT_LOADER_BODY "")
+set(EXT_REGISTER_BODY "")
 set(EXT_CAPI_DECLARATIONS "")
 foreach(EXT_NAME IN LISTS STATICALLY_LINKED_EXTENSIONS)
   string(TOUPPER ${EXT_NAME} EXT_NAME_UPPERCASE)
@@ -69,20 +69,18 @@ foreach(EXT_NAME IN LISTS STATICALLY_LINKED_EXTENSIONS)
       set(EXT_CAPI_DECLARATIONS
           "${EXT_CAPI_DECLARATIONS}extern \"C\" bool ${EXT_NAME}_init_c_api(duckdb_extension_info, duckdb_extension_access *);\n"
       )
-      set(EXT_LOADER_BODY
-          "${EXT_LOADER_BODY}\
-    if (extension==\"${EXT_NAME}\") {
+      set(EXT_REGISTER_BODY
+          "${EXT_REGISTER_BODY}\
+    config.linked_extensions.push_back({\"${EXT_NAME}\", [](DuckDB &db) {
         db.LoadStaticCAPIExtension(\"${EXT_NAME}\", ${EXT_NAME}_init_c_api);
-        return ExtensionLoadResult::LOADED_EXTENSION;
-    }
+    }});
 ")
     else()
-      set(EXT_LOADER_BODY
-          "${EXT_LOADER_BODY}\
-    if (extension==\"${EXT_NAME}\") {
+      set(EXT_REGISTER_BODY
+          "${EXT_REGISTER_BODY}\
+    config.linked_extensions.push_back({\"${EXT_NAME}\", [](DuckDB &db) {
         db.LoadStaticExtension<${EXT_NAME_CAMELCASE}Extension>();
-        return ExtensionLoadResult::LOADED_EXTENSION;
-    }
+    }});
 ")
     endif()
   endif()

--- a/extension/generated_extension_loader.cpp.in
+++ b/extension/generated_extension_loader.cpp.in
@@ -1,25 +1,22 @@
 #include "duckdb/main/extension/generated_extension_loader.hpp"
 #include "duckdb/main/extension_helper.hpp"
+#include "duckdb/main/config.hpp"
+#include "duckdb/main/database.hpp"
 
 ${EXT_CAPI_DECLARATIONS}
 namespace duckdb {
 
-//! Looks through the CMake-generated list of extensions that are linked into DuckDB currently to try load <extension>
-ExtensionLoadResult ExtensionHelper::LoadExtension(DuckDB &db, const std::string &extension) {
-${EXT_LOADER_BODY}
-    return ExtensionLoadResult::NOT_LOADED;
+//! Publishes the CMake-generated list of extensions linked into this binary onto the config, so that
+//! ExtensionHelper::LoadExtension can find them - including when it is called from code carrying its
+//! own copy of DuckDB, which links no generated loader of its own.
+void ExtensionHelper::RegisterLinkedExtensions(DBConfig &config) {
+${EXT_REGISTER_BODY}
 }
 
 vector<string> LinkedExtensions(){
     vector<string> VEC = {${EXT_NAME_VECTOR_INITIALIZER}
     };
     return VEC;
-}
-
-void ExtensionHelper::LoadAllExtensions(DuckDB &db) {
-    for (auto& ext_name : LinkedExtensions()) {
-        LoadExtension(db, ext_name);
-    }
 }
 
 vector<string> ExtensionHelper::LoadedExtensionTestPaths(){

--- a/extension/loader/dummy_static_extension_loader.cpp
+++ b/extension/loader/dummy_static_extension_loader.cpp
@@ -1,15 +1,16 @@
+#include "duckdb/main/config.hpp"
 #include "duckdb/main/extension_helper.hpp"
 
 // This is a dummy loader to produce a workable duckdb library without linking any extensions.
 // Link this to libduckdb_static.a to get a working system.
+//
+// Note that it no longer stubs out LoadExtension: that lives in core and reads the registry on the
+// config, so a binary (or an extension) that links this can still load whatever it was handed.
 
 namespace duckdb {
-ExtensionLoadResult ExtensionHelper::LoadExtension(DuckDB &db, const string &extension) {
-	return ExtensionLoadResult::NOT_LOADED;
-}
 
-void ExtensionHelper::LoadAllExtensions(DuckDB &db) {
-	// nop
+void ExtensionHelper::RegisterLinkedExtensions(DBConfig &config) {
+	// nothing is linked into this binary
 }
 
 vector<string> ExtensionHelper::LoadedExtensionTestPaths() {

--- a/scripts/package_build.py
+++ b/scripts/package_build.py
@@ -332,7 +332,7 @@ def build_package(
     # include the main extension helper
     include_files += [os.path.join('src', 'include', 'duckdb', 'main', 'extension_helper.hpp')]
     # include the separate extensions
-    ext_loader_body = ''
+    ext_register_body = ''
     ext_loader_defines = ''
     ext_headers = ''
     ext_name_vector_initializer = ''
@@ -356,23 +356,21 @@ def build_package(
                 f'extern "C" bool {ext}_init_c_api(duckdb_extension_info, duckdb_extension_access *);\n'
                 "#endif\n"
             )
-            ext_loader_body += (
+            ext_register_body += (
                 f"#if {ext_linked_define}\n"
-                f"    if (extension==\"{ext}\") {{\n"
+                f"    config.linked_extensions.push_back({{\"{ext}\", [](DuckDB &db) {{\n"
                 f"        db.LoadStaticCAPIExtension(\"{ext}\", {ext}_init_c_api);\n"
-                "        return ExtensionLoadResult::LOADED_EXTENSION;\n"
-                "    }\n"
+                "    }});\n"
                 "#endif\n"
             )
         else:
             ext_headers += f'#if {ext_linked_define}\n#include "{ext}_extension.hpp"\n#endif\n'
             ext_name_camelcase = ext.replace('_', ' ').title().replace(' ', '')
-            ext_loader_body += (
+            ext_register_body += (
                 f"#if {ext_linked_define}\n"
-                f"    if (extension==\"{ext}\") {{\n"
+                f"    config.linked_extensions.push_back({{\"{ext}\", [](DuckDB &db) {{\n"
                 f"        db.LoadStaticExtension<{ext_name_camelcase}Extension>();\n"
-                "        return ExtensionLoadResult::LOADED_EXTENSION;\n"
-                "    }\n"
+                "    }});\n"
                 "#endif\n"
             )
 
@@ -380,7 +378,7 @@ def build_package(
 
     loader_code = open(os.path.join('extension', 'generated_extension_loader.cpp.in'), 'rb').read().decode('utf8')
     loader_code = (
-        loader_code.replace('${EXT_LOADER_BODY}', ext_loader_body)
+        loader_code.replace('${EXT_REGISTER_BODY}', ext_register_body)
         .replace('${EXT_CAPI_DECLARATIONS}', ext_capi_declarations)
         .replace('${EXT_NAME_VECTOR_INITIALIZER}', ext_name_vector_initializer)
         .replace('${EXT_TEST_PATH_INITIALIZER}', '')

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -49,6 +49,13 @@ class BufferPool;
 class CastFunctionSet;
 class CollationBinding;
 class ClientContext;
+class DuckDB;
+
+//! An extension linked into the binary, and how to load it into a database.
+struct LinkedExtension {
+	string name;
+	std::function<void(DuckDB &)> load;
+};
 class ErrorManager;
 class CompressionFunction;
 class TableFunctionRef;
@@ -266,6 +273,14 @@ public:
 	DUCKDB_API bool HasArrowExtension(const LogicalType &type) const;
 	DUCKDB_API bool HasArrowExtension(ArrowExtensionMetadata info) const;
 	DUCKDB_API void RegisterArrowExtension(const ArrowTypeExtension &extension) const;
+
+	//! Extensions compiled into the binary that produced this config, published as callables rather
+	//! than as generated code. Code carrying its own copy of DuckDB - a statically built extension -
+	//! cannot see the generated loader, but it can read this; and copying it into a child config
+	//! hands a database the same capability set as the one that created it.
+	//! A vector, not a map: extensions load in registration order, and that order has to be stable
+	//! across runs and platforms.
+	vector<LinkedExtension> linked_extensions;
 
 	bool operator==(const DBConfig &other);
 	bool operator!=(const DBConfig &other);

--- a/src/include/duckdb/main/extension_helper.hpp
+++ b/src/include/duckdb/main/extension_helper.hpp
@@ -98,6 +98,9 @@ public:
 	static void LoadAllExtensions(DuckDB &db);
 	static vector<string> LoadedExtensionTestPaths();
 	static ExtensionLoadResult LoadExtension(DuckDB &db, const std::string &extension);
+	//! Publishes the extensions linked into this binary onto the config. Generated at build time;
+	//! a build that links none (or an extension carrying its own DuckDB) registers nothing.
+	static void RegisterLinkedExtensions(DBConfig &config);
 
 	//! Install an extension
 	static unique_ptr<ExtensionInstallInfo> InstallExtension(ClientContext &context, const string &extension,

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -302,6 +302,8 @@ void DatabaseInstance::Initialize(const char *database_path, DBConfig *user_conf
 	}
 
 	Configure(*config_ptr, database_path);
+	// publish what this binary links, unless the config already carries a set handed to us
+	ExtensionHelper::RegisterLinkedExtensions(config);
 
 	create_api_v1 = CreateAPIv1Wrapper;
 
@@ -477,6 +479,9 @@ Allocator &Allocator::Get(AttachedDatabase &db) {
 void DatabaseInstance::Configure(DBConfig &new_config, const char *database_path) {
 	config.options = new_config.options;
 	config.user_settings = new_config.user_settings;
+	// carry over a capability set handed to us, so a database created by code with its own copy of
+	// DuckDB can be given the extensions the binary that created it links
+	config.linked_extensions = new_config.linked_extensions;
 
 	if (Settings::Get<DuckDBAPISetting>(*this).empty()) {
 		config.SetOptionByName("duckdb_api", "cpp");

--- a/src/main/extension/extension_helper.cpp
+++ b/src/main/extension/extension_helper.cpp
@@ -90,6 +90,29 @@
 
 namespace duckdb {
 
+//! Loads an extension that was linked into the binary, via the registry the config carries. This is
+//! deliberately not generated code: an extension with its own copy of DuckDB links no generated
+//! loader, so a compile-time list would be invisible to it, while the config is data it can read.
+ExtensionLoadResult ExtensionHelper::LoadExtension(DuckDB &db, const std::string &extension) {
+	auto &config = DBConfig::GetConfig(*db.instance);
+	for (auto &linked : config.linked_extensions) {
+		if (StringUtil::CIEquals(linked.name, extension)) {
+			linked.load(db);
+			return ExtensionLoadResult::LOADED_EXTENSION;
+		}
+	}
+	return ExtensionLoadResult::NOT_LOADED;
+}
+
+void ExtensionHelper::LoadAllExtensions(DuckDB &db) {
+	// registration order, so a binary loads its extensions the same way on every run
+	auto &config = DBConfig::GetConfig(*db.instance);
+	auto linked = config.linked_extensions;
+	for (auto &entry : linked) {
+		entry.load(db);
+	}
+}
+
 //===--------------------------------------------------------------------===//
 // Default Extensions
 //===--------------------------------------------------------------------===//


### PR DESCRIPTION
Basically: currently LoadExtension would encode state of compile units.

Currently, let's say you build core + parquet, json and core_functions linked in + icu as loadable extension (but linking in static duckdb)

core, parquet, json and core_functions would agree in the fact 3 functions are already loaded.
icu would be aware only of himself.

This is problematic since depending on code-path that call to `LoadExtensions` takes different results will ensure. This is not great, and worked around in a couple of places.

Solution: once extensions are linked in, they will respond with the actual set of statically loaded extensions from DatabaseInstance, not the set they have backed-in at compile time.

---

ExtensionHelper::LoadExtension was generated code: CMake expanded an if-chain naming every statically linked extension, and a build linking none got a stub returning `NOT_LOADED`. That makes the capability set a property of one binary's link line, invisible to anyone holding a different copy of DuckDB - so any extension calling LoadExtension silently got `NOT_LOADED` for extensions the host had built in.

Publish the set as data instead. DBConfig carries a vector of {name, loader}, the generated code registers into it rather than defining a lookup, and LoadExtension becomes ordinary core code doing the lookup - one implementation shared by a binary that links extensions and one that links none. The dummy loader no longer stubs LoadExtension out; it only reports that it registers nothing, so a binary linking it can still load whatever it was handed.

DatabaseInstance::Configure carries the set over from a caller-supplied config, which is what lets a database created by an extension inherit the extensions of the binary that created it.

A vector rather than a map: extensions load in registration order, which is the order they are listed in the build config, and that has to stay stable across runs and platforms.