### PR TITLE
Fix GROUP BY ALL to preserve collation semantics when grouping collated expressions.

### DIFF
--- a/src/planner/binder/query_node/bind_select_node.cpp
+++ b/src/planner/binder/query_node/bind_select_node.cpp
@@ -38,6 +38,18 @@
 
 namespace duckdb {
 
+static ProjectionIndex CreateCollatedGroupAggregate(Binder &binder, BoundSelectNode &result,
+                                                    unique_ptr<Expression> uncollated_expr) {
+	auto first_fun = FirstFunctionGetter::GetFunction(uncollated_expr->GetReturnType());
+	vector<unique_ptr<Expression>> first_children;
+	first_children.push_back(std::move(uncollated_expr));
+
+	FunctionBinder function_binder(binder);
+	auto function = function_binder.BindAggregateFunction(first_fun, std::move(first_children));
+	function->SetAlias("__collated_group");
+	return ColumnBinding::PushExpression(result.aggregates, std::move(function));
+}
+
 unique_ptr<Expression> Binder::BindOrderExpression(OrderBinder &order_binder, unique_ptr<ParsedExpression> expr) {
 	// we treat the distinct list as an ORDER BY
 	auto bound_expr = order_binder.Bind(std::move(expr));
@@ -575,16 +587,7 @@ BoundStatement Binder::BindSelectNode(SelectNode &statement, BoundStatement from
 			if (!contains_subquery && requires_collation) {
 				// if there is a collation on a group x, we should group by the collated expr,
 				// but also push a first(x) aggregate in case x is selected (uncollated)
-
-				auto first_fun = FirstFunctionGetter::GetFunction(uncollated_expr->GetReturnType());
-				vector<unique_ptr<Expression>> first_children;
-				first_children.push_back(std::move(uncollated_expr));
-
-				FunctionBinder function_binder(*this);
-				auto function = function_binder.BindAggregateFunction(first_fun, std::move(first_children));
-				function->SetAlias("__collated_group");
-
-				auto collated_idx = ColumnBinding::PushExpression(result.aggregates, std::move(function));
+				auto collated_idx = CreateCollatedGroupAggregate(*this, result, std::move(uncollated_expr));
 				bind_state.collated_groups[ProjectionIndex(i)] = collated_idx;
 			}
 			result.groups.group_expressions.push_back(std::move(bound_expr));
@@ -697,11 +700,17 @@ BoundStatement Binder::BindSelectNode(SelectNode &statement, BoundStatement from
 	// push the GROUP BY ALL expressions into the group set
 	for (auto &group_by_all_index : group_by_all_indexes) {
 		auto &expr = result.select_list[group_by_all_index];
-		auto &return_type = expr->GetReturnType();
+		auto return_type = expr->GetReturnType();
+		auto uncollated_expr = expr->HasSubquery() ? nullptr : expr->Copy();
+		bool requires_collation = ExpressionBinder::PushCollation(context, expr, return_type);
 		auto group_proj_idx = ColumnBinding::PushExpression(result.groups.group_expressions, std::move(expr));
-		auto group_ref =
-		    make_uniq<BoundColumnRefExpression>(return_type, ColumnBinding(result.group_index, group_proj_idx));
-		expr = std::move(group_ref);
+		if (uncollated_expr && requires_collation) {
+			auto collated_idx = CreateCollatedGroupAggregate(*this, result, std::move(uncollated_expr));
+			expr =
+			    make_uniq<BoundColumnRefExpression>(return_type, ColumnBinding(result.aggregate_index, collated_idx));
+		} else {
+			expr = make_uniq<BoundColumnRefExpression>(return_type, ColumnBinding(result.group_index, group_proj_idx));
+		}
 	}
 	set<ProjectionIndex> group_by_all_indexes_set;
 	if (!group_by_all_indexes.empty()) {

--- a/test/issues/general/test_24795.test
+++ b/test/issues/general/test_24795.test
@@ -1,0 +1,47 @@
+# name: test/issues/general/test_24795.test
+# description: GROUP BY ALL preserves collation semantics
+# group: [general]
+
+statement ok
+CREATE TABLE collated_strings(c0 VARCHAR COLLATE NOCASE)
+
+statement ok
+INSERT INTO collated_strings VALUES ('A'), ('a'), ('b')
+
+query TI rowsort
+SELECT lower(c0), n
+FROM (SELECT c0, count(*) AS n FROM collated_strings GROUP BY ALL)
+----
+a	2
+b	1
+
+statement ok
+CREATE TABLE plain_strings(c0 VARCHAR)
+
+statement ok
+INSERT INTO plain_strings VALUES ('A'), ('a'), ('b')
+
+statement ok
+SET default_collation = 'nocase'
+
+query TI rowsort
+SELECT lower(c0), n
+FROM (SELECT c0, count(*) AS n FROM plain_strings GROUP BY ALL)
+----
+a	2
+b	1
+
+statement ok
+CREATE TABLE collated_lists(c0 VARCHAR[])
+
+statement ok
+INSERT INTO collated_lists VALUES (['A']), (['a']), (['b'])
+
+query II
+SELECT count(*), max(n)
+FROM (SELECT c0, count(*) AS n FROM collated_lists GROUP BY ALL)
+----
+2	2
+
+statement ok
+RESET default_collation


### PR DESCRIPTION
Fix #24795

### Problem
During explicit `GROUP BY` binding, DuckDB applies `ExpressionBinder::PushCollation` to each grouping expression and creates a hidden representative aggregate when collation changes the actual grouping key. However, `GROUP BY ALL` expands its grouping expressions later, after the `SELECT` list has already been bound, and previously moved those expressions directly into the group list without applying the same collation-aware binding process. As a result, values that compare as equal under the configured collation, such as `A` and `a` under `NOCASE`, could be placed into separate groups. The problem affected column-level collations, the session default collation, and nested collated types such as `VARCHAR[]`. Although the incorrect query could select a different physical aggregation operator, the divergence originated in the binder and remained reproducible with the optimizer completely disabled.

### Fix 
The fix applies the existing generic `ExpressionBinder::PushCollation` transformation when deferred `GROUP BY ALL` expressions are added to the group list. Before applying the transformation, it preserves a copy of the original expression because collation lowering may replace the expression tree. When lowering is required, the binder creates the same hidden `first(original_expression)` representative aggregate already used by explicit `GROUP BY`; the aggregation groups by the normalized collation key, while the visible SELECT expression references the representative aggregate. The representative-aggregate construction is extracted into a small helper shared by both grouping paths, keeping the correction localized to the select-node binder without adding special handling to optimizers or physical aggregation operators. Regression tests cover column-level `NOCASE`, session default collation, and nested `VARCHAR[]` collation.