### PR TITLE
Do not assert which of three equal intervals becomes the group key

### DIFF
--- a/test/sql/collate/test_collate_null_constant.test
+++ b/test/sql/collate/test_collate_null_constant.test
@@ -133,7 +133,9 @@ SELECT AGE(TIMESTAMP '2014-04-25', TIMESTAMP '2014-04-17') GROUP BY AGE(TIMESTAM
 ----
 8 days
 
-query II
-SELECT i, count(*) FROM (VALUES (INTERVAL '30' DAY), (INTERVAL '1' MONTH), (INTERVAL '720' HOUR)) t(i) GROUP BY i;
+# these three intervals compare equal, so they collapse into a single group - which of the
+# three representations ends up as the group key is not defined, so we only count the group
+query I
+SELECT count(*) FROM (VALUES (INTERVAL '30' DAY), (INTERVAL '1' MONTH), (INTERVAL '720' HOUR)) t(i) GROUP BY i;
 ----
-30 days	3
+3


### PR DESCRIPTION
`test/sql/collate/test_collate_null_constant.test` is flaky under `STANDARD_VECTOR_SIZE=2`:

```
error: FAIL test/sql/collate/test_collate_null_constant.test
  > 136  query II
    137  SELECT i, count(*) FROM (VALUES (INTERVAL '30' DAY), (INTERVAL '1' MONTH), (INTERVAL '720' HOUR)) t(i) GROUP BY i;
    138  ----
    139  30 days 3

Mismatch on row 1, column i(index 1)
720:00:00 <> 30 days
```

The three intervals all compare equal, so they collapse into a single group and the count is
always `3`. Which of the three representations survives as the group key depends on the order
the values reach the hash table, and at vector size 2 they are spread over separate chunks, so
it flips between `30 days` and `720:00:00` from run to run.

The case is titled "non-NULL constants of a collated type still group by the collated value", so
the group *count* is the point — had the values not grouped together the query would return three
rows of `1`. This asserts that and drops the undefined key.

Measured on the same `STANDARD_VECTOR_SIZE=2` build, 20 runs each:

| | passed |
| --- | --- |
| before | 5 / 20 |
| after | 20 / 20 |

Noticed via a `Vector Sizes` failure on an unrelated PR (#24752).
