### PR TITLE
Allow deserializing a parquet scan whose files were all pruned away

### DIFF
--- a/extension/parquet/parquet_multi_file_info.cpp
+++ b/extension/parquet/parquet_multi_file_info.cpp
@@ -317,7 +317,9 @@ static unique_ptr<FunctionData> ParquetScanDeserialize(Deserializer &deserialize
 		file_path.emplace_back(path);
 	}
 	FileGlobInput input(FileGlobOptions::FALLBACK_GLOB, "parquet");
-	input.allow_empty = serialization.file_options.allow_empty;
+	// we are restoring an already bound file list rather than globbing user input - it is legitimately empty
+	// when filter pushdown pruned every file away, and rejecting that makes the plan impossible to deserialize
+	input.allow_empty = true;
 
 	auto multi_file_reader = MultiFileReader::Create(function);
 	auto file_list = multi_file_reader->CreateFileList(context, Value::LIST(LogicalType::VARCHAR, file_path), input);

--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -124,6 +124,15 @@ public:
 			return std::move(result);
 		}
 
+		if (result->file_list->IsEmpty() && !return_types.empty()) {
+			// restoring a serialized plan whose files were all pruned away by filter pushdown - there is no file
+			// left to bind the readers on, but the schema is already known so we can use it as-is
+			result->types = return_types;
+			result->names = names;
+			result->columns = MultiFileColumnDefinition::ColumnsFromNamesAndTypes(result->names, result->types);
+			return std::move(result);
+		}
+
 		// now bind the readers
 		// there are two ways of binding the readers
 		// (1) MultiFileReader::Bind -> custom bind, used only for certain lakehouse extensions

--- a/test/sql/copy/parquet/parquet_hive_override_stats.test
+++ b/test/sql/copy/parquet/parquet_hive_override_stats.test
@@ -61,6 +61,12 @@ SELECT count(*) FROM read_parquet('{TEST_DIR}/hive_mismatch/part=7/disagrees.par
 ----
 1
 
+# filtering on the value stored in the file prunes the only file away, leaving an empty file list
+query I
+SELECT count(*) FROM read_parquet('{TEST_DIR}/hive_mismatch/part=7/disagrees.parquet') WHERE part = 999
+----
+0
+
 # the value stored in the file is only visible with hive partitioning turned off
 query II
 SELECT typeof(part), part

--- a/test/sql/copy/parquet/parquet_serialize_pruned_file_list.test
+++ b/test/sql/copy/parquet/parquet_serialize_pruned_file_list.test
@@ -1,0 +1,36 @@
+# name: test/sql/copy/parquet/parquet_serialize_pruned_file_list.test
+# description: A scan whose files were all pruned away by a hive filter must survive plan serialization
+# group: [parquet]
+
+require parquet
+
+statement ok
+COPY (SELECT 1 AS id, 7 AS part) TO '{TEST_DIR}/prune_all' (FORMAT parquet, PARTITION_BY (part))
+
+statement ok
+SET debug_verify_serializer=true
+
+# the filter prunes the only file, leaving an empty file list to serialize
+query I
+SELECT count(*) FROM read_parquet('{TEST_DIR}/prune_all/part=7/*.parquet') WHERE part = 999
+----
+0
+
+query II
+SELECT id, part FROM read_parquet('{TEST_DIR}/prune_all/part=7/*.parquet') WHERE part = 999
+----
+
+# the schema still has to survive the round trip when nothing is pruned
+query II
+SELECT id, part FROM read_parquet('{TEST_DIR}/prune_all/part=7/*.parquet') WHERE part = 7
+----
+1	7
+
+# a glob that genuinely matches no files is still an error
+statement error
+SELECT count(*) FROM read_parquet('{TEST_DIR}/prune_all/does_not_exist*.parquet')
+----
+<REGEX>:.*No files found that match the pattern.*
+
+statement ok
+SET debug_verify_serializer=false


### PR DESCRIPTION
A parquet scan whose files are all pruned away by a hive filter cannot be
deserialized:

```sql
COPY (SELECT 1 AS id, 7 AS part) TO 't' (FORMAT parquet, PARTITION_BY (part));
SET debug_verify_serializer=true;
SELECT count(*) FROM read_parquet('t/part=7/*.parquet') WHERE part = 999;
-- IO Error: read_parquet needs at least one file to read
```

Without the setting the query correctly returns `0`.

## Cause

`ParquetScanSerialize` writes out the resolved file list rather than the original
glob, and `Planner::VerifyPlan` runs after the optimizer, so hive partition
pruning can leave an empty list to serialize. `ParquetScanDeserialize` fed that
back through `CreateFileList` with the user's `allow_empty` (false by default),
which rejects it. Tracing the round trip:

```
CreateFileList npaths=1 paths=[t/part=7/d.parquet]   <- initial bind
CreateFileList npaths=1 paths=[t/part=7/d.parquet]   <- VerifyPlan in the planner
CreateFileList npaths=0 paths=                       <- VerifyPlan after the optimizer, throws
```

## Fix

Allow an empty file list when restoring a serialized plan. We are rebuilding an
already bound list, not globbing user input, so this does not weaken the error
for a glob that genuinely matches nothing - that is still raised at bind time.
The commented-out `CSVReaderDeserialize` already passed `ALLOW_EMPTY` here for
the same reason.

That alone is not sufficient: binding then has no file to bind the readers on and
tries to open `""`. Routing it through the existing `IsEmptyResult` path does not
work either, since that substitutes a single dummy `BOOLEAN` column and the
restored plan fails with `Failed to find referenced virtual column`. So when the
file list is empty and the schema is already known, take the schema as-is and
skip reader binding. `IsEmptyResult` is checked first, so the new branch is only
reachable when `allow_empty` is false, which for an empty list only happens on
this path.

This is not only a debug-setting problem - any consumer that serializes a logical
plan hits it - but `debug_verify_serializer` is what exercises it in CI.

## Testing

Two tests, both confirmed to fail with the original error when the fix is stashed:

* `parquet_serialize_pruned_file_list.test` - sets `debug_verify_serializer`
  directly, and checks a glob matching no files is still an error
* `parquet_hive_override_stats.test` - restores a `WHERE part = 999` case that was
  dropped from #24752 precisely because it tripped this bug; it fails under the
  `verify_serializer` config

Parquet suite passes under `verify_serializer`, `verify_statement_serialization`,
`verify_stats`, `verify_statement_prepare` and `disable_optimizer`; `test/sql/copy/*`
and the full `test/unittest` (976932 assertions) pass.
