### PR TITLE
Add support for GET request with suffix range

### DIFF
--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -210,6 +210,14 @@ CreateThriftFileProtocol(QueryContext context, CachingFileHandle &file_handle, b
 	return make_uniq<duckdb_apache::thrift::protocol::TCompactProtocolT<ThriftFileTransport>>(std::move(transport));
 }
 
+static unique_ptr<duckdb_apache::thrift::protocol::TProtocol> CreateThriftMemoryProtocol(data_ptr_t buffer,
+                                                                                         idx_t buffer_size) {
+	using duckdb_apache::thrift::transport::TMemoryBuffer;
+	auto transport =
+	    duckdb_base_std::make_shared<TMemoryBuffer>(buffer, NumericCast<uint32_t>(buffer_size), TMemoryBuffer::OBSERVE);
+	return make_uniq<duckdb_apache::thrift::protocol::TCompactProtocolT<TMemoryBuffer>>(std::move(transport));
+}
+
 static bool ShouldAndCanPrefetch(ClientContext &context, CachingFileHandle &file_handle) {
 	Value disable_prefetch = false;
 	context.TryGetCurrentSetting("disable_parquet_prefetching", disable_prefetch);
@@ -265,66 +273,109 @@ static shared_ptr<ParquetFileMetadataCache>
 LoadMetadata(ClientContext &context, Allocator &allocator, CachingFileHandle &file_handle,
              const shared_ptr<const ParquetEncryptionConfig> &encryption_config,
              shared_ptr<EncryptionUtil> &encryption_util, optional_idx footer_size) {
-	auto file_proto = CreateThriftFileProtocol(context, file_handle, false);
-	auto &transport = reinterpret_cast<ThriftFileTransport &>(*file_proto->getTransport());
-	auto file_size = transport.GetSize();
-	if (file_size < 12) {
-		throw InvalidInputException("File '%s' too small to be a Parquet file", file_handle.GetPath());
-	}
+	static constexpr idx_t ESTIMATED_FOOTER_RATIO = 1000; // Estimate 1/1000th of the file to be footer
+	static constexpr idx_t MIN_PREFETCH_SIZE = 16384;     // Prefetch at least this many bytes
+	static constexpr idx_t MAX_PREFETCH_SIZE = 262144;    // Prefetch/read at most this many bytes
 
+	unique_ptr<duckdb_apache::thrift::protocol::TProtocol> file_proto;
+	ResizeableBuffer suffix_buffer;
+	idx_t file_size = 0;
 	bool footer_encrypted;
 	uint32_t footer_len;
-	// footer size is not provided - read it from the back
-	if (!footer_size.IsValid()) {
-		// We have to do two reads here:
-		// 1. The 8 bytes from the back to check if it's a Parquet file and the footer size
-		// 2. The footer (after getting the size)
-		// For local reads this doesn't matter much, but for remote reads this means two round trips,
-		// which is especially bad for small Parquet files where the read cost is mostly round trips.
-		// So, we prefetch more, to hopefully save a round trip.
-		static constexpr idx_t ESTIMATED_FOOTER_RATIO = 1000; // Estimate 1/1000th of the file to be footer
-		static constexpr idx_t MIN_PREFETCH_SIZE = 16384;     // Prefetch at least this many bytes
-		static constexpr idx_t MAX_PREFETCH_SIZE = 262144;    // Prefetch at most this many bytes
-		idx_t prefetch_size = 8;
-		if (ShouldAndCanPrefetch(context, file_handle)) {
-			prefetch_size = ClampValue(file_size / ESTIMATED_FOOTER_RATIO, MIN_PREFETCH_SIZE, MAX_PREFETCH_SIZE);
-			prefetch_size = MinValue(NextPowerOfTwo(prefetch_size), file_size);
+	bool suffix_read = false;
+
+	if (!footer_size.IsValid() && file_handle.IsRemoteFile()) {
+		suffix_buffer.resize(allocator, MAX_PREFETCH_SIZE);
+		SuffixReadResult suffix_result;
+		if (file_handle.TryReadSuffix(suffix_buffer.ptr, MAX_PREFETCH_SIZE, suffix_result)) {
+			if (suffix_result.bytes_read > MAX_PREFETCH_SIZE || suffix_result.start_offset > suffix_result.file_size ||
+			    suffix_result.bytes_read != suffix_result.file_size - suffix_result.start_offset) {
+				throw IOException("Filesystem returned an invalid suffix range for file '%s'", file_handle.GetPath());
+			}
+			file_size = suffix_result.file_size;
+			if (file_size < 12) {
+				throw InvalidInputException("File '%s' too small to be a Parquet file", file_handle.GetPath());
+			}
+			if (suffix_result.bytes_read < 8) {
+				throw IOException("Filesystem returned an incomplete suffix for file '%s'", file_handle.GetPath());
+			}
+			ParseParquetFooter(suffix_buffer.ptr + suffix_result.bytes_read - 8, file_handle.GetPath(), file_size,
+			                   encryption_config, footer_len, footer_encrypted);
+			suffix_read = true;
+
+			const idx_t total_footer_len = footer_len + 8;
+			if (total_footer_len <= suffix_result.bytes_read) {
+				auto metadata_ptr = suffix_buffer.ptr + suffix_result.bytes_read - total_footer_len;
+				file_proto = CreateThriftMemoryProtocol(metadata_ptr, footer_len);
+			}
+		}
+	}
+
+	if (!file_proto) {
+		file_proto = CreateThriftFileProtocol(context, file_handle, false);
+		auto &transport = reinterpret_cast<ThriftFileTransport &>(*file_proto->getTransport());
+		if (!suffix_read) {
+			file_size = transport.GetSize();
+		}
+		if (file_size < 12) {
+			throw InvalidInputException("File '%s' too small to be a Parquet file", file_handle.GetPath());
 		}
 
-		ResizeableBuffer buf;
-		buf.resize(allocator, 8);
-		buf.zero();
+		// footer size is not provided and the optional suffix read was unavailable - read it from the back
+		if (!footer_size.IsValid() && !suffix_read) {
+			// We have to do two reads here:
+			// 1. The 8 bytes from the back to check if it's a Parquet file and the footer size
+			// 2. The footer (after getting the size)
+			// For local reads this doesn't matter much, but for remote reads this means two round trips,
+			// which is especially bad for small Parquet files where the read cost is mostly round trips.
+			// So, we prefetch more, to hopefully save a round trip.
+			idx_t prefetch_size = 8;
+			if (ShouldAndCanPrefetch(context, file_handle)) {
+				prefetch_size = ClampValue(file_size / ESTIMATED_FOOTER_RATIO, MIN_PREFETCH_SIZE, MAX_PREFETCH_SIZE);
+				prefetch_size = MinValue(NextPowerOfTwo(prefetch_size), file_size);
+			}
 
-		transport.Prefetch(file_size - prefetch_size, prefetch_size);
-		transport.SetLocation(file_size - 8);
-		transport.read(buf.ptr, 8);
+			ResizeableBuffer buf;
+			buf.resize(allocator, 8);
+			buf.zero();
 
-		ParseParquetFooter(buf.ptr, file_handle.GetPath(), file_size, encryption_config, footer_len, footer_encrypted);
+			transport.Prefetch(file_size - prefetch_size, prefetch_size);
+			transport.SetLocation(file_size - 8);
+			transport.read(buf.ptr, 8);
 
-		auto metadata_pos = file_size - (footer_len + 8);
-		transport.SetLocation(metadata_pos);
-		if (footer_len > prefetch_size - 8) {
+			ParseParquetFooter(buf.ptr, file_handle.GetPath(), file_size, encryption_config, footer_len,
+			                   footer_encrypted);
+
+			auto metadata_pos = file_size - (footer_len + 8);
+			transport.SetLocation(metadata_pos);
+			if (footer_len > prefetch_size - 8) {
+				transport.Prefetch(metadata_pos, footer_len);
+			}
+		} else if (suffix_read) {
+			auto metadata_pos = file_size - (footer_len + 8);
+			transport.SetLocation(metadata_pos);
 			transport.Prefetch(metadata_pos, footer_len);
-		}
-	} else {
-		footer_len = UnsafeNumericCast<uint32_t>(footer_size.GetIndex());
-		if (footer_len == 0 || file_size < 12 + footer_len) {
-			throw InvalidInputException("Invalid footer length provided for file '%s'", file_handle.GetPath());
-		}
+		} else {
+			footer_len = UnsafeNumericCast<uint32_t>(footer_size.GetIndex());
+			if (footer_len == 0 || file_size < 12 + footer_len) {
+				throw InvalidInputException("Invalid footer length provided for file '%s'", file_handle.GetPath());
+			}
 
-		idx_t total_footer_len = footer_len + 8;
-		auto metadata_pos = file_size - total_footer_len;
-		transport.SetLocation(metadata_pos);
-		transport.Prefetch(metadata_pos, total_footer_len);
+			idx_t total_footer_len = footer_len + 8;
+			auto metadata_pos = file_size - total_footer_len;
+			transport.SetLocation(metadata_pos);
+			transport.Prefetch(metadata_pos, total_footer_len);
 
-		auto read_head = transport.GetReadHead(metadata_pos);
-		auto data_ptr = read_head->buffer_ptr;
+			auto read_head = transport.GetReadHead(metadata_pos);
+			auto data_ptr = read_head->buffer_ptr;
 
-		uint32_t read_footer_len;
-		ParseParquetFooter(data_ptr + footer_len, file_handle.GetPath(), file_size, encryption_config, read_footer_len,
-		                   footer_encrypted);
-		if (read_footer_len != footer_len) {
-			throw InvalidInputException("Parquet footer length stored in file is not equal to footer length provided");
+			uint32_t read_footer_len;
+			ParseParquetFooter(data_ptr + footer_len, file_handle.GetPath(), file_size, encryption_config,
+			                   read_footer_len, footer_encrypted);
+			if (read_footer_len != footer_len) {
+				throw InvalidInputException(
+				    "Parquet footer length stored in file is not equal to footer length provided");
+			}
 		}
 	}
 
@@ -1277,12 +1328,6 @@ ParquetReader::ParquetReader(ClientContext &context_p, OpenFileInfo file_p, Parq
     : BaseFileReader(std::move(file_p)), fs(CachingFileSystem::Get(context_p)),
       allocator(BufferAllocator::Get(context_p)), parquet_options(std::move(parquet_options_p)),
       projection_expressions(std::move(projection_expressions_p)) {
-	file_handle = fs.OpenFile(context_p, file, FileFlags::FILE_FLAGS_READ);
-	if (!file_handle->CanSeek()) {
-		throw NotImplementedException(
-		    "Reading parquet files from a FIFO stream is not supported and cannot be efficiently supported since "
-		    "metadata is located at the end of the file. Write the stream to disk first and read from there instead.");
-	}
 	// read the extended file open info (if any)
 	optional_idx footer_size;
 	if (file.extended_info) {
@@ -1296,6 +1341,20 @@ ParquetReader::ParquetReader(ClientContext &context_p, OpenFileInfo file_p, Parq
 		if (footer_entry != open_options.end()) {
 			footer_size = UBigIntValue::Get(footer_entry->second);
 		}
+	}
+	if (!metadata_p && !footer_size.IsValid() && FileSystem::IsRemoteFile(file.path)) {
+		auto extended_info = make_shared_ptr<ExtendedOpenFileInfo>();
+		if (file.extended_info) {
+			*extended_info = *file.extended_info;
+		}
+		extended_info->options["defer_file_info"] = Value::BOOLEAN(true);
+		file.extended_info = std::move(extended_info);
+	}
+	file_handle = fs.OpenFile(context_p, file, FileFlags::FILE_FLAGS_READ);
+	if (!file_handle->CanSeek()) {
+		throw NotImplementedException(
+		    "Reading parquet files from a FIFO stream is not supported and cannot be efficiently supported since "
+		    "metadata is located at the end of the file. Write the stream to disk first and read from there instead.");
 	}
 
 	// If metadata cached is disabled

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -210,11 +210,11 @@ CreateThriftFileProtocol(QueryContext context, CachingFileHandle &file_handle, b
 	return make_uniq<duckdb_apache::thrift::protocol::TCompactProtocolT<ThriftFileTransport>>(std::move(transport));
 }
 
-static unique_ptr<duckdb_apache::thrift::protocol::TProtocol> CreateThriftMemoryProtocol(data_ptr_t buffer,
+static unique_ptr<duckdb_apache::thrift::protocol::TProtocol> CreateThriftMemoryProtocol(const_data_ptr_t buffer,
                                                                                          idx_t buffer_size) {
 	using duckdb_apache::thrift::transport::TMemoryBuffer;
-	auto transport =
-	    duckdb_base_std::make_shared<TMemoryBuffer>(buffer, NumericCast<uint32_t>(buffer_size), TMemoryBuffer::OBSERVE);
+	auto transport = duckdb_base_std::make_shared<TMemoryBuffer>(
+	    const_cast<data_ptr_t>(buffer), NumericCast<uint32_t>(buffer_size), TMemoryBuffer::OBSERVE);
 	return make_uniq<duckdb_apache::thrift::protocol::TCompactProtocolT<TMemoryBuffer>>(std::move(transport));
 }
 
@@ -278,16 +278,15 @@ LoadMetadata(ClientContext &context, Allocator &allocator, CachingFileHandle &fi
 	static constexpr idx_t MAX_PREFETCH_SIZE = 262144;    // Prefetch/read at most this many bytes
 
 	unique_ptr<duckdb_apache::thrift::protocol::TProtocol> file_proto;
-	ResizeableBuffer suffix_buffer;
+	FileBufferHandleGroup suffix_buffer;
 	idx_t file_size = 0;
 	bool footer_encrypted;
 	uint32_t footer_len;
 	bool suffix_read = false;
 
 	if (!footer_size.IsValid() && file_handle.IsRemoteFile()) {
-		suffix_buffer.resize(allocator, MAX_PREFETCH_SIZE);
 		SuffixReadResult suffix_result;
-		if (file_handle.TryReadSuffix(suffix_buffer.ptr, MAX_PREFETCH_SIZE, suffix_result)) {
+		if (file_handle.TryReadSuffix(MAX_PREFETCH_SIZE, suffix_buffer, suffix_result)) {
 			if (suffix_result.bytes_read > MAX_PREFETCH_SIZE || suffix_result.start_offset > suffix_result.file_size ||
 			    suffix_result.bytes_read != suffix_result.file_size - suffix_result.start_offset) {
 				throw IOException("Filesystem returned an invalid suffix range for file '%s'", file_handle.GetPath());
@@ -299,13 +298,14 @@ LoadMetadata(ClientContext &context, Allocator &allocator, CachingFileHandle &fi
 			if (suffix_result.bytes_read < 8) {
 				throw IOException("Filesystem returned an incomplete suffix for file '%s'", file_handle.GetPath());
 			}
-			ParseParquetFooter(suffix_buffer.ptr + suffix_result.bytes_read - 8, file_handle.GetPath(), file_size,
+			auto suffix_ptr = suffix_buffer.Ptr();
+			ParseParquetFooter(suffix_ptr + suffix_result.bytes_read - 8, file_handle.GetPath(), file_size,
 			                   encryption_config, footer_len, footer_encrypted);
 			suffix_read = true;
 
 			const idx_t total_footer_len = footer_len + 8;
 			if (total_footer_len <= suffix_result.bytes_read) {
-				auto metadata_ptr = suffix_buffer.ptr + suffix_result.bytes_read - total_footer_len;
+				auto metadata_ptr = suffix_ptr + suffix_result.bytes_read - total_footer_len;
 				file_proto = CreateThriftMemoryProtocol(metadata_ptr, footer_len);
 			}
 		}

--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -458,6 +458,10 @@ int64_t FileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes) {
 	throw NotImplementedException("%s: Read is not implemented!", GetName());
 }
 
+bool FileSystem::TryReadSuffix(FileHandle &handle, data_ptr_t buffer, idx_t buffer_len, SuffixReadResult &result) {
+	return false;
+}
+
 int64_t FileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes) {
 	throw NotImplementedException("%s: Write is not implemented!", GetName());
 }
@@ -770,6 +774,10 @@ int64_t FileHandle::Read(QueryContext context, void *buffer, idx_t nr_bytes) {
 	}
 
 	return bytes_read;
+}
+
+bool FileHandle::TryReadSuffix(data_ptr_t buffer, idx_t buffer_len, SuffixReadResult &result) {
+	return file_system.TryReadSuffix(*this, buffer, buffer_len, result);
 }
 
 bool FileHandle::Trim(idx_t offset_bytes, idx_t length_bytes) {

--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -82,6 +82,14 @@ struct NetworkThroughputEstimate {
 	double bandwidth_bytes_per_s = 0;
 };
 
+//! Result of an optional suffix read. The returned bytes cover
+//! [start_offset, start_offset + bytes_read) in a file of [file_size] bytes.
+struct SuffixReadResult {
+	idx_t bytes_read = 0;
+	idx_t file_size = 0;
+	idx_t start_offset = 0;
+};
+
 struct FileHandle {
 public:
 	DUCKDB_API FileHandle(FileSystem &file_system, string path, FileOpenFlags flags);
@@ -92,6 +100,9 @@ public:
 	// File offset will be changed, which advances for number of bytes read.
 	DUCKDB_API int64_t Read(void *buffer, idx_t nr_bytes);
 	DUCKDB_API int64_t Read(QueryContext context, void *buffer, idx_t nr_bytes);
+	//! Try to read up to [buffer_len] bytes from the end of the file without first obtaining its size.
+	//! Returns false when the filesystem does not support this optional operation.
+	DUCKDB_API bool TryReadSuffix(data_ptr_t buffer, idx_t buffer_len, SuffixReadResult &result);
 	DUCKDB_API int64_t Write(void *buffer, idx_t nr_bytes);
 	DUCKDB_API int64_t Write(QueryContext context, void *buffer, idx_t nr_bytes);
 	// Read at [nr_bytes] bytes into [buffer].
@@ -185,6 +196,9 @@ public:
 	//! Read nr_bytes from the specified file into the buffer, moving the file pointer forward by nr_bytes. Returns the
 	//! amount of bytes read.
 	DUCKDB_API virtual int64_t Read(FileHandle &handle, void *buffer, int64_t nr_bytes);
+	//! Optional suffix read. Filesystems that do not support it return false.
+	DUCKDB_API virtual bool TryReadSuffix(FileHandle &handle, data_ptr_t buffer, idx_t buffer_len,
+	                                      SuffixReadResult &result);
 	//! Write nr_bytes from the buffer into the file, moving the file pointer forward by nr_bytes.
 	DUCKDB_API virtual int64_t Write(FileHandle &handle, void *buffer, int64_t nr_bytes);
 	//! Excise a range of the file. The OS can drop pages from the page-cache, and the file-system is free to deallocate

--- a/src/include/duckdb/common/opener_file_system.hpp
+++ b/src/include/duckdb/common/opener_file_system.hpp
@@ -46,6 +46,9 @@ public:
 	int64_t Read(FileHandle &handle, void *buffer, int64_t nr_bytes) override {
 		return GetFileSystem().Read(handle, buffer, nr_bytes);
 	}
+	bool TryReadSuffix(FileHandle &handle, data_ptr_t buffer, idx_t buffer_len, SuffixReadResult &result) override {
+		return GetFileSystem().TryReadSuffix(handle, buffer, buffer_len, result);
+	}
 
 	int64_t Write(FileHandle &handle, void *buffer, int64_t nr_bytes) override {
 		return GetFileSystem().Write(handle, buffer, nr_bytes);

--- a/src/include/duckdb/storage/external_file_cache/caching_file_system.hpp
+++ b/src/include/duckdb/storage/external_file_cache/caching_file_system.hpp
@@ -28,6 +28,7 @@ class FileOpenFlags;
 class FileSystem;
 struct FileHandle;
 struct NetworkThroughputEstimate;
+struct SuffixReadResult;
 class QueryContext;
 class CachingFileSystem;
 
@@ -69,6 +70,8 @@ public:
 	DUCKDB_API FileBufferHandleGroup Read(idx_t &nr_bytes);
 	//! Read and record time
 	DUCKDB_API void ReadAndRecord(QueryContext context, data_ptr_t buffer, idx_t nr_bytes, idx_t location);
+	//! Try to read a suffix directly from the underlying filesystem.
+	DUCKDB_API bool TryReadSuffix(data_ptr_t buffer, idx_t buffer_len, SuffixReadResult &result);
 	//! Get some properties of the file
 	DUCKDB_API string GetPath() const;
 	DUCKDB_API idx_t GetFileSize();
@@ -89,6 +92,9 @@ private:
 	shared_ptr<CachedFile> EnsureCachedFileCurrent();
 	//! Record a timed read of a local file into the throughput estimate
 	void RecordReadThroughput(double total_seconds, idx_t bytes);
+	//! Populate this handle and the shared cache entry with metadata from the underlying handle.
+	void InitializeFileMetadata(const shared_ptr<FileHandle> &handle);
+	void EnsureFileMetadata();
 
 private:
 	QueryContext context;
@@ -115,6 +121,8 @@ private:
 	//! Last modified time and version tag (if FileHandle is opened)
 	timestamp_t last_modified;
 	string version_tag;
+	bool defer_file_info = false;
+	atomic<bool> file_metadata_initialized {false};
 
 	//! Current position (if non-seeking reads)
 	idx_t position;

--- a/src/include/duckdb/storage/external_file_cache/caching_file_system.hpp
+++ b/src/include/duckdb/storage/external_file_cache/caching_file_system.hpp
@@ -70,8 +70,8 @@ public:
 	DUCKDB_API FileBufferHandleGroup Read(idx_t &nr_bytes);
 	//! Read and record time
 	DUCKDB_API void ReadAndRecord(QueryContext context, data_ptr_t buffer, idx_t nr_bytes, idx_t location);
-	//! Try to read a suffix directly from the underlying filesystem.
-	DUCKDB_API bool TryReadSuffix(data_ptr_t buffer, idx_t buffer_len, SuffixReadResult &result);
+	//! Try to read a suffix into an owned buffer-manager allocation.
+	DUCKDB_API bool TryReadSuffix(idx_t max_bytes, FileBufferHandleGroup &data, SuffixReadResult &result);
 	//! Get some properties of the file
 	DUCKDB_API string GetPath() const;
 	DUCKDB_API idx_t GetFileSize();
@@ -95,6 +95,9 @@ private:
 	//! Populate this handle and the shared cache entry with metadata from the underlying handle.
 	void InitializeFileMetadata(const shared_ptr<FileHandle> &handle);
 	void EnsureFileMetadata();
+	//! Cache the aligned final block contained in a successful suffix read, adopting the buffer when provided.
+	void TryCacheSuffixBlock(optional_ptr<BufferHandle> owned_suffix, const_data_ptr_t suffix_data,
+	                         const SuffixReadResult &suffix_result, idx_t block_size);
 
 private:
 	QueryContext context;

--- a/src/include/duckdb/storage/external_file_cache/caching_file_system_wrapper.hpp
+++ b/src/include/duckdb/storage/external_file_cache/caching_file_system_wrapper.hpp
@@ -65,6 +65,8 @@ public:
 	DUCKDB_API void Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override;
 	DUCKDB_API void Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override;
 	DUCKDB_API int64_t Read(FileHandle &handle, void *buffer, int64_t nr_bytes) override;
+	DUCKDB_API bool TryReadSuffix(FileHandle &handle, data_ptr_t buffer, idx_t buffer_len,
+	                              SuffixReadResult &result) override;
 	DUCKDB_API int64_t Write(FileHandle &handle, void *buffer, int64_t nr_bytes) override;
 	DUCKDB_API bool Trim(FileHandle &handle, idx_t offset_bytes, idx_t length_bytes) override;
 

--- a/src/include/duckdb/storage/external_file_cache/external_file_cache_block.hpp
+++ b/src/include/duckdb/storage/external_file_cache/external_file_cache_block.hpp
@@ -26,6 +26,8 @@ struct CacheBlock {
 	mutable std::condition_variable cv DUCKDB_GUARDED_BY(mtx);
 	CacheBlockState state DUCKDB_GUARDED_BY(mtx) = CacheBlockState::EMPTY;
 	shared_ptr<BlockHandle> block_handle DUCKDB_GUARDED_BY(mtx);
+	//! Offset of the first valid byte within the buffer
+	idx_t buffer_offset DUCKDB_GUARDED_BY(mtx) = 0;
 	//! Number of valid bytes that were read into this block
 	idx_t nr_bytes DUCKDB_GUARDED_BY(mtx) = 0;
 #ifdef DEBUG

--- a/src/storage/external_file_cache/caching_file_system.cpp
+++ b/src/storage/external_file_cache/caching_file_system.cpp
@@ -1,12 +1,12 @@
 #include "duckdb/storage/external_file_cache/caching_file_system.hpp"
 
-#include "duckdb/common/checksum.hpp"
 #include "duckdb/common/chrono.hpp"
 #include "duckdb/common/enums/cache_validation_mode.hpp"
 #include "duckdb/common/enums/destroy_buffer_upon.hpp"
 #include "duckdb/common/enums/memory_tag.hpp"
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/main/client_context.hpp"
+#include "duckdb/common/types/hash.hpp"
 #include "duckdb/parallel/task_executor.hpp"
 #include "duckdb/parallel/task_scheduler.hpp"
 #include "duckdb/storage/buffer/block_handle.hpp"
@@ -52,7 +52,8 @@ public:
 				auto pin = buffer_manager.Pin(block->block_handle);
 				if (pin.IsValid()) {
 #ifdef DEBUG
-					D_ASSERT(Checksum(pin.Ptr(), block->nr_bytes) == block->checksum);
+					D_ASSERT(Hash(const_char_ptr_cast(pin.Ptr() + block->buffer_offset), block->nr_bytes) ==
+					         block->checksum);
 #endif
 					result_pin = std::move(pin);
 					return;
@@ -84,10 +85,11 @@ public:
 
 					lk.lock();
 					block->block_handle = buf.GetBlockHandle();
+					block->buffer_offset = 0;
 					block->nr_bytes = to_read;
 					block->state = CacheBlockState::LOADED;
 #ifdef DEBUG
-					block->checksum = Checksum(buf.Ptr(), to_read);
+					block->checksum = Hash(const_char_ptr_cast(buf.Ptr()), to_read);
 #endif
 					result_pin = std::move(buf);
 					block->cv.notify_all();
@@ -295,15 +297,123 @@ void CachingFileHandle::EnsureFileMetadata() {
 	}
 }
 
-bool CachingFileHandle::TryReadSuffix(data_ptr_t buffer, idx_t buffer_len, SuffixReadResult &result) {
-	auto handle = GetFileHandle();
-	if (!handle->TryReadSuffix(buffer, buffer_len, result)) {
+void CachingFileHandle::TryCacheSuffixBlock(optional_ptr<BufferHandle> owned_suffix, const_data_ptr_t suffix_data,
+                                            const SuffixReadResult &suffix_result, idx_t block_size) {
+	if (!external_file_cache.IsEnabled() || !external_file_cache.ShouldCacheFile(path.path) ||
+	    suffix_result.file_size == 0) {
+		return;
+	}
+
+	if (Validate()) {
+		annotated_lock_guard<annotated_mutex> guard(file_handle_mutex);
+		const bool no_validation_metadata =
+		    version_tag.empty() && (!last_modified.IsFinite() || last_modified == timestamp_t(0));
+		if (no_validation_metadata) {
+			return;
+		}
+	}
+
+	const idx_t last_block_idx = (suffix_result.file_size - 1) / block_size;
+	const idx_t last_block_start = last_block_idx * block_size;
+	const idx_t last_block_size = suffix_result.file_size - last_block_start;
+	if (last_block_start < suffix_result.start_offset) {
+		return;
+	}
+	const idx_t suffix_offset = last_block_start - suffix_result.start_offset;
+	if (suffix_offset > suffix_result.bytes_read || last_block_size > suffix_result.bytes_read - suffix_offset) {
+		return;
+	}
+
+	auto current_cached_file = EnsureCachedFileCurrent();
+	auto blocks = external_file_cache.ReindexAndAcquireBlocks(*current_cached_file, block_size, last_block_idx, 1);
+	auto &block = blocks[0];
+	{
+		annotated_lock_guard<annotated_mutex> block_guard(block->mtx);
+		if (block->state == CacheBlockState::LOADED || block->state == CacheBlockState::LOADING) {
+			return;
+		}
+		block->state = CacheBlockState::LOADING;
+	}
+
+	try {
+		BufferHandle copied_buffer;
+		shared_ptr<BlockHandle> cached_block_handle;
+		idx_t buffer_offset;
+		if (owned_suffix) {
+			cached_block_handle = owned_suffix->GetBlockHandle();
+			cached_block_handle->GetMemory().SetDestroyBufferUpon(DestroyBufferUpon::EVICTION);
+			buffer_offset = suffix_offset;
+		} else {
+			auto &buffer_manager = external_file_cache.GetBufferManager();
+			copied_buffer = buffer_manager.Allocate(MemoryTag::EXTERNAL_FILE_CACHE, last_block_size);
+			memcpy(copied_buffer.GetDataMutable(), suffix_data + suffix_offset, last_block_size);
+			cached_block_handle = copied_buffer.GetBlockHandle();
+			buffer_offset = 0;
+		}
+
+		annotated_lock_guard<annotated_mutex> block_guard(block->mtx);
+		block->block_handle = std::move(cached_block_handle);
+		block->buffer_offset = buffer_offset;
+		block->nr_bytes = last_block_size;
+		block->state = CacheBlockState::LOADED;
+#ifdef DEBUG
+		block->checksum = Hash(const_char_ptr_cast(suffix_data + suffix_offset), last_block_size);
+#endif
+		block->cv.notify_all();
+	} catch (...) {
+		annotated_lock_guard<annotated_mutex> block_guard(block->mtx);
+		block->state = CacheBlockState::IO_ERROR;
+		block->cv.notify_all();
+		throw;
+	}
+}
+
+bool CachingFileHandle::TryReadSuffix(idx_t max_bytes, FileBufferHandleGroup &data, SuffixReadResult &result) {
+	result = SuffixReadResult();
+	if (max_bytes == 0) {
 		return false;
 	}
-	annotated_lock_guard<annotated_mutex> guard(file_handle_mutex);
-	if (!file_metadata_initialized) {
-		InitializeFileMetadata(handle);
+
+	auto handle = GetFileHandle();
+	const bool should_cache = external_file_cache.IsEnabled() && external_file_cache.ShouldCacheFile(path.path);
+	const idx_t block_size = should_cache ? external_file_cache.GetCacheBlockSize(path.path) : 0;
+	const idx_t suffix_read_size = should_cache ? MaxValue(max_bytes, block_size) : max_bytes;
+	auto &buffer_manager = external_file_cache.GetBufferManager();
+	auto suffix_buffer = AllocateUncachedReadBuffer(buffer_manager, suffix_read_size);
+	SuffixReadResult suffix_result;
+	if (!handle->TryReadSuffix(suffix_buffer.GetDataMutable(), suffix_read_size, suffix_result)) {
+		return false;
 	}
+	if (suffix_result.bytes_read > suffix_read_size || suffix_result.start_offset > suffix_result.file_size ||
+	    suffix_result.bytes_read != suffix_result.file_size - suffix_result.start_offset) {
+		throw IOException("Filesystem returned an invalid suffix range for file '%s'", path.path);
+	}
+
+	{
+		annotated_lock_guard<annotated_mutex> guard(file_handle_mutex);
+		if (!file_metadata_initialized) {
+			InitializeFileMetadata(handle);
+		}
+	}
+
+	if (should_cache) {
+		if (max_bytes <= block_size) {
+			// The suffix and the aligned final cache block can begin at different offsets in the same allocation.
+			TryCacheSuffixBlock(&suffix_buffer, suffix_buffer.Ptr(), suffix_result, block_size);
+		} else {
+			TryCacheSuffixBlock(nullptr, suffix_buffer.Ptr(), suffix_result, block_size);
+		}
+	}
+
+	const idx_t returned_bytes = MinValue(max_bytes, suffix_result.bytes_read);
+	const idx_t returned_offset = suffix_result.bytes_read - returned_bytes;
+	result.bytes_read = returned_bytes;
+	result.file_size = suffix_result.file_size;
+	result.start_offset = suffix_result.file_size - returned_bytes;
+
+	vector<FileBufferHandleGroup::MemoryHandle> handles;
+	handles.push_back({std::move(suffix_buffer), returned_offset, returned_bytes});
+	data = FileBufferHandleGroup(std::move(handles));
 	return true;
 }
 
@@ -360,16 +470,18 @@ FileBufferHandleGroup CachingFileHandle::Read(const idx_t nr_bytes, const idx_t 
 	for (idx_t idx = 0; idx < num_blocks; idx++) {
 		const idx_t block_start = (first_block + idx) * block_size;
 		const idx_t offset_in_block = (idx == 0) ? (location - block_start) : 0;
+		idx_t block_buffer_offset = 0;
 		idx_t block_valid_bytes = 0;
 		{
 			auto &block = *blocks[idx];
 			annotated_lock_guard<annotated_mutex> block_guard(block.mtx);
+			block_buffer_offset = block.buffer_offset;
 			block_valid_bytes = block.nr_bytes;
 		}
 		const idx_t available_in_block =
 		    (block_valid_bytes > offset_in_block) ? (block_valid_bytes - offset_in_block) : 0;
 		const idx_t length = MinValue(available_in_block, remaining);
-		mem_handles.push_back({std::move(pins[idx]), offset_in_block, length});
+		mem_handles.push_back({std::move(pins[idx]), block_buffer_offset + offset_in_block, length});
 		remaining -= length;
 	}
 
@@ -496,6 +608,10 @@ bool CachingFileHandle::Validate() const {
 }
 
 bool CachingFileHandle::CanSeek() {
+	if (defer_file_info && !file_metadata_initialized) {
+		// Seekability is a filesystem capability and does not require loading deferred file metadata.
+		return GetFileHandle()->CanSeek();
+	}
 	if (!Validate()) {
 		auto current_cached_file = EnsureCachedFileCurrent();
 		annotated_lock_guard<annotated_mutex> guard(current_cached_file->meta_lock);

--- a/src/storage/external_file_cache/caching_file_system.cpp
+++ b/src/storage/external_file_cache/caching_file_system.cpp
@@ -207,6 +207,12 @@ CachingFileHandle::CachingFileHandle(QueryContext context, CachingFileSystem &ca
       validate(
           ExternalFileCacheUtil::GetCacheValidationMode(path_p, context.GetClientContext(), caching_file_system_p.db)),
       cached_file(nullptr), position(0) {
+	if (path.extended_info) {
+		auto entry = path.extended_info->options.find("defer_file_info");
+		if (entry != path.extended_info->options.end()) {
+			defer_file_info = entry->second.GetValue<bool>();
+		}
+	}
 	cached_file = external_file_cache.GetOrCreateCachedFile(path_p.path);
 	if (!external_file_cache.IsEnabled() || Validate()) {
 		// If caching is disabled, or if we must validate cache entries, we always have to open the file
@@ -242,27 +248,57 @@ shared_ptr<FileHandle> CachingFileHandle::GetFileHandle() {
 	// require explicit opt-in for concurrent pread-style access (e.g., HTTPFS).
 	auto internal_flags = flags | FileFlags::FILE_FLAGS_PARALLEL_ACCESS;
 	file_handle = caching_file_system.file_system.OpenFile(path, internal_flags, opener);
-	last_modified = caching_file_system.file_system.GetLastModifiedTime(*file_handle);
-	version_tag = caching_file_system.file_system.GetVersionTag(*file_handle);
-
-	{
-		annotated_lock_guard<annotated_mutex> meta_guard(cached_file->meta_lock);
-		const bool first_access = (cached_file->file_size == 0);
-		if (first_access || Validate()) {
-			if (!ExternalFileCache::IsValid(Validate(), cached_file->version_tag, cached_file->last_modified,
-			                                version_tag, last_modified)) {
-				annotated_lock_guard<annotated_mutex> map_guard(cached_file->map_lock);
-				cached_file->blocks.clear();
-				cached_file->cached_block_size.SetInvalid();
-			}
-			cached_file->file_size = file_handle->GetFileSize();
-			cached_file->last_modified = last_modified;
-			cached_file->version_tag = version_tag;
-			cached_file->can_seek = file_handle->CanSeek();
-			cached_file->on_disk_file = file_handle->OnDiskFile();
-		}
+	if (!defer_file_info) {
+		InitializeFileMetadata(file_handle);
 	}
 	return file_handle;
+}
+
+void CachingFileHandle::InitializeFileMetadata(const shared_ptr<FileHandle> &handle) {
+	D_ASSERT(handle);
+	D_ASSERT(!file_metadata_initialized);
+	last_modified = caching_file_system.file_system.GetLastModifiedTime(*handle);
+	version_tag = caching_file_system.file_system.GetVersionTag(*handle);
+
+	annotated_lock_guard<annotated_mutex> meta_guard(cached_file->meta_lock);
+	const bool first_access = (cached_file->file_size == 0);
+	if (first_access || Validate()) {
+		if (!ExternalFileCache::IsValid(Validate(), cached_file->version_tag, cached_file->last_modified, version_tag,
+		                                last_modified)) {
+			annotated_lock_guard<annotated_mutex> map_guard(cached_file->map_lock);
+			cached_file->blocks.clear();
+			cached_file->cached_block_size.SetInvalid();
+		}
+		cached_file->file_size = handle->GetFileSize();
+		cached_file->last_modified = last_modified;
+		cached_file->version_tag = version_tag;
+		cached_file->can_seek = handle->CanSeek();
+		cached_file->on_disk_file = handle->OnDiskFile();
+	}
+	file_metadata_initialized = true;
+}
+
+void CachingFileHandle::EnsureFileMetadata() {
+	if (file_metadata_initialized) {
+		return;
+	}
+	auto handle = GetFileHandle();
+	annotated_lock_guard<annotated_mutex> guard(file_handle_mutex);
+	if (!file_metadata_initialized) {
+		InitializeFileMetadata(handle);
+	}
+}
+
+bool CachingFileHandle::TryReadSuffix(data_ptr_t buffer, idx_t buffer_len, SuffixReadResult &result) {
+	auto handle = GetFileHandle();
+	if (!handle->TryReadSuffix(buffer, buffer_len, result)) {
+		return false;
+	}
+	annotated_lock_guard<annotated_mutex> guard(file_handle_mutex);
+	if (!file_metadata_initialized) {
+		InitializeFileMetadata(handle);
+	}
+	return true;
 }
 
 Allocator &CachingFileHandle::GetBufferAllocator() const {
@@ -397,6 +433,9 @@ string CachingFileHandle::GetPath() const {
 }
 
 idx_t CachingFileHandle::GetFileSize() {
+	if (defer_file_info && !file_metadata_initialized) {
+		EnsureFileMetadata();
+	}
 	if (!Validate()) {
 		auto current_cached_file = EnsureCachedFileCurrent();
 		annotated_lock_guard<annotated_mutex> guard(current_cached_file->meta_lock);
@@ -406,6 +445,9 @@ idx_t CachingFileHandle::GetFileSize() {
 }
 
 timestamp_t CachingFileHandle::GetLastModifiedTime() {
+	if (defer_file_info && !file_metadata_initialized) {
+		EnsureFileMetadata();
+	}
 	if (!Validate()) {
 		auto current_cached_file = EnsureCachedFileCurrent();
 		annotated_lock_guard<annotated_mutex> guard(current_cached_file->meta_lock);
@@ -417,6 +459,9 @@ timestamp_t CachingFileHandle::GetLastModifiedTime() {
 }
 
 string CachingFileHandle::GetVersionTag() {
+	if (defer_file_info && !file_metadata_initialized) {
+		EnsureFileMetadata();
+	}
 	if (!Validate()) {
 		auto current_cached_file = EnsureCachedFileCurrent();
 		annotated_lock_guard<annotated_mutex> guard(current_cached_file->meta_lock);

--- a/src/storage/external_file_cache/caching_file_system.cpp
+++ b/src/storage/external_file_cache/caching_file_system.cpp
@@ -179,6 +179,7 @@ bool CachingFileHandle::StripForceFullDownloadIfPresent() {
 
 shared_ptr<CachingFileHandle::CachedFile> CachingFileHandle::EnsureCachedFileCurrent() {
 	bool needs_reopen = false;
+	bool needs_metadata_refresh = false;
 	shared_ptr<CachedFile> current_cached_file;
 	{
 		annotated_lock_guard<annotated_mutex> guard(file_handle_mutex);
@@ -187,7 +188,9 @@ shared_ptr<CachingFileHandle::CachedFile> CachingFileHandle::EnsureCachedFileCur
 		}
 		needs_reopen = file_handle != nullptr;
 		if (needs_reopen) {
+			needs_metadata_refresh = file_metadata_initialized;
 			file_handle.reset();
+			file_metadata_initialized = false;
 		}
 		cached_file = external_file_cache.GetOrCreateCachedFile(path.path);
 		current_cached_file = cached_file;
@@ -195,6 +198,9 @@ shared_ptr<CachingFileHandle::CachedFile> CachingFileHandle::EnsureCachedFileCur
 
 	if (needs_reopen) {
 		GetFileHandle();
+		if (needs_metadata_refresh) {
+			EnsureFileMetadata();
+		}
 	}
 	return current_cached_file;
 }

--- a/src/storage/external_file_cache/caching_file_system_wrapper.cpp
+++ b/src/storage/external_file_cache/caching_file_system_wrapper.cpp
@@ -170,6 +170,15 @@ int64_t CachingFileSystemWrapper::Read(FileHandle &handle, void *buffer, int64_t
 	return nr_bytes;
 }
 
+bool CachingFileSystemWrapper::TryReadSuffix(FileHandle &handle, data_ptr_t buffer, idx_t buffer_len,
+                                             SuffixReadResult &result) {
+	auto *caching_handle = GetCachingHandleIfPossible(handle);
+	if (!caching_handle) {
+		return underlying_file_system.TryReadSuffix(handle, buffer, buffer_len, result);
+	}
+	return caching_handle->TryReadSuffix(buffer, buffer_len, result);
+}
+
 //===----------------------------------------------------------------------===//
 // File Metadata Operations
 //===----------------------------------------------------------------------===//

--- a/src/storage/external_file_cache/caching_file_system_wrapper.cpp
+++ b/src/storage/external_file_cache/caching_file_system_wrapper.cpp
@@ -176,7 +176,12 @@ bool CachingFileSystemWrapper::TryReadSuffix(FileHandle &handle, data_ptr_t buff
 	if (!caching_handle) {
 		return underlying_file_system.TryReadSuffix(handle, buffer, buffer_len, result);
 	}
-	return caching_handle->TryReadSuffix(buffer, buffer_len, result);
+	FileBufferHandleGroup data;
+	if (!caching_handle->TryReadSuffix(buffer_len, data, result)) {
+		return false;
+	}
+	data.CopyTo(buffer, result.bytes_read);
+	return true;
 }
 
 //===----------------------------------------------------------------------===//

--- a/src/storage/external_file_cache/external_file_cache.cpp
+++ b/src/storage/external_file_cache/external_file_cache.cpp
@@ -1,9 +1,9 @@
 #include "duckdb/storage/external_file_cache/external_file_cache.hpp"
 
-#include "duckdb/common/checksum.hpp"
 #include "duckdb/common/enums/memory_tag.hpp"
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/map.hpp"
+#include "duckdb/common/types/hash.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/database.hpp"
 #include "duckdb/main/settings.hpp"
@@ -80,7 +80,12 @@ void ExternalFileCache::ReindexCachedFileCore(CachedFile &cached_file, idx_t fil
 	D_ASSERT(new_block_size > 0);
 
 	// Phase 1: Pin all LOADED old blocks, sorted by block index.
-	map<idx_t, pair<BufferHandle, idx_t>> pinned;
+	struct PinnedBlock {
+		BufferHandle handle;
+		idx_t buffer_offset;
+		idx_t nr_bytes;
+	};
+	map<idx_t, PinnedBlock> pinned;
 	for (auto &block_entry : cached_file.blocks) {
 		const idx_t old_idx = block_entry.first;
 		auto &block = *block_entry.second;
@@ -95,7 +100,7 @@ void ExternalFileCache::ReindexCachedFileCore(CachedFile &cached_file, idx_t fil
 		}
 		auto pin = buffer_manager.Pin(block.block_handle);
 		if (pin.IsValid()) {
-			pinned.emplace(old_idx, make_pair(std::move(pin), block.nr_bytes));
+			pinned.emplace(old_idx, PinnedBlock {std::move(pin), block.buffer_offset, block.nr_bytes});
 		}
 	}
 
@@ -116,7 +121,7 @@ void ExternalFileCache::ReindexCachedFileCore(CachedFile &cached_file, idx_t fil
 		idx_t expected_idx = it->first;
 		auto run_end = it;
 		while (run_end != pinned.end() && run_end->first == expected_idx) {
-			run_byte_end = run_end->first * old_block_size + run_end->second.second;
+			run_byte_end = run_end->first * old_block_size + run_end->second.nr_bytes;
 			expected_idx++;
 			++run_end;
 		}
@@ -143,22 +148,24 @@ void ExternalFileCache::ReindexCachedFileCore(CachedFile &cached_file, idx_t fil
 				auto &old_entry = pinned.at(oi);
 				const idx_t oi_file_start = oi * old_block_size;
 				const idx_t copy_start = MaxValue(new_start, oi_file_start);
-				const idx_t copy_end = MinValue(new_end, oi_file_start + old_entry.second);
+				const idx_t copy_end = MinValue(new_end, oi_file_start + old_entry.nr_bytes);
 				if (copy_start >= copy_end) {
 					continue;
 				}
 				memcpy(buf.GetDataMutable() + (copy_start - new_start),
-				       old_entry.first.Ptr() + (copy_start - oi_file_start), copy_end - copy_start);
+				       old_entry.handle.Ptr() + old_entry.buffer_offset + (copy_start - oi_file_start),
+				       copy_end - copy_start);
 			}
 
 			auto new_block = make_shared_ptr<CacheBlock>();
 			{
 				const annotated_lock_guard<annotated_mutex> block_guard(new_block->mtx);
 				new_block->block_handle = buf.GetBlockHandle();
+				new_block->buffer_offset = 0;
 				new_block->nr_bytes = new_size;
 				new_block->state = CacheBlockState::LOADED;
 #ifdef DEBUG
-				new_block->checksum = Checksum(buf.Ptr(), new_size);
+				new_block->checksum = Hash(const_char_ptr_cast(buf.Ptr()), new_size);
 #endif
 			}
 			new_blocks[new_idx] = std::move(new_block);

--- a/test/common/test_external_file_cache.cpp
+++ b/test/common/test_external_file_cache.cpp
@@ -19,6 +19,26 @@ using EFCTestFileGuard = CachingTestFileGuard;
 using EFCTrackingFileSystem = SimpleTrackingFileSystem;
 using EFCNoMetadataFileSystem = NoValidationMetadataFileSystem;
 
+class EFCSuffixFileSystem : public SimpleTrackingFileSystem {
+public:
+	void Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override {
+		positional_reads++;
+		LocalFileSystem::Read(handle, buffer, nr_bytes, location);
+	}
+
+	bool TryReadSuffix(FileHandle &handle, data_ptr_t buffer, idx_t buffer_len, SuffixReadResult &result) override {
+		suffix_read_size = buffer_len;
+		result.file_size = NumericCast<idx_t>(LocalFileSystem::GetFileSize(handle));
+		result.bytes_read = MinValue(buffer_len, result.file_size);
+		result.start_offset = result.file_size - result.bytes_read;
+		LocalFileSystem::Read(handle, buffer, NumericCast<int64_t>(result.bytes_read), result.start_offset);
+		return true;
+	}
+
+	idx_t suffix_read_size = 0;
+	idx_t positional_reads = 0;
+};
+
 OpenFileInfo MakeTestOpenFileInfo(const string &path) {
 	OpenFileInfo info(path);
 	info.extended_info = make_shared_ptr<ExtendedOpenFileInfo>();
@@ -373,6 +393,44 @@ TEST_CASE("Re-enabled external file cache refreshes deferred live handle metadat
 	cache.SetEnabled(true);
 	REQUIRE(handle->GetFileSize() == content_b.size());
 	REQUIRE(cache.GetCachedFileCount() == 1);
+}
+
+TEST_CASE("Suffix reads cache the aligned final block", "[external_file_cache]") {
+	DuckDB db = MakeCacheLocalFilesDB();
+	auto &db_instance = *db.instance;
+	auto &cache = db_instance.GetExternalFileCache();
+
+	constexpr idx_t BLOCK_SIZE = 16384;
+	constexpr idx_t REQUEST_SIZE = 4096;
+	constexpr idx_t FINAL_BLOCK_SIZE = 12288;
+	constexpr idx_t FILE_SIZE = BLOCK_SIZE * 2 + FINAL_BLOCK_SIZE;
+	const auto content = MakeTestContent(FILE_SIZE);
+	EFCTestFileGuard test_file("test_efc_suffix_block.bin", content);
+
+	Connection con(db);
+	con.Query(StringUtil::Format("SET external_file_cache_local_block_size=%llu", BLOCK_SIZE));
+
+	auto suffix_fs = make_uniq<EFCSuffixFileSystem>();
+	auto suffix_fs_ptr = suffix_fs.get();
+	CachingFileSystem cfs(*suffix_fs, db_instance);
+	auto handle = cfs.OpenFile(MakeTestOpenFileInfo(test_file.GetPath()), FileFlags::FILE_FLAGS_READ);
+
+	FileBufferHandleGroup suffix_data;
+	SuffixReadResult suffix_result;
+	REQUIRE(handle->TryReadSuffix(REQUEST_SIZE, suffix_data, suffix_result));
+	REQUIRE(suffix_fs_ptr->suffix_read_size == BLOCK_SIZE);
+	REQUIRE(suffix_result.bytes_read == REQUEST_SIZE);
+	REQUIRE(suffix_result.file_size == FILE_SIZE);
+	REQUIRE(suffix_result.start_offset == FILE_SIZE - REQUEST_SIZE);
+
+	string suffix(REQUEST_SIZE, '\0');
+	suffix_data.CopyTo(reinterpret_cast<data_ptr_t>(&suffix[0]), REQUEST_SIZE);
+	REQUIRE(suffix == content.substr(FILE_SIZE - REQUEST_SIZE));
+	REQUIRE(CountCachedBlocks(cache) == 1);
+	REQUIRE(TotalCachedBytes(cache) == FINAL_BLOCK_SIZE);
+
+	REQUIRE(ReadFull(*handle, FINAL_BLOCK_SIZE, BLOCK_SIZE * 2) == content.substr(BLOCK_SIZE * 2));
+	REQUIRE(suffix_fs_ptr->positional_reads == 0);
 }
 
 TEST_CASE("Concurrent SET and Read do not corrupt data or cache state", "[external_file_cache]") {

--- a/test/common/test_external_file_cache.cpp
+++ b/test/common/test_external_file_cache.cpp
@@ -33,6 +33,12 @@ OpenFileInfo MakeValidatingOpenFileInfo(const string &path) {
 	return info;
 }
 
+OpenFileInfo MakeDeferredTestOpenFileInfo(const string &path) {
+	auto info = MakeTestOpenFileInfo(path);
+	info.extended_info->options["defer_file_info"] = Value::BOOLEAN(true);
+	return info;
+}
+
 string MakeTestContent(idx_t size) {
 	string content(size, '\0');
 	for (idx_t i = 0; i < size; i++) {
@@ -332,6 +338,31 @@ TEST_CASE("Re-enabled external file cache refreshes live handle metadata", "[ext
 	CachingFileSystem cfs(*tracking_fs, db_instance);
 
 	auto handle = cfs.OpenFile(MakeTestOpenFileInfo(test_file.GetPath()), FileFlags::FILE_FLAGS_READ);
+	REQUIRE(handle->GetFileSize() == content_a.size());
+	REQUIRE(cache.GetCachedFileCount() == 1);
+
+	cache.SetEnabled(false);
+	REQUIRE(cache.GetCachedFileCount() == 0);
+	WriteTestContent(test_file.GetPath(), content_b);
+
+	cache.SetEnabled(true);
+	REQUIRE(handle->GetFileSize() == content_b.size());
+	REQUIRE(cache.GetCachedFileCount() == 1);
+}
+
+TEST_CASE("Re-enabled external file cache refreshes deferred live handle metadata", "[external_file_cache]") {
+	DuckDB db = MakeCacheLocalFilesDB();
+	auto &db_instance = *db.instance;
+	auto &cache = db_instance.GetExternalFileCache();
+
+	const string content_a(64, 'A');
+	const string content_b(128, 'B');
+	EFCTestFileGuard test_file("test_efc_reenabled_deferred_live_handle_metadata.bin", content_a);
+
+	auto tracking_fs = make_uniq<EFCTrackingFileSystem>();
+	CachingFileSystem cfs(*tracking_fs, db_instance);
+
+	auto handle = cfs.OpenFile(MakeDeferredTestOpenFileInfo(test_file.GetPath()), FileFlags::FILE_FLAGS_READ);
 	REQUIRE(handle->GetFileSize() == content_a.size());
 	REQUIRE(cache.GetCachedFileCount() == 1);
 

--- a/test/extension/debug_fs/debug_file_system.cpp
+++ b/test/extension/debug_fs/debug_file_system.cpp
@@ -124,6 +124,12 @@ int64_t DebugFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes
 	return inner.file_system.Read(inner, buffer, nr_bytes);
 }
 
+bool DebugFileSystem::TryReadSuffix(FileHandle &handle, data_ptr_t buffer, idx_t buffer_len, SuffixReadResult &result) {
+	ApplyDelay();
+	auto &inner = *handle.Cast<DebugFileHandle>().inner;
+	return inner.file_system.TryReadSuffix(inner, buffer, buffer_len, result);
+}
+
 void DebugFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
 	ApplyDelay();
 	auto &inner = *handle.Cast<DebugFileHandle>().inner;

--- a/test/extension/debug_fs/include/debug_file_system.hpp
+++ b/test/extension/debug_fs/include/debug_file_system.hpp
@@ -41,6 +41,7 @@ public:
 
 	void Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override;
 	int64_t Read(FileHandle &handle, void *buffer, int64_t nr_bytes) override;
+	bool TryReadSuffix(FileHandle &handle, data_ptr_t buffer, idx_t buffer_len, SuffixReadResult &result) override;
 	void Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override;
 	int64_t Write(FileHandle &handle, void *buffer, int64_t nr_bytes) override;
 

--- a/test/sql/copy/parquet/parquet_suffix_range_httpfs.test
+++ b/test/sql/copy/parquet/parquet_suffix_range_httpfs.test
@@ -1,0 +1,16 @@
+# name: test/sql/copy/parquet/parquet_suffix_range_httpfs.test
+# description: Test Parquet suffix reads with the non-validating external file cache
+# group: [parquet]
+
+require parquet
+
+require httpfs
+
+statement ok
+SET validate_external_file_cache='NO_VALIDATION';
+
+query I
+SELECT count(*)
+FROM 'https://blobs.duckdb.org/data/taxi_2019_04.parquet';
+----
+7433139


### PR DESCRIPTION
### Context

When duckdb wants to use a parquet file, it needs the parquet footer to parse its metadata.

In httpfs, we're doing three or more requests:
1. First, a HEAD to get the total file size.
2. Next, a GET to fetch the footer using a range request (based on file size).
3. `n` GET range requests for the parquet data.

### Remove one HTTP roundtrip

We can replace the first two HTTP requests with a suffix range GET request:
1. First, a suffix range request (`Range: bytes=-262144`).
2. `n` GET range requests for the parquet data.

The first ranged response contains these headers:
```http
HTTP/1.1 206 Partial Content
Accept-Ranges: bytes
Content-Range: bytes 1048576-1310719/1310720
Content-Length: 262144
ETag: "abc123"
Last-Modified: Mon, 27 Jul 2026 10:00:00 GMT
Content-Type: application/octet-stream
```
so we get the total size (from `Content-Range:`), and other headers used for caching (like `ETag`, `Last-Modified`).

### Follow up in httpfs

This PR adds support for a GET request with a suffix range.

After merging this PR to main, we can bump duckdb and open a PR in httpfs to enable the actual suffix range logic on duckdb main.


## Comparison

```sql
CALL enable_logging('HTTP', storage='memory');

.timer on

SELECT count(*)
FROM 'https://blobs.duckdb.org/data/taxi_2019_04.parquet'
WHERE pickup_at BETWEEN '2019-04-15' AND '2019-04-20';

WITH logs AS (
    SELECT *
    FROM duckdb_logs_parsed('HTTP')
), log_start AS (
    SELECT min(request.start_time) AS start_time
    FROM logs
)
SELECT
    round(epoch(request.start_time) - epoch(log_start.start_time), 3) AS start_sec,
    request.type AS method,
    map_extract_value(request.headers, 'Range') AS range_header,
    response.status,
    map_extract_value(response.headers, 'Content-Length') AS content_length,
    request.duration_ms,
    left(request.url, 80) AS url
FROM logs, log_start
ORDER BY request.start_time;
```

### Before

We see one HEAD and one GET requests before the GET range request start at 0.302 sec:

```
┌───────────┬─────────┬───────────────────────────┬────────────────────┬────────────────┬─────────────┬────────────────────────────────────────────────────┐
│ start_sec │ method  │       range_header        │       status       │ content_length │ duration_ms │                        url                         │
│  double   │ varchar │          varchar          │      varchar       │    varchar     │    int64    │                      varchar                       │
├───────────┼─────────┼───────────────────────────┼────────────────────┼────────────────┼─────────────┼────────────────────────────────────────────────────┤
│       0.0 │ HEAD    │ NULL                      │ OK_200             │ 127056503      │         157 │ https://blobs.duckdb.org/data/taxi_2019_04.parquet │
│     0.158 │ GET     │ bytes=125829120-127056502 │ PartialContent_206 │ 1227383        │         136 │ https://blobs.duckdb.org/data/taxi_2019_04.parquet │
│     0.302 │ GET     │ bytes=65011712-67108863   │ PartialContent_206 │ 2097152        │         237 │ https://blobs.duckdb.org/data/taxi_2019_04.parquet │
...
```

Query Run Time (s): `real 1.819 user 0.339818 sys 0.338461`.

<details>
<summary>Full results</summary>

```
$ ./build/release/duckdb -f ../demos/taxi.sql 
┌────────────────┐
│  count_star()  │
│     int64      │
├────────────────┤
│    1276565     │
│ (1.28 million) │
└────────────────┘
Run Time (s): real 1.819 user 0.339818 sys 0.338461
┌───────────┬─────────┬───────────────────────────┬────────────────────┬────────────────┬─────────────┬────────────────────────────────────────────────────┐
│ start_sec │ method  │       range_header        │       status       │ content_length │ duration_ms │                        url                         │
│  double   │ varchar │          varchar          │      varchar       │    varchar     │    int64    │                      varchar                       │
├───────────┼─────────┼───────────────────────────┼────────────────────┼────────────────┼─────────────┼────────────────────────────────────────────────────┤
│       0.0 │ HEAD    │ NULL                      │ OK_200             │ 127056503      │         157 │ https://blobs.duckdb.org/data/taxi_2019_04.parquet │
│     0.158 │ GET     │ bytes=125829120-127056502 │ PartialContent_206 │ 1227383        │         136 │ https://blobs.duckdb.org/data/taxi_2019_04.parquet │
│     0.302 │ GET     │ bytes=65011712-67108863   │ PartialContent_206 │ 2097152        │         237 │ https://blobs.duckdb.org/data/taxi_2019_04.parquet │
│     0.302 │ GET     │ bytes=60817408-62914559   │ PartialContent_206 │ 2097152        │        1440 │ https://blobs.duckdb.org/data/taxi_2019_04.parquet │
│     0.302 │ GET     │ bytes=69206016-71303167   │ PartialContent_206 │ 2097152        │         931 │ https://blobs.duckdb.org/data/taxi_2019_04.parquet │
│     0.302 │ GET     │ bytes=71303168-73400319   │ PartialContent_206 │ 2097152        │        1049 │ https://blobs.duckdb.org/data/taxi_2019_04.parquet │
│     0.302 │ GET     │ bytes=73400320-75497471   │ PartialContent_206 │ 2097152        │         852 │ https://blobs.duckdb.org/data/taxi_2019_04.parquet │
│     0.302 │ GET     │ bytes=75497472-77594623   │ PartialContent_206 │ 2097152        │        1356 │ https://blobs.duckdb.org/data/taxi_2019_04.parquet │
│     0.302 │ GET     │ bytes=79691776-81788927   │ PartialContent_206 │ 2097152        │        1192 │ https://blobs.duckdb.org/data/taxi_2019_04.parquet │
│     0.302 │ GET     │ bytes=62914560-65011711   │ PartialContent_206 │ 2097152        │        1347 │ https://blobs.duckdb.org/data/taxi_2019_04.parquet │
│     0.302 │ GET     │ bytes=67108864-69206015   │ PartialContent_206 │ 2097152        │        1025 │ https://blobs.duckdb.org/data/taxi_2019_04.parquet │
│     0.302 │ GET     │ bytes=83886080-85983231   │ PartialContent_206 │ 2097152        │         852 │ https://blobs.duckdb.org/data/taxi_2019_04.parquet │
│     0.302 │ GET     │ bytes=46137344-48234495   │ PartialContent_206 │ 2097152        │        1038 │ https://blobs.duckdb.org/data/taxi_2019_04.parquet │
│     0.302 │ GET     │ bytes=85983232-88080383   │ PartialContent_206 │ 2097152        │        1277 │ https://blobs.duckdb.org/data/taxi_2019_04.parquet │
│     0.302 │ GET     │ bytes=92274688-94371839   │ PartialContent_206 │ 2097152        │        1051 │ https://blobs.duckdb.org/data/taxi_2019_04.parquet │
│     0.302 │ GET     │ bytes=102760448-104857599 │ PartialContent_206 │ 2097152        │        1194 │ https://blobs.duckdb.org/data/taxi_2019_04.parquet │
│     0.302 │ GET     │ bytes=96468992-98566143   │ PartialContent_206 │ 2097152        │        1264 │ https://blobs.duckdb.org/data/taxi_2019_04.parquet │
│     0.302 │ GET     │ bytes=98566144-100663295  │ PartialContent_206 │ 2097152        │        1171 │ https://blobs.duckdb.org/data/taxi_2019_04.parquet │
│     0.302 │ GET     │ bytes=104857600-106954751 │ PartialContent_206 │ 2097152        │        1354 │ https://blobs.duckdb.org/data/taxi_2019_04.parquet │
│     0.302 │ GET     │ bytes=111149056-113246207 │ PartialContent_206 │ 2097152        │        1114 │ https://blobs.duckdb.org/data/taxi_2019_04.parquet │
│     0.302 │ GET     │ bytes=106954752-109051903 │ PartialContent_206 │ 2097152        │        1498 │ https://blobs.duckdb.org/data/taxi_2019_04.parquet │
│     0.302 │ GET     │ bytes=113246208-115343359 │ PartialContent_206 │ 2097152        │        1201 │ https://blobs.duckdb.org/data/taxi_2019_04.parquet │
│     0.302 │ GET     │ bytes=115343360-117440511 │ PartialContent_206 │ 2097152        │        1336 │ https://blobs.duckdb.org/data/taxi_2019_04.parquet │
│     0.302 │ GET     │ bytes=58720256-60817407   │ PartialContent_206 │ 2097152        │        1510 │ https://blobs.duckdb.org/data/taxi_2019_04.parquet │
│     0.302 │ GET     │ bytes=77594624-79691775   │ PartialContent_206 │ 2097152        │        1336 │ https://blobs.duckdb.org/data/taxi_2019_04.parquet │
│     0.302 │ GET     │ bytes=123731968-125829119 │ PartialContent_206 │ 2097152        │         960 │ https://blobs.duckdb.org/data/taxi_2019_04.parquet │
│     0.302 │ GET     │ bytes=48234496-50331647   │ PartialContent_206 │ 2097152        │        1151 │ https://blobs.duckdb.org/data/taxi_2019_04.parquet │
│     0.302 │ GET     │ bytes=81788928-83886079   │ PartialContent_206 │ 2097152        │        1035 │ https://blobs.duckdb.org/data/taxi_2019_04.parquet │
│     0.302 │ GET     │ bytes=94371840-96468991   │ PartialContent_206 │ 2097152        │        1010 │ https://blobs.duckdb.org/data/taxi_2019_04.parquet │
└───────────┴─────────┴───────────────────────────┴────────────────────┴────────────────┴─────────────┴────────────────────────────────────────────────────┘
  29 rows                                                                                                                                        7 columns
```
</details>

### After

We see one GET request before the GET range request start at 0.202 sec:

```
┌───────────┬─────────┬───────────────────────────┬────────────────────┬────────────────┬─────────────┬────────────────────────────────────────────────────┐
│ start_sec │ method  │       range_header        │       status       │ content_length │ duration_ms │                        url                         │
│  double   │ varchar │          varchar          │      varchar       │    varchar     │    int64    │                      varchar                       │
├───────────┼─────────┼───────────────────────────┼────────────────────┼────────────────┼─────────────┼────────────────────────────────────────────────────┤
│       0.0 │ GET     │ bytes=-262144             │ PartialContent_206 │ 262144         │         197 │ https://blobs.duckdb.org/data/taxi_2019_04.parquet │
│     0.202 │ GET     │ bytes=58720256-60817407   │ PartialContent_206 │ 2097152        │         145 │ https://blobs.duckdb.org/data/taxi_2019_04.parquet │
...
```

Query Run Time (s): `real 1.727 user 0.321981 sys 0.417187`

<details>
<summary>Full results</summary>

```
$ ./build/release/duckdb -f ../demos/taxi.sql 
┌────────────────┐
│  count_star()  │
│     int64      │
├────────────────┤
│    1276565     │
│ (1.28 million) │
└────────────────┘
Run Time (s): real 1.727 user 0.321981 sys 0.417187
┌───────────┬─────────┬───────────────────────────┬────────────────────┬────────────────┬─────────────┬────────────────────────────────────────────────────┐
│ start_sec │ method  │       range_header        │       status       │ content_length │ duration_ms │                        url                         │
│  double   │ varchar │          varchar          │      varchar       │    varchar     │    int64    │                      varchar                       │
├───────────┼─────────┼───────────────────────────┼────────────────────┼────────────────┼─────────────┼────────────────────────────────────────────────────┤
│       0.0 │ GET     │ bytes=-262144             │ PartialContent_206 │ 262144         │         197 │ https://blobs.duckdb.org/data/taxi_2019_04.parquet │
│     0.202 │ GET     │ bytes=58720256-60817407   │ PartialContent_206 │ 2097152        │         145 │ https://blobs.duckdb.org/data/taxi_2019_04.parquet │
│     0.202 │ GET     │ bytes=60817408-62914559   │ PartialContent_206 │ 2097152        │         588 │ https://blobs.duckdb.org/data/taxi_2019_04.parquet │
│     0.202 │ GET     │ bytes=46137344-48234495   │ PartialContent_206 │ 2097152        │        1304 │ https://blobs.duckdb.org/data/taxi_2019_04.parquet │
│     0.202 │ GET     │ bytes=62914560-65011711   │ PartialContent_206 │ 2097152        │        1126 │ https://blobs.duckdb.org/data/taxi_2019_04.parquet │
│     0.202 │ GET     │ bytes=67108864-69206015   │ PartialContent_206 │ 2097152        │        1332 │ https://blobs.duckdb.org/data/taxi_2019_04.parquet │
│     0.202 │ GET     │ bytes=65011712-67108863   │ PartialContent_206 │ 2097152        │        1383 │ https://blobs.duckdb.org/data/taxi_2019_04.parquet │
│     0.202 │ GET     │ bytes=71303168-73400319   │ PartialContent_206 │ 2097152        │        1160 │ https://blobs.duckdb.org/data/taxi_2019_04.parquet │
│     0.202 │ GET     │ bytes=73400320-75497471   │ PartialContent_206 │ 2097152        │        1302 │ https://blobs.duckdb.org/data/taxi_2019_04.parquet │
│     0.202 │ GET     │ bytes=75497472-77594623   │ PartialContent_206 │ 2097152        │        1266 │ https://blobs.duckdb.org/data/taxi_2019_04.parquet │
│     0.202 │ GET     │ bytes=77594624-79691775   │ PartialContent_206 │ 2097152        │        1220 │ https://blobs.duckdb.org/data/taxi_2019_04.parquet │
│     0.202 │ GET     │ bytes=83886080-85983231   │ PartialContent_206 │ 2097152        │        1393 │ https://blobs.duckdb.org/data/taxi_2019_04.parquet │
│     0.202 │ GET     │ bytes=79691776-81788927   │ PartialContent_206 │ 2097152        │        1366 │ https://blobs.duckdb.org/data/taxi_2019_04.parquet │
│     0.202 │ GET     │ bytes=85983232-88080383   │ PartialContent_206 │ 2097152        │        1416 │ https://blobs.duckdb.org/data/taxi_2019_04.parquet │
│     0.202 │ GET     │ bytes=69206016-71303167   │ PartialContent_206 │ 2097152        │        1237 │ https://blobs.duckdb.org/data/taxi_2019_04.parquet │
│     0.202 │ GET     │ bytes=94371840-96468991   │ PartialContent_206 │ 2097152        │        1456 │ https://blobs.duckdb.org/data/taxi_2019_04.parquet │
│     0.202 │ GET     │ bytes=96468992-98566143   │ PartialContent_206 │ 2097152        │        1484 │ https://blobs.duckdb.org/data/taxi_2019_04.parquet │
│     0.202 │ GET     │ bytes=48234496-50331647   │ PartialContent_206 │ 2097152        │         402 │ https://blobs.duckdb.org/data/taxi_2019_04.parquet │
│     0.202 │ GET     │ bytes=81788928-83886079   │ PartialContent_206 │ 2097152        │        1518 │ https://blobs.duckdb.org/data/taxi_2019_04.parquet │
│     0.202 │ GET     │ bytes=92274688-94371839   │ PartialContent_206 │ 2097152        │         834 │ https://blobs.duckdb.org/data/taxi_2019_04.parquet │
│     0.202 │ GET     │ bytes=104857600-106954751 │ PartialContent_206 │ 2097152        │        1392 │ https://blobs.duckdb.org/data/taxi_2019_04.parquet │
│     0.202 │ GET     │ bytes=106954752-109051903 │ PartialContent_206 │ 2097152        │         813 │ https://blobs.duckdb.org/data/taxi_2019_04.parquet │
│     0.202 │ GET     │ bytes=111149056-113246207 │ PartialContent_206 │ 2097152        │        1402 │ https://blobs.duckdb.org/data/taxi_2019_04.parquet │
│     0.203 │ GET     │ bytes=123731968-125829119 │ PartialContent_206 │ 2097152        │         771 │ https://blobs.duckdb.org/data/taxi_2019_04.parquet │
│     0.203 │ GET     │ bytes=102760448-104857599 │ PartialContent_206 │ 2097152        │        1382 │ https://blobs.duckdb.org/data/taxi_2019_04.parquet │
│     0.203 │ GET     │ bytes=115343360-117440511 │ PartialContent_206 │ 2097152        │        1286 │ https://blobs.duckdb.org/data/taxi_2019_04.parquet │
│     0.203 │ GET     │ bytes=113246208-115343359 │ PartialContent_206 │ 2097152        │        1339 │ https://blobs.duckdb.org/data/taxi_2019_04.parquet │
│     0.203 │ GET     │ bytes=98566144-100663295  │ PartialContent_206 │ 2097152        │         818 │ https://blobs.duckdb.org/data/taxi_2019_04.parquet │
└───────────┴─────────┴───────────────────────────┴────────────────────┴────────────────┴─────────────┴────────────────────────────────────────────────────┘
  28 rows                                                                                                                                        7 columns
```
</details>
