### PR TITLE
Prune map extraction row group

### DIFF
--- a/extension/core_functions/scalar/map/map_extract.cpp
+++ b/extension/core_functions/scalar/map/map_extract.cpp
@@ -4,6 +4,8 @@
 #include "duckdb/function/scalar/list/contains_or_position.hpp"
 #include "duckdb/function/scalar/nested_functions.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "duckdb/storage/statistics/list_stats.hpp"
+#include "duckdb/storage/statistics/struct_stats.hpp"
 
 namespace duckdb {
 
@@ -95,11 +97,20 @@ static void MapExtractListFunc(DataChunk &args, ExpressionState &state, Vector &
 	}
 }
 
+static unique_ptr<BaseStatistics> MapExtractValueStats(ClientContext &, FunctionStatisticsInput &input) {
+	auto &entry_stats = ListStats::GetChildStats(input.child_stats[0]);
+	auto value_copy = StructStats::GetChildStats(entry_stats, 1).Copy();
+	// missing keys return NULL
+	value_copy.Set(StatsInfo::CAN_HAVE_NULL_VALUES);
+	return value_copy.ToUnique();
+}
+
 ScalarFunction MapExtractValueFun::GetFunction() {
 	auto key_type = LogicalType::TEMPLATE("K");
 	auto val_type = LogicalType::TEMPLATE("V");
 
 	ScalarFunction fun({LogicalType::MAP(key_type, val_type), key_type}, val_type, MapExtractValueFunc);
+	fun.SetStatisticsCallback(MapExtractValueStats);
 	fun.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 	return fun;
 }

--- a/extension/parquet/parquet_statistics.cpp
+++ b/extension/parquet/parquet_statistics.cpp
@@ -611,13 +611,13 @@ unique_ptr<BaseStatistics> ParquetStatisticsUtils::TransformColumnStatistics(con
                                                                              bool can_have_nan) {
 	// Not supported types
 	auto &type = schema.type;
-	if (type.id() == LogicalTypeId::ARRAY || type.id() == LogicalTypeId::MAP) {
+	if (type.id() == LogicalTypeId::ARRAY) {
 		return nullptr;
 	}
 
 	unique_ptr<BaseStatistics> row_group_stats;
 
-	if (type.id() == LogicalTypeId::LIST) {
+	if (type.id() == LogicalTypeId::LIST || type.id() == LogicalTypeId::MAP) {
 		auto list_stats = ListStats::CreateUnknown(type);
 		auto &child_schema = schema.children[0];
 		auto child_stats = ParquetStatisticsUtils::TransformColumnStatistics(child_schema, columns, can_have_nan);

--- a/test/configs/disable_optimizer.json
+++ b/test/configs/disable_optimizer.json
@@ -15,6 +15,8 @@
       "paths": [
         "test/sql/optimizer/nested_null_segment_pruning.test",
         "test/sql/optimizer/struct_segment_pruning.test",
+        "test/sql/optimizer/map_extract_row_group_pruning.test",
+        "test/sql/copy/parquet/map_extract_row_group_pruning.test",
         "test/sql/pragma/profiling/test_custom_profiling_row_group_metrics_local_storage.test",
         "test/sql/types/geo/geometry_parquet_pushdown.test",
         "test/optimizer/statistics/statistics_filter_pruning.test",

--- a/test/sql/copy/parquet/map_extract_row_group_pruning.test
+++ b/test/sql/copy/parquet/map_extract_row_group_pruning.test
@@ -1,0 +1,20 @@
+# name: test/sql/copy/parquet/map_extract_row_group_pruning.test
+# description: Parquet map value extracts use value-field statistics for row-group pruning
+# group: [parquet]
+
+require parquet
+
+statement ok
+COPY (SELECT MAP {'k': i} AS m FROM range(6144) t(i))
+TO '{TEST_DIR}/map_extract_row_group_pruning.parquet' (FORMAT PARQUET, ROW_GROUP_SIZE 2048);
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM '{TEST_DIR}/map_extract_row_group_pruning.parquet'
+WHERE m['k'] BETWEEN 2900 AND 3100;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
+
+query I
+SELECT count(*) FROM '{TEST_DIR}/map_extract_row_group_pruning.parquet' WHERE m['k'] BETWEEN 2900 AND 3100;
+----
+201

--- a/test/sql/optimizer/map_extract_row_group_pruning.test
+++ b/test/sql/optimizer/map_extract_row_group_pruning.test
@@ -1,0 +1,29 @@
+# name: test/sql/optimizer/map_extract_row_group_pruning.test
+# description: Map value extracts use value-field statistics for row-group pruning
+# group: [optimizer]
+
+statement ok
+ATTACH '{TEST_DIR}/map_extract_row_group_pruning.duckdb' AS db (ROW_GROUP_SIZE 2048);
+
+statement ok
+USE db;
+
+statement ok
+CREATE TABLE maps AS
+SELECT MAP {'k': i} AS m
+FROM range(6144) tbl(i);
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM maps WHERE m['k'] BETWEEN 2900 AND 3100;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
+
+query I
+SELECT count(*) FROM maps WHERE m['k'] BETWEEN 2900 AND 3100;
+----
+201
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM maps WHERE map_extract_value(m, 'k') BETWEEN 2900 AND 3100;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*


### PR DESCRIPTION
Hi team, I found for map operation, stats are not fully leveraged to prune row groups, for both DuckDB native format and parquet.
```sql
-- should access only one row group
memory D CREATE TABLE mymaps AS
         SELECT MAP {'k': i} AS m
         FROM range(122880 * 3) tbl(i);
memory D EXPLAIN ANALYZE SELECT count(*) FROM mymaps WHERE m['k'] BETWEEN 2900 AND 3100;
╭─ Summary ───────────╮
│ Total Time: 0.0047s │
╰─────────────────────╯
╭─ Ungrouped Aggregate ───────────────────────────╮
│ 1 row                                       0µs │
╰────────────────────────┒┎───────────────────────╯
╭─ Table Scan ───────────┚┖───────────────────────╮
│ Table: memory.main.mymaps                       │
│ Type: Sequential Scan                           │
│ Filters:                                        │
│ map_extract_value(m, 'k') BETWEEN 2900 AND 3100 │
│ Row Groups Scanned: 3 / 3                       │
│ 201 rows                                 10.0ms │
╰─────────────────────────────────────────────────╯

-- should access only one row group
memory D COPY (SELECT MAP {'k': i} AS m FROM range(6144) t(i))
           TO '/tmp/pd_map.parquet' (FORMAT PARQUET, ROW_GROUP_SIZE 2048);
memory D EXPLAIN ANALYZE SELECT count(*) FROM '/tmp/pd_map.parquet'
         WHERE m['k'] BETWEEN 2900 AND 3100;
╭─ Summary ───────────╮
│ Total Time: 0.0052s │
│ Data Read:  41.2 kB │
╰─────────────────────╯
╭─ Ungrouped Aggregate ───────────────────────────╮
│ Aggregates: count_star()                        │
│ 1 row                                       0µs │
╰────────────────────────┒┎───────────────────────╯
╭─ Table Scan ───────────┚┖───────────────────────╮
│ Function: PARQUET_SCAN                          │
│ Filters:                                        │
│ map_extract_value(m, 'k') BETWEEN 2900 AND 3100 │
│ Total Files Read: 1                             │
│ Filename(s): /tmp/pd_map.parquet                │
│ Row Groups Scanned: 3 / 3                       │
│ 201 rows                                    0µs │
╰─────────────────────────────────────────────────╯
```
In this PR, I made two changes:
- Propagate parquet stats -- DuckDB treats map list<struct<key, value>> -- so we handle it as the same way as list type; DuckDB native format already has the stats 
- Implement the stats callback for map value extraction function, so it expression filter could leverage the value min/max to prune
