### PR TITLE
Remove default database

### DIFF
--- a/.github/patches/extensions/bwc-test-utils/0001-default-database.patch
+++ b/.github/patches/extensions/bwc-test-utils/0001-default-database.patch
@@ -1,0 +1,100 @@
+commit ecd65bf3bcaac3ec2672cc79465934f2c189bd6f
+Author: dentinyhao <dentinyhao@gmail.com>
+Date:   Tue Aug 18 02:47:18 2026 -0700
+
+    Patch default database changes
+
+diff --git a/src/utils/misc.cpp b/src/utils/misc.cpp
+index 87f610c..ca1372c 100644
+--- a/src/utils/misc.cpp
++++ b/src/utils/misc.cpp
+@@ -3,6 +3,7 @@
+ #include <duckdb/common/types/uuid.hpp>
+ #include <duckdb/main/attached_database.hpp>
+ #include <duckdb/main/database_manager.hpp>
++#include <duckdb/parser/keyword_helper.hpp>
+ #include <duckdb/parser/parsed_data/transaction_info.hpp>
+ #include <duckdb/transaction/meta_transaction.hpp>
+ 
+@@ -11,6 +12,13 @@
+ 
+ namespace duckdb {
+ 
++static void UseDatabase(Connection &con, const string &db_name) {
++	auto result = con.Query("USE " + KeywordHelper::WriteOptionallyQuoted(db_name));
++	if (result->HasError()) {
++		result->ThrowError();
++	}
++}
++
+ void UseDBAndDetachOthers(Connection &con, const std::string &db_name, bool need_tx) {
+ 	auto &db_manager = DatabaseManager::Get(*con.context);
+ 
+@@ -19,7 +27,7 @@ void UseDBAndDetachOthers(Connection &con, const std::string &db_name, bool need
+ 	}
+ 
+ 	// First "USE" the desired database
+-	db_manager.SetDefaultDatabase(*con.context, db_name);
++	UseDatabase(con, db_name);
+ 
+ 	auto databases = db_manager.GetDatabases(*con.context);
+ 	for (auto &db : databases) {
+@@ -59,36 +67,27 @@ void DetachAllDatabases(ClientContext &context) {
+ 
+ 	// First, ensure 'memory' is the current default database
+ 	auto current_default_db = db_manager.GetDefaultDatabase(context);
+-	if (current_default_db != "memory") {
+-		Connection con(*context.db);
+-
+-		bool memory_attached = IsMemoryAttached(con);
+-		LOG_DEBUG("Current default database is '" << current_default_db << "'. Memory attached: " << memory_attached);
++	Connection con(*context.db);
+ 
+-		if (!memory_attached) {
+-			LOG_DEBUG("Attaching in-memory database 'memory' to switch default database.");
+-			auto res = con.Query("ATTACH ':memory:';");
+-			if (res->HasError()) {
+-				res->ThrowError();
+-			}
++	bool memory_attached = IsMemoryAttached(con);
++	LOG_DEBUG("Current default database is '" << current_default_db << "'. Memory attached: " << memory_attached);
+ 
+-			LOG_DEBUG("Successfully attached in-memory database 'memory'.");
+-		} else {
+-			LOG_DEBUG("In-memory database 'memory' is already attached.");
+-		}
+-		{
+-			auto res = con.Query("USE memory;");
+-			if (res->HasError()) {
+-				res->ThrowError();
+-			}
++	if (!memory_attached) {
++		LOG_DEBUG("Attaching in-memory database 'memory' to switch default database.");
++		auto res = con.Query("ATTACH ':memory:';");
++		if (res->HasError()) {
++			res->ThrowError();
+ 		}
+ 
+-		db_manager.SetDefaultDatabase(context, "memory");
++		LOG_DEBUG("Successfully attached in-memory database 'memory'.");
++	} else {
++		LOG_DEBUG("In-memory database 'memory' is already attached.");
+ 	}
++	UseDatabase(con, "memory");
+ 
+ 	LOG_DEBUG("Detaching all databases...");
+ 	// Detach all databases attached during the query
+-	auto databases = db_manager.GetDatabases(context);
++	auto databases = db_manager.GetDatabases(*con.context);
+ 	for (auto &db : databases) {
+ #if DUCKDB_VERSION_AT_MOST(1, 3, 2)
+ 		auto &db_instance = db.get();
+@@ -101,7 +100,7 @@ void DetachAllDatabases(ClientContext &context) {
+ 		}
+ 
+ 		LOG_DEBUG("Detaching database '" << name << "'");
+-		db_manager.DetachDatabase(context, name, OnEntryNotFound::THROW_EXCEPTION);
++		db_manager.DetachDatabase(*con.context, name, OnEntryNotFound::THROW_EXCEPTION);
+ 	}
+ }
+ 

--- a/.github/patches/extensions/test_utils/0004-remove-default-database.patch
+++ b/.github/patches/extensions/test_utils/0004-remove-default-database.patch
@@ -1,4 +1,11 @@
+commit ecd65bf3bcaac3ec2672cc79465934f2c189bd6f
+Author: dentinyhao <dentinyhao@gmail.com>
+Date:   Tue Aug 18 02:47:18 2026 -0700
+
+    Patch default database changes
+
 diff --git a/src/utils/misc.cpp b/src/utils/misc.cpp
+index 87f610c..ca1372c 100644
 --- a/src/utils/misc.cpp
 +++ b/src/utils/misc.cpp
 @@ -3,6 +3,7 @@
@@ -13,17 +20,17 @@ diff --git a/src/utils/misc.cpp b/src/utils/misc.cpp
  
  namespace duckdb {
  
-+static void UseDatabase(Connection &con, const Identifier &db_name) {
-+	auto result = con.Query("USE " + KeywordHelper::WriteOptionallyQuoted(db_name.GetIdentifierName()));
++static void UseDatabase(Connection &con, const string &db_name) {
++	auto result = con.Query("USE " + KeywordHelper::WriteOptionallyQuoted(db_name));
 +	if (result->HasError()) {
 +		result->ThrowError();
 +	}
 +}
 +
- void UseDBAndDetachOthers(Connection &con, const Identifier &db_name, bool need_tx) {
+ void UseDBAndDetachOthers(Connection &con, const std::string &db_name, bool need_tx) {
  	auto &db_manager = DatabaseManager::Get(*con.context);
  
-@@ -19,7 +27,7 @@ void UseDBAndDetachOthers(Connection &con, const Identifier &db_name, bool need_
+@@ -19,7 +27,7 @@ void UseDBAndDetachOthers(Connection &con, const std::string &db_name, bool need
  	}
  
  	// First "USE" the desired database

--- a/.github/patches/extensions/test_utils/0004-remove-default-database.patch
+++ b/.github/patches/extensions/test_utils/0004-remove-default-database.patch
@@ -1,11 +1,4 @@
-commit ecd65bf3bcaac3ec2672cc79465934f2c189bd6f
-Author: dentinyhao <dentinyhao@gmail.com>
-Date:   Tue Aug 18 02:47:18 2026 -0700
-
-    Patch default database changes
-
 diff --git a/src/utils/misc.cpp b/src/utils/misc.cpp
-index 87f610c..ca1372c 100644
 --- a/src/utils/misc.cpp
 +++ b/src/utils/misc.cpp
 @@ -3,6 +3,7 @@
@@ -20,17 +13,17 @@ index 87f610c..ca1372c 100644
  
  namespace duckdb {
  
-+static void UseDatabase(Connection &con, const string &db_name) {
-+	auto result = con.Query("USE " + KeywordHelper::WriteOptionallyQuoted(db_name));
++static void UseDatabase(Connection &con, const Identifier &db_name) {
++	auto result = con.Query("USE " + KeywordHelper::WriteOptionallyQuoted(db_name.GetIdentifierName()));
 +	if (result->HasError()) {
 +		result->ThrowError();
 +	}
 +}
 +
- void UseDBAndDetachOthers(Connection &con, const std::string &db_name, bool need_tx) {
+ void UseDBAndDetachOthers(Connection &con, const Identifier &db_name, bool need_tx) {
  	auto &db_manager = DatabaseManager::Get(*con.context);
  
-@@ -19,7 +27,7 @@ void UseDBAndDetachOthers(Connection &con, const std::string &db_name, bool need
+@@ -19,7 +27,7 @@ void UseDBAndDetachOthers(Connection &con, const Identifier &db_name, bool need_
  	}
  
  	// First "USE" the desired database

--- a/.github/patches/extensions/test_utils/0004-remove-default-database.patch
+++ b/.github/patches/extensions/test_utils/0004-remove-default-database.patch
@@ -1,11 +1,11 @@
-commit ecd65bf3bcaac3ec2672cc79465934f2c189bd6f
+commit dc66dd5cb36613b4a8a238fefc20b241a8761987
 Author: dentinyhao <dentinyhao@gmail.com>
-Date:   Tue Aug 18 02:47:18 2026 -0700
+Date:   Tue Aug 18 03:25:15 2026 -0700
 
     Patch default database changes
 
 diff --git a/src/utils/misc.cpp b/src/utils/misc.cpp
-index 87f610c..ca1372c 100644
+index 6f65b3f..fce9857 100644
 --- a/src/utils/misc.cpp
 +++ b/src/utils/misc.cpp
 @@ -3,6 +3,7 @@
@@ -20,17 +20,17 @@ index 87f610c..ca1372c 100644
  
  namespace duckdb {
  
-+static void UseDatabase(Connection &con, const string &db_name) {
-+	auto result = con.Query("USE " + KeywordHelper::WriteOptionallyQuoted(db_name));
++static void UseDatabase(Connection &con, const Identifier &db_name) {
++	auto result = con.Query("USE " + KeywordHelper::WriteOptionallyQuoted(db_name.GetIdentifierName()));
 +	if (result->HasError()) {
 +		result->ThrowError();
 +	}
 +}
 +
- void UseDBAndDetachOthers(Connection &con, const std::string &db_name, bool need_tx) {
+ void UseDBAndDetachOthers(Connection &con, const Identifier &db_name, bool need_tx) {
  	auto &db_manager = DatabaseManager::Get(*con.context);
  
-@@ -19,7 +27,7 @@ void UseDBAndDetachOthers(Connection &con, const std::string &db_name, bool need
+@@ -19,7 +27,7 @@ void UseDBAndDetachOthers(Connection &con, const Identifier &db_name, bool need_
  	}
  
  	// First "USE" the desired database

--- a/src/include/duckdb/main/database_manager.hpp
+++ b/src/include/duckdb/main/database_manager.hpp
@@ -64,7 +64,6 @@ public:
 	Catalog &GetSystemCatalog();
 
 	static Identifier GetDefaultDatabase(ClientContext &context);
-	void SetDefaultDatabase(ClientContext &context, const Identifier &new_value);
 
 	//! Inserts a path to name mapping to the database paths map
 	InsertDatabasePathResult InsertDatabasePath(const AttachInfo &info, AttachOptions &options);
@@ -104,8 +103,9 @@ public:
 	idx_t NextOid() {
 		return next_oid++;
 	}
-	bool HasDefaultDatabase() {
-		return !default_database.empty();
+	bool HasAttachedDatabase() {
+		lock_guard<mutex> guard(databases_lock);
+		return !databases.empty();
 	}
 	//! Gets a list of all attached database paths
 	vector<string> GetAttachedDatabasePaths();
@@ -132,8 +132,6 @@ private:
 	atomic<transaction_t> current_transaction_id;
 	//! Count of remote catalogs currently attached; used to skip the remote pushdown optimizer when zero
 	atomic<CheckedInteger<idx_t, InternalException>> remote_catalog_count;
-	//! The current default database
-	Identifier default_database;
 	//! Manager for ensuring we never open the same database file twice in the same program
 	shared_ptr<DatabaseFilePathManager> path_manager;
 

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -354,7 +354,7 @@ void DatabaseInstance::Initialize(const char *database_path, DBConfig *user_conf
 
 	LoadExtensionSettings();
 
-	if (!db_manager->HasDefaultDatabase()) {
+	if (!db_manager->HasAttachedDatabase()) {
 		CreateMainDatabase();
 	}
 

--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -417,6 +417,10 @@ Identifier DatabaseManager::GetDefaultDatabase(ClientContext &context) {
 		auto &manager = DatabaseManager::Get(context);
 		lock_guard<mutex> guard(manager.databases_lock);
 		if (manager.databases.empty()) {
+			auto modified_database = MetaTransaction::Get(context).ModifiedDatabase();
+			if (modified_database) {
+				return modified_database->GetName();
+			}
 			throw InternalException("Calling DatabaseManager::GetDefaultDatabase with no database attached");
 		}
 		// OIDs are assigned in attach order, so the oldest attached database is the default.

--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -206,10 +206,6 @@ shared_ptr<AttachedDatabase> DatabaseManager::AttachDatabase(ClientContext &cont
 	auto &db = DatabaseInstance::GetDatabase(context);
 	auto attached_db = db.CreateAttachedDatabase(context, info, options);
 
-	if (default_database.empty()) {
-		default_database = attached_db->GetName();
-	}
-
 	//! Initialize the database.
 	if (options.is_main_database) {
 		attached_db->SetInitialDatabase();
@@ -329,10 +325,6 @@ void DatabaseManager::RenameDatabase(ClientContext &context, const Identifier &o
 		attached_db->SetName(new_name);
 		databases[new_name] = attached_db;
 	}
-
-	if (old_name == default_database) {
-		default_database = new_name;
-	}
 }
 
 shared_ptr<AttachedDatabase> DatabaseManager::DetachInternal(const Identifier &name) {
@@ -345,9 +337,6 @@ shared_ptr<AttachedDatabase> DatabaseManager::DetachInternal(const Identifier &n
 		}
 		attached_db = std::move(entry->second);
 		databases.erase(entry);
-		if (name == default_database) {
-			default_database = databases.empty() ? Identifier() : databases.begin()->first;
-		}
 	}
 	if (attached_db && attached_db->GetCatalog().Supports(RemoteCapability::IS_REMOTE)) {
 		--remote_catalog_count;
@@ -425,30 +414,20 @@ Identifier DatabaseManager::GetDefaultDatabase(ClientContext &context) {
 	auto &config = ClientData::Get(context);
 	auto &default_entry = config.catalog_search_path->GetDefault();
 	if (IsInvalidCatalog(default_entry.GetCatalog())) {
-		auto &result = DatabaseManager::Get(context).default_database;
-		if (result.empty()) {
-			throw InternalException("Calling DatabaseManager::GetDefaultDatabase with no default database set");
+		auto &manager = DatabaseManager::Get(context);
+		lock_guard<mutex> guard(manager.databases_lock);
+		for (auto &entry : manager.databases) {
+			if (entry.second->IsInitialDatabase()) {
+				return entry.first;
+			}
 		}
-		return result;
+		if (manager.databases.empty()) {
+			throw InternalException("Calling DatabaseManager::GetDefaultDatabase with no database attached");
+		}
+		return manager.databases.begin()->first;
 	}
 	return default_entry.GetCatalog();
 }
-
-// LCOV_EXCL_START
-void DatabaseManager::SetDefaultDatabase(ClientContext &context, const Identifier &new_value) {
-	auto db_entry = GetDatabase(context, new_value);
-
-	if (!db_entry) {
-		throw InternalException("Database %s not found", new_value);
-	} else if (db_entry->IsTemporary()) {
-		throw InternalException("Cannot set the default database to a temporary database");
-	} else if (db_entry->IsSystem()) {
-		throw InternalException("Cannot set the default database to a system database");
-	}
-
-	default_database = new_value;
-}
-// LCOV_EXCL_STOP
 
 vector<shared_ptr<AttachedDatabase>> DatabaseManager::GetDatabases(ClientContext &context,
                                                                    const optional_idx max_db_count) {

--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -416,15 +416,17 @@ Identifier DatabaseManager::GetDefaultDatabase(ClientContext &context) {
 	if (IsInvalidCatalog(default_entry.GetCatalog())) {
 		auto &manager = DatabaseManager::Get(context);
 		lock_guard<mutex> guard(manager.databases_lock);
-		for (auto &entry : manager.databases) {
-			if (entry.second->IsInitialDatabase()) {
-				return entry.first;
-			}
-		}
 		if (manager.databases.empty()) {
 			throw InternalException("Calling DatabaseManager::GetDefaultDatabase with no database attached");
 		}
-		return manager.databases.begin()->first;
+		// OIDs are assigned in attach order, so the oldest attached database is the default.
+		auto default_database = manager.databases.begin();
+		for (auto entry = manager.databases.begin(); entry != manager.databases.end(); entry++) {
+			if (entry->second->oid < default_database->second->oid) {
+				default_database = entry;
+			}
+		}
+		return default_database->first;
 	}
 	return default_entry.GetCatalog();
 }

--- a/src/planner/binder/expression/bind_type_expression.cpp
+++ b/src/planner/binder/expression/bind_type_expression.cpp
@@ -31,7 +31,7 @@ BindResult ExpressionBinder::BindExpression(TypeExpression &type_expr, idx_t dep
 	auto &type_catalog = bound_name.Catalog();
 	bool is_qualified = bound_name.Path().size() > 1;
 
-	if (type_catalog.empty() && !DatabaseManager::Get(context).HasDefaultDatabase()) {
+	if (type_catalog.empty() && !DatabaseManager::Get(context).HasAttachedDatabase()) {
 		// Look in the system catalog if no catalog was specified
 		entry = binder.entry_retriever.GetEntry(
 		    EntryLookupInfo(type_lookup, bound_name.WithCatalog(Identifier::SystemCatalog())));

--- a/test/sql/storage/wal/wal_replay_default_database.test
+++ b/test/sql/storage/wal/wal_replay_default_database.test
@@ -14,6 +14,9 @@ statement ok
 CREATE TABLE test (i INTEGER);
 
 statement ok
+INSERT INTO test VALUES (42);
+
+statement ok
 ALTER TABLE test ALTER i TYPE VARCHAR USING concat(i, '');
 
 # Replay the ALTER before the main database is registered as attached

--- a/test/sql/storage/wal/wal_replay_default_database.test
+++ b/test/sql/storage/wal/wal_replay_default_database.test
@@ -1,0 +1,25 @@
+# name: test/sql/storage/wal/wal_replay_default_database.test
+# description: Resolve the default database while replaying the WAL
+# group: [wal]
+
+load {TEST_DIR}/wal_replay_default_database.db
+
+statement ok
+PRAGMA disable_checkpoint_on_shutdown
+
+statement ok
+PRAGMA wal_autocheckpoint='1TB';
+
+statement ok
+CREATE TABLE test (i INTEGER);
+
+statement ok
+ALTER TABLE test ALTER i TYPE VARCHAR USING concat(i, '');
+
+# Replay the ALTER before the main database is registered as attached
+restart
+
+query T
+SELECT typeof(i) FROM test;
+----
+VARCHAR


### PR DESCRIPTION
Followup PR for https://github.com/duckdb/duckdb/pull/24822#issuecomment-5324718792, which is a better solution for the initial dangling reference bug.

In one word, `default_database` is a redundant field, which could be replaced completely from attached databases; removing which saves a bunch of maintenance overhead (i.e., detach a DB should update to another attached one).

Regression test has been added in the above-mentioned PR.