### PR TITLE
Reject zero-comparison nested-loop joins so residual-only predicates fall back to the blockwise implementation instead of accessing an empty condition vector.

### DIFF
--- a/src/execution/operator/join/physical_nested_loop_join.cpp
+++ b/src/execution/operator/join/physical_nested_loop_join.cpp
@@ -124,27 +124,27 @@ bool PhysicalNestedLoopJoin::IsSupported(const vector<JoinCondition> &conditions
 	if (join_type == JoinType::MARK) {
 		return true;
 	}
+	idx_t comparison_count = 0;
 	for (auto &cond : conditions) {
 		if (!cond.IsComparison()) {
 			continue;
 		}
+		comparison_count++;
 		if (cond.GetLHS().GetReturnType().InternalType() == PhysicalType::STRUCT ||
 		    cond.GetLHS().GetReturnType().InternalType() == PhysicalType::LIST ||
 		    cond.GetLHS().GetReturnType().InternalType() == PhysicalType::ARRAY) {
 			return false;
 		}
 	}
+	// NestedLoopJoinInner requires a comparison condition to generate candidate pairs
+	if (comparison_count == 0) {
+		return false;
+	}
 
 	// To avoid situations like https://github.com/duckdb/duckdb/issues/10046
 	// If there is an equality in the conditions, a hash join is planned
 	// with one condition, we can use mark join logic, otherwise we should use physical blockwise nl join
 	if (join_type == JoinType::SEMI || join_type == JoinType::ANTI) {
-		idx_t comparison_count = 0;
-		for (auto &cond : conditions) {
-			if (cond.IsComparison()) {
-				comparison_count++;
-			}
-		}
 		return comparison_count == 1;
 	}
 	return true;

--- a/test/issues/general/test_23918.test
+++ b/test/issues/general/test_23918.test
@@ -1,0 +1,47 @@
+# name: test/issues/general/test_23918.test
+# description: Issue 23918 - Nested loop joins without comparison conditions
+# group: [general]
+
+statement ok
+SET profiling_renderer_settings = MAP {'operator_casing': 'upper'};
+
+statement ok
+CREATE TABLE t0(c0 INTEGER);
+
+statement ok
+CREATE TABLE t8(c0 INTEGER);
+
+statement ok
+INSERT INTO t0 VALUES (1);
+
+statement ok
+INSERT INTO t8 VALUES (1);
+
+# Statistics simplify the join conditions to a residual TRUE predicate.
+query II
+EXPLAIN SELECT * FROM t0 LEFT JOIN t8 ON t0.c0 >= t0.c0 AND t0.c0 <= t8.c0;
+----
+physical_plan	<REGEX>:.*BLOCKWISE_NL_JOIN.*
+
+query II
+SELECT * FROM t0 LEFT JOIN t8 ON t0.c0 >= t0.c0 AND t0.c0 <= t8.c0;
+----
+1	1
+
+statement ok
+CREATE TABLE l(a INTEGER);
+
+statement ok
+CREATE TABLE r(b INTEGER);
+
+statement ok
+INSERT INTO l VALUES (0);
+
+statement ok
+INSERT INTO r VALUES (0);
+
+# A residual FALSE predicate must preserve the NULL-extended left row.
+query II
+SELECT * FROM l LEFT JOIN r ON l.a <= r.b AND l.a > 0;
+----
+0	NULL


### PR DESCRIPTION
Fix #23918 

### Problem

When both tables contain a single known value, statistics propagation can simplify the entire join condition to the constant residual predicate `TRUE`. A similar query can simplify to `FALSE`.

The physical planner previously still selected `PhysicalNestedLoopJoin`. Its support check ignored non-comparison conditions and returned true for a LEFT join even when the number of actual comparison conditions was zero. During construction, comparison conditions and arbitrary residual predicates are separated. The nested-loop executor then tried to generate candidate pairs using its comparison-condition vectors before evaluating the residual predicate.

That execution path assumes at least one comparison condition and directly accesses the first condition and its input vectors. With zero comparison conditions, it therefore attempted to access index zero of an empty vector and raised `INTERNAL Error: Attempted to access index 0 within vector of size 0`

### Fix

The fix counts the actual comparison conditions in `PhysicalNestedLoopJoin::IsSupported`. When no comparison condition remains, the specialized nested-loop join is declared unsupported. The physical planner consequently falls back to `PhysicalBlockwiseNLJoin`, which is designed for arbitrary join expressions: it generates cross-product candidates, evaluates the complete residual predicate, and correctly maintains the match state needed by outer joins.

This gives the correct behavior for both important cases:

  - A residual TRUE predicate produces the matching left/right row.
  - A residual FALSE predicate produces a NULL-extended left row for a LEFT JOIN.

The fix is intentionally applied at the physical-operator eligibility boundary instead of adding a special zero-condition execution mode to `PhysicalNestedLoopJoin`. This keeps the specialized executor’s invariant explicit (there must be at least one comparison condition) and reuses the existing general-purpose implementation for residual-only joins. MARK join handling is left unchanged because it has separate NULL/UNKNOWN semantics and does not use the same blockwise fallback.