### PR TITLE
Fix top_n_window_elimination late materialization corrupting try-cast and nested-cast payloads

### DIFF
--- a/src/optimizer/topn_window_elimination.cpp
+++ b/src/optimizer/topn_window_elimination.cpp
@@ -187,8 +187,7 @@ bool IsRecreatableByLateMaterialization(const Expression &expr) {
 	if (expr.GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF) {
 		return true;
 	}
-	if (BoundCastExpression::IsCast(expr) &&
-	    !BoundCastExpression::IsTryCast(expr.Cast<BoundFunctionExpression>())) {
+	if (BoundCastExpression::IsCast(expr) && !BoundCastExpression::IsTryCast(expr.Cast<BoundFunctionExpression>())) {
 		return BoundCastExpression::Child(expr.Cast<BoundFunctionExpression>()).GetExpressionClass() ==
 		       ExpressionClass::BOUND_COLUMN_REF;
 	}

--- a/src/optimizer/topn_window_elimination.cpp
+++ b/src/optimizer/topn_window_elimination.cpp
@@ -177,16 +177,22 @@ LHSColumnInfo GetLHSColumnInfo(const unique_ptr<LogicalOperator> &op, idx_t colu
 	return result;
 }
 
-//! Late materialization recreates a payload by re-scanning the base table column and re-applying a type cast at the
-//! topmost projection. That only reproduces the original value when the projection expression is a plain column
-//! reference, optionally wrapped in casts. A value-transforming expression (e.g. parse_filename(col)) cannot be
-//! rebuilt that way, so it must not be eligible for late materialization.
+//! Late materialization recreates a payload by re-scanning the base table column and re-applying a single default
+//! (strict) cast at the topmost projection. That only reproduces the original value when the projection expression
+//! is a plain column reference, optionally wrapped in a single non-try cast. A value-transforming expression
+//! (e.g. parse_filename(col)) cannot be rebuilt that way. A try cast would be reconstructed as a strict cast
+//! (losing its NULL semantics), and a deeper cast chain would lose its intermediate conversions, so none of those
+//! shapes are eligible for late materialization.
 bool IsRecreatableByLateMaterialization(const Expression &expr) {
-	reference<const Expression> current = expr;
-	while (BoundCastExpression::IsCast(current.get())) {
-		current = BoundCastExpression::Child(current.get().Cast<BoundFunctionExpression>());
+	if (expr.GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF) {
+		return true;
 	}
-	return current.get().GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF;
+	if (BoundCastExpression::IsCast(expr) &&
+	    !BoundCastExpression::IsTryCast(expr.Cast<BoundFunctionExpression>())) {
+		return BoundCastExpression::Child(expr.Cast<BoundFunctionExpression>()).GetExpressionClass() ==
+		       ExpressionClass::BOUND_COLUMN_REF;
+	}
+	return false;
 }
 
 } // namespace

--- a/test/sql/optimizer/topn_window_elimination_late_materialization.test
+++ b/test/sql/optimizer/topn_window_elimination_late_materialization.test
@@ -151,3 +151,101 @@ WITH cte AS (SELECT a, b, c::TIMESTAMPTZ AS c FROM casted)
 SELECT * FROM cte QUALIFY row_number() OVER (PARTITION BY a ORDER BY c DESC) = 1
 ----
 x	false	2024-01-01 00:00:00+00
+
+# Issue #24609: a TRY_CAST payload must keep its NULL semantics. The rowid late-materialization
+# path reconstructs the payload with a strict default cast, turning TRY_CAST failures of winning
+# rows into Conversion Errors.
+
+statement ok
+CREATE TABLE try_cast_t (key VARCHAR, ts INTEGER, val VARCHAR, note VARCHAR);
+
+statement ok
+INSERT INTO try_cast_t VALUES ('a', 1, '100', 'n1'), ('a', 2, 'oops', 'n2'), ('b', 1, '7', 'n3'), ('b', 2, '8', 'n4');
+
+# The window is still eliminated ...
+query II
+EXPLAIN SELECT key, v, note FROM (
+  SELECT key, ts, TRY_CAST(val AS INTEGER) AS v, note FROM try_cast_t)
+QUALIFY row_number() OVER (PARTITION BY key ORDER BY ts DESC) = 1
+----
+logical_opt	<!REGEX>:.*FILTER.*WINDOW.*
+
+# ... but late materialization must not be used, because a TRY_CAST cannot be
+# reconstructed as a strict cast.
+query II
+EXPLAIN SELECT key, v, note FROM (
+  SELECT key, ts, TRY_CAST(val AS INTEGER) AS v, note FROM try_cast_t)
+QUALIFY row_number() OVER (PARTITION BY key ORDER BY ts DESC) = 1
+----
+logical_opt	<!REGEX>:.*COMPARISON_JOIN.*rowid = rowid.*
+
+# Un-castable winning rows must yield NULL, not a Conversion Error
+query III
+SELECT key, v, note FROM (
+  SELECT key, ts, TRY_CAST(val AS INTEGER) AS v, note FROM try_cast_t)
+QUALIFY row_number() OVER (PARTITION BY key ORDER BY ts DESC) = 1
+ORDER BY key
+----
+a	NULL	n2
+b	8	n4
+
+# Issue #24609: a nested cast payload must not be reconstructed as a plain raw-column
+# projection, which would silently drop the intermediate conversion.
+
+statement ok
+CREATE TABLE nested_cast_t (key VARCHAR, ts INTEGER, x DOUBLE, note VARCHAR);
+
+statement ok
+INSERT INTO nested_cast_t VALUES ('a', 1, 1.1, 'n1'), ('a', 2, 3.7, 'n2'), ('b', 1, 2.2, 'n3'), ('b', 2, 8.9, 'n4');
+
+# The window is still eliminated ...
+query II
+EXPLAIN SELECT key, r, note FROM (
+  SELECT key, ts, CAST(CAST(x AS INTEGER) AS DOUBLE) AS r, note FROM nested_cast_t)
+QUALIFY row_number() OVER (PARTITION BY key ORDER BY ts DESC) = 1
+----
+logical_opt	<!REGEX>:.*FILTER.*WINDOW.*
+
+# ... but late materialization must not be used, because the cast chain cannot be
+# reconstructed from a single default cast.
+query II
+EXPLAIN SELECT key, r, note FROM (
+  SELECT key, ts, CAST(CAST(x AS INTEGER) AS DOUBLE) AS r, note FROM nested_cast_t)
+QUALIFY row_number() OVER (PARTITION BY key ORDER BY ts DESC) = 1
+----
+logical_opt	<!REGEX>:.*COMPARISON_JOIN.*rowid = rowid.*
+
+# The intermediate integer truncation must be preserved
+query III
+SELECT key, r, note FROM (
+  SELECT key, ts, CAST(CAST(x AS INTEGER) AS DOUBLE) AS r, note FROM nested_cast_t)
+QUALIFY row_number() OVER (PARTITION BY key ORDER BY ts DESC) = 1
+ORDER BY key
+----
+a	4	n2
+b	9	n4
+
+# Differential check of both shapes against the same queries with the optimizer disabled
+statement ok
+SET disabled_optimizers = 'top_n_window_elimination'
+
+query III
+SELECT key, v, note FROM (
+  SELECT key, ts, TRY_CAST(val AS INTEGER) AS v, note FROM try_cast_t)
+QUALIFY row_number() OVER (PARTITION BY key ORDER BY ts DESC) = 1
+ORDER BY key
+----
+a	NULL	n2
+b	8	n4
+
+query III
+SELECT key, r, note FROM (
+  SELECT key, ts, CAST(CAST(x AS INTEGER) AS DOUBLE) AS r, note FROM nested_cast_t)
+QUALIFY row_number() OVER (PARTITION BY key ORDER BY ts DESC) = 1
+ORDER BY key
+----
+a	4	n2
+b	9	n4
+
+statement ok
+SET disabled_optimizers = ''


### PR DESCRIPTION
Fixes #24609

### Summary
When `top_n_window_elimination` takes the rowid late-materialization path, payload eligibility was gated by `IsRecreatableByLateMaterialization`, which stripped *any* cast chain and accepted everything over a column reference. The payload is then rebuilt by the rowid semi-join as the raw base-table column, and `UpdateTopmostBindings` re-applies at most one **default (strict)** cast. Consequently:

1. **TRY_CAST → Conversion Error**: `TRY_CAST(val AS INTEGER)` was rebuilt as a strict `CAST`, so an un-castable winning row aborted instead of returning NULL.
2. **Nested casts collapsed → silent wrong values**: `CAST(CAST(x AS INTEGER) AS DOUBLE)` was rebuilt without the intermediate truncation, returning the raw value with no error (3.7 instead of 4.0).

The v1.5.4/v1.5.5 release branches used a stricter gate (direct column ref only) and were unaffected; main's variant of #22892 (`f53b1cb245`) re-admitted cast chains, regressing this.

### Changes Made
- `src/optimizer/topn_window_elimination.cpp`: restrict `IsRecreatableByLateMaterialization` to a plain column ref optionally wrapped in **at most one non-try cast** — the only shapes the topmost projection reconstructs exactly. Try-cast and multi-cast payloads now fall back to carrying the computed value through the aggregate.
- `test/sql/optimizer/topn_window_elimination_late_materialization.test`: regression cases for both shapes — EXPLAIN checks (window still eliminated, but no rowid semi-join), result checks, and differential checks with the optimizer disabled.

### Notes
- Single plain casts over a base column remain late-materialization eligible (#22096 behaviour preserved by the pre-existing test at the bottom of the test file).
- Verified locally: `test/sql/optimizer/*` (74 cases), `test/sql/topn/*` (21), `test/sql/window/*` (82) all pass.