### PR TITLE
Prevent window self-join optimization from duplicating volatile expressions

### DIFF
--- a/src/optimizer/window_self_join.cpp
+++ b/src/optimizer/window_self_join.cpp
@@ -13,25 +13,6 @@
 
 namespace duckdb {
 
-class VolatileExpressionCounter : public LogicalOperatorVisitor {
-public:
-	static idx_t HasVolatiles(LogicalOperator &op) {
-		VolatileExpressionCounter counter;
-		counter.VisitOperator(op);
-		return counter.volatiles;
-	}
-
-	VolatileExpressionCounter() {
-	}
-
-	void VisitExpression(unique_ptr<Expression> *expression) override {
-		volatiles += (*expression)->IsVolatile();
-		LogicalOperatorVisitor::VisitExpression(expression);
-	}
-
-	idx_t volatiles = 0;
-};
-
 static bool IsOrderableDistinctAggregate(const BoundWindowExpression &w_expr) {
 	//	If the aggregate is order-sensitive and distinct,
 	//	then the ORDER BYs need to be functional dependencies of the arguments.
@@ -199,8 +180,8 @@ unique_ptr<LogicalOperator> WindowSelfJoinOptimizer::OptimizeInternal(unique_ptr
 		// Check recursively
 		window.children[0] = OptimizeInternal(std::move(window.children[0]), replacer);
 
-		//	We cannot perform self-join when there are volatile functions below us.
-		if (VolatileExpressionCounter::HasVolatiles(window)) {
+		// We cannot perform self-join when there are volatile functions below us.
+		if (window.HasVolatileExpressions()) {
 			return op;
 		}
 

--- a/test/issues/general/test_24302.test
+++ b/test/issues/general/test_24302.test
@@ -1,0 +1,71 @@
+# name: test/issues/general/test_24302.test
+# description: Issue 24302 - Window self-joins must not duplicate volatile filters
+# group: [general]
+
+statement ok
+CREATE SEQUENCE filter_seq;
+
+# This is the reported nested-window shape with a deterministic volatile filter.
+# Re-evaluating the filter in a copied self-join subtree advances the sequence twice and changes the input relation.
+query IIII
+SELECT count(*) AS rows,
+       count(*) FILTER (WHERE s = actual_sum) AS matching_rows,
+       any_value(s) AS observed_window_sum,
+       actual_sum AS expected_sum
+FROM (
+    SELECT i, s, sum(i) OVER () AS actual_sum
+    FROM (
+        SELECT i, sum(i) OVER (PARTITION BY g) AS s
+        FROM (
+            SELECT 1 AS g, i
+            FROM range(6) t(i)
+            WHERE nextval('filter_seq') <= 6
+        )
+    )
+)
+GROUP BY actual_sum;
+----
+6	6	15	15
+
+query I
+SELECT currval('filter_seq');
+----
+6
+
+# Disabling only the responsible optimizer must use the same single-evaluation semantics.
+statement ok
+DROP SEQUENCE filter_seq;
+
+statement ok
+CREATE SEQUENCE filter_seq;
+
+statement ok
+SET disabled_optimizers = 'window_self_join';
+
+query IIII
+SELECT count(*) AS rows,
+       count(*) FILTER (WHERE s = actual_sum) AS matching_rows,
+       any_value(s) AS observed_window_sum,
+       actual_sum AS expected_sum
+FROM (
+    SELECT i, s, sum(i) OVER () AS actual_sum
+    FROM (
+        SELECT i, sum(i) OVER (PARTITION BY g) AS s
+        FROM (
+            SELECT 1 AS g, i
+            FROM range(6) t(i)
+            WHERE nextval('filter_seq') <= 6
+        )
+    )
+)
+GROUP BY actual_sum;
+----
+6	6	15	15
+
+query I
+SELECT currval('filter_seq');
+----
+6
+
+statement ok
+SET disabled_optimizers = '';


### PR DESCRIPTION
Fix #24302

### Problem

The issue was caused by the `window_self_join` optimizer. DuckDB can rewrite a partition-wide window aggregate into a grouped aggregate and join the result back to the original input. To perform this rewrite, the optimizer deep-copies the window’s input plan.

This is safe for deterministic inputs, but not for inputs containing volatile expressions such as `random()` or `nextval()`.

For example, the reported query contains:

`WHERE random() < 0.5`

After the rewrite, the copied plans evaluate `random()` independently:

- The original branch produces the rows used by the outer window aggregate.
- The copied branch produces the grouped result replacing the inner window aggregate.

Because the two branches can select different rows, the inner and outer sums are calculated from different datasets. When `window_self_join` is disabled, the filter is evaluated only once, so both window aggregates operate on the same rows and the result is correct.

### Fix

Before copying the input plan, the optimizer now checks the entire window subtree for volatile expressions:

```
if (window.HasVolatileExpressions()) {
    return op;
}
```

If a volatile expression is found, DuckDB skips the self-join rewrite and preserves the original window plan. Deterministic inputs are unaffected and can still benefit from the optimization.

The current code already contained a private `VolatileExpressionCounter` implementing the same protection. This change replaces that local implementation with DuckDB’s standard `LogicalOperator::HasVolatileExpressions()` API. This avoids duplicate volatility-detection logic and keeps the optimizer consistent with other planner components.