### PR TITLE
Backport DuckDB 2.0 API spellings to 1.5

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -53,6 +53,7 @@ add_library_unity(
   fsst.cpp
   gzip_file_system.cpp
   hive_partitioning.cpp
+  identifier.cpp
   pipe_file_system.cpp
   local_file_system.cpp
   error_data.cpp

--- a/src/common/exception_format_value.cpp
+++ b/src/common/exception_format_value.cpp
@@ -7,6 +7,7 @@
 #include "duckdb/common/types/uhugeint.hpp"
 #include "duckdb/parser/keyword_helper.hpp"
 #include "duckdb/common/types/string.hpp"
+#include "duckdb/common/identifier.hpp"
 
 namespace duckdb {
 
@@ -58,6 +59,13 @@ ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(const String &value
 template <>
 ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(const SQLString &value) {
 	return KeywordHelper::WriteQuoted(value.raw_string, '\'');
+}
+
+template <>
+ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(const Identifier &value) {
+	// An Identifier is a SQL identifier, so it formats with SQL identifier rules (quoted only when required) -
+	// callers should never need to wrap an Identifier in SQLIdentifier when printing.
+	return SQLIdentifier::ToString(value.GetIdentifierName());
 }
 
 template <>

--- a/src/common/identifier.cpp
+++ b/src/common/identifier.cpp
@@ -1,0 +1,45 @@
+#include "duckdb/common/identifier.hpp"
+
+#include "duckdb/common/string_util.hpp"
+
+#include <ostream>
+
+namespace duckdb {
+
+bool Identifier::StartsWith(const string &prefix) const {
+	return StringUtil::CIStartsWith(value, prefix);
+}
+
+bool Identifier::EndsWith(const string &suffix) const {
+	return StringUtil::CIEndsWith(value, suffix);
+}
+
+hash_t Identifier::Hash() const {
+	return StringUtil::CIHash(value);
+}
+
+bool operator==(const Identifier &a, const Identifier &b) {
+	return StringUtil::CIEquals(a.GetIdentifierName(), b.GetIdentifierName());
+}
+bool operator==(const Identifier &a, const string &b) {
+	return StringUtil::CIEquals(a.GetIdentifierName(), b);
+}
+bool operator==(const string &a, const Identifier &b) {
+	return StringUtil::CIEquals(a, b.GetIdentifierName());
+}
+bool operator==(const Identifier &a, const char *b) {
+	return StringUtil::CIEquals(a.GetIdentifierName(), string(b));
+}
+bool operator==(const char *a, const Identifier &b) {
+	return StringUtil::CIEquals(string(a), b.GetIdentifierName());
+}
+
+bool operator<(const Identifier &a, const Identifier &b) {
+	return StringUtil::CILessThan(a.GetIdentifierName(), b.GetIdentifierName());
+}
+
+std::ostream &operator<<(std::ostream &os, const Identifier &id) {
+	return os << id.GetIdentifierName();
+}
+
+} // namespace duckdb

--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -441,6 +441,13 @@ bool StringUtil::CIStartsWith(const string &str, const string &prefix) {
 	return CIEquals(str.c_str(), prefix.size(), prefix.c_str(), prefix.size());
 }
 
+bool StringUtil::CIEndsWith(const string &str, const string &suffix) {
+	if (suffix.size() > str.size()) {
+		return false;
+	}
+	return CIEquals(str.c_str() + str.size() - suffix.size(), suffix.size(), suffix.c_str(), suffix.size());
+}
+
 bool StringUtil::CILessThan(const string &s1, const string &s2) {
 	const auto charmap = ASCII_TO_UPPER_MAP;
 

--- a/src/common/types/value.cpp
+++ b/src/common/types/value.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/common/types/value.hpp"
 
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/identifier.hpp"
 #include "duckdb/common/limits.hpp"
 #include "duckdb/common/operator/cast_operators.hpp"
 
@@ -147,6 +148,9 @@ Value::Value(float val) : type_(LogicalType::FLOAT), is_null(false) {
 
 Value::Value(double val) : type_(LogicalType::DOUBLE), is_null(false) {
 	value_.double_ = val;
+}
+
+Value::Value(const Identifier &val) : Value(val.GetIdentifierName()) {
 }
 
 Value::Value(const char *val) : Value(val ? string(val) : string()) {
@@ -1365,6 +1369,11 @@ DUCKDB_API interval_t Value::GetValue() const {
 template <>
 DUCKDB_API Value Value::GetValue() const {
 	return Value(*this);
+}
+
+template <>
+DUCKDB_API Identifier Value::GetValue() const {
+	return Identifier(GetValue<string>());
 }
 
 uintptr_t Value::GetPointer() const {

--- a/src/include/duckdb/catalog/catalog.hpp
+++ b/src/include/duckdb/catalog/catalog.hpp
@@ -20,6 +20,7 @@
 #include "duckdb/common/optional_ptr.hpp"
 #include "duckdb/common/reference_map.hpp"
 #include "duckdb/parser/query_error_context.hpp"
+#include "duckdb/parser/qualified_name.hpp"
 #include "duckdb/catalog/entry_lookup_info.hpp"
 #include "duckdb/common/types/string.hpp"
 
@@ -381,6 +382,20 @@ public:
 	                   const string &name, QueryErrorContext error_context = QueryErrorContext()) {
 		auto entry =
 		    GetEntry<T>(context, catalog_name, schema_name, name, OnEntryNotFound::THROW_EXCEPTION, error_context);
+		return *entry;
+	}
+
+	//! Look up an entry by its (optionally qualified) name - the 2.0 spelling of the catalog/schema/name overloads
+	//! above.
+	template <class T>
+	static optional_ptr<T> GetEntry(ClientContext &context, const QualifiedName &name, OnEntryNotFound if_not_found,
+	                                QueryErrorContext error_context = QueryErrorContext()) {
+		return GetEntry<T>(context, name.catalog, name.schema, name.name, if_not_found, error_context);
+	}
+	template <class T>
+	static T &GetEntry(ClientContext &context, const QualifiedName &name,
+	                   QueryErrorContext error_context = QueryErrorContext()) {
+		auto entry = GetEntry<T>(context, name, OnEntryNotFound::THROW_EXCEPTION, error_context);
 		return *entry;
 	}
 

--- a/src/include/duckdb/common/exception_format_value.hpp
+++ b/src/include/duckdb/common/exception_format_value.hpp
@@ -10,34 +10,15 @@
 
 #include "duckdb/common/string.hpp"
 #include "duckdb/common/hugeint.hpp"
+#include "duckdb/common/sql_identifier.hpp"
 
+#include <ostream>
 #include <vector>
 
 namespace duckdb {
 
 class String;
-
-// Helper class to support custom overloading
-// Escaping " and quoting the value with "
-class SQLIdentifier {
-public:
-	explicit SQLIdentifier(const string &raw_string) : raw_string(raw_string) {
-	}
-
-public:
-	string raw_string;
-};
-
-// Helper class to support custom overloading
-// Escaping ' and quoting the value with '
-class SQLString {
-public:
-	explicit SQLString(const string &raw_string) : raw_string(raw_string) {
-	}
-
-public:
-	string raw_string;
-};
+class Identifier;
 
 enum class PhysicalType : uint8_t;
 struct LogicalType;
@@ -90,6 +71,8 @@ template <>
 DUCKDB_API ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(const double &value);
 template <>
 DUCKDB_API ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(const string &value);
+template <>
+DUCKDB_API ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(const Identifier &value);
 template <>
 DUCKDB_API ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(const String &value);
 template <>

--- a/src/include/duckdb/common/identifier.hpp
+++ b/src/include/duckdb/common/identifier.hpp
@@ -1,0 +1,211 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/identifier.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/constants.hpp"
+#include "duckdb/common/unordered_map.hpp"
+#include "duckdb/common/unordered_set.hpp"
+#include "duckdb/common/string.hpp"
+#include "duckdb/common/map.hpp"
+#include "duckdb/common/vector.hpp"
+
+#include <iosfwd>
+
+namespace duckdb {
+
+//! An Identifier represents a SQL identifier (e.g. a column name, table name, alias, ...).
+//! Unlike a regular string, identifiers compare case-insensitively (using StringUtil::CIEquals).
+//! Internally the identifier is stored as-is (preserving the original casing), but all comparisons,
+//! hashing and ordering are case-insensitive.
+class Identifier {
+public:
+	Identifier() = default;
+	//! Construction from a string literal is implicit: literals in the source are identifiers by intent.
+	Identifier(const char *str) : value(str) { // NOLINT: implicit conversion from literals is intentional
+	}
+	//! NOTE(backport): DuckDB 2.0 makes these two constructors explicit, and the conversion back to a
+	//! string below as well. Every API on this branch still takes and returns `std::string`, so explicitness in
+	//! either direction would force a cast at every single call site into DuckDB - text that does not exist on the
+	//! 2.0 branch and would therefore *add* diff to carry and rebase. The rule for call sites is to write exactly
+	//! the casts the 2.0 branch writes and never any others: where 2.0 writes `Identifier(x)` or
+	//! `GetIdentifierName()`, write it here too (it compiles to the same thing); where 2.0 writes neither, write
+	//! neither and let the implicit conversion absorb the difference.
+	Identifier(const string &str) : value(str) { // NOLINT: implicit on purpose, see above
+	}
+	Identifier(string &&str) : value(std::move(str)) { // NOLINT: implicit on purpose, see above
+	}
+
+	//! Named constructors for well-known identifiers
+	static Identifier DefaultSchema() {
+		return Identifier(DEFAULT_SCHEMA);
+	}
+	static Identifier InvalidSchema() {
+		return Identifier(INVALID_SCHEMA);
+	}
+	static Identifier InvalidCatalog() {
+		return Identifier(INVALID_CATALOG);
+	}
+	static Identifier SystemCatalog() {
+		return Identifier(SYSTEM_CATALOG);
+	}
+	static Identifier TempCatalog() {
+		return Identifier(TEMP_CATALOG);
+	}
+
+	//! NOTE(backport): Conversion back to a string (implicit here, explicit on DuckDB 2.0 - see the note on the
+	//! constructors above)
+	operator const string &() const { // NOLINT: implicit on purpose, see above
+		return value;
+	}
+
+	//! The raw underlying string (preserving original casing)
+	const string &GetIdentifierName() const {
+		return value;
+	}
+
+	bool empty() const { // NOLINT: match std::string interface
+		return value.empty();
+	}
+	void clear() { // NOLINT: match std::string interface
+		value.clear();
+	}
+	idx_t size() const { // NOLINT: match std::string interface
+		return value.size();
+	}
+	const char *c_str() const { // NOLINT: match std::string interface
+		return value.c_str();
+	}
+
+	//! Whether the identifier starts with the given prefix (case-insensitive)
+	DUCKDB_API bool StartsWith(const string &prefix) const;
+
+	//! Whether the identifier ends with the given suffix (case-insensitive)
+	DUCKDB_API bool EndsWith(const string &suffix) const;
+
+	//! Case-insensitive hash of the identifier
+	DUCKDB_API hash_t Hash() const;
+
+private:
+	string value;
+};
+
+//! Equality (case-insensitive)
+DUCKDB_API bool operator==(const Identifier &a, const Identifier &b);
+DUCKDB_API bool operator==(const Identifier &a, const string &b);
+DUCKDB_API bool operator==(const string &a, const Identifier &b);
+DUCKDB_API bool operator==(const Identifier &a, const char *b);
+DUCKDB_API bool operator==(const char *a, const Identifier &b);
+
+inline bool operator!=(const Identifier &a, const Identifier &b) {
+	return !(a == b);
+}
+inline bool operator!=(const Identifier &a, const string &b) {
+	return !(a == b);
+}
+inline bool operator!=(const string &a, const Identifier &b) {
+	return !(a == b);
+}
+inline bool operator!=(const Identifier &a, const char *b) {
+	return !(a == b);
+}
+inline bool operator!=(const char *a, const Identifier &b) {
+	return !(a == b);
+}
+
+//! Ordering (case-insensitive)
+DUCKDB_API bool operator<(const Identifier &a, const Identifier &b);
+
+//! Streaming an identifier writes its raw name (without quotes) - this mirrors writing the underlying string
+DUCKDB_API std::ostream &operator<<(std::ostream &os, const Identifier &id);
+
+//! String concatenation (std::operator+ is a template and cannot use the implicit conversion, so we provide our own)
+inline string operator+(const Identifier &a, const string &b) {
+	return a.GetIdentifierName() + b;
+}
+inline string operator+(const string &a, const Identifier &b) {
+	return a + b.GetIdentifierName();
+}
+inline string operator+(const Identifier &a, const char *b) {
+	return a.GetIdentifierName() + b;
+}
+inline string operator+(const char *a, const Identifier &b) {
+	return a + b.GetIdentifierName();
+}
+inline string operator+(const Identifier &a, const Identifier &b) {
+	return a.GetIdentifierName() + b.GetIdentifierName();
+}
+inline string operator+(const Identifier &a, char b) {
+	return a.GetIdentifierName() + b;
+}
+inline string operator+(char a, const Identifier &b) {
+	return a + b.GetIdentifierName();
+}
+
+//! Appending an identifier to a string appends the raw name
+inline string &operator+=(string &a, const Identifier &b) {
+	a += b.GetIdentifierName();
+	return a;
+}
+
+struct IdentifierHashFunction {
+	uint64_t operator()(const Identifier &id) const {
+		return id.Hash();
+	}
+};
+
+struct IdentifierEquality {
+	bool operator()(const Identifier &a, const Identifier &b) const {
+		return a == b;
+	}
+};
+
+struct IdentifierCompare {
+	bool operator()(const Identifier &a, const Identifier &b) const {
+		return a < b;
+	}
+};
+
+template <typename T>
+using identifier_map_t = unordered_map<Identifier, T, IdentifierHashFunction, IdentifierEquality>;
+
+using identifier_set_t = unordered_set<Identifier, IdentifierHashFunction, IdentifierEquality>;
+
+template <typename T>
+using identifier_tree_t = map<Identifier, T, IdentifierCompare>;
+
+//! Helper to convert a vector of identifiers to a vector of (raw) strings (for interop with string-based APIs)
+inline vector<string> IdentifiersToStrings(const vector<Identifier> &identifiers) {
+	vector<string> result;
+	result.reserve(identifiers.size());
+	for (auto &identifier : identifiers) {
+		result.push_back(identifier.GetIdentifierName());
+	}
+	return result;
+}
+
+//! Helper to convert a vector of (raw) strings to a vector of identifiers (to be removed at the end of the rework)
+inline vector<Identifier> StringsToIdentifiers(const vector<string> &strings) {
+	vector<Identifier> result;
+	result.reserve(strings.size());
+	for (auto &str : strings) {
+		result.emplace_back(str);
+	}
+	return result;
+}
+
+//! Identifier-aware overloads of the invalid-catalog/schema checks. These live here (rather than next to the
+//! string versions in constants.hpp) because constants.hpp is a dependency of this header.
+inline bool IsInvalidCatalog(const Identifier &catalog) {
+	return catalog.empty();
+}
+inline bool IsInvalidSchema(const Identifier &schema) {
+	return schema.empty();
+}
+
+} // namespace duckdb

--- a/src/include/duckdb/common/serializer/deserializer.hpp
+++ b/src/include/duckdb/common/serializer/deserializer.hpp
@@ -487,6 +487,12 @@ private:
 		return ReadString();
 	}
 
+	// Deserialize an Identifier (stored identically to a plain string)
+	template <typename T = void>
+	inline typename std::enable_if<std::is_same<T, Identifier>::value, T>::type Read() {
+		return Identifier(ReadString());
+	}
+
 	// Deserialize a Enum
 	template <typename T = void>
 	inline typename std::enable_if<std::is_enum<T>::value, T>::type Read() {

--- a/src/include/duckdb/common/serializer/serialization_traits.hpp
+++ b/src/include/duckdb/common/serializer/serialization_traits.hpp
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <atomic>
 
+#include "duckdb/common/identifier.hpp"
 #include "duckdb/common/vector.hpp"
 #include "duckdb/common/map.hpp"
 #include "duckdb/common/unordered_map.hpp"
@@ -325,6 +326,16 @@ struct SerializationDefaultValue {
 
 	template <typename T = void>
 	static inline bool IsDefault(const typename std::enable_if<std::is_same<T, string>::value, T>::type &value) {
+		return value.empty();
+	}
+
+	template <typename T = void>
+	static inline typename std::enable_if<std::is_same<T, Identifier>::value, T>::type GetDefault() {
+		return T();
+	}
+
+	template <typename T = void>
+	static inline bool IsDefault(const typename std::enable_if<std::is_same<T, Identifier>::value, T>::type &value) {
 		return value.empty();
 	}
 

--- a/src/include/duckdb/common/serializer/serializer.hpp
+++ b/src/include/duckdb/common/serializer/serializer.hpp
@@ -366,6 +366,10 @@ protected:
 	virtual void WriteValue(const string &value) = 0;
 	virtual void WriteValue(const char *str) = 0;
 	virtual void WriteDataPtr(const_data_ptr_t ptr, idx_t count) = 0;
+	//! Identifiers are serialized identically to a plain string (preserving the original casing)
+	void WriteValue(const Identifier &value) {
+		WriteValue(value.GetIdentifierName());
+	}
 	void WriteValue(LogicalIndex value) {
 		WriteValue(value.index);
 	}

--- a/src/include/duckdb/common/sql_identifier.hpp
+++ b/src/include/duckdb/common/sql_identifier.hpp
@@ -1,0 +1,125 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/sql_identifier.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/string.hpp"
+
+#include <ostream>
+
+namespace duckdb {
+
+class String;
+class Identifier;
+
+// Helper class to support custom overloading
+// Optionally escaping " and quoting the value with " if required
+class SQLIdentifier {
+public:
+	explicit SQLIdentifier(const string &raw_string) : raw_string(raw_string) {
+	}
+	explicit SQLIdentifier(const char *raw_string) : raw_string(raw_string) {
+	}
+	explicit SQLIdentifier(const Identifier &id);
+
+	//! Emits an optionally quoted identifier including required escapes (i.e. ident -> ident, table -> "table")
+	static string ToString(const string &identifier);
+
+public:
+	string raw_string;
+};
+
+inline string operator+(const SQLIdentifier &lhs, const string &rhs) {
+	return SQLIdentifier::ToString(lhs.raw_string) + rhs;
+}
+inline string operator+(const SQLIdentifier &lhs, const char *rhs) {
+	return SQLIdentifier::ToString(lhs.raw_string) + rhs;
+}
+inline string operator+(const string &lhs, const SQLIdentifier &rhs) {
+	return lhs + SQLIdentifier::ToString(rhs.raw_string);
+}
+inline string operator+(const char *lhs, const SQLIdentifier &rhs) {
+	return lhs + SQLIdentifier::ToString(rhs.raw_string);
+}
+inline string &operator+=(string &lhs, const SQLIdentifier &rhs) {
+	return lhs += SQLIdentifier::ToString(rhs.raw_string);
+}
+inline std::ostream &operator<<(std::ostream &os, const SQLIdentifier &val) {
+	return os << SQLIdentifier::ToString(val.raw_string);
+}
+
+// Helper class to support custom overloading
+// Escaping " and quoting the value with " if required
+class SQLQuotedIdentifier {
+public:
+	explicit SQLQuotedIdentifier(const string &raw_string) : raw_string(raw_string) {
+	}
+	explicit SQLQuotedIdentifier(const char *raw_string) : raw_string(raw_string) {
+	}
+	explicit SQLQuotedIdentifier(const Identifier &id);
+
+	//! Emits an optionally quoted identifier including required escapes (i.e. ident -> ident, table -> "table")
+	static string ToString(const string &identifier);
+
+public:
+	string raw_string;
+};
+
+inline string operator+(const SQLQuotedIdentifier &lhs, const string &rhs) {
+	return SQLQuotedIdentifier::ToString(lhs.raw_string) + rhs;
+}
+inline string operator+(const SQLQuotedIdentifier &lhs, const char *rhs) {
+	return SQLQuotedIdentifier::ToString(lhs.raw_string) + rhs;
+}
+inline string operator+(const string &lhs, const SQLQuotedIdentifier &rhs) {
+	return lhs + SQLQuotedIdentifier::ToString(rhs.raw_string);
+}
+inline string operator+(const char *lhs, const SQLQuotedIdentifier &rhs) {
+	return lhs + SQLQuotedIdentifier::ToString(rhs.raw_string);
+}
+inline string &operator+=(string &lhs, const SQLQuotedIdentifier &rhs) {
+	return lhs += SQLQuotedIdentifier::ToString(rhs.raw_string);
+}
+inline std::ostream &operator<<(std::ostream &os, const SQLQuotedIdentifier &val) {
+	return os << SQLQuotedIdentifier::ToString(val.raw_string);
+}
+
+// Helper class to support custom overloading
+// Escaping ' and quoting the value with '
+class SQLString {
+public:
+	explicit SQLString(const string &raw_string) : raw_string(raw_string) {
+	}
+
+	//! Emits a quoted string literal including required escapes (i.e. ident -> 'ident')
+	static string ToString(const string &literal);
+
+public:
+	string raw_string;
+};
+
+inline string operator+(const SQLString &lhs, const string &rhs) {
+	return SQLString::ToString(lhs.raw_string) + rhs;
+}
+inline string operator+(const SQLString &lhs, const char *rhs) {
+	return SQLString::ToString(lhs.raw_string) + rhs;
+}
+inline string operator+(const string &lhs, const SQLString &rhs) {
+	return lhs + SQLString::ToString(rhs.raw_string);
+}
+inline string operator+(const char *lhs, const SQLString &rhs) {
+	return lhs + SQLString::ToString(rhs.raw_string);
+}
+inline string &operator+=(string &lhs, const SQLString &rhs) {
+	return lhs += SQLString::ToString(rhs.raw_string);
+}
+inline std::ostream &operator<<(std::ostream &os, const SQLString &val) {
+	return os << SQLString::ToString(val.raw_string);
+}
+
+} // namespace duckdb

--- a/src/include/duckdb/common/string_util.hpp
+++ b/src/include/duckdb/common/string_util.hpp
@@ -236,6 +236,9 @@ public:
 	//! Case insensitive starts-with
 	DUCKDB_API static bool CIStartsWith(const string &str, const string &prefix);
 
+	//! Case insensitive ends-with
+	DUCKDB_API static bool CIEndsWith(const string &str, const string &suffix);
+
 	//! Case insensitive compare
 	DUCKDB_API static bool CILessThan(const string &l1, const string &l2);
 

--- a/src/include/duckdb/common/types/data_chunk.hpp
+++ b/src/include/duckdb/common/types/data_chunk.hpp
@@ -63,6 +63,22 @@ public:
 	inline void SetCardinality(const DataChunk &other) {
 		SetCardinality(other.size());
 	}
+	//! NOTE(backport): on DuckDB 2.0 vectors carry their own size, so setting the cardinality of a chunk has to resize
+	//! its child vectors as well. Here vectors have no size of their own, so this is exactly SetCardinality - it only
+	//! exists so that code written against DuckDB 2.0 compiles and behaves the same.
+	inline void SetChildCardinality(idx_t count_p) {
+		SetCardinality(count_p);
+	}
+	//! NOTE(backport): the "unsafe" variant skips resizing the child vectors, which is a no-op here - see above.
+	inline void SetCardinalityUnsafe(idx_t count_p) {
+		SetCardinality(count_p);
+	}
+	//! NOTE(backport): on DuckDB 2.0 this verifies that the child vectors already have the given size and then drops
+	//! the chunk's own cardinality, which is derived from them. Here the count is the only size there is, so it sets it
+	//! instead - the same observable result, except that the mismatch 2.0 throws on cannot be detected here.
+	inline void CheckCardinality(idx_t count_p) {
+		SetCardinality(count_p);
+	}
 	inline idx_t GetCapacity() const {
 		return capacity;
 	}

--- a/src/include/duckdb/common/types/value.hpp
+++ b/src/include/duckdb/common/types/value.hpp
@@ -23,6 +23,7 @@
 namespace duckdb {
 
 class String;
+class Identifier;
 class CastFunctionSet;
 struct GetCastFunctionInput;
 struct ExtraValueInfo;
@@ -52,7 +53,8 @@ public:
 	//! Create a DOUBLE value
 	DUCKDB_API Value(double val); // NOLINT: Allow implicit conversion from `double`
 	//! Create a VARCHAR value
-	DUCKDB_API Value(const char *val); // NOLINT: Allow implicit conversion from `const char *`
+	DUCKDB_API Value(const char *val);       // NOLINT: Allow implicit conversion from `const char *`
+	DUCKDB_API Value(const Identifier &val); // NOLINT: Allow implicit conversion from `Identifier`
 	//! Create a NULL value
 	DUCKDB_API Value(std::nullptr_t val); // NOLINT: Allow implicit conversion from `nullptr_t`
 	//! Create a VARCHAR value
@@ -587,6 +589,10 @@ template <>
 DUCKDB_API interval_t Value::GetValue() const;
 template <>
 DUCKDB_API Value Value::GetValue() const;
+// Not a logical type like the specializations above, but a semantic wrapper around the string value. It mirrors the
+// implicit Value(const Identifier &) constructor, so identifiers can round-trip through a Value.
+template <>
+DUCKDB_API Identifier Value::GetValue() const;
 
 template <>
 DUCKDB_API bool Value::GetValueUnsafe() const;

--- a/src/include/duckdb/function/function.hpp
+++ b/src/include/duckdb/function/function.hpp
@@ -113,6 +113,30 @@ public:
 	string schema_name;
 
 public:
+	void SetName(string name_p) {
+		name = std::move(name_p);
+	}
+	void SetSchemaName(string schema_name_p) {
+		schema_name = std::move(schema_name_p);
+	}
+	void SetCatalogName(string catalog_name_p) {
+		catalog_name = std::move(catalog_name_p);
+	}
+
+	const string &GetName() const {
+		return name;
+	}
+	const string &GetSchemaName() const {
+		return schema_name;
+	}
+	const string &GetCatalogName() const {
+		return catalog_name;
+	}
+
+	const string &GetExtraInfo() const {
+		return extra_info;
+	}
+
 	//! Returns the formatted string name(arg1, arg2, ...)
 	DUCKDB_API static string CallToString(const string &catalog_name, const string &schema_name, const string &name,
 	                                      const vector<LogicalType> &arguments,
@@ -150,6 +174,30 @@ public:
 	DUCKDB_API virtual string ToString() const;
 
 	DUCKDB_API bool HasVarArgs() const;
+
+	vector<LogicalType> &GetArguments() {
+		return arguments;
+	}
+	const vector<LogicalType> &GetArguments() const {
+		return arguments;
+	}
+
+	vector<LogicalType> &GetOriginalArguments() {
+		return original_arguments;
+	}
+	const vector<LogicalType> &GetOriginalArguments() const {
+		return original_arguments;
+	}
+
+	LogicalType &GetVarArgs() {
+		return varargs;
+	}
+	const LogicalType &GetVarArgs() const {
+		return varargs;
+	}
+	void SetVarArgs(LogicalType varargs_p) {
+		varargs = std::move(varargs_p);
+	}
 };
 
 class SimpleNamedParameterFunction : public SimpleFunction {

--- a/src/include/duckdb/function/function_set.hpp
+++ b/src/include/duckdb/function/function_set.hpp
@@ -27,6 +27,13 @@ public:
 	vector<T> functions;
 
 public:
+	void SetName(string name_p) {
+		name = std::move(name_p);
+	}
+	const string &GetName() const {
+		return name;
+	}
+
 	void AddFunction(T function) {
 		functions.push_back(std::move(function));
 	}

--- a/src/include/duckdb/parser/keyword_helper.hpp
+++ b/src/include/duckdb/parser/keyword_helper.hpp
@@ -32,6 +32,9 @@ public:
 	//! Writes a string that is optionally quoted + escaped so it can be used as an identifier
 	static string WriteOptionallyQuoted(const string &text, char quote = '"', bool allow_caps = true,
 	                                    KeywordCategory category = KeywordCategory::KEYWORD_NONE);
+
+	//! Wraps the text in `quote` and escapes any occurrence of `quote` within it by doubling it
+	static string WriteQuotedAndEscaped(const string &text, char quote);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/parser/parsed_data/alter_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/alter_info.hpp
@@ -70,7 +70,9 @@ public:
 	QualifiedName GetQualifiedName() const {
 		return QualifiedName(catalog, schema, name);
 	}
-	void SetQualifiedName(QualifiedName qualified_name) {
+	//! NOTE(backport): DuckDB 2.0 takes the `QualifiedName` by value and moves it into the stored member; here the
+	//! separate string members are copied out of it, so a const reference avoids a pointless copy.
+	void SetQualifiedName(const QualifiedName &qualified_name) {
 		catalog = qualified_name.catalog;
 		schema = qualified_name.schema;
 		name = qualified_name.name;

--- a/src/include/duckdb/parser/parsed_data/alter_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/alter_info.hpp
@@ -12,6 +12,7 @@
 #include "duckdb/parser/parsed_data/parse_info.hpp"
 #include "duckdb/common/enums/on_entry_not_found.hpp"
 #include "duckdb/catalog/dependency_list.hpp"
+#include "duckdb/parser/qualified_name.hpp"
 
 namespace duckdb {
 
@@ -63,6 +64,20 @@ public:
 	bool allow_internal;
 	//! New dependencies for the altered entry (set during binding)
 	unique_ptr<LogicalDependencyList> new_dependencies;
+
+public:
+	//! NOTE(backport): see the note on CreateInfo::GetQualifiedName - assembled on demand, returned by value.
+	QualifiedName GetQualifiedName() const {
+		return QualifiedName(catalog, schema, name);
+	}
+	void SetQualifiedName(QualifiedName qualified_name) {
+		catalog = qualified_name.catalog;
+		schema = qualified_name.schema;
+		name = qualified_name.name;
+	}
+	void SetQualifiedName(string catalog_p, string schema_p, string name_p) {
+		SetQualifiedName(QualifiedName(std::move(catalog_p), std::move(schema_p), std::move(name_p)));
+	}
 
 public:
 	virtual CatalogType GetCatalogType() const = 0;

--- a/src/include/duckdb/parser/parsed_data/create_function_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_function_info.hpp
@@ -35,6 +35,29 @@ struct CreateFunctionInfo : public CreateInfo {
 	//! Function description
 	vector<FunctionDescription> descriptions;
 
+	//! NOTE(backport): DuckDB 2.0 hoists these onto `CreateInfo`, which stores a single `QualifiedName` covering the
+	//! catalog, schema and name. On this branch `CreateInfo` still keeps `catalog`/`schema` as separate strings and
+	//! the name lives on the subclass, so the accessors live here instead. The spelling at the call site is the same
+	//! (`info.SetName(x)`), which is what matters for keeping the 2.0 diff small.
+	void SetName(string name_p) {
+		name = std::move(name_p);
+	}
+	const string &GetName() const {
+		return name;
+	}
+	const string &GetFunctionName() const {
+		return name;
+	}
+	void SetFunctionName(string name_p) {
+		name = std::move(name_p);
+	}
+	const string &GetEntryName() const override {
+		return name;
+	}
+	void SetEntryName(string name_p) override {
+		name = std::move(name_p);
+	}
+
 	DUCKDB_API void CopyFunctionProperties(CreateFunctionInfo &other) const;
 };
 

--- a/src/include/duckdb/parser/parsed_data/create_index_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_index_info.hpp
@@ -26,6 +26,22 @@ struct CreateIndexInfo : public CreateInfo {
 	//! The name of the index
 	string index_name;
 
+	//! NOTE(backport): DuckDB 2.0 stores catalog/schema/name in a single `QualifiedName` on `CreateInfo`; here they are
+	//! separate strings and the name lives on the subclass. These accessors only exist so that call sites can be
+	//! spelled exactly as they are on the 2.0 branch.
+	const string &GetIndexName() const {
+		return index_name;
+	}
+	void SetIndexName(string name_p) {
+		index_name = std::move(name_p);
+	}
+	const string &GetEntryName() const override {
+		return index_name;
+	}
+	void SetEntryName(string name_p) override {
+		index_name = std::move(name_p);
+	}
+
 	//! Options values (WITH ...)
 	case_insensitive_map_t<Value> options;
 

--- a/src/include/duckdb/parser/parsed_data/create_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_info.hpp
@@ -60,7 +60,9 @@ public:
 	QualifiedName GetQualifiedName() const {
 		return QualifiedName(catalog, schema, GetEntryName());
 	}
-	void SetQualifiedName(QualifiedName qualified_name) {
+	//! NOTE(backport): DuckDB 2.0 takes the `QualifiedName` by value and moves it into the stored member; here the
+	//! separate string members are copied out of it, so a const reference avoids a pointless copy.
+	void SetQualifiedName(const QualifiedName &qualified_name) {
 		catalog = qualified_name.catalog;
 		schema = qualified_name.schema;
 		SetEntryName(qualified_name.name);

--- a/src/include/duckdb/parser/parsed_data/create_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_info.hpp
@@ -14,6 +14,7 @@
 #include "duckdb/common/enums/on_create_conflict.hpp"
 #include "duckdb/common/types/value.hpp"
 #include "duckdb/catalog/dependency_list.hpp"
+#include "duckdb/parser/qualified_name.hpp"
 
 namespace duckdb {
 struct AlterInfo;
@@ -50,6 +51,44 @@ public:
 	Value comment;
 	//! Key-value tags with additional metadata
 	InsertionOrderPreservingMap<string> tags;
+
+public:
+	//! NOTE(backport): DuckDB 2.0 stores a single `QualifiedName` here and `GetQualifiedName()` hands out a reference
+	//! to it. Here the catalog/schema are separate members and the name lives on the subclass, so the QualifiedName has
+	//! to be assembled on demand and is returned by value. `GetQualifiedNameMutable()` therefore cannot be provided -
+	//! there is nothing to hand out a reference to.
+	QualifiedName GetQualifiedName() const {
+		return QualifiedName(catalog, schema, GetEntryName());
+	}
+	void SetQualifiedName(QualifiedName qualified_name) {
+		catalog = qualified_name.catalog;
+		schema = qualified_name.schema;
+		SetEntryName(qualified_name.name);
+	}
+	void SetQualifiedName(string catalog_p, string schema_p, string name_p) {
+		SetQualifiedName(QualifiedName(std::move(catalog_p), std::move(schema_p), std::move(name_p)));
+	}
+
+	//! The name of the created entry. Overridden by every subclass that has a name of its own - the base
+	//! implementation covers the CreateInfo types that have none (e.g. CREATE SCHEMA).
+	virtual const string &GetEntryName() const {
+		static const string EMPTY_NAME;
+		return EMPTY_NAME;
+	}
+	virtual void SetEntryName(string name_p) { // NOLINT: unused in the base - see above
+		throw InternalException("SetEntryName not supported for this type of CreateInfo: '%s'",
+		                        CatalogTypeToString(type));
+	}
+
+public:
+	//! NOTE(backport): DuckDB 2.0 writes these through the `QualifiedName`; here they write the separate members
+	//! directly. They exist so that call sites can be spelled exactly as they are on the 2.0 branch.
+	void SetCatalog(string catalog_p) {
+		catalog = std::move(catalog_p);
+	}
+	void SetSchema(string schema_p) {
+		schema = std::move(schema_p);
+	}
 
 public:
 	void Serialize(Serializer &serializer) const override;

--- a/src/include/duckdb/parser/parsed_data/create_sequence_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_sequence_info.hpp
@@ -32,6 +32,22 @@ struct CreateSequenceInfo : public CreateInfo {
 
 	//! Sequence name to create
 	string name;
+
+	//! NOTE(backport): DuckDB 2.0 stores catalog/schema/name in a single `QualifiedName` on `CreateInfo`; here they are
+	//! separate strings and the name lives on the subclass. These accessors only exist so that call sites can be
+	//! spelled exactly as they are on the 2.0 branch.
+	const string &GetSequenceName() const {
+		return name;
+	}
+	void SetSequenceName(string name_p) {
+		name = std::move(name_p);
+	}
+	const string &GetEntryName() const override {
+		return name;
+	}
+	void SetEntryName(string name_p) override {
+		name = std::move(name_p);
+	}
 	//! Usage count of the sequence
 	uint64_t usage_count;
 	//! The increment value

--- a/src/include/duckdb/parser/parsed_data/create_table_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_table_info.hpp
@@ -23,6 +23,22 @@ struct CreateTableInfo : public CreateInfo {
 
 	//! Table name to insert to
 	string table;
+
+	//! NOTE(backport): DuckDB 2.0 stores catalog/schema/name in a single `QualifiedName` on `CreateInfo`; here they are
+	//! separate strings and the name lives on the subclass. These accessors only exist so that call sites can be
+	//! spelled exactly as they are on the 2.0 branch.
+	const string &GetTableName() const {
+		return table;
+	}
+	void SetTableName(string name_p) {
+		table = std::move(name_p);
+	}
+	const string &GetEntryName() const override {
+		return table;
+	}
+	void SetEntryName(string name_p) override {
+		table = std::move(name_p);
+	}
 	//! List of columns of the table
 	ColumnList columns;
 	//! List of constraints on the table

--- a/src/include/duckdb/parser/parsed_data/create_type_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_type_info.hpp
@@ -56,6 +56,22 @@ struct CreateTypeInfo : public CreateInfo {
 
 	//! Name of the Type
 	string name;
+
+	//! NOTE(backport): DuckDB 2.0 stores catalog/schema/name in a single `QualifiedName` on `CreateInfo`; here they are
+	//! separate strings and the name lives on the subclass. These accessors only exist so that call sites can be
+	//! spelled exactly as they are on the 2.0 branch.
+	const string &GetTypeName() const {
+		return name;
+	}
+	void SetTypeName(string name_p) {
+		name = std::move(name_p);
+	}
+	const string &GetEntryName() const override {
+		return name;
+	}
+	void SetEntryName(string name_p) override {
+		name = std::move(name_p);
+	}
 	//! Logical Type
 	LogicalType type;
 	//! Used by create enum from query

--- a/src/include/duckdb/parser/parsed_data/create_view_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_view_info.hpp
@@ -23,6 +23,22 @@ public:
 public:
 	//! View name
 	string view_name;
+
+	//! NOTE(backport): DuckDB 2.0 stores catalog/schema/name in a single `QualifiedName` on `CreateInfo`; here they are
+	//! separate strings and the name lives on the subclass. These accessors only exist so that call sites can be
+	//! spelled exactly as they are on the 2.0 branch.
+	const string &GetViewName() const {
+		return view_name;
+	}
+	void SetViewName(string name_p) {
+		view_name = std::move(name_p);
+	}
+	const string &GetEntryName() const override {
+		return view_name;
+	}
+	void SetEntryName(string name_p) override {
+		view_name = std::move(name_p);
+	}
 	//! Aliases of the view
 	vector<string> aliases;
 	//! Return types

--- a/src/include/duckdb/parser/parsed_data/drop_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/drop_info.hpp
@@ -12,6 +12,7 @@
 #include "duckdb/parser/parsed_data/parse_info.hpp"
 #include "duckdb/parser/parsed_data/extra_drop_info.hpp"
 #include "duckdb/common/enums/on_entry_not_found.hpp"
+#include "duckdb/parser/qualified_name.hpp"
 
 namespace duckdb {
 struct ExtraDropInfo;
@@ -43,6 +44,19 @@ public:
 	unique_ptr<ExtraDropInfo> extra_drop_info;
 
 public:
+	//! NOTE(backport): see the note on CreateInfo::GetQualifiedName - assembled on demand, returned by value.
+	QualifiedName GetQualifiedName() const {
+		return QualifiedName(catalog, schema, name);
+	}
+	void SetQualifiedName(QualifiedName qualified_name) {
+		catalog = qualified_name.catalog;
+		schema = qualified_name.schema;
+		name = qualified_name.name;
+	}
+	void SetQualifiedName(string catalog_p, string schema_p, string name_p) {
+		SetQualifiedName(QualifiedName(std::move(catalog_p), std::move(schema_p), std::move(name_p)));
+	}
+
 	virtual unique_ptr<DropInfo> Copy() const;
 	string ToString() const;
 

--- a/src/include/duckdb/parser/parsed_data/drop_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/drop_info.hpp
@@ -48,7 +48,9 @@ public:
 	QualifiedName GetQualifiedName() const {
 		return QualifiedName(catalog, schema, name);
 	}
-	void SetQualifiedName(QualifiedName qualified_name) {
+	//! NOTE(backport): DuckDB 2.0 takes the `QualifiedName` by value and moves it into the stored member; here the
+	//! separate string members are copied out of it, so a const reference avoids a pointless copy.
+	void SetQualifiedName(const QualifiedName &qualified_name) {
 		catalog = qualified_name.catalog;
 		schema = qualified_name.schema;
 		name = qualified_name.name;

--- a/src/include/duckdb/parser/qualified_name.hpp
+++ b/src/include/duckdb/parser/qualified_name.hpp
@@ -36,9 +36,6 @@ struct QualifiedName {
 	string schema;
 	string name;
 
-	//! NOTE(backport): these return references into this QualifiedName, exactly as DuckDB 2.0 does, so the reference is
-	//! only valid while the QualifiedName is - `const string &s = QualifiedName::Parse(x).Name();` dangles, as it does on
-	//! DuckDB 2.0. GCC's -Wdangling-reference catches some of those shapes; clang catches none of them.
 	const string &Catalog() const {
 		return catalog;
 	}

--- a/src/include/duckdb/parser/qualified_name.hpp
+++ b/src/include/duckdb/parser/qualified_name.hpp
@@ -9,15 +9,66 @@
 #pragma once
 
 #include "duckdb/common/string.hpp"
+#include "duckdb/common/constants.hpp"
+#include "duckdb/common/string_util.hpp"
 #include "duckdb/planner/binding_alias.hpp"
 #include "duckdb/parser/keyword_helper.hpp"
 
 namespace duckdb {
 
 struct QualifiedName {
+	QualifiedName() = default;
+	//! NOTE(backport): DuckDB 2.0 stores the components as a single `vector<Identifier> path` behind accessors, in
+	//! preparation for multi-level schemas, and its constructors and accessors deal in `Identifier`. On this branch
+	//! catalog/schema/name are plain strings everywhere, so they stay strings here too - `Identifier` converts
+	//! implicitly to and from `string` on this branch, so 2.0 call sites that pass an Identifier still compile.
+	//! `Path()`/`WithQualification()` are not provided, since there is no path to expose.
+	//! Construct an unqualified name (no catalog/schema). Implicit so that a name can be passed wherever an
+	//! unqualified QualifiedName lookup is expected.
+	QualifiedName(string name_p) // NOLINT: allow implicit conversion
+	    : catalog(INVALID_CATALOG), schema(INVALID_SCHEMA), name(std::move(name_p)) {
+	}
+	QualifiedName(string catalog_p, string schema_p, string name_p)
+	    : catalog(std::move(catalog_p)), schema(std::move(schema_p)), name(std::move(name_p)) {
+	}
+
 	string catalog;
 	string schema;
 	string name;
+
+	//! NOTE(backport): these return references into this QualifiedName, exactly as DuckDB 2.0 does, so the reference is
+	//! only valid while the QualifiedName is - `const string &s = QualifiedName::Parse(x).Name();` dangles, as it does on
+	//! DuckDB 2.0. GCC's -Wdangling-reference catches some of those shapes; clang catches none of them.
+	const string &Catalog() const {
+		return catalog;
+	}
+	const string &Schema() const {
+		return schema;
+	}
+	const string &Name() const {
+		return name;
+	}
+
+	//! Return a copy of this name with the name replaced, keeping the catalog/schema qualification
+	QualifiedName WithName(string name_p) const {
+		return QualifiedName(catalog, schema, std::move(name_p));
+	}
+	//! Return a copy of this name qualified with the given catalog, replacing the catalog it already has
+	QualifiedName WithCatalog(string catalog_p) const {
+		return QualifiedName(std::move(catalog_p), schema, name);
+	}
+	//! Drop the catalog component (if any), keeping the schema and the name
+	void StripCatalog() {
+		catalog = INVALID_CATALOG;
+	}
+
+	bool operator==(const QualifiedName &rhs) const {
+		return StringUtil::CIEquals(catalog, rhs.catalog) && StringUtil::CIEquals(schema, rhs.schema) &&
+		       StringUtil::CIEquals(name, rhs.name);
+	}
+	bool operator!=(const QualifiedName &rhs) const {
+		return !(*this == rhs);
+	}
 
 	//! Parse the (optional) schema and a name from a string in the format of e.g. "schema"."table"; if there is no dot
 	//! the schema will be set to INVALID_SCHEMA

--- a/src/parser/keyword_helper.cpp
+++ b/src/parser/keyword_helper.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/parser/keyword_helper.hpp"
 #include "duckdb/parser/parser.hpp"
 #include "duckdb/common/string_util.hpp"
+#include "duckdb/common/identifier.hpp"
 
 namespace duckdb {
 
@@ -37,6 +38,21 @@ string KeywordHelper::EscapeQuotes(const string &text, char quote) {
 	return StringUtil::Replace(text, string(1, quote), string(2, quote));
 }
 
+string KeywordHelper::WriteQuotedAndEscaped(const string &text, char quote) {
+	string result;
+	result.reserve(text.size() + 2);
+	result += quote;
+	for (auto c : text) {
+		if (c == quote) {
+			// character matches quote - escape by adding the quote again
+			result += quote;
+		}
+		result += c;
+	}
+	result += quote;
+	return result;
+}
+
 string KeywordHelper::WriteQuoted(const string &text, char quote) {
 	// 1. Escapes all occurences of 'quote' by doubling them (escape in SQL)
 	// 2. Adds quotes around the string
@@ -48,6 +64,27 @@ string KeywordHelper::WriteOptionallyQuoted(const string &text, char quote, bool
 		return text;
 	}
 	return WriteQuoted(text, quote);
+}
+
+SQLIdentifier::SQLIdentifier(const Identifier &id) : raw_string(id.GetIdentifierName()) {
+}
+
+string SQLIdentifier::ToString(const string &identifier) {
+	if (!KeywordHelper::RequiresQuotes(identifier)) {
+		return identifier;
+	}
+	return SQLQuotedIdentifier::ToString(identifier);
+}
+
+SQLQuotedIdentifier::SQLQuotedIdentifier(const Identifier &id) : raw_string(id.GetIdentifierName()) {
+}
+
+string SQLQuotedIdentifier::ToString(const string &identifier) {
+	return KeywordHelper::WriteQuotedAndEscaped(identifier, '"');
+}
+
+string SQLString::ToString(const string &literal) {
+	return KeywordHelper::WriteQuotedAndEscaped(literal, '\'');
 }
 
 } // namespace duckdb


### PR DESCRIPTION
Makes it possible to write code in "DuckDB 2.0 style" against 1.5.6. This is useful for extensions that want to continue developing for 1.5, while already preparing for DuckDB 2.0.

This changes no existing behaviour, it only adds new APIs that can optionally be called by extensions. The only non-additive part is moving `SQLIdentifier`/`SQLString` out of `exception_format_value.hpp` into the new `sql_identifier.hpp`.

Where 1.5 cannot express what 2.0 does, a `NOTE(backport)` comment records what differs and why.

Added:

- `Identifier`, the `SQLIdentifier`/`SQLQuotedIdentifier`/`SQLString` format helpers, and their `Value` and (de)serializer support
- `StringUtil::CIEndsWith` and `KeywordHelper::WriteQuotedAndEscaped`
- accessors on `Function`, `FunctionSet` and `CreateFunctionInfo`: `GetName`/`SetName`, `GetArguments`, `GetOriginalArguments`, `GetVarArgs`
- `DataChunk::SetChildCardinality`, `CheckCardinality` and `SetCardinalityUnsafe` - all equivalent to `SetCardinality` here, since vectors on this branch carry no size of their own to resize or verify
- name accessors on the `CreateXInfo` classes (`GetTableName`/`SetTableName`, `GetViewName`, `GetIndexName`, `GetTypeName`, `GetSequenceName`, `GetFunctionName`) plus `SetCatalog`/`SetSchema` on `CreateInfo`
- `QualifiedName` constructors, `Catalog()`/`Schema()`/`Name()`, `WithName`, `WithCatalog`, `StripCatalog` and `operator==`
- `Get`/`SetQualifiedName` on `CreateInfo`, `AlterInfo` and `DropInfo`
- `Catalog::GetEntry<T>(context, QualifiedName, ...)`
