### PR TITLE
Async streaming results

### DIFF
--- a/benchmark/group_descriptions.list
+++ b/benchmark/group_descriptions.list
@@ -30,6 +30,10 @@ The join micro benchmark set contains benchmarks that look at the speed of vario
 [Order]
 The order micro benchmark set contains benchmarks that look at the speed of sorting data using the ORDER BY clause.
 
+[result_collection]
+[Result Collection]
+The result collection benchmarks measure how query results are delivered to a client: streaming results in synchronous and asynchronous execution mode, drained fully or materialized.
+
 [tpch]
 [TPC-H]
 The TPC-H benchmark is an industry standard benchmark geared towards measuring the performance of OLAP systems. It consists of 22 different queries that test different optimizations in the system.

--- a/benchmark/include/interpreted_benchmark.hpp
+++ b/benchmark/include/interpreted_benchmark.hpp
@@ -7,6 +7,8 @@
 #pragma once
 
 #include "benchmark.hpp"
+#include "duckdb/common/query_parameters.hpp"
+#include "duckdb/common/enums/streaming_execution_mode.hpp"
 #include "duckdb/main/query_result.hpp"
 
 #include <unordered_map>
@@ -16,6 +18,7 @@
 namespace duckdb {
 struct BenchmarkFileReader;
 class MaterializedQueryResult;
+class StreamQueryResult;
 struct InterpretedBenchmarkState;
 
 const string DEFAULT_DB_PATH = "duckdb_benchmark_db.db";
@@ -83,6 +86,8 @@ private:
 	BenchmarkQuery ReadQueryFromReader(BenchmarkFileReader &reader, const string &sql, const string &header);
 
 	unique_ptr<QueryResult> RunLoadQuery(InterpretedBenchmarkState &state, const string &load_query);
+	//! Consume a streaming result according to the configured drain mode
+	unique_ptr<MaterializedQueryResult> DrainStream(InterpretedBenchmarkState &state, StreamQueryResult &stream);
 
 	void ProcessFile(const string &path);
 	void AddExtension(const string &extension, bool load_only);
@@ -118,6 +123,9 @@ private:
 	bool in_memory = true;
 	string storage_version;
 	QueryResultType result_type = QueryResultType::MATERIALIZED_RESULT;
+	StreamingExecutionMode execution_mode = StreamingExecutionMode::SYNC;
+	//! Discard fetched chunks instead of materializing them into the benchmark result
+	bool discard_stream_result = false;
 	idx_t arrow_batch_size = STANDARD_VECTOR_SIZE;
 	bool require_reinit = false;
 };

--- a/benchmark/interpreted_benchmark.cpp
+++ b/benchmark/interpreted_benchmark.cpp
@@ -2,11 +2,17 @@
 
 #include "benchmark_runner.hpp"
 #include "duckdb.hpp"
+#include "duckdb/common/enums/stream_execution_result.hpp"
+#include "duckdb/common/error_data.hpp"
 #include "duckdb/common/string_util.hpp"
+#include "duckdb/common/types/column/column_data_collection.hpp"
+#include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/client_config.hpp"
 #include "duckdb/main/extension_helper.hpp"
+#include "duckdb/main/materialized_query_result.hpp"
 #include "duckdb/main/query_profiler.hpp"
+#include "duckdb/main/stream_query_result.hpp"
 #include "test_helpers.hpp"
 #include "duckdb/common/helper.hpp"
 #include "duckdb/execution/operator/helper/physical_result_collector.hpp"
@@ -234,11 +240,31 @@ void InterpretedBenchmark::ProcessFile(const string &path) {
 				ThrowResultModeError(reader);
 			}
 			if (splits[1] == "streaming") {
-				if (splits.size() != 2) {
-					throw std::runtime_error(
-					    reader.FormatException("resultmode 'streaming' does not accept a parameter"));
-				}
 				result_type = QueryResultType::STREAM_RESULT;
+				bool mode_set = false;
+				bool drain_set = false;
+				for (idx_t i = 2; i < splits.size(); i++) {
+					if (splits[i] == "sync" || splits[i] == "async") {
+						if (mode_set) {
+							throw std::runtime_error(
+							    reader.FormatException("resultmode 'streaming' got more than one execution mode"));
+						}
+						mode_set = true;
+						execution_mode =
+						    splits[i] == "sync" ? StreamingExecutionMode::SYNC : StreamingExecutionMode::ASYNC;
+					} else if (splits[i] == "materialize" || splits[i] == "drop") {
+						if (drain_set) {
+							throw std::runtime_error(
+							    reader.FormatException("resultmode 'streaming' got more than one drain mode"));
+						}
+						drain_set = true;
+						discard_stream_result = splits[i] == "drop";
+					} else {
+						throw std::runtime_error(
+						    reader.FormatException("resultmode 'streaming' only accepts 'sync', 'async', "
+						                           "'materialize' and 'drop' as parameters"));
+					}
+				}
 			} else if (splits[1] == "arrow") {
 				arrow_batch_size = STANDARD_VECTOR_SIZE;
 				if (splits.size() == 3) {
@@ -607,6 +633,12 @@ unique_ptr<BenchmarkState> InterpretedBenchmark::Initialize(BenchmarkConfigurati
 		return Initialize(config);
 	}
 
+	if (execution_mode == StreamingExecutionMode::ASYNC) {
+		auto mode_result = state->con.Query("SET streaming_execution_mode='async'");
+		if (mode_result->HasError()) {
+			mode_result->ThrowError();
+		}
+	}
 	if (config.profile_info == BenchmarkProfileInfo::NORMAL) {
 		state->con.Query("PRAGMA enable_profiling");
 	} else if (config.profile_info == BenchmarkProfileInfo::DETAILED) {
@@ -659,21 +691,43 @@ void InterpretedBenchmark::Run(BenchmarkState *state_p) {
 
 	auto &config = ClientConfig::GetConfig(*context);
 	auto result_collector_setting = PrepareResultCollector(config, *this);
-	const bool use_streaming = result_type == QueryResultType::STREAM_RESULT;
-	auto temp_result = context->Query(run_query, use_streaming);
+	QueryParameters parameters(result_type == QueryResultType::STREAM_RESULT);
+	auto temp_result = context->Query(run_query, parameters);
+	if (temp_result->HasError()) {
+		// report the query error instead of failing the result type check below
+		state.result = make_uniq<MaterializedQueryResult>(temp_result->GetErrorObject());
+		return;
+	}
 	if (temp_result->GetResultType() != result_type) {
 		throw InternalException("Query did not produce the right result type, expected %s but got %s",
 		                        EnumUtil::ToString(result_type), EnumUtil::ToString(temp_result->GetResultType()));
 	}
 	if (temp_result->GetResultType() == QueryResultType::STREAM_RESULT) {
 		auto &stream_query = temp_result->Cast<StreamQueryResult>();
-		state.result = stream_query.Materialize();
+		state.result = DrainStream(state, stream_query);
 	} else if (temp_result->GetResultType() == QueryResultType::ARROW_RESULT) {
 		/* no-op, this is only used to test the overhead of the result collector */
 		state.result = nullptr;
 	} else {
 		state.result = unique_ptr_cast<duckdb::QueryResult, duckdb::MaterializedQueryResult>(std::move(temp_result));
 	}
+}
+
+unique_ptr<MaterializedQueryResult> InterpretedBenchmark::DrainStream(InterpretedBenchmarkState &state,
+                                                                      StreamQueryResult &stream) {
+	if (!discard_stream_result) {
+		return stream.Materialize();
+	}
+	while (true) {
+		auto chunk = stream.Fetch();
+		if (!chunk || chunk->size() == 0) {
+			break;
+		}
+	}
+	if (stream.HasError()) {
+		return make_uniq<MaterializedQueryResult>(stream.GetErrorObject());
+	}
+	return nullptr;
 }
 
 void InterpretedBenchmark::Cleanup(BenchmarkState *state_p) {

--- a/benchmark/micro/result_collection/stream_async_drop.benchmark
+++ b/benchmark/micro/result_collection/stream_async_drop.benchmark
@@ -1,0 +1,7 @@
+# name: benchmark/micro/result_collection/stream_async_drop.benchmark
+# description: Async streaming result: blocking Fetch parks on a condition variable, chunks dropped
+# group: [result_collection]
+
+template benchmark/micro/result_collection/stream_drain.benchmark.in
+mode=async
+drain=drop

--- a/benchmark/micro/result_collection/stream_async_materialize.benchmark
+++ b/benchmark/micro/result_collection/stream_async_materialize.benchmark
@@ -1,0 +1,7 @@
+# name: benchmark/micro/result_collection/stream_async_materialize.benchmark
+# description: Async streaming result: blocking Fetch parks on a condition variable, chunks materialized
+# group: [result_collection]
+
+template benchmark/micro/result_collection/stream_drain.benchmark.in
+mode=async
+drain=materialize

--- a/benchmark/micro/result_collection/stream_drain.benchmark.in
+++ b/benchmark/micro/result_collection/stream_drain.benchmark.in
@@ -1,0 +1,22 @@
+# name: benchmark/micro/result_collection/stream_drain.benchmark.in
+# description: Template for the streaming result drain benchmarks
+# group: [result_collection]
+
+name stream_${mode}_${drain}
+group micro
+subgroup result_collection
+
+resultmode streaming ${mode} ${drain}
+
+argument buffer_size 1000000b
+
+cache stream_drain_data.duckdb
+
+init
+set streaming_buffer_size='${buffer_size}';
+
+load
+create table tbl as select 'this is a reasonably long string ' || i as a from range(25000000) t(i);
+
+run
+select * from tbl;

--- a/benchmark/micro/result_collection/stream_sync_drop.benchmark
+++ b/benchmark/micro/result_collection/stream_sync_drop.benchmark
@@ -1,0 +1,7 @@
+# name: benchmark/micro/result_collection/stream_sync_drop.benchmark
+# description: Sync streaming result: blocking Fetch drives execution, chunks dropped
+# group: [result_collection]
+
+template benchmark/micro/result_collection/stream_drain.benchmark.in
+mode=sync
+drain=drop

--- a/benchmark/micro/result_collection/stream_sync_materialize.benchmark
+++ b/benchmark/micro/result_collection/stream_sync_materialize.benchmark
@@ -1,0 +1,7 @@
+# name: benchmark/micro/result_collection/stream_sync_materialize.benchmark
+# description: Sync streaming result: blocking Fetch drives execution, chunks materialized
+# group: [result_collection]
+
+template benchmark/micro/result_collection/stream_drain.benchmark.in
+mode=sync
+drain=materialize

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -75,6 +75,7 @@
 #include "duckdb/common/enums/statement_type.hpp"
 #include "duckdb/common/enums/storage_block_prefetch.hpp"
 #include "duckdb/common/enums/stream_execution_result.hpp"
+#include "duckdb/common/enums/streaming_execution_mode.hpp"
 #include "duckdb/common/enums/subquery_type.hpp"
 #include "duckdb/common/enums/table_function_identifier_conversion.hpp"
 #include "duckdb/common/enums/tableref_type.hpp"
@@ -6012,6 +6013,24 @@ const char* EnumUtil::ToChars<StreamExecutionResult>(StreamExecutionResult value
 template<>
 StreamExecutionResult EnumUtil::FromString<StreamExecutionResult>(const char *value) {
 	return static_cast<StreamExecutionResult>(StringUtil::StringToEnum(GetStreamExecutionResultValues(), 7, "StreamExecutionResult", value));
+}
+
+const StringUtil::EnumStringLiteral *GetStreamingExecutionModeValues() {
+	static constexpr StringUtil::EnumStringLiteral values[] {
+		{ static_cast<uint32_t>(StreamingExecutionMode::SYNC), "SYNC" },
+		{ static_cast<uint32_t>(StreamingExecutionMode::ASYNC), "ASYNC" }
+	};
+	return values;
+}
+
+template<>
+const char* EnumUtil::ToChars<StreamingExecutionMode>(StreamingExecutionMode value) {
+	return StringUtil::EnumToString(GetStreamingExecutionModeValues(), 2, "StreamingExecutionMode", static_cast<uint32_t>(value));
+}
+
+template<>
+StreamingExecutionMode EnumUtil::FromString<StreamingExecutionMode>(const char *value) {
+	return static_cast<StreamingExecutionMode>(StringUtil::StringToEnum(GetStreamingExecutionModeValues(), 2, "StreamingExecutionMode", value));
 }
 
 const StringUtil::EnumStringLiteral *GetSubqueryTypeValues() {

--- a/src/common/metrics.json
+++ b/src/common/metrics.json
@@ -51,6 +51,11 @@
 			"description": "Peak memory usage of the buffer manager",
 			"unit": "bytes"
 		},
+		"peak_streaming_buffer_size": {
+			"metric_type": "uint64",
+			"description": "Peak number of bytes buffered by a streaming query result",
+			"unit": "bytes"
+		},
 		"peak_temp_dir_size": {
 			"metric_type": "uint64",
 			"description": "Peak size of the temporary directory",

--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -1050,6 +1050,16 @@
         ]
     },
     {
+        "name": "max_streaming_buffer_size",
+        "description": "The maximum number of bytes a streaming query result buffers (e.g. 1GB). Buffered bytes stay under this cap plus at most one chunk: an oversized chunk is only admitted into an empty queue",
+        "type": "VARCHAR",
+        "scope": "local",
+        "custom_implementation": true,
+        "aliases": [
+            "streaming_buffer_size"
+        ]
+    },
+    {
         "name": "max_temp_directory_size",
         "description": "The maximum amount of data stored inside the 'temp_directory' (when set) (e.g. 1GB)",
         "type": "VARCHAR",
@@ -1331,9 +1341,9 @@
         "custom_implementation": true
     },
     {
-        "name": "streaming_buffer_size",
-        "description": "The maximum memory to buffer between fetching from a streaming result (e.g. 1GB)",
-        "type": "VARCHAR",
+        "name": "streaming_execution_mode",
+        "description": "Execution mode for streaming query results (SYNC or ASYNC). In SYNC mode fetching drives execution on the calling thread. In ASYNC mode background workers produce the result and fetching never runs engine work. Ignored for non-streaming results",
+        "type": "ENUM<StreamingExecutionMode>",
         "scope": "local",
         "custom_implementation": true
     },

--- a/src/execution/operator/helper/physical_buffered_batch_collector.cpp
+++ b/src/execution/operator/helper/physical_buffered_batch_collector.cpp
@@ -1,16 +1,18 @@
 #include "duckdb/execution/operator/helper/physical_buffered_batch_collector.hpp"
 
+#include "duckdb/common/query_parameters.hpp"
 #include "duckdb/common/types/batched_data_collection.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/materialized_query_result.hpp"
 #include "duckdb/main/buffered_data/buffered_data.hpp"
 #include "duckdb/main/buffered_data/batched_buffered_data.hpp"
+#include "duckdb/main/prepared_statement_data.hpp"
 #include "duckdb/main/stream_query_result.hpp"
 
 namespace duckdb {
 
 PhysicalBufferedBatchCollector::PhysicalBufferedBatchCollector(PhysicalPlan &physical_plan, PreparedStatementData &data)
-    : PhysicalResultCollector(physical_plan, data) {
+    : PhysicalResultCollector(physical_plan, data), async(data.execution_mode == StreamingExecutionMode::ASYNC) {
 }
 
 //===--------------------------------------------------------------------===//
@@ -35,19 +37,16 @@ SinkResultType PhysicalBufferedBatchCollector::Sink(ExecutionContext &context, D
 	auto min_batch_index = lstate.partition_info.min_batch_index.GetIndex();
 
 	auto &buffered_data = gstate.buffered_data->Cast<BatchedBufferedData>();
+	if (lstate.chunk_deposited) {
+		lstate.chunk_deposited = false;
+		return SinkResultType::NEED_MORE_INPUT;
+	}
 	buffered_data.UpdateMinBatchIndex(min_batch_index);
 
-	if (buffered_data.ShouldBlockBatch(batch)) {
-		auto callback_state = input.interrupt_state;
-		buffered_data.BlockSink(callback_state, batch);
+	if (buffered_data.AppendOrBlock(chunk, batch, input.interrupt_state)) {
+		lstate.chunk_deposited = true;
 		return SinkResultType::BLOCKED;
 	}
-
-	// FIXME: if we want to make this more accurate, we should grab a reservation on the buffer space
-	// while we're unlocked some other thread could also append, causing us to potentially cross our buffer size
-
-	buffered_data.Append(chunk, batch);
-
 	return SinkResultType::NEED_MORE_INPUT;
 }
 
@@ -101,7 +100,17 @@ unique_ptr<LocalSinkState> PhysicalBufferedBatchCollector::GetLocalSinkState(Exe
 unique_ptr<GlobalSinkState> PhysicalBufferedBatchCollector::GetGlobalSinkState(ClientContext &context) const {
 	auto state = make_uniq<BufferedBatchCollectorGlobalState>();
 	state->context = context.shared_from_this();
-	state->buffered_data = make_shared_ptr<BatchedBufferedData>(context);
+	if (async) {
+		state->buffered_data = make_shared_ptr<BatchedBufferedDataAsync>(context);
+		// A notify callback passed at execution time is set before this buffer exists
+		auto notifier = context.GetActiveResultNotifier();
+		if (notifier) {
+			state->buffered_data->SetResultNotifier(std::move(notifier));
+		}
+	} else {
+		state->buffered_data = make_shared_ptr<BatchedBufferedDataSync>(context);
+	}
+	Executor::Get(context).SetStreamingBufferedData(*state->buffered_data);
 	return std::move(state);
 }
 

--- a/src/execution/operator/helper/physical_buffered_collector.cpp
+++ b/src/execution/operator/helper/physical_buffered_collector.cpp
@@ -1,4 +1,6 @@
 #include "duckdb/execution/operator/helper/physical_buffered_collector.hpp"
+#include "duckdb/common/query_parameters.hpp"
+#include "duckdb/main/prepared_statement_data.hpp"
 #include "duckdb/main/stream_query_result.hpp"
 #include "duckdb/main/client_context.hpp"
 
@@ -6,7 +8,8 @@ namespace duckdb {
 
 PhysicalBufferedCollector::PhysicalBufferedCollector(PhysicalPlan &physical_plan, PreparedStatementData &data,
                                                      bool parallel)
-    : PhysicalResultCollector(physical_plan, data), parallel(parallel) {
+    : PhysicalResultCollector(physical_plan, data), parallel(parallel),
+      async(data.execution_mode == StreamingExecutionMode::ASYNC) {
 }
 
 //===--------------------------------------------------------------------===//
@@ -14,29 +17,31 @@ PhysicalBufferedCollector::PhysicalBufferedCollector(PhysicalPlan &physical_plan
 //===--------------------------------------------------------------------===//
 class BufferedCollectorGlobalState : public GlobalSinkState {
 public:
-	mutex glock;
 	//! This is weak to avoid creating a cyclical reference
 	weak_ptr<ClientContext> context;
+	//! Set once, before execution starts. The buffer synchronizes itself.
 	shared_ptr<BufferedData> buffered_data;
 };
 
-class BufferedCollectorLocalState : public LocalSinkState {};
+class BufferedCollectorLocalState : public LocalSinkState {
+public:
+	//! The parked chunk is deposited by restart selection. The re-entered Sink must not append it again
+	bool chunk_deposited = false;
+};
 
 SinkResultType PhysicalBufferedCollector::Sink(ExecutionContext &context, DataChunk &chunk,
                                                OperatorSinkInput &input) const {
 	auto &gstate = input.global_state.Cast<BufferedCollectorGlobalState>();
 	auto &lstate = input.local_state.Cast<BufferedCollectorLocalState>();
-	(void)lstate;
-
-	lock_guard<mutex> l(gstate.glock);
+	if (lstate.chunk_deposited) {
+		lstate.chunk_deposited = false;
+		return SinkResultType::NEED_MORE_INPUT;
+	}
 	auto &buffered_data = gstate.buffered_data->Cast<SimpleBufferedData>();
-
-	if (buffered_data.BufferIsFull()) {
-		auto callback_state = input.interrupt_state;
-		buffered_data.BlockSink(callback_state);
+	if (buffered_data.AppendOrBlock(chunk, input.interrupt_state)) {
+		lstate.chunk_deposited = true;
 		return SinkResultType::BLOCKED;
 	}
-	buffered_data.Append(chunk);
 	return SinkResultType::NEED_MORE_INPUT;
 }
 
@@ -48,7 +53,15 @@ SinkCombineResultType PhysicalBufferedCollector::Combine(ExecutionContext &conte
 unique_ptr<GlobalSinkState> PhysicalBufferedCollector::GetGlobalSinkState(ClientContext &context) const {
 	auto state = make_uniq<BufferedCollectorGlobalState>();
 	state->context = context.shared_from_this();
-	state->buffered_data = make_shared_ptr<SimpleBufferedData>(context);
+	state->buffered_data = make_shared_ptr<SimpleBufferedData>(context, async);
+	Executor::Get(context).SetStreamingBufferedData(*state->buffered_data);
+	if (async) {
+		// A notify callback passed at execution time is set before this buffer exists
+		auto notifier = context.GetActiveResultNotifier();
+		if (notifier) {
+			state->buffered_data->SetResultNotifier(std::move(notifier));
+		}
+	}
 	return std::move(state);
 }
 
@@ -59,7 +72,6 @@ unique_ptr<LocalSinkState> PhysicalBufferedCollector::GetLocalSinkState(Executio
 
 unique_ptr<QueryResult> PhysicalBufferedCollector::GetResult(GlobalSinkState &state) const {
 	auto &gstate = state.Cast<BufferedCollectorGlobalState>();
-	lock_guard<mutex> l(gstate.glock);
 	// FIXME: maybe we want to check if the execution was successful before creating the StreamQueryResult ?
 	auto cc = gstate.context.lock();
 	auto result = make_uniq<StreamQueryResult>(statement_type, properties, types, names, cc->GetClientProperties(),

--- a/src/execution/operator/helper/physical_result_collector.cpp
+++ b/src/execution/operator/helper/physical_result_collector.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/execution/operator/helper/physical_result_collector.hpp"
 
+#include "duckdb/common/exception.hpp"
 #include "duckdb/execution/operator/helper/physical_batch_collector.hpp"
 #include "duckdb/execution/operator/helper/physical_buffered_batch_collector.hpp"
 #include "duckdb/execution/operator/helper/physical_materialized_collector.hpp"

--- a/src/include/duckdb/common/enum_util.hpp
+++ b/src/include/duckdb/common/enum_util.hpp
@@ -540,6 +540,8 @@ enum class StrTimeSpecifier : uint8_t;
 
 enum class StreamExecutionResult : uint8_t;
 
+enum class StreamingExecutionMode : uint8_t;
+
 enum class SubqueryType : uint8_t;
 
 enum class SuggestionState : uint8_t;
@@ -1390,6 +1392,9 @@ const char* EnumUtil::ToChars<StrTimeSpecifier>(StrTimeSpecifier value);
 
 template<>
 const char* EnumUtil::ToChars<StreamExecutionResult>(StreamExecutionResult value);
+
+template<>
+const char* EnumUtil::ToChars<StreamingExecutionMode>(StreamingExecutionMode value);
 
 template<>
 const char* EnumUtil::ToChars<SubqueryType>(SubqueryType value);
@@ -2285,6 +2290,9 @@ StrTimeSpecifier EnumUtil::FromString<StrTimeSpecifier>(const char *value);
 
 template<>
 StreamExecutionResult EnumUtil::FromString<StreamExecutionResult>(const char *value);
+
+template<>
+StreamingExecutionMode EnumUtil::FromString<StreamingExecutionMode>(const char *value);
 
 template<>
 SubqueryType EnumUtil::FromString<SubqueryType>(const char *value);

--- a/src/include/duckdb/common/enums/streaming_execution_mode.hpp
+++ b/src/include/duckdb/common/enums/streaming_execution_mode.hpp
@@ -1,0 +1,21 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/enums/streaming_execution_mode.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/constants.hpp"
+
+namespace duckdb {
+
+//! SYNC is the default. Fetch calls drive execution and restart blocked producers.
+//! In ASYNC mode background workers keep the result buffer filled. Fetching never
+//! runs execution. Selected via the global streaming_execution_mode setting. Applies
+//! only to streaming results. Read once per query at submission.
+enum class StreamingExecutionMode : uint8_t { SYNC, ASYNC };
+
+} // namespace duckdb

--- a/src/include/duckdb/execution/executor.hpp
+++ b/src/include/duckdb/execution/executor.hpp
@@ -14,6 +14,7 @@
 #include "duckdb/common/pair.hpp"
 #include "duckdb/common/reference_map.hpp"
 #include "duckdb/main/query_result.hpp"
+#include "duckdb/main/query_result_notifier.hpp"
 #include "duckdb/execution/task_error_manager.hpp"
 #include "duckdb/execution/progress_data.hpp"
 #include "duckdb/parallel/pipeline.hpp"
@@ -21,6 +22,7 @@
 #include <condition_variable>
 
 namespace duckdb {
+class BufferedData;
 class ClientContext;
 class DataChunk;
 class PhysicalOperator;
@@ -57,6 +59,14 @@ public:
 	void CancelTasks();
 	PendingExecutionResult ExecuteTask(bool dry_run = false);
 	void WaitForTask();
+	//! Bounded wait for background progress. Ignores the producer queue, for async
+	//! result consumers that never run tasks.
+	void WaitForProgress();
+
+private:
+	void WaitForTaskInternal(bool consider_producer_queue);
+
+public:
 	void SignalTaskRescheduled(lock_guard<mutex> &);
 
 	void Reset();
@@ -89,9 +99,7 @@ public:
 	//! Returns the progress of the pipelines
 	idx_t GetPipelinesProgress(ProgressData &progress);
 
-	void CompletePipeline() {
-		completed_pipelines++;
-	}
+	void CompletePipeline();
 	ProducerToken &GetToken() {
 		return *producer;
 	}
@@ -115,6 +123,14 @@ public:
 	}
 	void UnregisterTask();
 
+	//! Notify an async stream consumer that execution reached a terminal state
+	void NotifyResultTerminal();
+	//! Publish the streaming result buffer for ResultIsObservable. Called by the
+	//! buffered collectors when their global sink state is created
+	void SetStreamingBufferedData(BufferedData &buffer);
+	//! Set the notifier called when execution finishes or errors (async streaming results)
+	void SetResultNotifier(shared_ptr<QueryResultNotifier> result_notifier_p);
+
 	idx_t GetTotalPipelines() const {
 		return total_pipelines;
 	}
@@ -126,6 +142,8 @@ public:
 private:
 	//! Check if the streaming query result is waiting to be fetched from, must hold the 'executor_lock'
 	bool ResultCollectorIsBlocked();
+	//! Whether the streaming result already holds a consumable chunk
+	bool ResultIsObservable();
 	void InitializeInternal(PhysicalOperator &physical_plan);
 
 	void ScheduleEvents(const vector<shared_ptr<MetaPipeline>> &meta_pipelines);
@@ -185,6 +203,19 @@ private:
 
 	//! Currently alive executor tasks
 	atomic<idx_t> executor_tasks;
+	//! Leaf lock for the notifier slot. PushError can run while a thread holds
+	//! executor_lock during event scheduling, so the slot must not share that lock.
+	annotated_mutex result_notifier_lock;
+	//! Called when execution finishes, errors, or is cancelled (may be null)
+	shared_ptr<QueryResultNotifier> result_notifier DUCKDB_GUARDED_BY(result_notifier_lock);
+	//! The running query's streaming result buffer, or null when the query has none.
+	//! The buffered result collector stores it here when it creates its global sink
+	//! state. That happens in a task on a worker thread, so the pointer is atomic:
+	//! reading the sink state itself from another thread would race with its creation.
+	//! The pointer cannot dangle. The sink state owns the buffer, it is only torn down
+	//! by Reset or by a new Initialize, and both hold the client context lock, just
+	//! like every reader (all reads happen inside ExecuteTask).
+	atomic<BufferedData *> streaming_buffered_data {nullptr};
 
 	//! Total time blocked while waiting on tasks. In ticks. One tick corresponds to WAIT_TIME.
 	atomic<idx_t> blocked_thread_time;

--- a/src/include/duckdb/execution/operator/helper/physical_buffered_batch_collector.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_buffered_batch_collector.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "duckdb/execution/operator/helper/physical_result_collector.hpp"
+#include "duckdb/common/enums/streaming_execution_mode.hpp"
 #include "duckdb/common/queue.hpp"
 
 namespace duckdb {
@@ -19,6 +20,8 @@ public:
 
 public:
 	idx_t current_batch = 0;
+	//! The parked chunk is deposited by restart selection. The re-entered Sink must not append it again
+	bool chunk_deposited = false;
 };
 
 class PhysicalBufferedBatchCollector : public PhysicalResultCollector {
@@ -53,6 +56,10 @@ public:
 	bool IsStreaming() const override {
 		return true;
 	}
+
+private:
+	//! Whether background workers keep the buffer filled (see StreamingExecutionMode)
+	bool async;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/execution/operator/helper/physical_buffered_collector.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_buffered_collector.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "duckdb/execution/operator/helper/physical_result_collector.hpp"
+#include "duckdb/common/enums/streaming_execution_mode.hpp"
 
 namespace duckdb {
 
@@ -17,6 +18,8 @@ public:
 	PhysicalBufferedCollector(PhysicalPlan &physical_plan, PreparedStatementData &data, bool parallel);
 
 	bool parallel;
+	//! Whether the result buffer is kept filled by background workers (see StreamingExecutionMode)
+	bool async;
 
 public:
 	unique_ptr<QueryResult> GetResult(GlobalSinkState &state) const override;

--- a/src/include/duckdb/main/buffered_data/batched_buffered_data.hpp
+++ b/src/include/duckdb/main/buffered_data/batched_buffered_data.hpp
@@ -10,10 +10,13 @@
 
 #include "duckdb/parallel/interrupt.hpp"
 #include "duckdb/common/deque.hpp"
+#include "duckdb/common/thread_annotation.hpp"
 #include "duckdb/common/vector_size.hpp"
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/main/buffered_data/simple_buffered_data.hpp"
 #include "duckdb/common/map.hpp"
+#include "duckdb/common/pair.hpp"
+#include "duckdb/common/vector.hpp"
 
 namespace duckdb {
 
@@ -27,25 +30,31 @@ public:
 	bool completed = false;
 };
 
+//! Shared base of the batched (order-preserving) streaming buffer. The subclasses
+//! differ only in who drives execution (see StreamingExecutionMode).
 class BatchedBufferedData : public BufferedData {
 public:
 	static constexpr const BufferedData::Type TYPE = BufferedData::Type::BATCHED;
 
-public:
-	explicit BatchedBufferedData(ClientContext &context);
+protected:
+	BatchedBufferedData(ClientContext &context, bool async);
 
 public:
-	void Append(const DataChunk &chunk, idx_t batch);
-	void BlockSink(const InterruptState &blocked_sink, idx_t batch);
+	//! Buffer a copy of the chunk, or block the sink when the chunk does not fit.
+	//! The decision and the byte accounting share one critical section, so racing
+	//! producers cannot push the buffered bytes past the cap. Returns true on block.
+	bool AppendOrBlock(const DataChunk &chunk, idx_t batch, const InterruptState &blocked_sink);
 
-	bool ShouldBlockBatch(idx_t batch);
-	StreamExecutionResult ExecuteTaskInternal(StreamQueryResult &result, ClientContextLock &context_lock) override;
 	unique_ptr<DataChunk> Scan() override;
 	void UpdateMinBatchIndex(idx_t min_batch_index);
-	bool IsMinimumBatchIndex(lock_guard<mutex> &lock, idx_t batch);
+	bool IsMinimumBatchIndex(annotated_lock_guard<annotated_mutex> &lock, idx_t batch) DUCKDB_REQUIRES(glock);
 	void CompleteBatch(idx_t batch);
 	bool BufferIsEmpty();
+	bool HasObservableChunk() override {
+		return !BufferIsEmpty();
+	}
 	void UnblockSinks() override;
+	void AssertNoBlockedSinks() override;
 
 	inline idx_t ReadQueueCapacity() const {
 		return read_queue_capacity;
@@ -53,27 +62,86 @@ public:
 	inline idx_t BufferCapacity() const {
 		return buffer_capacity;
 	}
+	//! Restarts performed by minimum batch advances that freed no bytes
+	idx_t MovedNothingRestarts() {
+		annotated_lock_guard<annotated_mutex> lock(glock);
+		return moved_nothing_restarts;
+	}
+	//! The highest number of bytes the buffer ever held
+	idx_t PeakBufferedBytes() override {
+		annotated_lock_guard<annotated_mutex> lock(glock);
+		return peak_buffered_bytes;
+	}
 
-private:
+protected:
 	void ResetReplenishState();
-	void MoveCompletedBatches(lock_guard<mutex> &lock);
+	void MoveCompletedBatches(annotated_lock_guard<annotated_mutex> &lock) DUCKDB_REQUIRES(glock);
+	//! Whether a chunk of incoming_bytes may not be buffered for this batch right now.
+	//! An oversized chunk is admitted only into an empty pool, so the stream keeps progressing
+	virtual bool ShouldBlockBatch(annotated_lock_guard<annotated_mutex> &lock, idx_t batch, idx_t incoming_bytes)
+	    DUCKDB_REQUIRES(glock);
+	//! Whether a pop can newly make a blocked sink eligible for restart. The caller holds glock
+	virtual bool PopMayFreeSinks(annotated_lock_guard<annotated_mutex> &lock) DUCKDB_REQUIRES(glock);
+	//! Pop restartable sinks into to_unblock. The caller holds glock
+	void CollectRestartableSinks(annotated_lock_guard<annotated_mutex> &lock,
+	                             vector<pair<idx_t, BlockedSink>> &to_unblock) DUCKDB_REQUIRES(glock);
+	//! Deposit a restarting sink's parked copy. The caller holds glock
+	void DepositParked(annotated_lock_guard<annotated_mutex> &lock, idx_t batch, BlockedSink &sink)
+	    DUCKDB_REQUIRES(glock);
+	//! Invoke the collected restarts. The callbacks take the executor lock, so they must
+	//! run outside glock. When one throws, the remaining sinks are blocked again
+	void InvokeUnblocks(vector<pair<idx_t, BlockedSink>> &to_unblock) DUCKDB_EXCLUDES(glock);
 
-private:
+protected:
 	//! The buffer where chunks are written before they are ready to be read.
-	map<idx_t, InProgressBatch> buffer;
+	map<idx_t, InProgressBatch> buffer DUCKDB_GUARDED_BY(glock);
 	idx_t buffer_capacity;
 	atomic<idx_t> buffer_byte_count;
 
 	//! The queue containing the chunks that can be read.
-	deque<unique_ptr<DataChunk>> read_queue;
+	deque<unique_ptr<DataChunk>> read_queue DUCKDB_GUARDED_BY(glock);
 	idx_t read_queue_capacity;
 	atomic<idx_t> read_queue_byte_count;
 
-	map<idx_t, InterruptState> blocked_sinks;
+	map<idx_t, BlockedSink> blocked_sinks DUCKDB_GUARDED_BY(glock);
 
-	idx_t min_batch;
+	idx_t min_batch DUCKDB_GUARDED_BY(glock);
 	//! Debug variable to verify that order is preserved correctly.
-	idx_t lowest_moved_batch = 0;
+	idx_t lowest_moved_batch DUCKDB_GUARDED_BY(glock) = 0;
+	//! Counts advances that freed no bytes yet woke a sink
+	idx_t moved_nothing_restarts DUCKDB_GUARDED_BY(glock) = 0;
+	//! The highest number of bytes ever buffered
+	idx_t peak_buffered_bytes DUCKDB_GUARDED_BY(glock) = 0;
+	//! The largest single chunk seen so far. Sizes the async reserve for the minimum batch
+	idx_t max_seen_chunk_bytes DUCKDB_GUARDED_BY(glock) = 0;
+};
+
+//! Sync subclass. The fetching thread unblocks sinks and executes tasks itself
+//! whenever the read queue is empty.
+class BatchedBufferedDataSync : public BatchedBufferedData {
+public:
+	explicit BatchedBufferedDataSync(ClientContext &context);
+
+public:
+	StreamExecutionResult ExecuteTaskInternal(StreamQueryResult &result, ClientContextLock &context_lock) override;
+};
+
+//! Async subclass. Fetching never executes tasks, so the buffer restarts blocked
+//! sinks itself. Blocking checks one shared byte budget, with a reserve for the
+//! minimum batch. A minimum batch producer only blocks while chunks are poppable.
+class BatchedBufferedDataAsync : public BatchedBufferedData {
+public:
+	explicit BatchedBufferedDataAsync(ClientContext &context);
+
+public:
+	StreamExecutionResult ExecuteTaskInternal(StreamQueryResult &result, ClientContextLock &context_lock) override;
+	void WaitForChunk(ClientContext &client_context, ClientContextLock &context_lock,
+	                  StreamQueryResult &result) override;
+
+protected:
+	bool ShouldBlockBatch(annotated_lock_guard<annotated_mutex> &lock, idx_t batch, idx_t incoming_bytes) override
+	    DUCKDB_REQUIRES(glock);
+	bool PopMayFreeSinks(annotated_lock_guard<annotated_mutex> &lock) override DUCKDB_REQUIRES(glock);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/main/buffered_data/buffered_data.hpp
+++ b/src/include/duckdb/main/buffered_data/buffered_data.hpp
@@ -16,19 +16,34 @@
 #include "duckdb/execution/physical_operator_states.hpp"
 #include "duckdb/common/enums/pending_execution_result.hpp"
 #include "duckdb/common/enums/stream_execution_result.hpp"
+#include "duckdb/common/enums/streaming_execution_mode.hpp"
+#include "duckdb/common/mutex.hpp"
 #include "duckdb/common/shared_ptr.hpp"
+#include "duckdb/main/query_result_notifier.hpp"
+
+#include <condition_variable>
 
 namespace duckdb {
 
 class StreamQueryResult;
 class ClientContextLock;
 
+//! A blocked sink. Holds the reschedule handle and the finished copy of the chunk it
+//! could not append. Restart selection only wakes the sink when that chunk fits, and
+//! deposits the copy before the wake, so the chunk needs no producer time to turn visible
+struct BlockedSink {
+public:
+	InterruptState state;
+	idx_t pending_bytes;
+	unique_ptr<DataChunk> pending_chunk;
+};
+
 class BufferedData {
 protected:
 	enum class Type { SIMPLE, BATCHED };
 
 public:
-	BufferedData(Type type, ClientContext &context);
+	BufferedData(Type type, ClientContext &context, bool async = false);
 	virtual ~BufferedData();
 
 public:
@@ -36,9 +51,32 @@ public:
 	virtual StreamExecutionResult ExecuteTaskInternal(StreamQueryResult &result, ClientContextLock &context_lock) = 0;
 	virtual unique_ptr<DataChunk> Scan() = 0;
 	virtual void UnblockSinks() = 0;
+	//! Blocking, bounded wait until a chunk may be available. The base waits for generic progress
+	virtual void WaitForChunk(ClientContext &client_context, ClientContextLock &context_lock,
+	                          StreamQueryResult &result);
 	shared_ptr<ClientContext> GetContext() {
 		return context.lock();
 	}
+	//! Whether background workers keep this buffer filled (see StreamingExecutionMode)
+	bool IsAsync() const {
+		return async;
+	}
+	//! Set the notifier called when the buffer turns non-empty (async streaming results)
+	void SetResultNotifier(shared_ptr<QueryResultNotifier> result_notifier_p) {
+		annotated_lock_guard<annotated_mutex> guard(glock);
+		result_notifier = std::move(result_notifier_p);
+	}
+	shared_ptr<QueryResultNotifier> GetResultNotifier() {
+		annotated_lock_guard<annotated_mutex> guard(glock);
+		return result_notifier;
+	}
+	//! The highest number of bytes the buffer ever held
+	virtual idx_t PeakBufferedBytes() = 0;
+	//! Whether a chunk is ready for the consumer to pop
+	virtual bool HasObservableChunk() = 0;
+	//! A blocked sink still holds an undelivered chunk, so none can survive a clean end
+	//! of stream. Compiled away without assertions.
+	virtual void AssertNoBlockedSinks() = 0;
 	bool Closed() const {
 		if (context.expired()) {
 			return true;
@@ -68,13 +106,27 @@ public:
 	}
 
 protected:
+	static StreamExecutionResult MapExecutionResult(PendingExecutionResult execution_result);
+	//! Signal the cv (blocking fetches) and the notifier (async consumers) that a chunk is
+	//! available. Capture the notifier under glock when appending.
+	void SignalChunkAvailable(const shared_ptr<QueryResultNotifier> &notifier) DUCKDB_EXCLUDES(glock);
+	//! Pops below this mark restart blocked sinks. The floor keeps it reachable for tiny buffers
+	static idx_t LowWaterMark(idx_t capacity);
+
+protected:
 	Type type;
 	//! This is weak to avoid a cyclical reference
 	weak_ptr<ClientContext> context;
 	//! The maximum amount of memory we should keep buffered
 	idx_t total_buffer_size;
+	//! Whether background workers keep the buffer filled (async results)
+	bool async;
+	//! Called when the buffer turns non-empty (may be null). Guarded by glock.
+	shared_ptr<QueryResultNotifier> result_notifier;
+	//! Signalled when the buffer turns non-empty, for blocking async fetches
+	std::condition_variable chunk_ready_cv;
 	//! Protect against populate/fetch race condition
-	mutex glock;
+	annotated_mutex glock;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/main/buffered_data/simple_buffered_data.hpp
+++ b/src/include/duckdb/main/buffered_data/simple_buffered_data.hpp
@@ -11,6 +11,7 @@
 #include "duckdb/main/buffered_data/buffered_data.hpp"
 #include "duckdb/parallel/interrupt.hpp"
 #include "duckdb/common/queue.hpp"
+#include "duckdb/common/vector.hpp"
 #include "duckdb/common/vector_size.hpp"
 #include "duckdb/common/types/data_chunk.hpp"
 
@@ -24,29 +25,53 @@ public:
 	static constexpr const BufferedData::Type TYPE = BufferedData::Type::SIMPLE;
 
 public:
-	explicit SimpleBufferedData(ClientContext &context);
+	explicit SimpleBufferedData(ClientContext &context, bool async = false);
 	~SimpleBufferedData() override;
 
 public:
-	void Append(const DataChunk &chunk);
-	void BlockSink(const InterruptState &blocked_sink);
-	bool BufferIsFull();
+	//! Buffer a copy of the chunk, or block the sink when the chunk does not fit.
+	//! The cap is never exceeded, except that one oversized chunk is admitted into an
+	//! empty buffer. Returns true on block. Safe to call from parallel producers.
+	bool AppendOrBlock(const DataChunk &chunk, const InterruptState &blocked_sink);
+	//! Whether the buffer can accept no further chunk right now. That is the case at
+	//! the cap, and when a producer already blocked because its chunk did not fit
+	bool BufferSaturated();
+	//! The highest number of bytes the buffer ever held
+	idx_t PeakBufferedBytes() override;
+	//! Whether a chunk is buffered. Readiness and notification both check the chunk
+	//! queue, never the byte count. Chunks with rows but zero data bytes exist.
+	bool HasBufferedChunk();
+	bool HasObservableChunk() override {
+		return HasBufferedChunk();
+	}
 	void UnblockSinks() override;
+	void AssertNoBlockedSinks() override;
 	StreamExecutionResult ExecuteTaskInternal(StreamQueryResult &result, ClientContextLock &context_lock) override;
 	unique_ptr<DataChunk> Scan() override;
+	void WaitForChunk(ClientContext &client_context, ClientContextLock &context_lock,
+	                  StreamQueryResult &result) override;
 	inline idx_t BufferSize() const {
 		return buffer_size;
 	}
 
 private:
+	//! Pop restartable sinks into to_unblock. The caller holds glock
+	void CollectRestartableSinks(vector<BlockedSink> &to_unblock);
+	//! Invoke the collected restarts. Called outside glock. When one throws, the
+	//! remaining sinks are blocked again
+	void InvokeUnblocks(vector<BlockedSink> &to_unblock);
+
+private:
 	//! Our handles to reschedule the blocked sink tasks
-	queue<InterruptState> blocked_sinks;
+	queue<BlockedSink> blocked_sinks;
 	//! The queue of chunks
 	queue<unique_ptr<DataChunk>> buffered_chunks;
-	//! The current capacity of the buffer (tuples)
+	//! The bytes currently buffered
 	atomic<idx_t> buffered_count;
-	//! The amount of tuples we should buffer
+	//! The byte cap of the buffer
 	idx_t buffer_size;
+	//! The highest number of bytes ever buffered
+	idx_t peak_buffered_bytes = 0;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/main/client_config.hpp
+++ b/src/include/duckdb/main/client_config.hpp
@@ -16,6 +16,7 @@
 #include "duckdb/common/progress_bar/progress_bar.hpp"
 #include "duckdb/common/types/value.hpp"
 #include "duckdb/common/enums/profiling_coverage.hpp"
+#include "duckdb/common/enums/streaming_execution_mode.hpp"
 #include "duckdb/main/user_settings.hpp"
 
 namespace duckdb {
@@ -60,7 +61,11 @@ struct ClientConfig {
 	bool use_replacement_scans = true;
 
 	//! The maximum amount of memory to keep buffered in a streaming query result. Default: 1mb.
-	idx_t streaming_buffer_size = 1000000;
+	idx_t max_streaming_buffer_size = 1000000;
+	//! Execution mode for streaming query results. Read once per query at submission.
+	//! Ignored for non-streaming results. Set through the setting, never directly:
+	//! the setting registers async connections with the task scheduler.
+	StreamingExecutionMode streaming_execution_mode = StreamingExecutionMode::SYNC;
 
 	//! The maximum memory for query intermediates (sorts, hash tables) per connection (in bytes). Default: Global
 	//! memory limit.
@@ -81,6 +86,10 @@ struct ClientConfig {
 
 	//! Function that is used to create the result collector for a materialized result.
 	get_result_collector_t get_result_collector = nullptr;
+	//! Called whenever an async streaming result's observable state may have changed.
+	//! Used by every ASYNC query on this connection. Ignored for SYNC queries.
+	//! Set on the query before execution starts. Callback rules: see QueryResultNotifier.
+	std::function<void()> notify_callback = nullptr;
 
 	//! The compiled grammar active for the connection
 	shared_ptr<CompiledGrammar> cached_grammar;

--- a/src/include/duckdb/main/client_context.hpp
+++ b/src/include/duckdb/main/client_context.hpp
@@ -24,6 +24,7 @@
 #include "duckdb/main/client_properties.hpp"
 #include "duckdb/main/external_dependencies.hpp"
 #include "duckdb/main/pending_query_result.hpp"
+#include "duckdb/main/query_result_notifier.hpp"
 #include "duckdb/main/table_description.hpp"
 #include "duckdb/planner/expression/bound_parameter_data.hpp"
 #include "duckdb/transaction/transaction_context.hpp"
@@ -88,11 +89,12 @@ enum class ClientInterruptState : uint8_t { NOT_INTERRUPTED, INTERRUPTED, INTERR
 //! The ClientContext holds information relevant to the current client session
 //! during execution
 class ClientContext : public enable_shared_from_this<ClientContext> {
-	friend class PendingQueryResult;  // LockContext
-	friend class BufferedData;        // ExecuteTaskInternal
-	friend class SimpleBufferedData;  // ExecuteTaskInternal
-	friend class BatchedBufferedData; // ExecuteTaskInternal
-	friend class StreamQueryResult;   // LockContext
+	friend class PendingQueryResult;       // LockContext
+	friend class BufferedData;             // ExecuteTaskInternal
+	friend class SimpleBufferedData;       // ExecuteTaskInternal
+	friend class BatchedBufferedDataSync;  // ExecuteTaskInternal
+	friend class BatchedBufferedDataAsync; // ExecuteTaskInternal
+	friend class StreamQueryResult;        // LockContext
 	friend class ConnectionManager;
 
 public:
@@ -105,6 +107,13 @@ public:
 	atomic<ClientInterruptState> interrupt_state {ClientInterruptState::NOT_INTERRUPTED};
 	//! The deadline for the current query (milliseconds since epoch)
 	optional_idx query_deadline;
+	//! Notifier of the active async stream result, called by Interrupt (may be null).
+	//! Has its own lock, because Interrupt must not take the context lock.
+	mutex notifier_lock;
+	shared_ptr<QueryResultNotifier> active_result_notifier;
+	//! Whether the notifier slot is set. Lets Interrupt skip the try-lock entirely
+	//! on connections that never ran an async query.
+	atomic<bool> has_result_notifier {false};
 	//! Set of optional states (e.g. Caches) that can be held by the ClientContext
 	unique_ptr<RegisteredStateManager> registered_state;
 	//! The logger to be used by this ClientContext
@@ -137,6 +146,8 @@ public:
 
 	//! Interrupt execution of a query
 	DUCKDB_API void Interrupt();
+	//! The notifier of the active async stream result, or null (read by the result collector)
+	DUCKDB_API shared_ptr<QueryResultNotifier> GetActiveResultNotifier();
 	DUCKDB_API bool IsInterrupted() const;
 	DUCKDB_API void ClearInterrupt();
 	//! Suppress all further interrupts for the current query (called after irreversible operations like COMMIT)
@@ -323,6 +334,7 @@ private:
 
 	//! Wait until a task is available to execute
 	void WaitForTask(ClientContextLock &lock, BaseQueryResult &result);
+	void WaitForProgress(ClientContextLock &lock, BaseQueryResult &result);
 	PendingExecutionResult ExecuteTaskInternal(ClientContextLock &lock, BaseQueryResult &result, bool dry_run = false);
 
 	unique_ptr<PendingQueryResult> PendingQueryInternal(ClientContextLock &, const shared_ptr<Relation> &relation,

--- a/src/include/duckdb/main/pending_query_result.hpp
+++ b/src/include/duckdb/main/pending_query_result.hpp
@@ -58,6 +58,8 @@ public:
 private:
 	shared_ptr<ClientContext> context;
 	bool allow_stream_result;
+	//! Whether the result executes async. The consumer thread then never runs tasks
+	bool async;
 
 private:
 	void CheckExecutableInternal(ClientContextLock &lock);

--- a/src/include/duckdb/main/prepared_statement_data.hpp
+++ b/src/include/duckdb/main/prepared_statement_data.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "duckdb/common/enums/statement_type.hpp"
+#include "duckdb/common/enums/streaming_execution_mode.hpp"
 #include "duckdb/common/types/value.hpp"
 #include "duckdb/common/unordered_map.hpp"
 #include "duckdb/common/unordered_set.hpp"
@@ -48,6 +49,8 @@ public:
 	QueryResultOutputType output_type;
 	//! Whether we are creating a buffer-managed result or not
 	QueryResultMemoryType memory_type;
+	//! Whether the result is produced by background workers or driven by the consumer
+	StreamingExecutionMode execution_mode = StreamingExecutionMode::SYNC;
 
 public:
 	void CheckParameterCount(idx_t parameter_count);

--- a/src/include/duckdb/main/profiler/metrics.hpp
+++ b/src/include/duckdb/main/profiler/metrics.hpp
@@ -87,6 +87,13 @@ struct MetricSystemPeakBufferMemory {
 	static constexpr const char *Unit = "bytes";
 	static constexpr const char *TypeStr = "uint64";
 };
+struct MetricSystemPeakStreamingBufferSize {
+	using METRIC_TYPE = uint64_t;
+	static constexpr const char *Name = "system.peak_streaming_buffer_size";
+	static constexpr const char *Description = "Peak number of bytes buffered by a streaming query result";
+	static constexpr const char *Unit = "bytes";
+	static constexpr const char *TypeStr = "uint64";
+};
 struct MetricSystemPeakTempDirSize {
 	using METRIC_TYPE = uint64_t;
 	static constexpr const char *Name = "system.peak_temp_dir_size";

--- a/src/include/duckdb/main/profiler/profiling_utils.hpp
+++ b/src/include/duckdb/main/profiler/profiling_utils.hpp
@@ -30,6 +30,7 @@ public:
 	~QueryMetrics();
 
 	idx_t system_peak_buffer_memory;
+	idx_t system_peak_streaming_buffer_size;
 	idx_t system_peak_temp_dir_size;
 	double blocked_thread_time;
 
@@ -108,6 +109,7 @@ public:
 		latency_timer.reset();
 		query_sql = "";
 		system_peak_buffer_memory = 0;
+		system_peak_streaming_buffer_size = 0;
 		system_peak_temp_dir_size = 0;
 		blocked_thread_time = 0;
 	}

--- a/src/include/duckdb/main/query_profiler.hpp
+++ b/src/include/duckdb/main/query_profiler.hpp
@@ -132,6 +132,8 @@ public:
 	DUCKDB_API void Flush(OperatorProfiler &profiler);
 	//! Adds the top level query information to the global profiler.
 	DUCKDB_API void SetBlockedTime(const double &blocked_thread_time);
+	//! Record the peak bytes a streaming result buffered. Called just before the query ends
+	DUCKDB_API void SetStreamingPeakBufferSize(idx_t peak_bytes);
 
 	DUCKDB_API void Initialize(const PhysicalOperator &root);
 

--- a/src/include/duckdb/main/query_result_notifier.hpp
+++ b/src/include/duckdb/main/query_result_notifier.hpp
@@ -1,0 +1,60 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/main/query_result_notifier.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/mutex.hpp"
+
+#include <functional>
+
+namespace duckdb {
+
+//! Notifies a waiting stream consumer that the result's observable state may have
+//! changed. Notifications might overlap and the state that triggered it may have
+//! changed by the time the consumer tries to fetch. The callback runs on an engine
+//! thread and so it _must_ be tiny and _must not_ call back into DuckDB. A callback
+//! that re-enters DuckDB can deadlock the connection.
+class QueryResultNotifier {
+public:
+	using notify_callback_t = std::function<void()>;
+
+	void Set(notify_callback_t callback_p) {
+		lock_guard<mutex> guard(lock);
+		callback = std::move(callback_p);
+	}
+	//! After Clear returns the callback is never called again
+	void Clear() {
+		lock_guard<mutex> guard(lock);
+		callback = nullptr;
+	}
+	//! Callers must not hold any engine lock. The callback runs under the notifier's lock.
+	void Notify() {
+		lock_guard<mutex> guard(lock);
+		if (callback) {
+			callback();
+		}
+	}
+	//! Non-blocking notify for signal handlers (ClientContext::Interrupt). On contention
+	//! the notification is dropped. That is safe. A contending Notify already wakes the
+	//! consumer, and a contending Clear means the result is going away.
+	void TryNotify() {
+		if (!lock.try_lock()) {
+			return;
+		}
+		if (callback) {
+			callback();
+		}
+		lock.unlock();
+	}
+
+private:
+	mutex lock;
+	notify_callback_t callback;
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -1547,6 +1547,18 @@ struct MaxMemorySetting {
 	static Value GetSetting(const ClientContext &context);
 };
 
+struct MaxStreamingBufferSizeSetting {
+	using RETURN_TYPE = string;
+	static constexpr const char *Name = "max_streaming_buffer_size";
+	static constexpr const char *Description =
+	    "The maximum number of bytes a streaming query result buffers (e.g. 1GB). Buffered bytes stay under this cap "
+	    "plus at most one chunk: an oversized chunk is only admitted into an empty queue";
+	static constexpr const char *InputType = "VARCHAR";
+	static void SetLocal(ClientContext &context, const Value &parameter);
+	static void ResetLocal(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
+};
+
 struct MaxTempDirectorySizeSetting {
 	using RETURN_TYPE = string;
 	static constexpr const char *Name = "max_temp_directory_size";
@@ -1953,11 +1965,13 @@ struct StorageCompatibilityVersionSetting {
 	static Value GetSetting(const ClientContext &context);
 };
 
-struct StreamingBufferSizeSetting {
-	using RETURN_TYPE = string;
-	static constexpr const char *Name = "streaming_buffer_size";
+struct StreamingExecutionModeSetting {
+	using RETURN_TYPE = StreamingExecutionMode;
+	static constexpr const char *Name = "streaming_execution_mode";
 	static constexpr const char *Description =
-	    "The maximum memory to buffer between fetching from a streaming result (e.g. 1GB)";
+	    "Execution mode for streaming query results (SYNC or ASYNC). In SYNC mode fetching drives execution on the "
+	    "calling thread. In ASYNC mode background workers produce the result and fetching never runs engine work. "
+	    "Ignored for non-streaming results";
 	static constexpr const char *InputType = "VARCHAR";
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);

--- a/src/include/duckdb/main/stream_query_result.hpp
+++ b/src/include/duckdb/main/stream_query_result.hpp
@@ -13,6 +13,7 @@
 #include "duckdb/parallel/interrupt.hpp"
 #include "duckdb/common/queue.hpp"
 #include "duckdb/common/enums/stream_execution_result.hpp"
+#include "duckdb/main/query_result_notifier.hpp"
 #include "duckdb/main/buffered_data/simple_buffered_data.hpp"
 
 namespace duckdb {
@@ -44,12 +45,26 @@ public:
 	DUCKDB_API void WaitForTask();
 	//! Executes a single task within the final pipeline, returning whether or not a chunk is ready to be fetched
 	DUCKDB_API StreamExecutionResult ExecuteTask();
+	//! Non-blocking fetch for an async result. Pops a chunk or reports the stream state.
+	//! Never runs execution work on the calling thread. CHUNK_READY means out_chunk holds
+	//! a chunk. After the stream ends, further calls keep reporting the terminal state.
+	DUCKDB_API StreamExecutionResult TryFetchChunk(unique_ptr<DataChunk> &out_chunk);
 	//! Converts the QueryResult to a string
 	DUCKDB_API string ToString() override;
 	//! Materializes the query result and turns it into a materialized query result
 	DUCKDB_API unique_ptr<MaterializedQueryResult> Materialize();
 
 	DUCKDB_API bool IsOpen();
+
+	//! The buffer backing this stream result
+	BufferedData &GetBufferedData() {
+		D_ASSERT(buffered_data);
+		return *buffered_data;
+	}
+	//! False for an error result, which never had a buffer
+	bool HasBufferedData() const {
+		return buffered_data != nullptr;
+	}
 
 	//! Closes the StreamQueryResult
 	DUCKDB_API void Close();
@@ -63,12 +78,17 @@ protected:
 private:
 	StreamExecutionResult ExecuteTaskInternal(ClientContextLock &lock);
 	unique_ptr<DataChunk> FetchNextInternal(ClientContextLock &lock);
+	//! Record a fetch-time failure. Processes the error, sets it on this result, and
+	//! cleans up the query
+	void HandleFetchFailure(ClientContextLock &lock, ErrorData error);
 	unique_ptr<ClientContextLock> LockContext();
 	void CheckExecutableInternal(ClientContextLock &lock);
 	bool IsOpenInternal(ClientContextLock &lock);
 
 private:
 	shared_ptr<BufferedData> buffered_data;
+	//! Notifier shared with the buffered data, the executor, and the client context (may be null)
+	shared_ptr<QueryResultNotifier> result_notifier;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/parallel/task_scheduler.hpp
+++ b/src/include/duckdb/parallel/task_scheduler.hpp
@@ -76,6 +76,12 @@ public:
 	void SetAsyncThreads(idx_t n);
 	void RelaunchThreads();
 
+	//! Register a connection with streaming_execution_mode = 'async'. Throws when no
+	//! DuckDB-managed worker thread exists. While registered connections exist,
+	//! SetThreads refuses changes that would leave no managed worker.
+	DUCKDB_API void RegisterAsyncStreamingConnection();
+	DUCKDB_API void UnregisterAsyncStreamingConnection();
+
 	//! Yield to other threads
 	static void YieldThread();
 	//! Get the number of the CPU on which the calling thread is currently executing.
@@ -101,6 +107,10 @@ private:
 	DatabaseInstance &db;
 	//! Lock for modifying the thread count
 	mutex thread_lock;
+	//! Serializes SetThreads against async streaming connection registration
+	mutex async_streaming_lock;
+	//! The number of connections with streaming_execution_mode = 'async'
+	idx_t async_streaming_connections = 0;
 	//! The thread pools
 	array<unique_ptr<TaskSchedulerPool>, TASK_SCHEDULER_TYPE_COUNT> pools;
 	//! The task queues

--- a/src/include/duckdb/parallel/task_scheduler_pool.hpp
+++ b/src/include/duckdb/parallel/task_scheduler_pool.hpp
@@ -29,6 +29,8 @@ public:
 public:
 	void SetThreads(idx_t n);
 	idx_t NumberOfThreads();
+	//! The thread count the next relaunch will establish
+	idx_t RequestedThreadCount();
 	void RelaunchThreads(TaskScheduler &scheduler, bool destroy);
 	void Signal(idx_t n);
 #ifndef DUCKDB_NO_THREADS

--- a/src/main/buffered_data/batched_buffered_data.cpp
+++ b/src/main/buffered_data/batched_buffered_data.cpp
@@ -1,71 +1,188 @@
 #include "duckdb/main/buffered_data/batched_buffered_data.hpp"
 #include "duckdb/common/printer.hpp"
+#include "duckdb/execution/executor.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/stream_query_result.hpp"
 #include "duckdb/common/helper.hpp"
 #include "duckdb/execution/operator/helper/physical_buffered_batch_collector.hpp"
 #include "duckdb/common/stack.hpp"
 
+#include <chrono>
+
 namespace duckdb {
 
-void BatchedBufferedData::BlockSink(const InterruptState &blocked_sink, idx_t batch) {
-	lock_guard<mutex> lock(glock);
-	D_ASSERT(!blocked_sinks.count(batch));
-	blocked_sinks.emplace(batch, blocked_sink);
-}
+bool BatchedBufferedData::AppendOrBlock(const DataChunk &to_append, idx_t batch, const InterruptState &blocked_sink) {
+	// Copy first. The block decision and the byte accounting share one critical
+	// section, so racing producers cannot exceed the cap. A block keeps the copy
+	// for wake time
+	auto chunk = make_uniq<DataChunk>();
+	chunk->Initialize(Allocator::DefaultAllocator(), to_append.GetTypes());
+	to_append.Copy(*chunk, 0);
+	const idx_t allocation_size = chunk->GetDataSize();
 
-BatchedBufferedData::BatchedBufferedData(ClientContext &context)
-    : BufferedData(BufferedData::Type::BATCHED, context), buffer_byte_count(0), read_queue_byte_count(0), min_batch(0) {
-	read_queue_capacity = (idx_t)(static_cast<double>(total_buffer_size) * 0.6);
-	buffer_capacity = (idx_t)(static_cast<double>(total_buffer_size) * 0.4);
-}
-
-bool BatchedBufferedData::ShouldBlockBatch(idx_t batch) {
-	lock_guard<mutex> lock(glock);
-	bool is_minimum = IsMinimumBatchIndex(lock, batch);
-	if (is_minimum) {
-		// If there is room in the read queue, we want to process the minimum batch
-		return read_queue_byte_count >= ReadQueueCapacity();
+	shared_ptr<QueryResultNotifier> notifier;
+	bool signal_chunk_ready = false;
+	{
+		annotated_lock_guard<annotated_mutex> lock(glock);
+		D_ASSERT(batch >= min_batch);
+		max_seen_chunk_bytes = MaxValue<idx_t>(max_seen_chunk_bytes, allocation_size);
+		if (ShouldBlockBatch(lock, batch, allocation_size)) {
+			// Park holding the finished copy. Restart selection deposits it at wake time
+			auto entry = blocked_sinks.emplace(batch, BlockedSink {blocked_sink, allocation_size, std::move(chunk)});
+			(void)entry;
+			D_ASSERT(entry.second);
+			return true;
+		}
+		auto is_minimum = IsMinimumBatchIndex(lock, batch);
+		if (is_minimum) {
+			for (auto &it : buffer) {
+				auto batch_index = it.first;
+				if (batch_index >= min_batch) {
+					break;
+				}
+				// There should not be any batches in the buffer that are lower or equal to the minimum batch index
+				throw InternalException("Batches remaining in buffer");
+			}
+			signal_chunk_ready = read_queue.empty();
+			read_queue.push_back(std::move(chunk));
+			read_queue_byte_count += allocation_size;
+			if (signal_chunk_ready) {
+				// The chunk is visible before the wake below, so a woken consumer always finds it
+				notifier = result_notifier;
+			}
+		} else {
+			auto &in_progress_batch = buffer[batch];
+			auto &chunks = in_progress_batch.chunks;
+			in_progress_batch.completed = false;
+			buffer_byte_count += allocation_size;
+			chunks.push_back(std::move(chunk));
+		}
+		peak_buffered_bytes = MaxValue<idx_t>(peak_buffered_bytes, read_queue_byte_count + buffer_byte_count);
 	}
-	return buffer_byte_count >= BufferCapacity();
+	if (signal_chunk_ready) {
+		// This collector's Sink holds no outer lock, so the buffer signals directly
+		SignalChunkAvailable(notifier);
+	}
+	return false;
+}
+
+BatchedBufferedData::BatchedBufferedData(ClientContext &context, bool async)
+    : BufferedData(BufferedData::Type::BATCHED, context, async), buffer_byte_count(0), read_queue_byte_count(0),
+      min_batch(0) {
+	// Both capacities must be able to admit a chunk. The split rounds tiny sizes to zero
+	read_queue_capacity = MaxValue<idx_t>((idx_t)(static_cast<double>(total_buffer_size) * 0.6), 1);
+	buffer_capacity = MaxValue<idx_t>((idx_t)(static_cast<double>(total_buffer_size) * 0.4), 1);
+}
+
+bool BatchedBufferedData::ShouldBlockBatch(annotated_lock_guard<annotated_mutex> &lock, idx_t batch,
+                                           idx_t incoming_bytes) {
+	if (IsMinimumBatchIndex(lock, batch)) {
+		// The read queue admits a chunk that fits, and always one chunk when empty
+		return read_queue_byte_count > 0 && read_queue_byte_count + incoming_bytes > ReadQueueCapacity();
+	}
+	// An oversized non-minimum chunk blocks until its batch becomes the minimum.
+	// The advance then moves its sink to the read queue rule above, so it is not lost
+	return buffer_byte_count > 0 && buffer_byte_count + incoming_bytes > BufferCapacity();
+}
+
+bool BatchedBufferedData::PopMayFreeSinks(annotated_lock_guard<annotated_mutex> &lock) {
+	// Pops only shrink the read queue, so only the minimum batch sink can become eligible
+	return read_queue_byte_count < ReadQueueCapacity();
+}
+
+bool BatchedBufferedDataAsync::ShouldBlockBatch(annotated_lock_guard<annotated_mutex> &lock, idx_t batch,
+                                                idx_t incoming_bytes) {
+	const idx_t total = read_queue_byte_count + buffer_byte_count;
+	if (IsMinimumBatchIndex(lock, batch)) {
+		// Only block the minimum batch producer while the consumer has chunks to pop.
+		// Every pop lowers the total, so consumption always wakes it again
+		return total + incoming_bytes > total_buffer_size && !read_queue.empty();
+	}
+	// Read-ahead batches may not use up the share reserved for the minimum batch.
+	// The reserve covers at least one chunk, so the empty-queue append above stays
+	// under the cap. A chunk larger than every chunk seen before can exceed it once,
+	// by at most its own size. It then blocks until its batch becomes the minimum.
+	const idx_t reserve = MaxValue<idx_t>(MaxValue<idx_t>(total_buffer_size / 8, max_seen_chunk_bytes), 1);
+	const idx_t threshold = total_buffer_size > reserve ? total_buffer_size - reserve : 1;
+	return total + incoming_bytes > threshold;
+}
+
+bool BatchedBufferedDataAsync::PopMayFreeSinks(annotated_lock_guard<annotated_mutex> &lock) {
+	// Every pop lowers the shared total that both block conditions check
+	return true;
 }
 
 bool BatchedBufferedData::BufferIsEmpty() {
-	lock_guard<mutex> lock(glock);
+	annotated_lock_guard<annotated_mutex> lock(glock);
 	return read_queue.empty();
 }
 
-bool BatchedBufferedData::IsMinimumBatchIndex(lock_guard<mutex> &lock, idx_t batch) {
+bool BatchedBufferedData::IsMinimumBatchIndex(annotated_lock_guard<annotated_mutex> &lock, idx_t batch) {
 	return min_batch == batch;
 }
 
-void BatchedBufferedData::UnblockSinks() {
-	lock_guard<mutex> lock(glock);
-	stack<idx_t> to_remove;
-	for (auto it = blocked_sinks.begin(); it != blocked_sinks.end(); it++) {
-		auto batch = it->first;
-		auto &blocked_sink = it->second;
-		const bool is_minimum = IsMinimumBatchIndex(lock, batch);
-		if (is_minimum) {
-			if (read_queue_byte_count >= ReadQueueCapacity()) {
-				continue;
-			}
-		} else {
-			if (buffer_byte_count >= BufferCapacity()) {
-				continue;
-			}
+void BatchedBufferedData::CollectRestartableSinks(annotated_lock_guard<annotated_mutex> &lock,
+                                                  vector<pair<idx_t, BlockedSink>> &to_unblock) {
+	D_ASSERT(to_unblock.empty());
+	// Reserve first so a failed allocation loses no blocked sink
+	to_unblock.reserve(blocked_sinks.size());
+	for (auto it = blocked_sinks.begin(); it != blocked_sinks.end();) {
+		if (ShouldBlockBatch(lock, it->first, it->second.pending_bytes)) {
+			it++;
+			continue;
 		}
-		blocked_sink.Callback();
-		to_remove.push(batch);
-	}
-	while (!to_remove.empty()) {
-		auto batch = to_remove.top();
-		to_remove.pop();
-		blocked_sinks.erase(batch);
+		DepositParked(lock, it->first, it->second);
+		to_unblock.emplace_back(it->first, std::move(it->second));
+		it = blocked_sinks.erase(it);
 	}
 }
 
-void BatchedBufferedData::MoveCompletedBatches(lock_guard<mutex> &lock) {
+void BatchedBufferedData::DepositParked(annotated_lock_guard<annotated_mutex> &lock, idx_t batch, BlockedSink &sink) {
+	// Deposit the parked copy, so the chunk is visible before the producer wakes.
+	// The batch may have become the minimum while the producer was parked.
+	// A sink blocked again after a failed restart already deposited and holds none
+	if (!sink.pending_chunk) {
+		return;
+	}
+	if (IsMinimumBatchIndex(lock, batch)) {
+		read_queue.push_back(std::move(sink.pending_chunk));
+		read_queue_byte_count += sink.pending_bytes;
+	} else {
+		auto &in_progress_batch = buffer[batch];
+		in_progress_batch.completed = false;
+		buffer_byte_count += sink.pending_bytes;
+		in_progress_batch.chunks.push_back(std::move(sink.pending_chunk));
+	}
+	peak_buffered_bytes = MaxValue<idx_t>(peak_buffered_bytes, read_queue_byte_count + buffer_byte_count);
+	sink.pending_bytes = 0;
+}
+
+void BatchedBufferedData::InvokeUnblocks(vector<pair<idx_t, BlockedSink>> &to_unblock) {
+	// Invoked outside glock. Callback() takes the executor lock
+	for (idx_t i = 0; i < to_unblock.size(); i++) {
+		try {
+			to_unblock[i].second.state.Callback();
+		} catch (...) {
+			// Block the sinks not yet restarted again so they are not lost
+			annotated_lock_guard<annotated_mutex> lock(glock);
+			for (idx_t remainder = i + 1; remainder < to_unblock.size(); remainder++) {
+				blocked_sinks.emplace(to_unblock[remainder].first, std::move(to_unblock[remainder].second));
+			}
+			throw;
+		}
+	}
+}
+
+void BatchedBufferedData::UnblockSinks() {
+	vector<pair<idx_t, BlockedSink>> to_unblock;
+	{
+		annotated_lock_guard<annotated_mutex> lock(glock);
+		CollectRestartableSinks(lock, to_unblock);
+	}
+	InvokeUnblocks(to_unblock);
+}
+
+void BatchedBufferedData::MoveCompletedBatches(annotated_lock_guard<annotated_mutex> &lock) {
 	stack<idx_t> to_remove;
 	for (auto &it : buffer) {
 		auto batch_index = it.first;
@@ -112,25 +229,92 @@ void BatchedBufferedData::MoveCompletedBatches(lock_guard<mutex> &lock) {
 }
 
 void BatchedBufferedData::UpdateMinBatchIndex(idx_t min_batch_index) {
-	lock_guard<mutex> lock(glock);
+	vector<pair<idx_t, BlockedSink>> to_unblock;
+	shared_ptr<QueryResultNotifier> notifier;
+	bool signal_chunk_ready = false;
+	{
+		annotated_lock_guard<annotated_mutex> lock(glock);
 
-	auto old_min_batch = min_batch;
-	auto new_min_batch = MaxValue(old_min_batch, min_batch_index);
-	if (new_min_batch == min_batch) {
-		// No change, early out
-		return;
+		auto old_min_batch = min_batch;
+		auto new_min_batch = MaxValue(old_min_batch, min_batch_index);
+		if (new_min_batch == min_batch) {
+			// No change, early out
+			return;
+		}
+		min_batch = new_min_batch;
+		const bool was_empty = read_queue.empty();
+		const idx_t buffered_before = buffer_byte_count;
+		MoveCompletedBatches(lock);
+		// The advance frees in-progress bytes AND moves the newly minimum batch's blocked
+		// sink to the read queue rule, so the selection must run even when nothing moved
+		CollectRestartableSinks(lock, to_unblock);
+		// Checked after selection. A wake deposit can also turn the read queue non-empty
+		if (was_empty && !read_queue.empty()) {
+			signal_chunk_ready = true;
+			notifier = result_notifier;
+		}
+		if (buffer_byte_count == buffered_before && !to_unblock.empty()) {
+			// The advance freed no bytes yet woke a sink. Buffered chunks always carry
+			// data bytes, so an advance that freed nothing also moved nothing.
+			moved_nothing_restarts++;
+		}
 	}
-	min_batch = new_min_batch;
-	MoveCompletedBatches(lock);
+	// Restart the sinks before signalling. The notifier runs user code, and a throw
+	// from it must not lose sinks that are already off the blocked list
+	InvokeUnblocks(to_unblock);
+	if (signal_chunk_ready) {
+		SignalChunkAvailable(notifier);
+	}
 }
 
-StreamExecutionResult BatchedBufferedData::ExecuteTaskInternal(StreamQueryResult &result,
-                                                               ClientContextLock &context_lock) {
+BatchedBufferedDataSync::BatchedBufferedDataSync(ClientContext &context) : BatchedBufferedData(context, false) {
+}
+
+BatchedBufferedDataAsync::BatchedBufferedDataAsync(ClientContext &context) : BatchedBufferedData(context, true) {
+}
+
+StreamExecutionResult BatchedBufferedDataAsync::ExecuteTaskInternal(StreamQueryResult &result,
+                                                                    ClientContextLock &context_lock) {
 	auto cc = context.lock();
 	if (!cc) {
 		return StreamExecutionResult::EXECUTION_CANCELLED;
 	}
+	if (!cc->IsActiveResult(context_lock, result)) {
+		return StreamExecutionResult::EXECUTION_CANCELLED;
+	}
+	const bool interrupted = cc->interrupt_state.load(std::memory_order_relaxed) == ClientInterruptState::INTERRUPTED;
+	if (interrupted && !Executor::Get(*cc).HasError()) {
+		// A worker error also raises the interrupt flag to stop sibling tasks. Only a flag
+		// without an executor error is a real cancel request. This is checked even when
+		// chunks are buffered, so a cancel is not detected only once the buffer is drained.
+		throw InterruptException();
+	}
+	if (!interrupted && !BufferIsEmpty()) {
+		// A chunk is ready and nothing needs the executor lock
+		return StreamExecutionResult::CHUNK_READY;
+	}
+	// Observe the execution state without running tasks. A pushed worker error
+	// converts to EXECUTION_ERROR carrying the real message
+	auto execution_result = cc->ExecuteTaskInternal(context_lock, result, true);
+	if (execution_result == PendingExecutionResult::EXECUTION_ERROR) {
+		if (result.HasError()) {
+			Close();
+		}
+		return StreamExecutionResult::EXECUTION_ERROR;
+	}
+	if (!BufferIsEmpty()) {
+		// An async consumer can fetch as soon as one chunk exists
+		return StreamExecutionResult::CHUNK_READY;
+	}
+	return MapExecutionResult(execution_result);
+}
 
+StreamExecutionResult BatchedBufferedDataSync::ExecuteTaskInternal(StreamQueryResult &result,
+                                                                   ClientContextLock &context_lock) {
+	auto cc = context.lock();
+	if (!cc) {
+		return StreamExecutionResult::EXECUTION_CANCELLED;
+	}
 	if (!BufferIsEmpty()) {
 		// The buffer isn't empty yet, just return
 		return StreamExecutionResult::CHUNK_READY;
@@ -149,22 +333,23 @@ StreamExecutionResult BatchedBufferedData::ExecuteTaskInternal(StreamQueryResult
 	if (result.HasError()) {
 		Close();
 	}
-	switch (execution_result) {
-	case PendingExecutionResult::NO_TASKS_AVAILABLE:
-	case PendingExecutionResult::RESULT_NOT_READY:
-		return StreamExecutionResult::CHUNK_NOT_READY;
-	case PendingExecutionResult::EXECUTION_FINISHED:
-		return StreamExecutionResult::EXECUTION_FINISHED;
-	case PendingExecutionResult::EXECUTION_ERROR:
-		return StreamExecutionResult::EXECUTION_ERROR;
-	default:
-		throw InternalException("No conversion from PendingExecutionResult (%s) -> StreamExecutionResult",
-		                        EnumUtil::ToString(execution_result));
+	return MapExecutionResult(execution_result);
+}
+
+// The condition variable needs a std::unique_lock, which the analysis cannot track
+void BatchedBufferedDataAsync::WaitForChunk(ClientContext &client_context, ClientContextLock &context_lock,
+                                            StreamQueryResult &result) DUCKDB_NO_THREAD_SAFETY_ANALYSIS {
+	// Wake when the read queue turns non-empty. The bounded wait covers progress that
+	// does not append
+	annotated_unique_lock<annotated_mutex> lock(glock);
+	if (!read_queue.empty()) {
+		return;
 	}
+	chunk_ready_cv.wait_for(lock, std::chrono::milliseconds(Executor::WAIT_TIME));
 }
 
 void BatchedBufferedData::CompleteBatch(idx_t batch) {
-	lock_guard<mutex> lock(glock);
+	annotated_lock_guard<annotated_mutex> lock(glock);
 	auto it = buffer.find(batch);
 	if (it == buffer.end()) {
 		return;
@@ -174,52 +359,36 @@ void BatchedBufferedData::CompleteBatch(idx_t batch) {
 	in_progress_batch.completed = true;
 }
 
+void BatchedBufferedData::AssertNoBlockedSinks() {
+#ifdef D_ASSERT_IS_ENABLED
+	annotated_lock_guard<annotated_mutex> lock(glock);
+	D_ASSERT(blocked_sinks.empty());
+#endif
+}
+
 unique_ptr<DataChunk> BatchedBufferedData::Scan() {
 	unique_ptr<DataChunk> chunk;
-	lock_guard<mutex> lock(glock);
-	if (!read_queue.empty()) {
+	vector<pair<idx_t, BlockedSink>> to_unblock;
+	{
+		annotated_lock_guard<annotated_mutex> lock(glock);
+		if (read_queue.empty()) {
+			context.reset();
+			D_ASSERT(blocked_sinks.empty());
+			D_ASSERT(buffer.empty());
+			return nullptr;
+		}
 		chunk = std::move(read_queue.front());
 		read_queue.pop_front();
 		auto allocation_size = chunk->GetDataSize();
 		read_queue_byte_count -= allocation_size;
-	} else {
-		context.reset();
-		D_ASSERT(blocked_sinks.empty());
-		D_ASSERT(buffer.empty());
-		return nullptr;
-	}
-	return chunk;
-}
-
-void BatchedBufferedData::Append(const DataChunk &to_append, idx_t batch) {
-	// We should never find any chunks with a smaller batch index than the minimum
-
-	auto chunk = make_uniq<DataChunk>();
-	chunk->Initialize(Allocator::DefaultAllocator(), to_append.GetTypes());
-	to_append.Copy(*chunk, 0);
-	auto allocation_size = chunk->GetDataSize();
-
-	lock_guard<mutex> lock(glock);
-	D_ASSERT(batch >= min_batch);
-	auto is_minimum = IsMinimumBatchIndex(lock, batch);
-	if (is_minimum) {
-		for (auto &it : buffer) {
-			auto batch_index = it.first;
-			if (batch_index >= min_batch) {
-				break;
-			}
-			// There should not be any batches in the buffer that are lower or equal to the minimum batch index
-			throw InternalException("Batches remaining in buffer");
+		// The walk is O(blocked sinks), so only run it when a sink exists and this pop
+		// can matter
+		if (!blocked_sinks.empty() && PopMayFreeSinks(lock)) {
+			CollectRestartableSinks(lock, to_unblock);
 		}
-		read_queue.push_back(std::move(chunk));
-		read_queue_byte_count += allocation_size;
-	} else {
-		auto &in_progress_batch = buffer[batch];
-		auto &chunks = in_progress_batch.chunks;
-		in_progress_batch.completed = false;
-		buffer_byte_count += allocation_size;
-		chunks.push_back(std::move(chunk));
 	}
+	InvokeUnblocks(to_unblock);
+	return chunk;
 }
 
 } // namespace duckdb

--- a/src/main/buffered_data/buffered_data.cpp
+++ b/src/main/buffered_data/buffered_data.cpp
@@ -1,16 +1,54 @@
 #include "duckdb/main/buffered_data/buffered_data.hpp"
+#include "duckdb/common/helper.hpp"
 #include "duckdb/main/stream_query_result.hpp"
 #include "duckdb/main/client_config.hpp"
 #include "duckdb/main/client_context.hpp"
 
 namespace duckdb {
 
-BufferedData::BufferedData(Type type, ClientContext &context_p) : type(type), context(context_p.shared_from_this()) {
+BufferedData::BufferedData(Type type, ClientContext &context_p, bool async)
+    : type(type), context(context_p.shared_from_this()), async(async) {
 	auto &config = ClientConfig::GetConfig(context_p);
-	total_buffer_size = config.streaming_buffer_size;
+	// The setting has no lower bound. A buffer that can never admit a chunk blocks
+	// every sink while empty, and the stream silently ends with zero rows
+	total_buffer_size = MaxValue<idx_t>(config.max_streaming_buffer_size, 1);
 }
 
 BufferedData::~BufferedData() {
+}
+
+StreamExecutionResult BufferedData::MapExecutionResult(PendingExecutionResult execution_result) {
+	switch (execution_result) {
+	case PendingExecutionResult::BLOCKED:
+	case PendingExecutionResult::RESULT_READY:
+		return StreamExecutionResult::BLOCKED;
+	case PendingExecutionResult::NO_TASKS_AVAILABLE:
+	case PendingExecutionResult::RESULT_NOT_READY:
+		return StreamExecutionResult::CHUNK_NOT_READY;
+	case PendingExecutionResult::EXECUTION_FINISHED:
+		return StreamExecutionResult::EXECUTION_FINISHED;
+	case PendingExecutionResult::EXECUTION_ERROR:
+		return StreamExecutionResult::EXECUTION_ERROR;
+	default:
+		throw InternalException("No conversion from PendingExecutionResult (%s) -> StreamExecutionResult",
+		                        EnumUtil::ToString(execution_result));
+	}
+}
+
+void BufferedData::WaitForChunk(ClientContext &client_context, ClientContextLock &context_lock,
+                                StreamQueryResult &result) {
+	client_context.WaitForProgress(context_lock, result);
+}
+
+void BufferedData::SignalChunkAvailable(const shared_ptr<QueryResultNotifier> &notifier) {
+	chunk_ready_cv.notify_all();
+	if (notifier) {
+		notifier->Notify();
+	}
+}
+
+idx_t BufferedData::LowWaterMark(idx_t capacity) {
+	return MaxValue<idx_t>(capacity / 2, 1);
 }
 
 StreamExecutionResult BufferedData::ReplenishBuffer(StreamQueryResult &result, ClientContextLock &context_lock) {
@@ -23,6 +61,13 @@ StreamExecutionResult BufferedData::ReplenishBuffer(StreamQueryResult &result, C
 	while (!StreamQueryResult::IsChunkReady(execution_result = ExecuteTaskInternal(result, context_lock))) {
 		if (execution_result == StreamExecutionResult::BLOCKED) {
 			UnblockSinks();
+		}
+		if (async) {
+			// A blocking fetch on an async result must wait, not spin. WaitForTask returns
+			// immediately while the producer queue is non-empty, which means nothing for
+			// a consumer that never runs tasks, so BLOCKED must wait here too.
+			WaitForChunk(*cc, context_lock, result);
+		} else if (execution_result == StreamExecutionResult::BLOCKED) {
 			cc->WaitForTask(context_lock, result);
 		}
 	}

--- a/src/main/buffered_data/simple_buffered_data.cpp
+++ b/src/main/buffered_data/simple_buffered_data.cpp
@@ -178,8 +178,8 @@ unique_ptr<DataChunk> SimpleBufferedData::Scan() {
 		buffered_chunks.pop();
 
 		if (chunk) {
-			auto allocation_size = chunk->GetDataSize();
-			buffered_count -= allocation_size;
+			auto chunk_data_size = chunk->GetDataSize();
+			buffered_count -= chunk_data_size;
 		}
 		// The pop restarts blocked producers below the low-water mark
 		if (buffered_count < LowWaterMark(BufferSize())) {
@@ -196,20 +196,20 @@ bool SimpleBufferedData::AppendOrBlock(const DataChunk &to_append, const Interru
 	auto chunk = make_uniq<DataChunk>();
 	chunk->Initialize(Allocator::DefaultAllocator(), to_append.GetTypes());
 	to_append.Copy(*chunk, 0);
-	auto allocation_size = chunk->GetDataSize();
+	auto chunk_data_size = chunk->GetDataSize();
 
 	shared_ptr<QueryResultNotifier> notifier;
 	bool was_empty;
 	{
 		annotated_unique_lock<annotated_mutex> lock(glock);
 		// The buffer admits a chunk that fits, and always one chunk when empty
-		if (buffered_count > 0 && buffered_count + allocation_size > BufferSize()) {
+		if (buffered_count > 0 && buffered_count + chunk_data_size > BufferSize()) {
 			// Park holding the finished copy. Restart selection deposits it at wake time
-			blocked_sinks.push(BlockedSink {blocked_sink, allocation_size, std::move(chunk)});
+			blocked_sinks.push(BlockedSink {blocked_sink, chunk_data_size, std::move(chunk)});
 			return true;
 		}
 		was_empty = buffered_chunks.empty();
-		buffered_count += allocation_size;
+		buffered_count += chunk_data_size;
 		buffered_chunks.push(std::move(chunk));
 		peak_buffered_bytes = MaxValue<idx_t>(peak_buffered_bytes, buffered_count);
 		if (was_empty) {

--- a/src/main/buffered_data/simple_buffered_data.cpp
+++ b/src/main/buffered_data/simple_buffered_data.cpp
@@ -1,12 +1,17 @@
 #include "duckdb/main/buffered_data/simple_buffered_data.hpp"
 #include "duckdb/common/printer.hpp"
+#include "duckdb/common/vector.hpp"
+#include "duckdb/execution/executor.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/stream_query_result.hpp"
 #include "duckdb/common/helper.hpp"
 
+#include <chrono>
+
 namespace duckdb {
 
-SimpleBufferedData::SimpleBufferedData(ClientContext &context) : BufferedData(BufferedData::Type::SIMPLE, context) {
+SimpleBufferedData::SimpleBufferedData(ClientContext &context, bool async)
+    : BufferedData(BufferedData::Type::SIMPLE, context, async) {
 	buffered_count = 0;
 	buffer_size = total_buffer_size;
 }
@@ -14,13 +19,58 @@ SimpleBufferedData::SimpleBufferedData(ClientContext &context) : BufferedData(Bu
 SimpleBufferedData::~SimpleBufferedData() {
 }
 
-void SimpleBufferedData::BlockSink(const InterruptState &blocked_sink) {
-	lock_guard<mutex> lock(glock);
-	blocked_sinks.push(blocked_sink);
+bool SimpleBufferedData::BufferSaturated() {
+	annotated_lock_guard<annotated_mutex> lock(glock);
+	return buffered_count >= BufferSize() || !blocked_sinks.empty();
 }
 
-bool SimpleBufferedData::BufferIsFull() {
-	return buffered_count >= BufferSize();
+idx_t SimpleBufferedData::PeakBufferedBytes() {
+	annotated_lock_guard<annotated_mutex> lock(glock);
+	return peak_buffered_bytes;
+}
+
+bool SimpleBufferedData::HasBufferedChunk() {
+	annotated_lock_guard<annotated_mutex> lock(glock);
+	return !buffered_chunks.empty();
+}
+
+void SimpleBufferedData::CollectRestartableSinks(vector<BlockedSink> &to_unblock) {
+	D_ASSERT(to_unblock.empty());
+	// Reserve first so a failed allocation loses no blocked sink
+	to_unblock.reserve(blocked_sinks.size());
+	while (!blocked_sinks.empty()) {
+		auto &front = blocked_sinks.front();
+		// Sinks restart in FIFO order. Stop at the first chunk that does not fit yet
+		if (buffered_count > 0 && buffered_count + front.pending_bytes > BufferSize()) {
+			break;
+		}
+		// Deposit the parked copy, so the chunk is visible before the producer wakes.
+		// A sink blocked again after a failed restart already deposited and holds none
+		if (front.pending_chunk) {
+			buffered_count += front.pending_bytes;
+			buffered_chunks.push(std::move(front.pending_chunk));
+			peak_buffered_bytes = MaxValue<idx_t>(peak_buffered_bytes, buffered_count);
+			front.pending_bytes = 0;
+		}
+		to_unblock.push_back(std::move(front));
+		blocked_sinks.pop();
+	}
+}
+
+void SimpleBufferedData::InvokeUnblocks(vector<BlockedSink> &to_unblock) {
+	// Invoked outside glock. Callback() takes the executor lock
+	for (idx_t i = 0; i < to_unblock.size(); i++) {
+		try {
+			to_unblock[i].state.Callback();
+		} catch (...) {
+			// Block the sinks not yet restarted again so they are not lost
+			annotated_lock_guard<annotated_mutex> lock(glock);
+			for (idx_t remainder = i + 1; remainder < to_unblock.size(); remainder++) {
+				blocked_sinks.push(std::move(to_unblock[remainder]));
+			}
+			throw;
+		}
+	}
 }
 
 void SimpleBufferedData::UnblockSinks() {
@@ -34,16 +84,12 @@ void SimpleBufferedData::UnblockSinks() {
 		return;
 	}
 	// Reschedule enough blocked sinks to populate the buffer
-	lock_guard<mutex> lock(glock);
-	while (!blocked_sinks.empty()) {
-		auto &blocked_sink = blocked_sinks.front();
-		if (buffered_count >= BufferSize()) {
-			// We have unblocked enough sinks already
-			break;
-		}
-		blocked_sink.Callback();
-		blocked_sinks.pop();
+	vector<BlockedSink> to_unblock;
+	{
+		annotated_lock_guard<annotated_mutex> lock(glock);
+		CollectRestartableSinks(to_unblock);
 	}
+	InvokeUnblocks(to_unblock);
 }
 
 StreamExecutionResult SimpleBufferedData::ExecuteTaskInternal(StreamQueryResult &result,
@@ -55,19 +101,47 @@ StreamExecutionResult SimpleBufferedData::ExecuteTaskInternal(StreamQueryResult 
 	if (!cc->IsActiveResult(context_lock, result)) {
 		return StreamExecutionResult::EXECUTION_CANCELLED;
 	}
+	if (async) {
+		const bool interrupted =
+		    cc->interrupt_state.load(std::memory_order_relaxed) == ClientInterruptState::INTERRUPTED;
+		if (interrupted && !Executor::Get(*cc).HasError()) {
+			// A worker error also raises the interrupt flag to stop sibling tasks. Only a flag
+			// without an executor error is a real cancel request. This is checked even when
+			// chunks are buffered, so a cancel is not detected only once the buffer is drained.
+			throw InterruptException();
+		}
+		if (!interrupted && HasBufferedChunk()) {
+			// A chunk is ready and nothing needs the executor lock
+			return StreamExecutionResult::CHUNK_READY;
+		}
+		// Observe the execution state without running tasks. A pushed worker error
+		// converts to EXECUTION_ERROR carrying the real message
+		auto execution_result = cc->ExecuteTaskInternal(context_lock, result, true);
+		if (execution_result == PendingExecutionResult::EXECUTION_ERROR) {
+			if (result.HasError()) {
+				Close();
+			}
+			return StreamExecutionResult::EXECUTION_ERROR;
+		}
+		if (HasBufferedChunk()) {
+			// An async consumer can fetch as soon as one chunk exists
+			return StreamExecutionResult::CHUNK_READY;
+		}
+		return MapExecutionResult(execution_result);
+	}
 	// Check for interrupt even if the buffer is full.
 	// Without this check, cancel requests would not be detected until the buffer is drained.
 	if (cc->interrupt_state.load(std::memory_order_relaxed) == ClientInterruptState::INTERRUPTED) {
 		throw InterruptException();
 	}
-	if (BufferIsFull()) {
-		// The buffer isn't empty yet, just return
+	if (BufferSaturated()) {
+		// A saturated buffer always holds a chunk, because blocking requires a non-empty buffer
 		return StreamExecutionResult::CHUNK_READY;
 	}
 	UnblockSinks();
 	// Let the executor run until the buffer is no longer empty
 	auto execution_result = cc->ExecuteTaskInternal(context_lock, result);
-	if (buffered_count >= BufferSize()) {
+	if (BufferSaturated()) {
 		return StreamExecutionResult::CHUNK_READY;
 	}
 	if (execution_result == PendingExecutionResult::BLOCKED ||
@@ -77,18 +151,14 @@ StreamExecutionResult SimpleBufferedData::ExecuteTaskInternal(StreamQueryResult 
 	if (result.HasError()) {
 		Close();
 	}
-	switch (execution_result) {
-	case PendingExecutionResult::NO_TASKS_AVAILABLE:
-	case PendingExecutionResult::RESULT_NOT_READY:
-		return StreamExecutionResult::CHUNK_NOT_READY;
-	case PendingExecutionResult::EXECUTION_FINISHED:
-		return StreamExecutionResult::EXECUTION_FINISHED;
-	case PendingExecutionResult::EXECUTION_ERROR:
-		return StreamExecutionResult::EXECUTION_ERROR;
-	default:
-		throw InternalException("No conversion from PendingExecutionResult (%s) -> StreamExecutionResult",
-		                        EnumUtil::ToString(execution_result));
-	}
+	return MapExecutionResult(execution_result);
+}
+
+void SimpleBufferedData::AssertNoBlockedSinks() {
+#ifdef D_ASSERT_IS_ENABLED
+	annotated_lock_guard<annotated_mutex> lock(glock);
+	D_ASSERT(blocked_sinks.empty());
+#endif
 }
 
 unique_ptr<DataChunk> SimpleBufferedData::Scan() {
@@ -96,30 +166,71 @@ unique_ptr<DataChunk> SimpleBufferedData::Scan() {
 		return nullptr;
 	}
 
-	lock_guard<mutex> lock(glock);
-	if (buffered_chunks.empty()) {
-		Close();
-		return nullptr;
-	}
-	auto chunk = std::move(buffered_chunks.front());
-	buffered_chunks.pop();
+	unique_ptr<DataChunk> chunk;
+	vector<BlockedSink> to_unblock;
+	{
+		annotated_lock_guard<annotated_mutex> lock(glock);
+		if (buffered_chunks.empty()) {
+			Close();
+			return nullptr;
+		}
+		chunk = std::move(buffered_chunks.front());
+		buffered_chunks.pop();
 
-	if (chunk) {
-		auto allocation_size = chunk->GetDataSize();
-		buffered_count -= allocation_size;
+		if (chunk) {
+			auto allocation_size = chunk->GetDataSize();
+			buffered_count -= allocation_size;
+		}
+		// The pop restarts blocked producers below the low-water mark
+		if (buffered_count < LowWaterMark(BufferSize())) {
+			CollectRestartableSinks(to_unblock);
+		}
 	}
+	InvokeUnblocks(to_unblock);
 	return chunk;
 }
 
-void SimpleBufferedData::Append(const DataChunk &to_append) {
+bool SimpleBufferedData::AppendOrBlock(const DataChunk &to_append, const InterruptState &blocked_sink) {
+	// Copy first. The cap check must use the flat copy's size. The source can be
+	// dictionary-compressed and much smaller. A block keeps the copy for wake time.
 	auto chunk = make_uniq<DataChunk>();
 	chunk->Initialize(Allocator::DefaultAllocator(), to_append.GetTypes());
 	to_append.Copy(*chunk, 0);
 	auto allocation_size = chunk->GetDataSize();
 
-	unique_lock<mutex> lock(glock);
-	buffered_count += allocation_size;
-	buffered_chunks.push(std::move(chunk));
+	shared_ptr<QueryResultNotifier> notifier;
+	bool was_empty;
+	{
+		annotated_unique_lock<annotated_mutex> lock(glock);
+		// The buffer admits a chunk that fits, and always one chunk when empty
+		if (buffered_count > 0 && buffered_count + allocation_size > BufferSize()) {
+			// Park holding the finished copy. Restart selection deposits it at wake time
+			blocked_sinks.push(BlockedSink {blocked_sink, allocation_size, std::move(chunk)});
+			return true;
+		}
+		was_empty = buffered_chunks.empty();
+		buffered_count += allocation_size;
+		buffered_chunks.push(std::move(chunk));
+		peak_buffered_bytes = MaxValue<idx_t>(peak_buffered_bytes, buffered_count);
+		if (was_empty) {
+			// The chunk is visible before the wake below, so a woken consumer always finds it
+			notifier = result_notifier;
+		}
+	}
+	if (was_empty) {
+		SignalChunkAvailable(notifier);
+	}
+	return false;
+}
+
+void SimpleBufferedData::WaitForChunk(ClientContext &client_context, ClientContextLock &context_lock,
+                                      StreamQueryResult &result) {
+	// Wake when a chunk is appended. The bounded wait covers progress that does not append
+	annotated_unique_lock<annotated_mutex> lock(glock);
+	if (!buffered_chunks.empty()) {
+		return;
+	}
+	chunk_ready_cv.wait_for(lock, std::chrono::milliseconds(Executor::WAIT_TIME));
 }
 
 } // namespace duckdb

--- a/src/main/client_config.cpp
+++ b/src/main/client_config.cpp
@@ -31,12 +31,12 @@ void ClientConfig::ResetUserVariable(const String &name) {
 
 void ClientConfig::SetDefaultStreamingBufferSize() {
 	auto memory = FileSystem::GetAvailableMemory();
-	auto default_size = ClientConfig().streaming_buffer_size;
+	auto default_size = ClientConfig().max_streaming_buffer_size;
 	if (!memory.IsValid()) {
-		streaming_buffer_size = default_size;
+		max_streaming_buffer_size = default_size;
 		return;
 	}
-	streaming_buffer_size = MinValue(memory.GetIndex(), default_size);
+	max_streaming_buffer_size = MinValue(memory.GetIndex(), default_size);
 }
 
 } // namespace duckdb

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -33,6 +33,7 @@
 #include "duckdb/parser/expression/function_expression.hpp"
 #include "duckdb/parser/expression/star_expression.hpp"
 #include "duckdb/parser/tableref/table_function_ref.hpp"
+#include "duckdb/parallel/task_scheduler.hpp"
 #include "duckdb/parser/expression/parameter_expression.hpp"
 #include "duckdb/parser/parsed_data/create_function_info.hpp"
 #include "duckdb/parser/parser.hpp"
@@ -215,6 +216,9 @@ ClientContext::ClientContext(shared_ptr<DatabaseInstance> database)
 }
 
 ClientContext::~ClientContext() {
+	if (config.streaming_execution_mode == StreamingExecutionMode::ASYNC) {
+		TaskScheduler::GetScheduler(*db).UnregisterAsyncStreamingConnection();
+	}
 	if (Exception::UncaughtException()) {
 		return;
 	}
@@ -340,6 +344,11 @@ void ClientContext::BeginQueryInternal(ClientContextLock &lock, const SQLStateme
 
 ErrorData ClientContext::EndQueryInternal(ClientContextLock &lock, bool success, bool invalidate_transaction,
                                           optional_ptr<ErrorData> previous_error) {
+	{
+		lock_guard<mutex> guard(notifier_lock);
+		active_result_notifier.reset();
+		has_result_notifier.store(false, std::memory_order_release);
+	}
 	if (active_query->executor) {
 		active_query->executor->CancelTasks();
 	}
@@ -405,6 +414,14 @@ void ClientContext::CleanupInternal(ClientContextLock &lock, BaseQueryResult *re
 	// Relaunch the threads if a SET THREADS command was issued
 	auto &scheduler = TaskScheduler::GetScheduler(*this);
 	scheduler.RelaunchThreads();
+
+	if (result && result->GetResultType() == QueryResultType::STREAM_RESULT) {
+		// Record the streaming buffer peak while the profiler is still running
+		auto &stream_result = static_cast<StreamQueryResult &>(*result);
+		if (stream_result.HasBufferedData()) {
+			QueryProfiler::Get(*this).SetStreamingPeakBufferSize(stream_result.GetBufferedData().PeakBufferedBytes());
+		}
+	}
 
 	optional_ptr<ErrorData> passed_error = nullptr;
 	if (result && result->HasError()) {
@@ -653,16 +670,32 @@ ClientContext::PendingPreparedStatementInternal(ClientContextLock &lock,
 	// Decide how to get the result collector.
 	get_result_collector_t get_collector = PhysicalResultCollector::GetResultCollector;
 	auto &client_config = ClientConfig::GetConfig(*this);
+	// The connection-local setting applies only to streaming results. A materialized
+	// result on an async connection simply runs sync. The mode is read here, at
+	// submission, once per query. The setting and the task scheduler maintain the
+	// invariant that async connections have a DuckDB-managed worker thread.
+	const auto async_result = stream_result && client_config.streaming_execution_mode == StreamingExecutionMode::ASYNC;
 	if (!stream_result && client_config.get_result_collector) {
 		get_collector = client_config.get_result_collector;
 	}
 	statement_data.output_type =
 	    stream_result ? QueryResultOutputType::ALLOW_STREAMING : QueryResultOutputType::FORCE_MATERIALIZED;
 	statement_data.memory_type = parameters.query_parameters.memory_type;
+	statement_data.execution_mode = async_result ? StreamingExecutionMode::ASYNC : StreamingExecutionMode::SYNC;
 
 	// Get the result collector and initialize the executor.
 	auto collector = get_collector(*this, statement_data);
 	D_ASSERT(collector->type == PhysicalOperatorType::RESULT_COLLECTOR);
+	if (async_result && client_config.notify_callback) {
+		// The connection's notifier is set before execution starts, so no notification can
+		// be missed. The buffered collector picks it up when it creates the result buffer.
+		auto notifier = make_shared_ptr<QueryResultNotifier>();
+		notifier->Set(client_config.notify_callback);
+		executor.SetResultNotifier(notifier);
+		lock_guard<mutex> guard(notifier_lock);
+		active_result_notifier = std::move(notifier);
+		has_result_notifier.store(true, std::memory_order_release);
+	}
 	executor.Initialize(std::move(collector));
 
 	auto types = executor.GetTypes();
@@ -678,6 +711,10 @@ ClientContext::PendingPreparedStatementInternal(ClientContextLock &lock,
 
 void ClientContext::WaitForTask(ClientContextLock &lock, BaseQueryResult &result) {
 	active_query->executor->WaitForTask();
+}
+
+void ClientContext::WaitForProgress(ClientContextLock &lock, BaseQueryResult &result) {
+	active_query->executor->WaitForProgress();
 }
 
 bool ClientContext::ErrorInvalidatesTransaction(ExceptionType type) {
@@ -742,6 +779,10 @@ void ClientContext::InitialCleanup(ClientContextLock &lock) {
 	//! Cleanup any open results and reset the interrupted flag
 	CleanupInternal(lock);
 	interrupt_state = ClientInterruptState::NOT_INTERRUPTED;
+	// Also covers a notifier set by a query whose creation failed before it could run
+	lock_guard<mutex> guard(notifier_lock);
+	active_result_notifier.reset();
+	has_result_notifier.store(false, std::memory_order_release);
 }
 
 StatementIterator ClientContext::IterateStatements(const string &query) {
@@ -1164,6 +1205,7 @@ unique_ptr<QueryResult> ClientContext::Query(const string &query, QueryParameter
 			PendingQueryParameters parameters;
 			parameters.query_parameters = query_parameters;
 			if (!is_last_overall) {
+				// Only the final result can stream (and thus be consumed asynchronously)
 				parameters.query_parameters.output_type = QueryResultOutputType::FORCE_MATERIALIZED;
 			}
 			auto pending_query = PendingQueryInternal(*lock, std::move(statement), parameters);
@@ -1308,6 +1350,24 @@ unique_ptr<QueryResult> ClientContext::ExecutePendingQueryInternal(ClientContext
 void ClientContext::Interrupt() {
 	ClientInterruptState expected = ClientInterruptState::NOT_INTERRUPTED;
 	interrupt_state.compare_exchange_strong(expected, ClientInterruptState::INTERRUPTED);
+	// Wake a waiting async stream consumer. Interrupt runs in signal handlers (the shell's
+	// Ctrl-C), so it must never block and must not allocate or free. It only tries the
+	// lock, and it notifies through the raw pointer while holding the lock, so no
+	// shared_ptr is copied and no destructor can run here. A contended lock means the
+	// query is being registered or torn down, so no consumer is waiting and skipping is
+	// safe. TryNotify only tries its own lock and calls the user callback, which the
+	// contract requires to be async-signal-safe.
+	if (has_result_notifier.load(std::memory_order_acquire) && notifier_lock.try_lock()) {
+		if (active_result_notifier) {
+			active_result_notifier->TryNotify();
+		}
+		notifier_lock.unlock();
+	}
+}
+
+shared_ptr<QueryResultNotifier> ClientContext::GetActiveResultNotifier() {
+	lock_guard<mutex> guard(notifier_lock);
+	return active_result_notifier;
 }
 
 bool ClientContext::IsInterrupted() const {

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -197,6 +197,7 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_SETTING(MaxExecutionTimeSetting),
     DUCKDB_SETTING(MaxExpressionDepthSetting),
     DUCKDB_GLOBAL(MaxMemorySetting),
+    DUCKDB_LOCAL(MaxStreamingBufferSizeSetting),
     DUCKDB_GLOBAL(MaxTempDirectorySizeSetting),
     DUCKDB_SETTING(MaxVacuumTasksSetting),
     DUCKDB_SETTING(MergeJoinThresholdSetting),
@@ -234,7 +235,7 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_GLOBAL(StandardVectorSizeSetting),
     DUCKDB_SETTING_CALLBACK(StorageBlockPrefetchSetting),
     DUCKDB_GLOBAL(StorageCompatibilityVersionSetting),
-    DUCKDB_LOCAL(StreamingBufferSizeSetting),
+    DUCKDB_LOCAL(StreamingExecutionModeSetting),
     DUCKDB_SETTING_CALLBACK(TableFunctionIdentifierConversionSetting),
     DUCKDB_GLOBAL(TempDirectorySetting),
     DUCKDB_SETTING_CALLBACK(TempFileEncryptionSetting),
@@ -255,10 +256,11 @@ static const ConfigurationAlias setting_aliases[] = {DUCKDB_SETTING_ALIAS("confi
                                                      DUCKDB_SETTING_ALIAS("custom_profiling_settings", 30),
                                                      DUCKDB_SETTING_ALIAS("memory_limit", 130),
                                                      DUCKDB_SETTING_ALIAS("null_order", 62),
-                                                     DUCKDB_SETTING_ALIAS("profile_output", 154),
-                                                     DUCKDB_SETTING_ALIAS("user", 174),
+                                                     DUCKDB_SETTING_ALIAS("profile_output", 155),
+                                                     DUCKDB_SETTING_ALIAS("streaming_buffer_size", 131),
+                                                     DUCKDB_SETTING_ALIAS("user", 175),
                                                      DUCKDB_SETTING_ALIAS("wal_autocheckpoint", 29),
-                                                     DUCKDB_SETTING_ALIAS("worker_threads", 172),
+                                                     DUCKDB_SETTING_ALIAS("worker_threads", 173),
                                                      FINAL_ALIAS};
 
 vector<ConfigurationOption> DBConfig::GetOptions() {

--- a/src/main/pending_query_result.cpp
+++ b/src/main/pending_query_result.cpp
@@ -10,11 +10,12 @@ PendingQueryResult::PendingQueryResult(shared_ptr<ClientContext> context_p, Prep
                                        vector<LogicalType> types_p, bool allow_stream_result)
     : BaseQueryResult(QueryResultType::PENDING_RESULT, statement.statement_type, statement.properties,
                       std::move(types_p), statement.names),
-      context(std::move(context_p)), allow_stream_result(allow_stream_result) {
+      context(std::move(context_p)), allow_stream_result(allow_stream_result),
+      async(statement.execution_mode == StreamingExecutionMode::ASYNC) {
 }
 
 PendingQueryResult::PendingQueryResult(ErrorData error)
-    : BaseQueryResult(QueryResultType::PENDING_RESULT, std::move(error)) {
+    : BaseQueryResult(QueryResultType::PENDING_RESULT, std::move(error)), allow_stream_result(false), async(false) {
 }
 
 PendingQueryResult::~PendingQueryResult() {
@@ -47,6 +48,12 @@ void PendingQueryResult::CheckExecutableInternal(ClientContextLock &lock) {
 
 void PendingQueryResult::WaitForTask() {
 	auto lock = LockContext();
+	if (async) {
+		// An async caller never runs tasks, so wait for worker progress. WaitForTask
+		// returns immediately whenever the producer queue is non-empty.
+		context->WaitForProgress(*lock, *this);
+		return;
+	}
 	context->WaitForTask(*lock, *this);
 }
 
@@ -67,7 +74,9 @@ bool PendingQueryResult::AllowStreamResult() const {
 
 PendingExecutionResult PendingQueryResult::ExecuteTaskInternal(ClientContextLock &lock) {
 	CheckExecutableInternal(lock);
-	return context->ExecuteTaskInternal(lock, *this, false);
+	// An async query never runs tasks on the consumer thread. The notify callback
+	// could otherwise run on this thread's stack under the context lock
+	return context->ExecuteTaskInternal(lock, *this, async);
 }
 
 unique_ptr<QueryResult> PendingQueryResult::ExecuteInternal(ClientContextLock &lock) {
@@ -75,7 +84,19 @@ unique_ptr<QueryResult> PendingQueryResult::ExecuteInternal(ClientContextLock &l
 
 	PendingExecutionResult execution_result;
 	while (!IsResultReady(execution_result = ExecuteTaskInternal(lock))) {
-		if (execution_result == PendingExecutionResult::BLOCKED) {
+		if (async) {
+			CheckExecutableInternal(lock);
+			if (context->IsInterrupted()) {
+				// Observing without running tasks cannot surface interrupts. The executing
+				// call throws on its interrupt guard before fetching any task, and its catch
+				// converts the interrupt into an error result exactly like the sync path.
+				execution_result = context->ExecuteTaskInternal(lock, *this, false);
+				break;
+			}
+			// An async consumer makes no progress itself, so wait for the workers here.
+			// WaitForTask would return immediately whenever the producer queue is non-empty.
+			context->WaitForProgress(lock, *this);
+		} else if (execution_result == PendingExecutionResult::BLOCKED) {
 			CheckExecutableInternal(lock);
 			context->WaitForTask(lock, *this);
 		}

--- a/src/main/profiler/metrics_manager.cpp
+++ b/src/main/profiler/metrics_manager.cpp
@@ -36,6 +36,7 @@ static const MetricDescriptor internal_metrics[] = {
 	DUCKDB_METRIC(MetricQueryTotalTime),
 	DUCKDB_METRIC(MetricSystemBlockedThreadTime),
 	DUCKDB_METRIC(MetricSystemPeakBufferMemory),
+	DUCKDB_METRIC(MetricSystemPeakStreamingBufferSize),
 	DUCKDB_METRIC(MetricSystemPeakTempDirSize),
 	DUCKDB_METRIC(MetricSystemTotalMemoryAllocated),
 	DUCKDB_METRIC(MetricIOTotalBytesRead),

--- a/src/main/profiler/profiling_utils.cpp
+++ b/src/main/profiler/profiling_utils.cpp
@@ -15,6 +15,7 @@ void QueryMetrics::FinalizeMetrics(GatheredMetrics &info) {
 	info.SetMetric<MetricIOTotalBytesWritten>(GetBytesWritten());
 	info.SetMetric<MetricSystemBlockedThreadTime>(blocked_thread_time);
 	info.SetMetric<MetricSystemPeakBufferMemory>(system_peak_buffer_memory);
+	info.SetMetric<MetricSystemPeakStreamingBufferSize>(system_peak_streaming_buffer_size);
 	info.SetMetric<MetricSystemPeakTempDirSize>(system_peak_temp_dir_size);
 	info.SetMetric<MetricSystemTotalMemoryAllocated>(GetTotalMemoryAllocated());
 }

--- a/src/main/query_profiler.cpp
+++ b/src/main/query_profiler.cpp
@@ -567,6 +567,14 @@ void QueryProfiler::SetBlockedTime(const double &blocked_thread_time) {
 	query_metrics.blocked_thread_time = blocked_thread_time;
 }
 
+void QueryProfiler::SetStreamingPeakBufferSize(idx_t peak_bytes) {
+	lock_guard<std::mutex> guard(lock);
+	if (!IsEnabled() || !running) {
+		return;
+	}
+	query_metrics.system_peak_streaming_buffer_size = peak_bytes;
+}
+
 string QueryProfiler::DrawPadded(const string &str, idx_t width) {
 	if (str.size() > width) {
 		return str.substr(0, width);
@@ -864,6 +872,7 @@ static LegacyCumulative LegacyOperatorToResultTree(const GatheredMetrics &info, 
 		result.AddValue("extra_info", it_extra->second);
 	}
 	result.AddValue("system_peak_buffer_memory", Value::UBIGINT(0));
+	result.AddValue("system_peak_streaming_buffer_size", Value::UBIGINT(0));
 	result.AddValue("system_peak_temp_dir_size", Value::UBIGINT(0));
 
 	LegacyCumulative cumulative;
@@ -918,6 +927,7 @@ unique_ptr<QueryProfileResult> QueryProfiler::ToLegacyResultTree() const {
 	emit("total_bytes_read", "io.total_bytes_read");
 	emit("system_peak_temp_dir_size", "system.peak_temp_dir_size");
 	emit("system_peak_buffer_memory", "system.peak_buffer_memory");
+	emit("system_peak_streaming_buffer_size", "system.peak_streaming_buffer_size");
 
 	// rows_returned = root operator's elements_returned (rows sent to client)
 	{

--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -1484,19 +1484,53 @@ Value StandardVectorSizeSetting::GetSetting(const ClientContext &) {
 //===----------------------------------------------------------------------===//
 // Streaming Buffer Size
 //===----------------------------------------------------------------------===//
-void StreamingBufferSizeSetting::SetLocal(ClientContext &context, const Value &input) {
+void MaxStreamingBufferSizeSetting::SetLocal(ClientContext &context, const Value &input) {
 	auto &config = ClientConfig::GetConfig(context);
-	config.streaming_buffer_size = DBConfig::ParseMemoryLimit(input.ToString());
+	config.max_streaming_buffer_size = DBConfig::ParseMemoryLimit(input.ToString());
 }
 
-void StreamingBufferSizeSetting::ResetLocal(ClientContext &context) {
+void MaxStreamingBufferSizeSetting::ResetLocal(ClientContext &context) {
 	auto &config = ClientConfig::GetConfig(context);
 	config.SetDefaultStreamingBufferSize();
 }
 
-Value StreamingBufferSizeSetting::GetSetting(const ClientContext &context) {
+Value MaxStreamingBufferSizeSetting::GetSetting(const ClientContext &context) {
 	auto &config = ClientConfig::GetConfig(context);
-	return Value(StringUtil::BytesToHumanReadableString(config.streaming_buffer_size));
+	return Value(StringUtil::BytesToHumanReadableString(config.max_streaming_buffer_size));
+}
+
+//===----------------------------------------------------------------------===//
+// Streaming Execution Mode
+//===----------------------------------------------------------------------===//
+static void SetStreamingExecutionMode(ClientContext &context, StreamingExecutionMode mode) {
+	auto &config = ClientConfig::GetConfig(context);
+	if (mode == config.streaming_execution_mode) {
+		return;
+	}
+	// The scheduler refuses async when no managed worker exists, and refuses thread
+	// changes that would remove the last managed worker while async connections exist.
+	// Pair on the old value, so only a registered connection ever unregisters.
+	auto &scheduler = TaskScheduler::GetScheduler(context);
+	if (config.streaming_execution_mode == StreamingExecutionMode::ASYNC) {
+		scheduler.UnregisterAsyncStreamingConnection();
+	} else if (mode == StreamingExecutionMode::ASYNC) {
+		scheduler.RegisterAsyncStreamingConnection();
+	}
+	config.streaming_execution_mode = mode;
+}
+
+void StreamingExecutionModeSetting::SetLocal(ClientContext &context, const Value &input) {
+	auto mode = EnumUtil::FromString<StreamingExecutionMode>(StringUtil::Upper(input.ToString()));
+	SetStreamingExecutionMode(context, mode);
+}
+
+void StreamingExecutionModeSetting::ResetLocal(ClientContext &context) {
+	SetStreamingExecutionMode(context, ClientConfig().streaming_execution_mode);
+}
+
+Value StreamingExecutionModeSetting::GetSetting(const ClientContext &context) {
+	auto &config = ClientConfig::GetConfig(context);
+	return Value(StringUtil::Lower(EnumUtil::ToString(config.streaming_execution_mode)));
 }
 
 //===----------------------------------------------------------------------===//

--- a/src/main/stream_query_result.cpp
+++ b/src/main/stream_query_result.cpp
@@ -14,12 +14,17 @@ StreamQueryResult::StreamQueryResult(StatementType statement_type, StatementProp
                   std::move(names), std::move(client_properties)),
       buffered_data(std::move(data)) {
 	context = buffered_data->GetContext();
+	// A notify callback passed at execution time already set a notifier on the buffer
+	result_notifier = buffered_data->GetResultNotifier();
 }
 
 StreamQueryResult::StreamQueryResult(ErrorData error) : QueryResult(QueryResultType::STREAM_RESULT, std::move(error)) {
 }
 
 StreamQueryResult::~StreamQueryResult() {
+	if (result_notifier) {
+		result_notifier->Clear();
+	}
 }
 
 string StreamQueryResult::ToString() {
@@ -53,9 +58,76 @@ StreamExecutionResult StreamQueryResult::ExecuteTask() {
 	return ExecuteTaskInternal(*lock);
 }
 
+void StreamQueryResult::HandleFetchFailure(ClientContextLock &lock, ErrorData error) {
+	bool invalidate_query = true;
+	if (!context->ErrorInvalidatesTransaction(error.Type())) {
+		// standard exceptions do not invalidate the current transaction
+		invalidate_query = false;
+	} else if (Exception::InvalidatesDatabase(error.Type())) {
+		// fatal exceptions invalidate the entire database
+		auto &db_instance = DatabaseInstance::GetDatabase(*context);
+		ValidChecker::Invalidate(db_instance, error.RawMessage());
+	}
+	context->ProcessError(error, context->GetCurrentQuery());
+	SetError(std::move(error));
+	context->CleanupInternal(lock, this, invalidate_query);
+}
+
+StreamExecutionResult StreamQueryResult::TryFetchChunk(unique_ptr<DataChunk> &out_chunk) {
+	out_chunk.reset();
+	if (!context) {
+		// The stream already closed. Keep reporting the terminal state
+		return HasError() ? StreamExecutionResult::EXECUTION_ERROR : StreamExecutionResult::EXECUTION_FINISHED;
+	}
+	if (!buffered_data || !buffered_data->IsAsync()) {
+		throw InvalidInputException(
+		    "TryFetchChunk can only be used on a streaming result executed with StreamingExecutionMode::ASYNC");
+	}
+	StreamExecutionResult execution_result;
+	{
+		auto lock = LockContext();
+		CheckExecutableInternal(*lock);
+		try {
+			execution_result = ExecuteTaskInternal(*lock);
+			if (execution_result == StreamExecutionResult::CHUNK_READY ||
+			    execution_result == StreamExecutionResult::EXECUTION_FINISHED) {
+				out_chunk = buffered_data->Scan();
+				if (out_chunk && out_chunk->ColumnCount() != 0 && out_chunk->size() != 0) {
+					return StreamExecutionResult::CHUNK_READY;
+				}
+				// The buffer is drained and execution is done. This is the end of the stream
+				buffered_data->AssertNoBlockedSinks();
+				out_chunk.reset();
+				context->CleanupInternal(*lock, this);
+				// Cleanup can fail on an autocommit commit. It sets the error without throwing
+				execution_result =
+				    HasError() ? StreamExecutionResult::EXECUTION_ERROR : StreamExecutionResult::EXECUTION_FINISHED;
+			}
+		} catch (std::exception &ex) {
+			HandleFetchFailure(*lock, ErrorData(ex));
+			execution_result = StreamExecutionResult::EXECUTION_ERROR;
+		} catch (...) { // LCOV_EXCL_START
+			SetError(ErrorData("Unhandled exception in TryFetchChunk"));
+			context->CleanupInternal(*lock, this, true);
+			execution_result = StreamExecutionResult::EXECUTION_ERROR;
+		} // LCOV_EXCL_STOP
+	}
+	if (execution_result == StreamExecutionResult::EXECUTION_FINISHED ||
+	    execution_result == StreamExecutionResult::EXECUTION_ERROR ||
+	    execution_result == StreamExecutionResult::EXECUTION_CANCELLED) {
+		Close();
+	}
+	return execution_result;
+}
+
 void StreamQueryResult::WaitForTask() {
 	auto lock = LockContext();
 	buffered_data->UnblockSinks();
+	if (buffered_data->IsAsync()) {
+		// Wake when a chunk is appended, instead of on the executor's task cadence
+		buffered_data->WaitForChunk(*context, *lock, *this);
+		return;
+	}
 	context->WaitForTask(*lock, *this);
 }
 
@@ -70,7 +142,6 @@ static bool ExecutionErrorOccurred(StreamExecutionResult result) {
 }
 
 unique_ptr<DataChunk> StreamQueryResult::FetchNextInternal(ClientContextLock &lock) {
-	bool invalidate_query = true;
 	unique_ptr<DataChunk> chunk;
 	try {
 		// fetch the chunk and return it
@@ -85,21 +156,11 @@ unique_ptr<DataChunk> StreamQueryResult::FetchNextInternal(ClientContextLock &lo
 		}
 		return chunk;
 	} catch (std::exception &ex) {
-		ErrorData error(ex);
-		if (!Exception::InvalidatesTransaction(error.Type())) {
-			// standard exceptions do not invalidate the current transaction
-			invalidate_query = false;
-		} else if (Exception::InvalidatesDatabase(error.Type())) {
-			// fatal exceptions invalidate the entire database
-			auto &db_instance = DatabaseInstance::GetDatabase(*context);
-			ValidChecker::Invalidate(db_instance, error.RawMessage());
-		}
-		context->ProcessError(error, context->GetCurrentQuery());
-		SetError(std::move(error));
+		HandleFetchFailure(lock, ErrorData(ex));
 	} catch (...) { // LCOV_EXCL_START
 		SetError(ErrorData("Unhandled exception in FetchInternal"));
+		context->CleanupInternal(lock, this, true);
 	} // LCOV_EXCL_STOP
-	context->CleanupInternal(lock, this, invalidate_query);
 	return nullptr;
 }
 
@@ -111,6 +172,9 @@ unique_ptr<DataChunk> StreamQueryResult::FetchInternal() {
 		chunk = FetchNextInternal(*lock);
 	}
 	if (!chunk || chunk->ColumnCount() == 0 || chunk->size() == 0) {
+		if (!HasError()) {
+			buffered_data->AssertNoBlockedSinks();
+		}
 		Close();
 		return nullptr;
 	}
@@ -192,6 +256,9 @@ bool StreamQueryResult::IsOpen() {
 }
 
 void StreamQueryResult::Close() {
+	if (result_notifier) {
+		result_notifier->Clear();
+	}
 	buffered_data->Close();
 	if (context) {
 		auto lock = LockContext();

--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -7,6 +7,7 @@
 #include "duckdb/execution/operator/set/physical_cte.hpp"
 #include "duckdb/execution/operator/set/physical_recursive_cte.hpp"
 #include "duckdb/execution/physical_operator.hpp"
+#include "duckdb/main/buffered_data/buffered_data.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/client_data.hpp"
 #include "duckdb/main/settings.hpp"
@@ -236,6 +237,7 @@ void Executor::InitializeInternal(PhysicalOperator &plan) {
 	{
 		lock_guard<mutex> elock(executor_lock);
 		physical_plan = &plan;
+		streaming_buffered_data.store(nullptr, std::memory_order_relaxed);
 
 		this->profiler = ClientData::Get(context).profiler;
 		this->producer = scheduler.CreateProducer();
@@ -278,12 +280,23 @@ void Executor::InitializeInternal(PhysicalOperator &plan) {
 void Executor::CancelTasks() {
 	task.reset();
 	reference_map_t<Task, shared_ptr<Task>> to_destroy;
+	shared_ptr<QueryResultNotifier> notifier;
 	{
 		lock_guard<mutex> elock(executor_lock);
 		// mark the query as cancelled so tasks will early-out
 		cancelled = true;
 		to_destroy = std::move(to_be_rescheduled_tasks);
 		to_be_rescheduled_tasks.clear();
+	}
+	{
+		annotated_lock_guard<annotated_mutex> l(result_notifier_lock);
+		notifier = std::move(result_notifier);
+	}
+	if (notifier) {
+		// Workers can still fire notifications while the query is torn down. The buffered
+		// data holds its own notifier reference, so resetting ours is not enough.
+		// Clear silences every copy.
+		notifier->Clear();
 	}
 	to_destroy.clear();
 	// Drain all tasks first — they hold references to pipelines/events/states,
@@ -345,23 +358,68 @@ void Executor::SignalTaskRescheduled(lock_guard<mutex> &) {
 	task_reschedule.notify_one();
 }
 
+void Executor::SetResultNotifier(shared_ptr<QueryResultNotifier> result_notifier_p) {
+	annotated_lock_guard<annotated_mutex> l(result_notifier_lock);
+	result_notifier = std::move(result_notifier_p);
+}
+
 void Executor::UnregisterTask() {
 #ifndef DUCKDB_NO_THREADS
-	lock_guard<mutex> l(executor_lock);
 	{
-		const annotated_lock_guard<annotated_mutex> producer_lock(producer->producer_lock);
-		executor_tasks--;
-		producer->producer_cv.notify_all();
+		lock_guard<mutex> l(executor_lock);
+		{
+			const annotated_lock_guard<annotated_mutex> producer_lock(producer->producer_lock);
+			executor_tasks--;
+			producer->producer_cv.notify_all();
+		}
+		task_reschedule.notify_all();
 	}
-	task_reschedule.notify_all();
 #else
 	executor_tasks--;
 #endif
 }
 
+void Executor::CompletePipeline() {
+	auto completed = ++completed_pipelines;
+	// The last completion flips ExecutionIsFinished, the transition an async consumer
+	// waits for. This runs on the thread that finished the pipeline, never on an async
+	// consumer path. The notify must not hang off task destruction: the last task
+	// reference can die on a consumer thread that restarted a blocked sink.
+	if (completed >= total_pipelines) {
+		NotifyResultTerminal();
+	}
+}
+
+void Executor::NotifyResultTerminal() {
+	shared_ptr<QueryResultNotifier> notifier;
+	{
+		annotated_lock_guard<annotated_mutex> l(result_notifier_lock);
+		notifier = result_notifier;
+	}
+	if (notifier) {
+		// Notify outside the lock. The callback must never run under an engine lock.
+		// A throwing callback (a contract violation) must not tear down the caller.
+		try {
+			notifier->Notify();
+		} catch (...) { // LCOV_EXCL_LINE
+		}
+	}
+}
+
 void Executor::WaitForTask() {
+	WaitForTaskInternal(true);
+}
+
+void Executor::WaitForProgress() {
+	// An async caller never runs tasks, so an available producer task is no reason
+	// to skip the wait
+	WaitForTaskInternal(false);
+}
+
+void Executor::WaitForTaskInternal(bool consider_producer_queue) {
 #ifndef DUCKDB_NO_THREADS
-	static constexpr std::chrono::microseconds WAIT_TIME_MS = std::chrono::microseconds(WAIT_TIME * 1000);
+	// WAIT_TIME is in milliseconds
+	static constexpr std::chrono::microseconds WAIT_INTERVAL = std::chrono::microseconds(WAIT_TIME * 1000);
 	auto begin = TimePoint::Tick();
 	std::unique_lock<mutex> l(executor_lock);
 	auto end = TimePoint::Tick();
@@ -372,20 +430,22 @@ void Executor::WaitForTask() {
 		return;
 	}
 	if (ResultCollectorIsBlocked()) {
-		// If the result collector is blocked, it won't get unblocked until the connection calls Fetch
+		// A chunk is buffered. The caller's next step will observe it
 		blocked_thread_time += blocked_micros;
 		return;
 	}
-	auto &scheduler = TaskScheduler::GetScheduler(context);
-	if (scheduler.GetTaskCountForProducer(*producer) > 0) {
-		// A task is available for the calling thread, the next step will make progress without waiting
-		blocked_thread_time += blocked_micros;
-		return;
+	if (consider_producer_queue) {
+		auto &scheduler = TaskScheduler::GetScheduler(context);
+		if (scheduler.GetTaskCountForProducer(*producer) > 0) {
+			// A task is available for the calling thread, the next step will make progress without waiting
+			blocked_thread_time += blocked_micros;
+			return;
+		}
 	}
-	// Nothing to run on this thread, all remaining tasks are either running on other threads or descheduled.
-	// Wait (bounded), but wake up on task completion or reschedule.
-	blocked_thread_time += blocked_micros + WAIT_TIME_MS.count();
-	task_reschedule.wait_for(l, WAIT_TIME_MS);
+	// Nothing this caller can advance itself. Wait with a bound, and wake up on task
+	// completion or reschedule.
+	blocked_thread_time += blocked_micros + WAIT_INTERVAL.count();
+	task_reschedule.wait_for(l, WAIT_INTERVAL);
 #endif
 }
 
@@ -405,6 +465,17 @@ void Executor::RescheduleTask(shared_ptr<Task> &task_p) {
 			break;
 		}
 	}
+}
+
+void Executor::SetStreamingBufferedData(BufferedData &buffer) {
+	streaming_buffered_data.store(&buffer, std::memory_order_release);
+}
+
+bool Executor::ResultIsObservable() {
+	// Acquire pairs with the release in SetStreamingBufferedData, so the buffer is
+	// fully constructed here. The member comment explains why it cannot dangle.
+	auto buffer = streaming_buffered_data.load(std::memory_order_acquire);
+	return buffer && buffer->HasObservableChunk();
 }
 
 bool Executor::ResultCollectorIsBlocked() {
@@ -431,6 +502,9 @@ void Executor::AddToBeRescheduled(shared_ptr<Task> &task_p) {
 	// Save the reference before move — evaluation order of operator[] key and assignment value is unspecified pre-C++17
 	auto &task_ref = *task_p;
 	to_be_rescheduled_tasks[task_ref] = std::move(task_p);
+	// A task blocking can turn ResultCollectorIsBlocked() true. Wake waiting async
+	// consumers, or they sleep a full WAIT_TIME despite a result chunk being observable
+	task_reschedule.notify_all();
 }
 
 bool Executor::ExecutionIsFinished() {
@@ -459,6 +533,12 @@ PendingExecutionResult Executor::ExecuteTask(bool dry_run) {
 		}
 
 		if (!current_task && !HasError()) {
+			// An async observer can consume as soon as a chunk is observable, before
+			// any producer blocks. Checked outside executor_lock: the buffer takes its
+			// own lock, and the two must not nest.
+			if (dry_run && ResultIsObservable()) {
+				return PendingExecutionResult::RESULT_READY;
+			}
 			// there are no tasks to be scheduled and there are tasks blocked
 			lock_guard<mutex> l(executor_lock);
 			if (to_be_rescheduled_tasks.empty()) {
@@ -522,6 +602,7 @@ PendingExecutionResult Executor::ExecuteTask(bool dry_run) {
 void Executor::Reset() {
 	lock_guard<mutex> elock(executor_lock);
 	physical_plan = nullptr;
+	streaming_buffered_data.store(nullptr, std::memory_order_relaxed);
 	cancelled = false;
 	root_executor.reset();
 	root_pipelines.clear();
@@ -569,6 +650,8 @@ void Executor::PushError(ErrorData exception) {
 		pipeline->FinishSourceAndPreventBlocking(context);
 		pipeline->PreventSinkBlocking();
 	}
+	// An error flips ExecutionIsFinished. Wake an async consumer waiting for that.
+	NotifyResultTerminal();
 }
 
 bool Executor::HasError() {

--- a/src/parallel/task_scheduler.cpp
+++ b/src/parallel/task_scheduler.cpp
@@ -317,7 +317,39 @@ void TaskScheduler::SetThreads(idx_t total_threads, idx_t external_threads) {
 		    "DuckDB was compiled without threads! Setting total_threads != external_threads is not allowed.");
 	}
 #endif
+	lock_guard<mutex> guard(async_streaming_lock);
+	if (total_threads == external_threads && async_streaming_connections > 0) {
+		throw InvalidInputException(
+		    "Cannot change the thread configuration: %llu connection(s) have streaming_execution_mode set to "
+		    "'async', which requires at least one DuckDB-managed worker thread. Increase 'threads' or lower "
+		    "'external_threads'",
+		    async_streaming_connections);
+	}
 	SetThreadsInternal(TaskSchedulerType::REGULAR, total_threads - external_threads);
+}
+
+void TaskScheduler::RegisterAsyncStreamingConnection() {
+#ifdef DUCKDB_NO_THREADS
+	throw NotImplementedException("streaming_execution_mode = 'async' requires a threaded build of DuckDB");
+#else
+	lock_guard<mutex> guard(async_streaming_lock);
+	// The requested count is the committed intent, updated atomically with the guard in
+	// SetThreads. It assumes RelaunchThreads can launch the requested workers. When the
+	// OS refuses every thread, RelaunchThreads gives up silently and an async query can
+	// still stall. That pre-existing weakness needs OS thread exhaustion to hit.
+	if (GetPool(TaskSchedulerType::REGULAR).RequestedThreadCount() == 0) {
+		throw InvalidInputException(
+		    "streaming_execution_mode = 'async' requires at least one DuckDB-managed worker thread, because "
+		    "background workers produce the result. Increase 'threads' or lower 'external_threads'");
+	}
+	async_streaming_connections++;
+#endif
+}
+
+void TaskScheduler::UnregisterAsyncStreamingConnection() {
+	lock_guard<mutex> guard(async_streaming_lock);
+	D_ASSERT(async_streaming_connections > 0);
+	async_streaming_connections--;
 }
 
 void TaskScheduler::SetAsyncThreads(idx_t n) {

--- a/src/parallel/task_scheduler_pool.cpp
+++ b/src/parallel/task_scheduler_pool.cpp
@@ -63,6 +63,10 @@ idx_t TaskSchedulerPool::NumberOfThreads() {
 	return current_thread_count.load();
 }
 
+idx_t TaskSchedulerPool::RequestedThreadCount() {
+	return requested_thread_count.load();
+}
+
 void TaskSchedulerPool::Signal(idx_t n) {
 #ifndef DUCKDB_NO_THREADS
 	if (n == 0) {

--- a/test/api/CMakeLists.txt
+++ b/test/api/CMakeLists.txt
@@ -29,6 +29,7 @@ set(TEST_API_OBJECTS
     test_appender_api.cpp
     test_lifecycle_hooks.cpp
     test_extension_schema_api.cpp
+    test_async_stream_result.cpp
     test_pending_query.cpp
     test_plan_serialization.cpp
     test_relation_api.cpp

--- a/test/api/test_async_stream_result.cpp
+++ b/test/api/test_async_stream_result.cpp
@@ -1,0 +1,1686 @@
+#include "catch.hpp"
+#include "test_helpers.hpp"
+
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/common/arrow/physical_arrow_collector.hpp"
+#include "duckdb/common/query_parameters.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/common/vector_operations/unary_executor.hpp"
+#include "duckdb/main/buffered_data/batched_buffered_data.hpp"
+#include "duckdb/main/client_config.hpp"
+#include "duckdb/main/query_profiler.hpp"
+#include "duckdb/main/stream_query_result.hpp"
+#include "duckdb/parser/parsed_data/create_scalar_function_info.hpp"
+#include "duckdb/storage/storage_info.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <thread>
+
+using namespace duckdb;
+
+namespace {
+
+//! A listener the callback wakes (Notify() -> cv.notify_one()). The consumer waits on it.
+//! Spurious notifications are part of the contract.
+struct NotifyListener {
+	std::mutex lock;
+	std::condition_variable cv;
+	bool woken = false;
+
+	void Notify() {
+		{
+			std::lock_guard<std::mutex> guard(lock);
+			woken = true;
+		}
+		cv.notify_one();
+	}
+	//! Returns false on timeout
+	bool WaitAndReset(std::chrono::milliseconds timeout) {
+		std::unique_lock<std::mutex> guard(lock);
+		if (!cv.wait_for(guard, timeout, [&]() { return woken; })) {
+			return false;
+		}
+		woken = false;
+		return true;
+	}
+};
+
+//! Bounds every drain loop, so a liveness bug fails the test instead of hanging the suite
+struct Deadline {
+	std::chrono::steady_clock::time_point expiry = std::chrono::steady_clock::now() + std::chrono::seconds(60);
+
+	bool Passed() const {
+		return std::chrono::steady_clock::now() >= expiry;
+	}
+};
+
+//! Interrupts the connection when the guarded scope outlives the deadline, so a hung
+//! blocking drain fails its test instead of hanging the suite
+class DrainWatchdog {
+public:
+	explicit DrainWatchdog(Connection &con)
+	    : watcher([this, &con]() {
+		      Deadline deadline;
+		      while (!done.load() && !deadline.Passed()) {
+			      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+		      }
+		      if (!done.load()) {
+			      con.Interrupt();
+		      }
+	      }) {
+	}
+	~DrainWatchdog() {
+		done = true;
+		watcher.join();
+	}
+
+private:
+	std::atomic<bool> done {false};
+	std::thread watcher;
+};
+
+//! Switch the connection to asynchronous streaming result consumption
+void EnableAsync(Connection &con) {
+	REQUIRE_NO_FAIL(con.Query("SET streaming_execution_mode='async'"));
+}
+
+unique_ptr<StreamQueryResult> ExecuteAsync(Connection &con, const string &query) {
+	EnableAsync(con);
+	auto pending = con.PendingQuery(query, QueryParameters(true));
+	if (pending->HasError()) {
+		FAIL(pending->GetError());
+	}
+	auto result = pending->Execute();
+	REQUIRE(result->GetResultType() == QueryResultType::STREAM_RESULT);
+	return unique_ptr_cast<QueryResult, StreamQueryResult>(std::move(result));
+}
+
+//! Install the connection notifier that wakes the listener
+void SetNotifier(Connection &con, NotifyListener &listener) {
+	auto &config = ClientConfig::GetConfig(*con.context);
+	config.notify_callback = [&listener]() {
+		listener.Notify();
+	};
+}
+
+//! Install a notifier that also counts the notifications it delivers
+void SetCountingNotifier(Connection &con, NotifyListener &listener, std::atomic<idx_t> &count) {
+	auto &config = ClientConfig::GetConfig(*con.context);
+	config.notify_callback = [&listener, &count]() {
+		count++;
+		listener.Notify();
+	};
+}
+
+//! Render the physical plan text so tests can assert the plan shape
+string PhysicalPlanText(Connection &con, const string &query) {
+	auto explain_result = con.Query("EXPLAIN " + query);
+	if (explain_result->HasError()) {
+		FAIL(explain_result->GetError());
+	}
+	string plan;
+	for (idx_t row = 0; row < explain_result->RowCount(); row++) {
+		plan += explain_result->GetValue(1, row).ToString();
+	}
+	return plan;
+}
+
+//! Verify a chunk column continues the ascending sequence. Returns the next expected value.
+//! Reads the vector data directly: the consumer must stay fast enough to outrun the
+//! producers, or the drain loops never wait and the wake paths go untested.
+int64_t VerifyAscending(DataChunk &chunk, int64_t next_value, idx_t column = 0) {
+	chunk.Flatten();
+	if (!FlatVector::Validity(chunk.data[column]).CheckAllValid(chunk.size())) {
+		FAIL("Unexpected NULL in ascending sequence");
+	}
+	auto data = FlatVector::GetData<int64_t>(chunk.data[column]);
+	for (idx_t i = 0; i < chunk.size(); i++) {
+		if (data[i] != next_value) {
+			FAIL(StringUtil::Format("Out-of-order row: expected %lld, got %lld", next_value, data[i]));
+		}
+		next_value++;
+	}
+	return next_value;
+}
+
+//! Counting listener that also records callbacks running on the consumer's own stack
+//! inside an engine call. Wrap engine calls in in_call to enable the check.
+struct StackCheckListener {
+	NotifyListener listener;
+	std::atomic<bool> in_call {false};
+	std::atomic<idx_t> consumer_stack_notifications {0};
+	std::atomic<idx_t> notification_count {0};
+	std::thread::id consumer_thread;
+
+	//! Install as the connection notifier. Records the calling thread as the consumer
+	void Install(Connection &con) {
+		consumer_thread = std::this_thread::get_id();
+		auto &config = ClientConfig::GetConfig(*con.context);
+		config.notify_callback = [this]() {
+			notification_count++;
+			if (std::this_thread::get_id() == consumer_thread && in_call.load()) {
+				consumer_stack_notifications++;
+			}
+			listener.Notify();
+		};
+	}
+};
+
+} // namespace
+
+#ifndef DUCKDB_NO_THREADS
+
+// Core contract: a full drain that never blocks and never executes engine work
+
+TEST_CASE("Async stream result completes using TryFetch only", "[api][async_stream]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	// A tiny buffer forces many block/restart cycles on the producer sinks
+	REQUIRE_NO_FAIL(con.Query("SET streaming_buffer_size='100KB'"));
+
+	auto stream = ExecuteAsync(con, "SELECT i FROM range(500000) t(i)");
+	Deadline deadline;
+	idx_t row_count = 0;
+	int64_t sum = 0;
+	while (true) {
+		REQUIRE(!deadline.Passed());
+		unique_ptr<DataChunk> chunk;
+		auto execution_result = stream->TryFetchChunk(chunk);
+		if (execution_result == StreamExecutionResult::CHUNK_READY) {
+			for (idx_t i = 0; i < chunk->size(); i++) {
+				sum += chunk->GetValue(0, i).GetValue<int64_t>();
+			}
+			row_count += chunk->size();
+			continue;
+		}
+		if (execution_result == StreamExecutionResult::EXECUTION_FINISHED) {
+			break;
+		}
+		REQUIRE((execution_result == StreamExecutionResult::BLOCKED ||
+		         execution_result == StreamExecutionResult::CHUNK_NOT_READY));
+		std::this_thread::sleep_for(std::chrono::microseconds(100));
+	}
+	REQUIRE(row_count == 500000);
+	REQUIRE(sum == 124999750000);
+
+	// The connection is usable again after the stream is drained
+	auto result = con.Query("SELECT 42");
+	REQUIRE(CHECK_COLUMN(result, 0, {42}));
+}
+
+TEST_CASE("A non-blocking pending consumer progresses on notifications alone", "[api][async_stream]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	REQUIRE_NO_FAIL(con.Query("SET streaming_buffer_size='100KB'"));
+	EnableAsync(con);
+
+	// The callback is read at submission, so install it first
+	NotifyListener listener;
+	SetNotifier(con, listener);
+
+	auto pending = con.PendingQuery("SELECT i FROM range(500000) t(i)", QueryParameters(true));
+	REQUIRE(!pending->HasError());
+
+	// Drive the pending phase the way an event-loop consumer does: observe with
+	// ExecuteTask, and sleep on the callback whenever no progress is possible. An
+	// observable chunk must make ExecuteTask report the result ready. Before that,
+	// readiness required a blocked producer, a transition with no notification, so
+	// this loop consumed the first-append notification and slept forever.
+	Deadline deadline;
+	while (true) {
+		REQUIRE(!deadline.Passed());
+		auto execution_result = pending->ExecuteTask();
+		if (PendingQueryResult::IsResultReady(execution_result)) {
+			break;
+		}
+		REQUIRE(execution_result != PendingExecutionResult::EXECUTION_ERROR);
+		REQUIRE(listener.WaitAndReset(std::chrono::seconds(10)));
+	}
+	auto result = pending->Execute();
+	REQUIRE(result->GetResultType() == QueryResultType::STREAM_RESULT);
+	auto &stream = result->Cast<StreamQueryResult>();
+
+	idx_t row_count = 0;
+	while (true) {
+		REQUIRE(!deadline.Passed());
+		unique_ptr<DataChunk> chunk;
+		auto execution_result = stream.TryFetchChunk(chunk);
+		if (execution_result == StreamExecutionResult::CHUNK_READY) {
+			row_count += chunk->size();
+			continue;
+		}
+		if (execution_result == StreamExecutionResult::EXECUTION_FINISHED) {
+			break;
+		}
+		REQUIRE(listener.WaitAndReset(std::chrono::seconds(10)));
+	}
+	REQUIRE(row_count == 500000);
+}
+
+TEST_CASE("TryFetchChunk refuses a sync stream result", "[api][async_stream]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+
+	auto pending = con.PendingQuery("SELECT i FROM range(10) t(i)", QueryParameters(true));
+	REQUIRE(!pending->HasError());
+	auto result = pending->Execute();
+	REQUIRE(result->GetResultType() == QueryResultType::STREAM_RESULT);
+	auto &stream = result->Cast<StreamQueryResult>();
+	unique_ptr<DataChunk> chunk;
+	REQUIRE_THROWS(stream.TryFetchChunk(chunk));
+}
+
+// Wake-ups: a waiting consumer is always woken, and never on its own stack
+
+TEST_CASE("Async stream result wakes a waiting consumer", "[api][async_stream]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	REQUIRE_NO_FAIL(con.Query("SET streaming_buffer_size='100KB'"));
+
+	// The callback must never run on the consumer's stack inside an engine call
+	StackCheckListener state;
+	state.Install(con);
+
+	state.in_call = true;
+	auto stream = ExecuteAsync(con, "SELECT i FROM range(500000) t(i)");
+	state.in_call = false;
+
+	Deadline deadline;
+	idx_t row_count = 0;
+	while (true) {
+		REQUIRE(!deadline.Passed());
+		unique_ptr<DataChunk> chunk;
+		state.in_call = true;
+		auto execution_result = stream->TryFetchChunk(chunk);
+		state.in_call = false;
+		if (execution_result == StreamExecutionResult::CHUNK_READY) {
+			row_count += chunk->size();
+			continue;
+		}
+		if (execution_result == StreamExecutionResult::EXECUTION_FINISHED) {
+			break;
+		}
+		REQUIRE((execution_result == StreamExecutionResult::BLOCKED ||
+		         execution_result == StreamExecutionResult::CHUNK_NOT_READY));
+		// Park until the engine wakes us. A missed notification fails here by timeout.
+		REQUIRE(state.listener.WaitAndReset(std::chrono::seconds(10)));
+	}
+	REQUIRE(row_count == 500000);
+	REQUIRE(state.consumer_stack_notifications.load() == 0);
+}
+
+TEST_CASE("Async batched stream result wakes a waiting consumer", "[api][async_stream]") {
+	constexpr idx_t ROW_COUNT = 500000;
+	DuckDB db(nullptr);
+	Connection con(db);
+	REQUIRE_NO_FAIL(con.Query(StringUtil::Format("CREATE TABLE t AS SELECT range i FROM range(%llu)", ROW_COUNT)));
+	// A one-chunk buffer forces waiting. The consumer drains to empty and waits between
+	// chunks in every build type, so each append wake is exercised
+	REQUIRE_NO_FAIL(con.Query("SET streaming_buffer_size='1B'"));
+
+	// The callback must never run on the consumer's stack inside an engine call
+	StackCheckListener state;
+	state.Install(con);
+
+	state.in_call = true;
+	auto stream = ExecuteAsync(con, "SELECT i FROM t");
+	state.in_call = false;
+
+	// Purely notification-driven. The consumer waits unconditionally
+	// between drains and only advances when the engine notifies. A missed chunk-arrival
+	// or terminal notification fails by timeout.
+	Deadline deadline;
+	int64_t next_value = 0;
+	bool finished = false;
+	while (!finished) {
+		REQUIRE(!deadline.Passed());
+		REQUIRE(state.listener.WaitAndReset(std::chrono::seconds(10)));
+		while (true) {
+			unique_ptr<DataChunk> chunk;
+			state.in_call = true;
+			auto execution_result = stream->TryFetchChunk(chunk);
+			state.in_call = false;
+			if (execution_result == StreamExecutionResult::CHUNK_READY) {
+				next_value = VerifyAscending(*chunk, next_value);
+				continue;
+			}
+			if (execution_result == StreamExecutionResult::EXECUTION_FINISHED) {
+				finished = true;
+			} else {
+				REQUIRE((execution_result == StreamExecutionResult::BLOCKED ||
+				         execution_result == StreamExecutionResult::CHUNK_NOT_READY));
+			}
+			break;
+		}
+	}
+	REQUIRE(next_value == int64_t(ROW_COUNT));
+	REQUIRE(state.consumer_stack_notifications.load() == 0);
+	// A chunk can arrive through the consumer's own restart selection, which deposits a
+	// parked chunk during the pop. Those arrivals are self-observed and must not notify:
+	// the callback never runs on the consumer's stack. Only appends into a queue the
+	// consumer may be sleeping on notify, so the count depends on timing. Delivery is
+	// pinned by the bounded waits above. The initial append always notifies.
+	INFO(state.notification_count.load());
+	REQUIRE(state.notification_count.load() >= 1);
+}
+
+TEST_CASE("Async stream result wakes the consumer on the terminal transition", "[api][async_stream]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+
+	// Produces no rows, so the only notification can come from execution finishing
+	NotifyListener listener;
+	SetNotifier(con, listener);
+	auto stream = ExecuteAsync(con, "SELECT i FROM range(50000000) t(i) WHERE i < 0");
+
+	Deadline deadline;
+	while (true) {
+		REQUIRE(!deadline.Passed());
+		unique_ptr<DataChunk> chunk;
+		auto execution_result = stream->TryFetchChunk(chunk);
+		if (execution_result == StreamExecutionResult::EXECUTION_FINISHED) {
+			break;
+		}
+		REQUIRE(execution_result != StreamExecutionResult::EXECUTION_ERROR);
+		if (execution_result == StreamExecutionResult::CHUNK_READY) {
+			// TryFetchChunk only reports CHUNK_READY for a non-empty chunk
+			FAIL("a rowless query produced a chunk");
+		}
+		REQUIRE(listener.WaitAndReset(std::chrono::seconds(10)));
+	}
+}
+
+TEST_CASE("Async batched stream result wakes on the terminal transition", "[api][async_stream]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE empty_t AS SELECT range i FROM range(0)"));
+
+	NotifyListener listener;
+	SetNotifier(con, listener);
+	// A rowless scan never appends. Only the terminal notification can wake us
+	auto stream = ExecuteAsync(con, "SELECT i FROM empty_t");
+	Deadline deadline;
+	while (true) {
+		REQUIRE(!deadline.Passed());
+		unique_ptr<DataChunk> chunk;
+		auto execution_result = stream->TryFetchChunk(chunk);
+		if (execution_result == StreamExecutionResult::EXECUTION_FINISHED) {
+			REQUIRE(!chunk);
+			break;
+		}
+		REQUIRE(execution_result != StreamExecutionResult::EXECUTION_ERROR);
+		REQUIRE(listener.WaitAndReset(std::chrono::seconds(10)));
+	}
+	// The terminal state is sticky: further calls keep reporting it
+	unique_ptr<DataChunk> chunk;
+	REQUIRE(stream->TryFetchChunk(chunk) == StreamExecutionResult::EXECUTION_FINISHED);
+}
+
+TEST_CASE("Async stream result wakes a waiting consumer on interrupt", "[api][async_stream]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	REQUIRE_NO_FAIL(con.Query("SET streaming_buffer_size='100KB'"));
+
+	NotifyListener listener;
+	SetNotifier(con, listener);
+	auto stream = ExecuteAsync(con, "SELECT i FROM range(100000000) t(i)");
+
+	// Deliberately waits without fetching, to pin the one case where only the interrupt
+	// notification can wake us: producers blocked on a full buffer. The loop tolerates the
+	// few early append notifications.
+	std::thread interruptor([&con]() {
+		std::this_thread::sleep_for(std::chrono::milliseconds(100));
+		con.Interrupt();
+	});
+	Deadline deadline;
+	while (true) {
+		REQUIRE(!deadline.Passed());
+		if (!listener.WaitAndReset(std::chrono::seconds(10))) {
+			FAIL("the interrupt did not wake the waiting consumer");
+		}
+		unique_ptr<DataChunk> chunk;
+		auto execution_result = stream->TryFetchChunk(chunk);
+		if (execution_result == StreamExecutionResult::EXECUTION_ERROR) {
+			break;
+		}
+		REQUIRE(execution_result != StreamExecutionResult::EXECUTION_FINISHED);
+	}
+	interruptor.join();
+	REQUIRE(stream->HasError());
+	REQUIRE(StringUtil::Contains(stream->GetError(), "INTERRUPT"));
+}
+
+TEST_CASE("The connection notifier observes completion without fetching", "[api][async_stream]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+
+	NotifyListener listener;
+	SetNotifier(con, listener);
+
+	EnableAsync(con);
+	auto pending = con.PendingQuery("SELECT 42", QueryParameters(true));
+	REQUIRE(!pending->HasError());
+	auto result = pending->Execute();
+	REQUIRE(result->GetResultType() == QueryResultType::STREAM_RESULT);
+	// The notifier was set before execution started, so the first chunk or the terminal
+	// transition must notify even though nothing has been fetched yet
+	REQUIRE(listener.WaitAndReset(std::chrono::seconds(10)));
+
+	auto &stream = result->Cast<StreamQueryResult>();
+	Deadline deadline;
+	idx_t row_count = 0;
+	while (true) {
+		REQUIRE(!deadline.Passed());
+		unique_ptr<DataChunk> chunk;
+		auto execution_result = stream.TryFetchChunk(chunk);
+		if (execution_result == StreamExecutionResult::CHUNK_READY) {
+			row_count += chunk->size();
+			REQUIRE(chunk->GetValue(0, 0).GetValue<int64_t>() == 42);
+			continue;
+		}
+		if (execution_result == StreamExecutionResult::EXECUTION_FINISHED) {
+			break;
+		}
+		std::this_thread::sleep_for(std::chrono::microseconds(100));
+	}
+	REQUIRE(row_count == 1);
+}
+
+// Notification discipline: fire on the empty-to-non-empty transition, and only there
+
+TEST_CASE("Async batched notifications fire only when the queue turns non-empty", "[api][async_stream]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	// A buffer far larger than the whole result: no producer ever blocks, and until the
+	// consumer pops, the read queue turns non-empty exactly once. Legitimate fires are
+	// that one transition plus a bounded terminal tail, on any machine at any vector
+	// size. A notifier that fired per append would fire once per chunk.
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE t AS SELECT range i FROM range(200000)"));
+	REQUIRE_NO_FAIL(con.Query("SET streaming_buffer_size='100MB'"));
+	// Bounds the terminal tail: each worker can observe the finished state once
+	REQUIRE_NO_FAIL(con.Query("SET threads=4"));
+
+	NotifyListener listener;
+	std::atomic<idx_t> notification_count {0};
+	SetCountingNotifier(con, listener, notification_count);
+
+	auto stream = ExecuteAsync(con, "SELECT i FROM t");
+	// Do not pop. With a buffer this large the collector never blocks, so ExecuteAsync
+	// returns only after the whole query completed. The wait below merely flushes
+	// straggler terminal notifications, and an early quiet verdict can only lower the
+	// count before the assertion, never raise it.
+	Deadline deadline;
+	REQUIRE(listener.WaitAndReset(std::chrono::seconds(10)));
+	while (listener.WaitAndReset(std::chrono::milliseconds(500))) {
+		REQUIRE(!deadline.Passed());
+	}
+	// Pins the append notify site. The move site contributes at most the one first-fill
+	// fire here (two row groups), and is exercised under blocking by the skew test
+	const auto observed_notifications = notification_count.load();
+	INFO(observed_notifications);
+	REQUIRE(observed_notifications <= 16);
+
+	// The result is intact: drain and verify
+	int64_t next_value = 0;
+	while (true) {
+		REQUIRE(!deadline.Passed());
+		unique_ptr<DataChunk> chunk;
+		auto execution_result = stream->TryFetchChunk(chunk);
+		if (execution_result == StreamExecutionResult::CHUNK_READY) {
+			next_value = VerifyAscending(*chunk, next_value);
+			continue;
+		}
+		if (execution_result == StreamExecutionResult::EXECUTION_FINISHED) {
+			break;
+		}
+		std::this_thread::sleep_for(std::chrono::microseconds(100));
+	}
+	REQUIRE(next_value == 200000);
+}
+
+TEST_CASE("Async stream result wakes on chunks with rows but no data bytes", "[api][async_stream]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+
+	// Empty-struct chunks have rows but zero data bytes: readiness and notification
+	// must both follow the chunk queue, not the byte count
+	NotifyListener listener;
+	SetNotifier(con, listener);
+	auto stream = ExecuteAsync(con, "SELECT struct_pack() FROM range(100000) t(i)");
+
+	Deadline deadline;
+	idx_t row_count = 0;
+	while (true) {
+		REQUIRE(!deadline.Passed());
+		unique_ptr<DataChunk> chunk;
+		auto execution_result = stream->TryFetchChunk(chunk);
+		if (execution_result == StreamExecutionResult::CHUNK_READY) {
+			row_count += chunk->size();
+			continue;
+		}
+		if (execution_result == StreamExecutionResult::EXECUTION_FINISHED) {
+			break;
+		}
+		REQUIRE(listener.WaitAndReset(std::chrono::seconds(10)));
+	}
+	REQUIRE(row_count == 100000);
+}
+
+// Order: the batched collector's reason to exist
+
+TEST_CASE("Async batched stream result preserves insertion order", "[api][async_stream]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE t AS SELECT range i FROM range(500000)"));
+	REQUIRE_NO_FAIL(con.Query("SET streaming_buffer_size='100KB'"));
+
+	// preserve_insertion_order is on by default: a table scan takes the batched streaming collector
+	auto stream = ExecuteAsync(con, "SELECT i FROM t");
+	REQUIRE_NOTHROW(stream->GetBufferedData().Cast<BatchedBufferedData>());
+	Deadline deadline;
+	int64_t next_value = 0;
+	while (true) {
+		REQUIRE(!deadline.Passed());
+		unique_ptr<DataChunk> chunk;
+		auto execution_result = stream->TryFetchChunk(chunk);
+		if (execution_result == StreamExecutionResult::CHUNK_READY) {
+			next_value = VerifyAscending(*chunk, next_value);
+			continue;
+		}
+		if (execution_result == StreamExecutionResult::EXECUTION_FINISHED) {
+			break;
+		}
+		REQUIRE((execution_result == StreamExecutionResult::BLOCKED ||
+		         execution_result == StreamExecutionResult::CHUNK_NOT_READY));
+		std::this_thread::sleep_for(std::chrono::microseconds(100));
+	}
+	REQUIRE(next_value == 500000);
+
+	// The connection is usable again after the stream is drained
+	auto result = con.Query("SELECT 42");
+	REQUIRE(CHECK_COLUMN(result, 0, {42}));
+}
+
+TEST_CASE("Async batched stream result under batch skew", "[api][async_stream]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	// Many row groups and a small buffer: high batches complete while the minimum lags
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE skew AS SELECT range i FROM range(2000000)"));
+	REQUIRE_NO_FAIL(con.Query("SET streaming_buffer_size='64KB'"));
+
+	NotifyListener listener;
+	SetNotifier(con, listener);
+	auto stream = ExecuteAsync(con, "SELECT i FROM skew");
+	Deadline deadline;
+	int64_t next_value = 0;
+	while (true) {
+		REQUIRE(!deadline.Passed());
+		unique_ptr<DataChunk> chunk;
+		auto execution_result = stream->TryFetchChunk(chunk);
+		if (execution_result == StreamExecutionResult::CHUNK_READY) {
+			next_value = VerifyAscending(*chunk, next_value);
+			continue;
+		}
+		if (execution_result == StreamExecutionResult::EXECUTION_FINISHED) {
+			break;
+		}
+		REQUIRE((execution_result == StreamExecutionResult::BLOCKED ||
+		         execution_result == StreamExecutionResult::CHUNK_NOT_READY));
+		// A lost wake under skewed batch completion fails here by timeout
+		REQUIRE(listener.WaitAndReset(std::chrono::seconds(10)));
+	}
+	REQUIRE(next_value == 2000000);
+}
+
+TEST_CASE("Async batched stream drain across buffer sizes", "[api][async_stream]") {
+	// Stresses restarts and notifications across buffer sizes: with a small buffer,
+	// faster batches fill the in-progress buffer while the minimum batch lags. A lost
+	// restart or notification fails by timeout.
+	auto drain_counting_moved_nothing = [](const char *buffer_size, idx_t row_count) -> idx_t {
+		DuckDB db(nullptr);
+		Connection con(db);
+		REQUIRE_NO_FAIL(con.Query(StringUtil::Format("CREATE TABLE t AS SELECT range i FROM range(%llu)", row_count)));
+		REQUIRE_NO_FAIL(con.Query(StringUtil::Format("SET streaming_buffer_size='%s'", buffer_size)));
+
+		NotifyListener listener;
+		SetNotifier(con, listener);
+		auto stream = ExecuteAsync(con, "SELECT i FROM t");
+		Deadline deadline;
+		int64_t next_value = 0;
+		while (true) {
+			REQUIRE(!deadline.Passed());
+			unique_ptr<DataChunk> chunk;
+			auto execution_result = stream->TryFetchChunk(chunk);
+			if (execution_result == StreamExecutionResult::CHUNK_READY) {
+				next_value = VerifyAscending(*chunk, next_value);
+				continue;
+			}
+			if (execution_result == StreamExecutionResult::EXECUTION_FINISHED) {
+				break;
+			}
+			// A lost restart or notification fails here by timeout
+			REQUIRE(listener.WaitAndReset(std::chrono::seconds(10)));
+		}
+		REQUIRE(next_value == int64_t(row_count));
+		return stream->GetBufferedData().Cast<BatchedBufferedData>().MovedNothingRestarts();
+	};
+
+	// Only the 1KB drain pins the deadlock shape at the default vector size: the queue
+	// capacity is fixed while the chunk cost scales with STANDARD_VECTOR_SIZE, so here
+	// "below capacity" means empty and a pop cannot rescue a blocked minimum
+	// sink. The larger sizes are stress only.
+	idx_t moved_nothing_restarts = drain_counting_moved_nothing("1KB", 1000000);
+	(void)drain_counting_moved_nothing("32KB", 1000000);
+	(void)drain_counting_moved_nothing("256KB", 1000000);
+
+	// The moved-nothing advance (a newly minimum batch that blocked before its first
+	// append) is scheduling-dependent. Hunt for it on a small table (the shape needs a
+	// few row groups in flight), bounded by attempts. The counter's job is to stop the
+	// hunt early on healthy code. Under the freed-bytes regression it stays zero, every
+	// attempt runs, and any drain that hits the shape hangs on the 10 second waits and
+	// fails. A zero result is reported for direct local runs only, never a failure.
+	for (idx_t attempt = 0; moved_nothing_restarts == 0 && attempt < 6; attempt++) {
+		moved_nothing_restarts += drain_counting_moved_nothing("1KB", 4 * DEFAULT_ROW_GROUP_SIZE);
+	}
+	if (moved_nothing_restarts == 0) {
+		WARN("moved-nothing advance not observed in this run");
+	}
+}
+
+// Endings: one terminal state per query, visible to the consumer and sticky
+
+TEST_CASE("Async stream result with an empty result", "[api][async_stream]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+
+	auto stream = ExecuteAsync(con, "SELECT i FROM range(0) t(i)");
+	Deadline deadline;
+	while (true) {
+		REQUIRE(!deadline.Passed());
+		unique_ptr<DataChunk> chunk;
+		auto execution_result = stream->TryFetchChunk(chunk);
+		if (execution_result == StreamExecutionResult::EXECUTION_FINISHED) {
+			REQUIRE(!chunk);
+			break;
+		}
+		REQUIRE(execution_result != StreamExecutionResult::EXECUTION_ERROR);
+		std::this_thread::sleep_for(std::chrono::microseconds(100));
+	}
+	// The terminal state is sticky: further calls keep reporting it
+	unique_ptr<DataChunk> chunk;
+	REQUIRE(stream->TryFetchChunk(chunk) == StreamExecutionResult::EXECUTION_FINISHED);
+	REQUIRE(stream->TryFetchChunk(chunk) == StreamExecutionResult::EXECUTION_FINISHED);
+}
+
+TEST_CASE("Async stream result surfaces a mid-stream execution error", "[api][async_stream]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	REQUIRE_NO_FAIL(con.Query("SET streaming_buffer_size='100KB'"));
+
+	// The error-side terminal notify (PushError) must never run on the consumer's stack
+	StackCheckListener state;
+	state.Install(con);
+
+	state.in_call = true;
+	auto stream = ExecuteAsync(
+	    con, "SELECT CASE WHEN i < 100000 THEN i ELSE CAST(concat('x', i) AS BIGINT) END FROM range(200000) t(i)");
+	state.in_call = false;
+	Deadline deadline;
+	idx_t clean_rows = 0;
+	while (true) {
+		REQUIRE(!deadline.Passed());
+		unique_ptr<DataChunk> chunk;
+		state.in_call = true;
+		auto execution_result = stream->TryFetchChunk(chunk);
+		state.in_call = false;
+		if (execution_result == StreamExecutionResult::EXECUTION_ERROR) {
+			break;
+		}
+		if (execution_result == StreamExecutionResult::CHUNK_READY) {
+			clean_rows += chunk->size();
+			continue;
+		}
+		REQUIRE(execution_result != StreamExecutionResult::EXECUTION_FINISHED);
+		std::this_thread::sleep_for(std::chrono::microseconds(100));
+	}
+	REQUIRE(state.consumer_stack_notifications.load() == 0);
+	REQUIRE(stream->HasError());
+	INFO(stream->GetError());
+	REQUIRE(StringUtil::Contains(stream->GetError(), "Conversion"));
+	// Only rows before the failing one can have been delivered
+	REQUIRE(clean_rows <= 100000);
+	// The terminal error is sticky: further calls keep reporting it
+	unique_ptr<DataChunk> chunk;
+	REQUIRE(stream->TryFetchChunk(chunk) == StreamExecutionResult::EXECUTION_ERROR);
+}
+
+TEST_CASE("Async batched stream result surfaces a mid-stream execution error", "[api][async_stream]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE t AS SELECT range i FROM range(200000)"));
+	REQUIRE_NO_FAIL(con.Query("SET streaming_buffer_size='100KB'"));
+
+	auto stream =
+	    ExecuteAsync(con, "SELECT CASE WHEN i < 100000 THEN i ELSE CAST(concat('x', i) AS BIGINT) END FROM t");
+	Deadline deadline;
+	idx_t clean_rows = 0;
+	while (true) {
+		REQUIRE(!deadline.Passed());
+		unique_ptr<DataChunk> chunk;
+		auto execution_result = stream->TryFetchChunk(chunk);
+		if (execution_result == StreamExecutionResult::EXECUTION_ERROR) {
+			break;
+		}
+		if (execution_result == StreamExecutionResult::CHUNK_READY) {
+			clean_rows += chunk->size();
+			continue;
+		}
+		REQUIRE(execution_result != StreamExecutionResult::EXECUTION_FINISHED);
+		std::this_thread::sleep_for(std::chrono::microseconds(100));
+	}
+	REQUIRE(stream->HasError());
+	INFO(stream->GetError());
+	REQUIRE(StringUtil::Contains(stream->GetError(), "Conversion"));
+	// Only rows before the failing one can have been delivered
+	REQUIRE(clean_rows <= 100000);
+	// The terminal error is sticky: further calls keep reporting it
+	unique_ptr<DataChunk> chunk;
+	REQUIRE(stream->TryFetchChunk(chunk) == StreamExecutionResult::EXECUTION_ERROR);
+}
+
+//! Throws a catalog error once the input values pass 100000, exercising a mid-stream
+//! failure with an exception type that Exception::InvalidatesTransaction exempts
+static void ThresholdBoomExec(DataChunk &args, ExpressionState &state, Vector &result) {
+	UnaryExecutor::Execute<int64_t, int64_t>(args.data[0], result, args.size(), [](int64_t input) {
+		if (input >= 100000) {
+			throw CatalogException("boom past the threshold");
+		}
+		return input;
+	});
+}
+
+TEST_CASE("A mid-stream fetch failure invalidates the transaction", "[api][async_stream]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	// Single-threaded, so the consumer executes the failing task inline and the error
+	// type reaches the fetch deterministically, instead of racing the interrupt flag
+	REQUIRE_NO_FAIL(con.Query("SET threads=1"));
+	REQUIRE_NO_FAIL(con.Query("SET streaming_buffer_size='100KB'"));
+	ScalarFunction boom("threshold_boom", {LogicalType::BIGINT}, LogicalType::BIGINT, ThresholdBoomExec);
+	CreateScalarFunctionInfo info(boom);
+	con.context->RunFunctionInTransaction(
+	    [&]() { Catalog::GetSystemCatalog(*con.context).CreateFunction(*con.context, info); });
+
+	// A catalog error is exempt from Exception::InvalidatesTransaction, but a fetch
+	// failure follows the context policy, like every other error site
+	REQUIRE_NO_FAIL(con.Query("BEGIN"));
+	auto stream = con.SendQuery("SELECT threshold_boom(i) FROM range(200000) t(i)", QueryParameters(true));
+	REQUIRE(!stream->HasError());
+	DrainWatchdog watchdog(con);
+	while (auto chunk = stream->Fetch()) {
+	}
+	REQUIRE(stream->HasError());
+	INFO(stream->GetError());
+	REQUIRE(StringUtil::Contains(stream->GetError(), "boom past the threshold"));
+
+	auto follow_up = con.Query("SELECT 1");
+	REQUIRE(follow_up->HasError());
+	REQUIRE(StringUtil::Contains(follow_up->GetError(), "aborted"));
+	REQUIRE_NO_FAIL(con.Query("ROLLBACK"));
+	REQUIRE_NO_FAIL(con.Query("SELECT 1"));
+}
+
+TEST_CASE("Async stream result observes an interrupt", "[api][async_stream]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	REQUIRE_NO_FAIL(con.Query("SET streaming_buffer_size='100KB'"));
+
+	auto stream = ExecuteAsync(con, "SELECT i FROM range(100000000) t(i)");
+	Deadline deadline;
+	// Consume a little, then interrupt
+	idx_t rows_before_interrupt = 0;
+	while (rows_before_interrupt < 10000) {
+		REQUIRE(!deadline.Passed());
+		unique_ptr<DataChunk> chunk;
+		auto execution_result = stream->TryFetchChunk(chunk);
+		if (execution_result == StreamExecutionResult::CHUNK_READY) {
+			rows_before_interrupt += chunk->size();
+			continue;
+		}
+		REQUIRE(execution_result != StreamExecutionResult::EXECUTION_ERROR);
+		REQUIRE(execution_result != StreamExecutionResult::EXECUTION_FINISHED);
+		std::this_thread::sleep_for(std::chrono::microseconds(100));
+	}
+	con.Interrupt();
+	while (true) {
+		REQUIRE(!deadline.Passed());
+		unique_ptr<DataChunk> chunk;
+		auto execution_result = stream->TryFetchChunk(chunk);
+		if (execution_result == StreamExecutionResult::EXECUTION_ERROR) {
+			break;
+		}
+		REQUIRE(execution_result != StreamExecutionResult::EXECUTION_FINISHED);
+		std::this_thread::sleep_for(std::chrono::microseconds(100));
+	}
+	REQUIRE(stream->HasError());
+	REQUIRE(StringUtil::Contains(stream->GetError(), "INTERRUPT"));
+}
+
+TEST_CASE("Async batched stream result observes an interrupt", "[api][async_stream]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE t AS SELECT range i FROM range(4000000)"));
+	REQUIRE_NO_FAIL(con.Query("SET streaming_buffer_size='100KB'"));
+
+	auto stream = ExecuteAsync(con, "SELECT i FROM t");
+	Deadline deadline;
+	// Consume a little, then interrupt while sinks are blocked in both buffers
+	int64_t next_value = 0;
+	while (next_value < 10000) {
+		REQUIRE(!deadline.Passed());
+		unique_ptr<DataChunk> chunk;
+		auto execution_result = stream->TryFetchChunk(chunk);
+		if (execution_result == StreamExecutionResult::CHUNK_READY) {
+			next_value = VerifyAscending(*chunk, next_value);
+			continue;
+		}
+		REQUIRE(execution_result != StreamExecutionResult::EXECUTION_ERROR);
+		REQUIRE(execution_result != StreamExecutionResult::EXECUTION_FINISHED);
+		std::this_thread::sleep_for(std::chrono::microseconds(100));
+	}
+	con.Interrupt();
+	while (true) {
+		REQUIRE(!deadline.Passed());
+		unique_ptr<DataChunk> chunk;
+		auto execution_result = stream->TryFetchChunk(chunk);
+		if (execution_result == StreamExecutionResult::EXECUTION_ERROR) {
+			break;
+		}
+		REQUIRE(execution_result != StreamExecutionResult::EXECUTION_FINISHED);
+		std::this_thread::sleep_for(std::chrono::microseconds(100));
+	}
+	REQUIRE(stream->HasError());
+	REQUIRE(StringUtil::Contains(stream->GetError(), "INTERRUPT"));
+	// Every blocked producer unwound: the connection is usable again
+	auto result = con.Query("SELECT 42");
+	REQUIRE(CHECK_COLUMN(result, 0, {42}));
+}
+
+// Cleanup: abandoning an undrained result unwinds the plan
+
+TEST_CASE("Abandoning an undrained async stream result unwinds a streaming-fanout plan", "[api][async_stream]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	// Order-destroying settings admit async. The tiny buffer keeps producer sinks blocked mid-plan
+	REQUIRE_NO_FAIL(con.Query("SET preserve_insertion_order=false"));
+	REQUIRE_NO_FAIL(con.Query("SET streaming_buffer_size='100KB'"));
+
+	// Two readers over one materialized CTE stream rows through the fanout into the result
+	const string query = "WITH c AS MATERIALIZED (SELECT i FROM range(2000000) t(i)) "
+	                     "SELECT i FROM c WHERE i % 7 = 0 UNION ALL SELECT i FROM c WHERE i % 11 = 3";
+	REQUIRE(StringUtil::Contains(PhysicalPlanText(con, query), "PIPELINE_DEPENDENT"));
+
+	NotifyListener listener;
+	SetNotifier(con, listener);
+
+	// Abandon at the pending stage: workers already produce in async mode, Execute never runs
+	{
+		EnableAsync(con);
+		auto pending = con.PendingQuery(query, QueryParameters(true));
+		if (pending->HasError()) {
+			FAIL(pending->GetError());
+		}
+		// Wait until production demonstrably started, then drop the pending result
+		REQUIRE(listener.WaitAndReset(std::chrono::seconds(10)));
+	}
+	auto result = con.Query("SELECT 42");
+	REQUIRE(CHECK_COLUMN(result, 0, {42}));
+
+	// Abandon mid-stream: fetch a little, then drop the result while producers sit blocked behind it
+	{
+		auto stream = ExecuteAsync(con, query);
+		Deadline deadline;
+		idx_t row_count = 0;
+		while (row_count < 10000) {
+			REQUIRE(!deadline.Passed());
+			unique_ptr<DataChunk> chunk;
+			auto execution_result = stream->TryFetchChunk(chunk);
+			if (execution_result == StreamExecutionResult::CHUNK_READY) {
+				row_count += chunk->size();
+				continue;
+			}
+			REQUIRE(execution_result != StreamExecutionResult::EXECUTION_ERROR);
+			REQUIRE(execution_result != StreamExecutionResult::EXECUTION_FINISHED);
+			REQUIRE(listener.WaitAndReset(std::chrono::seconds(10)));
+		}
+	}
+	result = con.Query("SELECT 42");
+	REQUIRE(CHECK_COLUMN(result, 0, {42}));
+}
+
+TEST_CASE("Abandoning an undrained async batched stream result unwinds a streaming-fanout plan",
+          "[api][async_stream]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE t AS SELECT range i FROM range(2000000)"));
+	REQUIRE_NO_FAIL(con.Query("SET streaming_buffer_size='100KB'"));
+
+	const string query = "WITH c AS MATERIALIZED (SELECT i FROM t) SELECT (SELECT COUNT(*) FROM c) total, i FROM c";
+	REQUIRE(StringUtil::Contains(PhysicalPlanText(con, query), "PIPELINE_DEPENDENT"));
+
+	NotifyListener listener;
+	SetNotifier(con, listener);
+
+	// Abandon at the pending stage: workers already produce in async mode, Execute never runs
+	{
+		EnableAsync(con);
+		auto pending = con.PendingQuery(query, QueryParameters(true));
+		if (pending->HasError()) {
+			FAIL(pending->GetError());
+		}
+		// Wait until production demonstrably started, then drop the pending result
+		REQUIRE(listener.WaitAndReset(std::chrono::seconds(10)));
+	}
+	auto result = con.Query("SELECT 42");
+	REQUIRE(CHECK_COLUMN(result, 0, {42}));
+
+	// Abandon mid-stream: fetch a little, then drop the result while producers sit blocked
+	{
+		auto stream = ExecuteAsync(con, query);
+		REQUIRE_NOTHROW(stream->GetBufferedData().Cast<BatchedBufferedData>());
+		Deadline deadline;
+		idx_t row_count = 0;
+		while (row_count < 10000) {
+			REQUIRE(!deadline.Passed());
+			unique_ptr<DataChunk> chunk;
+			auto execution_result = stream->TryFetchChunk(chunk);
+			if (execution_result == StreamExecutionResult::CHUNK_READY) {
+				row_count += chunk->size();
+				continue;
+			}
+			REQUIRE(execution_result != StreamExecutionResult::EXECUTION_ERROR);
+			REQUIRE(execution_result != StreamExecutionResult::EXECUTION_FINISHED);
+			REQUIRE(listener.WaitAndReset(std::chrono::seconds(10)));
+		}
+	}
+	result = con.Query("SELECT 42");
+	REQUIRE(CHECK_COLUMN(result, 0, {42}));
+}
+
+// Refusals: configurations async cannot serve are rejected at submission
+
+TEST_CASE("The async setting refuses a single-threaded database", "[api][async_stream]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	REQUIRE_NO_FAIL(con.Query("SET threads=1"));
+
+	auto result = con.Query("SET streaming_execution_mode='async'");
+	REQUIRE(result->HasError());
+	REQUIRE(StringUtil::Contains(result->GetError(), "worker thread"));
+	// The refusal has no side effects
+	auto setting = con.Query("SELECT current_setting('streaming_execution_mode')");
+	REQUIRE(CHECK_COLUMN(setting, 0, {"sync"}));
+	REQUIRE_NO_FAIL(con.Query("SET threads=4"));
+	EnableAsync(con);
+}
+
+TEST_CASE("The async setting refuses an external-threads-only scheduler", "[api][async_stream]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	// External threads never execute tasks on their own
+	REQUIRE_NO_FAIL(con.Query("SET threads=4"));
+	REQUIRE_NO_FAIL(con.Query("SET external_threads=4"));
+
+	auto result = con.Query("SET streaming_execution_mode='async'");
+	REQUIRE(result->HasError());
+	REQUIRE(StringUtil::Contains(result->GetError(), "worker thread"));
+}
+
+TEST_CASE("Changing threads is refused while an async connection exists", "[api][async_stream]") {
+	DuckDB db(nullptr);
+	Connection consumer(db);
+	Connection other(db);
+	EnableAsync(consumer);
+
+	// No connection can remove the last managed worker while an async connection exists
+	auto result = other.Query("SET threads=1");
+	REQUIRE(result->HasError());
+	REQUIRE(StringUtil::Contains(result->GetError(), "async"));
+	REQUIRE_NO_FAIL(other.Query("SET threads=4"));
+	result = other.Query("SET external_threads=4");
+	REQUIRE(result->HasError());
+	REQUIRE(StringUtil::Contains(result->GetError(), "async"));
+
+	// Shrinking while a worker remains is fine
+	REQUIRE_NO_FAIL(other.Query("SET threads=2"));
+
+	// Leaving async mode releases the restriction
+	REQUIRE_NO_FAIL(consumer.Query("SET streaming_execution_mode='sync'"));
+	REQUIRE_NO_FAIL(other.Query("SET threads=1"));
+	REQUIRE_NO_FAIL(other.Query("SET threads=4"));
+
+	// So does closing the async connection
+	{
+		Connection transient(db);
+		EnableAsync(transient);
+		result = other.Query("SET threads=1");
+		REQUIRE(result->HasError());
+	}
+	REQUIRE_NO_FAIL(other.Query("SET threads=1"));
+}
+
+TEST_CASE("Async works with one managed worker and no external threads", "[api][async_stream]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	// Newly allowed: the invariant is one managed worker, not threads > 1
+	REQUIRE_NO_FAIL(con.Query("SET external_threads=0"));
+	REQUIRE_NO_FAIL(con.Query("SET threads=1"));
+	EnableAsync(con);
+
+	auto stream = ExecuteAsync(con, "SELECT i FROM range(100000) t(i)");
+	Deadline deadline;
+	idx_t row_count = 0;
+	while (true) {
+		REQUIRE(!deadline.Passed());
+		unique_ptr<DataChunk> chunk;
+		auto execution_result = stream->TryFetchChunk(chunk);
+		if (execution_result == StreamExecutionResult::CHUNK_READY) {
+			row_count += chunk->size();
+			continue;
+		}
+		if (execution_result == StreamExecutionResult::EXECUTION_FINISHED) {
+			break;
+		}
+		std::this_thread::sleep_for(std::chrono::microseconds(100));
+	}
+	REQUIRE(row_count == 100000);
+}
+
+TEST_CASE("The async setting is connection-local", "[api][async_stream]") {
+	DuckDB db(nullptr);
+	Connection async_con(db);
+	Connection sync_con(db);
+	EnableAsync(async_con);
+
+	// The other connection's streams stay sync: TryFetchChunk refuses them
+	auto sync_stream = sync_con.SendQuery("SELECT i FROM range(1000) t(i)", QueryParameters(true));
+	REQUIRE(!sync_stream->HasError());
+	REQUIRE(sync_stream->GetResultType() == QueryResultType::STREAM_RESULT);
+	unique_ptr<DataChunk> chunk;
+	REQUIRE_THROWS(sync_stream->Cast<StreamQueryResult>().TryFetchChunk(chunk));
+	DrainWatchdog watchdog(sync_con);
+	idx_t sync_rows = 0;
+	while (auto sync_chunk = sync_stream->Fetch()) {
+		sync_rows += sync_chunk->size();
+	}
+	REQUIRE(sync_rows == 1000);
+
+	// The async connection's stream is async
+	auto stream = ExecuteAsync(async_con, "SELECT i FROM range(1000) t(i)");
+	Deadline deadline;
+	idx_t async_rows = 0;
+	while (true) {
+		REQUIRE(!deadline.Passed());
+		unique_ptr<DataChunk> async_chunk;
+		auto execution_result = stream->TryFetchChunk(async_chunk);
+		if (execution_result == StreamExecutionResult::CHUNK_READY) {
+			async_rows += async_chunk->size();
+			continue;
+		}
+		if (execution_result == StreamExecutionResult::EXECUTION_FINISHED) {
+			break;
+		}
+		std::this_thread::sleep_for(std::chrono::microseconds(100));
+	}
+	REQUIRE(async_rows == 1000);
+}
+
+TEST_CASE("The async setting is ignored for non-streaming results", "[api][async_stream]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	REQUIRE_NO_FAIL(con.Query("SET streaming_execution_mode='async'"));
+
+	// Materialized output runs sync under the async setting
+	auto pending =
+	    con.PendingQuery("SELECT i FROM range(10) t(i)", QueryParameters(QueryResultOutputType::FORCE_MATERIALIZED));
+	REQUIRE(!pending->HasError());
+	auto result = pending->Execute();
+	REQUIRE(result->GetResultType() == QueryResultType::MATERIALIZED_RESULT);
+	REQUIRE(result->Cast<MaterializedQueryResult>().RowCount() == 10);
+
+	// So does a statement type that cannot stream
+	pending = con.PendingQuery("CREATE TABLE integers(i INTEGER)", QueryParameters(true));
+	REQUIRE(!pending->HasError());
+	REQUIRE(!pending->Execute()->HasError());
+}
+
+// Coexistence: async must not disturb sync, multi-statement, or custom collectors
+
+TEST_CASE("Sync queries ignore the connection notifier", "[api][async_stream]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+
+	NotifyListener listener;
+	SetNotifier(con, listener);
+
+	// Materialized and sync streaming queries run normally with a default installed
+	auto materialized = con.Query("SELECT 42");
+	REQUIRE(CHECK_COLUMN(materialized, 0, {42}));
+	auto sync_stream = con.SendQuery("SELECT i FROM range(100) t(i)", QueryParameters(true));
+	REQUIRE(!sync_stream->HasError());
+	DrainWatchdog watchdog(con);
+	idx_t sync_rows = 0;
+	while (auto chunk = sync_stream->Fetch()) {
+		sync_rows += chunk->size();
+	}
+	REQUIRE(sync_rows == 100);
+
+	// The same default still drives a later async query on this connection
+	auto stream = ExecuteAsync(con, "SELECT i FROM range(1000) t(i)");
+	Deadline deadline;
+	idx_t row_count = 0;
+	while (true) {
+		REQUIRE(!deadline.Passed());
+		unique_ptr<DataChunk> chunk;
+		auto execution_result = stream->TryFetchChunk(chunk);
+		if (execution_result == StreamExecutionResult::CHUNK_READY) {
+			row_count += chunk->size();
+			continue;
+		}
+		if (execution_result == StreamExecutionResult::EXECUTION_FINISHED) {
+			break;
+		}
+		REQUIRE(listener.WaitAndReset(std::chrono::seconds(10)));
+	}
+	REQUIRE(row_count == 1000);
+}
+
+TEST_CASE("Async execution mode applies to the final statement of a multi-statement query", "[api][async_stream]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+
+	// Intermediates are materialized and sync, because the setting is ignored for them.
+	// Only the final result is async and notifies
+	NotifyListener listener;
+	SetNotifier(con, listener);
+	EnableAsync(con);
+	auto result = con.SendQuery("SELECT 1; SELECT 2", QueryParameters(true));
+	REQUIRE(!result->HasError());
+	// Walk to the final result of the chain
+	QueryResult *last = result.get();
+	while (last->next) {
+		last = last->next.get();
+		REQUIRE(!last->HasError());
+	}
+	REQUIRE(last->GetResultType() == QueryResultType::STREAM_RESULT);
+	auto &stream = last->Cast<StreamQueryResult>();
+	Deadline deadline;
+	idx_t row_count = 0;
+	int64_t value = -1;
+	while (true) {
+		REQUIRE(!deadline.Passed());
+		unique_ptr<DataChunk> chunk;
+		auto execution_result = stream.TryFetchChunk(chunk);
+		if (execution_result == StreamExecutionResult::CHUNK_READY) {
+			row_count += chunk->size();
+			value = chunk->GetValue(0, 0).GetValue<int64_t>();
+			continue;
+		}
+		if (execution_result == StreamExecutionResult::EXECUTION_FINISHED) {
+			break;
+		}
+		std::this_thread::sleep_for(std::chrono::microseconds(100));
+	}
+	REQUIRE(row_count == 1);
+	REQUIRE(value == 2);
+}
+
+TEST_CASE("Async mode is unaffected by an installed custom result collector", "[api][async_stream]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	// Canary for the invariant async mode relies on: the get_result_collector hook only ever
+	// applies to materialized results, so a custom collector can never observe ASYNC
+	auto &config = ClientConfig::GetConfig(*con.context);
+	config.get_result_collector = [](ClientContext &context, PreparedStatementData &data) {
+		return PhysicalArrowCollector::Create(context, data, 100);
+	};
+
+	// Sanity: the hook is live on the materialized path. Via PendingQuery: Connection::Query
+	// asserts a materialized result and does not support custom collectors.
+	auto materialized_pending =
+	    con.PendingQuery("SELECT 42", QueryParameters(QueryResultOutputType::FORCE_MATERIALIZED));
+	REQUIRE(!materialized_pending->HasError());
+	auto materialized = materialized_pending->Execute();
+	REQUIRE(materialized->GetResultType() == QueryResultType::ARROW_RESULT);
+
+	// The async setting is ignored for materialized output, so the custom collector
+	// hook still applies and produces the Arrow result exactly as in sync mode. The
+	// SET goes through the context: with the hook installed even a SET's materialized
+	// result becomes an Arrow result, which trips Connection::Query's assertion
+	auto set_result = con.context->Query("SET streaming_execution_mode='async'",
+	                                     QueryParameters(QueryResultOutputType::FORCE_MATERIALIZED));
+	REQUIRE(!set_result->HasError());
+	auto pending =
+	    con.PendingQuery("SELECT i FROM range(10) t(i)", QueryParameters(QueryResultOutputType::FORCE_MATERIALIZED));
+	REQUIRE(!pending->HasError());
+	REQUIRE(pending->Execute()->GetResultType() == QueryResultType::ARROW_RESULT);
+
+	// Async with streaming output bypasses the hook and keeps the async contract.
+	// The mode is already set, so submit directly instead of through ExecuteAsync,
+	// which would run another SET through Connection::Query
+	auto stream_pending = con.PendingQuery("SELECT i FROM range(10000) t(i)", QueryParameters(true));
+	REQUIRE(!stream_pending->HasError());
+	auto stream_result = stream_pending->Execute();
+	REQUIRE(stream_result->GetResultType() == QueryResultType::STREAM_RESULT);
+	auto stream = unique_ptr_cast<QueryResult, StreamQueryResult>(std::move(stream_result));
+	Deadline deadline;
+	idx_t row_count = 0;
+	while (true) {
+		REQUIRE(!deadline.Passed());
+		unique_ptr<DataChunk> chunk;
+		auto execution_result = stream->TryFetchChunk(chunk);
+		if (execution_result == StreamExecutionResult::CHUNK_READY) {
+			row_count += chunk->size();
+			continue;
+		}
+		if (execution_result == StreamExecutionResult::EXECUTION_FINISHED) {
+			break;
+		}
+		std::this_thread::sleep_for(std::chrono::microseconds(100));
+	}
+	REQUIRE(row_count == 10000);
+}
+
+TEST_CASE("Async stream result still supports blocking materialization", "[api][async_stream]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	REQUIRE_NO_FAIL(con.Query("SET streaming_buffer_size='100KB'"));
+
+	auto stream = ExecuteAsync(con, "SELECT i FROM range(500000) t(i)");
+	DrainWatchdog watchdog(con);
+	auto materialized = stream->Materialize();
+	REQUIRE(!materialized->HasError());
+	REQUIRE(materialized->RowCount() == 500000);
+}
+
+TEST_CASE("Blocking materialization of an async batched stream result", "[api][async_stream]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE t AS SELECT range i FROM range(500000)"));
+	REQUIRE_NO_FAIL(con.Query("SET streaming_buffer_size='100KB'"));
+
+	auto stream = ExecuteAsync(con, "SELECT i FROM t");
+	DrainWatchdog watchdog(con);
+	auto materialized = stream->Materialize();
+	REQUIRE(!materialized->HasError());
+	REQUIRE(materialized->RowCount() == 500000);
+	REQUIRE(materialized->GetValue(0, 0).GetValue<int64_t>() == 0);
+	REQUIRE(materialized->GetValue(0, 499999).GetValue<int64_t>() == 499999);
+}
+
+TEST_CASE("Async stream result on a table scan without insertion-order preservation", "[api][async_stream]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE t AS SELECT i FROM range(10000) t(i)"));
+
+	// Without insertion-order preservation the plain streaming collector serves a table scan
+	REQUIRE_NO_FAIL(con.Query("SET preserve_insertion_order=false"));
+	auto stream = ExecuteAsync(con, "SELECT i FROM t");
+	Deadline deadline;
+	idx_t row_count = 0;
+	while (true) {
+		REQUIRE(!deadline.Passed());
+		unique_ptr<DataChunk> chunk;
+		auto execution_result = stream->TryFetchChunk(chunk);
+		if (execution_result == StreamExecutionResult::CHUNK_READY) {
+			row_count += chunk->size();
+			continue;
+		}
+		if (execution_result == StreamExecutionResult::EXECUTION_FINISHED) {
+			break;
+		}
+		std::this_thread::sleep_for(std::chrono::microseconds(100));
+	}
+	REQUIRE(row_count == 10000);
+}
+
+TEST_CASE("Async stream result survives tiny stream buffers", "[api][async_stream]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+
+	// streaming_buffer_size has no lower bound. An async buffer must still admit chunks
+	for (auto size : {"'0B'", "'1B'"}) {
+		REQUIRE_NO_FAIL(con.Query(string("SET streaming_buffer_size=") + size));
+		auto stream = ExecuteAsync(con, "SELECT i FROM range(10000) t(i)");
+		Deadline deadline;
+		idx_t row_count = 0;
+		while (true) {
+			REQUIRE(!deadline.Passed());
+			unique_ptr<DataChunk> chunk;
+			auto execution_result = stream->TryFetchChunk(chunk);
+			if (execution_result == StreamExecutionResult::CHUNK_READY) {
+				row_count += chunk->size();
+				continue;
+			}
+			if (execution_result == StreamExecutionResult::EXECUTION_FINISHED) {
+				break;
+			}
+			std::this_thread::sleep_for(std::chrono::microseconds(100));
+		}
+		REQUIRE(row_count == 10000);
+
+		// The buffer floor also fixes the sync path, which used to end silently with zero rows at 0B
+		auto sync_stream = con.SendQuery("SELECT i FROM range(10000) t(i)", QueryParameters(true));
+		REQUIRE(!sync_stream->HasError());
+		DrainWatchdog watchdog(con);
+		idx_t sync_rows = 0;
+		while (auto sync_chunk = sync_stream->Fetch()) {
+			sync_rows += sync_chunk->size();
+		}
+		REQUIRE(sync_rows == 10000);
+	}
+}
+
+TEST_CASE("Async batched stream result survives tiny stream buffers", "[api][async_stream]") {
+	for (auto buffer_size : {"0B", "1B"}) {
+		DuckDB db(nullptr);
+		Connection con(db);
+		REQUIRE_NO_FAIL(con.Query("CREATE TABLE t AS SELECT range i FROM range(250000)"));
+		REQUIRE_NO_FAIL(con.Query(StringUtil::Format("SET streaming_buffer_size='%s'", buffer_size)));
+
+		auto stream = ExecuteAsync(con, "SELECT i FROM t");
+		Deadline deadline;
+		int64_t next_value = 0;
+		while (true) {
+			REQUIRE(!deadline.Passed());
+			unique_ptr<DataChunk> chunk;
+			auto execution_result = stream->TryFetchChunk(chunk);
+			if (execution_result == StreamExecutionResult::CHUNK_READY) {
+				next_value = VerifyAscending(*chunk, next_value);
+				continue;
+			}
+			if (execution_result == StreamExecutionResult::EXECUTION_FINISHED) {
+				break;
+			}
+			std::this_thread::sleep_for(std::chrono::microseconds(100));
+		}
+		REQUIRE(next_value == 250000);
+
+		// Sync leg: with both capacities floored at one byte the buffer still admits chunks.
+		// Before the floors this blocked every sink on an always-full empty buffer, an
+		// unbounded busy loop. The watchdog interrupt turns that regression into an error.
+		std::atomic<bool> sync_leg_done {false};
+		std::thread watchdog([&]() {
+			Deadline watchdog_deadline;
+			while (!sync_leg_done.load() && !watchdog_deadline.Passed()) {
+				std::this_thread::sleep_for(std::chrono::milliseconds(100));
+			}
+			if (!sync_leg_done.load()) {
+				con.Interrupt();
+			}
+		});
+		unique_ptr<MaterializedQueryResult> materialized;
+		try {
+			auto pending = con.PendingQuery("SELECT i FROM t", QueryParameters(true));
+			if (!pending->HasError()) {
+				auto result = pending->Execute();
+				if (result->GetResultType() == QueryResultType::STREAM_RESULT) {
+					materialized = result->Cast<StreamQueryResult>().Materialize();
+				}
+			}
+		} catch (...) {
+			// The watchdog must be joined on every path, or the thread dtor aborts
+			sync_leg_done = true;
+			watchdog.join();
+			throw;
+		}
+		sync_leg_done = true;
+		watchdog.join();
+		REQUIRE(materialized);
+		REQUIRE(!materialized->HasError());
+		REQUIRE(materialized->RowCount() == 250000);
+	}
+}
+
+// Fanout plans: async over a shared-CTE plan fed by the broadcast exchange
+
+TEST_CASE("Async stream result drains a streaming-fanout CTE plan", "[api][async_stream]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE fanout AS SELECT range i, range % 512 g FROM range(200000)"));
+
+	// Distinct aggregates are rewritten into a shared materialized CTE: one scan fans out to both consumers
+	const string query = "SELECT COUNT(DISTINCT i), SUM(DISTINCT g) FROM fanout";
+	REQUIRE(StringUtil::Contains(PhysicalPlanText(con, query), "PIPELINE_DEPENDENT"));
+
+	NotifyListener listener;
+	SetNotifier(con, listener);
+	auto stream = ExecuteAsync(con, query);
+	Deadline deadline;
+	idx_t row_count = 0;
+	int64_t count_distinct = -1;
+	int64_t sum_distinct = -1;
+	while (true) {
+		REQUIRE(!deadline.Passed());
+		unique_ptr<DataChunk> chunk;
+		auto execution_result = stream->TryFetchChunk(chunk);
+		if (execution_result == StreamExecutionResult::CHUNK_READY) {
+			for (idx_t i = 0; i < chunk->size(); i++) {
+				count_distinct = chunk->GetValue(0, i).GetValue<int64_t>();
+				sum_distinct = chunk->GetValue(1, i).GetValue<int64_t>();
+			}
+			row_count += chunk->size();
+			continue;
+		}
+		if (execution_result == StreamExecutionResult::EXECUTION_FINISHED) {
+			break;
+		}
+		REQUIRE((execution_result == StreamExecutionResult::BLOCKED ||
+		         execution_result == StreamExecutionResult::CHUNK_NOT_READY));
+		// Park until the engine wakes us. A missed notification over the fanout plan fails here by timeout.
+		REQUIRE(listener.WaitAndReset(std::chrono::seconds(10)));
+	}
+	REQUIRE(row_count == 1);
+	REQUIRE(count_distinct == 200000);
+	REQUIRE(sum_distinct == 130816);
+}
+
+TEST_CASE("Async batched stream result drains a streaming-fanout CTE plan", "[api][async_stream]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE t AS SELECT range i FROM range(500000)"));
+	REQUIRE_NO_FAIL(con.Query("SET streaming_buffer_size='100KB'"));
+
+	// Two readers over one table-backed materialized CTE: the batch index survives the
+	// exchange, so the order-preserving batched collector consumes fanout output directly
+	const string query = "WITH c AS MATERIALIZED (SELECT i FROM t) SELECT (SELECT COUNT(*) FROM c) total, i FROM c";
+	REQUIRE(StringUtil::Contains(PhysicalPlanText(con, query), "PIPELINE_DEPENDENT"));
+
+	NotifyListener listener;
+	SetNotifier(con, listener);
+	auto stream = ExecuteAsync(con, query);
+	// PIPELINE_DEPENDENT alone does not pin the collector: without a batch index this
+	// plan would silently fall back to the order-preserving simple collector
+	REQUIRE_NOTHROW(stream->GetBufferedData().Cast<BatchedBufferedData>());
+	Deadline deadline;
+	int64_t next_value = 0;
+	while (true) {
+		REQUIRE(!deadline.Passed());
+		unique_ptr<DataChunk> chunk;
+		auto execution_result = stream->TryFetchChunk(chunk);
+		if (execution_result == StreamExecutionResult::CHUNK_READY) {
+			chunk->Flatten();
+			auto totals = FlatVector::GetData<int64_t>(chunk->data[0]);
+			for (idx_t i = 0; i < chunk->size(); i++) {
+				if (totals[i] != 500000) {
+					FAIL(StringUtil::Format("Wrong total: %lld", totals[i]));
+				}
+			}
+			next_value = VerifyAscending(*chunk, next_value, 1);
+			continue;
+		}
+		if (execution_result == StreamExecutionResult::EXECUTION_FINISHED) {
+			break;
+		}
+		REQUIRE((execution_result == StreamExecutionResult::BLOCKED ||
+		         execution_result == StreamExecutionResult::CHUNK_NOT_READY));
+		REQUIRE(listener.WaitAndReset(std::chrono::seconds(10)));
+	}
+	REQUIRE(next_value == 500000);
+}
+
+// The buffer cap: buffered bytes never exceed max_streaming_buffer_size, except that a
+// single chunk larger than the cap is admitted into an empty pool
+
+TEST_CASE("Async batched stream result never exceeds the buffer cap", "[api][async_stream]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	REQUIRE_NO_FAIL(con.Query("SET max_streaming_buffer_size='250000b'"));
+	REQUIRE_NO_FAIL(con.Query("PRAGMA enable_profiling='no_output'"));
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE tbl AS SELECT 'padding-padding-' || i AS s FROM range(200000) t(i)"));
+
+	auto stream = ExecuteAsync(con, "SELECT * FROM tbl");
+	Deadline deadline;
+	idx_t row_count = 0;
+	while (true) {
+		REQUIRE(!deadline.Passed());
+		unique_ptr<DataChunk> chunk;
+		auto execution_result = stream->TryFetchChunk(chunk);
+		if (execution_result == StreamExecutionResult::CHUNK_READY) {
+			row_count += chunk->size();
+			continue;
+		}
+		if (execution_result == StreamExecutionResult::EXECUTION_FINISHED) {
+			break;
+		}
+		std::this_thread::sleep_for(std::chrono::microseconds(100));
+	}
+	REQUIRE(row_count == 200000);
+	REQUIRE(stream->GetBufferedData().Cast<BatchedBufferedData>().PeakBufferedBytes() <= 250000);
+
+	// The peak surfaces as a query-level profiling metric, carrying the real value
+	auto peak = stream->GetBufferedData().Cast<BatchedBufferedData>().PeakBufferedBytes();
+	auto profile = QueryProfiler::Get(*con.context).ToJSON();
+	auto key_pos = profile.find("\"peak_streaming_buffer_size\"");
+	REQUIRE(key_pos != string::npos);
+	auto colon_pos = profile.find(':', key_pos);
+	REQUIRE(colon_pos != string::npos);
+	auto reported = std::stoull(profile.substr(colon_pos + 1));
+	REQUIRE(reported == peak);
+	REQUIRE(reported > 0);
+}
+
+TEST_CASE("Sync batched stream result never exceeds the buffer cap", "[api][async_stream]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	REQUIRE_NO_FAIL(con.Query("SET max_streaming_buffer_size='250000b'"));
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE tbl AS SELECT 'padding-padding-' || i AS s FROM range(200000) t(i)"));
+
+	auto pending = con.PendingQuery("SELECT * FROM tbl", QueryParameters(true));
+	REQUIRE(!pending->HasError());
+	auto result = pending->Execute();
+	REQUIRE(result->GetResultType() == QueryResultType::STREAM_RESULT);
+	auto &stream = result->Cast<StreamQueryResult>();
+	DrainWatchdog watchdog(con);
+	idx_t row_count = 0;
+	while (auto chunk = stream.Fetch()) {
+		row_count += chunk->size();
+	}
+	REQUIRE(row_count == 200000);
+	REQUIRE(stream.GetBufferedData().Cast<BatchedBufferedData>().PeakBufferedBytes() <= 250000);
+}
+
+TEST_CASE("Async simple stream result never exceeds the buffer cap", "[api][async_stream]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	REQUIRE_NO_FAIL(con.Query("SET max_streaming_buffer_size='100000b'"));
+
+	// range() has no batch indexes, so this plan uses the simple buffer
+	auto stream = ExecuteAsync(con, "SELECT i FROM range(500000) t(i)");
+	Deadline deadline;
+	idx_t row_count = 0;
+	while (true) {
+		REQUIRE(!deadline.Passed());
+		unique_ptr<DataChunk> chunk;
+		auto execution_result = stream->TryFetchChunk(chunk);
+		if (execution_result == StreamExecutionResult::CHUNK_READY) {
+			row_count += chunk->size();
+			continue;
+		}
+		if (execution_result == StreamExecutionResult::EXECUTION_FINISHED) {
+			break;
+		}
+		std::this_thread::sleep_for(std::chrono::microseconds(100));
+	}
+	REQUIRE(row_count == 500000);
+	REQUIRE(stream->GetBufferedData().Cast<SimpleBufferedData>().PeakBufferedBytes() <= 100000);
+}
+
+TEST_CASE("Sync simple stream result never exceeds the buffer cap", "[api][async_stream]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	// Regression: the sync consumer must stop replenishing on a saturated buffer, not
+	// only on an exactly-full one, or the size-aware block spins the replenish loop
+	REQUIRE_NO_FAIL(con.Query("SET max_streaming_buffer_size='100000b'"));
+
+	auto pending = con.PendingQuery("SELECT i FROM range(500000) t(i)", QueryParameters(true));
+	REQUIRE(!pending->HasError());
+	auto result = pending->Execute();
+	REQUIRE(result->GetResultType() == QueryResultType::STREAM_RESULT);
+	auto &stream = result->Cast<StreamQueryResult>();
+	DrainWatchdog watchdog(con);
+	idx_t row_count = 0;
+	while (auto chunk = stream.Fetch()) {
+		row_count += chunk->size();
+	}
+	REQUIRE(row_count == 500000);
+	REQUIRE(stream.GetBufferedData().Cast<SimpleBufferedData>().PeakBufferedBytes() <= 100000);
+}
+
+TEST_CASE("A chunk larger than the buffer cap is admitted alone", "[api][async_stream]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	REQUIRE_NO_FAIL(con.Query("SET max_streaming_buffer_size='100KB'"));
+	// Every row holds a 150KB string, so any chunk exceeds the cap at every vector size
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE big AS SELECT repeat('x', 150000) || i AS s FROM range(8) t(i)"));
+
+	auto stream = ExecuteAsync(con, "SELECT * FROM big");
+	Deadline deadline;
+	idx_t row_count = 0;
+	idx_t largest_chunk = 0;
+	while (true) {
+		REQUIRE(!deadline.Passed());
+		unique_ptr<DataChunk> chunk;
+		auto execution_result = stream->TryFetchChunk(chunk);
+		if (execution_result == StreamExecutionResult::CHUNK_READY) {
+			row_count += chunk->size();
+			largest_chunk = MaxValue<idx_t>(largest_chunk, chunk->GetDataSize());
+			continue;
+		}
+		if (execution_result == StreamExecutionResult::EXECUTION_FINISHED) {
+			break;
+		}
+		std::this_thread::sleep_for(std::chrono::microseconds(100));
+	}
+	REQUIRE(row_count == 8);
+	// The floor admits one oversized chunk, but never stacks a second one on top,
+	// so the peak stays within the honest bound: the cap plus one chunk
+	auto peak = stream->GetBufferedData().Cast<BatchedBufferedData>().PeakBufferedBytes();
+	REQUIRE(peak >= 150000);
+	REQUIRE(largest_chunk >= 150000);
+	REQUIRE(peak <= 100000 + largest_chunk);
+}
+
+#else
+
+TEST_CASE("The async setting refuses a threadless build", "[api][async_stream]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+
+	auto result = con.Query("SET streaming_execution_mode='async'");
+	REQUIRE(result->HasError());
+}
+
+#endif

--- a/test/api/test_reset.cpp
+++ b/test/api/test_reset.cpp
@@ -57,6 +57,7 @@ OptionValueSet GetValueForOption(const string &name, const LogicalType &type) {
 	    {"default_collation", {"nocase"}},
 	    {"default_order", {"DESC"}},
 	    {"default_null_order", {"NULLS_FIRST"}},
+	    {"streaming_execution_mode", {"async"}},
 	    {"disabled_compression_methods", {"RLE"}},
 	    {"disabled_optimizers", {"extension"}},
 	    {"debug_force_external", {Value(true)}},
@@ -200,7 +201,8 @@ bool OptionIsExcludedFromTest(const string &name) {
 	    "temp_file_encryption",
 	    "enable_object_cache",
 	    "force_variant_shredding",
-	    "streaming_buffer_size",
+	    "max_streaming_buffer_size",
+	    "streaming_buffer_size", // alias of max_streaming_buffer_size
 	    "log_query_path",
 	    "password",
 	    "username",

--- a/test/configs/force_storage_restart.json
+++ b/test/configs/force_storage_restart.json
@@ -6,6 +6,12 @@
   "inherit_skip_tests": "test/configs/force_storage.json",
   "skip_tests": [
     {
+      "reason": "The connection-local streaming_execution_mode setting and its scheduler registration do not survive the forced restart between statements.",
+      "paths": [
+        "test/sql/settings/streaming_execution_mode.test"
+      ]
+    },
+    {
       "reason": "In-memory external resource type registry is instance-scoped and does not survive database restarts.",
       "paths": [
         "test/sql/table_function/external_resource_types.test",

--- a/test/sql/pragma/profiling/test_custom_profiling_peak_streaming_buffer_size.test
+++ b/test/sql/pragma/profiling/test_custom_profiling_peak_streaming_buffer_size.test
@@ -1,0 +1,36 @@
+# name: test/sql/pragma/profiling/test_custom_profiling_peak_streaming_buffer_size.test
+# description: Test the system.peak_streaming_buffer_size metric wiring
+# group: [profiling]
+
+# The value is only non-zero for streaming results, which this harness cannot run.
+# The value is pinned in test/api/test_async_stream_result.cpp.
+
+require json
+
+statement ok
+PRAGMA enable_profiling = 'json';
+
+statement ok
+PRAGMA profiling_output = '{TEST_DIR}/profiling_output.json';
+
+statement ok
+SET tracked_metrics = ['system.peak_streaming_buffer_size'];
+
+statement ok
+SELECT COUNT(*) FROM range(10000);
+
+statement ok
+PRAGMA disable_profiling;
+
+query I
+SELECT unnest(current_setting('tracked_metrics')) ORDER BY ALL
+----
+system.peak_streaming_buffer_size
+
+statement ok
+CREATE OR REPLACE TABLE metrics_output AS SELECT * FROM '{TEST_DIR}/profiling_output.json';
+
+query I
+SELECT COUNT(system.peak_streaming_buffer_size) FROM metrics_output;
+----
+1

--- a/test/sql/settings/max_streaming_buffer_size.test
+++ b/test/sql/settings/max_streaming_buffer_size.test
@@ -1,0 +1,28 @@
+# name: test/sql/settings/max_streaming_buffer_size.test
+# description: max_streaming_buffer_size and its streaming_buffer_size alias resolve to one option
+# group: [settings]
+
+statement ok
+SET max_streaming_buffer_size='2MiB'
+
+query II
+SELECT current_setting('max_streaming_buffer_size'), current_setting('streaming_buffer_size')
+----
+2.0 MiB	2.0 MiB
+
+# The alias writes the same backing option
+statement ok
+SET streaming_buffer_size='4.0MiB'
+
+query II
+SELECT current_setting('max_streaming_buffer_size'), current_setting('streaming_buffer_size')
+----
+4.0 MiB	4.0 MiB
+
+statement ok
+RESET streaming_buffer_size
+
+query I
+SELECT current_setting('max_streaming_buffer_size')
+----
+976.5 KiB

--- a/test/sql/settings/streaming_execution_mode.test
+++ b/test/sql/settings/streaming_execution_mode.test
@@ -1,0 +1,72 @@
+# name: test/sql/settings/streaming_execution_mode.test
+# description: The streaming_execution_mode setting: values, scope, and the worker-thread guard
+# group: [settings]
+
+query I
+SELECT current_setting('streaming_execution_mode')
+----
+sync
+
+statement ok
+SET streaming_execution_mode='async'
+
+query I
+SELECT current_setting('streaming_execution_mode')
+----
+async
+
+# Values are case-insensitive
+statement ok
+SET streaming_execution_mode='ASYNC'
+
+statement ok
+RESET streaming_execution_mode
+
+query I
+SELECT current_setting('streaming_execution_mode')
+----
+sync
+
+statement error
+SET streaming_execution_mode='turbo'
+----
+<REGEX>:.*unrecognized value.*
+
+# The setting is connection-local
+statement error
+SET GLOBAL streaming_execution_mode='async'
+----
+<REGEX>:.*cannot be set globally.*
+
+# Another connection's setting stays sync
+statement ok con1
+SET streaming_execution_mode='async'
+
+query I con2
+SELECT current_setting('streaming_execution_mode')
+----
+sync
+
+# No connection can remove the last managed worker while an async connection exists
+statement error con2
+SET threads=1
+----
+<REGEX>:.*async.*worker thread.*
+
+statement ok con1
+RESET streaming_execution_mode
+
+statement ok con2
+SET threads=1
+
+# Async needs a managed worker, so it is refused on a single-threaded instance
+statement error con1
+SET streaming_execution_mode='async'
+----
+<REGEX>:.*worker thread.*
+
+statement ok con2
+SET threads=4
+
+statement ok con1
+SET streaming_execution_mode='async'


### PR DESCRIPTION
This introduces asynchronous streaming query result consumption. It doesn't change the existing API, just adds to it, and existing streaming results (which are not async) keep working as normal. They do profit somewhat from these changes in terms of performance (see the bechmarks).

This work would enable asynchronous concurrency in clients - think Node and Python.

## Usage

- Enable async mode with the setting `SET streaming_execution_mode = 'async'`.
- For blocking fetches on a streaming result in async mode, use `stream.Fetch()`.
- For non-blocking fetches on a streaming result in async mode, use `stream.TryFetchChunk()`.
- For callback notifications of state changes (`CHUNK_READY`, `EXECUTION_FINISHED`, `EXECUTION_CANCELLED` or 
  `EXECUTION_ERROR`), set `notify_callback` on a connection's ClientConfig (`ClientConfig::GetConfig(*con.context)`).

**Important notes**:
- `streaming_execution_mode` is a connection-local config setting. Different connections can use sync or async mode,
  and are allowed to switch modes at any time.
- Async is only supported:
   - On streaming results. Make sure to set `QueryResultOutputType::ALLOW_STREAMING` in the query parameters. Also 
     make sure to check `result->GetResultType() == QueryResultType::STREAM_RESULT` after creating a result since 
     non-SELECT queries will always be materialized, i.e. not support async.
   - For multithreaded setups. Enabling async in single threaded mode will error, and `SET threads` / `SET 
   external_threads` when async is enabled on one or more connections will error.

## Example: blocking fetch in async mode

```cpp
Connection con(db);
con.Query("SET streaming_execution_mode = 'async'");

auto result = con.PendingQuery(query, QueryParameters(QueryResultOutputType::ALLOW_STREAMING))->Execute();
auto &stream = result->Cast<StreamQueryResult>();
// Fetch() blocks until a chunk is ready but never executes engine work on this thread.
while (auto chunk = stream.Fetch()) {
    Process(*chunk);
}
// Errors will surface here, no need to check the state
if (stream.HasError()) {
    HandleError(stream.GetError());
}
```

## Example: async execution with a callback

```cpp
Connection con(db);
con.Query("SET streaming_execution_mode = 'async'");

// Set the callback.
std::mutex m;
std::condition_variable cv; 
bool wake = false;
ClientConfig::GetConfig(*con.context).notify_callback = [&]() {
    std::lock_guard<std::mutex> guard(m);
    wake = true;
    cv.notify_one();
};

auto result = con.PendingQuery(query, QueryParameters(QueryResultOutputType::ALLOW_STREAMING))->Execute();
auto &stream = result->Cast<StreamQueryResult>();

unique_ptr<DataChunk> chunk;
while (true) {
    auto state = stream.TryFetchChunk(chunk);
    if (state == StreamExecutionResult::CHUNK_READY) {
            Process(*chunk);
            continue;
    }
    if (state == StreamExecutionResult::EXECUTION_FINISHED) {
            break;
    }
    if (state == StreamExecutionResult::EXECUTION_ERROR || state == StreamExecutionResult::EXECUTION_CANCELLED) {
            HandleError(stream.GetError());
            break;
    }
    // No chunk yet. Sleep until the engine notifies.
    std::unique_lock<std::mutex> guard(m);
    cv.wait(guard, [&]() { return wake; });
    wake = false;
}
```

**Notes**:
- The callback runs on an engine thread and so it _must_ be tiny and _must not_ call back into DuckDB.
- Callbacks might overlap and the state it triggered on might have changed by the time the consumer tries to fetch, so 
  the consumer must check the stream's state every time.
- `std::condition_variable` is not suitable for use in signal handlers on POSIX. E.g. the DuckDB CLI handles ctrl+c by
  calling Interrupt(), which will call the notify callback. If your code does something similar then use a more 
  suitable idiom, like a pipe.

# Changes

First some terminology: I make a distinction here between a **consumer thread** and an **engine thread**:
- A consumer thread is a thread from which a query is started, i.e. a thread that does something like `result = con->Query(...)`. In my mental model, this thread is "external".
- An engine thread is a thread that executes DuckDB pipeline tasks, and is part of the engine's threadpool. In my mental model, this thread is "internal".

In sync mode (i.e. how things currently work) when a consumer thread does this:
```cpp
Connection con(db);
auto result = con.PendingQuery(query, QueryParameters(QueryResultOutputType::ALLOW_STREAMING))->Execute();
auto &stream = result->Cast<StreamQueryResult>();
while (auto chunk = stream.Fetch()) {
    Process(*chunk);
}
```
... the consumer thread does multiple things when it calls `Fetch()`:
1. It participates in task execution alongside the engine threads.
1. It marks blocked tasks as unblocked.
1. It returns a data chunk to the caller, if one is available.

This PR introduces an async mode, where the consumer thread **never participates in task execution**. It adds:
- **Async query execution mode**: `streaming_execution_mode = [sync | async]`, a connection-scoped setting that controls the execution mode of queries running on the connection.
- **Polling**: `StreamExecutionResult StreamQueryResult::TryFetchChunk(unique_ptr<DataChunk> &out_chunk)`, which is unblocking in the sense that it will not make the caller wait until a chunk is available. This can be used to poll a query.
- **Async callback**: `ClientConfig::notify_callback`, an optional (connection scoped) callback that can be set to notify a consumer about a relevant change in state of the execution.

# Benchmarks

The below compares main (always sync) with this branch's sync and async modes. Two notes:
- Async will noticeably perform better than sync on buffer sizes that are tuned to the workload, with a sweet spot across different workloads between 16mb and 8mb. 
- More importantly: async enables evented (client) concurrency that significantly outperforms multihreaded concurrency, both in time and memory.

Running it:
```sh
BUILD_BENCHMARK=1 make release
./build/release/benchmark/benchmark_runner "benchmark/micro/result_collection/stream_(sync|async).*" --threads=5 --timed-runs 7 --buffer_size 8mb
```

Results
```
┌─────────┬─────────────┬───────────────┬────────────────┬──────────────────┬───────────────────┐
│ buffer  │ main_sync_s │ branch_sync_s │ branch_async_s │ sync_vs_main_pct │ async_vs_main_pct │
│ varchar │   double    │    double     │     double     │      double      │      double       │
├─────────┼─────────────┼───────────────┼────────────────┼──────────────────┼───────────────────┤
│ 100kb   │       0.558 │         0.493 │           0.55 │            -11.7 │              -1.5 │
│ 1mb     │       0.486 │         0.481 │          0.528 │             -0.9 │               8.6 │
│ 8mb     │       0.469 │         0.418 │          0.379 │            -10.9 │             -19.2 │
│ 64mb    │       0.143 │         0.111 │          0.174 │            -22.5 │              21.6 │
│ 100gb   │       0.121 │          0.11 │          0.137 │             -9.2 │              13.1 │
└─────────┴─────────────┴───────────────┴────────────────┴──────────────────┴───────────────────┘
```

# Related

duckdb/duckdb-quack#207
duckdb/duckdb-quack#208
duckdb/duckdb-quack#229
duckdb/duckdb-quack#252

# (Possible) follow ups

* Support async for `CREATE TABLE AS SELECT` type queries. Should be a small follow-up.
* Add support for custom collectors. Arrow & Quack use cases.
* Detach calling the notify callback from task execution (see [comment](https://github.com/duckdb/duckdb/pull/24853#issuecomment-5440346718)).
* Introduce something like a `ActiveQueryState` that is shared between the executor and the client context to wrap the state-data that needs to be shared, i.e. `interrupt_state`, `active_result_notifier`, `streaming_buffered_data`, `execution_result`, etc. I could also hold the `QueryProfiler`, `QueryProgress`, and maybe other things. Right now these are all scattered, and sometimes intertwined with execution (e.g. `CheckPulse()` does a dry run `ExecuteTask` to make sure blocked tasks are unblocked _and_ to get the current state; and we keep both the notifier callback and a pointer to the result buffer on the `Executor`).