### PR TITLE
Keep the list_aggregate bind data unambiguous

### DIFF
--- a/extension/core_functions/scalar/list/list_aggregates.cpp
+++ b/extension/core_functions/scalar/list/list_aggregates.cpp
@@ -35,7 +35,9 @@ unique_ptr<FunctionLocalState> ListAggregatesInitLocalState(ExpressionState &sta
 unique_ptr<FunctionData> ListAggregatesBindFailure(BoundScalarFunction &bound_function) {
 	bound_function.GetArguments()[0] = LogicalType::SQLNULL;
 	bound_function.SetReturnType(LogicalType::SQLNULL);
-	return make_uniq<VariableReturnBindData>(LogicalType::SQLNULL);
+	// no bind data, like the other path that binds nothing: the bind data of this function is always a
+	// ListAggregatesBindData, so anything else here cannot be told apart from one
+	return nullptr;
 }
 
 struct ListAggregatesBindData : public FunctionData {
@@ -66,7 +68,10 @@ struct ListAggregatesBindData : public FunctionData {
 
 	static void SerializeFunction(Serializer &serializer, const optional_ptr<FunctionData> bind_data_p,
 	                              const BoundScalarFunction &function) {
-		auto bind_data = dynamic_cast<const ListAggregatesBindData *>(bind_data_p.get());
+		const ListAggregatesBindData *bind_data = nullptr;
+		if (bind_data_p) {
+			bind_data = &bind_data_p->Cast<ListAggregatesBindData>();
+		}
 		serializer.WritePropertyWithDefault(100, "bind_data", bind_data, (const ListAggregatesBindData *)nullptr);
 	}
 

--- a/test/sql/function/list/aggregates/min.test
+++ b/test/sql/function/list/aggregates/min.test
@@ -108,3 +108,15 @@ statement ok
 DROP TABLE five
 
 endloop
+
+# a list of only NULLs binds successfully but has a SQLNULL return type - the bind data must still
+# survive plan serialization (run under test/configs/verify_serializer.json)
+query III
+SELECT list_aggregate([NULL], 'min'), list_aggregate([NULL, NULL], 'min'), list_aggregate([NULL::INT], 'min');
+----
+NULL	NULL	NULL
+
+query I
+SELECT list_aggregate([NULL], 'first');
+----
+NULL


### PR DESCRIPTION
list_aggregate has three bind outcomes: a ListAggregatesBindData, a VariableReturnBindData when the argument is SQLNULL, and no bind data at all when the argument is a prepared statement parameter. Serialization then had to tell them apart with a dynamic_cast.

Return no bind data from the SQLNULL path too, matching the parameter path, so the bind data of this function is either a ListAggregatesBindData or absent.

This also removes the only way a foreign bind data type could reach ListAggregatesFunction, which casts it with the unchecked Cast<>.

The added test covers a list of only NULLs, which binds successfully but has a SQLNULL return type, so it is not distinguishable from a bind failure by the return type alone. It runs under test/configs/verify_serializer.json.