### PR TITLE
Avoid overwriting streaming NTH_VALUE result on NULL rows

### DIFF
--- a/src/function/window/window_value_function.cpp
+++ b/src/function/window/window_value_function.cpp
@@ -1127,13 +1127,13 @@ void WindowNthValueStreamingState::StreamData(ExecutionContext &context, DataChu
 	for (idx_t i = 0; i < count; ++i) {
 		if (!any_value || validity.RowIsValidUnsafe(unified.sel->get_index(i))) {
 			++nth_count;
-		}
-		// One-based comparison.
-		if (nth_count == nth_index) {
-			auto v = arg.GetValue(i);
-			vec.Reference(v, count_t(count));
-			s = 1;
-			split.SetValue(s, v);
+			// One-based comparison.
+			if (nth_count == nth_index) {
+				auto v = arg.GetValue(i);
+				vec.Reference(v, count_t(count));
+				s = 1;
+				split.SetValue(s, v);
+			}
 		}
 		sel.set_index(i, s);
 	}

--- a/test/sql/window/test_streaming_nthvalue.test
+++ b/test/sql/window/test_streaming_nthvalue.test
@@ -63,6 +63,19 @@ A	NULL
 NULL	NULL
 B	B
 
+# Regression: later NULL rows should not overwrite the found value
+query II
+WITH src(id, x) AS (VALUES (1, 10), (2, 20), (3, NULL), (4, 30))
+SELECT id, NTH_VALUE(x, 2 IGNORE NULLS) OVER (
+	ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+) AS actual
+FROM src ORDER BY id
+----
+1	NULL
+2	20
+3	20
+4	20
+
 # Test short circuit
 query II
 select i, nth_value(i, 2049) over(ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) n


### PR DESCRIPTION
Fixes #24827

Streaming NTH_VALUE with IGNORE NULLS keeps a running count of non-NULL values. After the requested value has been found, later NULL rows should not overwrite the cached result.

This change only captures the NTH_VALUE result on rows that advance the running count, and adds regression coverage for trailing NULL rows.

Tested with:

  ```bash
./build/debug/test/unittest test/sql/window/test_streaming_nthvalue.test
```