### PR TITLE
Fix non-constant map switch bug

### DIFF
--- a/extension/core_functions/scalar/map/switch.cpp
+++ b/extension/core_functions/scalar/map/switch.cpp
@@ -53,7 +53,7 @@ unique_ptr<FunctionData> SwitchBindReturnType(BindScalarFunctionInput &input) {
 		throw BinderException("SWITCH expected a constant map for the cases");
 	}
 	auto &func = cases->Cast<BoundFunctionExpression>();
-	if (func.Function().GetName() != "map") {
+	if (func.Function().GetName() != "map" || !cases->IsFoldable()) {
 		throw BinderException("SWITCH expected a constant map for the cases");
 	}
 	auto map_value = ExpressionExecutor::EvaluateScalar(context, *cases);

--- a/test/sql/parser/switch_case.test
+++ b/test/sql/parser/switch_case.test
@@ -107,3 +107,8 @@ statement error
 SELECT SWITCH (1, i) FROM map_expr;
 ----
 Binder Error: SWITCH expected a constant map for the cases
+
+statement error
+SELECT switch(i, MAP {i : 1}) FROM (SELECT 1 i);
+----
+Binder Error: SWITCH expected a constant map for the cases


### PR DESCRIPTION
Switch didn't properly check if the input map was foldable which threw an internal error.

Fixes: https://github.com/duckdb/duckdb-fuzzer/issues/4612