### PR TITLE
Fix SUBSTR ASCII fast path returning wrong result for very negative o…

### DIFF
--- a/src/function/scalar/string/substring.cpp
+++ b/src/function/scalar/string/substring.cpp
@@ -61,7 +61,25 @@ static bool SubstringStartEnd(int64_t input_size, int64_t offset, int64_t length
 		start = MinValue<int64_t>(input_size, offset - 1);
 	} else if (offset < 0) {
 		// negative offset: scan from end (i.e. start = end + offset)
-		start = MaxValue<int64_t>(input_size + offset, 0);
+		int64_t virtual_start = input_size + offset;
+		if (length > 0) {
+			// end must be computed from the unclamped virtual start: clamping start to 0 first
+			// (and only then adding length) would forget how far left the window actually began,
+			// and could make an out-of-range window look like it still overlaps the string
+			int64_t virtual_end = virtual_start + length;
+			if (virtual_end <= 0) {
+				// the requested [offset, offset + length) window lies entirely before the string
+				return false;
+			}
+			start = MaxValue<int64_t>(virtual_start, 0);
+			end = MinValue<int64_t>(input_size, virtual_end);
+			if (start == end) {
+				return false;
+			}
+			D_ASSERT(start < end);
+			return true;
+		}
+		start = MaxValue<int64_t>(virtual_start, 0);
 	} else {
 		// offset = 0: special case, we start 1 character BEHIND the first character
 		start = 0;


### PR DESCRIPTION
Fix SUBSTR ASCII fast path returning wrong result for very negative offsets

The ASCII fast path clamped the negative-offset start position to 0 before adding length, which could make a [offset, offset+length) window that lies entirely before the string look like it still overlaps it. Fixes #24766.

Problem

CREATE TABLE t(s VARCHAR);
INSERT INTO t VALUES ('abc');

SELECT SUBSTR(s, -12345678, 12) FROM t;   -- 'abc'  (wrong)
SELECT SUBSTR('abc', -12345678, 12);      -- ''     (correct)

The heap-column query goes through SubstringFunctionASCII, swapped in by SubstringPropagateStats when column statistics indicate the value can't contain Unicode. The constant is instead evaluated via SubstringUnicode (through constant folding), which produces the correct result. Disabling the statistics_propagation optimizer also produces the correct result, since it prevents the ASCII fast path from being selected — confirming the bug is isolated to SubstringASCII/SubstringStartEnd.

Root cause

In SubstringStartEnd (src/function/scalar/string/substring.cpp), the negative-offset branch clamped the virtual start position to 0 immediately:

} else if (offset < 0) {
    start = MaxValue<int64_t>(input_size + offset, 0);
}

end was then computed from this already-clamped start, not from the true (unclamped) virtual start. This loses how far left the requested window actually began, so a window that never overlaps the string at all (e.g. offset = -12345678, length = 12 on a 3-character string) was miscomputed as starting at index 0 and extending length characters forward — producing a nonempty result instead of the correct empty one.

Fix

Compute end from the unclamped virtual start, and bail out early if the virtual end still lies at or before the beginning of the string:

int64_t virtual_start = input_size + offset;
if (length > 0) {
    int64_t virtual_end = virtual_start + length;
    if (virtual_end <= 0) {
        return false; // window lies entirely before the string
    }
    start = MaxValue<int64_t>(virtual_start, 0);
    end = MinValue<int64_t>(input_size, virtual_end);
    ...
}

This only touches the offset < 0 branch; positive-offset and offset-0 handling are unchanged.

Testing

- Reproduced the original issue and confirmed the fix resolves it, matching the Unicode/constant-fold path.
- test/sql/function/string/test_substring.test, test_substring_utf8.test, substring_zonemap_pruning.test — all pass.
- Existing OOB regression test (test/common/test_substring_oob.cpp) — passes.
- Exhaustive sweep of 1150 (offset, length) pairs for negative offsets (including huge magnitudes and exact boundary values) compared against the Unicode/constant-fold oracle — 0 mismatches.

Note: a separate, pre-existing mismatch between the ASCII and Unicode paths exists for positive offsets combined with negative lengths (e.g. SUBSTR('abcde', 7, -5)). That code path is untouched by this change and is out of scope here; filing separately.