### PR TITLE
Avoid re-evaluating volatile window order expressions in constant window aggregates

### DIFF
--- a/src/function/window/window_constant_aggregator.cpp
+++ b/src/function/window/window_constant_aggregator.cpp
@@ -113,6 +113,14 @@ bool WindowConstantAggregator::CanAggregate(const BoundWindowExpression &wexpr) 
 	if (wexpr.Distinct()) {
 		return false;
 	}
+	if (wexpr.AggregateFunction()->GetOrderDependent() == AggregateOrderDependent::ORDER_DEPENDENT &&
+	    wexpr.ArgOrders().empty()) {
+		for (const auto &order : wexpr.OrderBy()) {
+			if (order.expression->IsVolatile()) {
+				return false;
+			}
+		}
+	}
 
 	//	COUNT(*) is already handled efficiently by segment trees.
 	if (wexpr.GetChildren().empty()) {

--- a/test/issues/general/test_24830.test
+++ b/test/issues/general/test_24830.test
@@ -1,0 +1,34 @@
+# name: test/issues/general/test_24830.test
+# description: Volatile implicit ordering for constant window aggregates
+# group: [general]
+
+foreach windowmode "window" "combine" "separate"
+
+statement ok
+PRAGMA debug_window_mode={windowmode};
+
+statement ok
+DROP SEQUENCE IF EXISTS test_24830_seq;
+
+statement ok
+CREATE SEQUENCE test_24830_seq START 1;
+
+query I
+SELECT LIST(x) OVER (
+	ORDER BY (nextval('test_24830_seq') % 2 = 0), x
+	ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+) AS actual
+FROM (VALUES (1), (2), (3), (4), (5)) AS t(x)
+LIMIT 1;
+----
+[1, 3, 5, 2, 4]
+
+query I
+SELECT currval('test_24830_seq');
+----
+5
+
+endloop
+
+statement ok
+RESET debug_window_mode;


### PR DESCRIPTION
Fix #24830 

### Problem

The reported issue affected order-dependent window aggregates such as `LIST()` when the window’s `ORDER BY` clause contained a volatile expression—for example, `nextval()`:

```
SELECT LIST(x) OVER (
    ORDER BY (nextval('seq') % 2 = 0), x
    ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
)
FROM (VALUES (1), (2), (3), (4), (5)) t(x);
```

With the optimizer enabled, DuckDB selected the `WindowConstantAggregator` because the frame covered the entire partition and therefore produced the same aggregate result for every row. However, `LIST()` is order-dependent and had no explicit aggregate argument ordering, such as `LIST(x ORDER BY ...)`.

In that situation, the constant-window implementation implicitly copied the window’s `ORDER BY` expressions into a sorted aggregate wrapper. The window executor had already evaluated `nextval()` to establish the row order, but the sorted aggregate evaluated it again. Since `nextval()` is volatile and returns a different value on every call, the second evaluation generated different ordering keys. As a result, the aggregate could reorder rows inconsistently and advance the sequence twice per input row.

This is why disabling the optimizer produced the correct result: the non-optimized window path consumed the ordering established by the window operator without evaluating the volatile expression a second time.

### Fix

The fix adds a narrow eligibility check to `WindowConstantAggregator`. It declines the constant-window optimization only when all of the following are true:

  - The aggregate is order-dependent.
  - The aggregate has no explicit argument-level `ORDER BY`.
  - The inherited window ordering contains a volatile expression.

When these conditions are met, DuckDB falls back to the regular window aggregation path, which preserves the original ordering and evaluates the volatile expression only once per row.