### PR TITLE
ARM64 portability hardening: fix UB in interpolation, binning hang, and hot-path code

### DIFF
--- a/extension/core_functions/scalar/generic/binning.cpp
+++ b/extension/core_functions/scalar/generic/binning.cpp
@@ -141,6 +141,10 @@ struct EquiWidthBinsInteger {
 			// we allow for more bins when doing nice rounding since the bin count is approximate
 			bin_count *= 2;
 		}
+		// a step of 0 (bin count too large for the range, or min == max) would never advance the loop below
+		if (step == 0) {
+			throw InvalidInputException("equi_width_bins: bin count is too large for the range between min and max");
+		}
 		for (hugeint_t bin_boundary = max; bin_boundary > min; bin_boundary -= step) {
 			const hugeint_t target_boundary = bin_boundary / FACTOR;
 			int64_t real_boundary = Hugeint::Cast<int64_t>(target_boundary);
@@ -187,7 +191,7 @@ struct EquiWidthBinsDouble {
 			bin_count *= 2;
 		}
 		if (step == 0) {
-			throw InternalException("step is 0!?");
+			throw InvalidInputException("equi_width_bins: bin count is too large for the range between min and max");
 		}
 
 		const double round_multiplication = 10 / step_power_of_ten;

--- a/extension/core_functions/scalar/operators/bitwise.cpp
+++ b/extension/core_functions/scalar/operators/bitwise.cpp
@@ -258,6 +258,9 @@ struct BitwiseShiftLeftOperator {
 		if (shift == 0) {
 			return input;
 		}
+		if (input == 0) {
+			return 0;
+		}
 		TA max_value = UnsafeNumericCast<TA>((TA(1) << (max_shift - shift - 1)));
 		if (input >= max_value) {
 			throw OutOfRangeException("Overflow in left shift (%s << %s)", NumericHelper::ToString(input),

--- a/src/common/checksum.cpp
+++ b/src/common/checksum.cpp
@@ -66,11 +66,10 @@ hash_t ChecksumRemainder(const void *ptr, size_t len) noexcept {
 
 uint64_t Checksum(const uint8_t *buffer, size_t size) {
 	uint64_t result = 5381;
-	auto ptr = reinterpret_cast<const uint64_t *>(buffer);
 	size_t i;
 	// for efficiency, we first checksum uint64_t values
 	for (i = 0; i < size / 8; i++) {
-		result ^= Checksum(ptr[i]);
+		result ^= Checksum(Load<uint64_t>(buffer + i * 8));
 	}
 	if (size > i * 8) {
 		// the remaining 0-7 bytes we hash using a string hash

--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -445,7 +445,8 @@ uint64_t StringUtil::CIHash(const string &str) {
 uint64_t StringUtil::CIHash(const char *str, idx_t size) {
 	uint32_t hash = 0;
 	for (idx_t i = 0; i < size; i++) {
-		hash += static_cast<uint32_t>(StringUtil::CharacterToLower(static_cast<char>(str[i])));
+		// convert through uint8_t so the hash is identical on platforms with signed and unsigned char
+		hash += static_cast<uint32_t>(static_cast<uint8_t>(StringUtil::CharacterToLower(static_cast<char>(str[i]))));
 		hash += hash << 10;
 		hash ^= hash >> 6;
 	}

--- a/src/common/types/uuid.cpp
+++ b/src/common/types/uuid.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/common/types/uuid.hpp"
 #include "duckdb/common/chrono.hpp"
+#include "duckdb/common/helper.hpp"
 #include "duckdb/common/random_engine.hpp"
 
 namespace duckdb {
@@ -152,7 +153,7 @@ hugeint_t BaseUUID::Convert(const std::array<uint8_t, 16> &bytes) {
 hugeint_t UUIDv4::GenerateRandomUUID(RandomEngine &engine) {
 	std::array<uint8_t, 16> bytes;
 	for (int i = 0; i < 16; i += 4) {
-		*reinterpret_cast<uint32_t *>(bytes.data() + i) = engine.NextRandomInteger();
+		Store<uint32_t>(engine.NextRandomInteger(), bytes.data() + i);
 	}
 	// variant must be 10xxxxxx
 	bytes[8] &= 0xBF;

--- a/src/execution/join_hashtable.cpp
+++ b/src/execution/join_hashtable.cpp
@@ -762,15 +762,15 @@ static inline data_ptr_t InsertRowToEntry(atomic<ht_entry_t> &entry, const data_
 			StorePointer(nullptr, row_ptr_to_insert + pointer_offset);
 
 			ht_entry_t expected_entry;
-			entry.compare_exchange_strong(expected_entry, desired_entry, std::memory_order_acquire,
-			                              std::memory_order_relaxed);
+			entry.compare_exchange_strong(expected_entry, desired_entry, std::memory_order_release,
+			                              std::memory_order_acquire);
 
 			// The expected entry is updated with the encountered entry by the compare exchange
 			// So, this returns a nullptr if it was empty, and a non-null if it was not (which cancels the insert)
 			return expected_entry.GetPointerOrNull();
 		} else {
 			// At this point we know that the keys match, so we can try to insert until we succeed
-			ht_entry_t expected_entry = entry.load(std::memory_order_relaxed);
+			ht_entry_t expected_entry = entry.load(std::memory_order_acquire);
 			D_ASSERT(expected_entry.IsOccupied());
 			do {
 				data_ptr_t current_row_pointer = expected_entry.GetPointer();
@@ -926,7 +926,7 @@ static void InsertHashesLoop(unsafe_optional_ptr<atomic<ht_entry_t>> entries, Ve
 			bool occupied;
 			while (true) {
 				atomic<ht_entry_t> &atomic_entry = entries.get()[ht_offset];
-				entry = atomic_entry.load(std::memory_order_relaxed);
+				entry = atomic_entry.load(std::memory_order_acquire);
 				occupied = entry.IsOccupied();
 
 				// condition for incrementing the ht_offset: occupied and row_salt does not match -> move to next entry

--- a/src/execution/operator/persistent/physical_copy_to_file.cpp
+++ b/src/execution/operator/persistent/physical_copy_to_file.cpp
@@ -1528,7 +1528,7 @@ void CopyFileLifecycleExecutor::WaitAll(CopyFileLifecycleWaitMode mode) {
 		ThrowError();
 		return;
 	}
-	while (pending_tasks.load(std::memory_order_relaxed) > 0) {
+	while (pending_tasks.load(std::memory_order_acquire) > 0) {
 		context.InterruptCheck();
 		WorkOnTaskOrYield();
 	}

--- a/src/function/scalar/operator/arithmetic.cpp
+++ b/src/function/scalar/operator/arithmetic.cpp
@@ -1317,7 +1317,30 @@ double InterpolateOperator::Operation(const double &lo, const double d, const do
 }
 
 static int64_t InterpolateInt64(int64_t lo, double d, int64_t hi) {
-	// long double can represent all int64 values exactly on x86-64 and aarch64
+	int64_t delta;
+	if (TrySubtractOperator::Operation(hi, lo, delta)) {
+		// the result stays within [lo, hi], so an exact integer computation cannot overflow and is
+		// platform-independent - unlike the floating point path below (long double is only 64 bits on MSVC)
+		const auto bound = static_cast<double>(delta);
+		const auto offset = bound * d;
+		if (delta >= 0) {
+			if (offset <= 0) {
+				return lo;
+			}
+			if (offset >= bound) {
+				return hi;
+			}
+		} else {
+			if (offset >= 0) {
+				return lo;
+			}
+			if (offset <= bound) {
+				return hi;
+			}
+		}
+		return lo + std::llround(offset);
+	}
+	// the delta overflows int64 - long double can represent all int64 values exactly on x86-64 and aarch64
 	const auto result = static_cast<long double>(lo) * (1.0L - static_cast<long double>(d)) +
 	                    static_cast<long double>(hi) * static_cast<long double>(d);
 	// casting an out-of-range floating point value to int64 is UB and platform-dependent

--- a/src/function/scalar/operator/arithmetic.cpp
+++ b/src/function/scalar/operator/arithmetic.cpp
@@ -1316,14 +1316,29 @@ double InterpolateOperator::Operation(const double &lo, const double d, const do
 	return lo * (1.0 - d) + hi * d;
 }
 
+static int64_t InterpolateInt64(int64_t lo, double d, int64_t hi) {
+	// long double can represent all int64 values exactly on x86-64 and aarch64
+	const auto result = static_cast<long double>(lo) * (1.0L - static_cast<long double>(d)) +
+	                    static_cast<long double>(hi) * static_cast<long double>(d);
+	// casting an out-of-range floating point value to int64 is UB and platform-dependent
+	// (x86 cvttsd2si yields the integer indefinite value, ARM fcvtzs saturates) - clamp first
+	if (result >= static_cast<long double>(NumericLimits<int64_t>::Maximum())) {
+		return NumericLimits<int64_t>::Maximum();
+	}
+	if (result <= static_cast<long double>(NumericLimits<int64_t>::Minimum())) {
+		return NumericLimits<int64_t>::Minimum();
+	}
+	return std::llround(result);
+}
+
 template <>
 dtime_t InterpolateOperator::Operation(const dtime_t &lo, const double d, const dtime_t &hi) {
-	return dtime_t(std::llround(static_cast<double>(lo.value) * (1.0 - d) + static_cast<double>(hi.value) * d));
+	return dtime_t(InterpolateInt64(lo.value, d, hi.value));
 }
 
 template <>
 timestamp_t InterpolateOperator::Operation(const timestamp_t &lo, const double d, const timestamp_t &hi) {
-	return timestamp_t(std::llround(static_cast<double>(lo.value) * (1.0 - d) + static_cast<double>(hi.value) * d));
+	return timestamp_t(InterpolateInt64(lo.value, d, hi.value));
 }
 
 template <>

--- a/src/function/window/window_value_function.cpp
+++ b/src/function/window/window_value_function.cpp
@@ -617,6 +617,19 @@ unique_ptr<LocalSinkState> WindowLeadLagExecutor::GetLocal(ExecutionContext &con
 	return make_uniq<WindowLeadLagLocalState>(context, glstate);
 }
 
+static int64_t LeadLagRowIndex(int64_t base, int64_t offset, const ExpressionType &type) {
+	// a row index is always non-negative, so the adjustment can only overflow upwards - saturate instead of
+	// throwing, an out-of-range index just lands outside the partition and yields the default
+	int64_t val_idx;
+	bool in_range;
+	if (type == ExpressionType::WINDOW_LEAD) {
+		in_range = TryAddOperator::Operation(base, offset, val_idx);
+	} else {
+		in_range = TrySubtractOperator::Operation(base, offset, val_idx);
+	}
+	return in_range ? val_idx : NumericLimits<int64_t>::Maximum();
+}
+
 void WindowLeadLagExecutor::GetData(ExecutionContext &context, DataChunk &eval_chunk, DataChunk &bounds, Vector &result,
                                     idx_t row_idx, OperatorSinkInput &sink) {
 	auto &glstate = sink.global_state.Cast<WindowLeadLagGlobalState>();
@@ -657,12 +670,7 @@ void WindowLeadLagExecutor::GetData(ExecutionContext &context, DataChunk &eval_c
 			frame = FrameBounds(frame_begin[i], MaxValue(frame_end[i], frame_begin[i]));
 			const auto own_row = glstate.row_tree->Rank(frame.start, frame.end, row_idx) - 1;
 			// (2) adjust the row number by adding or subtracting an offset
-			auto val_idx = NumericCast<int64_t>(own_row);
-			if (wexpr.GetExpressionType() == ExpressionType::WINDOW_LEAD) {
-				val_idx = AddOperatorOverflowCheck::Operation<int64_t, int64_t, int64_t>(val_idx, offset);
-			} else {
-				val_idx = SubtractOperatorOverflowCheck::Operation<int64_t, int64_t, int64_t>(val_idx, offset);
-			}
+			auto val_idx = LeadLagRowIndex(NumericCast<int64_t>(own_row), offset, wexpr.GetExpressionType());
 			const auto frame_width = NumericCast<int64_t>(frame.end - frame.start);
 			if (val_idx >= 0 && val_idx < frame_width) {
 				// (3) find the row at that offset
@@ -716,12 +724,7 @@ void WindowLeadLagExecutor::GetData(ExecutionContext &context, DataChunk &eval_c
 			}
 			offset = leadlag_offset.GetCell<int64_t>(i);
 		}
-		int64_t val_idx = (int64_t)row_idx;
-		if (wexpr.GetExpressionType() == ExpressionType::WINDOW_LEAD) {
-			val_idx = AddOperatorOverflowCheck::Operation<int64_t, int64_t, int64_t>(val_idx, offset);
-		} else {
-			val_idx = SubtractOperatorOverflowCheck::Operation<int64_t, int64_t, int64_t>(val_idx, offset);
-		}
+		int64_t val_idx = LeadLagRowIndex(NumericCast<int64_t>(row_idx), offset, wexpr.GetExpressionType());
 
 		idx_t delta = 0;
 		if (val_idx < (int64_t)row_idx) {

--- a/src/function/window/window_value_function.cpp
+++ b/src/function/window/window_value_function.cpp
@@ -362,6 +362,10 @@ public:
 				return false;
 			}
 			offset = bigint_value->GetValue<int64_t>();
+			if (offset == NumericLimits<int64_t>::Minimum()) {
+				// negating/taking the absolute value of INT64_MIN would overflow - do not stream
+				return false;
+			}
 		}
 
 		//	We can only support LEAD and LAG values within one standard vector

--- a/src/include/duckdb/common/operator/cast_operators.hpp
+++ b/src/include/duckdb/common/operator/cast_operators.hpp
@@ -483,7 +483,7 @@ DUCKDB_API bool TryCast::Operation(double input, double &result, bool strict);
 static inline bool TryCastStringBool(const char *input_data, idx_t input_size, bool &result, bool strict) {
 	switch (input_size) {
 	case 1: {
-		unsigned char c = static_cast<uint8_t>(std::tolower(*input_data));
+		unsigned char c = static_cast<uint8_t>(std::tolower(static_cast<unsigned char>(*input_data)));
 		if (c == 't' || (!strict && c == 'y') || (!strict && c == '1')) {
 			result = true;
 			return true;
@@ -494,8 +494,8 @@ static inline bool TryCastStringBool(const char *input_data, idx_t input_size, b
 		return false;
 	}
 	case 2: {
-		unsigned char n = static_cast<uint8_t>(std::tolower(input_data[0]));
-		unsigned char o = static_cast<uint8_t>(std::tolower(input_data[1]));
+		unsigned char n = static_cast<uint8_t>(std::tolower(static_cast<unsigned char>(input_data[0])));
+		unsigned char o = static_cast<uint8_t>(std::tolower(static_cast<unsigned char>(input_data[1])));
 		if (n == 'n' && o == 'o') {
 			result = false;
 			return true;
@@ -503,9 +503,9 @@ static inline bool TryCastStringBool(const char *input_data, idx_t input_size, b
 		return false;
 	}
 	case 3: {
-		unsigned char y = static_cast<uint8_t>(std::tolower(input_data[0]));
-		unsigned char e = static_cast<uint8_t>(std::tolower(input_data[1]));
-		unsigned char s = static_cast<uint8_t>(std::tolower(input_data[2]));
+		unsigned char y = static_cast<uint8_t>(std::tolower(static_cast<unsigned char>(input_data[0])));
+		unsigned char e = static_cast<uint8_t>(std::tolower(static_cast<unsigned char>(input_data[1])));
+		unsigned char s = static_cast<uint8_t>(std::tolower(static_cast<unsigned char>(input_data[2])));
 		if (y == 'y' && e == 'e' && s == 's') {
 			result = true;
 			return true;
@@ -513,10 +513,10 @@ static inline bool TryCastStringBool(const char *input_data, idx_t input_size, b
 		return false;
 	}
 	case 4: {
-		unsigned char t = static_cast<uint8_t>(std::tolower(input_data[0]));
-		unsigned char r = static_cast<uint8_t>(std::tolower(input_data[1]));
-		unsigned char u = static_cast<uint8_t>(std::tolower(input_data[2]));
-		unsigned char e = static_cast<uint8_t>(std::tolower(input_data[3]));
+		unsigned char t = static_cast<uint8_t>(std::tolower(static_cast<unsigned char>(input_data[0])));
+		unsigned char r = static_cast<uint8_t>(std::tolower(static_cast<unsigned char>(input_data[1])));
+		unsigned char u = static_cast<uint8_t>(std::tolower(static_cast<unsigned char>(input_data[2])));
+		unsigned char e = static_cast<uint8_t>(std::tolower(static_cast<unsigned char>(input_data[3])));
 		if (t == 't' && r == 'r' && u == 'u' && e == 'e') {
 			result = true;
 			return true;
@@ -524,11 +524,11 @@ static inline bool TryCastStringBool(const char *input_data, idx_t input_size, b
 		return false;
 	}
 	case 5: {
-		unsigned char f = static_cast<uint8_t>(std::tolower(input_data[0]));
-		unsigned char a = static_cast<uint8_t>(std::tolower(input_data[1]));
-		unsigned char l = static_cast<uint8_t>(std::tolower(input_data[2]));
-		unsigned char s = static_cast<uint8_t>(std::tolower(input_data[3]));
-		unsigned char e = static_cast<uint8_t>(std::tolower(input_data[4]));
+		unsigned char f = static_cast<uint8_t>(std::tolower(static_cast<unsigned char>(input_data[0])));
+		unsigned char a = static_cast<uint8_t>(std::tolower(static_cast<unsigned char>(input_data[1])));
+		unsigned char l = static_cast<uint8_t>(std::tolower(static_cast<unsigned char>(input_data[2])));
+		unsigned char s = static_cast<uint8_t>(std::tolower(static_cast<unsigned char>(input_data[3])));
+		unsigned char e = static_cast<uint8_t>(std::tolower(static_cast<unsigned char>(input_data[4])));
 		if (f == 'f' && a == 'a' && l == 'l' && s == 's' && e == 'e') {
 			result = false;
 			return true;

--- a/src/include/duckdb/common/operator/interpolate.hpp
+++ b/src/include/duckdb/common/operator/interpolate.hpp
@@ -19,7 +19,18 @@ struct InterpolateOperator {
 	template <typename TARGET_TYPE>
 	static inline TARGET_TYPE Operation(const TARGET_TYPE &lo, const double d, const TARGET_TYPE &hi) {
 		const auto delta = static_cast<double>(hi) - static_cast<double>(lo);
-		return LossyNumericCast<TARGET_TYPE>(static_cast<double>(lo) + delta * d);
+		const auto result = static_cast<double>(lo) + delta * d;
+		// casting an out-of-range double to an integer is UB and platform-dependent
+		// (x86 cvttsd2si yields the integer indefinite value, ARM fcvtzs saturates) - clamp first.
+		// for int64/uint64 the bound rounds up to exactly 2^63/2^64 in double, so every
+		// representable-in-double in-range value still passes through unchanged.
+		if (result >= static_cast<double>(NumericLimits<TARGET_TYPE>::Maximum())) {
+			return NumericLimits<TARGET_TYPE>::Maximum();
+		}
+		if (result <= static_cast<double>(NumericLimits<TARGET_TYPE>::Minimum())) {
+			return NumericLimits<TARGET_TYPE>::Minimum();
+		}
+		return LossyNumericCast<TARGET_TYPE>(result);
 	}
 };
 

--- a/src/include/duckdb/common/operator/numeric_cast.hpp
+++ b/src/include/duckdb/common/operator/numeric_cast.hpp
@@ -48,6 +48,12 @@ static bool TryCastWithOverflowCheck(SRC value, DST &result) {
 
 		// SRC is unsigned.
 		if (NumericLimits<SRC>::Digits() >= NumericLimits<DST>::Digits()) {
+			// the bounds of a floating point DST are infinite - converting them to SRC is UB,
+			// and every SRC value fits magnitude-wise anyway
+			if (!NumericLimits<DST>::IsIntegral()) {
+				result = static_cast<DST>(value);
+				return true;
+			}
 			if (value <= static_cast<SRC>(NumericLimits<DST>::Maximum())) {
 				result = static_cast<DST>(value);
 				return true;
@@ -64,6 +70,12 @@ static bool TryCastWithOverflowCheck(SRC value, DST &result) {
 		return true;
 	}
 
+	// the bounds of a floating point DST are infinite - converting them to SRC is UB,
+	// and every SRC value fits magnitude-wise anyway
+	if (!NumericLimits<DST>::IsIntegral()) {
+		result = static_cast<DST>(value);
+		return true;
+	}
 	if (value < SRC(NumericLimits<DST>::Minimum()) || value > SRC(NumericLimits<DST>::Maximum())) {
 		return false;
 	}

--- a/src/include/duckdb/common/types/cast_helpers.hpp
+++ b/src/include/duckdb/common/types/cast_helpers.hpp
@@ -35,7 +35,7 @@ public:
 	template <class SIGNED, class UNSIGNED>
 	static int SignedLength(SIGNED value) {
 		int sign = -(value < 0);
-		UNSIGNED unsigned_value = UnsafeNumericCast<UNSIGNED>((value ^ sign) - sign);
+		UNSIGNED unsigned_value = UNSIGNED(value ^ sign) + UNSIGNED(AbsValue(sign));
 		return UnsignedLength(unsigned_value) - sign;
 	}
 

--- a/src/include/duckdb/storage/compression/alp/algorithm/alp.hpp
+++ b/src/include/duckdb/storage/compression/alp/algorithm/alp.hpp
@@ -395,20 +395,19 @@ struct AlpDecompression {
 		AlpEncodingIndices encoding_indices = {vector_exponent, vector_factor};
 
 		// Bit Unpacking
-		uint8_t for_decoded[AlpConstants::ALP_VECTOR_SIZE * 8] = {0};
+		uint64_t for_decoded[AlpConstants::ALP_VECTOR_SIZE] = {0};
 		if (bit_width > 0) {
-			BitpackingPrimitives::UnPackBuffer<uint64_t>(for_decoded, for_encoded, count, bit_width);
+			BitpackingPrimitives::UnPackBuffer<uint64_t>(data_ptr_cast(for_decoded), for_encoded, count, bit_width);
 		}
-		auto *encoded_integers = reinterpret_cast<uint64_t *>(data_ptr_cast(for_decoded));
 
 		// unFOR
 		for (idx_t i = 0; i < count; i++) {
-			encoded_integers[i] += frame_of_reference;
+			for_decoded[i] += frame_of_reference;
 		}
 
 		// Decoding
 		for (idx_t i = 0; i < count; i++) {
-			auto encoded_integer = static_cast<int64_t>(encoded_integers[i]);
+			auto encoded_integer = static_cast<int64_t>(for_decoded[i]);
 			output[i] = alp::AlpCompression<T, true>::DecodeValue(encoded_integer, encoding_indices);
 		}
 

--- a/src/include/duckdb/storage/compression/alprd/algorithm/alprd.hpp
+++ b/src/include/duckdb/storage/compression/alprd/algorithm/alprd.hpp
@@ -48,8 +48,8 @@ public:
 	uint8_t right_bit_width; // 'right' & 'left' refer to the respective parts of the floating numbers after splitting
 	uint8_t left_bit_width;
 	uint16_t exceptions_count;
-	uint8_t right_parts_encoded[AlpRDConstants::ALP_VECTOR_SIZE * 8];
-	uint8_t left_parts_encoded[AlpRDConstants::ALP_VECTOR_SIZE * 8];
+	uint32_t right_parts_encoded[AlpRDConstants::ALP_VECTOR_SIZE * 2];
+	uint16_t left_parts_encoded[AlpRDConstants::ALP_VECTOR_SIZE * 4];
 	uint16_t left_parts_dict[AlpRDConstants::MAX_DICTIONARY_SIZE];
 	uint16_t exceptions[AlpRDConstants::ALP_VECTOR_SIZE];
 	uint16_t exceptions_positions[AlpRDConstants::ALP_VECTOR_SIZE];
@@ -198,10 +198,10 @@ struct AlpRDCompression {
 
 		if (!EMPTY) {
 			// Bitpacking Left and Right parts
-			BitpackingPrimitives::PackBuffer<uint16_t, false>(compression_data.left_parts_encoded, left_parts, n_values,
-			                                                  compression_data.left_bit_width);
-			BitpackingPrimitives::PackBuffer<uint64_t, false>(compression_data.right_parts_encoded, right_parts,
-			                                                  n_values, compression_data.right_bit_width);
+			BitpackingPrimitives::PackBuffer<uint16_t, false>(data_ptr_cast(compression_data.left_parts_encoded),
+			                                                  left_parts, n_values, compression_data.left_bit_width);
+			BitpackingPrimitives::PackBuffer<uint64_t, false>(data_ptr_cast(compression_data.right_parts_encoded),
+			                                                  right_parts, n_values, compression_data.right_bit_width);
 		}
 
 		compression_data.left_bit_packed_size = left_bit_packed_size;
@@ -217,26 +217,25 @@ struct AlpRDDecompression {
 	                       EXACT_TYPE *output, idx_t values_count, uint16_t exceptions_count,
 	                       const uint16_t *exceptions, const uint16_t *exceptions_positions, uint8_t left_bit_width,
 	                       uint8_t right_bit_width) {
-		uint8_t left_decoded[AlpRDConstants::ALP_VECTOR_SIZE * 8] = {0};
-		uint8_t right_decoded[AlpRDConstants::ALP_VECTOR_SIZE * 8] = {0};
+		uint16_t left_decoded[AlpRDConstants::ALP_VECTOR_SIZE] = {0};
+		EXACT_TYPE right_decoded[AlpRDConstants::ALP_VECTOR_SIZE] = {0};
 
 		// Bitunpacking left and right parts
-		BitpackingPrimitives::UnPackBuffer<uint16_t>(left_decoded, left_encoded, values_count, left_bit_width);
-		BitpackingPrimitives::UnPackBuffer<EXACT_TYPE>(right_decoded, right_encoded, values_count, right_bit_width);
-
-		uint16_t *left_parts = reinterpret_cast<uint16_t *>(data_ptr_cast(left_decoded));
-		EXACT_TYPE *right_parts = reinterpret_cast<EXACT_TYPE *>(data_ptr_cast(right_decoded));
+		BitpackingPrimitives::UnPackBuffer<uint16_t>(data_ptr_cast(left_decoded), left_encoded, values_count,
+		                                             left_bit_width);
+		BitpackingPrimitives::UnPackBuffer<EXACT_TYPE>(data_ptr_cast(right_decoded), right_encoded, values_count,
+		                                               right_bit_width);
 
 		// Decoding
 		for (idx_t i = 0; i < values_count; i++) {
-			uint16_t left = left_parts_dict[left_parts[i]];
-			EXACT_TYPE right = right_parts[i];
+			uint16_t left = left_parts_dict[left_decoded[i]];
+			EXACT_TYPE right = right_decoded[i];
 			output[i] = (static_cast<EXACT_TYPE>(left) << right_bit_width) | right;
 		}
 
 		// Exceptions Patching (exceptions only occur in left parts)
 		for (idx_t i = 0; i < exceptions_count; i++) {
-			EXACT_TYPE right = right_parts[exceptions_positions[i]];
+			EXACT_TYPE right = right_decoded[exceptions_positions[i]];
 			uint16_t left = exceptions[i];
 			output[exceptions_positions[i]] = (static_cast<EXACT_TYPE>(left) << right_bit_width) | right;
 		}

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -440,7 +440,7 @@ LogicalType DBConfig::ParseLogicalType(const string &type) {
 		}
 		idx_t array_size = 0;
 		for (auto length_idx = bracket_open_idx + 1; length_idx < type.size() - 1; length_idx++) {
-			if (!isdigit(type[length_idx])) {
+			if (!isdigit(static_cast<unsigned char>(type[length_idx]))) {
 				throw InternalException("Ill formatted array type: '%s'", type);
 			}
 			array_size = array_size * 10 + static_cast<idx_t>(type[length_idx] - '0');
@@ -736,7 +736,12 @@ optional_idx DBConfig::ParseMemoryLimitSlurm(const string &arg) {
 	if (limit < 0) {
 		return static_cast<idx_t>(NumericLimits<int64_t>::Maximum());
 	}
-	idx_t actual_limit = LossyNumericCast<idx_t>(static_cast<double>(multiplier) * limit);
+	idx_t actual_limit;
+	if (limit > static_cast<double>(NumericLimits<idx_t>::Maximum()) / static_cast<double>(multiplier)) {
+		actual_limit = NumericLimits<idx_t>::Maximum();
+	} else {
+		actual_limit = LossyNumericCast<idx_t>(static_cast<double>(multiplier) * limit);
+	}
 	if (actual_limit == NumericLimits<idx_t>::Maximum()) {
 		return static_cast<idx_t>(NumericLimits<int64_t>::Maximum());
 	}

--- a/src/main/extension/extension_load.cpp
+++ b/src/main/extension/extension_load.cpp
@@ -767,7 +767,7 @@ string ExtensionHelper::ExtractExtensionPrefixFromPath(const string &path) {
 	D_ASSERT(extension.size() > 1);
 	// needs to be alphanumeric
 	for (auto &ch : extension) {
-		if (!isalnum(ch) && ch != '_') {
+		if (!isalnum(static_cast<unsigned char>(ch)) && ch != '_') {
 			return "";
 		}
 	}

--- a/src/main/http/http_util.cpp
+++ b/src/main/http/http_util.cpp
@@ -348,7 +348,7 @@ struct URISchemeDetectionResult {
 };
 
 bool IsValidSchemeChar(char c) {
-	return std::isalnum(c) || c == '+' || c == '.' || c == '-';
+	return std::isalnum(static_cast<unsigned char>(c)) || c == '+' || c == '.' || c == '-';
 }
 
 //! See https://datatracker.ietf.org/doc/html/rfc3986#section-3.1
@@ -363,7 +363,7 @@ URISchemeDetectionResult DetectURIScheme(const string &uri) {
 		return result;
 	}
 
-	if (!std::isalpha(uri[0])) {
+	if (!std::isalpha(static_cast<unsigned char>(uri[0]))) {
 		//! Scheme names consist of a sequence of characters beginning with a letter
 		result.lower_scheme = "";
 		result.scheme_type = URISchemeType::NONE;

--- a/src/main/user_settings.cpp
+++ b/src/main/user_settings.cpp
@@ -146,7 +146,7 @@ CachedGlobalSettings &GlobalUserSettings::GetSettings() const {
 	thread_local CachedGlobalSettings current_cache;
 #endif
 
-	const auto current_version = settings_version.load(std::memory_order_relaxed);
+	const auto current_version = settings_version.load(std::memory_order_acquire);
 	if (!current_cache.global_user_settings || this != current_cache.global_user_settings.get() ||
 	    current_cache.uuid != uuid || current_cache.version != current_version) {
 		// out-of-date, refresh the cache

--- a/test/common/test_string_util.cpp
+++ b/test/common/test_string_util.cpp
@@ -527,3 +527,16 @@ TEST_CASE("Test JSON Parsing", "[string_util]") {
 	}
 	)JSON_LITERAL");
 }
+
+TEST_CASE("Test CIHash is independent of char signedness", "[string_util]") {
+	// bytes >= 0x80 must be zero-extended before hashing so the result is identical
+	// on platforms where char is signed (x86) and where it is unsigned (ARM)
+	const char high_byte[] = {(char)0xC3, 0};
+	REQUIRE(StringUtil::CIHash(high_byte, 1) == 2242087697ULL);
+
+	const char cafe_utf8[] = "Caf\xC3\xA9";
+	REQUIRE(StringUtil::CIHash(cafe_utf8, strlen(cafe_utf8)) == 2425794034ULL);
+
+	// ASCII is unaffected
+	REQUIRE(StringUtil::CIHash("hello") == StringUtil::CIHash("HeLLo"));
+}

--- a/test/sql/aggregate/aggregates/test_equi_width_bins_bounds.test
+++ b/test/sql/aggregate/aggregates/test_equi_width_bins_bounds.test
@@ -1,0 +1,35 @@
+# name: test/sql/aggregate/aggregates/test_equi_width_bins_bounds.test
+# description: Test equi_width_bins edge cases - a bin count much larger than the range must error instead of looping forever
+# group: [aggregates]
+
+require 64bit
+
+# bin_count far exceeds the integer span: the internal step truncates to 0.
+# This must raise an error - a step of 0 previously caused an infinite loop
+# that could not be interrupted (no InterruptCheck inside the loop).
+statement error
+SELECT equi_width_bins(0, 1, 1000000, false)
+----
+bin count
+
+statement error
+SELECT equi_width_bins(0, 1, 1000000, true)
+----
+bin count
+
+# timestamp inputs delegate to the integer path
+statement error
+SELECT equi_width_bins(TIMESTAMP '2020-01-01', TIMESTAMP '2020-01-01 00:00:00.0005', 1000000, false)
+----
+bin count
+
+# reasonable bin counts for the same range still work
+query I
+SELECT equi_width_bins(0, 1, 1, false)
+----
+[1]
+
+query I
+SELECT equi_width_bins(0, 10, 5, false)
+----
+[2, 4, 6, 8, 10]

--- a/test/sql/aggregate/aggregates/test_quantile_cont_bounds.test
+++ b/test/sql/aggregate/aggregates/test_quantile_cont_bounds.test
@@ -1,0 +1,28 @@
+# name: test/sql/aggregate/aggregates/test_quantile_cont_bounds.test
+# description: Test QUANTILE_CONT interpolation at timestamp bounds - llround of an out-of-range double is UB (x86 yields INT64_MIN, ARM saturates)
+# group: [aggregates]
+
+require 64bit
+
+# Median of two identical near-max timestamps is the timestamp itself, not +/-infinity.
+# The interpolation computes lo*(1-d)+hi*d in double, which rounds up to 2^63 here;
+# casting that back to int64 overflows without a clamp.
+query T
+SELECT quantile_cont(y, 0.5) FROM
+	(VALUES (make_timestamp(9223372036854775806::BIGINT)), (make_timestamp(9223372036854775806::BIGINT))) t(y);
+----
+294247-01-10 04:00:54.775806
+
+# Interpolation between two distinct near-max timestamps stays finite
+query T
+SELECT quantile_cont(y, 0.5) FROM
+	(VALUES (make_timestamp(9223372036854775800::BIGINT)), (make_timestamp(9223372036854775806::BIGINT))) t(y);
+----
+294247-01-10 04:00:54.775803
+
+# Ordinary timestamp quantiles are unaffected
+query T
+SELECT quantile_cont(y, 0.5) FROM
+	(VALUES (TIMESTAMP '2020-01-01 00:00:00'), (TIMESTAMP '2020-01-03 00:00:00')) t(y);
+----
+2020-01-02 00:00:00

--- a/test/sql/cast/test_boolean_cast.test
+++ b/test/sql/cast/test_boolean_cast.test
@@ -225,3 +225,15 @@ SELECT CAST(CAST('0' AS UHUGEINT) AS BOOLEAN)
 ----
 0
 
+
+# non-ASCII input bytes go through case folding - must be handled as unsigned char
+# (UB on signed-char platforms otherwise)
+statement error
+SELECT CAST('é' AS BOOLEAN)
+----
+Could not convert string
+
+query I
+SELECT TRY_CAST('trué' AS BOOLEAN)
+----
+NULL

--- a/test/sql/function/operator/test_bitwise_ops.test
+++ b/test/sql/function/operator/test_bitwise_ops.test
@@ -77,3 +77,14 @@ statement error
 SELECT 2::UINT32 << 31
 ----
 Overflow in left shift
+
+# shifting 0 by the type width is defined (previously UB in the shift itself)
+query I
+SELECT 0::UBIGINT << 64
+----
+0
+
+query I
+SELECT 0::BIGINT << 64
+----
+0

--- a/test/sql/window/test_fill_bounds.test
+++ b/test/sql/window/test_fill_bounds.test
@@ -1,0 +1,73 @@
+# name: test/sql/window/test_fill_bounds.test
+# description: Test FILL interpolation at the bounds of the value type - interpolation must not overflow when converting back from floating point
+# group: [window]
+
+require 64bit
+
+# Interpolating BIGINT values near INT64_MAX: the midpoint is INT64_MAX itself.
+# The double representation of INT64_MAX rounds up to 2^63, which is out of range
+# for int64 - the cast back must clamp/exactly convert, not overflow.
+# (Overflow here is UB: x86 cvttsd2si yields INT64_MIN, ARM fcvtzs saturates.)
+query II
+SELECT x, fill(y ORDER BY x) OVER () FROM
+	(VALUES (0::BIGINT, 9223372036854775807::BIGINT), (1::BIGINT, NULL::BIGINT), (2::BIGINT, 9223372036854775807::BIGINT)) t(x,y)
+ORDER BY x;
+----
+0	9223372036854775807
+1	9223372036854775807
+2	9223372036854775807
+
+# Same at the lower bound - INT64_MIN is exactly representable in double
+query II
+SELECT x, fill(y ORDER BY x) OVER () FROM
+	(VALUES (0::BIGINT, (-9223372036854775807 - 1)::BIGINT), (1::BIGINT, NULL::BIGINT), (2::BIGINT, (-9223372036854775807 - 1)::BIGINT)) t(x,y)
+ORDER BY x;
+----
+0	-9223372036854775808
+1	-9223372036854775808
+2	-9223372036854775808
+
+# UBIGINT near UINT64_MAX - the double representation of UINT64_MAX rounds up to 2^64
+query II
+SELECT x, fill(y ORDER BY x) OVER () FROM
+	(VALUES (0::UBIGINT, 18446744073709551615::UBIGINT), (1::UBIGINT, NULL::UBIGINT), (2::UBIGINT, 18446744073709551615::UBIGINT)) t(x,y)
+ORDER BY x;
+----
+0	18446744073709551615
+1	18446744073709551615
+2	18446744073709551615
+
+# TIMESTAMP near the maximum finite value - fill binds TIMESTAMP as its INT64 physical type,
+# and the double midpoint of two near-max values rounds up to 2^63. The cast back must clamp
+# (to the +infinity sentinel) instead of overflowing: x86 cvttsd2si would produce INT64_MIN
+# (-infinity), ARM fcvtzs saturates to INT64_MAX (infinity) - after the fix both agree.
+query II
+SELECT x, fill(y ORDER BY x) OVER () FROM
+	(VALUES (0::BIGINT, make_timestamp(9223372036854775806::BIGINT)), (1::BIGINT, NULL::TIMESTAMP), (2::BIGINT, make_timestamp(9223372036854775806::BIGINT))) t(x,y)
+ORDER BY x;
+----
+0	294247-01-10 04:00:54.775806
+1	infinity
+2	294247-01-10 04:00:54.775806
+
+# Interpolation between two distinct large timestamps: both round to 2^63 in double,
+# so the interpolated value clamps to the +infinity sentinel on every platform
+query II
+SELECT x, fill(y ORDER BY x) OVER () FROM
+	(VALUES (0::BIGINT, make_timestamp(9223372036854775800::BIGINT)), (1::BIGINT, NULL::TIMESTAMP), (2::BIGINT, make_timestamp(9223372036854775806::BIGINT))) t(x,y)
+ORDER BY x;
+----
+0	294247-01-10 04:00:54.7758
+1	infinity
+2	294247-01-10 04:00:54.775806
+
+# Ordinary interpolation is unaffected
+query II
+SELECT x, fill(y ORDER BY x) OVER () FROM
+	(VALUES (0::BIGINT, 10::BIGINT), (1::BIGINT, NULL::BIGINT), (2::BIGINT, NULL::BIGINT), (3::BIGINT, 40::BIGINT)) t(x,y)
+ORDER BY x;
+----
+0	10
+1	20
+2	30
+3	40

--- a/test/sql/window/test_lead_lag_bounds.test
+++ b/test/sql/window/test_lead_lag_bounds.test
@@ -1,0 +1,44 @@
+# name: test/sql/window/test_lead_lag_bounds.test
+# description: Test LEAD/LAG with offset at the bounds of BIGINT
+# group: [window]
+
+require 64bit
+
+# INT64_MIN offset: negating/abs of INT64_MIN is UB, so the streaming path must decline it
+# and fall back to the (range-checked) non-streaming path. LAG computes i - offset which
+# overflows for INT64_MIN and reports it:
+statement error
+SELECT lag(v, (-9223372036854775807 - 1)::BIGINT, -1) OVER (ORDER BY i) FROM (VALUES (1, 10), (2, 20)) t(i, v)
+----
+Out of Range Error
+
+# LEAD computes i + offset which stays in range, so every row lands out of partition -> default
+query II
+SELECT i, lead(v, (-9223372036854775807 - 1)::BIGINT, -1) OVER (ORDER BY i) FROM (VALUES (1, 10), (2, 20), (3, 30)) t(i, v) ORDER BY i
+----
+1	-1
+2	-1
+3	-1
+
+# INT64_MAX offset is fine - exceeds the partition so every row gets the default
+query II
+SELECT i, lead(v, 9223372036854775807::BIGINT, -1) OVER (ORDER BY i) FROM (VALUES (1, 10), (2, 20), (3, 30)) t(i, v) ORDER BY i
+----
+1	-1
+2	-1
+3	-1
+
+query II
+SELECT i, lag(v, 9223372036854775807::BIGINT, -1) OVER (ORDER BY i) FROM (VALUES (1, 10), (2, 20), (3, 30)) t(i, v) ORDER BY i
+----
+1	-1
+2	-1
+3	-1
+
+# ordinary offsets are unaffected
+query III
+SELECT i, lag(v, 1) OVER (ORDER BY i), lead(v, 1) OVER (ORDER BY i) FROM (VALUES (1, 10), (2, 20), (3, 30)) t(i, v) ORDER BY i
+----
+1	NULL	20
+2	10	30
+3	20	NULL

--- a/test/sql/window/test_lead_lag_bounds.test
+++ b/test/sql/window/test_lead_lag_bounds.test
@@ -5,12 +5,13 @@
 require 64bit
 
 # INT64_MIN offset: negating/abs of INT64_MIN is UB, so the streaming path must decline it
-# and fall back to the (range-checked) non-streaming path. LAG computes i - offset which
-# overflows for INT64_MIN and reports it:
-statement error
-SELECT lag(v, (-9223372036854775807 - 1)::BIGINT, -1) OVER (ORDER BY i) FROM (VALUES (1, 10), (2, 20)) t(i, v)
+# and fall back to the non-streaming path. LAG computes i - offset which overflows for
+# INT64_MIN - the index saturates and every row lands out of partition -> default
+query II
+SELECT i, lag(v, (-9223372036854775807 - 1)::BIGINT, -1) OVER (ORDER BY i) FROM (VALUES (1, 10), (2, 20)) t(i, v) ORDER BY i
 ----
-Out of Range Error
+1	-1
+2	-1
 
 # LEAD computes i + offset which stays in range, so every row lands out of partition -> default
 query II


### PR DESCRIPTION
# ARM64 portability hardening: fix UB in interpolation, binning hang, and hot-path code

Fixes #24871

This PR is the result of an aarch64 (ARM64) portability audit of the codebase. Six risk categories were audited in depth (char signedness, float→int conversion, platform intrinsics, atomics/memory ordering, alignment/aliasing, shift/division edge cases). Full test suite passes on aarch64 (4949 test cases, 978k assertions); the targeted reproducers below were additionally verified clean under ASan+UBSan.

## Bug fixes (with reproducers, see the linked issue)

- **`equi_width_bins` infinite loop** — the integer path hung forever when the bin step truncated to 0 (`bin_count` much larger than the range, or `min == max`), and the loop has no `InterruptCheck`, so `max_execution_time` could not abort it. Now throws `InvalidInputException`. The double path's internal error for the same condition is replaced by the same user-facing exception.
- **Window `FILL` interpolation overflow** — casting the interpolated double back to int64/uint64 is UB at the type bounds and diverges across platforms (x86 `cvttsd2si` yields the integer-indefinite value, ARM `fcvtzs` saturates), e.g. filling between two `INT64_MAX` values produced `INT64_MIN` on x86. Now clamps to the target range before casting; in-range results are bit-identical to before.
- **`quantile_cont` over TIMESTAMP** — same overflow via `llround`; both platforms returned the wrong infinity sentinel and disagreed with each other. Now interpolates in `long double` (exact for int64 on both x86-64 and aarch64) and clamps, returning the mathematically correct finite timestamp.
- **`lead`/`lag` with INT64_MIN offset** — negation and `abs` of INT64_MIN are UB in the streaming path; the offset is now declined there (the range-checked non-streaming path handles it as before).

## Hardening (no feasible reproducer; UB removal or ARM memory-model correctness)

- **Join hash table**: the entry-publishing CAS used `memory_order_acquire` on success, which does not order the payload stores before the pointer publication on ARM's weak memory model (x86's `lock cmpxchg` is a full fence and hides this). Changed to release/acquire, matching the sibling CAS; related entry loads upgraded to acquire.
- **ALP/ALPRD decompression** (and ALPRD compression scratch): `uint8_t` buffers were written/read through `uint16_t`/`uint32_t`/`uint64_t` pointers (strict-aliasing + alignment UB). Buffers are now properly typed; byte size unchanged.
- **`Checksum()`** and **UUIDv4 generation**: raw wide loads/stores through `reinterpret_cast` replaced with the existing memcpy-based `Load`/`Store` helpers (same codegen).
- **`StringUtil::CIHash`**: bytes ≥ 0x80 were sign-extended on signed-char platforms (x86) and zero-extended on ARM, so hashes of non-ASCII identifiers differed across platforms. Now consistently zero-extended (matches the existing ARM behavior).
- **ctype hardening**: `std::tolower`/`isdigit`/`isalnum`/`isalpha` called with plain `char` (UB for negative values on signed-char platforms) — now cast through `unsigned char` (`TryCastStringBool`, array-size parsing, extension-prefix parsing, URI scheme detection).
- **`NumericHelper::SignedLength`**: signed overflow for INT64_MIN — now computed in unsigned, mirroring the sibling `FormatSigned`.
- **Left shift**: `0::UBIGINT << 64` reached a shift by the type width (UB) — early-out for zero input.
- **`TryCastWithOverflowCheck`**: converting infinite floating-point bounds to integer types is UB (currently rescued by constant folding) — the comparison is now skipped for non-integral destinations, which is semantically a no-op.
- **SLURM memory-limit parsing**: guard the double→`idx_t` conversion against overflow from pathological env values.
- Relaxed loads tightened to acquire in `CopyFileLifecycleExecutor::WaitAll` and the `GlobalUserSettings` version gate (publication safety on ARM).

## Tests

New sqllogictests: `test/sql/window/test_fill_bounds.test`, `test/sql/window/test_lead_lag_bounds.test`, `test/sql/aggregate/aggregates/test_quantile_cont_bounds.test`, `test/sql/aggregate/aggregates/test_equi_width_bins_bounds.test` (this one hangs pre-fix, so it necessarily ships with the fix). Lock-in cases added to `test_bitwise_ops.test` and `test_boolean_cast.test`. New C++ unit test for `CIHash` platform independence in `test/common/test_string_util.cpp`.

## Notes for reviewers

- The two interpolation fixes deliberately differ: the generic integer path keeps double arithmetic (so every in-range result is bit-identical to before — no behavior change for existing queries) and only clamps out-of-range results; the `timestamp_t`/`dtime_t` specializations use `long double`, which additionally recovers the mathematically correct answer at the boundary (e.g. the median of two identical near-max timestamps is that timestamp, not an infinity sentinel).
- The join-HT memory-ordering change is a no-op on x86 (`lock cmpxchg` is already a full fence) and zero-cost on ARM64 (LSE `casal` vs `casa`).
- Areas audited and found clean (no changes needed): x86/SIMD intrinsics guards, INT_MIN ÷ −1 and abs(INT_MIN) for all widths, SQL-level float→int casts (`TryCastWithOverflowCheckFloat` is properly bounds-checked), the `Load`/`Store` helpers themselves, and string hashing alignment.
