### PR TITLE
Prevent volatile  predicates from being pushed below window operators

### DIFF
--- a/src/optimizer/pushdown/pushdown_window.cpp
+++ b/src/optimizer/pushdown/pushdown_window.cpp
@@ -79,7 +79,7 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownWindow(unique_ptr<LogicalOpe
 		// the filter must be on all partition bindings
 		vector<ColumnBinding> bindings;
 		ExtractFilterBindings(*filters.at(i)->filter, bindings);
-		if (CanPushdownFilter(window_exprs_partition_bindings, bindings)) {
+		if (CanPushdownFilter(window_exprs_partition_bindings, bindings) && !filters.at(i)->filter->IsVolatile()) {
 			pushdown.filters.push_back(std::move(filters.at(i)));
 		} else {
 			leftover_filters.push_back(std::move(filters.at(i)));

--- a/test/issues/general/test_24829.test
+++ b/test/issues/general/test_24829.test
@@ -1,0 +1,34 @@
+# name: test/issues/general/test_24829.test
+# description: Volatile QUALIFY predicates remain above window aggregates
+# group: [general]
+
+statement ok
+CREATE TABLE window_input(p INTEGER, id INTEGER, x INTEGER);
+
+statement ok
+INSERT INTO window_input VALUES (1, 1, 10), (1, 2, 20), (1, 3, 30), (1, 4, 40);
+
+statement ok
+CREATE SEQUENCE qualify_sequence START 1;
+
+query IIII
+SELECT p, id, x, SUM(x) OVER (PARTITION BY p) AS partition_sum
+FROM window_input
+QUALIFY nextval('qualify_sequence') <= 2
+ORDER BY id;
+----
+1	1	10	100
+1	2	20	100
+
+statement ok
+CREATE SEQUENCE partition_qualify_sequence START 1;
+
+# Volatile predicates cannot move below the window even if they only reference partition columns
+query II
+SELECT id, SUM(x) OVER (PARTITION BY p) AS partition_sum
+FROM window_input
+QUALIFY nextval('partition_qualify_sequence') <= p + 1
+ORDER BY id;
+----
+1	100
+2	100


### PR DESCRIPTION
Fix #24829

The reported bug affected volatile predicates in a `QUALIFY` clause placed above a partitioned window function.

For example, the reported query computed `SUM(x) OVER (PARTITION BY p)` and then filtered the result with `QUALIFY nextval('sequence') <= 2`

Semantically, the window function must first process every row in the partition. The volatile `QUALIFY` predicate should then decide which completed result rows are returned. Therefore, with values `10, 20, 30, 40`, the window sum should be `100`, even if only the first two rows survive the filter.

With filter pushdown enabled, DuckDB incorrectly moved the volatile predicate below the window operator. The window consequently saw only `10` and `20` and returned `30`. Disabling the optimizer kept the filter above the window and produced the correct result, `100`.

The problem was in `FilterPushdown::PushdownWindow`. Its eligibility test only checked whether all columns referenced by a predicate were window partition columns. This is valid for stable predicates: a condition based only on partition keys selects or rejects an entire partition without changing its window results.

However, that reasoning does not apply to volatile functions such as `nextval()` or `random()`. Their results can change for every row, even when the predicate references no columns or only partition columns. The optimizer therefore violated its implicit assumption that an eligible predicate is constant within each partition.

### Fix
The fix adds the missing volatility condition `CanPushdownFilter(window_exprs_partition_bindings, bindings) && !filter->IsVolatile()`

This is deliberately narrow. It does not disable filter pushdown or exit the window optimization rule. Stable predicates are still pushed down normally, while only the individual volatile predicate remains above the window. The existing inexpensive column-binding check is performed first, so DuckDB only traverses the expression tree to check volatility for predicates that would otherwise qualify for pushdown.