### PR TITLE
Fix  with argument ordering to correctly handle frames that exclude the current row

### DIFF
--- a/src/function/window/window_rownumber_function.cpp
+++ b/src/function/window/window_rownumber_function.cpp
@@ -194,7 +194,8 @@ void WindowRowNumberExecutor::GetData(ExecutionContext &context, DataChunk &eval
 			}
 		} else {
 			for (idx_t i = 0; i < count; ++i, ++row_idx) {
-				rdata.WriteValue(UnsafeNumericCast<int64_t>(row_idx - frame_begin[i] + 1));
+				const auto frame_idx = MaxValue(frame_begin[i], MinValue(row_idx, frame_end[i]));
+				rdata.WriteValue(UnsafeNumericCast<int64_t>(frame_idx - frame_begin[i] + 1));
 			}
 		}
 		return;

--- a/test/issues/general/test_24828.test
+++ b/test/issues/general/test_24828.test
@@ -1,0 +1,14 @@
+# name: test/issues/general/test_24828.test
+# description: Issue 24828 - ROW_NUMBER argument order with a frame excluding the current row
+# group: [general]
+
+query III
+WITH t(id, x) AS (VALUES (1, 10), (2, 20))
+SELECT id,
+       ROW_NUMBER(ORDER BY x) OVER (ORDER BY x ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING),
+       ROW_NUMBER(ORDER BY x) OVER (ORDER BY x ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING)
+FROM t
+ORDER BY id;
+----
+1	1	1
+2	1	1


### PR DESCRIPTION
Fix #24828 

### Problem

This PR addresses an incorrect result in DuckDB’s argument-ordered `ROW_NUMBER` window function. The problematic query used an argument order and a window frame that excluded the current row:

```
  ROW_NUMBER(ORDER BY x) OVER (
      ORDER BY x
      ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING
  )
```

DuckDB returned `0`, while disabling the optimizer correctly returned `1`.

The issue was caused by an execution optimization. When the argument order matched the window order, DuckDB avoided building a separate ranking tree and calculated the row number using `row_idx - frame_begin + 1`

This calculation assumed that the current row was always inside the frame and ignored the frame’s upper boundary. Consequently, a following frame could produce zero or unsigned-integer underflow, while a preceding frame could produce a rank larger than the frame allowed.

### Fix

The fix preserves the optimization but clamps the current row’s position to both frame boundaries before calculating its rank `const auto frame_idx = MaxValue(frame_begin[i], MinValue(row_idx, frame_end[i]));`

This makes the optimized calculation equivalent to the general ranking-tree implementation for frames before, after, around, or excluding the current row—including empty and reversed frames.