### PR TITLE
Always quote identifiers in error messages

### DIFF
--- a/.github/config/extensions/aws.cmake
+++ b/.github/config/extensions/aws.cmake
@@ -3,5 +3,6 @@ if (NOT MINGW AND NOT ${WASM_ENABLED})
             LOAD_TESTS
             GIT_URL https://github.com/duckdb/duckdb-aws
             GIT_TAG 6c044194df8f9fa6ebc4365aa11c75095c1d5ef2
+            APPLY_PATCHES
             )
 endif()

--- a/.github/patches/extensions/avro/0002-identifier-quoting-in-error-messages.patch
+++ b/.github/patches/extensions/avro/0002-identifier-quoting-in-error-messages.patch
@@ -16,7 +16,7 @@ index 91a3526..8b9a6b5 100644
  	}
  	if (!unrecognized_options.empty()) {
 diff --git a/test/sql/copy/invalid_option.test b/test/sql/copy/invalid_option.test
-index ad94908..9a1f044 100644
+index ad94908..b97e2ef 100644
 --- a/test/sql/copy/invalid_option.test
 +++ b/test/sql/copy/invalid_option.test
 @@ -11,7 +11,7 @@ COPY (
@@ -28,3 +28,9 @@ index ad94908..9a1f044 100644
  
  statement error
  COPY (
+@@ -21,4 +21,4 @@ COPY (
+ 	ROOT_NAME 'test'
+ );
+ ----
+-Invalid Configuration Error: The following option(s) are not recognized: key: 'not_recognized' with value: 'with_value'
++Invalid Configuration Error: The following option(s) are not recognized: key: "not_recognized" with value: 'with_value'

--- a/.github/patches/extensions/avro/0002-identifier-quoting-in-error-messages.patch
+++ b/.github/patches/extensions/avro/0002-identifier-quoting-in-error-messages.patch
@@ -1,0 +1,30 @@
+diff --git a/src/avro_copy.cpp b/src/avro_copy.cpp
+index 91a3526..8b9a6b5 100644
+--- a/src/avro_copy.cpp
++++ b/src/avro_copy.cpp
+@@ -545,10 +545,10 @@ WriteAvroBindData::WriteAvroBindData(CopyFunctionBindInput &input, const vector<
+ 		}
+ 		auto key = option.first;
+ 		if (option.second.empty()) {
+-			unrecognized_options.push_back(StringUtil::Format("key: '%s'", key));
++			unrecognized_options.push_back(StringUtil::Format("key: %s", key));
+ 		} else {
+ 			unrecognized_options.push_back(
+-			    StringUtil::Format("key: '%s' with value: '%s'", key, option.second[0].ToString()));
++			    StringUtil::Format("key: %s with value: '%s'", key, option.second[0].ToString()));
+ 		}
+ 	}
+ 	if (!unrecognized_options.empty()) {
+diff --git a/test/sql/copy/invalid_option.test b/test/sql/copy/invalid_option.test
+index ad94908..9a1f044 100644
+--- a/test/sql/copy/invalid_option.test
++++ b/test/sql/copy/invalid_option.test
+@@ -11,7 +11,7 @@ COPY (
+ 	ROOT_NAME 'test'
+ );
+ ----
+-Invalid Configuration Error: The following option(s) are not recognized: key: 'not_recognized'
++Invalid Configuration Error: The following option(s) are not recognized: key: "not_recognized"
+ 
+ statement error
+ COPY (

--- a/.github/patches/extensions/aws/0001-identifier-quoting-in-error-messages.patch
+++ b/.github/patches/extensions/aws/0001-identifier-quoting-in-error-messages.patch
@@ -1,0 +1,13 @@
+diff --git a/test/sql/aws_errors.test b/test/sql/aws_errors.test
+index 30d4f5a..2ee1d09 100644
+--- a/test/sql/aws_errors.test
++++ b/test/sql/aws_errors.test
+@@ -8,7 +8,7 @@ require no_extension_autoloading "EXPECTED: Test relies on explicit INSTALL and
+ statement error
+ create secret s1 (type s3, provider 'credential_chain');
+ ----
+-Invalid Input Error: Secret provider credential_chain for type s3 does not exist, but it exists in the aws extension.
++Invalid Input Error: Secret provider "credential_chain" for type "s3" does not exist, but it exists in the aws extension.
+ 
+ # Require statement will ensure this test is run with this extension loaded
+ require aws

--- a/.github/patches/extensions/ducklake/0008-identifier-quoting-in-error-messages.patch
+++ b/.github/patches/extensions/ducklake/0008-identifier-quoting-in-error-messages.patch
@@ -1,0 +1,77 @@
+diff --git a/src/storage/ducklake_view_entry.cpp b/src/storage/ducklake_view_entry.cpp
+index 834917ba..f5abed1f 100644
+--- a/src/storage/ducklake_view_entry.cpp
++++ b/src/storage/ducklake_view_entry.cpp
+@@ -79,7 +79,7 @@ unique_ptr<CatalogEntry> DuckLakeViewEntry::Alter(DuckLakeTransaction &transacti
+ 		if (!aliases.empty()) {
+ 			auto alias_entry = std::find_if(aliases.begin(), aliases.end(), match_name);
+ 			if (alias_entry == aliases.end()) {
+-				throw BinderException("View \"%s\" does not have a column with name \"%s\"", name,
++				throw BinderException("View %s does not have a column with name %s", name,
+ 				                      resolved_column_name);
+ 			}
+ 			auto alias_index = NumericCast<idx_t>(std::distance(aliases.begin(), alias_entry));
+@@ -88,7 +88,7 @@ unique_ptr<CatalogEntry> DuckLakeViewEntry::Alter(DuckLakeTransaction &transacti
+ 		} else {
+ 			auto entry = std::find_if(names.begin(), names.end(), match_name);
+ 			if (entry == names.end()) {
+-				throw BinderException("View \"%s\" does not have a column with name \"%s\"", name,
++				throw BinderException("View %s does not have a column with name %s", name,
+ 				                      resolved_column_name);
+ 			}
+ 			resolved_column_name = *entry;
+diff --git a/test/sql/alter/rename_column.test b/test/sql/alter/rename_column.test
+index a9c7570f..14a91294 100644
+--- a/test/sql/alter/rename_column.test
++++ b/test/sql/alter/rename_column.test
+@@ -47,4 +47,4 @@ NULL	3
+ statement error
+ ALTER TABLE ducklake.test RENAME COLUMN blablabla TO k
+ ----
+-column blablabla does not exist
++column "blablabla" does not exist
+diff --git a/src/storage/ducklake_insert.cpp b/src/storage/ducklake_insert.cpp
+--- a/src/storage/ducklake_insert.cpp
++++ b/src/storage/ducklake_insert.cpp
+@@ -302,7 +302,7 @@
+ 	    OnEntryNotFound::RETURN_NULL);
+ 	if (!entry) {
+ 		throw MissingExtensionException(
+-		    "Could not load the copy function for \"%s\". Try explicitly loading the \"%s\" extension", name, name);
++		    "Could not load the copy function for %s. Try explicitly loading the %s extension", name, name);
+ 	}
+ 	return *entry;
+ }
+diff --git a/src/storage/ducklake_table_entry.cpp b/src/storage/ducklake_table_entry.cpp
+--- a/src/storage/ducklake_table_entry.cpp
++++ b/src/storage/ducklake_table_entry.cpp
+@@ -835,8 +835,7 @@
+ 		if (info.if_column_exists) {
+ 			return nullptr;
+ 		}
+-		throw BinderException("Table \"%s\" does not have a column with name \"%s\"", name.GetIdentifierName(),
+-		                      info.removed_column.GetIdentifierName());
++		throw BinderException("Table %s does not have a column with name %s", name, info.removed_column);
+ 	}
+ 
+ 	auto &col = table_info.columns.GetColumn(info.removed_column);
+@@ -1070,8 +1069,7 @@
+ 	auto create_info = GetInfo();
+ 	auto &table_info = create_info->Cast<CreateTableInfo>();
+ 	if (!ColumnExists(info.column_name)) {
+-		throw BinderException("Table \"%s\" does not have a column with name \"%s\"", name.GetIdentifierName(),
+-		                      info.column_name.GetIdentifierName());
++		throw BinderException("Table %s does not have a column with name %s", name, info.column_name);
+ 	}
+ 	auto &col = table_info.columns.GetColumn(info.column_name);
+ 	auto &field_id = GetFieldId(col.Physical());
+@@ -1307,8 +1305,7 @@
+ 	auto create_info = GetInfo();
+ 	auto &table_info = create_info->Cast<CreateTableInfo>();
+ 	if (!ColumnExists(info.column_name)) {
+-		throw BinderException("Table \"%s\" does not have a column with name \"%s\"", name.GetIdentifierName(),
+-		                      info.column_name.GetIdentifierName());
++		throw BinderException("Table %s does not have a column with name %s", name, info.column_name);
+ 	}
+ 	auto &col = table_info.columns.GetColumnMutable(info.column_name);
+ 	auto &field_id = GetFieldId(col.Physical());

--- a/.github/patches/extensions/httpfs/0002-identifier-quoting-in-error-messages.patch
+++ b/.github/patches/extensions/httpfs/0002-identifier-quoting-in-error-messages.patch
@@ -1,0 +1,65 @@
+diff --git a/test/sql/secrets/create_secret_binding.test b/test/sql/secrets/create_secret_binding.test
+index 7e5a095..5843031 100644
+--- a/test/sql/secrets/create_secret_binding.test
++++ b/test/sql/secrets/create_secret_binding.test
+@@ -114,7 +114,7 @@ CREATE SECRET incorrect_type (
+     USE_SSL 'fliepflap'
+ )
+ ----
+-Binder Error: Failed to cast option 'use_ssl' to type 'BOOLEAN': 'Could not convert string 'fliepflap' to BOOL'
++Binder Error: Failed to cast option "use_ssl" to type 'BOOLEAN': 'Could not convert string 'fliepflap' to BOOL'
+ 
+ # Refresh mode values should be normalized before validation and not be used together
+ statement error
+diff --git a/test/sql/secrets/create_secret_name_conflicts.test b/test/sql/secrets/create_secret_name_conflicts.test
+index 5f23bbf..a537e61 100644
+--- a/test/sql/secrets/create_secret_name_conflicts.test
++++ b/test/sql/secrets/create_secret_name_conflicts.test
+@@ -15,7 +15,7 @@ CREATE TEMPORARY SECRET s1 ( TYPE S3 )
+ statement error
+ CREATE TEMPORARY SECRET s1 ( TYPE S3 )
+ ----
+-Invalid Input Error: Temporary secret with name 's1' already exists!
++Invalid Input Error: Temporary secret with name "s1" already exists!
+ 
+ statement ok
+ CREATE PERSISTENT SECRET s1 ( TYPE S3 )
+diff --git a/test/sql/secrets/create_secret_overwriting.test b/test/sql/secrets/create_secret_overwriting.test
+index 55caa6f..cc350f2 100644
+--- a/test/sql/secrets/create_secret_overwriting.test
++++ b/test/sql/secrets/create_secret_overwriting.test
+@@ -28,7 +28,7 @@ CREATE SECRET my_secret (
+     SCOPE 's3://bucket1'
+ )
+ ----
+-Invalid Input Error: Temporary secret with name 'my_secret' already exists!
++Invalid Input Error: Temporary secret with name "my_secret" already exists!
+ 
+ # We should be able to replace the secret though
+ statement ok
+diff --git a/test/sql/secrets/create_secret_persistence.test b/test/sql/secrets/create_secret_persistence.test
+index 4ffe766..a7920ae 100644
+--- a/test/sql/secrets/create_secret_persistence.test
++++ b/test/sql/secrets/create_secret_persistence.test
+@@ -63,7 +63,7 @@ CREATE PERSISTENT SECRET my_tmp_secret_3 (
+     SCOPE 's3://bucket3_not_used'
+ )
+ ----
+-Invalid Input Error: Persistent secret with name 'my_tmp_secret_3' already exists in secret storage 'local_file'!
++Invalid Input Error: Persistent secret with name "my_tmp_secret_3" already exists in secret storage 'local_file'!
+ 
+ restart
+ 
+diff --git a/test/sql/secrets/create_secret_r2.test b/test/sql/secrets/create_secret_r2.test
+index a9c48be..2eb0519 100644
+--- a/test/sql/secrets/create_secret_r2.test
++++ b/test/sql/secrets/create_secret_r2.test
+@@ -45,7 +45,7 @@ CREATE SECRET (
+     SECRET 'my_secret'
+ )
+ ----
+-Binder Error: Unknown parameter 'account_id' for secret type 's3' with default provider 'config'
++Binder Error: Unknown parameter "account_id" for secret type "s3" with default provider "config"
+ 
+ # Account ID is only for R2, trying to set this for GCS will fail
+ statement error

--- a/.github/patches/extensions/httpfs/0002-identifier-quoting-in-error-messages.patch
+++ b/.github/patches/extensions/httpfs/0002-identifier-quoting-in-error-messages.patch
@@ -1,5 +1,5 @@
 diff --git a/test/sql/secrets/create_secret_binding.test b/test/sql/secrets/create_secret_binding.test
-index 7e5a095..5843031 100644
+index 7e5a095..5592b5a 100644
 --- a/test/sql/secrets/create_secret_binding.test
 +++ b/test/sql/secrets/create_secret_binding.test
 @@ -114,7 +114,7 @@ CREATE SECRET incorrect_type (
@@ -11,8 +11,26 @@ index 7e5a095..5843031 100644
  
  # Refresh mode values should be normalized before validation and not be used together
  statement error
+@@ -140,7 +140,7 @@ CREATE SECRET incorrect_type (
+     FLIEPFLAP true
+ )
+ ----
+-Binder Error: Unknown parameter 'fliepflap' for secret type 'r2' with provider 'config'
++Binder Error: Unknown parameter "fliepflap" for secret type "r2" with provider "config"
+ 
+ # Incorrect param for this type, but correct for other
+ statement error
+@@ -150,7 +150,7 @@ CREATE SECRET incorrect_type (
+     ACCOUNT_ID 'my_acount'
+ )
+ ----
+-Binder Error: Unknown parameter 'account_id' for secret type 's3' with provider 'config'
++Binder Error: Unknown parameter "account_id" for secret type "s3" with provider "config"
+ 
+ # Params can only occur once
+ statement error
 diff --git a/test/sql/secrets/create_secret_name_conflicts.test b/test/sql/secrets/create_secret_name_conflicts.test
-index 5f23bbf..a537e61 100644
+index 5f23bbf..f701ecf 100644
 --- a/test/sql/secrets/create_secret_name_conflicts.test
 +++ b/test/sql/secrets/create_secret_name_conflicts.test
 @@ -15,7 +15,7 @@ CREATE TEMPORARY SECRET s1 ( TYPE S3 )
@@ -24,8 +42,41 @@ index 5f23bbf..a537e61 100644
  
  statement ok
  CREATE PERSISTENT SECRET s1 ( TYPE S3 )
+@@ -23,12 +23,12 @@ CREATE PERSISTENT SECRET s1 ( TYPE S3 )
+ statement error
+ CREATE PERSISTENT SECRET s1 ( TYPE S3 )
+ ----
+-Persistent secret with name 's1' already exists in secret storage 'local_file'!
++Persistent secret with name "s1" already exists in secret storage 'local_file'!
+ 
+ statement error
+ DROP SECRET s1;
+ ----
+-Invalid Input Error: Ambiguity found for secret name 's1', secret occurs in multiple storages
++Invalid Input Error: Ambiguity found for secret name "s1", secret occurs in multiple storages
+ 
+ statement error
+ DROP SECRET s1 FROM bogus;
+@@ -42,7 +42,7 @@ DROP TEMPORARY SECRET s1;
+ statement error
+ DROP TEMPORARY SECRET s1;
+ ----
+-Invalid Input Error: Failed to remove non-existent secret with name 's1'
++Invalid Input Error: Failed to remove non-existent secret with name "s1"
+ 
+ query II
+ SELECT name, storage FROM duckdb_secrets()
+@@ -62,7 +62,7 @@ CREATE TEMPORARY SECRET s1 ( TYPE S3 )
+ statement error
+ DROP SECRET s1;
+ ----
+-Invalid Input Error: Ambiguity found for secret name 's1', secret occurs in multiple storages
++Invalid Input Error: Ambiguity found for secret name "s1", secret occurs in multiple storages
+ 
+ # Fully specified drop statement this time
+ statement ok
 diff --git a/test/sql/secrets/create_secret_overwriting.test b/test/sql/secrets/create_secret_overwriting.test
-index 55caa6f..cc350f2 100644
+index 55caa6f..684b6ce 100644
 --- a/test/sql/secrets/create_secret_overwriting.test
 +++ b/test/sql/secrets/create_secret_overwriting.test
 @@ -28,7 +28,7 @@ CREATE SECRET my_secret (
@@ -37,8 +88,17 @@ index 55caa6f..cc350f2 100644
  
  # We should be able to replace the secret though
  statement ok
+@@ -58,7 +58,7 @@ my_secret	['s3://bucket2']
+ statement error
+ DROP SECRET my_secret_does_not_exist;
+ ----
+-Failed to remove non-existent secret with name 'my_secret_does_not_exist'
++Failed to remove non-existent secret with name "my_secret_does_not_exist"
+ 
+ # Drop one that does exist
+ statement ok
 diff --git a/test/sql/secrets/create_secret_persistence.test b/test/sql/secrets/create_secret_persistence.test
-index 4ffe766..a7920ae 100644
+index 4ffe766..e02dcac 100644
 --- a/test/sql/secrets/create_secret_persistence.test
 +++ b/test/sql/secrets/create_secret_persistence.test
 @@ -63,7 +63,7 @@ CREATE PERSISTENT SECRET my_tmp_secret_3 (
@@ -50,8 +110,17 @@ index 4ffe766..a7920ae 100644
  
  restart
  
+@@ -77,7 +77,7 @@ CREATE PERSISTENT SECRET my_tmp_secret_3 (
+     SCOPE 's3://bucket3_not_used'
+ )
+ ----
+-Invalid Input Error: Persistent secret with name 'my_tmp_secret_3' already exists in secret storage 'local_file'!
++Invalid Input Error: Persistent secret with name "my_tmp_secret_3" already exists in secret storage 'local_file'!
+ 
+ restart
+ 
 diff --git a/test/sql/secrets/create_secret_r2.test b/test/sql/secrets/create_secret_r2.test
-index a9c48be..2eb0519 100644
+index a9c48be..785acaf 100644
 --- a/test/sql/secrets/create_secret_r2.test
 +++ b/test/sql/secrets/create_secret_r2.test
 @@ -45,7 +45,7 @@ CREATE SECRET (
@@ -63,3 +132,12 @@ index a9c48be..2eb0519 100644
  
  # Account ID is only for R2, trying to set this for GCS will fail
  statement error
+@@ -57,7 +57,7 @@ CREATE SECRET (
+     SECRET 'my_secret'
+ )
+ ----
+-Binder Error: Unknown parameter 'account_id' for secret type 'gcs' with provider 'config'
++Binder Error: Unknown parameter "account_id" for secret type "gcs" with provider "config"
+ 
+ # Ensure secret lookup works correctly;
+ statement ok

--- a/.github/patches/extensions/httpfs/0002-identifier-quoting-in-error-messages.patch
+++ b/.github/patches/extensions/httpfs/0002-identifier-quoting-in-error-messages.patch
@@ -30,7 +30,7 @@ index 7e5a095..5592b5a 100644
  # Params can only occur once
  statement error
 diff --git a/test/sql/secrets/create_secret_name_conflicts.test b/test/sql/secrets/create_secret_name_conflicts.test
-index 5f23bbf..f701ecf 100644
+index 5f23bbf..8ef9f4a 100644
 --- a/test/sql/secrets/create_secret_name_conflicts.test
 +++ b/test/sql/secrets/create_secret_name_conflicts.test
 @@ -15,7 +15,7 @@ CREATE TEMPORARY SECRET s1 ( TYPE S3 )
@@ -42,7 +42,7 @@ index 5f23bbf..f701ecf 100644
  
  statement ok
  CREATE PERSISTENT SECRET s1 ( TYPE S3 )
-@@ -23,12 +23,12 @@ CREATE PERSISTENT SECRET s1 ( TYPE S3 )
+@@ -23,17 +23,17 @@ CREATE PERSISTENT SECRET s1 ( TYPE S3 )
  statement error
  CREATE PERSISTENT SECRET s1 ( TYPE S3 )
  ----
@@ -57,6 +57,12 @@ index 5f23bbf..f701ecf 100644
  
  statement error
  DROP SECRET s1 FROM bogus;
+ ----
+-Invalid Input Error: Unknown storage type found for drop secret: 'bogus'
++Invalid Input Error: Unknown storage type found for drop secret: "bogus"
+ 
+ statement ok
+ DROP TEMPORARY SECRET s1;
 @@ -42,7 +42,7 @@ DROP TEMPORARY SECRET s1;
  statement error
  DROP TEMPORARY SECRET s1;

--- a/.github/patches/extensions/spatial/0006-identifier-quoting-in-error-messages.patch
+++ b/.github/patches/extensions/spatial/0006-identifier-quoting-in-error-messages.patch
@@ -1,0 +1,13 @@
+diff --git a/test/sql/index/rtree_persistence_load.test b/test/sql/index/rtree_persistence_load.test
+index 4da1f16..ebfaaa3 100644
+--- a/test/sql/index/rtree_persistence_load.test
++++ b/test/sql/index/rtree_persistence_load.test
+@@ -32,7 +32,7 @@ SET profiling_renderer_settings = MAP {'operator_casing': 'upper'};
+ statement error
+ DELETE FROM t1 WHERE rowid < 1000;
+ ----
+-Missing Extension Error: Cannot bind index 't1', unknown index type 'RTREE'. You need to load the extension that provides this index type before table 't1' can be modified.
++Missing Extension Error: Cannot bind index "t1", unknown index type 'RTREE'. You need to load the extension that provides this index type before table "t1" can be modified.
+ 
+ restart
+ 

--- a/extension/core_functions/scalar/array/array_functions.cpp
+++ b/extension/core_functions/scalar/array/array_functions.cpp
@@ -25,15 +25,15 @@ static unique_ptr<FunctionData> ArrayGenericBinaryBind(BindScalarFunctionInput &
 
 	if (bound_function.GetArguments()[0].id() != LogicalTypeId::ARRAY ||
 	    bound_function.GetArguments()[1].id() != LogicalTypeId::ARRAY) {
-		throw InvalidInputException(
-		    StringUtil::Format("%s: Arguments must be arrays of FLOAT or DOUBLE", bound_function.GetName()));
+		throw InvalidInputException(StringUtil::Format("%s: Arguments must be arrays of FLOAT or DOUBLE",
+		                                               SQLIdentifier(bound_function.GetName())));
 	}
 
 	const auto lhs_size = ArrayType::GetSize(bound_function.GetArguments()[0]);
 	const auto rhs_size = ArrayType::GetSize(bound_function.GetArguments()[1]);
 
 	if (lhs_size != rhs_size) {
-		throw BinderException("%s: Array arguments must be of the same size", bound_function.GetName());
+		throw BinderException("%s: Array arguments must be of the same size", SQLIdentifier(bound_function.GetName()));
 	}
 
 	const auto &lhs_element_type = ArrayType::GetChildType(bound_function.GetArguments()[0]);
@@ -43,12 +43,14 @@ static unique_ptr<FunctionData> ArrayGenericBinaryBind(BindScalarFunctionInput &
 	LogicalType common_type;
 	if (!LogicalType::TryGetMaxLogicalType(context, lhs_element_type, rhs_element_type, common_type)) {
 		throw BinderException("%s: Cannot infer common element type (left = '%s', right = '%s')",
-		                      bound_function.GetName(), lhs_element_type.ToString(), rhs_element_type.ToString());
+		                      SQLIdentifier(bound_function.GetName()), lhs_element_type.ToString(),
+		                      rhs_element_type.ToString());
 	}
 
 	// Ensure it is float or double
 	if (common_type.id() != LogicalTypeId::FLOAT && common_type.id() != LogicalTypeId::DOUBLE) {
-		throw BinderException("%s: Arguments must be arrays of FLOAT or DOUBLE", bound_function.GetName());
+		throw BinderException("%s: Arguments must be arrays of FLOAT or DOUBLE",
+		                      SQLIdentifier(bound_function.GetName()));
 	}
 
 	// The important part is just that we resolve the size of the input arrays
@@ -119,13 +121,14 @@ static void ArrayFixedCombine(DataChunk &args, ExpressionState &state, Vector &r
 
 		const auto left_offset = lhs_idx * N;
 		if (!lhs_child_validity.CheckAllValid(left_offset + N, left_offset)) {
-			throw InvalidInputException(StringUtil::Format("%s: left argument can not contain NULL values", func_name));
+			throw InvalidInputException(
+			    StringUtil::Format("%s: left argument can not contain NULL values", SQLIdentifier(func_name)));
 		}
 
 		const auto right_offset = rhs_idx * N;
 		if (!rhs_child_validity.CheckAllValid(right_offset + N, right_offset)) {
 			throw InvalidInputException(
-			    StringUtil::Format("%s: right argument can not contain NULL values", func_name));
+			    StringUtil::Format("%s: right argument can not contain NULL values", SQLIdentifier(func_name)));
 		}
 		const auto result_offset = i * N;
 
@@ -183,13 +186,14 @@ static void ArrayGenericFold(DataChunk &args, ExpressionState &state, Vector &re
 
 		const auto left_offset = lhs_idx * array_size;
 		if (!lhs_child_validity.CheckAllValid(left_offset + array_size, left_offset)) {
-			throw InvalidInputException(StringUtil::Format("%s: left argument can not contain NULL values", func_name));
+			throw InvalidInputException(
+			    StringUtil::Format("%s: left argument can not contain NULL values", SQLIdentifier(func_name)));
 		}
 
 		const auto right_offset = rhs_idx * array_size;
 		if (!rhs_child_validity.CheckAllValid(right_offset + array_size, right_offset)) {
 			throw InvalidInputException(
-			    StringUtil::Format("%s: right argument can not contain NULL values", func_name));
+			    StringUtil::Format("%s: right argument can not contain NULL values", SQLIdentifier(func_name)));
 		}
 
 		const auto lhs_data_ptr = lhs_data + left_offset;

--- a/extension/core_functions/scalar/debug/index_key.cpp
+++ b/extension/core_functions/scalar/debug/index_key.cpp
@@ -33,23 +33,20 @@ static TableDescription ExtractTableDescription(const child_list_t<LogicalType> 
 		auto field_name = StringUtil::Lower(field_types[i].first.GetIdentifierName());
 
 		if (fields.find(field_name) == fields.end()) {
-			throw BinderException("index_key: unknown field '%s' in path", field_types[i].first.GetIdentifierName());
+			throw BinderException("index_key: unknown field %s in path", field_types[i].first);
 		}
 
 		auto &field_value = field_values[i];
 		if (field_value.IsNull()) {
-			throw BinderException("index_key: path field '%s' cannot be NULL",
-			                      field_types[i].first.GetIdentifierName());
+			throw BinderException("index_key: path field %s cannot be NULL", field_types[i].first);
 		}
 		if (field_value.type().id() != LogicalTypeId::VARCHAR) {
-			throw BinderException("index_key: path field '%s' must be VARCHAR",
-			                      field_types[i].first.GetIdentifierName());
+			throw BinderException("index_key: path field %s must be VARCHAR", field_types[i].first);
 		}
 
 		auto value = StringValue::Get(field_value);
 		if (value.empty()) {
-			throw BinderException("index_key: path field '%s' cannot be empty",
-			                      field_types[i].first.GetIdentifierName());
+			throw BinderException("index_key: path field %s cannot be empty", field_types[i].first);
 		}
 		fields[field_name] = value;
 	}
@@ -92,12 +89,12 @@ static BoundIndex &FindBoundIndex(TableIndexList &index_list, const Identifier &
 	}
 
 	if (available.empty()) {
-		throw CatalogException("index_key: index '%s' was not found on table %s. No indexes found on this table.",
-		                       index_name.GetIdentifierName(), qualified_table);
+		throw CatalogException("index_key: index %s was not found on table %s. No indexes found on this table.",
+		                       index_name, qualified_table);
 	}
 	auto available_list = StringUtil::Join(available, ", ");
-	throw CatalogException("index_key: index '%s' was not found on table %s. Available indexes: %s",
-	                       index_name.GetIdentifierName(), qualified_table, available_list);
+	throw CatalogException("index_key: index %s was not found on table %s. Available indexes: %s", index_name,
+	                       qualified_table, available_list);
 }
 
 struct IndexKeyBindData : public FunctionData {

--- a/extension/core_functions/scalar/list/list_distance.cpp
+++ b/extension/core_functions/scalar/list/list_distance.cpp
@@ -33,11 +33,11 @@ static void ListGenericFold(DataChunk &args, ExpressionState &state, Vector &res
 	D_ASSERT(rhs_child.GetVectorType() == VectorType::FLAT_VECTOR);
 
 	if (!FlatVector::ValidityMutable(lhs_child).CheckAllValid(lhs_count)) {
-		throw InvalidInputException("%s: left argument can not contain NULL values", func_name);
+		throw InvalidInputException("%s: left argument can not contain NULL values", SQLIdentifier(func_name));
 	}
 
 	if (!FlatVector::ValidityMutable(rhs_child).CheckAllValid(rhs_count)) {
-		throw InvalidInputException("%s: right argument can not contain NULL values", func_name);
+		throw InvalidInputException("%s: right argument can not contain NULL values", SQLIdentifier(func_name));
 	}
 
 	auto lhs_data = FlatVector::GetData<TYPE>(lhs_child);
@@ -47,8 +47,8 @@ static void ListGenericFold(DataChunk &args, ExpressionState &state, Vector &res
 	    lhs_vec, rhs_vec, result, [&](const list_entry_t &left, const list_entry_t &right) -> optional<TYPE> {
 		    if (left.length != right.length) {
 			    throw InvalidInputException(
-			        "%s: list dimensions must be equal, got left length '%d' and right length '%d'", func_name,
-			        left.length, right.length);
+			        "%s: list dimensions must be equal, got left length '%d' and right length '%d'",
+			        SQLIdentifier(func_name), left.length, right.length);
 		    }
 
 		    if (!OP::ALLOW_EMPTY && left.length == 0) {

--- a/extension/core_functions/scalar/union/union_extract.cpp
+++ b/extension/core_functions/scalar/union/union_extract.cpp
@@ -88,7 +88,7 @@ unique_ptr<FunctionData> UnionExtractBind(BindScalarFunctionInput &input) {
 		}
 		auto closest_settings = StringUtil::TopNJaroWinkler(candidates, key);
 		auto message = StringUtil::CandidatesMessage(closest_settings, "Candidate Entries");
-		throw BinderException("Could not find key \"%s\" in union\n%s", key.GetIdentifierName(), message);
+		throw BinderException("Could not find key %s in union\n%s", key, message);
 	}
 
 	bound_function.SetReturnType(return_type);

--- a/extension/json/json_functions/copy_json.cpp
+++ b/extension/json/json_functions/copy_json.cpp
@@ -242,7 +242,7 @@ static BoundStatement CopyToJSONPlanInternal(Binder &binder, CopyStatement &stmt
 			csv_copy_options.insert(kv);
 		} else {
 			throw BinderException("Unknown option for COPY ... TO ... (FORMAT %s): %s.", GetJSONCopyFormatName(format),
-			                      option_name);
+			                      SQLIdentifier(option_name));
 		}
 	}
 	if (array_output) {

--- a/extension/tpch/dbgen/dbgen.cpp
+++ b/extension/tpch/dbgen/dbgen.cpp
@@ -792,8 +792,8 @@ static void ValidateTPCHTableSchema(const TableCatalogEntry &table, const string
 
 		if (column.Name() != Identifier(T::Columns[i])) {
 			throw InvalidInputException(
-			    "TPC-H table \"%s\" has an incompatible schema: expected column \"%s\" at position %llu but found \"%s\"",
-			    table_name, T::Columns[i], (unsigned long long)i, column.Name().GetIdentifierName());
+			    "TPC-H table \"%s\" has an incompatible schema: expected column \"%s\" at position %llu but found %s",
+			    table_name, T::Columns[i], (unsigned long long)i, column.Name());
 		}
 
 		if (column.Type() != T::Types[i]) {

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -105,7 +105,7 @@ optional_ptr<Catalog> Catalog::GetCatalogEntry(ClientContext &context, const Ide
 Catalog &Catalog::GetCatalog(CatalogEntryRetriever &retriever, const Identifier &catalog_name) {
 	auto catalog = Catalog::GetCatalogEntry(retriever, catalog_name);
 	if (!catalog) {
-		throw BinderException("Catalog \"%s\" does not exist!", catalog_name.GetIdentifierName());
+		throw BinderException("Catalog %s does not exist!", catalog_name);
 	}
 	return *catalog;
 }
@@ -476,7 +476,7 @@ static optional_ptr<SchemaCatalogEntry> NavigateNestedSchema(CatalogTransaction 
 	auto entry = parent.Cast<DuckSchemaEntry>().GetCatalogSet(CatalogType::SCHEMA_ENTRY).GetEntry(transaction, name);
 	if (!entry) {
 		if (if_not_found == OnEntryNotFound::THROW_EXCEPTION) {
-			throw CatalogException("Schema with name \"%s\" does not exist!", name.GetIdentifierName());
+			throw CatalogException("Schema with name %s does not exist!", name);
 		}
 		return nullptr;
 	}
@@ -1033,11 +1033,13 @@ static void ThrowDefaultTableAmbiguityException(CatalogEntryLookup &base_lookup,
 	auto entry_type = CatalogTypeToString(base_lookup.entry->type);
 	string fully_qualified_name_hint;
 	if (base_lookup.schema) {
-		fully_qualified_name_hint = StringUtil::Format(": '%s.%s.%s'", base_lookup.schema->catalog.GetName(),
-		                                               base_lookup.schema->name, base_lookup.entry->name);
+		fully_qualified_name_hint =
+		    StringUtil::Format(": '%s.%s.%s'", SQLIdentifier(base_lookup.schema->catalog.GetName()),
+		                       SQLIdentifier(base_lookup.schema->name), SQLIdentifier(base_lookup.entry->name));
 	}
-	string fully_qualified_catalog_name_hint = StringUtil::Format(
-	    ": '%s.%s.%s'", default_table.schema->catalog.GetName(), default_table.schema->name, default_table.entry->name);
+	string fully_qualified_catalog_name_hint =
+	    StringUtil::Format(": '%s.%s.%s'", SQLIdentifier(default_table.schema->catalog.GetName()),
+	                       SQLIdentifier(default_table.schema->name), SQLIdentifier(default_table.entry->name));
 	throw CatalogException(
 	    "Ambiguity detected for '%s': this could either refer to the '%s' '%s', or the "
 	    "attached catalog '%s' which has a default table. To avoid this error, either detach the catalog and "

--- a/src/catalog/catalog_entry/duck_schema_entry.cpp
+++ b/src/catalog/catalog_entry/duck_schema_entry.cpp
@@ -63,7 +63,7 @@ static void FindForeignKeyInformation(TableCatalogEntry &table, AlterForeignKeyT
 			                                                   alter_fk_type));
 		} else if (fk.info.type == ForeignKeyType::FK_TYPE_PRIMARY_KEY_TABLE &&
 		           alter_fk_type == AlterForeignKeyType::AFT_DELETE) {
-			throw CatalogException("Could not drop the table because this table is main key table of the table \"%s\"",
+			throw CatalogException("Could not drop the table because this table is main key table of the table %s",
 			                       fk.info.table);
 		}
 	}

--- a/src/catalog/catalog_entry/duck_table_entry.cpp
+++ b/src/catalog/catalog_entry/duck_table_entry.cpp
@@ -56,7 +56,7 @@ static void CheckTypeIsSupported(const LogicalType &logical_type, AttachedDataba
 				auto current = GetStorageVersionName(storage_version, false);
 
 				throw InvalidInputException("Aggregate state columns are not supported in storage versions prior to %s "
-				                            "(database \"%s\" is using storage version %s)",
+				                            "(database %s is using storage version %s)",
 				                            required, db.GetName(), current);
 			}
 			return false;
@@ -73,7 +73,7 @@ static void CheckTypeIsSupported(const LogicalType &logical_type, AttachedDataba
 				auto current = GetStorageVersionName(storage_version, false);
 
 				throw InvalidInputException("Empty STRUCT columns are not supported in storage versions prior to %s "
-				                            "(database \"%s\" is using storage version %s)",
+				                            "(database %s is using storage version %s)",
 				                            required, db.GetName(), current);
 			}
 			// an unnamed STRUCT is serialized identically to a TUPLE, so it must pass the same gate
@@ -82,7 +82,7 @@ static void CheckTypeIsSupported(const LogicalType &logical_type, AttachedDataba
 				auto current = GetStorageVersionName(storage_version, false);
 
 				throw InvalidInputException("TUPLE columns are not supported in storage versions prior to %s "
-				                            "(database \"%s\" is using storage version %s)",
+				                            "(database %s is using storage version %s)",
 				                            required, db.GetName(), current);
 			}
 		} break;
@@ -95,7 +95,7 @@ static void CheckTypeIsSupported(const LogicalType &logical_type, AttachedDataba
 				auto current = GetStorageVersionName(storage_version, false);
 
 				throw InvalidInputException("TUPLE columns are not supported in storage versions prior to %s "
-				                            "(database \"%s\" is using storage version %s)",
+				                            "(database %s is using storage version %s)",
 				                            required, db.GetName(), current);
 			}
 		} break;
@@ -107,7 +107,7 @@ static void CheckTypeIsSupported(const LogicalType &logical_type, AttachedDataba
 				auto current = GetStorageVersionName(storage_version, false);
 
 				throw InvalidInputException("VARIANT columns are not supported in storage versions prior to %s "
-				                            "(database \"%s\" is using storage version %s)",
+				                            "(database %s is using storage version %s)",
 				                            required, db.GetName(), current);
 			}
 		} break;
@@ -123,7 +123,7 @@ static void CheckTypeIsSupported(const LogicalType &logical_type, AttachedDataba
 				logger.WriteLog(DefaultLogType::NAME, LogLevel::LOG_WARNING,
 				                "GEOMETRY columns with coordinate reference system identifiers are not supported in "
 				                "storage versions prior "
-				                "to %s (database \"%s\" is using storage version %s). CRS will not be persisted.",
+				                "to %s (database %s is using storage version %s). CRS will not be persisted.",
 				                required, db.GetName(), current);
 			}
 		} break;
@@ -609,7 +609,7 @@ Value ConstructMapping(const Identifier &name, const LogicalType &type) {
 StructMappingInfo AddFieldToStruct(const LogicalType &type, const vector<Identifier> &column_path,
                                    const ColumnDefinition &new_field, idx_t depth = 0) {
 	if (!type.IsNested()) {
-		throw BinderException("Column '%s' is not a nested type, ADD COLUMN can only be used on nested types",
+		throw BinderException("Column %s is not a nested type, ADD COLUMN can only be used on nested types",
 		                      column_path[depth]);
 	}
 
@@ -628,7 +628,7 @@ StructMappingInfo AddFieldToStruct(const LogicalType &type, const vector<Identif
 		for (auto &entry : child_list) {
 			if (entry.first == new_field.Name()) {
 				// already exists!
-				result.error = ErrorData(CatalogException("Duplicate field \"%s\" - field already exists in struct %s",
+				result.error = ErrorData(CatalogException("Duplicate field %s - field already exists in struct %s",
 				                                          new_field.Name(), current_component));
 				return result;
 			}
@@ -738,7 +738,7 @@ void DuckTableEntry::UpdateConstraintsOnColumnDrop(const LogicalIndex &removed_i
 				if (bound_check.bound_columns.size() > 1) {
 					// CHECK constraint that concerns mult
 					throw CatalogException(
-					    "Cannot drop column \"%s\" because there is a CHECK constraint that depends on it",
+					    "Cannot drop column %s because there is a CHECK constraint that depends on it",
 					    info.removed_column);
 				} else {
 					// CHECK constraint that ONLY concerns this column, strip the constraint
@@ -756,7 +756,7 @@ void DuckTableEntry::UpdateConstraintsOnColumnDrop(const LogicalIndex &removed_i
 				// Single-column UNIQUE constraint
 				if (unique.GetIndex() == removed_index) {
 					throw CatalogException(
-					    "Cannot drop column \"%s\" because there is a UNIQUE constraint that depends on it",
+					    "Cannot drop column %s because there is a UNIQUE constraint that depends on it",
 					    info.removed_column);
 				}
 				unique.SetIndex(adjusted_indices[unique.GetIndex().index]);
@@ -766,9 +766,8 @@ void DuckTableEntry::UpdateConstraintsOnColumnDrop(const LogicalIndex &removed_i
 					if (col_name == info.removed_column) {
 						// Build constraint string for error message: UNIQUE(col1, col2, ...)
 						auto constraint_str = "UNIQUE(" + StringUtil::Join(unique.GetColumnNames(), ", ") + ")";
-						throw CatalogException(
-						    "Cannot drop column \"%s\" because it is referenced in unique constraint %s",
-						    info.removed_column, constraint_str);
+						throw CatalogException("Cannot drop column %s because it is referenced in unique constraint %s",
+						                       info.removed_column, constraint_str);
 					}
 				}
 			}
@@ -789,7 +788,7 @@ void DuckTableEntry::UpdateConstraintsOnColumnDrop(const LogicalIndex &removed_i
 			for (idx_t i = 0; i < columns.size(); i++) {
 				if (columns[i] == info.removed_column) {
 					throw CatalogException(
-					    "Cannot drop column \"%s\" because there is a FOREIGN KEY constraint that depends on it",
+					    "Cannot drop column %s because there is a FOREIGN KEY constraint that depends on it",
 					    info.removed_column);
 				}
 			}
@@ -862,7 +861,7 @@ struct DroppedFieldMapping {
 
 DroppedFieldMapping DropFieldFromStruct(const LogicalType &type, const vector<Identifier> &column_path, idx_t depth) {
 	if (!type.IsNested()) {
-		throw CatalogException("Cannot drop field from column \"%s\" - not a nested type", column_path[0]);
+		throw CatalogException("Cannot drop field from column %s - not a nested type", column_path[0]);
 	}
 	auto &dropped_entry = column_path[depth];
 	bool last_entry = depth + 1 == column_path.size();
@@ -880,9 +879,8 @@ DroppedFieldMapping DropFieldFromStruct(const LogicalType &type, const vector<Id
 			found = true;
 			if (last_entry) {
 				if (type.id() != LogicalTypeId::STRUCT) {
-					throw CatalogException("Cannot drop field '%s' from column '%s' - it's not a struct",
-					                       column_path.back().GetIdentifierName(),
-					                       column_path.front().GetIdentifierName());
+					throw CatalogException("Cannot drop field %s from column %s - it's not a struct",
+					                       column_path.back(), column_path.front());
 				}
 				// we are dropping this entry in its entirety - just skip
 				if (child_types.size() == 1) {
@@ -929,7 +927,7 @@ DroppedFieldMapping DropFieldFromStruct(const LogicalType &type, const vector<Id
 unique_ptr<CatalogEntry> DuckTableEntry::RemoveField(ClientContext &context, RemoveFieldInfo &info) {
 	if (!ColumnExists(info.column_path[0])) {
 		if (!info.if_column_exists) {
-			throw CatalogException("Cannot drop field from column \"%s\" - it does not exist", info.column_path[0]);
+			throw CatalogException("Cannot drop field from column %s - it does not exist", info.column_path[0]);
 		}
 		return nullptr;
 	}
@@ -960,7 +958,7 @@ unique_ptr<CatalogEntry> DuckTableEntry::RemoveField(ClientContext &context, Rem
 DroppedFieldMapping RenameFieldFromStruct(const LogicalType &type, const vector<Identifier> &column_path,
                                           const string &new_name, idx_t depth) {
 	if (!type.IsNested()) {
-		throw CatalogException("Cannot rename field from column \"%s\" - not a nested type", column_path[0]);
+		throw CatalogException("Cannot rename field from column %s - not a nested type", column_path[0]);
 	}
 	auto &rename_entry = column_path[depth];
 	bool last_entry = depth + 1 == column_path.size();
@@ -979,8 +977,8 @@ DroppedFieldMapping RenameFieldFromStruct(const LogicalType &type, const vector<
 			if (last_entry) {
 				if (type.id() != LogicalTypeId::STRUCT) {
 					throw CatalogException(
-					    "Cannot rename field '%s' from column '%s' - can only rename fields inside a struct",
-					    column_path.back().GetIdentifierName(), column_path.front().GetIdentifierName());
+					    "Cannot rename field %s from column %s - can only rename fields inside a struct",
+					    column_path.back(), column_path.front());
 				}
 				// we are renaming this entry
 				for (auto &sub_entry : child_types) {
@@ -1028,7 +1026,7 @@ DroppedFieldMapping RenameFieldFromStruct(const LogicalType &type, const vector<
 
 unique_ptr<CatalogEntry> DuckTableEntry::RenameField(ClientContext &context, RenameFieldInfo &info) {
 	if (!ColumnExists(info.column_path[0])) {
-		throw CatalogException("Cannot rename field from column \"%s\" - it does not exist", info.column_path[0]);
+		throw CatalogException("Cannot rename field from column %s - it does not exist", info.column_path[0]);
 	}
 
 	// follow the path
@@ -1063,7 +1061,7 @@ unique_ptr<CatalogEntry> DuckTableEntry::SetDefault(ClientContext &context, SetD
 	// Modify the column that was specified by 'column_name'
 	auto &col = table_info.columns.GetColumnMutable(default_idx);
 	if (col.Generated()) {
-		throw BinderException("Cannot SET DEFAULT for generated column \"%s\"", col.Name());
+		throw BinderException("Cannot SET DEFAULT for generated column %s", col.Name());
 	}
 	col.SetDefaultValue(info.expression ? info.expression->Copy() : nullptr);
 
@@ -1372,7 +1370,7 @@ unique_ptr<CatalogEntry> DuckTableEntry::AddConstraint(ClientContext &context, A
 
 		if (unique.is_primary_key && existing_pk) {
 			auto existing_name = existing_pk->ToString();
-			throw CatalogException("table \"%s\" can have only one primary key: %s", name, existing_name);
+			throw CatalogException("table %s can have only one primary key: %s", name, existing_name);
 		}
 		table_info.constraints.push_back(info.constraint->Copy());
 

--- a/src/catalog/catalog_entry/sequence_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/sequence_catalog_entry.cpp
@@ -67,7 +67,7 @@ int64_t SequenceCatalogEntry::NextValue(DuckTransaction &transaction) {
 		}
 	} else {
 		if (result < data.min_value || (overflow && data.increment < 0)) {
-			throw SequenceException("nextval: reached minimum value of sequence \"%s\" (%lld)", name, data.min_value);
+			throw SequenceException("nextval: reached minimum value of sequence %s (%lld)", name, data.min_value);
 		}
 		if (result > data.max_value || overflow) {
 			throw SequenceException("nextval: reached maximum value of sequence \"%s\" (%lld)", name, data.max_value);
@@ -85,7 +85,7 @@ int64_t SequenceCatalogEntry::SetValue(DuckTransaction &transaction, int64_t val
 	{
 		lock_guard<mutex> seqlock(lock);
 		if (value < data.min_value || value > data.max_value) {
-			throw SequenceException("setval: value %lld is out of bounds for sequence \"%s\" (%lld..%lld)", value, name,
+			throw SequenceException("setval: value %lld is out of bounds for sequence %s (%lld..%lld)", value, name,
 			                        data.min_value, data.max_value);
 		}
 

--- a/src/catalog/catalog_entry/table_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/table_catalog_entry.cpp
@@ -68,8 +68,7 @@ LogicalIndex TableCatalogEntry::GetColumnIndex(Identifier &column_name, bool if_
 		}
 		auto candidates =
 		    StringUtil::CandidatesErrorMessage(column_names, column_name.GetIdentifierName(), "Did you mean");
-		throw BinderException("Table \"%s\" does not have a column with name \"%s\"\n%s", name.GetIdentifierName(),
-		                      column_name, candidates);
+		throw BinderException("Table %s does not have a column with name %s\n%s", name, column_name, candidates);
 	}
 	return entry;
 }

--- a/src/catalog/catalog_entry/view_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/view_catalog_entry.cpp
@@ -88,8 +88,7 @@ unique_ptr<CatalogEntry> ViewCatalogEntry::AlterEntry(ClientContext &context, Al
 				// the column name might be a view alias - check those as well
 				auto alias_entry = std::find_if(aliases.begin(), aliases.end(), match_name);
 				if (alias_entry == aliases.end()) {
-					throw BinderException("View \"%s\" does not have a column with name \"%s\"",
-					                      name.GetIdentifierName(), resolved_column_name.GetIdentifierName());
+					throw BinderException("View %s does not have a column with name %s", name, resolved_column_name);
 				}
 				auto alias_index = NumericCast<idx_t>(std::distance(aliases.begin(), alias_entry));
 				D_ASSERT(alias_index < names.size());

--- a/src/catalog/catalog_search_path.cpp
+++ b/src/catalog/catalog_search_path.cpp
@@ -203,8 +203,8 @@ void CatalogSearchPath::Set(vector<CatalogSearchEntry> new_paths, CatalogSetPath
 	}
 	if (set_type == CatalogSetPathType::SET_SCHEMA) {
 		if (new_paths[0].GetCatalog() == TEMP_CATALOG || new_paths[0].GetCatalog() == SYSTEM_CATALOG) {
-			throw CatalogException("%s cannot be set to internal schema \"%s\"", GetSetName(set_type),
-			                       new_paths[0].GetCatalog().GetIdentifierName());
+			throw CatalogException("%s cannot be set to internal schema %s", GetSetName(set_type),
+			                       new_paths[0].GetCatalog());
 		}
 	}
 	SetPathsInternal(std::move(new_paths));

--- a/src/catalog/catalog_set.cpp
+++ b/src/catalog/catalog_set.cpp
@@ -144,10 +144,10 @@ void CatalogSet::CheckCatalogEntryInvariants(CatalogEntry &value, const Identifi
 			    name);
 		}
 		if (value.temporary && !catalog.IsTemporaryCatalog()) {
-			throw InternalException("Attempting to create temporary entry \"%s\" in non-temporary catalog", name);
+			throw InternalException("Attempting to create temporary entry %s in non-temporary catalog", name);
 		}
 		if (!value.temporary && catalog.IsTemporaryCatalog() && name != DEFAULT_SCHEMA) {
-			throw InvalidInputException("Cannot create non-temporary entry \"%s\" in temporary catalog", name);
+			throw InvalidInputException("Cannot create non-temporary entry %s in temporary catalog", name);
 		}
 	}
 }
@@ -232,7 +232,7 @@ optional_ptr<CatalogEntry> CatalogSet::GetEntryInternal(CatalogTransaction trans
 		// Another transaction has already made an edit to this catalog entry, because of limitations in the Catalog we
 		// can't create an edit alongside this even if the other transaction might end up getting aborted. So we have to
 		// abort the transaction.
-		throw TransactionException("Catalog write-write conflict on alter with \"%s\"", catalog_entry.name);
+		throw TransactionException("Catalog write-write conflict on alter with %s", catalog_entry.name);
 	}
 	// The entry is visible to our snapshot, check if it's deleted
 	if (catalog_entry.deleted) {
@@ -280,7 +280,7 @@ bool CatalogSet::RenameEntryInternal(CatalogTransaction transaction, CatalogEntr
 		if (!existing_entry.deleted) {
 			// There exists an entry by this name that is not deleted
 			old.UndoAlter(context, alter_info);
-			throw CatalogException("Could not rename \"%s\" to \"%s\": another entry with this name already exists!",
+			throw CatalogException("Could not rename %s to %s: another entry with this name already exists!",
 			                       original_name, new_name);
 		}
 	}
@@ -315,7 +315,7 @@ bool CatalogSet::AlterEntry(CatalogTransaction transaction, const Identifier &na
 		return false;
 	}
 	if (!alter_info.allow_internal && entry->internal) {
-		throw CatalogException("Cannot alter entry \"%s\" because it is an internal system entry", entry->name);
+		throw CatalogException("Cannot alter entry %s because it is an internal system entry", entry->name);
 	}
 
 	unique_ptr<CatalogEntry> value;
@@ -406,7 +406,7 @@ bool CatalogSet::DropDependencies(CatalogTransaction transaction, const Identifi
 		return false;
 	}
 	if (entry->internal && !allow_drop_internal) {
-		throw CatalogException("Cannot drop entry \"%s\" because it is an internal system entry", entry->name);
+		throw CatalogException("Cannot drop entry %s because it is an internal system entry", entry->name);
 	}
 	// check any dependencies of this object
 	D_ASSERT(entry->ParentCatalog().IsDuckCatalog());
@@ -423,7 +423,7 @@ bool CatalogSet::DropEntryInternal(CatalogTransaction transaction, const Identif
 		return false;
 	}
 	if (entry->internal && !allow_drop_internal) {
-		throw CatalogException("Cannot drop entry \"%s\" because it is an internal system entry", entry->name);
+		throw CatalogException("Cannot drop entry %s because it is an internal system entry", entry->name);
 	}
 
 	// create a new tombstone entry and replace the currently stored one

--- a/src/catalog/default/default_types.cpp
+++ b/src/catalog/default/default_types.cpp
@@ -587,7 +587,7 @@ LogicalType DefaultTypeGenerator::TryDefaultBind(const string &name, const vecto
 		if (params.empty()) {
 			return LogicalType(entry->type);
 		} else {
-			throw InvalidInputException("Type '%s' does not take any type parameters", name);
+			throw InvalidInputException("Type %s does not take any type parameters", name);
 		}
 	}
 

--- a/src/catalog/dependency_manager.cpp
+++ b/src/catalog/dependency_manager.cpp
@@ -310,8 +310,8 @@ void DependencyManager::CreateDependencies(CatalogTransaction transaction, const
 	for (auto &dependency : dependencies.Set()) {
 		if (dependency.catalog != object.ParentCatalog().GetName()) {
 			throw DependencyException(
-			    "Error adding dependency for object \"%s\" - dependency \"%s\" is in catalog "
-			    "\"%s\", which does not match the catalog \"%s\".\nCross catalog dependencies are not supported.",
+			    "Error adding dependency for object %s - dependency %s is in catalog "
+			    "%s, which does not match the catalog %s.\nCross catalog dependencies are not supported.",
 			    object.name, dependency.entry.name, dependency.catalog, object.ParentCatalog().GetName());
 		}
 	}
@@ -416,61 +416,61 @@ static string EntryToString(CatalogEntryInfo &info) {
 	auto type = info.type;
 	switch (type) {
 	case CatalogType::TABLE_ENTRY: {
-		return StringUtil::Format("table \"%s\"", info.name);
+		return StringUtil::Format("table %s", info.name);
 	}
 	case CatalogType::SCHEMA_ENTRY: {
-		return StringUtil::Format("schema \"%s\"", info.name);
+		return StringUtil::Format("schema %s", info.name);
 	}
 	case CatalogType::VIEW_ENTRY: {
-		return StringUtil::Format("view \"%s\"", info.name);
+		return StringUtil::Format("view %s", info.name);
 	}
 	case CatalogType::INDEX_ENTRY: {
-		return StringUtil::Format("index \"%s\"", info.name);
+		return StringUtil::Format("index %s", info.name);
 	}
 	case CatalogType::SEQUENCE_ENTRY: {
-		return StringUtil::Format("sequence \"%s\"", info.name);
+		return StringUtil::Format("sequence %s", info.name);
 	}
 	case CatalogType::COLLATION_ENTRY: {
-		return StringUtil::Format("collation \"%s\"", info.name);
+		return StringUtil::Format("collation %s", info.name);
 	}
 	case CatalogType::COORDINATE_SYSTEM_ENTRY: {
-		return StringUtil::Format("coordinate system \"%s\"", info.name);
+		return StringUtil::Format("coordinate system %s", info.name);
 	}
 	case CatalogType::TYPE_ENTRY: {
-		return StringUtil::Format("type \"%s\"", info.name);
+		return StringUtil::Format("type %s", info.name);
 	}
 	case CatalogType::TABLE_FUNCTION_ENTRY: {
-		return StringUtil::Format("table function \"%s\"", info.name);
+		return StringUtil::Format("table function %s", info.name);
 	}
 	case CatalogType::SCALAR_FUNCTION_ENTRY: {
-		return StringUtil::Format("scalar function \"%s\"", info.name);
+		return StringUtil::Format("scalar function %s", info.name);
 	}
 	case CatalogType::AGGREGATE_FUNCTION_ENTRY: {
-		return StringUtil::Format("aggregate function \"%s\"", info.name);
+		return StringUtil::Format("aggregate function %s", info.name);
 	}
 	case CatalogType::PRAGMA_FUNCTION_ENTRY: {
-		return StringUtil::Format("pragma function \"%s\"", info.name);
+		return StringUtil::Format("pragma function %s", info.name);
 	}
 	case CatalogType::COPY_FUNCTION_ENTRY: {
-		return StringUtil::Format("copy function \"%s\"", info.name);
+		return StringUtil::Format("copy function %s", info.name);
 	}
 	case CatalogType::MACRO_ENTRY: {
-		return StringUtil::Format("macro function \"%s\"", info.name);
+		return StringUtil::Format("macro function %s", info.name);
 	}
 	case CatalogType::TABLE_MACRO_ENTRY: {
-		return StringUtil::Format("table macro function \"%s\"", info.name);
+		return StringUtil::Format("table macro function %s", info.name);
 	}
 	case CatalogType::SECRET_ENTRY: {
-		return StringUtil::Format("secret \"%s\"", info.name);
+		return StringUtil::Format("secret %s", info.name);
 	}
 	case CatalogType::SECRET_TYPE_ENTRY: {
-		return StringUtil::Format("secret type \"%s\"", info.name);
+		return StringUtil::Format("secret type %s", info.name);
 	}
 	case CatalogType::SECRET_FUNCTION_ENTRY: {
-		return StringUtil::Format("secret function \"%s\"", info.name);
+		return StringUtil::Format("secret function %s", info.name);
 	}
 	case CatalogType::TRIGGER_ENTRY: {
-		return StringUtil::Format("trigger \"%s\"", info.name);
+		return StringUtil::Format("trigger %s", info.name);
 	}
 	default:
 		throw InternalException("CatalogType not handled in EntryToString (DependencyManager) for %s",
@@ -529,7 +529,7 @@ void DependencyManager::VerifyExistence(CatalogTransaction transaction, Dependen
 	}
 
 	if (lookup_result.reason == CatalogSet::EntryLookup::FailureReason::DELETED) {
-		throw DependencyException("Could not commit creation of dependency, subject \"%s\" has been deleted",
+		throw DependencyException("Could not commit creation of dependency, subject %s has been deleted",
 		                          object.SourceInfo().name);
 	}
 	// The subject still exists by name - check if it is the same object the dependency was created against
@@ -557,7 +557,7 @@ void DependencyManager::VerifyCommitDrop(CatalogTransaction transaction, transac
 			// Which differentiates between objects that we were already aware of (and will subsequently be dropped) and
 			// objects that were introduced inbetween, which should cause this error:
 			throw DependencyException(
-			    "Could not commit DROP of \"%s\" because a dependency was created after the transaction started",
+			    "Could not commit DROP of %s because a dependency was created after the transaction started",
 			    object.name);
 		}
 	});
@@ -572,7 +572,7 @@ void DependencyManager::VerifyCommitDrop(CatalogTransaction transaction, transac
 			// transaction. Only objects that were introduced by other transactions, that this transaction could not
 			// see, should cause this error:
 			throw DependencyException(
-			    "Could not commit DROP of \"%s\" because a dependency was created after the transaction started",
+			    "Could not commit DROP of %s because a dependency was created after the transaction started",
 			    object.name);
 		}
 	});
@@ -606,7 +606,7 @@ catalog_entry_set_t DependencyManager::CheckDropDependencies(CatalogTransaction 
 	});
 	if (!blocking_dependents.empty()) {
 		string error_string =
-		    StringUtil::Format("Cannot drop entry \"%s\" because there are entries that depend on it.\n", object.name);
+		    StringUtil::Format("Cannot drop entry %s because there are entries that depend on it.\n", object.name);
 		error_string += CollectDependents(transaction, blocking_dependents, info);
 		error_string += "Use DROP...CASCADE to drop all dependents.";
 		throw DependencyException(error_string);
@@ -736,7 +736,7 @@ void DependencyManager::AlterObject(CatalogTransaction transaction, CatalogEntry
 			break;
 		}
 		if (disallow_alter) {
-			throw DependencyException("Cannot alter entry \"%s\" because there are entries that "
+			throw DependencyException("Cannot alter entry %s because there are entries that "
 			                          "depend on it.",
 			                          old_obj.name);
 		}

--- a/src/catalog/duck_catalog.cpp
+++ b/src/catalog/duck_catalog.cpp
@@ -80,14 +80,14 @@ optional_ptr<CatalogEntry> DuckCatalog::CreateSchemaInternal(CatalogTransaction 
 	optional_ptr<CatalogEntry> parent_entry = schemas->GetEntry(transaction, parents[0]);
 	if (!parent_entry) {
 		// the root component was not a catalog (otherwise it would have been resolved as one) nor an existing schema
-		throw CatalogException("\"%s\" is not a catalog or schema", parents[0].GetIdentifierName());
+		throw CatalogException("%s is not a catalog or schema", parents[0]);
 	}
 	for (idx_t i = 1; i < parents.size(); i++) {
 		auto &duck_parent = parent_entry->Cast<DuckSchemaEntry>();
 		parent_entry = duck_parent.GetCatalogSet(CatalogType::SCHEMA_ENTRY).GetEntry(transaction, parents[i]);
 		if (!parent_entry) {
-			throw CatalogException("Cannot create nested schema \"%s\": parent schema \"%s\" does not exist",
-			                       info.SchemaName().GetIdentifierName(), parents[i].GetIdentifierName());
+			throw CatalogException("Cannot create nested schema %s: parent schema %s does not exist", info.SchemaName(),
+			                       parents[i]);
 		}
 	}
 	return parent_entry->Cast<DuckSchemaEntry>().CreateSchema(transaction, info);
@@ -139,8 +139,7 @@ void DuckCatalog::DropSchema(CatalogTransaction transaction, DropInfo &info) {
 		auto parent_entry = target_set.get().GetEntry(transaction, path[i]);
 		if (!parent_entry) {
 			if (info.if_not_found == OnEntryNotFound::THROW_EXCEPTION) {
-				throw CatalogException("Cannot drop schema \"%s\": parent schema \"%s\" does not exist",
-				                       schema_name.GetIdentifierName(), path[i].GetIdentifierName());
+				throw CatalogException("Cannot drop schema %s: parent schema %s does not exist", schema_name, path[i]);
 			}
 			return;
 		}

--- a/src/common/exception/catalog_exception.cpp
+++ b/src/common/exception/catalog_exception.cpp
@@ -58,7 +58,7 @@ CatalogException CatalogException::MissingEntry(const string &type, const Identi
 		extra_info["candidates"] = StringUtil::Join(suggestions, ", ");
 	}
 	return CatalogException(
-	    extra_info, StringUtil::Format("unrecognized %s \"%s\"\n%s", type, name,
+	    extra_info, StringUtil::Format("unrecognized %s %s\n%s", type, name,
 	                                   StringUtil::CandidatesErrorMessage(IdentifiersToStrings(suggestions),
 	                                                                      name.GetIdentifierName(), "Did you mean")));
 }

--- a/src/common/exception_format_value.cpp
+++ b/src/common/exception_format_value.cpp
@@ -60,7 +60,7 @@ template <>
 ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(const Identifier &value) {
 	// An Identifier is a SQL identifier, so it formats with SQL identifier rules (quoted only when required) -
 	// callers should never need to wrap an Identifier in SQLIdentifier when printing.
-	return SQLIdentifier::ToString(value.GetIdentifierName());
+	return SQLQuotedIdentifier::ToString(value.GetIdentifierName());
 }
 template <>
 ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(const SQLString &value) {

--- a/src/common/multi_file/multi_file_reader.cpp
+++ b/src/common/multi_file/multi_file_reader.cpp
@@ -186,7 +186,7 @@ bool MultiFileReader::ParseOption(const Identifier &key, const Value &val, Multi
 		for (idx_t i = 0; i < children.size(); i++) {
 			const Value &child = children[i];
 			if (child.type().id() != LogicalType::VARCHAR) {
-				throw InvalidInputException("hive_types: '%s' must be a VARCHAR, instead: '%s' was provided",
+				throw InvalidInputException("hive_types: %s must be a VARCHAR, instead: '%s' was provided",
 				                            StructType::GetChildName(val.type(), i), child.type().ToString());
 			}
 			// for every child of the struct, get the logical type
@@ -450,7 +450,7 @@ static string GetExtendedMultiFileError(const MultiFileBindData &bind_data, cons
 			target_column = "\"" + bind_data.table_columns[expr_idx] + "\" ";
 		}
 		extended_error = StringUtil::Format(
-		    "In file \"%s\" the column \"%s\" has type %s, but we are trying to load it into column %swith type "
+		    "In file \"%s\" the column %s has type %s, but we are trying to load it into column %swith type "
 		    "%s.\nThis means the %s schema does not match the schema of the table.\nPossible solutions:\n* Insert by "
 		    "name instead of by position using \"INSERT INTO tbl BY NAME SELECT * FROM %s(...)\"\n* Manually specify "
 		    "which columns to insert using \"INSERT INTO tbl SELECT ... FROM %s(...)\"",
@@ -459,7 +459,7 @@ static string GetExtendedMultiFileError(const MultiFileBindData &bind_data, cons
 	} else {
 		// read_parquet() with multiple files
 		extended_error = StringUtil::Format(
-		    "In file \"%s\" the column \"%s\" has type %s, but we are trying to read it as type %s."
+		    "In file \"%s\" the column %s has type %s, but we are trying to read it as type %s."
 		    "\nThis can happen when reading multiple %s files. The schema information is taken from "
 		    "the first %s file by default. Possible solutions:\n"
 		    "* Enable the union_by_name=True option to combine the schema of all %s files "
@@ -467,8 +467,8 @@ static string GetExtendedMultiFileError(const MultiFileBindData &bind_data, cons
 		    "* Use a COPY statement to automatically derive types from an existing table.",
 		    reader.GetFileName(), local_col.name, source_type, target_type, reader_type, reader_type, reader_type);
 	}
-	first_message = StringUtil::Format("failed to cast column \"%s\" from type %s to %s: ", local_col.name, source_type,
-	                                   target_type);
+	first_message =
+	    StringUtil::Format("failed to cast column %s from type %s to %s: ", local_col.name, source_type, target_type);
 	return extended_error;
 }
 

--- a/src/execution/column_binding_resolver.cpp
+++ b/src/execution/column_binding_resolver.cpp
@@ -222,12 +222,12 @@ unique_ptr<Expression> ColumnBindingResolver::VisitReplace(BoundColumnRefExpress
 			if (!types.empty()) {
 				if (bindings.size() != types.size()) {
 					throw InternalException(
-					    "Failed to bind column reference \"%s\" [%d.%d]: inequal num bindings/types (%llu != %llu)",
+					    "Failed to bind column reference %s [%d.%d]: inequal num bindings/types (%llu != %llu)",
 					    expr.GetAlias(), expr.Binding().table_index.index, expr.Binding().column_index, bindings.size(),
 					    types.size());
 				}
 				if (expr.GetReturnType() != types[i]) {
-					throw InternalException("Failed to bind column reference \"%s\" [%d.%d]: inequal types (%s != %s)",
+					throw InternalException("Failed to bind column reference %s [%d.%d]: inequal types (%s != %s)",
 					                        expr.GetAlias(), expr.Binding().table_index.index,
 					                        expr.Binding().column_index, expr.GetReturnType().ToString(),
 					                        types[i].ToString());
@@ -243,7 +243,7 @@ unique_ptr<Expression> ColumnBindingResolver::VisitReplace(BoundColumnRefExpress
 	// LCOV_EXCL_START
 	// could not bind the column reference, this should never happen and indicates a bug in the code
 	// generate an error message
-	throw InternalException("Failed to bind column reference \"%s\" [%d.%d] (bindings: %s)", expr.GetAlias(),
+	throw InternalException("Failed to bind column reference %s [%d.%d] (bindings: %s)", expr.GetAlias(),
 	                        expr.Binding().table_index.index, expr.Binding().column_index,
 	                        LogicalOperator::ColumnBindingsToString(bindings));
 	// LCOV_EXCL_STOP

--- a/src/execution/expression_executor/execute_function.cpp
+++ b/src/execution/expression_executor/execute_function.cpp
@@ -173,7 +173,7 @@ static void VerifyNullHandling(const BoundFunctionExpression &expr, DataChunk &a
 	for (idx_t i = 0; i < count; i++) {
 		if (!combined_mask.RowIsValid(i) && result_validity.IsValid(i)) {
 			throw InternalException(
-			    "VerifyNullHandling failed for scalar function \"%s\": row %d has a NULL argument but the result is "
+			    "VerifyNullHandling failed for scalar function %s: row %d has a NULL argument but the result is "
 			    "not NULL - functions with default NULL handling should return NULL for any NULL input",
 			    expr.Function().GetName(), i);
 		}

--- a/src/execution/operator/csv_scanner/table_function/csv_multi_file_info.cpp
+++ b/src/execution/operator/csv_scanner/table_function/csv_multi_file_info.cpp
@@ -231,7 +231,7 @@ void CSVMultiFileInfo::FinalizeBindData(MultiFileBindData &multi_file_data) {
 		}
 		for (auto &force_name : options.force_not_null_names) {
 			if (column_names.find(Identifier(force_name)) == column_names.end()) {
-				throw BinderException("force_not_null expected to find %s, but it was not found in the table",
+				throw BinderException("\"force_not_null\" expected to find %s, but it was not found in the table",
 				                      force_name);
 			}
 		}

--- a/src/execution/operator/helper/physical_connect.cpp
+++ b/src/execution/operator/helper/physical_connect.cpp
@@ -65,7 +65,7 @@ SourceResultType PhysicalConnect::GetDataInternal(ExecutionContext &context, Dat
 
 	auto target = db_manager.GetDatabase(info->name);
 	if (!target) {
-		throw InvalidInputException("Database \"%s\" is not attached", info->name);
+		throw InvalidInputException("Database %s is not attached", info->name);
 	}
 	// ConnectToCatalog resolves and caches the dispatch function name; throws if the catalog returns
 	// empty from GetConnectFunctionName (i.e. CONNECT is not supported in this context).

--- a/src/execution/operator/schema/physical_create_index.cpp
+++ b/src/execution/operator/schema/physical_create_index.cpp
@@ -148,7 +148,7 @@ SinkFinalizeType PhysicalCreateIndex::Finalize(Pipeline &pipeline, Event &event,
 		    schema.GetEntry(schema.GetCatalogTransaction(context), CatalogType::INDEX_ENTRY, info->GetIndexName());
 		if (entry) {
 			if (info->on_conflict != OnCreateConflict::IGNORE_ON_CONFLICT) {
-				throw CatalogException("Index with name \"%s\" already exists!", info->GetIndexName());
+				throw CatalogException("Index with name %s already exists!", info->GetIndexName());
 			}
 			// IF NOT EXISTS on existing index. We are done.
 			return SinkFinalizeType::READY;
@@ -165,7 +165,7 @@ SinkFinalizeType PhysicalCreateIndex::Finalize(Pipeline &pipeline, Event &event,
 		for (auto &index : indexes.Indexes()) {
 			if (index.GetIndexName() == info->GetIndexName()) {
 				throw CatalogException("an index with that name already exists for this table: %s",
-				                       info->GetIndexName());
+				                       SQLIdentifier(info->GetIndexName()));
 			}
 		}
 

--- a/src/execution/operator/schema/physical_detach.cpp
+++ b/src/execution/operator/schema/physical_detach.cpp
@@ -23,10 +23,9 @@ SourceResultType PhysicalDetach::GetDataInternal(ExecutionContext &context, Data
 		if (attached_db) {
 			auto &meta_transaction = MetaTransaction::Get(context.client);
 			if (meta_transaction.TryGetTransaction(*attached_db)) {
-				throw TransactionException(
-				    "Cannot detach database \"%s\" because the current transaction has outstanding "
-				    "work on it - commit or rollback first",
-				    info->name);
+				throw TransactionException("Cannot detach database %s because the current transaction has outstanding "
+				                           "work on it - commit or rollback first",
+				                           info->name);
 			}
 		}
 	}

--- a/src/execution/operator/schema/physical_drop.cpp
+++ b/src/execution/operator/schema/physical_drop.cpp
@@ -73,7 +73,7 @@ SourceResultType PhysicalDrop::GetDataInternal(ExecutionContext &context, DataCh
 		auto transaction = duck_table.catalog.GetCatalogTransaction(context.client);
 		if (!duck_table.DropTrigger(transaction, info->GetQualifiedName().Name(), info->cascade)) {
 			if (info->if_not_found == OnEntryNotFound::THROW_EXCEPTION) {
-				throw CatalogException("Trigger with name \"%s\" does not exist on table \"%s\"",
+				throw CatalogException("Trigger with name %s does not exist on table %s",
 				                       info->GetQualifiedName().Name(), base_table_ref.Table());
 			}
 		}

--- a/src/execution/physical_plan/plan_create_index.cpp
+++ b/src/execution/physical_plan/plan_create_index.cpp
@@ -100,7 +100,7 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalCreateIndex &op) {
 	    schema.GetEntry(schema.GetCatalogTransaction(context), CatalogType::INDEX_ENTRY, op.info->GetIndexName());
 	if (entry) {
 		if (op.info->on_conflict != OnCreateConflict::IGNORE_ON_CONFLICT) {
-			throw CatalogException("Index with name \"%s\" already exists!", op.info->GetIndexName());
+			throw CatalogException("Index with name %s already exists!", op.info->GetIndexName());
 		}
 		return Make<PhysicalDummyScan>(op.types, op.estimated_cardinality);
 	}

--- a/src/function/built_in_functions.cpp
+++ b/src/function/built_in_functions.cpp
@@ -113,7 +113,7 @@ static unique_ptr<Expression> BindExtensionFunction(FunctionBindExpressionInput 
 	auto &db = *context.db;
 
 	if (!ExtensionHelper::CanAutoloadExtension(extension_name)) {
-		throw BinderException("Trying to call function \"%s\" which is present in extension \"%s\" - but the extension "
+		throw BinderException("Trying to call function %s which is present in extension \"%s\" - but the extension "
 		                      "is not loaded and could not be auto-loaded",
 		                      bound_function.GetName(), extension_name);
 	}

--- a/src/function/copy_blob.cpp
+++ b/src/function/copy_blob.cpp
@@ -46,7 +46,7 @@ unique_ptr<FunctionData> WriteBlobBind(ClientContext &context, CopyFunctionBindI
 			auto compression_str = ParseStringOption(option_values[0], option_name);
 			result->compression_type = FileCompressionTypeFromString(compression_str);
 		} else {
-			throw BinderException("Unrecognized option for COPY (FORMAT BLOB): %s", option_name);
+			throw BinderException("Unrecognized option for COPY (FORMAT BLOB): %s", SQLIdentifier(option_name));
 		}
 	}
 

--- a/src/function/function.cpp
+++ b/src/function/function.cpp
@@ -71,9 +71,9 @@ static bool RequiresCatalogAndSchemaNamePrefix(const Identifier &catalog_name, c
 
 string FunctionParameter::ToString() const {
 	if (default_value) {
-		return StringUtil::Format("%s %s := %s", name, type.ToString(), default_value->ToString());
+		return StringUtil::Format("%s %s := %s", SQLIdentifier(name), type.ToString(), default_value->ToString());
 	}
-	return StringUtil::Format("%s %s", name, type.ToString());
+	return StringUtil::Format("%s %s", SQLIdentifier(name), type.ToString());
 }
 
 string FunctionSignature::ToString() const {
@@ -94,9 +94,10 @@ string FunctionSignature::ToString() const {
 
 string SimpleFunction::ToString() const {
 	if (RequiresCatalogAndSchemaNamePrefix(GetCatalogName(), GetSchemaName())) {
-		return StringUtil::Format("%s.%s.%s%s", GetCatalogName(), GetSchemaName(), name, signature.ToString());
+		return StringUtil::Format("%s.%s.%s%s", SQLIdentifier(GetCatalogName()), SQLIdentifier(GetSchemaName()),
+		                          SQLIdentifier(name), signature.ToString());
 	}
-	return name + signature.ToString();
+	return SQLIdentifier::ToString(name.GetIdentifierName()) + signature.ToString();
 }
 
 SimpleNamedParameterFunction::SimpleNamedParameterFunction(Identifier name_p, vector<LogicalType> arguments_p,
@@ -190,13 +191,13 @@ string Function::CallToString(const Identifier &catalog_name, const Identifier &
 		input_arguments.push_back(arg.ToString());
 	}
 	for (auto &kv : named_parameters) {
-		input_arguments.push_back(StringUtil::Format("%s : %s", kv.first, kv.second.ToString()));
+		input_arguments.push_back(StringUtil::Format("%s : %s", SQLIdentifier(kv.first), kv.second.ToString()));
 	}
 	string prefix = "";
 	if (RequiresCatalogAndSchemaNamePrefix(catalog_name, schema_name)) {
-		prefix = StringUtil::Format("%s.%s.", catalog_name, schema_name);
+		prefix = StringUtil::Format("%s.%s.", SQLIdentifier(catalog_name), SQLIdentifier(schema_name));
 	}
-	return StringUtil::Format("%s%s(%s)", prefix, name, StringUtil::Join(input_arguments, ", "));
+	return StringUtil::Format("%s%s(%s)", prefix, SQLIdentifier(name), StringUtil::Join(input_arguments, ", "));
 }
 
 hash_t BoundSimpleFunction::Hash() const {
@@ -260,12 +261,12 @@ Value BindFunctionInput::GetConstant(idx_t arg_idx, bool accept_null) const {
 	// Use the argument name if available, otherwise use the argument index
 	string argument_name;
 	if (argument_names && arg_idx < argument_names->size() && !argument_names->at(arg_idx).empty()) {
-		argument_name = StringUtil::Format("The '%s' argument", argument_names->at(arg_idx));
+		argument_name = StringUtil::Format("The %s argument", argument_names->at(arg_idx));
 	} else {
 		argument_name = StringUtil::Format("Argument #%llu", arg_idx + 1);
 	}
 	if (!expr.IsFoldable()) {
-		throw BinderException(expr, "%s in function '%s' must be a constant expression", argument_name,
+		throw BinderException(expr, "%s in function %s must be a constant expression", argument_name,
 		                      function.GetName());
 	}
 	auto value = ExpressionExecutor::EvaluateScalar(context, expr);
@@ -278,7 +279,7 @@ Value BindFunctionInput::GetConstant(idx_t arg_idx, bool accept_null) const {
 Value BindFunctionInput::GetConstant(const Identifier &name, bool accept_null) const {
 	const auto arg_idx = GetArgumentIndex(name);
 	if (!arg_idx.IsValid()) {
-		throw InternalException("Function '%s' does not have a parameter named '%s'", function.GetName(), name);
+		throw InternalException("Function %s does not have a parameter named %s", function.GetName(), name);
 	}
 	return GetConstant(arg_idx.GetIndex(), accept_null);
 }

--- a/src/function/function_binder.cpp
+++ b/src/function/function_binder.cpp
@@ -979,8 +979,8 @@ static vector<Identifier> ResolveArguments(const SimpleFunction &function, vecto
 
 		if (seen_names.count(name)) {
 			// This should also not really happen when invoked through SQL
-			throw BinderException(location, "Duplicate named argument '%s' in function call to '%s'",
-			                      name.GetIdentifierName(), function.GetName());
+			throw BinderException(location, "Duplicate named argument %s in function call to '%s'", name,
+			                      function.GetName());
 		}
 
 		seen_names.insert(name);
@@ -1023,7 +1023,7 @@ static vector<Identifier> ResolveArguments(const SimpleFunction &function, vecto
 			arguments[i]->SetAlias(param.GetName());
 
 		} else {
-			throw BinderException("Missing value for parameter '%s' in function call to '%s'", param.GetName(),
+			throw BinderException("Missing value for parameter %s in function call to %s", param.GetName(),
 			                      function.GetName());
 		}
 	}

--- a/src/function/macro_function.cpp
+++ b/src/function/macro_function.cpp
@@ -20,7 +20,7 @@ MacroFunction::MacroFunction(MacroType type) : type(type) {
 }
 
 string FormatMacroFunction(const MacroFunction &function, const Identifier &name) {
-	auto result = name + "(";
+	auto result = SQLIdentifier::ToString(name.GetIdentifierName()) + "(";
 	string parameters;
 	for (idx_t param_idx = 0; param_idx < function.parameters.size(); param_idx++) {
 		if (!parameters.empty()) {
@@ -196,7 +196,7 @@ MacroBindResult MacroFunction::BindMacroFunction(
 		string error;
 		if (result_indices.empty()) {
 			// No matching function found
-			error = StringUtil::Format("Macro %s() does not support the supplied arguments.", name);
+			error = StringUtil::Format("Macro %s() does not support the supplied arguments.", SQLIdentifier(name));
 			error += " You might need to add explicit type casts.\n";
 			error += "Candidate macros:";
 			for (auto &function : functions) {
@@ -204,7 +204,8 @@ MacroBindResult MacroFunction::BindMacroFunction(
 			}
 		} else {
 			// Multiple matching functions found
-			error = StringUtil::Format("Macro %s() has multiple overloads that match the supplied arguments.\n", name);
+			error = StringUtil::Format("Macro %s() has multiple overloads that match the supplied arguments.\n",
+			                           SQLIdentifier(name));
 			error += "In order to select one, please supply all arguments by name, and/or add explicit type casts.\n";
 			error += "Candidate macros:";
 			for (const auto &result_idx : result_indices) {

--- a/src/function/scalar/struct/struct_concat.cpp
+++ b/src/function/scalar/struct/struct_concat.cpp
@@ -51,12 +51,12 @@ static unique_ptr<FunctionData> StructConcatBind(BindScalarFunctionInput &input)
 				auto it = name_set.find(child.first);
 				if (it != name_set.end()) {
 					if (it->GetIdentifierName() == child.first.GetIdentifierName()) {
-						throw InvalidInputException("struct_concat: Arguments contain duplicate STRUCT entry \"%s\"",
-						                            child.first.GetIdentifierName());
+						throw InvalidInputException("struct_concat: Arguments contain duplicate STRUCT entry %s",
+						                            child.first);
 					}
 					throw InvalidInputException(
-					    "struct_concat: Arguments contain case-insensitive duplicate STRUCT entry \"%s\" and \"%s\"",
-					    child.first.GetIdentifierName(), it->GetIdentifierName());
+					    "struct_concat: Arguments contain case-insensitive duplicate STRUCT entry %s and %s",
+					    child.first, *it);
 				}
 				name_set.insert(child.first);
 			} else {

--- a/src/function/scalar/struct/struct_extract.cpp
+++ b/src/function/scalar/struct/struct_extract.cpp
@@ -75,7 +75,7 @@ static unique_ptr<FunctionData> StructExtractBind(BindScalarFunctionInput &input
 		}
 		auto closest_settings = StringUtil::TopNJaroWinkler(candidates, key);
 		auto message = StringUtil::CandidatesMessage(closest_settings, "Candidate Entries");
-		throw BinderException("Could not find key \"%s\" in struct\n%s", key.GetIdentifierName(), message);
+		throw BinderException("Could not find key %s in struct\n%s", key, message);
 	}
 
 	bound_function.SetReturnType(std::move(return_type));

--- a/src/function/scalar/variant/variant_bind_utils.cpp
+++ b/src/function/scalar/variant/variant_bind_utils.cpp
@@ -63,7 +63,7 @@ unique_ptr<FunctionData> VariantBindUtils::VariantPathBind(BindScalarFunctionInp
 	const auto &function_name = input.GetBoundFunction().GetName();
 
 	if (arguments.size() != 1 && arguments.size() != 2) {
-		throw BinderException("'%s' expects either one VARIANT column argument, or two VARIANT column and "
+		throw BinderException("%s expects either one VARIANT column argument, or two VARIANT column and "
 		                      "VARCHAR path arguments",
 		                      function_name);
 	}
@@ -76,13 +76,13 @@ unique_ptr<FunctionData> VariantBindUtils::VariantPathBind(BindScalarFunctionInp
 	const auto &path_expr = *arguments[1];
 	const auto &return_type = path_expr.GetReturnType();
 	if (return_type.id() != LogicalTypeId::VARCHAR && return_type.id() != LogicalTypeId::LIST) {
-		throw BinderException("'%s' expects the second argument to be of type VARCHAR or VARCHAR[], not %s",
+		throw BinderException("%s expects the second argument to be of type VARCHAR or VARCHAR[], not %s",
 		                      function_name, return_type.ToString());
 	}
 	if (return_type.id() == LogicalTypeId::LIST) {
 		const auto child_type_id = ListType::GetChildType(return_type).id();
 		if (child_type_id != LogicalTypeId::VARCHAR && child_type_id != LogicalTypeId::SQLNULL) {
-			throw BinderException("'%s' expects the second argument to be of type VARCHAR or VARCHAR[], not %s",
+			throw BinderException("%s expects the second argument to be of type VARCHAR or VARCHAR[], not %s",
 			                      function_name, return_type.ToString());
 		}
 	}

--- a/src/include/duckdb/catalog/catalog_entry/schema_catalog_entry.hpp
+++ b/src/include/duckdb/catalog/catalog_entry/schema_catalog_entry.hpp
@@ -94,7 +94,7 @@ public:
 	//! Create a coordinate system within the given schema
 	virtual optional_ptr<CatalogEntry> CreateCoordinateSystem(CatalogTransaction transaction,
 	                                                          CreateCoordinateSystemInfo &info) {
-		throw NotImplementedException("Coordinate systems are not supported in schema '%s'", name);
+		throw NotImplementedException("Coordinate systems are not supported in schema %s", name);
 	}
 
 	//! Create a enum within the given schema

--- a/src/main/appender.cpp
+++ b/src/main/appender.cpp
@@ -512,8 +512,8 @@ Appender::Appender(Connection &con, const Identifier &database_name, const Ident
 
 	description = con.TableInfo(database_name, schema_name, table_name);
 	if (!description) {
-		throw CatalogException(
-		    StringUtil::Format("Table \"%s.%s.%s\" could not be found", database_name, schema_name, table_name));
+		throw CatalogException(StringUtil::Format("Table '%s.%s.%s' could not be found", SQLIdentifier(database_name),
+		                                          SQLIdentifier(schema_name), SQLIdentifier(table_name)));
 	}
 	if (description->readonly) {
 		throw InvalidInputException("Cannot append to a readonly database.");

--- a/src/main/attached_database.cpp
+++ b/src/main/attached_database.cpp
@@ -341,9 +341,9 @@ void AttachedDatabase::Invalidate(const string &reason) {
 	string recovery = HasStorageManager() && GetStorageManager().InMemory()
 	                      ? "It is an in-memory database, so its data cannot be recovered."
 	                      : "Detach and reattach it before using it again.";
-	ValidChecker::Invalidate(*this, StringUtil::Format("Database \"%s\" has been invalidated because checkpointing "
+	ValidChecker::Invalidate(*this, StringUtil::Format("Database %s has been invalidated because checkpointing "
 	                                                   "failed. %s Original error: %s",
-	                                                   GetName().GetIdentifierName(), recovery, reason));
+	                                                   GetName(), recovery, reason));
 }
 
 void AttachedDatabase::SetInitialDatabase() {

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -615,7 +615,7 @@ void ClientContext::CheckIfPreparedStatementIsExecutable(PreparedStatementData &
 		}
 		if (entry->IsReadOnly()) {
 			throw InvalidInputException(StringUtil::Format(
-			    "Cannot execute statement of type \"%s\" on database \"%s\" which is attached in read-only mode!",
+			    "Cannot execute statement of type \"%s\" on database %s which is attached in read-only mode!",
 			    StatementTypeToString(statement.statement_type), modified_database));
 		}
 		meta_transaction.ModifyDatabase(*entry, it.second.modifications);

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -866,7 +866,7 @@ void DBConfig::AddAllowedConfig(const Identifier &config_name) {
 	}
 	duckdb::identifier_set_t always_disallowed_config {"allowed_configs", "lock_configuration"};
 	if (always_disallowed_config.find(config_name) != always_disallowed_config.end()) {
-		throw InvalidInputException("Cannot include '%s' in allowed_configs", config_name);
+		throw InvalidInputException("Cannot include %s in allowed_configs", config_name);
 	}
 	// Validate that the config name refers to a known setting (built-in or extension)
 	// and resolve aliases to canonical names
@@ -888,7 +888,7 @@ void DBConfig::AddAllowedConfig(const Identifier &config_name) {
 		options.allowed_configs.insert(config_name);
 		return;
 	}
-	throw InvalidInputException("Unknown configuration option '%s' in allowed_configs", config_name);
+	throw InvalidInputException("Unknown configuration option %s in allowed_configs", config_name);
 }
 
 void DBConfig::AddAllowedDirectory(const string &path) {

--- a/src/main/database_file_path_manager.cpp
+++ b/src/main/database_file_path_manager.cpp
@@ -46,15 +46,13 @@ InsertDatabasePathResult DatabaseFilePathManager::InsertDatabasePath(DatabaseMan
 				if (attached_in_this_system) {
 					return InsertDatabasePathResult::ALREADY_EXISTS;
 				}
-				throw BinderException(
-				    "Unique file handle conflict: Cannot attach \"%s\" - the database file \"%s\" is in "
-				    "the process of being detached",
-				    name, path);
+				throw BinderException("Unique file handle conflict: Cannot attach %s - the database file \"%s\" is in "
+				                      "the process of being detached",
+				                      name, path);
 			}
-			throw BinderException(
-			    "Unique file handle conflict: Cannot attach \"%s\" - the database file \"%s\" is already "
-			    "attached by database \"%s\"",
-			    name, path, existing.name);
+			throw BinderException("Unique file handle conflict: Cannot attach %s - the database file \"%s\" is already "
+			                      "attached by database \"%s\"",
+			                      name, path, existing.name);
 		}
 	}
 	options.stored_database_path = make_uniq<StoredDatabasePath>(manager, *this, path, name);

--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -192,8 +192,7 @@ shared_ptr<AttachedDatabase> DatabaseManager::AttachDatabase(ClientContext &cont
 		options.stored_database_path.reset();
 	}
 	if (AttachedDatabase::NameIsReserved(info.name)) {
-		throw BinderException("Attached database name \"%s\" cannot be used because it is a reserved name",
-		                      info.name.GetIdentifierName());
+		throw BinderException("Attached database name %s cannot be used because it is a reserved name", info.name);
 	}
 	if (!extension.empty()) {
 		if (!ExtensionHelper::TryAutoLoadExtension(context, extension)) {
@@ -265,16 +264,15 @@ optional_ptr<AttachedDatabase> DatabaseManager::FinalizeAttach(ClientContext &co
 
 void DatabaseManager::DetachDatabase(ClientContext &context, const Identifier &name, OnEntryNotFound if_not_found) {
 	if (GetDefaultDatabase(context) == name) {
-		throw BinderException("Cannot detach database \"%s\" because it is the default database. Select a different "
+		throw BinderException("Cannot detach database %s because it is the default database. Select a different "
 		                      "database using `USE` to allow detaching this database",
-		                      name.GetIdentifierName());
+		                      name);
 	}
 
 	auto attached_db = DetachInternal(name);
 	if (!attached_db) {
 		if (if_not_found == OnEntryNotFound::THROW_EXCEPTION) {
-			throw BinderException("Failed to detach database with name \"%s\": database not found",
-			                      name.GetIdentifierName());
+			throw BinderException("Failed to detach database with name %s: database not found", name);
 		}
 		return;
 	}
@@ -302,8 +300,7 @@ void DatabaseManager::Alter(ClientContext &context, AlterInfo &info) {
 void DatabaseManager::RenameDatabase(ClientContext &context, const Identifier &old_name, const Identifier &new_name,
                                      OnEntryNotFound if_not_found) {
 	if (AttachedDatabase::NameIsReserved(new_name)) {
-		throw BinderException("Database name \"%s\" cannot be used because it is a reserved name",
-		                      new_name.GetIdentifierName());
+		throw BinderException("Database name %s cannot be used because it is a reserved name", new_name);
 	}
 
 	shared_ptr<AttachedDatabase> attached_db;
@@ -312,16 +309,15 @@ void DatabaseManager::RenameDatabase(ClientContext &context, const Identifier &o
 		auto old_entry = databases.find(old_name);
 		if (old_entry == databases.end()) {
 			if (if_not_found == OnEntryNotFound::THROW_EXCEPTION) {
-				throw BinderException("Failed to rename database \"%s\": database not found",
-				                      old_name.GetIdentifierName());
+				throw BinderException("Failed to rename database %s: database not found", old_name);
 			}
 			return;
 		}
 
 		auto new_entry = databases.find(new_name);
 		if (new_entry != databases.end()) {
-			throw BinderException("Failed to rename database \"%s\" to \"%s\": database with new name already exists",
-			                      old_name.GetIdentifierName(), new_name.GetIdentifierName());
+			throw BinderException("Failed to rename database %s to %s: database with new name already exists", old_name,
+			                      new_name);
 		}
 
 		attached_db = old_entry->second;

--- a/src/main/extension/extension_loader.cpp
+++ b/src/main/extension/extension_loader.cpp
@@ -70,7 +70,7 @@ void ExtensionLoader::CreateSchema(const Identifier &name) const {
 void ExtensionLoader::UseDefaultSchema(const Identifier &name) {
 	if (loader_info.extension_schema != DEFAULT_SCHEMA && name != DEFAULT_SCHEMA &&
 	    loader_info.extension_schema != name) {
-		throw InvalidInputException("Cannot set extension schema to '%s', schema is already set to '%s'", name,
+		throw InvalidInputException("Cannot set extension schema to %s, schema is already set to %s", name,
 		                            loader_info.extension_schema);
 	}
 	if (name == "pg_catalog") {

--- a/src/main/extension_manager.cpp
+++ b/src/main/extension_manager.cpp
@@ -37,7 +37,7 @@ void ExtensionActiveLoad::LoadFail(const ErrorData &error) {
 		load_lock.unlock();
 		ExtensionManager::Get(db).RemoveExtensionInfo(alias.GetIdentifierName());
 	}
-	DUCKDB_LOG_INFO(db, "Failed to load extension '%s': %s", extension_name.GetIdentifierName(), error.Message());
+	DUCKDB_LOG_INFO(db, "Failed to load extension %s: %s", extension_name, error.Message());
 }
 
 ExtensionManager::ExtensionManager(DatabaseInstance &db) : db(db) {
@@ -92,8 +92,8 @@ unique_ptr<ExtensionActiveLoad> ExtensionManager::BeginLoad(const ExtensionLoadO
 		if (loaded_extensions_info.find(Identifier(options.alias.GetIdentifierName())) !=
 		    loaded_extensions_info.end()) {
 			auto &info = loaded_extensions_info[Identifier(options.alias.GetIdentifierName())];
-			throw InvalidInputException("Alias '%s' already exists for extension '%s'",
-			                            options.alias.GetIdentifierName(), info->orig_ext_name);
+			throw InvalidInputException("Alias %s already exists for extension '%s'", options.alias,
+			                            info->orig_ext_name);
 		}
 	}
 

--- a/src/main/secret/secret.cpp
+++ b/src/main/secret/secret.cpp
@@ -105,7 +105,7 @@ Value KeyValueSecret::TryGetValue(const Identifier &key, bool error_on_missing) 
 	auto lookup = secret_map.find(key);
 	if (lookup == secret_map.end()) {
 		if (error_on_missing) {
-			throw InternalException("Failed to fetch key '%s' from secret '%s' of type '%s'", key, name, type);
+			throw InternalException("Failed to fetch key %s from secret %s of type %s", key, name, type);
 		}
 		return Value();
 	}

--- a/src/main/secret/secret_manager.cpp
+++ b/src/main/secret/secret_manager.cpp
@@ -129,7 +129,7 @@ unique_ptr<BaseSecret> SecretManager::DeserializeSecret(Deserializer &deserializ
 
 	if (!deserialized_type.deserializer) {
 		throw InvalidConfigurationException(
-		    "Attempted to deserialize secret type '%s' which does not have a deserialization method", type);
+		    "Attempted to deserialize secret type %s which does not have a deserialization method", type);
 	}
 
 	return deserialized_type.deserializer(deserializer, BaseSecret(scope, type, provider, name));
@@ -268,7 +268,7 @@ unique_ptr<SecretEntry> SecretManager::CreateSecret(ClientContext &context, cons
 	auto secret = function_lookup->function(context, function_input);
 
 	if (!secret) {
-		throw InternalException("CreateSecretFunction for type: '%s' and provider: '%s' did not return a secret!",
+		throw InternalException("CreateSecretFunction for type: %s and provider: %s did not return a secret!",
 		                        input.type, input.provider);
 	}
 
@@ -383,7 +383,7 @@ unique_ptr<SecretEntry> SecretManager::GetSecretByName(CatalogTransaction transa
 		auto storage_lookup = GetSecretStorage(storage);
 
 		if (!storage_lookup) {
-			throw InvalidInputException("Unknown secret storage found: '%s'", storage);
+			throw InvalidInputException("Unknown secret storage found: %s", storage);
 		}
 
 		return storage_lookup->GetSecretByName(name, &transaction);
@@ -430,7 +430,7 @@ void SecretManager::DropSecretByName(CatalogTransaction transaction, const Ident
 	if (!storage.empty()) {
 		auto storage_lookup = GetSecretStorage(Identifier(storage));
 		if (!storage_lookup) {
-			throw InvalidInputException("Unknown storage type found for drop secret: '%s'", storage);
+			throw InvalidInputException("Unknown storage type found for drop secret: %s", storage);
 		}
 		matches.push_back(*storage_lookup.get());
 	} else {
@@ -483,7 +483,7 @@ SecretType SecretManager::LookupType(const string &type) {
 void SecretManager::RegisterSecretTypeInternal(SecretType &type) {
 	auto lookup = secret_types.find(type.name);
 	if (lookup != secret_types.end()) {
-		throw InternalException("Attempted to register an already registered secret type: '%s'", type.name);
+		throw InternalException("Attempted to register an already registered secret type: %s", type.name);
 	}
 	secret_types[type.name] = type;
 }
@@ -655,7 +655,7 @@ void SecretManager::ThrowTypeNotFoundError(const Identifier &type, const string 
 			error_message += "\n\nAlternatively, ";
 		}
 	} else {
-		error_message = StringUtil::Format("Secret type '%s' not found", type);
+		error_message = StringUtil::Format("Secret type %s not found", type);
 
 		if (!secret_path.empty()) {
 			error_message += ", ";

--- a/src/main/secret/secret_manager.cpp
+++ b/src/main/secret/secret_manager.cpp
@@ -457,7 +457,7 @@ void SecretManager::DropSecretByName(CatalogTransaction transaction, const Ident
 		list_of_matches.pop_back(); // trailing comma
 
 		throw InvalidInputException(
-		    "Ambiguity found for secret name '%s', secret occurs in multiple storages: [%s] Please specify which "
+		    "Ambiguity found for secret name %s, secret occurs in multiple storages: [%s] Please specify which "
 		    "secret to drop using: 'DROP <PERSISTENT|TEMPORARY> SECRET [FROM <storage>]'.",
 		    name, list_of_matches);
 	}

--- a/src/main/secret/secret_manager.cpp
+++ b/src/main/secret/secret_manager.cpp
@@ -308,15 +308,15 @@ BoundStatement SecretManager::BindCreateSecret(CatalogTransaction transaction, C
 	for (const auto &param : info.options) {
 		auto matched_param = function->named_parameters.find(Identifier(param.first));
 		if (matched_param == function->named_parameters.end()) {
-			throw BinderException("Unknown parameter '%s' for secret type '%s' with %sprovider '%s'", param.first, type,
-			                      default_string, provider);
+			throw BinderException("Unknown parameter %s for secret type %s with %sprovider %s", Identifier(param.first),
+			                      type, default_string, provider);
 		}
 
 		// Cast the provided value to the expected type
 		string error_msg;
 		auto cast_value = param.second.DefaultTryCastAs(matched_param->second, &error_msg);
 		if (!cast_value) {
-			throw BinderException("Failed to cast option '%s' to type '%s': '%s'", matched_param->first,
+			throw BinderException("Failed to cast option %s to type '%s': '%s'", matched_param->first,
 			                      matched_param->second.ToString(), error_msg);
 		}
 
@@ -415,7 +415,7 @@ void SecretManager::DropSecretByName(CatalogTransaction transaction, const Ident
 			return transaction_storage->DropSecretByName(name, on_entry_not_found, &transaction);
 		}
 		if (on_entry_not_found == OnEntryNotFound::THROW_EXCEPTION) {
-			throw InvalidInputException("Failed to remove non-existent transaction secret with name '%s'", name);
+			throw InvalidInputException("Failed to remove non-existent transaction secret with name %s", name);
 		}
 		return;
 	}
@@ -468,7 +468,7 @@ void SecretManager::DropSecretByName(CatalogTransaction transaction, const Ident
 			if (!storage.empty()) {
 				storage_str = " for storage '" + storage + "'";
 			}
-			throw InvalidInputException("Failed to remove non-existent secret with name '%s'%s", name, storage_str);
+			throw InvalidInputException("Failed to remove non-existent secret with name %s%s", name, storage_str);
 		}
 		// Do nothing on OnEntryNotFound::RETURN_NULL...
 	} else {

--- a/src/main/secret/secret_storage.cpp
+++ b/src/main/secret/secret_storage.cpp
@@ -36,7 +36,7 @@ unique_ptr<SecretEntry> TransactionSecretStorage::StoreSecret(unique_ptr<const B
 	if (entry != secrets.end()) {
 		switch (on_conflict) {
 		case OnCreateConflict::ERROR_ON_CONFLICT:
-			throw InvalidInputException("Transaction secret with name '%s' already exists!", secret->GetName());
+			throw InvalidInputException("Transaction secret with name %s already exists!", secret->GetName());
 		case OnCreateConflict::IGNORE_ON_CONFLICT:
 			return nullptr;
 		case OnCreateConflict::REPLACE_ON_CONFLICT:
@@ -133,7 +133,7 @@ unique_ptr<SecretEntry> CatalogSetSecretStorage::StoreSecret(unique_ptr<const Ba
 		if (on_conflict == OnCreateConflict::ERROR_ON_CONFLICT) {
 			string persist_string = persistent ? "Persistent" : "Temporary";
 			string storage_string = persistent ? " in secret storage '" + storage_name + "'" : "";
-			throw InvalidInputException("%s secret with name '%s' already exists%s!", persist_string, secret->GetName(),
+			throw InvalidInputException("%s secret with name %s already exists%s!", persist_string, secret->GetName(),
 			                            storage_string);
 		} else if (on_conflict == OnCreateConflict::IGNORE_ON_CONFLICT) {
 			return nullptr;

--- a/src/parser/column_list.cpp
+++ b/src/parser/column_list.cpp
@@ -69,7 +69,7 @@ ColumnDefinition &ColumnList::GetColumnMutable(PhysicalIndex physical) {
 ColumnDefinition &ColumnList::GetColumnMutable(const Identifier &name) {
 	auto entry = name_map.find(name);
 	if (entry == name_map.end()) {
-		throw InternalException("Column with name \"%s\" does not exist", name.GetIdentifierName());
+		throw InternalException("Column with name %s does not exist", name);
 	}
 	auto logical_index = entry->second;
 	D_ASSERT(logical_index < columns.size());

--- a/src/parser/parsed_data/alter_database_info.cpp
+++ b/src/parser/parsed_data/alter_database_info.cpp
@@ -40,7 +40,8 @@ string RenameDatabaseInfo::ToString() const {
 	if (if_not_found == OnEntryNotFound::RETURN_NULL) {
 		result += "IF EXISTS ";
 	}
-	result += StringUtil::Format("%s SET ALIAS TO %s", GetQualifiedName().Catalog(), new_name);
+	result +=
+	    StringUtil::Format("%s SET ALIAS TO %s", SQLIdentifier(GetQualifiedName().Catalog()), SQLIdentifier(new_name));
 	return result;
 }
 

--- a/src/parser/parsed_data/create_view_info.cpp
+++ b/src/parser/parsed_data/create_view_info.cpp
@@ -114,9 +114,8 @@ vector<Value> CreateViewInfo::GetColumnCommentsList() const {
 	for (auto &entry : column_comments_map) {
 		auto it = std::find_if(names.begin(), names.end(), [&](const Identifier &n) { return entry.first == n; });
 		if (it == names.end()) {
-			throw InternalException(
-			    "While serializing comments for view \"%s\" - did not find column \"%s\" in list of names",
-			    GetViewName(), entry.first.GetIdentifierName());
+			throw InternalException("While serializing comments for view %s - did not find column %s in list of names",
+			                        GetViewName(), entry.first);
 		}
 		result[NumericCast<idx_t>(it - names.begin())] = entry.second;
 	}

--- a/src/parser/peg/transformer/peg_transformer_factory.cpp
+++ b/src/parser/peg/transformer/peg_transformer_factory.cpp
@@ -299,8 +299,7 @@ bool PEGTransformerFactory::ConstructConstantFromExpression(const ParsedExpressi
 			values.reserve(function.GetArguments().size());
 			for (const auto &child : function.GetArguments()) {
 				if (!unique_names.insert(child.GetExpression().GetAlias()).second) {
-					throw BinderException("Duplicate struct entry name \"%s\"",
-					                      child.GetExpression().GetAlias().GetIdentifierName());
+					throw BinderException("Duplicate struct entry name %s", child.GetExpression().GetAlias());
 				}
 				Value child_value;
 				if (!ConstructConstantFromExpression(child.GetExpression(), child_value)) {

--- a/src/parser/peg/transformer/transform_comment.cpp
+++ b/src/parser/peg/transformer/transform_comment.cpp
@@ -18,7 +18,7 @@ unique_ptr<SQLStatement> PEGTransformerFactory::TransformCommentStatement(PEGTra
 		column_name = Identifier(identifier.back());
 		identifier.pop_back();
 		if (identifier.empty()) {
-			throw ParserException("Invalid column reference: '%s'", column_name.GetIdentifierName());
+			throw ParserException("Invalid column reference: %s", SQLIdentifier(column_name));
 		}
 		auto qualified_name = StringToQualifiedName(identifier);
 		info = make_uniq<SetColumnCommentInfo>(qualified_name.Catalog(), qualified_name.Schema(), qualified_name.Name(),

--- a/src/parser/peg/transformer/transform_create_macro.cpp
+++ b/src/parser/peg/transformer/transform_create_macro.cpp
@@ -52,7 +52,7 @@ PEGTransformerFactory::TransformMacroDefinition(PEGTransformer &transformer,
 	for (auto &parameter : *macro_parameters) {
 		D_ASSERT(!parameter.name.empty());
 		if (parameter_names.find(parameter.name) != parameter_names.end()) {
-			throw ParserException("Duplicate parameter '%s' in macro definition", parameter.name.GetIdentifierName());
+			throw ParserException("Duplicate parameter %s in macro definition", parameter.name);
 		}
 		parameter_names.insert(parameter.name);
 		if (parameter.is_default) {

--- a/src/parser/peg/transformer/transform_expression.cpp
+++ b/src/parser/peg/transformer/transform_expression.cpp
@@ -323,7 +323,7 @@ unique_ptr<ParsedExpression> PEGTransformerFactory::TransformFunctionExpression(
 			}
 			lowercase_name = "mode";
 		} else {
-			throw ParserException("Unknown ordered aggregate \"%s\".", qualified_function.Name());
+			throw ParserException("Unknown ordered aggregate %s.", qualified_function.Name());
 		}
 	}
 	auto result = make_uniq<FunctionExpression>(

--- a/src/parser/peg/transformer/transform_select.cpp
+++ b/src/parser/peg/transformer/transform_select.cpp
@@ -291,7 +291,7 @@ static void RegisterWindowClause(PEGTransformer &transformer, const Identifier &
                                  WindowExpression &window_function) {
 	auto it = transformer.window_clauses.find(window_name);
 	if (it != transformer.window_clauses.end()) {
-		throw ParserException("window \"%s\" is already defined", window_name.GetIdentifierName());
+		throw ParserException("window %s is already defined", window_name);
 	}
 	transformer.window_clauses[window_name] =
 	    unique_ptr_cast<ParsedExpression, WindowExpression>(window_function.Copy());
@@ -1158,7 +1158,7 @@ CommonTableExpressionMap PEGTransformerFactory::TransformWithClause(PEGTransform
 		auto it = result.map.find(cte_name);
 		if (it != result.map.end()) {
 			// can't have two CTEs with same name
-			throw ParserException("Duplicate CTE name \"%s\"", cte_name.GetIdentifierName());
+			throw ParserException("Duplicate CTE name %s", cte_name);
 		}
 		result.map.insert(with_entry.first, std::move(with_entry.second));
 	}
@@ -1197,7 +1197,7 @@ unique_ptr<TransformResultValue> PEGTransformerFactory::FinalizeWithClauseTrampo
 		auto &cte_name = with_entry.first;
 		auto it = result.map.find(cte_name);
 		if (it != result.map.end()) {
-			throw ParserException("Duplicate CTE name \"%s\"", cte_name.GetIdentifierName());
+			throw ParserException("Duplicate CTE name %s", cte_name);
 		}
 		result.map.insert(with_entry.first, std::move(with_entry.second));
 	}

--- a/src/parser/statement/execute_statement.cpp
+++ b/src/parser/statement/execute_statement.cpp
@@ -24,10 +24,11 @@ string ExecuteStatement::ToString() const {
 	result += " " + SQLIdentifier(name);
 	vector<string> stringified;
 	for (auto &val : named_values) {
-		stringified.push_back(StringUtil::Format("%s := %s", val.first, val.second->ToString()));
+		stringified.push_back(StringUtil::Format("%s := %s", SQLIdentifier(val.first), val.second->ToString()));
 	}
 	for (auto &val : bound_values) {
-		stringified.push_back(StringUtil::Format("%s := %s", val.first, val.second.GetValue().ToSQLString()));
+		stringified.push_back(
+		    StringUtil::Format("%s := %s", SQLIdentifier(val.first), val.second.GetValue().ToSQLString()));
 	}
 	if (!stringified.empty()) {
 		result += "(" + StringUtil::Join(stringified, ", ") + ")";

--- a/src/parser/tableref.cpp
+++ b/src/parser/tableref.cpp
@@ -15,7 +15,7 @@ string TableRef::BaseToString(string result) const {
 string TableRef::AliasToString(const vector<Identifier> &column_name_alias) const {
 	string result;
 	if (!alias.empty()) {
-		result += StringUtil::Format(" AS %s", alias);
+		result += StringUtil::Format(" AS %s", SQLIdentifier(alias));
 	}
 	if (!column_name_alias.empty()) {
 		D_ASSERT(!alias.empty());

--- a/src/planner/bind_context.cpp
+++ b/src/planner/bind_context.cpp
@@ -26,16 +26,16 @@ BindContext::BindContext(Binder &binder) : binder(binder) {
 
 string MinimumUniqueAlias(const BindingAlias &alias, const BindingAlias &other) {
 	if (alias.GetAlias() != other.GetAlias()) {
-		return alias.GetAlias().GetIdentifierName();
+		return SQLIdentifier::ToString(alias.GetAlias().GetIdentifierName());
 	}
 	// the table names are equal - qualify with as much of the (nested) schema path as needed to disambiguate,
 	// walking from the innermost schema outwards
 	auto schema_path = alias.GetSchemaPath();
 	auto other_path = other.GetSchemaPath();
-	string qualification = alias.GetAlias().GetIdentifierName();
+	string qualification = SQLIdentifier::ToString(alias.GetAlias().GetIdentifierName());
 	for (idx_t i = 0; i < schema_path.size(); i++) {
 		auto &schema = schema_path[schema_path.size() - 1 - i];
-		qualification = schema.GetIdentifierName() + "." + qualification;
+		qualification = SQLIdentifier::ToString(schema.GetIdentifierName()) + "." + qualification;
 		bool other_matches = i < other_path.size() && other_path[other_path.size() - 1 - i] == schema;
 		if (!other_matches) {
 			// this schema component distinguishes the two - we are done
@@ -56,12 +56,14 @@ optional_ptr<Binding> BindContext::GetMatchingBinding(const Identifier &column_n
 		}
 		if (binding.HasMatchingBinding(column_name)) {
 			if (result || is_using_binding) {
-				throw BinderException(
-				    context,
-				    "Ambiguous reference to column name \"%s\" (use: \"%s.%s\" "
-				    "or \"%s.%s\")",
-				    column_name, MinimumUniqueAlias(result->GetBindingAlias(), binding.GetBindingAlias()), column_name,
-				    MinimumUniqueAlias(binding.GetBindingAlias(), result->GetBindingAlias()), column_name);
+				throw BinderException(context,
+				                      "Ambiguous reference to column name %s (use: '%s.%s' "
+				                      "or '%s.%s')",
+				                      column_name,
+				                      MinimumUniqueAlias(result->GetBindingAlias(), binding.GetBindingAlias()),
+				                      SQLIdentifier(column_name),
+				                      MinimumUniqueAlias(binding.GetBindingAlias(), result->GetBindingAlias()),
+				                      SQLIdentifier(column_name));
 			}
 			result = &binding;
 		}
@@ -169,7 +171,7 @@ void BindContext::TransferUsingBinding(BindContext &current_context, optional_pt
 string BindContext::GetActualColumnName(Binding &binding, const Identifier &column_name) {
 	column_t binding_index;
 	if (!binding.TryGetBindingIndex(column_name, binding_index)) { // LCOV_EXCL_START
-		throw InternalException("Binding with name \"%s\" does not have a column named \"%s\"", binding.GetAlias(),
+		throw InternalException("Binding with name %s does not have a column named %s", binding.GetAlias(),
 		                        column_name);
 	} // LCOV_EXCL_STOP
 	return binding.GetColumnNames()[binding_index].GetIdentifierName();
@@ -673,7 +675,7 @@ void BindContext::GenerateAllColumnExpressions(StarExpression &expr,
 	//! Verify correctness of the replace list
 	for (auto &entry : expr.ReplaceList()) {
 		if (exclusion_info.excluded_columns.find(entry.first) == exclusion_info.excluded_columns.end()) {
-			throw BinderException("Column \"%s\" in REPLACE list not found in %s", entry.first.GetIdentifierName(),
+			throw BinderException("Column %s in REPLACE list not found in %s", entry.first,
 			                      expr.RelationName().empty() ? string("FROM clause")
 			                                                  : expr.RelationName().GetIdentifierName());
 		}
@@ -743,7 +745,7 @@ vector<Identifier> BindContext::AliasColumnNames(const Identifier &table_name, c
                                                  const vector<Identifier> &column_aliases) {
 	vector<Identifier> result;
 	if (column_aliases.size() > names.size()) {
-		throw BinderException("table \"%s\" has %lld columns available but %lld columns specified", table_name,
+		throw BinderException("table %s has %lld columns available but %lld columns specified", table_name,
 		                      names.size(), column_aliases.size());
 	}
 	identifier_set_t current_names;

--- a/src/planner/binder/expression/bind_function_expression.cpp
+++ b/src/planner/binder/expression/bind_function_expression.cpp
@@ -262,7 +262,7 @@ CatalogEntry &ExpressionBinder::BindFunction(FunctionExpression &function) {
 		                                  table_function_lookup, OnEntryNotFound::RETURN_NULL);
 		if (table_func) {
 			throw BinderException(function,
-			                      "Function \"%s\" is a table function but it was used as a scalar function. This "
+			                      "Function %s is a table function but it was used as a scalar function. This "
 			                      "function has to be called in a FROM clause (similar to a table).",
 			                      function.FunctionName());
 		}
@@ -285,7 +285,7 @@ BindResult ExpressionBinder::BindExpression(FunctionExpression &function, idx_t 
 		break;
 	default:
 		if (function.Distinct() || function.Filter() || !function.OrderBy()->orders.empty()) {
-			throw InvalidInputException("Function \"%s\" is a %s. \"DISTINCT\", \"FILTER\", and \"ORDER BY\" are only "
+			throw InvalidInputException("Function %s is a %s. \"DISTINCT\", \"FILTER\", and \"ORDER BY\" are only "
 			                            "applicable to window and aggregate functions.",
 			                            function.FunctionName(), CatalogTypeToString(func.type));
 		}

--- a/src/planner/binder/expression/bind_type_expression.cpp
+++ b/src/planner/binder/expression/bind_type_expression.cpp
@@ -77,7 +77,7 @@ BindResult ExpressionBinder::BindExpression(TypeExpression &type_expr, idx_t dep
 	if (!type_entry.bind_function) {
 		if (!unbound_parameters.empty()) {
 			// This type does not support type parameters
-			throw BinderException(type_expr, "Type '%s' does not take any type parameters", type_name);
+			throw BinderException(type_expr, "Type %s does not take any type parameters", type_name);
 		}
 
 		// Otherwise, return the user type directly!

--- a/src/planner/binder/expression/bind_unnest_expression.cpp
+++ b/src/planner/binder/expression/bind_unnest_expression.cpp
@@ -166,7 +166,7 @@ BindResult UnnestBinder::Bind(FunctionExpression &function, idx_t depth, bool ro
 			} else if (alias == "keep_parent_names") {
 				keep_parent_names = value.GetValue<bool>();
 			} else if (!alias.empty()) {
-				throw BinderException("Unsupported parameter \"%s\" for unnest", alias.GetIdentifierName());
+				throw BinderException("Unsupported parameter %s for unnest", alias);
 			} else {
 				break;
 			}

--- a/src/planner/binder/expression/bind_window_expression.cpp
+++ b/src/planner/binder/expression/bind_window_expression.cpp
@@ -283,7 +283,7 @@ BindResult BaseSelectBinder::BindWindowExpression(WindowExpression &window, idx_
 			                      window.FunctionName());
 		}
 		if (window.HasIgnoreNulls() && !bound_function.CanIgnoreNulls()) {
-			throw BinderException(error_context, "RESPECT/IGNORE NULLS is not supported for the window function \"%s\"",
+			throw BinderException(error_context, "RESPECT/IGNORE NULLS is not supported for the window function %s",
 			                      window.FunctionName());
 		}
 

--- a/src/planner/binder/query_node/bind_select_node.cpp
+++ b/src/planner/binder/query_node/bind_select_node.cpp
@@ -734,15 +734,14 @@ BoundStatement Binder::BindSelectNode(SelectNode &statement, BoundStatement from
 			}
 			if (!bound_columns.empty()) {
 				string error;
-				error = "column \"%s\" must appear in the GROUP BY clause or must be part of an aggregate function.";
+				error = "column %s must appear in the GROUP BY clause or must be part of an aggregate function.";
 				if (statement.aggregate_handling == AggregateHandling::FORCE_AGGREGATES) {
 					error += "\nGROUP BY ALL will only group entries in the SELECT list. Add it to the SELECT list or "
 					         "GROUP BY this entry explicitly.";
 					throw BinderException(bound_columns[0].query_location, error, bound_columns[0].name);
 				} else {
-					error +=
-					    "\nEither add it to the GROUP BY list, or use \"ANY_VALUE(%s)\" if the exact value of \"%s\" "
-					    "is not important.";
+					error += "\nEither add it to the GROUP BY list, or use ANY_VALUE(%s) if the exact value of %s "
+					         "is not important.";
 					throw BinderException(bound_columns[0].query_location, error, bound_columns[0].name,
 					                      bound_columns[0].name, bound_columns[0].name);
 				}

--- a/src/planner/binder/query_node/bind_trigger_expansion.cpp
+++ b/src/planner/binder/query_node/bind_trigger_expansion.cpp
@@ -50,7 +50,7 @@ unique_ptr<BoundStatement> Binder::TryExpandTriggers(QueryNode &node, TableCatal
 	if (expanded_tables.find(table) != expanded_tables.end()) {
 		if (global_binder_state->trigger_creation_table == &table) {
 			throw NotImplementedException("Recursive trigger chains are not yet supported (trigger cycle detected "
-			                              "through trigger \"%s\" on table \"%s\")",
+			                              "through trigger %s on table %s)",
 			                              global_binder_state->trigger_creation_name, table.name);
 		}
 		return nullptr;
@@ -679,7 +679,7 @@ BoundStatement Binder::ExpandRowTriggers(QueryNode &node, vector<unique_ptr<Pars
 
 		CorrelatedColumns corr_cols = std::move(child_binder->correlated_columns);
 		if (corr_cols.empty()) {
-			throw BinderException("FOR EACH ROW trigger \"%s\" on table \"%s\" must reference at least one NEW or OLD "
+			throw BinderException("FOR EACH ROW trigger %s on table %s must reference at least one NEW or OLD "
 			                      "column in the trigger body (use FOR EACH STATEMENT if row data is not needed)",
 			                      trigger.name, table.name);
 		}

--- a/src/planner/binder/statement/bind_copy_database.cpp
+++ b/src/planner/binder/statement/bind_copy_database.cpp
@@ -109,8 +109,8 @@ BoundStatement Binder::Bind(CopyDatabaseStatement &stmt) {
 	auto &source_catalog = Catalog::GetCatalog(context, stmt.from_database);
 	auto &target_catalog = Catalog::GetCatalog(context, stmt.to_database);
 	if (&source_catalog == &target_catalog) {
-		throw BinderException("Cannot copy from \"%s\" to \"%s\" - FROM and TO databases are the same",
-		                      stmt.from_database, stmt.to_database);
+		throw BinderException("Cannot copy from %s to %s - FROM and TO databases are the same", stmt.from_database,
+		                      stmt.to_database);
 	}
 	if (stmt.copy_type == CopyDatabaseType::COPY_SCHEMA) {
 		result.types = {LogicalType::BOOLEAN};

--- a/src/planner/binder/statement/bind_create.cpp
+++ b/src/planner/binder/statement/bind_create.cpp
@@ -96,8 +96,8 @@ void Binder::BindSchemaOrCatalog(CatalogEntryRetriever &retriever, Identifier &c
 		}
 		if (catalog_ptr->CheckAmbiguousCatalogOrSchema(context, schema)) {
 			throw BinderException(
-			    "Ambiguous reference to catalog or schema \"%s\" - use a fully qualified path like \"%s.%s\"",
-			    schema.GetIdentifierName(), catalog_name.GetIdentifierName(), schema.GetIdentifierName());
+			    "Ambiguous reference to catalog or schema %s - use a fully qualified path like '%s.%s'", schema,
+			    SQLIdentifier(catalog_name), SQLIdentifier(schema));
 		}
 	}
 	catalog = schema;
@@ -457,7 +457,7 @@ SchemaCatalogEntry &Binder::BindCreateFunctionInfo(CreateInfo &info) {
 				continue;
 			}
 
-			ConstantBinder binder(*this, context, StringUtil::Format("Default value for parameter '%s'", param_name));
+			ConstantBinder binder(*this, context, StringUtil::Format("Default value for parameter %s", param_name));
 			auto default_expr = param_expr->Copy();
 			auto bound_default = binder.Bind(default_expr);
 			if (!bound_default->IsFoldable()) {
@@ -760,7 +760,7 @@ SchemaCatalogEntry &Binder::BindCreateTriggerInfo(CreateTriggerInfo &create_trig
 		auto bound_body = body_binder->Bind(*body_copy);
 		validation_binder->GetActiveBinders().pop_back();
 		if (body_binder->correlated_columns.empty()) {
-			throw BinderException("FOR EACH ROW trigger \"%s\" on table \"%s\" must reference at least one NEW or OLD "
+			throw BinderException("FOR EACH ROW trigger %s on table %s must reference at least one NEW or OLD "
 			                      "column in the trigger body (use FOR EACH STATEMENT if row data is not needed)",
 			                      create_trigger_info.GetTriggerName(), table.name);
 		}

--- a/src/planner/binder/statement/bind_create_table.cpp
+++ b/src/planner/binder/statement/bind_create_table.cpp
@@ -74,9 +74,9 @@ static void VerifyCompressionType(ClientContext &context, optional_ptr<StorageMa
 		}
 		auto compression_method = config.TryGetCompressionFunction(compression_type, physical_type);
 		if (!compression_method) {
-			throw BinderException(
-			    "Can't compress column \"%s\" with type '%s' (physical: %s) using compression type '%s'", col.Name(),
-			    logical_type.ToString(), EnumUtil::ToString(physical_type), CompressionTypeToString(compression_type));
+			throw BinderException("Can't compress column %s with type '%s' (physical: %s) using compression type '%s'",
+			                      col.Name(), logical_type.ToString(), EnumUtil::ToString(physical_type),
+			                      CompressionTypeToString(compression_type));
 		}
 	}
 }
@@ -122,7 +122,7 @@ vector<unique_ptr<BoundConstraint>> Binder::BindNewConstraints(vector<unique_ptr
 			const auto &unique = bound_constr->Cast<BoundUniqueConstraint>();
 			if (unique.is_primary_key) {
 				if (has_primary_key) {
-					throw ParserException("table \"%s\" has more than one primary key", table_name);
+					throw ParserException("table %s has more than one primary key", table_name);
 				}
 				has_primary_key = true;
 				primary_keys = unique.keys;
@@ -187,11 +187,12 @@ unique_ptr<BoundConstraint> Binder::BindUniqueConstraint(const Constraint &const
 	// The UNIQUE constraint is defined on a list of columns.
 	for (auto &col_name : unique.GetColumnNames()) {
 		if (!columns.ColumnExists(col_name)) {
-			throw CatalogException("table \"%s\" does not have a column named \"%s\"", table, col_name);
+			throw CatalogException("table %s does not have a column named %s", table, col_name);
 		}
 		auto &col = columns.GetColumn(col_name);
 		if (col.Generated()) {
-			throw BinderException("cannot create a PRIMARY KEY on a generated column: %s", col.GetName());
+			throw BinderException("cannot create a PRIMARY KEY on a generated column: %s",
+			                      SQLIdentifier(col.GetName()));
 		}
 
 		auto physical_index = col.Physical();
@@ -441,7 +442,7 @@ static void FindForeignKeyIndexes(const ColumnList &columns, const vector<Identi
 	D_ASSERT(!names.empty());
 	for (auto &name : names) {
 		if (!columns.ColumnExists(name)) {
-			throw BinderException("column \"%s\" named in key does not exist", name.GetIdentifierName());
+			throw BinderException("column %s named in key does not exist", name);
 		}
 		auto &column = columns.GetColumn(name);
 		if (column.Generated()) {
@@ -507,22 +508,21 @@ static void FindMatchingPrimaryKeyColumns(const ColumnList &columns, const vecto
 	if (!found_constraint) {
 		// no unique constraint or primary key
 		string search_term = find_primary_key ? "primary key" : "primary key or unique constraint";
-		throw BinderException("Failed to create foreign key: there is no %s for referenced table \"%s\"", search_term,
-		                      fk.info.table.GetIdentifierName());
+		throw BinderException("Failed to create foreign key: there is no %s for referenced table %s", search_term,
+		                      fk.info.table);
 	}
 	// check if all the columns exist
 	for (auto &name : fk.pk_columns) {
 		bool found = columns.ColumnExists(name);
 		if (!found) {
-			throw BinderException(
-			    "Failed to create foreign key: referenced table \"%s\" does not have a column named \"%s\"",
-			    fk.info.table.GetIdentifierName(), name);
+			throw BinderException("Failed to create foreign key: referenced table %s does not have a column named %s",
+			                      fk.info.table, name);
 		}
 	}
 	auto fk_names = StringUtil::Join(fk.pk_columns, ",");
-	throw BinderException("Failed to create foreign key: referenced table \"%s\" does not have a primary key or unique "
+	throw BinderException("Failed to create foreign key: referenced table %s does not have a primary key or unique "
 	                      "constraint on the columns %s",
-	                      fk.info.table.GetIdentifierName(), fk_names);
+	                      fk.info.table, fk_names);
 }
 
 static void CheckForeignKeyTypes(const ColumnList &pk_columns, const ColumnList &fk_columns, ForeignKeyConstraint &fk) {
@@ -531,8 +531,8 @@ static void CheckForeignKeyTypes(const ColumnList &pk_columns, const ColumnList 
 		auto &pk_col = pk_columns.GetColumn(fk.info.pk_keys[c_idx]);
 		auto &fk_col = fk_columns.GetColumn(fk.info.fk_keys[c_idx]);
 		if (pk_col.Type() != fk_col.Type()) {
-			throw BinderException("Failed to create foreign key: incompatible types between column \"%s\" (\"%s\") and "
-			                      "column \"%s\" (\"%s\")",
+			throw BinderException("Failed to create foreign key: incompatible types between column %s (\"%s\") and "
+			                      "column %s (\"%s\")",
 			                      pk_col.Name(), pk_col.Type().ToString(), fk_col.Name(), fk_col.Type().ToString());
 		}
 	}

--- a/src/planner/binder/statement/bind_drop.cpp
+++ b/src/planner/binder/statement/bind_drop.cpp
@@ -95,7 +95,7 @@ BoundStatement Binder::Bind(DropStatement &stmt) {
 			break;
 		}
 		if (entry->internal) {
-			throw CatalogException("Cannot drop internal catalog entry \"%s\"!", entry->name.GetIdentifierName());
+			throw CatalogException("Cannot drop internal catalog entry %s!", entry->name);
 		}
 		// keep the entry's full (possibly nested) schema path so execution navigates the same schema
 		stmt.info->SetQualifiedName(entry->ParentSchema().GetQualifiedName(stmt.info->GetQualifiedName().Name()));

--- a/src/planner/binder/statement/bind_execute.cpp
+++ b/src/planner/binder/statement/bind_execute.cpp
@@ -21,7 +21,7 @@ BoundStatement Binder::Bind(ExecuteStatement &stmt) {
 
 	auto entry = client_data.prepared_statements.find(stmt.name);
 	if (entry == client_data.prepared_statements.end()) {
-		throw BinderException("Prepared statement \"%s\" does not exist", stmt.name);
+		throw BinderException("Prepared statement %s does not exist", stmt.name);
 	}
 
 	// check if we need to rebind the prepared statement

--- a/src/planner/binder/statement/bind_insert.cpp
+++ b/src/planner/binder/statement/bind_insert.cpp
@@ -290,7 +290,7 @@ void Binder::BindInsertColumnList(TableCatalogEntry &table, vector<Identifier> &
 		for (idx_t i = 0; i < columns.size(); i++) {
 			auto entry = column_name_map.insert(make_pair(columns[i], i));
 			if (!entry.second) {
-				throw BinderException("Duplicate column name \"%s\" in INSERT", columns[i]);
+				throw BinderException("Duplicate column name %s in INSERT", columns[i]);
 			}
 			auto column_index = table.GetColumnIndex(columns[i]);
 			if (column_index.index == COLUMN_IDENTIFIER_ROW_ID) {

--- a/src/planner/binder/statement/bind_vacuum.cpp
+++ b/src/planner/binder/statement/bind_vacuum.cpp
@@ -53,7 +53,7 @@ void Binder::BindVacuumTable(LogicalVacuum &vacuum, unique_ptr<LogicalOperator> 
 		// ignore generated column
 		if (col.Generated()) {
 			throw BinderException(
-			    "cannot vacuum or analyze generated column \"%s\" - specify non-generated columns to vacuum or analyze",
+			    "cannot vacuum or analyze generated column %s - specify non-generated columns to vacuum or analyze",
 			    col.GetName());
 		}
 		non_generated_column_names.emplace_back(col_name);

--- a/src/planner/binder/tableref/bind_basetableref.cpp
+++ b/src/planner/binder/tableref/bind_basetableref.cpp
@@ -222,9 +222,9 @@ BoundStatement Binder::Bind(BaseTableRef &ref) {
 		if (ctebinding) {
 			D_ASSERT(!ctebinding->CanBeReferenced());
 			throw BinderException(error_context,
-			                      "Circular reference to CTE \"%s\", use WITH RECURSIVE to "
+			                      "Circular reference to CTE %s, use WITH RECURSIVE to "
 			                      "use recursive CTEs.",
-			                      ref.Table().GetIdentifierName());
+			                      ref.Table());
 		}
 		// could not find an alternative: bind again to get the error
 		// note: this will always throw when using DuckDB as a catalog, but a second look-up might succeed

--- a/src/planner/binder/tableref/bind_joinref.cpp
+++ b/src/planner/binder/tableref/bind_joinref.cpp
@@ -69,8 +69,7 @@ bool Binder::TryFindBinding(const Identifier &using_column, const string &join_s
 BindingAlias Binder::FindBinding(const Identifier &using_column, const string &join_side) {
 	BindingAlias result;
 	if (!TryFindBinding(using_column, join_side, result)) {
-		throw BinderException("Column \"%s\" does not exist on %s side of join!", using_column.GetIdentifierName(),
-		                      join_side);
+		throw BinderException("Column %s does not exist on %s side of join!", using_column, join_side);
 	}
 	return result;
 }

--- a/src/planner/binder/tableref/bind_named_parameters.cpp
+++ b/src/planner/binder/tableref/bind_named_parameters.cpp
@@ -37,7 +37,7 @@ void Binder::BindNamedParameters(named_parameter_type_map_t &types, named_parame
 			} else {
 				error_msg = "Candidates:\n" + named_params;
 			}
-			throw BinderException(error_context, "Invalid named parameter \"%s\" for function %s\n%s", kv.first,
+			throw BinderException(error_context, "Invalid named parameter %s for function %s\n%s", kv.first,
 			                      func_name.GetIdentifierName(), error_msg);
 		}
 		if (entry->second.id() != LogicalTypeId::ANY) {

--- a/src/planner/binder/tableref/bind_pivot.cpp
+++ b/src/planner/binder/tableref/bind_pivot.cpp
@@ -643,8 +643,8 @@ unique_ptr<SelectNode> Binder::BindPivot(PivotRef &ref, vector<unique_ptr<Parsed
 			    context, QualifiedName(Identifier::InvalidCatalog(), Identifier::InvalidSchema(), pivot.pivot_enum));
 			auto type = type_entry.user_type;
 			if (type.id() != LogicalTypeId::ENUM) {
-				throw BinderException(ref, "Pivot must reference an ENUM type: \"%s\" is of type \"%s\"",
-				                      pivot.pivot_enum, type.ToString());
+				throw BinderException(ref, "Pivot must reference an ENUM type: %s is of type \"%s\"", pivot.pivot_enum,
+				                      type.ToString());
 			}
 			if (!type.IsComplete()) {
 				throw BinderException("ENUM type is incomplete");

--- a/src/planner/collation_binding.cpp
+++ b/src/planner/collation_binding.cpp
@@ -48,7 +48,7 @@ static vector<string> GetVarcharCollationFunctions(ClientContext &context, const
 			entries.insert(entries.begin(), collation_entry);
 		} else {
 			if (!entries.empty() && !entries.back().get().combinable) {
-				throw BinderException("Cannot combine collation types \"%s\" and \"%s\"", entries.back().get().name,
+				throw BinderException("Cannot combine collation types %s and %s", entries.back().get().name,
 				                      collation_entry.name);
 			}
 			entries.push_back(collation_entry);

--- a/src/planner/expression_binder/index_binder.cpp
+++ b/src/planner/expression_binder/index_binder.cpp
@@ -24,8 +24,8 @@ unique_ptr<BoundIndex> IndexBinder::BindIndex(const UnboundIndex &unbound_index)
 	// Do we know the type of this index now?
 	auto index_type = context.db->config.GetIndexTypes().FindByName(index_type_name);
 	if (!index_type) {
-		throw MissingExtensionException("Cannot bind index '%s', unknown index type '%s'. You need to load the "
-		                                "extension that provides this index type before table '%s' can be modified.",
+		throw MissingExtensionException("Cannot bind index %s, unknown index type '%s'. You need to load the "
+		                                "extension that provides this index type before table %s can be modified.",
 		                                unbound_index.GetTableName(), index_type_name, unbound_index.GetTableName());
 	}
 

--- a/src/planner/expression_binder/select_binder.cpp
+++ b/src/planner/expression_binder/select_binder.cpp
@@ -24,14 +24,14 @@ bool SelectBinder::TryResolveAliasReference(ColumnRefExpression &colref, idx_t d
 	auto alias_index = entry->second;
 	// Simple way to prevent circular aliasing (`SELECT alias.y as x, alias.x as y;`)
 	if (alias_index >= node.bound_column_count) {
-		throw BinderException("Column \"%s\" referenced that exists in the SELECT clause - but this column "
+		throw BinderException("Column %s referenced that exists in the SELECT clause - but this column "
 		                      "cannot be referenced before it is defined",
 		                      colref.ColumnNames().back());
 	}
 
 	if (node.bind_state.AliasHasSubquery(alias_index)) {
 		throw BinderException(colref,
-		                      "Alias \"%s\" referenced in a SELECT clause - but the expression has a subquery. This is "
+		                      "Alias %s referenced in a SELECT clause - but the expression has a subquery. This is "
 		                      "not yet supported.",
 		                      alias_name);
 	}

--- a/src/planner/operator/logical_get.cpp
+++ b/src/planner/operator/logical_get.cpp
@@ -405,10 +405,9 @@ unique_ptr<LogicalOperator> LogicalGet::Deserialize(Deserializer &deserializer) 
 				auto &ret_type = result->returned_types[idx];
 				auto &col_name = result->names[idx];
 				if (bind_return_types[idx] != ret_type) {
-					throw SerializationException(
-					    "Table function deserialization failure in function \"%s\" - column with "
-					    "name %s was serialized with type %s, but now has type %s",
-					    function.name, col_name, ret_type, bind_return_types[idx]);
+					throw SerializationException("Table function deserialization failure in function %s - column with "
+					                             "name %s was serialized with type %s, but now has type %s",
+					                             function.name, col_name, ret_type, bind_return_types[idx]);
 				}
 			}
 		}

--- a/src/planner/table_binding.cpp
+++ b/src/planner/table_binding.cpp
@@ -31,7 +31,7 @@ void Binding::Initialize() {
 		auto &name = names[i];
 		D_ASSERT(!name.empty());
 		if (name_map.find(name) != name_map.end()) {
-			throw BinderException("table \"%s\" has duplicate column name \"%s\"", alias.GetAlias(), name);
+			throw BinderException("table %s has duplicate column name %s", alias.GetAlias(), name);
 		}
 		name_map[name] = i;
 	}
@@ -114,8 +114,8 @@ void Binding::SetBoundColumnAlias(ColumnRefExpression &colref) {
 }
 
 ErrorData Binding::ColumnNotFoundError(const Identifier &column_name) const {
-	return ErrorData(ExceptionType::BINDER, StringUtil::Format("Values list \"%s\" does not have a column named \"%s\"",
-	                                                           GetAlias(), column_name));
+	return ErrorData(ExceptionType::BINDER,
+	                 StringUtil::Format("Values list %s does not have a column named %s", GetAlias(), column_name));
 }
 
 BindResult Binding::Bind(ColumnRefExpression &colref, idx_t depth) {
@@ -320,7 +320,7 @@ optional_ptr<StandardEntry> TableBinding::GetStandardEntry() {
 ErrorData TableBinding::ColumnNotFoundError(const Identifier &column_name) const {
 	auto candidate_message = StringUtil::CandidatesErrorMessage(
 	    IdentifiersToStrings(names), column_name.GetIdentifierName(), "Candidate bindings: ");
-	return ErrorData(ExceptionType::BINDER, StringUtil::Format("Table \"%s\" does not have a column named \"%s\"\n%s",
+	return ErrorData(ExceptionType::BINDER, StringUtil::Format("Table %s does not have a column named %s\n%s",
 	                                                           alias.GetAlias(), column_name, candidate_message));
 }
 

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -64,8 +64,7 @@ IndexStorageInfo DataTableInfo::ExtractIndexStorageInfo(const Identifier &name) 
 			return result;
 		}
 	}
-	throw InternalException("ExtractIndexStorageInfo: index storage info with name '%s' not found",
-	                        name.GetIdentifierName());
+	throw InternalException("ExtractIndexStorageInfo: index storage info with name %s not found", name);
 }
 
 DataTable::DataTable(AttachedDatabase &db, shared_ptr<TableIOManager> table_io_manager_p,
@@ -424,7 +423,7 @@ void DataTable::RebuildIndexes() {
 
 			auto error = bound_index.Append(table_chunk, row_ids);
 			if (error.HasError()) {
-				throw InternalException("Failed to rebuild index '%s' after vacuum: %s", bound_index.GetIndexName(),
+				throw InternalException("Failed to rebuild index %s after vacuum: %s", bound_index.GetIndexName(),
 				                        error.Message());
 			}
 		}
@@ -591,7 +590,7 @@ static void VerifyNotNullConstraint(TableCatalogEntry &table, const Vector &vect
 		return;
 	}
 
-	throw ConstraintException("NOT NULL constraint failed: %s.%s", table.name, col_name);
+	throw ConstraintException("NOT NULL constraint failed: %s.%s", SQLIdentifier(table.name), SQLIdentifier(col_name));
 }
 
 // To avoid throwing an error at SELECT, instead this moves the error detection to INSERT
@@ -607,8 +606,9 @@ static void VerifyGeneratedExpressionSuccess(ClientContext &context, TableCatalo
 		throw;
 	} catch (std::exception &ex) {
 		ErrorData error(ex);
-		throw ConstraintException("Incorrect value for generated column \"%s %s AS (%s)\" : %s", col.Name(),
-		                          col.Type().ToString(), col.GeneratedExpression().ToString(), error.RawMessage());
+		throw ConstraintException("Incorrect value for generated column '%s %s AS (%s)' : %s",
+		                          SQLIdentifier(col.Name()), col.Type().ToString(),
+		                          col.GeneratedExpression().ToString(), error.RawMessage());
 	}
 }
 

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -778,9 +778,9 @@ void SingleFileStorageManager::CreateCheckpoint(QueryContext context, Checkpoint
 			}
 			// A non-initial database can be detached and reattached, so scope invalidation to this db.
 			db.Invalidate(error.RawMessage());
-			throw IOException("Checkpoint failed for database \"%s\". The database has been invalidated. Original "
+			throw IOException("Checkpoint failed for database %s. The database has been invalidated. Original "
 			                  "error: %s",
-			                  db.GetName().GetIdentifierName(), error.RawMessage());
+			                  db.GetName(), error.RawMessage());
 		}
 	}
 

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -2512,7 +2512,8 @@ void RowGroupCollection::VerifyNewConstraint(const QueryContext &context, DataTa
 		// Verify the NOT NULL constraint.
 		if (VectorOperations::HasNull(scan_chunk.data[0])) {
 			auto name = parent.Columns()[physical_index].GetName();
-			throw ConstraintException("NOT NULL constraint failed: %s.%s", info->GetTableName(), name);
+			throw ConstraintException("NOT NULL constraint failed: %s.%s", SQLIdentifier(info->GetTableName()),
+			                          SQLIdentifier(name));
 		}
 	}
 }

--- a/src/transaction/meta_transaction.cpp
+++ b/src/transaction/meta_transaction.cpp
@@ -271,7 +271,7 @@ void MetaTransaction::ModifyDatabase(AttachedDatabase &db, DatabaseModificationT
 	}
 	if (&db != modified_database.get()) {
 		throw TransactionException(
-		    "Attempting to write to database \"%s\" in a transaction that has already modified database \"%s\" - a "
+		    "Attempting to write to database %s in a transaction that has already modified database %s - a "
 		    "single transaction can only write to a single attached database.",
 		    db.GetName(), modified_database->GetName());
 	}

--- a/test/extension/test_custom_type_modifier.test_slow
+++ b/test/extension/test_custom_type_modifier.test_slow
@@ -97,7 +97,7 @@ CREATE TYPE user_type AS INTEGER
 statement error
 CREATE TABLE t4 (i user_type(NULL));
 ----
-Binder Error: Type 'user_type' does not take any type parameters
+Binder Error: Type "user_type" does not take any type parameters
 
 statement error
 SELECT 1::BOUNDED(NULL)

--- a/test/extension/test_function_named_args.test
+++ b/test/extension/test_function_named_args.test
@@ -290,13 +290,13 @@ SELECT test_named_inspect();
 statement error
 SELECT test_named_inspect(b := 2);
 ----
-<REGEX>:Binder Error:.*Missing value for parameter 'a'.*
+<REGEX>:Binder Error:.*Missing value for parameter "a".*
 
 # A named vararg cannot satisfy a required positional parameter
 statement error
 SELECT test_named_varargs(x := 5);
 ----
-<REGEX>:Binder Error:.*Missing value for parameter 'a'.*
+<REGEX>:Binder Error:.*Missing value for parameter "a".*
 
 # Unknown parameter name on a function without varargs -> no candidate overload
 statement error
@@ -376,7 +376,7 @@ SELECT test_named_agg_inspect(x, c := 9) FROM (VALUES (5)) t(x);
 statement error
 SELECT test_named_agg_inspect(b := 2);
 ----
-<REGEX>:Binder Error:.*Missing value for parameter 'a'.*
+<REGEX>:Binder Error:.*Missing value for parameter "a".*
 
 ###===--------------------------------------------------------------------===#
 ## Automatic capturing of aliases as named arguments

--- a/test/extension/wrong_function_type.test
+++ b/test/extension/wrong_function_type.test
@@ -12,10 +12,10 @@ require no_extension_autoloading "EXPECTED: Test relies on autoloading being dis
 statement error
 select json_execute_serialized_sql(42) from range(5);
 ----
-Catalog Error: Scalar Function with name json_execute_serialized_sql is not in the catalog, functions with this name exist in the json extension, but they are of different types, namely Pragma Function, Table Function
+Catalog Error: Scalar Function with name "json_execute_serialized_sql" is not in the catalog, functions with this name exist in the json extension, but they are of different types, namely Pragma Function, Table Function
 
 # One of the two options is Table Function
 statement error
 CALL json_execute_serialized_sql('test');
 ----
-Catalog Error: Table Function with name json_execute_serialized_sql is not in the catalog, but it exists in the json extension.
+Catalog Error: Table Function with name "json_execute_serialized_sql" is not in the catalog, but it exists in the json extension.

--- a/test/fuzzer/pedro/restart_current_time.test
+++ b/test/fuzzer/pedro/restart_current_time.test
@@ -7,4 +7,4 @@ load {TEST_DIR}/restart_current_time.db
 statement error
 CREATE TABLE t0 (c1 INT, CHECK (CURRENT_TIME >= TIME '00:00:00'));
 ----
-Table does not contain column CURRENT_TIME
+Table does not contain column "CURRENT_TIME"

--- a/test/sql/aggregate/aggregates/approx_top_k.test
+++ b/test/sql/aggregate/aggregates/approx_top_k.test
@@ -85,7 +85,7 @@ FROM (VALUES
   (5,  49, 2)
 ) AS t(id, x, k)
 ----
-Binder Error: The 'col1' argument in function 'approx_top_k' must be a constant expression
+Binder Error: The "col1" argument in function "approx_top_k" must be a constant expression
 
 statement error
 SELECT id,
@@ -103,4 +103,4 @@ FROM (VALUES
 ) AS t(id, x, k)
 ORDER BY id;
 ----
-Binder Error: The 'col1' argument in function 'approx_top_k' must be a constant expression
+Binder Error: The "col1" argument in function "approx_top_k" must be a constant expression

--- a/test/sql/alter/alter_type/test_alter_type_incorrect.test
+++ b/test/sql/alter/alter_type/test_alter_type_incorrect.test
@@ -18,7 +18,7 @@ Binder Error: Table "test" does not have a column with name "blabla"
 statement error
 ALTER TABLE test ALTER i SET TYPE VARCHAR USING blabla
 ----
-Binder Error: Table does not contain column blabla referenced
+Binder Error: Table does not contain column "blabla" referenced
 
 # cannot use aggregates/window functions
 statement error

--- a/test/sql/alter/list/add_column_in_struct.test
+++ b/test/sql/alter/list/add_column_in_struct.test
@@ -64,4 +64,4 @@ SELECT * FROM test;
 statement error
 ALTER TABLE test ADD COLUMN s.a.not_element INTEGER
 ----
-<REGEX>:Binder Error.*Column a is not a struct - ALTER TABLE can only add fields to structs.*
+<REGEX>:Binder Error.*Column "a" is not a struct - ALTER TABLE can only add fields to structs.*

--- a/test/sql/alter/list/rename_column_in_struct.test
+++ b/test/sql/alter/list/rename_column_in_struct.test
@@ -18,7 +18,7 @@ INSERT INTO test VALUES
 statement error
 ALTER TABLE test RENAME COLUMN s.element TO not_element
 ----
-Catalog Error: Cannot rename field 'element' from column 's' - can only rename fields inside a struct
+Catalog Error: Cannot rename field "element" from column "s" - can only rename fields inside a struct
 
 statement ok
 ALTER TABLE test RENAME COLUMN s.element.j TO k

--- a/test/sql/alter/map/add_column_in_struct.test
+++ b/test/sql/alter/map/add_column_in_struct.test
@@ -119,10 +119,10 @@ select * from test;
 statement error
 ALTER TABLE test ADD COLUMN s.a.not_key INTEGER
 ----
-Binder Error: Column a is not a struct - ALTER TABLE can only add fields to structs
+Binder Error: Column "a" is not a struct - ALTER TABLE can only add fields to structs
 
 # attempt to add the 'key' field to a map
 statement error
 ALTER TABLE test ADD COLUMN s.a.key INTEGER
 ----
-Binder Error: Column a is not a struct - ALTER TABLE can only add fields to structs
+Binder Error: Column "a" is not a struct - ALTER TABLE can only add fields to structs

--- a/test/sql/alter/map/drop_column_in_struct.test
+++ b/test/sql/alter/map/drop_column_in_struct.test
@@ -24,13 +24,13 @@ INSERT INTO test VALUES
 statement error
 ALTER TABLE test DROP COLUMN s.key
 ----
-Catalog Error: Cannot drop field 'key' from column 's' - it's not a struct
+Catalog Error: Cannot drop field "key" from column "s" - it's not a struct
 
 # attempt to drop 'value' from the map
 statement error
 ALTER TABLE test DROP COLUMN s.value
 ----
-Catalog Error: Cannot drop field 'value' from column 's' - it's not a struct
+Catalog Error: Cannot drop field "value" from column "s" - it's not a struct
 
 
 # drop a column from the struct inside the 'value'

--- a/test/sql/alter/map/rename_column_in_struct.test
+++ b/test/sql/alter/map/rename_column_in_struct.test
@@ -24,13 +24,13 @@ INSERT INTO test VALUES
 statement error
 ALTER TABLE test RENAME COLUMN s.key to anything
 ----
-Catalog Error: Cannot rename field 'key' from column 's' - can only rename fields inside a struct
+Catalog Error: Cannot rename field "key" from column "s" - can only rename fields inside a struct
 
 # attempt to rename 'value'
 statement error
 ALTER TABLE test RENAME COLUMN s.value to anything
 ----
-Catalog Error: Cannot rename field 'value' from column 's' - can only rename fields inside a struct
+Catalog Error: Cannot rename field "value" from column "s" - can only rename fields inside a struct
 
 
 # rename a column from the struct inside the 'value'

--- a/test/sql/alter/struct/add_col_nested_struct.test
+++ b/test/sql/alter/struct/add_col_nested_struct.test
@@ -22,7 +22,7 @@ SELECT * FROM test
 statement error
 ALTER TABLE test ADD COLUMN s.s2.v1 VARCHAR
 ----
-field already exists in struct s2
+field already exists in struct "s2"
 
 # this just gets ignored
 statement ok
@@ -41,5 +41,5 @@ SELECT * FROM test
 statement error
 ALTER TABLE test ADD COLUMN s.s2.v1.x INTEGER
 ----
-Binder Error: Column 'v1' is not a nested type, ADD COLUMN can only be used on nested types
+Binder Error: Column "v1" is not a nested type, ADD COLUMN can only be used on nested types
 

--- a/test/sql/alter/struct/add_col_struct.test
+++ b/test/sql/alter/struct/add_col_struct.test
@@ -54,7 +54,7 @@ SELECT * FROM test
 statement error
 ALTER TABLE test ADD COLUMN s.i VARCHAR
 ----
-field already exists in struct s
+field already exists in struct "s"
 
 # this just gets ignored
 statement ok
@@ -70,7 +70,7 @@ SELECT * FROM test
 statement error
 ALTER TABLE test ADD COLUMN s.i.a INTEGER
 ----
-Binder Error: Column 'i' is not a nested type, ADD COLUMN can only be used on nested types
+Binder Error: Column "i" is not a nested type, ADD COLUMN can only be used on nested types
 
 # nested column does not exist
 statement error

--- a/test/sql/binder/test_having_alias.test
+++ b/test/sql/binder/test_having_alias.test
@@ -19,7 +19,7 @@ SELECT i, COUNT(*) AS k FROM integers GROUP BY i HAVING k=1 ORDER BY i;
 statement error
 SELECT i, COUNT(*) AS k FROM integers GROUP BY i HAVING integers.k=1 ORDER BY i;
 ----
-Binder Error: column k must appear in the GROUP BY clause
+Binder Error: column "k" must appear in the GROUP BY clause
 
 # column name wins over the alias
 query II
@@ -75,10 +75,10 @@ SELECT COUNT(*) FROM (SELECT i, SUM(RANDOM()) AS k FROM integers GROUP BY i HAVI
 statement error
 SELECT COUNT(i) AS i FROM integers HAVING integers.i=5 ORDER BY i;
 ----
-Binder Error: column i must appear in the GROUP BY clause
+Binder Error: column "i" must appear in the GROUP BY clause
 
 # recursive alias without aggregate
 statement error
 SELECT i + i AS i FROM integers HAVING i=5 ORDER BY i;
 ----
-Binder Error: column i must appear in the GROUP BY clause
+Binder Error: column "i" must appear in the GROUP BY clause

--- a/test/sql/catalog/comment_on_extended.test
+++ b/test/sql/catalog/comment_on_extended.test
@@ -108,7 +108,7 @@ db2	s2	very gezellige index 2
 statement error
 COMMENT ON COLUMN col1 IS 'no bueno'
 ----
-Parser Error: Invalid column reference: 'col1'
+Parser Error: Invalid column reference: col1
 
 statement error
 COMMENT ON COLUMN galaxy.db.schema.table.col1 IS 'no bueno'

--- a/test/sql/catalog/dependencies/test_alter_dependency_ownership.test
+++ b/test/sql/catalog/dependencies/test_alter_dependency_ownership.test
@@ -506,7 +506,7 @@ Dependency Error: "sequence2" can not become the owner, it is already owned by "
 statement error
 ALTER SEQUENCE sequence1 OWNED BY sequence3;
 ----
-Dependency Error: sequence1 already owns sequence2. Cannot have circular dependencies
+Dependency Error: "sequence1" already owns "sequence2". Cannot have circular dependencies
 
 statement ok
 ALTER SEQUENCE sequence3 OWNED BY sequence4;

--- a/test/sql/catalog/dependencies/test_alter_dependency_ownership.test
+++ b/test/sql/catalog/dependencies/test_alter_dependency_ownership.test
@@ -110,7 +110,7 @@ ALTER SEQUENCE sequence1 OWNED BY tablename;
 statement error
 ALTER SEQUENCE sequence1 OWNED BY tablename2;
 ----
-Dependency Error: sequence1 is already owned by tablename
+Dependency Error: "sequence1" is already owned by "tablename"
 
 statement ok
 DROP TABLE tablename;
@@ -240,7 +240,7 @@ CREATE TABLE tablename (
 statement error
 ALTER SEQUENCE sequence1 OWNED BY tablename;
 ----
-sequence1 is already owned by new_tablename
+"sequence1" is already owned by "new_tablename"
 
 statement error
 DROP SEQUENCE sequence1;
@@ -475,7 +475,7 @@ ALTER SEQUENCE sequence1 OWNED BY sequence2;
 statement error
 ALTER SEQUENCE sequence2 OWNED BY sequence1;
 ----
-Dependency Error: sequence1 can not become the owner, it is already owned by sequence2
+Dependency Error: "sequence1" can not become the owner, it is already owned by "sequence2"
 
 statement ok
 DROP SEQUENCE sequence2;
@@ -499,7 +499,7 @@ ALTER SEQUENCE sequence2 OWNED BY sequence1;
 statement error
 ALTER SEQUENCE sequence3 OWNED BY sequence2;
 ----
-Dependency Error: sequence2 can not become the owner, it is already owned by sequence1
+Dependency Error: "sequence2" can not become the owner, it is already owned by "sequence1"
 
 # FIXME: this error makes no sense, if there is no circular dependency
 # this should be allowed

--- a/test/sql/catalog/function/test_macro_default_arg.test
+++ b/test/sql/catalog/function/test_macro_default_arg.test
@@ -43,7 +43,7 @@ select f(x:=a) from t;
 statement error
 create macro my_macro1(a, b := a) as a + b;
 ----
-Binder Error: Default value for parameter 'b' cannot contain column names
+Binder Error: Default value for parameter "b" cannot contain column names
 
 
 statement ok
@@ -55,7 +55,7 @@ create macro my_macro2(a := i) as (
 	select min(a) from integers
 )
 ----
-Binder Error: Default value for parameter 'a' cannot contain column names
+Binder Error: Default value for parameter "a" cannot contain column names
 
 statement ok
 drop table integers;

--- a/test/sql/catalog/function/test_macro_default_arg_with_dependencies.test
+++ b/test/sql/catalog/function/test_macro_default_arg_with_dependencies.test
@@ -49,7 +49,7 @@ select f(x:=a) from t;
 statement error
 create macro my_macro1(a, b := a) as a + b;
 ----
-Binder Error: Default value for parameter 'b' cannot contain column names
+Binder Error: Default value for parameter "b" cannot contain column names
 
 statement ok
 create table integers (a integer);
@@ -60,7 +60,7 @@ create macro my_macro2(a := i) as (
 	select min(a) from integers
 );
 ----
-Binder Error: Default value for parameter 'a' cannot contain column names
+Binder Error: Default value for parameter "a" cannot contain column names
 
 # to test the dependencies we create this macro instead
 statement ok

--- a/test/sql/catalog/function/test_simple_macro.test
+++ b/test/sql/catalog/function/test_simple_macro.test
@@ -275,7 +275,7 @@ Parameter without a default follows parameter with a default
 statement error
 CREATE MACRO select_plus_floats(a, f := b) AS (SELECT a + f FROM floats)
 ----
-Binder Error: Default value for parameter 'f' cannot contain column names
+Binder Error: Default value for parameter "f" cannot contain column names
 
 # +(FLOAT, VARCHAR) does not work - but types are only checked once the macro is called
 statement ok

--- a/test/sql/catalog/test_catalog_errors.test
+++ b/test/sql/catalog/test_catalog_errors.test
@@ -24,13 +24,13 @@ Catalog Error: Table with name "integers" already exists!
 statement error
 CREATE OR REPLACE VIEW integers AS SELECT 42;
 ----
-<REGEX>:.*Catalog Error: Existing object integers.*
+<REGEX>:.*Catalog Error: Existing object "integers".*
 
 # cannot use DROP VIEW to drop a table
 statement error
 DROP VIEW integers
 ----
-<REGEX>:.*Catalog Error: Existing object integers.*
+<REGEX>:.*Catalog Error: Existing object "integers".*
 
 # cannot drop a table that does not exist
 statement error
@@ -48,7 +48,7 @@ ALTER TABLE blabla RENAME COLUMN i TO k
 statement error
 DROP TABLE IF EXISTS vintegers
 ----
-<REGEX>:.*Catalog Error: Existing object vintegers.*
+<REGEX>:.*Catalog Error: Existing object "vintegers".*
 
 statement ok
 CREATE INDEX i_index ON integers(i);

--- a/test/sql/catalog/test_extension_suggestion.test
+++ b/test/sql/catalog/test_extension_suggestion.test
@@ -9,4 +9,4 @@ require no_extension_autoloading "EXPECTED: This tests what happens when extensi
 statement error
 SELECT from_json('{DATA_DIR}/json/array_of_empty_arrays.json');
 ----
-Catalog Error: Scalar Function with name from_json is not in the catalog, but it exists in the json extension.
+Catalog Error: Scalar Function with name "from_json" is not in the catalog, but it exists in the json extension.

--- a/test/sql/constraints/check/test_update_check_non_updated_columns.test
+++ b/test/sql/constraints/check/test_update_check_non_updated_columns.test
@@ -47,7 +47,7 @@ INSERT INTO v1 VALUES (1, 1, 1);
 statement error
 UPDATE v1 SET c = 2;
 ----
-CHECK constraint failed on table v1
+CHECK constraint failed on table "v1"
 
 # Table remains unchanged
 query III
@@ -75,7 +75,7 @@ INSERT INTO v2 VALUES (2, 3, 5);
 statement error
 UPDATE v2 SET z = 7 WHERE x = 2;
 ----
-CHECK constraint failed on table v2
+CHECK constraint failed on table "v2"
 
 # Data unchanged
 query III
@@ -124,13 +124,13 @@ INSERT INTO v_char VALUES ('alice', 'active');
 statement error
 INSERT INTO v_char VALUES ('ab', 'active');
 ----
-CHECK constraint failed on table v_char
+CHECK constraint failed on table "v_char"
 
 # Invalid: status not in allowed set
 statement error
 INSERT INTO v_char VALUES ('charlie', 'pending');
 ----
-CHECK constraint failed on table v_char
+CHECK constraint failed on table "v_char"
 
 # UPDATE that violates CHECK(status IN (...)) must fail
 statement error

--- a/test/sql/constraints/check/test_update_check_non_updated_columns.test
+++ b/test/sql/constraints/check/test_update_check_non_updated_columns.test
@@ -136,7 +136,7 @@ CHECK constraint failed on table "v_char"
 statement error
 UPDATE v_char SET status = 'deleted' WHERE username = 'alice';
 ----
-CHECK constraint failed on table v_char
+CHECK constraint failed on table "v_char"
 
 # UPDATE that keeps constraints satisfied must succeed
 statement ok

--- a/test/sql/copy/csv/auto/test_auto_column_type_opt.test
+++ b/test/sql/copy/csv/auto/test_auto_column_type_opt.test
@@ -12,7 +12,7 @@ Columns with names: "a" do not exist in the CSV File
 statement error
 select * from read_csv_auto('{DATA_DIR}/csv/test/multi_column_string.csv',  COLUMN_TYPES=1)
 ----
-COLUMN_TYPES requires a struct or list as input
+"COLUMN_TYPES" requires a struct or list as input
 
 # An empty struct for COLUMN_TYPES provides no column type overrides (no-op)
 statement ok

--- a/test/sql/copy/csv/csv_duck_fuzz.test
+++ b/test/sql/copy/csv/csv_duck_fuzz.test
@@ -25,4 +25,4 @@ sniff_csv cannot take NULL as a file path parameter
 statement error
 SELECT NULL FROM read_csv(NULL)
 ----
-read_csv cannot take NULL list as parameter
+"read_csv" cannot take NULL list as parameter

--- a/test/sql/copy/csv/csv_nullstr_list.test
+++ b/test/sql/copy/csv/csv_nullstr_list.test
@@ -123,7 +123,7 @@ NULL
 statement error
 FROM read_csv('{DATA_DIR}/csv/null/multiple_nulls.csv', auto_detect=false, delim=',', quote='"', escape='"',  skip=0, header=true, columns={'name': 'VARCHAR', 'age': 'VARCHAR', 'height': 'VARCHAR'}, nullstr = ['','none','null'], force_not_null = ['dont_exist']);
 ----
-force_not_null expected to find dont_exist, but it was not found in the table
+"force_not_null" expected to find dont_exist, but it was not found in the table
 
 # Lests add a few tests with copy from
 statement ok

--- a/test/sql/copy/csv/csv_nullstr_list.test
+++ b/test/sql/copy/csv/csv_nullstr_list.test
@@ -140,12 +140,12 @@ NULL is not supported
 statement error
 COPY data FROM '{DATA_DIR}/csv/null/multiple_nulls.csv' (nullstr [NULL], HEADER 1);
 ----
-Binder Error: CSV Reader function option nullstr requires a non-empty list of possible null strings (varchar) as input
+Binder Error: CSV Reader function option "nullstr" requires a non-empty list of possible null strings (varchar) as input
 
 statement error
 COPY data FROM '{DATA_DIR}/csv/null/multiple_nulls.csv' (nullstr [42], HEADER 1);
 ----
-Binder Error: CSV Reader function option nullstr requires a non-empty list of possible null strings (varchar) as input
+Binder Error: CSV Reader function option "nullstr" requires a non-empty list of possible null strings (varchar) as input
 
 query III
 FROM data
@@ -157,4 +157,4 @@ Thijs	26	NULL
 statement error
 COPY data TO '{TEMP_DIR}/multiple_nulls.csv' (nullstr ['a', 'b']);
 ----
-CSV Writer function option nullstr only accepts one nullstr value.
+CSV Writer function option "nullstr" only accepts one nullstr value.

--- a/test/sql/copy/csv/csv_nullstr_list.test
+++ b/test/sql/copy/csv/csv_nullstr_list.test
@@ -30,25 +30,25 @@ Thijs	26	none
 statement error
 FROM read_csv('{DATA_DIR}/csv/null/multiple_nulls.csv', auto_detect=false, delim=',', quote='"', escape='"', skip=0, header=true, columns={'name': 'VARCHAR', 'age': 'VARCHAR', 'height': 'VARCHAR'}, nullstr = []);
 ----
-CSV Reader function option nullstr requires a non-empty list of possible null strings (varchar) as input
+CSV Reader function option "nullstr" requires a non-empty list of possible null strings (varchar) as input
 
 # Test nullstr = ['a', NULL]
 statement error
 FROM read_csv('{DATA_DIR}/csv/null/multiple_nulls.csv', auto_detect=false, delim=',', quote='"', escape='"',  skip=0, header=true, columns={'name': 'VARCHAR', 'age': 'VARCHAR', 'height': 'VARCHAR'}, nullstr = ['a', NULL]);
 ----
-CSV Reader function option nullstr does not accept NULL values as a valid nullstr option
+CSV Reader function option "nullstr" does not accept NULL values as a valid nullstr option
 
 # Test nullstr = NULL
 statement error
 FROM read_csv('{DATA_DIR}/csv/null/multiple_nulls.csv', auto_detect=false, delim=',', quote='"', escape='"',  skip=0, header=true, columns={'name': 'VARCHAR', 'age': 'VARCHAR', 'height': 'VARCHAR'}, nullstr = NULL);
 ----
-CSV Reader function option nullstr requires a string or a list as input
+CSV Reader function option "nullstr" requires a string or a list as input
 
 # Test nullstr = [42]
 statement error
 FROM read_csv('{DATA_DIR}/csv/null/multiple_nulls.csv', auto_detect=false, delim=',', quote='"', escape='"',  skip=0, header=true, columns={'name': 'VARCHAR', 'age': 'VARCHAR', 'height': 'VARCHAR'}, nullstr = [42]);
 ----
-CSV Reader function option nullstr requires a non-empty list of possible null strings (varchar) as input
+CSV Reader function option "nullstr" requires a non-empty list of possible null strings (varchar) as input
 
 # Test Null Strings equal to delim quote escape
 statement error

--- a/test/sql/copy/csv/test_copy.test
+++ b/test/sql/copy/csv/test_copy.test
@@ -109,13 +109,13 @@ COPY test4 (a,c) FROM '{TEMP_DIR}/test4.csv' (SEP ',', HEADER 0.2);
 statement error
 COPY test4 (a,c) FROM '{TEMP_DIR}/test4.csv' (SEP);
 ----
-<REGEX>:.*(SEP|sep) requires an argument of type VARCHAR.*
+<REGEX>:.*(SEP|"sep") requires an argument of type VARCHAR.*
 
 # number as delimiter
 statement error
 COPY test4 (a,c) FROM '{TEMP_DIR}/test4.csv' (SEP 1);
 ----
-<REGEX>:.*(SEP|sep) expected an argument of type VARCHAR.*
+<REGEX>:.*(SEP|"sep") expected an argument of type VARCHAR.*
 
 # multiple format options
 statement error
@@ -178,7 +178,7 @@ The CSV Reader does not support the encoding: "utf-42"
 statement error
 COPY test4 (a,c) FROM '{TEMP_DIR}/test4.csv' (MAGIC '42');
 ----
-<REGEX>:.*Unrecognized option (MAGIC|magic).*
+<REGEX>:.*Unrecognized option "(MAGIC|magic)".*
 
 # Try new_line option
 query I

--- a/test/sql/copy/csv/test_export_not_null.test
+++ b/test/sql/copy/csv/test_export_not_null.test
@@ -28,7 +28,7 @@ IMPORT DATABASE '{TEST_DIR}/broken_empty_string';
 statement error
 EXPORT DATABASE '{TEST_DIR}/broken_empty_string_2' (FORCE_NOT_NULL ['A']);
 ----
-force_not_null is not supported for writing - only for reading
+"force_not_null" is not supported for writing - only for reading
 
 statement ok
 abort;

--- a/test/sql/copy/csv/test_force_not_null.test
+++ b/test/sql/copy/csv/test_force_not_null.test
@@ -61,7 +61,7 @@ COPY test (col_b, col_a) FROM '{DATA_DIR}/csv/test/force_not_null_reordered.csv'
 statement error
 COPY test FROM '{DATA_DIR}/csv/test/force_not_null_reordered.csv' (FORCE_NOT_NULL (col_c, col_d));
 ----
-force_not_null expected to find col_d, but it was not found in the table
+"force_not_null" expected to find col_d, but it was not found in the table
 
 # FORCE_NOT_NULL fails on integer columns with NULL values, but only if there are null values
 query I

--- a/test/sql/copy/csv/test_force_not_null.test
+++ b/test/sql/copy/csv/test_force_not_null.test
@@ -38,24 +38,24 @@ SELECT * FROM test ORDER BY 1;
 statement error
 COPY test TO '{DATA_DIR}/csv/test/force_not_null.csv' (FORCE_NOT_NULL (col_b), NULL 'test', HEADER 0);
 ----
-<REGEX>:.*Option (FORCE_NOT_NULL|force_not_null) is not supported for writing.*
+<REGEX>:.*Option (FORCE_NOT_NULL|"force_not_null") is not supported for writing.*
 
 # FORCE_NOT_NULL must not be empty and must have the correct parameter type
 statement error
 COPY test FROM '{DATA_DIR}/csv/test/force_not_null.csv' (FORCE_NOT_NULL, NULL 'test');
 ----
-force_not_null expects a column list or * as parameter
+"force_not_null" expects a column list or * as parameter
 
 statement error
 COPY test FROM '{DATA_DIR}/csv/test/force_not_null.csv' (FORCE_NOT_NULL 42, NULL 'test');
 ----
-force_not_null expected to find 42, but it was not found in the table
+"force_not_null" expected to find 42, but it was not found in the table
 
 # test using a column in FORCE_NOT_NULL that is not set as output, but that is a column of the table
 statement error
 COPY test (col_b, col_a) FROM '{DATA_DIR}/csv/test/force_not_null_reordered.csv' (FORCE_NOT_NULL (col_c, col_b));
 ----
-force_not_null expected to find col_c, but it was not found in the table
+"force_not_null" expected to find col_c, but it was not found in the table
 
 # test using a column in FORCE_NOT_NULL that is not a column of the table
 statement error

--- a/test/sql/copy/csv/test_force_quote.test
+++ b/test/sql/copy/csv/test_force_quote.test
@@ -65,25 +65,25 @@ SELECT * FROM test2
 statement error
 COPY test (col_b, col_a) TO '{TEMP_DIR}/test_reorder.csv' (FORCE_QUOTE (col_c, col_b));
 ----
-force_quote expected to find col_c, but it was not found in the table
+"force_quote" expected to find col_c, but it was not found in the table
 
 # test using a column in FORCE_QUOTE that is not a column of the table
 statement error
 COPY test TO '{TEMP_DIR}/test_reorder.csv' (FORCE_QUOTE (col_c, col_d));
 ----
-force_quote expected to find col_d, but it was not found in the table
+"force_quote" expected to find col_d, but it was not found in the table
 
 # FORCE_QUOTE is only supported in COPY ... TO ...
 statement error
 COPY test FROM '{TEMP_DIR}/test_reorder.csv' (FORCE_QUOTE (col_c, col_d));
 ----
-<REGEX>:.*Option (FORCE_QUOTE|force_quote) is not supported for reading.*
+<REGEX>:.*Option "(FORCE_QUOTE|force_quote)" is not supported for reading.*
 
 # FORCE_QUOTE must not be empty and must have the correct parameter type
 statement error
 COPY test TO '{TEMP_DIR}/test_reorder.csv' (FORCE_QUOTE);
 ----
-force_quote expects a column list or * as parameter
+"force_quote" expects a column list or * as parameter
 
 statement error
 COPY test TO '{TEMP_DIR}/test_reorder.csv' (FORCE_QUOTE 42);

--- a/test/sql/copy/csv/test_force_quote.test
+++ b/test/sql/copy/csv/test_force_quote.test
@@ -88,5 +88,5 @@ COPY test TO '{TEMP_DIR}/test_reorder.csv' (FORCE_QUOTE);
 statement error
 COPY test TO '{TEMP_DIR}/test_reorder.csv' (FORCE_QUOTE 42);
 ----
-force_quote expected to find 42, but it was not found in the table
+"force_quote" expected to find 42, but it was not found in the table
 

--- a/test/sql/copy/csv/test_ignore_errors.test
+++ b/test/sql/copy/csv/test_ignore_errors.test
@@ -32,7 +32,7 @@ INSERT INTO integers SELECT * FROM read_csv('{DATA_DIR}/csv/test/error_too_littl
 statement error
 INSERT INTO integers SELECT * FROM read_csv('{DATA_DIR}/csv/test/error_too_little.csv', columns={'i': 'INTEGER'}, null_padding=0)
 ----
-table integers has 2 columns but 1 values were supplied
+table "integers" has 2 columns but 1 values were supplied
 
 # not enough columns provided
 query II

--- a/test/sql/copy/format_uuid.test
+++ b/test/sql/copy/format_uuid.test
@@ -132,7 +132,7 @@ Directory
 statement error
 COPY test4 TO '{TEST_DIR}/to_be_overwritten' (FORMAT PARQUET, PARTITION_BY (a), FILENAME_PATTERN);
 ----
-<REGEX>:(.*Copy option (FILENAME_PATTERN|filename_pattern) requires an argument of type VARCHAR.*)
+<REGEX>:(.*Copy option (FILENAME_PATTERN|"filename_pattern") requires an argument of type VARCHAR.*)
 
 statement ok
 COPY test4 TO '{TEST_DIR}/to_be_overwritten' (FORMAT PARQUET, PARTITION_BY (a), FILENAME_PATTERN a_file_name);

--- a/test/sql/copy/hive_types.test_slow
+++ b/test/sql/copy/hive_types.test_slow
@@ -49,7 +49,7 @@ Invalid Input Error: 'hive_types' only accepts a STRUCT
 statement error
 from read_parquet('{TEMP_DIR}/partition/**/*.parquet', hive_types={season:-42});
 ----
-Invalid Input Error: hive_types: 'season' must be a VARCHAR, instead: 'INTEGER' was provided
+Invalid Input Error: hive_types: "season" must be a VARCHAR, instead: 'INTEGER' was provided
 
 
 # basic tests with hive_types_autocast

--- a/test/sql/copy/parquet/parquet_write_codecs.test
+++ b/test/sql/copy/parquet/parquet_write_codecs.test
@@ -29,7 +29,7 @@ endloop
 statement error
 COPY (SELECT 42, 'hello') TO '{TEMP_DIR}/gzip.parquet' (FORMAT 'parquet', CODEC 'BLABLABLA');
 ----
-<REGEX>:.*Binder Error: Expected codec argument.*
+<REGEX>:.*Binder Error: Expected "codec" argument.*
 
 # empty codec
 statement error

--- a/test/sql/copy/partitioned/partitioned_order_by.test_slow
+++ b/test/sql/copy/partitioned/partitioned_order_by.test_slow
@@ -138,7 +138,7 @@ WHERE prev_p < p
 statement error
 copy (from range(10)) to '{TEST_DIR}/duplicated' (partition_by (range, range));
 ----
-Binder Error: partition_by does now allow duplicate columns
+Binder Error: "partition_by" does now allow duplicate columns
 
 statement ok
 CREATE TABLE order_by_expr_repro AS

--- a/test/sql/export/export_generated_columns.test
+++ b/test/sql/export/export_generated_columns.test
@@ -30,7 +30,7 @@ INSERT INTO tbl VALUES(5);
 statement error
 INSERT INTO tbl VALUES(2,3)
 ----
-<REGEX>:.*Binder Error: table tbl has 1 columns.*
+<REGEX>:.*Binder Error: table "tbl" has 1 columns.*
 
 # 'x' can not be removed, as 'gen_x' depends on it
 statement error
@@ -57,7 +57,7 @@ SELECT * FROM tbl
 statement error
 INSERT INTO tbl VALUES(2,3)
 ----
-<REGEX>:.*Binder Error: table tbl has 1 columns.*
+<REGEX>:.*Binder Error: table "tbl" has 1 columns.*
 
 statement error
 drop macro my_macro;

--- a/test/sql/extensions/aliasing.test
+++ b/test/sql/extensions/aliasing.test
@@ -31,7 +31,7 @@ Initialization function
 statement error
 LOAD '{BUILD_DIRECTORY}/test/extension/loadable_extension_demo.duckdb_extension' AS demo
 ----
-Alias 'demo' already exists for extension 'loadable_extension_demo'
+Alias "demo" already exists for extension 'loadable_extension_demo'
 
 # unqualified call works
 query I

--- a/test/sql/function/index/index_key.test
+++ b/test/sql/function/index/index_key.test
@@ -92,19 +92,19 @@ SELECT index_key({'catalog': current_catalog(), 'schema': 'main', 'table': 'tbl1
 statement error
 SELECT index_key({'catalog': '', 'table': 'tbl1'}, 'PRIMARY_tbl1_0', 1);
 ----
-Binder Error: index_key: path field 'catalog' cannot be empty
+Binder Error: index_key: path field "catalog" cannot be empty
 
 # NULL catalog is an error
 statement error
 SELECT index_key({'catalog': NULL::VARCHAR, 'table': 'tbl1'}, 'PRIMARY_tbl1_0', 1);
 ----
-Binder Error: index_key: path field 'catalog' cannot be NULL
+Binder Error: index_key: path field "catalog" cannot be NULL
 
 # NULL schema is an error
 statement error
 SELECT index_key({'schema': NULL::VARCHAR, 'table': 'tbl1'}, 'PRIMARY_tbl1_0', 1);
 ----
-Binder Error: index_key: path field 'schema' cannot be NULL
+Binder Error: index_key: path field "schema" cannot be NULL
 
 ########################################################################################################################
 #                                                                                                                      #
@@ -338,7 +338,7 @@ Binder Error: index_key: path must contain a 'table' field
 statement error
 SELECT index_key({'table': NULL::VARCHAR}, 'PRIMARY_tbl1_0', 1);
 ----
-Binder Error: index_key: path field 'table' cannot be NULL
+Binder Error: index_key: path field "table" cannot be NULL
 
 statement error
 SELECT index_key({'table': 123}, 'PRIMARY_tbl1_0', 1);

--- a/test/sql/function/index/index_key.test
+++ b/test/sql/function/index/index_key.test
@@ -343,18 +343,18 @@ Binder Error: index_key: path field "table" cannot be NULL
 statement error
 SELECT index_key({'table': 123}, 'PRIMARY_tbl1_0', 1);
 ----
-Binder Error: index_key: path field 'table' must be VARCHAR
+Binder Error: index_key: path field "table" must be VARCHAR
 
 statement error
 SELECT index_key({'table': ''}, 'PRIMARY_tbl1_0', 1);
 ----
-Binder Error: index_key: path field 'table' cannot be empty
+Binder Error: index_key: path field "table" cannot be empty
 
 
 statement error
 SELECT index_key({'foo': 'bar', 'table': 'tbl1'}, 'PRIMARY_tbl1_0', 1);
 ----
-Binder Error: index_key: unknown field 'foo' in path
+Binder Error: index_key: unknown field "foo" in path
 
 statement error
 SELECT index_key('tbl1', 'PRIMARY_tbl1_0', 1);
@@ -439,12 +439,12 @@ Catalog Error: Table with name nonexistent_table does not exist!
 statement error
 SELECT index_key({'table': 'tbl1'}, 'nonexistent_index', 1);
 ----
-Catalog Error: index_key: index 'nonexistent_index' was not found on table tbl1. Available indexes: PRIMARY_tbl1_0, UNIQUE_tbl1_1, tbl1_idx_composite, tbl1_idx_txt
+Catalog Error: index_key: index "nonexistent_index" was not found on table tbl1. Available indexes: PRIMARY_tbl1_0, UNIQUE_tbl1_1, tbl1_idx_composite, tbl1_idx_txt
 
 statement error
 SELECT index_key({'table': 'tbl2'}, 'FOREIGN_tbl2_2', 1);
 ----
-Catalog Error: index_key: index 'FOREIGN_tbl2_2' was not found on table tbl2. Available indexes: PRIMARY_tbl2_0, FOREIGN_tbl2_1
+Catalog Error: index_key: index "FOREIGN_tbl2_2" was not found on table tbl2. Available indexes: PRIMARY_tbl2_0, FOREIGN_tbl2_1
 
 statement ok
 CREATE TABLE no_index_tbl(id INTEGER, value VARCHAR);
@@ -452,7 +452,7 @@ CREATE TABLE no_index_tbl(id INTEGER, value VARCHAR);
 statement error
 SELECT index_key({'table': 'no_index_tbl'}, 'some_index', 1);
 ----
-Catalog Error: index_key: index 'some_index' was not found on table no_index_tbl. No indexes found on this table.
+Catalog Error: index_key: index "some_index" was not found on table no_index_tbl. No indexes found on this table.
 
 statement error
 SELECT index_key({'schema': 'nonexistent_schema', 'table': 'tbl1'}, 'PRIMARY_tbl1_0', 1);

--- a/test/sql/generated_columns/virtual/insert.test
+++ b/test/sql/generated_columns/virtual/insert.test
@@ -33,7 +33,7 @@ SELECT * FROM test
 statement error
 INSERT INTO test VALUES (22)
 ----
-<REGEX>:.*Binder Error.*table test has 2 columns.*
+<REGEX>:.*Binder Error.*table "test" has 2 columns.*
 
 #Using VALUES correctly
 statement ok
@@ -43,7 +43,7 @@ INSERT INTO test VALUES (22, 10);
 statement error
 INSERT INTO test VALUES (22, 10, 10)
 ----
-<REGEX>:.*Binder Error.*table test has 2 columns.*
+<REGEX>:.*Binder Error.*table "test" has 2 columns.*
 
 statement ok
 CREATE TABLE tbl (

--- a/test/sql/index/art/test_index_key_rebind.test
+++ b/test/sql/index/art/test_index_key_rebind.test
@@ -23,4 +23,4 @@ DROP INDEX idx;
 statement error
 EXECUTE stmt
 ----
-index 'idx' was not found
+index "idx" was not found

--- a/test/sql/insert/test_insert_invalid.test
+++ b/test/sql/insert/test_insert_invalid.test
@@ -22,12 +22,12 @@ INSERT INTO a VALUES (1, 2)
 statement error
 INSERT INTO a VALUES (1)
 ----
-<REGEX>:.*Binder Error.*table a has 2 columns.*
+<REGEX>:.*Binder Error.*table "a" has 2 columns.*
 
 statement error
 INSERT INTO a VALUES (1,2,3)
 ----
-<REGEX>:.*Binder Error.*table a has 2 columns.*
+<REGEX>:.*Binder Error.*table "a" has 2 columns.*
 
 statement error
 INSERT INTO a VALUES (1,2),(3)
@@ -43,4 +43,4 @@ INSERT INTO a VALUES (1,2),(3,4,5)
 statement error
 INSERT INTO a SELECT 42
 ----
-<REGEX>:.*Binder Error.*table a has 2 columns.*
+<REGEX>:.*Binder Error.*table "a" has 2 columns.*

--- a/test/sql/json/copy_json_null_options.test
+++ b/test/sql/json/copy_json_null_options.test
@@ -7,7 +7,7 @@ require json
 statement error
 COPY (SELECT 1 AS a) TO '{TEST_DIR}/test_null_use_tmp_file.csv' (FORMAT CSV, use_tmp_file NULL);
 ----
-<REGEX>:Binder Error.*NULL is not supported as a valid option for COPY option use_tmp_file.*
+<REGEX>:Binder Error.*NULL is not supported as a valid option for COPY option "use_tmp_file".*
 
 statement error
 COPY (SELECT 1 AS a) TO '{TEST_DIR}/test_null_dateformat.json' (FORMAT JSON, dateformat NULL);

--- a/test/sql/json/copy_json_partition_by.test
+++ b/test/sql/json/copy_json_partition_by.test
@@ -91,4 +91,4 @@ statement error
 COPY (SELECT 1 AS a, 2 AS b)
 TO '{TEST_DIR}/json_partition_bad_wpc' (FORMAT JSON, PARTITION_BY (a), WRITE_PARTITION_COLUMNS (true, false));
 ----
-Invalid Input Error: Copy option write_partition_columns did not expect a list as argument
+Invalid Input Error: Copy option "write_partition_columns" did not expect a list as argument

--- a/test/sql/logging/test_logging_function.test
+++ b/test/sql/logging/test_logging_function.test
@@ -11,7 +11,7 @@ from duckdb_logs
 statement error
 PRAGMA enable_logging;
 ----
-Pragma Function with name enable_logging does not exist, but a table function with the same name exists, try
+Pragma Function with name "enable_logging" does not exist, but a table function with the same name exists, try
 
 statement ok
  CALL enable_logging();

--- a/test/sql/peg_parser/transformer/alter_statement.test
+++ b/test/sql/peg_parser/transformer/alter_statement.test
@@ -60,7 +60,7 @@ ALTER TABLE person ADD COLUMN c STRUCT(
     current_mood mood
 );
 ----
-Catalog Error: Column with name c already exists!
+Catalog Error: Column with name "c" already exists!
 
 statement error
 ALTER TABLE unit ADD COLUMN total_profit INTEGER GENERATED ALWAYS AS (price * amount_sold) VIRTUAL;

--- a/test/sql/projection/test_value_list.test
+++ b/test/sql/projection/test_value_list.test
@@ -133,7 +133,7 @@ hello
 statement error
 INSERT INTO varchars VALUES (1, 2), ('hello', 3), (DEFAULT, DEFAULT);
 ----
-<REGEX>:.*Binder Error.*table varchars has 1 columns.*
+<REGEX>:.*Binder Error.*table "varchars" has 1 columns.*
 
 statement error
 INSERT INTO varchars (v) VALUES (1, 2), ('hello', 3), (DEFAULT, DEFAULT);

--- a/test/sql/secrets/create_secret_expression.test
+++ b/test/sql/secrets/create_secret_expression.test
@@ -13,7 +13,7 @@ CREATE SECRET a (TYPE http);
 statement error
 CREATE SECRET a (TYPE http);
 ----
-Invalid Input Error: Temporary secret with name 'a' already exists!
+Invalid Input Error: Temporary secret with name "a" already exists!
 
 statement ok
 CREATE PERSISTENT SECRET a (TYPE http);
@@ -24,7 +24,7 @@ CREATE PERSISTENT SECRET b (TYPE http);
 statement error
 CREATE PERSISTENT SECRET b (TYPE http);
 ----
-Invalid Input Error: Persistent secret with name 'b' already exists in secret storage 'local_file'!
+Invalid Input Error: Persistent secret with name "b" already exists in secret storage 'local_file'!
 
 statement ok
 CREATE OR REPLACE SECRET a (TYPE http);
@@ -81,7 +81,7 @@ CREATE OR REPLACE SECRET my_secret (TYPE HTTP, VERIFY_SSL 1);
 statement error
 CREATE OR REPLACE SECRET my_secret (TYPE HTTP, VERIFY_SSL something);
 ----
-Binder Error: Failed to cast option 'verify_ssl' to type 'BOOLEAN'
+Binder Error: Failed to cast option "verify_ssl" to type 'BOOLEAN'
 
 statement ok
 CREATE OR REPLACE SECRET my_secret (TYPE HTTP, SCOPE ['https://duckdb.org', 'http://extensions.duckdb.org'], BEARER_TOKEN getvariable('my_bearer_token'), HTTP_PROXY 'http://some-proxy/', VERIFY_SSL 1);

--- a/test/sql/secrets/create_secret_hffs_autoload.test
+++ b/test/sql/secrets/create_secret_hffs_autoload.test
@@ -22,7 +22,7 @@ CREATE SECRET hf1 (
     TOKEN 'bla'
 )
 ----
-Secret provider config for type huggingface does not exist, but it exists in the httfps extension.
+Secret provider "config" for type "huggingface" does not exist, but it exists in the httfps extension.
 
 # Cache provider will automatically try to fetch the token from the cache
 statement error
@@ -31,4 +31,4 @@ CREATE SECRET hf2 (
     PROVIDER 'credential_chain'
 )
 ----
-Secret provider credential_chain for type huggingface does not exist, but it exists in the httpfs extension.
+Secret provider "credential_chain" for type "huggingface" does not exist, but it exists in the httpfs extension.

--- a/test/sql/secrets/secret_autoloading_errors.test
+++ b/test/sql/secrets/secret_autoloading_errors.test
@@ -12,12 +12,12 @@ Secret type 's3' does not exist, but it exists in the httpfs extension.
 statement error
 CREATE SECRET (TYPE S3, PROVIDER CONFIG)
 ----
-Secret provider config for type s3 does not exist, but it exists in the httpfs extension.
+Secret provider "config" for type "s3" does not exist, but it exists in the httpfs extension.
 
 statement error
 CREATE SECRET (TYPE S3, PROVIDER CREDENTIAL_CHAIN)
 ----
-Secret provider credential_chain for type s3 does not exist, but it exists in the aws extension.
+Secret provider "credential_chain" for type "s3" does not exist, but it exists in the aws extension.
 
 statement error
 CREATE SECRET (TYPE AZURE)
@@ -27,9 +27,9 @@ Secret type 'azure' does not exist, but it exists in the azure extension.
 statement error
 CREATE SECRET (TYPE AZURE, PROVIDER CONFIG)
 ----
-Secret provider config for type azure does not exist, but it exists in the azure extension.
+Secret provider "config" for type "azure" does not exist, but it exists in the azure extension.
 
 statement error
 CREATE SECRET (TYPE AZURE, PROVIDER CREDENTIAL_CHAIN)
 ----
-Secret provider credential_chain for type azure does not exist, but it exists in the azure extension.
+Secret provider "credential_chain" for type "azure" does not exist, but it exists in the azure extension.

--- a/test/sql/settings/allowed_configs.test
+++ b/test/sql/settings/allowed_configs.test
@@ -5,12 +5,12 @@
 statement error
 SET allowed_configs=['lock_configuration']
 ----
-Cannot include 'lock_configuration' in allowed_configs
+Cannot include "lock_configuration" in allowed_configs
 
 statement error
 SET allowed_configs=['allowed_configs']
 ----
-Cannot include 'allowed_configs' in allowed_configs
+Cannot include "allowed_configs" in allowed_configs
 
 statement error
 SET allowed_configs=['']
@@ -21,7 +21,7 @@ Cannot provide an empty string for allowed_configs
 statement error
 SET allowed_configs=['not_a_real_setting']
 ----
-Unknown configuration option 'not_a_real_setting' in allowed_configs
+Unknown configuration option "not_a_real_setting" in allowed_configs
 
 # known extension configs are accepted even when the extension is not yet loaded
 # (the extension can be autoloaded later when the setting is actually used)

--- a/test/sql/types/struct/remap_struct.test
+++ b/test/sql/types/struct/remap_struct.test
@@ -165,7 +165,7 @@ SELECT remap_struct({'i': 1, 'j': 2}, NULL::ROW(v1 VARCHAR), {'v1': 'i'}, {'v1':
 statement error
 SELECT remap_struct({'i': 1, 'j': 2}, NULL::ROW(v1 VARCHAR, v2 VARCHAR), {'v1': 'i'}, NULL);
 ----
-<REGEX>:.*Binder Error.*Missing target value v2.*
+<REGEX>:.*Binder Error.*Missing target value "v2".*
 
 statement error
 SELECT remap_struct(struct_val, NULL::ROW(v1 VARCHAR, v2 VARCHAR, v3 VARCHAR), {'v1': 'j', 'v3': 'i'}, struct_val)

--- a/test/sql/types/struct/struct_contains.test
+++ b/test/sql/types/struct/struct_contains.test
@@ -253,4 +253,4 @@ SELECT c0, c0 IN x FROM (SELECT [c0, c1] AS x FROM t0) AS y, t0 ORDER BY c0, x;
 statement error
 SELECT struct_contains({'a': 1, 'b': 2}, 2);
 ----
-<REGEX>:Binder Error.*struct_contains can only be used on unnamed structs.*
+<REGEX>:Binder Error.*"struct_contains" can only be used on unnamed structs.*

--- a/test/sql/types/struct/struct_position.test
+++ b/test/sql/types/struct/struct_position.test
@@ -259,5 +259,5 @@ NULL
 statement error
 SELECT struct_position({'a': 1, 'b': 2}, 2);
 ----
-<REGEX>:Binder Error.*struct_position can only be used on unnamed structs.*
+<REGEX>:Binder Error.*"struct_position" can only be used on unnamed structs.*
 


### PR DESCRIPTION
`Identifier` now formats in exceptions through `SQLQuotedIdentifier` instead of `SQLIdentifier`. That way an identifier interpolated into an error message is always quoted rather than only when quoting is required in SQL. This makes it clear that a word is a name of an object and not a normal part of the sentence.

Most format strings already wrapped their `%s` in literal quotes, which was only correct as long as `Identifier` did not need quotes in SQL. Any name that needed quoting, for example one containing a space or special character, already produced doubled quotes like `""my db""`. Those literal quotes are now removed wherever the argument is an `Identifier`, leaving the quoting to the formatter, which also escapes an embedded `"` correctly.

Where the identifier is only one component of a larger construct - a dotted `catalog.schema.table` path, or the `col INTEGER AS (...)` snippet in a generated-column error - quoting every component would be noise, so those keep `SQLIdentifier` (quote only when required) and the surrounding construct is wrapped in single quotes instead.

Call sites that hand-quoted `X.GetIdentifierName()` now pass the `Identifier` itself, so they escape correctly instead of emitting a raw `"`.
