### PR TITLE
Preserve potentially failing DATE-to-TIMESTAMP casts unless column statistics prove the conversion safe

### DIFF
--- a/src/optimizer/rule/comparison_simplification.cpp
+++ b/src/optimizer/rule/comparison_simplification.cpp
@@ -8,7 +8,10 @@
 #include "duckdb/optimizer/expression_rewriter.hpp"
 #include "duckdb/planner/expression/bound_comparison_expression.hpp"
 #include "duckdb/planner/expression/bound_conjunction_expression.hpp"
+#include "duckdb/planner/expression/bound_columnref_expression.hpp"
 #include "duckdb/planner/expression/bound_operator_expression.hpp"
+#include "duckdb/planner/operator/logical_get.hpp"
+#include "duckdb/storage/statistics/numeric_stats.hpp"
 
 namespace duckdb {
 
@@ -91,6 +94,58 @@ static unique_ptr<Expression> CreateNullCheckExpression(ExpressionType expressio
 	auto result = make_uniq<BoundOperatorExpression>(expression_type, LogicalType::BOOLEAN);
 	result->GetChildrenMutable().push_back(std::move(child));
 	return std::move(result);
+}
+
+static unique_ptr<BaseStatistics> GetColumnStatistics(LogicalOperator &op, const ColumnBinding &binding,
+                                                      ClientContext &context) {
+	if (op.type == LogicalOperatorType::LOGICAL_GET) {
+		auto &get = op.Cast<LogicalGet>();
+		if (get.table_index == binding.table_index && binding.column_index.GetIndex() < get.GetColumnIds().size() &&
+		    get.bind_data) {
+			auto &column_index = get.GetColumnIndex(binding);
+			if (get.function.statistics_extended) {
+				TableFunctionGetStatisticsInput input(get.bind_data.get(), column_index);
+				return get.function.statistics_extended(context, input);
+			}
+			if (get.function.statistics) {
+				return get.function.statistics(context, get.bind_data.get(), column_index.GetPrimaryIndex());
+			}
+		}
+	}
+	for (auto &child : op.children) {
+		auto stats = GetColumnStatistics(*child, binding, context);
+		if (stats) {
+			return stats;
+		}
+	}
+	return nullptr;
+}
+
+static bool DateTimestampCastFitsStatistics(LogicalOperator &op, BoundFunctionExpression &cast_expression,
+                                            ClientContext &context) {
+	if (BoundCastExpression::SourceType(cast_expression).id() != LogicalTypeId::DATE ||
+	    cast_expression.GetReturnType().id() != LogicalTypeId::TIMESTAMP) {
+		return false;
+	}
+	auto &child = *BoundCastExpression::ChildMutable(cast_expression);
+	if (child.GetExpressionClass() != ExpressionClass::BOUND_COLUMN_REF) {
+		return false;
+	}
+	auto &column_ref = child.Cast<BoundColumnRefExpression>();
+	if (column_ref.Depth() != 0) {
+		return false;
+	}
+	auto stats = GetColumnStatistics(op, column_ref.Binding(), context);
+	if (!stats || stats->GetStatsType() != StatisticsType::NUMERIC_STATS || !NumericStats::HasMinMax(*stats)) {
+		return false;
+	}
+	auto min = NumericStats::Min(*stats);
+	auto max = NumericStats::Max(*stats);
+	if (!min.GetValue<date_t>().IsFinite() || !max.GetValue<date_t>().IsFinite()) {
+		return false;
+	}
+	return min.DefaultTryCastAs(cast_expression.GetReturnType()) &&
+	       max.DefaultTryCastAs(cast_expression.GetReturnType());
 }
 
 ComparisonSimplificationRule::ComparisonSimplificationRule(ExpressionRewriter &rewriter) : Rule(rewriter) {
@@ -184,11 +239,13 @@ unique_ptr<Expression> ComparisonSimplificationRule::Apply(LogicalOperator &op, 
 	}
 	if (BoundCastExpression::IsCast(column_ref_expr)) {
 		//! Here we check if we can apply the expression on the constant side
-		//! We can do this if the cast itself is invertible and casting the constant is
+		//! We can do this if the cast itself is invertible and cannot fail for the input, and casting the constant is
 		//! invertible in practice.
 		auto &cast_expression = column_ref_expr.Cast<BoundFunctionExpression>();
 		auto target_type = BoundCastExpression::SourceType(cast_expression);
-		if (!BoundCastExpression::CastIsInvertible(target_type, cast_expression.GetReturnType())) {
+		if (!BoundCastExpression::CastIsInvertible(target_type, cast_expression.GetReturnType()) ||
+		    (BoundCastExpression::CastCanThrow(target_type, cast_expression.GetReturnType(), false) &&
+		     !DateTimestampCastFitsStatistics(op, cast_expression, rewriter.context))) {
 			return nullptr;
 		}
 

--- a/test/issues/general/test_24241.test
+++ b/test/issues/general/test_24241.test
@@ -1,0 +1,50 @@
+# name: test/issues/general/test_24241.test
+# description: Preserve failures when simplifying DATE to TIMESTAMP comparisons
+# group: [general]
+
+statement ok
+CREATE TABLE dates(d DATE);
+
+statement ok
+INSERT INTO dates VALUES
+	(DATE '294247-01-10'),
+	(DATE '294247-01-11'),
+	(DATE '5874897-12-31'),
+	(DATE 'infinity'),
+	(NULL);
+
+statement error
+SELECT d
+FROM dates
+WHERE CAST(d AS TIMESTAMP) > TIMESTAMP '294247-01-10 04:00:00'
+ORDER BY d;
+----
+<REGEX>:Conversion Error:.*294247-01-11.*can't be cast.*
+
+query I
+SELECT count(*)
+FROM dates
+WHERE TRY_CAST(d AS TIMESTAMP) > TIMESTAMP '294247-01-10 04:00:00';
+----
+1
+
+statement ok
+SET disabled_optimizers = 'expression_rewriter';
+
+statement error
+SELECT d
+FROM dates
+WHERE CAST(d AS TIMESTAMP) > TIMESTAMP '294247-01-10 04:00:00'
+ORDER BY d;
+----
+<REGEX>:Conversion Error:.*294247-01-11.*can't be cast.*
+
+query I
+SELECT count(*)
+FROM dates
+WHERE TRY_CAST(d AS TIMESTAMP) > TIMESTAMP '294247-01-10 04:00:00';
+----
+1
+
+statement ok
+SET disabled_optimizers = '';


### PR DESCRIPTION
Fix #24241 

### Problem                                                                                                                                                                                                                                                  

DuckDB’s comparison simplification optimizer could incorrectly remove a potentially failing `DATE → TIMESTAMP` cast.

A simplified version of the reported query is:

```
  SELECT d
  FROM dates
  WHERE CAST(d AS TIMESTAMP) >
        TIMESTAMP '294247-01-10 04:00:00';
```

DuckDB’s `DATE` type stores a signed 32-bit number of days, while `TIMESTAMP` stores a signed 64-bit number of microseconds. Despite using a wider integer representation, `TIMESTAMP` covers a much smaller range because each day must be multiplied by the number of microseconds per day. Consequently, some valid finite `DATE` values, such as `DATE '294247-01-11'` cannot be represented as a `TIMESTAMP`. An explicit cast must therefore raise a conversion error. `TRY_CAST` must return `NULL` for the same value.

### Incorrect optimizer behavior

With the expression rewriter enabled, DuckDB transformed `CAST(d AS TIMESTAMP) > TIMESTAMP '294247-01-10 04:00:00'` into a direct `DATE` comparison similar to `d > DATE '294247-01-10'`
               
The rewritten comparison no longer executed the original cast. As a result:

  - `CAST` stopped raising an error for out-of-range finite dates.
  - `TRY_CAST`, which should have produced `NULL`, behaved like a normal comparison.
  - The optimized and unoptimized execution paths returned different results.

Disabling only the `expression_rewriter` optimizer reproduced the correct conversion error, which isolated the defect to ComparisonSimplificationRule.

### Root cause

The rule used `CastIsInvertible` to decide whether a cast could be moved from the column side to the constant side. However, invertibility and totality are different properties:

  - An invertible cast does not map two successfully converted source values to the same target value.
  - A total cast succeeds for every possible source value.

`DATE → TIMESTAMP` is invertible for values that convert successfully, but it is not total because sufficiently distant finite dates overflow the TIMESTAMP range. The optimizer checked the first property but implicitly assumed the second one. Infinity also requires special treatment. DuckDB intentionally maps: `DATE 'infinity' → TIMESTAMP 'infinity'`

Therefore, merely checking whether the statistical minimum and maximum can be converted is insufficient. If the maximum is `DATE 'infinity'`, that endpoint converts successfully while an out-of-range finite date immediately below it may still fail.

### Fix

The comparison simplification rule now first asks whether the cast can throw.

For casts that cannot throw, the existing optimization continues unchanged. For a potentially throwing `DATE → TIMESTAMP` cast, the optimizer removes the cast only when it can prove that every value read from the column is representable as a `TIMESTAMP`.

The proof works as follows:

  1. The cast operand must be a direct, non-correlated column reference.
  2. The optimizer locates the corresponding table scan.
  3. It obtains the column’s min/max statistics through the table-scan statistics callback.
  4. Both bounds must be present and finite.
  5. Both bounds must successfully convert to `TIMESTAMP`.

For finite dates, conversion to midnight `TIMESTAMP` is monotonic, and the representable source domain is contiguous. Therefore, if both finite endpoints of the column’s range convert successfully, every date between them also converts successfully.

If statistics are unavailable, either endpoint is infinite, or either conversion fails, the optimizer conservatively keeps the original cast.

This is also safe for transaction-local modifications: DuckDB’s table-scan statistics callback returns no statistics when the table has outstanding local changes, so newly inserted values cannot be missed by the proof.

### Resulting behavior

For ordinary tables containing dates such as `2024` or `2025`, DuckDB can still simplify the predicate to a direct `DATE` comparison and retain the existing optimization.

For a table containing an out-of-range finite date, the plan keeps `CAST(d AS TIMESTAMP)` and execution raises the same conversion error regardless of whether the expression rewriter is enabled.

For `TRY_CAST`, failed conversions remain `NULL` instead of being replaced by a direct `DATE` comparison.

DuckDB may still derive an optional `DATE` filter for zonemap pruning, but that filter is only an optimization hint. The authoritative `CAST` expression remains in the plan and preserves the required error or `NULL` semantics.
