### PR TITLE
Return the aggregate's empty-input result for correlated subqueries

### DIFF
--- a/src/include/duckdb/planner/subquery/flatten_dependent_join.hpp
+++ b/src/include/duckdb/planner/subquery/flatten_dependent_join.hpp
@@ -84,7 +84,7 @@ private:
 	void AddReplacementAliases(const BindingReplacementGraph &replacements);
 	Binder &binder;
 	column_binding_map_t<ColumnBinding> correlated_aliases;
-	column_binding_map_t<idx_t> replacement_map;
+	column_binding_map_t<Value> replacement_map;
 	const CorrelatedColumns &correlated_columns;
 	vector<LogicalType> delim_types;
 

--- a/src/include/duckdb/planner/subquery/rewrite_correlated_expressions.hpp
+++ b/src/include/duckdb/planner/subquery/rewrite_correlated_expressions.hpp
@@ -31,15 +31,16 @@ private:
 	column_binding_map_t<ColumnBinding> &correlated_aliases;
 };
 
-//! Helper class that rewrites COUNT aggregates into a CASE expression turning NULL into 0 after a LEFT OUTER JOIN
+//! Helper class that rewrites aggregates returning a non-NULL result for zero rows into a CASE expression turning
+//! the NULL of a LEFT OUTER JOIN back into that result
 class RewriteCountAggregates : public LogicalOperatorVisitor {
 public:
-	static void Rewrite(LogicalOperator &op, column_binding_map_t<idx_t> &replacement_map);
+	static void Rewrite(LogicalOperator &op, column_binding_map_t<Value> &replacement_map);
 
 private:
-	explicit RewriteCountAggregates(column_binding_map_t<idx_t> &replacement_map);
+	explicit RewriteCountAggregates(column_binding_map_t<Value> &replacement_map);
 	unique_ptr<Expression> VisitReplace(BoundColumnRefExpression &expr, unique_ptr<Expression> *expr_ptr) override;
-	column_binding_map_t<idx_t> &replacement_map;
+	column_binding_map_t<Value> &replacement_map;
 };
 
 } // namespace duckdb

--- a/src/planner/subquery/flatten_dependent_join.cpp
+++ b/src/planner/subquery/flatten_dependent_join.cpp
@@ -4,7 +4,7 @@
 
 #include "duckdb/common/operator/add.hpp"
 #include "duckdb/common/exception/parser_exception.hpp"
-#include "duckdb/function/aggregate/distributive_functions.hpp"
+#include "duckdb/storage/arena_allocator.hpp"
 #include "duckdb/function/aggregate/distributive_function_utils.hpp"
 #include "duckdb/function/window/rows_functions.hpp"
 #include "duckdb/main/settings.hpp"
@@ -801,6 +801,45 @@ FlattenDependentJoins::UnnestingState FlattenDependentJoins::PushDownProjection(
 	return result;
 }
 
+//! The result of an aggregate for zero input rows, obtained by finalizing a freshly initialized state
+//! Returns NULL for volatile aggregates and for aggregates that cannot be finalized without aggregating rows
+static Value AggregateEmptyResult(const BoundAggregateExpression &aggr) {
+	auto &func = aggr.Function();
+	// finalizing a volatile aggregate can have observable effects - it may only be evaluated during execution
+	if (func.GetStability() == FunctionStability::VOLATILE) {
+		return Value(func.GetReturnType());
+	}
+	// state export aggregates serialize their state on finalize - not every state supports that
+	if (func.GetReturnType().IsAggregateState()) {
+		return Value(func.GetReturnType());
+	}
+	if (!func.HasStateSizeCallback() || !func.HasStateInitCallback() || !func.HasStateFinalizeCallback()) {
+		return Value(func.GetReturnType());
+	}
+	auto bind_data = aggr.BindInfo().get();
+	AggregateStateInput state_input(func, bind_data);
+	auto state = make_unsafe_uniq_array_uninitialized<data_t>(func.GetStateSizeCallback()(state_input));
+	data_ptr_t state_ptr = state.get();
+	func.GetStateInitCallback()(state_input, &state_ptr, 1);
+
+	ArenaAllocator allocator(Allocator::DefaultAllocator());
+	Vector state_vector(Value::POINTER(CastPointerToValue(state_ptr)), count_t(1));
+	state_vector.SetVectorType(VectorType::FLAT_VECTOR);
+	Vector result(func.GetReturnType());
+	// finalizing a state that never aggregated a row yields the result for zero input rows
+	AggregateFinalizeInputData finalize_input(func, bind_data, allocator);
+	func.GetStateFinalizeCallback()(state_vector, finalize_input, result, 1, 0);
+	FlatVector::SetSize(result, count_t(1));
+	auto empty_result = result.GetValue(0);
+
+	auto destructor = func.GetStateDestructorCallback();
+	if (destructor) {
+		AggregateInputData destructor_input(func, bind_data, allocator);
+		destructor(state_vector, destructor_input, 1);
+	}
+	return empty_result;
+}
+
 FlattenDependentJoins::UnnestingState FlattenDependentJoins::PushDownAggregate(unique_ptr<LogicalOperator> &plan,
                                                                                bool propagate_null_values,
                                                                                vector<ColumnBinding> state) {
@@ -835,13 +874,20 @@ FlattenDependentJoins::UnnestingState FlattenDependentJoins::PushDownAggregate(u
 		return result;
 	}
 
+	// aggregates that produce a non-NULL result for zero rows need a row for every delim key
+	vector<Value> empty_results;
+	for (auto &aggr_exp : aggr.expressions) {
+		auto &b_aggr_exp = aggr_exp->Cast<BoundAggregateExpression>();
+		empty_results.push_back(AggregateEmptyResult(b_aggr_exp));
+	}
+
 	JoinType join_type = JoinType::INNER;
 	if (any_join || !propagate_null_values) {
 		join_type = JoinType::LEFT;
 	}
-	for (auto &aggr_exp : aggr.expressions) {
-		auto &b_aggr_exp = aggr_exp->Cast<BoundAggregateExpression>();
-		if (!b_aggr_exp.PropagatesNullValues()) {
+	for (idx_t i = 0; i < aggr.expressions.size(); i++) {
+		auto &b_aggr_exp = aggr.expressions[i]->Cast<BoundAggregateExpression>();
+		if (!b_aggr_exp.PropagatesNullValues() || !empty_results[i].IsNull()) {
 			join_type = JoinType::LEFT;
 			break;
 		}
@@ -862,21 +908,11 @@ FlattenDependentJoins::UnnestingState FlattenDependentJoins::PushDownAggregate(u
 		join->conditions.push_back(std::move(cond));
 	}
 	for (idx_t i = 0; i < aggr.expressions.size(); i++) {
-		D_ASSERT(aggr.expressions[i]->GetExpressionClass() == ExpressionClass::BOUND_AGGREGATE);
-		auto &bound_func = aggr.expressions[i]->Cast<BoundAggregateExpression>().Function();
-
-		auto count_fun = CountFunctionBase::GetFunction();
-		auto count_star_fun = CountStarFun::GetFunction();
-
-		const auto is_count_func =
-		    bound_func.GetName() == count_fun.name && bound_func.GetCallbacks() == count_fun.GetCallbacks();
-
-		const auto is_count_star_func =
-		    bound_func.GetName() == count_star_fun.name && bound_func.GetCallbacks() == count_star_fun.GetCallbacks();
-
-		if (is_count_func || is_count_star_func) {
-			replacement_map[ColumnBinding(aggr.aggregate_index, ProjectionIndex(i))] = i;
+		if (empty_results[i].IsNull()) {
+			continue;
 		}
+		// the LEFT join emits NULL for delim keys without a matching group - rewrite it back into the empty result
+		replacement_map[ColumnBinding(aggr.aggregate_index, ProjectionIndex(i))] = empty_results[i];
 	}
 	plan = std::move(join);
 	result.bindings = CreateContiguousState(ColumnBinding(left_index, ProjectionIndex(0)));

--- a/src/planner/subquery/rewrite_correlated_expressions.cpp
+++ b/src/planner/subquery/rewrite_correlated_expressions.cpp
@@ -78,11 +78,11 @@ unique_ptr<Expression> RewriteCorrelatedExpressions::VisitReplace(BoundColumnRef
 	return nullptr;
 }
 
-RewriteCountAggregates::RewriteCountAggregates(column_binding_map_t<idx_t> &replacement_map)
+RewriteCountAggregates::RewriteCountAggregates(column_binding_map_t<Value> &replacement_map)
     : replacement_map(replacement_map) {
 }
 
-void RewriteCountAggregates::Rewrite(LogicalOperator &op, column_binding_map_t<idx_t> &replacement_map) {
+void RewriteCountAggregates::Rewrite(LogicalOperator &op, column_binding_map_t<Value> &replacement_map) {
 	RewriteCountAggregates rewriter(replacement_map);
 	rewriter.VisitOperator(op);
 }
@@ -91,12 +91,12 @@ unique_ptr<Expression> RewriteCountAggregates::VisitReplace(BoundColumnRefExpres
                                                             unique_ptr<Expression> *expr_ptr) {
 	auto entry = replacement_map.find(expr.Binding());
 	if (entry != replacement_map.end()) {
-		// reference to a COUNT(*) aggregate
-		// replace this with CASE WHEN COUNT(*) IS NULL THEN 0 ELSE COUNT(*) END
+		// reference to an aggregate that returns a non-NULL result for zero rows
+		// replace this with CASE WHEN aggr IS NULL THEN empty_result ELSE aggr END
 		auto is_null = make_uniq<BoundOperatorExpression>(ExpressionType::OPERATOR_IS_NULL, LogicalType::BOOLEAN);
 		is_null->GetChildrenMutable().push_back(expr.Copy());
 		auto check = std::move(is_null);
-		auto result_if_true = make_uniq<BoundConstantExpression>(Value::Numeric(expr.GetReturnType(), 0));
+		auto result_if_true = make_uniq<BoundConstantExpression>(entry->second);
 		auto result_if_false = std::move(*expr_ptr);
 		return make_uniq<BoundCaseExpression>(std::move(check), std::move(result_if_true), std::move(result_if_false));
 	}

--- a/test/configs/verify_aggregate_state_export.json
+++ b/test/configs/verify_aggregate_state_export.json
@@ -79,6 +79,7 @@
         "test/sql/show_select/summarize_subquery.test",
         "test/sql/show_select/test_summarize.test",
         "test/sql/show_select/test_summarize_quoted.test",
+        "test/sql/subquery/scalar/test_aggregate_zero_on_empty_subquery.test",
         "test/sql/types/bignum/test_big_bignum.test",
         "test/sql/types/bignum/test_bignum_implicit_cast.test",
         "test/sql/types/bignum/test_bignum_sum.test",

--- a/test/sql/subquery/scalar/test_aggregate_zero_on_empty_subquery.test
+++ b/test/sql/subquery/scalar/test_aggregate_zero_on_empty_subquery.test
@@ -1,0 +1,99 @@
+# name: test/sql/subquery/scalar/test_aggregate_zero_on_empty_subquery.test
+# description: Aggregates that return 0 for zero rows must also return 0 in correlated subqueries
+# group: [scalar]
+
+statement ok
+CREATE TABLE foo (a INT, b INT);
+
+statement ok
+CREATE TABLE bar (c INT, d INT);
+
+statement ok
+INSERT INTO foo SELECT range, range + 1 FROM range(1, 21);
+
+statement ok
+INSERT INTO bar SELECT range % 6 + 1, range + 2 FROM range(1, 21);
+
+# foo.a = 7..20 has no matching group in bar, so the subquery must return 0 instead of NULL
+query I
+SELECT count(*) FROM foo
+WHERE a > (SELECT regr_count(bar.c, bar.d) FROM bar WHERE foo.a = bar.c);
+----
+17
+
+query II
+SELECT foo.a, (SELECT regr_count(bar.c, bar.d) FROM bar WHERE foo.a = bar.c) AS rc
+FROM foo
+WHERE foo.a >= 5
+ORDER BY foo.a;
+----
+5	3
+6	3
+7	0
+8	0
+9	0
+10	0
+11	0
+12	0
+13	0
+14	0
+15	0
+16	0
+17	0
+18	0
+19	0
+20	0
+
+statement ok
+CREATE TABLE t1 (k INT);
+
+statement ok
+INSERT INTO t1 VALUES (1), (99);
+
+statement ok
+CREATE TABLE t2 (k INT, v INT);
+
+statement ok
+INSERT INTO t2 VALUES (1, 10), (1, 20);
+
+# empty input returns 0 for these aggregates
+query IIIII
+SELECT count(*), count(v), regr_count(k, v), approx_count_distinct(v), entropy(v) FROM t2 WHERE k = 99;
+----
+0	0	0	0	0.0
+
+# a correlated subquery over an empty group must return the same values
+query IIIIII
+SELECT k,
+	(SELECT count(*) FROM t2 WHERE t2.k = t1.k),
+	(SELECT count(t2.v) FROM t2 WHERE t2.k = t1.k),
+	(SELECT regr_count(t2.k, t2.v) FROM t2 WHERE t2.k = t1.k),
+	(SELECT approx_count_distinct(t2.v) FROM t2 WHERE t2.k = t1.k),
+	(SELECT entropy(t2.v) FROM t2 WHERE t2.k = t1.k)
+FROM t1
+ORDER BY k;
+----
+1	2	2	2	2	1.0
+99	0	0	0	0	0.0
+
+# aggregates that return NULL for zero rows must keep returning NULL
+query III
+SELECT k,
+	(SELECT sum(t2.v) FROM t2 WHERE t2.k = t1.k),
+	(SELECT list(t2.v) FROM t2 WHERE t2.k = t1.k)
+FROM t1
+ORDER BY k;
+----
+1	30	[10, 20]
+99	NULL	NULL
+
+# DISTINCT and FILTER modifiers keep the 0 semantics
+query III
+SELECT k,
+	(SELECT regr_count(DISTINCT t2.k, t2.v) FROM t2 WHERE t2.k = t1.k),
+	(SELECT count(t2.v) FILTER (WHERE t2.v > 100) FROM t2 WHERE t2.k = t1.k)
+FROM t1
+ORDER BY k;
+----
+1	2	0
+99	0	0


### PR DESCRIPTION
`count` returns 0 when aggregating zero rows, and so do `regr_count`,
`approx_count_distinct` and `entropy`. In a correlated subquery over an empty
group, however, only `count`/`count_star` returned 0 — the others returned NULL:

```sql
CREATE TABLE t1 AS SELECT * FROM (VALUES (1), (99)) t(k);
CREATE TABLE t2 AS SELECT * FROM (VALUES (1, 10), (1, 20)) t(k, v);
       
SELECT k,
       (SELECT count(*) FROM t2 WHERE t2.k = t1.k),
       (SELECT regr_count(t2.k, t2.v) FROM t2 WHERE t2.k = t1.k),
       (SELECT approx_count_distinct(t2.v) FROM t2 WHERE t2.k = t1.k),
       (SELECT entropy(t2.v) FROM t2 WHERE t2.k = t1.k)
FROM t1 ORDER BY k;
-- 1  | 2 | 2    | 2    | 1.0
-- 99 | 0 | NULL | NULL | NULL   <-- should be 0, 0, 0.0
```

  The planner recognized the two count functions by comparing name plus callbacks
  — which cannot reach the aggregates in core_functions — and hardcoded 0 as the
  replacement value.
  
  This derives it from callbacks every aggregate already has: initializing a state
  and finalizing it without aggregating a row is the result for zero input rows.
  PushDownAggregate uses that Value to 
  
  - force the LEFT join that keeps a row for every delim key (entropy propagates
    NULL values, so it got an INNER join and its row was dropped entirely), and
  - rewrite the reference into CASE WHEN x IS NULL THEN <empty result> ELSE x END.
  
  No aggregate declares anything, no name or callback comparisons remain, and
  extension aggregates are covered automatically. Volatile aggregates are excluded
  — finalizing them can have observable effects, so they may only be evaluated
  during execution. 
  
  Sweeping every single- and two-argument aggregate shows no remaining mismatch
  between the plain empty-input result and the correlated one. The new test covers
  the four affected aggregates, DISTINCT/FILTER modifiers, and a guard that
  sum/list still return NULL.
  
  Note: entropy is registered with DEFAULT_NULL_HANDLING yet returns 0.0 for
  zero rows, contradicting what VerifyNullHandling documents. This PR does not
  depend on that annotation — happy to fix it here or separately.

The planner no longer compares function names or callback pointers here.