### PR TITLE
Update MODE’s tie-break position when the earliest matching row leaves a sliding window frame

### DIFF
--- a/extension/core_functions/aggregate/holistic/mode.cpp
+++ b/extension/core_functions/aggregate/holistic/mode.cpp
@@ -300,14 +300,31 @@ struct ModeState {
 		}
 	}
 
-	void ModeRm(idx_t frame) {
-		const auto &key = GetCell(frame);
-		auto &attr = (*frequency_map)[key];
+	template <class INCLUDED>
+	void ModeRm(idx_t row, const SubFrames &frames, INCLUDED &included) {
+		const auto &key = GetCell(row);
+		auto entry = frequency_map->find(key);
+		D_ASSERT(entry != frequency_map->end());
+		auto &attr = entry->second;
 		auto old_count = attr.count;
 		nonzero -= size_t(old_count == 1);
 
 		attr.count -= 1;
-		if (count == old_count && TYPE_OP::IsEqual(key, *mode)) {
+		if (attr.count && attr.first_row == row) {
+			attr.first_row = std::numeric_limits<idx_t>::max();
+			for (const auto &frame : frames) {
+				for (auto candidate = frame.start; candidate < frame.end; ++candidate) {
+					if (included(candidate) && TYPE_OP::IsEqual(entry->first, GetCell(candidate))) {
+						attr.first_row = candidate;
+						break;
+					}
+				}
+				if (attr.first_row != std::numeric_limits<idx_t>::max()) {
+					break;
+				}
+			}
+		}
+		if (count == old_count && TYPE_OP::IsEqual(entry->first, *mode)) {
 			valid = false;
 		}
 	}
@@ -426,8 +443,10 @@ struct ModeFunction : TypedModeFunction<TYPE_OP> {
 	struct UpdateWindowState {
 		STATE &state;
 		ModeIncluded<STATE> &included;
+		const SubFrames &frames;
 
-		inline UpdateWindowState(STATE &state, ModeIncluded<STATE> &included) : state(state), included(included) {
+		inline UpdateWindowState(STATE &state, ModeIncluded<STATE> &included, const SubFrames &frames)
+		    : state(state), included(included), frames(frames) {
 		}
 
 		inline void Neither(idx_t begin, idx_t end) {
@@ -436,7 +455,7 @@ struct ModeFunction : TypedModeFunction<TYPE_OP> {
 		inline void Left(idx_t begin, idx_t end) {
 			for (; begin < end; ++begin) {
 				if (included(begin)) {
-					state.ModeRm(begin);
+					state.ModeRm(begin, frames, included);
 				}
 			}
 		}
@@ -472,7 +491,6 @@ struct ModeFunction : TypedModeFunction<TYPE_OP> {
 		ModeIncluded<STATE> included(fmask, state);
 
 		using Updater = UpdateWindowState<STATE, INPUT_TYPE>;
-		Updater updater(state, included);
 
 		if (!state.frequency_map) {
 			state.frequency_map = TYPE_OP::CreateEmpty(Allocator::DefaultAllocator());
@@ -493,6 +511,7 @@ struct ModeFunction : TypedModeFunction<TYPE_OP> {
 					}
 				}
 			} else {
+				Updater updater(state, included, frames);
 				AggregateExecutor::IntersectFrames(prevs, frames, updater);
 			}
 

--- a/test/sql/window/test_mode_window.test
+++ b/test/sql/window/test_mode_window.test
@@ -172,6 +172,25 @@ NULL	NULL	0
 
 endloop
 
+statement ok
+PRAGMA debug_window_mode='window'
+
+query II
+WITH t(id, x) AS (
+	VALUES (1, 'A'), (2, 'B'), (3, 'A'), (4, 'B'), (5, 'A')
+)
+SELECT id, MODE(x ORDER BY id) OVER (
+	ORDER BY id ROWS BETWEEN 3 PRECEDING AND CURRENT ROW
+) AS actual
+FROM t
+ORDER BY id
+----
+1	A
+2	A
+3	A
+4	A
+5	B
+
 query I
 WITH src(x) AS (
   VALUES (0), (2)


### PR DESCRIPTION
Fix #24826 

### Problem

The bug affected ordered MODE aggregates used over sliding window frames, such as:

```
  MODE(x ORDER BY id) OVER (
      ORDER BY id
      ROWS BETWEEN 3 PRECEDING AND CURRENT ROW
  )
```

When multiple values have the same frequency, `MODE(... ORDER BY ...)` must use the aggregate-local ordering to break the tie. In the reported example, the final frame contains `B, A, B, A`. Both values occur twice, but `B` appears first in the current frame, so the correct result is `B`. DuckDB incorrectly returned `A`.

With optimization enabled, DuckDB recognizes that the aggregate’s `ORDER BY` id is identical to the window ordering and removes the redundant aggregate-local order. This is a valid optimization because the input is already arranged in the required order. Native window execution then selects MODE’s incremental custom-window implementation.

That implementation maintains a frequency-map entry for every value `value → { occurrence count, first row position }`

When a row entered the frame, both fields were updated correctly. However, when a row left the frame, `ModeState::ModeRm` only decremented the occurrence count. If the removed row was the earliest occurrence of that value, its stored `first_row` remained unchanged.

For the failing frame, A therefore retained a position belonging to a row that had already left the frame. When MODE rescanned the frequency map to resolve the 2–2 tie, the stale position made `A` appear earlier than `B`.

This also explains the execution-path differences:

  - Native `WINDOW` mode reused the incremental state and produced the wrong result.
  - Disabling the optimizer forced naïve window aggregation, which recomputed every frame and returned `B`.
  - `SEPARATE` and `COMBINE` modes also avoided the affected custom-window path and returned `B`.
  - Disabling individual named optimizer passes did not fix the result, because the relevant order simplification and window-aggregator selection happen during window executor construction rather than in one registered logical optimizer pass.

### Fix
The fix keeps the optimized MODE implementation instead of disabling it. When ModeRm removes a value’s current `first_row` and other occurrences of that value remain, it now scans the target window subframes in order and records the next included occurrence. The scan respects:

  - the current frame boundaries,
  - `FILTER` conditions,
  - `NULL` exclusion,
  - and window `EXCLUDE` subframes.

It also compares against the key owned by the frequency map rather than retaining a reference into the window collection. This matters because scanning another row can load a different collection page and invalidate a reference to the original row data. The resulting behavior is:

```
  remove earliest occurrence
          ↓
  value still exists in the new frame?
          ↓ yes
  find its first valid occurrence in the target subframes
          ↓
  update first_row before resolving the mode
```

This is narrower than falling back to naïve aggregation for every ordered MODE window. It preserves the existing incremental accelerator and only performs additional work when the specific earliest-occurrence metadata becomes invalid.

