### PR TITLE
ARM64 portability hardening: mechanical UB fixes without behavior change

### DIFF
--- a/extension/core_functions/scalar/operators/bitwise.cpp
+++ b/extension/core_functions/scalar/operators/bitwise.cpp
@@ -258,6 +258,9 @@ struct BitwiseShiftLeftOperator {
 		if (shift == 0) {
 			return input;
 		}
+		if (input == 0) {
+			return 0;
+		}
 		TA max_value = UnsafeNumericCast<TA>((TA(1) << (max_shift - shift - 1)));
 		if (input >= max_value) {
 			throw OutOfRangeException("Overflow in left shift (%s << %s)", NumericHelper::ToString(input),

--- a/src/common/checksum.cpp
+++ b/src/common/checksum.cpp
@@ -66,11 +66,10 @@ hash_t ChecksumRemainder(const void *ptr, size_t len) noexcept {
 
 uint64_t Checksum(const uint8_t *buffer, size_t size) {
 	uint64_t result = 5381;
-	auto ptr = reinterpret_cast<const uint64_t *>(buffer);
 	size_t i;
 	// for efficiency, we first checksum uint64_t values
 	for (i = 0; i < size / 8; i++) {
-		result ^= Checksum(ptr[i]);
+		result ^= Checksum(Load<uint64_t>(buffer + i * 8));
 	}
 	if (size > i * 8) {
 		// the remaining 0-7 bytes we hash using a string hash

--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -445,7 +445,8 @@ uint64_t StringUtil::CIHash(const string &str) {
 uint64_t StringUtil::CIHash(const char *str, idx_t size) {
 	uint32_t hash = 0;
 	for (idx_t i = 0; i < size; i++) {
-		hash += static_cast<uint32_t>(StringUtil::CharacterToLower(static_cast<char>(str[i])));
+		// convert through uint8_t so the hash is identical on platforms with signed and unsigned char
+		hash += static_cast<uint32_t>(static_cast<uint8_t>(StringUtil::CharacterToLower(static_cast<char>(str[i]))));
 		hash += hash << 10;
 		hash ^= hash >> 6;
 	}

--- a/src/common/types/uuid.cpp
+++ b/src/common/types/uuid.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/common/types/uuid.hpp"
 #include "duckdb/common/chrono.hpp"
+#include "duckdb/common/helper.hpp"
 #include "duckdb/common/random_engine.hpp"
 
 namespace duckdb {
@@ -152,7 +153,7 @@ hugeint_t BaseUUID::Convert(const std::array<uint8_t, 16> &bytes) {
 hugeint_t UUIDv4::GenerateRandomUUID(RandomEngine &engine) {
 	std::array<uint8_t, 16> bytes;
 	for (int i = 0; i < 16; i += 4) {
-		*reinterpret_cast<uint32_t *>(bytes.data() + i) = engine.NextRandomInteger();
+		Store<uint32_t>(engine.NextRandomInteger(), bytes.data() + i);
 	}
 	// variant must be 10xxxxxx
 	bytes[8] &= 0xBF;

--- a/src/execution/join_hashtable.cpp
+++ b/src/execution/join_hashtable.cpp
@@ -762,15 +762,15 @@ static inline data_ptr_t InsertRowToEntry(atomic<ht_entry_t> &entry, const data_
 			StorePointer(nullptr, row_ptr_to_insert + pointer_offset);
 
 			ht_entry_t expected_entry;
-			entry.compare_exchange_strong(expected_entry, desired_entry, std::memory_order_acquire,
-			                              std::memory_order_relaxed);
+			entry.compare_exchange_strong(expected_entry, desired_entry, std::memory_order_release,
+			                              std::memory_order_acquire);
 
 			// The expected entry is updated with the encountered entry by the compare exchange
 			// So, this returns a nullptr if it was empty, and a non-null if it was not (which cancels the insert)
 			return expected_entry.GetPointerOrNull();
 		} else {
 			// At this point we know that the keys match, so we can try to insert until we succeed
-			ht_entry_t expected_entry = entry.load(std::memory_order_relaxed);
+			ht_entry_t expected_entry = entry.load(std::memory_order_acquire);
 			D_ASSERT(expected_entry.IsOccupied());
 			do {
 				data_ptr_t current_row_pointer = expected_entry.GetPointer();
@@ -926,7 +926,7 @@ static void InsertHashesLoop(unsafe_optional_ptr<atomic<ht_entry_t>> entries, Ve
 			bool occupied;
 			while (true) {
 				atomic<ht_entry_t> &atomic_entry = entries.get()[ht_offset];
-				entry = atomic_entry.load(std::memory_order_relaxed);
+				entry = atomic_entry.load(std::memory_order_acquire);
 				occupied = entry.IsOccupied();
 
 				// condition for incrementing the ht_offset: occupied and row_salt does not match -> move to next entry

--- a/src/execution/operator/persistent/physical_copy_to_file.cpp
+++ b/src/execution/operator/persistent/physical_copy_to_file.cpp
@@ -1528,7 +1528,7 @@ void CopyFileLifecycleExecutor::WaitAll(CopyFileLifecycleWaitMode mode) {
 		ThrowError();
 		return;
 	}
-	while (pending_tasks.load(std::memory_order_relaxed) > 0) {
+	while (pending_tasks.load(std::memory_order_acquire) > 0) {
 		context.InterruptCheck();
 		WorkOnTaskOrYield();
 	}

--- a/src/include/duckdb/common/types/cast_helpers.hpp
+++ b/src/include/duckdb/common/types/cast_helpers.hpp
@@ -35,7 +35,7 @@ public:
 	template <class SIGNED, class UNSIGNED>
 	static int SignedLength(SIGNED value) {
 		int sign = -(value < 0);
-		UNSIGNED unsigned_value = UnsafeNumericCast<UNSIGNED>((value ^ sign) - sign);
+		UNSIGNED unsigned_value = UNSIGNED(value ^ sign) + UNSIGNED(AbsValue(sign));
 		return UnsignedLength(unsigned_value) - sign;
 	}
 

--- a/src/include/duckdb/storage/compression/alp/algorithm/alp.hpp
+++ b/src/include/duckdb/storage/compression/alp/algorithm/alp.hpp
@@ -86,7 +86,7 @@ public:
 	T exceptions[AlpConstants::ALP_VECTOR_SIZE];
 	uint16_t exceptions_positions[AlpConstants::ALP_VECTOR_SIZE];
 	vector<AlpCombination> best_k_combinations;
-	uint8_t values_encoded[AlpConstants::ALP_VECTOR_SIZE * 8];
+	uint32_t values_encoded[AlpConstants::ALP_VECTOR_SIZE * 2];
 	using EXACT_TYPE = typename FloatingToExact<T>::TYPE;
 
 	idx_t RequiredSpace() const {
@@ -371,8 +371,8 @@ struct AlpCompression {
 		auto bit_width = BitpackingPrimitives::MinimumBitWidth<uint64_t, false>(min_max_diff);
 		auto bp_size = BitpackingPrimitives::GetRequiredSize(n_values, bit_width);
 		if (!EMPTY && bit_width > 0) { //! We only execute the BP if we are writing the data
-			BitpackingPrimitives::PackBuffer<uint64_t, false>(compression_data.values_encoded, u_encoded_integers,
-			                                                  n_values, bit_width);
+			BitpackingPrimitives::PackBuffer<uint64_t, false>(data_ptr_cast(compression_data.values_encoded),
+			                                                  u_encoded_integers, n_values, bit_width);
 		}
 		compression_data.bit_width = bit_width;                                 // in bits
 		compression_data.bp_size = bp_size;                                     // in bytes

--- a/src/include/duckdb/storage/compression/alp/algorithm/alp.hpp
+++ b/src/include/duckdb/storage/compression/alp/algorithm/alp.hpp
@@ -395,20 +395,19 @@ struct AlpDecompression {
 		AlpEncodingIndices encoding_indices = {vector_exponent, vector_factor};
 
 		// Bit Unpacking
-		uint8_t for_decoded[AlpConstants::ALP_VECTOR_SIZE * 8] = {0};
+		uint64_t for_decoded[AlpConstants::ALP_VECTOR_SIZE] = {0};
 		if (bit_width > 0) {
-			BitpackingPrimitives::UnPackBuffer<uint64_t>(for_decoded, for_encoded, count, bit_width);
+			BitpackingPrimitives::UnPackBuffer<uint64_t>(data_ptr_cast(for_decoded), for_encoded, count, bit_width);
 		}
-		auto *encoded_integers = reinterpret_cast<uint64_t *>(data_ptr_cast(for_decoded));
 
 		// unFOR
 		for (idx_t i = 0; i < count; i++) {
-			encoded_integers[i] += frame_of_reference;
+			for_decoded[i] += frame_of_reference;
 		}
 
 		// Decoding
 		for (idx_t i = 0; i < count; i++) {
-			auto encoded_integer = static_cast<int64_t>(encoded_integers[i]);
+			auto encoded_integer = static_cast<int64_t>(for_decoded[i]);
 			output[i] = alp::AlpCompression<T, true>::DecodeValue(encoded_integer, encoding_indices);
 		}
 

--- a/src/include/duckdb/storage/compression/alprd/algorithm/alprd.hpp
+++ b/src/include/duckdb/storage/compression/alprd/algorithm/alprd.hpp
@@ -48,8 +48,8 @@ public:
 	uint8_t right_bit_width; // 'right' & 'left' refer to the respective parts of the floating numbers after splitting
 	uint8_t left_bit_width;
 	uint16_t exceptions_count;
-	uint8_t right_parts_encoded[AlpRDConstants::ALP_VECTOR_SIZE * 8];
-	uint8_t left_parts_encoded[AlpRDConstants::ALP_VECTOR_SIZE * 8];
+	uint32_t right_parts_encoded[AlpRDConstants::ALP_VECTOR_SIZE * 2];
+	uint16_t left_parts_encoded[AlpRDConstants::ALP_VECTOR_SIZE * 4];
 	uint16_t left_parts_dict[AlpRDConstants::MAX_DICTIONARY_SIZE];
 	uint16_t exceptions[AlpRDConstants::ALP_VECTOR_SIZE];
 	uint16_t exceptions_positions[AlpRDConstants::ALP_VECTOR_SIZE];
@@ -198,10 +198,10 @@ struct AlpRDCompression {
 
 		if (!EMPTY) {
 			// Bitpacking Left and Right parts
-			BitpackingPrimitives::PackBuffer<uint16_t, false>(compression_data.left_parts_encoded, left_parts, n_values,
-			                                                  compression_data.left_bit_width);
-			BitpackingPrimitives::PackBuffer<uint64_t, false>(compression_data.right_parts_encoded, right_parts,
-			                                                  n_values, compression_data.right_bit_width);
+			BitpackingPrimitives::PackBuffer<uint16_t, false>(data_ptr_cast(compression_data.left_parts_encoded),
+			                                                  left_parts, n_values, compression_data.left_bit_width);
+			BitpackingPrimitives::PackBuffer<uint64_t, false>(data_ptr_cast(compression_data.right_parts_encoded),
+			                                                  right_parts, n_values, compression_data.right_bit_width);
 		}
 
 		compression_data.left_bit_packed_size = left_bit_packed_size;
@@ -217,26 +217,25 @@ struct AlpRDDecompression {
 	                       EXACT_TYPE *output, idx_t values_count, uint16_t exceptions_count,
 	                       const uint16_t *exceptions, const uint16_t *exceptions_positions, uint8_t left_bit_width,
 	                       uint8_t right_bit_width) {
-		uint8_t left_decoded[AlpRDConstants::ALP_VECTOR_SIZE * 8] = {0};
-		uint8_t right_decoded[AlpRDConstants::ALP_VECTOR_SIZE * 8] = {0};
+		uint16_t left_decoded[AlpRDConstants::ALP_VECTOR_SIZE] = {0};
+		EXACT_TYPE right_decoded[AlpRDConstants::ALP_VECTOR_SIZE] = {0};
 
 		// Bitunpacking left and right parts
-		BitpackingPrimitives::UnPackBuffer<uint16_t>(left_decoded, left_encoded, values_count, left_bit_width);
-		BitpackingPrimitives::UnPackBuffer<EXACT_TYPE>(right_decoded, right_encoded, values_count, right_bit_width);
-
-		uint16_t *left_parts = reinterpret_cast<uint16_t *>(data_ptr_cast(left_decoded));
-		EXACT_TYPE *right_parts = reinterpret_cast<EXACT_TYPE *>(data_ptr_cast(right_decoded));
+		BitpackingPrimitives::UnPackBuffer<uint16_t>(data_ptr_cast(left_decoded), left_encoded, values_count,
+		                                             left_bit_width);
+		BitpackingPrimitives::UnPackBuffer<EXACT_TYPE>(data_ptr_cast(right_decoded), right_encoded, values_count,
+		                                               right_bit_width);
 
 		// Decoding
 		for (idx_t i = 0; i < values_count; i++) {
-			uint16_t left = left_parts_dict[left_parts[i]];
-			EXACT_TYPE right = right_parts[i];
+			uint16_t left = left_parts_dict[left_decoded[i]];
+			EXACT_TYPE right = right_decoded[i];
 			output[i] = (static_cast<EXACT_TYPE>(left) << right_bit_width) | right;
 		}
 
 		// Exceptions Patching (exceptions only occur in left parts)
 		for (idx_t i = 0; i < exceptions_count; i++) {
-			EXACT_TYPE right = right_parts[exceptions_positions[i]];
+			EXACT_TYPE right = right_decoded[exceptions_positions[i]];
 			uint16_t left = exceptions[i];
 			output[exceptions_positions[i]] = (static_cast<EXACT_TYPE>(left) << right_bit_width) | right;
 		}

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -733,11 +733,15 @@ optional_idx DBConfig::ParseMemoryLimitSlurm(const string &arg) {
 		return optional_idx();
 	}
 
+	if (Value::IsNan(limit)) {
+		return optional_idx();
+	}
 	if (limit < 0) {
 		return static_cast<idx_t>(NumericLimits<int64_t>::Maximum());
 	}
 	idx_t actual_limit;
-	if (limit > static_cast<double>(NumericLimits<idx_t>::Maximum()) / static_cast<double>(multiplier)) {
+	// double(idx_max) rounds up to 2^64, so equality already means the product is not representable
+	if (limit >= static_cast<double>(NumericLimits<idx_t>::Maximum()) / static_cast<double>(multiplier)) {
 		actual_limit = NumericLimits<idx_t>::Maximum();
 	} else {
 		actual_limit = LossyNumericCast<idx_t>(static_cast<double>(multiplier) * limit);

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -440,7 +440,7 @@ LogicalType DBConfig::ParseLogicalType(const string &type) {
 		}
 		idx_t array_size = 0;
 		for (auto length_idx = bracket_open_idx + 1; length_idx < type.size() - 1; length_idx++) {
-			if (!isdigit(type[length_idx])) {
+			if (!isdigit(static_cast<unsigned char>(type[length_idx]))) {
 				throw InternalException("Ill formatted array type: '%s'", type);
 			}
 			array_size = array_size * 10 + static_cast<idx_t>(type[length_idx] - '0');
@@ -736,7 +736,12 @@ optional_idx DBConfig::ParseMemoryLimitSlurm(const string &arg) {
 	if (limit < 0) {
 		return static_cast<idx_t>(NumericLimits<int64_t>::Maximum());
 	}
-	idx_t actual_limit = LossyNumericCast<idx_t>(static_cast<double>(multiplier) * limit);
+	idx_t actual_limit;
+	if (limit > static_cast<double>(NumericLimits<idx_t>::Maximum()) / static_cast<double>(multiplier)) {
+		actual_limit = NumericLimits<idx_t>::Maximum();
+	} else {
+		actual_limit = LossyNumericCast<idx_t>(static_cast<double>(multiplier) * limit);
+	}
 	if (actual_limit == NumericLimits<idx_t>::Maximum()) {
 		return static_cast<idx_t>(NumericLimits<int64_t>::Maximum());
 	}

--- a/src/main/extension/extension_load.cpp
+++ b/src/main/extension/extension_load.cpp
@@ -767,7 +767,7 @@ string ExtensionHelper::ExtractExtensionPrefixFromPath(const string &path) {
 	D_ASSERT(extension.size() > 1);
 	// needs to be alphanumeric
 	for (auto &ch : extension) {
-		if (!isalnum(ch) && ch != '_') {
+		if (!isalnum(static_cast<unsigned char>(ch)) && ch != '_') {
 			return "";
 		}
 	}

--- a/src/main/http/http_util.cpp
+++ b/src/main/http/http_util.cpp
@@ -348,7 +348,7 @@ struct URISchemeDetectionResult {
 };
 
 bool IsValidSchemeChar(char c) {
-	return std::isalnum(c) || c == '+' || c == '.' || c == '-';
+	return std::isalnum(static_cast<unsigned char>(c)) || c == '+' || c == '.' || c == '-';
 }
 
 //! See https://datatracker.ietf.org/doc/html/rfc3986#section-3.1
@@ -363,7 +363,7 @@ URISchemeDetectionResult DetectURIScheme(const string &uri) {
 		return result;
 	}
 
-	if (!std::isalpha(uri[0])) {
+	if (!std::isalpha(static_cast<unsigned char>(uri[0]))) {
 		//! Scheme names consist of a sequence of characters beginning with a letter
 		result.lower_scheme = "";
 		result.scheme_type = URISchemeType::NONE;

--- a/src/main/user_settings.cpp
+++ b/src/main/user_settings.cpp
@@ -146,7 +146,7 @@ CachedGlobalSettings &GlobalUserSettings::GetSettings() const {
 	thread_local CachedGlobalSettings current_cache;
 #endif
 
-	const auto current_version = settings_version.load(std::memory_order_relaxed);
+	const auto current_version = settings_version.load(std::memory_order_acquire);
 	if (!current_cache.global_user_settings || this != current_cache.global_user_settings.get() ||
 	    current_cache.uuid != uuid || current_cache.version != current_version) {
 		// out-of-date, refresh the cache

--- a/test/common/CMakeLists.txt
+++ b/test/common/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library_unity(
   test_parse_expression.cpp
   test_parse_load_statement.cpp
   test_parse_logical_type.cpp
+  test_parse_memory_limit_slurm.cpp
   test_recursive_cte_metrics.cpp
   test_scalar_executor.cpp
   test_logical_type_is_complete.cpp

--- a/test/common/test_parse_memory_limit_slurm.cpp
+++ b/test/common/test_parse_memory_limit_slurm.cpp
@@ -1,0 +1,31 @@
+#include "catch.hpp"
+#include "duckdb/main/config.hpp"
+
+using namespace duckdb;
+
+TEST_CASE("Test ParseMemoryLimitSlurm", "[config]") {
+	static constexpr idx_t UNLIMITED = static_cast<idx_t>(NumericLimits<int64_t>::Maximum());
+
+	// empty or unparseable input is invalid
+	REQUIRE(!DBConfig::ParseMemoryLimitSlurm("").IsValid());
+	REQUIRE(!DBConfig::ParseMemoryLimitSlurm("abc").IsValid());
+	REQUIRE(!DBConfig::ParseMemoryLimitSlurm("nan").IsValid());
+
+	// plain numbers default to MB, suffixes K/M/G/T scale by powers of 1000
+	REQUIRE(DBConfig::ParseMemoryLimitSlurm("1000").GetIndex() == 1000ULL * 1000 * 1000);
+	REQUIRE(DBConfig::ParseMemoryLimitSlurm("10K").GetIndex() == 10ULL * 1000);
+	REQUIRE(DBConfig::ParseMemoryLimitSlurm("2g").GetIndex() == 2ULL * 1000 * 1000 * 1000);
+	REQUIRE(DBConfig::ParseMemoryLimitSlurm("1.5G").GetIndex() == 1500ULL * 1000 * 1000);
+	REQUIRE(DBConfig::ParseMemoryLimitSlurm("1T").GetIndex() == 1000ULL * 1000 * 1000 * 1000);
+
+	// negative means unlimited
+	REQUIRE(DBConfig::ParseMemoryLimitSlurm("-1").GetIndex() == UNLIMITED);
+
+	// values whose scaled result is not representable in idx_t are clamped to unlimited
+	REQUIRE(DBConfig::ParseMemoryLimitSlurm("inf").GetIndex() == UNLIMITED);
+	REQUIRE(DBConfig::ParseMemoryLimitSlurm("1000000000T").GetIndex() == UNLIMITED);
+	// double(idx_max) rounds up to 2^64 - this value sits exactly on the clamp boundary
+	REQUIRE(DBConfig::ParseMemoryLimitSlurm("18446744073709552K").GetIndex() == UNLIMITED);
+	// one representable double below the boundary stays an exact value
+	REQUIRE(DBConfig::ParseMemoryLimitSlurm("18446744073709548K").GetIndex() == 18446744073709547520ULL);
+}

--- a/test/common/test_string_util.cpp
+++ b/test/common/test_string_util.cpp
@@ -527,3 +527,16 @@ TEST_CASE("Test JSON Parsing", "[string_util]") {
 	}
 	)JSON_LITERAL");
 }
+
+TEST_CASE("Test CIHash is independent of char signedness", "[string_util]") {
+	// bytes >= 0x80 must be zero-extended before hashing so the result is identical
+	// on platforms where char is signed (x86) and where it is unsigned (ARM)
+	const char high_byte[] = {(char)0xC3, 0};
+	REQUIRE(StringUtil::CIHash(high_byte, 1) == 2242087697ULL);
+
+	const char cafe_utf8[] = "Caf\xC3\xA9";
+	REQUIRE(StringUtil::CIHash(cafe_utf8, strlen(cafe_utf8)) == 2425794034ULL);
+
+	// ASCII is unaffected
+	REQUIRE(StringUtil::CIHash("hello") == StringUtil::CIHash("HeLLo"));
+}

--- a/test/sql/function/operator/test_bitwise_ops.test
+++ b/test/sql/function/operator/test_bitwise_ops.test
@@ -77,3 +77,14 @@ statement error
 SELECT 2::UINT32 << 31
 ----
 Overflow in left shift
+
+# shifting 0 by the type width is defined (previously UB in the shift itself)
+query I
+SELECT 0::UBIGINT << 64
+----
+0
+
+query I
+SELECT 0::BIGINT << 64
+----
+0


### PR DESCRIPTION
Split out from #24872 (behavior-neutral half). See #24871 for the full ARM64 audit context. The behavior-affecting fixes (interpolation, binning hang, lead/lag bounds) are in #24883.

These changes remove undefined or implementation-defined behavior **without changing any observable results**:

- **checksum / uuid**: go through `Load`/`Store` instead of `reinterpret_cast` (alignment/aliasing UB)
- **`StringUtil::CIHash`**: zero-extend bytes >= 0x80 so the hash is identical on signed-char (x86) and unsigned-char (ARM) platforms — comes with a C++ unit test locking in the exact hash values
- **join hashtable / copy-to-file / user settings**: correct atomic memory orderings in publish/read patterns. The `InsertRowToEntry` EXPECT_EMPTY CAS had the two orderings inverted for their roles: success is a publish (the new row's next-pointer is initialized immediately before → release), failure is a load whose result is immediately dereferenced for key comparison (→ acquire) — the else-branch CAS just below already used release-on-success. Probe/insert loads feeding row-pointer dereferences become acquire; `WaitAll`'s flag load pairs with the release in workers' `--pending_tasks`; `user_settings` version check becomes acquire (payload is mutex-protected today; model hygiene). Zero codegen cost on x86-64 (TSO); on ARM64 `ldr`→`ldar` on cache-miss-dominated paths — measured in **Verification** below.
- **ALP/ALPRD**: typed buffers instead of byte-buffer casts — decompression side, plus the compress-side `values_encoded` (was `uint8_t[]` feeding `PackBuffer<uint64_t>`, whose fastpack writes `uint32_t` units; now typed `uint32_t[]`). Byte size and on-disk layout unchanged.
- **`SignedLength`**: unsigned arithmetic instead of `(value ^ sign) - sign`
- **left shift**: guard `0 << width`
- **ctype calls** (`isdigit`/`isalnum`/`isalpha`): pass `unsigned char`
- **SLURM memory limit parsing**: guard the double→`idx_t` conversion against overflow. The clamp boundary uses `>=` because `double(UINT64_MAX)` rounds up to 2^64 — an input landing exactly on the boundary otherwise produced exactly 2^64, an out-of-range conversion with platform-divergent results (x86: 2^63, ARM64: `UINT64_MAX`) — and `nan` is rejected (fast_float parses it, and NaN bypasses every comparison into the same cast). Covered by a new unit test (suffixes, invalid/NaN input, the exact clamp boundary).

### Verification (128-core ARM64, Kunpeng-class, gcc 11.4, reldebug)

This PR (`523094ee9e`) vs its base commit (`326202015f`), interleaved runs on an idle machine:

- Fast unittest suite: zero failures on both sides — 4,959 vs 4,961 cases (the +2 are this PR's new unit tests), identical 434-case skip set.
- Hash join, 40M-row build (one publish CAS/row) + 200M-row probe (one acquire load/row), 5 interleaved runs: median **1.200s (base) vs 1.186s (PR)**, means identical at 2.009s.
- `COPY (30M rows) TO PARQUET` (`WaitAll` path): median **7.453s (base) vs 7.189s (PR)**.

(CI note: the regression-bench failures on the first commit died in the workflow's Install step before any benchmark ran — infra flake, not a regression signal.)
