### PR TITLE
Reserve column_ids.size() in CollectionScanState::Initialize

### DIFF
--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -316,7 +316,7 @@ void ColumnScanState::Initialize(const QueryContext &context_p, const LogicalTyp
 void CollectionScanState::Initialize(const QueryContext &context, const vector<LogicalType> &types) {
 	auto &column_ids = GetColumnIds();
 	D_ASSERT(column_scans.empty());
-	column_scans.reserve(column_scans.size());
+	column_scans.reserve(column_ids.size());
 	for (idx_t i = 0; i < column_ids.size(); i++) {
 		column_scans.emplace_back(*this);
 	}


### PR DESCRIPTION
`CollectionScanState::Initialize` calls `column_scans.reserve(column_scans.size())`, but the line above asserts the vector is empty, so the reserve is always `reserve(0)` and does nothing. The intent was `column_ids.size()`.

Without it the vector reallocates its way up while emplacing one `ColumnScanState` per scanned column.