### PR TITLE
Propagate column renames to UPDATE OF triggers while preserving MVCC, concurrency, and WAL correctness

### DIFF
--- a/src/catalog/catalog_entry/duck_table_entry.cpp
+++ b/src/catalog/catalog_entry/duck_table_entry.cpp
@@ -484,7 +484,32 @@ unique_ptr<CatalogEntry> DuckTableEntry::RenameColumn(ClientContext &context, Re
 	auto binder = Binder::CreateBinder(context);
 	auto bound_create_info = binder->BindCreateTableInfo(std::move(create_info), schema, info.bind_mode);
 	SetAlterDependencies(*bound_create_info, info);
-	return make_uniq<DuckTableEntry>(catalog, schema, *bound_create_info, storage, triggers);
+
+	auto transaction = catalog.GetCatalogTransaction(context);
+	vector<Identifier> triggers_to_update;
+	triggers->ScanWithConflictDetection(
+	    transaction,
+	    [&](CatalogEntry &entry) {
+		    auto &trigger = entry.Cast<TriggerCatalogEntry>();
+		    if (std::find(trigger.columns.begin(), trigger.columns.end(), info.old_name) != trigger.columns.end()) {
+			    triggers_to_update.push_back(trigger.name);
+		    }
+	    },
+	    [&](CatalogEntry &entry) {
+		    if (entry.type != CatalogType::TRIGGER_ENTRY || entry.deleted) {
+			    return;
+		    }
+		    auto &trigger = entry.Cast<TriggerCatalogEntry>();
+		    if (std::find(trigger.columns.begin(), trigger.columns.end(), info.old_name) != trigger.columns.end()) {
+			    throw TransactionException("Catalog write-write conflict on alter with \"%s\"", name);
+		    }
+	    });
+	for (const auto &trigger_name : triggers_to_update) {
+		triggers->AlterEntry(transaction, trigger_name, info);
+	}
+	auto result = make_uniq<DuckTableEntry>(catalog, schema, *bound_create_info, storage, triggers);
+	result->trigger_column_rename = info.old_name;
+	return std::move(result);
 }
 
 unique_ptr<CatalogEntry> DuckTableEntry::AddColumn(ClientContext &context, AddColumnInfo &info) {
@@ -1463,8 +1488,26 @@ TableStorageInfo DuckTableEntry::GetStorageInfo(ClientContext &context) {
 	return storage->GetStorageInfo();
 }
 
+void DuckTableEntry::ValidateTriggerColumnRename() {
+	if (!trigger_column_rename) {
+		return;
+	}
+	auto validate = [&](CatalogEntry &entry) {
+		if (entry.type != CatalogType::TRIGGER_ENTRY || entry.deleted) {
+			return;
+		}
+		auto &trigger = entry.Cast<TriggerCatalogEntry>();
+		if (std::find(trigger.columns.begin(), trigger.columns.end(), *trigger_column_rename) !=
+		    trigger.columns.end()) {
+			throw TransactionException("Catalog write-write conflict on alter with \"%s\"", name);
+		}
+	};
+	triggers->Scan(validate);
+	trigger_column_rename.reset();
+}
+
 optional_ptr<CatalogEntry> DuckTableEntry::CreateTrigger(CatalogTransaction transaction, CreateTriggerInfo &info) {
-	auto trigger = make_uniq<TriggerCatalogEntry>(catalog, schema, info);
+	auto trigger = make_uniq<TriggerCatalogEntry>(catalog, schema, info, this);
 	auto entry_name = trigger->name;
 	LogicalDependencyList dependencies = trigger->dependencies;
 	if (info.on_conflict == OnCreateConflict::IGNORE_ON_CONFLICT) {

--- a/src/catalog/catalog_entry/trigger_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/trigger_catalog_entry.cpp
@@ -4,26 +4,49 @@
 #include "duckdb/catalog/catalog_entry/schema_catalog_entry.hpp"
 #include "duckdb/common/enum_util.hpp"
 #include "duckdb/parser/keyword_helper.hpp"
+#include "duckdb/parser/parsed_data/alter_table_info.hpp"
 #include "duckdb/parser/parsed_data/parse_info.hpp"
 
 namespace duckdb {
 
-TriggerCatalogEntry::TriggerCatalogEntry(Catalog &catalog, SchemaCatalogEntry &schema, CreateTriggerInfo &info)
+TriggerCatalogEntry::TriggerCatalogEntry(Catalog &catalog, SchemaCatalogEntry &schema, CreateTriggerInfo &info,
+                                         optional_ptr<TableCatalogEntry> bound_table_p)
     : StandardEntry(CatalogType::TRIGGER_ENTRY, schema, catalog, info.GetTriggerName()),
       base_table(unique_ptr_cast<TableRef, BaseTableRef>(info.base_table->Copy())), timing(info.timing),
       event_type(info.event_type), columns(info.columns), for_each(info.for_each),
       referencing_new_table(info.referencing_new_table), referencing_old_table(info.referencing_old_table),
-      trigger_action(info.trigger_action->Copy()) {
+      trigger_action(info.trigger_action->Copy()), bound_table(bound_table_p) {
 	this->temporary = info.temporary;
 	this->dependencies = info.dependencies;
 	this->comment = info.comment;
 	this->tags = info.tags;
 }
 
+unique_ptr<CatalogEntry> TriggerCatalogEntry::AlterEntry(CatalogTransaction transaction, AlterInfo &alter_info) {
+	if (alter_info.type != AlterType::ALTER_TABLE) {
+		return CatalogEntry::AlterEntry(transaction, alter_info);
+	}
+	auto &table_info = alter_info.Cast<AlterTableInfo>();
+	if (table_info.alter_table_type != AlterTableType::RENAME_COLUMN) {
+		return CatalogEntry::AlterEntry(transaction, alter_info);
+	}
+	auto &rename_info = alter_info.Cast<RenameColumnInfo>();
+	auto info_copy = GetInfo();
+	auto &trigger_info = info_copy->Cast<CreateTriggerInfo>();
+	for (auto &column : trigger_info.columns) {
+		if (column == rename_info.old_name) {
+			column = rename_info.new_name;
+		}
+	}
+	auto result = make_uniq<TriggerCatalogEntry>(catalog, schema, trigger_info, bound_table);
+	result->column_rename = true;
+	return std::move(result);
+}
+
 unique_ptr<CatalogEntry> TriggerCatalogEntry::Copy(ClientContext &context) const {
 	auto info_copy = GetInfo();
 	auto &cast_info = info_copy->Cast<CreateTriggerInfo>();
-	return make_uniq<TriggerCatalogEntry>(catalog, schema, cast_info);
+	return make_uniq<TriggerCatalogEntry>(catalog, schema, cast_info, bound_table);
 }
 
 unique_ptr<CreateInfo> TriggerCatalogEntry::GetInfo() const {

--- a/src/catalog/catalog_set.cpp
+++ b/src/catalog/catalog_set.cpp
@@ -521,6 +521,12 @@ bool CatalogSet::HasConflict(CatalogTransaction transaction, transaction_t times
 	return CreatedByOtherActiveTransaction(transaction, timestamp) || CommittedAfterStarting(transaction, timestamp);
 }
 
+bool CatalogSet::IsCurrentEntry(CatalogTransaction transaction, CatalogEntry &entry) {
+	lock_guard<mutex> lock(catalog_lock);
+	auto head = map.GetEntry(entry.name);
+	return head && (head.get() == &entry || head->timestamp == transaction.transaction_id);
+}
+
 bool CatalogSet::IsCommitted(transaction_t timestamp) {
 	//! FIXME: `transaction_t` itself should be a class that has these methods
 	return timestamp < TRANSACTION_ID_START;
@@ -737,6 +743,24 @@ void CatalogSet::ScanWithReturn(CatalogTransaction transaction, const std::funct
 			if (!callback(entry_for_transaction)) {
 				return;
 			}
+		}
+	}
+}
+
+void CatalogSet::ScanWithConflictDetection(CatalogTransaction transaction,
+                                           const std::function<void(CatalogEntry &)> &scan_callback,
+                                           const std::function<void(CatalogEntry &)> &conflict_callback) {
+	unique_lock<mutex> lock(catalog_lock);
+	CreateDefaultEntries(transaction, lock);
+
+	for (auto &kv : map.Entries()) {
+		auto &entry = *kv.second;
+		if (HasConflict(transaction, entry.timestamp) && !entry.deleted) {
+			conflict_callback(entry);
+		}
+		auto &entry_for_transaction = GetEntryForTransaction(transaction, entry);
+		if (!entry_for_transaction.deleted) {
+			scan_callback(entry_for_transaction);
 		}
 	}
 }

--- a/src/include/duckdb/catalog/catalog_entry/duck_table_entry.hpp
+++ b/src/include/duckdb/catalog/catalog_entry/duck_table_entry.hpp
@@ -50,6 +50,7 @@ public:
 
 	void CommitAlter(string &column_name, CommitDropState &drop_state);
 	void CommitDrop(CommitDropState &drop_state);
+	void ValidateTriggerColumnRename();
 
 	TableFunction GetScanFunction(ClientContext &context, unique_ptr<FunctionData> &bind_data) override;
 
@@ -104,6 +105,8 @@ private:
 	shared_ptr<DataTable> storage;
 	//! The catalog set holding triggers for this table
 	shared_ptr<CatalogSet> triggers;
+	//! Column whose trigger references must be rechecked when this table version commits
+	optional<Identifier> trigger_column_rename;
 	//! Manages dependencies of the individual columns of the table
 	ColumnDependencyManager column_dependency_manager;
 };

--- a/src/include/duckdb/catalog/catalog_entry/trigger_catalog_entry.hpp
+++ b/src/include/duckdb/catalog/catalog_entry/trigger_catalog_entry.hpp
@@ -7,6 +7,8 @@
 
 namespace duckdb {
 
+class TableCatalogEntry;
+
 //! A trigger catalog entry
 class TriggerCatalogEntry : public StandardEntry {
 public:
@@ -14,7 +16,8 @@ public:
 	static constexpr const char *Name = "trigger";
 
 public:
-	TriggerCatalogEntry(Catalog &catalog, SchemaCatalogEntry &schema, CreateTriggerInfo &info);
+	TriggerCatalogEntry(Catalog &catalog, SchemaCatalogEntry &schema, CreateTriggerInfo &info,
+	                    optional_ptr<TableCatalogEntry> bound_table = nullptr);
 
 	//! The table the trigger is on
 	unique_ptr<BaseTableRef> base_table;
@@ -32,8 +35,13 @@ public:
 	Identifier referencing_old_table;
 	//! The trigger action (INSERT/UPDATE/DELETE as QueryNode)
 	unique_ptr<QueryNode> trigger_action;
+	//! Owning table version, retained only until CREATE [OR REPLACE] commits
+	optional_ptr<TableCatalogEntry> bound_table;
+	//! Whether this version was produced by the owning table's column rename
+	bool column_rename = false;
 
 public:
+	unique_ptr<CatalogEntry> AlterEntry(CatalogTransaction transaction, AlterInfo &info) override;
 	unique_ptr<CatalogEntry> Copy(ClientContext &context) const override;
 	unique_ptr<CreateInfo> GetInfo() const override;
 

--- a/src/include/duckdb/catalog/catalog_set.hpp
+++ b/src/include/duckdb/catalog/catalog_set.hpp
@@ -107,6 +107,9 @@ public:
 	                               const Identifier &prefix);
 	DUCKDB_API void Scan(CatalogTransaction transaction, const std::function<void(CatalogEntry &)> &callback);
 	DUCKDB_API void ScanWithReturn(CatalogTransaction transaction, const std::function<bool(CatalogEntry &)> &callback);
+	DUCKDB_API void ScanWithConflictDetection(CatalogTransaction transaction,
+	                                          const std::function<void(CatalogEntry &)> &scan_callback,
+	                                          const std::function<void(CatalogEntry &)> &conflict_callback);
 	DUCKDB_API void Scan(ClientContext &context, const std::function<void(CatalogEntry &)> &callback);
 	DUCKDB_API void ScanWithReturn(ClientContext &context, const std::function<bool(CatalogEntry &)> &callback);
 
@@ -120,6 +123,7 @@ public:
 	DUCKDB_API bool CreatedByOtherActiveTransaction(CatalogTransaction transaction, transaction_t timestamp);
 	DUCKDB_API bool CommittedAfterStarting(CatalogTransaction transaction, transaction_t timestamp);
 	DUCKDB_API bool HasConflict(CatalogTransaction transaction, transaction_t timestamp);
+	DUCKDB_API bool IsCurrentEntry(CatalogTransaction transaction, CatalogEntry &entry);
 	DUCKDB_API bool UseTimestamp(CatalogTransaction transaction, transaction_t timestamp);
 	static bool IsCommitted(transaction_t timestamp);
 

--- a/src/transaction/commit_state.cpp
+++ b/src/transaction/commit_state.cpp
@@ -2,6 +2,7 @@
 
 #include "duckdb/catalog/catalog_entry/duck_index_entry.hpp"
 #include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
+#include "duckdb/catalog/catalog_entry/trigger_catalog_entry.hpp"
 #include "duckdb/catalog/catalog_entry/scalar_macro_catalog_entry.hpp"
 #include "duckdb/catalog/catalog_entry/type_catalog_entry.hpp"
 #include "duckdb/catalog/catalog_entry/view_catalog_entry.hpp"
@@ -298,6 +299,22 @@ void CommitState::CommitEntry(UndoFlags type, data_ptr_t data, CommitInfo &info)
 		auto &duck_catalog = catalog.Cast<DuckCatalog>();
 		lock_guard<mutex> write_lock(duck_catalog.GetWriteLock());
 		lock_guard<mutex> read_lock(old_entry.set->GetCatalogLock());
+		CatalogTransaction catalog_transaction(duck_catalog.GetDatabase(), transaction.transaction_id,
+		                                       transaction.start_time);
+		if (new_entry.type == CatalogType::TABLE_ENTRY && old_entry.type == CatalogType::TABLE_ENTRY) {
+			new_entry.Cast<DuckTableEntry>().ValidateTriggerColumnRename();
+		}
+		if (new_entry.type == CatalogType::TRIGGER_ENTRY) {
+			auto &trigger = new_entry.Cast<TriggerCatalogEntry>();
+			if (trigger.bound_table) {
+				if (!trigger.bound_table->set->IsCurrentEntry(catalog_transaction, *trigger.bound_table)) {
+					throw TransactionException("Catalog write-write conflict on create with \"%s\": table \"%s\" "
+					                           "was altered by a concurrent transaction",
+					                           trigger.name, trigger.base_table->Table());
+				}
+				trigger.bound_table = nullptr;
+			}
+		}
 		// Set the timestamp of the catalog entry to the given commit_id, marking it as committed
 		CatalogSet::UpdateTimestamp(old_entry.Parent(), commit_id);
 

--- a/src/transaction/wal_write_state.cpp
+++ b/src/transaction/wal_write_state.cpp
@@ -48,11 +48,14 @@ void WALWriteState::WriteCatalogEntry(CatalogEntry &entry, data_ptr_t dataptr) {
 	auto &parent = entry.Parent();
 
 	switch (parent.type) {
-	case CatalogType::TRIGGER_ENTRY:
-		// Triggers do not support ALTER — always a CREATE
+	case CatalogType::TRIGGER_ENTRY: {
 		D_ASSERT(entry.type != CatalogType::RENAMED_ENTRY);
-		log.WriteCreateTrigger(parent.Cast<TriggerCatalogEntry>());
+		auto &trigger = parent.Cast<TriggerCatalogEntry>();
+		if (!trigger.column_rename) {
+			log.WriteCreateTrigger(trigger);
+		}
 		break;
+	}
 	case CatalogType::TABLE_ENTRY:
 	case CatalogType::VIEW_ENTRY:
 	case CatalogType::INDEX_ENTRY:

--- a/test/issues/general/test_24209.test
+++ b/test/issues/general/test_24209.test
@@ -1,0 +1,172 @@
+# name: test/issues/general/test_24209.test
+# description: UPDATE OF triggers follow renamed columns
+# group: [general]
+
+require noforcestorage
+
+statement ok
+CREATE TABLE t(i INT, j INT, z INT);
+
+statement ok
+CREATE TABLE audit(x INT);
+
+statement ok
+CREATE TRIGGER tr AFTER UPDATE OF j, z ON t FOR EACH STATEMENT INSERT INTO audit VALUES (1);
+
+statement ok
+INSERT INTO t VALUES (0, 0, 0);
+
+statement ok
+UPDATE t SET j = 1;
+
+statement ok
+ALTER TABLE t RENAME COLUMN j TO k;
+
+query T
+SELECT columns FROM duckdb_triggers() WHERE trigger_name = 'tr';
+----
+[k, z]
+
+statement ok
+UPDATE t SET k = 2;
+
+statement ok
+UPDATE t SET i = 3;
+
+statement ok
+UPDATE t SET z = 4;
+
+query I
+SELECT count(*) FROM audit;
+----
+3
+
+# Trigger metadata follows transaction rollback
+statement ok
+BEGIN;
+
+statement ok
+ALTER TABLE t RENAME COLUMN k TO j;
+
+query T
+SELECT columns FROM duckdb_triggers() WHERE trigger_name = 'tr';
+----
+[j, z]
+
+statement ok
+ROLLBACK;
+
+query T
+SELECT columns FROM duckdb_triggers() WHERE trigger_name = 'tr';
+----
+[k, z]
+
+# Concurrent trigger creation and column rename conflict in either order
+statement ok
+CREATE TABLE tx_t(i INT, j INT);
+
+statement ok
+CREATE TABLE tx_audit(x INT);
+
+statement ok con2
+BEGIN;
+
+statement ok con2
+CREATE TRIGGER tx_tr AFTER UPDATE OF j ON tx_t INSERT INTO tx_audit VALUES (1);
+
+statement error con1
+ALTER TABLE tx_t RENAME COLUMN j TO k;
+----
+<REGEX>:.*write-write conflict.*
+
+statement ok con2
+ROLLBACK;
+
+statement ok con1
+BEGIN;
+
+statement ok con1
+ALTER TABLE tx_t RENAME COLUMN j TO k;
+
+statement error con2
+CREATE TRIGGER tx_tr AFTER UPDATE OF j ON tx_t INSERT INTO tx_audit VALUES (1);
+----
+<REGEX>:.*write-write conflict.*
+
+statement ok con1
+ROLLBACK;
+
+# ALTER then CREATE in one transaction binds to the altered table version
+statement ok
+BEGIN;
+
+statement ok
+ALTER TABLE tx_t RENAME COLUMN j TO k;
+
+statement ok
+CREATE TRIGGER tx_tr AFTER UPDATE OF k ON tx_t INSERT INTO tx_audit VALUES (1);
+
+statement ok
+COMMIT;
+
+statement ok
+INSERT INTO tx_t VALUES (0, 0);
+
+statement ok
+UPDATE tx_t SET k = 1;
+
+query I
+SELECT count(*) FROM tx_audit;
+----
+1
+
+# CREATE then ALTER in one transaction propagates the new trigger definition
+statement ok
+CREATE TABLE order_t(i INT, j INT);
+
+statement ok
+CREATE TABLE order_audit(x INT);
+
+statement ok
+BEGIN;
+
+statement ok
+CREATE TRIGGER order_tr AFTER UPDATE OF j ON order_t INSERT INTO order_audit VALUES (1);
+
+statement ok
+ALTER TABLE order_t RENAME COLUMN j TO k;
+
+statement ok
+COMMIT;
+
+statement ok
+INSERT INTO order_t VALUES (0, 0);
+
+statement ok
+UPDATE order_t SET k = 1;
+
+query I
+SELECT count(*) FROM order_audit;
+----
+1
+
+# A replacement against an old table snapshot must not escape a concurrent rename
+statement ok
+CREATE TABLE replace_t(i INT, j INT);
+
+statement ok
+CREATE TRIGGER replace_tr AFTER UPDATE OF i ON replace_t INSERT INTO tx_audit VALUES (2);
+
+statement ok con1
+BEGIN;
+
+statement ok con1
+ALTER TABLE replace_t RENAME COLUMN j TO k;
+
+statement error con2
+CREATE OR REPLACE TRIGGER replace_tr AFTER UPDATE OF j ON replace_t INSERT INTO tx_audit VALUES (2);
+----
+<REGEX>:.*create with "replace_tr".*table "replace_t" was altered by a concurrent transaction.*
+
+statement ok con1
+ROLLBACK;


### PR DESCRIPTION
Fix #24209

### Problem

Issue #24209 concerns `UPDATE OF` triggers after a referenced column is renamed.

For example:

```
  CREATE TABLE t(i INTEGER, j INTEGER);
  CREATE TRIGGER tr
  AFTER UPDATE OF j ON t
  INSERT INTO audit VALUES (1);

  ALTER TABLE t RENAME COLUMN j TO k;
  UPDATE t SET k = 42;
```

The trigger should continue to fire because `k` is the renamed version of `j`. Previously, it did not fire, and `duckdb_triggers()` still reported the stale column name `j`.

The root cause is that an `UPDATE OF` trigger stores its referenced columns as a `vector<Identifier>`, meaning it stores column names rather than stable column IDs.

When `ALTER TABLE ... RENAME COLUMN` created a new MVCC version of the table, it updated the table’s columns and constraints but reused the existing table-local trigger catalog without updating the trigger definitions. This produced an inconsistent catalog state:

  - The new table version contained column `k`.
  - The trigger still referenced column `j`.

During `UPDATE` planning, DuckDB correctly intersects the columns in the SET clause with the trigger’s stored `UPDATE OF` list. Because `k` and stale `j` did not match, the planner correctly but undesirably excluded the trigger. The bug was therefore introduced during the column rename, not during trigger execution.

### Fix

The repair propagates the column rename into affected trigger definitions as transactional catalog alterations.

Instead of mutating `TriggerCatalogEntry::columns` in place, DuckDB now:

  1. Finds `UPDATE OF` triggers that reference the old column name.
  2. Copies each trigger definition.
  3. Replaces the old identifier with the new one.
  4. Installs the result as a new catalog version through `CatalogSet::AlterEntry`.

Creating new versions is important because table and trigger metadata participate in MVCC. Direct mutation would expose uncommitted changes to older snapshots and would not roll back safely.

#### Concurrency handling

Tables and their triggers live in separate `CatalogSet` instances, so their normal per-entry write-conflict detection cannot serialize a table rename against a concurrent `CREATE TRIGGER`.

The fix handles both commit orderings:

  - A trigger created against a table retains a temporary pointer to the exact table version used during binding. At trigger commit, DuckDB verifies that this table version is still current, or that its replacement belongs to the same transaction.
  - A column rename checks for conflicting trigger versions and, at commit time, rechecks committed trigger heads for references to the old column name.

The commit-time recheck closes the small window between scanning the triggers and installing the new table catalog version. Consequently, either the rename or the concurrent trigger creation succeeds, while the other receives a catalog write-write conflict; they cannot both commit an inconsistent catalog.

This also supports valid same-transaction sequences in both directions:

```
  ALTER TABLE ... RENAME COLUMN ...;
  CREATE TRIGGER ...;
```
  and:
```
  CREATE TRIGGER ...;
  ALTER TABLE ... RENAME COLUMN ...;
```
`CREATE OR REPLACE TRIGGER` is covered by the same exact-table-version validation.


#### WAL and persistence

The owning `ALTER TABLE` WAL record is sufficient to reproduce trigger propagation during replay. Writing an additional `CREATE TRIGGER` record for every derived trigger version would be redundant and could produce incorrect replay ordering.

A transient marker identifies trigger versions produced specifically by column-rename propagation. WAL generation skips only those versions, while genuine `CREATE TRIGGER` and `CREATE OR REPLACE TRIGGER` operations remain durable.