### PR TITLE
Fix writing NULL fixed-size arrays to Parquet

### DIFF
--- a/extension/parquet/writer/array_column_writer.cpp
+++ b/extension/parquet/writer/array_column_writer.cpp
@@ -5,6 +5,7 @@
 #include "column_writer.hpp"
 #include "duckdb/common/typedefs.hpp"
 #include "duckdb/common/types.hpp"
+#include "duckdb/common/types/selection_vector.hpp"
 #include "duckdb/common/types/validity_mask.hpp"
 #include "duckdb/common/types/vector.hpp"
 #include "duckdb/common/unique_ptr.hpp"
@@ -13,6 +14,39 @@
 #include "writer/list_column_writer.hpp"
 
 namespace duckdb {
+
+static idx_t GetConsecutiveChildArray(Vector &array, Vector &result, idx_t count) {
+	auto &validity = FlatVector::ValidityMutable(array);
+	auto array_size = ArrayType::GetSize(array.GetType());
+	bool is_consecutive = true;
+	idx_t total_length = 0;
+	for (idx_t array_idx = 0; array_idx < count; array_idx++) {
+		if (!validity.RowIsValid(array_idx)) {
+			continue;
+		}
+		if (array_idx * array_size != total_length) {
+			is_consecutive = false;
+		}
+		total_length += array_size;
+	}
+	if (is_consecutive) {
+		return total_length;
+	}
+
+	SelectionVector sel(total_length);
+	idx_t result_idx = 0;
+	for (idx_t array_idx = 0; array_idx < count; array_idx++) {
+		if (!validity.RowIsValid(array_idx)) {
+			continue;
+		}
+		for (idx_t child_idx = 0; child_idx < array_size; child_idx++) {
+			sel.set_index(result_idx++, array_idx * array_size + child_idx);
+		}
+	}
+	result.Slice(sel, total_length);
+	result.Flatten();
+	return total_length;
+}
 
 void ArrayColumnWriter::Analyze(ColumnWriterState &state_p, ColumnWriterState *parent, Vector &vector, idx_t count) {
 	auto &state = state_p.Cast<ListColumnWriterState>();
@@ -45,8 +79,8 @@ void ArrayColumnWriter::Prepare(ColumnWriterState &state_p, ColumnWriterState *p
 	auto &validity = FlatVector::ValidityMutable(vector);
 
 	// write definition levels and repeats
-	// the main difference between this and ListColumnWriter::Prepare is that we need to make sure to write out
-	// repetition levels and definitions for the child elements of the array even if the array itself is NULL.
+	// The main difference between this and ListColumnWriter::Prepare is that valid arrays always have array_size
+	// child elements.
 	idx_t vcount = parent ? parent->definition_levels.size() - state.parent_index : count;
 	idx_t vector_index = 0;
 	for (idx_t i = 0; i < vcount; i++) {
@@ -59,29 +93,32 @@ void ArrayColumnWriter::Prepare(ColumnWriterState &state_p, ColumnWriterState *p
 		auto first_repeat_level =
 		    parent && !parent->repetition_levels.empty() ? parent->repetition_levels[parent_index] : MaxRepeat();
 		if (parent && parent->definition_levels[parent_index] != PARQUET_DEFINE_VALID) {
-			WriteArrayState(state, array_size, first_repeat_level, parent->definition_levels[parent_index]);
+			WriteArrayState(state, array_size, first_repeat_level, parent->definition_levels[parent_index], true);
 		} else if (validity.RowIsValid(vector_index)) {
 			// push the repetition levels
 			WriteArrayState(state, array_size, first_repeat_level, PARQUET_DEFINE_VALID);
 		} else {
 			//! Produce a null
-			WriteArrayState(state, array_size, first_repeat_level, MaxDefine() - 1);
+			WriteArrayState(state, array_size, first_repeat_level, MaxDefine() - 1, true);
 		}
 		vector_index++;
 	}
 	state.parent_index += vcount;
 
 	auto &array_child = ArrayVector::GetChildMutable(vector);
+	Vector child_array(Vector::Ref(array_child));
+	auto child_count = GetConsecutiveChildArray(vector, child_array, count);
 	// The elements of a single array should not span multiple Parquet pages
 	// So, we force the entire vector to fit on a single page by setting "vector_can_span_multiple_pages=false"
-	GetChildWriter().Prepare(*state.child_state, &state_p, array_child, count * array_size, false);
+	GetChildWriter().Prepare(*state.child_state, &state_p, child_array, child_count, false);
 }
 
 void ArrayColumnWriter::Write(ColumnWriterState &state_p, Vector &vector, idx_t count) {
 	auto &state = state_p.Cast<ListColumnWriterState>();
-	auto array_size = ArrayType::GetSize(vector.GetType());
 	auto &array_child = ArrayVector::GetChildMutable(vector);
-	GetChildWriter().Write(*state.child_state, array_child, count * array_size);
+	Vector child_array(Vector::Ref(array_child));
+	auto child_count = GetConsecutiveChildArray(vector, child_array, count);
+	GetChildWriter().Write(*state.child_state, child_array, child_count);
 }
 
 } // namespace duckdb

--- a/extension/parquet/writer/array_column_writer.cpp
+++ b/extension/parquet/writer/array_column_writer.cpp
@@ -51,8 +51,9 @@ static idx_t GetConsecutiveChildArray(Vector &array, Vector &result, idx_t count
 void ArrayColumnWriter::Analyze(ColumnWriterState &state_p, ColumnWriterState *parent, Vector &vector, idx_t count) {
 	auto &state = state_p.Cast<ListColumnWriterState>();
 	auto &array_child = ArrayVector::GetChildMutable(vector);
-	auto array_size = ArrayType::GetSize(vector.GetType());
-	GetChildWriter().Analyze(*state.child_state, &state_p, array_child, array_size * count);
+	Vector child_array(Vector::Ref(array_child));
+	auto child_count = GetConsecutiveChildArray(vector, child_array, count);
+	GetChildWriter().Analyze(*state.child_state, &state_p, child_array, child_count);
 }
 
 void ArrayColumnWriter::WriteArrayState(ListColumnWriterState &state, idx_t array_size, uint16_t first_repeat_level,

--- a/test/sql/copy/parquet/writer/parquet_write_null_array.test
+++ b/test/sql/copy/parquet/writer/parquet_write_null_array.test
@@ -1,0 +1,60 @@
+# name: test/sql/copy/parquet/writer/parquet_write_null_array.test
+# description: Write NULL fixed-size arrays to Parquet
+# group: [writer]
+
+require parquet
+
+# NULL arrays emit one level record, while present arrays emit one per child
+statement ok
+COPY (SELECT * FROM (VALUES
+	([TRUE, FALSE]::BOOLEAN[2]),
+	(NULL::BOOLEAN[2]),
+	([FALSE, TRUE]::BOOLEAN[2]),
+	([NULL, NULL]::BOOLEAN[2])
+) t(c0)) TO '{TEST_DIR}/null_array.parquet' (FORMAT PARQUET);
+
+query II
+SELECT num_values, stats_null_count FROM parquet_metadata('{TEST_DIR}/null_array.parquet')
+----
+7	3
+
+query I
+SELECT c0 FROM read_parquet('{TEST_DIR}/null_array.parquet')
+----
+[true, false]
+NULL
+[false, true]
+[NULL, NULL]
+
+# Propagate NULLs through a struct parent without emitting array children
+statement ok
+COPY (SELECT * FROM (VALUES
+	(NULL::STRUCT(a BOOLEAN[2])),
+	({'a': NULL::BOOLEAN[2]}),
+	({'a': [TRUE, FALSE]::BOOLEAN[2]})
+) t(c0)) TO '{TEST_DIR}/null_array_struct.parquet' (FORMAT PARQUET);
+
+query II
+SELECT num_values, stats_null_count FROM parquet_metadata('{TEST_DIR}/null_array_struct.parquet')
+----
+4	2
+
+# Skip NULL array slots when arrays are nested in a list
+statement ok
+COPY (SELECT [[TRUE, FALSE]::BOOLEAN[2], NULL::BOOLEAN[2], [FALSE, TRUE]::BOOLEAN[2]] AS c0)
+TO '{TEST_DIR}/null_array_list.parquet' (FORMAT PARQUET);
+
+query II
+SELECT num_values, stats_null_count FROM parquet_metadata('{TEST_DIR}/null_array_list.parquet')
+----
+5	1
+
+# Skip NULL inner-array slots when arrays are nested in another array
+statement ok
+COPY (SELECT [NULL::BOOLEAN[2], [TRUE, FALSE]::BOOLEAN[2]]::BOOLEAN[2][2] AS c0)
+TO '{TEST_DIR}/null_array_nested.parquet' (FORMAT PARQUET);
+
+query II
+SELECT num_values, stats_null_count FROM parquet_metadata('{TEST_DIR}/null_array_nested.parquet')
+----
+3	1


### PR DESCRIPTION
Fixes #24731.

**Problem:**
DuckDB’s in-memory representation reserves a fixed number of child-vector slots for every fixed-size array, including NULL parent arrays. For NULL arrays, these reserved slots do not represent actual child elements. 

`ArrayColumnWriter` previously treated NULL arrays as non-empty while generating Parquet repetition and definition levels. As a result, it emitted child-level records for the reserved slots even though no corresponding physical child values were written. This produced invalid Parquet level data that PyArrow could not decode.

**Solution:**
1. Treat NULL fixed-size arrays as empty when generating array-level data.
2. Filter reserved child slots belonging to NULL arrays before passing the child vector to the child writer.
3. Apply the same filtering during analysis so statistics and sizing only include values that will actually be written.

This solution changes the physical Parquet encoding. A NULL array remains NULL and is not converted into an empty array or an array containing NULL elements.

**Tests:**
- Added `test/sql/copy/parquet/writer/parquet_write_null_array.test` which covers top-level, mixed, nested, string, struct, and multi-row-group cases