### PR TITLE
Don't narrow a pushed-down filter constant to the file's physical type

### DIFF
--- a/src/common/multi_file/multi_file_column_mapper.cpp
+++ b/src/common/multi_file/multi_file_column_mapper.cpp
@@ -8,7 +8,6 @@
 #include "duckdb/planner/expression/bound_operator_expression.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/parser/expression/constant_expression.hpp"
-#include "duckdb/optimizer/statistics_propagator.hpp"
 #include "duckdb/planner/filter/list.hpp"
 #include "duckdb/function/scalar/struct_functions.hpp"
 #include "duckdb/function/scalar/struct_utils.hpp"
@@ -884,7 +883,9 @@ static unique_ptr<Expression> CreateStructExtractExpression(unique_ptr<Expressio
 }
 
 static bool TryCastConstant(Value &constant, const LogicalType &target_type) {
-	if (!StatisticsPropagator::CanPropagateCast(constant.type(), target_type)) {
+	// this filter replaces the global one in the reader, so a constant that does not survive the cast
+	// exactly would silently change which rows match
+	if (!BoundCastExpression::CastIsInvertible(constant.type(), target_type)) {
 		return false;
 	}
 	auto cast = constant.DefaultTryCastAs(target_type);

--- a/test/sql/copy/parquet/parquet_filter_narrowing_cast.test
+++ b/test/sql/copy/parquet/parquet_filter_narrowing_cast.test
@@ -1,0 +1,113 @@
+# name: test/sql/copy/parquet/parquet_filter_narrowing_cast.test
+# description: Filter pushdown into Parquet with a narrowing cast
+# group: [parquet]
+
+require parquet
+
+# the file stores FLOAT but is read as DOUBLE, so the scan yields 0.10000000149011612 - pushing the
+# filter must not round the constant down to FLOAT and make that row compare equal to 0.1
+
+statement ok
+COPY (SELECT 0.1::FLOAT AS c) TO '{TEST_DIR}/narrow_float.parquet' (FORMAT parquet)
+
+statement ok
+CREATE VIEW f AS SELECT * FROM read_parquet('{TEST_DIR}/narrow_float.parquet',
+	schema=map{'c': {'name': 'c', 'type': 'DOUBLE', 'default_value': NULL}})
+
+query I
+SELECT c FROM f
+----
+0.10000000149011612
+
+query I
+SELECT COUNT(*) FROM f WHERE c > 0.1
+----
+1
+
+query I
+SELECT COUNT(*) FROM f WHERE c >= 0.1
+----
+1
+
+query I
+SELECT COUNT(*) FROM f WHERE c = 0.1
+----
+0
+
+query I
+SELECT COUNT(*) FROM f WHERE c <> 0.1
+----
+1
+
+query I
+SELECT COUNT(*) FROM f WHERE c IN (0.1)
+----
+0
+
+query I
+SELECT COUNT(*) FROM f WHERE c < 0.1
+----
+0
+
+# a constant that rounds the other way: (FLOAT 0.7)::DOUBLE = 0.699999988079071 < 0.7
+
+statement ok
+COPY (SELECT 0.7::FLOAT AS c) TO '{TEST_DIR}/narrow_float7.parquet' (FORMAT parquet)
+
+statement ok
+CREATE VIEW f7 AS SELECT * FROM read_parquet('{TEST_DIR}/narrow_float7.parquet',
+	schema=map{'c': {'name': 'c', 'type': 'DOUBLE', 'default_value': NULL}})
+
+query I
+SELECT COUNT(*) FROM f7 WHERE c < 0.7
+----
+1
+
+query I
+SELECT COUNT(*) FROM f7 WHERE c >= 0.7
+----
+0
+
+# the filter must survive alongside row group pruning rather than being masked by it
+
+statement ok
+COPY (SELECT unnest([0.1, 0.5])::FLOAT AS c) TO '{TEST_DIR}/narrow_two_rows.parquet' (FORMAT parquet)
+
+query I
+SELECT c FROM read_parquet('{TEST_DIR}/narrow_two_rows.parquet',
+	schema=map{'c': {'name': 'c', 'type': 'DOUBLE', 'default_value': NULL}})
+WHERE c > 0.1 ORDER BY c
+----
+0.10000000149011612
+0.5
+
+# integer files under a floating schema round the same way
+
+statement ok
+COPY (SELECT 2::BIGINT AS c) TO '{TEST_DIR}/narrow_bigint.parquet' (FORMAT parquet)
+
+statement ok
+CREATE VIEW b AS SELECT * FROM read_parquet('{TEST_DIR}/narrow_bigint.parquet',
+	schema=map{'c': {'name': 'c', 'type': 'DOUBLE', 'default_value': NULL}})
+
+query I
+SELECT COUNT(*) FROM b WHERE c > 1.5
+----
+1
+
+query I
+SELECT COUNT(*) FROM b WHERE c = 1.5
+----
+0
+
+# a decimal file read at a finer scale
+
+statement ok
+COPY (SELECT 1.25::DECIMAL(18,2) AS c) TO '{TEST_DIR}/narrow_decimal.parquet' (FORMAT parquet)
+
+query I
+SELECT COUNT(*) FROM read_parquet('{TEST_DIR}/narrow_decimal.parquet',
+	schema=map{'c': {'name': 'c', 'type': 'DECIMAL(18,3)', 'default_value': NULL}})
+WHERE c > 1.245
+----
+1


### PR DESCRIPTION
Fixes #24900

A multi-file scan that presents a column at a wider type than the file physically stores narrows pushed-down filter constants to the file's type. The rounded constant changes which rows match. A FLOAT `0.1` read under a DOUBLE schema comes back as `0.10000000149011612`, but `c > 0.1` does not match it and `c = 0.1` does.

`TryCastConstant` guarded the narrowing with `StatisticsPropagator::CanPropagateCast`, which accepts every numeric pair because carrying statistics through a cast tolerates rounding. Rewriting a predicate does not. This switches the guard to `BoundCastExpression::CastIsInvertible`, which `comparison_simplification.cpp` and `in_clause_simplification_rule.cpp` already use for the same rewrite.

Declining the rewrite does not give up row group pruning. The existing fallback registers the cast in `reader.expression_map` and prunes through `ExpressionColumnReader::Stats()`, so the cost is materialising and casting the column before filtering rather than scanning more row groups.