### PR TITLE
Preserve exact empty-input results for correlated aggregates after decorrelation

### DIFF
--- a/src/include/duckdb/planner/subquery/flatten_dependent_join.hpp
+++ b/src/include/duckdb/planner/subquery/flatten_dependent_join.hpp
@@ -84,7 +84,7 @@ private:
 	void AddReplacementAliases(const BindingReplacementGraph &replacements);
 	Binder &binder;
 	column_binding_map_t<ColumnBinding> correlated_aliases;
-	column_binding_map_t<idx_t> replacement_map;
+	column_binding_map_t<pair<ColumnBinding, ColumnBinding>> replacement_map;
 	const CorrelatedColumns &correlated_columns;
 	vector<LogicalType> delim_types;
 

--- a/src/include/duckdb/planner/subquery/rewrite_correlated_expressions.hpp
+++ b/src/include/duckdb/planner/subquery/rewrite_correlated_expressions.hpp
@@ -31,15 +31,15 @@ private:
 	column_binding_map_t<ColumnBinding> &correlated_aliases;
 };
 
-//! Helper class that rewrites COUNT aggregates into a CASE expression turning NULL into 0 after a LEFT OUTER JOIN
-class RewriteCountAggregates : public LogicalOperatorVisitor {
+//! Rewrites aggregate results after a LEFT OUTER JOIN to preserve their empty-input result
+class RewriteCorrelatedAggregates : public LogicalOperatorVisitor {
 public:
-	static void Rewrite(LogicalOperator &op, column_binding_map_t<idx_t> &replacement_map);
+	static void Rewrite(LogicalOperator &op, column_binding_map_t<pair<ColumnBinding, ColumnBinding>> &replacement_map);
 
 private:
-	explicit RewriteCountAggregates(column_binding_map_t<idx_t> &replacement_map);
+	explicit RewriteCorrelatedAggregates(column_binding_map_t<pair<ColumnBinding, ColumnBinding>> &replacement_map);
 	unique_ptr<Expression> VisitReplace(BoundColumnRefExpression &expr, unique_ptr<Expression> *expr_ptr) override;
-	column_binding_map_t<idx_t> &replacement_map;
+	column_binding_map_t<pair<ColumnBinding, ColumnBinding>> &replacement_map;
 };
 
 } // namespace duckdb

--- a/src/planner/subquery/flatten_dependent_join.cpp
+++ b/src/planner/subquery/flatten_dependent_join.cpp
@@ -733,8 +733,7 @@ FlattenDependentJoins::UnnestingState FlattenDependentJoins::PushDownCorrelatedN
                                                                                     bool propagate_null_values) {
 	auto state = PushDownCorrelatedNode(plan, propagate_null_values, {});
 	if (!replacement_map.empty()) {
-		// check if we have to replace any COUNT aggregates into "CASE WHEN X IS NULL THEN 0 ELSE COUNT END"
-		RewriteCountAggregates::Rewrite(*plan, replacement_map);
+		RewriteCorrelatedAggregates::Rewrite(*plan, replacement_map);
 	}
 	if (!parent) {
 		ColumnBindingResolver::Verify(binder.context, *plan);
@@ -861,24 +860,57 @@ FlattenDependentJoins::UnnestingState FlattenDependentJoins::PushDownAggregate(u
 		    ExpressionType::COMPARE_NOT_DISTINCT_FROM);
 		join->conditions.push_back(std::move(cond));
 	}
+	vector<ColumnBinding> aggregate_bindings;
+	vector<unique_ptr<Expression>> empty_aggregates;
 	for (idx_t i = 0; i < aggr.expressions.size(); i++) {
 		D_ASSERT(aggr.expressions[i]->GetExpressionClass() == ExpressionClass::BOUND_AGGREGATE);
-		auto &bound_func = aggr.expressions[i]->Cast<BoundAggregateExpression>().Function();
+		auto &aggregate = aggr.expressions[i]->Cast<BoundAggregateExpression>();
+		if (aggregate.Function().GetNullHandling() == FunctionNullHandling::SPECIAL_HANDLING) {
+			aggregate_bindings.emplace_back(aggr.aggregate_index, ProjectionIndex(i));
+			empty_aggregates.push_back(aggregate.Copy());
+		}
+	}
+	unique_ptr<LogicalOperator> empty_aggregate;
+	if (!empty_aggregates.empty()) {
+		auto marker_index = ProjectionIndex(aggr.expressions.size());
+		BoundAggregateFunction marker_function(CountStarFun::GetFunction());
+		aggr.expressions.push_back(make_uniq<BoundAggregateExpression>(std::move(marker_function),
+		                                                               vector<unique_ptr<Expression>>(), nullptr,
+		                                                               nullptr, AggregateType::NON_DISTINCT));
 
-		auto count_fun = CountFunctionBase::GetFunction();
-		auto count_star_fun = CountStarFun::GetFunction();
+		auto empty_input_index = binder.GenerateTableIndex();
+		vector<LogicalType> empty_input_types;
+		column_binding_map_t<ColumnBinding> empty_input_map;
+		for (auto &empty_expression : empty_aggregates) {
+			ExpressionIterator::VisitExpressionMutable<BoundColumnRefExpression>(
+			    empty_expression, [&](BoundColumnRefExpression &colref, unique_ptr<Expression> &) {
+				    auto entry = empty_input_map.find(colref.Binding());
+				    if (entry == empty_input_map.end()) {
+					    auto new_binding = ColumnBinding(empty_input_index, ProjectionIndex(empty_input_types.size()));
+					    entry = empty_input_map.emplace(colref.Binding(), new_binding).first;
+					    empty_input_types.push_back(colref.GetReturnType());
+				    }
+				    colref.BindingMutable() = entry->second;
+				    colref.DepthMutable() = 0;
+			    });
+		}
+		auto empty_input = make_uniq<LogicalEmptyResult>(
+		    empty_input_types, LogicalOperator::GenerateColumnBindings(empty_input_index, empty_input_types.size()));
+		auto empty_aggregate_index = binder.GenerateTableIndex();
+		empty_aggregate = make_uniq<LogicalAggregate>(binder.GenerateTableIndex(), empty_aggregate_index,
+		                                              std::move(empty_aggregates));
+		empty_aggregate->children.push_back(std::move(empty_input));
 
-		const auto is_count_func =
-		    bound_func.GetName() == count_fun.name && bound_func.GetCallbacks() == count_fun.GetCallbacks();
-
-		const auto is_count_star_func =
-		    bound_func.GetName() == count_star_fun.name && bound_func.GetCallbacks() == count_star_fun.GetCallbacks();
-
-		if (is_count_func || is_count_star_func) {
-			replacement_map[ColumnBinding(aggr.aggregate_index, ProjectionIndex(i))] = i;
+		auto marker_binding = ColumnBinding(aggr.aggregate_index, marker_index);
+		for (idx_t i = 0; i < aggregate_bindings.size(); i++) {
+			replacement_map[aggregate_bindings[i]] =
+			    make_pair(marker_binding, ColumnBinding(empty_aggregate_index, ProjectionIndex(i)));
 		}
 	}
 	plan = std::move(join);
+	if (empty_aggregate) {
+		plan = LogicalCrossProduct::Create(std::move(plan), std::move(empty_aggregate));
+	}
 	result.bindings = CreateContiguousState(ColumnBinding(left_index, ProjectionIndex(0)));
 	return result;
 }

--- a/src/planner/subquery/rewrite_correlated_expressions.cpp
+++ b/src/planner/subquery/rewrite_correlated_expressions.cpp
@@ -2,7 +2,6 @@
 
 #include "duckdb/planner/expression/bound_case_expression.hpp"
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
-#include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression/bound_operator_expression.hpp"
 #include "duckdb/planner/expression/bound_subquery_expression.hpp"
 #include "duckdb/planner/query_node/bound_select_node.hpp"
@@ -78,25 +77,27 @@ unique_ptr<Expression> RewriteCorrelatedExpressions::VisitReplace(BoundColumnRef
 	return nullptr;
 }
 
-RewriteCountAggregates::RewriteCountAggregates(column_binding_map_t<idx_t> &replacement_map)
+RewriteCorrelatedAggregates::RewriteCorrelatedAggregates(
+    column_binding_map_t<pair<ColumnBinding, ColumnBinding>> &replacement_map)
     : replacement_map(replacement_map) {
 }
 
-void RewriteCountAggregates::Rewrite(LogicalOperator &op, column_binding_map_t<idx_t> &replacement_map) {
-	RewriteCountAggregates rewriter(replacement_map);
+void RewriteCorrelatedAggregates::Rewrite(LogicalOperator &op,
+                                          column_binding_map_t<pair<ColumnBinding, ColumnBinding>> &replacement_map) {
+	RewriteCorrelatedAggregates rewriter(replacement_map);
 	rewriter.VisitOperator(op);
 }
 
-unique_ptr<Expression> RewriteCountAggregates::VisitReplace(BoundColumnRefExpression &expr,
-                                                            unique_ptr<Expression> *expr_ptr) {
+unique_ptr<Expression> RewriteCorrelatedAggregates::VisitReplace(BoundColumnRefExpression &expr,
+                                                                 unique_ptr<Expression> *expr_ptr) {
 	auto entry = replacement_map.find(expr.Binding());
 	if (entry != replacement_map.end()) {
-		// reference to a COUNT(*) aggregate
-		// replace this with CASE WHEN COUNT(*) IS NULL THEN 0 ELSE COUNT(*) END
+		// Replace missing groups with the aggregate's result over empty input.
 		auto is_null = make_uniq<BoundOperatorExpression>(ExpressionType::OPERATOR_IS_NULL, LogicalType::BOOLEAN);
-		is_null->GetChildrenMutable().push_back(expr.Copy());
+		is_null->GetChildrenMutable().push_back(
+		    make_uniq<BoundColumnRefExpression>(LogicalType::BIGINT, entry->second.first));
 		auto check = std::move(is_null);
-		auto result_if_true = make_uniq<BoundConstantExpression>(Value::Numeric(expr.GetReturnType(), 0));
+		auto result_if_true = make_uniq<BoundColumnRefExpression>(expr.GetReturnType(), entry->second.second);
 		auto result_if_false = std::move(*expr_ptr);
 		return make_uniq<BoundCaseExpression>(std::move(check), std::move(result_if_true), std::move(result_if_false));
 	}

--- a/test/configs/verify_aggregate_state_export.json
+++ b/test/configs/verify_aggregate_state_export.json
@@ -65,6 +65,7 @@
       "paths": [
         "test/extension/test_function_named_args.test",
         "test/extension/volatile_aggregate.test",
+        "test/issues/general/test_24049.test",
         "test/sql/aggregate/aggregates/test_approximate_distinct_count.test",
         "test/sql/aggregate/aggregates/test_stddev.test",
         "test/sql/cte/cte_describe.test",

--- a/test/issues/general/test_24049.test
+++ b/test/issues/general/test_24049.test
@@ -1,0 +1,54 @@
+# name: test/issues/general/test_24049.test
+# description: Correlated aggregates preserve their empty-input result
+# group: [general]
+
+query IIII
+WITH t1(id, k) AS (VALUES (11,1), (22,2), (33,3), (44,4)),
+     t2(id, k) AS (VALUES (101,1), (301,3), (302,3), (303,3))
+SELECT id,
+       (SELECT regr_count(1.0, 1.0) FROM t2 WHERE t2.k=t1.k),
+       (SELECT approx_count_distinct(t2.id) FROM t2 WHERE t2.k=t1.k),
+       (SELECT round(entropy(t2.id), 6) FROM t2 WHERE t2.k=t1.k)
+FROM t1
+ORDER BY id;
+----
+11	1	1	0.0
+22	0	0	0.0
+33	3	3	1.584963
+44	0	0	0.0
+
+# Empty exported states retain their type, while default-null aggregates stay NULL.
+query IIII
+WITH outer_t(k) AS (VALUES (NULL::INTEGER), (2)),
+     inner_t(k, v) AS (VALUES (NULL::INTEGER, 10))
+SELECT k IS NULL,
+       (SELECT approx_count_distinct(v)
+        FROM inner_t WHERE inner_t.k IS NOT DISTINCT FROM outer_t.k),
+       (SELECT finalize(count(*) EXPORT_STATE)
+        FROM inner_t WHERE inner_t.k IS NOT DISTINCT FROM outer_t.k),
+       (SELECT sum(v)
+        FROM inner_t WHERE inner_t.k IS NOT DISTINCT FROM outer_t.k)
+FROM outer_t
+ORDER BY k NULLS FIRST;
+----
+true	1	1	10
+false	0	0	NULL
+
+# A LIST key exercises the non-delim path and replacement references in HAVING.
+query III
+WITH outer_t(k) AS (VALUES ([1]), ([2])),
+     inner_t(k, v) AS (VALUES ([1], 10))
+SELECT k,
+       (SELECT regr_count(v, v)
+        FROM inner_t
+        WHERE inner_t.k = outer_t.k
+        HAVING regr_count(v, v) = 0),
+       (SELECT regr_count(v, v)
+        FROM inner_t
+        WHERE inner_t.k = outer_t.k
+        GROUP BY ())
+FROM outer_t
+ORDER BY k;
+----
+[1]	NULL	1
+[2]	0	0


### PR DESCRIPTION
Fix #24049 

### Problem

The reported issue affected correlated scalar subqueries containing aggregates whose result for an empty input is not `NULL`, such as `regr_count`, `approx_count_distinct`, and `entropy`.

For example, consider an outer row whose correlation key has no matching rows in the inner table:

```
  SELECT
      id,
      (SELECT regr_count(1.0, 1.0)
       FROM inner_table
       WHERE inner_table.key = outer_table.key)
  FROM outer_table;
```

An ordinary ungrouped aggregate always produces one row, even when its input is empty. Therefore, `regr_count` should return `0` for that outer row. DuckDB incorrectly returned `NULL`.

The problem was caused by `correlated-subquery` decorrelation. DuckDB transforms the correlated aggregate into a grouped aggregate by adding the correlation columns as grouping keys. Unlike an ungrouped aggregate, a grouped aggregate produces no row when no input rows match. DuckDB then joins those groups back to the outer correlation domain with a left join, which creates a row containing `NULL` values for a missing group. This loses the aggregate function’s actual empty-input result.

### Fix

This fix preserves the empty-input result of the exact bound aggregate expression instead of describing it with static metadata.

During decorrelation, DuckDB now:

  1. Identifies bound aggregates using special `NULL` handling. Aggregates using default `NULL` handling are already guaranteed to return `NULL` for empty input and need no replacement.
  2. Copies each affected bound aggregate expression, preserving its function, bind data, filters, `DISTINCT`, ordering, return type, and state-export mode.
  3. Evaluates those copies in one ungrouped aggregate over a `LogicalEmptyResult`. This invokes the normal aggregate initialization and finalization lifecycle and therefore computes the real empty-input value at execution time.
  4. Adds an unfiltered `count_star()` to the grouped aggregate as a group-presence marker.
  5. Rewrites each affected result conceptually as:
```
  CASE
      WHEN group_presence_marker IS NULL
      THEN aggregate_result_over_empty_input
      ELSE grouped_aggregate_result
  END
```

A separate presence marker is important because neither the aggregate result nor the correlation key can reliably indicate whether a group existed. A real group may legitimately produce `NULL` or zero, and a valid correlation key may itself be `NULL`.

The copied empty-input expressions are also rebound to an independent set of column bindings. Their input contains no rows, so those columns are never read, but the independent bindings ensure that multiple correlated scalar subqueries can be decorrelated without binding conflicts.