### PR TITLE
Fix map_contains to respect collations by rewriting collated key lookups through map_keys and list_contains

### DIFF
--- a/src/function/scalar/map/map_contains.cpp
+++ b/src/function/scalar/map/map_contains.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/common/vector/map_vector.hpp"
+#include "duckdb/function/function_binder.hpp"
 #include "duckdb/function/scalar/list/contains_or_position.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/function/scalar/map_functions.hpp"
@@ -15,12 +16,52 @@ static void MapContainsFunction(DataChunk &input, ExpressionState &state, Vector
 	ListSearchOp<bool>(map_vec, key_vec, arg_vec, result, count);
 }
 
+static bool TypeHasCollation(const LogicalType &type) {
+	switch (type.id()) {
+	case LogicalTypeId::VARCHAR:
+		return !type.HasAlias() && !StringType::GetCollation(type).empty();
+	case LogicalTypeId::LIST:
+		return TypeHasCollation(ListType::GetChildType(type));
+	case LogicalTypeId::ARRAY:
+		return TypeHasCollation(ArrayType::GetChildType(type));
+	default:
+		return false;
+	}
+}
+
+static unique_ptr<Expression> BindMapContainsExpression(FunctionBindExpressionInput &input) {
+	const auto &key_type = input.children[1]->GetReturnType();
+	const auto &map_key_type = MapType::KeyType(input.children[0]->GetReturnType());
+	if (!TypeHasCollation(key_type) && !TypeHasCollation(map_key_type)) {
+		return nullptr;
+	}
+
+	FunctionBinder function_binder(input.context);
+	ErrorData error;
+	vector<unique_ptr<Expression>> children;
+	children.push_back(std::move(input.children[0]));
+	auto keys = function_binder.BindScalarFunction(Identifier::DefaultSchema(), "map_keys", std::move(children), error);
+	if (!keys) {
+		error.Throw();
+	}
+	children.clear();
+	children.push_back(std::move(keys));
+	children.push_back(std::move(input.children[1]));
+	auto result =
+	    function_binder.BindScalarFunction(Identifier::DefaultSchema(), "list_contains", std::move(children), error);
+	if (!result) {
+		error.Throw();
+	}
+	return result;
+}
+
 ScalarFunction MapContainsFun::GetFunction() {
 	auto key_type = LogicalType::TEMPLATE("K");
 	auto val_type = LogicalType::TEMPLATE("V");
 
 	ScalarFunction fun("map_contains", {LogicalType::MAP(key_type, val_type), key_type}, LogicalType::BOOLEAN,
 	                   MapContainsFunction);
+	fun.SetBindExpressionCallback(BindMapContainsExpression);
 	return fun;
 }
 

--- a/test/issues/general/test_24328.test
+++ b/test/issues/general/test_24328.test
@@ -1,0 +1,30 @@
+# name: test/issues/general/test_24328.test
+# description: map_contains respects collations on map keys
+# group: [general]
+
+statement ok
+SET debug_verify_serializer = true;
+
+query IIIIIII
+SELECT map_contains(MAP {'Apple': 1}, 'apple' COLLATE NOCASE),
+       contains(MAP {'Apple': 1}, 'apple' COLLATE NOCASE),
+       map_contains(map(['Apple' COLLATE NOCASE], [1]), 'apple'),
+       map_contains(MAP {'Apple': 1}, 'banana' COLLATE NOCASE),
+       map_contains(map([['Apple' COLLATE NOCASE]], [1]), ['apple']),
+       map_contains(map([array_value('Apple' COLLATE NOCASE)], [1]), array_value('apple')),
+       map_contains(NULL::MAP(VARCHAR, INTEGER), 'apple' COLLATE NOCASE);
+----
+true	true	true	false	true	true	NULL
+
+query I
+WITH data(m, key) AS (
+    VALUES (MAP {'Apple': 1}, 'APPLE'),
+           (MAP {'Banana': 2}, 'banana'),
+           (MAP {'Cherry': 3}, 'pear')
+)
+SELECT map_contains(m, key COLLATE NOCASE)
+FROM data;
+----
+true
+true
+false


### PR DESCRIPTION
Fix #24328

### Problem

DuckDB’s `map_contains` returned the wrong result when a map key was compared using an explicit collation such as NOCASE: 
```
  SELECT map_contains(MAP {'Apple': 1}, 'apple' COLLATE NOCASE);
```
The expected result is true, but DuckDB returned false. An equivalent lookup using `list_contains(map_keys(...), ...)` correctly returned true.

The problem occurred during expression binding. `map_contains` ultimately reused `ListSearchOp`, which performs ordinary equality on the values it receives. Collation-aware list functions transform both operands into comparable collation keys first. For example, applying lower for NOCASE. However, `map_contains` did not request this transformation, and the generic collation binder cannot descend through a MAP to transform its key vector. Consequently, execution compared "Apple" and "apple" as raw strings.

### Fix

For map lookups whose key type or search key carries a collation, the binder now rewrites `map_contains(map, key)` into the equivalent collation-aware expression `list_contains(map_keys(map), key)`. The existing `list_contains` binder then applies the appropriate transformations to both the map keys and the search key. For `NOCASE`, the resulting plan is conceptually:
```
  list_contains(list_transform(map_keys(map)), lower(key))
```

The rewrite supports collations on either operand, including collations nested inside `LIST` or `ARRAY` map-key types. Calls without collations continue using the original direct vector implementation, preserving the existing fast path and behavior.