### PR TITLE
Prevent outer-join NULL constraints from propagating through LIMIT and TOP_N by using isolated optimizer visitors

### DIFF
--- a/src/optimizer/outer_join_simplification.cpp
+++ b/src/optimizer/outer_join_simplification.cpp
@@ -376,7 +376,8 @@ void OuterJoinSimplification::VisitTopN(LogicalTopN &top_n, LogicalOperator &op)
 	for (const auto &order_node : top_n.orders) {
 		AddRequiredColumns(*order_node.expression);
 	}
-	VisitOperatorChildren(op);
+	OuterJoinSimplification child_simplification(required_columns);
+	child_simplification.VisitOperator(*op.children[0]);
 }
 
 void OuterJoinSimplification::VisitAggregate(LogicalAggregate &aggregate, LogicalOperator &op) {
@@ -431,9 +432,11 @@ void OuterJoinSimplification::VisitOperator(LogicalOperator &op) {
 		VisitTopN(top_n, op);
 		return;
 	}
-	case LogicalOperatorType::LOGICAL_LIMIT:
-		VisitOperatorChildren(op);
+	case LogicalOperatorType::LOGICAL_LIMIT: {
+		OuterJoinSimplification child_simplification(required_columns);
+		child_simplification.VisitOperator(*op.children[0]);
 		return;
+	}
 	case LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY: {
 		auto &aggregate = op.Cast<LogicalAggregate>();
 		VisitAggregate(aggregate, op);

--- a/test/issues/general/test_24542.test
+++ b/test/issues/general/test_24542.test
@@ -1,0 +1,41 @@
+# name: test/issues/general/test_24542.test
+# description: NULL constraints do not cross row-reducing operators
+# group: [general]
+
+statement ok
+CREATE TABLE l2(a BIGINT, ak VARCHAR)
+
+statement ok
+CREATE TABLE r2(b BIGINT, bk VARCHAR)
+
+statement ok
+INSERT INTO l2 VALUES (1, 'x'), (2, 'y'), (3, 'p')
+
+statement ok
+INSERT INTO r2 VALUES (10, 'p'), (11, 'q')
+
+query III
+SELECT * FROM (
+    SELECT l2.a, l2.ak, r2.b
+    FROM l2 LEFT JOIN r2 ON l2.ak = r2.bk
+    ORDER BY b DESC NULLS FIRST, a ASC NULLS LAST
+    LIMIT 2
+) s
+WHERE s.b <= 20;
+----
+
+statement ok
+SET disabled_optimizers = 'top_n'
+
+query III
+SELECT * FROM (
+    SELECT l2.a, l2.ak, r2.b
+    FROM l2 LEFT JOIN r2 ON l2.ak = r2.bk
+    ORDER BY b DESC NULLS FIRST, a ASC NULLS LAST
+    LIMIT 2
+) s
+WHERE s.b <= 20;
+----
+
+statement ok
+RESET disabled_optimizers


### PR DESCRIPTION
Fix #24542

### Problem

The issue was a logic bug involving a filter above a limited `LEFT JOIN`.

In the reported query, the `LEFT JOIN` first produces two unmatched rows with `NULL` values on the right side. Because those rows sort first, `LIMIT 2` selects them. The outer predicate `b <= 20` should then reject both rows, so the correct result is empty. Instead, DuckDB returned the matched row `(3, 'p', 10)`.

The root cause was in `OuterJoinSimplification`. This optimizer tracks predicates that reject `NULL` values and uses them to safely convert outer joins into inner joins. However, it incorrectly propagated a predicate from above `LIMIT` or `TOP_N` into the operator’s input. In this case, it treated `b <= 20` as if it applied before the limit and converted the `LEFT JOIN` into an `INNER JOIN`. That changed the rows seen by the limit, violating query semantics.

### Fix

The fix treats `LIMIT` and `TOP_N` as semantic barriers. When the optimizer descends through either operator, it now creates a separate `OuterJoinSimplification` visitor. This prevents `NULL`-related facts and rewrite results collected above the row-reducing operator from leaking into its child plan. The new visitor still receives an exact copy of required_columns, including `TOP_N` ordering dependencies, so legitimate optimizations inside the child remain available without losing column-liveness information.