### PR TITLE
Propagate column binding replacements through nested Top-N window rewrites before constructing the outer payload

### DIFF
--- a/src/optimizer/topn_window_elimination.cpp
+++ b/src/optimizer/topn_window_elimination.cpp
@@ -244,6 +244,22 @@ unique_ptr<LogicalOperator> TopNWindowElimination::OptimizeInternal(unique_ptr<L
 	// We have made sure that this is an operator sequence of filter -> N optional projections -> window
 	auto &filter = op->Cast<LogicalFilter>();
 	reference<LogicalOperator> child = *filter.children[0];
+	while (child.get().type == LogicalOperatorType::LOGICAL_PROJECTION) {
+		child = *child.get().children[0];
+	}
+	D_ASSERT(child.get().type == LogicalOperatorType::LOGICAL_WINDOW);
+	auto &window = child.get().Cast<LogicalWindow>();
+
+	// Optimize window children and propagate any changed bindings through the owning plan
+	ColumnBindingReplacer child_replacer;
+	window.children[0] = OptimizeInternal(std::move(window.children[0]), child_replacer);
+	if (!child_replacer.replacement_bindings.empty()) {
+		child_replacer.VisitOperator(*op);
+		replacer.replacement_bindings.insert(replacer.replacement_bindings.end(),
+		                                     child_replacer.replacement_bindings.begin(),
+		                                     child_replacer.replacement_bindings.end());
+	}
+	child = *filter.children[0];
 
 	// Get bindings and types from filter to use in top-most operator later
 	const auto topmost_bindings = filter.GetColumnBindings();
@@ -254,7 +270,6 @@ unique_ptr<LogicalOperator> TopNWindowElimination::OptimizeInternal(unique_ptr<L
 	}
 
 	D_ASSERT(child.get().type == LogicalOperatorType::LOGICAL_WINDOW);
-	auto &window = child.get().Cast<LogicalWindow>();
 	const TableIndex window_idx = window.window_index;
 
 	// Map the input column offsets of the group columns to the output offset if there are projections on the group
@@ -271,9 +286,6 @@ unique_ptr<LogicalOperator> TopNWindowElimination::OptimizeInternal(unique_ptr<L
 			params.payload_type = TopNPayloadType::SINGLE_COLUMN;
 		}
 	}
-
-	// Optimize window children
-	window.children[0] = Optimize(std::move(window.children[0]));
 
 	op = CreateAggregateOperator(window, std::move(aggregate_payload), params);
 	op = TryCreateUnnestOperator(std::move(op), params);

--- a/test/issues/general/test_24710.test
+++ b/test/issues/general/test_24710.test
@@ -1,0 +1,23 @@
+# name: test/issues/general/test_24710.test
+# description: Issue 24710 - propagate bindings through nested Top-N window rewrites
+# group: [general]
+
+statement ok
+CREATE TABLE t (a BIGINT, b BIGINT);
+
+statement ok
+INSERT INTO t VALUES (1, 5);
+
+statement ok
+CREATE VIEW v AS
+SELECT a, b
+FROM t
+QUALIFY row_number() OVER (PARTITION BY a ORDER BY a) = 1;
+
+query II
+SELECT *
+FROM v
+WHERE b::BOOLEAN
+QUALIFY row_number() OVER (ORDER BY a) <= 1;
+----
+1	5


### PR DESCRIPTION
Fix #24710 

### Problem

This issue caused an internal column-binding error when a query applied `QUALIFY ROW_NUMBER()` to a view that already contained another eligible `ROW_NUMBER()/QUALIFY` pattern. The failure occurred when the outer query also had a cast-based filter, such as:

```
  SELECT *
  FROM v
  WHERE value::BOOLEAN
  QUALIFY ROW_NUMBER() OVER (ORDER BY id) <= 1;
```

With normal optimization, DuckDB raised: `INTERNAL Error: Failed to bind column reference`

Disabling `top_n_window_elimination` made the query work.

#### Root cause

The Top-N window elimination optimizer replaces patterns such as `ROW_NUMBER() OVER (...) <= N` with more efficient grouped Top-N aggregates such as `arg_min` or `arg_min_nulls_last`.

For nested eligible windows, the optimizer previously performed these operations in the wrong order:

  1. It collected the outer window’s column bindings and constructed its aggregate payload.
  2. It recursively optimized the inner window.
  3. The inner rewrite generated new output bindings.
  4. The outer payload and ancestor projections still referenced the old bindings.

For example, the inner rewrite could change an output from binding `[0.0]` to `[17.0]`, while an expression already created for the outer aggregate continued to reference `[0.0]`. `ColumnBindingResolver` correctly rejected this invalid logical plan.

The cast was not itself broken. It affected the optimizer’s plan shape: the cast filter remained a separate filter, leaving both the inner and outer window patterns eligible for Top-N elimination. Without the cast, predicate processing could combine filters and prevent the inner rewrite, accidentally avoiding the bug.

### Fix

The fix changes the order and propagation of nested optimization:

  1. Optimize the inner window subtree first using a local `ColumnBindingReplacer`.
  2. Apply the resulting binding replacements through the current owning plan.
  3. Merge those replacements into the mapping returned to ancestor operators, preserving the complete old → intermediate → final binding chain.
  4. Only then collect bindings and construct the outer aggregate payload.
