### PR TITLE
Preserve filter rewrites across pushdown and statistics propagation

### DIFF
--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -172,6 +172,7 @@
 #include "duckdb/optimizer/relation_statistics/relation_statistics.hpp"
 #include "duckdb/optimizer/remove_unused_columns.hpp"
 #include "duckdb/optimizer/rule/like_optimizations.hpp"
+#include "duckdb/optimizer/statistics_propagator.hpp"
 #include "duckdb/parallel/async_result.hpp"
 #include "duckdb/parallel/interrupt.hpp"
 #include "duckdb/parallel/meta_pipeline.hpp"
@@ -5730,6 +5731,24 @@ const char* EnumUtil::ToChars<StatementType>(StatementType value) {
 template<>
 StatementType EnumUtil::FromString<StatementType>(const char *value) {
 	return static_cast<StatementType>(StringUtil::StringToEnum(GetStatementTypeValues(), 34, "StatementType", value));
+}
+
+const StringUtil::EnumStringLiteral *GetStatisticsPropagationModeValues() {
+	static constexpr StringUtil::EnumStringLiteral values[] {
+		{ static_cast<uint32_t>(StatisticsPropagationMode::FILTER_SIMPLIFICATION), "FILTER_SIMPLIFICATION" },
+		{ static_cast<uint32_t>(StatisticsPropagationMode::FULL), "FULL" }
+	};
+	return values;
+}
+
+template<>
+const char* EnumUtil::ToChars<StatisticsPropagationMode>(StatisticsPropagationMode value) {
+	return StringUtil::EnumToString(GetStatisticsPropagationModeValues(), 2, "StatisticsPropagationMode", static_cast<uint32_t>(value));
+}
+
+template<>
+StatisticsPropagationMode EnumUtil::FromString<StatisticsPropagationMode>(const char *value) {
+	return static_cast<StatisticsPropagationMode>(StringUtil::StringToEnum(GetStatisticsPropagationModeValues(), 2, "StatisticsPropagationMode", value));
 }
 
 const StringUtil::EnumStringLiteral *GetStatisticsTypeValues() {

--- a/src/include/duckdb/common/enum_util.hpp
+++ b/src/include/duckdb/common/enum_util.hpp
@@ -522,6 +522,8 @@ enum class StatementReturnType : uint8_t;
 
 enum class StatementType : uint8_t;
 
+enum class StatisticsPropagationMode : uint8_t;
+
 enum class StatisticsType : uint8_t;
 
 enum class StatsInfo : uint8_t;
@@ -1359,6 +1361,9 @@ const char* EnumUtil::ToChars<StatementReturnType>(StatementReturnType value);
 
 template<>
 const char* EnumUtil::ToChars<StatementType>(StatementType value);
+
+template<>
+const char* EnumUtil::ToChars<StatisticsPropagationMode>(StatisticsPropagationMode value);
 
 template<>
 const char* EnumUtil::ToChars<StatisticsType>(StatisticsType value);
@@ -2248,6 +2253,9 @@ StatementReturnType EnumUtil::FromString<StatementReturnType>(const char *value)
 
 template<>
 StatementType EnumUtil::FromString<StatementType>(const char *value);
+
+template<>
+StatisticsPropagationMode EnumUtil::FromString<StatisticsPropagationMode>(const char *value);
 
 template<>
 StatisticsType EnumUtil::FromString<StatisticsType>(const char *value);

--- a/src/include/duckdb/optimizer/filter_statistics.hpp
+++ b/src/include/duckdb/optimizer/filter_statistics.hpp
@@ -1,0 +1,32 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/optimizer/filter_statistics.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/common.hpp"
+
+namespace duckdb {
+
+class LogicalOperator;
+class Optimizer;
+
+class FilterStatisticsOptimizer {
+public:
+	explicit FilterStatisticsOptimizer(Optimizer &optimizer);
+
+	void Optimize(unique_ptr<LogicalOperator> &plan);
+
+private:
+	bool HasMultiBindingFilter(const LogicalOperator &op) const;
+	bool ContainsDelimJoin(const LogicalOperator &op) const;
+
+private:
+	Optimizer &optimizer;
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/optimizer/in_clause_rewriter.hpp
+++ b/src/include/duckdb/optimizer/in_clause_rewriter.hpp
@@ -29,6 +29,7 @@ public:
 public:
 	// Minimum number of values to use a hash join
 	static constexpr idx_t IN_CLAUSE_REWRITE_THRESHOLD = 6;
+	static bool HasRewritableInClause(const Expression &expr);
 	unique_ptr<LogicalOperator> Rewrite(unique_ptr<LogicalOperator> op);
 	unique_ptr<Expression> VisitReplace(BoundOperatorExpression &expr, unique_ptr<Expression> *expr_ptr) override;
 };

--- a/src/include/duckdb/optimizer/optimizer.hpp
+++ b/src/include/duckdb/optimizer/optimizer.hpp
@@ -17,6 +17,7 @@
 
 namespace duckdb {
 class Binder;
+class FilterStatisticsOptimizer;
 class SQLStatement;
 
 class Optimizer {
@@ -42,6 +43,8 @@ public:
 	ExpressionRewriter rewriter;
 
 private:
+	friend class FilterStatisticsOptimizer;
+
 	void RunBuiltInOptimizers();
 	void RunOptimizer(OptimizerType type, const std::function<void()> &callback);
 	void Verify(LogicalOperator &op);

--- a/src/include/duckdb/optimizer/statistics_propagator.hpp
+++ b/src/include/duckdb/optimizer/statistics_propagator.hpp
@@ -27,14 +27,20 @@ class LogicalOperator;
 class TableFilter;
 struct BoundOrderByNode;
 
+enum class StatisticsPropagationMode : uint8_t { FILTER_SIMPLIFICATION, FULL };
+
 class StatisticsPropagator {
 public:
-	StatisticsPropagator(Optimizer &optimizer, LogicalOperator &root);
+	StatisticsPropagator(Optimizer &optimizer, LogicalOperator &root,
+	                     StatisticsPropagationMode mode = StatisticsPropagationMode::FULL);
 
 	unique_ptr<NodeStatistics> PropagateStatistics(unique_ptr<LogicalOperator> &node_ptr);
 
 	column_binding_map_t<unique_ptr<BaseStatistics>> GetStatisticsMap() {
 		return std::move(statistics_map);
+	}
+	bool FilterBindingsChanged() const {
+		return filter_bindings_changed;
 	}
 
 	//! Whether or not we can propagate a cast between two types
@@ -86,8 +92,10 @@ private:
 	void UpdateFilterStatistics(const Expression &condition);
 	//! Set the statistics of a specific column binding to not contain null values
 	void SetStatisticsNotNull(ColumnBinding binding);
-	//! Propagate a filter condition and determine whether it can be pruned; does not update any statistics
-	FilterPropagateResult ClassifyFilter(unique_ptr<Expression> &condition);
+	//! Determine whether a propagated condition can be pruned
+	FilterPropagateResult ClassifyFilter(Expression &condition);
+	//! Simplify conjunctions using filter truth semantics
+	bool SimplifyFilter(unique_ptr<Expression> &condition);
 	//! Propagate a filter condition
 	FilterPropagateResult HandleFilter(unique_ptr<Expression> &condition);
 	//! Rewrite a join whose condition can never match; returns true if the operator was replaced
@@ -138,6 +146,7 @@ private:
 private:
 	Optimizer &optimizer;
 	ClientContext &context;
+	StatisticsPropagationMode mode;
 	//! The root of the query plan
 	optional_ptr<LogicalOperator> root;
 	//! The map of ColumnBinding -> statistics for the various nodes
@@ -153,6 +162,8 @@ private:
 	unordered_map<TableIndex, CTEStatistics> cte_stats_map;
 	//! Node stats for the current node
 	unique_ptr<NodeStatistics> node_stats;
+	//! Whether statistics changed which relations a filter depends on
+	bool filter_bindings_changed = false;
 };
 
 } // namespace duckdb

--- a/src/optimizer/CMakeLists.txt
+++ b/src/optimizer/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library_unity(
   multi_stage_aggregate_rewriter.cpp
   expression_heuristics.cpp
   expression_rewriter.cpp
+  filter_statistics.cpp
   filter_combiner.cpp
   filter_pullup.cpp
   filter_pushdown.cpp

--- a/src/optimizer/filter_statistics.cpp
+++ b/src/optimizer/filter_statistics.cpp
@@ -1,0 +1,76 @@
+#include "duckdb/optimizer/filter_statistics.hpp"
+
+#include "duckdb/optimizer/filter_pushdown.hpp"
+#include "duckdb/optimizer/optimizer.hpp"
+#include "duckdb/optimizer/statistics_propagator.hpp"
+#include "duckdb/planner/expression/bound_columnref_expression.hpp"
+#include "duckdb/planner/expression_iterator.hpp"
+#include "duckdb/planner/operator/logical_filter.hpp"
+
+namespace duckdb {
+
+FilterStatisticsOptimizer::FilterStatisticsOptimizer(Optimizer &optimizer) : optimizer(optimizer) {
+}
+
+static bool HasMultipleBindings(const Expression &expr) {
+	unordered_set<TableIndex> bindings;
+	ExpressionIterator::VisitExpression<BoundColumnRefExpression>(expr, [&](const BoundColumnRefExpression &ref) {
+		if (ref.Depth() == 0) {
+			bindings.insert(ref.Binding().table_index);
+		}
+	});
+	return bindings.size() > 1;
+}
+
+bool FilterStatisticsOptimizer::HasMultiBindingFilter(const LogicalOperator &op) const {
+	if (op.type == LogicalOperatorType::LOGICAL_FILTER) {
+		for (auto &expr : op.Cast<LogicalFilter>().expressions) {
+			if (HasMultipleBindings(*expr)) {
+				return true;
+			}
+		}
+	}
+	for (auto &child : op.children) {
+		if (HasMultiBindingFilter(*child)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+bool FilterStatisticsOptimizer::ContainsDelimJoin(const LogicalOperator &op) const {
+	if (op.type == LogicalOperatorType::LOGICAL_DELIM_JOIN) {
+		return true;
+	}
+	for (auto &child : op.children) {
+		if (ContainsDelimJoin(*child)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+void FilterStatisticsOptimizer::Optimize(unique_ptr<LogicalOperator> &plan) {
+	if (ContainsDelimJoin(*plan) || !HasMultiBindingFilter(*plan)) {
+		return;
+	}
+
+	bool filter_bindings_changed = false;
+	optimizer.RunOptimizer(OptimizerType::STATISTICS_PROPAGATION, [&]() {
+		StatisticsPropagator propagator(optimizer, *plan, StatisticsPropagationMode::FILTER_SIMPLIFICATION);
+		propagator.PropagateStatistics(plan);
+		filter_bindings_changed = propagator.FilterBindingsChanged();
+	});
+	if (!filter_bindings_changed) {
+		return;
+	}
+
+	optimizer.RunOptimizer(OptimizerType::FILTER_PUSHDOWN, [&]() {
+		FilterPushdown filter_pushdown(optimizer);
+		unordered_set<TableIndex> top_bindings;
+		filter_pushdown.CheckMarkToSemi(*plan, top_bindings);
+		plan = filter_pushdown.Rewrite(std::move(plan));
+	});
+}
+
+} // namespace duckdb

--- a/src/optimizer/in_clause_rewriter.cpp
+++ b/src/optimizer/in_clause_rewriter.cpp
@@ -19,12 +19,16 @@ bool InClauseRewriter::HasRewritableInClause(const Expression &expr) {
 	     expr.GetExpressionType() == ExpressionType::COMPARE_NOT_IN)) {
 		auto &op = expr.Cast<BoundOperatorExpression>();
 		if (op.GetChildren().size() >= InClauseRewriter::IN_CLAUSE_REWRITE_THRESHOLD) {
+			bool all_foldable = true;
 			for (idx_t child_idx = 1; child_idx < op.GetChildren().size(); child_idx++) {
 				if (!op.GetChildren()[child_idx]->IsFoldable()) {
-					return false;
+					all_foldable = false;
+					break;
 				}
 			}
-			return true;
+			if (all_foldable) {
+				return true;
+			}
 		}
 	}
 	bool result = false;
@@ -73,6 +77,10 @@ unique_ptr<Expression> InClauseRewriter::VisitReplace(BoundOperatorExpression &e
 			all_scalar = false;
 		}
 	}
+	const bool rewrite_to_join = expr.GetChildrenMutable().size() >= IN_CLAUSE_REWRITE_THRESHOLD && all_scalar;
+	if (!rewrite_to_join) {
+		VisitExpressionChildren(expr);
+	}
 	if (expr.GetChildrenMutable().size() == 2) {
 		// only one child
 		// IN: turn into X = 1
@@ -81,7 +89,7 @@ unique_ptr<Expression> InClauseRewriter::VisitReplace(BoundOperatorExpression &e
 		    is_regular_in ? ExpressionType::COMPARE_EQUAL : ExpressionType::COMPARE_NOTEQUAL,
 		    std::move(expr.GetChildrenMutable()[0]), std::move(expr.GetChildrenMutable()[1]));
 	}
-	if (expr.GetChildrenMutable().size() < IN_CLAUSE_REWRITE_THRESHOLD || !all_scalar) {
+	if (!rewrite_to_join) {
 		// low amount of children or not all scalar
 		// IN: turn into (X = 1 OR X = 2 OR X = 3...)
 		// NOT IN: turn into (X <> 1 AND X <> 2 AND X <> 3 ...)

--- a/src/optimizer/in_clause_rewriter.cpp
+++ b/src/optimizer/in_clause_rewriter.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/planner/expression/bound_comparison_expression.hpp"
 #include "duckdb/planner/expression/bound_conjunction_expression.hpp"
 #include "duckdb/planner/expression/bound_operator_expression.hpp"
+#include "duckdb/planner/expression_iterator.hpp"
 #include "duckdb/planner/operator/logical_column_data_get.hpp"
 #include "duckdb/planner/operator/logical_comparison_join.hpp"
 #include "duckdb/planner/operator/logical_filter.hpp"
@@ -11,6 +12,29 @@
 #include "duckdb/execution/expression_executor.hpp"
 
 namespace duckdb {
+
+bool InClauseRewriter::HasRewritableInClause(const Expression &expr) {
+	if (expr.GetExpressionClass() == ExpressionClass::BOUND_OPERATOR &&
+	    (expr.GetExpressionType() == ExpressionType::COMPARE_IN ||
+	     expr.GetExpressionType() == ExpressionType::COMPARE_NOT_IN)) {
+		auto &op = expr.Cast<BoundOperatorExpression>();
+		if (op.GetChildren().size() >= InClauseRewriter::IN_CLAUSE_REWRITE_THRESHOLD) {
+			for (idx_t child_idx = 1; child_idx < op.GetChildren().size(); child_idx++) {
+				if (!op.GetChildren()[child_idx]->IsFoldable()) {
+					return false;
+				}
+			}
+			return true;
+		}
+	}
+	bool result = false;
+	ExpressionIterator::EnumerateChildren(expr, [&](const Expression &child) {
+		if (!result && HasRewritableInClause(child)) {
+			result = true;
+		}
+	});
+	return result;
+}
 
 unique_ptr<LogicalOperator> InClauseRewriter::Rewrite(unique_ptr<LogicalOperator> op) {
 	switch (op->type) {

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -16,6 +16,7 @@
 #include "duckdb/optimizer/multi_stage_aggregate_rewriter.hpp"
 #include "duckdb/optimizer/empty_result_pullup.hpp"
 #include "duckdb/optimizer/expression_heuristics.hpp"
+#include "duckdb/optimizer/filter_statistics.hpp"
 #include "duckdb/optimizer/filter_pullup.hpp"
 #include "duckdb/optimizer/filter_pushdown.hpp"
 #include "duckdb/optimizer/grouping_sets_optimizer.hpp"
@@ -256,6 +257,11 @@ void Optimizer::RunBuiltInOptimizers() {
 		plan = filter_pushdown.Rewrite(std::move(plan));
 	});
 
+	if (!CTEContainsDML(*plan)) {
+		FilterStatisticsOptimizer filter_statistics(*this);
+		filter_statistics.Optimize(plan);
+	}
+
 	// derive and push filters into materialized CTEs
 	RunOptimizer(OptimizerType::CTE_FILTER_PUSHER, [&]() {
 		CTEFilterPusher cte_filter_pusher(*this);
@@ -426,12 +432,27 @@ void Optimizer::RunBuiltInOptimizers() {
 	// DML CTEs can invalidate the table statistics captured during planning.
 	column_binding_map_t<unique_ptr<BaseStatistics>> statistics_map;
 	bool propagated_statistics = false;
+	bool filter_bindings_changed = false;
 	if (!CTEContainsDML(*plan)) {
 		RunOptimizer(OptimizerType::STATISTICS_PROPAGATION, [&]() {
 			StatisticsPropagator propagator(*this, *plan);
 			propagator.PropagateStatistics(plan);
 			statistics_map = propagator.GetStatisticsMap();
+			filter_bindings_changed = propagator.FilterBindingsChanged();
 			propagated_statistics = true;
+		});
+	}
+	if (filter_bindings_changed) {
+		RunOptimizer(OptimizerType::FILTER_PUSHDOWN, [&]() {
+			FilterPushdown filter_pushdown(*this);
+			unordered_set<TableIndex> top_bindings;
+			filter_pushdown.CheckMarkToSemi(*plan, top_bindings);
+			plan = filter_pushdown.Rewrite(std::move(plan));
+		});
+		RunOptimizer(OptimizerType::STATISTICS_PROPAGATION, [&]() {
+			StatisticsPropagator propagator(*this, *plan);
+			propagator.PropagateStatistics(plan);
+			statistics_map = propagator.GetStatisticsMap();
 		});
 	}
 	if (propagated_statistics) {

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -432,27 +432,12 @@ void Optimizer::RunBuiltInOptimizers() {
 	// DML CTEs can invalidate the table statistics captured during planning.
 	column_binding_map_t<unique_ptr<BaseStatistics>> statistics_map;
 	bool propagated_statistics = false;
-	bool filter_bindings_changed = false;
 	if (!CTEContainsDML(*plan)) {
 		RunOptimizer(OptimizerType::STATISTICS_PROPAGATION, [&]() {
 			StatisticsPropagator propagator(*this, *plan);
 			propagator.PropagateStatistics(plan);
 			statistics_map = propagator.GetStatisticsMap();
-			filter_bindings_changed = propagator.FilterBindingsChanged();
 			propagated_statistics = true;
-		});
-	}
-	if (filter_bindings_changed) {
-		RunOptimizer(OptimizerType::FILTER_PUSHDOWN, [&]() {
-			FilterPushdown filter_pushdown(*this);
-			unordered_set<TableIndex> top_bindings;
-			filter_pushdown.CheckMarkToSemi(*plan, top_bindings);
-			plan = filter_pushdown.Rewrite(std::move(plan));
-		});
-		RunOptimizer(OptimizerType::STATISTICS_PROPAGATION, [&]() {
-			StatisticsPropagator propagator(*this, *plan);
-			propagator.PropagateStatistics(plan);
-			statistics_map = propagator.GetStatisticsMap();
 		});
 	}
 	if (propagated_statistics) {

--- a/src/optimizer/pushdown/pushdown_cross_product.cpp
+++ b/src/optimizer/pushdown/pushdown_cross_product.cpp
@@ -1,6 +1,8 @@
 #include "duckdb/optimizer/filter_pushdown.hpp"
+#include "duckdb/optimizer/in_clause_rewriter.hpp"
 #include "duckdb/planner/operator/logical_comparison_join.hpp"
 #include "duckdb/planner/operator/logical_cross_product.hpp"
+#include "duckdb/planner/operator/logical_filter.hpp"
 
 namespace duckdb {
 
@@ -11,6 +13,7 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownCrossProduct(unique_ptr<Logi
 	FilterPushdown left_pushdown(optimizer, convert_mark_joins, projection_mode);
 	FilterPushdown right_pushdown(optimizer, convert_mark_joins, projection_mode);
 	vector<unique_ptr<Expression>> join_expressions;
+	vector<unique_ptr<Expression>> deferred_filters;
 	auto join_ref_type = JoinRefType::REGULAR;
 	switch (op->type) {
 	case LogicalOperatorType::LOGICAL_CROSS_PRODUCT:
@@ -34,8 +37,12 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownCrossProduct(unique_ptr<Logi
 				right_pushdown.filters.push_back(std::move(f));
 			} else {
 				D_ASSERT(side == JoinSide::BOTH || side == JoinSide::NONE);
-				// bindings match both: turn into join condition
-				join_expressions.push_back(std::move(f->filter));
+				if (InClauseRewriter::HasRewritableInClause(*f->filter)) {
+					deferred_filters.push_back(std::move(f->filter));
+				} else {
+					// bindings match both: turn into join condition
+					join_expressions.push_back(std::move(f->filter));
+				}
 			}
 		}
 	}
@@ -43,6 +50,7 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownCrossProduct(unique_ptr<Logi
 	op->children[0] = left_pushdown.Rewrite(std::move(op->children[0]));
 	op->children[1] = right_pushdown.Rewrite(std::move(op->children[1]));
 
+	unique_ptr<LogicalOperator> result;
 	if (!join_expressions.empty()) {
 		// join conditions found: turn into inner join
 		// extract join conditions
@@ -52,25 +60,34 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownCrossProduct(unique_ptr<Logi
 		                                             op->children[1], left_bindings, right_bindings, join_expressions,
 		                                             conditions);
 		// create the join from the join conditions
-		auto new_op = LogicalComparisonJoin::CreateJoin(join_type, join_ref_type, std::move(op->children[0]),
-		                                                std::move(op->children[1]), std::move(conditions));
+		result = LogicalComparisonJoin::CreateJoin(join_type, join_ref_type, std::move(op->children[0]),
+		                                           std::move(op->children[1]), std::move(conditions));
 
 		// possible cases are: AnyJoin, ComparisonJoin, or Filter + ComparisonJoin
 		if (op->has_estimated_cardinality) {
 			// set the estimated cardinality of the new operator
-			new_op->SetEstimatedCardinality(op->estimated_cardinality);
-			if (new_op->type == LogicalOperatorType::LOGICAL_FILTER) {
+			result->SetEstimatedCardinality(op->estimated_cardinality);
+			if (result->type == LogicalOperatorType::LOGICAL_FILTER) {
 				// if the new operators are Filter + ComparisonJoin, also set the estimated cardinality for the join
-				D_ASSERT(new_op->children[0]->type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN);
-				new_op->children[0]->SetEstimatedCardinality(op->estimated_cardinality);
+				D_ASSERT(result->children[0]->type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN);
+				result->children[0]->SetEstimatedCardinality(op->estimated_cardinality);
 			}
 		}
-		return new_op;
 	} else {
 		// no join conditions found: keep as cross product
 		D_ASSERT(op->type == LogicalOperatorType::LOGICAL_CROSS_PRODUCT);
-		return op;
+		result = std::move(op);
 	}
+	if (deferred_filters.empty()) {
+		return result;
+	}
+	auto filter = make_uniq<LogicalFilter>();
+	filter->expressions = std::move(deferred_filters);
+	filter->children.push_back(std::move(result));
+	if (filter->children[0]->has_estimated_cardinality) {
+		filter->SetEstimatedCardinality(filter->children[0]->estimated_cardinality);
+	}
+	return std::move(filter);
 }
 
 } // namespace duckdb

--- a/src/optimizer/statistics/operator/propagate_filter.cpp
+++ b/src/optimizer/statistics/operator/propagate_filter.cpp
@@ -295,10 +295,15 @@ bool StatisticsPropagator::SimplifyFilter(unique_ptr<Expression> &condition) {
 }
 
 FilterPropagateResult StatisticsPropagator::HandleFilter(unique_ptr<Expression> &condition) {
-	auto original_bindings = GetFilterBindings(*condition);
+	unordered_set<TableIndex> original_bindings;
+	if (mode == StatisticsPropagationMode::FILTER_SIMPLIFICATION) {
+		original_bindings = GetFilterBindings(*condition);
+	}
 	PropagateExpression(condition);
-	SimplifyFilter(condition);
-	filter_bindings_changed |= original_bindings != GetFilterBindings(*condition);
+	if (mode == StatisticsPropagationMode::FILTER_SIMPLIFICATION) {
+		SimplifyFilter(condition);
+		filter_bindings_changed |= original_bindings != GetFilterBindings(*condition);
+	}
 	auto prune_result = ClassifyFilter(*condition);
 	if (prune_result == FilterPropagateResult::NO_PRUNING_POSSIBLE) {
 		// cannot prune this filter: propagate statistics from the filter

--- a/src/optimizer/statistics/operator/propagate_filter.cpp
+++ b/src/optimizer/statistics/operator/propagate_filter.cpp
@@ -5,7 +5,9 @@
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
 #include "duckdb/planner/expression/bound_comparison_expression.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
+#include "duckdb/planner/expression/bound_conjunction_expression.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "duckdb/planner/expression_iterator.hpp"
 #include "duckdb/planner/operator/logical_filter.hpp"
 #include "duckdb/storage/statistics/base_statistics.hpp"
 
@@ -226,28 +228,78 @@ void StatisticsPropagator::UpdateFilterStatistics(const Expression &condition) {
 	}
 }
 
-FilterPropagateResult StatisticsPropagator::ClassifyFilter(unique_ptr<Expression> &condition) {
-	PropagateExpression(condition);
-
-	if (ExpressionIsConstant(*condition, Value::BOOLEAN(true))) {
+FilterPropagateResult StatisticsPropagator::ClassifyFilter(Expression &condition) {
+	if (ExpressionIsConstant(condition, Value::BOOLEAN(true))) {
 		return FilterPropagateResult::FILTER_ALWAYS_TRUE;
 	}
 
-	if (ExpressionIsConstantOrNull(*condition, Value::BOOLEAN(true))) {
+	if (ExpressionIsConstantOrNull(condition, Value::BOOLEAN(true))) {
 		return FilterPropagateResult::FILTER_TRUE_OR_NULL;
 	}
 
-	if (ExpressionIsConstant(*condition, Value::BOOLEAN(false))) {
+	if (ExpressionIsConstant(condition, Value::BOOLEAN(false))) {
 		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
-	} else if (ExpressionIsConstantOrNull(*condition, Value::BOOLEAN(false))) {
+	} else if (ExpressionIsConstantOrNull(condition, Value::BOOLEAN(false))) {
 		return FilterPropagateResult::FILTER_FALSE_OR_NULL;
 	}
 
 	return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 }
 
+static unordered_set<TableIndex> GetFilterBindings(const Expression &condition) {
+	unordered_set<TableIndex> bindings;
+	ExpressionIterator::VisitExpression<BoundColumnRefExpression>(
+	    condition, [&](const BoundColumnRefExpression &column_ref) {
+		    if (column_ref.Depth() == 0) {
+			    bindings.insert(column_ref.Binding().table_index);
+		    }
+	    });
+	return bindings;
+}
+
+bool StatisticsPropagator::SimplifyFilter(unique_ptr<Expression> &condition) {
+	if (condition->GetExpressionClass() != ExpressionClass::BOUND_CONJUNCTION) {
+		return false;
+	}
+	auto &conjunction = condition->Cast<BoundConjunctionExpression>();
+	auto &children = conjunction.GetChildrenMutable();
+	const auto is_and = conjunction.GetExpressionType() == ExpressionType::CONJUNCTION_AND;
+	bool changed = false;
+
+	for (idx_t child_idx = 0; child_idx < children.size(); child_idx++) {
+		auto &child = children[child_idx];
+		changed |= SimplifyFilter(child);
+
+		const auto is_true = ExpressionIsConstant(*child, Value::BOOLEAN(true));
+		const auto is_false = ExpressionIsConstant(*child, Value::BOOLEAN(false));
+		const auto is_false_or_null = ExpressionIsConstantOrNull(*child, Value::BOOLEAN(false));
+		if ((is_and && (is_false || is_false_or_null)) || (!is_and && is_true)) {
+			condition = make_uniq<BoundConstantExpression>(Value::BOOLEAN(!is_and));
+			return true;
+		}
+		if ((is_and && is_true) || (!is_and && (is_false || is_false_or_null))) {
+			children.erase_at(child_idx);
+			child_idx--;
+			changed = true;
+		}
+	}
+	if (children.empty()) {
+		condition = make_uniq<BoundConstantExpression>(Value::BOOLEAN(is_and));
+		return true;
+	}
+	if (children.size() == 1) {
+		condition = std::move(children[0]);
+		return true;
+	}
+	return changed;
+}
+
 FilterPropagateResult StatisticsPropagator::HandleFilter(unique_ptr<Expression> &condition) {
-	auto prune_result = ClassifyFilter(condition);
+	auto original_bindings = GetFilterBindings(*condition);
+	PropagateExpression(condition);
+	SimplifyFilter(condition);
+	filter_bindings_changed |= original_bindings != GetFilterBindings(*condition);
+	auto prune_result = ClassifyFilter(*condition);
 	if (prune_result == FilterPropagateResult::NO_PRUNING_POSSIBLE) {
 		// cannot prune this filter: propagate statistics from the filter
 		UpdateFilterStatistics(*condition);

--- a/src/optimizer/statistics/operator/propagate_join.cpp
+++ b/src/optimizer/statistics/operator/propagate_join.cpp
@@ -190,7 +190,8 @@ void StatisticsPropagator::PropagateStatistics(LogicalComparisonJoin &join, uniq
 void StatisticsPropagator::PropagateStatistics(LogicalAnyJoin &join, unique_ptr<LogicalOperator> &node_ptr) {
 	// propagate the expression into the join condition
 	// note that a condition that is TRUE_OR_NULL does not always match: a NULL condition rejects the pair
-	switch (ClassifyFilter(join.condition)) {
+	PropagateExpression(join.condition);
+	switch (ClassifyFilter(*join.condition)) {
 	case FilterPropagateResult::FILTER_ALWAYS_TRUE:
 		HandleJoinAlwaysMatches(join, node_ptr);
 		break;

--- a/src/optimizer/statistics_propagator.cpp
+++ b/src/optimizer/statistics_propagator.cpp
@@ -25,8 +25,9 @@
 
 namespace duckdb {
 
-StatisticsPropagator::StatisticsPropagator(Optimizer &optimizer_p, LogicalOperator &root_p)
-    : optimizer(optimizer_p), context(optimizer.context), root(&root_p) {
+StatisticsPropagator::StatisticsPropagator(Optimizer &optimizer_p, LogicalOperator &root_p,
+                                           StatisticsPropagationMode mode_p)
+    : optimizer(optimizer_p), context(optimizer.context), mode(mode_p), root(&root_p) {
 	root->ResolveOperatorTypes();
 }
 
@@ -98,7 +99,8 @@ unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalOper
 		result = PropagateChildren(node, node_ptr);
 	}
 
-	if (!optimizer.OptimizerDisabled(OptimizerType::COMPRESSED_MATERIALIZATION)) {
+	if (mode == StatisticsPropagationMode::FULL &&
+	    !optimizer.OptimizerDisabled(OptimizerType::COMPRESSED_MATERIALIZATION)) {
 		// compress data based on statistics for materializing operators
 		CompressedMaterialization compressed_materialization(optimizer, *root, statistics_map);
 		compressed_materialization.Compress(node_ptr);

--- a/test/optimizer/in_clause_rewriter_join.test
+++ b/test/optimizer/in_clause_rewriter_join.test
@@ -35,6 +35,16 @@ WHERE in_left.i = in_right.i
 ----
 logical_opt	<!REGEX>:.*MARK.*
 
+# A non-rewritable outer IN clause does not hide a nested rewritable IN clause
+query II
+EXPLAIN SELECT *
+FROM in_left, in_right
+WHERE (CASE WHEN in_left.j IN (1, 2, 3, 4, 5, 6)
+	THEN in_left.i ELSE 0 END)
+	IN (in_right.i, 10, 20, 30, 40, 50);
+----
+logical_opt	<REGEX>:.*MARK.*
+
 query III
 SELECT *
 FROM in_left, in_right
@@ -44,3 +54,23 @@ ORDER BY ALL;
 ----
 1	1	1
 11	8	11
+
+foreach do '' 'in_clause'
+
+statement ok
+SET disabled_optimizers = {do};
+
+query III
+SELECT *
+FROM in_left, in_right
+WHERE (CASE WHEN in_left.j IN (1, 2, 3, 4, 5, 6)
+	THEN in_left.i ELSE 0 END)
+	IN (in_right.i, 10, 20, 30, 40, 50)
+ORDER BY ALL;
+----
+1	1	1
+
+endloop
+
+statement ok
+SET disabled_optimizers = '';

--- a/test/optimizer/in_clause_rewriter_join.test
+++ b/test/optimizer/in_clause_rewriter_join.test
@@ -1,0 +1,46 @@
+# name: test/optimizer/in_clause_rewriter_join.test
+# description: Keep large IN clauses visible to the IN clause rewriter
+# group: [optimizer]
+
+statement ok
+CREATE TABLE in_left(i INTEGER, j INTEGER);
+
+statement ok
+CREATE TABLE in_right(i INTEGER);
+
+statement ok
+INSERT INTO in_left VALUES (1, 1), (2, 8), (11, 8);
+
+statement ok
+INSERT INTO in_right VALUES (1), (2), (11);
+
+statement ok
+PRAGMA explain_output = OPTIMIZED_ONLY;
+
+# A large IN clause nested in a cross-table predicate is rewritten to a MARK join
+query II
+EXPLAIN SELECT *
+FROM in_left, in_right
+WHERE in_left.i = in_right.i
+  AND (in_left.j IN (1, 2, 3, 4, 5, 6) OR in_right.i > 10);
+----
+logical_opt	<REGEX>:.*MARK.*
+
+# Small IN clauses stay in the comparison join residual predicate
+query II
+EXPLAIN SELECT *
+FROM in_left, in_right
+WHERE in_left.i = in_right.i
+  AND (in_left.j IN (1, 2, 3) OR in_right.i > 10);
+----
+logical_opt	<!REGEX>:.*MARK.*
+
+query III
+SELECT *
+FROM in_left, in_right
+WHERE in_left.i = in_right.i
+  AND (in_left.j IN (1, 2, 3, 4, 5, 6) OR in_right.i > 10)
+ORDER BY ALL;
+----
+1	1	1
+11	8	11

--- a/test/optimizer/statistics/statistics_filter_context.test
+++ b/test/optimizer/statistics/statistics_filter_context.test
@@ -1,0 +1,209 @@
+# name: test/optimizer/statistics/statistics_filter_context.test
+# description: Simplify statistics-derived constants using filter truth semantics
+# group: [statistics]
+
+statement ok
+CREATE TABLE filter_context_address(k INTEGER, zip VARCHAR, state VARCHAR);
+
+statement ok
+INSERT INTO filter_context_address VALUES
+	(1, '10000', 'NY'),
+	(2, '20000', 'CA'),
+	(3, NULL, 'NY'),
+	(4, '80000', 'NY');
+
+statement ok
+CREATE TABLE filter_context_sales(k INTEGER, price INTEGER);
+
+statement ok
+INSERT INTO filter_context_sales VALUES
+	(1, 10),
+	(2, NULL),
+	(3, NULL),
+	(4, 20);
+
+statement ok
+CHECKPOINT;
+
+statement ok
+PRAGMA explain_output = OPTIMIZED_ONLY;
+
+# price > 100 is FALSE or NULL from statistics. In filter context it cannot make the OR pass, so the
+# address-only predicate is pushed below the join before the large IN clause becomes a MARK join.
+query II
+EXPLAIN SELECT count(*)
+FROM filter_context_address address
+JOIN filter_context_sales sales USING (k)
+WHERE substring(zip, 1, 5) IN ('10000', '30000', '40000', '50000', '60000', '70000')
+	OR state = 'CA'
+	OR price > 100;
+----
+logical_opt	<REGEX>:.*INNER.*IN \(\.\.\.\).*MARK.*filter_context_address.*
+
+query II
+EXPLAIN SELECT count(*)
+FROM filter_context_address address
+JOIN filter_context_sales sales USING (k)
+WHERE substring(zip, 1, 5) IN ('10000', '30000', '40000', '50000', '60000', '70000')
+	OR state = 'CA'
+	OR price > 100;
+----
+logical_opt	<!REGEX>:.*constant_or_null.*
+
+query I
+SELECT count(*)
+FROM filter_context_address address
+JOIN filter_context_sales sales USING (k)
+WHERE substring(zip, 1, 5) IN ('10000', '30000', '40000', '50000', '60000', '70000')
+	OR state = 'CA'
+	OR price > 100;
+----
+2
+
+# PropagateExpression can remove a NOT NULL impossible branch before SimplifyFilter sees the conjunction.
+statement ok
+CREATE TABLE filter_context_sales_not_null(k INTEGER, price INTEGER NOT NULL);
+
+statement ok
+INSERT INTO filter_context_sales_not_null VALUES (1, 10), (2, 20), (3, 15), (4, 20);
+
+statement ok
+CHECKPOINT;
+
+query II
+EXPLAIN SELECT count(*)
+FROM filter_context_address address
+JOIN filter_context_sales_not_null sales USING (k)
+WHERE substring(zip, 1, 5) IN ('10000', '30000', '40000', '50000', '60000', '70000')
+	OR state = 'CA'
+	OR price > 100;
+----
+logical_opt	<REGEX>:.*INNER.*IN \(\.\.\.\).*MARK.*filter_context_address.*
+
+query I
+SELECT count(*)
+FROM filter_context_address address
+JOIN filter_context_sales_not_null sales USING (k)
+WHERE substring(zip, 1, 5) IN ('10000', '30000', '40000', '50000', '60000', '70000')
+	OR state = 'CA'
+	OR price > 100;
+----
+2
+
+# The early statistics pass is selected by relation dependencies, not by a comparison expression shape.
+query II
+EXPLAIN SELECT count(*)
+FROM filter_context_address address
+JOIN filter_context_sales_not_null sales USING (k)
+WHERE substring(zip, 1, 5) IN ('10000', '30000', '40000', '50000', '60000', '70000')
+	OR price IS NULL;
+----
+logical_opt	<REGEX>:.*INNER.*IN \(\.\.\.\).*MARK.*filter_context_address.*
+
+query I
+SELECT count(*)
+FROM filter_context_address address
+JOIN filter_context_sales_not_null sales USING (k)
+WHERE substring(zip, 1, 5) IN ('10000', '30000', '40000', '50000', '60000', '70000')
+	OR price IS NULL;
+----
+1
+
+# Projection context must retain the NULL produced by the impossible comparison.
+query II
+SELECT k, state = 'CA' OR price > 100
+FROM filter_context_address address
+JOIN filter_context_sales sales USING (k)
+ORDER BY k;
+----
+1	false
+2	true
+3	NULL
+4	false
+
+query II
+EXPLAIN SELECT state = 'CA' OR price > 100
+FROM filter_context_address address
+JOIN filter_context_sales sales USING (k);
+----
+logical_opt	<REGEX>:.*constant_or_null.*
+
+# Do not apply positive filter-context simplification through NOT.
+query I
+SELECT k
+FROM filter_context_address address
+JOIN filter_context_sales sales USING (k)
+WHERE NOT (state = 'CA' OR price > 100)
+ORDER BY k;
+----
+1
+4
+
+# Join conditions are not row filters: preserve false-or-NULL branches for join-specific NULL semantics.
+statement ok
+CREATE TABLE join_filter_left(k INTEGER, flag BOOLEAN);
+
+statement ok
+INSERT INTO join_filter_left VALUES (1, false), (2, true);
+
+statement ok
+CREATE TABLE join_filter_right(v INTEGER);
+
+statement ok
+INSERT INTO join_filter_right VALUES (10), (NULL);
+
+statement ok
+CHECKPOINT;
+
+query II
+EXPLAIN SELECT *
+FROM join_filter_left
+LEFT JOIN join_filter_right ON flag OR v > 100;
+----
+logical_opt	<REGEX>:.*constant_or_null.*
+
+query III
+SELECT *
+FROM join_filter_left
+LEFT JOIN join_filter_right ON flag OR v > 100
+ORDER BY k, v;
+----
+1	false	NULL
+2	true	10
+2	true	NULL
+
+# Compare the original result against the optimizer-disabled reference.
+statement ok
+PRAGMA disable_optimizer;
+
+query I
+SELECT count(*)
+FROM filter_context_address address
+JOIN filter_context_sales sales USING (k)
+WHERE substring(zip, 1, 5) IN ('10000', '30000', '40000', '50000', '60000', '70000')
+	OR state = 'CA'
+	OR price > 100;
+----
+2
+
+query I
+SELECT count(*)
+FROM filter_context_address address
+JOIN filter_context_sales_not_null sales USING (k)
+WHERE substring(zip, 1, 5) IN ('10000', '30000', '40000', '50000', '60000', '70000')
+	OR state = 'CA'
+	OR price > 100;
+----
+2
+
+query I
+SELECT count(*)
+FROM filter_context_address address
+JOIN filter_context_sales_not_null sales USING (k)
+WHERE substring(zip, 1, 5) IN ('10000', '30000', '40000', '50000', '60000', '70000')
+	OR price IS NULL;
+----
+1
+
+statement ok
+PRAGMA enable_optimizer;

--- a/test/sql/cte/materialized/cte_filter_pusher.test
+++ b/test/sql/cte/materialized/cte_filter_pusher.test
@@ -124,3 +124,62 @@ WHERE x = 2 OR x IS NULL;
 -1	C
 2	A
 2	B
+
+# Statistics can make a cross-relation filter local to a materialized CTE reference.
+statement ok
+CREATE TABLE cte_filter_context(x INTEGER);
+
+statement ok
+INSERT INTO cte_filter_context VALUES (10), (20), (NULL);
+
+statement ok
+CHECKPOINT;
+
+query II
+EXPLAIN (FORMAT JSON) WITH cte AS MATERIALIZED (
+	SELECT i AS k, i % 10 AS v FROM range(1000000000) t(i)
+)
+SELECT count(*)
+FROM cte c, cte_filter_context s
+WHERE c.v IN (1, 2, 3, 4, 5, 6) OR s.x > 100;
+----
+logical_opt	<REGEX>:(?s).*"name": "CTE".*"name": "COMPARISON_JOIN".*"name": "RANGE".*"Join Type": "MARK".*"Expressions": "IN \(\.\.\.\)".*"name": "CTE_SCAN".*
+
+query I
+WITH cte AS MATERIALIZED (
+	SELECT i AS k, i % 10 AS v FROM range(100) t(i)
+)
+SELECT count(*)
+FROM cte c, cte_filter_context s
+WHERE c.v IN (1, 2, 3, 4, 5, 6) OR s.x > 100;
+----
+180
+
+# An unfiltered consumer still prevents pushing a partial consumer domain into the definition.
+query II
+EXPLAIN (FORMAT JSON) WITH cte AS MATERIALIZED (
+	SELECT i AS k, i % 10 AS v FROM range(1000000000) t(i)
+)
+SELECT count(*)
+FROM cte c, cte_filter_context s
+WHERE c.v IN (1, 2, 3, 4, 5, 6) OR s.x > 100
+UNION ALL
+SELECT count(*) FROM cte;
+----
+logical_opt	<!REGEX>:(?s).*"name": "CTE".*"name": "COMPARISON_JOIN".*"name": "RANGE".*"Join Type": "MARK".*"Expressions": "IN \(\.\.\.\)".*"name": "CTE_SCAN".*
+
+statement ok
+PRAGMA disable_optimizer;
+
+query I
+WITH cte AS MATERIALIZED (
+	SELECT i AS k, i % 10 AS v FROM range(100) t(i)
+)
+SELECT count(*)
+FROM cte c, cte_filter_context s
+WHERE c.v IN (1, 2, 3, 4, 5, 6) OR s.x > 100;
+----
+180
+
+statement ok
+PRAGMA enable_optimizer;


### PR DESCRIPTION
I found this while comparing the TPC benchmark queries against 1.5.5. TPC-DS Q15 had become roughly 60% slower because three optimizer decisions interacted badly.

Filter pushdown first moves a cross-table predicate into a join residual. That residual contains a large constant `IN` clause, but the IN-clause rewriter only visits filters and projections, so it can no longer turn the list into a MARK join. Statistics propagation then proves another branch of the filter impossible from the `cs_sales_price` statistics. Once that branch disappears, the remaining filter refers to fewer relations and another filter-pushdown pass can place it much earlier, but the optimizer did not revisit filter pushdown at that point.

I initially expressed the reoptimization trigger by recognizing the particular OR/comparison shape in Q15. That was too specific, and it also put lifecycle policy directly in `Optimizer`. I replaced it with a dedicated `FilterStatisticsOptimizer`. It considers residual filters that still span multiple bindings, runs statistics propagation in a filter-simplification mode, and reruns filter pushdown only when simplification changes the filter's binding ownership. Materialized CTE filter propagation follows that pass so the CTE definition sees the newly pushed filters as well.

The distinction between filter simplification and the normal statistics pass is explicit. The early pass applies WHERE-filter truth semantics, where both `FALSE` and `NULL` remove the row, but it does not reuse those rules under `NOT`, in projections, or in join predicates. Compressed materialization remains part of the full statistics pass only.

I also keep residual predicates containing a rewritable `IN` clause in a `LogicalFilter` until the IN-clause rewriter can consume them. The recursive search and rewrite now continue through a non-rewritable parent `IN`, so a dynamic outer list cannot hide an independently rewritable constant list below it.

| workload | main median | branch median | range on main | range on branch |
|---|---:|---:|---:|---:|
| TPC-DS Q15 | 0.058 s | 0.027 s | 0.057–0.060 s | 0.024–0.037 s |
