### PR TITLE
Reduce keyed recursive UNION update overhead

### DIFF
--- a/src/execution/operator/set/physical_recursive_cte.cpp
+++ b/src/execution/operator/set/physical_recursive_cte.cpp
@@ -218,6 +218,10 @@ void RecursiveCTEState::CombineOutput(ColumnDataCollection &output) {
 	    collect_metrics ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point();
 	const auto row_count = output.Count();
 	CurrentOutputTable().Combine(output);
+	// Keyed workers can resume shared appends after publishing local output.
+	if (op.using_key) {
+		InitializeSharedOutputAppend();
+	}
 	if (collect_metrics) {
 		const auto after_work = std::chrono::steady_clock::now();
 		RecordSinkMetrics(

--- a/src/execution/operator/set/physical_recursive_cte.cpp
+++ b/src/execution/operator/set/physical_recursive_cte.cpp
@@ -373,6 +373,8 @@ unique_ptr<GlobalSinkState> PhysicalRecursiveCTE::GetGlobalSinkState(ClientConte
 	return make_uniq<RecursiveCTEState>(context, *this);
 }
 
+enum class RecursiveCTELocalPreaggregationDecision : uint8_t { DEFER, PREAGGREGATE, DIRECT };
+
 class RecursiveCTELocalPreaggregationState {
 public:
 	RecursiveCTELocalPreaggregationState(ClientContext &context_p, const PhysicalRecursiveCTE &op_p)
@@ -398,26 +400,34 @@ public:
 		input.Initialize(Allocator::Get(context), op.internal_types);
 	}
 
-	bool ShouldPreaggregate(ColumnDataCollection &candidates, idx_t frontier_count) {
+	RecursiveCTELocalPreaggregationDecision Classify(ColumnDataCollection &candidates) {
 		const auto candidate_count = candidates.Count();
-		if (candidate_count < STANDARD_VECTOR_SIZE || frontier_count >= candidate_count) {
-			return false;
-		}
-		HyperLogLog cardinality;
-		const auto group_limit = candidate_count / 4;
+		D_ASSERT(candidate_count >= STANDARD_VECTOR_SIZE);
+		sampled_candidate_count += candidate_count;
 		ColumnDataScanState scan_state;
 		candidates.InitializeScan(scan_state);
 		while (candidates.Scan(scan_state, input)) {
 			ExtractKeys(input);
 			keys.Hash(hashes);
 			cardinality.Update(hashes);
-			const auto distinct_upper_bound =
-			    LossyNumericCast<idx_t>((1 + HyperLogLog::GetErrorRate()) * static_cast<double>(cardinality.Count()));
-			if (distinct_upper_bound >= group_limit) {
-				return false;
-			}
 		}
-		return true;
+		const auto distinct_upper_bound =
+		    LossyNumericCast<idx_t>((1 + HyperLogLog::GetErrorRate()) * static_cast<double>(cardinality.Count()));
+		if (distinct_upper_bound < sampled_candidate_count / 4) {
+			return RecursiveCTELocalPreaggregationDecision::PREAGGREGATE;
+		}
+		// Keep sampling across vector boundaries, but bound the extra hashing for unique streams.
+		static constexpr idx_t MAX_SAMPLE_VECTORS = 8;
+		const auto sample_size = MaxValue<idx_t>(STANDARD_VECTOR_SIZE, 16);
+		if (sampled_candidate_count >= sample_size * MAX_SAMPLE_VECTORS) {
+			return RecursiveCTELocalPreaggregationDecision::DIRECT;
+		}
+		return RecursiveCTELocalPreaggregationDecision::DEFER;
+	}
+
+	void ResetClassification() {
+		cardinality = HyperLogLog();
+		sampled_candidate_count = 0;
 	}
 
 	unique_ptr<GroupedAggregateHashTable> Preaggregate(ColumnDataCollection &candidates) {
@@ -465,6 +475,8 @@ private:
 	DataChunk payload;
 	DataChunk input;
 	Vector hashes;
+	HyperLogLog cardinality;
+	idx_t sampled_candidate_count = 0;
 };
 
 class RecursiveCTELocalState : public LocalSinkState {
@@ -472,8 +484,8 @@ public:
 	RecursiveCTELocalState(ClientContext &context, const PhysicalRecursiveCTE &op)
 	    : context(context), op(op), hashes(LogicalType::HASH), partition_hashes(LogicalType::HASH),
 	      dummy_addresses(LogicalType::POINTER), new_groups(STANDARD_VECTOR_SIZE) {
-		if (!op.using_key || !op.union_all) {
-			output = make_uniq<ColumnDataCollection>(context, op.using_key ? op.internal_types : op.GetTypes());
+		if (!op.using_key) {
+			output = make_uniq<ColumnDataCollection>(context, op.GetTypes());
 			output->InitializeAppend(append_state);
 		}
 		if (!op.using_key && !op.union_all) {
@@ -492,21 +504,75 @@ public:
 	DataChunk partition_chunk;
 	vector<SelectionVector> partition_selections;
 	vector<idx_t> partition_counts;
+	idx_t using_key_candidate_count = 0;
+	idx_t using_key_classification_work_ns = 0;
+	bool buffer_using_key_output = false;
+	bool direct_using_key_output = false;
+	unique_ptr<RecursiveCTELocalPreaggregationState> using_key_preaggregation;
 
-	unique_ptr<GroupedAggregateHashTable> TryPreaggregate(idx_t frontier_count, idx_t &classification_work_ns,
-	                                                      idx_t &preaggregation_work_ns) {
-		D_ASSERT(output && op.using_key && !op.union_all);
-		RecursiveCTELocalPreaggregationState preaggregation(context, op);
-		const auto classification_start = std::chrono::steady_clock::now();
-		const auto selected = preaggregation.ShouldPreaggregate(*output, frontier_count);
-		const auto classification_end = std::chrono::steady_clock::now();
-		classification_work_ns = NumericCast<idx_t>(
-		    std::chrono::duration_cast<std::chrono::nanoseconds>(classification_end - classification_start).count());
-		if (!selected) {
-			return nullptr;
+	void SinkUsingKeyOutput(DataChunk &chunk, RecursiveCTEState &gstate) {
+		D_ASSERT(op.using_key && !op.union_all);
+		using_key_candidate_count += chunk.size();
+		if (buffer_using_key_output) {
+			BufferUsingKeyOutput(chunk);
+			return;
 		}
+		const auto sample_size = MaxValue<idx_t>(STANDARD_VECTOR_SIZE, 16);
+		const auto coalesce_small_chunks = chunk.size() < sample_size && (using_key_candidate_count >= sample_size ||
+		                                                                  gstate.CurrentInputCount() >= sample_size);
+		if (direct_using_key_output || !gstate.CanPreaggregateUsingKey()) {
+			if (coalesce_small_chunks) {
+				BufferUsingKeyOutput(chunk);
+			} else {
+				gstate.AppendOutput(chunk);
+			}
+			return;
+		}
+		if (using_key_candidate_count <= gstate.CurrentInputCount() && !coalesce_small_chunks) {
+			gstate.AppendOutput(chunk);
+			return;
+		}
+		BufferUsingKeyOutput(chunk);
+		if (output->Count() < sample_size) {
+			return;
+		}
+		ClassifyBufferedUsingKeyOutput();
+		if (!buffer_using_key_output) {
+			gstate.CombineOutput(*output);
+			output->ResetForReuse();
+			output->InitializeAppend(append_state);
+		}
+	}
+
+	void ClassifyBufferedUsingKeyOutput() {
+		D_ASSERT(output && output->Count() >= STANDARD_VECTOR_SIZE && !buffer_using_key_output &&
+		         !direct_using_key_output);
+		if (!using_key_preaggregation) {
+			using_key_preaggregation = make_uniq<RecursiveCTELocalPreaggregationState>(context, op);
+		}
+		const auto classification_start = std::chrono::steady_clock::now();
+		const auto decision = using_key_preaggregation->Classify(*output);
+		const auto classification_end = std::chrono::steady_clock::now();
+		using_key_classification_work_ns += NumericCast<idx_t>(
+		    std::chrono::duration_cast<std::chrono::nanoseconds>(classification_end - classification_start).count());
+		buffer_using_key_output = decision == RecursiveCTELocalPreaggregationDecision::PREAGGREGATE;
+		direct_using_key_output = decision == RecursiveCTELocalPreaggregationDecision::DIRECT;
+	}
+
+	void BufferUsingKeyOutput(DataChunk &chunk) {
+		D_ASSERT(op.using_key && !op.union_all);
+		if (!output) {
+			output = make_uniq<ColumnDataCollection>(context, op.internal_types);
+			output->InitializeAppend(append_state);
+		}
+		output->Append(append_state, chunk);
+	}
+
+	unique_ptr<GroupedAggregateHashTable> Preaggregate(idx_t &preaggregation_work_ns) {
+		D_ASSERT(output && op.using_key && !op.union_all);
+		D_ASSERT(buffer_using_key_output && using_key_preaggregation);
 		const auto preaggregation_start = std::chrono::steady_clock::now();
-		auto result = preaggregation.Preaggregate(*output);
+		auto result = using_key_preaggregation->Preaggregate(*output);
 		const auto preaggregation_end = std::chrono::steady_clock::now();
 		preaggregation_work_ns = NumericCast<idx_t>(
 		    std::chrono::duration_cast<std::chrono::nanoseconds>(preaggregation_end - preaggregation_start).count());
@@ -530,6 +596,13 @@ public:
 	}
 
 	void Reset(ExecutionContext &context, GlobalSinkState &gstate) override {
+		using_key_candidate_count = 0;
+		using_key_classification_work_ns = 0;
+		buffer_using_key_output = false;
+		direct_using_key_output = false;
+		if (using_key_preaggregation) {
+			using_key_preaggregation->ResetClassification();
+		}
 		if (!output) {
 			return;
 		}
@@ -836,7 +909,8 @@ void RecursiveCTEState::CommitUsingKeyUpdatesInternal() {
 			const auto index_start =
 			    COLLECT_METRICS ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point();
 			for (auto &index : partial_key_indexes) {
-				index->AddGroups(distinct_rows, new_groups, new_group_addresses, new_group_count);
+				index->AddGroups(distinct_rows, new_groups, new_group_addresses,
+				                 *FlatVector::IncrementalSelectionVector(), new_group_count);
 			}
 			if constexpr (COLLECT_METRICS) {
 				const auto index_end = std::chrono::steady_clock::now();
@@ -870,7 +944,8 @@ void RecursiveCTEState::CommitUsingKeyUpdatesInternal() {
 		const auto index_start =
 		    COLLECT_METRICS ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point();
 		for (auto &index : partial_key_indexes) {
-			index->AddGroups(distinct_rows, new_groups, new_group_addresses, new_group_count);
+			index->AddGroups(distinct_rows, new_groups, new_group_addresses, *FlatVector::IncrementalSelectionVector(),
+			                 new_group_count);
 		}
 		if constexpr (COLLECT_METRICS) {
 			const auto index_end = std::chrono::steady_clock::now();
@@ -1237,8 +1312,7 @@ SinkResultType PhysicalRecursiveCTE::Sink(ExecutionContext &context, DataChunk &
 		return SinkResultType::NEED_MORE_INPUT;
 	}
 	auto &lstate = input.local_state.Cast<RecursiveCTELocalState>();
-	D_ASSERT(lstate.output);
-	lstate.output->Append(lstate.append_state, chunk);
+	lstate.SinkUsingKeyOutput(chunk, gstate);
 	return SinkResultType::NEED_MORE_INPUT;
 }
 
@@ -1253,24 +1327,29 @@ SinkCombineResultType PhysicalRecursiveCTE::Combine(ExecutionContext &context, O
 	if (using_key) {
 		if (!union_all) {
 			auto &lstate = input.local_state.Cast<RecursiveCTELocalState>();
+			if (!lstate.buffer_using_key_output && !lstate.direct_using_key_output && lstate.output &&
+			    lstate.output->Count() >= STANDARD_VECTOR_SIZE &&
+			    lstate.using_key_candidate_count > gstate.CurrentInputCount() && gstate.CanPreaggregateUsingKey()) {
+				lstate.ClassifyBufferedUsingKeyOutput();
+			}
+			if (!lstate.buffer_using_key_output) {
+				if (gstate.GetMetrics().Enabled() && lstate.using_key_classification_work_ns > 0) {
+					gstate.GetEpochMetrics().RecordLocalKeyPreaggregationClassification(
+					    lstate.using_key_classification_work_ns);
+				}
+				if (lstate.output && lstate.output->Count() > 0) {
+					gstate.CombineOutput(*lstate.output);
+				}
+				return SinkCombineResultType::FINISHED;
+			}
 			D_ASSERT(lstate.output);
 			const auto candidate_count = lstate.output->Count();
-			if (candidate_count >= STANDARD_VECTOR_SIZE && gstate.CurrentInputCount() < candidate_count &&
-			    gstate.CanPreaggregateUsingKey()) {
-				idx_t classification_work_ns = 0;
-				idx_t preaggregation_work_ns = 0;
-				auto local_ht =
-				    lstate.TryPreaggregate(gstate.CurrentInputCount(), classification_work_ns, preaggregation_work_ns);
-				if (local_ht) {
-					gstate.RegisterLocalPreaggregation(std::move(local_ht), candidate_count, classification_work_ns,
-					                                   preaggregation_work_ns);
-					return SinkCombineResultType::FINISHED;
-				}
-				if (gstate.GetMetrics().Enabled()) {
-					gstate.GetEpochMetrics().RecordLocalKeyPreaggregationClassification(classification_work_ns);
-				}
-			}
-			gstate.CombineOutput(*lstate.output);
+			D_ASSERT(candidate_count > 0 && lstate.buffer_using_key_output && gstate.CanPreaggregateUsingKey());
+			idx_t preaggregation_work_ns = 0;
+			auto local_ht = lstate.Preaggregate(preaggregation_work_ns);
+			gstate.RegisterLocalPreaggregation(std::move(local_ht), candidate_count,
+			                                   lstate.using_key_classification_work_ns, preaggregation_work_ns);
+			return SinkCombineResultType::FINISHED;
 		}
 	} else {
 		if (union_all && !gstate.UsesLocalUnionAllOutput()) {

--- a/src/execution/operator/set/physical_recursive_cte.cpp
+++ b/src/execution/operator/set/physical_recursive_cte.cpp
@@ -227,6 +227,23 @@ void RecursiveCTEState::CombineOutput(ColumnDataCollection &output) {
 	}
 }
 
+void RecursiveCTEState::RegisterLocalPreaggregation(unique_ptr<GroupedAggregateHashTable> local_ht,
+                                                    idx_t candidate_rows, idx_t classification_work_ns,
+                                                    idx_t preaggregation_work_ns) {
+	D_ASSERT(local_ht && candidate_rows > 0 && local_ht->Count() <= candidate_rows);
+	const auto group_count = local_ht->Count();
+	{
+		lock_guard<mutex> guard(intermediate_table_lock);
+		local_preaggregate_candidate_count += candidate_rows;
+		local_preaggregates.push_back(std::move(local_ht));
+	}
+	if (metrics.Enabled()) {
+		metrics.RecordHashRows(candidate_rows);
+		GetEpochMetrics().RecordLocalKeyPreaggregationClassification(classification_work_ns);
+		GetEpochMetrics().RecordLocalKeyPreaggregation(candidate_rows, group_count, preaggregation_work_ns);
+	}
+}
+
 void RecursiveCTEState::AssembleStateRows(DataChunk &keys, DataChunk &aggregates, DataChunk &result) const {
 	result.Reset();
 	for (idx_t key_idx = 0; key_idx < op.distinct_idx.size(); key_idx++) {
@@ -352,11 +369,105 @@ unique_ptr<GlobalSinkState> PhysicalRecursiveCTE::GetGlobalSinkState(ClientConte
 	return make_uniq<RecursiveCTEState>(context, *this);
 }
 
+class RecursiveCTELocalPreaggregationState {
+public:
+	RecursiveCTELocalPreaggregationState(ClientContext &context_p, const PhysicalRecursiveCTE &op_p)
+	    : context(context_p), op(op_p), payload_executor(context), hashes(LogicalType::HASH) {
+		vector<LogicalType> aggregate_input_types;
+		for (auto &payload_aggregate : op.payload_aggregates) {
+			auto &bound_aggregate = payload_aggregate->Cast<BoundAggregateExpression>();
+			for (auto &child : bound_aggregate.GetChildren()) {
+				payload_executor.AddExpression(*child);
+				aggregate_input_types.push_back(child->GetReturnType());
+			}
+			aggregates.emplace_back(bound_aggregate);
+		}
+		if (!op.key_normalizers.empty()) {
+			key_executor = make_uniq<ExpressionExecutor>(context);
+			for (auto &normalizer : op.key_normalizers) {
+				key_executor->AddExpression(*normalizer);
+			}
+			raw_keys.Initialize(Allocator::Get(context), op.distinct_types);
+		}
+		keys.Initialize(Allocator::Get(context), op.hash_key_types);
+		payload.Initialize(Allocator::Get(context), aggregate_input_types);
+		input.Initialize(Allocator::Get(context), op.internal_types);
+	}
+
+	bool ShouldPreaggregate(ColumnDataCollection &candidates, idx_t frontier_count) {
+		const auto candidate_count = candidates.Count();
+		if (candidate_count < STANDARD_VECTOR_SIZE || frontier_count >= candidate_count) {
+			return false;
+		}
+		HyperLogLog cardinality;
+		const auto group_limit = candidate_count / 4;
+		ColumnDataScanState scan_state;
+		candidates.InitializeScan(scan_state);
+		while (candidates.Scan(scan_state, input)) {
+			ExtractKeys(input);
+			keys.Hash(hashes);
+			cardinality.Update(hashes);
+			const auto distinct_upper_bound =
+			    LossyNumericCast<idx_t>((1 + HyperLogLog::GetErrorRate()) * static_cast<double>(cardinality.Count()));
+			if (distinct_upper_bound >= group_limit) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	unique_ptr<GroupedAggregateHashTable> Preaggregate(ColumnDataCollection &candidates) {
+		auto result = make_uniq<GroupedAggregateHashTable>(context, BufferAllocator::Get(context), op.hash_key_types,
+		                                                   op.aggregate_types, aggregates);
+		ColumnDataScanState scan_state;
+		candidates.InitializeScan(scan_state);
+		while (candidates.Scan(scan_state, input)) {
+			ExtractKeys(input);
+			if (!payload_executor.expressions.empty()) {
+				payload.Reset();
+				payload_executor.Execute(input, payload);
+			}
+			result->AddChunk(keys, payload, AggregateType::NON_DISTINCT);
+		}
+		return result;
+	}
+
+private:
+	void ExtractKeys(DataChunk &source) {
+		keys.Reset();
+		if (!key_executor) {
+			for (idx_t key_idx = 0; key_idx < op.distinct_idx.size(); key_idx++) {
+				keys.data[key_idx].Reference(source.data[op.distinct_idx[key_idx]]);
+			}
+			keys.CheckCardinality(source.size());
+			return;
+		}
+		raw_keys.Reset();
+		for (idx_t key_idx = 0; key_idx < op.distinct_idx.size(); key_idx++) {
+			raw_keys.data[key_idx].Reference(source.data[op.distinct_idx[key_idx]]);
+		}
+		raw_keys.CheckCardinality(source.size());
+		key_executor->Execute(raw_keys, keys);
+	}
+
+private:
+	ClientContext &context;
+	const PhysicalRecursiveCTE &op;
+	ExpressionExecutor payload_executor;
+	unique_ptr<ExpressionExecutor> key_executor;
+	vector<AggregateObject> aggregates;
+	DataChunk raw_keys;
+	DataChunk keys;
+	DataChunk payload;
+	DataChunk input;
+	Vector hashes;
+};
+
 class RecursiveCTELocalState : public LocalSinkState {
 public:
 	RecursiveCTELocalState(ClientContext &context, const PhysicalRecursiveCTE &op)
-	    : hashes(LogicalType::HASH), partition_hashes(LogicalType::HASH), dummy_addresses(LogicalType::POINTER),
-	      new_groups(STANDARD_VECTOR_SIZE) {
+	    : context(context), op(op), hashes(LogicalType::HASH), partition_hashes(LogicalType::HASH),
+	      dummy_addresses(LogicalType::POINTER), new_groups(STANDARD_VECTOR_SIZE) {
 		if (!op.using_key || !op.union_all) {
 			output = make_uniq<ColumnDataCollection>(context, op.using_key ? op.internal_types : op.GetTypes());
 			output->InitializeAppend(append_state);
@@ -366,6 +477,8 @@ public:
 		}
 	}
 
+	ClientContext &context;
+	const PhysicalRecursiveCTE &op;
 	unique_ptr<ColumnDataCollection> output;
 	ColumnDataAppendState append_state;
 	Vector hashes;
@@ -375,6 +488,26 @@ public:
 	DataChunk partition_chunk;
 	vector<SelectionVector> partition_selections;
 	vector<idx_t> partition_counts;
+
+	unique_ptr<GroupedAggregateHashTable> TryPreaggregate(idx_t frontier_count, idx_t &classification_work_ns,
+	                                                      idx_t &preaggregation_work_ns) {
+		D_ASSERT(output && op.using_key && !op.union_all);
+		RecursiveCTELocalPreaggregationState preaggregation(context, op);
+		const auto classification_start = std::chrono::steady_clock::now();
+		const auto selected = preaggregation.ShouldPreaggregate(*output, frontier_count);
+		const auto classification_end = std::chrono::steady_clock::now();
+		classification_work_ns = NumericCast<idx_t>(
+		    std::chrono::duration_cast<std::chrono::nanoseconds>(classification_end - classification_start).count());
+		if (!selected) {
+			return nullptr;
+		}
+		const auto preaggregation_start = std::chrono::steady_clock::now();
+		auto result = preaggregation.Preaggregate(*output);
+		const auto preaggregation_end = std::chrono::steady_clock::now();
+		preaggregation_work_ns = NumericCast<idx_t>(
+		    std::chrono::duration_cast<std::chrono::nanoseconds>(preaggregation_end - preaggregation_start).count());
+		return result;
+	}
 
 	void InitializePartitions(idx_t partition_count) {
 		if (partition_selections.size() == partition_count) {
@@ -565,6 +698,60 @@ bool RecursiveCTEState::ShouldPreaggregateUsingKeyUpdates(idx_t candidate_count)
 template <bool COLLECT_METRICS>
 void RecursiveCTEState::CommitUsingKeyUpdatesInternal() {
 	D_ASSERT(op.using_key);
+	if (!local_preaggregates.empty()) {
+		D_ASSERT(!op.union_all && local_preaggregate_candidate_count > 0);
+		const auto combine_start =
+		    COLLECT_METRICS ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point();
+		auto epoch_ht = std::move(local_preaggregates[0]);
+		for (idx_t local_idx = 1; local_idx < local_preaggregates.size(); local_idx++) {
+			epoch_ht->Combine(*local_preaggregates[local_idx]);
+		}
+		local_preaggregates.clear();
+		auto preaggregated_candidate_count = local_preaggregate_candidate_count;
+		local_preaggregate_candidate_count = 0;
+		if constexpr (COLLECT_METRICS) {
+			const auto combine_end = std::chrono::steady_clock::now();
+			GetEpochMetrics().RecordKeyPreaggregationCombine(NumericCast<idx_t>(
+			    std::chrono::duration_cast<std::chrono::nanoseconds>(combine_end - combine_start).count()));
+		}
+
+		const auto raw_candidate_count = intermediate_table.Count();
+		if constexpr (COLLECT_METRICS) {
+			GetEpochMetrics().RecordLocalKeyPreaggregationResidual(raw_candidate_count);
+		}
+		bool preaggregate_raw_candidates = false;
+		if (raw_candidate_count >= STANDARD_VECTOR_SIZE) {
+			const auto classification_start =
+			    COLLECT_METRICS ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point();
+			preaggregate_raw_candidates = ShouldPreaggregateUsingKeyUpdates(raw_candidate_count);
+			if constexpr (COLLECT_METRICS) {
+				const auto classification_end = std::chrono::steady_clock::now();
+				GetEpochMetrics().RecordKeyPreaggregationClassification(NumericCast<idx_t>(
+				    std::chrono::duration_cast<std::chrono::nanoseconds>(classification_end - classification_start)
+				        .count()));
+			}
+		}
+		if (preaggregate_raw_candidates) {
+			auto raw_ht = CreateUsingKeyHashTable();
+			const auto preaggregation_work_ns = PreaggregateUsingKeyUpdates<COLLECT_METRICS>(*raw_ht);
+			if constexpr (COLLECT_METRICS) {
+				GetEpochMetrics().RecordKeyPreaggregation(raw_candidate_count, raw_ht->Count(), preaggregation_work_ns);
+			}
+			const auto raw_combine_start =
+			    COLLECT_METRICS ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point();
+			epoch_ht->Combine(*raw_ht);
+			if constexpr (COLLECT_METRICS) {
+				const auto raw_combine_end = std::chrono::steady_clock::now();
+				GetEpochMetrics().RecordKeyPreaggregationCombine(NumericCast<idx_t>(
+				    std::chrono::duration_cast<std::chrono::nanoseconds>(raw_combine_end - raw_combine_start).count()));
+			}
+			preaggregated_candidate_count += raw_candidate_count;
+			intermediate_table.ResetForReuse();
+			InitializeIntermediateAppend();
+		}
+		CommitMixedUsingKeyUpdatesInternal<COLLECT_METRICS>(std::move(epoch_ht), preaggregated_candidate_count);
+		return;
+	}
 	const auto candidate_count = intermediate_table.Count();
 	bool use_preaggregation = false;
 	if (can_preaggregate_using_key && candidate_count >= STANDARD_VECTOR_SIZE) {
@@ -719,6 +906,128 @@ void RecursiveCTEState::CommitUsingKeyUpdatesInternal() {
 }
 
 template <bool COLLECT_METRICS>
+void RecursiveCTEState::CommitMixedUsingKeyUpdatesInternal(unique_ptr<GroupedAggregateHashTable> epoch_ht,
+                                                           idx_t preaggregated_candidate_count) {
+	D_ASSERT(op.using_key && !op.union_all && key_delta && epoch_ht && preaggregated_candidate_count > 0);
+	auto &delta = *key_delta;
+	const auto raw_candidate_count = intermediate_table.Count();
+	const auto delta_candidate_count = raw_candidate_count + preaggregated_candidate_count;
+	idx_t delta_work_ns = 0;
+	const auto reset_start =
+	    COLLECT_METRICS ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point();
+	delta.Reset();
+	if constexpr (COLLECT_METRICS) {
+		const auto reset_end = std::chrono::steady_clock::now();
+		delta_work_ns +=
+		    NumericCast<idx_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(reset_end - reset_start).count());
+	}
+
+	ColumnDataScanState update_scan_state;
+	intermediate_table.InitializeScan(update_scan_state);
+	while (intermediate_table.Scan(update_scan_state, update_rows)) {
+		if constexpr (COLLECT_METRICS) {
+			metrics.RecordHashRows(update_rows.size());
+		}
+		const auto hash_start =
+		    COLLECT_METRICS ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point();
+		idx_t snapshot_work_ns = 0;
+		ExtractUsingKeyKeys(update_rows);
+		if (!executor.expressions.empty()) {
+			payload_rows.Reset();
+			executor.Execute(update_rows, payload_rows);
+		}
+		ht->AddChunk(
+		    distinct_rows, payload_rows, AggregateType::NON_DISTINCT,
+		    [&](const Vector &group_addresses, const SelectionVector &new_groups, idx_t new_group_count) {
+			    const auto snapshot_start =
+			        COLLECT_METRICS ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point();
+			    SnapshotUsingKeyDelta(group_addresses, new_groups, new_group_count, update_rows.size(), false);
+			    if constexpr (COLLECT_METRICS) {
+				    const auto snapshot_end = std::chrono::steady_clock::now();
+				    snapshot_work_ns = NumericCast<idx_t>(
+				        std::chrono::duration_cast<std::chrono::nanoseconds>(snapshot_end - snapshot_start).count());
+				    delta_work_ns += snapshot_work_ns;
+			    }
+		    });
+		if constexpr (COLLECT_METRICS) {
+			const auto hash_end = std::chrono::steady_clock::now();
+			const auto hash_work_ns =
+			    NumericCast<idx_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(hash_end - hash_start).count());
+			D_ASSERT(snapshot_work_ns <= hash_work_ns);
+			GetEpochMetrics().RecordKeyedHashCommit(hash_work_ns - snapshot_work_ns);
+		}
+	}
+
+	AggregateHTScanState epoch_scan_state;
+	epoch_ht->InitializeScan(epoch_scan_state);
+	while (epoch_ht->ScanGroups(epoch_scan_state, distinct_rows)) {
+		if (distinct_rows.size() == 0) {
+			continue;
+		}
+		const auto snapshot_start =
+		    COLLECT_METRICS ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point();
+		SnapshotPreaggregatedUsingKeyDeltaGroups(distinct_rows);
+		if constexpr (COLLECT_METRICS) {
+			const auto snapshot_end = std::chrono::steady_clock::now();
+			delta_work_ns += NumericCast<idx_t>(
+			    std::chrono::duration_cast<std::chrono::nanoseconds>(snapshot_end - snapshot_start).count());
+		}
+	}
+
+	const auto combine_start =
+	    COLLECT_METRICS ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point();
+	ht->Combine(*epoch_ht);
+	if constexpr (COLLECT_METRICS) {
+		const auto combine_end = std::chrono::steady_clock::now();
+		GetEpochMetrics().RecordKeyPreaggregationCombine(NumericCast<idx_t>(
+		    std::chrono::duration_cast<std::chrono::nanoseconds>(combine_end - combine_start).count()));
+	}
+
+	const auto finalize_start =
+	    COLLECT_METRICS ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point();
+	op.working_table->ResetForReuse();
+	op.working_table->InitializeAppend(working_append_state);
+	const auto index_work_ns = FinalizeUsingKeyDelta(!partial_key_indexes.empty(), COLLECT_METRICS);
+	intermediate_table.ResetForReuse();
+	InitializeIntermediateAppend();
+	if constexpr (COLLECT_METRICS) {
+		const auto finalize_end = std::chrono::steady_clock::now();
+		const auto finalize_work_ns = NumericCast<idx_t>(
+		    std::chrono::duration_cast<std::chrono::nanoseconds>(finalize_end - finalize_start).count());
+		D_ASSERT(index_work_ns <= finalize_work_ns);
+		delta_work_ns += finalize_work_ns - index_work_ns;
+		GetEpochMetrics().RecordKeyDelta(delta_candidate_count, delta.touched_count, delta.new_count,
+		                                 delta.changed_count, delta_work_ns);
+	}
+}
+
+template <bool COLLECT_METRICS>
+idx_t RecursiveCTEState::PreaggregateUsingKeyUpdates(GroupedAggregateHashTable &epoch_ht) {
+	idx_t preaggregation_work_ns = 0;
+	ColumnDataScanState update_scan_state;
+	intermediate_table.InitializeScan(update_scan_state);
+	while (intermediate_table.Scan(update_scan_state, update_rows)) {
+		if constexpr (COLLECT_METRICS) {
+			metrics.RecordHashRows(update_rows.size());
+		}
+		const auto hash_start =
+		    COLLECT_METRICS ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point();
+		ExtractUsingKeyKeys(update_rows);
+		if (!executor.expressions.empty()) {
+			payload_rows.Reset();
+			executor.Execute(update_rows, payload_rows);
+		}
+		epoch_ht.AddChunk(distinct_rows, payload_rows, AggregateType::NON_DISTINCT);
+		if constexpr (COLLECT_METRICS) {
+			const auto hash_end = std::chrono::steady_clock::now();
+			preaggregation_work_ns +=
+			    NumericCast<idx_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(hash_end - hash_start).count());
+		}
+	}
+	return preaggregation_work_ns;
+}
+
+template <bool COLLECT_METRICS>
 void RecursiveCTEState::CommitPreaggregatedUsingKeyUpdatesInternal() {
 	D_ASSERT(op.using_key && !op.union_all && key_delta);
 	auto &delta = *key_delta;
@@ -734,27 +1043,7 @@ void RecursiveCTEState::CommitPreaggregatedUsingKeyUpdatesInternal() {
 	}
 
 	auto epoch_ht = CreateUsingKeyHashTable();
-	idx_t preaggregation_work_ns = 0;
-	ColumnDataScanState update_scan_state;
-	intermediate_table.InitializeScan(update_scan_state);
-	while (intermediate_table.Scan(update_scan_state, update_rows)) {
-		if constexpr (COLLECT_METRICS) {
-			metrics.RecordHashRows(update_rows.size());
-		}
-		const auto hash_start =
-		    COLLECT_METRICS ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point();
-		ExtractUsingKeyKeys(update_rows);
-		if (!executor.expressions.empty()) {
-			payload_rows.Reset();
-			executor.Execute(update_rows, payload_rows);
-		}
-		epoch_ht->AddChunk(distinct_rows, payload_rows, AggregateType::NON_DISTINCT);
-		if constexpr (COLLECT_METRICS) {
-			const auto hash_end = std::chrono::steady_clock::now();
-			preaggregation_work_ns +=
-			    NumericCast<idx_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(hash_end - hash_start).count());
-		}
-	}
+	const auto preaggregation_work_ns = PreaggregateUsingKeyUpdates<COLLECT_METRICS>(*epoch_ht);
 	if constexpr (COLLECT_METRICS) {
 		GetEpochMetrics().RecordKeyPreaggregation(delta_candidate_count, epoch_ht->Count(), preaggregation_work_ns);
 	}
@@ -961,6 +1250,22 @@ SinkCombineResultType PhysicalRecursiveCTE::Combine(ExecutionContext &context, O
 		if (!union_all) {
 			auto &lstate = input.local_state.Cast<RecursiveCTELocalState>();
 			D_ASSERT(lstate.output);
+			const auto candidate_count = lstate.output->Count();
+			if (candidate_count >= STANDARD_VECTOR_SIZE && gstate.CurrentInputCount() < candidate_count &&
+			    gstate.CanPreaggregateUsingKey()) {
+				idx_t classification_work_ns = 0;
+				idx_t preaggregation_work_ns = 0;
+				auto local_ht =
+				    lstate.TryPreaggregate(gstate.CurrentInputCount(), classification_work_ns, preaggregation_work_ns);
+				if (local_ht) {
+					gstate.RegisterLocalPreaggregation(std::move(local_ht), candidate_count, classification_work_ns,
+					                                   preaggregation_work_ns);
+					return SinkCombineResultType::FINISHED;
+				}
+				if (gstate.GetMetrics().Enabled()) {
+					gstate.GetEpochMetrics().RecordLocalKeyPreaggregationClassification(classification_work_ns);
+				}
+			}
 			gstate.CombineOutput(*lstate.output);
 		}
 	} else {

--- a/src/execution/operator/set/physical_recursive_cte.cpp
+++ b/src/execution/operator/set/physical_recursive_cte.cpp
@@ -357,8 +357,8 @@ public:
 	RecursiveCTELocalState(ClientContext &context, const PhysicalRecursiveCTE &op)
 	    : hashes(LogicalType::HASH), partition_hashes(LogicalType::HASH), dummy_addresses(LogicalType::POINTER),
 	      new_groups(STANDARD_VECTOR_SIZE) {
-		if (!op.using_key) {
-			output = make_uniq<ColumnDataCollection>(context, op.GetTypes());
+		if (!op.using_key || !op.union_all) {
+			output = make_uniq<ColumnDataCollection>(context, op.using_key ? op.internal_types : op.GetTypes());
 			output->InitializeAppend(append_state);
 		}
 		if (!op.using_key && !op.union_all) {
@@ -939,7 +939,13 @@ SinkResultType PhysicalRecursiveCTE::Sink(ExecutionContext &context, DataChunk &
 		return SinkResultType::NEED_MORE_INPUT;
 	}
 
-	gstate.AppendOutput(chunk);
+	if (union_all) {
+		gstate.AppendOutput(chunk);
+		return SinkResultType::NEED_MORE_INPUT;
+	}
+	auto &lstate = input.local_state.Cast<RecursiveCTELocalState>();
+	D_ASSERT(lstate.output);
+	lstate.output->Append(lstate.append_state, chunk);
 	return SinkResultType::NEED_MORE_INPUT;
 }
 
@@ -950,8 +956,14 @@ void PhysicalRecursiveCTE::PrepareFinalize(ClientContext &context, GlobalSinkSta
 }
 
 SinkCombineResultType PhysicalRecursiveCTE::Combine(ExecutionContext &context, OperatorSinkCombineInput &input) const {
-	if (!using_key) {
-		auto &gstate = input.global_state.Cast<RecursiveCTEState>();
+	auto &gstate = input.global_state.Cast<RecursiveCTEState>();
+	if (using_key) {
+		if (!union_all) {
+			auto &lstate = input.local_state.Cast<RecursiveCTELocalState>();
+			D_ASSERT(lstate.output);
+			gstate.CombineOutput(*lstate.output);
+		}
+	} else {
 		if (union_all && !gstate.UsesLocalUnionAllOutput()) {
 			return SinkCombineResultType::FINISHED;
 		}

--- a/src/execution/operator/set/physical_recursive_cte.cpp
+++ b/src/execution/operator/set/physical_recursive_cte.cpp
@@ -985,6 +985,34 @@ void RecursiveCTEState::CommitUsingKeyUpdatesInternal() {
 }
 
 template <bool COLLECT_METRICS>
+void RecursiveCTEState::ApplyPreaggregatedUsingKeyUpdates(GroupedAggregateHashTable &epoch_ht, idx_t &delta_work_ns) {
+	AggregateHTScanState epoch_scan_state;
+	epoch_ht.InitializeScan(epoch_scan_state);
+	while (epoch_ht.ScanGroups(epoch_scan_state, distinct_rows)) {
+		if (distinct_rows.size() == 0) {
+			continue;
+		}
+		const auto snapshot_start =
+		    COLLECT_METRICS ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point();
+		SnapshotPreaggregatedUsingKeyDeltaGroups(distinct_rows);
+		if constexpr (COLLECT_METRICS) {
+			const auto snapshot_end = std::chrono::steady_clock::now();
+			delta_work_ns += NumericCast<idx_t>(
+			    std::chrono::duration_cast<std::chrono::nanoseconds>(snapshot_end - snapshot_start).count());
+		}
+	}
+
+	const auto combine_start =
+	    COLLECT_METRICS ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point();
+	ht->Combine(epoch_ht);
+	if constexpr (COLLECT_METRICS) {
+		const auto combine_end = std::chrono::steady_clock::now();
+		GetEpochMetrics().RecordKeyPreaggregationCombine(NumericCast<idx_t>(
+		    std::chrono::duration_cast<std::chrono::nanoseconds>(combine_end - combine_start).count()));
+	}
+}
+
+template <bool COLLECT_METRICS>
 void RecursiveCTEState::CommitMixedUsingKeyUpdatesInternal(unique_ptr<GroupedAggregateHashTable> epoch_ht,
                                                            idx_t preaggregated_candidate_count) {
 	D_ASSERT(op.using_key && !op.union_all && key_delta && epoch_ht && preaggregated_candidate_count > 0);
@@ -1037,30 +1065,7 @@ void RecursiveCTEState::CommitMixedUsingKeyUpdatesInternal(unique_ptr<GroupedAgg
 		}
 	}
 
-	AggregateHTScanState epoch_scan_state;
-	epoch_ht->InitializeScan(epoch_scan_state);
-	while (epoch_ht->ScanGroups(epoch_scan_state, distinct_rows)) {
-		if (distinct_rows.size() == 0) {
-			continue;
-		}
-		const auto snapshot_start =
-		    COLLECT_METRICS ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point();
-		SnapshotPreaggregatedUsingKeyDeltaGroups(distinct_rows);
-		if constexpr (COLLECT_METRICS) {
-			const auto snapshot_end = std::chrono::steady_clock::now();
-			delta_work_ns += NumericCast<idx_t>(
-			    std::chrono::duration_cast<std::chrono::nanoseconds>(snapshot_end - snapshot_start).count());
-		}
-	}
-
-	const auto combine_start =
-	    COLLECT_METRICS ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point();
-	ht->Combine(*epoch_ht);
-	if constexpr (COLLECT_METRICS) {
-		const auto combine_end = std::chrono::steady_clock::now();
-		GetEpochMetrics().RecordKeyPreaggregationCombine(NumericCast<idx_t>(
-		    std::chrono::duration_cast<std::chrono::nanoseconds>(combine_end - combine_start).count()));
-	}
+	ApplyPreaggregatedUsingKeyUpdates<COLLECT_METRICS>(*epoch_ht, delta_work_ns);
 
 	const auto finalize_start =
 	    COLLECT_METRICS ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point();
@@ -1126,30 +1131,7 @@ void RecursiveCTEState::CommitPreaggregatedUsingKeyUpdatesInternal() {
 	if constexpr (COLLECT_METRICS) {
 		GetEpochMetrics().RecordKeyPreaggregation(delta_candidate_count, epoch_ht->Count(), preaggregation_work_ns);
 	}
-	AggregateHTScanState epoch_scan_state;
-	epoch_ht->InitializeScan(epoch_scan_state);
-	while (epoch_ht->ScanGroups(epoch_scan_state, distinct_rows)) {
-		if (distinct_rows.size() == 0) {
-			continue;
-		}
-		const auto snapshot_start =
-		    COLLECT_METRICS ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point();
-		SnapshotPreaggregatedUsingKeyDeltaGroups(distinct_rows);
-		if constexpr (COLLECT_METRICS) {
-			const auto snapshot_end = std::chrono::steady_clock::now();
-			delta_work_ns += NumericCast<idx_t>(
-			    std::chrono::duration_cast<std::chrono::nanoseconds>(snapshot_end - snapshot_start).count());
-		}
-	}
-
-	const auto hash_start =
-	    COLLECT_METRICS ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point();
-	ht->Combine(*epoch_ht);
-	if constexpr (COLLECT_METRICS) {
-		const auto hash_end = std::chrono::steady_clock::now();
-		GetEpochMetrics().RecordKeyPreaggregationCombine(
-		    NumericCast<idx_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(hash_end - hash_start).count()));
-	}
+	ApplyPreaggregatedUsingKeyUpdates<COLLECT_METRICS>(*epoch_ht, delta_work_ns);
 
 	const auto finalize_start =
 	    COLLECT_METRICS ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point();

--- a/src/execution/operator/set/physical_recursive_cte_delta.cpp
+++ b/src/execution/operator/set/physical_recursive_cte_delta.cpp
@@ -182,19 +182,20 @@ void RecursiveCTEState::SnapshotExistingUsingKeyDeltaAddresses(Vector &addresses
 }
 
 void RecursiveCTEState::SnapshotUsingKeyDelta(const Vector &group_addresses, const SelectionVector &new_groups,
-                                              idx_t new_group_count, idx_t row_count) {
+                                              idx_t new_group_count, idx_t row_count, bool allow_candidate_reuse) {
 	D_ASSERT(key_delta);
 	auto &delta = *key_delta;
 	const auto candidate_count = intermediate_table.Count();
-	const auto skip_new_group_addresses = can_reuse_new_group_candidates && partial_key_indexes.empty() &&
-	                                      new_group_count == candidate_count && row_count == candidate_count;
+	const auto skip_new_group_addresses = allow_candidate_reuse && can_reuse_new_group_candidates &&
+	                                      partial_key_indexes.empty() && new_group_count == candidate_count &&
+	                                      row_count == candidate_count;
 	if (skip_new_group_addresses) {
 		D_ASSERT(partial_key_indexes.empty() && new_group_count == row_count);
 		delta.new_count += new_group_count;
 		delta.touched_count += new_group_count;
 		return;
 	}
-	if (can_reuse_new_group_candidates) {
+	if (allow_candidate_reuse && can_reuse_new_group_candidates) {
 		delta.new_group_addresses.reserve(candidate_count);
 	}
 
@@ -233,7 +234,7 @@ void RecursiveCTEState::SnapshotUsingKeyDelta(const Vector &group_addresses, con
 
 	auto matched_addresses = FlatVector::GetDataMutable<data_ptr_t>(delta.matched_addresses);
 	idx_t matched_count = 0;
-	if (candidate_count == 1) {
+	if (allow_candidate_reuse && candidate_count == 1) {
 		D_ASSERT(row_count == 1);
 		matched_addresses[matched_count++] = source_addresses[0];
 	} else {
@@ -256,8 +257,8 @@ void RecursiveCTEState::SnapshotUsingKeyDelta(const Vector &group_addresses, con
 	delta.touched_count += matched_count;
 	FlatVector::SetSize(delta.matched_addresses, matched_count);
 	// Keep prior values vector-local while direct candidate reuse remains possible.
-	const auto defer_append = can_reuse_changed_group_candidates && row_count == candidate_count &&
-	                          new_group_count == 0 && matched_count == row_count;
+	const auto defer_append = allow_candidate_reuse && can_reuse_changed_group_candidates &&
+	                          row_count == candidate_count && new_group_count == 0 && matched_count == row_count;
 	SnapshotExistingUsingKeyDeltaAddresses(delta.matched_addresses, matched_count, defer_append);
 }
 
@@ -304,16 +305,15 @@ void RecursiveCTEState::SnapshotPreaggregatedUsingKeyDeltaGroups(DataChunk &keys
 	D_ASSERT(key_delta);
 	auto &delta = *key_delta;
 	delta.PrepareCollections();
-	const auto first_touch_count = keys.size();
-	delta.touched_count += first_touch_count;
-	if (first_touch_count == 0) {
+	const auto group_count = keys.size();
+	if (group_count == 0) {
 		return;
 	}
 	const auto found_count = ht->LookupGroups(keys, delta.lookup_state, delta.found_groups);
 
 	idx_t found_idx = 0;
 	idx_t missing_count = 0;
-	for (idx_t key_idx = 0; key_idx < first_touch_count; key_idx++) {
+	for (idx_t key_idx = 0; key_idx < group_count; key_idx++) {
 		if (found_idx < found_count && delta.found_groups.get_index_unsafe(found_idx) == key_idx) {
 			found_idx++;
 			continue;
@@ -322,10 +322,32 @@ void RecursiveCTEState::SnapshotPreaggregatedUsingKeyDeltaGroups(DataChunk &keys
 	}
 	D_ASSERT(found_idx == found_count);
 	delta.new_count += missing_count;
+	delta.touched_count += missing_count;
 
 	if (found_count > 0) {
-		CopySelectedAddresses(delta.lookup_state.addresses, delta.found_groups, found_count, delta.matched_addresses);
-		SnapshotExistingUsingKeyDeltaAddresses(delta.matched_addresses, found_count);
+		if (!delta.new_group_address_set_built) {
+			delta.new_group_address_set.Reserve(delta.new_group_addresses.size());
+			for (auto address : delta.new_group_addresses) {
+				delta.new_group_address_set.Insert(address);
+			}
+			delta.new_group_address_set_built = true;
+		}
+		delta.lookup_state.addresses.Flatten();
+		auto source_addresses = FlatVector::GetData<data_ptr_t>(delta.lookup_state.addresses);
+		auto matched_addresses = FlatVector::GetDataMutable<data_ptr_t>(delta.matched_addresses);
+		delta.touched_addresses.Reserve(delta.touched_count + found_count);
+		idx_t matched_count = 0;
+		for (idx_t match_idx = 0; match_idx < found_count; match_idx++) {
+			const auto input_idx = delta.found_groups.get_index_unsafe(match_idx);
+			const auto address = source_addresses[input_idx];
+			if (delta.new_group_address_set.Contains(address) || !delta.touched_addresses.Insert(address)) {
+				continue;
+			}
+			matched_addresses[matched_count++] = address;
+		}
+		delta.touched_count += matched_count;
+		FlatVector::SetSize(delta.matched_addresses, matched_count);
+		SnapshotExistingUsingKeyDeltaAddresses(delta.matched_addresses, matched_count);
 	}
 
 	if (missing_count > 0) {

--- a/src/execution/operator/set/physical_recursive_cte_delta.cpp
+++ b/src/execution/operator/set/physical_recursive_cte_delta.cpp
@@ -484,7 +484,7 @@ idx_t RecursiveCTEState::FinalizeUsingKeyDelta(bool update_partial_indexes, bool
 			    collect_metrics ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point();
 			for (auto &index : partial_key_indexes) {
 				index->AddGroups(delta.key_scan_rows, *FlatVector::IncrementalSelectionVector(), group_addresses,
-				                 row_count);
+				                 *FlatVector::IncrementalSelectionVector(), row_count);
 			}
 			if (collect_metrics) {
 				const auto index_end = std::chrono::steady_clock::now();

--- a/src/execution/operator/set/physical_recursive_cte_state.cpp
+++ b/src/execution/operator/set/physical_recursive_cte_state.cpp
@@ -33,12 +33,13 @@ void RecursiveCTEPartialKeyIndex::Resize(idx_t capacity) {
 	}
 }
 
-void RecursiveCTEPartialKeyIndex::AddGroups(DataChunk &full_keys, const SelectionVector &new_groups,
-                                            Vector &new_group_addresses, idx_t new_group_count) {
-	if (new_group_count == 0) {
+void RecursiveCTEPartialKeyIndex::AddGroups(DataChunk &full_keys, const SelectionVector &key_selection,
+                                            Vector &group_addresses, const SelectionVector &address_selection,
+                                            idx_t group_count) {
+	if (group_count == 0) {
 		return;
 	}
-	while (entries.size() + new_group_count > heads.size()) {
+	while (entries.size() + group_count > heads.size()) {
 		Resize(heads.size() * 2);
 	}
 	partial_keys.Reset();
@@ -47,15 +48,15 @@ void RecursiveCTEPartialKeyIndex::AddGroups(DataChunk &full_keys, const Selectio
 	}
 	partial_keys.CheckCardinality(full_keys.size());
 	selected_keys.Reset();
-	selected_keys.Slice(partial_keys, new_groups, new_group_count);
+	selected_keys.Slice(partial_keys, key_selection, group_count);
 	selected_keys.Hash(hashes);
 
 	const auto hash_values = hashes.Values<hash_t>();
-	const auto addresses = FlatVector::GetData<data_ptr_t>(new_group_addresses);
-	for (idx_t new_group_idx = 0; new_group_idx < new_group_count; new_group_idx++) {
-		const auto hash = hash_values[new_group_idx].GetValue();
+	const auto addresses = FlatVector::GetData<data_ptr_t>(group_addresses);
+	for (idx_t group_idx = 0; group_idx < group_count; group_idx++) {
+		const auto hash = hash_values[group_idx].GetValue();
 		const auto bucket = hash & (heads.size() - 1);
-		entries.push_back({hash, addresses[new_group_idx], heads[bucket]});
+		entries.push_back({hash, addresses[address_selection.get_index(group_idx)], heads[bucket]});
 		heads[bucket] = entries.size() - 1;
 	}
 }

--- a/src/execution/operator/set/physical_recursive_cte_state.cpp
+++ b/src/execution/operator/set/physical_recursive_cte_state.cpp
@@ -149,6 +149,22 @@ void RecursiveCTEEpochMetrics::RecordKeyPreaggregationCombine(idx_t elapsed_ns) 
 	key_preaggregation_combine_work_ns.fetch_add(elapsed_ns);
 }
 
+void RecursiveCTEEpochMetrics::RecordLocalKeyPreaggregationClassification(idx_t elapsed_ns) {
+	local_key_preaggregation_classification_work_ns.fetch_add(elapsed_ns);
+}
+
+void RecursiveCTEEpochMetrics::RecordLocalKeyPreaggregation(idx_t candidate_rows, idx_t groups, idx_t elapsed_ns) {
+	D_ASSERT(groups <= candidate_rows);
+	local_key_preaggregation_candidate_rows.fetch_add(candidate_rows);
+	local_key_preaggregation_groups.fetch_add(groups);
+	local_key_preaggregation_states.fetch_add(1);
+	local_key_preaggregation_work_ns.fetch_add(elapsed_ns);
+}
+
+void RecursiveCTEEpochMetrics::RecordLocalKeyPreaggregationResidual(idx_t candidate_rows) {
+	local_key_preaggregation_residual_rows.fetch_add(candidate_rows);
+}
+
 void RecursiveCTEEpochMetrics::RecordPartialIndexMaintenance(idx_t elapsed_ns) {
 	partial_index_maintenance_work_ns.fetch_add(elapsed_ns);
 }
@@ -357,6 +373,15 @@ void RecursiveCTEMetrics::LogEpochSummary(const RecursiveCTEEpochMetrics &epoch_
 	     {"key_preaggregation_combine_work_ns", to_string(epoch_metrics.key_preaggregation_combine_work_ns.load())},
 	     {"key_preaggregation_candidate_rows", to_string(epoch_metrics.key_preaggregation_candidate_rows.load())},
 	     {"key_preaggregation_groups", to_string(epoch_metrics.key_preaggregation_groups.load())},
+	     {"local_key_preaggregation_classification_work_ns",
+	      to_string(epoch_metrics.local_key_preaggregation_classification_work_ns.load())},
+	     {"local_key_preaggregation_work_ns", to_string(epoch_metrics.local_key_preaggregation_work_ns.load())},
+	     {"local_key_preaggregation_candidate_rows",
+	      to_string(epoch_metrics.local_key_preaggregation_candidate_rows.load())},
+	     {"local_key_preaggregation_groups", to_string(epoch_metrics.local_key_preaggregation_groups.load())},
+	     {"local_key_preaggregation_states", to_string(epoch_metrics.local_key_preaggregation_states.load())},
+	     {"local_key_preaggregation_residual_rows",
+	      to_string(epoch_metrics.local_key_preaggregation_residual_rows.load())},
 	     {"partial_index_maintenance_work_ns", to_string(epoch_metrics.partial_index_maintenance_work_ns.load())},
 	     {"key_delta_work_ns", to_string(epoch_metrics.key_delta_work_ns.load())},
 	     {"key_delta_candidate_rows", to_string(epoch_metrics.key_delta_candidate_rows.load())},

--- a/src/include/duckdb/execution/operator/set/physical_recursive_cte_state.hpp
+++ b/src/include/duckdb/execution/operator/set/physical_recursive_cte_state.hpp
@@ -108,6 +108,9 @@ struct RecursiveCTEEpochMetrics {
 	void RecordKeyPreaggregationClassification(idx_t elapsed_ns);
 	void RecordKeyPreaggregation(idx_t candidate_rows, idx_t groups, idx_t elapsed_ns);
 	void RecordKeyPreaggregationCombine(idx_t elapsed_ns);
+	void RecordLocalKeyPreaggregationClassification(idx_t elapsed_ns);
+	void RecordLocalKeyPreaggregation(idx_t candidate_rows, idx_t groups, idx_t elapsed_ns);
+	void RecordLocalKeyPreaggregationResidual(idx_t candidate_rows);
 	void RecordPartialIndexMaintenance(idx_t elapsed_ns);
 	void RecordKeyDelta(idx_t candidate_rows, idx_t touched_keys, idx_t new_keys, idx_t changed_keys, idx_t elapsed_ns);
 	void RecordRecurringScan(idx_t elapsed_ns);
@@ -132,6 +135,12 @@ struct RecursiveCTEEpochMetrics {
 	atomic<idx_t> key_preaggregation_combine_work_ns {0};
 	atomic<idx_t> key_preaggregation_candidate_rows {0};
 	atomic<idx_t> key_preaggregation_groups {0};
+	atomic<idx_t> local_key_preaggregation_classification_work_ns {0};
+	atomic<idx_t> local_key_preaggregation_work_ns {0};
+	atomic<idx_t> local_key_preaggregation_candidate_rows {0};
+	atomic<idx_t> local_key_preaggregation_groups {0};
+	atomic<idx_t> local_key_preaggregation_states {0};
+	atomic<idx_t> local_key_preaggregation_residual_rows {0};
 	atomic<idx_t> partial_index_maintenance_work_ns {0};
 	atomic<idx_t> key_delta_work_ns {0};
 	atomic<idx_t> key_delta_candidate_rows {0};
@@ -242,6 +251,9 @@ public:
 
 	SourceResultType GetData(ExecutionContext &context, DataChunk &chunk);
 	const ColumnDataCollection &CurrentInputTable() const;
+	idx_t CurrentInputCount() const {
+		return CurrentInputTable().Count();
+	}
 	void InitializeSharedOutputAppend();
 	void CommitUsingKeyUpdates();
 	void PromoteDistinctState(ClientContext &context, idx_t partition_count);
@@ -249,6 +261,8 @@ public:
 	const RecursiveCTEPartialKeyIndex &GetPartialKeyIndex(const vector<idx_t> &key_indices) const;
 	void AppendOutput(DataChunk &chunk);
 	void CombineOutput(ColumnDataCollection &output);
+	void RegisterLocalPreaggregation(unique_ptr<GroupedAggregateHashTable> local_ht, idx_t candidate_rows,
+	                                 idx_t classification_work_ns, idx_t preaggregation_work_ns);
 	void SinkSerialDistinct(DataChunk &chunk, RecursiveCTELocalState &local_state);
 	void SinkDistinct(DataChunk &chunk, RecursiveCTELocalState &local_state, bool emit_rows = true,
 	                  bool record_sink_metrics = true);
@@ -299,6 +313,9 @@ public:
 	bool HasMaterializedInvariantPipelines() const {
 		return invariant_meta_pipelines_materialized;
 	}
+	bool CanPreaggregateUsingKey() const {
+		return can_preaggregate_using_key;
+	}
 	void MarkInvariantPipelinesMaterialized() {
 		invariant_meta_pipelines_materialized = true;
 	}
@@ -308,11 +325,16 @@ private:
 	void CommitUsingKeyUpdatesInternal();
 	template <bool COLLECT_METRICS>
 	void CommitPreaggregatedUsingKeyUpdatesInternal();
+	template <bool COLLECT_METRICS>
+	void CommitMixedUsingKeyUpdatesInternal(unique_ptr<GroupedAggregateHashTable> epoch_ht,
+	                                        idx_t preaggregated_candidate_count);
+	template <bool COLLECT_METRICS>
+	idx_t PreaggregateUsingKeyUpdates(GroupedAggregateHashTable &epoch_ht);
 	unique_ptr<GroupedAggregateHashTable> CreateUsingKeyHashTable() const;
 	void ExtractUsingKeyKeys(DataChunk &input);
 	bool ShouldPreaggregateUsingKeyUpdates(idx_t candidate_count);
 	void SnapshotUsingKeyDelta(const Vector &group_addresses, const SelectionVector &new_groups, idx_t new_group_count,
-	                           idx_t row_count);
+	                           idx_t row_count, bool allow_candidate_reuse = true);
 	void SnapshotPreaggregatedUsingKeyDeltaGroups(DataChunk &keys);
 	void SnapshotExistingUsingKeyDeltaAddresses(Vector &addresses, idx_t count, bool defer_append = false);
 	void AppendPreviousUsingKeyDeltaRows(Vector &addresses, idx_t count);
@@ -338,6 +360,8 @@ private:
 	ColumnDataAppendState working_append_state;
 	ColumnDataAppendState recurring_append_state;
 	ColumnDataScanState scan_state;
+	vector<unique_ptr<GroupedAggregateHashTable>> local_preaggregates;
+	idx_t local_preaggregate_candidate_count = 0;
 	RecursiveCTESourcePhase source_phase = RecursiveCTESourcePhase::INITIAL;
 	bool output_is_working = false;
 	//! Cached chunk for distinct key extraction in the using_key Sink path

--- a/src/include/duckdb/execution/operator/set/physical_recursive_cte_state.hpp
+++ b/src/include/duckdb/execution/operator/set/physical_recursive_cte_state.hpp
@@ -43,8 +43,9 @@ public:
 	RecursiveCTEPartialKeyIndex(Allocator &allocator, const vector<LogicalType> &full_key_types,
 	                            vector<idx_t> key_indices);
 
-	void AddGroups(DataChunk &full_keys, const SelectionVector &new_groups, Vector &new_group_addresses,
-	               idx_t new_group_count);
+	//! Key and address selections can differ when addresses have already been compacted.
+	void AddGroups(DataChunk &full_keys, const SelectionVector &key_selection, Vector &group_addresses,
+	               const SelectionVector &address_selection, idx_t group_count);
 	idx_t GetHead(hash_t hash) const;
 	const Entry &GetEntry(idx_t entry_idx) const;
 	idx_t Count() const;

--- a/src/include/duckdb/execution/operator/set/physical_recursive_cte_state.hpp
+++ b/src/include/duckdb/execution/operator/set/physical_recursive_cte_state.hpp
@@ -330,6 +330,8 @@ private:
 	void CommitMixedUsingKeyUpdatesInternal(unique_ptr<GroupedAggregateHashTable> epoch_ht,
 	                                        idx_t preaggregated_candidate_count);
 	template <bool COLLECT_METRICS>
+	void ApplyPreaggregatedUsingKeyUpdates(GroupedAggregateHashTable &epoch_ht, idx_t &delta_work_ns);
+	template <bool COLLECT_METRICS>
 	idx_t PreaggregateUsingKeyUpdates(GroupedAggregateHashTable &epoch_ht);
 	unique_ptr<GroupedAggregateHashTable> CreateUsingKeyHashTable() const;
 	void ExtractUsingKeyKeys(DataChunk &input);

--- a/test/configs/force_storage_restart.json
+++ b/test/configs/force_storage_restart.json
@@ -48,6 +48,7 @@
         "test/sql/logging/physical_operator_logging.test_slow",
         "test/sql/cte/recursive_cte_logging.test",
         "test/sql/cte/recursive_cte_invariant_build_logging.test",
+        "test/sql/cte/recursive_cte_parallel_output_publication.test",
         "test/logging/warnings_as_errors.test",
         "test/logging/offset_order_warning.test",
         "test/sql/copy/parquet/multi_file/adaptive_filter_carryover.test",

--- a/test/sql/cte/recursive_cte_key_union.test
+++ b/test/sql/cte/recursive_cte_key_union.test
@@ -231,6 +231,22 @@ SELECT count(*), min(lo) FROM t;
 ----
 1	0
 
+# Preaggregated groups may be new, changed, or unchanged when combined into recurring state.
+query II rowsort
+WITH RECURSIVE t(k, v) USING KEY (k, min(v)) AS (
+	VALUES (1, 10), (2, 10)
+	UNION
+	SELECT CASE WHEN i % 4 = 0 THEN 3 ELSE k END,
+	       CASE WHEN i % 4 = 0 THEN 7 WHEN k = 1 THEN 5 ELSE 11 END
+	FROM t, range(current_setting('standard_vector_size')::BIGINT * 4) r(i)
+	WHERE v = 10
+)
+TABLE t;
+----
+1	5
+2	10
+3	7
+
 # Address tracking is cleared between wide and narrow epochs without retaining stale groups.
 query III
 WITH RECURSIVE t(k, v) USING KEY (k) AS (
@@ -646,7 +662,7 @@ SELECT count(*), min(lower(label)), min(v) FROM t;
 ----
 1	a	0
 
-# Preaggregation and partial-key probes share stable recurring group addresses.
+# Preaggregation keeps partial-key hashes aligned with reordered recurring group addresses.
 query III
 WITH RECURSIVE t(k1, k2, v) USING KEY (k1, k2, min(v)) AS (
 	SELECT i, i % 4, 2

--- a/test/sql/cte/recursive_cte_logging.test
+++ b/test/sql/cte/recursive_cte_logging.test
@@ -663,7 +663,12 @@ CALL enable_logging('PhysicalOperator');
 statement ok
 CALL truncate_duckdb_logs();
 
-# Duplicate-heavy epochs activate preaggregation.
+# Duplicate-heavy epochs activate preaggregation after streaming at most the current frontier.
+# The bounded classifier can stream multiple sample batches, so validate the attribution invariant rather than an
+# exact local-versus-residual split that depends on vector layout.
+statement ok
+SET threads=1;
+
 query II
 WITH RECURSIVE t(k, v) USING KEY (k, min(v)) AS (
 	SELECT i, 3
@@ -679,17 +684,18 @@ statement ok
 CALL disable_logging();
 
 query IIIIIIIIIIIII
-SELECT info.key_preaggregation_classification_work_ns::UBIGINT = 0,
-	   info.key_preaggregation_work_ns::UBIGINT = 0,
+SELECT info.key_preaggregation_classification_work_ns::UBIGINT > 0,
 	   info.key_preaggregation_combine_work_ns::UBIGINT > 0,
-	   info.key_preaggregation_candidate_rows::UBIGINT = 0,
-	   info.key_preaggregation_groups::UBIGINT = 0,
 	   info.local_key_preaggregation_classification_work_ns::UBIGINT > 0,
 	   info.local_key_preaggregation_work_ns::UBIGINT > 0,
-	   info.local_key_preaggregation_candidate_rows::UBIGINT = current_setting('standard_vector_size')::UBIGINT * 32,
-	   info.local_key_preaggregation_groups::UBIGINT = current_setting('standard_vector_size')::UBIGINT * 4,
+	   info.local_key_preaggregation_candidate_rows::UBIGINT > 0,
+	   info.local_key_preaggregation_groups::UBIGINT > 0,
+	   info.local_key_preaggregation_groups::UBIGINT <= info.local_key_preaggregation_candidate_rows::UBIGINT,
 	   info.local_key_preaggregation_states::UBIGINT > 0,
-	   info.local_key_preaggregation_residual_rows::UBIGINT = 0,
+	   info.local_key_preaggregation_residual_rows::UBIGINT > 0,
+	   info.local_key_preaggregation_candidate_rows::UBIGINT +
+	       info.local_key_preaggregation_residual_rows::UBIGINT = info.key_delta_candidate_rows::UBIGINT,
+	   info.key_preaggregation_candidate_rows::UBIGINT <= info.local_key_preaggregation_residual_rows::UBIGINT,
 	   info.key_delta_candidate_rows::UBIGINT = current_setting('standard_vector_size')::UBIGINT * 32,
 	   info.key_delta_touched_keys::UBIGINT = current_setting('standard_vector_size')::UBIGINT * 4
 FROM duckdb_logs_parsed('PhysicalOperator')
@@ -698,12 +704,16 @@ WHERE class = 'PhysicalRecursiveCTE' AND event = 'EpochSummary';
 1	1	1	1	1	1	1	1	1	1	1	1	1
 
 statement ok
+SET threads=8;
+
+statement ok
 CALL enable_logging('PhysicalOperator');
 
 statement ok
 CALL truncate_duckdb_logs();
 
-# Preaggregated worker output and a raw residual preserve one pre-epoch delta snapshot.
+# Preaggregated worker output and a raw residual preserve one pre-epoch delta snapshot. The classifier's streamed
+# sample is part of the residual, so the exact split depends on vector layout.
 query II
 WITH RECURSIVE t(k, v) USING KEY (k, min(v)) AS (
 	(
@@ -725,14 +735,16 @@ SELECT count(*) = current_setting('standard_vector_size')::BIGINT + 1, max(v) FR
 statement ok
 CALL disable_logging();
 
-query IIIIIIIII
-SELECT info.local_key_preaggregation_candidate_rows::UBIGINT =
-	       current_setting('standard_vector_size')::UBIGINT * 32,
+query IIIIIIIIII
+SELECT info.local_key_preaggregation_candidate_rows::UBIGINT > 0,
 	   info.local_key_preaggregation_groups::UBIGINT > 0,
 	   info.local_key_preaggregation_groups::UBIGINT <
 	       info.local_key_preaggregation_candidate_rows::UBIGINT / 4,
 	   info.local_key_preaggregation_states::UBIGINT > 0,
-	   info.local_key_preaggregation_residual_rows::UBIGINT = 1,
+	   info.local_key_preaggregation_residual_rows::UBIGINT > 0,
+	   info.local_key_preaggregation_candidate_rows::UBIGINT +
+	       info.local_key_preaggregation_residual_rows::UBIGINT =
+	       current_setting('standard_vector_size')::UBIGINT * 32 + 1,
 	   info.key_delta_candidate_rows::UBIGINT =
 	       current_setting('standard_vector_size')::UBIGINT * 32 +
 	       (current_setting('standard_vector_size')::UBIGINT + 1) * 2 + 1,
@@ -742,7 +754,7 @@ SELECT info.local_key_preaggregation_candidate_rows::UBIGINT =
 FROM duckdb_logs_parsed('PhysicalOperator')
 WHERE class = 'PhysicalRecursiveCTE' AND event = 'EpochSummary';
 ----
-1	1	1	1	1	1	1	1	1
+1	1	1	1	1	1	1	1	1	1
 
 statement ok
 CALL enable_logging('PhysicalOperator');

--- a/test/sql/cte/recursive_cte_logging.test
+++ b/test/sql/cte/recursive_cte_logging.test
@@ -636,7 +636,7 @@ TABLE t;
 statement ok
 CALL disable_logging();
 
-query IIIIIIIIII
+query IIIIIIIIIIIIIII
 SELECT info.key_delta_work_ns::UBIGINT > 0,
        info.key_delta_candidate_rows::UBIGINT = 5,
        info.key_delta_touched_keys::UBIGINT = 4,
@@ -646,11 +646,16 @@ SELECT info.key_delta_work_ns::UBIGINT > 0,
 	   info.key_preaggregation_work_ns::UBIGINT = 0,
 	   info.key_preaggregation_combine_work_ns::UBIGINT = 0,
 	   info.key_preaggregation_candidate_rows::UBIGINT = 0,
-	   info.key_preaggregation_groups::UBIGINT = 0
+	   info.key_preaggregation_groups::UBIGINT = 0,
+	   info.local_key_preaggregation_work_ns::UBIGINT = 0,
+	   info.local_key_preaggregation_candidate_rows::UBIGINT = 0,
+	   info.local_key_preaggregation_groups::UBIGINT = 0,
+	   info.local_key_preaggregation_states::UBIGINT = 0,
+	   info.local_key_preaggregation_residual_rows::UBIGINT = 0
 FROM duckdb_logs_parsed('PhysicalOperator')
 WHERE class = 'PhysicalRecursiveCTE' AND event = 'EpochSummary';
 ----
-1	1	1	1	1	1	1	1	1	1
+1	1	1	1	1	1	1	1	1	1	1	1	1	1	1
 
 statement ok
 CALL enable_logging('PhysicalOperator');
@@ -673,18 +678,71 @@ SELECT count(*) = current_setting('standard_vector_size')::BIGINT, max(v) FROM t
 statement ok
 CALL disable_logging();
 
-query IIIIIII
-SELECT info.key_preaggregation_classification_work_ns::UBIGINT > 0,
-	   info.key_preaggregation_work_ns::UBIGINT > 0,
+query IIIIIIIIIIIII
+SELECT info.key_preaggregation_classification_work_ns::UBIGINT = 0,
+	   info.key_preaggregation_work_ns::UBIGINT = 0,
 	   info.key_preaggregation_combine_work_ns::UBIGINT > 0,
-	   info.key_preaggregation_candidate_rows::UBIGINT = current_setting('standard_vector_size')::UBIGINT * 32,
-	   info.key_preaggregation_groups::UBIGINT = current_setting('standard_vector_size')::UBIGINT * 4,
+	   info.key_preaggregation_candidate_rows::UBIGINT = 0,
+	   info.key_preaggregation_groups::UBIGINT = 0,
+	   info.local_key_preaggregation_classification_work_ns::UBIGINT > 0,
+	   info.local_key_preaggregation_work_ns::UBIGINT > 0,
+	   info.local_key_preaggregation_candidate_rows::UBIGINT = current_setting('standard_vector_size')::UBIGINT * 32,
+	   info.local_key_preaggregation_groups::UBIGINT = current_setting('standard_vector_size')::UBIGINT * 4,
+	   info.local_key_preaggregation_states::UBIGINT > 0,
+	   info.local_key_preaggregation_residual_rows::UBIGINT = 0,
 	   info.key_delta_candidate_rows::UBIGINT = current_setting('standard_vector_size')::UBIGINT * 32,
 	   info.key_delta_touched_keys::UBIGINT = current_setting('standard_vector_size')::UBIGINT * 4
 FROM duckdb_logs_parsed('PhysicalOperator')
 WHERE class = 'PhysicalRecursiveCTE' AND event = 'EpochSummary';
 ----
-1	1	1	1	1	1	1
+1	1	1	1	1	1	1	1	1	1	1	1	1
+
+statement ok
+CALL enable_logging('PhysicalOperator');
+
+statement ok
+CALL truncate_duckdb_logs();
+
+# Preaggregated worker output and a raw residual preserve one pre-epoch delta snapshot.
+query II
+WITH RECURSIVE t(k, v) USING KEY (k, min(v)) AS (
+	(
+		SELECT i, 2
+		FROM range(current_setting('standard_vector_size')::BIGINT) r(i), range(32) duplicates(_)
+	)
+	UNION ALL
+	(
+		SELECT current_setting('standard_vector_size')::BIGINT + i, 2
+		FROM range(1) r(i)
+	)
+	UNION
+	SELECT k, v - 1 FROM t WHERE v > 0
+)
+SELECT count(*) = current_setting('standard_vector_size')::BIGINT + 1, max(v) FROM t;
+----
+1	0
+
+statement ok
+CALL disable_logging();
+
+query IIIIIIIII
+SELECT info.local_key_preaggregation_candidate_rows::UBIGINT =
+	       current_setting('standard_vector_size')::UBIGINT * 32,
+	   info.local_key_preaggregation_groups::UBIGINT > 0,
+	   info.local_key_preaggregation_groups::UBIGINT <
+	       info.local_key_preaggregation_candidate_rows::UBIGINT / 4,
+	   info.local_key_preaggregation_states::UBIGINT > 0,
+	   info.local_key_preaggregation_residual_rows::UBIGINT = 1,
+	   info.key_delta_candidate_rows::UBIGINT =
+	       current_setting('standard_vector_size')::UBIGINT * 32 +
+	       (current_setting('standard_vector_size')::UBIGINT + 1) * 2 + 1,
+	   info.key_delta_touched_keys::UBIGINT = (current_setting('standard_vector_size')::UBIGINT + 1) * 3,
+	   info.key_delta_new_keys::UBIGINT = current_setting('standard_vector_size')::UBIGINT + 1,
+	   info.key_delta_changed_keys::UBIGINT = (current_setting('standard_vector_size')::UBIGINT + 1) * 2
+FROM duckdb_logs_parsed('PhysicalOperator')
+WHERE class = 'PhysicalRecursiveCTE' AND event = 'EpochSummary';
+----
+1	1	1	1	1	1	1	1	1
 
 statement ok
 CALL enable_logging('PhysicalOperator');
@@ -706,13 +764,19 @@ TABLE t;
 statement ok
 CALL disable_logging();
 
-query IIIII
+query IIIIIIIIIII
 SELECT info.keyed_hash_commit_work_ns::UBIGINT > 0,
        info.key_preaggregation_work_ns::UBIGINT = 0,
        info.key_preaggregation_combine_work_ns::UBIGINT = 0,
        info.key_preaggregation_candidate_rows::UBIGINT = 0,
-       info.key_preaggregation_groups::UBIGINT = 0
+       info.key_preaggregation_groups::UBIGINT = 0,
+	   info.local_key_preaggregation_classification_work_ns::UBIGINT = 0,
+	   info.local_key_preaggregation_work_ns::UBIGINT = 0,
+	   info.local_key_preaggregation_candidate_rows::UBIGINT = 0,
+	   info.local_key_preaggregation_groups::UBIGINT = 0,
+	   info.local_key_preaggregation_states::UBIGINT = 0,
+	   info.local_key_preaggregation_residual_rows::UBIGINT = 0
 FROM duckdb_logs_parsed('PhysicalOperator')
 WHERE class = 'PhysicalRecursiveCTE' AND event = 'EpochSummary';
 ----
-1	1	1	1	1
+1	1	1	1	1	1	1	1	1	1	1

--- a/test/sql/cte/recursive_cte_parallel_output_publication.test
+++ b/test/sql/cte/recursive_cte_parallel_output_publication.test
@@ -1,5 +1,5 @@
 # name: test/sql/cte/recursive_cte_parallel_output_publication.test
-# description: Parallel recursive workers publish private output without binding a shared append state
+# description: Parallel correlated recursive workers publish private output without binding a shared append state
 # group: [cte]
 
 require vector_size 2048
@@ -10,19 +10,39 @@ SET threads=2;
 statement ok
 SET max_execution_time=10000;
 
-# Keep the real parallel correlated shape while bounding the number of candidate obstacles.
 statement ok
-SET VARIABLE aoc_sql = (
-	SELECT replace(
-		content,
-		'candidates(vx,vy) as (select * from part1pos, startpos where vx<>x or vy<>y)',
-		'candidate_pool(vx,vy) as (select * from part1pos, startpos where vx<>x or vy<>y), ' ||
-		'candidates(vx,vy) as (select * from candidate_pool order by vx, vy limit 3072)'
-	)
-	FROM read_text('benchmark/aoc24/queries/day06.sql')
-);
+CALL enable_logging('PhysicalOperator');
+
+statement ok
+CALL truncate_duckdb_logs();
 
 query II
-SELECT * FROM query(getvariable('aoc_sql'));
+WITH candidates AS MATERIALIZED (
+	SELECT i FROM range(8192) r(i)
+)
+SELECT count(*), sum(i)
+FROM candidates c
+WHERE EXISTS (
+	WITH RECURSIVE t(v) AS (
+		VALUES (0)
+		UNION ALL
+		SELECT v + 1 FROM t WHERE v < c.i % 4
+	)
+	SELECT 1 FROM t WHERE v = c.i % 4
+);
 ----
-5131	1154
+8192	33550336
+
+statement ok
+CALL disable_logging();
+
+# Multiple workers must actually publish local recursive output for this to cover the append-state path.
+query I
+SELECT count(*)
+FROM duckdb_logs_parsed('PhysicalOperator')
+WHERE class = 'PhysicalRecursiveCTE' AND event = 'RuntimeMetrics'
+  AND info.epochs::UBIGINT = 4
+  AND info.scheduled_workers::UBIGINT > info.epochs::UBIGINT
+  AND info.scheduled_tasks::UBIGINT >= info.scheduled_workers::UBIGINT;
+----
+1

--- a/test/sql/cte/recursive_cte_parallel_output_publication.test
+++ b/test/sql/cte/recursive_cte_parallel_output_publication.test
@@ -1,0 +1,28 @@
+# name: test/sql/cte/recursive_cte_parallel_output_publication.test
+# description: Parallel recursive workers publish private output without binding a shared append state
+# group: [cte]
+
+require vector_size 2048
+
+statement ok
+SET threads=2;
+
+statement ok
+SET max_execution_time=10000;
+
+# Keep the real parallel correlated shape while bounding the number of candidate obstacles.
+statement ok
+SET VARIABLE aoc_sql = (
+	SELECT replace(
+		content,
+		'candidates(vx,vy) as (select * from part1pos, startpos where vx<>x or vy<>y)',
+		'candidate_pool(vx,vy) as (select * from part1pos, startpos where vx<>x or vy<>y), ' ||
+		'candidates(vx,vy) as (select * from candidate_pool order by vx, vy limit 3072)'
+	)
+	FROM read_text('benchmark/aoc24/queries/day06.sql')
+);
+
+query II
+SELECT * FROM query(getvariable('aoc_sql'));
+----
+5131	1154


### PR DESCRIPTION
While profiling the changed-key implementation from #24647 on the public LDBC SF100 pathfinding workload, I found that duplicate-heavy recursive epochs still paid two avoidable costs before reaching the recurring hash table. Parallel workers published candidate chunks through a shared append lock, and redundant updates were only collapsed after all of that output had been materialized globally.

This is a follow-up to #24647. It keeps the keyed `UNION` semantics from that PR and changes only how eligible candidate streams are published and preaggregated.

In short, this PR:

- buffers keyed `UNION` output per worker and publishes it once instead of taking the shared append lock for every chunk;
- adaptively preaggregates duplicate-heavy worker output before it reaches the recurring hash table;
- combines worker-local aggregate states with any raw residual candidates against the same pre-epoch delta; and
- adds structured metrics for classification, worker-local preaggregation, residual rows, and combine work.

Each keyed `UNION` sink starts by buffering its output locally. Once it has enough rows to justify classification, it carries a HyperLogLog sketch across a bounded number of vectors. It selects worker-local preaggregation only when the sketch's conservative distinct-count upper bound shows substantial fan-in. Tiny, non-expanding, and locally unique streams remain as raw candidates, and sampling stops after a bounded budget when the stream stays unique.

Preaggregation is restricted to payload aggregates that have a combine callback and are explicitly not order-dependent. Selected workers build private keyed aggregate hash tables. At the epoch boundary, the recursive operator combines those states and applies any raw residual candidates through the existing generic changed-key path. This preserves aggregate allocator ownership, the first-touch snapshot boundary, and the finalized SQL-visible result. Order-dependent and non-combinable aggregates retain the raw path.

The buffering change also keeps publication semantics deliberately narrow. `USING KEY ... UNION ALL` continues to forward every candidate, including duplicates, and ordinary recursive CTEs retain their existing output path. The output-publication tests cover keyed `UNION`, keyed `UNION ALL`, and ordinary recursive CTEs under parallel execution.