### PR TITLE
Preserve projection maps during column pruning

### DIFF
--- a/src/include/duckdb/optimizer/remove_unused_columns.hpp
+++ b/src/include/duckdb/optimizer/remove_unused_columns.hpp
@@ -164,8 +164,8 @@ private:
 	                                 unordered_set<ProjectionIndex> &recursive_dependencies);
 	bool ComputeRecursiveRequiredColumns(LogicalRecursiveCTE &rec, unordered_set<ProjectionIndex> &required_columns);
 	void ApplyRecursiveProjections(LogicalRecursiveCTE &rec, const unordered_set<ProjectionIndex> &required_columns);
-	void RewriteRecursiveCTEReferences(LogicalRecursiveCTE &rec,
-	                                   const unordered_set<ProjectionIndex> &required_columns);
+	vector<ReplacementBinding> RewriteRecursiveCTEReferences(LogicalRecursiveCTE &rec,
+	                                                         const unordered_set<ProjectionIndex> &required_columns);
 	bool TryPruneRecursiveCTE(LogicalRecursiveCTE &rec);
 	void VisitPrunableChildren(LogicalOperator &op);
 	void WritePushdownExtractColumns(

--- a/src/include/duckdb/optimizer/remove_unused_columns.hpp
+++ b/src/include/duckdb/optimizer/remove_unused_columns.hpp
@@ -150,6 +150,7 @@ private:
 
 	RemoveUnusedColumns &root;
 	unique_ptr<unordered_map<TableIndex, MaterializedCTEInfo>> root_cte_map;
+	column_binding_map_t<vector<ColumnBinding>> projection_map_replacements;
 
 private:
 	template <class T>
@@ -166,6 +167,7 @@ private:
 	void RewriteRecursiveCTEReferences(LogicalRecursiveCTE &rec,
 	                                   const unordered_set<ProjectionIndex> &required_columns);
 	bool TryPruneRecursiveCTE(LogicalRecursiveCTE &rec);
+	void VisitPrunableChildren(LogicalOperator &op);
 	void WritePushdownExtractColumns(
 	    ReferencedColumn &col,
 	    const std::function<ProjectionIndex(const ColumnIndex &new_index, optional_ptr<const LogicalType> cast_type)>
@@ -183,6 +185,7 @@ public:
 private:
 	const TableIndex cte_index;
 	const unordered_set<ProjectionIndex> &referenced_columns;
+	column_binding_map_t<vector<ColumnBinding>> projection_map_replacements;
 
 public:
 	vector<ReplacementBinding> binding_replacements;

--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -31,6 +31,7 @@
 #include "duckdb/optimizer/filter_pushdown.hpp"
 #include "duckdb/optimizer/optimizer.hpp"
 #include "duckdb/planner/logical_operator_repeatability.hpp"
+#include "duckdb/planner/subquery/column_binding_layout.hpp"
 #include <utility>
 
 namespace duckdb {
@@ -162,6 +163,9 @@ void RemoveUnusedColumns::RewriteRecursiveCTEReferences(LogicalRecursiveCTE &rec
 	D_ASSERT(mode == RemoveUnusedColumnsMode::APPLY);
 	CTERefPruner cte_ref_pruner(rec.table_index, required_columns);
 	cte_ref_pruner.VisitOperator(*rec.children[1]);
+	for (auto &replacement : cte_ref_pruner.binding_replacements) {
+		root.projection_map_replacements[replacement.old_binding] = {replacement.new_binding};
+	}
 	ColumnBindingReplacer column_binding_replacer;
 	column_binding_replacer.replacement_bindings = std::move(cte_ref_pruner.binding_replacements);
 	column_binding_replacer.VisitOperator(*rec.children[1]);
@@ -241,11 +245,98 @@ void RemoveUnusedColumns::ClearUnusedExpressions(vector<T> &list, TableIndex tab
 		}
 		if (should_replace) {
 			// column is used but the ColumnBinding has changed because of removed columns
-			auto created_bindings =
-			    ReplaceBinding(current_binding, ColumnBinding(table_idx, ProjectionIndex(new_col_idx)));
+			auto new_binding = ColumnBinding(table_idx, ProjectionIndex(new_col_idx));
+			auto created_bindings = ReplaceBinding(current_binding, new_binding);
+			auto &map_replacements = root.projection_map_replacements[current_binding];
+			map_replacements.clear();
+			for (idx_t binding_idx = 0; binding_idx < created_bindings; binding_idx++) {
+				map_replacements.emplace_back(table_idx, ProjectionIndex(new_col_idx + binding_idx));
+			}
 			new_col_idx += created_bindings;
 		} else {
 			new_col_idx++;
+		}
+	}
+}
+
+enum class ProjectionBindingResolution : uint8_t { SELECTED, REPLACEMENT };
+
+static void ResolveProjectionBindings(ColumnBinding binding, const column_binding_set_t &new_bindings,
+                                      const column_binding_map_t<vector<ColumnBinding>> &replacements,
+                                      column_binding_set_t &active_bindings, vector<ColumnBinding> &resolved_bindings,
+                                      ProjectionBindingResolution resolution) {
+	if (resolution == ProjectionBindingResolution::REPLACEMENT && new_bindings.find(binding) != new_bindings.end()) {
+		resolved_bindings.push_back(binding);
+		return;
+	}
+	auto replacement = replacements.find(binding);
+	if (replacement != replacements.end()) {
+		if (!active_bindings.insert(binding).second) {
+			throw InternalException("Cyclic column pruning replacement for %s", binding.ToString());
+		}
+		for (auto &new_binding : replacement->second) {
+			if (new_binding == binding) {
+				if (new_bindings.find(new_binding) != new_bindings.end()) {
+					resolved_bindings.push_back(new_binding);
+				}
+			} else {
+				ResolveProjectionBindings(new_binding, new_bindings, replacements, active_bindings, resolved_bindings,
+				                          ProjectionBindingResolution::REPLACEMENT);
+			}
+		}
+		active_bindings.erase(binding);
+		return;
+	}
+	if (new_bindings.find(binding) != new_bindings.end()) {
+		resolved_bindings.push_back(binding);
+	}
+}
+
+static void RemapPrunedProjectionMap(LogicalOperator &op, idx_t child_index,
+                                     const vector<ColumnBinding> &old_child_bindings,
+                                     const column_binding_map_t<vector<ColumnBinding>> &replacements) {
+	auto projection_map = LogicalOperatorVisitor::GetProjectionMap(op, child_index);
+	D_ASSERT(projection_map);
+	vector<ColumnBinding> selected_bindings;
+	if (projection_map->empty()) {
+		selected_bindings = old_child_bindings;
+	} else {
+		selected_bindings.reserve(projection_map->size());
+		for (auto projection_index : *projection_map) {
+			if (projection_index.GetIndex() >= old_child_bindings.size()) {
+				throw InternalException("Projection map references a missing child column");
+			}
+			selected_bindings.push_back(old_child_bindings[projection_index.GetIndex()]);
+		}
+	}
+
+	auto new_child_bindings = op.children[child_index]->GetColumnBindings();
+	column_binding_set_t new_binding_set(new_child_bindings.begin(), new_child_bindings.end());
+	vector<ColumnBinding> rewritten_bindings;
+	for (auto &binding : selected_bindings) {
+		column_binding_set_t active_bindings;
+		ResolveProjectionBindings(binding, new_binding_set, replacements, active_bindings, rewritten_bindings,
+		                          ProjectionBindingResolution::SELECTED);
+	}
+	if (rewritten_bindings.empty()) {
+		if (new_child_bindings.size() > 1) {
+			*projection_map = {ProjectionIndex(0)};
+		} else {
+			projection_map->clear();
+		}
+	} else if (rewritten_bindings == new_child_bindings) {
+		projection_map->clear();
+	} else {
+		*projection_map = ColumnBindingLayout(new_child_bindings).CreateProjectionMap(rewritten_bindings);
+	}
+}
+
+void RemoveUnusedColumns::VisitPrunableChildren(LogicalOperator &op) {
+	for (idx_t child_index = 0; child_index < op.children.size(); child_index++) {
+		auto old_child_bindings = op.children[child_index]->GetColumnBindings();
+		VisitOperator(op.children[child_index]);
+		if (op.HasProjectionMap()) {
+			RemapPrunedProjectionMap(op, child_index, old_child_bindings, root.projection_map_replacements);
 		}
 	}
 }
@@ -635,6 +726,9 @@ void RemoveUnusedColumns::VisitOperator(unique_ptr<LogicalOperator> &op_ref) {
 			// removed columns.
 			CTERefPruner cte_ref_pruner(cte.table_index, referenced_columns_in_rhs);
 			cte_ref_pruner.VisitOperator(*cte.children[1]);
+			for (auto &replacement : cte_ref_pruner.binding_replacements) {
+				root.projection_map_replacements[replacement.old_binding] = {replacement.new_binding};
+			}
 
 			// We also need to rewrite the column bindings in the right-hand side of the CTE to account for the removed
 			// columns on the left-hand side. Conveniently, the CTERefPruner already has the information about which
@@ -684,7 +778,7 @@ void RemoveUnusedColumns::VisitOperator(unique_ptr<LogicalOperator> &op_ref) {
 		break;
 	}
 	LogicalOperatorVisitor::VisitOperatorExpressions(op);
-	LogicalOperatorVisitor::VisitOperatorChildren(op);
+	VisitPrunableChildren(op);
 
 	if (!analyze &&
 	    (op.type == LogicalOperatorType::LOGICAL_ASOF_JOIN || op.type == LogicalOperatorType::LOGICAL_DELIM_JOIN ||
@@ -1184,6 +1278,7 @@ void CTERefPruner::VisitOperator(LogicalOperator &op) {
 					ColumnBinding source_binding(cte_ref.table_index, ProjectionIndex(i));
 					ColumnBinding target_binding(cte_ref.table_index, ProjectionIndex(i - skipped));
 					binding_replacements.push_back(ReplacementBinding(source_binding, target_binding));
+					projection_map_replacements[source_binding] = {target_binding};
 				}
 			} else {
 				skipped++;
@@ -1192,7 +1287,14 @@ void CTERefPruner::VisitOperator(LogicalOperator &op) {
 		cte_ref.types = std::move(types);
 		cte_ref.chunk_types = cte_ref.types;
 	}
-	LogicalOperatorVisitor::VisitOperator(op);
+	for (idx_t child_index = 0; child_index < op.children.size(); child_index++) {
+		auto old_child_bindings = op.children[child_index]->GetColumnBindings();
+		VisitOperator(*op.children[child_index]);
+		if (op.HasProjectionMap()) {
+			RemapPrunedProjectionMap(op, child_index, old_child_bindings, projection_map_replacements);
+		}
+	}
+	VisitOperatorExpressions(op);
 }
 
 void BaseColumnPruner::SetMode(BaseColumnPrunerMode mode) {

--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -228,6 +228,9 @@ void RemoveUnusedColumns::ClearUnusedExpressions(vector<T> &list, TableIndex tab
 		auto current_binding = ColumnBinding(table_idx, ProjectionIndex(col_idx + offset));
 		auto entry = column_references.find(current_binding);
 		if (entry == column_references.end()) {
+			if (replace) {
+				root.projection_map_replacements[current_binding].clear();
+			}
 			// this entry is not referred to, erase it from the set of expressions
 			list.erase_at(col_idx);
 			offset++;
@@ -1284,6 +1287,7 @@ void CTERefPruner::VisitOperator(LogicalOperator &op) {
 					projection_map_replacements[source_binding] = {target_binding};
 				}
 			} else {
+				projection_map_replacements[ColumnBinding(cte_ref.table_index, ProjectionIndex(i))].clear();
 				skipped++;
 			}
 		}

--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -158,17 +158,17 @@ void RemoveUnusedColumns::ApplyRecursiveProjections(LogicalRecursiveCTE &rec,
 	rec.column_count = entries.size();
 }
 
-void RemoveUnusedColumns::RewriteRecursiveCTEReferences(LogicalRecursiveCTE &rec,
-                                                        const unordered_set<ProjectionIndex> &required_columns) {
+vector<ReplacementBinding>
+RemoveUnusedColumns::RewriteRecursiveCTEReferences(LogicalRecursiveCTE &rec,
+                                                   const unordered_set<ProjectionIndex> &required_columns) {
 	D_ASSERT(mode == RemoveUnusedColumnsMode::APPLY);
 	CTERefPruner cte_ref_pruner(rec.table_index, required_columns);
 	cte_ref_pruner.VisitOperator(*rec.children[1]);
-	for (auto &replacement : cte_ref_pruner.binding_replacements) {
-		root.projection_map_replacements[replacement.old_binding] = {replacement.new_binding};
-	}
+	auto binding_replacements = std::move(cte_ref_pruner.binding_replacements);
 	ColumnBindingReplacer column_binding_replacer;
-	column_binding_replacer.replacement_bindings = std::move(cte_ref_pruner.binding_replacements);
+	column_binding_replacer.replacement_bindings = binding_replacements;
 	column_binding_replacer.VisitOperator(*rec.children[1]);
+	return binding_replacements;
 }
 
 bool RemoveUnusedColumns::TryPruneRecursiveCTE(LogicalRecursiveCTE &rec) {
@@ -183,10 +183,13 @@ bool RemoveUnusedColumns::TryPruneRecursiveCTE(LogicalRecursiveCTE &rec) {
 		return false;
 	}
 	ApplyRecursiveProjections(rec, required_columns);
-	RewriteRecursiveCTEReferences(rec, required_columns);
+	auto reference_replacements = RewriteRecursiveCTEReferences(rec, required_columns);
 	for (auto &child : rec.children) {
 		RemoveUnusedColumns remove(*this, true);
 		remove.VisitOperator(child);
+	}
+	for (auto &replacement : reference_replacements) {
+		root.projection_map_replacements[replacement.old_binding] = {replacement.new_binding};
 	}
 	return true;
 }

--- a/test/optimizer/CMakeLists.txt
+++ b/test/optimizer/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library_unity(
   filter_pushdown_alias.cpp
   join_order_conflict_detector.cpp
   relation_statistics.cpp
+  remove_unused_columns.cpp
   union_alls.cpp)
 
 set(UNITTEST_OBJECT_FILES

--- a/test/optimizer/remove_unused_columns.cpp
+++ b/test/optimizer/remove_unused_columns.cpp
@@ -1,14 +1,18 @@
 #include "catch.hpp"
 
+#include "duckdb/execution/column_binding_resolver.hpp"
 #include "duckdb/main/connection.hpp"
 #include "duckdb/optimizer/optimizer.hpp"
 #include "duckdb/optimizer/remove_unused_columns.hpp"
+#include "duckdb/parser/parser.hpp"
 #include "duckdb/planner/binder.hpp"
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
+#include "duckdb/planner/planner.hpp"
 #include "duckdb/planner/operator/logical_dummy_scan.hpp"
 #include "duckdb/planner/operator/logical_filter.hpp"
 #include "duckdb/planner/operator/logical_projection.hpp"
+#include "duckdb/planner/operator/logical_recursive_cte.hpp"
 
 using namespace duckdb;
 
@@ -39,6 +43,28 @@ static void ApplyColumnPruning(Connection &connection, unique_ptr<LogicalOperato
 		remove_unused.VisitOperator(plan);
 	}
 	connection.Rollback();
+}
+
+static unique_ptr<LogicalOperator> PlanUnusedColumnsQuery(Connection &connection, const string &query) {
+	Parser parser(connection.context->GetParserOptions());
+	parser.ParseQuery(query);
+	REQUIRE(parser.statements.size() == 1);
+	Planner planner(*connection.context);
+	planner.CreatePlan(std::move(parser.statements[0]));
+	return std::move(planner.plan);
+}
+
+static optional_ptr<LogicalOperator> FindUnusedColumnsOperator(LogicalOperator &op, LogicalOperatorType type) {
+	if (op.type == type) {
+		return op;
+	}
+	for (auto &child : op.children) {
+		auto result = FindUnusedColumnsOperator(*child, type);
+		if (result) {
+			return result;
+		}
+	}
+	return nullptr;
 }
 
 TEST_CASE("Column pruning removes dead projection map entries", "[optimizer][unused_columns]") {
@@ -157,4 +183,44 @@ TEST_CASE("Column pruning retains a minimum layout for removed projection map en
 	        vector<ColumnBinding> {ColumnBinding(child_table, ProjectionIndex(0)),
 	                               ColumnBinding(child_table, ProjectionIndex(1))});
 	REQUIRE(filter_ref.GetColumnBindings() == vector<ColumnBinding> {ColumnBinding(child_table, ProjectionIndex(0))});
+}
+
+TEST_CASE("Recursive CTE pruning does not reapply projection map replacements", "[optimizer][unused_columns]") {
+	DuckDB db;
+	Connection connection(db);
+	connection.BeginTransaction();
+
+	auto plan = PlanUnusedColumnsQuery(connection, R"(
+		WITH RECURSIVE t(unused, a, b) AS (
+			SELECT 100, 1, 10
+			UNION ALL
+			SELECT 100, 4, b + 10 FROM t WHERE a < 3
+		)
+		SELECT b FROM t
+	)");
+	auto recursive = FindUnusedColumnsOperator(*plan, LogicalOperatorType::LOGICAL_RECURSIVE_CTE);
+	REQUIRE(recursive);
+	auto filter = FindUnusedColumnsOperator(*recursive->children[1], LogicalOperatorType::LOGICAL_FILTER);
+	REQUIRE(filter);
+	auto &filter_ref = filter->Cast<LogicalFilter>();
+	REQUIRE(filter_ref.children[0]->GetColumnBindings().size() == 3);
+	filter_ref.projection_map = {ProjectionIndex(2)};
+
+	ResolveTypes(*plan);
+	ColumnBindingResolver initial_resolver(true);
+	REQUIRE_NOTHROW(initial_resolver.VisitOperator(*plan));
+	{
+		auto binder = Binder::CreateBinder(*connection.context);
+		Optimizer optimizer(*binder, *connection.context);
+		RemoveUnusedColumns remove_unused(optimizer);
+		remove_unused.VisitOperator(plan);
+	}
+
+	plan->ResolveOperatorTypes();
+	ColumnBindingResolver resolver(true);
+	REQUIRE_NOTHROW(resolver.VisitOperator(*plan));
+	REQUIRE(filter_ref.projection_map == vector<ProjectionIndex> {ProjectionIndex(1)});
+	REQUIRE(filter_ref.children[0]->GetColumnBindings().size() == 2);
+
+	connection.Rollback();
 }

--- a/test/optimizer/remove_unused_columns.cpp
+++ b/test/optimizer/remove_unused_columns.cpp
@@ -36,12 +36,17 @@ static void ResolveTypes(LogicalOperator &op) {
 static void ApplyColumnPruning(Connection &connection, unique_ptr<LogicalOperator> &plan) {
 	connection.BeginTransaction();
 	ResolveTypes(*plan);
+	ColumnBindingResolver initial_resolver(true);
+	REQUIRE_NOTHROW(initial_resolver.VisitOperator(*plan));
 	{
 		auto binder = Binder::CreateBinder(*connection.context);
 		Optimizer optimizer(*binder, *connection.context);
 		RemoveUnusedColumns remove_unused(optimizer);
 		remove_unused.VisitOperator(plan);
 	}
+	plan->ResolveOperatorTypes();
+	ColumnBindingResolver resolver(true);
+	REQUIRE_NOTHROW(resolver.VisitOperator(*plan));
 	connection.Rollback();
 }
 
@@ -185,6 +190,37 @@ TEST_CASE("Column pruning retains a minimum layout for removed projection map en
 	REQUIRE(filter_ref.GetColumnBindings() == vector<ColumnBinding> {ColumnBinding(child_table, ProjectionIndex(0))});
 }
 
+TEST_CASE("Column pruning distinguishes removed projection map entries from shifted bindings",
+          "[optimizer][unused_columns]") {
+	DuckDB db;
+	Connection connection(db);
+	const auto child_table = TableIndex(1000);
+	const auto output_table = TableIndex(1001);
+
+	auto child = CreatePrunableProjection(child_table);
+	auto filter = make_uniq<LogicalFilter>(
+	    make_uniq<BoundColumnRefExpression>(LogicalType::BOOLEAN, ColumnBinding(child_table, ProjectionIndex(0))));
+	filter->expressions.push_back(
+	    make_uniq<BoundColumnRefExpression>(LogicalType::BOOLEAN, ColumnBinding(child_table, ProjectionIndex(2))));
+	filter->projection_map = {ProjectionIndex(1)};
+	filter->children.push_back(std::move(child));
+	auto &filter_ref = *filter;
+
+	vector<unique_ptr<Expression>> output_expressions;
+	output_expressions.push_back(make_uniq<BoundConstantExpression>(Value::INTEGER(42)));
+	auto output = make_uniq<LogicalProjection>(output_table, std::move(output_expressions));
+	output->children.push_back(std::move(filter));
+	unique_ptr<LogicalOperator> plan = std::move(output);
+
+	ApplyColumnPruning(connection, plan);
+
+	REQUIRE(filter_ref.projection_map == vector<ProjectionIndex> {ProjectionIndex(0)});
+	REQUIRE(filter_ref.children[0]->GetColumnBindings() ==
+	        vector<ColumnBinding> {ColumnBinding(child_table, ProjectionIndex(0)),
+	                               ColumnBinding(child_table, ProjectionIndex(1))});
+	REQUIRE(filter_ref.GetColumnBindings() == vector<ColumnBinding> {ColumnBinding(child_table, ProjectionIndex(0))});
+}
+
 TEST_CASE("Recursive CTE pruning does not reapply projection map replacements", "[optimizer][unused_columns]") {
 	DuckDB db;
 	Connection connection(db);
@@ -205,6 +241,47 @@ TEST_CASE("Recursive CTE pruning does not reapply projection map replacements", 
 	auto &filter_ref = filter->Cast<LogicalFilter>();
 	REQUIRE(filter_ref.children[0]->GetColumnBindings().size() == 3);
 	filter_ref.projection_map = {ProjectionIndex(2)};
+
+	ResolveTypes(*plan);
+	ColumnBindingResolver initial_resolver(true);
+	REQUIRE_NOTHROW(initial_resolver.VisitOperator(*plan));
+	{
+		auto binder = Binder::CreateBinder(*connection.context);
+		Optimizer optimizer(*binder, *connection.context);
+		RemoveUnusedColumns remove_unused(optimizer);
+		remove_unused.VisitOperator(plan);
+	}
+
+	plan->ResolveOperatorTypes();
+	ColumnBindingResolver resolver(true);
+	REQUIRE_NOTHROW(resolver.VisitOperator(*plan));
+	REQUIRE(filter_ref.projection_map == vector<ProjectionIndex> {ProjectionIndex(1)});
+	REQUIRE(filter_ref.children[0]->GetColumnBindings().size() == 2);
+
+	connection.Rollback();
+}
+
+TEST_CASE("Recursive CTE pruning distinguishes removed projection map entries from shifted bindings",
+          "[optimizer][unused_columns]") {
+	DuckDB db;
+	Connection connection(db);
+	connection.BeginTransaction();
+
+	auto plan = PlanUnusedColumnsQuery(connection, R"(
+		WITH RECURSIVE t(a, unused, b) AS (
+			SELECT 1, 100, 10
+			UNION ALL
+			SELECT 4, 100, b + 10 FROM t WHERE a < 3
+		)
+		SELECT b FROM t
+	)");
+	auto recursive = FindUnusedColumnsOperator(*plan, LogicalOperatorType::LOGICAL_RECURSIVE_CTE);
+	REQUIRE(recursive);
+	auto filter = FindUnusedColumnsOperator(*recursive->children[1], LogicalOperatorType::LOGICAL_FILTER);
+	REQUIRE(filter);
+	auto &filter_ref = filter->Cast<LogicalFilter>();
+	REQUIRE(filter_ref.children[0]->GetColumnBindings().size() == 3);
+	filter_ref.projection_map = {ProjectionIndex(1), ProjectionIndex(2)};
 
 	ResolveTypes(*plan);
 	ColumnBindingResolver initial_resolver(true);

--- a/test/optimizer/remove_unused_columns.cpp
+++ b/test/optimizer/remove_unused_columns.cpp
@@ -1,0 +1,160 @@
+#include "catch.hpp"
+
+#include "duckdb/main/connection.hpp"
+#include "duckdb/optimizer/optimizer.hpp"
+#include "duckdb/optimizer/remove_unused_columns.hpp"
+#include "duckdb/planner/binder.hpp"
+#include "duckdb/planner/expression/bound_columnref_expression.hpp"
+#include "duckdb/planner/expression/bound_constant_expression.hpp"
+#include "duckdb/planner/operator/logical_dummy_scan.hpp"
+#include "duckdb/planner/operator/logical_filter.hpp"
+#include "duckdb/planner/operator/logical_projection.hpp"
+
+using namespace duckdb;
+
+static unique_ptr<LogicalProjection> CreatePrunableProjection(TableIndex table_index) {
+	vector<unique_ptr<Expression>> expressions;
+	expressions.push_back(make_uniq<BoundConstantExpression>(Value::BOOLEAN(true)));
+	expressions.push_back(make_uniq<BoundConstantExpression>(Value::BOOLEAN(true)));
+	expressions.push_back(make_uniq<BoundConstantExpression>(Value::BOOLEAN(true)));
+	auto projection = make_uniq<LogicalProjection>(table_index, std::move(expressions));
+	projection->children.push_back(make_uniq<LogicalDummyScan>(TableIndex(table_index.index + 1000)));
+	return projection;
+}
+
+static void ResolveTypes(LogicalOperator &op) {
+	for (auto &child : op.children) {
+		ResolveTypes(*child);
+	}
+	op.ResolveOperatorTypes();
+}
+
+static void ApplyColumnPruning(Connection &connection, unique_ptr<LogicalOperator> &plan) {
+	connection.BeginTransaction();
+	ResolveTypes(*plan);
+	{
+		auto binder = Binder::CreateBinder(*connection.context);
+		Optimizer optimizer(*binder, *connection.context);
+		RemoveUnusedColumns remove_unused(optimizer);
+		remove_unused.VisitOperator(plan);
+	}
+	connection.Rollback();
+}
+
+TEST_CASE("Column pruning removes dead projection map entries", "[optimizer][unused_columns]") {
+	DuckDB db;
+	Connection connection(db);
+	const auto child_table = TableIndex(1000);
+	const auto output_table = TableIndex(1001);
+
+	auto child = CreatePrunableProjection(child_table);
+	auto filter = make_uniq<LogicalFilter>(
+	    make_uniq<BoundColumnRefExpression>(LogicalType::BOOLEAN, ColumnBinding(child_table, ProjectionIndex(1))));
+	filter->projection_map = {ProjectionIndex(0), ProjectionIndex(2)};
+	filter->children.push_back(std::move(child));
+	auto &filter_ref = *filter;
+
+	vector<unique_ptr<Expression>> output_expressions;
+	output_expressions.push_back(
+	    make_uniq<BoundColumnRefExpression>(LogicalType::BOOLEAN, ColumnBinding(child_table, ProjectionIndex(0))));
+	auto output = make_uniq<LogicalProjection>(output_table, std::move(output_expressions));
+	output->children.push_back(std::move(filter));
+	unique_ptr<LogicalOperator> plan = std::move(output);
+
+	ApplyColumnPruning(connection, plan);
+
+	REQUIRE(filter_ref.projection_map == vector<ProjectionIndex> {ProjectionIndex(0)});
+	REQUIRE(filter_ref.children[0]->GetColumnBindings() ==
+	        vector<ColumnBinding> {ColumnBinding(child_table, ProjectionIndex(0)),
+	                               ColumnBinding(child_table, ProjectionIndex(1))});
+	REQUIRE(filter_ref.GetColumnBindings() == vector<ColumnBinding> {ColumnBinding(child_table, ProjectionIndex(0))});
+}
+
+TEST_CASE("Column pruning remaps retained projection map entries", "[optimizer][unused_columns]") {
+	DuckDB db;
+	Connection connection(db);
+	const auto child_table = TableIndex(1000);
+	const auto output_table = TableIndex(1001);
+
+	auto child = CreatePrunableProjection(child_table);
+	auto filter = make_uniq<LogicalFilter>(
+	    make_uniq<BoundColumnRefExpression>(LogicalType::BOOLEAN, ColumnBinding(child_table, ProjectionIndex(1))));
+	filter->projection_map = {ProjectionIndex(2)};
+	filter->children.push_back(std::move(child));
+	auto &filter_ref = *filter;
+
+	vector<unique_ptr<Expression>> output_expressions;
+	output_expressions.push_back(
+	    make_uniq<BoundColumnRefExpression>(LogicalType::BOOLEAN, ColumnBinding(child_table, ProjectionIndex(2))));
+	auto output = make_uniq<LogicalProjection>(output_table, std::move(output_expressions));
+	output->children.push_back(std::move(filter));
+	unique_ptr<LogicalOperator> plan = std::move(output);
+
+	ApplyColumnPruning(connection, plan);
+
+	REQUIRE(filter_ref.projection_map == vector<ProjectionIndex> {ProjectionIndex(1)});
+	REQUIRE(filter_ref.children[0]->GetColumnBindings() ==
+	        vector<ColumnBinding> {ColumnBinding(child_table, ProjectionIndex(0)),
+	                               ColumnBinding(child_table, ProjectionIndex(1))});
+	REQUIRE(filter_ref.GetColumnBindings() == vector<ColumnBinding> {ColumnBinding(child_table, ProjectionIndex(1))});
+}
+
+TEST_CASE("Column pruning follows replacements before matching projection map bindings",
+          "[optimizer][unused_columns]") {
+	DuckDB db;
+	Connection connection(db);
+	const auto child_table = TableIndex(1000);
+	const auto output_table = TableIndex(1001);
+
+	auto child = CreatePrunableProjection(child_table);
+	auto filter = make_uniq<LogicalFilter>(
+	    make_uniq<BoundColumnRefExpression>(LogicalType::BOOLEAN, ColumnBinding(child_table, ProjectionIndex(2))));
+	filter->projection_map = {ProjectionIndex(1)};
+	filter->children.push_back(std::move(child));
+	auto &filter_ref = *filter;
+
+	vector<unique_ptr<Expression>> output_expressions;
+	output_expressions.push_back(
+	    make_uniq<BoundColumnRefExpression>(LogicalType::BOOLEAN, ColumnBinding(child_table, ProjectionIndex(1))));
+	auto output = make_uniq<LogicalProjection>(output_table, std::move(output_expressions));
+	output->children.push_back(std::move(filter));
+	unique_ptr<LogicalOperator> plan = std::move(output);
+
+	ApplyColumnPruning(connection, plan);
+
+	REQUIRE(filter_ref.projection_map == vector<ProjectionIndex> {ProjectionIndex(0)});
+	REQUIRE(filter_ref.children[0]->GetColumnBindings() ==
+	        vector<ColumnBinding> {ColumnBinding(child_table, ProjectionIndex(0)),
+	                               ColumnBinding(child_table, ProjectionIndex(1))});
+	REQUIRE(filter_ref.GetColumnBindings() == vector<ColumnBinding> {ColumnBinding(child_table, ProjectionIndex(0))});
+}
+
+TEST_CASE("Column pruning retains a minimum layout for removed projection map entries", "[optimizer][unused_columns]") {
+	DuckDB db;
+	Connection connection(db);
+	const auto child_table = TableIndex(1000);
+	const auto output_table = TableIndex(1001);
+
+	auto child = CreatePrunableProjection(child_table);
+	auto filter = make_uniq<LogicalFilter>(
+	    make_uniq<BoundColumnRefExpression>(LogicalType::BOOLEAN, ColumnBinding(child_table, ProjectionIndex(0))));
+	filter->expressions.push_back(
+	    make_uniq<BoundColumnRefExpression>(LogicalType::BOOLEAN, ColumnBinding(child_table, ProjectionIndex(1))));
+	filter->projection_map = {ProjectionIndex(2)};
+	filter->children.push_back(std::move(child));
+	auto &filter_ref = *filter;
+
+	vector<unique_ptr<Expression>> output_expressions;
+	output_expressions.push_back(make_uniq<BoundConstantExpression>(Value::INTEGER(42)));
+	auto output = make_uniq<LogicalProjection>(output_table, std::move(output_expressions));
+	output->children.push_back(std::move(filter));
+	unique_ptr<LogicalOperator> plan = std::move(output);
+
+	ApplyColumnPruning(connection, plan);
+
+	REQUIRE(filter_ref.projection_map == vector<ProjectionIndex> {ProjectionIndex(0)});
+	REQUIRE(filter_ref.children[0]->GetColumnBindings() ==
+	        vector<ColumnBinding> {ColumnBinding(child_table, ProjectionIndex(0)),
+	                               ColumnBinding(child_table, ProjectionIndex(1))});
+	REQUIRE(filter_ref.GetColumnBindings() == vector<ColumnBinding> {ColumnBinding(child_table, ProjectionIndex(0))});
+}


### PR DESCRIPTION
While auditing the projection-map handling, I found an issue in `RemoveUnusedColumns`. The generic logical-operator visitor remaps a projection map by matching the bindings produced before and after a child rewrite. If a selected binding disappears, it clears the map. That is a reasonable containment fallback for an unknown rewrite, but it is the wrong abstraction for a pass whose purpose is to remove and renumber bindings: an empty projection map means "project every surviving column", not "the selected column was pruned".

This showed up in the unused-column pass run by Top-N window elimination while optimizing a materialized common subplan. A parent projection map selected a CTE-derived binding that column pruning then removed. The visitor cleared the complete map, widening the parent layout to every remaining child column. Renumbering has a second subtle case: after removing an earlier column, an old binding can still occur numerically in the new layout while now representing a different original column, so matching bindings without their replacement provenance can silently select the wrong output.

I make projection-map maintenance part of the pruning rewrite. The pass records binding replacements when projection, aggregate, CTE, and related outputs are compacted, including the one-to-many replacements created by pushed-down nested extracts. After visiting a child, it resolves the old selection at that output boundary and rebuilds the map from the bindings that remain reachable. Replacement targets stop at the new boundary, which distinguishes simultaneous renumbering from a transitive rewrite even when their numeric bindings overlap. If every selected binding was removed, the pass retains the minimum valid child layout instead of turning the map into "all columns".

Recursive CTE pruning has an additional lifetime boundary. Its reference pruner rewrites projection maps inside the recursive term before `RemoveUnusedColumns` traverses that term again. I therefore keep those reference replacements local until the follow-up traversal has completed, and only then publish them for ancestors outside the recursive operator. Publishing them earlier would allow an already-renumbered binding to be interpreted as an old binding with the same numeric index and remapped a second time.

The replacement relation and remapping logic remain private to `RemoveUnusedColumns` and its CTE-reference helper. This does not introduce the indexed plan, ancestor traversal, or mutation protocol; the trade-off is a small amount of pass-specific bookkeeping in exchange for giving pruning explicit ownership of its output-layout semantics.