### PR TITLE
Fix qualified name APIs to correctly handle nested schemas

### DIFF
--- a/src/include/duckdb/parser/expression/type_expression.hpp
+++ b/src/include/duckdb/parser/expression/type_expression.hpp
@@ -50,7 +50,7 @@ public:
 		return qualified_name.Catalog();
 	}
 	void SetCatalog(Identifier new_catalog) {
-		qualified_name = QualifiedName(std::move(new_catalog), qualified_name.Schema(), qualified_name.Name());
+		qualified_name = qualified_name.WithCatalog(std::move(new_catalog));
 	}
 	const vector<unique_ptr<ParsedExpression>> &GetChildren() const {
 		return children;

--- a/src/include/duckdb/parser/parsed_data/create_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_info.hpp
@@ -76,7 +76,7 @@ public:
 	}
 	//! Set the catalog, keeping the schema and name
 	void SetCatalog(Identifier catalog) {
-		qualified_name = QualifiedName(std::move(catalog), qualified_name.Schema(), qualified_name.Name());
+		qualified_name = qualified_name.WithCatalog(std::move(catalog));
 	}
 	//! Renders the qualified name for ToString - the catalog is omitted for temporary entries and the default schema is
 	//! hidden

--- a/src/include/duckdb/parser/parsed_data/drop_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/drop_info.hpp
@@ -58,7 +58,7 @@ public:
 		qualified_name = QualifiedName(qualified_name.Catalog(), std::move(schema), qualified_name.Name());
 	}
 	void SetCatalog(Identifier catalog) {
-		qualified_name = QualifiedName(std::move(catalog), qualified_name.Schema(), qualified_name.Name());
+		qualified_name = qualified_name.WithCatalog(std::move(catalog));
 	}
 
 public:

--- a/src/include/duckdb/parser/qualified_name.hpp
+++ b/src/include/duckdb/parser/qualified_name.hpp
@@ -88,9 +88,19 @@ struct QualifiedName {
 			return;
 		}
 		path.erase(path.begin());
+		if (path.size() >= 2 && path[0].empty()) {
+			// the name was catalog-qualified without a schema - drop the empty schema placeholder as well
+			path.erase(path.begin());
+		}
 	}
-	//! Return a copy of this name qualified with the given catalog, replacing the catalog component it already has
+	//! Return a copy of this name qualified with the given catalog, replacing the catalog component it already has.
+	//! An empty catalog strips the catalog qualification.
 	QualifiedName WithCatalog(Identifier catalog) const {
+		if (catalog.empty()) {
+			auto result = *this;
+			result.StripCatalog();
+			return result;
+		}
 		if (path.size() < 2) {
 			return QualifiedName(std::move(catalog), Identifier(), Name());
 		}

--- a/src/include/duckdb/parser/tableref/showref.hpp
+++ b/src/include/duckdb/parser/tableref/showref.hpp
@@ -49,7 +49,7 @@ public:
 		return qualified_name.Catalog();
 	}
 	void SetCatalogName(Identifier catalog_name) {
-		qualified_name = QualifiedName(std::move(catalog_name), qualified_name.Schema(), qualified_name.Name());
+		qualified_name = qualified_name.WithCatalog(std::move(catalog_name));
 	}
 	//! The schema name (if any)
 	const Identifier &GetSchemaName() const {

--- a/src/parser/parsed_data/create_info.cpp
+++ b/src/parser/parsed_data/create_info.cpp
@@ -32,10 +32,9 @@ string CreateInfo::QualifiedNameToString() const {
 		return qualified_name.ToString(QualifiedNameToStringMode::HIDE_DEFAULT_SCHEMA);
 	}
 	// for temporary entries the catalog is implied, so it is omitted from the rendered name
-	auto &path = qualified_name.Path();
-	vector<Identifier> schema_path(path.begin() + (path.size() >= 3 ? 1 : 0), path.end() - 1);
-	return QualifiedName(std::move(schema_path), qualified_name.Name())
-	    .ToString(QualifiedNameToStringMode::HIDE_DEFAULT_SCHEMA);
+	auto name = qualified_name;
+	name.StripCatalog();
+	return name.ToString(QualifiedNameToStringMode::HIDE_DEFAULT_SCHEMA);
 }
 
 string CreateInfo::GetCreatePrefix(const string &entry) const {

--- a/src/parser/qualified_name.cpp
+++ b/src/parser/qualified_name.cpp
@@ -104,14 +104,25 @@ end:
 }
 
 hash_t QualifiedName::Hash() const {
-	hash_t result = Catalog().Hash();
-	result = CombineHash(result, Schema().Hash());
-	result = CombineHash(result, Name().Hash());
+	// hash the full path - the qualification can be deeper than [catalog, schema]
+	hash_t result = duckdb::Hash<idx_t>(path.size());
+	for (auto &component : path) {
+		result = CombineHash(result, component.Hash());
+	}
 	return result;
 }
 
 bool QualifiedName::operator==(const QualifiedName &rhs) const {
-	return Catalog() == rhs.Catalog() && Schema() == rhs.Schema() && Name() == rhs.Name();
+	// compare the full path - the qualification can be deeper than [catalog, schema]
+	if (path.size() != rhs.path.size()) {
+		return false;
+	}
+	for (idx_t i = 0; i < path.size(); i++) {
+		if (path[i] != rhs.path[i]) {
+			return false;
+		}
+	}
+	return true;
 }
 
 bool QualifiedName::operator!=(const QualifiedName &rhs) const {

--- a/src/parser/tableref/basetableref.cpp
+++ b/src/parser/tableref/basetableref.cpp
@@ -7,10 +7,7 @@
 namespace duckdb {
 
 string BaseTableRef::ToString() const {
-	string result;
-	result += GetQualifiedName().Catalog().empty() ? "" : (SQLIdentifier(GetQualifiedName().Catalog()) + ".");
-	result += GetQualifiedName().Schema().empty() ? "" : (SQLIdentifier(GetQualifiedName().Schema()) + ".");
-	result += SQLIdentifier(GetQualifiedName().Name());
+	string result = GetQualifiedName().ToString();
 	result += AliasToString(column_name_alias);
 	if (at_clause) {
 		result += " " + at_clause->ToString();
@@ -24,9 +21,7 @@ bool BaseTableRef::Equals(const TableRef &other_p) const {
 		return false;
 	}
 	auto &other = other_p.Cast<BaseTableRef>();
-	return other.GetQualifiedName().Catalog() == GetQualifiedName().Catalog() &&
-	       other.GetQualifiedName().Schema() == GetQualifiedName().Schema() &&
-	       other.Table() == GetQualifiedName().Name() && column_name_alias == other.column_name_alias &&
+	return other.GetQualifiedName() == GetQualifiedName() && column_name_alias == other.column_name_alias &&
 	       AtClause::Equals(at_clause.get(), other.at_clause.get());
 }
 

--- a/src/parser/tableref/showref.cpp
+++ b/src/parser/tableref/showref.cpp
@@ -40,11 +40,11 @@ bool ShowRef::Equals(const TableRef &other_p) const {
 	}
 	auto &other = other_p.Cast<ShowRef>();
 	if (other.query.get() != query.get()) {
-		if (!other.query->Equals(query.get())) {
+		if (!query || !query->Equals(other.query.get())) {
 			return false;
 		}
 	}
-	return GetTableName() == other.GetTableName() && show_type == other.show_type;
+	return qualified_name == other.qualified_name && show_type == other.show_type;
 }
 
 unique_ptr<TableRef> ShowRef::Copy() {

--- a/src/planner/binding_alias.cpp
+++ b/src/planner/binding_alias.cpp
@@ -63,7 +63,7 @@ vector<Identifier> BindingAlias::GetSchemaPath() const {
 }
 
 string BindingAlias::ToString() const {
-	// QualifiedName::ToString only renders [catalog, schema, name], so we render the full (possibly nested) path here
+	// the catalog is stored separately from the [schema path..., alias] path
 	string result;
 	if (!catalog.empty()) {
 		result += SQLIdentifier(catalog);
@@ -106,21 +106,7 @@ bool BindingAlias::Matches(const BindingAlias &other) const {
 }
 
 bool BindingAlias::operator==(const BindingAlias &other) const {
-	// QualifiedName::operator== only compares [catalog, schema, name], so we compare the full path here
-	if (catalog != other.catalog) {
-		return false;
-	}
-	auto &path = qualified_name.Path();
-	auto &other_path = other.qualified_name.Path();
-	if (path.size() != other_path.size()) {
-		return false;
-	}
-	for (idx_t i = 0; i < path.size(); i++) {
-		if (path[i] != other_path[i]) {
-			return false;
-		}
-	}
-	return true;
+	return catalog == other.catalog && qualified_name == other.qualified_name;
 }
 
 } // namespace duckdb

--- a/src/storage/wal_replay.cpp
+++ b/src/storage/wal_replay.cpp
@@ -64,15 +64,14 @@ public:
 	WALReplayState replay_state;
 
 	struct ReplayIndexInfo {
-		ReplayIndexInfo(TableIndexList &index_list, unique_ptr<Index> index, const Identifier &table_schema,
-		                const Identifier &table_name)
-		    : index_list(index_list), index(std::move(index)), table_schema(table_schema), table_name(table_name) {
+		ReplayIndexInfo(TableIndexList &index_list, unique_ptr<Index> index, QualifiedName table_name)
+		    : index_list(index_list), index(std::move(index)), table_name(std::move(table_name)) {
 		}
 
 		reference<TableIndexList> index_list;
 		unique_ptr<Index> index;
-		Identifier table_schema;
-		Identifier table_name;
+		//! The fully-qualified name of the table the index belongs to ([catalog, schema path..., table])
+		QualifiedName table_name;
 	};
 	vector<ReplayIndexInfo> replay_index_infos;
 };
@@ -863,9 +862,7 @@ void WriteAheadLogDeserializer::ReplayDropTable() {
 	// Remove any replay indexes of this table.
 	state.replay_index_infos.erase(std::remove_if(state.replay_index_infos.begin(), state.replay_index_infos.end(),
 	                                              [&info](const ReplayState::ReplayIndexInfo &replay_info) {
-		                                              return replay_info.table_schema ==
-		                                                         info.GetQualifiedName().Schema() &&
-		                                                     replay_info.table_name == info.GetQualifiedName().Name();
+		                                              return replay_info.table_name == info.GetQualifiedName();
 	                                              }),
 	                               state.replay_index_infos.end());
 
@@ -940,10 +937,8 @@ void WriteAheadLogDeserializer::ReplayAlter() {
 	auto &constraint_info = table_info.Cast<AddConstraintInfo>();
 	auto &unique_info = constraint_info.constraint->Cast<UniqueConstraint>();
 
-	auto &table = catalog
-	                  .GetEntry<TableCatalogEntry>(context, ReplayQualifiedName(catalog, table_info.GetQualifiedName(),
-	                                                                            table_info.GetQualifiedName().Name()))
-	                  .Cast<DuckTableEntry>();
+	auto table_name = ReplayQualifiedName(catalog, table_info.GetQualifiedName(), table_info.GetQualifiedName().Name());
+	auto &table = catalog.GetEntry<TableCatalogEntry>(context, table_name).Cast<DuckTableEntry>();
 	auto &column_list = table.GetColumns();
 
 	// Add the table to the bind context to bind the parsed expressions.
@@ -985,8 +980,7 @@ void WriteAheadLogDeserializer::ReplayAlter() {
 	auto index_instance = index_type->create_instance(input);
 
 	auto &table_index_list = storage.GetDataTableInfo()->GetIndexes();
-	state.replay_index_infos.emplace_back(table_index_list, std::move(index_instance),
-	                                      table_info.GetQualifiedName().Schema(), table_info.GetQualifiedName().Name());
+	state.replay_index_infos.emplace_back(table_index_list, std::move(index_instance), std::move(table_name));
 
 	catalog.Alter(context, alter_info);
 }
@@ -1237,12 +1231,9 @@ void WriteAheadLogDeserializer::ReplayCreateIndex() {
 		info.index_type = ART::TYPE_NAME;
 	}
 
-	const auto schema_name = create_info->GetQualifiedName().Schema();
-	const auto table_name = info.table;
-
 	// the table lives in the same (possibly nested) schema as the index
-	auto &entry = catalog.GetEntry<TableCatalogEntry>(
-	    context, ReplayQualifiedName(catalog, create_info->GetQualifiedName(), table_name));
+	auto table_name = ReplayQualifiedName(catalog, create_info->GetQualifiedName(), info.table);
+	auto &entry = catalog.GetEntry<TableCatalogEntry>(context, table_name);
 	auto &table = entry.Cast<DuckTableEntry>();
 	auto &storage = table.GetStorage();
 	auto &io_manager = TableIOManager::Get(storage);
@@ -1254,7 +1245,7 @@ void WriteAheadLogDeserializer::ReplayCreateIndex() {
 	auto unbound_index = make_uniq<UnboundIndex>(std::move(create_info), std::move(index_info), io_manager, db);
 
 	auto &table_index_list = storage.GetDataTableInfo()->GetIndexes();
-	state.replay_index_infos.emplace_back(table_index_list, std::move(unbound_index), schema_name, table_name);
+	state.replay_index_infos.emplace_back(table_index_list, std::move(unbound_index), std::move(table_name));
 }
 
 void WriteAheadLogDeserializer::ReplayDropIndex() {
@@ -1266,14 +1257,14 @@ void WriteAheadLogDeserializer::ReplayDropIndex() {
 		return;
 	}
 
-	// Remove the replay index, if any.
-	state.replay_index_infos.erase(
-	    std::remove_if(state.replay_index_infos.begin(), state.replay_index_infos.end(),
-	                   [&info](const ReplayState::ReplayIndexInfo &replay_info) {
-		                   return replay_info.table_schema == info.GetQualifiedName().Schema() &&
-		                          replay_info.index->GetIndexName() == info.GetQualifiedName().Name();
-	                   }),
-	    state.replay_index_infos.end());
+	// Remove the replay index, if any - the index lives in the same (possibly nested) schema as its table
+	state.replay_index_infos.erase(std::remove_if(state.replay_index_infos.begin(), state.replay_index_infos.end(),
+	                                              [&info](const ReplayState::ReplayIndexInfo &replay_info) {
+		                                              return replay_info.table_name.WithName(
+		                                                         replay_info.index->GetIndexName()) ==
+		                                                     info.GetQualifiedName();
+	                                              }),
+	                               state.replay_index_infos.end());
 
 	catalog.DropEntry(context, info);
 }

--- a/test/sql/catalog/nested_schema/nested_wal_replay_index.test
+++ b/test/sql/catalog/nested_schema/nested_wal_replay_index.test
@@ -1,0 +1,94 @@
+# name: test/sql/catalog/nested_schema/nested_wal_replay_index.test
+# description: Replaying indexes of identically-named tables in different nested schemas
+# group: [nested_schema]
+
+load {TEST_DIR}/nested_wal_replay_index.db readwrite v2.0.0
+
+statement ok
+SET wal_autocheckpoint='1TB';
+
+statement ok
+PRAGMA disable_checkpoint_on_shutdown;
+
+statement ok
+CREATE SCHEMA s1;
+
+statement ok
+CREATE SCHEMA s1.x;
+
+statement ok
+CREATE SCHEMA s2;
+
+statement ok
+CREATE SCHEMA s2.x;
+
+statement ok
+CREATE TABLE s1.x.t(i INTEGER);
+
+statement ok
+CREATE TABLE s2.x.t(i INTEGER);
+
+statement ok
+INSERT INTO s2.x.t VALUES (1);
+
+# dropping s1.x.t must not discard the index of the identically-named table in s2.x
+statement ok
+BEGIN
+
+statement ok
+CREATE UNIQUE INDEX idx ON s1.x.t(i);
+
+statement ok
+CREATE UNIQUE INDEX idx ON s2.x.t(i);
+
+statement ok
+DROP TABLE s1.x.t;
+
+statement ok
+COMMIT
+
+restart
+
+statement ok
+SET wal_autocheckpoint='1TB';
+
+statement ok
+PRAGMA disable_checkpoint_on_shutdown;
+
+query II
+SELECT schema_name, index_name FROM duckdb_indexes();
+----
+x	idx
+
+statement error
+INSERT INTO s2.x.t VALUES (1);
+----
+<REGEX>:.*Constraint Error.*
+
+# dropping the index of one nested table must not discard the index of the other
+statement ok
+CREATE TABLE s1.x.t(i INTEGER);
+
+statement ok
+BEGIN
+
+statement ok
+CREATE UNIQUE INDEX idx2 ON s1.x.t(i);
+
+statement ok
+DROP INDEX s2.x.idx;
+
+statement ok
+COMMIT
+
+restart
+
+query II
+SELECT schema_name, index_name FROM duckdb_indexes();
+----
+x	idx2
+
+statement error
+INSERT INTO s1.x.t VALUES (1), (1);
+----
+<REGEX>:.*Constraint Error.*


### PR DESCRIPTION
Several of the APIs in the `QualifiedName` class were not correctly dealing with nested schemas yet, causing them to be subtly incorrect in certain situations. This PR addresses that.