### PR TITLE
Restore static linking behaviour for C API

### DIFF
--- a/api_spec/v1/extension/duckdb_extension.h.in
+++ b/api_spec/v1/extension/duckdb_extension.h.in
@@ -107,12 +107,21 @@ typedef struct {
 //===--------------------------------------------------------------------===//
 // Typedefs mapping functions to struct entries
 //===--------------------------------------------------------------------===//
-
+// When building as a static extension, DuckDB symbols are resolved directly at link time.
+// The vtable (duckdb_ext_api) is not used -- skip these macro redirections.
+#ifndef DUCKDB_BUILD_STATIC_EXTENSION
 // capigen:begin appended
 // capigen:end appended
+#endif // DUCKDB_BUILD_STATIC_EXTENSION
+
 //===--------------------------------------------------------------------===//
 // Struct Global Macros
 //===--------------------------------------------------------------------===//
+#ifdef DUCKDB_BUILD_STATIC_EXTENSION
+// No vtable global needed for static builds -- DuckDB symbols are resolved directly at link time
+#define DUCKDB_EXTENSION_GLOBAL
+#define DUCKDB_EXTENSION_API_INIT(info, access, minimum_api_version)
+#else
 // This goes in the c/c++ file containing the entrypoint (handle
 #define DUCKDB_EXTENSION_GLOBAL duckdb_ext_api_v1 duckdb_ext_api = {0};
 // Initializes the C Extension API: First thing to call in the extension entrypoint
@@ -122,6 +131,7 @@ typedef struct {
 		return false;                                                                                                  \
 	};                                                                                                                 \
 	duckdb_ext_api = *res;
+#endif // DUCKDB_BUILD_STATIC_EXTENSION
 
 // Place in global scope of any C/C++ file that needs to access the extension API
 #define DUCKDB_EXTENSION_EXTERN extern duckdb_ext_api_v1 duckdb_ext_api;

--- a/src/include/duckdb_extension.h
+++ b/src/include/duckdb_extension.h
@@ -734,7 +734,9 @@ typedef struct {
 //===--------------------------------------------------------------------===//
 // Typedefs mapping functions to struct entries
 //===--------------------------------------------------------------------===//
-
+// When building as a static extension, DuckDB symbols are resolved directly at link time.
+// The vtable (duckdb_ext_api) is not used -- skip these macro redirections.
+#ifndef DUCKDB_BUILD_STATIC_EXTENSION
 // capigen:begin appended
 #define duckdb_open duckdb_ext_api.duckdb_open
 #if DUCKDB_API_VERSION_AT_LEAST(0, 2, 8)
@@ -2353,9 +2355,16 @@ typedef struct {
 #define duckdb_get_timestamp_tz_ns duckdb_ext_api.duckdb_get_timestamp_tz_ns
 #endif
 // capigen:end appended
+#endif // DUCKDB_BUILD_STATIC_EXTENSION
+
 //===--------------------------------------------------------------------===//
 // Struct Global Macros
 //===--------------------------------------------------------------------===//
+#ifdef DUCKDB_BUILD_STATIC_EXTENSION
+// No vtable global needed for static builds -- DuckDB symbols are resolved directly at link time
+#define DUCKDB_EXTENSION_GLOBAL
+#define DUCKDB_EXTENSION_API_INIT(info, access, minimum_api_version)
+#else
 // This goes in the c/c++ file containing the entrypoint (handle
 #define DUCKDB_EXTENSION_GLOBAL duckdb_ext_api_v1 duckdb_ext_api = {0};
 // Initializes the C Extension API: First thing to call in the extension entrypoint
@@ -2365,6 +2374,7 @@ typedef struct {
 		return false;                                                                                                  \
 	};                                                                                                                 \
 	duckdb_ext_api = *res;
+#endif // DUCKDB_BUILD_STATIC_EXTENSION
 
 // Place in global scope of any C/C++ file that needs to access the extension API
 #define DUCKDB_EXTENSION_EXTERN extern duckdb_ext_api_v1 duckdb_ext_api;


### PR DESCRIPTION
#22251 added support for statically linking C extensions, where #24135 changed the way the C API was generated. In #24135 the change to the code generation from #22251 was missed when migrating to the new code generation. Consequence of this is that any C extension that is statically linked to DuckDB now triggers a segfault as getAPI is a nullptr (due to the missing guards). 

This PR adds the guards from #22251 back into the template added by #24135

This can be reproduced by removing the DONT_LINK option from the capi_demo in main_core.cmake. I did not see a nice way to add a test to Ci for this, let me know if you have a suggestion for this.