### PR TITLE
Preserve selected domains during delim join rewriting

### DIFF
--- a/src/include/duckdb/planner/subquery/delim_join_cte_rewriter.hpp
+++ b/src/include/duckdb/planner/subquery/delim_join_cte_rewriter.hpp
@@ -27,12 +27,16 @@ private:
 	                                                bool null_rejecting_filter_above = false,
 	                                                bool preserve_evidence_side = false);
 	BindingReplacementGraph MaterializeDelimJoinAsCTE(unique_ptr<LogicalOperator> &plan, LogicalOperator &rewrite_root,
-	                                                  bool null_rejecting_filter_above, bool preserve_evidence_side);
+	                                                  bool null_rejecting_filter_above, bool preserve_evidence_side,
+	                                                  bool preserve_nested_evidence_side);
 
 private:
 	Binder &binder;
 	bool cte_deliminator_enabled;
 	vector<TableIndex> generated_dedup_cte_indexes;
+	set<TableIndex> marker_indexes;
+	set<TableIndex> preserve_marker_indexes;
+	set<TableIndex> preserve_nested_marker_indexes;
 };
 
 } // namespace duckdb

--- a/src/planner/subquery/delim_join_cte_rewriter.cpp
+++ b/src/planner/subquery/delim_join_cte_rewriter.cpp
@@ -238,6 +238,68 @@ static bool FilterNegatesDelimJoinMarker(LogicalFilter &filter, LogicalCompariso
 	return false;
 }
 
+static void CollectDelimJoinMarkerIndexes(LogicalOperator &op, set<TableIndex> &marker_indexes) {
+	if (op.type == LogicalOperatorType::LOGICAL_DELIM_JOIN) {
+		auto &join = op.Cast<LogicalComparisonJoin>();
+		if (join.join_type == JoinType::MARK) {
+			marker_indexes.insert(join.mark_index);
+		}
+	}
+	for (auto &child : op.children) {
+		CollectDelimJoinMarkerIndexes(*child, marker_indexes);
+	}
+}
+
+static void CollectExpressionMarkerReferences(Expression &expr, const set<TableIndex> &marker_indexes,
+                                              set<TableIndex> &referenced_markers) {
+	ExpressionIterator::VisitExpression<BoundColumnRefExpression>(expr, [&](const BoundColumnRefExpression &colref) {
+		if (colref.Depth() == 0 && marker_indexes.find(colref.Binding().table_index) != marker_indexes.end()) {
+			referenced_markers.insert(colref.Binding().table_index);
+		}
+	});
+}
+
+static bool ExpressionHasComplexMarkerReference(Expression &expr, const set<TableIndex> &marker_indexes) {
+	if (expr.GetExpressionType() == ExpressionType::BOUND_COLUMN_REF) {
+		return false;
+	}
+	if (expr.GetExpressionType() == ExpressionType::OPERATOR_NOT) {
+		auto &not_expr = expr.Cast<BoundOperatorExpression>();
+		if (not_expr.GetChildren().size() == 1 &&
+		    not_expr.GetChildren()[0]->GetExpressionType() == ExpressionType::BOUND_COLUMN_REF) {
+			return false;
+		}
+	}
+	set<TableIndex> referenced_markers;
+	CollectExpressionMarkerReferences(expr, marker_indexes, referenced_markers);
+	return !referenced_markers.empty();
+}
+
+static void CollectComplexMarkerReferences(LogicalOperator &op, const set<TableIndex> &marker_indexes,
+                                           set<TableIndex> &preserve_marker_indexes,
+                                           set<TableIndex> &simple_marker_indexes) {
+	vector<reference<Expression>> expressions;
+	LogicalOperatorVisitor::EnumerateExpressions(
+	    op, [&](unique_ptr<Expression> *expr) { expressions.emplace_back(**expr); });
+	bool has_complex_marker_reference = false;
+	for (auto &expr : expressions) {
+		has_complex_marker_reference =
+		    has_complex_marker_reference || ExpressionHasComplexMarkerReference(expr.get(), marker_indexes);
+	}
+	set<TableIndex> referenced_markers;
+	for (auto &expr : expressions) {
+		CollectExpressionMarkerReferences(expr.get(), marker_indexes, referenced_markers);
+	}
+	if (has_complex_marker_reference) {
+		preserve_marker_indexes.insert(referenced_markers.begin(), referenced_markers.end());
+	} else if (op.type != LogicalOperatorType::LOGICAL_FILTER) {
+		simple_marker_indexes.insert(referenced_markers.begin(), referenced_markers.end());
+	}
+	for (auto &child : op.children) {
+		CollectComplexMarkerReferences(*child, marker_indexes, preserve_marker_indexes, simple_marker_indexes);
+	}
+}
+
 static bool PushEligibleFilterExpressionsIntoDelimJoinInputs(unique_ptr<LogicalOperator> &plan) {
 	auto &filter = plan->Cast<LogicalFilter>();
 	if (filter.HasProjectionMap()) {
@@ -311,6 +373,82 @@ static bool IsNonSelectiveJoinPredicate(Expression &expr) {
 	return IsColumnEqualityPredicate(expr);
 }
 
+static bool IsSubqueryEvidenceSide(const LogicalOperator &op, idx_t child_idx) {
+	if (op.type != LogicalOperatorType::LOGICAL_COMPARISON_JOIN && op.type != LogicalOperatorType::LOGICAL_DELIM_JOIN) {
+		return false;
+	}
+	auto &join = op.Cast<LogicalComparisonJoin>();
+	switch (join.join_type) {
+	case JoinType::MARK:
+	case JoinType::SEMI:
+	case JoinType::ANTI:
+		return child_idx == 1;
+	case JoinType::RIGHT_SEMI:
+	case JoinType::RIGHT_ANTI:
+		return child_idx == 0;
+	default:
+		return false;
+	}
+}
+
+static void ReplaceExpressionBindings(unique_ptr<Expression> &expr, const vector<ColumnBinding> &bindings,
+                                      const vector<unique_ptr<Expression>> &expressions);
+
+static vector<unique_ptr<Expression>>
+TraceCorrelatedColumnsIntoChild(const LogicalOperator &op, idx_t child_idx,
+                                const vector<unique_ptr<Expression>> &correlated_columns) {
+	vector<unique_ptr<Expression>> result;
+	result.reserve(correlated_columns.size());
+	for (auto &column : correlated_columns) {
+		result.push_back(column->Copy());
+	}
+	if (op.type == LogicalOperatorType::LOGICAL_PROJECTION && child_idx == 0) {
+		auto &projection = op.Cast<LogicalProjection>();
+		auto projection_bindings =
+		    LogicalOperator::GenerateColumnBindings(projection.table_index, projection.expressions.size());
+		for (auto &column : result) {
+			ReplaceExpressionBindings(column, projection_bindings, projection.expressions);
+		}
+	} else if (op.type == LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY && child_idx == 0) {
+		auto &aggregate = op.Cast<LogicalAggregate>();
+		auto group_bindings = LogicalOperator::GenerateColumnBindings(aggregate.group_index, aggregate.groups.size());
+		for (auto &column : result) {
+			ReplaceExpressionBindings(column, group_bindings, aggregate.groups);
+		}
+	}
+	return result;
+}
+
+static bool CorrelatedColumnsReferenceOnlyChild(const vector<unique_ptr<Expression>> &correlated_columns,
+                                                LogicalOperator &child) {
+	if (correlated_columns.empty()) {
+		return false;
+	}
+	for (auto &column : correlated_columns) {
+		column_binding_set_t bindings;
+		if (!GetExpressionColumnBindings(*column, bindings) || bindings.empty() ||
+		    !ChildContainsBindings(child, bindings)) {
+			return false;
+		}
+	}
+	return true;
+}
+
+static bool IsUnrelatedNullableJoinSide(const LogicalOperator &op, idx_t child_idx,
+                                        const vector<unique_ptr<Expression>> &correlated_columns) {
+	if (op.type != LogicalOperatorType::LOGICAL_COMPARISON_JOIN && op.type != LogicalOperatorType::LOGICAL_DELIM_JOIN) {
+		return false;
+	}
+	auto &join = op.Cast<LogicalComparisonJoin>();
+	if ((join.join_type == JoinType::LEFT || join.join_type == JoinType::SINGLE) && child_idx == 1) {
+		return CorrelatedColumnsReferenceOnlyChild(correlated_columns, *op.children[0]);
+	}
+	if (join.join_type == JoinType::RIGHT && child_idx == 0) {
+		return CorrelatedColumnsReferenceOnlyChild(correlated_columns, *op.children[1]);
+	}
+	return false;
+}
+
 static bool HasSelection(const LogicalOperator &op) {
 	switch (op.type) {
 	case LogicalOperatorType::LOGICAL_GET: {
@@ -341,6 +479,55 @@ static bool HasSelection(const LogicalOperator &op) {
 
 	for (auto &child : op.children) {
 		if (HasSelection(*child)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+static bool HasDelimiterDomainSelection(const LogicalOperator &op, const set<TableIndex> &marker_indexes,
+                                        bool ignore_marker_filters,
+                                        const vector<unique_ptr<Expression>> &correlated_columns) {
+	switch (op.type) {
+	case LogicalOperatorType::LOGICAL_GET: {
+		auto &get = op.Cast<LogicalGet>();
+		for (const auto &entry : get.table_filters) {
+			auto &expr_filter = ExpressionFilter::GetExpressionFilter(
+			    entry.Filter(), "DelimJoinCTERewriter::HasDelimiterDomainSelection");
+			auto &expr = *expr_filter.expr;
+			if (expr.GetExpressionClass() != ExpressionClass::BOUND_OPERATOR ||
+			    expr.GetExpressionType() != ExpressionType::OPERATOR_IS_NOT_NULL) {
+				return true;
+			}
+		}
+		break;
+	}
+	case LogicalOperatorType::LOGICAL_FILTER: {
+		auto &filter = op.Cast<LogicalFilter>();
+		for (auto &expr : filter.expressions) {
+			if (ignore_marker_filters) {
+				set<TableIndex> referenced_markers;
+				CollectExpressionMarkerReferences(*expr, marker_indexes, referenced_markers);
+				if (!referenced_markers.empty()) {
+					continue;
+				}
+			}
+			if (!IsNonSelectiveJoinPredicate(*expr)) {
+				return true;
+			}
+		}
+		break;
+	}
+	default:
+		break;
+	}
+	for (idx_t child_idx = 0; child_idx < op.children.size(); child_idx++) {
+		if (IsSubqueryEvidenceSide(op, child_idx) || IsUnrelatedNullableJoinSide(op, child_idx, correlated_columns)) {
+			continue;
+		}
+		auto child_correlated_columns = TraceCorrelatedColumnsIntoChild(op, child_idx, correlated_columns);
+		if (HasDelimiterDomainSelection(*op.children[child_idx], marker_indexes, ignore_marker_filters,
+		                                child_correlated_columns)) {
 			return true;
 		}
 	}
@@ -397,6 +584,35 @@ static bool ContainsSubqueryJoin(LogicalOperator &op) {
 	return false;
 }
 
+static bool NestedDelimJoinUsesAdditionalCorrelation(const LogicalOperator &op,
+                                                     const vector<unique_ptr<Expression>> &correlated_columns) {
+	if (op.type == LogicalOperatorType::LOGICAL_DELIM_JOIN) {
+		auto &join = op.Cast<LogicalComparisonJoin>();
+		for (auto &nested_column : join.duplicate_eliminated_columns) {
+			bool found = false;
+			for (auto &column : correlated_columns) {
+				if (Expression::Equals(*nested_column, *column)) {
+					found = true;
+					break;
+				}
+			}
+			if (!found) {
+				return true;
+			}
+		}
+	}
+	for (idx_t child_idx = 0; child_idx < op.children.size(); child_idx++) {
+		if (IsSubqueryEvidenceSide(op, child_idx) || IsUnrelatedNullableJoinSide(op, child_idx, correlated_columns)) {
+			continue;
+		}
+		auto child_correlated_columns = TraceCorrelatedColumnsIntoChild(op, child_idx, correlated_columns);
+		if (NestedDelimJoinUsesAdditionalCorrelation(*op.children[child_idx], child_correlated_columns)) {
+			return true;
+		}
+	}
+	return false;
+}
+
 struct GeneratedDedupRef {
 	optional_ptr<LogicalCTERef> cte_ref;
 	vector<ColumnBinding> output_bindings;
@@ -417,6 +633,47 @@ static bool IsEqualityComparison(ExpressionType comparison_type) {
 
 static bool IsEqualityJoinCondition(const JoinCondition &cond) {
 	return cond.IsComparison() && IsEqualityComparison(cond.GetComparisonType());
+}
+
+static bool HasSingleEqualityJoinCondition(const LogicalComparisonJoin &join) {
+	if (join.conditions.size() != 1) {
+		return false;
+	}
+	auto &condition = join.conditions[0];
+	return condition.IsComparison() && (condition.GetComparisonType() == ExpressionType::COMPARE_EQUAL ||
+	                                    condition.GetComparisonType() == ExpressionType::COMPARE_NOT_DISTINCT_FROM);
+}
+
+static void CollectEligibleSimpleMarkerIndexes(LogicalOperator &op, const set<TableIndex> &simple_marker_indexes,
+                                               set<TableIndex> &preserve_marker_indexes) {
+	if (op.type == LogicalOperatorType::LOGICAL_DELIM_JOIN) {
+		auto &join = op.Cast<LogicalComparisonJoin>();
+		if (join.join_type == JoinType::MARK &&
+		    simple_marker_indexes.find(join.mark_index) != simple_marker_indexes.end() &&
+		    HasSingleEqualityJoinCondition(join)) {
+			preserve_marker_indexes.insert(join.mark_index);
+		}
+	}
+	for (auto &child : op.children) {
+		CollectEligibleSimpleMarkerIndexes(*child, simple_marker_indexes, preserve_marker_indexes);
+	}
+}
+
+static bool IsTautologicalNotDistinctComparison(const Expression &expr) {
+	if (expr.GetExpressionType() != ExpressionType::COMPARE_NOT_DISTINCT_FROM ||
+	    !BoundComparisonExpression::IsComparison(expr)) {
+		return false;
+	}
+	auto &comparison = expr.Cast<BoundFunctionExpression>();
+	auto &lhs = BoundComparisonExpression::Left(comparison);
+	auto &rhs = BoundComparisonExpression::Right(comparison);
+	if (lhs.GetExpressionType() != ExpressionType::BOUND_COLUMN_REF ||
+	    rhs.GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
+		return false;
+	}
+	auto &lhs_colref = lhs.Cast<BoundColumnRefExpression>();
+	auto &rhs_colref = rhs.Cast<BoundColumnRefExpression>();
+	return lhs_colref.Depth() == rhs_colref.Depth() && lhs_colref.Binding() == rhs_colref.Binding();
 }
 
 static bool FindAndReplaceBindings(vector<ColumnBinding> &traced_bindings,
@@ -578,7 +835,7 @@ class GeneratedDedupRefEliminator {
 public:
 	GeneratedDedupRefEliminator(ClientContext &context, unique_ptr<LogicalOperator> &delim_join_op,
 	                            TableIndex dedup_cte_index, idx_t dedup_ref_count, LogicalOperator &rewrite_root,
-	                            bool preserve_evidence_side);
+	                            bool preserve_evidence_side, bool preserve_nested_evidence_side);
 
 	idx_t Remove();
 
@@ -610,15 +867,17 @@ private:
 	idx_t dedup_ref_count;
 	LogicalOperator &rewrite_root;
 	bool preserve_evidence_side;
+	bool preserve_nested_evidence_side;
 };
 
 GeneratedDedupRefEliminator::GeneratedDedupRefEliminator(ClientContext &context,
                                                          unique_ptr<LogicalOperator> &delim_join_op,
                                                          TableIndex dedup_cte_index, idx_t dedup_ref_count,
-                                                         LogicalOperator &rewrite_root, bool preserve_evidence_side)
+                                                         LogicalOperator &rewrite_root, bool preserve_evidence_side,
+                                                         bool preserve_nested_evidence_side)
     : context(context), delim_join_op(delim_join_op), delim_join(delim_join_op->Cast<LogicalComparisonJoin>()),
       dedup_cte_index(dedup_cte_index), dedup_ref_count(dedup_ref_count), rewrite_root(rewrite_root),
-      preserve_evidence_side(preserve_evidence_side) {
+      preserve_evidence_side(preserve_evidence_side), preserve_nested_evidence_side(preserve_nested_evidence_side) {
 }
 
 unique_ptr<GeneratedDedupRef> GeneratedDedupRefEliminator::GetGeneratedDedupRef(LogicalOperator &op,
@@ -1284,6 +1543,9 @@ bool GeneratedDedupRefEliminator::RemoveJoin(unique_ptr<LogicalOperator> &join, 
 			if (ExpressionReferencesGeneratedSide(*expr, *dedup_ref)) {
 				return false;
 			}
+			if (IsTautologicalNotDistinctComparison(*expr)) {
+				continue;
+			}
 			filter_expressions.push_back(std::move(expr));
 		}
 	} else {
@@ -1436,10 +1698,13 @@ bool GeneratedDedupRefEliminator::RemoveFilterCrossProduct(unique_ptr<LogicalOpe
 }
 
 idx_t GeneratedDedupRefEliminator::Remove() {
-	auto preserve_selected_domain = HasSelection(*delim_join.children[0]);
+	set<TableIndex> marker_indexes;
+	auto preserve_selected_domain = HasDelimiterDomainSelection(*delim_join.children[0], marker_indexes, false,
+	                                                            delim_join.duplicate_eliminated_columns);
 	auto selected_evidence_side = preserve_selected_domain && preserve_evidence_side &&
 	                              HasEvidenceSide(delim_join.join_type) &&
-	                              !ContainsSubqueryJoin(*delim_join.children[0]);
+	                              (!ContainsSubqueryJoin(*delim_join.children[0]) ||
+	                               (preserve_nested_evidence_side && HasSingleEqualityJoinCondition(delim_join)));
 	auto old_right_bindings = delim_join.children[1]->GetColumnBindings();
 	BindingReplacementGraph right_replacements;
 	if (RewriteSubtree(delim_join.children[1], preserve_selected_domain, right_replacements, false,
@@ -1462,7 +1727,8 @@ struct GeneratedDomainRef {
 class GeneratedDomainJoinEliminator {
 public:
 	GeneratedDomainJoinEliminator(unique_ptr<LogicalOperator> &rewrite_root,
-	                              const vector<TableIndex> &generated_dedup_cte_indexes);
+	                              const vector<TableIndex> &generated_dedup_cte_indexes,
+	                              const set<TableIndex> &preserve_marker_indexes);
 
 	bool Rewrite();
 
@@ -1493,12 +1759,15 @@ private:
 private:
 	unique_ptr<LogicalOperator> &rewrite_root;
 	const vector<TableIndex> &generated_dedup_cte_indexes;
+	const set<TableIndex> &preserve_marker_indexes;
 	vector<reference<LogicalCTE>> ctes;
 };
 
 GeneratedDomainJoinEliminator::GeneratedDomainJoinEliminator(unique_ptr<LogicalOperator> &rewrite_root,
-                                                             const vector<TableIndex> &generated_dedup_cte_indexes)
-    : rewrite_root(rewrite_root), generated_dedup_cte_indexes(generated_dedup_cte_indexes) {
+                                                             const vector<TableIndex> &generated_dedup_cte_indexes,
+                                                             const set<TableIndex> &preserve_marker_indexes)
+    : rewrite_root(rewrite_root), generated_dedup_cte_indexes(generated_dedup_cte_indexes),
+      preserve_marker_indexes(preserve_marker_indexes) {
 }
 
 void GeneratedDomainJoinEliminator::CollectCTEs(LogicalOperator &op) {
@@ -1881,6 +2150,9 @@ bool GeneratedDomainJoinEliminator::RemoveGeneratedDedupJoin(unique_ptr<LogicalO
 		    ExpressionReferencesBinding(*expr, cte_bindings)) {
 			return false;
 		}
+		if (IsTautologicalNotDistinctComparison(*expr)) {
+			continue;
+		}
 		filter_expressions.push_back(std::move(expr));
 	}
 
@@ -2005,6 +2277,9 @@ bool GeneratedDomainJoinEliminator::RemoveGeneratedDomainJoin(unique_ptr<Logical
 		    ExpressionReferencesBinding(*expr, domain_ref->source_bindings)) {
 			return false;
 		}
+		if (IsTautologicalNotDistinctComparison(*expr)) {
+			continue;
+		}
 		filter_expressions.push_back(std::move(expr));
 	}
 
@@ -2031,7 +2306,11 @@ bool GeneratedDomainJoinEliminator::TryRewriteOnce(unique_ptr<LogicalOperator> &
 			child_under_evidence_side = true;
 		} else if (!under_evidence_side && op->type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN) {
 			auto &join = op->Cast<LogicalComparisonJoin>();
-			if ((join.join_type == JoinType::ANTI || join.join_type == JoinType::RIGHT_ANTI) &&
+			const auto preserve_mark_evidence =
+			    join.join_type == JoinType::MARK &&
+			    preserve_marker_indexes.find(join.mark_index) != preserve_marker_indexes.end();
+			if ((join.join_type == JoinType::ANTI || join.join_type == JoinType::RIGHT_ANTI ||
+			     preserve_mark_evidence) &&
 			    IsEvidenceSide(*op, child_idx)) {
 				child_under_evidence_side = true;
 			}
@@ -2141,7 +2420,8 @@ DelimJoinCTERewriter::DelimJoinCTERewriter(Binder &binder) : binder(binder) {
 BindingReplacementGraph DelimJoinCTERewriter::MaterializeDelimJoinAsCTE(unique_ptr<LogicalOperator> &plan,
                                                                         LogicalOperator &rewrite_root,
                                                                         bool null_rejecting_filter_above,
-                                                                        bool preserve_evidence_side) {
+                                                                        bool preserve_evidence_side,
+                                                                        bool preserve_nested_evidence_side) {
 	BindingReplacementGraph output_replacements;
 	{
 		auto &join = plan->Cast<LogicalComparisonJoin>();
@@ -2158,7 +2438,7 @@ BindingReplacementGraph DelimJoinCTERewriter::MaterializeDelimJoinAsCTE(unique_p
 		auto cte_deliminator_timer =
 		    QueryProfiler::Get(binder.context).StartTimerInternal(CTE_DELIMINATOR_PROFILER_KEY);
 		GeneratedDedupRefEliminator eliminator(binder.context, plan, dedup_cte_index, dedup_ref_count, rewrite_root,
-		                                       preserve_evidence_side);
+		                                       preserve_evidence_side, preserve_nested_evidence_side);
 		dedup_ref_count = eliminator.Remove();
 		auto &join = plan->Cast<LogicalComparisonJoin>();
 		if (SingleJoinRHSIsDeduplicated(join)) {
@@ -2302,6 +2582,15 @@ BindingReplacementGraph DelimJoinCTERewriter::RewriteDelimJoinsToCTEs(unique_ptr
                                                                       bool null_rejecting_filter_above,
                                                                       bool preserve_evidence_side) {
 	BindingReplacementGraph output_replacements;
+	bool preserve_nested_evidence_side = false;
+	bool has_non_subquery_selection = false;
+	if (plan->type == LogicalOperatorType::LOGICAL_DELIM_JOIN) {
+		auto &join = plan->Cast<LogicalComparisonJoin>();
+		preserve_nested_evidence_side =
+		    NestedDelimJoinUsesAdditionalCorrelation(*join.children[0], join.duplicate_eliminated_columns);
+		has_non_subquery_selection =
+		    HasDelimiterDomainSelection(*join.children[0], marker_indexes, true, join.duplicate_eliminated_columns);
+	}
 	for (idx_t child_idx = 0; child_idx < plan->children.size(); child_idx++) {
 		auto &child = plan->children[child_idx];
 		auto old_child_bindings = child->GetColumnBindings();
@@ -2320,8 +2609,16 @@ BindingReplacementGraph DelimJoinCTERewriter::RewriteDelimJoinsToCTEs(unique_ptr
 		output_replacements.Merge(child_replacements);
 	}
 	if (plan->type == LogicalOperatorType::LOGICAL_DELIM_JOIN) {
-		auto materialize_replacements =
-		    MaterializeDelimJoinAsCTE(plan, rewrite_root, null_rejecting_filter_above, preserve_evidence_side);
+		auto &join = plan->Cast<LogicalComparisonJoin>();
+		if (join.join_type == JoinType::MARK &&
+		    preserve_marker_indexes.find(join.mark_index) != preserve_marker_indexes.end()) {
+			preserve_evidence_side = true;
+			preserve_nested_evidence_side =
+			    preserve_nested_evidence_side || has_non_subquery_selection ||
+			    preserve_nested_marker_indexes.find(join.mark_index) != preserve_nested_marker_indexes.end();
+		}
+		auto materialize_replacements = MaterializeDelimJoinAsCTE(
+		    plan, rewrite_root, null_rejecting_filter_above, preserve_evidence_side, preserve_nested_evidence_side);
 		output_replacements.Merge(materialize_replacements);
 	}
 	return output_replacements;
@@ -2333,6 +2630,14 @@ void DelimJoinCTERewriter::Rewrite(Binder &binder, unique_ptr<LogicalOperator> &
 }
 
 void DelimJoinCTERewriter::Rewrite(unique_ptr<LogicalOperator> &plan) {
+	marker_indexes.clear();
+	preserve_marker_indexes.clear();
+	preserve_nested_marker_indexes.clear();
+	CollectDelimJoinMarkerIndexes(*plan, marker_indexes);
+	set<TableIndex> simple_marker_indexes;
+	CollectComplexMarkerReferences(*plan, marker_indexes, preserve_marker_indexes, simple_marker_indexes);
+	CollectEligibleSimpleMarkerIndexes(*plan, simple_marker_indexes, preserve_nested_marker_indexes);
+	preserve_marker_indexes.insert(preserve_nested_marker_indexes.begin(), preserve_nested_marker_indexes.end());
 	bool filters_pushed;
 	do {
 		filters_pushed = PushEligibleFiltersIntoDelimJoinInputs(plan);
@@ -2341,7 +2646,8 @@ void DelimJoinCTERewriter::Rewrite(unique_ptr<LogicalOperator> &plan) {
 	if (cte_deliminator_enabled) {
 		auto cte_deliminator_timer =
 		    QueryProfiler::Get(binder.context).StartTimerInternal(CTE_DELIMINATOR_PROFILER_KEY);
-		GeneratedDomainJoinEliminator generated_domain_join_eliminator(plan, generated_dedup_cte_indexes);
+		GeneratedDomainJoinEliminator generated_domain_join_eliminator(plan, generated_dedup_cte_indexes,
+		                                                               preserve_marker_indexes);
 		generated_domain_join_eliminator.Rewrite();
 	}
 	VerifyNoDelim(*plan);

--- a/src/planner/subquery/delim_join_cte_rewriter.cpp
+++ b/src/planner/subquery/delim_join_cte_rewriter.cpp
@@ -250,6 +250,13 @@ static void CollectDelimJoinMarkerIndexes(LogicalOperator &op, set<TableIndex> &
 	}
 }
 
+struct MarkerBindingInfo {
+	set<TableIndex> marker_indexes;
+	bool simple = false;
+};
+
+using marker_binding_map_t = column_binding_map_t<MarkerBindingInfo>;
+
 static void CollectExpressionMarkerReferences(Expression &expr, const set<TableIndex> &marker_indexes,
                                               set<TableIndex> &referenced_markers) {
 	ExpressionIterator::VisitExpression<BoundColumnRefExpression>(expr, [&](const BoundColumnRefExpression &colref) {
@@ -259,44 +266,103 @@ static void CollectExpressionMarkerReferences(Expression &expr, const set<TableI
 	});
 }
 
-static bool ExpressionHasComplexMarkerReference(Expression &expr, const set<TableIndex> &marker_indexes) {
-	if (expr.GetExpressionType() == ExpressionType::BOUND_COLUMN_REF) {
-		return false;
+static marker_binding_map_t CreateMarkerBindingMap(const set<TableIndex> &marker_indexes) {
+	marker_binding_map_t result;
+	for (auto marker_index : marker_indexes) {
+		MarkerBindingInfo info;
+		info.marker_indexes.insert(marker_index);
+		info.simple = true;
+		result.emplace(ColumnBinding(marker_index, ProjectionIndex(0)), std::move(info));
 	}
-	if (expr.GetExpressionType() == ExpressionType::OPERATOR_NOT) {
-		auto &not_expr = expr.Cast<BoundOperatorExpression>();
-		if (not_expr.GetChildren().size() == 1 &&
-		    not_expr.GetChildren()[0]->GetExpressionType() == ExpressionType::BOUND_COLUMN_REF) {
-			return false;
-		}
-	}
-	set<TableIndex> referenced_markers;
-	CollectExpressionMarkerReferences(expr, marker_indexes, referenced_markers);
-	return !referenced_markers.empty();
+	return result;
 }
 
-static void CollectComplexMarkerReferences(LogicalOperator &op, const set<TableIndex> &marker_indexes,
-                                           set<TableIndex> &preserve_marker_indexes,
-                                           set<TableIndex> &simple_marker_indexes) {
+static void CollectExpressionMarkerReferences(Expression &expr, const marker_binding_map_t &marker_bindings,
+                                              set<TableIndex> &referenced_markers) {
+	ExpressionIterator::VisitExpression<BoundColumnRefExpression>(expr, [&](const BoundColumnRefExpression &colref) {
+		if (colref.Depth() != 0) {
+			return;
+		}
+		auto entry = marker_bindings.find(colref.Binding());
+		if (entry == marker_bindings.end()) {
+			return;
+		}
+		referenced_markers.insert(entry->second.marker_indexes.begin(), entry->second.marker_indexes.end());
+	});
+}
+
+static bool ExpressionIsSimpleMarkerBinding(Expression &expr, const marker_binding_map_t &marker_bindings) {
+	if (expr.GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
+		return false;
+	}
+	auto &colref = expr.Cast<BoundColumnRefExpression>();
+	if (colref.Depth() != 0) {
+		return false;
+	}
+	auto entry = marker_bindings.find(colref.Binding());
+	return entry != marker_bindings.end() && entry->second.simple;
+}
+
+static bool ExpressionIsSimpleMarkerReference(Expression &expr, const marker_binding_map_t &marker_bindings) {
+	if (ExpressionIsSimpleMarkerBinding(expr, marker_bindings)) {
+		return true;
+	}
+	if (expr.GetExpressionType() != ExpressionType::OPERATOR_NOT) {
+		return false;
+	}
+	auto &not_expr = expr.Cast<BoundOperatorExpression>();
+	return not_expr.GetChildren().size() == 1 &&
+	       ExpressionIsSimpleMarkerBinding(*not_expr.GetChildren()[0], marker_bindings);
+}
+
+static MarkerBindingInfo GetMarkerBindingInfo(Expression &expr, const marker_binding_map_t &marker_bindings) {
+	MarkerBindingInfo result;
+	CollectExpressionMarkerReferences(expr, marker_bindings, result.marker_indexes);
+	result.simple = !result.marker_indexes.empty() && ExpressionIsSimpleMarkerReference(expr, marker_bindings);
+	return result;
+}
+
+static void AddProjectionMarkerBindings(LogicalProjection &projection, marker_binding_map_t &marker_bindings) {
+	auto projection_bindings = projection.GetColumnBindings();
+	D_ASSERT(projection_bindings.size() == projection.expressions.size());
+	for (idx_t expr_idx = 0; expr_idx < projection.expressions.size(); expr_idx++) {
+		auto info = GetMarkerBindingInfo(*projection.expressions[expr_idx], marker_bindings);
+		if (info.marker_indexes.empty()) {
+			continue;
+		}
+		marker_bindings.emplace(projection_bindings[expr_idx], std::move(info));
+	}
+}
+
+static void CollectMarkerReferences(LogicalOperator &op, marker_binding_map_t &marker_bindings,
+                                    set<TableIndex> &preserve_marker_indexes, set<TableIndex> &simple_marker_indexes) {
+	for (auto &child : op.children) {
+		CollectMarkerReferences(*child, marker_bindings, preserve_marker_indexes, simple_marker_indexes);
+	}
 	vector<reference<Expression>> expressions;
 	LogicalOperatorVisitor::EnumerateExpressions(
 	    op, [&](unique_ptr<Expression> *expr) { expressions.emplace_back(**expr); });
+	set<TableIndex> simple_filter_markers;
 	bool has_complex_marker_reference = false;
 	for (auto &expr : expressions) {
-		has_complex_marker_reference =
-		    has_complex_marker_reference || ExpressionHasComplexMarkerReference(expr.get(), marker_indexes);
-	}
-	set<TableIndex> referenced_markers;
-	for (auto &expr : expressions) {
-		CollectExpressionMarkerReferences(expr.get(), marker_indexes, referenced_markers);
+		auto info = GetMarkerBindingInfo(expr.get(), marker_bindings);
+		if (info.marker_indexes.empty()) {
+			continue;
+		}
+		if (!info.simple) {
+			preserve_marker_indexes.insert(info.marker_indexes.begin(), info.marker_indexes.end());
+			has_complex_marker_reference = true;
+		} else if (op.type == LogicalOperatorType::LOGICAL_FILTER) {
+			simple_filter_markers.insert(info.marker_indexes.begin(), info.marker_indexes.end());
+		} else {
+			simple_marker_indexes.insert(info.marker_indexes.begin(), info.marker_indexes.end());
+		}
 	}
 	if (has_complex_marker_reference) {
-		preserve_marker_indexes.insert(referenced_markers.begin(), referenced_markers.end());
-	} else if (op.type != LogicalOperatorType::LOGICAL_FILTER) {
-		simple_marker_indexes.insert(referenced_markers.begin(), referenced_markers.end());
+		simple_marker_indexes.insert(simple_filter_markers.begin(), simple_filter_markers.end());
 	}
-	for (auto &child : op.children) {
-		CollectComplexMarkerReferences(*child, marker_indexes, preserve_marker_indexes, simple_marker_indexes);
+	if (op.type == LogicalOperatorType::LOGICAL_PROJECTION) {
+		AddProjectionMarkerBindings(op.Cast<LogicalProjection>(), marker_bindings);
 	}
 }
 
@@ -2634,8 +2700,9 @@ void DelimJoinCTERewriter::Rewrite(unique_ptr<LogicalOperator> &plan) {
 	preserve_marker_indexes.clear();
 	preserve_nested_marker_indexes.clear();
 	CollectDelimJoinMarkerIndexes(*plan, marker_indexes);
+	auto marker_bindings = CreateMarkerBindingMap(marker_indexes);
 	set<TableIndex> simple_marker_indexes;
-	CollectComplexMarkerReferences(*plan, marker_indexes, preserve_marker_indexes, simple_marker_indexes);
+	CollectMarkerReferences(*plan, marker_bindings, preserve_marker_indexes, simple_marker_indexes);
 	CollectEligibleSimpleMarkerIndexes(*plan, simple_marker_indexes, preserve_nested_marker_indexes);
 	preserve_marker_indexes.insert(preserve_nested_marker_indexes.begin(), preserve_nested_marker_indexes.end());
 	bool filters_pushed;

--- a/test/optimizer/deliminator.test
+++ b/test/optimizer/deliminator.test
@@ -488,6 +488,132 @@ ORDER BY x, z;
 1	0	false
 1	1	true
 
+# Complex marker expressions preserve only the marker domains they reference
+query II
+EXPLAIN SELECT x, z,
+	EXISTS (SELECT 1 FROM range(1000000000) a(y) WHERE y = o.x AND y = p.z),
+	EXISTS (SELECT 1 FROM range(1000000000) b(y) WHERE y = o.x)
+		OR EXISTS (SELECT 1 FROM range(1000000000) c(y) WHERE y = o.x)
+FROM range(1000000) o(x), range(1000000) p(z)
+WHERE x < 10 AND z < 10;
+----
+logical_opt	<REGEX>:.*CTE Name: __duckdb_delim.*CTE Name: __duckdb_delim.*Join Type: RIGHT_SEMI.*Join Type: RIGHT_SEMI.*
+
+query II
+EXPLAIN SELECT x, z,
+	EXISTS (SELECT 1 FROM range(1000000000) a(y) WHERE y = o.x AND y = p.z),
+	EXISTS (SELECT 1 FROM range(1000000000) b(y) WHERE y = o.x)
+		OR EXISTS (SELECT 1 FROM range(1000000000) c(y) WHERE y = o.x)
+FROM range(1000000) o(x), range(1000000) p(z)
+WHERE x < 10 AND z < 10;
+----
+logical_opt	<!REGEX>:.*Join Type: RIGHT_SEMI.*Conditions: x = y,.*z = y.*
+
+# Simple filter markers remain subject to the single-equality guard
+query II
+EXPLAIN SELECT count(*)
+FROM range(1000000) o(x), range(1000000) p(z)
+WHERE x < 10 AND z < 10
+	AND EXISTS (SELECT 1 FROM range(1000000000) a(y) WHERE y = o.x AND y = p.z)
+	AND (
+		EXISTS (SELECT 1 FROM range(1000000000) b(y) WHERE y = o.x)
+		OR EXISTS (SELECT 1 FROM range(1000000000) c(y) WHERE y = o.x)
+	);
+----
+logical_opt	<REGEX>:.*CTE Name: __duckdb_delim.*CTE Name: __duckdb_delim.*Join Type: RIGHT_SEMI.*Join Type: RIGHT_SEMI.*
+
+query II
+EXPLAIN SELECT count(*)
+FROM range(1000000) o(x), range(1000000) p(z)
+WHERE x < 10 AND z < 10
+	AND EXISTS (SELECT 1 FROM range(1000000000) a(y) WHERE y = o.x AND y = p.z)
+	AND (
+		EXISTS (SELECT 1 FROM range(1000000000) b(y) WHERE y = o.x)
+		OR EXISTS (SELECT 1 FROM range(1000000000) c(y) WHERE y = o.x)
+	);
+----
+logical_opt	<!REGEX>:.*Join Type: RIGHT_SEMI.*Conditions: x = y,.*z = y.*
+
+query I
+SELECT count(*)
+FROM range(2) o(x), range(2) p(z)
+WHERE EXISTS (SELECT 1 FROM range(2) a(y) WHERE y = o.x AND y = p.z)
+	AND (
+		EXISTS (SELECT 1 FROM range(1) b(y) WHERE y = o.x)
+		OR EXISTS (SELECT 1 FROM range(2, 3) c(y) WHERE y = o.x)
+	);
+----
+1
+
+# Marker provenance is preserved through projection aliases
+query II
+EXPLAIN SELECT x, z,
+	coalesce(EXISTS (SELECT 1 FROM range(1000000000) a(y) WHERE y = o.x AND y = p.z), false)
+FROM range(1000000) o(x), range(1000000) p(z)
+WHERE x < 10 AND z < 10;
+----
+logical_opt	<REGEX>:.*CTE Name: __duckdb_delim.*Join Type: RIGHT_SEMI.*Conditions: x = y,.*z = y.*
+
+query II
+EXPLAIN SELECT x, z, coalesce(m, false)
+FROM (
+	SELECT x, z, EXISTS (SELECT 1 FROM range(1000000000) a(y) WHERE y = o.x AND y = p.z) AS m
+	FROM range(1000000) o(x), range(1000000) p(z)
+	WHERE x < 10 AND z < 10
+) q;
+----
+logical_opt	<REGEX>:.*CTE Name: __duckdb_delim.*Join Type: RIGHT_SEMI.*Conditions: x = y,.*z = y.*
+
+query II
+EXPLAIN SELECT x, z, coalesce(m2, false)
+FROM (
+	SELECT x, z, m AS m2
+	FROM (
+		SELECT x, z, EXISTS (SELECT 1 FROM range(1000000000) a(y) WHERE y = o.x AND y = p.z) AS m
+		FROM range(1000000) o(x), range(1000000) p(z)
+		WHERE x < 10 AND z < 10
+	) q1
+) q2;
+----
+logical_opt	<REGEX>:.*CTE Name: __duckdb_delim.*Join Type: RIGHT_SEMI.*Conditions: x = y,.*z = y.*
+
+# A simple aliased marker with multiple equality keys stays on the ordinary MARK path
+query II
+EXPLAIN SELECT x, z, m
+FROM (
+	SELECT x, z, EXISTS (SELECT 1 FROM range(1000000000) a(y) WHERE y = o.x AND y = p.z) AS m
+	FROM range(1000000) o(x), range(1000000) p(z)
+	WHERE x < 10 AND z < 10
+) q;
+----
+logical_opt	<!REGEX>:.*CTE Name: __duckdb_delim.*
+
+query IIII
+SELECT x, z,
+	EXISTS (SELECT 1 FROM range(2) a(y) WHERE y = o.x AND y = p.z),
+	EXISTS (SELECT 1 FROM range(1) b(y) WHERE y = o.x)
+		OR EXISTS (SELECT 1 FROM range(2, 3) c(y) WHERE y = o.x)
+FROM range(2) o(x), range(2) p(z)
+ORDER BY x, z;
+----
+0	0	true	true
+0	1	false	true
+1	0	false	false
+1	1	true	false
+
+query III
+SELECT x, z, coalesce(m, false)
+FROM (
+	SELECT x, z, EXISTS (SELECT 1 FROM range(2) a(y) WHERE y = o.x AND y = p.z) AS m
+	FROM range(2) o(x), range(2) p(z)
+) q
+ORDER BY x, z;
+----
+0	0	true
+0	1	false
+1	0	false
+1	1	true
+
 query I
 SELECT count(*) FILTER (WHERE
 	EXISTS (SELECT 1 FROM range(3) a(y) WHERE y = o.x)
@@ -548,6 +674,43 @@ query III
 SELECT x, z,
 	EXISTS (SELECT 1 FROM range(2) a(y) WHERE y = o.x AND y = p.z)
 FROM range(2) o(x), range(2) p(z)
+ORDER BY x, z;
+----
+0	0	true
+0	1	false
+1	0	false
+1	1	true
+
+query IIII
+SELECT x, z,
+	EXISTS (SELECT 1 FROM range(2) a(y) WHERE y = o.x AND y = p.z),
+	EXISTS (SELECT 1 FROM range(1) b(y) WHERE y = o.x)
+		OR EXISTS (SELECT 1 FROM range(2, 3) c(y) WHERE y = o.x)
+FROM range(2) o(x), range(2) p(z)
+ORDER BY x, z;
+----
+0	0	true	true
+0	1	false	true
+1	0	false	false
+1	1	true	false
+
+query I
+SELECT count(*)
+FROM range(2) o(x), range(2) p(z)
+WHERE EXISTS (SELECT 1 FROM range(2) a(y) WHERE y = o.x AND y = p.z)
+	AND (
+		EXISTS (SELECT 1 FROM range(1) b(y) WHERE y = o.x)
+		OR EXISTS (SELECT 1 FROM range(2, 3) c(y) WHERE y = o.x)
+	);
+----
+1
+
+query III
+SELECT x, z, coalesce(m, false)
+FROM (
+	SELECT x, z, EXISTS (SELECT 1 FROM range(2) a(y) WHERE y = o.x AND y = p.z) AS m
+	FROM range(2) o(x), range(2) p(z)
+) q
 ORDER BY x, z;
 ----
 0	0	true

--- a/test/optimizer/deliminator.test
+++ b/test/optimizer/deliminator.test
@@ -59,6 +59,12 @@ explain SELECT s_name, s_address FROM supplier, nation WHERE s_suppkey IN ( SELE
 ----
 logical_opt	<REGEX>:.*Groups: ps_suppkey, ps_partkey.*Join Type: SEMI.*l_partkey = ps_partkey.*l_suppkey = ps_suppkey.*(DELIM_GET|CTE_SCAN).*
 
+# Eliminating the generated domain join must not leave tautological filters on the lineitem scan
+query II
+explain SELECT s_name, s_address FROM supplier, nation WHERE s_suppkey IN ( SELECT ps_suppkey FROM partsupp WHERE ps_partkey IN ( SELECT p_partkey FROM part WHERE p_name LIKE 'forest%') AND ps_availqty > ( SELECT 0.5 * sum(l_quantity) FROM lineitem WHERE l_partkey = ps_partkey AND l_suppkey = ps_suppkey AND l_shipdate >= CAST('1994-01-01' AS date) AND l_shipdate < CAST('1995-01-01' AS date))) AND s_nationkey = n_nationkey AND n_name = 'CANADA' ORDER BY s_name;
+----
+logical_opt	<!REGEX>:.*(l_partkey IS NOT DISTINCT FROM l_partkey|l_suppkey IS NOT DISTINCT FROM l_suppkey).*
+
 # Reduced SQLStorm 6064: a pair-dependent predicate below a reused window CTE remains in the
 # normal decorrelation pipeline and exposes both join keys to the optimizer. MARK is retained
 # when column liveness cannot prove that conversion to SEMI is safe.
@@ -250,6 +256,381 @@ query II
 EXPLAIN SELECT x FROM range(1000000) o(x) WHERE x < 10000 AND EXISTS (SELECT 1 FROM range(10000000) l(y) WHERE y = x AND y > 0);
 ----
 logical_opt	<REGEX>:.*Join Type: RIGHT_SEMI.*x = x.*
+
+# All evidence sides in a complex marker filter should retain the selected outer domain
+statement ok
+CREATE TABLE outer_fact(id BIGINT, dim_id BIGINT, payload BIGINT);
+
+statement ok
+CREATE TABLE selected_dim(id BIGINT, selected BOOLEAN);
+
+statement ok
+CREATE TABLE evidence_a(id BIGINT);
+
+statement ok
+CREATE TABLE evidence_b(id BIGINT);
+
+statement ok
+CREATE TABLE evidence_c(id BIGINT);
+
+statement ok
+CREATE TABLE evidence_d(id BIGINT);
+
+statement ok
+CREATE TABLE evidence_a_flag(id BIGINT, selected BOOLEAN);
+
+statement ok
+CREATE TABLE evidence_b_flag(id BIGINT, selected BOOLEAN);
+
+statement ok
+CREATE TABLE evidence_c_flag(id BIGINT, selected BOOLEAN);
+
+statement ok
+INSERT INTO outer_fact VALUES (1, 10, 100), (2, 10, 200), (3, 20, 300), (4, 10, NULL), (NULL, 10, 400);
+
+statement ok
+INSERT INTO selected_dim VALUES (10, true), (20, false);
+
+statement ok
+INSERT INTO evidence_a VALUES (1), (1), (2), (3), (NULL);
+
+statement ok
+INSERT INTO evidence_b VALUES (2), (4), (NULL);
+
+statement ok
+INSERT INTO evidence_c VALUES (1), (1), (4);
+
+statement ok
+INSERT INTO evidence_d VALUES (4);
+
+statement ok
+INSERT INTO evidence_a_flag SELECT id, true FROM evidence_a;
+
+statement ok
+INSERT INTO evidence_b_flag SELECT id, true FROM evidence_b;
+
+statement ok
+INSERT INTO evidence_c_flag SELECT id, true FROM evidence_c;
+
+query II
+EXPLAIN SELECT count(*), sum(payload) FROM outer_fact o, selected_dim d WHERE o.dim_id = d.id AND d.selected AND EXISTS (SELECT 1 FROM evidence_a a WHERE a.id = o.id) AND (EXISTS (SELECT 1 FROM evidence_b b WHERE b.id = o.id) OR EXISTS (SELECT 1 FROM evidence_c c WHERE c.id = o.id));
+----
+logical_opt	<REGEX>:.*CTE Name: __duckdb_delim.*Join Type: SEMI.*Join Type: SEMI.*Join Type: SEMI.*
+
+query II
+SELECT count(*), sum(payload) FROM outer_fact o, selected_dim d WHERE o.dim_id = d.id AND d.selected AND EXISTS (SELECT 1 FROM evidence_a a WHERE a.id = o.id) AND (EXISTS (SELECT 1 FROM evidence_b b WHERE b.id = o.id) OR EXISTS (SELECT 1 FROM evidence_c c WHERE c.id = o.id));
+----
+2	300
+
+# Evidence-side filters do not select the outer delimiter domain
+query II
+EXPLAIN SELECT count(*), sum(payload) FROM outer_fact o WHERE EXISTS (SELECT 1 FROM evidence_a_flag a WHERE a.id = o.id AND a.selected) AND (EXISTS (SELECT 1 FROM evidence_b_flag b WHERE b.id = o.id AND b.selected) OR EXISTS (SELECT 1 FROM evidence_c_flag c WHERE c.id = o.id AND c.selected));
+----
+logical_opt	<!REGEX>:.*CTE Name: __duckdb_delim.*
+
+query II
+SELECT count(*), sum(payload) FROM outer_fact o WHERE EXISTS (SELECT 1 FROM evidence_a_flag a WHERE a.id = o.id AND a.selected) AND (EXISTS (SELECT 1 FROM evidence_b_flag b WHERE b.id = o.id AND b.selected) OR EXISTS (SELECT 1 FROM evidence_c_flag c WHERE c.id = o.id AND c.selected));
+----
+2	300
+
+# Filters on an unrelated nullable join side do not select the delimiter domain
+query II
+EXPLAIN SELECT count(*), sum(payload) FROM outer_fact o LEFT JOIN (SELECT * FROM selected_dim WHERE selected) d ON d.id = o.dim_id WHERE EXISTS (SELECT 1 FROM evidence_a a WHERE a.id = o.id) AND (EXISTS (SELECT 1 FROM evidence_b b WHERE b.id = o.id) OR EXISTS (SELECT 1 FROM evidence_c c WHERE c.id = o.id));
+----
+logical_opt	<!REGEX>:.*CTE Name: __duckdb_delim.*
+
+query II
+EXPLAIN SELECT count(*), sum(payload) FROM (SELECT * FROM selected_dim WHERE selected) d RIGHT JOIN outer_fact o ON d.id = o.dim_id WHERE EXISTS (SELECT 1 FROM evidence_a a WHERE a.id = o.id) AND (EXISTS (SELECT 1 FROM evidence_b b WHERE b.id = o.id) OR EXISTS (SELECT 1 FROM evidence_c c WHERE c.id = o.id));
+----
+logical_opt	<!REGEX>:.*CTE Name: __duckdb_delim.*
+
+query II
+SELECT count(*), sum(payload) FROM outer_fact o LEFT JOIN (SELECT * FROM selected_dim WHERE selected) d ON d.id = o.dim_id WHERE EXISTS (SELECT 1 FROM evidence_a a WHERE a.id = o.id) AND (EXISTS (SELECT 1 FROM evidence_b b WHERE b.id = o.id) OR EXISTS (SELECT 1 FROM evidence_c c WHERE c.id = o.id));
+----
+2	300
+
+# Grouping preserves the lineage of a delimiter key from the preserved join side
+query II
+EXPLAIN SELECT count(*) FILTER (WHERE EXISTS (SELECT 1 FROM range(10000000) b(x) WHERE b.x = q.key) OR EXISTS (SELECT 1 FROM range(10000000) c(x) WHERE c.x = q.key)) FROM (SELECT o.k AS key, count(*) n FROM range(1000000) o(k) LEFT JOIN (SELECT * FROM range(10000000) d(y) WHERE y < 10) d ON d.y = o.k GROUP BY o.k) q;
+----
+logical_opt	<!REGEX>:.*CTE Name: __duckdb_delim.*
+
+query I
+SELECT count(*) FILTER (WHERE EXISTS (SELECT 1 FROM range(2) b(x) WHERE b.x = q.key) OR EXISTS (SELECT 1 FROM range(2, 3) c(x) WHERE c.x = q.key)) FROM (SELECT o.k AS key, count(*) n FROM range(6) o(k) LEFT JOIN (SELECT * FROM range(6) d(y) WHERE y < 3) d ON d.y = o.k GROUP BY o.k) q;
+----
+3
+
+# A selected nullable side remains relevant when it supplies a projected delimiter key
+query II
+EXPLAIN SELECT count(*) FILTER (WHERE EXISTS (SELECT 1 FROM range(10000000) b(x) WHERE b.x = q.key) OR EXISTS (SELECT 1 FROM range(10000000) c(x) WHERE c.x = q.key)) FROM (SELECT o.k, d.y AS key FROM range(1000000) o(k) LEFT JOIN (SELECT * FROM range(10000000) d(y) WHERE y < 10) d ON d.y = o.k) q;
+----
+logical_opt	<REGEX>:.*CTE Name: __duckdb_delim.*Join Type: SEMI.*Join Type: SEMI.*
+
+query I
+SELECT count(*) FILTER (WHERE EXISTS (SELECT 1 FROM range(2) b(x) WHERE b.x = q.key) OR EXISTS (SELECT 1 FROM range(2, 3) c(x) WHERE c.x = q.key)) FROM (SELECT o.k, d.y AS key FROM range(6) o(k) LEFT JOIN (SELECT * FROM range(6) d(y) WHERE y < 3) d ON d.y = o.k) q;
+----
+3
+
+# A scalar subquery side is relevant only when it supplies the delimiter key
+query II
+EXPLAIN SELECT count(*) FILTER (WHERE EXISTS (SELECT 1 FROM range(10000000) b(x) WHERE b.x = q.k) OR EXISTS (SELECT 1 FROM range(10000000) c(x) WHERE c.x = q.k)) FROM (SELECT o.k, (SELECT e.x FROM range(10000000) e(x) WHERE e.x = o.k AND e.x < 10) v FROM range(1000000) o(k)) q;
+----
+logical_opt	<!REGEX>:.*CTE Name: __duckdb_delim.*
+
+query II
+EXPLAIN SELECT count(*) FILTER (WHERE EXISTS (SELECT 1 FROM range(10000000) b(x) WHERE b.x = q.v) OR EXISTS (SELECT 1 FROM range(10000000) c(x) WHERE c.x = q.v)) FROM (SELECT o.k, (SELECT e.x FROM range(10000000) e(x) WHERE e.x = o.k AND e.x < 10) v FROM range(1000000) o(k)) q;
+----
+logical_opt	<REGEX>:.*CTE Name: __duckdb_delim.*Join Type: SEMI.*Join Type: SEMI.*
+
+query I
+SELECT count(*) FILTER (WHERE EXISTS (SELECT 1 FROM range(2) b(x) WHERE b.x = q.v) OR EXISTS (SELECT 1 FROM range(2, 3) c(x) WHERE c.x = q.v)) FROM (SELECT o.k, (SELECT e.x FROM range(6) e(x) WHERE e.x = o.k AND e.x < 3) v FROM range(6) o(k)) q;
+----
+3
+
+# Local correlation inside an evidence subtree does not add an outer delimiter key
+query II
+EXPLAIN SELECT count(*), sum(payload) FROM outer_fact o WHERE EXISTS (SELECT 1 FROM evidence_a a WHERE a.id = o.id AND EXISTS (SELECT 1 FROM evidence_c c WHERE c.id = a.id)) AND NOT EXISTS (SELECT 1 FROM evidence_b b WHERE b.id = o.id);
+----
+logical_opt	<!REGEX>:.*CTE Name: __duckdb_delim.*
+
+query II
+SELECT count(*), sum(payload) FROM outer_fact o WHERE EXISTS (SELECT 1 FROM evidence_a a WHERE a.id = o.id AND EXISTS (SELECT 1 FROM evidence_c c WHERE c.id = a.id)) AND NOT EXISTS (SELECT 1 FROM evidence_b b WHERE b.id = o.id);
+----
+1	100
+
+# Local correlation on an unrelated nullable side does not add an outer delimiter key
+query II
+EXPLAIN SELECT count(*) FROM range(1000000) o(k) LEFT JOIN (SELECT * FROM range(10000000) d(y) WHERE EXISTS (SELECT 1 FROM range(10000000) e(g) WHERE e.g = d.y)) d ON d.y = o.k WHERE o.k < 10 AND EXISTS (SELECT 1 FROM range(10000000) a(x) WHERE a.x = o.k) AND NOT EXISTS (SELECT 1 FROM range(10000000) b(x) WHERE b.x = o.k) AND NOT EXISTS (SELECT 1 FROM range(10000000) c(x) WHERE c.x = o.k);
+----
+logical_opt	<!REGEX>:.*CTE Name: __duckdb_delim.*
+
+query I
+SELECT count(*) FROM range(6) o(k) LEFT JOIN (SELECT * FROM range(6) d(y) WHERE EXISTS (SELECT 1 FROM range(6) e(g) WHERE e.g = d.y)) d ON d.y = o.k WHERE o.k < 4 AND EXISTS (SELECT 1 FROM range(6) a(x) WHERE a.x = o.k) AND NOT EXISTS (SELECT 1 FROM range(1) b(x) WHERE b.x = o.k) AND NOT EXISTS (SELECT 1 FROM range(2, 3) c(x) WHERE c.x = o.k);
+----
+2
+
+# Same-key nested evidence joins can use the ordinary SEMI/ANTI rewrite
+query II
+EXPLAIN SELECT count(*), sum(payload) FROM outer_fact o, selected_dim d WHERE o.dim_id = d.id AND d.selected AND EXISTS (SELECT 1 FROM evidence_a a WHERE a.id = o.id) AND NOT EXISTS (SELECT 1 FROM evidence_b b WHERE b.id = o.id) AND NOT EXISTS (SELECT 1 FROM evidence_d e WHERE e.id = o.id);
+----
+logical_opt	<REGEX>:.*Join Type: RIGHT_ANTI.*Join Type: ANTI.*Join Type: SEMI.*
+
+query II
+EXPLAIN SELECT count(*), sum(payload) FROM outer_fact o, selected_dim d WHERE o.dim_id = d.id AND d.selected AND EXISTS (SELECT 1 FROM evidence_a a WHERE a.id = o.id) AND NOT EXISTS (SELECT 1 FROM evidence_b b WHERE b.id = o.id) AND NOT EXISTS (SELECT 1 FROM evidence_d e WHERE e.id = o.id);
+----
+logical_opt	<!REGEX>:.*CTE Name: __duckdb_delim.*
+
+query II
+SELECT count(*), sum(payload) FROM outer_fact o, selected_dim d WHERE o.dim_id = d.id AND d.selected AND EXISTS (SELECT 1 FROM evidence_a a WHERE a.id = o.id) AND NOT EXISTS (SELECT 1 FROM evidence_b b WHERE b.id = o.id) AND NOT EXISTS (SELECT 1 FROM evidence_d e WHERE e.id = o.id);
+----
+1	100
+
+# Aggregate FILTER and projection expressions consume marker domains outside LogicalFilter.
+query II
+EXPLAIN SELECT count(*) FILTER (WHERE
+	EXISTS (SELECT 1 FROM range(1000000000) a(y) WHERE y = o.x)
+	OR EXISTS (SELECT 1 FROM range(1000000000) b(z) WHERE z = o.x)
+)
+FROM range(1000000) o(x)
+WHERE x < 10;
+----
+logical_opt	<REGEX>:.*CTE Name: __duckdb_delim.*Join Type: SEMI.*Join Type: SEMI.*
+
+query II
+EXPLAIN SELECT x,
+	EXISTS (SELECT 1 FROM range(1000000000) a(y) WHERE y = o.x)
+	OR EXISTS (SELECT 1 FROM range(1000000000) b(z) WHERE z = o.x)
+FROM range(1000000) o(x)
+WHERE x < 10;
+----
+logical_opt	<REGEX>:.*CTE Name: __duckdb_delim.*Join Type: SEMI.*Join Type: SEMI.*
+
+# A projected marker cannot use the simple filter conversion to SEMI or ANTI.
+query II
+EXPLAIN SELECT x, EXISTS (SELECT 1 FROM range(1000000000) a(y) WHERE y = o.x)
+FROM range(1000000) o(x)
+WHERE x < 10;
+----
+logical_opt	<REGEX>:.*CTE Name: __duckdb_delim.*Join Type: SEMI.*
+
+query II
+EXPLAIN SELECT x, NOT EXISTS (SELECT 1 FROM range(1000000000) a(y) WHERE y = o.x)
+FROM range(1000000) o(x)
+WHERE x < 10;
+----
+logical_opt	<REGEX>:.*CTE Name: __duckdb_delim.*Join Type: SEMI.*
+
+# A projected marker with multiple equality keys cannot use a single-key delimiter domain
+query II
+EXPLAIN SELECT x, z,
+	EXISTS (SELECT 1 FROM range(1000000000) a(y) WHERE y = o.x AND y = p.z)
+FROM range(1000000) o(x), range(1000000) p(z)
+WHERE x < 10 AND z < 10;
+----
+logical_opt	<!REGEX>:.*CTE Name: __duckdb_delim.*
+
+query II
+EXPLAIN SELECT x, z,
+	EXISTS (SELECT 1 FROM range(1000000000) a(y) WHERE y = o.x AND y = p.z)
+FROM range(1000000) o(x), range(1000000) p(z)
+WHERE x < 10 AND z < 10;
+----
+logical_opt	<REGEX>:.*Join Type: MARK.*
+
+query III
+SELECT x, z,
+	EXISTS (SELECT 1 FROM range(2) a(y) WHERE y = o.x AND y = p.z)
+FROM range(2) o(x), range(2) p(z)
+ORDER BY x, z;
+----
+0	0	true
+0	1	false
+1	0	false
+1	1	true
+
+query I
+SELECT count(*) FILTER (WHERE
+	EXISTS (SELECT 1 FROM range(3) a(y) WHERE y = o.x)
+	OR EXISTS (SELECT 1 FROM range(3, 5) b(z) WHERE z = o.x)
+)
+FROM range(6) o(x)
+WHERE x < 5;
+----
+5
+
+query II
+SELECT x,
+	EXISTS (SELECT 1 FROM range(3) a(y) WHERE y = o.x)
+	OR EXISTS (SELECT 1 FROM range(3, 5) b(z) WHERE z = o.x)
+FROM range(6) o(x)
+WHERE x < 5
+ORDER BY x;
+----
+0	true
+1	true
+2	true
+3	true
+4	true
+
+# A nested single-key NOT EXISTS should retain its selected domain
+statement ok
+CREATE TABLE selected_orders(order_id BIGINT, warehouse BIGINT, dim_id BIGINT, cost BIGINT);
+
+statement ok
+CREATE TABLE other_sales(order_id BIGINT, warehouse BIGINT);
+
+statement ok
+CREATE TABLE returned_orders(order_id BIGINT);
+
+statement ok
+INSERT INTO selected_orders VALUES (1, 1, 10, 100), (1, 2, 10, 150), (2, 1, 10, 200), (3, 1, 20, 300), (4, NULL, 10, 400), (NULL, 1, 10, 500);
+
+statement ok
+INSERT INTO other_sales VALUES (1, 1), (1, 2), (2, 2), (4, 2), (NULL, 2);
+
+statement ok
+INSERT INTO returned_orders VALUES (2), (2), (NULL);
+
+query II
+EXPLAIN SELECT count(DISTINCT order_id), sum(cost) FROM selected_orders o, selected_dim d WHERE o.dim_id = d.id AND d.selected AND EXISTS (SELECT 1 FROM other_sales s WHERE s.order_id = o.order_id AND s.warehouse <> o.warehouse) AND NOT EXISTS (SELECT 1 FROM returned_orders r WHERE r.order_id = o.order_id);
+----
+logical_opt	<REGEX>:.*CTE Name: __duckdb_delim.*Join Type: MARK.*Join Type: SEMI.*order_id = order_id.*
+
+query II
+SELECT count(DISTINCT order_id), sum(cost) FROM selected_orders o, selected_dim d WHERE o.dim_id = d.id AND d.selected AND EXISTS (SELECT 1 FROM other_sales s WHERE s.order_id = o.order_id AND s.warehouse <> o.warehouse) AND NOT EXISTS (SELECT 1 FROM returned_orders r WHERE r.order_id = o.order_id);
+----
+1	250
+
+statement ok
+SET disabled_optimizers='deliminator';
+
+query III
+SELECT x, z,
+	EXISTS (SELECT 1 FROM range(2) a(y) WHERE y = o.x AND y = p.z)
+FROM range(2) o(x), range(2) p(z)
+ORDER BY x, z;
+----
+0	0	true
+0	1	false
+1	0	false
+1	1	true
+
+query I
+SELECT count(*) FILTER (WHERE
+	EXISTS (SELECT 1 FROM range(3) a(y) WHERE y = o.x)
+	OR EXISTS (SELECT 1 FROM range(3, 5) b(z) WHERE z = o.x)
+)
+FROM range(6) o(x)
+WHERE x < 5;
+----
+5
+
+query II
+SELECT x,
+	EXISTS (SELECT 1 FROM range(3) a(y) WHERE y = o.x)
+	OR EXISTS (SELECT 1 FROM range(3, 5) b(z) WHERE z = o.x)
+FROM range(6) o(x)
+WHERE x < 5
+ORDER BY x;
+----
+0	true
+1	true
+2	true
+3	true
+4	true
+
+query II
+SELECT count(*), sum(payload) FROM outer_fact o, selected_dim d WHERE o.dim_id = d.id AND d.selected AND EXISTS (SELECT 1 FROM evidence_a a WHERE a.id = o.id) AND (EXISTS (SELECT 1 FROM evidence_b b WHERE b.id = o.id) OR EXISTS (SELECT 1 FROM evidence_c c WHERE c.id = o.id));
+----
+2	300
+
+query II
+SELECT count(*), sum(payload) FROM outer_fact o WHERE EXISTS (SELECT 1 FROM evidence_a_flag a WHERE a.id = o.id AND a.selected) AND (EXISTS (SELECT 1 FROM evidence_b_flag b WHERE b.id = o.id AND b.selected) OR EXISTS (SELECT 1 FROM evidence_c_flag c WHERE c.id = o.id AND c.selected));
+----
+2	300
+
+query II
+SELECT count(*), sum(payload) FROM outer_fact o LEFT JOIN (SELECT * FROM selected_dim WHERE selected) d ON d.id = o.dim_id WHERE EXISTS (SELECT 1 FROM evidence_a a WHERE a.id = o.id) AND (EXISTS (SELECT 1 FROM evidence_b b WHERE b.id = o.id) OR EXISTS (SELECT 1 FROM evidence_c c WHERE c.id = o.id));
+----
+2	300
+
+query I
+SELECT count(*) FILTER (WHERE EXISTS (SELECT 1 FROM range(2) b(x) WHERE b.x = q.key) OR EXISTS (SELECT 1 FROM range(2, 3) c(x) WHERE c.x = q.key)) FROM (SELECT o.k AS key, count(*) n FROM range(6) o(k) LEFT JOIN (SELECT * FROM range(6) d(y) WHERE y < 3) d ON d.y = o.k GROUP BY o.k) q;
+----
+3
+
+query I
+SELECT count(*) FILTER (WHERE EXISTS (SELECT 1 FROM range(2) b(x) WHERE b.x = q.key) OR EXISTS (SELECT 1 FROM range(2, 3) c(x) WHERE c.x = q.key)) FROM (SELECT o.k, d.y AS key FROM range(6) o(k) LEFT JOIN (SELECT * FROM range(6) d(y) WHERE y < 3) d ON d.y = o.k) q;
+----
+3
+
+query I
+SELECT count(*) FILTER (WHERE EXISTS (SELECT 1 FROM range(2) b(x) WHERE b.x = q.v) OR EXISTS (SELECT 1 FROM range(2, 3) c(x) WHERE c.x = q.v)) FROM (SELECT o.k, (SELECT e.x FROM range(6) e(x) WHERE e.x = o.k AND e.x < 3) v FROM range(6) o(k)) q;
+----
+3
+
+query II
+SELECT count(*), sum(payload) FROM outer_fact o WHERE EXISTS (SELECT 1 FROM evidence_a a WHERE a.id = o.id AND EXISTS (SELECT 1 FROM evidence_c c WHERE c.id = a.id)) AND NOT EXISTS (SELECT 1 FROM evidence_b b WHERE b.id = o.id);
+----
+1	100
+
+query I
+SELECT count(*) FROM range(6) o(k) LEFT JOIN (SELECT * FROM range(6) d(y) WHERE EXISTS (SELECT 1 FROM range(6) e(g) WHERE e.g = d.y)) d ON d.y = o.k WHERE o.k < 4 AND EXISTS (SELECT 1 FROM range(6) a(x) WHERE a.x = o.k) AND NOT EXISTS (SELECT 1 FROM range(1) b(x) WHERE b.x = o.k) AND NOT EXISTS (SELECT 1 FROM range(2, 3) c(x) WHERE c.x = o.k);
+----
+2
+
+query II
+SELECT count(*), sum(payload) FROM outer_fact o, selected_dim d WHERE o.dim_id = d.id AND d.selected AND EXISTS (SELECT 1 FROM evidence_a a WHERE a.id = o.id) AND NOT EXISTS (SELECT 1 FROM evidence_b b WHERE b.id = o.id) AND NOT EXISTS (SELECT 1 FROM evidence_d e WHERE e.id = o.id);
+----
+1	100
+
+query II
+SELECT count(DISTINCT order_id), sum(cost) FROM selected_orders o, selected_dim d WHERE o.dim_id = d.id AND d.selected AND EXISTS (SELECT 1 FROM other_sales s WHERE s.order_id = o.order_id AND s.warehouse <> o.warehouse) AND NOT EXISTS (SELECT 1 FROM returned_orders r WHERE r.order_id = o.order_id);
+----
+1	250
+
+statement ok
+SET disabled_optimizers='';
 
 # Q 22: the selected delimiter domain should still restrict the NOT EXISTS evidence side
 query II


### PR DESCRIPTION
I found a related group of regressions in TPC-DS Q10 and Q16 and TPC-H Q20 while comparing the current optimizer against 1.5.5. They came from the delimiter-join-to-CTE rewrite losing the selected outer domain before all correlated evidence consumers had used it. Once that domain disappears, the remaining MARK, SEMI, or ANTI side scans its full input instead of the much smaller set of correlated keys.

The difficult part is deciding which consumers need the domain. A marker can be consumed by a filter, an aggregate `FILTER`, or a projection; nested delimiter joins can introduce either the same outer key or a genuinely additional correlation key; and LEFT, RIGHT, and SINGLE joins have output-bearing nullable sides that cannot be treated like MARK/SEMI/ANTI evidence sides.

I now collect marker consumers from every logical-operator expression, trace delimiter expressions through projections and aggregate group bindings, and use the same ownership boundary both when detecting selected domains and when classifying nested correlation. Evidence-only sides are skipped, while nullable or scalar-output sides are skipped only when the traced delimiter expressions are proven to come exclusively from the preserved side. Direct projected markers retain a domain only for a single equality or null-safe equality; a marker with multiple correlated equality keys remains in the ordinary MARK path.

The general and nested marker sets remain separate through recursive rewriting and are combined only for late generated-domain cleanup. If lineage cannot be proven through an operator, the rewrite is conservative and can retain an unnecessary delimiter CTE rather than discard a domain that an evidence consumer still needs.

| query | main median | branch median | change |
|---|---:|---:|---:|
| TPC-DS Q10 | 0.118 s | 0.099 s | 16% faster |
| TPC-DS Q16 | 0.0185 s | 0.0155 s | 16% faster |
| TPC-DS Q35 | 0.241 s | 0.243 s | 0.8% slower |
| TPC-DS Q69 | 0.116 s | 0.116 s | unchanged |
