### PR TITLE
Fix pathological scan memory for NULLs trailing an overflow string (#24897)

### DIFF
--- a/src/include/duckdb/storage/string_uncompressed.hpp
+++ b/src/include/duckdb/storage/string_uncompressed.hpp
@@ -252,6 +252,15 @@ public:
 
 			auto str_ptr = char_ptr_cast(dict_pos);
 			return string_t(str_ptr, string_length);
+		} else if (string_length == 0) {
+			// NULL values are stored as a copy of the previous entry's dictionary offset (see
+			// StringAppendBase). When the previous entry is a big (overflow) string, its offset is
+			// negative, so the NULL inherits that negative offset even though it references no
+			// overflow data (its computed length is 0). Return an empty string here instead of
+			// following the marker into ReadOverflowString - otherwise every NULL that trails a big
+			// string re-reads and re-allocates the entire overflow string (O(num_nulls * big_size)
+			// memory, tagged OVERFLOW_STRINGS). The value is masked NULL by the caller regardless.
+			return string_t(char_ptr_cast(base_ptr), 0);
 		} else {
 			// read overflow string
 			block_id_t block_id;

--- a/test/sql/storage/overflow_strings/null_overflow_string_memory.test
+++ b/test/sql/storage/overflow_strings/null_overflow_string_memory.test
@@ -1,0 +1,52 @@
+# name: test/sql/storage/overflow_strings/null_overflow_string_memory.test
+# description: Scanning an uncompressed VARCHAR column with NULLs interleaved with an overflow string must not allocate O(vector_size * string_size) memory
+# group: [overflow_strings]
+
+# the memory limit below is calibrated for the default 256KB block size
+require block_size 262144
+
+load {TEST_DIR}/null_overflow_string_memory.db
+
+statement ok
+PRAGMA force_compression='uncompressed'
+
+statement ok
+SET threads=1
+
+# one 2MB overflow string at row 0, every other row NULL
+statement ok
+CREATE TABLE t AS
+SELECT CASE WHEN i = 0 THEN repeat('x', 2*1024*1024) ELSE NULL END AS v
+FROM range(50000) tbl(i);
+
+statement ok
+CHECKPOINT
+
+# the column must be stored uncompressed; the 2MB value is far above the string block limit,
+# so it is stored out of line as an overflow string
+query I
+SELECT compression FROM pragma_storage_info('t') WHERE segment_type='VARCHAR' AND compression != 'Uncompressed';
+----
+
+# reopen fresh so the scan reads the overflow block cold from disk
+restart
+
+statement ok
+SET threads=1
+
+# disable spilling so the memory limit actually bites (OVERFLOW_STRINGS is non-spillable regardless)
+statement ok
+PRAGMA temp_directory=''
+
+statement ok
+PRAGMA max_temp_directory_size='0B'
+
+# a single 2MB value needs a few MB to scan; the bug re-reads the 2MB overflow string once per
+# trailing NULL, needing ~STANDARD_VECTOR_SIZE (2048) * 2MB ~= 4GB, so it OOMs under this limit
+statement ok
+SET memory_limit='512MB'
+
+query I
+SELECT sum(length(v)) FROM t;
+----
+2097152


### PR DESCRIPTION
This is a a backport of https://github.com/duckdb/duckdb/pull/24898. The testcase needed to avoid the use of `include_segment_info` which does not exist in 1.5.x

Uncompressed VARCHAR overflow strings are stored with a negative dictionary offset, and a NULL copies the previous row's offset verbatim to make its delta-computed length 0. This copies the sign too, so a NULL following an overflow string inherits its negative offset and FetchStringFromDict routes it to ReadOverflowString, allocating a full pinned copy of the big string per trailing NULL (~STANDARD_VECTOR_SIZE copies per vector, tag OVERFLOW_STRINGS).

A NULL that copied a marker has a negative offset but a computed length of 0, whereas a real overflow string always has length BIG_STRING_MARKER_SIZE. Short- circuit the negative branch when the length is 0 and return an empty string. This is a scan-side fix at the single choke point, so it also repairs already- written databases with no storage-format change.
