### PR TITLE
Optimize art rowid container

### DIFF
--- a/src/execution/index/art/art.cpp
+++ b/src/execution/index/art/art.cpp
@@ -697,18 +697,17 @@ bool ART::HasLegacyGeometryKeys() const {
 //===--------------------------------------------------------------------===//
 // Point and range lookups
 //===--------------------------------------------------------------------===//
-bool ART::FullScan(idx_t max_count, set<row_t> &row_ids) const {
+bool ART::FullScan(RowIdVectorOutput &row_ids) const {
 	if (!tree.HasMetadata()) {
 		return true;
 	}
 	Iterator it(*this);
 	it.FindMinimum(tree);
 	const auto empty_key = ARTKey();
-	RowIdSetOutput output(row_ids, max_count);
-	return it.Scan(empty_key, output, false) == ARTScanResult::COMPLETED;
+	return it.Scan(empty_key, row_ids, false) == ARTScanResult::COMPLETED;
 }
 
-bool ART::SearchEqual(const ARTKey &key, idx_t max_count, set<row_t> &row_ids) const {
+bool ART::SearchEqual(const ARTKey &key, RowIdVectorOutput &row_ids) const {
 	auto leaf = ARTOperator::Lookup(*this, tree, key, 0);
 	if (!leaf) {
 		return true;
@@ -717,11 +716,10 @@ bool ART::SearchEqual(const ARTKey &key, idx_t max_count, set<row_t> &row_ids) c
 	Iterator it(*this);
 	it.FindMinimum(leaf.Get());
 	const auto empty_key = ARTKey();
-	RowIdSetOutput output(row_ids, max_count);
-	return it.Scan(empty_key, output, false) == ARTScanResult::COMPLETED;
+	return it.Scan(empty_key, row_ids, false) == ARTScanResult::COMPLETED;
 }
 
-bool ART::SearchGreater(const ARTKey &key, bool equal, idx_t max_count, set<row_t> &row_ids) const {
+bool ART::SearchGreater(const ARTKey &key, bool equal, RowIdVectorOutput &row_ids) const {
 	if (!tree.HasMetadata()) {
 		return true;
 	}
@@ -736,11 +734,10 @@ bool ART::SearchGreater(const ARTKey &key, bool equal, idx_t max_count, set<row_
 
 	// We continue the scan. We do not check the bounds as any value following this value is
 	// greater and satisfies our predicate.
-	RowIdSetOutput output(row_ids, max_count);
-	return it.Scan(ARTKey(), output, false) == ARTScanResult::COMPLETED;
+	return it.Scan(ARTKey(), row_ids, false) == ARTScanResult::COMPLETED;
 }
 
-bool ART::SearchLess(const ARTKey &upper_bound, bool equal, idx_t max_count, set<row_t> &row_ids) const {
+bool ART::SearchLess(const ARTKey &upper_bound, bool equal, RowIdVectorOutput &row_ids) const {
 	if (!tree.HasMetadata()) {
 		return true;
 	}
@@ -755,12 +752,11 @@ bool ART::SearchLess(const ARTKey &upper_bound, bool equal, idx_t max_count, set
 	}
 
 	// Continue the scan until we reach the upper bound.
-	RowIdSetOutput output(row_ids, max_count);
-	return it.Scan(upper_bound, output, equal) == ARTScanResult::COMPLETED;
+	return it.Scan(upper_bound, row_ids, equal) == ARTScanResult::COMPLETED;
 }
 
 bool ART::SearchCloseRange(const ARTKey &lower_bound, const ARTKey &upper_bound, bool left_equal, bool right_equal,
-                           idx_t max_count, set<row_t> &row_ids) const {
+                           RowIdVectorOutput &row_ids) const {
 	if (!tree.HasMetadata()) {
 		return true;
 	}
@@ -774,16 +770,15 @@ bool ART::SearchCloseRange(const ARTKey &lower_bound, const ARTKey &upper_bound,
 	}
 
 	// Continue the scan until we reach the upper bound.
-	RowIdSetOutput output(row_ids, max_count);
-	return it.Scan(upper_bound, output, right_equal) == ARTScanResult::COMPLETED;
+	return it.Scan(upper_bound, row_ids, right_equal) == ARTScanResult::COMPLETED;
 }
 
-bool ART::Scan(IndexScanState &state, const idx_t max_count, set<row_t> &row_ids) const {
+bool ART::Scan(IndexScanState &state, RowIdVectorOutput &row_ids) const {
 	auto &scan_state = state.Cast<ARTIndexScanState>();
 	if (scan_state.values[0].IsNull()) {
 		// full scan
 		lock_guard<mutex> l(lock);
-		return FullScan(max_count, row_ids);
+		return FullScan(row_ids);
 	}
 	D_ASSERT(scan_state.values[0].type().InternalType() == types[0]);
 	ArenaAllocator arena_allocator(Allocator::Get(db));
@@ -795,15 +790,15 @@ bool ART::Scan(IndexScanState &state, const idx_t max_count, set<row_t> &row_ids
 		// Single predicate.
 		switch (scan_state.expressions[0]) {
 		case ExpressionType::COMPARE_EQUAL:
-			return SearchEqual(key, max_count, row_ids);
+			return SearchEqual(key, row_ids);
 		case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
-			return SearchGreater(key, true, max_count, row_ids);
+			return SearchGreater(key, true, row_ids);
 		case ExpressionType::COMPARE_GREATERTHAN:
-			return SearchGreater(key, false, max_count, row_ids);
+			return SearchGreater(key, false, row_ids);
 		case ExpressionType::COMPARE_LESSTHANOREQUALTO:
-			return SearchLess(key, true, max_count, row_ids);
+			return SearchLess(key, true, row_ids);
 		case ExpressionType::COMPARE_LESSTHAN:
-			return SearchLess(key, false, max_count, row_ids);
+			return SearchLess(key, false, row_ids);
 		default:
 			throw InternalException("Index scan type not implemented");
 		}
@@ -816,7 +811,7 @@ bool ART::Scan(IndexScanState &state, const idx_t max_count, set<row_t> &row_ids
 
 	bool left_equal = scan_state.expressions[0] == ExpressionType ::COMPARE_GREATERTHANOREQUALTO;
 	bool right_equal = scan_state.expressions[1] == ExpressionType ::COMPARE_LESSTHANOREQUALTO;
-	return SearchCloseRange(key, upper_bound, left_equal, right_equal, max_count, row_ids);
+	return SearchCloseRange(key, upper_bound, left_equal, right_equal, row_ids);
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/execution/index/art/iterator.cpp
+++ b/src/execution/index/art/iterator.cpp
@@ -1,6 +1,8 @@
 #include "duckdb/execution/index/art/iterator.hpp"
 
+#include "duckdb/common/algorithm.hpp"
 #include "duckdb/common/limits.hpp"
+#include "duckdb/common/vector_size.hpp"
 #include "duckdb/execution/index/art/art.hpp"
 #include "duckdb/execution/index/art/const_prefix_handle.hpp"
 #include "duckdb/execution/index/art/node.hpp"
@@ -8,6 +10,36 @@
 #include "duckdb/execution/index/art/prefix.hpp"
 
 namespace duckdb {
+
+RowIdVectorOutput::RowIdVectorOutput(const idx_t capacity_p) : capacity(capacity_p) {
+	row_ids.reserve(MinValue<idx_t>(capacity, STANDARD_VECTOR_SIZE));
+}
+
+bool RowIdVectorOutput::TryAdd(const row_t row_id) {
+	D_ASSERT(row_ids.size() <= capacity);
+	if (row_ids.size() >= capacity) {
+		Normalize();
+		if (row_ids.size() >= capacity) {
+			return false;
+		}
+	}
+	row_ids.push_back(row_id);
+	return true;
+}
+
+void RowIdVectorOutput::Reset() {
+	row_ids.clear();
+}
+
+void RowIdVectorOutput::Normalize() {
+	std::sort(row_ids.begin(), row_ids.end());
+	row_ids.erase(std::unique(row_ids.begin(), row_ids.end()), row_ids.end());
+}
+
+unsafe_vector<row_t> RowIdVectorOutput::TakeRows() {
+	Normalize();
+	return std::move(row_ids);
+}
 
 //===--------------------------------------------------------------------===//
 // IteratorKey
@@ -64,10 +96,9 @@ ARTScanResult Iterator::Scan(const ARTKey &upper_bound, Output &output, bool equ
 
 		switch (last_leaf.GetType()) {
 		case NType::LEAF_INLINED: {
-			if (output.IsFull()) {
+			if (!output.TryAdd(last_leaf.GetRowId())) {
 				return ARTScanResult::PAUSED;
 			}
-			output.Add(last_leaf.GetRowId());
 			break;
 		}
 		case NType::LEAF: {
@@ -80,11 +111,10 @@ ARTScanResult Iterator::Scan(const ARTKey &upper_bound, Output &output, bool equ
 			}
 			// Try to output the next entry in the deprecated leaf chain.
 			while (resume_state.cached_row_ids_it != resume_state.cached_row_ids.end()) {
-				if (output.IsFull()) {
+				if (!output.TryAdd(*resume_state.cached_row_ids_it)) {
 					// If we pause here, then scanning will resume at cached_row_ids_it.
 					return ARTScanResult::PAUSED;
 				}
-				output.Add(*resume_state.cached_row_ids_it);
 				++resume_state.cached_row_ids_it;
 			}
 			resume_state.has_cached_row_ids = false;
@@ -101,13 +131,12 @@ ARTScanResult Iterator::Scan(const ARTKey &upper_bound, Output &output, bool equ
 			}
 			// Try to output the next inlined leaf.
 			while (last_leaf.GetNextByte(art, resume_state.nested_byte)) {
-				if (output.IsFull()) {
+				row_id[ROW_ID_SIZE - 1] = resume_state.nested_byte;
+				ARTKey rid_key(&row_id[0], ROW_ID_SIZE);
+				if (!output.TryAdd(rid_key.GetRowId())) {
 					// If we pause here, then scanning will resume at nested_byte in the current leaf.
 					return ARTScanResult::PAUSED;
 				}
-				row_id[ROW_ID_SIZE - 1] = resume_state.nested_byte;
-				ARTKey rid_key(&row_id[0], ROW_ID_SIZE);
-				output.Add(rid_key.GetRowId());
 
 				if (resume_state.nested_byte == NumericLimits<uint8_t>::Maximum()) {
 					break;
@@ -127,8 +156,9 @@ ARTScanResult Iterator::Scan(const ARTKey &upper_bound, Output &output, bool equ
 	return ARTScanResult::COMPLETED;
 }
 
-// Explicit template instantiations for the two output policies.
+// Explicit template instantiations for the output policies.
 template ARTScanResult Iterator::Scan<RowIdSetOutput>(const ARTKey &, RowIdSetOutput &, bool);
+template ARTScanResult Iterator::Scan<RowIdVectorOutput>(const ARTKey &, RowIdVectorOutput &, bool);
 template ARTScanResult Iterator::Scan<KeyRowIdOutput>(const ARTKey &, KeyRowIdOutput &, bool);
 
 void Iterator::FindMinimum(NodePtr current) {

--- a/src/function/table/table_scan.cpp
+++ b/src/function/table/table_scan.cpp
@@ -11,6 +11,7 @@
 #include "duckdb/common/types/value_map.hpp"
 #include "duckdb/common/unique_ptr.hpp"
 #include "duckdb/execution/index/art/art.hpp"
+#include "duckdb/execution/index/art/iterator.hpp"
 #include "duckdb/function/function_set.hpp"
 #include "duckdb/function/table_function.hpp"
 #include "duckdb/main/attached_database.hpp"
@@ -108,20 +109,16 @@ public:
 
 class DuckIndexScanState : public TableScanGlobalState {
 public:
-	DuckIndexScanState(ClientContext &context, const FunctionData *bind_data_p)
-	    : TableScanGlobalState(context, bind_data_p), next_batch_index(0), arena(Allocator::Get(context)),
-	      row_ids(nullptr), row_id_count(0), finished_first_phase(false), started_last_phase(false) {
+	DuckIndexScanState(ClientContext &context, const FunctionData *bind_data_p, unsafe_vector<row_t> &&row_ids_p)
+	    : TableScanGlobalState(context, bind_data_p), next_batch_index(0), row_ids(std::move(row_ids_p)),
+	      finished_first_phase(row_ids.empty()), started_last_phase(false) {
 	}
 
 	//! The batch index of the next Sink.
 	//! Also determines the offset of the next chunk. I.e., offset = next_batch_index * STANDARD_VECTOR_SIZE.
 	atomic<idx_t> next_batch_index;
-	//! The arena allocator containing the memory of the row IDs.
-	ArenaAllocator arena;
-	//! A pointer to the row IDs.
-	row_t *row_ids;
-	//! The number of scanned row IDs.
-	idx_t row_id_count;
+	//! Finalized before construction and only read by Fetch tasks.
+	unsafe_vector<row_t> row_ids;
 	//! The column IDs of the to-be-scanned columns.
 	vector<StorageIndex> column_ids;
 	//! True, if no more row IDs must be scanned.
@@ -179,7 +176,7 @@ public:
 					next_batch_index++;
 
 					offset = l_state.batch_index * STANDARD_VECTOR_SIZE;
-					auto remaining = row_id_count - offset;
+					auto remaining = row_ids.size() - offset;
 					scan_count = remaining <= STANDARD_VECTOR_SIZE ? remaining : STANDARD_VECTOR_SIZE;
 					finished_first_phase = remaining <= STANDARD_VECTOR_SIZE ? true : false;
 					phase_to_be_performed = ExecutionPhase::STORAGE;
@@ -201,7 +198,7 @@ public:
 			}
 			case ExecutionPhase::STORAGE: {
 				// Scan (in parallel) storage
-				auto row_id_data = reinterpret_cast<data_ptr_t>(row_ids + offset);
+				auto row_id_data = reinterpret_cast<data_ptr_t>(row_ids.data() + offset);
 				Vector local_vector(LogicalType::ROW_TYPE, row_id_data, scan_count);
 
 				if (CanRemoveFilterColumns()) {
@@ -246,11 +243,11 @@ public:
 	}
 
 	double TableScanProgress(ClientContext &context, const FunctionData *bind_data_p) const override {
-		if (row_id_count == 0) {
+		if (row_ids.empty()) {
 			return 100;
 		}
 		auto scanned_rows = next_batch_index * STANDARD_VECTOR_SIZE;
-		auto percentage = 100 * (static_cast<double>(scanned_rows) / static_cast<double>(row_id_count));
+		auto percentage = 100 * (static_cast<double>(scanned_rows) / static_cast<double>(row_ids.size()));
 		return percentage > 100 ? 100 : percentage;
 	}
 
@@ -510,23 +507,11 @@ unique_ptr<GlobalTableFunctionState> DuckTableScanInitGlobal(ClientContext &cont
 }
 
 unique_ptr<GlobalTableFunctionState> DuckIndexScanInitGlobal(ClientContext &context, TableFunctionInitInput &input,
-                                                             const TableScanBindData &bind_data, set<row_t> &row_ids,
+                                                             const TableScanBindData &bind_data,
+                                                             unsafe_vector<row_t> &&row_ids,
                                                              unique_ptr<StorageLockKey> vacuum_lock) {
-	auto g_state = make_uniq<DuckIndexScanState>(context, input.bind_data.get());
+	auto g_state = make_uniq<DuckIndexScanState>(context, input.bind_data.get(), std::move(row_ids));
 	g_state->vacuum_lock = std::move(vacuum_lock);
-	g_state->finished_first_phase = row_ids.empty() ? true : false;
-	g_state->started_last_phase = false;
-
-	if (!row_ids.empty()) {
-		auto row_id_ptr = g_state->arena.AllocateAligned(row_ids.size() * sizeof(row_t));
-		g_state->row_ids = reinterpret_cast<row_t *>(row_id_ptr);
-		g_state->row_id_count = row_ids.size();
-
-		idx_t row_id_count = 0;
-		for (const auto row_id : row_ids) {
-			g_state->row_ids[row_id_count++] = row_id;
-		}
-	}
 
 	auto &duck_table = bind_data.table.Cast<DuckTableEntry>();
 	if (input.CanRemoveFilterColumns()) {
@@ -721,7 +706,8 @@ vector<unique_ptr<Expression>> ExtractFilterExpressions(const ColumnDefinition &
 }
 
 bool TryScanIndex(const IndexReadHandle<ART> &art, const ColumnList &column_list, TableFunctionInitInput &input,
-                  TableFilterSet &filter_set, idx_t max_count, set<row_t> &row_ids) {
+                  TableFilterSet &filter_set, RowIdVectorOutput &row_ids) {
+	row_ids.Reset();
 	// FIXME: No support for index scans on compound ARTs.
 	// See note above on multi-filter support.
 	if (art->UnboundExpressionCount() > 1) {
@@ -793,11 +779,12 @@ bool TryScanIndex(const IndexReadHandle<ART> &art, const ColumnList &column_list
 	for (const auto &filter_expr : expressions) {
 		auto scan_state = art->TryInitializeScan(*index_expr, *filter_expr);
 		if (!scan_state) {
+			row_ids.Reset();
 			return false;
 		}
 
-		if (!art->Scan(*scan_state, max_count, row_ids)) {
-			row_ids.clear();
+		if (!art->Scan(*scan_state, row_ids)) {
+			row_ids.Reset();
 			return false;
 		}
 		for (const auto delta : {IndexDeltaType::DELETED_ROWS_IN_USE, IndexDeltaType::ADDED_DATA_DURING_CHECKPOINT}) {
@@ -807,12 +794,13 @@ bool TryScanIndex(const IndexReadHandle<ART> &art, const ColumnList &column_list
 			}
 			auto delta_scan_state = delta_index->TryInitializeScan(*index_expr, *filter_expr);
 			if (!delta_scan_state) {
+				row_ids.Reset();
 				return false;
 			}
 
 			// Check if we can use an index scan, and already retrieve the matching row ids.
-			if (!delta_index->Scan(*delta_scan_state, max_count, row_ids)) {
-				row_ids.clear();
+			if (!delta_index->Scan(*delta_scan_state, row_ids)) {
+				row_ids.Reset();
 				return false;
 			}
 		}
@@ -864,7 +852,7 @@ unique_ptr<GlobalTableFunctionState> TableScanInitGlobal(ClientContext &context,
 
 	auto &column_list = duck_table.GetColumns();
 	bool index_scan = false;
-	set<row_t> row_ids;
+	RowIdVectorOutput row_ids(max_count);
 
 	info->BindIndexes(context, ART::TYPE_NAME);
 
@@ -882,8 +870,10 @@ unique_ptr<GlobalTableFunctionState> TableScanInitGlobal(ClientContext &context,
 		if (entry->GetBindState() != IndexBindState::BOUND || entry->GetIndexType() != ART::TYPE_NAME) {
 			continue;
 		}
-		auto index = entry->GetReadHandle<ART>();
-		index_scan = TryScanIndex(index, column_list, input, filter_set, max_count, row_ids);
+		{
+			auto index = entry->GetReadHandle<ART>();
+			index_scan = TryScanIndex(index, column_list, input, filter_set, row_ids);
+		}
 		if (index_scan) {
 			// found an index - break
 			break;
@@ -893,7 +883,7 @@ unique_ptr<GlobalTableFunctionState> TableScanInitGlobal(ClientContext &context,
 	if (!index_scan) {
 		return DuckTableScanInitGlobal(context, input, storage, bind_data);
 	}
-	return DuckIndexScanInitGlobal(context, input, bind_data, row_ids, std::move(vacuum_lock));
+	return DuckIndexScanInitGlobal(context, input, bind_data, row_ids.TakeRows(), std::move(vacuum_lock));
 }
 
 static unique_ptr<BaseStatistics> TableScanStatistics(ClientContext &context, TableFunctionGetStatisticsInput &input) {

--- a/src/include/duckdb/execution/index/art/art.hpp
+++ b/src/include/duckdb/execution/index/art/art.hpp
@@ -21,6 +21,7 @@ enum class ARTConflictType : uint8_t { NO_CONFLICT = 0, CONSTRAINT = 1 };
 class ConflictManager;
 class ARTKey;
 class ARTKeySection;
+class RowIdVectorOutput;
 class FixedSizeAllocator;
 
 struct ARTIndexScanState;
@@ -75,9 +76,9 @@ public:
 	//! Try to initialize a scan on the ART with the given expression and filter.
 	unique_ptr<IndexScanState> TryInitializeScan(const Expression &expr, const Expression &filter_expr) const;
 	unique_ptr<IndexScanState> InitializeFullScan();
-	//! Perform a lookup on the ART, fetching up to max_count row IDs.
+	//! Perform a lookup on the ART, fetching up to the collection capacity.
 	//! If all row IDs were fetched, it return true, else false.
-	bool Scan(IndexScanState &state, idx_t max_count, set<row_t> &row_ids) const;
+	bool Scan(IndexScanState &state, RowIdVectorOutput &row_ids) const;
 
 	//! Simple merge: scan source ART and delete each (key, rowid) from this ART.
 	// FIXME: replace with structural tree delete merge.
@@ -175,12 +176,12 @@ private:
 	//! The number of bytes fitting in the prefix.
 	uint8_t prefix_count;
 
-	bool FullScan(idx_t max_count, set<row_t> &row_ids) const;
-	bool SearchEqual(const ARTKey &key, idx_t max_count, set<row_t> &row_ids) const;
-	bool SearchGreater(const ARTKey &key, bool equal, idx_t max_count, set<row_t> &row_ids) const;
-	bool SearchLess(const ARTKey &upper_bound, bool equal, idx_t max_count, set<row_t> &row_ids) const;
+	bool FullScan(RowIdVectorOutput &row_ids) const;
+	bool SearchEqual(const ARTKey &key, RowIdVectorOutput &row_ids) const;
+	bool SearchGreater(const ARTKey &key, bool equal, RowIdVectorOutput &row_ids) const;
+	bool SearchLess(const ARTKey &upper_bound, bool equal, RowIdVectorOutput &row_ids) const;
 	bool SearchCloseRange(const ARTKey &lower_bound, const ARTKey &upper_bound, bool left_equal, bool right_equal,
-	                      idx_t max_count, set<row_t> &row_ids) const;
+	                      RowIdVectorOutput &row_ids) const;
 
 	string GenerateErrorKeyName(DataChunk &input, idx_t row) const;
 	string GenerateConstraintErrorMessage(VerifyExistenceType verify_type, const string &key_name) const;

--- a/src/include/duckdb/execution/index/art/iterator.hpp
+++ b/src/include/duckdb/execution/index/art/iterator.hpp
@@ -70,16 +70,40 @@ struct RowIdSetOutput {
 	RowIdSetOutput(set<row_t> &row_ids, const idx_t capacity) : row_ids(row_ids), capacity(capacity) {
 	}
 
-	bool IsFull() const {
+	bool TryAdd(const row_t rid) {
 		D_ASSERT(row_ids.size() <= capacity);
-		return row_ids.size() >= capacity;
+		if (row_ids.size() >= capacity) {
+			return false;
+		}
+		row_ids.insert(rid);
+		return true;
 	}
 	void SetKey(const IteratorKey &, const idx_t) {
 		// No-op: we don't need keys for row ID output.
 	}
-	void Add(const row_t rid) {
-		row_ids.insert(rid);
+};
+
+//! Stores Row IDs in an unsafe_vector with sorting and deduplication.
+class RowIdVectorOutput {
+public:
+	explicit RowIdVectorOutput(idx_t capacity);
+
+	bool TryAdd(row_t row_id);
+	void SetKey(const IteratorKey &, const idx_t) {
+		// No-op: we don't need keys for row ID output.
 	}
+
+	//! Clear all collection state while retaining reusable vector storage.
+	void Reset();
+	//! Normalize and transfer ownership of the contiguous Row IDs.
+	unsafe_vector<row_t> TakeRows();
+
+private:
+	void Normalize();
+
+private:
+	unsafe_vector<row_t> row_ids;
+	const idx_t capacity;
 };
 
 //! Output policy for scanning keys and row IDs.
@@ -104,18 +128,19 @@ struct KeyRowIdOutput {
 		count = 0;
 		arena.Reset();
 	}
-	bool IsFull() const {
+	bool TryAdd(const row_t rid) {
 		D_ASSERT(count <= capacity);
-		return count >= capacity;
+		if (count >= capacity) {
+			return false;
+		}
+		keys[count] = ARTKey::CreateARTKeyFromBytes(arena, key_data, key_len);
+		row_id_keys[count] = ARTKey::CreateARTKey<row_t>(arena, rid);
+		count++;
+		return true;
 	}
 	void SetKey(const IteratorKey &current_key, const idx_t column_key_len) {
 		key_data = current_key.Data();
 		key_len = column_key_len;
-	}
-	void Add(const row_t rid) {
-		keys[count] = ARTKey::CreateARTKeyFromBytes(arena, key_data, key_len);
-		row_id_keys[count] = ARTKey::CreateARTKey<row_t>(arena, rid);
-		count++;
 	}
 };
 

--- a/test/sql/index/art/scan/test_art_rowid_collection.test
+++ b/test/sql/index/art/scan/test_art_rowid_collection.test
@@ -1,0 +1,205 @@
+# name: test/sql/index/art/scan/test_art_rowid_collection.test
+# description: Test ART row ID collection order, capacity, and ownership.
+# group: [scan]
+
+load {TEST_DIR}/test_art_rowid_collection.db
+
+statement ok
+SET index_scan_percentage = 0
+
+# Preserve the existing exact-capacity boundary.
+
+statement ok
+CREATE TABLE scan_limits AS SELECT i::BIGINT AS id, i::BIGINT AS key FROM range(3) t(i)
+
+statement ok
+CREATE INDEX idx_scan_limits ON scan_limits(key)
+
+statement ok
+SET index_scan_max_count = 2
+
+query II
+EXPLAIN ANALYZE SELECT id FROM scan_limits WHERE key < 2
+----
+analyzed_plan	<REGEX>:.*Type: Index Scan.*
+
+query II
+SELECT count(*), sum(id) FROM scan_limits WHERE key < 2
+----
+2	1
+
+statement ok
+SET index_scan_max_count = 1
+
+query II
+EXPLAIN ANALYZE SELECT id FROM scan_limits WHERE key < 2
+----
+analyzed_plan	<REGEX>:.*Type: Sequential Scan.*
+
+# Skip an incompatible candidate and use a later matching ART.
+
+statement ok
+CREATE TABLE candidate_reset AS SELECT i::BIGINT AS key FROM range(16) t(i)
+
+statement ok
+CREATE INDEX idx_candidate_expression ON candidate_reset((key + 1))
+
+statement ok
+CREATE INDEX idx_candidate_key ON candidate_reset(key)
+
+statement ok
+SET index_scan_max_count = 8
+
+query II
+EXPLAIN ANALYZE SELECT sum(key) FROM candidate_reset WHERE key < 8
+----
+analyzed_plan	<REGEX>:.*Type: Index Scan.*
+
+query II
+SELECT count(*), sum(key) FROM candidate_reset WHERE key < 8
+----
+8	28
+
+# ART key order produces unordered physical Row IDs that must be sorted.
+
+statement ok
+CREATE TABLE indexed AS
+SELECT
+	i::BIGINT AS id,
+	((i::BIGINT * 15485863) % 131072)::BIGINT AS sparse_key
+FROM range(131072) t(i)
+
+statement ok
+CREATE INDEX idx_sparse ON indexed(sparse_key)
+
+statement ok
+SET threads = 32
+
+statement ok
+SET index_scan_max_count = 8192
+
+query II
+EXPLAIN ANALYZE SELECT count(*), count(DISTINCT id) FROM indexed WHERE sparse_key < 8192
+----
+analyzed_plan	<REGEX>:.*Type: Index Scan.*
+
+query II
+SELECT count(*), count(DISTINCT id) FROM indexed WHERE sparse_key < 8192
+----
+8192	8192
+
+statement ok
+SET index_scan_max_count = 4096
+
+query II
+EXPLAIN ANALYZE SELECT count(*), count(DISTINCT id) FROM indexed WHERE sparse_key < 4096
+----
+analyzed_plan	<REGEX>:.*Type: Index Scan.*
+
+query II
+SELECT count(*), count(DISTINCT id) FROM indexed WHERE sparse_key < 4096
+----
+4096	4096
+
+statement ok
+SET index_scan_max_count = 4095
+
+query II
+EXPLAIN ANALYZE SELECT id FROM indexed WHERE sparse_key < 4096
+----
+analyzed_plan	<REGEX>:.*Type: Sequential Scan.*
+
+# Reverse ART key order produces descending physical Row IDs.
+
+statement ok
+CREATE TABLE reverse_indexed AS
+SELECT i::BIGINT AS id, (65535 - i)::BIGINT AS reverse_key
+FROM range(65536) t(i)
+
+statement ok
+CREATE INDEX idx_reverse ON reverse_indexed(reverse_key)
+
+statement ok
+SET index_scan_max_count = 4096
+
+query II
+EXPLAIN ANALYZE SELECT count(*), count(DISTINCT id) FROM reverse_indexed WHERE reverse_key < 4096
+----
+analyzed_plan	<REGEX>:.*Type: Index Scan.*
+
+query II
+SELECT count(*), count(DISTINCT id) FROM reverse_indexed WHERE reverse_key < 4096
+----
+4096	4096
+
+# Multiple unique IN probes reach the exact combined capacity.
+
+statement ok
+CREATE TABLE duplicate_keys AS
+SELECT i::BIGINT AS id, (i % 4)::INTEGER AS key
+FROM range(10000) t(i)
+ORDER BY hash(i)
+
+statement ok
+CREATE INDEX idx_duplicate ON duplicate_keys(key)
+
+statement ok
+SET index_scan_max_count = 5000
+
+query II
+EXPLAIN ANALYZE SELECT count(*), count(DISTINCT id) FROM duplicate_keys WHERE key IN (1, 3)
+----
+analyzed_plan	<REGEX>:.*Type: Index Scan.*
+
+query II
+SELECT count(*), count(DISTINCT id) FROM duplicate_keys WHERE key IN (1, 3)
+----
+5000	5000
+
+# Persist and reload the ART before scanning the same unordered Row IDs.
+
+statement ok
+CHECKPOINT
+
+restart
+
+statement ok
+SET index_scan_percentage = 0
+
+statement ok
+SET index_scan_max_count = 5000
+
+query II
+EXPLAIN ANALYZE SELECT count(*), count(DISTINCT id) FROM duplicate_keys WHERE key IN (1, 3)
+----
+analyzed_plan	<REGEX>:.*Type: Index Scan.*
+
+query II
+SELECT count(*), count(DISTINCT id) FROM duplicate_keys WHERE key IN (1, 3)
+----
+5000	5000
+
+# Preserve transaction-local rows when the persistent part uses an index scan.
+
+statement ok
+BEGIN TRANSACTION
+
+statement ok
+INSERT INTO duplicate_keys
+SELECT i, 1 FROM range(10000, 10100) t(i)
+
+statement ok
+SET index_scan_max_count = 5100
+
+query II
+EXPLAIN ANALYZE SELECT count(*), count(DISTINCT id) FROM duplicate_keys WHERE key IN (1, 3)
+----
+analyzed_plan	<REGEX>:.*Type: Index Scan.*
+
+query II
+SELECT count(*), count(DISTINCT id) FROM duplicate_keys WHERE key IN (1, 3)
+----
+5100	5100
+
+statement ok
+ROLLBACK


### PR DESCRIPTION
Hi DuckDB team,

I am trying to optimize the ART index scan and would like to see your opinions.

An ART index scan has two main phases:

1. Probe the ART and collect sorted Row IDs. ART index scans currently collect matching Row IDs in a `std::set<row_t>`. This PR replaces that query-only path with an `unsafe_vector`-backed collector that defers ordering and deduplication until needed. This outperforms a `std::set<row_t>`. I noticed that [PR #18274](https://github.com/duckdb/duckdb/pull/18274) changed this path from `std::vector` to `std::set`. Was there a particular reason for this change? Note that #24942 may confict with this PR.

2. Fetch the projected table columns for those Row IDs. I have a separate optimization for this phase and plan to open another PR later.

### Design

`Iterator::Scan` submits each Row ID through `TryAdd()`. When the raw vector reaches capacity, the collector normalizes it before deciding whether the next candidate must trigger the existing table-scan fallback. This preserves the existing set-based distinct-count capacity semantics across multiple probes and ART storage overlays.

While the vector remains sorted, duplicates equal to its tail are skipped directly. The collector uses binary search for
duplicates of earlier Row IDs only within the final 16 capacity slots. This prevents repeated normalization in the
measured near-capacity case without adding membership state. For a specially constructed workload of 20K candidates starting with `capacity - 16` unique Row IDs followed by older duplicates, this collector takes 0.70 ms versus 0.47 ms for `std::set`.

During normalization, the collector selects one of the following paths:

- non-decreasing input: `unique`;
- reverse input: `reverse` plus `unique`;
- dense unordered input: bitmap materialization;
- other unordered input: DuckDB's branchless pdqsort plus `unique`.

The bitmap requires at least 8,192 Row IDs, a non-negative and safely representable span, and bitmap storage no larger than one quarter of the input Row-ID array's size. The minimum and maximum Row IDs and reverse ordering are checked only during normalization.

### Benchmarks

The selected official DuckDB ART benchmarks, run with 32 threads, show no measurable regressions, while the broader scans improve:

| Benchmark | Baseline | This PR | Change |
|---|---:|---:|---:|
| `point_query_with_art` | 0.72 | 0.73 | no measurable regression |
| `point_query_with_art_and_many_keys` | 41.93 | 21.66 | 48.35% faster |
| `wide_range_query_with_art` | 956.44 | 517.30 | 45.91% faster |
| `delete_colocated_fetch` | 1886.85 | 1875.71 | no regression |

A custom 100K Row-ID collector benchmark shows improvements across all five tested distributions:

| Distribution | `std::set` | This PR | Change |
|---|---:|---:|---:|
| ascending | 16.91 | 1.03 | 93.91% faster |
| descending | 17.20 | 1.10 | 93.61% faster |
| dense unordered | 22.02 | 2.96 | 86.57% faster |
| sparse unordered | 22.96 | 4.02 | 82.47% faster |
| duplicates | 2.84 | 1.24 | 56.33% faster |




### Further Questions

ART lookup also remains serial and materializes all Row IDs before table fetching begins. Is there an existing plan to
parallelize ART lookup or stream Row-ID batches into table fetching?


