### PR TITLE
CSV: use identifier matching for column lookups

### DIFF
--- a/src/execution/operator/csv_scanner/scanner/csv_schema.cpp
+++ b/src/execution/operator/csv_scanner/scanner/csv_schema.cpp
@@ -158,11 +158,11 @@ bool CSVSchema::SchemasMatch(string &error_message, SnifferResult &sniffer_resul
                              bool is_minimal_sniffer) const {
 	D_ASSERT(sniffer_result.names.size() == sniffer_result.return_types.size());
 	bool match = true;
-	unordered_map<string, TypeIdxPair> current_schema;
+	identifier_map_t<TypeIdxPair> current_schema;
 
 	for (idx_t i = 0; i < sniffer_result.names.size(); i++) {
 		// Populate our little schema
-		current_schema[sniffer_result.names[i].GetIdentifierName()] = {sniffer_result.return_types[i], i};
+		current_schema[sniffer_result.names[i]] = {sniffer_result.return_types[i], i};
 	}
 	if (is_minimal_sniffer) {
 		auto min_sniffer = static_cast<AdaptiveSnifferResult &>(sniffer_result);
@@ -170,7 +170,7 @@ bool CSVSchema::SchemasMatch(string &error_message, SnifferResult &sniffer_resul
 			bool min_sniff_match = true;
 			// If we don't have more than one row, either the names must match or the types must match.
 			for (auto &column : columns) {
-				if (current_schema.find(column.name.GetIdentifierName()) == current_schema.end()) {
+				if (current_schema.find(column.name) == current_schema.end()) {
 					min_sniff_match = false;
 					break;
 				}
@@ -213,15 +213,16 @@ bool CSVSchema::SchemasMatch(string &error_message, SnifferResult &sniffer_resul
 	error << "Current file: " << cur_file_path << "\n";
 
 	for (auto &column : columns) {
-		if (current_schema.find(column.name.GetIdentifierName()) == current_schema.end()) {
+		auto schema_entry = current_schema.find(column.name);
+		if (schema_entry == current_schema.end()) {
 			error << "Column with name: \"" << column.name.GetIdentifierName() << "\" is missing"
 			      << "\n";
 			match = false;
 		} else {
-			if (!CanWeCastIt(current_schema[column.name.GetIdentifierName()].type.id(), column.type.id())) {
+			if (!CanWeCastIt(schema_entry->second.type.id(), column.type.id())) {
 				error << "Column with name: \"" << column.name.GetIdentifierName()
 				      << "\" is expected to have type: " << column.type.ToString();
-				error << " But has type: " << current_schema[column.name.GetIdentifierName()].type.ToString() << "\n";
+				error << " But has type: " << schema_entry->second.type.ToString() << "\n";
 				match = false;
 			}
 		}

--- a/src/execution/operator/csv_scanner/table_function/csv_multi_file_info.cpp
+++ b/src/execution/operator/csv_scanner/table_function/csv_multi_file_info.cpp
@@ -230,14 +230,14 @@ void CSVMultiFileInfo::FinalizeBindData(MultiFileBindData &multi_file_data) {
 			column_names.insert(name);
 		}
 		for (auto &force_name : options.force_not_null_names) {
-			if (column_names.find(Identifier(force_name)) == column_names.end()) {
+			if (column_names.find(force_name) == column_names.end()) {
 				throw BinderException("\"force_not_null\" expected to find %s, but it was not found in the table",
-				                      force_name);
+				                      force_name.GetIdentifierName());
 			}
 		}
 		D_ASSERT(options.force_not_null.empty());
 		for (idx_t i = 0; i < names.size(); i++) {
-			if (options.force_not_null_names.find(names[i].GetIdentifierName()) != options.force_not_null_names.end()) {
+			if (options.force_not_null_names.find(names[i]) != options.force_not_null_names.end()) {
 				options.force_not_null.push_back(true);
 			} else {
 				options.force_not_null.push_back(false);

--- a/src/execution/operator/csv_scanner/util/csv_reader_options.cpp
+++ b/src/execution/operator/csv_scanner/util/csv_reader_options.cpp
@@ -328,7 +328,7 @@ void CSVReaderOptions::SetReadOption(const Identifier &loption, const Value &val
 			auto &children = ListValue::GetChildren(value);
 			for (auto &child : children) {
 				auto col_name = child.GetValue<string>();
-				force_not_null_names.insert(col_name);
+				force_not_null_names.insert(Identifier(col_name));
 			}
 		}
 

--- a/src/include/duckdb/execution/operator/csv_scanner/csv_reader_options.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/csv_reader_options.hpp
@@ -100,7 +100,7 @@ struct CSVReaderOptions {
 	//! Whether header names shall be normalized
 	bool normalize_names = false;
 	//! True, if column with that index must skip null check
-	unordered_set<string> force_not_null_names;
+	identifier_set_t force_not_null_names;
 	//! True, if column with that index must skip null check
 	vector<bool> force_not_null;
 	//! Result size of sniffing phases

--- a/test/sql/copy/csv/csv_identifier_case_matching.test
+++ b/test/sql/copy/csv/csv_identifier_case_matching.test
@@ -1,0 +1,24 @@
+# name: test/sql/copy/csv/csv_identifier_case_matching.test
+# description: CSV options and schema matching should use identifier semantics
+# group: [csv]
+
+statement ok
+COPY (SELECT '__NULL__'::VARCHAR AS "A") TO '{TEMP_DIR}/force_not_null_case.csv' (HEADER);
+
+query T
+SELECT CASE WHEN A IS NULL THEN 'null' ELSE 'not_null' END
+FROM read_csv('{TEMP_DIR}/force_not_null_case.csv', header = true, nullstr = '__NULL__', force_not_null = ['a']);
+----
+not_null
+
+statement ok
+COPY (SELECT 1 AS "A") TO '{TEMP_DIR}/csv_schema_case_1.csv' (HEADER);
+
+statement ok
+COPY (SELECT 2 AS "a") TO '{TEMP_DIR}/csv_schema_case_2.csv' (HEADER);
+
+query I
+SELECT SUM(A)
+FROM read_csv(['{TEMP_DIR}/csv_schema_case_1.csv', '{TEMP_DIR}/csv_schema_case_2.csv'], header = true);
+----
+3


### PR DESCRIPTION
## Summary
- keep `force_not_null` column matching in Identifier containers instead of raw string sets
- use Identifier-backed schema matching for multi-file CSV validation
- add regression coverage for differently cased CSV headers in `force_not_null` and multi-file schema checks

## Tests
- `GEN=ninja make reldebug -j8`
- `build/reldebug/test/unittest test/sql/copy/csv/csv_identifier_case_matching.test`
- `build/reldebug/test/unittest test/sql/copy/csv/test_mismatch_schemas.test`
- `build/reldebug/test/unittest test/sql/copy/csv/test_copy_null.test`
- `build/reldebug/test/unittest test/sql/copy/csv/test_union_by_name.test`
