### PR TITLE
feature: add streaming select to ZSTD and DICTIONARY

### DIFF
--- a/src/include/duckdb/storage/compression/dictionary/decompression.hpp
+++ b/src/include/duckdb/storage/compression/dictionary/decompression.hpp
@@ -22,6 +22,7 @@ public:
 	void ScanToFlatVector(Vector &result, idx_t result_offset, idx_t start, idx_t scan_count);
 	void ScanToDictionaryVector(ColumnSegment &segment, Vector &result, idx_t result_offset, idx_t start,
 	                            idx_t scan_count);
+	void Select(Vector &result, idx_t start, const SelectionVector &sel, idx_t sel_count);
 
 private:
 	string_t FetchStringFromDict(uint32_t dict_offset, uint16_t string_len);

--- a/src/storage/compression/dictionary/decompression.cpp
+++ b/src/storage/compression/dictionary/decompression.cpp
@@ -180,6 +180,44 @@ template void CompressedStringScanState::ScanToFlatVector<false>(Vector &result,
 template void CompressedStringScanState::ScanToFlatVector<true>(Vector &result, idx_t result_offset, idx_t start,
                                                                 idx_t scan_count);
 
+void CompressedStringScanState::Select(Vector &result, idx_t start, const SelectionVector &sel, idx_t sel_count) {
+	static constexpr idx_t GROUP_SIZE = BitpackingPrimitives::BITPACKING_ALGORITHM_GROUP_SIZE;
+
+	auto result_data = FlatVector::Writer<string_t>(result, sel_count);
+
+	// A dictionary vector emitted by an earlier scan can still reference sel_vec, so unpack into a
+	// local buffer rather than reusing it.
+	sel_t group[GROUP_SIZE];
+
+	// Only unpack the bitpacking groups that actually contain a selected row, instead of every group
+	// spanned by the vector.
+	bool has_error = false;
+	idx_t unpacked_group = DConstants::INVALID_INDEX;
+	for (idx_t i = 0; i < sel_count; i++) {
+		idx_t index = start + sel.get_index(i);
+		idx_t group_start = index - (index % GROUP_SIZE);
+		if (group_start != unpacked_group) {
+			data_ptr_t src = &base_data[(group_start * current_width) / 8];
+			BitpackingPrimitives::UnPackBuffer<sel_t>(data_ptr_cast(group), src, GROUP_SIZE, current_width);
+			unpacked_group = group_start;
+		}
+		auto string_number = group[index - group_start];
+		const bool elem_error = string_number >= index_buffer_count;
+		string_number = elem_error ? 0 : string_number;
+		has_error |= elem_error;
+
+		const auto dict_offset = index_buffer_ptr[string_number];
+		const auto str_len = GetStringLength(string_number);
+		result_data.WriteStringRef(FetchStringFromDict(dict_offset, str_len));
+	}
+
+	if (has_error) {
+		throw DataCorruptionException(
+		    "Failed to scan dictionary string - dictionary index was out of range. Database file appears "
+		    "to be corrupted.");
+	}
+}
+
 void CompressedStringScanState::ScanToDictionaryVector(ColumnSegment &segment, Vector &result, idx_t result_offset,
                                                        idx_t start, idx_t scan_count) {
 	D_ASSERT(scan_count == STANDARD_VECTOR_SIZE);

--- a/src/storage/compression/dictionary_compression.cpp
+++ b/src/storage/compression/dictionary_compression.cpp
@@ -60,6 +60,8 @@ struct DictionaryCompressionStorage {
 	static void StringScanPartial(ColumnSegment &segment, ColumnScanState &state, idx_t scan_count, Vector &result,
 	                              idx_t result_offset);
 	static void StringScan(ColumnSegment &segment, ColumnScanState &state, idx_t scan_count, Vector &result);
+	static void Select(ColumnSegment &segment, ColumnScanState &state, idx_t vector_count, Vector &result,
+	                   const SelectionVector &sel, idx_t sel_count);
 	static void StringFetchRow(ColumnSegment &segment, ColumnFetchState &state, row_t row_id, Vector &result,
 	                           idx_t result_idx);
 };
@@ -150,6 +152,17 @@ void DictionaryCompressionStorage::StringScan(ColumnSegment &segment, ColumnScan
 }
 
 //===--------------------------------------------------------------------===//
+// Select
+//===--------------------------------------------------------------------===//
+void DictionaryCompressionStorage::Select(ColumnSegment &segment, ColumnScanState &state, idx_t vector_count,
+                                          Vector &result, const SelectionVector &sel, idx_t sel_count) {
+	auto &scan_state = state.scan_state->Cast<CompressedStringScanState>();
+	auto start = state.GetPositionInSegment();
+
+	scan_state.Select(result, start, sel, sel_count);
+}
+
+//===--------------------------------------------------------------------===//
 // Fetch
 //===--------------------------------------------------------------------===//
 void DictionaryCompressionStorage::StringFetchRow(ColumnSegment &segment, ColumnFetchState &state, row_t row_id,
@@ -164,7 +177,7 @@ void DictionaryCompressionStorage::StringFetchRow(ColumnSegment &segment, Column
 // Get Function
 //===--------------------------------------------------------------------===//
 CompressionFunction DictionaryCompressionFun::GetFunction(PhysicalType data_type) {
-	return CompressionFunction(
+	auto res = CompressionFunction(
 	    CompressionType::COMPRESSION_DICTIONARY, data_type, DictionaryCompressionStorage ::StringInitAnalyze,
 	    DictionaryCompressionStorage::StringAnalyze, DictionaryCompressionStorage::StringFinalAnalyze,
 	    DictionaryCompressionStorage::InitCompression, DictionaryCompressionStorage::Compress,
@@ -172,6 +185,8 @@ CompressionFunction DictionaryCompressionFun::GetFunction(PhysicalType data_type
 	    DictionaryCompressionStorage::StringScan, DictionaryCompressionStorage::StringScanPartial<false>,
 	    DictionaryCompressionStorage::StringFetchRow, UncompressedFunctions::EmptySkip,
 	    UncompressedStringStorage::StringInitSegment);
+	res.select = DictionaryCompressionStorage::Select;
+	return res;
 }
 
 bool DictionaryCompressionFun::TypeIsSupported(const PhysicalType physical_type) {

--- a/src/storage/compression/validity_uncompressed.cpp
+++ b/src/storage/compression/validity_uncompressed.cpp
@@ -597,12 +597,14 @@ void ValidityRevertAppend(ColumnSegment &segment, idx_t new_count) {
 //===--------------------------------------------------------------------===//
 CompressionFunction ValidityUncompressed::GetFunction(PhysicalType data_type) {
 	D_ASSERT(data_type == PhysicalType::BIT);
-	return CompressionFunction(CompressionType::COMPRESSION_UNCOMPRESSED, data_type, ValidityInitAnalyze,
-	                           ValidityAnalyze, ValidityFinalAnalyze, UncompressedFunctions::InitCompression,
-	                           UncompressedFunctions::Compress, UncompressedFunctions::FinalizeCompress,
-	                           ValidityInitScan, ValidityScan, ValidityScanPartial, ValidityFetchRow,
-	                           UncompressedFunctions::EmptySkip, ValidityInitSegment, ValidityInitAppend,
-	                           ValidityAppend, ValidityFinalizeAppend, ValidityRevertAppend);
+	CompressionFunction res(CompressionType::COMPRESSION_UNCOMPRESSED, data_type, ValidityInitAnalyze, ValidityAnalyze,
+	                        ValidityFinalAnalyze, UncompressedFunctions::InitCompression,
+	                        UncompressedFunctions::Compress, UncompressedFunctions::FinalizeCompress, ValidityInitScan,
+	                        ValidityScan, ValidityScanPartial, ValidityFetchRow, UncompressedFunctions::EmptySkip,
+	                        ValidityInitSegment, ValidityInitAppend, ValidityAppend, ValidityFinalizeAppend,
+	                        ValidityRevertAppend);
+	res.select = ValiditySelect;
+	return res;
 }
 
 } // namespace duckdb

--- a/src/storage/compression/zstd.cpp
+++ b/src/storage/compression/zstd.cpp
@@ -82,6 +82,8 @@ struct ZSTDStorage {
 	static void StringScanPartial(ColumnSegment &segment, ColumnScanState &state, idx_t scan_count, Vector &result,
 	                              idx_t result_offset);
 	static void StringScan(ColumnSegment &segment, ColumnScanState &state, idx_t scan_count, Vector &result);
+	static void Select(ColumnSegment &segment, ColumnScanState &state, idx_t vector_count, Vector &result,
+	                   const SelectionVector &sel, idx_t sel_count);
 	static void StringFetchRow(ColumnSegment &segment, ColumnFetchState &state, row_t row_id, Vector &result,
 	                           idx_t result_idx);
 	static void StringSkip(ColumnSegment &segment, ColumnScanState &state, idx_t skip_count) {
@@ -837,6 +839,23 @@ public:
 		return scan_state;
 	}
 
+	//! Like LoadVector, but tolerates a stream that is already positioned inside the vector.
+	//! LoadVector only reuses the cached state on an exact offset match, which would force a full
+	//! re-initialization (and a skip from the start of the frame) for every selected row.
+	ZSTDVectorScanState &LoadVectorForSelect(idx_t vector_idx, idx_t internal_offset) {
+		if (current_vector && current_vector->metadata.vector_idx == vector_idx &&
+		    current_vector->scanned_count <= internal_offset) {
+			auto &scan_state = *current_vector;
+			if (scan_state.scanned_count < internal_offset) {
+				Skip(scan_state, internal_offset - scan_state.scanned_count);
+			}
+			return scan_state;
+		}
+		// Either no vector is loaded, a different vector is loaded, or the stream is already past the
+		// requested row - a zstd frame can only be read forwards, so restart from the beginning.
+		return LoadVector(vector_idx, internal_offset);
+	}
+
 	void LoadNextPageForVector(ZSTDVectorScanState &scan_state) {
 		if (scan_state.in_buffer.pos != scan_state.in_buffer.size) {
 			throw InternalException(
@@ -950,6 +969,34 @@ public:
 		scanned_count += count;
 	}
 
+	//! Decompress only the selected rows. The gaps between them are streamed through the fixed-size
+	//! skip_buffer, so the memory required is proportional to the selected data instead of to the
+	//! size of the entire vector.
+	void SelectPartial(idx_t start_idx, Vector &result, const SelectionVector &sel, idx_t sel_count) {
+		D_ASSERT(result.GetType().InternalType() == PhysicalType::VARCHAR);
+		auto result_data = FlatVector::GetDataMutable<string_t>(result);
+
+		for (idx_t i = 0; i < sel_count; i++) {
+			idx_t internal_offset;
+			idx_t vector_idx = GetVectorIndex(start_idx + sel.get_index(i), internal_offset);
+			auto &scan_state = LoadVectorForSelect(vector_idx, internal_offset);
+			D_ASSERT(scan_state.scanned_count == internal_offset);
+
+			auto string_length = scan_state.string_lengths[internal_offset];
+			auto str = StringVector::EmptyString(result, string_length);
+			DecompressString(scan_state, data_ptr_cast(str.GetDataWriteable()), string_length);
+			str.Finalize();
+			result_data[i] = str;
+
+			scan_state.scanned_count++;
+			scanned_count++;
+		}
+
+		// The remainder of the vector is never decompressed. The stream is left in the middle of the
+		// frame, which the scan path cannot reuse, so release it here to unpin the frame's pages.
+		current_vector.reset();
+	}
+
 	void ScanPartial(idx_t start_idx, Vector &result, idx_t offset, idx_t count) {
 		idx_t remaining = count;
 		idx_t scanned = 0;
@@ -1018,6 +1065,17 @@ void ZSTDStorage::StringScan(ColumnSegment &segment, ColumnScanState &state, idx
 }
 
 //===--------------------------------------------------------------------===//
+// Select
+//===--------------------------------------------------------------------===//
+void ZSTDStorage::Select(ColumnSegment &segment, ColumnScanState &state, idx_t vector_count, Vector &result,
+                         const SelectionVector &sel, idx_t sel_count) {
+	auto &scan_state = state.scan_state->template Cast<ZSTDScanState>();
+	auto start = state.GetPositionInSegment();
+
+	scan_state.SelectPartial(start, result, sel, sel_count);
+}
+
+//===--------------------------------------------------------------------===//
 // Fetch
 //===--------------------------------------------------------------------===//
 void ZSTDStorage::StringFetchRow(ColumnSegment &segment, ColumnFetchState &state, row_t row_id, Vector &result,
@@ -1072,6 +1130,7 @@ CompressionFunction ZSTDFun::GetFunction(PhysicalType data_type) {
 	    ZSTDStorage::StringFinalAnalyze, ZSTDStorage::InitCompression, ZSTDStorage::Compress,
 	    ZSTDStorage::FinalizeCompress, ZSTDStorage::StringInitScan, ZSTDStorage::StringScan,
 	    ZSTDStorage::StringScanPartial, ZSTDStorage::StringFetchRow, ZSTDStorage::StringSkip);
+	zstd.select = ZSTDStorage::Select;
 	zstd.init_segment = ZSTDStorage::StringInitSegment;
 	zstd.serialize_state = ZSTDStorage::SerializeState;
 	zstd.deserialize_state = ZSTDStorage::DeserializeState;

--- a/src/storage/table/column_data.cpp
+++ b/src/storage/table/column_data.cpp
@@ -268,10 +268,11 @@ void ColumnData::SelectVector(ColumnScanState &state, Vector &result, idx_t targ
 		throw InternalException("ColumnData::SelectVector should be able to fetch everything from one segment");
 	}
 	if (state.scan_options && state.scan_options->force_fetch_row) {
+		auto start = state.GetPositionInSegment();
 		for (idx_t i = 0; i < sel_count; i++) {
 			auto source_idx = sel.get_index(i);
 			ColumnFetchState fetch_state;
-			current.FetchRow(fetch_state, UnsafeNumericCast<row_t>(state.offset_in_column + source_idx), result, i);
+			current.FetchRow(fetch_state, UnsafeNumericCast<row_t>(start + source_idx), result, i);
 		}
 	} else {
 		current.Select(state, target_count, result, sel, sel_count);

--- a/test/configs/disable_optimizer.json
+++ b/test/configs/disable_optimizer.json
@@ -25,6 +25,12 @@
       ]
     },
     {
+      "reason": "Select pushdown into compressed data requires filter pushdown from optimizer.",
+      "paths": [
+        "test/sql/storage/compression/zstd/zstd_select_memory.test"
+      ]
+    },
+    {
       "reason": "Unoptimized statement differs from original result (cross product, conversion, overflow, statistics).",
       "paths": [
         "test/fuzzer/duckfuzz/semi_join_has_correct_left_right_relations.test",

--- a/test/sql/storage/compression/dictionary/dictionary_select.test
+++ b/test/sql/storage/compression/dictionary/dictionary_select.test
@@ -1,0 +1,135 @@
+# name: test/sql/storage/compression/dictionary/dictionary_select.test
+# description: Test select (filter pushdown) on Dictionary compressed columns
+# group: [dictionary]
+
+require no_latest_storage
+
+require vector_size 2048
+
+load {TEST_DIR}/dictionary_select.db readwrite v1.0.0
+
+statement ok
+PRAGMA force_compression='dictionary'
+
+# 4096 rows spans multiple bitpacking groups, every 7th value is NULL
+# `sparse` and `dense` exist so a filter that is pushed into the scan can produce a sparse
+# respectively a dense selection vector for `v`
+statement ok
+CREATE TABLE t AS
+SELECT
+	i AS id,
+	i % 977 = 0 AS sparse,
+	i % 3 = 0 AS dense,
+	CASE WHEN i % 7 = 0 THEN NULL ELSE 'thisisalongstring_' || (i % 500) END AS v
+FROM range(4096) tbl(i);
+
+statement ok
+CHECKPOINT
+
+query I
+SELECT compression FROM pragma_storage_info('t') WHERE segment_type='VARCHAR' LIMIT 1
+----
+Dictionary
+
+# all filters below are on columns other than `v`, so `v` is read through the select path with a
+# partially selected vector
+
+# single row
+query II
+SELECT id, v FROM t WHERE id = 1234
+----
+1234	thisisalongstring_234
+
+# single row that is NULL
+query II
+SELECT id, v FROM t WHERE id = 1239
+----
+1239	NULL
+
+# range straddling the vector boundary at 2048
+query II
+SELECT id, v FROM t WHERE id BETWEEN 2044 AND 2051 ORDER BY id
+----
+2044	NULL
+2045	thisisalongstring_45
+2046	thisisalongstring_46
+2047	thisisalongstring_47
+2048	thisisalongstring_48
+2049	thisisalongstring_49
+2050	thisisalongstring_50
+2051	NULL
+
+# range at the start of the segment
+query II
+SELECT id, v FROM t WHERE id < 10 ORDER BY id
+----
+0	NULL
+1	thisisalongstring_1
+2	thisisalongstring_2
+3	thisisalongstring_3
+4	thisisalongstring_4
+5	thisisalongstring_5
+6	thisisalongstring_6
+7	NULL
+8	thisisalongstring_8
+9	thisisalongstring_9
+
+# sparse selection - at most one row per vector
+query II
+SELECT id, v FROM t WHERE sparse ORDER BY id
+----
+0	NULL
+977	thisisalongstring_477
+1954	thisisalongstring_454
+2931	thisisalongstring_431
+3908	thisisalongstring_408
+
+# dense selection - a third of every vector
+query II
+SELECT count(*), count(v) FROM t WHERE dense
+----
+1366	1170
+
+# near-complete selection
+query II
+SELECT count(*), count(v) FROM t WHERE NOT sparse
+----
+4091	3506
+
+# selecting every row
+query II
+SELECT count(*), count(v) FROM t WHERE id >= 0
+----
+4096	3510
+
+# compare the values produced by the select path against the expected ones; the two-column
+# predicate cannot be pushed into the scan, so the pushed-down filter still drives the select
+query I
+SELECT count(*) FROM t
+WHERE dense AND v IS NOT DISTINCT FROM CASE WHEN id % 7 = 0 THEN NULL ELSE 'thisisalongstring_' || (id % 500) END
+----
+1366
+
+query I
+SELECT count(*) FROM t
+WHERE sparse AND v IS NOT DISTINCT FROM CASE WHEN id % 7 = 0 THEN NULL ELSE 'thisisalongstring_' || (id % 500) END
+----
+5
+
+query I
+SELECT count(*) FROM t
+WHERE NOT sparse AND v IS NOT DISTINCT FROM CASE WHEN id % 7 = 0 THEN NULL ELSE 'thisisalongstring_' || (id % 500) END
+----
+4091
+
+query I
+SELECT count(*) FROM t
+WHERE id < 2048 AND v IS NOT DISTINCT FROM CASE WHEN id % 7 = 0 THEN NULL ELSE 'thisisalongstring_' || (id % 500) END
+----
+2048
+
+query I
+SELECT count(*) FROM t
+WHERE id >= 2048 AND v IS NOT DISTINCT FROM CASE WHEN id % 7 = 0 THEN NULL ELSE 'thisisalongstring_' || (id % 500) END
+----
+2048

--- a/test/sql/storage/compression/zstd/zstd_select.test
+++ b/test/sql/storage/compression/zstd/zstd_select.test
@@ -1,0 +1,133 @@
+# name: test/sql/storage/compression/zstd/zstd_select.test
+# description: Test select (filter pushdown) on ZSTD compressed columns
+# group: [zstd]
+
+require vector_size 2048
+
+load {TEST_DIR}/zstd_select.db readwrite v1.2.0
+
+statement ok
+PRAGMA force_compression='zstd'
+
+# 4096 rows spans two ZSTD vectors, every 7th value is NULL
+# `sparse` and `dense` exist so a filter that is pushed into the scan can produce a sparse
+# respectively a dense selection vector for `v`
+statement ok
+CREATE TABLE t AS
+SELECT
+	i AS id,
+	i % 977 = 0 AS sparse,
+	i % 3 = 0 AS dense,
+	CASE WHEN i % 7 = 0 THEN NULL ELSE 'thisisalongstring_' || i END AS v
+FROM range(4096) tbl(i);
+
+statement ok
+CHECKPOINT
+
+query I
+SELECT compression FROM pragma_storage_info('t') WHERE segment_type='VARCHAR' LIMIT 1
+----
+ZSTD
+
+# all filters below are on columns other than `v`, so `v` is read through the select path with a
+# partially selected vector
+
+# single row
+query II
+SELECT id, v FROM t WHERE id = 1234
+----
+1234	thisisalongstring_1234
+
+# single row that is NULL
+query II
+SELECT id, v FROM t WHERE id = 1239
+----
+1239	NULL
+
+# range straddling the ZSTD vector boundary at 2048
+query II
+SELECT id, v FROM t WHERE id BETWEEN 2044 AND 2051 ORDER BY id
+----
+2044	NULL
+2045	thisisalongstring_2045
+2046	thisisalongstring_2046
+2047	thisisalongstring_2047
+2048	thisisalongstring_2048
+2049	thisisalongstring_2049
+2050	thisisalongstring_2050
+2051	NULL
+
+# range at the start of the segment
+query II
+SELECT id, v FROM t WHERE id < 10 ORDER BY id
+----
+0	NULL
+1	thisisalongstring_1
+2	thisisalongstring_2
+3	thisisalongstring_3
+4	thisisalongstring_4
+5	thisisalongstring_5
+6	thisisalongstring_6
+7	NULL
+8	thisisalongstring_8
+9	thisisalongstring_9
+
+# sparse selection - at most one row per vector
+query II
+SELECT id, v FROM t WHERE sparse ORDER BY id
+----
+0	NULL
+977	thisisalongstring_977
+1954	thisisalongstring_1954
+2931	thisisalongstring_2931
+3908	thisisalongstring_3908
+
+# dense selection - a third of every vector
+query II
+SELECT count(*), count(v) FROM t WHERE dense
+----
+1366	1170
+
+# near-complete selection
+query II
+SELECT count(*), count(v) FROM t WHERE NOT sparse
+----
+4091	3506
+
+# selecting every row
+query II
+SELECT count(*), count(v) FROM t WHERE id >= 0
+----
+4096	3510
+
+# compare the values produced by the select path against the expected ones; the two-column
+# predicate cannot be pushed into the scan, so the pushed-down filter still drives the select
+query I
+SELECT count(*) FROM t
+WHERE dense AND v IS NOT DISTINCT FROM CASE WHEN id % 7 = 0 THEN NULL ELSE 'thisisalongstring_' || id END
+----
+1366
+
+query I
+SELECT count(*) FROM t
+WHERE sparse AND v IS NOT DISTINCT FROM CASE WHEN id % 7 = 0 THEN NULL ELSE 'thisisalongstring_' || id END
+----
+5
+
+query I
+SELECT count(*) FROM t
+WHERE NOT sparse AND v IS NOT DISTINCT FROM CASE WHEN id % 7 = 0 THEN NULL ELSE 'thisisalongstring_' || id END
+----
+4091
+
+query I
+SELECT count(*) FROM t
+WHERE id < 2048 AND v IS NOT DISTINCT FROM CASE WHEN id % 7 = 0 THEN NULL ELSE 'thisisalongstring_' || id END
+----
+2048
+
+query I
+SELECT count(*) FROM t
+WHERE id >= 2048 AND v IS NOT DISTINCT FROM CASE WHEN id % 7 = 0 THEN NULL ELSE 'thisisalongstring_' || id END
+----
+2048

--- a/test/sql/storage/compression/zstd/zstd_select_memory.test
+++ b/test/sql/storage/compression/zstd/zstd_select_memory.test
@@ -1,0 +1,73 @@
+# name: test/sql/storage/compression/zstd/zstd_select_memory.test
+# description: A point lookup in a ZSTD column must only decompress the selected rows, not the entire vector
+# group: [zstd]
+
+require vector_size 2048
+
+load {TEST_DIR}/zstd_select_memory.db readwrite v1.2.0
+
+statement ok
+PRAGMA force_compression='zstd'
+
+statement ok
+SET threads=1
+
+# 2048 rows of 128KB fill exactly one ZSTD vector; the values are highly compressible so the
+# database file stays small
+# the NULLs matter: without them the validity column is constant-compressed, with them it is
+# uncompressed, which is the case that used to fall back to scanning the entire vector
+statement ok
+CREATE TABLE t AS
+SELECT
+	i AS id,
+	i % 512 = 1 AS sparse,
+	CASE WHEN i % 7 = 0 THEN NULL ELSE repeat(chr((97 + i % 26)::INTEGER), 128000) END AS v
+FROM range(2048) tbl(i);
+
+statement ok
+CHECKPOINT
+
+query I
+SELECT compression FROM pragma_storage_info('t') WHERE segment_type='VARCHAR'
+----
+ZSTD
+
+query I
+SELECT compression FROM pragma_storage_info('t') WHERE column_name='v' AND segment_type='VALIDITY'
+----
+Uncompressed
+
+# reopen so the scan reads the segment cold from disk
+restart
+
+statement ok
+SET threads=1
+
+# disable spilling so the memory limit actually bites
+statement ok
+PRAGMA temp_directory=''
+
+statement ok
+PRAGMA max_temp_directory_size='0B'
+
+# decompressing the selected rows needs a few hundred KB, decompressing the whole vector needs
+# a 256MB buffer and does not fit in this limit
+statement ok
+SET memory_limit='100MB'
+
+query II
+SELECT id, length(v) FROM t WHERE id = 1000
+----
+1000	128000
+
+query II
+SELECT id, length(v) FROM t WHERE id BETWEEN 1000 AND 1002 ORDER BY id
+----
+1000	128000
+1001	NULL
+1002	128000
+
+query III
+SELECT count(*), count(v), sum(length(v)) FROM t WHERE sparse
+----
+4	4	512000


### PR DESCRIPTION
ZSTD and DICTIONARY did not implement the optional select callback of the compression function framework, so a filtered point lookup fell back to ColumnData::Select, which scans the entire vector and then slices out the matching rows. With roughly 1 MB per row, returning a single row decompressed and materialized about 2 GB, an amplification of about 2000x that could push an instance into OOM under concurrency.

Changes made:
- zstd.cpp: add ZSTDStorage::Select and ZSTDScanState::SelectPartial, which decompress only the selected rows and advance the zstd frame over the gaps through the existing fixed-size skip_buffer. Peak memory drops from the size of the whole vector to the size of the selected rows plus about 128 KB. CPU is unchanged because a zstd frame can only be read forwards, so skipped bytes must still be decompressed.
- dictionary/decompression.cpp: add CompressedStringScanState::Select, unpacking only the bitpacking groups that contain a selected row instead of every group the vector spans. The dictionary format is not streaming and hands out zero-copy pointers into the pinned block, so this saves CPU rather than memory. Unpacking goes to a local buffer so that a dictionary vector emitted by an earlier scan keeps owning sel_vec.
- dictionary_compression.cpp: register the new select callback.

Testing performed:
- 2048 rows of about 180 KB in a single ZSTD vector: a one-row point lookup fails with "failed to allocate data of size 512.0 MiB" on the unpatched build and succeeds under memory_limit=100MB with the patch.
- Results compared against the non-pushdown plan for single-row, vector-boundary, sparse, dense and range selections, with and without NULLs, for both compression methods.
- test/sql/storage/compression: 158 test cases, 423170 assertions.