### PR TITLE
Fall back to naive window aggregation when dynamic Top-N arguments make partial aggregate states unsafe to combine

### DIFF
--- a/extension/core_functions/aggregate/distributive/arg_min_max.cpp
+++ b/extension/core_functions/aggregate/distributive/arg_min_max.cpp
@@ -891,6 +891,7 @@ unique_ptr<FunctionData> ArgMinMaxNBind(BindAggregateFunctionInput &input) {
 	const auto val_type = arguments[0]->GetReturnType().InternalType();
 	const auto arg_type = arguments[1]->GetReturnType().InternalType();
 	function.SetReturnType(LogicalType::LIST(arguments[0]->GetReturnType()));
+	function.SetWindowStateCombineSafe(!arguments[2]->HasParameter() && arguments[2]->IsFoldable());
 
 	// Specialize the function based on the input types
 	auto function_data = make_uniq<ArgMinMaxFunctionData>(NULL_HANDLING, NULLS_LAST);

--- a/src/function/aggregate/distributive/minmax.cpp
+++ b/src/function/aggregate/distributive/minmax.cpp
@@ -565,6 +565,7 @@ unique_ptr<FunctionData> MinMaxNBind(BindAggregateFunctionInput &input) {
 	}
 
 	const auto val_type = arguments[0]->GetReturnType().InternalType();
+	function.SetWindowStateCombineSafe(!arguments[1]->HasParameter() && arguments[1]->IsFoldable());
 
 	// Specialize the function based on the input types
 	SpecializeMinMaxNFunction<COMPARATOR>(val_type, function);

--- a/src/function/aggregate_function.cpp
+++ b/src/function/aggregate_function.cpp
@@ -52,7 +52,8 @@ void AggregateFinalizeInputData::InitializeLocalState() {
 
 bool AggregateFunctionProperties::operator==(const AggregateFunctionProperties &rhs) const {
 	return FunctionProperties::operator==(rhs) && order_dependent == rhs.order_dependent &&
-	       distinct_dependent == rhs.distinct_dependent && single_value_identity == rhs.single_value_identity;
+	       distinct_dependent == rhs.distinct_dependent && single_value_identity == rhs.single_value_identity &&
+	       window_state_combine_safe == rhs.window_state_combine_safe;
 }
 bool AggregateFunctionProperties::operator!=(const AggregateFunctionProperties &rhs) const {
 	return !(*this == rhs);

--- a/src/function/window/window_aggregate_function.cpp
+++ b/src/function/window/window_aggregate_function.cpp
@@ -57,7 +57,8 @@ WindowAggregateExecutor::WindowAggregateExecutor(BoundWindowExpression &wexpr, C
     : WindowExecutor(SimplifyWindowedAggregate(wexpr, client), shared),
       mode(Settings::Get<DebugWindowModeSetting>(client)) {
 	// Force naive for SEPARATE mode or for (currently!) unsupported functionality
-	if (!Settings::Get<EnableOptimizerSetting>(client) || mode == WindowAggregationMode::SEPARATE) {
+	if (!Settings::Get<EnableOptimizerSetting>(client) || mode == WindowAggregationMode::SEPARATE ||
+	    !wexpr.AggregateFunction()->IsWindowStateCombineSafe()) {
 		if (!WindowNaiveAggregator::CanAggregate(wexpr)) {
 			throw InvalidInputException("Cannot use non-aggregate window function with naive window executor!");
 		}

--- a/src/include/duckdb/function/aggregate_function.hpp
+++ b/src/include/duckdb/function/aggregate_function.hpp
@@ -336,6 +336,8 @@ public:
 
 	//! Whether a single input row finalizes to that input's first argument unchanged
 	bool single_value_identity = false;
+	//! Whether arbitrary partial states can be combined during window aggregation
+	bool window_state_combine_safe = true;
 
 	bool operator==(const AggregateFunctionProperties &rhs) const;
 	bool operator!=(const AggregateFunctionProperties &rhs) const;
@@ -382,6 +384,8 @@ public: // Properties
 	//! Whether a single input row finalizes to that input's first argument unchanged
 	auto HasSingleValueIdentity() const -> bool { return properties.single_value_identity; }
 	auto SetSingleValueIdentity(bool value) -> void { properties.single_value_identity = value; }
+	auto IsWindowStateCombineSafe() const -> bool { return properties.window_state_combine_safe; }
+	auto SetWindowStateCombineSafe(bool value) -> void { properties.window_state_combine_safe = value; }
 
 	// Derived properties
 	bool CanAggregate() const { return callbacks.update || callbacks.combine || callbacks.finalize; }

--- a/test/issues/general/test_24449.test
+++ b/test/issues/general/test_24449.test
@@ -1,0 +1,39 @@
+# name: test/issues/general/test_24449.test
+# description: Dynamic N values in min/max window aggregates
+# group: [general]
+
+query II
+SELECT bool_and(min_result = [i]), bool_and(arg_min_result = [i])
+FROM (
+	SELECT i,
+		min(i, CASE WHEN i < 16 THEN 1 ELSE 2 END) OVER (ROWS BETWEEN CURRENT ROW AND CURRENT ROW) min_result,
+		arg_min(i, i, CASE WHEN i < 16 THEN 1 ELSE 2 END) OVER (ROWS BETWEEN CURRENT ROW AND CURRENT ROW) arg_min_result
+	FROM range(17) t(i)
+);
+----
+true	true
+
+query II
+SELECT bool_and(min_result = [i]), bool_and(arg_min_result = [i])
+FROM (
+	SELECT i,
+		min(DISTINCT i, CASE WHEN i < 16 THEN 1 ELSE 2 END) OVER (ROWS BETWEEN CURRENT ROW AND CURRENT ROW) min_result,
+		arg_min(DISTINCT i, i, CASE WHEN i < 16 THEN 1 ELSE 2 END)
+			OVER (ROWS BETWEEN CURRENT ROW AND CURRENT ROW) arg_min_result
+	FROM range(17) t(i)
+);
+----
+true	true
+
+statement ok
+PRAGMA threads=4;
+
+query I
+SELECT result
+FROM (
+	SELECT min(i, CASE WHEN i < 2500 THEN 1 ELSE 2 END) OVER () result
+	FROM range(5000) t(i)
+)
+LIMIT 1;
+----
+[0]


### PR DESCRIPTION
Fix #24449 

### Problem

The bug affected DuckDB’s Top-N aggregate variants:`min(value, n)`, `max(value, n)`, `arg_min(..., n)`, and `arg_max(..., n)`, when they were used as window functions with a row-dependent `n`.

For example, this query has a window frame containing exactly one row:

```
  SELECT min(i, CASE WHEN i < 16 THEN 1 ELSE 2 END) OVER (
      ROWS BETWEEN CURRENT ROW AND CURRENT ROW
  )
  FROM range(17) t(i);
```

Every result should therefore contain only the current value: `[0], [1], …, [16]`. Instead, DuckDB raised `Mismatched n values in min/max/arg_min/arg_max`

The problem was caused by optimized window execution. DuckDB’s segment tree eagerly constructed partial aggregate states over groups of rows, even though those rows would never appear together in any requested singleton frame. A Top-N state fixes its heap capacity from the first `n` value it sees. When partial states created with different capacities were later combined, the aggregate correctly detected the mismatch and threw an exception.

The segment tree has a fanout of `16`, which explains why the original `17`-row example triggered the bug: one partial state was initialized with `n = 1`, while the state beginning at row `17` was initialized with `n = 2`.

The same underlying assumption also existed in other optimized window paths. In particular:

  - A `DISTINCT` version of the query failed in the distinct-window accelerator.
  - A full-partition dynamic-N window could fail when parallel constant-window states were combined.

### Fix

The implemented fix introduces a small capability property on the bound aggregate function indicating whether arbitrary partial states are safe to combine during window aggregation. It defaults to true, so existing aggregates are unaffected.

The Top-N binders set this property to false when `n` is row-dependent, non-foldable, or parameterized. The window executor checks the property before selecting any optimized implementation. When combining states is unsafe, it uses the existing naive window executor, which evaluates the actual window frames without constructing invalid cross-frame partial states.