### PR TITLE
Allow some archs like musl to fail (for alpha releases)

### DIFF
--- a/.github/workflows/Extensions.yml
+++ b/.github/workflows/Extensions.yml
@@ -27,6 +27,10 @@ on:
         type: string
         required: false
         default: ''
+      allow_failure_archs:
+        type: string
+        required: false
+        default: ''
       runners:
         type: string
         required: true
@@ -188,6 +192,7 @@ jobs:
       ci_tools_version: main
       exclude_archs: ${{ matrix.exclude_archs }}
       opt_in_archs: ${{ matrix.opt_in_archs }}
+      allow_failure_archs: ${{ inputs.allow_failure_archs }}
       extra_toolchains: ${{ matrix.extra_toolchains }}
       use_merged_vcpkg_manifest: '1'
       duckdb_tag: ${{ inputs.override_git_describe }}

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -92,6 +92,7 @@ jobs:
       runner_provider: ${{ steps.runners.outputs.runner_provider }}
       skip_tests: ${{ steps.config.outputs.skip_tests }}
       effective_git_describe: ${{ steps.version.outputs.effective_git_describe }}
+      extension_allow_failure_archs: ${{ steps.version.outputs.extension_allow_failure_archs }}
     env:
       GEN: ninja
     steps:
@@ -116,11 +117,15 @@ jobs:
         shell: bash
         run: |
           effective_git_describe="${{ github.event_name == 'workflow_dispatch' && inputs.override_git_describe || '' }}"
+          extension_allow_failure_archs=
           if [[ "${{ github.event_name }}" == "workflow_dispatch" && -z "${{ inputs.git_ref }}" && -z "$effective_git_describe" ]]; then
             effective_git_describe="v2.0.0-alpha${{ github.run_number }}"
+            extension_allow_failure_archs="linux_amd64_musl;linux_arm64_musl"
           fi
           echo "effective_git_describe=$effective_git_describe" >> "$GITHUB_OUTPUT"
+          echo "extension_allow_failure_archs=$extension_allow_failure_archs" >> "$GITHUB_OUTPUT"
           echo "Using effective_git_describe=$effective_git_describe"
+          echo "Using extension_allow_failure_archs=$extension_allow_failure_archs"
 
       - name: "Checkout"
         uses: duckdb/duckdb-ci/.github/actions/checkout@main
@@ -436,6 +441,7 @@ jobs:
       skip_tests: ${{ fromJson(needs.prepare.outputs.skip_tests) }}
       run_all: ${{ github.event_name != 'workflow_dispatch' || inputs.run_all }}
       opt_in_archs: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch') && 'windows_arm64;linux_amd64_musl;linux_arm64_musl' || (github.event_name == 'pull_request' && needs.prepare.outputs.extensions_changed == 'true' && 'linux_arm64_musl') || '' }}
+      allow_failure_archs: ${{ needs.prepare.outputs.extension_allow_failure_archs }}
       runners: ${{ needs.prepare.outputs.runners }}
       runner_provider: ${{ needs.prepare.outputs.runner_provider }}
       save_cache: ${{ fromJson(needs.prepare.outputs.save_cache) }}


### PR DESCRIPTION
If a musl build [fails](https://github.com/duckdb/duckdb/actions/runs/32432696462/job/96629753610) for an extension group, we're not running the downstream checks (benchmarks, clients, etc.) because the dispatch call is checking if all previous CI jobs succeeded.

The extension workflow is one "job" in that sense so any extension job that fails gives:
```
### Check CI status
Run NEEDS_JSON='{
One or more required jobs failed or were cancelled.
extensions: failure
Error: Process completed with exit code 1.
```
and the release dispatch call is skipped (because GitHub actions cannot distinguish if the whole extensions workflow failed or a subset).

`allow_failure_archs` [sets](https://github.com/duckdb/extension-ci-tools/pull/399) `continue-on-error: true` for specific platforms (like musl) so we can continue the CI run and downstream checks for alpha release builds.

Note: we omit `allow_failure_archs` for official release builds, so we avoid releasing a duckdb version without (partial) musl extensions.

### Follow-up tasks

We should [track](https://github.com/duckdblabs/duckdb-internal/issues/10485) CI failures from partially failed CI runs to create github issues for these optional musl job failures.