### PR TITLE
Ensure COUNT(DISTINCT) uses logical collation keys, including for VARIANT and window aggregates

### DIFF
--- a/src/function/aggregate/distributive/count.cpp
+++ b/src/function/aggregate/distributive/count.cpp
@@ -296,6 +296,7 @@ AggregateFunction CountFunctionBase::GetFunction() {
 	                      FunctionNullHandling::SPECIAL_HANDLING, CountFunction::CountClusterUpdate);
 	fun.SetName("count");
 	fun.SetOrderDependent(AggregateOrderDependent::NOT_ORDER_DEPENDENT);
+	fun.SetCollateDistinctArguments(true);
 	fun.SetStructStateExport(GetCountStateType);
 	fun.SetStatisticsCallback(CountPropagateStats);
 	return fun;

--- a/src/function/aggregate_function.cpp
+++ b/src/function/aggregate_function.cpp
@@ -52,7 +52,8 @@ void AggregateFinalizeInputData::InitializeLocalState() {
 
 bool AggregateFunctionProperties::operator==(const AggregateFunctionProperties &rhs) const {
 	return FunctionProperties::operator==(rhs) && order_dependent == rhs.order_dependent &&
-	       distinct_dependent == rhs.distinct_dependent && single_value_identity == rhs.single_value_identity;
+	       distinct_dependent == rhs.distinct_dependent && single_value_identity == rhs.single_value_identity &&
+	       collate_distinct_arguments == rhs.collate_distinct_arguments;
 }
 bool AggregateFunctionProperties::operator!=(const AggregateFunctionProperties &rhs) const {
 	return !(*this == rhs);

--- a/src/function/function_binder.cpp
+++ b/src/function/function_binder.cpp
@@ -1179,6 +1179,14 @@ unique_ptr<BoundAggregateExpression>
 FunctionBinder::BindAggregateFunction(const AggregateFunction &function, vector<unique_ptr<Expression>> children,
                                       vector<pair<Identifier, unique_ptr<Expression>>> keyword_args,
                                       unique_ptr<Expression> filter, AggregateType aggr_type) {
+	if (aggr_type == AggregateType::DISTINCT && function.CollateDistinctArguments()) {
+		for (auto &child : children) {
+			ExpressionBinder::PushCollation(context, child, child->GetReturnType());
+		}
+		for (auto &argument : keyword_args) {
+			ExpressionBinder::PushCollation(context, argument.second, argument.second->GetReturnType());
+		}
+	}
 	auto [bound_function, bind_info] = ResolveFunction(function, children, keyword_args);
 
 	return make_uniq<BoundAggregateExpression>(std::move(bound_function), std::move(children), std::move(filter),

--- a/src/include/duckdb/function/aggregate_function.hpp
+++ b/src/include/duckdb/function/aggregate_function.hpp
@@ -337,6 +337,9 @@ public:
 	//! Whether a single input row finalizes to that input's first argument unchanged
 	bool single_value_identity = false;
 
+	//! Whether DISTINCT arguments can be replaced by their collation keys
+	bool collate_distinct_arguments = false;
+
 	bool operator==(const AggregateFunctionProperties &rhs) const;
 	bool operator!=(const AggregateFunctionProperties &rhs) const;
 };
@@ -382,6 +385,10 @@ public: // Properties
 	//! Whether a single input row finalizes to that input's first argument unchanged
 	auto HasSingleValueIdentity() const -> bool { return properties.single_value_identity; }
 	auto SetSingleValueIdentity(bool value) -> void { properties.single_value_identity = value; }
+
+	//! Whether DISTINCT arguments can be replaced by their collation keys
+	auto CollateDistinctArguments() const -> bool { return properties.collate_distinct_arguments; }
+	auto SetCollateDistinctArguments(bool value) -> void { properties.collate_distinct_arguments = value; }
 
 	// Derived properties
 	bool CanAggregate() const { return callbacks.update || callbacks.combine || callbacks.finalize; }

--- a/src/optimizer/compressed_materialization/compress_comparison_join.cpp
+++ b/src/optimizer/compressed_materialization/compress_comparison_join.cpp
@@ -186,7 +186,8 @@ void CompressedMaterialization::CompressComparisonJoin(unique_ptr<LogicalOperato
 					auto lhs_it = statistics_map.find(lhs_colref.Binding());
 					auto rhs_it = statistics_map.find(rhs_colref.Binding());
 					if (lhs_it != statistics_map.end() && rhs_it != statistics_map.end() && lhs_it->second &&
-					    rhs_it->second) {
+					    rhs_it->second && lhs_it->second->GetType() == lhs_colref.GetReturnType() &&
+					    rhs_it->second->GetType() == rhs_colref.GetReturnType()) {
 						// For joins we need to compress both using the same statistics, otherwise comparisons don't
 						// work
 						auto merged_stats = lhs_it->second->Copy();

--- a/src/planner/binder/expression/bind_window_expression.cpp
+++ b/src/planner/binder/expression/bind_window_expression.cpp
@@ -238,7 +238,9 @@ BindResult BaseSelectBinder::BindWindowExpression(WindowExpression &window, idx_
 
 		// bind the aggregate
 		FunctionBinder function_binder(binder);
-		auto window_bound_aggregate = function_binder.BindAggregateFunction(func, std::move(arguments), error, nullptr);
+		auto window_bound_aggregate = function_binder.BindAggregateFunction(
+		    func, std::move(arguments), error, nullptr,
+		    window.Distinct() ? AggregateType::DISTINCT : AggregateType::NON_DISTINCT);
 		// No function found, throw an error
 		if (!window_bound_aggregate) {
 			error.AddQueryLocation(window);

--- a/test/issues/general/test_23924.test
+++ b/test/issues/general/test_23924.test
@@ -1,0 +1,45 @@
+# name: test/issues/general/test_23924.test
+# description: Issue 23924 - COUNT DISTINCT uses VARIANT comparison semantics
+# group: [general]
+
+query TI
+WITH x(v) AS (
+	VALUES (1::INTEGER::VARIANT), (1::BIGINT::VARIANT)
+)
+SELECT min(v = 1::INTEGER::VARIANT), count(DISTINCT v) FROM x;
+----
+true	1
+
+# Equivalent numeric values use one NUMBER comparison class; SQL NULL is ignored.
+query I
+WITH x(v) AS (
+	VALUES (1::TINYINT::VARIANT), (1::BIGINT::VARIANT), (1.00::DECIMAL(4, 2)::VARIANT),
+	       (2::INTEGER::VARIANT), (NULL::VARIANT)
+)
+SELECT count(DISTINCT v) FROM x;
+----
+2
+
+# The native distinct-aggregate hash table must use the same keys as the logical rewrite.
+statement ok
+SET disabled_optimizers = 'distinct_aggregate_rewrite';
+
+query I
+WITH x(v) AS (
+	VALUES (1::INTEGER::VARIANT), (1::BIGINT::VARIANT)
+)
+SELECT count(DISTINCT v) FROM x;
+----
+1
+
+statement ok
+SET disabled_optimizers = '';
+
+# Windowed COUNT DISTINCT is bound through a separate path.
+query I
+WITH x(v) AS (
+	VALUES (1::INTEGER::VARIANT), (1::BIGINT::VARIANT)
+)
+SELECT DISTINCT count(DISTINCT v) OVER () FROM x;
+----
+1


### PR DESCRIPTION
Fix #23924

### Problem

This issue affected `COUNT(DISTINCT)` on DuckDB’s `VARIANT` type. For example:

```
  WITH x(v) AS (
      VALUES (1::INTEGER::VARIANT),
             (1::BIGINT::VARIANT)
  )
  SELECT
      min(v = 1::INTEGER::VARIANT) AS both_equal,
      count(DISTINCT v) AS distinct_count
  FROM x;
```

DuckDB returned:
```
  both_equal = true
  distinct_count = 2
```

This was inconsistent: the two values compared equal but were placed into different `DISTINCT` groups.

Internally, `VARIANT` is physically stored as a struct containing value data and type information. Therefore, an `INTEGER` value and a `BIGINT` value have different physical representations even when they represent the same logical number.

Normal comparisons and `GROUP BY` operations do not compare this physical representation directly. They apply `variant_comparator`, which generates a logical comparison key. This key normalizes integers of different widths, decimals, and big numbers into the same numeric category, so logically equal numeric values receive identical keys.

However, aggregate `DISTINCT` binding did not apply that transformation. Both the logical `DISTINCT`-aggregate rewrite and the native `DISTINCT` hash table received the raw `VARIANT` values. Consequently, they hashed the different internal type tags and incorrectly counted the values as distinct.

### Fix

The fix introduces an opt-in aggregate-function property indicating that `DISTINCT` arguments may safely be replaced with their logical collation keys. `COUNT` enables this property, and the common aggregate binder applies the appropriate comparator before overload resolution and `DISTINCT` processing. Because the transformation happens at the shared binding point, it covers both the optimized logical rewrite and the native DISTINCT hash-table implementation.

The property is deliberately opt-in. Replacing an argument with an irreversible comparison key is safe for `COUNT`, because it only needs to know whether a value is null and whether it belongs to an existing equivalence class. It would not be safe to apply this universally to value-returning aggregates such as `list(DISTINCT value)`, which must preserve an original representative value rather than return an internal binary comparison key.

Window aggregates use a separate binding path, so that path was also updated to pass the `DISTINCT` state into the common aggregate binder. This makes `COUNT(DISTINCT variant) OVER (...)` use the same logical equality semantics as an ordinary aggregate.

During regression testing, the corrected comparator key exposed an existing optimizer problem in a mixed `DISTINCT`/non-`DISTINCT` grouped query over shredded `VARIANT` storage. Compressed materialization attempted to merge `VARIANT` statistics with statistics for a `BLOB` comparator key. The fix adds a small defensive check requiring each statistics object’s logical type to match its column reference before the optimizer merges or uses those statistics for compression. If they do not match, that optional compression is skipped.
