### PR TITLE
re-enable art prefix test

### DIFF
--- a/test/sql/index/art/nodes/test_art_prefix_transform_deprecated_create.test
+++ b/test/sql/index/art/nodes/test_art_prefix_transform_deprecated_create.test
@@ -2,9 +2,6 @@
 # description: Test transforming a prefix to v1.0.0 storage with CHECKPOINT after CREATE INDEX
 # group: [nodes]
 
-# FIXME: sporadically breaks
-mode skip instable
-
 statement ok
 SET checkpoint_threshold = '10.0 GB';
 


### PR DESCRIPTION
I think this flaky test was fixed, possibly by https://github.com/duckdb/duckdb/pull/23103.

It seemed to be triggering a use after free crash in the row group append path. I could reliably reproduce it on commits around the time it was reported as failing on CI, and not on recent main. 

However, if it fails again please just mark it as skipped and let me know so I can take another look at it. 