### PR TITLE
Add a bound aggregate capability to fall back to naive window aggregation when row-dependent histogram bins make partial states unsafe to combine

### DIFF
--- a/extension/core_functions/aggregate/nested/binned_histogram.cpp
+++ b/extension/core_functions/aggregate/nested/binned_histogram.cpp
@@ -391,6 +391,7 @@ unique_ptr<FunctionData> HistogramBinBindFunction(BindAggregateFunctionInput &in
 	}
 
 	function.ReplaceImplementation(GetHistogramBinFunction<HIST>(arguments[0]->GetReturnType()));
+	function.SetWindowStateCombineSafe(!arguments[1]->HasParameter() && arguments[1]->IsFoldable());
 	return nullptr;
 }
 

--- a/src/function/aggregate_function.cpp
+++ b/src/function/aggregate_function.cpp
@@ -52,7 +52,8 @@ void AggregateFinalizeInputData::InitializeLocalState() {
 
 bool AggregateFunctionProperties::operator==(const AggregateFunctionProperties &rhs) const {
 	return FunctionProperties::operator==(rhs) && order_dependent == rhs.order_dependent &&
-	       distinct_dependent == rhs.distinct_dependent && single_value_identity == rhs.single_value_identity;
+	       distinct_dependent == rhs.distinct_dependent && single_value_identity == rhs.single_value_identity &&
+	       window_state_combine_safe == rhs.window_state_combine_safe;
 }
 bool AggregateFunctionProperties::operator!=(const AggregateFunctionProperties &rhs) const {
 	return !(*this == rhs);

--- a/src/function/window/window_aggregate_function.cpp
+++ b/src/function/window/window_aggregate_function.cpp
@@ -57,7 +57,8 @@ WindowAggregateExecutor::WindowAggregateExecutor(BoundWindowExpression &wexpr, C
     : WindowExecutor(SimplifyWindowedAggregate(wexpr, client), shared),
       mode(Settings::Get<DebugWindowModeSetting>(client)) {
 	// Force naive for SEPARATE mode or for (currently!) unsupported functionality
-	if (!Settings::Get<EnableOptimizerSetting>(client) || mode == WindowAggregationMode::SEPARATE) {
+	if (!Settings::Get<EnableOptimizerSetting>(client) || mode == WindowAggregationMode::SEPARATE ||
+	    !wexpr.AggregateFunction()->IsWindowStateCombineSafe()) {
 		if (!WindowNaiveAggregator::CanAggregate(wexpr)) {
 			throw InvalidInputException("Cannot use non-aggregate window function with naive window executor!");
 		}

--- a/src/include/duckdb/function/aggregate_function.hpp
+++ b/src/include/duckdb/function/aggregate_function.hpp
@@ -336,6 +336,8 @@ public:
 
 	//! Whether a single input row finalizes to that input's first argument unchanged
 	bool single_value_identity = false;
+	//! Whether arbitrary partial states can be combined during window aggregation
+	bool window_state_combine_safe = true;
 
 	bool operator==(const AggregateFunctionProperties &rhs) const;
 	bool operator!=(const AggregateFunctionProperties &rhs) const;
@@ -382,6 +384,8 @@ public: // Properties
 	//! Whether a single input row finalizes to that input's first argument unchanged
 	auto HasSingleValueIdentity() const -> bool { return properties.single_value_identity; }
 	auto SetSingleValueIdentity(bool value) -> void { properties.single_value_identity = value; }
+	auto IsWindowStateCombineSafe() const -> bool { return properties.window_state_combine_safe; }
+	auto SetWindowStateCombineSafe(bool value) -> void { properties.window_state_combine_safe = value; }
 
 	// Derived properties
 	bool CanAggregate() const { return callbacks.update || callbacks.combine || callbacks.finalize; }

--- a/test/issues/general/test_24451.test
+++ b/test/issues/general/test_24451.test
@@ -1,0 +1,20 @@
+# name: test/issues/general/test_24451.test
+# description: Window histograms with row-dependent bins do not combine states outside their frames
+# group: [general]
+
+query IIIII
+SELECT
+    count(*),
+    sum(window_result[0]),
+    sum(window_result[2147483647]),
+    sum(distinct_result[0]),
+    sum(distinct_result[2147483647])
+FROM (
+    SELECT
+        histogram_exact(0, CASE WHEN i < 16 THEN [0] ELSE [1] END) OVER singleton AS window_result,
+        histogram_exact(DISTINCT 0, CASE WHEN i < 16 THEN [0] ELSE [1] END) OVER singleton AS distinct_result
+    FROM range(17) AS t(i)
+    WINDOW singleton AS (ORDER BY i ROWS BETWEEN CURRENT ROW AND CURRENT ROW)
+) windowed;
+----
+17	16	1	16	1


### PR DESCRIPTION
Fix #24451

### Problem

This issue affected `HISTOGRAM_EXACT(value, bins)` when used as a window aggregate with row-dependent bin lists. Even if every window frame contained only the current row, DuckDB could throw an error saying that histograms with different bin boundaries could not be combined.

The failure came from DuckDB’s optimized window aggregation. The segment-tree executor eagerly builds intermediate aggregate states for groups of rows, including rows that may never appear together in an actual window frame. Histogram states initialize their bin boundaries from the first row they process, and combining two states with different boundaries correctly raises an error. With a segment-tree fanout of 16, the reported 17-row query created one state using `[0]` and another using `[1]`, then attempted to combine them before evaluating the singleton frames. The same underlying problem also affected the separate `DISTINCT` window accelerator.

### Fix

The fix introduces an explicit aggregate capability named `window_state_combine_safe`. It is enabled by default, so existing aggregates retain their current optimized behavior. During histogram binding, the capability is disabled when the bins expression is row-dependent or parameterized. The top-level window executor checks this capability before selecting any optimized aggregator and falls back to the existing naive implementation when arbitrary partial-state combination is unsafe. Constant bin expressions remain eligible for optimized execution.