### PR TITLE
Fix integer underflow in NTILE with argument ordering on future-only frames

### DIFF
--- a/src/function/window/window_rownumber_function.cpp
+++ b/src/function/window/window_rownumber_function.cpp
@@ -288,12 +288,12 @@ void WindowNtileExecutor::GetData(ExecutionContext &context, DataChunk &eval_chu
 			}
 			int64_t n_size = (n_total / n_param);
 			// find the row idx within the group
-			D_ASSERT(row_idx >= begin);
 			idx_t partition_idx = 0;
 			if (grstate.token_tree) {
-				partition_idx = grstate.token_tree->Rank(begin, end, row_idx) - 1;
+				partition_idx = MinValue(grstate.token_tree->Rank(begin, end, row_idx) - 1, idx_t(n_total - 1));
 			} else {
-				partition_idx = row_idx - begin;
+				const auto frame_row_idx = MinValue(MaxValue(begin, row_idx), idx_t(end - 1));
+				partition_idx = frame_row_idx - begin;
 			}
 			auto adjusted_row_idx = NumericCast<int64_t>(partition_idx);
 

--- a/test/sql/window/test_rownumber_orderby.test
+++ b/test/sql/window/test_rownumber_orderby.test
@@ -24,3 +24,25 @@ ORDER BY 2
 9	8	2	1
 6	9	4	2
 3	10	8	3
+
+# Future-only and past-only frames with argument ordering for NTILE and ROW_NUMBER
+query IIII
+SELECT
+  id,
+  NTILE(2 ORDER BY y) OVER (
+    ORDER BY y
+    ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING
+  ) AS ntile_following,
+  NTILE(2 ORDER BY y) OVER (
+    ORDER BY y
+    ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING
+  ) AS ntile_preceding,
+  ROW_NUMBER(ORDER BY y) OVER (
+    ORDER BY y
+    ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING
+  ) AS row_following
+FROM (VALUES (1, 1), (2, 2)) AS t(id, y)
+ORDER BY id;
+----
+1	1	NULL	1
+2	NULL	1	1


### PR DESCRIPTION
Fixes #24831

### The Problem
When evaluating `NTILE` with an argument `ORDER BY` clause over a future-only `ROWS` frame (for example: `ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING`), the current `row_idx < begin`. In `WindowNtileExecutor::GetData`, computing `partition_idx = row_idx - begin` resulted in unsigned integer underflow on `idx_t`, which then threw an internal error during `NumericCast<int64_t>(partition_idx)`.

### The Solution
Clamp the relative row positions to the frame bounds (`[begin, end - 1]`) in `WindowNtileExecutor::GetData` and `WindowRowNumberExecutor::GetData` to prevent underflow when rows precede or follow the frame.

### Adding tests
Added regression tests to `test/sql/window/test_rownumber_orderby.test` covering future-only and past-only `ROWS` frames with argument ordering.