### PR TITLE
Fix Lambda invoke expression property propagation

### DIFF
--- a/src/function/scalar/generic/invoke.cpp
+++ b/src/function/scalar/generic/invoke.cpp
@@ -9,6 +9,15 @@ namespace duckdb {
 
 namespace {
 
+static void PropagateLambdaProperties(BoundScalarFunction &function, const Expression &lambda_expr) {
+	if (lambda_expr.IsVolatile()) {
+		function.SetVolatile();
+	}
+	if (lambda_expr.CanThrow()) {
+		function.SetFallible();
+	}
+}
+
 struct LambdaInvokeData final : public LambdaFunctionData {
 	unique_ptr<Expression> lambda_expr;
 
@@ -36,8 +45,9 @@ struct LambdaInvokeData final : public LambdaFunctionData {
 	static unique_ptr<FunctionData> Deserialize(Deserializer &deserializer, BoundScalarFunction &function) {
 		auto lambda_expr = deserializer.ReadPropertyWithExplicitDefault<unique_ptr<Expression>>(
 		    101, "lambda_expr", unique_ptr<Expression>());
-		if (lambda_expr && lambda_expr->Cast<BoundLambdaExpression>().LambdaExpr()->CanThrow()) {
-			function.SetFallible();
+		if (lambda_expr) {
+			auto &bound_lambda_expr = lambda_expr->Cast<BoundLambdaExpression>();
+			PropagateLambdaProperties(function, *bound_lambda_expr.LambdaExpr());
 		}
 		return make_uniq<LambdaInvokeData>(std::move(lambda_expr));
 	}
@@ -114,9 +124,7 @@ unique_ptr<FunctionData> LambdaInvokeBind(BindScalarFunctionInput &input) {
 	}
 
 	bound_function.SetReturnType(bound_lambda_expr.LambdaExpr()->GetReturnType());
-	if (bound_lambda_expr.LambdaExpr()->CanThrow()) {
-		bound_function.SetFallible();
-	}
+	PropagateLambdaProperties(bound_function, *bound_lambda_expr.LambdaExpr());
 
 	return make_uniq<LambdaInvokeData>(bound_lambda_expr.Copy());
 }

--- a/src/function/scalar/generic/invoke.cpp
+++ b/src/function/scalar/generic/invoke.cpp
@@ -33,9 +33,12 @@ struct LambdaInvokeData final : public LambdaFunctionData {
 	}
 
 	//! Deserializes a lambda function's bind data
-	static unique_ptr<FunctionData> Deserialize(Deserializer &deserializer, BoundScalarFunction &) {
+	static unique_ptr<FunctionData> Deserialize(Deserializer &deserializer, BoundScalarFunction &function) {
 		auto lambda_expr = deserializer.ReadPropertyWithExplicitDefault<unique_ptr<Expression>>(
 		    101, "lambda_expr", unique_ptr<Expression>());
+		if (lambda_expr && lambda_expr->Cast<BoundLambdaExpression>().LambdaExpr()->CanThrow()) {
+			function.SetFallible();
+		}
 		return make_uniq<LambdaInvokeData>(std::move(lambda_expr));
 	}
 
@@ -111,6 +114,9 @@ unique_ptr<FunctionData> LambdaInvokeBind(BindScalarFunctionInput &input) {
 	}
 
 	bound_function.SetReturnType(bound_lambda_expr.LambdaExpr()->GetReturnType());
+	if (bound_lambda_expr.LambdaExpr()->CanThrow()) {
+		bound_function.SetFallible();
+	}
 
 	return make_uniq<LambdaInvokeData>(bound_lambda_expr.Copy());
 }

--- a/src/planner/expression/bound_function_expression.cpp
+++ b/src/planner/expression/bound_function_expression.cpp
@@ -9,6 +9,14 @@
 
 namespace duckdb {
 
+static optional_ptr<const Expression> GetLambdaExpression(const BoundFunctionExpression &expr) {
+	if (!expr.Function().HasBindLambdaCallback()) {
+		return nullptr;
+	}
+	D_ASSERT(expr.BindInfo());
+	return expr.BindInfo()->Cast<LambdaFunctionData>().GetLambdaExpression();
+}
+
 BoundFunctionExpression::BoundFunctionExpression(BoundScalarFunction bound_function,
                                                  vector<unique_ptr<Expression>> arguments,
                                                  unique_ptr<FunctionData> bind_info_p, bool is_operator)
@@ -27,32 +35,30 @@ ExpressionType BoundFunctionExpression::GetFunctionExpressionType(const BoundSca
 }
 
 bool BoundFunctionExpression::IsVolatile() const {
-	return function.GetStability() == FunctionStability::VOLATILE ? true : Expression::IsVolatile();
+	auto lambda_expr = GetLambdaExpression(*this);
+	return function.GetStability() == FunctionStability::VOLATILE || (lambda_expr && lambda_expr->IsVolatile()) ||
+	       Expression::IsVolatile();
 }
 
 bool BoundFunctionExpression::IsConsistent() const {
-	return function.GetStability() != FunctionStability::CONSISTENT ? false : Expression::IsConsistent();
+	auto lambda_expr = GetLambdaExpression(*this);
+	return function.GetStability() == FunctionStability::CONSISTENT && (!lambda_expr || lambda_expr->IsConsistent()) &&
+	       Expression::IsConsistent();
 }
 
 bool BoundFunctionExpression::IsFoldable() const {
 	// functions with side effects cannot be folded: they have to be executed once for every row
-	if (function.HasBindLambdaCallback()) {
-		// This is a lambda function
-		D_ASSERT(bind_info);
-		auto &lambda_bind_data = bind_info->Cast<LambdaFunctionData>();
-		auto lambda_expr = lambda_bind_data.GetLambdaExpression();
-		if (lambda_expr && lambda_expr->IsVolatile()) {
-			return false;
-		}
+	auto lambda_expr = GetLambdaExpression(*this);
+	if (lambda_expr && lambda_expr->IsVolatile()) {
+		return false;
 	}
 	return function.GetStability() == FunctionStability::VOLATILE ? false : Expression::IsFoldable();
 }
 
 bool BoundFunctionExpression::CanThrow() const {
-	if (function.GetErrorMode() == FunctionErrors::CAN_THROW_RUNTIME_ERROR) {
-		return true;
-	}
-	return Expression::CanThrow();
+	auto lambda_expr = GetLambdaExpression(*this);
+	return function.GetErrorMode() == FunctionErrors::CAN_THROW_RUNTIME_ERROR ||
+	       (lambda_expr && lambda_expr->CanThrow()) || Expression::CanThrow();
 }
 
 string BoundFunctionExpression::ToString() const {

--- a/test/sql/function/generic/invoke.test
+++ b/test/sql/function/generic/invoke.test
@@ -7,6 +7,27 @@ select invoke(lambda x: x * x, 2) as square_of_x
 ----
 4
 
+# Lambda volatility must be visible to common subexpression elimination.
+statement ok
+CREATE SEQUENCE invoke_cse_seq START 1
+
+query II
+SELECT count(*) FILTER (WHERE a = b), count(*)
+FROM (
+	SELECT
+		invoke(lambda x: nextval('invoke_cse_seq'), i) a,
+		invoke(lambda x: nextval('invoke_cse_seq'), i) b
+	FROM range(10000) tbl(i)
+)
+----
+0	10000
+
+# Throwing lambda bodies must produce the original execution error.
+statement error
+SELECT invoke(lambda x: error('expected'), 1)
+----
+expected
+
 # Multiple bindings using nested invoke
 query I
 select invoke(lambda a: invoke(lambda b: a + b, 4), 3) as sum_ab
@@ -116,6 +137,27 @@ CREATE TABLE invoke_order_tbl AS SELECT 1 a, 2 b, 3 c
 statement ok
 CREATE VIEW invoke_order_view AS SELECT invoke(lambda x, y, z: x * 100 + y * 10 + z, a, b, c) AS result FROM invoke_order_tbl
 
+statement ok
+CREATE TABLE invoke_dictionary_tbl AS
+	SELECT CASE WHEN i % 2 = 0 THEN 'x' ELSE 'y' END s FROM range(10000) tbl(i)
+
+statement ok
+CREATE SEQUENCE invoke_dictionary_seq START 1
+
+statement ok
+CREATE SEQUENCE invoke_stored_volatile_seq START 1
+
+statement ok
+CREATE VIEW invoke_stored_volatile_view AS
+	SELECT
+		invoke(lambda x: nextval('invoke_stored_volatile_seq'), i) a,
+		invoke(lambda x: nextval('invoke_stored_volatile_seq'), i) b
+	FROM range(1000) tbl(i)
+
+statement ok
+CREATE TABLE invoke_throw_dictionary_tbl AS
+	SELECT CASE WHEN i % 2 = 0 THEN '1' ELSE 'bad' END s FROM range(10000) tbl(i)
+
 query I
 SELECT result FROM invoke_order_view
 ----
@@ -127,6 +169,24 @@ query I
 SELECT result FROM invoke_order_view
 ----
 123
+
+# Volatility in deserialized lambda bind data must remain visible to the optimizer.
+query II
+SELECT count(*) FILTER (WHERE a = b), count(*) FROM invoke_stored_volatile_view
+----
+0	1000
+
+# Volatile lambda bodies must execute once per row, not once per dictionary entry.
+query I
+SELECT count(DISTINCT invoke(lambda x: nextval('invoke_dictionary_seq'), s)) FROM invoke_dictionary_tbl
+----
+10000
+
+# Dictionary evaluation must not evaluate throwing bodies for filtered-out values.
+query I
+SELECT sum(invoke(lambda x: x::INTEGER, s)) FROM invoke_throw_dictionary_tbl WHERE s = '1'
+----
+5000
 
 # Errors
 statement error

--- a/test/sql/function/generic/invoke.test
+++ b/test/sql/function/generic/invoke.test
@@ -22,11 +22,29 @@ FROM (
 ----
 0	10000
 
+# Volatile lambda bodies must not be constant-folded when all invoke arguments are constant.
+statement ok
+CREATE SEQUENCE invoke_constant_seq START 1
+
+query I
+SELECT count(DISTINCT invoke(lambda x: nextval('invoke_constant_seq'), 1)) FROM range(10000)
+----
+10000
+
 # Throwing lambda bodies must produce the original execution error.
 statement error
 SELECT invoke(lambda x: error('expected'), 1)
 ----
 expected
+
+# CONSISTENT_WITHIN_QUERY lambda bodies must remain inconsistent for persistent expressions.
+statement ok
+CREATE TABLE invoke_consistency_tbl(i INTEGER)
+
+statement error
+CREATE INDEX invoke_consistency_idx ON invoke_consistency_tbl (invoke(lambda x: current_schema(), i))
+----
+Index keys cannot contain expressions with side effects
 
 # Multiple bindings using nested invoke
 query I
@@ -155,6 +173,17 @@ CREATE VIEW invoke_stored_volatile_view AS
 	FROM range(1000) tbl(i)
 
 statement ok
+CREATE SEQUENCE invoke_stored_constant_seq START 1
+
+statement ok
+CREATE VIEW invoke_stored_constant_view AS
+	SELECT invoke(lambda x: nextval('invoke_stored_constant_seq'), 1) v FROM range(10000)
+
+statement ok
+CREATE VIEW invoke_stored_error_view AS
+	SELECT invoke(lambda x: error('stored expected'), 1) v
+
+statement ok
 CREATE TABLE invoke_throw_dictionary_tbl AS
 	SELECT CASE WHEN i % 2 = 0 THEN '1' ELSE 'bad' END s FROM range(10000) tbl(i)
 
@@ -175,6 +204,18 @@ query II
 SELECT count(*) FILTER (WHERE a = b), count(*) FROM invoke_stored_volatile_view
 ----
 0	1000
+
+# Deserialized volatile lambda bodies must also bypass constant-vector execution.
+query I
+SELECT count(DISTINCT v) FROM invoke_stored_constant_view
+----
+10000
+
+# Deserialization must restore fallibility on the bound function metadata.
+statement error
+SELECT * FROM invoke_stored_error_view
+----
+<REGEX>:Invalid Input Error.*stored expected.*
 
 # Volatile lambda bodies must execute once per row, not once per dictionary entry.
 query I


### PR DESCRIPTION
`invoke` stores its bound lambda body in `LambdaFunctionData`, outside the function expression's ordinary children. As a result, volatility, consistency, and fallibility inside the lambda were invisible to several planner and execution paths.

This could cause volatile lambdas to be common-subexpression eliminated. With all-constant arguments, the scalar executor could also evaluate a volatile lambda only once per vector instead of once per row.

This PR propagates `IsVolatile`, `IsConsistent`, and `CanThrow` from Lambda bind data through `BoundFunctionExpression`.