### PR TITLE
Prune row group for string contains on equal strings

### DIFF
--- a/src/function/scalar/string/contains.cpp
+++ b/src/function/scalar/string/contains.cpp
@@ -140,11 +140,29 @@ static FilterPropagateResult ContainsFilterPrune(const FunctionStatisticsPruneIn
 		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
 	}
 	auto &needle = StringValue::Get(needle_value);
+
+	// if the max string length is less than the needle size, we can prune the filter.
 	if (StringStats::HasMaxStringLength(*haystack_stats) &&
 	    StringStats::MaxStringLength(*haystack_stats) < needle.size()) {
 		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
 	}
-	return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+
+	if (StringStats::GetMinType(*haystack_stats) != StringStatsType::EXACT_STATS ||
+	    StringStats::GetMaxType(*haystack_stats) != StringStatsType::EXACT_STATS) {
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+
+	const auto min = StringStats::Min(*haystack_stats);
+	const auto max = StringStats::Max(*haystack_stats);
+	if (min != max) {
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+	// If all strings are the same, we can evaluate the predicate directly.
+	if (FindStrInStr(string_t(min), string_t(needle)) == DConstants::INVALID_INDEX) {
+		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
+	}
+	return haystack_stats->CanHaveNull() ? FilterPropagateResult::NO_PRUNING_POSSIBLE
+	                                     : FilterPropagateResult::FILTER_ALWAYS_TRUE;
 }
 
 ScalarFunction GetStringContains() {

--- a/test/sql/optimizer/contains_row_group_pruning.test
+++ b/test/sql/optimizer/contains_row_group_pruning.test
@@ -1,0 +1,70 @@
+# name: test/sql/optimizer/contains_row_group_pruning.test
+# description: Row-group pruning through contains when all values in a row group are identical
+# group: [optimizer]
+
+statement ok
+ATTACH '{TEST_DIR}/contains_prune.duckdb' AS db (ROW_GROUP_SIZE 2048);
+
+statement ok
+USE db;
+
+# 3 row groups: varying 'apple_N' values, a constant 'duckdb' group, and varying 'zebra_N' values
+statement ok
+CREATE TABLE t AS
+    SELECT CASE
+        WHEN range < 2048 THEN 'apple_' || range::VARCHAR
+        WHEN range < 4096 THEN 'duckdb'
+        ELSE 'zebra_' || range::VARCHAR END AS s
+    FROM range(6144);
+
+query I
+SELECT count(*) FROM t WHERE contains(s, 'python');
+----
+0
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM t WHERE contains(s, 'python');
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 2 / 3.*
+
+# needle found in the constant value: the filter is always true for that row group
+query I
+SELECT count(*) FROM t WHERE contains(s, 'ckd');
+----
+2048
+
+# empty needle is always true
+query I
+SELECT count(*) FROM t WHERE contains(s, '');
+----
+6144
+
+# NULLs in a constant row group must not be turned into matches by the always-true path
+statement ok
+CREATE TABLE with_nulls AS
+    SELECT CASE WHEN range % 4 = 0 THEN NULL ELSE 'duckdb' END AS s
+    FROM range(6144);
+
+query I
+SELECT count(*) FROM with_nulls WHERE contains(s, 'ckd');
+----
+4608
+
+query I
+SELECT count(*) FROM with_nulls WHERE contains(s, 'python');
+----
+0
+
+# strings longer than the stats prefix are not exact: no pruning, but results stay correct
+statement ok
+CREATE TABLE long_strings AS SELECT 'duckduckgo_search' AS s FROM range(6144);
+
+query I
+SELECT count(*) FROM long_strings WHERE contains(s, 'go_search');
+----
+6144
+
+query I
+SELECT count(*) FROM long_strings WHERE contains(s, 'python');
+----
+0


### PR DESCRIPTION
Hi team, in the current string `contains` implementation, we only prune row groups based on max haystack length and needle length; another useful pruning scenario is where all strings are equal, so we could directly check the value and needle.