### PR TITLE
docs: fix typo in StringUtil::BytesToHumanReadableString comment

### DIFF
--- a/src/include/duckdb/common/string_util.hpp
+++ b/src/include/duckdb/common/string_util.hpp
@@ -196,7 +196,7 @@ public:
 		return result;
 	}
 
-	//! Return a string that formats the give number of bytes
+	//! Return a string that formats the given number of bytes
 	DUCKDB_API static string BytesToHumanReadableString(idx_t bytes, idx_t multiplier = 1024);
 
 	DUCKDB_API static string TryParseFormattedBytes(const string &arg, idx_t &result);


### PR DESCRIPTION
## Description
Fixes a small typo in `duckdb/common/string_util.hpp`:
```diff
-	//! Return a string that formats the give number of bytes
+	//! Return a string that formats the given number of bytes
 	DUCKDB_API static string BytesToHumanReadableString(idx_t bytes, idx_t multiplier = 1024);
```