### PR TITLE
Fix PRAGMA enable_progress_bar and enable_progress_bar_print NULL han…

### DIFF
--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -905,6 +905,12 @@ Value EnableProfilingSetting::GetSetting(const ClientContext &context) {
 // Enable Progress Bar Print
 //===----------------------------------------------------------------------===//
 void EnableProgressBarPrintSetting::SetLocal(ClientContext &context, const Value &input) {
+	if (input.IsNull()) {
+		throw InvalidInputException("enable_progress_bar_print setting cannot be NULL");
+	}
+	if (input.type().id() != LogicalTypeId::BOOLEAN) {
+		throw InvalidInputException("enable_progress_bar_print setting must be a boolean value");
+	}
 	auto &config = ClientConfig::GetConfig(context);
 	ProgressBar::SystemOverrideCheck(config);
 	config.print_progress_bar = input.GetValue<bool>();
@@ -924,6 +930,12 @@ Value EnableProgressBarPrintSetting::GetSetting(const ClientContext &context) {
 // Enable Progress Bar
 //===----------------------------------------------------------------------===//
 bool EnableProgressBarSetting::OnLocalSet(ClientContext &context, const Value &input) {
+	if (input.IsNull()) {
+		throw InvalidInputException("enable_progress_bar setting cannot be NULL");
+	}
+	if (input.type().id() != LogicalTypeId::BOOLEAN) {
+		throw InvalidInputException("enable_progress_bar setting must be a boolean value");
+	}
 	auto &config = ClientConfig::GetConfig(context);
 	ProgressBar::SystemOverrideCheck(config);
 	return true;

--- a/test/sql/settings/test_progress_bar_null.test
+++ b/test/sql/settings/test_progress_bar_null.test
@@ -1,0 +1,39 @@
+# name: test/sql/settings/test_progress_bar_null.test
+# description: Test PRAGMA enable_progress_bar and enable_progress_bar_print with NULL and invalid values
+# group: [settings]
+
+# Test NULL value for enable_progress_bar
+statement error
+PRAGMA enable_progress_bar=null;
+----
+Invalid Input Error: enable_progress_bar setting cannot be NULL
+
+# Test NULL value for enable_progress_bar_print
+statement error
+PRAGMA enable_progress_bar_print=null;
+----
+Invalid Input Error: enable_progress_bar_print setting cannot be NULL
+
+# Test valid boolean values still work
+statement ok
+PRAGMA enable_progress_bar=true;
+
+statement ok
+PRAGMA enable_progress_bar=false;
+
+statement ok
+PRAGMA enable_progress_bar_print=true;
+
+statement ok
+PRAGMA enable_progress_bar_print=false;
+
+# Test invalid string value (cast error)
+statement error
+PRAGMA enable_progress_bar='invalid';
+----
+Invalid Input Error: Failed to cast value
+
+statement error
+PRAGMA enable_progress_bar_print='invalid';
+----
+Invalid Input Error: Failed to cast value


### PR DESCRIPTION
…dling

Add validation to reject NULL values for enable_progress_bar and enable_progress_bar_print settings. Previously, passing NULL would cause an INTERNAL Error due to calling GetValue<bool>() on a NULL value.

Also add type validation to ensure the value is a boolean.

Fixes #18448.