### PR TITLE
Abandon() and any_abandoned

### DIFF
--- a/src/execution/radix_partitioned_hashtable.cpp
+++ b/src/execution/radix_partitioned_hashtable.cpp
@@ -833,8 +833,8 @@ void RadixPartitionedHashTable::Sink(ExecutionContext &context, DataChunk &chunk
 		// 'Reset' the HT without taking its data, we can just keep appending to the same collection
 		// This only works because we never resize the HT
 		// We don't do this when running with 1 or 2 threads, it only makes sense when there's many threads
-		ht.Abandon();
 		gstate.any_abandoned = true;
+		ht.Abandon();
 	}
 
 	// Check if we need to repartition
@@ -860,8 +860,8 @@ void RadixPartitionedHashTable::Sink(ExecutionContext &context, DataChunk &chunk
 			gstate.config.SetRadixBitsToExternal();
 			ht.SetRadixBits(gstate.config.GetRadixBits());
 		}
-		ht.Abandon();
 		gstate.any_abandoned = true;
+		ht.Abandon();
 		if (!lstate.abandoned_data) {
 			lstate.abandoned_data = make_uniq<RadixPartitionedTupleData>(
 			    BufferManager::GetBufferManager(context.client), gstate.radix_ht.GetLayoutPtr(), MemoryTag::HASH_TABLE,

--- a/src/execution/radix_partitioned_hashtable.cpp
+++ b/src/execution/radix_partitioned_hashtable.cpp
@@ -565,6 +565,7 @@ void DecideAdaptation(RadixHTGlobalSinkState &gstate, RadixHTLocalSinkState &lst
 		const auto new_capacity = MinValue(GroupedAggregateHashTable::GetCapacityForCount(hll_count),
 		                                   RadixHTLocalSinkState::ADAPTIVITY_THRESHOLD);
 		lstate.local_sink_capacity = MaxValue(gstate.config.sink_capacity, new_capacity);
+		gstate.any_abandoned = true;
 		ht.Abandon();
 		ht.Resize(lstate.local_sink_capacity);
 	}
@@ -843,6 +844,7 @@ void RadixPartitionedHashTable::Sink(ExecutionContext &context, DataChunk &chunk
 
 	if (repartitioned && ht.Count() != 0) {
 		// We repartitioned, but we didn't clear the pointer table / reset the count because we're on 1 or 2 threads
+		gstate.any_abandoned = true;
 		ht.Abandon();
 		if (gstate.external) {
 			ht.Resize(lstate.local_sink_capacity);


### PR DESCRIPTION
Fix two issues with current coupling between `ht.Abandon()` and setting `gstate.any_abandoned = true`: it must happen in all call site for which `any_abandoned` might still be consulted, and correct ordering that prevent races is set first, work later.

Fixes a bug introduced in https://github.com/duckdb/duckdb/pull/22211.
Found by stress testing own private test suite, in this case via `HASH_ZERO=1` configuration where:
```sql
CREATE TABLE a AS SELECT i AS x, (i*7)%997
AS y FROM range (3000) t(i);
CREATE TABLE b AS SELECT i AS x, (i*11)%997 AS y FROM range(3000) t(i);
SELECT sum( (SELECT count (*) FROM b WHERE b.x > a.x AND b.y < a.y)) FROM a;
```
would fail like:
```
Invalid Input Error: More than one row returned by a subquery used as an expression - scalar subqueries can only return a single row
```
instead of returning the correct `2200518`.

To be considered a `gstate.Abandon(ht)` that could package both `any_abandoned = true; ht.Abandon();` in an utility function.