### PR TITLE
Fix async writer flaky test

### DIFF
--- a/test/common/test_async_file_writer.cpp
+++ b/test/common/test_async_file_writer.cpp
@@ -1592,12 +1592,9 @@ TEST_CASE("AsyncFileWriter rethrows asynchronous write errors on close", "[async
 	fs.fail_writes = true;
 
 	AsyncFileWriter writer(*con->context, fs, path);
-	{
+	try {
 		auto batch_guard = writer.StartBatch();
 		writer.WriteData(make_uniq<StringAsyncWriteBuffer>("abcd"));
-		batch_guard.Finish();
-	}
-	try {
 		writer.Close();
 		FAIL("Expected async write failure");
 	} catch (const Exception &ex) {


### PR DESCRIPTION
Hi team, I found the unit test failed in my own fork, which is completely unrelated to my code change: https://github.com/dentiny/duckdb/actions/runs/32606272066/job/97117604076?pr=167

```sh
  > 1584  TEST_CASE("AsyncFileWriter rethrows asynchronous write errors on close", "[async_file_writer]") {
    1585      DuckDB db(nullptr);
    1586      auto con = CreateConnectionWithAsyncThreads(db);
    1587      TrackingWriteFileSystem fs;

FAILED: {Unknown expression after the reported line}
```
The reason is, `BatchGuard::Finish` internally applies backpressure and schedules write; based on our failure mode config, write could fail and exception thrown before we enter into the try-catch block.