### PR TITLE
Prune row group for prefix functions

### DIFF
--- a/extension/core_functions/scalar/string/starts_with.cpp
+++ b/extension/core_functions/scalar/string/starts_with.cpp
@@ -2,6 +2,7 @@
 
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
+#include "duckdb/function/scalar/string_common.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 
 namespace duckdb {
@@ -39,6 +40,7 @@ ScalarFunction StartsWithOperatorFun::GetFunction() {
 	ScalarFunction starts_with({LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::BOOLEAN,
 	                           ScalarFunction::BinaryFunction<string_t, string_t, bool, StartsWithOperator>);
 	starts_with.SetCollationHandling(FunctionCollationHandling::PUSH_COMBINABLE_COLLATIONS);
+	starts_with.SetFilterPruneCallback(PrefixFilterPrune);
 	return starts_with;
 }
 

--- a/src/function/scalar/string/CMakeLists.txt
+++ b/src/function/scalar/string/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library_unity(
   sha1.cpp
   sha256.cpp
   strip_accents.cpp
+  string_common.cpp
   string_split.cpp
   string_slice.cpp
   suffix.cpp

--- a/src/function/scalar/string/prefix.cpp
+++ b/src/function/scalar/string/prefix.cpp
@@ -135,6 +135,14 @@ FilterPropagateResult PrefixFilterPrune(const FunctionStatisticsPruneInput &inpu
 			return FilterPropagateResult::FILTER_ALWAYS_FALSE;
 		}
 	}
+	// Cases where min and max both start with the prefix.
+	if (min.size() >= prefix.size() && max.size() >= prefix.size() &&
+	    memcmp(min.c_str(), prefix.c_str(), prefix.size()) == 0 &&
+	    memcmp(max.c_str(), prefix.c_str(), prefix.size()) == 0) {
+		// NULL values produce NULL rather than true, so they prevent an always-true result
+		return column_stats->CanHaveNull() ? FilterPropagateResult::NO_PRUNING_POSSIBLE
+		                                   : FilterPropagateResult::FILTER_ALWAYS_TRUE;
+	}
 	return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 }
 

--- a/src/function/scalar/string/prefix.cpp
+++ b/src/function/scalar/string/prefix.cpp
@@ -1,11 +1,7 @@
 #include "duckdb/function/scalar/string_functions.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/types/string_type.hpp"
-#include "duckdb/common/types/value.hpp"
-#include "duckdb/planner/expression/bound_constant_expression.hpp"
-#include "duckdb/planner/expression/bound_function_expression.hpp"
-#include "duckdb/storage/statistics/base_statistics.hpp"
-#include "duckdb/storage/statistics/string_stats.hpp"
+#include "duckdb/function/scalar/string_common.hpp"
 
 namespace duckdb {
 
@@ -62,89 +58,6 @@ struct PrefixOperator {
 		return PrefixFunction(left, right);
 	}
 };
-
-// Update the prefix to be the next string of the given one, which is with less or equal length to the given prefix
-bool FindNextPrefix(string &prefix) {
-	for (idx_t idx = prefix.size(); idx > 0; idx--) {
-		auto c = static_cast<uint8_t>(prefix[idx - 1]);
-		if (c == 0xFF) {
-			continue;
-		}
-		prefix[idx - 1] = static_cast<char>(c + 1);
-		prefix.resize(idx);
-		return true;
-	}
-	return false;
-}
-
-FilterPropagateResult PrefixFilterPrune(const FunctionStatisticsPruneInput &input) {
-	auto &children = input.function.GetChildren();
-
-	// First check whether it's possible to prune completely.
-	if (children.size() != 2 || children[1]->GetExpressionType() != ExpressionType::VALUE_CONSTANT) {
-		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
-	}
-
-	auto column_stats = input.ChildStats(0);
-	if (!column_stats || column_stats->GetStatsType() != StatisticsType::STRING_STATS) {
-		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
-	}
-	// If all rows are null, always false
-	if (!column_stats->CanHaveNoNull()) {
-		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
-	}
-	// If the constant is null, always false
-	auto &constant = children[1]->Cast<BoundConstantExpression>().GetValue();
-	if (constant.IsNull()) {
-		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
-	}
-	// Handle empty prefix
-	auto prefix = StringValue::Get(constant);
-	if (prefix.empty()) {
-		return column_stats->CanHaveNull() ? FilterPropagateResult::NO_PRUNING_POSSIBLE
-		                                   : FilterPropagateResult::FILTER_ALWAYS_TRUE;
-	}
-
-	// Then check row group pruning with string stats min/max.
-	if (StringStats::HasMaxStringLength(*column_stats) && StringStats::MaxStringLength(*column_stats) < prefix.size()) {
-		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
-	}
-	if (!StringStats::HasMinMax(*column_stats)) {
-		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
-	}
-
-	const auto min = StringStats::Min(*column_stats);
-	const auto max = StringStats::Max(*column_stats);
-
-	// prefix > max, always false
-	if (StringStats::CompareStringStats(string_t(prefix.c_str(), prefix.size()), string_t(max.c_str(), max.size()),
-	                                    StringStats::GetMaxType(*column_stats)) > 0) {
-		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
-	}
-
-	// next(prefix) <= min, always false
-	auto upper_bound = prefix;
-	if (FindNextPrefix(upper_bound)) {
-		const auto min_compare =
-		    StringStats::CompareStringStats(string_t(upper_bound.c_str(), upper_bound.size()),
-		                                    string_t(min.c_str(), min.size()), StringStats::GetMinType(*column_stats));
-		if (min_compare < 0) {
-			return FilterPropagateResult::FILTER_ALWAYS_FALSE;
-		}
-		if (min_compare == 0 && StringStats::GetMinType(*column_stats) == StringStatsType::EXACT_STATS) {
-			return FilterPropagateResult::FILTER_ALWAYS_FALSE;
-		}
-	}
-	// Cases where min and max both start with the prefix.
-	if (min.size() >= prefix.size() && max.size() >= prefix.size() &&
-	    memcmp(min.c_str(), prefix.c_str(), prefix.size()) == 0 &&
-	    memcmp(max.c_str(), prefix.c_str(), prefix.size()) == 0) {
-		// NULL values produce NULL rather than true, so they prevent an always-true result
-		return column_stats->CanHaveNull() ? FilterPropagateResult::NO_PRUNING_POSSIBLE
-		                                   : FilterPropagateResult::FILTER_ALWAYS_TRUE;
-	}
-	return FilterPropagateResult::NO_PRUNING_POSSIBLE;
-}
 
 } // namespace
 

--- a/src/function/scalar/string/string_common.cpp
+++ b/src/function/scalar/string/string_common.cpp
@@ -3,6 +3,7 @@
 #include "duckdb/common/types/string_type.hpp"
 #include "duckdb/common/types/value.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/storage/statistics/base_statistics.hpp"
 #include "duckdb/storage/statistics/string_stats.hpp"
 

--- a/src/function/scalar/string/string_common.cpp
+++ b/src/function/scalar/string/string_common.cpp
@@ -1,0 +1,98 @@
+#include "duckdb/function/scalar/string_common.hpp"
+
+#include "duckdb/common/types/string_type.hpp"
+#include "duckdb/common/types/value.hpp"
+#include "duckdb/planner/expression/bound_constant_expression.hpp"
+#include "duckdb/storage/statistics/base_statistics.hpp"
+#include "duckdb/storage/statistics/string_stats.hpp"
+
+namespace duckdb {
+
+namespace {
+
+// Update the prefix to be the next string of the given one, which is with less or equal length to the given prefix
+bool FindNextPrefix(string &prefix) {
+	for (idx_t idx = prefix.size(); idx > 0; idx--) {
+		auto c = static_cast<uint8_t>(prefix[idx - 1]);
+		if (c == 0xFF) {
+			continue;
+		}
+		prefix[idx - 1] = static_cast<char>(c + 1);
+		prefix.resize(idx);
+		return true;
+	}
+	return false;
+}
+
+} // namespace
+
+FilterPropagateResult PrefixFilterPrune(const FunctionStatisticsPruneInput &input) {
+	auto &children = input.function.GetChildren();
+
+	// First check whether it's possible to prune completely.
+	if (children.size() != 2 || children[1]->GetExpressionType() != ExpressionType::VALUE_CONSTANT) {
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+
+	auto column_stats = input.ChildStats(0);
+	if (!column_stats || column_stats->GetStatsType() != StatisticsType::STRING_STATS) {
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+	// If all rows are null, always false
+	if (!column_stats->CanHaveNoNull()) {
+		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
+	}
+	// If the constant is null, always false
+	auto &constant = children[1]->Cast<BoundConstantExpression>().GetValue();
+	if (constant.IsNull()) {
+		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
+	}
+	// Handle empty prefix
+	auto prefix = StringValue::Get(constant);
+	if (prefix.empty()) {
+		return column_stats->CanHaveNull() ? FilterPropagateResult::NO_PRUNING_POSSIBLE
+		                                   : FilterPropagateResult::FILTER_ALWAYS_TRUE;
+	}
+
+	// Then check row group pruning with string stats min/max.
+	if (StringStats::HasMaxStringLength(*column_stats) && StringStats::MaxStringLength(*column_stats) < prefix.size()) {
+		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
+	}
+	if (!StringStats::HasMinMax(*column_stats)) {
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+
+	const auto min = StringStats::Min(*column_stats);
+	const auto max = StringStats::Max(*column_stats);
+
+	// prefix > max, always false
+	if (StringStats::CompareStringStats(string_t(prefix.c_str(), prefix.size()), string_t(max.c_str(), max.size()),
+	                                    StringStats::GetMaxType(*column_stats)) > 0) {
+		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
+	}
+
+	// next(prefix) <= min, always false
+	auto upper_bound = prefix;
+	if (FindNextPrefix(upper_bound)) {
+		const auto min_compare =
+		    StringStats::CompareStringStats(string_t(upper_bound.c_str(), upper_bound.size()),
+		                                    string_t(min.c_str(), min.size()), StringStats::GetMinType(*column_stats));
+		if (min_compare < 0) {
+			return FilterPropagateResult::FILTER_ALWAYS_FALSE;
+		}
+		if (min_compare == 0 && StringStats::GetMinType(*column_stats) == StringStatsType::EXACT_STATS) {
+			return FilterPropagateResult::FILTER_ALWAYS_FALSE;
+		}
+	}
+	// Cases where min and max both start with the prefix.
+	if (min.size() >= prefix.size() && max.size() >= prefix.size() &&
+	    memcmp(min.c_str(), prefix.c_str(), prefix.size()) == 0 &&
+	    memcmp(max.c_str(), prefix.c_str(), prefix.size()) == 0) {
+		// NULL values produce NULL rather than true, so they prevent an always-true result
+		return column_stats->CanHaveNull() ? FilterPropagateResult::NO_PRUNING_POSSIBLE
+		                                   : FilterPropagateResult::FILTER_ALWAYS_TRUE;
+	}
+	return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+}
+
+} // namespace duckdb

--- a/src/include/duckdb/function/scalar/string_common.hpp
+++ b/src/include/duckdb/function/scalar/string_common.hpp
@@ -18,7 +18,7 @@ string_t SubstringGrapheme(Vector &result, string_t input, int64_t offset, int64
 bool SubstringInSupportedRange(int64_t offset, int64_t length);
 unique_ptr<BaseStatistics> PropagateStringSliceStats(FunctionStatisticsInput &input, idx_t start_character_index,
                                                      optional_idx character_count);
-//! Zonemap pruning for `prefix(s, constant)`, shared with starts_with / ^@
+//! Common util zonemap pruning for `prefix(s, constant)`.
 FilterPropagateResult PrefixFilterPrune(const FunctionStatisticsPruneInput &input);
 
 ScalarFunction GetStringContains();

--- a/src/include/duckdb/function/scalar/string_common.hpp
+++ b/src/include/duckdb/function/scalar/string_common.hpp
@@ -18,6 +18,8 @@ string_t SubstringGrapheme(Vector &result, string_t input, int64_t offset, int64
 bool SubstringInSupportedRange(int64_t offset, int64_t length);
 unique_ptr<BaseStatistics> PropagateStringSliceStats(FunctionStatisticsInput &input, idx_t start_character_index,
                                                      optional_idx character_count);
+//! Zonemap pruning for `prefix(s, constant)`, shared with starts_with / ^@
+FilterPropagateResult PrefixFilterPrune(const FunctionStatisticsPruneInput &input);
 
 ScalarFunction GetStringContains();
 DUCKDB_API bool Glob(const char *s, idx_t slen, const char *pattern, idx_t plen, bool allow_question_mark = true);

--- a/test/sql/copy/parquet/parquet_expression_filter_pruning.test
+++ b/test/sql/copy/parquet/parquet_expression_filter_pruning.test
@@ -271,10 +271,11 @@ WHERE prefix(s, p) OR prefix(s, 'd')
 ----
 analyzed_plan	<REGEX>:(?s).*Row Groups Scanned: 4 / 4.*
 
-# Byte-wise prefix successor should prune across a UTF-8 byte boundary
+# Byte-wise prefix successor should prune across a UTF-8 byte boundary. The first
+# row group mixes chr(254) and chr(255) so it stays inconclusive and is scanned.
 statement ok
 COPY (
-	SELECT CASE WHEN range < 2048 THEN chr(255) || 'a' ELSE chr(256) || 'a' END AS s
+	SELECT CASE WHEN range < 2048 THEN chr((254 + range % 2)::INT) || 'a' ELSE chr(256) || 'a' END AS s
 	FROM range(4096)
 ) TO '{TEST_DIR}/expr_prune_prefix_utf8_boundary.parquet' (FORMAT PARQUET, ROW_GROUP_SIZE 2048)
 
@@ -283,7 +284,7 @@ SELECT count(*)
 FROM '{TEST_DIR}/expr_prune_prefix_utf8_boundary.parquet'
 WHERE prefix(s, chr(255)) OR prefix(s, 'zz')
 ----
-2048
+1024
 
 query II
 EXPLAIN ANALYZE SELECT count(*)
@@ -291,6 +292,20 @@ FROM '{TEST_DIR}/expr_prune_prefix_utf8_boundary.parquet'
 WHERE prefix(s, chr(255)) OR prefix(s, 'zz')
 ----
 analyzed_plan	<REGEX>:(?s).*Row Groups Scanned: 1 / 2.*
+
+# When min and max of a row group both start with the prefix, the filter is proven true for the whole row group: the count is answered from row group metadata without any scan.
+statement ok
+COPY (
+	SELECT CASE WHEN range < 2048 THEN chr(255) || 'a' ELSE chr(256) || 'a' END AS s
+	FROM range(4096)
+) TO '{TEST_DIR}/expr_prune_prefix_always_true.parquet' (FORMAT PARQUET, ROW_GROUP_SIZE 2048)
+
+query I
+SELECT count(*)
+FROM '{TEST_DIR}/expr_prune_prefix_always_true.parquet'
+WHERE prefix(s, chr(255)) OR prefix(s, 'zz')
+----
+2048
 
 # ILIKE uses conservative ASCII bounds while retaining the original filter
 query I

--- a/test/sql/optimizer/prefix_zonemap_pruning.test
+++ b/test/sql/optimizer/prefix_zonemap_pruning.test
@@ -1,5 +1,5 @@
 # name: test/sql/optimizer/prefix_zonemap_pruning.test
-# description: Prune row groups for NOT prefix()/starts_with() when the zonemap proves a shared prefix
+# description: Prune row groups for prefix scan function when the zonemap proves a shared prefix
 # group: [optimizer]
 
 statement ok

--- a/test/sql/optimizer/prefix_zonemap_pruning.test
+++ b/test/sql/optimizer/prefix_zonemap_pruning.test
@@ -26,36 +26,25 @@ SELECT count(*) FROM prefix_pruning WHERE starts_with(s, '0040');
 ----
 100
 
-# When a row group's min and max both start with the needle, every string in the
-# row group does, so NOT prefix() is provably false and prunes the row group.
+# When the table-level min and max both start with the needle, every string in the table does, fold into empty directly.
 query II
 EXPLAIN ANALYZE SELECT count(*) FROM prefix_pruning WHERE NOT prefix(s, '00');
 ----
-analyzed_plan	<REGEX>:.*Row Groups Scanned: 0 / 3.*
+analyzed_plan	<REGEX>:.*Empty Result.*
 
 query I
 SELECT count(*) FROM prefix_pruning WHERE NOT prefix(s, '00');
 ----
 0
 
-# starts_with() and the ^@ operator share the same pruning callback.
+# starts_with() and the ^@ operator share the same pruning callback as prefix().
 query II
 EXPLAIN ANALYZE SELECT count(*) FROM prefix_pruning WHERE NOT starts_with(s, '00');
 ----
-analyzed_plan	<REGEX>:.*Row Groups Scanned: 0 / 3.*
+analyzed_plan	<REGEX>:.*Empty Result.*
 
 query I
 SELECT count(*) FROM prefix_pruning WHERE NOT starts_with(s, '00');
-----
-0
-
-query II
-EXPLAIN ANALYZE SELECT count(*) FROM prefix_pruning WHERE NOT (s ^@ '00');
-----
-analyzed_plan	<REGEX>:.*Row Groups Scanned: 0 / 3.*
-
-query I
-SELECT count(*) FROM prefix_pruning WHERE NOT (s ^@ '00');
 ----
 0
 
@@ -70,13 +59,42 @@ SELECT count(*) FROM prefix_pruning WHERE NOT starts_with(s, '0040');
 ----
 6044
 
-# String zonemaps store an 8-byte prefix, so a longer needle cannot be proven
-# to be shared by the whole row group.
+# When only some row groups share the prefix, pruning happens per row group:
+# the two '00' row groups are pruned and only the '99' row group is scanned.
+statement ok
+CREATE TABLE prefix_mixed AS
+SELECT i::INTEGER AS i, CASE WHEN i < 4096 THEN '00' ELSE '99' END || lpad(i::VARCHAR, 6, '0') AS s
+FROM range(6144) r(i);
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM prefix_mixed WHERE NOT starts_with(s, '00');
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
+
+query I
+SELECT count(*) FROM prefix_mixed WHERE NOT starts_with(s, '00');
+----
+2048
+
+# String zonemaps store a 12-byte prefix verbatim, so a needle that fits in the
+# stored bytes is provable while a longer needle is not.
 statement ok
 CREATE TABLE prefix_truncated AS
 SELECT i::INTEGER AS i, 'ppppppppppppp' || lpad(i::VARCHAR, 6, '0') AS s
 FROM range(6144) r(i);
 
+# 12-byte needle: fits in the stored prefix bytes.
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM prefix_truncated WHERE NOT starts_with(s, 'pppppppppppp');
+----
+analyzed_plan	<REGEX>:.*Empty Result.*
+
+query I
+SELECT count(*) FROM prefix_truncated WHERE NOT starts_with(s, 'pppppppppppp');
+----
+0
+
+# 13-byte needle: longer than the stored prefix bytes, cannot be proven.
 query II
 EXPLAIN ANALYZE SELECT count(*) FROM prefix_truncated WHERE NOT starts_with(s, 'ppppppppppppp');
 ----
@@ -112,7 +130,7 @@ FROM range(6144) r(i);
 query II
 EXPLAIN ANALYZE SELECT count(*) FROM prefix_utf8 WHERE NOT starts_with(s, '🦆');
 ----
-analyzed_plan	<REGEX>:.*Row Groups Scanned: 0 / 3.*
+analyzed_plan	<REGEX>:.*Empty Result.*
 
 query I
 SELECT count(*) FROM prefix_utf8 WHERE NOT starts_with(s, '🦆');

--- a/test/sql/optimizer/prefix_zonemap_pruning.test
+++ b/test/sql/optimizer/prefix_zonemap_pruning.test
@@ -1,0 +1,120 @@
+# name: test/sql/optimizer/prefix_zonemap_pruning.test
+# description: Prune row groups for NOT prefix()/starts_with() when the zonemap proves a shared prefix
+# group: [optimizer]
+
+statement ok
+ATTACH '{TEST_DIR}/prefix_zonemap_pruning.duckdb' AS db (ROW_GROUP_SIZE 2048);
+
+statement ok
+USE db;
+
+# 6144 rows -> 3 row groups of 2048 rows. Every row starts with '00' and the
+# min/max of every row group share that prefix.
+statement ok
+CREATE TABLE prefix_pruning AS
+SELECT i::INTEGER AS i, lpad(i::VARCHAR, 6, '0') AS s
+FROM range(6144) r(i);
+
+# The positive form is rewritten into a range predicate on the column itself.
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM prefix_pruning WHERE starts_with(s, '0040');
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 2 / 3.*
+
+query I
+SELECT count(*) FROM prefix_pruning WHERE starts_with(s, '0040');
+----
+100
+
+# When a row group's min and max both start with the needle, every string in the
+# row group does, so NOT prefix() is provably false and prunes the row group.
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM prefix_pruning WHERE NOT prefix(s, '00');
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 0 / 3.*
+
+query I
+SELECT count(*) FROM prefix_pruning WHERE NOT prefix(s, '00');
+----
+0
+
+# starts_with() and the ^@ operator share the same pruning callback.
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM prefix_pruning WHERE NOT starts_with(s, '00');
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 0 / 3.*
+
+query I
+SELECT count(*) FROM prefix_pruning WHERE NOT starts_with(s, '00');
+----
+0
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM prefix_pruning WHERE NOT (s ^@ '00');
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 0 / 3.*
+
+query I
+SELECT count(*) FROM prefix_pruning WHERE NOT (s ^@ '00');
+----
+0
+
+# A needle matching only part of each row group cannot prune.
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM prefix_pruning WHERE NOT starts_with(s, '0040');
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 3 / 3.*
+
+query I
+SELECT count(*) FROM prefix_pruning WHERE NOT starts_with(s, '0040');
+----
+6044
+
+# String zonemaps store an 8-byte prefix, so a longer needle cannot be proven
+# to be shared by the whole row group.
+statement ok
+CREATE TABLE prefix_truncated AS
+SELECT i::INTEGER AS i, 'ppppppppppppp' || lpad(i::VARCHAR, 6, '0') AS s
+FROM range(6144) r(i);
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM prefix_truncated WHERE NOT starts_with(s, 'ppppppppppppp');
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 3 / 3.*
+
+query I
+SELECT count(*) FROM prefix_truncated WHERE NOT starts_with(s, 'ppppppppppppp');
+----
+0
+
+# NULL rows produce NULL rather than false, so a nullable column is not pruned.
+statement ok
+CREATE TABLE prefix_nullable AS
+SELECT i::INTEGER AS i, CASE WHEN i % 100 = 50 THEN NULL ELSE lpad(i::VARCHAR, 6, '0') END AS s
+FROM range(6144) r(i);
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM prefix_nullable WHERE NOT starts_with(s, '00');
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 3 / 3.*
+
+query I
+SELECT count(*) FROM prefix_nullable WHERE NOT starts_with(s, '00');
+----
+0
+
+# Multi-byte needles within the stored prefix bytes are provable.
+statement ok
+CREATE TABLE prefix_utf8 AS
+SELECT i::INTEGER AS i, '🦆' || lpad(i::VARCHAR, 6, '0') AS s
+FROM range(6144) r(i);
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM prefix_utf8 WHERE NOT starts_with(s, '🦆');
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 0 / 3.*
+
+query I
+SELECT count(*) FROM prefix_utf8 WHERE NOT starts_with(s, '🦆');
+----
+0


### PR DESCRIPTION
Hi team, I found prefix doesn't always prune row group as expected, for example,
```sql
memory D ATTACH '/tmp/prefix_zonemap_pruning.duckdb' AS db (ROW_GROUP_SIZE 2048);
memory D USE db;
db D CREATE TABLE prefix_pruning AS
     SELECT i::INTEGER AS i, lpad(i::VARCHAR, 6, '0') AS s
     FROM range(6144) r(i);
-- no value starts with '00', so no row group should be scanned.
db D EXPLAIN ANALYZE SELECT count(*) FROM prefix_pruning WHERE NOT prefix(s, '00');
╭─ Summary ───────────╮
│ Total Time: 0.0015s │
╰─────────────────────╯
╭─ Ungrouped Aggregate ─────────╮
│ Aggregates: count_star()      │
│ 1 row                     0µs │
╰───────────────┬───────────────╯
╭─ Table Scan ──┴───────────────╮
│ Table: db.main.prefix_pruning │
│ Type: Sequential Scan         │
│ Filters: NOT prefix(s, '00')  │
│ Row Groups Scanned: 3 / 3     │
│ 0 rows                    0µs │
╰───────────────────────────────╯
```
This PR updates two cased for row group pruning for prefix scan filter:
- Set pruning callback for `starts_with`, previously it's only set to `prefix` function
- When min/max already to starts with prefix, we could return ALWAYS_TRUE directly