### PR TITLE
Propagate case conversion stats for row group prune

### DIFF
--- a/src/function/scalar/string/caseconvert.cpp
+++ b/src/function/scalar/string/caseconvert.cpp
@@ -140,6 +140,26 @@ static unique_ptr<BaseStatistics> CaseConvertPropagateStats(ClientContext &conte
 	}
 	// case conversion is not order- or length-preserving, but it never turns a valid string into NULL
 	auto result = StringStats::CreateUnknown(expr.GetReturnType());
+	// If all values are a single known string, the result is the case-converted string
+	if (StringStats::HasMinMax(child_stats[0]) &&
+	    StringStats::GetMinType(child_stats[0]) == StringStatsType::EXACT_STATS &&
+	    StringStats::GetMaxType(child_stats[0]) == StringStatsType::EXACT_STATS) {
+		auto min = StringStats::Min(child_stats[0]);
+		auto max = StringStats::Max(child_stats[0]);
+		if (min == max) {
+			string converted;
+			converted.resize(GetResultLength<IS_UPPER>(min.c_str(), min.size()));
+			CaseConvert<IS_UPPER>(min.c_str(), min.size(), &converted[0]);
+			// case conversion can lengthen a string beyond what the stats can store
+			auto stats_type = StringStatsType::EXACT_STATS;
+			if (converted.size() > StringStatsData::CURRENT_MAX_STRING_MINMAX_SIZE) {
+				converted.resize(StringStatsData::CURRENT_MAX_STRING_MINMAX_SIZE);
+				stats_type = StringStatsType::TRUNCATED_STATS;
+			}
+			StringStats::SetMin(result, string_t(converted), stats_type);
+			StringStats::SetMax(result, string_t(converted), stats_type);
+		}
+	}
 	result.CopyValidity(child_stats[0]);
 	return result.ToUnique();
 }

--- a/src/function/scalar/string/caseconvert.cpp
+++ b/src/function/scalar/string/caseconvert.cpp
@@ -140,27 +140,40 @@ static unique_ptr<BaseStatistics> CaseConvertPropagateStats(ClientContext &conte
 	}
 	// case conversion is not order- or length-preserving, but it never turns a valid string into NULL
 	auto result = StringStats::CreateUnknown(expr.GetReturnType());
-	// If all values are a single known string, the result is the case-converted string
-	if (StringStats::HasMinMax(child_stats[0]) &&
-	    StringStats::GetMinType(child_stats[0]) == StringStatsType::EXACT_STATS &&
-	    StringStats::GetMaxType(child_stats[0]) == StringStatsType::EXACT_STATS) {
-		auto min = StringStats::Min(child_stats[0]);
-		auto max = StringStats::Max(child_stats[0]);
-		if (min == max) {
-			string converted;
-			converted.resize(GetResultLength<IS_UPPER>(min.c_str(), min.size()));
-			CaseConvert<IS_UPPER>(min.c_str(), min.size(), &converted[0]);
-			// case conversion can lengthen a string beyond what the stats can store
-			auto stats_type = StringStatsType::EXACT_STATS;
-			if (converted.size() > StringStatsData::CURRENT_MAX_STRING_MINMAX_SIZE) {
-				converted.resize(StringStatsData::CURRENT_MAX_STRING_MINMAX_SIZE);
-				stats_type = StringStatsType::TRUNCATED_STATS;
-			}
-			StringStats::SetMin(result, string_t(converted), stats_type);
-			StringStats::SetMax(result, string_t(converted), stats_type);
+	result.CopyValidity(child_stats[0]);
+	if (!StringStats::HasMinMax(child_stats[0])) {
+		return result.ToUnique();
+	}
+	// When min == max, all values share the stored string (exact) or the stored prefix (truncated).
+	// Case conversion is codepoint-local, so the converted string/prefix bounds the result.
+	auto min = StringStats::Min(child_stats[0]);
+	auto max = StringStats::Max(child_stats[0]);
+	if (min != max) {
+		return result.ToUnique();
+	}
+	const bool is_exact = StringStats::GetMinType(child_stats[0]) == StringStatsType::EXACT_STATS &&
+	                      StringStats::GetMaxType(child_stats[0]) == StringStatsType::EXACT_STATS;
+	if (!is_exact) {
+		// truncated stats can end in the middle of a character - only complete ones can be converted
+		size_t invalid_pos = 0;
+		if (Utf8Proc::Analyze(min.c_str(), min.size(), nullptr, &invalid_pos) == UnicodeType::INVALID) {
+			min.resize(invalid_pos);
+		}
+		if (min.empty()) {
+			return result.ToUnique();
 		}
 	}
-	result.CopyValidity(child_stats[0]);
+	string converted;
+	converted.resize(GetResultLength<IS_UPPER>(min.c_str(), min.size()));
+	CaseConvert<IS_UPPER>(min.c_str(), min.size(), &converted[0]);
+	auto stats_type = is_exact ? StringStatsType::EXACT_STATS : StringStatsType::TRUNCATED_STATS;
+	// case conversion can lengthen a string beyond what the stats can store
+	if (converted.size() > StringStatsData::CURRENT_MAX_STRING_MINMAX_SIZE) {
+		converted.resize(StringStatsData::CURRENT_MAX_STRING_MINMAX_SIZE);
+		stats_type = StringStatsType::TRUNCATED_STATS;
+	}
+	StringStats::SetMin(result, string_t(converted), stats_type);
+	StringStats::SetMax(result, string_t(converted), stats_type);
 	return result.ToUnique();
 }
 

--- a/test/sql/optimizer/upper_lower_zonemap_pruning.test
+++ b/test/sql/optimizer/upper_lower_zonemap_pruning.test
@@ -53,6 +53,25 @@ SELECT count(*) FROM case_mixed WHERE upper(s) = 'V004000';
 ----
 1
 
+# Unicode case conversion can lengthen a string beyond the stored zonemap prefix:
+# upper('ɐɐɐɐɐɐ') is the 18-byte 'ⱯⱯⱯⱯⱯⱯ', so the propagated stats must be marked
+# truncated. The 'ɐ' row group stays inconclusive (scanned and matched), while the
+# other row groups are still pruned.
+statement ok
+CREATE TABLE case_lengthening AS
+SELECT i::INTEGER AS i, CASE WHEN i < 2048 THEN 'ɐɐɐɐɐɐ' WHEN i < 4096 THEN 'oooooo' ELSE 'zzzzzz' END AS s
+FROM range(6144) r(i);
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM case_lengthening WHERE upper(s) = 'ⱯⱯⱯⱯⱯⱯ';
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
+
+query I
+SELECT count(*) FROM case_lengthening WHERE upper(s) = 'ⱯⱯⱯⱯⱯⱯ';
+----
+2048
+
 # Strings longer than the stored zonemap prefix only have truncated stats: even identical values cannot be proven equal, so no pruning is possible.
 statement ok
 CREATE TABLE case_truncated AS

--- a/test/sql/optimizer/upper_lower_zonemap_pruning.test
+++ b/test/sql/optimizer/upper_lower_zonemap_pruning.test
@@ -72,7 +72,7 @@ SELECT count(*) FROM case_lengthening WHERE upper(s) = 'ⱯⱯⱯⱯⱯⱯ';
 ----
 2048
 
-# Strings longer than the stored zonemap prefix only have truncated stats: even identical values cannot be proven equal, so no pruning is possible.
+# All row groups share the same truncated 12-byte prefix 'prefixprefix': the constant matches that prefix everywhere, so nothing can be pruned.
 statement ok
 CREATE TABLE case_truncated AS
 SELECT i::INTEGER AS i,
@@ -88,3 +88,51 @@ query I
 SELECT count(*) FROM case_truncated WHERE upper(s) = 'PREFIXPREFIX_BETA';
 ----
 2048
+
+# Truncated stats with min == max mean all values in a row group share the stored 12-byte prefix.
+# Case conversion is codepoint-local, so the converted prefix can be propagated as truncated stats: row groups with a different prefix are pruned.
+statement ok
+CREATE TABLE case_truncated_distinct AS
+SELECT i::INTEGER AS i,
+       CASE WHEN i < 2048 THEN 'aaaaaaaaaaaa' WHEN i < 4096 THEN 'bbbbbbbbbbbb' ELSE 'cccccccccccc' END
+           || lpad(i::VARCHAR, 6, '0') AS s
+FROM range(6144) r(i);
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM case_truncated_distinct WHERE upper(s) = 'BBBBBBBBBBBB002500';
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
+
+query I
+SELECT count(*) FROM case_truncated_distinct WHERE upper(s) = 'BBBBBBBBBBBB002500';
+----
+1
+
+# A constant that matches no prefix prunes every row group.
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM case_truncated_distinct WHERE upper(s) = 'ZZZZ';
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 0 / 3.*
+
+query I
+SELECT count(*) FROM case_truncated_distinct WHERE upper(s) = 'ZZZZ';
+----
+0
+
+# The 12-byte truncation point can split a multi-byte character: byte 12 lands in the middle of the duck emoji, so only the complete leading characters can be converted and propagated.
+statement ok
+CREATE TABLE case_split_char AS
+SELECT i::INTEGER AS i,
+       CASE WHEN i < 2048 THEN 'abcdefghij' WHEN i < 4096 THEN 'klmnopqrst' ELSE 'uvwxyzabcd' END
+           || '🦆' || lpad(i::VARCHAR, 6, '0') AS s
+FROM range(6144) r(i);
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM case_split_char WHERE upper(s) = 'KLMNOPQRST🦆002500';
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
+
+query I
+SELECT count(*) FROM case_split_char WHERE upper(s) = 'KLMNOPQRST🦆002500';
+----
+1

--- a/test/sql/optimizer/upper_lower_zonemap_pruning.test
+++ b/test/sql/optimizer/upper_lower_zonemap_pruning.test
@@ -1,0 +1,71 @@
+# name: test/sql/optimizer/upper_lower_zonemap_pruning.test
+# description: Prune row groups for upper()/lower() when a row group's min == max
+# group: [optimizer]
+
+statement ok
+ATTACH '{TEST_DIR}/upper_lower_zonemap_pruning.duckdb' AS db (ROW_GROUP_SIZE 2048);
+
+statement ok
+USE db;
+
+# 6144 rows -> 3 row groups of 2048 rows, each holding a single constant string,
+# so every row group has min == max exact stats.
+statement ok
+CREATE TABLE case_pruning AS
+SELECT i::INTEGER AS i, CASE WHEN i < 2048 THEN 'alpha' WHEN i < 4096 THEN 'Beta' ELSE 'GAMMA' END AS s
+FROM range(6144) r(i);
+
+# When min == max, upper() of the row group is a single known value: only the 'Beta' row group can match.
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM case_pruning WHERE upper(s) = 'BETA';
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
+
+query I
+SELECT count(*) FROM case_pruning WHERE upper(s) = 'BETA';
+----
+2048
+
+# lower() shares the same propagation.
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM case_pruning WHERE lower(s) = 'gamma';
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
+
+query I
+SELECT count(*) FROM case_pruning WHERE lower(s) = 'gamma';
+----
+2048
+
+# upper()/lower() are not order-preserving, so a row group with min != max cannot be pruned.
+statement ok
+CREATE TABLE case_mixed AS
+SELECT i::INTEGER AS i, 'v' || lpad(i::VARCHAR, 6, '0') AS s
+FROM range(6144) r(i);
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM case_mixed WHERE upper(s) = 'V004000';
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 3 / 3.*
+
+query I
+SELECT count(*) FROM case_mixed WHERE upper(s) = 'V004000';
+----
+1
+
+# Strings longer than the stored zonemap prefix only have truncated stats: even identical values cannot be proven equal, so no pruning is possible.
+statement ok
+CREATE TABLE case_truncated AS
+SELECT i::INTEGER AS i,
+       CASE WHEN i < 2048 THEN 'prefixprefix_alpha' WHEN i < 4096 THEN 'prefixprefix_beta' ELSE 'prefixprefix_gamma' END AS s
+FROM range(6144) r(i);
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM case_truncated WHERE upper(s) = 'PREFIXPREFIX_BETA';
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 3 / 3.*
+
+query I
+SELECT count(*) FROM case_truncated WHERE upper(s) = 'PREFIXPREFIX_BETA';
+----
+2048


### PR DESCRIPTION
In the current implementation, case conversion doesn't propagate useful stats for pruning, so the queries like below doesn't prune as expected
```sql
memory D ATTACH '/tmp/upper_lower_zonemap_pruning.duckdb' AS db (ROW_GROUP_SIZE 2048);
memory D USE db;
db D CREATE TABLE case_pruning AS
     SELECT i::INTEGER AS i, CASE WHEN i < 2048 THEN 'alpha' WHEN i < 4096 THEN 'Beta' ELSE 'GAMMA' END AS s
     FROM range(6144) r(i);
db D EXPLAIN ANALYZE SELECT count(*) FROM case_pruning WHERE upper(s) = 'BETA';
╭─ Summary ───────────╮
│ Total Time: 0.0016s │
╰─────────────────────╯
╭─ Ungrouped Aggregate ───────╮
│ Aggregates: count_star()    │
│ 1 row                   0µs │
╰──────────────┒┎─────────────╯
╭─ Table Scan ─┚┖─────────────╮
│ Table: db.main.case_pruning │
│ Type: Sequential Scan       │
│ Filters: upper(s) = 'BETA'  │
│ Row Groups Scanned: 3 / 3   │
│ 2,048 rows              0µs │
╰─────────────────────────────╯
```
This PR propagates stats when min==max (whether exact or in-exact stats), the tricky case is case conversion could change string size.
```sql
memory D SELECT upper('ɐ') AS u,
                strlen('ɐ') AS lower_bytes,      -- 2
                strlen(upper('ɐ')) AS upper_bytes; -- 3
┌─────────┬─────────────┬─────────────┐
│    u    │ lower_bytes │ upper_bytes │
│ varchar │    int64    │    int64    │
├─────────┼─────────────┼─────────────┤
│ Ɐ       │           2 │           3 │
└─────────┴─────────────┴─────────────┘
```