### PR TITLE
Parquet writer: write ColumnMetaData.encoding_stats

### DIFF
--- a/extension/parquet/parquet_metadata.cpp
+++ b/extension/parquet/parquet_metadata.cpp
@@ -354,6 +354,13 @@ void ParquetMetaDataOperator::BindSchema<ParquetMetadataOperatorType::META_DATA>
 
 	names.emplace_back("geo_types");
 	return_types.emplace_back(LogicalType::LIST(LogicalType::VARCHAR));
+
+	names.emplace_back("encoding_stats");
+	return_types.emplace_back(LogicalType::LIST(LogicalType::STRUCT({
+	    {"page_type", LogicalType::VARCHAR},
+	    {"encoding", LogicalType::VARCHAR},
+	    {"count", LogicalType::INTEGER},
+	})));
 }
 
 static Value ConvertParquetStats(const LogicalType &type, const ParquetColumnSchema &schema_ele, bool stats_is_set,
@@ -388,6 +395,27 @@ static Value ConvertParquetGeoStatsBBOX(const duckdb_parquet::GeospatialStatisti
 	    {"mmin", stats.bbox.__isset.mmin ? Value::DOUBLE(stats.bbox.mmin) : Value(LogicalTypeId::DOUBLE)},
 	    {"mmax", stats.bbox.__isset.mmax ? Value::DOUBLE(stats.bbox.mmax) : Value(LogicalTypeId::DOUBLE)},
 	});
+}
+
+static Value ConvertParquetEncodingStats(const duckdb_parquet::ColumnMetaData &col_meta) {
+	auto stat_type = LogicalType::STRUCT({
+	    {"page_type", LogicalType::VARCHAR},
+	    {"encoding", LogicalType::VARCHAR},
+	    {"count", LogicalType::INTEGER},
+	});
+	if (!col_meta.__isset.encoding_stats) {
+		return Value(LogicalType::LIST(stat_type));
+	}
+	vector<Value> stats;
+	stats.reserve(col_meta.encoding_stats.size());
+	for (auto &entry : col_meta.encoding_stats) {
+		stats.push_back(Value::STRUCT({
+		    {"page_type", Value(ConvertParquetElementToString(entry.page_type))},
+		    {"encoding", Value(ConvertParquetElementToString(entry.encoding))},
+		    {"count", Value::INTEGER(entry.count)},
+		}));
+	}
+	return Value::LIST(stat_type, std::move(stats));
 }
 
 static Value ConvertParquetGeoStatsTypes(const duckdb_parquet::GeospatialStatistics &stats) {
@@ -525,6 +553,9 @@ void ParquetRowGroupMetadataProcessor::ReadRow(vector<reference<Vector>> &output
 
 	// geo_stats_types, LogicalType::LIST(LogicalType::VARCHAR)
 	output[30].get().Append(ConvertParquetGeoStatsTypes(col_meta.geospatial_statistics));
+
+	// encoding_stats, LogicalType::LIST(LogicalType::STRUCT(...))
+	output[31].get().Append(ConvertParquetEncodingStats(col_meta));
 }
 
 //===--------------------------------------------------------------------===//

--- a/extension/parquet/writer/primitive_column_writer.cpp
+++ b/extension/parquet/writer/primitive_column_writer.cpp
@@ -337,18 +337,42 @@ void PrimitiveColumnWriter::SetParquetStatistics(PrimitiveColumnWriterState &sta
 		column_chunk.meta_data.encodings.push_back(encoding);
 	};
 
+	auto add_encoding_stat = [&](duckdb_parquet::PageType::type page_type, duckdb_parquet::Encoding::type encoding) {
+		for (auto &existing_stat : column_chunk.meta_data.encoding_stats) {
+			if (existing_stat.page_type == page_type && existing_stat.encoding == encoding) {
+				existing_stat.count++;
+				return;
+			}
+		}
+		duckdb_parquet::PageEncodingStats stat;
+		stat.page_type = page_type;
+		stat.encoding = encoding;
+		stat.count = 1;
+		column_chunk.meta_data.encoding_stats.push_back(stat);
+	};
+
 	for (const auto &write_info : state.write_info) {
 		// only care about data page encodings, data_page_header.encoding is meaningless for dict
 		switch (write_info.page_header.type) {
 		case PageType::DATA_PAGE:
 			add_encoding(write_info.page_header.data_page_header.encoding);
+			add_encoding_stat(write_info.page_header.type, write_info.page_header.data_page_header.encoding);
 			break;
 		case PageType::DATA_PAGE_V2:
 			add_encoding(write_info.page_header.data_page_header_v2.encoding);
+			add_encoding_stat(write_info.page_header.type, write_info.page_header.data_page_header_v2.encoding);
+			break;
+		case PageType::DICTIONARY_PAGE:
+			add_encoding_stat(write_info.page_header.type, write_info.page_header.dictionary_page_header.encoding);
 			break;
 		default:
 			break;
 		}
+	}
+	// write_info holds the dictionary page (if any) first, so encoding_stats lists it first -
+	// the physical page order, and the order other writers (parquet-cpp, parquet-rs) produce
+	if (!column_chunk.meta_data.encoding_stats.empty()) {
+		column_chunk.meta_data.__isset.encoding_stats = true;
 	}
 
 	if (!state.stats_state) {

--- a/test/sql/copy/parquet/writer/parquet_encoding_stats.test
+++ b/test/sql/copy/parquet/writer/parquet_encoding_stats.test
@@ -58,3 +58,45 @@ SELECT encoding_stats FROM parquet_metadata('data/parquet-testing/userdata1.parq
 WHERE path_in_schema = 'first_name'
 ----
 NULL
+
+# every writer-supported type carries the field, consistent with the chunk's
+# dictionary_page_offset: a dictionary chunk lists DICTIONARY_PAGE first, a chunk
+# without a dictionary opens with DATA_PAGE and lists no DICTIONARY_PAGE at all
+statement ok
+CREATE TABLE all_types AS SELECT
+    i % 3 = 0 AS bool_col,
+    (i % 3)::TINYINT AS tinyint_col,
+    (i % 3)::SMALLINT AS smallint_col,
+    (i % 3)::INTEGER AS int_col,
+    (i % 3)::BIGINT AS bigint_col,
+    (i % 3)::FLOAT AS float_col,
+    (i % 3)::DOUBLE AS double_col,
+    ((i % 3) + 0.5)::DECIMAL(9,2) AS dec9_col,
+    ((i % 3) + 0.5)::DECIMAL(18,3) AS dec18_col,
+    ((i % 3) + 0.5)::DECIMAL(38,4) AS dec38_col,
+    DATE '2024-01-01' + (i % 3)::INTEGER AS date_col,
+    TIME '01:02:03' AS time_col,
+    TIMESTAMP '2024-01-01 01:02:03' + (i % 3) * INTERVAL 1 HOUR AS ts_col,
+    (i % 3)::VARCHAR AS varchar_col,
+    encode((i % 3)::VARCHAR) AS blob_col
+FROM range(1000) tbl(i);
+
+statement ok
+COPY all_types TO '{TEST_DIR}/encoding_stats_all_types.parquet' (FORMAT PARQUET);
+
+query I
+SELECT count(*) FROM parquet_metadata('{TEST_DIR}/encoding_stats_all_types.parquet')
+----
+15
+
+query I
+SELECT count(*)
+FROM (
+    SELECT dictionary_page_offset, (encoding_stats[1]).page_type AS first_page_type
+    FROM parquet_metadata('{TEST_DIR}/encoding_stats_all_types.parquet')
+)
+WHERE first_page_type IS NULL
+   OR (dictionary_page_offset IS NOT NULL AND first_page_type <> 'DICTIONARY_PAGE')
+   OR (dictionary_page_offset IS NULL AND first_page_type <> 'DATA_PAGE')
+----
+0

--- a/test/sql/copy/parquet/writer/parquet_encoding_stats.test
+++ b/test/sql/copy/parquet/writer/parquet_encoding_stats.test
@@ -1,0 +1,60 @@
+# name: test/sql/copy/parquet/writer/parquet_encoding_stats.test
+# description: Writer populates ColumnMetaData.encoding_stats (PageEncodingStats)
+# group: [writer]
+
+require parquet
+
+statement ok
+CREATE TABLE strings AS SELECT (i % 3)::VARCHAR AS s FROM range(1000) tbl(i);
+
+statement ok
+COPY strings TO '{TEST_DIR}/encoding_stats_v1.parquet' (FORMAT PARQUET, PARQUET_VERSION v1);
+
+# the dictionary page is listed first: that is the physical page order, and readers exist that
+# check the first entry to decide whether a dictionary page leads the chunk
+query TTI
+SELECT s.page_type, s.encoding, s."count"
+FROM (SELECT unnest(encoding_stats) AS s FROM parquet_metadata('{TEST_DIR}/encoding_stats_v1.parquet'))
+----
+DICTIONARY_PAGE	PLAIN	1
+DATA_PAGE	PLAIN_DICTIONARY	1
+
+statement ok
+COPY strings TO '{TEST_DIR}/encoding_stats_v2.parquet' (FORMAT PARQUET, PARQUET_VERSION v2);
+
+query TTI
+SELECT s.page_type, s.encoding, s."count"
+FROM (SELECT unnest(encoding_stats) AS s FROM parquet_metadata('{TEST_DIR}/encoding_stats_v2.parquet'))
+----
+DICTIONARY_PAGE	PLAIN	1
+DATA_PAGE	RLE_DICTIONARY	1
+
+# non-dictionary chunk: no DICTIONARY_PAGE entry
+statement ok
+CREATE TABLE distinct_strings AS SELECT i::VARCHAR AS s FROM range(30) tbl(i);
+
+statement ok
+COPY distinct_strings TO '{TEST_DIR}/encoding_stats_plain.parquet' (FORMAT PARQUET);
+
+query TTI
+SELECT s.page_type, s.encoding, s."count"
+FROM (SELECT unnest(encoding_stats) AS s FROM parquet_metadata('{TEST_DIR}/encoding_stats_plain.parquet'))
+----
+DATA_PAGE	PLAIN	1
+
+# reading the field back from a parquet-mr file that carries it
+query TTI
+SELECT s.page_type, s.encoding, s."count"
+FROM (SELECT unnest(encoding_stats) AS s
+      FROM parquet_metadata('data/parquet-testing/enum.parquet')
+      WHERE path_in_schema = 'trace_id')
+----
+DICTIONARY_PAGE	PLAIN_DICTIONARY	1
+DATA_PAGE	PLAIN_DICTIONARY	1
+
+# a file written without the field reads back NULL
+query I
+SELECT encoding_stats FROM parquet_metadata('data/parquet-testing/userdata1.parquet')
+WHERE path_in_schema = 'first_name'
+----
+NULL


### PR DESCRIPTION
DuckDB's parquet writer never writes `ColumnMetaData.encoding_stats` (`PageEncodingStats`, footer field 13). It is the only footer structure that tells a reader a column chunk is fully dictionary-encoded without decoding page headers; readers that key on it take a slow path on DuckDB files. parquet-cpp and parquet-rs both write it.

Fixes #12892 (closed by stale bot, not on merits). Full investigation in #24956.

**Measured effect** — Microsoft Fabric Direct Lake, cold `DISTINCTCOUNT` over a 142M-row dictionary string column, identical write config, only the duckdb binary differing:

| writer | cold probe |
|---|---|
| nightly `1.6.0.dev365` | 10857.5 ms |
| this branch | 689.3 ms |

Public runs: [before](https://github.com/djouallah/duckrun/actions/runs/32641748532), [after](https://github.com/djouallah/duckrun/actions/runs/32645345614) (the "after" binary is this branch's CLI, built by Main.yml). Injecting only this field into an otherwise untouched DuckDB file reproduces the same speedup ([run](https://github.com/djouallah/duckrun/actions/runs/32638013982)), so the field alone accounts for it.

**Changes**
- `primitive_column_writer.cpp`: accumulate per-`(page_type, encoding)` counts in the existing `SetParquetStatistics` page loop. The dictionary page entry comes first — `write_info` holds it first, matching the physical page order and other writers.
- `parquet_metadata.cpp`: expose `encoding_stats` as a new trailing column.
- `test/sql/copy/parquet/writer/parquet_encoding_stats.test`: v1 (`DICTIONARY_PAGE/PLAIN` + `DATA_PAGE/PLAIN_DICTIONARY`), v2 (`RLE_DICTIONARY`), non-dictionary fallback (`DATA_PAGE/PLAIN`), reading a parquet-mr file that carries the field, NULL for a file that does not.


---
This code was written by Claude (Anthropic), directed and verified by me.
