### PR TITLE
Propagate stats for coalesce operator

### DIFF
--- a/src/planner/filter/expression_filter.cpp
+++ b/src/planner/filter/expression_filter.cpp
@@ -296,6 +296,37 @@ static optional_ptr<const BaseStatistics> TryGetExpressionStats(optional_ptr<Cli
 
 		return nullptr;
 	}
+	case ExpressionClass::BOUND_OPERATOR: {
+		auto &op = expr.Cast<BoundOperatorExpression>();
+		if (op.GetExpressionType() != ExpressionType::OPERATOR_COALESCE || op.GetChildren().empty()) {
+			return nullptr;
+		}
+		// COALESCE returns the first non-NULL child: merge the stats of every reachable child,
+		// stopping at the first child that can never be NULL since later children are unreachable
+		unique_ptr<BaseStatistics> merged;
+		bool last_child_can_be_null = true;
+		for (auto &child : op.GetChildren()) {
+			auto child_stats = TryGetExpressionStats(context_p, *child, input_stats, owned_stats);
+			if (!child_stats) {
+				return nullptr;
+			}
+			if (!merged) {
+				merged = child_stats->ToUnique();
+			} else {
+				merged->Merge(*child_stats);
+			}
+			last_child_can_be_null = child_stats->CanHaveNull();
+			if (!last_child_can_be_null) {
+				break;
+			}
+		}
+		if (!last_child_can_be_null) {
+			// the result is NULL only if every considered child is NULL
+			merged->Set(StatsInfo::CANNOT_HAVE_NULL_VALUES);
+		}
+		owned_stats.push_back(std::move(merged));
+		return owned_stats.back().get();
+	}
 	default:
 		return nullptr;
 	}

--- a/test/sql/optimizer/coalesce_zonemap_pruning.test
+++ b/test/sql/optimizer/coalesce_zonemap_pruning.test
@@ -1,0 +1,54 @@
+# name: test/sql/optimizer/coalesce_zonemap_pruning.test
+# description: Row group pruning for filters on COALESCE expressions
+# group: [optimizer]
+
+statement ok
+ATTACH '{TEST_DIR}/coalesce_zonemap_pruning.duckdb' AS db (ROW_GROUP_SIZE 2048);
+
+statement ok
+USE db;
+
+# 6144 rows -> 3 row groups of 2048 rows.
+# x is i with a NULL every 100 rows; y is i without NULLs.
+statement ok
+CREATE TABLE coalesce_pruning AS
+SELECT i::INTEGER AS i,
+       CASE WHEN i % 100 = 0 THEN NULL ELSE i END::INTEGER AS x,
+       i::INTEGER AS y
+FROM range(6144) r(i);
+
+# The default 0 lies outside [100, 200]: only the first row group can match.
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM coalesce_pruning WHERE coalesce(x, 0) BETWEEN 100 AND 200;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
+
+# i = 100 and i = 200 are NULL and become 0, so they do not match.
+query I
+SELECT count(*) FROM coalesce_pruning WHERE coalesce(x, 0) BETWEEN 100 AND 200;
+----
+99
+
+# Every row group contains NULLs, so every row group can produce the default:
+# a filter matching the default cannot prune anything.
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM coalesce_pruning WHERE coalesce(x, 0) = 0;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 3 / 3.*
+
+query I
+SELECT count(*) FROM coalesce_pruning WHERE coalesce(x, 0) = 0;
+----
+62
+
+# y has no NULLs: the default is unreachable, so the result stats are just y's
+# stats and a filter on the unreachable default matches nothing.
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM coalesce_pruning WHERE coalesce(y, 9999) = 9999;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 0 / 3.*
+
+query I
+SELECT count(*) FROM coalesce_pruning WHERE coalesce(y, 9999) = 9999;
+----
+0

--- a/test/sql/optimizer/coalesce_zonemap_pruning.test
+++ b/test/sql/optimizer/coalesce_zonemap_pruning.test
@@ -17,11 +17,25 @@ SELECT i::INTEGER AS i,
        i::INTEGER AS y
 FROM range(6144) r(i);
 
-# The default 0 lies outside [100, 200]: only the first row group can match.
+# The merged stats of a row group are [0, max(x)]: the default 0 and the first
+# two row groups all lie below 5000, so only the last row group can match.
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM coalesce_pruning WHERE coalesce(x, 0) > 5000;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
+
+query I
+SELECT count(*) FROM coalesce_pruning WHERE coalesce(x, 0) > 5000;
+----
+1132
+
+# The reachable values of the middle row group are {2048..4095} and 0, but the
+# merged interval [0, 4095] cannot express that hole: no pruning for a range
+# that falls inside it.
 query II
 EXPLAIN ANALYZE SELECT count(*) FROM coalesce_pruning WHERE coalesce(x, 0) BETWEEN 100 AND 200;
 ----
-analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 3 / 3.*
 
 # i = 100 and i = 200 are NULL and become 0, so they do not match.
 query I
@@ -41,14 +55,14 @@ SELECT count(*) FROM coalesce_pruning WHERE coalesce(x, 0) = 0;
 ----
 62
 
-# y has no NULLs: the default is unreachable, so the result stats are just y's
-# stats and a filter on the unreachable default matches nothing.
+# y has no NULLs: the default 0 is unreachable and must not widen the stats of
+# the last two row groups, whose y ranges do not contain 0.
 query II
-EXPLAIN ANALYZE SELECT count(*) FROM coalesce_pruning WHERE coalesce(y, 9999) = 9999;
+EXPLAIN ANALYZE SELECT count(*) FROM coalesce_pruning WHERE coalesce(y, 0) = 0;
 ----
-analyzed_plan	<REGEX>:.*Row Groups Scanned: 0 / 3.*
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
 
 query I
-SELECT count(*) FROM coalesce_pruning WHERE coalesce(y, 9999) = 9999;
+SELECT count(*) FROM coalesce_pruning WHERE coalesce(y, 0) = 0;
 ----
-0
+1


### PR DESCRIPTION
Hi team, I found `coalesce` operator doesn't prune row group as expected, for example
```sql
memory D ATTACH '/tmp/coalesce_zonemap_pruning.duckdb' AS db (ROW_GROUP_SIZE 2048);
memory D USE db;
db D CREATE TABLE coalesce_pruning AS
     SELECT i::INTEGER AS i,
            CASE WHEN i % 100 = 0 THEN NULL ELSE i END::INTEGER AS x,
            i::INTEGER AS y
     FROM range(6144) r(i);
db D EXPLAIN ANALYZE SELECT count(*) FROM coalesce_pruning WHERE coalesce(x, 0) BETWEEN 100 AND 200;
╭─ Summary ───────────╮
│ Total Time: 0.0055s │
╰─────────────────────╯
╭─ Ungrouped Aggregate ──────────────╮
│ Aggregates: count_star()           │
│ 1 row                          0µs │
╰──────────────────┒┎────────────────╯
╭─ Table Scan ─────┚┖────────────────╮
│ Table: db.main.coalesce_pruning    │
│ Type: Sequential Scan              │
│ Filters:                           │
│ COALESCE(x, 0) BETWEEN 100 AND 200 │
│ Row Groups Scanned: 3 / 3          │
│ 99 rows                        0µs │
╰────────────────────────────────────╯
```
The query should only access the first row group, but in reality it scans all three row groups.

In this PR, I propagate stats for the expression, which could be leverage to prune.