### PR TITLE
Avoid plan-time partial precomputation when not complete

### DIFF
--- a/src/optimizer/statistics/operator/propagate_aggregate.cpp
+++ b/src/optimizer/statistics/operator/propagate_aggregate.cpp
@@ -396,6 +396,13 @@ void StatisticsPropagator::TryExecuteAggregates(LogicalAggregate &aggr, unique_p
 	}
 
 	if (need_to_scan) {
+		// Partial precomputation combines plan-time partition statistics with an execution-time scan that
+		// skips partitions by their index in the row-group list. That list can change in between
+		// (concurrent appends, checkpoints), in which case a skipped partition is scanned again and its
+		// rows are counted twice. Only the full precomputation (no scan) is safe.
+		return;
+	}
+	if (need_to_scan) {
 		// Partial precomputation: some partitions need scanning
 		// Insert a LogicalProjection above the aggregate that combines pre-computed constants with scan results
 		if (!get.function.set_partitions_to_scan) {

--- a/test/optimizer/partial_aggregate_precomputation.test
+++ b/test/optimizer/partial_aggregate_precomputation.test
@@ -47,11 +47,15 @@ SELECT count(*), min(i), max(i) FROM t WHERE i >= 2048
 ----
 6144	2048	8191
 
+mode skip "This optimization is currently disabled due to issues with rowgroup reordering"
+
 # Partial precompute: PROJECTION merges precomputed constants with aggregate results
 query II
 EXPLAIN SELECT count(*), min(i), max(i) FROM t WHERE i >= 2048 AND j > 5000
 ----
 physical_plan	<REGEX>:.*COALESCE.*least.*UNGROUPED_AGGREGATE.*
+
+mode unskip
 
 query III
 SELECT count(*), min(i), max(i) FROM t WHERE i >= 2048 AND j > 5000
@@ -112,10 +116,14 @@ analyzed_plan	<REGEX>:.*Type: Index Scan.*
 statement ok
 RESET disabled_optimizers
 
+mode skip "This optimization is currently disabled due to issues with rowgroup reordering"
+
 query II
 EXPLAIN ANALYZE SELECT count(*), min(i), max(i) FROM t WHERE j > 5000
 ----
 analyzed_plan	<REGEX>:.*Type: Sequential Scan.*
+
+mode unskip
 
 query III
 SELECT count(*), min(i), max(i) FROM t WHERE j > 5000


### PR DESCRIPTION
https://github.com/duckdb/duckdb/pull/21831 introduced a super cool optimization, but I think that under load (like multiple connections inserting data) then numbering of row group blocks.

Current proposal is avoiding the optimization when it can't be applied for all row groups, that should keep some improvements, but also bear a cost. I am not sure what's the path to stable numbering for row groups, but I can imagine that would allow to re-enable this.

Problematic test is `test/sql/parallelism/interquery/concurrent_checkpoint_insert.test`, in particular with system slowed down (possibly by TSan build), since scheduling here is needed to align for the bad path to occur.