### PR TITLE
Prune row groups for column-constant OR

### DIFF
--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -453,20 +453,6 @@ static bool CanPushdownMultiColumnExpression(const Expression &expr, const vecto
 	return IsDirectNumericColumnComparison(expr, bindings) || IsColumnConstantOr(expr);
 }
 
-// Remove query-specific metadata so equivalent filters serialize identically for common-subplan matching.
-static void CanonicalizeMultiColumnFilterExpression(unique_ptr<Expression> &expr) {
-	ExpressionIterator::EnumerateChildren(
-	    *expr, [&](unique_ptr<Expression> &child) { CanonicalizeMultiColumnFilterExpression(child); });
-	if (BoundComparisonExpression::IsComparison(*expr)) {
-		auto &comparison = expr->Cast<BoundFunctionExpression>();
-		auto left = std::move(BoundComparisonExpression::LeftMutable(comparison));
-		auto right = std::move(BoundComparisonExpression::RightMutable(comparison));
-		expr = BoundComparisonExpression::Create(comparison.GetExpressionType(), std::move(left), std::move(right));
-	}
-	expr->ClearAlias();
-	expr->SetQueryLocation(optional_idx());
-}
-
 static unique_ptr<ExpressionFilter> TryCreateMultiColumnExpressionFilter(LogicalGet &get, const Expression &expr,
                                                                          const vector<ColumnBinding> &bindings) {
 	vector<ColumnBinding> distinct_bindings;
@@ -501,7 +487,11 @@ static unique_ptr<ExpressionFilter> TryCreateMultiColumnExpressionFilter(Logical
 		    child =
 		        make_uniq<BoundReferenceExpression>(column_ref.GetAlias(), column_ref.GetReturnType(), entry->second);
 	    });
-	CanonicalizeMultiColumnFilterExpression(filter_expr);
+	// Remove query-specific metadata so equivalent filters serialize identically for common-subplan matching.
+	ExpressionIterator::EnumerateExpression(filter_expr, [](Expression &expr) {
+		expr.ClearAlias();
+		expr.SetQueryLocation(optional_idx());
+	});
 	return make_uniq<ExpressionFilter>(std::move(filter_expr), std::move(column_indexes));
 }
 

--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/function/scalar/string_common.hpp"
 #include "duckdb/optimizer/optimizer.hpp"
+#include "duckdb/planner/column_binding_map.hpp"
 #include "duckdb/planner/expression.hpp"
 #include "duckdb/planner/expression/bound_between_expression.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
@@ -392,6 +393,118 @@ void ReplaceWithBoundReference(unique_ptr<Expression> &root_expr) {
 	    });
 }
 
+static bool IsColumnConstantOr(const Expression &expr) {
+	if (expr.GetExpressionClass() != ExpressionClass::BOUND_CONJUNCTION ||
+	    expr.GetExpressionType() != ExpressionType::CONJUNCTION_OR) {
+		return false;
+	}
+	const auto &conjunction = expr.Cast<BoundConjunctionExpression>();
+	if (conjunction.GetChildren().empty()) {
+		return false;
+	}
+	for (const auto &child : conjunction.GetChildren()) {
+		if (!BoundComparisonExpression::IsComparison(*child) ||
+		    !SupportedFilterComparison(child->GetExpressionType())) {
+			return false;
+		}
+		const auto &comparison = child->Cast<BoundFunctionExpression>();
+		const auto &left = BoundComparisonExpression::Left(comparison);
+		const auto &right = BoundComparisonExpression::Right(comparison);
+		optional_ptr<const BoundColumnRefExpression> column_ref;
+		optional_ptr<const BoundConstantExpression> constant;
+		if (left.GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF &&
+		    right.GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
+			column_ref = left.Cast<BoundColumnRefExpression>();
+			constant = right.Cast<BoundConstantExpression>();
+		} else if (left.GetExpressionClass() == ExpressionClass::BOUND_CONSTANT &&
+		           right.GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF) {
+			column_ref = right.Cast<BoundColumnRefExpression>();
+			constant = left.Cast<BoundConstantExpression>();
+		} else {
+			return false;
+		}
+		if (constant->GetValue().IsNull() || !TypeSupportsConstantFilter(column_ref->GetReturnType())) {
+			return false;
+		}
+	}
+	return true;
+}
+
+static bool IsDirectNumericColumnComparison(const Expression &expr, const vector<ColumnBinding> &bindings) {
+	if (bindings.size() != 2 || bindings[0] == bindings[1] || !BoundComparisonExpression::IsComparison(expr)) {
+		return false;
+	}
+	const auto &comparison = expr.Cast<BoundFunctionExpression>();
+	const auto &left = BoundComparisonExpression::Left(comparison);
+	const auto &right = BoundComparisonExpression::Right(comparison);
+	const auto comparison_type = comparison.GetExpressionType();
+	const bool supported_comparison = comparison_type == ExpressionType::COMPARE_EQUAL ||
+	                                  comparison_type == ExpressionType::COMPARE_NOTEQUAL ||
+	                                  comparison_type == ExpressionType::COMPARE_GREATERTHAN ||
+	                                  comparison_type == ExpressionType::COMPARE_GREATERTHANOREQUALTO ||
+	                                  comparison_type == ExpressionType::COMPARE_LESSTHAN ||
+	                                  comparison_type == ExpressionType::COMPARE_LESSTHANOREQUALTO;
+	return supported_comparison && left.GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF &&
+	       right.GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF && left.GetReturnType().IsNumeric() &&
+	       right.GetReturnType().IsNumeric();
+}
+
+static bool CanPushdownMultiColumnExpression(const Expression &expr, const vector<ColumnBinding> &bindings) {
+	return IsDirectNumericColumnComparison(expr, bindings) || IsColumnConstantOr(expr);
+}
+
+// Remove query-specific metadata so equivalent filters serialize identically for common-subplan matching.
+static void CanonicalizeMultiColumnFilterExpression(unique_ptr<Expression> &expr) {
+	ExpressionIterator::EnumerateChildren(
+	    *expr, [&](unique_ptr<Expression> &child) { CanonicalizeMultiColumnFilterExpression(child); });
+	if (BoundComparisonExpression::IsComparison(*expr)) {
+		auto &comparison = expr->Cast<BoundFunctionExpression>();
+		auto left = std::move(BoundComparisonExpression::LeftMutable(comparison));
+		auto right = std::move(BoundComparisonExpression::RightMutable(comparison));
+		expr = BoundComparisonExpression::Create(comparison.GetExpressionType(), std::move(left), std::move(right));
+	}
+	expr->ClearAlias();
+	expr->SetQueryLocation(optional_idx());
+}
+
+static unique_ptr<ExpressionFilter> TryCreateMultiColumnExpressionFilter(LogicalGet &get, const Expression &expr,
+                                                                         const vector<ColumnBinding> &bindings) {
+	vector<ColumnBinding> distinct_bindings;
+	distinct_bindings.reserve(bindings.size());
+	// Maps column bindings to dense BoundReference indexes.
+	column_binding_map_t<idx_t> binding_indexes;
+	for (const auto &binding : bindings) {
+		const auto insert_result = binding_indexes.emplace(binding, distinct_bindings.size());
+		if (insert_result.second) {
+			distinct_bindings.push_back(binding);
+		}
+	}
+	if (distinct_bindings.size() <= 1) {
+		return nullptr;
+	}
+
+	vector<ProjectionIndex> column_indexes;
+	column_indexes.reserve(distinct_bindings.size());
+	for (const auto &binding : distinct_bindings) {
+		if (binding.table_index != get.table_index || binding.column_index >= get.GetColumnIds().size() ||
+		    get.GetColumnIds()[binding.column_index].IsVirtualColumn()) {
+			return nullptr;
+		}
+		column_indexes.emplace_back(binding.column_index);
+	}
+
+	auto filter_expr = expr.Copy();
+	ExpressionIterator::VisitExpressionMutable<BoundColumnRefExpression>(
+	    filter_expr, [&](BoundColumnRefExpression &column_ref, unique_ptr<Expression> &child) {
+		    const auto entry = binding_indexes.find(column_ref.Binding());
+		    D_ASSERT(entry != binding_indexes.end());
+		    child =
+		        make_uniq<BoundReferenceExpression>(column_ref.GetAlias(), column_ref.GetReturnType(), entry->second);
+	    });
+	CanonicalizeMultiColumnFilterExpression(filter_expr);
+	return make_uniq<ExpressionFilter>(std::move(filter_expr), std::move(column_indexes));
+}
+
 FilterPushdownResult FilterCombiner::TryPushdownGenericExpression(LogicalGet &get, Expression &expr) {
 	if (!get.function.pushdown_expression) {
 		// the scan does not support pushing down generic expressions
@@ -404,40 +517,12 @@ FilterPushdownResult FilterCombiner::TryPushdownGenericExpression(LogicalGet &ge
 		return FilterPushdownResult::NO_PUSHDOWN;
 	}
 	auto table = get.GetTable();
-	if (bindings.size() == 2 && bindings[0] != bindings[1] && table && table->IsDuckTable() &&
-	    BoundComparisonExpression::IsComparison(expr)) {
-		const auto &comparison = expr.Cast<BoundFunctionExpression>();
-		const auto &left = BoundComparisonExpression::Left(comparison);
-		const auto &right = BoundComparisonExpression::Right(comparison);
-		const auto comparison_type = comparison.GetExpressionType();
-		const bool supported_comparison = comparison_type == ExpressionType::COMPARE_EQUAL ||
-		                                  comparison_type == ExpressionType::COMPARE_NOTEQUAL ||
-		                                  comparison_type == ExpressionType::COMPARE_GREATERTHAN ||
-		                                  comparison_type == ExpressionType::COMPARE_GREATERTHANOREQUALTO ||
-		                                  comparison_type == ExpressionType::COMPARE_LESSTHAN ||
-		                                  comparison_type == ExpressionType::COMPARE_LESSTHANOREQUALTO;
-		if (!supported_comparison || left.GetExpressionClass() != ExpressionClass::BOUND_COLUMN_REF ||
-		    right.GetExpressionClass() != ExpressionClass::BOUND_COLUMN_REF || !left.GetReturnType().IsNumeric() ||
-		    !right.GetReturnType().IsNumeric()) {
+	if (table && table->IsDuckTable() && CanPushdownMultiColumnExpression(expr, bindings)) {
+		auto filter = TryCreateMultiColumnExpressionFilter(get, expr, bindings);
+		if (!filter) {
 			return FilterPushdownResult::NO_PUSHDOWN;
 		}
-		const auto &left_ref = left.Cast<BoundColumnRefExpression>();
-		const auto &right_ref = right.Cast<BoundColumnRefExpression>();
-		if (left_ref.Binding().table_index != get.table_index || right_ref.Binding().table_index != get.table_index ||
-		    left_ref.Binding().column_index >= get.GetColumnIds().size() ||
-		    right_ref.Binding().column_index >= get.GetColumnIds().size() ||
-		    get.GetColumnIds()[left_ref.Binding().column_index].IsVirtualColumn() ||
-		    get.GetColumnIds()[right_ref.Binding().column_index].IsVirtualColumn()) {
-			return FilterPushdownResult::NO_PUSHDOWN;
-		}
-
-		auto left_bound_ref = make_uniq<BoundReferenceExpression>(left_ref.GetAlias(), left_ref.GetReturnType(), 0);
-		auto right_bound_ref = make_uniq<BoundReferenceExpression>(right_ref.GetAlias(), right_ref.GetReturnType(), 1);
-		auto filter_expr =
-		    BoundComparisonExpression::Create(comparison_type, std::move(left_bound_ref), std::move(right_bound_ref));
-		vector<ProjectionIndex> column_indexes {left_ref.Binding().column_index, right_ref.Binding().column_index};
-		get.table_filters.PushMultiColumnFilter(
-		    make_uniq<ExpressionFilter>(std::move(filter_expr), std::move(column_indexes)));
+		get.table_filters.PushMultiColumnFilter(std::move(filter));
 		return FilterPushdownResult::PUSHED_DOWN_PARTIALLY;
 	}
 	// we can only pushdown expressions that refer to exactly one column

--- a/test/sql/optimizer/cross_column_or_stats_pruning.test
+++ b/test/sql/optimizer/cross_column_or_stats_pruning.test
@@ -1,0 +1,104 @@
+# name: test/sql/optimizer/cross_column_or_stats_pruning.test
+# description: Use row-group statistics for simple OR predicates across columns
+# group: [optimizer]
+
+statement ok
+ATTACH '{TEST_DIR}/cross_column_or_stats_pruning.duckdb' AS rg (ROW_GROUP_SIZE 2048);
+
+statement ok
+USE rg;
+
+statement ok
+CREATE TABLE t AS
+SELECT range::BIGINT AS x, lpad(range::VARCHAR, 8, '0') AS s, range::INTEGER AS y
+FROM range(8192);
+
+statement ok
+CHECKPOINT;
+
+query II
+EXPLAIN ANALYZE SELECT sum(x) FROM t WHERE x < 100 OR s > '00008000';
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 2 / 4.*
+
+query II
+SELECT count(*), sum(x) FROM t WHERE x < 100 OR s > '00008000';
+----
+291	1551286
+
+# Constants can appear on either side of the comparison
+query II
+EXPLAIN ANALYZE SELECT sum(x) FROM t WHERE 100 > x OR '00008000' < s;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 2 / 4.*
+
+# Support more than two distinct columns
+query II
+EXPLAIN ANALYZE SELECT sum(x) FROM t WHERE x < 100 OR s > '00008000' OR y = 3000;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 3 / 4.*
+
+query II
+SELECT count(*), sum(x) FROM t WHERE x < 100 OR s > '00008000' OR y = 3000;
+----
+292	1554286
+
+# Repeated column bindings use the same input statistics
+query II
+EXPLAIN ANALYZE SELECT sum(x) FROM t WHERE x < 100 OR x = 3000 OR s > '00008000';
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 3 / 4.*
+
+# Preserve the existing single-column OR path
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM t WHERE x < 100 OR x > 8000;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 2 / 4.*
+
+statement ok
+CREATE TABLE nullable_t AS
+SELECT CASE WHEN range % 2 = 0 THEN NULL ELSE range END::BIGINT AS a,
+       CASE WHEN range % 3 = 0 THEN NULL ELSE range + 10000 END::BIGINT AS b
+FROM range(8192);
+
+statement ok
+CHECKPOINT;
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM nullable_t WHERE a < 0 OR b < 0;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 0 / 4.*
+
+query I
+SELECT count(*) FROM nullable_t WHERE a < 0 OR b < 0;
+----
+0
+
+# Dynamic filters retain the cross-column filter when filter sets are merged
+query II
+EXPLAIN ANALYZE
+SELECT sum(t.x)
+FROM t
+JOIN (VALUES (50::BIGINT), (3000::BIGINT), (5000::BIGINT), (8050::BIGINT)) keys(x) USING (x)
+WHERE t.x < 100 OR t.s > '00008000';
+----
+analyzed_plan	<REGEX>:.*Dynamic Filters:.*x IN.*Row Groups Scanned: 2 / 4.*
+
+query II
+SELECT count(*), sum(t.x)
+FROM t
+JOIN (VALUES (50::BIGINT), (3000::BIGINT), (5000::BIGINT), (8050::BIGINT)) keys(x) USING (x)
+WHERE t.x < 100 OR t.s > '00008000';
+----
+2	8100
+
+# Multi-column OR filters are canonical across equivalent subplans
+statement ok
+PRAGMA explain_output='optimized_only';
+
+query II
+EXPLAIN SELECT count(*) FROM t WHERE x < 100 OR s > '00008000'
+UNION ALL
+SELECT count(*) FROM t WHERE x < 100 OR s > '00008000';
+----
+logical_opt	<REGEX>:.*CTE.*


### PR DESCRIPTION
## Summary

Resolves #23898

Currently, cross-column OR predicates are evaluated only after scanning every row group, even when each branch can be ruled out using column statistics. This change converts OR expressions whose children are column-to-constant comparisons into the existing `ExpressionFilter` representation with multiple column indexes, allowing the row-group statistics evaluator to prune non-matching row groups.

## Results

```sql
ATTACH '/tmp/cross_column_or_pruning.duckdb' AS rg (ROW_GROUP_SIZE 2048);
USE rg;
CREATE TABLE t AS
SELECT range::BIGINT AS x, lpad(range::VARCHAR, 8, '0') AS s
FROM range(8192);
CHECKPOINT;

EXPLAIN ANALYZE
SELECT sum(x) FROM t WHERE x < 100 OR s > '00008000';
```

### Before

```sql
╭─ Table Scan ────────────────────╮
│ Table: rg.main.t                │
│ Type: Sequential Scan           │
│ Projections: x, s               │
│ Row Groups Scanned: 4 / 4       │
│ 8,192 rows                  0µs │
╰─────────────────────────────────╯
```

### After

```sql
╭─ Table Scan ────────────────────╮
│ Table: rg.main.t                │
│ Type: Sequential Scan           │
│ Projections: x, s               │
│ Row Groups Scanned: 2 / 4       │
│ 4,096 rows                  0µs │
╰─────────────────────────────────╯
```
