### PR TITLE
Make `FunctionSet` and `Bound*Function` contain `shared_ptr<const Function>`s

### DIFF
--- a/.github/patches/extensions/delta/0002-function-set-shared-ptr.patch
+++ b/.github/patches/extensions/delta/0002-function-set-shared-ptr.patch
@@ -1,0 +1,49 @@
+diff --git a/src/functions/delta_scan/delta_scan.cpp b/src/functions/delta_scan/delta_scan.cpp
+index 4fb288d..074cfca 100644
+--- a/src/functions/delta_scan/delta_scan.cpp
++++ b/src/functions/delta_scan/delta_scan.cpp
+@@ -90,7 +90,7 @@ TableFunctionSet DeltaFunctions::GetDeltaScanFunction(ExtensionLoader &loader) {
+ 	auto &parquet_scan = loader.GetTableFunction("parquet_scan");
+ 	auto parquet_scan_copy = parquet_scan.functions;
+ 
+-	for (auto &function : parquet_scan_copy.functions) {
++	parquet_scan_copy.ApplyToFunctions([](TableFunction &function) {
+ 		// Register the MultiFileReader as the driver for reads
+ 		function.get_multi_file_reader = DeltaMultiFileReader::CreateInstance;
+ 
+@@ -116,7 +116,7 @@ TableFunctionSet DeltaFunctions::GetDeltaScanFunction(ExtensionLoader &loader) {
+ 		function.named_parameters["version"] = LogicalType::UBIGINT;
+ 
+ 		function.SetName("delta_scan");
+-	}
++	});
+ 
+ 	parquet_scan_copy.SetName("delta_scan");
+ 	return parquet_scan_copy;
+diff --git a/src/storage/delta_table_entry.cpp b/src/storage/delta_table_entry.cpp
+index 05e92d3..9fdc2f7 100644
+--- a/src/storage/delta_table_entry.cpp
++++ b/src/storage/delta_table_entry.cpp
+@@ -43,7 +43,8 @@ TableFunction DeltaTableEntry::GetScanFunctionInternal(ClientContext &context, u
+ 	}
+ 	auto &delta_function_set = catalog_entry->Cast<TableFunctionCatalogEntry>();
+ 
+-	auto delta_scan_function = delta_function_set.functions.GetFunctionByArguments(context, {LogicalType::VARCHAR});
++	// copied out of the set: the bind mutates function_info and needs a mutable function
++	auto delta_scan_function = *delta_function_set.functions.GetFunctionByArguments(context, {LogicalType::VARCHAR});
+ 	auto &delta_catalog = catalog.Cast<DeltaCatalog>();
+ 
+ 	auto &transaction = DeltaTransaction::Get(context, delta_catalog);
+diff --git a/src/storage/delta_transaction.cpp b/src/storage/delta_transaction.cpp
+index 07e7e88..37fbfe8 100644
+--- a/src/storage/delta_transaction.cpp
++++ b/src/storage/delta_transaction.cpp
+@@ -377,7 +377,7 @@ ffi::OptionalValue<ffi::Handle<ffi::ExclusiveRustString>> DeltaTransaction::Comm
+ 		}
+ 		// Special function that expects a 2-sized ANY datachunk containing the input on row 1 that will place the
+ 		// output on row 2
+-		transaction->commit_function->functions.functions[0].function(*current_context, data, output);
++		transaction->commit_function->functions.functions[0]->function(*current_context, data, output);
+ 
+ 		auto result = output.GetValue(1, 0);
+ 		if (result.IsNull()) {

--- a/.github/patches/extensions/ducklake/0009-function-set-shared-ptr.patch
+++ b/.github/patches/extensions/ducklake/0009-function-set-shared-ptr.patch
@@ -1,0 +1,26 @@
+diff --git a/src/common/parquet_file_scanner.cpp b/src/common/parquet_file_scanner.cpp
+index 91f49172..7dc26751 100644
+--- a/src/common/parquet_file_scanner.cpp
++++ b/src/common/parquet_file_scanner.cpp
+@@ -16,7 +16,7 @@ ParquetFileScanner::ParquetFileScanner(ClientContext &context, const DuckLakeFil
+ 	auto &instance = DatabaseInstance::GetDatabase(context);
+ 	ExtensionLoader loader(instance, "ducklake");
+ 	auto &parquet_scan_entry = loader.GetTableFunction("parquet_scan");
+-	parquet_scan = parquet_scan_entry.functions.functions[0];
++	parquet_scan = *parquet_scan_entry.functions.functions[0];
+ 
+ 	// Prepare the inputs for the bind
+ 	vector<Value> children;
+diff --git a/src/storage/ducklake_scan.cpp b/src/storage/ducklake_scan.cpp
+index 97730353..83c1a911 100644
+--- a/src/storage/ducklake_scan.cpp
++++ b/src/storage/ducklake_scan.cpp
+@@ -238,7 +238,7 @@ TableFunction DuckLakeFunctions::GetDuckLakeScanFunction(DatabaseInstance &insta
+ 	auto parquet_entry = loader.TryGetTableFunction("parquet_scan");
+ 	if (parquet_entry) {
+ 		auto &parquet_scan = parquet_entry->Cast<TableFunctionCatalogEntry>();
+-		function = parquet_scan.functions.GetFunctionByOffset(0);
++		function = *parquet_scan.functions.GetFunctionByOffset(0);
+ 		function.get_multi_file_reader = DuckLakeMultiFileReader::CreateInstance;
+ 	}
+ 

--- a/.github/patches/extensions/iceberg/0008-function-set-shared-ptr.patch
+++ b/.github/patches/extensions/iceberg/0008-function-set-shared-ptr.patch
@@ -1,0 +1,97 @@
+diff --git a/src/catalog/rest/catalog_entry/table/iceberg_table_entry.cpp b/src/catalog/rest/catalog_entry/table/iceberg_table_entry.cpp
+index 77410ba1..cc6274b7 100644
+--- a/src/catalog/rest/catalog_entry/table/iceberg_table_entry.cpp
++++ b/src/catalog/rest/catalog_entry/table/iceberg_table_entry.cpp
+@@ -54,7 +54,7 @@ TableFunction IcebergTableEntry::GetScanFunction(ClientContext &context, unique_
+ 	}
+ 	auto &iceberg_scan_function_set = catalog_entry->Cast<TableFunctionCatalogEntry>();
+ 	auto iceberg_scan_function =
+-	    iceberg_scan_function_set.functions.GetFunctionByArguments(context, {LogicalType::VARCHAR});
++	    *iceberg_scan_function_set.functions.GetFunctionByArguments(context, {LogicalType::VARCHAR});
+ 	PrepareIcebergScanFromEntry(context);
+ 
+ 	if (!schema_id.IsValid()) {
+diff --git a/src/function/scan/iceberg_scan.cpp b/src/function/scan/iceberg_scan.cpp
+index e4344d57..c2ab31fc 100644
+--- a/src/function/scan/iceberg_scan.cpp
++++ b/src/function/scan/iceberg_scan.cpp
+@@ -96,7 +96,7 @@ TableFunctionSet IcebergFunctions::GetIcebergScanFunction(ExtensionLoader &loade
+ 	auto &parquet_scan = loader.GetTableFunction("parquet_scan");
+ 	auto parquet_scan_copy = parquet_scan.functions;
+ 
+-	for (auto &function : parquet_scan_copy.functions) {
++	parquet_scan_copy.ApplyToFunctions([](TableFunction &function) {
+ 		// Register the MultiFileReader as the driver for reads
+ 		function.get_multi_file_reader = IcebergMultiFileReader::CreateInstance;
+ 		function.late_materialization = false;
+@@ -119,7 +119,7 @@ TableFunctionSet IcebergFunctions::GetIcebergScanFunction(ExtensionLoader &loade
+ 		AddNamedParameters(function);
+ 
+ 		function.SetName("iceberg_scan");
+-	}
++	});
+ 
+ 	parquet_scan_copy.SetName("iceberg_scan");
+ 	return parquet_scan_copy;
+diff --git a/src/include/planning/metadata_io/avro/avro_scan.hpp b/src/include/planning/metadata_io/avro/avro_scan.hpp
+index 55c9a255..1bedddf1 100644
+--- a/src/include/planning/metadata_io/avro/avro_scan.hpp
++++ b/src/include/planning/metadata_io/avro/avro_scan.hpp
+@@ -43,7 +43,7 @@ public:
+ 
+ public:
+ 	string path;
+-	optional_ptr<TableFunction> avro_scan;
++	optional_ptr<const TableFunction> avro_scan;
+ 	ClientContext &context;
+ 	unique_ptr<FunctionData> bind_data;
+ 	unique_ptr<GlobalTableFunctionState> global_state;
+diff --git a/src/planning/iceberg_multi_file_list.cpp b/src/planning/iceberg_multi_file_list.cpp
+index 8abe147a..9a2e0830 100644
+--- a/src/planning/iceberg_multi_file_list.cpp
++++ b/src/planning/iceberg_multi_file_list.cpp
+@@ -1559,7 +1559,8 @@ void IcebergMultiFileList::ScanDeleteFile(const BoundIcebergManifestEntry &bound
+ 	auto &data_file = manifest_entry.data_file;
+ 	auto delete_file_path = data_file.file_path;
+ 	auto iceberg_deletes_scan = IcebergFunctions::GetIcebergDeletesScanFunction(context);
+-	auto &delete_scan_function = iceberg_deletes_scan.functions[0];
++	// copied out of the local set: the bind mutates function_info and needs a mutable function
++	auto delete_scan_function = *iceberg_deletes_scan.functions[0];
+ 
+ 	if (options.allow_moved_paths) {
+ 		auto iceberg_path = GetPath();
+diff --git a/src/planning/metadata_io/avro/avro_scan.cpp b/src/planning/metadata_io/avro/avro_scan.cpp
+index 3f14d7e9..17ba5e56 100644
+--- a/src/planning/metadata_io/avro/avro_scan.cpp
++++ b/src/planning/metadata_io/avro/avro_scan.cpp
+@@ -33,7 +33,7 @@ AvroScan::AvroScan(const string &path, ClientContext &context, shared_ptr<Iceber
+ 		throw InvalidInputException("Function with name \"read_avro\" not found!");
+ 	}
+ 	auto &avro_scan_entry = catalog_entry->Cast<TableFunctionCatalogEntry>();
+-	avro_scan = avro_scan_entry.functions.functions[0];
++	avro_scan = *avro_scan_entry.functions.functions[0];
+ 
+ 	vector<Value> children;
+ 	children.reserve(1);
+diff --git a/src/planning/metadata_io/deletes/iceberg_deletes_file_reader.cpp b/src/planning/metadata_io/deletes/iceberg_deletes_file_reader.cpp
+index 49c1d280..c855b90b 100644
+--- a/src/planning/metadata_io/deletes/iceberg_deletes_file_reader.cpp
++++ b/src/planning/metadata_io/deletes/iceberg_deletes_file_reader.cpp
+@@ -42,7 +42,7 @@ TableFunctionSet IcebergFunctions::GetIcebergDeletesScanFunction(ClientContext &
+ 	auto &parquet_scan = catalog_entry->Cast<TableFunctionCatalogEntry>();
+ 	auto parquet_scan_copy = parquet_scan.functions;
+ 
+-	for (auto &function : parquet_scan_copy.functions) {
++	parquet_scan_copy.ApplyToFunctions([](TableFunction &function) {
+ 		// Register the MultiFileReader as the driver for reads
+ 		function.get_multi_file_reader = IcebergDeleteFileReader::CreateInstance;
+ 		function.late_materialization = false;
+@@ -60,7 +60,7 @@ TableFunctionSet IcebergFunctions::GetIcebergDeletesScanFunction(ClientContext &
+ 		// Schema param is just confusing here
+ 		function.named_parameters.erase("schema");
+ 		function.SetName("iceberg_deletes_scan");
+-	}
++	});
+ 
+ 	parquet_scan_copy.SetName("iceberg_deletes_scan");
+ 	return parquet_scan_copy;

--- a/.github/patches/extensions/spatial/0007-function-set-shared-ptr.patch
+++ b/.github/patches/extensions/spatial/0007-function-set-shared-ptr.patch
@@ -1,0 +1,116 @@
+diff --git a/src/spatial/index/rtree/rtree_index.cpp b/src/spatial/index/rtree/rtree_index.cpp
+index f793b05..7469bcd 100644
+--- a/src/spatial/index/rtree/rtree_index.cpp
++++ b/src/spatial/index/rtree/rtree_index.cpp
+@@ -114,7 +114,7 @@ RTreeIndex::RTreeIndex(const Identifier &name, IndexConstraintType index_constra
+ 	auto &catalog = Catalog::GetSystemCatalog(context);
+ 	auto &entry = catalog.GetEntry<ScalarFunctionCatalogEntry>(
+ 	    context, QualifiedName(catalog.GetName(), Identifier::DefaultSchema(), "ST_Extent_Approx"));
+-	const auto &func = entry.functions.GetFunctionByArguments(context, {source_type});
++	const auto &func = *entry.functions.GetFunctionByArguments(context, {source_type});
+ 	auto child_expr = make_uniq<BoundReferenceExpression>(source_type, 0);
+ 
+ 	vector<unique_ptr<Expression>> children;
+diff --git a/src/spatial/index/rtree/rtree_index_create_logical.cpp b/src/spatial/index/rtree/rtree_index_create_logical.cpp
+index 5a9df4e..de6b9de 100644
+--- a/src/spatial/index/rtree/rtree_index_create_logical.cpp
++++ b/src/spatial/index/rtree/rtree_index_create_logical.cpp
+@@ -55,7 +55,7 @@ static PhysicalOperator &CreateNullFilter(PhysicalPlanGenerator &generator, cons
+ 	auto &is_empty_entry = catalog.GetEntry(context, CatalogType::SCALAR_FUNCTION_ENTRY, Identifier::DefaultSchema(), "ST_IsEmpty")
+ 	                           .Cast<ScalarFunctionCatalogEntry>();
+ 
+-	auto is_empty_func = is_empty_entry.functions.GetFunctionByArguments(context, {LogicalType::GEOMETRY()});
++	auto is_empty_func = *is_empty_entry.functions.GetFunctionByArguments(context, {LogicalType::GEOMETRY()});
+ 	vector<unique_ptr<Expression>> is_empty_args;
+ 	is_empty_args.push_back(std::move(bound_ref));
+ 	auto is_empty_expr = is_empty_func.Bind(context, std::move(is_empty_args));
+@@ -79,7 +79,7 @@ static PhysicalOperator &CreateBoundingBoxProjection(PhysicalPlanGenerator &plan
+ 	auto &bbox_func_entry =
+ 	    catalog.GetEntry(context, CatalogType::SCALAR_FUNCTION_ENTRY, Identifier::DefaultSchema(), "ST_Extent_Approx")
+ 	        .Cast<ScalarFunctionCatalogEntry>();
+-	const auto &bbox_func = bbox_func_entry.functions.GetFunctionByArguments(context, {LogicalType::GEOMETRY()});
++	const auto &bbox_func = *bbox_func_entry.functions.GetFunctionByArguments(context, {LogicalType::GEOMETRY()});
+ 
+ 	auto geom_ref_expr = make_uniq_base<Expression, BoundReferenceExpression>(LogicalType::GEOMETRY(), 0);
+ 	vector<unique_ptr<Expression>> bbox_args;
+@@ -105,7 +105,7 @@ static PhysicalOperator &CreateOrderByMinX(PhysicalPlanGenerator &planner, const
+ 	auto &centroid_func_entry =
+ 	    catalog.GetEntry(context, CatalogType::SCALAR_FUNCTION_ENTRY, Identifier::DefaultSchema(), "st_centroid")
+ 	        .Cast<ScalarFunctionCatalogEntry>();
+-	const auto &centroid_func = centroid_func_entry.functions.GetFunctionByArguments(context, {GeoTypes::BOX_2DF()});
++	const auto &centroid_func = *centroid_func_entry.functions.GetFunctionByArguments(context, {GeoTypes::BOX_2DF()});
+ 	vector<unique_ptr<Expression>> centroid_func_args;
+ 
+ 	// Reference the geometry column
+@@ -117,7 +117,7 @@ static PhysicalOperator &CreateOrderByMinX(PhysicalPlanGenerator &planner, const
+ 	// Get the xmin value function
+ 	auto &xmin_func_entry = catalog.GetEntry(context, CatalogType::SCALAR_FUNCTION_ENTRY, Identifier::DefaultSchema(), "st_xmin")
+ 	                            .Cast<ScalarFunctionCatalogEntry>();
+-	const auto &xmin_func = xmin_func_entry.functions.GetFunctionByArguments(context, {GeoTypes::POINT_2D()});
++	const auto &xmin_func = *xmin_func_entry.functions.GetFunctionByArguments(context, {GeoTypes::POINT_2D()});
+ 	vector<unique_ptr<Expression>> xmin_func_args;
+ 
+ 	// Reference the centroid
+diff --git a/src/spatial/index/rtree/rtree_index_plan_scan.cpp b/src/spatial/index/rtree/rtree_index_plan_scan.cpp
+index 34e1a1c..73063da 100644
+--- a/src/spatial/index/rtree/rtree_index_plan_scan.cpp
++++ b/src/spatial/index/rtree/rtree_index_plan_scan.cpp
+@@ -122,7 +122,7 @@ public:
+ 		auto &catalog = Catalog::GetSystemCatalog(context);
+ 		auto &entry = catalog.GetEntry<ScalarFunctionCatalogEntry>(
+ 		    context, QualifiedName(catalog.GetName(), Identifier::DefaultSchema(), "ST_Extent_Approx"));
+-		const auto &func = entry.functions.GetFunctionByArguments(context, {LogicalType::GEOMETRY()});
++		const auto &func = *entry.functions.GetFunctionByArguments(context, {LogicalType::GEOMETRY()});
+ 
+ 		vector<unique_ptr<Expression>> children;
+ 		children.push_back(expr.Copy());
+diff --git a/src/spatial/operators/spatial_join_optimizer.cpp b/src/spatial/operators/spatial_join_optimizer.cpp
+index 9f6e6dc..8e6bac9 100644
+--- a/src/spatial/operators/spatial_join_optimizer.cpp
++++ b/src/spatial/operators/spatial_join_optimizer.cpp
+@@ -71,7 +71,7 @@ static unique_ptr<Expression> GetInversePredicate(ClientContext &context, unique
+ 	auto &catalog = Catalog::GetSystemCatalog(context);
+ 	auto &entry = catalog.GetEntry<ScalarFunctionCatalogEntry>(
+ 	    context, QualifiedName(catalog.GetName(), Identifier::DefaultSchema(), Identifier(it->second)));
+-	const auto &inverse_func = entry.functions.GetFunctionByArguments(
++	const auto &inverse_func = *entry.functions.GetFunctionByArguments(
+ 	    context, {func.GetChildren()[0]->GetReturnType(), func.GetChildren()[1]->GetReturnType()});
+ 
+ 	auto func_expr = inverse_func.Bind(context, std::move(func.GetChildrenMutable()));
+diff --git a/src/spatial/operators/spatial_join_physical.cpp b/src/spatial/operators/spatial_join_physical.cpp
+index d433e64..5fab1fc 100644
+--- a/src/spatial/operators/spatial_join_physical.cpp
++++ b/src/spatial/operators/spatial_join_physical.cpp
+@@ -389,7 +389,7 @@ static unique_ptr<Expression> GetBBOXExpression(ClientContext &context, const Lo
+ 	auto &catalog = Catalog::GetSystemCatalog(context);
+ 	auto &entry = catalog.GetEntry<ScalarFunctionCatalogEntry>(
+ 	    context, QualifiedName(catalog.GetName(), Identifier::DefaultSchema(), "ST_Extent_Approx"));
+-	const auto &func = entry.functions.GetFunctionByArguments(context, {geom_type});
++	const auto &func = *entry.functions.GetFunctionByArguments(context, {geom_type});
+ 
+ 	auto child_expr = make_uniq<BoundReferenceExpression>(geom_type, 0);
+ 	vector<unique_ptr<Expression>> children;
+@@ -550,7 +550,7 @@ public:
+ 		auto &catalog = Catalog::GetSystemCatalog(context);
+ 		auto &entry = catalog.GetEntry<ScalarFunctionCatalogEntry>(
+ 		    context, QualifiedName(catalog.GetName(), Identifier::DefaultSchema(), "ST_IsEmpty"));
+-		const auto &func = entry.functions.GetFunctionByArguments(context, {geom_type});
++		const auto &func = *entry.functions.GetFunctionByArguments(context, {geom_type});
+ 
+ 		vector<unique_ptr<Expression>> children;
+ 		children.push_back(make_uniq_base<Expression, BoundReferenceExpression>(geom_type, 0));
+diff --git a/src/spatial/util/function_builder.hpp b/src/spatial/util/function_builder.hpp
+index 5057774..ce92029 100644
+--- a/src/spatial/util/function_builder.hpp
++++ b/src/spatial/util/function_builder.hpp
+@@ -225,9 +225,7 @@ inline void AggregateFunctionBuilder::SetTag(const string &key, const string &va
+ }
+ 
+ inline void AggregateFunctionBuilder::CanThrowErrors() {
+-	for (auto &function : set.functions) {
+-		function.SetFallible();
+-	}
++	set.ApplyToFunctions([](AggregateFunction &function) { function.SetFallible(); });
+ }
+ 
+ //------------------------------------------------------------------------------

--- a/.github/patches/extensions/sqlsmith/0012-function-set-shared-ptr.patch
+++ b/.github/patches/extensions/sqlsmith/0012-function-set-shared-ptr.patch
@@ -1,0 +1,49 @@
+diff --git a/src/statement_generator.cpp b/src/statement_generator.cpp
+index 8a975db..4116420 100644
+--- a/src/statement_generator.cpp
++++ b/src/statement_generator.cpp
+@@ -566,7 +566,7 @@ unique_ptr<TableRef> StatementGenerator::GenerateTableFunctionRef() {
+ 		table_function_ref = &generator_context->table_functions[random_val];
+ 	}
+ 	auto &entry = table_function_ref->get().Cast<TableFunctionCatalogEntry>();
+-	auto table_function = entry.functions.GetFunctionByOffset(RandomValue(entry.functions.Size()));
++	auto table_function = *entry.functions.GetFunctionByOffset(RandomValue(entry.functions.Size()));
+ 
+ 	auto result = make_uniq<TableFunctionRef>();
+ 	vector<unique_ptr<ParsedExpression>> children;
+@@ -765,7 +765,7 @@ unique_ptr<ParsedExpression> StatementGenerator::GenerateFunction() {
+ 	case CatalogType::SCALAR_FUNCTION_ENTRY: {
+ 		auto &scalar_entry = function.Cast<ScalarFunctionCatalogEntry>();
+ 		auto offset = RandomValue(scalar_entry.functions.Size());
+-		auto actual_function = scalar_entry.functions.GetFunctionByOffset(offset);
++		auto actual_function = *scalar_entry.functions.GetFunctionByOffset(offset);
+ 		name = scalar_entry.name.GetIdentifierName();
+ 		for (auto &arg : actual_function.GetSignature().GetParameters()) {
+ 			arguments.push_back(arg.GetType());
+@@ -780,7 +780,7 @@ unique_ptr<ParsedExpression> StatementGenerator::GenerateFunction() {
+ 	case CatalogType::AGGREGATE_FUNCTION_ENTRY: {
+ 		auto &aggregate_entry = function.Cast<AggregateFunctionCatalogEntry>();
+ 		auto actual_function =
+-		    aggregate_entry.functions.GetFunctionByOffset(RandomValue(aggregate_entry.functions.Size()));
++		    *aggregate_entry.functions.GetFunctionByOffset(RandomValue(aggregate_entry.functions.Size()));
+ 
+ 		name = aggregate_entry.name.GetIdentifierName();
+ 		min_parameters = actual_function.GetSignature().GetParameterCount();
+@@ -1379,7 +1379,7 @@ string StatementGenerator::GenerateCast(const LogicalType &target, const string
+ 
+ void StatementGenerator::GenerateAllScalar(ScalarFunctionCatalogEntry &scalar_function, vector<string> &result) {
+ 	for (idx_t offset = 0; offset < scalar_function.functions.Size(); offset++) {
+-		auto function = scalar_function.functions.GetFunctionByOffset(offset);
++		auto function = *scalar_function.functions.GetFunctionByOffset(offset);
+ 
+ 		result.push_back(GenerateTestAllTypes(function));
+ 		result.push_back(GenerateTestVectorTypes(function));
+@@ -1389,7 +1389,7 @@ void StatementGenerator::GenerateAllScalar(ScalarFunctionCatalogEntry &scalar_fu
+ void StatementGenerator::GenerateAllAggregate(AggregateFunctionCatalogEntry &aggregate_function,
+                                               vector<string> &result) {
+ 	for (idx_t offset = 0; offset < aggregate_function.functions.Size(); offset++) {
+-		auto function = aggregate_function.functions.GetFunctionByOffset(offset);
++		auto function = *aggregate_function.functions.GetFunctionByOffset(offset);
+ 
+ 		result.push_back(GenerateTestAllTypes(function));
+ 		result.push_back(GenerateTestVectorTypes(function));

--- a/.github/patches/extensions/vss/zzzzzzzzz-function-set-shared-ptr.patch
+++ b/.github/patches/extensions/vss/zzzzzzzzz-function-set-shared-ptr.patch
@@ -1,0 +1,26 @@
+diff --git a/src/hnsw/hnsw_optimize_expr.cpp b/src/hnsw/hnsw_optimize_expr.cpp
+index e519d60..8473c7e 100644
+--- a/src/hnsw/hnsw_optimize_expr.cpp
++++ b/src/hnsw/hnsw_optimize_expr.cpp
+@@ -65,7 +65,7 @@ unique_ptr<Expression> CosineDistanceRule::Apply(LogicalOperator &op, vector<ref
+ 		}
+ 
+ 		changes_made = true;
+-		const auto &func = func_entry->functions.GetFunctionByArguments(context, arg_types);
++		const auto &func = *func_entry->functions.GetFunctionByArguments(context, arg_types);
+ 		return func.Bind(context, std::move(args));
+ 	}
+ 	return nullptr;
+diff --git a/src/hnsw/hnsw_optimize_topk.cpp b/src/hnsw/hnsw_optimize_topk.cpp
+index 79a5e6a..280b399 100644
+--- a/src/hnsw/hnsw_optimize_topk.cpp
++++ b/src/hnsw/hnsw_optimize_topk.cpp
+@@ -33,7 +33,7 @@ static unique_ptr<Expression> CreateListOrderByExpr(ClientContext &context, uniq
+ 		return nullptr;
+ 	}
+ 
+-	const auto &func = func_entry->functions.GetFunctionByOffset(0);
++	const auto &func = *func_entry->functions.GetFunctionByOffset(0);
+ 	vector<unique_ptr<Expression>> arguments;
+ 	arguments.push_back(std::move(elem_expr));
+ 

--- a/extension/core_functions/scalar/array/array_functions.cpp
+++ b/extension/core_functions/scalar/array/array_functions.cpp
@@ -307,9 +307,7 @@ ScalarFunctionSet ArrayCrossProductFun::GetFunctions() {
 	    ScalarFunction({float_array, float_array}, float_array, ArrayFixedCombine<float, CrossProductOp, 3>));
 	set.AddFunction(
 	    ScalarFunction({double_array, double_array}, double_array, ArrayFixedCombine<double, CrossProductOp, 3>));
-	for (auto &func : set.functions) {
-		func.SetFallible();
-	}
+	set.SetFallible();
 	return set;
 }
 

--- a/extension/core_functions/scalar/bit/bitstring.cpp
+++ b/extension/core_functions/scalar/bit/bitstring.cpp
@@ -42,9 +42,7 @@ ScalarFunctionSet BitStringFun::GetFunctions() {
 	    ScalarFunction({LogicalType::VARCHAR, LogicalType::INTEGER}, LogicalType::BIT, BitStringFunction<true>));
 	bitstring.AddFunction(
 	    ScalarFunction({LogicalType::BIT, LogicalType::INTEGER}, LogicalType::BIT, BitStringFunction<false>));
-	for (auto &func : bitstring.functions) {
-		func.SetFallible();
-	}
+	bitstring.SetFallible();
 	return bitstring;
 }
 

--- a/extension/core_functions/scalar/date/date_part.cpp
+++ b/extension/core_functions/scalar/date/date_part.cpp
@@ -2050,9 +2050,7 @@ ScalarFunctionSet GetGenericDatePartFunction(scalar_function_t date_func, scalar
 	operator_set.AddFunction(ScalarFunction({LogicalType::TIMESTAMP}, LogicalType::BIGINT, std::move(ts_func), nullptr,
 	                                        ts_stats, DATE_CACHE));
 	operator_set.AddFunction(ScalarFunction({LogicalType::INTERVAL}, LogicalType::BIGINT, std::move(interval_func)));
-	for (auto &func : operator_set.functions) {
-		func.SetFallible();
-	}
+	operator_set.SetFallible();
 	return operator_set;
 }
 
@@ -2343,9 +2341,7 @@ ScalarFunctionSet QuarterFun::GetFunctions() {
 
 ScalarFunctionSet DayOfWeekFun::GetFunctions() {
 	auto set = GetDatePartFunction<DatePart::DayOfWeekOperator>();
-	for (auto &func : set.functions) {
-		func.SetFallible();
-	}
+	set.SetFallible();
 	return set;
 }
 
@@ -2382,9 +2378,7 @@ ScalarFunctionSet TimezoneFun::GetFunctions() {
 
 	operator_set.AddFunction(function);
 
-	for (auto &func : operator_set.functions) {
-		func.SetFallible();
-	}
+	operator_set.SetFallible();
 
 	return operator_set;
 }
@@ -2417,9 +2411,7 @@ ScalarFunctionSet EpochNsFun::GetFunctions() {
 	operator_set.AddFunction(ScalarFunction({LogicalType::TIMESTAMP_TZ_NS}, LogicalType::BIGINT, tsns_func));
 	operator_set.SetUnaryArgProperties(ArgProperties().NonDecreasing());
 	// these overflow at the representable extremes, so the failure must be reportable
-	for (auto &func : operator_set.functions) {
-		func.SetFallible();
-	}
+	operator_set.SetFallible();
 	return operator_set;
 }
 
@@ -2434,9 +2426,7 @@ ScalarFunctionSet EpochUsFun::GetFunctions() {
 	    ScalarFunction({LogicalType::TIMESTAMP_TZ}, LogicalType::BIGINT, tstz_func, nullptr, tstz_stats));
 	operator_set.SetUnaryArgProperties(ArgProperties().NonDecreasing());
 	// these overflow at the representable extremes, so the failure must be reportable
-	for (auto &func : operator_set.functions) {
-		func.SetFallible();
-	}
+	operator_set.SetFallible();
 	return operator_set;
 }
 
@@ -2456,9 +2446,7 @@ ScalarFunctionSet EpochMsFun::GetFunctions() {
 
 	operator_set.SetUnaryArgProperties(ArgProperties().NonDecreasing());
 	// these overflow at the representable extremes, so the failure must be reportable
-	for (auto &func : operator_set.functions) {
-		func.SetFallible();
-	}
+	operator_set.SetFallible();
 	return operator_set;
 }
 
@@ -2468,9 +2456,7 @@ ScalarFunctionSet MakeTimestampMsFun::GetFunctions() {
 	    ScalarFunction({LogicalType::BIGINT}, LogicalType::TIMESTAMP, DatePart::EpochMillisOperator::Inverse));
 	operator_set.SetUnaryArgProperties(ArgProperties().NonDecreasing());
 	// these overflow at the representable extremes, so the failure must be reportable
-	for (auto &func : operator_set.functions) {
-		func.SetFallible();
-	}
+	operator_set.SetFallible();
 	return operator_set;
 }
 
@@ -2595,9 +2581,7 @@ ScalarFunctionSet DatePartFun::GetFunctions() {
 	date_part.AddFunction(StructDatePart::GetFunction<interval_t>(LogicalType::INTERVAL));
 	date_part.AddFunction(StructDatePart::GetFunction<dtime_tz_t>(LogicalType::TIME_TZ));
 
-	for (auto &func : date_part.functions) {
-		func.SetFallible();
-	}
+	date_part.SetFallible();
 
 	return date_part;
 }

--- a/extension/core_functions/scalar/date/date_trunc.cpp
+++ b/extension/core_functions/scalar/date/date_trunc.cpp
@@ -590,10 +590,10 @@ ScalarFunctionSet DateTruncFun::GetFunctions() {
 	                                      DateTruncFunction<date_t, timestamp_t>, DateTruncBind));
 	date_trunc.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::INTERVAL}, LogicalType::INTERVAL,
 	                                      DateTruncFunction<interval_t, interval_t>));
-	for (auto &func : date_trunc.functions) {
+	date_trunc.ApplyToFunctions([](ScalarFunction &func) {
 		func.SetFallible();
 		func.SetArgProperties(1, ArgProperties().NonDecreasing());
-	}
+	});
 	return date_trunc;
 }
 

--- a/extension/core_functions/scalar/date/make_date.cpp
+++ b/extension/core_functions/scalar/date/make_date.cpp
@@ -152,10 +152,10 @@ ScalarFunctionSet MakeDateFun::GetFunctions() {
 	    {"year", LogicalType::BIGINT}, {"month", LogicalType::BIGINT}, {"day", LogicalType::BIGINT}};
 	make_date.AddFunction(
 	    ScalarFunction({LogicalType::STRUCT(make_date_children)}, LogicalType::DATE, ExecuteStructMakeDate<int64_t>));
-	for (auto &func : make_date.functions) {
+	make_date.ApplyToFunctions([](ScalarFunction &func) {
 		func.SetFallible();
 		func.SetUnaryArgProperties(ArgProperties().StrictlyIncreasing());
-	}
+	});
 	return make_date;
 }
 
@@ -174,10 +174,10 @@ ScalarFunctionSet MakeTimestampFun::GetFunctions() {
 	operator_set.AddFunction(
 	    ScalarFunction({LogicalType::BIGINT}, LogicalType::TIMESTAMP, ExecuteMakeTimestamp<int64_t>));
 
-	for (auto &func : operator_set.functions) {
+	operator_set.ApplyToFunctions([](ScalarFunction &func) {
 		func.SetFallible();
 		func.SetUnaryArgProperties(ArgProperties().StrictlyIncreasing());
-	}
+	});
 	return operator_set;
 }
 

--- a/extension/core_functions/scalar/date/time_bucket.cpp
+++ b/extension/core_functions/scalar/date/time_bucket.cpp
@@ -401,9 +401,8 @@ ScalarFunctionSet TimeBucketFun::GetFunctions() {
 	time_bucket.AddFunction(ScalarFunction({LogicalType::INTERVAL, LogicalType::TIMESTAMP, LogicalType::TIMESTAMP},
 	                                       LogicalType::TIMESTAMP, TimeBucketOriginFunction<timestamp_t>));
 
-	for (auto &func : time_bucket.functions) {
-		func.SetArgProperties(1, ArgProperties().NonDecreasing());
-	}
+	time_bucket.ApplyToFunctions(
+	    [](ScalarFunction &func) { func.SetArgProperties(1, ArgProperties().NonDecreasing()); });
 
 	//	Not monotonic (wraps)
 	time_bucket.AddFunction(
@@ -413,9 +412,7 @@ ScalarFunctionSet TimeBucketFun::GetFunctions() {
 	time_bucket.AddFunction(ScalarFunction({LogicalType::INTERVAL, LogicalType::TIME, LogicalType::TIME},
 	                                       LogicalType::TIME, TimeBucketOriginFunction<dtime_t>));
 
-	for (auto &func : time_bucket.functions) {
-		func.SetFallible();
-	}
+	time_bucket.SetFallible();
 
 	return time_bucket;
 }

--- a/extension/core_functions/scalar/date/to_interval.cpp
+++ b/extension/core_functions/scalar/date/to_interval.cpp
@@ -182,9 +182,7 @@ ScalarFunctionSet GetIntegerIntervalFunctions() {
 	                                        ScalarFunction::UnaryFunction<int32_t, interval_t, OP>));
 	function_set.AddFunction(ScalarFunction({LogicalType::BIGINT}, LogicalType::INTERVAL,
 	                                        ScalarFunction::UnaryFunction<int64_t, interval_t, OP>));
-	for (auto &func : function_set.functions) {
-		func.SetFallible();
-	}
+	function_set.SetFallible();
 	return function_set;
 }
 

--- a/extension/core_functions/scalar/generic/binning.cpp
+++ b/extension/core_functions/scalar/generic/binning.cpp
@@ -502,11 +502,11 @@ ScalarFunctionSet EquiWidthBinsFun::GetFunctions() {
 	    ScalarFunction({LogicalType::ANY_PARAMS(LogicalType::ANY, 150), LogicalType::ANY_PARAMS(LogicalType::ANY, 150),
 	                    LogicalType::BIGINT, LogicalType::BOOLEAN},
 	                   LogicalType::LIST(LogicalType::ANY), UnsupportedEquiWidth, BindEquiWidthFunction));
-	for (auto &function : functions.functions) {
+	functions.ApplyToFunctions([](ScalarFunction &function) {
 		function.SetSerializeCallback(EquiWidthBinSerialize);
 		function.SetDeserializeCallback(EquiWidthBinDeserialize);
 		function.SetFallible();
-	}
+	});
 	return functions;
 }
 

--- a/extension/core_functions/scalar/list/list_aggregates.cpp
+++ b/extension/core_functions/scalar/list/list_aggregates.cpp
@@ -492,7 +492,7 @@ unique_ptr<FunctionData> ListAggregatesBind(BindScalarFunctionInput &input) {
 	}
 
 	// found a matching function, bind it as an aggregate
-	const auto &best_function = func.functions.GetFunctionByOffset(best_function_idx.GetIndex());
+	const auto &best_function = *func.functions.GetFunctionByOffset(best_function_idx.GetIndex());
 	if (IS_AGGR) {
 		if (best_function.GetErrorMode() == FunctionErrors::CAN_THROW_RUNTIME_ERROR) {
 			// never clear the error mode here - executing the aggregate can throw regardless of how it is declared

--- a/extension/core_functions/scalar/list/list_distance.cpp
+++ b/extension/core_functions/scalar/list/list_distance.cpp
@@ -80,9 +80,7 @@ ScalarFunctionSet ListDistanceFun::GetFunctions() {
 	for (auto &type : LogicalType::Real()) {
 		AddListFoldFunction<DistanceOp>(set, type);
 	}
-	for (auto &func : set.functions) {
-		func.SetFallible();
-	}
+	set.SetFallible();
 	return set;
 }
 
@@ -91,9 +89,7 @@ ScalarFunctionSet ListInnerProductFun::GetFunctions() {
 	for (auto &type : LogicalType::Real()) {
 		AddListFoldFunction<InnerProductOp>(set, type);
 	}
-	for (auto &func : set.functions) {
-		func.SetFallible();
-	}
+	set.SetFallible();
 	return set;
 }
 
@@ -102,9 +98,7 @@ ScalarFunctionSet ListNegativeInnerProductFun::GetFunctions() {
 	for (auto &type : LogicalType::Real()) {
 		AddListFoldFunction<NegativeInnerProductOp>(set, type);
 	}
-	for (auto &func : set.functions) {
-		func.SetFallible();
-	}
+	set.SetFallible();
 	return set;
 }
 
@@ -113,9 +107,7 @@ ScalarFunctionSet ListCosineSimilarityFun::GetFunctions() {
 	for (auto &type : LogicalType::Real()) {
 		AddListFoldFunction<CosineSimilarityOp>(set, type);
 	}
-	for (auto &func : set.functions) {
-		func.SetFallible();
-	}
+	set.SetFallible();
 	return set;
 }
 
@@ -124,9 +116,7 @@ ScalarFunctionSet ListCosineDistanceFun::GetFunctions() {
 	for (auto &type : LogicalType::Real()) {
 		AddListFoldFunction<CosineDistanceOp>(set, type);
 	}
-	for (auto &func : set.functions) {
-		func.SetFallible();
-	}
+	set.SetFallible();
 	return set;
 }
 

--- a/extension/core_functions/scalar/list/range.cpp
+++ b/extension/core_functions/scalar/list/range.cpp
@@ -232,9 +232,7 @@ ScalarFunctionSet ListRangeFun::GetFunctions() {
 	range_set.AddFunction(ScalarFunction({LogicalType::TIMESTAMP, LogicalType::TIMESTAMP, LogicalType::INTERVAL},
 	                                     LogicalType::LIST(LogicalType::TIMESTAMP),
 	                                     ListRangeFunction<TimestampRangeInfo, false>));
-	for (auto &func : range_set.functions) {
-		func.SetFallible();
-	}
+	range_set.SetFallible();
 	return range_set;
 }
 
@@ -251,9 +249,7 @@ ScalarFunctionSet GenerateSeriesFun::GetFunctions() {
 	generate_series.AddFunction(ScalarFunction({LogicalType::TIMESTAMP, LogicalType::TIMESTAMP, LogicalType::INTERVAL},
 	                                           LogicalType::LIST(LogicalType::TIMESTAMP),
 	                                           ListRangeFunction<TimestampRangeInfo, true>));
-	for (auto &func : generate_series.functions) {
-		func.SetFallible();
-	}
+	generate_series.SetFallible();
 	return generate_series;
 }
 

--- a/extension/core_functions/scalar/math/numeric.cpp
+++ b/extension/core_functions/scalar/math/numeric.cpp
@@ -265,9 +265,7 @@ ScalarFunctionSet AbsOperatorFun::GetFunctions() {
 			break;
 		}
 	}
-	for (auto &func : abs.functions) {
-		func.SetFallible();
-	}
+	abs.SetFallible();
 	return abs;
 }
 
@@ -1365,9 +1363,7 @@ ScalarFunctionSet LogFun::GetFunctions() {
 	funcs.AddFunction(std::move(log10));
 	funcs.AddFunction(ScalarFunction({LogicalType::DOUBLE, LogicalType::DOUBLE}, LogicalType::DOUBLE, nullptr,
 	                                 BindIEEEFloatingBinary<LogBaseOperator, IEEELogBaseOperator>));
-	for (auto &function : funcs.functions) {
-		function.SetFallible();
-	}
+	funcs.SetFallible();
 	return funcs;
 }
 
@@ -2093,9 +2089,7 @@ ScalarFunctionSet GreatestCommonDivisorFun::GetFunctions() {
 	    ScalarFunction({LogicalType::HUGEINT, LogicalType::HUGEINT}, LogicalType::HUGEINT,
 	                   ScalarFunction::BinaryFunction<hugeint_t, hugeint_t, hugeint_t, GreatestCommonDivisorOperator>));
 	// negating the minimum value overflows, so the failure must be reportable
-	for (auto &func : funcs.functions) {
-		func.SetFallible();
-	}
+	funcs.SetFallible();
 	return funcs;
 }
 
@@ -2129,9 +2123,7 @@ ScalarFunctionSet LeastCommonMultipleFun::GetFunctions() {
 	funcs.AddFunction(
 	    ScalarFunction({LogicalType::HUGEINT, LogicalType::HUGEINT}, LogicalType::HUGEINT,
 	                   ScalarFunction::BinaryFunction<hugeint_t, hugeint_t, hugeint_t, LeastCommonMultipleOperator>));
-	for (auto &function : funcs.functions) {
-		function.SetFallible();
-	}
+	funcs.SetFallible();
 	return funcs;
 }
 

--- a/extension/core_functions/scalar/operators/bitwise.cpp
+++ b/extension/core_functions/scalar/operators/bitwise.cpp
@@ -116,9 +116,7 @@ ScalarFunctionSet BitwiseAndFun::GetFunctions() {
 		    ScalarFunction({type, type}, type, GetScalarIntegerBinaryFunction<BitwiseANDOperator>(type)));
 	}
 	functions.AddFunction(ScalarFunction({LogicalType::BIT, LogicalType::BIT}, LogicalType::BIT, BitwiseANDOperation));
-	for (auto &function : functions.functions) {
-		function.SetFallible();
-	}
+	functions.SetFallible();
 	return functions;
 }
 
@@ -154,9 +152,7 @@ ScalarFunctionSet BitwiseOrFun::GetFunctions() {
 		    ScalarFunction({type, type}, type, GetScalarIntegerBinaryFunction<BitwiseOROperator>(type)));
 	}
 	functions.AddFunction(ScalarFunction({LogicalType::BIT, LogicalType::BIT}, LogicalType::BIT, BitwiseOROperation));
-	for (auto &function : functions.functions) {
-		function.SetFallible();
-	}
+	functions.SetFallible();
 	return functions;
 }
 
@@ -192,9 +188,7 @@ ScalarFunctionSet BitwiseXorFun::GetFunctions() {
 		    ScalarFunction({type, type}, type, GetScalarIntegerBinaryFunction<BitwiseXOROperator>(type)));
 	}
 	functions.AddFunction(ScalarFunction({LogicalType::BIT, LogicalType::BIT}, LogicalType::BIT, BitwiseXOROperation));
-	for (auto &function : functions.functions) {
-		function.SetFallible();
-	}
+	functions.SetFallible();
 	return functions;
 }
 
@@ -228,9 +222,7 @@ ScalarFunctionSet BitwiseNotFun::GetFunctions() {
 		functions.AddFunction(ScalarFunction({type}, type, GetScalarIntegerUnaryFunction<BitwiseNotOperator>(type)));
 	}
 	functions.AddFunction(ScalarFunction({LogicalType::BIT}, LogicalType::BIT, BitwiseNOTOperation));
-	for (auto &function : functions.functions) {
-		function.SetFallible();
-	}
+	functions.SetFallible();
 	return functions;
 }
 
@@ -300,9 +292,7 @@ ScalarFunctionSet LeftShiftFun::GetFunctions() {
 	}
 	functions.AddFunction(
 	    ScalarFunction({LogicalType::BIT, LogicalType::INTEGER}, LogicalType::BIT, BitwiseShiftLeftOperation));
-	for (auto &function : functions.functions) {
-		function.SetFallible();
-	}
+	functions.SetFallible();
 	return functions;
 }
 
@@ -350,9 +340,7 @@ ScalarFunctionSet RightShiftFun::GetFunctions() {
 	}
 	functions.AddFunction(
 	    ScalarFunction({LogicalType::BIT, LogicalType::INTEGER}, LogicalType::BIT, BitwiseShiftRightOperation));
-	for (auto &function : functions.functions) {
-		function.SetFallible();
-	}
+	functions.SetFallible();
 	return functions;
 }
 

--- a/extension/core_functions/scalar/string/repeat.cpp
+++ b/extension/core_functions/scalar/string/repeat.cpp
@@ -77,9 +77,7 @@ ScalarFunctionSet RepeatFun::GetFunctions() {
 	}
 	repeat.AddFunction(ScalarFunction({LogicalType::LIST(LogicalType::TEMPLATE("T")), LogicalType::BIGINT},
 	                                  LogicalType::LIST(LogicalType::TEMPLATE("T")), RepeatListFunction));
-	for (auto &func : repeat.functions) {
-		func.SetFallible();
-	}
+	repeat.SetFallible();
 	return repeat;
 }
 

--- a/extension/icu/icu-datepart.cpp
+++ b/extension/icu/icu-datepart.cpp
@@ -599,9 +599,7 @@ struct ICUDatePart : public ICUDateFunc {
 		ScalarFunctionSet set {name};
 		set.AddFunction(GetBinaryPartCodeFunction<timestamp_tz_t, double>(LogicalType::TIMESTAMP_TZ));
 		set.AddFunction(GetStructFunction<timestamp_tz_t>(LogicalType::TIMESTAMP_TZ));
-		for (auto &func : set.functions) {
-			func.SetFallible();
-		}
+		set.SetFallible();
 		loader.RegisterFunction(set);
 	}
 

--- a/extension/icu/icu-strptime.cpp
+++ b/extension/icu/icu-strptime.cpp
@@ -340,7 +340,7 @@ struct ICUStrptime : public ICUDateFunc {
 		auto &functions = scalar_function.functions.functions;
 		optional_idx best_index;
 		for (idx_t i = 0; i < functions.size(); i++) {
-			const auto &sig = functions[i].GetSignature();
+			const auto &sig = functions[i]->GetSignature();
 			if (sig.GetParameterCount() != types.size()) {
 				continue;
 			}
@@ -362,9 +362,11 @@ struct ICUStrptime : public ICUDateFunc {
 		if (!best_index.IsValid()) {
 			throw InternalException("ICU - Function for TailPatch not found");
 		}
-		auto &bound_function = functions[best_index.GetIndex()];
-		bind_strptime = bound_function.GetBindCallback();
-		bound_function.SetBindCallback(StrpTimeBindFunction);
+		// the overloads are immutable - swap in a patched copy
+		auto patched = make_shared_ptr<ScalarFunction>(*functions[best_index.GetIndex()]);
+		bind_strptime = patched->GetBindCallback();
+		patched->SetBindCallback(StrpTimeBindFunction);
+		functions[best_index.GetIndex()] = std::move(patched);
 	}
 
 	static void AddBinaryTimestampFunction(const Identifier &name, ExtensionLoader &loader) {

--- a/extension/icu/icu-timebucket.cpp
+++ b/extension/icu/icu-timebucket.cpp
@@ -621,11 +621,11 @@ struct ICUTimeBucket : public ICUDateFunc {
 		                               LogicalType::TIMESTAMP_TZ, ICUTimeBucketOriginFunction, Bind));
 		set.AddFunction(ScalarFunction({LogicalType::INTERVAL, LogicalType::TIMESTAMP_TZ, LogicalType::VARCHAR},
 		                               LogicalType::TIMESTAMP_TZ, ICUTimeBucketTimeZoneFunction, Bind));
-		for (auto &func : set.functions) {
+		set.ApplyToFunctions([](ScalarFunction &func) {
 			func.SetFallible();
 			func.SetInitStateCallback(InitCalendarCache);
 			func.SetArgProperties(1, ArgProperties().NonDecreasing());
-		}
+		});
 		loader.RegisterFunction(set);
 	}
 };

--- a/extension/icu/icu-timezone.cpp
+++ b/extension/icu/icu-timezone.cpp
@@ -657,10 +657,10 @@ struct ICUTimeZoneFunc : public ICUDateFunc {
 		                               Execute<ICUToNaiveTimestamp, timestamp_tz_t, timestamp_t>, Bind));
 		set.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::TIME_TZ}, LogicalType::TIME_TZ,
 		                               Execute<ICUToTimeTZ, dtime_tz_t, dtime_tz_t>, Bind));
-		for (auto &func : set.functions) {
+		set.ApplyToFunctions([](ScalarFunction &func) {
 			func.SetFallible();
 			func.SetInitStateCallback(InitCalendarCache);
-		}
+		});
 		loader.RegisterFunction(set);
 	}
 };

--- a/extension/json/json_functions/json_array_length.cpp
+++ b/extension/json/json_functions/json_array_length.cpp
@@ -33,13 +33,13 @@ ScalarFunctionSet JSONFunctions::GetArrayLengthFunction() {
 	ScalarFunctionSet set("json_array_length");
 	GetArrayLengthFunctionsInternal(set, LogicalType::VARCHAR);
 	GetArrayLengthFunctionsInternal(set, LogicalType::JSON());
-	for (auto &func : set.functions) {
+	set.ApplyToFunctions([](ScalarFunction &func) {
 		const auto &sig = func.GetSignature();
 		if (sig.GetParameterCount() == 1 && sig.GetParameter(0).GetType().IsJSONType()) {
-			continue;
+			return;
 		}
 		func.SetFallible();
-	}
+	});
 	return set;
 }
 

--- a/extension/json/json_functions/json_contains.cpp
+++ b/extension/json/json_functions/json_contains.cpp
@@ -144,9 +144,7 @@ ScalarFunctionSet JSONFunctions::GetContainsFunction() {
 	GetContainsFunctionInternal(set, LogicalType::VARCHAR, LogicalType::VARCHAR);
 	GetContainsFunctionInternal(set, LogicalType::VARCHAR, LogicalType::JSON());
 	GetContainsFunctionInternal(set, LogicalType::JSON(), LogicalType::VARCHAR);
-	for (auto &func : set.functions) {
-		func.SetFallible();
-	}
+	set.SetFallible();
 	GetContainsFunctionInternal(set, LogicalType::JSON(), LogicalType::JSON());
 	// TODO: implement json_contains that accepts path argument as well
 

--- a/extension/json/json_functions/json_exists.cpp
+++ b/extension/json/json_functions/json_exists.cpp
@@ -26,9 +26,7 @@ ScalarFunctionSet JSONFunctions::GetExistsFunction() {
 	ScalarFunctionSet set("json_exists");
 	GetExistsFunctionsInternal(set, LogicalType::VARCHAR);
 	GetExistsFunctionsInternal(set, LogicalType::JSON());
-	for (auto &func : set.functions) {
-		func.SetFallible();
-	}
+	set.SetFallible();
 	return set;
 }
 

--- a/extension/json/json_functions/json_extract.cpp
+++ b/extension/json/json_functions/json_extract.cpp
@@ -49,13 +49,13 @@ ScalarFunctionSet JSONFunctions::GetExtractFunction() {
 	ScalarFunctionSet set("json_extract");
 	GetExtractFunctionsInternal(set, LogicalType::VARCHAR);
 	GetExtractFunctionsInternal(set, LogicalType::JSON());
-	for (auto &func : set.functions) {
+	set.ApplyToFunctions([](ScalarFunction &func) {
 		const auto &sig = func.GetSignature();
 		if (sig.GetParameter(0).GetType().IsJSONType() && sig.GetParameter(1).GetType().IsNumeric()) {
-			continue;
+			return;
 		}
 		func.SetFallible();
-	}
+	});
 	return set;
 }
 
@@ -74,13 +74,13 @@ ScalarFunctionSet JSONFunctions::GetExtractStringFunction() {
 	ScalarFunctionSet set("json_extract_string");
 	GetExtractStringFunctionsInternal(set, LogicalType::VARCHAR);
 	GetExtractStringFunctionsInternal(set, LogicalType::JSON());
-	for (auto &func : set.functions) {
+	set.ApplyToFunctions([](ScalarFunction &func) {
 		const auto &sig = func.GetSignature();
 		if (sig.GetParameter(0).GetType().IsJSONType() && sig.GetParameter(1).GetType().IsNumeric()) {
-			continue;
+			return;
 		}
 		func.SetFallible();
-	}
+	});
 	return set;
 }
 

--- a/extension/json/json_functions/json_keys.cpp
+++ b/extension/json/json_functions/json_keys.cpp
@@ -53,13 +53,13 @@ ScalarFunctionSet JSONFunctions::GetKeysFunction() {
 	ScalarFunctionSet set("json_keys");
 	GetJSONKeysFunctionsInternal(set, LogicalType::VARCHAR);
 	GetJSONKeysFunctionsInternal(set, LogicalType::JSON());
-	for (auto &func : set.functions) {
+	set.ApplyToFunctions([](ScalarFunction &func) {
 		const auto &sig = func.GetSignature();
 		if (sig.GetParameterCount() == 1 && sig.GetParameter(0).GetType().IsJSONType()) {
-			continue;
+			return;
 		}
 		func.SetFallible();
-	}
+	});
 	return set;
 }
 

--- a/extension/json/json_functions/json_structure.cpp
+++ b/extension/json/json_functions/json_structure.cpp
@@ -672,9 +672,7 @@ static void GetStructureFunctionInternal(ScalarFunctionSet &set, const LogicalTy
 ScalarFunctionSet JSONFunctions::GetStructureFunction() {
 	ScalarFunctionSet set("json_structure");
 	GetStructureFunctionInternal(set, LogicalType::VARCHAR);
-	for (auto &func : set.functions) {
-		func.SetFallible();
-	}
+	set.SetFallible();
 	GetStructureFunctionInternal(set, LogicalType::JSON());
 	return set;
 }

--- a/extension/json/json_functions/json_transform.cpp
+++ b/extension/json/json_functions/json_transform.cpp
@@ -1152,9 +1152,7 @@ ScalarFunctionSet JSONFunctions::GetTransformFunction() {
 	ScalarFunctionSet set("json_transform");
 	GetTransformFunctionInternal(set, LogicalType::VARCHAR);
 	GetTransformFunctionInternal(set, LogicalType::JSON());
-	for (auto &func : set.functions) {
-		func.SetFallible();
-	}
+	set.SetFallible();
 	return set;
 }
 
@@ -1167,9 +1165,7 @@ ScalarFunctionSet JSONFunctions::GetTransformStrictFunction() {
 	ScalarFunctionSet set("json_transform_strict");
 	GetTransformStrictFunctionInternal(set, LogicalType::VARCHAR);
 	GetTransformStrictFunctionInternal(set, LogicalType::JSON());
-	for (auto &func : set.functions) {
-		func.SetFallible();
-	}
+	set.SetFallible();
 	return set;
 }
 

--- a/extension/json/json_functions/json_type.cpp
+++ b/extension/json/json_functions/json_type.cpp
@@ -32,13 +32,13 @@ ScalarFunctionSet JSONFunctions::GetTypeFunction() {
 	ScalarFunctionSet set("json_type");
 	GetTypeFunctionsInternal(set, LogicalType::VARCHAR);
 	GetTypeFunctionsInternal(set, LogicalType::JSON());
-	for (auto &func : set.functions) {
+	set.ApplyToFunctions([](ScalarFunction &func) {
 		const auto &sig = func.GetSignature();
 		if (sig.GetParameterCount() == 1 && sig.GetParameter(0).GetType().IsJSONType()) {
-			continue;
+			return;
 		}
 		func.SetFallible();
-	}
+	});
 	return set;
 }
 

--- a/extension/json/json_functions/json_value.cpp
+++ b/extension/json/json_functions/json_value.cpp
@@ -25,13 +25,13 @@ ScalarFunctionSet JSONFunctions::GetValueFunction() {
 	ScalarFunctionSet set("json_value");
 	GetValueFunctionsInternal(set, LogicalType::VARCHAR);
 	GetValueFunctionsInternal(set, LogicalType::JSON());
-	for (auto &func : set.functions) {
+	set.ApplyToFunctions([](ScalarFunction &func) {
 		const auto &sig = func.GetSignature();
 		if (sig.GetParameter(0).GetType().IsJSONType() && sig.GetParameter(1).GetType().IsNumeric()) {
-			continue;
+			return;
 		}
 		func.SetFallible();
-	}
+	});
 	return set;
 }
 

--- a/extension/parquet/parquet_extension.cpp
+++ b/extension/parquet/parquet_extension.cpp
@@ -1051,7 +1051,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	function.execution_mode = ParquetWriteExecutionMode;
 	function.initialize_operator = ParquetWriteInitializeOperator;
 	function.copy_from_bind = MultiFileFunction<ParquetMultiFileInfo>::MultiFileBindCopy;
-	function.copy_from_function = scan_fun.functions[0];
+	function.copy_from_function = *scan_fun.functions[0];
 
 	function.prepare_batch = ParquetWritePrepareBatch;
 	function.flush_batch = ParquetWriteFlushBatch;

--- a/src/catalog/catalog_entry/aggregate_function_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/aggregate_function_catalog_entry.cpp
@@ -9,10 +9,10 @@ namespace duckdb {
 AggregateFunctionCatalogEntry::AggregateFunctionCatalogEntry(Catalog &catalog, SchemaCatalogEntry &schema,
                                                              CreateAggregateFunctionInfo &info)
     : FunctionEntry(CatalogType::AGGREGATE_FUNCTION_ENTRY, catalog, schema, info), functions(info.functions) {
-	for (auto &function : functions.functions) {
+	functions.ApplyToFunctions([&](AggregateFunction &function) {
 		function.SetCatalogName(catalog.GetAttached().GetName());
 		function.SetSchemaName(schema.name);
-	}
+	});
 }
 
 } // namespace duckdb

--- a/src/catalog/catalog_entry/scalar_function_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/scalar_function_catalog_entry.cpp
@@ -13,10 +13,10 @@ constexpr const char *ScalarFunctionCatalogEntry::Name;
 ScalarFunctionCatalogEntry::ScalarFunctionCatalogEntry(Catalog &catalog, SchemaCatalogEntry &schema,
                                                        CreateScalarFunctionInfo &info)
     : FunctionEntry(CatalogType::SCALAR_FUNCTION_ENTRY, catalog, schema, info), functions(info.functions) {
-	for (auto &function : functions.functions) {
+	functions.ApplyToFunctions([&](ScalarFunction &function) {
 		function.SetCatalogName(catalog.GetAttached().GetName());
 		function.SetSchemaName(schema.name);
-	}
+	});
 }
 
 unique_ptr<CatalogEntry> ScalarFunctionCatalogEntry::AlterEntry(CatalogTransaction transaction, AlterInfo &info) {

--- a/src/catalog/catalog_entry/table_function_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/table_function_catalog_entry.cpp
@@ -13,10 +13,10 @@ TableFunctionCatalogEntry::TableFunctionCatalogEntry(Catalog &catalog, SchemaCat
                                                      CreateTableFunctionInfo &info)
     : FunctionEntry(CatalogType::TABLE_FUNCTION_ENTRY, catalog, schema, info), functions(std::move(info.functions)) {
 	D_ASSERT(this->functions.Size() > 0);
-	for (auto &function : functions.functions) {
+	functions.ApplyToFunctions([&](TableFunction &function) {
 		function.SetCatalogName(catalog.GetAttached().GetName());
 		function.SetSchemaName(schema.name);
-	}
+	});
 }
 
 unique_ptr<CatalogEntry> TableFunctionCatalogEntry::AlterEntry(CatalogTransaction transaction, AlterInfo &info) {

--- a/src/catalog/catalog_entry/window_function_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/window_function_catalog_entry.cpp
@@ -10,10 +10,10 @@ namespace duckdb {
 WindowFunctionCatalogEntry::WindowFunctionCatalogEntry(Catalog &catalog, SchemaCatalogEntry &schema,
                                                        CreateWindowFunctionInfo &info)
     : FunctionEntry(Type, catalog, schema, info), functions(info.functions) {
-	for (auto &function : functions.functions) {
+	functions.ApplyToFunctions([&](WindowFunction &function) {
 		function.SetCatalogName(catalog.GetAttached().GetName());
 		function.SetSchemaName(schema.name);
-	}
+	});
 }
 
 } // namespace duckdb

--- a/src/function/aggregate/distributive/minmax.cpp
+++ b/src/function/aggregate/distributive/minmax.cpp
@@ -402,7 +402,10 @@ unique_ptr<FunctionData> BindMinMax(BindAggregateFunctionInput &input) {
 	auto expr = minmax_func.Bind(context, std::move(arguments));
 	arguments = std::move(expr->GetChildrenMutable());
 
+	auto definition = function.GetDefinition();
 	function = std::move(expr->FunctionMutable());
+	// the specialized implementation is not the function we were bound from
+	function.SetDefinition(std::move(definition));
 	return std::move(expr->BindInfoMutable());
 }
 
@@ -559,7 +562,10 @@ unique_ptr<FunctionData> MinMaxNBind(BindAggregateFunctionInput &input) {
 			collated_arguments.push_back(std::move(arguments[1]));
 			auto expr = collated_function.Bind(context, std::move(collated_arguments));
 			arguments = std::move(expr->GetChildrenMutable());
+			auto definition = function.GetDefinition();
 			function = std::move(expr->FunctionMutable());
+			// the collated implementation is not the function we were bound from
+			function.SetDefinition(std::move(definition));
 			return std::move(expr->BindInfoMutable());
 		}
 	}

--- a/src/function/aggregate/distributive/minmax.cpp
+++ b/src/function/aggregate/distributive/minmax.cpp
@@ -331,8 +331,8 @@ static AggregateFunction GetMinMaxOperator(const LogicalType &type) {
 	}
 }
 
-const AggregateFunction &GetCollatedMinMaxFunction(ClientContext &context, const Identifier &name,
-                                                   const vector<LogicalType> &types) {
+shared_ptr<const AggregateFunction> GetCollatedMinMaxFunction(ClientContext &context, const Identifier &name,
+                                                              const vector<LogicalType> &types) {
 	const auto function_name = name == "min" ? "arg_min" : "arg_max";
 	QueryErrorContext error_context;
 	auto func = Catalog::GetEntry<AggregateFunctionCatalogEntry>(
@@ -373,7 +373,7 @@ unique_ptr<FunctionData> BindMinMax(BindAggregateFunctionInput &input) {
 		// If aggr function is min/max and uses collations, replace bound_function with arg_min/arg_max
 		// to make sure the result's correctness.
 		vector<LogicalType> types {arguments[0]->GetReturnType(), collated_arg->GetReturnType()};
-		function.ReplaceImplementation(GetCollatedMinMaxFunction(context, function.GetName(), types));
+		function.ReplaceImplementation(*GetCollatedMinMaxFunction(context, function.GetName(), types));
 		function.SetSingleValueIdentity(true);
 
 		// Bind function like arg_min/arg_max.
@@ -553,14 +553,16 @@ unique_ptr<FunctionData> MinMaxNBind(BindAggregateFunctionInput &input) {
 		if (ExpressionBinder::PushCollation(context, collated_arg, collated_arg->GetReturnType())) {
 			vector<LogicalType> types {arguments[0]->GetReturnType(), collated_arg->GetReturnType(),
 			                           arguments[1]->GetReturnType()};
-			auto &collated_function = GetCollatedMinMaxFunction(context, function.GetName(), types);
+			auto collated_function = GetCollatedMinMaxFunction(context, function.GetName(), types);
 
 			vector<unique_ptr<Expression>> collated_arguments;
 			collated_arguments.reserve(3);
 			collated_arguments.push_back(std::move(arguments[0]));
 			collated_arguments.push_back(std::move(collated_arg));
 			collated_arguments.push_back(std::move(arguments[1]));
-			auto expr = collated_function.Bind(context, std::move(collated_arguments));
+			FunctionBinder function_binder(context);
+			auto expr =
+			    function_binder.BindAggregateFunction(std::move(collated_function), std::move(collated_arguments));
 			arguments = std::move(expr->GetChildrenMutable());
 			auto definition = function.GetDefinition();
 			function = std::move(expr->FunctionMutable());

--- a/src/function/aggregate_function.cpp
+++ b/src/function/aggregate_function.cpp
@@ -84,7 +84,14 @@ unique_ptr<BoundAggregateExpression> AggregateFunction::Bind(ClientContext &cont
 	return func_binder.BindAggregateFunction(*this, std::move(arguments));
 }
 
-BoundAggregateFunction::BoundAggregateFunction(const AggregateFunction &function) {
+BoundAggregateFunction::BoundAggregateFunction(const AggregateFunction &function)
+    // TODO: remove this copy once FunctionSet stores shared_ptr functions
+    : BoundAggregateFunction(make_shared_ptr<AggregateFunction>(function)) {
+}
+
+BoundAggregateFunction::BoundAggregateFunction(shared_ptr<const AggregateFunction> function_p)
+    : definition(std::move(function_p)) {
+	auto &function = *definition;
 	name = function.name;
 	schema_name = function.GetSchemaName();
 	catalog_name = function.GetCatalogName();

--- a/src/function/aggregate_function.cpp
+++ b/src/function/aggregate_function.cpp
@@ -85,7 +85,7 @@ unique_ptr<BoundAggregateExpression> AggregateFunction::Bind(ClientContext &cont
 }
 
 BoundAggregateFunction::BoundAggregateFunction(const AggregateFunction &function)
-    // TODO: remove this copy once FunctionSet stores shared_ptr functions
+    // the function does not come from a function set - copy it into a definition of its own
     : BoundAggregateFunction(make_shared_ptr<AggregateFunction>(function)) {
 }
 

--- a/src/function/built_in_functions.cpp
+++ b/src/function/built_in_functions.cpp
@@ -12,7 +12,7 @@
 #include "duckdb/parser/parsed_data/create_window_function_info.hpp"
 #include "duckdb/main/extension_helper.hpp"
 #include "duckdb/main/config.hpp"
-
+#include "duckdb/function/function_binder.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 
 namespace duckdb {

--- a/src/function/built_in_functions.cpp
+++ b/src/function/built_in_functions.cpp
@@ -126,8 +126,9 @@ static unique_ptr<Expression> BindExtensionFunction(FunctionBindExpressionInput 
 	    context, QualifiedName(catalog.GetName(), Identifier::DefaultSchema(), bound_function.GetName()));
 
 	// override the function with the extension function
-	const auto &func = function_entry.functions.GetFunctionByArguments(context, bound_function.GetArguments());
-	return func.Bind(context, std::move(arguments));
+	auto func = function_entry.functions.GetFunctionByArguments(context, bound_function.GetArguments());
+	FunctionBinder function_binder(context);
+	return function_binder.BindScalarFunction(std::move(func), std::move(arguments));
 }
 
 void BuiltinFunctions::AddExtensionFunction(ScalarFunctionSet set) {

--- a/src/function/function_binder.cpp
+++ b/src/function/function_binder.cpp
@@ -231,7 +231,7 @@ vector<idx_t> FunctionBinder::BindFunctionsFromArguments(const Identifier &name,
 	idx_t lowest_cost = NumericLimits<idx_t>::Maximum();
 	vector<idx_t> candidate_functions;
 	for (idx_t f_idx = 0; f_idx < functions.functions.size(); f_idx++) {
-		auto &func = functions.functions[f_idx];
+		auto &func = *functions.functions[f_idx];
 		// check the arguments of the function
 		auto bind_cost = BindFunctionCost(func, arguments, named_arguments);
 		if (!bind_cost.IsValid()) {
@@ -256,13 +256,13 @@ vector<idx_t> FunctionBinder::BindFunctionsFromArguments(const Identifier &name,
 		Identifier catalog_name;
 		Identifier schema_name;
 		for (auto &f : functions.functions) {
-			if (catalog_name.empty() && !f.GetCatalogName().empty()) {
-				catalog_name = f.GetCatalogName();
+			if (catalog_name.empty() && !f->GetCatalogName().empty()) {
+				catalog_name = f->GetCatalogName();
 			}
-			if (schema_name.empty() && !f.GetSchemaName().empty()) {
-				schema_name = f.GetSchemaName();
+			if (schema_name.empty() && !f->GetSchemaName().empty()) {
+				schema_name = f->GetSchemaName();
 			}
-			candidates.push_back(f.ToString());
+			candidates.push_back(f->ToString());
 		}
 		error = ErrorData(BinderException::NoMatchingFunction(catalog_name, schema_name, name, arguments,
 		                                                      named_arguments, candidates));
@@ -285,7 +285,7 @@ MultipleCandidateException(const Identifier &catalog_name, const Identifier &sch
 	string candidate_str;
 	for (auto &conf : candidate_functions) {
 		const auto &f = functions.GetFunctionByOffset(conf);
-		candidate_str += "\t" + f.ToString() + "\n";
+		candidate_str += "\t" + f->ToString() + "\n";
 	}
 	error = ErrorData(
 	    ExceptionType::BINDER,
@@ -313,8 +313,8 @@ optional_idx FunctionBinder::BindFunctionFromArguments(const Identifier &name, c
 				throw ParameterNotResolvedException();
 			}
 		}
-		auto catalog_name = functions.functions.size() > 0 ? functions.functions[0].GetCatalogName() : Identifier();
-		auto schema_name = functions.functions.size() > 0 ? functions.functions[0].GetSchemaName() : Identifier();
+		auto catalog_name = functions.functions.size() > 0 ? functions.functions[0]->GetCatalogName() : Identifier();
+		auto schema_name = functions.functions.size() > 0 ? functions.functions[0]->GetSchemaName() : Identifier();
 		return MultipleCandidateException(catalog_name, schema_name, name, functions, candidate_functions, arguments,
 		                                  named_arguments, error);
 	}
@@ -324,7 +324,7 @@ optional_idx FunctionBinder::BindFunctionFromArguments(const Identifier &name, c
 template <class T>
 static bool AnyOverloadSupportsImplicitArgumentNames(const FunctionSet<T> &functions) {
 	for (auto &func : functions.functions) {
-		if (func.GetProperties().GetCaptureArgumentAliases()) {
+		if (func->GetProperties().GetCaptureArgumentAliases()) {
 			return true;
 		}
 	}
@@ -417,7 +417,7 @@ optional_idx FunctionBinder::BindFunction(const Identifier &name, const PragmaFu
 	if (!entry.IsValid()) {
 		error.Throw();
 	}
-	const auto &candidate_function = functions.GetFunctionByOffset(entry.GetIndex());
+	const auto &candidate_function = *functions.GetFunctionByOffset(entry.GetIndex());
 	// cast the input parameters
 	for (idx_t i = 0; i < parameters.size(); i++) {
 		auto target_type = i < candidate_function.GetArguments().size() ? candidate_function.GetArguments()[i]
@@ -578,7 +578,8 @@ unique_ptr<Expression> FunctionBinder::BindScalarFunction(const ScalarFunctionCa
 	}
 
 	// found a matching function!
-	const auto &bound_function = func.functions.GetFunctionByOffset(best_function.GetIndex());
+	auto selected_function = func.functions.GetFunctionByOffset(best_function.GetIndex());
+	auto &bound_function = *selected_function;
 
 	// now that the overload is fixed, split the arguments into their final positional/named children
 	auto [regular_args, keyword_args] = SplitArguments(std::move(arguments));
@@ -622,7 +623,8 @@ unique_ptr<Expression> FunctionBinder::BindScalarFunction(const ScalarFunctionCa
 			}
 		}
 	}
-	return BindScalarFunction(bound_function, std::move(regular_args), std::move(keyword_args), is_operator, binder);
+	return BindScalarFunction(std::move(selected_function), std::move(regular_args), std::move(keyword_args),
+	                          is_operator, binder);
 }
 
 static bool RequiresCollationPropagation(const LogicalType &type) {
@@ -1057,13 +1059,14 @@ static vector<Identifier> ResolveArguments(const SimpleFunction &function, vecto
 }
 
 pair<BoundScalarFunction, unique_ptr<FunctionData>>
-FunctionBinder::ResolveFunction(const ScalarFunction &function, vector<unique_ptr<Expression>> &arguments,
+FunctionBinder::ResolveFunction(shared_ptr<const ScalarFunction> function_p, vector<unique_ptr<Expression>> &arguments,
                                 vector<pair<Identifier, unique_ptr<Expression>>> &named_arguments) {
+	auto &function = *function_p;
 	// Reorder named args
 	auto argument_names = ResolveArguments(function, arguments, named_arguments);
 
 	// Make a BoundScalarFunction out of the ScalarFunction, so we can store bind info and other properties in it.
-	BoundScalarFunction bound_function(function);
+	BoundScalarFunction bound_function(std::move(function_p));
 
 	// Expand varargs if necessary
 	if (function.HasVarArgs()) {
@@ -1100,17 +1103,31 @@ FunctionBinder::ResolveFunction(const ScalarFunction &function, vector<unique_pt
 	return {std::move(bound_function), std::move(bind_info)};
 }
 
+unique_ptr<Expression> FunctionBinder::BindScalarFunction(shared_ptr<const ScalarFunction> function,
+                                                          vector<unique_ptr<Expression>> children, bool is_operator,
+                                                          optional_ptr<Binder> binder) {
+	return BindScalarFunction(std::move(function), std::move(children), {}, is_operator, binder);
+}
+
 unique_ptr<Expression> FunctionBinder::BindScalarFunction(const ScalarFunction &function,
                                                           vector<unique_ptr<Expression>> children, bool is_operator,
                                                           optional_ptr<Binder> binder) {
-	return BindScalarFunction(function, std::move(children), {}, is_operator, binder);
+	return BindScalarFunction(make_shared_ptr<ScalarFunction>(function), std::move(children), {}, is_operator, binder);
 }
 
 unique_ptr<Expression> FunctionBinder::BindScalarFunction(const ScalarFunction &function,
                                                           vector<unique_ptr<Expression>> children,
                                                           vector<pair<Identifier, unique_ptr<Expression>>> keyword_args,
                                                           bool is_operator, optional_ptr<Binder> binder) {
-	auto [bound_function, bind_info] = ResolveFunction(function, children, keyword_args);
+	return BindScalarFunction(make_shared_ptr<ScalarFunction>(function), std::move(children), std::move(keyword_args),
+	                          is_operator, binder);
+}
+
+unique_ptr<Expression> FunctionBinder::BindScalarFunction(shared_ptr<const ScalarFunction> function,
+                                                          vector<unique_ptr<Expression>> children,
+                                                          vector<pair<Identifier, unique_ptr<Expression>>> keyword_args,
+                                                          bool is_operator, optional_ptr<Binder> binder) {
+	auto [bound_function, bind_info] = ResolveFunction(std::move(function), children, keyword_args);
 
 	unique_ptr<Expression> result;
 
@@ -1132,13 +1149,15 @@ unique_ptr<Expression> FunctionBinder::BindScalarFunction(const ScalarFunction &
 }
 
 pair<BoundAggregateFunction, unique_ptr<FunctionData>>
-FunctionBinder::ResolveFunction(const AggregateFunction &function, vector<unique_ptr<Expression>> &children,
+FunctionBinder::ResolveFunction(shared_ptr<const AggregateFunction> function_p,
+                                vector<unique_ptr<Expression>> &children,
                                 vector<pair<Identifier, unique_ptr<Expression>>> &named_arguments) {
+	auto &function = *function_p;
 	// Reorder named args
 	auto argument_names = ResolveArguments(function, children, named_arguments);
 
 	// Make a BoundFunction out of the func
-	BoundAggregateFunction bound_function(function);
+	BoundAggregateFunction bound_function(std::move(function_p));
 
 	// Expand varargs if necessary
 	if (function.HasVarArgs()) {
@@ -1168,18 +1187,35 @@ FunctionBinder::ResolveFunction(const AggregateFunction &function, vector<unique
 	return {std::move(bound_function), std::move(bind_info)};
 }
 
+unique_ptr<BoundAggregateExpression> FunctionBinder::BindAggregateFunction(shared_ptr<const AggregateFunction> function,
+                                                                           vector<unique_ptr<Expression>> children,
+                                                                           unique_ptr<Expression> filter,
+                                                                           AggregateType aggr_type) {
+	return BindAggregateFunction(std::move(function), std::move(children), {}, std::move(filter), aggr_type);
+}
+
 unique_ptr<BoundAggregateExpression> FunctionBinder::BindAggregateFunction(const AggregateFunction &function,
                                                                            vector<unique_ptr<Expression>> children,
                                                                            unique_ptr<Expression> filter,
                                                                            AggregateType aggr_type) {
-	return BindAggregateFunction(function, std::move(children), {}, std::move(filter), aggr_type);
+	return BindAggregateFunction(make_shared_ptr<AggregateFunction>(function), std::move(children), {},
+	                             std::move(filter), aggr_type);
 }
 
 unique_ptr<BoundAggregateExpression>
 FunctionBinder::BindAggregateFunction(const AggregateFunction &function, vector<unique_ptr<Expression>> children,
                                       vector<pair<Identifier, unique_ptr<Expression>>> keyword_args,
                                       unique_ptr<Expression> filter, AggregateType aggr_type) {
-	auto [bound_function, bind_info] = ResolveFunction(function, children, keyword_args);
+	return BindAggregateFunction(make_shared_ptr<AggregateFunction>(function), std::move(children),
+	                             std::move(keyword_args), std::move(filter), aggr_type);
+}
+
+unique_ptr<BoundAggregateExpression>
+FunctionBinder::BindAggregateFunction(shared_ptr<const AggregateFunction> function,
+                                      vector<unique_ptr<Expression>> children,
+                                      vector<pair<Identifier, unique_ptr<Expression>>> keyword_args,
+                                      unique_ptr<Expression> filter, AggregateType aggr_type) {
+	auto [bound_function, bind_info] = ResolveFunction(std::move(function), children, keyword_args);
 
 	return make_uniq<BoundAggregateExpression>(std::move(bound_function), std::move(children), std::move(filter),
 	                                           std::move(bind_info), aggr_type);
@@ -1197,24 +1233,25 @@ FunctionBinder::BindAggregateFunction(const AggregateFunctionCatalogEntry &func,
 	}
 
 	// found a matching function!
-	const auto &bound_function = func.functions.GetFunctionByOffset(best_function.GetIndex());
+	auto bound_function = func.functions.GetFunctionByOffset(best_function.GetIndex());
 
 	// now that the overload is fixed, split the arguments into their final positional/named children
 	auto [regular_args, keyword_args] = SplitArguments(std::move(arguments));
 
-	return BindAggregateFunction(bound_function, std::move(regular_args), std::move(keyword_args), std::move(filter),
-	                             aggr_type);
+	return BindAggregateFunction(std::move(bound_function), std::move(regular_args), std::move(keyword_args),
+	                             std::move(filter), aggr_type);
 }
 
 pair<BoundWindowFunction, unique_ptr<FunctionData>>
-FunctionBinder::ResolveFunction(const WindowFunction &function, vector<unique_ptr<Expression>> &children,
+FunctionBinder::ResolveFunction(shared_ptr<const WindowFunction> function_p, vector<unique_ptr<Expression>> &children,
                                 vector<pair<Identifier, unique_ptr<Expression>>> &named_arguments,
                                 optional_ptr<vector<OrderByNode>> orders,
                                 optional_ptr<vector<OrderByNode>> arg_orders) {
+	auto &function = *function_p;
 	// Reorder named args
 	auto argument_names = ResolveArguments(function, children, named_arguments);
 
-	BoundWindowFunction bound_function(function);
+	BoundWindowFunction bound_function(std::move(function_p));
 
 	// Expand varargs if necessary
 	if (function.HasVarArgs()) {
@@ -1244,10 +1281,10 @@ FunctionBinder::ResolveFunction(const WindowFunction &function, vector<unique_pt
 }
 
 unique_ptr<BoundWindowExpression>
-FunctionBinder::BindWindowFunction(const WindowFunction &function, vector<unique_ptr<Expression>> children,
+FunctionBinder::BindWindowFunction(shared_ptr<const WindowFunction> function, vector<unique_ptr<Expression>> children,
                                    vector<pair<Identifier, unique_ptr<Expression>>> keyword_args,
                                    vector<OrderByNode> &orders, vector<OrderByNode> &arg_orders) {
-	auto [bound_function, bind_info] = ResolveFunction(function, children, keyword_args, orders, arg_orders);
+	auto [bound_function, bind_info] = ResolveFunction(std::move(function), children, keyword_args, orders, arg_orders);
 	auto return_type = bound_function.GetReturnType();
 
 	auto window = make_uniq<BoundWindowFunction>(std::move(bound_function));
@@ -1257,12 +1294,30 @@ FunctionBinder::BindWindowFunction(const WindowFunction &function, vector<unique
 	return result;
 }
 
+unique_ptr<BoundWindowExpression>
+FunctionBinder::BindWindowFunction(const WindowFunction &function, vector<unique_ptr<Expression>> children,
+                                   vector<pair<Identifier, unique_ptr<Expression>>> keyword_args,
+                                   vector<OrderByNode> &orders, vector<OrderByNode> &arg_orders) {
+	return BindWindowFunction(make_shared_ptr<WindowFunction>(function), std::move(children), std::move(keyword_args),
+	                          orders, arg_orders);
+}
+
+unique_ptr<BoundWindowExpression> FunctionBinder::BindWindowFunction(shared_ptr<const WindowFunction> function,
+                                                                     vector<unique_ptr<Expression>> children,
+                                                                     vector<OrderByNode> &orders,
+                                                                     vector<OrderByNode> &arg_orders) {
+	vector<pair<Identifier, unique_ptr<Expression>>> empty_keyword_args;
+	return BindWindowFunction(std::move(function), std::move(children), std::move(empty_keyword_args), orders,
+	                          arg_orders);
+}
+
 unique_ptr<BoundWindowExpression> FunctionBinder::BindWindowFunction(const WindowFunction &function,
                                                                      vector<unique_ptr<Expression>> children,
                                                                      vector<OrderByNode> &orders,
                                                                      vector<OrderByNode> &arg_orders) {
 	vector<pair<Identifier, unique_ptr<Expression>>> empty_keyword_args;
-	return BindWindowFunction(function, std::move(children), std::move(empty_keyword_args), orders, arg_orders);
+	return BindWindowFunction(make_shared_ptr<WindowFunction>(function), std::move(children),
+	                          std::move(empty_keyword_args), orders, arg_orders);
 }
 
 unique_ptr<BoundWindowExpression>
@@ -1276,12 +1331,13 @@ FunctionBinder::BindWindowFunction(const WindowFunctionCatalogEntry &func,
 	}
 
 	// found a matching function!
-	const auto &bound_function = func.functions.GetFunctionByOffset(best_function.GetIndex());
+	auto bound_function = func.functions.GetFunctionByOffset(best_function.GetIndex());
 
 	// now that the overload is fixed, split the arguments into their final positional/named children
 	auto [regular_args, keyword_args] = SplitArguments(std::move(arguments));
 
-	return BindWindowFunction(bound_function, std::move(regular_args), std::move(keyword_args), orders, arg_orders);
+	return BindWindowFunction(std::move(bound_function), std::move(regular_args), std::move(keyword_args), orders,
+	                          arg_orders);
 }
 
 } // namespace duckdb

--- a/src/function/function_set.cpp
+++ b/src/function/function_set.cpp
@@ -10,11 +10,11 @@ ScalarFunctionSet::ScalarFunctionSet(Identifier name) : FunctionSet(std::move(na
 }
 
 ScalarFunctionSet::ScalarFunctionSet(ScalarFunction fun) : FunctionSet(fun.name) {
-	functions.push_back(std::move(fun));
+	AddFunction(std::move(fun));
 }
 
-const ScalarFunction &ScalarFunctionSet::GetFunctionByArguments(ClientContext &context,
-                                                                const vector<LogicalType> &arguments) {
+shared_ptr<const ScalarFunction> ScalarFunctionSet::GetFunctionByArguments(ClientContext &context,
+                                                                           const vector<LogicalType> &arguments) {
 	ErrorData error;
 	FunctionBinder binder(context);
 	auto index = binder.BindFunction(name, *this, arguments, error);
@@ -32,11 +32,11 @@ AggregateFunctionSet::AggregateFunctionSet(Identifier name) : FunctionSet(std::m
 }
 
 AggregateFunctionSet::AggregateFunctionSet(AggregateFunction fun) : FunctionSet(fun.name) {
-	functions.push_back(std::move(fun));
+	AddFunction(std::move(fun));
 }
 
-const AggregateFunction &AggregateFunctionSet::GetFunctionByArguments(ClientContext &context,
-                                                                      const vector<LogicalType> &arguments) {
+shared_ptr<const AggregateFunction> AggregateFunctionSet::GetFunctionByArguments(ClientContext &context,
+                                                                                 const vector<LogicalType> &arguments) {
 	ErrorData error;
 	FunctionBinder binder(context);
 	auto index = binder.BindFunction(name, *this, arguments, error);
@@ -45,7 +45,7 @@ const AggregateFunction &AggregateFunctionSet::GetFunctionByArguments(ClientCont
 		// this is used for functions such as quantile or string_agg that delete part of their arguments during bind
 		// FIXME: we should come up with a better solution here
 		for (auto &func : functions) {
-			auto &sig = func.GetSignature();
+			auto &sig = func->GetSignature();
 			if (arguments.size() >= sig.GetParameters().size()) {
 				continue;
 			}
@@ -73,11 +73,11 @@ WindowFunctionSet::WindowFunctionSet(Identifier name) : FunctionSet(std::move(na
 }
 
 WindowFunctionSet::WindowFunctionSet(WindowFunction fun) : FunctionSet(fun.name) {
-	functions.push_back(std::move(fun));
+	AddFunction(std::move(fun));
 }
 
-const WindowFunction &WindowFunctionSet::GetFunctionByArguments(ClientContext &context,
-                                                                const vector<LogicalType> &arguments) {
+shared_ptr<const WindowFunction> WindowFunctionSet::GetFunctionByArguments(ClientContext &context,
+                                                                           const vector<LogicalType> &arguments) {
 	ErrorData error;
 	FunctionBinder binder(context);
 	auto index = binder.BindFunction(name, *this, arguments, error);
@@ -92,11 +92,11 @@ TableFunctionSet::TableFunctionSet(Identifier name) : FunctionSet(std::move(name
 }
 
 TableFunctionSet::TableFunctionSet(TableFunction fun) : FunctionSet(fun.name) {
-	functions.push_back(std::move(fun));
+	AddFunction(std::move(fun));
 }
 
-const TableFunction &TableFunctionSet::GetFunctionByArguments(ClientContext &context,
-                                                              const vector<LogicalType> &arguments) {
+shared_ptr<const TableFunction> TableFunctionSet::GetFunctionByArguments(ClientContext &context,
+                                                                         const vector<LogicalType> &arguments) {
 	ErrorData error;
 	FunctionBinder binder(context);
 	auto index = binder.BindFunction(name, *this, arguments, error);
@@ -111,7 +111,7 @@ PragmaFunctionSet::PragmaFunctionSet(Identifier name) : FunctionSet(std::move(na
 }
 
 PragmaFunctionSet::PragmaFunctionSet(PragmaFunction fun) : FunctionSet(fun.name) {
-	functions.push_back(std::move(fun));
+	AddFunction(std::move(fun));
 }
 
 } // namespace duckdb

--- a/src/function/scalar/operator/arithmetic.cpp
+++ b/src/function/scalar/operator/arithmetic.cpp
@@ -1071,9 +1071,7 @@ ScalarFunctionSet OperatorMultiplyFun::GetFunctions() {
 	multiply.AddFunction(
 	    ScalarFunction({LogicalType::INTERVAL, LogicalType::BIGINT}, LogicalType::INTERVAL,
 	                   ScalarFunction::BinaryFunction<interval_t, int64_t, interval_t, MultiplyOperator>));
-	for (auto &func : multiply.functions) {
-		func.SetFallible();
-	}
+	multiply.SetFallible();
 
 	return multiply;
 }
@@ -1226,9 +1224,7 @@ ScalarFunctionSet OperatorFloatDivideFun::GetFunctions() {
 	fp_divide.AddFunction(
 	    ScalarFunction({LogicalType::INTERVAL, LogicalType::DOUBLE}, LogicalType::INTERVAL,
 	                   BinaryScalarFunctionIgnoreZero<interval_t, double, interval_t, DivideOperator>));
-	for (auto &func : fp_divide.functions) {
-		func.SetFallible();
-	}
+	fp_divide.SetFallible();
 	return fp_divide;
 }
 
@@ -1242,9 +1238,7 @@ ScalarFunctionSet OperatorIntegerDivideFun::GetFunctions() {
 			    ScalarFunction({type, type}, type, GetBinaryFunctionIgnoreZero<DivideOperator>(type.InternalType())));
 		}
 	}
-	for (auto &func : full_divide.functions) {
-		func.SetFallible();
-	}
+	full_divide.SetFallible();
 	return full_divide;
 }
 
@@ -1300,9 +1294,7 @@ ScalarFunctionSet OperatorModuloFun::GetFunctions() {
 			    ScalarFunction({type, type}, type, GetBinaryFunctionIgnoreZero<ModuloOperator>(type.InternalType())));
 		}
 	}
-	for (auto &func : modulo.functions) {
-		func.SetFallible();
-	}
+	modulo.SetFallible();
 
 	return modulo;
 }

--- a/src/function/scalar/string/length.cpp
+++ b/src/function/scalar/string/length.cpp
@@ -287,9 +287,7 @@ ScalarFunctionSet ArrayLengthFun::GetFunctions() {
 	    ScalarFunction({LogicalType::LIST(LogicalType::ANY)}, LogicalType::BIGINT, nullptr, ArrayOrListLengthBind));
 	array_length.AddFunction(ScalarFunction({LogicalType::LIST(LogicalType::ANY), LogicalType::BIGINT},
 	                                        LogicalType::BIGINT, nullptr, ArrayOrListLengthBinaryBind));
-	for (auto &func : array_length.functions) {
-		func.SetFallible();
-	}
+	array_length.SetFallible();
 	return (array_length);
 }
 

--- a/src/function/scalar/string/regexp.cpp
+++ b/src/function/scalar/string/regexp.cpp
@@ -412,9 +412,7 @@ ScalarFunctionSet RegexpFun::GetFunctions() {
 	    {{"string", LogicalType::VARCHAR}, {"regex", LogicalType::VARCHAR}, {"options", LogicalType::VARCHAR}},
 	    LogicalType::BOOLEAN, RegexpMatchesFunction<RegexFullMatch>, RegexpMatchesBind, nullptr, RegexInitLocalState,
 	    LogicalType::INVALID, FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING));
-	for (auto &func : regexp_full_match.functions) {
-		func.SetFallible();
-	}
+	regexp_full_match.SetFallible();
 	return (regexp_full_match);
 }
 
@@ -428,9 +426,7 @@ ScalarFunctionSet RegexpMatchesFun::GetFunctions() {
 	    {{"string", LogicalType::VARCHAR}, {"regex", LogicalType::VARCHAR}, {"options", LogicalType::VARCHAR}},
 	    LogicalType::BOOLEAN, RegexpMatchesFunction<RegexPartialMatch>, RegexpMatchesBind, nullptr, RegexInitLocalState,
 	    LogicalType::INVALID, FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING));
-	for (auto &func : regexp_partial_match.functions) {
-		func.SetFallible();
-	}
+	regexp_partial_match.SetFallible();
 	return (regexp_partial_match);
 }
 

--- a/src/function/scalar_function.cpp
+++ b/src/function/scalar_function.cpp
@@ -117,7 +117,14 @@ unique_ptr<BoundFunctionExpression> ScalarFunction::Bind(ClientContext &context,
 	return unique_ptr_cast<Expression, BoundFunctionExpression>(std::move(expr));
 }
 
-BoundScalarFunction::BoundScalarFunction(const ScalarFunction &function) {
+BoundScalarFunction::BoundScalarFunction(const ScalarFunction &function)
+    // TODO: remove this copy once FunctionSet stores shared_ptr functions
+    : BoundScalarFunction(make_shared_ptr<ScalarFunction>(function)) {
+}
+
+BoundScalarFunction::BoundScalarFunction(shared_ptr<const ScalarFunction> function_p)
+    : definition(std::move(function_p)) {
+	auto &function = *definition;
 	name = function.name;
 	schema_name = function.GetSchemaName();
 	catalog_name = function.GetCatalogName();

--- a/src/function/scalar_function.cpp
+++ b/src/function/scalar_function.cpp
@@ -118,7 +118,7 @@ unique_ptr<BoundFunctionExpression> ScalarFunction::Bind(ClientContext &context,
 }
 
 BoundScalarFunction::BoundScalarFunction(const ScalarFunction &function)
-    // TODO: remove this copy once FunctionSet stores shared_ptr functions
+    // the function does not come from a function set - copy it into a definition of its own
     : BoundScalarFunction(make_shared_ptr<ScalarFunction>(function)) {
 }
 

--- a/src/function/table/system/duckdb_functions.cpp
+++ b/src/function/table/system/duckdb_functions.cpp
@@ -147,12 +147,12 @@ struct ScalarFunctionExtractor {
 	}
 
 	static Value GetReturnType(ScalarFunctionCatalogEntry &entry, idx_t offset) {
-		return Value(entry.functions.GetFunctionByOffset(offset).GetReturnType().ToString());
+		return Value(entry.functions.GetFunctionByOffset(offset)->GetReturnType().ToString());
 	}
 
 	static vector<Value> GetParameters(ScalarFunctionCatalogEntry &entry, idx_t offset) {
 		vector<Value> results;
-		for (auto &param : entry.functions.GetFunctionByOffset(offset).GetSignature().GetParameters()) {
+		for (auto &param : entry.functions.GetFunctionByOffset(offset)->GetSignature().GetParameters()) {
 			results.emplace_back(param.GetName());
 		}
 		return results;
@@ -160,7 +160,7 @@ struct ScalarFunctionExtractor {
 
 	static Value GetParameterTypes(ScalarFunctionCatalogEntry &entry, idx_t offset) {
 		vector<Value> results;
-		const auto &fun = entry.functions.GetFunctionByOffset(offset);
+		const auto &fun = *entry.functions.GetFunctionByOffset(offset);
 		for (idx_t i = 0; i < fun.GetSignature().GetParameterCount(); i++) {
 			results.emplace_back(fun.GetSignature().GetParameter(i).GetType().ToString());
 		}
@@ -168,7 +168,7 @@ struct ScalarFunctionExtractor {
 	}
 
 	static vector<LogicalType> GetParameterLogicalTypes(ScalarFunctionCatalogEntry &entry, idx_t offset) {
-		const auto &fun = entry.functions.GetFunctionByOffset(offset);
+		const auto &fun = *entry.functions.GetFunctionByOffset(offset);
 		vector<LogicalType> results;
 		for (idx_t i = 0; i < fun.GetSignature().GetParameterCount(); i++) {
 			results.emplace_back(fun.GetSignature().GetParameter(i).GetType());
@@ -177,7 +177,7 @@ struct ScalarFunctionExtractor {
 	}
 
 	static Value GetVarArgs(ScalarFunctionCatalogEntry &entry, idx_t offset) {
-		const auto &fun = entry.functions.GetFunctionByOffset(offset);
+		const auto &fun = *entry.functions.GetFunctionByOffset(offset);
 		return !fun.HasVarArgs() ? Value() : Value(fun.GetVarArgs().ToString());
 	}
 
@@ -186,12 +186,12 @@ struct ScalarFunctionExtractor {
 	}
 
 	static Value IsVolatile(ScalarFunctionCatalogEntry &entry, idx_t offset) {
-		return Value::BOOLEAN(entry.functions.GetFunctionByOffset(offset).GetStability() ==
+		return Value::BOOLEAN(entry.functions.GetFunctionByOffset(offset)->GetStability() ==
 		                      FunctionStability::VOLATILE);
 	}
 
 	static Value ResultType(ScalarFunctionCatalogEntry &entry, idx_t offset) {
-		return FunctionStabilityToValue(entry.functions.GetFunctionByOffset(offset).GetStability());
+		return FunctionStabilityToValue(entry.functions.GetFunctionByOffset(offset)->GetStability());
 	}
 };
 
@@ -205,12 +205,12 @@ struct WindowFunctionExtractor {
 	}
 
 	static Value GetReturnType(WindowFunctionCatalogEntry &entry, idx_t offset) {
-		return Value(entry.functions.GetFunctionByOffset(offset).GetReturnType().ToString());
+		return Value(entry.functions.GetFunctionByOffset(offset)->GetReturnType().ToString());
 	}
 
 	static vector<Value> GetParameters(WindowFunctionCatalogEntry &entry, idx_t offset) {
 		vector<Value> results;
-		for (auto &param : entry.functions.GetFunctionByOffset(offset).GetSignature().GetParameters()) {
+		for (auto &param : entry.functions.GetFunctionByOffset(offset)->GetSignature().GetParameters()) {
 			results.emplace_back(param.GetName());
 		}
 		return results;
@@ -218,7 +218,7 @@ struct WindowFunctionExtractor {
 
 	static Value GetParameterTypes(WindowFunctionCatalogEntry &entry, idx_t offset) {
 		vector<Value> results;
-		const auto &fun = entry.functions.GetFunctionByOffset(offset);
+		const auto &fun = *entry.functions.GetFunctionByOffset(offset);
 		for (idx_t i = 0; i < fun.GetSignature().GetParameterCount(); i++) {
 			results.emplace_back(fun.GetSignature().GetParameter(i).GetType().ToString());
 		}
@@ -226,7 +226,7 @@ struct WindowFunctionExtractor {
 	}
 
 	static vector<LogicalType> GetParameterLogicalTypes(WindowFunctionCatalogEntry &entry, idx_t offset) {
-		const auto &fun = entry.functions.GetFunctionByOffset(offset);
+		const auto &fun = *entry.functions.GetFunctionByOffset(offset);
 		vector<LogicalType> results;
 		for (idx_t i = 0; i < fun.GetSignature().GetParameterCount(); i++) {
 			results.emplace_back(fun.GetSignature().GetParameter(i).GetType());
@@ -261,12 +261,12 @@ struct AggregateFunctionExtractor {
 	}
 
 	static Value GetReturnType(AggregateFunctionCatalogEntry &entry, idx_t offset) {
-		return Value(entry.functions.GetFunctionByOffset(offset).GetReturnType().ToString());
+		return Value(entry.functions.GetFunctionByOffset(offset)->GetReturnType().ToString());
 	}
 
 	static vector<Value> GetParameters(AggregateFunctionCatalogEntry &entry, idx_t offset) {
 		vector<Value> results;
-		for (auto &param : entry.functions.GetFunctionByOffset(offset).GetSignature().GetParameters()) {
+		for (auto &param : entry.functions.GetFunctionByOffset(offset)->GetSignature().GetParameters()) {
 			results.emplace_back(param.GetName());
 		}
 		return results;
@@ -274,7 +274,7 @@ struct AggregateFunctionExtractor {
 
 	static Value GetParameterTypes(AggregateFunctionCatalogEntry &entry, idx_t offset) {
 		vector<Value> results;
-		const auto &fun = entry.functions.GetFunctionByOffset(offset);
+		const auto &fun = *entry.functions.GetFunctionByOffset(offset);
 		for (idx_t i = 0; i < fun.GetSignature().GetParameterCount(); i++) {
 			results.emplace_back(fun.GetSignature().GetParameter(i).GetType().ToString());
 		}
@@ -282,7 +282,7 @@ struct AggregateFunctionExtractor {
 	}
 
 	static vector<LogicalType> GetParameterLogicalTypes(AggregateFunctionCatalogEntry &entry, idx_t offset) {
-		const auto &fun = entry.functions.GetFunctionByOffset(offset);
+		const auto &fun = *entry.functions.GetFunctionByOffset(offset);
 		vector<LogicalType> results;
 		for (idx_t i = 0; i < fun.GetSignature().GetParameterCount(); i++) {
 			results.emplace_back(fun.GetSignature().GetParameter(i).GetType());
@@ -291,7 +291,7 @@ struct AggregateFunctionExtractor {
 	}
 
 	static Value GetVarArgs(AggregateFunctionCatalogEntry &entry, idx_t offset) {
-		const auto &fun = entry.functions.GetFunctionByOffset(offset);
+		const auto &fun = *entry.functions.GetFunctionByOffset(offset);
 		return !fun.HasVarArgs() ? Value() : Value(fun.GetVarArgs().ToString());
 	}
 
@@ -300,12 +300,12 @@ struct AggregateFunctionExtractor {
 	}
 
 	static Value IsVolatile(AggregateFunctionCatalogEntry &entry, idx_t offset) {
-		return Value::BOOLEAN(entry.functions.GetFunctionByOffset(offset).GetStability() ==
+		return Value::BOOLEAN(entry.functions.GetFunctionByOffset(offset)->GetStability() ==
 		                      FunctionStability::VOLATILE);
 	}
 
 	static Value ResultType(AggregateFunctionCatalogEntry &entry, idx_t offset) {
-		return FunctionStabilityToValue(entry.functions.GetFunctionByOffset(offset).GetStability());
+		return FunctionStabilityToValue(entry.functions.GetFunctionByOffset(offset)->GetStability());
 	}
 };
 
@@ -452,7 +452,7 @@ struct TableFunctionExtractor {
 
 	static vector<Value> GetParameters(TableFunctionCatalogEntry &entry, idx_t offset) {
 		vector<Value> results;
-		const auto &fun = entry.functions.GetFunctionByOffset(offset);
+		const auto &fun = *entry.functions.GetFunctionByOffset(offset);
 		for (idx_t i = 0; i < fun.GetArguments().size(); i++) {
 			results.emplace_back("col" + to_string(i));
 		}
@@ -464,7 +464,7 @@ struct TableFunctionExtractor {
 
 	static Value GetParameterTypes(TableFunctionCatalogEntry &entry, idx_t offset) {
 		vector<Value> results;
-		const auto &fun = entry.functions.GetFunctionByOffset(offset);
+		const auto &fun = *entry.functions.GetFunctionByOffset(offset);
 
 		for (idx_t i = 0; i < fun.GetArguments().size(); i++) {
 			results.emplace_back(fun.GetArguments()[i].ToString());
@@ -476,12 +476,12 @@ struct TableFunctionExtractor {
 	}
 
 	static vector<LogicalType> GetParameterLogicalTypes(TableFunctionCatalogEntry &entry, idx_t offset) {
-		const auto &fun = entry.functions.GetFunctionByOffset(offset);
+		const auto &fun = *entry.functions.GetFunctionByOffset(offset);
 		return fun.GetArguments();
 	}
 
 	static Value GetVarArgs(TableFunctionCatalogEntry &entry, idx_t offset) {
-		const auto &fun = entry.functions.GetFunctionByOffset(offset);
+		const auto &fun = *entry.functions.GetFunctionByOffset(offset);
 		return !fun.HasVarArgs() ? Value() : Value(fun.GetVarArgs().ToString());
 	}
 
@@ -513,7 +513,7 @@ struct PragmaFunctionExtractor {
 
 	static vector<Value> GetParameters(PragmaFunctionCatalogEntry &entry, idx_t offset) {
 		vector<Value> results;
-		const auto &fun = entry.functions.GetFunctionByOffset(offset);
+		const auto &fun = *entry.functions.GetFunctionByOffset(offset);
 
 		for (idx_t i = 0; i < fun.GetArguments().size(); i++) {
 			results.emplace_back("col" + to_string(i));
@@ -526,7 +526,7 @@ struct PragmaFunctionExtractor {
 
 	static Value GetParameterTypes(PragmaFunctionCatalogEntry &entry, idx_t offset) {
 		vector<Value> results;
-		const auto &fun = entry.functions.GetFunctionByOffset(offset);
+		const auto &fun = *entry.functions.GetFunctionByOffset(offset);
 
 		for (idx_t i = 0; i < fun.GetArguments().size(); i++) {
 			results.emplace_back(fun.GetArguments()[i].ToString());
@@ -538,12 +538,12 @@ struct PragmaFunctionExtractor {
 	}
 
 	static vector<LogicalType> GetParameterLogicalTypes(PragmaFunctionCatalogEntry &entry, idx_t offset) {
-		const auto &fun = entry.functions.GetFunctionByOffset(offset);
+		const auto &fun = *entry.functions.GetFunctionByOffset(offset);
 		return fun.GetArguments();
 	}
 
 	static Value GetVarArgs(PragmaFunctionCatalogEntry &entry, idx_t offset) {
-		const auto &fun = entry.functions.GetFunctionByOffset(offset);
+		const auto &fun = *entry.functions.GetFunctionByOffset(offset);
 		return !fun.HasVarArgs() ? Value() : Value(fun.GetVarArgs().ToString());
 	}
 

--- a/src/function/window_function.cpp
+++ b/src/function/window_function.cpp
@@ -18,7 +18,14 @@ unique_ptr<BoundWindowExpression> WindowFunction::Bind(ClientContext &context,
 	return func_binder.BindWindowFunction(*this, std::move(arguments), orders, arg_orders);
 }
 
-BoundWindowFunction::BoundWindowFunction(const WindowFunction &base) : window_enum(base.window_enum) {
+BoundWindowFunction::BoundWindowFunction(const WindowFunction &base)
+    // TODO: remove this copy once FunctionSet stores shared_ptr functions
+    : BoundWindowFunction(make_shared_ptr<WindowFunction>(base)) {
+}
+
+BoundWindowFunction::BoundWindowFunction(shared_ptr<const WindowFunction> base_p)
+    : window_enum(base_p->window_enum), definition(std::move(base_p)) {
+	auto &base = *definition;
 	name = base.name;
 	schema_name = base.GetSchemaName();
 	catalog_name = base.GetCatalogName();

--- a/src/function/window_function.cpp
+++ b/src/function/window_function.cpp
@@ -19,7 +19,7 @@ unique_ptr<BoundWindowExpression> WindowFunction::Bind(ClientContext &context,
 }
 
 BoundWindowFunction::BoundWindowFunction(const WindowFunction &base)
-    // TODO: remove this copy once FunctionSet stores shared_ptr functions
+    // the function does not come from a function set - copy it into a definition of its own
     : BoundWindowFunction(make_shared_ptr<WindowFunction>(base)) {
 }
 

--- a/src/include/duckdb/function/aggregate_function.hpp
+++ b/src/include/duckdb/function/aggregate_function.hpp
@@ -832,11 +832,26 @@ public:
 class BoundAggregateFunction : public BaseAggregateFunction, public BoundSimpleFunction {
 public:
 	explicit BoundAggregateFunction(const AggregateFunction &function);
+	explicit BoundAggregateFunction(shared_ptr<const AggregateFunction> function);
 
+	//! Swap in a different implementation, keeping the definition this was bound from intact
 	void ReplaceImplementation(const AggregateFunction &function);
 
 	DUCKDB_API bool operator==(const BoundAggregateFunction &rhs) const;
 	DUCKDB_API bool operator!=(const BoundAggregateFunction &rhs) const;
+
+public:
+	//! The function this was bound from. Unaffected by ReplaceImplementation and by later mutation of the bound
+	//! function, e.g. statistics propagation swapping in a specialized implementation.
+	//! NOTE: the definition is currently a per-bind copy, so pointer identity is only stable within one expression
+	//! lineage - inspect the function itself rather than comparing pointers.
+	const shared_ptr<const AggregateFunction> &GetDefinition() const {
+		return definition;
+	}
+	//! Restore the definition after the bound function has been replaced wholesale
+	void SetDefinition(shared_ptr<const AggregateFunction> definition_p) {
+		definition = std::move(definition_p);
+	}
 
 	AggregateStateLayout GetStateType(optional_ptr<FunctionData> bind_data) const {
 		D_ASSERT(callbacks.get_state_type);
@@ -850,6 +865,9 @@ public:
 		AggregateStateInput input(*this, bind_data);
 		return callbacks.state_size(input);
 	}
+
+private:
+	shared_ptr<const AggregateFunction> definition;
 };
 
 // Defined here (after BoundAggregateFunction is complete) so the lambda body can call GetReturnType().

--- a/src/include/duckdb/function/aggregate_function.hpp
+++ b/src/include/duckdb/function/aggregate_function.hpp
@@ -842,9 +842,10 @@ public:
 
 public:
 	//! The function this was bound from. Unaffected by ReplaceImplementation and by later mutation of the bound
-	//! function, e.g. statistics propagation swapping in a specialized implementation.
-	//! NOTE: the definition is currently a per-bind copy, so pointer identity is only stable within one expression
-	//! lineage - inspect the function itself rather than comparing pointers.
+	//! function, e.g. statistics propagation swapping in a specialized implementation. For a function bound from an
+	//! AggregateFunctionSet this is the set's own overload, so it compares equal by pointer across binds. Functions
+	//! bound outside of a set are copied into a definition of their own.
+	//! Only null in a moved-from bound function.
 	const shared_ptr<const AggregateFunction> &GetDefinition() const {
 		return definition;
 	}

--- a/src/include/duckdb/function/function_binder.hpp
+++ b/src/include/duckdb/function/function_binder.hpp
@@ -108,7 +108,13 @@ public:
 	                                                     bool is_operator = false,
 	                                                     optional_ptr<Binder> binder = nullptr);
 
-	DUCKDB_API unique_ptr<Expression> BindScalarFunction(const ScalarFunction &bound_function,
+	DUCKDB_API unique_ptr<Expression> BindScalarFunction(shared_ptr<const ScalarFunction> function,
+	                                                     vector<unique_ptr<Expression>> children,
+	                                                     bool is_operator = false,
+	                                                     optional_ptr<Binder> binder = nullptr);
+
+	//! Bind a function that does not come from a function set - the function is copied into a definition of its own
+	DUCKDB_API unique_ptr<Expression> BindScalarFunction(const ScalarFunction &function,
 	                                                     vector<unique_ptr<Expression>> children,
 	                                                     bool is_operator = false,
 	                                                     optional_ptr<Binder> binder = nullptr);
@@ -121,16 +127,33 @@ public:
 	                                                     ErrorData &error, bool is_operator = false,
 	                                                     optional_ptr<Binder> binder = nullptr);
 
-	DUCKDB_API unique_ptr<Expression> BindScalarFunction(const ScalarFunction &bound_function,
+	DUCKDB_API unique_ptr<Expression> BindScalarFunction(shared_ptr<const ScalarFunction> function,
+	                                                     vector<unique_ptr<Expression>> children,
+	                                                     vector<pair<Identifier, unique_ptr<Expression>>> keyword_args,
+	                                                     bool is_operator = false,
+	                                                     optional_ptr<Binder> binder = nullptr);
+
+	DUCKDB_API unique_ptr<Expression> BindScalarFunction(const ScalarFunction &function,
 	                                                     vector<unique_ptr<Expression>> children,
 	                                                     vector<pair<Identifier, unique_ptr<Expression>>> keyword_args,
 	                                                     bool is_operator = false,
 	                                                     optional_ptr<Binder> binder = nullptr);
 
 	DUCKDB_API unique_ptr<BoundAggregateExpression>
-	BindAggregateFunction(const AggregateFunction &bound_function, vector<unique_ptr<Expression>> children,
+	BindAggregateFunction(shared_ptr<const AggregateFunction> function, vector<unique_ptr<Expression>> children,
 	                      unique_ptr<Expression> filter = nullptr,
 	                      AggregateType aggr_type = AggregateType::NON_DISTINCT);
+
+	//! Bind a function that does not come from a function set - the function is copied into a definition of its own
+	DUCKDB_API unique_ptr<BoundAggregateExpression>
+	BindAggregateFunction(const AggregateFunction &function, vector<unique_ptr<Expression>> children,
+	                      unique_ptr<Expression> filter = nullptr,
+	                      AggregateType aggr_type = AggregateType::NON_DISTINCT);
+
+	DUCKDB_API unique_ptr<BoundAggregateExpression>
+	BindAggregateFunction(shared_ptr<const AggregateFunction> function, vector<unique_ptr<Expression>> children,
+	                      vector<pair<Identifier, unique_ptr<Expression>>> keyword_args, unique_ptr<Expression> filter,
+	                      AggregateType aggr_type);
 
 	DUCKDB_API unique_ptr<BoundAggregateExpression>
 	BindAggregateFunction(const AggregateFunction &function, vector<unique_ptr<Expression>> children,
@@ -164,9 +187,20 @@ public:
 	                         const vector<SortedAggregateStateOrder> &orders, idx_t argument_count);
 
 	DUCKDB_API unique_ptr<BoundWindowExpression>
+	BindWindowFunction(shared_ptr<const WindowFunction> function, vector<unique_ptr<Expression>> children,
+	                   vector<pair<Identifier, unique_ptr<Expression>>> keyword_args, vector<OrderByNode> &orders,
+	                   vector<OrderByNode> &arg_orders);
+
+	//! Bind a function that does not come from a function set - the function is copied into a definition of its own
+	DUCKDB_API unique_ptr<BoundWindowExpression>
 	BindWindowFunction(const WindowFunction &function, vector<unique_ptr<Expression>> children,
 	                   vector<pair<Identifier, unique_ptr<Expression>>> keyword_args, vector<OrderByNode> &orders,
 	                   vector<OrderByNode> &arg_orders);
+
+	DUCKDB_API unique_ptr<BoundWindowExpression> BindWindowFunction(shared_ptr<const WindowFunction> function,
+	                                                                vector<unique_ptr<Expression>> children,
+	                                                                vector<OrderByNode> &orders,
+	                                                                vector<OrderByNode> &arg_orders);
 
 	DUCKDB_API unique_ptr<BoundWindowExpression> BindWindowFunction(const WindowFunction &function,
 	                                                                vector<unique_ptr<Expression>> children,
@@ -178,36 +212,74 @@ public:
 	                   vector<pair<Identifier, unique_ptr<Expression>>> arguments, ErrorData &error,
 	                   vector<OrderByNode> &orders, vector<OrderByNode> &arg_orders);
 
-	pair<BoundScalarFunction, unique_ptr<FunctionData>> ResolveFunction(const ScalarFunction &function,
+	//! Turn a function into a BoundScalarFunction bound to the given arguments. The function is kept as the
+	//! definition of the resulting bound function - see BoundScalarFunction::GetDefinition().
+	pair<BoundScalarFunction, unique_ptr<FunctionData>>
+	ResolveFunction(shared_ptr<const ScalarFunction> function, vector<unique_ptr<Expression>> &children,
+	                vector<pair<Identifier, unique_ptr<Expression>>> &keyword_args);
+
+	pair<BoundScalarFunction, unique_ptr<FunctionData>> ResolveFunction(shared_ptr<const ScalarFunction> function,
 	                                                                    vector<unique_ptr<Expression>> &children) {
 		vector<pair<Identifier, unique_ptr<Expression>>> empty_keyword_args;
-		return ResolveFunction(function, children, empty_keyword_args);
+		return ResolveFunction(std::move(function), children, empty_keyword_args);
 	}
 
+	//! Resolve a function that does not come from a function set - it is copied into a definition of its own
 	pair<BoundScalarFunction, unique_ptr<FunctionData>>
 	ResolveFunction(const ScalarFunction &function, vector<unique_ptr<Expression>> &children,
+	                vector<pair<Identifier, unique_ptr<Expression>>> &keyword_args) {
+		return ResolveFunction(make_shared_ptr<ScalarFunction>(function), children, keyword_args);
+	}
+
+	pair<BoundScalarFunction, unique_ptr<FunctionData>> ResolveFunction(const ScalarFunction &function,
+	                                                                    vector<unique_ptr<Expression>> &children) {
+		return ResolveFunction(make_shared_ptr<ScalarFunction>(function), children);
+	}
+
+	pair<BoundAggregateFunction, unique_ptr<FunctionData>>
+	ResolveFunction(shared_ptr<const AggregateFunction> function, vector<unique_ptr<Expression>> &children,
 	                vector<pair<Identifier, unique_ptr<Expression>>> &keyword_args);
+
+	pair<BoundAggregateFunction, unique_ptr<FunctionData>> ResolveFunction(shared_ptr<const AggregateFunction> function,
+	                                                                       vector<unique_ptr<Expression>> &children) {
+		vector<pair<Identifier, unique_ptr<Expression>>> empty_keyword_args;
+		return ResolveFunction(std::move(function), children, empty_keyword_args);
+	}
 
 	pair<BoundAggregateFunction, unique_ptr<FunctionData>>
 	ResolveFunction(const AggregateFunction &function, vector<unique_ptr<Expression>> &children,
-	                vector<pair<Identifier, unique_ptr<Expression>>> &keyword_args);
+	                vector<pair<Identifier, unique_ptr<Expression>>> &keyword_args) {
+		return ResolveFunction(make_shared_ptr<AggregateFunction>(function), children, keyword_args);
+	}
 
 	pair<BoundAggregateFunction, unique_ptr<FunctionData>> ResolveFunction(const AggregateFunction &function,
 	                                                                       vector<unique_ptr<Expression>> &children) {
+		return ResolveFunction(make_shared_ptr<AggregateFunction>(function), children);
+	}
+
+	pair<BoundWindowFunction, unique_ptr<FunctionData>>
+	ResolveFunction(shared_ptr<const WindowFunction> function, vector<unique_ptr<Expression>> &children,
+	                vector<pair<Identifier, unique_ptr<Expression>>> &keyword_args,
+	                optional_ptr<vector<OrderByNode>> orders = nullptr,
+	                optional_ptr<vector<OrderByNode>> arg_orders = nullptr);
+
+	pair<BoundWindowFunction, unique_ptr<FunctionData>> ResolveFunction(shared_ptr<const WindowFunction> function,
+	                                                                    vector<unique_ptr<Expression>> &children) {
 		vector<pair<Identifier, unique_ptr<Expression>>> empty_keyword_args;
-		return ResolveFunction(function, children, empty_keyword_args);
+		return ResolveFunction(std::move(function), children, empty_keyword_args);
 	}
 
 	pair<BoundWindowFunction, unique_ptr<FunctionData>>
 	ResolveFunction(const WindowFunction &function, vector<unique_ptr<Expression>> &children,
 	                vector<pair<Identifier, unique_ptr<Expression>>> &keyword_args,
 	                optional_ptr<vector<OrderByNode>> orders = nullptr,
-	                optional_ptr<vector<OrderByNode>> arg_orders = nullptr);
+	                optional_ptr<vector<OrderByNode>> arg_orders = nullptr) {
+		return ResolveFunction(make_shared_ptr<WindowFunction>(function), children, keyword_args, orders, arg_orders);
+	}
 
 	pair<BoundWindowFunction, unique_ptr<FunctionData>> ResolveFunction(const WindowFunction &function,
 	                                                                    vector<unique_ptr<Expression>> &children) {
-		vector<pair<Identifier, unique_ptr<Expression>>> empty_keyword_args;
-		return ResolveFunction(function, children, empty_keyword_args);
+		return ResolveFunction(make_shared_ptr<WindowFunction>(function), children);
 	}
 
 private:

--- a/src/include/duckdb/function/function_serialization.hpp
+++ b/src/include/duckdb/function/function_serialization.hpp
@@ -68,8 +68,7 @@ public:
 			                        name.GetIdentifierName());
 		}
 		auto &functions = func_catalog.Cast<CATALOG_ENTRY>();
-		auto function = functions.functions.GetFunctionByArguments(context, arguments);
-		return function;
+		return *functions.functions.GetFunctionByArguments(context, arguments);
 	}
 
 	template <class FUNC, class CATALOG_ENTRY>

--- a/src/include/duckdb/function/function_set.hpp
+++ b/src/include/duckdb/function/function_set.hpp
@@ -30,20 +30,35 @@ public:
 	void SetName(Identifier name_p) {
 		name = std::move(name_p);
 	}
-	//! The set of functions.
-	vector<T> functions;
+	//! The set of functions. The overloads are immutable and shared with every function bound from them - use
+	//! ApplyToFunctions() to change them.
+	vector<shared_ptr<const T>> functions;
 
 public:
 	void AddFunction(T function) {
+		functions.push_back(make_shared_ptr<T>(std::move(function)));
+	}
+	void AddFunction(shared_ptr<const T> function) {
 		functions.push_back(std::move(function));
 	}
 	idx_t Size() {
 		return functions.size();
 	}
 
-	const T &GetFunctionByOffset(idx_t offset) const {
+	const shared_ptr<const T> &GetFunctionByOffset(idx_t offset) const {
 		D_ASSERT(offset < functions.size());
 		return functions[offset];
+	}
+
+	//! Apply a modification to every overload in the set. The overloads are immutable once bound from, so each is
+	//! replaced by a modified copy rather than being changed in place.
+	template <class CALLBACK>
+	void ApplyToFunctions(CALLBACK &&callback) {
+		for (auto &function : functions) {
+			auto modified = make_shared_ptr<T>(*function);
+			callback(*modified);
+			function = std::move(modified);
+		}
 	}
 
 	bool MergeFunctionSet(FunctionSet<T> new_functions, bool override = false) {
@@ -51,7 +66,7 @@ public:
 		for (auto &new_func : new_functions.functions) {
 			bool overwritten = false;
 			for (auto &func : functions) {
-				if (new_func.Equal(func)) {
+				if (new_func->Equal(*func)) {
 					// function overload already exists
 					if (override) {
 						// override it
@@ -78,31 +93,23 @@ public:
 	DUCKDB_API explicit ScalarFunctionSet(Identifier name);
 	DUCKDB_API explicit ScalarFunctionSet(ScalarFunction fun);
 
-	DUCKDB_API const ScalarFunction &GetFunctionByArguments(ClientContext &context,
-	                                                        const vector<LogicalType> &arguments);
+	DUCKDB_API shared_ptr<const ScalarFunction> GetFunctionByArguments(ClientContext &context,
+	                                                                   const vector<LogicalType> &arguments);
 
 	//! Mark every overload in the set as fallible (can throw runtime errors)
 	void SetFallible() {
-		for (auto &fun : functions) {
-			fun.SetFallible();
-		}
+		ApplyToFunctions([](ScalarFunction &fun) { fun.SetFallible(); });
 	}
 
 	//! Apply the same per-arg property to every overload in the set.
 	void SetArgProperties(idx_t arg_idx, ArgProperties props) {
-		for (auto &fun : functions) {
-			fun.SetArgProperties(arg_idx, props);
-		}
+		ApplyToFunctions([&](ScalarFunction &fun) { fun.SetArgProperties(arg_idx, props); });
 	}
 	void SetArgProperties(const vector<ArgProperties> &props) {
-		for (auto &fun : functions) {
-			fun.SetArgProperties(props);
-		}
+		ApplyToFunctions([&](ScalarFunction &fun) { fun.SetArgProperties(props); });
 	}
 	void SetUnaryArgProperties(ArgProperties props) {
-		for (auto &fun : functions) {
-			fun.SetUnaryArgProperties(props);
-		}
+		ApplyToFunctions([&](ScalarFunction &fun) { fun.SetUnaryArgProperties(props); });
 	}
 };
 
@@ -112,8 +119,8 @@ public:
 	DUCKDB_API explicit AggregateFunctionSet(Identifier name);
 	DUCKDB_API explicit AggregateFunctionSet(AggregateFunction fun);
 
-	DUCKDB_API const AggregateFunction &GetFunctionByArguments(ClientContext &context,
-	                                                           const vector<LogicalType> &arguments);
+	DUCKDB_API shared_ptr<const AggregateFunction> GetFunctionByArguments(ClientContext &context,
+	                                                                      const vector<LogicalType> &arguments);
 };
 
 class WindowFunctionSet : public FunctionSet<WindowFunction> {
@@ -122,8 +129,8 @@ public:
 	DUCKDB_API explicit WindowFunctionSet(Identifier name);
 	DUCKDB_API explicit WindowFunctionSet(WindowFunction fun);
 
-	DUCKDB_API const WindowFunction &GetFunctionByArguments(ClientContext &context,
-	                                                        const vector<LogicalType> &arguments);
+	DUCKDB_API shared_ptr<const WindowFunction> GetFunctionByArguments(ClientContext &context,
+	                                                                   const vector<LogicalType> &arguments);
 };
 
 class TableFunctionSet : public FunctionSet<TableFunction> {
@@ -131,8 +138,8 @@ public:
 	DUCKDB_API explicit TableFunctionSet(Identifier name);
 	DUCKDB_API explicit TableFunctionSet(TableFunction fun);
 
-	DUCKDB_API const TableFunction &GetFunctionByArguments(ClientContext &context,
-	                                                       const vector<LogicalType> &arguments);
+	DUCKDB_API shared_ptr<const TableFunction> GetFunctionByArguments(ClientContext &context,
+	                                                                  const vector<LogicalType> &arguments);
 };
 
 class PragmaFunctionSet : public FunctionSet<PragmaFunction> {

--- a/src/include/duckdb/function/function_set.hpp
+++ b/src/include/duckdb/function/function_set.hpp
@@ -52,8 +52,8 @@ public:
 
 	//! Apply a modification to every overload in the set. The overloads are immutable once bound from, so each is
 	//! replaced by a modified copy rather than being changed in place.
-	template <class CALLBACK>
-	void ApplyToFunctions(CALLBACK &&callback) {
+	template <class FUNC>
+	void ApplyToFunctions(FUNC &&callback) {
 		for (auto &function : functions) {
 			auto modified = make_shared_ptr<T>(*function);
 			callback(*modified);

--- a/src/include/duckdb/function/scalar_function.hpp
+++ b/src/include/duckdb/function/scalar_function.hpp
@@ -561,9 +561,26 @@ public:
 class BoundScalarFunction : public BaseScalarFunction<BoundScalarFunction>, public BoundSimpleFunction {
 public:
 	explicit BoundScalarFunction(const ScalarFunction &function);
+	explicit BoundScalarFunction(shared_ptr<const ScalarFunction> function);
 
 	bool operator==(const BoundScalarFunction &rhs) const;
 	bool operator!=(const BoundScalarFunction &rhs) const;
+
+public:
+	//! The function this was bound from. Unaffected by later mutation of the bound function, e.g. statistics
+	//! propagation swapping in a specialized implementation.
+	//! NOTE: the definition is currently a per-bind copy, so pointer identity is only stable within one expression
+	//! lineage - inspect the function itself rather than comparing pointers.
+	const shared_ptr<const ScalarFunction> &GetDefinition() const {
+		return definition;
+	}
+	//! Restore the definition after the bound function has been replaced wholesale
+	void SetDefinition(shared_ptr<const ScalarFunction> definition_p) {
+		definition = std::move(definition_p);
+	}
+
+private:
+	shared_ptr<const ScalarFunction> definition;
 };
 
 class BindScalarFunctionInput : public BindFunctionInput {

--- a/src/include/duckdb/function/scalar_function.hpp
+++ b/src/include/duckdb/function/scalar_function.hpp
@@ -568,9 +568,10 @@ public:
 
 public:
 	//! The function this was bound from. Unaffected by later mutation of the bound function, e.g. statistics
-	//! propagation swapping in a specialized implementation.
-	//! NOTE: the definition is currently a per-bind copy, so pointer identity is only stable within one expression
-	//! lineage - inspect the function itself rather than comparing pointers.
+	//! propagation swapping in a specialized implementation. For a function bound from a ScalarFunctionSet this is
+	//! the set's own overload, so it compares equal by pointer across binds. Functions bound outside of a set are
+	//! copied into a definition of their own.
+	//! Only null in a moved-from bound function.
 	const shared_ptr<const ScalarFunction> &GetDefinition() const {
 		return definition;
 	}

--- a/src/include/duckdb/function/window_function.hpp
+++ b/src/include/duckdb/function/window_function.hpp
@@ -363,9 +363,10 @@ public:
 	DUCKDB_API bool operator!=(const BoundWindowFunction &rhs) const;
 
 public:
-	//! The function this was bound from. Unaffected by later mutation of the bound function.
-	//! NOTE: the definition is currently a per-bind copy, so pointer identity is only stable within one expression
-	//! lineage - inspect the function itself rather than comparing pointers.
+	//! The function this was bound from. Unaffected by later mutation of the bound function. For a function bound
+	//! from a WindowFunctionSet this is the set's own overload, so it compares equal by pointer across binds.
+	//! Functions bound outside of a set are copied into a definition of their own.
+	//! Only null in a moved-from bound function.
 	const shared_ptr<const WindowFunction> &GetDefinition() const {
 		return definition;
 	}

--- a/src/include/duckdb/function/window_function.hpp
+++ b/src/include/duckdb/function/window_function.hpp
@@ -354,12 +354,25 @@ public:
 class BoundWindowFunction : public BaseWindowFunction, public BoundSimpleFunction {
 public:
 	explicit BoundWindowFunction(const WindowFunction &base);
+	explicit BoundWindowFunction(shared_ptr<const WindowFunction> base);
 
 public:
 	const ExpressionType window_enum;
 
 	DUCKDB_API bool operator==(const BoundWindowFunction &rhs) const;
 	DUCKDB_API bool operator!=(const BoundWindowFunction &rhs) const;
+
+public:
+	//! The function this was bound from. Unaffected by later mutation of the bound function.
+	//! NOTE: the definition is currently a per-bind copy, so pointer identity is only stable within one expression
+	//! lineage - inspect the function itself rather than comparing pointers.
+	const shared_ptr<const WindowFunction> &GetDefinition() const {
+		return definition;
+	}
+	//! Restore the definition after the bound function has been replaced wholesale
+	void SetDefinition(shared_ptr<const WindowFunction> definition_p) {
+		definition = std::move(definition_p);
+	}
 
 public:
 	void GetBounds(WindowBoundsSet &bounds, const BoundWindowExpression &wexpr) const {
@@ -417,6 +430,9 @@ public:
 		D_ASSERT(HasStreamingDataCallback());
 		GetStreamingDataCallback()(context, input, delayed, delayed_capacity, result, lstate);
 	}
+
+private:
+	shared_ptr<const WindowFunction> definition;
 };
 
 } // namespace duckdb

--- a/src/main/capi/aggregate_function-c.cpp
+++ b/src/main/capi/aggregate_function-c.cpp
@@ -307,7 +307,7 @@ duckdb_state duckdb_register_aggregate_function_set(duckdb_connection connection
 	}
 	auto &set = duckdb::GetCAggregateFunctionSet(function_set);
 	for (idx_t idx = 0; idx < set.Size(); idx++) {
-		const auto &aggregate_function = set.GetFunctionByOffset(idx);
+		const auto &aggregate_function = *set.GetFunctionByOffset(idx);
 		auto &info = aggregate_function.GetExtraFunctionInfo().Cast<duckdb::CAggregateFunctionInfo>();
 
 		if (aggregate_function.name.empty() || !info.update || !info.combine || !info.finalize) {

--- a/src/main/capi/scalar_function-c.cpp
+++ b/src/main/capi/scalar_function-c.cpp
@@ -511,7 +511,7 @@ duckdb_state duckdb_register_scalar_function_set(duckdb_connection connection, d
 	}
 	auto &scalar_function_set = GetCScalarFunctionSet(set);
 	for (idx_t idx = 0; idx < scalar_function_set.Size(); idx++) {
-		const auto &scalar_function = scalar_function_set.GetFunctionByOffset(idx);
+		const auto &scalar_function = *scalar_function_set.GetFunctionByOffset(idx);
 		auto &info = scalar_function.GetExtraFunctionInfo().Cast<duckdb::CScalarFunctionInfo>();
 
 		if (scalar_function.name.empty() || !info.function) {

--- a/src/main/extension/extension_loader.cpp
+++ b/src/main/extension/extension_loader.cpp
@@ -303,16 +303,16 @@ void ExtensionLoader::AddFunctionOverload(ScalarFunction function) {
 void ExtensionLoader::AddFunctionOverload(ScalarFunctionSet functions) { // NOLINT
 	D_ASSERT(!functions.name.empty());
 	auto &scalar_function = GetFunction(functions.name);
+	functions.ApplyToFunctions([&](ScalarFunction &function) { function.name = functions.name; });
 	for (auto &function : functions.functions) {
-		function.name = functions.name;
 		scalar_function.functions.AddFunction(std::move(function));
 	}
 }
 
 void ExtensionLoader::AddFunctionOverload(TableFunctionSet functions) { // NOLINT
 	auto &table_function = GetTableFunction(functions.name);
+	functions.ApplyToFunctions([&](TableFunction &function) { function.name = functions.name; });
 	for (auto &function : functions.functions) {
-		function.name = functions.name;
 		table_function.functions.AddFunction(std::move(function));
 	}
 }

--- a/src/optimizer/remote_pushdown_optimizer.cpp
+++ b/src/optimizer/remote_pushdown_optimizer.cpp
@@ -868,7 +868,7 @@ CatalogPushdownResult RemotePushdownOptimizer::RewriteTableFunctionOnly(TableFun
 			auto &tf_entry = entry->Cast<TableFunctionCatalogEntry>();
 			bool is_set_returning = false;
 			for (auto &func : tf_entry.functions.functions) {
-				if (func.return_type == TableFunctionReturnType::SET_RETURNING_FUNCTION) {
+				if (func->return_type == TableFunctionReturnType::SET_RETURNING_FUNCTION) {
 					is_set_returning = true;
 					break;
 				}
@@ -1102,7 +1102,7 @@ ExpressionPushdownResult RemotePushdownOptimizer::AnalyzeExpression(const Functi
 		// at least one overload must be non-volatile (the selected overload is verified after binding)
 		auto &scalar_entry = entry->Cast<ScalarFunctionCatalogEntry>();
 		for (auto &overload : scalar_entry.functions.functions) {
-			if (foldable_modifiers && overload.GetStability() != FunctionStability::VOLATILE) {
+			if (foldable_modifiers && overload->GetStability() != FunctionStability::VOLATILE) {
 				state.foldability = ExpressionFoldability::FOLDABLE;
 				break;
 			}

--- a/src/parser/parsed_data/create_aggregate_function_info.cpp
+++ b/src/parser/parsed_data/create_aggregate_function_info.cpp
@@ -12,9 +12,7 @@ CreateAggregateFunctionInfo::CreateAggregateFunctionInfo(AggregateFunction funct
 CreateAggregateFunctionInfo::CreateAggregateFunctionInfo(AggregateFunctionSet set)
     : CreateFunctionInfo(CatalogType::AGGREGATE_FUNCTION_ENTRY), functions(std::move(set)) {
 	SetFunctionName(functions.name);
-	for (auto &func : functions.functions) {
-		func.name = functions.name;
-	}
+	functions.ApplyToFunctions([&](AggregateFunction &func) { func.name = functions.name; });
 	internal = true;
 }
 

--- a/src/parser/parsed_data/create_scalar_function_info.cpp
+++ b/src/parser/parsed_data/create_scalar_function_info.cpp
@@ -12,9 +12,7 @@ CreateScalarFunctionInfo::CreateScalarFunctionInfo(ScalarFunction function)
 CreateScalarFunctionInfo::CreateScalarFunctionInfo(ScalarFunctionSet set)
     : CreateFunctionInfo(CatalogType::SCALAR_FUNCTION_ENTRY), functions(std::move(set)) {
 	SetFunctionName(functions.name);
-	for (auto &func : functions.functions) {
-		func.name = functions.name;
-	}
+	functions.ApplyToFunctions([&](ScalarFunction &func) { func.name = functions.name; });
 	internal = true;
 }
 

--- a/src/parser/parsed_data/create_table_function_info.cpp
+++ b/src/parser/parsed_data/create_table_function_info.cpp
@@ -12,9 +12,7 @@ CreateTableFunctionInfo::CreateTableFunctionInfo(TableFunction function)
 CreateTableFunctionInfo::CreateTableFunctionInfo(TableFunctionSet set)
     : CreateFunctionInfo(CatalogType::TABLE_FUNCTION_ENTRY), functions(std::move(set)) {
 	SetFunctionName(functions.name);
-	for (auto &func : functions.functions) {
-		func.name = functions.name;
-	}
+	functions.ApplyToFunctions([&](TableFunction &func) { func.name = functions.name; });
 	internal = true;
 }
 

--- a/src/parser/parsed_data/create_window_function_info.cpp
+++ b/src/parser/parsed_data/create_window_function_info.cpp
@@ -12,9 +12,7 @@ CreateWindowFunctionInfo::CreateWindowFunctionInfo(WindowFunction function)
 CreateWindowFunctionInfo::CreateWindowFunctionInfo(WindowFunctionSet set)
     : CreateFunctionInfo(CatalogType::WINDOW_FUNCTION_ENTRY), functions(std::move(set)) {
 	SetFunctionName(functions.name);
-	for (auto &func : functions.functions) {
-		func.name = functions.name;
-	}
+	functions.ApplyToFunctions([&](WindowFunction &func) { func.name = functions.name; });
 	internal = true;
 }
 

--- a/src/planner/binder/expression/bind_function_expression.cpp
+++ b/src/planner/binder/expression/bind_function_expression.cpp
@@ -373,7 +373,7 @@ BindResult ExpressionBinder::BindFunction(FunctionExpression &function, ScalarFu
 BindResult ExpressionBinder::BindLambdaFunction(FunctionExpression &function, ScalarFunctionCatalogEntry &func,
                                                 idx_t depth) {
 	// get the callback function for the lambda parameter types
-	auto &scalar_function = func.functions.functions.front();
+	auto &scalar_function = *func.functions.functions.front();
 	auto bind_lambda_function = scalar_function.GetBindLambdaCallback();
 	if (!bind_lambda_function) {
 		return BindResult("This scalar function does not support lambdas!");

--- a/src/planner/binder/statement/bind_pragma.cpp
+++ b/src/planner/binder/statement/bind_pragma.cpp
@@ -57,7 +57,7 @@ unique_ptr<BoundPragmaInfo> Binder::BindPragma(PragmaInfo &info, QueryErrorConte
 		error.AddQueryLocation(error_context);
 		error.Throw();
 	}
-	auto bound_function = entry->functions.GetFunctionByOffset(bound_idx.GetIndex());
+	auto bound_function = *entry->functions.GetFunctionByOffset(bound_idx.GetIndex());
 	// bind and check named params
 	BindNamedParameters(bound_function.named_parameters, named_parameters, error_context, bound_function.name);
 	return make_uniq<BoundPragmaInfo>(std::move(bound_function), std::move(params), std::move(named_parameters));

--- a/src/planner/binder/tableref/bind_table_function.cpp
+++ b/src/planner/binder/tableref/bind_table_function.cpp
@@ -43,7 +43,7 @@ static TableFunctionBindType GetTableFunctionBindType(TableFunctionCatalogEntry 
 	bool has_standard_table_function = false;
 	bool has_table_parameter = false;
 	for (idx_t function_idx = 0; function_idx < table_function.functions.Size(); function_idx++) {
-		const auto &function = table_function.functions.GetFunctionByOffset(function_idx);
+		const auto &function = *table_function.functions.GetFunctionByOffset(function_idx);
 		for (auto &arg : function.GetArguments()) {
 			if (arg.id() == LogicalTypeId::TABLE) {
 				has_table_parameter = true;
@@ -119,7 +119,7 @@ bool Binder::BindTableFunctionParameters(TableFunctionCatalogEntry &table_functi
 		if (bind_type == TableFunctionBindType::TABLE_PARAMETER_FUNCTION &&
 		    child->GetExpressionType() == ExpressionType::SUBQUERY) {
 			D_ASSERT(table_function.functions.Size() == 1);
-			const auto &fun = table_function.functions.GetFunctionByOffset(0);
+			const auto &fun = *table_function.functions.GetFunctionByOffset(0);
 			if (table_function.functions.Size() != 1 || fun.GetArguments().empty()) {
 				throw BinderException(
 				    "Only table-in-out functions can have subquery parameters - %s only accepts constant parameters",
@@ -449,7 +449,8 @@ BoundStatement Binder::Bind(TableFunctionRef &ref) {
 		error.AddQueryLocation(ref);
 		error.Throw();
 	}
-	auto table_function = function.functions.GetFunctionByOffset(best_function_idx.GetIndex());
+	// copied out of the set: BindTableFunctionInternal fills in the bound arguments/return types
+	auto table_function = *function.functions.GetFunctionByOffset(best_function_idx.GetIndex());
 
 	// now check the named parameters
 	BindNamedParameters(table_function.named_parameters, named_parameters, error_context, table_function.name);

--- a/src/planner/expression/bound_function_expression.cpp
+++ b/src/planner/expression/bound_function_expression.cpp
@@ -146,6 +146,7 @@ unique_ptr<Expression> BoundFunctionExpression::Copy() const {
 
 void BoundFunctionExpression::Verify() const {
 	D_ASSERT(!function.GetName().empty());
+	D_ASSERT(function.GetDefinition());
 }
 
 void BoundFunctionExpression::Serialize(Serializer &serializer) const {

--- a/test/optimizer/aggregate_rewrite.cpp
+++ b/test/optimizer/aggregate_rewrite.cpp
@@ -26,7 +26,7 @@ static unique_ptr<BoundAggregateExpression> BindAggregate(ClientContext &context
 	auto &catalog = Catalog::GetSystemCatalog(context);
 	auto &entry = catalog.GetEntry<AggregateFunctionCatalogEntry>(
 	    context, QualifiedName(catalog.GetName(), Identifier::DefaultSchema(), name));
-	const auto &function = entry.functions.GetFunctionByArguments(context, {child->GetReturnType()});
+	auto function = entry.functions.GetFunctionByArguments(context, {child->GetReturnType()});
 	FunctionBinder function_binder(context);
 	vector<unique_ptr<Expression>> children;
 	children.push_back(std::move(child));
@@ -127,7 +127,7 @@ static void RegisterDagAggregate(Connection &con, const char *name = "test_dag_a
                                  OptimizerType optimizer_type = OptimizerType::INVALID,
                                  aggregate_rewrite_cost_t cost = nullptr) {
 	auto functions = CountFun::GetFunctions();
-	auto function = functions.GetFunctionByArguments(*con.context, {LogicalType::BIGINT});
+	auto function = *functions.GetFunctionByArguments(*con.context, {LogicalType::BIGINT});
 	function.SetName(name);
 	function.SetRewriteCallback(RewriteDagAggregate, policy, optimizer_type, cost);
 	CreateAggregateFunctionInfo info(function);


### PR DESCRIPTION
This makes it easier to identify which function a "bound" function was instantiated from, as well as makes it cheaper to "copy" functions and function sets (especially now that they carry `FunctionSignature`s.

Most of the diff is the patches, almost all the changes in the files are just one-line dereference-the-shared-pointer edits.