### PR TITLE
Allow extension to register custom compression filesystem

### DIFF
--- a/.github/patches/extensions/spatial/0007-compression-file-open-options.patch
+++ b/.github/patches/extensions/spatial/0007-compression-file-open-options.patch
@@ -1,0 +1,28 @@
+commit 16f027631e496e8ed902f9ff64722a93aa88d03e
+Author: dentinyhao <dentinyhao@gmail.com>
+Date:   Mon Aug 24 02:47:13 2026 -0700
+
+    Fix compression on file open option
+
+diff --git a/src/spatial/modules/shapefile/shapefile_module.cpp b/src/spatial/modules/shapefile/shapefile_module.cpp
+index 6ef8fb5..fe81e1f 100644
+--- a/src/spatial/modules/shapefile/shapefile_module.cpp
++++ b/src/spatial/modules/shapefile/shapefile_module.cpp
+@@ -124,7 +124,7 @@ struct EncodingUtil {
+ SAFile DuckDBShapefileOpen(void *userData, const char *filename, const char *access_mode) {
+ 	try {
+ 		auto &fs = *static_cast<FileSystem *>(userData);
+-		constexpr auto flags = FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS;
++		const auto flags = FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS;
+ 		auto file_handle = fs.OpenFile(filename, flags);
+ 		if (!file_handle) {
+ 			return nullptr;
+@@ -194,7 +194,7 @@ int DuckDBShapefileClose(SAFile file) {
+ int DuckDBShapefileRemove(void *userData, const char *filename) {
+ 	try {
+ 		auto &fs = *reinterpret_cast<FileSystem *>(userData);
+-		constexpr auto flags = FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS;
++		const auto flags = FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS;
+ 		const auto file = fs.OpenFile(filename, flags);
+ 		if (!file) {
+ 			return -1;

--- a/extension/json/json_multi_file_info.cpp
+++ b/extension/json/json_multi_file_info.cpp
@@ -70,7 +70,7 @@ bool JSONMultiFileInfo::ParseOption(ClientContext &context, const Identifier &ke
 		return true;
 	}
 	if (key == "compression") {
-		options.compression = FileCompressionTypeFromString(StringValue::Get(value));
+		options.compression = FileCompressionType(StringValue::Get(value));
 		return true;
 	}
 	if (key == "columns") {
@@ -252,7 +252,7 @@ bool JSONMultiFileInfo::ParseCopyOption(ClientContext &context, const Identifier
 	}
 	if (key == "compression") {
 		JSONCheckSingleParameter(key, values);
-		options.compression = FileCompressionTypeFromString(StringValue::Get(values.back()));
+		options.compression = FileCompressionType(StringValue::Get(values.back()));
 		return true;
 	}
 	if (key == "array") {

--- a/extension/json/json_multi_file_info.cpp
+++ b/extension/json/json_multi_file_info.cpp
@@ -70,7 +70,7 @@ bool JSONMultiFileInfo::ParseOption(ClientContext &context, const Identifier &ke
 		return true;
 	}
 	if (key == "compression") {
-		options.compression = EnumUtil::FromString<FileCompressionType>(StringUtil::Upper(StringValue::Get(value)));
+		options.compression = FileCompressionTypeFromString(StringValue::Get(value));
 		return true;
 	}
 	if (key == "columns") {
@@ -252,8 +252,7 @@ bool JSONMultiFileInfo::ParseCopyOption(ClientContext &context, const Identifier
 	}
 	if (key == "compression") {
 		JSONCheckSingleParameter(key, values);
-		options.compression =
-		    EnumUtil::FromString<FileCompressionType>(StringUtil::Upper(StringValue::Get(values.back())));
+		options.compression = FileCompressionTypeFromString(StringValue::Get(values.back()));
 		return true;
 	}
 	if (key == "array") {

--- a/extension/parquet/include/zstd_file_system.hpp
+++ b/extension/parquet/include/zstd_file_system.hpp
@@ -27,6 +27,14 @@ public:
 		return "ZStdFileSystem";
 	}
 
+	FileCompressionType GetCompressionType() override {
+		return FileCompressionType::ZSTD;
+	}
+
+	bool CanHandleFile(const string &fpath) override {
+		return IsFileCompressed(fpath, FileCompressionType::ZSTD);
+	}
+
 	unique_ptr<StreamWrapper> CreateStream() override;
 	idx_t InBufferSize() override;
 	idx_t OutBufferSize() override;

--- a/extension/parquet/parquet_extension.cpp
+++ b/extension/parquet/parquet_extension.cpp
@@ -999,7 +999,7 @@ static vector<unique_ptr<Expression>> ParquetWriteSelect(CopyToSelectInput &inpu
 static void LoadInternal(ExtensionLoader &loader) {
 	auto &db_instance = loader.GetDatabaseInstance();
 	auto &fs = db_instance.GetFileSystem();
-	fs.RegisterSubSystem(FileCompressionType::ZSTD, make_uniq<ZStdFileSystem>());
+	fs.RegisterCompressionFilesystem(make_uniq<ZStdFileSystem>());
 
 	auto scan_fun = ParquetScanFunction::GetFunctionSet();
 	scan_fun.SetName("read_parquet");

--- a/src/common/compressed_file_system.cpp
+++ b/src/common/compressed_file_system.cpp
@@ -8,6 +8,10 @@ namespace duckdb {
 StreamWrapper::~StreamWrapper() {
 }
 
+bool CompressedFileSystem::CanHandleFile(const string &fpath) {
+	return false;
+}
+
 CompressedFile::CompressedFile(CompressedFileSystem &fs, unique_ptr<FileHandle> child_handle_p, const string &path)
     : FileHandle(fs, path, child_handle_p->GetFlags()), compressed_fs(fs), child_handle(std::move(child_handle_p)) {
 	// The real on-disk I/O happens on the (compressed) child handle; attribute the bytes there instead of

--- a/src/common/csv_writer.cpp
+++ b/src/common/csv_writer.cpp
@@ -69,7 +69,7 @@ CSVWriter::CSVWriter(CSVReaderOptions &options_p, FileSystem &fs, const string &
                      options.dialect_options.state_machine_options.quote.GetValue(), options.write_newline),
       file_writer(make_uniq<BufferedFileWriter>(fs, file_path,
                                                 FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE_NEW |
-                                                    FileLockType::WRITE_LOCK | compression,
+                                                    FileLockType::WRITE_LOCK | std::move(compression),
                                                 context)),
       write_stream(*file_writer), should_initialize(true), shared(shared) {
 	if (!shared) {

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -2445,26 +2445,6 @@ FileBufferType EnumUtil::FromString<FileBufferType>(const char *value) {
 	return static_cast<FileBufferType>(StringUtil::StringToEnum(GetFileBufferTypeValues(), 4, "FileBufferType", value));
 }
 
-const StringUtil::EnumStringLiteral *GetFileCompressionTypeValues() {
-	static constexpr StringUtil::EnumStringLiteral values[] {
-		{ static_cast<uint32_t>(FileCompressionType::AUTO_DETECT), "AUTO_DETECT" },
-		{ static_cast<uint32_t>(FileCompressionType::UNCOMPRESSED), "UNCOMPRESSED" },
-		{ static_cast<uint32_t>(FileCompressionType::GZIP), "GZIP" },
-		{ static_cast<uint32_t>(FileCompressionType::ZSTD), "ZSTD" }
-	};
-	return values;
-}
-
-template<>
-const char* EnumUtil::ToChars<FileCompressionType>(FileCompressionType value) {
-	return StringUtil::EnumToString(GetFileCompressionTypeValues(), 4, "FileCompressionType", static_cast<uint32_t>(value));
-}
-
-template<>
-FileCompressionType EnumUtil::FromString<FileCompressionType>(const char *value) {
-	return static_cast<FileCompressionType>(StringUtil::StringToEnum(GetFileCompressionTypeValues(), 4, "FileCompressionType", value));
-}
-
 const StringUtil::EnumStringLiteral *GetFileExpandResultValues() {
 	static constexpr StringUtil::EnumStringLiteral values[] {
 		{ static_cast<uint32_t>(FileExpandResult::NO_FILES), "NO_FILES" },

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -37,7 +37,6 @@
 #include "duckdb/common/enums/destroy_buffer_upon.hpp"
 #include "duckdb/common/enums/dialect_compatibility_mode.hpp"
 #include "duckdb/common/enums/expression_type.hpp"
-#include "duckdb/common/enums/file_compression_type.hpp"
 #include "duckdb/common/enums/file_glob_options.hpp"
 #include "duckdb/common/enums/file_write_mode.hpp"
 #include "duckdb/common/enums/filter_propagate_result.hpp"

--- a/src/common/enums/file_compression_type.cpp
+++ b/src/common/enums/file_compression_type.cpp
@@ -1,36 +1,37 @@
 #include "duckdb/common/enums/file_compression_type.hpp"
 #include "duckdb/common/string_util.hpp"
-#include "duckdb/common/exception/parser_exception.hpp"
+#include "duckdb/common/exception.hpp"
 
 namespace duckdb {
 
+const FileCompressionType FileCompressionType::AUTO_DETECT = FileCompressionType("auto_detect");
+const FileCompressionType FileCompressionType::UNCOMPRESSED = FileCompressionType("uncompressed");
+const FileCompressionType FileCompressionType::GZIP = FileCompressionType("gzip");
+const FileCompressionType FileCompressionType::ZSTD = FileCompressionType("zstd");
+
+FileCompressionType::FileCompressionType(string compression_p) : compression(StringUtil::Lower(compression_p)) {
+	if (compression == "infer" || compression == "auto") {
+		compression = "auto_detect";
+	} else if (compression == "none" || compression.empty()) {
+		compression = "uncompressed";
+	}
+}
+
 FileCompressionType FileCompressionTypeFromString(const string &input) {
-	auto parameter = StringUtil::Lower(input);
-	if (parameter == "infer" || parameter == "auto") {
-		return FileCompressionType::AUTO_DETECT;
-	} else if (parameter == "gzip") {
-		return FileCompressionType::GZIP;
-	} else if (parameter == "zstd") {
-		return FileCompressionType::ZSTD;
-	} else if (parameter == "uncompressed" || parameter == "none" || parameter.empty()) {
-		return FileCompressionType::UNCOMPRESSED;
-	} else {
-		throw ParserException("Unrecognized file compression type \"%s\"", input);
-	}
+	return FileCompressionType(input);
 }
 
-string CompressionExtensionFromType(const FileCompressionType type) {
-	switch (type) {
-	case FileCompressionType::GZIP:
+string CompressionExtensionFromType(const FileCompressionType &type) {
+	if (type == FileCompressionType::GZIP) {
 		return ".gz";
-	case FileCompressionType::ZSTD:
-		return ".zst";
-	default:
-		throw NotImplementedException("Compression Extension of file compression type is not implemented");
 	}
+	if (type == FileCompressionType::ZSTD) {
+		return ".zst";
+	}
+	throw NotImplementedException("Compression Extension of file compression type is not implemented");
 }
 
-bool IsFileCompressed(string path, FileCompressionType type) {
+bool IsFileCompressed(string path, const FileCompressionType &type) {
 	auto extension = CompressionExtensionFromType(type);
 	std::size_t question_mark_pos = std::string::npos;
 	if (!StringUtil::StartsWith(path, "\\\\?\\")) {

--- a/src/common/enums/file_compression_type.cpp
+++ b/src/common/enums/file_compression_type.cpp
@@ -17,10 +17,6 @@ FileCompressionType::FileCompressionType(string compression_p) : compression(Str
 	}
 }
 
-FileCompressionType FileCompressionTypeFromString(const string &input) {
-	return FileCompressionType(input);
-}
-
 string CompressionExtensionFromType(const FileCompressionType &type) {
 	if (type == FileCompressionType::GZIP) {
 		return ".gz";

--- a/src/common/enums/file_compression_type.cpp
+++ b/src/common/enums/file_compression_type.cpp
@@ -9,12 +9,42 @@ const FileCompressionType FileCompressionType::UNCOMPRESSED = FileCompressionTyp
 const FileCompressionType FileCompressionType::GZIP = FileCompressionType("gzip");
 const FileCompressionType FileCompressionType::ZSTD = FileCompressionType("zstd");
 
+// note: the constructors and predicates below use string literals instead of the constants above, as they can run
+// during static initialization of globals in other translation units (e.g. FileFlags), before the constants are
+// initialized
+FileCompressionType::FileCompressionType() : compression("uncompressed") {
+}
+
 FileCompressionType::FileCompressionType(string compression_p) : compression(StringUtil::Lower(compression_p)) {
 	if (compression == "infer" || compression == "auto") {
 		compression = "auto_detect";
 	} else if (compression == "none" || compression.empty()) {
 		compression = "uncompressed";
 	}
+}
+
+bool FileCompressionType::operator==(const FileCompressionType &other) const {
+	return compression == other.compression;
+}
+
+bool FileCompressionType::operator!=(const FileCompressionType &other) const {
+	return compression != other.compression;
+}
+
+bool FileCompressionType::IsCompressed() const {
+	return !IsUncompressed() && !IsAutoDetect();
+}
+
+bool FileCompressionType::IsUncompressed() const {
+	return compression == "uncompressed";
+}
+
+bool FileCompressionType::IsAutoDetect() const {
+	return compression == "auto_detect";
+}
+
+const string &FileCompressionType::ToString() const {
+	return compression;
 }
 
 string CompressionExtensionFromType(const FileCompressionType &type) {

--- a/src/common/enums/file_compression_type.cpp
+++ b/src/common/enums/file_compression_type.cpp
@@ -15,7 +15,7 @@ const FileCompressionType FileCompressionType::ZSTD = FileCompressionType("zstd"
 FileCompressionType::FileCompressionType() : compression("uncompressed") {
 }
 
-FileCompressionType::FileCompressionType(string compression_p) : compression(StringUtil::Lower(compression_p)) {
+FileCompressionType::FileCompressionType(const string &compression_p) : compression(StringUtil::Lower(compression_p)) {
 	if (compression == "infer" || compression == "auto") {
 		compression = "auto_detect";
 	} else if (compression == "none" || compression.empty()) {

--- a/src/common/enums/file_compression_type.cpp
+++ b/src/common/enums/file_compression_type.cpp
@@ -15,7 +15,8 @@ const FileCompressionType FileCompressionType::ZSTD = FileCompressionType("zstd"
 FileCompressionType::FileCompressionType() : compression("uncompressed") {
 }
 
-FileCompressionType::FileCompressionType(const string &compression_p) : compression(StringUtil::Lower(compression_p)) {
+FileCompressionType::FileCompressionType(string compression_p) : compression(std::move(compression_p)) {
+	compression = StringUtil::Lower(compression);
 	if (compression == "infer" || compression == "auto") {
 		compression = "auto_detect";
 	} else if (compression == "none" || compression.empty()) {

--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -658,6 +658,11 @@ void FileSystem::UnregisterSubSystem(const string &name) {
 	throw NotImplementedException("%s: Can't unregister a sub system on a non-virtual file system", GetName());
 }
 
+void FileSystem::RegisterCompressionFilesystem(unique_ptr<FileSystem> fs) {
+	throw NotImplementedException("%s: Can't register a compression filesystem on a non-virtual file system",
+	                              GetName());
+}
+
 unique_ptr<FileSystem> FileSystem::ExtractSubSystem(const string &name) {
 	throw NotImplementedException("%s: Can't extract a sub system on a non-virtual file system", GetName());
 }

--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/common/file_system.hpp"
 
 #include "duckdb/common/checksum.hpp"
+#include "duckdb/common/compressed_file_system.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/file_opener.hpp"
 #include "duckdb/common/helper.hpp"
@@ -48,20 +49,23 @@ extern "C" WINBASEAPI BOOL WINAPI GetPhysicallyInstalledSystemMemory(PULONGLONG)
 
 namespace duckdb {
 
-constexpr FileOpenFlags FileFlags::FILE_FLAGS_READ;
-constexpr FileOpenFlags FileFlags::FILE_FLAGS_WRITE;
-constexpr FileOpenFlags FileFlags::FILE_FLAGS_DIRECT_IO;
-constexpr FileOpenFlags FileFlags::FILE_FLAGS_FILE_CREATE;
-constexpr FileOpenFlags FileFlags::FILE_FLAGS_FILE_CREATE_NEW;
-constexpr FileOpenFlags FileFlags::FILE_FLAGS_APPEND;
-constexpr FileOpenFlags FileFlags::FILE_FLAGS_PRIVATE;
-constexpr FileOpenFlags FileFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS;
-constexpr FileOpenFlags FileFlags::FILE_FLAGS_PARALLEL_ACCESS;
-constexpr FileOpenFlags FileFlags::FILE_FLAGS_EXCLUSIVE_CREATE;
-constexpr FileOpenFlags FileFlags::FILE_FLAGS_NULL_IF_EXISTS;
-constexpr FileOpenFlags FileFlags::FILE_FLAGS_MULTI_CLIENT_ACCESS;
-constexpr FileOpenFlags FileFlags::FILE_FLAGS_DISABLE_LOGGING;
-constexpr FileOpenFlags FileFlags::FILE_FLAGS_ENABLE_EXTENSION_INSTALL;
+const FileOpenFlags FileFlags::FILE_FLAGS_READ = FileOpenFlags(FileOpenFlags::FILE_FLAGS_READ);
+const FileOpenFlags FileFlags::FILE_FLAGS_WRITE = FileOpenFlags(FileOpenFlags::FILE_FLAGS_WRITE);
+const FileOpenFlags FileFlags::FILE_FLAGS_DIRECT_IO = FileOpenFlags(FileOpenFlags::FILE_FLAGS_DIRECT_IO);
+const FileOpenFlags FileFlags::FILE_FLAGS_FILE_CREATE = FileOpenFlags(FileOpenFlags::FILE_FLAGS_FILE_CREATE);
+const FileOpenFlags FileFlags::FILE_FLAGS_FILE_CREATE_NEW = FileOpenFlags(FileOpenFlags::FILE_FLAGS_FILE_CREATE_NEW);
+const FileOpenFlags FileFlags::FILE_FLAGS_APPEND = FileOpenFlags(FileOpenFlags::FILE_FLAGS_APPEND);
+const FileOpenFlags FileFlags::FILE_FLAGS_PRIVATE = FileOpenFlags(FileOpenFlags::FILE_FLAGS_PRIVATE);
+const FileOpenFlags FileFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS =
+    FileOpenFlags(FileOpenFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS);
+const FileOpenFlags FileFlags::FILE_FLAGS_PARALLEL_ACCESS = FileOpenFlags(FileOpenFlags::FILE_FLAGS_PARALLEL_ACCESS);
+const FileOpenFlags FileFlags::FILE_FLAGS_EXCLUSIVE_CREATE = FileOpenFlags(FileOpenFlags::FILE_FLAGS_EXCLUSIVE_CREATE);
+const FileOpenFlags FileFlags::FILE_FLAGS_NULL_IF_EXISTS = FileOpenFlags(FileOpenFlags::FILE_FLAGS_NULL_IF_EXISTS);
+const FileOpenFlags FileFlags::FILE_FLAGS_MULTI_CLIENT_ACCESS =
+    FileOpenFlags(FileOpenFlags::FILE_FLAGS_MULTI_CLIENT_ACCESS);
+const FileOpenFlags FileFlags::FILE_FLAGS_DISABLE_LOGGING = FileOpenFlags(FileOpenFlags::FILE_FLAGS_DISABLE_LOGGING);
+const FileOpenFlags FileFlags::FILE_FLAGS_ENABLE_EXTENSION_INSTALL =
+    FileOpenFlags(FileOpenFlags::FILE_FLAGS_ENABLE_EXTENSION_INSTALL);
 
 void FileOpenFlags::Verify() {
 #ifdef DEBUG
@@ -650,15 +654,11 @@ void FileSystem::RegisterSubSystem(unique_ptr<FileSystem> sub_fs) {
 	throw NotImplementedException("%s: Can't register a sub system on a non-virtual file system", GetName());
 }
 
-void FileSystem::RegisterSubSystem(FileCompressionType compression_type, unique_ptr<FileSystem> sub_fs) {
-	throw NotImplementedException("%s: Can't register a sub system on a non-virtual file system", GetName());
-}
-
 void FileSystem::UnregisterSubSystem(const string &name) {
 	throw NotImplementedException("%s: Can't unregister a sub system on a non-virtual file system", GetName());
 }
 
-void FileSystem::RegisterCompressionFilesystem(unique_ptr<FileSystem> fs) {
+void FileSystem::RegisterCompressionFilesystem(unique_ptr<CompressedFileSystem> fs) {
 	throw NotImplementedException("%s: Can't register a compression filesystem on a non-virtual file system",
 	                              GetName());
 }

--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -412,7 +412,8 @@ string FileSystem::ExpandPath(const string &path) {
 }
 
 // LCOV_EXCL_START
-unique_ptr<FileHandle> FileSystem::OpenFileExtended(const OpenFileInfo &path, FileOpenFlags flags,
+unique_ptr<FileHandle> FileSystem::OpenFileExtended(const OpenFileInfo &path,
+                                                    FileOpenFlags flags, // NOLINT: virtual, overrides mutate flags
                                                     optional_ptr<FileOpener> opener) {
 	throw NotImplementedException("%s: OpenFileExtended is not implemented!", GetName());
 }
@@ -424,12 +425,12 @@ bool FileSystem::ListFilesExtended(const string &directory, const std::function<
 
 unique_ptr<FileHandle> FileSystem::OpenFile(const string &path, FileOpenFlags flags, optional_ptr<FileOpener> opener) {
 	if (SupportsOpenFileExtended()) {
-		return OpenFileExtended(OpenFileInfo(path), flags, opener);
+		return OpenFileExtended(OpenFileInfo(path), std::move(flags), opener);
 	}
 	throw NotImplementedException("%s: OpenFile is not implemented!", GetName());
 }
 
-unique_ptr<FileHandle> FileSystem::OpenFile(const OpenFileInfo &file, FileOpenFlags flags,
+unique_ptr<FileHandle> FileSystem::OpenFile(const OpenFileInfo &file, const FileOpenFlags &flags,
                                             optional_ptr<FileOpener> opener) {
 	if (SupportsOpenFileExtended()) {
 		return OpenFileExtended(file, flags, opener);
@@ -755,8 +756,8 @@ bool FileSystem::TryGetNetworkThroughput(FileHandle &handle, NetworkThroughputEs
 	return false;
 }
 
-FileHandle::FileHandle(FileSystem &file_system, string path_p, FileOpenFlags flags)
-    : file_system(file_system), path(std::move(path_p)), flags(flags) {
+FileHandle::FileHandle(FileSystem &file_system, string path_p, FileOpenFlags flags_p)
+    : file_system(file_system), path(std::move(path_p)), flags(std::move(flags_p)) {
 }
 
 FileHandle::~FileHandle() {

--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -204,7 +204,7 @@ bool LocalFileSystem::IsPipe(const string &filename, optional_ptr<FileOpener> op
 struct UnixFileHandle : public FileHandle {
 public:
 	UnixFileHandle(FileSystem &file_system, string path, int fd, FileOpenFlags flags, optional_ptr<DatabaseInstance> db)
-	    : FileHandle(file_system, std::move(path), flags), fd(fd), db(db) {
+	    : FileHandle(file_system, std::move(path), std::move(flags)), fd(fd), db(db) {
 	}
 	~UnixFileHandle() override {
 		UnixFileHandle::Close();
@@ -915,7 +915,7 @@ private:
 
 UnixMemoryMappedFile::UnixMemoryMappedFile(string path_p, FileOpenFlags flags_p, int fd_p, data_ptr_t data_p,
                                            idx_t size_p)
-    : MemoryMappedFile(std::move(path_p), flags_p, data_p, size_p), fd(fd_p) {
+    : MemoryMappedFile(std::move(path_p), std::move(flags_p), data_p, size_p), fd(fd_p) {
 }
 
 UnixMemoryMappedFile::~UnixMemoryMappedFile() {

--- a/src/common/memory_mapped_file.cpp
+++ b/src/common/memory_mapped_file.cpp
@@ -8,7 +8,7 @@ namespace duckdb {
 // Platform-specific MemoryMappedFile subclasses and the LocalFileSystem::MemoryMapFile
 // factory live in src/common/local_file_system.cpp.
 MemoryMappedFile::MemoryMappedFile(string path_p, FileOpenFlags flags_p, data_ptr_t data_p, idx_t size_p)
-    : path(std::move(path_p)), flags(flags_p), data(data_p), size(size_p) {
+    : path(std::move(path_p)), flags(std::move(flags_p)), data(data_p), size(size_p) {
 }
 
 MemoryMappedFile::~MemoryMappedFile() {
@@ -32,7 +32,8 @@ data_ptr_t MemoryMappedFile::GetDataMutable(idx_t location, idx_t nr_bytes) {
 	return data + location;
 }
 
-unique_ptr<MemoryMappedFile> FileSystem::MemoryMapFile(const OpenFileInfo &path, FileOpenFlags flags,
+unique_ptr<MemoryMappedFile> FileSystem::MemoryMapFile(const OpenFileInfo &path,
+                                                       FileOpenFlags flags, // NOLINT: signature fixed by virtual API
                                                        const MMapOptions &options, optional_ptr<FileOpener> opener) {
 	throw NotImplementedException("Memory-mapped file access is not supported by this file system (%s) for path \"%s\"",
 	                              GetName(), path.path);

--- a/src/common/opener_file_system.cpp
+++ b/src/common/opener_file_system.cpp
@@ -1,10 +1,15 @@
 #include "duckdb/common/opener_file_system.hpp"
+#include "duckdb/common/compressed_file_system.hpp"
 #include "duckdb/common/file_opener.hpp"
 #include "duckdb/common/memory_mapped_file.hpp"
 #include "duckdb/main/database.hpp"
 #include "duckdb/main/config.hpp"
 
 namespace duckdb {
+
+void OpenerFileSystem::RegisterCompressionFilesystem(unique_ptr<CompressedFileSystem> fs) {
+	GetFileSystem().RegisterCompressionFilesystem(std::move(fs));
+}
 
 unique_ptr<MemoryMappedFile> OpenerFileSystem::MemoryMapFile(const OpenFileInfo &path, FileOpenFlags flags,
                                                              const MMapOptions &options,

--- a/src/common/serializer/async_file_writer.cpp
+++ b/src/common/serializer/async_file_writer.cpp
@@ -9,7 +9,6 @@
 
 namespace duckdb {
 
-// Initialized from the raw flag bits to avoid depending on cross-translation-unit initialization order
 const FileOpenFlags AsyncFileWriter::DEFAULT_OPEN_FLAGS =
     FileOpenFlags(FileOpenFlags::FILE_FLAGS_WRITE | FileOpenFlags::FILE_FLAGS_FILE_CREATE);
 

--- a/src/common/serializer/async_file_writer.cpp
+++ b/src/common/serializer/async_file_writer.cpp
@@ -51,7 +51,7 @@ static ClientContext &RequireClientContext(QueryContext context) {
 }
 
 AsyncFileWriter::AsyncFileWriter(QueryContext context_p, FileSystem &fs_p, const string &path_p,
-                                 FileOpenFlags open_flags)
+                                 const FileOpenFlags &open_flags)
     : context(context_p), client_context(RequireClientContext(context_p)), fs(fs_p), path(path_p) {
 	handle = fs.OpenFile(path, open_flags | FileLockType::WRITE_LOCK);
 

--- a/src/common/serializer/async_file_writer.cpp
+++ b/src/common/serializer/async_file_writer.cpp
@@ -9,6 +9,10 @@
 
 namespace duckdb {
 
+// Initialized from the raw flag bits to avoid depending on cross-translation-unit initialization order
+const FileOpenFlags AsyncFileWriter::DEFAULT_OPEN_FLAGS =
+    FileOpenFlags(FileOpenFlags::FILE_FLAGS_WRITE | FileOpenFlags::FILE_FLAGS_FILE_CREATE);
+
 class CopiedAsyncWriteBuffer : public AsyncWriteBuffer {
 public:
 	CopiedAsyncWriteBuffer(ClientContext &context, idx_t capacity_p)

--- a/src/common/serializer/buffered_file_writer.cpp
+++ b/src/common/serializer/buffered_file_writer.cpp
@@ -8,8 +8,6 @@
 
 namespace duckdb {
 
-// Remove this when we switch C++17: https://stackoverflow.com/a/53350948
-// Initialized from the raw flag bits to avoid depending on cross-translation-unit initialization order
 const FileOpenFlags BufferedFileWriter::DEFAULT_OPEN_FLAGS =
     FileOpenFlags(FileOpenFlags::FILE_FLAGS_WRITE | FileOpenFlags::FILE_FLAGS_FILE_CREATE);
 

--- a/src/common/serializer/buffered_file_writer.cpp
+++ b/src/common/serializer/buffered_file_writer.cpp
@@ -9,7 +9,9 @@
 namespace duckdb {
 
 // Remove this when we switch C++17: https://stackoverflow.com/a/53350948
-constexpr FileOpenFlags BufferedFileWriter::DEFAULT_OPEN_FLAGS;
+// Initialized from the raw flag bits to avoid depending on cross-translation-unit initialization order
+const FileOpenFlags BufferedFileWriter::DEFAULT_OPEN_FLAGS =
+    FileOpenFlags(FileOpenFlags::FILE_FLAGS_WRITE | FileOpenFlags::FILE_FLAGS_FILE_CREATE);
 
 BufferedFileWriter::BufferedFileWriter(FileSystem &fs, const string &path_p, FileOpenFlags open_flags,
                                        QueryContext context_p)

--- a/src/common/serializer/buffered_file_writer.cpp
+++ b/src/common/serializer/buffered_file_writer.cpp
@@ -11,7 +11,7 @@ namespace duckdb {
 const FileOpenFlags BufferedFileWriter::DEFAULT_OPEN_FLAGS =
     FileOpenFlags(FileOpenFlags::FILE_FLAGS_WRITE | FileOpenFlags::FILE_FLAGS_FILE_CREATE);
 
-BufferedFileWriter::BufferedFileWriter(FileSystem &fs, const string &path_p, FileOpenFlags open_flags,
+BufferedFileWriter::BufferedFileWriter(FileSystem &fs, const string &path_p, const FileOpenFlags &open_flags,
                                        QueryContext context_p)
     : fs(fs), path(path_p), data(make_unsafe_uniq_array_uninitialized<data_t>(FILE_BUFFER_SIZE)), offset(0),
       total_written(0), context(context_p) {

--- a/src/common/virtual_file_system.cpp
+++ b/src/common/virtual_file_system.cpp
@@ -5,6 +5,8 @@
 #include "duckdb/common/gzip_file_system.hpp"
 #include "duckdb/common/pipe_file_system.hpp"
 #include "duckdb/common/string_util.hpp"
+#include "duckdb/common/unordered_map.hpp"
+#include "duckdb/common/unordered_set.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/storage/external_file_cache/caching_file_system_wrapper.hpp"
 #include "duckdb/common/multi_file/multi_file_list.hpp"
@@ -31,14 +33,18 @@ struct FileSystemRegistry {
 	}
 
 	vector<shared_ptr<FileSystemHandle>> sub_systems;
-	map<FileCompressionType, shared_ptr<FileSystemHandle>> compressed_fs;
 	const shared_ptr<FileSystemHandle> default_fs;
 	unordered_set<string> disabled_file_systems;
+	// Registered duckdb internal compression filesystem.
+	unordered_map<FileCompressionType, shared_ptr<FileSystemHandle>> compressed_fs;
+	// Registered external compression filesystems (i.e., extensions).
+	vector<shared_ptr<FileSystemHandle>> external_compressed_fs;
 
 public:
 	shared_ptr<FileSystemRegistry> RegisterSubSystem(unique_ptr<FileSystem> fs) const;
 	shared_ptr<FileSystemRegistry> RegisterSubSystem(FileCompressionType compression_type,
 	                                                 unique_ptr<FileSystem> fs) const;
+	shared_ptr<FileSystemRegistry> RegisterCompressionFilesystem(unique_ptr<FileSystem> fs) const;
 	shared_ptr<FileSystemRegistry> SetDisabledFileSystems(const vector<string> &names) const;
 	shared_ptr<FileSystemRegistry> ExtractSubSystem(const string &name, unique_ptr<FileSystem> &result) const;
 };
@@ -60,6 +66,12 @@ shared_ptr<FileSystemRegistry> FileSystemRegistry::RegisterSubSystem(FileCompres
                                                                      unique_ptr<FileSystem> fs) const {
 	auto new_registry = make_shared_ptr<FileSystemRegistry>(*this);
 	new_registry->compressed_fs[compression_type] = make_shared_ptr<FileSystemHandle>(std::move(fs));
+	return new_registry;
+}
+
+shared_ptr<FileSystemRegistry> FileSystemRegistry::RegisterCompressionFilesystem(unique_ptr<FileSystem> fs) const {
+	auto new_registry = make_shared_ptr<FileSystemRegistry>(*this);
+	new_registry->external_compressed_fs.emplace_back(make_shared_ptr<FileSystemHandle>(std::move(fs)));
 	return new_registry;
 }
 
@@ -133,25 +145,58 @@ FileSystem &VirtualFileSystem::GetDefaultFileSystem() {
 	return fs;
 }
 
-unique_ptr<FileHandle> VirtualFileSystem::OpenFileExtended(const OpenFileInfo &file, FileOpenFlags flags,
-                                                           optional_ptr<FileOpener> opener) {
-	auto compression = flags.Compression();
-	if (compression == FileCompressionType::AUTO_DETECT) {
-		// auto-detect compression settings based on file name
-		auto lower_path = StringUtil::Lower(file.path);
+optional_ptr<FileSystem> VirtualFileSystem::FindCompressionFileSystem(FileCompressionType compression_type,
+                                                                      const string &filepath) {
+	if (compression_type == FileCompressionType::UNCOMPRESSED) {
+		return nullptr;
+	}
+
+	// For auto-detection mode, check if it's a known pattern for duckdb internal compressions.
+	if (compression_type == FileCompressionType::AUTO_DETECT) {
+		auto lower_path = StringUtil::Lower(filepath);
 		if (StringUtil::EndsWith(lower_path, ".tmp")) {
 			// strip .tmp
 			lower_path = lower_path.substr(0, lower_path.length() - 4);
 		}
-		if (IsFileCompressed(file.path, FileCompressionType::GZIP)) {
-			compression = FileCompressionType::GZIP;
-		} else if (IsFileCompressed(file.path, FileCompressionType::ZSTD)) {
-			compression = FileCompressionType::ZSTD;
-		} else {
-			compression = FileCompressionType::UNCOMPRESSED;
+		if (IsFileCompressed(lower_path, FileCompressionType::GZIP)) {
+			compression_type = FileCompressionType::GZIP;
+		} else if (IsFileCompressed(lower_path, FileCompressionType::ZSTD)) {
+			compression_type = FileCompressionType::ZSTD;
 		}
 	}
 
+	// If caller explicitly specifies a duckdb internal compression type to use, or a known pattern is detected, try to
+	// fetch it explicitly.
+	if (compression_type != FileCompressionType::AUTO_DETECT) {
+		auto iter = file_system_registry->compressed_fs.find(compression_type);
+		if (iter != file_system_registry->compressed_fs.end()) {
+			return iter->second->file_system.get();
+		}
+		if (compression_type == FileCompressionType::ZSTD) {
+			throw NotImplementedException(
+			    "Attempting to open a compressed file, but the compression type is not supported.\nConsider "
+			    "explicitly \"INSTALL parquet; LOAD parquet;\" to support this compression scheme");
+		}
+		throw NotImplementedException(
+		    "Attempting to open a compressed file, but the compression type is not supported");
+	}
+
+	// We've checked over all duckdb internal compression types, fallback to try externally registered compression
+	// filesystems.
+	for (auto &cur_compressed_fs : file_system_registry->external_compressed_fs) {
+		if (cur_compressed_fs->file_system->CanHandleFile(filepath)) {
+			return cur_compressed_fs->file_system.get();
+		}
+	}
+
+	// No applicable compression filesystem is found, so we consider it uncompressed.
+	return nullptr;
+}
+
+unique_ptr<FileHandle> VirtualFileSystem::OpenFileExtended(const OpenFileInfo &file, FileOpenFlags flags,
+                                                           optional_ptr<FileOpener> opener) {
+	const auto compression = flags.Compression();
+	auto compression_filesystem = FindCompressionFileSystem(compression, file.path);
 	// open the base file handle in UNCOMPRESSED mode
 	flags.SetCompression(FileCompressionType::UNCOMPRESSED);
 
@@ -178,19 +223,9 @@ unique_ptr<FileHandle> VirtualFileSystem::OpenFileExtended(const OpenFileInfo &f
 	const auto context = !flags.MultiClientAccess() ? FileOpener::TryGetClientContext(opener) : QueryContext();
 	if (file_handle->GetType() == FileType::FILE_TYPE_FIFO) {
 		file_handle = PipeFileSystem::OpenPipe(context, std::move(file_handle));
-	} else if (compression != FileCompressionType::UNCOMPRESSED) {
-		auto entry = registry->compressed_fs.find(compression);
-		if (entry == registry->compressed_fs.end()) {
-			if (compression == FileCompressionType::ZSTD) {
-				throw NotImplementedException(
-				    "Attempting to open a compressed file, but the compression type is not supported.\nConsider "
-				    "explicitly \"INSTALL parquet; LOAD parquet;\" to support this compression scheme");
-			}
-			throw NotImplementedException(
-			    "Attempting to open a compressed file, but the compression type is not supported");
-		}
-		auto &compressed_fs = *entry->second->file_system;
-		file_handle = compressed_fs.OpenCompressedFile(context, std::move(file_handle), flags.OpenForWriting());
+	} else if (compression_filesystem) {
+		file_handle =
+		    compression_filesystem->OpenCompressedFile(context, std::move(file_handle), flags.OpenForWriting());
 	}
 	return file_handle;
 }
@@ -309,6 +344,12 @@ void VirtualFileSystem::RegisterSubSystem(FileCompressionType compression_type, 
 	file_system_registry.atomic_store(new_registry);
 }
 
+void VirtualFileSystem::RegisterCompressionFilesystem(unique_ptr<FileSystem> fs) {
+	const lock_guard<mutex> guard(registry_lock);
+	auto new_registry = file_system_registry->RegisterCompressionFilesystem(std::move(fs));
+	file_system_registry.atomic_store(new_registry);
+}
+
 void VirtualFileSystem::UnregisterSubSystem(const string &name) {
 	auto sub_system = ExtractSubSystem(name);
 
@@ -321,6 +362,7 @@ void VirtualFileSystem::SetDisabledFileSystems(const vector<string> &names) {
 	auto new_registry = file_system_registry->SetDisabledFileSystems(names);
 	file_system_registry.atomic_store(new_registry);
 }
+
 unique_ptr<FileSystem> VirtualFileSystem::ExtractSubSystem(const string &name) {
 	lock_guard<mutex> guard(registry_lock);
 	unique_ptr<FileSystem> result;

--- a/src/common/virtual_file_system.cpp
+++ b/src/common/virtual_file_system.cpp
@@ -138,12 +138,9 @@ FileSystem &VirtualFileSystem::GetDefaultFileSystem() {
 optional_ptr<FileSystem> VirtualFileSystem::FindCompressionFileSystem(FileSystemRegistry &registry,
                                                                       const FileCompressionType &compression,
                                                                       const string &filepath) {
-	if (compression.IsUncompressed()) {
-		return nullptr;
-	}
-
+	auto resolved = compression;
 	// For auto-detection, check whether any registered compression filesystem can handle this file.
-	if (compression.IsAutoDetect()) {
+	if (resolved.IsAutoDetect()) {
 		auto lower_path = StringUtil::Lower(filepath);
 		if (StringUtil::EndsWith(lower_path, ".tmp")) {
 			// strip .tmp
@@ -154,29 +151,30 @@ optional_ptr<FileSystem> VirtualFileSystem::FindCompressionFileSystem(FileSystem
 				return entry.second->file_system.get();
 			}
 		}
-		// zstd support is provided by the parquet extension - hint at loading it if the file looks zstd-compressed
-		if (IsFileCompressed(lower_path, FileCompressionType::ZSTD)) {
-			throw NotImplementedException(
-			    "Attempting to open a compressed file, but the compression type is not supported.\nConsider "
-			    "explicitly \"INSTALL parquet; LOAD parquet;\" to support this compression scheme");
+		if (!IsFileCompressed(lower_path, FileCompressionType::ZSTD)) {
+			// no applicable compression filesystem was found - consider the file uncompressed
+			return nullptr;
 		}
-		// no applicable compression filesystem was found - consider the file uncompressed
+		// the file looks zstd-compressed but zstd is not registered - fall through to raise an error below
+		resolved = FileCompressionType::ZSTD;
+	}
+	if (resolved.IsUncompressed()) {
 		return nullptr;
 	}
 
 	// An explicit compression type was requested - look it up in the registry.
-	auto iter = registry.compressed_fs.find(compression.ToString());
+	auto iter = registry.compressed_fs.find(resolved.ToString());
 	if (iter != registry.compressed_fs.end()) {
 		return iter->second->file_system.get();
 	}
-	if (compression == FileCompressionType::ZSTD) {
-		throw NotImplementedException(
-		    "Attempting to open a compressed file, but the compression type is not supported.\nConsider "
-		    "explicitly \"INSTALL parquet; LOAD parquet;\" to support this compression scheme");
+	// zstd support is provided by the parquet extension - hint at loading it
+	string hint;
+	if (resolved == FileCompressionType::ZSTD) {
+		hint = "\nConsider explicitly \"INSTALL parquet; LOAD parquet;\" to support this compression scheme";
 	}
-	throw NotImplementedException("Attempting to open a file with compression type \"%s\", but no compression "
-	                              "filesystem with that type has been registered",
-	                              compression.ToString());
+	throw NotImplementedException(
+	    "Attempting to open a compressed file, but the compression type is not supported (compression type \"%s\")%s",
+	    resolved.ToString(), hint);
 }
 
 unique_ptr<FileHandle> VirtualFileSystem::OpenFileExtended(const OpenFileInfo &file, FileOpenFlags flags,

--- a/src/common/virtual_file_system.cpp
+++ b/src/common/virtual_file_system.cpp
@@ -57,8 +57,8 @@ shared_ptr<FileSystemRegistry> FileSystemRegistry::RegisterSubSystem(unique_ptr<
 	return new_registry;
 }
 
-shared_ptr<FileSystemRegistry> FileSystemRegistry::RegisterCompressionFilesystem(
-    unique_ptr<CompressedFileSystem> fs) const {
+shared_ptr<FileSystemRegistry>
+FileSystemRegistry::RegisterCompressionFilesystem(unique_ptr<CompressedFileSystem> fs) const {
 	auto new_registry = make_shared_ptr<FileSystemRegistry>(*this);
 	auto compression_type = fs->GetCompressionType().ToString();
 	new_registry->compressed_fs[compression_type] = make_shared_ptr<FileSystemHandle>(std::move(fs));
@@ -207,7 +207,6 @@ unique_ptr<FileHandle> VirtualFileSystem::OpenFileExtended(const OpenFileInfo &f
 	if (file_handle->GetType() == FileType::FILE_TYPE_FIFO) {
 		file_handle = PipeFileSystem::OpenPipe(context, std::move(file_handle));
 	} else {
-		// note: FindFileSystem may have refreshed the registry after autoloading an extension
 		auto compression_filesystem = FindCompressionFileSystem(*registry, compression, file.path);
 		if (compression_filesystem) {
 			file_handle =

--- a/src/common/virtual_file_system.cpp
+++ b/src/common/virtual_file_system.cpp
@@ -1,12 +1,11 @@
 #include "duckdb/common/virtual_file_system.hpp"
 
+#include "duckdb/common/compressed_file_system.hpp"
 #include "duckdb/common/file_opener.hpp"
 #include "duckdb/common/memory_mapped_file.hpp"
 #include "duckdb/common/gzip_file_system.hpp"
 #include "duckdb/common/pipe_file_system.hpp"
 #include "duckdb/common/string_util.hpp"
-#include "duckdb/common/unordered_map.hpp"
-#include "duckdb/common/unordered_set.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/storage/external_file_cache/caching_file_system_wrapper.hpp"
 #include "duckdb/common/multi_file/multi_file_list.hpp"
@@ -35,16 +34,12 @@ struct FileSystemRegistry {
 	vector<shared_ptr<FileSystemHandle>> sub_systems;
 	const shared_ptr<FileSystemHandle> default_fs;
 	unordered_set<string> disabled_file_systems;
-	// Registered duckdb internal compression filesystem.
-	unordered_map<FileCompressionType, shared_ptr<FileSystemHandle>> compressed_fs;
-	// Registered external compression filesystems (i.e., extensions).
-	vector<shared_ptr<FileSystemHandle>> external_compressed_fs;
+	//! Registered compression filesystems (both built-in and provided by extensions), keyed by compression type
+	map<string, shared_ptr<FileSystemHandle>> compressed_fs;
 
 public:
 	shared_ptr<FileSystemRegistry> RegisterSubSystem(unique_ptr<FileSystem> fs) const;
-	shared_ptr<FileSystemRegistry> RegisterSubSystem(FileCompressionType compression_type,
-	                                                 unique_ptr<FileSystem> fs) const;
-	shared_ptr<FileSystemRegistry> RegisterCompressionFilesystem(unique_ptr<FileSystem> fs) const;
+	shared_ptr<FileSystemRegistry> RegisterCompressionFilesystem(unique_ptr<CompressedFileSystem> fs) const;
 	shared_ptr<FileSystemRegistry> SetDisabledFileSystems(const vector<string> &names) const;
 	shared_ptr<FileSystemRegistry> ExtractSubSystem(const string &name, unique_ptr<FileSystem> &result) const;
 };
@@ -62,16 +57,11 @@ shared_ptr<FileSystemRegistry> FileSystemRegistry::RegisterSubSystem(unique_ptr<
 	return new_registry;
 }
 
-shared_ptr<FileSystemRegistry> FileSystemRegistry::RegisterSubSystem(FileCompressionType compression_type,
-                                                                     unique_ptr<FileSystem> fs) const {
+shared_ptr<FileSystemRegistry> FileSystemRegistry::RegisterCompressionFilesystem(
+    unique_ptr<CompressedFileSystem> fs) const {
 	auto new_registry = make_shared_ptr<FileSystemRegistry>(*this);
+	auto compression_type = fs->GetCompressionType().ToString();
 	new_registry->compressed_fs[compression_type] = make_shared_ptr<FileSystemHandle>(std::move(fs));
-	return new_registry;
-}
-
-shared_ptr<FileSystemRegistry> FileSystemRegistry::RegisterCompressionFilesystem(unique_ptr<FileSystem> fs) const {
-	auto new_registry = make_shared_ptr<FileSystemRegistry>(*this);
-	new_registry->external_compressed_fs.emplace_back(make_shared_ptr<FileSystemHandle>(std::move(fs)));
 	return new_registry;
 }
 
@@ -123,7 +113,7 @@ VirtualFileSystem::VirtualFileSystem() : VirtualFileSystem(FileSystem::CreateLoc
 
 VirtualFileSystem::VirtualFileSystem(unique_ptr<FileSystem> &&inner)
     : file_system_registry(make_shared_ptr<FileSystemRegistry>(std::move(inner))) {
-	VirtualFileSystem::RegisterSubSystem(FileCompressionType::GZIP, make_uniq<GZipFileSystem>());
+	VirtualFileSystem::RegisterCompressionFilesystem(make_uniq<GZipFileSystem>());
 }
 
 VirtualFileSystem::~VirtualFileSystem() {
@@ -145,58 +135,53 @@ FileSystem &VirtualFileSystem::GetDefaultFileSystem() {
 	return fs;
 }
 
-optional_ptr<FileSystem> VirtualFileSystem::FindCompressionFileSystem(FileCompressionType compression_type,
+optional_ptr<FileSystem> VirtualFileSystem::FindCompressionFileSystem(FileSystemRegistry &registry,
+                                                                      const FileCompressionType &compression,
                                                                       const string &filepath) {
-	if (compression_type == FileCompressionType::UNCOMPRESSED) {
+	if (compression.IsUncompressed()) {
 		return nullptr;
 	}
 
-	// For auto-detection mode, check if it's a known pattern for duckdb internal compressions.
-	if (compression_type == FileCompressionType::AUTO_DETECT) {
+	// For auto-detection, check whether any registered compression filesystem can handle this file.
+	if (compression.IsAutoDetect()) {
 		auto lower_path = StringUtil::Lower(filepath);
 		if (StringUtil::EndsWith(lower_path, ".tmp")) {
 			// strip .tmp
 			lower_path = lower_path.substr(0, lower_path.length() - 4);
 		}
-		if (IsFileCompressed(lower_path, FileCompressionType::GZIP)) {
-			compression_type = FileCompressionType::GZIP;
-		} else if (IsFileCompressed(lower_path, FileCompressionType::ZSTD)) {
-			compression_type = FileCompressionType::ZSTD;
+		for (auto &entry : registry.compressed_fs) {
+			if (entry.second->file_system->CanHandleFile(lower_path)) {
+				return entry.second->file_system.get();
+			}
 		}
-	}
-
-	// If caller explicitly specifies a duckdb internal compression type to use, or a known pattern is detected, try to
-	// fetch it explicitly.
-	if (compression_type != FileCompressionType::AUTO_DETECT) {
-		auto iter = file_system_registry->compressed_fs.find(compression_type);
-		if (iter != file_system_registry->compressed_fs.end()) {
-			return iter->second->file_system.get();
-		}
-		if (compression_type == FileCompressionType::ZSTD) {
+		// zstd support is provided by the parquet extension - hint at loading it if the file looks zstd-compressed
+		if (IsFileCompressed(lower_path, FileCompressionType::ZSTD)) {
 			throw NotImplementedException(
 			    "Attempting to open a compressed file, but the compression type is not supported.\nConsider "
 			    "explicitly \"INSTALL parquet; LOAD parquet;\" to support this compression scheme");
 		}
+		// no applicable compression filesystem was found - consider the file uncompressed
+		return nullptr;
+	}
+
+	// An explicit compression type was requested - look it up in the registry.
+	auto iter = registry.compressed_fs.find(compression.ToString());
+	if (iter != registry.compressed_fs.end()) {
+		return iter->second->file_system.get();
+	}
+	if (compression == FileCompressionType::ZSTD) {
 		throw NotImplementedException(
-		    "Attempting to open a compressed file, but the compression type is not supported");
+		    "Attempting to open a compressed file, but the compression type is not supported.\nConsider "
+		    "explicitly \"INSTALL parquet; LOAD parquet;\" to support this compression scheme");
 	}
-
-	// We've checked over all duckdb internal compression types, fallback to try externally registered compression
-	// filesystems.
-	for (auto &cur_compressed_fs : file_system_registry->external_compressed_fs) {
-		if (cur_compressed_fs->file_system->CanHandleFile(filepath)) {
-			return cur_compressed_fs->file_system.get();
-		}
-	}
-
-	// No applicable compression filesystem is found, so we consider it uncompressed.
-	return nullptr;
+	throw NotImplementedException("Attempting to open a file with compression type \"%s\", but no compression "
+	                              "filesystem with that type has been registered",
+	                              compression.ToString());
 }
 
 unique_ptr<FileHandle> VirtualFileSystem::OpenFileExtended(const OpenFileInfo &file, FileOpenFlags flags,
                                                            optional_ptr<FileOpener> opener) {
-	const auto compression = flags.Compression();
-	auto compression_filesystem = FindCompressionFileSystem(compression, file.path);
+	const FileCompressionType compression = flags.Compression();
 	// open the base file handle in UNCOMPRESSED mode
 	flags.SetCompression(FileCompressionType::UNCOMPRESSED);
 
@@ -223,9 +208,13 @@ unique_ptr<FileHandle> VirtualFileSystem::OpenFileExtended(const OpenFileInfo &f
 	const auto context = !flags.MultiClientAccess() ? FileOpener::TryGetClientContext(opener) : QueryContext();
 	if (file_handle->GetType() == FileType::FILE_TYPE_FIFO) {
 		file_handle = PipeFileSystem::OpenPipe(context, std::move(file_handle));
-	} else if (compression_filesystem) {
-		file_handle =
-		    compression_filesystem->OpenCompressedFile(context, std::move(file_handle), flags.OpenForWriting());
+	} else {
+		// note: FindFileSystem may have refreshed the registry after autoloading an extension
+		auto compression_filesystem = FindCompressionFileSystem(*registry, compression, file.path);
+		if (compression_filesystem) {
+			file_handle =
+			    compression_filesystem->OpenCompressedFile(context, std::move(file_handle), flags.OpenForWriting());
+		}
 	}
 	return file_handle;
 }
@@ -338,13 +327,7 @@ void VirtualFileSystem::RegisterSubSystem(unique_ptr<FileSystem> fs) {
 	file_system_registry.atomic_store(new_registry);
 }
 
-void VirtualFileSystem::RegisterSubSystem(FileCompressionType compression_type, unique_ptr<FileSystem> fs) {
-	lock_guard<mutex> guard(registry_lock);
-	auto new_registry = file_system_registry->RegisterSubSystem(compression_type, std::move(fs));
-	file_system_registry.atomic_store(new_registry);
-}
-
-void VirtualFileSystem::RegisterCompressionFilesystem(unique_ptr<FileSystem> fs) {
+void VirtualFileSystem::RegisterCompressionFilesystem(unique_ptr<CompressedFileSystem> fs) {
 	const lock_guard<mutex> guard(registry_lock);
 	auto new_registry = file_system_registry->RegisterCompressionFilesystem(std::move(fs));
 	file_system_registry.atomic_store(new_registry);

--- a/src/execution/operator/csv_scanner/buffer_manager/csv_file_handle.cpp
+++ b/src/execution/operator/csv_scanner/buffer_manager/csv_file_handle.cpp
@@ -20,7 +20,7 @@ CSVFileHandle::CSVFileHandle(ClientContext &context_p, unique_ptr<FileHandle> fi
 
 unique_ptr<FileHandle> CSVFileHandle::OpenFileHandle(FileSystem &fs, Allocator &allocator, const OpenFileInfo &file,
                                                      FileCompressionType compression) {
-	FileOpenFlags flags = FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_PARALLEL_ACCESS | compression;
+	FileOpenFlags flags = FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_PARALLEL_ACCESS | std::move(compression);
 	flags.SetCachingMode(CachingMode::CACHE_REMOTE_ONLY);
 	auto file_handle = fs.OpenFile(file, flags);
 	if (file_handle->CanSeek()) {

--- a/src/execution/operator/csv_scanner/util/csv_reader_options.cpp
+++ b/src/execution/operator/csv_scanner/util/csv_reader_options.cpp
@@ -111,7 +111,7 @@ void CSVReaderOptions::SetHeader(bool input) {
 }
 
 void CSVReaderOptions::SetCompression(const string &compression_p) {
-	this->compression = FileCompressionTypeFromString(compression_p);
+	this->compression = FileCompressionType(compression_p);
 }
 
 string CSVReaderOptions::GetEscape() const {

--- a/src/function/copy_blob.cpp
+++ b/src/function/copy_blob.cpp
@@ -44,7 +44,7 @@ unique_ptr<FunctionData> WriteBlobBind(ClientContext &context, CopyFunctionBindI
 	for (auto &[option_name, option_values] : input.info.options) {
 		if (option_name == "compression") {
 			auto compression_str = ParseStringOption(option_values[0], option_name);
-			result->compression_type = FileCompressionTypeFromString(compression_str);
+			result->compression_type = FileCompressionType(compression_str);
 		} else {
 			throw BinderException("Unrecognized option for COPY (FORMAT BLOB): %s", SQLIdentifier(option_name));
 		}

--- a/src/function/table/copy_csv.cpp
+++ b/src/function/table/copy_csv.cpp
@@ -188,19 +188,11 @@ static unique_ptr<FunctionData> WriteCSVBind(ClientContext &context, CopyFunctio
 	}
 	bind_data->Finalize();
 
-	switch (bind_data->options.compression) {
-	case FileCompressionType::GZIP:
-		if (!IsFileCompressed(input.file_extension, FileCompressionType::GZIP)) {
-			input.file_extension += CompressionExtensionFromType(FileCompressionType::GZIP);
+	auto &compression = bind_data->options.compression;
+	if (compression == FileCompressionType::GZIP || compression == FileCompressionType::ZSTD) {
+		if (!IsFileCompressed(input.file_extension, compression)) {
+			input.file_extension += CompressionExtensionFromType(compression);
 		}
-		break;
-	case FileCompressionType::ZSTD:
-		if (!IsFileCompressed(input.file_extension, FileCompressionType::ZSTD)) {
-			input.file_extension += CompressionExtensionFromType(FileCompressionType::ZSTD);
-		}
-		break;
-	default:
-		break;
 	}
 
 	auto expressions = CreateCastExpressions(*bind_data, context, names, sql_types);

--- a/src/function/table/copy_csv.cpp
+++ b/src/function/table/copy_csv.cpp
@@ -266,7 +266,7 @@ public:
 struct GlobalWriteCSVData : public GlobalFunctionData {
 	GlobalWriteCSVData(CSVReaderOptions &options, FileSystem &fs, const string &file_path,
 	                   FileCompressionType compression, QueryContext context)
-	    : writer(options, fs, file_path, compression, context) {
+	    : writer(options, fs, file_path, std::move(compression), context) {
 	}
 
 	idx_t FileSize() {

--- a/src/include/duckdb/common/compressed_file_system.hpp
+++ b/src/include/duckdb/common/compressed_file_system.hpp
@@ -52,6 +52,12 @@ public:
 	DUCKDB_API bool OnDiskFile(FileHandle &handle) override;
 	DUCKDB_API bool CanSeek() override;
 
+	//! The compression scheme provided by this filesystem, e.g. "gzip"
+	DUCKDB_API virtual FileCompressionType GetCompressionType() = 0;
+	//! Whether this filesystem can decompress the given file - used to auto-detect compression from the file name.
+	//! Filesystems that do not override this do not participate in compression auto-detection.
+	DUCKDB_API bool CanHandleFile(const string &fpath) override;
+
 	DUCKDB_API virtual unique_ptr<StreamWrapper> CreateStream() = 0;
 	DUCKDB_API virtual idx_t InBufferSize() = 0;
 	DUCKDB_API virtual idx_t OutBufferSize() = 0;

--- a/src/include/duckdb/common/enum_util.hpp
+++ b/src/include/duckdb/common/enum_util.hpp
@@ -234,8 +234,6 @@ enum class ExtraTypeInfoType : uint8_t;
 
 enum class FileBufferType : uint8_t;
 
-enum class FileCompressionType : uint8_t;
-
 enum class FileExpandResult : uint8_t;
 
 enum class FileGlobOptions : uint8_t;
@@ -929,9 +927,6 @@ const char* EnumUtil::ToChars<ExtraTypeInfoType>(ExtraTypeInfoType value);
 
 template<>
 const char* EnumUtil::ToChars<FileBufferType>(FileBufferType value);
-
-template<>
-const char* EnumUtil::ToChars<FileCompressionType>(FileCompressionType value);
 
 template<>
 const char* EnumUtil::ToChars<FileExpandResult>(FileExpandResult value);
@@ -1821,9 +1816,6 @@ ExtraTypeInfoType EnumUtil::FromString<ExtraTypeInfoType>(const char *value);
 
 template<>
 FileBufferType EnumUtil::FromString<FileBufferType>(const char *value);
-
-template<>
-FileCompressionType EnumUtil::FromString<FileCompressionType>(const char *value);
 
 template<>
 FileExpandResult EnumUtil::FromString<FileExpandResult>(const char *value);

--- a/src/include/duckdb/common/enums/file_compression_type.hpp
+++ b/src/include/duckdb/common/enums/file_compression_type.hpp
@@ -20,7 +20,7 @@ public:
 	//! Creates an UNCOMPRESSED compression type
 	DUCKDB_API FileCompressionType();
 	//! Creates a compression type from a string, normalizing known aliases (e.g. "infer" -> auto detection)
-	DUCKDB_API FileCompressionType(const string &compression); // NOLINT: allow implicit conversion from string
+	DUCKDB_API FileCompressionType(string compression); // NOLINT: allow implicit conversion from string
 
 	//! Detect the compression type based on the file name
 	DUCKDB_API static const FileCompressionType AUTO_DETECT;

--- a/src/include/duckdb/common/enums/file_compression_type.hpp
+++ b/src/include/duckdb/common/enums/file_compression_type.hpp
@@ -20,7 +20,7 @@ public:
 	//! Creates an UNCOMPRESSED compression type
 	DUCKDB_API FileCompressionType();
 	//! Creates a compression type from a string, normalizing known aliases (e.g. "infer" -> auto detection)
-	DUCKDB_API FileCompressionType(string compression); // NOLINT: allow implicit conversion from string
+	DUCKDB_API FileCompressionType(const string &compression); // NOLINT: allow implicit conversion from string
 
 	//! Detect the compression type based on the file name
 	DUCKDB_API static const FileCompressionType AUTO_DETECT;

--- a/src/include/duckdb/common/enums/file_compression_type.hpp
+++ b/src/include/duckdb/common/enums/file_compression_type.hpp
@@ -9,15 +9,58 @@
 #pragma once
 
 #include "duckdb/common/constants.hpp"
+#include "duckdb/common/string.hpp"
 
 namespace duckdb {
 
-enum class FileCompressionType : uint8_t { AUTO_DETECT = 0, UNCOMPRESSED = 1, GZIP = 2, ZSTD = 3 };
+//! FileCompressionType represents a file compression scheme by its name (e.g. "gzip"), so extensions can register
+//! their own compression filesystems in addition to the built-in ones
+class FileCompressionType {
+public:
+	//! Creates an UNCOMPRESSED compression type
+	FileCompressionType() : compression("uncompressed") {
+	}
+	//! Creates a compression type from a string, normalizing known aliases (e.g. "infer" -> auto detection)
+	DUCKDB_API FileCompressionType(string compression); // NOLINT: allow implicit conversion from string
 
-FileCompressionType FileCompressionTypeFromString(const string &input);
+	//! Detect the compression type based on the file name
+	DUCKDB_API static const FileCompressionType AUTO_DETECT;
+	//! No compression
+	DUCKDB_API static const FileCompressionType UNCOMPRESSED;
+	//! Built-in compression types
+	DUCKDB_API static const FileCompressionType GZIP;
+	DUCKDB_API static const FileCompressionType ZSTD;
 
-string CompressionExtensionFromType(const FileCompressionType type);
+public:
+	bool operator==(const FileCompressionType &other) const {
+		return compression == other.compression;
+	}
+	bool operator!=(const FileCompressionType &other) const {
+		return compression != other.compression;
+	}
+	//! Whether this refers to an actual compression scheme (i.e. not uncompressed and not auto-detection)
+	bool IsCompressed() const {
+		return !IsUncompressed() && !IsAutoDetect();
+	}
+	bool IsUncompressed() const {
+		return compression == "uncompressed";
+	}
+	bool IsAutoDetect() const {
+		return compression == "auto_detect";
+	}
+	//! The canonical (lower-case) name of the compression scheme, e.g. "gzip"
+	const string &ToString() const {
+		return compression;
+	}
 
-bool IsFileCompressed(string path, FileCompressionType type);
+private:
+	string compression;
+};
+
+DUCKDB_API FileCompressionType FileCompressionTypeFromString(const string &input);
+
+DUCKDB_API string CompressionExtensionFromType(const FileCompressionType &type);
+
+DUCKDB_API bool IsFileCompressed(string path, const FileCompressionType &type);
 
 } // namespace duckdb

--- a/src/include/duckdb/common/enums/file_compression_type.hpp
+++ b/src/include/duckdb/common/enums/file_compression_type.hpp
@@ -18,8 +18,7 @@ namespace duckdb {
 class FileCompressionType {
 public:
 	//! Creates an UNCOMPRESSED compression type
-	FileCompressionType() : compression("uncompressed") {
-	}
+	DUCKDB_API FileCompressionType();
 	//! Creates a compression type from a string, normalizing known aliases (e.g. "infer" -> auto detection)
 	DUCKDB_API FileCompressionType(string compression); // NOLINT: allow implicit conversion from string
 
@@ -32,26 +31,14 @@ public:
 	DUCKDB_API static const FileCompressionType ZSTD;
 
 public:
-	bool operator==(const FileCompressionType &other) const {
-		return compression == other.compression;
-	}
-	bool operator!=(const FileCompressionType &other) const {
-		return compression != other.compression;
-	}
+	DUCKDB_API bool operator==(const FileCompressionType &other) const;
+	DUCKDB_API bool operator!=(const FileCompressionType &other) const;
 	//! Whether this refers to an actual compression scheme (i.e. not uncompressed and not auto-detection)
-	bool IsCompressed() const {
-		return !IsUncompressed() && !IsAutoDetect();
-	}
-	bool IsUncompressed() const {
-		return compression == "uncompressed";
-	}
-	bool IsAutoDetect() const {
-		return compression == "auto_detect";
-	}
+	DUCKDB_API bool IsCompressed() const;
+	DUCKDB_API bool IsUncompressed() const;
+	DUCKDB_API bool IsAutoDetect() const;
 	//! The canonical (lower-case) name of the compression scheme, e.g. "gzip"
-	const string &ToString() const {
-		return compression;
-	}
+	DUCKDB_API const string &ToString() const;
 
 private:
 	string compression;

--- a/src/include/duckdb/common/enums/file_compression_type.hpp
+++ b/src/include/duckdb/common/enums/file_compression_type.hpp
@@ -57,8 +57,6 @@ private:
 	string compression;
 };
 
-DUCKDB_API FileCompressionType FileCompressionTypeFromString(const string &input);
-
 DUCKDB_API string CompressionExtensionFromType(const FileCompressionType &type);
 
 DUCKDB_API bool IsFileCompressed(string path, const FileCompressionType &type);

--- a/src/include/duckdb/common/file_open_flags.hpp
+++ b/src/include/duckdb/common/file_open_flags.hpp
@@ -35,33 +35,34 @@ public:
 
 public:
 	FileOpenFlags() = default;
-	constexpr FileOpenFlags(idx_t flags) : flags(flags) { // NOLINT: allow implicit conversion
+	FileOpenFlags(idx_t flags) : flags(flags) { // NOLINT: allow implicit conversion
 	}
-	constexpr FileOpenFlags(FileLockType lock) : lock(lock) { // NOLINT: allow implicit conversion
+	FileOpenFlags(FileLockType lock) : lock(lock) { // NOLINT: allow implicit conversion
 	}
-	constexpr FileOpenFlags(FileCompressionType compression) // NOLINT: allow implicit conversion
-	    : compression(compression) {
+	FileOpenFlags(FileCompressionType compression) // NOLINT: allow implicit conversion
+	    : compression(std::move(compression)) {
 	}
-	constexpr FileOpenFlags(idx_t flags, FileLockType lock, FileCompressionType compression)
-	    : flags(flags), lock(lock), compression(compression) {
+	FileOpenFlags(idx_t flags, FileLockType lock, FileCompressionType compression)
+	    : flags(flags), lock(lock), compression(std::move(compression)) {
 	}
 
 	static constexpr FileLockType MergeLock(FileLockType a, FileLockType b) {
 		return a == FileLockType::NO_LOCK ? b : a;
 	}
 
-	static constexpr FileCompressionType MergeCompression(FileCompressionType a, FileCompressionType b) {
-		return a == FileCompressionType::UNCOMPRESSED ? b : a;
+	//! An uncompressed flag acts as the identity - any other compression flag wins the merge
+	static FileCompressionType MergeCompression(const FileCompressionType &a, const FileCompressionType &b) {
+		return a.IsUncompressed() ? b : a;
 	}
 
 	static constexpr CachingMode MergeCachingMode(CachingMode a, CachingMode b) {
 		return a == CachingMode::NO_CACHING ? b : a;
 	}
 
-	inline constexpr FileOpenFlags operator|(FileOpenFlags b) const {
+	inline FileOpenFlags operator|(const FileOpenFlags &b) const {
 		return FileOpenFlags(flags | b.flags, MergeLock(lock, b.lock), MergeCompression(compression, b.compression));
 	}
-	inline FileOpenFlags &operator|=(FileOpenFlags b) {
+	inline FileOpenFlags &operator|=(const FileOpenFlags &b) {
 		flags |= b.flags;
 		lock = MergeLock(lock, b.lock);
 		compression = MergeCompression(compression, b.compression);
@@ -73,12 +74,12 @@ public:
 		return lock;
 	}
 
-	FileCompressionType Compression() {
+	const FileCompressionType &Compression() const {
 		return compression;
 	}
 
 	void SetCompression(FileCompressionType new_compression) {
-		compression = new_compression;
+		compression = std::move(new_compression);
 	}
 
 	CachingMode GetCachingMode() {
@@ -140,46 +141,40 @@ private:
 	idx_t flags = 0;
 	FileLockType lock = FileLockType::NO_LOCK;
 	CachingMode caching_mode = CachingMode::NO_CACHING;
-	FileCompressionType compression = FileCompressionType::UNCOMPRESSED;
+	//! Default-constructed FileCompressionType is UNCOMPRESSED
+	FileCompressionType compression;
 };
 
 class FileFlags {
 public:
 	//! Open file with read access
-	static constexpr FileOpenFlags FILE_FLAGS_READ = FileOpenFlags(FileOpenFlags::FILE_FLAGS_READ);
+	DUCKDB_API static const FileOpenFlags FILE_FLAGS_READ;
 	//! Open file with write access
-	static constexpr FileOpenFlags FILE_FLAGS_WRITE = FileOpenFlags(FileOpenFlags::FILE_FLAGS_WRITE);
+	DUCKDB_API static const FileOpenFlags FILE_FLAGS_WRITE;
 	//! Use direct IO when reading/writing to the file
-	static constexpr FileOpenFlags FILE_FLAGS_DIRECT_IO = FileOpenFlags(FileOpenFlags::FILE_FLAGS_DIRECT_IO);
+	DUCKDB_API static const FileOpenFlags FILE_FLAGS_DIRECT_IO;
 	//! Create file if not exists, can only be used together with WRITE
-	static constexpr FileOpenFlags FILE_FLAGS_FILE_CREATE = FileOpenFlags(FileOpenFlags::FILE_FLAGS_FILE_CREATE);
+	DUCKDB_API static const FileOpenFlags FILE_FLAGS_FILE_CREATE;
 	//! Always create a new file. If a file exists, the file is truncated. Cannot be used together with CREATE.
-	static constexpr FileOpenFlags FILE_FLAGS_FILE_CREATE_NEW =
-	    FileOpenFlags(FileOpenFlags::FILE_FLAGS_FILE_CREATE_NEW);
+	DUCKDB_API static const FileOpenFlags FILE_FLAGS_FILE_CREATE_NEW;
 	//! Open file in append mode
-	static constexpr FileOpenFlags FILE_FLAGS_APPEND = FileOpenFlags(FileOpenFlags::FILE_FLAGS_APPEND);
+	DUCKDB_API static const FileOpenFlags FILE_FLAGS_APPEND;
 	//! Open file with restrictive permissions (600 on linux/mac) can only be used when creating, throws if file exists
-	static constexpr FileOpenFlags FILE_FLAGS_PRIVATE = FileOpenFlags(FileOpenFlags::FILE_FLAGS_PRIVATE);
+	DUCKDB_API static const FileOpenFlags FILE_FLAGS_PRIVATE;
 	//! Return NULL if the file does not exist instead of throwing an error
-	static constexpr FileOpenFlags FILE_FLAGS_NULL_IF_NOT_EXISTS =
-	    FileOpenFlags(FileOpenFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS);
+	DUCKDB_API static const FileOpenFlags FILE_FLAGS_NULL_IF_NOT_EXISTS;
 	//! Multiple threads may perform reads and writes in parallel
-	static constexpr FileOpenFlags FILE_FLAGS_PARALLEL_ACCESS =
-	    FileOpenFlags(FileOpenFlags::FILE_FLAGS_PARALLEL_ACCESS);
+	DUCKDB_API static const FileOpenFlags FILE_FLAGS_PARALLEL_ACCESS;
 	//! Ensure that this call creates the file, throw is file exists
-	static constexpr FileOpenFlags FILE_FLAGS_EXCLUSIVE_CREATE =
-	    FileOpenFlags(FileOpenFlags::FILE_FLAGS_EXCLUSIVE_CREATE);
+	DUCKDB_API static const FileOpenFlags FILE_FLAGS_EXCLUSIVE_CREATE;
 	//!  Return NULL if the file exist instead of throwing an error
-	static constexpr FileOpenFlags FILE_FLAGS_NULL_IF_EXISTS = FileOpenFlags(FileOpenFlags::FILE_FLAGS_NULL_IF_EXISTS);
+	DUCKDB_API static const FileOpenFlags FILE_FLAGS_NULL_IF_EXISTS;
 	//! Multiple clients may access the file at the same time
-	static constexpr FileOpenFlags FILE_FLAGS_MULTI_CLIENT_ACCESS =
-	    FileOpenFlags(FileOpenFlags::FILE_FLAGS_MULTI_CLIENT_ACCESS);
+	DUCKDB_API static const FileOpenFlags FILE_FLAGS_MULTI_CLIENT_ACCESS;
 	//! Disables logging to avoid infinite loops when using FileHandle-backed log storage
-	static constexpr FileOpenFlags FILE_FLAGS_DISABLE_LOGGING =
-	    FileOpenFlags(FileOpenFlags::FILE_FLAGS_DISABLE_LOGGING);
+	DUCKDB_API static const FileOpenFlags FILE_FLAGS_DISABLE_LOGGING;
 	//! Opened file is allowed to be a duckdb_extension
-	static constexpr FileOpenFlags FILE_FLAGS_ENABLE_EXTENSION_INSTALL =
-	    FileOpenFlags(FileOpenFlags::FILE_FLAGS_ENABLE_EXTENSION_INSTALL);
+	DUCKDB_API static const FileOpenFlags FILE_FLAGS_ENABLE_EXTENSION_INSTALL;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -290,7 +290,10 @@ public:
 
 	//! registers a sub-file system to handle certain file name prefixes, e.g. http:// etc.
 	DUCKDB_API virtual void RegisterSubSystem(unique_ptr<FileSystem> sub_fs);
+	//! Register a duckdb internally supported compression filesystem.
 	DUCKDB_API virtual void RegisterSubSystem(FileCompressionType compression_type, unique_ptr<FileSystem> fs);
+	//! Register an external compression filesystem (i.e., by extensions).
+	DUCKDB_API virtual void RegisterCompressionFilesystem(unique_ptr<FileSystem> fs);
 
 	//! Unregister a sub-filesystem by name
 	DUCKDB_API virtual void UnregisterSubSystem(const string &name);

--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -169,7 +169,7 @@ public:
 
 	DUCKDB_API virtual unique_ptr<FileHandle> OpenFile(const string &path, FileOpenFlags flags,
 	                                                   optional_ptr<FileOpener> opener = nullptr);
-	DUCKDB_API unique_ptr<FileHandle> OpenFile(const OpenFileInfo &path, FileOpenFlags flags,
+	DUCKDB_API unique_ptr<FileHandle> OpenFile(const OpenFileInfo &path, const FileOpenFlags &flags,
 	                                           optional_ptr<FileOpener> opener = nullptr);
 
 	//! Open a memory-mapped view of [path]. Throws if not supported by this filesystem.

--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -39,6 +39,7 @@ class FileOpener;
 class FileSystem;
 class Logger;
 class ClientContext;
+class CompressedFileSystem;
 class QueryContext;
 class MemoryMappedFile;
 struct MMapOptions;
@@ -290,10 +291,8 @@ public:
 
 	//! registers a sub-file system to handle certain file name prefixes, e.g. http:// etc.
 	DUCKDB_API virtual void RegisterSubSystem(unique_ptr<FileSystem> sub_fs);
-	//! Register a duckdb internally supported compression filesystem.
-	DUCKDB_API virtual void RegisterSubSystem(FileCompressionType compression_type, unique_ptr<FileSystem> fs);
-	//! Register an external compression filesystem (i.e., by extensions).
-	DUCKDB_API virtual void RegisterCompressionFilesystem(unique_ptr<FileSystem> fs);
+	//! Register a compression filesystem (both built-in and provided by extensions), keyed by its compression type
+	DUCKDB_API virtual void RegisterCompressionFilesystem(unique_ptr<CompressedFileSystem> fs);
 
 	//! Unregister a sub-filesystem by name
 	DUCKDB_API virtual void UnregisterSubSystem(const string &name);

--- a/src/include/duckdb/common/gzip_file_system.hpp
+++ b/src/include/duckdb/common/gzip_file_system.hpp
@@ -23,6 +23,14 @@ public:
 		return "GZipFileSystem";
 	}
 
+	FileCompressionType GetCompressionType() override {
+		return FileCompressionType::GZIP;
+	}
+
+	bool CanHandleFile(const string &fpath) override {
+		return IsFileCompressed(fpath, FileCompressionType::GZIP);
+	}
+
 	//! Verifies that a buffer contains a valid GZIP header
 	static void VerifyGZIPHeader(uint8_t gzip_hdr[], idx_t read_count, optional_ptr<CompressedFile> source_file);
 	static bool CheckIsZip(const char *length, idx_t size);

--- a/src/include/duckdb/common/opener_file_system.hpp
+++ b/src/include/duckdb/common/opener_file_system.hpp
@@ -190,9 +190,7 @@ public:
 		GetFileSystem().RegisterSubSystem(std::move(sub_fs));
 	}
 
-	void RegisterSubSystem(FileCompressionType compression_type, unique_ptr<FileSystem> fs) override {
-		GetFileSystem().RegisterSubSystem(compression_type, std::move(fs));
-	}
+	void RegisterCompressionFilesystem(unique_ptr<CompressedFileSystem> fs) override;
 
 	void UnregisterSubSystem(const string &name) override {
 		GetFileSystem().UnregisterSubSystem(name);

--- a/src/include/duckdb/common/serializer/async_file_writer.hpp
+++ b/src/include/duckdb/common/serializer/async_file_writer.hpp
@@ -49,7 +49,7 @@ public:
 	};
 
 	//! Default file-open behavior for creating a write-locked output file.
-	static constexpr FileOpenFlags DEFAULT_OPEN_FLAGS = FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE;
+	DUCKDB_API static const FileOpenFlags DEFAULT_OPEN_FLAGS;
 
 public:
 	DUCKDB_API AsyncFileWriter(QueryContext context, FileSystem &fs, const string &path,

--- a/src/include/duckdb/common/serializer/async_file_writer.hpp
+++ b/src/include/duckdb/common/serializer/async_file_writer.hpp
@@ -53,7 +53,7 @@ public:
 
 public:
 	DUCKDB_API AsyncFileWriter(QueryContext context, FileSystem &fs, const string &path,
-	                           FileOpenFlags open_flags = DEFAULT_OPEN_FLAGS);
+	                           const FileOpenFlags &open_flags = DEFAULT_OPEN_FLAGS);
 	DUCKDB_API ~AsyncFileWriter() override;
 	using WriteStream::Write;
 

--- a/src/include/duckdb/common/serializer/buffered_file_writer.hpp
+++ b/src/include/duckdb/common/serializer/buffered_file_writer.hpp
@@ -23,7 +23,8 @@ public:
 	//! Serializes to a buffer allocated by the serializer, will expand when
 	//! writing past the initial threshold. The optional QueryContext is used to attribute
 	//! the written bytes to the query's I/O metrics.
-	DUCKDB_API BufferedFileWriter(FileSystem &fs, const string &path, FileOpenFlags open_flags = DEFAULT_OPEN_FLAGS,
+	DUCKDB_API BufferedFileWriter(FileSystem &fs, const string &path,
+	                              const FileOpenFlags &open_flags = DEFAULT_OPEN_FLAGS,
 	                              QueryContext context = QueryContext());
 
 	FileSystem &fs;

--- a/src/include/duckdb/common/serializer/buffered_file_writer.hpp
+++ b/src/include/duckdb/common/serializer/buffered_file_writer.hpp
@@ -18,7 +18,7 @@ namespace duckdb {
 
 class BufferedFileWriter : public WriteStream {
 public:
-	static constexpr FileOpenFlags DEFAULT_OPEN_FLAGS = FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE;
+	DUCKDB_API static const FileOpenFlags DEFAULT_OPEN_FLAGS;
 
 	//! Serializes to a buffer allocated by the serializer, will expand when
 	//! writing past the initial threshold. The optional QueryContext is used to attribute

--- a/src/include/duckdb/common/virtual_file_system.hpp
+++ b/src/include/duckdb/common/virtual_file_system.hpp
@@ -59,6 +59,7 @@ public:
 
 	void RegisterSubSystem(unique_ptr<FileSystem> fs) override;
 	void RegisterSubSystem(FileCompressionType compression_type, unique_ptr<FileSystem> fs) override;
+	void RegisterCompressionFilesystem(unique_ptr<FileSystem> fs) override;
 	void UnregisterSubSystem(const string &name) override;
 	unique_ptr<FileSystem> ExtractSubSystem(const string &name) override;
 
@@ -101,6 +102,9 @@ private:
 	FileSystem &FindFileSystem(shared_ptr<FileSystemRegistry> &registry, const string &path,
 	                           optional_ptr<FileOpener> file_opener);
 	optional_ptr<FileSystem> FindFileSystemInternal(FileSystemRegistry &registry, const string &path);
+	// Return nullptr if compression is not involved, throw exception if compression is requested but no usable
+	// filesystem gets registered.
+	optional_ptr<FileSystem> FindCompressionFileSystem(FileCompressionType compression_type, const string &path);
 
 private:
 	mutex registry_lock;

--- a/src/include/duckdb/common/virtual_file_system.hpp
+++ b/src/include/duckdb/common/virtual_file_system.hpp
@@ -58,8 +58,7 @@ public:
 	void RemoveFiles(const vector<string> &filenames, optional_ptr<FileOpener> opener) override;
 
 	void RegisterSubSystem(unique_ptr<FileSystem> fs) override;
-	void RegisterSubSystem(FileCompressionType compression_type, unique_ptr<FileSystem> fs) override;
-	void RegisterCompressionFilesystem(unique_ptr<FileSystem> fs) override;
+	void RegisterCompressionFilesystem(unique_ptr<CompressedFileSystem> fs) override;
 	void UnregisterSubSystem(const string &name) override;
 	unique_ptr<FileSystem> ExtractSubSystem(const string &name) override;
 
@@ -104,7 +103,8 @@ private:
 	optional_ptr<FileSystem> FindFileSystemInternal(FileSystemRegistry &registry, const string &path);
 	// Return nullptr if compression is not involved, throw exception if compression is requested but no usable
 	// filesystem gets registered.
-	optional_ptr<FileSystem> FindCompressionFileSystem(FileCompressionType compression_type, const string &path);
+	optional_ptr<FileSystem> FindCompressionFileSystem(FileSystemRegistry &registry,
+	                                                   const FileCompressionType &compression, const string &path);
 
 private:
 	mutex registry_lock;

--- a/src/include/duckdb/storage/external_file_cache/caching_file_system_wrapper.hpp
+++ b/src/include/duckdb/storage/external_file_cache/caching_file_system_wrapper.hpp
@@ -28,7 +28,7 @@ class CachingFileHandleWrapper : public FileHandle {
 
 public:
 	DUCKDB_API CachingFileHandleWrapper(shared_ptr<CachingFileSystemWrapper> file_system,
-	                                    unique_ptr<CachingFileHandle> handle, FileOpenFlags flags);
+	                                    unique_ptr<CachingFileHandle> handle, const FileOpenFlags &flags);
 
 	DUCKDB_API ~CachingFileHandleWrapper() override;
 

--- a/src/include/duckdb/storage/external_file_cache/caching_file_system_wrapper.hpp
+++ b/src/include/duckdb/storage/external_file_cache/caching_file_system_wrapper.hpp
@@ -98,7 +98,7 @@ public:
 	DUCKDB_API vector<OpenFileInfo> Glob(const string &path, FileOpener *opener = nullptr) override;
 
 	DUCKDB_API void RegisterSubSystem(unique_ptr<FileSystem> sub_fs) override;
-	DUCKDB_API void RegisterSubSystem(FileCompressionType compression_type, unique_ptr<FileSystem> fs) override;
+	DUCKDB_API void RegisterCompressionFilesystem(unique_ptr<CompressedFileSystem> fs) override;
 	DUCKDB_API void UnregisterSubSystem(const string &name) override;
 	DUCKDB_API unique_ptr<FileSystem> ExtractSubSystem(const string &name) override;
 	DUCKDB_API vector<string> ListSubSystems() override;

--- a/src/include/duckdb/storage/serialization/nodes.json
+++ b/src/include/duckdb/storage/serialization/nodes.json
@@ -790,8 +790,9 @@
       {
         "id": 103,
         "name": "compression",
-        "type": "FileCompressionType",
-        "property": "options.compression"
+        "type": "string",
+        "serialize_property": "options.compression.ToString()",
+        "deserialize_property": "options.compression"
       },
       {
         "id": 104,

--- a/src/storage/external_file_cache/caching_file_system.cpp
+++ b/src/storage/external_file_cache/caching_file_system.cpp
@@ -203,9 +203,9 @@ CachingFileHandle::CachingFileHandle(QueryContext context, CachingFileSystem &ca
                                      const OpenFileInfo &path_p, FileOpenFlags flags_p,
                                      optional_ptr<FileOpener> opener_p)
     : context(context), caching_file_system(caching_file_system_p),
-      external_file_cache(caching_file_system.external_file_cache), path(path_p), flags(flags_p), opener(opener_p),
-      validate(
-          ExternalFileCacheUtil::GetCacheValidationMode(path_p, context.GetClientContext(), caching_file_system_p.db)),
+      external_file_cache(caching_file_system.external_file_cache), path(path_p), flags(std::move(flags_p)),
+      opener(opener_p), validate(ExternalFileCacheUtil::GetCacheValidationMode(path_p, context.GetClientContext(),
+                                                                               caching_file_system_p.db)),
       cached_file(nullptr), position(0) {
 	cached_file = external_file_cache.GetOrCreateCachedFile(path_p.path);
 	if (!external_file_cache.IsEnabled() || Validate()) {

--- a/src/storage/external_file_cache/caching_file_system_wrapper.cpp
+++ b/src/storage/external_file_cache/caching_file_system_wrapper.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/storage/external_file_cache/caching_file_system_wrapper.hpp"
 
+#include "duckdb/common/compressed_file_system.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/numeric_utils.hpp"
@@ -303,8 +304,8 @@ void CachingFileSystemWrapper::RegisterSubSystem(unique_ptr<FileSystem> sub_fs) 
 	underlying_file_system.RegisterSubSystem(std::move(sub_fs));
 }
 
-void CachingFileSystemWrapper::RegisterSubSystem(FileCompressionType compression_type, unique_ptr<FileSystem> fs) {
-	underlying_file_system.RegisterSubSystem(compression_type, std::move(fs));
+void CachingFileSystemWrapper::RegisterCompressionFilesystem(unique_ptr<CompressedFileSystem> fs) {
+	underlying_file_system.RegisterCompressionFilesystem(std::move(fs));
 }
 
 void CachingFileSystemWrapper::UnregisterSubSystem(const string &name) {

--- a/src/storage/external_file_cache/caching_file_system_wrapper.cpp
+++ b/src/storage/external_file_cache/caching_file_system_wrapper.cpp
@@ -26,7 +26,7 @@ DatabaseInstance &GetDatabaseInstance(optional_ptr<FileOpener> file_opener) {
 // CachingFileHandleWrapper implementation
 //===----------------------------------------------------------------------===//
 CachingFileHandleWrapper::CachingFileHandleWrapper(shared_ptr<CachingFileSystemWrapper> file_system,
-                                                   unique_ptr<CachingFileHandle> handle, FileOpenFlags flags)
+                                                   unique_ptr<CachingFileHandle> handle, const FileOpenFlags &flags)
     : FileHandle(*file_system, handle->GetPath(), flags), caching_file_system(std::move(file_system)),
       caching_handle(std::move(handle)) {
 	D_ASSERT(!flags.OpenForWriting());
@@ -121,7 +121,7 @@ unique_ptr<FileHandle> CachingFileSystemWrapper::OpenFile(const string &path, Fi
 unique_ptr<FileHandle> CachingFileSystemWrapper::OpenFile(const OpenFileInfo &path, FileOpenFlags flags,
                                                           optional_ptr<FileOpener> opener) {
 	if (SupportsOpenFileExtended()) {
-		return OpenFileExtended(path, flags, opener);
+		return OpenFileExtended(path, std::move(flags), opener);
 	}
 	throw NotImplementedException("CachingFileSystemWrapper: OpenFile is not implemented!");
 }

--- a/src/storage/serialization/serialize_nodes.cpp
+++ b/src/storage/serialization/serialize_nodes.cpp
@@ -578,7 +578,7 @@ void SerializedCSVReaderOptions::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<bool>(100, "ignore_errors", options.ignore_errors, false);
 	serializer.WritePropertyWithDefault<idx_t>(101, "buffer_sample_size", options.buffer_sample_size);
 	serializer.WritePropertyWithDefault<vector<string>>(102, "null_str", options.null_str);
-	serializer.WriteProperty<FileCompressionType>(103, "compression", options.compression);
+	serializer.WritePropertyWithDefault<string>(103, "compression", options.compression.ToString());
 	serializer.WritePropertyWithDefault<bool>(104, "allow_quoted_nulls", options.allow_quoted_nulls);
 	serializer.WriteProperty<CSVOption<idx_t>>(105, "maximum_line_size", options.maximum_line_size);
 	serializer.WritePropertyWithDefault<bool>(106, "normalize_names", options.normalize_names);
@@ -626,7 +626,7 @@ SerializedCSVReaderOptions SerializedCSVReaderOptions::Deserialize(Deserializer 
 	auto options_ignore_errors = deserializer.ReadPropertyWithExplicitDefault<bool>(100, "ignore_errors", false);
 	auto options_buffer_sample_size = deserializer.ReadPropertyWithDefault<idx_t>(101, "buffer_sample_size");
 	auto options_null_str = deserializer.ReadPropertyWithDefault<vector<string>>(102, "null_str");
-	auto options_compression = deserializer.ReadProperty<FileCompressionType>(103, "compression");
+	auto options_compression = deserializer.ReadPropertyWithDefault<string>(103, "compression");
 	auto options_allow_quoted_nulls = deserializer.ReadPropertyWithDefault<bool>(104, "allow_quoted_nulls");
 	auto options_maximum_line_size = deserializer.ReadProperty<CSVOption<idx_t>>(105, "maximum_line_size");
 	auto options_normalize_names = deserializer.ReadPropertyWithDefault<bool>(106, "normalize_names");
@@ -669,7 +669,7 @@ SerializedCSVReaderOptions SerializedCSVReaderOptions::Deserialize(Deserializer 
 	result.options.ignore_errors = options_ignore_errors;
 	result.options.buffer_sample_size = options_buffer_sample_size;
 	result.options.null_str = std::move(options_null_str);
-	result.options.compression = options_compression;
+	result.options.compression = std::move(options_compression);
 	result.options.allow_quoted_nulls = options_allow_quoted_nulls;
 	result.options.maximum_line_size = options_maximum_line_size;
 	result.options.normalize_names = options_normalize_names;

--- a/test/common/test_file_system.cpp
+++ b/test/common/test_file_system.cpp
@@ -22,7 +22,7 @@ using namespace duckdb;
 
 namespace {
 
-void create_dummy_file(string fname) {
+void CreateDummyFile(string fname) {
 	string normalized_string;
 	if (StringUtil::StartsWith(fname, "file:///")) {
 #ifdef _WIN32
@@ -126,7 +126,7 @@ TEST_CASE("Make sure the file:// protocol works as expected", "[file_system]") {
 	auto fname_in_dir2 = fs->JoinPath(dname_localhost, fname2);
 	auto fname_in_dir3 = fs->JoinPath(dname_no_host, fname2);
 
-	create_dummy_file(fname_in_dir);
+	CreateDummyFile(fname_in_dir);
 	REQUIRE(fs->FileExists(fname_in_dir));
 	REQUIRE(!fs->DirectoryExists(fname_in_dir));
 
@@ -174,7 +174,7 @@ TEST_CASE("Make sure file system operators work as advertised", "[file_system]")
 	auto fname_in_dir = fs->JoinPath(dname, fname);
 	auto fname_in_dir2 = fs->JoinPath(dname, fname2);
 
-	create_dummy_file(fname_in_dir);
+	CreateDummyFile(fname_in_dir);
 	REQUIRE(fs->FileExists(fname_in_dir));
 	REQUIRE(!fs->DirectoryExists(fname_in_dir));
 
@@ -273,9 +273,9 @@ TEST_CASE("Test RemoveFiles", "[file_system]") {
 	auto file2 = fs->JoinPath(dname, "file2.txt");
 	auto file3 = fs->JoinPath(dname, "file3.txt");
 	auto file4 = fs->JoinPath(dname, "file4.txt");
-	create_dummy_file(file1);
-	create_dummy_file(file2);
-	create_dummy_file(file3);
+	CreateDummyFile(file1);
+	CreateDummyFile(file2);
+	CreateDummyFile(file3);
 
 	REQUIRE(fs->FileExists(file1));
 	REQUIRE(fs->FileExists(file2));

--- a/test/common/test_file_system.cpp
+++ b/test/common/test_file_system.cpp
@@ -70,6 +70,9 @@ public:
 		return make_uniq<FakeCompressFileHandle>(*this, std::move(handle));
 	}
 
+	FileCompressionType GetCompressionType() override {
+		return FileCompressionType("fake_compress");
+	}
 	bool CanHandleFile(const string &fpath) override {
 		return StringUtil::EndsWith(fpath, ".compress");
 	}
@@ -1176,9 +1179,9 @@ TEST_CASE("compression filesystem registration and lookup", "[file_system]") {
 	}
 
 	VirtualFileSystem vfs;
-	auto fake_compress_filesystem = make_uniq<FakeCompressFileSystem>();
-	vfs.RegisterCompressionFilesystem(std::move(fake_compress_filesystem));
+	vfs.RegisterCompressionFilesystem(make_uniq<FakeCompressFileSystem>());
 
+	// Auto-detection matches the fake compression filesystem based on the file name.
 	FileOpenFlags flags = FileOpenFlags::FILE_FLAGS_READ;
 	flags.SetCompression(FileCompressionType::AUTO_DETECT);
 	auto file_handle = vfs.OpenFile(filepath, flags, /*opener=*/nullptr);
@@ -1188,10 +1191,17 @@ TEST_CASE("compression filesystem registration and lookup", "[file_system]") {
 	auto &compressed_file_handle = file_handle->Cast<FakeCompressFileHandle>();
 	REQUIRE(compressed_file_handle.internal_file_handle != nullptr);
 	file_handle.reset();
-	fs->RemoveFile(filepath);
 
-	// If we give a new compressed file, which cannot be handled by already registered compression filesystems, we
-	// cannot proceed.
-	const string another_compressed_filepath = "fake_compression_file.another_compress";
+	// Explicitly requesting the registered compression type works as well.
+	flags.SetCompression(FileCompressionType("fake_compress"));
+	file_handle = vfs.OpenFile(filepath, flags, /*opener=*/nullptr);
+	REQUIRE(file_handle != nullptr);
+	REQUIRE(file_handle->Cast<FakeCompressFileHandle>().internal_file_handle != nullptr);
+	file_handle.reset();
+
+	// Explicitly requesting a compression type that has not been registered throws.
+	flags.SetCompression(FileCompressionType("nonexistent_compress"));
 	REQUIRE_THROWS(vfs.OpenFile(filepath, flags, /*opener=*/nullptr));
+
+	fs->RemoveFile(filepath);
 }

--- a/test/common/test_file_system.cpp
+++ b/test/common/test_file_system.cpp
@@ -1,9 +1,12 @@
 #include "catch.hpp"
+#include "duckdb/common/compressed_file_system.hpp"
 #include "duckdb/common/file_buffer.hpp"
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/fstream.hpp"
 #include "duckdb/common/local_file_system.hpp"
+#include "duckdb/common/string.hpp"
 #include "duckdb/common/string_util.hpp"
+#include "duckdb/common/unique_ptr.hpp"
 #include "duckdb/common/vector.hpp"
 #include "duckdb/common/virtual_file_system.hpp"
 #include "duckdb/main/database_manager.hpp"
@@ -17,7 +20,9 @@
 
 using namespace duckdb;
 
-static void create_dummy_file(string fname) {
+namespace {
+
+void create_dummy_file(string fname) {
 	string normalized_string;
 	if (StringUtil::StartsWith(fname, "file:///")) {
 #ifdef _WIN32
@@ -40,6 +45,49 @@ static void create_dummy_file(string fname) {
 	outfile << "I_AM_A_DUMMY" << endl;
 	outfile.close();
 }
+
+// Fake compress file handle and filesystem implementation, which doesn't contain any (de)compression functionality but
+// just the interface compatibility.
+class FakeCompressFileHandle : public FileHandle {
+public:
+	FakeCompressFileHandle(FileSystem &internal_file_system, duckdb::unique_ptr<FileHandle> internal_file_handle_p)
+	    : FileHandle(internal_file_system, internal_file_handle_p->GetPath(), internal_file_handle_p->GetFlags()),
+	      internal_file_handle(std::move(internal_file_handle_p)) {
+	}
+
+	void Close() override {
+		internal_file_handle->Close();
+	}
+
+	duckdb::unique_ptr<FileHandle> internal_file_handle;
+};
+class FakeCompressFileSystem : public CompressedFileSystem {
+public:
+	duckdb::unique_ptr<FileHandle> OpenCompressedFile(QueryContext context, duckdb::unique_ptr<FileHandle> handle,
+	                                                  bool write) override {
+		(void)context; // Suppress compilation warning.
+		(void)write;
+		return make_uniq<FakeCompressFileHandle>(*this, std::move(handle));
+	}
+
+	bool CanHandleFile(const string &fpath) override {
+		return StringUtil::EndsWith(fpath, ".compress");
+	}
+	duckdb::unique_ptr<StreamWrapper> CreateStream() override {
+		return nullptr;
+	}
+	idx_t InBufferSize() override {
+		return 0;
+	}
+	idx_t OutBufferSize() override {
+		return 0;
+	}
+	string GetName() const override {
+		return "FakeCompress";
+	}
+};
+
+} // namespace
 
 TEST_CASE("Make sure the file:// protocol works as expected", "[file_system]") {
 	duckdb::unique_ptr<FileSystem> fs = FileSystem::CreateLocal();
@@ -1114,3 +1162,36 @@ TEST_CASE("Test long paths on Windows", "[file_system]") {
 	fs->RemoveDirectory(work_dir);
 }
 #endif // _WIN32
+
+TEST_CASE("compression filesystem registration and lookup", "[file_system]") {
+	// Create a local file which pretends to be fake-compressed.
+	auto filepath = TestCreatePath("fake_compression_file.compress");
+	auto fs = FileSystem::CreateLocal();
+	{
+		const string payload = "CREATE_COMPRESSED_FILE";
+		auto write_handle = fs->OpenFile(filepath, FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE);
+		write_handle->Write(QueryContext(), static_cast<void *>(const_cast<char *>(payload.c_str())), payload.size(),
+		                    0);
+		write_handle->Sync();
+	}
+
+	VirtualFileSystem vfs;
+	auto fake_compress_filesystem = make_uniq<FakeCompressFileSystem>();
+	vfs.RegisterCompressionFilesystem(std::move(fake_compress_filesystem));
+
+	FileOpenFlags flags = FileOpenFlags::FILE_FLAGS_READ;
+	flags.SetCompression(FileCompressionType::AUTO_DETECT);
+	auto file_handle = vfs.OpenFile(filepath, flags, /*opener=*/nullptr);
+
+	// Downcast to make sure compressed file handle is created.
+	REQUIRE(file_handle != nullptr);
+	auto &compressed_file_handle = file_handle->Cast<FakeCompressFileHandle>();
+	REQUIRE(compressed_file_handle.internal_file_handle != nullptr);
+	file_handle.reset();
+	fs->RemoveFile(filepath);
+
+	// If we give a new compressed file, which cannot be handled by already registered compression filesystems, we
+	// cannot proceed.
+	const string another_compressed_filepath = "fake_compression_file.another_compress";
+	REQUIRE_THROWS(vfs.OpenFile(filepath, flags, /*opener=*/nullptr));
+}

--- a/test/extension/debug_fs/debug_file_system.cpp
+++ b/test/extension/debug_fs/debug_file_system.cpp
@@ -1,3 +1,4 @@
+#include "duckdb/common/compressed_file_system.hpp"
 #include "duckdb/common/memory_mapped_file.hpp"
 #include "duckdb/common/multi_file/multi_file_list.hpp"
 #include "debug_file_system.hpp"
@@ -270,8 +271,8 @@ void DebugFileSystem::RegisterSubSystem(unique_ptr<FileSystem> sub_fs) {
 	inner_fs->RegisterSubSystem(std::move(sub_fs));
 }
 
-void DebugFileSystem::RegisterSubSystem(FileCompressionType compression_type, unique_ptr<FileSystem> fs) {
-	inner_fs->RegisterSubSystem(compression_type, std::move(fs));
+void DebugFileSystem::RegisterCompressionFilesystem(unique_ptr<CompressedFileSystem> fs) {
+	inner_fs->RegisterCompressionFilesystem(std::move(fs));
 }
 
 void DebugFileSystem::UnregisterSubSystem(const string &name) {

--- a/test/extension/debug_fs/include/debug_file_system.hpp
+++ b/test/extension/debug_fs/include/debug_file_system.hpp
@@ -74,7 +74,7 @@ public:
 	string PathSeparator(const string &path) override;
 	vector<OpenFileInfo> Glob(const string &path, FileOpener *opener = nullptr) override;
 	void RegisterSubSystem(unique_ptr<FileSystem> sub_fs) override;
-	void RegisterSubSystem(FileCompressionType compression_type, unique_ptr<FileSystem> fs) override;
+	void RegisterCompressionFilesystem(unique_ptr<CompressedFileSystem> fs) override;
 	void UnregisterSubSystem(const string &name) override;
 	unique_ptr<FileSystem> ExtractSubSystem(const string &name) override;
 	void SetDisabledFileSystems(const vector<string> &names) override;

--- a/test/sql/copy/csv/zstd_crash.test
+++ b/test/sql/copy/csv/zstd_crash.test
@@ -37,7 +37,7 @@ Attempting to open a compressed file, but the compression type is not supported
 statement error
 COPY test_zst FROM '{DATA_DIR}/csv/broken/test.csv.zst' (COMPRESSION UNKNOWN);
 ----
-Attempting to open a file with compression type "unknown", but no compression filesystem with that type has been registered
+Attempting to open a compressed file, but the compression type is not supported (compression type "unknown")
 
 # zstd works once we load the parquet extension
 require parquet

--- a/test/sql/copy/csv/zstd_crash.test
+++ b/test/sql/copy/csv/zstd_crash.test
@@ -37,7 +37,7 @@ Attempting to open a compressed file, but the compression type is not supported
 statement error
 COPY test_zst FROM '{DATA_DIR}/csv/broken/test.csv.zst' (COMPRESSION UNKNOWN);
 ----
-Unrecognized file compression type "UNKNOWN"
+Attempting to open a file with compression type "unknown", but no compression filesystem with that type has been registered
 
 # zstd works once we load the parquet extension
 require parquet


### PR DESCRIPTION
Revive and rework https://github.com/duckdb/duckdb/pull/20580, I still think it's a helpful feature to get in, copy the PR description here.

Hi team, I've seen multiple discussion threads from duckdb users calling for more compression supports, like [1](https://github.com/duckdb/duckdb/discussions/12232) and [2](https://github.com/duckdb/duckdb/discussions/20475).

For now, there're two workarounds I could see
- [shellfs](https://github.com/query-farm/shellfs): which allows user to interact with the shell environment
- [zipfs](https://github.com/isaacbrodsky/duckdb-zipfs): which adds zip (de)compressor support but have to tolerate additional filepath prefix

I would personally prefer better integration with DuckDB filesystem if possible.
The biggest obstacle preventing extensions from making their own extension is the enum [`FileCompressionType`](https://github.com/duckdb/duckdb/blob/1c62e11b8201923466431e7d109a6ba8b3710c7b/src/include/duckdb/common/enums/file_compression_type.hpp#L15), so in this PR I update it completely to string type.
It makes sense for DuckDB core, because it only needs to maintain limited number of compressions, and min required dependencies (good for builds and CI as well).

In this PR, I propose to add support to allow extensions to register their own compression filesystems into duckdb filesystem, by simply adding extra check for externally registered compression filesystems, so it doesn't affect current DuckDB compatibility or performance.