### PR TITLE
Remove redundant `DISTINCT` in `UNION`, `INTERSECT` and `EXCEPT` branches

### DIFF
--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -3984,19 +3984,20 @@ const StringUtil::EnumStringLiteral *GetOptimizerTypeValues() {
 		{ static_cast<uint32_t>(OptimizerType::TYPE_PUSHDOWN), "TYPE_PUSHDOWN" },
 		{ static_cast<uint32_t>(OptimizerType::SCALAR_FN_PUSHDOWN), "SCALAR_FN_PUSHDOWN" },
 		{ static_cast<uint32_t>(OptimizerType::DISTINCT_AGGREGATE_REWRITE), "DISTINCT_AGGREGATE_REWRITE" },
-		{ static_cast<uint32_t>(OptimizerType::AGGREGATE_REUSE), "AGGREGATE_REUSE" }
+		{ static_cast<uint32_t>(OptimizerType::AGGREGATE_REUSE), "AGGREGATE_REUSE" },
+		{ static_cast<uint32_t>(OptimizerType::REDUNDANT_DISTINCT), "REDUNDANT_DISTINCT" }
 	};
 	return values;
 }
 
 template<>
 const char* EnumUtil::ToChars<OptimizerType>(OptimizerType value) {
-	return StringUtil::EnumToString(GetOptimizerTypeValues(), 45, "OptimizerType", static_cast<uint32_t>(value));
+	return StringUtil::EnumToString(GetOptimizerTypeValues(), 46, "OptimizerType", static_cast<uint32_t>(value));
 }
 
 template<>
 OptimizerType EnumUtil::FromString<OptimizerType>(const char *value) {
-	return static_cast<OptimizerType>(StringUtil::StringToEnum(GetOptimizerTypeValues(), 45, "OptimizerType", value));
+	return static_cast<OptimizerType>(StringUtil::StringToEnum(GetOptimizerTypeValues(), 46, "OptimizerType", value));
 }
 
 const StringUtil::EnumStringLiteral *GetOrderByColumnTypeValues() {

--- a/src/common/enums/optimizer_type.cpp
+++ b/src/common/enums/optimizer_type.cpp
@@ -57,6 +57,7 @@ static const DefaultOptimizerType internal_optimizer_types[] = {
     {"scalar_fn_pushdown", OptimizerType::SCALAR_FN_PUSHDOWN},
     {"distinct_aggregate_rewrite", OptimizerType::DISTINCT_AGGREGATE_REWRITE},
     {"aggregate_reuse", OptimizerType::AGGREGATE_REUSE},
+    {"redundant_distinct", OptimizerType::REDUNDANT_DISTINCT},
     {nullptr, OptimizerType::INVALID}};
 
 string OptimizerTypeToString(OptimizerType type) {

--- a/src/include/duckdb/common/enums/optimizer_type.hpp
+++ b/src/include/duckdb/common/enums/optimizer_type.hpp
@@ -58,7 +58,8 @@ enum class OptimizerType : uint32_t {
 	TYPE_PUSHDOWN = 41,
 	SCALAR_FN_PUSHDOWN = 42,
 	DISTINCT_AGGREGATE_REWRITE = 43,
-	AGGREGATE_REUSE = 44
+	AGGREGATE_REUSE = 44,
+	REDUNDANT_DISTINCT = 45
 };
 
 string OptimizerTypeToString(OptimizerType type);

--- a/src/include/duckdb/optimizer/redundant_distinct_remover.hpp
+++ b/src/include/duckdb/optimizer/redundant_distinct_remover.hpp
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/optimizer/redundant_distinct_remover.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/planner/logical_operator.hpp"
+
+namespace duckdb {
+
+class Optimizer;
+
+//! Removes DISTINCT operators whose duplicates are already discarded by an operator above them, such as
+//! the branches of UNION, INTERSECT and EXCEPT, which are defined on sets.
+class RedundantDistinctRemover {
+public:
+	explicit RedundantDistinctRemover(Optimizer &optimizer);
+
+	unique_ptr<LogicalOperator> Optimize(unique_ptr<LogicalOperator> op);
+
+private:
+	//! `deduplicated` says that every duplicate this subtree emits is discarded further up, so a DISTINCT
+	//! inside it cannot change the result.
+	unique_ptr<LogicalOperator> Visit(unique_ptr<LogicalOperator> op, bool deduplicated);
+
+private:
+	Optimizer &optimizer;
+};
+
+} // namespace duckdb

--- a/src/optimizer/CMakeLists.txt
+++ b/src/optimizer/CMakeLists.txt
@@ -57,6 +57,7 @@ add_library_unity(
   type_pushdown.cpp
   scalar_fn_pushdown.cpp
   projection_pullup.cpp
+  redundant_distinct_remover.cpp
   remote_pushdown_optimizer.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_optimizer>

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -13,6 +13,7 @@
 #include "duckdb/optimizer/cte_inlining.hpp"
 #include "duckdb/optimizer/cte_filter_pusher.hpp"
 #include "duckdb/optimizer/deliminator.hpp"
+#include "duckdb/optimizer/redundant_distinct_remover.hpp"
 #include "duckdb/optimizer/multi_stage_aggregate_rewriter.hpp"
 #include "duckdb/optimizer/empty_result_pullup.hpp"
 #include "duckdb/optimizer/expression_heuristics.hpp"
@@ -270,6 +271,12 @@ void Optimizer::RunBuiltInOptimizers() {
 	RunOptimizer(OptimizerType::IN_CLAUSE, [&]() {
 		InClauseRewriter ic_rewriter(context, *this);
 		plan = ic_rewriter.Rewrite(std::move(plan));
+	});
+
+	// removes DISTINCT operators whose duplicates are discarded by an operator above them
+	RunOptimizer(OptimizerType::REDUNDANT_DISTINCT, [&]() {
+		RedundantDistinctRemover redundant_distinct(*this);
+		plan = redundant_distinct.Optimize(std::move(plan));
 	});
 
 	// removes any redundant DelimGets/DelimJoins

--- a/src/optimizer/redundant_distinct_remover.cpp
+++ b/src/optimizer/redundant_distinct_remover.cpp
@@ -1,0 +1,72 @@
+#include "duckdb/optimizer/redundant_distinct_remover.hpp"
+
+#include "duckdb/optimizer/optimizer.hpp"
+#include "duckdb/planner/operator/logical_distinct.hpp"
+#include "duckdb/planner/operator/logical_set_operation.hpp"
+
+namespace duckdb {
+
+RedundantDistinctRemover::RedundantDistinctRemover(Optimizer &optimizer_p) : optimizer(optimizer_p) {
+}
+
+unique_ptr<LogicalOperator> RedundantDistinctRemover::Optimize(unique_ptr<LogicalOperator> op) {
+	return Visit(std::move(op), false);
+}
+
+//! A projection emits one row per input row, so when its expressions are deterministic the set of values
+//! reaching an ancestor that removes duplicates does not depend on duplicates below it. A volatile
+//! expression breaks that, because it is evaluated once per row and feeding it fewer rows changes what it
+//! produces.
+static bool ProjectionPreservesDeduplication(const LogicalOperator &op) {
+	for (auto &expr : op.expressions) {
+		if (expr->IsVolatile()) {
+			return false;
+		}
+	}
+	return true;
+}
+
+unique_ptr<LogicalOperator> RedundantDistinctRemover::Visit(unique_ptr<LogicalOperator> op, bool deduplicated) {
+	switch (op->type) {
+	case LogicalOperatorType::LOGICAL_DISTINCT: {
+		auto &distinct = op->Cast<LogicalDistinct>();
+		// DISTINCT ON keeps one particular row per group rather than collapsing exact duplicates, so it
+		// neither is redundant nor makes what is below it redundant.
+		if (distinct.distinct_type != DistinctType::DISTINCT) {
+			break;
+		}
+		if (deduplicated) {
+			return Visit(std::move(op->children[0]), true);
+		}
+		// this operator discards the duplicates of everything below it
+		op->children[0] = Visit(std::move(op->children[0]), true);
+		return op;
+	}
+	case LogicalOperatorType::LOGICAL_PROJECTION: {
+		op->children[0] = Visit(std::move(op->children[0]), deduplicated && ProjectionPreservesDeduplication(*op));
+		return op;
+	}
+	case LogicalOperatorType::LOGICAL_UNION:
+	case LogicalOperatorType::LOGICAL_EXCEPT:
+	case LogicalOperatorType::LOGICAL_INTERSECT: {
+		auto &setop = op->Cast<LogicalSetOperation>();
+		// The ALL variants are defined on multisets, so a duplicate coming out of a branch is part of the
+		// result and the branch DISTINCT is doing real work.
+		auto propagate = deduplicated && !setop.setop_all;
+		for (auto &child : op->children) {
+			child = Visit(std::move(child), propagate);
+		}
+		return op;
+	}
+	default:
+		break;
+	}
+	// Any other operator may turn the rows below it into something whose duplicates do survive, so stop
+	// carrying the property across it.
+	for (auto &child : op->children) {
+		child = Visit(std::move(child), false);
+	}
+	return op;
+}
+
+} // namespace duckdb

--- a/test/optimizer/redundant_distinct.test
+++ b/test/optimizer/redundant_distinct.test
@@ -1,0 +1,144 @@
+# name: test/optimizer/redundant_distinct.test
+# description: DISTINCT is removed when an operator above it already discards duplicates
+# group: [optimizer]
+
+statement ok
+SET profiling_renderer_settings = MAP {'operator_casing': 'upper'};
+
+statement ok
+PRAGMA explain_output = OPTIMIZED_ONLY;
+
+statement ok
+CREATE TABLE a(v INTEGER);
+
+statement ok
+INSERT INTO a VALUES (1), (1), (2), (3), (NULL), (NULL);
+
+statement ok
+CREATE TABLE b(v INTEGER);
+
+statement ok
+INSERT INTO b VALUES (2), (2), (3), (4), (NULL);
+
+# --- results are unchanged by a branch DISTINCT under set semantics
+
+query I
+(SELECT DISTINCT v FROM a) UNION (SELECT v FROM b) ORDER BY v
+----
+1
+2
+3
+4
+NULL
+
+query I
+(SELECT v FROM a) UNION (SELECT DISTINCT v FROM b) ORDER BY v
+----
+1
+2
+3
+4
+NULL
+
+query I
+(SELECT DISTINCT v FROM a) INTERSECT (SELECT v FROM b) ORDER BY v
+----
+2
+3
+NULL
+
+query I
+(SELECT DISTINCT v FROM a) EXCEPT (SELECT v FROM b) ORDER BY v
+----
+1
+
+# --- the ALL variants are defined on multisets, so a branch DISTINCT still matters there
+
+query I
+(SELECT DISTINCT v FROM a) UNION ALL (SELECT v FROM b) ORDER BY v
+----
+1
+2
+2
+2
+3
+3
+4
+NULL
+NULL
+
+query I
+(SELECT DISTINCT v FROM a) INTERSECT ALL (SELECT v FROM b) ORDER BY v
+----
+2
+3
+NULL
+
+query I
+(SELECT DISTINCT v FROM a) EXCEPT ALL (SELECT v FROM b) ORDER BY v
+----
+1
+
+# --- DISTINCT ON picks particular rows, so it is not redundant
+
+query II
+(SELECT DISTINCT ON (v) v, v + 10 FROM a) UNION (SELECT v, v + 10 FROM b) ORDER BY 1
+----
+1	11
+2	12
+3	13
+4	14
+NULL	NULL
+
+# --- the redundant branch DISTINCT is actually gone from the plan
+# The operator renders as DISTINCT while its parameter line renders as "Distinct Targets", so a
+# case sensitive match counts operators rather than parameters.
+
+# only the set operation's own DISTINCT is left, not the branch one
+query II
+EXPLAIN (SELECT DISTINCT v FROM a) UNION (SELECT v FROM b)
+----
+logical_opt	<!REGEX>:(?s).*DISTINCT.*DISTINCT.*
+
+query II
+EXPLAIN (SELECT DISTINCT v FROM a) INTERSECT (SELECT v FROM b)
+----
+logical_opt	<!REGEX>:(?s).*DISTINCT.*DISTINCT.*
+
+query II
+EXPLAIN (SELECT DISTINCT v FROM a) EXCEPT (SELECT v FROM b)
+----
+logical_opt	<!REGEX>:(?s).*DISTINCT.*DISTINCT.*
+
+# UNION ALL has no dedup of its own, so the branch DISTINCT has to stay
+query II
+EXPLAIN (SELECT DISTINCT v FROM a) UNION ALL (SELECT v FROM b)
+----
+logical_opt	<REGEX>:(?s).*DISTINCT.*
+
+# turning the optimizer off brings the second DISTINCT back, which is what pins the removal on it
+statement ok
+SET disabled_optimizers = 'redundant_distinct';
+
+query II
+EXPLAIN (SELECT DISTINCT v FROM a) UNION (SELECT v FROM b)
+----
+logical_opt	<REGEX>:(?s).*DISTINCT.*DISTINCT.*
+
+statement ok
+RESET disabled_optimizers;
+
+# --- cases where the DISTINCT is doing real work and has to survive
+
+# a LIMIT decides which rows leave the branch, so removing the DISTINCT under it would change which
+# rows the LIMIT picks
+query II
+EXPLAIN (SELECT DISTINCT v FROM a LIMIT 2) UNION (SELECT v FROM b)
+----
+logical_opt	<REGEX>:(?s).*DISTINCT.*DISTINCT.*
+
+# a volatile expression is evaluated once per row, so feeding it fewer rows changes what it produces
+query II
+EXPLAIN (SELECT (random() > 2)::INTEGER AS z FROM (SELECT DISTINCT v FROM a)) UNION (SELECT v FROM b)
+----
+logical_opt	<REGEX>:(?s).*DISTINCT.*DISTINCT.*


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb/issues/24151

`UNION`, `INTERSECT` and `EXCEPT` are defined on sets, so duplicates coming out of one of their branches cannot change the result. A `DISTINCT` in a branch is redundant, but we still plan and execute it:

```sql
CREATE TABLE a(v INTEGER);
CREATE TABLE b(v INTEGER);
INSERT INTO a SELECT i::INTEGER FROM range(1000000) t(i);
INSERT INTO b SELECT (i + 500000)::INTEGER FROM range(1000000) t(i);

PRAGMA threads=1;

-- 0.110s
SELECT count(*) FROM ((SELECT v FROM a) UNION (SELECT v FROM b));

-- 0.130s, one extra HASH_GROUP_BY for a DISTINCT that cannot change anything
SELECT count(*) FROM ((SELECT DISTINCT v FROM a) UNION (SELECT v FROM b));
```

Removing the child of the set operation does not work, because that is not where the operator ends up. `bind_setop_node` plans a non-`ALL` set operation as a `LogicalSetOperation` plus a separate `DistinctModifier`, so the dedup that makes the branch redundant sits above the set operation with projections in between. This optimizer carries a flag down the plan instead, saying that duplicates from this subtree are discarded further up. A plain `DISTINCT` sets the flag for its own subtree, and a plain `DISTINCT` that meets the flag already set is removed. Nested `SELECT DISTINCT` inside `SELECT DISTINCT` is handled by the same rule.

The flag stops at the `ALL` variants, which are defined on multisets and where a duplicate leaving a branch is part of the answer. It stops at `DISTINCT ON`, which keeps one particular row per group rather than collapsing exact duplicates, so it is neither removed nor treated as a dedup. It stops at a projection holding a volatile expression, which is evaluated once per row and would see a different number of rows. It stops at every other operator.

With this the branch `DISTINCT` costs nothing and both queries above run in 0.110s. `INTERSECT` goes from 0.061s to 0.043s and `EXCEPT` from 0.063s to 0.042s, measured with 1,000,000 unique rows per table on a single thread. It can be switched off with `SET disabled_optimizers='redundant_distinct'`.

One thing I ran into while writing this. `bind_setop_node.cpp:294` sets `statement.setop_all = false` under a comment saying "Already handled". The assignment does nothing, and `result.setop_all` was already copied from it at line 241, so it could not take effect anyway. I left it alone, since this optimizer relies on `setop_all` still being false at that point, but it looks like a leftover.
