### PR TITLE
Fix out of bounds read when a GZIP member is missing its footer

### DIFF
--- a/test/common/CMakeLists.txt
+++ b/test/common/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library_unity(
   test_column_data_allocator.cpp
   test_file_buffer_handle_group.cpp
   test_file_system.cpp
+  test_gzip_member_oob.cpp
   test_caching_file_system_wrapper.cpp
   test_external_file_cache.cpp
   test_hyperlog.cpp

--- a/test/common/test_gzip_member_oob.cpp
+++ b/test/common/test_gzip_member_oob.cpp
@@ -1,0 +1,92 @@
+#include "catch.hpp"
+#include "duckdb/common/helper.hpp"
+#include "miniz_wrapper.hpp"
+
+#include <cstring>
+#include <string>
+
+using namespace duckdb;
+
+namespace {
+
+// Builds one complete gzip member (header + deflate stream + footer) into an exactly sized buffer.
+unsafe_unique_array<char> CompressToExactBuffer(const std::string &input, size_t &member_size) {
+	auto scratch_size = MiniZStream::MaxCompressedLength(input.size());
+	auto scratch = make_unsafe_uniq_array<char>(scratch_size);
+
+	MiniZStream compressor;
+	member_size = scratch_size;
+	compressor.Compress(input.c_str(), input.size(), scratch.get(), &member_size);
+
+	auto member = make_unsafe_uniq_array<char>(member_size);
+	memcpy(member.get(), scratch.get(), member_size);
+	return member;
+}
+
+// Copies the first `keep` bytes into an allocation of exactly that size, so a read past the end of
+// the member lands outside a real allocation rather than in slack the allocator happened to give us.
+unsafe_unique_array<char> TruncateToExactBuffer(const unsafe_unique_array<char> &member, size_t keep) {
+	auto truncated = make_unsafe_uniq_array<char>(keep);
+	memcpy(truncated.get(), member.get(), keep);
+	return truncated;
+}
+
+} // namespace
+
+TEST_CASE("gzip member missing its footer is rejected", "[miniz]") {
+	const std::string payload(4096, 'q');
+
+	size_t member_size;
+	auto member = CompressToExactBuffer(payload, member_size);
+	REQUIRE(member_size > MiniZStream::GZIP_HEADER_MINSIZE + MiniZStream::GZIP_FOOTER_SIZE);
+
+	// The intact member round trips.
+	{
+		auto out = make_unsafe_uniq_array<char>(payload.size());
+		MiniZStream decompressor;
+		decompressor.Decompress(member.get(), member_size, out.get(), payload.size());
+		REQUIRE(memcmp(out.get(), payload.c_str(), payload.size()) == 0);
+	}
+
+	// Dropping any part of the 8 byte footer used to underflow the remaining-size counter, so the
+	// member loop ran once more and read a gzip header out of bounds. It has to be reported as a
+	// truncated member instead. Checking the message matters: the out of bounds read usually landed
+	// on bytes that failed the magic check, so "it throws" alone held before the fix as well.
+	for (size_t missing = 1; missing <= MiniZStream::GZIP_FOOTER_SIZE; missing++) {
+		auto keep = member_size - missing;
+		auto truncated = TruncateToExactBuffer(member, keep);
+
+		auto out = make_unsafe_uniq_array<char>(payload.size());
+		MiniZStream decompressor;
+		bool threw = false;
+		try {
+			decompressor.Decompress(truncated.get(), keep, out.get(), payload.size());
+		} catch (const std::exception &ex) {
+			threw = true;
+			REQUIRE(std::string(ex.what()).find("incomplete gzip member footer") != std::string::npos);
+		}
+		REQUIRE(threw);
+	}
+}
+
+TEST_CASE("concatenated gzip members still decompress", "[miniz]") {
+	// The bounds check sits inside the member loop, so keep a multi member stream covered.
+	const std::string first(1024, 'a');
+	const std::string second(2048, 'b');
+
+	size_t first_size;
+	auto first_member = CompressToExactBuffer(first, first_size);
+	size_t second_size;
+	auto second_member = CompressToExactBuffer(second, second_size);
+
+	auto combined_size = first_size + second_size;
+	auto combined = make_unsafe_uniq_array<char>(combined_size);
+	memcpy(combined.get(), first_member.get(), first_size);
+	memcpy(combined.get() + first_size, second_member.get(), second_size);
+
+	auto expected = first + second;
+	auto out = make_unsafe_uniq_array<char>(expected.size());
+	MiniZStream decompressor;
+	decompressor.Decompress(combined.get(), combined_size, out.get(), expected.size());
+	REQUIRE(memcmp(out.get(), expected.c_str(), expected.size()) == 0);
+}

--- a/third_party/miniz/miniz_wrapper.hpp
+++ b/third_party/miniz/miniz_wrapper.hpp
@@ -86,6 +86,12 @@ public:
 			mz_inflateEnd(&stream);
 
 			// Update indices
+			// The member's footer has to be inside the buffer. Without this check the subtraction
+			// below underflows, the loop keeps going, and the next iteration reads a gzip header
+			// past the end of the input.
+			if (stream.total_in > compressed_size || compressed_size - stream.total_in < GZIP_FOOTER_SIZE) {
+				FormatException("Failed to decompress GZIP block: incomplete gzip member footer");
+			}
 			compressed_data += GZIP_FOOTER_SIZE + stream.total_in;
 			compressed_size -= GZIP_FOOTER_SIZE + stream.total_in;
 			out_data += stream.total_out;


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb/issues/24955

`MiniZStream::Decompress` walks a gzip stream member by member, skipping the deflate bytes it consumed plus the 8 byte footer at the end of each one. Nothing checked that those footer bytes were actually in the buffer, so a member whose deflate stream ends with fewer than 8 bytes left underflows `compressed_size`, which is a `size_t`. The loop condition stays true and the next iteration reads a gzip header past the end of the input. The parquet reader takes this path for `GZIP` pages and sizes the buffer from file metadata, so a crafted file gets there through `read_parquet`.

Compiling `third_party/miniz` as it is and handing `Decompress` a member with its last byte removed:

```
AddressSanitizer: heap-buffer-overflow
READ of size 1
  duckdb::MiniZStream::Decompress(char const*, unsigned long, char*, unsigned long) miniz_wrapper.hpp:62
located 1 bytes after 38-byte region
```

Line 62 is the `gzip_hdr[0]` read at the top of the member loop.

The test asserts on the error message rather than only that the call throws. Before this change the out of bounds read usually landed on bytes that failed the magic number check, so the call threw anyway and a plain check for throwing would have passed on the broken code too. Without a sanitizer the unpatched build reports `Input is invalid/unsupported GZIP stream` and the patched one reports `incomplete gzip member footer`, so the test does fail on unpatched code in a normal build.
