### PR TITLE
Fix `Value::ToSQLString` nested type round-tripping

### DIFF
--- a/src/common/types/value.cpp
+++ b/src/common/types/value.cpp
@@ -32,6 +32,7 @@
 #include "duckdb/common/serializer/binary_serializer.hpp"
 #include "duckdb/common/serializer/binary_deserializer.hpp"
 #include "duckdb/common/serializer/memory_stream.hpp"
+#include "duckdb/common/sql_identifier.hpp"
 #include "duckdb/common/types/string.hpp"
 #include "duckdb/common/types/value_map.hpp"
 #include "duckdb/function/scalar/variant_utils.hpp"
@@ -1733,6 +1734,7 @@ string Value::ToSQLString() const {
 	case LogicalTypeId::TIMESTAMP_NS:
 	case LogicalTypeId::INTERVAL:
 	case LogicalTypeId::BLOB:
+	case LogicalTypeId::BIT:
 		return "'" + ToString() + "'::" + type_.ToString();
 	case LogicalTypeId::VARCHAR:
 	case LogicalTypeId::ENUM: {
@@ -1766,7 +1768,7 @@ string Value::ToSQLString() const {
 			if (is_unnamed) {
 				ret += child.ToSQLString();
 			} else {
-				ret += "'" + name + "': " + child.ToSQLString();
+				ret += "'" + StringUtil::Replace(name.GetIdentifierName(), "'", "''") + "': " + child.ToSQLString();
 			}
 			if (i < struct_values.size() - 1) {
 				ret += ", ";
@@ -1843,9 +1845,9 @@ string Value::ToSQLString() const {
 		string ret = "union_value(";
 		auto union_tag = UnionValue::GetTag(*this);
 		auto &tag_name = UnionType::GetMemberName(type(), union_tag);
-		ret += tag_name + " := ";
+		ret += SQLIdentifier(tag_name) + " := ";
 		ret += UnionValue::GetValue(*this).ToSQLString();
-		ret += ")";
+		ret += ")::" + type_.ToString();
 		return ret;
 	}
 	default:

--- a/test/common/test_value_to_sql_string.cpp
+++ b/test/common/test_value_to_sql_string.cpp
@@ -45,3 +45,18 @@ TEST_CASE("Value::ToSQLString round-trips MAP values", "[api]") {
 	// the explicit cast also preserves narrower integer subtypes
 	RequireRoundTrip(con, "MAP {1::SMALLINT: 2::SMALLINT}");
 }
+
+TEST_CASE("Value::ToSQLString round-trips STRUCT, BIT and UNION values", "[api]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+
+	SECTION("STRUCT key containing a quote") {
+		RequireRoundTrip(con, "{'it''s': 42}");
+	}
+	SECTION("BIT value") {
+		RequireRoundTrip(con, "'101'::BIT");
+	}
+	SECTION("UNION member types") {
+		RequireRoundTrip(con, "union_value(i := 42::SMALLINT)::UNION(i SMALLINT, s VARCHAR)");
+	}
+}


### PR DESCRIPTION
This PR fixes round-trip for STRUCT, BIT, and UNION values.