### PR TITLE
feature: fetch selected rows for overflow string scans

### DIFF
--- a/src/include/duckdb/function/compression_function.hpp
+++ b/src/include/duckdb/function/compression_function.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/enums/compression_type.hpp"
+#include "duckdb/common/enums/scan_vector_type.hpp"
 #include "duckdb/common/map.hpp"
 #include "duckdb/common/insertion_order_preserving_map.hpp"
 #include "duckdb/common/mutex.hpp"
@@ -162,8 +163,11 @@ typedef void (*compression_scan_vector_t)(ColumnSegment &segment, ColumnScanStat
 typedef void (*compression_scan_partial_t)(ColumnSegment &segment, ColumnScanState &state, idx_t scan_count,
                                            Vector &result, idx_t result_offset);
 //! Function prototype used for reading a subset of the values of a vector indicated by a selection vector
+//! The selected values are written to 'result' starting at 'result_offset'. Emitting a compressed vector (e.g. a
+//! constant vector) is only allowed if 'scan_type' is SCAN_ENTIRE_VECTOR
 typedef void (*compression_select_t)(ColumnSegment &segment, ColumnScanState &state, idx_t vector_count, Vector &result,
-                                     const SelectionVector &sel, idx_t sel_count);
+                                     const SelectionVector &sel, idx_t sel_count, idx_t result_offset,
+                                     ScanVectorType scan_type);
 //! Function prototype used for applying a filter to a vector while scanning that vector
 typedef void (*compression_filter_t)(ColumnSegment &segment, ColumnScanState &state, idx_t vector_count, Vector &result,
                                      SelectionVector &sel, idx_t &sel_count, const TableFilter &filter,

--- a/src/include/duckdb/storage/compression/dict_fsst/decompression.hpp
+++ b/src/include/duckdb/storage/compression/dict_fsst/decompression.hpp
@@ -26,7 +26,7 @@ public:
 	void ScanToDictionaryVector(ColumnSegment &segment, Vector &result, idx_t result_offset, idx_t start,
 	                            idx_t scan_count);
 	const SelectionVector &GetSelVec(idx_t start, idx_t scan_count);
-	void Select(Vector &result, idx_t start, const SelectionVector &sel, idx_t sel_count);
+	void Select(Vector &result, idx_t result_offset, idx_t start, const SelectionVector &sel, idx_t sel_count);
 
 	bool AllowDictionaryScan(idx_t scan_count);
 

--- a/src/include/duckdb/storage/compression/empty_validity.hpp
+++ b/src/include/duckdb/storage/compression/empty_validity.hpp
@@ -98,7 +98,7 @@ public:
 	                   TableFilterState &filter_state) {
 	}
 	static void Select(ColumnSegment &segment, ColumnScanState &state, idx_t vector_count, Vector &result,
-	                   const SelectionVector &sel, idx_t sel_count) {
+	                   const SelectionVector &sel, idx_t sel_count, idx_t result_offset, ScanVectorType scan_type) {
 	}
 };
 

--- a/src/include/duckdb/storage/string_uncompressed.hpp
+++ b/src/include/duckdb/storage/string_uncompressed.hpp
@@ -67,7 +67,7 @@ public:
 	                              idx_t result_offset);
 	static void StringScan(ColumnSegment &segment, ColumnScanState &state, idx_t scan_count, Vector &result);
 	static void Select(ColumnSegment &segment, ColumnScanState &state, idx_t vector_count, Vector &result,
-	                   const SelectionVector &sel, idx_t sel_count);
+	                   const SelectionVector &sel, idx_t sel_count, idx_t result_offset, ScanVectorType scan_type);
 
 	static void StringFetchRow(ColumnSegment &segment, ColumnFetchState &state, row_t row_id, Vector &result,
 	                           idx_t result_idx);

--- a/src/include/duckdb/storage/table/column_data.hpp
+++ b/src/include/duckdb/storage/table/column_data.hpp
@@ -244,7 +244,7 @@ protected:
 	idx_t ScanVector(TransactionData transaction, idx_t vector_index, ColumnScanState &state, Vector &result,
 	                 idx_t target_scan, UpdateScanType update_type);
 	void SelectVector(ColumnScanState &state, Vector &result, idx_t target_count, const SelectionVector &sel,
-	                  idx_t sel_count);
+	                  idx_t sel_count, ScanVectorType scan_type);
 	void FilterVector(ColumnScanState &state, Vector &result, idx_t target_count, SelectionVector &sel,
 	                  idx_t &sel_count, const TableFilter &filter, TableFilterState &filter_state);
 

--- a/src/include/duckdb/storage/table/column_segment.hpp
+++ b/src/include/duckdb/storage/table/column_segment.hpp
@@ -64,7 +64,8 @@ public:
 	//! Scan one vector from this segment
 	void Scan(ColumnScanState &state, idx_t scan_count, Vector &result, idx_t result_offset, ScanVectorType scan_type);
 	//! Scan a subset of a vector (defined by the selection vector)
-	void Select(ColumnScanState &state, idx_t scan_count, Vector &result, const SelectionVector &sel, idx_t sel_count);
+	void Select(ColumnScanState &state, idx_t scan_count, Vector &result, const SelectionVector &sel, idx_t sel_count,
+	            idx_t result_offset, ScanVectorType scan_type);
 	//! Scan one vector while applying a filter to the vector, returning only the matching elements
 	void Filter(ColumnScanState &state, idx_t scan_count, Vector &result, SelectionVector &sel, idx_t &sel_count,
 	            const TableFilter &filter, TableFilterState &filter_state);

--- a/src/storage/compression/dict_fsst.cpp
+++ b/src/storage/compression/dict_fsst.cpp
@@ -160,17 +160,15 @@ void DictFSSTCompressionStorage::StringFetchRow(ColumnSegment &segment, ColumnFe
 // Select
 //===--------------------------------------------------------------------===//
 void DictFSSTSelect(ColumnSegment &segment, ColumnScanState &state, idx_t vector_count, Vector &result,
-                    const SelectionVector &sel, idx_t sel_count) {
+                    const SelectionVector &sel, idx_t sel_count, idx_t result_offset, ScanVectorType scan_type) {
 	auto &scan_state = state.scan_state->Cast<CompressedStringScanState>();
-	if (scan_state.mode == DictFSSTMode::FSST_ONLY) {
-		// for FSST only
-		auto start = state.GetPositionInSegment();
-		scan_state.Select(result, start, sel, sel_count);
+	if (scan_state.mode != DictFSSTMode::FSST_ONLY && scan_type == ScanVectorType::SCAN_ENTIRE_VECTOR) {
+		// scan + slice, so that we can emit a dictionary vector
+		DictFSSTCompressionStorage::StringScan(segment, state, vector_count, result);
+		result.Slice(sel, sel_count);
 		return;
 	}
-	// fallback: scan + slice
-	DictFSSTCompressionStorage::StringScan(segment, state, vector_count, result);
-	result.Slice(sel, sel_count);
+	scan_state.Select(result, result_offset, state.GetPositionInSegment(), sel, sel_count);
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/storage/compression/dict_fsst/decompression.cpp
+++ b/src/storage/compression/dict_fsst/decompression.cpp
@@ -192,21 +192,43 @@ void CompressedStringScanState::ScanToFlatVector(Vector &result, idx_t result_of
 	result.Verify();
 }
 
-void CompressedStringScanState::Select(Vector &result, idx_t start, const SelectionVector &sel, idx_t sel_count) {
-	D_ASSERT(!dictionary);
-	D_ASSERT(mode == DictFSSTMode::FSST_ONLY);
-	idx_t start_offset = start + 1;
-	auto result_data = FlatVector::Writer<string_t>(result, sel_count);
-	for (idx_t i = 0; i < sel_count; i++) {
-		// Lookup dict offset in index buffer
-		auto string_number = start_offset + sel.get_index(i);
-		if (decompress_position > string_number) {
-			throw InternalException("DICT_FSST: not performing a sequential scan?");
+void CompressedStringScanState::Select(Vector &result, idx_t result_offset, idx_t start, const SelectionVector &sel,
+                                       idx_t sel_count) {
+	D_ASSERT(sel_count > 0);
+	auto &selvec = GetSelVec(start, sel.get_index(sel_count - 1) + 1);
+
+	//! (index 0 is reserved for NULL, which we don't have in this mode)
+	const idx_t start_offset = mode == DictFSSTMode::FSST_ONLY ? start + 1 : 0;
+
+	auto result_data = FlatVector::Writer<string_t>(result, sel_count, result_offset);
+	if (dictionary) {
+		// We have prepared the full dictionary, we can reference these strings directly
+		auto dictionary_values = FlatVector::GetData<string_t>(dictionary->data);
+		for (idx_t i = 0; i < sel_count; i++) {
+			// Lookup dict offset in index buffer
+			auto string_number = selvec.get_index(start_offset + sel.get_index(i));
+			if (string_number == 0) {
+				result_data.WriteNull();
+				continue;
+			}
+			result_data.WriteStringRef(dictionary_values[string_number]);
 		}
-		for (; decompress_position < string_number; decompress_position++) {
-			decompress_offset += string_lengths[decompress_position];
+	} else {
+		for (idx_t i = 0; i < sel_count; i++) {
+			// Lookup dict offset in index buffer
+			auto string_number = selvec.get_index(start_offset + sel.get_index(i));
+			if (string_number == 0) {
+				result_data.WriteNull();
+				continue;
+			}
+			if (decompress_position > string_number) {
+				throw InternalException("DICT_FSST: not performing a sequential scan?");
+			}
+			for (; decompress_position < string_number; decompress_position++) {
+				decompress_offset += string_lengths[decompress_position];
+			}
+			result_data.WriteStringRef(FetchStringFromDict(result, decompress_offset, string_number));
 		}
-		result_data.WriteValue(FetchStringFromDict(result, decompress_offset, string_number));
 	}
 }
 

--- a/src/storage/compression/fsst.cpp
+++ b/src/storage/compression/fsst.cpp
@@ -54,7 +54,7 @@ struct FSSTStorage {
 	static void StringFetchRow(ColumnSegment &segment, ColumnFetchState &state, row_t row_id, Vector &result,
 	                           idx_t result_idx);
 	static void Select(ColumnSegment &segment, ColumnScanState &state, idx_t vector_count, Vector &result,
-	                   const SelectionVector &sel, idx_t sel_count);
+	                   const SelectionVector &sel, idx_t sel_count, idx_t result_offset, ScanVectorType scan_type);
 
 	static void SetDictionary(ColumnSegment &segment, BufferHandle &handle, StringDictionaryContainer container);
 	static StringDictionaryContainer GetDictionary(ColumnSegment &segment, BufferHandle &handle);
@@ -701,7 +701,7 @@ void FSSTStorage::StringScan(ColumnSegment &segment, ColumnScanState &state, idx
 // Select
 //===--------------------------------------------------------------------===//
 void FSSTStorage::Select(ColumnSegment &segment, ColumnScanState &state, idx_t vector_count, Vector &result,
-                         const SelectionVector &sel, idx_t sel_count) {
+                         const SelectionVector &sel, idx_t sel_count, idx_t result_offset, ScanVectorType) {
 	auto &scan_state = state.scan_state->Cast<FSSTScanState>();
 	auto start = state.GetPositionInSegment();
 
@@ -717,7 +717,7 @@ void FSSTStorage::Select(ColumnSegment &segment, ColumnScanState &state, idx_t v
 
 	for (idx_t i = 0; i < sel_count; i++) {
 		idx_t index = sel.get_index(i);
-		result_data[i] = scan_state.DecompressString(dict, baseptr, offsets, index, str_allocator);
+		result_data[result_offset + i] = scan_state.DecompressString(dict, baseptr, offsets, index, str_allocator);
 	}
 	EndScan(scan_state, offsets, start, vector_count);
 }

--- a/src/storage/compression/numeric_constant.cpp
+++ b/src/storage/compression/numeric_constant.cpp
@@ -266,14 +266,23 @@ void ConstantFetchRow(ColumnSegment &segment, ColumnFetchState &state, row_t row
 // Select
 //===--------------------------------------------------------------------===//
 void ConstantSelectValidity(ColumnSegment &segment, ColumnScanState &state, idx_t vector_count, Vector &result,
-                            const SelectionVector &sel, idx_t sel_count) {
-	ConstantScanFunctionValidity(segment, state, sel_count, result);
+                            const SelectionVector &sel, idx_t sel_count, idx_t result_offset,
+                            ScanVectorType scan_type) {
+	if (scan_type == ScanVectorType::SCAN_ENTIRE_VECTOR) {
+		ConstantScanFunctionValidity(segment, state, sel_count, result);
+		return;
+	}
+	ConstantScanPartialValidity(segment, state, sel_count, result, result_offset);
 }
 
 template <class T>
 void ConstantSelect(ColumnSegment &segment, ColumnScanState &state, idx_t vector_count, Vector &result,
-                    const SelectionVector &sel, idx_t sel_count) {
-	ConstantScanFunction<T>(segment, state, vector_count, result);
+                    const SelectionVector &sel, idx_t sel_count, idx_t result_offset, ScanVectorType scan_type) {
+	if (scan_type == ScanVectorType::SCAN_ENTIRE_VECTOR) {
+		ConstantScanFunction<T>(segment, state, vector_count, result);
+		return;
+	}
+	ConstantScanPartial<T>(segment, state, sel_count, result, result_offset);
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/storage/compression/rle.cpp
+++ b/src/storage/compression/rle.cpp
@@ -412,17 +412,18 @@ void RLEScan(ColumnSegment &segment, ColumnScanState &state, idx_t scan_count, V
 //===--------------------------------------------------------------------===//
 template <class T>
 void RLESelect(ColumnSegment &segment, ColumnScanState &state, idx_t vector_count, Vector &result,
-               const SelectionVector &sel, idx_t sel_count) {
+               const SelectionVector &sel, idx_t sel_count, idx_t result_offset, ScanVectorType scan_type) {
 	auto &scan_state = state.scan_state->Cast<RLEScanState<T>>();
 
 	// If we are scanning an entire Vector and it contains only a single run we don't need to select at all
-	if (CanEmitConstantVector<true>(scan_state.position_in_entry, scan_state.index_pointer[scan_state.entry_pos],
+	if (scan_type == ScanVectorType::SCAN_ENTIRE_VECTOR &&
+	    CanEmitConstantVector<true>(scan_state.position_in_entry, scan_state.index_pointer[scan_state.entry_pos],
 	                                vector_count)) {
 		RLEScanConstant<T>(scan_state, vector_count, result);
 		return;
 	}
 
-	auto result_data = FlatVector::Writer<T>(result, sel_count);
+	auto result_data = FlatVector::Writer<T>(result, sel_count, result_offset);
 
 	idx_t prev_idx = 0;
 	for (idx_t i = 0; i < sel_count; i++) {

--- a/src/storage/compression/string_uncompressed.cpp
+++ b/src/storage/compression/string_uncompressed.cpp
@@ -121,7 +121,8 @@ void UncompressedStringStorage::StringScan(ColumnSegment &segment, ColumnScanSta
 // Select
 //===--------------------------------------------------------------------===//
 void UncompressedStringStorage::Select(ColumnSegment &segment, ColumnScanState &state, idx_t vector_count,
-                                       Vector &result, const SelectionVector &sel, idx_t sel_count) {
+                                       Vector &result, const SelectionVector &sel, idx_t sel_count, idx_t result_offset,
+                                       ScanVectorType) {
 	// clear any previously locked buffers and get the primary buffer handle
 	auto &scan_state = state.scan_state->Cast<StringScanState>();
 	auto start = state.GetPositionInSegment();
@@ -136,7 +137,8 @@ void UncompressedStringStorage::Select(ColumnSegment &segment, ColumnScanState &
 		auto current_offset = base_data[index];
 		auto prev_offset = index > 0 ? base_data[index - 1] : 0;
 		auto string_length = UnsafeNumericCast<uint32_t>(std::abs(current_offset) - std::abs(prev_offset));
-		result_data[i] = FetchStringFromDict(segment, dict_end, result, baseptr, current_offset, string_length);
+		result_data[result_offset + i] =
+		    FetchStringFromDict(segment, dict_end, result, baseptr, current_offset, string_length);
 	}
 }
 

--- a/src/storage/compression/validity_uncompressed.cpp
+++ b/src/storage/compression/validity_uncompressed.cpp
@@ -487,8 +487,10 @@ void ValidityScan(ColumnSegment &segment, ColumnScanState &state, idx_t scan_cou
 // Select
 //===--------------------------------------------------------------------===//
 void ValiditySelect(ColumnSegment &segment, ColumnScanState &state, idx_t, Vector &result, const SelectionVector &sel,
-                    idx_t sel_count) {
-	result.Flatten();
+                    idx_t sel_count, idx_t result_offset, ScanVectorType) {
+	if (result_offset == 0) {
+		result.Flatten();
+	}
 
 	auto &scan_state = state.scan_state->Cast<ValidityScanState>();
 	auto buffer_ptr = scan_state.handle.GetDataMutable() + segment.GetBlockOffset();
@@ -500,7 +502,7 @@ void ValiditySelect(ColumnSegment &segment, ColumnScanState &state, idx_t, Vecto
 	for (idx_t i = 0; i < sel_count; i++) {
 		auto source_idx = start + sel.get_index(i);
 		if (!source_mask.RowIsValidUnsafe(source_idx)) {
-			result_mask.SetInvalid(i);
+			result_mask.SetInvalid(result_offset + i);
 		}
 	}
 }
@@ -597,12 +599,14 @@ void ValidityRevertAppend(ColumnSegment &segment, idx_t new_count) {
 //===--------------------------------------------------------------------===//
 CompressionFunction ValidityUncompressed::GetFunction(PhysicalType data_type) {
 	D_ASSERT(data_type == PhysicalType::BIT);
-	return CompressionFunction(CompressionType::COMPRESSION_UNCOMPRESSED, data_type, ValidityInitAnalyze,
+	CompressionFunction result(CompressionType::COMPRESSION_UNCOMPRESSED, data_type, ValidityInitAnalyze,
 	                           ValidityAnalyze, ValidityFinalAnalyze, UncompressedFunctions::InitCompression,
 	                           UncompressedFunctions::Compress, UncompressedFunctions::FinalizeCompress,
 	                           ValidityInitScan, ValidityScan, ValidityScanPartial, ValidityFetchRow,
 	                           UncompressedFunctions::EmptySkip, ValidityInitSegment, ValidityInitAppend,
 	                           ValidityAppend, ValidityFinalizeAppend, ValidityRevertAppend);
+	result.select = ValiditySelect;
+	return result;
 }
 
 } // namespace duckdb

--- a/src/storage/table/column_data.cpp
+++ b/src/storage/table/column_data.cpp
@@ -261,23 +261,71 @@ idx_t ColumnData::ScanVector(ColumnScanState &state, Vector &result, idx_t remai
 }
 
 void ColumnData::SelectVector(ColumnScanState &state, Vector &result, idx_t target_count, const SelectionVector &sel,
-                              idx_t sel_count) {
+                              idx_t sel_count, ScanVectorType scan_type) {
 	BeginScanVectorInternal(state);
-	auto &current = state.current->GetNode();
-	if (state.current->GetRowStart() + current.count - state.offset_in_column < target_count) {
-		throw InternalException("ColumnData::SelectVector should be able to fetch everything from one segment");
-	}
-	if (state.scan_options && state.scan_options->force_fetch_row) {
-		for (idx_t i = 0; i < sel_count; i++) {
-			auto source_idx = sel.get_index(i);
-			ColumnFetchState fetch_state;
-			current.FetchRow(fetch_state, UnsafeNumericCast<row_t>(state.offset_in_column + source_idx), result, i);
+	// scratch space to rebase the selection vector to the start of a segment scan
+	// this owns its data, as compression functions can retain the selection vector (e.g. by slicing the result)
+	SelectionVector rebased_sel;
+	idx_t sel_offset = 0;
+	idx_t scanned_count = 0;
+	// the position up to which the scan state of the current segment has been advanced
+	// segments without any selected rows are not scanned, so they must be skipped in the next scan
+	idx_t segment_internal_index = state.offset_in_column;
+	while (scanned_count < target_count) {
+		auto &current = state.current->GetNode();
+		auto current_start = state.current->GetRowStart();
+		idx_t scan_count =
+		    MinValue<idx_t>(target_count - scanned_count, current_start + current.count - state.offset_in_column);
+		segment_internal_index = state.offset_in_column;
+		// gather the selected rows that fall within this segment
+		idx_t segment_sel_count = 0;
+		while (sel_offset + segment_sel_count < sel_count &&
+		       sel.get_index(sel_offset + segment_sel_count) < scanned_count + scan_count) {
+			segment_sel_count++;
 		}
-	} else {
-		current.Select(state, target_count, result, sel, sel_count);
+		if (segment_sel_count > 0) {
+			// the indices must be relative to the start of the segment scan - for the first segment this is
+			// already the case, so we can forward the selection vector of the caller directly
+			reference<const SelectionVector> segment_sel(sel);
+			if (scanned_count > 0) {
+				if (!rebased_sel.IsSet()) {
+					rebased_sel.Initialize();
+				}
+				for (idx_t i = 0; i < segment_sel_count; i++) {
+					rebased_sel.set_index(i, sel.get_index(sel_offset + i) - scanned_count);
+				}
+				segment_sel = rebased_sel;
+			}
+			if (state.scan_options && state.scan_options->force_fetch_row) {
+				for (idx_t i = 0; i < segment_sel_count; i++) {
+					ColumnFetchState fetch_state;
+					auto source_idx = state.offset_in_column + segment_sel.get().get_index(i) - current_start;
+					current.FetchRow(fetch_state, UnsafeNumericCast<row_t>(source_idx), result, sel_offset + i);
+				}
+			} else {
+				current.Select(state, scan_count, result, segment_sel.get(), segment_sel_count, sel_offset, scan_type);
+			}
+			segment_internal_index = state.offset_in_column + scan_count;
+		}
+		sel_offset += segment_sel_count;
+		scanned_count += scan_count;
+		state.offset_in_column += scan_count;
+		if (scanned_count < target_count) {
+			auto next = data.GetNextSegment(*state.current);
+			if (!next) {
+				break;
+			}
+			state.previous_states.emplace_back(std::move(state.scan_state));
+			state.current = next;
+			state.current->GetNode().InitializeScan(state);
+			state.segment_checked = false;
+		}
 	}
-	state.offset_in_column += target_count;
-	state.internal_index = state.offset_in_column;
+	if (scan_type == ScanVectorType::SCAN_FLAT_VECTOR) {
+		// not every compression function sets the size of the result
+		FlatVector::SetSize(result, count_t(sel_count));
+	}
+	state.internal_index = segment_internal_index;
 }
 
 void ColumnData::FilterVector(ColumnScanState &state, Vector &result, idx_t target_count, SelectionVector &sel,

--- a/src/storage/table/column_segment.cpp
+++ b/src/storage/table/column_segment.cpp
@@ -143,11 +143,16 @@ void ColumnSegment::Scan(ColumnScanState &state, idx_t scan_count, Vector &resul
 }
 
 void ColumnSegment::Select(ColumnScanState &state, idx_t scan_count, Vector &result, const SelectionVector &sel,
-                           idx_t sel_count) {
+                           idx_t sel_count, idx_t result_offset, ScanVectorType scan_type) {
 	if (!function.get().select) {
 		throw InternalException("ColumnSegment::Select not implemented for this compression method");
 	}
-	function.get().select(*this, state, scan_count, result, sel, sel_count);
+	if (scan_type == ScanVectorType::SCAN_ENTIRE_VECTOR) {
+		D_ASSERT(result_offset == 0);
+	} else {
+		D_ASSERT(result.GetVectorType() == VectorType::FLAT_VECTOR);
+	}
+	function.get().select(*this, state, scan_count, result, sel, sel_count, result_offset, scan_type);
 }
 
 void ColumnSegment::Filter(ColumnScanState &state, idx_t scan_count, Vector &result, SelectionVector &sel,

--- a/src/storage/table/standard_column_data.cpp
+++ b/src/storage/table/standard_column_data.cpp
@@ -110,14 +110,13 @@ void StandardColumnData::Select(TransactionData transaction, idx_t vector_index,
 	bool validity_has_select = validity_compression && validity_compression->select;
 	auto target_count = GetVectorCount(vector_index);
 	auto scan_type = GetVectorScanType(state, target_count, result);
-	bool scan_entire_vector = scan_type == ScanVectorType::SCAN_ENTIRE_VECTOR;
-	if (!has_select || !validity_has_select || !scan_entire_vector) {
-		// we are not scanning an entire vector - this can have several causes (updates, etc)
+	if (!has_select || !validity_has_select || HasUpdates() || validity->HasUpdates()) {
+		// the updates need to be merged into the entire vector, so we cannot select
 		ColumnData::Select(transaction, vector_index, state, result, sel, sel_count);
 		return;
 	}
-	SelectVector(state, result, target_count, sel, sel_count);
-	validity->SelectVector(state.child_states[0], result, target_count, sel, sel_count);
+	SelectVector(state, result, target_count, sel, sel_count, scan_type);
+	validity->SelectVector(state.child_states[0], result, target_count, sel, sel_count, scan_type);
 }
 
 void StandardColumnData::InitializeAppend(ColumnAppendState &state) {

--- a/test/configs/disable_optimizer.json
+++ b/test/configs/disable_optimizer.json
@@ -25,6 +25,12 @@
       ]
     },
     {
+      "reason": "Fetching only the selected rows requires filter pushdown from optimizer.",
+      "paths": [
+        "test/sql/storage/overflow_strings/blob_row_fetch.test"
+      ]
+    },
+    {
       "reason": "Unoptimized statement differs from original result (cross product, conversion, overflow, statistics).",
       "paths": [
         "test/fuzzer/duckfuzz/semi_join_has_correct_left_right_relations.test",

--- a/test/configs/prefetch_all_storage.json
+++ b/test/configs/prefetch_all_storage.json
@@ -8,6 +8,12 @@
       "paths": [
         "test/sql/storage/constraints/foreignkey/foreign_key_persistent_memory_limit.test"
       ]
+    },
+    {
+      "reason": "Forced prefetching reads all blocks of the column at once, which exceeds the memory limit the test relies on.",
+      "paths": [
+        "test/sql/storage/overflow_strings/blob_row_fetch.test"
+      ]
     }
   ]
 }

--- a/test/sql/storage/overflow_strings/blob_row_fetch.test
+++ b/test/sql/storage/overflow_strings/blob_row_fetch.test
@@ -1,0 +1,175 @@
+# name: test/sql/storage/overflow_strings/blob_row_fetch.test
+# description: Selective lookups on overflow string columns fetch only the selected rows
+# group: [overflow_strings]
+
+# Every string at or above the string block limit gets its own overflow buffer,
+# so scanning a whole vector to return a handful of rows materializes
+# STANDARD_VECTOR_SIZE buffers. The memory limit set below is far smaller than a
+# whole vector of blobs but much larger than the rows the queries return, so it
+# only holds if the compression specific Select writes just the selected rows -
+# including for vectors that span more than one column segment.
+
+require vector_size 2048
+
+statement ok
+ATTACH '{TEST_DIR}/blob_row_fetch.db' AS db (BLOCK_SIZE 16384);
+
+# the blobs below are highly compressible, so keep them uncompressed to get the
+# overflow buffers this test is about
+statement ok
+SET force_compression='uncompressed';
+
+statement ok
+CREATE TABLE db.t(id INTEGER, val BLOB);
+
+statement ok
+INSERT INTO db.t SELECT i, ('row' || i || repeat('Y', 50000))::BLOB FROM range(2500) tbl(i);
+
+# NULLs must not leak between vectors, and updates have to be visible. The blobs
+# are smaller here because the update path materializes a whole vector of its
+# own, which is beyond what the memory limit below allows.
+statement ok
+CREATE TABLE db.t2(id INTEGER, val BLOB);
+
+statement ok
+INSERT INTO db.t2 SELECT i, CASE WHEN i % 7 = 0 THEN NULL ELSE ('row' || i || repeat('Y', 5000))::BLOB END FROM range(2500) tbl(i);
+
+statement ok
+CHECKPOINT db;
+
+# the lookups below only stay within the memory limit while these hold: the
+# column is stored uncompressed, every value has an overflow buffer, and the rows
+# are spread over more than one segment so that a vector spans segments
+query I
+SELECT compression FROM pragma_storage_info('db.t') WHERE segment_type = 'BLOB' AND compression != 'Uncompressed';
+----
+
+query I
+SELECT bool_and(len(additional_block_ids) > 0) FROM pragma_storage_info('db.t') WHERE segment_type = 'BLOB';
+----
+true
+
+query I
+SELECT count(*) > 1 FROM pragma_storage_info('db.t') WHERE segment_type = 'BLOB';
+----
+true
+
+query I
+SELECT count(*) > 1 FROM pragma_storage_info('db.t2') WHERE segment_type = 'BLOB';
+----
+true
+
+# re-attach so the columns are loaded from the persisted data pointers - the
+# compression function of a column is only known once its segments are appended
+# through ColumnData, which checkpointing in the same session does not do
+statement ok
+DETACH db;
+
+statement ok
+ATTACH '{TEST_DIR}/blob_row_fetch.db' AS db (BLOCK_SIZE 16384);
+
+statement ok
+SET threads=1;
+
+# disable spilling so the memory limit actually bites
+statement ok
+PRAGMA temp_directory='';
+
+statement ok
+PRAGMA max_temp_directory_size='0B';
+
+# a vector of 2048 blobs needs over 100MB of overflow buffers and does not fit in
+# this limit, while the handful of rows the queries below return needs 50KB each
+statement ok
+SET memory_limit='90MB';
+
+# the first row of the first segment
+query I
+SELECT val = ('row0' || repeat('Y', 50000))::BLOB FROM db.t WHERE id = 0;
+----
+true
+
+# the rows on both sides of the first segment boundary
+query I
+SELECT val = ('row1022' || repeat('Y', 50000))::BLOB FROM db.t WHERE id = 1022;
+----
+true
+
+query I
+SELECT val = ('row1023' || repeat('Y', 50000))::BLOB FROM db.t WHERE id = 1023;
+----
+true
+
+# the rows on both sides of the first vector boundary
+query I
+SELECT val = ('row2047' || repeat('Y', 50000))::BLOB FROM db.t WHERE id = 2047;
+----
+true
+
+query I
+SELECT val = ('row2048' || repeat('Y', 50000))::BLOB FROM db.t WHERE id = 2048;
+----
+true
+
+# the last row of the last segment
+query I
+SELECT val = ('row2499' || repeat('Y', 50000))::BLOB FROM db.t WHERE id = 2499;
+----
+true
+
+# a range of rows straddling a segment boundary
+query II
+SELECT count(*), bool_and(val = ('row' || id || repeat('Y', 50000))::BLOB)
+FROM db.t WHERE id BETWEEN 1020 AND 1026;
+----
+7	true
+
+statement ok
+SET memory_limit='2GB';
+
+query I
+SELECT val IS NULL FROM db.t2 WHERE id = 1022;
+----
+true
+
+query I
+SELECT val = ('row1023' || repeat('Y', 5000))::BLOB FROM db.t2 WHERE id = 1023;
+----
+true
+
+# a range mixing NULL and non-NULL rows across a segment boundary
+query III
+SELECT count(*), count(val), bool_and(val IS NULL OR val = ('row' || id || repeat('Y', 5000))::BLOB)
+FROM db.t2 WHERE id BETWEEN 1015 AND 1030;
+----
+16	13	true
+
+statement ok
+UPDATE db.t2 SET val = ('upd' || id || repeat('Z', 5000))::BLOB WHERE id IN (1500, 1505);
+
+statement ok
+UPDATE db.t2 SET val = NULL WHERE id = 1501;
+
+query I
+SELECT val = ('upd1500' || repeat('Z', 5000))::BLOB FROM db.t2 WHERE id = 1500;
+----
+true
+
+query I
+SELECT val IS NULL FROM db.t2 WHERE id = 1501;
+----
+true
+
+query I
+SELECT val = ('row1502' || repeat('Y', 5000))::BLOB FROM db.t2 WHERE id = 1502;
+----
+true
+
+query II
+SELECT count(*), bool_and(CASE
+	WHEN id IN (1500, 1505) THEN val = ('upd' || id || repeat('Z', 5000))::BLOB
+	WHEN id = 1501 OR id % 7 = 0 THEN val IS NULL
+	ELSE val = ('row' || id || repeat('Y', 5000))::BLOB END)
+FROM db.t2 WHERE id BETWEEN 1495 AND 1510;
+----
+16	true


### PR DESCRIPTION
A vector that spans column segments cannot use the compression specific Select, so the generic path scans the entire vector and slices it. 
Every string at or above the string block limit gets its own overflow buffer, so a point lookup materializes STANDARD_VECTOR_SIZE buffers to return a single row, which can push the scan out of memory. 
At low selectivity fetch only the selected rows through the batched FetchRows API instead.