### PR TITLE
convert recursion to stack-based transversal of variant to parquet

### DIFF
--- a/extension/parquet/reader/variant/parquet_variant_iterator.cpp
+++ b/extension/parquet/reader/variant/parquet_variant_iterator.cpp
@@ -713,6 +713,7 @@ ScalarFunction ParquetVariantConversion::GetBytesToVariantFunction() {
 	ScalarFunction function("variant_bytes_to_variant", {LogicalType::BLOB}, LogicalType::VARIANT(),
 	                        VariantBytesToVariantFunction);
 	function.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
+	function.SetFallible();
 	return function;
 }
 

--- a/src/include/duckdb/common/types/variant/variant_builder.hpp
+++ b/src/include/duckdb/common/types/variant/variant_builder.hpp
@@ -101,6 +101,8 @@ struct VariantBuilder {
 	//! maps a key string to its (unsorted) dictionary index, owned by the result's keys vector
 	OrderedOwningStringMap<uint32_t> &dictionary;
 
+	static constexpr idx_t MAX_RECURSION_DEPTH = 16;
+
 	//! the offsets at which the current row's entries begin
 	idx_t row_values = 0;
 	idx_t row_children = 0;
@@ -154,7 +156,10 @@ struct VariantBuilder {
 
 	//! Emit an ARRAY value with 'n' elements. 'emit_fn(i)' must emit exactly one value for element i.
 	template <class EMIT_FN>
-	void EmitArray(idx_t n, EMIT_FN &&emit_fn) {
+	void EmitArray(idx_t n, EMIT_FN &&emit_fn, idx_t depth = 0) {
+		if (depth >= MAX_RECURSION_DEPTH) {
+			throw InvalidInputException("VARIANT nesting exceeds maximum of %d", MAX_RECURSION_DEPTH);
+		}
 		auto byte_offset = NumericCast<uint32_t>(blob.size());
 		type_ids.push_back(static_cast<uint8_t>(VariantLogicalType::ARRAY));
 		byte_offsets.push_back(byte_offset);
@@ -474,7 +479,10 @@ auto CollectObjectChildren(const NODE &it) {
 
 //! Traverse a VariantNode-like cursor 'it' (any type exposing the node concept) into the builder.
 template <class NODE>
-void EmitIterator(const NODE &it, VariantBuilder &builder) {
+void EmitIterator(const NODE &it, VariantBuilder &builder, idx_t depth = 0) {
+	if (depth >= VariantBuilder::MAX_RECURSION_DEPTH) {
+		throw InvalidInputException("VARIANT nesting exceeds maximum of %d", VariantBuilder::MAX_RECURSION_DEPTH);
+	}
 	if (it.IsNull() || it.IsMissing()) {
 		builder.EmitNull();
 		return;
@@ -486,12 +494,13 @@ void EmitIterator(const NODE &it, VariantBuilder &builder) {
 		auto children = CollectObjectChildren(it);
 		builder.EmitObject(
 		    children.size(), [&](idx_t i) { return children[i].key; },
-		    [&](idx_t i) { EmitIterator(children[i].value, builder); });
+		    [&](idx_t i) { EmitIterator(children[i].value, builder, depth + 1); });
 		break;
 	}
 	case VariantLogicalType::ARRAY: {
 		auto array = it.GetArrayChildren();
-		builder.EmitArray(array.size(), [&](idx_t i) { EmitIterator(array[i], builder); });
+		builder.EmitArray(
+		    array.size(), [&](idx_t i) { EmitIterator(array[i], builder, depth + 1); }, depth + 1);
 		break;
 	}
 	default:

--- a/src/include/duckdb/common/types/variant/variant_builder.hpp
+++ b/src/include/duckdb/common/types/variant/variant_builder.hpp
@@ -29,6 +29,7 @@
 #include "duckdb/common/owning_string_map.hpp"
 #include "duckdb/common/numeric_utils.hpp"
 #include "duckdb/common/limits.hpp"
+#include "reader/variant/parquet_variant_iterator.hpp"
 
 #include <type_traits>
 #include <cstring>
@@ -460,6 +461,47 @@ struct VariantBuilder {
 			throw InternalException("EmitPrimitiveNode: unhandled VariantLogicalType (%d)", static_cast<int>(type_id));
 		}
 	}
+
+	idx_t BeginObject(idx_t n) {
+		auto byte_offset = NumericCast<uint32_t>(blob.size());
+		type_ids.push_back(static_cast<uint8_t>(VariantLogicalType::OBJECT));
+		byte_offsets.push_back(byte_offset);
+		VariantBuilderAppendVarint(blob, NumericCast<uint32_t>(n));
+		if (!n) {
+			return DConstants::INVALID_INDEX;
+		}
+		VariantBuilderAppendVarint(blob, LocalChild());
+		auto block = child_value_ids.size();
+		child_value_ids.resize(block + n);
+		child_key_ids.resize(block + n);
+		return block;
+	}
+
+	idx_t BeginArray(idx_t n) {
+		auto byte_offset = NumericCast<uint32_t>(blob.size());
+		type_ids.push_back(static_cast<uint8_t>(VariantLogicalType::ARRAY));
+		byte_offsets.push_back(byte_offset);
+		VariantBuilderAppendVarint(blob, NumericCast<uint32_t>(n));
+		if (!n) {
+			return DConstants::INVALID_INDEX;
+		}
+		VariantBuilderAppendVarint(blob, LocalChild());
+		auto block = child_value_ids.size();
+		child_value_ids.resize(block + n);
+		child_key_ids.resize(block + n);
+		return block;
+	}
+
+	void AssignObjectChild(idx_t block, idx_t i, string_t key) {
+		child_value_ids[block + i] = LocalValue();
+		child_key_ids[block + i] = LocalKey();
+		key_slots.push_back(VariantBuilderGetOrCreateIndex(dictionary, key));
+	}
+
+	void AssignArrayChild(idx_t block, idx_t i) {
+		child_value_ids[block + i] = LocalValue();
+		child_key_ids[block + i] = VARIANT_INVALID_KEY;
+	}
 };
 
 //===--------------------------------------------------------------------===//
@@ -479,33 +521,80 @@ auto CollectObjectChildren(const NODE &it) {
 
 //! Traverse a VariantNode-like cursor 'it' (any type exposing the node concept) into the builder.
 template <class NODE>
-void EmitIterator(const NODE &it, VariantBuilder &builder, idx_t depth = 0) {
-	if (depth >= VariantBuilder::MAX_RECURSION_DEPTH) {
-		throw InvalidInputException("VARIANT nesting exceeds maximum of %d", VariantBuilder::MAX_RECURSION_DEPTH);
-	}
-	if (it.IsNull() || it.IsMissing()) {
-		builder.EmitNull();
-		return;
-	}
+void EmitIterator(const NODE &root, VariantBuilder &builder) {
+	using EntryT = typename decltype(CollectObjectChildren(root))::value_type;
+	using ArrayIterT = decltype(std::declval<NODE>().GetArrayChildren());
 
-	auto type_id = it.GetTypeId();
-	switch (type_id) {
-	case VariantLogicalType::OBJECT: {
-		auto children = CollectObjectChildren(it);
-		builder.EmitObject(
-		    children.size(), [&](idx_t i) { return children[i].key; },
-		    [&](idx_t i) { EmitIterator(children[i].value, builder, depth + 1); });
-		break;
-	}
-	case VariantLogicalType::ARRAY: {
-		auto array = it.GetArrayChildren();
-		builder.EmitArray(
-		    array.size(), [&](idx_t i) { EmitIterator(array[i], builder, depth + 1); }, depth + 1);
-		break;
-	}
-	default:
-		builder.EmitPrimitiveNode(it, type_id);
-		break;
+	struct Frame {
+		bool is_object = false;
+		idx_t index = 0;
+		idx_t block = 0;
+		vector<EntryT> object_children;
+		unique_ptr<ArrayIterT> array_children;
+	};
+
+	vector<Frame> stack;
+
+	auto ProcessNode = [&](const NODE &node) {
+		if (node.IsNull() || node.IsMissing()) {
+			builder.EmitNull();
+			return;
+		}
+		auto type_id = node.GetTypeId();
+		switch (type_id) {
+		case VariantLogicalType::OBJECT: {
+			auto children = CollectObjectChildren(node);
+			auto n = children.size();
+			auto block = builder.BeginObject(n);
+			if (block != DConstants::INVALID_INDEX) {
+				Frame frame;
+				frame.is_object = true;
+				frame.block = block;
+				frame.object_children = std::move(children);
+				stack.push_back(std::move(frame));
+			}
+			break;
+		}
+		case VariantLogicalType::ARRAY: {
+			auto array_iter = node.GetArrayChildren();
+			auto n = array_iter.size();
+			auto block = builder.BeginArray(n);
+			if (block != DConstants::INVALID_INDEX) {
+				Frame frame;
+				frame.is_object = false;
+				frame.block = block;
+				frame.array_children = unique_ptr<ArrayIterT>(new ArrayIterT(std::move(array_iter)));
+				stack.push_back(std::move(frame));
+			}
+			break;
+		}
+		default:
+			builder.EmitPrimitiveNode(node, type_id);
+			break;
+		}
+	};
+
+	ProcessNode(root);
+
+	while (!stack.empty()) {
+		auto &frame = stack.back();
+		idx_t count = frame.is_object ? frame.object_children.size() : frame.array_children->size();
+		if (frame.index >= count) {
+			stack.pop_back();
+			continue;
+		}
+		idx_t i = frame.index++;
+		if (frame.is_object) {
+			auto &entry = frame.object_children[i];
+			builder.AssignObjectChild(frame.block, i, entry.key);
+			ProcessNode(entry.value);
+		} else {
+			builder.AssignArrayChild(frame.block, i);
+			ProcessNode((*frame.array_children)[i]);
+		}
+		// frame may be invalidated by ProcessNode's push_back reallocating `stack` —
+		// nothing below this line touches frame, and the loop re-fetches stack.back()
+		// fresh on the next iteration.
 	}
 }
 

--- a/src/include/duckdb/common/types/variant/variant_builder.hpp
+++ b/src/include/duckdb/common/types/variant/variant_builder.hpp
@@ -29,7 +29,7 @@
 #include "duckdb/common/owning_string_map.hpp"
 #include "duckdb/common/numeric_utils.hpp"
 #include "duckdb/common/limits.hpp"
-#include "reader/variant/parquet_variant_iterator.hpp"
+//#include "duckdb/extension/parquet/include/reader/variant/parquet_variant_iterator.hpp"
 
 #include <type_traits>
 #include <cstring>

--- a/src/include/duckdb/common/types/variant/variant_builder.hpp
+++ b/src/include/duckdb/common/types/variant/variant_builder.hpp
@@ -29,7 +29,6 @@
 #include "duckdb/common/owning_string_map.hpp"
 #include "duckdb/common/numeric_utils.hpp"
 #include "duckdb/common/limits.hpp"
-//#include "duckdb/extension/parquet/include/reader/variant/parquet_variant_iterator.hpp"
 
 #include <type_traits>
 #include <cstring>
@@ -102,7 +101,7 @@ struct VariantBuilder {
 	//! maps a key string to its (unsorted) dictionary index, owned by the result's keys vector
 	OrderedOwningStringMap<uint32_t> &dictionary;
 
-	static constexpr idx_t MAX_RECURSION_DEPTH = 16;
+	static constexpr idx_t MAX_NESTING_DEPTH = 16;
 
 	//! the offsets at which the current row's entries begin
 	idx_t row_values = 0;
@@ -157,10 +156,7 @@ struct VariantBuilder {
 
 	//! Emit an ARRAY value with 'n' elements. 'emit_fn(i)' must emit exactly one value for element i.
 	template <class EMIT_FN>
-	void EmitArray(idx_t n, EMIT_FN &&emit_fn, idx_t depth = 0) {
-		if (depth >= MAX_RECURSION_DEPTH) {
-			throw InvalidInputException("VARIANT nesting exceeds maximum of %d", MAX_RECURSION_DEPTH);
-		}
+	void EmitArray(idx_t n, EMIT_FN &&emit_fn) {
 		auto byte_offset = NumericCast<uint32_t>(blob.size());
 		type_ids.push_back(static_cast<uint8_t>(VariantLogicalType::ARRAY));
 		byte_offsets.push_back(byte_offset);
@@ -462,24 +458,9 @@ struct VariantBuilder {
 		}
 	}
 
-	idx_t BeginObject(idx_t n) {
+	idx_t BeginContainer(VariantLogicalType type_id, idx_t n) {
 		auto byte_offset = NumericCast<uint32_t>(blob.size());
-		type_ids.push_back(static_cast<uint8_t>(VariantLogicalType::OBJECT));
-		byte_offsets.push_back(byte_offset);
-		VariantBuilderAppendVarint(blob, NumericCast<uint32_t>(n));
-		if (!n) {
-			return DConstants::INVALID_INDEX;
-		}
-		VariantBuilderAppendVarint(blob, LocalChild());
-		auto block = child_value_ids.size();
-		child_value_ids.resize(block + n);
-		child_key_ids.resize(block + n);
-		return block;
-	}
-
-	idx_t BeginArray(idx_t n) {
-		auto byte_offset = NumericCast<uint32_t>(blob.size());
-		type_ids.push_back(static_cast<uint8_t>(VariantLogicalType::ARRAY));
+		type_ids.push_back(static_cast<uint8_t>(type_id));
 		byte_offsets.push_back(byte_offset);
 		VariantBuilderAppendVarint(blob, NumericCast<uint32_t>(n));
 		if (!n) {
@@ -530,10 +511,11 @@ void EmitIterator(const NODE &root, VariantBuilder &builder) {
 		idx_t index = 0;
 		idx_t block = 0;
 		vector<EntryT> object_children;
-		unique_ptr<ArrayIterT> array_children;
+		optional<ArrayIterT> array_children;
 	};
 
 	vector<Frame> stack;
+	stack.reserve(VariantBuilder::MAX_NESTING_DEPTH);
 
 	auto ProcessNode = [&](const NODE &node) {
 		if (node.IsNull() || node.IsMissing()) {
@@ -545,7 +527,10 @@ void EmitIterator(const NODE &root, VariantBuilder &builder) {
 		case VariantLogicalType::OBJECT: {
 			auto children = CollectObjectChildren(node);
 			auto n = children.size();
-			auto block = builder.BeginObject(n);
+			if (stack.size() >= VariantBuilder::MAX_NESTING_DEPTH) {
+				throw InvalidInputException("VARIANT nesting exceeds maximum of %d", VariantBuilder::MAX_NESTING_DEPTH);
+			}
+			auto block = builder.BeginContainer(VariantLogicalType::OBJECT, n);
 			if (block != DConstants::INVALID_INDEX) {
 				Frame frame;
 				frame.is_object = true;
@@ -558,12 +543,15 @@ void EmitIterator(const NODE &root, VariantBuilder &builder) {
 		case VariantLogicalType::ARRAY: {
 			auto array_iter = node.GetArrayChildren();
 			auto n = array_iter.size();
-			auto block = builder.BeginArray(n);
+			if (stack.size() >= VariantBuilder::MAX_NESTING_DEPTH) {
+				throw InvalidInputException("VARIANT nesting exceeds maximum of %d", VariantBuilder::MAX_NESTING_DEPTH);
+			}
+			auto block = builder.BeginContainer(VariantLogicalType::ARRAY, n);
 			if (block != DConstants::INVALID_INDEX) {
 				Frame frame;
 				frame.is_object = false;
 				frame.block = block;
-				frame.array_children = unique_ptr<ArrayIterT>(new ArrayIterT(std::move(array_iter)));
+				frame.array_children.emplace(std::move(array_iter));
 				stack.push_back(std::move(frame));
 			}
 			break;
@@ -578,23 +566,26 @@ void EmitIterator(const NODE &root, VariantBuilder &builder) {
 
 	while (!stack.empty()) {
 		auto &frame = stack.back();
-		idx_t count = frame.is_object ? frame.object_children.size() : frame.array_children->size();
+
+		const idx_t count = frame.is_object ? frame.object_children.size() : frame.array_children->size();
+
 		if (frame.index >= count) {
 			stack.pop_back();
 			continue;
 		}
-		idx_t i = frame.index++;
-		if (frame.is_object) {
+
+		const bool is_object = frame.is_object;
+		const idx_t block = frame.block;
+		const idx_t i = frame.index++;
+
+		if (is_object) {
 			auto &entry = frame.object_children[i];
-			builder.AssignObjectChild(frame.block, i, entry.key);
+			builder.AssignObjectChild(block, i, entry.key);
 			ProcessNode(entry.value);
 		} else {
-			builder.AssignArrayChild(frame.block, i);
+			builder.AssignArrayChild(block, i);
 			ProcessNode((*frame.array_children)[i]);
 		}
-		// frame may be invalidated by ProcessNode's push_back reallocating `stack` —
-		// nothing below this line touches frame, and the loop re-fetches stack.back()
-		// fresh on the next iteration.
 	}
 }
 

--- a/test/sql/variant/variant_nested_arrays.test
+++ b/test/sql/variant/variant_nested_arrays.test
@@ -1,0 +1,30 @@
+# name: test/sql/variant/variant_nested_arrays.test
+# description: Test the nesting level limit (16) of variant arrays
+# group: [variant]
+
+require parquet
+
+
+# nested VARIANT with 16 levels (limit)
+query I
+SELECT variant_to_parquet_variant(
+    variant_bytes_to_variant(X'1100000301003d0301003903010035030100310301002d0301002903010025030100210301001d0301001903010015030100110301000d03010009030100050301000100')
+) IS NOT NULL
+----
+true
+
+# nested VARIANT with 17 levels (exceeding the maximum depth)
+statement error
+SELECT variant_to_parquet_variant(
+    variant_bytes_to_variant(X'110000030100410301003d0301003903010035030100310301002d0301002903010025030100210301001d0301001903010015030100110301000d03010009030100050301000100')
+)
+----
+VARIANT nesting exceeds maximum
+
+# nested VARIANT with 18 levels (exceeding the maximum depth)
+statement error
+SELECT variant_to_parquet_variant(
+    variant_bytes_to_variant(X'11000003010045030100410301003d0301003903010035030100310301002d0301002903010025030100210301001d0301001903010015030100110301000d03010009030100050301000100')
+)
+----
+VARIANT nesting exceeds maximum


### PR DESCRIPTION
Closes https://github.com/duckdblabs/duckdb-internal/issues/10306

Fix unbounded recursion when converting deeply nested VARIANT arrays and objects to Parquet.

`EmitIterator` previously used recursion to transverse nested VARIANT values. A deeply nested VARIANT could exhaust the native stack and cause a stack overflow.

### Changes

* Replace recursive traversal in `EmitIterator` with stack-based traversal.
* Track the current container and child index in each frame, allowing deeply nested values to be processed without growing the native call stack.
* Reserve the stack up front using the nesting limit to avoid reallocations during traversal.
* Add an initial VARIANT nesting depth of 8 and grow the stack as needed using `NextPowerOfTwo`.
* Collapse `BeginArray` and `BeginObject` into `BeginContainer`, which returns an optional_idx to make the empty-container case explicit.

### Testing

Added regression coverage for VARIANT arrays around the initial stack capacity.

* Verified 7 and 8 levels are successfully converted without requiring stack growth.
* Verified 9 levels are successfully converted, proving stack growth beyond the initial capacity.
* Reproduced the original deeply nested (~15,000 levels) input and confirmed it now returns a controlled `InvalidInputException` instead of causing a stack overflow/crash.