### PR TITLE
[Serialization][Parquet][Variant] Fix bug related to `ShreddingType` equality operator

### DIFF
--- a/extension/parquet/parquet_shredding.cpp
+++ b/extension/parquet/parquet_shredding.cpp
@@ -31,10 +31,7 @@ bool ShreddingType::operator==(const ShreddingType &other) const {
 	if (set != other.set) {
 		return false;
 	}
-	if (!set) {
-		return true;
-	}
-	if (type != other.type) {
+	if (set && type != other.type) {
 		return false;
 	}
 	if (!children.types && !other.children.types) {

--- a/test/parquet/variant/variant_shredding_serialize.test
+++ b/test/parquet/variant/variant_shredding_serialize.test
@@ -1,0 +1,51 @@
+# name: test/parquet/variant/variant_shredding_serialize.test
+# description: Test serializing the Parquet SHREDDING option
+# group: [variant]
+
+require parquet
+
+foreach serialize_enabled true false
+
+statement ok
+SET debug_verify_serializer = {serialize_enabled}
+
+statement ok
+COPY (
+	SELECT {'a': 42::INTEGER}::VARIANT AS v
+) TO '{TEST_DIR}/variant_shredding_serialize.parquet' (
+	SHREDDING {v: 'STRUCT(a INTEGER, b VARCHAR)'}
+)
+
+query I
+SELECT name
+FROM parquet_schema('{TEST_DIR}/variant_shredding_serialize.parquet')
+WHERE name IN ('a', 'b')
+ORDER BY column_id
+----
+a
+b
+
+query I
+SELECT v
+FROM read_parquet('{TEST_DIR}/variant_shredding_serialize.parquet')
+----
+{'a': 42}
+
+statement ok
+COPY (
+	SELECT {'a': 1::INTEGER, 'b': {'x': 2}::VARIANT}::VARIANT AS v
+) TO '{TEST_DIR}/variant_nested_shredding_serialize.parquet' (
+	SHREDDING {v: 'STRUCT(a INTEGER, b VARIANT)'}
+);
+
+query I
+SELECT name
+FROM parquet_schema('{TEST_DIR}/variant_nested_shredding_serialize.parquet')
+WHERE name IN ('a', 'b')
+ORDER BY column_id;
+----
+a
+b
+
+# serialize_enabled
+endloop


### PR DESCRIPTION
Found in https://github.com/duckdb/duckdb/pull/24136

It was previously not found because many variant tests skip the "verify serialization" test config, due to them testing stat-related behavior, which isn't consistent through serialization.