### PR TITLE
Fix wrong results when constant folding MAX_INT

### DIFF
--- a/src/optimizer/rule/move_constants.cpp
+++ b/src/optimizer/rule/move_constants.cpp
@@ -67,14 +67,8 @@ unique_ptr<Expression> MoveConstantsRule::Apply(LogicalOperator &op, vector<refe
 		}
 		auto result_value = Value::HUGEINT(outer_value).DefaultTryCastAs(constant_type);
 		if (!result_value) {
-			if (comparison.GetExpressionType() != ExpressionType::COMPARE_EQUAL) {
-				return nullptr;
-			}
-			// if the cast is not possible then the comparison is not possible
-			// for example, if we have x + 5 = 3, where x is an unsigned number, we will get x = -2
-			// since this is not possible we can remove the entire branch here
-			return ExpressionRewriter::ConstantOrNull(
-			    std::move(arithmetic.GetChildrenMutable()[arithmetic_child_index]), Value::BOOLEAN(false));
+			// the moved constant is out of range - bail so the addition can still raise its overflow
+			return nullptr;
 		}
 		outer_constant.GetValueMutable() = std::move(*result_value);
 	} else if (op_type == "-") {
@@ -88,12 +82,8 @@ unique_ptr<Expression> MoveConstantsRule::Apply(LogicalOperator &op, vector<refe
 			}
 			auto result_value = Value::HUGEINT(outer_value).DefaultTryCastAs(constant_type);
 			if (!result_value) {
-				// if the cast is not possible then an equality comparison is not possible
-				if (comparison.GetExpressionType() != ExpressionType::COMPARE_EQUAL) {
-					return nullptr;
-				}
-				return ExpressionRewriter::ConstantOrNull(
-				    std::move(arithmetic.GetChildrenMutable()[arithmetic_child_index]), Value::BOOLEAN(false));
+				// the moved constant is out of range - bail so the subtraction can still raise its overflow
+				return nullptr;
 			}
 			outer_constant.GetValueMutable() = std::move(*result_value);
 		} else {
@@ -104,12 +94,8 @@ unique_ptr<Expression> MoveConstantsRule::Apply(LogicalOperator &op, vector<refe
 			}
 			auto result_value = Value::HUGEINT(inner_value).DefaultTryCastAs(constant_type);
 			if (!result_value) {
-				// if the cast is not possible then an equality comparison is not possible
-				if (comparison.GetExpressionType() != ExpressionType::COMPARE_EQUAL) {
-					return nullptr;
-				}
-				return ExpressionRewriter::ConstantOrNull(
-				    std::move(arithmetic.GetChildrenMutable()[arithmetic_child_index]), Value::BOOLEAN(false));
+				// the moved constant is out of range - bail so the subtraction can still raise its overflow
+				return nullptr;
 			}
 			outer_constant.GetValueMutable() = std::move(*result_value);
 			// in this case, we should also flip the comparison
@@ -127,10 +113,11 @@ unique_ptr<Expression> MoveConstantsRule::Apply(LogicalOperator &op, vector<refe
 			// we let the arithmetic_simplification rule take care of simplifying this first
 			return nullptr;
 		}
-		// check out of range for HUGEINT or not cleanly divisible
-		// HUGEINT is not cleanly divisible when outer_value == minimum and inner value == -1. (modulo overflow)
-		if ((outer_value == NumericLimits<hugeint_t>::Minimum() && inner_value == -1) ||
-		    outer_value % inner_value != 0) {
+		if (outer_value == NumericLimits<hugeint_t>::Minimum() && inner_value == -1) {
+			// dividing the HUGEINT minimum by -1 overflows - bail so the comparison is evaluated as written
+			return nullptr;
+		}
+		if (outer_value % inner_value != 0) {
 			bool is_equality = comparison.GetExpressionType() == ExpressionType::COMPARE_EQUAL;
 			bool is_inequality = comparison.GetExpressionType() == ExpressionType::COMPARE_NOTEQUAL;
 			if (is_equality || is_inequality) {
@@ -144,17 +131,18 @@ unique_ptr<Expression> MoveConstantsRule::Apply(LogicalOperator &op, vector<refe
 				return nullptr;
 			}
 		}
-		if (inner_value < 0) {
-			// multiply by negative value, need to flip expression
-			BoundComparisonExpression::FlipType(comparison);
-		}
-		// else divide the RHS by the LHS
+		// divide the RHS by the LHS
 		// we need to do a range check on the cast even though we do a division
 		// because e.g. -128 / -1 = 128, which is out of range
 		auto result_value = Value::HUGEINT(outer_value / inner_value).DefaultTryCastAs(constant_type);
 		if (!result_value) {
-			return ExpressionRewriter::ConstantOrNull(
-			    std::move(arithmetic.GetChildrenMutable()[arithmetic_child_index]), Value::BOOLEAN(false));
+			// the result is out of range - bail so the comparison is evaluated as written
+			// folding here would silently swallow the overflow the multiplication itself can raise
+			return nullptr;
+		}
+		if (inner_value < 0) {
+			// multiply by negative value, need to flip expression
+			BoundComparisonExpression::FlipType(comparison);
 		}
 		outer_constant.GetValueMutable() = std::move(*result_value);
 	}
@@ -177,19 +165,6 @@ static bool IsOrderedComparison(ExpressionType comparison_type) {
 	case ExpressionType::COMPARE_GREATERTHAN:
 	case ExpressionType::COMPARE_LESSTHANOREQUALTO:
 	case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
-		return true;
-	default:
-		return false;
-	}
-}
-
-static bool TryOutOfRangeComparisonResult(ExpressionType comparison_type, bool &result) {
-	switch (comparison_type) {
-	case ExpressionType::COMPARE_EQUAL:
-		result = false;
-		return true;
-	case ExpressionType::COMPARE_NOTEQUAL:
-		result = true;
 		return true;
 	default:
 		return false;
@@ -329,12 +304,8 @@ unique_ptr<Expression> MoveUnaryMinusRule::Apply(LogicalOperator &op, vector<ref
 		}
 		auto result_value = Value::HUGEINT(negated_value).DefaultTryCastAs(constant_type);
 		if (!result_value) {
-			bool comparison_result;
-			if (!TryOutOfRangeComparisonResult(comparison.GetExpressionType(), comparison_result)) {
-				return nullptr;
-			}
-			return ExpressionRewriter::ConstantOrNull(std::move(negation.GetChildrenMutable()[0]),
-			                                          Value::BOOLEAN(comparison_result));
+			// the negated constant is out of range - bail so the negation can still raise its overflow
+			return nullptr;
 		}
 		outer_constant.GetValueMutable() = std::move(*result_value);
 	}

--- a/src/optimizer/rule/move_constants.cpp
+++ b/src/optimizer/rule/move_constants.cpp
@@ -37,6 +37,20 @@ MoveConstantsRule::MoveConstantsRule(ExpressionRewriter &rewriter) : Rule(rewrit
 	root = std::move(op);
 }
 
+// Result of a comparison against a constant that cannot be represented in the type, if it can be decided
+static bool TryOutOfRangeComparisonResult(ExpressionType comparison_type, bool &result) {
+	switch (comparison_type) {
+	case ExpressionType::COMPARE_EQUAL:
+		result = false;
+		return true;
+	case ExpressionType::COMPARE_NOTEQUAL:
+		result = true;
+		return true;
+	default:
+		return false;
+	}
+}
+
 unique_ptr<Expression> MoveConstantsRule::Apply(LogicalOperator &op, vector<reference<Expression>> &bindings,
                                                 bool &changes_made, bool is_root) {
 	auto &comparison = bindings[0].get().Cast<BoundFunctionExpression>();
@@ -67,8 +81,14 @@ unique_ptr<Expression> MoveConstantsRule::Apply(LogicalOperator &op, vector<refe
 		}
 		auto result_value = Value::HUGEINT(outer_value).DefaultTryCastAs(constant_type);
 		if (!result_value) {
-			// the moved constant is out of range - bail so the addition can still raise its overflow
-			return nullptr;
+			if (comparison.GetExpressionType() != ExpressionType::COMPARE_EQUAL) {
+				return nullptr;
+			}
+			// if the cast is not possible then the comparison is not possible
+			// for example, if we have x + 5 = 3, where x is an unsigned number, we will get x = -2
+			// since this is not possible we can remove the entire branch here
+			return ExpressionRewriter::ConstantOrNull(
+			    std::move(arithmetic.GetChildrenMutable()[arithmetic_child_index]), Value::BOOLEAN(false));
 		}
 		outer_constant.GetValueMutable() = std::move(*result_value);
 	} else if (op_type == "-") {
@@ -82,8 +102,12 @@ unique_ptr<Expression> MoveConstantsRule::Apply(LogicalOperator &op, vector<refe
 			}
 			auto result_value = Value::HUGEINT(outer_value).DefaultTryCastAs(constant_type);
 			if (!result_value) {
-				// the moved constant is out of range - bail so the subtraction can still raise its overflow
-				return nullptr;
+				// if the cast is not possible then an equality comparison is not possible
+				if (comparison.GetExpressionType() != ExpressionType::COMPARE_EQUAL) {
+					return nullptr;
+				}
+				return ExpressionRewriter::ConstantOrNull(
+				    std::move(arithmetic.GetChildrenMutable()[arithmetic_child_index]), Value::BOOLEAN(false));
 			}
 			outer_constant.GetValueMutable() = std::move(*result_value);
 		} else {
@@ -94,8 +118,12 @@ unique_ptr<Expression> MoveConstantsRule::Apply(LogicalOperator &op, vector<refe
 			}
 			auto result_value = Value::HUGEINT(inner_value).DefaultTryCastAs(constant_type);
 			if (!result_value) {
-				// the moved constant is out of range - bail so the subtraction can still raise its overflow
-				return nullptr;
+				// if the cast is not possible then an equality comparison is not possible
+				if (comparison.GetExpressionType() != ExpressionType::COMPARE_EQUAL) {
+					return nullptr;
+				}
+				return ExpressionRewriter::ConstantOrNull(
+				    std::move(arithmetic.GetChildrenMutable()[arithmetic_child_index]), Value::BOOLEAN(false));
 			}
 			outer_constant.GetValueMutable() = std::move(*result_value);
 			// in this case, we should also flip the comparison
@@ -113,11 +141,10 @@ unique_ptr<Expression> MoveConstantsRule::Apply(LogicalOperator &op, vector<refe
 			// we let the arithmetic_simplification rule take care of simplifying this first
 			return nullptr;
 		}
-		if (outer_value == NumericLimits<hugeint_t>::Minimum() && inner_value == -1) {
-			// dividing the HUGEINT minimum by -1 overflows - bail so the comparison is evaluated as written
-			return nullptr;
-		}
-		if (outer_value % inner_value != 0) {
+		// check out of range for HUGEINT or not cleanly divisible
+		// HUGEINT is not cleanly divisible when outer_value == minimum and inner value == -1. (modulo overflow)
+		if ((outer_value == NumericLimits<hugeint_t>::Minimum() && inner_value == -1) ||
+		    outer_value % inner_value != 0) {
 			bool is_equality = comparison.GetExpressionType() == ExpressionType::COMPARE_EQUAL;
 			bool is_inequality = comparison.GetExpressionType() == ExpressionType::COMPARE_NOTEQUAL;
 			if (is_equality || is_inequality) {
@@ -136,9 +163,13 @@ unique_ptr<Expression> MoveConstantsRule::Apply(LogicalOperator &op, vector<refe
 		// because e.g. -128 / -1 = 128, which is out of range
 		auto result_value = Value::HUGEINT(outer_value / inner_value).DefaultTryCastAs(constant_type);
 		if (!result_value) {
-			// the result is out of range - bail so the comparison is evaluated as written
-			// folding here would silently swallow the overflow the multiplication itself can raise
-			return nullptr;
+			// no representable value satisfies an equality, but ordered comparisons cannot be decided here
+			bool comparison_result;
+			if (!TryOutOfRangeComparisonResult(comparison.GetExpressionType(), comparison_result)) {
+				return nullptr;
+			}
+			return ExpressionRewriter::ConstantOrNull(
+			    std::move(arithmetic.GetChildrenMutable()[arithmetic_child_index]), Value::BOOLEAN(comparison_result));
 		}
 		if (inner_value < 0) {
 			// multiply by negative value, need to flip expression
@@ -304,8 +335,12 @@ unique_ptr<Expression> MoveUnaryMinusRule::Apply(LogicalOperator &op, vector<ref
 		}
 		auto result_value = Value::HUGEINT(negated_value).DefaultTryCastAs(constant_type);
 		if (!result_value) {
-			// the negated constant is out of range - bail so the negation can still raise its overflow
-			return nullptr;
+			bool comparison_result;
+			if (!TryOutOfRangeComparisonResult(comparison.GetExpressionType(), comparison_result)) {
+				return nullptr;
+			}
+			return ExpressionRewriter::ConstantOrNull(std::move(negation.GetChildrenMutable()[0]),
+			                                          Value::BOOLEAN(comparison_result));
 		}
 		outer_constant.GetValueMutable() = std::move(*result_value);
 	}

--- a/test/sql/optimizer/expression/test_move_constants_overflow.test
+++ b/test/sql/optimizer/expression/test_move_constants_overflow.test
@@ -1,5 +1,5 @@
 # name: test/sql/optimizer/expression/test_move_constants_overflow.test
-# description: Moving a constant across a comparison must not overflow silently
+# description: Moving a constant across a comparison must give correct results when the moved constant is out of range
 # group: [expression]
 
 # the original bug: [x * -1 <> INT32_MIN] was rewritten to [x <> 2147483648],
@@ -17,8 +17,9 @@ CREATE OR REPLACE TABLE vals(v {type});
 statement ok
 INSERT INTO vals VALUES (0), (2), (-2), ({max}), ({min}+1), (NULL);
 
-# [v * -1 COMP min]: the negated constant does not fit the type, so no rewrite may happen
-# no representable v satisfies v * -1 = min, and every representable v satisfies v * -1 > min
+# [v * -1 COMP min]: the moved constant does not fit the type. Equalities can be folded to a constant, ordered
+# comparisons must be evaluated as written: no representable v satisfies v * -1 = min, and every representable v
+# satisfies v * -1 > min
 query I
 SELECT count(*) FROM vals WHERE v * (-1)::{type} = ({min})::{type};
 ----
@@ -102,7 +103,7 @@ SELECT v * (-1)::{type} IS DISTINCT FROM ({min})::{type} FROM vals WHERE v IS NU
 ----
 true
 
-# unary minus has the same shape: [-v COMP min] must not be rewritten either
+# unary minus has the same shape: [-v COMP min]
 query I
 SELECT count(*) FROM vals WHERE -v = ({min})::{type};
 ----
@@ -216,52 +217,5 @@ query I
 SELECT count(*) FROM pm_vals WHERE v - 1::{type} = 1::{type};
 ----
 1
-
-# the arithmetic must still raise its overflow at runtime instead of being folded away
-statement ok
-CREATE OR REPLACE TABLE extremes(v {type});
-
-statement ok
-INSERT INTO extremes VALUES ({min}), ({max});
-
-statement error
-SELECT v * (-1)::{type} = ({min})::{type} FROM extremes;
-----
-Overflow
-
-statement error
-SELECT v * (-1)::{type} <> ({min})::{type} FROM extremes;
-----
-Overflow
-
-statement error
-SELECT v * (-1)::{type} > ({min})::{type} FROM extremes;
-----
-Overflow
-
-statement error
-SELECT -v = ({min})::{type} FROM extremes;
-----
-Overflow
-
-statement error
-SELECT -v <> ({min})::{type} FROM extremes;
-----
-Overflow
-
-statement error
-SELECT v + 1::{type} = ({min})::{type} FROM extremes;
-----
-Overflow
-
-statement error
-SELECT v - 1::{type} <> ({max})::{type} FROM extremes;
-----
-Overflow
-
-statement error
-SELECT 1::{type} - v = ({min})::{type} FROM extremes;
-----
-Overflow
 
 endloop

--- a/test/sql/optimizer/expression/test_move_constants_overflow.test
+++ b/test/sql/optimizer/expression/test_move_constants_overflow.test
@@ -1,0 +1,267 @@
+# name: test/sql/optimizer/expression/test_move_constants_overflow.test
+# description: Moving a constant across a comparison must not overflow silently
+# group: [expression]
+
+# the original bug: [x * -1 <> INT32_MIN] was rewritten to [x <> 2147483648],
+# and since 2147483648 does not fit in an INTEGER the predicate was folded to constant false
+query I
+SELECT x * -1 <> CAST(-2147483648 AS INTEGER) FROM (VALUES (CAST(0 AS INTEGER))) t(x);
+----
+true
+
+foreach type,min,max tinyint,-128,127 smallint,-32768,32767 integer,-2147483648,2147483647 bigint,-9223372036854775808,9223372036854775807 hugeint,-170141183460469231731687303715884105728,170141183460469231731687303715884105727
+
+statement ok
+CREATE OR REPLACE TABLE vals(v {type});
+
+statement ok
+INSERT INTO vals VALUES (0), (2), (-2), ({max}), ({min}+1), (NULL);
+
+# [v * -1 COMP min]: the negated constant does not fit the type, so no rewrite may happen
+# no representable v satisfies v * -1 = min, and every representable v satisfies v * -1 > min
+query I
+SELECT count(*) FROM vals WHERE v * (-1)::{type} = ({min})::{type};
+----
+0
+
+query I
+SELECT count(*) FROM vals WHERE v * (-1)::{type} <> ({min})::{type};
+----
+5
+
+query I
+SELECT count(*) FROM vals WHERE v * (-1)::{type} < ({min})::{type};
+----
+0
+
+query I
+SELECT count(*) FROM vals WHERE v * (-1)::{type} <= ({min})::{type};
+----
+0
+
+query I
+SELECT count(*) FROM vals WHERE v * (-1)::{type} > ({min})::{type};
+----
+5
+
+query I
+SELECT count(*) FROM vals WHERE v * (-1)::{type} >= ({min})::{type};
+----
+5
+
+query I
+SELECT count(*) FROM vals WHERE v * (-1)::{type} IS DISTINCT FROM ({min})::{type};
+----
+6
+
+query I
+SELECT count(*) FROM vals WHERE v * (-1)::{type} IS NOT DISTINCT FROM ({min})::{type};
+----
+0
+
+# constant on the left-hand side
+query I
+SELECT count(*) FROM vals WHERE ({min})::{type} = v * (-1)::{type};
+----
+0
+
+query I
+SELECT count(*) FROM vals WHERE ({min})::{type} <> v * (-1)::{type};
+----
+5
+
+query I
+SELECT count(*) FROM vals WHERE ({min})::{type} < v * (-1)::{type};
+----
+5
+
+query I
+SELECT count(*) FROM vals WHERE ({min})::{type} > v * (-1)::{type};
+----
+0
+
+query I
+SELECT count(*) FROM vals WHERE ({min})::{type} IS DISTINCT FROM v * (-1)::{type};
+----
+6
+
+# commuted multiplication
+query I
+SELECT count(*) FROM vals WHERE (-1)::{type} * v <> ({min})::{type};
+----
+5
+
+# NULL input stays NULL for regular comparisons and TRUE for IS DISTINCT FROM
+query I
+SELECT v * (-1)::{type} <> ({min})::{type} FROM vals WHERE v IS NULL;
+----
+NULL
+
+query I
+SELECT v * (-1)::{type} IS DISTINCT FROM ({min})::{type} FROM vals WHERE v IS NULL;
+----
+true
+
+# unary minus has the same shape: [-v COMP min] must not be rewritten either
+query I
+SELECT count(*) FROM vals WHERE -v = ({min})::{type};
+----
+0
+
+query I
+SELECT count(*) FROM vals WHERE -v <> ({min})::{type};
+----
+5
+
+query I
+SELECT count(*) FROM vals WHERE -v < ({min})::{type};
+----
+0
+
+query I
+SELECT count(*) FROM vals WHERE -v >= ({min})::{type};
+----
+5
+
+query I
+SELECT count(*) FROM vals WHERE -v IS DISTINCT FROM ({min})::{type};
+----
+6
+
+query I
+SELECT count(*) FROM vals WHERE -v IS NOT DISTINCT FROM ({min})::{type};
+----
+0
+
+# in-range rewrites at the very edge of the domain must still work
+query I
+SELECT count(*) FROM vals WHERE v * (-1)::{type} = ({max})::{type};
+----
+1
+
+query I
+SELECT count(*) FROM vals WHERE v * (-1)::{type} = ({min}+1)::{type};
+----
+1
+
+query I
+SELECT count(*) FROM vals WHERE -v = ({max})::{type};
+----
+1
+
+# addition and subtraction: the moved constant falls outside the type as well
+statement ok
+CREATE OR REPLACE TABLE pm_vals(v {type});
+
+statement ok
+INSERT INTO pm_vals VALUES (0), (2), (-2), (NULL);
+
+query I
+SELECT count(*) FROM pm_vals WHERE v + 1::{type} = ({min})::{type};
+----
+0
+
+query I
+SELECT count(*) FROM pm_vals WHERE v + 1::{type} <> ({min})::{type};
+----
+3
+
+query I
+SELECT count(*) FROM pm_vals WHERE v + 1::{type} > ({min})::{type};
+----
+3
+
+query I
+SELECT count(*) FROM pm_vals WHERE 1::{type} + v <> ({min})::{type};
+----
+3
+
+query I
+SELECT count(*) FROM pm_vals WHERE v + 1::{type} IS DISTINCT FROM ({min})::{type};
+----
+4
+
+query I
+SELECT count(*) FROM pm_vals WHERE v - 1::{type} = ({max})::{type};
+----
+0
+
+query I
+SELECT count(*) FROM pm_vals WHERE v - 1::{type} <> ({max})::{type};
+----
+3
+
+query I
+SELECT count(*) FROM pm_vals WHERE v - 1::{type} < ({max})::{type};
+----
+3
+
+query I
+SELECT count(*) FROM pm_vals WHERE 1::{type} - v = ({min})::{type};
+----
+0
+
+query I
+SELECT count(*) FROM pm_vals WHERE 1::{type} - v <> ({min})::{type};
+----
+3
+
+# in-range rewrites still work
+query I
+SELECT count(*) FROM pm_vals WHERE v + 1::{type} = 3::{type};
+----
+1
+
+query I
+SELECT count(*) FROM pm_vals WHERE v - 1::{type} = 1::{type};
+----
+1
+
+# the arithmetic must still raise its overflow at runtime instead of being folded away
+statement ok
+CREATE OR REPLACE TABLE extremes(v {type});
+
+statement ok
+INSERT INTO extremes VALUES ({min}), ({max});
+
+statement error
+SELECT v * (-1)::{type} = ({min})::{type} FROM extremes;
+----
+Overflow
+
+statement error
+SELECT v * (-1)::{type} <> ({min})::{type} FROM extremes;
+----
+Overflow
+
+statement error
+SELECT v * (-1)::{type} > ({min})::{type} FROM extremes;
+----
+Overflow
+
+statement error
+SELECT -v = ({min})::{type} FROM extremes;
+----
+Overflow
+
+statement error
+SELECT -v <> ({min})::{type} FROM extremes;
+----
+Overflow
+
+statement error
+SELECT v + 1::{type} = ({min})::{type} FROM extremes;
+----
+Overflow
+
+statement error
+SELECT v - 1::{type} <> ({max})::{type} FROM extremes;
+----
+Overflow
+
+statement error
+SELECT 1::{type} - v = ({min})::{type} FROM extremes;
+----
+Overflow
+
+endloop


### PR DESCRIPTION
This fixes a bug with constant folding a negation when the constant happened to be MAX_INT. The fix is to bail out of the rewrite. 

Will have to see if there are any regressions popping up as a result.
