### PR TITLE
Prune row groups for length()/char_length() filters via code-point lower bound

### DIFF
--- a/src/function/scalar/string/length.cpp
+++ b/src/function/scalar/string/length.cpp
@@ -61,6 +61,7 @@ struct BitStringLenOperator {
 	}
 };
 
+template <bool COUNTS_CODEPOINTS>
 unique_ptr<BaseStatistics> LengthPropagateStats(ClientContext &context, FunctionStatisticsInput &input) {
 	auto &child_stats = input.child_stats;
 	auto &expr = input.expr;
@@ -82,8 +83,13 @@ unique_ptr<BaseStatistics> LengthPropagateStats(ClientContext &context, Function
 			// ASCII-only: the character count is exactly the byte count
 			min_length = NumericCast<int64_t>(min_string_length.GetIndex());
 		} else if (min_string_length.GetIndex() > 0) {
-			// non-empty strings contain at least one character
-			min_length = 1;
+			if (COUNTS_CODEPOINTS) {
+				// every codepoint takes at most four bytes
+				min_length = NumericCast<int64_t>((min_string_length.GetIndex() + 3) / 4);
+			} else {
+				// a grapheme cluster can span arbitrarily many codepoints - no better bound exists
+				min_length = 1;
+			}
 		}
 	}
 	auto result = NumericStats::CreateEmpty(expr.GetReturnType());
@@ -265,7 +271,7 @@ ScalarFunctionSet LengthFun::GetFunctions() {
 	ScalarFunctionSet length("length");
 	length.AddFunction(ScalarFunction({LogicalType::VARCHAR}, LogicalType::BIGINT,
 	                                  ScalarFunction::UnaryFunction<string_t, int64_t, StringLengthOperator>, nullptr,
-	                                  LengthPropagateStats));
+	                                  LengthPropagateStats<true>));
 	length.AddFunction(ScalarFunction({LogicalType::BIT}, LogicalType::BIGINT,
 	                                  ScalarFunction::UnaryFunction<string_t, int64_t, BitStringLenOperator>));
 	length.AddFunction(
@@ -277,7 +283,7 @@ ScalarFunctionSet LengthGraphemeFun::GetFunctions() {
 	ScalarFunctionSet length_grapheme("length_grapheme");
 	length_grapheme.AddFunction(ScalarFunction({LogicalType::VARCHAR}, LogicalType::BIGINT,
 	                                           ScalarFunction::UnaryFunction<string_t, int64_t, GraphemeCountOperator>,
-	                                           nullptr, LengthPropagateStats));
+	                                           nullptr, LengthPropagateStats<false>));
 	return (length_grapheme);
 }
 

--- a/test/optimizer/statistics/statistics_string_length.test
+++ b/test/optimizer/statistics/statistics_string_length.test
@@ -28,3 +28,112 @@ query II
 EXPLAIN ANALYZE SELECT sum(strlen(v)) FROM varying_string_lengths WHERE strlen(v) < 10;
 ----
 analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 2.*
+
+# unicode partitions: every codepoint takes at most four bytes, so a partition whose shortest
+# string has 40 bytes cannot contain anything shorter than ceil(40 / 4) = 10 characters
+statement ok
+CREATE TABLE unicode_min_lengths AS
+SELECT CASE WHEN i < 122880 THEN 'é' || repeat('a', i % 10 + 4) ELSE repeat('é', 20) END AS v
+FROM range(245760) tbl(i);
+
+query II
+EXPLAIN ANALYZE SELECT sum(length(v)) FROM unicode_min_lengths WHERE length(v) < 10;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 2.*
+
+# group A holds characters 5..14, half of which match - group B holds exactly 20 characters
+query I
+SELECT sum(length(v)) FROM unicode_min_lengths WHERE length(v) < 10;
+----
+430080
+
+# rounding boundary: 41 bytes imply at least ceil(41 / 4) = 11 characters, so group A is
+# dropped while the three-character strings of group B still have to be read
+statement ok
+CREATE TABLE odd_byte_lengths AS
+SELECT CASE WHEN i < 122880 THEN repeat('é', 20) || 'a' ELSE 'ééé' END AS v
+FROM range(245760) tbl(i);
+
+query II
+EXPLAIN ANALYZE SELECT sum(length(v)) FROM odd_byte_lengths WHERE length(v) < 11;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 2.*
+
+query I
+SELECT sum(length(v)) FROM odd_byte_lengths WHERE length(v) < 11;
+----
+368640
+
+# grapheme clusters can span arbitrarily many codepoints - each row below is a single cluster
+# of 37 bytes and 19 codepoints, so the strengthened byte-derived bound must stay exclusive
+# to length() and must never apply to length_grapheme()
+statement ok
+CREATE TABLE grapheme_clusters AS
+SELECT 'e' || repeat(chr(771), 18) AS v
+FROM range(245760) tbl(i);
+
+query II
+EXPLAIN ANALYZE SELECT sum(length_grapheme(v)) FROM grapheme_clusters WHERE length_grapheme(v) < 10;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 2 / 2.*
+
+query I
+SELECT sum(length_grapheme(v)) FROM grapheme_clusters WHERE length_grapheme(v) < 10;
+----
+245760
+
+# codepoint counting on the same data: every row has exactly 19 codepoints, nothing matches
+query II
+EXPLAIN ANALYZE SELECT sum(length(v)) FROM grapheme_clusters WHERE length(v) < 10;
+----
+analyzed_plan	<REGEX>:.*Empty Result.*
+
+query I
+SELECT sum(length(v)) FROM grapheme_clusters WHERE length(v) < 10;
+----
+NULL
+
+# empty strings make the minimum byte length zero - the bound degrades to zero and the
+# partition must still be read
+statement ok
+CREATE TABLE empty_strings AS
+SELECT CASE WHEN i < 122880 THEN '' ELSE repeat('é', 20) END AS v
+FROM range(245760) tbl(i);
+
+query II
+EXPLAIN ANALYZE SELECT sum(length(v)) FROM empty_strings WHERE length(v) < 10;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 2.*
+
+query I
+SELECT sum(length(v)) FROM empty_strings WHERE length(v) < 10;
+----
+0
+
+# NULL never satisfies a comparison - once every non-NULL value of a partition fails the
+# predicate, the partition can be dropped regardless of how many NULLs it holds
+statement ok
+CREATE TABLE null_mix AS
+SELECT CASE WHEN i % 2 = 0 THEN NULL::VARCHAR ELSE repeat('é', 20) END AS v
+FROM range(245760) tbl(i);
+
+query II
+EXPLAIN ANALYZE SELECT sum(length(v)) FROM null_mix WHERE length(v) < 10;
+----
+analyzed_plan	<REGEX>:.*Empty Result.*
+
+query I
+SELECT sum(length(v)) FROM null_mix WHERE length(v) < 10;
+----
+NULL
+
+# an entirely NULL partition satisfies no comparison either
+statement ok
+CREATE TABLE null_only AS
+SELECT CASE WHEN i < 122880 THEN NULL::VARCHAR ELSE 'x' END AS v
+FROM range(245760) tbl(i);
+
+query I
+SELECT count(*) FROM null_only WHERE length(v) > 5;
+----
+0


### PR DESCRIPTION
close https://github.com/duckdb/duckdb/issues/25001

Hi team!

This extends #23873 to code-point functions: filters like `WHERE length(v) < K` can now prune row groups containing unicode strings.

Every code point takes at most four UTF-8 bytes, so a string of n bytes has at least ceil(n / 4) code points. The statistics propagation of `length()` now derives the minimum character count from `min_string_length` using this bound instead of the previous fixed 0/1. The max side already used the byte upper bound and is unchanged, and VARCHAR is guaranteed valid UTF-8, so the bound always holds.

`length_grapheme()` keeps the conservative minimum because grapheme clusters can span arbitrarily many code points. The callback is templated on the counting semantics so the split holds by construction; the ASCII fast-path applies to both. Aliases (`char_length`, `character_length`, `len`) resolve to the same function entry and benefit automatically.

On a table with two unicode row groups where group B holds only 40-byte (= 20-char) strings:

```sql
EXPLAIN ANALYZE SELECT sum(length(v)) FROM t WHERE length(v) < 10;
-- main:  Row Groups Scanned: 2 / 2
-- patch: Row Groups Scanned: 1 / 2
```

Happy to also take the aggregate-side MIN/MAX over length() as a separate follow-up, which #24967 leaves open.