### PR TITLE
Determine return type when folding a function call with a typed NULL argument

### DIFF
--- a/src/function/function_binder.cpp
+++ b/src/function/function_binder.cpp
@@ -566,6 +566,46 @@ unique_ptr<Expression> FunctionBinder::BindScalarFunction(const ScalarFunctionCa
 	return BindScalarFunction(func, std::move(arguments), error, is_operator, binder);
 }
 
+//! Returns true if any argument is an untyped NULL, i.e. has type SQLNULL
+static bool HasUntypedNullArgument(const vector<unique_ptr<Expression>> &regular_args,
+                                   const vector<pair<Identifier, unique_ptr<Expression>>> &keyword_args) {
+	for (auto &child : regular_args) {
+		if (child->GetReturnType() == LogicalTypeId::SQLNULL) {
+			return true;
+		}
+	}
+	for (auto &child : keyword_args) {
+		if (child.second->GetReturnType() == LogicalTypeId::SQLNULL) {
+			return true;
+		}
+	}
+	return false;
+}
+
+static bool FoldsToNull(ClientContext &context, const Expression &child) {
+	if (!child.IsFoldable()) {
+		return false;
+	}
+	Value result;
+	return ExpressionExecutor::TryEvaluateScalar(context, child, result) && result.IsNull();
+}
+
+//! Returns true if any argument is a constant expression that evaluates to NULL
+static bool HasNullConstantArgument(ClientContext &context, const vector<unique_ptr<Expression>> &regular_args,
+                                    const vector<pair<Identifier, unique_ptr<Expression>>> &keyword_args) {
+	for (auto &child : regular_args) {
+		if (FoldsToNull(context, *child)) {
+			return true;
+		}
+	}
+	for (auto &child : keyword_args) {
+		if (FoldsToNull(context, *child.second)) {
+			return true;
+		}
+	}
+	return false;
+}
+
 unique_ptr<Expression> FunctionBinder::BindScalarFunction(const ScalarFunctionCatalogEntry &func,
                                                           vector<pair<Identifier, unique_ptr<Expression>>> arguments,
                                                           ErrorData &error, bool is_operator,
@@ -585,42 +625,21 @@ unique_ptr<Expression> FunctionBinder::BindScalarFunction(const ScalarFunctionCa
 	auto [regular_args, keyword_args] = SplitArguments(std::move(arguments));
 
 	// If any of the parameters are NULL, the function will just be replaced with a NULL constant.
-	// We try to give the NULL constant the correct type, but we have to do this without binding the function,
-	// because functions with DEFAULT_NULL_HANDLING should not have to deal with NULL inputs in their bind code.
-	// Some functions may have an invalid default return type, as they must be bound to infer the return type.
-	// In those cases, we default to SQLNULL.
-	const auto return_type_if_null =
-	    bound_function.GetReturnType().IsComplete() ? bound_function.GetReturnType() : LogicalType::SQLNULL;
+	// Bind code should not have to deal with untyped NULL inputs, so for those we never bind the function.
+	// Typed NULL constants are safe to bind, so we bind when that is the only way to determine the return type.
 	if (bound_function.GetNullHandling() == FunctionNullHandling::DEFAULT_NULL_HANDLING) {
-		for (auto &child : regular_args) {
-			if (child->GetReturnType() == LogicalTypeId::SQLNULL) {
-				return make_uniq<BoundConstantExpression>(Value(return_type_if_null));
-			}
-			if (!child->IsFoldable()) {
-				continue;
-			}
-			Value result;
-			if (!ExpressionExecutor::TryEvaluateScalar(context, *child, result)) {
-				continue;
-			}
-			if (result.IsNull()) {
-				return make_uniq<BoundConstantExpression>(Value(return_type_if_null));
-			}
+		const auto &return_type = bound_function.GetReturnType();
+		if (HasUntypedNullArgument(regular_args, keyword_args)) {
+			return make_uniq<BoundConstantExpression>(
+			    Value(return_type.IsComplete() ? return_type : LogicalType::SQLNULL));
 		}
-		for (auto &child : keyword_args) {
-			if (child.second->GetReturnType() == LogicalTypeId::SQLNULL) {
-				return make_uniq<BoundConstantExpression>(Value(return_type_if_null));
+		if (HasNullConstantArgument(context, regular_args, keyword_args)) {
+			if (return_type.IsComplete()) {
+				return make_uniq<BoundConstantExpression>(Value(return_type));
 			}
-			if (!child.second->IsFoldable()) {
-				continue;
-			}
-			Value result;
-			if (!ExpressionExecutor::TryEvaluateScalar(context, *child.second, result)) {
-				continue;
-			}
-			if (result.IsNull()) {
-				return make_uniq<BoundConstantExpression>(Value(return_type_if_null));
-			}
+			auto bound_expr = BindScalarFunction(std::move(selected_function), std::move(regular_args),
+			                                     std::move(keyword_args), is_operator, binder);
+			return make_uniq<BoundConstantExpression>(Value(bound_expr->GetReturnType()));
 		}
 	}
 	return BindScalarFunction(std::move(selected_function), std::move(regular_args), std::move(keyword_args),

--- a/test/sql/function/generic/null_constant_return_type.test
+++ b/test/sql/function/generic/null_constant_return_type.test
@@ -1,0 +1,183 @@
+# name: test/sql/function/generic/null_constant_return_type.test
+# description: A function call with a typed NULL constant argument must keep its return type when folded to NULL
+# group: [generic]
+
+# the original bug: || with a typed NULL constant was folded to an untyped NULL,
+# which made repeat() resolve to the BLOB overload
+query I
+SELECT typeof(repeat(CAST(NULL AS VARCHAR) || 'z', 2))
+----
+VARCHAR
+
+# the BLOB type then leaked into the UNION and corrupted the other branch
+query III
+SELECT s = 'a' || chr(9) || 'b', length(s), typeof(s) FROM (
+	SELECT ('a' || chr(9) || 'b') AS s UNION ALL
+	SELECT repeat(CAST(NULL AS VARCHAR) || 'z', 2)) u WHERE s IS NOT NULL
+----
+true	3	VARCHAR
+
+query I
+SELECT typeof(s) FROM (
+	SELECT ('a' || chr(9) || 'b') AS s UNION ALL
+	SELECT repeat(CAST(NULL AS VARCHAR) || 'z', 2)) u
+----
+VARCHAR
+VARCHAR
+
+# functions whose return type is only known after binding (|| is declared as ANY -> ANY)
+query IIII
+SELECT typeof(NULL::VARCHAR || 'z'), typeof('z' || NULL::VARCHAR), typeof(NULL::VARCHAR || NULL::VARCHAR), typeof(NULL::INT || 'z')
+----
+VARCHAR	VARCHAR	VARCHAR	VARCHAR
+
+query III
+SELECT typeof(NULL::BLOB || 'z'::BLOB), typeof('z'::BLOB || NULL::BLOB), typeof(NULL::BLOB || NULL::BLOB)
+----
+BLOB	BLOB	BLOB
+
+# BLOB || VARCHAR is VARCHAR regardless of NULL-ness
+query II
+SELECT typeof(NULL::BLOB || 'z'), typeof('z'::BLOB || 'z')
+----
+VARCHAR	VARCHAR
+
+query III
+SELECT typeof([1] || NULL::INT[]), typeof(NULL::INT[] || [2]), typeof(NULL::INT[] || NULL::INT[])
+----
+INTEGER[]	INTEGER[]	INTEGER[]
+
+query II
+SELECT typeof([1] || NULL::BIGINT[]), typeof(NULL::INT[3] || [2])
+----
+BIGINT[]	INTEGER[]
+
+# other bind-typed functions
+query IIII
+SELECT typeof(list_extract(NULL::INT[], 1)), typeof(struct_extract(NULL::STRUCT(a DATE), 'a')), typeof(list_aggr(NULL::INT[], 'sum')), typeof(struct_insert(NULL::STRUCT(x INT), a := 'a'))
+----
+INTEGER	DATE	HUGEINT	STRUCT(x INTEGER, a VARCHAR)
+
+query III
+SELECT typeof(list_concat(NULL::INT[], [1::BIGINT])), typeof(array_slice(NULL::INT[3], 1, 2)), typeof(map_extract(NULL::MAP(INT, DATE), 1))
+----
+BIGINT[]	INTEGER[]	DATE[]
+
+# the folded NULL is still NULL
+query IIII
+SELECT NULL::VARCHAR || 'z', [1] || NULL::INT[], NULL::BLOB || 'z'::BLOB, list_extract(NULL::INT[], 1)
+----
+NULL	NULL	NULL	NULL
+
+# NULL constants that are not literal casts (e.g. function calls that fold to NULL)
+query III
+SELECT typeof(nullif('a', 'a') || 'z'), typeof(repeat(nullif('a', 'a') || 'z', 2)), typeof(upper(NULL::VARCHAR) || 'z')
+----
+VARCHAR	VARCHAR	VARCHAR
+
+query II
+SELECT typeof((CASE WHEN 1=1 THEN NULL::INT[] END) || [1]), typeof(list_extract((CASE WHEN 1=1 THEN NULL::DATE[] END), 1))
+----
+INTEGER[]	DATE
+
+# nested: the type must propagate into enclosing constructs
+query III
+SELECT typeof(struct_pack(a := NULL::VARCHAR || 'z')), typeof([NULL::VARCHAR || 'z']), typeof(coalesce(NULL::BLOB || 'z'::BLOB, 'q'::BLOB))
+----
+STRUCT(a VARCHAR)	VARCHAR[]	BLOB
+
+query III
+SELECT typeof(repeat(NULL::BLOB || 'z'::BLOB, 2)), typeof(length(NULL::VARCHAR || 'z')), typeof(list_extract([NULL::INT[] || [1]], 1))
+----
+BLOB	BIGINT	INTEGER[]
+
+# overload resolution downstream picks the same overload as the non-NULL case
+query IIII
+SELECT typeof(repeat('z', 2)), typeof(repeat(NULL::VARCHAR || 'z', 2)), typeof(repeat('z'::BLOB, 2)), typeof(repeat(NULL::BLOB || 'z'::BLOB, 2))
+----
+VARCHAR	VARCHAR	BLOB	BLOB
+
+# type resolution in set operations
+query I
+SELECT typeof(s) FROM (SELECT 'a' AS s UNION ALL SELECT NULL::VARCHAR || 'z') u
+----
+VARCHAR
+VARCHAR
+
+query I
+SELECT typeof(s) FROM (SELECT [1] AS s UNION ALL SELECT NULL::INT[] || [2]) u
+----
+INTEGER[]
+INTEGER[]
+
+# type resolution when creating tables / views
+statement ok
+CREATE TABLE tbl AS SELECT NULL::VARCHAR || 'z' AS s, NULL::INT[] || [1] AS l, NULL::BLOB || 'z'::BLOB AS b
+
+query III
+SELECT typeof(s), typeof(l), typeof(b) FROM tbl
+----
+VARCHAR	INTEGER[]	BLOB
+
+statement ok
+CREATE VIEW v AS SELECT repeat(NULL::VARCHAR || 'z', 2) AS s
+
+query I
+SELECT data_type FROM duckdb_columns() WHERE table_name = 'v'
+----
+VARCHAR
+
+# typed NULL constants in macros
+statement ok
+CREATE MACRO concat_null(x) AS x || NULL::VARCHAR
+
+query II
+SELECT typeof(concat_null('a')), typeof(repeat(concat_null('a'), 2))
+----
+VARCHAR	VARCHAR
+
+# with prepared statement parameters the type is not known at bind time
+statement ok
+PREPARE p AS SELECT typeof(repeat(?::VARCHAR || 'z', 2))
+
+query I
+EXECUTE p(NULL)
+----
+VARCHAR
+
+# typed NULL constants in the column of a table scan are not constants and go through regular execution
+statement ok
+CREATE TABLE nulls AS SELECT NULL::VARCHAR AS s, NULL::INT[] AS l
+
+query II
+SELECT typeof(repeat(s || 'z', 2)), typeof(l || [1]) FROM nulls
+----
+VARCHAR	INTEGER[]
+
+# a type error is a type error, regardless of whether the value is NULL
+statement error
+SELECT [1] || NULL::VARCHAR
+----
+Cannot concatenate types INTEGER[] and VARCHAR
+
+statement error
+SELECT struct_extract(NULL::INT, 'a')
+----
+
+# untyped NULLs keep their untyped behaviour
+query IIII
+SELECT typeof(NULL || 'z'), typeof([1] || NULL), typeof(NULL || NULL), typeof(list_extract(NULL, 1))
+----
+"NULL"	"NULL"	"NULL"	VARCHAR
+
+# functions with a known return type still fold typed NULLs without binding
+query IIII
+SELECT typeof(upper(NULL::VARCHAR)), typeof(concat(NULL::VARCHAR, 'z')), typeof(length(NULL::VARCHAR)), typeof(abs(NULL::DOUBLE))
+----
+VARCHAR	VARCHAR	BIGINT	DOUBLE
+
+# functions with special NULL handling are unaffected
+query III
+SELECT coalesce(NULL::VARCHAR, 'z'), list_concat(NULL::INT[], [1]), constant_or_null('a', NULL::INT)
+----
+z	[1]	NULL


### PR DESCRIPTION
Under `DEFAULT_NULL_HANDLING`, a function call with a `NULL` argument returns `NULL`. For functions with `ANY` return type, the result was an untyped `SQLNULL`. This caused issues. We now call the bind function if needed to figure out the correct type of `NULL` to return.
