### PR TITLE
[Dev][Parser] Fix `MatchParseResult` regression

### DIFF
--- a/src/include/duckdb/parser/peg/matcher.hpp
+++ b/src/include/duckdb/parser/peg/matcher.hpp
@@ -155,7 +155,7 @@ struct MatchState {
 	MatchState(MatchState &state)
 	    : token_iterator(state.token_iterator), suggestions(state.suggestions), allocator(state.allocator),
 	      max_token_index(state.max_token_index), identifier_case_mode(state.identifier_case_mode),
-	      packrat_cache(state.packrat_cache), mode(state.mode) {
+	      packrat_cache(state.packrat_cache), mode(state.mode), rule(state.rule) {
 	}
 
 	TokenIterator token_iterator;
@@ -166,6 +166,7 @@ struct MatchState {
 	IdentifierCaseMode identifier_case_mode = IdentifierCaseMode::PRESERVE_CASE;
 	ParserPackratCache *packrat_cache;
 	MatchMode mode;
+	optional_ptr<const CompiledGrammarRule> rule;
 
 	bool BuildParseResult() const {
 		return mode == MatchMode::BUILD_PARSE_RESULT;
@@ -315,7 +316,12 @@ MatcherResult MatchState::AllocateParseResult(ARGS &&... args) {
 	if (!BuildParseResult()) {
 		return MatcherResult::Success();
 	}
-	return MatcherResult::Success(allocator.Allocate(make_uniq<RESULT>(std::forward<ARGS>(args)...)));
+	auto result = allocator.Allocate(make_uniq<RESULT>(std::forward<ARGS>(args)...));
+	if (rule) {
+		result->SetRule(*rule);
+		result->name = rule->name;
+	}
+	return MatcherResult::Success(result);
 }
 
 } // namespace duckdb

--- a/src/parser/peg/matcher.cpp
+++ b/src/parser/peg/matcher.cpp
@@ -18,18 +18,11 @@
 namespace duckdb {
 
 MatcherResult Matcher::MatchParseResult(MatchState &state) const {
-	auto result = MatcherResult::Failure();
+	state.rule = rule;
 	if (state.packrat_cache && IsPackratMemoized()) {
-		result = state.packrat_cache->Match(*this, state);
-	} else {
-		result = MatchParseResultInternal(state);
+		return state.packrat_cache->Match(*this, state);
 	}
-	if (result.HasParseResult() && rule) {
-		auto parse_result = result.GetParseResult();
-		parse_result->SetRule(*rule);
-		parse_result->name = rule->name;
-	}
-	return result;
+	return MatchParseResultInternal(state);
 }
 
 SuggestionType Matcher::AddSuggestion(MatchState &state) const {


### PR DESCRIPTION
This PR relates to https://github.com/duckdblabs/duckdb-internal/issues/10511

Carry the rule reference in the MatchState, instead of adding it after the fact, fixing the regression in `MatchParseResult`.