### PR TITLE
Fix ALTER TYPE dropping concurrently committed updates

### DIFF
--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -186,7 +186,7 @@ DataTable::DataTable(ClientContext &context, DataTable &parent, idx_t changed_id
 	auto &transaction = DuckTransaction::Get(context, db);
 	auto &local_storage = LocalStorage::Get(transaction);
 	// prevent any tuples from being added to the parent
-	lock_guard<mutex> lock(append_lock);
+	lock_guard<mutex> parent_lock(parent.append_lock);
 	for (auto &column_def : parent.column_definitions) {
 		column_definitions.emplace_back(column_def.Copy());
 	}
@@ -208,13 +208,24 @@ DataTable::DataTable(ClientContext &context, DataTable &parent, idx_t changed_id
 
 	// set up the statistics for the table
 	// the column that had its type changed will have the new statistics computed during conversion
-	row_groups = parent.row_groups->AlterType(context, changed_idx, target_type, bound_columns, cast_expr, transaction);
-
-	// scan the original table, and fill the new column with the transformed value
-	local_storage.ChangeType(parent, *this, changed_idx, target_type, bound_columns, cast_expr);
-
-	// this table replaces the previous table, hence the parent is no longer the root DataTable
+	// mark the parent altered before reading, so a concurrent modification conflicts instead of
+	// being dropped by the rewrite
+	auto previous_version = parent.version.load();
 	parent.version = DataTableVersion::ALTERED;
+	try {
+		// read at the commits seen so far, not at this transaction's older snapshot
+		auto &transaction_manager = DuckTransactionManager::Get(db);
+		TransactionData rewrite_visibility(transaction.transaction_id, transaction_manager.GetLastCommit() + 1);
+		row_groups = parent.row_groups->AlterType(context, changed_idx, target_type, bound_columns, cast_expr,
+		                                          rewrite_visibility);
+
+		// scan the original table, and fill the new column with the transformed value
+		local_storage.ChangeType(parent, *this, changed_idx, target_type, bound_columns, cast_expr);
+	} catch (...) {
+		// nothing reached the catalog, so no undo entry will restore the parent
+		parent.version = previous_version;
+		throw;
+	}
 }
 
 vector<LogicalType> DataTable::GetTypes() {

--- a/test/sql/alter/alter_type/alter_type_concurrent_committed_update.test
+++ b/test/sql/alter/alter_type/alter_type_concurrent_committed_update.test
@@ -1,0 +1,39 @@
+# name: test/sql/alter/alter_type/alter_type_concurrent_committed_update.test
+# description: ALTER TYPE must not discard a committed update its own snapshot cannot see
+# group: [alter_type]
+
+statement ok con1
+CREATE TABLE t(id INTEGER, v INTEGER)
+
+statement ok con1
+INSERT INTO t VALUES (1, 0)
+
+# con2 takes its snapshot before the update commits
+statement ok con2
+BEGIN TRANSACTION
+
+query I con2
+SELECT v FROM t
+----
+0
+
+statement ok con1
+UPDATE t SET v = 7
+
+# the retype rewrites the column, and the new column does not inherit the old column's update
+# segments - so a rewrite that resolved values at con2's snapshot would drop the committed update
+statement ok con2
+ALTER TABLE t ALTER COLUMN v SET DATA TYPE BIGINT
+
+statement ok con2
+COMMIT
+
+query I con1
+SELECT v FROM t
+----
+7
+
+query I con1
+SELECT typeof(v) FROM t
+----
+BIGINT

--- a/test/sql/alter/alter_type/alter_type_failed_cast_keeps_table_usable.test
+++ b/test/sql/alter/alter_type/alter_type_failed_cast_keeps_table_usable.test
@@ -1,0 +1,31 @@
+# name: test/sql/alter/alter_type/alter_type_failed_cast_keeps_table_usable.test
+# description: a rewrite that fails must leave the table usable, not marked altered
+# group: [alter_type]
+
+statement ok
+CREATE TABLE t(v VARCHAR)
+
+statement ok
+INSERT INTO t VALUES ('not a number')
+
+# the rewrite fails on the cast
+statement error
+ALTER TABLE t ALTER COLUMN v SET DATA TYPE INTEGER
+----
+
+# the table must still be usable: the failed alter must not leave it marked altered
+statement ok
+INSERT INTO t VALUES ('still works')
+
+query I
+SELECT count(*) FROM t
+----
+2
+
+statement ok
+UPDATE t SET v = 'updated'
+
+query I
+SELECT count(*) FROM t WHERE v = 'updated'
+----
+2


### PR DESCRIPTION
The column rewrite resolved values at the altering transaction's snapshot, never locked the parent, and marked it altered only after scanning every row group. Each of those lets an acknowledged update vanish, because the new column does not inherit the old column's update segments:

- read at GetLastCommit() + 1, as index rebuild and vacuum already do
- lock parent.append_lock, as the add column, remove column and add constraint constructors already do; this one locked its own, unreachable mutex
- mark the parent altered before reading rather than after the scan, so a transaction committing meanwhile conflicts instead of being silently dropped

The mark has to be restored if the rewrite throws: a failed cast throws before the catalog entry is swapped, so no undo entry restores it, and the table would reject every modification from then on.

A modification committing during a rewrite that is later rolled back now aborts where it previously succeeded.