### PR TITLE
Test musl thread stack size in CI on all (slow) tests for release

### DIFF
--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -724,7 +724,7 @@ jobs:
         tar -xzf build/release-artifact.tar.gz -C build
 
     - name: Run all release unit tests
-      run: make allunit
+      run: make allunit T="--test-flags='--thread-stack-size 131072'"
 
     - name: Release tests
       shell: bash

--- a/scripts/ci/run_tests.py
+++ b/scripts/ci/run_tests.py
@@ -996,6 +996,10 @@ def parse_failure_info(message: str | None, stdout: str, stderr: str, batch, ret
             if detail_lines:
                 detail_lines.append("")
             detail_lines.extend(preferred_assertion.detail_lines)
+    if not snippet_lines and test_name is not None and line_number is not None:
+        snippet_lines = render_test_snippet(test_name, line_number)
+    if not detail_lines and stderr_info.failing_summary_block:
+        detail_lines.extend(stderr_info.failing_summary_block)
     if not detail_lines:
         if stdout_info.fallback_failure_block:
             stdout_failure_test_name, stdout_failure_block = stdout_info.fallback_failure_block
@@ -1004,10 +1008,6 @@ def parse_failure_info(message: str | None, stdout: str, stderr: str, batch, ret
             )
             reproduce_batch = [test_name] if test_name else list(batch)
             detail_lines.extend(stdout_failure_block)
-    if not snippet_lines and test_name is not None and line_number is not None:
-        snippet_lines = render_test_snippet(test_name, line_number)
-    if not detail_lines and stderr_info.failing_summary_block:
-        detail_lines.extend(stderr_info.failing_summary_block)
     if not detail_lines:
         detail_lines.extend(extract_interesting_failure_block(stderr_lines))
     if not detail_lines:

--- a/scripts/ci/run_tests.py
+++ b/scripts/ci/run_tests.py
@@ -117,6 +117,7 @@ class StdoutParse:
     last_unfinished_test: str | None
     preferred_assertion: StdoutAssertionFailure | None
     fallback_failure_block: tuple[str | None, list[str]] | None
+    fatal_error_lines: list[str]
     failed_reason_line: str | None
 
 
@@ -602,6 +603,32 @@ def infer_timed_out_test_from_stdout(stdout_lines: list[str], batch):
     return None
 
 
+def extract_fatal_error_lines(stdout_lines: list[str]):
+    for idx, line in enumerate(stdout_lines):
+        if not FATAL_ERROR_PATTERN.match(line):
+            continue
+
+        lines = []
+        for next_line in stdout_lines[idx + 1 :]:
+            stripped = next_line.strip()
+            if PROGRESS_TEST_START_PATTERN.match(stripped):
+                break
+            if stripped.startswith("test cases:") or stripped.startswith("assertions:"):
+                break
+            if stripped.startswith("==============================================================================="):
+                break
+            if stripped.startswith("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"):
+                break
+            lines.append(stripped)
+
+        while lines and not lines[0].strip():
+            lines.pop(0)
+        while lines and not lines[-1].strip():
+            lines.pop()
+        return lines
+    return []
+
+
 def extract_failed_reason_line(stdout_lines: list[str]):
     for idx, line in enumerate(stdout_lines):
         if not FAILED_HEADER_PATTERN.match(line):
@@ -755,6 +782,7 @@ def parse_stdout_failure_info(stdout_lines: list[str]):
         last_unfinished_test=last_unfinished_test,
         preferred_assertion=preferred_assertion,
         fallback_failure_block=fallback_failure_block,
+        fatal_error_lines=extract_fatal_error_lines(stdout_lines),
         failed_reason_line=extract_failed_reason_line(stdout_lines),
     )
 
@@ -948,6 +976,8 @@ def parse_failure_info(message: str | None, stdout: str, stderr: str, batch, ret
 
     test_name = stderr_info.test_name
     line_number = stderr_info.line_number
+    if stdout_info.fatal_error_lines and stdout_info.last_started_test:
+        test_name, line_number = retarget_failing_test(stdout_info.last_started_test, test_name, line_number)
     if test_name is None and returncode is not None and returncode < 0:
         test_name = stdout_info.last_unfinished_test or infer_timed_out_test_from_stdout(stdout_lines, batch)
     reproduce_batch = [test_name] if test_name else list(batch)
@@ -983,6 +1013,8 @@ def parse_failure_info(message: str | None, stdout: str, stderr: str, batch, ret
     snippet_lines = []
     if stderr_info.query_failure_lines:
         detail_lines.extend(stderr_info.query_failure_lines)
+    elif stdout_info.fatal_error_lines:
+        detail_lines.extend(stdout_info.fatal_error_lines)
 
     preferred_assertion = stdout_info.preferred_assertion
     if preferred_assertion is not None:

--- a/scripts/ci/test_run_tests.py
+++ b/scripts/ci/test_run_tests.py
@@ -1276,6 +1276,34 @@ Replacing deprecated string __TEST_DIR__ in path "__TEST_DIR__/hnsw_reclaim_spac
             ["/duckdb_build_dir/build/release/_deps/vss_extension_fc-src/test/sql/hnsw/hnsw_lateral_join_group.test"],
         )
 
+    def test_fatal_stdout_failure_preserves_stacktrace(self):
+        batch = ["test/sql/crash.test"]
+        stdout = """
+[0/1] (0%): test/sql/crash.test
+/duckdb/test/sqlite/test_sqllogictest.cpp:41: FAILED:
+  {Unknown expression after the reported line}
+due to a fatal error condition:
+  SIGSEGV - Segmentation violation signal
+
+/duckdb/build/release/test/unittest(duckdb::CrashHere()+0x12) [0x1234]
+/duckdb/build/release/src/libduckdb.so(duckdb::Execute()+0x34) [0x5678]
+===============================================================================
+test cases: 1 | 1 failed
+"""
+        lines, reproduce_batch = run_tests.summarize_failure_output(None, stdout, "", batch, returncode=-11)
+        self.assertEqual(
+            strip_ansi_lines(lines)[1:],
+            [
+                "error: FAIL test/sql/crash.test",
+                "",
+                "SIGSEGV - Segmentation violation signal",
+                "",
+                "/duckdb/build/release/test/unittest(duckdb::CrashHere()+0x12) [0x1234]",
+                "/duckdb/build/release/src/libduckdb.so(duckdb::Execute()+0x34) [0x5678]",
+            ],
+        )
+        self.assertEqual(reproduce_batch, batch)
+
     def test_signal_only_failure_prefers_returncode_over_unrelated_stdout(self):
         batch = ["test/sql/crash.test"]
         lines, reproduce_batch = run_tests.summarize_failure_output(

--- a/scripts/ci/test_run_tests.py
+++ b/scripts/ci/test_run_tests.py
@@ -1196,6 +1196,54 @@ unittest is a Catch v2.13.7 host application.
             ],
         )
 
+    def test_empty_stdout_assertion_uses_sqllogictest_stderr_diagnostics(self):
+        batch = ["/tmp/fail.test"]
+        stdout = """
+Filters: /tmp/fail.test
+
+[0/1] (0%): /tmp/fail.test
+-------------------------------------------------------------------------------
+/tmp/fail.test
+-------------------------------------------------------------------------------
+/duckdb/test/sqlite/test_sqllogictest.cpp:47
+...............................................................................
+
+/tmp/fail.test:314: FAILED:
+
+
+[1/1] (100%): /tmp/fail.test took 0.015s
+===============================================================================
+test cases:  1 |  0 passed | 1 failed
+assertions: 28 | 27 passed | 1 failed
+"""
+        stderr = """
+1. /tmp/fail.test:314
+================================================================================
+Query unexpectedly failed (/tmp/fail.test:314)
+ (/tmp/fail.test:314)!
+================================================================================
+SELECT x'303132' IN (SELECT * FROM t1);
+================================================================================
+Actual result:
+================================================================================
+Binder Error: Cannot compare values of type BLOB and INTEGER in IN/ANY/ALL clause - an explicit cast is required
+
+LINE 1: SELECT x'303132' IN (SELECT * FROM t1)
+                            ^^^^^^^^^^^^^^^^^^
+"""
+        lines, reproduce_batch = run_tests.summarize_failure_output(None, stdout, stderr, batch)
+        stripped_lines = strip_ansi_lines(lines)
+
+        self.assertEqual(reproduce_batch, batch)
+        self.assertIn("error: FAIL /tmp/fail.test", stripped_lines)
+        self.assertIn(
+            "Binder Error: Cannot compare values of type BLOB and INTEGER in IN/ANY/ALL clause - "
+            "an explicit cast is required",
+            stripped_lines,
+        )
+        self.assertIn("LINE 1: SELECT x'303132' IN (SELECT * FROM t1)", stripped_lines)
+        self.assertIn("                            ^^^^^^^^^^^^^^^^^^", stripped_lines)
+
     def test_fatal_stdout_failure_uses_last_started_test_and_signal(self):
         batch = [
             "/duckdb_build_dir/build/release/_deps/vss_extension_fc-src/test/sql/slow/hnsw_reclaim_storage.test_slow",

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -51,6 +51,16 @@ endif()
 
 add_executable(unittest unittest.cpp ${UNITTEST_OBJECT_FILES})
 
+# Enable best-effort stack traces for fatal signals in the test runner without
+# enabling stack traces for every DuckDB exception.
+if((CMAKE_SYSTEM_NAME STREQUAL "Linux" AND NOT MUSL_ENABLED) OR APPLE)
+  target_compile_definitions(unittest PRIVATE DUCKDB_UNITTEST_CRASH_STACKTRACE)
+endif()
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND NOT MUSL_ENABLED)
+  set_target_properties(unittest PROPERTIES ENABLE_EXPORTS ON)
+endif()
+
 set(RUN_WRAPPER_UNITTEST_NAME "unittest")
 if(WIN32)
   set(RUN_WRAPPER_UNITTEST_NAME "unittest.exe")

--- a/test/unittest.cpp
+++ b/test/unittest.cpp
@@ -5,6 +5,7 @@
 #define CATCH_CONFIG_RUNNER
 #include "catch.hpp"
 #include <stdlib.h>
+#include <cerrno>
 #include <cstring>
 #include <fstream>
 #include <limits>
@@ -62,6 +63,88 @@ static string PthreadError(const char *function, int error) {
 	return string(function) + " failed: " + std::strerror(error);
 }
 
+enum class ThreadStackProbeResult : uint8_t { SUCCESS, TOO_SMALL, ERROR };
+
+// glibc's fixed Linux minimum excludes the binary-specific static TLS overhead.
+static constexpr size_t GLIBC_PTHREAD_STACK_MIN = 16384;
+
+static void *MinimumThreadStackProbe(void *) {
+	return nullptr;
+}
+
+static ThreadStackProbeResult TryThreadStackSize(size_t stack_size, string &error) {
+	pthread_attr_t attributes;
+	auto result = pthread_getattr_default_np(&attributes);
+	if (result != 0) {
+		error = PthreadError("pthread_getattr_default_np", result);
+		return ThreadStackProbeResult::ERROR;
+	}
+
+	result = pthread_attr_setstacksize(&attributes, stack_size);
+	if (result != 0) {
+		pthread_attr_destroy(&attributes);
+		if (result == EINVAL) {
+			return ThreadStackProbeResult::TOO_SMALL;
+		}
+		error = PthreadError("pthread_attr_setstacksize", result);
+		return ThreadStackProbeResult::ERROR;
+	}
+
+	pthread_t probe;
+	result = pthread_create(&probe, &attributes, MinimumThreadStackProbe, nullptr);
+	auto destroy_result = pthread_attr_destroy(&attributes);
+	if (result != 0) {
+		if (result == EINVAL) {
+			return ThreadStackProbeResult::TOO_SMALL;
+		}
+		error = PthreadError("pthread_create", result);
+		return ThreadStackProbeResult::ERROR;
+	}
+	auto join_result = pthread_join(probe, nullptr);
+	if (join_result != 0) {
+		error = PthreadError("pthread_join", join_result);
+		return ThreadStackProbeResult::ERROR;
+	}
+	if (destroy_result != 0) {
+		error = PthreadError("pthread_attr_destroy", destroy_result);
+		return ThreadStackProbeResult::ERROR;
+	}
+	return ThreadStackProbeResult::SUCCESS;
+}
+
+static bool GetMinimumThreadStackSize(size_t default_stack_size, size_t page_size, size_t &minimum_stack_size,
+                                      string &error) {
+	auto lower_page = (GLIBC_PTHREAD_STACK_MIN + page_size - 1) / page_size;
+	auto upper_page = default_stack_size / page_size;
+	if (upper_page < lower_page) {
+		error = "Default pthread stack size is below the glibc minimum";
+		return false;
+	}
+	auto default_probe_result = TryThreadStackSize(upper_page * page_size, error);
+	if (default_probe_result != ThreadStackProbeResult::SUCCESS) {
+		if (default_probe_result == ThreadStackProbeResult::TOO_SMALL) {
+			error = "Unable to create a thread with the default pthread stack size";
+		} else {
+			error = "Unable to create a thread with the default pthread stack size: " + error;
+		}
+		return false;
+	}
+
+	while (lower_page < upper_page) {
+		auto middle_page = lower_page + (upper_page - lower_page) / 2;
+		auto probe_result = TryThreadStackSize(middle_page * page_size, error);
+		if (probe_result == ThreadStackProbeResult::SUCCESS) {
+			upper_page = middle_page;
+		} else if (probe_result == ThreadStackProbeResult::TOO_SMALL) {
+			lower_page = middle_page + 1;
+		} else {
+			return false;
+		}
+	}
+	minimum_stack_size = lower_page * page_size;
+	return true;
+}
+
 static bool SetThreadStackSize(size_t requested_stack_size, string &error) {
 	pthread_attr_t default_attributes;
 	auto result = pthread_getattr_default_np(&default_attributes);
@@ -70,7 +153,34 @@ static bool SetThreadStackSize(size_t requested_stack_size, string &error) {
 		return false;
 	}
 
-	result = pthread_attr_setstacksize(&default_attributes, requested_stack_size);
+	size_t default_stack_size;
+	result = pthread_attr_getstacksize(&default_attributes, &default_stack_size);
+	if (result != 0) {
+		pthread_attr_destroy(&default_attributes);
+		error = PthreadError("pthread_attr_getstacksize", result);
+		return false;
+	}
+	auto page_size_result = sysconf(_SC_PAGESIZE);
+	if (page_size_result <= 0) {
+		pthread_attr_destroy(&default_attributes);
+		error = "Failed to determine the system page size";
+		return false;
+	}
+	auto page_size = static_cast<size_t>(page_size_result);
+	size_t minimum_stack_size;
+	if (!GetMinimumThreadStackSize(default_stack_size, page_size, minimum_stack_size, error)) {
+		pthread_attr_destroy(&default_attributes);
+		return false;
+	}
+	auto stack_overhead = minimum_stack_size - GLIBC_PTHREAD_STACK_MIN;
+	if (requested_stack_size > std::numeric_limits<size_t>::max() - stack_overhead) {
+		pthread_attr_destroy(&default_attributes);
+		error = "--thread-stack-size is too large";
+		return false;
+	}
+	auto configured_stack_size = requested_stack_size + stack_overhead;
+
+	result = pthread_attr_setstacksize(&default_attributes, configured_stack_size);
 	if (result == 0) {
 		result = pthread_setattr_default_np(&default_attributes);
 	}
@@ -109,15 +219,12 @@ static bool SetThreadStackSize(size_t requested_stack_size, string &error) {
 		return false;
 	}
 
-	auto page_size = sysconf(_SC_PAGESIZE);
-	if (page_size <= 0) {
-		error = "Failed to determine the system page size";
-		return false;
-	}
-	auto difference = observed_stack_size > requested_stack_size ? observed_stack_size - requested_stack_size
-	                                                             : requested_stack_size - observed_stack_size;
-	if (difference > static_cast<size_t>(page_size)) {
-		error = "Thread stack size probe reported " + to_string(observed_stack_size) + " bytes after requesting " +
+	auto effective_stack_size = observed_stack_size > stack_overhead ? observed_stack_size - stack_overhead : 0;
+	auto difference = effective_stack_size > requested_stack_size ? effective_stack_size - requested_stack_size
+	                                                              : requested_stack_size - effective_stack_size;
+	if (difference > page_size) {
+		error = "Thread stack size probe reported " + to_string(observed_stack_size) + " total bytes (" +
+		        to_string(effective_stack_size) + " after glibc overhead) after requesting " +
 		        to_string(requested_stack_size) + " bytes";
 		return false;
 	}

--- a/test/unittest.cpp
+++ b/test/unittest.cpp
@@ -1,8 +1,21 @@
+#if defined(__linux__) && !defined(_GNU_SOURCE)
+#define _GNU_SOURCE
+#endif
+
 #define CATCH_CONFIG_RUNNER
 #include "catch.hpp"
 #include <stdlib.h>
+#include <cstring>
 #include <fstream>
+#include <limits>
+#include <thread>
 #include <unordered_set>
+
+#if defined(__linux__)
+#include <features.h>
+#include <pthread.h>
+#include <unistd.h>
+#endif
 
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/string_util.hpp"
@@ -15,6 +28,137 @@
 using namespace duckdb;
 
 namespace {
+
+#if defined(__linux__) && !defined(DUCKDB_NO_THREADS) && defined(__GLIBC_PREREQ)
+#if __GLIBC_PREREQ(2, 18)
+#define DUCKDB_UNITTEST_HAS_DEFAULT_PTHREAD_ATTRIBUTES
+#endif
+#endif
+
+static bool TryParseThreadStackSize(const string &value, size_t &result) {
+	if (value.empty()) {
+		return false;
+	}
+	size_t parsed_value = 0;
+	for (auto character : value) {
+		if (character < '0' || character > '9') {
+			return false;
+		}
+		auto digit = static_cast<size_t>(character - '0');
+		if (parsed_value > (std::numeric_limits<size_t>::max() - digit) / 10) {
+			return false;
+		}
+		parsed_value = parsed_value * 10 + digit;
+	}
+	if (parsed_value == 0) {
+		return false;
+	}
+	result = parsed_value;
+	return true;
+}
+
+#ifdef DUCKDB_UNITTEST_HAS_DEFAULT_PTHREAD_ATTRIBUTES
+static string PthreadError(const char *function, int error) {
+	return string(function) + " failed: " + std::strerror(error);
+}
+
+static bool SetThreadStackSize(size_t requested_stack_size, string &error) {
+	pthread_attr_t default_attributes;
+	auto result = pthread_getattr_default_np(&default_attributes);
+	if (result != 0) {
+		error = PthreadError("pthread_getattr_default_np", result);
+		return false;
+	}
+
+	result = pthread_attr_setstacksize(&default_attributes, requested_stack_size);
+	if (result == 0) {
+		result = pthread_setattr_default_np(&default_attributes);
+	}
+	auto destroy_result = pthread_attr_destroy(&default_attributes);
+	if (result != 0) {
+		error = PthreadError("setting the default pthread stack size", result);
+		return false;
+	}
+	if (destroy_result != 0) {
+		error = PthreadError("pthread_attr_destroy", destroy_result);
+		return false;
+	}
+
+	size_t observed_stack_size = 0;
+	int probe_result = 0;
+	try {
+		std::thread probe([&]() {
+			pthread_attr_t probe_attributes;
+			probe_result = pthread_getattr_np(pthread_self(), &probe_attributes);
+			if (probe_result != 0) {
+				return;
+			}
+			probe_result = pthread_attr_getstacksize(&probe_attributes, &observed_stack_size);
+			auto probe_destroy_result = pthread_attr_destroy(&probe_attributes);
+			if (probe_result == 0) {
+				probe_result = probe_destroy_result;
+			}
+		});
+		probe.join();
+	} catch (std::exception &ex) {
+		error = string("Failed to create thread stack size probe: ") + ex.what();
+		return false;
+	}
+	if (probe_result != 0) {
+		error = PthreadError("reading the probe thread stack size", probe_result);
+		return false;
+	}
+
+	auto page_size = sysconf(_SC_PAGESIZE);
+	if (page_size <= 0) {
+		error = "Failed to determine the system page size";
+		return false;
+	}
+	auto difference = observed_stack_size > requested_stack_size ? observed_stack_size - requested_stack_size
+	                                                             : requested_stack_size - observed_stack_size;
+	if (difference > static_cast<size_t>(page_size)) {
+		error = "Thread stack size probe reported " + to_string(observed_stack_size) + " bytes after requesting " +
+		        to_string(requested_stack_size) + " bytes";
+		return false;
+	}
+	return true;
+}
+#endif
+
+static bool ConfigureThreadStackSize(int argc, char *argv[], string &error) {
+	bool stack_size_specified = false;
+	size_t requested_stack_size = 0;
+	for (int i = 1; i < argc; i++) {
+		if (string(argv[i]) != "--thread-stack-size") {
+			continue;
+		}
+		if (stack_size_specified) {
+			error = "--thread-stack-size may only be specified once";
+			return false;
+		}
+		if (++i >= argc) {
+			error = "--thread-stack-size expected a size in bytes";
+			return false;
+		}
+		size_t parsed_stack_size;
+		if (!TryParseThreadStackSize(argv[i], parsed_stack_size)) {
+			error = "--thread-stack-size expected a positive integer size in bytes";
+			return false;
+		}
+		requested_stack_size = parsed_stack_size;
+		stack_size_specified = true;
+	}
+	if (!stack_size_specified) {
+		return true;
+	}
+
+#ifdef DUCKDB_UNITTEST_HAS_DEFAULT_PTHREAD_ATTRIBUTES
+	return SetThreadStackSize(requested_stack_size, error);
+#else
+	error = "--thread-stack-size is only supported on Linux with glibc 2.18 or newer";
+	return false;
+#endif
+}
 
 struct TempDirReclaimer {
 	~TempDirReclaimer() {
@@ -65,6 +209,12 @@ static bool TryReadExactSQLLogicTestFilter(const vector<string> &input_files, ve
 }
 
 int main(int argc_in, char *argv[]) {
+	string thread_stack_error;
+	if (!ConfigureThreadStackSize(argc_in, argv, thread_stack_error)) {
+		fprintf(stderr, "%s\n", thread_stack_error.c_str());
+		return 1;
+	}
+
 	string test_directory = DUCKDB_ROOT_DIRECTORY;
 
 	// route the sqllogictest runner's verdicts into the Catch session
@@ -104,6 +254,8 @@ int main(int argc_in, char *argv[]) {
 			use_stdin = true;
 		} else if (argument == "--emit-test-events") {
 			SetEmitTestEvents(true);
+		} else if (argument == "--thread-stack-size") {
+			i++;
 		} else {
 			try {
 				if (!test_config.ParseArgument(argument, argc, argv, i)) {

--- a/third_party/catch/catch.hpp
+++ b/third_party/catch/catch.hpp
@@ -24,9 +24,9 @@ namespace duckdb_base_std {
 } // namespace duckdb_base_std
 #endif
 // optional support for printing stacktraces on a crash -- using the backtrace support in DuckDB
-#ifdef DUCKDB_DEBUG_STACKTRACE
+#if defined(DUCKDB_DEBUG_STACKTRACE) || defined(DUCKDB_UNITTEST_CRASH_STACKTRACE)
 #include "duckdb/common/exception.hpp"
-#define CATCH_STACKTRACE(X) duckdb::Exception::FormatStackTrace(X).c_str()
+#define CATCH_STACKTRACE(X) duckdb::Exception::FormatStackTrace(X)
 #endif
 
 #define CATCH_VERSION_MAJOR 2
@@ -10878,7 +10878,8 @@ namespace {
     //! Signals fatal error message to the run context
     void reportFatal( char const * message ) {
 #ifdef CATCH_STACKTRACE
-        message = (const char*) CATCH_STACKTRACE(message); //enrich error message with a stacktrace
+        auto messageWithStacktrace = CATCH_STACKTRACE(message);
+        message = messageWithStacktrace.c_str();
 #endif
         Catch::getCurrentContext().getResultCapture()->handleFatalErrorCondition( message );
     }
@@ -11001,7 +11002,7 @@ namespace Catch {
             sigaction(signalDefs[i].id, &oldSigActions[i], nullptr);
         }
         // Return the old stack
-#ifndef CATCH_STACKTRACE
+#if !defined(CATCH_STACKTRACE) || !defined(__APPLE__)
         sigaltstack(&oldSigStack, nullptr); // sigaltstack prevents catch-stacktrace to work (on MacOS)
 #endif
     }
@@ -11042,7 +11043,7 @@ namespace Catch {
         sigStack.ss_sp = altStackMem;
         sigStack.ss_size = altStackSize;
         sigStack.ss_flags = 0;
-#ifndef CATCH_STACKTRACE
+#if !defined(CATCH_STACKTRACE) || !defined(__APPLE__)
         sigaltstack(&sigStack, &oldSigStack); // sigaltstack prevents catch-stacktrace to work (on MacOS)
 #endif
         struct sigaction sa = { };


### PR DESCRIPTION
There are linux amd64 and arm64 musl test failures in CI:

- [Aug 22](https://github.com/duckdb/duckdb/actions/runs/32540385326/job/96949958060)
- [Aug 21](https://github.com/duckdb/duckdb/actions/runs/32432696462/job/96629753610).

It also crashes on [Aug 24](https://github.com/duckdb/duckdb/actions/runs/32793666975/job/97642563619#step:11:71), but recovered after the second retry.

The segfault is caused by a worker-thread stack overflow in DuckDB’s PEG parser.

Alpine/musl gives new threads only 128 KiB of stack by default, versus several MiB under glibc. The unittest binary’s PT_GNU_STACK requests no larger size. [musl thread stack documentation](https://wiki.musl-libc.org/functional-differences-from-glibc.html#thread-stack-size)

See issue: https://github.com/duckdblabs/duckdb-internal/issues/10511
And parser stack overflow fix: https://github.com/duckdb/duckdb/pull/25007.

### Minimum stack size computation on linux

The linux release binary’s large static thread local storage (TLS) footprint raises glibc’s actual minimum stack:

- Fixed glibc minimum: 16,384 bytes
- Actual binary minimum: 139,264 bytes
- TLS overhead: 122,880 bytes
- Total configured for 128 KiB usable stack: 253,952 bytes

The unittest binary now calibrates this overhead with `pthread` APIs, adds it to the requested usable stack, and verifies the effective size.

This PR builds on top of https://github.com/duckdb/duckdb/pull/25364 so we can see stack traces for segfaulting tests.