### PR TITLE
[Parquet][Read] Add an optional 'children' field to the `SCHEMA` parameter

### DIFF
--- a/extension/parquet/include/parquet.json
+++ b/extension/parquet/include/parquet.json
@@ -30,6 +30,12 @@
         "name": "identifier",
         "type": "Value",
         "default": "Value()"
+      },
+      {
+        "id": 106,
+        "name": "children",
+        "type": "vector<ParquetColumnDefinition>",
+        "default": "vector<ParquetColumnDefinition>()"
       }
     ],
     "pointer_type": "none"

--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -249,7 +249,12 @@ public:
 
 struct ParquetColumnDefinition {
 public:
-	static ParquetColumnDefinition FromSchemaValue(ClientContext &context, const Value &column_value);
+	static vector<ParquetColumnDefinition> FromSchemaMap(ClientContext &context, const Value &schema_value);
+	MultiFileColumnDefinition ToMultiFileColumnDefinition() const;
+	bool operator==(const ParquetColumnDefinition &other) const {
+		return field_id == other.field_id && name == other.name && type == other.type &&
+		       default_value == other.default_value && identifier == other.identifier && children == other.children;
+	}
 
 public:
 	// DEPRECATED, use 'identifier' instead
@@ -258,6 +263,7 @@ public:
 	LogicalType type;
 	Value default_value;
 	Value identifier;
+	vector<ParquetColumnDefinition> children;
 
 public:
 	void Serialize(Serializer &serializer) const;

--- a/extension/parquet/parquet_multi_file_info.cpp
+++ b/extension/parquet/parquet_multi_file_info.cpp
@@ -152,8 +152,7 @@ static void BindSchema(ClientContext &context, vector<LogicalType> &return_types
 		schema_col_names.push_back(Identifier(column.name));
 		schema_col_types.push_back(column.type);
 
-		auto res = MultiFileColumnDefinition(column.name, column.type);
-		res.identifier = column.identifier;
+		auto res = column.ToMultiFileColumnDefinition();
 #ifdef DEBUG
 		if (match_by_field_id) {
 			D_ASSERT(res.identifier.type().id() == LogicalTypeId::INTEGER);
@@ -162,7 +161,6 @@ static void BindSchema(ClientContext &context, vector<LogicalType> &return_types
 		}
 #endif
 
-		res.default_expression = make_uniq<ConstantExpression>(column.default_value);
 		reader_bind.schema.emplace_back(res);
 	}
 	ParseFileRowNumberOption(reader_bind, options, return_types, names);
@@ -229,52 +227,6 @@ static bool ParquetScanSupportPushdownExtract(const FunctionData &bind_data_p, c
 	auto &column = bind_data.columns[col_idx.index];
 	auto &column_type = column.type;
 	return column_type.id() == LogicalTypeId::STRUCT || column_type.id() == LogicalTypeId::VARIANT;
-}
-
-static void VerifyParquetSchemaParameter(const Value &schema) {
-	LogicalType::MAP(LogicalType::BLOB, LogicalType::STRUCT({{{"name", LogicalType::VARCHAR},
-	                                                          {"type", LogicalType::VARCHAR},
-	                                                          {"default_value", LogicalType::VARCHAR}}}));
-	auto &map_type = schema.type();
-	if (map_type.id() != LogicalTypeId::MAP) {
-		throw InvalidInputException("'schema' expects a value of type MAP, not %s",
-		                            LogicalTypeIdToString(map_type.id()));
-	}
-	auto &key_type = MapType::KeyType(map_type);
-	auto &value_type = MapType::ValueType(map_type);
-
-	if (value_type.id() != LogicalTypeId::STRUCT) {
-		throw InvalidInputException("'schema' expects a STRUCT as the value type of the map");
-	}
-	auto &children = StructType::GetChildTypes(value_type);
-	if (children.size() < 3) {
-		throw InvalidInputException(
-		    "'schema' expects the STRUCT to have 3 children, 'name', 'type' and 'default_value");
-	}
-	if (children[0].first != "name") {
-		throw InvalidInputException("'schema' expects the first field of the struct to be called 'name'");
-	}
-	if (children[0].second.id() != LogicalTypeId::VARCHAR) {
-		throw InvalidInputException("'schema' expects the 'name' field to be of type VARCHAR, not %s",
-		                            LogicalTypeIdToString(children[0].second.id()));
-	}
-	if (children[1].first != "type") {
-		throw InvalidInputException("'schema' expects the second field of the struct to be called 'type'");
-	}
-	if (children[1].second.id() != LogicalTypeId::VARCHAR) {
-		throw InvalidInputException("'schema' expects the 'type' field to be of type VARCHAR, not %s",
-		                            LogicalTypeIdToString(children[1].second.id()));
-	}
-	if (children[2].first != "default_value") {
-		throw InvalidInputException("'schema' expects the third field of the struct to be called 'default_value'");
-	}
-	//! NOTE: default_value can be any type
-
-	if (key_type.id() != LogicalTypeId::INTEGER && key_type.id() != LogicalTypeId::VARCHAR) {
-		throw InvalidInputException(
-		    "'schema' expects the value type of the map to be either INTEGER or VARCHAR, not %s",
-		    LogicalTypeIdToString(key_type.id()));
-	}
 }
 
 static void ParquetScanSerialize(Serializer &serializer, const optional_ptr<FunctionData> bind_data_p,
@@ -681,16 +633,11 @@ bool ParquetMultiFileInfo::ParseOption(ClientContext &context, const Identifier 
 	}
 	if (key == "schema") {
 		// Argument is a map that defines the schema
-		const auto &schema_value = val;
-		VerifyParquetSchemaParameter(schema_value);
-		const auto column_values = ListValue::GetChildren(schema_value);
-		if (column_values.empty()) {
+		auto schema = ParquetColumnDefinition::FromSchemaMap(context, val);
+		if (schema.empty()) {
 			throw BinderException("Parquet schema cannot be empty");
 		}
-		options.schema.reserve(column_values.size());
-		for (idx_t i = 0; i < column_values.size(); i++) {
-			options.schema.emplace_back(ParquetColumnDefinition::FromSchemaValue(context, column_values[i]));
-		}
+		options.schema = std::move(schema);
 		file_options.auto_detect_hive_partitioning = false;
 		return true;
 	}

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1258,9 +1258,11 @@ static void VerifyParquetSchemaDefinitionType(const LogicalType &definition_type
 		                      definition_type.ToString());
 	}
 	auto &fields = StructType::GetChildTypes(definition_type);
-	if (fields.size() < 3) {
+	if (fields.size() != 3 && fields.size() != 4) {
 		throw InvalidInputException(
-		    "'schema' expects the STRUCT to have 3 children, 'name', 'type' and 'default_value'");
+		    "'schema' expects the STRUCT to have 3 or 4 fields, 'name', 'type', 'default_value' and optionally "
+		    "'children', not %d",
+		    fields.size());
 	}
 	if (fields[0].first != "name") {
 		throw InvalidInputException("'schema' expects the first field of the struct to be called 'name'");
@@ -1279,7 +1281,7 @@ static void VerifyParquetSchemaDefinitionType(const LogicalType &definition_type
 	if (fields[2].first != "default_value") {
 		throw InvalidInputException("'schema' expects the third field of the struct to be called 'default_value'");
 	}
-	if (fields.size() > 3 && fields[3].first != "children") {
+	if (fields.size() == 4 && fields[3].first != "children") {
 		throw InvalidInputException("'schema' expects the fourth field of the struct to be called 'children'");
 	}
 }

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1330,7 +1330,7 @@ static void VerifyParquetSchemaChildren(const ParquetColumnDefinition &column) {
 		break;
 	}
 	case LogicalTypeId::LIST:
-		VerifyParquetSchemaChildType(column, column.children[0], string(), ListType::GetChildType(column.type), false);
+		VerifyParquetSchemaChildType(column, column.children[0], "element", ListType::GetChildType(column.type), true);
 		break;
 	case LogicalTypeId::MAP:
 		VerifyParquetSchemaChildType(column, column.children[0], "key", MapType::KeyType(column.type), true);

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1249,13 +1249,110 @@ ParquetOptions::ParquetOptions(ClientContext &context) {
 	}
 }
 
-ParquetColumnDefinition ParquetColumnDefinition::FromSchemaValue(ClientContext &context, const Value &column_value) {
-	ParquetColumnDefinition result;
-	auto &identifier = StructValue::GetChildren(column_value)[0];
-	result.identifier = identifier;
+static void VerifyParquetSchemaDefinitionType(const LogicalType &definition_type, bool is_root) {
+	if (definition_type.id() != LogicalTypeId::STRUCT) {
+		if (is_root) {
+			throw InvalidInputException("'schema' expects a STRUCT as the value type of the map");
+		}
+		throw BinderException("Parquet schema 'children' expects a STRUCT as the value type of the map, not %s",
+		                      definition_type.ToString());
+	}
+	auto &fields = StructType::GetChildTypes(definition_type);
+	if (fields.size() < 3) {
+		throw InvalidInputException(
+		    "'schema' expects the STRUCT to have 3 children, 'name', 'type' and 'default_value'");
+	}
+	if (fields[0].first != "name") {
+		throw InvalidInputException("'schema' expects the first field of the struct to be called 'name'");
+	}
+	if (fields[0].second.id() != LogicalTypeId::VARCHAR) {
+		throw InvalidInputException("'schema' expects the 'name' field to be of type VARCHAR, not %s",
+		                            LogicalTypeIdToString(fields[0].second.id()));
+	}
+	if (fields[1].first != "type") {
+		throw InvalidInputException("'schema' expects the second field of the struct to be called 'type'");
+	}
+	if (fields[1].second.id() != LogicalTypeId::VARCHAR) {
+		throw InvalidInputException("'schema' expects the 'type' field to be of type VARCHAR, not %s",
+		                            LogicalTypeIdToString(fields[1].second.id()));
+	}
+	if (fields[2].first != "default_value") {
+		throw InvalidInputException("'schema' expects the third field of the struct to be called 'default_value'");
+	}
+	if (fields.size() > 3 && fields[3].first != "children") {
+		throw InvalidInputException("'schema' expects the fourth field of the struct to be called 'children'");
+	}
+}
 
-	const auto &column_def = StructValue::GetChildren(column_value)[1];
-	D_ASSERT(column_def.type().id() == LogicalTypeId::STRUCT);
+static void VerifyParquetSchemaChildType(const ParquetColumnDefinition &column, const ParquetColumnDefinition &child,
+                                         const string &expected_name, const LogicalType &expected_type,
+                                         bool verify_name) {
+	if (verify_name && child.name != expected_name) {
+		throw BinderException("Parquet schema column \"%s\" expects child %s to be named \"%s\", not \"%s\"",
+		                      column.name, column.type.ToString(), expected_name, child.name);
+	}
+	if (child.type != expected_type) {
+		throw BinderException("Parquet schema column \"%s\" expects child \"%s\" to have type %s, not %s", column.name,
+		                      child.name, expected_type.ToString(), child.type.ToString());
+	}
+}
+
+static void VerifyParquetSchemaChildren(const ParquetColumnDefinition &column) {
+	idx_t expected_count;
+	switch (column.type.id()) {
+	case LogicalTypeId::STRUCT:
+		expected_count = StructType::GetChildCount(column.type);
+		break;
+	case LogicalTypeId::LIST:
+		expected_count = 1;
+		break;
+	case LogicalTypeId::MAP:
+		expected_count = 2;
+		break;
+	default:
+		throw BinderException("Parquet schema column \"%s\" of type %s cannot define nested children", column.name,
+		                      column.type.ToString());
+	}
+	if (column.children.size() != expected_count) {
+		throw BinderException("Parquet schema column \"%s\" of type %s expects %d child definitions, not %d",
+		                      column.name, column.type.ToString(), expected_count, column.children.size());
+	}
+
+	switch (column.type.id()) {
+	case LogicalTypeId::STRUCT: {
+		auto &expected_children = StructType::GetChildTypes(column.type);
+		for (idx_t i = 0; i < expected_children.size(); i++) {
+			VerifyParquetSchemaChildType(column, column.children[i], expected_children[i].first.GetIdentifierName(),
+			                             expected_children[i].second, true);
+		}
+		break;
+	}
+	case LogicalTypeId::LIST:
+		VerifyParquetSchemaChildType(column, column.children[0], string(), ListType::GetChildType(column.type), false);
+		break;
+	case LogicalTypeId::MAP:
+		VerifyParquetSchemaChildType(column, column.children[0], "key", MapType::KeyType(column.type), true);
+		VerifyParquetSchemaChildType(column, column.children[1], "value", MapType::ValueType(column.type), true);
+		break;
+	default:
+		throw InternalException("Unexpected Parquet schema type with children");
+	}
+}
+
+static vector<ParquetColumnDefinition> ParseParquetSchemaMap(ClientContext &context, const Value &schema_value,
+                                                             const LogicalType &root_key_type, bool is_root);
+
+static ParquetColumnDefinition ParseParquetSchemaDefinition(ClientContext &context, const Value &column_value,
+                                                            const LogicalType &root_key_type) {
+	ParquetColumnDefinition result;
+	auto &map_entry = StructValue::GetChildren(column_value);
+	result.identifier = map_entry[0];
+
+	const auto &column_def = map_entry[1];
+	if (column_def.IsNull()) {
+		throw BinderException("Parquet schema definition cannot be NULL");
+	}
+	VerifyParquetSchemaDefinitionType(column_def.type(), false);
 
 	const auto children = StructValue::GetChildren(column_def);
 	result.name = StringValue::Get(children[0]);
@@ -1267,7 +1364,65 @@ ParquetColumnDefinition ParquetColumnDefinition::FromSchemaValue(ClientContext &
 		                      result.type.ToString());
 	}
 	result.default_value = std::move(*default_value);
+	if (children.size() > 3 && !children[3].IsNull()) {
+		result.children = ParseParquetSchemaMap(context, children[3], root_key_type, false);
+		VerifyParquetSchemaChildren(result);
+	}
 
+	return result;
+}
+
+static vector<ParquetColumnDefinition> ParseParquetSchemaMap(ClientContext &context, const Value &schema_value,
+                                                             const LogicalType &root_key_type, bool is_root) {
+	if (schema_value.type().id() != LogicalTypeId::MAP) {
+		if (is_root) {
+			throw InvalidInputException("'schema' expects a value of type MAP, not %s",
+			                            LogicalTypeIdToString(schema_value.type().id()));
+		}
+		throw BinderException("Parquet schema 'children' expects a value of type MAP, not %s",
+		                      LogicalTypeIdToString(schema_value.type().id()));
+	}
+	auto &map_type = schema_value.type();
+	auto &key_type = MapType::KeyType(map_type);
+	auto &value_type = MapType::ValueType(map_type);
+	VerifyParquetSchemaDefinitionType(value_type, is_root);
+	if (is_root) {
+		if (key_type.id() != LogicalTypeId::INTEGER && key_type.id() != LogicalTypeId::VARCHAR) {
+			throw InvalidInputException(
+			    "'schema' expects the value type of the map to be either INTEGER or VARCHAR, not %s",
+			    LogicalTypeIdToString(key_type.id()));
+		}
+	} else if (key_type != root_key_type) {
+		throw BinderException("Parquet schema 'children' key type must match the root schema key type %s, not %s",
+		                      root_key_type.ToString(), key_type.ToString());
+	}
+
+	auto &entries = ListValue::GetChildren(schema_value);
+	vector<ParquetColumnDefinition> result;
+	result.reserve(entries.size());
+	for (auto &entry : entries) {
+		result.emplace_back(ParseParquetSchemaDefinition(context, entry, root_key_type));
+	}
+	return result;
+}
+
+vector<ParquetColumnDefinition> ParquetColumnDefinition::FromSchemaMap(ClientContext &context,
+                                                                       const Value &schema_value) {
+	if (schema_value.type().id() != LogicalTypeId::MAP) {
+		throw InvalidInputException("'schema' expects a value of type MAP, not %s",
+		                            LogicalTypeIdToString(schema_value.type().id()));
+	}
+	return ParseParquetSchemaMap(context, schema_value, MapType::KeyType(schema_value.type()), true);
+}
+
+MultiFileColumnDefinition ParquetColumnDefinition::ToMultiFileColumnDefinition() const {
+	MultiFileColumnDefinition result(name, type);
+	result.identifier = identifier;
+	result.default_expression = make_uniq<ConstantExpression>(default_value);
+	result.children.reserve(children.size());
+	for (auto &child : children) {
+		result.children.emplace_back(child.ToMultiFileColumnDefinition());
+	}
 	return result;
 }
 

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1287,16 +1287,29 @@ static void VerifyParquetSchemaDefinitionType(const LogicalType &definition_type
 }
 
 static void VerifyParquetSchemaChildType(const ParquetColumnDefinition &column, const ParquetColumnDefinition &child,
-                                         const string &expected_name, const LogicalType &expected_type,
-                                         bool verify_name) {
-	if (verify_name && child.name != expected_name) {
-		throw BinderException("Parquet schema column \"%s\" expects child %s to be named \"%s\", not \"%s\"",
-		                      column.name, column.type.ToString(), expected_name, child.name);
+                                         const string &expected_name, const LogicalType &expected_type) {
+	auto &column_name = column.name;
+
+	const bool name_equivalent = child.name == expected_name;
+	const bool type_equivalent = child.type == expected_type;
+	if (name_equivalent && type_equivalent) {
+		return;
 	}
-	if (child.type != expected_type) {
-		throw BinderException("Parquet schema column \"%s\" expects child \"%s\" to have type %s, not %s", column.name,
-		                      child.name, expected_type.ToString(), child.type.ToString());
+	string error;
+	if (!name_equivalent) {
+		error = StringUtil::Format("name \"%s\" (got \"%s\")", expected_name, child.name);
 	}
+	if (!type_equivalent) {
+		const bool name_mentioned = !error.empty();
+		if (name_mentioned) {
+			error += " and ";
+		} else {
+			error += StringUtil::Format("name \"%s\" to have ", expected_name);
+		}
+		error += StringUtil::Format("type \"%s\" (got \"%s\")", expected_type.ToString(), child.type.ToString());
+	}
+
+	throw BinderException("Parquet schema column \"%s\" expects a child with %s", column_name, error);
 }
 
 static void VerifyParquetSchemaChildren(const ParquetColumnDefinition &column) {
@@ -1325,16 +1338,16 @@ static void VerifyParquetSchemaChildren(const ParquetColumnDefinition &column) {
 		auto &expected_children = StructType::GetChildTypes(column.type);
 		for (idx_t i = 0; i < expected_children.size(); i++) {
 			VerifyParquetSchemaChildType(column, column.children[i], expected_children[i].first.GetIdentifierName(),
-			                             expected_children[i].second, true);
+			                             expected_children[i].second);
 		}
 		break;
 	}
 	case LogicalTypeId::LIST:
-		VerifyParquetSchemaChildType(column, column.children[0], "element", ListType::GetChildType(column.type), true);
+		VerifyParquetSchemaChildType(column, column.children[0], "element", ListType::GetChildType(column.type));
 		break;
 	case LogicalTypeId::MAP:
-		VerifyParquetSchemaChildType(column, column.children[0], "key", MapType::KeyType(column.type), true);
-		VerifyParquetSchemaChildType(column, column.children[1], "value", MapType::ValueType(column.type), true);
+		VerifyParquetSchemaChildType(column, column.children[0], "key", MapType::KeyType(column.type));
+		VerifyParquetSchemaChildType(column, column.children[1], "value", MapType::ValueType(column.type));
 		break;
 	default:
 		throw InternalException("Unexpected Parquet schema type with children");

--- a/extension/parquet/serialize_parquet.cpp
+++ b/extension/parquet/serialize_parquet.cpp
@@ -52,6 +52,7 @@ void ParquetColumnDefinition::Serialize(Serializer &serializer) const {
 	serializer.WriteProperty<LogicalType>(103, "type", type);
 	serializer.WriteProperty<Value>(104, "default_value", default_value);
 	serializer.WritePropertyWithDefault<Value>(105, "identifier", identifier, Value());
+	serializer.WritePropertyWithDefault<vector<ParquetColumnDefinition>>(106, "children", children, vector<ParquetColumnDefinition>());
 }
 
 ParquetColumnDefinition ParquetColumnDefinition::Deserialize(Deserializer &deserializer) {
@@ -61,6 +62,7 @@ ParquetColumnDefinition ParquetColumnDefinition::Deserialize(Deserializer &deser
 	deserializer.ReadProperty<LogicalType>(103, "type", result.type);
 	deserializer.ReadProperty<Value>(104, "default_value", result.default_value);
 	deserializer.ReadPropertyWithExplicitDefault<Value>(105, "identifier", result.identifier, Value());
+	deserializer.ReadPropertyWithExplicitDefault<vector<ParquetColumnDefinition>>(106, "children", result.children, vector<ParquetColumnDefinition>());
 	return result;
 }
 

--- a/src/function/cast/variant/from_variant.cpp
+++ b/src/function/cast/variant/from_variant.cpp
@@ -512,6 +512,24 @@ static bool CastVariantToJSON(FromVariantConversionData &conversion_data, Vector
 	return true;
 }
 
+static bool CastVariantToSQLNull(FromVariantConversionData &conversion_data, Vector &result, const SelectionVector &sel,
+                                 idx_t offset, idx_t count, optional_idx row) {
+	for (idx_t i = 0; i < count; i++) {
+		auto row_index = row.IsValid() ? row.GetIndex() : i;
+		if (conversion_data.variant.RowIsValid(row_index)) {
+			auto type_id = conversion_data.variant.GetTypeId(row_index, sel[i]);
+			if (type_id != VariantLogicalType::VARIANT_NULL) {
+				auto value = VariantUtils::ConvertVariantToValue(conversion_data.variant, row_index, sel[i]);
+				conversion_data.error = StringUtil::Format("Can't convert VARIANT(%s) value '%s'",
+				                                           EnumUtil::ToString(type_id), value.ToString());
+				return false;
+			}
+		}
+		FlatVector::SetNull(result, offset + i, true);
+	}
+	return true;
+}
+
 //! * @param conversion_data The constant data relevant at all rows of the conversion
 //! * @param result The typed Vector to populate in this call
 //! * @param sel The selection of value indices to cast
@@ -593,6 +611,8 @@ static bool CastVariant(FromVariantConversionData &conversion_data, Vector &resu
 	} else {
 		EmptyConversionPayloadFromVariant empty_payload;
 		switch (target_type.id()) {
+		case LogicalTypeId::SQLNULL:
+			return CastVariantToSQLNull(conversion_data, result, sel, offset, count, row);
 		case LogicalTypeId::BOOLEAN:
 			return CastVariantToPrimitive<VariantBooleanConversion>(conversion_data, result, sel, offset, count, row,
 			                                                        empty_payload);

--- a/src/function/cast/variant/from_variant.cpp
+++ b/src/function/cast/variant/from_variant.cpp
@@ -512,24 +512,6 @@ static bool CastVariantToJSON(FromVariantConversionData &conversion_data, Vector
 	return true;
 }
 
-static bool CastVariantToSQLNull(FromVariantConversionData &conversion_data, Vector &result, const SelectionVector &sel,
-                                 idx_t offset, idx_t count, optional_idx row) {
-	for (idx_t i = 0; i < count; i++) {
-		auto row_index = row.IsValid() ? row.GetIndex() : i;
-		if (conversion_data.variant.RowIsValid(row_index)) {
-			auto type_id = conversion_data.variant.GetTypeId(row_index, sel[i]);
-			if (type_id != VariantLogicalType::VARIANT_NULL) {
-				auto value = VariantUtils::ConvertVariantToValue(conversion_data.variant, row_index, sel[i]);
-				conversion_data.error = StringUtil::Format("Can't convert VARIANT(%s) value '%s'",
-				                                           EnumUtil::ToString(type_id), value.ToString());
-				return false;
-			}
-		}
-		FlatVector::SetNull(result, offset + i, true);
-	}
-	return true;
-}
-
 //! * @param conversion_data The constant data relevant at all rows of the conversion
 //! * @param result The typed Vector to populate in this call
 //! * @param sel The selection of value indices to cast
@@ -611,8 +593,6 @@ static bool CastVariant(FromVariantConversionData &conversion_data, Vector &resu
 	} else {
 		EmptyConversionPayloadFromVariant empty_payload;
 		switch (target_type.id()) {
-		case LogicalTypeId::SQLNULL:
-			return CastVariantToSQLNull(conversion_data, result, sel, offset, count, row);
 		case LogicalTypeId::BOOLEAN:
 			return CastVariantToPrimitive<VariantBooleanConversion>(conversion_data, result, sel, offset, count, row,
 			                                                        empty_payload);

--- a/test/configs/variant_vector.json
+++ b/test/configs/variant_vector.json
@@ -10,6 +10,12 @@
 				"test/sql/types/type/test_make_get_type.test",
 				"test/parquet/constant_dictionary_vector_parquet.test_slow"
 			]
+		},
+		{
+			"reason": "Roundtrip is not possible (MAP type)",
+			"paths": [
+				"test/parquet/test_parquet_schema.test"
+			]
 		}
 	]
 }

--- a/test/parquet/test_parquet_schema.test
+++ b/test/parquet/test_parquet_schema.test
@@ -617,3 +617,37 @@ SELECT * FROM read_parquet(
 )
 ----
 Binder Error: Parquet schema column "i" of type BIGINT cannot define nested children
+
+# schema definitions have exactly three fields, or four when children is present
+statement error
+SELECT * FROM read_parquet(
+	'{TEMP_DIR}/nested_schema.parquet',
+	schema=map {
+		'i': {name: 'i', type: 'BIGINT', default_value: NULL, children: NULL, extra_field: 42}
+	}
+)
+----
+Invalid Input Error: 'schema' expects the STRUCT to have 3 or 4 fields, 'name', 'type', 'default_value' and optionally 'children', not 5
+
+statement error
+SELECT * FROM read_parquet(
+	'{TEMP_DIR}/nested_schema.parquet',
+	schema=map {
+		's': {
+			name: 's',
+			type: 'STRUCT("inner" STRUCT(source_x BIGINT))',
+			default_value: NULL,
+			children: map {
+				'inner': {
+					name: 'inner',
+					type: 'STRUCT(source_x BIGINT)',
+					default_value: NULL,
+					children: NULL,
+					extra_field: 42
+				}
+			}
+		}
+	}
+)
+----
+Invalid Input Error: 'schema' expects the STRUCT to have 3 or 4 fields, 'name', 'type', 'default_value' and optionally 'children', not 5

--- a/test/parquet/test_parquet_schema.test
+++ b/test/parquet/test_parquet_schema.test
@@ -605,6 +605,40 @@ statement error
 SELECT * FROM read_parquet(
 	'{TEMP_DIR}/nested_schema.parquet',
 	schema=map {
+		'l': {
+			name: 'l',
+			type: 'STRUCT(y BIGINT)[]',
+			default_value: NULL,
+			children: map {
+				'list': {name: 'item', type: 'STRUCT(y BIGINT)', default_value: NULL}
+			}
+		}
+	}
+)
+----
+Binder Error: Parquet schema column "l" expects child STRUCT(y BIGINT)[] to be named "element", not "item"
+
+query I
+SELECT * FROM read_parquet(
+	'{TEMP_DIR}/nested_schema.parquet',
+	schema=map {
+		'l': {
+			name: 'l',
+			type: 'STRUCT(y BIGINT)[]',
+			default_value: NULL,
+			children: map {
+				'list': {name: 'element', type: 'STRUCT(y BIGINT)', default_value: NULL}
+			}
+		}
+	}
+)
+----
+[{'y': 100}]
+
+statement error
+SELECT * FROM read_parquet(
+	'{TEMP_DIR}/nested_schema.parquet',
+	schema=map {
 		'i': {
 			name: 'i',
 			type: 'BIGINT',

--- a/test/parquet/test_parquet_schema.test
+++ b/test/parquet/test_parquet_schema.test
@@ -355,3 +355,265 @@ from read_parquet(
 	},
 	filename=True
 ) where x = 1;
+
+# nested child schemas use the same typed MAP shape recursively
+statement ok
+COPY (
+	SELECT
+		7::INTEGER AS i,
+		struct_pack(inner := struct_pack(source_x := 42::INTEGER)) AS s,
+		[struct_pack(y := 100::INTEGER)] AS l,
+		MAP([10::INTEGER], [struct_pack(z := 200::INTEGER)]) AS m
+) TO '{TEMP_DIR}/nested_schema.parquet'
+
+query IIIIII
+SELECT i, s.inner.missing, s.inner.renamed_x, l[1].y, m[10].z, root_missing
+FROM read_parquet(
+	'{TEMP_DIR}/nested_schema.parquet',
+	schema=map {
+		'i': {name: 'i', type: 'BIGINT', default_value: NULL},
+		's': {
+			name: 's',
+			type: 'STRUCT("inner" STRUCT(missing BIGINT, renamed_x BIGINT))',
+			default_value: NULL,
+			children: map {
+				'inner': {
+					name: 'inner',
+					type: 'STRUCT(missing BIGINT, renamed_x BIGINT)',
+					default_value: NULL,
+					children: map {
+						'missing': {name: 'missing', type: 'BIGINT', default_value: '9'},
+						'source_x': {name: 'renamed_x', type: 'BIGINT', default_value: NULL}
+					}
+				}
+			}
+		},
+		'l': {
+			name: 'l',
+			type: 'STRUCT(y BIGINT)[]',
+			default_value: NULL,
+			children: map {
+				'list': {
+					name: 'element',
+					type: 'STRUCT(y BIGINT)',
+					default_value: NULL,
+					children: map {
+						'y': {name: 'y', type: 'BIGINT', default_value: NULL}
+					}
+				}
+			}
+		},
+		'm': {
+			name: 'm',
+			type: 'MAP(BIGINT, STRUCT(z BIGINT))',
+			default_value: NULL,
+			children: map {
+				'key': {name: 'key', type: 'BIGINT', default_value: NULL},
+				'value': {
+					name: 'value',
+					type: 'STRUCT(z BIGINT)',
+					default_value: NULL,
+					children: map {
+						'z': {name: 'z', type: 'BIGINT', default_value: NULL}
+					}
+				}
+			}
+		},
+		'root_missing': {name: 'root_missing', type: 'BIGINT', default_value: '11'}
+	}
+)
+----
+7	9	42	100	200	11
+
+# nested projection pushdown preserves the recursive mapping
+query I
+SELECT s.inner.renamed_x
+FROM read_parquet(
+	'{TEMP_DIR}/nested_schema.parquet',
+	schema=map {
+		's': {
+			name: 's',
+			type: 'STRUCT("inner" STRUCT(renamed_x BIGINT))',
+			default_value: NULL,
+			children: map {
+				'inner': {
+					name: 'inner',
+					type: 'STRUCT(renamed_x BIGINT)',
+					default_value: NULL,
+					children: map {
+						'source_x': {name: 'renamed_x', type: 'BIGINT', default_value: NULL}
+					}
+				}
+			}
+		}
+	}
+)
+----
+42
+
+# integer identifiers are supported recursively
+statement ok
+COPY (
+	SELECT struct_pack(f := 42::INTEGER) AS s
+) TO '{TEMP_DIR}/nested_field_ids.parquet' (
+	FIELD_IDS {s: {__duckdb_field_id: 10, f: 11}}
+)
+
+query I
+SELECT s.f
+FROM read_parquet(
+	'{TEMP_DIR}/nested_field_ids.parquet',
+	schema=map {
+		10: {
+			name: 's',
+			type: 'STRUCT(f BIGINT)',
+			default_value: NULL,
+			children: map {
+				11: {name: 'f', type: 'BIGINT', default_value: NULL}
+			}
+		}
+	}
+)
+----
+42
+
+# children may be omitted or explicitly NULL
+query II
+SELECT s.inner.source_x, i
+FROM read_parquet(
+	'{TEMP_DIR}/nested_schema.parquet',
+	schema=map {
+		's': {name: 's', type: 'STRUCT("inner" STRUCT(source_x BIGINT))', default_value: NULL, children: NULL},
+		'i': {name: 'i', type: 'BIGINT', default_value: NULL}
+	}
+)
+----
+42	7
+
+# every child map must use the root map's exact key type
+statement error
+SELECT * FROM read_parquet(
+	'{TEMP_DIR}/nested_schema.parquet',
+	schema=map {
+		's': {
+			name: 's',
+			type: 'STRUCT("inner" STRUCT(source_x BIGINT))',
+			default_value: NULL,
+			children: map {
+				1: {name: 'inner', type: 'STRUCT(source_x BIGINT)', default_value: NULL}
+			}
+		}
+	}
+)
+----
+Binder Error: Parquet schema 'children' key type must match the root schema key type VARCHAR, not INTEGER
+
+statement error
+SELECT * FROM read_parquet(
+	'{TEMP_DIR}/nested_field_ids.parquet',
+	schema=map {
+		10: {
+			name: 's',
+			type: 'STRUCT(f BIGINT)',
+			default_value: NULL,
+			children: map {
+				'11': {name: 'f', type: 'BIGINT', default_value: NULL}
+			}
+		}
+	}
+)
+----
+Binder Error: Parquet schema 'children' key type must match the root schema key type INTEGER, not VARCHAR
+
+# children must themselves be schema maps
+statement error
+SELECT * FROM read_parquet(
+	'{TEMP_DIR}/nested_schema.parquet',
+	schema=map {
+		's': {name: 's', type: 'STRUCT("inner" STRUCT(source_x BIGINT))', default_value: NULL, children: {}}
+	}
+)
+----
+Binder Error: Parquet schema 'children' expects a value of type MAP, not STRUCT
+
+statement error
+SELECT * FROM read_parquet(
+	'{TEMP_DIR}/nested_schema.parquet',
+	schema=map {
+		's': {
+			name: 's',
+			type: 'STRUCT("inner" STRUCT(source_x BIGINT))',
+			default_value: NULL,
+			children: map {'inner': 42}
+		}
+	}
+)
+----
+Binder Error: Parquet schema 'children' expects a STRUCT as the value type of the map, not INTEGER
+
+# explicitly supplied children must agree with the declared parent type
+statement error
+SELECT * FROM read_parquet(
+	'{TEMP_DIR}/nested_schema.parquet',
+	schema=map {
+		's': {
+			name: 's',
+			type: 'STRUCT("inner" STRUCT(source_x BIGINT))',
+			default_value: NULL,
+			children: map {}
+		}
+	}::MAP(VARCHAR, STRUCT(name VARCHAR, type VARCHAR, default_value VARCHAR, children MAP(VARCHAR, STRUCT(name VARCHAR, type VARCHAR, default_value VARCHAR))))
+)
+----
+Binder Error: Parquet schema column "s" of type STRUCT("inner" STRUCT(source_x BIGINT)) expects 1 child definitions, not 0
+
+statement error
+SELECT * FROM read_parquet(
+	'{TEMP_DIR}/nested_schema.parquet',
+	schema=map {
+		's': {
+			name: 's',
+			type: 'STRUCT(expected BIGINT)',
+			default_value: NULL,
+			children: map {
+				'source_x': {name: 'different', type: 'BIGINT', default_value: NULL}
+			}
+		}
+	}
+)
+----
+Binder Error: Parquet schema column "s" expects child STRUCT(expected BIGINT) to be named "expected", not "different"
+
+statement error
+SELECT * FROM read_parquet(
+	'{TEMP_DIR}/nested_schema.parquet',
+	schema=map {
+		's': {
+			name: 's',
+			type: 'STRUCT(expected BIGINT)',
+			default_value: NULL,
+			children: map {
+				'expected': {name: 'expected', type: 'VARCHAR', default_value: NULL}
+			}
+		}
+	}
+)
+----
+Binder Error: Parquet schema column "s" expects child "expected" to have type BIGINT, not VARCHAR
+
+statement error
+SELECT * FROM read_parquet(
+	'{TEMP_DIR}/nested_schema.parquet',
+	schema=map {
+		'i': {
+			name: 'i',
+			type: 'BIGINT',
+			default_value: NULL,
+			children: map {
+				'i': {name: 'i', type: 'BIGINT', default_value: NULL}
+			}
+		}
+	}
+)
+----
+Binder Error: Parquet schema column "i" of type BIGINT cannot define nested children

--- a/test/parquet/test_parquet_schema.test
+++ b/test/parquet/test_parquet_schema.test
@@ -582,7 +582,7 @@ SELECT * FROM read_parquet(
 	}
 )
 ----
-Binder Error: Parquet schema column "s" expects child STRUCT(expected BIGINT) to be named "expected", not "different"
+Binder Error: Parquet schema column "s" expects a child with name "expected" (got "different")
 
 statement error
 SELECT * FROM read_parquet(
@@ -599,7 +599,7 @@ SELECT * FROM read_parquet(
 	}
 )
 ----
-Binder Error: Parquet schema column "s" expects child "expected" to have type BIGINT, not VARCHAR
+Binder Error: Parquet schema column "s" expects a child with name "expected" to have type "BIGINT" (got "VARCHAR")
 
 statement error
 SELECT * FROM read_parquet(
@@ -616,7 +616,7 @@ SELECT * FROM read_parquet(
 	}
 )
 ----
-Binder Error: Parquet schema column "l" expects child STRUCT(y BIGINT)[] to be named "element", not "item"
+Binder Error: Parquet schema column "l" expects a child with name "element" (got "item")
 
 query I
 SELECT * FROM read_parquet(


### PR DESCRIPTION
This PR supersedes https://github.com/duckdb/duckdb/pull/24407

Intention is the same: this should make it easier to test the MultiFileReader's mapping ability, without requiring going through an extension like iceberg, delta, ducklake