### PR TITLE
Fix mixed path separators for extension/loader in amalgamation

### DIFF
--- a/scripts/amalgamation.py
+++ b/scripts/amalgamation.py
@@ -7,7 +7,7 @@ from python_helpers import open_utf8, normalize_path
 import shutil
 
 src_dir = 'src'
-compile_directories = [src_dir] + package_build.third_party_sources() + ['extension/loader']
+compile_directories = [src_dir] + package_build.third_party_sources() + [normalize_path('extension/loader')]
 include_dir = os.path.join(src_dir, 'include')
 include_paths = [include_dir] + package_build.third_party_includes()
 excluded_files = ['grammar.cpp', 'grammar.hpp', 'symbols.cpp']


### PR DESCRIPTION
'extension/loader' is the only `compile_directories` entry not built with `os.path.join`, so on Windows it yields mixed paths that `build_package()` cannot split into parent directories. The fix: route it through `normalize_path()`.

This is one of the Windows bugs I found and hotfixed while working on https://github.com/duckdb/duckdb-rs/pull/831