### PR TITLE
Fix mixed path separators for extension/loader in amalgamation (v1.5 backport)

### DIFF
--- a/scripts/amalgamation.py
+++ b/scripts/amalgamation.py
@@ -91,7 +91,7 @@ import package_build
 # include paths for where to search for include files during amalgamation
 include_paths = [include_dir] + package_build.third_party_includes()
 # paths of where to look for files to compile and include to the final amalgamation
-compile_directories = [src_dir] + package_build.third_party_sources() + ['extension/loader']
+compile_directories = [src_dir] + package_build.third_party_sources() + [normalize_path('extension/loader')]
 
 # files always excluded
 always_excluded = normalize_path(


### PR DESCRIPTION
'extension/loader' is the only `compile_directories` entry not built with `os.path.join`, so on Windows it yields mixed paths that `build_package()` cannot split into parent directories. The fix: route it through `normalize_path()`.

This is one of the Windows bugs I found and hotfixed while working on https://github.com/duckdb/duckdb-rs/pull/831

Backport of https://github.com/duckdb/duckdb/pull/25025 to v1.5.