### PR TITLE
Allow integral types in variant_extract via cast to UINTEGER

### DIFF
--- a/src/function/scalar/variant/variant_extract.cpp
+++ b/src/function/scalar/variant/variant_extract.cpp
@@ -60,9 +60,8 @@ static unique_ptr<FunctionData> VariantExtractBind(BindScalarFunctionInput &inpu
 		throw BinderException("'variant_extract' expects two arguments, VARIANT column and VARCHAR path");
 	}
 	const auto &path = *arguments[1];
-	if (path.GetReturnType().id() != LogicalTypeId::VARCHAR && path.GetReturnType().id() != LogicalTypeId::UINTEGER &&
-	    !path.GetReturnType().IsIntegral()) {
-		throw BinderException("'variant_extract' expects the second argument to be of type VARCHAR or UINTEGER, not %s",
+	if (path.GetReturnType().id() != LogicalTypeId::VARCHAR && !path.GetReturnType().IsIntegral()) {
+		throw BinderException("'variant_extract' expects the second argument to be of type VARCHAR or any integer type, not %s",
 		                      path.GetReturnType().ToString());
 	}
 
@@ -73,7 +72,7 @@ static unique_ptr<FunctionData> VariantExtractBind(BindScalarFunctionInput &inpu
 	} else if (constant_arg.type().IsIntegral()) {
 		return make_uniq<VariantExtractBindData>(constant_arg.GetValue<uint32_t>());
 	} else {
-		throw InternalException("Constant-folded argument was not of type UINTEGER or VARCHAR");
+		throw InternalException("Constant-folded argument was not of type VARCHAR or any integer type");
 	}
 }
 

--- a/src/function/scalar/variant/variant_extract.cpp
+++ b/src/function/scalar/variant/variant_extract.cpp
@@ -61,22 +61,17 @@ static unique_ptr<FunctionData> VariantExtractBind(BindScalarFunctionInput &inpu
 		throw BinderException("'variant_extract' expects two arguments, VARIANT column and VARCHAR path");
 	}
 	const auto &path = *arguments[1];
-	if (path.GetReturnType().id() != LogicalTypeId::VARCHAR && path.GetReturnType().id() != LogicalTypeId::UINTEGER) {
-		// Accept any integer-ish literal by casting it to UINTEGER explicitly
-		if (path.GetReturnType().IsIntegral()) {
-			arguments[1] = BoundCastExpression::AddCastToType(input.GetClientContext(), std::move(arguments[1]), LogicalType::UINTEGER);
-		}
-		else {
-			throw BinderException("'variant_extract' expects the second argument to be of type VARCHAR or UINTEGER, not %s",
-								  path.GetReturnType().ToString());
-		}
+	if (path.GetReturnType().id() != LogicalTypeId::VARCHAR && path.GetReturnType().id() != LogicalTypeId::UINTEGER &&
+	    !path.GetReturnType().IsIntegral()) {
+		throw BinderException("'variant_extract' expects the second argument to be of type VARCHAR or UINTEGER, not %s",
+		                      path.GetReturnType().ToString());
 	}
 
 	auto constant_arg = input.GetNonNullConstant(1);
 
 	if (constant_arg.type().id() == LogicalTypeId::VARCHAR) {
 		return make_uniq<VariantExtractBindData>(constant_arg.GetValue<string>());
-	} else if (constant_arg.type().id() == LogicalTypeId::UINTEGER) {
+	} else if (constant_arg.type().IsIntegral()) {
 		return make_uniq<VariantExtractBindData>(constant_arg.GetValue<uint32_t>());
 	} else {
 		throw InternalException("Constant-folded argument was not of type UINTEGER or VARCHAR");

--- a/src/function/scalar/variant/variant_extract.cpp
+++ b/src/function/scalar/variant/variant_extract.cpp
@@ -61,8 +61,9 @@ static unique_ptr<FunctionData> VariantExtractBind(BindScalarFunctionInput &inpu
 	}
 	const auto &path = *arguments[1];
 	if (path.GetReturnType().id() != LogicalTypeId::VARCHAR && !path.GetReturnType().IsIntegral()) {
-		throw BinderException("'variant_extract' expects the second argument to be of type VARCHAR or any integer type, not %s",
-		                      path.GetReturnType().ToString());
+		throw BinderException(
+		    "'variant_extract' expects the second argument to be of type VARCHAR or any integer type, not %s",
+		    path.GetReturnType().ToString());
 	}
 
 	auto constant_arg = input.GetNonNullConstant(1);

--- a/src/function/scalar/variant/variant_extract.cpp
+++ b/src/function/scalar/variant/variant_extract.cpp
@@ -9,7 +9,6 @@
 #include "duckdb/function/scalar/variant_functions.hpp"
 #include "duckdb/function/scalar/regexp.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
-#include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/storage/statistics/struct_stats.hpp"
 
 namespace duckdb {

--- a/src/function/scalar/variant/variant_extract.cpp
+++ b/src/function/scalar/variant/variant_extract.cpp
@@ -9,6 +9,7 @@
 #include "duckdb/function/scalar/variant_functions.hpp"
 #include "duckdb/function/scalar/regexp.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/storage/statistics/struct_stats.hpp"
 
 namespace duckdb {
@@ -61,8 +62,14 @@ static unique_ptr<FunctionData> VariantExtractBind(BindScalarFunctionInput &inpu
 	}
 	const auto &path = *arguments[1];
 	if (path.GetReturnType().id() != LogicalTypeId::VARCHAR && path.GetReturnType().id() != LogicalTypeId::UINTEGER) {
-		throw BinderException("'variant_extract' expects the second argument to be of type VARCHAR or UINTEGER, not %s",
-		                      path.GetReturnType().ToString());
+		// Accept any integer-ish literal by casting it to UINTEGER explicitly
+		if (path.GetReturnType().IsIntegral()) {
+			arguments[1] = BoundCastExpression::AddCastToType(input.GetClientContext(), std::move(arguments[1]), LogicalType::UINTEGER);
+		}
+		else {
+			throw BinderException("'variant_extract' expects the second argument to be of type VARCHAR or UINTEGER, not %s",
+								  path.GetReturnType().ToString());
+		}
 	}
 
 	auto constant_arg = input.GetNonNullConstant(1);

--- a/test/sql/function/variant/variant_extract.test
+++ b/test/sql/function/variant/variant_extract.test
@@ -97,3 +97,38 @@ query I
 SELECT variant_extract((SELECT list(i) FROM range(500) t(i))::VARIANT, 300::UINTEGER)::BIGINT;
 ----
 299
+
+query I
+SELECT variant_extract( ['A','B']::variant, 1)
+----
+A
+
+query I
+SELECT variant_extract( ['A','B']::variant, 1::UINTEGER)
+----
+A
+
+statement error
+SELECT variant_extract( ['A','B']::variant, 0)
+----
+indexes are 1-based
+
+statement error
+SELECT variant_extract( ['A','B']::variant, 4294967296::UINTEGER)
+----
+Conversion Error
+
+statement error
+SELECT variant_extract( ['A','B']::variant, 4294967296)
+----
+No function matches
+
+statement error
+SELECT variant_extract( ['A','B']::variant, 4294967296::UINTEGER)
+----
+Conversion Error
+
+statement error
+SELECT variant_extract( ['A','B']::variant, -1)
+----
+No function matches


### PR DESCRIPTION
Fixes #24941

Calling `variant_extract( variant_value, integer_literal)` with non `UINTEGER` but valid `INTEGER` second argument previously threw `Binder Error`.

Fix extends support for integral logical types (`LogicalType::IsIntegral()`) by inserting an explicit cast to `UINTEGER`. All range validation is handled by existing logic.

Tests check support for various second argument values:
- Trivial case: 1
- Valid bound UINTMIN: 0 
- Invalid bound UINTMAX+1: 4294967296
- Invalid bound: -1
