### PR TITLE
FinalizeScan() for MultiFileReader

### DIFF
--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -63,6 +63,11 @@ struct MultiFileReaderInterface {
 	                                                const MultiFileOptions &file_options);
 	virtual void FinishReading(ClientContext &context, GlobalTableFunctionState &global_state,
 	                           LocalTableFunctionState &local_state);
+	//! Emit one chunk after every file has been read. Implementations must sync inside this function so
+	//! chunk is produced once per scan
+	virtual bool FinalizeScan(ClientContext &context, GlobalTableFunctionState &global_state, DataChunk &output) {
+		return false;
+	}
 	virtual unique_ptr<NodeStatistics> GetCardinality(const MultiFileBindData &bind_data, idx_t file_count) {
 		return nullptr;
 	}
@@ -863,6 +868,13 @@ public:
 
 	static void MultiFileScan(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
 		if (!data_p.local_state) {
+			auto &gstate = data_p.global_state->Cast<MultiFileGlobalState>();
+			auto &bind_data = data_p.bind_data->CastNoConst<MultiFileBindData>();
+			if (gstate.global_state && bind_data.interface &&
+			    bind_data.interface->FinalizeScan(context, *gstate.global_state, output)) {
+				data_p.async_result = SourceResultType::HAVE_MORE_OUTPUT;
+				return;
+			}
 			data_p.async_result = SourceResultType::FINISHED;
 			return;
 		}
@@ -879,6 +891,10 @@ public:
 				case ScanReadAheadAcquire::PARKED:
 					return;
 				case ScanReadAheadAcquire::EXHAUSTED:
+					if (bind_data.interface->FinalizeScan(context, *gstate.global_state, output)) {
+						data_p.async_result = SourceResultType::HAVE_MORE_OUTPUT;
+						return;
+					}
 					data_p.async_result = SourceResultType::FINISHED;
 					return;
 				case ScanReadAheadAcquire::ACQUIRED:


### PR DESCRIPTION
MultiFileReader lacks a method which would allow to populate another DataChunk after all scanning is finished (for example, custom aggregation machinery needs to write final rows after processing threads exit).