### PR TITLE
[Dev] Fix unity build + remove third-party include from public-facing header

### DIFF
--- a/src/include/duckdb/function/function.hpp
+++ b/src/include/duckdb/function/function.hpp
@@ -17,7 +17,6 @@
 #include "duckdb/common/optional_idx.hpp"
 #include "duckdb/common/optional.hpp"
 #include "duckdb/common/optional_ptr.hpp"
-#include "fmt/core.h"
 
 namespace duckdb {
 class CatalogEntry;

--- a/test/optimizer/remove_unused_columns.cpp
+++ b/test/optimizer/remove_unused_columns.cpp
@@ -2,6 +2,7 @@
 
 #include "duckdb/execution/column_binding_resolver.hpp"
 #include "duckdb/main/connection.hpp"
+#include "duckdb/main/database.hpp"
 #include "duckdb/optimizer/optimizer.hpp"
 #include "duckdb/optimizer/remove_unused_columns.hpp"
 #include "duckdb/parser/parser.hpp"


### PR DESCRIPTION
This PR should fix https://github.com/duckdb/duckdb/issues/23256

Also included a fix for a test that was missing an include, which was causing `DISABLE_UNITY=1 make` to fail