### PR TITLE
Fix foreign key side effects in `CREATE TABLE IF NOT EXISTS`

### DIFF
--- a/src/catalog/catalog_entry/duck_schema_entry.cpp
+++ b/src/catalog/catalog_entry/duck_schema_entry.cpp
@@ -187,27 +187,13 @@ optional_ptr<CatalogEntry> DuckSchemaEntry::AddEntryInternal(CatalogTransaction 
 }
 
 optional_ptr<CatalogEntry> DuckSchemaEntry::CreateTable(CatalogTransaction transaction, BoundCreateTableInfo &info) {
-	// Check table existence before modifying the catalog.
-	auto &base = info.Base();
-	if (base.on_conflict == OnCreateConflict::IGNORE_ON_CONFLICT) {
-		auto &set = GetCatalogSet(CatalogType::TABLE_ENTRY);
-		if (set.GetEntry(transaction, base.GetTableName())) {
-			return nullptr;
-		}
-	}
-
 	auto table = make_uniq<DuckTableEntry>(catalog, *this, info);
-	auto &dependencies = base.dependencies;
+	auto &dependencies = info.Base().dependencies;
 
-	// add a foreign key constraint in main key table if there is a foreign key constraint
 	vector<unique_ptr<AlterForeignKeyInfo>> fk_arrays;
 	FindForeignKeyInformation(*table, AlterForeignKeyType::AFT_ADD, fk_arrays);
 	for (idx_t i = 0; i < fk_arrays.size(); i++) {
-		// alter primary key table
 		auto &fk_info = *fk_arrays[i];
-		Alter(transaction, fk_info);
-
-		// make a dependency between this table and referenced table
 		auto &set = GetCatalogSet(CatalogType::TABLE_ENTRY);
 		dependencies.AddDependency(*set.GetEntry(transaction, fk_info.GetQualifiedName().Name()));
 	}
@@ -215,9 +201,14 @@ optional_ptr<CatalogEntry> DuckSchemaEntry::CreateTable(CatalogTransaction trans
 		table->dependencies.AddDependency(dep);
 	}
 
-	auto entry = AddEntryInternal(transaction, std::move(table), base.on_conflict, dependencies);
+	auto entry = AddEntryInternal(transaction, std::move(table), info.Base().on_conflict, dependencies);
 	if (!entry) {
 		return nullptr;
+	}
+
+	// add a foreign key constraint in main key table if there is a foreign key constraint
+	for (auto &fk_info : fk_arrays) {
+		Alter(transaction, *fk_info);
 	}
 
 	return entry;

--- a/src/catalog/catalog_entry/duck_schema_entry.cpp
+++ b/src/catalog/catalog_entry/duck_schema_entry.cpp
@@ -187,8 +187,17 @@ optional_ptr<CatalogEntry> DuckSchemaEntry::AddEntryInternal(CatalogTransaction 
 }
 
 optional_ptr<CatalogEntry> DuckSchemaEntry::CreateTable(CatalogTransaction transaction, BoundCreateTableInfo &info) {
+	// Check table existence before modifying the catalog.
+	auto &base = info.Base();
+	if (base.on_conflict == OnCreateConflict::IGNORE_ON_CONFLICT) {
+		auto &set = GetCatalogSet(CatalogType::TABLE_ENTRY);
+		if (set.GetEntry(transaction, base.GetTableName())) {
+			return nullptr;
+		}
+	}
+
 	auto table = make_uniq<DuckTableEntry>(catalog, *this, info);
-	auto &dependencies = info.Base().dependencies;
+	auto &dependencies = base.dependencies;
 
 	// add a foreign key constraint in main key table if there is a foreign key constraint
 	vector<unique_ptr<AlterForeignKeyInfo>> fk_arrays;
@@ -206,7 +215,7 @@ optional_ptr<CatalogEntry> DuckSchemaEntry::CreateTable(CatalogTransaction trans
 		table->dependencies.AddDependency(dep);
 	}
 
-	auto entry = AddEntryInternal(transaction, std::move(table), info.Base().on_conflict, dependencies);
+	auto entry = AddEntryInternal(transaction, std::move(table), base.on_conflict, dependencies);
 	if (!entry) {
 		return nullptr;
 	}

--- a/test/issues/general/issue_25015.test
+++ b/test/issues/general/issue_25015.test
@@ -1,0 +1,18 @@
+# name: test/issues/general/issue_25015.test
+# description: Issue #25015: CREATE TABLE IF NOT EXISTS must not add foreign key metadata
+# group: [issues]
+
+statement ok
+CREATE TABLE parent(i INTEGER PRIMARY KEY);
+
+statement ok
+CREATE TABLE child(i INTEGER);
+
+statement ok
+INSERT INTO parent VALUES (1);
+
+statement ok
+CREATE TABLE IF NOT EXISTS child(i INTEGER REFERENCES parent);
+
+statement ok
+UPDATE parent SET i = i;

--- a/test/issues/general/issue_25015.test
+++ b/test/issues/general/issue_25015.test
@@ -1,6 +1,6 @@
 # name: test/issues/general/issue_25015.test
 # description: Issue #25015: CREATE TABLE IF NOT EXISTS must not add foreign key metadata
-# group: [issues]
+# group: [general]
 
 statement ok
 CREATE TABLE parent(i INTEGER PRIMARY KEY);


### PR DESCRIPTION
Closes https://github.com/duckdb/duckdb/issues/25015

The issue is, when we create a table, before we "return early" because the table already exists, we make updates to parent table; the proposed fix in this PR is straightforward, just to check existence before we make any updates.

The function call chain looks below, should be straightforward 
```sh
PhysicalCreateTable::GetDataInternal
└─ Catalog::CreateTable
   └─ DuckSchemaEntry::CreateTable(child)
      ├─ FindForeignKeyInformation(child)
      ├─ DuckSchemaEntry::Alter(parent, AFT_ADD)
      │  └─ CatalogSet::AlterEntry(parent)
      │     └─ DuckTableEntry::AlterEntry
      │        └─ DuckTableEntry::AddForeignKeyConstraint
      │           ├─ Add FK_TYPE_PRIMARY_KEY_TABLE metadata to parent
      │           └─ Create a new DuckTableEntry sharing the existing storage  <-- parent table FK created already
      │     └─ CatalogSet::map.UpdateEntry(parent)
      │
      └─ AddEntryInternal(child, IGNORE_ON_CONFLICT)  <-- return due to already existence table entries
         └─ CatalogSet::GetEntry(child)
            └─ child already exists → return nullptr
```