### PR TITLE
Automatically register extensions to avoid an undefined reference when linking

### DIFF
--- a/extension/CMakeLists.txt
+++ b/extension/CMakeLists.txt
@@ -1,5 +1,5 @@
-# To link extensions into DuckDB and auto-load them on startup, we generated an
-# include file and a loader function based on the `DUCKDB_EXTENSION_NAMES`
+# To link extensions into DuckDB and auto-load them on startup, we generate an
+# include file and a registrar object based on the `DUCKDB_EXTENSION_NAMES`
 # parameter.
 
 # generated_extension_headers.hpp we first write into a 'candidate' file and
@@ -120,14 +120,19 @@ endif()
 set(GENERATED_CPP_FILE
     ${PROJECT_BINARY_DIR}/codegen/src/generated_extension_loader.cpp)
 configure_file(generated_extension_loader.cpp.in "${GENERATED_CPP_FILE}")
-add_library(duckdb_generated_extension_loader STATIC ${GENERATED_CPP_FILE})
-
-set(ALL_OBJECT_FILES
-    ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_generated_extension_loader>
-    PARENT_SCOPE)
+add_library(duckdb_generated_extension_loader_object OBJECT
+            ${GENERATED_CPP_FILE})
+add_library(duckdb_generated_extension_loader STATIC
+            $<TARGET_OBJECTS:duckdb_generated_extension_loader_object>)
+# Keep the archive while forcing its registrar object into CMake consumers.
+target_sources(
+  duckdb_generated_extension_loader
+  INTERFACE $<TARGET_OBJECTS:duckdb_generated_extension_loader_object>)
 
 install(
   TARGETS duckdb_generated_extension_loader
+          duckdb_generated_extension_loader_object
   EXPORT "${DUCKDB_EXPORT_SET}"
   LIBRARY DESTINATION "${INSTALL_LIB_DIR}"
-  ARCHIVE DESTINATION "${INSTALL_LIB_DIR}")
+  ARCHIVE DESTINATION "${INSTALL_LIB_DIR}"
+  OBJECTS DESTINATION "${INSTALL_LIB_DIR}")

--- a/extension/extension_build_tools.cmake
+++ b/extension/extension_build_tools.cmake
@@ -156,19 +156,19 @@ function(build_loadable_extension_directory NAME ABI_TYPE OUTPUT_DIRECTORY EXTEN
         # TODO strip all symbols except the capi init
     elseif (EXTENSION_STATIC_BUILD)
         if (WIN32)
-            target_link_libraries(${TARGET_NAME} duckdb_static dummy_static_extension_loader ${DUCKDB_EXTRA_LINK_FLAGS})
+            target_link_libraries(${TARGET_NAME} duckdb_static ${DUCKDB_EXTRA_LINK_FLAGS})
         elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
             if (APPLE)
                 set_target_properties(${TARGET_NAME} PROPERTIES CXX_VISIBILITY_PRESET hidden)
                 # Note that on MacOS we need to use the -exported_symbol whitelist feature due to a lack of -exclude-libs flag in mac's ld variant
                 set(WHITELIST "-Wl,-exported_symbol,_${NAME}_duckdb_cpp_init")
-                target_link_libraries(${TARGET_NAME} duckdb_static dummy_static_extension_loader ${DUCKDB_EXTRA_LINK_FLAGS} -Wl,-dead_strip ${WHITELIST})
+                target_link_libraries(${TARGET_NAME} duckdb_static ${DUCKDB_EXTRA_LINK_FLAGS} -Wl,-dead_strip ${WHITELIST})
             elseif (ZOS)
-                target_link_libraries(${TARGET_NAME} duckdb_static dummy_static_extension_loader ${DUCKDB_EXTRA_LINK_FLAGS})
+                target_link_libraries(${TARGET_NAME} duckdb_static ${DUCKDB_EXTRA_LINK_FLAGS})
             else()
                 # For GNU we rely on fvisibility=hidden to hide the extension symbols and use -exclude-libs to hide the duckdb symbols
                 set_target_properties(${TARGET_NAME} PROPERTIES CXX_VISIBILITY_PRESET hidden)
-                target_link_libraries(${TARGET_NAME} duckdb_static dummy_static_extension_loader ${DUCKDB_EXTRA_LINK_FLAGS} -Wl,--gc-sections -Wl,--exclude-libs,ALL)
+                target_link_libraries(${TARGET_NAME} duckdb_static ${DUCKDB_EXTRA_LINK_FLAGS} -Wl,--gc-sections -Wl,--exclude-libs,ALL)
             endif()
         else()
             message(FATAL_ERROR, "EXTENSION static build is only intended for Linux and Windows on MVSC")

--- a/extension/generated_extension_loader.cpp.in
+++ b/extension/generated_extension_loader.cpp.in
@@ -9,19 +9,27 @@ namespace duckdb {
 //! Publishes the CMake-generated list of extensions linked into this binary onto the config, so that
 //! ExtensionHelper::LoadExtension can find them - including when it is called from code carrying its
 //! own copy of DuckDB, which links no generated loader of its own.
-void ExtensionHelper::RegisterLinkedExtensions(DBConfig &config) {
+static void RegisterGeneratedLinkedExtensions(DBConfig &config) {
 ${EXT_REGISTER_BODY}
 }
 
-vector<string> LinkedExtensions(){
-    vector<string> VEC = {${EXT_NAME_VECTOR_INITIALIZER}
-    };
-    return VEC;
+static vector<string> GeneratedExtensionTestPaths() {
+	vector<string> result = {${EXT_TEST_PATH_INITIALIZER}
+	};
+	return result;
 }
 
-vector<string> ExtensionHelper::LoadedExtensionTestPaths(){
-    vector<string> VEC = {${EXT_TEST_PATH_INITIALIZER}
-    };
-    return VEC;
+struct GeneratedExtensionLoader {
+	GeneratedExtensionLoader() {
+		ExtensionHelper::SetLinkedExtensionHooks(RegisterGeneratedLinkedExtensions, GeneratedExtensionTestPaths);
+	}
+};
+
+static GeneratedExtensionLoader generated_extension_loader;
+
+vector<string> LinkedExtensions() {
+	vector<string> result = {${EXT_NAME_VECTOR_INITIALIZER}
+	};
+	return result;
 }
-}
+} // namespace duckdb

--- a/extension/loader/dummy_static_extension_loader.cpp
+++ b/extension/loader/dummy_static_extension_loader.cpp
@@ -1,20 +1,2 @@
-#include "duckdb/main/config.hpp"
-#include "duckdb/main/extension_helper.hpp"
-
-// This is a dummy loader to produce a workable duckdb library without linking any extensions.
-// Link this to libduckdb_static.a to get a working system.
-//
-// Note that it no longer stubs out LoadExtension: that lives in core and reads the registry on the
-// config, so a binary (or an extension) that links this can still load whatever it was handed.
-
-namespace duckdb {
-
-void ExtensionHelper::RegisterLinkedExtensions(DBConfig &config) {
-	// nothing is linked into this binary
-}
-
-vector<string> ExtensionHelper::LoadedExtensionTestPaths() {
-	return {};
-}
-
-} // namespace duckdb
+// Compatibility archive for consumers that still link dummy_static_extension_loader.
+// The core library now provides the no-extension behavior itself.

--- a/src/include/duckdb/main/extension_helper.hpp
+++ b/src/include/duckdb/main/extension_helper.hpp
@@ -99,12 +99,17 @@ struct ExtensionInstallOptions {
 
 class ExtensionHelper {
 public:
+	typedef void (*register_linked_extensions_t)(DBConfig &config);
+	typedef vector<string> (*loaded_extension_test_paths_t)();
+
 	static void LoadAllExtensions(DuckDB &db);
 	static vector<string> LoadedExtensionTestPaths();
 	static ExtensionLoadResult LoadExtension(DuckDB &db, const std::string &extension);
-	//! Publishes the extensions linked into this binary onto the config. Generated at build time;
-	//! a build that links none (or an extension carrying its own DuckDB) registers nothing.
+	//! Publishes the extensions linked into this binary onto the config.
 	static void RegisterLinkedExtensions(DBConfig &config);
+	//! Installs the build-generated linked extension hooks.
+	static void SetLinkedExtensionHooks(register_linked_extensions_t register_extensions,
+	                                    loaded_extension_test_paths_t loaded_test_paths);
 
 	//! Install an extension
 	static unique_ptr<ExtensionInstallInfo> InstallExtension(ClientContext &context, const string &extension,

--- a/src/main/extension/extension_helper.cpp
+++ b/src/main/extension/extension_helper.cpp
@@ -90,6 +90,31 @@
 
 namespace duckdb {
 
+static ExtensionHelper::register_linked_extensions_t register_linked_extensions = nullptr;
+static ExtensionHelper::loaded_extension_test_paths_t loaded_extension_test_paths = nullptr;
+
+void ExtensionHelper::SetLinkedExtensionHooks(register_linked_extensions_t register_extensions,
+                                              loaded_extension_test_paths_t loaded_test_paths) {
+	D_ASSERT(!register_linked_extensions);
+	D_ASSERT(!loaded_extension_test_paths);
+	register_linked_extensions = register_extensions;
+	loaded_extension_test_paths = loaded_test_paths;
+}
+
+void ExtensionHelper::RegisterLinkedExtensions(DBConfig &config) {
+	if (!config.linked_extensions.empty() || !register_linked_extensions) {
+		return;
+	}
+	register_linked_extensions(config);
+}
+
+vector<string> ExtensionHelper::LoadedExtensionTestPaths() {
+	if (!loaded_extension_test_paths) {
+		return {};
+	}
+	return loaded_extension_test_paths();
+}
+
 //! Loads an extension that was linked into the binary, via the registry the config carries. This is
 //! deliberately not generated code: an extension with its own copy of DuckDB links no generated
 //! loader, so a compile-time list would be invisible to it, while the config is data it can read.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -51,6 +51,10 @@ endif()
 
 add_executable(unittest unittest.cpp ${UNITTEST_OBJECT_FILES})
 
+add_executable(duckdb_static_library_test api/test_static_library.cpp)
+target_link_libraries(duckdb_static_library_test duckdb_static)
+add_dependencies(unittest duckdb_static_library_test)
+
 set(RUN_WRAPPER_UNITTEST_NAME "unittest")
 if(WIN32)
   set(RUN_WRAPPER_UNITTEST_NAME "unittest.exe")

--- a/test/api/test_config.cpp
+++ b/test/api/test_config.cpp
@@ -55,6 +55,17 @@ TEST_CASE("Test DB config configuration", "[api]") {
 	}
 }
 
+TEST_CASE("Linked extension registry preserves inherited config", "[api][extension]") {
+	DBConfig config;
+	config.linked_extensions.push_back({"inherited", [](DuckDB &) {
+	                                    }});
+
+	DuckDB db(nullptr, &config);
+	auto &db_config = DBConfig::GetConfig(*db.instance);
+	REQUIRE(db_config.linked_extensions.size() == 1);
+	REQUIRE(db_config.linked_extensions[0].name == "inherited");
+}
+
 TEST_CASE("Test allowed options", "[api]") {
 	identifier_map_t<Value> config_dict;
 	string option;

--- a/test/api/test_static_library.cpp
+++ b/test/api/test_static_library.cpp
@@ -1,0 +1,13 @@
+#include "duckdb.hpp"
+
+using namespace duckdb;
+
+int main() {
+	DuckDB db(nullptr);
+	Connection connection(db);
+	auto result = connection.Query("SELECT 42");
+	if (!result || result->HasError()) {
+		return 1;
+	}
+	return result->GetValue(0, 0).GetValue<int32_t>() == 42 ? 0 : 1;
+}


### PR DESCRIPTION
### Context

Linking libduck.a can fail with:
```
test -f "/__w/duckdb-ci/duckdb-ci/duckdb-static/duckdb.h"; \
test -f "/__w/duckdb-ci/duckdb-ci/duckdb-static/libduckdb.a"; \
mkdir -p "build"; \
cc -I"/__w/duckdb-ci/duckdb-ci/duckdb-static" smoke.c "/__w/duckdb-ci/duckdb-ci/duckdb-static/libduckdb.a" -ldl -lpthread -lm -lstdc++ -o "build/compat_smoke"
/usr/lib/gcc/x86_64-alpine-linux-musl/14.2.0/../../../../x86_64-alpine-linux-musl/bin/ld: /__w/duckdb-ci/duckdb-ci/duckdb-static/libduckdb.a(ub_duckdb_main.cpp.o): in function `duckdb::DatabaseInstance::Initialize(char const*, duckdb::DBConfig*)':
ub_duckdb_main.cpp:(.text._ZN6duckdb16DatabaseInstance10InitializeEPKcPNS_8DBConfigE+0x80): undefined reference to `duckdb::ExtensionHelper::RegisterLinkedExtensions(duckdb::DBConfig&)'
collect2: error: ld returned 1 exit status
make[1]: *** [Makefile:41: build/compat_smoke] Error 1
make: *** [Makefile:9: test_compat] Error 2
```
because libduckdb.a expects the symbol `duckdb::ExtensionHelper::RegisterLinkedExtensions` to exist in the extension code.

### How to refactor

For most extensions, no source-level refactor is needed. Registration belongs to the final DuckDB binary, not each extension.

A C++ extension should retain its normal entrypoint:

```cpp
class FooExtension : public Extension {
public:
	void Load(ExtensionLoader &loader) override {
		// Register functions, types, etc.
	}
};
```

The generated registrar creates the link-time entry:

```cpp
config.linked_extensions.push_back({"foo", [](DuckDB &db) {
	db.LoadStaticExtension<FooExtension>();
}});
```

Do not add a static initializer or call `SetLinkedExtensionHooks` from the extension itself. An extension archive cannot reliably self-register because its object may never be extracted by the linker.

For a statically built loadable extension, only its link setup changes:

```cmake
# Before
target_link_libraries(foo duckdb_static dummy_static_extension_loader)

# After
target_link_libraries(foo duckdb_static)
```

If an extension currently defines either of these, remove them:

```cpp
ExtensionHelper::RegisterLinkedExtensions(...)
ExtensionHelper::LoadedExtensionTestPaths(...)
```

Core now owns those definitions.

If an extension creates a nested DuckDB and should inherit the host’s statically linked extensions, explicitly hand over the registry:

```cpp
auto &host_config = DBConfig::GetConfig(loader.GetDatabaseInstance());

DBConfig child_config;
child_config.linked_extensions = host_config.linked_extensions;

DuckDB child_db(nullptr, &child_config);
```

One issue remains for C API V2 extensions: [extension/CMakeLists.txt](extension/CMakeLists.txt) still writes their registration into the obsolete `EXT_LOADER_BODY`. That branch should instead append this to `EXT_REGISTER_BODY`:

```cpp
config.linked_extensions.push_back({"foo", [](DuckDB &db) {
	db.LoadStaticCAPIExtensionV2("foo", foo_init_c_api_v2);
}});
```

So the rule is: extensions expose normal init functions; the generated registrar records how to invoke them; core provides the empty fallback.

### Test

- [] Open a built extension in `duckdb-python` locally to verify registration works correctly when Python uses `dlopen` with visibility hidden.