### PR TITLE
[CAPI][Extension] Improve inline docs of extension loading API (V1 and V2)

### DIFF
--- a/api_spec/v1/extension/duckdb_extension.h.in
+++ b/api_spec/v1/extension/duckdb_extension.h.in
@@ -170,7 +170,8 @@ typedef struct {
 	}                                                                                                                  \
 	DUCKDB_EXTENSION_EXTERN_C_GUARD_CLOSE static bool DUCKDB_EXTENSION_GLUE(DUCKDB_EXTENSION_NAME, _init_c_api_internal)
 
-// Custom entrypoint: just forwards the info and access
+// Custom entrypoint: just forwards info and access. Both, and any database returned by access->get_database(info), are
+// borrowed for the duration of the entrypoint and must not be retained or destroyed.
 #define DUCKDB_EXTENSION_ENTRYPOINT_CUSTOM                                                                             \
 	DUCKDB_EXTENSION_GLOBAL static bool DUCKDB_EXTENSION_GLUE(DUCKDB_EXTENSION_NAME, _init_c_api_internal)(            \
 	    duckdb_extension_info info, struct duckdb_extension_access * access);                                          \

--- a/api_spec/v2/extension/extension.yaml
+++ b/api_spec/v2/extension/extension.yaml
@@ -47,7 +47,10 @@ structs:
         description: The extension being loaded, and the token get_api takes.
       - name: context
         type: context
-        description: A context to read and run queries through, with a transaction already active.
+        description: |
+          A borrowed context to read and run queries through, with a transaction
+          already active. Valid only until the extension entrypoint returns; do
+          not retain or destroy it.
       - name: err
         type: error_info
         pointer: 1

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -10363,13 +10363,7 @@ typedef duckdb_bignum duckdb_varint;
 struct duckdb_extension_access {
 	//! Indicate that an error has occurred.
 	void (*set_error)(duckdb_extension_info info, const char *error);
-	/*!
-	 * Fetch the database on which to register the extension.
-	 *
-	 * The returned pointer and the database handle it points to are borrowed and valid only until this function is
-	 * called again or the extension entrypoint returns. Do not retain either value or call `duckdb_close` on the
-	 * handle.
-	 */
+	//! Fetch the database on which to register the extension.
 	duckdb_database *(*get_database)(duckdb_extension_info info);
 	//! Fetch the API struct pointer.
 	const void *(*get_api)(duckdb_extension_info info, const char *version);

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -10363,7 +10363,13 @@ typedef duckdb_bignum duckdb_varint;
 struct duckdb_extension_access {
 	//! Indicate that an error has occurred.
 	void (*set_error)(duckdb_extension_info info, const char *error);
-	//! Fetch the database on which to register the extension.
+	/*!
+	 * Fetch the database on which to register the extension.
+	 *
+	 * The returned pointer and the database handle it points to are borrowed and valid only until this function is
+	 * called again or the extension entrypoint returns. Do not retain either value or call `duckdb_close` on the
+	 * handle.
+	 */
 	duckdb_database *(*get_database)(duckdb_extension_info info);
 	//! Fetch the API struct pointer.
 	const void *(*get_api)(duckdb_extension_info info, const char *version);

--- a/src/include/duckdb_extension.h
+++ b/src/include/duckdb_extension.h
@@ -2413,7 +2413,8 @@ typedef struct {
 	}                                                                                                                  \
 	DUCKDB_EXTENSION_EXTERN_C_GUARD_CLOSE static bool DUCKDB_EXTENSION_GLUE(DUCKDB_EXTENSION_NAME, _init_c_api_internal)
 
-// Custom entrypoint: just forwards the info and access
+// Custom entrypoint: just forwards info and access. Both, and any database returned by access->get_database(info), are
+// borrowed for the duration of the entrypoint and must not be retained or destroyed.
 #define DUCKDB_EXTENSION_ENTRYPOINT_CUSTOM                                                                             \
 	DUCKDB_EXTENSION_GLOBAL static bool DUCKDB_EXTENSION_GLUE(DUCKDB_EXTENSION_NAME, _init_c_api_internal)(            \
 	    duckdb_extension_info info, struct duckdb_extension_access * access);                                          \

--- a/src/include/duckdb_v2.h
+++ b/src/include/duckdb_v2.h
@@ -1319,7 +1319,10 @@ struct duckdb_v2_extension_input {
 	//! The extension being loaded, and the token get_api takes.
 	duckdb_v2_extension_handle extension;
 
-	//! A context to read and run queries through, with a transaction already active.
+	/*!
+	 * A borrowed context to read and run queries through, with a transaction already active. Valid only until the
+	 * extension entrypoint returns; do not retain or destroy it.
+	 */
 	duckdb_v2_context_handle context;
 
 	/*!

--- a/src/main/extension/extension_load.cpp
+++ b/src/main/extension/extension_load.cpp
@@ -62,8 +62,8 @@ struct DuckDBExtensionLoadState {
 	//! The init result from initializing the extension
 	ExtensionInitResult &init_result;
 
-	//! This is the duckdb_database struct that will be passed to the extension during initialization. Note that the
-	//! extension does not need to free it.
+	//! The borrowed duckdb_database passed to the extension during initialization. Replaced on each GetDatabase call
+	//! and destroyed when the entrypoint returns; the extension must not retain or free it.
 	unique_ptr<DatabaseWrapper> database_data;
 
 	//! The function pointer struct passed to the extension. The extension is expected to copy this struct during


### PR DESCRIPTION
This PR fixes https://github.com/duckdb/duckdb/issues/23544

Improve inline docs to clarify ownership/lifetime of returned pointer/references

Accompanying PR: https://github.com/duckdb/capigen/pull/5