### PR TITLE
ISSUE-21492: Optimizer: fold `struct_extract(struct_pack(...))` for table subscripts

### DIFF
--- a/src/include/duckdb/optimizer/rule/list.hpp
+++ b/src/include/duckdb/optimizer/rule/list.hpp
@@ -17,5 +17,6 @@
 #include "duckdb/optimizer/rule/not_conjunction_simplification.hpp"
 #include "duckdb/optimizer/rule/enum_comparison.hpp"
 #include "duckdb/optimizer/rule/regex_optimizations.hpp"
+#include "duckdb/optimizer/rule/struct_extract_struct_pack_folding.hpp"
 #include "duckdb/optimizer/rule/ordered_aggregate_optimizer.hpp"
 #include "duckdb/optimizer/rule/timestamp_comparison.hpp"

--- a/src/include/duckdb/optimizer/rule/struct_extract_struct_pack_folding.hpp
+++ b/src/include/duckdb/optimizer/rule/struct_extract_struct_pack_folding.hpp
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/optimizer/rule/struct_extract_struct_pack_folding.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/optimizer/rule.hpp"
+
+namespace duckdb {
+
+//! Fold struct_extract(struct_pack(c0, c1, ...), key) to the bound child expression for `key`.
+//! This keeps table subscript forms (e.g. alias['col']) from materializing full-row structs,
+//! restoring column pruning for scans.
+class StructExtractStructPackFoldingRule : public Rule {
+public:
+	explicit StructExtractStructPackFoldingRule(ExpressionRewriter &rewriter);
+
+	unique_ptr<Expression> Apply(LogicalOperator &op, vector<reference<Expression>> &bindings, bool &changes_made,
+	                             bool is_root) override;
+};
+
+} // namespace duckdb

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -68,6 +68,7 @@ namespace duckdb {
 Optimizer::Optimizer(Binder &binder, ClientContext &context) : context(context), binder(binder), rewriter(context) {
 	rewriter.rules.push_back(make_uniq<ConstantOrderNormalizationRule>(rewriter));
 	rewriter.rules.push_back(make_uniq<ConstantFoldingRule>(rewriter));
+	rewriter.rules.push_back(make_uniq<StructExtractStructPackFoldingRule>(rewriter));
 	rewriter.rules.push_back(make_uniq<DistributivityRule>(rewriter));
 	rewriter.rules.push_back(make_uniq<ArithmeticSimplificationRule>(rewriter));
 	rewriter.rules.push_back(make_uniq<LeastGreatestSimplificationRule>(rewriter));

--- a/src/optimizer/rule/CMakeLists.txt
+++ b/src/optimizer/rule/CMakeLists.txt
@@ -26,6 +26,7 @@ add_library_unity(
   ordered_aggregate_optimizer.cpp
   predicate_factoring.cpp
   regex_optimizations.cpp
+  struct_extract_struct_pack_folding.cpp
   timestamp_comparison.cpp
   constant_order_normalization.cpp
   contains_to_in_clause.cpp)

--- a/src/optimizer/rule/struct_extract_struct_pack_folding.cpp
+++ b/src/optimizer/rule/struct_extract_struct_pack_folding.cpp
@@ -1,0 +1,42 @@
+#include "duckdb/optimizer/rule/struct_extract_struct_pack_folding.hpp"
+
+#include "duckdb/function/scalar/struct_utils.hpp"
+#include "duckdb/optimizer/matcher/expression_matcher.hpp"
+#include "duckdb/planner/expression/bound_cast_expression.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
+
+namespace duckdb {
+
+StructExtractStructPackFoldingRule::StructExtractStructPackFoldingRule(ExpressionRewriter &rewriter) : Rule(rewriter) {
+	auto func = make_uniq<FunctionExpressionMatcher>();
+	// a bracket subscript on a struct binds to the "array_extract" overload - fold both the same way
+	func->function = make_uniq<ManyFunctionMatcher>(identifier_set_t {"struct_extract", "array_extract"});
+	func->policy = SetMatcher::Policy::ORDERED;
+	auto packed = make_uniq<FunctionExpressionMatcher>();
+	packed->function = make_uniq<SpecificFunctionMatcher>("struct_pack");
+	packed->policy = SetMatcher::Policy::SOME;
+	func->matchers.push_back(std::move(packed));
+	func->matchers.push_back(make_uniq<ExpressionMatcher>());
+	root = std::move(func);
+}
+
+unique_ptr<Expression> StructExtractStructPackFoldingRule::Apply(LogicalOperator &op,
+                                                                 vector<reference<Expression>> &bindings,
+                                                                 bool &changes_made, bool is_root) {
+	auto &extract = bindings[0].get().Cast<BoundFunctionExpression>();
+	auto &packed = bindings[1].get().Cast<BoundFunctionExpression>();
+	auto &bind_info = extract.BindInfo();
+	if (!bind_info) {
+		return nullptr;
+	}
+	auto &extract_data = bind_info->Cast<StructExtractBindData>();
+	auto &packed_children = packed.GetChildrenMutable();
+	if (extract_data.index >= packed_children.size()) {
+		return nullptr;
+	}
+	// struct_extract(struct_pack(e0, .., en), ki) is equivalent to ei
+	auto result = std::move(packed_children[extract_data.index]);
+	return BoundCastExpression::AddCastToType(GetContext(), std::move(result), extract.Function().GetReturnType());
+}
+
+} // namespace duckdb

--- a/test/issues/general/test_21492.test
+++ b/test/issues/general/test_21492.test
@@ -1,0 +1,94 @@
+# name: test/issues/general/test_21492.test
+# description: Issue 21492 - table subscripts should fold to a column reference so columns can be pruned
+# group: [general]
+
+statement ok
+CREATE TABLE t (grd_quart INTEGER, typl INTEGER, ipondl INTEGER, catl VARCHAR);
+
+statement ok
+INSERT INTO t VALUES (1, 2, 100, '1'), (1, 2, 200, '1');
+
+# a bracket subscript returns the same result as a direct column reference
+query III
+FROM t AS s
+SELECT grd_quart, s['typl'], sum(ipondl) AS eft
+WHERE catl = '1'
+GROUP BY ALL
+ORDER BY ALL
+----
+1	2	300
+
+query III
+FROM t AS s
+SELECT grd_quart, typl, sum(ipondl) AS eft
+WHERE catl = '1'
+GROUP BY ALL
+ORDER BY ALL
+----
+1	2	300
+
+statement ok
+SET VARIABLE col = 'typl'
+
+query III
+FROM t AS s
+SELECT grd_quart, s[getvariable('col')], sum(ipondl) AS eft
+WHERE catl = '1'
+GROUP BY ALL
+ORDER BY ALL
+----
+1	2	300
+
+# the fold must not leave a struct_pack in the plan - that would force reading every column
+query II
+EXPLAIN SELECT grd_quart, s['typl'], sum(ipondl) FROM t AS s WHERE catl = '1' GROUP BY ALL
+----
+physical_plan	<!REGEX>:(?s).*struct_pack.*
+
+query II
+EXPLAIN SELECT grd_quart, s[getvariable('col')], sum(ipondl) FROM t AS s WHERE catl = '1' GROUP BY ALL
+----
+physical_plan	<!REGEX>:(?s).*struct_pack.*
+
+statement ok
+RESET VARIABLE col
+
+# folding is semantics-preserving for struct_pack that is not a table subscript
+query I
+SELECT struct_extract(struct_pack(a := 40, b := 2), 'a')
+----
+40
+
+query I
+SELECT struct_pack(a := 40, b := 2)['b']
+----
+2
+
+query I
+SELECT struct_extract(struct_pack(a := i + 1, b := i * 2), 'b') FROM range(3) tbl(i) ORDER BY ALL
+----
+0
+2
+4
+
+# unnamed structs are extracted by index
+query I
+SELECT struct_extract(row(40, 2), 2)
+----
+2
+
+query I
+SELECT struct_extract_at(struct_pack(a := 40, b := 2), 1)
+----
+40
+
+# NULL keys and out-of-range keys keep erroring at bind time
+statement error
+SELECT struct_extract(struct_pack(a := 40), 'c')
+----
+<REGEX>:.*Could not find key.*
+
+statement error
+SELECT struct_extract(row(40, 2), 3)
+----
+<REGEX>:.*out of range.*


### PR DESCRIPTION
## Description

Bracket access on a table alias (`alias['col']`, including `getvariable('col')` after bind) was planned as `struct_extract` over a full-row `struct_pack`, which blocked column pruning on scans (e.g. remote Parquet  [duckdb/duckdb#21492](https://github.com/duckdb/duckdb/issues/21492)).

- Add `StructExtractStructPackFoldingRule`: fold `struct_extract(struct_pack(e₀…eₙ), k)` → bound child `eᵢ`.
- Test: `test/issues/general/test_21492.test`.

Fixes https://github.com/duckdb/duckdb/issues/21492
