### PR TITLE
Respect `ROW_GROUP_SIZE_BYTES`

### DIFF
--- a/src/execution/operator/persistent/physical_batch_copy_to_file.cpp
+++ b/src/execution/operator/persistent/physical_batch_copy_to_file.cpp
@@ -500,6 +500,7 @@ void PhysicalBatchCopyToFile::RepartitionBatches(ClientContext &context, GlobalS
 	}
 	unique_ptr<FixedRawBatchData> append_batch;
 	ColumnDataAppendState append_state;
+	CopyBatchAppender batch_appender(children[0].get().GetTypes(), batch_size, batch_size_bytes);
 	// now perform the actual repartitioning
 	for (auto &current_batch : raw_batches) {
 		if (!append_batch) {
@@ -523,6 +524,7 @@ void PhysicalBatchCopyToFile::RepartitionBatches(ClientContext &context, GlobalS
 			}
 			if (append_batch) {
 				append_batch->collection->InitializeAppend(append_state);
+				batch_appender.SetCollectionBytes(append_batch->collection->SizeInBytes());
 			}
 		}
 		if (!current_batch) {
@@ -533,20 +535,21 @@ void PhysicalBatchCopyToFile::RepartitionBatches(ClientContext &context, GlobalS
 		append_batch->memory_usage += current_batch->memory_usage;
 		// iterate the collection while appending
 		for (auto &chunk : current_collection.Chunks()) {
-			// append the chunk to the collection
-			append_batch->collection->Append(append_state, chunk);
-			const CopyFunctionBatchAnalyzer batch_analyzer(*append_batch->collection, batch_size, batch_size_bytes);
-			if (!batch_analyzer.MeetsFlushCriteria()) {
-				// the collection is still under the desired batch size - continue
-				continue;
-			}
-			// the collection is full - move it to the result and create a new one
-			task_manager.AddTask(make_uniq<PrepareBatchTask>(gstate.scheduled_batch_index++, std::move(append_batch)));
+			idx_t offset = 0;
+			while (offset < chunk.size()) {
+				if (!batch_appender.AppendUntilFull(*append_batch->collection, append_state, chunk, offset)) {
+					continue; // the collection is still under the desired batch size
+				}
+				// the collection is full - move it to the result and create a new one
+				task_manager.AddTask(
+				    make_uniq<PrepareBatchTask>(gstate.scheduled_batch_index++, std::move(append_batch)));
 
-			auto new_collection = make_uniq<ColumnDataCollection>(context, children[0].get().GetTypes());
-			new_collection->SetPartitionIndex(0); // Makes the buffer manager less likely to spill this data
-			append_batch = make_uniq<FixedRawBatchData>(0U, std::move(new_collection));
-			append_batch->collection->InitializeAppend(append_state);
+				auto new_collection = make_uniq<ColumnDataCollection>(context, children[0].get().GetTypes());
+				new_collection->SetPartitionIndex(0); // Makes the buffer manager less likely to spill this data
+				append_batch = make_uniq<FixedRawBatchData>(0U, std::move(new_collection));
+				append_batch->collection->InitializeAppend(append_state);
+				batch_appender.SetCollectionBytes(0);
+			}
 		}
 	}
 	if (append_batch && append_batch->collection->Count() > 0) {

--- a/src/execution/operator/persistent/physical_copy_to_file.cpp
+++ b/src/execution/operator/persistent/physical_copy_to_file.cpp
@@ -526,6 +526,8 @@ public:
 	//! Current append batch (unpartitioned write)
 	unique_ptr<ColumnDataCollection> batch;
 	ColumnDataAppendState batch_append_state;
+	//! Cuts chunks so BATCH_SIZE_BYTES is reachable
+	unique_ptr<CopyBatchAppender> batch_appender;
 
 	//! Local state (partitioned write)
 	unique_ptr<PartitionedCopyLocalState> partitioned_copy_local_state;
@@ -1947,6 +1949,8 @@ optional<PartitionedCopyTask> PartitionedCopyHashGroup::TryNextBatchTask() {
 		// Uses entry-level validity mask iteration to skip 64 rows at a time (see ExecuteFlat in unary_executor.hpp)
 		D_ASSERT(batch_row_idx <= batch_scan_state.next_row_index);
 		const idx_t chunk_end = batch_scan_state.next_row_index;
+		const idx_t chunk_begin = batch_scan_state.current_row_index;
+		const idx_t row_before = batch_row_idx;
 		// Skip batch_row_idx itself if it's the start of the current partition
 		const idx_t search_start = batch_row_idx + (batch_row_idx == task.begin_idx ? 1 : 0);
 		if (search_start < chunk_end) {
@@ -1978,13 +1982,33 @@ optional<PartitionedCopyTask> PartitionedCopyHashGroup::TryNextBatchTask() {
 			batch_row_idx = chunk_end;
 		}
 
-		// Did not find the next partition boundary, add chunk
+		// Did not find the next partition boundary, add the rows taken from this chunk
 		auto &segment = segments[batch_scan_state.segment_index];
+		const idx_t chunk_bytes = segment->GetChunkAllocationSize(batch_scan_state.chunk_index - 1);
+		const idx_t chunk_rows = chunk_end - chunk_begin;
+		const idx_t chunk_bytes_per_row = chunk_rows == 0 ? chunk_bytes : (chunk_bytes + chunk_rows - 1) / chunk_rows;
+		idx_t rows_taken = batch_row_idx - row_before;
+
+		// A batch can only end where this loop stops, so cut inside a chunk holding more than
+		// BATCH_SIZE_BYTES. The average row width avoids reading the chunk to get exact widths
+		bool cut_for_size = false;
+		const auto &batch_size_bytes = partitioned_copy.op.batch_size_bytes;
+		if (batch_size_bytes.IsValid() && rows_taken > 1 && chunk_bytes_per_row > 0) {
+			const idx_t limit = batch_size_bytes.GetIndex();
+			const idx_t budget = limit > current_batch_size_bytes ? limit - current_batch_size_bytes : 0;
+			const idx_t fits = MaxValue<idx_t>(budget / chunk_bytes_per_row, 1);
+			if (fits < rows_taken) {
+				batch_row_idx = row_before + fits;
+				rows_taken = fits;
+				found_next_partition = false; // we stopped short of the boundary
+				cut_for_size = true;
+			}
+		}
+		current_batch_size_bytes += chunk_bytes_per_row * rows_taken;
+
 		const auto current_batch_size = batch_row_idx - task.begin_idx;
-		current_batch_size_bytes += segment->GetChunkAllocationSize(batch_scan_state.chunk_index - 1);
 		const CopyFunctionBatchAnalyzer batch_analyzer(current_batch_size, current_batch_size_bytes,
-		                                               partitioned_copy.op.batch_size,
-		                                               partitioned_copy.op.batch_size_bytes);
+		                                               partitioned_copy.op.batch_size, batch_size_bytes);
 
 		// Move to the next chunk if we exhausted this one
 		if (batch_row_idx == batch_scan_state.next_row_index) {
@@ -1994,7 +2018,7 @@ optional<PartitionedCopyTask> PartitionedCopyHashGroup::TryNextBatchTask() {
 			collection->NextScanIndex(batch_scan_state, chunk_index, segment_index, row_index);
 		}
 
-		if (found_next_partition || batch_analyzer.MeetsFlushCriteria()) {
+		if (cut_for_size || found_next_partition || batch_analyzer.MeetsFlushCriteria()) {
 			break; // Move to the next partition or batch
 		}
 	}
@@ -3052,6 +3076,7 @@ void PartitionedCopy::FlushDelayedPartitionRun(const vector<Value> &values, Part
 		auto batch = make_uniq<ColumnDataCollection>(context, write_types);
 		ColumnDataAppendState append_state;
 		batch->InitializeAppend(append_state);
+		CopyBatchAppender batch_appender(write_types, op.batch_size, op.batch_size_bytes);
 
 		const auto flush_batch = [&]() {
 			if (batch->Count() == 0) {
@@ -3065,13 +3090,15 @@ void PartitionedCopy::FlushDelayedPartitionRun(const vector<Value> &values, Part
 
 			batch = make_uniq<ColumnDataCollection>(context, write_types);
 			batch->InitializeAppend(append_state);
+			batch_appender.SetCollectionBytes(0);
 		};
 
 		while (collection.Scan(scan_state, scan_chunk)) {
-			batch->Append(append_state, scan_chunk);
-			const CopyFunctionBatchAnalyzer batch_analyzer(*batch, op.batch_size, op.batch_size_bytes);
-			if (batch_analyzer.MeetsFlushCriteria()) {
-				flush_batch();
+			idx_t offset = 0;
+			while (offset < scan_chunk.size()) {
+				if (batch_appender.AppendUntilFull(*batch, append_state, scan_chunk, offset)) {
+					flush_batch();
+				}
 			}
 		}
 		flush_batch();
@@ -3547,7 +3574,9 @@ CopyToFileLocalState::CopyToFileLocalState(const PhysicalCopyToFile &op_p, Execu
 	if (op.partition_output) {
 		++gstate.partitioned_copy->locals;
 		partitioned_copy_local_state = make_uniq<PartitionedCopyLocalState>();
+		return;
 	}
+	batch_appender = make_uniq<CopyBatchAppender>(op.expected_types, op.batch_size, op.batch_size_bytes);
 }
 
 //===--------------------------------------------------------------------===//
@@ -3697,16 +3726,18 @@ SinkResultType PhysicalCopyToFile::Sink(ExecutionContext &context, DataChunk &ch
 	}
 	auto &file_state = per_thread_output ? lstate.global_file_state : gstate.global_state;
 
-	if (!lstate.batch) {
-		lstate.batch = make_uniq<ColumnDataCollection>(context.client, expected_types);
-		lstate.batch->InitializeAppend(lstate.batch_append_state);
-	}
-	lstate.batch->Append(lstate.batch_append_state, chunk);
-
-	const CopyFunctionBatchAnalyzer batch_analyzer(*lstate.batch, batch_size, batch_size_bytes);
-	if (batch_analyzer.MeetsFlushCriteria()) {
-		lstate.batch_append_state.current_chunk_state.handles.clear();
-		PrepareAndFlushBatch(context.client, gstate, file_state, gstate.create_file_state_fun, std::move(lstate.batch));
+	idx_t offset = 0;
+	while (offset < chunk.size()) {
+		if (!lstate.batch) {
+			lstate.batch = make_uniq<ColumnDataCollection>(context.client, expected_types);
+			lstate.batch->InitializeAppend(lstate.batch_append_state);
+			lstate.batch_appender->SetCollectionBytes(0);
+		}
+		if (lstate.batch_appender->AppendUntilFull(*lstate.batch, lstate.batch_append_state, chunk, offset)) {
+			lstate.batch_append_state.current_chunk_state.handles.clear();
+			PrepareAndFlushBatch(context.client, gstate, file_state, gstate.create_file_state_fun,
+			                     std::move(lstate.batch));
+		}
 	}
 
 	return SinkResultType::NEED_MORE_INPUT;

--- a/src/function/copy_function.cpp
+++ b/src/function/copy_function.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/function/copy_function.hpp"
 
 #include "duckdb/common/types/column/column_data_collection.hpp"
+#include "duckdb/common/types/row/tuple_data_collection.hpp"
 
 namespace duckdb {
 
@@ -10,6 +11,139 @@ CopyFunction::CopyFunction(const Identifier &name)
       copy_to_sink(nullptr), copy_to_combine(nullptr), copy_to_finalize(nullptr), execution_mode(nullptr),
       initialize_operator(nullptr), prepare_batch(nullptr), flush_batch(nullptr), file_size_bytes(nullptr),
       desired_batch_size(nullptr), serialize(nullptr), deserialize(nullptr), copy_from_bind(nullptr) {
+}
+
+//===--------------------------------------------------------------------===//
+// Copy Batch Appender
+//===--------------------------------------------------------------------===//
+//! How far past BATCH_SIZE_BYTES a batch may run before a chunk is cut
+static constexpr idx_t BATCH_SIZE_BYTES_SLACK_DIVISOR = 8;
+
+//! Bytes a row of this type always occupies. ComputeHeapSizes ignores fixed-width struct children, so sum them
+static idx_t FixedRowBytes(const LogicalType &type) {
+	if (type.InternalType() != PhysicalType::STRUCT) {
+		return GetTypeIdSize(type.InternalType());
+	}
+	idx_t result = 0;
+	for (const auto &child_type : StructType::GetChildTypes(type)) {
+		result += FixedRowBytes(child_type.second);
+	}
+	return result;
+}
+
+static bool HasVariableRowBytes(const LogicalType &type) {
+	switch (type.InternalType()) {
+	case PhysicalType::VARCHAR:
+	case PhysicalType::LIST:
+	case PhysicalType::ARRAY:
+		return true;
+	case PhysicalType::STRUCT:
+		for (const auto &child_type : StructType::GetChildTypes(type)) {
+			if (HasVariableRowBytes(child_type.second)) {
+				return true;
+			}
+		}
+		return false;
+	default:
+		return false;
+	}
+}
+
+CopyBatchAppender::CopyBatchAppender(const vector<LogicalType> &types, const optional_idx &batch_size_p,
+                                     const optional_idx &batch_size_bytes_p)
+    : batch_size(batch_size_p), batch_size_bytes(batch_size_bytes_p) {
+	if (!batch_size_bytes.IsValid()) {
+		// no byte limit, chunks are always appended whole
+		return;
+	}
+	vector<column_t> variable_columns;
+	for (idx_t col_idx = 0; col_idx < types.size(); col_idx++) {
+		fixed_row_bytes += FixedRowBytes(types[col_idx]);
+		if (HasVariableRowBytes(types[col_idx])) {
+			variable_columns.push_back(col_idx);
+		}
+	}
+	variable_row_bytes = !variable_columns.empty();
+	partial = make_uniq<DataChunk>();
+	partial->InitializeEmpty(types);
+	if (variable_row_bytes) {
+		row_bytes_state = make_uniq<TupleDataChunkState>();
+		// only these columns need ToUnifiedFormat - ComputeHeapSizes returns early for the rest
+		TupleDataCollection::InitializeChunkState(*row_bytes_state, types, std::move(variable_columns));
+	}
+}
+
+CopyBatchAppender::~CopyBatchAppender() {
+}
+
+void CopyBatchAppender::ComputeRowBytes(DataChunk &chunk) {
+	TupleDataCollection::ToUnifiedFormat(*row_bytes_state, chunk);
+	TupleDataCollection::ComputeHeapSizes(*row_bytes_state, chunk, *FlatVector::IncrementalSelectionVector(),
+	                                      chunk.size());
+}
+
+idx_t CopyBatchAppender::RowsThatFit(const idx_t count, const idx_t offset, const idx_t budget) const {
+	const idx_t remaining = count - offset;
+	if (!variable_row_bytes) {
+		// every row costs the same - round up so the batch reaches the limit
+		if (fixed_row_bytes == 0) {
+			return remaining;
+		}
+		const idx_t fits = (budget + fixed_row_bytes - 1) / fixed_row_bytes;
+		return MaxValue<idx_t>(MinValue(remaining, fits), 1);
+	}
+	// rows differ in size - stop at the first row reaching the budget, overshooting by at most one
+	const auto heap_sizes = FlatVector::GetData<idx_t>(row_bytes_state->heap_sizes);
+	idx_t total = 0;
+	for (idx_t i = 0; i < remaining; i++) {
+		total += fixed_row_bytes + heap_sizes[offset + i];
+		if (total >= budget) {
+			return i + 1;
+		}
+	}
+	return remaining;
+}
+
+void CopyBatchAppender::Append(ColumnDataCollection &collection, ColumnDataAppendState &append_state, DataChunk &chunk,
+                               idx_t &offset) {
+	const idx_t count = chunk.size();
+	if (!batch_size_bytes.IsValid()) {
+		collection.Append(append_state, chunk);
+		offset = count;
+		return;
+	}
+	if (variable_row_bytes && offset == 0) {
+		// the per-row sizes are reused for every slice of this chunk
+		ComputeRowBytes(chunk);
+	}
+	const idx_t limit = batch_size_bytes.GetIndex();
+	// cutting a chunk that only just crosses the limit is not worth a slice, so allow some slack
+	const idx_t slack_limit = limit + limit / BATCH_SIZE_BYTES_SLACK_DIVISOR;
+	idx_t append_count =
+	    RowsThatFit(count, offset, slack_limit > collection_bytes ? slack_limit - collection_bytes : 0);
+	if (append_count < count - offset) {
+		// the chunk has to be cut, so cut it at the limit rather than at the slack
+		append_count = RowsThatFit(count, offset, limit > collection_bytes ? limit - collection_bytes : 0);
+	}
+
+	if (offset == 0 && append_count == count) {
+		collection.Append(append_state, chunk);
+	} else {
+		for (idx_t col_idx = 0; col_idx < chunk.ColumnCount(); col_idx++) {
+			partial->data[col_idx].Slice(chunk.data[col_idx], offset, offset + append_count);
+		}
+		partial->CheckCardinality(append_count);
+		collection.Append(append_state, *partial);
+	}
+	offset += append_count;
+	collection_bytes = collection.SizeInBytes();
+}
+
+bool CopyBatchAppender::AppendUntilFull(ColumnDataCollection &collection, ColumnDataAppendState &append_state,
+                                        DataChunk &chunk, idx_t &offset) {
+	Append(collection, append_state, chunk, offset);
+	const CopyFunctionBatchAnalyzer batch_analyzer(collection.Count(), collection_bytes, batch_size, batch_size_bytes);
+	return batch_analyzer.MeetsFlushCriteria();
 }
 
 CopyOption::CopyOption() : type(LogicalType::ANY), mode(CopyOptionMode::READ_WRITE) {

--- a/src/include/duckdb/function/copy_function.hpp
+++ b/src/include/duckdb/function/copy_function.hpp
@@ -25,6 +25,8 @@ class Binder;
 class ColumnDataCollection;
 class ExecutionContext;
 class PhysicalOperatorLogger;
+struct ColumnDataAppendState;
+struct TupleDataChunkState;
 
 struct CopyFunctionInfo {
 	virtual ~CopyFunctionInfo() = default;
@@ -232,6 +234,46 @@ public:
 
 	const optional_idx batch_size;
 	const optional_idx batch_size_bytes;
+};
+
+//! Appends chunks into a batch collection, cutting within a chunk to respect BATCH_SIZE_BYTES.
+//! A batch can only end on an append boundary, so a chunk wider than the limit makes it unreachable
+class CopyBatchAppender {
+public:
+	CopyBatchAppender(const vector<LogicalType> &types, const optional_idx &batch_size,
+	                  const optional_idx &batch_size_bytes);
+	~CopyBatchAppender();
+
+public:
+	//! Appends rows from offset and returns whether the collection meets the flush criteria.
+	//! Always appends at least one row, so looping until offset == chunk.size() terminates
+	bool AppendUntilFull(ColumnDataCollection &collection, ColumnDataAppendState &append_state, DataChunk &chunk,
+	                     idx_t &offset);
+	//! Bytes already in the collection - 0 when fresh
+	void SetCollectionBytes(idx_t bytes) {
+		collection_bytes = bytes;
+	}
+
+private:
+	void Append(ColumnDataCollection &collection, ColumnDataAppendState &append_state, DataChunk &chunk, idx_t &offset);
+	//! Fills row_bytes_state with the per-row heap sizes of chunk
+	void ComputeRowBytes(DataChunk &chunk);
+	//! Rows from offset that still fit in budget, at least one
+	idx_t RowsThatFit(idx_t count, idx_t offset, idx_t budget) const;
+
+private:
+	const optional_idx batch_size;
+	const optional_idx batch_size_bytes;
+	//! Bytes a row occupies regardless of its contents
+	idx_t fixed_row_bytes = 0;
+	//! Whether any column can carry a variable-sized payload
+	bool variable_row_bytes = false;
+	//! Per-row sizes of the chunk being appended, only filled if variable_row_bytes
+	unique_ptr<TupleDataChunkState> row_bytes_state;
+	//! View used to append part of a chunk
+	unique_ptr<DataChunk> partial;
+	//! Bytes held by the collection, carried so SizeInBytes() is called once per append
+	idx_t collection_bytes = 0;
 };
 
 class CopyFunction : public Function { // NOLINT: work-around bug in clang-tidy

--- a/test/sql/copy/parquet/writer/row_group_size_bytes.test
+++ b/test/sql/copy/parquet/writer/row_group_size_bytes.test
@@ -80,8 +80,8 @@ select max(row_group_num_rows) from parquet_metadata('{TEST_DIR}/tbl.parquet')
 ----
 10240
 
-# these strings take around 16 + 50 = 66 bytes per string, so 2048 * 66 = 135168 per chunk
-# if we set the limit to 200000, then we should get row groups of 4096
+# these strings take around 16 + 50 = 66 bytes per string, so the limit of 200000 is crossed
+# part-way through the second chunk, and that is where the row group ends
 statement ok
 copy (
     select range || repeat('0', 50) c0
@@ -89,9 +89,9 @@ copy (
 ) to '{TEST_DIR}/tbl.parquet' (ROW_GROUP_SIZE_BYTES 200000)
 
 query T
-select max(row_group_num_rows) from parquet_metadata('{TEST_DIR}/tbl.parquet')
+select max(row_group_num_rows) between 2600 and 4096 from parquet_metadata('{TEST_DIR}/tbl.parquet')
 ----
-4096
+true
 
 # if we set it to 650000 we should get 10240 row groups
 statement ok

--- a/test/sql/copy/parquet/writer/row_group_size_bytes_wide.test
+++ b/test/sql/copy/parquet/writer/row_group_size_bytes_wide.test
@@ -1,0 +1,108 @@
+# name: test/sql/copy/parquet/writer/row_group_size_bytes_wide.test
+# description: ROW_GROUP_SIZE_BYTES must be honoured when a chunk is wider than the limit
+# group: [writer]
+
+require parquet
+
+# 64 kB rows, so one vector is far wider than the 1 MB limit used below
+statement ok
+CREATE TABLE wide AS SELECT i, repeat(md5(i::VARCHAR), 2048)::BLOB AS payload FROM range(600) t(i)
+
+# the unordered sink
+statement ok
+SET preserve_insertion_order=false
+
+statement ok
+COPY wide TO '{TEST_DIR}/unordered.parquet' (FORMAT parquet, COMPRESSION uncompressed, ROW_GROUP_SIZE_BYTES 1000000)
+
+query T
+SELECT max(row_group_bytes) < 1300000 FROM parquet_metadata('{TEST_DIR}/unordered.parquet')
+----
+true
+
+# the order-preserving sink writes through repartitioning instead
+statement ok
+SET preserve_insertion_order=true
+
+statement ok
+COPY wide TO '{TEST_DIR}/ordered.parquet' (FORMAT parquet, COMPRESSION uncompressed, ROW_GROUP_SIZE_BYTES 1000000)
+
+query IT
+SELECT count(*), bool_and(payload = repeat(md5(i::VARCHAR), 2048)::BLOB) FROM '{TEST_DIR}/ordered.parquet'
+----
+600	true
+
+query T
+SELECT max(row_group_bytes) < 1300000 FROM parquet_metadata('{TEST_DIR}/ordered.parquet')
+----
+true
+
+# partitioned writes batch on their own
+statement ok
+COPY (SELECT i % 4 AS p, i, payload FROM wide) TO '{TEST_DIR}/part' (FORMAT parquet, COMPRESSION uncompressed, ROW_GROUP_SIZE_BYTES 1000000, PARTITION_BY ('p'))
+
+query T
+SELECT max(row_group_bytes) < 1300000 FROM parquet_metadata('{TEST_DIR}/part/**/*.parquet')
+----
+true
+
+# a partition below partitioned_write_flush_threshold is merged back into one collection before it is
+# split into row groups again
+statement ok
+CREATE TABLE mixed AS SELECT i, CASE WHEN i % 100 = 0 THEN repeat(md5(i::VARCHAR), 4096) ELSE md5(i::VARCHAR) END::BLOB AS payload FROM range(20000) t(i)
+
+statement ok
+COPY (SELECT i % 4 AS p, i, payload FROM mixed) TO '{TEST_DIR}/mixed' (FORMAT parquet, COMPRESSION uncompressed, ROW_GROUP_SIZE_BYTES 1000000, PARTITION_BY ('p'))
+
+query T
+SELECT max(row_group_bytes) < 1300000 FROM parquet_metadata('{TEST_DIR}/mixed/**/*.parquet')
+----
+true
+
+# nested types are sliced per column, so they need the same bound and must round-trip
+statement ok
+CREATE TABLE nested AS SELECT
+    range(i, i + 400) AS lst,
+    {'a': repeat(md5(i::VARCHAR), 20), 'b': i} AS strct,
+    [repeat(md5(i::VARCHAR), 10), repeat(md5((i + 1)::VARCHAR), 10)]::VARCHAR[2] AS arr,
+    map_from_entries([(i, repeat(md5(i::VARCHAR), 20))]) AS mp
+FROM range(1200) t(i)
+
+statement ok
+COPY nested TO '{TEST_DIR}/nested.parquet' (FORMAT parquet, COMPRESSION uncompressed, ROW_GROUP_SIZE_BYTES 1000000)
+
+query T
+SELECT max(row_group_bytes) < 1300000 FROM parquet_metadata('{TEST_DIR}/nested.parquet')
+----
+true
+
+query II
+SELECT (SELECT count(*) FROM (FROM nested EXCEPT FROM '{TEST_DIR}/nested.parquet')),
+       (SELECT count(*) FROM (FROM '{TEST_DIR}/nested.parquet' EXCEPT FROM nested))
+----
+0	0
+
+# a struct has no payload of its own, and nothing reports a heap size for fixed-width children, so
+# its width has to come from summing them. One vector of these is 128 kB, well past the 50 kB limit
+statement ok
+CREATE TABLE fixed_struct AS SELECT {'a': i, 'b': i, 'c': i, 'd': i, 'e': i, 'f': i, 'g': i, 'h': i} AS s FROM range(20000) t(i)
+
+statement ok
+COPY fixed_struct TO '{TEST_DIR}/fixed_struct.parquet' (FORMAT parquet, COMPRESSION uncompressed, ROW_GROUP_SIZE_BYTES 50000)
+
+query T
+SELECT max(row_group_bytes) < 65000 FROM parquet_metadata('{TEST_DIR}/fixed_struct.parquet')
+----
+true
+
+# a row wider than the limit cannot be split further - one row per row group, and no hang
+statement ok
+CREATE TABLE huge AS SELECT repeat(md5(i::VARCHAR), 262144)::BLOB AS payload FROM range(8) t(i)
+
+statement ok
+COPY huge TO '{TEST_DIR}/huge.parquet' (FORMAT parquet, COMPRESSION uncompressed, ROW_GROUP_SIZE_BYTES 1000000)
+
+query I
+SELECT count(DISTINCT row_group_id) FROM parquet_metadata('{TEST_DIR}/huge.parquet')
+----
+8

--- a/test/sql/settings/enable_caching_operators.test_slow
+++ b/test/sql/settings/enable_caching_operators.test_slow
@@ -29,15 +29,24 @@ set memory_limit='300mb'
 statement ok
 set read_ahead_depth=0
 
-# runs out of memory when caching operators are enabled because strings are accumulated
+# caching operators merge the small chunks into one, so the writer is handed all 64 strings at once.
+# ROW_GROUP_SIZE rounds up to a chunk, so the whole 512 MB is buffered before it can be flushed
 statement error
 copy (
     select c
     from '{TEST_DIR}/enable_caching_operators_input*.parquet'
     where id in (from build)
-) to '{TEST_DIR}/enable_caching_operators_output.parquet' (row_group_size_bytes '64mb');
+) to '{TEST_DIR}/enable_caching_operators_output.parquet' (row_group_size 8);
 ----
 Out of Memory
+
+# ROW_GROUP_SIZE_BYTES is not rounded up to a chunk, so the same write stays within the memory limit
+statement ok
+copy (
+    select c
+    from '{TEST_DIR}/enable_caching_operators_input*.parquet'
+    where id in (from build)
+) to '{TEST_DIR}/enable_caching_operators_output.parquet' (row_group_size_bytes '64mb');
 
 # runs fine when disabled
 statement ok
@@ -48,4 +57,4 @@ copy (
     select c
     from '{TEST_DIR}/enable_caching_operators_input*.parquet'
     where id in (from build)
-) to '{TEST_DIR}/enable_caching_operators_output.parquet' (row_group_size_bytes '64mb');
+) to '{TEST_DIR}/enable_caching_operators_output.parquet' (row_group_size 8);


### PR DESCRIPTION
`ROW_GROUP_SIZE_BYTES` (bound to the copy layer as `BATCH_SIZE_BYTES`) becomes unreachable once a
single chunk is wider than the limit, because the whole chunk is appended before the size is
compared:

```cpp
lstate.batch->Append(lstate.batch_append_state, chunk);

const CopyFunctionBatchAnalyzer batch_analyzer(*lstate.batch, batch_size, batch_size_bytes);
if (batch_analyzer.MeetsFlushCriteria()) {
```

So the limit holds while a chunk fits inside it, and is ignored once one chunk exceeds it. This
hits hardest with wide rows, particularly BLOBs:

```sql
COPY (SELECT i, repeat(md5(i::VARCHAR), 8125)::BLOB AS payload FROM range(4000) t(i))
  TO 'wide.parquet' (FORMAT parquet, COMPRESSION uncompressed, ROW_GROUP_SIZE_BYTES 8388608);
```

Every batching path in the copy layer quantises the same way. `max(row_group_bytes)` from
`parquet_metadata`, uncompressed, 8 MiB requested:

| | before | after |
|---|---|---|
| unordered write | 507.84 MiB | 8.68 MiB |
| order-preserving write | 507.84 MiB | 8.68 MiB |
| `PARTITION_BY` | 247.97 MiB | 9.17 MiB |
| narrow rows, chunk already fits (control) | 8.05 MiB | 8.05 MiB |

#21480, which took these options out of the Parquet writer, set out to "make our fine-grained writes more exact", and #22225 lists as future work:

> Finally, we should support `ROW_GROUP_SIZE_BYTES` and `FILE_SIZE_BYTES` for partitioned (and
> sorted) writes, reduce lock contention for that, and improve the accuracy of these parameters.

This is the accuracy half of that, for `ROW_GROUP_SIZE_BYTES` across all write paths. It does not
touch `FILE_SIZE_BYTES` or lock contention.

## Approach

A `CopyBatchAppender` appends only as much of a chunk as fits, so a batch can end inside a chunk
rather than only on its boundary. Where a whole chunk fits it appends unsliced, so behaviour is
unchanged. The cut uses exact per-row widths, since within one chunk they can differ by orders of
magnitude. `PartitionedCopyHashGroup::TryNextBatchTask` is the exception — it walks the partition
mask without reading chunk data, so it charges the chunk's average row width to keep it that way,
which is where the 9.17 MiB above comes from.

Best effort, not a hard bound, and targeting the size before compression, consistent with other
writers. A batch may overshoot by one row, a marginal crossing is left unsliced, and a single row
wider than the limit gets a row group to itself.

## Performance

Median of 3, 32 threads.

| | before | after |
|---|---|---|
| 30M narrow rows, option unset | 1.59 s | 1.61 s |
| 30M narrow rows, option set, chunk still fits | 1.60 s | 1.60 s |
| 1.04 GB of 260 kB blobs, 8 MiB limit | 1.53 s | 1.10 s |

The wide case gets faster because the writer stops buffering half a gigabyte per row group.

Done with AI help