### PR TITLE
Prune row group on FALSE_OR_NULL

### DIFF
--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -760,7 +760,8 @@ bool RowGroup::CheckZonemap(optional_ptr<ClientContext> context, ScanFilterInfo 
 		} else {
 			prune_result = GetColumn(base_column_index).CheckZonemap(context, base_column_index, filter);
 		}
-		if (prune_result == FilterPropagateResult::FILTER_ALWAYS_FALSE) {
+		if (prune_result == FilterPropagateResult::FILTER_ALWAYS_FALSE ||
+		    prune_result == FilterPropagateResult::FILTER_FALSE_OR_NULL) {
 			return false;
 		}
 		if (ExpressionFilter::IsRootNonSelectivityOptionalFilter(filter)) {

--- a/test/sql/optimizer/list_contains_row_group_pruning.test
+++ b/test/sql/optimizer/list_contains_row_group_pruning.test
@@ -28,6 +28,25 @@ EXPLAIN ANALYZE SELECT count(*) FROM lists WHERE contains(l, 3000);
 ----
 analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
 
+statement ok
+CREATE TABLE nullable_lists AS
+SELECT CASE
+           WHEN i % 100 = 0 THEN NULL
+           WHEN i < 4096 THEN [i]
+           ELSE [3000 + 2 * (i % 2)]
+       END AS l
+FROM range(6144) tbl(i);
+
+query I
+SELECT count(*) FROM nullable_lists WHERE list_contains(l, 3001);
+----
+1
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM nullable_lists WHERE list_contains(l, 3001);
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 2 / 3.*
+
 # Preserve lossy intermediate casts when deriving needle statistics
 statement ok
 CREATE TABLE cast_lists AS

--- a/test/sql/optimizer/list_contains_row_group_pruning.test
+++ b/test/sql/optimizer/list_contains_row_group_pruning.test
@@ -28,13 +28,10 @@ EXPLAIN ANALYZE SELECT count(*) FROM lists WHERE contains(l, 3000);
 ----
 analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
 
+# FILTER_FALSE_OR_NULL can still prune a row group
 statement ok
 CREATE TABLE nullable_lists AS
-SELECT CASE
-           WHEN i % 100 = 0 THEN NULL
-           WHEN i < 4096 THEN [i]
-           ELSE [3000 + 2 * (i % 2)]
-       END AS l
+SELECT CASE WHEN i % 100 = 0 THEN NULL ELSE [i] END AS l
 FROM range(6144) tbl(i);
 
 query I
@@ -45,7 +42,7 @@ SELECT count(*) FROM nullable_lists WHERE list_contains(l, 3001);
 query II
 EXPLAIN ANALYZE SELECT count(*) FROM nullable_lists WHERE list_contains(l, 3001);
 ----
-analyzed_plan	<REGEX>:.*Row Groups Scanned: 2 / 3.*
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
 
 # Preserve lossy intermediate casts when deriving needle statistics
 statement ok


### PR DESCRIPTION
Hi team, I found for `list_contains` function, row group pruning doesn't always work as expected, for example,
```sql
memory D ATTACH '/tmp/list_contains_row_group_pruning.duckdb' AS db (ROW_GROUP_SIZE 2048);
memory D USE db;
db D CREATE TABLE nullable_lists AS
     SELECT CASE WHEN i % 100 = 0 THEN NULL ELSE [i] END AS l
     FROM range(6144) tbl(i);
db D EXPLAIN ANALYZE SELECT count(*) FROM nullable_lists WHERE list_contains(l, 3001);
╭─ Summary ───────────╮
│ Total Time: 0.0016s │
╰─────────────────────╯
╭─ Ungrouped Aggregate ───────────╮
│ Aggregates: count_star()        │
│ 1 row                       0µs │
╰────────────────┒┎───────────────╯
╭─ Table Scan ───┚┖───────────────╮
│ Table: db.main.nullable_lists   │
│ Type: Sequential Scan           │
│ Filters: list_contains(l, 3001) │
│ Row Groups Scanned: 3 / 3       │
│ 1 row                       0µs │
╰─────────────────────────────────╯
```
Here we should only access one single row group, but somehow all of them are accessed.

I think the reason is, currently we only prune for [`ALWAYS_FALSE`](https://github.com/duckdb/duckdb/blob/5b1ef771b29aa1bf7d1013028cd622352e5adeda/src/storage/table/row_group.cpp#L763-L765), which doesn't consider NULL cases.

The same prune result is applied [earlier in the same function](https://github.com/duckdb/duckdb/blob/5b1ef771b29aa1bf7d1013028cd622352e5adeda/src/storage/table/row_group.cpp#L742-L745).