### PR TITLE
Prune segment on FALSE_OR_NULL

### DIFF
--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -790,7 +790,8 @@ bool RowGroup::CheckZonemapSegments(CollectionScanState &state) {
 
 		optional_ptr<SegmentNode<ColumnSegment>> current_segment;
 		auto prune_result = column_data.CheckZonemap(state.column_scans[column_idx], filter, current_segment);
-		if (prune_result != FilterPropagateResult::FILTER_ALWAYS_FALSE) {
+		if (prune_result != FilterPropagateResult::FILTER_ALWAYS_FALSE &&
+		    prune_result != FilterPropagateResult::FILTER_FALSE_OR_NULL) {
 			continue;
 		}
 

--- a/test/configs/compressed_in_memory.json
+++ b/test/configs/compressed_in_memory.json
@@ -31,7 +31,8 @@
     {
       "reason": "Compression packs validity into one segment, so zonemap pruning cannot skip rows.",
       "paths": [
-        "test/sql/optimizer/nested_null_segment_pruning.test"
+        "test/sql/optimizer/nested_null_segment_pruning.test",
+        "test/sql/optimizer/false_or_null_segment_pruning.test"
       ]
     }
   ]

--- a/test/configs/disable_optimizer.json
+++ b/test/configs/disable_optimizer.json
@@ -14,6 +14,7 @@
       "reason": "Zone map pruning requires filter pushdown from optimizer.",
       "paths": [
         "test/sql/optimizer/nested_null_segment_pruning.test",
+        "test/sql/optimizer/false_or_null_segment_pruning.test",
         "test/sql/optimizer/struct_segment_pruning.test",
         "test/sql/optimizer/list_contains_row_group_pruning.test",
         "test/sql/copy/parquet/list_contains_row_group_pruning.test",

--- a/test/configs/encryption.json
+++ b/test/configs/encryption.json
@@ -102,7 +102,8 @@
     {
       "reason": "Encrypted persistent storage packs validity into one segment, so zonemap pruning cannot skip rows.",
       "paths": [
-        "test/sql/optimizer/nested_null_segment_pruning.test"
+        "test/sql/optimizer/nested_null_segment_pruning.test",
+        "test/sql/optimizer/false_or_null_segment_pruning.test"
       ]
     },
     {

--- a/test/sql/optimizer/false_or_null_segment_pruning.test
+++ b/test/sql/optimizer/false_or_null_segment_pruning.test
@@ -1,0 +1,41 @@
+# name: test/sql/optimizer/false_or_null_segment_pruning.test
+# description: FILTER_FALSE_OR_NULL prunes segments in native scans
+# group: [optimizer]
+
+require json
+
+require no_force_storage
+
+require vector_size 2048
+
+statement ok
+SET threads = 1
+
+statement ok
+CREATE TABLE integers AS
+SELECT CASE WHEN range % 2 = 0 THEN range::INTEGER ELSE NULL END AS x
+FROM range(100000);
+
+statement ok
+PRAGMA enable_profiling = 'json'
+
+statement ok
+PRAGMA profiling_output = '{TEST_DIR}/false_or_null_segment_profile.json'
+
+statement ok
+SET tracked_metrics = ['query.total_rows_scanned']
+
+query I
+SELECT count(*) FROM integers WHERE x > 100000 - x;
+----
+24999
+
+statement ok
+PRAGMA disable_profiling
+
+# A full scan is 100000 rows
+query I
+SELECT query.total_rows_scanned < 100000
+FROM '{TEST_DIR}/false_or_null_segment_profile.json'
+----
+true


### PR DESCRIPTION
Hi team, similar to https://github.com/duckdb/duckdb/pull/25063, I think we could prune segments more properly.
For example, 
```sql
memory D CREATE TABLE integers AS
         SELECT CASE WHEN range % 2 = 0 THEN range::INTEGER ELSE NULL END AS x
         FROM range(100000);
memory D PRAGMA enable_profiling = 'json';
memory D SET tracked_metrics = ['query.total_rows_scanned'];
memory D SELECT count(*) FROM integers WHERE x > 100000 - x;
{
    "query": {
        "total_rows_scanned": 100000
    }
}
```
The query scans all rows and segments unexpectedly, but only later segments should be accessed.

The reason is, when pruning segments, either FALSE or NULL should be used to prune, but we only check [ALWAYS_FALSE](https://github.com/duckdb/duckdb/blob/5b1ef771b29aa1bf7d1013028cd622352e5adeda/src/storage/table/row_group.cpp#L793-L795) for now.