### PR TITLE
Run osx workflow in main CI based on changed files

### DIFF
--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -31,6 +31,7 @@ on:
       - '.github/workflows/Windows.yml'
       - '.github/workflows/Regression.yml'
       - '.github/workflows/Extensions.yml'
+      - '.github/workflows/OSX.yml'
   merge_group:
   pull_request:
     types: [opened, reopened, ready_for_review, converted_to_draft, synchronize]
@@ -46,6 +47,7 @@ on:
       - '.github/workflows/Windows.yml'
       - '.github/workflows/Regression.yml'
       - '.github/workflows/Extensions.yml'
+      - '.github/workflows/OSX.yml'
 
 
 concurrency:
@@ -148,6 +150,15 @@ jobs:
           files_yaml: |
             github:
               - .github/**
+            osx:
+              - '**'
+              - '!**.md'
+              - '!test/configs/**'
+              - '!tools/**'
+              - 'tools/shell/**'
+              - '!.github/patches/duckdb-wasm/**'
+              - '!.github/workflows/**'
+              - '.github/workflows/OSX.yml'
             extensions:
               - .github/config/**
               - .github/patches/**

--- a/.github/workflows/OSX.yml
+++ b/.github/workflows/OSX.yml
@@ -110,6 +110,7 @@ jobs:
 
         #     from https://docs.github.com/en/actions/deployment/deploying-xcode-applications/installing-an-apple-certificate-on-macos-runners-for-xcode-development
       - name: Sign Binaries
+        if: github.repository == 'duckdb/duckdb' && github.event_name != 'pull_request'
         shell: bash
         env:
           BUILD_CERTIFICATE_BASE64: ${{ secrets.OSX_CODESIGN_BUILD_CERTIFICATE_BASE64 }}

--- a/.github/workflows/OSX.yml
+++ b/.github/workflows/OSX.yml
@@ -10,22 +10,6 @@ on:
         type: boolean
       run_all:
         type: boolean
-  push:
-    branches-ignore:
-      - 'main'
-      - 'feature'
-      - 'v*.*-*'
-      - 'gh-readonly-queue/**'
-    paths:
-      - '**'
-      - '!**.md'
-      - '!test/configs/**'
-      - '!tools/**'
-      - 'tools/shell/**'
-      - '!.github/patches/duckdb-wasm/**'
-      - '!.github/workflows/**'
-      - '.github/workflows/OSX.yml'
-
 
 concurrency:
   group: osx-${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}-${{ inputs.override_git_describe }}

--- a/.github/workflows/OSX.yml
+++ b/.github/workflows/OSX.yml
@@ -167,9 +167,9 @@ jobs:
           for library in build/release/libs/*.a; do
             library_name="$(basename "$library")"
             lipo -extract arm64 -output "build/release_arm64/libs/$library_name" "$library"
-            lipo -verify_arch arm64 "build/release_arm64/libs/$library_name"
+            lipo "build/release_arm64/libs/$library_name" -verify_arch arm64
             lipo -extract x86_64 -output "build/release_amd64/libs/$library_name" "$library"
-            lipo -verify_arch x86_64 "build/release_amd64/libs/$library_name"
+            lipo "build/release_amd64/libs/$library_name" -verify_arch x86_64
           done
 
           make cli-release-artifact ARTIFACT_SUFFIX=osx-universal CLI_BINARY=build/release/duckdb

--- a/scripts/ci/job_stages.py
+++ b/scripts/ci/job_stages.py
@@ -111,6 +111,13 @@ def enabled_jobs(selection_input: JobSelectionInput) -> list[str]:
     if selection_input.skip_tests:
         selected_jobs = [job for job in selected_jobs if job not in SKIP_TESTS_JOBS]
 
+    if (
+        selection_input.event_name in {"push", "pull_request"}
+        and "osx" in selection_input.changed_keys
+        and "osx" not in selected_jobs
+    ):
+        selected_jobs.append("osx")
+
     if selection_input.event_name in {"workflow_dispatch", "repository_dispatch"}:
         selected_jobs.extend(RELEASE_JOBS)
 

--- a/scripts/ci/test_job_stages.py
+++ b/scripts/ci/test_job_stages.py
@@ -126,16 +126,19 @@ class JobStagesTest(unittest.TestCase):
 
     @unittest.skipIf(os.getenv("OVERRIDE_JOBS") is not None, SKIP_IF_OVERRIDE)
     def test_merge_group_minimal_jobs(self):
-        selection = self._compute_job_selection("merge_group", "gh-readonly-queue/main/pr-1-abc", "duckdb/duckdb")
+        selection = self._compute_job_selection(
+            "merge_group", "gh-readonly-queue/main/pr-1-abc", "duckdb/duckdb", changed_keys={"osx"}
+        )
         required_jobs = {"linux-relassert", "linux-release", "linux-release-tests", "tidy-check"}
         self.assertTrue(required_jobs.issubset(set(selection.enabled_jobs)))
+        self.assertNotIn("osx", selection.enabled_jobs)
         self.assertTrue(selection.save_cache)
 
     @unittest.skipIf(os.getenv("OVERRIDE_JOBS") is not None, SKIP_IF_OVERRIDE)
     def test_main_includes_main_only_jobs(self):
-        selection = self._compute_job_selection("push", "main", "duckdb/duckdb")
+        selection = self._compute_job_selection("push", "main", "duckdb/duckdb", changed_keys={"osx"})
         self.assertIn("codecov", selection.enabled_jobs)
-        self.assertIn("osx", selection.enabled_jobs)
+        self.assertEqual(selection.enabled_jobs.count("osx"), 1)
         self.assertTrue(selection.save_cache)
 
     @unittest.skipIf(os.getenv("OVERRIDE_JOBS") is not None, SKIP_IF_OVERRIDE)
@@ -155,7 +158,16 @@ class JobStagesTest(unittest.TestCase):
     def test_regular_branch_excludes_main_only_jobs(self):
         selection = self._compute_job_selection("pull_request", "feature/my-branch", "duckdb/duckdb")
         self.assertNotIn("codecov", selection.enabled_jobs)
+        self.assertNotIn("osx", selection.enabled_jobs)
         self.assertFalse(selection.save_cache)
+
+    @unittest.skipIf(os.getenv("OVERRIDE_JOBS") is not None, SKIP_IF_OVERRIDE)
+    def test_osx_changed_key_enables_osx(self):
+        for event_name in ["push", "pull_request"]:
+            selection = self._compute_job_selection(
+                event_name, "feature/my-branch", "duckdb/duckdb", changed_keys={"osx"}
+            )
+            self.assertIn("osx", selection.enabled_jobs)
 
     def test_fork_saves_cache(self):
         selection = self._compute_job_selection("pull_request", "feature/my-branch", "somefork/duckdb")


### PR DESCRIPTION
- Fix osx lipo command arguments order.
- Run osx workflow in PR if changed.
- Only sign OSX release binaries for a release (otherwise, secrets are missing, and CI fails).