### PR TITLE
Add latch_database_read_only(): one-way runtime read-only latch

### DIFF
--- a/src/function/table/checkpoint.cpp
+++ b/src/function/table/checkpoint.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/function/table/range.hpp"
+#include "duckdb/main/attached_database.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/storage/storage_manager.hpp"
 #include "duckdb/transaction/transaction_manager.hpp"
@@ -24,11 +25,8 @@ public:
 	}
 };
 
-static unique_ptr<FunctionData> CheckpointBind(ClientContext &context, TableFunctionBindInput &input,
-                                               vector<LogicalType> &return_types, vector<Identifier> &names) {
-	return_types.emplace_back(LogicalType::BOOLEAN);
-	names.emplace_back("Success");
-
+//! Resolve the (optional) database-name argument to an attached database.
+static optional_ptr<AttachedDatabase> BindTargetDatabase(ClientContext &context, TableFunctionBindInput &input) {
 	optional_ptr<AttachedDatabase> db;
 	auto &db_manager = DatabaseManager::Get(context);
 	if (!input.inputs.empty()) {
@@ -43,7 +41,14 @@ static unique_ptr<FunctionData> CheckpointBind(ClientContext &context, TableFunc
 	} else {
 		db = db_manager.GetDatabase(context, DatabaseManager::GetDefaultDatabase(context));
 	}
-	return make_uniq<CheckpointBindData>(db);
+	return db;
+}
+
+static unique_ptr<FunctionData> CheckpointBind(ClientContext &context, TableFunctionBindInput &input,
+                                               vector<LogicalType> &return_types, vector<Identifier> &names) {
+	return_types.emplace_back(LogicalType::BOOLEAN);
+	names.emplace_back("Success");
+	return make_uniq<CheckpointBindData>(BindTargetDatabase(context, input));
 }
 
 template <bool FORCE>
@@ -64,6 +69,48 @@ void CheckpointFunction::RegisterFunction(BuiltinFunctions &set) {
 	force_checkpoint.AddFunction(
 	    TableFunction({LogicalType::VARCHAR}, TemplatedCheckpointFunction<true>, CheckpointBind));
 	set.AddFunction(force_checkpoint);
+}
+
+//===--------------------------------------------------------------------===//
+// latch_database_read_only
+//===--------------------------------------------------------------------===//
+struct LatchReadOnlyGlobalState : public GlobalTableFunctionState {
+	bool finished = false;
+};
+
+static unique_ptr<GlobalTableFunctionState> LatchReadOnlyInit(ClientContext &context, TableFunctionInitInput &input) {
+	return make_uniq<LatchReadOnlyGlobalState>();
+}
+
+static unique_ptr<FunctionData> LatchReadOnlyBind(ClientContext &context, TableFunctionBindInput &input,
+                                                  vector<LogicalType> &return_types, vector<Identifier> &names) {
+	return_types.emplace_back(LogicalType::BOOLEAN);
+	names.emplace_back("latched");
+	return make_uniq<CheckpointBindData>(BindTargetDatabase(context, input));
+}
+
+static void LatchReadOnlyExecute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &state = data_p.global_state->Cast<LatchReadOnlyGlobalState>();
+	if (state.finished) {
+		return;
+	}
+	state.finished = true;
+	auto &bind_data = data_p.bind_data->Cast<CheckpointBindData>();
+	auto &db = *bind_data.db.get_mutable();
+	bool latched = db.LatchReadOnly(context);
+	// emit a single row: whether this call flipped the database to read-only (false if it already was)
+	output.SetCardinality(1);
+	output.SetValue(0, 0, Value::BOOLEAN(latched));
+}
+
+void LatchReadOnlyFunction::RegisterFunction(BuiltinFunctions &set) {
+	// one-way latch: flips a read-write database to read-only at runtime, attempting a checkpoint;
+	// shares the database-name resolution with checkpoint() but reports its result as `latched`
+	TableFunctionSet latch("latch_database_read_only");
+	latch.AddFunction(TableFunction({}, LatchReadOnlyExecute, LatchReadOnlyBind, LatchReadOnlyInit));
+	latch.AddFunction(
+	    TableFunction({LogicalType::VARCHAR}, LatchReadOnlyExecute, LatchReadOnlyBind, LatchReadOnlyInit));
+	set.AddFunction(latch);
 }
 
 } // namespace duckdb

--- a/src/function/table/range.cpp
+++ b/src/function/table/range.cpp
@@ -448,6 +448,7 @@ void BuiltinFunctions::RegisterTableFunctions() {
 	ReadBlobFunction::RegisterFunction(*this);
 	ReadTextFunction::RegisterFunction(*this);
 	QueryTableFunction::RegisterFunction(*this);
+	LatchReadOnlyFunction::RegisterFunction(*this);
 }
 
 } // namespace duckdb

--- a/src/include/duckdb/function/table/range.hpp
+++ b/src/include/duckdb/function/table/range.hpp
@@ -17,6 +17,10 @@ struct CheckpointFunction {
 	static void RegisterFunction(BuiltinFunctions &set);
 };
 
+struct LatchReadOnlyFunction {
+	static void RegisterFunction(BuiltinFunctions &set);
+};
+
 struct GlobTableFunction {
 	static void RegisterFunction(BuiltinFunctions &set);
 };

--- a/src/include/duckdb/main/attached_database.hpp
+++ b/src/include/duckdb/main/attached_database.hpp
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include "duckdb/common/atomic.hpp"
+#include "duckdb/common/mutex.hpp"
 #include "duckdb/common/optional.hpp"
 #include "duckdb/common/prefetched_file_data.hpp"
 #include "duckdb/main/config.hpp"
@@ -143,6 +145,18 @@ public:
 	bool IsInitialDatabase() const;
 	void SetInitialDatabase();
 	void SetReadOnlyDatabase();
+	//! One-way latch: flip a read-write database to read-only at runtime. This is an SQL-level write gate: after the
+	//! flip, new statements can no longer register writes against this attached database entry. The latch only gates
+	//! the entry, not the file: there is no unlatch statement, but DETACH followed by re-ATTACH creates a new,
+	//! writable entry, so in an untrusted-SQL setting the latch must be combined with disabling ATTACH/DETACH
+	//! (e.g. SET enable_external_access = false plus SET lock_configuration = true). The storage layer itself stays
+	//! open read-write - the OS file lock is unchanged, and CHECKPOINT on a latched database still writes to the file
+	//! (unlike a genuine READ_ONLY attach, where it is a no-op) - and a write transaction admitted in the window just
+	//! before the flip can still commit afterwards. Attempts a checkpoint after the flip; throws (and reverts) if the
+	//! calling transaction has pending changes on the database or other write transactions are active (for
+	//! storage-extension catalogs this active-write-transaction check does not apply). Returns false if already
+	//! read-only.
+	bool LatchReadOnly(ClientContext &context);
 	void OnDetach(ClientContext &context);
 	RecoveryMode GetRecoveryMode() const {
 		return recovery_mode;
@@ -180,7 +194,10 @@ private:
 	unique_ptr<StorageManager> storage;
 	unique_ptr<Catalog> catalog;
 	unique_ptr<TransactionManager> transaction_manager;
-	AttachedDatabaseType type;
+	//! Atomic: LatchReadOnly can flip this to READ_ONLY_DATABASE while other threads read it
+	atomic<AttachedDatabaseType> type;
+	//! Serializes LatchReadOnly calls, so a concurrent latch cannot observe a mid-flight flip that later reverts
+	mutex latch_lock;
 	optional_ptr<Catalog> parent_catalog;
 	optional_ptr<StorageExtension> storage_extension;
 	RecoveryMode recovery_mode = RecoveryMode::DEFAULT;

--- a/src/main/attached_database.cpp
+++ b/src/main/attached_database.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/catalog/duck_catalog.hpp"
 #include "duckdb/common/constants.hpp"
 #include "duckdb/common/enums/checkpoint_on_detach.hpp"
+#include "duckdb/common/exception/transaction_exception.hpp"
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/main/database.hpp"
 #include "duckdb/main/database_manager.hpp"
@@ -12,6 +13,7 @@
 #include "duckdb/parser/qualified_name.hpp"
 #include "duckdb/storage/storage_extension.hpp"
 #include "duckdb/storage/storage_manager.hpp"
+#include "duckdb/transaction/duck_transaction.hpp"
 #include "duckdb/transaction/duck_transaction_manager.hpp"
 #include "duckdb/main/database_path_and_type.hpp"
 #include "duckdb/main/valid_checker.hpp"
@@ -138,12 +140,9 @@ AttachedDatabase::AttachedDatabase(DatabaseInstance &db, AttachedDatabaseType ty
 AttachedDatabase::AttachedDatabase(DatabaseInstance &db, Catalog &catalog_p, Identifier name_p, string file_path_p,
                                    AttachOptions &options)
     : CatalogEntry(CatalogType::DATABASE_ENTRY, catalog_p, std::move(name_p)), db(db), validity(db),
+      type(options.access_mode == AccessMode::READ_ONLY ? AttachedDatabaseType::READ_ONLY_DATABASE
+                                                        : AttachedDatabaseType::READ_WRITE_DATABASE),
       parent_catalog(&catalog_p), close_lock(make_shared_ptr<mutex>()) {
-	if (options.access_mode == AccessMode::READ_ONLY) {
-		type = AttachedDatabaseType::READ_ONLY_DATABASE;
-	} else {
-		type = AttachedDatabaseType::READ_WRITE_DATABASE;
-	}
 	recovery_mode = options.recovery_mode;
 	visibility = options.visibility;
 	ephemeral = options.ephemeral;
@@ -162,12 +161,9 @@ AttachedDatabase::AttachedDatabase(DatabaseInstance &db, Catalog &catalog_p, Ide
 AttachedDatabase::AttachedDatabase(DatabaseInstance &db, Catalog &catalog_p, StorageExtension &storage_extension_p,
                                    ClientContext &context, Identifier name_p, AttachInfo &info, AttachOptions &options)
     : CatalogEntry(CatalogType::DATABASE_ENTRY, catalog_p, std::move(name_p)), db(db), validity(db),
+      type(options.access_mode == AccessMode::READ_ONLY ? AttachedDatabaseType::READ_ONLY_DATABASE
+                                                        : AttachedDatabaseType::READ_WRITE_DATABASE),
       parent_catalog(&catalog_p), storage_extension(&storage_extension_p), close_lock(make_shared_ptr<mutex>()) {
-	if (options.access_mode == AccessMode::READ_ONLY) {
-		type = AttachedDatabaseType::READ_ONLY_DATABASE;
-	} else {
-		type = AttachedDatabaseType::READ_WRITE_DATABASE;
-	}
 	recovery_mode = options.recovery_mode;
 	visibility = options.visibility;
 	ephemeral = options.ephemeral;
@@ -352,6 +348,69 @@ void AttachedDatabase::SetInitialDatabase() {
 
 void AttachedDatabase::SetReadOnlyDatabase() {
 	type = AttachedDatabaseType::READ_ONLY_DATABASE;
+}
+
+bool AttachedDatabase::LatchReadOnly(ClientContext &context) {
+	// serialize latch attempts - a concurrent latch must not observe a mid-flight flip that later reverts
+	lock_guard<mutex> latch_guard(latch_lock);
+	if (IsReadOnly()) {
+		// the latch is idempotent - latching an already read-only database is a no-op
+		return false;
+	}
+	if (IsSystem() || IsTemporary()) {
+		throw InvalidInputException("Cannot latch database \"%s\" to read-only: only regular databases can be latched",
+		                            GetName().GetIdentifierName());
+	}
+	if (!transaction_manager->IsDuckTransactionManager()) {
+		// extension catalog (e.g. a storage extension): the latch closes the SQL-level write gate only. The
+		// extension's own storage/transaction manager is not informed of the flip, in-flight extension
+		// transactions are unaffected, and the active-write-transaction check below does not apply.
+		SetReadOnlyDatabase();
+		return true;
+	}
+	auto &duck_tm = transaction_manager->Cast<DuckTransactionManager>();
+	{
+		// The calling transaction itself may have pending changes on this database - report that specifically,
+		// instead of the generic concurrent-conflict errors below.
+		auto current = Transaction::TryGet(context, *this);
+		if (current && current->Cast<DuckTransaction>().ChangesMade()) {
+			throw TransactionException(
+			    "Cannot latch database \"%s\" to read-only: the current transaction has pending changes on it",
+			    GetName().GetIdentifierName());
+		}
+	}
+	{
+		// Pre-check: the shared vacuum lock is held by insert/delete transactions, but also by index scans and
+		// checkpoints. If it cannot be taken exclusively, some concurrent operation is in flight and the caller
+		// should retry. Update/DDL transactions are rejected by Checkpoint() below instead.
+		auto vacuum_lock = duck_tm.TryGetVacuumLock();
+		if (!vacuum_lock) {
+			throw TransactionException(
+			    "Cannot latch database \"%s\" to read-only: concurrent operations prevent latching, retry later",
+			    GetName().GetIdentifierName());
+		}
+	}
+	// close the SQL-level write gate: after this, no new statement can register writes against this attached
+	// database entry. The gate covers the entry only - DETACH followed by re-ATTACH creates a new, writable
+	// entry, so in an untrusted-SQL setting the latch must be combined with disabling ATTACH/DETACH
+	// (e.g. SET enable_external_access = false plus SET lock_configuration = true). The storage layer stays
+	// open read-write (the OS file lock is unchanged and CHECKPOINT still writes to the file), and a write
+	// transaction admitted in the window before this flip can still commit afterwards - its data is preserved
+	// in the WAL, it is just not covered by the checkpoint below.
+	SetReadOnlyDatabase();
+	try {
+		// attempt to checkpoint so the on-disk state is up to date;
+		// this throws if other write transactions are active - the latch fails and the type is restored
+		transaction_manager->Checkpoint(context, false);
+	} catch (TransactionException &) {
+		type = AttachedDatabaseType::READ_WRITE_DATABASE;
+		throw TransactionException("Cannot latch database \"%s\" to read-only: there are active write transactions",
+		                           GetName().GetIdentifierName());
+	} catch (...) {
+		type = AttachedDatabaseType::READ_WRITE_DATABASE;
+		throw;
+	}
+	return true;
 }
 
 void AttachedDatabase::OnDetach(ClientContext &context) {

--- a/test/sql/storage/latch_database_read_only.test
+++ b/test/sql/storage/latch_database_read_only.test
@@ -1,0 +1,259 @@
+# name: test/sql/storage/latch_database_read_only.test
+# description: One-way runtime read-only latch on a database
+# group: [storage]
+
+# the latch is runtime-only state - reloading the database from disk would silently drop it
+require skip_reload
+
+load {TEST_DIR}/latch_ro.db
+
+statement ok
+CREATE TABLE t AS SELECT 42 AS i;
+
+statement ok
+CREATE MACRO answer() AS TABLE SELECT i FROM t;
+
+# a write prepared before the latch, executed after it (below)
+statement ok
+PREPARE ins AS INSERT INTO t VALUES (99);
+
+# the bare form latches the current database; `latched` reports that this call flipped the database
+query I
+CALL latch_database_read_only();
+----
+true
+
+# reads still work, including objects created pre-latch
+query I
+SELECT * FROM answer();
+----
+42
+
+# the database now reports as read-only
+query I
+SELECT readonly FROM duckdb_databases() WHERE database_name = 'latch_ro';
+----
+true
+
+# writes are rejected with the same error as ATTACH (READ_ONLY)
+statement error
+CREATE TABLE t2 (i INTEGER);
+----
+read-only
+
+statement error
+INSERT INTO t VALUES (1);
+----
+read-only
+
+statement error
+DROP TABLE t;
+----
+read-only
+
+# a prepared write created before the latch fails at execution time
+statement error
+EXECUTE ins;
+----
+read-only
+
+# temp objects remain writable, as in -readonly mode
+statement ok
+CREATE TEMPORARY TABLE tmp (i INTEGER);
+
+statement ok
+INSERT INTO tmp VALUES (1);
+
+# the latch is idempotent - a second call reports that nothing was flipped
+query I
+CALL latch_database_read_only();
+----
+false
+
+# CHECKPOINT of a latched database still succeeds - the storage layer stays open read-write
+statement ok
+CHECKPOINT;
+
+# the latch also works on attached databases, by name
+statement ok
+ATTACH '{TEST_DIR}/latch_ro_other.db' AS other;
+
+statement ok
+CREATE TABLE other.x AS SELECT 7 AS i;
+
+statement ok
+CALL latch_database_read_only('other');
+
+statement error
+INSERT INTO other.x VALUES (8);
+----
+read-only
+
+query I
+SELECT i FROM other.x;
+----
+7
+
+# in-memory databases can be latched too; the result column is named `latched`
+statement ok
+ATTACH ':memory:' AS mem;
+
+statement ok
+CREATE TABLE mem.m AS SELECT 1 AS i;
+
+query I
+SELECT latched FROM latch_database_read_only('mem');
+----
+true
+
+query I
+SELECT i FROM mem.m;
+----
+1
+
+statement error
+INSERT INTO mem.m VALUES (2);
+----
+read-only
+
+# system/temp databases cannot be latched
+statement error
+CALL latch_database_read_only('temp');
+----
+only regular databases
+
+statement error
+CALL latch_database_read_only('system');
+----
+only regular databases
+
+# the latch is runtime state, not a transactional change - rolling back the surrounding
+# transaction does not undo it
+statement ok
+ATTACH ':memory:' AS mem2;
+
+statement ok
+CREATE TABLE mem2.z (i INTEGER);
+
+statement ok
+BEGIN;
+
+query I
+CALL latch_database_read_only('mem2');
+----
+true
+
+statement ok
+ROLLBACK;
+
+statement error
+INSERT INTO mem2.z VALUES (1);
+----
+read-only
+
+query I
+SELECT readonly FROM duckdb_databases() WHERE database_name = 'mem2';
+----
+true
+
+# the calling transaction's own pending changes block the latch with a specific error
+statement ok
+ATTACH ':memory:' AS mem3;
+
+statement ok
+CREATE TABLE mem3.w (i INTEGER);
+
+statement ok
+BEGIN;
+
+statement ok
+INSERT INTO mem3.w VALUES (1);
+
+statement error
+CALL latch_database_read_only('mem3');
+----
+the current transaction has pending changes on it
+
+statement ok
+ROLLBACK;
+
+# the failed latch left the database writable
+statement ok
+INSERT INTO mem3.w VALUES (2);
+
+# a write transaction with local changes blocks the latch
+statement ok
+ATTACH '{TEST_DIR}/latch_ro_third.db' AS third;
+
+statement ok
+CREATE TABLE third.y (i INTEGER);
+
+statement ok
+INSERT INTO third.y VALUES (0);
+
+# an in-flight UPDATE is rejected by the checkpoint attempt
+statement ok con1
+BEGIN;
+
+statement ok con1
+UPDATE third.y SET i = 1;
+
+statement error con2
+CALL latch_database_read_only('third');
+----
+there are active write transactions
+
+statement ok con1
+ROLLBACK;
+
+# an in-flight INSERT holds the shared vacuum lock and is rejected by the pre-check
+statement ok con1
+BEGIN;
+
+statement ok con1
+INSERT INTO third.y VALUES (2);
+
+statement error con2
+CALL latch_database_read_only('third');
+----
+concurrent operations prevent latching
+
+statement ok con1
+COMMIT;
+
+statement ok con2
+CALL latch_database_read_only('third');
+
+# documented behavior: the latch gates the attached database entry only. DETACH followed by
+# re-ATTACH creates a new, writable entry - this is why untrusted-SQL setups must also disable
+# ATTACH/DETACH (SET enable_external_access = false plus SET lock_configuration = true).
+statement ok
+ATTACH '{TEST_DIR}/latch_ro_bypass.db' AS bypass;
+
+statement ok
+CREATE TABLE bypass.b AS SELECT 1 AS i;
+
+query I
+CALL latch_database_read_only('bypass');
+----
+true
+
+statement error
+INSERT INTO bypass.b VALUES (2);
+----
+read-only
+
+statement ok
+DETACH bypass;
+
+statement ok
+ATTACH '{TEST_DIR}/latch_ro_bypass.db' AS bypass;
+
+statement ok
+INSERT INTO bypass.b VALUES (2);
+
+# after a restart the database is writable again - the latch is per-process, like -readonly
+restart
+
+statement ok
+CREATE TABLE t3 (i INTEGER);


### PR DESCRIPTION
Feature suggestion: `CALL latch_database_read_only('db')` — switch an attached database from read-write to read-only at runtime. One-way: nothing flips it back except detach/restart.

**Why.** Serve-only processes (read replicas, SQL-serving pods) want a bootstrap-then-lock lifecycle: open writable, create macros/views/secrets, latch, serve. Read-only is currently decidable only at open time, so this setup has to happen out-of-band.

One-way here means there is no unlatch statement. `DETACH` + re-`ATTACH` does create a fresh writable entry, though — so for serving untrusted SQL, combine the latch with `SET enable_external_access = false` (plus `SET lock_configuration = true`).

**Example** — a read pod serving SQL over [quack](https://github.com/duckdb/duckdb-quack); this currently requires provisioning the database from a second process and starting this one with `-readonly`:

```sql
-- opened read-write for bootstrap
INSTALL quack; LOAD quack;
CREATE MACRO authz(sid, q) AS (...);          -- authorization hook for served queries
SET quack_authorization_function = 'authz';

-- Latch the current database (the one this process opened, like bare CHECKPOINT):
-- from here on, no statement can write to it.
CALL latch_database_read_only();
-- A specific attached database can be latched by name:
--   CALL latch_database_read_only('lake');

SELECT * FROM quack_serve('quack:0.0.0.0:9494', token => getenv('TOKEN'));
```

**Semantics.**
- Refuses `system` and `temp`; temp tables stay writable after the latch.
- Errors if write transactions are active; on failure the flag is reverted.
- Attempts a checkpoint on success so the WAL is flushed.
- `CHECKPOINT` on a latched database still writes the file (WAL flush remains possible).
- The result column `latched` reports whether this call performed the flip.
- Not persisted: a restart honors the configured access mode again.

**Scope, to be clear:** this is an SQL-level write gate — the same statement-level enforcement `-readonly` uses. The storage layer stays open read-write (OS file lock unchanged), and a write transaction admitted in the instant before the flip can still commit afterwards.

**Implementation.** Builds on the existing public `AttachedDatabase::SetReadOnlyDatabase()`, makes the access-mode flag atomic (latch calls serialized by a mutex), and reuses the checkpoint machinery to reject concurrent writers. Sqllogictest included.

No attachment to the surface or the name — happy to rework it as `ALTER DATABASE ... READ ONLY` or otherwise if the capability itself is of interest.

