### PR TITLE
Restore replaced database after ATTACH OR REPLACE rollback

### DIFF
--- a/src/include/duckdb/main/attached_database.hpp
+++ b/src/include/duckdb/main/attached_database.hpp
@@ -143,6 +143,12 @@ public:
 	bool IsInitialDatabase() const;
 	void SetInitialDatabase();
 	void SetReadOnlyDatabase();
+	bool IsPendingReplacement() const {
+		return pending_replacement;
+	}
+	void SetPendingReplacement(bool value) {
+		pending_replacement = value;
+	}
 	void OnDetach(ClientContext &context);
 	RecoveryMode GetRecoveryMode() const {
 		return recovery_mode;
@@ -187,6 +193,7 @@ private:
 	AttachVisibility visibility = AttachVisibility::SHOWN;
 	bool ephemeral = false;
 	bool is_initial_database = false;
+	atomic<bool> pending_replacement = false;
 	bool is_closed = false;
 	bool is_closing = false;
 	shared_ptr<mutex> close_lock;

--- a/src/include/duckdb/main/database_manager.hpp
+++ b/src/include/duckdb/main/database_manager.hpp
@@ -60,6 +60,7 @@ public:
 	void Alter(ClientContext &context, AlterInfo &info);
 	//! Rollback the attach of a database
 	shared_ptr<AttachedDatabase> DetachInternal(const Identifier &name);
+	void RollbackAttach(AttachedDatabase &database, optional_ptr<AttachedDatabase> replaced_database);
 	//! Returns a reference to the system catalog
 	Catalog &GetSystemCatalog();
 

--- a/src/include/duckdb/transaction/duck_transaction.hpp
+++ b/src/include/duckdb/transaction/duck_transaction.hpp
@@ -59,7 +59,7 @@ public:
 	LocalStorage &GetLocalStorage();
 
 	void PushCatalogEntry(CatalogEntry &entry, data_ptr_t extra_data, idx_t extra_data_size);
-	void PushAttach(AttachedDatabase &db);
+	void PushAttach(AttachedDatabase &db, optional_ptr<AttachedDatabase> replaced_database);
 
 	void SetModifications(DatabaseModificationType type) override;
 

--- a/src/include/duckdb/transaction/duck_transaction_manager.hpp
+++ b/src/include/duckdb/transaction/duck_transaction_manager.hpp
@@ -80,7 +80,8 @@ public:
 
 	void PushCatalogEntry(Transaction &transaction_p, CatalogEntry &entry, data_ptr_t extra_data = nullptr,
 	                      idx_t extra_data_size = 0);
-	void PushAttach(Transaction &transaction_p, AttachedDatabase &db);
+	void PushAttach(Transaction &transaction_p, AttachedDatabase &db,
+	                optional_ptr<AttachedDatabase> replaced_database = nullptr);
 
 protected:
 	struct CheckpointDecision {

--- a/src/include/duckdb/transaction/meta_transaction.hpp
+++ b/src/include/duckdb/transaction/meta_transaction.hpp
@@ -83,7 +83,8 @@ public:
 	optional_ptr<AttachedDatabase> GetReferencedDatabase(const Identifier &name);
 	shared_ptr<AttachedDatabase> GetReferencedDatabaseOwning(const Identifier &name);
 	AttachedDatabase &UseDatabase(shared_ptr<AttachedDatabase> &database);
-	void DetachDatabase(AttachedDatabase &database);
+	AttachedDatabase &AttachDatabase(shared_ptr<AttachedDatabase> &database);
+	void ReplaceDatabase(shared_ptr<AttachedDatabase> &database);
 
 private:
 	friend class SecretManager;
@@ -104,6 +105,10 @@ private:
 	reference_map_t<AttachedDatabase, shared_ptr<AttachedDatabase>> referenced_databases;
 	//! Map of name -> database for databases that are in-use by this transaction.
 	identifier_map_t<reference<AttachedDatabase>> used_databases;
+	//! Databases replaced by an attachment in this transaction.
+	vector<reference<AttachedDatabase>> replaced_databases;
+	//! Replacement databases attached in this transaction.
+	vector<reference<AttachedDatabase>> replacement_databases;
 	//! Secrets that only live for the duration of this transaction.
 	unique_ptr<SecretStorage> transaction_secret_storage;
 };

--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -14,6 +14,7 @@
 #include "duckdb/transaction/duck_transaction.hpp"
 #include "duckdb/transaction/duck_transaction_manager.hpp"
 #include "duckdb/common/enums/on_entry_not_found.hpp"
+#include "duckdb/common/exception/transaction_exception.hpp"
 #include "duckdb/transaction/meta_transaction.hpp"
 
 namespace duckdb {
@@ -225,36 +226,44 @@ optional_ptr<AttachedDatabase> DatabaseManager::FinalizeAttach(ClientContext &co
                                                                shared_ptr<AttachedDatabase> attached_db) {
 	const auto name = attached_db->GetName();
 	attached_db->oid = NextOid();
+	auto &meta_transaction = MetaTransaction::Get(context);
+	auto &transaction = DuckTransaction::Get(context, *system);
+	auto &transaction_manager = DuckTransactionManager::Get(*system);
 	shared_ptr<AttachedDatabase> detached_db;
+	optional_ptr<AttachedDatabase> db_ref;
 	{
 		lock_guard<mutex> guard(databases_lock);
-		auto entry = databases.emplace(name, attached_db);
-		if (!entry.second) {
+		auto entry = databases.find(name);
+		if (entry != databases.end()) {
 			if (info.on_conflict == OnCreateConflict::REPLACE_ON_CONFLICT) {
-				// override existing entry
-				detached_db = std::move(entry.first->second);
-				databases[name] = attached_db;
+				if (entry->second->IsPendingReplacement()) {
+					throw TransactionException(
+					    "Cannot replace database %s because it has uncommitted attachment changes", name);
+				}
+				detached_db = entry->second;
+				meta_transaction.ReplaceDatabase(detached_db);
 			} else {
 				throw BinderException("Failed to attach database: database with name \"%s\" already exists", name);
 			}
 		}
+		db_ref = detached_db ? meta_transaction.AttachDatabase(attached_db) : meta_transaction.UseDatabase(attached_db);
+		transaction_manager.PushAttach(transaction, *db_ref, detached_db);
+		attached_db->SetPendingReplacement(detached_db != nullptr);
+		if (entry == databases.end()) {
+			auto inserted = databases.emplace(name, attached_db);
+			D_ASSERT(inserted.second);
+		} else {
+			entry->second = attached_db;
+		}
 	}
-	auto &meta_transaction = MetaTransaction::Get(context);
 	if (detached_db) {
 		if (detached_db->GetCatalog().Supports(RemoteCapability::IS_REMOTE)) {
 			--remote_catalog_count;
 		}
-		meta_transaction.DetachDatabase(*detached_db);
-		detached_db->OnDetach(context);
-		detached_db.reset();
 	}
 	if (attached_db->GetCatalog().Supports(RemoteCapability::IS_REMOTE)) {
 		++remote_catalog_count;
 	}
-	auto &db_ref = meta_transaction.UseDatabase(attached_db);
-	auto &transaction = DuckTransaction::Get(context, *system);
-	auto &transaction_manager = DuckTransactionManager::Get(*system);
-	transaction_manager.PushAttach(transaction, db_ref);
 	return db_ref;
 }
 
@@ -309,6 +318,10 @@ void DatabaseManager::RenameDatabase(ClientContext &context, const Identifier &o
 			}
 			return;
 		}
+		if (old_entry->second->IsPendingReplacement()) {
+			throw TransactionException("Cannot rename database %s because it has uncommitted attachment changes",
+			                           old_name);
+		}
 
 		auto new_entry = databases.find(new_name);
 		if (new_entry != databases.end()) {
@@ -331,6 +344,9 @@ shared_ptr<AttachedDatabase> DatabaseManager::DetachInternal(const Identifier &n
 		if (entry == databases.end()) {
 			return nullptr;
 		}
+		if (entry->second->IsPendingReplacement()) {
+			throw TransactionException("Cannot detach database %s because it has uncommitted attachment changes", name);
+		}
 		attached_db = std::move(entry->second);
 		databases.erase(entry);
 	}
@@ -338,6 +354,33 @@ shared_ptr<AttachedDatabase> DatabaseManager::DetachInternal(const Identifier &n
 		--remote_catalog_count;
 	}
 	return attached_db;
+}
+
+void DatabaseManager::RollbackAttach(AttachedDatabase &database, optional_ptr<AttachedDatabase> replaced_database) {
+	bool detached_remote_database = false;
+	bool restored_remote_database = false;
+	{
+		lock_guard<mutex> guard(databases_lock);
+		auto entry = databases.find(database.GetName());
+		if (replaced_database) {
+			D_ASSERT(entry != databases.end() && entry->second.get() == &database);
+			if (entry != databases.end() && entry->second.get() == &database) {
+				detached_remote_database = database.GetCatalog().Supports(RemoteCapability::IS_REMOTE);
+				restored_remote_database = replaced_database->GetCatalog().Supports(RemoteCapability::IS_REMOTE);
+				entry->second = replaced_database->shared_from_this();
+			}
+		} else if (entry != databases.end() && entry->second.get() == &database) {
+			detached_remote_database = database.GetCatalog().Supports(RemoteCapability::IS_REMOTE);
+			databases.erase(entry);
+		}
+		database.SetPendingReplacement(false);
+	}
+	if (detached_remote_database) {
+		--remote_catalog_count;
+	}
+	if (restored_remote_database) {
+		++remote_catalog_count;
+	}
 }
 
 idx_t DatabaseManager::ApproxDatabaseCount() {

--- a/src/transaction/duck_transaction.cpp
+++ b/src/transaction/duck_transaction.cpp
@@ -85,11 +85,11 @@ void DuckTransaction::PushCatalogEntry(CatalogEntry &entry, data_ptr_t extra_dat
 	}
 }
 
-void DuckTransaction::PushAttach(AttachedDatabase &db) {
-	auto undo_entry = undo_buffer.CreateEntry(UndoFlags::ATTACHED_DATABASE, sizeof(AttachedDatabase *));
+void DuckTransaction::PushAttach(AttachedDatabase &db, optional_ptr<AttachedDatabase> replaced_database) {
+	auto undo_entry = undo_buffer.CreateEntry(UndoFlags::ATTACHED_DATABASE, sizeof(AttachedDatabase *) * 2);
 	auto ptr = undo_entry.GetDataMutable();
-	// store the pointer to the database
-	Store<CatalogEntry *>(&db, ptr);
+	Store<AttachedDatabase *>(&db, ptr);
+	Store<AttachedDatabase *>(replaced_database.get(), ptr + sizeof(AttachedDatabase *));
 }
 
 void DuckTransaction::PushDelete(DuckTableEntry &table_entry, RowVersionManager &info, idx_t vector_idx, row_t rows[],

--- a/src/transaction/duck_transaction_manager.cpp
+++ b/src/transaction/duck_transaction_manager.cpp
@@ -585,13 +585,14 @@ void DuckTransactionManager::PushCatalogEntry(Transaction &transaction_p, duckdb
 	transaction.PushCatalogEntry(entry, extra_data, extra_data_size);
 }
 
-void DuckTransactionManager::PushAttach(Transaction &transaction_p, AttachedDatabase &attached_db) {
+void DuckTransactionManager::PushAttach(Transaction &transaction_p, AttachedDatabase &attached_db,
+                                        optional_ptr<AttachedDatabase> replaced_database) {
 	auto &transaction = transaction_p.Cast<DuckTransaction>();
 	if (!db.IsSystem()) {
 		throw InternalException("Can only ATTACH in the system catalog");
 	}
 	transaction.catalog_version = ++last_uncommitted_catalog_version;
-	transaction.PushAttach(attached_db);
+	transaction.PushAttach(attached_db, replaced_database);
 }
 
 } // namespace duckdb

--- a/src/transaction/meta_transaction.cpp
+++ b/src/transaction/meta_transaction.cpp
@@ -190,6 +190,21 @@ void MetaTransaction::Rollback() {
 }
 
 void MetaTransaction::Finalize() {
+	bool attachments_committed = false;
+	for (auto &transaction : transactions) {
+		if (transaction.first.get().IsSystem() && transaction.second.state == TransactionState::COMMITTED) {
+			attachments_committed = true;
+			break;
+		}
+	}
+	if (attachments_committed) {
+		for (auto &database : replacement_databases) {
+			database.get().SetPendingReplacement(false);
+		}
+		for (auto &database : replaced_databases) {
+			database.get().OnDetach(context);
+		}
+	}
 	// Try to checkpoint any attached databases potentially still held by this transaction.
 	for (auto &database : referenced_databases) {
 		// If the use count is down to one, then we already detached the database.
@@ -229,9 +244,12 @@ shared_ptr<AttachedDatabase> MetaTransaction::GetReferencedDatabaseOwning(const 
 	return nullptr;
 }
 
-void MetaTransaction::DetachDatabase(AttachedDatabase &database) {
+void MetaTransaction::ReplaceDatabase(shared_ptr<AttachedDatabase> &database) {
 	lock_guard<mutex> guard(referenced_database_lock);
-	used_databases.erase(database.GetName());
+	auto &database_ref = *database;
+	used_databases.erase(database_ref.GetName());
+	referenced_databases.emplace(reference<AttachedDatabase>(database_ref), database);
+	replaced_databases.push_back(database_ref);
 }
 
 AttachedDatabase &MetaTransaction::UseDatabase(shared_ptr<AttachedDatabase> &database) {
@@ -248,6 +266,12 @@ AttachedDatabase &MetaTransaction::UseDatabase(shared_ptr<AttachedDatabase> &dat
 		}
 		referenced_databases.emplace(reference<AttachedDatabase>(db_ref), database);
 	}
+	return db_ref;
+}
+
+AttachedDatabase &MetaTransaction::AttachDatabase(shared_ptr<AttachedDatabase> &database) {
+	auto &db_ref = UseDatabase(database);
+	replacement_databases.push_back(db_ref);
 	return db_ref;
 }
 

--- a/src/transaction/rollback_state.cpp
+++ b/src/transaction/rollback_state.cpp
@@ -46,9 +46,10 @@ void RollbackState::RollbackEntry(UndoFlags type, data_ptr_t data) {
 		break;
 	}
 	case UndoFlags::ATTACHED_DATABASE: {
-		auto db = Load<AttachedDatabase *>(data);
-		auto &db_manager = DatabaseManager::Get(db->GetDatabase());
-		db_manager.DetachInternal(db->name);
+		auto database = Load<AttachedDatabase *>(data);
+		auto replaced_database = Load<AttachedDatabase *>(data + sizeof(AttachedDatabase *));
+		auto &db_manager = DatabaseManager::Get(database->GetDatabase());
+		db_manager.RollbackAttach(*database, replaced_database);
 		break;
 	}
 	case UndoFlags::SEQUENCE_VALUE:

--- a/src/transaction/transaction_context.cpp
+++ b/src/transaction/transaction_context.cpp
@@ -72,6 +72,7 @@ void TransactionContext::Commit() {
 		for (auto const &s : context.registered_state->States()) {
 			s->TransactionRollback(*transaction, context, error);
 		}
+		transaction->Finalize();
 		if (Exception::InvalidatesDatabase(error.Type()) || error.Type() == ExceptionType::INTERNAL) {
 			// throw fatal / internal exceptions directly
 			error.Throw();

--- a/test/api/test_storage_extension_alias.cpp
+++ b/test/api/test_storage_extension_alias.cpp
@@ -22,6 +22,39 @@ struct DummyStorageExtension : StorageExtension {
 	}
 };
 
+struct DetachTrackingCatalog : DuckCatalog {
+	DetachTrackingCatalog(AttachedDatabase &db, idx_t &detach_count_p) : DuckCatalog(db), detach_count(detach_count_p) {
+	}
+
+	void OnDetach(ClientContext &) override {
+		detach_count++;
+	}
+
+	idx_t &detach_count;
+};
+
+struct DetachTrackingStorageExtensionInfo : StorageExtensionInfo {
+	explicit DetachTrackingStorageExtensionInfo(idx_t &detach_count_p) : detach_count(detach_count_p) {
+	}
+
+	idx_t &detach_count;
+};
+
+struct DetachTrackingStorageExtension : StorageExtension {
+	explicit DetachTrackingStorageExtension(idx_t &detach_count) {
+		storage_info = make_shared_ptr<DetachTrackingStorageExtensionInfo>(detach_count);
+		attach = [](optional_ptr<StorageExtensionInfo> storage_info, ClientContext &, AttachedDatabase &db,
+		            const string &, AttachInfo &, AttachOptions &) -> unique_ptr<Catalog> {
+			auto &tracking_info = static_cast<DetachTrackingStorageExtensionInfo &>(*storage_info);
+			return make_uniq_base<Catalog, DetachTrackingCatalog>(db, tracking_info.detach_count);
+		};
+		create_transaction_manager = [](optional_ptr<StorageExtensionInfo>, AttachedDatabase &db,
+		                                Catalog &) -> unique_ptr<TransactionManager> {
+			return make_uniq<DuckTransactionManager>(db);
+		};
+	}
+};
+
 TEST_CASE("Test storage extension lookup full-name", "[api]") {
 	DBConfig config;
 
@@ -63,4 +96,52 @@ TEST_CASE("Test storage extension lookup alias", "[api]") {
 		     "Query: " +
 		     query + "\n" + "Error: " + result->GetError());
 	}
+}
+
+TEST_CASE("Uncommitted attachment aliases cannot be reused", "[api]") {
+	auto path_a = TestCreatePath("pending_attach_a.db");
+	auto path_b = TestCreatePath("pending_attach_b.db");
+	auto path_c = TestCreatePath("pending_attach_c.db");
+	DuckDB db(nullptr);
+	Connection owner(db);
+	Connection other(db);
+
+	REQUIRE_NO_FAIL(owner.Query("ATTACH '" + path_a + "' AS x"));
+	REQUIRE_NO_FAIL(owner.Query("CREATE TABLE x.marker AS SELECT 1 AS value"));
+	REQUIRE_NO_FAIL(owner.Query("DETACH x"));
+	REQUIRE_NO_FAIL(owner.Query("ATTACH '" + path_b + "' AS x"));
+	REQUIRE_NO_FAIL(owner.Query("CREATE TABLE x.marker AS SELECT 2 AS value"));
+	REQUIRE_NO_FAIL(owner.Query("DETACH x"));
+	REQUIRE_NO_FAIL(owner.Query("ATTACH '" + path_a + "' AS x"));
+	REQUIRE_NO_FAIL(owner.Query("BEGIN"));
+	REQUIRE_NO_FAIL(owner.Query("ATTACH OR REPLACE '" + path_b + "' AS x"));
+
+	REQUIRE(other.Query("DETACH x")->HasError());
+	REQUIRE(other.Query("ALTER DATABASE x SET ALIAS TO y")->HasError());
+	REQUIRE(other.Query("ATTACH OR REPLACE '" + path_c + "' AS x")->HasError());
+	REQUIRE_NO_FAIL(owner.Query("ROLLBACK"));
+	auto result = owner.Query("SELECT value FROM x.marker");
+	REQUIRE(!result->HasError());
+	REQUIRE(result->GetValue<int32_t>(0, 0) == 1);
+}
+
+TEST_CASE("Replaced catalogs detach after a later commit failure", "[api]") {
+	idx_t detach_count = 0;
+	DBConfig config;
+	StorageExtension::Register(config, "detach_tracking",
+	                           make_shared_ptr<DetachTrackingStorageExtension>(detach_count));
+	DuckDB db(nullptr, &config);
+	Connection con(db);
+	auto old_path = TestCreatePath("detach_tracking_old.db");
+	auto new_path = TestCreatePath("detach_tracking_new.db");
+
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE commit_failure(i INTEGER)"));
+	REQUIRE_NO_FAIL(con.Query("ATTACH '" + old_path + "' AS x (TYPE detach_tracking)"));
+	REQUIRE_NO_FAIL(con.Query("SET debug_force_commit_failure=true"));
+	REQUIRE_NO_FAIL(con.Query("BEGIN"));
+	REQUIRE_NO_FAIL(con.Query("INSERT INTO commit_failure VALUES (1)"));
+	REQUIRE_NO_FAIL(con.Query("ATTACH OR REPLACE '" + new_path + "' AS x (TYPE detach_tracking)"));
+	auto result = con.Query("COMMIT");
+	REQUIRE(result->HasError());
+	REQUIRE(detach_count == 1);
 }

--- a/test/sql/attach/attach_or_replace.test
+++ b/test/sql/attach/attach_or_replace.test
@@ -54,11 +54,20 @@ ATTACH '{TEST_DIR}/attach_or_replace.db' AS db2;
 statement ok
 SELECT * FROM db2.all_types;
 
-# ATTACH is not transactional: rolling back a transaction that replaced an attachment does not restore
-# the replaced one. The replacement is undone and the original stays detached, so the name is left
-# unattached entirely.
 statement ok
 ATTACH '{TEST_DIR}/attach_or_replace_txn.db' AS db3;
+
+statement ok
+CREATE TABLE db3.marker AS SELECT 3 AS value;
+
+statement ok
+ATTACH '{TEST_DIR}/attach_or_replace_txn_new.db' AS db4;
+
+statement ok
+CREATE TABLE db4.marker AS SELECT 4 AS value;
+
+statement ok
+DETACH db4;
 
 statement ok
 BEGIN;
@@ -66,11 +75,148 @@ BEGIN;
 statement ok
 ATTACH OR REPLACE '{TEST_DIR}/attach_or_replace_txn_new.db' AS db3;
 
+query I
+SELECT value FROM db3.marker;
+----
+4
+
+statement error
+ATTACH '{TEST_DIR}/attach_or_replace_txn.db' AS db5;
+----
+already attached
+
 statement ok
 ROLLBACK;
 
 query I
-SELECT count(*) FROM duckdb_databases() WHERE database_name = 'db3';
+SELECT value FROM db3.marker;
+----
+3
+
+# Uncommitted replacements cannot be detached or renamed
+statement ok
+BEGIN;
+
+statement ok
+ATTACH OR REPLACE '{TEST_DIR}/attach_or_replace_txn_new.db' AS db3;
+
+statement error
+DETACH db3;
+----
+uncommitted attachment changes
+
+statement ok
+ROLLBACK;
+
+statement ok
+BEGIN;
+
+statement ok
+ATTACH OR REPLACE '{TEST_DIR}/attach_or_replace_txn_new.db' AS db3;
+
+statement error
+ALTER DATABASE db3 SET ALIAS TO db5;
+----
+uncommitted attachment changes
+
+statement ok
+ROLLBACK;
+
+# A path-conflict rejection leaves the original database attached
+statement ok
+ATTACH '{TEST_DIR}/attach_or_replace_txn_new.db' AS db4;
+
+statement ok
+BEGIN;
+
+statement error
+ATTACH OR REPLACE '{TEST_DIR}/attach_or_replace_txn_new.db' AS db3;
+----
+already attached
+
+statement ok
+ROLLBACK;
+
+query I
+SELECT value FROM db3.marker;
+----
+3
+
+statement ok
+DETACH db4;
+
+# Committing keeps the replacement
+statement ok
+BEGIN;
+
+statement ok
+ATTACH OR REPLACE '{TEST_DIR}/attach_or_replace_txn_new.db' AS db3;
+
+statement ok
+COMMIT;
+
+query I
+SELECT value FROM db3.marker;
+----
+4
+
+statement ok
+DETACH db3;
+
+statement ok
+ATTACH '{TEST_DIR}/attach_or_replace_txn.db' AS db3;
+
+query I
+SELECT value FROM db3.marker;
+----
+3
+
+# In-memory replacements restore the original catalog on rollback
+statement ok
+ATTACH ':memory:' AS memory_db;
+
+statement ok
+CREATE TABLE memory_db.marker AS SELECT 5 AS value;
+
+statement ok
+BEGIN;
+
+statement ok
+ATTACH OR REPLACE '' AS memory_db;
+
+statement ok
+CREATE TABLE memory_db.replacement AS SELECT 6 AS value;
+
+statement ok
+ROLLBACK;
+
+query I
+SELECT value FROM memory_db.marker;
+----
+5
+
+query I
+SELECT count(*) FROM duckdb_tables() WHERE database_name = 'memory_db' AND table_name = 'replacement';
 ----
 0
 
+# Read-only replacements restore the original catalog on rollback
+statement ok
+DETACH db3;
+
+statement ok
+ATTACH '{TEST_DIR}/attach_or_replace_txn.db' AS db3 (READ_ONLY);
+
+statement ok
+BEGIN;
+
+statement ok
+ATTACH OR REPLACE '{TEST_DIR}/attach_or_replace_txn_new.db' AS db3 (READ_ONLY);
+
+statement ok
+ROLLBACK;
+
+query I
+SELECT value FROM db3.marker;
+----
+3


### PR DESCRIPTION
## Problem

Rolling back `ATTACH OR REPLACE` removed both databases: the replacement was detached by rollback, but the original database had already been destroyed. The alias was left missing instead of pointing back to the original database.

Fixes https://github.com/duckdb/duckdb/issues/23724.

## Solution

The replaced `AttachedDatabase` now stays owned by the meta transaction until the transaction ends. The system-catalog undo record stores both databases and is registered before the replacement is published. Rollback swaps the original object back into the existing alias entry; commit defers `OnDetach` and close until the system transaction commits.

While a replacement is uncommitted, detach, rename, and another replacement of that alias are rejected under the database-manager lock. This prevents alias reuse from making rollback fail. Failed multi-database commits also run attachment finalization when the system-catalog change already committed.

## Testing

The issue reproducer uses two persistent databases:

```sql
ATTACH 'a.db' AS a;
CREATE TABLE a.marker(v INT);
INSERT INTO a.marker VALUES (1);
DETACH a;

ATTACH 'b.db' AS b;
CREATE TABLE b.marker(v INT);
INSERT INTO b.marker VALUES (2);
DETACH b;

ATTACH 'a.db' AS xdb;
SELECT 'before', * FROM xdb.marker;
BEGIN;
ATTACH OR REPLACE 'b.db' AS xdb;
SELECT 'during', * FROM xdb.marker;
ROLLBACK;
SELECT 'after', * FROM xdb.marker;
```

<details>
<summary>Before and after</summary>

Before:

```text
before  1
during  2
Catalog Error: Table with name "xdb.marker" does not exist because schema "xdb" does not exist.
```

After:

```text
before  1
during  2
after   1
```

</details>

<details>
<summary>Test results</summary>

```text
attach_or_replace.test: 60 assertions passed
attach suite: 2,714 assertions passed
transaction suite: 1,368 assertions passed
storage catalog suite: 564 assertions passed
concurrent detach: 1,200 assertions passed
concurrent replacement: 1,037 assertions passed
API suite: 418,009 assertions passed
custom storage commit-failure cleanup: 8 assertions passed
```

</details>
