### PR TITLE
FileSystem: Add optional async TryStartRead (disabled by default)

### DIFF
--- a/extension/parquet/include/thrift_tools.hpp
+++ b/extension/parquet/include/thrift_tools.hpp
@@ -49,12 +49,29 @@ struct ReadHead {
 	}
 
 	void Fetch(CachingFileHandle &file_handle) {
+		VerifyWithinFile(file_handle);
+		handle_group = file_handle.Read(size, location);
+		FinishFetch(file_handle);
+	}
+
+	//! Try to fetch this read head's bytes asynchronously, returns false when the caller must use Fetch() instead.
+	//! On success FinishFetch must be called once the callback has fired.
+	bool TryStartFetch(CachingFileHandle &file_handle, AsyncIOCallback callback) {
+		VerifyWithinFile(file_handle);
+		return file_handle.TryStartRead(size, location, handle_group, std::move(callback));
+	}
+
+	//! Make the fetched bytes available through buffer_ptr
+	void FinishFetch(CachingFileHandle &file_handle) {
+		Materialize(file_handle.GetBufferAllocator());
+		data_isset = true;
+	}
+
+private:
+	void VerifyWithinFile(CachingFileHandle &file_handle) {
 		if (GetEnd() > file_handle.GetFileSize()) {
 			throw std::runtime_error("Prefetch registered requested for bytes outside file");
 		}
-		handle_group = file_handle.Read(size, location);
-		Materialize(file_handle.GetBufferAllocator());
-		data_isset = true;
 	}
 };
 

--- a/extension/parquet/include/thrift_tools.hpp
+++ b/extension/parquet/include/thrift_tools.hpp
@@ -12,6 +12,7 @@
 #include "thrift/transport/TBufferTransports.h"
 
 #include "duckdb.hpp"
+#include "duckdb/storage/external_file_cache/async_file_read_task.hpp"
 #include "duckdb/storage/external_file_cache/caching_file_system.hpp"
 #include "duckdb/storage/external_file_cache/file_buffer_handle_group.hpp"
 #include "duckdb/common/file_system.hpp"
@@ -48,17 +49,12 @@ struct ReadHead {
 		}
 	}
 
-	void Fetch(CachingFileHandle &file_handle) {
-		VerifyWithinFile(file_handle);
-		handle_group = file_handle.Read(size, location);
-		FinishFetch(file_handle);
-	}
-
-	//! Try to fetch this read head's bytes asynchronously, returns false when the caller must use Fetch() instead.
-	//! On success FinishFetch must be called once the callback has fired.
-	bool TryStartFetch(CachingFileHandle &file_handle, AsyncIOCallback callback) {
-		VerifyWithinFile(file_handle);
-		return file_handle.TryStartRead(size, location, handle_group, std::move(callback));
+	//! Describe the read this head needs, validating the requested range
+	AsyncReadRequest PrepareFetch(CachingFileHandle &file_handle) {
+		if (GetEnd() > file_handle.GetFileSize()) {
+			throw std::runtime_error("Prefetch registered requested for bytes outside file");
+		}
+		return AsyncReadRequest(file_handle, size, location, handle_group);
 	}
 
 	//! Make the fetched bytes available through buffer_ptr
@@ -67,11 +63,11 @@ struct ReadHead {
 		data_isset = true;
 	}
 
-private:
-	void VerifyWithinFile(CachingFileHandle &file_handle) {
-		if (GetEnd() > file_handle.GetFileSize()) {
-			throw std::runtime_error("Prefetch registered requested for bytes outside file");
-		}
+	//! Fetch this read head's bytes, blocking until they have landed
+	void Fetch(CachingFileHandle &file_handle) {
+		auto request = PrepareFetch(file_handle);
+		handle_group = file_handle.Read(request.nr_bytes, request.location);
+		FinishFetch(file_handle);
 	}
 };
 

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -2166,6 +2166,40 @@ void ParquetReader::GetPartitionStats(const duckdb_parquet::FileMetaData &metada
 	}
 }
 
+// Fetches one read head's bytes, handing the read off to the file system when it can read asynchronously.
+// A read head is one contiguous byte range, i.e. exactly one read, so this blocks at most once.
+class ReadHeadIOTask : public AsyncTask {
+public:
+	ReadHeadIOTask(shared_ptr<ReadHead> read_head_p, shared_ptr<CachingFileHandle> file_handle_p)
+	    : read_head(std::move(read_head_p)), file_handle(std::move(file_handle_p)) {
+	}
+
+	void Execute() override {
+		read_head->Fetch(*file_handle);
+	}
+
+	AsyncTaskExecutionResult TryExecuteAsync(AsyncIOCallback on_complete) override {
+		if (!read_head->TryStartFetch(*file_handle, std::move(on_complete))) {
+			// this file system reads synchronously - do the read here, holding the calling thread
+			read_head->Fetch(*file_handle);
+			return AsyncTaskExecutionResult::FINISHED;
+		}
+		return AsyncTaskExecutionResult::PENDING;
+	}
+
+	void FinishAsync() override {
+		read_head->FinishFetch(*file_handle);
+	}
+
+	idx_t GetIOSize() const override {
+		return read_head->size;
+	}
+
+private:
+	shared_ptr<ReadHead> read_head;
+	shared_ptr<CachingFileHandle> file_handle;
+};
+
 // Async I/O tasks for the read heads in the index range [from, to), skipping any that are already fetched.
 static vector<unique_ptr<AsyncTask>>
 CollectIOTasks(ThriftFileTransport &trans, const shared_ptr<CachingFileHandle> &file_handle, idx_t from, idx_t to) {
@@ -2175,8 +2209,7 @@ CollectIOTasks(ThriftFileTransport &trans, const shared_ptr<CachingFileHandle> &
 		auto &read_head = read_heads[i];
 		if (!read_head->data_isset) {
 			// fetch the read head's bytes on the async pool
-			io_tasks.push_back(make_uniq<CallbackAsyncTask>(
-			    [read_head, file_handle] { read_head->Fetch(*file_handle); }, read_head->size));
+			io_tasks.push_back(make_uniq<ReadHeadIOTask>(read_head, file_handle));
 		}
 	}
 	return io_tasks;

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -2166,33 +2166,25 @@ void ParquetReader::GetPartitionStats(const duckdb_parquet::FileMetaData &metada
 	}
 }
 
-// Fetches one read head's bytes, handing the read off to the file system when it can read asynchronously.
-// A read head is one contiguous byte range, i.e. exactly one read, so this blocks at most once.
-class ReadHeadIOTask : public AsyncTask {
+// Fetches one read head's bytes. A read head is one contiguous byte range, i.e. exactly one read, so whether that
+// read blocks or is handed to the file system is left to AsyncFileReadTask.
+class ReadHeadIOTask : public AsyncFileReadTask {
 public:
 	ReadHeadIOTask(shared_ptr<ReadHead> read_head_p, shared_ptr<CachingFileHandle> file_handle_p)
 	    : read_head(std::move(read_head_p)), file_handle(std::move(file_handle_p)) {
 	}
 
-	void Execute() override {
-		read_head->Fetch(*file_handle);
-	}
-
-	AsyncTaskExecutionResult TryExecuteAsync(AsyncIOCallback on_complete) override {
-		if (!read_head->TryStartFetch(*file_handle, std::move(on_complete))) {
-			// this file system reads synchronously - do the read here, holding the calling thread
-			read_head->Fetch(*file_handle);
-			return AsyncTaskExecutionResult::FINISHED;
-		}
-		return AsyncTaskExecutionResult::PENDING;
-	}
-
-	void FinishAsync() override {
-		read_head->FinishFetch(*file_handle);
-	}
-
 	idx_t GetIOSize() const override {
 		return read_head->size;
+	}
+
+protected:
+	AsyncReadRequest PrepareRead() override {
+		return read_head->PrepareFetch(*file_handle);
+	}
+
+	void FinishRead() override {
+		read_head->FinishFetch(*file_handle);
 	}
 
 private:

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -93,6 +93,7 @@
 #include "duckdb/common/extra_type_info.hpp"
 #include "duckdb/common/file_buffer.hpp"
 #include "duckdb/common/file_open_flags.hpp"
+#include "duckdb/common/file_system.hpp"
 #include "duckdb/common/filename_pattern.hpp"
 #include "duckdb/common/http_util.hpp"
 #include "duckdb/common/multi_file/multi_file_data.hpp"
@@ -2599,6 +2600,25 @@ const char* EnumUtil::ToChars<FileNameSegmentType>(FileNameSegmentType value) {
 template<>
 FileNameSegmentType EnumUtil::FromString<FileNameSegmentType>(const char *value) {
 	return static_cast<FileNameSegmentType>(StringUtil::StringToEnum(GetFileNameSegmentTypeValues(), 4, "FileNameSegmentType", value));
+}
+
+const StringUtil::EnumStringLiteral *GetFileReadSubmissionValues() {
+	static constexpr StringUtil::EnumStringLiteral values[] {
+		{ static_cast<uint32_t>(FileReadSubmission::UNSUPPORTED), "UNSUPPORTED" },
+		{ static_cast<uint32_t>(FileReadSubmission::COMPLETED), "COMPLETED" },
+		{ static_cast<uint32_t>(FileReadSubmission::PENDING), "PENDING" }
+	};
+	return values;
+}
+
+template<>
+const char* EnumUtil::ToChars<FileReadSubmission>(FileReadSubmission value) {
+	return StringUtil::EnumToString(GetFileReadSubmissionValues(), 3, "FileReadSubmission", static_cast<uint32_t>(value));
+}
+
+template<>
+FileReadSubmission EnumUtil::FromString<FileReadSubmission>(const char *value) {
+	return static_cast<FileReadSubmission>(StringUtil::StringToEnum(GetFileReadSubmissionValues(), 3, "FileReadSubmission", value));
 }
 
 const StringUtil::EnumStringLiteral *GetFileWriteModeValues() {

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -831,6 +831,24 @@ AsyncResultsExecutionMode EnumUtil::FromString<AsyncResultsExecutionMode>(const 
 	return static_cast<AsyncResultsExecutionMode>(StringUtil::StringToEnum(GetAsyncResultsExecutionModeValues(), 2, "AsyncResultsExecutionMode", value));
 }
 
+const StringUtil::EnumStringLiteral *GetAsyncTaskExecutionResultValues() {
+	static constexpr StringUtil::EnumStringLiteral values[] {
+		{ static_cast<uint32_t>(AsyncTaskExecutionResult::FINISHED), "FINISHED" },
+		{ static_cast<uint32_t>(AsyncTaskExecutionResult::PENDING), "PENDING" }
+	};
+	return values;
+}
+
+template<>
+const char* EnumUtil::ToChars<AsyncTaskExecutionResult>(AsyncTaskExecutionResult value) {
+	return StringUtil::EnumToString(GetAsyncTaskExecutionResultValues(), 2, "AsyncTaskExecutionResult", static_cast<uint32_t>(value));
+}
+
+template<>
+AsyncTaskExecutionResult EnumUtil::FromString<AsyncTaskExecutionResult>(const char *value) {
+	return static_cast<AsyncTaskExecutionResult>(StringUtil::StringToEnum(GetAsyncTaskExecutionResultValues(), 2, "AsyncTaskExecutionResult", value));
+}
+
 const StringUtil::EnumStringLiteral *GetBaseColumnPrunerModeValues() {
 	static constexpr StringUtil::EnumStringLiteral values[] {
 		{ static_cast<uint32_t>(BaseColumnPrunerMode::DEFAULT), "DEFAULT" },

--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -455,6 +455,12 @@ void FileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t 
 	throw NotImplementedException("%s: Read (with location) is not implemented!", GetName());
 }
 
+bool FileSystem::TryStartRead(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location,
+                              AsyncIOCallback callback) { // NOLINT: sink parameter, ignored by the default impl
+	// by default a file system has no asynchronous read path, callers fall back to the synchronous Read
+	return false;
+}
+
 void FileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
 	throw NotImplementedException("%s: Write (with location) is not implemented!", GetName());
 }
@@ -842,6 +848,10 @@ void FileHandle::Read(QueryContext context, void *buffer, idx_t nr_bytes, idx_t 
 	}
 
 	file_system.Read(*this, buffer, UnsafeNumericCast<int64_t>(nr_bytes), location);
+}
+
+bool FileHandle::TryStartRead(void *buffer, idx_t nr_bytes, idx_t location, AsyncIOCallback callback) {
+	return file_system.TryStartRead(*this, buffer, UnsafeNumericCast<int64_t>(nr_bytes), location, std::move(callback));
 }
 
 void FileHandle::Write(QueryContext context, void *buffer, idx_t nr_bytes, idx_t location) {

--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -455,8 +455,8 @@ void FileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t 
 	throw NotImplementedException("%s: Read (with location) is not implemented!", GetName());
 }
 
-FileReadSubmission FileSystem::TryStartRead(shared_ptr<const FileReadRequest> request,
-                                            AsyncIOCallback callback) { // NOLINT: sink params, unused by default
+// NOLINTNEXTLINE: sink params, taken by value so an override can move them into its queue
+FileReadSubmission FileSystem::TryStartRead(shared_ptr<const FileReadRequest> request, AsyncIOCallback callback) {
 	// by default a file system has no asynchronous read path, callers fall back to the synchronous Read
 	return FileReadSubmission::UNSUPPORTED;
 }

--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -854,6 +854,15 @@ bool FileHandle::TryStartRead(void *buffer, idx_t nr_bytes, idx_t location, Asyn
 	return file_system.TryStartRead(*this, buffer, UnsafeNumericCast<int64_t>(nr_bytes), location, std::move(callback));
 }
 
+bool FileHandle::TryStartRead(QueryContext context, void *buffer, idx_t nr_bytes, idx_t location,
+                              AsyncIOCallback callback) {
+	// tracked up front, the same as the synchronous Read at this location does
+	if (track_io && context.GetClientContext() != nullptr) {
+		QueryProfiler::Get(*context.GetClientContext()).TrackBytesRead(nr_bytes);
+	}
+	return TryStartRead(buffer, nr_bytes, location, std::move(callback));
+}
+
 void FileHandle::Write(QueryContext context, void *buffer, idx_t nr_bytes, idx_t location) {
 	if (track_io && context.GetClientContext() != nullptr) {
 		QueryProfiler::Get(*context.GetClientContext()).TrackBytesWritten(nr_bytes);

--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -455,10 +455,10 @@ void FileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t 
 	throw NotImplementedException("%s: Read (with location) is not implemented!", GetName());
 }
 
-bool FileSystem::TryStartRead(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location,
-                              AsyncIOCallback callback) { // NOLINT: sink parameter, ignored by the default impl
+FileReadSubmission FileSystem::TryStartRead(shared_ptr<const FileReadRequest> request,
+                                            AsyncIOCallback callback) { // NOLINT: sink params, unused by default
 	// by default a file system has no asynchronous read path, callers fall back to the synchronous Read
-	return false;
+	return FileReadSubmission::UNSUPPORTED;
 }
 
 void FileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
@@ -850,17 +850,11 @@ void FileHandle::Read(QueryContext context, void *buffer, idx_t nr_bytes, idx_t 
 	file_system.Read(*this, buffer, UnsafeNumericCast<int64_t>(nr_bytes), location);
 }
 
-bool FileHandle::TryStartRead(void *buffer, idx_t nr_bytes, idx_t location, AsyncIOCallback callback) {
-	return file_system.TryStartRead(*this, buffer, UnsafeNumericCast<int64_t>(nr_bytes), location, std::move(callback));
-}
-
-bool FileHandle::TryStartRead(QueryContext context, void *buffer, idx_t nr_bytes, idx_t location,
-                              AsyncIOCallback callback) {
-	// tracked up front, the same as the synchronous Read at this location does
+void FileHandle::TrackBytesRead(QueryContext context, idx_t nr_bytes) {
+	// tracked up front, the same as the synchronous Read at a location does
 	if (track_io && context.GetClientContext() != nullptr) {
 		QueryProfiler::Get(*context.GetClientContext()).TrackBytesRead(nr_bytes);
 	}
-	return TryStartRead(buffer, nr_bytes, location, std::move(callback));
 }
 
 void FileHandle::Write(QueryContext context, void *buffer, idx_t nr_bytes, idx_t location) {

--- a/src/common/virtual_file_system.cpp
+++ b/src/common/virtual_file_system.cpp
@@ -231,6 +231,11 @@ void VirtualFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes,
 	handle.file_system.Read(handle, buffer, nr_bytes, location);
 }
 
+bool VirtualFileSystem::TryStartRead(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location,
+                                     AsyncIOCallback callback) {
+	return handle.file_system.TryStartRead(handle, buffer, nr_bytes, location, std::move(callback));
+}
+
 void VirtualFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
 	handle.file_system.Write(handle, buffer, nr_bytes, location);
 }

--- a/src/common/virtual_file_system.cpp
+++ b/src/common/virtual_file_system.cpp
@@ -231,9 +231,10 @@ void VirtualFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes,
 	handle.file_system.Read(handle, buffer, nr_bytes, location);
 }
 
-bool VirtualFileSystem::TryStartRead(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location,
-                                     AsyncIOCallback callback) {
-	return handle.file_system.TryStartRead(handle, buffer, nr_bytes, location, std::move(callback));
+FileReadSubmission VirtualFileSystem::TryStartRead(shared_ptr<const FileReadRequest> request,
+                                                   AsyncIOCallback callback) {
+	auto &file_system = request->handle->file_system;
+	return file_system.TryStartRead(std::move(request), std::move(callback));
 }
 
 void VirtualFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {

--- a/src/include/duckdb/common/async_io_callback.hpp
+++ b/src/include/duckdb/common/async_io_callback.hpp
@@ -1,0 +1,22 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/async_io_callback.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/error_data.hpp"
+#include "duckdb/common/optional_ptr.hpp"
+
+#include <functional>
+
+namespace duckdb {
+
+//! Invoked exactly once when an asynchronous I/O operation completes, [error] is null when it succeeded.
+//! May be invoked on any thread, including inline from the call that started the operation.
+using AsyncIOCallback = std::function<void(optional_ptr<ErrorData> error)>;
+
+} // namespace duckdb

--- a/src/include/duckdb/common/enum_util.hpp
+++ b/src/include/duckdb/common/enum_util.hpp
@@ -250,6 +250,8 @@ enum class FileLockType : uint8_t;
 
 enum class FileNameSegmentType : uint8_t;
 
+enum class FileReadSubmission : uint8_t;
+
 enum class FileWriteMode : uint8_t;
 
 enum class FilterPropagateResult : uint8_t;
@@ -973,6 +975,9 @@ const char* EnumUtil::ToChars<FileLockType>(FileLockType value);
 
 template<>
 const char* EnumUtil::ToChars<FileNameSegmentType>(FileNameSegmentType value);
+
+template<>
+const char* EnumUtil::ToChars<FileReadSubmission>(FileReadSubmission value);
 
 template<>
 const char* EnumUtil::ToChars<FileWriteMode>(FileWriteMode value);
@@ -1895,6 +1900,9 @@ FileLockType EnumUtil::FromString<FileLockType>(const char *value);
 
 template<>
 FileNameSegmentType EnumUtil::FromString<FileNameSegmentType>(const char *value);
+
+template<>
+FileReadSubmission EnumUtil::FromString<FileReadSubmission>(const char *value);
 
 template<>
 FileWriteMode EnumUtil::FromString<FileWriteMode>(const char *value);

--- a/src/include/duckdb/common/enum_util.hpp
+++ b/src/include/duckdb/common/enum_util.hpp
@@ -92,6 +92,8 @@ enum class AsyncResultType : uint8_t;
 
 enum class AsyncResultsExecutionMode : uint8_t;
 
+enum class AsyncTaskExecutionResult : uint8_t;
+
 enum class BaseColumnPrunerMode : uint8_t;
 
 enum class BinderType : uint8_t;
@@ -734,6 +736,9 @@ const char* EnumUtil::ToChars<AsyncResultType>(AsyncResultType value);
 
 template<>
 const char* EnumUtil::ToChars<AsyncResultsExecutionMode>(AsyncResultsExecutionMode value);
+
+template<>
+const char* EnumUtil::ToChars<AsyncTaskExecutionResult>(AsyncTaskExecutionResult value);
 
 template<>
 const char* EnumUtil::ToChars<BaseColumnPrunerMode>(BaseColumnPrunerMode value);
@@ -1653,6 +1658,9 @@ AsyncResultType EnumUtil::FromString<AsyncResultType>(const char *value);
 
 template<>
 AsyncResultsExecutionMode EnumUtil::FromString<AsyncResultsExecutionMode>(const char *value);
+
+template<>
+AsyncTaskExecutionResult EnumUtil::FromString<AsyncTaskExecutionResult>(const char *value);
 
 template<>
 BaseColumnPrunerMode EnumUtil::FromString<BaseColumnPrunerMode>(const char *value);

--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "duckdb/common/async_io_callback.hpp"
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/enums/file_compression_type.hpp"
 #include "duckdb/common/enums/file_glob_options.hpp"
@@ -128,6 +129,8 @@ public:
 	// File offset will not be changed.
 	DUCKDB_API void Read(void *buffer, idx_t nr_bytes, idx_t location);
 	DUCKDB_API void Read(QueryContext context, void *buffer, idx_t nr_bytes, idx_t location);
+	//! Try to start an asynchronous read, see FileSystem::TryStartRead
+	DUCKDB_API bool TryStartRead(void *buffer, idx_t nr_bytes, idx_t location, AsyncIOCallback callback);
 	DUCKDB_API void Write(QueryContext context, void *buffer, idx_t nr_bytes, idx_t location);
 	DUCKDB_API void Seek(idx_t location);
 	DUCKDB_API void Reset();
@@ -211,6 +214,12 @@ public:
 	//! Read exactly nr_bytes from the specified location in the file. Fails if nr_bytes could not be read. This is
 	//! equivalent to calling SetFilePointer(location) followed by calling Read().
 	DUCKDB_API virtual void Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location);
+	//! Try to start an asynchronous read of exactly nr_bytes from [location] into [buffer], releasing the calling
+	//! thread while the read is in flight. Returns false when this file system cannot read asynchronously, in which
+	//! case the caller must fall back to Read(). When it returns true [callback] is invoked exactly once, and
+	//! [handle] and [buffer] must stay alive until it fires.
+	DUCKDB_API virtual bool TryStartRead(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location,
+	                                     AsyncIOCallback callback);
 	//! Write exactly nr_bytes to the specified location in the file. Fails if nr_bytes could not be written. This is
 	//! equivalent to calling SetFilePointer(location) followed by calling Write().
 	DUCKDB_API virtual void Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location);

--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -131,6 +131,8 @@ public:
 	DUCKDB_API void Read(QueryContext context, void *buffer, idx_t nr_bytes, idx_t location);
 	//! Try to start an asynchronous read, see FileSystem::TryStartRead
 	DUCKDB_API bool TryStartRead(void *buffer, idx_t nr_bytes, idx_t location, AsyncIOCallback callback);
+	DUCKDB_API bool TryStartRead(QueryContext context, void *buffer, idx_t nr_bytes, idx_t location,
+	                             AsyncIOCallback callback);
 	DUCKDB_API void Write(QueryContext context, void *buffer, idx_t nr_bytes, idx_t location);
 	DUCKDB_API void Seek(idx_t location);
 	DUCKDB_API void Reset();

--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -129,10 +129,8 @@ public:
 	// File offset will not be changed.
 	DUCKDB_API void Read(void *buffer, idx_t nr_bytes, idx_t location);
 	DUCKDB_API void Read(QueryContext context, void *buffer, idx_t nr_bytes, idx_t location);
-	//! Try to start an asynchronous read, see FileSystem::TryStartRead
-	DUCKDB_API bool TryStartRead(void *buffer, idx_t nr_bytes, idx_t location, AsyncIOCallback callback);
-	DUCKDB_API bool TryStartRead(QueryContext context, void *buffer, idx_t nr_bytes, idx_t location,
-	                             AsyncIOCallback callback);
+	//! Report [nr_bytes] to the profiler, for a caller that reads through TryStartRead rather than Read
+	DUCKDB_API void TrackBytesRead(QueryContext context, idx_t nr_bytes);
 	DUCKDB_API void Write(QueryContext context, void *buffer, idx_t nr_bytes, idx_t location);
 	DUCKDB_API void Seek(idx_t location);
 	DUCKDB_API void Reset();
@@ -193,6 +191,32 @@ public:
 	bool track_io = true;
 };
 
+//! Where an asynchronous read lands. Shared, so the buffer outlives the call that started the read.
+class FileReadDestination {
+public:
+	virtual ~FileReadDestination() = default;
+	virtual data_ptr_t Data() = 0;
+	virtual idx_t Size() const = 0;
+};
+
+//! One asynchronous read. Everything it names is shared, so nothing it reads or writes can be freed
+//! while the read is still in flight.
+struct FileReadRequest {
+	shared_ptr<FileHandle> handle;
+	shared_ptr<FileReadDestination> destination;
+	idx_t location;
+};
+
+//! What became of an attempt to start an asynchronous read. The callback fires if and only if PENDING.
+enum class FileReadSubmission : uint8_t {
+	//! This file system has no asynchronous path, the caller must use Read()
+	UNSUPPORTED,
+	//! The bytes already landed, so the caller can consume them without waiting
+	COMPLETED,
+	//! The read is in flight, the callback fires when it lands
+	PENDING
+};
+
 class FileSystem {
 public:
 	DUCKDB_API virtual ~FileSystem();
@@ -216,11 +240,12 @@ public:
 	//! Read exactly nr_bytes from the specified location in the file. Fails if nr_bytes could not be read. This is
 	//! equivalent to calling SetFilePointer(location) followed by calling Read().
 	DUCKDB_API virtual void Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location);
-	//! Try to read [nr_bytes] from [location] into [buffer] without holding the calling thread.
-	//! Returns false when this file system has no asynchronous path, and the caller must use Read() instead.
-	//! [handle] and [buffer] must outlive [callback], which is invoked exactly once.
-	DUCKDB_API virtual bool TryStartRead(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location,
-	                                     AsyncIOCallback callback);
+	//! Try to read [request] without holding the calling thread. UNSUPPORTED means this file system has no
+	//! asynchronous path and the caller must use Read(), COMPLETED means the read was already served, and only
+	//! PENDING invokes [callback], exactly once. A read that does not reach PENDING reports failure by throwing.
+	//! The request owns what it reads into, so it can be held for as long as the read takes.
+	DUCKDB_API virtual FileReadSubmission TryStartRead(shared_ptr<const FileReadRequest> request,
+	                                                   AsyncIOCallback callback);
 	//! Write exactly nr_bytes to the specified location in the file. Fails if nr_bytes could not be written. This is
 	//! equivalent to calling SetFilePointer(location) followed by calling Write().
 	DUCKDB_API virtual void Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location);

--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -214,10 +214,9 @@ public:
 	//! Read exactly nr_bytes from the specified location in the file. Fails if nr_bytes could not be read. This is
 	//! equivalent to calling SetFilePointer(location) followed by calling Read().
 	DUCKDB_API virtual void Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location);
-	//! Try to start an asynchronous read of exactly nr_bytes from [location] into [buffer], releasing the calling
-	//! thread while the read is in flight. Returns false when this file system cannot read asynchronously, in which
-	//! case the caller must fall back to Read(). When it returns true [callback] is invoked exactly once, and
-	//! [handle] and [buffer] must stay alive until it fires.
+	//! Try to read [nr_bytes] from [location] into [buffer] without holding the calling thread.
+	//! Returns false when this file system has no asynchronous path, and the caller must use Read() instead.
+	//! [handle] and [buffer] must outlive [callback], which is invoked exactly once.
 	DUCKDB_API virtual bool TryStartRead(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location,
 	                                     AsyncIOCallback callback);
 	//! Write exactly nr_bytes to the specified location in the file. Fails if nr_bytes could not be written. This is

--- a/src/include/duckdb/common/opener_file_system.hpp
+++ b/src/include/duckdb/common/opener_file_system.hpp
@@ -46,6 +46,11 @@ public:
 		GetFileSystem().Read(handle, buffer, nr_bytes, location);
 	}
 
+	bool TryStartRead(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location,
+	                  AsyncIOCallback callback) override {
+		return GetFileSystem().TryStartRead(handle, buffer, nr_bytes, location, std::move(callback));
+	}
+
 	void Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override {
 		throw InternalException("writing on the OpenerFileSystem is undefined");
 	}

--- a/src/include/duckdb/common/opener_file_system.hpp
+++ b/src/include/duckdb/common/opener_file_system.hpp
@@ -46,9 +46,8 @@ public:
 		GetFileSystem().Read(handle, buffer, nr_bytes, location);
 	}
 
-	bool TryStartRead(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location,
-	                  AsyncIOCallback callback) override {
-		return GetFileSystem().TryStartRead(handle, buffer, nr_bytes, location, std::move(callback));
+	FileReadSubmission TryStartRead(shared_ptr<const FileReadRequest> request, AsyncIOCallback callback) override {
+		return GetFileSystem().TryStartRead(std::move(request), std::move(callback));
 	}
 
 	void Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override {

--- a/src/include/duckdb/common/virtual_file_system.hpp
+++ b/src/include/duckdb/common/virtual_file_system.hpp
@@ -24,6 +24,8 @@ public:
 	~VirtualFileSystem() override;
 
 	void Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override;
+	bool TryStartRead(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location,
+	                  AsyncIOCallback callback) override;
 	void Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override;
 	int64_t Read(FileHandle &handle, void *buffer, int64_t nr_bytes) override;
 	int64_t Write(FileHandle &handle, void *buffer, int64_t nr_bytes) override;

--- a/src/include/duckdb/common/virtual_file_system.hpp
+++ b/src/include/duckdb/common/virtual_file_system.hpp
@@ -24,8 +24,7 @@ public:
 	~VirtualFileSystem() override;
 
 	void Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override;
-	bool TryStartRead(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location,
-	                  AsyncIOCallback callback) override;
+	FileReadSubmission TryStartRead(shared_ptr<const FileReadRequest> request, AsyncIOCallback callback) override;
 	void Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override;
 	int64_t Read(FileHandle &handle, void *buffer, int64_t nr_bytes) override;
 	int64_t Write(FileHandle &handle, void *buffer, int64_t nr_bytes) override;

--- a/src/include/duckdb/parallel/async_result.hpp
+++ b/src/include/duckdb/parallel/async_result.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "duckdb/common/async_io_callback.hpp"
 #include "duckdb/common/enum_util.hpp"
 #include "duckdb/common/unique_ptr.hpp"
 #include "duckdb/common/vector.hpp"
@@ -26,10 +27,31 @@ enum class AsyncResultsExecutionMode : uint8_t {
 	TASK_EXECUTOR //! BLOCKED is allowed
 };
 
+//! Outcome of AsyncTask::TryExecuteAsync
+enum class AsyncTaskExecutionResult : uint8_t {
+	//! The task did all of its work, no completion callback will be made
+	FINISHED,
+	//! The task handed its work off, the completion callback fires exactly once when the work lands,
+	//! after which FinishAsync() must be called to consume the result
+	PENDING
+};
+
 class AsyncTask {
 public:
 	virtual ~AsyncTask() {};
+	//! Do all of the task's work, blocking the calling thread until it is done
 	virtual void Execute() = 0;
+	//! Try to hand the task's work off so the calling thread is released while it is in flight.
+	//! A task blocks AT MOST ONCE: TryExecuteAsync is never called twice, and a PENDING result is always followed
+	//! by exactly one [on_complete] and then one FinishAsync().
+	//! The default implementation just does the work synchronously, so overriding this is opt-in.
+	virtual AsyncTaskExecutionResult TryExecuteAsync(AsyncIOCallback on_complete) { // NOLINT
+		Execute();
+		return AsyncTaskExecutionResult::FINISHED;
+	}
+	//! Consume the result of the work started by TryExecuteAsync, only called after it returned PENDING
+	virtual void FinishAsync() {
+	}
 	//! The number of bytes this task reads, when known (used to budget I/O scheduled ahead by the read-ahead)
 	virtual idx_t GetIOSize() const {
 		return 0;

--- a/src/include/duckdb/parallel/async_result.hpp
+++ b/src/include/duckdb/parallel/async_result.hpp
@@ -31,8 +31,7 @@ enum class AsyncResultsExecutionMode : uint8_t {
 enum class AsyncTaskExecutionResult : uint8_t {
 	//! The task did all of its work, no completion callback will be made
 	FINISHED,
-	//! The task handed its work off, the completion callback fires exactly once when the work lands,
-	//! after which FinishAsync() must be called to consume the result
+	//! The work was handed off: one completion callback, then FinishAsync() to consume it
 	PENDING
 };
 
@@ -41,10 +40,8 @@ public:
 	virtual ~AsyncTask() {};
 	//! Do all of the task's work, blocking the calling thread until it is done
 	virtual void Execute() = 0;
-	//! Try to hand the task's work off so the calling thread is released while it is in flight.
-	//! A task blocks AT MOST ONCE: TryExecuteAsync is never called twice, and a PENDING result is always followed
-	//! by exactly one [on_complete] and then one FinishAsync().
-	//! The default implementation just does the work synchronously, so overriding this is opt-in.
+	//! Try to hand the task's work off, releasing the calling thread while it is in flight.
+	//! A task blocks at most once, so this is never called twice. Defaults to doing the work synchronously.
 	virtual AsyncTaskExecutionResult TryExecuteAsync(AsyncIOCallback on_complete) { // NOLINT
 		Execute();
 		return AsyncTaskExecutionResult::FINISHED;

--- a/src/include/duckdb/storage/external_file_cache/async_file_read_task.hpp
+++ b/src/include/duckdb/storage/external_file_cache/async_file_read_task.hpp
@@ -1,0 +1,69 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/storage/external_file_cache/async_file_read_task.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/parallel/async_result.hpp"
+#include "duckdb/storage/external_file_cache/caching_file_system.hpp"
+#include "duckdb/storage/external_file_cache/file_buffer_handle_group.hpp"
+
+namespace duckdb {
+
+//! The read an AsyncFileReadTask needs performed: [nr_bytes] at [location], landing in [destination]
+struct AsyncReadRequest {
+	AsyncReadRequest(CachingFileHandle &handle, idx_t nr_bytes, idx_t location, FileBufferHandleGroup &destination)
+	    : handle(handle), nr_bytes(nr_bytes), location(location), destination(destination) {
+	}
+
+	CachingFileHandle &handle;
+	idx_t nr_bytes;
+	idx_t location;
+	//! Where the bytes land, only valid once the read has completed
+	FileBufferHandleGroup &destination;
+};
+
+//! An async task that performs exactly one read through a CachingFileHandle.
+//! Subclasses only describe the read and consume it - whether it blocks the calling thread or is handed off to the
+//! file system is decided here, so no task has to carry a fallback of its own.
+class AsyncFileReadTask : public AsyncTask {
+public:
+	void Execute() final {
+		auto request = PrepareRead();
+		PerformRead(request);
+		FinishRead();
+	}
+
+	AsyncTaskExecutionResult TryExecuteAsync(AsyncIOCallback on_complete) final {
+		auto request = PrepareRead();
+		if (request.handle.TryStartRead(request.nr_bytes, request.location, request.destination,
+		                                std::move(on_complete))) {
+			return AsyncTaskExecutionResult::PENDING;
+		}
+		// this file system reads synchronously - do the read here, holding the calling thread
+		PerformRead(request);
+		FinishRead();
+		return AsyncTaskExecutionResult::FINISHED;
+	}
+
+	void FinishAsync() final {
+		FinishRead();
+	}
+
+protected:
+	//! Describe the read, doing any set-up it needs. Called exactly once per execution, before any I/O.
+	virtual AsyncReadRequest PrepareRead() = 0;
+	//! Consume the bytes once they have landed
+	virtual void FinishRead() = 0;
+
+private:
+	static void PerformRead(AsyncReadRequest &request) {
+		request.destination = request.handle.Read(request.nr_bytes, request.location);
+	}
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/storage/external_file_cache/async_file_read_task.hpp
+++ b/src/include/duckdb/storage/external_file_cache/async_file_read_task.hpp
@@ -27,6 +27,13 @@ struct AsyncReadRequest {
 	FileBufferHandleGroup &destination;
 };
 
+//! When an asynchronous read started and landed, stamped by the read itself rather than by whoever
+//! picks the result up, so a reschedule is not counted as time on the wire
+struct AsyncReadTiming {
+	TimePoint started;
+	TimePoint finished;
+};
+
 //! An async task that performs exactly one read through a CachingFileHandle. Subclasses describe the read and
 //! consume it; whether it blocks or is handed to the file system is decided here, not by the task.
 class AsyncFileReadTask : public AsyncTask {
@@ -38,19 +45,34 @@ public:
 	}
 
 	AsyncTaskExecutionResult TryExecuteAsync(AsyncIOCallback on_complete) final {
-		auto request = PrepareRead();
-		if (request.handle.TryStartRead(request.nr_bytes, request.location, request.destination,
-		                                std::move(on_complete))) {
+		read = make_uniq<AsyncReadRequest>(PrepareRead());
+		timing = make_shared_ptr<AsyncReadTiming>();
+		timing->started = TimePoint::Tick();
+		// the completion stamps its own finish time, so a reschedule is not counted as time on the wire
+		auto stamp = timing;
+		auto submission = read->handle.TryStartRead(read->nr_bytes, read->location, destination,
+		                                            [stamp, on_complete](optional_ptr<ErrorData> error) {
+			                                            stamp->finished = TimePoint::Tick();
+			                                            on_complete(error);
+		                                            });
+		switch (submission) {
+		case FileReadSubmission::PENDING:
 			return AsyncTaskExecutionResult::PENDING;
+		case FileReadSubmission::COMPLETED:
+			// the bytes are already here, so take delivery now rather than paying for a reschedule
+			timing->finished = TimePoint::Tick();
+			TakeDelivery();
+			return AsyncTaskExecutionResult::FINISHED;
+		default:
+			// this file system reads synchronously - do the read here, holding the calling thread
+			PerformRead(*read);
+			FinishRead();
+			return AsyncTaskExecutionResult::FINISHED;
 		}
-		// this file system reads synchronously - do the read here, holding the calling thread
-		PerformRead(request);
-		FinishRead();
-		return AsyncTaskExecutionResult::FINISHED;
 	}
 
 	void FinishAsync() final {
-		FinishRead();
+		TakeDelivery();
 	}
 
 protected:
@@ -63,6 +85,20 @@ private:
 	static void PerformRead(AsyncReadRequest &request) {
 		request.destination = request.handle.Read(request.nr_bytes, request.location);
 	}
+
+	//! Take a read the file system performed off its hands: the bookkeeping the synchronous read does after
+	//! the fact, then the bytes themselves
+	void TakeDelivery() {
+		read->handle.RecordAsyncRead(timing->started, timing->finished, read->nr_bytes);
+		read->destination = destination->TakeGroup();
+		FinishRead();
+	}
+
+private:
+	//! The read started by TryExecuteAsync, held so FinishAsync can finish the same one
+	unique_ptr<AsyncReadRequest> read;
+	shared_ptr<FileBufferReadDestination> destination;
+	shared_ptr<AsyncReadTiming> timing;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/external_file_cache/async_file_read_task.hpp
+++ b/src/include/duckdb/storage/external_file_cache/async_file_read_task.hpp
@@ -27,9 +27,8 @@ struct AsyncReadRequest {
 	FileBufferHandleGroup &destination;
 };
 
-//! An async task that performs exactly one read through a CachingFileHandle.
-//! Subclasses only describe the read and consume it - whether it blocks the calling thread or is handed off to the
-//! file system is decided here, so no task has to carry a fallback of its own.
+//! An async task that performs exactly one read through a CachingFileHandle. Subclasses describe the read and
+//! consume it; whether it blocks or is handed to the file system is decided here, not by the task.
 class AsyncFileReadTask : public AsyncTask {
 public:
 	void Execute() final {

--- a/src/include/duckdb/storage/external_file_cache/caching_file_system.hpp
+++ b/src/include/duckdb/storage/external_file_cache/caching_file_system.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "duckdb/common/async_io_callback.hpp"
 #include "duckdb/common/enums/cache_validation_mode.hpp"
 #include "duckdb/common/file_open_flags.hpp"
 #include "duckdb/common/file_opener.hpp"
@@ -65,6 +66,12 @@ public:
 	//! Read [nr_bytes] bytes at the requested [location].
 	//! Returns a buffer handle group that keeps the data pinned in memory.
 	DUCKDB_API FileBufferHandleGroup Read(idx_t nr_bytes, idx_t location);
+	//! Try to start an asynchronous read of [nr_bytes] bytes at [location], releasing the calling thread while the
+	//! read is in flight. On success [out_group] is set to the destination buffer - its contents are only valid once
+	//! [callback] has fired. Returns false when this read cannot be served asynchronously (the external file cache
+	//! block path, or a file system without asynchronous reads), in which case the caller must use Read().
+	DUCKDB_API bool TryStartRead(idx_t nr_bytes, idx_t location, FileBufferHandleGroup &out_group,
+	                             AsyncIOCallback callback);
 	//! Read [nr_bytes] bytes and sets [nr_bytes] to the actually read bytes.
 	DUCKDB_API FileBufferHandleGroup Read(idx_t &nr_bytes);
 	//! Read and record time
@@ -85,6 +92,8 @@ public:
 	DUCKDB_API void Seek(idx_t location);
 
 private:
+	//! Whether reads on this handle bypass the external file cache and go straight to the file system
+	bool UsesUncachedReadPath();
 	//! Remove the 'force_full_download' option from the file handle if present, and return whether it was present
 	bool StripForceFullDownloadIfPresent();
 	//! Refresh the cached file if the global cache state has changed.

--- a/src/include/duckdb/storage/external_file_cache/caching_file_system.hpp
+++ b/src/include/duckdb/storage/external_file_cache/caching_file_system.hpp
@@ -66,10 +66,8 @@ public:
 	//! Read [nr_bytes] bytes at the requested [location].
 	//! Returns a buffer handle group that keeps the data pinned in memory.
 	DUCKDB_API FileBufferHandleGroup Read(idx_t nr_bytes, idx_t location);
-	//! Try to start an asynchronous read of [nr_bytes] bytes at [location], releasing the calling thread while the
-	//! read is in flight. On success [out_group] is set to the destination buffer - its contents are only valid once
-	//! [callback] has fired. Returns false when this read cannot be served asynchronously (the external file cache
-	//! block path, or a file system without asynchronous reads), in which case the caller must use Read().
+	//! Try to read [nr_bytes] at [location] without holding the calling thread. On success [out_group] is the
+	//! destination, valid only once [callback] has fired. Returns false when the caller must use Read() instead.
 	DUCKDB_API bool TryStartRead(idx_t nr_bytes, idx_t location, FileBufferHandleGroup &out_group,
 	                             AsyncIOCallback callback);
 	//! Read [nr_bytes] bytes and sets [nr_bytes] to the actually read bytes.

--- a/src/include/duckdb/storage/external_file_cache/caching_file_system.hpp
+++ b/src/include/duckdb/storage/external_file_cache/caching_file_system.hpp
@@ -9,9 +9,11 @@
 #pragma once
 
 #include "duckdb/common/async_io_callback.hpp"
+#include "duckdb/common/time_point.hpp"
 #include "duckdb/common/enums/cache_validation_mode.hpp"
 #include "duckdb/common/file_open_flags.hpp"
 #include "duckdb/common/file_opener.hpp"
+#include "duckdb/common/file_system.hpp"
 #include "duckdb/common/mutex.hpp"
 #include "duckdb/common/open_file_info.hpp"
 #include "duckdb/common/shared_ptr.hpp"
@@ -49,6 +51,30 @@ private:
 	double sum_bytes_seconds = 0;
 };
 
+//! An asynchronous read's destination, backed by the pinned buffer its handle group holds. Owning the
+//! group is what lets the read outlive the call that started it.
+class FileBufferReadDestination : public FileReadDestination {
+public:
+	DUCKDB_API FileBufferReadDestination(BufferManager &buffer_manager, idx_t nr_bytes);
+
+	data_ptr_t Data() override {
+		return data;
+	}
+	idx_t Size() const override {
+		return nr_bytes;
+	}
+
+	//! Hand the bytes over once the read has landed
+	FileBufferHandleGroup TakeGroup() {
+		return std::move(group);
+	}
+
+private:
+	idx_t nr_bytes;
+	data_ptr_t data = nullptr;
+	FileBufferHandleGroup group;
+};
+
 struct CachingFileHandle {
 public:
 	using CachedFile = ExternalFileCache::CachedFile;
@@ -66,10 +92,13 @@ public:
 	//! Read [nr_bytes] bytes at the requested [location].
 	//! Returns a buffer handle group that keeps the data pinned in memory.
 	DUCKDB_API FileBufferHandleGroup Read(idx_t nr_bytes, idx_t location);
-	//! Try to read [nr_bytes] at [location] without holding the calling thread. On success [out_group] is the
-	//! destination, valid only once [callback] has fired. Returns false when the caller must use Read() instead.
-	DUCKDB_API bool TryStartRead(idx_t nr_bytes, idx_t location, FileBufferHandleGroup &out_group,
-	                             AsyncIOCallback callback);
+	//! Try to read [nr_bytes] at [location] without holding the calling thread, see FileSystem::TryStartRead.
+	//! [out_destination] holds the bytes once the read has landed, UNSUPPORTED means the caller must use Read().
+	DUCKDB_API FileReadSubmission TryStartRead(idx_t nr_bytes, idx_t location,
+	                                           shared_ptr<FileBufferReadDestination> &out_destination,
+	                                           AsyncIOCallback callback);
+	//! The bookkeeping ReadAndRecord does after a read, for one that completed asynchronously
+	DUCKDB_API void RecordAsyncRead(const TimePoint &started, const TimePoint &finished, idx_t nr_bytes);
 	//! Read [nr_bytes] bytes and sets [nr_bytes] to the actually read bytes.
 	DUCKDB_API FileBufferHandleGroup Read(idx_t &nr_bytes);
 	//! Read and record time

--- a/src/include/duckdb/storage/external_file_cache/caching_file_system_wrapper.hpp
+++ b/src/include/duckdb/storage/external_file_cache/caching_file_system_wrapper.hpp
@@ -63,6 +63,8 @@ public:
 	                                           optional_ptr<FileOpener> opener = nullptr);
 
 	DUCKDB_API void Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override;
+	DUCKDB_API bool TryStartRead(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location,
+	                             AsyncIOCallback callback) override;
 	DUCKDB_API void Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override;
 	DUCKDB_API int64_t Read(FileHandle &handle, void *buffer, int64_t nr_bytes) override;
 	DUCKDB_API int64_t Write(FileHandle &handle, void *buffer, int64_t nr_bytes) override;

--- a/src/include/duckdb/storage/external_file_cache/caching_file_system_wrapper.hpp
+++ b/src/include/duckdb/storage/external_file_cache/caching_file_system_wrapper.hpp
@@ -63,8 +63,8 @@ public:
 	                                           optional_ptr<FileOpener> opener = nullptr);
 
 	DUCKDB_API void Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override;
-	DUCKDB_API bool TryStartRead(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location,
-	                             AsyncIOCallback callback) override;
+	DUCKDB_API FileReadSubmission TryStartRead(shared_ptr<const FileReadRequest> request,
+	                                           AsyncIOCallback callback) override;
 	DUCKDB_API void Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override;
 	DUCKDB_API int64_t Read(FileHandle &handle, void *buffer, int64_t nr_bytes) override;
 	DUCKDB_API int64_t Write(FileHandle &handle, void *buffer, int64_t nr_bytes) override;

--- a/src/parallel/async_result.cpp
+++ b/src/parallel/async_result.cpp
@@ -1,3 +1,4 @@
+#include "duckdb/common/atomic.hpp"
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/parallel/executor_task.hpp"
 #include "duckdb/parallel/async_result.hpp"
@@ -36,6 +37,15 @@ private:
 
 class AsyncExecutionTask : public ExecutorTask {
 	enum class CompletionSignal { BATCH_FINISHED, BATCH_ERRORED };
+	//! An async task blocks at most once, so three states are enough to describe its whole life
+	enum class AsyncState : uint8_t {
+		//! TryExecuteAsync has not returned yet, the completion may still land inline
+		RUNNING,
+		//! we returned TASK_BLOCKED, the completion must reschedule us
+		BLOCKED,
+		//! the completion has landed
+		COMPLETED
+	};
 
 public:
 	AsyncExecutionTask(Executor &executor, unique_ptr<AsyncTask> &&async_task, InterruptState &interrupt_state,
@@ -44,8 +54,27 @@ public:
 	      completion(std::move(completion)) {
 	}
 	TaskExecutionResult ExecuteTask(TaskExecutionMode mode) override {
+		if (!started) {
+			started = true;
+			if (StartAsyncWork() == AsyncTaskExecutionResult::PENDING) {
+				// the work is in flight - park unless the completion already landed inline
+				auto expected = AsyncState::RUNNING;
+				if (async_state.compare_exchange_strong(expected, AsyncState::BLOCKED)) {
+					return TaskExecutionResult::TASK_BLOCKED;
+				}
+			} else {
+				// the task did all of its work synchronously
+				SignalCompletion(CompletionSignal::BATCH_FINISHED);
+				return TaskExecutionResult::TASK_FINISHED;
+			}
+		}
+		// the asynchronous work has landed - consume its result
+		if (async_error.HasError()) {
+			SignalCompletion(CompletionSignal::BATCH_ERRORED);
+			async_error.Throw();
+		}
 		try {
-			async_task->Execute();
+			async_task->FinishAsync();
 		} catch (...) {
 			SignalCompletion(CompletionSignal::BATCH_ERRORED);
 			throw;
@@ -56,6 +85,32 @@ public:
 
 	string TaskType() const override {
 		return "AsyncTask";
+	}
+
+private:
+	//! Start the task's work, routing an early failure through the batch completion like Execute() does
+	AsyncTaskExecutionResult StartAsyncWork() {
+		// keep ourselves alive for as long as the work is in flight, the completion may outlive the scheduler's
+		// reference to us
+		auto self = shared_from_this();
+		try {
+			return async_task->TryExecuteAsync([this, self](optional_ptr<ErrorData> error) { OnAsyncDone(error); });
+		} catch (...) {
+			SignalCompletion(CompletionSignal::BATCH_ERRORED);
+			throw;
+		}
+	}
+
+	//! Invoked (on any thread) when the asynchronous work started by TryExecuteAsync has landed
+	void OnAsyncDone(optional_ptr<ErrorData> error) {
+		if (error) {
+			async_error = *error;
+		}
+		if (async_state.exchange(AsyncState::COMPLETED) == AsyncState::BLOCKED) {
+			// we already parked, so the completion is the one that has to wake us up again
+			Reschedule();
+		}
+		// otherwise ExecuteTask has not returned yet and will pick the result up itself
 	}
 
 private:
@@ -75,6 +130,11 @@ private:
 	unique_ptr<AsyncTask> async_task;
 	InterruptState interrupt_state;
 	shared_ptr<AsyncBatchCompletion> completion;
+	//! Whether TryExecuteAsync has been called, a task only ever blocks once
+	bool started = false;
+	atomic<AsyncState> async_state {AsyncState::RUNNING};
+	//! Error reported by the asynchronous work, only read after async_state became COMPLETED
+	ErrorData async_error;
 };
 
 AsyncResult::AsyncResult(SourceResultType t) : AsyncResult(GetAsyncResultType(t)) {

--- a/src/parallel/async_result.cpp
+++ b/src/parallel/async_result.cpp
@@ -90,8 +90,7 @@ public:
 private:
 	//! Start the task's work, routing an early failure through the batch completion like Execute() does
 	AsyncTaskExecutionResult StartAsyncWork() {
-		// keep ourselves alive for as long as the work is in flight, the completion may outlive the scheduler's
-		// reference to us
+		// the completion may outlive the scheduler's reference to us
 		auto self = shared_from_this();
 		try {
 			return async_task->TryExecuteAsync([this, self](optional_ptr<ErrorData> error) { OnAsyncDone(error); });

--- a/src/storage/external_file_cache/caching_file_system.cpp
+++ b/src/storage/external_file_cache/caching_file_system.cpp
@@ -339,12 +339,41 @@ Allocator &CachingFileHandle::GetBufferAllocator() const {
 	return external_file_cache.GetBufferManager().GetBufferAllocator();
 }
 
+bool CachingFileHandle::UsesUncachedReadPath() {
+	return !external_file_cache.IsEnabled() || !external_file_cache.ShouldCacheFile(path.path) || !CanUseCache();
+}
+
+bool CachingFileHandle::TryStartRead(const idx_t nr_bytes, const idx_t location, FileBufferHandleGroup &out_group,
+                                     AsyncIOCallback callback) {
+	if (nr_bytes == 0) {
+		// nothing to read, the (trivial) synchronous path handles this
+		return false;
+	}
+	if (!UsesUncachedReadPath()) {
+		// a cached read fans out over several cache blocks, which has no asynchronous path yet
+		return false;
+	}
+	auto file_handle = GetFileHandle();
+	auto buf = AllocateUncachedReadBuffer(external_file_cache.GetBufferManager(), nr_bytes);
+	// the buffer stays pinned in out_group, so this pointer survives the move below
+	auto destination = buf.GetDataMutable();
+	vector<FileBufferHandleGroup::MemoryHandle> mem_handles;
+	mem_handles.push_back({std::move(buf), 0, nr_bytes});
+	// publish the destination before starting the read - the callback may fire inline
+	out_group = FileBufferHandleGroup(std::move(mem_handles));
+	if (!file_handle->TryStartRead(destination, nr_bytes, location, std::move(callback))) {
+		out_group = FileBufferHandleGroup();
+		return false;
+	}
+	return true;
+}
+
 FileBufferHandleGroup CachingFileHandle::Read(const idx_t nr_bytes, const idx_t location) {
 	if (nr_bytes == 0) {
 		return FileBufferHandleGroup();
 	}
 
-	if (!external_file_cache.IsEnabled() || !external_file_cache.ShouldCacheFile(path.path) || !CanUseCache()) {
+	if (UsesUncachedReadPath()) {
 		auto buf = AllocateUncachedReadBuffer(external_file_cache.GetBufferManager(), nr_bytes);
 		ReadAndRecord(context, buf.GetDataMutable(), nr_bytes, location);
 		vector<FileBufferHandleGroup::MemoryHandle> mem_handles;

--- a/src/storage/external_file_cache/caching_file_system.cpp
+++ b/src/storage/external_file_cache/caching_file_system.cpp
@@ -46,6 +46,17 @@ void TightenCacheDeadline(optional<timestamp_t> &cached, const optional<timestam
 	}
 }
 
+// Allocate an uncached read buffer and wrap it in a handle group, setting [destination] to where the bytes go.
+// The buffer stays pinned by the group, so [destination] stays valid for as long as the group is held.
+FileBufferHandleGroup AllocateUncachedReadGroup(BufferManager &buffer_manager, idx_t nr_bytes,
+                                                data_ptr_t &destination) {
+	auto buffer = AllocateUncachedReadBuffer(buffer_manager, nr_bytes);
+	destination = buffer.GetDataMutable();
+	vector<FileBufferHandleGroup::MemoryHandle> mem_handles;
+	mem_handles.push_back({std::move(buffer), 0, nr_bytes});
+	return FileBufferHandleGroup(std::move(mem_handles));
+}
+
 //===----------------------------------------------------------------------===//
 // FetchBlockTask
 //===----------------------------------------------------------------------===//
@@ -354,13 +365,9 @@ bool CachingFileHandle::TryStartRead(const idx_t nr_bytes, const idx_t location,
 		return false;
 	}
 	auto file_handle = GetFileHandle();
-	auto buf = AllocateUncachedReadBuffer(external_file_cache.GetBufferManager(), nr_bytes);
-	// the buffer stays pinned in out_group, so this pointer survives the move below
-	auto destination = buf.GetDataMutable();
-	vector<FileBufferHandleGroup::MemoryHandle> mem_handles;
-	mem_handles.push_back({std::move(buf), 0, nr_bytes});
+	data_ptr_t destination;
 	// publish the destination before starting the read - the callback may fire inline
-	out_group = FileBufferHandleGroup(std::move(mem_handles));
+	out_group = AllocateUncachedReadGroup(external_file_cache.GetBufferManager(), nr_bytes, destination);
 	if (!file_handle->TryStartRead(destination, nr_bytes, location, std::move(callback))) {
 		out_group = FileBufferHandleGroup();
 		return false;
@@ -374,11 +381,10 @@ FileBufferHandleGroup CachingFileHandle::Read(const idx_t nr_bytes, const idx_t 
 	}
 
 	if (UsesUncachedReadPath()) {
-		auto buf = AllocateUncachedReadBuffer(external_file_cache.GetBufferManager(), nr_bytes);
-		ReadAndRecord(context, buf.GetDataMutable(), nr_bytes, location);
-		vector<FileBufferHandleGroup::MemoryHandle> mem_handles;
-		mem_handles.push_back({std::move(buf), 0, nr_bytes});
-		return FileBufferHandleGroup(std::move(mem_handles));
+		data_ptr_t destination;
+		auto group = AllocateUncachedReadGroup(external_file_cache.GetBufferManager(), nr_bytes, destination);
+		ReadAndRecord(context, destination, nr_bytes, location);
+		return group;
 	}
 
 	auto current_cached_file = EnsureCachedFileCurrent();

--- a/src/storage/external_file_cache/caching_file_system.cpp
+++ b/src/storage/external_file_cache/caching_file_system.cpp
@@ -354,25 +354,47 @@ bool CachingFileHandle::UsesUncachedReadPath() {
 	return !external_file_cache.IsEnabled() || !external_file_cache.ShouldCacheFile(path.path) || !CanUseCache();
 }
 
-bool CachingFileHandle::TryStartRead(const idx_t nr_bytes, const idx_t location, FileBufferHandleGroup &out_group,
-                                     AsyncIOCallback callback) {
+FileBufferReadDestination::FileBufferReadDestination(BufferManager &buffer_manager, const idx_t nr_bytes)
+    : nr_bytes(nr_bytes) {
+	group = AllocateUncachedReadGroup(buffer_manager, nr_bytes, data);
+}
+
+FileReadSubmission CachingFileHandle::TryStartRead(const idx_t nr_bytes, const idx_t location,
+                                                   shared_ptr<FileBufferReadDestination> &out_destination,
+                                                   AsyncIOCallback callback) {
 	if (nr_bytes == 0) {
 		// nothing to read, the (trivial) synchronous path handles this
-		return false;
+		return FileReadSubmission::UNSUPPORTED;
 	}
 	if (!UsesUncachedReadPath()) {
 		// a cached read fans out over several cache blocks, which has no asynchronous path yet
-		return false;
+		return FileReadSubmission::UNSUPPORTED;
 	}
 	auto file_handle = GetFileHandle();
-	data_ptr_t destination;
+	auto destination = make_shared_ptr<FileBufferReadDestination>(external_file_cache.GetBufferManager(), nr_bytes);
+	auto request = make_shared_ptr<const FileReadRequest>(FileReadRequest {file_handle, destination, location});
+
 	// publish the destination before starting the read - the callback may fire inline
-	out_group = AllocateUncachedReadGroup(external_file_cache.GetBufferManager(), nr_bytes, destination);
-	if (!file_handle->TryStartRead(context, destination, nr_bytes, location, std::move(callback))) {
-		out_group = FileBufferHandleGroup();
-		return false;
+	out_destination = destination;
+	auto submission = file_handle->file_system.TryStartRead(request, std::move(callback));
+	if (submission == FileReadSubmission::UNSUPPORTED) {
+		out_destination = nullptr;
+		return submission;
 	}
-	return true;
+	file_handle->TrackBytesRead(context, nr_bytes);
+	return submission;
+}
+
+void CachingFileHandle::RecordAsyncRead(const TimePoint &started, const TimePoint &finished, const idx_t nr_bytes) {
+	auto handle = GetFileHandle();
+	auto cache_valid_until = handle->file_system.GetCacheValidUntil(*handle);
+	if (cache_valid_until) {
+		const annotated_lock_guard<annotated_mutex> guard(file_handle_mutex);
+		if (file_handle == handle) {
+			TightenCacheDeadline(validation_info.cache_valid_until, cache_valid_until);
+		}
+	}
+	RecordReadThroughput(TimePoint::ElapsedSeconds(started, finished), nr_bytes);
 }
 
 FileBufferHandleGroup CachingFileHandle::Read(const idx_t nr_bytes, const idx_t location) {

--- a/src/storage/external_file_cache/caching_file_system.cpp
+++ b/src/storage/external_file_cache/caching_file_system.cpp
@@ -368,7 +368,7 @@ bool CachingFileHandle::TryStartRead(const idx_t nr_bytes, const idx_t location,
 	data_ptr_t destination;
 	// publish the destination before starting the read - the callback may fire inline
 	out_group = AllocateUncachedReadGroup(external_file_cache.GetBufferManager(), nr_bytes, destination);
-	if (!file_handle->TryStartRead(destination, nr_bytes, location, std::move(callback))) {
+	if (!file_handle->TryStartRead(context, destination, nr_bytes, location, std::move(callback))) {
 		out_group = FileBufferHandleGroup();
 		return false;
 	}

--- a/src/storage/external_file_cache/caching_file_system_wrapper.cpp
+++ b/src/storage/external_file_cache/caching_file_system_wrapper.cpp
@@ -162,6 +162,16 @@ void CachingFileSystemWrapper::Read(FileHandle &handle, void *buffer, int64_t nr
 	group.CopyTo(static_cast<data_ptr_t>(buffer), NumericCast<idx_t>(nr_bytes));
 }
 
+bool CachingFileSystemWrapper::TryStartRead(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location,
+                                            AsyncIOCallback callback) {
+	auto *caching_handle = GetCachingHandleIfPossible(handle);
+	if (!caching_handle) {
+		return underlying_file_system.TryStartRead(handle, buffer, nr_bytes, location, std::move(callback));
+	}
+	// reads served through the external file cache are not asynchronous, the caller falls back to Read
+	return false;
+}
+
 int64_t CachingFileSystemWrapper::Read(FileHandle &handle, void *buffer, int64_t nr_bytes) {
 	const idx_t current_position = SeekPosition(handle);
 	const idx_t max_read = NumericCast<idx_t>(GetFileSize(handle)) - current_position;

--- a/src/storage/external_file_cache/caching_file_system_wrapper.cpp
+++ b/src/storage/external_file_cache/caching_file_system_wrapper.cpp
@@ -162,14 +162,14 @@ void CachingFileSystemWrapper::Read(FileHandle &handle, void *buffer, int64_t nr
 	group.CopyTo(static_cast<data_ptr_t>(buffer), NumericCast<idx_t>(nr_bytes));
 }
 
-bool CachingFileSystemWrapper::TryStartRead(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location,
-                                            AsyncIOCallback callback) {
-	auto *caching_handle = GetCachingHandleIfPossible(handle);
+FileReadSubmission CachingFileSystemWrapper::TryStartRead(shared_ptr<const FileReadRequest> request,
+                                                          AsyncIOCallback callback) {
+	auto *caching_handle = GetCachingHandleIfPossible(*request->handle);
 	if (!caching_handle) {
-		return underlying_file_system.TryStartRead(handle, buffer, nr_bytes, location, std::move(callback));
+		return underlying_file_system.TryStartRead(std::move(request), std::move(callback));
 	}
 	// reads served through the external file cache are not asynchronous, the caller falls back to Read
-	return false;
+	return FileReadSubmission::UNSUPPORTED;
 }
 
 int64_t CachingFileSystemWrapper::Read(FileHandle &handle, void *buffer, int64_t nr_bytes) {

--- a/test/configs/force_storage_restart.json
+++ b/test/configs/force_storage_restart.json
@@ -18,6 +18,12 @@
       ]
     },
     {
+      "reason": "Restarting resets the thread count and drops the DebugFileSystem, so the read statistics this test asserts on are gone.",
+      "paths": [
+        "test/sql/copy/parquet/parquet_async_read.test"
+      ]
+    },
+    {
       "reason": "Contains explicit use of the memory catalog.",
       "paths": [
         "test/sql/attach/attach_use_rollback.test",

--- a/test/extension/debug_fs/debug_file_system.cpp
+++ b/test/extension/debug_fs/debug_file_system.cpp
@@ -5,6 +5,7 @@
 
 #include "duckdb/common/helper.hpp"
 #include "duckdb/common/thread.hpp"
+#include "duckdb/common/time_point.hpp"
 #include "duckdb/common/types/timestamp.hpp"
 #include "duckdb/logging/logger.hpp"
 #include "duckdb/main/database.hpp"
@@ -32,9 +33,98 @@ FileCompressionType DebugFileHandle::GetFileCompressionType() {
 	return inner->GetFileCompressionType();
 }
 
+#ifndef DUCKDB_NO_THREADS
+//! One read that was started asynchronously and has not been completed yet
+struct PendingDebugRead {
+	FileHandle *handle;
+	void *buffer;
+	int64_t nr_bytes;
+	idx_t location;
+	AsyncIOCallback callback;
+	//! When this read should be completed, in milliseconds since the queue was created
+	double due_ms;
+};
+
+//! Completes asynchronously started reads on a dedicated thread, standing in for a platform whose I/O genuinely
+//! completes out-of-band (e.g. a browser handing a fetch response back to the event loop).
+class DebugAsyncReadQueue {
+public:
+	DebugAsyncReadQueue() : start(TimePoint::Tick()), thread([this] { Run(); }) {
+	}
+	~DebugAsyncReadQueue() {
+		{
+			unique_lock<std::mutex> lock(queue_lock);
+			shutdown = true;
+		}
+		queue_cv.notify_all();
+		thread.join();
+	}
+
+	void Push(PendingDebugRead read) {
+		{
+			unique_lock<std::mutex> lock(queue_lock);
+			pending.push_back(std::move(read));
+		}
+		queue_cv.notify_one();
+	}
+
+	double ElapsedMs() const {
+		return static_cast<double>(TimePoint::ElapsedMicros(start, TimePoint::Tick())) / 1000.0;
+	}
+
+private:
+	void Run() {
+		while (true) {
+			PendingDebugRead read;
+			{
+				unique_lock<std::mutex> lock(queue_lock);
+				queue_cv.wait(lock, [this] { return shutdown || !pending.empty(); });
+				if (pending.empty()) {
+					// only wake up for shutdown once everything that was started has been completed
+					return;
+				}
+				// complete whichever read is due first, so injected latencies overlap instead of serializing
+				auto earliest = pending.begin();
+				for (auto it = pending.begin(); it != pending.end(); it++) {
+					if (it->due_ms < earliest->due_ms) {
+						earliest = it;
+					}
+				}
+				read = std::move(*earliest);
+				pending.erase(earliest);
+			}
+			auto remaining_ms = read.due_ms - ElapsedMs();
+			if (remaining_ms > 0) {
+				ThreadUtil::SleepMs(LossyNumericCast<idx_t>(remaining_ms));
+			}
+			try {
+				read.handle->file_system.Read(*read.handle, read.buffer, read.nr_bytes, read.location);
+			} catch (std::exception &ex) {
+				ErrorData error(ex);
+				read.callback(&error);
+				continue;
+			}
+			read.callback(nullptr);
+		}
+	}
+
+	TimePoint start;
+	std::mutex queue_lock;
+	std::condition_variable queue_cv;
+	vector<PendingDebugRead> pending;
+	bool shutdown = false;
+	//! Declared last so the thread only starts once every member it touches is initialized
+	std::thread thread;
+};
+#else
+class DebugAsyncReadQueue {};
+#endif
+
 DebugFileSystem::DebugFileSystem(unique_ptr<FileSystem> inner_fs, DatabaseInstance &db)
     : inner_fs(std::move(inner_fs)), db(db) {
 }
+
+DebugFileSystem::~DebugFileSystem() = default;
 
 void DebugFileSystem::SetDelayMeanMs(double v) {
 	const annotated_lock_guard<annotated_mutex> guard(random_engine_lock);
@@ -73,8 +163,7 @@ void DebugFileSystem::EnsureRandomEngineInitialized() {
 	DUCKDB_LOG_INFO(db, "DebugFileSystem initialized with random seed: %llu", seed);
 }
 
-void DebugFileSystem::ApplyDelay() {
-#ifndef DUCKDB_NO_THREADS
+double DebugFileSystem::SampleDelayMs() {
 	double mean_ms = 0;
 	double stddev_ms = 0;
 	{
@@ -84,23 +173,54 @@ void DebugFileSystem::ApplyDelay() {
 	}
 
 	if (mean_ms == 0.0) {
-		return;
+		return 0.0;
 	}
 
 	// Lazy initialize the random engine on first IO operation, so user-set random seed could be applied.
 	EnsureRandomEngineInitialized();
 
-	double delay_ms = 0;
 	if (stddev_ms == 0.0) {
-		delay_ms = mean_ms;
-	} else {
-		const annotated_lock_guard<annotated_mutex> guard(random_engine_lock);
-		delay_ms = IoLatencyModel(mean_ms, stddev_ms).SampleLatency(*random_engine);
+		return mean_ms;
 	}
+	const annotated_lock_guard<annotated_mutex> guard(random_engine_lock);
+	return IoLatencyModel(mean_ms, stddev_ms).SampleLatency(*random_engine);
+}
+
+void DebugFileSystem::ApplyDelay() {
+#ifndef DUCKDB_NO_THREADS
+	auto delay_ms = SampleDelayMs();
 	if (delay_ms > 0.0) {
 		ThreadUtil::SleepMs(LossyNumericCast<idx_t>(delay_ms));
 	}
 #endif
+}
+
+void DebugFileSystem::SetAsyncReads(bool async_reads_p) {
+	async_reads = async_reads_p;
+}
+
+idx_t DebugFileSystem::GetMaxConcurrentReads() const {
+	return max_concurrent_reads.load();
+}
+
+idx_t DebugFileSystem::GetAsyncReadCount() const {
+	return async_read_count.load();
+}
+
+void DebugFileSystem::ResetReadStats() {
+	max_concurrent_reads = 0;
+	async_read_count = 0;
+}
+
+void DebugFileSystem::ReadStarted() {
+	const auto in_flight = ++reads_in_flight;
+	auto observed = max_concurrent_reads.load();
+	while (in_flight > observed && !max_concurrent_reads.compare_exchange_weak(observed, in_flight)) {
+	}
+}
+
+void DebugFileSystem::ReadFinished() {
+	--reads_in_flight;
 }
 
 unique_ptr<FileHandle> DebugFileSystem::OpenFileExtended(const OpenFileInfo &file, FileOpenFlags flags,
@@ -114,9 +234,40 @@ unique_ptr<FileHandle> DebugFileSystem::OpenFileExtended(const OpenFileInfo &fil
 }
 
 void DebugFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
+	ReadStarted();
 	ApplyDelay();
 	auto &inner = *handle.Cast<DebugFileHandle>().inner;
 	inner.file_system.Read(inner, buffer, nr_bytes, location);
+	ReadFinished();
+}
+
+bool DebugFileSystem::TryStartRead(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location,
+                                   AsyncIOCallback callback) {
+#ifdef DUCKDB_NO_THREADS
+	return false;
+#else
+	if (!async_reads) {
+		return false;
+	}
+	if (!async_queue) {
+		const annotated_lock_guard<annotated_mutex> guard(random_engine_lock);
+		if (!async_queue) {
+			async_queue = make_uniq<DebugAsyncReadQueue>();
+		}
+	}
+	auto delay_ms = SampleDelayMs();
+	ReadStarted();
+	async_read_count++;
+	auto &inner = *handle.Cast<DebugFileHandle>().inner;
+	// the injected latency is served by the completion thread, so the caller is free while it elapses
+	async_queue->Push(PendingDebugRead {&inner, buffer, nr_bytes, location,
+	                                    [this, callback](optional_ptr<ErrorData> error) {
+		                                    ReadFinished();
+		                                    callback(error);
+	                                    },
+	                                    async_queue->ElapsedMs() + delay_ms});
+	return true;
+#endif
 }
 
 int64_t DebugFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes) {

--- a/test/extension/debug_fs/debug_file_system.cpp
+++ b/test/extension/debug_fs/debug_file_system.cpp
@@ -43,6 +43,13 @@ struct PendingDebugRead {
 	double due_ms;
 };
 
+//! Perform a requested read, straight to the inner handle: whatever delay it owes has been served already
+static void PerformRequestedRead(const FileReadRequest &request) {
+	auto &inner = *request.handle->Cast<DebugFileHandle>().inner;
+	auto &destination = *request.destination;
+	inner.file_system.Read(inner, destination.Data(), NumericCast<int64_t>(destination.Size()), request.location);
+}
+
 //! Completes asynchronously started reads on a dedicated thread, standing in for a platform whose I/O genuinely
 //! completes out-of-band (e.g. a browser handing a fetch response back to the event loop).
 class DebugAsyncReadQueue {
@@ -96,11 +103,7 @@ private:
 				ThreadUtil::SleepMs(LossyNumericCast<idx_t>(remaining_ms));
 			}
 			try {
-				// straight to the inner handle, the delay this read owes was already served above
-				auto &inner = *read.request->handle->Cast<DebugFileHandle>().inner;
-				auto &destination = *read.request->destination;
-				inner.file_system.Read(inner, destination.Data(), NumericCast<int64_t>(destination.Size()),
-				                       read.request->location);
+				PerformRequestedRead(*read.request);
 			} catch (std::exception &ex) {
 				ErrorData error(ex);
 				read.callback(&error);
@@ -250,15 +253,21 @@ FileReadSubmission DebugFileSystem::TryStartRead(shared_ptr<const FileReadReques
 	if (!async_reads) {
 		return FileReadSubmission::UNSUPPORTED;
 	}
+	auto delay_ms = SampleDelayMs();
+	ReadStarted();
+	async_read_count++;
+	if (delay_ms <= 0) {
+		// no latency to serve means nothing to wait for, so the bytes are there before we return
+		PerformRequestedRead(*request);
+		ReadFinished();
+		return FileReadSubmission::COMPLETED;
+	}
 	if (!async_queue) {
 		const annotated_lock_guard<annotated_mutex> guard(random_engine_lock);
 		if (!async_queue) {
 			async_queue = make_uniq<DebugAsyncReadQueue>();
 		}
 	}
-	auto delay_ms = SampleDelayMs();
-	ReadStarted();
-	async_read_count++;
 	// the injected latency is served by the completion thread, so the caller is free while it elapses
 	async_queue->Push(PendingDebugRead {std::move(request),
 	                                    [this, callback](optional_ptr<ErrorData> error) {

--- a/test/extension/debug_fs/debug_file_system.cpp
+++ b/test/extension/debug_fs/debug_file_system.cpp
@@ -34,12 +34,10 @@ FileCompressionType DebugFileHandle::GetFileCompressionType() {
 }
 
 #ifndef DUCKDB_NO_THREADS
-//! One read that was started asynchronously and has not been completed yet
+//! One read that was started asynchronously and has not been completed yet. Holding the request is what
+//! keeps the handle and the buffer alive until the queue gets to it.
 struct PendingDebugRead {
-	FileHandle *handle;
-	void *buffer;
-	int64_t nr_bytes;
-	idx_t location;
+	shared_ptr<const FileReadRequest> request;
 	AsyncIOCallback callback;
 	//! When this read should be completed, in milliseconds since the queue was created
 	double due_ms;
@@ -98,7 +96,11 @@ private:
 				ThreadUtil::SleepMs(LossyNumericCast<idx_t>(remaining_ms));
 			}
 			try {
-				read.handle->file_system.Read(*read.handle, read.buffer, read.nr_bytes, read.location);
+				// straight to the inner handle, the delay this read owes was already served above
+				auto &inner = *read.request->handle->Cast<DebugFileHandle>().inner;
+				auto &destination = *read.request->destination;
+				inner.file_system.Read(inner, destination.Data(), NumericCast<int64_t>(destination.Size()),
+				                       read.request->location);
 			} catch (std::exception &ex) {
 				ErrorData error(ex);
 				read.callback(&error);
@@ -241,13 +243,12 @@ void DebugFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes, i
 	ReadFinished();
 }
 
-bool DebugFileSystem::TryStartRead(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location,
-                                   AsyncIOCallback callback) {
+FileReadSubmission DebugFileSystem::TryStartRead(shared_ptr<const FileReadRequest> request, AsyncIOCallback callback) {
 #ifdef DUCKDB_NO_THREADS
-	return false;
+	return FileReadSubmission::UNSUPPORTED;
 #else
 	if (!async_reads) {
-		return false;
+		return FileReadSubmission::UNSUPPORTED;
 	}
 	if (!async_queue) {
 		const annotated_lock_guard<annotated_mutex> guard(random_engine_lock);
@@ -258,15 +259,14 @@ bool DebugFileSystem::TryStartRead(FileHandle &handle, void *buffer, int64_t nr_
 	auto delay_ms = SampleDelayMs();
 	ReadStarted();
 	async_read_count++;
-	auto &inner = *handle.Cast<DebugFileHandle>().inner;
 	// the injected latency is served by the completion thread, so the caller is free while it elapses
-	async_queue->Push(PendingDebugRead {&inner, buffer, nr_bytes, location,
+	async_queue->Push(PendingDebugRead {std::move(request),
 	                                    [this, callback](optional_ptr<ErrorData> error) {
 		                                    ReadFinished();
 		                                    callback(error);
 	                                    },
 	                                    async_queue->ElapsedMs() + delay_ms});
-	return true;
+	return FileReadSubmission::PENDING;
 #endif
 }
 

--- a/test/extension/debug_fs/debug_fs_extension.cpp
+++ b/test/extension/debug_fs/debug_fs_extension.cpp
@@ -80,11 +80,50 @@ void OnSetRandomSeed(ClientContext &context, SetScope, Value &parameter) {
 	debug_fs.SetRandomSeed(parameter.GetValue<uint64_t>());
 }
 
+void OnSetAsyncReads(ClientContext &context, SetScope, Value &parameter) {
+	GetDebugFileSystemOrThrow(DatabaseInstance::GetDatabase(context)).SetAsyncReads(parameter.GetValue<bool>());
+}
+
+//! debug_fs_max_concurrent_reads() - highest number of reads that were in flight at the same time
+void MaxConcurrentReadsFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &context = state.GetContext();
+	auto &debug_fs = GetDebugFileSystemOrThrow(DatabaseInstance::GetDatabase(context));
+	result.SetVectorType(VectorType::CONSTANT_VECTOR);
+	ConstantVector::GetData<uint64_t>(result)[0] = debug_fs.GetMaxConcurrentReads();
+}
+
+//! debug_fs_async_read_count() - number of reads that were served asynchronously
+void AsyncReadCountFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &context = state.GetContext();
+	auto &debug_fs = GetDebugFileSystemOrThrow(DatabaseInstance::GetDatabase(context));
+	result.SetVectorType(VectorType::CONSTANT_VECTOR);
+	ConstantVector::GetData<uint64_t>(result)[0] = debug_fs.GetAsyncReadCount();
+}
+
+//! debug_fs_reset_read_stats() - clear the counters above
+void ResetReadStatsFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &context = state.GetContext();
+	auto &debug_fs = GetDebugFileSystemOrThrow(DatabaseInstance::GetDatabase(context));
+	debug_fs.ResetReadStats();
+	result.SetVectorType(VectorType::CONSTANT_VECTOR);
+	ConstantVector::GetData<bool>(result)[0] = true;
+}
+
 void LoadInternal(ExtensionLoader &loader) {
 	auto &db = loader.GetDatabaseInstance();
 	EnsureDebugFileSystemInstalled(db);
 
+	loader.RegisterFunction(
+	    ScalarFunction("debug_fs_max_concurrent_reads", {}, LogicalType::UBIGINT, MaxConcurrentReadsFunction));
+	loader.RegisterFunction(
+	    ScalarFunction("debug_fs_async_read_count", {}, LogicalType::UBIGINT, AsyncReadCountFunction));
+	loader.RegisterFunction(
+	    ScalarFunction("debug_fs_reset_read_stats", {}, LogicalType::BOOLEAN, ResetReadStatsFunction));
+
 	auto &config = DBConfig::GetConfig(db);
+	config.AddExtensionOption("debug_fs_async_reads",
+	                          "Serve reads asynchronously off a completion thread instead of blocking the caller.",
+	                          LogicalType::BOOLEAN, Value(false), OnSetAsyncReads);
 	config.AddExtensionOption("debug_fs_delay_mean_ms", "Mean latency (ms) for filesystem operations.",
 	                          LogicalType::DOUBLE, Value(0.0), OnSetDelayMeanMs);
 	config.AddExtensionOption("debug_fs_delay_stddev_ms", "Standard deviation (ms) for filesystem operation latency.",

--- a/test/extension/debug_fs/include/debug_file_system.hpp
+++ b/test/extension/debug_fs/include/debug_file_system.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "duckdb/common/atomic.hpp"
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/mutex.hpp"
 #include "duckdb/common/random_engine.hpp"
@@ -19,6 +20,7 @@ class DatabaseInstance;
 
 // Forwards declaration.
 class DebugFileSystem;
+class DebugAsyncReadQueue;
 
 struct DebugFileHandle : public FileHandle {
 	DebugFileHandle(DebugFileSystem &fs, unique_ptr<FileHandle> inner_p);
@@ -33,13 +35,25 @@ struct DebugFileHandle : public FileHandle {
 class DebugFileSystem : public FileSystem {
 public:
 	DebugFileSystem(unique_ptr<FileSystem> inner_fs, DatabaseInstance &db);
+	~DebugFileSystem() override;
 
 	void SetDelayMeanMs(double v);
 	void SetDelayStddevMs(double v);
 	void SetRandomSeed(optional_idx seed);
 	bool RandomEngineInitialized();
 
+	//! Whether reads are served asynchronously, i.e. off a completion thread instead of blocking the caller.
+	//! This stands in for a platform that has genuinely asynchronous I/O (e.g. a browser's fetch callback).
+	void SetAsyncReads(bool async_reads);
+	//! Highest number of reads that were in flight at the same time, this is 1 for a purely synchronous file system
+	idx_t GetMaxConcurrentReads() const;
+	//! Number of reads that were served asynchronously
+	idx_t GetAsyncReadCount() const;
+	void ResetReadStats();
+
 	void Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override;
+	bool TryStartRead(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location,
+	                  AsyncIOCallback callback) override;
 	int64_t Read(FileHandle &handle, void *buffer, int64_t nr_bytes) override;
 	void Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override;
 	int64_t Write(FileHandle &handle, void *buffer, int64_t nr_bytes) override;
@@ -114,6 +128,11 @@ private:
 	// Random engine is initialized lazily on first IO operation, so users could set the random seed for reproduction.
 	void ApplyDelay();
 	void EnsureRandomEngineInitialized();
+	//! Sample the configured latency, in milliseconds
+	double SampleDelayMs();
+	//! Record that one more read went in flight, and update the concurrency high-water mark
+	void ReadStarted();
+	void ReadFinished();
 
 	unique_ptr<FileSystem> inner_fs;
 	DatabaseInstance &db;
@@ -122,6 +141,12 @@ private:
 	optional_idx random_seed DUCKDB_GUARDED_BY(random_engine_lock);
 	double delay_mean_ms DUCKDB_GUARDED_BY(random_engine_lock) = 0.0;
 	double delay_stddev_ms DUCKDB_GUARDED_BY(random_engine_lock) = 0.0;
+	atomic<bool> async_reads {false};
+	atomic<idx_t> reads_in_flight {0};
+	atomic<idx_t> max_concurrent_reads {0};
+	atomic<idx_t> async_read_count {0};
+	//! Completions for asynchronously started reads, drained by [completion_thread]
+	unique_ptr<DebugAsyncReadQueue> async_queue;
 };
 
 } // namespace duckdb

--- a/test/extension/debug_fs/include/debug_file_system.hpp
+++ b/test/extension/debug_fs/include/debug_file_system.hpp
@@ -52,8 +52,7 @@ public:
 	void ResetReadStats();
 
 	void Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override;
-	bool TryStartRead(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location,
-	                  AsyncIOCallback callback) override;
+	FileReadSubmission TryStartRead(shared_ptr<const FileReadRequest> request, AsyncIOCallback callback) override;
 	int64_t Read(FileHandle &handle, void *buffer, int64_t nr_bytes) override;
 	void Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override;
 	int64_t Write(FileHandle &handle, void *buffer, int64_t nr_bytes) override;

--- a/test/sql/copy/parquet/parquet_async_read.test
+++ b/test/sql/copy/parquet/parquet_async_read.test
@@ -1,0 +1,87 @@
+# name: test/sql/copy/parquet/parquet_async_read.test
+# description: Parquet read heads are fetched through the file system's asynchronous read path when it has one
+# group: [parquet]
+
+require parquet
+
+# Keep row-group I/O on the per-scan async path, where a BLOCKED result parks the scan task.
+statement ok
+SET read_ahead_depth=0
+
+# No I/O threads at all: any overlap between reads can only come from the asynchronous file system.
+statement ok
+SET threads=1
+
+statement ok
+SET async_threads=0
+
+statement ok
+SET GLOBAL debug_fs_random_seed=424242
+
+# Five columns, of which we project three non-adjacent ones, so each row group needs several
+# separate read heads rather than one merged range.
+statement ok
+COPY (
+    SELECT i AS c0, i * 2 AS c1, i * 3 AS c2, i * 4 AS c3, i * 5 AS c4
+    FROM range(100000) t(i)
+) TO '{TEST_DIR}/parquet_async_read.parquet'
+(FORMAT PARQUET, ROW_GROUP_SIZE 50000)
+
+# Make each read take long enough that overlapping reads are clearly distinguishable.
+statement ok
+SET GLOBAL debug_fs_delay_mean_ms=20
+
+statement ok
+SET GLOBAL debug_fs_delay_stddev_ms=0
+
+statement ok
+SELECT debug_fs_reset_read_stats()
+
+# Synchronous file system: unchanged behaviour, every read blocks its caller.
+statement ok
+SET GLOBAL debug_fs_async_reads=false
+
+query I
+SELECT sum(c0) + sum(c2) + sum(c4) FROM '{TEST_DIR}/parquet_async_read.parquet'
+----
+44999550000
+
+query I
+SELECT debug_fs_async_read_count()
+----
+0
+
+# With a single thread and no asynchronous reads, only one read can ever be in flight.
+query I
+SELECT debug_fs_max_concurrent_reads()
+----
+1
+
+statement ok
+SELECT debug_fs_reset_read_stats()
+
+# Asynchronous file system: the read heads are handed off, so the scan task parks instead of blocking.
+statement ok
+SET GLOBAL debug_fs_async_reads=true
+
+query I
+SELECT sum(c0) + sum(c2) + sum(c4) FROM '{TEST_DIR}/parquet_async_read.parquet'
+----
+44999550000
+
+query I
+SELECT debug_fs_async_read_count() > 0
+----
+true
+
+# Several reads were in flight at once even though there is not a single I/O thread to hold them.
+query I
+SELECT debug_fs_max_concurrent_reads() > 1
+----
+true
+
+statement ok
+SET GLOBAL debug_fs_delay_mean_ms=0
+
+statement ok
+SET GLOBAL debug_fs_async_reads=false

--- a/test/sql/copy/parquet/parquet_async_read.test
+++ b/test/sql/copy/parquet/parquet_async_read.test
@@ -4,6 +4,11 @@
 
 require parquet
 
+# this test exercises the async I/O path, so override any forced-synchronous
+# table scan execution strategy (e.g. from test_table_scan's --on-init)
+statement ok
+SET debug_physical_table_scan_execution_strategy=DEFAULT
+
 # Keep row-group I/O on the per-scan async path, where a BLOCKED result parks the scan task.
 statement ok
 SET read_ahead_depth=0

--- a/test/sql/copy/parquet/parquet_async_read.test
+++ b/test/sql/copy/parquet/parquet_async_read.test
@@ -86,7 +86,28 @@ SELECT debug_fs_max_concurrent_reads() > 1
 true
 
 statement ok
+SELECT debug_fs_reset_read_stats()
+
+# With no latency to inject the file system serves each read before returning, so the scan takes delivery
+# on the spot instead of parking. The asynchronous path is still the one taken.
+statement ok
 SET GLOBAL debug_fs_delay_mean_ms=0
+
+query I
+SELECT sum(c0) + sum(c2) + sum(c4) FROM '{TEST_DIR}/parquet_async_read.parquet'
+----
+44999550000
+
+query I
+SELECT debug_fs_async_read_count() > 0
+----
+true
+
+# Nothing is ever in flight, so no two reads can overlap.
+query I
+SELECT debug_fs_max_concurrent_reads()
+----
+1
 
 statement ok
 SET GLOBAL debug_fs_async_reads=false

--- a/test/sql/copy/parquet/parquet_async_read_metrics.test
+++ b/test/sql/copy/parquet/parquet_async_read_metrics.test
@@ -31,6 +31,11 @@ COPY (
 statement ok
 SET GLOBAL debug_fs_async_reads=true
 
+# a latency to serve keeps the reads on the deferred path, which is the one that has to account for
+# its bytes without a synchronous Read to do it
+statement ok
+SET GLOBAL debug_fs_delay_mean_ms=1
+
 statement ok
 PRAGMA enable_profiling = 'json'
 
@@ -48,6 +53,9 @@ PRAGMA disable_profiling
 
 statement ok
 SET GLOBAL debug_fs_async_reads=false
+
+statement ok
+SET GLOBAL debug_fs_delay_mean_ms=0
 
 # the column data dwarfs the metadata, so untracked read heads leave only a few tens of KB behind
 query I

--- a/test/sql/copy/parquet/parquet_async_read_metrics.test
+++ b/test/sql/copy/parquet/parquet_async_read_metrics.test
@@ -1,0 +1,56 @@
+# name: test/sql/copy/parquet/parquet_async_read_metrics.test
+# description: A parquet read served through the asynchronous path still reports the bytes it read
+# group: [parquet]
+
+require parquet
+
+require json
+
+# same single-threaded setup as parquet_async_read.test, so the reads really go through TryStartRead
+statement ok
+SET debug_physical_table_scan_execution_strategy=DEFAULT
+
+statement ok
+SET read_ahead_depth=0
+
+statement ok
+SET threads=1
+
+statement ok
+SET async_threads=0
+
+statement ok
+COPY (
+    SELECT i AS c0, i * 2 AS c1, i * 3 AS c2
+    FROM range(50000) t(i)
+) TO '{TEST_DIR}/parquet_async_read_metrics.parquet'
+(FORMAT PARQUET, ROW_GROUP_SIZE 10000)
+
+# everything that is not the measured scan happens before profiling starts, so nothing else
+# overwrites the profiling output
+statement ok
+SET GLOBAL debug_fs_async_reads=true
+
+statement ok
+PRAGMA enable_profiling = 'json'
+
+statement ok
+PRAGMA profiling_output = '{TEST_DIR}/async_read_metrics.json'
+
+statement ok
+SET tracked_metrics = ['io.total_bytes_read']
+
+statement ok
+SELECT sum(c0) + sum(c2) FROM '{TEST_DIR}/parquet_async_read_metrics.parquet'
+
+statement ok
+PRAGMA disable_profiling
+
+statement ok
+SET GLOBAL debug_fs_async_reads=false
+
+# the column data dwarfs the metadata, so untracked read heads leave only a few tens of KB behind
+query I
+SELECT io.total_bytes_read > 100000 FROM '{TEST_DIR}/async_read_metrics.json'
+----
+true


### PR DESCRIPTION
This adds some machinery, currently disabled, that once armed could unlock async IO to be driven by external (e.g. application) owned threads. This would also unlock, together with an independent change to HTTPUtil, to experiment with moving towards `multi_curl` and async I/O to land for single threaded Wasm (delegating to JS event loop `fetch` the eventual completion).

Main changes are the following:
1. Add `FileSystem::TryStartRead`, that default to `return false;`
2. Use that in `TryExecuteAsync`:
```c++
	AsyncTaskExecutionResult TryExecuteAsync(AsyncIOCallback on_complete) final {
		auto request = PrepareRead();
		if (request.handle.TryStartRead(request.nr_bytes, request.location, request.destination,
		                                std::move(on_complete))) {
			return AsyncTaskExecutionResult::PENDING;
		}
		// this file system reads synchronously - do the read here, holding the calling thread
		PerformRead(request);
		FinishRead();
		return AsyncTaskExecutionResult::FINISHED;
	}
```
3. Enabled in the parquet read path
4. Expand the test `debug_fs` to experiment / stress test this

Note that as long as `TryStartRead` defaults to `return false;`, this should be provably just shuffling code around, but enable to restructure the code to have non-duckdb owned threads drive FileSystem work, at least for the parquet path.