### PR TITLE
Propagate comparison for INTERVAL type

### DIFF
--- a/src/optimizer/statistics/expression/propagate_comparison.cpp
+++ b/src/optimizer/statistics/expression/propagate_comparison.cpp
@@ -132,6 +132,7 @@ FilterPropagateResult StatisticsPropagator::PropagateComparison(const BaseStatis
 	case PhysicalType::INT128:
 	case PhysicalType::FLOAT:
 	case PhysicalType::DOUBLE:
+	case PhysicalType::INTERVAL:
 		break;
 	default:
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;

--- a/test/sql/optimizer/list_contains_row_group_pruning.test
+++ b/test/sql/optimizer/list_contains_row_group_pruning.test
@@ -137,3 +137,19 @@ query I
 SELECT count(*) FROM long_string_lists WHERE list_contains(l, repeat('a', 19) || 'b');
 ----
 0
+
+# Interval child min/max can prune impossible needles
+statement ok
+CREATE TABLE interval_lists AS
+SELECT [i * INTERVAL '1 day'] AS l
+FROM range(6144) tbl(i);
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM interval_lists WHERE list_contains(l, INTERVAL '3000 days');
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
+
+query I
+SELECT count(*) FROM interval_lists WHERE list_contains(l, INTERVAL '3000 days');
+----
+1


### PR DESCRIPTION
Hi team, I think currently we propagate comparison doesn't support INTERVAL type, even if it does support min/max, so it leads to missing row group pruning. For example,
```sql
memory D ATTACH '/tmp/list_contains_row_group_pruning.duckdb' AS db (ROW_GROUP_SIZE 2048);
memory D USE db;
db D CREATE TABLE interval_lists AS
     SELECT [i * INTERVAL '1 day'] AS l
     FROM range(6144) tbl(i);
db D EXPLAIN ANALYZE SELECT count(*) FROM interval_lists WHERE list_contains(l, INTERVAL '3000 days');
╭─ Summary ───────────╮
│ Total Time: 0.0025s │
│ Data Read: 262.1 kB │
╰─────────────────────╯
╭─ Ungrouped Aggregate ───────────────────╮
│ Aggregates: count_star()                │
│ 1 row                               0µs │
╰────────────────────┒┎───────────────────╯
╭─ Table Scan ───────┚┖───────────────────╮
│ Table: db.main.interval_lists           │
│ Type: Sequential Scan                   │
│ Filters:                                │
│ list_contains(l, '3000 days'::INTERVAL) │
│ Row Groups Scanned: 3 / 3               │
│ 1 row                               0µs │
╰─────────────────────────────────────────╯
```
The above example should access only one row group, but in reality all three are read.