### PR TITLE
HTTPUtil: Add support for optional async requests

### DIFF
--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -2881,6 +2881,61 @@ HTTPClientCachePolicy EnumUtil::FromString<HTTPClientCachePolicy>(const char *va
 	return static_cast<HTTPClientCachePolicy>(StringUtil::StringToEnum(GetHTTPClientCachePolicyValues(), 2, "HTTPClientCachePolicy", value));
 }
 
+const StringUtil::EnumStringLiteral *GetHTTPExecutionModeValues() {
+	static constexpr StringUtil::EnumStringLiteral values[] {
+		{ static_cast<uint32_t>(HTTPExecutionMode::BLOCKING), "BLOCKING" },
+		{ static_cast<uint32_t>(HTTPExecutionMode::DEFERRABLE), "DEFERRABLE" }
+	};
+	return values;
+}
+
+template<>
+const char* EnumUtil::ToChars<HTTPExecutionMode>(HTTPExecutionMode value) {
+	return StringUtil::EnumToString(GetHTTPExecutionModeValues(), 2, "HTTPExecutionMode", static_cast<uint32_t>(value));
+}
+
+template<>
+HTTPExecutionMode EnumUtil::FromString<HTTPExecutionMode>(const char *value) {
+	return static_cast<HTTPExecutionMode>(StringUtil::StringToEnum(GetHTTPExecutionModeValues(), 2, "HTTPExecutionMode", value));
+}
+
+const StringUtil::EnumStringLiteral *GetHTTPRequestStateValues() {
+	static constexpr StringUtil::EnumStringLiteral values[] {
+		{ static_cast<uint32_t>(HTTPRequestState::COMPLETED), "COMPLETED" },
+		{ static_cast<uint32_t>(HTTPRequestState::PENDING), "PENDING" }
+	};
+	return values;
+}
+
+template<>
+const char* EnumUtil::ToChars<HTTPRequestState>(HTTPRequestState value) {
+	return StringUtil::EnumToString(GetHTTPRequestStateValues(), 2, "HTTPRequestState", static_cast<uint32_t>(value));
+}
+
+template<>
+HTTPRequestState EnumUtil::FromString<HTTPRequestState>(const char *value) {
+	return static_cast<HTTPRequestState>(StringUtil::StringToEnum(GetHTTPRequestStateValues(), 2, "HTTPRequestState", value));
+}
+
+const StringUtil::EnumStringLiteral *GetHTTPRetryDecisionValues() {
+	static constexpr StringUtil::EnumStringLiteral values[] {
+		{ static_cast<uint32_t>(HTTPRetryDecision::FINISHED), "FINISHED" },
+		{ static_cast<uint32_t>(HTTPRetryDecision::RETRY), "RETRY" },
+		{ static_cast<uint32_t>(HTTPRetryDecision::FAILED), "FAILED" }
+	};
+	return values;
+}
+
+template<>
+const char* EnumUtil::ToChars<HTTPRetryDecision>(HTTPRetryDecision value) {
+	return StringUtil::EnumToString(GetHTTPRetryDecisionValues(), 3, "HTTPRetryDecision", static_cast<uint32_t>(value));
+}
+
+template<>
+HTTPRetryDecision EnumUtil::FromString<HTTPRetryDecision>(const char *value) {
+	return static_cast<HTTPRetryDecision>(StringUtil::StringToEnum(GetHTTPRetryDecisionValues(), 3, "HTTPRetryDecision", value));
+}
+
 const StringUtil::EnumStringLiteral *GetHTTPStatusCodeValues() {
 	static constexpr StringUtil::EnumStringLiteral values[] {
 		{ static_cast<uint32_t>(HTTPStatusCode::INVALID), "INVALID" },

--- a/src/include/duckdb/common/enum_util.hpp
+++ b/src/include/duckdb/common/enum_util.hpp
@@ -276,6 +276,12 @@ enum class HLLStorageType : uint8_t;
 
 enum class HTTPClientCachePolicy : uint8_t;
 
+enum class HTTPExecutionMode : uint8_t;
+
+enum class HTTPRequestState : uint8_t;
+
+enum class HTTPRetryDecision : uint8_t;
+
 enum class HTTPStatusCode : uint16_t;
 
 enum class HTTPTransportReusePolicy : uint8_t;
@@ -1010,6 +1016,15 @@ const char* EnumUtil::ToChars<HLLStorageType>(HLLStorageType value);
 
 template<>
 const char* EnumUtil::ToChars<HTTPClientCachePolicy>(HTTPClientCachePolicy value);
+
+template<>
+const char* EnumUtil::ToChars<HTTPExecutionMode>(HTTPExecutionMode value);
+
+template<>
+const char* EnumUtil::ToChars<HTTPRequestState>(HTTPRequestState value);
+
+template<>
+const char* EnumUtil::ToChars<HTTPRetryDecision>(HTTPRetryDecision value);
 
 template<>
 const char* EnumUtil::ToChars<HTTPStatusCode>(HTTPStatusCode value);
@@ -1929,6 +1944,15 @@ HLLStorageType EnumUtil::FromString<HLLStorageType>(const char *value);
 
 template<>
 HTTPClientCachePolicy EnumUtil::FromString<HTTPClientCachePolicy>(const char *value);
+
+template<>
+HTTPExecutionMode EnumUtil::FromString<HTTPExecutionMode>(const char *value);
+
+template<>
+HTTPRequestState EnumUtil::FromString<HTTPRequestState>(const char *value);
+
+template<>
+HTTPRetryDecision EnumUtil::FromString<HTTPRetryDecision>(const char *value);
 
 template<>
 HTTPStatusCode EnumUtil::FromString<HTTPStatusCode>(const char *value);

--- a/src/include/duckdb/common/http_util.hpp
+++ b/src/include/duckdb/common/http_util.hpp
@@ -316,7 +316,7 @@ enum class HTTPRequestState : uint8_t {
 
 //! Invoked exactly once when a request completes, unless the call that started it threw.
 //! For a GET with a content_handler the body has already been streamed, so [response] carries status and headers.
-using HTTPResponseCallback = std::function<void(unique_ptr<HTTPResponse> response, optional_ptr<ErrorData> error)>;
+using HTTPResponseCallback = std::function<void(unique_ptr<HTTPResponse> response, ErrorData error)>;
 
 class HTTPClient {
 public:

--- a/src/include/duckdb/common/http_util.hpp
+++ b/src/include/duckdb/common/http_util.hpp
@@ -383,12 +383,17 @@ enum class HTTPRetryDecision : uint8_t {
 struct HTTPAttempt {
 	//! The response, null when the attempt threw
 	unique_ptr<HTTPResponse> response;
-	//! The exception the attempt threw, if any
+	//! The exception the attempt threw, if any. Only set when the attempt threw on this thread.
 	std::exception_ptr caught_e = nullptr;
+	//! The error the attempt reported, kept whole so a failure keeps its type when it is rethrown
+	ErrorData error;
 	string exception_error;
 	//! Status and Retry-After recovered from an HTTPException, used for throttle detection
 	string caught_status;
 	string caught_retry_after;
+
+	//! Record [error_p] as this attempt's failure, recovering the status and Retry-After it carries
+	DUCKDB_API void SetError(ErrorData error_p);
 };
 
 //! The retry policy of one HTTP request, carried across its attempts. It does no waiting of its own:
@@ -457,6 +462,7 @@ public:
 	//! the completion fires.
 	//! The completion may fire on another thread, so a caller that suspends on PENDING must arbitrate
 	//! between suspending and being resumed itself - see AsyncExecutionTask for the pattern.
+	//! COMPLETED is reported only once the completion has returned, so the result it wrote is readable.
 	DUCKDB_API virtual HTTPRequestState Send(BaseRequest &request, unique_ptr<HTTPClient> &client,
 	                                         HTTPExecutionMode mode, HTTPResponseCallback on_complete);
 
@@ -466,8 +472,8 @@ public:
 
 	//! Wait [delay_ms] before the next attempt of a request, then run [resume].
 	//! The default sleeps the calling thread, which is what the retry backoff has always done.
-	//! A platform that must not block overrides this to schedule [resume] and return PENDING.
-	DUCKDB_API virtual HTTPRequestState Wait(uint64_t delay_ms, std::function<void()> resume);
+	//! A platform that must not block overrides this to schedule [resume] and return immediately.
+	DUCKDB_API virtual void Wait(uint64_t delay_ms, std::function<void()> resume);
 	virtual void LogRequest(BaseRequest &request, optional_ptr<HTTPResponse> response);
 
 	//! Whether a failed request should be retried, possibly using HTTPResponse information, and allowing overrides

--- a/src/include/duckdb/common/http_util.hpp
+++ b/src/include/duckdb/common/http_util.hpp
@@ -452,6 +452,10 @@ public:
 	DUCKDB_API virtual HTTPRequestState Send(BaseRequest &request, unique_ptr<HTTPClient> &client,
 	                                         HTTPExecutionMode mode, HTTPResponseCallback on_complete);
 
+	//! Whether this platform can delay between attempts, which is what makes a backoff worth granting.
+	//! A platform that overrides Wait to schedule overrides this too, to say the schedule is real.
+	DUCKDB_API virtual bool CanWait() const;
+
 	//! Wait [delay_ms] before the next attempt of a request, then run [resume].
 	//! The default sleeps the calling thread, which is what the retry backoff has always done.
 	//! A platform that must not block overrides this to schedule [resume] and return PENDING.

--- a/src/include/duckdb/common/http_util.hpp
+++ b/src/include/duckdb/common/http_util.hpp
@@ -13,6 +13,7 @@
 #include "duckdb/common/encryption_state.hpp"
 #include "duckdb/common/enums/http_status_code.hpp"
 #include "duckdb/common/error_data.hpp"
+#include "duckdb/common/shared_ptr.hpp"
 #include "duckdb/common/types/timestamp.hpp"
 #include "duckdb/common/time_point.hpp"
 #include <exception>
@@ -318,7 +319,10 @@ enum class HTTPRequestState : uint8_t {
 //! For a GET with a content_handler the body has already been streamed, so [response] carries status and headers.
 using HTTPResponseCallback = std::function<void(unique_ptr<HTTPResponse> response, ErrorData error)>;
 
-class HTTPClient {
+//! Shared rather than unique because a deferred request outlives the call that made it: the transport
+//! keeps its own reference across the completion, so releasing the request's does not destroy the
+//! client while its own callback is still running.
+class HTTPClient : public enable_shared_from_this<HTTPClient> {
 public:
 	HTTPClient() = default;
 	explicit HTTPClient(const string &proto_host_port) : base_url(proto_host_port) {
@@ -340,6 +344,8 @@ public:
 	//! Perform [request], delivering the result through [on_complete] rather than returning it.
 	//! Returns PENDING only when [mode] is DEFERRABLE and the request was handed off.
 	//! The default performs the synchronous request, so a backend without an async transport needs no change.
+	//! A backend that does defer must keep itself alive across the completion - capture shared_from_this()
+	//! in whatever it schedules - because the request releases its own reference from inside that callback.
 	DUCKDB_API virtual HTTPRequestState Send(BaseRequest &request, HTTPExecutionMode mode,
 	                                         HTTPResponseCallback on_complete);
 
@@ -446,7 +452,9 @@ public:
 	//! SendRequest, delivering the result through [on_complete] instead of returning it.
 	//! BLOCKING goes through SendRequest, so an implementation overriding that one keeps its behaviour.
 	//! DEFERRABLE retries here, driving HTTPClient::Send one attempt at a time, so a client that defers
-	//! keeps the retry policy. [request] and [client] must stay alive until the completion fires.
+	//! keeps the retry policy. It takes [client] over and leaves the caller's pointer empty, so no
+	//! completion writes back into it when a retry replaces the client. [request] must stay alive until
+	//! the completion fires.
 	//! The completion may fire on another thread, so a caller that suspends on PENDING must arbitrate
 	//! between suspending and being resumed itself - see AsyncExecutionTask for the pattern.
 	DUCKDB_API virtual HTTPRequestState Send(BaseRequest &request, unique_ptr<HTTPClient> &client,

--- a/src/include/duckdb/common/http_util.hpp
+++ b/src/include/duckdb/common/http_util.hpp
@@ -12,6 +12,7 @@
 #include "duckdb/common/case_insensitive_map.hpp"
 #include "duckdb/common/encryption_state.hpp"
 #include "duckdb/common/enums/http_status_code.hpp"
+#include "duckdb/common/error_data.hpp"
 #include "duckdb/common/types/timestamp.hpp"
 #include "duckdb/common/time_point.hpp"
 #include <exception>
@@ -298,6 +299,28 @@ struct PostRequestInfo : public BaseRequest {
 	bool send_post_as_get_request = false;
 };
 
+//! Whether the caller of a request can be handed a result that is not ready yet
+enum class HTTPExecutionMode : uint8_t {
+	//! The caller needs the response before the call returns
+	BLOCKING,
+	//! The caller can take PENDING and be resumed once the completion fires
+	DEFERRABLE
+};
+
+//! Whether a request completed before returning, or will complete later
+enum class HTTPRequestState : uint8_t {
+	//! The completion has already been invoked
+	COMPLETED,
+	//! The completion will be invoked later, only ever returned for DEFERRABLE
+	PENDING
+};
+
+//! Invoked exactly once when a request completes, unless the call that started it threw.
+//! [error] is set when the request failed after it was handed off. Note that for a GET carrying a
+//! content_handler the body has already been streamed through it, so [response] carries the status
+//! and headers rather than the payload.
+using HTTPResponseCallback = std::function<void(unique_ptr<HTTPResponse> response, optional_ptr<ErrorData> error)>;
+
 class HTTPClient {
 public:
 	HTTPClient() = default;
@@ -316,6 +339,15 @@ public:
 	virtual void Cleanup() {};
 
 	unique_ptr<HTTPResponse> Request(BaseRequest &request);
+
+	//! Perform [request], delivering the result through [on_complete] rather than returning it.
+	//! Returns PENDING only when [mode] is DEFERRABLE and the request was handed off; BLOCKING always
+	//! returns COMPLETED. One entry point covers every verb because Request already dispatches on the
+	//! request type, so a backend that is only asynchronous for some verbs can defer the rest here.
+	//! The default performs the existing synchronous request, so a backend without an asynchronous
+	//! transport needs no change.
+	DUCKDB_API virtual HTTPRequestState Send(BaseRequest &request, HTTPExecutionMode mode,
+	                                         HTTPResponseCallback on_complete);
 
 	const string &GetBaseUrl() const {
 		return base_url;
@@ -418,6 +450,11 @@ public:
 
 	//! Advanced provider hook used by the checked Request wrappers.
 	virtual unique_ptr<HTTPResponse> SendRequest(BaseRequest &request, unique_ptr<HTTPClient> &client);
+	//! SendRequest, delivering the result through [on_complete] instead of returning it.
+	//! The default delegates to SendRequest above, so an implementation that only overrides that one
+	//! keeps working unchanged and stays in charge of its own retry and logging.
+	DUCKDB_API virtual HTTPRequestState Send(BaseRequest &request, unique_ptr<HTTPClient> &client,
+	                                         HTTPExecutionMode mode, HTTPResponseCallback on_complete);
 	virtual void LogRequest(BaseRequest &request, optional_ptr<HTTPResponse> response);
 
 	//! Whether a failed request should be retried, possibly using HTTPResponse information, and allowing overrides

--- a/src/include/duckdb/common/http_util.hpp
+++ b/src/include/duckdb/common/http_util.hpp
@@ -451,10 +451,20 @@ public:
 	//! Advanced provider hook used by the checked Request wrappers.
 	virtual unique_ptr<HTTPResponse> SendRequest(BaseRequest &request, unique_ptr<HTTPClient> &client);
 	//! SendRequest, delivering the result through [on_complete] instead of returning it.
-	//! The default delegates to SendRequest above, so an implementation that only overrides that one
-	//! keeps working unchanged and stays in charge of its own retry and logging.
+	//! BLOCKING goes through SendRequest above, so an implementation that overrides that one keeps
+	//! its behaviour exactly. DEFERRABLE retries here instead, driving HTTPClient::Send one attempt
+	//! at a time, so a client that defers a request still gets the retry policy rather than losing
+	//! it - a backend implements HTTPClient::Send, and does not need to override this at all.
+	//! [request] and [client] must stay alive until the completion fires.
 	DUCKDB_API virtual HTTPRequestState Send(BaseRequest &request, unique_ptr<HTTPClient> &client,
 	                                         HTTPExecutionMode mode, HTTPResponseCallback on_complete);
+
+	//! Wait [delay_ms] before the next attempt of a request, then run [resume].
+	//! The default sleeps the calling thread and returns COMPLETED, which is what the retry backoff
+	//! has always done. An implementation that must not block - a browser, an event loop - overrides
+	//! this to schedule [resume] and return PENDING, which is the only platform-specific piece of
+	//! retrying without a thread to wait on.
+	DUCKDB_API virtual HTTPRequestState Wait(uint64_t delay_ms, std::function<void()> resume);
 	virtual void LogRequest(BaseRequest &request, optional_ptr<HTTPResponse> response);
 
 	//! Whether a failed request should be retried, possibly using HTTPResponse information, and allowing overrides

--- a/src/include/duckdb/common/http_util.hpp
+++ b/src/include/duckdb/common/http_util.hpp
@@ -447,6 +447,8 @@ public:
 	//! BLOCKING goes through SendRequest, so an implementation overriding that one keeps its behaviour.
 	//! DEFERRABLE retries here, driving HTTPClient::Send one attempt at a time, so a client that defers
 	//! keeps the retry policy. [request] and [client] must stay alive until the completion fires.
+	//! The completion may fire on another thread, so a caller that suspends on PENDING must arbitrate
+	//! between suspending and being resumed itself - see AsyncExecutionTask for the pattern.
 	DUCKDB_API virtual HTTPRequestState Send(BaseRequest &request, unique_ptr<HTTPClient> &client,
 	                                         HTTPExecutionMode mode, HTTPResponseCallback on_complete);
 

--- a/src/include/duckdb/common/http_util.hpp
+++ b/src/include/duckdb/common/http_util.hpp
@@ -299,26 +299,23 @@ struct PostRequestInfo : public BaseRequest {
 	bool send_post_as_get_request = false;
 };
 
-//! Whether the caller of a request can be handed a result that is not ready yet
+//! Whether the caller can be handed a result that is not ready yet
 enum class HTTPExecutionMode : uint8_t {
 	//! The caller needs the response before the call returns
 	BLOCKING,
-	//! The caller can take PENDING and be resumed once the completion fires
+	//! The caller can take PENDING and be resumed when the completion fires
 	DEFERRABLE
 };
 
 //! Whether a request completed before returning, or will complete later
 enum class HTTPRequestState : uint8_t {
-	//! The completion has already been invoked
 	COMPLETED,
-	//! The completion will be invoked later, only ever returned for DEFERRABLE
+	//! Only ever returned for DEFERRABLE
 	PENDING
 };
 
 //! Invoked exactly once when a request completes, unless the call that started it threw.
-//! [error] is set when the request failed after it was handed off. Note that for a GET carrying a
-//! content_handler the body has already been streamed through it, so [response] carries the status
-//! and headers rather than the payload.
+//! For a GET with a content_handler the body has already been streamed, so [response] carries status and headers.
 using HTTPResponseCallback = std::function<void(unique_ptr<HTTPResponse> response, optional_ptr<ErrorData> error)>;
 
 class HTTPClient {
@@ -341,11 +338,8 @@ public:
 	unique_ptr<HTTPResponse> Request(BaseRequest &request);
 
 	//! Perform [request], delivering the result through [on_complete] rather than returning it.
-	//! Returns PENDING only when [mode] is DEFERRABLE and the request was handed off; BLOCKING always
-	//! returns COMPLETED. One entry point covers every verb because Request already dispatches on the
-	//! request type, so a backend that is only asynchronous for some verbs can defer the rest here.
-	//! The default performs the existing synchronous request, so a backend without an asynchronous
-	//! transport needs no change.
+	//! Returns PENDING only when [mode] is DEFERRABLE and the request was handed off.
+	//! The default performs the synchronous request, so a backend without an async transport needs no change.
 	DUCKDB_API virtual HTTPRequestState Send(BaseRequest &request, HTTPExecutionMode mode,
 	                                         HTTPResponseCallback on_complete);
 
@@ -371,11 +365,11 @@ enum class HTTPTransportReusePolicy : uint8_t {
 
 //! What should happen after one attempt of an HTTP request
 enum class HTTPRetryDecision : uint8_t {
-	//! The response is final and should be returned to the caller
+	//! The response is final
 	FINISHED,
-	//! The request should be attempted again, after the delay the policy reported
+	//! Attempt again, after the delay the policy reported
 	RETRY,
-	//! The retries are exhausted, the caller must produce the failure
+	//! Retries are exhausted, the caller must produce the failure
 	FAILED
 };
 
@@ -391,14 +385,13 @@ struct HTTPAttempt {
 	string caught_retry_after;
 };
 
-//! The retry policy of one HTTP request, carried across its attempts.
-//! It does no waiting of its own: a synchronous caller sleeps for the delay it reports, an
-//! asynchronous one schedules the next attempt after it, so both share this one policy.
+//! The retry policy of one HTTP request, carried across its attempts. It does no waiting of its own:
+//! the caller either sleeps for the delay it reports or schedules the next attempt after it.
 class HTTPRetryState {
 public:
 	//! Record one attempt and decide what happens next. [delay_ms] is only set for RETRY.
 	DUCKDB_API HTTPRetryDecision OnAttempt(const BaseRequest &request, HTTPAttempt &attempt, uint64_t &delay_ms);
-	//! Produce the outcome of a FAILED decision: a failed response when the request asked for one, else it throws
+	//! Outcome of a FAILED decision: a failed response when the request asked for one, else it throws
 	DUCKDB_API unique_ptr<HTTPResponse> Finalize(const BaseRequest &request, HTTPAttempt &attempt);
 
 private:
@@ -451,19 +444,15 @@ public:
 	//! Advanced provider hook used by the checked Request wrappers.
 	virtual unique_ptr<HTTPResponse> SendRequest(BaseRequest &request, unique_ptr<HTTPClient> &client);
 	//! SendRequest, delivering the result through [on_complete] instead of returning it.
-	//! BLOCKING goes through SendRequest above, so an implementation that overrides that one keeps
-	//! its behaviour exactly. DEFERRABLE retries here instead, driving HTTPClient::Send one attempt
-	//! at a time, so a client that defers a request still gets the retry policy rather than losing
-	//! it - a backend implements HTTPClient::Send, and does not need to override this at all.
-	//! [request] and [client] must stay alive until the completion fires.
+	//! BLOCKING goes through SendRequest, so an implementation overriding that one keeps its behaviour.
+	//! DEFERRABLE retries here, driving HTTPClient::Send one attempt at a time, so a client that defers
+	//! keeps the retry policy. [request] and [client] must stay alive until the completion fires.
 	DUCKDB_API virtual HTTPRequestState Send(BaseRequest &request, unique_ptr<HTTPClient> &client,
 	                                         HTTPExecutionMode mode, HTTPResponseCallback on_complete);
 
 	//! Wait [delay_ms] before the next attempt of a request, then run [resume].
-	//! The default sleeps the calling thread and returns COMPLETED, which is what the retry backoff
-	//! has always done. An implementation that must not block - a browser, an event loop - overrides
-	//! this to schedule [resume] and return PENDING, which is the only platform-specific piece of
-	//! retrying without a thread to wait on.
+	//! The default sleeps the calling thread, which is what the retry backoff has always done.
+	//! A platform that must not block overrides this to schedule [resume] and return PENDING.
 	DUCKDB_API virtual HTTPRequestState Wait(uint64_t delay_ms, std::function<void()> resume);
 	virtual void LogRequest(BaseRequest &request, optional_ptr<HTTPResponse> response);
 

--- a/src/include/duckdb/common/http_util.hpp
+++ b/src/include/duckdb/common/http_util.hpp
@@ -14,6 +14,7 @@
 #include "duckdb/common/enums/http_status_code.hpp"
 #include "duckdb/common/types/timestamp.hpp"
 #include "duckdb/common/time_point.hpp"
+#include <exception>
 #include <functional>
 
 namespace duckdb {
@@ -334,6 +335,43 @@ enum class HTTPTransportReusePolicy : uint8_t {
 	SESSION_LOCAL,
 	//! Compatible clients may be reused across sessions in one DatabaseInstance.
 	SHARED
+};
+
+//! What should happen after one attempt of an HTTP request
+enum class HTTPRetryDecision : uint8_t {
+	//! The response is final and should be returned to the caller
+	FINISHED,
+	//! The request should be attempted again, after the delay the policy reported
+	RETRY,
+	//! The retries are exhausted, the caller must produce the failure
+	FAILED
+};
+
+//! The outcome of one attempt of an HTTP request, whether it produced a response or threw
+struct HTTPAttempt {
+	//! The response, null when the attempt threw
+	unique_ptr<HTTPResponse> response;
+	//! The exception the attempt threw, if any
+	std::exception_ptr caught_e = nullptr;
+	string exception_error;
+	//! Status and Retry-After recovered from an HTTPException, used for throttle detection
+	string caught_status;
+	string caught_retry_after;
+};
+
+//! The retry policy of one HTTP request, carried across its attempts.
+//! It does no waiting of its own: a synchronous caller sleeps for the delay it reports, an
+//! asynchronous one schedules the next attempt after it, so both share this one policy.
+class HTTPRetryState {
+public:
+	//! Record one attempt and decide what happens next. [delay_ms] is only set for RETRY.
+	DUCKDB_API HTTPRetryDecision OnAttempt(const BaseRequest &request, HTTPAttempt &attempt, uint64_t &delay_ms);
+	//! Produce the outcome of a FAILED decision: a failed response when the request asked for one, else it throws
+	DUCKDB_API unique_ptr<HTTPResponse> Finalize(const BaseRequest &request, HTTPAttempt &attempt);
+
+private:
+	//! Attempts made so far
+	idx_t tries = 0;
 };
 
 class HTTPUtil {

--- a/src/main/http/http_util.cpp
+++ b/src/main/http/http_util.cpp
@@ -283,6 +283,14 @@ HTTPRequestState HTTPUtil::Send(BaseRequest &request, unique_ptr<HTTPClient> &cl
 	return driver->Start();
 }
 
+bool HTTPUtil::CanWait() const {
+#ifdef DUCKDB_NO_THREADS
+	return false;
+#else
+	return true;
+#endif
+}
+
 // NOLINTNEXTLINE: taken by value so an asynchronous override can move it into its scheduler
 HTTPRequestState HTTPUtil::Wait(uint64_t delay_ms, std::function<void()> resume) {
 	// this platform has a thread to wait on
@@ -669,15 +677,11 @@ HTTPRetryDecision HTTPRetryState::OnAttempt(const BaseRequest &request, HTTPAtte
 	const bool throttled = (response && (response->status == HTTPStatusCode::TooManyRequests_429 ||
 	                                     response->status == HTTPStatusCode::ServiceUnavailable_503)) ||
 	                       attempt.caught_status == "429" || attempt.caught_status == "503";
-#ifndef DUCKDB_NO_THREADS
-	static constexpr idx_t THROTTLE_EXTRA_RETRIES = 5;
-#else
-	// without threads we cannot sleep between retries, so do not add zero-delay retries
-	static constexpr idx_t THROTTLE_EXTRA_RETRIES = 0;
-#endif
+	// zero-delay retries only add load, so the extra ones need a platform that can actually back off
+	const idx_t throttle_extra_retries = params.http_util.CanWait() ? 5 : 0;
 	static constexpr uint64_t THROTTLE_MAX_BACKOFF_MS = 10000;
 	const idx_t max_tries =
-	    !HTTPUtil::IsIdempotent(request.type) ? 0 : params.retries + (throttled ? THROTTLE_EXTRA_RETRIES : 0);
+	    !HTTPUtil::IsIdempotent(request.type) ? 0 : params.retries + (throttled ? throttle_extra_retries : 0);
 	if (tries > max_tries) {
 		return HTTPRetryDecision::FAILED;
 	}

--- a/src/main/http/http_util.cpp
+++ b/src/main/http/http_util.cpp
@@ -176,6 +176,20 @@ bool HTTPUtil::ShouldRetry(const BaseRequest &request, const HTTPResponse &respo
 	return response.ShouldRetry();
 }
 
+HTTPRequestState HTTPClient::Send(BaseRequest &request, HTTPExecutionMode mode, HTTPResponseCallback on_complete) {
+	// default: this client has no asynchronous transport, so the request is already done when it returns
+	on_complete(Request(request), nullptr);
+	return HTTPRequestState::COMPLETED;
+}
+
+HTTPRequestState HTTPUtil::Send(BaseRequest &request, unique_ptr<HTTPClient> &client, HTTPExecutionMode mode,
+                                HTTPResponseCallback on_complete) {
+	// default: go through SendRequest, so an implementation that overrides only that one keeps its
+	// retry, timing and logging behaviour
+	on_complete(SendRequest(request, client), nullptr);
+	return HTTPRequestState::COMPLETED;
+}
+
 unique_ptr<HTTPResponse> HTTPUtil::Request(BaseRequest &request) {
 	unique_ptr<HTTPClient> client;
 	return Request(request, client);

--- a/src/main/http/http_util.cpp
+++ b/src/main/http/http_util.cpp
@@ -176,6 +176,7 @@ bool HTTPUtil::ShouldRetry(const BaseRequest &request, const HTTPResponse &respo
 	return response.ShouldRetry();
 }
 
+// NOLINTNEXTLINE: taken by value so an asynchronous override can move it into its scheduler
 HTTPRequestState HTTPClient::Send(BaseRequest &request, HTTPExecutionMode mode, HTTPResponseCallback on_complete) {
 	// default: this client has no asynchronous transport, so the request is already done when it returns
 	on_complete(Request(request), nullptr);
@@ -284,6 +285,7 @@ HTTPRequestState HTTPUtil::Send(BaseRequest &request, unique_ptr<HTTPClient> &cl
 	return driver->Start();
 }
 
+// NOLINTNEXTLINE: taken by value so an asynchronous override can move it into its scheduler
 HTTPRequestState HTTPUtil::Wait(uint64_t delay_ms, std::function<void()> resume) {
 	// default: this platform has a thread to wait on, which is what the retry backoff has always done
 #ifndef DUCKDB_NO_THREADS

--- a/src/main/http/http_util.cpp
+++ b/src/main/http/http_util.cpp
@@ -179,7 +179,7 @@ bool HTTPUtil::ShouldRetry(const BaseRequest &request, const HTTPResponse &respo
 // NOLINTNEXTLINE: taken by value so an asynchronous override can move it into its scheduler
 HTTPRequestState HTTPClient::Send(BaseRequest &request, HTTPExecutionMode mode, HTTPResponseCallback on_complete) {
 	// no asynchronous transport, so the request is already done when it returns
-	on_complete(Request(request), nullptr);
+	on_complete(Request(request), ErrorData());
 	return HTTPRequestState::COMPLETED;
 }
 
@@ -206,23 +206,23 @@ private:
 		auto self = shared_from_this();
 		// the returned state is not needed: an attempt that finished inline has already called back
 		client->Send(request, HTTPExecutionMode::DEFERRABLE,
-		             [self](unique_ptr<HTTPResponse> response, optional_ptr<ErrorData> error) {
-			             self->OnAttemptDone(std::move(response), error);
+		             [self](unique_ptr<HTTPResponse> response, ErrorData error) {
+			             self->OnAttemptDone(std::move(response), std::move(error));
 		             });
 	}
 
-	void OnAttemptDone(unique_ptr<HTTPResponse> response, optional_ptr<ErrorData> error) {
+	void OnAttemptDone(unique_ptr<HTTPResponse> response, ErrorData error) {
 		HTTPAttempt attempt;
 		attempt.response = std::move(response);
-		if (error) {
-			attempt.exception_error = error->RawMessage();
+		if (error.HasError()) {
+			attempt.exception_error = error.RawMessage();
 		}
 		http_util.LogRequest(request, attempt.response.get());
 
 		uint64_t delay_ms = 0;
 		switch (retry_state.OnAttempt(request, attempt, delay_ms)) {
 		case HTTPRetryDecision::FINISHED:
-			Deliver(std::move(attempt.response), nullptr);
+			Deliver(std::move(attempt.response), ErrorData());
 			return;
 		case HTTPRetryDecision::FAILED:
 			DeliverFailure(attempt);
@@ -240,16 +240,15 @@ private:
 	//! A throw has nowhere to go from a completion, so Finalize's exception is delivered as an error
 	void DeliverFailure(HTTPAttempt &attempt) {
 		try {
-			Deliver(retry_state.Finalize(request, attempt), nullptr);
+			Deliver(retry_state.Finalize(request, attempt), ErrorData());
 		} catch (std::exception &ex) {
-			ErrorData error(ex);
-			Deliver(nullptr, &error);
+			Deliver(nullptr, ErrorData(ex));
 		}
 	}
 
-	void Deliver(unique_ptr<HTTPResponse> response, optional_ptr<ErrorData> error) {
+	void Deliver(unique_ptr<HTTPResponse> response, ErrorData error) {
 		delivered = true;
-		on_complete(std::move(response), error);
+		on_complete(std::move(response), std::move(error));
 	}
 
 private:
@@ -268,7 +267,7 @@ HTTPRequestState HTTPUtil::Send(BaseRequest &request, unique_ptr<HTTPClient> &cl
                                 HTTPResponseCallback on_complete) {
 	if (mode == HTTPExecutionMode::BLOCKING) {
 		// the caller needs an answer now, so take the synchronous path an implementation may override
-		on_complete(SendRequest(request, client), nullptr);
+		on_complete(SendRequest(request, client), ErrorData());
 		return HTTPRequestState::COMPLETED;
 	}
 	if (!client) {

--- a/src/main/http/http_util.cpp
+++ b/src/main/http/http_util.cpp
@@ -488,133 +488,160 @@ void HTTPUtil::DecomposeURL(const string &input, string &path_out, string &proto
 	}
 }
 
+namespace {
+
+//! Perform one attempt, capturing whatever it produced - a response, or an exception plus the status
+//! and Retry-After that the handlers folded into it
+HTTPAttempt RunOneAttempt(const std::function<unique_ptr<HTTPResponse>(void)> &on_request, const BaseRequest &request) {
+	HTTPAttempt attempt;
+	try {
+		attempt.response = on_request();
+		if (attempt.response) {
+			attempt.response->url = request.url;
+		}
+	} catch (IOException &e) {
+		attempt.exception_error = e.what();
+		attempt.caught_e = std::current_exception();
+	} catch (HTTPException &e) {
+		attempt.exception_error = e.what();
+		attempt.caught_e = std::current_exception();
+		// handlers turn error statuses into exceptions; recover the status for throttle detection
+		ErrorData error_data(e);
+		auto entry = error_data.ExtraInfo().find("status_code");
+		if (entry != error_data.ExtraInfo().end()) {
+			attempt.caught_status = entry->second;
+		}
+		auto retry_entry = error_data.ExtraInfo().find("header_Retry-After");
+		if (retry_entry != error_data.ExtraInfo().end()) {
+			attempt.caught_retry_after = retry_entry->second;
+		}
+	}
+	return attempt;
+}
+
+} // namespace
+
+HTTPRetryDecision HTTPRetryState::OnAttempt(const BaseRequest &request, HTTPAttempt &attempt, uint64_t &delay_ms) {
+	auto &params = request.params;
+	auto &response = attempt.response;
+	delay_ms = 0;
+
+	// Request errors and caught exceptions are eligible for retry without a response status
+	bool should_retry = !response || params.http_util.ShouldRetry(request, *response);
+	if (!should_retry) {
+		auto response_code = static_cast<uint16_t>(response->status);
+		if (response_code >= 200 && response_code < 300) {
+			response->success = true;
+			return HTTPRetryDecision::FINISHED;
+		}
+		switch (response->status) {
+		case HTTPStatusCode::NotModified_304:
+			response->success = true;
+			break;
+		default:
+			response->success = false;
+			break;
+		}
+		return HTTPRetryDecision::FINISHED;
+	}
+
+	tries += 1;
+	// throttle responses get extra, capped, jittered backoff so bursts degrade instead of failing queries
+	const bool throttled = (response && (response->status == HTTPStatusCode::TooManyRequests_429 ||
+	                                     response->status == HTTPStatusCode::ServiceUnavailable_503)) ||
+	                       attempt.caught_status == "429" || attempt.caught_status == "503";
+#ifndef DUCKDB_NO_THREADS
+	static constexpr idx_t THROTTLE_EXTRA_RETRIES = 5;
+#else
+	// without threads we cannot sleep between retries, so do not add zero-delay retries
+	static constexpr idx_t THROTTLE_EXTRA_RETRIES = 0;
+#endif
+	static constexpr uint64_t THROTTLE_MAX_BACKOFF_MS = 10000;
+	const idx_t max_tries =
+	    !HTTPUtil::IsIdempotent(request.type) ? 0 : params.retries + (throttled ? THROTTLE_EXTRA_RETRIES : 0);
+	if (tries > max_tries) {
+		return HTTPRetryDecision::FAILED;
+	}
+	if (tries > 1 || throttled) {
+		const auto backoff_exp = static_cast<double>(throttled ? tries - 1 : tries - 2);
+		const auto backoff_ms = (double)params.retry_wait_ms * pow(params.retry_backoff, backoff_exp);
+		// cap in the double domain to avoid overflow in the cast
+		uint64_t sleep_amount = (uint64_t)MinValue<double>(backoff_ms, (double)NumericLimits<int64_t>::Maximum());
+		if (throttled) {
+			sleep_amount = MinValue<uint64_t>(sleep_amount, THROTTLE_MAX_BACKOFF_MS);
+			string retry_after = attempt.caught_retry_after;
+			if (response && response->headers.HasHeader("Retry-After")) {
+				retry_after = response->headers.GetHeaderValue("Retry-After");
+			}
+			if (!retry_after.empty()) {
+				// honor a numeric Retry-After (seconds), capped like the backoff
+				uint64_t retry_after_s = 0;
+				if (TryCast::Operation<string_t, uint64_t>(string_t(retry_after), retry_after_s)) {
+					retry_after_s = MinValue<uint64_t>(retry_after_s, THROTTLE_MAX_BACKOFF_MS / 1000);
+					sleep_amount = MaxValue<uint64_t>(sleep_amount, retry_after_s * 1000);
+				}
+			}
+			// subtractive jitter ([base/2, base]) de-synchronizes retry bursts while honoring the cap
+			RandomEngine random;
+			sleep_amount -= random.NextRandomInteger64() % (sleep_amount / 2 + 1);
+		}
+		delay_ms = sleep_amount;
+	}
+	return HTTPRetryDecision::RETRY;
+}
+
+unique_ptr<HTTPResponse> HTTPRetryState::Finalize(const BaseRequest &request, HTTPAttempt &attempt) {
+	auto &response = attempt.response;
+	if (request.try_request) {
+		// try request - return the failure
+		if (!response) {
+			response = make_uniq<HTTPResponse>(HTTPStatusCode::INVALID);
+			string error = "Unknown error";
+			if (!attempt.exception_error.empty()) {
+				error = std::move(attempt.exception_error);
+			}
+			response->request_error = std::move(error);
+		}
+		response->success = false;
+		return std::move(response);
+	}
+	auto method = EnumUtil::ToString(request.type);
+	if (attempt.caught_e) {
+		std::rethrow_exception(attempt.caught_e);
+	} else if (response && !response->HasRequestError()) {
+		throw HTTPException(*response, "Request returned HTTP %d for HTTP %s to '%s'",
+		                    static_cast<int>(response->status), method, request.url);
+	} else {
+		string error = response ? response->GetError() : "Unknown error";
+		throw IOException("%s error for HTTP %s to '%s'", error, method, request.url);
+	}
+}
+
 // Retry the request performed by fun using the exponential backoff strategy defined in params. Before retry, the
 // retry callback is called
 duckdb::unique_ptr<HTTPResponse>
 HTTPUtil::RunRequestWithRetry(const std::function<unique_ptr<HTTPResponse>(void)> &on_request,
                               const BaseRequest &request, const std::function<void(void)> &retry_cb) {
-	auto &params = request.params;
-	idx_t tries = 0;
+	HTTPRetryState retry_state;
 	while (true) {
-		std::exception_ptr caught_e = nullptr;
-		unique_ptr<HTTPResponse> response;
-		string exception_error;
-		string caught_status;
-		string caught_retry_after;
-
-		try {
-			response = on_request();
-			if (response) {
-				response->url = request.url;
-			}
-		} catch (IOException &e) {
-			exception_error = e.what();
-			caught_e = std::current_exception();
-		} catch (HTTPException &e) {
-			exception_error = e.what();
-			caught_e = std::current_exception();
-			// handlers turn error statuses into exceptions; recover the status for throttle detection
-			ErrorData error_data(e);
-			auto entry = error_data.ExtraInfo().find("status_code");
-			if (entry != error_data.ExtraInfo().end()) {
-				caught_status = entry->second;
-			}
-			auto retry_entry = error_data.ExtraInfo().find("header_Retry-After");
-			if (retry_entry != error_data.ExtraInfo().end()) {
-				caught_retry_after = retry_entry->second;
-			}
-		}
-
-		// Request errors and caught exceptions are eligible for retry without a response status
-		bool should_retry = !response || params.http_util.ShouldRetry(request, *response);
-		if (!should_retry) {
-			auto response_code = static_cast<uint16_t>(response->status);
-			if (response_code >= 200 && response_code < 300) {
-				response->success = true;
-				return response;
-			}
-			switch (response->status) {
-			case HTTPStatusCode::NotModified_304:
-				response->success = true;
-				break;
-			default:
-				response->success = false;
-				break;
-			}
-			return response;
-		}
-
-		tries += 1;
-		// throttle responses get extra, capped, jittered backoff so bursts degrade instead of failing queries
-		const bool throttled = (response && (response->status == HTTPStatusCode::TooManyRequests_429 ||
-		                                     response->status == HTTPStatusCode::ServiceUnavailable_503)) ||
-		                       caught_status == "429" || caught_status == "503";
+		auto attempt = RunOneAttempt(on_request, request);
+		uint64_t delay_ms = 0;
+		switch (retry_state.OnAttempt(request, attempt, delay_ms)) {
+		case HTTPRetryDecision::FINISHED:
+			return std::move(attempt.response);
+		case HTTPRetryDecision::FAILED:
+			return retry_state.Finalize(request, attempt);
+		case HTTPRetryDecision::RETRY:
+			// the only step an asynchronous driver replaces: it schedules the next attempt instead of waiting here
+			if (delay_ms > 0) {
 #ifndef DUCKDB_NO_THREADS
-		static constexpr idx_t THROTTLE_EXTRA_RETRIES = 5;
-#else
-		// without threads we cannot sleep between retries, so do not add zero-delay retries
-		static constexpr idx_t THROTTLE_EXTRA_RETRIES = 0;
-#endif
-		static constexpr uint64_t THROTTLE_MAX_BACKOFF_MS = 10000;
-		const idx_t max_tries =
-		    !HTTPUtil::IsIdempotent(request.type) ? 0 : params.retries + (throttled ? THROTTLE_EXTRA_RETRIES : 0);
-		if (tries <= max_tries) {
-			if (tries > 1 || throttled) {
-#ifndef DUCKDB_NO_THREADS
-				const auto backoff_exp = static_cast<double>(throttled ? tries - 1 : tries - 2);
-				const auto backoff_ms = (double)params.retry_wait_ms * pow(params.retry_backoff, backoff_exp);
-				// cap in the double domain to avoid overflow in the cast
-				uint64_t sleep_amount =
-				    (uint64_t)MinValue<double>(backoff_ms, (double)NumericLimits<int64_t>::Maximum());
-				if (throttled) {
-					sleep_amount = MinValue<uint64_t>(sleep_amount, THROTTLE_MAX_BACKOFF_MS);
-					string retry_after = caught_retry_after;
-					if (response && response->headers.HasHeader("Retry-After")) {
-						retry_after = response->headers.GetHeaderValue("Retry-After");
-					}
-					if (!retry_after.empty()) {
-						// honor a numeric Retry-After (seconds), capped like the backoff
-						uint64_t retry_after_s = 0;
-						if (TryCast::Operation<string_t, uint64_t>(string_t(retry_after), retry_after_s)) {
-							retry_after_s = MinValue<uint64_t>(retry_after_s, THROTTLE_MAX_BACKOFF_MS / 1000);
-							sleep_amount = MaxValue<uint64_t>(sleep_amount, retry_after_s * 1000);
-						}
-					}
-					// subtractive jitter ([base/2, base]) de-synchronizes retry bursts while honoring the cap
-					RandomEngine random;
-					sleep_amount -= random.NextRandomInteger64() % (sleep_amount / 2 + 1);
-				}
-				std::this_thread::sleep_for(std::chrono::milliseconds(sleep_amount));
+				std::this_thread::sleep_for(std::chrono::milliseconds(delay_ms));
 #endif
 			}
 			if (retry_cb) {
 				retry_cb();
 			}
-		} else {
-			// failed and we cannot retry
-			if (request.try_request) {
-				// try request - return the failure
-				if (!response) {
-					response = make_uniq<HTTPResponse>(HTTPStatusCode::INVALID);
-					string error = "Unknown error";
-					if (!exception_error.empty()) {
-						error = std::move(exception_error);
-					}
-					response->request_error = std::move(error);
-				}
-				response->success = false;
-				return response;
-			}
-			auto method = EnumUtil::ToString(request.type);
-			if (caught_e) {
-				std::rethrow_exception(caught_e);
-			} else if (response && !response->HasRequestError()) {
-				throw HTTPException(*response, "Request returned HTTP %d for HTTP %s to '%s'",
-				                    static_cast<int>(response->status), method, request.url);
-			} else {
-				string error = response ? response->GetError() : "Unknown error";
-				throw IOException("%s error for HTTP %s to '%s'", error, method, request.url);
-			}
+			break;
 		}
 	}
 }

--- a/src/main/http/http_util.cpp
+++ b/src/main/http/http_util.cpp
@@ -248,8 +248,12 @@ private:
 			DeliverFailure(attempt);
 			return;
 		case HTTPRetryDecision::RETRY: {
-			// refresh the client for the next attempt, mirroring the synchronous retry callback
+			// refresh the client for the next attempt, as the synchronous retry callback does
 			client = http_util.InitializeClient(request.params, request.proto_host_port);
+			if (!client) {
+				Deliver(nullptr, ErrorData("HTTP provider returned a null client during retry"));
+				return;
+			}
 			auto self = shared_from_this();
 			http_util.Wait(delay_ms, [self]() { self->Attempt(); });
 			return;

--- a/src/main/http/http_util.cpp
+++ b/src/main/http/http_util.cpp
@@ -202,20 +202,26 @@ void EndRequestTiming(BaseRequest &request) {
 }
 
 //! Runs one request's attempts without blocking the caller, asking HTTPUtil::Wait to come back later
-//! rather than sleeping here. Uses the same HTTPRetryState as the synchronous path.
+//! rather than sleeping here. Uses the same HTTPRetryState and cache policy as the synchronous path.
 //! Each callback holds a reference to the driver, which keeps it alive across a deferral.
 class AsyncRetryDriver : public enable_shared_from_this<AsyncRetryDriver> {
 public:
+	//! Produces the client for the next attempt under the cache policy that attempt calls for
+	using ClientFactory = std::function<unique_ptr<HTTPClient>(HTTPClientCachePolicy)>;
+
 	AsyncRetryDriver(HTTPUtil &http_util, BaseRequest &request, shared_ptr<HTTPClient> client_p,
+	                 HTTPClientCachePolicy initial_cache_policy_p, ClientFactory create_client_p,
 	                 HTTPResponseCallback on_complete)
-	    : http_util(http_util), request(request), client(std::move(client_p)), on_complete(std::move(on_complete)) {
+	    : http_util(http_util), request(request), client(std::move(client_p)),
+	      initial_cache_policy(initial_cache_policy_p), retry_cache_policy(initial_cache_policy_p),
+	      create_client(std::move(create_client_p)), on_complete(std::move(on_complete)) {
 	}
 
 	//! Issue the request, reporting whether everything resolved before returning
 	HTTPRequestState Start() {
 		Attempt();
 		// the completion may have landed on another thread while we were unwinding
-		return delivered ? HTTPRequestState::COMPLETED : HTTPRequestState::PENDING;
+		return finished ? HTTPRequestState::COMPLETED : HTTPRequestState::PENDING;
 	}
 
 private:
@@ -223,19 +229,37 @@ private:
 		auto self = shared_from_this();
 		// the span runs across the deferral, so it is opened here and closed by the completion
 		BeginRequestTiming(request);
-		// the returned state is not needed: an attempt that finished inline has already called back
-		client->Send(request, HTTPExecutionMode::DEFERRABLE,
-		             [self](unique_ptr<HTTPResponse> response, ErrorData error) {
-			             self->OnAttemptDone(std::move(response), std::move(error));
-		             });
+		attempt_reported = false;
+		try {
+			// the returned state is not needed: an attempt that finished inline has already called back
+			client->Send(request, HTTPExecutionMode::DEFERRABLE,
+			             [self](unique_ptr<HTTPResponse> response, ErrorData error) {
+				             self->attempt_reported = true;
+				             self->OnAttemptDone(std::move(response), std::move(error));
+			             });
+		} catch (std::exception &ex) {
+			if (attempt_reported) {
+				// this attempt already reported its outcome, so the throw came back out of our own completion
+				throw;
+			}
+			// a transport that throws instead of reporting still made an attempt, which may be retried
+			OnAttemptDone(nullptr, ErrorData(ex));
+		}
 	}
 
 	void OnAttemptDone(unique_ptr<HTTPResponse> response, ErrorData error) {
 		HTTPAttempt attempt;
 		attempt.response = std::move(response);
-		if (error.HasError()) {
-			attempt.exception_error = error.RawMessage();
+		if (attempt.response) {
+			attempt.response->url = request.url;
 		}
+		if (error.HasError()) {
+			attempt.SetError(std::move(error));
+		}
+		// a failed attempt must not be replayed on the transport that failed it, as SendRequestOnce also ensures
+		retry_cache_policy = (!attempt.response || attempt.response->HasRequestError())
+		                         ? HTTPClientCachePolicy::BYPASS_CACHE
+		                         : initial_cache_policy;
 		EndRequestTiming(request);
 		http_util.LogRequest(request, attempt.response.get());
 
@@ -247,32 +271,60 @@ private:
 		case HTTPRetryDecision::FAILED:
 			DeliverFailure(attempt);
 			return;
-		case HTTPRetryDecision::RETRY: {
-			// refresh the client for the next attempt, as the synchronous retry callback does
-			client = http_util.InitializeClient(request.params, request.proto_host_port);
-			if (!client) {
-				Deliver(nullptr, ErrorData("HTTP provider returned a null client during retry"));
-				return;
-			}
-			auto self = shared_from_this();
-			http_util.Wait(delay_ms, [self]() { self->Attempt(); });
+		case HTTPRetryDecision::RETRY:
+			Retry(delay_ms);
 			return;
-		}
 		}
 	}
 
-	//! A throw has nowhere to go from a completion, so Finalize's exception is delivered as an error
-	void DeliverFailure(HTTPAttempt &attempt) {
+	//! Refresh the client and schedule the next attempt, as the synchronous retry callback does.
+	//! An accepted request has to complete, so a failure to do either is delivered rather than thrown.
+	void Retry(uint64_t delay_ms) {
+		shared_ptr<HTTPClient> next_client;
 		try {
-			Deliver(retry_state.Finalize(request, attempt), ErrorData());
+			next_client = create_client(retry_cache_policy);
 		} catch (std::exception &ex) {
+			Deliver(nullptr, ErrorData(ex));
+			return;
+		}
+		if (!next_client) {
+			Deliver(nullptr, ErrorData("HTTP provider returned a null client during retry"));
+			return;
+		}
+		client = std::move(next_client);
+		auto self = shared_from_this();
+		try {
+			http_util.Wait(delay_ms, [self]() { self->Attempt(); });
+		} catch (std::exception &ex) {
+			if (completing) {
+				// the wait resumed us inline and we ran to completion, so this is the completion's own throw
+				throw;
+			}
 			Deliver(nullptr, ErrorData(ex));
 		}
 	}
 
+	//! A throw has nowhere to go from a completion, so Finalize's exception is delivered as an error.
+	//! Finalizing outside the completion keeps a throwing callback from being invoked a second time.
+	void DeliverFailure(HTTPAttempt &attempt) {
+		unique_ptr<HTTPResponse> response;
+		ErrorData error;
+		try {
+			response = retry_state.Finalize(request, attempt);
+		} catch (std::exception &ex) {
+			error = ErrorData(ex);
+		}
+		Deliver(std::move(response), std::move(error));
+	}
+
 	void Deliver(unique_ptr<HTTPResponse> response, ErrorData error) {
-		delivered = true;
+		if (completing.exchange(true)) {
+			// the completion runs exactly once, however many ways an attempt found to fail
+			return;
+		}
 		on_complete(std::move(response), std::move(error));
+		// published only now, so a caller that is told COMPLETED can read what the completion wrote
+		finished = true;
 	}
 
 private:
@@ -280,10 +332,18 @@ private:
 	BaseRequest &request;
 	//! Held, not borrowed, so a retry replacing it never writes into the caller's pointer
 	shared_ptr<HTTPClient> client;
+	//! The policy a successful attempt uses, and the one a failed attempt escalates away from
+	HTTPClientCachePolicy initial_cache_policy;
+	HTTPClientCachePolicy retry_cache_policy;
+	ClientFactory create_client;
 	HTTPResponseCallback on_complete;
 	HTTPRetryState retry_state;
-	//! Whether the completion has been invoked - written by whichever thread completes the request
-	atomic<bool> delivered {false};
+	//! Whether the current attempt reported an outcome, distinguishing a transport throw from our own
+	atomic<bool> attempt_reported {false};
+	//! Whether the completion has been entered - written by whichever thread completes the request
+	atomic<bool> completing {false};
+	//! Whether the completion has returned, which is what makes the result safe to read
+	atomic<bool> finished {false};
 };
 
 } // namespace
@@ -295,8 +355,12 @@ HTTPRequestState HTTPUtil::Send(BaseRequest &request, unique_ptr<HTTPClient> &cl
 		on_complete(SendRequest(request, client), ErrorData());
 		return HTTPRequestState::COMPLETED;
 	}
+	const auto initial_cache_policy =
+	    request.params.transport_manager ? HTTPClientCachePolicy::BYPASS_CACHE : HTTPClientCachePolicy::DEFAULT;
 	if (!client) {
-		client = InitializeClient(request.params, request.proto_host_port);
+		client = initial_cache_policy == HTTPClientCachePolicy::BYPASS_CACHE
+		             ? InitializeClientWithPolicy(request, initial_cache_policy)
+		             : InitializeClient(request.params, request.proto_host_port);
 		if (!client) {
 			throw InvalidConfigurationException(
 			    "HTTPClient is not been setup yet (possibly due to configuration), no HTTP request can be performed");
@@ -304,7 +368,10 @@ HTTPRequestState HTTPUtil::Send(BaseRequest &request, unique_ptr<HTTPClient> &cl
 	}
 	// the request takes the client over, and shares it so the transport can outlive our reference
 	shared_ptr<HTTPClient> owned_client = std::move(client);
-	auto driver = make_shared_ptr<AsyncRetryDriver>(*this, request, std::move(owned_client), std::move(on_complete));
+	auto driver = make_shared_ptr<AsyncRetryDriver>(
+	    *this, request, std::move(owned_client), initial_cache_policy,
+	    [this, &request](HTTPClientCachePolicy policy) { return InitializeClientWithPolicy(request, policy); },
+	    std::move(on_complete));
 	return driver->Start();
 }
 
@@ -317,7 +384,7 @@ bool HTTPUtil::CanWait() const {
 }
 
 // NOLINTNEXTLINE: taken by value so an asynchronous override can move it into its scheduler
-HTTPRequestState HTTPUtil::Wait(uint64_t delay_ms, std::function<void()> resume) {
+void HTTPUtil::Wait(uint64_t delay_ms, std::function<void()> resume) {
 	// this platform has a thread to wait on
 #ifndef DUCKDB_NO_THREADS
 	if (delay_ms > 0) {
@@ -325,7 +392,6 @@ HTTPRequestState HTTPUtil::Wait(uint64_t delay_ms, std::function<void()> resume)
 	}
 #endif
 	resume();
-	return HTTPRequestState::COMPLETED;
 }
 
 unique_ptr<HTTPResponse> HTTPUtil::Request(BaseRequest &request) {
@@ -635,7 +701,29 @@ void HTTPUtil::DecomposeURL(const string &input, string &path_out, string &proto
 	}
 }
 
+void HTTPAttempt::SetError(ErrorData error_p) {
+	error = std::move(error_p);
+	exception_error = error.RawMessage();
+	// handlers turn error statuses into exceptions; recover the status for throttle detection
+	auto entry = error.ExtraInfo().find("status_code");
+	if (entry != error.ExtraInfo().end()) {
+		caught_status = entry->second;
+	}
+	auto retry_entry = error.ExtraInfo().find("header_Retry-After");
+	if (retry_entry != error.ExtraInfo().end()) {
+		caught_retry_after = retry_entry->second;
+	}
+}
+
 namespace {
+
+//! Record the exception an attempt threw, keeping the exact one so it can be rethrown unchanged
+void CaptureException(HTTPAttempt &attempt, const std::exception &e) {
+	attempt.SetError(ErrorData(e));
+	attempt.caught_e = std::current_exception();
+	// what() is the serialized form a try_request has always reported, so it is kept over the raw message
+	attempt.exception_error = e.what();
+}
 
 //! Perform one attempt, capturing whatever it produced - a response, or an exception plus the status
 //! and Retry-After that the handlers folded into it
@@ -647,21 +735,9 @@ HTTPAttempt RunOneAttempt(const std::function<unique_ptr<HTTPResponse>(void)> &o
 			attempt.response->url = request.url;
 		}
 	} catch (IOException &e) {
-		attempt.exception_error = e.what();
-		attempt.caught_e = std::current_exception();
+		CaptureException(attempt, e);
 	} catch (HTTPException &e) {
-		attempt.exception_error = e.what();
-		attempt.caught_e = std::current_exception();
-		// handlers turn error statuses into exceptions; recover the status for throttle detection
-		ErrorData error_data(e);
-		auto entry = error_data.ExtraInfo().find("status_code");
-		if (entry != error_data.ExtraInfo().end()) {
-			attempt.caught_status = entry->second;
-		}
-		auto retry_entry = error_data.ExtraInfo().find("header_Retry-After");
-		if (retry_entry != error_data.ExtraInfo().end()) {
-			attempt.caught_retry_after = retry_entry->second;
-		}
+		CaptureException(attempt, e);
 	}
 	return attempt;
 }
@@ -751,6 +827,9 @@ unique_ptr<HTTPResponse> HTTPRetryState::Finalize(const BaseRequest &request, HT
 	auto method = EnumUtil::ToString(request.type);
 	if (attempt.caught_e) {
 		std::rethrow_exception(attempt.caught_e);
+	} else if (attempt.error.HasError()) {
+		// the attempt failed on another thread, so its error is rethrown from the type it was caught as
+		attempt.error.Throw();
 	} else if (response && !response->HasRequestError()) {
 		throw HTTPException(*response, "Request returned HTTP %d for HTTP %s to '%s'",
 		                    static_cast<int>(response->status), method, request.url);

--- a/src/main/http/http_util.cpp
+++ b/src/main/http/http_util.cpp
@@ -186,6 +186,21 @@ HTTPRequestState HTTPClient::Send(BaseRequest &request, HTTPExecutionMode mode, 
 
 namespace {
 
+//! Mark when a request goes on the wire. Paired with EndRequestTiming, which every path must reach
+//! before it logs, otherwise the log reports no start time and no duration at all.
+void BeginRequestTiming(BaseRequest &request) {
+	// timings are only collected when they will be logged
+	if (request.params.logger) {
+		request.have_request_timing = request.params.logger->ShouldLog(HTTPLogType::NAME, HTTPLogType::LEVEL);
+	}
+	request.request_system_start = Timestamp::GetCurrentTimestamp();
+	request.request_monotonic_start = TimePoint::Tick();
+}
+
+void EndRequestTiming(BaseRequest &request) {
+	request.request_monotonic_end = TimePoint::Tick();
+}
+
 //! Runs one request's attempts without blocking the caller, asking HTTPUtil::Wait to come back later
 //! rather than sleeping here. Uses the same HTTPRetryState as the synchronous path.
 //! Each callback holds a reference to the driver, which keeps it alive across a deferral.
@@ -206,6 +221,8 @@ public:
 private:
 	void Attempt() {
 		auto self = shared_from_this();
+		// the span runs across the deferral, so it is opened here and closed by the completion
+		BeginRequestTiming(request);
 		// the returned state is not needed: an attempt that finished inline has already called back
 		client->Send(request, HTTPExecutionMode::DEFERRABLE,
 		             [self](unique_ptr<HTTPResponse> response, ErrorData error) {
@@ -219,6 +236,7 @@ private:
 		if (error.HasError()) {
 			attempt.exception_error = error.RawMessage();
 		}
+		EndRequestTiming(request);
 		http_util.LogRequest(request, attempt.response.get());
 
 		uint64_t delay_ms = 0;
@@ -455,26 +473,21 @@ unique_ptr<HTTPResponse> HTTPUtil::SendRequestOnce(BaseRequest &request, HTTPCli
                                                    HTTPClientCachePolicy &retry_cache_policy) {
 	retry_cache_policy = initial_cache_policy;
 
-	// When logging is enabled, we collect request timings
-	if (request.params.logger) {
-		request.have_request_timing = request.params.logger->ShouldLog(HTTPLogType::NAME, HTTPLogType::LEVEL);
-	}
+	BeginRequestTiming(request);
 
 	unique_ptr<HTTPResponse> response;
 	try {
-		request.request_system_start = Timestamp::GetCurrentTimestamp();
-		request.request_monotonic_start = TimePoint::Tick();
 		response = client.Request(request);
 	} catch (...) {
 		retry_cache_policy = HTTPClientCachePolicy::BYPASS_CACHE;
-		request.request_monotonic_end = TimePoint::Tick();
+		EndRequestTiming(request);
 		LogRequest(request, nullptr);
 		throw;
 	}
 	if (!response || response->HasRequestError()) {
 		retry_cache_policy = HTTPClientCachePolicy::BYPASS_CACHE;
 	}
-	request.request_monotonic_end = TimePoint::Tick();
+	EndRequestTiming(request);
 	LogRequest(request, response ? response.get() : nullptr);
 	return response;
 }

--- a/src/main/http/http_util.cpp
+++ b/src/main/http/http_util.cpp
@@ -182,11 +182,116 @@ HTTPRequestState HTTPClient::Send(BaseRequest &request, HTTPExecutionMode mode, 
 	return HTTPRequestState::COMPLETED;
 }
 
+namespace {
+
+//! Runs one request's attempts without blocking the caller: it issues each attempt through the
+//! client, and on a retryable failure asks HTTPUtil::Wait to come back later rather than sleeping
+//! here. The retry policy is the same HTTPRetryState the synchronous path uses, so a client that
+//! defers a request keeps the retry behaviour instead of losing it.
+//! Each callback holds a reference to the driver, which is what keeps it alive across a deferral.
+class AsyncRetryDriver : public enable_shared_from_this<AsyncRetryDriver> {
+public:
+	AsyncRetryDriver(HTTPUtil &http_util, BaseRequest &request, unique_ptr<HTTPClient> &client,
+	                 HTTPResponseCallback on_complete)
+	    : http_util(http_util), request(request), client(client), on_complete(std::move(on_complete)) {
+	}
+
+	//! Issue the request, reporting whether everything resolved before returning
+	HTTPRequestState Start() {
+		Attempt();
+		return delivered ? HTTPRequestState::COMPLETED : HTTPRequestState::PENDING;
+	}
+
+private:
+	void Attempt() {
+		auto self = shared_from_this();
+		// the returned state is not needed: an attempt that finished inline has already called back
+		client->Send(request, HTTPExecutionMode::DEFERRABLE,
+		             [self](unique_ptr<HTTPResponse> response, optional_ptr<ErrorData> error) {
+			             self->OnAttemptDone(std::move(response), error);
+		             });
+	}
+
+	void OnAttemptDone(unique_ptr<HTTPResponse> response, optional_ptr<ErrorData> error) {
+		HTTPAttempt attempt;
+		attempt.response = std::move(response);
+		if (error) {
+			attempt.exception_error = error->RawMessage();
+		}
+		http_util.LogRequest(request, attempt.response.get());
+
+		uint64_t delay_ms = 0;
+		switch (retry_state.OnAttempt(request, attempt, delay_ms)) {
+		case HTTPRetryDecision::FINISHED:
+			Deliver(std::move(attempt.response), nullptr);
+			return;
+		case HTTPRetryDecision::FAILED:
+			DeliverFailure(attempt);
+			return;
+		case HTTPRetryDecision::RETRY: {
+			// refresh the client for the next attempt, mirroring the synchronous retry callback
+			client = http_util.InitializeClient(request.params, request.proto_host_port);
+			auto self = shared_from_this();
+			http_util.Wait(delay_ms, [self]() { self->Attempt(); });
+			return;
+		}
+		}
+	}
+
+	//! Finalize turns an exhausted request into either a failed response or a throw, and a throw has
+	//! nowhere to go from a completion, so it is delivered as an error instead
+	void DeliverFailure(HTTPAttempt &attempt) {
+		try {
+			Deliver(retry_state.Finalize(request, attempt), nullptr);
+		} catch (std::exception &ex) {
+			ErrorData error(ex);
+			Deliver(nullptr, &error);
+		}
+	}
+
+	void Deliver(unique_ptr<HTTPResponse> response, optional_ptr<ErrorData> error) {
+		delivered = true;
+		on_complete(std::move(response), error);
+	}
+
+private:
+	HTTPUtil &http_util;
+	BaseRequest &request;
+	unique_ptr<HTTPClient> &client;
+	HTTPResponseCallback on_complete;
+	HTTPRetryState retry_state;
+	//! Whether the completion has been invoked, read only on the synchronous unwind out of Start
+	bool delivered = false;
+};
+
+} // namespace
+
 HTTPRequestState HTTPUtil::Send(BaseRequest &request, unique_ptr<HTTPClient> &client, HTTPExecutionMode mode,
                                 HTTPResponseCallback on_complete) {
-	// default: go through SendRequest, so an implementation that overrides only that one keeps its
-	// retry, timing and logging behaviour
-	on_complete(SendRequest(request, client), nullptr);
+	if (mode == HTTPExecutionMode::BLOCKING) {
+		// the caller needs an answer now, so take the synchronous path an implementation may override
+		on_complete(SendRequest(request, client), nullptr);
+		return HTTPRequestState::COMPLETED;
+	}
+	if (!client) {
+		client = InitializeClient(request.params, request.proto_host_port);
+		if (!client) {
+			throw InvalidConfigurationException(
+			    "HTTPClient is not been setup yet (possibly due to configuration), no HTTP request can be performed");
+		}
+	}
+	auto driver = make_shared_ptr<AsyncRetryDriver>(*this, request, client, std::move(on_complete));
+	return driver->Start();
+}
+
+HTTPRequestState HTTPUtil::Wait(uint64_t delay_ms, std::function<void()> resume) {
+	// default: this platform has a thread to wait on, which is what the retry backoff has always done
+#ifndef DUCKDB_NO_THREADS
+	if (delay_ms > 0) {
+		std::this_thread::sleep_for(std::chrono::milliseconds(delay_ms));
+	}
+#endif
+	resume();
 	return HTTPRequestState::COMPLETED;
 }
 

--- a/src/main/http/http_util.cpp
+++ b/src/main/http/http_util.cpp
@@ -206,9 +206,9 @@ void EndRequestTiming(BaseRequest &request) {
 //! Each callback holds a reference to the driver, which keeps it alive across a deferral.
 class AsyncRetryDriver : public enable_shared_from_this<AsyncRetryDriver> {
 public:
-	AsyncRetryDriver(HTTPUtil &http_util, BaseRequest &request, unique_ptr<HTTPClient> &client,
+	AsyncRetryDriver(HTTPUtil &http_util, BaseRequest &request, shared_ptr<HTTPClient> client_p,
 	                 HTTPResponseCallback on_complete)
-	    : http_util(http_util), request(request), client(client), on_complete(std::move(on_complete)) {
+	    : http_util(http_util), request(request), client(std::move(client_p)), on_complete(std::move(on_complete)) {
 	}
 
 	//! Issue the request, reporting whether everything resolved before returning
@@ -278,7 +278,8 @@ private:
 private:
 	HTTPUtil &http_util;
 	BaseRequest &request;
-	unique_ptr<HTTPClient> &client;
+	//! Held, not borrowed, so a retry replacing it never writes into the caller's pointer
+	shared_ptr<HTTPClient> client;
 	HTTPResponseCallback on_complete;
 	HTTPRetryState retry_state;
 	//! Whether the completion has been invoked - written by whichever thread completes the request
@@ -301,7 +302,9 @@ HTTPRequestState HTTPUtil::Send(BaseRequest &request, unique_ptr<HTTPClient> &cl
 			    "HTTPClient is not been setup yet (possibly due to configuration), no HTTP request can be performed");
 		}
 	}
-	auto driver = make_shared_ptr<AsyncRetryDriver>(*this, request, client, std::move(on_complete));
+	// the request takes the client over, and shares it so the transport can outlive our reference
+	shared_ptr<HTTPClient> owned_client = std::move(client);
+	auto driver = make_shared_ptr<AsyncRetryDriver>(*this, request, std::move(owned_client), std::move(on_complete));
 	return driver->Start();
 }
 

--- a/src/main/http/http_util.cpp
+++ b/src/main/http/http_util.cpp
@@ -178,18 +178,16 @@ bool HTTPUtil::ShouldRetry(const BaseRequest &request, const HTTPResponse &respo
 
 // NOLINTNEXTLINE: taken by value so an asynchronous override can move it into its scheduler
 HTTPRequestState HTTPClient::Send(BaseRequest &request, HTTPExecutionMode mode, HTTPResponseCallback on_complete) {
-	// default: this client has no asynchronous transport, so the request is already done when it returns
+	// no asynchronous transport, so the request is already done when it returns
 	on_complete(Request(request), nullptr);
 	return HTTPRequestState::COMPLETED;
 }
 
 namespace {
 
-//! Runs one request's attempts without blocking the caller: it issues each attempt through the
-//! client, and on a retryable failure asks HTTPUtil::Wait to come back later rather than sleeping
-//! here. The retry policy is the same HTTPRetryState the synchronous path uses, so a client that
-//! defers a request keeps the retry behaviour instead of losing it.
-//! Each callback holds a reference to the driver, which is what keeps it alive across a deferral.
+//! Runs one request's attempts without blocking the caller, asking HTTPUtil::Wait to come back later
+//! rather than sleeping here. Uses the same HTTPRetryState as the synchronous path.
+//! Each callback holds a reference to the driver, which keeps it alive across a deferral.
 class AsyncRetryDriver : public enable_shared_from_this<AsyncRetryDriver> {
 public:
 	AsyncRetryDriver(HTTPUtil &http_util, BaseRequest &request, unique_ptr<HTTPClient> &client,
@@ -239,8 +237,7 @@ private:
 		}
 	}
 
-	//! Finalize turns an exhausted request into either a failed response or a throw, and a throw has
-	//! nowhere to go from a completion, so it is delivered as an error instead
+	//! A throw has nowhere to go from a completion, so Finalize's exception is delivered as an error
 	void DeliverFailure(HTTPAttempt &attempt) {
 		try {
 			Deliver(retry_state.Finalize(request, attempt), nullptr);
@@ -287,7 +284,7 @@ HTTPRequestState HTTPUtil::Send(BaseRequest &request, unique_ptr<HTTPClient> &cl
 
 // NOLINTNEXTLINE: taken by value so an asynchronous override can move it into its scheduler
 HTTPRequestState HTTPUtil::Wait(uint64_t delay_ms, std::function<void()> resume) {
-	// default: this platform has a thread to wait on, which is what the retry backoff has always done
+	// this platform has a thread to wait on
 #ifndef DUCKDB_NO_THREADS
 	if (delay_ms > 0) {
 		std::this_thread::sleep_for(std::chrono::milliseconds(delay_ms));

--- a/src/main/http/http_util.cpp
+++ b/src/main/http/http_util.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/common/http_util.hpp"
 
+#include "duckdb/common/atomic.hpp"
 #include "duckdb/common/error_data.hpp"
 #include "duckdb/common/exception/http_exception.hpp"
 #include "duckdb/common/hash_functions.hpp"
@@ -198,6 +199,7 @@ public:
 	//! Issue the request, reporting whether everything resolved before returning
 	HTTPRequestState Start() {
 		Attempt();
+		// the completion may have landed on another thread while we were unwinding
 		return delivered ? HTTPRequestState::COMPLETED : HTTPRequestState::PENDING;
 	}
 
@@ -257,8 +259,8 @@ private:
 	unique_ptr<HTTPClient> &client;
 	HTTPResponseCallback on_complete;
 	HTTPRetryState retry_state;
-	//! Whether the completion has been invoked, read only on the synchronous unwind out of Start
-	bool delivered = false;
+	//! Whether the completion has been invoked - written by whichever thread completes the request
+	atomic<bool> delivered {false};
 };
 
 } // namespace

--- a/test/api/CMakeLists.txt
+++ b/test/api/CMakeLists.txt
@@ -16,6 +16,7 @@ set(TEST_API_OBJECTS
     test_scalar_function_decimal_return.cpp
     test_aggregate_state_bind_data.cpp
     test_config.cpp
+    test_http_retry.cpp
     test_connection_secrets.cpp
     test_copy_output_lifecycle.cpp
     test_custom_allocator.cpp

--- a/test/api/test_http_retry.cpp
+++ b/test/api/test_http_retry.cpp
@@ -458,3 +458,28 @@ TEST_CASE("HTTP core grants a throttled deferred request extra retries", "[api]"
 	// and it actually backed off rather than hammering
 	REQUIRE(http_util.last_delay_ms > 0);
 }
+
+TEST_CASE("HTTP retry policy never retries a non-idempotent request", "[api]") {
+	RetryFixture fixture;
+	fixture.params.retries = 3;
+	HTTPHeaders headers;
+	// POST is the one method that cannot be assumed safe to replay
+	PostRequestInfo request("http://example.com/file", headers, fixture.params, nullptr, 0);
+	HTTPRetryState state;
+	uint64_t delay_ms = 0;
+
+	// a 500 would be retried for a GET, but a POST has no retries at all
+	auto attempt = ResponseAttempt(HTTPStatusCode::InternalServerError_500);
+	REQUIRE(state.OnAttempt(request, attempt, delay_ms) == HTTPRetryDecision::FAILED);
+}
+
+TEST_CASE("HTTP retry policy still retries an idempotent request of the same shape", "[api]") {
+	RetryFixture fixture;
+	fixture.params.retries = 3;
+	HTTPRetryState state;
+	uint64_t delay_ms = 0;
+
+	// the same status on a HEAD, which is idempotent, is retried
+	auto attempt = ResponseAttempt(HTTPStatusCode::InternalServerError_500);
+	REQUIRE(state.OnAttempt(fixture.request, attempt, delay_ms) == HTTPRetryDecision::RETRY);
+}

--- a/test/api/test_http_retry.cpp
+++ b/test/api/test_http_retry.cpp
@@ -1,0 +1,178 @@
+#include "catch.hpp"
+#include "duckdb/common/http_util.hpp"
+#include "test_helpers.hpp"
+
+using namespace duckdb;
+
+namespace {
+
+//! Holds the objects a BaseRequest borrows, so a test can talk to the retry policy without a server
+struct RetryFixture {
+	RetryFixture() : params(http_util), request("http://example.com/file", headers, params) {
+	}
+
+	HTTPUtil http_util;
+	HTTPHeaders headers;
+	HTTPParams params;
+	HeadRequestInfo request;
+};
+
+HTTPAttempt ResponseAttempt(HTTPStatusCode status) {
+	HTTPAttempt attempt;
+	attempt.response = make_uniq<HTTPResponse>(status);
+	return attempt;
+}
+
+//! An attempt that failed without producing a response, which is always retried
+HTTPAttempt ErroredAttempt() {
+	HTTPAttempt attempt;
+	attempt.exception_error = "connection reset";
+	return attempt;
+}
+
+} // namespace
+
+TEST_CASE("HTTP retry policy finishes on success", "[api]") {
+	RetryFixture fixture;
+	HTTPRetryState state;
+	uint64_t delay_ms = 42;
+
+	auto attempt = ResponseAttempt(HTTPStatusCode::OK_200);
+	REQUIRE(state.OnAttempt(fixture.request, attempt, delay_ms) == HTTPRetryDecision::FINISHED);
+	REQUIRE(attempt.response->success);
+	REQUIRE(delay_ms == 0);
+}
+
+TEST_CASE("HTTP retry policy treats 304 as a non-retryable success", "[api]") {
+	RetryFixture fixture;
+	HTTPRetryState state;
+	uint64_t delay_ms = 0;
+
+	auto attempt = ResponseAttempt(HTTPStatusCode::NotModified_304);
+	REQUIRE(state.OnAttempt(fixture.request, attempt, delay_ms) == HTTPRetryDecision::FINISHED);
+	REQUIRE(attempt.response->success);
+}
+
+TEST_CASE("HTTP retry policy does not retry a plain client error", "[api]") {
+	RetryFixture fixture;
+	HTTPRetryState state;
+	uint64_t delay_ms = 0;
+
+	auto attempt = ResponseAttempt(HTTPStatusCode::NotFound_404);
+	REQUIRE(state.OnAttempt(fixture.request, attempt, delay_ms) == HTTPRetryDecision::FINISHED);
+	REQUIRE(!attempt.response->success);
+}
+
+TEST_CASE("HTTP retry policy stops after the configured number of retries", "[api]") {
+	RetryFixture fixture;
+	fixture.params.retries = 3;
+	HTTPRetryState state;
+	uint64_t delay_ms = 0;
+
+	// a 500 is retryable, so we should get exactly `retries` RETRY decisions before FAILED
+	for (idx_t i = 0; i < 3; i++) {
+		auto attempt = ResponseAttempt(HTTPStatusCode::InternalServerError_500);
+		REQUIRE(state.OnAttempt(fixture.request, attempt, delay_ms) == HTTPRetryDecision::RETRY);
+	}
+	auto attempt = ResponseAttempt(HTTPStatusCode::InternalServerError_500);
+	REQUIRE(state.OnAttempt(fixture.request, attempt, delay_ms) == HTTPRetryDecision::FAILED);
+}
+
+TEST_CASE("HTTP retry policy backs off exponentially", "[api]") {
+	RetryFixture fixture;
+	fixture.params.retries = 4;
+	fixture.params.retry_wait_ms = 100;
+	fixture.params.retry_backoff = 4;
+	HTTPRetryState state;
+
+	// the first retry is immediate, later ones grow by retry_backoff each time
+	uint64_t first = 1;
+	auto attempt1 = ResponseAttempt(HTTPStatusCode::InternalServerError_500);
+	REQUIRE(state.OnAttempt(fixture.request, attempt1, first) == HTTPRetryDecision::RETRY);
+	REQUIRE(first == 0);
+
+	uint64_t second = 0;
+	auto attempt2 = ResponseAttempt(HTTPStatusCode::InternalServerError_500);
+	REQUIRE(state.OnAttempt(fixture.request, attempt2, second) == HTTPRetryDecision::RETRY);
+	REQUIRE(second == 100);
+
+	uint64_t third = 0;
+	auto attempt3 = ResponseAttempt(HTTPStatusCode::InternalServerError_500);
+	REQUIRE(state.OnAttempt(fixture.request, attempt3, third) == HTTPRetryDecision::RETRY);
+	REQUIRE(third == 400);
+}
+
+TEST_CASE("HTTP retry policy always retries an attempt that produced no response", "[api]") {
+	RetryFixture fixture;
+	fixture.params.retries = 1;
+	HTTPRetryState state;
+	uint64_t delay_ms = 0;
+
+	auto attempt = ErroredAttempt();
+	REQUIRE(state.OnAttempt(fixture.request, attempt, delay_ms) == HTTPRetryDecision::RETRY);
+	auto second = ErroredAttempt();
+	REQUIRE(state.OnAttempt(fixture.request, second, delay_ms) == HTTPRetryDecision::FAILED);
+}
+
+TEST_CASE("HTTP retry policy jitters a throttled retry within its cap", "[api]") {
+	RetryFixture fixture;
+	fixture.params.retries = 1;
+	fixture.params.retry_wait_ms = 1000;
+	fixture.params.retry_backoff = 1;
+	HTTPRetryState state;
+	uint64_t delay_ms = 0;
+
+	// a 429 backs off from the very first retry, and the jitter keeps it inside [base/2, base]
+	auto attempt = ResponseAttempt(HTTPStatusCode::TooManyRequests_429);
+	REQUIRE(state.OnAttempt(fixture.request, attempt, delay_ms) == HTTPRetryDecision::RETRY);
+	REQUIRE(delay_ms <= 1000);
+	REQUIRE(delay_ms >= 500);
+}
+
+TEST_CASE("HTTP retry policy honors a numeric Retry-After", "[api]") {
+	RetryFixture fixture;
+	fixture.params.retries = 1;
+	fixture.params.retry_wait_ms = 1;
+	fixture.params.retry_backoff = 1;
+	HTTPRetryState state;
+	uint64_t delay_ms = 0;
+
+	// Retry-After raises the delay well above the configured backoff, jitter can halve it at most
+	auto attempt = ResponseAttempt(HTTPStatusCode::TooManyRequests_429);
+	attempt.response->headers.Insert("Retry-After", "5");
+	REQUIRE(state.OnAttempt(fixture.request, attempt, delay_ms) == HTTPRetryDecision::RETRY);
+	REQUIRE(delay_ms >= 2500);
+	REQUIRE(delay_ms <= 5000);
+}
+
+TEST_CASE("HTTP retry policy caps a very large Retry-After", "[api]") {
+	RetryFixture fixture;
+	fixture.params.retries = 1;
+	HTTPRetryState state;
+	uint64_t delay_ms = 0;
+
+	auto attempt = ResponseAttempt(HTTPStatusCode::ServiceUnavailable_503);
+	attempt.response->headers.Insert("Retry-After", "100000");
+	REQUIRE(state.OnAttempt(fixture.request, attempt, delay_ms) == HTTPRetryDecision::RETRY);
+	// the cap is 10s, and jitter only subtracts
+	REQUIRE(delay_ms <= 10000);
+}
+
+TEST_CASE("HTTP retry policy returns a failed response for a try request", "[api]") {
+	RetryFixture fixture;
+	fixture.request.try_request = true;
+	HTTPRetryState state;
+
+	auto attempt = ResponseAttempt(HTTPStatusCode::InternalServerError_500);
+	auto response = state.Finalize(fixture.request, attempt);
+	REQUIRE(response);
+	REQUIRE(!response->success);
+}
+
+TEST_CASE("HTTP retry policy throws for a non-try request", "[api]") {
+	RetryFixture fixture;
+	HTTPRetryState state;
+
+	auto attempt = ResponseAttempt(HTTPStatusCode::InternalServerError_500);
+	REQUIRE_THROWS(state.Finalize(fixture.request, attempt));
+}

--- a/test/api/test_http_retry.cpp
+++ b/test/api/test_http_retry.cpp
@@ -204,7 +204,6 @@ public:
 	unique_ptr<HTTPResponse> Options(OptionsRequestInfo &) override {
 		throw NotImplementedException("OPTIONS");
 	}
-
 };
 
 //! A client with no asynchronous transport, i.e. every backend that exists today. It does not

--- a/test/api/test_http_retry.cpp
+++ b/test/api/test_http_retry.cpp
@@ -176,3 +176,105 @@ TEST_CASE("HTTP retry policy throws for a non-try request", "[api]") {
 	auto attempt = ResponseAttempt(HTTPStatusCode::InternalServerError_500);
 	REQUIRE_THROWS(state.Finalize(fixture.request, attempt));
 }
+
+namespace {
+
+//! The verb boilerplate both test clients need, none of which is what is under test
+class StubClient : public HTTPClient {
+public:
+	void Initialize(HTTPParams &) override {
+	}
+	unique_ptr<HTTPResponse> Get(GetRequestInfo &) override {
+		auto response = make_uniq<HTTPResponse>(HTTPStatusCode::OK_200);
+		response->success = true;
+		return response;
+	}
+	unique_ptr<HTTPResponse> Put(PutRequestInfo &) override {
+		throw NotImplementedException("PUT");
+	}
+	unique_ptr<HTTPResponse> Head(HeadRequestInfo &) override {
+		throw NotImplementedException("HEAD");
+	}
+	unique_ptr<HTTPResponse> Delete(DeleteRequestInfo &) override {
+		throw NotImplementedException("DELETE");
+	}
+	unique_ptr<HTTPResponse> Post(PostRequestInfo &) override {
+		throw NotImplementedException("POST");
+	}
+	unique_ptr<HTTPResponse> Options(OptionsRequestInfo &) override {
+		throw NotImplementedException("OPTIONS");
+	}
+
+};
+
+//! A client with no asynchronous transport, i.e. every backend that exists today. It does not
+//! override Send, so it inherits the synchronous default.
+class SynchronousClient : public StubClient {};
+
+//! A client that can hand a request off instead of answering it, so a test can exercise both modes
+class DeferringClient : public StubClient {
+public:
+	HTTPRequestState Send(BaseRequest &request, HTTPExecutionMode mode, HTTPResponseCallback on_complete) override {
+		if (mode == HTTPExecutionMode::BLOCKING) {
+			return HTTPClient::Send(request, mode, std::move(on_complete));
+		}
+		pending = std::move(on_complete);
+		return HTTPRequestState::PENDING;
+	}
+
+	//! Deliver the deferred response, standing in for a transport completing out of band
+	void Complete() {
+		auto response = make_uniq<HTTPResponse>(HTTPStatusCode::OK_200);
+		response->success = true;
+		auto callback = std::move(pending);
+		pending = nullptr;
+		callback(std::move(response), nullptr);
+	}
+
+private:
+	HTTPResponseCallback pending;
+};
+
+} // namespace
+
+TEST_CASE("HTTP client without an async transport completes inline", "[api]") {
+	RetryFixture fixture;
+	HTTPHeaders headers;
+	GetRequestInfo request("http://example.com/file", headers, fixture.params, nullptr, nullptr);
+	SynchronousClient client;
+
+	idx_t completions = 0;
+	auto state = client.Send(request, HTTPExecutionMode::DEFERRABLE,
+	                         [&](unique_ptr<HTTPResponse> response, optional_ptr<ErrorData> error) {
+		                         completions++;
+		                         REQUIRE(response);
+		                         REQUIRE(!error);
+	                         });
+	// the default inherits the synchronous path, so even DEFERRABLE finishes before returning
+	REQUIRE(state == HTTPRequestState::COMPLETED);
+	REQUIRE(completions == 1);
+}
+
+TEST_CASE("HTTP client defers a request only when the caller allows it", "[api]") {
+	RetryFixture fixture;
+	HTTPHeaders headers;
+	GetRequestInfo request("http://example.com/file", headers, fixture.params, nullptr, nullptr);
+	DeferringClient client;
+
+	idx_t completions = 0;
+	auto on_complete = [&](unique_ptr<HTTPResponse> response, optional_ptr<ErrorData> error) {
+		completions++;
+		REQUIRE(response);
+		REQUIRE(!error);
+	};
+
+	// BLOCKING must never be handed a result that is not ready
+	REQUIRE(client.Send(request, HTTPExecutionMode::BLOCKING, on_complete) == HTTPRequestState::COMPLETED);
+	REQUIRE(completions == 1);
+
+	// DEFERRABLE lets it hand the request off, and the completion arrives later
+	REQUIRE(client.Send(request, HTTPExecutionMode::DEFERRABLE, on_complete) == HTTPRequestState::PENDING);
+	REQUIRE(completions == 1);
+	client.Complete();
+	REQUIRE(completions == 2);
+}

--- a/test/api/test_http_retry.cpp
+++ b/test/api/test_http_retry.cpp
@@ -278,3 +278,183 @@ TEST_CASE("HTTP client defers a request only when the caller allows it", "[api]"
 	client.Complete();
 	REQUIRE(completions == 2);
 }
+
+namespace {
+
+//! Models a transport that always defers and fails a fixed number of times before succeeding.
+//! The state lives on the util rather than the client because core refreshes the client between
+//! retries, exactly as the synchronous path does, so any per-client counter would be thrown away.
+class NonBlockingUtil : public HTTPUtil {
+public:
+	NonBlockingUtil(idx_t failures, HTTPStatusCode failure_status)
+	    : failure_status(failure_status), failures_left(failures) {
+	}
+
+	unique_ptr<HTTPClient> InitializeClient(HTTPParams &http_params, const string &proto_host_port) override;
+
+	HTTPRequestState Wait(uint64_t delay_ms, std::function<void()> resume) override {
+		waits++;
+		last_delay_ms = delay_ms;
+		scheduled = std::move(resume);
+		return HTTPRequestState::PENDING;
+	}
+
+	//! Run whatever the retry asked us to come back to, standing in for a timer firing
+	void FireTimer() {
+		auto callback = std::move(scheduled);
+		scheduled = nullptr;
+		callback();
+	}
+
+	//! Deliver the deferred response, standing in for a transport completing out of band
+	void Complete() {
+		auto status = failures_left > 0 ? failure_status : HTTPStatusCode::OK_200;
+		if (failures_left > 0) {
+			failures_left--;
+		}
+		auto response = make_uniq<HTTPResponse>(status);
+		auto callback = std::move(pending);
+		pending = nullptr;
+		callback(std::move(response), nullptr);
+	}
+
+	idx_t attempts = 0;
+	idx_t waits = 0;
+	uint64_t last_delay_ms = 0;
+	HTTPResponseCallback pending;
+
+private:
+	//! 429 and 503 are throttle statuses and earn extra retries, anything else uses the plain ceiling
+	HTTPStatusCode failure_status;
+	idx_t failures_left;
+	std::function<void()> scheduled;
+};
+
+class FlakyDeferringClient : public StubClient {
+public:
+	explicit FlakyDeferringClient(NonBlockingUtil &util) : util(util) {
+	}
+
+	HTTPRequestState Send(BaseRequest &request, HTTPExecutionMode mode, HTTPResponseCallback on_complete) override {
+		util.attempts++;
+		if (mode == HTTPExecutionMode::BLOCKING) {
+			return HTTPClient::Send(request, mode, std::move(on_complete));
+		}
+		util.pending = std::move(on_complete);
+		return HTTPRequestState::PENDING;
+	}
+
+private:
+	NonBlockingUtil &util;
+};
+
+unique_ptr<HTTPClient> NonBlockingUtil::InitializeClient(HTTPParams &, const string &) {
+	return make_uniq<FlakyDeferringClient>(*this);
+}
+
+} // namespace
+
+TEST_CASE("HTTP core retries a request the transport deferred", "[api]") {
+	NonBlockingUtil http_util(2, HTTPStatusCode::ServiceUnavailable_503);
+	HTTPParams params(http_util);
+	params.retries = 3;
+	HTTPHeaders headers;
+	GetRequestInfo request("http://example.com/file", headers, params, nullptr, nullptr);
+	unique_ptr<HTTPClient> client;
+
+	idx_t completions = 0;
+	bool succeeded = false;
+	auto state = http_util.Send(request, client, HTTPExecutionMode::DEFERRABLE,
+	                            [&](unique_ptr<HTTPResponse> response, optional_ptr<ErrorData> error) {
+		                            completions++;
+		                            succeeded = response && response->success;
+	                            });
+
+	// the first attempt is in flight, so nothing has been delivered yet
+	REQUIRE(state == HTTPRequestState::PENDING);
+	REQUIRE(http_util.attempts == 1);
+	REQUIRE(completions == 0);
+
+	// two 503s, each of which core turns into a scheduled retry rather than a failure
+	http_util.Complete();
+	REQUIRE(completions == 0);
+	REQUIRE(http_util.waits == 1);
+	http_util.FireTimer();
+	REQUIRE(http_util.attempts == 2);
+
+	http_util.Complete();
+	REQUIRE(completions == 0);
+	REQUIRE(http_util.waits == 2);
+	http_util.FireTimer();
+	REQUIRE(http_util.attempts == 3);
+
+	// the third attempt succeeds, and only now is the caller told
+	http_util.Complete();
+	REQUIRE(completions == 1);
+	REQUIRE(succeeded);
+}
+
+TEST_CASE("HTTP core gives up on a deferred request after its retries", "[api]") {
+	// never succeeds, and a 500 is not a throttle status so the plain retry ceiling ends it
+	NonBlockingUtil http_util(100, HTTPStatusCode::InternalServerError_500);
+	HTTPParams params(http_util);
+	params.retries = 1;
+	HTTPHeaders headers;
+	GetRequestInfo request("http://example.com/file", headers, params, nullptr, nullptr);
+	request.try_request = true;
+	unique_ptr<HTTPClient> client;
+
+	idx_t completions = 0;
+	bool failed = false;
+	http_util.Send(request, client, HTTPExecutionMode::DEFERRABLE,
+	               [&](unique_ptr<HTTPResponse> response, optional_ptr<ErrorData> error) {
+		               completions++;
+		               failed = response && !response->success;
+	               });
+
+	http_util.Complete();
+	http_util.FireTimer();
+	http_util.Complete();
+
+	REQUIRE(completions == 1);
+	REQUIRE(failed);
+	// one retry allowed, so two attempts total
+	REQUIRE(http_util.attempts == 2);
+}
+
+TEST_CASE("HTTP default Wait sleeps rather than scheduling", "[api]") {
+	HTTPUtil http_util;
+	idx_t resumed = 0;
+	auto state = http_util.Wait(0, [&]() { resumed++; });
+	REQUIRE(state == HTTPRequestState::COMPLETED);
+	REQUIRE(resumed == 1);
+}
+
+TEST_CASE("HTTP core grants a throttled deferred request extra retries", "[api]") {
+	// a 503 is a throttle status, so it earns THROTTLE_EXTRA_RETRIES on top of the configured ceiling
+	NonBlockingUtil http_util(100, HTTPStatusCode::ServiceUnavailable_503);
+	HTTPParams params(http_util);
+	params.retries = 1;
+	HTTPHeaders headers;
+	GetRequestInfo request("http://example.com/file", headers, params, nullptr, nullptr);
+	request.try_request = true;
+	unique_ptr<HTTPClient> client;
+
+	idx_t completions = 0;
+	http_util.Send(request, client, HTTPExecutionMode::DEFERRABLE,
+	               [&](unique_ptr<HTTPResponse> response, optional_ptr<ErrorData> error) { completions++; });
+
+	// drive it until core stops asking for retries
+	for (idx_t i = 0; i < 20 && completions == 0; i++) {
+		http_util.Complete();
+		if (completions == 0) {
+			http_util.FireTimer();
+		}
+	}
+	REQUIRE(completions == 1);
+	// 1 configured retry + 5 throttle retries + the original attempt
+	REQUIRE(http_util.attempts == 7);
+	REQUIRE(http_util.waits == 6);
+	// and it actually backed off rather than hammering
+	REQUIRE(http_util.last_delay_ms > 0);
+}

--- a/test/api/test_http_retry.cpp
+++ b/test/api/test_http_retry.cpp
@@ -227,7 +227,7 @@ public:
 		response->success = true;
 		auto callback = std::move(pending);
 		pending = nullptr;
-		callback(std::move(response), nullptr);
+		callback(std::move(response), ErrorData());
 	}
 
 private:
@@ -243,12 +243,12 @@ TEST_CASE("HTTP client without an async transport completes inline", "[api]") {
 	SynchronousClient client;
 
 	idx_t completions = 0;
-	auto state = client.Send(request, HTTPExecutionMode::DEFERRABLE,
-	                         [&](unique_ptr<HTTPResponse> response, optional_ptr<ErrorData> error) {
-		                         completions++;
-		                         REQUIRE(response);
-		                         REQUIRE(!error);
-	                         });
+	auto state =
+	    client.Send(request, HTTPExecutionMode::DEFERRABLE, [&](unique_ptr<HTTPResponse> response, ErrorData error) {
+		    completions++;
+		    REQUIRE(response);
+		    REQUIRE(!error.HasError());
+	    });
 	// the default inherits the synchronous path, so even DEFERRABLE finishes before returning
 	REQUIRE(state == HTTPRequestState::COMPLETED);
 	REQUIRE(completions == 1);
@@ -261,10 +261,10 @@ TEST_CASE("HTTP client defers a request only when the caller allows it", "[api]"
 	DeferringClient client;
 
 	idx_t completions = 0;
-	auto on_complete = [&](unique_ptr<HTTPResponse> response, optional_ptr<ErrorData> error) {
+	auto on_complete = [&](unique_ptr<HTTPResponse> response, ErrorData error) {
 		completions++;
 		REQUIRE(response);
-		REQUIRE(!error);
+		REQUIRE(!error.HasError());
 	};
 
 	// BLOCKING must never be handed a result that is not ready
@@ -314,7 +314,7 @@ public:
 		auto response = make_uniq<HTTPResponse>(status);
 		auto callback = std::move(pending);
 		pending = nullptr;
-		callback(std::move(response), nullptr);
+		callback(std::move(response), ErrorData());
 	}
 
 	idx_t attempts = 0;
@@ -364,7 +364,7 @@ TEST_CASE("HTTP core retries a request the transport deferred", "[api]") {
 	idx_t completions = 0;
 	bool succeeded = false;
 	auto state = http_util.Send(request, client, HTTPExecutionMode::DEFERRABLE,
-	                            [&](unique_ptr<HTTPResponse> response, optional_ptr<ErrorData> error) {
+	                            [&](unique_ptr<HTTPResponse> response, ErrorData error) {
 		                            completions++;
 		                            succeeded = response && response->success;
 	                            });
@@ -406,7 +406,7 @@ TEST_CASE("HTTP core gives up on a deferred request after its retries", "[api]")
 	idx_t completions = 0;
 	bool failed = false;
 	http_util.Send(request, client, HTTPExecutionMode::DEFERRABLE,
-	               [&](unique_ptr<HTTPResponse> response, optional_ptr<ErrorData> error) {
+	               [&](unique_ptr<HTTPResponse> response, ErrorData error) {
 		               completions++;
 		               failed = response && !response->success;
 	               });
@@ -441,7 +441,7 @@ TEST_CASE("HTTP core grants a throttled deferred request extra retries", "[api]"
 
 	idx_t completions = 0;
 	http_util.Send(request, client, HTTPExecutionMode::DEFERRABLE,
-	               [&](unique_ptr<HTTPResponse> response, optional_ptr<ErrorData> error) { completions++; });
+	               [&](unique_ptr<HTTPResponse> response, ErrorData error) { completions++; });
 
 	// drive it until core stops asking for retries
 	for (idx_t i = 0; i < 20 && completions == 0; i++) {

--- a/test/api/test_http_retry.cpp
+++ b/test/api/test_http_retry.cpp
@@ -546,3 +546,53 @@ TEST_CASE("HTTP request completing on another thread is delivered exactly once",
 		REQUIRE((state == HTTPRequestState::PENDING || state == HTTPRequestState::COMPLETED));
 	}
 }
+
+namespace {
+
+//! Stands in for a platform whose Wait schedules rather than sleeps, the Wasm case: it cannot block,
+//! but it can still delay an attempt, so the backoff is worth granting
+class SchedulingUtil : public HTTPUtil {
+public:
+	bool CanWait() const override {
+		return true;
+	}
+};
+
+//! A platform with no way to delay an attempt at all
+class ImmediateUtil : public HTTPUtil {
+public:
+	bool CanWait() const override {
+		return false;
+	}
+};
+
+//! Drive a throttled request until the policy stops retrying, and report how many retries it granted
+idx_t CountThrottledRetries(HTTPUtil &http_util) {
+	HTTPParams params(http_util);
+	params.retries = 1;
+	HTTPHeaders headers;
+	HeadRequestInfo request("http://example.com/file", headers, params);
+	HTTPRetryState state;
+
+	idx_t retries = 0;
+	while (true) {
+		auto attempt = ResponseAttempt(HTTPStatusCode::TooManyRequests_429);
+		uint64_t delay_ms = 0;
+		if (state.OnAttempt(request, attempt, delay_ms) != HTTPRetryDecision::RETRY) {
+			return retries;
+		}
+		retries++;
+	}
+}
+
+} // namespace
+
+TEST_CASE("HTTP throttle retries follow the platform's ability to wait", "[api]") {
+	// a platform that can delay gets the plain retry plus the throttle allowance
+	SchedulingUtil scheduling;
+	REQUIRE(CountThrottledRetries(scheduling) == 6);
+
+	// one that cannot is left with the plain retry, since the extra ones would not back off
+	ImmediateUtil immediate;
+	REQUIRE(CountThrottledRetries(immediate) == 1);
+}

--- a/test/api/test_http_retry.cpp
+++ b/test/api/test_http_retry.cpp
@@ -1,6 +1,9 @@
 #include "catch.hpp"
+#include "duckdb/common/atomic.hpp"
 #include "duckdb/common/http_util.hpp"
 #include "test_helpers.hpp"
+
+#include <thread>
 
 using namespace duckdb;
 
@@ -481,4 +484,65 @@ TEST_CASE("HTTP retry policy still retries an idempotent request of the same sha
 	// the same status on a HEAD, which is idempotent, is retried
 	auto attempt = ResponseAttempt(HTTPStatusCode::InternalServerError_500);
 	REQUIRE(state.OnAttempt(fixture.request, attempt, delay_ms) == HTTPRetryDecision::RETRY);
+}
+
+namespace {
+
+//! A client whose transport completes on another thread, which is what makes the state a request
+//! reports on the way out racy: the completion can land while Send is still unwinding
+class ThreadedClient : public StubClient {
+public:
+	HTTPRequestState Send(BaseRequest &request, HTTPExecutionMode mode, HTTPResponseCallback on_complete) override {
+		if (mode == HTTPExecutionMode::BLOCKING) {
+			return HTTPClient::Send(request, mode, std::move(on_complete));
+		}
+		worker = std::thread([callback = std::move(on_complete)]() {
+			auto response = make_uniq<HTTPResponse>(HTTPStatusCode::OK_200);
+			response->success = true;
+			callback(std::move(response), ErrorData());
+		});
+		return HTTPRequestState::PENDING;
+	}
+
+	void Join() {
+		if (worker.joinable()) {
+			worker.join();
+		}
+	}
+
+private:
+	std::thread worker;
+};
+
+class ThreadedUtil : public HTTPUtil {
+public:
+	unique_ptr<HTTPClient> InitializeClient(HTTPParams &, const string &) override {
+		auto result = make_uniq<ThreadedClient>();
+		last_client = result.get();
+		return std::move(result);
+	}
+
+	optional_ptr<ThreadedClient> last_client;
+};
+
+} // namespace
+
+TEST_CASE("HTTP request completing on another thread is delivered exactly once", "[api]") {
+	// repeated so the completion lands at varying points of Send's unwind
+	for (idx_t run = 0; run < 200; run++) {
+		ThreadedUtil http_util;
+		HTTPParams params(http_util);
+		HTTPHeaders headers;
+		GetRequestInfo request("http://example.com/file", headers, params, nullptr, nullptr);
+		unique_ptr<HTTPClient> client;
+
+		atomic<idx_t> completions {0};
+		auto state = http_util.Send(request, client, HTTPExecutionMode::DEFERRABLE,
+		                            [&](unique_ptr<HTTPResponse> response, ErrorData error) { completions++; });
+		http_util.last_client->Join();
+
+		// whichever side won the race, the completion runs once and the state is one of the two answers
+		REQUIRE(completions == 1);
+		REQUIRE((state == HTTPRequestState::PENDING || state == HTTPRequestState::COMPLETED));
+	}
 }

--- a/test/api/test_http_retry.cpp
+++ b/test/api/test_http_retry.cpp
@@ -617,3 +617,45 @@ TEST_CASE("HTTP timing of a deferred request spans the deferral", "[api]") {
 	REQUIRE(TimePoint::ElapsedMillis(before, request.request_monotonic_start) >= 0);
 	REQUIRE(TimePoint::ElapsedMillis(request.request_monotonic_start, request.request_monotonic_end) >= 10);
 }
+
+namespace {
+
+//! Runs out of clients on the retry, which the synchronous path reports as a configuration error
+class NullOnRetryUtil : public NonBlockingUtil {
+public:
+	NullOnRetryUtil() : NonBlockingUtil(1, HTTPStatusCode::InternalServerError_500) {
+	}
+
+	unique_ptr<HTTPClient> InitializeClient(HTTPParams &params, const string &proto_host_port) override {
+		if (initialized++ > 0) {
+			return nullptr;
+		}
+		return NonBlockingUtil::InitializeClient(params, proto_host_port);
+	}
+
+	idx_t initialized = 0;
+};
+
+} // namespace
+
+TEST_CASE("HTTP deferred retry reports a null client instead of dereferencing it", "[api]") {
+	NullOnRetryUtil http_util;
+	HTTPParams params(http_util);
+	params.retries = 3;
+	HTTPHeaders headers;
+	GetRequestInfo request("http://example.com/file", headers, params, nullptr, nullptr);
+	unique_ptr<HTTPClient> client;
+
+	idx_t completions = 0;
+	bool reported_error = false;
+	http_util.Send(request, client, HTTPExecutionMode::DEFERRABLE,
+	               [&](unique_ptr<HTTPResponse> response, ErrorData error) {
+		               completions++;
+		               reported_error = error.HasError();
+	               });
+
+	// the 500 asks for a retry, and the retry cannot get a client to make it with
+	http_util.Complete();
+	REQUIRE(completions == 1);
+	REQUIRE(reported_error);
+}

--- a/test/api/test_http_retry.cpp
+++ b/test/api/test_http_retry.cpp
@@ -488,20 +488,31 @@ TEST_CASE("HTTP retry policy still retries an idempotent request of the same sha
 
 namespace {
 
+class ThreadedUtil;
+
 //! A client whose transport completes on another thread, which is what makes the state a request
-//! reports on the way out racy: the completion can land while Send is still unwinding
+//! reports on the way out racy: the completion can land while Send is still unwinding.
+//! It keeps itself alive across that completion, which is what a deferring backend has to do - the
+//! request releases its own reference from inside the callback.
 class ThreadedClient : public StubClient {
 public:
-	HTTPRequestState Send(BaseRequest &request, HTTPExecutionMode mode, HTTPResponseCallback on_complete) override {
-		if (mode == HTTPExecutionMode::BLOCKING) {
-			return HTTPClient::Send(request, mode, std::move(on_complete));
-		}
-		worker = std::thread([callback = std::move(on_complete)]() {
-			auto response = make_uniq<HTTPResponse>(HTTPStatusCode::OK_200);
-			response->success = true;
-			callback(std::move(response), ErrorData());
-		});
-		return HTTPRequestState::PENDING;
+	explicit ThreadedClient(ThreadedUtil &util) : util(util) {
+	}
+
+	HTTPRequestState Send(BaseRequest &request, HTTPExecutionMode mode, HTTPResponseCallback on_complete) override;
+
+private:
+	ThreadedUtil &util;
+};
+
+class ThreadedUtil : public HTTPUtil {
+public:
+	~ThreadedUtil() override {
+		Join();
+	}
+
+	unique_ptr<HTTPClient> InitializeClient(HTTPParams &, const string &) override {
+		return make_uniq<ThreadedClient>(*this);
 	}
 
 	void Join() {
@@ -510,20 +521,32 @@ public:
 		}
 	}
 
-private:
+	//! The thread belongs to the platform, not to the client, the way a real event loop does
 	std::thread worker;
+	//! Watches the client without holding it up, so the transport can check it outlived the callback
+	weak_ptr<HTTPClient> client_watch;
+	bool alive_after_completion = false;
 };
 
-class ThreadedUtil : public HTTPUtil {
-public:
-	unique_ptr<HTTPClient> InitializeClient(HTTPParams &, const string &) override {
-		auto result = make_uniq<ThreadedClient>();
-		last_client = result.get();
-		return std::move(result);
+HTTPRequestState ThreadedClient::Send(BaseRequest &request, HTTPExecutionMode mode, HTTPResponseCallback on_complete) {
+	if (mode == HTTPExecutionMode::BLOCKING) {
+		return HTTPClient::Send(request, mode, std::move(on_complete));
 	}
-
-	optional_ptr<ThreadedClient> last_client;
-};
+	// the reference that keeps this client alive until the completion has returned
+	auto self = shared_from_this();
+	auto &platform = util;
+	platform.client_watch = self;
+	platform.worker = std::thread([self, &platform, callback = std::move(on_complete)]() mutable {
+		auto response = make_uniq<HTTPResponse>(HTTPStatusCode::OK_200);
+		response->success = true;
+		callback(std::move(response), ErrorData());
+		// done with the request, so let it go the way a transport does once it has delivered
+		callback = nullptr;
+		// that dropped the request's reference to us, and only [self] is still holding us up
+		platform.alive_after_completion = !platform.client_watch.expired();
+	});
+	return HTTPRequestState::PENDING;
+}
 
 } // namespace
 
@@ -539,11 +562,13 @@ TEST_CASE("HTTP request completing on another thread is delivered exactly once",
 		atomic<idx_t> completions {0};
 		auto state = http_util.Send(request, client, HTTPExecutionMode::DEFERRABLE,
 		                            [&](unique_ptr<HTTPResponse> response, ErrorData error) { completions++; });
-		http_util.last_client->Join();
+		http_util.Join();
 
 		// whichever side won the race, the completion runs once and the state is one of the two answers
 		REQUIRE(completions == 1);
 		REQUIRE((state == HTTPRequestState::PENDING || state == HTTPRequestState::COMPLETED));
+		// and the transport was not destroyed by the completion it delivered
+		REQUIRE(http_util.alive_after_completion);
 	}
 }
 

--- a/test/api/test_http_retry.cpp
+++ b/test/api/test_http_retry.cpp
@@ -596,3 +596,24 @@ TEST_CASE("HTTP throttle retries follow the platform's ability to wait", "[api]"
 	ImmediateUtil immediate;
 	REQUIRE(CountThrottledRetries(immediate) == 1);
 }
+
+TEST_CASE("HTTP timing of a deferred request spans the deferral", "[api]") {
+	// succeeds on the first attempt, so the whole span is the one deferral the test controls
+	NonBlockingUtil http_util(0, HTTPStatusCode::OK_200);
+	HTTPParams params(http_util);
+	HTTPHeaders headers;
+	GetRequestInfo request("http://example.com/file", headers, params, nullptr, nullptr);
+	unique_ptr<HTTPClient> client;
+
+	auto before = TimePoint::Tick();
+	http_util.Send(request, client, HTTPExecutionMode::DEFERRABLE,
+	               [](unique_ptr<HTTPResponse> response, ErrorData error) {});
+
+	// the transport takes its time, which is exactly what the sync path could never measure
+	std::this_thread::sleep_for(std::chrono::milliseconds(20));
+	http_util.Complete();
+
+	// the span opened at dispatch and closed at completion, so it contains the wait
+	REQUIRE(TimePoint::ElapsedMillis(before, request.request_monotonic_start) >= 0);
+	REQUIRE(TimePoint::ElapsedMillis(request.request_monotonic_start, request.request_monotonic_end) >= 10);
+}

--- a/test/api/test_http_retry.cpp
+++ b/test/api/test_http_retry.cpp
@@ -1,5 +1,6 @@
 #include "catch.hpp"
 #include "duckdb/common/atomic.hpp"
+#include "duckdb/common/exception/http_exception.hpp"
 #include "duckdb/common/http_util.hpp"
 #include "test_helpers.hpp"
 
@@ -294,11 +295,10 @@ public:
 
 	unique_ptr<HTTPClient> InitializeClient(HTTPParams &http_params, const string &proto_host_port) override;
 
-	HTTPRequestState Wait(uint64_t delay_ms, std::function<void()> resume) override {
+	void Wait(uint64_t delay_ms, std::function<void()> resume) override {
 		waits++;
 		last_delay_ms = delay_ms;
 		scheduled = std::move(resume);
-		return HTTPRequestState::PENDING;
 	}
 
 	//! Run whatever the retry asked us to come back to, standing in for a timer firing
@@ -427,8 +427,7 @@ TEST_CASE("HTTP core gives up on a deferred request after its retries", "[api]")
 TEST_CASE("HTTP default Wait sleeps rather than scheduling", "[api]") {
 	HTTPUtil http_util;
 	idx_t resumed = 0;
-	auto state = http_util.Wait(0, [&]() { resumed++; });
-	REQUIRE(state == HTTPRequestState::COMPLETED);
+	http_util.Wait(0, [&]() { resumed++; });
 	REQUIRE(resumed == 1);
 }
 
@@ -683,4 +682,321 @@ TEST_CASE("HTTP deferred retry reports a null client instead of dereferencing it
 	http_util.Complete();
 	REQUIRE(completions == 1);
 	REQUIRE(reported_error);
+}
+
+namespace {
+
+//! A transport that completes on another thread and does not return from its own Send until that
+//! completion is running. That is the window in which the caller must not be told COMPLETED.
+class ConcurrentCompletionClient : public StubClient {
+public:
+	ConcurrentCompletionClient(std::thread &worker, atomic<bool> &entered) : worker(worker), entered(entered) {
+	}
+
+	HTTPRequestState Send(BaseRequest &, HTTPExecutionMode, HTTPResponseCallback on_complete) override {
+		worker = std::thread([callback = std::move(on_complete)]() mutable {
+			auto response = make_uniq<HTTPResponse>(HTTPStatusCode::OK_200);
+			response->success = true;
+			callback(std::move(response), ErrorData());
+		});
+		while (!entered) {
+			std::this_thread::yield();
+		}
+		return HTTPRequestState::PENDING;
+	}
+
+private:
+	std::thread &worker;
+	atomic<bool> &entered;
+};
+
+} // namespace
+
+TEST_CASE("HTTP completion is published only once the callback has run", "[api]") {
+	HTTPUtil http_util;
+	HTTPParams params(http_util);
+	HTTPHeaders headers;
+	GetRequestInfo request("http://example.com/file", headers, params, nullptr, nullptr);
+
+	std::thread worker;
+	atomic<bool> entered {false};
+	atomic<bool> release {false};
+	atomic<bool> result_ready {false};
+	unique_ptr<HTTPClient> client = make_uniq<ConcurrentCompletionClient>(worker, entered);
+
+	idx_t completions = 0;
+	auto state = http_util.Send(request, client, HTTPExecutionMode::DEFERRABLE,
+	                            [&](unique_ptr<HTTPResponse> response, ErrorData error) {
+		                            entered = true;
+		                            while (!release) {
+			                            std::this_thread::yield();
+		                            }
+		                            completions++;
+		                            result_ready = true;
+	                            });
+	const bool ready_at_return = result_ready;
+	release = true;
+	worker.join();
+
+	// the completion had not finished writing its result, so the caller must not have been told COMPLETED
+	REQUIRE(!ready_at_return);
+	REQUIRE(state == HTTPRequestState::PENDING);
+	REQUIRE(completions == 1);
+}
+
+namespace {
+
+//! A util whose transport hands every request off, so a test drives each attempt by hand
+class SteeredUtil : public HTTPUtil {
+public:
+	unique_ptr<HTTPClient> InitializeClient(HTTPParams &http_params, const string &proto_host_port) override;
+
+	unique_ptr<HTTPClient> InitializeClientExtended(HTTPParams &http_params, const string &proto_host_port,
+	                                                const HTTPClientInitializationOptions &options) override {
+		last_cache_policy = options.cache_policy;
+		if (fail_init) {
+			throw IOException("no client for you");
+		}
+		return InitializeClient(http_params, proto_host_port);
+	}
+
+	void Wait(uint64_t delay_ms, std::function<void()> resume) override {
+		waits++;
+		last_delay_ms = delay_ms;
+		scheduled = std::move(resume);
+	}
+
+	//! Run whatever the retry asked us to come back to, standing in for a timer firing
+	void FireTimer() {
+		auto callback = std::move(scheduled);
+		scheduled = nullptr;
+		callback();
+	}
+
+	//! Deliver the outcome of the attempt currently in flight
+	void Complete(unique_ptr<HTTPResponse> response, ErrorData error) {
+		auto callback = std::move(pending);
+		pending = nullptr;
+		callback(std::move(response), std::move(error));
+	}
+
+	idx_t attempts = 0;
+	idx_t waits = 0;
+	uint64_t last_delay_ms = 0;
+	bool fail_init = false;
+	HTTPClientCachePolicy last_cache_policy = HTTPClientCachePolicy::DEFAULT;
+	HTTPResponseCallback pending;
+
+private:
+	std::function<void()> scheduled;
+};
+
+class SteeredClient : public StubClient {
+public:
+	explicit SteeredClient(SteeredUtil &util) : util(util) {
+	}
+
+	HTTPRequestState Send(BaseRequest &, HTTPExecutionMode, HTTPResponseCallback on_complete) override {
+		util.attempts++;
+		util.pending = std::move(on_complete);
+		return HTTPRequestState::PENDING;
+	}
+
+private:
+	SteeredUtil &util;
+};
+
+unique_ptr<HTTPClient> SteeredUtil::InitializeClient(HTTPParams &, const string &) {
+	return make_uniq<SteeredClient>(*this);
+}
+
+unique_ptr<HTTPResponse> StatusResponse(HTTPStatusCode status) {
+	auto response = make_uniq<HTTPResponse>(status);
+	response->success = false;
+	return response;
+}
+
+//! The error a throttling server produces once a handler has turned its response into an exception
+ErrorData ThrottleError() {
+	HTTPResponse response(HTTPStatusCode::TooManyRequests_429);
+	response.headers.Insert("Retry-After", "5");
+	HTTPException throttled(response, "Request returned HTTP 429");
+	return ErrorData(throttled);
+}
+
+} // namespace
+
+TEST_CASE("HTTP deferred retry initialization failure completes the request", "[api]") {
+	SteeredUtil http_util;
+	HTTPParams params(http_util);
+	params.retries = 1;
+	HTTPHeaders headers;
+	GetRequestInfo request("http://example.com/file", headers, params, nullptr, nullptr);
+	unique_ptr<HTTPClient> client = make_uniq<SteeredClient>(http_util);
+
+	idx_t completions = 0;
+	bool reported_error = false;
+	http_util.Send(request, client, HTTPExecutionMode::DEFERRABLE,
+	               [&](unique_ptr<HTTPResponse> response, ErrorData error) {
+		               completions++;
+		               reported_error = error.HasError();
+	               });
+
+	// the retry cannot get a client, and an accepted request still has to complete
+	http_util.fail_init = true;
+	http_util.Complete(StatusResponse(HTTPStatusCode::InternalServerError_500), ErrorData());
+	REQUIRE(completions == 1);
+	REQUIRE(reported_error);
+	REQUIRE(http_util.waits == 0);
+}
+
+namespace {
+
+//! A client with no asynchronous transport whose first attempt throws, as a dropped socket does
+class ThrowOnceClient : public StubClient {
+public:
+	explicit ThrowOnceClient(idx_t &attempts) : attempts(attempts) {
+	}
+
+	unique_ptr<HTTPResponse> Get(GetRequestInfo &) override {
+		attempts++;
+		if (attempts == 1) {
+			throw IOException("connection reset");
+		}
+		auto response = make_uniq<HTTPResponse>(HTTPStatusCode::OK_200);
+		response->success = true;
+		return response;
+	}
+
+private:
+	idx_t &attempts;
+};
+
+class ThrowOnceUtil : public HTTPUtil {
+public:
+	unique_ptr<HTTPClient> InitializeClient(HTTPParams &, const string &) override {
+		return make_uniq<ThrowOnceClient>(attempts);
+	}
+
+	idx_t attempts = 0;
+};
+
+} // namespace
+
+TEST_CASE("HTTP deferred request retries a transport that throws", "[api]") {
+	ThrowOnceUtil http_util;
+	HTTPParams params(http_util);
+	params.retries = 1;
+	params.retry_wait_ms = 0;
+	HTTPHeaders headers;
+	GetRequestInfo request("http://example.com/file", headers, params, nullptr, nullptr);
+
+	idx_t completions = 0;
+	bool succeeded = false;
+	unique_ptr<HTTPClient> client = make_uniq<ThrowOnceClient>(http_util.attempts);
+	auto state = http_util.Send(request, client, HTTPExecutionMode::DEFERRABLE,
+	                            [&](unique_ptr<HTTPResponse> response, ErrorData error) {
+		                            completions++;
+		                            succeeded = response && response->success;
+	                            });
+
+	// the throw is an attempt like any other, so the retry that the blocking path would make happens here too
+	REQUIRE(state == HTTPRequestState::COMPLETED);
+	REQUIRE(completions == 1);
+	REQUIRE(succeeded);
+	REQUIRE(http_util.attempts == 2);
+}
+
+TEST_CASE("HTTP deferred error keeps its status, Retry-After and type", "[api]") {
+	SteeredUtil http_util;
+	HTTPParams params(http_util);
+	params.retries = 1;
+	HTTPHeaders headers;
+	GetRequestInfo request("http://example.com/file", headers, params, nullptr, nullptr);
+	unique_ptr<HTTPClient> client = make_uniq<SteeredClient>(http_util);
+
+	idx_t completions = 0;
+	ExceptionType reported_type = ExceptionType::INVALID;
+	http_util.Send(request, client, HTTPExecutionMode::DEFERRABLE,
+	               [&](unique_ptr<HTTPResponse> response, ErrorData error) {
+		               completions++;
+		               reported_type = error.Type();
+	               });
+
+	// a 429 is a throttle status even when a handler folded it into an exception, so it earns the extra
+	// retries and the Retry-After the response carried
+	http_util.Complete(nullptr, ThrottleError());
+	REQUIRE(http_util.waits == 1);
+	// Retry-After is 5s, and the jitter only ever subtracts half of it
+	REQUIRE(http_util.last_delay_ms >= 2500);
+	REQUIRE(http_util.last_delay_ms <= 5000);
+
+	// one configured retry plus five throttle retries, so seven attempts in total
+	while (http_util.attempts < 7) {
+		http_util.FireTimer();
+		http_util.Complete(nullptr, ThrottleError());
+	}
+	REQUIRE(completions == 1);
+	REQUIRE(reported_type == ExceptionType::HTTP);
+}
+
+TEST_CASE("HTTP deferred retry bypasses the cache after a transport failure", "[api]") {
+	SteeredUtil http_util;
+	HTTPParams params(http_util);
+	params.retries = 2;
+	HTTPHeaders headers;
+	GetRequestInfo request("http://example.com/file", headers, params, nullptr, nullptr);
+	unique_ptr<HTTPClient> client = make_uniq<SteeredClient>(http_util);
+
+	http_util.Send(request, client, HTTPExecutionMode::DEFERRABLE, [](unique_ptr<HTTPResponse>, ErrorData) {});
+
+	// an attempt that produced no response failed in the transport, which must not be reused
+	http_util.Complete(nullptr, ErrorData(IOException("connection reset")));
+	REQUIRE(http_util.last_cache_policy == HTTPClientCachePolicy::BYPASS_CACHE);
+
+	// a server that answered leaves the transport intact, exactly as the synchronous path decides
+	http_util.last_cache_policy = HTTPClientCachePolicy::BYPASS_CACHE;
+	http_util.FireTimer();
+	http_util.Complete(StatusResponse(HTTPStatusCode::InternalServerError_500), ErrorData());
+	REQUIRE(http_util.last_cache_policy == HTTPClientCachePolicy::DEFAULT);
+}
+
+TEST_CASE("HTTP completion that throws is not invoked a second time", "[api]") {
+	SteeredUtil http_util;
+	HTTPParams params(http_util);
+	params.retries = 0;
+	HTTPHeaders headers;
+	GetRequestInfo request("http://example.com/file", headers, params, nullptr, nullptr);
+	request.try_request = true;
+	unique_ptr<HTTPClient> client = make_uniq<SteeredClient>(http_util);
+
+	idx_t completions = 0;
+	http_util.Send(request, client, HTTPExecutionMode::DEFERRABLE,
+	               [&](unique_ptr<HTTPResponse> response, ErrorData error) {
+		               completions++;
+		               throw IOException("the caller could not take the result");
+	               });
+
+	// the throw belongs to the caller, and it does not earn them a second completion
+	REQUIRE_THROWS(http_util.Complete(StatusResponse(HTTPStatusCode::InternalServerError_500), ErrorData()));
+	REQUIRE(completions == 1);
+}
+
+TEST_CASE("HTTP deferred response carries the request url", "[api]") {
+	SteeredUtil http_util;
+	HTTPParams params(http_util);
+	HTTPHeaders headers;
+	GetRequestInfo request("http://example.com/file", headers, params, nullptr, nullptr);
+	unique_ptr<HTTPClient> client = make_uniq<SteeredClient>(http_util);
+
+	string reported_url;
+	http_util.Send(request, client, HTTPExecutionMode::DEFERRABLE,
+	               [&](unique_ptr<HTTPResponse> response, ErrorData error) {
+		               reported_url = response ? response->url : string();
+	               });
+
+	auto response = make_uniq<HTTPResponse>(HTTPStatusCode::OK_200);
+	response->success = true;
+	http_util.Complete(std::move(response), ErrorData());
+	REQUIRE(reported_url == request.url);
 }


### PR DESCRIPTION
Refactor `HTTPUtil` to allow override of `HTTPUtil::Wait`, and restructure code around retries.
Add a new function, `Send`, that is currently always implemented as `SendRequest(...); callback(...);`, but allow whoever overrides `HTTPUtil` to provide actual externally driven async network requests.

This would, together with the connected, but independent PR at https://github.com/duckdb/duckdb/pull/25089, to allow embedders such as duckdb-wasm to experiment with externally driven (in this case the JS event loop) proper async network requests to work also in the single threaded case.

Plan would be to add this callbacks, allowing extensions to experiment with this (at their risk!), default path for `httpfs` provided stack will stay syncronous.