### PR TITLE
Decouple the sqllogictest runner from Catch behind a TestReporter

### DIFF
--- a/test/helpers/CMakeLists.txt
+++ b/test/helpers/CMakeLists.txt
@@ -2,6 +2,6 @@ add_definitions(-DDUCKDB_ROOT_DIRECTORY="${PROJECT_SOURCE_DIR}"
                 -DDUCKDB_BUILD_DIRECTORY="${PROJECT_BINARY_DIR}")
 
 set(DUCKDB_TEST_HELPERS_UNITS test_helpers.cpp capi_tester.cpp pid.cpp
-                              test_config.cpp)
+                              test_config.cpp test_reporter.cpp)
 
 add_library(test_helpers STATIC ${DUCKDB_TEST_HELPERS_UNITS})

--- a/test/helpers/test_helpers.cpp
+++ b/test/helpers/test_helpers.cpp
@@ -1,5 +1,5 @@
 // #define CATCH_CONFIG_RUNNER
-#include "catch.hpp"
+#include "test_reporter.hpp"
 
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/path.hpp"
@@ -383,7 +383,7 @@ static string ResolveTestId() {
 	}
 	string name;
 	try {
-		name = Catch::getResultCapture().getCurrentTestName();
+		name = TestReporter::Get().CurrentTestName();
 	} catch (...) {
 		name = "";
 	}

--- a/test/helpers/test_reporter.cpp
+++ b/test/helpers/test_reporter.cpp
@@ -1,0 +1,44 @@
+#include "test_reporter.hpp"
+
+#include "duckdb/common/string_util.hpp"
+
+namespace duckdb {
+
+//! Reporter used when no driver installed one: failures become exceptions, everything else is
+//! tallied on the reporter itself. This is what the unittester extension runs on.
+static TestReporter default_reporter;
+static TestReporter *active_reporter = &default_reporter;
+
+void TestReporter::Fail(const string &message, const string &file, idx_t line) {
+	throw TestFailureException(message, file, line);
+}
+
+void TestReporter::Skip(const string &reason) {
+	skip_reason = reason;
+}
+
+void TestReporter::Assertion() {
+	assertion_count++;
+}
+
+string TestReporter::CurrentTestName() {
+	return string();
+}
+
+void TestReporter::Require(bool condition, const char *expression) {
+	if (!condition) {
+		Fail(StringUtil::Format("REQUIRE(%s) failed", expression));
+		return;
+	}
+	Assertion();
+}
+
+TestReporter &TestReporter::Get() {
+	return *active_reporter;
+}
+
+void TestReporter::Set(optional_ptr<TestReporter> reporter) {
+	active_reporter = reporter ? reporter.get() : &default_reporter;
+}
+
+} // namespace duckdb

--- a/test/include/test_reporter.hpp
+++ b/test/include/test_reporter.hpp
@@ -1,0 +1,75 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// test_reporter.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/atomic.hpp"
+#include "duckdb/common/optional_ptr.hpp"
+#include "duckdb/common/string.hpp"
+#include "duckdb/common/numeric_utils.hpp"
+#include "duckdb/common/types.hpp"
+
+namespace duckdb {
+
+//! Thrown by TestReporter::Fail to abort the running test. Deliberately NOT derived from
+//! std::exception: the test runner catches std::exception in many places to turn a failing query
+//! into a test result, and a verdict must never be swallowed there. Mirrors how Catch's own
+//! TestFailureException escapes such handlers.
+struct TestFailureException {
+	TestFailureException(string message_p, string file_p, idx_t line_p)
+	    : message(std::move(message_p)), file(std::move(file_p)), line(line_p) {
+	}
+
+	string message;
+	//! Location of the failing command in the .test script ("" when the failure has no script line)
+	string file;
+	idx_t line;
+};
+
+//! Sink for the verdicts the sqllogictest runner produces. The runner reports through this
+//! interface instead of calling a test framework directly, so the same runner can be driven by the
+//! Catch-based unittest binary or in-process (the unittester extension).
+class TestReporter {
+public:
+	virtual ~TestReporter() = default;
+
+	//! Abort the currently running test with a failure. Never returns. `file`/`line` locate the
+	//! failing command in the .test script; they are empty when the failure has no script line.
+	virtual void Fail(const string &message, const string &file, idx_t line);
+	void Fail(const string &message) {
+		Fail(message, string(), 0);
+	}
+	//! Record why the current test is skipped. Does NOT abort - callers stop on their own.
+	virtual void Skip(const string &reason);
+	//! Record one passed assertion.
+	virtual void Assertion();
+	//! Name of the test being executed, or an empty string if the driver tracks none.
+	virtual string CurrentTestName();
+
+	//! Fail unless the condition holds.
+	void Require(bool condition, const char *expression);
+
+	//! The reporter driving the current process.
+	static TestReporter &Get();
+	//! Install a reporter; passing nullptr restores the default one.
+	static void Set(optional_ptr<TestReporter> reporter);
+
+public:
+	//! Assertions recorded so far. Written from the worker threads of a concurrentloop.
+	atomic<idx_t> assertion_count {0};
+	//! Reason passed to the last Skip call.
+	string skip_reason;
+};
+
+} // namespace duckdb
+
+#define TEST_FAIL(message) duckdb::TestReporter::Get().Fail(message)
+#define TEST_FAIL_LINE(file, line, message)                                                                            \
+	duckdb::TestReporter::Get().Fail(message, file, duckdb::NumericCast<duckdb::idx_t>(line))
+#define TEST_REQUIRE(condition) duckdb::TestReporter::Get().Require((condition) ? true : false, #condition)
+#define TEST_ASSERTION()        duckdb::TestReporter::Get().Assertion()

--- a/test/sqlite/CMakeLists.txt
+++ b/test/sqlite/CMakeLists.txt
@@ -4,8 +4,13 @@ add_definitions(-DDUCKDB_ROOT_DIRECTORY="${PROJECT_SOURCE_DIR}"
                 -DDUCKDB_BUILD_DIRECTORY="${PROJECT_BINARY_DIR}")
 
 set(SQLITE_TEST_RUNNER_SOURCES
-    result_helper.cpp sqllogic_command.cpp sqllogic_test_runner.cpp
-    sqllogic_parser.cpp test_sqllogictest.cpp sqllogic_test_logger.cpp)
+    result_helper.cpp
+    sqllogic_command.cpp
+    sqllogic_test_runner.cpp
+    sqllogic_parser.cpp
+    test_sqllogictest.cpp
+    sqllogic_test_logger.cpp
+    catch_test_reporter.cpp)
 
 add_library_unity(test_sqlite OBJECT ${SQLITE_TEST_RUNNER_SOURCES})
 set(UNITTEST_OBJECT_FILES

--- a/test/sqlite/catch_test_reporter.cpp
+++ b/test/sqlite/catch_test_reporter.cpp
@@ -1,0 +1,30 @@
+#include "catch_test_reporter.hpp"
+
+#include "catch.hpp"
+
+namespace duckdb {
+
+void CatchTestReporter::Fail(const string &message, const string &file, idx_t line) {
+	// FAIL/FAIL_LINE throw Catch's own TestFailureException, so this never returns.
+	if (file.empty()) {
+		FAIL(message);
+	}
+	FAIL_LINE(file, NumericCast<int>(line), message);
+}
+
+void CatchTestReporter::Skip(const string &reason) {
+	TestReporter::Skip(reason);
+	Catch::getResultCapture().skipTestDuringRun(reason);
+}
+
+void CatchTestReporter::Assertion() {
+	TestReporter::Assertion();
+	// keep Catch's assertion tally moving
+	REQUIRE(true);
+}
+
+string CatchTestReporter::CurrentTestName() {
+	return Catch::getResultCapture().getCurrentTestName();
+}
+
+} // namespace duckdb

--- a/test/sqlite/catch_test_reporter.hpp
+++ b/test/sqlite/catch_test_reporter.hpp
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// catch_test_reporter.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "test_reporter.hpp"
+
+namespace duckdb {
+
+//! Routes the sqllogictest runner's verdicts into the Catch session that the unittest binary runs.
+//! Only the unittest binary links this; the unittester extension uses the default reporter.
+class CatchTestReporter : public TestReporter {
+public:
+	void Fail(const string &message, const string &file, idx_t line) override;
+	using TestReporter::Fail;
+	void Skip(const string &reason) override;
+	void Assertion() override;
+	string CurrentTestName() override;
+};
+
+} // namespace duckdb

--- a/test/sqlite/result_helper.cpp
+++ b/test/sqlite/result_helper.cpp
@@ -1,6 +1,5 @@
 #include "result_helper.hpp"
 
-#include "catch.hpp"
 #include "duckdb/common/crypto/md5.hpp"
 #include "duckdb/parser/qualified_name.hpp"
 #include "re2/re2.h"
@@ -9,16 +8,16 @@
 #include "termcolor.hpp"
 #include "test_helpers.hpp"
 #include "test_config.hpp"
+#include "test_reporter.hpp"
 
 #include <thread>
 
-// PROTOTYPE: shadow Catch's SKIP_TEST to also emit the parseable skip marker.
-// Skip sites here live in TestResultHelper, which holds a `runner` reference.
-#undef SKIP_TEST
+// Skips here also emit the parseable marker before recording the skip with the reporter.
+// The skip sites live in TestResultHelper, which holds a `runner` reference.
 #define SKIP_TEST(reason)                                                                                              \
 	do {                                                                                                               \
 		duckdb::SQLLogicTestLogger::PrintSkip(runner.file_name, (reason));                                             \
-		Catch::getResultCapture().skipTestDuringRun(reason);                                                           \
+		duckdb::TestReporter::Get().Skip(reason);                                                                      \
 	} while (0)
 
 namespace duckdb {
@@ -34,8 +33,9 @@ void TestResultHelper::SortQueryResult(SortStyle sort_style, vector<string> &res
 	}
 	if (result.size() % ncols != 0) {
 		// row-sort failed: result is not row-wise aligned, bail
-		FAIL(StringUtil::Format("Failed to sort query result - result is not aligned. Found %d rows with %d columns",
-		                        result.size(), ncols));
+		TEST_FAIL(
+		    StringUtil::Format("Failed to sort query result - result is not aligned. Found %d rows with %d columns",
+		                       result.size(), ncols));
 		return;
 	}
 	// row-oriented sorting
@@ -235,9 +235,7 @@ bool TestResultHelper::CheckQueryResult(const Query &query, ExecuteContext &cont
 				if (!success) {
 					break;
 				}
-				// we do this just to increment the assertion counter
-				string success_log = StringUtil::Format("CheckQueryResult: %s:%d", query.file_name, query.query_line);
-				REQUIRE(success_log.c_str());
+				TEST_ASSERTION();
 
 				current_column++;
 				if (current_column == expected_column_count) {
@@ -288,7 +286,7 @@ bool TestResultHelper::CheckQueryResult(const Query &query, ExecuteContext &cont
 			});
 			return false;
 		}
-		REQUIRE(!hash_compare_error);
+		TEST_REQUIRE(!hash_compare_error);
 	}
 	return true;
 }
@@ -340,9 +338,7 @@ bool TestResultHelper::CheckStatementResult(const Statement &statement, ExecuteC
 						return false;
 					}
 				}
-				string success_log =
-				    StringUtil::Format("CheckStatementResult: %s:%d", statement.file_name, statement.query_line);
-				REQUIRE(success_log.c_str());
+				TEST_ASSERTION();
 				return true;
 			}
 		}
@@ -359,13 +355,7 @@ bool TestResultHelper::CheckStatementResult(const Statement &statement, ExecuteC
 		}
 		return false;
 	}
-	if (error) {
-		REQUIRE(false);
-	} else {
-		string success_log =
-		    StringUtil::Format("CheckStatementResult: %s:%d", statement.file_name, statement.query_line);
-		REQUIRE(success_log.c_str());
-	}
+	TEST_ASSERTION();
 	return true;
 }
 

--- a/test/sqlite/result_helper.cpp
+++ b/test/sqlite/result_helper.cpp
@@ -12,14 +12,6 @@
 
 #include <thread>
 
-// Skips here also emit the parseable marker before recording the skip with the reporter.
-// The skip sites live in TestResultHelper, which holds a `runner` reference.
-#define SKIP_TEST(reason)                                                                                              \
-	do {                                                                                                               \
-		duckdb::SQLLogicTestLogger::PrintSkip(runner.file_name, (reason));                                             \
-		duckdb::TestReporter::Get().Skip(reason);                                                                      \
-	} while (0)
-
 namespace duckdb {
 
 void TestResultHelper::SortQueryResult(SortStyle sort_style, vector<string> &result, idx_t ncols) {
@@ -401,7 +393,7 @@ vector<string> TestResultHelper::LoadResultFromFile(string fname, vector<string>
 bool TestResultHelper::SkipErrorMessage(const string &message) {
 	for (auto &error_message : runner.ignore_error_messages) {
 		if (StringUtil::Contains(message, error_message)) {
-			SKIP_TEST(string("skip on error_message matching '") + error_message + string("'"));
+			SQLLogicTestLogger::ReportSkip(runner.file_name, "skip on error_message matching '" + error_message + "'");
 			return true;
 		}
 	}

--- a/test/sqlite/sqllogic_command.cpp
+++ b/test/sqlite/sqllogic_command.cpp
@@ -13,7 +13,7 @@
 #include "test_helpers.hpp"
 #include "test_config.hpp"
 #include "sqllogic_test_logger.hpp"
-#include "catch.hpp"
+#include "test_reporter.hpp"
 
 #include <algorithm>
 #include <chrono>
@@ -40,7 +40,7 @@ static Connection &GetConnection(SQLLogicTestRunner &runner, DuckDB &db,
 		if (!init_cmd.empty()) {
 			auto res = con->Query(runner.ReplaceKeywords(init_cmd));
 			if (res->HasError()) {
-				FAIL("Startup queries provided via on_new_connection failed: " + res->GetError());
+				TEST_FAIL("Startup queries provided via on_new_connection failed: " + res->GetError());
 			}
 		}
 		auto &res = *con;
@@ -49,7 +49,7 @@ static Connection &GetConnection(SQLLogicTestRunner &runner, DuckDB &db,
 		return res;
 	}
 	if (!RefersToSameObject(*entry->second->context->db, *db.instance)) {
-		FAIL("Named connection has been started with different target databases");
+		TEST_FAIL("Named connection has been started with different target databases");
 	}
 	return *entry->second;
 }
@@ -59,7 +59,7 @@ static Connection &GetConnection(SQLLogicTestRunner &runner,
 	if (StringUtil::Contains(con_name, ":")) {
 		auto splits = StringUtil::Split(con_name, ":");
 		if (splits.size() != 2) {
-			FAIL("Expected either connection name or database:connection");
+			TEST_FAIL("Expected either connection name or database:connection");
 		}
 		auto &db_name = splits[0];
 		auto &con_name = splits[1];
@@ -70,7 +70,7 @@ static Connection &GetConnection(SQLLogicTestRunner &runner,
 		}
 		// no database - create it
 		if (runner.named_connection_map.find(con_name) != runner.named_connection_map.end()) {
-			FAIL("Database did not exist, but named connection already existed");
+			TEST_FAIL("Database did not exist, but named connection already existed");
 		}
 		auto result = runner.CreateDatabase(":memory:", true);
 		auto &result_con = *result.con;
@@ -102,7 +102,7 @@ Connection &Command::CommandConnection(ExecuteContext &context) const {
 					if (context.is_parallel) {
 						throw std::runtime_error(error_msg);
 					} else {
-						FAIL(error_msg);
+						TEST_FAIL(error_msg);
 					}
 				}
 			}
@@ -361,7 +361,7 @@ void ResetLabel::ExecuteInternal(ExecuteContext &context) const {
 		auto it = map.find(query_label);
 		//! should we allow this to be missing at all?
 		if (it == map.end()) {
-			FAIL_LINE(file_name, query_line, 0);
+			TEST_FAIL_LINE(file_name, query_line, "");
 		}
 		map.erase(it);
 	});
@@ -693,9 +693,9 @@ void LoopCommand::ExecuteInternal(ExecuteContext &context) const {
 				runner.test_failure_locator =
 				    StringUtil::Format("%s:%d", execute_context.error_file, execute_context.error_line);
 				if (!execute_context.error_message.empty()) {
-					FAIL(execute_context.error_message);
+					TEST_FAIL(execute_context.error_message);
 				} else {
-					FAIL_LINE(execute_context.error_file, execute_context.error_line, 0);
+					TEST_FAIL_LINE(execute_context.error_file, execute_context.error_line, "");
 				}
 			}
 		}
@@ -768,7 +768,7 @@ void Query::ExecuteInternal(ExecuteContext &context) const {
 			context.error_line = query_line;
 		} else {
 			runner.test_failure_locator = StringUtil::Format("%s:%d", file_name, query_line);
-			FAIL_LINE(file_name, query_line, 0);
+			TEST_FAIL_LINE(file_name, query_line, "");
 		}
 	}
 }
@@ -883,7 +883,7 @@ void Statement::ExecuteInternal(ExecuteContext &context) const {
 			context.error_line = query_line;
 		} else {
 			runner.test_failure_locator = StringUtil::Format("%s:%d", file_name, query_line);
-			FAIL_LINE(file_name, query_line, 0);
+			TEST_FAIL_LINE(file_name, query_line, "");
 		}
 	}
 }
@@ -944,7 +944,7 @@ void LoadCommand::ExecuteInternal(ExecuteContext &context) const {
 			} catch (std::exception &ex) {
 				ErrorData err(ex);
 				SQLLogicTestLogger::LoadDatabaseFail(runner.file_name, dbpath, err.Message());
-				FAIL();
+				TEST_FAIL("");
 			}
 		}
 	}

--- a/test/sqlite/sqllogic_parser.cpp
+++ b/test/sqlite/sqllogic_parser.cpp
@@ -1,5 +1,5 @@
 #include "sqllogic_parser.hpp"
-#include "catch.hpp"
+#include "test_reporter.hpp"
 
 #include <fstream>
 
@@ -191,7 +191,7 @@ string SQLLogicParser::ExtractExpectedError(ExpectedResult expected_result, bool
 void SQLLogicParser::FailRecursive(const string &msg, vector<ExceptionFormatValue> &values) {
 	auto error_message =
 	    file_name + ":" + to_string(current_line + 1) + ": " + ExceptionFormatValue::Format(msg, values);
-	FAIL(error_message.c_str());
+	TEST_FAIL(error_message);
 }
 
 SQLLogicToken SQLLogicParser::Tokenize() {

--- a/test/sqlite/sqllogic_test_logger.cpp
+++ b/test/sqlite/sqllogic_test_logger.cpp
@@ -4,6 +4,7 @@
 #include "result_helper.hpp"
 #include "sqllogic_test_runner.hpp"
 #include "test_helpers.hpp"
+#include "test_reporter.hpp"
 #include "duckdb/common/box_renderer.hpp"
 #include "duckdb/common/box_renderer_context.hpp"
 
@@ -53,6 +54,11 @@ void SQLLogicTestLogger::PrintSkip(const string &file_name, const string &reason
 	// (which survives subprocess capture) per skipped test, so skips are attributable
 	// even inside a batched invocation.
 	std::cerr << "[SKIP_TEST] " << file_name << " :: " << reason << "\n";
+}
+
+void SQLLogicTestLogger::ReportSkip(const string &file_name, const string &reason) {
+	PrintSkip(file_name, reason);
+	TestReporter::Get().Skip(reason);
 }
 
 void SQLLogicTestLogger::PrintSummaryHeader(const std::string &file_name, idx_t query_line) {

--- a/test/sqlite/sqllogic_test_logger.hpp
+++ b/test/sqlite/sqllogic_test_logger.hpp
@@ -24,6 +24,8 @@ public:
 
 	static void Log(const string &annotation, const string &str);
 	static void PrintSkip(const string &file_name, const string &reason);
+	//! Emit the parseable skip marker and record the skip with the reporter
+	static void ReportSkip(const string &file_name, const string &reason);
 	void PrintExpectedResult(const vector<string> &values, idx_t columns, bool row_wise);
 	static void PrintLineSep();
 	static void PrintHeader(string header);

--- a/test/sqlite/sqllogic_test_runner.cpp
+++ b/test/sqlite/sqllogic_test_runner.cpp
@@ -1,7 +1,6 @@
 
 #include "sqllogic_test_runner.hpp"
 
-#include "catch.hpp"
 #include "duckdb/common/file_open_flags.hpp"
 #include "duckdb/common/json_document.hpp"
 #include "duckdb/common/virtual_file_system.hpp"
@@ -13,6 +12,7 @@
 #include "debug_fs_extension.hpp"
 #include "sqllogic_parser.hpp"
 #include "test_helpers.hpp"
+#include "test_reporter.hpp"
 #include "sqllogic_test_logger.hpp"
 #include "duckdb/common/random_engine.hpp"
 
@@ -20,14 +20,13 @@
 #include DUCKDB_EXTENSION_HEADER
 #endif
 
-// PROTOTYPE: shadow Catch's SKIP_TEST so every skip also emits a stable, parseable
-// marker (consumed by the pytest collector) before recording the skip with Catch.
-// `file_name` is the runner's member, in scope at all skip sites in this TU.
-#undef SKIP_TEST
+// Every skip also emits a stable, parseable marker (consumed by the pytest collector) before
+// recording the skip with the reporter. `file_name` is the runner's member, in scope at all skip
+// sites in this TU.
 #define SKIP_TEST(reason)                                                                                              \
 	do {                                                                                                               \
 		duckdb::SQLLogicTestLogger::PrintSkip(file_name, (reason));                                                    \
-		Catch::getResultCapture().skipTestDuringRun(reason);                                                           \
+		duckdb::TestReporter::Get().Skip(reason);                                                                      \
 	} while (0)
 
 namespace duckdb {
@@ -273,7 +272,7 @@ NewDatabaseConnection SQLLogicTestRunner::CreateDatabase(const string &db_path, 
 	} catch (std::exception &ex) {
 		ErrorData err(ex);
 		SQLLogicTestLogger::LoadDatabaseFail(file_name, db_path, err.Message());
-		FAIL();
+		TEST_FAIL("");
 	}
 	result.con = ConnectToDatabase(*result.db);
 	// load any previously loaded extensions again
@@ -322,7 +321,7 @@ unique_ptr<Connection> SQLLogicTestRunner::ConnectToDatabase(DuckDB &db_ref) {
 		test_config.ProcessPath(init_cmd, file_name);
 		auto res = result->Query(ReplaceKeywords(init_cmd));
 		if (res->HasError()) {
-			FAIL("Startup queries provided via on_init failed: " + res->GetError());
+			TEST_FAIL("Startup queries provided via on_init failed: " + res->GetError());
 		}
 	}
 	return result;
@@ -350,8 +349,8 @@ string SQLLogicTestRunner::ReplaceLoopIterator(string text, string loop_iterator
 		auto name_splits = StringUtil::Split(loop_iterator_name, ",");
 		auto replacement_splits = StringUtil::Split(replacement, ",");
 		if (name_splits.size() != replacement_splits.size()) {
-			FAIL("foreach loop: number of commas in loop iterator (" + loop_iterator_name +
-			     ") does not match number of commas in replacement (" + replacement + ")");
+			TEST_FAIL("foreach loop: number of commas in loop iterator (" + loop_iterator_name +
+			          ") does not match number of commas in replacement (" + replacement + ")");
 		}
 		for (idx_t i = 0; i < name_splits.size(); i++) {
 			StringReplaceLoopIterator(text, name_splits[i], replacement_splits[i], file_name);
@@ -776,7 +775,7 @@ void SQLLogicTestRunner::ExecuteFile(string script) {
 	SQLLogicParser parser;
 	bool success = parser.OpenFile(script);
 	if (!success) {
-		FAIL("Could not find test script '" + script + "'. Perhaps run `make sqlite`. ");
+		TEST_FAIL("Could not find test script '" + script + "'. Perhaps run `make sqlite`. ");
 	}
 	ExecuteInternal(parser, script);
 }
@@ -785,7 +784,7 @@ void SQLLogicTestRunner::ExecuteStream(std::istream &input, const string &source
 	SQLLogicParser parser;
 	bool success = parser.OpenStream(input, source_name);
 	if (!success) {
-		FAIL("Could not read sqllogictest stream '" + source_name + "'");
+		TEST_FAIL("Could not read sqllogictest stream '" + source_name + "'");
 	}
 	ExecuteInternal(parser, source_name);
 }
@@ -828,7 +827,7 @@ void SQLLogicTestRunner::ExecuteInternal(SQLLogicParser &parser, const string &s
 	if (!init_sqllogic.empty()) {
 		SQLLogicParser init_parser;
 		if (!init_parser.OpenFile(init_sqllogic)) {
-			FAIL("Could not find init_sqllogic '" + init_sqllogic + "'");
+			TEST_FAIL("Could not find init_sqllogic '" + init_sqllogic + "'");
 		}
 		ExecuteScript(init_parser, script);
 	}
@@ -839,7 +838,7 @@ void SQLLogicTestRunner::ExecuteInternal(SQLLogicParser &parser, const string &s
 	if (!cleanup_sqllogic.empty()) {
 		SQLLogicParser cleanup_parser;
 		if (!cleanup_parser.OpenFile(cleanup_sqllogic)) {
-			FAIL("Could not find cleanup_sqllogic '" + cleanup_sqllogic + "'");
+			TEST_FAIL("Could not find cleanup_sqllogic '" + cleanup_sqllogic + "'");
 		}
 		ExecuteScript(cleanup_parser, script);
 	}

--- a/test/sqlite/sqllogic_test_runner.cpp
+++ b/test/sqlite/sqllogic_test_runner.cpp
@@ -20,15 +20,6 @@
 #include DUCKDB_EXTENSION_HEADER
 #endif
 
-// Every skip also emits a stable, parseable marker (consumed by the pytest collector) before
-// recording the skip with the reporter. `file_name` is the runner's member, in scope at all skip
-// sites in this TU.
-#define SKIP_TEST(reason)                                                                                              \
-	do {                                                                                                               \
-		duckdb::SQLLogicTestLogger::PrintSkip(file_name, (reason));                                                    \
-		duckdb::TestReporter::Get().Skip(reason);                                                                      \
-	} while (0)
-
 namespace duckdb {
 
 mutex SQLLogicTestRunner::skip_reason_lock;
@@ -118,7 +109,7 @@ void SQLLogicTestRunner::SkipTest(const string &reason) {
 	// Catch wrapper emit the single end {status:"skip-requirement"} terminal.
 	test_skipped_requirement = true;
 	test_skip_reason = reason;
-	SKIP_TEST(reason);
+	SQLLogicTestLogger::ReportSkip(file_name, reason);
 }
 
 string SQLLogicTestRunner::GetSkipReasonSummary() {

--- a/test/unittest.cpp
+++ b/test/unittest.cpp
@@ -6,6 +6,7 @@
 
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/string_util.hpp"
+#include "sqlite/catch_test_reporter.hpp"
 #include "sqlite/sqllogic_test_logger.hpp"
 #include "sqlite/sqllogic_test_runner.hpp"
 #include "test_helpers.hpp"
@@ -65,6 +66,10 @@ static bool TryReadExactSQLLogicTestFilter(const vector<string> &input_files, ve
 
 int main(int argc_in, char *argv[]) {
 	string test_directory = DUCKDB_ROOT_DIRECTORY;
+
+	// route the sqllogictest runner's verdicts into the Catch session
+	static CatchTestReporter catch_reporter;
+	TestReporter::Set(catch_reporter);
 
 	auto &test_config = TestConfiguration::Get();
 	try {


### PR DESCRIPTION
The runner called Catch's FAIL/FAIL_LINE/REQUIRE/SKIP_TEST and getCurrentTestName directly, which tied it to the unittest binary's Catch session. Route those through a TestReporter interface instead: the unittest binary installs a Catch-backed implementation, and the default implementation turns a failure into a TestFailureException (deliberately not a std::exception, so the runner's own handlers cannot swallow a verdict).

This leaves the runner usable outside a Catch session, which is what a loadable test-runner extension needs.