### PR TITLE
Fix incorrect column expansion

### DIFF
--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -618,7 +618,8 @@ private:
 	                                   vector<unique_ptr<ParsedExpression>> &replacements, StarExpression &star,
 	                                   optional_ptr<duckdb_re2::RE2> regex);
 	void BindWhereStarExpression(unique_ptr<ParsedExpression> &expr);
-	void BindFilterStarExpressions(ParsedExpression &expr);
+	void NormalizeFilterStarExpression(ParsedExpression &expr);
+	void NormalizeFilterStarExpressions(SelectNode &statement);
 
 	//! If only a schema name is provided (e.g. "a.b") then figure out if "a" is a schema or a catalog name
 	void BindSchemaOrCatalog(Identifier &catalog_name, Identifier &schema_name);

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -618,6 +618,7 @@ private:
 	                                   vector<unique_ptr<ParsedExpression>> &replacements, StarExpression &star,
 	                                   optional_ptr<duckdb_re2::RE2> regex);
 	void BindWhereStarExpression(unique_ptr<ParsedExpression> &expr);
+	void BindFilterStarExpressions(ParsedExpression &expr);
 
 	//! If only a schema name is provided (e.g. "a.b") then figure out if "a" is a schema or a catalog name
 	void BindSchemaOrCatalog(Identifier &catalog_name, Identifier &schema_name);

--- a/src/planner/binder/query_node/bind_select_node.cpp
+++ b/src/planner/binder/query_node/bind_select_node.cpp
@@ -13,6 +13,7 @@
 #include "duckdb/parser/expression/function_expression.hpp"
 #include "duckdb/parser/expression/star_expression.hpp"
 #include "duckdb/parser/expression/subquery_expression.hpp"
+#include "duckdb/parser/expression/window_expression.hpp"
 #include "duckdb/parser/parsed_expression_iterator.hpp"
 #include "duckdb/parser/query_node/select_node.hpp"
 #include "duckdb/parser/tableref/basetableref.hpp"
@@ -139,6 +140,7 @@ void Binder::PrepareModifiers(OrderBinder &order_binder, QueryNode &statement, B
 			order_binder.SetQueryComponent("DISTINCT ON");
 			auto &order_binders = order_binder.GetBinders();
 			for (auto &distinct_on_target : distinct.distinct_on_targets) {
+				order_binders[0].get().BindFilterStarExpressions(*distinct_on_target);
 				vector<unique_ptr<ParsedExpression>> target_list;
 				order_binders[0].get().ExpandStarExpression(std::move(distinct_on_target), target_list);
 				for (auto &target : target_list) {
@@ -235,6 +237,7 @@ void Binder::PrepareModifiers(OrderBinder &order_binder, QueryNode &statement, B
 				}
 			}
 			for (auto &order_node : order.orders) {
+				order_binders[0].get().BindFilterStarExpressions(*order_node.expression);
 				vector<unique_ptr<ParsedExpression>> order_list;
 				order_binders[0].get().ExpandStarExpression(std::move(order_node.expression), order_list);
 
@@ -447,6 +450,23 @@ void Binder::BindWhereStarExpression(unique_ptr<ParsedExpression> &expr) {
 	}
 }
 
+void Binder::BindFilterStarExpressions(ParsedExpression &expr) {
+	if (expr.GetExpressionClass() == ExpressionClass::FUNCTION) {
+		auto &function = expr.Cast<FunctionExpression>();
+		if (function.Filter()) {
+			BindWhereStarExpression(function.FilterMutable());
+		}
+	} else if (expr.GetExpressionClass() == ExpressionClass::WINDOW) {
+		auto &window = expr.Cast<WindowExpression>();
+		if (window.Filter()) {
+			BindWhereStarExpression(window.FilterMutable());
+		}
+	}
+
+	ParsedExpressionIterator::EnumerateChildren(expr,
+	                                            [&](ParsedExpression &child) { BindFilterStarExpressions(child); });
+}
+
 Identifier Binder::GetExpressionName(const ParsedExpression &expr) {
 	if (!expr.GetAlias().empty()) {
 		return expr.GetAlias();
@@ -471,6 +491,10 @@ BoundStatement Binder::BindSelectNode(SelectNode &statement, BoundStatement from
 	if (statement.sample) {
 		result.from_table.plan =
 		    make_uniq<LogicalSample>(std::move(statement.sample), std::move(result.from_table.plan));
+	}
+
+	for (auto &select_element : statement.select_list) {
+		BindFilterStarExpressions(*select_element);
 	}
 
 	// visit the select list and expand any "*" statements
@@ -513,6 +537,7 @@ BoundStatement Binder::BindSelectNode(SelectNode &statement, BoundStatement from
 	}
 
 	if (statement.qualify) {
+		BindFilterStarExpressions(*statement.qualify);
 		ExpressionBinder::QualifyColumnNames(*this, statement.qualify);
 	}
 
@@ -595,6 +620,7 @@ BoundStatement Binder::BindSelectNode(SelectNode &statement, BoundStatement from
 
 	// bind the HAVING clause, if any
 	if (statement.having) {
+		BindFilterStarExpressions(*statement.having);
 		HavingBinder having_binder(*this, context, result, statement.aggregate_handling);
 		ExpressionBinder::QualifyColumnNames(having_binder, statement.having);
 		result.having = having_binder.Bind(statement.having);

--- a/src/planner/binder/query_node/bind_select_node.cpp
+++ b/src/planner/binder/query_node/bind_select_node.cpp
@@ -140,7 +140,6 @@ void Binder::PrepareModifiers(OrderBinder &order_binder, QueryNode &statement, B
 			order_binder.SetQueryComponent("DISTINCT ON");
 			auto &order_binders = order_binder.GetBinders();
 			for (auto &distinct_on_target : distinct.distinct_on_targets) {
-				order_binders[0].get().BindFilterStarExpressions(*distinct_on_target);
 				vector<unique_ptr<ParsedExpression>> target_list;
 				order_binders[0].get().ExpandStarExpression(std::move(distinct_on_target), target_list);
 				for (auto &target : target_list) {
@@ -237,7 +236,6 @@ void Binder::PrepareModifiers(OrderBinder &order_binder, QueryNode &statement, B
 				}
 			}
 			for (auto &order_node : order.orders) {
-				order_binders[0].get().BindFilterStarExpressions(*order_node.expression);
 				vector<unique_ptr<ParsedExpression>> order_list;
 				order_binders[0].get().ExpandStarExpression(std::move(order_node.expression), order_list);
 
@@ -450,7 +448,7 @@ void Binder::BindWhereStarExpression(unique_ptr<ParsedExpression> &expr) {
 	}
 }
 
-void Binder::BindFilterStarExpressions(ParsedExpression &expr) {
+void Binder::NormalizeFilterStarExpression(ParsedExpression &expr) {
 	if (expr.GetExpressionClass() == ExpressionClass::FUNCTION) {
 		auto &function = expr.Cast<FunctionExpression>();
 		if (function.Filter()) {
@@ -464,7 +462,41 @@ void Binder::BindFilterStarExpressions(ParsedExpression &expr) {
 	}
 
 	ParsedExpressionIterator::EnumerateChildren(expr,
-	                                            [&](ParsedExpression &child) { BindFilterStarExpressions(child); });
+	                                            [&](ParsedExpression &child) { NormalizeFilterStarExpression(child); });
+}
+
+void Binder::NormalizeFilterStarExpressions(SelectNode &statement) {
+	for (auto &select_element : statement.select_list) {
+		NormalizeFilterStarExpression(*select_element);
+	}
+
+	for (auto &modifier : statement.modifiers) {
+		switch (modifier->type) {
+		case ResultModifierType::DISTINCT_MODIFIER: {
+			auto &distinct = modifier->Cast<DistinctModifier>();
+			for (auto &target : distinct.distinct_on_targets) {
+				NormalizeFilterStarExpression(*target);
+			}
+			break;
+		}
+		case ResultModifierType::ORDER_MODIFIER: {
+			auto &order = modifier->Cast<OrderModifier>();
+			for (auto &order_node : order.orders) {
+				NormalizeFilterStarExpression(*order_node.expression);
+			}
+			break;
+		}
+		default:
+			break;
+		}
+	}
+
+	if (statement.having) {
+		NormalizeFilterStarExpression(*statement.having);
+	}
+	if (statement.qualify) {
+		NormalizeFilterStarExpression(*statement.qualify);
+	}
 }
 
 Identifier Binder::GetExpressionName(const ParsedExpression &expr) {
@@ -493,9 +525,9 @@ BoundStatement Binder::BindSelectNode(SelectNode &statement, BoundStatement from
 		    make_uniq<LogicalSample>(std::move(statement.sample), std::move(result.from_table.plan));
 	}
 
-	for (auto &select_element : statement.select_list) {
-		BindFilterStarExpressions(*select_element);
-	}
+	// do this before column expansion to preserve FILTER semantics,
+	// without normalization the enclosing expression would be duplicated once per column
+	NormalizeFilterStarExpressions(statement);
 
 	// visit the select list and expand any "*" statements
 	vector<unique_ptr<ParsedExpression>> new_select_list;
@@ -537,7 +569,6 @@ BoundStatement Binder::BindSelectNode(SelectNode &statement, BoundStatement from
 	}
 
 	if (statement.qualify) {
-		BindFilterStarExpressions(*statement.qualify);
 		ExpressionBinder::QualifyColumnNames(*this, statement.qualify);
 	}
 
@@ -620,7 +651,6 @@ BoundStatement Binder::BindSelectNode(SelectNode &statement, BoundStatement from
 
 	// bind the HAVING clause, if any
 	if (statement.having) {
-		BindFilterStarExpressions(*statement.having);
 		HavingBinder having_binder(*this, context, result, statement.aggregate_handling);
 		ExpressionBinder::QualifyColumnNames(having_binder, statement.having);
 		result.having = having_binder.Bind(statement.having);

--- a/test/sql/filter/test_columns_filter.test
+++ b/test/sql/filter/test_columns_filter.test
@@ -1,0 +1,64 @@
+# name: test/sql/filter/test_columns_filter.test
+# description: Test COLUMNS expansion in aggregate FILTER predicates
+# group: [filter]
+
+query I
+SELECT sum(x) FILTER (WHERE COLUMNS(*) IS NOT NULL)
+FROM (VALUES (1, 10, 100), (2, NULL, 200), (3, 30, NULL)) v(x, a, b);
+----
+1
+
+query I
+SELECT coalesce(sum(x) FILTER (WHERE COLUMNS(*) IS NOT NULL), 0)
+FROM (VALUES (1, 10, 100), (2, NULL, 200), (3, 30, NULL)) v(x, a, b);
+----
+1
+
+query I
+SELECT sum(x) FILTER (WHERE COLUMNS(*) IS NOT NULL) OVER ()
+FROM (VALUES (1, 10, 100), (2, NULL, 200), (3, 30, NULL)) v(x, a, b);
+----
+1
+1
+1
+
+# FILTER star expansion also applies to ORDER BY expressions.
+query II
+SELECT g, sum(x) FILTER (WHERE COLUMNS(*) IS NOT NULL) AS s
+FROM (VALUES (1, 1000, NULL, 1), (1, 1, 1, 1), (2, 100, 1, 1)) v(g, x, a, b)
+GROUP BY g
+ORDER BY sum(x) FILTER (WHERE COLUMNS(*) IS NOT NULL);
+----
+1	1
+2	100
+
+# DISTINCT ON must use the combined filter predicate as one key.
+query II
+SELECT DISTINCT ON (sum(x) FILTER (WHERE COLUMNS(*) IS NOT NULL)) g,
+       sum(x) FILTER (WHERE COLUMNS(*) IS NOT NULL) AS s
+FROM (VALUES (1, 1, 1, NULL), (1, 1, NULL, 1), (2, 1, 1, 1), (2, 1, NULL, NULL)) v(g, x, a, b)
+GROUP BY g
+ORDER BY sum(x) FILTER (WHERE COLUMNS(*) IS NOT NULL) DESC, g;
+----
+2	1
+1	NULL
+
+# FILTER star expansion also applies to HAVING expressions.
+query II
+SELECT g, sum(x) FILTER (WHERE COLUMNS(*) IS NOT NULL) AS s
+FROM (VALUES (1, 1, 1, NULL), (1, 1, NULL, 1), (2, 1, 1, 1), (2, 1, NULL, NULL)) v(g, x, a, b)
+GROUP BY g
+HAVING sum(x) FILTER (WHERE COLUMNS(*) IS NOT NULL) > 0
+ORDER BY g;
+----
+2	1
+
+# FILTER star expansion also applies to QUALIFY window expressions.
+query II
+SELECT g, x
+FROM (VALUES (1, 1, 1, NULL), (1, 1, NULL, 1), (2, 1, 1, 1), (2, 1, NULL, NULL)) v(g, x, a, b)
+QUALIFY sum(x) FILTER (WHERE COLUMNS(*) IS NOT NULL) OVER (PARTITION BY g) > 0
+ORDER BY g, x;
+----
+2	1
+2	1


### PR DESCRIPTION
Resolves https://github.com/duckdblabs/duckdb-internal/issues/10313 by normalizing filter predicates.

Previously the below query would be expanded incorrectly:
```sql
CREATE TABLE v AS VALUES (1,10,100),(2,NULL,200),(3,30,NULL);

SELECT sum(x) FILTER (WHERE COLUMNS(*) IS NOT NULL) FROM  v AS t(x,a,b);

--- rough expanded version
SELECT 
sum(x) FILTER (WHERE x IS NOT NULL), 
sum(x) FILTER (WHERE a IS NOT NULL), 
sum(x) FILTER (WHERE b IS NOT NULL) 
FROM  v AS t(x,a,b);
```

With normalization we now get:
```sql
SELECT sum(x) FILTER ( WHERE 
x IS NOT NULL AND
a IS NOT NULL AND
b IS NOT NULL
) FROM  v AS t(x,a,b);
```

This normalization was previously missing for `FILTER` expressions in the `SELECT` list, `DISTINCT ON` targets, `ORDER BY` expressions, `QUALIFY`, and `HAVING` clauses.