### PR TITLE
Change Concat_ws to accept lists

### DIFF
--- a/src/function/scalar/string/concat_ws.cpp
+++ b/src/function/scalar/string/concat_ws.cpp
@@ -1,15 +1,40 @@
 #include "duckdb/function/scalar/string_functions.hpp"
+#include "duckdb/planner/expression/bound_cast_expression.hpp"
 
 #include <string.h>
 
 namespace duckdb {
 
+struct ConcatWSBindData : public FunctionData {
+	explicit ConcatWSBindData(vector<bool> is_list_p) : is_list(std::move(is_list_p)) {
+	}
+	vector<bool> is_list; // one entry per non-separator argument, in call order
+
+	unique_ptr<FunctionData> Copy() const override {
+		return make_uniq<ConcatWSBindData>(is_list);
+	}
+	bool Equals(const FunctionData &other_p) const override {
+		return is_list == other_p.Cast<ConcatWSBindData>().is_list;
+	}
+};
+
 static void ConcatWSFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &func_expr = state.expr.Cast<BoundFunctionExpression>();
+	auto &info = func_expr.BindInfo()->Cast<ConcatWSBindData>();
+
 	auto count = args.size();
 	auto sep_data = args.data[0].Values<string_t>();
-	vector<VectorIterator<string_t>> iterators;
+
+	// build one iterator per vararg, keyed by column; lists get two (entries + child elements)
+	vector<VectorIterator<string_t>> scalar_iterators;
+	vector<VectorIterator<VectorListType<string_t>>> list_iterators;
+
 	for (idx_t col_idx = 1; col_idx < args.ColumnCount(); col_idx++) {
-		iterators.emplace_back(args.data[col_idx].Values<string_t>());
+		if (info.is_list[col_idx - 1]) {
+			list_iterators.emplace_back(args.data[col_idx]);
+		} else {
+			scalar_iterators.emplace_back(args.data[col_idx]);
+		}
 	}
 
 	auto result_data = FlatVector::Writer<string_t>(result, count);
@@ -22,52 +47,107 @@ static void ConcatWSFunction(DataChunk &args, ExpressionState &state, Vector &re
 		auto sep = sep_entry.GetValue();
 		auto sep_ptr = sep.GetData();
 		auto sep_size = sep.GetSize();
-
 		// first figure out the length of the result string
 		idx_t result_length = 0;
+
+		// track separate counters into scalar_iterators/list_iterators
+		idx_t scalar_i = 0, list_i = 0;
+
 		bool has_result = false;
 		for (idx_t col_idx = 1; col_idx < args.ColumnCount(); col_idx++) {
-			auto &idata = iterators[col_idx - 1];
-			auto input = idata[r];
-			if (!input.IsValid()) {
-				continue;
+			if (!info.is_list[col_idx - 1]) {
+				auto input = scalar_iterators[scalar_i++][r];
+				if (!input.IsValid())
+					continue;
+				if (has_result)
+					result_length += sep.GetSize();
+				result_length += input.GetValue().GetSize();
+				has_result = true;
+			} else {
+				auto list_entry = list_iterators[list_i++][r];
+				if (!list_entry.IsValid())
+					continue;
+				for (idx_t e = 0; e < list_entry.GetListLength(); e++) {
+					auto elem = list_entry.GetChildValue(e);
+					if (!elem.IsValid())
+						continue;
+					auto elem_str = elem.GetValue();
+					if (has_result)
+						result_length += sep.GetSize();
+					result_length += elem_str.GetSize();
+					has_result = true;
+				}
 			}
-			if (has_result) {
-				result_length += sep.GetSize();
-			}
-			result_length += input.GetValue().GetSize();
-			has_result = true;
 		}
+
 		auto &result_str = result_data.WriteEmptyString(result_length);
 		auto result_ptr = result_str.GetDataWriteable();
 		// now write the result string
 		result_length = 0;
 		has_result = false;
+		scalar_i = 0;
+		list_i = 0;
+
 		for (idx_t col_idx = 1; col_idx < args.ColumnCount(); col_idx++) {
-			auto &idata = iterators[col_idx - 1];
-			auto input = idata[r];
-			if (!input.IsValid()) {
-				continue;
+			if (!info.is_list[col_idx - 1]) {
+				auto input = scalar_iterators[scalar_i++][r];
+				if (!input.IsValid())
+					continue;
+				if (has_result) {
+					memcpy(result_ptr + result_length, sep_ptr, sep_size);
+					result_length += sep.GetSize();
+				}
+				auto input_str = input.GetValue();
+				memcpy(result_ptr + result_length, input_str.GetData(), input_str.GetSize());
+				result_length += input_str.GetSize();
+				has_result = true;
+			} else {
+				auto list_entry = list_iterators[list_i++][r];
+				if (!list_entry.IsValid())
+					continue;
+				auto entry = list_entry.GetValue();
+				for (idx_t e = 0; e < entry.length; e++) {
+					auto elem = list_entry.GetChildValue(e);
+					if (!elem.IsValid())
+						continue;
+					if (has_result) {
+						memcpy(result_ptr + result_length, sep_ptr, sep_size);
+						result_length += sep.GetSize();
+					}
+					auto elem_str = elem.GetValue();
+					memcpy(result_ptr + result_length, elem_str.GetData(), elem_str.GetSize());
+					result_length += elem_str.GetSize();
+					has_result = true;
+				}
 			}
-			if (has_result) {
-				memcpy(result_ptr + result_length, sep_ptr, sep_size);
-				result_length += sep.GetSize();
-			}
-			auto input_str = input.GetValue();
-			memcpy(result_ptr + result_length, input_str.GetData(), input_str.GetSize());
-			result_length += input.GetValue().GetSize();
-			has_result = true;
 		}
 		result_str.Finalize();
 	}
 }
 
 static unique_ptr<FunctionData> BindConcatWSFunction(BindScalarFunctionInput &input) {
-	auto &bound_function = input.GetBoundFunction();
-	for (auto &arg : bound_function.GetArguments()) {
-		arg = LogicalType::VARCHAR;
+	auto &args = input.GetArguments();
+	vector<bool> is_list(args.size() - 1, false);
+
+	for (idx_t i = 1; i < args.size(); i++) {
+		auto &arg_type = args[i]->GetReturnType();
+		if (arg_type.id() == LogicalTypeId::LIST) {
+			is_list[i - 1] = true;
+			auto child_type = ListType::GetChildType(arg_type);
+			if (child_type.id() == LogicalTypeId::LIST) {
+				throw BinderException("concat_ws() does not support nested lists");
+			}
+			if (child_type.id() != LogicalTypeId::VARCHAR) {
+				args[i] = BoundCastExpression::AddCastToType(input.GetClientContext(), std::move(args[i]),
+				                                             LogicalType::LIST(LogicalType::VARCHAR));
+			}
+		} else if (arg_type.id() != LogicalTypeId::VARCHAR) {
+			args[i] =
+			    BoundCastExpression::AddCastToType(input.GetClientContext(), std::move(args[i]), LogicalType::VARCHAR);
+		}
 	}
-	return nullptr;
+
+	return make_uniq<ConcatWSBindData>(std::move(is_list));
 }
 
 ScalarFunction ConcatWsFun::GetFunction() {

--- a/src/function/scalar/string/concat_ws.cpp
+++ b/src/function/scalar/string/concat_ws.cpp
@@ -57,23 +57,28 @@ static void ConcatWSFunction(DataChunk &args, ExpressionState &state, Vector &re
 		for (idx_t col_idx = 1; col_idx < args.ColumnCount(); col_idx++) {
 			if (!info.is_list[col_idx - 1]) {
 				auto input = scalar_iterators[scalar_i++][r];
-				if (!input.IsValid())
+				if (!input.IsValid()) {
 					continue;
-				if (has_result)
+				}
+				if (has_result) {
 					result_length += sep.GetSize();
+				}
 				result_length += input.GetValue().GetSize();
 				has_result = true;
 			} else {
 				auto list_entry = list_iterators[list_i++][r];
-				if (!list_entry.IsValid())
+				if (!list_entry.IsValid()) {
 					continue;
+				}
 				for (idx_t e = 0; e < list_entry.GetListLength(); e++) {
 					auto elem = list_entry.GetChildValue(e);
-					if (!elem.IsValid())
+					if (!elem.IsValid()) {
 						continue;
+					}
 					auto elem_str = elem.GetValue();
-					if (has_result)
+					if (has_result) {
 						result_length += sep.GetSize();
+					}
 					result_length += elem_str.GetSize();
 					has_result = true;
 				}
@@ -91,8 +96,9 @@ static void ConcatWSFunction(DataChunk &args, ExpressionState &state, Vector &re
 		for (idx_t col_idx = 1; col_idx < args.ColumnCount(); col_idx++) {
 			if (!info.is_list[col_idx - 1]) {
 				auto input = scalar_iterators[scalar_i++][r];
-				if (!input.IsValid())
+				if (!input.IsValid()) {
 					continue;
+				}
 				if (has_result) {
 					memcpy(result_ptr + result_length, sep_ptr, sep_size);
 					result_length += sep.GetSize();
@@ -103,13 +109,15 @@ static void ConcatWSFunction(DataChunk &args, ExpressionState &state, Vector &re
 				has_result = true;
 			} else {
 				auto list_entry = list_iterators[list_i++][r];
-				if (!list_entry.IsValid())
+				if (!list_entry.IsValid()) {
 					continue;
+				}
 				auto entry = list_entry.GetValue();
 				for (idx_t e = 0; e < entry.length; e++) {
 					auto elem = list_entry.GetChildValue(e);
-					if (!elem.IsValid())
+					if (!elem.IsValid()) {
 						continue;
+					}
 					if (has_result) {
 						memcpy(result_ptr + result_length, sep_ptr, sep_size);
 						result_length += sep.GetSize();

--- a/test/sql/function/string/test_concat_ws.test
+++ b/test/sql/function/string/test_concat_ws.test
@@ -155,3 +155,111 @@ WorldHello
 (empty)
 RÄcksMotörHead
 
+# list 
+
+query T
+select CONCAT_WS(',', ['a', 'b', 'c'])
+----
+a,b,c
+
+# list argument with scalar
+
+query T
+select CONCAT_WS(',', ['a', 'b'], 'c')
+----
+a,b,c
+
+# scalar with list argument
+
+query T
+select CONCAT_WS(',', 'a', ['b', 'c'])
+----
+a,b,c
+
+# multiple list arguments
+
+query T
+select CONCAT_WS(',', ['a', 'b'], ['c', 'd'])
+----
+a,b,c,d
+
+# NULL list elements
+
+query T
+select CONCAT_WS(',', ['a', NULL, 'b'])
+----
+a,b
+
+# empty list
+
+query T
+select CONCAT_WS(',', [])
+----
+(empty)
+
+# empty string in list
+
+query T
+select CONCAT_WS(',', ['a', ''])
+----
+a,
+
+# non-VARCHAR list
+
+query T
+select CONCAT_WS(',', [1, 2, 3])
+----
+1,2,3
+
+# mixed list and scalar types
+
+query T
+select CONCAT_WS(',', ['a', 'b'], 5)
+----
+a,b,5
+
+# nested lists are not supported
+
+statement error
+select CONCAT_WS(',', [['a', 'b'], ['c']])
+----
+
+query T
+select CONCAT_WS(',', NULL::VARCHAR[], 'a')
+----
+a
+
+query T
+select CONCAT_WS(NULL, ['a', 'b'])
+----
+NULL
+
+query T
+select CONCAT_WS(',', [NULL, NULL])
+----
+(empty)
+
+query T
+select CONCAT_WS(',', [], 'a', ['b','c'])
+----
+a,b,c
+
+statement ok
+CREATE TABLE lists(sep VARCHAR, l VARCHAR[]);
+
+statement ok
+INSERT INTO lists VALUES (',', ['a','b']), (';', ['x']), ('-', []), (',', NULL), (',', ['p','q','r']);
+
+query T
+SELECT CONCAT_WS(sep, l) FROM lists ORDER BY rowid
+----
+a,b
+x
+(empty)
+(empty)
+p,q,r
+
+query T
+select CONCAT_WS(',', NULL::VARCHAR[], ['c', 'd'])
+----
+c,d

--- a/test/sql/types/list/list_to_varchar_cast.test
+++ b/test/sql/types/list/list_to_varchar_cast.test
@@ -5,5 +5,5 @@
 query I
 SELECT concat_ws('.', list_reverse(string_split('1.2..3', '.')));
 ----
-[3, '', 2, 1]
+3..2.1
 


### PR DESCRIPTION
Closes https://github.com/duckdblabs/duckdb-internal/issues/3620

`concat_ws` previously stringified `LIST` arguments as a whole (e.g. producing something like `[a, b, c]` as a single joined value) instead of treating list elements as individual values to join. This PR makes `concat_ws` flatten `LIST` arguments in place alongside scalar arguments, joining every element with the given separator.

```sql
SELECT concat_ws(',', 'a', ['x', 'y', 'z'], 'b');
-- a,x,y,z,b
```

## Behaviour

- List arguments are flattened in place: elements from a list argument are joined using the same separator as every other argument, in call order, mixed freely with scalar arguments.
- Multiple list arguments in a single call are supported.
- Existing NULL-handling rules extend naturally to lists, with no special-casing:
  - A `NULL` list argument contributes nothing (same as a NULL scalar argument)
  - A `NULL` element *within* a non-NULL list is skipped individually; other elements in that same list are still joined normally
  - An empty list (`[]`) contributes nothing
  - The separator itself being `NULL` still causes the whole result to be `NULL`, unchanged from prior behavior
- Non-`VARCHAR` list element types are implicitly cast to `VARCHAR` (e.g. `concat_ws(',', [1, 2, 3])` → `1,2,3`), matching how non-`VARCHAR` scalar arguments are already handled
- Nested lists (`LIST(LIST(...))`) are rejected at bind time with a clear error rather than attempting to recursively flatten

## Implementation

- `BindConcatWSFunction`: inspects each vararg's resolved type. For `LIST` arguments, casts the *child* type to `VARCHAR` when needed (rather than casting the list as a whole, which was the source of the original stringification behavior) and throws a `BinderException` on nested lists. Non-list, non-`VARCHAR` arguments are cast to `VARCHAR` as before. Records which argument positions are lists in a new `ConcatWSBindData`
- `ConcatWSFunction`: extended the existing loop to branch per argument on whether it's a list. List arguments iterate their elements via `VectorListType<string_t>`, contributing each valid element to the running length/write exactly as a scalar argument would, sharing the same `has_result` flag so flattening reads naturally left-to-right regardless of which arguments are lists vs. scalars

## Tests

Added test cases to `test/sql/function/string/test_concat_ws.test`
Also changed the output of the test case of `test/sql/types/list/list_to_varchar_cast.test` to match the function's new behaviour