### PR TITLE
Fix crash in Top-N with LIMIT 0 (#24794)

### DIFF
--- a/src/execution/operator/order/physical_top_n.cpp
+++ b/src/execution/operator/order/physical_top_n.cpp
@@ -138,8 +138,12 @@ public:
 
 private:
 	inline bool EntryShouldBeAdded(const string_t &sort_key) {
+		if (heap_size == 0) {
+			// the heap has no capacity (LIMIT 0) - no entry can ever be added
+			return false;
+		}
 		if (heap.size() < heap_size) {
-			// heap is full - check the latest entry
+			// heap is not full yet - the entry can be added
 			return true;
 		}
 		if (sort_key < heap.front().sort_key) {
@@ -151,7 +155,9 @@ private:
 	}
 
 	inline void AddEntryToHeap(const TopNEntry &entry) {
+		D_ASSERT(heap_size > 0);
 		if (heap.size() >= heap_size) {
+			D_ASSERT(!heap.empty());
 			std::pop_heap(heap.begin(), heap.end());
 			heap.pop_back();
 		}
@@ -347,6 +353,11 @@ bool TopNHeap::CheckBoundaryValues(DataChunk &sort_chunk, DataChunk &payload, To
 void TopNHeap::Sink(DataChunk &input, optional_ptr<TopNBoundaryValue> global_boundary) {
 	static constexpr idx_t SMALL_HEAP_THRESHOLD = 100;
 
+	if (heap_size == 0) {
+		// LIMIT 0 without OFFSET - the heap can never hold any entry, so there is nothing to do
+		return;
+	}
+
 	// compute the ordering values for the new chunk
 	sort_chunk.Reset();
 	executor.Execute(input, sort_chunk);
@@ -372,7 +383,7 @@ void TopNHeap::Sink(DataChunk &input, optional_ptr<TopNBoundaryValue> global_bou
 
 	// if we modified the heap we might be able to update the global boundary
 	// note that the global boundary only applies to FULL heaps
-	if (heap.size() >= heap_size && global_boundary) {
+	if (!heap.empty() && heap.size() >= heap_size && global_boundary) {
 		global_boundary->UpdateValue(heap.front().sort_key);
 	}
 }

--- a/test/sql/order/top_n_limit_zero.test
+++ b/test/sql/order/top_n_limit_zero.test
@@ -1,0 +1,47 @@
+# name: test/sql/order/top_n_limit_zero.test
+# description: Issue #24794 - repeated execution of a Top-N with LIMIT 0 crashes
+# group: [order]
+
+statement ok
+SET disabled_optimizers='filter_pushdown,join_order';
+
+statement ok
+SET threads=4;
+
+statement ok
+CREATE TABLE src(vp_rowid BIGINT PRIMARY KEY, c0 BOOLEAN, c1 BOOLEAN, c2 BIGINT);
+
+statement ok
+INSERT INTO src VALUES (1, TRUE, NULL, NULL), (2, TRUE, FALSE, 42);
+
+statement ok
+CREATE TABLE l AS SELECT vp_rowid, c2 FROM src;
+
+statement ok
+CREATE TABLE r AS SELECT vp_rowid, c0, c1 FROM src;
+
+query I
+SELECT c2 FROM src ORDER BY vp_rowid LIMIT 0
+----
+
+query I
+SELECT c2 FROM src ORDER BY vp_rowid LIMIT 0 OFFSET 1
+----
+
+# the zero-sized heap used to read uninitialized memory through heap.front()
+# this only crashes once the memory has been recycled a number of times, hence the loop
+loop i 0 500
+
+query I
+SELECT sub.c2
+FROM (
+    SELECT l.vp_rowid, r.c0, r.c1, l.c2
+    FROM l
+    JOIN r ON l.vp_rowid = r.vp_rowid
+    WHERE NOT EXISTS (SELECT 1 FROM r rx WHERE rx.vp_rowid = l.vp_rowid AND rx.vp_rowid <> l.vp_rowid)
+) sub
+ORDER BY sub.vp_rowid
+LIMIT 0
+----
+
+endloop


### PR DESCRIPTION
Fixes: #24794 

`TopNHeap` accessed `heap.front()` when `heap_size == 0`, causing an unchecked read from an empty `unsafe_arena_vector` and potentially dereferencing a stale `string_t` pointer. This is reachable when `filter_pushdown` is disabled, since `LIMIT 0` is normally rewritten to `LogicalEmptyResult`.

The fix handles zero-sized heaps in `EntryShouldBeAdded()` and `Sink()`, guards the global boundary update with `!heap.empty()`, and adds `D_ASSERT`s for the heap invariants.

Tests: new `test/sql/order/top_n_limit_zero.test` covering 500 consecutive executions of the reproducer. The query crashes on `main` under ASAN and passes with the patch. The relevant `[order]`, `[optimizer]`, `[explain]`, and `[subquery]` test groups pass.