### PR TITLE
Do not reuse blocks freed by a checkpoint until its header is durable

### DIFF
--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -1323,12 +1323,9 @@ void SingleFileBlockManager::WriteHeader(QueryContext context, DatabaseHeader he
 	header.iteration = ++iteration_count;
 
 	set<block_id_t> all_free_blocks = free_list;
-	set<block_id_t> fully_freed_blocks;
-	for (auto &block : modified_blocks) {
+	auto checkpoint_freed_blocks = modified_blocks;
+	for (auto &block : checkpoint_freed_blocks) {
 		all_free_blocks.insert(block);
-		if (AddFreeBlock(lock, block)) {
-			fully_freed_blocks.insert(block);
-		}
 	}
 	auto written_multi_use_blocks = multi_use_blocks;
 	// newly used blocks are still free blocks for this checkpoint - so add them to the free list that we write
@@ -1336,7 +1333,6 @@ void SingleFileBlockManager::WriteHeader(QueryContext context, DatabaseHeader he
 		all_free_blocks.insert(newly_used_block);
 		written_multi_use_blocks.erase(newly_used_block);
 	}
-	modified_blocks.clear();
 
 	if (!free_list_blocks.empty()) {
 		// there are blocks to write, either in the free_list or in the modified_blocks
@@ -1405,6 +1401,16 @@ void SingleFileBlockManager::WriteHeader(QueryContext context, DatabaseHeader he
 	active_header = 1 - active_header;
 	//! Ensure the header write ends up on disk
 	handle->Sync();
+	set<block_id_t> fully_freed_blocks;
+	{
+		unique_lock<mutex> release_lock(single_file_block_lock);
+		for (auto &block : checkpoint_freed_blocks) {
+			modified_blocks.erase(block);
+			if (AddFreeBlock(release_lock, block)) {
+				fully_freed_blocks.insert(block);
+			}
+		}
+	}
 	// Release the free fully freed blocks to the filesystem.
 	TrimFreeBlocks(fully_freed_blocks);
 }

--- a/test/sql/storage/metadata_reuse_optimistic_write.test_slow
+++ b/test/sql/storage/metadata_reuse_optimistic_write.test_slow
@@ -1,0 +1,82 @@
+# name: test/sql/storage/metadata_reuse_optimistic_write.test_slow
+# description: A concurrent optimistic writer must not claim a block the durable header still needs
+# group: [storage]
+
+# WriteHeader frees this checkpoint's blocks into free_list before the new header is durable, so an
+# optimistic write (a row group flush, which allocates during execution rather than at commit) can
+# claim one and overwrite a block the header on disk still points at. Aborting before the header
+# write leaves that state on disk.
+
+load __TEST_DIR__/metadata_reuse_optimistic.db
+
+statement ok
+PRAGMA disable_checkpoint_on_shutdown;
+
+statement ok
+SET wal_autocheckpoint='128KB';
+
+statement ok
+CREATE TABLE base AS SELECT i, hash(i * 40503)::VARCHAR AS s FROM range(20000) t(i);
+
+statement ok
+CREATE TABLE sink(i BIGINT, s VARCHAR);
+
+# A big catalog makes the metadata flush, and so the window, longer.
+loop i 0 6000
+
+statement ok
+CREATE OR REPLACE VIEW v${i} AS SELECT i, s FROM base WHERE i % 7 = ${i} % 7;
+
+endloop
+
+statement ok
+CHECKPOINT;
+
+# Shrink the catalog so metadata blocks are fully freed.
+loop i 0 1500
+
+statement ok
+DROP VIEW v${i};
+
+endloop
+
+# The abort is one-shot, so hold checkpoints off until the writers are mid-flight.
+statement ok
+SET GLOBAL wal_autocheckpoint='1TB';
+
+statement ok
+SET GLOBAL debug_checkpoint_abort='after_free_list_write';
+
+concurrentloop threadid 0 8
+
+# Thread 0 frees metadata, and doubles as the delay before checkpoints resume.
+loop j 1500 1800
+
+onlyif threadid=0
+statement maybe
+DROP VIEW IF EXISTS v${j};
+----
+
+endloop
+
+onlyif threadid=0
+statement maybe
+SET GLOBAL wal_autocheckpoint='128KB';
+----
+
+# Past a row group (~122880 rows), so these flush mid-statement.
+loop k 0 20
+
+onlyif threadid<>0
+statement maybe
+INSERT INTO sink SELECT i, hash(i * ${threadid} + ${k})::VARCHAR FROM range(${k} * 300000, ${k} * 300000 + 300000) t(i);
+----
+
+endloop
+
+endloop
+
+restart
+
+statement ok
+SELECT count(*) FROM sink;


### PR DESCRIPTION
WriteHeader moves a checkpoint's freed blocks out of modified_blocks and into free_list, releases single_file_block_lock, and only then flushes metadata and writes the new header. Anything allocating in that window (e.g. optimistic writes) gets one of those blocks, and overwrites a block the header currently on disk still points at.

Usually this is invisible, because the new header lands and supersedes the one that referenced the block. If there's a crash in-between though, reopening the database afterwards reads a next-pointer out of a block that now holds row data:

```
IO Error: Could not read enough bytes from file "...": attempted to read 262144 bytes from location 39413575680
```

The fix is to free the blocks only after the header is durable instead of before.

The test reproduces the race with concurrent optimistic writers and uses debug_checkpoint_abort='after_free_list_write' to stop the checkpoint inside the window, so the old header stays newest on disk, then asks whether the database reopens. It failed 5 runs out of 5 before this change and passes after.