### PR TITLE
Issue#25085:  Interval Invert Overflow

### DIFF
--- a/src/common/types/interval.cpp
+++ b/src/common/types/interval.cpp
@@ -546,6 +546,10 @@ interval_t Interval::FromMicro(int64_t delta_us) {
 }
 
 interval_t Interval::Invert(interval_t interval) {
+	if (interval.months == NumericLimits<int32_t>::Minimum() || interval.days == NumericLimits<int32_t>::Minimum() ||
+	    interval.micros == NumericLimits<int64_t>::Minimum()) {
+		throw OutOfRangeException("Interval value is out of range for negation");
+	}
 	interval.days = -interval.days;
 	interval.micros = -interval.micros;
 	interval.months = -interval.months;

--- a/test/sql/types/interval/interval_invert_overflow.test
+++ b/test/sql/types/interval/interval_invert_overflow.test
@@ -1,0 +1,41 @@
+# name: test/sql/types/interval/interval_invert_overflow.test
+# description: Interval negation of extreme values should error instead of overflowing
+# group: [interval]
+
+# Issue #25085: DATE/TIMESTAMP subtraction negates the interval without bounds checking
+
+statement error
+SELECT DATE '2000-01-01' - INTERVAL '-2147483648 months';
+----
+<REGEX>:Out of Range Error:.*negat.*
+
+statement error
+SELECT DATE '2000-01-01' - INTERVAL '-2147483648 days';
+----
+<REGEX>:Out of Range Error:.*negat.*
+
+statement error
+SELECT TIMESTAMP '2000-01-01 00:00:00' - INTERVAL '-2147483648 months';
+----
+<REGEX>:Out of Range Error:.*negat.*
+
+statement error
+SELECT TIMESTAMP '2000-01-01 00:00:00' - INTERVAL '-2147483648 days';
+----
+<REGEX>:Out of Range Error:.*negat.*
+
+statement error
+SELECT TIMESTAMP '2000-01-01 00:00:00' - (INTERVAL (-9223372036854775808) MICROSECONDS);
+----
+<REGEX>:Out of Range Error:.*negat.*
+
+statement error
+SELECT time_bucket(INTERVAL '1 month', TIMESTAMP '2000-01-01 00:00:00', INTERVAL '-2147483648 months');
+----
+<REGEX>:Out of Range Error:.*negat.*
+
+# negating in-range negative values still works
+query I
+SELECT DATE '2000-01-01' - INTERVAL '-5 days';
+----
+2000-01-06 00:00:00


### PR DESCRIPTION
* Negating an interval field at its minimum value (INT32_MIN months/days, INT64_MIN micros) is undefined behavior; 
* throw OutOfRangeException instead.

fixes: #25085
