### PR TITLE
Issue#25071: Interval Colon Overflow

### DIFF
--- a/src/common/types/interval.cpp
+++ b/src/common/types/interval.cpp
@@ -169,11 +169,10 @@ interval_parse_time : {
 	if (!Time::TryConvertInterval(str + start_pos, len - start_pos, pos, time)) {
 		return false;
 	}
-	result.micros += time.value;
-	found_any = true;
-	if (negative) {
-		result.micros = -result.micros;
+	if (!IntervalTryAddition<int64_t>(result.micros, negative ? -time.value : time.value, 1, error_message)) {
+		return false;
 	}
+	found_any = true;
 	goto end_of_string;
 }
 interval_parse_identifier:

--- a/test/sql/types/interval/interval_colon_time_overflow.test
+++ b/test/sql/types/interval/interval_colon_time_overflow.test
@@ -1,0 +1,47 @@
+# name: test/sql/types/interval/interval_colon_time_overflow.test
+# description: Colon-separated time terms in interval parsing should use checked arithmetic
+# group: [interval]
+
+# Issue #25071: unchecked int64 overflow when adding a colon-time term
+
+statement error
+SELECT '9223372036854775807 microseconds 999999999:00:00'::INTERVAL;
+----
+<REGEX>:.*interval value is out of range.*
+
+statement error
+SELECT INTERVAL '9223372036854775807 microseconds 999999999:00:00';
+----
+<REGEX>:.*interval value is out of range.*
+
+statement error
+SELECT INTERVAL '-9223372036854775807 microseconds -999999999:00:00';
+----
+<REGEX>:.*interval value is out of range.*
+
+# adding a negative time term to the minimum interval is fine
+query I
+SELECT INTERVAL '-9223372036854775807 microseconds -1 microseconds -00:00:00';
+----
+-2562047788:00:54.775808
+
+# the sign of a time term applies to that term only (PostgreSQL semantics)
+query I
+SELECT INTERVAL '1 hour -00:30:00';
+----
+00:30:00
+
+query I
+SELECT INTERVAL '1 day -01:00:00';
+----
+1 day -01:00:00
+
+query I
+SELECT INTERVAL '-00:30:00';
+----
+-00:30:00
+
+query I
+SELECT INTERVAL '999999999:00:00';
+----
+999999999:00:00


### PR DESCRIPTION
Colon-separated time terms were added to the accumulated micros without overflow checking, and a negative sign negated the entire accumulation (UB at INT64_MIN). Apply the sign to the time term only and add it via the checked IntervalTryAddition path, matching PostgreSQL semantics for mixed-sign inputs such as '1 hour -00:30:00'.

fixes: #25071
