### PR TITLE
Remove redundant condition in GetMatchingBinding ( /src/planner/bind_context.cpp )

### DIFF
--- a/src/planner/bind_context.cpp
+++ b/src/planner/bind_context.cpp
@@ -55,7 +55,7 @@ optional_ptr<Binding> BindContext::GetMatchingBinding(const Identifier &column_n
 			continue;
 		}
 		if (binding.HasMatchingBinding(column_name)) {
-			if (result || is_using_binding) {
+			if (result) {
 				throw BinderException(context,
 				                      "Ambiguous reference to column name %s (use: '%s.%s' "
 				                      "or '%s.%s')",


### PR DESCRIPTION
Remove a redundant `is_using_binding` check in `BindContext::GetMatchingBinding`.

https://github.com/duckdb/duckdb/blob/main/src/planner/bind_context.cpp#L58

If `is_using_binding` is true, the preceding branch immediately continues to the next iteration. Therefore, `is_using_binding` is always false when the ambiguity check is reached, making the second part of the condition unreachable.

It is recommended to remove `is_using_binding` in the second check and leave only `result` in the condition

Found using the cppcheck static analyzer
Reporter: Guschin Egor ([guschin058@yandex.ru](mailto:guschin058@yandex.ru))