### PR TITLE
Reject `CREATE TEMPORARY INDEX` / `TRIGGER`, inherit trigger temporariness

### DIFF
--- a/src/parser/peg/transformer/transform_create_table.cpp
+++ b/src/parser/peg/transformer/transform_create_table.cpp
@@ -38,6 +38,18 @@ PEGTransformerFactory::TransformCreateStatement(PEGTransformer &transformer, con
 		secret_info.persist_type = temporary ? *temporary : SecretPersistType::DEFAULT;
 	}
 	result->info->temporary = temporary && *temporary == SecretPersistType::TEMPORARY;
+	if (result->info->temporary) {
+		// the grammar allows TEMPORARY in front of every create variation - reject it where the entry does not
+		// carry a user-supplied flag, but derives one from the table it belongs to
+		switch (result->info->type) {
+		case CatalogType::INDEX_ENTRY:
+			throw ParserException("Temporary indexes are not supported");
+		case CatalogType::TRIGGER_ENTRY:
+			throw ParserException("Temporary triggers are not supported");
+		default:
+			break;
+		}
+	}
 	return std::move(result);
 }
 

--- a/src/planner/binder/statement/bind_create.cpp
+++ b/src/planner/binder/statement/bind_create.cpp
@@ -630,6 +630,10 @@ void Binder::BindLogicalType(LogicalType &type) {
 bool BoundBodyContainsTrigger(const LogicalOperator &op);
 
 SchemaCatalogEntry &Binder::BindCreateTriggerInfo(CreateTriggerInfo &create_trigger_info) {
+	if (create_trigger_info.temporary) {
+		// unsupported - a trigger is temporary iff its base table is (see below)
+		throw BinderException("Temporary triggers are not supported");
+	}
 	// Resolve the base table first — triggers inherit catalog/schema from their table (like Postgres).
 	// Promote a catalog-qualified base table (e.g. attached_db.tbl) so downstream lookups carry the resolved
 	// catalog instead of a bare schema (matches the DROP TRIGGER path).
@@ -652,6 +656,8 @@ SchemaCatalogEntry &Binder::BindCreateTriggerInfo(CreateTriggerInfo &create_trig
 
 	// Trigger inherits the catalog and the (possibly nested) schema from the base table
 	create_trigger_info.SetQualifiedName(table.schema.GetQualifiedName(create_trigger_info.GetQualifiedName().Name()));
+	// ... and its temporariness, so that a trigger on a temporary table lands in the temp catalog
+	create_trigger_info.temporary = table.temporary;
 
 	auto &schema = BindCreateSchema(create_trigger_info);
 
@@ -878,6 +884,10 @@ BoundStatement Binder::Bind(CreateStatement &stmt) {
 	}
 	case CatalogType::INDEX_ENTRY: {
 		auto &create_index_info = stmt.info->Cast<CreateIndexInfo>();
+		if (create_index_info.temporary) {
+			// unsupported - an index is temporary iff the table it is created on is (see below)
+			throw BinderException("Temporary indexes are not supported");
+		}
 
 		// Plan the table scan - the table lives in the same (possibly nested) schema as the index.
 		TableDescription table_description(create_index_info.GetQualifiedName().WithName(create_index_info.table));

--- a/test/sql/catalog/test_temporary_index.test
+++ b/test/sql/catalog/test_temporary_index.test
@@ -1,0 +1,48 @@
+# name: test/sql/catalog/test_temporary_index.test
+# description: CREATE TEMPORARY INDEX is rejected - an index is temporary iff its table is
+# group: [catalog]
+
+statement ok
+CREATE TABLE t(i INTEGER)
+
+statement ok
+CREATE TEMPORARY TABLE tmp(i INTEGER)
+
+statement error
+CREATE TEMPORARY INDEX i1 ON t(i)
+----
+<REGEX>:.*Temporary indexes are not supported.*
+
+statement error
+CREATE TEMP INDEX i1 ON t(i)
+----
+<REGEX>:.*Temporary indexes are not supported.*
+
+# also rejected on a temporary table, where it would merely be redundant
+statement error
+CREATE TEMPORARY INDEX i1 ON tmp(i)
+----
+<REGEX>:.*Temporary indexes are not supported.*
+
+statement error
+CREATE TEMPORARY INDEX IF NOT EXISTS i1 ON t(i)
+----
+<REGEX>:.*Temporary indexes are not supported.*
+
+query I
+SELECT count(*) FROM duckdb_indexes()
+----
+0
+
+# without TEMPORARY the index inherits the temporariness of its table
+statement ok
+CREATE INDEX i1 ON t(i)
+
+statement ok
+CREATE INDEX i2 ON tmp(i)
+
+query II
+SELECT index_name, database_name='temp' FROM duckdb_indexes() ORDER BY index_name
+----
+i1	false
+i2	true

--- a/test/sql/trigger/temporary_trigger.test
+++ b/test/sql/trigger/temporary_trigger.test
@@ -1,0 +1,74 @@
+# name: test/sql/trigger/temporary_trigger.test
+# description: CREATE TEMPORARY TRIGGER is rejected - a trigger is temporary iff its base table is
+# group: [trigger]
+
+require noforcestorage
+
+load {TEST_DIR}/temporary_trigger.db
+
+statement ok
+CREATE TABLE t(i INTEGER)
+
+statement ok
+CREATE TABLE audit(msg VARCHAR)
+
+statement ok
+CREATE TEMPORARY TABLE tmp(i INTEGER)
+
+statement ok
+CREATE TEMPORARY TABLE tmp_audit(msg VARCHAR)
+
+statement error
+CREATE TEMPORARY TRIGGER trg AFTER INSERT ON t FOR EACH STATEMENT INSERT INTO audit VALUES ('x')
+----
+<REGEX>:.*Temporary triggers are not supported.*
+
+statement error
+CREATE TEMP TRIGGER trg AFTER INSERT ON t FOR EACH STATEMENT INSERT INTO audit VALUES ('x')
+----
+<REGEX>:.*Temporary triggers are not supported.*
+
+# also rejected on a temporary base table - the trigger is temporary because the table is
+statement error
+CREATE TEMPORARY TRIGGER trg AFTER INSERT ON tmp FOR EACH STATEMENT INSERT INTO tmp_audit VALUES ('x')
+----
+<REGEX>:.*Temporary triggers are not supported.*
+
+query I
+SELECT count(*) FROM duckdb_triggers()
+----
+0
+
+# a trigger on a temporary table is created in the temp catalog and fires
+statement ok
+CREATE TRIGGER trg AFTER INSERT ON tmp FOR EACH STATEMENT INSERT INTO tmp_audit VALUES ('fired')
+
+query III
+SELECT database_name, trigger_name, temporary FROM duckdb_triggers()
+----
+temp	trg	true
+
+statement ok
+INSERT INTO tmp VALUES (1)
+
+query I
+SELECT * FROM tmp_audit
+----
+fired
+
+# a trigger on a persistent table is not temporary
+statement ok
+CREATE TRIGGER trg_persistent AFTER INSERT ON t FOR EACH STATEMENT INSERT INTO audit VALUES ('fired')
+
+query II
+SELECT trigger_name, temporary FROM duckdb_triggers() WHERE NOT temporary
+----
+trg_persistent	false
+
+restart
+
+# only the persistent trigger survives
+query II
+SELECT trigger_name, temporary FROM duckdb_triggers()
+----
+trg_persistent	false


### PR DESCRIPTION
Similar to https://github.com/duckdb/duckdb/pull/25118, this I am less sure, should `TEMPORARY` indexes or trigger be explicitly tagged, or (as done in the PR) they follow the characterisation of the relevant resource?