### PR TITLE
Fix overflowing interval ago negation

### DIFF
--- a/src/common/types/interval.cpp
+++ b/src/common/types/interval.cpp
@@ -352,8 +352,10 @@ interval_parse_ago:
 		}
 	}
 	// invert all the values
-	if (result.months == NumericLimits<int32_t>::Minimum() || result.days == NumericLimits<int32_t>::Minimum()) {
-		throw OutOfRangeException("AGO interval value is out of range");
+	if (result.months == NumericLimits<int32_t>::Minimum() || result.days == NumericLimits<int32_t>::Minimum() ||
+	    result.micros == NumericLimits<int64_t>::Minimum()) {
+		AssignOutOfRangeErrorOrThrow("AGO interval value is out of range", error_message);
+		return false;
 	}
 
 	result.months = -result.months;

--- a/test/sql/types/interval/interval_try_cast.test
+++ b/test/sql/types/interval/interval_try_cast.test
@@ -99,6 +99,14 @@ SELECT
 ----
 NULL	NULL	NULL	NULL
 
+query III
+SELECT
+	TRY_CAST('-2147483648 months ago' AS INTERVAL),
+	TRY_CAST('-2147483648 days ago' AS INTERVAL),
+	TRY_CAST('-9223372036854775800 microseconds -8 microseconds ago' AS INTERVAL);
+----
+NULL	NULL	NULL
+
 statement error
 SELECT CAST('2147483648 days' AS INTERVAL);
 ----

--- a/test/sql/types/interval/test_interval.test
+++ b/test/sql/types/interval/test_interval.test
@@ -84,6 +84,18 @@ SELECT interval '-2147483648 months' AS without_ago,
 ----
 AGO interval value is out of range
 
+# Issue #25072: negating INT64_MIN with ago is out of range
+statement error
+SELECT '-9223372036854775800 microseconds -8 microseconds ago'::INTERVAL;
+----
+AGO interval value is out of range
+
+query II
+SELECT INTERVAL '-9223372036854775807 microseconds ago' = INTERVAL '9223372036854775807 microseconds',
+       INTERVAL '9223372036854775807 microseconds ago' = INTERVAL '-9223372036854775807 microseconds';
+----
+true	true
+
 # months and hours, with optional @
 query T
 SELECT INTERVAL '@2mons 1H';


### PR DESCRIPTION
## Summary

Resolves #25072

This PR prevents overflow when `ago` negates the minimum interval microseconds value and makes `TRY_CAST` return `NULL` for out-of-range inputs.
