### PR TITLE
Fix #24880: Use 0777 base mode for directory creation to respect ACLs

### DIFF
--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -731,7 +731,7 @@ bool LocalFileSystem::CreateDirectoryExtended(const string &directory, const Cre
 		throw InternalException("Unknown CreateDirectoryMode");
 	}
 	auto normalized_dir = ExpandPath(directory, opener);
-	if (mkdir(normalized_dir.c_str(), 0755) == 0) {
+	if (mkdir(normalized_dir.c_str(), 0777) == 0) {
 		return true;
 	}
 	auto error = errno;


### PR DESCRIPTION
Fix #24880: Use 0777 base mode for directory creation to respect ACLs

Previously, `LocalFileSystem::CreateDirectoryExtended` hardcoded `0755` when calling `mkdir` on Unix systems. 
This capped permissions, preventing directories (like Hive-partitioned outputs) from inheriting group-write access via default ACLs, even when the environment permitted it.

By requesting a base mode of `0777`, we delegate security to the host OS, allowing the user's `umask` and inherited ACLs to properly dictate the final directory permissions. This brings directory creation into parity with how DuckDB currently creates raw files (0666).

Closes #24880