### PR TITLE
Propagate stats for CASE expression

### DIFF
--- a/src/planner/filter/expression_filter.cpp
+++ b/src/planner/filter/expression_filter.cpp
@@ -6,6 +6,7 @@
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/planner/expression_iterator.hpp"
 #include "duckdb/planner/expression/bound_between_expression.hpp"
+#include "duckdb/planner/expression/bound_case_expression.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/planner/expression/bound_comparison_expression.hpp"
 #include "duckdb/planner/expression/bound_conjunction_expression.hpp"
@@ -294,6 +295,24 @@ static optional_ptr<const BaseStatistics> TryGetExpressionStats(optional_ptr<Cli
 		}
 
 		return nullptr;
+	}
+	case ExpressionClass::BOUND_CASE: {
+		// Output range is the union of the ELSE and every THEN branch.
+		auto &case_expr = expr.Cast<BoundCaseExpression>();
+		auto else_stats = TryGetExpressionStats(context_p, case_expr.Else(), input_stats, owned_stats);
+		if (!else_stats) {
+			return nullptr;
+		}
+		auto merged = else_stats->ToUnique();
+		for (auto &check : case_expr.CaseChecks()) {
+			auto then_stats = TryGetExpressionStats(context_p, *check.then_expr, input_stats, owned_stats);
+			if (!then_stats) {
+				return nullptr;
+			}
+			merged->Merge(*then_stats);
+		}
+		owned_stats.push_back(std::move(merged));
+		return owned_stats.back().get();
 	}
 	case ExpressionClass::BOUND_OPERATOR: {
 		auto &op = expr.Cast<BoundOperatorExpression>();

--- a/test/sql/optimizer/case_zonemap_pruning.test
+++ b/test/sql/optimizer/case_zonemap_pruning.test
@@ -1,0 +1,117 @@
+# name: test/sql/optimizer/case_zonemap_pruning.test
+# description: Row-group pruning for filters on CASE WHEN expressions
+# group: [optimizer]
+
+statement ok
+ATTACH '{TEST_DIR}/case_zonemap_pruning.duckdb' AS db (ROW_GROUP_SIZE 2048);
+
+statement ok
+USE db;
+
+# 6144 rows -> 3 row groups of 2048 rows.
+# x is the row id; y is the row id shifted by 10000 so its stats do not overlap
+# with x's stats in any row group.
+statement ok
+CREATE TABLE case_pruning AS
+SELECT i::INTEGER AS i,
+       i::INTEGER AS x,
+       (i + 10000)::INTEGER AS y
+FROM range(6144) r(i);
+
+statement ok
+CHECKPOINT;
+
+# Baseline: a direct filter on x prunes to the last row group.
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM case_pruning WHERE x > 5000;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
+
+# Both CASE branches evaluate to x, so the merged stats equal x's stats and the
+# filter must prune exactly like the baseline.
+query II
+EXPLAIN ANALYZE
+SELECT count(*) FROM case_pruning
+WHERE (CASE WHEN i % 2 = 0 THEN x ELSE x END) > 5000;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
+
+query I
+SELECT count(*) FROM case_pruning
+WHERE (CASE WHEN i % 2 = 0 THEN x ELSE x END) > 5000;
+----
+1143
+
+# THEN=x, ELSE=constant(0). Merged stats of the first two row groups are
+# [0, <=4095] and cannot match > 5000, so only the last row group survives.
+query II
+EXPLAIN ANALYZE
+SELECT count(*) FROM case_pruning
+WHERE (CASE WHEN i % 2 = 0 THEN x ELSE 0 END) > 5000;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
+
+query I
+SELECT count(*) FROM case_pruning
+WHERE (CASE WHEN i % 2 = 0 THEN x ELSE 0 END) > 5000;
+----
+571
+
+# THEN=y (>= 10000 everywhere), ELSE=x. The merged range still covers x's
+# range, and no row group can be pruned by a threshold that falls inside x's
+# lowest row group.
+query II
+EXPLAIN ANALYZE
+SELECT count(*) FROM case_pruning
+WHERE (CASE WHEN i % 2 = 0 THEN y ELSE x END) < 1000;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
+
+query I
+SELECT count(*) FROM case_pruning
+WHERE (CASE WHEN i % 2 = 0 THEN y ELSE x END) < 1000;
+----
+500
+
+# Threshold above both branches everywhere -> filter is always false and every
+# row group must be pruned.
+query II
+EXPLAIN ANALYZE
+SELECT count(*) FROM case_pruning
+WHERE (CASE WHEN i % 2 = 0 THEN x ELSE y END) > 1000000;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 0 / 3.*
+
+query I
+SELECT count(*) FROM case_pruning
+WHERE (CASE WHEN i % 2 = 0 THEN x ELSE y END) > 1000000;
+----
+0
+
+# Threshold inside the merged range of every row group -> no pruning is
+# possible, and the whole table is scanned. Guards against over-pruning.
+query II
+EXPLAIN ANALYZE
+SELECT count(*) FROM case_pruning
+WHERE (CASE WHEN i % 2 = 0 THEN x ELSE y END) BETWEEN 100 AND 200;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 3 / 3.*
+
+query I
+SELECT count(*) FROM case_pruning
+WHERE (CASE WHEN i % 2 = 0 THEN x ELSE y END) BETWEEN 100 AND 200;
+----
+51
+
+# Correctness: pruning must not drop matching rows relative to a non-CASE
+# equivalent expression.
+query I
+SELECT count(*) FROM case_pruning
+WHERE (CASE WHEN i % 2 = 0 THEN x ELSE x END) > 5000;
+----
+1143
+
+query I
+SELECT count(*) FROM case_pruning WHERE x > 5000;
+----
+1143

--- a/test/sql/optimizer/case_zonemap_pruning.test
+++ b/test/sql/optimizer/case_zonemap_pruning.test
@@ -9,109 +9,60 @@ statement ok
 USE db;
 
 # 6144 rows -> 3 row groups of 2048 rows.
-# x is the row id; y is the row id shifted by 10000 so its stats do not overlap
-# with x's stats in any row group.
+# All CASE expressions below reference only x so the scan can push them down
+# as single-column table filters; the CASE stats logic then merges the ELSE
+# and THEN ranges and prunes against the row group zonemap of x.
 statement ok
 CREATE TABLE case_pruning AS
-SELECT i::INTEGER AS i,
-       i::INTEGER AS x,
-       (i + 10000)::INTEGER AS y
+SELECT i::INTEGER AS x
 FROM range(6144) r(i);
 
 statement ok
 CHECKPOINT;
 
-# Baseline: a direct filter on x prunes to the last row group.
+# Baseline
 query II
 EXPLAIN ANALYZE SELECT count(*) FROM case_pruning WHERE x > 5000;
 ----
 analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
 
-# Both CASE branches evaluate to x, so the merged stats equal x's stats and the
-# filter must prune exactly like the baseline.
 query II
 EXPLAIN ANALYZE
 SELECT count(*) FROM case_pruning
-WHERE (CASE WHEN i % 2 = 0 THEN x ELSE x END) > 5000;
+WHERE (CASE WHEN x % 2 = 0 THEN x ELSE x END) > 5000;
 ----
 analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
 
 query I
 SELECT count(*) FROM case_pruning
-WHERE (CASE WHEN i % 2 = 0 THEN x ELSE x END) > 5000;
+WHERE (CASE WHEN x % 2 = 0 THEN x ELSE x END) > 5000;
 ----
 1143
 
-# THEN=x, ELSE=constant(0). Merged stats of the first two row groups are
-# [0, <=4095] and cannot match > 5000, so only the last row group survives.
 query II
 EXPLAIN ANALYZE
 SELECT count(*) FROM case_pruning
-WHERE (CASE WHEN i % 2 = 0 THEN x ELSE 0 END) > 5000;
+WHERE (CASE WHEN x % 2 = 0 THEN x ELSE 0 END) > 5000;
 ----
 analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
 
 query I
 SELECT count(*) FROM case_pruning
-WHERE (CASE WHEN i % 2 = 0 THEN x ELSE 0 END) > 5000;
+WHERE (CASE WHEN x % 2 = 0 THEN x ELSE 0 END) > 5000;
 ----
 571
 
-# THEN=y (>= 10000 everywhere), ELSE=x. The merged range still covers x's
-# range, and no row group can be pruned by a threshold that falls inside x's
-# lowest row group.
+# Threshold above both branches everywhere -> the filter is provably always
+# false, so the scan collapses to an Empty Result at plan time.
 query II
 EXPLAIN ANALYZE
 SELECT count(*) FROM case_pruning
-WHERE (CASE WHEN i % 2 = 0 THEN y ELSE x END) < 1000;
+WHERE (CASE WHEN x % 2 = 0 THEN x ELSE 0 END) > 1000000;
 ----
-analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
+analyzed_plan	<REGEX>:.*Empty Result.*
 
 query I
 SELECT count(*) FROM case_pruning
-WHERE (CASE WHEN i % 2 = 0 THEN y ELSE x END) < 1000;
-----
-500
-
-# Threshold above both branches everywhere -> filter is always false and every
-# row group must be pruned.
-query II
-EXPLAIN ANALYZE
-SELECT count(*) FROM case_pruning
-WHERE (CASE WHEN i % 2 = 0 THEN x ELSE y END) > 1000000;
-----
-analyzed_plan	<REGEX>:.*Row Groups Scanned: 0 / 3.*
-
-query I
-SELECT count(*) FROM case_pruning
-WHERE (CASE WHEN i % 2 = 0 THEN x ELSE y END) > 1000000;
+WHERE (CASE WHEN x % 2 = 0 THEN x ELSE 0 END) > 1000000;
 ----
 0
-
-# Threshold inside the merged range of every row group -> no pruning is
-# possible, and the whole table is scanned. Guards against over-pruning.
-query II
-EXPLAIN ANALYZE
-SELECT count(*) FROM case_pruning
-WHERE (CASE WHEN i % 2 = 0 THEN x ELSE y END) BETWEEN 100 AND 200;
-----
-analyzed_plan	<REGEX>:.*Row Groups Scanned: 3 / 3.*
-
-query I
-SELECT count(*) FROM case_pruning
-WHERE (CASE WHEN i % 2 = 0 THEN x ELSE y END) BETWEEN 100 AND 200;
-----
-51
-
-# Correctness: pruning must not drop matching rows relative to a non-CASE
-# equivalent expression.
-query I
-SELECT count(*) FROM case_pruning
-WHERE (CASE WHEN i % 2 = 0 THEN x ELSE x END) > 5000;
-----
-1143
-
-query I
-SELECT count(*) FROM case_pruning WHERE x > 5000;
-----
-1143


### PR DESCRIPTION
Hi team, I found case expression is somehow missed when propagating stats for expressions, for examples,
```sql
memory D ATTACH '/tmp/case_zonemap_pruning.duckdb' AS db (ROW_GROUP_SIZE 2048);
memory D USE db;
db D CREATE TABLE case_pruning AS
     SELECT i::INTEGER AS i,
            i::INTEGER AS x,
            (i + 10000)::INTEGER AS y
     FROM range(6144) r(i);
db D EXPLAIN ANALYZE
     SELECT count(*) FROM case_pruning
     WHERE (CASE WHEN i % 2 = 0 THEN x ELSE 0 END) > 5000;
╭─ Summary ───────────╮
│ Total Time: 0.0005s │
╰─────────────────────╯
╭─ Ungrouped Aggregate ────────────────────────────╮
│ Aggregates: count_star()                         │
│ 1 row                                        0µs │
╰─────────────────────────┬────────────────────────╯
╭─ Filter ────────────────┴────────────────────────╮
│ Expression:                                      │
│ CASE WHEN (((i % 2) = 0)) THEN (x) ELSE 0 END >  │
│ 5000                                             │
│ 571 rows                                     0µs │
╰─────────────────────────┒┎───────────────────────╯
╭─ Table Scan ────────────┚┖───────────────────────╮
│ Table: db.main.case_pruning                      │
│ Type: Sequential Scan                            │
│ Projections: i, x                                │
│ Row Groups Scanned: 3 / 3                        │
│ 6,144 rows                                   0µs │
╰──────────────────────────────────────────────────╯
```
In the above example, we should only access one row group, but all row groups are accessed.