### PR TITLE
fix: allow INTERVAL text with 10-digit hours to round-trip

### DIFF
--- a/src/common/types/time.cpp
+++ b/src/common/types/time.cpp
@@ -20,7 +20,8 @@ static_assert(sizeof(dtime_t) == sizeof(int64_t), "dtime_t was padded");
 
 bool Time::TryConvertInternal(const char *buf, idx_t len, idx_t &pos, dtime_t &result, bool strict,
                               optional_ptr<int32_t> nanos) {
-	int32_t hour = -1, min = -1, sec = -1, micros = -1;
+	int64_t hour = -1;
+	int32_t min = -1, sec = -1, micros = -1;
 	pos = 0;
 
 	if (len == 0) {
@@ -42,14 +43,21 @@ bool Time::TryConvertInternal(const char *buf, idx_t len, idx_t &pos, dtime_t &r
 		return false;
 	}
 
-	// Allow up to 9 digit hours to support intervals
+	// Allow up to 10 digit hours to support intervals (Interval::ToString can
+	// emit the full int64-micros range, whose hour component is up to 10 digits).
+	// Still reject hours that do not fit in int64 micros (max representable
+	// interval is 2562047788 hours + 54m 54.775807s), mirroring the old int32
+	// rejection for values that would overflow.
 	hour = 0;
-	for (int32_t digits = 9; pos < len && StringUtil::CharacterIsDigit(buf[pos]); ++pos) {
+	for (int32_t digits = 10; pos < len && StringUtil::CharacterIsDigit(buf[pos]); ++pos) {
 		if (digits-- > 0) {
 			hour = hour * 10 + (buf[pos] - '0');
 		} else {
 			return false;
 		}
+	}
+	if (hour > NumericLimits<int64_t>::Maximum() / Interval::MICROS_PER_HOUR) {
+		return false;
 	}
 
 	if (pos >= len) {
@@ -285,7 +293,7 @@ string Time::ToUTCOffset(int hour_offset, int minute_offset) {
 	return string(buffer, length);
 }
 
-dtime_t Time::FromTime(int32_t hour, int32_t minute, int32_t second, int32_t microseconds) {
+dtime_t Time::FromTime(int64_t hour, int32_t minute, int32_t second, int32_t microseconds) {
 	int64_t result;
 	result = hour;                                             // hours
 	result = result * Interval::MINS_PER_HOUR + minute;        // hours -> minutes

--- a/src/include/duckdb/common/types/time.hpp
+++ b/src/include/duckdb/common/types/time.hpp
@@ -36,7 +36,7 @@ public:
 	//! Convert a UTC offset to ±HH[:MM]
 	DUCKDB_API static string ToUTCOffset(int hour_offset, int minute_offset);
 
-	DUCKDB_API static dtime_t FromTime(int32_t hour, int32_t minute, int32_t second, int32_t microseconds = 0);
+	DUCKDB_API static dtime_t FromTime(int64_t hour, int32_t minute, int32_t second, int32_t microseconds = 0);
 	DUCKDB_API static int64_t ToNanoTime(int32_t hour, int32_t minute, int32_t second, int32_t nanoseconds = 0);
 
 	//! Normalize a TIME_TZ by adding the offset to the time part and returning the TIME

--- a/test/sql/types/interval/test_interval_roundtrip.test
+++ b/test/sql/types/interval/test_interval_roundtrip.test
@@ -1,0 +1,13 @@
+# name: test/sql/types/interval/test_interval_roundtrip.test
+# description: INTERVAL text round-trip must work across the full int64-micros range (10-digit hours)
+# group: [interval]
+
+query T
+SELECT to_microseconds(9223372036854775807)::VARCHAR
+----
+2562047788:00:54.775807
+
+query I
+SELECT (to_microseconds(9223372036854775807)::VARCHAR)::INTERVAL = to_microseconds(9223372036854775807)
+----
+true


### PR DESCRIPTION
## What

`INTERVAL::VARCHAR` can emit up to 10-digit hours (the full int64-micros range is `2562047788:00:54.775807`), but casting that string back to `INTERVAL` failed:

```sql
SELECT to_microseconds(9223372036854775807)::VARCHAR;
-- 2562047788:00:54.775807
SELECT '2562047788:00:54.775807'::INTERVAL;
-- Conversion Error: Could not convert string '2562047788:00:54.775807' to INTERVAL
```

So DuckDB's own output could not be parsed back (`to_microseconds(...)::VARCHAR::INTERVAL` fails).

## Root cause

`Time::TryConvertInternal` (`src/common/types/time.cpp`) capped the hour at **9 digits** and stored it in an **`int32_t`** (`// Allow up to 9 digit hours to support intervals`). The max representable interval's hour component is `2562047788` (10 digits), which overflows `int32_t` and is rejected.

## Fix

- Widen the parsed `hour` to `int64_t` in `TryConvertInternal` and in `Time::FromTime` (declaration + definition) so a 10-digit hour is representable.
- Raise the digit cap 9 → 10.
- Still reject hours that exceed the int64-micros range (max `2562047788` hours + `54m 54.775807s`), preserving the previous behavior for genuinely out-of-range values (e.g. `9999999999:54:32`).

## Tests

Added `test/sql/types/interval/test_interval_roundtrip.test` asserting `to_microseconds(9223372036854775807)::VARCHAR` = `2562047788:00:54.775807` and that casting it back equals the original. Existing `test_interval.test` (which expects out-of-range 10-digit hours to error) still passes.
