### PR TITLE
Fix unchecked int64 overflow in interval colon-time addition

### DIFF
--- a/src/common/types/interval.cpp
+++ b/src/common/types/interval.cpp
@@ -169,7 +169,10 @@ interval_parse_time : {
 	if (!Time::TryConvertInterval(str + start_pos, len - start_pos, pos, time)) {
 		return false;
 	}
-	result.micros += time.value;
+	if (!TryAddOperator::Operation<int64_t, int64_t, int64_t>(result.micros, time.value, result.micros)) {
+		AssignOutOfRangeErrorOrThrow("interval value is out of range", error_message);
+		return false;
+	}
 	found_any = true;
 	if (negative) {
 		result.micros = -result.micros;

--- a/test/sql/types/test_interval_overflow.test
+++ b/test/sql/types/test_interval_overflow.test
@@ -1,0 +1,21 @@
+# name: test/sql/types/test_interval_overflow.test
+# description: Test for unchecked int64 overflow in interval colon-time addition
+# group: [types]
+
+# Issue #25071: Unchecked int64 Overflow in Interval Colon-Time Addition
+# The colon-time branch in Interval::FromCString did a raw result.micros += time.value
+# without overflow checking, causing signed integer overflow (undefined behavior).
+
+statement error
+SELECT '9223372036854775807 microseconds 999999999:00:00'::INTERVAL;
+----
+<REGEX>:.*out of range.*
+
+statement error
+SELECT '9223372036854775807 microseconds 999999999:59:59'::INTERVAL;
+----
+<REGEX>:.*out of range.*
+
+# Normal cases should still work
+statement ok
+SELECT '1 hour 30 minutes'::INTERVAL;


### PR DESCRIPTION
The colon-time branch in Interval::FromCString did a raw result.micros += time.value without overflow checking, causing signed integer overflow (undefined behavior) on release builds and a runtime error on debug builds.

Use TryAddOperator::Operation to safely add the time value, matching the overflow-checking pattern used everywhere else in this file.

Fixes #25071