### PR TITLE
Prune row groups for ENUM predicates whose constants cover the full domain

### DIFF
--- a/src/include/duckdb/storage/statistics/numeric_stats.hpp
+++ b/src/include/duckdb/storage/statistics/numeric_stats.hpp
@@ -76,6 +76,9 @@ struct NumericStats {
 	//! Whether the constants cover every value in [min, max] - only meaningful for integral types
 	static bool ConstantsCoverRange(const BaseStatistics &stats, array_ptr<const Value> constants);
 
+	//! Whether the constants cover the entire declared domain of an ENUM - no zonemaps needed
+	DUCKDB_API static bool ConstantsCoverDomain(const BaseStatistics &stats, array_ptr<const Value> constants);
+
 	DUCKDB_API static void Merge(BaseStatistics &stats, const BaseStatistics &other_p);
 
 	DUCKDB_API static void Serialize(const BaseStatistics &stats, Serializer &serializer);

--- a/src/planner/filter/expression_filter.cpp
+++ b/src/planner/filter/expression_filter.cpp
@@ -609,6 +609,38 @@ static FilterPropagateResult CheckInOperatorStatistics(optional_ptr<ClientContex
 	return result;
 }
 
+static bool InCoversEnumDomain(optional_ptr<ClientContext> context_p, const Expression &expr,
+                               array_ptr<const BaseStatistics> input_stats) {
+	if (expr.GetExpressionType() != ExpressionType::COMPARE_IN) {
+		return false;
+	}
+	auto &op_expr = expr.Cast<BoundOperatorExpression>();
+	if (op_expr.GetChildren().size() <= 1) {
+		return false;
+	}
+	vector<unique_ptr<BaseStatistics>> owned_stats;
+	auto filter_stats = TryGetFilterStats(context_p, *op_expr.GetChildren()[0], input_stats, owned_stats);
+	if (!filter_stats || filter_stats->GetType().id() != LogicalTypeId::ENUM) {
+		return false;
+	}
+	vector<Value> values;
+	values.reserve(op_expr.GetChildren().size() - 1);
+	for (idx_t i = 1; i < op_expr.GetChildren().size(); i++) {
+		if (op_expr.GetChildren()[i]->GetExpressionType() != ExpressionType::VALUE_CONSTANT) {
+			return false;
+		}
+		auto &value = op_expr.GetChildren()[i]->Cast<BoundConstantExpression>().GetValue();
+		if (!value.IsNull()) {
+			values.push_back(value);
+		}
+	}
+	if (values.empty()) {
+		return false;
+	}
+	array_ptr<const Value> constants(values.data(), values.size());
+	return NumericStats::ConstantsCoverDomain(*filter_stats, constants);
+}
+
 static FilterPropagateResult CheckNotOperatorStatistics(optional_ptr<ClientContext> context_p,
                                                         const BoundOperatorExpression &op_expr,
                                                         array_ptr<const BaseStatistics> input_stats) {
@@ -628,6 +660,12 @@ static FilterPropagateResult CheckNotOperatorStatistics(optional_ptr<ClientConte
 	if (ExpressionFilter::CheckExpressionStatistics(context_p, child, input_stats) ==
 	    FilterPropagateResult::FILTER_ALWAYS_TRUE) {
 		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
+	}
+	// an IN over the full declared domain of an ENUM matches every non-NULL value and yields NULL
+	// for NULL values, so the NOT of it matches no row. The child IN itself cannot be classified
+	// as always-true when the column can be NULL (it is then true-or-NULL), so check coverage here
+	if (InCoversEnumDomain(context_p, child, input_stats)) {
+		return FilterPropagateResult::FILTER_FALSE_OR_NULL;
 	}
 	return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 }

--- a/src/storage/statistics/numeric_stats.cpp
+++ b/src/storage/statistics/numeric_stats.cpp
@@ -285,8 +285,46 @@ FilterPropagateResult NumericStats::CheckZonemap(const BaseStatistics &stats, Ex
 	}
 }
 
+bool NumericStats::ConstantsCoverDomain(const BaseStatistics &stats, array_ptr<const Value> constants) {
+	auto &type = stats.GetType();
+	if (type.id() != LogicalTypeId::ENUM) {
+		return false;
+	}
+	const auto domain_size = EnumType::GetSize(type);
+	// covering the full domain requires at least one constant per enum value
+	if (constants.size() < domain_size) {
+		return false;
+	}
+	// positions are 0-based indices into the declared domain
+	vector<bool> covered(domain_size, false);
+	idx_t covered_count = 0;
+	for (auto &constant : constants) {
+		if (constant.type() != type) {
+			return false;
+		}
+		if (constant.IsNull()) {
+			continue;
+		}
+		const auto pos = constant.GetValue<uint32_t>();
+		if (pos >= domain_size) {
+			// defensive: an ENUM-typed constant is always within the declared domain
+			return false;
+		}
+		if (!covered[pos]) {
+			covered[pos] = true;
+			covered_count++;
+		}
+	}
+	return covered_count == domain_size;
+}
+
 bool NumericStats::ConstantsCoverRange(const BaseStatistics &stats, array_ptr<const Value> constants) {
 	auto &type = stats.GetType();
+	if (type.id() == LogicalTypeId::ENUM) {
+		// an ENUM is a closed domain: coverage is a set test against the declared domain
+		// rather than a [min, max] interval test, and requires no zonemaps
+		return ConstantsCoverDomain(stats, constants);
+	}
 	// values are compared as hugeint_t, which cannot hold large UINT128 values
 	if (!type.IsIntegral() || type.InternalType() == PhysicalType::UINT128 || !NumericStats::HasMinMax(stats)) {
 		return false;

--- a/test/sql/optimizer/enum_domain_row_group_pruning.test
+++ b/test/sql/optimizer/enum_domain_row_group_pruning.test
@@ -71,6 +71,13 @@ SELECT count(*) FROM nullables WHERE m IN ('sad', 'ok', 'happy');
 ----
 6144
 
+# the NOT of an IN over the full domain is false-or-NULL for every row - even a NULL
+# row does not survive, so the whole filter collapses to an empty result
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM nullables WHERE m NOT IN ('sad', 'ok', 'happy');
+----
+analyzed_plan	<REGEX>:.*Empty Result.*
+
 
 # domains above 255 values use a UINT16 physical type - coverage must hold there too
 statement ok

--- a/test/sql/optimizer/enum_domain_row_group_pruning.test
+++ b/test/sql/optimizer/enum_domain_row_group_pruning.test
@@ -78,6 +78,26 @@ EXPLAIN ANALYZE SELECT count(*) FROM nullables WHERE m NOT IN ('sad', 'ok', 'hap
 ----
 analyzed_plan	<REGEX>:.*Empty Result.*
 
+# volatile expressions in the query must not block the empty-result collapse
+query II
+EXPLAIN ANALYZE SELECT random() FROM covered WHERE m NOT IN ('sad', 'ok', 'happy');
+----
+analyzed_plan	<REGEX>:.*Empty Result.*
+
+statement ok
+CREATE SEQUENCE seq_test;
+
+# EXPLAIN ANALYZE executes the plan: nextval must not be evaluated at all
+query II
+EXPLAIN ANALYZE SELECT nextval('seq_test') FROM nullables WHERE m NOT IN ('sad', 'ok', 'happy');
+----
+analyzed_plan	<REGEX>:.*Empty Result.*
+
+statement error
+SELECT currval('seq_test');
+----
+<REGEX>:.*currval.*not yet defined.*
+
 
 # domains above 255 values use a UINT16 physical type - coverage must hold there too
 statement ok
@@ -95,3 +115,21 @@ query I
 SELECT count(*) FROM wide WHERE m NOT IN ('v0', 'v1', 'v2');
 ----
 6072
+
+# the minimal domain: a single enum value sits at position 0 - coverage must not
+# mistake it for a NULL sentinel
+statement ok
+CREATE TYPE solo AS ENUM('only');
+
+statement ok
+CREATE TABLE solo_tab AS SELECT 'only'::solo AS m FROM range(2048);
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM solo_tab WHERE m NOT IN ('only');
+----
+analyzed_plan	<REGEX>:.*Empty Result.*
+
+query I
+SELECT count(*) FROM solo_tab WHERE m IN ('only');
+----
+2048

--- a/test/sql/optimizer/enum_domain_row_group_pruning.test
+++ b/test/sql/optimizer/enum_domain_row_group_pruning.test
@@ -1,0 +1,90 @@
+# name: test/sql/optimizer/enum_domain_row_group_pruning.test
+# description: Prune row groups for ENUM predicates whose constants cover the full declared domain
+# group: [optimizer]
+
+statement ok
+ATTACH '{TEST_DIR}/enum_domain_prune.duckdb' AS db (ROW_GROUP_SIZE 2048);
+
+statement ok
+USE db;
+
+statement ok
+CREATE TYPE mood AS ENUM('sad', 'ok', 'happy');
+
+# 3 row groups, values spread over the full ENUM domain
+statement ok
+CREATE TABLE covered AS SELECT ['sad', 'ok', 'happy'][1 + (range % 3)]::mood AS m FROM range(6144);
+
+# NOT IN over the full declared domain matches no row and no row group
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM covered WHERE m NOT IN ('sad', 'ok', 'happy');
+----
+analyzed_plan	<REGEX>:.*Empty Result.*
+
+# duplicates of domain values still cover the domain
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM covered WHERE m NOT IN ('sad', 'ok', 'happy', 'sad');
+----
+analyzed_plan	<REGEX>:.*Empty Result.*
+
+# the positive form: the scan-level IN filter is eliminated (the OR rewrite above the scan remains)
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM covered WHERE m IN ('sad', 'ok', 'happy');
+----
+analyzed_plan	<!REGEX>:.*optional.*
+
+# explicit casts to VARCHAR are rewritten away before the statistics layer sees the filter
+query I
+SELECT count(*) FROM covered WHERE CAST(m AS VARCHAR) NOT IN ('sad', 'ok', 'happy');
+----
+0
+
+# NOT IN (NULL) matches no row (false or NULL for every row)
+query I
+SELECT count(*) FROM covered WHERE m NOT IN (NULL);
+----
+0
+
+# partial lists must survive: only row groups outside the listed values are pruned
+statement ok
+CREATE TABLE mixed AS SELECT CASE WHEN range < 2048 THEN ['sad', 'ok', 'happy'][1 + (range % 3)]::mood ELSE 'happy'::mood END AS m FROM range(6144);
+
+query I
+SELECT count(*) FROM mixed WHERE m NOT IN ('sad');
+----
+5461
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM mixed WHERE m IN ('sad', 'ok');
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
+
+# a NULL row must not break the full-domain NOT IN classification
+statement ok
+CREATE TABLE nullables AS SELECT ['sad', 'ok', 'happy'][1 + (range % 3)]::mood AS m FROM range(6144);
+
+statement ok
+INSERT INTO nullables VALUES (NULL);
+
+query I
+SELECT count(*) FROM nullables WHERE m IN ('sad', 'ok', 'happy');
+----
+6144
+
+
+# domains above 255 values use a UINT16 physical type - coverage must hold there too
+statement ok
+CREATE TYPE big_enum AS ENUM('v0', 'v1', 'v2', 'v3', 'v4', 'v5', 'v6', 'v7', 'v8', 'v9', 'v10', 'v11', 'v12', 'v13', 'v14', 'v15', 'v16', 'v17', 'v18', 'v19', 'v20', 'v21', 'v22', 'v23', 'v24', 'v25', 'v26', 'v27', 'v28', 'v29', 'v30', 'v31', 'v32', 'v33', 'v34', 'v35', 'v36', 'v37', 'v38', 'v39', 'v40', 'v41', 'v42', 'v43', 'v44', 'v45', 'v46', 'v47', 'v48', 'v49', 'v50', 'v51', 'v52', 'v53', 'v54', 'v55', 'v56', 'v57', 'v58', 'v59', 'v60', 'v61', 'v62', 'v63', 'v64', 'v65', 'v66', 'v67', 'v68', 'v69', 'v70', 'v71', 'v72', 'v73', 'v74', 'v75', 'v76', 'v77', 'v78', 'v79', 'v80', 'v81', 'v82', 'v83', 'v84', 'v85', 'v86', 'v87', 'v88', 'v89', 'v90', 'v91', 'v92', 'v93', 'v94', 'v95', 'v96', 'v97', 'v98', 'v99', 'v100', 'v101', 'v102', 'v103', 'v104', 'v105', 'v106', 'v107', 'v108', 'v109', 'v110', 'v111', 'v112', 'v113', 'v114', 'v115', 'v116', 'v117', 'v118', 'v119', 'v120', 'v121', 'v122', 'v123', 'v124', 'v125', 'v126', 'v127', 'v128', 'v129', 'v130', 'v131', 'v132', 'v133', 'v134', 'v135', 'v136', 'v137', 'v138', 'v139', 'v140', 'v141', 'v142', 'v143', 'v144', 'v145', 'v146', 'v147', 'v148', 'v149', 'v150', 'v151', 'v152', 'v153', 'v154', 'v155', 'v156', 'v157', 'v158', 'v159', 'v160', 'v161', 'v162', 'v163', 'v164', 'v165', 'v166', 'v167', 'v168', 'v169', 'v170', 'v171', 'v172', 'v173', 'v174', 'v175', 'v176', 'v177', 'v178', 'v179', 'v180', 'v181', 'v182', 'v183', 'v184', 'v185', 'v186', 'v187', 'v188', 'v189', 'v190', 'v191', 'v192', 'v193', 'v194', 'v195', 'v196', 'v197', 'v198', 'v199', 'v200', 'v201', 'v202', 'v203', 'v204', 'v205', 'v206', 'v207', 'v208', 'v209', 'v210', 'v211', 'v212', 'v213', 'v214', 'v215', 'v216', 'v217', 'v218', 'v219', 'v220', 'v221', 'v222', 'v223', 'v224', 'v225', 'v226', 'v227', 'v228', 'v229', 'v230', 'v231', 'v232', 'v233', 'v234', 'v235', 'v236', 'v237', 'v238', 'v239', 'v240', 'v241', 'v242', 'v243', 'v244', 'v245', 'v246', 'v247', 'v248', 'v249', 'v250', 'v251', 'v252', 'v253', 'v254', 'v255', 'v256', 'v257', 'v258', 'v259');
+
+statement ok
+CREATE TABLE wide AS SELECT ('v' || (range % 260))::big_enum AS m FROM range(6144);
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM wide WHERE m NOT IN ('v0', 'v1', 'v2', 'v3', 'v4', 'v5', 'v6', 'v7', 'v8', 'v9', 'v10', 'v11', 'v12', 'v13', 'v14', 'v15', 'v16', 'v17', 'v18', 'v19', 'v20', 'v21', 'v22', 'v23', 'v24', 'v25', 'v26', 'v27', 'v28', 'v29', 'v30', 'v31', 'v32', 'v33', 'v34', 'v35', 'v36', 'v37', 'v38', 'v39', 'v40', 'v41', 'v42', 'v43', 'v44', 'v45', 'v46', 'v47', 'v48', 'v49', 'v50', 'v51', 'v52', 'v53', 'v54', 'v55', 'v56', 'v57', 'v58', 'v59', 'v60', 'v61', 'v62', 'v63', 'v64', 'v65', 'v66', 'v67', 'v68', 'v69', 'v70', 'v71', 'v72', 'v73', 'v74', 'v75', 'v76', 'v77', 'v78', 'v79', 'v80', 'v81', 'v82', 'v83', 'v84', 'v85', 'v86', 'v87', 'v88', 'v89', 'v90', 'v91', 'v92', 'v93', 'v94', 'v95', 'v96', 'v97', 'v98', 'v99', 'v100', 'v101', 'v102', 'v103', 'v104', 'v105', 'v106', 'v107', 'v108', 'v109', 'v110', 'v111', 'v112', 'v113', 'v114', 'v115', 'v116', 'v117', 'v118', 'v119', 'v120', 'v121', 'v122', 'v123', 'v124', 'v125', 'v126', 'v127', 'v128', 'v129', 'v130', 'v131', 'v132', 'v133', 'v134', 'v135', 'v136', 'v137', 'v138', 'v139', 'v140', 'v141', 'v142', 'v143', 'v144', 'v145', 'v146', 'v147', 'v148', 'v149', 'v150', 'v151', 'v152', 'v153', 'v154', 'v155', 'v156', 'v157', 'v158', 'v159', 'v160', 'v161', 'v162', 'v163', 'v164', 'v165', 'v166', 'v167', 'v168', 'v169', 'v170', 'v171', 'v172', 'v173', 'v174', 'v175', 'v176', 'v177', 'v178', 'v179', 'v180', 'v181', 'v182', 'v183', 'v184', 'v185', 'v186', 'v187', 'v188', 'v189', 'v190', 'v191', 'v192', 'v193', 'v194', 'v195', 'v196', 'v197', 'v198', 'v199', 'v200', 'v201', 'v202', 'v203', 'v204', 'v205', 'v206', 'v207', 'v208', 'v209', 'v210', 'v211', 'v212', 'v213', 'v214', 'v215', 'v216', 'v217', 'v218', 'v219', 'v220', 'v221', 'v222', 'v223', 'v224', 'v225', 'v226', 'v227', 'v228', 'v229', 'v230', 'v231', 'v232', 'v233', 'v234', 'v235', 'v236', 'v237', 'v238', 'v239', 'v240', 'v241', 'v242', 'v243', 'v244', 'v245', 'v246', 'v247', 'v248', 'v249', 'v250', 'v251', 'v252', 'v253', 'v254', 'v255', 'v256', 'v257', 'v258', 'v259');
+----
+analyzed_plan	<REGEX>:.*Empty Result.*
+
+query I
+SELECT count(*) FROM wide WHERE m NOT IN ('v0', 'v1', 'v2');
+----
+6072

--- a/test/sql/optimizer/enum_domain_row_group_pruning.test
+++ b/test/sql/optimizer/enum_domain_row_group_pruning.test
@@ -98,6 +98,21 @@ SELECT currval('seq_test');
 ----
 <REGEX>:.*currval.*not yet defined.*
 
+# the empty-result collapse reaches DML plans: no rows flow to the DELETE,
+# so nothing is removed while every row group is pruned
+query II
+EXPLAIN DELETE FROM covered WHERE m NOT IN ('sad', 'ok', 'happy');
+----
+physical_plan	<REGEX>:.*Empty Result.*
+
+statement ok
+DELETE FROM covered WHERE m NOT IN ('sad', 'ok', 'happy');
+
+query I
+SELECT count(*) FROM covered;
+----
+6144
+
 
 # domains above 255 values use a UINT16 physical type - coverage must hold there too
 statement ok


### PR DESCRIPTION
Hi team!

This fixes #24417: a `NOT IN` listing every value of an ENUM column is unsatisfiable, but DuckDB still reads every row group and filters row by row. The integer side of this has worked since #24521; ENUM falls one step short of the same machinery.

`NumericStats::ConstantsCoverRange` gates full-range constant coverage on `type.IsIntegral()`, and ENUM is not in that set even though ENUM columns carry numeric min/max zonemaps. An ENUM is a closed domain declared by its type, so coverage is a set test against the declared domain rather than a `[min, max]` interval test and needs no zonemaps at all: this adds `NumericStats::ConstantsCoverDomain` and routes ENUM statistics to it from `ConstantsCoverRange`. For nullable columns the child `IN` can never classify as always-true (it is true-or-NULL), so `CheckNotOperatorStatistics` detects the coverage itself and returns `FILTER_FALSE_OR_NULL`, which the existing empty-result machinery collapses. And this also reaches DELETE/UPDATE plans through the default statistics propagation.

On three row groups whose values span the full domain:

```sql
EXPLAIN ANALYZE SELECT count(*) FROM t WHERE m NOT IN ('sad', 'ok', 'happy');
-- main:  Row Groups Scanned: 3 / 3
-- patch: Empty Result
```

I notice that there is an open expression-rewrite attempt for the same issue in #24706. While the changes in this branch takes the statistics-layer route, and also covers nullable columns and DML plans where a rewrite pass keeps the filter in place.
#24706 can do two things this route cannot. For the positive `IN` over the full domain it removes the filter entirely - here an OR rewrite above the scan still evaluates per row. And its rewrite needs no column statistics, so it also helps stats-free inputs like `VALUES`, where this change does nothing.

```sql
EXPLAIN SELECT count(*) FROM t WHERE m IN ('sad', 'ok', 'happy');
-- #24706: filter gone - the IN rewrites to a constant true on non-NULL columns
-- patch:  scan-level IN filter dropped, but (m = 'sad') OR (m = 'ok') OR (m = 'happy') stays and evaluates per row

SELECT count(*) FROM (VALUES ('sad'::mood), ('ok'::mood), ('happy'::mood)) v(m) WHERE m NOT IN ('sad', 'ok', 'happy');
-- #24706: predicate rewritten to a cheap per-row constant_or_null without any statistics
-- patch:  nothing to classify without statistics, the filter passes through unchanged
```
I verified those two behaviors against both branches as well and add test cases in `test/sql/optimizer/enum_domain_row_group_pruning.test`