### PR TITLE
Fix signed integer overflow via negation of INT64_MIN interval microseconds

### DIFF
--- a/src/common/types/interval.cpp
+++ b/src/common/types/interval.cpp
@@ -10,6 +10,7 @@
 #include "duckdb/common/operator/multiply.hpp"
 #include "duckdb/common/operator/subtract.hpp"
 #include "duckdb/common/string_util.hpp"
+#include "duckdb/common/limits.hpp"
 
 namespace duckdb {
 
@@ -546,6 +547,15 @@ interval_t Interval::FromMicro(int64_t delta_us) {
 }
 
 interval_t Interval::Invert(interval_t interval) {
+	if (interval.days == NumericLimits<int32_t>::Minimum()) {
+		throw OutOfRangeException("Interval days value out of range");
+	}
+	if (interval.micros == NumericLimits<int64_t>::Minimum()) {
+		throw OutOfRangeException("Interval micros value out of range");
+	}
+	if (interval.months == NumericLimits<int32_t>::Minimum()) {
+		throw OutOfRangeException("Interval months value out of range");
+	}
 	interval.days = -interval.days;
 	interval.micros = -interval.micros;
 	interval.months = -interval.months;

--- a/src/function/scalar/operator/subtract.cpp
+++ b/src/function/scalar/operator/subtract.cpp
@@ -240,12 +240,18 @@ hugeint_t DecimalSubtractOverflowCheck::Operation(hugeint_t left, hugeint_t righ
 //===--------------------------------------------------------------------===//
 template <>
 dtime_t SubtractTimeOperator::Operation(dtime_t left, interval_t right) {
+	if (right.micros == NumericLimits<int64_t>::Minimum()) {
+		throw OutOfRangeException("Interval micros value out of range");
+	}
 	right.micros = -right.micros;
 	return AddTimeOperator::Operation<dtime_t, interval_t, dtime_t>(left, right);
 }
 
 template <>
 dtime_tz_t SubtractTimeOperator::Operation(dtime_tz_t left, interval_t right) {
+	if (right.micros == NumericLimits<int64_t>::Minimum()) {
+		throw OutOfRangeException("Interval micros value out of range");
+	}
 	right.micros = -right.micros;
 	return AddTimeOperator::Operation<dtime_tz_t, interval_t, dtime_tz_t>(left, right);
 }

--- a/test/sql/types/test_interval_negation_overflow.test
+++ b/test/sql/types/test_interval_negation_overflow.test
@@ -1,0 +1,38 @@
+# name: test/sql/types/test_interval_negation_overflow.test
+# description: Test for signed integer overflow via negation of INT64_MIN interval microseconds
+# group: [types]
+
+# Issue #25084: Signed Integer Overflow via Negation of INT64_MIN Interval Microseconds
+# SubtractTimeOperator::Operation negates right.micros without checking for INT64_MIN,
+# causing signed integer overflow (undefined behavior).
+
+# TIME - INTERVAL with INT64_MIN microseconds should throw an error, not overflow
+statement error
+SELECT TIME '12:00:00' - INTERVAL '-4611686018427387904 microseconds -4611686018427387904 microseconds';
+----
+<REGEX>:.*out of range.*
+
+# TIMETZ - INTERVAL with INT64_MIN microseconds should throw an error, not overflow
+statement error
+SELECT TIMETZ '12:00:00+00' - INTERVAL '-4611686018427387904 microseconds -4611686018427387904 microseconds';
+----
+<REGEX>:.*out of range.*
+
+# Interval::Invert with INT64_MIN micros should also throw
+statement error
+SELECT '1 hour'::INTERVAL - INTERVAL '9223372036854775807 microseconds 1 microseconds';
+----
+<REGEX>:.*out of range.*
+
+# Normal cases should still work
+statement ok
+SELECT TIME '12:00:00' - INTERVAL '1 hour';
+
+statement ok
+SELECT TIMETZ '12:00:00+00' - INTERVAL '1 hour';
+
+statement ok
+SELECT DATE '2024-01-01' - INTERVAL '1 month';
+
+statement ok
+SELECT TIMESTAMP '2024-01-01 12:00:00' - INTERVAL '1 day';


### PR DESCRIPTION
Fixes #25084

SubtractTimeOperator::Operation negated right.micros without checking
for INT64_MIN, causing signed integer overflow (undefined behavior).
Interval::Invert had the same issue for all three fields.

Add overflow checks before each negation, throwing OutOfRangeException.

3 files changed, 54 insertions
All interval, time, date, and timestamp tests passing.