### PR TITLE
Backport #22678: avoid per-row DATE->TIMESTAMP casts in comparisons

### DIFF
--- a/src/optimizer/rule/comparison_simplification.cpp
+++ b/src/optimizer/rule/comparison_simplification.cpp
@@ -38,7 +38,6 @@ static bool DateTimestampComparisonIsInvertible(BoundComparisonExpression &expr,
 	default:
 		break;
 	}
-
 	// The examples describe the column-left form; column-right comparisons invert the day bump.
 	bool add_one_day;
 	switch (op) {

--- a/src/optimizer/rule/comparison_simplification.cpp
+++ b/src/optimizer/rule/comparison_simplification.cpp
@@ -1,11 +1,84 @@
 #include "duckdb/planner/expression/list.hpp"
 #include "duckdb/optimizer/rule/comparison_simplification.hpp"
 
+#include "duckdb/common/helper.hpp"
+#include "duckdb/common/types/timestamp.hpp"
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/optimizer/expression_rewriter.hpp"
 
 namespace duckdb {
+
+static bool DateTimestampComparisonIsInvertible(BoundComparisonExpression &expr, BoundCastExpression &cast_expression,
+                                                const Value &constant_value, Value &cast_constant, bool column_ref_left,
+                                                unique_ptr<Expression> &replacement) {
+	if (Timestamp::GetTime(constant_value.GetValue<timestamp_t>()) == dtime_t(0)) {
+		return true; // it's midnight: no replacement needed
+	}
+	auto op = expr.GetExpressionType();
+
+	// Non-midnight TIMESTAMPs cannot equal DATE values.
+	switch (op) {
+	case ExpressionType::COMPARE_EQUAL:
+		// d =  T   -> false, preserving NULL
+		replacement = ExpressionRewriter::ConstantOrNull(std::move(cast_expression.child), Value::BOOLEAN(false));
+		return true;
+	case ExpressionType::COMPARE_NOTEQUAL:
+		// d != T   -> true, preserving NULL
+		replacement = ExpressionRewriter::ConstantOrNull(std::move(cast_expression.child), Value::BOOLEAN(true));
+		return true;
+	case ExpressionType::COMPARE_DISTINCT_FROM:
+		// d IS DISTINCT FROM T     -> true
+		replacement = make_uniq<BoundConstantExpression>(Value::BOOLEAN(true));
+		return true;
+	case ExpressionType::COMPARE_NOT_DISTINCT_FROM:
+		// d IS NOT DISTINCT FROM T -> false
+		replacement = make_uniq<BoundConstantExpression>(Value::BOOLEAN(false));
+		return true;
+	default:
+		break;
+	}
+
+	// The examples describe the column-left form; column-right comparisons invert the day bump.
+	bool add_one_day;
+	switch (op) {
+	case ExpressionType::COMPARE_LESSTHAN:
+		// d <  T   -> d <  DATE '2024-06-16'  -- needs +1
+		add_one_day = column_ref_left;
+		break;
+	case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+		// d >= T   -> d >= DATE '2024-06-16'  -- needs +1
+		add_one_day = column_ref_left;
+		break;
+	case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+		// d <= T   -> d <= DATE '2024-06-15'  -- no +1
+		add_one_day = !column_ref_left;
+		break;
+	case ExpressionType::COMPARE_GREATERTHAN:
+		// d >  T   -> d >  DATE '2024-06-15'  -- no +1
+		add_one_day = !column_ref_left;
+		break;
+	default:
+		return false;
+	}
+	if (add_one_day) {
+		cast_constant = Value::DATE(date_t(cast_constant.GetValue<date_t>().days + 1));
+	}
+	return true;
+}
+
+static bool ConstantCastIsInvertible(BoundComparisonExpression &expr, BoundCastExpression &cast_expression,
+                                     const Value &constant_value, Value &cast_constant, const LogicalType &target_type,
+                                     bool column_ref_left, unique_ptr<Expression> &replacement) {
+	if (cast_constant.IsNull() || BoundCastExpression::CastIsInvertible(cast_expression.return_type, target_type)) {
+		return true;
+	}
+	if (target_type.id() != LogicalTypeId::DATE || cast_expression.return_type.id() != LogicalTypeId::TIMESTAMP) {
+		return false;
+	}
+	return DateTimestampComparisonIsInvertible(expr, cast_expression, constant_value, cast_constant, column_ref_left,
+	                                           replacement);
+}
 
 ComparisonSimplificationRule::ComparisonSimplificationRule(ExpressionRewriter &rewriter) : Rule(rewriter) {
 	// match on a ComparisonExpression that has a ConstantExpression as a check
@@ -53,10 +126,13 @@ unique_ptr<Expression> ComparisonSimplificationRule::Apply(LogicalOperator &op, 
 		}
 
 		// Is the constant cast invertible?
-		if (!cast_constant.IsNull() &&
-		    !BoundCastExpression::CastIsInvertible(cast_expression.return_type, target_type)) {
-			// Cast is not invertible, so we do not rewrite this expression to ensure that the cast is executed
+		unique_ptr<Expression> replacement;
+		if (!ConstantCastIsInvertible(expr, cast_expression, constant_value, cast_constant, target_type,
+		                              column_ref_left, replacement)) {
 			return nullptr;
+		}
+		if (replacement) {
+			return replacement;
 		}
 
 		//! We can cast, now we change our column_ref_expression from an operator cast to a column reference

--- a/test/optimizer/comparison_simplification.test
+++ b/test/optimizer/comparison_simplification.test
@@ -50,3 +50,247 @@ EXPLAIN SELECT X='1' FROM test
 query I nosort constantshift
 EXPLAIN SELECT X::BIGINT='1' FROM test
 ----
+
+# DATE column compared to TIMESTAMP constant: cast is eliminated for ordering ops
+statement ok
+CREATE TABLE date_test(d DATE);
+
+statement ok
+INSERT INTO date_test VALUES ('2024-01-01'), ('2024-06-15'), ('2025-01-01');
+
+statement ok
+PRAGMA explain_output = PHYSICAL_ONLY;
+
+# --- midnight, column LEFT: all 6 ops rewrite to direct DATE comparison ---
+query II
+EXPLAIN SELECT * FROM date_test WHERE d < timestamp '2024-06-15 00:00:00';
+----
+physical_plan	<REGEX>:.*d<'2024-06-15'::DATE.*
+
+query II
+EXPLAIN SELECT * FROM date_test WHERE d <= timestamp '2024-06-15 00:00:00';
+----
+physical_plan	<REGEX>:.*d<='2024-06-15'::DATE.*
+
+query II
+EXPLAIN SELECT * FROM date_test WHERE d > timestamp '2024-06-15 00:00:00';
+----
+physical_plan	<REGEX>:.*d>'2024-06-15'::DATE.*
+
+query II
+EXPLAIN SELECT * FROM date_test WHERE d >= timestamp '2024-06-15 00:00:00';
+----
+physical_plan	<REGEX>:.*d>='2024-06-15'::DATE.*
+
+query II
+EXPLAIN SELECT * FROM date_test WHERE d = timestamp '2024-06-15 00:00:00';
+----
+physical_plan	<REGEX>:.*d='2024-06-15'::DATE.*
+
+query II
+EXPLAIN SELECT * FROM date_test WHERE d != timestamp '2024-06-15 00:00:00';
+----
+physical_plan	<REGEX>:.*d!='2024-06-15'::DATE.*
+
+# --- non-midnight, column LEFT ---
+# non-midnight, < : floor + 1 day
+query II
+EXPLAIN SELECT * FROM date_test WHERE d < timestamp '2024-06-15 12:00:00';
+----
+physical_plan	<REGEX>:.*d<'2024-06-16'::DATE.*
+
+# non-midnight, <= : floor
+query II
+EXPLAIN SELECT * FROM date_test WHERE d <= timestamp '2024-06-15 12:00:00';
+----
+physical_plan	<REGEX>:.*d<='2024-06-15'::DATE.*
+
+# non-midnight, > : floor
+query II
+EXPLAIN SELECT * FROM date_test WHERE d > timestamp '2024-06-15 12:00:00';
+----
+physical_plan	<REGEX>:.*d>'2024-06-15'::DATE.*
+
+# non-midnight, >= : floor + 1 day
+query II
+EXPLAIN SELECT * FROM date_test WHERE d >= timestamp '2024-06-15 12:00:00';
+----
+physical_plan	<REGEX>:.*d>='2024-06-16'::DATE.*
+
+# non-midnight, = : never matches — rewritten to constant_or_null(d, false)
+query II
+EXPLAIN SELECT * FROM date_test WHERE d = timestamp '2024-06-15 12:00:00';
+----
+physical_plan	<!REGEX>:.*CAST.*
+
+# non-midnight, != : always true (modulo NULL) — rewritten to constant_or_null(d, true)
+query II
+EXPLAIN SELECT * FROM date_test WHERE d != timestamp '2024-06-15 12:00:00';
+----
+physical_plan	<!REGEX>:.*CAST.*
+
+# non-midnight, IS DISTINCT FROM : always true
+query II
+EXPLAIN SELECT * FROM date_test WHERE d IS DISTINCT FROM timestamp '2024-06-15 12:00:00';
+----
+physical_plan	<!REGEX>:.*CAST.*
+
+# non-midnight, IS NOT DISTINCT FROM : always false
+query II
+EXPLAIN SELECT * FROM date_test WHERE d IS NOT DISTINCT FROM timestamp '2024-06-15 12:00:00';
+----
+physical_plan	<REGEX>:.*EMPTY_RESULT.*
+
+# correctness: =/!= against non-midnight preserve NULL semantics
+statement ok
+INSERT INTO date_test VALUES (NULL);
+
+query II
+SELECT d, d = timestamp '2024-06-15 12:00:00' AS r FROM date_test ORDER BY d;
+----
+2024-01-01	false
+2024-06-15	false
+2025-01-01	false
+NULL	NULL
+
+query II
+SELECT d, d != timestamp '2024-06-15 12:00:00' AS r FROM date_test ORDER BY d;
+----
+2024-01-01	true
+2024-06-15	true
+2025-01-01	true
+NULL	NULL
+
+query II
+SELECT d, d IS DISTINCT FROM timestamp '2024-06-15 12:00:00' AS r FROM date_test ORDER BY d;
+----
+2024-01-01	true
+2024-06-15	true
+2025-01-01	true
+NULL	true
+
+query II
+SELECT d, d IS NOT DISTINCT FROM timestamp '2024-06-15 12:00:00' AS r FROM date_test ORDER BY d;
+----
+2024-01-01	false
+2024-06-15	false
+2025-01-01	false
+NULL	false
+
+# correctness: non-midnight rewrites preserve semantics across all 4 ordering ops
+query I
+SELECT d FROM date_test WHERE d < timestamp '2024-06-15 12:00:00' ORDER BY d;
+----
+2024-01-01
+2024-06-15
+
+query I
+SELECT d FROM date_test WHERE d <= timestamp '2024-06-15 12:00:00' ORDER BY d;
+----
+2024-01-01
+2024-06-15
+
+query I
+SELECT d FROM date_test WHERE d > timestamp '2024-06-15 12:00:00' ORDER BY d;
+----
+2025-01-01
+
+query I
+SELECT d FROM date_test WHERE d >= timestamp '2024-06-15 12:00:00' ORDER BY d;
+----
+2025-01-01
+
+# --- column RIGHT: plan tests (normalized by other rules to column-left form) ---
+# midnight, T < col  ↔  col > D
+query II
+EXPLAIN SELECT * FROM date_test WHERE timestamp '2024-06-15 00:00:00' < d;
+----
+physical_plan	<REGEX>:.*d>'2024-06-15'::DATE.*
+
+# non-midnight, T < col  ↔  col > floor (no adjust)
+query II
+EXPLAIN SELECT * FROM date_test WHERE timestamp '2024-06-15 12:00:00' < d;
+----
+physical_plan	<REGEX>:.*d>'2024-06-15'::DATE.*
+
+# non-midnight, T <= col  ↔  col >= floor+1
+query II
+EXPLAIN SELECT * FROM date_test WHERE timestamp '2024-06-15 12:00:00' <= d;
+----
+physical_plan	<REGEX>:.*d>='2024-06-16'::DATE.*
+
+# non-midnight, T > col  ↔  col < floor+1
+query II
+EXPLAIN SELECT * FROM date_test WHERE timestamp '2024-06-15 12:00:00' > d;
+----
+physical_plan	<REGEX>:.*d<'2024-06-16'::DATE.*
+
+# non-midnight, T >= col  ↔  col <= floor (no adjust)
+query II
+EXPLAIN SELECT * FROM date_test WHERE timestamp '2024-06-15 12:00:00' >= d;
+----
+physical_plan	<REGEX>:.*d<='2024-06-15'::DATE.*
+
+# non-midnight, T = col → constant_or_null
+query II
+EXPLAIN SELECT * FROM date_test WHERE timestamp '2024-06-15 12:00:00' = d;
+----
+physical_plan	<!REGEX>:.*CAST.*
+
+# --- correctness: column on the right, all 4 ordering ops + =/!= ---
+query I
+SELECT d FROM date_test WHERE timestamp '2024-06-15 12:00:00' < d ORDER BY d;
+----
+2025-01-01
+
+query I
+SELECT d FROM date_test WHERE timestamp '2024-06-15 12:00:00' <= d ORDER BY d;
+----
+2025-01-01
+
+query I
+SELECT d FROM date_test WHERE timestamp '2024-06-15 12:00:00' > d ORDER BY d;
+----
+2024-01-01
+2024-06-15
+
+query I
+SELECT d FROM date_test WHERE timestamp '2024-06-15 12:00:00' >= d ORDER BY d;
+----
+2024-01-01
+2024-06-15
+
+query II
+SELECT d, timestamp '2024-06-15 12:00:00' = d AS r FROM date_test ORDER BY d;
+----
+2024-01-01	false
+2024-06-15	false
+2025-01-01	false
+NULL	NULL
+
+# --- correctness: midnight column LEFT and RIGHT ---
+query I
+SELECT d FROM date_test WHERE d = timestamp '2024-06-15 00:00:00' ORDER BY d;
+----
+2024-06-15
+
+query I
+SELECT d FROM date_test WHERE d != timestamp '2024-06-15 00:00:00' ORDER BY d;
+----
+2024-01-01
+2025-01-01
+
+query I
+SELECT d FROM date_test WHERE d IS NOT DISTINCT FROM timestamp '2024-06-15 00:00:00' ORDER BY d;
+----
+2024-06-15
+
+query I
+SELECT d FROM date_test WHERE timestamp '2024-06-15 00:00:00' < d ORDER BY d;
+----
+2025-01-01
+
+query I
+SELECT d FROM date_test WHERE timestamp '2024-06-15 00:00:00' = d ORDER BY d;
+----
+2024-06-15


### PR DESCRIPTION
Backport of duckdb/duckdb#22678 ("Be careful at midnight", merge commit 88a0b62d40) from main onto the 1.5 release line.