### PR TITLE
Move SigV4 signing logic from httpfs into core

### DIFF
--- a/.github/patches/extensions/httpfs/0004-hash-functions-core.patch
+++ b/.github/patches/extensions/httpfs/0004-hash-functions-core.patch
@@ -1,0 +1,70 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index ebc01e0..cd50fb9 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -1,5 +1,4 @@
+-set(HTTPFS_SOURCES hffs.cpp hash_functions.cpp create_secret_functions.cpp
+-                   httpfs_extension.cpp)
++set(HTTPFS_SOURCES hffs.cpp create_secret_functions.cpp httpfs_extension.cpp)
+ if(NOT EMSCRIPTEN)
+   list(APPEND HTTPFS_SOURCES crypto.cpp)
+ endif()
+diff --git a/src/hash_functions.cpp b/src/hash_functions.cpp
+deleted file mode 100644
+index c5293bb..0000000
+--- a/src/hash_functions.cpp
++++ /dev/null
+@@ -1,25 +0,0 @@
+-#include "hash_functions.hpp"
+-
+-namespace duckdb {
+-
+-void sha256(EncryptionUtil &encryption_util, const_data_ptr_t in, idx_t in_len, hash_bytes &out) {
+-	D_ASSERT(CryptoHash::GetDigestSize(CryptoHashFunction::SHA256) == sizeof(hash_bytes));
+-	encryption_util.Hash(CryptoHashFunction::SHA256, in, in_len, out);
+-}
+-
+-void hmac256(EncryptionUtil &encryption_util, const std::string &message, const_data_ptr_t secret, idx_t secret_len,
+-             hash_bytes &out) {
+-	D_ASSERT(CryptoHash::GetDigestSize(CryptoHashFunction::SHA256) == sizeof(hash_bytes));
+-	encryption_util.Hmac(CryptoHashFunction::SHA256, secret, secret_len, const_data_ptr_cast(message.data()),
+-	                     message.size(), out);
+-}
+-
+-void hmac256(EncryptionUtil &encryption_util, std::string message, hash_bytes secret, hash_bytes &out) {
+-	hmac256(encryption_util, message, secret, sizeof(hash_bytes), out);
+-}
+-
+-void hex256(hash_bytes &in, hash_str &out) {
+-	CryptoHash::ToHex(in, sizeof(hash_bytes), char_ptr_cast(out));
+-}
+-
+-} // namespace duckdb
+diff --git a/src/include/hash_functions.hpp b/src/include/hash_functions.hpp
+deleted file mode 100644
+index 27fc855..0000000
+--- a/src/include/hash_functions.hpp
++++ /dev/null
+@@ -1,22 +0,0 @@
+-#pragma once
+-
+-#include "duckdb/common/encryption_state.hpp"
+-#include "duckdb/common/helper.hpp"
+-
+-#include <string>
+-
+-namespace duckdb {
+-
+-typedef unsigned char hash_bytes[32];
+-typedef unsigned char hash_str[64];
+-
+-void sha256(EncryptionUtil &encryption_util, const_data_ptr_t in, idx_t in_len, hash_bytes &out);
+-
+-void hmac256(EncryptionUtil &encryption_util, const std::string &message, const_data_ptr_t secret, idx_t secret_len,
+-             hash_bytes &out);
+-
+-void hmac256(EncryptionUtil &encryption_util, std::string message, hash_bytes secret, hash_bytes &out);
+-
+-void hex256(hash_bytes &in, hash_str &out);
+-
+-} // namespace duckdb

--- a/.github/patches/extensions/httpfs/0005-sigv4-core-patch.patch
+++ b/.github/patches/extensions/httpfs/0005-sigv4-core-patch.patch
@@ -1,0 +1,53 @@
+diff --git a/src/s3/s3_request.cpp b/src/s3/s3_request.cpp
+index 10802ae..3131312 100644
+--- a/src/s3/s3_request.cpp
++++ b/src/s3/s3_request.cpp
+@@ -2,11 +2,12 @@
+ 
+ #include "s3/s3fs.hpp"
+ #include "create_secret_functions.hpp"
+-#include "hash_functions.hpp"
+ #include "http/http_state.hpp"
+ 
+ #include "duckdb/common/exception/http_exception.hpp"
++#include "duckdb/common/hash_functions.hpp"
+ #include "duckdb/common/helper.hpp"
++#include "duckdb/common/http_util.hpp"
+ #include "duckdb/common/string_util.hpp"
+ #include "duckdb/common/thread.hpp"
+ #include "duckdb/common/types/timestamp.hpp"
+@@ -124,25 +125,15 @@ private:
+ 	}
+ 
+ 	string CreateSignature(const string &canonical_request) const {
+-		hash_bytes canonical_request_hash;
+-		hash_str canonical_request_hash_str;
+-		sha256(encryption_util, const_data_ptr_cast(canonical_request.data()), canonical_request.length(),
+-		       canonical_request_hash);
+-		hex256(canonical_request_hash, canonical_request_hash_str);
+-
+-		auto string_to_sign = "AWS4-HMAC-SHA256\n" + datetime_now + "\n" + CredentialScope() + "\n" +
+-		                      string(const_char_ptr_cast(canonical_request_hash_str), sizeof(hash_str));
+-		hash_bytes k_date, k_region, k_service, signing_key, signature;
+-		auto sign_key = "AWS4" + auth_params.secret_access_key;
+-		hmac256(encryption_util, date_now, const_data_ptr_cast(sign_key.data()), sign_key.length(), k_date);
+-		hmac256(encryption_util, auth_params.region, k_date, k_region);
+-		hmac256(encryption_util, service, k_region, k_service);
+-		hmac256(encryption_util, "aws4_request", k_service, signing_key);
+-		hmac256(encryption_util, string_to_sign, signing_key, signature);
+-
+-		hash_str signature_str;
+-		hex256(signature, signature_str);
+-		return string(const_char_ptr_cast(signature_str), sizeof(hash_str));
++		SignatureV4Params sig_params;
++		sig_params.canonical_request = canonical_request;
++		sig_params.credential_scope = CredentialScope();
++		sig_params.region = auth_params.region;
++		sig_params.service = service;
++		sig_params.secret_access_key = auth_params.secret_access_key;
++		sig_params.date_now = date_now;
++		sig_params.datetime_now = datetime_now;
++		return HTTPUtil::CreateSignatureV4(encryption_util, sig_params);
+ 	}
+ 
+ 	string CredentialScope() const {

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -57,6 +57,7 @@ add_library_unity(
   path.cpp
   fsst.cpp
   gzip_file_system.cpp
+  hash_functions.cpp
   identifier.cpp
   memory_safety.cpp
   hive_partitioning.cpp

--- a/src/common/hash_functions.cpp
+++ b/src/common/hash_functions.cpp
@@ -1,0 +1,25 @@
+#include "duckdb/common/hash_functions.hpp"
+
+namespace duckdb {
+
+void sha256(EncryptionUtil &encryption_util, const_data_ptr_t in, idx_t in_len, hash_bytes &out) {
+	D_ASSERT(CryptoHash::GetDigestSize(CryptoHashFunction::SHA256) == sizeof(hash_bytes));
+	encryption_util.Hash(CryptoHashFunction::SHA256, in, in_len, out);
+}
+
+void hmac256(EncryptionUtil &encryption_util, const std::string &message, const_data_ptr_t secret, idx_t secret_len,
+             hash_bytes &out) {
+	D_ASSERT(CryptoHash::GetDigestSize(CryptoHashFunction::SHA256) == sizeof(hash_bytes));
+	encryption_util.Hmac(CryptoHashFunction::SHA256, secret, secret_len, const_data_ptr_cast(message.data()),
+	                     message.size(), out);
+}
+
+void hmac256(EncryptionUtil &encryption_util, std::string message, hash_bytes secret, hash_bytes &out) {
+	hmac256(encryption_util, message, secret, sizeof(hash_bytes), out);
+}
+
+void hex256(hash_bytes &in, hash_str &out) {
+	CryptoHash::ToHex(in, sizeof(hash_bytes), char_ptr_cast(out));
+}
+
+} // namespace duckdb

--- a/src/common/hash_functions.cpp
+++ b/src/common/hash_functions.cpp
@@ -14,7 +14,7 @@ void hmac256(EncryptionUtil &encryption_util, const std::string &message, const_
 	                     message.size(), out);
 }
 
-void hmac256(EncryptionUtil &encryption_util, std::string message, hash_bytes secret, hash_bytes &out) {
+void hmac256(EncryptionUtil &encryption_util, const std::string &message, hash_bytes secret, hash_bytes &out) {
 	hmac256(encryption_util, message, secret, sizeof(hash_bytes), out);
 }
 

--- a/src/include/duckdb/common/hash_functions.hpp
+++ b/src/include/duckdb/common/hash_functions.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "duckdb/common/encryption_state.hpp"
+#include "duckdb/common/helper.hpp"
+
+#include <string>
+
+namespace duckdb {
+
+typedef unsigned char hash_bytes[32];
+typedef unsigned char hash_str[64];
+
+void sha256(EncryptionUtil &encryption_util, const_data_ptr_t in, idx_t in_len, hash_bytes &out);
+
+void hmac256(EncryptionUtil &encryption_util, const std::string &message, const_data_ptr_t secret, idx_t secret_len,
+             hash_bytes &out);
+
+void hmac256(EncryptionUtil &encryption_util, std::string message, hash_bytes secret, hash_bytes &out);
+
+void hex256(hash_bytes &in, hash_str &out);
+
+} // namespace duckdb

--- a/src/include/duckdb/common/hash_functions.hpp
+++ b/src/include/duckdb/common/hash_functions.hpp
@@ -15,7 +15,7 @@ void sha256(EncryptionUtil &encryption_util, const_data_ptr_t in, idx_t in_len, 
 void hmac256(EncryptionUtil &encryption_util, const std::string &message, const_data_ptr_t secret, idx_t secret_len,
              hash_bytes &out);
 
-void hmac256(EncryptionUtil &encryption_util, std::string message, hash_bytes secret, hash_bytes &out);
+void hmac256(EncryptionUtil &encryption_util, const std::string &message, hash_bytes secret, hash_bytes &out);
 
 void hex256(hash_bytes &in, hash_str &out);
 

--- a/src/include/duckdb/common/http_util.hpp
+++ b/src/include/duckdb/common/http_util.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb/common/types.hpp"
 #include "duckdb/common/case_insensitive_map.hpp"
+#include "duckdb/common/encryption_state.hpp"
 #include "duckdb/common/enums/http_status_code.hpp"
 #include "duckdb/common/types/timestamp.hpp"
 #include "duckdb/common/time_point.hpp"
@@ -64,6 +65,16 @@ public:
 		DynamicCastCheck<TARGET>(this);
 		return reinterpret_cast<const TARGET &>(*this);
 	}
+};
+
+struct SignatureV4Params {
+	string canonical_request;
+	string credential_scope;
+	string region;
+	string service;
+	string secret_access_key;
+	string date_now;
+	string datetime_now;
 };
 
 enum class RequestType : uint8_t {
@@ -340,6 +351,7 @@ public:
 	static string GetStatusMessage(HTTPStatusCode status);
 	static bool IsHTTPProtocol(const string &url);
 	static void BumpToSecureProtocol(string &url);
+	static string CreateSignatureV4(EncryptionUtil &encryption_util, const SignatureV4Params &sig_params);
 
 public:
 	static duckdb::unique_ptr<HTTPResponse>

--- a/src/main/http/http_util.cpp
+++ b/src/main/http/http_util.cpp
@@ -2,6 +2,7 @@
 
 #include "duckdb/common/error_data.hpp"
 #include "duckdb/common/exception/http_exception.hpp"
+#include "duckdb/common/hash_functions.hpp"
 #include "duckdb/common/limits.hpp"
 #include "duckdb/common/operator/cast_operators.hpp"
 #include "duckdb/common/random_engine.hpp"
@@ -639,6 +640,28 @@ void HTTPUtil::BumpToSecureProtocol(string &url) {
 	if (IsHTTPProtocol(url)) {
 		url = "https://" + url.substr(7);
 	}
+}
+
+string HTTPUtil::CreateSignatureV4(EncryptionUtil &encryption_util, const SignatureV4Params &sig_params) {
+	hash_bytes canonical_request_hash;
+	hash_str canonical_request_hash_str;
+	sha256(encryption_util, const_data_ptr_cast(sig_params.canonical_request.data()),
+	       sig_params.canonical_request.length(), canonical_request_hash);
+	hex256(canonical_request_hash, canonical_request_hash_str);
+
+	auto string_to_sign = "AWS4-HMAC-SHA256\n" + sig_params.datetime_now + "\n" + sig_params.credential_scope + "\n" +
+	                      string(const_char_ptr_cast(canonical_request_hash_str), sizeof(hash_str));
+	hash_bytes k_date, k_region, k_service, signing_key, signature;
+	auto sign_key = "AWS4" + sig_params.secret_access_key;
+	hmac256(encryption_util, sig_params.date_now, const_data_ptr_cast(sign_key.data()), sign_key.length(), k_date);
+	hmac256(encryption_util, sig_params.region, k_date, k_region);
+	hmac256(encryption_util, sig_params.service, k_region, k_service);
+	hmac256(encryption_util, "aws4_request", k_service, signing_key);
+	hmac256(encryption_util, string_to_sign, signing_key, signature);
+
+	hash_str signature_str;
+	hex256(signature, signature_str);
+	return string(const_char_ptr_cast(signature_str), sizeof(hash_str));
 }
 
 } // namespace duckdb


### PR DESCRIPTION
This PR moves the implementation of the [Signature Version 4](https://docs.aws.amazon.com/AmazonS3/latest/developerguide/sig-v4-authenticating-requests.html) from `duckdb-httpfs` into `HTTPUtil` in core.

Implementation of a few hash functions is also moved from `httpfs` to core as a required dependency to SigV4 generation.

There are no functional changes, generating logic and its usage in `httpfs` remains the same as before.

Ref: duckdblabs/duckdb-internal#5731