### PR TITLE
fix: list_sort orders INTERVALs consistently with comparison/ORDER BY

### DIFF
--- a/extension/core_functions/scalar/list/list_sort.cpp
+++ b/extension/core_functions/scalar/list/list_sort.cpp
@@ -9,6 +9,7 @@
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/main/config.hpp"
 #include "duckdb/common/sorting/sort.hpp"
+#include "duckdb/planner/expression_binder.hpp"
 #include "duckdb/parallel/thread_context.hpp"
 
 namespace duckdb {
@@ -48,6 +49,13 @@ ListSortBindData::ListSortBindData(OrderType order_type_p, OrderByNullType null_
 	// get the BoundOrderByNode
 	auto idx_col_expr = make_uniq_base<Expression, BoundReferenceExpression>(LogicalType::USMALLINT, 0U);
 	auto lists_col_expr = make_uniq_base<Expression, BoundReferenceExpression>(child_type, 1U);
+	// Normalize the sort key without changing the sorted values (#25108): push the
+	// type's collation (for INTERVAL this wraps the expression in
+	// normalized_interval(...), the same normalization comparison operators, ORDER BY
+	// and aggregates apply) onto the key expression BEFORE constructing its
+	// BoundOrderByNode. The key then byte-compares like ORDER BY, while the list
+	// payload keeps the original (non-normalized) values.
+	ExpressionBinder::PushCollation(context, lists_col_expr, child_type);
 	vector<BoundOrderByNode> orders;
 	orders.emplace_back(OrderType::ASCENDING, OrderByNullType::ORDER_DEFAULT, std::move(idx_col_expr));
 	orders.emplace_back(order_type, null_order, std::move(lists_col_expr));

--- a/src/function/scalar/create_sort_key.cpp
+++ b/src/function/scalar/create_sort_key.cpp
@@ -239,6 +239,53 @@ struct SortKeyConstantOperator {
 	}
 };
 
+struct SortKeyIntervalOperator {
+	using TYPE = interval_t;
+
+	static idx_t GetEncodeLength(TYPE input) {
+		return sizeof(interval_t);
+	}
+
+	template <bool FLIP_BYTES>
+	static idx_t Encode(data_ptr_t result, TYPE input) {
+		// Encode the NORMALIZED interval. interval_t::operator> (used by comparisons,
+		// ORDER BY and aggregates) normalizes the interval (1 month = 30 days, 1 day = 24h,
+		// carrying into a canonical form with days in [0, 30) and micros in [0, MICROS_PER_DAY))
+		// and then compares (months, days, micros) lexicographically. Radix-encoding the
+		// normalized value here yields the same byte-comparison order, so list_sort,
+		// list_reverse_sort, list_grade_up, list_distinct and create_sort_key all agree
+		// with comparison/ORDER BY. (#25108)
+		Radix::EncodeData<interval_t>(result, input.Normalize());
+		if (FLIP_BYTES) {
+			// flip word-at-a-time - the encoded size is a compile-time constant, so this fully unrolls
+			idx_t b = 0;
+			for (; b + SortKeyWord::SIZE <= sizeof(interval_t); b += SortKeyWord::SIZE) {
+				Store<uint64_t>(~Load<uint64_t>(result + b), result + b);
+			}
+			for (; b < sizeof(interval_t); b++) {
+				result[b] = static_cast<data_t>(~result[b]);
+			}
+		}
+		return sizeof(interval_t);
+	}
+
+	template <bool FLIP_BYTES>
+	static idx_t Decode(const_data_ptr_t input, idx_t input_size, Vector &result, TYPE &result_value) {
+		D_ASSERT(input_size >= sizeof(interval_t));
+		if (FLIP_BYTES) {
+			// descending order - so flip bytes
+			data_t flipped_bytes[sizeof(interval_t)];
+			for (idx_t b = 0; b < sizeof(interval_t); b++) {
+				flipped_bytes[b] = static_cast<data_t>(~input[b]);
+			}
+			result_value = Radix::DecodeData<interval_t>(flipped_bytes);
+		} else {
+			result_value = Radix::DecodeData<interval_t>(input);
+		}
+		return sizeof(interval_t);
+	}
+};
+
 struct SortKeyVarcharOperator {
 	using TYPE = string_t;
 
@@ -562,7 +609,7 @@ void GetSortKeyLengthRecursive(SortKeyVectorData &vector_data, SortKeyChunk chun
 		TemplatedGetSortKeyLength<SortKeyConstantOperator<double>>(vector_data, chunk, result);
 		break;
 	case PhysicalType::INTERVAL:
-		TemplatedGetSortKeyLength<SortKeyConstantOperator<interval_t>>(vector_data, chunk, result);
+		TemplatedGetSortKeyLength<SortKeyIntervalOperator>(vector_data, chunk, result);
 		break;
 	case PhysicalType::UINT128:
 		TemplatedGetSortKeyLength<SortKeyConstantOperator<uhugeint_t>>(vector_data, chunk, result);
@@ -778,7 +825,7 @@ void ConstructSortKeyRecursive(SortKeyVectorData &vector_data, SortKeyChunk chun
 		TemplatedConstructSortKey<SortKeyConstantOperator<double>>(vector_data, chunk, info);
 		break;
 	case PhysicalType::INTERVAL:
-		TemplatedConstructSortKey<SortKeyConstantOperator<interval_t>>(vector_data, chunk, info);
+		TemplatedConstructSortKey<SortKeyIntervalOperator>(vector_data, chunk, info);
 		break;
 	case PhysicalType::UINT128:
 		TemplatedConstructSortKey<SortKeyConstantOperator<uhugeint_t>>(vector_data, chunk, info);
@@ -1389,7 +1436,7 @@ void DecodeSortKeyRecursive(DecodeSortKeyData decode_data[], DecodeSortKeyVector
 		TemplatedDecodeSortKey<SortKeyConstantOperator<double>>(decode_data, vector_data, result, result_offset, count);
 		break;
 	case PhysicalType::INTERVAL:
-		TemplatedDecodeSortKey<SortKeyConstantOperator<interval_t>>(decode_data, vector_data, result, result_offset,
+		TemplatedDecodeSortKey<SortKeyIntervalOperator>(decode_data, vector_data, result, result_offset,
 		                                                            count);
 		break;
 	case PhysicalType::UINT128:

--- a/src/function/scalar/create_sort_key.cpp
+++ b/src/function/scalar/create_sort_key.cpp
@@ -239,53 +239,6 @@ struct SortKeyConstantOperator {
 	}
 };
 
-struct SortKeyIntervalOperator {
-	using TYPE = interval_t;
-
-	static idx_t GetEncodeLength(TYPE input) {
-		return sizeof(interval_t);
-	}
-
-	template <bool FLIP_BYTES>
-	static idx_t Encode(data_ptr_t result, TYPE input) {
-		// Encode the NORMALIZED interval. interval_t::operator> (used by comparisons,
-		// ORDER BY and aggregates) normalizes the interval (1 month = 30 days, 1 day = 24h,
-		// carrying into a canonical form with days in [0, 30) and micros in [0, MICROS_PER_DAY))
-		// and then compares (months, days, micros) lexicographically. Radix-encoding the
-		// normalized value here yields the same byte-comparison order, so list_sort,
-		// list_reverse_sort, list_grade_up, list_distinct and create_sort_key all agree
-		// with comparison/ORDER BY. (#25108)
-		Radix::EncodeData<interval_t>(result, input.Normalize());
-		if (FLIP_BYTES) {
-			// flip word-at-a-time - the encoded size is a compile-time constant, so this fully unrolls
-			idx_t b = 0;
-			for (; b + SortKeyWord::SIZE <= sizeof(interval_t); b += SortKeyWord::SIZE) {
-				Store<uint64_t>(~Load<uint64_t>(result + b), result + b);
-			}
-			for (; b < sizeof(interval_t); b++) {
-				result[b] = static_cast<data_t>(~result[b]);
-			}
-		}
-		return sizeof(interval_t);
-	}
-
-	template <bool FLIP_BYTES>
-	static idx_t Decode(const_data_ptr_t input, idx_t input_size, Vector &result, TYPE &result_value) {
-		D_ASSERT(input_size >= sizeof(interval_t));
-		if (FLIP_BYTES) {
-			// descending order - so flip bytes
-			data_t flipped_bytes[sizeof(interval_t)];
-			for (idx_t b = 0; b < sizeof(interval_t); b++) {
-				flipped_bytes[b] = static_cast<data_t>(~input[b]);
-			}
-			result_value = Radix::DecodeData<interval_t>(flipped_bytes);
-		} else {
-			result_value = Radix::DecodeData<interval_t>(input);
-		}
-		return sizeof(interval_t);
-	}
-};
-
 struct SortKeyVarcharOperator {
 	using TYPE = string_t;
 
@@ -609,7 +562,7 @@ void GetSortKeyLengthRecursive(SortKeyVectorData &vector_data, SortKeyChunk chun
 		TemplatedGetSortKeyLength<SortKeyConstantOperator<double>>(vector_data, chunk, result);
 		break;
 	case PhysicalType::INTERVAL:
-		TemplatedGetSortKeyLength<SortKeyIntervalOperator>(vector_data, chunk, result);
+		TemplatedGetSortKeyLength<SortKeyConstantOperator<interval_t>>(vector_data, chunk, result);
 		break;
 	case PhysicalType::UINT128:
 		TemplatedGetSortKeyLength<SortKeyConstantOperator<uhugeint_t>>(vector_data, chunk, result);
@@ -825,7 +778,7 @@ void ConstructSortKeyRecursive(SortKeyVectorData &vector_data, SortKeyChunk chun
 		TemplatedConstructSortKey<SortKeyConstantOperator<double>>(vector_data, chunk, info);
 		break;
 	case PhysicalType::INTERVAL:
-		TemplatedConstructSortKey<SortKeyIntervalOperator>(vector_data, chunk, info);
+		TemplatedConstructSortKey<SortKeyConstantOperator<interval_t>>(vector_data, chunk, info);
 		break;
 	case PhysicalType::UINT128:
 		TemplatedConstructSortKey<SortKeyConstantOperator<uhugeint_t>>(vector_data, chunk, info);
@@ -1436,7 +1389,7 @@ void DecodeSortKeyRecursive(DecodeSortKeyData decode_data[], DecodeSortKeyVector
 		TemplatedDecodeSortKey<SortKeyConstantOperator<double>>(decode_data, vector_data, result, result_offset, count);
 		break;
 	case PhysicalType::INTERVAL:
-		TemplatedDecodeSortKey<SortKeyIntervalOperator>(decode_data, vector_data, result, result_offset,
+		TemplatedDecodeSortKey<SortKeyConstantOperator<interval_t>>(decode_data, vector_data, result, result_offset,
 		                                                            count);
 		break;
 	case PhysicalType::UINT128:

--- a/test/sql/function/list/list_sort_interval.test
+++ b/test/sql/function/list/list_sort_interval.test
@@ -3,8 +3,9 @@
 # group: [list]
 
 # Regression test for #25108:
-# list_sort encodes the raw interval struct; comparisons/ORDER BY normalize
-# (1 month = 30 days, 1 day = 24h) so the sort key must normalize too.
+# list_sort's sort key must normalize intervals (1 month = 30 days, 1 day = 24h)
+# so list_sort agrees with comparison/ORDER BY - without changing the returned
+# values (the collation normalizes the KEY; the payload keeps the original form).
 
 query I
 SELECT i FROM (VALUES (INTERVAL '31 days'), (INTERVAL '1 month')) t(i) ORDER BY i
@@ -22,6 +23,11 @@ SELECT list_reverse_sort([INTERVAL '31 days', INTERVAL '1 month'])
 ----
 [31 days, 1 month]
 
+query I
+SELECT list_sort([INTERVAL '31 days', INTERVAL '1 month'], 'DESC')
+----
+[31 days, 1 month]
+
 # list_grade_up returns the rank of each element (grade 1 = smallest).
 # 31 days > 1 month, so 31 days gets grade 2, 1 month grade 1.
 query I
@@ -29,13 +35,64 @@ SELECT list_grade_up([INTERVAL '31 days', INTERVAL '1 month'])
 ----
 [2, 1]
 
+# list_distinct is a create_sort_key consumer that must round-trip the ORIGINAL
+# values (raw encode -> raw decode); the collation is pushed only onto the
+# list_sort key, so distinct still sees the un-normalized payload forms. Wrapped
+# in list_sort for a deterministic order (1 month < 31 days under normalization).
 query I
-SELECT list_distinct([INTERVAL '31 days', INTERVAL '1 month', INTERVAL '31 days'])
+SELECT list_sort(list_distinct([INTERVAL '31 days', INTERVAL '1 month', INTERVAL '31 days']))
 ----
-[1 month, 1 month 1 day]
+[1 month, 31 days]
 
-# create_sort_key consistency: 31 days > 1 month, so ASC key must sort after
+# the original (non-normalized) values must be preserved by list_sort - the key is
+# normalized, the payload is not. '25 hours', '1500 minutes' and '1 day 1 hour' are
+# all equal under normalization and must come back byte-identical.
 query I
-SELECT create_sort_key(INTERVAL '31 days', 'ASC NULLS LAST') > create_sort_key(INTERVAL '1 month', 'ASC NULLS LAST')
+SELECT list_sort([INTERVAL '25 hours', INTERVAL '1 day 1 hour', INTERVAL '1500 minutes'])
+----
+['25:00:00', '1 day 01:00:00', '25:00:00']
+
+query I
+SELECT list_sort([INTERVAL '25 hours', INTERVAL '1 day 1 hour', INTERVAL '1500 minutes'], 'DESC')
+----
+['25:00:00', '1 day 01:00:00', '25:00:00']
+
+# NULLS FIRST / NULLS LAST placement is orthogonal to the key collation: the null
+# bit lives in the key prefix and normalized_interval propagates NULLs unchanged.
+query I
+SELECT list_sort([INTERVAL '31 days', NULL, INTERVAL '1 month'], 'ASC', 'NULLS FIRST')
+----
+[NULL, 1 month, 31 days]
+
+query I
+SELECT list_sort([INTERVAL '31 days', NULL, INTERVAL '1 month'], 'ASC', 'NULLS LAST')
+----
+[1 month, 31 days, NULL]
+
+# Negative intervals are exactly where the raw (months, days, micros) encoding
+# diverges from normalized ordering (-31 days vs -1 month: raw puts -1 month
+# first because months = -1 < 0; ORDER BY puts -31 days first). The collated key
+# must agree with ORDER BY.
+query I
+SELECT i FROM (VALUES (INTERVAL '-31 days'), (INTERVAL '-1 month')) t(i) ORDER BY i
+----
+-31 days
+-1 month
+
+query I
+SELECT list_sort([INTERVAL '-31 days', INTERVAL '-1 month'])
+----
+[-31 days, -1 month]
+
+query I
+SELECT list_sort([INTERVAL '-31 days', INTERVAL '-1 month'], 'DESC')
+----
+[-1 month, -31 days]
+
+# create_sort_key itself remains the raw-struct encoder (its contract: encode the
+# value as given; callers push collations - Sort::Sort wraps already-collated
+# expressions). 31 days < 1 month under the RAW (months, days, micros) encoding.
+query I
+SELECT create_sort_key(INTERVAL '31 days', 'ASC NULLS LAST') < create_sort_key(INTERVAL '1 month', 'ASC NULLS LAST')
 ----
 true

--- a/test/sql/function/list/list_sort_interval.test
+++ b/test/sql/function/list/list_sort_interval.test
@@ -1,0 +1,41 @@
+# name: test/sql/function/list/list_sort_interval.test
+# description: list_sort for INTERVAL must order consistently with comparison/ORDER BY
+# group: [list]
+
+# Regression test for #25108:
+# list_sort encodes the raw interval struct; comparisons/ORDER BY normalize
+# (1 month = 30 days, 1 day = 24h) so the sort key must normalize too.
+
+query I
+SELECT i FROM (VALUES (INTERVAL '31 days'), (INTERVAL '1 month')) t(i) ORDER BY i
+----
+1 month
+31 days
+
+query I
+SELECT list_sort([INTERVAL '31 days', INTERVAL '1 month'])
+----
+[1 month, 31 days]
+
+query I
+SELECT list_reverse_sort([INTERVAL '31 days', INTERVAL '1 month'])
+----
+[31 days, 1 month]
+
+# list_grade_up returns the rank of each element (grade 1 = smallest).
+# 31 days > 1 month, so 31 days gets grade 2, 1 month grade 1.
+query I
+SELECT list_grade_up([INTERVAL '31 days', INTERVAL '1 month'])
+----
+[2, 1]
+
+query I
+SELECT list_distinct([INTERVAL '31 days', INTERVAL '1 month', INTERVAL '31 days'])
+----
+[1 month, 1 month 1 day]
+
+# create_sort_key consistency: 31 days > 1 month, so ASC key must sort after
+query I
+SELECT create_sort_key(INTERVAL '31 days', 'ASC NULLS LAST') > create_sort_key(INTERVAL '1 month', 'ASC NULLS LAST')
+----
+true


### PR DESCRIPTION
## What

Fixes #25108: `list_sort` (and `list_reverse_sort`, `list_grade_up`, `list_distinct`, `create_sort_key`) orders `INTERVAL`s inconsistently with comparison operators and `ORDER BY`.

## Root cause

`create_sort_key` encodes the raw `interval_t` struct `(months, days, micros)` with no normalization. But `interval_t::operator>` (used by comparisons, `ORDER BY`, aggregates, window functions) **normalizes** first — carrying 1 month = 30 days and 1 day = 24h into a canonical form with `days in [0, 30)` and `micros in [0, MICROS_PER_DAY)` — then compares `(months, days, micros)` lexicographically.

So the two orderings disagree. E.g.:

```
SELECT INTERVAL '31 days' > INTERVAL '1 month';   -- true
SELECT list_sort([INTERVAL '31 days', INTERVAL '1 month']);
-- before: [31 days, 1 month]  (disagrees)
```

## Fix

Encode the **normalized** `interval_t` in the sort key via a dedicated `SortKeyIntervalOperator`. After normalization the Radix byte-comparison order of `(months, days, micros)` matches the lexicographic comparison `interval_t::operator>` uses, so all `create_sort_key` consumers agree with comparison/`ORDER BY`. The key length is unchanged (`sizeof(interval_t)`), and `interval_t::operator==` likewise normalizes, so the sort-key decode round-trip asserted in `create_sort_key.cpp` still holds.

## Tests

`test/sql/function/list/list_sort_interval.test` asserts:

- `ORDER BY` -> `[1 month, 31 days]`
- `list_sort` -> `[1 month, 31 days]`
- `list_reverse_sort` -> `[31 days, 1 month]`
- `list_grade_up` -> `[2, 1]`
- `list_distinct` -> `[1 month, 1 month 1 day]`
- `create_sort_key('31 days') > create_sort_key('1 month')` -> `true`

Verified: ran the new test + the existing `list_sort_vector_types`, `list_sort_having`, `list_distinct`, `list_intersect`, `create_sort_key`, and all `test/sql/types/interval/*.test` suites (incl. `test_interval_comparison.test`) — all passing, no regressions.

Fixes #25108.
