### PR TITLE
Propagate stats for sum aggregation function

### DIFF
--- a/extension/core_functions/aggregate/distributive/sum.cpp
+++ b/extension/core_functions/aggregate/distributive/sum.cpp
@@ -279,37 +279,58 @@ AggregateFunction GetSumAggregateNoOverflowDecimal() {
 
 unique_ptr<BaseStatistics> SumPropagateStats(ClientContext &context, BoundAggregateExpression &expr,
                                              AggregateStatisticsInput &input) {
-	if (input.node_stats && input.node_stats->has_max_cardinality) {
-		auto &numeric_stats = input.child_stats[0];
-		if (!NumericStats::HasMinMax(numeric_stats)) {
-			return nullptr;
-		}
-		auto internal_type = numeric_stats.GetType().InternalType();
-		hugeint_t max_negative;
-		hugeint_t max_positive;
-		switch (internal_type) {
-		case PhysicalType::INT32:
-			max_negative = NumericStats::Min(numeric_stats).GetValueUnsafe<int32_t>();
-			max_positive = NumericStats::Max(numeric_stats).GetValueUnsafe<int32_t>();
-			break;
-		case PhysicalType::INT64:
-			max_negative = NumericStats::Min(numeric_stats).GetValueUnsafe<int64_t>();
-			max_positive = NumericStats::Max(numeric_stats).GetValueUnsafe<int64_t>();
-			break;
-		default:
-			throw InternalException("Unsupported type for propagate sum stats");
-		}
-		auto max_sum_negative = max_negative * Hugeint::Convert(input.node_stats->max_cardinality);
-		auto max_sum_positive = max_positive * Hugeint::Convert(input.node_stats->max_cardinality);
-		if (max_sum_positive >= NumericLimits<int64_t>::Maximum() ||
-		    max_sum_negative <= NumericLimits<int64_t>::Minimum()) {
-			// sum can potentially exceed int64_t bounds: use hugeint sum
-			return nullptr;
-		}
-		// total sum is guaranteed to fit in a single int64: use int64 sum instead of hugeint sum
+	if (!input.node_stats || !input.node_stats->has_max_cardinality) {
+		return nullptr;
+	}
+	auto &numeric_stats = input.child_stats[0];
+	if (!NumericStats::HasMinMax(numeric_stats)) {
+		return nullptr;
+	}
+	auto internal_type = numeric_stats.GetType().InternalType();
+	hugeint_t max_negative = 0;
+	hugeint_t max_positive = 0;
+	switch (internal_type) {
+	case PhysicalType::BOOL:
+		max_negative = NumericStats::Min(numeric_stats).GetValueUnsafe<bool>() ? 1 : 0;
+		max_positive = NumericStats::Max(numeric_stats).GetValueUnsafe<bool>() ? 1 : 0;
+		break;
+	case PhysicalType::INT16:
+		max_negative = NumericStats::Min(numeric_stats).GetValueUnsafe<int16_t>();
+		max_positive = NumericStats::Max(numeric_stats).GetValueUnsafe<int16_t>();
+		break;
+	case PhysicalType::INT32:
+		max_negative = NumericStats::Min(numeric_stats).GetValueUnsafe<int32_t>();
+		max_positive = NumericStats::Max(numeric_stats).GetValueUnsafe<int32_t>();
+		break;
+	case PhysicalType::INT64:
+		max_negative = NumericStats::Min(numeric_stats).GetValueUnsafe<int64_t>();
+		max_positive = NumericStats::Max(numeric_stats).GetValueUnsafe<int64_t>();
+		break;
+	default:
+		throw InternalException("Unsupported type for propagate sum stats");
+	}
+	auto max_card = Hugeint::Convert(input.node_stats->max_cardinality);
+	auto wide_negative = max_negative * max_card;
+	auto wide_positive = max_positive * max_card;
+	// only INT32/INT64 have a narrower no-overflow implementation to swap in; BOOL/INT16 already
+	// accumulate in int64 and cannot overflow given any realistic row count
+	if ((internal_type == PhysicalType::INT32 || internal_type == PhysicalType::INT64) &&
+	    wide_positive < NumericLimits<int64_t>::Maximum() &&
+	    wide_negative > NumericLimits<int64_t>::Minimum()) {
 		expr.FunctionMutable().ReplaceImplementation(GetSumAggregateNoOverflow(internal_type));
 	}
-	return nullptr;
+	// a group may contain 1..cardinality rows, so the tightest sound bound multiplies by
+	// cardinality only on the side that straddles zero; a single-row group can produce a
+	// sum equal to the per-row min/max on the other side
+	auto sum_min = max_negative <= 0 ? wide_negative : max_negative;
+	auto sum_max = max_positive >= 0 ? wide_positive : max_positive;
+	auto result = NumericStats::CreateEmpty(expr.GetReturnType()).ToUnique();
+	NumericStats::SetMin(*result, Value::HUGEINT(sum_min));
+	NumericStats::SetMax(*result, Value::HUGEINT(sum_max));
+	// sum returns NULL only on an empty/all-NULL group and a non-NULL value otherwise:
+	// mark both possibilities so downstream passes don't mistake this for an all-NULL column
+	result->Set(StatsInfo::CAN_HAVE_NULL_AND_VALID_VALUES);
+	return result;
 }
 
 AggregateFunction GetSumAggregate(PhysicalType type) {
@@ -317,12 +338,14 @@ AggregateFunction GetSumAggregate(PhysicalType type) {
 	case PhysicalType::BOOL: {
 		auto function = AggregateFunction::UnaryAggregate<SumState<int64_t>, bool, hugeint_t, IntegerSumOperation>(
 		    LogicalType::BOOLEAN, LogicalType::HUGEINT);
+		function.SetStatisticsCallback(SumPropagateStats);
 		function.SetOrderDependent(AggregateOrderDependent::NOT_ORDER_DEPENDENT);
 		return function;
 	}
 	case PhysicalType::INT16: {
 		auto function = AggregateFunction::UnaryAggregate<SumState<int64_t>, int16_t, hugeint_t, IntegerSumOperation>(
 		    LogicalType::SMALLINT, LogicalType::HUGEINT);
+		function.SetStatisticsCallback(SumPropagateStats);
 		function.SetOrderDependent(AggregateOrderDependent::NOT_ORDER_DEPENDENT);
 		return function;
 	}

--- a/extension/core_functions/aggregate/distributive/sum.cpp
+++ b/extension/core_functions/aggregate/distributive/sum.cpp
@@ -322,7 +322,8 @@ unique_ptr<BaseStatistics> SumPropagateStats(ClientContext &context, BoundAggreg
 		return nullptr;
 	}
 
-	// Replace fast implementation when possible: only INT32/INT64 have a narrower no-overflow implementation to swap in.
+	// Replace with fast implementation when possible: only INT32/INT64 have a narrower no-overflow implementation to
+	// swap in.
 	const bool has_no_overflow_variant = internal_type == PhysicalType::INT32 || internal_type == PhysicalType::INT64;
 	const bool sum_fits_in_int64 =
 	    wide_negative > NumericLimits<int64_t>::Minimum() && wide_positive < NumericLimits<int64_t>::Maximum();

--- a/extension/core_functions/aggregate/distributive/sum.cpp
+++ b/extension/core_functions/aggregate/distributive/sum.cpp
@@ -325,8 +325,7 @@ unique_ptr<BaseStatistics> SumPropagateStats(ClientContext &context, BoundAggreg
 	// only INT32/INT64 have a narrower no-overflow implementation to swap in; BOOL/INT16 already
 	// accumulate in int64 and cannot overflow given any realistic row count
 	if ((internal_type == PhysicalType::INT32 || internal_type == PhysicalType::INT64) &&
-	    wide_positive < NumericLimits<int64_t>::Maximum() &&
-	    wide_negative > NumericLimits<int64_t>::Minimum()) {
+	    wide_positive < NumericLimits<int64_t>::Maximum() && wide_negative > NumericLimits<int64_t>::Minimum()) {
 		expr.FunctionMutable().ReplaceImplementation(GetSumAggregateNoOverflow(internal_type));
 	}
 	// a group may contain 1..cardinality rows, so the tightest sound bound multiplies by

--- a/extension/core_functions/aggregate/distributive/sum.cpp
+++ b/extension/core_functions/aggregate/distributive/sum.cpp
@@ -306,12 +306,22 @@ unique_ptr<BaseStatistics> SumPropagateStats(ClientContext &context, BoundAggreg
 		max_negative = NumericStats::Min(numeric_stats).GetValueUnsafe<int64_t>();
 		max_positive = NumericStats::Max(numeric_stats).GetValueUnsafe<int64_t>();
 		break;
+	case PhysicalType::INT128:
+		max_negative = NumericStats::Min(numeric_stats).GetValueUnsafe<hugeint_t>();
+		max_positive = NumericStats::Max(numeric_stats).GetValueUnsafe<hugeint_t>();
+		break;
 	default:
 		throw InternalException("Unsupported type for propagate sum stats");
 	}
 	auto max_card = Hugeint::Convert(input.node_stats->max_cardinality);
-	auto wide_negative = max_negative * max_card;
-	auto wide_positive = max_positive * max_card;
+	hugeint_t wide_negative = 0;
+	hugeint_t wide_positive = 0;
+	// use a checked multiply: cardinality * min/max can overflow hugeint for INT128 inputs and,
+	// in extreme cases, for INT64 inputs as well; bail out with no stats when it does
+	if (!Hugeint::TryMultiply(max_negative, max_card, wide_negative) ||
+	    !Hugeint::TryMultiply(max_positive, max_card, wide_positive)) {
+		return nullptr;
+	}
 	// only INT32/INT64 have a narrower no-overflow implementation to swap in; BOOL/INT16 already
 	// accumulate in int64 and cannot overflow given any realistic row count
 	if ((internal_type == PhysicalType::INT32 || internal_type == PhysicalType::INT64) &&
@@ -370,6 +380,7 @@ AggregateFunction GetSumAggregate(PhysicalType type) {
 		auto function =
 		    AggregateFunction::UnaryAggregate<SumState<hugeint_t>, hugeint_t, hugeint_t, HugeintSumOperation>(
 		        LogicalType::HUGEINT, LogicalType::HUGEINT);
+		function.SetStatisticsCallback(SumPropagateStats);
 		function.SetOrderDependent(AggregateOrderDependent::NOT_ORDER_DEPENDENT);
 		return function;
 	}

--- a/extension/core_functions/aggregate/distributive/sum.cpp
+++ b/extension/core_functions/aggregate/distributive/sum.cpp
@@ -321,22 +321,21 @@ unique_ptr<BaseStatistics> SumPropagateStats(ClientContext &context, BoundAggreg
 	    !Hugeint::TryMultiply(max_positive, max_card, wide_positive)) {
 		return nullptr;
 	}
-	// only INT32/INT64 have a narrower no-overflow implementation to swap in; BOOL/INT16 already
-	// accumulate in int64 and cannot overflow given any realistic row count
-	if ((internal_type == PhysicalType::INT32 || internal_type == PhysicalType::INT64) &&
-	    wide_positive < NumericLimits<int64_t>::Maximum() && wide_negative > NumericLimits<int64_t>::Minimum()) {
+
+	// Relace fast implementation when possible: only INT32/INT64 have a narrower no-overflow implementation to swap in.
+	const bool has_no_overflow_variant = internal_type == PhysicalType::INT32 || internal_type == PhysicalType::INT64;
+	const bool sum_fits_in_int64 =
+	    wide_negative > NumericLimits<int64_t>::Minimum() && wide_positive < NumericLimits<int64_t>::Maximum();
+	if (has_no_overflow_variant && sum_fits_in_int64) {
 		expr.FunctionMutable().ReplaceImplementation(GetSumAggregateNoOverflow(internal_type));
 	}
-	// a group may contain 1..cardinality rows, so the tightest sound bound multiplies by
-	// cardinality only on the side that straddles zero; a single-row group can produce a
-	// sum equal to the per-row min/max on the other side
+
+	// Propagate stats.
 	auto sum_min = max_negative <= 0 ? wide_negative : max_negative;
 	auto sum_max = max_positive >= 0 ? wide_positive : max_positive;
 	auto result = NumericStats::CreateEmpty(expr.GetReturnType()).ToUnique();
 	NumericStats::SetMin(*result, Value::HUGEINT(sum_min));
 	NumericStats::SetMax(*result, Value::HUGEINT(sum_max));
-	// sum returns NULL only on an empty/all-NULL group and a non-NULL value otherwise:
-	// mark both possibilities so downstream passes don't mistake this for an all-NULL column
 	result->Set(StatsInfo::CAN_HAVE_NULL_AND_VALID_VALUES);
 	return result;
 }

--- a/extension/core_functions/aggregate/distributive/sum.cpp
+++ b/extension/core_functions/aggregate/distributive/sum.cpp
@@ -313,11 +313,10 @@ unique_ptr<BaseStatistics> SumPropagateStats(ClientContext &context, BoundAggreg
 	default:
 		throw InternalException("Unsupported type for propagate sum stats");
 	}
-	auto max_card = Hugeint::Convert(input.node_stats->max_cardinality);
+
+	const auto max_card = Hugeint::Convert(input.node_stats->max_cardinality);
 	hugeint_t wide_negative = 0;
 	hugeint_t wide_positive = 0;
-	// use a checked multiply: cardinality * min/max can overflow hugeint for INT128 inputs and,
-	// in extreme cases, for INT64 inputs as well; bail out with no stats when it does
 	if (!Hugeint::TryMultiply(max_negative, max_card, wide_negative) ||
 	    !Hugeint::TryMultiply(max_positive, max_card, wide_positive)) {
 		return nullptr;

--- a/extension/core_functions/aggregate/distributive/sum.cpp
+++ b/extension/core_functions/aggregate/distributive/sum.cpp
@@ -322,7 +322,7 @@ unique_ptr<BaseStatistics> SumPropagateStats(ClientContext &context, BoundAggreg
 		return nullptr;
 	}
 
-	// Relace fast implementation when possible: only INT32/INT64 have a narrower no-overflow implementation to swap in.
+	// Replace fast implementation when possible: only INT32/INT64 have a narrower no-overflow implementation to swap in.
 	const bool has_no_overflow_variant = internal_type == PhysicalType::INT32 || internal_type == PhysicalType::INT64;
 	const bool sum_fits_in_int64 =
 	    wide_negative > NumericLimits<int64_t>::Minimum() && wide_positive < NumericLimits<int64_t>::Maximum();

--- a/test/configs/verify_aggregate_state_export.json
+++ b/test/configs/verify_aggregate_state_export.json
@@ -21,6 +21,7 @@
         "test/sql/copy/parquet/parquet_expression_filter_pruning.test",
         "test/sql/copy/parquet/parquet_stats.test",
         "test/sql/optimizer/aggregate_stats_propagation.test",
+        "test/sql/optimizer/sum_aggregate_stats_propagation.test",
         "test/sql/optimizer/expression/test_common_aggregate.test",
         "test/sql/pragma/profiling/test_custom_profiling_row_group_metrics_local_storage.test"
       ]

--- a/test/optimizer/aggregate_reuse.test
+++ b/test/optimizer/aggregate_reuse.test
@@ -160,7 +160,7 @@ physical_plan	<REGEX>:(?s).*reuse_fact.*reuse_fact.*
 query II
 EXPLAIN SELECT o.k, d.label, sum(f.v)
 FROM reuse_owner o JOIN reuse_dim d ON o.dim_id = d.id JOIN reuse_fact f USING (k)
-WHERE o.k IN (SELECT CAST(sum(v) AS INTEGER) FROM reuse_fact GROUP BY k HAVING sum(v) > 25)
+WHERE o.k IN (SELECT CAST(count(*) AS INTEGER) FROM reuse_fact GROUP BY k HAVING sum(v) > 25)
 GROUP BY o.k, d.label
 ----
 physical_plan	<REGEX>:(?s).*reuse_fact.*reuse_fact.*

--- a/test/sql/optimizer/sum_aggregate_stats_propagation.test
+++ b/test/sql/optimizer/sum_aggregate_stats_propagation.test
@@ -348,12 +348,6 @@ SELECT sum(x) FROM tu64 HAVING sum(x) > 0;
 ----
 495000
 
-# same-sign inputs (all-negative or all-positive) exercise the branch of the sum-bound
-# ternary that uses the per-row min/max rather than min/max * cardinality. Without it,
-# a single-row GROUP BY group would falsely be excluded: e.g. for v in [-100, -1] one
-# group can produce sum = -1, but wide_positive = -1 * cardinality = -10000 would
-# incorrectly cap sum_max below -1 and fold satisfiable HAVING clauses.
-
 statement ok
 CREATE TABLE tallneg AS SELECT range::INTEGER AS g, (-1 - (range % 100))::INTEGER AS v FROM range(10000);
 

--- a/test/sql/optimizer/sum_aggregate_stats_propagation.test
+++ b/test/sql/optimizer/sum_aggregate_stats_propagation.test
@@ -201,3 +201,56 @@ query I
 SELECT sum(s) FROM tshn HAVING sum(s) < 0;
 ----
 -495000
+
+# HUGEINT (INT128) input: overflow-checked bounds still fold impossible HAVING
+statement ok
+CREATE TABLE thh AS SELECT range::HUGEINT AS x FROM range(10000);
+
+query III
+SELECT min(x), max(x), sum(x) FROM thh;
+----
+0	9999	49995000
+
+query II
+EXPLAIN SELECT sum(x) FROM thh HAVING sum(x) < 0;
+----
+physical_plan	<REGEX>:.*Empty Result.*
+
+query I
+SELECT count(*) FROM (SELECT sum(x) AS r FROM thh HAVING sum(x) < 0);
+----
+0
+
+query II
+EXPLAIN SELECT sum(x) FROM thh HAVING sum(x) > 100000000;
+----
+physical_plan	<REGEX>:.*Empty Result.*
+
+query I
+SELECT count(*) FROM (SELECT sum(x) AS r FROM thh HAVING sum(x) > 100000000);
+----
+0
+
+query II
+EXPLAIN SELECT sum(x) FROM thh HAVING sum(x) > 0;
+----
+physical_plan	<!REGEX>:.*Empty Result.*
+
+query I
+SELECT sum(x) FROM thh HAVING sum(x) > 0;
+----
+49995000
+
+statement ok
+CREATE TABLE thbig AS SELECT ('170141183460469231731687303715884105727'::HUGEINT - range)::HUGEINT AS x
+                     FROM range(10);
+
+query I
+SELECT count(*) FROM thbig;
+----
+10
+
+query II
+EXPLAIN SELECT sum(x) FROM thbig HAVING sum(x) < 0;
+----
+physical_plan	<!REGEX>:.*Empty Result.*

--- a/test/sql/optimizer/sum_aggregate_stats_propagation.test
+++ b/test/sql/optimizer/sum_aggregate_stats_propagation.test
@@ -1,0 +1,101 @@
+# name: test/sql/optimizer/sum_aggregate_stats_propagation.test
+# description: sum(x) output stats should be bounded by [cardinality * min(x), cardinality * max(x)]
+# group: [optimizer]
+
+statement ok
+CREATE TABLE t AS SELECT range::INTEGER AS x FROM range(10000);
+
+query III
+SELECT min(x), max(x), sum(x) FROM t;
+----
+0	9999	49995000
+
+# baseline: min / max propagate stats and fold impossible HAVING to Empty Result
+query II
+EXPLAIN SELECT max(x) FROM t HAVING max(x) < 0;
+----
+physical_plan	<REGEX>:.*Empty Result.*
+
+query I
+SELECT count(*) FROM (SELECT max(x) AS m FROM t HAVING max(x) < 0);
+----
+0
+
+query II
+EXPLAIN SELECT min(x) FROM t HAVING min(x) > 9999;
+----
+physical_plan	<REGEX>:.*Empty Result.*
+
+query I
+SELECT count(*) FROM (SELECT min(x) AS m FROM t HAVING min(x) > 9999);
+----
+0
+
+# sum(x) should also be bounded and fold impossible HAVING
+query II
+EXPLAIN SELECT sum(x) FROM t HAVING sum(x) < 0;
+----
+physical_plan	<REGEX>:.*Empty Result.*
+
+query I
+SELECT count(*) FROM (SELECT sum(x) AS s FROM t HAVING sum(x) < 0);
+----
+0
+
+query II
+EXPLAIN SELECT sum(x) FROM t HAVING sum(x) > 100000000;
+----
+physical_plan	<REGEX>:.*Empty Result.*
+
+query I
+SELECT count(*) FROM (SELECT sum(x) AS s FROM t HAVING sum(x) > 100000000);
+----
+0
+
+query II
+EXPLAIN SELECT sum(x) FROM t HAVING sum(x) BETWEEN -1000 AND -1;
+----
+physical_plan	<REGEX>:.*Empty Result.*
+
+query I
+SELECT count(*) FROM (SELECT sum(x) AS s FROM t HAVING sum(x) BETWEEN -1000 AND -1);
+----
+0
+
+query II
+EXPLAIN SELECT sum(x) FROM t HAVING sum(x) > 0;
+----
+physical_plan	<!REGEX>:.*Empty Result.*
+
+query I
+SELECT sum(x) FROM t HAVING sum(x) > 0;
+----
+49995000
+
+query I
+SELECT sum(x) FROM t HAVING sum(x) BETWEEN 40000000 AND 60000000;
+----
+49995000
+
+statement ok
+CREATE TABLE tneg AS SELECT (-range)::INTEGER AS x FROM range(10000);
+
+query III
+SELECT min(x), max(x), sum(x) FROM tneg;
+----
+-9999	0	-49995000
+
+query II
+EXPLAIN SELECT sum(x) FROM tneg HAVING sum(x) > 0;
+----
+physical_plan	<REGEX>:.*Empty Result.*
+
+query I
+SELECT count(*) FROM (SELECT sum(x) AS s FROM tneg HAVING sum(x) > 0);
+----
+0
+
+query I
+SELECT sum(x) FROM tneg HAVING sum(x) < 0;
+----
+-49995000

--- a/test/sql/optimizer/sum_aggregate_stats_propagation.test
+++ b/test/sql/optimizer/sum_aggregate_stats_propagation.test
@@ -2,13 +2,9 @@
 # description: sum(x) output stats should be bounded by [cardinality * min(x), cardinality * max(x)]
 # group: [optimizer]
 
+# INT32 baseline: sum bounds fold impossible HAVING on both sides and preserve satisfiable ones
 statement ok
 CREATE TABLE t AS SELECT range::INTEGER AS x FROM range(10000);
-
-query III
-SELECT min(x), max(x), sum(x) FROM t;
-----
-0	9999	49995000
 
 query II
 EXPLAIN SELECT sum(x) FROM t HAVING sum(x) < 0;
@@ -31,16 +27,6 @@ SELECT count(*) FROM (SELECT sum(x) AS s FROM t HAVING sum(x) > 100000000);
 0
 
 query II
-EXPLAIN SELECT sum(x) FROM t HAVING sum(x) BETWEEN -1000 AND -1;
-----
-physical_plan	<REGEX>:.*Empty Result.*
-
-query I
-SELECT count(*) FROM (SELECT sum(x) AS s FROM t HAVING sum(x) BETWEEN -1000 AND -1);
-----
-0
-
-query II
 EXPLAIN SELECT sum(x) FROM t HAVING sum(x) > 0;
 ----
 physical_plan	<!REGEX>:.*Empty Result.*
@@ -50,42 +36,9 @@ SELECT sum(x) FROM t HAVING sum(x) > 0;
 ----
 49995000
 
-query I
-SELECT sum(x) FROM t HAVING sum(x) BETWEEN 40000000 AND 60000000;
-----
-49995000
-
-statement ok
-CREATE TABLE tneg AS SELECT (-range)::INTEGER AS x FROM range(10000);
-
-query III
-SELECT min(x), max(x), sum(x) FROM tneg;
-----
--9999	0	-49995000
-
-query II
-EXPLAIN SELECT sum(x) FROM tneg HAVING sum(x) > 0;
-----
-physical_plan	<REGEX>:.*Empty Result.*
-
-query I
-SELECT count(*) FROM (SELECT sum(x) AS s FROM tneg HAVING sum(x) > 0);
-----
-0
-
-query I
-SELECT sum(x) FROM tneg HAVING sum(x) < 0;
-----
--49995000
-
 # BOOL input: sum(b) is bounded by [0, cardinality]
 statement ok
 CREATE TABLE tb AS SELECT (range % 3 = 0) AS b FROM range(10000);
-
-query III
-SELECT min(b), max(b), sum(b) FROM tb;
-----
-false	true	3334
 
 query II
 EXPLAIN SELECT sum(b) FROM tb HAVING sum(b) < 0;
@@ -93,63 +46,18 @@ EXPLAIN SELECT sum(b) FROM tb HAVING sum(b) < 0;
 physical_plan	<REGEX>:.*Empty Result.*
 
 query I
-SELECT count(*) FROM (SELECT sum(b) AS s FROM tb HAVING sum(b) < 0);
-----
-0
-
-query II
-EXPLAIN SELECT sum(b) FROM tb HAVING sum(b) > 10000;
-----
-physical_plan	<REGEX>:.*Empty Result.*
-
-query I
-SELECT count(*) FROM (SELECT sum(b) AS s FROM tb HAVING sum(b) > 10000);
-----
-0
-
-query II
-EXPLAIN SELECT sum(b) FROM tb HAVING sum(b) > 0;
-----
-physical_plan	<!REGEX>:.*Empty Result.*
-
-query I
 SELECT sum(b) FROM tb HAVING sum(b) > 0;
 ----
 3334
 
-# SMALLINT (INT16) input: sum(s) is bounded by [cardinality * min, cardinality * max]
+# SMALLINT (INT16) input
 statement ok
 CREATE TABLE tsh AS SELECT (range % 100)::SMALLINT AS s FROM range(10000);
-
-query III
-SELECT min(s), max(s), sum(s) FROM tsh;
-----
-0	99	495000
 
 query II
 EXPLAIN SELECT sum(s) FROM tsh HAVING sum(s) < 0;
 ----
 physical_plan	<REGEX>:.*Empty Result.*
-
-query I
-SELECT count(*) FROM (SELECT sum(s) AS r FROM tsh HAVING sum(s) < 0);
-----
-0
-
-query II
-EXPLAIN SELECT sum(s) FROM tsh HAVING sum(s) > 990000;
-----
-physical_plan	<REGEX>:.*Empty Result.*
-
-query I
-SELECT count(*) FROM (SELECT sum(s) AS r FROM tsh HAVING sum(s) > 990000);
-----
-0
-
-query II
-EXPLAIN SELECT sum(s) FROM tsh HAVING sum(s) > 0;
-----
-physical_plan	<!REGEX>:.*Empty Result.*
 
 query I
 SELECT sum(s) FROM tsh HAVING sum(s) > 0;
@@ -160,20 +68,10 @@ SELECT sum(s) FROM tsh HAVING sum(s) > 0;
 statement ok
 CREATE TABLE tshn AS SELECT (-(range % 100))::SMALLINT AS s FROM range(10000);
 
-query III
-SELECT min(s), max(s), sum(s) FROM tshn;
-----
--99	0	-495000
-
 query II
 EXPLAIN SELECT sum(s) FROM tshn HAVING sum(s) > 0;
 ----
 physical_plan	<REGEX>:.*Empty Result.*
-
-query I
-SELECT count(*) FROM (SELECT sum(s) AS r FROM tshn HAVING sum(s) > 0);
-----
-0
 
 query I
 SELECT sum(s) FROM tshn HAVING sum(s) < 0;
@@ -184,59 +82,19 @@ SELECT sum(s) FROM tshn HAVING sum(s) < 0;
 statement ok
 CREATE TABLE thh AS SELECT range::HUGEINT AS x FROM range(10000);
 
-query III
-SELECT min(x), max(x), sum(x) FROM thh;
-----
-0	9999	49995000
-
 query II
 EXPLAIN SELECT sum(x) FROM thh HAVING sum(x) < 0;
 ----
 physical_plan	<REGEX>:.*Empty Result.*
 
 query I
-SELECT count(*) FROM (SELECT sum(x) AS r FROM thh HAVING sum(x) < 0);
-----
-0
-
-query II
-EXPLAIN SELECT sum(x) FROM thh HAVING sum(x) > 100000000;
-----
-physical_plan	<REGEX>:.*Empty Result.*
-
-query I
-SELECT count(*) FROM (SELECT sum(x) AS r FROM thh HAVING sum(x) > 100000000);
-----
-0
-
-query II
-EXPLAIN SELECT sum(x) FROM thh HAVING sum(x) > 0;
-----
-physical_plan	<!REGEX>:.*Empty Result.*
-
-query I
 SELECT sum(x) FROM thh HAVING sum(x) > 0;
 ----
 49995000
 
-statement ok
-CREATE TABLE thbig AS SELECT ('170141183460469231731687303715884105727'::HUGEINT - range)::HUGEINT AS x
-                     FROM range(10);
-
-query I
-SELECT count(*) FROM thbig;
-----
-10
-
-query II
-EXPLAIN SELECT sum(x) FROM thbig HAVING sum(x) < 0;
-----
-physical_plan	<!REGEX>:.*Empty Result.*
-
 # unsigned integer inputs reach the callback via an implicit widening cast:
-# UTINYINT / USMALLINT / UINTEGER  -> BIGINT   -> INT64 case
-# UBIGINT                          -> HUGEINT  -> INT128 case
-# every width should fold impossible HAVING sum(x) < 0 the same way
+#   UTINYINT / USMALLINT / UINTEGER -> BIGINT  -> INT64 case
+#   UBIGINT                         -> HUGEINT -> INT128 case
 
 statement ok
 CREATE TABLE tu8  AS SELECT (range % 100)::UTINYINT  AS x FROM range(10000);
@@ -250,55 +108,20 @@ CREATE TABLE tu32 AS SELECT (range % 100)::UINTEGER  AS x FROM range(10000);
 statement ok
 CREATE TABLE tu64 AS SELECT (range % 100)::UBIGINT   AS x FROM range(10000);
 
-query I
-SELECT sum(x) FROM tu8;
-----
-495000
-
-query I
-SELECT sum(x) FROM tu16;
-----
-495000
-
-query I
-SELECT sum(x) FROM tu32;
-----
-495000
-
-query I
-SELECT sum(x) FROM tu64;
-----
-495000
-
 query II
 EXPLAIN SELECT sum(x) FROM tu8  HAVING sum(x) < 0;
 ----
 physical_plan	<REGEX>:.*Empty Result.*
-
-query I
-SELECT count(*) FROM (SELECT sum(x) AS r FROM tu8 HAVING sum(x) < 0);
-----
-0
 
 query II
 EXPLAIN SELECT sum(x) FROM tu16 HAVING sum(x) < 0;
 ----
 physical_plan	<REGEX>:.*Empty Result.*
 
-query I
-SELECT count(*) FROM (SELECT sum(x) AS r FROM tu16 HAVING sum(x) < 0);
-----
-0
-
 query II
 EXPLAIN SELECT sum(x) FROM tu32 HAVING sum(x) < 0;
 ----
 physical_plan	<REGEX>:.*Empty Result.*
-
-query I
-SELECT count(*) FROM (SELECT sum(x) AS r FROM tu32 HAVING sum(x) < 0);
-----
-0
 
 query II
 EXPLAIN SELECT sum(x) FROM tu64 HAVING sum(x) < 0;
@@ -306,26 +129,14 @@ EXPLAIN SELECT sum(x) FROM tu64 HAVING sum(x) < 0;
 physical_plan	<REGEX>:.*Empty Result.*
 
 query I
-SELECT count(*) FROM (SELECT sum(x) AS r FROM tu64 HAVING sum(x) < 0);
-----
-0
-
-# satisfiable HAVING must survive for every unsigned width
-query II
-EXPLAIN SELECT sum(x) FROM tu32 HAVING sum(x) > 0;
-----
-physical_plan	<!REGEX>:.*Empty Result.*
-
-query I
-SELECT sum(x) FROM tu32 HAVING sum(x) > 0;
-----
-495000
-
-query I
 SELECT sum(x) FROM tu64 HAVING sum(x) > 0;
 ----
 495000
 
+# same-sign inputs (all-negative or all-positive) exercise the branch of the sum-bound
+# ternary that uses per-row min/max rather than min/max * cardinality; without it a
+# single-row GROUP BY group would be falsely excluded (a 1-row group of v = -1 produces
+# sum = -1, but wide_positive = -1 * cardinality would incorrectly cap sum_max below -1)
 statement ok
 CREATE TABLE tallneg AS SELECT range::INTEGER AS g, (-1 - (range % 100))::INTEGER AS v FROM range(10000);
 
@@ -344,11 +155,6 @@ EXPLAIN SELECT g FROM tallneg GROUP BY g HAVING sum(v) > 0;
 ----
 physical_plan	<REGEX>:.*Empty Result.*
 
-query I
-SELECT count(*) FROM (SELECT g FROM tallneg GROUP BY g HAVING sum(v) > 0);
-----
-0
-
 statement ok
 CREATE TABLE tallpos AS SELECT range::INTEGER AS g, (1 + (range % 100))::INTEGER AS v FROM range(10000);
 
@@ -366,8 +172,3 @@ query II
 EXPLAIN SELECT g FROM tallpos GROUP BY g HAVING sum(v) < 0;
 ----
 physical_plan	<REGEX>:.*Empty Result.*
-
-query I
-SELECT count(*) FROM (SELECT g FROM tallpos GROUP BY g HAVING sum(v) < 0);
-----
-0

--- a/test/sql/optimizer/sum_aggregate_stats_propagation.test
+++ b/test/sql/optimizer/sum_aggregate_stats_propagation.test
@@ -133,10 +133,6 @@ SELECT sum(x) FROM tu64 HAVING sum(x) > 0;
 ----
 495000
 
-# same-sign inputs (all-negative or all-positive) exercise the branch of the sum-bound
-# ternary that uses per-row min/max rather than min/max * cardinality; without it a
-# single-row GROUP BY group would be falsely excluded (a 1-row group of v = -1 produces
-# sum = -1, but wide_positive = -1 * cardinality would incorrectly cap sum_max below -1)
 statement ok
 CREATE TABLE tallneg AS SELECT range::INTEGER AS g, (-1 - (range % 100))::INTEGER AS v FROM range(10000);
 

--- a/test/sql/optimizer/sum_aggregate_stats_propagation.test
+++ b/test/sql/optimizer/sum_aggregate_stats_propagation.test
@@ -99,3 +99,105 @@ query I
 SELECT sum(x) FROM tneg HAVING sum(x) < 0;
 ----
 -49995000
+
+# BOOL input: sum(b) is bounded by [0, cardinality]
+statement ok
+CREATE TABLE tb AS SELECT (range % 3 = 0) AS b FROM range(10000);
+
+query III
+SELECT min(b), max(b), sum(b) FROM tb;
+----
+false	true	3334
+
+query II
+EXPLAIN SELECT sum(b) FROM tb HAVING sum(b) < 0;
+----
+physical_plan	<REGEX>:.*Empty Result.*
+
+query I
+SELECT count(*) FROM (SELECT sum(b) AS s FROM tb HAVING sum(b) < 0);
+----
+0
+
+query II
+EXPLAIN SELECT sum(b) FROM tb HAVING sum(b) > 10000;
+----
+physical_plan	<REGEX>:.*Empty Result.*
+
+query I
+SELECT count(*) FROM (SELECT sum(b) AS s FROM tb HAVING sum(b) > 10000);
+----
+0
+
+query II
+EXPLAIN SELECT sum(b) FROM tb HAVING sum(b) > 0;
+----
+physical_plan	<!REGEX>:.*Empty Result.*
+
+query I
+SELECT sum(b) FROM tb HAVING sum(b) > 0;
+----
+3334
+
+# SMALLINT (INT16) input: sum(s) is bounded by [cardinality * min, cardinality * max]
+statement ok
+CREATE TABLE tsh AS SELECT (range % 100)::SMALLINT AS s FROM range(10000);
+
+query III
+SELECT min(s), max(s), sum(s) FROM tsh;
+----
+0	99	495000
+
+query II
+EXPLAIN SELECT sum(s) FROM tsh HAVING sum(s) < 0;
+----
+physical_plan	<REGEX>:.*Empty Result.*
+
+query I
+SELECT count(*) FROM (SELECT sum(s) AS r FROM tsh HAVING sum(s) < 0);
+----
+0
+
+query II
+EXPLAIN SELECT sum(s) FROM tsh HAVING sum(s) > 990000;
+----
+physical_plan	<REGEX>:.*Empty Result.*
+
+query I
+SELECT count(*) FROM (SELECT sum(s) AS r FROM tsh HAVING sum(s) > 990000);
+----
+0
+
+query II
+EXPLAIN SELECT sum(s) FROM tsh HAVING sum(s) > 0;
+----
+physical_plan	<!REGEX>:.*Empty Result.*
+
+query I
+SELECT sum(s) FROM tsh HAVING sum(s) > 0;
+----
+495000
+
+# negative-valued SMALLINT: sum bounds must flip direction
+statement ok
+CREATE TABLE tshn AS SELECT (-(range % 100))::SMALLINT AS s FROM range(10000);
+
+query III
+SELECT min(s), max(s), sum(s) FROM tshn;
+----
+-99	0	-495000
+
+query II
+EXPLAIN SELECT sum(s) FROM tshn HAVING sum(s) > 0;
+----
+physical_plan	<REGEX>:.*Empty Result.*
+
+query I
+SELECT count(*) FROM (SELECT sum(s) AS r FROM tshn HAVING sum(s) > 0);
+----
+0
+
+query I
+SELECT sum(s) FROM tshn HAVING sum(s) < 0;
+----
+-495000

--- a/test/sql/optimizer/sum_aggregate_stats_propagation.test
+++ b/test/sql/optimizer/sum_aggregate_stats_propagation.test
@@ -254,3 +254,96 @@ query II
 EXPLAIN SELECT sum(x) FROM thbig HAVING sum(x) < 0;
 ----
 physical_plan	<!REGEX>:.*Empty Result.*
+
+# unsigned integer inputs reach the callback via an implicit widening cast:
+# UTINYINT / USMALLINT / UINTEGER  -> BIGINT   -> INT64 case
+# UBIGINT                          -> HUGEINT  -> INT128 case
+# every width should fold impossible HAVING sum(x) < 0 the same way
+
+statement ok
+CREATE TABLE tu8  AS SELECT (range % 100)::UTINYINT  AS x FROM range(10000);
+
+statement ok
+CREATE TABLE tu16 AS SELECT (range % 100)::USMALLINT AS x FROM range(10000);
+
+statement ok
+CREATE TABLE tu32 AS SELECT (range % 100)::UINTEGER  AS x FROM range(10000);
+
+statement ok
+CREATE TABLE tu64 AS SELECT (range % 100)::UBIGINT   AS x FROM range(10000);
+
+query I
+SELECT sum(x) FROM tu8;
+----
+495000
+
+query I
+SELECT sum(x) FROM tu16;
+----
+495000
+
+query I
+SELECT sum(x) FROM tu32;
+----
+495000
+
+query I
+SELECT sum(x) FROM tu64;
+----
+495000
+
+query II
+EXPLAIN SELECT sum(x) FROM tu8  HAVING sum(x) < 0;
+----
+physical_plan	<REGEX>:.*Empty Result.*
+
+query I
+SELECT count(*) FROM (SELECT sum(x) AS r FROM tu8 HAVING sum(x) < 0);
+----
+0
+
+query II
+EXPLAIN SELECT sum(x) FROM tu16 HAVING sum(x) < 0;
+----
+physical_plan	<REGEX>:.*Empty Result.*
+
+query I
+SELECT count(*) FROM (SELECT sum(x) AS r FROM tu16 HAVING sum(x) < 0);
+----
+0
+
+query II
+EXPLAIN SELECT sum(x) FROM tu32 HAVING sum(x) < 0;
+----
+physical_plan	<REGEX>:.*Empty Result.*
+
+query I
+SELECT count(*) FROM (SELECT sum(x) AS r FROM tu32 HAVING sum(x) < 0);
+----
+0
+
+query II
+EXPLAIN SELECT sum(x) FROM tu64 HAVING sum(x) < 0;
+----
+physical_plan	<REGEX>:.*Empty Result.*
+
+query I
+SELECT count(*) FROM (SELECT sum(x) AS r FROM tu64 HAVING sum(x) < 0);
+----
+0
+
+# satisfiable HAVING must survive for every unsigned width
+query II
+EXPLAIN SELECT sum(x) FROM tu32 HAVING sum(x) > 0;
+----
+physical_plan	<!REGEX>:.*Empty Result.*
+
+query I
+SELECT sum(x) FROM tu32 HAVING sum(x) > 0;
+----
+495000
+
+query I
+SELECT sum(x) FROM tu64 HAVING sum(x) > 0;
+----
+495000

--- a/test/sql/optimizer/sum_aggregate_stats_propagation.test
+++ b/test/sql/optimizer/sum_aggregate_stats_propagation.test
@@ -347,3 +347,55 @@ query I
 SELECT sum(x) FROM tu64 HAVING sum(x) > 0;
 ----
 495000
+
+# same-sign inputs (all-negative or all-positive) exercise the branch of the sum-bound
+# ternary that uses the per-row min/max rather than min/max * cardinality. Without it,
+# a single-row GROUP BY group would falsely be excluded: e.g. for v in [-100, -1] one
+# group can produce sum = -1, but wide_positive = -1 * cardinality = -10000 would
+# incorrectly cap sum_max below -1 and fold satisfiable HAVING clauses.
+
+statement ok
+CREATE TABLE tallneg AS SELECT range::INTEGER AS g, (-1 - (range % 100))::INTEGER AS v FROM range(10000);
+
+query II
+EXPLAIN SELECT g FROM tallneg GROUP BY g HAVING sum(v) > -50;
+----
+physical_plan	<!REGEX>:.*Empty Result.*
+
+query I
+SELECT count(*) FROM (SELECT g FROM tallneg GROUP BY g HAVING sum(v) > -50);
+----
+4900
+
+query II
+EXPLAIN SELECT g FROM tallneg GROUP BY g HAVING sum(v) > 0;
+----
+physical_plan	<REGEX>:.*Empty Result.*
+
+query I
+SELECT count(*) FROM (SELECT g FROM tallneg GROUP BY g HAVING sum(v) > 0);
+----
+0
+
+statement ok
+CREATE TABLE tallpos AS SELECT range::INTEGER AS g, (1 + (range % 100))::INTEGER AS v FROM range(10000);
+
+query II
+EXPLAIN SELECT g FROM tallpos GROUP BY g HAVING sum(v) < 50;
+----
+physical_plan	<!REGEX>:.*Empty Result.*
+
+query I
+SELECT count(*) FROM (SELECT g FROM tallpos GROUP BY g HAVING sum(v) < 50);
+----
+4900
+
+query II
+EXPLAIN SELECT g FROM tallpos GROUP BY g HAVING sum(v) < 0;
+----
+physical_plan	<REGEX>:.*Empty Result.*
+
+query I
+SELECT count(*) FROM (SELECT g FROM tallpos GROUP BY g HAVING sum(v) < 0);
+----
+0

--- a/test/sql/optimizer/sum_aggregate_stats_propagation.test
+++ b/test/sql/optimizer/sum_aggregate_stats_propagation.test
@@ -10,28 +10,6 @@ SELECT min(x), max(x), sum(x) FROM t;
 ----
 0	9999	49995000
 
-# baseline: min / max propagate stats and fold impossible HAVING to Empty Result
-query II
-EXPLAIN SELECT max(x) FROM t HAVING max(x) < 0;
-----
-physical_plan	<REGEX>:.*Empty Result.*
-
-query I
-SELECT count(*) FROM (SELECT max(x) AS m FROM t HAVING max(x) < 0);
-----
-0
-
-query II
-EXPLAIN SELECT min(x) FROM t HAVING min(x) > 9999;
-----
-physical_plan	<REGEX>:.*Empty Result.*
-
-query I
-SELECT count(*) FROM (SELECT min(x) AS m FROM t HAVING min(x) > 9999);
-----
-0
-
-# sum(x) should also be bounded and fold impossible HAVING
 query II
 EXPLAIN SELECT sum(x) FROM t HAVING sum(x) < 0;
 ----


### PR DESCRIPTION
Hi team, I found current implementation doesn't propagate stats for `sum` aggregates; for example
```sql
memory D CREATE TABLE t AS SELECT range::INTEGER AS x FROM range(10000);
memory D EXPLAIN SELECT sum(x) FROM t HAVING sum(x) < 0;
╭─ Filter ────────────────────────╮
│ Expression: sum(x) < 0          │
│ ~0 rows                         │
╰────────────────┬────────────────╯
╭─ Ungrouped Aggregate ───────────╮
│ Aggregates: sum_no_overflow(#0) │
│ ~1 row                          │
╰────────────────┬────────────────╯
╭─ Projection ───┴────────────────╮
│ Projections: x                  │
│ ~10,000 rows                    │
╰────────────────┬────────────────╯
╭─ Seq Scan ─────┴────────────────╮
│ Table: memory.main.t            │
│ Type: Sequential Scan           │
│ Projections: x                  │
│ ~10,000 rows                    │
╰─────────────────────────────────╯
```
The above query should be able to prune all row groups, but we're accessing every row groups.

The reason is 
- We do have stats propagation callback for `sum` aggregate, but it's only to [replace a fast sum implementation](https://github.com/duckdb/duckdb/blob/8616efa9da9921b9111fe46373af7936a5d96d16/extension/core_functions/aggregate/distributive/sum.cpp#L280-L313) when possible
- BUT the calculates stats is never returned -- all paths are returning NULL

This PR does a few things:
- The fast sum aggregation is kept for INT16/INT32 types when possible
- Propagated the calculated stats so they could be used to prune
- Expand the sum aggregate type from limited ones, to all possible types, except HUGEINT