### PR TITLE
Check simple load and autoload of extensions

### DIFF
--- a/src/include/duckdb/main/extension_helper.hpp
+++ b/src/include/duckdb/main/extension_helper.hpp
@@ -182,6 +182,13 @@ public:
 	static vector<string> GetTrustedPublicKeys(DatabaseInstance &db, ExtensionRepositoryType repository_type,
 	                                           const string &repository_name);
 
+	//! The origin whose signing keys a load trusts. Without an explicit FROM (a bare load, which is also what
+	//! autoloading performs) only the fixed core and community keys are trusted: a community extension keeps its
+	//! community keys, while every other origin - including a user-provided repository that merely redeploys an
+	//! extension - is verified against the core keys, never the repository's own. With a FROM the named origin is used.
+	static ExtensionRepositoryType ResolveTrustedSignatureOrigin(bool has_from_clause,
+	                                                             ExtensionRepositoryType recorded_origin);
+
 	// Returns extension name, or empty string if not a replacement open path
 	static string ExtractExtensionPrefixFromPath(const string &path);
 

--- a/src/include/duckdb/main/extension_helper.hpp
+++ b/src/include/duckdb/main/extension_helper.hpp
@@ -182,11 +182,12 @@ public:
 	static vector<string> GetTrustedPublicKeys(DatabaseInstance &db, ExtensionRepositoryType repository_type,
 	                                           const string &repository_name);
 
-	//! The origin whose signing keys a load trusts. Without an explicit FROM (a bare load, which is also what
-	//! autoloading performs) only the fixed core and community keys are trusted: a community extension keeps its
-	//! community keys, while every other origin - including a user-provided repository that merely redeploys an
-	//! extension - is verified against the core keys, never the repository's own. With a FROM the named origin is used.
-	static ExtensionRepositoryType ResolveTrustedSignatureOrigin(bool has_from_clause,
+	//! The origin whose signing keys a load trusts. With an explicit FROM the named origin is used. An autoload
+	//! (core_only) trusts only the core keys - every autoloadable extension is a core extension, so it never needs to
+	//! accept a community or user-provided origin. A plain bare LOAD trusts the fixed core and community keys (a
+	//! community extension keeps its community keys), but never a user-provided repository's own keys - those, and a
+	//! user-provided repository that merely redeploys an extension, are verified against the core keys instead.
+	static ExtensionRepositoryType ResolveTrustedSignatureOrigin(bool has_from_clause, bool core_only,
 	                                                             ExtensionRepositoryType recorded_origin);
 
 	// Returns extension name, or empty string if not a replacement open path
@@ -282,13 +283,14 @@ private:
 	static vector<string> DefaultExtensionFolders(FileSystem &fs);
 	static bool AllowAutoInstall(const string &extension);
 	static ExtensionInitResult InitialLoad(DatabaseInstance &db, FileSystem &fs, const string &extension,
-	                                       const string &repository_name = string());
+	                                       const string &repository_name = string(), bool core_only = false);
 	static bool TryInitialLoad(DatabaseInstance &db, FileSystem &fs, const string &extension,
-	                           const string &repository_name, ExtensionInitResult &result, string &error);
+	                           const string &repository_name, bool core_only, ExtensionInitResult &result,
+	                           string &error);
 	//! Version tags occur with and without 'v', tag in extension path is always with 'v'
 	static const string NormalizeVersionTag(const string &version_tag);
 	static void LoadExternalExtensionInternal(DatabaseInstance &db, FileSystem &fs, const string &extension,
-	                                          const string &repository_name, ExtensionActiveLoad &info,
+	                                          const string &repository_name, bool core_only, ExtensionActiveLoad &info,
 	                                          optional_ptr<ClientContext> context);
 
 private:

--- a/src/include/duckdb/main/extension_helper.hpp
+++ b/src/include/duckdb/main/extension_helper.hpp
@@ -182,11 +182,9 @@ public:
 	static vector<string> GetTrustedPublicKeys(DatabaseInstance &db, ExtensionRepositoryType repository_type,
 	                                           const string &repository_name);
 
-	//! The origin whose signing keys a load trusts. With an explicit FROM the named origin is used. An autoload
-	//! (core_only) trusts only the core keys - every autoloadable extension is a core extension, so it never needs to
-	//! accept a community or user-provided origin. A plain bare LOAD trusts the fixed core and community keys (a
-	//! community extension keeps its community keys), but never a user-provided repository's own keys - those, and a
-	//! user-provided repository that merely redeploys an extension, are verified against the core keys instead.
+	//! The origin whose signing keys a load trusts: an explicit FROM trusts the named origin, an autoload (core_only)
+	//! trusts the core keys only, and a plain bare LOAD trusts the core keys plus the community keys for a community
+	//! extension - never a user-provided repository's own keys
 	static ExtensionRepositoryType ResolveTrustedSignatureOrigin(bool has_from_clause, bool core_only,
 	                                                             ExtensionRepositoryType recorded_origin);
 

--- a/src/include/duckdb/main/extension_load_options.hpp
+++ b/src/include/duckdb/main/extension_load_options.hpp
@@ -24,8 +24,7 @@ struct ExtensionLoadOptions {
 	//! The repository named in the FROM clause the extension is loaded from (e.g. LOAD httpfs FROM core). Empty for a
 	//! bare LOAD, which only resolves core and community extensions
 	string repository;
-	//! Set for an autoload: only core extensions are autoloadable, so the load trusts the core keys exclusively -
-	//! never the community or a user-provided repository's keys, even if the on-disk .info records such an origin
+	//! Set for an autoload: only core extensions are autoloadable, so only the core keys are trusted
 	bool core_only = false;
 };
 

--- a/src/include/duckdb/main/extension_load_options.hpp
+++ b/src/include/duckdb/main/extension_load_options.hpp
@@ -24,6 +24,9 @@ struct ExtensionLoadOptions {
 	//! The repository named in the FROM clause the extension is loaded from (e.g. LOAD httpfs FROM core). Empty for a
 	//! bare LOAD, which only resolves core and community extensions
 	string repository;
+	//! Set for an autoload: only core extensions are autoloadable, so the load trusts the core keys exclusively -
+	//! never the community or a user-provided repository's keys, even if the on-disk .info records such an origin
+	bool core_only = false;
 };
 
 } // namespace duckdb

--- a/src/main/extension/extension_helper.cpp
+++ b/src/main/extension/extension_helper.cpp
@@ -227,6 +227,13 @@ string ExtensionHelper::AddExtensionInstallHintToErrorMsg(DatabaseInstance &db, 
 	return base_error;
 }
 
+// autoloading only ever targets core extensions, so the load trusts the core keys exclusively
+static ExtensionLoadOptions AutoLoadOptions(const string &extension_name) {
+	ExtensionLoadOptions options(extension_name);
+	options.core_only = true;
+	return options;
+}
+
 bool ExtensionHelper::TryAutoLoadExtension(ClientContext &context, const string &extension_name) noexcept {
 	if (context.db->ExtensionIsLoaded(extension_name)) {
 		return true;
@@ -239,7 +246,7 @@ bool ExtensionHelper::TryAutoLoadExtension(ClientContext &context, const string 
 			options.repository = autoinstall_repo;
 			ExtensionHelper::InstallExtension(context, extension_name, options);
 		}
-		ExtensionHelper::LoadExternalExtension(context, {extension_name});
+		ExtensionHelper::LoadExternalExtension(context, AutoLoadOptions(extension_name));
 		return true;
 	} catch (...) {
 		return false;
@@ -269,7 +276,7 @@ bool ExtensionHelper::TryAutoLoadExtension(DatabaseInstance &instance, const str
 			ExtensionHelper::InstallExtension(instance, fs, extension_name, options);
 		}
 		if (Settings::Get<AutoloadKnownExtensionsSetting>(instance)) {
-			ExtensionHelper::LoadExternalExtension(instance, fs, {extension_name});
+			ExtensionHelper::LoadExternalExtension(instance, fs, AutoLoadOptions(extension_name));
 			return true;
 		}
 		return false;
@@ -284,7 +291,7 @@ bool ExtensionHelper::TryAutoLoadAvailableExtension(DatabaseInstance &instance, 
 	}
 	try {
 		auto &fs = FileSystem::GetFileSystem(instance);
-		ExtensionHelper::LoadExternalExtension(instance, fs, {extension_name});
+		ExtensionHelper::LoadExternalExtension(instance, fs, AutoLoadOptions(extension_name));
 		return true;
 	} catch (...) {
 		return false;
@@ -438,7 +445,7 @@ void ExtensionHelper::AutoLoadExtension(DatabaseInstance &db, const string &exte
 			ExtensionHelper::InstallExtension(db, fs, extension_name, options);
 		}
 #endif
-		ExtensionHelper::LoadExternalExtension(db, fs, {extension_name});
+		ExtensionHelper::LoadExternalExtension(db, fs, AutoLoadOptions(extension_name));
 		DUCKDB_LOG_INFO(db, "Loaded extension '%s'", extension_name);
 	} catch (std::exception &e) {
 		ErrorData error(e);
@@ -933,13 +940,17 @@ vector<string> ExtensionHelper::GetTrustedPublicKeys(DatabaseInstance &db, Exten
 	}
 }
 
-ExtensionRepositoryType ExtensionHelper::ResolveTrustedSignatureOrigin(bool has_from_clause,
+ExtensionRepositoryType ExtensionHelper::ResolveTrustedSignatureOrigin(bool has_from_clause, bool core_only,
                                                                        ExtensionRepositoryType recorded_origin) {
 	if (has_from_clause) {
 		// an explicit FROM names the origin, so its keys are the ones to trust
 		return recorded_origin;
 	}
-	// a bare load trusts only the fixed core and community keys: a community extension keeps its community keys, every
+	if (core_only) {
+		// autoloading only ever targets core extensions, so it trusts nothing but the core keys - not even community
+		return ExtensionRepositoryType::CORE;
+	}
+	// a plain bare load trusts the fixed core and community keys: a community extension keeps its community keys, every
 	// other origin (including a user-provided repository) is verified against the core keys, never its own
 	if (recorded_origin == ExtensionRepositoryType::COMMUNITY) {
 		return ExtensionRepositoryType::COMMUNITY;

--- a/src/main/extension/extension_helper.cpp
+++ b/src/main/extension/extension_helper.cpp
@@ -933,4 +933,18 @@ vector<string> ExtensionHelper::GetTrustedPublicKeys(DatabaseInstance &db, Exten
 	}
 }
 
+ExtensionRepositoryType ExtensionHelper::ResolveTrustedSignatureOrigin(bool has_from_clause,
+                                                                       ExtensionRepositoryType recorded_origin) {
+	if (has_from_clause) {
+		// an explicit FROM names the origin, so its keys are the ones to trust
+		return recorded_origin;
+	}
+	// a bare load trusts only the fixed core and community keys: a community extension keeps its community keys, every
+	// other origin (including a user-provided repository) is verified against the core keys, never its own
+	if (recorded_origin == ExtensionRepositoryType::COMMUNITY) {
+		return ExtensionRepositoryType::COMMUNITY;
+	}
+	return ExtensionRepositoryType::CORE;
+}
+
 } // namespace duckdb

--- a/src/main/extension/extension_helper.cpp
+++ b/src/main/extension/extension_helper.cpp
@@ -227,7 +227,7 @@ string ExtensionHelper::AddExtensionInstallHintToErrorMsg(DatabaseInstance &db, 
 	return base_error;
 }
 
-// autoloading only ever targets core extensions, so the load trusts the core keys exclusively
+// autoloading only ever targets core extensions, so it trusts the core keys exclusively
 static ExtensionLoadOptions AutoLoadOptions(const string &extension_name) {
 	ExtensionLoadOptions options(extension_name);
 	options.core_only = true;
@@ -947,7 +947,7 @@ ExtensionRepositoryType ExtensionHelper::ResolveTrustedSignatureOrigin(bool has_
 		return recorded_origin;
 	}
 	if (core_only) {
-		// autoloading only ever targets core extensions, so it trusts nothing but the core keys - not even community
+		// autoloading only ever targets core extensions - not even community keys are trusted
 		return ExtensionRepositoryType::CORE;
 	}
 	// a plain bare load trusts the fixed core and community keys: a community extension keeps its community keys, every

--- a/src/main/extension/extension_load.cpp
+++ b/src/main/extension/extension_load.cpp
@@ -624,11 +624,23 @@ bool ExtensionHelper::TryInitialLoad(DatabaseInstance &db, FileSystem &fs, const
 
 	if (!Settings::Get<AllowUnsignedExtensionsSetting>(db)) {
 		bool signature_valid;
+		// The recorded origin (from the .info) determines which keys could have signed the extension, but without an
+		// explicit FROM a bare load - which is also how autoloading loads - trusts only the fixed core/community keys,
+		// never a user-provided repository's own keys. So an extension a repository merely redeploys still loads if it
+		// is genuinely core-signed, while one signed by the repository's own key does not. This stops a repointed
+		// extension_directory (a repository's served layout matches an extension directory's) from loading native code
+		// under a user-provided key.
+		bool bare_load = repository_name.empty();
+		auto recorded_origin = install_info ? install_info->repository_type : ExtensionRepositoryType::CORE;
+		auto trusted_origin = ExtensionHelper::ResolveTrustedSignatureOrigin(!bare_load, recorded_origin);
+		auto signing_repository_name = install_info ? install_info->repository_name : string();
+		if (trusted_origin != recorded_origin) {
+			// forced onto the core keys - the repository's own name is no longer the trust anchor
+			signing_repository_name = string();
+		}
 		if (parsed_metadata.AppearsValid()) {
-			// the repository the extension was installed from determines which keys can have signed it
-			auto repository_type = install_info ? install_info->repository_type : ExtensionRepositoryType::CORE;
-			auto repository_name = install_info ? install_info->repository_name : string();
-			signature_valid = CheckExtensionSignature(db, *handle, parsed_metadata, repository_type, repository_name);
+			signature_valid =
+			    CheckExtensionSignature(db, *handle, parsed_metadata, trusted_origin, signing_repository_name);
 		} else {
 			signature_valid = false;
 		}
@@ -638,6 +650,15 @@ bool ExtensionHelper::TryInitialLoad(DatabaseInstance &db, FileSystem &fs, const
 		}
 
 		if (!signature_valid) {
+			// an extension from a user-provided repository is trusted only when the repository is named: a plain load
+			// verifies it against the core keys, so it fails here. Keep the message generic - reaching this needs an
+			// unusual setup (a repointed extension_directory), and it must not spell out how to load the refused file
+			if (bare_load && install_info &&
+			    install_info->repository_type == ExtensionRepositoryType::USER_PROVIDED) {
+				throw IOException("Extension '%s' was installed from a user-provided repository; a plain LOAD only "
+				                  "loads core and community extensions. Load it explicitly from its repository.",
+				                  extension);
+			}
 			throw IOException(db.config.error_manager->FormatException(ErrorType::UNSIGNED_EXTENSION, filename));
 		}
 	} else if (!Settings::Get<AllowExtensionsMetadataMismatchSetting>(db)) {

--- a/src/main/extension/extension_load.cpp
+++ b/src/main/extension/extension_load.cpp
@@ -453,7 +453,8 @@ bool ExtensionHelper::CheckExtensionBufferSignature(DatabaseInstance &db, const 
 }
 
 bool ExtensionHelper::TryInitialLoad(DatabaseInstance &db, FileSystem &fs, const string &extension,
-                                     const string &repository_name, ExtensionInitResult &result, string &error) {
+                                     const string &repository_name, bool core_only, ExtensionInitResult &result,
+                                     string &error) {
 #ifdef DUCKDB_DISABLE_EXTENSION_LOAD
 	throw PermissionException("Loading external extensions is disabled through a compile time flag");
 #else
@@ -632,7 +633,7 @@ bool ExtensionHelper::TryInitialLoad(DatabaseInstance &db, FileSystem &fs, const
 		// under a user-provided key.
 		bool bare_load = repository_name.empty();
 		auto recorded_origin = install_info ? install_info->repository_type : ExtensionRepositoryType::CORE;
-		auto trusted_origin = ExtensionHelper::ResolveTrustedSignatureOrigin(!bare_load, recorded_origin);
+		auto trusted_origin = ExtensionHelper::ResolveTrustedSignatureOrigin(!bare_load, core_only, recorded_origin);
 		auto signing_repository_name = install_info ? install_info->repository_name : string();
 		if (trusted_origin != recorded_origin) {
 			// forced onto the core keys - the repository's own name is no longer the trust anchor
@@ -653,8 +654,7 @@ bool ExtensionHelper::TryInitialLoad(DatabaseInstance &db, FileSystem &fs, const
 			// an extension from a user-provided repository is trusted only when the repository is named: a plain load
 			// verifies it against the core keys, so it fails here. Keep the message generic - reaching this needs an
 			// unusual setup (a repointed extension_directory), and it must not spell out how to load the refused file
-			if (bare_load && install_info &&
-			    install_info->repository_type == ExtensionRepositoryType::USER_PROVIDED) {
+			if (bare_load && install_info && install_info->repository_type == ExtensionRepositoryType::USER_PROVIDED) {
 				throw IOException("Extension '%s' was installed from a user-provided repository; a plain LOAD only "
 				                  "loads core and community extensions. Load it explicitly from its repository.",
 				                  extension);
@@ -728,10 +728,10 @@ bool ExtensionHelper::TryInitialLoad(DatabaseInstance &db, FileSystem &fs, const
 }
 
 ExtensionInitResult ExtensionHelper::InitialLoad(DatabaseInstance &db, FileSystem &fs, const string &extension,
-                                                 const string &repository_name) {
+                                                 const string &repository_name, bool core_only) {
 	string error;
 	ExtensionInitResult result;
-	if (!TryInitialLoad(db, fs, extension, repository_name, result, error)) {
+	if (!TryInitialLoad(db, fs, extension, repository_name, core_only, result, error)) {
 		if (!Settings::Get<AutoinstallKnownExtensionsSetting>(db) || !ExtensionHelper::AllowAutoInstall(extension)) {
 			throw IOException(error);
 		}
@@ -745,7 +745,7 @@ ExtensionInitResult ExtensionHelper::InitialLoad(DatabaseInstance &db, FileSyste
 		}
 		ExtensionHelper::InstallExtension(db, fs, extension, options);
 		// try loading again
-		if (!TryInitialLoad(db, fs, extension, repository_name, result, error)) {
+		if (!TryInitialLoad(db, fs, extension, repository_name, core_only, result, error)) {
 			throw IOException(error);
 		}
 	}
@@ -796,7 +796,8 @@ void ExtensionHelper::LoadExternalExtension(DatabaseInstance &db, FileSystem &fs
 		return;
 	}
 	try {
-		LoadExternalExtensionInternal(db, fs, options.extension_name, options.repository, *info, context);
+		LoadExternalExtensionInternal(db, fs, options.extension_name, options.repository, options.core_only, *info,
+		                              context);
 	} catch (std::exception &ex) {
 		ErrorData error(ex);
 		info->LoadFail(error);
@@ -805,12 +806,12 @@ void ExtensionHelper::LoadExternalExtension(DatabaseInstance &db, FileSystem &fs
 }
 
 void ExtensionHelper::LoadExternalExtensionInternal(DatabaseInstance &db, FileSystem &fs, const string &extension,
-                                                    const string &repository_name, ExtensionActiveLoad &info,
-                                                    optional_ptr<ClientContext> context) {
+                                                    const string &repository_name, bool core_only,
+                                                    ExtensionActiveLoad &info, optional_ptr<ClientContext> context) {
 #ifdef DUCKDB_DISABLE_EXTENSION_LOAD
 	throw PermissionException("Loading external extensions is disabled through a compile time flag");
 #else
-	auto extension_init_result = InitialLoad(db, fs, extension, repository_name);
+	auto extension_init_result = InitialLoad(db, fs, extension, repository_name, core_only);
 
 	// C++ ABI
 	if (extension_init_result.abi_type == ExtensionABIType::CPP) {

--- a/test/api/test_extension_repositories.cpp
+++ b/test/api/test_extension_repositories.cpp
@@ -223,31 +223,27 @@ TEST_CASE("Test which signing keys a load trusts", "[api]") {
 	REQUIRE(ExtensionHelper::ResolveTrustedSignatureOrigin(true, false, T::COMMUNITY) == T::COMMUNITY);
 	REQUIRE(ExtensionHelper::ResolveTrustedSignatureOrigin(true, false, T::USER_PROVIDED) == T::USER_PROVIDED);
 
-	// a plain bare LOAD trusts the fixed core/community keys: core stays core, a community extension keeps its
-	// community keys, and a user-provided origin is verified against the core keys - never the repository's own. This
-	// stops a repointed extension_directory from loading native code under a user-provided key off an on-disk .info
+	// a plain bare LOAD keeps the community keys for a community extension, but verifies a user-provided origin
+	// against the core keys - so a repointed extension_directory cannot load code under a user-provided key
 	REQUIRE(ExtensionHelper::ResolveTrustedSignatureOrigin(false, false, T::CORE) == T::CORE);
 	REQUIRE(ExtensionHelper::ResolveTrustedSignatureOrigin(false, false, T::COMMUNITY) == T::COMMUNITY);
 	REQUIRE(ExtensionHelper::ResolveTrustedSignatureOrigin(false, false, T::USER_PROVIDED) == T::CORE);
 
-	// an autoload (core_only) targets only core extensions, so it trusts nothing but the core keys - not even a
-	// community origin can be autoloaded, closing the last way a non-core-signed extension could be loaded implicitly
+	// an autoload targets only core extensions, so nothing but the core keys is trusted - not even community
 	REQUIRE(ExtensionHelper::ResolveTrustedSignatureOrigin(false, true, T::CORE) == T::CORE);
 	REQUIRE(ExtensionHelper::ResolveTrustedSignatureOrigin(false, true, T::COMMUNITY) == T::CORE);
 	REQUIRE(ExtensionHelper::ResolveTrustedSignatureOrigin(false, true, T::USER_PROVIDED) == T::CORE);
 }
 
-// A test legitimately stages the on-disk state an install would produce, so it writes the reserved
-// '.duckdb_extension' trust domain the way INSTALL does
+// Stages the on-disk state an install would produce, writing to the reserved '.duckdb_extension' domain like INSTALL
 static void WriteExtensionFile(FileSystem &fs, const string &path, void *data, idx_t size) {
 	auto handle = fs.OpenFile(path, FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE_NEW |
 	                                    FileFlags::FILE_FLAGS_ENABLE_EXTENSION_INSTALL);
 	handle->Write(data, size);
 }
 
-// Stage <extension_directory>/<version>/<platform>/<name>.duckdb_extension plus a .info recording a user-provided
-// origin, in the flat top-level layout a bare load resolves - as pointing extension_directory at a repository's own
-// prefix would expose. The binary is a stub: these tests assert the origin handling, not a real load.
+// Stage an extension plus a .info recording a user-provided origin, in the flat layout a bare load resolves. The
+// binary is a stub: these tests assert the origin handling, not a real load
 static void StageUserRepoExtensionFlat(DatabaseInstance &db, const string &name, const string &repository_name) {
 	auto fs = FileSystem::CreateLocal();
 	string dir = ExtensionHelper::ExtensionDirectory(db, *fs);
@@ -271,9 +267,8 @@ TEST_CASE("Test that a user repository does not block an unsigned load", "[api]"
 	auto repository_directory = TestCreatePath("ext_repo_devflow");
 	auto extension_directory = TestCreatePath("ext_repo_devflow_ext");
 
-	// pointing at a build folder (or a repository prefix) to test autoloading is a real workflow: when the signature
-	// trust model is off (allow_unsigned_extensions), a user-provided origin must NOT impose an extra load barrier -
-	// the extension load is attempted like any other and fails only on the stub binary, not on an origin rule
+	// pointing at a build folder to test autoloading is a real workflow: with allow_unsigned_extensions the trust
+	// model is off, so a user-provided origin must not impose an extra load barrier
 	DBConfig config;
 	config.SetOptionByName("extension_repository_directory", repository_directory);
 	config.SetOptionByName("extension_directory", extension_directory);

--- a/test/api/test_extension_repositories.cpp
+++ b/test/api/test_extension_repositories.cpp
@@ -7,8 +7,6 @@
 #include "duckdb/main/extension_repository_manager.hpp"
 #include "test_helpers.hpp"
 
-#include <fstream>
-
 using namespace duckdb;
 
 static constexpr const char *TEST_PUBLIC_KEY =
@@ -239,13 +237,12 @@ TEST_CASE("Test which signing keys a load trusts", "[api]") {
 	REQUIRE(ExtensionHelper::ResolveTrustedSignatureOrigin(false, true, T::USER_PROVIDED) == T::CORE);
 }
 
-// Write raw bytes to a path directly, bypassing DuckDB's filesystem (which reserves the '.duckdb_extension' trust
-// domain from writes). A test legitimately stages the on-disk state an install would produce.
-static void WriteFileRaw(const string &path, const char *data, idx_t size) {
-	std::ofstream out(path, std::ios::binary | std::ios::trunc);
-	REQUIRE(out.good());
-	out.write(data, static_cast<std::streamsize>(size));
-	out.close();
+// A test legitimately stages the on-disk state an install would produce, so it writes the reserved
+// '.duckdb_extension' trust domain the way INSTALL does
+static void WriteExtensionFile(FileSystem &fs, const string &path, void *data, idx_t size) {
+	auto handle = fs.OpenFile(path, FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE_NEW |
+	                                    FileFlags::FILE_FLAGS_ENABLE_EXTENSION_INSTALL);
+	handle->Write(data, size);
 }
 
 // Stage <extension_directory>/<version>/<platform>/<name>.duckdb_extension plus a .info recording a user-provided
@@ -257,8 +254,8 @@ static void StageUserRepoExtensionFlat(DatabaseInstance &db, const string &name,
 	fs->CreateDirectoriesRecursive(dir);
 
 	string ext_path = fs->JoinPath(dir, name + ".duckdb_extension");
-	string zeros(ParsedExtensionMetaData::FOOTER_SIZE, '\0');
-	WriteFileRaw(ext_path, zeros.c_str(), zeros.size());
+	vector<data_t> stub(ParsedExtensionMetaData::FOOTER_SIZE, 0);
+	WriteExtensionFile(*fs, ext_path, stub.data(), stub.size());
 
 	ExtensionInstallInfo info;
 	info.mode = ExtensionInstallMode::REPOSITORY;
@@ -267,12 +264,12 @@ static void StageUserRepoExtensionFlat(DatabaseInstance &db, const string &name,
 	info.version = "";
 	MemoryStream stream;
 	BinarySerializer::Serialize(info, stream);
-	WriteFileRaw(ext_path + ".info", const_char_ptr_cast(stream.GetData()), stream.GetPosition());
+	WriteExtensionFile(*fs, ext_path + ".info", stream.GetData(), stream.GetPosition());
 }
 
-TEST_CASE("Test that a user-provided repository does not block loading when unsigned extensions are allowed", "[api]") {
-	auto repository_directory = TestCreatePath("extension_repositories_devflow");
-	auto extension_directory = TestCreatePath("extension_repositories_devflow_extdir");
+TEST_CASE("Test that a user repository does not block an unsigned load", "[api]") {
+	auto repository_directory = TestCreatePath("ext_repo_devflow");
+	auto extension_directory = TestCreatePath("ext_repo_devflow_ext");
 
 	// pointing at a build folder (or a repository prefix) to test autoloading is a real workflow: when the signature
 	// trust model is off (allow_unsigned_extensions), a user-provided origin must NOT impose an extra load barrier -

--- a/test/api/test_extension_repositories.cpp
+++ b/test/api/test_extension_repositories.cpp
@@ -216,21 +216,27 @@ TEST_CASE("Test that the extension repository directory is a startup-only trust 
 	}
 }
 
-
-TEST_CASE("Test that a bare load trusts only core and community keys", "[api]") {
+TEST_CASE("Test which signing keys a load trusts", "[api]") {
 	using T = ExtensionRepositoryType;
-	// with an explicit FROM, the named origin's keys are the ones trusted
-	REQUIRE(ExtensionHelper::ResolveTrustedSignatureOrigin(true, T::CORE) == T::CORE);
-	REQUIRE(ExtensionHelper::ResolveTrustedSignatureOrigin(true, T::COMMUNITY) == T::COMMUNITY);
-	REQUIRE(ExtensionHelper::ResolveTrustedSignatureOrigin(true, T::USER_PROVIDED) == T::USER_PROVIDED);
+	// signature (has_from_clause, core_only, recorded_origin)
 
-	// a bare load (no FROM, which is also how autoloading loads) trusts only the fixed core/community keys: core stays
-	// core, a community extension keeps its community keys, and a user-provided origin is verified against the core
-	// keys - never the repository's own. This is what stops a repointed extension_directory from loading native code
-	// under a user-provided key off an on-disk .info
-	REQUIRE(ExtensionHelper::ResolveTrustedSignatureOrigin(false, T::CORE) == T::CORE);
-	REQUIRE(ExtensionHelper::ResolveTrustedSignatureOrigin(false, T::COMMUNITY) == T::COMMUNITY);
-	REQUIRE(ExtensionHelper::ResolveTrustedSignatureOrigin(false, T::USER_PROVIDED) == T::CORE);
+	// with an explicit FROM, the named origin's keys are the ones trusted
+	REQUIRE(ExtensionHelper::ResolveTrustedSignatureOrigin(true, false, T::CORE) == T::CORE);
+	REQUIRE(ExtensionHelper::ResolveTrustedSignatureOrigin(true, false, T::COMMUNITY) == T::COMMUNITY);
+	REQUIRE(ExtensionHelper::ResolveTrustedSignatureOrigin(true, false, T::USER_PROVIDED) == T::USER_PROVIDED);
+
+	// a plain bare LOAD trusts the fixed core/community keys: core stays core, a community extension keeps its
+	// community keys, and a user-provided origin is verified against the core keys - never the repository's own. This
+	// stops a repointed extension_directory from loading native code under a user-provided key off an on-disk .info
+	REQUIRE(ExtensionHelper::ResolveTrustedSignatureOrigin(false, false, T::CORE) == T::CORE);
+	REQUIRE(ExtensionHelper::ResolveTrustedSignatureOrigin(false, false, T::COMMUNITY) == T::COMMUNITY);
+	REQUIRE(ExtensionHelper::ResolveTrustedSignatureOrigin(false, false, T::USER_PROVIDED) == T::CORE);
+
+	// an autoload (core_only) targets only core extensions, so it trusts nothing but the core keys - not even a
+	// community origin can be autoloaded, closing the last way a non-core-signed extension could be loaded implicitly
+	REQUIRE(ExtensionHelper::ResolveTrustedSignatureOrigin(false, true, T::CORE) == T::CORE);
+	REQUIRE(ExtensionHelper::ResolveTrustedSignatureOrigin(false, true, T::COMMUNITY) == T::CORE);
+	REQUIRE(ExtensionHelper::ResolveTrustedSignatureOrigin(false, true, T::USER_PROVIDED) == T::CORE);
 }
 
 // Write raw bytes to a path directly, bypassing DuckDB's filesystem (which reserves the '.duckdb_extension' trust

--- a/test/api/test_extension_repositories.cpp
+++ b/test/api/test_extension_repositories.cpp
@@ -1,7 +1,13 @@
 #include "catch.hpp"
+#include "duckdb/common/serializer/binary_serializer.hpp"
+#include "duckdb/common/serializer/memory_stream.hpp"
+#include "duckdb/main/extension.hpp"
 #include "duckdb/main/extension_helper.hpp"
+#include "duckdb/main/extension_install_info.hpp"
 #include "duckdb/main/extension_repository_manager.hpp"
 #include "test_helpers.hpp"
+
+#include <fstream>
 
 using namespace duckdb;
 
@@ -208,4 +214,79 @@ TEST_CASE("Test that the extension repository directory is a startup-only trust 
 		Connection con(db);
 		REQUIRE_NO_FAIL(con.Query("SET extension_repository_directory='" + repository_directory + "'"));
 	}
+}
+
+
+TEST_CASE("Test that a bare load trusts only core and community keys", "[api]") {
+	using T = ExtensionRepositoryType;
+	// with an explicit FROM, the named origin's keys are the ones trusted
+	REQUIRE(ExtensionHelper::ResolveTrustedSignatureOrigin(true, T::CORE) == T::CORE);
+	REQUIRE(ExtensionHelper::ResolveTrustedSignatureOrigin(true, T::COMMUNITY) == T::COMMUNITY);
+	REQUIRE(ExtensionHelper::ResolveTrustedSignatureOrigin(true, T::USER_PROVIDED) == T::USER_PROVIDED);
+
+	// a bare load (no FROM, which is also how autoloading loads) trusts only the fixed core/community keys: core stays
+	// core, a community extension keeps its community keys, and a user-provided origin is verified against the core
+	// keys - never the repository's own. This is what stops a repointed extension_directory from loading native code
+	// under a user-provided key off an on-disk .info
+	REQUIRE(ExtensionHelper::ResolveTrustedSignatureOrigin(false, T::CORE) == T::CORE);
+	REQUIRE(ExtensionHelper::ResolveTrustedSignatureOrigin(false, T::COMMUNITY) == T::COMMUNITY);
+	REQUIRE(ExtensionHelper::ResolveTrustedSignatureOrigin(false, T::USER_PROVIDED) == T::CORE);
+}
+
+// Write raw bytes to a path directly, bypassing DuckDB's filesystem (which reserves the '.duckdb_extension' trust
+// domain from writes). A test legitimately stages the on-disk state an install would produce.
+static void WriteFileRaw(const string &path, const char *data, idx_t size) {
+	std::ofstream out(path, std::ios::binary | std::ios::trunc);
+	REQUIRE(out.good());
+	out.write(data, static_cast<std::streamsize>(size));
+	out.close();
+}
+
+// Stage <extension_directory>/<version>/<platform>/<name>.duckdb_extension plus a .info recording a user-provided
+// origin, in the flat top-level layout a bare load resolves - as pointing extension_directory at a repository's own
+// prefix would expose. The binary is a stub: these tests assert the origin handling, not a real load.
+static void StageUserRepoExtensionFlat(DatabaseInstance &db, const string &name, const string &repository_name) {
+	auto fs = FileSystem::CreateLocal();
+	string dir = ExtensionHelper::ExtensionDirectory(db, *fs);
+	fs->CreateDirectoriesRecursive(dir);
+
+	string ext_path = fs->JoinPath(dir, name + ".duckdb_extension");
+	string zeros(ParsedExtensionMetaData::FOOTER_SIZE, '\0');
+	WriteFileRaw(ext_path, zeros.c_str(), zeros.size());
+
+	ExtensionInstallInfo info;
+	info.mode = ExtensionInstallMode::REPOSITORY;
+	info.repository_type = ExtensionRepositoryType::USER_PROVIDED;
+	info.repository_name = repository_name;
+	info.version = "";
+	MemoryStream stream;
+	BinarySerializer::Serialize(info, stream);
+	WriteFileRaw(ext_path + ".info", const_char_ptr_cast(stream.GetData()), stream.GetPosition());
+}
+
+TEST_CASE("Test that a user-provided repository does not block loading when unsigned extensions are allowed", "[api]") {
+	auto repository_directory = TestCreatePath("extension_repositories_devflow");
+	auto extension_directory = TestCreatePath("extension_repositories_devflow_extdir");
+
+	// pointing at a build folder (or a repository prefix) to test autoloading is a real workflow: when the signature
+	// trust model is off (allow_unsigned_extensions), a user-provided origin must NOT impose an extra load barrier -
+	// the extension load is attempted like any other and fails only on the stub binary, not on an origin rule
+	DBConfig config;
+	config.SetOptionByName("extension_repository_directory", repository_directory);
+	config.SetOptionByName("extension_directory", extension_directory);
+	config.SetOptionByName("allow_extension_repositories", "allowed");
+	config.SetOptionByName("allow_unsigned_extensions", true);
+	config.SetOptionByName("allow_extensions_metadata_mismatch", true);
+	DuckDB db(nullptr, &config);
+	Connection con(db);
+
+	REQUIRE_NO_FAIL(con.Query(StringUtil::Format(
+	    "CREATE EXTENSION REPOSITORY quackquack WITH PREFIX 'http://quackquack.com' USING PUBLIC KEY '%s'",
+	    TEST_PUBLIC_KEY)));
+	StageUserRepoExtensionFlat(*db.instance, "some_ext", "quackquack");
+
+	auto bare = con.Query("LOAD some_ext");
+	REQUIRE(bare->HasError());
+	// it fails on the stub binary, not on a user-provided-origin rule: the dev flow is not blocked
+	REQUIRE(!StringUtil::Contains(bare->GetError(), "installed from a user-provided repository"));
 }

--- a/test/sql/extensions/extension_repository_not_autoloaded.test
+++ b/test/sql/extensions/extension_repository_not_autoloaded.test
@@ -1,0 +1,52 @@
+# name: test/sql/extensions/extension_repository_not_autoloaded.test
+# description: A user-provided repository is invisible to a bare LOAD, and therefore to autoloading
+# group: [extensions]
+
+# Autoloading always performs a bare load: ExtensionHelper::AutoLoadExtension takes only an extension name, so it can
+# never name a repository. A bare load resolves the flat top-level layout, while a user-provided repository installs
+# into a per-repository subfolder - which is what keeps an extension from a user repository out of autoloading.
+
+statement ok
+SET extension_directory='{TEST_DIR}/repo_not_autoloaded'
+
+statement ok
+SET extension_repository_directory='{TEST_DIR}/repo_not_autoloaded_repos'
+
+statement ok
+CREATE EXTENSION REPOSITORY myrepo WITH PREFIX '{TEST_DIR}/repo_not_autoloaded_prefix' USING PUBLIC KEY 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAt9+KeDkWJa7SiBb7AMdXAPV2qpRunztoC2c7DtRmN9+Lq2YQm4rMQmmAQcwyxTxcK8vwPKOiE4mLMwmQMvTty9tL+buREfvg5KJ+FY3Bv05cZYsf7VuYgUDcw41zSEE5W1thh5PiafcrMn7CPF0jN0oFfVvAHB/fAM0yaZGPKs3WYqnHAHa6v/cVMeiWZ/lQORCBqqL2hii1fEiuIqw6AOEoZVsN0/lqm7GfnD899zrzLOPRuP4YFg46drL1UyNdg+4TquJ2OV9kR4CAfdGRexqHFWLmoxkTfnUxJ4yL+gkV57K1H+smEdKrDhDX68pEFM/34E2eVKZoRU/0paxDZQIDAQAB'
+
+# installing from a user-provided repository targets the per-repository subfolder: the install fails on the (empty)
+# prefix, but it has already created the directory it would have installed into
+statement error
+INSTALL some_ext FROM myrepo
+----
+<REGEX>:.*repo_not_autoloaded_prefix.*some_ext\.duckdb_extension.*
+
+query I
+SELECT count(*) FROM glob('{TEST_DIR}/repo_not_autoloaded/*/*/repositories/myrepo')
+----
+1
+
+# a load with an explicit FROM resolves the per-repository subfolder
+statement error
+LOAD some_ext FROM myrepo
+----
+<REGEX>:.*repo_not_autoloaded[/\\][^/\\]*[/\\][^/\\]*[/\\]repositories[/\\]myrepo[/\\]some_ext\.duckdb_extension.*not found.*
+
+# a bare load resolves only the flat <version>/<platform> layout: there is no 'repositories' segment, so nothing that
+# was installed from a user repository can be reached this way
+statement error
+LOAD some_ext
+----
+<REGEX>:.*repo_not_autoloaded[/\\][^/\\]*[/\\][^/\\]*[/\\]some_ext\.duckdb_extension.*not found.*
+
+# repointing extension_directory at the repository subfolder does not help either: the <version> and <platform>
+# components are always appended to the configured directory, so the flat search path can never be aliased onto a
+# repository subfolder
+statement ok
+SET extension_directory='{TEST_DIR}/repo_not_autoloaded/v0/plat/repositories/myrepo'
+
+statement error
+LOAD some_ext
+----
+<REGEX>:.*repositories[/\\]myrepo[/\\][^/\\]*[/\\][^/\\]*[/\\]some_ext\.duckdb_extension.*not found.*


### PR DESCRIPTION
Iterates on https://github.com/duckdb/duckdb/pull/24777, by making so that:

* Explicit `LOAD <name>` can only ever accept core or community keys (this is on par with 1.5.5, but was relaxed by the PR in non standard setups)
* Autoload can only ever accept core keys (this is stricter than 1.5.5, where also community keys were accepted IF name were to match, and that relies on no collisions being merged)

I think this avoid some potential issues / unclarity of misuse, since issuing a `FROM 's3://bucket/path/to/file.parquet';` will autoload httpfs only if:
1. autoloading is enabled
2. the current local state does have a core signature extension at `httpfs.duckdb_extension`

Similarly, if extension is not available, autoinstall will also require a core signature on the binary.

----

Note `LOAD httpfs FROM my_repo;` would still allow that to override `httpfs` behaviour, but that needs then to be explicitly issued.

Note that the following cases have also been considered (and keeps working as intended):
* re-distributing core-signed extensions via a different repository works
* those restrictions are available only when signature checks are performed, so unsigned local development tests are kept functional