### PR TITLE
Do not corrupt the transaction lists when an allocation fails

### DIFF
--- a/src/include/duckdb/transaction/duck_transaction_manager.hpp
+++ b/src/include/duckdb/transaction/duck_transaction_manager.hpp
@@ -96,10 +96,17 @@ protected:
 private:
 	//! Generates a new commit timestamp
 	transaction_t GetCommitTimestamp();
+	//! Allocates the cleanup info, and reserves the space RemoveTransaction needs to re-home a transaction.
+	//! RemoveTransaction is noexcept, so it cannot do this itself: it must not allocate at all. Call this with
+	//! transaction_lock held, immediately before RemoveTransaction, so that a failure to allocate is reported
+	//! while the transaction lists are still untouched.
+	unique_ptr<DuckCleanupInfo> CreateCleanupInfo();
 	//! Remove the given transaction from the list of active transactions
-	unique_ptr<DuckCleanupInfo> RemoveTransaction(DuckTransaction &transaction) noexcept;
+	unique_ptr<DuckCleanupInfo> RemoveTransaction(DuckTransaction &transaction,
+	                                              unique_ptr<DuckCleanupInfo> cleanup_info) noexcept;
 	//! Remove the given transaction from the list of active transactions
-	unique_ptr<DuckCleanupInfo> RemoveTransaction(DuckTransaction &transaction, bool store_transaction) noexcept;
+	unique_ptr<DuckCleanupInfo> RemoveTransaction(DuckTransaction &transaction, bool store_transaction,
+	                                              unique_ptr<DuckCleanupInfo> cleanup_info) noexcept;
 
 	//! Whether or not we can checkpoint
 	CheckpointDecision CanCheckpoint(DuckTransaction &transaction, unique_ptr<StorageLockKey> &checkpoint_lock,

--- a/src/transaction/duck_transaction_manager.cpp
+++ b/src/transaction/duck_transaction_manager.cpp
@@ -426,7 +426,7 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 	                         undo_properties.has_catalog_changes || error.HasError();
 
 	// Remove the transaction from the list of active transactions and gather cleanup information.
-	auto cleanup_info = RemoveTransaction(transaction, store_transaction);
+	auto cleanup_info = RemoveTransaction(transaction, store_transaction, CreateCleanupInfo());
 	if (cleanup_info->ScheduleCleanup()) {
 		lock_guard<mutex> q_lock(cleanup_queue_lock);
 		cleanup_queue.emplace(std::move(cleanup_info));
@@ -482,7 +482,7 @@ void DuckTransactionManager::RollbackTransaction(Transaction &transaction_p) {
 		error = transaction.Rollback();
 
 		// Remove the transaction from the list of active transactions and gather cleanup information.
-		auto cleanup_info = RemoveTransaction(transaction);
+		auto cleanup_info = RemoveTransaction(transaction, CreateCleanupInfo());
 		if (cleanup_info->ScheduleCleanup()) {
 			lock_guard<mutex> q_lock(cleanup_queue_lock);
 			cleanup_queue.emplace(std::move(cleanup_info));
@@ -496,13 +496,26 @@ void DuckTransactionManager::RollbackTransaction(Transaction &transaction_p) {
 	}
 }
 
-unique_ptr<DuckCleanupInfo> DuckTransactionManager::RemoveTransaction(DuckTransaction &transaction) noexcept {
-	return RemoveTransaction(transaction, transaction.ChangesMade());
+unique_ptr<DuckCleanupInfo> DuckTransactionManager::CreateCleanupInfo() {
+	auto cleanup_info = make_uniq<DuckCleanupInfo>();
+	// RemoveTransaction moves the transaction out of active_transactions before re-homing it in one of these
+	// lists. It is noexcept, so a failure to allocate there would terminate the process and lose the transaction;
+	// reserve everything it can need here instead, where throwing is safe and modifies nothing.
+	cleanup_info->transactions.reserve(recently_committed_transactions.size() + 1);
+	recently_committed_transactions.reserve(recently_committed_transactions.size() + 1);
+	return cleanup_info;
 }
 
-unique_ptr<DuckCleanupInfo> DuckTransactionManager::RemoveTransaction(DuckTransaction &transaction,
-                                                                      bool store_transaction) noexcept {
-	auto cleanup_info = make_uniq<DuckCleanupInfo>();
+unique_ptr<DuckCleanupInfo>
+DuckTransactionManager::RemoveTransaction(DuckTransaction &transaction,
+                                          unique_ptr<DuckCleanupInfo> cleanup_info) noexcept {
+	return RemoveTransaction(transaction, transaction.ChangesMade(), std::move(cleanup_info));
+}
+
+unique_ptr<DuckCleanupInfo>
+DuckTransactionManager::RemoveTransaction(DuckTransaction &transaction, bool store_transaction,
+                                          unique_ptr<DuckCleanupInfo> cleanup_info) noexcept {
+	// Nothing here may allocate: CreateCleanupInfo has reserved everything this needs (see its comment).
 
 	// Find the transaction in the active transactions,
 	// as well as the lowest start time, transaction id, and active query.

--- a/src/transaction/meta_transaction.cpp
+++ b/src/transaction/meta_transaction.cpp
@@ -69,8 +69,12 @@ Transaction &MetaTransaction::GetTransaction(AttachedDatabase &db) {
 #ifdef DEBUG
 		VerifyAllTransactionsUnique(db, all_transactions);
 #endif
-		all_transactions.push_back(db);
+		// Rollback looks every entry of all_transactions up in transactions, so the two must not get out of sync:
+		// reserve first, then insert, so that a failing allocation happens before either is modified and the
+		// push_back that follows cannot allocate.
+		all_transactions.reserve(all_transactions.size() + 1);
 		transactions.insert(make_pair(reference<AttachedDatabase>(db), TransactionReference(new_transaction)));
+		all_transactions.push_back(db);
 		auto shared_db = db.shared_from_this();
 		UseDatabase(shared_db);
 


### PR DESCRIPTION
Two failure paths, both reached by failing an allocation during a query:

MetaTransaction::GetTransaction registered a database in all_transactions and then inserted it into transactions. When that insert failed to allocate, the two were left out of sync, and MetaTransaction::Rollback - which walks all_transactions and looks each entry up in transactions - dereferenced the end iterator. That is a segfault in release; the D_ASSERT that would have caught it is compiled out. Reserve first, then insert, then push_back into the reserved space, so a failure happens before either is modified.

DuckTransactionManager::RemoveTransaction is noexcept and allocated: it moves the transaction out of active_transactions before re-homing it in recently_committed_ transactions or in the cleanup info, so an allocation failure in between terminated the process and lost the transaction. Reserving inside the function does not fix this - reserve allocates too, and it is still noexcept. Move the allocation to the callers, which already hold transaction_lock and may throw: CreateCleanupInfo allocates the cleanup info and reserves the space for both lists, leaving RemoveTransaction genuinely allocation-free.

Between them these accounted for eight tests that crashed under allocation failure injection (two segfaulting in MetaTransaction::Rollback, three aborting in RemoveTransaction, and three more whose stacks were too corrupt to attribute); all eight now survive 36 injected runs each.