### PR TITLE
Fix out-of-bounds path offset for file:// URIs without a path

### DIFF
--- a/src/common/path.cpp
+++ b/src/common/path.cpp
@@ -221,6 +221,7 @@ void Path::NormalizeSegments(const string &raw, size_t path_offset) {
 	}
 
 	vector<string> raw_segs;
+	D_ASSERT(path_offset <= raw.size());
 	SegmentAndNormalizePath(raw.begin() + static_cast<string::difference_type>(path_offset), raw.end(), raw_segs);
 	segments.clear();
 	for (auto &seg : raw_segs) {
@@ -298,12 +299,12 @@ size_t Path::ParseFileSchemes(const string &input, Path &parsed) {
 		parsed.anchor = "/";
 		path_begin = 8;
 	} else if (/* file:// */ input_len >= 7 && input[6] == '/') {
-		ParseURIScheme(input, parsed);
+		// NOTE: the anchor may be synthesized, so the offset must come from ParseURIScheme, not from the sizes
+		path_begin = ParseURIScheme(input, parsed);
 		if (StringUtil::Lower(parsed.authority) != "localhost") {
 			throw InvalidInputException("Path: file:// scheme only supports localhost authority, got: %s",
 			                            parsed.authority);
 		}
-		path_begin = parsed.scheme.size() + parsed.authority.size() + parsed.anchor.size();
 	} else /* file:/ */ {
 		parsed.scheme = "file:";
 		parsed.anchor = "/";

--- a/test/common/test_file_system.cpp
+++ b/test/common/test_file_system.cpp
@@ -854,11 +854,14 @@ TEST_CASE("Path::FromString/ToString round-trips", "[file_system]") {
 		    make_tuple(OK_, "file:/a",      "file:/a"),
 		    make_tuple(OK_, "file:/a/b",    "file:/a/b"),
 
+		    make_tuple(OK_, "file://localhost",     "file://localhost/"),
 		    make_tuple(OK_, "file://localhost/",    "file://localhost/"),
 		    make_tuple(OK_, "file://localhost/a",   "file://localhost/a"),
 		    make_tuple(OK_, "file://localhost/a/b", "file://localhost/a/b"),
 
 		    make_tuple(ERR, "file://otherhost/a/b", ""),
+		    make_tuple(ERR, "file://otherhost",     ""),
+		    make_tuple(ERR, "file://",              ""),
 
 		    make_tuple(OK_, "file:///",     "file:///"),
 		    make_tuple(OK_, "file:///a",    "file:///a"),

--- a/test/sql/function/string/path_join.test
+++ b/test/sql/function/string/path_join.test
@@ -137,3 +137,19 @@ query I
 SELECT path_join(A, B, C, B, A) FROM (SELECT A:'a', B: 'b', C: 'c');
 ----
 a/b/c/b/a
+
+# file:// URI with an authority but no trailing path
+query I
+SELECT path_join('file://localhost');
+----
+file://localhost/
+
+query I
+SELECT path_join('file://localhost', 'a/b');
+----
+file://localhost/a/b
+
+statement error
+SELECT path_join('file://otherhost');
+----
+only supports localhost authority


### PR DESCRIPTION
Fixes #25083

`Path::ParseFileSchemes` computed the consumed prefix of a `file://<authority>` URI by summing `scheme.size() + authority.size() + anchor.size()`. `ParseURIScheme` synthesizes `anchor = "/"` even when nothing follows the authority, so for `file://localhost` the sum overcounts by one, `path_offset` lands past the end of the string, and `SegmentAndNormalizePath` reads out of bounds - reachable from SQL via `SELECT path_join('file://localhost')`.

`ParseURIScheme` already returns the correct offset; use it instead of the sum, and assert `path_offset <= raw.size()` in `NormalizeSegments`. Only the broken case changes behavior: `file://localhost` now parses as `file://localhost/`.
