### PR TITLE
Fix PiecewiseMergeJoin arbitrary predicate candidate indexing

### DIFF
--- a/src/execution/operator/join/physical_piecewise_merge_join.cpp
+++ b/src/execution/operator/join/physical_piecewise_merge_join.cpp
@@ -723,6 +723,9 @@ OperatorResultType PhysicalPiecewiseMergeJoin::ResolveComplexJoin(ExecutionConte
 			if (predicate) {
 				result_count = state.pred_executor.SelectExpression(chunk, state.pred_matches);
 				chunk.Slice(state.pred_matches, result_count);
+				for (idx_t i = 0; i < result_count; i++) {
+					state.pred_matches.set_index(i, sel->get_index(state.pred_matches.get_index(i)));
+				}
 				sel = &state.pred_matches;
 			}
 

--- a/test/sql/join/test_merge_join_predicate.test
+++ b/test/sql/join/test_merge_join_predicate.test
@@ -231,3 +231,52 @@ order by all
 8	NULL
 9	NULL
 
+# Preserve candidate indexes when applying an arbitrary predicate
+
+statement ok
+create or replace table tleft(c0 INTEGER, c2 BOOLEAN);
+
+statement ok
+create table tright(c0 INTEGER, c1 BOOLEAN);
+
+statement ok
+insert into tleft values (1, false), (0, true);
+
+statement ok
+insert into tright values (-1, false), (-1, false), (2, false);
+
+statement ok
+set disabled_optimizers = 'build_side_probe_side';
+
+statement ok
+set nested_loop_join_threshold = 0;
+
+query II
+explain
+select l.c2
+from tleft l
+left join tright r
+on l.c0 >= r.c0
+and l.c2 != r.c1
+and l.c2
+----
+physical_plan	<REGEX>:.*PIECEWISE_MERGE_JOIN.*
+
+query I
+select l.c2
+from tleft l
+left join tright r
+on l.c0 >= r.c0
+and l.c2 != r.c1
+and l.c2
+order by 1
+----
+false
+true
+true
+
+statement ok
+reset disabled_optimizers;
+
+statement ok
+reset nested_loop_join_threshold;


### PR DESCRIPTION
Fixes #25046

### Problem

When `PhysicalPiecewiseMergeJoin` applies an arbitrary predicate after earlier predicates have filtered the candidate pairs, `pred_matches` contains indices into the sliced chunk. These indices were then used directly against the original candidate arrays which resulted in incorrect outer join match tracking.

Specifically, for LEFT JOINs, this can cause the wrong left-hand row to be marked as matched, which means the later `if (!found_match[i])` check in `ConstructLeftJoinResult` may skip a row that should instead have been returned as unmatched.



### Fix

Convert the `pred_matches` indexes back to the corresponding original candidate indexes before using them.

### Tests

Added a regression test covering the affected `PIECEWISE_MERGE_JOIN` LEFT JOIN path.
