### PR TITLE
Fix use-after-free on EXECUTE of prepared table functions that bind a catalog entry

### DIFF
--- a/src/function/table/system/pragma_storage_info.cpp
+++ b/src/function/table/system/pragma_storage_info.cpp
@@ -114,6 +114,7 @@ static unique_ptr<FunctionData> PragmaStorageInfoBind(ClientContext &context, Ta
 	CatalogEntryRetriever retriever(context);
 	qname = Binder::BindTableName(retriever, qname);
 	auto &table_entry = Catalog::GetEntry<TableCatalogEntry>(context, qname);
+	Binder::RegisterEntryRead(input.binder, context, table_entry);
 	return make_uniq<PragmaStorageFunctionData>(table_entry, options);
 }
 

--- a/src/function/table/system/pragma_table_info.cpp
+++ b/src/function/table/system/pragma_table_info.cpp
@@ -173,6 +173,7 @@ static unique_ptr<FunctionData> PragmaTableInfoBind(ClientContext &context, Tabl
 	CatalogEntryRetriever retriever(context);
 	qname = Binder::BindTableName(retriever, qname);
 	auto &entry = Catalog::GetEntry(context, CatalogType::TABLE_ENTRY, qname);
+	Binder::RegisterEntryRead(input.binder, context, entry);
 	return make_uniq<PragmaTableFunctionData>(entry, IS_PRAGMA_TABLE_INFO);
 }
 

--- a/src/function/table/system/pragma_table_sample.cpp
+++ b/src/function/table/system/pragma_table_sample.cpp
@@ -52,6 +52,7 @@ static unique_ptr<FunctionData> DuckDBTableSampleBind(ClientContext &context, Ta
 		names.push_back(col.GetName());
 	}
 
+	Binder::RegisterEntryRead(input.binder, context, entry);
 	return make_uniq<DuckDBTableSampleFunctionData>(entry);
 }
 

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -290,6 +290,9 @@ public:
 	//! names and names with a single schema level keep the (catalog, schema, name) shape so that the search path
 	//! applies; a nested schema path yields a fully resolved [catalog, schema path..., name].
 	static QualifiedName BindTableName(CatalogEntryRetriever &retriever, const QualifiedName &name);
+	//! Register a read of the catalog owning the entry - required when bind data holds a reference to the entry,
+	//! so that cached prepared statement plans are invalidated when the catalog changes
+	static void RegisterEntryRead(optional_ptr<Binder> binder, ClientContext &context, CatalogEntry &entry);
 	QualifiedName BindTableName(const QualifiedName &name);
 	//! Resolve the (possibly nested) name of a CREATE SCHEMA statement into a canonical [catalog, parents..., schema]
 	void BindCreateSchema(CreateSchemaInfo &info);

--- a/src/planner/binder/statement/bind_create.cpp
+++ b/src/planner/binder/statement/bind_create.cpp
@@ -270,6 +270,14 @@ QualifiedName Binder::BindTableName(const QualifiedName &name) {
 	return BindTableName(retriever, name);
 }
 
+void Binder::RegisterEntryRead(optional_ptr<Binder> binder, ClientContext &context, CatalogEntry &entry) {
+	if (!binder) {
+		// no binder available (e.g. when re-binding a deserialized plan) - nothing is cached in that case
+		return;
+	}
+	binder->GetStatementProperties().RegisterDBRead(entry.ParentCatalog(), context);
+}
+
 void Binder::BindCreateSchema(CreateSchemaInfo &info) {
 	// the qualified name carries the dotted path with the new schema as the last component; resolve its leading
 	// component into a catalog (prepending the default catalog when it is a schema)

--- a/test/sql/prepared/prepare_catalog_table_functions.test
+++ b/test/sql/prepared/prepare_catalog_table_functions.test
@@ -1,0 +1,51 @@
+# name: test/sql/prepared/prepare_catalog_table_functions.test
+# description: Prepared table functions that hold a catalog entry must be rebound after DDL
+# group: [prepared]
+
+foreach func pragma_table_info pragma_show pragma_storage_info duckdb_table_sample
+
+statement ok
+CREATE TABLE t(a INTEGER)
+
+statement ok
+PREPARE p AS SELECT * FROM {func}('t')
+
+statement ok
+EXECUTE p
+
+statement ok
+DROP TABLE t
+
+statement error
+EXECUTE p
+----
+<REGEX>:Catalog Error:.*t does not exist.*
+
+statement ok
+DEALLOCATE p
+
+endloop
+
+# a recreated table is picked up by the prepared statement
+statement ok
+CREATE TABLE t(a INTEGER)
+
+statement ok
+PREPARE p AS SELECT name, type FROM pragma_table_info('t')
+
+query II
+EXECUTE p
+----
+a	INTEGER
+
+statement ok
+DROP TABLE t
+
+statement ok
+CREATE TABLE t(zzz VARCHAR, q DOUBLE)
+
+query II
+EXECUTE p
+----
+zzz	VARCHAR
+q	DOUBLE


### PR DESCRIPTION
Fixes #25075

`PragmaTableInfoBind` stores a raw `CatalogEntry &` in its bind data but never calls `RegisterDBRead`, so `read_databases` stays empty and both the rebind guard in `Optimizer::Optimize()` and `PreparedStatementData::RequireRebind()` treat the cached physical plan as safe to reuse. Dropping the table between two `EXECUTE`s frees the `DuckTableEntry` the plan still references - a heap-use-after-free.

Three more table functions bind a catalog entry the same way and reproduce the same UAF: `pragma_show`, `pragma_storage_info` and `duckdb_table_sample`. All four now register the read via a small `Binder::RegisterEntryRead` helper, mirroring what `bind_basetableref.cpp` already does for base tables, and return the same `Catalog Error: Table with name t does not exist!` that a plain table scan gives.