### PR TITLE
Propagate numeric stats for unsigned integers

### DIFF
--- a/src/function/scalar/operator/arithmetic.cpp
+++ b/src/function/scalar/operator/arithmetic.cpp
@@ -109,6 +109,16 @@ static Value NumericStatsValue(const LogicalType &type, hugeint_t value) {
 	return Value::Numeric(type, value);
 }
 
+static Value NumericStatsValue(const LogicalType &type, uint64_t value) {
+	D_ASSERT(type.IsNumeric());
+	return Value::Numeric(type, uhugeint_t(value));
+}
+
+static Value NumericStatsValue(const LogicalType &type, uhugeint_t value) {
+	D_ASSERT(type.IsNumeric());
+	return Value::Numeric(type, value);
+}
+
 template <class T>
 static bool WidenFloatingBounds(const LogicalType &type, Value &new_min, Value &new_max) {
 	auto min = new_min.GetValue<T>();
@@ -227,6 +237,26 @@ unique_ptr<BaseStatistics> PropagateNumericStats(ClientContext &context, Functio
 		case PhysicalType::INT128:
 			potential_overflow =
 			    PROPAGATE::template Operation<hugeint_t, OP>(expr.GetReturnType(), lstats, rstats, new_min, new_max);
+			break;
+		case PhysicalType::UINT8:
+			potential_overflow =
+			    PROPAGATE::template Operation<uint8_t, OP>(expr.GetReturnType(), lstats, rstats, new_min, new_max);
+			break;
+		case PhysicalType::UINT16:
+			potential_overflow =
+			    PROPAGATE::template Operation<uint16_t, OP>(expr.GetReturnType(), lstats, rstats, new_min, new_max);
+			break;
+		case PhysicalType::UINT32:
+			potential_overflow =
+			    PROPAGATE::template Operation<uint32_t, OP>(expr.GetReturnType(), lstats, rstats, new_min, new_max);
+			break;
+		case PhysicalType::UINT64:
+			potential_overflow =
+			    PROPAGATE::template Operation<uint64_t, OP>(expr.GetReturnType(), lstats, rstats, new_min, new_max);
+			break;
+		case PhysicalType::UINT128:
+			potential_overflow =
+			    PROPAGATE::template Operation<uhugeint_t, OP>(expr.GetReturnType(), lstats, rstats, new_min, new_max);
 			break;
 		default:
 			return nullptr;

--- a/test/optimizer/statistics/statistics_unsigned_arithmetic_pruning.test
+++ b/test/optimizer/statistics/statistics_unsigned_arithmetic_pruning.test
@@ -1,0 +1,28 @@
+# name: test/optimizer/statistics/statistics_unsigned_arithmetic_pruning.test
+# description: PropagateNumericStats should propagate min/max through arithmetic on unsigned integer columns (currently only signed widths are handled), so downstream filters can fold to Empty Result.
+# group: [statistics]
+
+statement ok
+ATTACH '{TEST_DIR}/uint_arith_pruning.duckdb' AS db (ROW_GROUP_SIZE 2048);
+
+statement ok
+USE db;
+
+statement ok
+CREATE TABLE tu(x UINTEGER NOT NULL);
+
+statement ok
+INSERT INTO tu SELECT range::UINTEGER FROM range(0, 10240);
+
+statement ok
+CHECKPOINT;
+
+query II
+EXPLAIN SELECT count(*) FROM (SELECT (x + 100::UINTEGER) AS y FROM tu) WHERE y > 100000::UINTEGER;
+----
+physical_plan	<REGEX>:.*Empty Result.*
+
+query I
+SELECT count(*) FROM (SELECT (x + 100::UINTEGER) AS y FROM tu) WHERE y > 100000::UINTEGER;
+----
+0

--- a/test/optimizer/statistics/statistics_unsigned_arithmetic_pruning.test
+++ b/test/optimizer/statistics/statistics_unsigned_arithmetic_pruning.test
@@ -1,5 +1,5 @@
 # name: test/optimizer/statistics/statistics_unsigned_arithmetic_pruning.test
-# description: PropagateNumericStats should propagate min/max through arithmetic on unsigned integer columns (currently only signed widths are handled), so downstream filters can fold to Empty Result.
+# description: unsigned integer columns propagate stats
 # group: [statistics]
 
 statement ok


### PR DESCRIPTION
Hi team, I found current numeric columns only propagate stats for signed values, which leads missing row group pruning for unsigned values, for example,
```sql
memory D ATTACH '/tmp/uint_arith_pruning.duckdb' AS db (ROW_GROUP_SIZE 2048);
memory D USE db;
db D CREATE TABLE ti(x INTEGER NOT NULL);
db D INSERT INTO ti SELECT range::INTEGER FROM range(0, 10240);

-- signed columns prune row groups correctly
db D EXPLAIN SELECT count(*) FROM (SELECT (x + 100) AS y FROM ti) WHERE y > 100000;
╭─ Ungrouped Aggregate ────╮
│ Aggregates: count_star() │
│ ~1 row                   │
╰─────────────┬────────────╯
╭─ Empty Result ───────────╮
╰──────────────────────────╯

db D CREATE TABLE tu(x UINTEGER NOT NULL);
db D INSERT INTO tu SELECT range::UINTEGER FROM range(0, 10240);

-- but unsigned columns don't prune at all
db D EXPLAIN SELECT count(*) FROM (SELECT (x + 100::UINTEGER) AS y FROM tu) WHERE y > 100000::UINTEGER;
╭─ Ungrouped Aggregate ───────╮
│ Aggregates: count_star()    │
│ ~1 row                      │
╰──────────────┬──────────────╯
╭─ Projection ─┴──────────────╮
│ Projections: 42             │
│ ~2,048 rows                 │
╰──────────────┬──────────────╯
╭─ Seq Scan ───┴──────────────╮
│ Table: db.main.tu           │
│ Type: Sequential Scan       │
│ Filters: (x + 100) > 100000 │
│ ~2,048 rows                 │
╰─────────────────────────────╯
```