### PR TITLE
Fix distinct comparisons in index value extraction

### DIFF
--- a/src/function/table/table_scan.cpp
+++ b/src/function/table/table_scan.cpp
@@ -658,6 +658,12 @@ static bool ValueQualifies(const Value &value, const vector<ComparisonCondition>
 		case ExpressionType::COMPARE_LESSTHANOREQUALTO:
 			passes = ValueOperations::LessThanEquals(value, comp.constant);
 			break;
+		case ExpressionType::COMPARE_DISTINCT_FROM:
+			passes = ValueOperations::DistinctFrom(value, comp.constant);
+			break;
+		case ExpressionType::COMPARE_NOT_DISTINCT_FROM:
+			passes = ValueOperations::NotDistinctFrom(value, comp.constant);
+			break;
 		default:
 			return true;
 		}

--- a/test/sql/index/art/issues/test_art_issue_25155.test
+++ b/test/sql/index/art/issues/test_art_issue_25155.test
@@ -1,0 +1,35 @@
+# name: test/sql/index/art/issues/test_art_issue_25155.test
+# description: Issue #25155 - IN with distinct comparisons returns incorrect index scan results
+# group: [issues]
+
+statement ok
+SET index_scan_percentage = 1.0;
+
+statement ok
+CREATE TABLE t(a INTEGER, p INTEGER);
+
+statement ok
+INSERT INTO t VALUES (1, 10), (3, 30);
+
+statement ok
+CREATE INDEX t_a ON t(a);
+
+query II
+EXPLAIN ANALYZE SELECT p FROM t WHERE a IN (1, 3) AND a IS NOT DISTINCT FROM 1;
+----
+analyzed_plan	<REGEX>:.*Type: Index Scan.*
+
+query I
+SELECT p FROM t WHERE a IN (1, 3) AND a IS NOT DISTINCT FROM 1 ORDER BY p;
+----
+10
+
+query II
+EXPLAIN ANALYZE SELECT p FROM t WHERE a IN (1, 3) AND a IS DISTINCT FROM 1;
+----
+analyzed_plan	<REGEX>:.*Type: Index Scan.*
+
+query I
+SELECT p FROM t WHERE a IN (1, 3) AND a IS DISTINCT FROM 1 ORDER BY p;
+----
+30


### PR DESCRIPTION
Closes #25155 

This PR fixes incorrect ART index scan results when an `IN` predicate is combined with `IS DISTINCT FROM` or `IS NOT DISTINCT FROM` on the same column.

During exact-value extraction for an index scan, `ValueQualifies` did not handle `COMPARE_DISTINCT_FROM` and `COMPARE_NOT_DISTINCT_FROM`. These comparisons therefore reached the default case and incorrectly retained all candidate values extracted from the `IN` predicate.