### PR TITLE
Propagate stats for TIME_NS type from parquet

### DIFF
--- a/extension/parquet/parquet_statistics.cpp
+++ b/extension/parquet/parquet_statistics.cpp
@@ -493,6 +493,7 @@ ParquetStatisticsUtils::TransformParquetStatistics(const LogicalType &type, cons
 	case LogicalTypeId::BIGINT:
 	case LogicalTypeId::DATE:
 	case LogicalTypeId::TIME:
+	case LogicalTypeId::TIME_NS:
 	case LogicalTypeId::TIME_TZ:
 	case LogicalTypeId::TIMESTAMP:
 	case LogicalTypeId::TIMESTAMP_TZ:

--- a/test/parquet/timens_parquet.test
+++ b/test/parquet/timens_parquet.test
@@ -82,3 +82,29 @@ FROM read_parquet(['{TEST_DIR}/time_micro.parquet', '{TEST_DIR}/time_nano.parque
 ----
 TIME_NS	12:34:56.123456
 TIME_NS	12:34:56.123456789
+
+# Row-group pruning via TIME_NS min/max statistics.
+statement ok
+COPY (SELECT (TIME '00:00:00' + INTERVAL (i) SECOND)::TIME_NS AS t FROM range(6144) tbl(i))
+TO '{TEST_DIR}/time_ns_pruning.parquet' (FORMAT PARQUET, ROW_GROUP_SIZE 2048);
+
+# Row group max values are 00:34:07, 01:08:15, 01:42:23 -- only the last can satisfy the predicate.
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM '{TEST_DIR}/time_ns_pruning.parquet' WHERE t >= TIME_NS '01:30:00';
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
+
+query I
+SELECT count(*) FROM '{TEST_DIR}/time_ns_pruning.parquet' WHERE t >= TIME_NS '01:30:00';
+----
+744
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM '{TEST_DIR}/time_ns_pruning.parquet' WHERE t > TIME_NS '23:59:59.999999999';
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 0 / 3.*
+
+query I
+SELECT count(*) FROM '{TEST_DIR}/time_ns_pruning.parquet' WHERE t > TIME_NS '23:59:59.999999999';
+----
+0

--- a/test/parquet/timens_parquet.test
+++ b/test/parquet/timens_parquet.test
@@ -102,7 +102,7 @@ SELECT count(*) FROM '{TEST_DIR}/time_ns_pruning.parquet' WHERE t >= TIME_NS '01
 query II
 EXPLAIN ANALYZE SELECT count(*) FROM '{TEST_DIR}/time_ns_pruning.parquet' WHERE t > TIME_NS '23:59:59.999999999';
 ----
-analyzed_plan	<REGEX>:.*Row Groups Scanned: 0 / 3.*
+analyzed_plan	<REGEX>:.*Empty Result.*
 
 query I
 SELECT count(*) FROM '{TEST_DIR}/time_ns_pruning.parquet' WHERE t > TIME_NS '23:59:59.999999999';


### PR DESCRIPTION
Hi team, I found when transforming parquet stats to DuckDB stats, we seem to miss `TIME_NS` type, which leads to missing row group pruning, for example,
```sql
memory D COPY (SELECT (TIME '00:00:00' + INTERVAL (i) SECOND)::TIME_NS AS t FROM range(6144) tbl(i))
         TO '/tmp/time_ns_pruning.parquet' (FORMAT PARQUET, ROW_GROUP_SIZE 2048);

-- should prune all row groups, but access all of them
memory D EXPLAIN ANALYZE SELECT count(*) FROM '/tmp/time_ns_pruning.parquet' WHERE t >= TIME_NS '23:59:59.999999999';
╭─ Summary ───────────╮
│ Total Time: 0.0006s │
│ Data Read:  54.7 kB │
╰─────────────────────╯
╭─ Ungrouped Aggregate ──────────────╮
│ Aggregates: count_star()           │
│ 1 row                          0µs │
╰──────────────────┬─────────────────╯
╭─ Table Scan ─────┴─────────────────╮
│ Function: PARQUET_SCAN             │
│ Filters:                           │
│ t >= '23:59:59.999999999'::TIME_NS │
│ Total Files Read: 1                │
│ Filename(s):                       │
│ /tmp/time_ns_pruning.parquet       │
│ Row Groups Scanned: 3 / 3          │
│ 0 rows                         0µs │
╰────────────────────────────────────╯
```