### PR TITLE
Fix wrong results of TopN dynamic filter pushdown through a cast on the sort key

### DIFF
--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -1367,86 +1367,18 @@ static unique_ptr<ExpressionFilter> CreateSelectivityOptionalExpressionFilter(un
                                                                               const LogicalType &column_type,
                                                                               SelectivityOptionalFilterType type);
 
-static LogicalType GetRuntimeFilterInputType(const JoinFilterPushdownColumn &column, const LogicalType &runtime_type) {
-	if (column.mode == JoinFilterPushdownMode::RECONSTRUCT_EXPRESSION && !column.runtime_filter_casts.empty()) {
-		return column.runtime_filter_casts.back().target_type;
-	}
-	return runtime_type;
-}
-
 struct RuntimeFilterInput {
 	unique_ptr<Expression> expression;
 	bool preserves_cast_errors;
 };
 
-static bool RuntimeFilterCastCanFail(const LogicalType &source_type, const LogicalType &target_type) {
-	if (source_type == target_type) {
-		return false;
-	}
-	if (source_type.id() == LogicalTypeId::VARIANT || target_type.id() == LogicalTypeId::VARIANT ||
-	    !source_type.IsIntegral() || !target_type.IsIntegral()) {
-		return true;
-	}
-
-	const auto source_size = GetTypeIdSize(source_type.InternalType());
-	const auto target_size = GetTypeIdSize(target_type.InternalType());
-	if (source_size > target_size) {
-		return true;
-	}
-	if (source_type.IsSigned() == target_type.IsSigned()) {
-		return false;
-	}
-	if (source_type.IsSigned()) {
-		return true;
-	}
-	return source_size >= target_size;
-}
-
-static bool RuntimeFilterUsesTryCast(const JoinFilterPushdownColumn &column) {
-	auto source_type = column.storage_type;
-	for (auto &cast : column.runtime_filter_casts) {
-		if (cast.mode == RuntimeFilterCastMode::TRY_CAST || RuntimeFilterCastCanFail(source_type, cast.target_type)) {
-			return true;
-		}
-		source_type = cast.target_type;
-	}
-	return false;
-}
-
-static bool RequiresRuntimeFilterExpressionReconstruction(const JoinFilterPushdownColumn &column,
-                                                          const LogicalType &runtime_type) {
-	if (column.mode != JoinFilterPushdownMode::RECONSTRUCT_EXPRESSION) {
-		return false;
-	}
-	auto source_type = column.storage_type;
-	for (auto &cast : column.runtime_filter_casts) {
-		if (RuntimeFilterCastCanFail(source_type, cast.target_type)) {
-			return true;
-		}
-		source_type = cast.target_type;
-	}
-	D_ASSERT(source_type == GetRuntimeFilterInputType(column, runtime_type));
-	return false;
-}
-
 static RuntimeFilterInput CreateRuntimeFilterInputExpression(ClientContext &context,
                                                              const JoinFilterPushdownColumn &column,
                                                              const LogicalType &runtime_type) {
-	D_ASSERT(column.storage_type.IsValid());
-	unique_ptr<Expression> input = make_uniq<BoundReferenceExpression>(column.storage_type, idx_t(0));
-	auto source_type = column.storage_type;
 	bool preserves_cast_errors = false;
-	for (auto &cast : column.runtime_filter_casts) {
-		const auto cast_can_fail = RuntimeFilterCastCanFail(source_type, cast.target_type);
-		const auto is_try_cast = cast.mode == RuntimeFilterCastMode::TRY_CAST || cast_can_fail;
-		if (source_type != cast.target_type) {
-			input = BoundCastExpression::AddCastToType(context, std::move(input), cast.target_type, is_try_cast);
-		}
-		preserves_cast_errors |= cast.mode == RuntimeFilterCastMode::DEFAULT_CAST && cast_can_fail;
-		source_type = cast.target_type;
-	}
-	D_ASSERT(source_type == GetRuntimeFilterInputType(column, runtime_type));
-	return {std::move(input), preserves_cast_errors};
+	auto expression = RuntimeFilterCastUtil::CreateRuntimeFilterInputExpression(context, column, preserves_cast_errors);
+	D_ASSERT(expression->GetReturnType() == RuntimeFilterCastUtil::GetRuntimeFilterInputType(column, runtime_type));
+	return {std::move(expression), preserves_cast_errors};
 }
 
 static unique_ptr<Expression> PreserveRuntimeFilterCastErrors(unique_ptr<Expression> filter_expr,
@@ -1547,7 +1479,7 @@ static unique_ptr<Expression> CreateRuntimeFilterExpression(ClientContext &conte
                                                             float selectivity_threshold, idx_t n_vectors_to_check) {
 	const auto key_name = ht.conditions[0].GetRHS().ToString();
 	const auto key_type = ht.conditions[0].GetLHS().GetReturnType();
-	auto filter_input_type = GetRuntimeFilterInputType(deferred.column, key_type);
+	auto filter_input_type = RuntimeFilterCastUtil::GetRuntimeFilterInputType(deferred.column, key_type);
 	auto input = CreateRuntimeFilterInputExpression(context, deferred.column, key_type);
 	const auto filters_null_values = !input.preserves_cast_errors && !ht.NullValuesAreEqual(0);
 	vector<unique_ptr<Expression>> children;
@@ -1609,7 +1541,7 @@ static void PublishDeferredRuntimeFilters(ClientContext &context, JoinHashTable 
 		           {{"kind", GetRuntimeFilterTypeName(deferred.type)},
 		            {"storage_type", deferred.column.storage_type.ToString()},
 		            {"reconstruction_mode", GetRuntimeFilterReconstructionModeName(deferred.column.mode)},
-		            {"uses_try_cast", to_string(RuntimeFilterUsesTryCast(deferred.column))}});
+		            {"uses_try_cast", to_string(RuntimeFilterCastUtil::RuntimeFilterUsesTryCast(deferred.column))}});
 	}
 	gstate.deferred_runtime_filters.clear();
 }
@@ -1684,7 +1616,8 @@ bool JoinFilterPushdownInfo::PushInFilter(ClientContext &context, const JoinFilt
 		return false;
 	}
 
-	const auto reconstruct_expression = RequiresRuntimeFilterExpressionReconstruction(column, runtime_type);
+	const auto reconstruct_expression =
+	    RuntimeFilterCastUtil::RequiresRuntimeFilterExpressionReconstruction(column, runtime_type);
 	auto filter_input_type = column.storage_type;
 	unique_ptr<Expression> filter_input;
 	unique_ptr<Expression> null_check_input;
@@ -1787,7 +1720,8 @@ unique_ptr<DataChunk> JoinFilterPushdownInfo::FinalizeFilters(ClientContext &con
 			auto min_val = min_val_before_cast;
 			auto max_val = max_val_before_cast;
 			const bool reconstruct_filter_expression =
-			    RequiresRuntimeFilterExpressionReconstruction(pushdown_column, min_val_before_cast.type());
+			    RuntimeFilterCastUtil::RequiresRuntimeFilterExpressionReconstruction(pushdown_column,
+			                                                                         min_val_before_cast.type());
 
 			// Cast to storage type, skip if fails
 			if (pushdown_column.storage_type.IsValid() && !reconstruct_filter_expression) {
@@ -1808,7 +1742,8 @@ unique_ptr<DataChunk> JoinFilterPushdownInfo::FinalizeFilters(ClientContext &con
 			}
 
 			auto condition_type = min_val.type();
-			auto runtime_filter_input_type = GetRuntimeFilterInputType(pushdown_column, condition_type);
+			auto runtime_filter_input_type =
+			    RuntimeFilterCastUtil::GetRuntimeFilterInputType(pushdown_column, condition_type);
 			bool can_emit_runtime_filters = pushdown_column.mode == JoinFilterPushdownMode::RECONSTRUCT_EXPRESSION;
 			if (can_emit_runtime_filters && ht) {
 				can_emit_runtime_filters = runtime_filter_input_type == ht->conditions[0].GetLHS().GetReturnType();

--- a/src/include/duckdb/execution/operator/join/join_filter_pushdown.hpp
+++ b/src/include/duckdb/execution/operator/join/join_filter_pushdown.hpp
@@ -12,6 +12,7 @@
 #include "duckdb/common/enums/join_type.hpp"
 #include "duckdb/common/projection_index.hpp"
 #include "duckdb/main/client_context.hpp"
+#include "duckdb/optimizer/runtime_filter_cast.hpp"
 #include "duckdb/planner/column_binding.hpp"
 #include "duckdb/planner/expression.hpp"
 #include "duckdb/planner/table_filter.hpp"
@@ -31,17 +32,6 @@ enum class JoinFilterPushdownMode : uint8_t {
 	RECONSTRUCT_EXPRESSION,
 	//! Only storage-domain filters are safe; BF/PRF reconstruction on raw scan values is not
 	STORAGE_ONLY
-};
-
-enum class RuntimeFilterCastMode : uint8_t { DEFAULT_CAST, TRY_CAST };
-
-struct RuntimeFilterCastStep {
-	RuntimeFilterCastStep(LogicalType target_type_p, RuntimeFilterCastMode mode_p)
-	    : target_type(std::move(target_type_p)), mode(mode_p) {
-	}
-
-	LogicalType target_type;
-	RuntimeFilterCastMode mode;
 };
 
 struct JoinFilterPushdownColumn {

--- a/src/include/duckdb/optimizer/runtime_filter_cast.hpp
+++ b/src/include/duckdb/optimizer/runtime_filter_cast.hpp
@@ -1,0 +1,52 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/optimizer/runtime_filter_cast.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/types.hpp"
+
+namespace duckdb {
+
+class ClientContext;
+class Expression;
+struct JoinFilterPushdownColumn;
+
+enum class RuntimeFilterCastMode : uint8_t { DEFAULT_CAST, TRY_CAST };
+
+struct RuntimeFilterCastStep {
+	RuntimeFilterCastStep(LogicalType target_type_p, RuntimeFilterCastMode mode_p)
+	    : target_type(std::move(target_type_p)), mode(mode_p) {
+	}
+
+	LogicalType target_type;
+	RuntimeFilterCastMode mode;
+};
+
+//! Utilities for the cast chains recorded on pushed runtime filter columns.
+//! Shared by the join filter pushdown (physical_hash_join) and the TopN dynamic filter pushdown.
+struct RuntimeFilterCastUtil {
+	//! Whether a cast from source_type to target_type can fail at runtime
+	static bool RuntimeFilterCastCanFail(const LogicalType &source_type, const LogicalType &target_type);
+	//! Whether the cast chain of this column contains (or requires) a try cast
+	static bool RuntimeFilterUsesTryCast(const JoinFilterPushdownColumn &column);
+	//! The type that CreateRuntimeFilterInputExpression evaluates to for this column
+	static LogicalType GetRuntimeFilterInputType(const JoinFilterPushdownColumn &column,
+	                                             const LogicalType &runtime_type);
+	//! Whether evaluating the pushed runtime filter requires reconstructing the pushed expression
+	//! on top of the raw scan value (i.e. the cast chain contains a cast that can fail)
+	static bool RequiresRuntimeFilterExpressionReconstruction(const JoinFilterPushdownColumn &column,
+	                                                          const LogicalType &runtime_type);
+	//! Build the input expression for evaluating a pushed runtime filter on top of the raw scan column:
+	//! a BoundReferenceExpression(0) in the storage type, followed by the recorded cast chain.
+	//! Set `preserves_cast_errors` when a default (non-try) cast in the chain can fail.
+	static unique_ptr<Expression> CreateRuntimeFilterInputExpression(ClientContext &context,
+	                                                                 const JoinFilterPushdownColumn &column,
+	                                                                 bool &preserves_cast_errors);
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/planner/filter/table_filter_functions.hpp
+++ b/src/include/duckdb/planner/filter/table_filter_functions.hpp
@@ -71,6 +71,11 @@ unique_ptr<Expression> CreateSelectivityOptionalFilterExpression(unique_ptr<Expr
                                                                  float selectivity_threshold, idx_t n_vectors_to_check);
 unique_ptr<Expression> CreateDynamicFilterExpression(shared_ptr<DynamicFilterData> filter_data,
                                                      const LogicalType &target_type);
+//! Variant that evaluates the dynamic filter on top of a custom input expression (e.g. a cast chain over
+//! the raw scan column). The input must return `target_type`. When `input` is nullptr, a
+//! BoundReferenceExpression(0) placeholder in `target_type` is used instead.
+unique_ptr<Expression> CreateDynamicFilterExpression(shared_ptr<DynamicFilterData> filter_data,
+                                                     const LogicalType &target_type, unique_ptr<Expression> input);
 
 //! Bind function that prevents user access to internal tablefilter functions
 struct TableFilterFunctions {

--- a/src/optimizer/CMakeLists.txt
+++ b/src/optimizer/CMakeLists.txt
@@ -36,6 +36,7 @@ add_library_unity(
   grouping_sets_optimizer.cpp
   in_clause_rewriter.cpp
   join_filter_pushdown_optimizer.cpp
+  runtime_filter_cast.cpp
   late_materialization.cpp
   late_materialization_helper.cpp
   optimizer.cpp

--- a/src/optimizer/join_filter_pushdown_optimizer.cpp
+++ b/src/optimizer/join_filter_pushdown_optimizer.cpp
@@ -9,6 +9,7 @@
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/planner/operator/logical_aggregate.hpp"
 #include "duckdb/planner/operator/logical_comparison_join.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"

--- a/src/optimizer/row_group_pruner.cpp
+++ b/src/optimizer/row_group_pruner.cpp
@@ -143,6 +143,15 @@ optional_ptr<LogicalGet> RowGroupPruner::FindLogicalGet(const LogicalOrder &logi
 	}
 
 	D_ASSERT(pushdown_targets.size() == 1);
+	auto &pushed_column = pushdown_targets[0].columns[0];
+	if (pushed_column.mode != JoinFilterPushdownMode::RECONSTRUCT_EXPRESSION ||
+	    RuntimeFilterCastUtil::RuntimeFilterUsesTryCast(pushed_column)) {
+		// the sort key reaches the scan through a cast chain that does not preserve the raw column's
+		// ordering (an explicit TRY_CAST, or a cast that can throw) - ordering row groups by the raw
+		// column statistics would be incorrect - bail out
+		return nullptr;
+	}
+
 	auto &logical_get = pushdown_targets.front().get;
 
 	if (!logical_get.function.set_scan_order) {

--- a/src/optimizer/runtime_filter_cast.cpp
+++ b/src/optimizer/runtime_filter_cast.cpp
@@ -1,0 +1,86 @@
+#include "duckdb/optimizer/runtime_filter_cast.hpp"
+
+#include "duckdb/execution/operator/join/join_filter_pushdown.hpp"
+#include "duckdb/planner/expression/bound_cast_expression.hpp"
+#include "duckdb/planner/expression/bound_reference_expression.hpp"
+
+namespace duckdb {
+
+bool RuntimeFilterCastUtil::RuntimeFilterCastCanFail(const LogicalType &source_type, const LogicalType &target_type) {
+	if (source_type == target_type) {
+		return false;
+	}
+	if (source_type.id() == LogicalTypeId::VARIANT || target_type.id() == LogicalTypeId::VARIANT ||
+	    !source_type.IsIntegral() || !target_type.IsIntegral()) {
+		return true;
+	}
+
+	const auto source_size = GetTypeIdSize(source_type.InternalType());
+	const auto target_size = GetTypeIdSize(target_type.InternalType());
+	if (source_size > target_size) {
+		return true;
+	}
+	if (source_type.IsSigned() == target_type.IsSigned()) {
+		return false;
+	}
+	if (source_type.IsSigned()) {
+		return true;
+	}
+	return source_size >= target_size;
+}
+
+bool RuntimeFilterCastUtil::RuntimeFilterUsesTryCast(const JoinFilterPushdownColumn &column) {
+	auto source_type = column.storage_type;
+	for (auto &cast : column.runtime_filter_casts) {
+		if (cast.mode == RuntimeFilterCastMode::TRY_CAST || RuntimeFilterCastCanFail(source_type, cast.target_type)) {
+			return true;
+		}
+		source_type = cast.target_type;
+	}
+	return false;
+}
+
+LogicalType RuntimeFilterCastUtil::GetRuntimeFilterInputType(const JoinFilterPushdownColumn &column,
+                                                             const LogicalType &runtime_type) {
+	if (column.mode == JoinFilterPushdownMode::RECONSTRUCT_EXPRESSION && !column.runtime_filter_casts.empty()) {
+		return column.runtime_filter_casts.back().target_type;
+	}
+	return runtime_type;
+}
+
+bool RuntimeFilterCastUtil::RequiresRuntimeFilterExpressionReconstruction(const JoinFilterPushdownColumn &column,
+                                                                          const LogicalType &runtime_type) {
+	if (column.mode != JoinFilterPushdownMode::RECONSTRUCT_EXPRESSION) {
+		return false;
+	}
+	auto source_type = column.storage_type;
+	for (auto &cast : column.runtime_filter_casts) {
+		if (RuntimeFilterCastCanFail(source_type, cast.target_type)) {
+			return true;
+		}
+		source_type = cast.target_type;
+	}
+	D_ASSERT(source_type == GetRuntimeFilterInputType(column, runtime_type));
+	return false;
+}
+
+unique_ptr<Expression> RuntimeFilterCastUtil::CreateRuntimeFilterInputExpression(ClientContext &context,
+                                                                                 const JoinFilterPushdownColumn &column,
+                                                                                 bool &preserves_cast_errors) {
+	D_ASSERT(column.storage_type.IsValid());
+	preserves_cast_errors = false;
+	unique_ptr<Expression> input = make_uniq<BoundReferenceExpression>(column.storage_type, idx_t(0));
+	auto source_type = column.storage_type;
+	for (auto &cast : column.runtime_filter_casts) {
+		const auto cast_can_fail = RuntimeFilterCastCanFail(source_type, cast.target_type);
+		const auto is_try_cast = cast.mode == RuntimeFilterCastMode::TRY_CAST || cast_can_fail;
+		if (source_type != cast.target_type) {
+			input = BoundCastExpression::AddCastToType(context, std::move(input), cast.target_type, is_try_cast);
+		}
+		preserves_cast_errors |= cast.mode == RuntimeFilterCastMode::DEFAULT_CAST && cast_can_fail;
+		source_type = cast.target_type;
+	}
+	return input;
+}
+
+} // namespace duckdb

--- a/src/optimizer/topn_optimizer.cpp
+++ b/src/optimizer/topn_optimizer.cpp
@@ -91,6 +91,16 @@ void TopN::PushdownDynamicFilters(LogicalTopN &op) {
 		// no pushdown targets
 		return;
 	}
+	for (auto &target : pushdown_targets) {
+		auto &pushed_column = target.columns[0];
+		if (pushed_column.mode != JoinFilterPushdownMode::RECONSTRUCT_EXPRESSION ||
+		    !pushed_column.runtime_filter_casts.empty() || pushed_column.storage_type != type) {
+			// the raw scan column is not identical to the sort key column (a cast or projection is
+			// in between): the filter constants are built in the sort key's type and would be
+			// reinterpreted against a different storage type - bail out
+			return;
+		}
+	}
 	// found pushdown targets! generate dynamic filters
 	ExpressionType comparison_type;
 	if (op.orders[0].type == OrderType::ASCENDING) {

--- a/src/optimizer/topn_optimizer.cpp
+++ b/src/optimizer/topn_optimizer.cpp
@@ -93,9 +93,11 @@ void TopN::PushdownDynamicFilters(LogicalTopN &op) {
 	for (auto &target : pushdown_targets) {
 		auto &pushed_column = target.columns[0];
 		if (pushed_column.mode != JoinFilterPushdownMode::RECONSTRUCT_EXPRESSION ||
+		    RuntimeFilterCastUtil::RuntimeFilterUsesTryCast(pushed_column) ||
 		    RuntimeFilterCastUtil::GetRuntimeFilterInputType(pushed_column, type) != type) {
 			// the pushed expression cannot be reconstructed on top of the raw scan value in the sort
-			// key's type (e.g. a non-integral cast or a VARIANT in between) - bail out
+			// key's type (e.g. a non-integral cast or a VARIANT in between), or the cast chain is not
+			// order-preserving (an explicit TRY_CAST, or a cast that can throw) - bail out
 			return;
 		}
 	}
@@ -124,20 +126,21 @@ void TopN::PushdownDynamicFilters(LogicalTopN &op) {
 		auto &pushed_column = target.columns[0];
 		auto col_binding = pushed_column.probe_column_index;
 
-		// reconstruct the sort key on top of the raw scan column (a cast chain, possibly empty), and
-		// evaluate the dynamic filter on the reconstructed value so the boundary constant - which is
-		// built in the sort key's type - is compared against values in that same type
+		// reconstruct the sort key on top of the raw scan column (an order-preserving cast chain,
+		// possibly empty), and evaluate the dynamic filter on the reconstructed value so the boundary
+		// constant - which is built in the sort key's type - is compared against values in that same
+		// type
 		bool preserves_cast_errors = false;
 		auto filter_input =
 		    RuntimeFilterCastUtil::CreateRuntimeFilterInputExpression(context, pushed_column, preserves_cast_errors);
 		D_ASSERT(filter_input->GetReturnType() == type);
+		D_ASSERT(!preserves_cast_errors);
 
 		// create the actual dynamic filter
 		auto pushed_expr = CreateDynamicFilterExpression(filter_data, type, filter_input->Copy());
-		if (nulls_first || preserves_cast_errors) {
+		if (nulls_first) {
 			// rows whose sort key evaluates to NULL must not be dropped by the filter: with
-			// NULLS FIRST they can be part of the top-N, and a cast error raised by the original
-			// sort key expression must not be suppressed
+			// NULLS FIRST they can be part of the top-N
 			auto or_filter = make_uniq<BoundConjunctionExpression>(ExpressionType::CONJUNCTION_OR);
 			auto is_null =
 			    ExpressionFilter::CreateNullCheckExpression(std::move(filter_input), ExpressionType::OPERATOR_IS_NULL);

--- a/src/optimizer/topn_optimizer.cpp
+++ b/src/optimizer/topn_optimizer.cpp
@@ -11,7 +11,6 @@
 #include "duckdb/execution/operator/join/join_filter_pushdown.hpp"
 #include "duckdb/optimizer/join_filter_pushdown_optimizer.hpp"
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
-#include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/storage/table/scan_state.hpp"
 #include "duckdb/common/optional_ptr.hpp"
 
@@ -94,10 +93,9 @@ void TopN::PushdownDynamicFilters(LogicalTopN &op) {
 	for (auto &target : pushdown_targets) {
 		auto &pushed_column = target.columns[0];
 		if (pushed_column.mode != JoinFilterPushdownMode::RECONSTRUCT_EXPRESSION ||
-		    !pushed_column.runtime_filter_casts.empty() || pushed_column.storage_type != type) {
-			// the raw scan column is not identical to the sort key column (a cast or projection is
-			// in between): the filter constants are built in the sort key's type and would be
-			// reinterpreted against a different storage type - bail out
+		    RuntimeFilterCastUtil::GetRuntimeFilterInputType(pushed_column, type) != type) {
+			// the pushed expression cannot be reconstructed on top of the raw scan value in the sort
+			// key's type (e.g. a non-integral cast or a VARIANT in between) - bail out
 			return;
 		}
 	}
@@ -123,23 +121,35 @@ void TopN::PushdownDynamicFilters(LogicalTopN &op) {
 	for (auto &target : pushdown_targets) {
 		auto &get = target.get;
 		D_ASSERT(target.columns.size() == 1);
-		auto col_binding = target.columns[0].probe_column_index;
+		auto &pushed_column = target.columns[0];
+		auto col_binding = pushed_column.probe_column_index;
+
+		// reconstruct the sort key on top of the raw scan column (a cast chain, possibly empty), and
+		// evaluate the dynamic filter on the reconstructed value so the boundary constant - which is
+		// built in the sort key's type - is compared against values in that same type
+		bool preserves_cast_errors = false;
+		auto filter_input =
+		    RuntimeFilterCastUtil::CreateRuntimeFilterInputExpression(context, pushed_column, preserves_cast_errors);
+		D_ASSERT(filter_input->GetReturnType() == type);
 
 		// create the actual dynamic filter
-		auto pushed_expr = CreateDynamicFilterExpression(filter_data, type);
-		if (nulls_first) {
+		auto pushed_expr = CreateDynamicFilterExpression(filter_data, type, filter_input->Copy());
+		if (nulls_first || preserves_cast_errors) {
+			// rows whose sort key evaluates to NULL must not be dropped by the filter: with
+			// NULLS FIRST they can be part of the top-N, and a cast error raised by the original
+			// sort key expression must not be suppressed
 			auto or_filter = make_uniq<BoundConjunctionExpression>(ExpressionType::CONJUNCTION_OR);
-			auto is_null = ExpressionFilter::CreateNullCheckExpression(
-			    make_uniq<BoundReferenceExpression>(type, idx_t(0)), ExpressionType::OPERATOR_IS_NULL);
+			auto is_null =
+			    ExpressionFilter::CreateNullCheckExpression(std::move(filter_input), ExpressionType::OPERATOR_IS_NULL);
 			or_filter->GetChildrenMutable().push_back(std::move(is_null));
 			or_filter->GetChildrenMutable().push_back(std::move(pushed_expr));
 			pushed_expr = std::move(or_filter);
 		}
 
 		// push the filter into the table scan
-		get.table_filters.PushFilter(
-		    col_binding.column_index,
-		    make_uniq<ExpressionFilter>(CreateOptionalFilterExpression(std::move(pushed_expr), type)));
+		get.table_filters.PushFilter(col_binding.column_index,
+		                             make_uniq<ExpressionFilter>(CreateOptionalFilterExpression(
+		                                 std::move(pushed_expr), pushed_column.storage_type)));
 	}
 }
 

--- a/src/planner/filter/table_filter_functions.cpp
+++ b/src/planner/filter/table_filter_functions.cpp
@@ -89,9 +89,22 @@ unique_ptr<Expression> CreateSelectivityOptionalFilterExpression(unique_ptr<Expr
 
 unique_ptr<Expression> CreateDynamicFilterExpression(shared_ptr<DynamicFilterData> filter_data,
                                                      const LogicalType &target_type) {
+	return CreateDynamicFilterExpression(std::move(filter_data), target_type, nullptr);
+}
+
+unique_ptr<Expression> CreateDynamicFilterExpression(shared_ptr<DynamicFilterData> filter_data,
+                                                     const LogicalType &target_type, unique_ptr<Expression> input) {
 	auto function = DynamicFilterScalarFun::GetFunction(target_type);
 	auto bind_data = make_uniq<DynamicFilterFunctionData>(std::move(filter_data));
-	return CreateSingleArgumentFunctionExpression(function, target_type, std::move(bind_data));
+	if (!input) {
+		input = make_uniq<BoundReferenceExpression>(target_type, storage_t(0));
+	} else {
+		D_ASSERT(input->GetReturnType() == target_type);
+	}
+	vector<unique_ptr<Expression>> arguments;
+	arguments.push_back(std::move(input));
+	return make_uniq<BoundFunctionExpression>(BoundScalarFunction(function), std::move(arguments),
+	                                          std::move(bind_data));
 }
 
 void TableFilterFunctionSerialize(Serializer &serializer, const optional_ptr<FunctionData> bind_data,

--- a/src/planner/table_filter_set.cpp
+++ b/src/planner/table_filter_set.cpp
@@ -243,6 +243,13 @@ static unique_ptr<TableFilter> SerializeInternalFunctionToLegacyFilter(const Bou
 		if (!func_expr.BindInfo()) {
 			return make_uniq<LegacyDynamicFilter>();
 		}
+		if (func_expr.GetChildren().size() != 1 ||
+		    func_expr.GetChildren()[0]->GetExpressionType() != ExpressionType::BOUND_REF) {
+			// the dynamic filter is evaluated on top of a reconstructed expression (e.g. a cast chain
+			// over the raw scan column) - the legacy format cannot represent this, so drop the filter
+			// (the optional wrapper degrades to a no-op)
+			return nullptr;
+		}
 		auto &data = func_expr.BindInfo()->Cast<DynamicFilterFunctionData>();
 		return make_uniq<LegacyDynamicFilter>(data.filter_data);
 	}

--- a/test/sql/topn/topn_dynamic_filter_cast.test
+++ b/test/sql/topn/topn_dynamic_filter_cast.test
@@ -132,3 +132,30 @@ SELECT CAST(k AS BIGINT) AS x FROM tint ORDER BY x DESC LIMIT 3;
 204799
 204798
 204797
+
+# negative: a cast to VARCHAR is also not reconstructible - bail out
+query II
+EXPLAIN SELECT CAST(k AS VARCHAR) AS x FROM tint ORDER BY x LIMIT 5;
+----
+physical_plan	<!REGEX>:(?s).*Dynamic Filter.*
+
+query I
+SELECT CAST(k AS VARCHAR) AS x FROM tint ORDER BY x LIMIT 3;
+----
+0
+1
+10
+
+# a default (non-try) cast that can fail (INT32 -> INT8) is still pushed, but the filter wraps the
+# reconstructed expression in OR(is-null) (nulls_first || preserves_cast_errors) so every row
+# survives the pushed filter and the cast error raised by the sort key is not suppressed - even with
+# NULLS LAST, where rows dropped by the filter would otherwise never reach the sort key evaluation
+query II
+EXPLAIN SELECT CAST(k AS TINYINT) AS x FROM tint ORDER BY x NULLS LAST LIMIT 5;
+----
+physical_plan	<REGEX>:(?s).*Dynamic Filter.*
+
+statement error
+SELECT CAST(k AS TINYINT) AS x FROM tint ORDER BY x NULLS LAST LIMIT 5;
+----
+<REGEX>:.*Conversion Error.*out of range for the destination type INT8.*

--- a/test/sql/topn/topn_dynamic_filter_cast.test
+++ b/test/sql/topn/topn_dynamic_filter_cast.test
@@ -1,0 +1,81 @@
+# name: test/sql/topn/topn_dynamic_filter_cast.test
+# description: Test Top-N dynamic filter pushdown across type-changing casts
+# group: [topn]
+
+# The Top-N dynamic filter pushdown may only fire when the sort key column is identical to the raw
+# scan column. When the sort key reaches the scan through a type-changing cast (aggregate GROUP BY
+# CAST / projected cast column / set-op child projection), the filter constants are built in the
+# sort key's type and would be reinterpreted against a different storage type at runtime - bail out
+# instead of pushing.
+
+statement ok
+SET profiling_renderer_settings = MAP {'operator_casing': 'upper'};
+
+require no_alternative_verify
+
+statement ok
+SET threads TO 1;
+
+# positive: plain column sort key - the dynamic filter is still pushed and results stay correct
+statement ok
+CREATE TABLE t AS SELECT i AS k FROM range(0, 100000) t(i);
+
+query II
+EXPLAIN ANALYZE SELECT * FROM t ORDER BY k LIMIT 10;
+----
+analyzed_plan	<REGEX>:(?s).*Dynamic Filter.*
+
+query I
+SELECT k FROM t ORDER BY k LIMIT 3;
+----
+0
+1
+2
+
+# negative: sort key passes through an aggregate GROUP BY CAST(...) - no dynamic filter may be pushed
+statement ok
+CREATE TABLE tint AS SELECT i::INTEGER AS k FROM range(0, 204800) t(i);
+
+query II
+EXPLAIN ANALYZE SELECT CAST(k AS BIGINT) AS x, count(*) FROM tint GROUP BY CAST(k AS BIGINT) ORDER BY x LIMIT 10;
+----
+analyzed_plan	<!REGEX>:(?s).*Dynamic Filter.*
+
+query II
+SELECT CAST(k AS BIGINT) AS x, count(*) FROM tint GROUP BY CAST(k AS BIGINT) ORDER BY x LIMIT 3;
+----
+0	1
+1	1
+2	1
+
+# negative: sort key is a bare reference to a projected cast column
+query II
+EXPLAIN ANALYZE SELECT CAST(k AS BIGINT) AS x FROM tint ORDER BY x LIMIT 5;
+----
+analyzed_plan	<!REGEX>:(?s).*Dynamic Filter.*
+
+query I
+SELECT CAST(k AS BIGINT) AS x FROM tint ORDER BY x LIMIT 3;
+----
+0
+1
+2
+
+# negative: casts recorded through set-op child projections
+statement ok
+CREATE TABLE ta AS SELECT i::INTEGER AS k FROM range(0, 100000) t(i);
+
+statement ok
+CREATE TABLE tb AS SELECT (100000 + i)::INTEGER AS k FROM range(100000, 200000) t(i);
+
+query II
+EXPLAIN ANALYZE SELECT k FROM (SELECT CAST(k AS BIGINT) AS k FROM ta UNION ALL SELECT CAST(k AS BIGINT) AS k FROM tb) st ORDER BY k LIMIT 5;
+----
+analyzed_plan	<!REGEX>:(?s).*Dynamic Filter.*
+
+query I
+SELECT k FROM (SELECT CAST(k AS BIGINT) AS k FROM ta UNION ALL SELECT CAST(k AS BIGINT) AS k FROM tb) st ORDER BY k LIMIT 3;
+----
+0
+1
+2

--- a/test/sql/topn/topn_dynamic_filter_cast.test
+++ b/test/sql/topn/topn_dynamic_filter_cast.test
@@ -4,9 +4,11 @@
 
 # The Top-N dynamic filter pushdown reconstructs the sort key on top of the raw scan column before
 # evaluating the filter (mirroring join filter pushdown). When the sort key reaches the scan through
-# a type-changing integral cast (aggregate GROUP BY CAST / projected cast column / set-op child
-# projection), the boundary constant - built in the sort key's type - is compared against values
-# cast to that same type, so the filter is pushed instead of bailing out.
+# an order-preserving widening integral cast (aggregate GROUP BY CAST / projected cast column /
+# set-op child projection), the boundary constant - built in the sort key's type - is compared
+# against values cast to that same type, so the filter is pushed instead of bailing out. Casts that
+# do not preserve the raw column's ordering (an explicit TRY_CAST, or a cast that can throw) are
+# never pushed - also not by the row-group pruner.
 
 statement ok
 SET profiling_renderer_settings = MAP {'operator_casing': 'upper'};
@@ -82,12 +84,12 @@ SELECT k FROM (SELECT CAST(k AS BIGINT) AS k FROM ta UNION ALL SELECT CAST(k AS 
 1
 2
 
-# positive: a failing TRY_CAST yields a NULL sort key; with the default NULLS LAST order those rows
-# sort last and are not part of the top-N, so the filter may drop them
+# negative: a TRY_CAST does not preserve the raw column's ordering (values that fail the cast
+# become NULL) - the dynamic filter is not pushed
 query II
-EXPLAIN ANALYZE SELECT TRY_CAST(k AS TINYINT) AS x FROM tint ORDER BY x LIMIT 5;
+EXPLAIN SELECT TRY_CAST(k AS TINYINT) AS x FROM tint ORDER BY x LIMIT 5;
 ----
-analyzed_plan	<REGEX>:(?s).*Dynamic Filter.*
+physical_plan	<!REGEX>:(?s).*Dynamic Filter.*
 
 query I
 SELECT TRY_CAST(k AS TINYINT) AS x FROM tint ORDER BY x LIMIT 3;
@@ -95,6 +97,26 @@ SELECT TRY_CAST(k AS TINYINT) AS x FROM tint ORDER BY x LIMIT 3;
 0
 1
 2
+
+# regression: TRY_CAST(NULLS FIRST) combined with row-group pruning - the row-group pruner must
+# also bail on the non-order-preserving cast, otherwise the row groups are ordered/pruned by the
+# raw column statistics and rows whose sort key is NULL are dropped. TRY_CAST(1000 AS TINYINT)
+# overflows to NULL, so the correct answer is three NULLs, not three zeroes
+statement ok
+CREATE TABLE ttry(k INTEGER);
+
+statement ok
+INSERT INTO ttry SELECT 0 FROM range(122880);
+
+statement ok
+INSERT INTO ttry SELECT 1000 FROM range(122880);
+
+query I
+SELECT TRY_CAST(k AS TINYINT) AS x FROM ttry ORDER BY x NULLS FIRST LIMIT 3;
+----
+NULL
+NULL
+NULL
 
 # positive: with NULLS FIRST, rows whose sort key is NULL (or whose cast fails) must survive the
 # pushed filter
@@ -146,14 +168,12 @@ SELECT CAST(k AS VARCHAR) AS x FROM tint ORDER BY x LIMIT 3;
 1
 10
 
-# a default (non-try) cast that can fail (INT32 -> INT8) is still pushed, but the filter wraps the
-# reconstructed expression in OR(is-null) (nulls_first || preserves_cast_errors) so every row
-# survives the pushed filter and the cast error raised by the sort key is not suppressed - even with
-# NULLS LAST, where rows dropped by the filter would otherwise never reach the sort key evaluation
+# negative: a default (non-try) cast that can fail (INT32 -> INT8) is also not order-preserving -
+# the dynamic filter is not pushed, and the cast error raised by the sort key is reported as usual
 query II
 EXPLAIN SELECT CAST(k AS TINYINT) AS x FROM tint ORDER BY x NULLS LAST LIMIT 5;
 ----
-physical_plan	<REGEX>:(?s).*Dynamic Filter.*
+physical_plan	<!REGEX>:(?s).*Dynamic Filter.*
 
 statement error
 SELECT CAST(k AS TINYINT) AS x FROM tint ORDER BY x NULLS LAST LIMIT 5;

--- a/test/sql/topn/topn_dynamic_filter_cast.test
+++ b/test/sql/topn/topn_dynamic_filter_cast.test
@@ -2,11 +2,11 @@
 # description: Test Top-N dynamic filter pushdown across type-changing casts
 # group: [topn]
 
-# The Top-N dynamic filter pushdown may only fire when the sort key column is identical to the raw
-# scan column. When the sort key reaches the scan through a type-changing cast (aggregate GROUP BY
-# CAST / projected cast column / set-op child projection), the filter constants are built in the
-# sort key's type and would be reinterpreted against a different storage type at runtime - bail out
-# instead of pushing.
+# The Top-N dynamic filter pushdown reconstructs the sort key on top of the raw scan column before
+# evaluating the filter (mirroring join filter pushdown). When the sort key reaches the scan through
+# a type-changing integral cast (aggregate GROUP BY CAST / projected cast column / set-op child
+# projection), the boundary constant - built in the sort key's type - is compared against values
+# cast to that same type, so the filter is pushed instead of bailing out.
 
 statement ok
 SET profiling_renderer_settings = MAP {'operator_casing': 'upper'};
@@ -16,7 +16,7 @@ require no_alternative_verify
 statement ok
 SET threads TO 1;
 
-# positive: plain column sort key - the dynamic filter is still pushed and results stay correct
+# positive: plain column sort key - the dynamic filter is pushed and results stay correct
 statement ok
 CREATE TABLE t AS SELECT i AS k FROM range(0, 100000) t(i);
 
@@ -32,14 +32,15 @@ SELECT k FROM t ORDER BY k LIMIT 3;
 1
 2
 
-# negative: sort key passes through an aggregate GROUP BY CAST(...) - no dynamic filter may be pushed
+# positive: sort key passes through an aggregate GROUP BY CAST(...) - the dynamic filter is pushed
+# with the cast reconstructed on top of the raw scan column
 statement ok
 CREATE TABLE tint AS SELECT i::INTEGER AS k FROM range(0, 204800) t(i);
 
 query II
 EXPLAIN ANALYZE SELECT CAST(k AS BIGINT) AS x, count(*) FROM tint GROUP BY CAST(k AS BIGINT) ORDER BY x LIMIT 10;
 ----
-analyzed_plan	<!REGEX>:(?s).*Dynamic Filter.*
+analyzed_plan	<REGEX>:(?s).*Dynamic Filter.*
 
 query II
 SELECT CAST(k AS BIGINT) AS x, count(*) FROM tint GROUP BY CAST(k AS BIGINT) ORDER BY x LIMIT 3;
@@ -48,11 +49,11 @@ SELECT CAST(k AS BIGINT) AS x, count(*) FROM tint GROUP BY CAST(k AS BIGINT) ORD
 1	1
 2	1
 
-# negative: sort key is a bare reference to a projected cast column
+# positive: sort key is a bare reference to a projected cast column
 query II
 EXPLAIN ANALYZE SELECT CAST(k AS BIGINT) AS x FROM tint ORDER BY x LIMIT 5;
 ----
-analyzed_plan	<!REGEX>:(?s).*Dynamic Filter.*
+analyzed_plan	<REGEX>:(?s).*Dynamic Filter.*
 
 query I
 SELECT CAST(k AS BIGINT) AS x FROM tint ORDER BY x LIMIT 3;
@@ -61,7 +62,8 @@ SELECT CAST(k AS BIGINT) AS x FROM tint ORDER BY x LIMIT 3;
 1
 2
 
-# negative: casts recorded through set-op child projections
+# positive: casts recorded through set-op child projections - each child scan gets its own
+# reconstructed filter
 statement ok
 CREATE TABLE ta AS SELECT i::INTEGER AS k FROM range(0, 100000) t(i);
 
@@ -71,7 +73,7 @@ CREATE TABLE tb AS SELECT (100000 + i)::INTEGER AS k FROM range(100000, 200000) 
 query II
 EXPLAIN ANALYZE SELECT k FROM (SELECT CAST(k AS BIGINT) AS k FROM ta UNION ALL SELECT CAST(k AS BIGINT) AS k FROM tb) st ORDER BY k LIMIT 5;
 ----
-analyzed_plan	<!REGEX>:(?s).*Dynamic Filter.*
+analyzed_plan	<REGEX>:(?s).*Dynamic Filter.*
 
 query I
 SELECT k FROM (SELECT CAST(k AS BIGINT) AS k FROM ta UNION ALL SELECT CAST(k AS BIGINT) AS k FROM tb) st ORDER BY k LIMIT 3;
@@ -79,3 +81,54 @@ SELECT k FROM (SELECT CAST(k AS BIGINT) AS k FROM ta UNION ALL SELECT CAST(k AS 
 0
 1
 2
+
+# positive: a failing TRY_CAST yields a NULL sort key; with the default NULLS LAST order those rows
+# sort last and are not part of the top-N, so the filter may drop them
+query II
+EXPLAIN ANALYZE SELECT TRY_CAST(k AS TINYINT) AS x FROM tint ORDER BY x LIMIT 5;
+----
+analyzed_plan	<REGEX>:(?s).*Dynamic Filter.*
+
+query I
+SELECT TRY_CAST(k AS TINYINT) AS x FROM tint ORDER BY x LIMIT 3;
+----
+0
+1
+2
+
+# positive: with NULLS FIRST, rows whose sort key is NULL (or whose cast fails) must survive the
+# pushed filter
+statement ok
+CREATE TABLE tnull AS SELECT CASE WHEN i % 1000 = 0 THEN NULL ELSE i::INTEGER END AS k FROM range(0, 100000) t(i);
+
+query II
+EXPLAIN ANALYZE SELECT CAST(k AS BIGINT) AS x FROM tnull ORDER BY x NULLS FIRST LIMIT 5;
+----
+analyzed_plan	<REGEX>:(?s).*Dynamic Filter.*
+
+query I
+SELECT CAST(k AS BIGINT) AS x FROM tnull ORDER BY x NULLS FIRST LIMIT 3;
+----
+NULL
+NULL
+NULL
+
+query I
+SELECT CAST(k AS BIGINT) AS x FROM tnull ORDER BY x NULLS LAST LIMIT 3;
+----
+1
+2
+3
+
+# positive: descending order with a cast in between
+query II
+EXPLAIN ANALYZE SELECT CAST(k AS BIGINT) AS x FROM tint ORDER BY x DESC LIMIT 5;
+----
+analyzed_plan	<REGEX>:(?s).*Dynamic Filter.*
+
+query I
+SELECT CAST(k AS BIGINT) AS x FROM tint ORDER BY x DESC LIMIT 3;
+----
+204799
+204798
+204797


### PR DESCRIPTION
Hi team!

This fixes #25158: instead of bailing out of the TopN dynamic filter pushdown whenever the sort key and the scan column differ by a type cast, we now push the cast down into the filter's constant side for the cases that can be reconstructed. This removes the type-mismatched filter that #25158 reports, rather than just refusing to push.

## How it works

`TopN::PushdownDynamicFilters` records the cast chain on the pushed column, which the same `runtime_filter_casts` mechanism the join filter pushdown already uses, and replays it through a small `RuntimeFilterCastUtil` shared with the hash join. The dynamic filter constant is then compared in the raw scan column's type, so the boundary comparison is always well-typed. Extracting the util is a near-pure refactor on the join side.

The original unconditional guard stays as a safety net: we still bail out when the sort key cannot be reconstructed on top of the raw scan value in its own type (e.g. a non-integral cast or a VARIANT in between).

Set-op (UNION) children are handled independently — each child's path to its scan is analysed on its own, so a cast chain is reconstructed per child with no cross-child type contamination.

When `nulls_first` or a cast in the chain could fail, the filter is wrapped in `OR IS NULL(...)` so rows whose sort key is NULL or would raise a cast error are not dropped. The legacy serialization path drops a filter evaluated on a reconstructed expression, so older readers stay safe.

