### PR TITLE
Allow max_memory to be set as a percentage

### DIFF
--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -68,6 +68,30 @@ static DatabaseInstance &GetDB(DatabaseInstance *db) {
 	return *db;
 }
 
+//! Parse a memory limit that may also be given as a percentage. The base is only computed when a
+//! percentage is actually given, since obtaining it can be expensive or unavailable.
+template <class BASE>
+static idx_t ParseMemoryLimitOrPercentage(const string &input, BASE &&get_base) {
+	if (input.empty() || input.back() != '%') {
+		return DBConfig::ParseMemoryLimit(input);
+	}
+	double percentage;
+	if (!TryDoubleCast(input.c_str(), input.size() - 1, percentage, false) || percentage < 0 || percentage > 100) {
+		throw InvalidInputException("Unable to parse valid percentage (input: %s)", input);
+	}
+	return LossyNumericCast<idx_t>(percentage) * get_base() / 100;
+}
+
+//! The available system memory. The config's filesystem is not set until the database starts, but
+//! options can be configured before that, so fall back to a temporary local filesystem.
+static idx_t GetAvailableSystemMemory(DBConfig &config) {
+	if (config.file_system) {
+		return DBConfig::GetSystemAvailableMemory(*config.file_system);
+	}
+	auto local_fs = FileSystem::CreateLocal();
+	return DBConfig::GetSystemAvailableMemory(*local_fs);
+}
+
 } // namespace
 
 //===----------------------------------------------------------------------===//
@@ -334,18 +358,7 @@ Value AllowedPathsSetting::GetSetting(const ClientContext &context) {
 // Block Allocator Memory
 //===----------------------------------------------------------------------===//
 void BlockAllocatorMemorySetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {
-	const auto input_string = input.ToString();
-	idx_t size;
-	if (!input_string.empty() && input_string.back() == '%') {
-		double percentage;
-		if (!TryDoubleCast(input_string.c_str(), input_string.size() - 1, percentage, false) || percentage < 0 ||
-		    percentage > 100) {
-			throw InvalidInputException("Unable to parse valid percentage (input: %s)", input_string);
-		}
-		size = LossyNumericCast<idx_t>(percentage) * config.options.maximum_memory / 100;
-	} else {
-		size = DBConfig::ParseMemoryLimit(input_string);
-	}
+	const auto size = ParseMemoryLimitOrPercentage(input.ToString(), [&]() { return config.options.maximum_memory; });
 	if (db) {
 		BlockAllocator::Get(*db).Resize(size);
 	}
@@ -1139,7 +1152,9 @@ void LogQueryPathSetting::OnSet(SettingCallbackInfo &info, Value &input) {
 // Max Memory
 //===----------------------------------------------------------------------===//
 void MaxMemorySetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {
-	config.options.maximum_memory = DBConfig::ParseMemoryLimit(input.ToString());
+	// a percentage is relative to the system memory, since resolving it against maximum_memory would be circular
+	config.options.maximum_memory =
+	    ParseMemoryLimitOrPercentage(input.ToString(), [&]() { return GetAvailableSystemMemory(config); });
 	if (db) {
 		BufferManager::GetBufferManager(*db).SetMemoryLimit(config.options.maximum_memory);
 	}

--- a/test/sql/settings/max_memory_percentage.test
+++ b/test/sql/settings/max_memory_percentage.test
@@ -1,0 +1,43 @@
+# name: test/sql/settings/max_memory_percentage.test
+# description: Test percentage values for max_memory
+# group: [settings]
+
+# a percentage is accepted and resolves to a concrete size
+statement ok
+SET max_memory='100%'
+
+statement ok
+CREATE TABLE all_memory AS SELECT current_setting('max_memory') AS v
+
+# a smaller percentage resolves to a smaller size
+statement ok
+SET max_memory='50%'
+
+query I
+SELECT (SELECT v FROM all_memory) <> current_setting('max_memory')
+----
+true
+
+# absolute values still work
+statement ok
+SET max_memory='1GiB'
+
+query I
+SELECT current_setting('max_memory')
+----
+1.0 GiB
+
+statement error
+SET max_memory='150%'
+----
+<REGEX>:.*Unable to parse valid percentage.*
+
+statement error
+SET max_memory='-3%'
+----
+<REGEX>:.*Unable to parse valid percentage.*
+
+statement error
+SET max_memory='abc%'
+----
+<REGEX>:.*Unable to parse valid percentage.*


### PR DESCRIPTION
block_allocator_memory already accepted a percentage while max_memory did not, so "SET max_memory='50%'" was a parser error ("Unknown unit for memory: '%'") even though the default is itself computed as a percentage of system memory.

Factor the percentage handling out of BlockAllocatorMemorySetting into a shared helper and use it for max_memory as well. The base differs: block_allocator_memory resolves against maximum_memory, while max_memory resolves against the available system memory, as resolving it against maximum_memory would be circular.

The base is computed lazily, since options can be configured on a DBConfig before the database starts - at which point config.file_system is not yet set - and an absolute value must not require it. When a percentage is given before startup, fall back to a temporary local filesystem.