### PR TITLE
Remove the duplicated value argument from optimizer-generated constant_or_null()

### DIFF
--- a/src/optimizer/expression_rewriter.cpp
+++ b/src/optimizer/expression_rewriter.cpp
@@ -81,7 +81,6 @@ unique_ptr<Expression> ExpressionRewriter::ApplyRules(LogicalOperator &op, const
 
 unique_ptr<Expression> ExpressionRewriter::ConstantOrNull(unique_ptr<Expression> child, Value value) {
 	vector<unique_ptr<Expression>> children;
-	children.push_back(make_uniq<BoundConstantExpression>(value));
 	children.push_back(std::move(child));
 	return ConstantOrNull(std::move(children), std::move(value));
 }

--- a/test/optimizer/constant_or_null_value_arg.test
+++ b/test/optimizer/constant_or_null_value_arg.test
@@ -1,0 +1,23 @@
+# name: test/optimizer/constant_or_null_value_arg.test
+# description: Optimizer-generated constant_or_null() must not duplicate the value argument
+# group: [optimizer]
+
+statement ok
+CREATE TABLE t(x INTEGER)
+
+# arithmetic_simplification rewrites x*0 -> constant_or_null(0, x). The one-arg
+# ConstantOrNull(child, value) overload must NOT push `value` into children before
+# delegating to the vector overload (which inserts value itself); otherwise the
+# plan carries constant_or_null(0, 0, x) instead of constant_or_null(0, x).
+
+# regression guard: the duplicated value form must NOT appear
+query II
+EXPLAIN SELECT count(*) FROM t WHERE x * 0 = 1
+----
+physical_plan	<!REGEX>:.*constant_or_null\(0, 0,.*
+
+# the non-duplicated form (value once, then child) must appear
+query II
+EXPLAIN SELECT count(*) FROM t WHERE x * 0 = 1
+----
+physical_plan	<REGEX>:.*constant_or_null\(0, x\).*


### PR DESCRIPTION
Hi team!

The `ExpressionRewriter::ConstantOrNull(child, value)` overload no longer emits `constant_or_null(value, value, child)`. Instead, it pushed `value` into `children` and then delegated to the vector overload, which inserts `value` at the front again, so every rule going through the one-arg form carried a duplicated value argument visible in `EXPLAIN` output.

Dropping the redundant `push_back` is the whole fix, the vector overload inserts the value itself. This covers ~18 one-arg call sites across the expression rewriter rules.

Query results are unaffected. Because `children[0]` is the return value and `children[1..]` are only NULL-checked, so an extra non-NULL constant copy never changes the outcome, which is why it went unnoticed for so long. It's plan hygiene only, but the duplication compounds when a later rewrite stacks on top (e.g. #24706 emits `constant_or_null(false, false, true, m)` on top of this).

```sql
CREATE TABLE t(x INTEGER);
EXPLAIN SELECT count(*) FROM t WHERE x * 0 = 1;
-- main:  Filters: constant_or_null(0, 0, x) = 1
-- patch: Filters: constant_or_null(0, x) = 1
```