### PR TITLE
Special handling for block comments after an operator

### DIFF
--- a/src/include/duckdb/parser/peg/tokenizer/tokenizer.hpp
+++ b/src/include/duckdb/parser/peg/tokenizer/tokenizer.hpp
@@ -70,6 +70,7 @@ private:
 	//! `TokenizeInput()` is the one that appends `GetTerminator()` (clean) or `END_OF_INPUT`
 	//! (dirty) based on the return value.
 	bool TokenizeInputInternal(TokenizerBehavior &behavior) const;
+	static void PushOperatorToken(TokenizerBehavior &behavior, idx_t start, idx_t end);
 
 public:
 	bool IsSpecialOperator(const string &sql, idx_t pos, idx_t &op_len) const;

--- a/src/parser/peg/tokenizer/base_tokenizer.cpp
+++ b/src/parser/peg/tokenizer/base_tokenizer.cpp
@@ -575,8 +575,10 @@ bool Tokenizer::TokenizeInputInternal(TokenizerBehavior &behavior) const {
 
 	switch (state) {
 	case TokenizeState::SINGLE_LINE_COMMENT:
-	case TokenizeState::MULTI_LINE_COMMENT:
 		behavior.PushToken(last_pos, sql.size(), TokenType::COMMENT);
+		return false;
+	case TokenizeState::MULTI_LINE_COMMENT:
+		behavior.PushToken(last_pos, sql.size(), TokenType::COMMENT, true);
 		return false;
 	case TokenizeState::OPERATOR:
 		PushOperatorToken(behavior, last_pos, sql.size());

--- a/src/parser/peg/tokenizer/base_tokenizer.cpp
+++ b/src/parser/peg/tokenizer/base_tokenizer.cpp
@@ -252,6 +252,34 @@ bool Tokenizer::TokenizeInput(TokenizerBehavior &behavior) const {
 	return !tokens.empty() && tokens.back().type == TokenType::END_OF_INPUT_AUTOCOMPLETE;
 }
 
+void Tokenizer::PushOperatorToken(TokenizerBehavior &behavior, idx_t start, idx_t end) {
+	auto &sql = behavior.sql;
+	auto &tokens = behavior.tokens;
+	// Apply PostgreSQL trimming rule: an operator cannot end in '+' unless
+	// it contains at least one of: ~ ! @ # % ^ & | ` ?
+	idx_t end_pos = end;
+	bool has_special = false;
+	for (idx_t pos = start; pos < end_pos; pos++) {
+		char operator_char = sql[pos];
+		if (operator_char == '~' || operator_char == '!' || operator_char == '@' || operator_char == '#' ||
+		    operator_char == '%' || operator_char == '^' || operator_char == '&' || operator_char == '|' ||
+		    operator_char == '`' || operator_char == '?') {
+			has_special = true;
+			break;
+		}
+	}
+	if (!has_special) {
+		while (end_pos > start && sql[end_pos - 1] == '+') {
+			end_pos--;
+		}
+	}
+	behavior.PushToken(start, end_pos, TokenType::OPERATOR);
+	// Push any trimmed '+' characters as individual tokens
+	for (idx_t pos = end_pos; pos < end; pos++) {
+		tokens.emplace_back(string(1, sql[pos]), pos, TokenType::OPERATOR);
+	}
+}
+
 bool Tokenizer::TokenizeInputInternal(TokenizerBehavior &behavior) const {
 	auto &sql = behavior.sql;
 	auto &tokens = behavior.tokens;
@@ -339,6 +367,11 @@ bool Tokenizer::TokenizeInputInternal(TokenizerBehavior &behavior) const {
 			}
 			idx_t op_len;
 			if (IsSpecialOperator(sql, i, op_len)) {
+				if (i + op_len < sql.size() && CharacterIsOperator(sql[i + op_len])) {
+					state = TokenizeState::OPERATOR;
+					last_pos = i;
+					break;
+				}
 				// special operator - push the special operator
 				tokens.emplace_back(sql.substr(i, op_len), last_pos, TokenType::OPERATOR);
 				i += op_len - 1;
@@ -421,30 +454,17 @@ bool Tokenizer::TokenizeInputInternal(TokenizerBehavior &behavior) const {
 			i--;
 			break;
 		case TokenizeState::OPERATOR:
+			if (c == '/' && i + 1 < sql.size() && sql[i + 1] == '*') {
+				PushOperatorToken(behavior, last_pos, i);
+				// Go back to STANDARD state so it tokenizes as a block comment
+				state = TokenizeState::STANDARD;
+				last_pos = i;
+				i--;
+				break;
+			}
 			// operator literal - check if this is still an operator
 			if (!CharacterIsOperator(c)) {
-				// Apply PostgreSQL trimming rule: an operator cannot end in '+' unless
-				// it contains at least one of: ~ ! @ # % ^ & | ` ?
-				idx_t end_pos = i;
-				bool has_special = false;
-				for (idx_t j = last_pos; j < end_pos; j++) {
-					char oc = sql[j];
-					if (oc == '~' || oc == '!' || oc == '@' || oc == '#' || oc == '%' || oc == '^' || oc == '&' ||
-					    oc == '|' || oc == '`' || oc == '?') {
-						has_special = true;
-						break;
-					}
-				}
-				if (!has_special) {
-					while (end_pos > last_pos && sql[end_pos - 1] == '+') {
-						end_pos--;
-					}
-				}
-				behavior.PushToken(last_pos, end_pos, TokenType::OPERATOR);
-				// Push any trimmed '+' characters as individual tokens
-				for (idx_t j = end_pos; j < i; j++) {
-					tokens.emplace_back(string(1, sql[j]), j, TokenType::OPERATOR);
-				}
+				PushOperatorToken(behavior, last_pos, i);
 				state = TokenizeState::STANDARD;
 				last_pos = i;
 				i--;
@@ -558,6 +578,9 @@ bool Tokenizer::TokenizeInputInternal(TokenizerBehavior &behavior) const {
 	case TokenizeState::MULTI_LINE_COMMENT:
 		behavior.PushToken(last_pos, sql.size(), TokenType::COMMENT);
 		return false;
+	case TokenizeState::OPERATOR:
+		PushOperatorToken(behavior, last_pos, sql.size());
+		return true;
 	case TokenizeState::DOLLAR_QUOTED_STRING:
 		behavior.PushToken(last_pos, sql.size(), TokenType::STRING_LITERAL, true);
 		return false;

--- a/src/parser/peg/tokenizer/parser_tokenizer.cpp
+++ b/src/parser/peg/tokenizer/parser_tokenizer.cpp
@@ -12,6 +12,9 @@ ParserTokenizerBehavior::ParserTokenizerBehavior(const string &sql, vector<Match
 }
 
 void ParserTokenizerBehavior::PushToken(idx_t start, idx_t end, TokenType type, bool unterminated) {
+	if (type == TokenType::COMMENT && unterminated) {
+		throw ParserException::SyntaxError(sql, "unterminated /* comment", optional_idx(start));
+	}
 	if (IsEmptyQuotedIdentifier(sql, start, end, type)) {
 		throw ParserException::SyntaxError(sql, "zero-length delimited identifier", optional_idx(start));
 	}

--- a/src/parser/peg/tokenizer/parser_tokenizer.cpp
+++ b/src/parser/peg/tokenizer/parser_tokenizer.cpp
@@ -13,7 +13,9 @@ ParserTokenizerBehavior::ParserTokenizerBehavior(const string &sql, vector<Match
 
 void ParserTokenizerBehavior::PushToken(idx_t start, idx_t end, TokenType type, bool unterminated) {
 	if (type == TokenType::COMMENT && unterminated) {
-		throw ParserException::SyntaxError(sql, "unterminated /* comment", optional_idx(start));
+		auto comment = sql.substr(start, end - start);
+		throw ParserException::SyntaxError(sql, "unterminated /* comment at or near \"" + comment + "\"",
+		                                   optional_idx(start));
 	}
 	if (IsEmptyQuotedIdentifier(sql, start, end, type)) {
 		throw ParserException::SyntaxError(sql, "zero-length delimited identifier", optional_idx(start));

--- a/test/sql/peg_parser/parser/comments.test
+++ b/test/sql/peg_parser/parser/comments.test
@@ -15,6 +15,16 @@ SELECT 1 -- /* not a block */ rest
 ----
 3
 
+query III
+SELECT 1+/**/2, 1*/**/2, 1+/* comment */2;
+----
+3	2	3
+
+query I
+SELECT 8//**/2;
+----
+4
+
 statement ok
 CALL check_peg_parser($TEST_PEG_PARSER$SELECT 1 /* outer /* inner */ rest */ + 2;$TEST_PEG_PARSER$);
 

--- a/test/sql/peg_parser/unterminated_literals.test
+++ b/test/sql/peg_parser/unterminated_literals.test
@@ -23,6 +23,6 @@ SELECT "my_col
 Parser Error: unterminated quoted identifier
 
 statement error
-SELECT 1 /*
+SELECT 1 /*;
 ----
-Parser Error: unterminated /* comment
+Parser Error: unterminated /* comment at or near "/*;"

--- a/test/sql/peg_parser/unterminated_literals.test
+++ b/test/sql/peg_parser/unterminated_literals.test
@@ -1,5 +1,5 @@
 # name: test/sql/peg_parser/unterminated_literals.test
-# description: Test that unterminated string literals and quoted identifiers are rejected
+# description: Test that unterminated string literals, quoted identifiers, and block comments are rejected
 # group: [peg_parser]
 
 statement error
@@ -21,3 +21,8 @@ statement error
 SELECT "my_col
 ----
 Parser Error: unterminated quoted identifier
+
+statement error
+SELECT 1 /*
+----
+Parser Error: unterminated /* comment

--- a/tools/shell/tests/test_command_line_arguments.py
+++ b/tools/shell/tests/test_command_line_arguments.py
@@ -53,11 +53,11 @@ def test_command(shell):
     result.check_stdout("42")
 
 def test_command_unterminated_block_comment(shell):
-    test = ShellTest(shell).add_argument("-c", "SELECT 1/*")
+    test = ShellTest(shell).add_argument("-c", "SELECT 1/*;")
     result = test.run()
     assert result.status_code == 1
     assert result.stdout == ""
-    result.check_stderr("Parser Error: unterminated /* comment")
+    result.check_stderr('Parser Error: unterminated /* comment at or near "/*;"')
 
 def test_version(shell):
     test = (

--- a/tools/shell/tests/test_command_line_arguments.py
+++ b/tools/shell/tests/test_command_line_arguments.py
@@ -52,6 +52,13 @@ def test_command(shell):
     result = test.run()
     result.check_stdout("42")
 
+def test_command_unterminated_block_comment(shell):
+    test = ShellTest(shell).add_argument("-c", "SELECT 1/*")
+    result = test.run()
+    assert result.status_code == 1
+    assert result.stdout == ""
+    result.check_stderr("Parser Error: unterminated /* comment")
+
 def test_version(shell):
     test = (
         ShellTest(shell)


### PR DESCRIPTION
Part of: https://github.com/duckdblabs/duckdb-internal/issues/9093

Having a block comment `/* */` right after an operator caused incorrect tokenization.

```sql
memory D SELECT 1+/**/2;
┌─────────┐
│ (1 + 2) │
│  int32  │
├─────────┤
│       3 │
└─────────┘
memory D SELECT 1*/**/2;
┌─────────┐
│ (1 * 2) │
│  int32  │
├─────────┤
│       2 │
└─────────┘
memory D SELECT 1+/* comment */2;
┌─────────┐
│ (1 + 2) │
│  int32  │
├─────────┤
│       3 │
└─────────┘
```

This was a regression between the old parser and the new parser, so now we have the same behaviour as PostgreSQL here again :) 
