### PR TITLE
[Dev] Use `PhysicalResultCollector::IsStreaming` rather than just the hint if streaming is allowed

### DIFF
--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -445,11 +445,12 @@ unique_ptr<QueryResult> ClientContext::FetchResultInternal(ClientContextLock &lo
 	auto &prepared = *active_query->prepared;
 	bool create_stream_result =
 	    prepared.properties.output_type == QueryResultOutputType::ALLOW_STREAMING && pending.allow_stream_result;
+	const bool keep_result_open = create_stream_result || executor.HasStreamingResultCollector();
 	unique_ptr<QueryResult> result;
 	D_ASSERT(executor.HasResultCollector());
 	// we have a result collector - fetch the result directly from the result collector
 	result = executor.GetResult();
-	if (!create_stream_result) {
+	if (!keep_result_open) {
 		CleanupInternal(lock, result.get(), false);
 	} else {
 		active_query->SetOpenResult(*result);


### PR DESCRIPTION
This PR is cherry picked from #25145 

Check the type of the result collector, not just whether "allow stream result" is set, to also support custom result collectors.