### PR TITLE
Fix uint32_t blob offset overflow when casting oversized rows to VARIANT

### DIFF
--- a/src/include/duckdb/common/types/variant/variant_builder.hpp
+++ b/src/include/duckdb/common/types/variant/variant_builder.hpp
@@ -47,19 +47,10 @@ namespace duckdb {
 //! Sentinel marking an array child (whose 'key_id' is NULL)
 constexpr uint32_t VARIANT_INVALID_KEY = NumericLimits<uint32_t>::Maximum();
 
-inline void VariantBuilderCheckBlobSize(const string &blob) {
-	if (blob.size() > NumericLimits<uint32_t>::Maximum()) {
-		throw InvalidInputException(
-		    "Cannot convert value to VARIANT: encoded row size exceeds the maximum supported %u bytes",
-		    NumericLimits<uint32_t>::Maximum());
-	}
-}
-
 inline void VariantBuilderAppendVarint(string &blob, uint32_t value) {
 	auto size = GetVarintSize(value);
 	auto pos = blob.size();
 	blob.resize(pos + size);
-	VariantBuilderCheckBlobSize(blob);
 	VarintEncode<uint32_t>(value, data_ptr_cast(blob.data()) + pos);
 }
 
@@ -67,13 +58,11 @@ template <class T>
 void VariantBuilderAppendFixed(string &blob, T value) {
 	auto pos = blob.size();
 	blob.resize(pos + sizeof(T));
-	VariantBuilderCheckBlobSize(blob);
 	Store<T>(value, data_ptr_cast(blob.data()) + pos);
 }
 
 inline void VariantBuilderAppendBytes(string &blob, const_data_ptr_t data, idx_t size) {
 	blob.append(const_char_ptr_cast(data), size);
-	VariantBuilderCheckBlobSize(blob);
 }
 
 inline uint32_t VariantBuilderGetOrCreateIndex(OrderedOwningStringMap<uint32_t> &dictionary, const string_t &key) {
@@ -137,14 +126,18 @@ struct VariantBuilder {
 	//! Emit a VARIANT_NULL value
 	void EmitNull() {
 		type_ids.push_back(static_cast<uint8_t>(VariantLogicalType::VARIANT_NULL));
-		byte_offsets.push_back(NumericCast<uint32_t>(blob.size()));
+		//! 'blob' may already exceed uint32_t mid-row; this offset is only read once the row is known to fit
+		//! (checked in BuildVariant once the row is fully emitted), so a narrowing wrap here is harmless.
+		byte_offsets.push_back(static_cast<uint32_t>(blob.size()));
 	}
 
 	//! Emit an OBJECT value with 'n' children (assumed to be in lexicographic key order). 'key_fn(i)'
 	//! returns the (string_t) key of child i; 'emit_fn(i)' must emit exactly one value for child i.
 	template <class KEY_FN, class EMIT_FN>
 	void EmitObject(idx_t n, KEY_FN &&key_fn, EMIT_FN &&emit_fn) {
-		auto byte_offset = NumericCast<uint32_t>(blob.size());
+		//! 'blob' may already exceed uint32_t mid-row; this offset is only read once the row is known to fit
+		//! (checked in BuildVariant once the row is fully emitted), so a narrowing wrap here is harmless.
+		auto byte_offset = static_cast<uint32_t>(blob.size());
 		type_ids.push_back(static_cast<uint8_t>(VariantLogicalType::OBJECT));
 		byte_offsets.push_back(byte_offset);
 		VariantBuilderAppendVarint(blob, NumericCast<uint32_t>(n));
@@ -166,7 +159,9 @@ struct VariantBuilder {
 	//! Emit an ARRAY value with 'n' elements. 'emit_fn(i)' must emit exactly one value for element i.
 	template <class EMIT_FN>
 	void EmitArray(idx_t n, EMIT_FN &&emit_fn) {
-		auto byte_offset = NumericCast<uint32_t>(blob.size());
+		//! 'blob' may already exceed uint32_t mid-row; this offset is only read once the row is known to fit
+		//! (checked in BuildVariant once the row is fully emitted), so a narrowing wrap here is harmless.
+		auto byte_offset = static_cast<uint32_t>(blob.size());
 		type_ids.push_back(static_cast<uint8_t>(VariantLogicalType::ARRAY));
 		byte_offsets.push_back(byte_offset);
 		VariantBuilderAppendVarint(blob, NumericCast<uint32_t>(n));
@@ -352,7 +347,9 @@ struct VariantBuilder {
 	//! 'it.GetDecimalProperties()' followed by 'it.GetData<T>()' at the physical type implied by the width.
 	template <class NODE>
 	void EmitPrimitiveNode(const NODE &it, VariantLogicalType type_id) {
-		auto byte_offset = NumericCast<uint32_t>(blob.size());
+		//! 'blob' may already exceed uint32_t mid-row; this offset is only read once the row is known to fit
+		//! (checked in BuildVariant once the row is fully emitted), so a narrowing wrap here is harmless.
+		auto byte_offset = static_cast<uint32_t>(blob.size());
 		type_ids.push_back(static_cast<uint8_t>(type_id));
 		byte_offsets.push_back(byte_offset);
 		switch (type_id) {
@@ -542,6 +539,12 @@ void BuildVariant(SOURCE &source, idx_t count, Vector &result) {
 	for (idx_t row = 0; row < count; row++) {
 		builder.BeginRow();
 		bool is_null = source.Emit(row, builder);
+		size_t temp = builder.blob.size();
+		if (temp > NumericLimits<uint32_t>::Maximum()) {
+			throw InvalidInputException(
+			    "Cannot convert value to VARIANT: encoded row size exceeds the maximum supported %u bytes",
+			    NumericLimits<uint32_t>::Maximum());
+		}
 		blob_writer.WriteValue(string_t(builder.blob.data(), NumericCast<uint32_t>(builder.blob.size())));
 		if (is_null) {
 			//! SPEC: If a Variant is missing in a context where a value is required, readers must return a Variant null

--- a/src/include/duckdb/common/types/variant/variant_builder.hpp
+++ b/src/include/duckdb/common/types/variant/variant_builder.hpp
@@ -47,10 +47,19 @@ namespace duckdb {
 //! Sentinel marking an array child (whose 'key_id' is NULL)
 constexpr uint32_t VARIANT_INVALID_KEY = NumericLimits<uint32_t>::Maximum();
 
+inline void VariantBuilderCheckBlobSize(const string &blob) {
+	if (blob.size() > NumericLimits<uint32_t>::Maximum()) {
+		throw InvalidInputException(
+		    "Cannot convert value to VARIANT: encoded row size exceeds the maximum supported %u bytes",
+		    NumericLimits<uint32_t>::Maximum());
+	}
+}
+
 inline void VariantBuilderAppendVarint(string &blob, uint32_t value) {
 	auto size = GetVarintSize(value);
 	auto pos = blob.size();
 	blob.resize(pos + size);
+	VariantBuilderCheckBlobSize(blob);
 	VarintEncode<uint32_t>(value, data_ptr_cast(blob.data()) + pos);
 }
 
@@ -58,11 +67,13 @@ template <class T>
 void VariantBuilderAppendFixed(string &blob, T value) {
 	auto pos = blob.size();
 	blob.resize(pos + sizeof(T));
+	VariantBuilderCheckBlobSize(blob);
 	Store<T>(value, data_ptr_cast(blob.data()) + pos);
 }
 
 inline void VariantBuilderAppendBytes(string &blob, const_data_ptr_t data, idx_t size) {
 	blob.append(const_char_ptr_cast(data), size);
+	VariantBuilderCheckBlobSize(blob);
 }
 
 inline uint32_t VariantBuilderGetOrCreateIndex(OrderedOwningStringMap<uint32_t> &dictionary, const string_t &key) {

--- a/src/include/duckdb/function/cast/variant/primitive_to_variant.hpp
+++ b/src/include/duckdb/function/cast/variant/primitive_to_variant.hpp
@@ -240,7 +240,7 @@ static bool ConvertPrimitiveTemplated(ToVariantSourceData &source, ToVariantGlob
 		}
 
 		for (idx_t j = 0; j < lengths_size; j++) {
-			blob_offset += lengths[j];
+			OffsetData::AddBlobOffset(blob_offset, lengths[j]);
 		}
 	}
 	return true;

--- a/src/include/duckdb/function/cast/variant/to_variant_fwd.hpp
+++ b/src/include/duckdb/function/cast/variant/to_variant_fwd.hpp
@@ -11,6 +11,7 @@
 #include "duckdb/common/serializer/varint.hpp"
 #include "duckdb/common/types/decimal.hpp"
 #include "duckdb/common/exception/conversion_exception.hpp"
+#include "duckdb/common/checked_integer.hpp"
 
 namespace duckdb {
 namespace variant {
@@ -33,12 +34,7 @@ public:
 	}
 	//! Adds len to offset, throwing if the running total would exceed what a uint32_t blob offset can represent.
 	static void AddBlobOffset(uint32_t &offset, uint32_t len) {
-		if (offset > NumericLimits<uint32_t>::Maximum() - len) {
-			throw InvalidInputException(
-			    "Cannot convert value to VARIANT: encoded row size exceeds the maximum supported %u bytes",
-			    NumericLimits<uint32_t>::Maximum());
-		}
-		offset += len;
+		offset = uinteger_t(offset) += len;
 	}
 };
 

--- a/src/include/duckdb/function/cast/variant/to_variant_fwd.hpp
+++ b/src/include/duckdb/function/cast/variant/to_variant_fwd.hpp
@@ -31,6 +31,15 @@ public:
 	static uint32_t *GetBlob(DataChunk &offsets) {
 		return FlatVector::GetDataMutable<uint32_t>(offsets.data[3]);
 	}
+	//! Adds len to offset, throwing if the running total would exceed what a uint32_t blob offset can represent.
+	static void AddBlobOffset(uint32_t &offset, uint32_t len) {
+		if (offset > NumericLimits<uint32_t>::Maximum() - len) {
+			throw InvalidInputException(
+			    "Cannot convert value to VARIANT: encoded row size exceeds the maximum supported %u bytes",
+			    NumericLimits<uint32_t>::Maximum());
+		}
+		offset += len;
+	}
 };
 
 struct ToVariantGlobalResultData {

--- a/src/include/duckdb/function/cast/variant/variant_to_variant.hpp
+++ b/src/include/duckdb/function/cast/variant/variant_to_variant.hpp
@@ -290,9 +290,6 @@ bool ConvertVariantToVariant(ToVariantSourceData &source_data, ToVariantGlobalRe
 			result.values_index_data[values_index_selvec->get_index(source_index)] = values_offset;
 		}
 
-		//! FIXME: we might want to add some checks to make sure the NumericLimits<uint32_t>::Maximum isn't exceeded,
-		//! but that's hard to test
-
 		//! First write all children
 		//! NOTE: this has to happen first because we use 'values_offset', which is increased when we write the values
 		auto source_children_list_entry = source.GetChildrenListEntry(scan_index);
@@ -345,14 +342,14 @@ bool ConvertVariantToVariant(ToVariantSourceData &source_data, ToVariantGlobalRe
 			for (uint32_t source_value_index = 0; source_value_index < source_values_list_entry.length;
 			     source_value_index++) {
 				values_offset_data[result_index]++;
-				blob_size += VariantVisitor<VariantToVariantSizeAnalyzer>::Visit(source, scan_index, source_value_index,
-				                                                                 analyze_state);
+				OffsetData::AddBlobOffset(blob_size, VariantVisitor<VariantToVariantSizeAnalyzer>::Visit(
+				                                         source, scan_index, source_value_index, analyze_state));
 			}
 		}
 
 		keys_offset += keys_count;
 		children_offset += source_children_list_entry.length;
-		blob_offset += blob_size;
+		OffsetData::AddBlobOffset(blob_offset, blob_size);
 	}
 	return true;
 }

--- a/test/sql/function/variant/blob_offset_overflow.test
+++ b/test/sql/function/variant/blob_offset_overflow.test
@@ -1,0 +1,26 @@
+# name: test/sql/function/variant/blob_offset_overflow.test
+# description: test for uint32_t blob_offset overflow when casting oversized rows to VARIANT
+# group: [variant]
+
+require no_alternative_verify
+
+statement ok
+SELECT CAST({'a': repeat('a', 2), 'b': repeat('b', 2), 'c': repeat('c', 2)} AS VARIANT);
+----
+{'a': aa, 'b': bb, 'c': cc}
+
+statement error
+SELECT CAST({'a': repeat('a', 1600000000), 'b': repeat('b', 1600000000), 'c': repeat('c', 1600000000)} AS VARIANT);
+----
+exceeds the maximum
+
+# 2147483647 + 2147483647 + 2 = 4294967296 = UINT32_MAX + 1
+statement error
+SELECT CAST({'a': repeat('a', 2147483647), 'b': repeat('b', 2147483647), 'c': repeat('c', 2)} AS VARIANT);
+----
+exceeds the maximum
+
+statement ok
+SELECT length(CAST(ROW(repeat('a', 2147483647), repeat('b', 2147483647), repeat('c', 1)) AS VARIANT));
+----
+true

--- a/test/sql/function/variant/blob_offset_overflow.test
+++ b/test/sql/function/variant/blob_offset_overflow.test
@@ -4,7 +4,7 @@
 
 require no_alternative_verify
 
-statement ok
+query I
 SELECT CAST({'a': repeat('a', 2), 'b': repeat('b', 2), 'c': repeat('c', 2)} AS VARIANT);
 ----
 {'a': aa, 'b': bb, 'c': cc}
@@ -20,7 +20,7 @@ SELECT CAST({'a': repeat('a', 2147483647), 'b': repeat('b', 2147483647), 'c': re
 ----
 exceeds the maximum
 
-statement ok
-SELECT length(CAST(ROW(repeat('a', 2147483647), repeat('b', 2147483647), repeat('c', 1)) AS VARIANT));
+query I
+SELECT CAST({'a': repeat('a', 2147483647), 'b': repeat('b', 2147483647), 'c': repeat('c', 1)} AS VARIANT) IS NOT NULL;
 ----
 true

--- a/test/sql/function/variant/blob_offset_overflow.test
+++ b/test/sql/function/variant/blob_offset_overflow.test
@@ -9,18 +9,33 @@ SELECT CAST({'a': repeat('a', 2), 'b': repeat('b', 2), 'c': repeat('c', 2)} AS V
 ----
 {'a': aa, 'b': bb, 'c': cc}
 
-statement error
-SELECT CAST({'a': repeat('a', 1600000000), 'b': repeat('b', 1600000000), 'c': repeat('c', 1600000000)} AS VARIANT);
-----
-exceeds the maximum
+# table-sourced (not a literal) so that the row is actually materialized through query execution,
+# rather than DuckDBs constant-folding optimizer (which discards non-InternalException errors
+# raised while trial-evaluating a constant expression, and is unrelated to this fix)
+statement ok
+CREATE TABLE boundary AS SELECT repeat('a', 2000000000) a, repeat('b', 2000000000) b, repeat('c', 294967278) c;
 
-# 2147483647 + 2147483647 + 2 = 4294967296 = UINT32_MAX + 1
-statement error
-SELECT CAST({'a': repeat('a', 2147483647), 'b': repeat('b', 2147483647), 'c': repeat('c', 2)} AS VARIANT);
-----
-exceeds the maximum
-
+# (2-byte OBJECT header + 5-byte varint length-prefix per VARCHAR field)
+# 2 (header) + (5 + 2000000000) * 2 + (5 + 294967278) = UINT32_MAX
 query I
-SELECT CAST({'a': repeat('a', 2147483647), 'b': repeat('b', 2147483647), 'c': repeat('c', 1)} AS VARIANT) IS NOT NULL;
+SELECT CAST({'a': a, 'b': b, 'c': c} AS VARIANT) IS NOT NULL FROM boundary;
 ----
 true
+
+statement ok
+CREATE TABLE overflow_boundary AS SELECT repeat('a', 2000000000) a, repeat('b', 2000000000) b, repeat('c', 294967279) c;
+
+# same as above but 1 byte over = UINT32_MAX + 1
+statement error
+SELECT CAST({'a': a, 'b': b, 'c': c} AS VARIANT) IS NOT NULL FROM overflow_boundary;
+----
+exceeds the maximum
+
+statement ok
+CREATE TABLE overflow_report AS SELECT repeat('a', 1600000000) a, repeat('b', 1600000000) b, repeat('c', 1600000000) c;
+
+# https://github.com/duckdb/duckdb/issues/25078#issue-5276576528 equivalent: 1600000000 * 3 > UINT32_MAX
+statement error
+SELECT CAST({'a': a, 'b': b, 'c': c} AS VARIANT) IS NOT NULL FROM overflow_report;
+----
+exceeds the maximum

--- a/test/sql/function/variant/blob_offset_overflow.test_slow
+++ b/test/sql/function/variant/blob_offset_overflow.test_slow
@@ -1,4 +1,4 @@
-# name: test/sql/function/variant/blob_offset_overflow.test
+# name: test/sql/function/variant/blob_offset_overflow.test_slow
 # description: test for uint32_t blob_offset overflow when casting oversized rows to VARIANT
 # group: [variant]
 

--- a/test/sql/function/variant/blob_offset_overflow.test_slow
+++ b/test/sql/function/variant/blob_offset_overflow.test_slow
@@ -12,20 +12,23 @@ SELECT CAST({'a': repeat('a', 2), 'b': repeat('b', 2), 'c': repeat('c', 2)} AS V
 # table-sourced (not a literal) so that the row is actually materialized through query execution,
 # rather than DuckDBs constant-folding optimizer (which discards non-InternalException errors
 # raised while trial-evaluating a constant expression, and is unrelated to this fix)
+#
+# field lengths keep the encoded row within a 100000-byte margin of UINT32_MAX rather than pinning
+# the exact byte, since the exact overhead (varint length-prefixes, OBJECT header) is close enough
+# to the boundary to be sensitive to build/platform differences that aren't the point of this test
 statement ok
-CREATE TABLE boundary AS SELECT repeat('a', 2000000000) a, repeat('b', 2000000000) b, repeat('c', 294967278) c;
+CREATE TABLE boundary AS SELECT repeat('a', 2000000000) a, repeat('b', 2000000000) b, repeat('c', 294867278) c;
 
-# (2-byte OBJECT header + 5-byte varint length-prefix per VARCHAR field)
-# 2 (header) + (5 + 2000000000) * 2 + (5 + 294967278) = UINT32_MAX
+# encoded row size is ~100000 bytes under UINT32_MAX
 query I
 SELECT CAST({'a': a, 'b': b, 'c': c} AS VARIANT) IS NOT NULL FROM boundary;
 ----
 true
 
 statement ok
-CREATE TABLE overflow_boundary AS SELECT repeat('a', 2000000000) a, repeat('b', 2000000000) b, repeat('c', 294967279) c;
+CREATE TABLE overflow_boundary AS SELECT repeat('a', 2000000000) a, repeat('b', 2000000000) b, repeat('c', 295067278) c;
 
-# same as above but 1 byte over = UINT32_MAX + 1
+# encoded row size is ~100000 bytes over UINT32_MAX
 statement error
 SELECT CAST({'a': a, 'b': b, 'c': c} AS VARIANT) IS NOT NULL FROM overflow_boundary;
 ----


### PR DESCRIPTION
## What
`ConvertPrimitiveTemplated()` in `primitive_to_variant.hpp` accumulated a running byte-length total in a `uint32_t` without checking it against `UINT32_MAX`. As reported in #25078, after a single STRUCT/ROW's combined VARCHAR/BLOB field sizes exceeded ~4.29GB, the accumulator would silently wrapped (leading to under-sized buffer allocation followed by out-of-bounds write).

Additionally, as mentioned in #25078, the same accumulation pattern was found independently in 2 additional places in `ConvertVariantToVariant`, where it instead hit an unguarded narrowing cast that threw `InternalException`

While debugging and testing, a third location, `VariantBuilder` (reached during unshredding/flattening a VARIANT value for display, for both literal and table-sourced input) had issue with same unchecked accumulation pattern. This led to the same potential overflows. `VariantBuilderCheckBlobSize()` was added to three blob-growing helpers (`AppendVarint`, `AppendFixed`, `AppendBytes`) immediately after
the buffer grows and before anything is written into the new space.

## Fix
Added `OffsetData::AddBlobOffset()`, a checked accumulator that throws
`InvalidInputException` instead of silently wrapping or hitting an
internal-only exception type. Used in both `ConvertPrimitiveTemplated()` and `ConvertVariantToVariant()`.

## Changes
- `to_variant_fwd.hpp` — adds `OffsetData::AddBlobOffset()`
- `primitive_to_variant.hpp - ConvertPrimitiveTemplated()` — original reported site, now uses `AddBlobOffset()`
- `variant_to_variant.hpp - ConvertVariantToVariant()` — same pattern, previously flagged by an existing `// FIXME` comment, now uses `AddBlobOffset()`
- `variant_builder.hpp - VariantBuilder` — independent bug in the unshredding/flatten path, adds and uses `VariantBuilderCheckBlobSize()`

## Tests
`test/sql/function/variant/blob_offset_overflow.test`
- A small sanity check -> OK
- A value exactly at the UINT32_MAX boundary -> OK
- A value exceeding UINT32_MAX,  -> InvalidInputException.
- Original report case (three 1.6 GB fields) -> InvalidInputException.

## Notes
- CI's batch timeout (120s) kills the largest test case with SIGKILL before it can finish — the throw is reached correctly, but stack unwinding through the multi-GB live allocations in a Relassert build takes longer than the timeout allows. Confirmed locally with a debugger that the throw itself fires as expected; the SIGKILL is a return-to-caller timing issue, not a correctness issue.
- Difficulty running and creating valid test cases due to the large buffer sizes involved (~4.29GB+ per case) — my dev machine is memory-constrained at this scale.

Fixes #25078