### PR TITLE
Bound the async backlog budget by the memory limit

### DIFF
--- a/src/common/serializer/async_memory_governor.cpp
+++ b/src/common/serializer/async_memory_governor.cpp
@@ -3,6 +3,7 @@
 #include "duckdb/common/helper.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/parallel/task_scheduler.hpp"
+#include "duckdb/storage/buffer_manager.hpp"
 #include "duckdb/storage/temporary_memory_manager.hpp"
 
 namespace duckdb {
@@ -12,9 +13,12 @@ ManagedAsyncMemoryGovernor::ManagedAsyncMemoryGovernor(ClientContext &client_con
 	auto &scheduler = TaskScheduler::GetScheduler(client_context);
 	auto regular_threads = MaxValue<idx_t>(NumericCast<idx_t>(scheduler.NumberOfThreads()), 1);
 	auto async_threads = NumericCast<idx_t>(scheduler.NumberOfAsyncThreads());
-	max_pending_bytes = ManagedAsyncMemoryConfig::MAX_PENDING_BYTES_PER_THREAD * regular_threads;
+	auto max_memory = BufferManager::GetBufferManager(client_context).GetMaxMemory();
+	max_pending_bytes = MinValue(ManagedAsyncMemoryConfig::MAX_PENDING_BYTES_PER_THREAD * regular_threads,
+	                             max_memory / ManagedAsyncMemoryConfig::MAX_PENDING_MEMORY_LIMIT_DIVISOR);
 	min_pending_bytes =
-	    MinValue(max_pending_bytes, ManagedAsyncMemoryConfig::MIN_PENDING_BYTES_PER_THREAD * regular_threads);
+	    MinValue(max_pending_bytes, MinValue(ManagedAsyncMemoryConfig::MIN_PENDING_BYTES_PER_THREAD * regular_threads,
+	                                         max_memory / ManagedAsyncMemoryConfig::MIN_PENDING_MEMORY_LIMIT_DIVISOR));
 	// A reservation is only useful when drain tasks run asynchronously; synchronous draining bounds itself.
 	if (async_threads > 0 && max_pending_bytes > 0) {
 		memory_state = TemporaryMemoryManager::Get(client_context).Register(client_context);

--- a/src/include/duckdb/common/serializer/async_memory_governor.hpp
+++ b/src/include/duckdb/common/serializer/async_memory_governor.hpp
@@ -21,6 +21,10 @@ struct ManagedAsyncMemoryConfig {
 	static constexpr idx_t MAX_PENDING_BYTES_PER_THREAD = 64ULL * 1024ULL * 1024ULL;
 	//! Minimum async reservation requested per regular execution thread.
 	static constexpr idx_t MIN_PENDING_BYTES_PER_THREAD = 8ULL * 1024ULL * 1024ULL;
+	//! Maximum fraction of the memory limit the async backlog may claim.
+	static constexpr idx_t MAX_PENDING_MEMORY_LIMIT_DIVISOR = 8ULL;
+	//! Maximum fraction of the memory limit the minimum async reservation may claim.
+	static constexpr idx_t MIN_PENDING_MEMORY_LIMIT_DIVISOR = 16ULL;
 	//! Below this reservation, do not retain an async backlog (behave close to synchronous draining).
 	static constexpr idx_t MIN_RESERVATION_FOR_BACKLOG = 8ULL * 1024ULL * 1024ULL;
 };

--- a/src/include/duckdb/parallel/scan_read_ahead.hpp
+++ b/src/include/duckdb/parallel/scan_read_ahead.hpp
@@ -129,6 +129,7 @@ private:
 		~ProducerReservation() {
 			if (!committed) {
 				read_ahead.ReleaseSlot();
+				read_ahead.pending_io_bytes -= MINIMUM_JOB_IO_CHARGE;
 			}
 			--read_ahead.active_producers;
 		}
@@ -164,6 +165,10 @@ private:
 	void ReleaseSlot();
 
 private:
+	//! Minimum budget charge per job, beyond its scheduled I/O a job carries scan-state overhead (decode buffers)
+	static constexpr idx_t MINIMUM_JOB_IO_CHARGE = 16ULL * 1024 * 1024;
+
+private:
 	//! Maximum number of jobs scheduled ahead of decoding, unlimited in the -1 auto mode
 	const idx_t read_ahead_depth;
 	//! Async memory governor
@@ -179,7 +184,7 @@ private:
 	idx_t next_batch_index = 0;
 	//! Jobs scheduled ahead of decoding
 	atomic<idx_t> active_jobs {0};
-	//! Bytes of scheduled I/O that has not completed yet, released once the claimed job's I/O finished
+	//! Budget charge of the backlog: reserved producer slots plus scheduled jobs, released per job in WaitForJob
 	atomic<idx_t> pending_io_bytes {0};
 	atomic<bool> done {false};
 	//! Threads that reserved a slot but have not pushed their job yet

--- a/src/parallel/scan_read_ahead.cpp
+++ b/src/parallel/scan_read_ahead.cpp
@@ -212,10 +212,17 @@ void ScanReadAhead::SetDone() {
 }
 
 bool ScanReadAhead::TryReserveSlot() {
-	const bool over_budget = pending_io_bytes.load() >= backlog_budget.load();
-	const idx_t depth = over_budget ? 1 : read_ahead_depth;
-	if (active_jobs.fetch_add(1) >= depth) {
+	// take the minimum job charge up front so concurrent producers cannot all pass the budget check together
+	const auto backlog = pending_io_bytes.fetch_add(MINIMUM_JOB_IO_CHARGE);
+	// admit while the backlog is below budget, overshooting it by at most one job charge;
+	// an empty backlog always admits one job so the scan makes progress under any budget
+	if (backlog != 0 && backlog >= backlog_budget.load()) {
+		pending_io_bytes -= MINIMUM_JOB_IO_CHARGE;
+		return false;
+	}
+	if (active_jobs.fetch_add(1) >= read_ahead_depth) {
 		--active_jobs;
+		pending_io_bytes -= MINIMUM_JOB_IO_CHARGE;
 		return false;
 	}
 	++active_producers;
@@ -223,8 +230,6 @@ bool ScanReadAhead::TryReserveSlot() {
 }
 
 void ScanReadAhead::PushJob(unique_ptr<ScanReadAheadJob> job, vector<unique_ptr<AsyncTask>> io_tasks) {
-	// beyond its scheduled I/O a job carries scan-state overhead (row-group sized decode buffers)
-	static constexpr idx_t MINIMUM_JOB_IO_CHARGE = 16ULL * 1024 * 1024;
 	auto completion = make_shared_ptr<ReadAheadJobCompletion>(executor);
 	job->io_completion = completion;
 	// wrap all reads before scheduling any, a wrapped task settles the completion even when scheduling throws
@@ -235,7 +240,8 @@ void ScanReadAhead::PushJob(unique_ptr<ScanReadAheadJob> job, vector<unique_ptr<
 		read_tasks.push_back(make_uniq<ReadAheadIOTask>(*executor, std::move(task), completion));
 	}
 	job->io_bytes = MaxValue<idx_t>(job->io_bytes, MINIMUM_JOB_IO_CHARGE);
-	pending_io_bytes += job->io_bytes;
+	// the minimum charge was taken by TryReserveSlot, charge the remainder
+	pending_io_bytes += job->io_bytes - MINIMUM_JOB_IO_CHARGE;
 	// schedule the reads detached on the async pool right away
 	for (auto &task : read_tasks) {
 		executor->ScheduleTask(std::move(task));

--- a/test/sql/copy/parquet/batched_write/batch_memory_usage.test_slow
+++ b/test/sql/copy/parquet/batched_write/batch_memory_usage.test_slow
@@ -2,8 +2,6 @@
 # description: Batched Parquet write memory usage
 # group: [batched_write]
 
-mode skip "Test is failing at random depending on threads / available memory in the specific machine that run this job"
-
 require parquet
 
 set seed 0.72

--- a/test/sql/copy/parquet/batched_write/batch_memory_usage_small.test_slow
+++ b/test/sql/copy/parquet/batched_write/batch_memory_usage_small.test_slow
@@ -2,8 +2,6 @@
 # description: Batched Parquet write memory usage
 # group: [batched_write]
 
-mode skip "Test is failing at random depending on threads / available memory in the specific machine that run this job"
-
 require parquet
 
 set seed 0.72

--- a/test/sql/copy/parquet/batched_write/read_ahead_memory_limit.test_slow
+++ b/test/sql/copy/parquet/batched_write/read_ahead_memory_limit.test_slow
@@ -1,0 +1,31 @@
+# name: test/sql/copy/parquet/batched_write/read_ahead_memory_limit.test_slow
+# description: Default read-ahead must respect the memory limit of a batched parquet copy
+# group: [batched_write]
+
+require parquet
+
+set seed 0.72
+
+statement ok
+COPY (SELECT uuid()::VARCHAR AS varchar, uuid() AS uuid FROM range(5000000) t(i)) TO '{TEST_DIR}/read_ahead_uuids.parquet'
+
+# pin the thread count, the read-ahead memory floor scales with it
+statement ok
+SET threads=16
+
+statement ok
+SET memory_limit='150MB'
+
+# with read-ahead disabled this copy fits comfortably
+statement ok
+SET read_ahead_depth=0
+
+statement ok
+COPY '{TEST_DIR}/read_ahead_uuids.parquet' TO '{TEST_DIR}/read_ahead_uuids_copy.parquet'
+
+# the default read-ahead depth must fit in the same limit
+statement ok
+RESET read_ahead_depth
+
+statement ok
+COPY '{TEST_DIR}/read_ahead_uuids.parquet' TO '{TEST_DIR}/read_ahead_uuids_copy.parquet'

--- a/test/sql/copy/parquet/batched_write/read_ahead_memory_limit.test_slow
+++ b/test/sql/copy/parquet/batched_write/read_ahead_memory_limit.test_slow
@@ -14,7 +14,7 @@ statement ok
 SET threads=16
 
 statement ok
-SET memory_limit='150MB'
+SET memory_limit='200MB'
 
 # with read-ahead disabled this copy fits comfortably
 statement ok


### PR DESCRIPTION
This PR changes how the ManagedAsyncMemoryGovernor sets its memory budget. Previously, the budget came from the thread count alone, then in tight memory limits, we could go over it. We now cap it at `memory_limit/8` and the minimum reservation at `memory_limit/16` (similar to what the TemporaryMemoryManager does).

Fix: https://github.com/duckdblabs/duckdb-internal/issues/9942