### PR TITLE
Fix COMMENT ON COLUMN when a remote catalog is attached

### DIFF
--- a/src/optimizer/remote_pushdown_optimizer.cpp
+++ b/src/optimizer/remote_pushdown_optimizer.cpp
@@ -775,7 +775,9 @@ CatalogPushdownResult RemotePushdownOptimizer::RewriteStatement(AlterStatement &
 		// CREATE resolves an OnCreateConflict, so they never reach the optimizer as a parsed statement
 		return CatalogPushdownResult::Unknown();
 	}
-	auto target = ResolveDDLTarget(info.GetQualifiedName(), DDLTarget::EXISTING_ENTRY, info.GetCatalogType());
+	// COMMENT ON COLUMN targets either a table or a view, the exact type is only resolved at bind time
+	auto entry_type = info.type == AlterType::SET_COLUMN_COMMENT ? CatalogType::TABLE_ENTRY : info.GetCatalogType();
+	auto target = ResolveDDLTarget(info.GetQualifiedName(), DDLTarget::EXISTING_ENTRY, entry_type);
 	return VerifyStatementSupport(statement, std::move(target));
 }
 

--- a/test/sql/catalog/comment_on_column_remote_catalog.test
+++ b/test/sql/catalog/comment_on_column_remote_catalog.test
@@ -1,0 +1,52 @@
+# name: test/sql/catalog/comment_on_column_remote_catalog.test
+# description: COMMENT ON COLUMN while a remote catalog is attached (the remote pushdown optimizer inspects every statement)
+# group: [catalog]
+
+require quack
+
+require httpfs
+
+statement ok
+CALL quack_serve(token='test_token');
+
+statement ok
+ATTACH 'quack:localhost' AS qk (TOKEN 'test_token');
+
+# local table - the statement is not pushed down
+statement ok
+CREATE TABLE tbl(i INTEGER, j INTEGER);
+
+statement ok
+COMMENT ON COLUMN tbl.i IS 'local column comment';
+
+query I
+SELECT comment FROM duckdb_columns() WHERE table_name = 'tbl' AND column_name = 'i';
+----
+local column comment
+
+# local view - the target type is only known at bind time
+statement ok
+CREATE VIEW v AS SELECT i AS vi, j AS vj FROM tbl;
+
+statement ok
+COMMENT ON COLUMN v.vi IS 'local view column comment';
+
+query I
+SELECT comment FROM duckdb_columns() WHERE table_name = 'v' AND column_name = 'vi';
+----
+local view column comment
+
+# fully qualified local target
+statement ok
+COMMENT ON COLUMN memory.main.tbl.j IS 'qualified local column comment';
+
+query I
+SELECT comment FROM duckdb_columns() WHERE table_name = 'tbl' AND column_name = 'j';
+----
+qualified local column comment
+
+# a target that exists nowhere is a regular catalog error
+statement error
+COMMENT ON COLUMN missing_tbl.i IS 'no such table';
+----
+<REGEX>:Catalog Error:.*missing_tbl.*

--- a/test/sql/catalog/comment_on_column_remote_catalog.test
+++ b/test/sql/catalog/comment_on_column_remote_catalog.test
@@ -12,7 +12,6 @@ CALL quack_serve(token='test_token');
 statement ok
 ATTACH 'quack:localhost' AS qk (TOKEN 'test_token');
 
-# local table - the statement is not pushed down
 statement ok
 CREATE TABLE tbl(i INTEGER, j INTEGER);
 
@@ -24,7 +23,6 @@ SELECT comment FROM duckdb_columns() WHERE table_name = 'tbl' AND column_name = 
 ----
 local column comment
 
-# local view - the target type is only known at bind time
 statement ok
 CREATE VIEW v AS SELECT i AS vi, j AS vj FROM tbl;
 
@@ -36,7 +34,6 @@ SELECT comment FROM duckdb_columns() WHERE table_name = 'v' AND column_name = 'v
 ----
 local view column comment
 
-# fully qualified local target
 statement ok
 COMMENT ON COLUMN memory.main.tbl.j IS 'qualified local column comment';
 
@@ -45,7 +42,6 @@ SELECT comment FROM duckdb_columns() WHERE table_name = 'tbl' AND column_name = 
 ----
 qualified local column comment
 
-# a target that exists nowhere is a regular catalog error
 statement error
 COMMENT ON COLUMN missing_tbl.i IS 'no such table';
 ----


### PR DESCRIPTION
This pr fixes an unresolved catalog type access for `COMMENT ON COLUMN` in the remote pushdown optimizer. Came across it in DuckLake.