### PR TITLE
Fix symbol checks for linux arm64 CLI on main (different with Clang)

### DIFF
--- a/scripts/ci/test_exported_symbols_check.py
+++ b/scripts/ci/test_exported_symbols_check.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts import exported_symbols_check
+
+
+class ExportedSymbolsCheckTest(unittest.TestCase):
+    def test_get_symbols_uses_nm_filter(self):
+        result = subprocess.CompletedProcess([], 0, stdout="duckdb_api\n\nother_symbol\n", stderr="")
+        with mock.patch.object(exported_symbols_check.subprocess, "run", return_value=result) as run:
+            symbols = exported_symbols_check.get_symbols("libduckdb.so", "--defined-only")
+
+        self.assertEqual(symbols, ["duckdb_api", "other_symbol"])
+        run.assert_called_once_with(
+            [
+                "nm",
+                "--extern-only",
+                "--demangle",
+                "--format=just-symbols",
+                "--defined-only",
+                "libduckdb.so",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+    def test_get_symbols_propagates_nm_failure(self):
+        error = subprocess.CalledProcessError(1, ["nm"])
+        with mock.patch.object(exported_symbols_check.subprocess, "run", side_effect=error):
+            with self.assertRaises(subprocess.CalledProcessError):
+                exported_symbols_check.get_symbols("libduckdb.so", "--defined-only")
+
+    def test_find_culprits(self):
+        defined_symbols = [
+            "duckdb::Allowed()",
+            "std::vector<int>::size()",
+            "leaked_symbol",
+            "std::random_device::operator()()",
+        ]
+        undefined_symbols = [
+            "U",
+            "puts",
+            "std::random_device::random_device()",
+        ]
+
+        self.assertEqual(
+            exported_symbols_check.find_culprits(defined_symbols, undefined_symbols),
+            [
+                "leaked_symbol",
+                "std::random_device::operator()()",
+                "std::random_device::random_device()",
+            ],
+        )
+
+    def test_main_selects_defined_and_undefined_symbols(self):
+        with tempfile.NamedTemporaryFile() as library:
+            with mock.patch.object(
+                exported_symbols_check,
+                "get_symbols",
+                side_effect=[["duckdb_api"], ["puts"]],
+            ) as get_symbols:
+                result = exported_symbols_check.main(["exported_symbols_check.py", library.name])
+
+        self.assertEqual(result, 0)
+        self.assertEqual(
+            get_symbols.call_args_list,
+            [
+                mock.call(library.name, "--defined-only"),
+                mock.call(library.name, "--undefined-only"),
+            ],
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/exported_symbols_check.py
+++ b/scripts/exported_symbols_check.py
@@ -1,19 +1,8 @@
+import os
 import subprocess
 import sys
-import os
-import re
 
-if len(sys.argv) < 2 or not os.path.isfile(sys.argv[1]):
-    print("Usage: [libduckdb dynamic library file, release build]")
-    exit(1)
-
-res = subprocess.run('nm -g -C -P'.split(' ') + [sys.argv[1]], check=True, capture_output=True)
-if res.returncode != 0:
-    raise ValueError('Failed to run `nm`')
-
-culprits = []
-
-whitelist = [
+WHITELIST = [
     '@GLIBC',
     '@GCC',
     '@CXXABI',
@@ -48,30 +37,49 @@ whitelist = [
     'CreateAPIv1()',
 ]
 
-for value in res.stdout.decode('utf-8').split('\n'):
-    symbol = value.strip()
-    if not symbol:
-        continue
-    if re.search(r' [Uw]$', symbol):  # undefined because dynamic linker
-        continue
-    if re.search(r' [Uw] 0 0$', symbol) and "random_device" not in symbol:  # undefined because dynamic linker
-        continue
 
-    is_whitelisted = False
-    for entry in whitelist:
-        if entry in symbol and "random_device" not in symbol:
-            is_whitelisted = True
-    if is_whitelisted:
-        continue
-
-    culprits.append(symbol)
-
-
-if len(culprits) > 0:
-    print("Found leaked symbols. Either white-list above or change visibility:")
-    for symbol in culprits:
-        print(symbol)
-    sys.exit(1)
+def get_symbols(library: str, selection: str) -> list[str]:
+    result = subprocess.run(
+        [
+            'nm',
+            '--extern-only',
+            '--demangle',
+            '--format=just-symbols',
+            selection,
+            library,
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [symbol.strip() for symbol in result.stdout.splitlines() if symbol.strip()]
 
 
-sys.exit(0)
+def find_culprits(defined_symbols: list[str], undefined_symbols: list[str]) -> list[str]:
+    candidates = defined_symbols + [symbol for symbol in undefined_symbols if 'random_device' in symbol]
+    return [
+        symbol for symbol in candidates if not any(entry in symbol for entry in WHITELIST) or 'random_device' in symbol
+    ]
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2 or not os.path.isfile(argv[1]):
+        print("Usage: [libduckdb dynamic library file, release build]")
+        return 1
+
+    library = argv[1]
+    defined_symbols = get_symbols(library, '--defined-only')
+    undefined_symbols = get_symbols(library, '--undefined-only')
+    culprits = find_culprits(defined_symbols, undefined_symbols)
+
+    if culprits:
+        print("Found leaked symbols. Either white-list above or change visibility:")
+        for symbol in culprits:
+            print(symbol)
+        return 1
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
On main, CI [fails](https://github.com/duckdb/duckdb/actions/runs/33378803026/job/99446395447#step:8:21) for `Linux Release (arm64 compatibility/optimized)`:
```
Run make -j4 --output-sync=target symbol-checks
found 156 object files
python3 scripts/banned_symbols_check.py --directory build/release/src
No banned symbols found.
python3 scripts/exported_symbols_check.py build/release/src/libduckdb*.so
Found leaked symbols. Either white-list above or change visibility:
U
U
U
U
...
U
U
U
Error: Process completed with exit code 2.
```