### PR TITLE
State the snapshot visibility rule once

### DIFF
--- a/extension/tpcds/dsdgen/append_info-c.cpp
+++ b/extension/tpcds/dsdgen/append_info-c.cpp
@@ -156,7 +156,7 @@ void tpcds_append_information::FinalizeOptimisticAppend() {
 		return;
 	}
 	FlushChunk();
-	duckdb::TransactionData transaction_data(0, 0);
+	auto transaction_data = duckdb::TransactionData::Unversioned();
 	auto &row_collection = *optimistic_collection->collection;
 	row_collection.FinalizeAppend(transaction_data, append_state);
 	finalized = true;

--- a/extension/tpch/dbgen/dbgen.cpp
+++ b/extension/tpch/dbgen/dbgen.cpp
@@ -161,7 +161,7 @@ struct tpch_append_information {
 			return;
 		}
 		FlushChunk();
-		TransactionData transaction_data(0, 0);
+		auto transaction_data = TransactionData::Unversioned();
 		auto &row_collection = *optimistic_collection->collection;
 		row_collection.FinalizeAppend(transaction_data, append_state);
 		finalized = true;

--- a/src/catalog/catalog_set.cpp
+++ b/src/catalog/catalog_set.cpp
@@ -202,7 +202,7 @@ bool CatalogSet::CreateEntry(CatalogTransaction transaction, const Identifier &n
 	CheckCatalogEntryInvariants(*value, name);
 
 	// Mark this entry as being created by the current active transaction
-	value->timestamp = transaction.transaction_id;
+	value->timestamp = transaction.GetTransactionId();
 	value->set = this;
 	catalog.GetDependencyManager()->AddObject(transaction, *value, dependencies);
 
@@ -289,7 +289,7 @@ bool CatalogSet::RenameEntryInternal(CatalogTransaction transaction, CatalogEntr
 	// Add a RENAMED_ENTRY before adding a DELETED_ENTRY, this makes it so that when this is committed
 	// we know that this was not a DROP statement.
 	auto renamed_tombstone = make_uniq<InCatalogEntry>(CatalogType::RENAMED_ENTRY, old.ParentCatalog(), original_name);
-	renamed_tombstone->timestamp = transaction.transaction_id;
+	renamed_tombstone->timestamp = transaction.GetTransactionId();
 	renamed_tombstone->deleted = false;
 	renamed_tombstone->set = this;
 	if (!CreateEntryInternal(transaction, original_name, std::move(renamed_tombstone), read_lock,
@@ -303,7 +303,7 @@ bool CatalogSet::RenameEntryInternal(CatalogTransaction transaction, CatalogEntr
 	// Add the renamed entry
 	// Start this off with a RENAMED_ENTRY node, for commit/cleanup/rollback purposes
 	auto renamed_node = make_uniq<InCatalogEntry>(CatalogType::RENAMED_ENTRY, catalog, new_name);
-	renamed_node->timestamp = transaction.transaction_id;
+	renamed_node->timestamp = transaction.GetTransactionId();
 	renamed_node->deleted = false;
 	renamed_node->set = this;
 	return CreateEntryInternal(transaction, new_name, std::move(renamed_node), read_lock);
@@ -360,7 +360,7 @@ bool CatalogSet::AlterEntry(CatalogTransaction transaction, const Identifier &na
 	entry = GetEntryInternal(transaction, name);
 
 	// Mark this entry as being created by this transaction
-	value->timestamp = transaction.transaction_id;
+	value->timestamp = transaction.GetTransactionId();
 	value->set = this;
 	// Preserve the oid across the alter: an altered entry is the same logical object as before
 	value->oid = entry->oid;
@@ -431,7 +431,7 @@ bool CatalogSet::DropEntryInternal(CatalogTransaction transaction, const Identif
 	// set the timestamp to the timestamp of the current transaction
 	// and point it at the tombstone node
 	auto value = make_uniq<InCatalogEntry>(CatalogType::DELETED_ENTRY, entry->ParentCatalog(), entry->name);
-	value->timestamp = transaction.transaction_id;
+	value->timestamp = transaction.GetTransactionId();
 	value->set = this;
 	value->deleted = true;
 	auto value_ptr = value.get();
@@ -467,8 +467,8 @@ void CatalogSet::VerifyExistenceOfDependency(transaction_t commit_id, CatalogEnt
 	auto transaction_id = MAX_TRANSACTION_ID;
 	D_ASSERT(IsCommitted(commit_id));
 	// This will allow us to see all committed changes made before this COMMIT happened
-	auto snapshot_bound = commit_id + 1;
-	CatalogTransaction commit_transaction(duck_catalog.GetDatabase(), transaction_id, snapshot_bound);
+	CatalogTransaction commit_transaction(duck_catalog.GetDatabase(), transaction_id,
+	                                      VisibilityBound::Through(commit_id));
 
 	D_ASSERT(entry.type == CatalogType::DEPENDENCY_ENTRY);
 	auto &dep = entry.Cast<DependencyEntry>();
@@ -477,7 +477,7 @@ void CatalogSet::VerifyExistenceOfDependency(transaction_t commit_id, CatalogEnt
 
 //! Verify that no dependencies creations were committed since our transaction started, that reference the entry we're
 //! dropping
-void CatalogSet::CommitDrop(transaction_t commit_id, transaction_t snapshot_bound, CatalogEntry &entry) {
+void CatalogSet::CommitDrop(transaction_t commit_id, VisibilityBound visibility_bound, CatalogEntry &entry) {
 	auto &duck_catalog = GetCatalog();
 
 	entry.OnDrop();
@@ -485,10 +485,10 @@ void CatalogSet::CommitDrop(transaction_t commit_id, transaction_t snapshot_boun
 	auto transaction_id = MAX_TRANSACTION_ID;
 	D_ASSERT(IsCommitted(commit_id));
 	// This will allow us to see all committed changes made before this COMMIT happened
-	auto commit_snapshot_bound = commit_id;
-	CatalogTransaction commit_transaction(duck_catalog.GetDatabase(), transaction_id, commit_snapshot_bound);
+	CatalogTransaction commit_transaction(duck_catalog.GetDatabase(), transaction_id,
+	                                      VisibilityBound::Before(commit_id));
 
-	duck_catalog.GetDependencyManager()->VerifyCommitDrop(commit_transaction, snapshot_bound, entry);
+	duck_catalog.GetDependencyManager()->VerifyCommitDrop(commit_transaction, visibility_bound, entry);
 }
 
 DuckCatalog &CatalogSet::GetCatalog() {
@@ -512,27 +512,22 @@ void CatalogSet::CleanupEntry(CatalogEntry &catalog_entry) {
 bool CatalogSet::CreatedByOtherActiveTransaction(CatalogTransaction transaction, transaction_t timestamp) {
 	// True if this transaction is not committed yet and the entry was made by another active (not committed)
 	// transaction
-	return !IsCommitted(timestamp) && timestamp != transaction.transaction_id;
+	return !IsCommitted(timestamp) && timestamp != transaction.GetTransactionId();
 }
 
 bool CatalogSet::CommittedAfterStarting(CatalogTransaction transaction, transaction_t timestamp) {
-	// the entry is committed but not usable by this transaction, so it is not our source of truth
-	return IsCommitted(timestamp) && !UseTimestamp(transaction, timestamp);
+	// the entry is committed but not visible to this transaction, so it is not our source of truth
+	return IsCommitted(timestamp) && !transaction.view.Sees(timestamp);
 }
 
 bool CatalogSet::HasConflict(CatalogTransaction transaction, transaction_t timestamp) {
 	// a version conflicts exactly when it is not visible to the transaction: it is either another
 	// active transaction's uncommitted version, or committed outside this transaction's snapshot
-	return !UseTimestamp(transaction, timestamp);
+	return !transaction.view.Sees(timestamp);
 }
 
 bool CatalogSet::UseTimestamp(CatalogTransaction transaction, transaction_t timestamp) {
-	if (timestamp == transaction.transaction_id) {
-		// we created this version
-		return true;
-	}
-	// otherwise it is usable exactly when the transaction's snapshot contains it
-	return VisibleToSnapshot(timestamp, transaction.snapshot_bound);
+	return transaction.view.Sees(timestamp);
 }
 
 CatalogEntry &CatalogSet::GetEntryForTransaction(CatalogTransaction transaction, CatalogEntry &current) {
@@ -556,7 +551,7 @@ CatalogEntry &CatalogSet::GetEntryForTransaction(CatalogTransaction transaction,
 CatalogEntry &CatalogSet::GetCommittedEntry(CatalogEntry &current) {
 	reference<CatalogEntry> entry(current);
 	while (entry.get().HasChild()) {
-		if (IsCommitted(entry.get().timestamp)) {
+		if (IsCommitted(entry.get().timestamp.load())) {
 			// this entry is committed: use it
 			break;
 		}

--- a/src/catalog/catalog_set.cpp
+++ b/src/catalog/catalog_set.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/catalog/catalog_set.hpp"
+#include "duckdb/transaction/transaction_data.hpp"
 
 #include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
@@ -464,9 +465,10 @@ void CatalogSet::VerifyExistenceOfDependency(transaction_t commit_id, CatalogEnt
 
 	// Make sure that we don't see any uncommitted changes
 	auto transaction_id = MAX_TRANSACTION_ID;
+	D_ASSERT(IsCommitted(commit_id));
 	// This will allow us to see all committed changes made before this COMMIT happened
-	auto tx_start_time = commit_id + 1;
-	CatalogTransaction commit_transaction(duck_catalog.GetDatabase(), transaction_id, tx_start_time);
+	auto snapshot_bound = commit_id + 1;
+	CatalogTransaction commit_transaction(duck_catalog.GetDatabase(), transaction_id, snapshot_bound);
 
 	D_ASSERT(entry.type == CatalogType::DEPENDENCY_ENTRY);
 	auto &dep = entry.Cast<DependencyEntry>();
@@ -475,17 +477,18 @@ void CatalogSet::VerifyExistenceOfDependency(transaction_t commit_id, CatalogEnt
 
 //! Verify that no dependencies creations were committed since our transaction started, that reference the entry we're
 //! dropping
-void CatalogSet::CommitDrop(transaction_t commit_id, transaction_t start_time, CatalogEntry &entry) {
+void CatalogSet::CommitDrop(transaction_t commit_id, transaction_t snapshot_bound, CatalogEntry &entry) {
 	auto &duck_catalog = GetCatalog();
 
 	entry.OnDrop();
 	// Make sure that we don't see any uncommitted changes
 	auto transaction_id = MAX_TRANSACTION_ID;
+	D_ASSERT(IsCommitted(commit_id));
 	// This will allow us to see all committed changes made before this COMMIT happened
-	auto tx_start_time = commit_id;
-	CatalogTransaction commit_transaction(duck_catalog.GetDatabase(), transaction_id, tx_start_time);
+	auto commit_snapshot_bound = commit_id;
+	CatalogTransaction commit_transaction(duck_catalog.GetDatabase(), transaction_id, commit_snapshot_bound);
 
-	duck_catalog.GetDependencyManager()->VerifyCommitDrop(commit_transaction, start_time, entry);
+	duck_catalog.GetDependencyManager()->VerifyCommitDrop(commit_transaction, snapshot_bound, entry);
 }
 
 DuckCatalog &CatalogSet::GetCatalog() {
@@ -509,21 +512,18 @@ void CatalogSet::CleanupEntry(CatalogEntry &catalog_entry) {
 bool CatalogSet::CreatedByOtherActiveTransaction(CatalogTransaction transaction, transaction_t timestamp) {
 	// True if this transaction is not committed yet and the entry was made by another active (not committed)
 	// transaction
-	return (timestamp >= TRANSACTION_ID_START && timestamp != transaction.transaction_id);
+	return !IsCommitted(timestamp) && timestamp != transaction.transaction_id;
 }
 
 bool CatalogSet::CommittedAfterStarting(CatalogTransaction transaction, transaction_t timestamp) {
-	// The entry has been committed after this transaction started, this is not our source of truth.
-	return (timestamp < TRANSACTION_ID_START && timestamp > transaction.start_time);
+	// the entry is committed but not usable by this transaction, so it is not our source of truth
+	return IsCommitted(timestamp) && !UseTimestamp(transaction, timestamp);
 }
 
 bool CatalogSet::HasConflict(CatalogTransaction transaction, transaction_t timestamp) {
-	return CreatedByOtherActiveTransaction(transaction, timestamp) || CommittedAfterStarting(transaction, timestamp);
-}
-
-bool CatalogSet::IsCommitted(transaction_t timestamp) {
-	//! FIXME: `transaction_t` itself should be a class that has these methods
-	return timestamp < TRANSACTION_ID_START;
+	// a version conflicts exactly when it is not visible to the transaction: it is either another
+	// active transaction's uncommitted version, or committed outside this transaction's snapshot
+	return !UseTimestamp(transaction, timestamp);
 }
 
 bool CatalogSet::UseTimestamp(CatalogTransaction transaction, transaction_t timestamp) {
@@ -531,11 +531,8 @@ bool CatalogSet::UseTimestamp(CatalogTransaction transaction, transaction_t time
 		// we created this version
 		return true;
 	}
-	if (timestamp < transaction.start_time) {
-		// this version was committed before we started the transaction
-		return true;
-	}
-	return false;
+	// otherwise it is usable exactly when the transaction's snapshot contains it
+	return VisibleToSnapshot(timestamp, transaction.snapshot_bound);
 }
 
 CatalogEntry &CatalogSet::GetEntryForTransaction(CatalogTransaction transaction, CatalogEntry &current) {
@@ -559,7 +556,7 @@ CatalogEntry &CatalogSet::GetEntryForTransaction(CatalogTransaction transaction,
 CatalogEntry &CatalogSet::GetCommittedEntry(CatalogEntry &current) {
 	reference<CatalogEntry> entry(current);
 	while (entry.get().HasChild()) {
-		if (entry.get().timestamp < TRANSACTION_ID_START) {
+		if (IsCommitted(entry.get().timestamp)) {
 			// this entry is committed: use it
 			break;
 		}

--- a/src/catalog/catalog_transaction.cpp
+++ b/src/catalog/catalog_transaction.cpp
@@ -10,18 +10,20 @@ CatalogTransaction::CatalogTransaction(Catalog &catalog, ClientContext &context)
 	this->db = &DatabaseInstance::GetDatabase(context);
 	if (!transaction.IsDuckTransaction()) {
 		this->transaction_id = transaction_t(-1);
-		this->start_time = transaction_t(-1);
+		this->snapshot_bound = transaction_t(-1);
 	} else {
 		auto &dtransaction = transaction.Cast<DuckTransaction>();
 		this->transaction_id = dtransaction.transaction_id;
-		this->start_time = dtransaction.start_time;
+		this->snapshot_bound = dtransaction.start_time;
 	}
 	this->transaction = &transaction;
 	this->context = &context;
 }
 
-CatalogTransaction::CatalogTransaction(DatabaseInstance &db, transaction_t transaction_id_p, transaction_t start_time_p)
-    : db(&db), context(nullptr), transaction(nullptr), transaction_id(transaction_id_p), start_time(start_time_p) {
+CatalogTransaction::CatalogTransaction(DatabaseInstance &db, transaction_t transaction_id_p,
+                                       transaction_t snapshot_bound_p)
+    : db(&db), context(nullptr), transaction(nullptr), transaction_id(transaction_id_p),
+      snapshot_bound(snapshot_bound_p) {
 }
 
 ClientContext &CatalogTransaction::GetContext() {
@@ -36,7 +38,9 @@ CatalogTransaction CatalogTransaction::GetSystemCatalogTransaction(ClientContext
 }
 
 CatalogTransaction CatalogTransaction::GetSystemTransaction(DatabaseInstance &db) {
-	return CatalogTransaction(db, 1, 1);
+	// the bound is one past the bootstrap stamp: the system transaction sees the bootstrap entries
+	// and nothing else, since the timestamp counter starts above them
+	return CatalogTransaction(db, SYSTEM_TRANSACTION_TIMESTAMP, SYSTEM_TRANSACTION_TIMESTAMP + 1);
 }
 
 } // namespace duckdb

--- a/src/catalog/catalog_transaction.cpp
+++ b/src/catalog/catalog_transaction.cpp
@@ -1,29 +1,18 @@
 #include "duckdb/catalog/catalog_transaction.hpp"
 #include "duckdb/catalog/catalog.hpp"
-#include "duckdb/transaction/duck_transaction.hpp"
 #include "duckdb/main/database.hpp"
+#include "duckdb/transaction/transaction.hpp"
 
 namespace duckdb {
 
-CatalogTransaction::CatalogTransaction(Catalog &catalog, ClientContext &context) {
-	auto &transaction = Transaction::Get(context, catalog);
-	this->db = &DatabaseInstance::GetDatabase(context);
-	if (!transaction.IsDuckTransaction()) {
-		this->transaction_id = transaction_t(-1);
-		this->snapshot_bound = transaction_t(-1);
-	} else {
-		auto &dtransaction = transaction.Cast<DuckTransaction>();
-		this->transaction_id = dtransaction.transaction_id;
-		this->snapshot_bound = dtransaction.start_time;
-	}
-	this->transaction = &transaction;
-	this->context = &context;
+CatalogTransaction::CatalogTransaction(Catalog &catalog, ClientContext &context)
+    : db(&DatabaseInstance::GetDatabase(context)), context(&context), transaction(&Transaction::Get(context, catalog)),
+      view(transaction->GetSnapshotView()) {
 }
 
 CatalogTransaction::CatalogTransaction(DatabaseInstance &db, transaction_t transaction_id_p,
-                                       transaction_t snapshot_bound_p)
-    : db(&db), context(nullptr), transaction(nullptr), transaction_id(transaction_id_p),
-      snapshot_bound(snapshot_bound_p) {
+                                       VisibilityBound visibility_bound_p)
+    : db(&db), context(nullptr), transaction(nullptr), view(transaction_id_p, visibility_bound_p) {
 }
 
 ClientContext &CatalogTransaction::GetContext() {
@@ -38,9 +27,7 @@ CatalogTransaction CatalogTransaction::GetSystemCatalogTransaction(ClientContext
 }
 
 CatalogTransaction CatalogTransaction::GetSystemTransaction(DatabaseInstance &db) {
-	// the bound is one past the bootstrap stamp: the system transaction sees the bootstrap entries
-	// and nothing else, since the timestamp counter starts above them
-	return CatalogTransaction(db, SYSTEM_TRANSACTION_TIMESTAMP, SYSTEM_TRANSACTION_TIMESTAMP + 1);
+	return CatalogTransaction(db, SYSTEM_TRANSACTION_TIMESTAMP, VisibilityBound::Through(SYSTEM_TRANSACTION_TIMESTAMP));
 }
 
 } // namespace duckdb

--- a/src/catalog/dependency_manager.cpp
+++ b/src/catalog/dependency_manager.cpp
@@ -569,7 +569,7 @@ void DependencyManager::VerifyExistence(CatalogTransaction transaction, Dependen
 	}
 }
 
-void DependencyManager::VerifyCommitDrop(CatalogTransaction transaction, transaction_t snapshot_bound,
+void DependencyManager::VerifyCommitDrop(CatalogTransaction transaction, VisibilityBound visibility_bound,
                                          CatalogEntry &object) {
 	if (IsSystemEntry(object)) {
 		return;
@@ -577,7 +577,7 @@ void DependencyManager::VerifyCommitDrop(CatalogTransaction transaction, transac
 	auto info = GetLookupProperties(object);
 	ScanDependents(transaction, info, [&](DependencyEntry &dep) {
 		auto dep_committed_at = dep.timestamp.load();
-		if (!VisibleToSnapshot(dep_committed_at, snapshot_bound)) {
+		if (dep_committed_at >= visibility_bound) {
 			// In the event of a CASCADE, the dependency drop has not committed yet
 			// so we would be halted by the existence of a dependency we are already dropping unless we check the
 			// timestamp
@@ -595,7 +595,7 @@ void DependencyManager::VerifyCommitDrop(CatalogTransaction transaction, transac
 			return;
 		}
 		D_ASSERT(dep.Subject().flags.IsOwnership());
-		if (!VisibleToSnapshot(dep_committed_at, snapshot_bound)) {
+		if (dep_committed_at >= visibility_bound) {
 			// Same as above, objects that are owned by the object that is being dropped will be dropped as part of this
 			// transaction. Only objects that were introduced by other transactions, that this transaction could not
 			// see, should cause this error:
@@ -677,7 +677,7 @@ void DependencyManager::ReorderEntries(catalog_entry_vector_t &entries, ClientCo
 
 void DependencyManager::ReorderEntries(catalog_entry_vector_t &entries) {
 	// Read all committed entries. A checkpoint writes internal entries too
-	CatalogTransaction transaction(catalog.GetDatabase(), TRANSACTION_ID_START - 1, TRANSACTION_ID_START - 1);
+	CatalogTransaction transaction(catalog.GetDatabase(), MAX_COMMIT_ID, VisibilityBound::Before(MAX_COMMIT_ID));
 	ReorderEntries(entries, transaction, true);
 }
 

--- a/src/catalog/dependency_manager.cpp
+++ b/src/catalog/dependency_manager.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/catalog/dependency_manager.hpp"
+#include "duckdb/transaction/transaction_data.hpp"
 #include "duckdb/catalog/catalog_entry/type_catalog_entry.hpp"
 #include "duckdb/catalog/duck_catalog.hpp"
 #include "duckdb/catalog/catalog_entry.hpp"
@@ -568,7 +569,7 @@ void DependencyManager::VerifyExistence(CatalogTransaction transaction, Dependen
 	}
 }
 
-void DependencyManager::VerifyCommitDrop(CatalogTransaction transaction, transaction_t start_time,
+void DependencyManager::VerifyCommitDrop(CatalogTransaction transaction, transaction_t snapshot_bound,
                                          CatalogEntry &object) {
 	if (IsSystemEntry(object)) {
 		return;
@@ -576,7 +577,7 @@ void DependencyManager::VerifyCommitDrop(CatalogTransaction transaction, transac
 	auto info = GetLookupProperties(object);
 	ScanDependents(transaction, info, [&](DependencyEntry &dep) {
 		auto dep_committed_at = dep.timestamp.load();
-		if (dep_committed_at > start_time) {
+		if (!VisibleToSnapshot(dep_committed_at, snapshot_bound)) {
 			// In the event of a CASCADE, the dependency drop has not committed yet
 			// so we would be halted by the existence of a dependency we are already dropping unless we check the
 			// timestamp
@@ -594,7 +595,7 @@ void DependencyManager::VerifyCommitDrop(CatalogTransaction transaction, transac
 			return;
 		}
 		D_ASSERT(dep.Subject().flags.IsOwnership());
-		if (dep_committed_at > start_time) {
+		if (!VisibleToSnapshot(dep_committed_at, snapshot_bound)) {
 			// Same as above, objects that are owned by the object that is being dropped will be dropped as part of this
 			// transaction. Only objects that were introduced by other transactions, that this transaction could not
 			// see, should cause this error:
@@ -670,21 +671,19 @@ void DependencyManager::DropObject(CatalogTransaction transaction, CatalogEntry 
 
 void DependencyManager::ReorderEntries(catalog_entry_vector_t &entries, ClientContext &context) {
 	auto transaction = catalog.GetCatalogTransaction(context);
-	// Read all the entries visible to this snapshot
-	ReorderEntries(entries, transaction);
+	// Read all the entries visible to this snapshot. Internal entries are not exported
+	ReorderEntries(entries, transaction, false);
 }
 
 void DependencyManager::ReorderEntries(catalog_entry_vector_t &entries) {
-	// Read all committed entries
+	// Read all committed entries. A checkpoint writes internal entries too
 	CatalogTransaction transaction(catalog.GetDatabase(), TRANSACTION_ID_START - 1, TRANSACTION_ID_START - 1);
-	ReorderEntries(entries, transaction);
+	ReorderEntries(entries, transaction, true);
 }
 
 void DependencyManager::ReorderEntry(CatalogTransaction transaction, CatalogEntry &entry, catalog_entry_set_t &visited,
-                                     catalog_entry_vector_t &order) {
+                                     catalog_entry_vector_t &order, bool allow_internal) {
 	auto &catalog_entry = *LookupEntry(transaction, entry);
-	// We use this in CheckpointManager, it has the highest commit ID, allowing us to read any committed data
-	bool allow_internal = transaction.start_time == TRANSACTION_ID_START - 1;
 	if (visited.count(catalog_entry) || (!allow_internal && catalog_entry.internal)) {
 		// Already seen and ordered appropriately
 		return;
@@ -695,7 +694,7 @@ void DependencyManager::ReorderEntry(CatalogTransaction transaction, CatalogEntr
 	auto info = GetLookupProperties(entry);
 	ScanSubjects(transaction, info, [&](DependencyEntry &dep) { dependents.push_back(dep); });
 	for (auto &dep : dependents) {
-		ReorderEntry(transaction, dep, visited, order);
+		ReorderEntry(transaction, dep, visited, order, allow_internal);
 	}
 
 	// Then write the entry
@@ -703,11 +702,12 @@ void DependencyManager::ReorderEntry(CatalogTransaction transaction, CatalogEntr
 	order.push_back(catalog_entry);
 }
 
-void DependencyManager::ReorderEntries(catalog_entry_vector_t &entries, CatalogTransaction transaction) {
+void DependencyManager::ReorderEntries(catalog_entry_vector_t &entries, CatalogTransaction transaction,
+                                       bool allow_internal) {
 	catalog_entry_vector_t reordered;
 	catalog_entry_set_t visited;
 	for (auto &entry : entries) {
-		ReorderEntry(transaction, entry, visited, reordered);
+		ReorderEntry(transaction, entry, visited, reordered, allow_internal);
 	}
 	// If this would fail, that means there are more entries that we somehow reached through the dependency manager
 	// but those entries should not actually be visible to this transaction

--- a/src/common/constants.cpp
+++ b/src/common/constants.cpp
@@ -17,6 +17,7 @@ const double PI = 3.141592653589793;
 
 const transaction_t SYSTEM_TRANSACTION_TIMESTAMP = 1;
 const transaction_t TRANSACTION_ID_START = 4611686018427388000ULL;                // 2^62
+const transaction_t MAX_COMMIT_ID = TRANSACTION_ID_START - 1;                     // 2^62 - 1
 const transaction_t MAX_TRANSACTION_ID = NumericLimits<transaction_t>::Maximum(); // 2^63
 const transaction_t NOT_DELETED_ID = NumericLimits<transaction_t>::Maximum() - 1; // 2^64 - 1
 const transaction_t MAXIMUM_QUERY_ID = NumericLimits<transaction_t>::Maximum();   // 2^64

--- a/src/common/constants.cpp
+++ b/src/common/constants.cpp
@@ -15,6 +15,7 @@ const column_t COLUMN_IDENTIFIER_ROW_NUMBER = UINT64_C(18446744073709551613);
 const column_t VIRTUAL_COLUMN_START = UINT64_C(9223372036854775808); // 2^63
 const double PI = 3.141592653589793;
 
+const transaction_t SYSTEM_TRANSACTION_TIMESTAMP = 1;
 const transaction_t TRANSACTION_ID_START = 4611686018427388000ULL;                // 2^62
 const transaction_t MAX_TRANSACTION_ID = NumericLimits<transaction_t>::Maximum(); // 2^63
 const transaction_t NOT_DELETED_ID = NumericLimits<transaction_t>::Maximum() - 1; // 2^64 - 1

--- a/src/execution/operator/persistent/physical_batch_insert.cpp
+++ b/src/execution/operator/persistent/physical_batch_insert.cpp
@@ -386,7 +386,7 @@ SinkNextBatchType PhysicalBatchInsert::NextBatch(ExecutionContext &context, Oper
 			throw InternalException("NextBatch called with the same batch index?");
 		}
 		// batch index has changed: move the old collection to the global state and create a new collection
-		TransactionData tdata(0, 0);
+		auto tdata = TransactionData::Unversioned();
 		auto &optimistic_collection =
 		    gstate.table.GetStorage().GetOptimisticCollection(context.client, lstate.collection_index);
 		auto &collection = *optimistic_collection.collection;
@@ -496,7 +496,7 @@ SinkCombineResultType PhysicalBatchInsert::Combine(ExecutionContext &context, Op
 	memory_manager.UpdateMinBatchIndex(lstate.partition_info.min_batch_index.GetIndex());
 
 	if (lstate.collection_index.IsValid()) {
-		TransactionData tdata(0, 0);
+		auto tdata = TransactionData::Unversioned();
 		auto &optimistic_collection =
 		    gstate.table.GetStorage().GetOptimisticCollection(context.client, lstate.collection_index);
 		auto &collection = *optimistic_collection.collection;

--- a/src/execution/operator/persistent/physical_insert.cpp
+++ b/src/execution/operator/persistent/physical_insert.cpp
@@ -668,7 +668,7 @@ SinkCombineResultType PhysicalInsert::Combine(ExecutionContext &context, Operato
 	const idx_t row_group_size = storage.GetRowGroupSize();
 
 	// parallel append: finalize the append
-	TransactionData tdata(0, 0);
+	auto tdata = TransactionData::Unversioned();
 	auto &data_table = gstate.table.GetStorage();
 	auto &optimistic_collection = data_table.GetOptimisticCollection(context.client, lstate.collection_index);
 	auto &collection = *optimistic_collection.collection;

--- a/src/include/duckdb/catalog/catalog_set.hpp
+++ b/src/include/duckdb/catalog/catalog_set.hpp
@@ -79,7 +79,7 @@ public:
 	//! Verify that the entry referenced by the dependency is still alive
 	DUCKDB_API void VerifyExistenceOfDependency(transaction_t commit_id, CatalogEntry &entry);
 	//! Verify we can still drop the entry while committing
-	DUCKDB_API void CommitDrop(transaction_t commit_id, transaction_t start_time, CatalogEntry &entry);
+	DUCKDB_API void CommitDrop(transaction_t commit_id, transaction_t snapshot_bound, CatalogEntry &entry);
 
 	DUCKDB_API DuckCatalog &GetCatalog();
 
@@ -129,7 +129,6 @@ public:
 	DUCKDB_API bool CommittedAfterStarting(CatalogTransaction transaction, transaction_t timestamp);
 	DUCKDB_API bool HasConflict(CatalogTransaction transaction, transaction_t timestamp);
 	DUCKDB_API bool UseTimestamp(CatalogTransaction transaction, transaction_t timestamp);
-	static bool IsCommitted(transaction_t timestamp);
 
 	static void UpdateTimestamp(CatalogEntry &entry, transaction_t timestamp);
 

--- a/src/include/duckdb/catalog/catalog_set.hpp
+++ b/src/include/duckdb/catalog/catalog_set.hpp
@@ -79,7 +79,7 @@ public:
 	//! Verify that the entry referenced by the dependency is still alive
 	DUCKDB_API void VerifyExistenceOfDependency(transaction_t commit_id, CatalogEntry &entry);
 	//! Verify we can still drop the entry while committing
-	DUCKDB_API void CommitDrop(transaction_t commit_id, transaction_t snapshot_bound, CatalogEntry &entry);
+	DUCKDB_API void CommitDrop(transaction_t commit_id, VisibilityBound visibility_bound, CatalogEntry &entry);
 
 	DUCKDB_API DuckCatalog &GetCatalog();
 

--- a/src/include/duckdb/catalog/catalog_transaction.hpp
+++ b/src/include/duckdb/catalog/catalog_transaction.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/optional_ptr.hpp"
+#include "duckdb/transaction/transaction_data.hpp"
 
 namespace duckdb {
 class Catalog;
@@ -19,14 +20,16 @@ class Transaction;
 
 struct CatalogTransaction {
 	CatalogTransaction(Catalog &catalog, ClientContext &context);
-	CatalogTransaction(DatabaseInstance &db, transaction_t transaction_id_p, transaction_t snapshot_bound_p);
+	CatalogTransaction(DatabaseInstance &db, transaction_t transaction_id_p, VisibilityBound visibility_bound_p);
 
 	optional_ptr<DatabaseInstance> db;
 	optional_ptr<ClientContext> context;
 	optional_ptr<Transaction> transaction;
-	transaction_t transaction_id;
-	transaction_t snapshot_bound;
+	SnapshotView view;
 
+	transaction_t GetTransactionId() const {
+		return view.transaction_id;
+	}
 	bool HasContext() const {
 		return context;
 	}

--- a/src/include/duckdb/catalog/catalog_transaction.hpp
+++ b/src/include/duckdb/catalog/catalog_transaction.hpp
@@ -19,13 +19,13 @@ class Transaction;
 
 struct CatalogTransaction {
 	CatalogTransaction(Catalog &catalog, ClientContext &context);
-	CatalogTransaction(DatabaseInstance &db, transaction_t transaction_id_p, transaction_t start_time_p);
+	CatalogTransaction(DatabaseInstance &db, transaction_t transaction_id_p, transaction_t snapshot_bound_p);
 
 	optional_ptr<DatabaseInstance> db;
 	optional_ptr<ClientContext> context;
 	optional_ptr<Transaction> transaction;
 	transaction_t transaction_id;
-	transaction_t start_time;
+	transaction_t snapshot_bound;
 
 	bool HasContext() const {
 		return context;

--- a/src/include/duckdb/catalog/dependency_manager.hpp
+++ b/src/include/duckdb/catalog/dependency_manager.hpp
@@ -126,11 +126,11 @@ public:
 
 private:
 	void ReorderEntry(CatalogTransaction transaction, CatalogEntry &entry, catalog_entry_set_t &visited,
-	                  catalog_entry_vector_t &order);
-	void ReorderEntries(catalog_entry_vector_t &entries, CatalogTransaction transaction);
+	                  catalog_entry_vector_t &order, bool allow_internal);
+	void ReorderEntries(catalog_entry_vector_t &entries, CatalogTransaction transaction, bool allow_internal);
 	void AddObject(CatalogTransaction transaction, CatalogEntry &object, const LogicalDependencyList &dependencies);
 	void VerifyExistence(CatalogTransaction transaction, DependencyEntry &object);
-	void VerifyCommitDrop(CatalogTransaction transaction, transaction_t start_time, CatalogEntry &object);
+	void VerifyCommitDrop(CatalogTransaction transaction, transaction_t snapshot_bound, CatalogEntry &object);
 	//! Returns the objects that should be dropped alongside the object
 	catalog_entry_set_t CheckDropDependencies(CatalogTransaction transaction, CatalogEntry &object, bool cascade);
 	void DropObject(CatalogTransaction transaction, CatalogEntry &object, bool cascade);

--- a/src/include/duckdb/catalog/dependency_manager.hpp
+++ b/src/include/duckdb/catalog/dependency_manager.hpp
@@ -130,7 +130,7 @@ private:
 	void ReorderEntries(catalog_entry_vector_t &entries, CatalogTransaction transaction, bool allow_internal);
 	void AddObject(CatalogTransaction transaction, CatalogEntry &object, const LogicalDependencyList &dependencies);
 	void VerifyExistence(CatalogTransaction transaction, DependencyEntry &object);
-	void VerifyCommitDrop(CatalogTransaction transaction, transaction_t snapshot_bound, CatalogEntry &object);
+	void VerifyCommitDrop(CatalogTransaction transaction, VisibilityBound visibility_bound, CatalogEntry &object);
 	//! Returns the objects that should be dropped alongside the object
 	catalog_entry_set_t CheckDropDependencies(CatalogTransaction transaction, CatalogEntry &object, bool cascade);
 	void DropObject(CatalogTransaction transaction, CatalogEntry &object, bool cascade);

--- a/src/include/duckdb/common/constants.hpp
+++ b/src/include/duckdb/common/constants.hpp
@@ -54,6 +54,7 @@ extern const row_t MAX_ROW_ID;
 //! Transaction-local row IDs start at MAX_ROW_ID
 extern const row_t MAX_ROW_ID_LOCAL;
 
+extern const transaction_t SYSTEM_TRANSACTION_TIMESTAMP;
 extern const transaction_t TRANSACTION_ID_START;
 extern const transaction_t MAX_TRANSACTION_ID;
 extern const transaction_t MAXIMUM_QUERY_ID;

--- a/src/include/duckdb/common/constants.hpp
+++ b/src/include/duckdb/common/constants.hpp
@@ -56,9 +56,61 @@ extern const row_t MAX_ROW_ID_LOCAL;
 
 extern const transaction_t SYSTEM_TRANSACTION_TIMESTAMP;
 extern const transaction_t TRANSACTION_ID_START;
+//! The largest timestamp that is still a commit id, one below the first transaction id
+extern const transaction_t MAX_COMMIT_ID;
 extern const transaction_t MAX_TRANSACTION_ID;
 extern const transaction_t MAXIMUM_QUERY_ID;
 extern const transaction_t NOT_DELETED_ID;
+
+//! An exclusive bound on the transaction timeline: timestamps below it are visible. Its own type, so
+//! it cannot be swapped or assigned with a timestamp; compare with < and >= only.
+struct VisibilityBound {
+	VisibilityBound() = default;
+
+	//! Visible up to and including this timestamp
+	static VisibilityBound Through(transaction_t timestamp) {
+		return VisibilityBound(timestamp + 1);
+	}
+	//! Visible strictly before this timestamp
+	static VisibilityBound Before(transaction_t timestamp) {
+		return VisibilityBound(timestamp);
+	}
+	static VisibilityBound AllCommitted() {
+		return Through(MAX_COMMIT_ID);
+	}
+	static VisibilityBound IncludingUncommitted() {
+		return VisibilityBound(MAX_TRANSACTION_ID);
+	}
+	static VisibilityBound Min(VisibilityBound a, VisibilityBound b) {
+		return a.value < b.value ? a : b;
+	}
+
+private:
+	explicit VisibilityBound(transaction_t value_p) : value(value_p) {
+	}
+
+	friend bool operator==(VisibilityBound a, VisibilityBound b);
+	friend bool operator!=(VisibilityBound a, VisibilityBound b);
+	friend bool operator<(transaction_t timestamp, VisibilityBound bound);
+	friend bool operator>=(transaction_t timestamp, VisibilityBound bound);
+
+	transaction_t value = 0;
+};
+
+inline bool operator==(VisibilityBound a, VisibilityBound b) {
+	return a.value == b.value;
+}
+inline bool operator!=(VisibilityBound a, VisibilityBound b) {
+	return a.value != b.value;
+}
+
+//! Only < and >= exist; <= and > do not compile, so a bound stays exclusive.
+inline bool operator<(transaction_t timestamp, VisibilityBound bound) {
+	return timestamp < bound.value;
+}
+inline bool operator>=(transaction_t timestamp, VisibilityBound bound) {
+	return !(timestamp < bound);
+}
 
 extern const double PI;
 

--- a/src/include/duckdb/execution/operator/persistent/collection_merger.hpp
+++ b/src/include/duckdb/execution/operator/persistent/collection_merger.hpp
@@ -89,7 +89,7 @@ public:
 				}
 				data_table.ResetOptimisticCollection(context, collection_indexes[i]);
 			}
-			result_collection.FinalizeAppend(TransactionData(0, 0), append_state);
+			result_collection.FinalizeAppend(TransactionData::Unversioned(), append_state);
 			writer.WriteUnflushedRowGroups(optimistic_collection);
 		} else if (batch_type == RowGroupBatchType::NOT_FLUSHED) {
 			writer.WriteUnflushedRowGroups(optimistic_collection);

--- a/src/include/duckdb/storage/checkpoint/checkpoint_options.hpp
+++ b/src/include/duckdb/storage/checkpoint/checkpoint_options.hpp
@@ -18,7 +18,7 @@ namespace duckdb {
 struct CheckpointOptions {
 	CheckpointOptions()
 	    : wal_action(CheckpointWALAction::DONT_DELETE_WAL), action(CheckpointAction::CHECKPOINT_IF_REQUIRED),
-	      type(CheckpointType::FULL_CHECKPOINT), snapshot_bound(MAX_TRANSACTION_ID) {
+	      type(CheckpointType::FULL_CHECKPOINT), visibility_bound(VisibilityBound::IncludingUncommitted()) {
 	}
 
 	CheckpointWALAction wal_action;
@@ -26,8 +26,8 @@ struct CheckpointOptions {
 	CheckpointType type;
 	//! Identifies this checkpoint. Compared for equality only; empty when no checkpoint is running
 	optional_idx checkpoint_id;
-	//! What this checkpoint sees: stamps below this bound are written
-	transaction_t snapshot_bound;
+	//! What this checkpoint sees: timestamps below this bound are written
+	VisibilityBound visibility_bound;
 	//! The WAL lock - in case we are holding it during the entire checkpoint.
 	//! This is only required if we are doing a checkpoint instead of writing to the WAL
 	optional_ptr<unique_lock<mutex>> wal_lock;

--- a/src/include/duckdb/storage/checkpoint/checkpoint_options.hpp
+++ b/src/include/duckdb/storage/checkpoint/checkpoint_options.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb/common/enums/checkpoint_type.hpp"
 #include "duckdb/common/mutex.hpp"
+#include "duckdb/common/optional_idx.hpp"
 #include "duckdb/common/optional_ptr.hpp"
 
 namespace duckdb {
@@ -17,13 +18,16 @@ namespace duckdb {
 struct CheckpointOptions {
 	CheckpointOptions()
 	    : wal_action(CheckpointWALAction::DONT_DELETE_WAL), action(CheckpointAction::CHECKPOINT_IF_REQUIRED),
-	      type(CheckpointType::FULL_CHECKPOINT), transaction_id(MAX_TRANSACTION_ID) {
+	      type(CheckpointType::FULL_CHECKPOINT), snapshot_bound(MAX_TRANSACTION_ID) {
 	}
 
 	CheckpointWALAction wal_action;
 	CheckpointAction action;
 	CheckpointType type;
-	transaction_t transaction_id;
+	//! Identifies this checkpoint. Compared for equality only; empty when no checkpoint is running
+	optional_idx checkpoint_id;
+	//! What this checkpoint sees: stamps below this bound are written
+	transaction_t snapshot_bound;
 	//! The WAL lock - in case we are holding it during the entire checkpoint.
 	//! This is only required if we are doing a checkpoint instead of writing to the WAL
 	optional_ptr<unique_lock<mutex>> wal_lock;

--- a/src/include/duckdb/storage/data_table.hpp
+++ b/src/include/duckdb/storage/data_table.hpp
@@ -275,7 +275,7 @@ public:
 	void SetIndexStorageInfo(vector<IndexStorageInfo> index_storage_info);
 	void VacuumIndexes();
 	void VerifyIndexBuffers() const;
-	void CleanupAppend(transaction_t lowest_transaction, idx_t start, idx_t count);
+	void CleanupAppend(transaction_t lowest_snapshot_bound, idx_t start, idx_t count);
 	void Destroy();
 
 	Identifier GetTableName() const;

--- a/src/include/duckdb/storage/data_table.hpp
+++ b/src/include/duckdb/storage/data_table.hpp
@@ -275,7 +275,7 @@ public:
 	void SetIndexStorageInfo(vector<IndexStorageInfo> index_storage_info);
 	void VacuumIndexes();
 	void VerifyIndexBuffers() const;
-	void CleanupAppend(transaction_t lowest_snapshot_bound, idx_t start, idx_t count);
+	void CleanupAppend(VisibilityBound lowest_visibility_bound, idx_t start, idx_t count);
 	void Destroy();
 
 	Identifier GetTableName() const;

--- a/src/include/duckdb/storage/table/chunk_info.hpp
+++ b/src/include/duckdb/storage/table/chunk_info.hpp
@@ -67,7 +67,7 @@ public:
 	//! Returns whether or not a single row in the ChunkVectorInfo should be used or not for the given transaction
 	bool Fetch(TransactionData transaction, row_t row);
 	void CommitAppend(transaction_t commit_id, idx_t start, idx_t end);
-	bool Cleanup(transaction_t lowest_transaction) const;
+	bool Cleanup(transaction_t lowest_snapshot_bound) const;
 	string ToString(idx_t max_count) const;
 
 	void Append(idx_t start, idx_t end, transaction_t commit_id);
@@ -82,8 +82,8 @@ public:
 
 	//! Attempts to compress the per-row insert/delete ids into constants
 	//! This is possible when the ids behave identically for all transactions with a start time of at least
-	//! lowest_active_start (i.e. all active and future transactions)
-	VersionCompressionResult CompressVersionIds(transaction_t lowest_active_start);
+	//! lowest_snapshot_bound (i.e. all active and future transactions)
+	VersionCompressionResult CompressVersionIds(transaction_t lowest_snapshot_bound);
 	//! Whether a compression pass could achieve anything for this vector (see recheck_compression)
 	bool RecheckCompression() const {
 		return recheck_compression;
@@ -92,7 +92,7 @@ public:
 	//! compressible now or in the future without a modification that re-arms the check
 	void VerifyCachedCompressionState() const;
 
-	bool HasDeletes(transaction_t transaction_id = MAX_TRANSACTION_ID) const;
+	bool HasDeletes(transaction_t snapshot_bound = MAX_TRANSACTION_ID) const;
 	bool HasUncommittedChanges() const;
 	bool AnyDeleted() const;
 	bool HasConstantInsertionId() const;
@@ -100,12 +100,12 @@ public:
 	bool HasConstantDeleteId() const;
 	transaction_t ConstantDeleteId() const;
 
-	void Write(WriteStream &writer, transaction_t transaction_id) const;
+	void Write(WriteStream &writer, transaction_t snapshot_bound) const;
 	static unique_ptr<ChunkVectorInfo> Read(FixedSizeAllocator &allocator, ReadStream &reader);
 
 private:
 	template <class INSERT_OP, class DELETE_OP>
-	idx_t TemplatedGetSelVector(transaction_t start_time, transaction_t transaction_id,
+	idx_t TemplatedGetSelVector(transaction_t snapshot_bound, transaction_t transaction_id,
 	                            optional_ptr<SelectionVector> sel_vector, idx_t max_count) const;
 
 	IndexPointer GetInsertedPointer() const;

--- a/src/include/duckdb/storage/table/chunk_info.hpp
+++ b/src/include/duckdb/storage/table/chunk_info.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb/execution/index/index_pointer.hpp"
 #include "duckdb/common/enums/scan_options.hpp"
+#include "duckdb/transaction/transaction_data.hpp"
 #include "duckdb/common/types/validity_mask.hpp"
 
 namespace duckdb {
@@ -67,7 +68,7 @@ public:
 	//! Returns whether or not a single row in the ChunkVectorInfo should be used or not for the given transaction
 	bool Fetch(TransactionData transaction, row_t row);
 	void CommitAppend(transaction_t commit_id, idx_t start, idx_t end);
-	bool Cleanup(transaction_t lowest_snapshot_bound) const;
+	bool Cleanup(VisibilityBound lowest_visibility_bound) const;
 	string ToString(idx_t max_count) const;
 
 	void Append(idx_t start, idx_t end, transaction_t commit_id);
@@ -80,10 +81,9 @@ public:
 	idx_t Delete(transaction_t transaction_id, row_t rows[], idx_t count);
 	void CommitDelete(transaction_t commit_id, const DeleteInfo &info);
 
-	//! Attempts to compress the per-row insert/delete ids into constants
-	//! This is possible when the ids behave identically for all transactions with a start time of at least
-	//! lowest_snapshot_bound (i.e. all active and future transactions)
-	VersionCompressionResult CompressVersionIds(transaction_t lowest_snapshot_bound);
+	//! Attempts to compress the per-row insert/delete ids into constants. Ids that precede
+	//! lowest_visibility_bound look the same to every active and future transaction, so they can collapse
+	VersionCompressionResult CompressVersionIds(VisibilityBound lowest_visibility_bound);
 	//! Whether a compression pass could achieve anything for this vector (see recheck_compression)
 	bool RecheckCompression() const {
 		return recheck_compression;
@@ -92,7 +92,7 @@ public:
 	//! compressible now or in the future without a modification that re-arms the check
 	void VerifyCachedCompressionState() const;
 
-	bool HasDeletes(transaction_t snapshot_bound = MAX_TRANSACTION_ID) const;
+	bool HasDeletes(VisibilityBound visibility_bound = VisibilityBound::IncludingUncommitted()) const;
 	bool HasUncommittedChanges() const;
 	bool AnyDeleted() const;
 	bool HasConstantInsertionId() const;
@@ -100,13 +100,13 @@ public:
 	bool HasConstantDeleteId() const;
 	transaction_t ConstantDeleteId() const;
 
-	void Write(WriteStream &writer, transaction_t snapshot_bound) const;
+	void Write(WriteStream &writer, VisibilityBound visibility_bound) const;
 	static unique_ptr<ChunkVectorInfo> Read(FixedSizeAllocator &allocator, ReadStream &reader);
 
 private:
 	template <class INSERT_OP, class DELETE_OP>
-	idx_t TemplatedGetSelVector(transaction_t snapshot_bound, transaction_t transaction_id,
-	                            optional_ptr<SelectionVector> sel_vector, idx_t max_count) const;
+	idx_t TemplatedGetSelVector(const SnapshotView &view, optional_ptr<SelectionVector> sel_vector,
+	                            idx_t max_count) const;
 
 	IndexPointer GetInsertedPointer() const;
 	IndexPointer GetDeletedPointer() const;

--- a/src/include/duckdb/storage/table/data_table_info.hpp
+++ b/src/include/duckdb/storage/table/data_table_info.hpp
@@ -48,7 +48,7 @@ public:
 	unique_ptr<StorageLockKey> GetSharedLock() {
 		return checkpoint_lock.GetSharedLock();
 	}
-	bool AppendRequiresNewRowGroup(RowGroupCollection &collection, transaction_t checkpoint_id);
+	bool AppendRequiresNewRowGroup(RowGroupCollection &collection, optional_idx checkpoint_id);
 	optional_idx CheckpointRowGroupCount(const CheckpointOptions &options) const;
 	void VerifyIndexBuffers() const;
 

--- a/src/include/duckdb/storage/table/index_entry.hpp
+++ b/src/include/duckdb/storage/table/index_entry.hpp
@@ -42,7 +42,7 @@ public:
 	BoundIndex &GetOrCreate(BoundIndex &index, IndexDeltaType type);
 	bool ShouldUse(optional_idx active_checkpoint) const;
 	ErrorData MergeCheckpointDeltas(BoundIndex &index);
-	void MarkWritten(transaction_t checkpoint_id);
+	void MarkWritten(optional_idx checkpoint_id);
 	void Reset();
 
 private:
@@ -168,7 +168,7 @@ public:
 	//! Serializes the bound physical index for the write-ahead log.
 	IndexStorageInfo SerializeToWAL(const case_insensitive_map_t<Value> &options);
 	//! Merges checkpoint deltas into the bound physical index and marks the checkpoint as written.
-	void MergeCheckpointDeltas(transaction_t checkpoint_id);
+	void MergeCheckpointDeltas(optional_idx checkpoint_id);
 	//! Adds transaction-local copies of the physical index to the target lists when required.
 	void InitializeLocalIndexes(TableIndexList &delete_indexes, TableIndexList &append_indexes) const;
 

--- a/src/include/duckdb/storage/table/row_group.hpp
+++ b/src/include/duckdb/storage/table/row_group.hpp
@@ -184,7 +184,7 @@ public:
 	//! Revert a previous append made by RowGroup::AppendVersionInfo
 	void RevertAppend(idx_t new_count);
 	//! Clean up append states that can either be compressed or deleted
-	void CleanupAppend(transaction_t lowest_transaction, idx_t start, idx_t count);
+	void CleanupAppend(transaction_t lowest_snapshot_bound, idx_t start, idx_t count);
 
 	//! Delete the given set of rows in the version manager
 	idx_t Delete(TransactionData transaction, DuckTableEntry &table_entry, row_t *row_ids, idx_t count,
@@ -250,8 +250,8 @@ public:
 	vector<MetaBlockPointer> CheckpointDeletes(RowGroupWriter &writer);
 	//! Attempts to compress the version information of the row group
 	//! Per-row insert/delete ids that behave identically for all transactions with a start time of at least
-	//! lowest_active_start (i.e. all active and future transactions) are compressed into constants
-	void CompressVersionInfo(transaction_t lowest_active_start);
+	//! lowest_snapshot_bound (i.e. all active and future transactions) are compressed into constants
+	void CompressVersionInfo(transaction_t lowest_snapshot_bound);
 
 	//! Direct accessors, fall outside of general use but can be useful to some extensions
 	ColumnData &GetRawColumnData(const StorageIndex &c) const;

--- a/src/include/duckdb/storage/table/row_group.hpp
+++ b/src/include/duckdb/storage/table/row_group.hpp
@@ -184,7 +184,7 @@ public:
 	//! Revert a previous append made by RowGroup::AppendVersionInfo
 	void RevertAppend(idx_t new_count);
 	//! Clean up append states that can either be compressed or deleted
-	void CleanupAppend(transaction_t lowest_snapshot_bound, idx_t start, idx_t count);
+	void CleanupAppend(VisibilityBound lowest_visibility_bound, idx_t start, idx_t count);
 
 	//! Delete the given set of rows in the version manager
 	idx_t Delete(TransactionData transaction, DuckTableEntry &table_entry, row_t *row_ids, idx_t count,
@@ -248,10 +248,10 @@ public:
 	idx_t GetColumnCount() const;
 
 	vector<MetaBlockPointer> CheckpointDeletes(RowGroupWriter &writer);
-	//! Attempts to compress the version information of the row group
-	//! Per-row insert/delete ids that behave identically for all transactions with a start time of at least
-	//! lowest_snapshot_bound (i.e. all active and future transactions) are compressed into constants
-	void CompressVersionInfo(transaction_t lowest_snapshot_bound);
+	//! Attempts to compress the version information of the row group. Insert and delete ids that precede
+	//! lowest_visibility_bound look the same to every active and future transaction, so they can be
+	//! collapsed into constants
+	void CompressVersionInfo(VisibilityBound lowest_visibility_bound);
 
 	//! Direct accessors, fall outside of general use but can be useful to some extensions
 	ColumnData &GetRawColumnData(const StorageIndex &c) const;

--- a/src/include/duckdb/storage/table/row_group_collection.hpp
+++ b/src/include/duckdb/storage/table/row_group_collection.hpp
@@ -128,7 +128,7 @@ public:
 	void FinalizeAppend(TransactionData transaction, TableAppendState &state);
 	void CommitAppend(transaction_t commit_id, idx_t row_start, idx_t count);
 	void RevertAppendInternal(idx_t start_row);
-	void CleanupAppend(transaction_t lowest_transaction, idx_t start, idx_t count);
+	void CleanupAppend(transaction_t lowest_snapshot_bound, idx_t start, idx_t count);
 
 	void MergeStorage(RowGroupCollection &data, optional_ptr<DataTable> table,
 	                  optional_ptr<StorageCommitState> commit_state);

--- a/src/include/duckdb/storage/table/row_group_collection.hpp
+++ b/src/include/duckdb/storage/table/row_group_collection.hpp
@@ -128,7 +128,7 @@ public:
 	void FinalizeAppend(TransactionData transaction, TableAppendState &state);
 	void CommitAppend(transaction_t commit_id, idx_t row_start, idx_t count);
 	void RevertAppendInternal(idx_t start_row);
-	void CleanupAppend(transaction_t lowest_snapshot_bound, idx_t start, idx_t count);
+	void CleanupAppend(VisibilityBound lowest_visibility_bound, idx_t start, idx_t count);
 
 	void MergeStorage(RowGroupCollection &data, optional_ptr<DataTable> table,
 	                  optional_ptr<StorageCommitState> commit_state);

--- a/src/include/duckdb/storage/table/row_version_manager.hpp
+++ b/src/include/duckdb/storage/table/row_version_manager.hpp
@@ -34,17 +34,16 @@ public:
 	void AppendVersionInfo(TransactionData transaction, idx_t count, idx_t row_group_start, idx_t row_group_end);
 	void CommitAppend(transaction_t commit_id, idx_t row_group_start, idx_t count);
 	void RevertAppend(idx_t new_count);
-	void CleanupAppend(transaction_t lowest_snapshot_bound, idx_t row_group_start, idx_t count);
+	void CleanupAppend(VisibilityBound lowest_visibility_bound, idx_t row_group_start, idx_t count);
 
 	idx_t DeleteRows(idx_t vector_idx, transaction_t transaction_id, row_t rows[], idx_t count);
 	void CommitDelete(idx_t vector_idx, transaction_t commit_id, const DeleteInfo &info);
 
-	//! Attempts to compress the per-row insert/delete ids of each vector into constants
-	//! This is possible when the ids behave identically for all transactions with a start time of at least
-	//! lowest_snapshot_bound (i.e. all active and future transactions)
+	//! Attempts to compress the per-row insert/delete ids of each vector into constants. Ids that precede
+	//! lowest_visibility_bound look the same to every active and future transaction, so they can collapse.
 	//! Cheap when nothing can have changed: the pass only runs when version ids were modified since the
 	//! last pass, or when a previous pass left ids that can still compress once older transactions finish
-	void CompressVersionIds(transaction_t lowest_snapshot_bound);
+	void CompressVersionIds(VisibilityBound lowest_visibility_bound);
 
 	vector<MetaBlockPointer> Checkpoint(RowGroupWriter &writer);
 	static shared_ptr<RowVersionManager> Deserialize(MetaBlockPointer delete_pointer, MetadataManager &manager);

--- a/src/include/duckdb/storage/table/row_version_manager.hpp
+++ b/src/include/duckdb/storage/table/row_version_manager.hpp
@@ -34,17 +34,17 @@ public:
 	void AppendVersionInfo(TransactionData transaction, idx_t count, idx_t row_group_start, idx_t row_group_end);
 	void CommitAppend(transaction_t commit_id, idx_t row_group_start, idx_t count);
 	void RevertAppend(idx_t new_count);
-	void CleanupAppend(transaction_t lowest_active_transaction, idx_t row_group_start, idx_t count);
+	void CleanupAppend(transaction_t lowest_snapshot_bound, idx_t row_group_start, idx_t count);
 
 	idx_t DeleteRows(idx_t vector_idx, transaction_t transaction_id, row_t rows[], idx_t count);
 	void CommitDelete(idx_t vector_idx, transaction_t commit_id, const DeleteInfo &info);
 
 	//! Attempts to compress the per-row insert/delete ids of each vector into constants
 	//! This is possible when the ids behave identically for all transactions with a start time of at least
-	//! lowest_active_start (i.e. all active and future transactions)
+	//! lowest_snapshot_bound (i.e. all active and future transactions)
 	//! Cheap when nothing can have changed: the pass only runs when version ids were modified since the
 	//! last pass, or when a previous pass left ids that can still compress once older transactions finish
-	void CompressVersionIds(transaction_t lowest_active_start);
+	void CompressVersionIds(transaction_t lowest_snapshot_bound);
 
 	vector<MetaBlockPointer> Checkpoint(RowGroupWriter &writer);
 	static shared_ptr<RowVersionManager> Deserialize(MetaBlockPointer delete_pointer, MetadataManager &manager);

--- a/src/include/duckdb/storage/table/table_index_list.hpp
+++ b/src/include/duckdb/storage/table/table_index_list.hpp
@@ -33,7 +33,6 @@ class TableIndexIterationHelper;
 
 struct IndexSerializationInfo {
 	case_insensitive_map_t<Value> options;
-	transaction_t checkpoint_id;
 };
 
 // IndexStorageInfo is move-only. Keep every serialized info in owned_infos and expose stable ordered references.
@@ -125,7 +124,7 @@ public:
 		other.unbound_count = 0;
 	}
 	//! Merge any changes added to deltas during a checkpoint back into the main indexes
-	void MergeCheckpointDeltas(transaction_t checkpoint_id) const;
+	void MergeCheckpointDeltas(optional_idx checkpoint_id) const;
 	//! Returns true, if all indexes
 	//! Find the foreign key matching the keys.
 	shared_ptr<IndexEntry> FindForeignKeyIndex(const vector<PhysicalIndex> &fk_keys, const ForeignKeyType fk_type);

--- a/src/include/duckdb/storage/table/update_segment.hpp
+++ b/src/include/duckdb/storage/table/update_segment.hpp
@@ -74,14 +74,13 @@ public:
 	typedef void (*merge_update_function_t)(UpdateInfo &base_info, Vector &base_data, UpdateInfo &update_info,
 	                                        UnifiedVectorFormat &update, row_t *ids, idx_t count,
 	                                        const SelectionVector &sel, idx_t row_group_start);
-	typedef void (*fetch_update_function_t)(transaction_t snapshot_bound, transaction_t transaction_id,
-	                                        UpdateInfo &info, Vector &result);
+	typedef void (*fetch_update_function_t)(const SnapshotView &view, UpdateInfo &info, Vector &result);
 	typedef void (*fetch_committed_function_t)(UpdateInfo &info, Vector &result);
 	typedef void (*fetch_committed_range_function_t)(UpdateInfo &info, idx_t start, idx_t end, idx_t result_offset,
 	                                                 Vector &result);
-	typedef void (*fetch_rows_function_t)(transaction_t snapshot_bound, transaction_t transaction_id, UpdateInfo &info,
-	                                      const idx_t *offsets, const SelectionVector &sel, idx_t fetch_offset,
-	                                      idx_t count, idx_t vector_offset, Vector &result, idx_t result_offset);
+	typedef void (*fetch_rows_function_t)(const SnapshotView &view, UpdateInfo &info, const idx_t *offsets,
+	                                      const SelectionVector &sel, idx_t fetch_offset, idx_t count,
+	                                      idx_t vector_offset, Vector &result, idx_t result_offset);
 	typedef void (*rollback_update_function_t)(UpdateInfo &base_info, UpdateInfo &rollback_info);
 	typedef idx_t (*statistics_update_function_t)(UpdateSegment *segment, SegmentStatistics &stats,
 	                                              UnifiedVectorFormat &update, idx_t count, SelectionVector &sel);

--- a/src/include/duckdb/storage/table/update_segment.hpp
+++ b/src/include/duckdb/storage/table/update_segment.hpp
@@ -74,12 +74,12 @@ public:
 	typedef void (*merge_update_function_t)(UpdateInfo &base_info, Vector &base_data, UpdateInfo &update_info,
 	                                        UnifiedVectorFormat &update, row_t *ids, idx_t count,
 	                                        const SelectionVector &sel, idx_t row_group_start);
-	typedef void (*fetch_update_function_t)(transaction_t start_time, transaction_t transaction_id, UpdateInfo &info,
-	                                        Vector &result);
+	typedef void (*fetch_update_function_t)(transaction_t snapshot_bound, transaction_t transaction_id,
+	                                        UpdateInfo &info, Vector &result);
 	typedef void (*fetch_committed_function_t)(UpdateInfo &info, Vector &result);
 	typedef void (*fetch_committed_range_function_t)(UpdateInfo &info, idx_t start, idx_t end, idx_t result_offset,
 	                                                 Vector &result);
-	typedef void (*fetch_rows_function_t)(transaction_t start_time, transaction_t transaction_id, UpdateInfo &info,
+	typedef void (*fetch_rows_function_t)(transaction_t snapshot_bound, transaction_t transaction_id, UpdateInfo &info,
 	                                      const idx_t *offsets, const SelectionVector &sel, idx_t fetch_offset,
 	                                      idx_t count, idx_t vector_offset, Vector &result, idx_t result_offset);
 	typedef void (*rollback_update_function_t)(UpdateInfo &base_info, UpdateInfo &rollback_info);

--- a/src/include/duckdb/transaction/cleanup_state.hpp
+++ b/src/include/duckdb/transaction/cleanup_state.hpp
@@ -22,7 +22,7 @@ struct UpdateInfo;
 
 class CleanupState {
 public:
-	explicit CleanupState(DuckTransaction &transaction, transaction_t lowest_active_transaction,
+	explicit CleanupState(DuckTransaction &transaction, transaction_t lowest_snapshot_bound,
 	                      ActiveTransactionState transaction_state);
 
 public:
@@ -30,7 +30,7 @@ public:
 
 private:
 	//! Lowest active transaction
-	transaction_t lowest_active_transaction;
+	transaction_t lowest_snapshot_bound;
 	ActiveTransactionState transaction_state;
 	//! While cleaning up, we remove data from any delta indexes we added data to during the commit
 	IndexDataRemover index_data_remover;

--- a/src/include/duckdb/transaction/cleanup_state.hpp
+++ b/src/include/duckdb/transaction/cleanup_state.hpp
@@ -22,7 +22,7 @@ struct UpdateInfo;
 
 class CleanupState {
 public:
-	explicit CleanupState(DuckTransaction &transaction, transaction_t lowest_snapshot_bound,
+	explicit CleanupState(DuckTransaction &transaction, VisibilityBound lowest_visibility_bound,
 	                      ActiveTransactionState transaction_state);
 
 public:
@@ -30,7 +30,7 @@ public:
 
 private:
 	//! Lowest active transaction
-	transaction_t lowest_snapshot_bound;
+	VisibilityBound lowest_visibility_bound;
 	ActiveTransactionState transaction_state;
 	//! While cleaning up, we remove data from any delta indexes we added data to during the commit
 	IndexDataRemover index_data_remover;

--- a/src/include/duckdb/transaction/duck_transaction.hpp
+++ b/src/include/duckdb/transaction/duck_transaction.hpp
@@ -77,7 +77,7 @@ public:
 	//! Rollback
 	ErrorData Rollback();
 	//! Cleanup the undo buffer
-	void Cleanup(transaction_t lowest_snapshot_bound);
+	void Cleanup(VisibilityBound lowest_visibility_bound);
 
 	bool ChangesMade();
 	UndoBufferProperties GetUndoProperties();
@@ -93,6 +93,7 @@ public:
 	bool IsDuckTransaction() const override {
 		return true;
 	}
+	SnapshotView GetSnapshotView() const override;
 
 	unique_ptr<StorageLockKey> TryGetCheckpointLock();
 

--- a/src/include/duckdb/transaction/duck_transaction.hpp
+++ b/src/include/duckdb/transaction/duck_transaction.hpp
@@ -77,7 +77,7 @@ public:
 	//! Rollback
 	ErrorData Rollback();
 	//! Cleanup the undo buffer
-	void Cleanup(transaction_t lowest_active_transaction);
+	void Cleanup(transaction_t lowest_snapshot_bound);
 
 	bool ChangesMade();
 	UndoBufferProperties GetUndoProperties();

--- a/src/include/duckdb/transaction/duck_transaction_manager.hpp
+++ b/src/include/duckdb/transaction/duck_transaction_manager.hpp
@@ -21,8 +21,8 @@ struct UndoBufferProperties;
 //! CleanupInfo collects transactions awaiting cleanup.
 //! This ensures we can clean up after releasing the transaction lock.
 struct DuckCleanupInfo {
-	//! All transactions in a cleanup info share the same lowest_start_time.
-	transaction_t lowest_start_time;
+	//! All transactions in a cleanup info share the same lowest_snapshot_bound.
+	transaction_t lowest_snapshot_bound;
 	vector<unique_ptr<DuckTransaction>> transactions;
 
 	void Cleanup();
@@ -51,16 +51,20 @@ public:
 	transaction_t LowestActiveId() const {
 		return lowest_active_id;
 	}
-	transaction_t LowestActiveStart() const {
-		return lowest_active_start;
+	transaction_t LowestSnapshotBound() const {
+		return lowest_snapshot_bound;
 	}
 	transaction_t GetLastCommit() const {
 		return last_commit;
 	}
-	transaction_t GetActiveCheckpoint() const {
-		return active_checkpoint;
+	optional_idx GetActiveCheckpoint() const {
+		auto id = active_checkpoint.load();
+		return id == 0 ? optional_idx() : optional_idx(id);
 	}
-	void SetActiveCheckpoint(transaction_t checkpoint_id);
+	idx_t NextCheckpointId() {
+		return ++next_checkpoint_id;
+	}
+	void SetActiveCheckpoint(idx_t checkpoint_id);
 	void ResetActiveCheckpoint();
 
 	bool IsDuckTransactionManager() override {
@@ -125,11 +129,13 @@ private:
 	//! The lowest active transaction id
 	atomic<transaction_t> lowest_active_id;
 	//! The lowest active transaction timestamp
-	atomic<transaction_t> lowest_active_start;
+	atomic<transaction_t> lowest_snapshot_bound;
 	//! The last commit timestamp
 	atomic<transaction_t> last_commit;
-	//! The currently active checkpoint
-	atomic<transaction_t> active_checkpoint;
+	//! The currently active checkpoint, zero when none is running
+	atomic<idx_t> active_checkpoint;
+	//! Source of checkpoint identities
+	atomic<idx_t> next_checkpoint_id = {0};
 	//! Set of currently running transactions
 	vector<unique_ptr<DuckTransaction>> active_transactions;
 	//! Set of recently committed transactions

--- a/src/include/duckdb/transaction/duck_transaction_manager.hpp
+++ b/src/include/duckdb/transaction/duck_transaction_manager.hpp
@@ -21,8 +21,8 @@ struct UndoBufferProperties;
 //! CleanupInfo collects transactions awaiting cleanup.
 //! This ensures we can clean up after releasing the transaction lock.
 struct DuckCleanupInfo {
-	//! All transactions in a cleanup info share the same lowest_snapshot_bound.
-	transaction_t lowest_snapshot_bound;
+	//! All transactions in a cleanup info share the same lowest_visibility_bound.
+	VisibilityBound lowest_visibility_bound;
 	vector<unique_ptr<DuckTransaction>> transactions;
 
 	void Cleanup();
@@ -51,8 +51,8 @@ public:
 	transaction_t LowestActiveId() const {
 		return lowest_active_id;
 	}
-	transaction_t LowestSnapshotBound() const {
-		return lowest_snapshot_bound;
+	VisibilityBound LowestVisibilityBound() const {
+		return lowest_visibility_bound;
 	}
 	transaction_t GetLastCommit() const {
 		return last_commit;
@@ -128,8 +128,9 @@ private:
 	transaction_t current_transaction_id;
 	//! The lowest active transaction id
 	atomic<transaction_t> lowest_active_id;
-	//! The lowest active transaction timestamp
-	atomic<transaction_t> lowest_snapshot_bound;
+	//! The lowest bound any active transaction reads at. A version preceding it is visible to
+	//! every active transaction, so whatever it supersedes can be cleaned up or compacted
+	atomic<VisibilityBound> lowest_visibility_bound;
 	//! The last commit timestamp
 	atomic<transaction_t> last_commit;
 	//! The currently active checkpoint, zero when none is running

--- a/src/include/duckdb/transaction/transaction.hpp
+++ b/src/include/duckdb/transaction/transaction.hpp
@@ -65,6 +65,10 @@ public:
 	virtual bool IsDuckTransaction() const {
 		return false;
 	}
+	//! What this transaction sees. A transaction without MVCC state of its own sees everything.
+	virtual SnapshotView GetSnapshotView() const {
+		return SnapshotView(transaction_t(-1), VisibilityBound::IncludingUncommitted());
+	}
 
 public:
 	template <class TARGET>

--- a/src/include/duckdb/transaction/transaction_data.hpp
+++ b/src/include/duckdb/transaction/transaction_data.hpp
@@ -17,15 +17,28 @@ class Transaction;
 
 struct TransactionData {
 	TransactionData(DuckTransaction &transaction_p); // NOLINT: allow implicit conversion
-	TransactionData(transaction_t transaction_id_p, transaction_t start_time_p);
+	TransactionData(transaction_t transaction_id_p, transaction_t snapshot_bound_p);
 
 	optional_ptr<DuckTransaction> transaction;
 	transaction_t transaction_id;
-	transaction_t start_time;
+	transaction_t snapshot_bound;
 
 	static TransactionData Committed() {
 		return TransactionData(MAX_TRANSACTION_ID, 0);
 	}
 };
+
+//! Commit ids fall below TRANSACTION_ID_START and transaction ids above it, so a stamp says by
+//! itself whether the transaction that wrote it committed. Catalog versions use the same split.
+inline bool IsCommitted(transaction_t timestamp) {
+	return timestamp < TRANSACTION_ID_START;
+}
+
+//! All stamps < snapshot_bound are visible to the snapshot; all stamps >= it are invisible. Not
+//! every bound is a transaction's start time: callers also derive one from a commit id, or from
+//! the last commit.
+inline bool VisibleToSnapshot(transaction_t timestamp, transaction_t snapshot_bound) {
+	return timestamp < snapshot_bound;
+}
 
 } // namespace duckdb

--- a/src/include/duckdb/transaction/transaction_data.hpp
+++ b/src/include/duckdb/transaction/transaction_data.hpp
@@ -15,30 +15,42 @@ namespace duckdb {
 class DuckTransaction;
 class Transaction;
 
-struct TransactionData {
-	TransactionData(DuckTransaction &transaction_p); // NOLINT: allow implicit conversion
-	TransactionData(transaction_t transaction_id_p, transaction_t snapshot_bound_p);
+inline bool IsCommitted(transaction_t timestamp) {
+	return timestamp <= MAX_COMMIT_ID;
+}
 
-	optional_ptr<DuckTransaction> transaction;
+//! What a transaction sees: everything before its exclusive bound, plus its own writes.
+struct SnapshotView {
+	SnapshotView(transaction_t transaction_id_p, VisibilityBound visibility_bound_p)
+	    : transaction_id(transaction_id_p), visibility_bound(visibility_bound_p) {
+	}
+
+	//! The reading transaction, so that its own writes are visible to it
 	transaction_t transaction_id;
-	transaction_t snapshot_bound;
+	//! Exclusive: timestamps below it are visible
+	VisibilityBound visibility_bound;
 
-	static TransactionData Committed() {
-		return TransactionData(MAX_TRANSACTION_ID, 0);
+	//! Below the bound, or written by this transaction
+	bool Sees(transaction_t timestamp) const {
+		return timestamp < visibility_bound || timestamp == transaction_id;
 	}
 };
 
-//! Commit ids fall below TRANSACTION_ID_START and transaction ids above it, so a stamp says by
-//! itself whether the transaction that wrote it committed. Catalog versions use the same split.
-inline bool IsCommitted(transaction_t timestamp) {
-	return timestamp < TRANSACTION_ID_START;
-}
+struct TransactionData {
+	TransactionData(DuckTransaction &transaction_p); // NOLINT: allow implicit conversion
+	TransactionData(transaction_t transaction_id_p, VisibilityBound visibility_bound_p);
 
-//! All stamps < snapshot_bound are visible to the snapshot; all stamps >= it are invisible. Not
-//! every bound is a transaction's start time: callers also derive one from a commit id, or from
-//! the last commit.
-inline bool VisibleToSnapshot(transaction_t timestamp, transaction_t snapshot_bound) {
-	return timestamp < snapshot_bound;
-}
+	optional_ptr<DuckTransaction> transaction;
+	SnapshotView view;
+
+	transaction_t GetTransactionId() const {
+		return view.transaction_id;
+	}
+
+	//! For writes into a collection private to one transaction
+	static TransactionData Unversioned() {
+		return TransactionData(0, VisibilityBound::Before(0));
+	}
+};
 
 } // namespace duckdb

--- a/src/include/duckdb/transaction/undo_buffer.hpp
+++ b/src/include/duckdb/transaction/undo_buffer.hpp
@@ -54,7 +54,7 @@ public:
 	UndoBufferProperties GetProperties();
 
 	//! Cleanup the undo buffer
-	void Cleanup(transaction_t lowest_snapshot_bound);
+	void Cleanup(VisibilityBound lowest_visibility_bound);
 	//! Commit the changes made in the UndoBuffer: should be called on commit
 	void WriteToWAL(WriteAheadLog &wal, optional_ptr<StorageCommitState> commit_state);
 	//! Iterate the undo buffer and commit each entry. Deferred drop side effects accumulate in

--- a/src/include/duckdb/transaction/undo_buffer.hpp
+++ b/src/include/duckdb/transaction/undo_buffer.hpp
@@ -54,7 +54,7 @@ public:
 	UndoBufferProperties GetProperties();
 
 	//! Cleanup the undo buffer
-	void Cleanup(transaction_t lowest_active_transaction);
+	void Cleanup(transaction_t lowest_snapshot_bound);
 	//! Commit the changes made in the UndoBuffer: should be called on commit
 	void WriteToWAL(WriteAheadLog &wal, optional_ptr<StorageCommitState> commit_state);
 	//! Iterate the undo buffer and commit each entry. Deferred drop side effects accumulate in

--- a/src/include/duckdb/transaction/update_info.hpp
+++ b/src/include/duckdb/transaction/update_info.hpp
@@ -58,29 +58,28 @@ struct UpdateInfo {
 		return reinterpret_cast<T *>(GetValues());
 	}
 
-	bool AppliesToTransaction(transaction_t snapshot_bound, transaction_t transaction_id) {
+	bool AppliesToTransaction(const SnapshotView &view) {
 		// these tuples are either committed outside this transaction's snapshot or not committed yet, use
 		// tuples stored in this version
-		if (version_number == TRANSACTION_ID_START - 1) {
+		if (version_number == MAX_COMMIT_ID) {
 			// dummy transaction number for the root element - should always match
 			return true;
 		}
-		return !VisibleToSnapshot(version_number, snapshot_bound) && version_number != transaction_id;
+		return !view.Sees(version_number.load());
 	}
 
 	//! Loop over the update chain and execute the specified callback on all UpdateInfo's that are relevant for that
 	//! transaction in-order of newest to oldest
 	template <class T>
-	static void UpdatesForTransaction(UpdateInfo &current, transaction_t snapshot_bound, transaction_t transaction_id,
-	                                  T &&callback) {
-		if (current.AppliesToTransaction(snapshot_bound, transaction_id)) {
+	static void UpdatesForTransaction(UpdateInfo &current, const SnapshotView &view, T &&callback) {
+		if (current.AppliesToTransaction(view)) {
 			callback(current);
 		}
 		auto update_ptr = current.next;
 		while (update_ptr.IsSet()) {
 			auto pin = update_ptr.Pin();
 			auto &info = Get(pin);
-			if (info.AppliesToTransaction(snapshot_bound, transaction_id)) {
+			if (info.AppliesToTransaction(view)) {
 				callback(info);
 			}
 			update_ptr = info.next;

--- a/src/include/duckdb/transaction/update_info.hpp
+++ b/src/include/duckdb/transaction/update_info.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "duckdb/common/constants.hpp"
+#include "duckdb/transaction/transaction_data.hpp"
 #include "duckdb/common/types/vector.hpp"
 #include "duckdb/common/types/validity_mask.hpp"
 #include "duckdb/transaction/undo_buffer_allocator.hpp"
@@ -57,29 +58,29 @@ struct UpdateInfo {
 		return reinterpret_cast<T *>(GetValues());
 	}
 
-	bool AppliesToTransaction(transaction_t start_time, transaction_t transaction_id) {
-		// these tuples were either committed AFTER this transaction started or are not committed yet, use
+	bool AppliesToTransaction(transaction_t snapshot_bound, transaction_t transaction_id) {
+		// these tuples are either committed outside this transaction's snapshot or not committed yet, use
 		// tuples stored in this version
 		if (version_number == TRANSACTION_ID_START - 1) {
 			// dummy transaction number for the root element - should always match
 			return true;
 		}
-		return version_number > start_time && version_number != transaction_id;
+		return !VisibleToSnapshot(version_number, snapshot_bound) && version_number != transaction_id;
 	}
 
 	//! Loop over the update chain and execute the specified callback on all UpdateInfo's that are relevant for that
 	//! transaction in-order of newest to oldest
 	template <class T>
-	static void UpdatesForTransaction(UpdateInfo &current, transaction_t start_time, transaction_t transaction_id,
+	static void UpdatesForTransaction(UpdateInfo &current, transaction_t snapshot_bound, transaction_t transaction_id,
 	                                  T &&callback) {
-		if (current.AppliesToTransaction(start_time, transaction_id)) {
+		if (current.AppliesToTransaction(snapshot_bound, transaction_id)) {
 			callback(current);
 		}
 		auto update_ptr = current.next;
 		while (update_ptr.IsSet()) {
 			auto pin = update_ptr.Pin();
 			auto &info = Get(pin);
-			if (info.AppliesToTransaction(start_time, transaction_id)) {
+			if (info.AppliesToTransaction(snapshot_bound, transaction_id)) {
 				callback(info);
 			}
 			update_ptr = info.next;

--- a/src/storage/checkpoint/table_data_writer.cpp
+++ b/src/storage/checkpoint/table_data_writer.cpp
@@ -195,7 +195,6 @@ void SingleFileTableDataWriter::FinalizeTable(const TableStatistics &global_stat
 	if (!v1_0_0_storage) {
 		serialization_info.options.emplace("v1_0_0_storage", v1_0_0_storage);
 	}
-	serialization_info.checkpoint_id = GetCheckpointOptions().transaction_id;
 
 	auto index_storage_infos = info.GetIndexes().SerializeToDisk(context, serialization_info);
 

--- a/src/storage/checkpoint_manager.cpp
+++ b/src/storage/checkpoint_manager.cpp
@@ -67,7 +67,7 @@ void ActiveCheckpointWrapper::GetCheckpointTransaction(CheckpointOptions &option
 	transaction.SetIsCheckpointTransaction();
 	checkpoint_transaction = &transaction;
 	options.checkpoint_id = transaction_manager.NextCheckpointId();
-	options.snapshot_bound = transaction.start_time;
+	options.visibility_bound = VisibilityBound::Before(transaction.start_time);
 	transaction_manager.SetActiveCheckpoint(options.checkpoint_id.GetIndex());
 }
 

--- a/src/storage/checkpoint_manager.cpp
+++ b/src/storage/checkpoint_manager.cpp
@@ -66,8 +66,9 @@ void ActiveCheckpointWrapper::GetCheckpointTransaction(CheckpointOptions &option
 	auto &transaction = DuckTransaction::Get(*checkpoint_context, db);
 	transaction.SetIsCheckpointTransaction();
 	checkpoint_transaction = &transaction;
-	options.transaction_id = transaction.start_time;
-	transaction_manager.SetActiveCheckpoint(transaction.start_time);
+	options.checkpoint_id = transaction_manager.NextCheckpointId();
+	options.snapshot_bound = transaction.start_time;
+	transaction_manager.SetActiveCheckpoint(options.checkpoint_id.GetIndex());
 }
 
 void ActiveCheckpointWrapper::Commit() {
@@ -364,7 +365,7 @@ void SingleFileCheckpointWriter::CreateCheckpoint() {
 		auto &storage = table.GetStorage();
 		auto &table_info = storage.GetDataTableInfo();
 		auto &index_list = table_info->GetIndexes();
-		index_list.MergeCheckpointDeltas(options.transaction_id);
+		index_list.MergeCheckpointDeltas(options.checkpoint_id);
 	}
 	active_checkpoint.Commit();
 }

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -211,7 +211,8 @@ DataTable::DataTable(ClientContext &context, DataTable &parent, idx_t changed_id
 	try {
 		// read at the commits seen so far, not at this transaction's older snapshot
 		auto &transaction_manager = DuckTransactionManager::Get(db);
-		TransactionData rewrite_visibility(transaction.transaction_id, transaction_manager.GetLastCommit() + 1);
+		TransactionData rewrite_visibility(transaction.transaction_id,
+		                                   VisibilityBound::Through(transaction_manager.GetLastCommit()));
 		row_groups = parent.row_groups->AlterType(context, changed_idx, target_type, bound_columns, cast_expr,
 		                                          rewrite_visibility);
 
@@ -418,8 +419,8 @@ void DataTableInfo::VerifyIndexBuffers() const {
 	indexes.VerifyBuffers();
 }
 
-void DataTable::CleanupAppend(transaction_t lowest_snapshot_bound, idx_t start, idx_t count) {
-	row_groups->CleanupAppend(lowest_snapshot_bound, start, count);
+void DataTable::CleanupAppend(VisibilityBound lowest_visibility_bound, idx_t start, idx_t count) {
+	row_groups->CleanupAppend(lowest_visibility_bound, start, count);
 }
 
 bool DataTable::IndexNameIsUnique(const string &name) {
@@ -538,7 +539,7 @@ void DataTable::Fetch(DuckTransaction &transaction, DataChunk &result, const vec
 
 void DataTable::FetchCommitted(DataChunk &result, const vector<StorageIndex> &column_ids, const Vector &row_identifiers,
                                idx_t fetch_count, ColumnFetchState &state) {
-	TransactionData commit_transaction(MAX_TRANSACTION_ID, TRANSACTION_ID_START - 1);
+	TransactionData commit_transaction(MAX_TRANSACTION_ID, VisibilityBound::Before(MAX_COMMIT_ID));
 	row_groups->Fetch(commit_transaction, result, column_ids, row_identifiers, fetch_count, state);
 }
 

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -418,8 +418,8 @@ void DataTableInfo::VerifyIndexBuffers() const {
 	indexes.VerifyBuffers();
 }
 
-void DataTable::CleanupAppend(transaction_t lowest_transaction, idx_t start, idx_t count) {
-	row_groups->CleanupAppend(lowest_transaction, start, count);
+void DataTable::CleanupAppend(transaction_t lowest_snapshot_bound, idx_t start, idx_t count) {
+	row_groups->CleanupAppend(lowest_snapshot_bound, start, count);
 }
 
 bool DataTable::IndexNameIsUnique(const string &name) {
@@ -1061,13 +1061,13 @@ void DataTable::AppendLock(DuckTransaction &transaction, TableAppendState &state
 	}
 }
 
-bool DataTableInfo::AppendRequiresNewRowGroup(RowGroupCollection &collection, transaction_t checkpoint_id) {
-	if (checkpoint_id == MAX_TRANSACTION_ID) {
+bool DataTableInfo::AppendRequiresNewRowGroup(RowGroupCollection &collection, optional_idx checkpoint_id) {
+	if (!checkpoint_id.IsValid()) {
 		// no active checkpoint
 		return false;
 	}
 	auto current_segment_count = collection.GetSegmentCount();
-	if (last_seen_checkpoint.IsValid() && last_seen_checkpoint.GetIndex() == checkpoint_id) {
+	if (last_seen_checkpoint.IsValid() && last_seen_checkpoint.GetIndex() == checkpoint_id.GetIndex()) {
 		// we have already seen this checkpoint
 		// however, we might still need to append a new row group if a previous append was reverted
 		return current_segment_count <= checkpoint_row_group_count.GetIndex();
@@ -1080,7 +1080,8 @@ bool DataTableInfo::AppendRequiresNewRowGroup(RowGroupCollection &collection, tr
 }
 
 optional_idx DataTableInfo::CheckpointRowGroupCount(const CheckpointOptions &options) const {
-	if (!last_seen_checkpoint.IsValid() || last_seen_checkpoint.GetIndex() != options.transaction_id) {
+	if (!last_seen_checkpoint.IsValid() || !options.checkpoint_id.IsValid() ||
+	    last_seen_checkpoint.GetIndex() != options.checkpoint_id.GetIndex()) {
 		return optional_idx();
 	}
 	return checkpoint_row_group_count;

--- a/src/storage/index_entry.cpp
+++ b/src/storage/index_entry.cpp
@@ -488,7 +488,7 @@ IndexStorageInfo IndexEntry::SerializeToWAL(const case_insensitive_map_t<Value> 
 	return owned_index->Cast<BoundIndex>().SerializeToWAL(options);
 }
 
-void IndexEntry::MergeCheckpointDeltas(const transaction_t checkpoint_id) {
+void IndexEntry::MergeCheckpointDeltas(const optional_idx checkpoint_id) {
 	auto entry_lock = lock.GetExclusiveLock();
 	// Merge any data appended to the index while the checkpoint was running.
 	if (!owned_index->IsBound()) {
@@ -576,7 +576,7 @@ ErrorData IndexDeltas::MergeCheckpointDeltas(BoundIndex &index) {
 	return ErrorData();
 }
 
-void IndexDeltas::MarkWritten(const transaction_t checkpoint_id) {
+void IndexDeltas::MarkWritten(const optional_idx checkpoint_id) {
 	checkpoint.last_written_checkpoint = checkpoint_id;
 }
 

--- a/src/storage/local_storage.cpp
+++ b/src/storage/local_storage.cpp
@@ -538,7 +538,7 @@ idx_t LocalStorage::Delete(DataTable &table, DuckTableEntry &table_entry, Vector
 	}
 
 	auto ids = FlatVector::GetDataMutable<row_t>(row_ids);
-	idx_t delete_count = storage->GetCollection().Delete(TransactionData(0, 0), table_entry, ids, count);
+	idx_t delete_count = storage->GetCollection().Delete(TransactionData::Unversioned(), table_entry, ids, count);
 	storage->deleted_rows += delete_count;
 	return delete_count;
 }
@@ -550,7 +550,7 @@ void LocalStorage::Update(DataTable &table, DuckTableEntry &table_entry, Vector 
 	D_ASSERT(storage);
 
 	auto ids = FlatVector::GetDataMutable<row_t>(row_ids);
-	storage->GetCollection().Update(TransactionData(0, 0), table_entry, ids, column_ids, updates);
+	storage->GetCollection().Update(TransactionData::Unversioned(), table_entry, ids, column_ids, updates);
 }
 
 void LocalStorage::Flush(DataTable &table, LocalTableStorage &storage, optional_ptr<StorageCommitState> commit_state) {

--- a/src/storage/local_storage.cpp
+++ b/src/storage/local_storage.cpp
@@ -161,8 +161,7 @@ ErrorData LocalTableStorage::AppendToIndexes(DuckTransaction &transaction, RowGr
 		mapped_column_ids.emplace_back(col);
 	}
 	std::sort(mapped_column_ids.begin(), mapped_column_ids.end());
-	auto active_checkpoint = transaction.GetTransactionManager().Cast<DuckTransactionManager>().GetActiveCheckpoint();
-	auto checkpoint_id = active_checkpoint == MAX_TRANSACTION_ID ? optional_idx() : active_checkpoint;
+	auto checkpoint_id = transaction.GetTransactionManager().Cast<DuckTransactionManager>().GetActiveCheckpoint();
 
 	// The bound expressions of the indexes (and their bound column references) are in relation to
 	// ALL table columns, so we create an empty table chunk based on the table types. It references

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -263,10 +263,12 @@ bool StorageManager::WALStartCheckpoint(MetaBlockPointer meta_block, CheckpointO
 		active_checkpoint.GetCheckpointTransaction(options);
 	} else {
 		auto &transaction_manager = db.GetTransactionManager().Cast<DuckTransactionManager>();
-		options.transaction_id = transaction_manager.GetLastCommit();
+		options.checkpoint_id = transaction_manager.NextCheckpointId();
+		options.snapshot_bound = transaction_manager.GetLastCommit() + 1;
 	}
 
-	DUCKDB_LOG(db.GetDatabase(), TransactionLogType, db, "Start Checkpoint", options.transaction_id);
+	D_ASSERT(options.checkpoint_id.IsValid());
+	DUCKDB_LOG(db.GetDatabase(), TransactionLogType, db, "Start Checkpoint", options.checkpoint_id.GetIndex());
 	if (!wal) {
 		return false;
 	}

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -264,7 +264,7 @@ bool StorageManager::WALStartCheckpoint(MetaBlockPointer meta_block, CheckpointO
 	} else {
 		auto &transaction_manager = db.GetTransactionManager().Cast<DuckTransactionManager>();
 		options.checkpoint_id = transaction_manager.NextCheckpointId();
-		options.snapshot_bound = transaction_manager.GetLastCommit() + 1;
+		options.visibility_bound = VisibilityBound::Through(transaction_manager.GetLastCommit());
 	}
 
 	D_ASSERT(options.checkpoint_id.IsValid());

--- a/src/storage/table/chunk_info.cpp
+++ b/src/storage/table/chunk_info.cpp
@@ -11,38 +11,38 @@
 namespace duckdb {
 
 struct StandardInsertOperator {
-	static bool UseInsertedVersion(transaction_t snapshot_bound, transaction_t transaction_id, transaction_t id) {
-		return VisibleToSnapshot(id, snapshot_bound) || id == transaction_id;
+	static bool UseInsertedVersion(const SnapshotView &view, transaction_t id) {
+		return view.Sees(id);
 	}
 };
 
 struct IncludeAllInsertedOperator {
-	static bool UseInsertedVersion(transaction_t snapshot_bound, transaction_t transaction_id, transaction_t id) {
+	static bool UseInsertedVersion(const SnapshotView &view, transaction_t id) {
 		return true;
 	}
 };
 
 struct StandardDeleteOperator {
-	static bool IsDeleted(transaction_t snapshot_bound, transaction_t transaction_id, transaction_t id) {
-		return StandardInsertOperator::UseInsertedVersion(snapshot_bound, transaction_id, id);
+	static bool IsDeleted(const SnapshotView &view, transaction_t id) {
+		return view.Sees(id);
 	}
 };
 
 struct CommittedDeleteOperator {
-	static bool IsDeleted(transaction_t snapshot_bound, transaction_t transaction_id, transaction_t id) {
-		// check if this row was deleted before the given bound
-		return VisibleToSnapshot(id, snapshot_bound);
+	static bool IsDeleted(const SnapshotView &view, transaction_t id) {
+		// check if this row was deleted before the given bound, regardless of who deleted it
+		return id < view.visibility_bound;
 	}
 };
 
 struct IncludeAllDeletedOperator {
-	static bool IsDeleted(transaction_t snapshot_bound, transaction_t transaction_id, transaction_t id) {
+	static bool IsDeleted(const SnapshotView &view, transaction_t id) {
 		return false;
 	}
 };
 
 static bool UseVersion(TransactionData transaction, transaction_t id) {
-	return StandardInsertOperator::UseInsertedVersion(transaction.snapshot_bound, transaction.transaction_id, id);
+	return transaction.view.Sees(id);
 }
 
 ChunkVectorInfo::ChunkVectorInfo(FixedSizeAllocator &allocator_p, idx_t start, transaction_t insert_id_p)
@@ -66,19 +66,19 @@ ChunkVectorInfo::~ChunkVectorInfo() {
 }
 
 template <class INSERT_OP, class DELETE_OP>
-idx_t ChunkVectorInfo::TemplatedGetSelVector(transaction_t snapshot_bound, transaction_t transaction_id,
-                                             optional_ptr<SelectionVector> sel_vector, idx_t max_count) const {
+idx_t ChunkVectorInfo::TemplatedGetSelVector(const SnapshotView &view, optional_ptr<SelectionVector> sel_vector,
+                                             idx_t max_count) const {
 	switch (delete_state) {
 	case DeleteIdState::CONSTANT: {
 		// all tuples have the same deleted id
-		if (DELETE_OP::IsDeleted(snapshot_bound, transaction_id, ConstantDeleteId())) {
+		if (DELETE_OP::IsDeleted(view, ConstantDeleteId())) {
 			// all tuples are deleted
 			return 0;
 		}
 		// no tuples are deleted: we only have to check the inserted ids
 		if (HasConstantInsertionId()) {
 			// all tuples have the same inserted id as well
-			if (INSERT_OP::UseInsertedVersion(snapshot_bound, transaction_id, ConstantInsertId())) {
+			if (INSERT_OP::UseInsertedVersion(view, ConstantInsertId())) {
 				return max_count;
 			} else {
 				return 0;
@@ -90,7 +90,7 @@ idx_t ChunkVectorInfo::TemplatedGetSelVector(transaction_t snapshot_bound, trans
 
 		idx_t count = 0;
 		for (idx_t i = 0; i < max_count; i++) {
-			if (!INSERT_OP::UseInsertedVersion(snapshot_bound, transaction_id, inserted[i])) {
+			if (!INSERT_OP::UseInsertedVersion(view, inserted[i])) {
 				continue;
 			}
 			if (sel_vector) {
@@ -103,9 +103,9 @@ idx_t ChunkVectorInfo::TemplatedGetSelVector(transaction_t snapshot_bound, trans
 	case DeleteIdState::MASKED: {
 		// every deleted row shares mask_delete_id and alive rows are NOT_DELETED_ID (never deleted), so the
 		// delete decision is a single constant for the whole vector
-		const bool masked_deleted = DELETE_OP::IsDeleted(snapshot_bound, transaction_id, mask_delete_id);
+		const bool masked_deleted = DELETE_OP::IsDeleted(view, mask_delete_id);
 		if (HasConstantInsertionId()) {
-			if (!INSERT_OP::UseInsertedVersion(snapshot_bound, transaction_id, ConstantInsertId())) {
+			if (!INSERT_OP::UseInsertedVersion(view, ConstantInsertId())) {
 				return 0;
 			}
 			if (!masked_deleted) {
@@ -149,7 +149,7 @@ idx_t ChunkVectorInfo::TemplatedGetSelVector(transaction_t snapshot_bound, trans
 		auto inserted = insert_segment.GetPtr<transaction_t>();
 		idx_t count = 0;
 		for (idx_t i = 0; i < max_count; i++) {
-			if (!INSERT_OP::UseInsertedVersion(snapshot_bound, transaction_id, inserted[i])) {
+			if (!INSERT_OP::UseInsertedVersion(view, inserted[i])) {
 				continue;
 			}
 			if (masked_deleted && deleted_mask.RowIsValid(i)) {
@@ -165,7 +165,7 @@ idx_t ChunkVectorInfo::TemplatedGetSelVector(transaction_t snapshot_bound, trans
 	}
 	case DeleteIdState::ARRAY: {
 		if (HasConstantInsertionId()) {
-			if (!INSERT_OP::UseInsertedVersion(snapshot_bound, transaction_id, ConstantInsertId())) {
+			if (!INSERT_OP::UseInsertedVersion(view, ConstantInsertId())) {
 				return 0;
 			}
 			// have to check deleted flag
@@ -173,7 +173,7 @@ idx_t ChunkVectorInfo::TemplatedGetSelVector(transaction_t snapshot_bound, trans
 			auto segment = allocator.GetHandle(GetDeletedPointer());
 			auto deleted = segment.GetPtr<transaction_t>();
 			for (idx_t i = 0; i < max_count; i++) {
-				if (DELETE_OP::IsDeleted(snapshot_bound, transaction_id, deleted[i])) {
+				if (DELETE_OP::IsDeleted(view, deleted[i])) {
 					continue;
 				}
 				if (sel_vector) {
@@ -192,10 +192,10 @@ idx_t ChunkVectorInfo::TemplatedGetSelVector(transaction_t snapshot_bound, trans
 		auto delete_segment = allocator.GetHandle(GetDeletedPointer());
 		auto deleted = delete_segment.GetPtr<transaction_t>();
 		for (idx_t i = 0; i < max_count; i++) {
-			if (!INSERT_OP::UseInsertedVersion(snapshot_bound, transaction_id, inserted[i])) {
+			if (!INSERT_OP::UseInsertedVersion(view, inserted[i])) {
 				continue;
 			}
-			if (DELETE_OP::IsDeleted(snapshot_bound, transaction_id, deleted[i])) {
+			if (DELETE_OP::IsDeleted(view, deleted[i])) {
 				continue;
 			}
 			if (sel_vector) {
@@ -215,30 +215,30 @@ idx_t ChunkVectorInfo::GetSelVector(ScanOptions options, optional_ptr<SelectionV
 	auto &transaction = options.transaction;
 	if (options.insert_type == InsertedScanType::STANDARD) {
 		if (options.delete_type == DeletedScanType::STANDARD) {
-			return TemplatedGetSelVector<StandardInsertOperator, StandardDeleteOperator>(
-			    transaction.snapshot_bound, transaction.transaction_id, sel_vector, max_count);
+			return TemplatedGetSelVector<StandardInsertOperator, StandardDeleteOperator>(transaction.view, sel_vector,
+			                                                                             max_count);
 		}
 		if (options.delete_type == DeletedScanType::INCLUDE_ALL_DELETED) {
-			return TemplatedGetSelVector<StandardInsertOperator, IncludeAllDeletedOperator>(
-			    transaction.snapshot_bound, transaction.transaction_id, sel_vector, max_count);
+			return TemplatedGetSelVector<StandardInsertOperator, IncludeAllDeletedOperator>(transaction.view,
+			                                                                                sel_vector, max_count);
 		}
 		if (options.delete_type == DeletedScanType::OMIT_COMMITTED_DELETES) {
-			return TemplatedGetSelVector<StandardInsertOperator, CommittedDeleteOperator>(
-			    transaction.snapshot_bound, transaction.transaction_id, sel_vector, max_count);
+			return TemplatedGetSelVector<StandardInsertOperator, CommittedDeleteOperator>(transaction.view, sel_vector,
+			                                                                              max_count);
 		}
 	}
 	if (options.insert_type == InsertedScanType::ALL_ROWS) {
 		if (options.delete_type == DeletedScanType::STANDARD) {
-			return TemplatedGetSelVector<IncludeAllInsertedOperator, StandardDeleteOperator>(
-			    transaction.snapshot_bound, transaction.transaction_id, sel_vector, max_count);
+			return TemplatedGetSelVector<IncludeAllInsertedOperator, StandardDeleteOperator>(transaction.view,
+			                                                                                 sel_vector, max_count);
 		}
 		if (options.delete_type == DeletedScanType::INCLUDE_ALL_DELETED) {
 			// include all rows
 			return max_count;
 		}
 		if (options.delete_type == DeletedScanType::OMIT_COMMITTED_DELETES) {
-			return TemplatedGetSelVector<IncludeAllInsertedOperator, CommittedDeleteOperator>(
-			    transaction.snapshot_bound, transaction.transaction_id, sel_vector, max_count);
+			return TemplatedGetSelVector<IncludeAllInsertedOperator, CommittedDeleteOperator>(transaction.view,
+			                                                                                  sel_vector, max_count);
 		}
 	}
 	throw InternalException("Unsupported combination of insert / delete types in ChunkVectorInfo::GetSelVector");
@@ -488,7 +488,7 @@ void ChunkVectorInfo::VerifyCachedCompressionState() const {
 #endif
 }
 
-VersionCompressionResult ChunkVectorInfo::CompressVersionIds(transaction_t lowest_snapshot_bound) {
+VersionCompressionResult ChunkVectorInfo::CompressVersionIds(VisibilityBound lowest_visibility_bound) {
 	if (!recheck_compression) {
 		// no ids were modified since this vector last settled - only a further modification
 		// (which re-arms the check) can make it compressible, so skip re-scanning the ids
@@ -516,7 +516,7 @@ VersionCompressionResult ChunkVectorInfo::CompressVersionIds(transaction_t lowes
 					rows_alive = true;
 					continue;
 				}
-				if (!VisibleToSnapshot(deleted[i], lowest_snapshot_bound)) {
+				if (deleted[i] >= lowest_visibility_bound) {
 					// deleted, but the delete is not yet visible to all transactions
 					deletes_pending = true;
 					if (!IsCommitted(deleted[i])) {
@@ -562,7 +562,7 @@ VersionCompressionResult ChunkVectorInfo::CompressVersionIds(transaction_t lowes
 			auto segment = allocator.GetHandle(GetInsertedPointer());
 			auto inserted = segment.GetPtr<transaction_t>();
 			for (idx_t i = 0; i < STANDARD_VECTOR_SIZE; i++) {
-				if (!VisibleToSnapshot(inserted[i], lowest_snapshot_bound)) {
+				if (inserted[i] >= lowest_visibility_bound) {
 					// the insert is not yet visible to all transactions
 					can_compress = false;
 					break;
@@ -620,7 +620,7 @@ void ChunkVectorInfo::CommitAppend(transaction_t commit_id, idx_t start, idx_t e
 	}
 }
 
-bool ChunkVectorInfo::Cleanup(transaction_t lowest_snapshot_bound) const {
+bool ChunkVectorInfo::Cleanup(VisibilityBound lowest_visibility_bound) const {
 	if (AnyDeleted()) {
 		// if any rows are deleted we can't clean-up
 		return false;
@@ -632,18 +632,18 @@ bool ChunkVectorInfo::Cleanup(transaction_t lowest_snapshot_bound) const {
 
 		// from 1: index 0 holds the first append, which carries the lowest insert id
 		for (idx_t idx = 1; idx < STANDARD_VECTOR_SIZE; idx++) {
-			if (!VisibleToSnapshot(inserted[idx], lowest_snapshot_bound)) {
+			if (inserted[idx] >= lowest_visibility_bound) {
 				// not yet visible to every current and future snapshot - cannot compress
 				return false;
 			}
 		}
-	} else if (!VisibleToSnapshot(ConstantInsertId(), lowest_snapshot_bound)) {
+	} else if (ConstantInsertId() >= lowest_visibility_bound) {
 		return false;
 	}
 	return true;
 }
 
-bool ChunkVectorInfo::HasDeletes(transaction_t transaction_id) const {
+bool ChunkVectorInfo::HasDeletes(VisibilityBound visibility_bound) const {
 	if (HasConstantInsertionId() && !IsCommitted(ConstantInsertId())) {
 		// the vector was inserted by a transaction that has not committed yet
 		// the rows have to be masked as deleted when writing a checkpoint
@@ -652,20 +652,20 @@ bool ChunkVectorInfo::HasDeletes(transaction_t transaction_id) const {
 	if (!AnyDeleted()) {
 		return false;
 	}
-	if (transaction_id == MAX_TRANSACTION_ID) {
+	if (visibility_bound == VisibilityBound::IncludingUncommitted()) {
 		return true;
 	}
 	switch (delete_state) {
 	case DeleteIdState::CONSTANT:
-		return ConstantDeleteId() <= transaction_id;
+		return ConstantDeleteId() < visibility_bound;
 	case DeleteIdState::MASKED:
 		// AnyDeleted() above guaranteed at least one deleted row; they all share mask_delete_id
-		return mask_delete_id <= transaction_id;
+		return mask_delete_id < visibility_bound;
 	case DeleteIdState::ARRAY: {
 		auto segment = allocator.GetHandle(GetDeletedPointer());
 		auto deleted = segment.GetPtr<transaction_t>();
 		for (idx_t i = 0; i < STANDARD_VECTOR_SIZE; i++) {
-			if (deleted[i] <= transaction_id) {
+			if (deleted[i] < visibility_bound) {
 				return true;
 			}
 		}
@@ -806,10 +806,10 @@ transaction_t ChunkVectorInfo::ConstantDeleteId() const {
 	return constant_delete_id;
 }
 
-void ChunkVectorInfo::Write(WriteStream &writer, transaction_t snapshot_bound) const {
+void ChunkVectorInfo::Write(WriteStream &writer, VisibilityBound visibility_bound) const {
 	SelectionVector sel(STANDARD_VECTOR_SIZE);
 	transaction_t transaction_id = DConstants::INVALID_INDEX;
-	idx_t count = GetSelVector(TransactionData(transaction_id, snapshot_bound), sel, STANDARD_VECTOR_SIZE);
+	idx_t count = GetSelVector(TransactionData(transaction_id, visibility_bound), sel, STANDARD_VECTOR_SIZE);
 	if (count == STANDARD_VECTOR_SIZE) {
 		// nothing is deleted: skip writing anything
 		writer.Write<ChunkInfoType>(ChunkInfoType::EMPTY_INFO);

--- a/src/storage/table/chunk_info.cpp
+++ b/src/storage/table/chunk_info.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/storage/table/chunk_info.hpp"
 
 #include "duckdb/transaction/transaction.hpp"
+#include "duckdb/transaction/transaction_data.hpp"
 #include "duckdb/common/exception/transaction_exception.hpp"
 #include "duckdb/common/serializer/deserializer.hpp"
 #include "duckdb/common/serializer/memory_stream.hpp"
@@ -10,38 +11,38 @@
 namespace duckdb {
 
 struct StandardInsertOperator {
-	static bool UseInsertedVersion(transaction_t start_time, transaction_t transaction_id, transaction_t id) {
-		return id < start_time || id == transaction_id;
+	static bool UseInsertedVersion(transaction_t snapshot_bound, transaction_t transaction_id, transaction_t id) {
+		return VisibleToSnapshot(id, snapshot_bound) || id == transaction_id;
 	}
 };
 
 struct IncludeAllInsertedOperator {
-	static bool UseInsertedVersion(transaction_t start_time, transaction_t transaction_id, transaction_t id) {
+	static bool UseInsertedVersion(transaction_t snapshot_bound, transaction_t transaction_id, transaction_t id) {
 		return true;
 	}
 };
 
 struct StandardDeleteOperator {
-	static bool IsDeleted(transaction_t start_time, transaction_t transaction_id, transaction_t id) {
-		return StandardInsertOperator::UseInsertedVersion(start_time, transaction_id, id);
+	static bool IsDeleted(transaction_t snapshot_bound, transaction_t transaction_id, transaction_t id) {
+		return StandardInsertOperator::UseInsertedVersion(snapshot_bound, transaction_id, id);
 	}
 };
 
 struct CommittedDeleteOperator {
-	static bool IsDeleted(transaction_t min_start_time, transaction_t min_transaction_id, transaction_t id) {
-		// check if this row was deleted before the given start time
-		return id < min_start_time;
+	static bool IsDeleted(transaction_t snapshot_bound, transaction_t transaction_id, transaction_t id) {
+		// check if this row was deleted before the given bound
+		return VisibleToSnapshot(id, snapshot_bound);
 	}
 };
 
 struct IncludeAllDeletedOperator {
-	static bool IsDeleted(transaction_t min_start_time, transaction_t min_transaction_id, transaction_t id) {
+	static bool IsDeleted(transaction_t snapshot_bound, transaction_t transaction_id, transaction_t id) {
 		return false;
 	}
 };
 
 static bool UseVersion(TransactionData transaction, transaction_t id) {
-	return StandardInsertOperator::UseInsertedVersion(transaction.start_time, transaction.transaction_id, id);
+	return StandardInsertOperator::UseInsertedVersion(transaction.snapshot_bound, transaction.transaction_id, id);
 }
 
 ChunkVectorInfo::ChunkVectorInfo(FixedSizeAllocator &allocator_p, idx_t start, transaction_t insert_id_p)
@@ -65,19 +66,19 @@ ChunkVectorInfo::~ChunkVectorInfo() {
 }
 
 template <class INSERT_OP, class DELETE_OP>
-idx_t ChunkVectorInfo::TemplatedGetSelVector(transaction_t start_time, transaction_t transaction_id,
+idx_t ChunkVectorInfo::TemplatedGetSelVector(transaction_t snapshot_bound, transaction_t transaction_id,
                                              optional_ptr<SelectionVector> sel_vector, idx_t max_count) const {
 	switch (delete_state) {
 	case DeleteIdState::CONSTANT: {
 		// all tuples have the same deleted id
-		if (DELETE_OP::IsDeleted(start_time, transaction_id, ConstantDeleteId())) {
+		if (DELETE_OP::IsDeleted(snapshot_bound, transaction_id, ConstantDeleteId())) {
 			// all tuples are deleted
 			return 0;
 		}
 		// no tuples are deleted: we only have to check the inserted ids
 		if (HasConstantInsertionId()) {
 			// all tuples have the same inserted id as well
-			if (INSERT_OP::UseInsertedVersion(start_time, transaction_id, ConstantInsertId())) {
+			if (INSERT_OP::UseInsertedVersion(snapshot_bound, transaction_id, ConstantInsertId())) {
 				return max_count;
 			} else {
 				return 0;
@@ -89,7 +90,7 @@ idx_t ChunkVectorInfo::TemplatedGetSelVector(transaction_t start_time, transacti
 
 		idx_t count = 0;
 		for (idx_t i = 0; i < max_count; i++) {
-			if (!INSERT_OP::UseInsertedVersion(start_time, transaction_id, inserted[i])) {
+			if (!INSERT_OP::UseInsertedVersion(snapshot_bound, transaction_id, inserted[i])) {
 				continue;
 			}
 			if (sel_vector) {
@@ -102,9 +103,9 @@ idx_t ChunkVectorInfo::TemplatedGetSelVector(transaction_t start_time, transacti
 	case DeleteIdState::MASKED: {
 		// every deleted row shares mask_delete_id and alive rows are NOT_DELETED_ID (never deleted), so the
 		// delete decision is a single constant for the whole vector
-		const bool masked_deleted = DELETE_OP::IsDeleted(start_time, transaction_id, mask_delete_id);
+		const bool masked_deleted = DELETE_OP::IsDeleted(snapshot_bound, transaction_id, mask_delete_id);
 		if (HasConstantInsertionId()) {
-			if (!INSERT_OP::UseInsertedVersion(start_time, transaction_id, ConstantInsertId())) {
+			if (!INSERT_OP::UseInsertedVersion(snapshot_bound, transaction_id, ConstantInsertId())) {
 				return 0;
 			}
 			if (!masked_deleted) {
@@ -148,7 +149,7 @@ idx_t ChunkVectorInfo::TemplatedGetSelVector(transaction_t start_time, transacti
 		auto inserted = insert_segment.GetPtr<transaction_t>();
 		idx_t count = 0;
 		for (idx_t i = 0; i < max_count; i++) {
-			if (!INSERT_OP::UseInsertedVersion(start_time, transaction_id, inserted[i])) {
+			if (!INSERT_OP::UseInsertedVersion(snapshot_bound, transaction_id, inserted[i])) {
 				continue;
 			}
 			if (masked_deleted && deleted_mask.RowIsValid(i)) {
@@ -164,7 +165,7 @@ idx_t ChunkVectorInfo::TemplatedGetSelVector(transaction_t start_time, transacti
 	}
 	case DeleteIdState::ARRAY: {
 		if (HasConstantInsertionId()) {
-			if (!INSERT_OP::UseInsertedVersion(start_time, transaction_id, ConstantInsertId())) {
+			if (!INSERT_OP::UseInsertedVersion(snapshot_bound, transaction_id, ConstantInsertId())) {
 				return 0;
 			}
 			// have to check deleted flag
@@ -172,7 +173,7 @@ idx_t ChunkVectorInfo::TemplatedGetSelVector(transaction_t start_time, transacti
 			auto segment = allocator.GetHandle(GetDeletedPointer());
 			auto deleted = segment.GetPtr<transaction_t>();
 			for (idx_t i = 0; i < max_count; i++) {
-				if (DELETE_OP::IsDeleted(start_time, transaction_id, deleted[i])) {
+				if (DELETE_OP::IsDeleted(snapshot_bound, transaction_id, deleted[i])) {
 					continue;
 				}
 				if (sel_vector) {
@@ -191,10 +192,10 @@ idx_t ChunkVectorInfo::TemplatedGetSelVector(transaction_t start_time, transacti
 		auto delete_segment = allocator.GetHandle(GetDeletedPointer());
 		auto deleted = delete_segment.GetPtr<transaction_t>();
 		for (idx_t i = 0; i < max_count; i++) {
-			if (!INSERT_OP::UseInsertedVersion(start_time, transaction_id, inserted[i])) {
+			if (!INSERT_OP::UseInsertedVersion(snapshot_bound, transaction_id, inserted[i])) {
 				continue;
 			}
-			if (DELETE_OP::IsDeleted(start_time, transaction_id, deleted[i])) {
+			if (DELETE_OP::IsDeleted(snapshot_bound, transaction_id, deleted[i])) {
 				continue;
 			}
 			if (sel_vector) {
@@ -215,21 +216,21 @@ idx_t ChunkVectorInfo::GetSelVector(ScanOptions options, optional_ptr<SelectionV
 	if (options.insert_type == InsertedScanType::STANDARD) {
 		if (options.delete_type == DeletedScanType::STANDARD) {
 			return TemplatedGetSelVector<StandardInsertOperator, StandardDeleteOperator>(
-			    transaction.start_time, transaction.transaction_id, sel_vector, max_count);
+			    transaction.snapshot_bound, transaction.transaction_id, sel_vector, max_count);
 		}
 		if (options.delete_type == DeletedScanType::INCLUDE_ALL_DELETED) {
 			return TemplatedGetSelVector<StandardInsertOperator, IncludeAllDeletedOperator>(
-			    transaction.start_time, transaction.transaction_id, sel_vector, max_count);
+			    transaction.snapshot_bound, transaction.transaction_id, sel_vector, max_count);
 		}
 		if (options.delete_type == DeletedScanType::OMIT_COMMITTED_DELETES) {
 			return TemplatedGetSelVector<StandardInsertOperator, CommittedDeleteOperator>(
-			    transaction.start_time, transaction.transaction_id, sel_vector, max_count);
+			    transaction.snapshot_bound, transaction.transaction_id, sel_vector, max_count);
 		}
 	}
 	if (options.insert_type == InsertedScanType::ALL_ROWS) {
 		if (options.delete_type == DeletedScanType::STANDARD) {
 			return TemplatedGetSelVector<IncludeAllInsertedOperator, StandardDeleteOperator>(
-			    transaction.start_time, transaction.transaction_id, sel_vector, max_count);
+			    transaction.snapshot_bound, transaction.transaction_id, sel_vector, max_count);
 		}
 		if (options.delete_type == DeletedScanType::INCLUDE_ALL_DELETED) {
 			// include all rows
@@ -237,7 +238,7 @@ idx_t ChunkVectorInfo::GetSelVector(ScanOptions options, optional_ptr<SelectionV
 		}
 		if (options.delete_type == DeletedScanType::OMIT_COMMITTED_DELETES) {
 			return TemplatedGetSelVector<IncludeAllInsertedOperator, CommittedDeleteOperator>(
-			    transaction.start_time, transaction.transaction_id, sel_vector, max_count);
+			    transaction.snapshot_bound, transaction.transaction_id, sel_vector, max_count);
 		}
 	}
 	throw InternalException("Unsupported combination of insert / delete types in ChunkVectorInfo::GetSelVector");
@@ -334,7 +335,7 @@ void ChunkVectorInfo::FreeDeleteData() {
 void ChunkVectorInfo::CompressDeleteToMask(transaction_t mask_id) {
 	D_ASSERT(delete_state == DeleteIdState::ARRAY);
 	// the mask can only carry a single committed id shared by every deleted row
-	D_ASSERT(mask_id < TRANSACTION_ID_START);
+	D_ASSERT(IsCommitted(mask_id));
 	// start all-valid (== all deleted), then mark the alive rows invalid
 	deleted_mask.Initialize(STANDARD_VECTOR_SIZE);
 	{
@@ -487,7 +488,7 @@ void ChunkVectorInfo::VerifyCachedCompressionState() const {
 #endif
 }
 
-VersionCompressionResult ChunkVectorInfo::CompressVersionIds(transaction_t lowest_active_start) {
+VersionCompressionResult ChunkVectorInfo::CompressVersionIds(transaction_t lowest_snapshot_bound) {
 	if (!recheck_compression) {
 		// no ids were modified since this vector last settled - only a further modification
 		// (which re-arms the check) can make it compressible, so skip re-scanning the ids
@@ -515,10 +516,10 @@ VersionCompressionResult ChunkVectorInfo::CompressVersionIds(transaction_t lowes
 					rows_alive = true;
 					continue;
 				}
-				if (deleted[i] >= lowest_active_start) {
+				if (!VisibleToSnapshot(deleted[i], lowest_snapshot_bound)) {
 					// deleted, but the delete is not yet visible to all transactions
 					deletes_pending = true;
-					if (deleted[i] >= TRANSACTION_ID_START) {
+					if (!IsCommitted(deleted[i])) {
 						// the delete is not even committed yet - the array must be kept
 						deletes_uncommitted = true;
 					}
@@ -561,7 +562,7 @@ VersionCompressionResult ChunkVectorInfo::CompressVersionIds(transaction_t lowes
 			auto segment = allocator.GetHandle(GetInsertedPointer());
 			auto inserted = segment.GetPtr<transaction_t>();
 			for (idx_t i = 0; i < STANDARD_VECTOR_SIZE; i++) {
-				if (inserted[i] >= lowest_active_start) {
+				if (!VisibleToSnapshot(inserted[i], lowest_snapshot_bound)) {
 					// the insert is not yet visible to all transactions
 					can_compress = false;
 					break;
@@ -619,7 +620,7 @@ void ChunkVectorInfo::CommitAppend(transaction_t commit_id, idx_t start, idx_t e
 	}
 }
 
-bool ChunkVectorInfo::Cleanup(transaction_t lowest_transaction) const {
+bool ChunkVectorInfo::Cleanup(transaction_t lowest_snapshot_bound) const {
 	if (AnyDeleted()) {
 		// if any rows are deleted we can't clean-up
 		return false;
@@ -629,23 +630,21 @@ bool ChunkVectorInfo::Cleanup(transaction_t lowest_transaction) const {
 		auto segment = allocator.GetHandle(GetInsertedPointer());
 		auto inserted = segment.GetPtr<transaction_t>();
 
+		// from 1: index 0 holds the first append, which carries the lowest insert id
 		for (idx_t idx = 1; idx < STANDARD_VECTOR_SIZE; idx++) {
-			if (inserted[idx] > lowest_transaction) {
-				// transaction was inserted after the lowest transaction start
-				// we still need to use an older version - cannot compress
+			if (!VisibleToSnapshot(inserted[idx], lowest_snapshot_bound)) {
+				// not yet visible to every current and future snapshot - cannot compress
 				return false;
 			}
 		}
-	} else if (ConstantInsertId() > lowest_transaction) {
-		// transaction was inserted after the lowest transaction start
-		// we still need to use an older version - cannot compress
+	} else if (!VisibleToSnapshot(ConstantInsertId(), lowest_snapshot_bound)) {
 		return false;
 	}
 	return true;
 }
 
 bool ChunkVectorInfo::HasDeletes(transaction_t transaction_id) const {
-	if (HasConstantInsertionId() && ConstantInsertId() >= TRANSACTION_ID_START) {
+	if (HasConstantInsertionId() && !IsCommitted(ConstantInsertId())) {
 		// the vector was inserted by a transaction that has not committed yet
 		// the rows have to be masked as deleted when writing a checkpoint
 		return true;
@@ -679,30 +678,30 @@ bool ChunkVectorInfo::HasDeletes(transaction_t transaction_id) const {
 
 bool ChunkVectorInfo::HasUncommittedChanges() const {
 	if (HasConstantInsertionId()) {
-		if (ConstantInsertId() >= TRANSACTION_ID_START) {
+		if (!IsCommitted(ConstantInsertId())) {
 			return true;
 		}
 	} else {
 		auto insert_segment = allocator.GetHandle(GetInsertedPointer());
 		auto inserted = insert_segment.GetPtr<transaction_t>();
 		for (idx_t i = 0; i < STANDARD_VECTOR_SIZE; i++) {
-			if (inserted[i] >= TRANSACTION_ID_START) {
+			if (!IsCommitted(inserted[i])) {
 				return true;
 			}
 		}
 	}
 	switch (delete_state) {
 	case DeleteIdState::CONSTANT:
-		return ConstantDeleteId() != NOT_DELETED_ID && ConstantDeleteId() >= TRANSACTION_ID_START;
+		return ConstantDeleteId() != NOT_DELETED_ID && !IsCommitted(ConstantDeleteId());
 	case DeleteIdState::MASKED:
 		// the mask is only ever folded from committed deletes, so mask_delete_id is always committed
-		D_ASSERT(mask_delete_id < TRANSACTION_ID_START);
+		D_ASSERT(IsCommitted(mask_delete_id));
 		return false;
 	case DeleteIdState::ARRAY: {
 		auto delete_segment = allocator.GetHandle(GetDeletedPointer());
 		auto deleted = delete_segment.GetPtr<transaction_t>();
 		for (idx_t i = 0; i < STANDARD_VECTOR_SIZE; i++) {
-			if (deleted[i] != NOT_DELETED_ID && deleted[i] >= TRANSACTION_ID_START) {
+			if (deleted[i] != NOT_DELETED_ID && !IsCommitted(deleted[i])) {
 				return true;
 			}
 		}
@@ -807,11 +806,10 @@ transaction_t ChunkVectorInfo::ConstantDeleteId() const {
 	return constant_delete_id;
 }
 
-void ChunkVectorInfo::Write(WriteStream &writer, transaction_t checkpoint_id) const {
+void ChunkVectorInfo::Write(WriteStream &writer, transaction_t snapshot_bound) const {
 	SelectionVector sel(STANDARD_VECTOR_SIZE);
-	transaction_t start_time = checkpoint_id == MAX_TRANSACTION_ID ? TRANSACTION_ID_START - 1 : checkpoint_id + 1;
 	transaction_t transaction_id = DConstants::INVALID_INDEX;
-	idx_t count = GetSelVector(TransactionData(transaction_id, start_time), sel, STANDARD_VECTOR_SIZE);
+	idx_t count = GetSelVector(TransactionData(transaction_id, snapshot_bound), sel, STANDARD_VECTOR_SIZE);
 	if (count == STANDARD_VECTOR_SIZE) {
 		// nothing is deleted: skip writing anything
 		writer.Write<ChunkInfoType>(ChunkInfoType::EMPTY_INFO);

--- a/src/storage/table/geo_column_data.cpp
+++ b/src/storage/table/geo_column_data.cpp
@@ -418,7 +418,7 @@ unique_ptr<ColumnCheckpointState> GeoColumnData::Checkpoint(const RowGroup &row_
 			scan_chunk.Reset();
 
 			auto to_scan = MinValue(total_count - scanned, static_cast<idx_t>(STANDARD_VECTOR_SIZE));
-			Scan(TransactionData::Committed(), vector_index++, scan_state, scan_chunk.data[0], to_scan);
+			Scan(TransactionData::Unversioned(), vector_index++, scan_state, scan_chunk.data[0], to_scan);
 
 			// Verify the scan chunk
 			scan_chunk.Verify(GetDatabase());
@@ -514,7 +514,7 @@ unique_ptr<ColumnCheckpointState> GeoColumnData::Checkpoint(const RowGroup &row_
 		scan_chunk.Reset();
 
 		auto to_scan = MinValue(total_count - scanned, static_cast<idx_t>(STANDARD_VECTOR_SIZE));
-		Scan(TransactionData::Committed(), vector_index++, scan_state, scan_chunk.data[0], to_scan);
+		Scan(TransactionData::Unversioned(), vector_index++, scan_state, scan_chunk.data[0], to_scan);
 
 		// Verify the scan chunk
 		scan_chunk.Verify(GetDatabase());

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -1072,7 +1072,7 @@ void RowGroup::Scan(CollectionScanState &state, DataChunk &result, TableScanType
 		start_ts = transaction_manager.GetLastCommit() + 1;
 		transaction_id = MAX_TRANSACTION_ID;
 	} else {
-		start_ts = transaction_manager.LowestActiveStart();
+		start_ts = transaction_manager.LowestSnapshotBound();
 		transaction_id = transaction_manager.LowestActiveId();
 	}
 	TransactionData transaction(transaction_id, start_ts);
@@ -1292,9 +1292,9 @@ void RowGroup::FinalizeAppend(RowGroupAppendState &state) {
 	}
 }
 
-void RowGroup::CleanupAppend(transaction_t lowest_transaction, idx_t start, idx_t count) {
+void RowGroup::CleanupAppend(transaction_t lowest_snapshot_bound, idx_t start, idx_t count) {
 	auto &vinfo = GetOrCreateVersionInfo();
-	vinfo.CleanupAppend(lowest_transaction, start, count);
+	vinfo.CleanupAppend(lowest_snapshot_bound, start, count);
 }
 
 void RowGroup::Update(TransactionData transaction, DuckTableEntry &table_entry, DataChunk &update_chunk, row_t *ids,
@@ -1918,7 +1918,7 @@ PersistentRowGroupData RowGroup::SerializeRowGroupInfo(idx_t row_group_start) co
 	return result;
 }
 
-void RowGroup::CompressVersionInfo(transaction_t lowest_active_start) {
+void RowGroup::CompressVersionInfo(transaction_t lowest_snapshot_bound) {
 	if (HasUnloadedDeletes()) {
 		// deletes were not loaded - they are still stored in their compact serialized form
 		return;
@@ -1927,7 +1927,7 @@ void RowGroup::CompressVersionInfo(transaction_t lowest_active_start) {
 	if (!vinfo) {
 		return;
 	}
-	vinfo->CompressVersionIds(lowest_active_start);
+	vinfo->CompressVersionIds(lowest_snapshot_bound);
 }
 
 vector<MetaBlockPointer> RowGroup::CheckpointDeletes(RowGroupWriter &writer) {

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -1066,16 +1066,16 @@ ScanOptions::ScanOptions(TransactionData transaction) : transaction(transaction)
 void RowGroup::Scan(CollectionScanState &state, DataChunk &result, TableScanType type) {
 	auto &transaction_manager = DuckTransactionManager::Get(GetCollection().GetAttached());
 
-	transaction_t start_ts;
+	VisibilityBound visibility_bound;
 	transaction_t transaction_id;
 	if (type == TableScanType::TABLE_SCAN_COMMITTED_ROWS) {
-		start_ts = transaction_manager.GetLastCommit() + 1;
+		visibility_bound = VisibilityBound::Through(transaction_manager.GetLastCommit());
 		transaction_id = MAX_TRANSACTION_ID;
 	} else {
-		start_ts = transaction_manager.LowestSnapshotBound();
+		visibility_bound = transaction_manager.LowestVisibilityBound();
 		transaction_id = transaction_manager.LowestActiveId();
 	}
-	TransactionData transaction(transaction_id, start_ts);
+	TransactionData transaction(transaction_id, visibility_bound);
 
 	ScanOptions options(transaction);
 	options.insert_type = InsertedScanType::ALL_ROWS;
@@ -1292,9 +1292,9 @@ void RowGroup::FinalizeAppend(RowGroupAppendState &state) {
 	}
 }
 
-void RowGroup::CleanupAppend(transaction_t lowest_snapshot_bound, idx_t start, idx_t count) {
+void RowGroup::CleanupAppend(VisibilityBound lowest_visibility_bound, idx_t start, idx_t count) {
 	auto &vinfo = GetOrCreateVersionInfo();
-	vinfo.CleanupAppend(lowest_snapshot_bound, start, count);
+	vinfo.CleanupAppend(lowest_visibility_bound, start, count);
 }
 
 void RowGroup::Update(TransactionData transaction, DuckTableEntry &table_entry, DataChunk &update_chunk, row_t *ids,
@@ -1485,7 +1485,7 @@ idx_t RowGroup::GetCommittedRowCount() {
 	if (!vinfo) {
 		return count;
 	}
-	ScanOptions options(TransactionData(0, TRANSACTION_ID_START));
+	ScanOptions options(TransactionData(0, VisibilityBound::AllCommitted()));
 	options.insert_type = InsertedScanType::ALL_ROWS;
 	options.delete_type = DeletedScanType::OMIT_COMMITTED_DELETES;
 	return vinfo->GetRowCount(options, count);
@@ -1918,7 +1918,7 @@ PersistentRowGroupData RowGroup::SerializeRowGroupInfo(idx_t row_group_start) co
 	return result;
 }
 
-void RowGroup::CompressVersionInfo(transaction_t lowest_snapshot_bound) {
+void RowGroup::CompressVersionInfo(VisibilityBound lowest_visibility_bound) {
 	if (HasUnloadedDeletes()) {
 		// deletes were not loaded - they are still stored in their compact serialized form
 		return;
@@ -1927,7 +1927,7 @@ void RowGroup::CompressVersionInfo(transaction_t lowest_snapshot_bound) {
 	if (!vinfo) {
 		return;
 	}
-	vinfo->CompressVersionIds(lowest_snapshot_bound);
+	vinfo->CompressVersionIds(lowest_visibility_bound);
 }
 
 vector<MetaBlockPointer> RowGroup::CheckpointDeletes(RowGroupWriter &writer) {
@@ -2138,7 +2138,7 @@ void VersionDeleteState::Flush() {
 	// it is possible for delete statements to delete the same tuple multiple times when combined with a USING clause
 	// in the current_info->Delete, we check which tuples are actually deleted (excluding duplicate deletions)
 	// this is returned in the actual_delete_count
-	auto actual_delete_count = info.DeleteRows(current_chunk, transaction.transaction_id, rows, count);
+	auto actual_delete_count = info.DeleteRows(current_chunk, transaction.GetTransactionId(), rows, count);
 	delete_count += actual_delete_count;
 	if (transaction.transaction && actual_delete_count > 0) {
 		// now push the delete into the undo buffer, but only if any deletes were actually performed

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -819,7 +819,7 @@ void RowGroupCollection::RevertAppendInternal(idx_t new_end_idx) {
 	D_ASSERT(next_row_id.load() >= total_rows.load());
 }
 
-void RowGroupCollection::CleanupAppend(transaction_t lowest_transaction, idx_t start, idx_t count) {
+void RowGroupCollection::CleanupAppend(transaction_t lowest_snapshot_bound, idx_t start, idx_t count) {
 	auto row_groups = GetRowGroups();
 	auto row_group = row_groups->GetSegment(start);
 	D_ASSERT(row_group);
@@ -830,7 +830,7 @@ void RowGroupCollection::CleanupAppend(transaction_t lowest_transaction, idx_t s
 		idx_t start_in_row_group = current_row - row_group->GetRowStart();
 		idx_t append_count = MinValue<idx_t>(current_row_group.count - start_in_row_group, remaining);
 
-		current_row_group.CleanupAppend(lowest_transaction, start_in_row_group, append_count);
+		current_row_group.CleanupAppend(lowest_snapshot_bound, start_in_row_group, append_count);
 
 		current_row += append_count;
 		remaining -= append_count;
@@ -1710,7 +1710,7 @@ void RowGroupCollection::Checkpoint(TableDataWriter &writer, TableStatistics &gl
 	InitializeVacuumState(checkpoint_state, vacuum_state, writer.GetRowGroupCount());
 
 	auto &transaction_manager = DuckTransactionManager::Get(GetAttached());
-	auto lowest_active_start = transaction_manager.LowestActiveStart();
+	auto lowest_snapshot_bound = transaction_manager.LowestSnapshotBound();
 	try {
 		// schedule tasks
 		idx_t total_vacuum_tasks = 0;
@@ -1734,7 +1734,7 @@ void RowGroupCollection::Checkpoint(TableDataWriter &writer, TableStatistics &gl
 				throw InternalException("RowGroup Vacuum - row group collection of row group changed");
 			}
 			// the row group is kept as-is: try to compress its version information
-			row_group.CompressVersionInfo(lowest_active_start);
+			row_group.CompressVersionInfo(lowest_snapshot_bound);
 			if (writer.GetCheckpointOptions().type != CheckpointType::VACUUM_ONLY) {
 				DUCKDB_LOG(checkpoint_state.writer.GetDatabase(), CheckpointLogType, GetAttached(), *info, segment_idx,
 				           row_group, vacuum_state.row_start);

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -612,8 +612,8 @@ bool RowGroupCollection::CanFetch(TransactionData transaction, const row_t row_i
 // Append
 //===--------------------------------------------------------------------===//
 TableAppendState::TableAppendState()
-    : row_group_append_state(*this), total_append_count(0), start_row_group(nullptr), transaction(0, 0),
-      hashes(LogicalType::HASH) {
+    : row_group_append_state(*this), total_append_count(0), start_row_group(nullptr),
+      transaction(TransactionData::Unversioned()), hashes(LogicalType::HASH) {
 }
 
 TableAppendState::~TableAppendState() {
@@ -667,7 +667,7 @@ void RowGroupCollection::InitializeAppend(TransactionData transaction, TableAppe
 }
 
 void RowGroupCollection::InitializeAppend(TableAppendState &state) {
-	TransactionData tdata(0, 0);
+	auto tdata = TransactionData::Unversioned();
 	InitializeAppend(tdata, state);
 }
 
@@ -819,7 +819,7 @@ void RowGroupCollection::RevertAppendInternal(idx_t new_end_idx) {
 	D_ASSERT(next_row_id.load() >= total_rows.load());
 }
 
-void RowGroupCollection::CleanupAppend(transaction_t lowest_snapshot_bound, idx_t start, idx_t count) {
+void RowGroupCollection::CleanupAppend(VisibilityBound lowest_visibility_bound, idx_t start, idx_t count) {
 	auto row_groups = GetRowGroups();
 	auto row_group = row_groups->GetSegment(start);
 	D_ASSERT(row_group);
@@ -830,7 +830,7 @@ void RowGroupCollection::CleanupAppend(transaction_t lowest_snapshot_bound, idx_
 		idx_t start_in_row_group = current_row - row_group->GetRowStart();
 		idx_t append_count = MinValue<idx_t>(current_row_group.count - start_in_row_group, remaining);
 
-		current_row_group.CleanupAppend(lowest_snapshot_bound, start_in_row_group, append_count);
+		current_row_group.CleanupAppend(lowest_visibility_bound, start_in_row_group, append_count);
 
 		current_row += append_count;
 		remaining -= append_count;
@@ -1029,7 +1029,7 @@ void RowGroupCollection::RemoveFromIndexes(const QueryContext &context, TableInd
 
 	ColumnFetchState state;
 	state.fetch_type = FetchType::FORCE_FETCH;
-	TransactionData commit_transaction(MAX_TRANSACTION_ID, TRANSACTION_ID_START - 1);
+	TransactionData commit_transaction(MAX_TRANSACTION_ID, VisibilityBound::Before(MAX_COMMIT_ID));
 	Fetch(commit_transaction, fetch_chunk, column_ids, row_identifiers, count, state);
 
 	// Used for index value removal.
@@ -1710,7 +1710,7 @@ void RowGroupCollection::Checkpoint(TableDataWriter &writer, TableStatistics &gl
 	InitializeVacuumState(checkpoint_state, vacuum_state, writer.GetRowGroupCount());
 
 	auto &transaction_manager = DuckTransactionManager::Get(GetAttached());
-	auto lowest_snapshot_bound = transaction_manager.LowestSnapshotBound();
+	auto lowest_visibility_bound = transaction_manager.LowestVisibilityBound();
 	try {
 		// schedule tasks
 		idx_t total_vacuum_tasks = 0;
@@ -1734,7 +1734,7 @@ void RowGroupCollection::Checkpoint(TableDataWriter &writer, TableStatistics &gl
 				throw InternalException("RowGroup Vacuum - row group collection of row group changed");
 			}
 			// the row group is kept as-is: try to compress its version information
-			row_group.CompressVersionInfo(lowest_snapshot_bound);
+			row_group.CompressVersionInfo(lowest_visibility_bound);
 			if (writer.GetCheckpointOptions().type != CheckpointType::VACUUM_ONLY) {
 				DUCKDB_LOG(checkpoint_state.writer.GetDatabase(), CheckpointLogType, GetAttached(), *info, segment_idx,
 				           row_group, vacuum_state.row_start);

--- a/src/storage/table/row_version_manager.cpp
+++ b/src/storage/table/row_version_manager.cpp
@@ -112,15 +112,15 @@ void RowVersionManager::AppendVersionInfo(TransactionData transaction, idx_t cou
 		    vector_idx == end_vector_idx ? row_group_end - end_vector_idx * STANDARD_VECTOR_SIZE : STANDARD_VECTOR_SIZE;
 		if (vector_start == 0 && vector_end == STANDARD_VECTOR_SIZE) {
 			// entire vector is encapsulated by append: store a single constant insert id
-			vector_info[vector_idx] =
-			    make_uniq<ChunkVectorInfo>(allocator, vector_idx * STANDARD_VECTOR_SIZE, transaction.transaction_id);
+			vector_info[vector_idx] = make_uniq<ChunkVectorInfo>(allocator, vector_idx * STANDARD_VECTOR_SIZE,
+			                                                     transaction.GetTransactionId());
 		} else {
 			// part of a vector is encapsulated: append to that part
 			if (!vector_info[vector_idx]) {
 				// first time appending to this vector: create new info
 				vector_info[vector_idx] = make_uniq<ChunkVectorInfo>(allocator, vector_idx * STANDARD_VECTOR_SIZE);
 			}
-			vector_info[vector_idx]->Append(vector_start, vector_end, transaction.transaction_id);
+			vector_info[vector_idx]->Append(vector_start, vector_end, transaction.GetTransactionId());
 		}
 	}
 }
@@ -143,7 +143,7 @@ void RowVersionManager::CommitAppend(transaction_t commit_id, idx_t row_group_st
 	}
 }
 
-void RowVersionManager::CleanupAppend(transaction_t lowest_snapshot_bound, idx_t row_group_start, idx_t count) {
+void RowVersionManager::CleanupAppend(VisibilityBound lowest_visibility_bound, idx_t row_group_start, idx_t count) {
 	if (count == 0) {
 		return;
 	}
@@ -165,7 +165,7 @@ void RowVersionManager::CleanupAppend(transaction_t lowest_snapshot_bound, idx_t
 		}
 		auto &info = *vector_info[vector_idx];
 		// if we wrote the entire chunk info try to compress it
-		auto cleanup = info.Cleanup(lowest_snapshot_bound);
+		auto cleanup = info.Cleanup(lowest_visibility_bound);
 		if (cleanup) {
 			vector_info[vector_idx].reset();
 		}
@@ -205,7 +205,7 @@ void RowVersionManager::CommitDelete(idx_t vector_idx, transaction_t commit_id, 
 	GetVectorInfo(vector_idx).CommitDelete(commit_id, info);
 }
 
-void RowVersionManager::CompressVersionIds(transaction_t lowest_snapshot_bound) {
+void RowVersionManager::CompressVersionIds(VisibilityBound lowest_visibility_bound) {
 	lock_guard<mutex> lock(version_lock);
 	if (!needs_compression_check) {
 		// no version ids were modified since the last pass, and the last pass left nothing
@@ -224,7 +224,7 @@ void RowVersionManager::CompressVersionIds(transaction_t lowest_snapshot_bound) 
 	}
 	bool pending = false;
 	for (auto &info : vector_info) {
-		if (info && info->CompressVersionIds(lowest_snapshot_bound) == VersionCompressionResult::PENDING) {
+		if (info && info->CompressVersionIds(lowest_visibility_bound) == VersionCompressionResult::PENDING) {
 			// some ids can still compress once the lowest active start advances - check again next pass
 			pending = true;
 		}
@@ -253,7 +253,7 @@ vector<MetaBlockPointer> RowVersionManager::Checkpoint(RowGroupWriter &writer) {
 		if (!chunk_info) {
 			continue;
 		}
-		if (!chunk_info->HasDeletes(options.snapshot_bound)) {
+		if (!chunk_info->HasDeletes(options.visibility_bound)) {
 			continue;
 		}
 		to_serialize.emplace_back(vector_idx, *chunk_info);
@@ -269,13 +269,12 @@ vector<MetaBlockPointer> RowVersionManager::Checkpoint(RowGroupWriter &writer) {
 			auto &vector_idx = entry.first;
 			auto &chunk_info = entry.second.get();
 			metadata_writer.Write<idx_t>(vector_idx);
-			chunk_info.Write(metadata_writer, options.snapshot_bound);
+			chunk_info.Write(metadata_writer, options.visibility_bound);
 		}
 		metadata_writer.Flush();
 	}
 
-	if (uncheckpointed_delete_commit.IsValid() &&
-	    VisibleToSnapshot(uncheckpointed_delete_commit.GetIndex(), options.snapshot_bound)) {
+	if (uncheckpointed_delete_commit.IsValid() && uncheckpointed_delete_commit.GetIndex() < options.visibility_bound) {
 		// the last checkpointed id was either before or on the transaction we are checkpointing
 		// nothing to checkpoint in future commits until more deletes appear
 		uncheckpointed_delete_commit = optional_idx();

--- a/src/storage/table/row_version_manager.cpp
+++ b/src/storage/table/row_version_manager.cpp
@@ -143,7 +143,7 @@ void RowVersionManager::CommitAppend(transaction_t commit_id, idx_t row_group_st
 	}
 }
 
-void RowVersionManager::CleanupAppend(transaction_t lowest_active_transaction, idx_t row_group_start, idx_t count) {
+void RowVersionManager::CleanupAppend(transaction_t lowest_snapshot_bound, idx_t row_group_start, idx_t count) {
 	if (count == 0) {
 		return;
 	}
@@ -165,7 +165,7 @@ void RowVersionManager::CleanupAppend(transaction_t lowest_active_transaction, i
 		}
 		auto &info = *vector_info[vector_idx];
 		// if we wrote the entire chunk info try to compress it
-		auto cleanup = info.Cleanup(lowest_active_transaction);
+		auto cleanup = info.Cleanup(lowest_snapshot_bound);
 		if (cleanup) {
 			vector_info[vector_idx].reset();
 		}
@@ -205,7 +205,7 @@ void RowVersionManager::CommitDelete(idx_t vector_idx, transaction_t commit_id, 
 	GetVectorInfo(vector_idx).CommitDelete(commit_id, info);
 }
 
-void RowVersionManager::CompressVersionIds(transaction_t lowest_active_start) {
+void RowVersionManager::CompressVersionIds(transaction_t lowest_snapshot_bound) {
 	lock_guard<mutex> lock(version_lock);
 	if (!needs_compression_check) {
 		// no version ids were modified since the last pass, and the last pass left nothing
@@ -224,7 +224,7 @@ void RowVersionManager::CompressVersionIds(transaction_t lowest_active_start) {
 	}
 	bool pending = false;
 	for (auto &info : vector_info) {
-		if (info && info->CompressVersionIds(lowest_active_start) == VersionCompressionResult::PENDING) {
+		if (info && info->CompressVersionIds(lowest_snapshot_bound) == VersionCompressionResult::PENDING) {
 			// some ids can still compress once the lowest active start advances - check again next pass
 			pending = true;
 		}
@@ -253,7 +253,7 @@ vector<MetaBlockPointer> RowVersionManager::Checkpoint(RowGroupWriter &writer) {
 		if (!chunk_info) {
 			continue;
 		}
-		if (!chunk_info->HasDeletes(options.transaction_id)) {
+		if (!chunk_info->HasDeletes(options.snapshot_bound)) {
 			continue;
 		}
 		to_serialize.emplace_back(vector_idx, *chunk_info);
@@ -269,12 +269,13 @@ vector<MetaBlockPointer> RowVersionManager::Checkpoint(RowGroupWriter &writer) {
 			auto &vector_idx = entry.first;
 			auto &chunk_info = entry.second.get();
 			metadata_writer.Write<idx_t>(vector_idx);
-			chunk_info.Write(metadata_writer, options.transaction_id);
+			chunk_info.Write(metadata_writer, options.snapshot_bound);
 		}
 		metadata_writer.Flush();
 	}
 
-	if (uncheckpointed_delete_commit.IsValid() && uncheckpointed_delete_commit.GetIndex() <= options.transaction_id) {
+	if (uncheckpointed_delete_commit.IsValid() &&
+	    VisibleToSnapshot(uncheckpointed_delete_commit.GetIndex(), options.snapshot_bound)) {
 		// the last checkpointed id was either before or on the transaction we are checkpointing
 		// nothing to checkpoint in future commits until more deletes appear
 		uncheckpointed_delete_commit = optional_idx();

--- a/src/storage/table/update_segment.cpp
+++ b/src/storage/table/update_segment.cpp
@@ -161,10 +161,10 @@ static void MergeValidityInfo(UpdateInfo &current, ValidityMask &result_mask) {
 	}
 }
 
-static void UpdateMergeValidity(transaction_t start_time, transaction_t transaction_id, UpdateInfo &info,
+static void UpdateMergeValidity(transaction_t snapshot_bound, transaction_t transaction_id, UpdateInfo &info,
                                 Vector &result) {
 	auto &result_mask = FlatVector::ValidityMutable(result);
-	UpdateInfo::UpdatesForTransaction(info, start_time, transaction_id,
+	UpdateInfo::UpdatesForTransaction(info, snapshot_bound, transaction_id,
 	                                  [&](UpdateInfo &current) { MergeValidityInfo(current, result_mask); });
 }
 
@@ -185,9 +185,10 @@ static void MergeUpdateInfo(UpdateInfo &current, T *result_data) {
 }
 
 template <class T>
-static void UpdateMergeFetch(transaction_t start_time, transaction_t transaction_id, UpdateInfo &info, Vector &result) {
+static void UpdateMergeFetch(transaction_t snapshot_bound, transaction_t transaction_id, UpdateInfo &info,
+                             Vector &result) {
 	auto result_data = FlatVector::GetDataMutable<T>(result);
-	UpdateInfo::UpdatesForTransaction(info, start_time, transaction_id,
+	UpdateInfo::UpdatesForTransaction(info, snapshot_bound, transaction_id,
 	                                  [&](UpdateInfo &current) { MergeUpdateInfo<T>(current, result_data); });
 }
 
@@ -248,7 +249,7 @@ void UpdateSegment::FetchUpdates(TransactionData transaction, idx_t vector_index
 	// FIXME: normalify if this is not the case... need to pass in count?
 	D_ASSERT(result.GetVectorType() == VectorType::FLAT_VECTOR);
 	auto pin = node.Pin();
-	fetch_update_function(transaction.start_time, transaction.transaction_id, UpdateInfo::Get(pin), result);
+	fetch_update_function(transaction.snapshot_bound, transaction.transaction_id, UpdateInfo::Get(pin), result);
 }
 
 UpdateNode::UpdateNode(BufferManager &manager) : allocator(manager) {
@@ -458,11 +459,11 @@ static bool FindUpdatedTuple(UpdateInfo &current, idx_t row_idx, idx_t &update_i
 	return false;
 }
 
-static void FetchRowsValidity(transaction_t start_time, transaction_t transaction_id, UpdateInfo &info,
+static void FetchRowsValidity(transaction_t snapshot_bound, transaction_t transaction_id, UpdateInfo &info,
                               const idx_t *offsets, const SelectionVector &sel, idx_t fetch_offset, idx_t count,
                               idx_t vector_offset, Vector &result, idx_t result_offset) {
 	auto &result_mask = FlatVector::ValidityMutable(result);
-	UpdateInfo::UpdatesForTransaction(info, start_time, transaction_id, [&](UpdateInfo &current) {
+	UpdateInfo::UpdatesForTransaction(info, snapshot_bound, transaction_id, [&](UpdateInfo &current) {
 		auto info_data = current.GetData<bool>();
 		for (idx_t idx = 0; idx < count; idx++) {
 			const idx_t row_idx = offsets[sel.get_index(fetch_offset + idx)] - vector_offset;
@@ -475,11 +476,11 @@ static void FetchRowsValidity(transaction_t start_time, transaction_t transactio
 }
 
 template <class T>
-static void TemplatedFetchRows(transaction_t start_time, transaction_t transaction_id, UpdateInfo &info,
+static void TemplatedFetchRows(transaction_t snapshot_bound, transaction_t transaction_id, UpdateInfo &info,
                                const idx_t *offsets, const SelectionVector &sel, idx_t fetch_offset, idx_t count,
                                idx_t vector_offset, Vector &result, idx_t result_offset) {
 	auto result_data = FlatVector::GetDataMutable<T>(result);
-	UpdateInfo::UpdatesForTransaction(info, start_time, transaction_id, [&](UpdateInfo &current) {
+	UpdateInfo::UpdatesForTransaction(info, snapshot_bound, transaction_id, [&](UpdateInfo &current) {
 		auto info_data = current.GetData<T>();
 		for (idx_t idx = 0; idx < count; idx++) {
 			const idx_t row_idx = offsets[sel.get_index(fetch_offset + idx)] - vector_offset;
@@ -558,8 +559,8 @@ void UpdateSegment::FetchRows(TransactionData transaction, const idx_t *offsets,
 		auto entry = GetUpdateNode(*lock_handle, vector_index);
 		if (entry.IsSet()) {
 			auto pin = entry.Pin();
-			fetch_rows_function(transaction.start_time, transaction.transaction_id, UpdateInfo::Get(pin), offsets, sel,
-			                    idx, vector_count, vector_offset, result, result_offset);
+			fetch_rows_function(transaction.snapshot_bound, transaction.transaction_id, UpdateInfo::Get(pin), offsets,
+			                    sel, idx, vector_count, vector_offset, result, result_offset);
 		}
 		idx += vector_count;
 	}
@@ -673,7 +674,7 @@ static void CheckForConflicts(UndoBufferPointer next_ptr, TransactionData transa
 		if (info.version_number == transaction.transaction_id) {
 			// this UpdateInfo belongs to the current transaction, set it in the node
 			node_ref = std::move(pin);
-		} else if (info.version_number > transaction.start_time) {
+		} else if (!VisibleToSnapshot(info.version_number, transaction.snapshot_bound)) {
 			// potential conflict, check that tuple ids do not conflict
 			// as both ids and info->tuples are sorted, this is similar to a merge join
 			idx_t i = 0, j = 0;

--- a/src/storage/table/update_segment.cpp
+++ b/src/storage/table/update_segment.cpp
@@ -66,7 +66,7 @@ void UpdateInfo::Print() {
 string UpdateInfo::ToString() {
 	auto &type = segment->column_data.type;
 	string result = "Update Info [" + type.ToString() + ", Count: " + to_string(N) +
-	                ", Transaction Id: " + to_string(version_number) + "]\n";
+	                ", Transaction Id: " + to_string(version_number.load()) + "]\n";
 	auto tuples = GetTuples();
 	for (idx_t i = 0; i < N; i++) {
 		result += to_string(tuples[i]) + ": " + GetValue(i).ToString() + "\n";
@@ -161,10 +161,9 @@ static void MergeValidityInfo(UpdateInfo &current, ValidityMask &result_mask) {
 	}
 }
 
-static void UpdateMergeValidity(transaction_t snapshot_bound, transaction_t transaction_id, UpdateInfo &info,
-                                Vector &result) {
+static void UpdateMergeValidity(const SnapshotView &view, UpdateInfo &info, Vector &result) {
 	auto &result_mask = FlatVector::ValidityMutable(result);
-	UpdateInfo::UpdatesForTransaction(info, snapshot_bound, transaction_id,
+	UpdateInfo::UpdatesForTransaction(info, view,
 	                                  [&](UpdateInfo &current) { MergeValidityInfo(current, result_mask); });
 }
 
@@ -185,10 +184,9 @@ static void MergeUpdateInfo(UpdateInfo &current, T *result_data) {
 }
 
 template <class T>
-static void UpdateMergeFetch(transaction_t snapshot_bound, transaction_t transaction_id, UpdateInfo &info,
-                             Vector &result) {
+static void UpdateMergeFetch(const SnapshotView &view, UpdateInfo &info, Vector &result) {
 	auto result_data = FlatVector::GetDataMutable<T>(result);
-	UpdateInfo::UpdatesForTransaction(info, snapshot_bound, transaction_id,
+	UpdateInfo::UpdatesForTransaction(info, view,
 	                                  [&](UpdateInfo &current) { MergeUpdateInfo<T>(current, result_data); });
 }
 
@@ -249,7 +247,7 @@ void UpdateSegment::FetchUpdates(TransactionData transaction, idx_t vector_index
 	// FIXME: normalify if this is not the case... need to pass in count?
 	D_ASSERT(result.GetVectorType() == VectorType::FLAT_VECTOR);
 	auto pin = node.Pin();
-	fetch_update_function(transaction.snapshot_bound, transaction.transaction_id, UpdateInfo::Get(pin), result);
+	fetch_update_function(transaction.view, UpdateInfo::Get(pin), result);
 }
 
 UpdateNode::UpdateNode(BufferManager &manager) : allocator(manager) {
@@ -459,11 +457,11 @@ static bool FindUpdatedTuple(UpdateInfo &current, idx_t row_idx, idx_t &update_i
 	return false;
 }
 
-static void FetchRowsValidity(transaction_t snapshot_bound, transaction_t transaction_id, UpdateInfo &info,
-                              const idx_t *offsets, const SelectionVector &sel, idx_t fetch_offset, idx_t count,
-                              idx_t vector_offset, Vector &result, idx_t result_offset) {
+static void FetchRowsValidity(const SnapshotView &view, UpdateInfo &info, const idx_t *offsets,
+                              const SelectionVector &sel, idx_t fetch_offset, idx_t count, idx_t vector_offset,
+                              Vector &result, idx_t result_offset) {
 	auto &result_mask = FlatVector::ValidityMutable(result);
-	UpdateInfo::UpdatesForTransaction(info, snapshot_bound, transaction_id, [&](UpdateInfo &current) {
+	UpdateInfo::UpdatesForTransaction(info, view, [&](UpdateInfo &current) {
 		auto info_data = current.GetData<bool>();
 		for (idx_t idx = 0; idx < count; idx++) {
 			const idx_t row_idx = offsets[sel.get_index(fetch_offset + idx)] - vector_offset;
@@ -476,11 +474,11 @@ static void FetchRowsValidity(transaction_t snapshot_bound, transaction_t transa
 }
 
 template <class T>
-static void TemplatedFetchRows(transaction_t snapshot_bound, transaction_t transaction_id, UpdateInfo &info,
-                               const idx_t *offsets, const SelectionVector &sel, idx_t fetch_offset, idx_t count,
-                               idx_t vector_offset, Vector &result, idx_t result_offset) {
+static void TemplatedFetchRows(const SnapshotView &view, UpdateInfo &info, const idx_t *offsets,
+                               const SelectionVector &sel, idx_t fetch_offset, idx_t count, idx_t vector_offset,
+                               Vector &result, idx_t result_offset) {
 	auto result_data = FlatVector::GetDataMutable<T>(result);
-	UpdateInfo::UpdatesForTransaction(info, snapshot_bound, transaction_id, [&](UpdateInfo &current) {
+	UpdateInfo::UpdatesForTransaction(info, view, [&](UpdateInfo &current) {
 		auto info_data = current.GetData<T>();
 		for (idx_t idx = 0; idx < count; idx++) {
 			const idx_t row_idx = offsets[sel.get_index(fetch_offset + idx)] - vector_offset;
@@ -559,8 +557,8 @@ void UpdateSegment::FetchRows(TransactionData transaction, const idx_t *offsets,
 		auto entry = GetUpdateNode(*lock_handle, vector_index);
 		if (entry.IsSet()) {
 			auto pin = entry.Pin();
-			fetch_rows_function(transaction.snapshot_bound, transaction.transaction_id, UpdateInfo::Get(pin), offsets,
-			                    sel, idx, vector_count, vector_offset, result, result_offset);
+			fetch_rows_function(transaction.view, UpdateInfo::Get(pin), offsets, sel, idx, vector_count, vector_offset,
+			                    result, result_offset);
 		}
 		idx += vector_count;
 	}
@@ -671,10 +669,10 @@ static void CheckForConflicts(UndoBufferPointer next_ptr, TransactionData transa
 	while (next_ptr.IsSet()) {
 		auto pin = next_ptr.Pin();
 		auto &info = UpdateInfo::Get(pin);
-		if (info.version_number == transaction.transaction_id) {
+		if (info.version_number == transaction.GetTransactionId()) {
 			// this UpdateInfo belongs to the current transaction, set it in the node
 			node_ref = std::move(pin);
-		} else if (!VisibleToSnapshot(info.version_number, transaction.snapshot_bound)) {
+		} else if (info.version_number.load() >= transaction.view.visibility_bound) {
 			// potential conflict, check that tuple ids do not conflict
 			// as both ids and info->tuples are sorted, this is similar to a merge join
 			idx_t i = 0, j = 0;
@@ -1334,7 +1332,7 @@ UpdateInfo *CreateEmptyUpdateInfo(TransactionData transaction, DuckTableEntry &t
                                   idx_t count, unsafe_unique_array<char> &data, idx_t row_group_start) {
 	data = make_unsafe_uniq_array_uninitialized<char>(UpdateInfo::GetAllocSize(type_size));
 	auto update_info = reinterpret_cast<UpdateInfo *>(data.get());
-	UpdateInfo::Initialize(*update_info, table_entry, transaction.transaction_id, row_group_start);
+	UpdateInfo::Initialize(*update_info, table_entry, transaction.GetTransactionId(), row_group_start);
 	return update_info;
 }
 
@@ -1502,7 +1500,7 @@ void UpdateSegment::Update(TransactionData transaction, DuckTableEntry &table_en
 		idx_t alloc_size = UpdateInfo::GetAllocSize(type_size, compact_capacity);
 		auto handle = root->allocator.Allocate(alloc_size);
 		auto &update_info = UpdateInfo::Get(handle);
-		UpdateInfo::Initialize(update_info, table_entry, TRANSACTION_ID_START - 1, row_group_start, compact_capacity);
+		UpdateInfo::Initialize(update_info, table_entry, MAX_COMMIT_ID, row_group_start, compact_capacity);
 		update_info.column_index = column_index;
 
 		InitializeUpdateInfo(update_info, ids, sel, count, vector_index, vector_offset);

--- a/src/storage/table/variant_column_data.cpp
+++ b/src/storage/table/variant_column_data.cpp
@@ -683,7 +683,7 @@ vector<shared_ptr<ColumnData>> VariantColumnData::WriteShreddedData(const RowGro
 	for (idx_t scanned = 0; scanned < total_count; scanned += STANDARD_VECTOR_SIZE) {
 		scan_chunk.Reset();
 		auto to_scan = MinValue(total_count - scanned, static_cast<idx_t>(STANDARD_VECTOR_SIZE));
-		Scan(TransactionData::Committed(), vector_index++, scan_state, scan_vector, to_scan);
+		Scan(TransactionData::Unversioned(), vector_index++, scan_state, scan_vector, to_scan);
 		append_chunk.Reset();
 
 		AppendShredded(scan_vector, append_vector, to_scan, append_data);
@@ -709,7 +709,7 @@ LogicalType VariantColumnData::GetShreddedType() {
 	for (idx_t scanned = 0; scanned < total_count; scanned += STANDARD_VECTOR_SIZE) {
 		scan_chunk.Reset();
 		auto to_scan = MinValue(total_count - scanned, static_cast<idx_t>(STANDARD_VECTOR_SIZE));
-		Scan(TransactionData::Committed(), vector_index++, scan_state, scan_vector, to_scan);
+		Scan(TransactionData::Unversioned(), vector_index++, scan_state, scan_vector, to_scan);
 		variant_stats.Update(scan_vector, to_scan);
 	}
 

--- a/src/storage/table_index_list.cpp
+++ b/src/storage/table_index_list.cpp
@@ -544,7 +544,7 @@ unique_ptr<IndexStorageInfo> TableIndexList::SerializeToWAL(const Identifier &na
 	return nullptr;
 }
 
-void TableIndexList::MergeCheckpointDeltas(const transaction_t checkpoint_id) const {
+void TableIndexList::MergeCheckpointDeltas(const optional_idx checkpoint_id) const {
 	annotated_lock_guard lock(index_entries_lock);
 	for (const auto &entry : index_entries) {
 		entry->MergeCheckpointDeltas(checkpoint_id);

--- a/src/transaction/cleanup_state.cpp
+++ b/src/transaction/cleanup_state.cpp
@@ -15,9 +15,9 @@
 
 namespace duckdb {
 
-CleanupState::CleanupState(DuckTransaction &transaction, transaction_t lowest_snapshot_bound,
+CleanupState::CleanupState(DuckTransaction &transaction, VisibilityBound lowest_visibility_bound,
                            ActiveTransactionState transaction_state)
-    : lowest_snapshot_bound(lowest_snapshot_bound), transaction_state(transaction_state),
+    : lowest_visibility_bound(lowest_visibility_bound), transaction_state(transaction_state),
       index_data_remover(transaction, QueryContext(), IndexRemovalType::DELETED_ROWS_IN_USE) {
 }
 
@@ -34,7 +34,7 @@ void CleanupState::CleanupEntry(UndoFlags type, data_ptr_t data) {
 	case UndoFlags::INSERT_TUPLE: {
 		auto info = reinterpret_cast<AppendInfo *>(data);
 		// mark the tuples as committed
-		info->table->GetStorage().CleanupAppend(lowest_snapshot_bound, info->start_row, info->count);
+		info->table->GetStorage().CleanupAppend(lowest_visibility_bound, info->start_row, info->count);
 		break;
 	}
 	case UndoFlags::DELETE_TUPLE: {

--- a/src/transaction/cleanup_state.cpp
+++ b/src/transaction/cleanup_state.cpp
@@ -15,9 +15,9 @@
 
 namespace duckdb {
 
-CleanupState::CleanupState(DuckTransaction &transaction, transaction_t lowest_active_transaction,
+CleanupState::CleanupState(DuckTransaction &transaction, transaction_t lowest_snapshot_bound,
                            ActiveTransactionState transaction_state)
-    : lowest_active_transaction(lowest_active_transaction), transaction_state(transaction_state),
+    : lowest_snapshot_bound(lowest_snapshot_bound), transaction_state(transaction_state),
       index_data_remover(transaction, QueryContext(), IndexRemovalType::DELETED_ROWS_IN_USE) {
 }
 
@@ -34,7 +34,7 @@ void CleanupState::CleanupEntry(UndoFlags type, data_ptr_t data) {
 	case UndoFlags::INSERT_TUPLE: {
 		auto info = reinterpret_cast<AppendInfo *>(data);
 		// mark the tuples as committed
-		info->table->GetStorage().CleanupAppend(lowest_active_transaction, info->start_row, info->count);
+		info->table->GetStorage().CleanupAppend(lowest_snapshot_bound, info->start_row, info->count);
 		break;
 	}
 	case UndoFlags::DELETE_TUPLE: {

--- a/src/transaction/commit_state.cpp
+++ b/src/transaction/commit_state.cpp
@@ -295,7 +295,7 @@ void CommitState::CommitEntry(UndoFlags type, data_ptr_t data, CommitInfo &info)
 				new_entry.set->VerifyExistenceOfDependency(commit_id, new_entry);
 			}
 		} else if (new_entry.type == CatalogType::DELETED_ENTRY && old_entry.set) {
-			old_entry.set->CommitDrop(commit_id, transaction.start_time, old_entry);
+			old_entry.set->CommitDrop(commit_id, VisibilityBound::Before(transaction.start_time), old_entry);
 		}
 		// Grab a write lock on the catalog
 		auto &duck_catalog = catalog.Cast<DuckCatalog>();
@@ -318,9 +318,11 @@ void CommitState::CommitEntry(UndoFlags type, data_ptr_t data, CommitInfo &info)
 				// Transaction view at bind time (what the trigger saw when it was created).
 				// Use commit_id as the transaction_id so that earlier catalog changes in this
 				// same transaction (already stamped with commit_id) are visible here.
-				CatalogTransaction bind_txn(duck_catalog.GetDatabase(), commit_id, transaction.start_time);
+				CatalogTransaction bind_txn(duck_catalog.GetDatabase(), commit_id,
+				                            VisibilityBound::Before(transaction.start_time));
 				// Transaction view at commit time (all changes committed before this commit)
-				CatalogTransaction commit_txn(duck_catalog.GetDatabase(), MAX_TRANSACTION_ID, commit_id + 1);
+				CatalogTransaction commit_txn(duck_catalog.GetDatabase(), MAX_TRANSACTION_ID,
+				                              VisibilityBound::Through(commit_id));
 
 				auto bound_table = trig.schema.GetEntry(bind_txn, CatalogType::TABLE_ENTRY, trig.base_table->Table());
 				auto current_table =

--- a/src/transaction/commit_state.cpp
+++ b/src/transaction/commit_state.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/transaction/commit_state.hpp"
+#include "duckdb/transaction/transaction_data.hpp"
 
 #include "duckdb/catalog/catalog_entry/duck_index_entry.hpp"
 #include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
@@ -115,8 +116,7 @@ void IndexDataRemover::Flush(DataTable &table, row_t *row_numbers, idx_t count) 
 	// set up the row identifiers vector
 	Vector row_identifiers(LogicalType::ROW_TYPE, data_ptr_cast(row_numbers), count);
 
-	auto active_checkpoint = transaction.GetTransactionManager().Cast<DuckTransactionManager>().GetActiveCheckpoint();
-	auto checkpoint_id = active_checkpoint == MAX_TRANSACTION_ID ? optional_idx() : active_checkpoint;
+	auto checkpoint_id = transaction.GetTransactionManager().Cast<DuckTransactionManager>().GetActiveCheckpoint();
 	// delete the tuples from all the indexes.
 	// If there is any issue with removal, a FatalException must be thrown since there may be a corruption of
 	// data, hence the transaction cannot be guaranteed.
@@ -139,6 +139,7 @@ CommitState::CommitState(DuckTransaction &transaction_p, transaction_t commit_id
     : transaction(transaction_p), commit_id(commit_id),
       index_data_remover(transaction, *transaction.context.lock(),
                          GetIndexRemovalType(transaction_state, commit_mode)) {
+	D_ASSERT(commit_mode != CommitMode::COMMIT || IsCommitted(commit_id));
 }
 
 IndexRemovalType CommitState::GetIndexRemovalType(ActiveTransactionState transaction_state, CommitMode commit_mode) {

--- a/src/transaction/duck_transaction.cpp
+++ b/src/transaction/duck_transaction.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/transaction/duck_transaction.hpp"
+#include "duckdb/transaction/transaction_data.hpp"
 #include "duckdb/transaction/commit_state.hpp"
 #include "duckdb/transaction/duck_transaction_manager.hpp"
 #include "duckdb/main/client_context.hpp"
@@ -28,10 +29,11 @@
 namespace duckdb {
 
 TransactionData::TransactionData(DuckTransaction &transaction_p) // NOLINT
-    : transaction(&transaction_p), transaction_id(transaction_p.transaction_id), start_time(transaction_p.start_time) {
+    : transaction(&transaction_p), transaction_id(transaction_p.transaction_id),
+      snapshot_bound(transaction_p.start_time) {
 }
-TransactionData::TransactionData(transaction_t transaction_id_p, transaction_t start_time_p)
-    : transaction(nullptr), transaction_id(transaction_id_p), start_time(start_time_p) {
+TransactionData::TransactionData(transaction_t transaction_id_p, transaction_t snapshot_bound_p)
+    : transaction(nullptr), transaction_id(transaction_id_p), snapshot_bound(snapshot_bound_p) {
 }
 
 DuckTransaction::DuckTransaction(DuckTransactionManager &manager, ClientContext &context_p, transaction_t start_time,
@@ -39,6 +41,7 @@ DuckTransaction::DuckTransaction(DuckTransactionManager &manager, ClientContext 
     : Transaction(manager, context_p), start_time(start_time), transaction_id(transaction_id), commit_id(0),
       catalog_version(catalog_version_p), awaiting_cleanup(false), undo_buffer(*this, context_p),
       storage(make_uniq<LocalStorage>(context_p, *this)) {
+	D_ASSERT(IsCommitted(start_time) && !IsCommitted(transaction_id));
 }
 
 DuckTransaction::~DuckTransaction() {
@@ -334,8 +337,8 @@ ErrorData DuckTransaction::Rollback() {
 	}
 }
 
-void DuckTransaction::Cleanup(transaction_t lowest_active_transaction) {
-	undo_buffer.Cleanup(lowest_active_transaction);
+void DuckTransaction::Cleanup(transaction_t lowest_snapshot_bound) {
+	undo_buffer.Cleanup(lowest_snapshot_bound);
 }
 
 void DuckTransaction::SetModifications(DatabaseModificationType type) {

--- a/src/transaction/duck_transaction.cpp
+++ b/src/transaction/duck_transaction.cpp
@@ -29,11 +29,10 @@
 namespace duckdb {
 
 TransactionData::TransactionData(DuckTransaction &transaction_p) // NOLINT
-    : transaction(&transaction_p), transaction_id(transaction_p.transaction_id),
-      snapshot_bound(transaction_p.start_time) {
+    : transaction(&transaction_p), view(transaction_p.GetSnapshotView()) {
 }
-TransactionData::TransactionData(transaction_t transaction_id_p, transaction_t snapshot_bound_p)
-    : transaction(nullptr), transaction_id(transaction_id_p), snapshot_bound(snapshot_bound_p) {
+TransactionData::TransactionData(transaction_t transaction_id_p, VisibilityBound visibility_bound_p)
+    : transaction(nullptr), view(transaction_id_p, visibility_bound_p) {
 }
 
 DuckTransaction::DuckTransaction(DuckTransactionManager &manager, ClientContext &context_p, transaction_t start_time,
@@ -42,6 +41,10 @@ DuckTransaction::DuckTransaction(DuckTransactionManager &manager, ClientContext 
       catalog_version(catalog_version_p), awaiting_cleanup(false), undo_buffer(*this, context_p),
       storage(make_uniq<LocalStorage>(context_p, *this)) {
 	D_ASSERT(IsCommitted(start_time) && !IsCommitted(transaction_id));
+}
+
+SnapshotView DuckTransaction::GetSnapshotView() const {
+	return SnapshotView(transaction_id, VisibilityBound::Before(start_time));
 }
 
 DuckTransaction::~DuckTransaction() {
@@ -337,8 +340,8 @@ ErrorData DuckTransaction::Rollback() {
 	}
 }
 
-void DuckTransaction::Cleanup(transaction_t lowest_snapshot_bound) {
-	undo_buffer.Cleanup(lowest_snapshot_bound);
+void DuckTransaction::Cleanup(VisibilityBound lowest_visibility_bound) {
+	undo_buffer.Cleanup(lowest_visibility_bound);
 }
 
 void DuckTransaction::SetModifications(DatabaseModificationType type) {

--- a/src/transaction/duck_transaction_manager.cpp
+++ b/src/transaction/duck_transaction_manager.cpp
@@ -36,7 +36,7 @@ static ErrorData BuildAutocheckpointError(AttachedDatabase &db, const std::excep
 void DuckCleanupInfo::Cleanup() {
 	for (auto &transaction : transactions) {
 		if (transaction->awaiting_cleanup) {
-			transaction->Cleanup(lowest_snapshot_bound);
+			transaction->Cleanup(lowest_visibility_bound);
 		}
 	}
 }
@@ -55,7 +55,7 @@ DuckTransactionManager::DuckTransactionManager(AttachedDatabase &db) : Transacti
 	// uncommitted data could be read by
 	current_transaction_id = TRANSACTION_ID_START;
 	lowest_active_id = TRANSACTION_ID_START;
-	lowest_snapshot_bound = MAX_TRANSACTION_ID;
+	lowest_visibility_bound = VisibilityBound::IncludingUncommitted();
 	active_checkpoint = 0;
 	if (!db.GetCatalog().IsDuckCatalog()) {
 		// Specifically the StorageManager of the DuckCatalog is relied on, with `db.GetStorageManager`
@@ -91,7 +91,7 @@ Transaction &DuckTransactionManager::StartTransaction(ClientContext &context) {
 	transaction_t start_time = current_start_timestamp++;
 	transaction_t transaction_id = current_transaction_id++;
 	if (active_transactions.empty()) {
-		lowest_snapshot_bound = start_time;
+		lowest_visibility_bound = VisibilityBound::Before(start_time);
 		lowest_active_id = transaction_id;
 	}
 
@@ -246,7 +246,7 @@ void DuckTransactionManager::Checkpoint(ClientContext &context, bool force) {
 		}
 	}
 	CheckpointOptions options;
-	if (!VisibleToSnapshot(GetLastCommit(), LowestSnapshotBound())) {
+	if (GetLastCommit() >= LowestVisibilityBound()) {
 		// we cannot do a full checkpoint if any transaction needs to read old data
 		options.type = CheckpointType::CONCURRENT_CHECKPOINT;
 	}
@@ -410,7 +410,7 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 		last_commit = info.commit_id;
 
 		// check if catalog changes were made
-		if (!IsCommitted(transaction.catalog_version)) {
+		if (transaction.catalog_version >= TRANSACTION_ID_START) {
 			transaction.catalog_version = ++last_committed_version;
 		}
 	}
@@ -522,17 +522,18 @@ DuckTransactionManager::RemoveTransaction(DuckTransaction &transaction, bool sto
 	// Find the transaction in the active transactions,
 	// as well as the lowest start time, transaction id, and active query.
 	idx_t t_index = active_transactions.size();
-	auto lowest_snapshot_bound = TRANSACTION_ID_START;
+	auto computed_lowest_visibility_bound = VisibilityBound::AllCommitted();
 	auto lowest_transaction_id = MAX_TRANSACTION_ID;
 	for (idx_t i = 0; i < active_transactions.size(); i++) {
 		if (active_transactions[i].get() == &transaction) {
 			t_index = i;
 			continue;
 		}
-		lowest_snapshot_bound = MinValue(lowest_snapshot_bound, active_transactions[i]->start_time);
+		computed_lowest_visibility_bound = VisibilityBound::Min(
+		    computed_lowest_visibility_bound, VisibilityBound::Before(active_transactions[i]->start_time));
 		lowest_transaction_id = MinValue(lowest_transaction_id, active_transactions[i]->transaction_id);
 	}
-	this->lowest_snapshot_bound = lowest_snapshot_bound;
+	lowest_visibility_bound = computed_lowest_visibility_bound;
 	lowest_active_id = lowest_transaction_id;
 	D_ASSERT(t_index != active_transactions.size());
 
@@ -553,7 +554,7 @@ DuckTransactionManager::RemoveTransaction(DuckTransaction &transaction, bool sto
 		current_transaction->awaiting_cleanup = true;
 		cleanup_info->transactions.push_back(std::move(current_transaction));
 	}
-	cleanup_info->lowest_snapshot_bound = lowest_snapshot_bound;
+	cleanup_info->lowest_visibility_bound = computed_lowest_visibility_bound;
 
 	// Remove the transaction from the list of active transactions.
 	active_transactions.unsafe_erase_at(t_index);
@@ -563,10 +564,10 @@ DuckTransactionManager::RemoveTransaction(DuckTransaction &transaction, bool sto
 	idx_t i = 0;
 	for (; i < recently_committed_transactions.size(); i++) {
 		D_ASSERT(recently_committed_transactions[i]);
-		if (!VisibleToSnapshot(recently_committed_transactions[i]->commit_id, lowest_snapshot_bound)) {
+		if (recently_committed_transactions[i]->commit_id >= computed_lowest_visibility_bound) {
 			// recently_committed_transactions is ordered on commit_id.
 			// Thus, if the current commit_id is greater than
-			// lowest_snapshot_bound, any subsequent commit IDs are also greater.
+			// lowest_visibility_bound, any subsequent commit IDs are also greater.
 			break;
 		}
 

--- a/src/transaction/duck_transaction_manager.cpp
+++ b/src/transaction/duck_transaction_manager.cpp
@@ -12,6 +12,7 @@
 #include "duckdb/catalog/dependency_manager.hpp"
 #include "duckdb/storage/storage_manager.hpp"
 #include "duckdb/transaction/duck_transaction.hpp"
+#include "duckdb/transaction/transaction_data.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/connection_manager.hpp"
 #include "duckdb/main/attached_database.hpp"
@@ -35,7 +36,7 @@ static ErrorData BuildAutocheckpointError(AttachedDatabase &db, const std::excep
 void DuckCleanupInfo::Cleanup() {
 	for (auto &transaction : transactions) {
 		if (transaction->awaiting_cleanup) {
-			transaction->Cleanup(lowest_start_time);
+			transaction->Cleanup(lowest_snapshot_bound);
 		}
 	}
 }
@@ -45,16 +46,17 @@ bool DuckCleanupInfo::ScheduleCleanup() noexcept {
 }
 
 DuckTransactionManager::DuckTransactionManager(AttachedDatabase &db) : TransactionManager(db) {
-	// start timestamp starts at two
-	current_start_timestamp = 2;
+	// the first timestamp a real transaction can draw: one past the bootstrap stamp, which is also
+	// the bound the system transaction reads at
+	current_start_timestamp = SYSTEM_TRANSACTION_TIMESTAMP + 1;
 	// transaction ID starts very high:
 	// it should be much higher than the current start timestamp
 	// if transaction_id < start_timestamp for any set of active transactions
 	// uncommitted data could be read by
 	current_transaction_id = TRANSACTION_ID_START;
 	lowest_active_id = TRANSACTION_ID_START;
-	lowest_active_start = MAX_TRANSACTION_ID;
-	active_checkpoint = MAX_TRANSACTION_ID;
+	lowest_snapshot_bound = MAX_TRANSACTION_ID;
+	active_checkpoint = 0;
 	if (!db.GetCatalog().IsDuckCatalog()) {
 		// Specifically the StorageManager of the DuckCatalog is relied on, with `db.GetStorageManager`
 		throw InternalException("DuckTransactionManager should only be created together with a DuckCatalog");
@@ -89,7 +91,7 @@ Transaction &DuckTransactionManager::StartTransaction(ClientContext &context) {
 	transaction_t start_time = current_start_timestamp++;
 	transaction_t transaction_id = current_transaction_id++;
 	if (active_transactions.empty()) {
-		lowest_active_start = start_time;
+		lowest_snapshot_bound = start_time;
 		lowest_active_id = transaction_id;
 	}
 
@@ -102,12 +104,12 @@ Transaction &DuckTransactionManager::StartTransaction(ClientContext &context) {
 	return transaction_ref;
 }
 
-void DuckTransactionManager::SetActiveCheckpoint(transaction_t checkpoint_id) {
+void DuckTransactionManager::SetActiveCheckpoint(idx_t checkpoint_id) {
 	active_checkpoint = checkpoint_id;
 }
 
 void DuckTransactionManager::ResetActiveCheckpoint() {
-	active_checkpoint = MAX_TRANSACTION_ID;
+	active_checkpoint = 0;
 }
 
 DuckTransactionManager::CheckpointDecision::CheckpointDecision(string reason_p)
@@ -244,7 +246,7 @@ void DuckTransactionManager::Checkpoint(ClientContext &context, bool force) {
 		}
 	}
 	CheckpointOptions options;
-	if (GetLastCommit() > LowestActiveStart()) {
+	if (!VisibleToSnapshot(GetLastCommit(), LowestSnapshotBound())) {
 		// we cannot do a full checkpoint if any transaction needs to read old data
 		options.type = CheckpointType::CONCURRENT_CHECKPOINT;
 	}
@@ -408,7 +410,7 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 		last_commit = info.commit_id;
 
 		// check if catalog changes were made
-		if (transaction.catalog_version >= TRANSACTION_ID_START) {
+		if (!IsCommitted(transaction.catalog_version)) {
 			transaction.catalog_version = ++last_committed_version;
 		}
 	}
@@ -520,17 +522,17 @@ DuckTransactionManager::RemoveTransaction(DuckTransaction &transaction, bool sto
 	// Find the transaction in the active transactions,
 	// as well as the lowest start time, transaction id, and active query.
 	idx_t t_index = active_transactions.size();
-	auto lowest_start_time = TRANSACTION_ID_START;
+	auto lowest_snapshot_bound = TRANSACTION_ID_START;
 	auto lowest_transaction_id = MAX_TRANSACTION_ID;
 	for (idx_t i = 0; i < active_transactions.size(); i++) {
 		if (active_transactions[i].get() == &transaction) {
 			t_index = i;
 			continue;
 		}
-		lowest_start_time = MinValue(lowest_start_time, active_transactions[i]->start_time);
+		lowest_snapshot_bound = MinValue(lowest_snapshot_bound, active_transactions[i]->start_time);
 		lowest_transaction_id = MinValue(lowest_transaction_id, active_transactions[i]->transaction_id);
 	}
-	lowest_active_start = lowest_start_time;
+	this->lowest_snapshot_bound = lowest_snapshot_bound;
 	lowest_active_id = lowest_transaction_id;
 	D_ASSERT(t_index != active_transactions.size());
 
@@ -551,7 +553,7 @@ DuckTransactionManager::RemoveTransaction(DuckTransaction &transaction, bool sto
 		current_transaction->awaiting_cleanup = true;
 		cleanup_info->transactions.push_back(std::move(current_transaction));
 	}
-	cleanup_info->lowest_start_time = lowest_start_time;
+	cleanup_info->lowest_snapshot_bound = lowest_snapshot_bound;
 
 	// Remove the transaction from the list of active transactions.
 	active_transactions.unsafe_erase_at(t_index);
@@ -561,10 +563,10 @@ DuckTransactionManager::RemoveTransaction(DuckTransaction &transaction, bool sto
 	idx_t i = 0;
 	for (; i < recently_committed_transactions.size(); i++) {
 		D_ASSERT(recently_committed_transactions[i]);
-		if (recently_committed_transactions[i]->commit_id >= lowest_start_time) {
+		if (!VisibleToSnapshot(recently_committed_transactions[i]->commit_id, lowest_snapshot_bound)) {
 			// recently_committed_transactions is ordered on commit_id.
 			// Thus, if the current commit_id is greater than
-			// lowest_start_time, any subsequent commit IDs are also greater.
+			// lowest_snapshot_bound, any subsequent commit IDs are also greater.
 			break;
 		}
 

--- a/src/transaction/undo_buffer.cpp
+++ b/src/transaction/undo_buffer.cpp
@@ -173,7 +173,7 @@ UndoBufferProperties UndoBuffer::GetProperties() {
 	return properties;
 }
 
-void UndoBuffer::Cleanup(transaction_t lowest_active_transaction) {
+void UndoBuffer::Cleanup(transaction_t lowest_snapshot_bound) {
 	// garbage collect everything in the Undo Chunk
 	// this should only happen if
 	//  (1) the transaction this UndoBuffer belongs to has successfully
@@ -182,7 +182,7 @@ void UndoBuffer::Cleanup(transaction_t lowest_active_transaction) {
 	//      the chunks)
 	//  (2) there is no active transaction with start_id < commit_id of this
 	//  transaction
-	CleanupState state(transaction, lowest_active_transaction, active_transaction_state);
+	CleanupState state(transaction, lowest_snapshot_bound, active_transaction_state);
 	UndoBuffer::IteratorState iterator_state;
 	IterateEntries(iterator_state, [&](UndoFlags type, data_ptr_t data) { state.CleanupEntry(type, data); });
 }

--- a/src/transaction/undo_buffer.cpp
+++ b/src/transaction/undo_buffer.cpp
@@ -173,7 +173,7 @@ UndoBufferProperties UndoBuffer::GetProperties() {
 	return properties;
 }
 
-void UndoBuffer::Cleanup(transaction_t lowest_snapshot_bound) {
+void UndoBuffer::Cleanup(VisibilityBound lowest_visibility_bound) {
 	// garbage collect everything in the Undo Chunk
 	// this should only happen if
 	//  (1) the transaction this UndoBuffer belongs to has successfully
@@ -182,7 +182,7 @@ void UndoBuffer::Cleanup(transaction_t lowest_snapshot_bound) {
 	//      the chunks)
 	//  (2) there is no active transaction with start_id < commit_id of this
 	//  transaction
-	CleanupState state(transaction, lowest_snapshot_bound, active_transaction_state);
+	CleanupState state(transaction, lowest_visibility_bound, active_transaction_state);
 	UndoBuffer::IteratorState iterator_state;
 	IterateEntries(iterator_state, [&](UndoFlags type, data_ptr_t data) { state.CleanupEntry(type, data); });
 }


### PR DESCRIPTION
DuckDB's MVCC visibility test is currently written out by hand wherever it is needed. Two types of comparisons,
- `timestamp < start_time` for "visible to this snapshot" and
- `timestamp < TRANSACTION_ID_START` for "committed"

appear inline across the catalog, the table storage, the version managers and the transaction manager. A bound and a timestamp are both `transaction_t`, so they can be swapped, assigned to each other, or compared inclusively without the compiler noticing. The codebase actually has all three: the `DuckTransactionManager` constructor initialises `lowest_active_id` and `lowest_visibility_bound` to each other's identity, `CheckpointOptions` defaults its bound to `MAX_TRANSACTION_ID` (a value above the split) without saying so, and `TransactionData` takes `(transaction_id, visibility_bound)` while every storage function takes them the other way round.

In preparation for #23631, where a transaction's visibility bound is no longer always its start time, this PR gives these visibility tests a single, explicit form and makes the bound a type of its own.

```cpp
inline bool IsCommitted(transaction_t timestamp) {
	return timestamp <= MAX_COMMIT_ID;
}

// a VisibilityBound is built, never assigned from a timestamp
VisibilityBound::Through(last_commit);   // visible up to and including last_commit
VisibilityBound::Before(start_time);     // visible strictly before start_time

// and these are the only comparisons against one: <= and > do not compile
timestamp < visibility_bound;
timestamp >= visibility_bound;
```

