### PR TITLE
Report parser profiling time per statement

### DIFF
--- a/src/include/duckdb/main/query_profiler.hpp
+++ b/src/include/duckdb/main/query_profiler.hpp
@@ -111,8 +111,8 @@ public:
 	DUCKDB_API void TrackTotalMemoryAllocated(idx_t amount);
 	//! Add to a metric counter (profiling-only).
 	DUCKDB_API void AddToMetricCounter(const string &key, idx_t amount);
-	//! Add parser time, including time measured before the per-statement profiler was started.
-	void AddParserTime(idx_t parser_time_ns);
+	//! Add parser time measured before the per-statement profiler was started.
+	void AddParserTime(const Profiler &parser_timer);
 
 	//! Set an arbitrary metric value (profiling-only; no-op when profiling is disabled).
 	DUCKDB_API void SetMetric(const string &key, Value new_value);
@@ -206,8 +206,6 @@ private:
 	bool is_explain_analyze;
 	//! Whether root metrics have been finalized for output
 	bool metrics_finalized;
-	//! Parser time measured before the per-statement profiler was started.
-	idx_t pending_parser_time_ns = 0;
 
 public:
 	const TreeMap &GetTreeMap() const {

--- a/src/include/duckdb/main/query_profiler.hpp
+++ b/src/include/duckdb/main/query_profiler.hpp
@@ -111,6 +111,8 @@ public:
 	DUCKDB_API void TrackTotalMemoryAllocated(idx_t amount);
 	//! Add to a metric counter (profiling-only).
 	DUCKDB_API void AddToMetricCounter(const string &key, idx_t amount);
+	//! Add parser time, including time measured before the per-statement profiler was started.
+	void AddParserTime(idx_t parser_time_ns);
 
 	//! Set an arbitrary metric value (profiling-only; no-op when profiling is disabled).
 	DUCKDB_API void SetMetric(const string &key, Value new_value);
@@ -204,6 +206,8 @@ private:
 	bool is_explain_analyze;
 	//! Whether root metrics have been finalized for output
 	bool metrics_finalized;
+	//! Parser time measured before the per-statement profiler was started.
+	idx_t pending_parser_time_ns = 0;
 
 public:
 	const TreeMap &GetTreeMap() const {

--- a/src/include/duckdb/main/statement_iterator.hpp
+++ b/src/include/duckdb/main/statement_iterator.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "duckdb/common/optional_ptr.hpp"
+#include "duckdb/common/profiler.hpp"
 #include "duckdb/common/unique_ptr.hpp"
 #include "duckdb/common/vector.hpp"
 #include "duckdb/main/parse_iterator.hpp"
@@ -70,6 +71,10 @@ private:
 	ParseIterator source;
 	//! The bound context, inherited from `source`. Used for preprocessing / transaction state / locking.
 	ClientContext &context;
+	//! The parse-facing statement buffered by Peek, waiting to be handed to preprocessing.
+	unique_ptr<SQLStatement> pending_statement;
+	//! Stores the parser timing until the statement is handed to the engine-facing iterator.
+	Profiler parser_timer;
 	//! Engine-facing statements produced by preprocessing one parse-facing peel. Drained
 	//! one-at-a-time across GetStatement calls before pulling + preprocessing the next peel.
 	vector<unique_ptr<SQLStatement>> buffer;

--- a/src/include/duckdb/main/statement_iterator.hpp
+++ b/src/include/duckdb/main/statement_iterator.hpp
@@ -9,7 +9,6 @@
 #pragma once
 
 #include "duckdb/common/optional_ptr.hpp"
-#include "duckdb/common/profiler.hpp"
 #include "duckdb/common/unique_ptr.hpp"
 #include "duckdb/common/vector.hpp"
 #include "duckdb/main/parse_iterator.hpp"
@@ -71,10 +70,6 @@ private:
 	ParseIterator source;
 	//! The bound context, inherited from `source`. Used for preprocessing / transaction state / locking.
 	ClientContext &context;
-	//! The parse-facing statement buffered by Peek, waiting to be handed to preprocessing.
-	unique_ptr<SQLStatement> pending_statement;
-	//! Stores the parser timing until the statement is handed to the engine-facing iterator.
-	Profiler parser_timer;
 	//! Engine-facing statements produced by preprocessing one parse-facing peel. Drained
 	//! one-at-a-time across GetStatement calls before pulling + preprocessing the next peel.
 	vector<unique_ptr<SQLStatement>> buffer;

--- a/src/include/duckdb/parser/sql_statement.hpp
+++ b/src/include/duckdb/parser/sql_statement.hpp
@@ -13,6 +13,7 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/printer.hpp"
 #include "duckdb/common/named_parameter_map.hpp"
+#include "duckdb/common/profiler.hpp"
 #include "duckdb/common/query_location.hpp"
 
 namespace duckdb {
@@ -38,6 +39,8 @@ public:
 	bool has_anonymous_parameters = false;
 	//! The query text that corresponds to this SQL statement
 	string query;
+	//! Parser timing collected before the statement is handed to the engine
+	Profiler parser_timer;
 
 protected:
 	SQLStatement(const SQLStatement &other) = default;

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -475,7 +475,6 @@ shared_ptr<PreparedStatementData> ClientContext::CreatePreparedStatementInternal
 	auto result = make_shared_ptr<PreparedStatementData>(statement_type);
 
 	auto &profiler = QueryProfiler::Get(*this);
-	profiler.StartQuery(statement->query, IsExplainAnalyze(statement.get()));
 	Planner logical_planner(*this);
 	if (parameters.parameters) {
 		auto &parameter_values = *parameters.parameters;
@@ -539,6 +538,10 @@ shared_ptr<PreparedStatementData> ClientContext::CreatePreparedStatementInternal
 shared_ptr<PreparedStatementData> ClientContext::CreatePreparedStatement(ClientContextLock &lock,
                                                                          unique_ptr<SQLStatement> statement,
                                                                          PendingQueryParameters parameters) {
+	auto &profiler = QueryProfiler::Get(*this);
+	profiler.StartQuery(statement->query, IsExplainAnalyze(statement.get()));
+	profiler.AddParserTime(statement->parser_timer);
+
 	// check if any client context state could request a rebind
 	bool can_request_rebind = false;
 	for (auto &state : registered_state->States()) {

--- a/src/main/parse_iterator.cpp
+++ b/src/main/parse_iterator.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/main/parse_iterator.hpp"
 #include "duckdb/main/database.hpp"
 
+#include "duckdb/common/profiler.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/extension_callback_manager.hpp"
 #include "duckdb/main/query_profiler.hpp"
@@ -37,9 +38,10 @@ bool ParseIterator::Peek() {
 	if (exhausted) {
 		return false;
 	}
-	// Charge the time spent tokenizing/parsing on this Peek to MetricParserTotalTime so callers
-	// get parse metrics without each having to remember to wrap us in a timer.
-	auto parser_timer = QueryProfiler::Get(client_context).StartTimer<MetricParserTotalTime>();
+	// The query profiler owns the accumulated parser metric. This timer is local because parsing can
+	// happen before the per-statement profiler is started.
+	Profiler parser_timer;
+	parser_timer.Start();
 	auto options = client_context.GetParserOptions();
 	// On the very first Peek, give `parser_override` extensions a chance to claim the whole
 	// query. If one does, we yield its statements one at a time and skip the PEG path entirely.
@@ -79,9 +81,12 @@ bool ParseIterator::Peek() {
 	if (overridden_statements) {
 		if (override_cursor >= overridden_statements->size()) {
 			exhausted = true;
+			parser_timer.End();
 			return false;
 		}
 		current_statement = std::move((*overridden_statements)[override_cursor++]);
+		parser_timer.End();
+		QueryProfiler::Get(client_context).AddParserTime(parser_timer.ElapsedNanos());
 		return true;
 	}
 	if (!parser) {
@@ -95,6 +100,7 @@ bool ParseIterator::Peek() {
 	while (true) {
 		if (token_iterator->AtEnd()) {
 			exhausted = true;
+			parser_timer.End();
 			return false;
 		}
 		unique_ptr<SQLStatement> stmt;
@@ -128,10 +134,13 @@ bool ParseIterator::Peek() {
 				create.info->sql = stmt->query;
 			}
 			current_statement = std::move(stmt);
+			parser_timer.End();
+			QueryProfiler::Get(client_context).AddParserTime(parser_timer.ElapsedNanos());
 			return true;
 		}
 		if (token_iterator->AtEnd()) {
 			exhausted = true;
+			parser_timer.End();
 			return false;
 		}
 		// separator-only TLS in the middle of the input — loop and try the next.

--- a/src/main/parse_iterator.cpp
+++ b/src/main/parse_iterator.cpp
@@ -3,6 +3,7 @@
 
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/extension_callback_manager.hpp"
+#include "duckdb/common/profiler.hpp"
 #include "duckdb/parser/parser.hpp"
 #include "duckdb/parser/parser_extension.hpp"
 #include "duckdb/parser/token_iterator.hpp"
@@ -36,6 +37,8 @@ bool ParseIterator::Peek() {
 	if (exhausted) {
 		return false;
 	}
+	Profiler parser_timer;
+	parser_timer.Start();
 	auto options = client_context.GetParserOptions();
 	// On the very first Peek, give `parser_override` extensions a chance to claim the whole
 	// query. If one does, we yield its statements one at a time and skip the PEG path entirely.
@@ -78,6 +81,8 @@ bool ParseIterator::Peek() {
 			return false;
 		}
 		current_statement = std::move((*overridden_statements)[override_cursor++]);
+		parser_timer.End();
+		current_statement->parser_timer = parser_timer;
 		return true;
 	}
 	if (!parser) {
@@ -124,6 +129,8 @@ bool ParseIterator::Peek() {
 				create.info->sql = stmt->query;
 			}
 			current_statement = std::move(stmt);
+			parser_timer.End();
+			current_statement->parser_timer = parser_timer;
 			return true;
 		}
 		if (token_iterator->AtEnd()) {

--- a/src/main/parse_iterator.cpp
+++ b/src/main/parse_iterator.cpp
@@ -1,10 +1,8 @@
 #include "duckdb/main/parse_iterator.hpp"
 #include "duckdb/main/database.hpp"
 
-#include "duckdb/common/profiler.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/extension_callback_manager.hpp"
-#include "duckdb/main/query_profiler.hpp"
 #include "duckdb/parser/parser.hpp"
 #include "duckdb/parser/parser_extension.hpp"
 #include "duckdb/parser/token_iterator.hpp"
@@ -38,10 +36,6 @@ bool ParseIterator::Peek() {
 	if (exhausted) {
 		return false;
 	}
-	// The query profiler owns the accumulated parser metric. This timer is local because parsing can
-	// happen before the per-statement profiler is started.
-	Profiler parser_timer;
-	parser_timer.Start();
 	auto options = client_context.GetParserOptions();
 	// On the very first Peek, give `parser_override` extensions a chance to claim the whole
 	// query. If one does, we yield its statements one at a time and skip the PEG path entirely.
@@ -81,12 +75,9 @@ bool ParseIterator::Peek() {
 	if (overridden_statements) {
 		if (override_cursor >= overridden_statements->size()) {
 			exhausted = true;
-			parser_timer.End();
 			return false;
 		}
 		current_statement = std::move((*overridden_statements)[override_cursor++]);
-		parser_timer.End();
-		QueryProfiler::Get(client_context).AddParserTime(parser_timer.ElapsedNanos());
 		return true;
 	}
 	if (!parser) {
@@ -100,7 +91,6 @@ bool ParseIterator::Peek() {
 	while (true) {
 		if (token_iterator->AtEnd()) {
 			exhausted = true;
-			parser_timer.End();
 			return false;
 		}
 		unique_ptr<SQLStatement> stmt;
@@ -134,13 +124,10 @@ bool ParseIterator::Peek() {
 				create.info->sql = stmt->query;
 			}
 			current_statement = std::move(stmt);
-			parser_timer.End();
-			QueryProfiler::Get(client_context).AddParserTime(parser_timer.ElapsedNanos());
 			return true;
 		}
 		if (token_iterator->AtEnd()) {
 			exhausted = true;
-			parser_timer.End();
 			return false;
 		}
 		// separator-only TLS in the middle of the input — loop and try the next.

--- a/src/main/query_profiler.cpp
+++ b/src/main/query_profiler.cpp
@@ -120,10 +120,15 @@ QueryProfiler &QueryProfiler::Get(ClientContext &context) {
 }
 
 void QueryProfiler::Start(const string &query) {
+	auto parser_time_ns = pending_parser_time_ns;
+	pending_parser_time_ns = 0;
 	Reset();
 	running = true;
 	query_metrics.query_sql = query;
 	query_metrics.latency_timer = make_uniq<MetricsTimer>(StartTimer<MetricQueryTotalTime>());
+	if (parser_time_ns) {
+		query_metrics.UpdateMetric(MetricParserTotalTime::Name, parser_time_ns);
+	}
 }
 
 void QueryProfiler::Reset() {
@@ -134,6 +139,7 @@ void QueryProfiler::Reset() {
 	query_metrics.Reset();
 	result_tree.reset();
 	metrics_finalized = false;
+	pending_parser_time_ns = 0;
 }
 
 void QueryProfiler::StartQuery(const string &query, bool is_explain_analyze_p, bool start_at_optimizer) {
@@ -145,6 +151,7 @@ void QueryProfiler::StartQuery(const string &query, bool is_explain_analyze_p, b
 		StartExplainAnalyze();
 	}
 	if (!IsEnabled()) {
+		pending_parser_time_ns = 0;
 		return;
 	}
 	if (start_at_optimizer && !PrintOptimizerOutput()) {
@@ -152,11 +159,27 @@ void QueryProfiler::StartQuery(const string &query, bool is_explain_analyze_p, b
 		return;
 	}
 	if (running) {
-		// Called while already running: this should only happen when we print optimizer output
+		// Called while already running: this happens when statement setup follows parser timing,
+		// or when we print optimizer output.
 		// D_ASSERT(PrintOptimizerOutput());
+		query_metrics.query_sql = query;
 		return;
 	}
 	Start(query);
+}
+
+void QueryProfiler::AddParserTime(idx_t parser_time_ns) {
+	if (!parser_time_ns) {
+		return;
+	}
+	if (!running) {
+		pending_parser_time_ns += parser_time_ns;
+		return;
+	}
+	if (!IsEnabled()) {
+		return;
+	}
+	query_metrics.UpdateMetric(MetricParserTotalTime::Name, parser_time_ns);
 }
 
 bool QueryProfiler::OperatorRequiresProfiling(const PhysicalOperatorType op_type) {

--- a/src/main/query_profiler.cpp
+++ b/src/main/query_profiler.cpp
@@ -120,15 +120,10 @@ QueryProfiler &QueryProfiler::Get(ClientContext &context) {
 }
 
 void QueryProfiler::Start(const string &query) {
-	auto parser_time_ns = pending_parser_time_ns;
-	pending_parser_time_ns = 0;
 	Reset();
 	running = true;
 	query_metrics.query_sql = query;
 	query_metrics.latency_timer = make_uniq<MetricsTimer>(StartTimer<MetricQueryTotalTime>());
-	if (parser_time_ns) {
-		query_metrics.UpdateMetric(MetricParserTotalTime::Name, parser_time_ns);
-	}
 }
 
 void QueryProfiler::Reset() {
@@ -139,7 +134,6 @@ void QueryProfiler::Reset() {
 	query_metrics.Reset();
 	result_tree.reset();
 	metrics_finalized = false;
-	pending_parser_time_ns = 0;
 }
 
 void QueryProfiler::StartQuery(const string &query, bool is_explain_analyze_p, bool start_at_optimizer) {
@@ -151,7 +145,6 @@ void QueryProfiler::StartQuery(const string &query, bool is_explain_analyze_p, b
 		StartExplainAnalyze();
 	}
 	if (!IsEnabled()) {
-		pending_parser_time_ns = 0;
 		return;
 	}
 	if (start_at_optimizer && !PrintOptimizerOutput()) {
@@ -168,15 +161,12 @@ void QueryProfiler::StartQuery(const string &query, bool is_explain_analyze_p, b
 	Start(query);
 }
 
-void QueryProfiler::AddParserTime(idx_t parser_time_ns) {
+void QueryProfiler::AddParserTime(const Profiler &parser_timer) {
+	if (!running || !IsEnabled()) {
+		return;
+	}
+	auto parser_time_ns = parser_timer.ElapsedNanos();
 	if (!parser_time_ns) {
-		return;
-	}
-	if (!running) {
-		pending_parser_time_ns += parser_time_ns;
-		return;
-	}
-	if (!IsEnabled()) {
 		return;
 	}
 	query_metrics.UpdateMetric(MetricParserTotalTime::Name, parser_time_ns);

--- a/src/main/statement_iterator.cpp
+++ b/src/main/statement_iterator.cpp
@@ -1,18 +1,9 @@
 #include "duckdb/main/statement_iterator.hpp"
 
 #include "duckdb/main/client_context.hpp"
-#include "duckdb/main/query_profiler.hpp"
 #include "duckdb/parser/sql_statement.hpp"
-#include "duckdb/parser/statement/explain_statement.hpp"
 
 namespace duckdb {
-
-static bool IsExplainAnalyzeForIterator(SQLStatement *statement) {
-	if (!statement || statement->type != StatementType::EXPLAIN_STATEMENT) {
-		return false;
-	}
-	return statement->Cast<ExplainStatement>().explain_type == ExplainType::EXPLAIN_ANALYZE;
-}
 
 StatementIterator::StatementIterator(ParseIterator &&parse_iterator)
     : source(std::move(parse_iterator)), context(source.GetClientContext()) {
@@ -27,31 +18,14 @@ bool StatementIterator::Peek() {
 	if (buffer_cursor < buffer.size()) {
 		return true;
 	}
-	if (pending_statement) {
-		return true;
-	}
 	// Otherwise, is there another parse-facing statement to pull? Parses ahead, does NOT preprocess
 	// — safe to use as a lookahead.
-	parser_timer.Start();
-	if (!source.Peek()) {
-		parser_timer.Reset();
-		return false;
-	}
-	parser_timer.End();
-	pending_statement = source.GetStatement();
-	if (!pending_statement) {
-		parser_timer.Reset();
-		return false;
-	}
-	return true;
+	return source.Peek();
 }
 
 bool StatementIterator::HasMore() {
 	// Buffered engine statements from the current peel still remain?
 	if (buffer_cursor < buffer.size()) {
-		return true;
-	}
-	if (pending_statement) {
 		return true;
 	}
 	// Otherwise defer to the parse-facing source's grammar-free existence check.
@@ -64,20 +38,11 @@ unique_ptr<SQLStatement> StatementIterator::GetStatementInternal(optional_ptr<Cl
 		return std::move(buffer[buffer_cursor++]);
 	}
 	// Pull the next parse-facing statement.
-	if (!pending_statement && !Peek()) {
+	if (!source.Peek()) {
 		return nullptr; // exhausted
 	}
-	auto stmt = std::move(pending_statement);
-	if (!stmt) {
-		return nullptr;
-	}
-	// Parsing happens before the statement is preprocessed or planned. Start the profiler here so
-	// the parser duration is charged to this statement, including EXPLAIN ANALYZE when profiling
-	// was not enabled globally before the statement was parsed.
-	auto &profiler = QueryProfiler::Get(context);
-	profiler.StartQuery(stmt->query, IsExplainAnalyzeForIterator(stmt.get()));
-	profiler.AddParserTime(parser_timer);
-	parser_timer.Reset();
+	auto stmt = source.GetStatement();
+	auto parser_timer = stmt->parser_timer;
 	buffer.clear();
 	buffer_cursor = 0;
 	buffer.push_back(std::move(stmt));
@@ -88,6 +53,7 @@ unique_ptr<SQLStatement> StatementIterator::GetStatementInternal(optional_ptr<Cl
 		// Preprocessing swallowed the peel — caller skips with `continue`; the next Get pulls on.
 		return nullptr;
 	}
+	buffer[0]->parser_timer = parser_timer;
 	buffer_cursor = 1;
 	return std::move(buffer[0]);
 }

--- a/src/main/statement_iterator.cpp
+++ b/src/main/statement_iterator.cpp
@@ -27,14 +27,31 @@ bool StatementIterator::Peek() {
 	if (buffer_cursor < buffer.size()) {
 		return true;
 	}
+	if (pending_statement) {
+		return true;
+	}
 	// Otherwise, is there another parse-facing statement to pull? Parses ahead, does NOT preprocess
 	// — safe to use as a lookahead.
-	return source.Peek();
+	parser_timer.Start();
+	if (!source.Peek()) {
+		parser_timer.Reset();
+		return false;
+	}
+	parser_timer.End();
+	pending_statement = source.GetStatement();
+	if (!pending_statement) {
+		parser_timer.Reset();
+		return false;
+	}
+	return true;
 }
 
 bool StatementIterator::HasMore() {
 	// Buffered engine statements from the current peel still remain?
 	if (buffer_cursor < buffer.size()) {
+		return true;
+	}
+	if (pending_statement) {
 		return true;
 	}
 	// Otherwise defer to the parse-facing source's grammar-free existence check.
@@ -47,10 +64,10 @@ unique_ptr<SQLStatement> StatementIterator::GetStatementInternal(optional_ptr<Cl
 		return std::move(buffer[buffer_cursor++]);
 	}
 	// Pull the next parse-facing statement.
-	if (!source.Peek()) {
+	if (!pending_statement && !Peek()) {
 		return nullptr; // exhausted
 	}
-	auto stmt = source.GetStatement();
+	auto stmt = std::move(pending_statement);
 	if (!stmt) {
 		return nullptr;
 	}
@@ -59,6 +76,8 @@ unique_ptr<SQLStatement> StatementIterator::GetStatementInternal(optional_ptr<Cl
 	// was not enabled globally before the statement was parsed.
 	auto &profiler = QueryProfiler::Get(context);
 	profiler.StartQuery(stmt->query, IsExplainAnalyzeForIterator(stmt.get()));
+	profiler.AddParserTime(parser_timer);
+	parser_timer.Reset();
 	buffer.clear();
 	buffer_cursor = 0;
 	buffer.push_back(std::move(stmt));

--- a/src/main/statement_iterator.cpp
+++ b/src/main/statement_iterator.cpp
@@ -1,9 +1,18 @@
 #include "duckdb/main/statement_iterator.hpp"
 
 #include "duckdb/main/client_context.hpp"
+#include "duckdb/main/query_profiler.hpp"
 #include "duckdb/parser/sql_statement.hpp"
+#include "duckdb/parser/statement/explain_statement.hpp"
 
 namespace duckdb {
+
+static bool IsExplainAnalyzeForIterator(SQLStatement *statement) {
+	if (!statement || statement->type != StatementType::EXPLAIN_STATEMENT) {
+		return false;
+	}
+	return statement->Cast<ExplainStatement>().explain_type == ExplainType::EXPLAIN_ANALYZE;
+}
 
 StatementIterator::StatementIterator(ParseIterator &&parse_iterator)
     : source(std::move(parse_iterator)), context(source.GetClientContext()) {
@@ -42,6 +51,14 @@ unique_ptr<SQLStatement> StatementIterator::GetStatementInternal(optional_ptr<Cl
 		return nullptr; // exhausted
 	}
 	auto stmt = source.GetStatement();
+	if (!stmt) {
+		return nullptr;
+	}
+	// Parsing happens before the statement is preprocessed or planned. Start the profiler here so
+	// the parser duration is charged to this statement, including EXPLAIN ANALYZE when profiling
+	// was not enabled globally before the statement was parsed.
+	auto &profiler = QueryProfiler::Get(context);
+	profiler.StartQuery(stmt->query, IsExplainAnalyzeForIterator(stmt.get()));
 	buffer.clear();
 	buffer_cursor = 0;
 	buffer.push_back(std::move(stmt));

--- a/test/api/test_query_profiler.cpp
+++ b/test/api/test_query_profiler.cpp
@@ -1,5 +1,6 @@
 #include "catch.hpp"
 #include "test_helpers.hpp"
+#include "duckdb/main/query_profiler.hpp"
 #include "duckdb/main/statement_iterator.hpp"
 
 #include <iostream>
@@ -82,6 +83,24 @@ TEST_CASE("Test parser timing is reported per statement", "[api]") {
 		REQUIRE(output.find(expected_query) != std::string::npos);
 	}
 	REQUIRE_FALSE(iterator.Peek());
+}
+
+TEST_CASE("Extracting statements does not start the query profiler", "[api]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	con.EnableProfiling();
+	con.context->config.profiler_save_location = TestCreatePath("test_query_profiler_extract_output.txt");
+	con.context->config.tracked_metrics = {"parser.total_time", "query.sql"};
+
+	auto statements = con.ExtractStatements("SELECT 44;");
+	REQUIRE(statements.size() == 1);
+	REQUIRE(statements[0]->parser_timer.ElapsedNanos() > 0);
+	REQUIRE(QueryProfiler::Get(*con.context).GetQuerySQL().empty());
+
+	REQUIRE_NO_FAIL(con.Query(std::move(statements[0])));
+	auto output = con.GetProfilingInformation(ProfilerPrintFormat::JSON());
+	REQUIRE(output.find("\"parser\"") != std::string::npos);
+	REQUIRE(output.find("SELECT 44;") != std::string::npos);
 }
 
 TEST_CASE("Test latency when interrupting query", "[api]") {

--- a/test/api/test_query_profiler.cpp
+++ b/test/api/test_query_profiler.cpp
@@ -1,5 +1,6 @@
 #include "catch.hpp"
 #include "test_helpers.hpp"
+#include "duckdb/main/statement_iterator.hpp"
 
 #include <iostream>
 #include <thread>
@@ -54,6 +55,33 @@ TEST_CASE("Test query profiler, no query in the profiling output.", "[api]") {
 	REQUIRE(output.size() > 0);
 	query_not_found_in_output = output.find(query) == std::string::npos;
 	REQUIRE(query_not_found_in_output);
+}
+
+TEST_CASE("Test parser timing is reported per statement", "[api]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	con.EnableProfiling();
+	con.context->config.profiler_save_location = TestCreatePath("test_query_profiler_parser_output.txt");
+	con.context->config.tracked_metrics = {"parser.total_time", "query.sql"};
+
+	REQUIRE_NO_FAIL(con.Query("SELECT 7;"));
+	auto single_statement_output = con.GetProfilingInformation(ProfilerPrintFormat::JSON());
+	REQUIRE(single_statement_output.find("\"parser\"") != std::string::npos);
+	REQUIRE(single_statement_output.find("SELECT 7;") != std::string::npos);
+
+	auto iterator = con.context->IterateStatements("SELECT 42; SELECT 43;");
+	for (const auto expected_query : {"SELECT 42; ", "SELECT 43;"}) {
+		REQUIRE(iterator.Peek());
+		auto statement = iterator.GetStatement();
+		REQUIRE(statement);
+		REQUIRE(statement->query == expected_query);
+		REQUIRE_NO_FAIL(con.Query(std::move(statement)));
+
+		auto output = con.GetProfilingInformation(ProfilerPrintFormat::JSON());
+		REQUIRE(output.find("\"parser\"") != std::string::npos);
+		REQUIRE(output.find(expected_query) != std::string::npos);
+	}
+	REQUIRE_FALSE(iterator.Peek());
 }
 
 TEST_CASE("Test latency when interrupting query", "[api]") {


### PR DESCRIPTION
Parser profiling currently depends on the query profiler already running while `ParseIterator` parses. That loses parser timings in lazy consumers such as the shell, where parsing happens before the statement is handed to execution.

This change:
- measures each parse-facing statement with `Profiler` and carries the completed timer on `SQLStatement`;
- transfers that timing through statement preprocessing and adds it when `CreatePreparedStatement` starts the correct per-statement `QueryProfiler`;
- keeps `query.sql` aligned with each statement in multi-statement input;
- avoids starting `QueryProfiler` for parse-only consumers such as `ExtractStatements`; and
- includes parser timing in `EXPLAIN ANALYZE` even when global profiling is disabled.

Validation:
- `CCACHE_DIR=/tmp/duckpgq-ccache make reldebug -j2`
- parser timing regression tests (22 assertions)
- `[parse_iterator]` tests (59 assertions)
- existing `Test query profiler` test
- `EXPLAIN ANALYZE (FORMAT json) SELECT 42;`
- format check against `upstream/main`