### PR TITLE
Fix: Do not produce invalid UTF8 from printf's %c conversion

### DIFF
--- a/extension/core_functions/scalar/string/printf.cpp
+++ b/extension/core_functions/scalar/string/printf.cpp
@@ -3,6 +3,7 @@
 #include "duckdb/common/limits.hpp"
 #include "fmt/format.h"
 #include "fmt/printf.h"
+#include "utf8proc_wrapper.hpp"
 
 namespace duckdb {
 
@@ -172,6 +173,11 @@ static void PrintfFunction(DataChunk &args, ExpressionState &state, Vector &resu
 
 		// finally actually perform the format
 		string dynamic_result = FORMAT_FUN::template OP<CTX>(format_string.c_str(), current_args);
+		if (!Utf8Proc::IsValid(dynamic_result.c_str(), dynamic_result.size())) {
+			throw InvalidInputException("Invalid UTF8 produced by format string \"%s\" - note that %%c writes a "
+			                            "single byte, use chr(...) to write a Unicode code point",
+			                            format_string);
+		}
 		result_data.WriteValue(dynamic_result);
 	}
 }

--- a/test/sql/function/string/test_printf.test
+++ b/test/sql/function/string/test_printf.test
@@ -144,6 +144,27 @@ SELECT printf('%c', 65)
 ----
 A
 
+# %c writes a single raw byte - it may not produce invalid UTF8
+statement error
+SELECT printf('%c', 255)
+----
+<REGEX>:Invalid Input Error:.*Invalid UTF8 produced by format string.*
+
+statement error
+SELECT lower(printf('%c', 255))
+----
+<REGEX>:Invalid Input Error:.*Invalid UTF8 produced by format string.*
+
+statement error
+SELECT strip_accents(printf('%c', 255))
+----
+<REGEX>:Invalid Input Error:.*Invalid UTF8 produced by format string.*
+
+statement error
+SELECT printf('%c', i) FROM range(200, 300) t(i)
+----
+<REGEX>:Invalid Input Error:.*Invalid UTF8 produced by format string.*
+
 # width trick
 query T
 SELECT printf('%*d', 5, 10)


### PR DESCRIPTION
Fixes #25166

`printf('%c', 255)` writes the raw byte `0xFF` into a VARCHAR, which isn't valid UTF-8. 
Everything downstream then falls on a string that was already corrupt before it got there:

```sql
SELECT lower(printf('%c', 255));         -- INTERNAL Error: invalid lead byte
SELECT trim(printf('%c', 255));          -- INTERNAL Error: string of size 18446744073709551613
SELECT strip_accents(printf('%c', 255)); -- Segfault
```

So reject a format result that isn't valid UTF-8 in the path shared by `printf` and `format`:

```
Invalid Input Error: Invalid UTF8 produced by format string "%c" - note that
%c writes a single byte, use chr(...) to write a Unicode code point
```

## Tests

Added to `test/sql/function/string/test_printf.test`