### PR TITLE
Add a session-scoped refresh overlay for secret storages

### DIFF
--- a/src/include/duckdb/main/secret/secret_manager.hpp
+++ b/src/include/duckdb/main/secret/secret_manager.hpp
@@ -101,6 +101,8 @@ public:
 	static constexpr const char *TRANSACTION_STORAGE_NAME = "transaction";
 	//! Connection-scoped storage: secrets live only for the creating connection and are reaped when it closes.
 	static constexpr const char *CONNECTION_STORAGE_NAME = "connection";
+	//! Session-scoped storage holding refreshed copies of secrets that live in another storage
+	static constexpr const char *REFRESH_STORAGE_NAME = "refresh";
 
 	//! Static Helper Functions
 	DUCKDB_API static SecretManager &Get(ClientContext &context);

--- a/src/include/duckdb/main/secret/secret_storage.hpp
+++ b/src/include/duckdb/main/secret/secret_storage.hpp
@@ -40,6 +40,7 @@ public:
 	//! Default storage backend offsets. Lower offsets win tie-breaks (equal path-match score), so the connection-scoped
 	//! storage is preferred over the global ones when a connection secret and a global secret match equally well.
 	static const int64_t TRANSACTION_STORAGE_OFFSET = 0;
+	static const int64_t REFRESH_STORAGE_OFFSET = 1;
 	static const int64_t CONNECTION_STORAGE_OFFSET = 5;
 	static const int64_t TEMPORARY_STORAGE_OFFSET = 10;
 	static const int64_t LOCAL_FILE_STORAGE_OFFSET = 20;
@@ -74,6 +75,12 @@ public:
 
 	virtual bool Persistent() const {
 		return persistent;
+	}
+
+	//! Whether this storage shadows the others. A shadowing storage holds a transient copy of a secret that also lives
+	//! in another storage, so by-name resolution reaches it first instead of reporting the two copies as ambiguous.
+	virtual bool Shadowing() const {
+		return false;
 	}
 
 protected:
@@ -195,7 +202,8 @@ protected:
 //! aborted transaction is undone, like in the global storages.
 class ConnectionSecretStorage : public SecretStorage {
 public:
-	explicit ConnectionSecretStorage(const string &name_p) : SecretStorage(name_p, CONNECTION_STORAGE_OFFSET) {
+	explicit ConnectionSecretStorage(const string &name_p, const int64_t offset = CONNECTION_STORAGE_OFFSET)
+	    : SecretStorage(name_p, offset), state_key("connection_secret_storage_" + name_p) {
 		// persistent stays false (base default): these secrets are connection-lifetime only.
 	}
 
@@ -209,6 +217,26 @@ public:
 	                         optional_ptr<CatalogTransaction> transaction = nullptr) override;
 	unique_ptr<SecretEntry> GetSecretByName(const string &name,
 	                                        optional_ptr<CatalogTransaction> transaction = nullptr) override;
+
+protected:
+	//! RegisteredStateManager key for this storage's per-connection container. Derived from the storage name so that
+	//! two connection-scoped storages on one context keep separate secrets.
+	string state_key;
+};
+
+//! Session-scoped storage holding refreshed copies of secrets that live in another storage. Re-resolved credential
+//! material is session-local: writing it back to its origin storage throws where the session cannot write, and
+//! durably mutates a shared store where it can. Refreshes land here instead, shadowing the origin so that one secret
+//! name stays unambiguous.
+class RefreshSecretStorage : public ConnectionSecretStorage {
+public:
+	explicit RefreshSecretStorage(const string &name_p) : ConnectionSecretStorage(name_p, REFRESH_STORAGE_OFFSET) {
+	}
+
+public:
+	bool Shadowing() const override {
+		return true;
+	}
 };
 
 } // namespace duckdb

--- a/src/main/secret/secret_manager.cpp
+++ b/src/main/secret/secret_manager.cpp
@@ -281,6 +281,10 @@ BoundStatement SecretManager::BindCreateSecret(CatalogTransaction transaction, C
 	if (info.persist_type == SecretPersistType::TRANSACTION || info.storage_type == TRANSACTION_STORAGE_NAME) {
 		throw BinderException("Transaction-scoped secrets cannot be created through SQL");
 	}
+	if (info.storage_type == REFRESH_STORAGE_NAME) {
+		throw BinderException("The '%s' secret storage is written by credential refreshes, not through SQL",
+		                      REFRESH_STORAGE_NAME);
+	}
 	InitializeSecrets(transaction);
 
 	auto type = info.type;
@@ -389,7 +393,21 @@ unique_ptr<SecretEntry> SecretManager::GetSecretByName(CatalogTransaction transa
 		return storage_lookup->GetSecretByName(name, &transaction);
 	}
 
+	// A shadowing storage holds a transient copy of a secret that also lives elsewhere, so it answers first rather
+	// than counting as a second match below.
 	for (const auto &storage_ref : GetSecretStorages()) {
+		if (!storage_ref.get().Shadowing()) {
+			continue;
+		}
+		if (auto lookup = storage_ref.get().GetSecretByName(name, &transaction)) {
+			return lookup;
+		}
+	}
+
+	for (const auto &storage_ref : GetSecretStorages()) {
+		if (storage_ref.get().Shadowing()) {
+			continue;
+		}
 		auto lookup = storage_ref.get().GetSecretByName(name, &transaction);
 		if (lookup) {
 			if (found) {
@@ -435,6 +453,12 @@ void SecretManager::DropSecretByName(CatalogTransaction transaction, const Ident
 		matches.push_back(*storage_lookup.get());
 	} else {
 		for (const auto &storage_ref : GetSecretStorages()) {
+			// A shadow must not outlive the secret it shadows, and must not read as a second match: drop it here
+			// rather than collecting it.
+			if (storage_ref.get().Shadowing()) {
+				storage_ref.get().DropSecretByName(name, OnEntryNotFound::RETURN_NULL, &transaction);
+				continue;
+			}
 			if (persist_type == SecretPersistType::PERSISTENT && !storage_ref.get().Persistent()) {
 				continue;
 			}
@@ -623,6 +647,10 @@ void SecretManager::InitializeSecrets(CatalogTransaction transaction) {
 		// load the connection-scoped storage: secrets created `IN connection_storage` are visible only to the
 		// connection that created them, and are dropped automatically when that connection closes.
 		LoadSecretStorageInternal(make_uniq<ConnectionSecretStorage>(CONNECTION_STORAGE_NAME));
+
+		// load the refresh overlay: a credential refresh re-resolves session-local material, so the refreshed copy
+		// lands here instead of being written back to the storage the secret was loaded from.
+		LoadSecretStorageInternal(make_uniq<RefreshSecretStorage>(REFRESH_STORAGE_NAME));
 
 		if (config.allow_persistent_secrets) {
 			// load the persistent storage if enabled

--- a/src/main/secret/secret_storage.cpp
+++ b/src/main/secret/secret_storage.cpp
@@ -333,8 +333,6 @@ void LocalFileSecretStorage::RemoveSecret(const string &secret, OnEntryNotFound 
 //===--------------------------------------------------------------------===//
 namespace {
 
-constexpr const char *CONNECTION_SECRET_STATE_KEY = "connection_secret_storage";
-
 //! Per-connection secret container. Lives on the ClientContext's RegisteredStateManager, so it is destroyed exactly
 //! when the connection (its ClientContext) goes away - giving automatic, crash-robust cleanup with no cooperation.
 //! Rollback is implemented here rather than by storing the secrets in a CatalogSet: the container is private to a
@@ -388,15 +386,16 @@ private:
 
 //! Fetch the calling connection's secret container. With create=false returns nullptr when there is no context or no
 //! container yet; with create=true it allocates the container on the context (used by StoreSecret).
-optional_ptr<ConnectionSecretState> GetConnectionState(optional_ptr<CatalogTransaction> transaction, bool create) {
+optional_ptr<ConnectionSecretState> GetConnectionState(optional_ptr<CatalogTransaction> transaction, bool create,
+                                                       const string &state_key) {
 	if (!transaction || !transaction->HasContext()) {
 		return nullptr;
 	}
 	auto &context = transaction->GetContext();
 	if (create) {
-		return context.registered_state->GetOrCreate<ConnectionSecretState>(CONNECTION_SECRET_STATE_KEY).get();
+		return context.registered_state->GetOrCreate<ConnectionSecretState>(state_key).get();
 	}
-	return context.registered_state->Get<ConnectionSecretState>(CONNECTION_SECRET_STATE_KEY).get();
+	return context.registered_state->Get<ConnectionSecretState>(state_key).get();
 }
 
 } // namespace
@@ -404,7 +403,7 @@ optional_ptr<ConnectionSecretState> GetConnectionState(optional_ptr<CatalogTrans
 unique_ptr<SecretEntry> ConnectionSecretStorage::StoreSecret(unique_ptr<const BaseSecret> secret,
                                                              OnCreateConflict on_conflict,
                                                              optional_ptr<CatalogTransaction> transaction) {
-	auto state = GetConnectionState(transaction, true);
+	auto state = GetConnectionState(transaction, true, state_key);
 	if (!state) {
 		throw InvalidInputException("Cannot create a connection-scoped secret without an active client context");
 	}
@@ -436,7 +435,7 @@ unique_ptr<SecretEntry> ConnectionSecretStorage::StoreSecret(unique_ptr<const Ba
 
 SecretMatch ConnectionSecretStorage::LookupSecret(const string &path, const string &type,
                                                   optional_ptr<CatalogTransaction> transaction) {
-	auto state = GetConnectionState(transaction, false);
+	auto state = GetConnectionState(transaction, false, state_key);
 	if (!state) {
 		// No connection context (or nothing stored yet) - decline, so the global storages serve this lookup.
 		return SecretMatch();
@@ -453,7 +452,7 @@ SecretMatch ConnectionSecretStorage::LookupSecret(const string &path, const stri
 
 unique_ptr<SecretEntry> ConnectionSecretStorage::GetSecretByName(const string &name,
                                                                  optional_ptr<CatalogTransaction> transaction) {
-	auto state = GetConnectionState(transaction, false);
+	auto state = GetConnectionState(transaction, false, state_key);
 	if (!state) {
 		return nullptr;
 	}
@@ -467,7 +466,7 @@ unique_ptr<SecretEntry> ConnectionSecretStorage::GetSecretByName(const string &n
 
 void ConnectionSecretStorage::DropSecretByName(const Identifier &name, OnEntryNotFound on_entry_not_found,
                                                optional_ptr<CatalogTransaction> transaction) {
-	auto state = GetConnectionState(transaction, false);
+	auto state = GetConnectionState(transaction, false, state_key);
 	idx_t erased = 0;
 	if (state) {
 		lock_guard<mutex> guard(state->lock);
@@ -483,7 +482,7 @@ void ConnectionSecretStorage::DropSecretByName(const Identifier &name, OnEntryNo
 
 vector<SecretEntry> ConnectionSecretStorage::AllSecrets(optional_ptr<CatalogTransaction> transaction) {
 	vector<SecretEntry> result;
-	auto state = GetConnectionState(transaction, false);
+	auto state = GetConnectionState(transaction, false, state_key);
 	if (!state) {
 		return result;
 	}


### PR DESCRIPTION
Enables the in-place credential refresh that duckdb/duckdb-httpfs#412 asks for, and resolves duckdb/duckdb-httpfs#195. Opening this for direction — happy to adjust the shape.

## Problem

A credential refresh re-resolves material that has gone stale. That material is session-local, but today an extension has only one way to record it: call `CreateSecret` again and let it write back to the storage the secret came from. That is wrong in both directions:

* **read-only storage session** → the write throws, so a read the fresh credentials could have served fails instead (duckdb/duckdb-httpfs#195, for an `sts`-chain persistent secret);
* **writable shared storage** → the refresh silently persists to a store other sessions read. A long-lived session was observed resurrecting rows another session had deleted hours earlier.

Landing the refreshed copy in some *other* existing storage does not work either: two copies of one name in two storages is exactly the state `GetSecretByName` and `DROP SECRET` report as ambiguous.

## Change

A `refresh` storage that holds the refreshed copy for the life of the session and shadows the original.

**Shadowing** is the new `SecretStorage` property: a shadowing storage holds a transient copy of a secret that also lives elsewhere, so by-name resolution reaches it first instead of counting it as a second match, and a `DROP SECRET` takes the shadow along with the secret it shadows.

```cpp
virtual bool Shadowing() const {
	return false;
}
```

Implementation notes:

* it reuses `ConnectionSecretStorage` — that per-`ClientContext` container already gives session lifetime, crash-robust cleanup and transaction rollback. Its `RegisteredStateManager` key is now derived from the storage name so the two instances keep separate secrets;
* its tie-break offset is `1`, below every storage but the transaction one. `LoadSecretStorage` already rejects a colliding offset, so a refreshed secret outranks its origin whatever offset that origin chose;
* `CREATE SECRET … IN refresh` is rejected in `BindCreateSecret` — the overlay is written by the refresh path, not by SQL;
* both copies stay visible in `duckdb_secrets()`, so a user can see that a refresh shadowed a stored secret:

```
┌───────────────┬────────────┬────────────┐
│     name      │ persistent │  storage   │
├───────────────┼────────────┼────────────┤
│ persistent_s3 │ true       │ local_file │
│ persistent_s3 │ false      │ refresh    │
└───────────────┴────────────┴────────────┘
```

## Consumer

duckdb/duckdb-httpfs#416 is the httpfs side and is what exercises this. Its `GenerateRefreshSecretInfo` becomes:

```cpp
if (result.persist_type != SecretPersistType::TRANSACTION) {
	result.persist_type = SecretPersistType::TEMPORARY;
	result.storage_type = Identifier(SecretManager::REFRESH_STORAGE_NAME);
}
```

so a refresh never writes to a secret storage — one rule, for every storage.

That PR also stands against an alternative, duckdb/duckdb-httpfs#413, which fixes the same correctness bug with no core change by routing the refresh to the transaction storage. It works, but the copy dies at each commit. Measured over three reads in three transactions against a mock S3 server: **12 wasted stale-credential round-trips** and three credential-chain resolutions, versus **4 and one** with this overlay — the same cost as a `memory`-backed secret. Maintainers can pick either; this is the one that needs core.

## Tests

Core suites run green: `test/sql/secrets/*` (including `connection_secret_storage.test` and `create_transaction_secret.test`), the hidden `[secret]` C++ tests (custom secret storage, tie-break penalty collisions, storage name collisions), `[api]` (171 cases), and `test/sql/catalog/*` (148 cases).

I have not added core-side tests yet — the behaviour is currently covered from the httpfs side. Glad to add them here once the shape looks right to you.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
