### PR TITLE
Report query text for relation API statements

### DIFF
--- a/src/include/duckdb/main/relation/materialized_relation.hpp
+++ b/src/include/duckdb/main/relation/materialized_relation.hpp
@@ -27,6 +27,7 @@ public:
 	string GetAlias() override;
 	unique_ptr<TableRef> GetTableRef() override;
 	unique_ptr<QueryNode> GetQueryNode() override;
+	string GetQuery() override;
 };
 
 } // namespace duckdb

--- a/src/main/relation/create_table_relation.cpp
+++ b/src/main/relation/create_table_relation.cpp
@@ -43,7 +43,13 @@ unique_ptr<QueryNode> CreateTableRelation::GetQueryNode() {
 }
 
 string CreateTableRelation::GetQuery() {
-	return string();
+	// reuse the catalog's prefix rendering for OR REPLACE / TEMP / IF NOT EXISTS
+	CreateTableInfo info;
+	info.on_conflict = on_conflict;
+	info.temporary = temporary;
+	return info.GetCreatePrefix("TABLE") +
+	       ParseInfo::QualifierToString(temporary ? "" : catalog_name, schema_name, table_name) + " AS " +
+	       child->GetQuery();
 }
 
 const vector<ColumnDefinition> &CreateTableRelation::Columns() {

--- a/src/main/relation/create_view_relation.cpp
+++ b/src/main/relation/create_view_relation.cpp
@@ -40,7 +40,12 @@ unique_ptr<QueryNode> CreateViewRelation::GetQueryNode() {
 }
 
 string CreateViewRelation::GetQuery() {
-	return string();
+	// reuse the catalog's prefix rendering for OR REPLACE / TEMP
+	CreateViewInfo info;
+	info.on_conflict = replace ? OnCreateConflict::REPLACE_ON_CONFLICT : OnCreateConflict::ERROR_ON_CONFLICT;
+	info.temporary = temporary;
+	return info.GetCreatePrefix("VIEW") + ParseInfo::QualifierToString("", schema_name, view_name) + " AS " +
+	       child->GetQuery();
 }
 
 const vector<ColumnDefinition> &CreateViewRelation::Columns() {

--- a/src/main/relation/delete_relation.cpp
+++ b/src/main/relation/delete_relation.cpp
@@ -31,7 +31,11 @@ unique_ptr<QueryNode> DeleteRelation::GetQueryNode() {
 }
 
 string DeleteRelation::GetQuery() {
-	return string();
+	string result = "DELETE FROM " + ParseInfo::QualifierToString(catalog_name, schema_name, table_name);
+	if (condition) {
+		result += " WHERE " + condition->ToString();
+	}
+	return result;
 }
 
 const vector<ColumnDefinition> &DeleteRelation::Columns() {
@@ -39,12 +43,7 @@ const vector<ColumnDefinition> &DeleteRelation::Columns() {
 }
 
 string DeleteRelation::ToString(idx_t depth) {
-	string str =
-	    RenderWhitespace(depth) + "DELETE FROM " + ParseInfo::QualifierToString(catalog_name, schema_name, table_name);
-	if (condition) {
-		str += " WHERE " + condition->ToString();
-	}
-	return str;
+	return RenderWhitespace(depth) + GetQuery();
 }
 
 } // namespace duckdb

--- a/src/main/relation/explain_relation.cpp
+++ b/src/main/relation/explain_relation.cpp
@@ -25,7 +25,14 @@ unique_ptr<QueryNode> ExplainRelation::GetQueryNode() {
 }
 
 string ExplainRelation::GetQuery() {
-	return string();
+	// reuse the statement's option rendering so ANALYZE and FORMAT stay in sync
+	ExplainStatement explain(nullptr, type, format);
+	auto options = explain.OptionsToString();
+	string result = "EXPLAIN";
+	if (!options.empty()) {
+		result += " " + options;
+	}
+	return result + " " + child->GetQuery();
 }
 
 const vector<ColumnDefinition> &ExplainRelation::Columns() {

--- a/src/main/relation/insert_relation.cpp
+++ b/src/main/relation/insert_relation.cpp
@@ -36,7 +36,8 @@ unique_ptr<QueryNode> InsertRelation::GetQueryNode() {
 }
 
 string InsertRelation::GetQuery() {
-	return string();
+	return "INSERT INTO " + ParseInfo::QualifierToString(catalog_name, schema_name, table_name) + " " +
+	       child->GetQuery();
 }
 
 const vector<ColumnDefinition> &InsertRelation::Columns() {

--- a/src/main/relation/materialized_relation.cpp
+++ b/src/main/relation/materialized_relation.cpp
@@ -47,6 +47,12 @@ string MaterializedRelation::GetAlias() {
 	return alias;
 }
 
+string MaterializedRelation::GetQuery() {
+	// the collection only exists in this process, so no SQL reproduces it. Naming it would produce a statement
+	// that binds against whatever else carries that name, so put the description in a comment instead
+	return "SELECT * FROM /* client-side data: " + alias + " */";
+}
+
 const vector<ColumnDefinition> &MaterializedRelation::Columns() {
 	return columns;
 }

--- a/src/main/relation/update_relation.cpp
+++ b/src/main/relation/update_relation.cpp
@@ -1,3 +1,4 @@
+#include "duckdb/common/sql_identifier.hpp"
 #include "duckdb/main/relation/update_relation.hpp"
 #include "duckdb/parser/statement/update_statement.hpp"
 #include "duckdb/planner/binder.hpp"
@@ -40,7 +41,17 @@ unique_ptr<QueryNode> UpdateRelation::GetQueryNode() {
 }
 
 string UpdateRelation::GetQuery() {
-	return string();
+	string result = "UPDATE " + ParseInfo::QualifierToString(catalog_name, schema_name, table_name) + " SET ";
+	for (idx_t i = 0; i < expressions.size(); i++) {
+		if (i > 0) {
+			result += ", ";
+		}
+		result += SQLIdentifier(update_columns[i]) + " = " + expressions[i]->ToString();
+	}
+	if (condition) {
+		result += " WHERE " + condition->ToString();
+	}
+	return result;
 }
 
 const vector<ColumnDefinition> &UpdateRelation::Columns() {
@@ -48,15 +59,7 @@ const vector<ColumnDefinition> &UpdateRelation::Columns() {
 }
 
 string UpdateRelation::ToString(idx_t depth) {
-	string str = RenderWhitespace(depth) + "UPDATE " +
-	             ParseInfo::QualifierToString(catalog_name, schema_name, table_name) + " SET\n";
-	for (idx_t i = 0; i < expressions.size(); i++) {
-		str += update_columns[i] + " = " + expressions[i]->ToString() + "\n";
-	}
-	if (condition) {
-		str += "WHERE " + condition->ToString() + "\n";
-	}
-	return str;
+	return RenderWhitespace(depth) + GetQuery();
 }
 
 } // namespace duckdb

--- a/src/main/relation/write_csv_relation.cpp
+++ b/src/main/relation/write_csv_relation.cpp
@@ -1,3 +1,4 @@
+#include "duckdb/common/sql_identifier.hpp"
 #include "duckdb/main/relation/write_csv_relation.hpp"
 #include "duckdb/parser/statement/copy_statement.hpp"
 #include "duckdb/parser/parsed_data/create_table_info.hpp"
@@ -30,7 +31,11 @@ unique_ptr<QueryNode> WriteCSVRelation::GetQueryNode() {
 }
 
 string WriteCSVRelation::GetQuery() {
-	return string();
+	CopyInfo info;
+	info.format = "csv";
+	info.is_format_auto_detected = false;
+	info.options = options;
+	return "COPY (" + child->GetQuery() + ") TO " + SQLString(csv_file) + info.CopyOptionsToString();
 }
 
 const vector<ColumnDefinition> &WriteCSVRelation::Columns() {

--- a/src/main/relation/write_parquet_relation.cpp
+++ b/src/main/relation/write_parquet_relation.cpp
@@ -1,3 +1,4 @@
+#include "duckdb/common/sql_identifier.hpp"
 #include "duckdb/main/relation/write_parquet_relation.hpp"
 #include "duckdb/parser/statement/copy_statement.hpp"
 #include "duckdb/parser/parsed_data/create_table_info.hpp"
@@ -30,7 +31,11 @@ unique_ptr<QueryNode> WriteParquetRelation::GetQueryNode() {
 }
 
 string WriteParquetRelation::GetQuery() {
-	return string();
+	CopyInfo info;
+	info.format = "parquet";
+	info.is_format_auto_detected = false;
+	info.options = options;
+	return "COPY (" + child->GetQuery() + ") TO " + SQLString(parquet_file) + info.CopyOptionsToString();
 }
 
 const vector<ColumnDefinition> &WriteParquetRelation::Columns() {

--- a/src/parser/parsed_data/copy_info.cpp
+++ b/src/parser/parsed_data/copy_info.cpp
@@ -1,4 +1,6 @@
 #include "duckdb/parser/parsed_data/copy_info.hpp"
+
+#include <algorithm>
 #include "duckdb/parser/query_node.hpp"
 
 namespace duckdb {
@@ -38,8 +40,9 @@ string CopyInfo::CopyOptionsToString() const {
 
 	result += " (";
 	vector<string> stringified;
+	string format_option;
 	if (!format.empty() && !is_format_auto_detected) {
-		stringified.push_back(StringUtil::Format(" FORMAT %s", format));
+		format_option = StringUtil::Format(" FORMAT %s", format);
 	}
 	for (auto &opt : parsed_options) {
 		auto &name = opt.first;
@@ -68,6 +71,11 @@ string CopyInfo::CopyOptionsToString() const {
 			}
 			stringified.push_back(option + "( " + StringUtil::Join(sub_values, ", ") + " )");
 		}
+	}
+	// the option maps are unordered - sort for stable text, FORMAT first
+	std::sort(stringified.begin(), stringified.end());
+	if (!format_option.empty()) {
+		stringified.insert(stringified.begin(), format_option);
 	}
 	result += StringUtil::Join(stringified, ", ");
 	result += " )";

--- a/test/api/test_relation_api.cpp
+++ b/test/api/test_relation_api.cpp
@@ -6,6 +6,14 @@
 #include "duckdb/main/relation/value_relation.hpp"
 #include "iostream"
 #include "test_helpers.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/parser/parser.hpp"
+#include "duckdb/parser/statement/relation_statement.hpp"
+#include "duckdb/main/relation/update_relation.hpp"
+#include "duckdb/main/relation/delete_relation.hpp"
+#include "duckdb/main/relation/create_view_relation.hpp"
+#include "duckdb/main/relation/explain_relation.hpp"
+#include "duckdb/main/relation/materialized_relation.hpp"
 #include "duckdb/main/relation/materialized_relation.hpp"
 
 using namespace duckdb;
@@ -1165,4 +1173,148 @@ TEST_CASE("Test create table with empty name", "[relation_api]") {
 
 	auto values = con.Values("(42)");
 	REQUIRE_THROWS_AS(values->Create(""), ParserException);
+}
+
+TEST_CASE("Test query text of relation API statements", "[relation_api]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE integers(i INTEGER)"));
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE dest(i INTEGER)"));
+
+	auto tbl = con.Table("integers");
+	// compose expectations from the child rather than hard-coding its SQL
+	auto child = tbl->GetQuery();
+	REQUIRE(!child.empty());
+
+	// action relations report the SQL they are equivalent to, rather than an empty string
+	REQUIRE(tbl->InsertRel(DEFAULT_SCHEMA, "dest")->GetQuery() == "INSERT INTO dest " + child);
+	REQUIRE(tbl->CreateRel(DEFAULT_SCHEMA, "new_tbl")->GetQuery() == "CREATE TABLE new_tbl AS " + child);
+	REQUIRE(tbl->WriteCSVRel("out.csv")->GetQuery() == "COPY (" + child + ") TO 'out.csv' ( FORMAT csv )");
+	REQUIRE(tbl->WriteParquetRel("out.parquet")->GetQuery() ==
+	        "COPY (" + child + ") TO 'out.parquet' ( FORMAT parquet )");
+
+	auto view_rel = make_shared_ptr<CreateViewRelation>(tbl, "v", false, false);
+	REQUIRE(view_rel->GetQuery() == "CREATE VIEW v AS " + child);
+
+	auto explain_rel = make_shared_ptr<ExplainRelation>(tbl);
+	REQUIRE(explain_rel->GetQuery() == "EXPLAIN " + child);
+
+	// the text survives being wrapped in a statement, which is what consumers read
+	auto insert_rel = tbl->InsertRel(DEFAULT_SCHEMA, "dest");
+	RelationStatement insert_stmt(insert_rel);
+	REQUIRE(insert_stmt.query == "INSERT INTO dest " + child);
+
+	// UPDATE / DELETE render their condition and SET list
+	auto delete_rel = make_shared_ptr<DeleteRelation>(tbl->context, make_uniq<ConstantExpression>(Value::BOOLEAN(true)),
+	                                                  INVALID_CATALOG, DEFAULT_SCHEMA, "integers");
+	REQUIRE(delete_rel->GetQuery() == "DELETE FROM integers WHERE " + Value::BOOLEAN(true).ToSQLString());
+
+	duckdb::vector<duckdb::unique_ptr<ParsedExpression>> update_expressions;
+	update_expressions.push_back(make_uniq<ConstantExpression>(Value::INTEGER(42)));
+	auto update_rel =
+	    make_shared_ptr<UpdateRelation>(tbl->context, nullptr, INVALID_CATALOG, DEFAULT_SCHEMA, "integers",
+	                                    duckdb::vector<string> {"i"}, std::move(update_expressions));
+	REQUIRE(update_rel->GetQuery() == "UPDATE integers SET i = 42");
+}
+
+TEST_CASE("Test query text uses the canonical CREATE prefix and EXPLAIN options", "[relation_api]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE integers(i INTEGER)"));
+	auto tbl = con.Table("integers");
+	auto child = tbl->GetQuery();
+
+	// TEMP, not TEMPORARY - matches CreateInfo::GetCreatePrefix. A temporary table drops the catalog, as
+	// CreateTableInfo::ToString does.
+	auto temp_tbl =
+	    tbl->CreateRel(INVALID_CATALOG, DEFAULT_SCHEMA, "tmp_tbl", true, OnCreateConflict::REPLACE_ON_CONFLICT);
+	REQUIRE(temp_tbl->GetQuery() == "CREATE OR REPLACE TEMP TABLE tmp_tbl AS " + child);
+
+	auto temp_view = make_shared_ptr<CreateViewRelation>(tbl, "tmp_v", true, true);
+	REQUIRE(temp_view->GetQuery() == "CREATE OR REPLACE TEMP VIEW tmp_v AS " + child);
+
+	// EXPLAIN carries ANALYZE through
+	auto analyze = make_shared_ptr<ExplainRelation>(tbl, ExplainType::EXPLAIN_ANALYZE);
+	REQUIRE(analyze->GetQuery() == "EXPLAIN (ANALYZE) " + child);
+}
+
+TEST_CASE("Test query text quotes identifiers that need it", "[relation_api]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE integers(i INTEGER)"));
+	// "target" is a keyword and "my table" has a space - both must be quoted to stay valid SQL
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE target(i INTEGER)"));
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE \"my table\"(i INTEGER)"));
+
+	auto tbl = con.Table("integers");
+	auto child = tbl->GetQuery();
+	REQUIRE(tbl->InsertRel(DEFAULT_SCHEMA, "target")->GetQuery() == "INSERT INTO \"target\" " + child);
+	REQUIRE(tbl->InsertRel(DEFAULT_SCHEMA, "my table")->GetQuery() == "INSERT INTO \"my table\" " + child);
+
+	// the rendered text is valid SQL that round-trips through the parser
+	Parser parser;
+	REQUIRE_NOTHROW(parser.ParseQuery(tbl->InsertRel(DEFAULT_SCHEMA, "my table")->GetQuery()));
+	REQUIRE(parser.statements.size() == 1);
+}
+
+TEST_CASE("Test synthesized query text is never truncated", "[relation_api]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE dest(i INTEGER)"));
+
+	// A shortened statement can still parse - cutting a UNION ALL chain after a complete SELECT leaves valid SQL
+	// that inserts fewer rows. ClientContext forwards `query` to Catalog::RemoteExecute for a catalog that
+	// declares RemoteCapability::CONNECT, so query text is reported whole or not at all.
+	string sel = "SELECT 1 AS i";
+	for (idx_t i = 2; i <= 600; i++) {
+		sel += " UNION ALL SELECT " + std::to_string(i);
+	}
+	auto ins = con.RelationFromQuery(sel)->InsertRel(DEFAULT_SCHEMA, "dest");
+	RelationStatement stmt(ins);
+	REQUIRE(!StringUtil::Contains(stmt.query, "truncated"));
+	REQUIRE(StringUtil::Contains(stmt.query, "SELECT 600"));
+
+	// the reported text runs to the same effect as the relation itself
+	REQUIRE_NO_FAIL(con.Query(stmt.query));
+	auto count = con.Query("SELECT count(*) FROM dest");
+	REQUIRE(CHECK_COLUMN(count, 0, {600}));
+}
+
+TEST_CASE("Test client-side data relations report either faithful or non-SQL text", "[relation_api]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE dest(i INTEGER)"));
+
+	// A value list carries its rows inside the statement, so its text is reported in full and runs to the same
+	// effect wherever it is sent.
+	auto values = con.Values("(42), (84)");
+	RelationStatement direct(values);
+	REQUIRE(StringUtil::Contains(direct.query, "42"));
+	RelationStatement embedded(values->InsertRel(DEFAULT_SCHEMA, "dest"));
+	REQUIRE(StringUtil::Contains(embedded.query, "42"));
+	REQUIRE_NO_FAIL(con.Query(embedded.query));
+	auto sum_result = con.Query("SELECT sum(i)::INTEGER FROM dest");
+	REQUIRE(CHECK_COLUMN(sum_result, 0, {126}));
+
+	// A materialized collection exists only in this process, so no SQL reproduces it. Naming it would produce a
+	// statement that binds against whatever else carries that name - describe it instead.
+	auto result = con.Query("SELECT 7 AS i");
+	auto &materialized_result = result->Cast<MaterializedQueryResult>();
+	auto materialized = make_shared_ptr<MaterializedRelation>(con.context, materialized_result.TakeCollection(),
+	                                                          result->names, "uploaded");
+	RelationStatement mat(materialized);
+	REQUIRE(mat.query == "SELECT * FROM /* client-side data: uploaded */");
+	RelationStatement mat_insert(materialized->InsertRel(DEFAULT_SCHEMA, "dest"));
+	REQUIRE(mat_insert.query == "INSERT INTO dest SELECT * FROM /* client-side data: uploaded */");
+
+	// neither form can be mistaken for a runnable statement
+	for (auto &text : duckdb::vector<string> {mat.query, mat_insert.query}) {
+		Parser parser;
+		REQUIRE_THROWS(parser.ParseQuery(text));
+	}
+	// but the relation itself still executes
+	REQUIRE_NO_FAIL(materialized->InsertRel(DEFAULT_SCHEMA, "dest")->Execute());
+	auto count_result = con.Query("SELECT count(*)::INTEGER FROM dest WHERE i = 7");
+	REQUIRE(CHECK_COLUMN(count_result, 0, {1}));
 }


### PR DESCRIPTION
Relations that perform an action rather than produce rows return an empty string from `GetQuery()`, so executing them through the Relation API leaves `SQLStatement::query` blank. Anything reading that field such as the profiler, `current_query()`, or a catalog that receives forwarded SQL has no way to attribute the query. A load driven by `rel.insert_into(...)` reports no SQL at all, while the same load written as `con.execute("INSERT INTO ...")` is fully attributable.

This is the same class of bug as #22769 (PIVOT's `MultiStatement` rewrite) and #22057 (the `ALTER TABLE ... ADD COLUMN ... DEFAULT` backfill): an internally-synthesized `SQLStatement` whose `.query` was never populated. Those two had a SQL string available and simply failed to propagate it. The Relation API is different in kind since these paths never go through SQL text at all, so there is nothing to propagate and the text has to be synthesized.

The empty string is an unfinished corner rather than a design decision. Previous PRs split out a `GetQuery()` method and stubbing those relations to `return string();`. This fills the stubs in.

### What each relation reports

| Relation | Query text |
|---|---|
| `InsertRelation` | `INSERT INTO <name> <child>` |
| `CreateTableRelation` | `CREATE [OR REPLACE] [TEMP] TABLE [IF NOT EXISTS] <name> AS <child>` |
| `CreateViewRelation` | `CREATE [OR REPLACE] [TEMP] VIEW <name> AS <child>` |
| `DeleteRelation` | `DELETE FROM <name> [WHERE <cond>]` |
| `UpdateRelation` | `UPDATE <name> SET <col> = <expr>, … [WHERE <cond>]` |
| `WriteParquetRelation` / `WriteCSVRelation` | `COPY (<child>) TO '<file>' ( FORMAT … )` |
| `ExplainRelation` | `EXPLAIN [(ANALYZE)] <child>` |

The prefixes come from `CreateInfo::GetCreatePrefix` and `ExplainStatement::OptionsToString` rather than being spelled out again, so `OR REPLACE` / `TEMP` / `IF NOT EXISTS` and `ANALYZE` stay in step with the SQL those already render. `DeleteRelation::ToString` and `UpdateRelation::ToString` now delegate to `GetQuery()` instead of duplicating it; the relations that render a child keep their tree form, which is what `Print` is for.
