### PR TITLE
Fix duplicate table filter cardinality estimation

### DIFF
--- a/src/include/duckdb/planner/operator/logical_get.hpp
+++ b/src/include/duckdb/planner/operator/logical_get.hpp
@@ -87,6 +87,8 @@ public:
 	vector<ColumnIndex> &GetMutableColumnIds();
 	vector<ColumnBinding> GetColumnBindings() override;
 	idx_t EstimateCardinality(ClientContext &context) override;
+	//! Estimate cardinality from the source without using this operator's cached estimate.
+	idx_t EstimateSourceCardinality(ClientContext &context);
 	bool TryGetStorageIndex(const ColumnIndex &column_index, StorageIndex &out_index) const;
 	void SetScanOrder(unique_ptr<RowGroupOrderOptions> options);
 	void SetPartitionsToScan(vector<idx_t> partition_indices);

--- a/src/optimizer/relation_statistics/relation_statistics_scan.cpp
+++ b/src/optimizer/relation_statistics/relation_statistics_scan.cpp
@@ -133,7 +133,7 @@ DistinctCount RelationStatisticsHelper::GetDistinctCount(LogicalGet &get, Client
 
 RelationStats RelationStatisticsHelper::ExtractGetStats(LogicalGet &get, ClientContext &context) {
 	RelationStats result;
-	auto base_table_cardinality = get.EstimateCardinality(context);
+	auto base_table_cardinality = get.EstimateSourceCardinality(context);
 	auto cardinality_after_filters = base_table_cardinality;
 	result.table_name = get.GetTable() ? get.GetTable()->name : Identifier(get.GetName());
 

--- a/src/planner/operator/logical_get.cpp
+++ b/src/planner/operator/logical_get.cpp
@@ -276,6 +276,10 @@ idx_t LogicalGet::EstimateCardinality(ClientContext &context) {
 	if (has_estimated_cardinality) {
 		return estimated_cardinality;
 	}
+	return EstimateSourceCardinality(context);
+}
+
+idx_t LogicalGet::EstimateSourceCardinality(ClientContext &context) {
 	if (function.cardinality) {
 		auto node_stats = function.cardinality(context, bind_data.get());
 		if (node_stats && node_stats->has_estimated_cardinality) {

--- a/test/optimizer/partial_aggregate_pushdown.test
+++ b/test/optimizer/partial_aggregate_pushdown.test
@@ -1338,7 +1338,7 @@ EXPLAIN SELECT o.k, count(e.event_id)
 FROM outer_count_nullable o LEFT JOIN outer_count_events e ON o.k = e.k AND e.keep
 GROUP BY o.k
 ----
-physical_plan	<!REGEX>:.*COALESCE.*
+physical_plan	<REGEX>:.*COALESCE.*
 
 # NULL owner keys retain their unmatched count semantics when reliable key statistics are available.
 query II


### PR DESCRIPTION
The current implementation of `RelationStatisticsHelper::ExtractGetStats` first calls `get.EstimateCardinality` to get the base cardinality. If the `get` has table filters, it then estimates the output cardinality after applying those filters.

However, the result of `LogicalGet::EstimateCardinality` may already include the effect of the table filters. As a result, `ExtractGetStats` can apply the same filters twice and produce an incorrect estimate.

The main issue is that `LogicalGet::EstimateCardinality` does not distinguish between the source cardinality and the output cardinality of `LogicalGet`. This PR adds `LogicalGet::EstimateSourceCardinality` to return the cardinality of the source itself.

In the following example, the table filter selectivity is applied twice. The pre-aggregation optimizer estimates `fact` as having only `100 * 0.2 * 0.2 = 4` rows and incorrectly skips pre-aggregation. After the fix, pre-aggregation is selected successfully.

```sql
CREATE TABLE dim(k INTEGER);
INSERT INTO dim VALUES (1), (2);

CREATE TABLE fact(k INTEGER);
INSERT INTO fact SELECT 1 + i % 2 FROM range(100) t(i);

ANALYZE;

EXPLAIN
SELECT o.k, count(f.k)
FROM dim o
LEFT JOIN fact f ON o.k = f.k AND f.k > 0
GROUP BY o.k;
```

After this fix, an existing test that previously did not trigger pushdown now does, which is the expected behavior.