### PR TITLE
Prune multi-column interval comparisons

### DIFF
--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -449,8 +449,30 @@ static bool IsDirectNumericColumnComparison(const Expression &expr, const vector
 	       right.GetReturnType().IsNumeric();
 }
 
+static bool IsMonotoneIntervalColumn(const Expression &expr) {
+	if (expr.GetExpressionClass() != ExpressionClass::BOUND_FUNCTION || expr.GetReturnType() != LogicalType::INTERVAL) {
+		return false;
+	}
+	const auto &function = expr.Cast<BoundFunctionExpression>();
+	return function.GetChildren().size() == 1 &&
+	       function.GetChildren()[0]->GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF &&
+	       function.Function().GetStability() == FunctionStability::CONSISTENT &&
+	       IsKnownMonotonic(function.Function().GetArgProperties(0).monotonicity);
+}
+
+static bool IsMonotoneIntervalColumnComparison(const Expression &expr, const vector<ColumnBinding> &bindings) {
+	if (bindings.size() != 2 || bindings[0] == bindings[1] || !BoundComparisonExpression::IsComparison(expr)) {
+		return false;
+	}
+	const auto &comparison = expr.Cast<BoundFunctionExpression>();
+	return SupportedFilterComparison(comparison.GetExpressionType()) &&
+	       IsMonotoneIntervalColumn(BoundComparisonExpression::Left(comparison)) &&
+	       IsMonotoneIntervalColumn(BoundComparisonExpression::Right(comparison));
+}
+
 static bool CanPushdownMultiColumnExpression(const Expression &expr, const vector<ColumnBinding> &bindings) {
-	return IsDirectNumericColumnComparison(expr, bindings) || IsColumnConstantOr(expr);
+	return IsDirectNumericColumnComparison(expr, bindings) || IsMonotoneIntervalColumnComparison(expr, bindings) ||
+	       IsColumnConstantOr(expr);
 }
 
 static unique_ptr<ExpressionFilter> TryCreateMultiColumnExpressionFilter(LogicalGet &get, const Expression &expr,

--- a/src/optimizer/statistics/expression/propagate_comparison.cpp
+++ b/src/optimizer/statistics/expression/propagate_comparison.cpp
@@ -132,6 +132,7 @@ FilterPropagateResult StatisticsPropagator::PropagateComparison(const BaseStatis
 	case PhysicalType::INT128:
 	case PhysicalType::FLOAT:
 	case PhysicalType::DOUBLE:
+	case PhysicalType::INTERVAL:
 		break;
 	default:
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;

--- a/test/sql/optimizer/interval_column_stats_pruning.test
+++ b/test/sql/optimizer/interval_column_stats_pruning.test
@@ -1,0 +1,28 @@
+# name: test/sql/optimizer/interval_column_stats_pruning.test
+# description: Use row-group statistics for interval column comparisons
+# group: [optimizer]
+
+statement ok
+ATTACH '{TEST_DIR}/interval_column_stats_pruning.duckdb' AS db (ROW_GROUP_SIZE 2048, STORAGE_VERSION 'v2.0.0');
+
+statement ok
+USE db;
+
+statement ok
+CREATE TABLE interval_pairs AS
+SELECT (CASE range // 2048 WHEN 0 THEN 1 WHEN 1 THEN 1 ELSE 10 END) * INTERVAL '1 day' AS a,
+       (CASE range // 2048 WHEN 0 THEN 10 WHEN 1 THEN 10 ELSE 1 END) * INTERVAL '1 day' AS b
+FROM range(6144);
+
+statement ok
+CHECKPOINT;
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM interval_pairs WHERE a > b;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
+
+query I
+SELECT count(*) FROM interval_pairs WHERE a > b;
+----
+2048


### PR DESCRIPTION
## Summary

cross-column interval comparisons currently do not use row-group statistics for pruning. This change adds monotone interval expressions to the existing multi-column comparison path, allowing non-matching row groups to be skipped using interval min/max statistics.

## Results

```sql
ATTACH '/tmp/interval_prune.duckdb' AS db (ROW_GROUP_SIZE 2048, STORAGE_VERSION 'v2.0.0');
USE db;
CREATE TABLE interval_pairs AS
SELECT (CASE range // 2048 WHEN 0 THEN 1 WHEN 1 THEN 1 ELSE 10 END) * INTERVAL '1 day' AS a,
       (CASE range // 2048 WHEN 0 THEN 10 WHEN 1 THEN 10 ELSE 1 END) * INTERVAL '1 day' AS b
FROM range(6144);
CHECKPOINT;
EXPLAIN ANALYZE SELECT count(*) FROM interval_pairs WHERE a > b;
```

### Before

```sql
╭─ Summary ───────────╮
│ Total Time: 0.0011s │
╰─────────────────────╯
╭─ Ungrouped Aggregate ───────────────────────────╮
│ Aggregates: count_star()                        │
│ 1 row                                       0µs │
╰────────────────────────┰────────────────────────╯
╭─ Filter ───────────────┸────────────────────────╮
│ Expression:                                     │
│ normalized_interval(a) > normalized_interval(b) │
│ 2,048 rows                                  0µs │
╰────────────────────────┒┎───────────────────────╯
╭─ Table Scan ───────────┚┖───────────────────────╮
│ Table: db.main.interval_pairs                   │
│ Type: Sequential Scan                           │
│ Projections: a, b                               │
│ Row Groups Scanned: 3 / 3                       │
│ 6,144 rows                                  0µs │
╰─────────────────────────────────────────────────╯
```

### After

```sql
╭─ Summary ───────────╮
│ Total Time: 0.0007s │
╰─────────────────────╯
╭─ Ungrouped Aggregate ───────────────────────────╮
│ Aggregates: count_star()                        │
│ 1 row                                       0µs │
╰────────────────────────┒┎───────────────────────╯
╭─ Filter ───────────────┚┖───────────────────────╮
│ Expression:                                     │
│ normalized_interval(a) > normalized_interval(b) │
│ 2,048 rows                                  0µs │
╰────────────────────────┒┎───────────────────────╯
╭─ Table Scan ───────────┚┖───────────────────────╮
│ Table: db.main.interval_pairs                   │
│ Type: Sequential Scan                           │
│ Projections: a, b                               │
│ Row Groups Scanned: 1 / 3                       │
│ 2,048 rows                                  0µs │
╰─────────────────────────────────────────────────╯
```
