### PR TITLE
[Parser] Replace `PEGToken` with `PEGExpression`

### DIFF
--- a/src/include/duckdb/parser/peg/matcher_factory.hpp
+++ b/src/include/duckdb/parser/peg/matcher_factory.hpp
@@ -2,41 +2,29 @@
 
 #include "duckdb/common/string_map_set.hpp"
 #include "duckdb/common/optional.hpp"
+#include "duckdb/common/queue.hpp"
 #include "duckdb/parser/peg/matcher/list.hpp"
 
 namespace duckdb {
 struct CompiledGrammar;
+struct PEGExpression;
 
 class MatcherFactory;
 
 //! Class for building matchers
 class MatcherFactory {
 private:
-	struct MatcherList {
-	public:
-		struct Entry {
-			explicit Entry(Matcher &matcher) : matcher(matcher), function_name() {
-			}
-			Entry(Matcher &matcher, string_t function_name_p) : matcher(matcher), function_name(function_name_p) {
-			}
-
-			Matcher &matcher;
-			//! Left empty for non-function entries
-			optional<string_t> function_name;
-		};
-
-	public:
-		explicit MatcherList(MatcherFactory &factory);
-		void AddMatcher(Matcher &matcher);
-		void AddRootMatcher(Matcher &matcher);
-		idx_t GetRootMatcherCount() const;
-		void BeginFunction(string_t function_name);
-		void CloseBracket();
-		MatcherList::Entry &GetLastRootMatcher();
+	struct MatcherConstructionState {
+		void Register(string_t rule_name);
+		void Schedule(string_t rule_name);
+		bool Begin(string_t rule_name);
+		bool HasScheduled() const;
+		string_t TakeNext();
 
 	private:
-		MatcherFactory &factory;
-		vector<MatcherList::Entry> matchers;
+		string_set_t unconstructed;
+		string_set_t scheduled;
+		queue<string_t> pending;
 	};
 
 public:
@@ -44,11 +32,8 @@ public:
 	virtual ~MatcherFactory() = default;
 
 public:
-	//! Create a matcher from a PEG grammar
-	Matcher &CreateMatcher(string_t root_rule);
 	Matcher &CreateRootMatcher(const string &root_rule);
-	//! Look up a matcher for a rule that was already built (as a sub-rule of a previous
-	//! CreateMatcher call). Throws if the rule has not been built.
+	//! Look up a matcher for a rule that was built by CreateRootMatcher. Throws if the rule has not been built.
 	Matcher &GetMatcher(const string &rule_name);
 
 private:
@@ -70,13 +55,17 @@ private:
 	void AddRuleOverride(const char *name, Matcher &matcher);
 	void AddPackratMemoizedRule(const char *name);
 	void SuppressSuggestions(const char *name);
+	Matcher &CreateMatcher(string_t rule_name);
 	Matcher &CreateMatcher(string_t rule_name, vector<reference<Matcher>> &parameters);
+	Matcher &CreateMatcher(const PEGExpression &expression, const string_map_t<idx_t> &parameter_map,
+	                       vector<reference<Matcher>> &parameters);
 
 private:
 	MatcherAllocator &allocator;
 	const ParsedGrammar &grammar;
 	CompiledGrammar &compiled;
 	string_map_t<reference<Matcher>> matchers;
+	MatcherConstructionState construction_state;
 	mutable case_insensitive_map_t<reference<KeywordMatcher>> keywords;
 	case_insensitive_map_t<KeywordInfo> keyword_overrides;
 	string_set_t no_suggestion_rules;

--- a/src/include/duckdb/parser/peg/peg_parser.hpp
+++ b/src/include/duckdb/parser/peg/peg_parser.hpp
@@ -1,52 +1,56 @@
 #pragma once
 #include "duckdb/common/case_insensitive_map.hpp"
 #include "duckdb/common/string_map_set.hpp"
+#include "duckdb/common/vector.hpp"
+#include "duckdb/common/string.hpp"
 #include "duckdb/common/windows_undefs.hpp"
 
 namespace duckdb {
-enum class PEGRuleType {
-	LITERAL,   // literal rule ('Keyword')
-	REFERENCE, // reference to another rule (Rule)
-	OPTIONAL,  // optional rule (Rule?)
-	OR,        // or rule (Rule1 / Rule2)
-	REPEAT     // repeat rule (Rule1*
-};
 
-enum class PEGTokenType {
-	LITERAL,       // literal token ('Keyword')
-	REFERENCE,     // reference token (Rule)
-	OPERATOR,      // operator token (/ or )
-	FUNCTION_CALL, // start of function call (i.e. Function(...))
-	REGEX          // regular expression ([ \t\n\r] or <[a-z_]i[a-z0-9_]i>)
-};
+struct PEGExpression {
+	enum class Type : uint8_t {
+		LITERAL,         // keyword/string literal
+		REFERENCE,       // reference to a parameter or another rule
+		FUNCTION_CALL,   // function-call marker wrapping a child
+		SEQUENCE,        // ordered "AND" of children
+		CHOICE,          // "OR" between children ('/')
+		OPTIONAL,        // child?
+		REPEAT,          // child+  (one or more)
+		OPTIONAL_REPEAT, // child*  (zero or more)
+		REGEX            // regex
+	};
 
-struct PEGToken {
-	PEGTokenType type;
+public:
+	explicit PEGExpression(Type type_p) : type(type_p), text(string_t("")) {
+	}
+	PEGExpression(Type type_p, string_t text_p) : type(type_p), text(std::move(text_p)) {
+	}
+
+public:
+	Type type;
+	//! literal text / reference name / function name
 	string_t text;
+	//! used by SEQUENCE, CHOICE, OPTIONAL, REPEAT*, FUNCTION_CALL
+	vector<PEGExpression> children;
 };
 
 struct PEGRule {
-	string_map_t<idx_t> parameters;
-	vector<PEGToken> tokens;
-
-	void Clear() {
-		parameters.clear();
-		tokens.clear();
+public:
+	PEGRule(string_map_t<idx_t> &&parameters, PEGExpression &&expression)
+	    : parameters(std::move(parameters)), expression(std::move(expression)) {
 	}
+
+public:
+	string_map_t<idx_t> parameters;
+	PEGExpression expression;
 };
 
 struct PEGParser {
 public:
 	void ParseRules(const char *grammar);
-	void AddRule(string_t rule_name, PEGRule rule);
+	void AddRule(string_t rule_name, PEGRule &&rule);
 
 	case_insensitive_map_t<PEGRule> rules;
-};
-
-enum class PEGParseState {
-	RULE_NAME,      // Rule name
-	RULE_SEPARATOR, // look for <-
-	RULE_DEFINITION // part of rule definition
 };
 
 inline bool IsPEGOperator(char c) {

--- a/src/parser/peg/compiled_grammar.cpp
+++ b/src/parser/peg/compiled_grammar.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/parser/peg/compiled_grammar.hpp"
 #include "duckdb/parser/peg/matcher_factory.hpp"
 #include "duckdb/parser/peg/keyword_helper/parsed_grammar_keyword_helper.hpp"
+#include "duckdb/common/string_util.hpp"
 #include "duckdb/main/database.hpp"
 #include "duckdb/main/client_config.hpp"
 
@@ -42,6 +43,23 @@ static void ValidateParsedGrammarRoots(const ParsedGrammar &grammar) {
 	}
 }
 
+static void CheckReference(const ParsedGrammar &grammar, const ParsedGrammarRule &parsed_rule,
+                           const PEGExpression &expression) {
+	if (expression.type == PEGExpression::Type::REFERENCE || expression.type == PEGExpression::Type::FUNCTION_CALL) {
+		if (expression.type != PEGExpression::Type::REFERENCE ||
+		    !parsed_rule.recipe.parameters.count(expression.text)) {
+			if (!StringUtil::CIEquals(expression.text.GetString(), "EndOfInput") &&
+			    !grammar.GetRule(expression.text.GetString())) {
+				throw InvalidInputException("Grammar rule '%s' references missing rule '%s'", parsed_rule.name,
+				                            expression.text.GetString());
+			}
+		}
+	}
+	for (auto &child : expression.children) {
+		CheckReference(grammar, parsed_rule, child);
+	}
+}
+
 shared_ptr<CompiledGrammar> ParserCache::GetMatcher(optional_ptr<ClientContext> context) {
 	{
 		std::unique_lock<std::mutex> lock(mutex);
@@ -53,19 +71,8 @@ shared_ptr<CompiledGrammar> ParserCache::GetMatcher(optional_ptr<ClientContext> 
 	auto grammar = ParsedGrammar::CreateDefault();
 	ValidateParsedGrammarRoots(grammar);
 	for (auto &entry : grammar.rules) {
-		auto &rule = *entry.second;
-		for (auto &token : rule.recipe.tokens) {
-			if (token.type != PEGTokenType::REFERENCE && token.type != PEGTokenType::FUNCTION_CALL) {
-				continue;
-			}
-			if (token.type == PEGTokenType::REFERENCE && rule.recipe.parameters.count(token.text)) {
-				continue;
-			}
-			if (!grammar.GetRule(token.text.GetString())) {
-				throw InvalidInputException("Grammar rule '%s' references missing rule '%s'", rule.name,
-				                            token.text.GetString());
-			}
-		}
+		auto &parsed_rule = *entry.second;
+		CheckReference(grammar, parsed_rule, parsed_rule.recipe.expression);
 	}
 
 	auto new_matcher = shared_ptr<CompiledGrammar>(new CompiledGrammar(*this, grammar));

--- a/src/parser/peg/keyword_helper/parsed_grammar_keyword_helper.cpp
+++ b/src/parser/peg/keyword_helper/parsed_grammar_keyword_helper.cpp
@@ -7,6 +7,26 @@
 namespace duckdb {
 
 static void PopulateKeywordMap(const ParsedGrammar &grammar, const string &root_rule_name, const string &rule_name,
+                               case_insensitive_set_t &keyword_map, case_insensitive_set_t &active_rules);
+
+static void ExpressionToKeyword(const ParsedGrammar &grammar, const string &root_rule_name, const string &rule_name,
+                                const PEGExpression &expression, case_insensitive_set_t &keyword_map,
+                                case_insensitive_set_t &active_rules) {
+	if (expression.type == PEGExpression::Type::LITERAL) {
+		keyword_map.insert(StringUtil::Lower(expression.text.GetString()));
+	} else if (expression.type == PEGExpression::Type::REFERENCE) {
+		PopulateKeywordMap(grammar, root_rule_name, expression.text.GetString(), keyword_map, active_rules);
+	} else if (expression.type == PEGExpression::Type::CHOICE) {
+		for (auto &child : expression.children) {
+			ExpressionToKeyword(grammar, root_rule_name, rule_name, child, keyword_map, active_rules);
+		}
+	} else {
+		throw InvalidInputException("Keyword grammar rule '%s' contains unsupported token '%s' in rule '%s'",
+		                            root_rule_name, expression.text.GetString(), rule_name);
+	}
+}
+
+static void PopulateKeywordMap(const ParsedGrammar &grammar, const string &root_rule_name, const string &rule_name,
                                case_insensitive_set_t &keyword_map, case_insensitive_set_t &active_rules) {
 	if (!active_rules.insert(rule_name).second) {
 		throw InvalidInputException("Keyword grammar rule '%s' contains a recursive reference to rule '%s'",
@@ -22,28 +42,7 @@ static void PopulateKeywordMap(const ParsedGrammar &grammar, const string &root_
 		                            rule_name);
 	}
 
-	bool expect_keyword = true;
-	for (auto &token : rule.recipe.tokens) {
-		if (expect_keyword) {
-			switch (token.type) {
-			case PEGTokenType::LITERAL:
-				keyword_map.insert(StringUtil::Lower(token.text.GetString()));
-				break;
-			case PEGTokenType::REFERENCE:
-				PopulateKeywordMap(grammar, root_rule_name, token.text.GetString(), keyword_map, active_rules);
-				break;
-			default:
-				throw InvalidInputException("Keyword grammar rule '%s' contains unsupported token '%s' in rule '%s'",
-				                            root_rule_name, token.text.GetString(), rule_name);
-			}
-		} else if (token.type != PEGTokenType::OPERATOR || token.text.GetString() != "/") {
-			throw InvalidInputException("Keyword grammar rule '%s' must contain only alternatives", root_rule_name);
-		}
-		expect_keyword = !expect_keyword;
-	}
-	if (expect_keyword) {
-		throw InvalidInputException("Keyword grammar rule '%s' ends with an incomplete alternative", root_rule_name);
-	}
+	ExpressionToKeyword(grammar, root_rule_name, rule_name, rule.recipe.expression, keyword_map, active_rules);
 	active_rules.erase(rule_name);
 }
 

--- a/src/parser/peg/matcher_factory.cpp
+++ b/src/parser/peg/matcher_factory.cpp
@@ -5,240 +5,131 @@
 
 namespace duckdb {
 
-MatcherFactory::MatcherList::MatcherList(MatcherFactory &factory) : factory(factory) {
+void MatcherFactory::MatcherConstructionState::Register(string_t rule_name) {
+	unconstructed.insert(rule_name);
 }
 
-void MatcherFactory::MatcherList::AddMatcher(Matcher &matcher) {
-	auto &root_matcher = matchers.back().matcher;
-	switch (root_matcher.Type()) {
-	case MatcherType::LIST: {
-		auto &root_list = root_matcher.Cast<ListMatcher>();
-		root_list.matchers.push_back(matcher);
-		break;
+void MatcherFactory::MatcherConstructionState::Schedule(string_t rule_name) {
+	if (unconstructed.count(rule_name) && scheduled.insert(rule_name).second) {
+		pending.push(rule_name);
 	}
-	case MatcherType::CHOICE:
-		// for a choice matcher we need to pop the choice matcher from the stack afterwards
-		if (matchers.size() <= 1) {
-			throw InternalException("Choice matcher should never be the root in the matcher stack");
+}
+
+bool MatcherFactory::MatcherConstructionState::Begin(string_t rule_name) {
+	return unconstructed.erase(rule_name);
+}
+
+bool MatcherFactory::MatcherConstructionState::HasScheduled() const {
+	return !pending.empty();
+}
+
+string_t MatcherFactory::MatcherConstructionState::TakeNext() {
+	auto rule_name = pending.front();
+	pending.pop();
+	scheduled.erase(rule_name);
+	return rule_name;
+}
+
+Matcher &MatcherFactory::CreateMatcher(const PEGExpression &expression, const string_map_t<idx_t> &parameter_map,
+                                       vector<reference<Matcher>> &parameters) {
+	switch (expression.type) {
+	case PEGExpression::Type::LITERAL:
+		return Keyword(expression.text.GetString());
+	case PEGExpression::Type::REFERENCE: {
+		auto parameter = parameter_map.find(expression.text);
+		if (parameter != parameter_map.end()) {
+			return parameters[parameter->second].get();
 		}
-		root_matcher.Cast<ChoiceMatcher>().matchers.push_back(matcher);
-		if (!matchers.empty()) {
-			matchers.pop_back();
+		auto matcher = matchers.find(expression.text);
+		if (matcher != matchers.end()) {
+			construction_state.Schedule(expression.text);
+			return matcher->second.get();
 		}
-		break;
+		return CreateMatcher(expression.text);
+	}
+	case PEGExpression::Type::FUNCTION_CALL: {
+		if (expression.children.size() != 1) {
+			throw InternalException("Function call '%s' expected a single argument", expression.text.GetString());
+		}
+		vector<reference<Matcher>> function_parameters;
+		function_parameters.push_back(CreateMatcher(expression.children[0], parameter_map, parameters));
+		return CreateMatcher(expression.text, function_parameters);
+	}
+	case PEGExpression::Type::SEQUENCE: {
+		vector<reference<Matcher>> children;
+		for (auto &child : expression.children) {
+			children.push_back(CreateMatcher(child, parameter_map, parameters));
+		}
+		return List(std::move(children));
+	}
+	case PEGExpression::Type::CHOICE: {
+		vector<reference<Matcher>> children;
+		for (auto &child : expression.children) {
+			children.push_back(CreateMatcher(child, parameter_map, parameters));
+		}
+		return Choice(std::move(children));
+	}
+	case PEGExpression::Type::OPTIONAL:
+	case PEGExpression::Type::REPEAT:
+	case PEGExpression::Type::OPTIONAL_REPEAT: {
+		if (expression.children.size() != 1) {
+			throw InternalException("PEG postfix expression expected a single child");
+		}
+		auto &child = CreateMatcher(expression.children[0], parameter_map, parameters);
+		if (expression.type == PEGExpression::Type::OPTIONAL) {
+			return Optional(child);
+		}
+		auto &repeat = Repeat(child);
+		if (expression.type == PEGExpression::Type::OPTIONAL_REPEAT) {
+			return Optional(repeat);
+		}
+		return repeat;
+	}
+	case PEGExpression::Type::REGEX:
+		throw InternalException("REGEX operator not supported in PEG grammar");
 	default:
-		throw InternalException("Cannot add matcher to root matcher of this type");
+		throw InternalException("Unrecognized PEG expression type");
 	}
-}
-
-void MatcherFactory::MatcherList::AddRootMatcher(Matcher &matcher) {
-	matchers.emplace_back(matcher);
-}
-
-idx_t MatcherFactory::MatcherList::GetRootMatcherCount() const {
-	return matchers.size();
-}
-
-void MatcherFactory::MatcherList::BeginFunction(string_t function_name) {
-	auto &parameter_list = factory.List();
-	matchers.emplace_back(parameter_list, function_name);
-}
-
-void MatcherFactory::MatcherList::CloseBracket() {
-	if (matchers.size() <= 1) {
-		throw InternalException("PEG matcher create error - found too many close brackets");
-	}
-	auto &root_bracket_matcher = matchers.back();
-	if (!root_bracket_matcher.function_name) {
-		// not a function
-		auto &bracket_matcher = root_bracket_matcher.matcher;
-		// remove the last matcher from the stack
-		matchers.pop_back();
-		// push it into the last matcher
-		AddMatcher(bracket_matcher);
-	} else {
-		// function matcher
-		auto &function_name = *root_bracket_matcher.function_name;
-		auto &function_parameters = root_bracket_matcher.matcher.Cast<ListMatcher>();
-
-		// wrap the parameters in a list if there is more than one
-		auto &parameter = function_parameters.matchers.size() == 1 ? function_parameters.matchers[0].get()
-		                                                           : factory.List(function_parameters.matchers);
-		vector<reference<Matcher>> parameters;
-		parameters.push_back(parameter);
-		// do the substitution of the function call
-		auto &function_call = factory.CreateMatcher(function_name, parameters);
-		// remove the last matcher from the stack
-		matchers.pop_back();
-		// push it into the last matcher
-		AddMatcher(function_call);
-	}
-}
-
-MatcherFactory::MatcherList::Entry &MatcherFactory::MatcherList::GetLastRootMatcher() {
-	return matchers.back();
 }
 
 Matcher &MatcherFactory::CreateMatcher(string_t rule_name, vector<reference<Matcher>> &parameters) {
 	bool is_function_call = !parameters.empty();
+	auto matcher_entry = matchers.find(rule_name);
 	if (!is_function_call) {
-		// check if the matcher has already been created first
-		auto matcher_entry = matchers.find(rule_name);
-		if (matcher_entry != matchers.end()) {
-			// return the created matcher
+		if (matcher_entry == matchers.end()) {
+			throw InvalidConfigurationException("Recipe references rule %s, which doesn't exist in the grammar",
+			                                    rule_name.GetString());
+		}
+		if (!construction_state.Begin(rule_name)) {
+			//! Already constructed, return the cached matcher
 			return matcher_entry->second.get();
 		}
+	} else {
+		matcher_entry = matchers.end();
 	}
+	// Named matchers are registered before any bodies are constructed so recursive references can resolve immediately.
+	auto &matcher = is_function_call ? List() : matcher_entry->second.get().Cast<ListMatcher>();
+
+	// fill the matcher from the given set of rules
 	// look up the rule
 	auto entry = grammar.rules.find(rule_name.GetString());
 	if (entry == grammar.rules.end()) {
-		throw InternalException("Failed to create matcher for rule %s - rule is missing", rule_name.GetString());
+		throw InvalidConfigurationException("Failed to create matcher for rule %s - rule is missing",
+		                                    rule_name.GetString());
 	}
-	// create a matcher and cache it
-	// since matchers can be recursive we need to cache it prior to recursively constructing the other rules
-	auto &matcher = List();
-	if (!is_function_call) {
-		matchers.insert(make_pair(string_t(entry->second->name), reference<Matcher>(matcher)));
-	}
-
-	MatcherList list(*this);
-	list.AddRootMatcher(matcher);
-	// fill the matcher from the given set of rules
 	auto &rule = entry->second->recipe;
 	if (rule.parameters.size() > 1) {
-		throw InternalException("Only functions with a single parameter are supported");
+		throw InvalidConfigurationException("Only functions with a single parameter are supported");
 	}
 	if (parameters.size() != rule.parameters.size()) {
-		throw InternalException("Parameter count mismatch (rule %s expected %d parameters but got %d)",
-		                        rule_name.GetString(), rule.parameters.size(), parameters.size());
+		throw InvalidConfigurationException("Parameter count mismatch (rule %s expected %d parameters but got %d)",
+		                                    rule_name.GetString(), rule.parameters.size(), parameters.size());
 	}
-	for (idx_t token_idx = 0; token_idx < rule.tokens.size(); token_idx++) {
-		auto &token = rule.tokens[token_idx];
-		switch (token.type) {
-		case PEGTokenType::LITERAL:
-			// literal - push the keyword
-			list.AddMatcher(Keyword(token.text.GetString()));
-			break;
-		case PEGTokenType::REFERENCE: {
-			// check if we are referring to a keyword
-			auto param_entry = rule.parameters.find(token.text);
-			if (param_entry != rule.parameters.end()) {
-				// refers to a parameter - refer to it directly
-				list.AddMatcher(parameters[param_entry->second].get());
-			} else {
-				// refers to a different rule - create the matcher for that rule
-				list.AddMatcher(CreateMatcher(token.text));
-			}
-			break;
-		}
-		case PEGTokenType::FUNCTION_CALL: {
-			// function call - get the name of the function
-			list.BeginFunction(token.text);
-			break;
-		}
-		case PEGTokenType::OPERATOR: {
-			// tokens need to be one byte
-			auto op_type = token.text.GetData()[0];
-			switch (op_type) {
-			case '?':
-			case '*': {
-				// optional/repeat - make the last rule optional/repeat
-				auto &last_matcher = list.GetLastRootMatcher().matcher;
-				if (last_matcher.Type() != MatcherType::LIST) {
-					throw InternalException("Optional/Repeat expected a list matcher");
-				}
-				auto &list_matcher = last_matcher.Cast<ListMatcher>();
-				if (list_matcher.matchers.empty()) {
-					throw InternalException("Optional/Repeat rule found as first token");
-				}
-				auto &final_matcher = list_matcher.matchers.back();
-				if (op_type == '*') {
-					// * is Optional(Repeat(CHILD))
-					final_matcher = Repeat(final_matcher.get());
-				}
-				auto &replaced_matcher = Optional(final_matcher);
-				if (!list_matcher.matchers.empty()) {
-					list_matcher.matchers.pop_back();
-				}
-				list_matcher.matchers.push_back(replaced_matcher);
-				break;
-			}
-			case '+': {
-				// Similar to '*' except it is not optional and just repeat (match at least once)
-				auto &last_matcher = list.GetLastRootMatcher().matcher;
-				if (last_matcher.Type() != MatcherType::LIST) {
-					throw InternalException("Repeat expected a list matcher");
-				}
-				auto &list_matcher = last_matcher.Cast<ListMatcher>();
-				if (list_matcher.matchers.empty()) {
-					throw InternalException("Repeat rule found as first token");
-				}
-				auto &final_matcher = list_matcher.matchers.back();
-				final_matcher = Repeat(final_matcher.get());
-				if (!list_matcher.matchers.empty()) {
-					list_matcher.matchers.pop_back();
-				}
-				list_matcher.matchers.push_back(final_matcher);
-				break;
-			}
-			case '/': {
-				// OR operator - this signifies a choice between the last rule and the next rule
-				auto &last_root_matcher = list.GetLastRootMatcher().matcher;
-				if (last_root_matcher.Type() != MatcherType::LIST) {
-					throw InternalException("OR expected a list matcher");
-				}
-				auto &list_matcher = last_root_matcher.Cast<ListMatcher>();
-				if (list_matcher.matchers.empty()) {
-					throw InternalException("OR rule found as first token");
-				}
-				auto &previous_matcher = list_matcher.matchers.back();
-
-				if (previous_matcher.get().Type() == MatcherType::CHOICE) {
-					list.AddRootMatcher(previous_matcher);
-				} else {
-					vector<reference<Matcher>> choice_options;
-					choice_options.push_back(previous_matcher);
-					auto &new_choice_matcher = Choice(std::move(choice_options));
-
-					if (!list_matcher.matchers.empty()) {
-						list_matcher.matchers.pop_back();
-					}
-					list_matcher.matchers.push_back(new_choice_matcher);
-
-					list.AddRootMatcher(new_choice_matcher);
-				}
-				break;
-			}
-			case '(': {
-				// bracket open - push a new list matcher onto the stack
-				auto &bracket_matcher = List();
-				list.AddRootMatcher(bracket_matcher);
-				break;
-			}
-			case ')': {
-				list.CloseBracket();
-				break;
-			}
-			case '!': {
-				// throw InternalException("NOT operator not supported in PEG grammar (found in rule %s)",
-				// rule_name.GetString());
-				// FIXME: we just ignore NOT operators here
-				break;
-			}
-			default:
-				throw InternalException("unrecognized peg operator type");
-			}
-			break;
-		}
-		case PEGTokenType::REGEX:
-			throw InternalException("REGEX operator not supported in PEG grammar (found in rule %s)",
-			                        rule_name.GetString());
-		default:
-			throw InternalException("unrecognized peg token type");
-		}
-	}
-	if (list.GetRootMatcherCount() != 1) {
-		throw InternalException("PEG matcher create error - unclosed bracket found");
+	auto &expression_matcher = CreateMatcher(rule.expression, rule.parameters, parameters);
+	if (rule.expression.type == PEGExpression::Type::SEQUENCE) {
+		matcher.matchers = std::move(expression_matcher.Cast<ListMatcher>().matchers);
+	} else {
+		matcher.matchers.push_back(expression_matcher);
 	}
 
 	auto rule_name_str = rule_name.GetString();
@@ -274,7 +165,7 @@ void MatcherFactory::AddRuleOverride(const char *name, Matcher &matcher) {
 		auto &rule = *rule_p;
 		matcher.SetRule(rule);
 	}
-	matchers.insert(make_pair(name, reference<Matcher>(matcher)));
+	matchers.emplace(name, reference<Matcher>(matcher));
 }
 
 void MatcherFactory::AddPackratMemoizedRule(const char *name) {
@@ -390,8 +281,30 @@ Matcher &MatcherFactory::CreateRootMatcher(const string &root_rule) {
 	SuppressSuggestions("ShowDeprecatedQualifiedTableName");
 	SuppressSuggestions("ShowDeprecatedSelect");
 
-	// now create the matchers for each of the rules recursively - starting at the root rule
-	return CreateMatcher(string_t(root_rule));
+	// Register all named rules before constructing any children. Grammar changes can introduce cycles through
+	// parameterized rules, so registering only the current recursive path is insufficient.
+	for (auto &entry : grammar.rules) {
+		if (!entry.second->recipe.parameters.empty()) {
+			//! Parameterized rule, can't cache
+			continue;
+		}
+		if (matchers.count(entry.first)) {
+			//! Pre-made rule, doesn't get built by the matcher factory
+			continue;
+		}
+		auto &matcher = List();
+		auto rule_name = string_t(entry.second->name);
+		matchers.emplace(rule_name, reference<Matcher>(matcher));
+		construction_state.Register(rule_name);
+	}
+
+	// Populate the reachable rules without recursively constructing referenced bodies. The queue grows as references
+	// are encountered and therefore also handles cycles that pass through parameterized rules.
+	CreateMatcher(root_rule);
+	while (construction_state.HasScheduled()) {
+		CreateMatcher(construction_state.TakeNext());
+	}
+	return GetMatcher(root_rule);
 }
 
 unique_ptr<KeywordMatcher> MatcherFactory::CreateKeyword(const string &keyword, const KeywordInfo &info) const {

--- a/src/parser/peg/parsed_grammar.cpp
+++ b/src/parser/peg/parsed_grammar.cpp
@@ -44,9 +44,6 @@ ParsedGrammar ParsedGrammar::CreateDefault() {
 	const char *grammar = const_char_ptr_cast(INLINED_PEG_GRAMMAR);
 #endif
 	auto result = Parse(grammar);
-	if (!result.GetRule("EndOfInput")) {
-		result.AddParsedRule(ParsedGrammarRule("EndOfInput", PEGRule()));
-	}
 	PEGTransformerFactory::RegisterDefaultTransforms(result);
 	return result;
 }
@@ -76,15 +73,20 @@ ParsedGrammarRule ParsedGrammar::ParseSingleRule(const string &rule_definition) 
 	return ParsedGrammarRule(entry.first, std::move(entry.second));
 }
 
+static void RegisterText(StringHeap &string_heap, PEGExpression &expression) {
+	expression.text = string_heap.AddString(expression.text);
+	for (auto &child : expression.children) {
+		RegisterText(string_heap, child);
+	}
+}
+
 void ParsedGrammar::RegisterStrings(PEGRule &rule) {
 	string_map_t<idx_t> parameters;
 	for (auto &entry : rule.parameters) {
 		parameters.emplace(string_heap.AddString(entry.first), entry.second);
 	}
 	rule.parameters = std::move(parameters);
-	for (auto &token : rule.tokens) {
-		token.text = string_heap.AddString(token.text);
-	}
+	RegisterText(string_heap, rule.expression);
 }
 
 void ParsedGrammar::AddParsedRule(ParsedGrammarRule rule) {

--- a/src/parser/peg/peg_parser.cpp
+++ b/src/parser/peg/peg_parser.cpp
@@ -7,7 +7,165 @@
 
 namespace duckdb {
 
-void PEGParser::AddRule(string_t rule_name, PEGRule rule) {
+namespace {
+
+enum class PEGTokenType {
+	LITERAL,       // literal token ('Keyword')
+	REFERENCE,     // reference token (Rule)
+	OPERATOR,      // operator token (/ or )
+	FUNCTION_CALL, // start of function call (i.e. Function(...))
+	REGEX          // regular expression ([ \t\n\r] or <[a-z_]i[a-z0-9_]i>)
+};
+
+struct PEGToken {
+	PEGTokenType type;
+	string_t text;
+};
+
+enum class PEGParseState {
+	RULE_NAME,      // Rule name
+	RULE_SEPARATOR, // look for <-
+	RULE_DEFINITION // part of rule definition
+};
+
+class PEGExpressionParser {
+public:
+	explicit PEGExpressionParser(const vector<PEGToken> &tokens_p) : tokens(tokens_p), pos(0) {
+	}
+
+	PEGExpression Parse() {
+		auto root = ParseChoice();
+		if (pos != tokens.size()) {
+			throw InternalException("Unexpected trailing tokens in PEG rule");
+		}
+		return root;
+	}
+
+private:
+	const vector<PEGToken> &tokens;
+	idx_t pos;
+
+	bool HasNext() const {
+		return pos < tokens.size();
+	}
+	const PEGToken &Peek() const {
+		return tokens[pos];
+	}
+	const PEGToken &Advance() {
+		return tokens[pos++];
+	}
+	bool IsOp(char op) const {
+		return HasNext() && Peek().type == PEGTokenType::OPERATOR && Peek().text.GetData()[0] == op;
+	}
+
+	// choice := sequence ('/' sequence)*
+	PEGExpression ParseChoice() {
+		auto first = ParseSequence();
+		if (!IsOp('/')) {
+			return first;
+		}
+		PEGExpression choice(PEGExpression::Type::CHOICE);
+		choice.children.push_back(std::move(first));
+		while (IsOp('/')) {
+			Advance();
+			choice.children.push_back(ParseSequence());
+		}
+		return choice;
+	}
+
+	// sequence := postfix*
+	PEGExpression ParseSequence() {
+		PEGExpression seq(PEGExpression::Type::SEQUENCE);
+		while (HasNext() && !IsOp('/') && !IsOp(')')) {
+			seq.children.push_back(ParsePostfix());
+		}
+		if (seq.children.size() == 1) {
+			return std::move(seq.children[0]); // collapse trivial sequences
+		}
+		return seq;
+	}
+
+	// postfix := primary ('?' | '*' | '+')?
+	PEGExpression ParsePostfix() {
+		auto node = ParsePrimary();
+		if (IsOp('?')) {
+			Advance();
+			PEGExpression n(PEGExpression::Type::OPTIONAL);
+			n.children.push_back(std::move(node));
+			return n;
+		}
+		if (IsOp('*')) {
+			Advance();
+			PEGExpression n(PEGExpression::Type::OPTIONAL_REPEAT);
+			n.children.push_back(std::move(node));
+			return n;
+		}
+		if (IsOp('+')) {
+			Advance();
+			PEGExpression n(PEGExpression::Type::REPEAT);
+			n.children.push_back(std::move(node));
+			return n;
+		}
+		return node;
+	}
+
+	// primary := '(' choice ')' | literal | reference | function_call
+	PEGExpression ParsePrimary() {
+		if (IsOp('(')) {
+			Advance();
+			auto inner = ParseChoice();
+			if (!IsOp(')')) {
+				throw InternalException("Expected closing ')' in PEG rule");
+			}
+			Advance();
+			if (inner.type == PEGExpression::Type::SEQUENCE) {
+				return inner;
+			}
+			PEGExpression group(PEGExpression::Type::SEQUENCE);
+			group.children.push_back(std::move(inner));
+			return group;
+		}
+		if (IsOp('!')) {
+			// FIXME: NOT ignored when parsing
+			Advance();
+			return ParsePrimary();
+		}
+		if (!HasNext()) {
+			throw InternalException("Unexpected end of PEG rule tokens");
+		}
+		auto &token = Advance();
+		switch (token.type) {
+		case PEGTokenType::LITERAL:
+			return PEGExpression(PEGExpression::Type::LITERAL, token.text);
+		case PEGTokenType::REFERENCE:
+			return PEGExpression(PEGExpression::Type::REFERENCE, token.text);
+		case PEGTokenType::FUNCTION_CALL: {
+			PEGExpression fn(PEGExpression::Type::FUNCTION_CALL, token.text);
+			auto body = ParseChoice(); // same "consume until close" as '(' does
+			if (!IsOp(')')) {
+				throw InternalException("Expected closing ')' after function call '%s'", token.text.GetString());
+			}
+			Advance();
+			fn.children.push_back(std::move(body));
+			return fn;
+		}
+		case PEGTokenType::REGEX:
+			return PEGExpression(PEGExpression::Type::REGEX, token.text);
+		default:
+			throw InternalException("unrecognized peg token type");
+		}
+	}
+};
+
+static PEGExpression BuildExpression(vector<PEGToken> &tokens) {
+	PEGExpressionParser parser(tokens);
+	return parser.Parse();
+	tokens.clear();
+}
+
+} // namespace
+
+void PEGParser::AddRule(string_t rule_name, PEGRule &&rule) {
 	auto entry = rules.find(rule_name.GetString());
 	if (entry != rules.end()) {
 		throw InternalException("Failed to parse grammar - duplicate rule name %s", rule_name.GetString());
@@ -17,9 +175,14 @@ void PEGParser::AddRule(string_t rule_name, PEGRule rule) {
 
 void PEGParser::ParseRules(const char *grammar) {
 	string_t rule_name;
-	PEGRule rule;
 	PEGParseState parse_state = PEGParseState::RULE_NAME;
 	idx_t bracket_count = 0;
+	vector<PEGToken> tokens;
+	string_map_t<idx_t> parameters;
+	auto clear_state = [&tokens, &parameters]() {
+		tokens.clear();
+		parameters.clear();
+	};
 	bool in_or_clause = false;
 	// look for the rules
 	idx_t c = 0;
@@ -32,10 +195,10 @@ void PEGParser::ParseRules(const char *grammar) {
 			continue;
 		}
 		if (parse_state == PEGParseState::RULE_DEFINITION && StringUtil::CharacterIsNewline(grammar[c]) &&
-		    bracket_count == 0 && !in_or_clause && !rule.tokens.empty()) {
+		    bracket_count == 0 && !in_or_clause && !tokens.empty()) {
 			// if we see a newline while we are parsing a rule definition we can complete the rule
-			AddRule(rule_name, std::move(rule));
-			rule = PEGRule();
+			auto new_rule = PEGRule(std::move(parameters), BuildExpression(tokens));
+			AddRule(rule_name, std::move(new_rule));
 			rule_name = string_t();
 			// look for the subsequent rule
 			parse_state = PEGParseState::RULE_NAME;
@@ -62,13 +225,13 @@ void PEGParser::ParseRules(const char *grammar) {
 				throw InternalException("Failed to parse grammar - expected an alpha-numeric rule name (pos %d)", c);
 			}
 			rule_name = string_t(grammar + start_pos, UnsafeNumericCast<uint32_t>(c - start_pos));
-			rule.Clear();
+			clear_state();
 			parse_state = PEGParseState::RULE_SEPARATOR;
 			break;
 		}
 		case PEGParseState::RULE_SEPARATOR: {
 			if (grammar[c] == '(') {
-				if (!rule.parameters.empty()) {
+				if (!parameters.empty()) {
 					throw InternalException("Failed to parse grammar - multiple parameters at position %d", c);
 				}
 				// parameter
@@ -80,9 +243,9 @@ void PEGParser::ParseRules(const char *grammar) {
 				if (parameter_start == c) {
 					throw InternalException("Failed to parse grammar - expected a parameter at position %d", c);
 				}
-				rule.parameters.insert(
+				parameters.insert(
 				    make_pair(string_t(grammar + parameter_start, UnsafeNumericCast<uint32_t>(c - parameter_start)),
-				              rule.parameters.size()));
+				              parameters.size()));
 				if (grammar[c] != ')') {
 					throw InternalException("Failed to parse grammar - expected closing bracket at position %d", c);
 				}
@@ -119,7 +282,7 @@ void PEGParser::ParseRules(const char *grammar) {
 				PEGToken token;
 				token.text = string_t(grammar + literal_start, UnsafeNumericCast<uint32_t>(c - literal_start));
 				token.type = PEGTokenType::LITERAL;
-				rule.tokens.push_back(token);
+				tokens.push_back(token);
 				c++;
 				if (grammar[c] == 'i') {
 					throw InternalException("Failed to parse grammar - unexpected \"i\" found in grammar near rule %s",
@@ -141,7 +304,7 @@ void PEGParser::ParseRules(const char *grammar) {
 				} else {
 					token.type = PEGTokenType::REFERENCE;
 				}
-				rule.tokens.push_back(token);
+				tokens.push_back(token);
 			} else if (grammar[c] == '[' || grammar[c] == '<') {
 				// regular expression- [^"] or <...>
 				idx_t rule_start = c;
@@ -159,7 +322,7 @@ void PEGParser::ParseRules(const char *grammar) {
 				PEGToken token;
 				token.text = string_t(grammar + rule_start, UnsafeNumericCast<uint32_t>(c - rule_start));
 				token.type = PEGTokenType::REGEX;
-				rule.tokens.push_back(token);
+				tokens.push_back(token);
 			} else if (IsPEGOperator(grammar[c])) {
 				if (grammar[c] == '(') {
 					bracket_count++;
@@ -176,7 +339,7 @@ void PEGParser::ParseRules(const char *grammar) {
 				PEGToken token;
 				token.text = string_t(grammar + c, 1);
 				token.type = PEGTokenType::OPERATOR;
-				rule.tokens.push_back(token);
+				tokens.push_back(token);
 				c++;
 			} else {
 				throw InternalException("Unrecognized rule contents in rule %s (character %s)", rule_name.GetString(),
@@ -195,10 +358,11 @@ void PEGParser::ParseRules(const char *grammar) {
 		throw InternalException("Failed to parse grammar - rule %s does not have a definition", rule_name.GetString());
 	}
 	if (parse_state == PEGParseState::RULE_DEFINITION) {
-		if (rule.tokens.empty()) {
+		if (tokens.empty()) {
 			throw InternalException("Failed to parse grammar - rule %s is empty", rule_name.GetString());
 		}
-		AddRule(rule_name, std::move(rule));
+		auto new_rule = PEGRule(std::move(parameters), BuildExpression(tokens));
+		AddRule(rule_name, std::move(new_rule));
 	}
 }
 


### PR DESCRIPTION
This PR is a cherry picked subset of changes from #24919 

We move `PEGToken` to a private detail of the `PEGParser`, replacing it with `PEGExpression` in public-facing methods.

As a result of this change, the `MatcherFactory` logic is impacted, and replaced to a queue-based iterative creation pattern. (to better deal with highly recursive grammars and malicious crafted grammars)

The `ParsedGrammarKeywordHelper` used to use `PEGToken` as well, this has also been moved to the new `PEGExpression`.