### PR TITLE
Cleanup unused else branch

### DIFF
--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -1696,10 +1696,6 @@ RowGroupWriteData RowGroup::WriteToDisk(RowGroupWriter &writer) {
 			result_row_group->per_column_metadata_blocks.AddColumn(reused_columns[i], extras[i]);
 		}
 		result_row_group->has_per_column_metadata_blocks = true;
-	} else if (partial_reuse) {
-		// we planned to partially re-use column metadata, but every column ended up being rewritten -
-		// downgrade to a full checkpoint as there is no column metadata to carry forward
-		result.write_action = RowGroupWriteAction::FULLY_CHECKPOINT_ROW_GROUP;
 	}
 
 	result.result_row_group = std::move(result_row_group);


### PR DESCRIPTION
Random find, the else branch shouldn't be accessed anyway (`partial_reuse` already checked several lines above).