### PR TITLE
[Dev][Parser] `TypedTransformResult` result fetching/unwrapping changes

### DIFF
--- a/src/include/duckdb/parser/peg/transformer/peg_transformer.hpp
+++ b/src/include/duckdb/parser/peg/transformer/peg_transformer.hpp
@@ -119,7 +119,7 @@ struct TransformStackFrame {
 		if (slot >= child_results.size() || !child_results[slot]) {
 			throw InternalException("Missing trampoline transformer result for slot %llu in rule '%s'", slot, ops.name);
 		}
-		auto *result_value = TryGetTransformResult<T>(*child_results[slot]);
+		auto result_value = TryGetTransformResult<T>(*child_results[slot]);
 		if (!result_value) {
 			auto bridged = TryBridgeTransformResultValue<T>(*child_results[slot]);
 			if (bridged) {
@@ -140,7 +140,7 @@ struct TransformStackFrame {
 		if (slot >= child_results.size() || !child_results[slot]) {
 			throw InternalException("Missing trampoline transformer result for slot %llu in rule '%s'", slot, ops.name);
 		}
-		auto *result_value = TryGetTransformResult<T>(*child_results[slot]);
+		auto result_value = TryGetTransformResult<T>(*child_results[slot]);
 		if (!result_value) {
 			throw InternalException("Unexpected trampoline transformer result type for slot %llu in rule '%s'", slot,
 			                        ops.name);
@@ -167,7 +167,7 @@ public:
 	template <class T>
 	T Execute(ParseResult &parse_result, const TransformFrameOps &ops) {
 		auto base_result = ExecuteInternal(parse_result, ops);
-		auto *result_value = TryGetTransformResult<T>(*base_result);
+		auto result_value = TryGetTransformResult<T>(*base_result);
 		if (!result_value) {
 			throw InternalException("Unexpected trampoline transformer result type for root rule '%s'", ops.name);
 		}
@@ -218,7 +218,7 @@ public:
 			throw InternalException("Transformer for rule '%s' returned a nullptr.", parse_result.name);
 		}
 
-		auto *result_value = TryGetTransformResult<T>(*base_result);
+		auto result_value = TryGetTransformResult<T>(*base_result);
 		if (!result_value) {
 			// allow transparent bridging between string-typed and Identifier-typed rules
 			auto bridged = TryBridgeTransformResult<T>(*base_result);
@@ -339,7 +339,7 @@ inline unique_ptr<TypedTransformResult<T>> TryBridgeTransformResultValue(Transfo
 template <>
 inline unique_ptr<TypedTransformResult<string>>
 TryBridgeTransformResultValue<string>(TransformResultValue &base_result) {
-	if (auto *ident = TryGetTransformResult<Identifier>(base_result)) {
+	if (auto ident = TryGetTransformResult<Identifier>(base_result)) {
 		return make_uniq<TypedTransformResult<string>>(ident->GetIdentifierName());
 	}
 	return nullptr;
@@ -348,7 +348,7 @@ TryBridgeTransformResultValue<string>(TransformResultValue &base_result) {
 template <>
 inline unique_ptr<TypedTransformResult<Identifier>>
 TryBridgeTransformResultValue<Identifier>(TransformResultValue &base_result) {
-	if (auto *str = TryGetTransformResult<string>(base_result)) {
+	if (auto str = TryGetTransformResult<string>(base_result)) {
 		return make_uniq<TypedTransformResult<Identifier>>(Identifier(*str));
 	}
 	return nullptr;
@@ -357,7 +357,7 @@ TryBridgeTransformResultValue<Identifier>(TransformResultValue &base_result) {
 template <>
 inline unique_ptr<TypedTransformResult<vector<string>>>
 TryBridgeTransformResultValue<vector<string>>(TransformResultValue &base_result) {
-	if (auto *idents = TryGetTransformResult<vector<Identifier>>(base_result)) {
+	if (auto idents = TryGetTransformResult<vector<Identifier>>(base_result)) {
 		return make_uniq<TypedTransformResult<vector<string>>>(IdentifiersToStrings(*idents));
 	}
 	return nullptr;
@@ -366,7 +366,7 @@ TryBridgeTransformResultValue<vector<string>>(TransformResultValue &base_result)
 template <>
 inline unique_ptr<TypedTransformResult<vector<Identifier>>>
 TryBridgeTransformResultValue<vector<Identifier>>(TransformResultValue &base_result) {
-	if (auto *strs = TryGetTransformResult<vector<string>>(base_result)) {
+	if (auto strs = TryGetTransformResult<vector<string>>(base_result)) {
 		return make_uniq<TypedTransformResult<vector<Identifier>>>(StringsToIdentifiers(*strs));
 	}
 	return nullptr;

--- a/src/include/duckdb/parser/peg/transformer/peg_transformer.hpp
+++ b/src/include/duckdb/parser/peg/transformer/peg_transformer.hpp
@@ -64,6 +64,7 @@ namespace duckdb {
 
 // Forward declare
 struct QualifiedName;
+struct CompiledGrammar;
 struct MatcherToken;
 struct GroupingExpressionMap;
 class Matcher;
@@ -119,8 +120,8 @@ struct TransformStackFrame {
 		if (slot >= child_results.size() || !child_results[slot]) {
 			throw InternalException("Missing trampoline transformer result for slot %llu in rule '%s'", slot, ops.name);
 		}
-		auto *typed_result = TryCastTransformResult<T>(child_results[slot].get());
-		if (!typed_result) {
+		auto *result_value = TryGetTransformResult<T>(*child_results[slot]);
+		if (!result_value) {
 			auto bridged = TryBridgeTransformResultValue<T>(*child_results[slot]);
 			if (bridged) {
 				auto bridged_result = std::move(bridged->value);
@@ -130,7 +131,7 @@ struct TransformStackFrame {
 			throw InternalException("Unexpected trampoline transformer result type for slot %llu in rule '%s'", slot,
 			                        ops.name);
 		}
-		auto result = std::move(typed_result->value);
+		auto result = std::move(*result_value);
 		child_results[slot].reset();
 		return result;
 	}
@@ -140,12 +141,12 @@ struct TransformStackFrame {
 		if (slot >= child_results.size() || !child_results[slot]) {
 			throw InternalException("Missing trampoline transformer result for slot %llu in rule '%s'", slot, ops.name);
 		}
-		auto *typed_result = TryCastTransformResult<T>(child_results[slot].get());
-		if (!typed_result) {
+		auto *result_value = TryGetTransformResult<T>(*child_results[slot]);
+		if (!result_value) {
 			throw InternalException("Unexpected trampoline transformer result type for slot %llu in rule '%s'", slot,
 			                        ops.name);
 		}
-		return typed_result->value;
+		return *result_value;
 	}
 
 	const transform_frame_index_t frame_index;
@@ -167,11 +168,11 @@ public:
 	template <class T>
 	T Execute(ParseResult &parse_result, const TransformFrameOps &ops) {
 		auto base_result = ExecuteInternal(parse_result, ops);
-		auto *typed_result = TryCastTransformResult<T>(base_result.get());
-		if (!typed_result) {
+		auto *result_value = TryGetTransformResult<T>(*base_result);
+		if (!result_value) {
 			throw InternalException("Unexpected trampoline transformer result type for root rule '%s'", ops.name);
 		}
-		return std::move(typed_result->value);
+		return std::move(*result_value);
 	}
 
 	TransformStackFrame &GetFrame(transform_frame_index_t frame_index);
@@ -218,8 +219,8 @@ public:
 			throw InternalException("Transformer for rule '%s' returned a nullptr.", parse_result.name);
 		}
 
-		auto *typed_result_ptr = TryCastTransformResult<T>(base_result.get());
-		if (!typed_result_ptr) {
+		auto *result_value = TryGetTransformResult<T>(*base_result);
+		if (!result_value) {
 			// allow transparent bridging between string-typed and Identifier-typed rules
 			auto bridged = TryBridgeTransformResult<T>(*base_result);
 			if (bridged) {
@@ -230,7 +231,7 @@ public:
 			throw InternalException("Transformer for rule '" + parse_result.name + "' returned an unexpected type.");
 		}
 
-		auto result = std::move(typed_result_ptr->value);
+		auto result = std::move(*result_value);
 		SetResultLocation(result, parse_result.GetLocation());
 		return result;
 	}
@@ -339,8 +340,8 @@ inline unique_ptr<TypedTransformResult<T>> TryBridgeTransformResultValue(Transfo
 template <>
 inline unique_ptr<TypedTransformResult<string>>
 TryBridgeTransformResultValue<string>(TransformResultValue &base_result) {
-	if (auto *ident = TryCastTransformResult<Identifier>(base_result)) {
-		return make_uniq<TypedTransformResult<string>>(ident->value.GetIdentifierName());
+	if (auto *ident = TryGetTransformResult<Identifier>(base_result)) {
+		return make_uniq<TypedTransformResult<string>>(ident->GetIdentifierName());
 	}
 	return nullptr;
 }
@@ -348,8 +349,8 @@ TryBridgeTransformResultValue<string>(TransformResultValue &base_result) {
 template <>
 inline unique_ptr<TypedTransformResult<Identifier>>
 TryBridgeTransformResultValue<Identifier>(TransformResultValue &base_result) {
-	if (auto *str = TryCastTransformResult<string>(base_result)) {
-		return make_uniq<TypedTransformResult<Identifier>>(Identifier(str->value));
+	if (auto *str = TryGetTransformResult<string>(base_result)) {
+		return make_uniq<TypedTransformResult<Identifier>>(Identifier(*str));
 	}
 	return nullptr;
 }
@@ -357,8 +358,8 @@ TryBridgeTransformResultValue<Identifier>(TransformResultValue &base_result) {
 template <>
 inline unique_ptr<TypedTransformResult<vector<string>>>
 TryBridgeTransformResultValue<vector<string>>(TransformResultValue &base_result) {
-	if (auto *idents = TryCastTransformResult<vector<Identifier>>(base_result)) {
-		return make_uniq<TypedTransformResult<vector<string>>>(IdentifiersToStrings(idents->value));
+	if (auto *idents = TryGetTransformResult<vector<Identifier>>(base_result)) {
+		return make_uniq<TypedTransformResult<vector<string>>>(IdentifiersToStrings(*idents));
 	}
 	return nullptr;
 }
@@ -366,8 +367,8 @@ TryBridgeTransformResultValue<vector<string>>(TransformResultValue &base_result)
 template <>
 inline unique_ptr<TypedTransformResult<vector<Identifier>>>
 TryBridgeTransformResultValue<vector<Identifier>>(TransformResultValue &base_result) {
-	if (auto *strs = TryCastTransformResult<vector<string>>(base_result)) {
-		return make_uniq<TypedTransformResult<vector<Identifier>>>(StringsToIdentifiers(strs->value));
+	if (auto *strs = TryGetTransformResult<vector<string>>(base_result)) {
+		return make_uniq<TypedTransformResult<vector<Identifier>>>(StringsToIdentifiers(*strs));
 	}
 	return nullptr;
 }

--- a/src/include/duckdb/parser/peg/transformer/peg_transformer.hpp
+++ b/src/include/duckdb/parser/peg/transformer/peg_transformer.hpp
@@ -64,7 +64,6 @@ namespace duckdb {
 
 // Forward declare
 struct QualifiedName;
-struct CompiledGrammar;
 struct MatcherToken;
 struct GroupingExpressionMap;
 class Matcher;

--- a/src/include/duckdb/parser/peg/transformer/transform_result.hpp
+++ b/src/include/duckdb/parser/peg/transformer/transform_result.hpp
@@ -19,43 +19,32 @@ const char *TransformResultTypeName() {
 #endif
 }
 
-struct TransformResultValue {
+struct DUCKDB_API TransformResultValue {
 	virtual ~TransformResultValue() = default;
 
-	//! Identifies the concrete TypedTransformResult<T> without relying on RTTI
-	virtual const char *TypeTag() const = 0;
+	//! Returns a pointer to the value if its type matches, without relying on RTTI
+	virtual void *GetValuePointer(const char *type_name) = 0;
 };
 
 template <class T>
-struct TypedTransformResult : public TransformResultValue {
+struct DUCKDB_API TypedTransformResult : public TransformResultValue {
 	explicit TypedTransformResult(T value_p) : value(std::move(value_p)) {
 	}
+	TypedTransformResult(const TypedTransformResult &) = delete;
+	TypedTransformResult &operator=(const TypedTransformResult &) = delete;
 
-	const char *TypeTag() const override {
-		return TransformResultTypeName<T>();
+	void *GetValuePointer(const char *type_name) override {
+		auto expected = TransformResultTypeName<T>();
+		return type_name == expected || std::strcmp(type_name, expected) == 0 ? &value : nullptr;
 	}
 
 	T value;
 };
 
-//! Casts to TypedTransformResult<T> if the result holds exactly that type, and returns nullptr otherwise
+//! Returns a pointer to the contained value if the result holds exactly T, and nullptr otherwise
 template <class T>
-TypedTransformResult<T> *TryCastTransformResult(TransformResultValue *result) {
-	if (!result) {
-		return nullptr;
-	}
-	auto tag = result->TypeTag();
-	auto expected = TransformResultTypeName<T>();
-	// the pointers are equal whenever both sides come from the same image, which is the common case
-	if (tag != expected && std::strcmp(tag, expected) != 0) {
-		return nullptr;
-	}
-	return static_cast<TypedTransformResult<T> *>(result);
-}
-
-template <class T>
-TypedTransformResult<T> *TryCastTransformResult(TransformResultValue &result) {
-	return TryCastTransformResult<T>(&result);
+T *TryGetTransformResult(TransformResultValue &result) {
+	return reinterpret_cast<T *>(result.GetValuePointer(TransformResultTypeName<T>()));
 }
 
 } // namespace duckdb

--- a/src/include/duckdb/parser/peg/transformer/transform_result.hpp
+++ b/src/include/duckdb/parser/peg/transformer/transform_result.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "duckdb/common/common.hpp"
+#include "duckdb/common/optional_ptr.hpp"
 
 #include <cstring>
 
@@ -43,7 +44,7 @@ struct DUCKDB_API TypedTransformResult : public TransformResultValue {
 
 //! Returns a pointer to the contained value if the result holds exactly T, and nullptr otherwise
 template <class T>
-T *TryGetTransformResult(TransformResultValue &result) {
+optional_ptr<T> TryGetTransformResult(TransformResultValue &result) {
 	return reinterpret_cast<T *>(result.GetValuePointer(TransformResultTypeName<T>()));
 }
 

--- a/src/parser/peg/transformer/peg_transformer.cpp
+++ b/src/parser/peg/transformer/peg_transformer.cpp
@@ -114,14 +114,14 @@ void TransformStack::SetResultLocation(ParseResult &parse_result, TransformResul
 	if (!parse_result.offset.IsValid()) {
 		return;
 	}
-	auto *expression_result = TryCastTransformResult<unique_ptr<ParsedExpression>>(result);
-	if (expression_result && expression_result->value && !expression_result->value->HasQueryLocation()) {
-		transformer.SetQueryLocation(*expression_result->value, parse_result.GetLocation());
+	auto *expression_result = TryGetTransformResult<unique_ptr<ParsedExpression>>(result);
+	if (expression_result && *expression_result && !(*expression_result)->HasQueryLocation()) {
+		transformer.SetQueryLocation(**expression_result, parse_result.GetLocation());
 		return;
 	}
-	auto *table_ref_result = TryCastTransformResult<unique_ptr<TableRef>>(result);
-	if (table_ref_result && table_ref_result->value && !table_ref_result->value->query_location.IsValid()) {
-		transformer.SetQueryLocation(*table_ref_result->value, parse_result.GetLocation());
+	auto *table_ref_result = TryGetTransformResult<unique_ptr<TableRef>>(result);
+	if (table_ref_result && *table_ref_result && !(*table_ref_result)->query_location.IsValid()) {
+		transformer.SetQueryLocation(**table_ref_result, parse_result.GetLocation());
 		return;
 	}
 }

--- a/src/parser/peg/transformer/peg_transformer.cpp
+++ b/src/parser/peg/transformer/peg_transformer.cpp
@@ -114,12 +114,12 @@ void TransformStack::SetResultLocation(ParseResult &parse_result, TransformResul
 	if (!parse_result.offset.IsValid()) {
 		return;
 	}
-	auto *expression_result = TryGetTransformResult<unique_ptr<ParsedExpression>>(result);
+	auto expression_result = TryGetTransformResult<unique_ptr<ParsedExpression>>(result);
 	if (expression_result && *expression_result && !(*expression_result)->HasQueryLocation()) {
 		transformer.SetQueryLocation(**expression_result, parse_result.GetLocation());
 		return;
 	}
-	auto *table_ref_result = TryGetTransformResult<unique_ptr<TableRef>>(result);
+	auto table_ref_result = TryGetTransformResult<unique_ptr<TableRef>>(result);
 	if (table_ref_result && *table_ref_result && !(*table_ref_result)->query_location.IsValid()) {
 		transformer.SetQueryLocation(**table_ref_result, parse_result.GetLocation());
 		return;

--- a/src/parser/peg/transformer/peg_transformer_factory.cpp
+++ b/src/parser/peg/transformer/peg_transformer_factory.cpp
@@ -1,5 +1,4 @@
 #include "duckdb/parser/peg/transformer/peg_transformer.hpp"
-#include "duckdb/parser/peg/compiled_grammar.hpp"
 #include "duckdb/common/enums/trigger_type.hpp"
 #include "duckdb/common/query_location.hpp"
 #include "duckdb/parser/peg/matcher.hpp"

--- a/src/parser/peg/transformer/peg_transformer_factory.cpp
+++ b/src/parser/peg/transformer/peg_transformer_factory.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/parser/peg/transformer/peg_transformer.hpp"
+#include "duckdb/parser/peg/compiled_grammar.hpp"
 #include "duckdb/common/enums/trigger_type.hpp"
 #include "duckdb/common/query_location.hpp"
 #include "duckdb/parser/peg/matcher.hpp"


### PR DESCRIPTION
Reworks a change made by #24858 in preparation for #24919 

In short, we return the wrapped T directly, rather than wrapping it in another `TypedTransformResult`, this is what:

> removes the remaining cross-DLL dependency on the concrete wrapper type

Which I won't pretend to fully understand, but it makes sense to reduce the amount of classes that are used across linking boundaries.