### PR TITLE
Allow bypassing HTTP client cache

### DIFF
--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -2836,6 +2836,24 @@ HLLStorageType EnumUtil::FromString<HLLStorageType>(const char *value) {
 	return static_cast<HLLStorageType>(StringUtil::StringToEnum(GetHLLStorageTypeValues(), 2, "HLLStorageType", value));
 }
 
+const StringUtil::EnumStringLiteral *GetHTTPClientCachePolicyValues() {
+	static constexpr StringUtil::EnumStringLiteral values[] {
+		{ static_cast<uint32_t>(HTTPClientCachePolicy::DEFAULT), "DEFAULT" },
+		{ static_cast<uint32_t>(HTTPClientCachePolicy::BYPASS_CACHE), "BYPASS_CACHE" }
+	};
+	return values;
+}
+
+template<>
+const char* EnumUtil::ToChars<HTTPClientCachePolicy>(HTTPClientCachePolicy value) {
+	return StringUtil::EnumToString(GetHTTPClientCachePolicyValues(), 2, "HTTPClientCachePolicy", static_cast<uint32_t>(value));
+}
+
+template<>
+HTTPClientCachePolicy EnumUtil::FromString<HTTPClientCachePolicy>(const char *value) {
+	return static_cast<HTTPClientCachePolicy>(StringUtil::StringToEnum(GetHTTPClientCachePolicyValues(), 2, "HTTPClientCachePolicy", value));
+}
+
 const StringUtil::EnumStringLiteral *GetHTTPStatusCodeValues() {
 	static constexpr StringUtil::EnumStringLiteral values[] {
 		{ static_cast<uint32_t>(HTTPStatusCode::INVALID), "INVALID" },

--- a/src/common/path.cpp
+++ b/src/common/path.cpp
@@ -245,7 +245,7 @@ size_t Path::ParseURIScheme(const string &input, Path &parsed) {
 	parsed.scheme = input.substr(0, auth_begin);
 
 	const size_t path_begin = input.find('/', auth_begin);
-	D_ASSERT(path_begin == string::npos || path_begin > auth_begin);
+	D_ASSERT(path_begin == string::npos || path_begin >= auth_begin);
 	parsed.authority = input.substr(auth_begin, path_begin == string::npos ? string::npos : path_begin - auth_begin);
 	parsed.anchor = '/';
 	return path_begin == string::npos ? input.size() : path_begin + 1;

--- a/src/include/duckdb/common/enum_util.hpp
+++ b/src/include/duckdb/common/enum_util.hpp
@@ -272,6 +272,8 @@ enum class GroupByExpressionInfoType : uint8_t;
 
 enum class HLLStorageType : uint8_t;
 
+enum class HTTPClientCachePolicy : uint8_t;
+
 enum class HTTPStatusCode : uint16_t;
 
 enum class IdentifierCaseMode : uint8_t;
@@ -994,6 +996,9 @@ const char* EnumUtil::ToChars<GroupByExpressionInfoType>(GroupByExpressionInfoTy
 
 template<>
 const char* EnumUtil::ToChars<HLLStorageType>(HLLStorageType value);
+
+template<>
+const char* EnumUtil::ToChars<HTTPClientCachePolicy>(HTTPClientCachePolicy value);
 
 template<>
 const char* EnumUtil::ToChars<HTTPStatusCode>(HTTPStatusCode value);
@@ -1898,6 +1903,9 @@ GroupByExpressionInfoType EnumUtil::FromString<GroupByExpressionInfoType>(const 
 
 template<>
 HLLStorageType EnumUtil::FromString<HLLStorageType>(const char *value);
+
+template<>
+HTTPClientCachePolicy EnumUtil::FromString<HTTPClientCachePolicy>(const char *value);
 
 template<>
 HTTPStatusCode EnumUtil::FromString<HTTPStatusCode>(const char *value);

--- a/src/include/duckdb/common/http_util.hpp
+++ b/src/include/duckdb/common/http_util.hpp
@@ -86,6 +86,12 @@ enum class RequestType : uint8_t {
 	OPTIONS_REQUEST
 };
 
+enum class HTTPClientCachePolicy : uint8_t { DEFAULT, BYPASS_CACHE };
+
+struct HTTPClientInitializationOptions {
+	HTTPClientCachePolicy cache_policy = HTTPClientCachePolicy::DEFAULT;
+};
+
 struct HTTPHeaders {
 	using header_values_t = vector<string>;
 	using header_map_t = case_insensitive_map_t<string>;
@@ -329,6 +335,9 @@ public:
 	                                                    optional_ptr<FileOpenerInfo> info);
 
 	virtual unique_ptr<HTTPClient> InitializeClient(HTTPParams &http_params, const string &proto_host_port);
+	DUCKDB_API virtual unique_ptr<HTTPClient> InitializeClientExtended(HTTPParams &http_params,
+	                                                                   const string &proto_host_port,
+	                                                                   const HTTPClientInitializationOptions &options);
 
 	//! Close a client — implementations may cache it for reuse
 	virtual void CloseClient(unique_ptr<HTTPClient> &&client);

--- a/src/main/http/http_util.cpp
+++ b/src/main/http/http_util.cpp
@@ -291,6 +291,11 @@ unique_ptr<HTTPClient> HTTPUtil::InitializeClient(HTTPParams &http_params, const
 #endif
 }
 
+unique_ptr<HTTPClient> HTTPUtil::InitializeClientExtended(HTTPParams &http_params, const string &proto_host_port,
+                                                          const HTTPClientInitializationOptions &) {
+	return InitializeClient(http_params, proto_host_port);
+}
+
 void HTTPUtil::CloseClient(unique_ptr<HTTPClient> &&) {
 	// default: no-op, client is destroyed
 }
@@ -304,8 +309,10 @@ unique_ptr<HTTPResponse> HTTPUtil::SendRequest(BaseRequest &request, unique_ptr<
 		}
 	}
 
+	auto cache_policy = HTTPClientCachePolicy::DEFAULT;
 	std::function<unique_ptr<HTTPResponse>(void)> on_request([&]() {
 		unique_ptr<HTTPResponse> response;
+		cache_policy = HTTPClientCachePolicy::DEFAULT;
 
 		// When logging is enabled, we collect request timings
 		if (request.params.logger) {
@@ -317,9 +324,13 @@ unique_ptr<HTTPResponse> HTTPUtil::SendRequest(BaseRequest &request, unique_ptr<
 			request.request_monotonic_start = TimePoint::Tick();
 			response = client->Request(request);
 		} catch (...) {
+			cache_policy = HTTPClientCachePolicy::BYPASS_CACHE;
 			request.request_monotonic_end = TimePoint::Tick();
 			LogRequest(request, nullptr);
 			throw;
+		}
+		if (!response || response->HasRequestError()) {
+			cache_policy = HTTPClientCachePolicy::BYPASS_CACHE;
 		}
 		request.request_monotonic_end = TimePoint::Tick();
 		LogRequest(request, response ? response.get() : nullptr);
@@ -327,7 +338,11 @@ unique_ptr<HTTPResponse> HTTPUtil::SendRequest(BaseRequest &request, unique_ptr<
 	});
 
 	// Refresh the client on retries
-	std::function<void(void)> on_retry([&]() { client = InitializeClient(request.params, request.proto_host_port); });
+	std::function<void(void)> on_retry([&]() {
+		HTTPClientInitializationOptions options;
+		options.cache_policy = cache_policy;
+		client = InitializeClientExtended(request.params, request.proto_host_port, options);
+	});
 
 	return RunRequestWithRetry(on_request, request, on_retry);
 }


### PR DESCRIPTION
This is needed after transport errors - we can't reuse and a cached connection could be stale.