### PR TITLE
Do not assume NULL columns on right side of LEFT JOIN

### DIFF
--- a/src/include/duckdb/optimizer/outer_join_simplification.hpp
+++ b/src/include/duckdb/optimizer/outer_join_simplification.hpp
@@ -56,6 +56,7 @@ private:
 	bool HasNullRequiredColumns(const vector<ColumnBinding> &bindings);
 	bool HasRequiredColumns(const vector<ColumnBinding> &bindings);
 	void MarkEliminatedNullColumns(const vector<ColumnBinding> &bindings);
+	void EraseNullRequiredColumns(LogicalOperator &child);
 	vector<ColumnBinding> GetRightBindings(LogicalJoin &join);
 	void SimplifyOuterJoinType(LogicalComparisonJoin &join);
 

--- a/src/optimizer/outer_join_simplification.cpp
+++ b/src/optimizer/outer_join_simplification.cpp
@@ -186,6 +186,12 @@ bool OuterJoinSimplification::HasRequiredColumns(const vector<ColumnBinding> &bi
 	return false;
 }
 
+void OuterJoinSimplification::EraseNullRequiredColumns(LogicalOperator &child) {
+	for (const auto &binding : child.GetColumnBindings()) {
+		null_required_columns.erase(binding);
+	}
+}
+
 void OuterJoinSimplification::MarkEliminatedNullColumns(const vector<ColumnBinding> &bindings) {
 	for (const auto &binding : bindings) {
 		eliminated_null_columns.insert(binding);
@@ -297,6 +303,7 @@ void OuterJoinSimplification::VisitInnerOrSemiJoin(LogicalComparisonJoin &join, 
 void OuterJoinSimplification::VisitOuterJoin(LogicalComparisonJoin &join, LogicalOperator &op) {
 	if (TryConvertLeftToAntiJoin(join)) {
 		AddRequiredColumns(join.conditions);
+		EraseNullRequiredColumns(*join.children[1]);
 		VisitOperatorChildren(op);
 		return;
 	}
@@ -308,6 +315,14 @@ void OuterJoinSimplification::VisitOuterJoin(LogicalComparisonJoin &join, Logica
 	}
 
 	AddRequiredColumns(join.conditions);
+	// NULL values in the NULL-extended side can be introduced by this join itself,
+	// so columns of that side are not guaranteed to be NULL below the join
+	if (join.join_type == JoinType::LEFT || join.join_type == JoinType::OUTER) {
+		EraseNullRequiredColumns(*join.children[1]);
+	}
+	if (join.join_type == JoinType::RIGHT || join.join_type == JoinType::OUTER) {
+		EraseNullRequiredColumns(*join.children[0]);
+	}
 	VisitOperatorChildren(op);
 }
 

--- a/test/sql/join/left_outer/left_join_issue_24540.test
+++ b/test/sql/join/left_outer/left_join_issue_24540.test
@@ -1,7 +1,6 @@
 # name: test/sql/join/left_outer/left_join_issue_24540.test
-# description: left join do not assume right child is null. 
+# description: left join do not assume right child is null.
 # group: [left_outer]
-
 
 query III
 SELECT * FROM (VALUES (1),(2),(NULL)) AS a(x)

--- a/test/sql/join/left_outer/left_join_issue_24540.test
+++ b/test/sql/join/left_outer/left_join_issue_24540.test
@@ -1,0 +1,14 @@
+# name: test/sql/join/left_outer/left_join_issue_24540.test
+# description: left join do not assume right child is null. 
+# group: [left_outer]
+
+
+query III
+SELECT * FROM (VALUES (1),(2),(NULL)) AS a(x)
+LEFT JOIN (SELECT p.y AS y, q.z AS z
+           FROM (VALUES (2),(3),(NULL)) AS p(y)
+           LEFT JOIN (VALUES (1),(3),(NULL)) AS q(z) ON p.y <> q.z) AS s
+ON a.x <> s.y
+WHERE s.z IS NULL;
+----
+NULL	NULL	NULL


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb/issues/24540. 
Fixes https://github.com/duckdblabs/duckdb-internal/issues/10240

OuterJoinSimplification walks the plan top-down, recording columns that a predicate forces to be NULL  in null_required_columns. This allows the optimizer to rewrite LEFT joins into ANTI joins. When an IS NULL predicate sits above a LEFT join, the `IS NULL` is carried into the join's right child, as a way to assume only NULL values will survive, to apply any optimizations knowing that will hold true. This is incorrect, however, since the LEFT JOIN will extend non-matching rows and produce new NULLS. Therefore, holding onto the `null_required_columns` on the right side of a left join is incorrect, this caused the second join to be rewritten into an ANTI join.
 
Before descending into the side a join can null-extend (the right child for LEFT, the left child for RIGHT, both for OUTER), that side's column bindings are now erased from null_required_columns. The same is done for the right child when the join itself has just been converted to ANTI, since its columns produce no output at all.

This may be a candidate to backport to the v2.0.0 branch once it gets cut
