### PR TITLE
Backport #24878: Always quote identifiers in error messages

### DIFF
--- a/src/common/exception_format_value.cpp
+++ b/src/common/exception_format_value.cpp
@@ -63,9 +63,7 @@ ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(const SQLString &va
 
 template <>
 ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(const Identifier &value) {
-	// An Identifier is a SQL identifier, so it formats with SQL identifier rules (quoted only when required) -
-	// callers should never need to wrap an Identifier in SQLIdentifier when printing.
-	return SQLIdentifier::ToString(value.GetIdentifierName());
+	return SQLQuotedIdentifier::ToString(value);
 }
 
 template <>


### PR DESCRIPTION
On main, an `Identifier` interpolated into an exception format string is rendered through `SQLQuotedIdentifier`, so it is always quoted rather than only when quoting is required in SQL. On v1.5 it still went through `SQLIdentifier`, so an extension throwing e.g. `BinderException("Table %s does not exist", identifier)` produced differently quoted error messages on v1.5 than on main. This only matters to extensions that use the new APIs on the v1.5.

This is a follow-up to #24852 to backport some new behaviour from main that was introduced after that initial backport was merged.
