### PR TITLE
Fix join elimination dropping rows when UNNEST duplicates the inner side

### DIFF
--- a/src/include/duckdb/optimizer/join_elimination.hpp
+++ b/src/include/duckdb/optimizer/join_elimination.hpp
@@ -37,6 +37,8 @@ public:
 	// pushdown filter condition(ex in table scan operator),
 	// if have outer table columns then cannot elimination
 	bool has_filter = false;
+	// whether an operator above can duplicate bindings from this subtree
+	bool has_duplicate_child_bindings = false;
 
 	optional_ptr<LogicalOperator> join_parent = nullptr;
 	idx_t join_index = 0;
@@ -75,6 +77,7 @@ public:
 
 private:
 	unique_ptr<LogicalOperator> TryEliminateJoin();
+	void AddDistinctGroup(TableIndex table_index, column_binding_set_t distinct_group);
 	// void ExtractDistinctReferences(vector<Expression> &expressions, idx_t target_table_index);
 	bool ContainDistinctGroup(vector<ColumnBinding> &exprs);
 

--- a/src/optimizer/join_elimination.cpp
+++ b/src/optimizer/join_elimination.cpp
@@ -19,6 +19,29 @@
 #include <utility>
 
 namespace duckdb {
+
+//! Whether op can emit more rows than it consumes while passing its child's bindings through. Both properties
+//! are required: PIVOT can multiply rows but exposes only its own bindings; WINDOW passes child bindings through
+//! but preserves row count.
+static bool CanDuplicateChildBindings(const LogicalOperator &op) {
+	switch (op.type) {
+	case LogicalOperatorType::LOGICAL_UNNEST:
+	// an extension operator can do anything, so assume the worst of it
+	case LogicalOperatorType::LOGICAL_EXTENSION_OPERATOR:
+		return true;
+	default:
+		return false;
+	}
+}
+
+void JoinElimination::AddDistinctGroup(TableIndex table_index, column_binding_set_t distinct_group) {
+	if (pipe_info.has_duplicate_child_bindings) {
+		// the distinct group may not remain unique at the join
+		return;
+	}
+	pipe_info.distinct_groups[table_index] = std::move(distinct_group);
+}
+
 void JoinElimination::OptimizeChildren(LogicalOperator &op, optional_ptr<LogicalOperator> parent, idx_t idx) {
 	if (op.type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN) {
 		if (!parent) {
@@ -58,7 +81,7 @@ void JoinElimination::OptimizeChildren(LogicalOperator &op, optional_ptr<Logical
 			D_ASSERT(table_idx == col_ref.Binding().table_index);
 		}
 		if (can_add) {
-			pipe_info.distinct_groups[table_idx] = std::move(distinct_group);
+			AddDistinctGroup(table_idx, std::move(distinct_group));
 		}
 		break;
 	}
@@ -74,7 +97,7 @@ void JoinElimination::OptimizeChildren(LogicalOperator &op, optional_ptr<Logical
 			distinct_group.insert(ColumnBinding(aggr.group_index, ProjectionIndex(i)));
 		}
 		if (!distinct_group.empty()) {
-			pipe_info.distinct_groups[table_idx] = std::move(distinct_group);
+			AddDistinctGroup(table_idx, std::move(distinct_group));
 		}
 		break;
 	}
@@ -110,7 +133,7 @@ void JoinElimination::OptimizeChildren(LogicalOperator &op, optional_ptr<Logical
 				new_distinct_group.insert(col_ref.Binding());
 			}
 			if (could_add) {
-				pipe_info.distinct_groups[ref_id] = std::move(new_distinct_group);
+				AddDistinctGroup(ref_id, std::move(new_distinct_group));
 			}
 		}
 		break;
@@ -127,7 +150,13 @@ void JoinElimination::OptimizeChildren(LogicalOperator &op, optional_ptr<Logical
 	}
 
 	if (op.children.size() == 1) {
+		// only the pipe below op loses its uniqueness, so the flag is restored on the way back up
+		auto old_has_duplicate_child_bindings = pipe_info.has_duplicate_child_bindings;
+		if (CanDuplicateChildBindings(op)) {
+			pipe_info.has_duplicate_child_bindings = true;
+		}
 		OptimizeChildren(*op.children[0], op, idx);
+		pipe_info.has_duplicate_child_bindings = old_has_duplicate_child_bindings;
 	} else {
 		children_root = op;
 		for (auto &child : op.children) {
@@ -165,7 +194,7 @@ void JoinElimination::OptimizeChildren(LogicalOperator &op, optional_ptr<Logical
 		}
 		for (auto &refs : ref_table_columns) {
 			if (refs.second.ref_column_ids.empty()) {
-				pipe_info.distinct_groups[projection.table_index] = std::move(refs.second.distinct_group);
+				AddDistinctGroup(projection.table_index, std::move(refs.second.distinct_group));
 			}
 		}
 		break;

--- a/test/optimizer/join_elimination.test
+++ b/test/optimizer/join_elimination.test
@@ -244,3 +244,38 @@ query II
 explain select a.ida from b right join (select ida from a group by ida) as a on ida < idb;
 ----
 physical_plan	<REGEX>:.*JOIN.*
+
+# unnest repeats the key, so the distinct group below it does not survive
+
+query II
+explain select b.* from b left join (select ida, unnest([1,2,3]) as e from (select distinct ida from a) s) t on t.ida = b.idb;
+----
+physical_plan	<REGEX>:.*JOIN.*
+
+query II
+select b.* from b left join (select ida, unnest([1,2,3]) as e from (select distinct ida from a) s) t on t.ida = b.idb order by all;
+----
+1	1
+1	1
+1	1
+2	2
+2	2
+2	2
+3	3
+3	3
+3	3
+3	3
+3	3
+3	3
+3	NULL
+3	NULL
+3	NULL
+4	4
+NULL	4
+NULL	NULL
+
+# a distinct above the unnest restores uniqueness, so that join is still eliminated
+query II
+explain select b.* from b left join (select ida from (select distinct ida from (select ida, unnest([1,2,3]) e from a))) t on t.ida = b.idb;
+----
+physical_plan	<!REGEX>:.*JOIN.*

--- a/test/optimizer/join_elimination.test
+++ b/test/optimizer/join_elimination.test
@@ -274,6 +274,13 @@ select b.* from b left join (select ida, unnest([1,2,3]) as e from (select disti
 NULL	4
 NULL	NULL
 
+# a group by establishes the same distinct group, and loses it to the unnest the same way
+
+query II
+explain select b.* from b left join (select ida, unnest([1,2,3]) as e from (select ida from a group by ida) s) t on t.ida = b.idb;
+----
+physical_plan	<REGEX>:.*JOIN.*
+
 # a distinct above the unnest restores uniqueness, so that join is still eliminated
 query II
 explain select b.* from b left join (select ida from (select distinct ida from (select ida, unnest([1,2,3]) e from a))) t on t.ida = b.idb;


### PR DESCRIPTION
Fixes #25213

`join_elimination` can remove a `LEFT JOIN` when an `UNNEST` is there between `DISTINCT` or `GROUP BY` and the join:

```sql
CREATE TABLE dup_keys(k INTEGER);
INSERT INTO dup_keys VALUES (1), (1), (2), (3);

CREATE TABLE probe_keys(idb INTEGER);
INSERT INTO probe_keys VALUES (1), (1), (2), (3), (4), (NULL), (2), (3);

SELECT count(*)
FROM probe_keys
LEFT JOIN (
    SELECT k, unnest([1, 2, 3]) AS e
    FROM (SELECT DISTINCT k FROM dup_keys)
) AS unnest_keys ON unnest_keys.k = probe_keys.idb;
```

The query returns 8 rows. 
Disabling `join_elimination` returns the expected 20 (valid ones).

## The fix
Track whether the optimizer has crossed an operator that can duplicate child rows while preserving their bindings. 
All distinct-group recording passes through `AddDistinctGroup`, which ignores groups encountered below `UNNEST` or an extension operator. 

## Tests
Extend `test/optimizer/join_elimination.test` with:
- an `EXPLAIN` assertion that the join remains when uniqueness was established below `UNNEST`
- an end-to-end result asserting the duplicated rows
- an `EXPLAIN` assertion that `DISTINCT` above `UNNEST` still eliminates the join
