### PR TITLE
Use tracked allocator for JSON parsing in the cast to VARIANT

### DIFF
--- a/src/function/cast/variant/to_variant.cpp
+++ b/src/function/cast/variant/to_variant.cpp
@@ -116,9 +116,13 @@ struct VariantCastData : BoundCastData {
 };
 
 struct VariantLocalData : FunctionLocalState {
-	explicit VariantLocalData(const LogicalType &shredded_type) {
+	VariantLocalData(const LogicalType &shredded_type, Allocator &allocator) : allocator(allocator) {
 		Initialize(shredded_type, STANDARD_VECTOR_SIZE);
 	}
+
+	//! Allocator for temporary conversion memory (e.g. JSON parsing), backed by the buffer allocator when possible
+	//! so the memory is tracked
+	Allocator &allocator;
 
 	void Initialize(const LogicalType &shredded_type, idx_t new_capacity) {
 		capacity = new_capacity;
@@ -147,7 +151,8 @@ private:
 
 unique_ptr<FunctionLocalState> CastToVariantLocalState(CastLocalStateParameters &parameters) {
 	auto &cast_data = parameters.cast_data->Cast<VariantCastData>();
-	return make_uniq<VariantLocalData>(cast_data.shredded_type);
+	auto &allocator = parameters.context ? BufferAllocator::Get(*parameters.context) : Allocator::DefaultAllocator();
+	return make_uniq<VariantLocalData>(cast_data.shredded_type, allocator);
 }
 
 static bool SupportsShreddedCast(const LogicalType &type) {
@@ -214,6 +219,7 @@ static bool CastToVARIANT(Vector &source, Vector &result, idx_t count, CastParam
 	if (TryToShreddedCast(source, result, count, parameters)) {
 		return true;
 	}
+	auto &local_data = parameters.local_state->Cast<VariantLocalData>();
 	DataChunk offsets;
 	offsets.Initialize(Allocator::DefaultAllocator(),
 	                   {LogicalType::UINTEGER, LogicalType::UINTEGER, LogicalType::UINTEGER, LogicalType::UINTEGER},
@@ -229,7 +235,7 @@ static bool CastToVARIANT(Vector &source, Vector &result, idx_t count, CastParam
 
 	{
 		VariantVectorData variant_data(result);
-		ToVariantGlobalResultData result_data(variant_data, offsets, dictionary, keys_selvec);
+		ToVariantGlobalResultData result_data(variant_data, offsets, dictionary, keys_selvec, local_data.allocator);
 		if (!GatherOffsetsAndSizes(source_data, result_data, count)) {
 			return false;
 		}
@@ -241,7 +247,7 @@ static bool CastToVARIANT(Vector &source, Vector &result, idx_t count, CastParam
 
 	{
 		VariantVectorData variant_data(result);
-		ToVariantGlobalResultData result_data(variant_data, offsets, dictionary, keys_selvec);
+		ToVariantGlobalResultData result_data(variant_data, offsets, dictionary, keys_selvec, local_data.allocator);
 		if (!WriteVariantResultData(source_data, result_data, count)) {
 			return false;
 		}

--- a/src/include/duckdb/function/cast/variant/json_to_variant.hpp
+++ b/src/include/duckdb/function/cast/variant/json_to_variant.hpp
@@ -4,6 +4,7 @@
 #include "duckdb/function/scalar/variant_utils.hpp"
 #include "duckdb/function/cast/default_casts.hpp"
 #include "yyjson.hpp"
+#include "yyjson_memory.hpp"
 #include "duckdb/common/serializer/memory_stream.hpp"
 #include "duckdb/common/serializer/varint.hpp"
 #include "duckdb/common/typedefs.hpp"
@@ -20,22 +21,6 @@ namespace variant {
 using namespace duckdb_yyjson; // NOLINT
 
 namespace {
-
-struct ReadJSONHolder {
-public:
-	~ReadJSONHolder() {
-		if (doc) {
-			yyjson_doc_free(doc);
-		}
-	}
-	void Reset() {
-		yyjson_doc_free(doc);
-		doc = nullptr;
-	}
-
-public:
-	yyjson_doc *doc = nullptr;
-};
 
 static inline string_t GetString(yyjson_val *val) {
 	return string_t(unsafe_yyjson_get_str(val), NumericCast<uint32_t>(unsafe_yyjson_get_len(val)));
@@ -271,7 +256,7 @@ bool ConvertJSONToVariant(ToVariantSourceData &source, ToVariantGlobalResultData
 	auto blob_offset_data = OffsetData::GetBlob(result.offsets);
 
 	auto &variant = result.variant;
-	ReadJSONHolder json_holder;
+	JSONAllocator json_allocator(result.allocator);
 	for (idx_t i = 0; i < count; i++) {
 		auto source_index = source[i];
 		auto result_index = selvec ? selvec->get_index(i) : i;
@@ -290,22 +275,24 @@ bool ConvertJSONToVariant(ToVariantSourceData &source, ToVariantGlobalResultData
 		}
 
 		auto &val = source_data[source_index];
-		json_holder.doc =
-		    yyjson_read(val.GetData(), val.GetSize(),
-		                YYJSON_READ_ALLOW_INF_AND_NAN | YYJSON_READ_ALLOW_TRAILING_COMMAS | YYJSON_READ_BIGNUM_AS_RAW);
-		if (!json_holder.doc) {
+		auto doc = yyjson_read_opts(val.GetDataWriteable(), val.GetSize(),
+		                            YYJSON_READ_ALLOW_INF_AND_NAN | YYJSON_READ_ALLOW_TRAILING_COMMAS |
+		                                YYJSON_READ_BIGNUM_AS_RAW,
+		                            json_allocator.GetYYAlc(), nullptr);
+		if (!doc) {
+			json_allocator.Reset();
 			if (!IGNORE_NULLS) {
 				HandleVariantNull<WRITE_DATA>(result, result_index, values_offset_data, blob_offset_data[result_index],
 				                              values_index_selvec, i, is_root);
 			}
 			continue;
 		}
-		auto *root = yyjson_doc_get_root(json_holder.doc);
+		auto *root = yyjson_doc_get_root(doc);
 
 		if (!ConvertJSON<WRITE_DATA, IGNORE_NULLS>(root, result, result_index, is_root)) {
 			return false;
 		}
-		json_holder.Reset();
+		json_allocator.Reset();
 	}
 	return true;
 }

--- a/src/include/duckdb/function/cast/variant/to_variant_fwd.hpp
+++ b/src/include/duckdb/function/cast/variant/to_variant_fwd.hpp
@@ -36,8 +36,9 @@ public:
 struct ToVariantGlobalResultData {
 public:
 	ToVariantGlobalResultData(VariantVectorData &variant, DataChunk &offsets,
-	                          OrderedOwningStringMap<uint32_t> &dictionary, SelectionVector &keys_selvec)
-	    : variant(variant), offsets(offsets), dictionary(dictionary), keys_selvec(keys_selvec) {
+	                          OrderedOwningStringMap<uint32_t> &dictionary, SelectionVector &keys_selvec,
+	                          Allocator &allocator)
+	    : variant(variant), offsets(offsets), dictionary(dictionary), keys_selvec(keys_selvec), allocator(allocator) {
 	}
 
 public:
@@ -54,6 +55,8 @@ public:
 	OrderedOwningStringMap<uint32_t> &dictionary;
 	//! The selection vector to populate with mapping from keys index -> dictionary index
 	SelectionVector &keys_selvec;
+	//! Allocator for temporary conversion memory (e.g. JSON parsing), tracked by DuckDB's memory accounting
+	Allocator &allocator;
 };
 
 template <bool WRITE_DATA>


### PR DESCRIPTION
Casting a JSON value to VARIANT parsed each value with a bare
three-argument `yyjson_read(data, size, flags)`, without passing a
`yyjson_alc`. The parse tree therefore came from raw `malloc` and was
invisible to DuckDB's memory accounting and `memory_limit` is not
adhered too (possibly causing OOM-kills). This fixes that by using an
explicit allocator for these yyjson calls.