### PR TITLE
Improve IN operator propagation result

### DIFF
--- a/src/planner/filter/expression_filter.cpp
+++ b/src/planner/filter/expression_filter.cpp
@@ -623,7 +623,7 @@ static FilterPropagateResult CheckInOperatorStatistics(optional_ptr<ClientContex
 		result = FilterPropagateResult::FILTER_ALWAYS_TRUE;
 	}
 	if (result == FilterPropagateResult::FILTER_ALWAYS_TRUE && filter_stats->CanHaveNull()) {
-		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+		return FilterPropagateResult::FILTER_TRUE_OR_NULL;
 	}
 	return result;
 }
@@ -678,9 +678,12 @@ static FilterPropagateResult CheckNotOperatorStatistics(optional_ptr<ClientConte
 	}
 	// a child matching every row makes NOT match no row - the converse does not hold, since a child
 	// that matches no row may be NULL rather than false, and NOT NULL does not match either
-	if (ExpressionFilter::CheckExpressionStatistics(context_p, child, input_stats) ==
-	    FilterPropagateResult::FILTER_ALWAYS_TRUE) {
+	auto child_result = ExpressionFilter::CheckExpressionStatistics(context_p, child, input_stats);
+	if (child_result == FilterPropagateResult::FILTER_ALWAYS_TRUE) {
 		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
+	}
+	if (child_result == FilterPropagateResult::FILTER_TRUE_OR_NULL) {
+		return FilterPropagateResult::FILTER_FALSE_OR_NULL;
 	}
 	return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 }

--- a/test/sql/optimizer/in_list_row_group_pruning.test
+++ b/test/sql/optimizer/in_list_row_group_pruning.test
@@ -33,6 +33,25 @@ EXPLAIN ANALYZE SELECT count(*) FROM mixed WHERE i NOT IN (1, 2, 3);
 ----
 analyzed_plan	<REGEX>:.*Row Groups Scanned: 2 / 3.*
 
+# NULL values in a covered row group cannot pass the NOT IN predicate either
+statement ok
+CREATE TABLE mixed_nullable AS
+    SELECT CASE
+        WHEN range < 2048 THEN CASE WHEN range % 4 = 0 THEN NULL ELSE (range % 3 + 1)::INTEGER END
+        ELSE (range % 2 + 4)::INTEGER
+    END AS i
+    FROM range(6144);
+
+query I
+SELECT count(*) FROM mixed_nullable WHERE i NOT IN (1, 2, 3);
+----
+4096
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM mixed_nullable WHERE i NOT IN (1, 2, 3);
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 2 / 3.*
+
 # a DOUBLE zonemap of [1, 3] still holds 1.5, so the range is never covered
 statement ok
 CREATE TABLE doubles AS SELECT unnest([1.0, 1.5, 3.0])::DOUBLE AS i;


### PR DESCRIPTION
Hi team, I found the `NOT IN` operator doesn't seem to prune row group as expected when NULL involved; for example,
```sql
memory D ATTACH '/tmp/in_list_prune.duckdb' AS db (ROW_GROUP_SIZE 2048);
memory D USE db;
db D CREATE TABLE mixed_nullable AS
         SELECT CASE
             WHEN range < 2048 THEN CASE WHEN range % 4 = 0 THEN NULL ELSE (range % 3 + 1)::INTEGER END
             ELSE (range % 2 + 4)::INTEGER
         END AS i
         FROM range(6144);

-- should only need to access two row groups, but actually access three
db D EXPLAIN ANALYZE SELECT count(*) FROM mixed_nullable WHERE i NOT IN (1, 2, 3);
╭─ Summary ───────────╮
│ Total Time: 0.0015s │
╰─────────────────────╯
╭─ Ungrouped Aggregate ─────────╮
│ Aggregates: count_star()      │
│ 1 row                     0µs │
╰───────────────┒┎──────────────╯
╭─ Table Scan ──┚┖──────────────╮
│ Table: db.main.mixed_nullable │
│ Type: Sequential Scan         │
│ Filters: NOT (i IN (1, 2, 3)) │
│ Row Groups Scanned: 3 / 3     │
│ 4,096 rows                0µs │
╰───────────────────────────────╯
```