### PR TITLE
Improve parquet bloom filter pruning for IN operator on NULL

### DIFF
--- a/extension/parquet/parquet_statistics.cpp
+++ b/extension/parquet/parquet_statistics.cpp
@@ -755,7 +755,7 @@ GetBloomFilterInExpression(const Expression &expr, ParquetBloomFilterHashStrateg
 			return nullptr;
 		}
 		auto &constant = children[child_idx]->Cast<BoundConstantExpression>().GetValue();
-		if (constant.IsNull() || column.GetReturnType() != constant.type()) {
+		if (!constant.IsNull() && column.GetReturnType() != constant.type()) {
 			return nullptr;
 		}
 	}
@@ -1026,6 +1026,9 @@ static bool ApplyBloomFilter(const Expression &expr, ParquetBloomFilter &bloom_f
 		// An IN filter is excluded only when every candidate is absent.
 		for (idx_t child_idx = 1; child_idx < children.size(); ++child_idx) {
 			auto &constant = children[child_idx]->Cast<BoundConstantExpression>().GetValue();
+			if (constant.IsNull()) {
+				continue;
+			}
 			if (!BloomFilterExcludes(constant, bloom_filter, schema, hash_strategy)) {
 				return false;
 			}

--- a/test/sql/copy/parquet/bloom_filters.test
+++ b/test/sql/copy/parquet/bloom_filters.test
@@ -87,6 +87,15 @@ WHERE r IN (101, 103);
 ----
 analyzed_plan	<REGEX>:(?s).*Row Groups Scanned: 0 / 10.*
 
+# NULL candidates should not prevent Bloom filter pruning
+query II
+EXPLAIN ANALYZE
+SELECT sum(payload)
+FROM read_parquet('{TEST_DIR}/bloom_in.parquet')
+WHERE r IN (101, NULL);
+----
+analyzed_plan	<REGEX>:(?s).*Row Groups Scanned: 0 / 10.*
+
 # Optional OR filters should also use the bloom filter
 query II
 EXPLAIN ANALYZE

--- a/test/sql/copy/parquet/bloom_filters.test
+++ b/test/sql/copy/parquet/bloom_filters.test
@@ -69,7 +69,7 @@ analyzed_plan	<REGEX>:(?s).*Row Groups Scanned: 0 / 10.*
 statement ok
 COPY (
 	SELECT
-		((i % 100) * 2)::INTEGER AS r,
+		CASE WHEN i = 0 THEN NULL ELSE ((i % 100) * 2)::INTEGER END AS r,
 		i::BIGINT AS payload
 	FROM range(20480) t(i)
 ) TO '{TEST_DIR}/bloom_in.parquet' (
@@ -95,6 +95,35 @@ FROM read_parquet('{TEST_DIR}/bloom_in.parquet')
 WHERE r IN (101, NULL);
 ----
 analyzed_plan	<REGEX>:(?s).*Row Groups Scanned: 0 / 10.*
+
+query I
+SELECT count(*)
+FROM read_parquet('{TEST_DIR}/bloom_in.parquet')
+WHERE r IN (101, NULL);
+----
+0
+
+query I
+SELECT r IN (NULL)
+FROM read_parquet('{TEST_DIR}/bloom_in.parquet')
+WHERE r IS NULL;
+----
+NULL
+
+query I
+SELECT count(*)
+FROM read_parquet('{TEST_DIR}/bloom_in.parquet')
+WHERE r IN (NULL);
+----
+0
+
+query II
+EXPLAIN ANALYZE
+SELECT count(*)
+FROM read_parquet('{TEST_DIR}/bloom_in.parquet')
+WHERE r IN (NULL);
+----
+analyzed_plan	<REGEX>:(?s).*Empty Result.*
 
 # Optional OR filters should also use the bloom filter
 query II


### PR DESCRIPTION
Hi team, I found the following query doesn't prune row groups as expected.
```sql
memory D COPY (
             SELECT
                 ((i % 100) * 2)::INTEGER AS r,
                 i::BIGINT AS payload
             FROM range(20480) t(i)
         ) TO '/tmp/bloom_in.parquet' (
             FORMAT PARQUET,
             ROW_GROUP_SIZE 2048,
             WRITE_BLOOM_FILTER TRUE
         );

-- pruning works fine without NULL involved
memory D EXPLAIN ANALYZE
         SELECT sum(payload)
         FROM read_parquet('/tmp/bloom_in.parquet')
         WHERE r IN (101);
╭─ Summary ───────────╮
│ Total Time: 0.0033s │
│ Data Read:  17.8 kB │
╰─────────────────────╯
╭────────────────────────────────────╮
│ Ungrouped Aggregate    1 row · 0µs │
│ Projection            0 rows · 0µs │
╰──────────────────┬─────────────────╯
╭─ Table Scan ─────┴─────────────────╮
│ Function: READ_PARQUET             │
│ Projections: payload               │
│ Filters: r = 101                   │
│ Total Files Read: 1                │
│ Filename(s): /tmp/bloom_in.parquet │
│ Row Groups Scanned: 0 / 10         │
│ 0 rows                      10.0ms │
╰────────────────────────────────────╯

-- but we scan all row groups with NULL involved
memory D EXPLAIN ANALYZE
         SELECT sum(payload)
         FROM read_parquet('/tmp/bloom_in.parquet')
         WHERE r IN (101, NULL);
╭─ Summary ───────────╮
│ Total Time: 0.0033s │
│ Data Read: 107.0 kB │
╰─────────────────────╯
╭────────────────────────────────────╮
│ Ungrouped Aggregate    1 row · 0µs │
│ Projection            0 rows · 0µs │
╰──────────────────┬─────────────────╯
╭─ Table Scan ─────┴─────────────────╮
│ Function: READ_PARQUET             │
│ Projections: payload               │
│ Filters: r IN (101, NULL::INTEGER) │
│ Total Files Read: 1                │
│ Filename(s): /tmp/bloom_in.parquet │
│ Row Groups Scanned: 10 / 10        │
│ 0 rows                      10.0ms │
╰────────────────────────────────────╯
```
There're two things included in the PR
- Don't skip bloom filter propagation when NULL child met
- Skip evaluating on NULL child against bloom filter (doesn't affect correctness anyway)