### PR TITLE
Optimize self-comparison filter pruning

### DIFF
--- a/src/planner/filter/expression_filter.cpp
+++ b/src/planner/filter/expression_filter.cpp
@@ -443,6 +443,10 @@ static FilterPropagateResult CheckComparisonStatistics(optional_ptr<ClientContex
 		case ExpressionType::COMPARE_GREATERTHAN:
 		case ExpressionType::COMPARE_LESSTHAN:
 			return FilterPropagateResult::FILTER_FALSE_OR_NULL;
+		case ExpressionType::COMPARE_DISTINCT_FROM:
+			return FilterPropagateResult::FILTER_ALWAYS_FALSE;
+		case ExpressionType::COMPARE_NOT_DISTINCT_FROM:
+			return FilterPropagateResult::FILTER_ALWAYS_TRUE;
 		default:
 			break;
 		}

--- a/src/planner/filter/expression_filter.cpp
+++ b/src/planner/filter/expression_filter.cpp
@@ -435,6 +435,18 @@ static FilterPropagateResult CheckComparisonStatistics(optional_ptr<ClientContex
 	auto comparison_type = comp_expr.GetExpressionType();
 	auto &left = BoundComparisonExpression::Left(comp_expr);
 	auto &right = BoundComparisonExpression::Right(comp_expr);
+	if (left.GetExpressionClass() == ExpressionClass::BOUND_REF &&
+	    right.GetExpressionClass() == ExpressionClass::BOUND_REF &&
+	    left.Cast<BoundReferenceExpression>().Index() == right.Cast<BoundReferenceExpression>().Index()) {
+		switch (comparison_type) {
+		case ExpressionType::COMPARE_NOTEQUAL:
+		case ExpressionType::COMPARE_GREATERTHAN:
+		case ExpressionType::COMPARE_LESSTHAN:
+			return FilterPropagateResult::FILTER_FALSE_OR_NULL;
+		default:
+			break;
+		}
+	}
 	if (right.GetExpressionType() == ExpressionType::VALUE_CONSTANT) {
 		filter_stats = TryGetFilterStats(context_p, left, input_stats, owned_stats);
 		constant_expr = &right.Cast<BoundConstantExpression>();

--- a/test/sql/optimizer/multiple_column_stats_pruning.test
+++ b/test/sql/optimizer/multiple_column_stats_pruning.test
@@ -40,6 +40,27 @@ SELECT count(*) FROM xy WHERE i > j;
 ----
 0
 
+# Self-comparisons are always false, preserving NULL semantics
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM xy WHERE i > i;
+----
+analyzed_plan	<REGEX>:.*Empty Result.*
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM xy WHERE i < i;
+----
+analyzed_plan	<REGEX>:.*Empty Result.*
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM xy WHERE i <> i;
+----
+analyzed_plan	<REGEX>:.*Empty Result.*
+
+query I
+SELECT count(*) FROM xy WHERE i <> i;
+----
+0
+
 # Multi-column filters survive common-subplan canonicalization alongside regular filters
 statement ok
 PRAGMA explain_output='optimized_only';

--- a/test/sql/optimizer/multiple_column_stats_pruning.test
+++ b/test/sql/optimizer/multiple_column_stats_pruning.test
@@ -61,6 +61,23 @@ SELECT count(*) FROM xy WHERE i <> i;
 ----
 0
 
+# x IS DISTINCT FROM x is always false regardless of nullability
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM xy WHERE i IS DISTINCT FROM i;
+----
+analyzed_plan	<REGEX>:.*Empty Result.*
+
+query I
+SELECT count(*) FROM xy WHERE i IS DISTINCT FROM i;
+----
+0
+
+# x IS NOT DISTINCT FROM x is always true regardless of nullability - the filter is dropped
+query I
+SELECT count(*) FROM xy WHERE i IS NOT DISTINCT FROM i;
+----
+400000
+
 # Multi-column filters survive common-subplan canonicalization alongside regular filters
 statement ok
 PRAGMA explain_output='optimized_only';


### PR DESCRIPTION
  Prune always-false comparisons of the same bound column:
  `>`, `<`, and `<>`.

before:
```sql
memory D ATTACH '/tmp/self_compare.duckdb' AS rg (ROW_GROUP_SIZE 2048);
memory D   USE rg;
rg D 
rg D   CREATE TABLE self_compare AS
       SELECT CASE WHEN range % 2 = 0 THEN NULL ELSE range END::BIGINT AS i
       FROM range(8192);
Catalog Error:
Table with name "self_compare" already exists!
rg D   CHECKPOINT;
┌─────────┐
│ Success │
│ boolean │
└─────────┘
  0 rows 
rg D 
rg D   EXPLAIN ANALYZE
       SELECT count(*)
       FROM self_compare
       WHERE i > i;
╭─ Summary ───────────╮
│ Total Time: 0.0011s │
│ Data Read: 262.1 kB │
╰─────────────────────╯
╭─ Ungrouped Aggregate ───────╮
│ Aggregates: count_star()    │
│ 1 row                   0µs │
╰──────────────┬──────────────╯
╭─ Table Scan ─┴──────────────╮
│ Table: rg.main.self_compare │
│ Type: Sequential Scan       │
│ Filters: i > i              │
│ Row Groups Scanned: 4 / 4   │
│ 0 rows                  0µs │
╰─────────────────────────────╯
```

after

```sql
memory D   ATTACH '/tmp/self_compare.duckdb' AS rg (ROW_GROUP_SIZE 2048);
memory D   USE rg;
rg D 
rg D   CREATE TABLE self_compare AS
       SELECT CASE WHEN range % 2 = 0 THEN NULL ELSE range END::BIGINT AS i
       FROM range(8192);
Catalog Error:
Table with name "self_compare" already exists!
rg D   CHECKPOINT;
┌─────────┐
│ Success │
│ boolean │
└─────────┘
  0 rows 
rg D 
rg D   EXPLAIN ANALYZE
       SELECT count(*)
       FROM self_compare
       WHERE i > i;
╭─ Summary ───────────╮
│ Total Time: 0.0026s │
╰─────────────────────╯
╭─ Ungrouped Aggregate ────╮
│ Aggregates: count_star() │
│ 1 row                0µs │
╰─────────────┬────────────╯
╭─ Empty Result ───────────╮
│ 0 rows               0µs │
╰──────────────────────────╯
```