### PR TITLE
Create multi-column filter for rowid column

### DIFF
--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -478,8 +478,11 @@ static unique_ptr<ExpressionFilter> TryCreateMultiColumnExpressionFilter(Logical
 	vector<ProjectionIndex> column_indexes;
 	column_indexes.reserve(distinct_bindings.size());
 	for (const auto &binding : distinct_bindings) {
-		if (binding.table_index != get.table_index || binding.column_index >= get.GetColumnIds().size() ||
-		    get.GetColumnIds()[binding.column_index].IsVirtualColumn()) {
+		if (binding.table_index != get.table_index || binding.column_index >= get.GetColumnIds().size()) {
+			return nullptr;
+		}
+		auto &column_id = get.GetColumnIds()[binding.column_index];
+		if (column_id.IsVirtualColumn() && !column_id.IsRowIdColumn()) {
 			return nullptr;
 		}
 		column_indexes.emplace_back(binding.column_index);

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -704,18 +704,24 @@ static idx_t IntersectSelections(const SelectionVector &left, idx_t left_count, 
 	return result_count;
 }
 
+static BaseStatistics CreateRowIdStats(idx_t beg_row, idx_t end_row) {
+	D_ASSERT(end_row > beg_row);
+	auto result = NumericStats::CreateEmpty(LogicalType::ROW_TYPE);
+	result.SetHasNoNullFast();
+	NumericStats::SetMin(result, UnsafeNumericCast<row_t>(beg_row));
+	NumericStats::SetMax(result, UnsafeNumericCast<row_t>(end_row - 1));
+	return result;
+}
+
 FilterPropagateResult RowGroup::CheckRowIdFilter(const TableFilter &filter, idx_t beg_row, idx_t end_row) {
 	if (end_row <= beg_row) {
 		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
 	}
 	// RowId columns dont have a zonemap, but we can trivially create stats to check the filter against.
-	BaseStatistics dummy_stats = NumericStats::CreateEmpty(LogicalType::ROW_TYPE);
-	dummy_stats.SetHasNoNullFast();
-	NumericStats::SetMin(dummy_stats, UnsafeNumericCast<row_t>(beg_row));
-	NumericStats::SetMax(dummy_stats, UnsafeNumericCast<row_t>(end_row - 1));
+	auto rowid_stats = CreateRowIdStats(beg_row, end_row);
 
 	auto &expr_filter = ExpressionFilter::GetExpressionFilter(filter, "RowGroup::CheckRowIdFilter");
-	return expr_filter.CheckStatistics(dummy_stats);
+	return expr_filter.CheckStatistics(rowid_stats);
 }
 
 bool RowGroup::CheckZonemap(optional_ptr<ClientContext> context, ScanFilterInfo &filters, idx_t row_start) {
@@ -732,7 +738,11 @@ bool RowGroup::CheckZonemap(optional_ptr<ClientContext> context, ScanFilterInfo 
 					throw InternalException("Multi-column filter column index out of range");
 				}
 				const auto &storage_index = (*column_ids)[column_index.GetIndex()];
-				if (storage_index.IsRowIdColumn() || storage_index.IsRowNumberColumn()) {
+				if (storage_index.IsRowIdColumn()) {
+					input_stats.push_back(CreateRowIdStats(row_start, row_start + count));
+					continue;
+				}
+				if (storage_index.IsRowNumberColumn()) {
 					supported = false;
 					break;
 				}

--- a/test/sql/optimizer/test_rowid_pruning.test
+++ b/test/sql/optimizer/test_rowid_pruning.test
@@ -85,3 +85,23 @@ query I
 SELECT count(*) FROM empty_rowid_prune WHERE rowid = 0;
 ----
 0
+
+# Multi-column filters can combine exact rowid ranges with stored column statistics.
+# Only the middle row group can satisfy rowid < boundary.
+statement ok
+CREATE TABLE rowid_column_prune AS
+SELECT CASE
+           WHEN range >= 122880 AND range < 245760 THEN 400000
+           ELSE -1
+       END::BIGINT AS boundary
+FROM range(300000);
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM rowid_column_prune WHERE rowid < boundary;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
+
+query I
+SELECT count(*) FROM rowid_column_prune WHERE rowid < boundary;
+----
+122880


### PR DESCRIPTION
Hi team, I found for multi-column queries involving rowid column, they don't seem to be pruned correctly; for example,
```sql
memory D CREATE TABLE rowid_column_prune AS
         SELECT CASE
                    WHEN range >= 122880 AND range < 245760 THEN 400000
                    ELSE -1
                END::BIGINT AS boundary
         FROM range(300000);
memory D EXPLAIN ANALYZE SELECT count(*) FROM rowid_column_prune WHERE rowid < boundary;
╭─ Summary ───────────╮
│ Total Time: 0.0013s │
╰─────────────────────╯
╭─ Ungrouped Aggregate ─────────────────╮
│ Aggregates: count_star()              │
│ 1 row                             0µs │
╰───────────────────┰───────────────────╯
╭─ Filter ──────────┸───────────────────╮
│ Expression: rowid < boundary          │
│ 122,880 rows                      0µs │
╰───────────────────┒┎──────────────────╯
╭─ Table Scan ──────┚┖──────────────────╮
│ Table: memory.main.rowid_column_prune │
│ Type: Sequential Scan                 │
│ Projections: boundary                 │
│ Row Groups Scanned: 3 / 3             │
│ 300,000 rows                      0µs │
╰───────────────────────────────────────╯
```
In the above example, we should be able to only access one row group.

There're two issues I could tell
- When creating a multi-column filter pushdown, when rowid is contained, it's [skipped directly](https://github.com/duckdb/duckdb/blob/4a0d6fdecbf8363d15a2d8132338a346f9225957/src/optimizer/filter_combiner.cpp#L482-L483)
- Even if filter pushdown has been activated correctly, we're not yet creating stats [for rowid column](https://github.com/duckdb/duckdb/blob/4a0d6fdecbf8363d15a2d8132338a346f9225957/src/storage/table/row_group.cpp#L735-L738)