### PR TITLE
Improve filter propagation result for string-result functions

### DIFF
--- a/src/function/scalar/string/contains.cpp
+++ b/src/function/scalar/string/contains.cpp
@@ -161,7 +161,7 @@ static FilterPropagateResult ContainsFilterPrune(const FunctionStatisticsPruneIn
 	if (FindStrInStr(string_t(min), string_t(needle)) == DConstants::INVALID_INDEX) {
 		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
 	}
-	return haystack_stats->CanHaveNull() ? FilterPropagateResult::NO_PRUNING_POSSIBLE
+	return haystack_stats->CanHaveNull() ? FilterPropagateResult::FILTER_TRUE_OR_NULL
 	                                     : FilterPropagateResult::FILTER_ALWAYS_TRUE;
 }
 

--- a/src/function/scalar/string/string_common.cpp
+++ b/src/function/scalar/string/string_common.cpp
@@ -34,7 +34,7 @@ FilterPropagateResult PrefixFilterPrune(const FunctionStatisticsPruneInput &inpu
 	// Handle empty prefix
 	auto prefix = StringValue::Get(constant);
 	if (prefix.empty()) {
-		return column_stats->CanHaveNull() ? FilterPropagateResult::NO_PRUNING_POSSIBLE
+		return column_stats->CanHaveNull() ? FilterPropagateResult::FILTER_TRUE_OR_NULL
 		                                   : FilterPropagateResult::FILTER_ALWAYS_TRUE;
 	}
 
@@ -74,7 +74,7 @@ FilterPropagateResult PrefixFilterPrune(const FunctionStatisticsPruneInput &inpu
 	    memcmp(min.c_str(), prefix.c_str(), prefix.size()) == 0 &&
 	    memcmp(max.c_str(), prefix.c_str(), prefix.size()) == 0) {
 		// NULL values produce NULL rather than true, so they prevent an always-true result
-		return column_stats->CanHaveNull() ? FilterPropagateResult::NO_PRUNING_POSSIBLE
+		return column_stats->CanHaveNull() ? FilterPropagateResult::FILTER_TRUE_OR_NULL
 		                                   : FilterPropagateResult::FILTER_ALWAYS_TRUE;
 	}
 	return FilterPropagateResult::NO_PRUNING_POSSIBLE;

--- a/src/function/scalar/string/suffix.cpp
+++ b/src/function/scalar/string/suffix.cpp
@@ -71,7 +71,7 @@ FilterPropagateResult SuffixFilterPrune(const FunctionStatisticsPruneInput &inpu
 	if (!SuffixFunction(string_t(min), string_t(suffix))) {
 		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
 	}
-	return string_stats->CanHaveNull() ? FilterPropagateResult::NO_PRUNING_POSSIBLE
+	return string_stats->CanHaveNull() ? FilterPropagateResult::FILTER_TRUE_OR_NULL
 	                                   : FilterPropagateResult::FILTER_ALWAYS_TRUE;
 }
 

--- a/src/planner/filter/expression_filter.cpp
+++ b/src/planner/filter/expression_filter.cpp
@@ -678,9 +678,12 @@ static FilterPropagateResult CheckNotOperatorStatistics(optional_ptr<ClientConte
 	}
 	// a child matching every row makes NOT match no row - the converse does not hold, since a child
 	// that matches no row may be NULL rather than false, and NOT NULL does not match either
-	if (ExpressionFilter::CheckExpressionStatistics(context_p, child, input_stats) ==
-	    FilterPropagateResult::FILTER_ALWAYS_TRUE) {
+	auto child_result = ExpressionFilter::CheckExpressionStatistics(context_p, child, input_stats);
+	if (child_result == FilterPropagateResult::FILTER_ALWAYS_TRUE) {
 		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
+	}
+	if (child_result == FilterPropagateResult::FILTER_TRUE_OR_NULL) {
+		return FilterPropagateResult::FILTER_FALSE_OR_NULL;
 	}
 	return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 }

--- a/test/optimizer/statistics/statistics_suffix.test
+++ b/test/optimizer/statistics/statistics_suffix.test
@@ -49,6 +49,17 @@ EXPLAIN ANALYZE SELECT sum(i) FROM nullable_suffix_constants WHERE suffix(s, 'q'
 ----
 analyzed_plan	<REGEX>:.*Row Groups Scanned: 0 / 2.*
 
+query I
+SELECT count(*) FROM nullable_suffix_constants WHERE NOT suffix(s, 'c');
+----
+61440
+
+# The first row group produces true-or-NULL, so its negation cannot match any rows.
+query II
+EXPLAIN ANALYZE SELECT sum(i) FROM nullable_suffix_constants WHERE NOT suffix(s, 'c');
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 2.*
+
 statement ok
 CREATE TABLE suffix_lengths AS
 SELECT i, CASE WHEN i < 122880 THEN 'short' ELSE repeat('x', 50) END AS s

--- a/test/sql/optimizer/contains_row_group_pruning.test
+++ b/test/sql/optimizer/contains_row_group_pruning.test
@@ -55,6 +55,26 @@ SELECT count(*) FROM with_nulls WHERE contains(s, 'python');
 ----
 0
 
+# A nullable constant group produces true-or-NULL, so its negation cannot match any rows.
+statement ok
+CREATE TABLE negated_nullable_contains AS
+SELECT CASE
+           WHEN range < 2048 THEN CASE WHEN range % 2 = 0 THEN 'abc' ELSE NULL END
+           WHEN range < 4096 THEN 'zzz'
+           ELSE 'abc'
+       END::VARCHAR AS s
+FROM range(6144)
+
+query I
+SELECT count(*) FROM negated_nullable_contains WHERE NOT contains(s, 'a')
+----
+2048
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM negated_nullable_contains WHERE NOT contains(s, 'a')
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
+
 # strings longer than the stats prefix are not exact: no pruning, but results stay correct
 statement ok
 CREATE TABLE long_strings AS SELECT 'duckduckgo_search' AS s FROM range(6144);

--- a/test/sql/optimizer/prefix_zonemap_pruning.test
+++ b/test/sql/optimizer/prefix_zonemap_pruning.test
@@ -121,6 +121,26 @@ SELECT count(*) FROM prefix_nullable WHERE NOT starts_with(s, '00');
 ----
 0
 
+# A nullable constant group produces true-or-NULL, so its negation cannot match any rows.
+statement ok
+CREATE TABLE prefix_nullable_mixed AS
+SELECT CASE
+           WHEN range < 2048 THEN CASE WHEN range % 2 = 0 THEN 'abc' ELSE NULL END
+           WHEN range < 4096 THEN 'zzz'
+           ELSE 'abc'
+       END::VARCHAR AS s
+FROM range(6144)
+
+query I
+SELECT count(*) FROM prefix_nullable_mixed WHERE NOT prefix(s, 'a')
+----
+2048
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM prefix_nullable_mixed WHERE NOT prefix(s, 'a')
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
+
 # Multi-byte needles within the stored prefix bytes are provable.
 statement ok
 CREATE TABLE prefix_utf8 AS

--- a/test/sql/optimizer/prefix_zonemap_pruning.test
+++ b/test/sql/optimizer/prefix_zonemap_pruning.test
@@ -105,7 +105,7 @@ SELECT count(*) FROM prefix_truncated WHERE NOT starts_with(s, 'ppppppppppppp');
 ----
 0
 
-# NULL rows produce NULL rather than false, so a nullable column is not pruned.
+# NULL rows do not satisfy the negated predicate, so true-or-NULL can be pruned.
 statement ok
 CREATE TABLE prefix_nullable AS
 SELECT i::INTEGER AS i, CASE WHEN i % 100 = 50 THEN NULL ELSE lpad(i::VARCHAR, 6, '0') END AS s
@@ -114,7 +114,7 @@ FROM range(6144) r(i);
 query II
 EXPLAIN ANALYZE SELECT count(*) FROM prefix_nullable WHERE NOT starts_with(s, '00');
 ----
-analyzed_plan	<REGEX>:.*Row Groups Scanned: 3 / 3.*
+analyzed_plan	<REGEX>:.*Empty Result.*
 
 query I
 SELECT count(*) FROM prefix_nullable WHERE NOT starts_with(s, '00');


### PR DESCRIPTION
Hi team, I think currently string-related functions return over-conservative filter propagation result, which leads to unnecessary row group access; for example,
```sql
memory D ATTACH '/tmp/prefix_zonemap_pruning.duckdb' AS db (ROW_GROUP_SIZE 2048);
memory D USE db;
db D CREATE TABLE prefix_nullable_mixed AS
     SELECT CASE
                WHEN range < 2048 THEN CASE WHEN range % 2 = 0 THEN 'abc' ELSE NULL END
                WHEN range < 4096 THEN 'zzz'
                ELSE 'abc'
            END::VARCHAR AS s
     FROM range(6144);

-- we should only access one row group
db D EXPLAIN ANALYZE SELECT count(*) FROM prefix_nullable_mixed WHERE NOT prefix(s, 'a');
╭─ Summary ───────────╮
│ Total Time: 0.0022s │
╰─────────────────────╯
╭─ Ungrouped Aggregate ────────────────╮
│ Aggregates: count_star()             │
│ 1 row                            0µs │
╰───────────────────┒┎─────────────────╯
╭─ Table Scan ──────┚┖─────────────────╮
│ Table: db.main.prefix_nullable_mixed │
│ Type: Sequential Scan                │
│ Filters: NOT prefix(s, 'a')          │
│ Row Groups Scanned: 2 / 3            │
│ 2,048 rows                       0µs │
╰──────────────────────────────────────╯
``` 