### PR TITLE
Remove redundant CMake CMP00xx policy settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,22 +4,6 @@ if(NOT CLANG_TIDY)
   find_package(Python3)
 endif()
 
-if(POLICY CMP0026)
-  cmake_policy(SET CMP0026 NEW)
-endif()
-
-if(POLICY CMP0051)
-  cmake_policy(SET CMP0051 NEW)
-endif()
-
-if(POLICY CMP0054)
-  cmake_policy(SET CMP0054 NEW)
-endif()
-
-if(POLICY CMP0063)
-  cmake_policy(SET CMP0063 NEW)
-endif()
-
 project(DuckDB)
 
 find_package(Threads REQUIRED)

--- a/third_party/fastpforlib/CMakeLists.txt
+++ b/third_party/fastpforlib/CMakeLists.txt
@@ -1,7 +1,3 @@
-if(POLICY CMP0063)
-    cmake_policy(SET CMP0063 NEW)
-endif()
-
 add_library(duckdb_fastpforlib STATIC bitpacking.cpp)
 
 target_include_directories(

--- a/third_party/fmt/CMakeLists.txt
+++ b/third_party/fmt/CMakeLists.txt
@@ -1,7 +1,3 @@
-if(POLICY CMP0063)
-    cmake_policy(SET CMP0063 NEW)
-endif()
-
 add_library(duckdb_fmt STATIC format.cc)
 
 target_include_directories(duckdb_fmt PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)

--- a/third_party/fsst/CMakeLists.txt
+++ b/third_party/fsst/CMakeLists.txt
@@ -1,7 +1,3 @@
-if(POLICY CMP0063)
-    cmake_policy(SET CMP0063 NEW)
-endif()
-
 find_package(Threads REQUIRED)
 
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)

--- a/third_party/hyperloglog/CMakeLists.txt
+++ b/third_party/hyperloglog/CMakeLists.txt
@@ -1,7 +1,3 @@
-if(POLICY CMP0063)
-    cmake_policy(SET CMP0063 NEW)
-endif()
-
 add_library(duckdb_hyperloglog STATIC hyperloglog.cpp sds.cpp)
 
 target_include_directories(

--- a/third_party/imdb/CMakeLists.txt
+++ b/third_party/imdb/CMakeLists.txt
@@ -1,9 +1,5 @@
 cmake_minimum_required(VERSION 3.5...3.29)
 
-if(POLICY CMP0063)
-    cmake_policy(SET CMP0063 NEW)
-endif()
-
 project(imdb CXX)
 
 include_directories(include)

--- a/third_party/mbedtls/CMakeLists.txt
+++ b/third_party/mbedtls/CMakeLists.txt
@@ -1,7 +1,3 @@
-if(POLICY CMP0063)
-    cmake_policy(SET CMP0063 NEW)
-endif()
-
 include_directories(include)
 
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)

--- a/third_party/miniz/CMakeLists.txt
+++ b/third_party/miniz/CMakeLists.txt
@@ -1,7 +1,3 @@
-if(POLICY CMP0063)
-    cmake_policy(SET CMP0063 NEW)
-endif()
-
 add_library(duckdb_miniz STATIC miniz.cpp)
 
 target_include_directories(

--- a/third_party/re2/CMakeLists.txt
+++ b/third_party/re2/CMakeLists.txt
@@ -3,14 +3,6 @@
 
 cmake_minimum_required(VERSION 3.5...3.29)
 
-if(POLICY CMP0048)
-  cmake_policy(SET CMP0048 NEW)
-endif()
-
-if(POLICY CMP0063)
-  cmake_policy(SET CMP0063 NEW)
-endif()
-
 project(RE2 CXX)
 
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)

--- a/third_party/skiplist/CMakeLists.txt
+++ b/third_party/skiplist/CMakeLists.txt
@@ -1,7 +1,3 @@
-if(POLICY CMP0063)
-    cmake_policy(SET CMP0063 NEW)
-endif()
-
 add_library(duckdb_skiplistlib STATIC SkipList.cpp)
 
 target_include_directories(

--- a/third_party/utf8proc/CMakeLists.txt
+++ b/third_party/utf8proc/CMakeLists.txt
@@ -1,7 +1,3 @@
-if(POLICY CMP0063)
-    cmake_policy(SET CMP0063 NEW)
-endif()
-
 include_directories(include)
 
 add_library(duckdb_utf8proc STATIC utf8proc.cpp utf8proc_wrapper.cpp)

--- a/third_party/yyjson/CMakeLists.txt
+++ b/third_party/yyjson/CMakeLists.txt
@@ -1,7 +1,3 @@
-if(POLICY CMP0063)
-    cmake_policy(SET CMP0063 NEW)
-endif()
-
 add_library(duckdb_yyjson STATIC yyjson.cpp)
 
 target_include_directories(

--- a/third_party/zstd/CMakeLists.txt
+++ b/third_party/zstd/CMakeLists.txt
@@ -1,7 +1,3 @@
-if(POLICY CMP0063)
-    cmake_policy(SET CMP0063 NEW)
-endif()
-
 set(ZSTD_FILES
 	compress/zstd_compress_superblock.cpp
 	compress/zstdmt_compress.cpp


### PR DESCRIPTION
##   Alternatives:
  -  Drop no-op cmake_policy(SET CMP00xx) now implied by CMake 3.14
  -  Remove obsolete cmake_policy CMP00xx blocks from CMakeLists

## Summary
  - `cmake_minimum_required(VERSION 3.14...3.29)` already sets every policy introduced in CMake 3.14 or earlier to NEW, so explicit `cmake_policy(SET
  CMP00xx NEW)` is a no-op.
  - Remove those leftover `if(POLICY) ... cmake_policy(SET ... NEW)` blocks from the root `CMakeLists.txt` and vendored `third_party` CMake files
  (CMP0026, CMP0048, CMP0051, CMP0054, CMP0063).
  - Build behavior is unchanged: CMake 4.0 also removed the OLD implementations of these policies, so NEW is the only remaining option.

  ## Test plan
  - [ ] `cmake -S . -B build/check` completes without policy warnings for CMP0026/CMP0048/CMP0051/CMP0054/CMP0063
  - [ ] A normal `make reldebug` (or Ninja) configure and build still succeeds