### PR TITLE
Leverage bloom filter for parquet MAP type

### DIFF
--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1564,6 +1564,20 @@ static bool TryGetNestedBloomFilterLeaf(ColumnReader &column_reader, const Expre
 		return true;
 	}
 
+	// Handle MAP value extraction.
+	if (leaf_reader->Type().id() == LogicalTypeId::MAP && function.Function().GetName() == "map_extract_value") {
+		auto &entry_reader = leaf_reader->Cast<ListColumnReader>().GetChildReader();
+		if (entry_reader.Type().id() != LogicalTypeId::STRUCT) {
+			return false;
+		}
+		auto &struct_reader = entry_reader.Cast<StructColumnReader>();
+		if (struct_reader.child_readers.size() != 2 || !struct_reader.child_readers[1]) {
+			return false;
+		}
+		leaf_reader = struct_reader.child_readers[1].get();
+		return true;
+	}
+
 	// Handle STRUCT type.
 	if (leaf_reader->Type().id() == LogicalTypeId::STRUCT) {
 		idx_t child_idx;

--- a/test/sql/copy/parquet/map_extract_row_group_pruning.test
+++ b/test/sql/copy/parquet/map_extract_row_group_pruning.test
@@ -18,3 +18,29 @@ query I
 SELECT count(*) FROM '{TEST_DIR}/map_extract_row_group_pruning.parquet' WHERE m['k'] BETWEEN 2900 AND 3100;
 ----
 201
+
+# Map value extraction should reach the value leaf Bloom filter when the map is projected.
+statement ok
+COPY (
+	SELECT MAP {'k': ((i % 100) * 2)::INTEGER} AS m, i AS payload
+	FROM range(20480) t(i)
+) TO '{TEST_DIR}/map_extract_bloom_pruning.parquet' (
+	FORMAT PARQUET,
+	ROW_GROUP_SIZE 2048,
+	DICTIONARY_SIZE_LIMIT 1000,
+	WRITE_BLOOM_FILTER TRUE
+)
+
+query I
+SELECT count(*) FROM read_parquet('{TEST_DIR}/map_extract_bloom_pruning.parquet')
+WHERE m['k'] = 101
+----
+0
+
+# 101 is absent but within every value leaf's min/max range, so only the Bloom filter can exclude it.
+query II
+EXPLAIN ANALYZE
+SELECT m, payload FROM read_parquet('{TEST_DIR}/map_extract_bloom_pruning.parquet')
+WHERE m['k'] = 101
+----
+analyzed_plan	<REGEX>:(?s).*Row Groups Scanned: 0 / 10.*


### PR DESCRIPTION
Hi team, I found query against parquet map value doesn't seem to prune row group as expected; for example,
```sql
memory D COPY (
             SELECT MAP {'k': ((i % 100) * 2)::INTEGER} AS m, i AS payload
             FROM range(20480) t(i)
         ) TO '/tmp/map_extract_bloom_pruning.parquet' (
             FORMAT PARQUET,
             ROW_GROUP_SIZE 2048,
             DICTIONARY_SIZE_LIMIT 1000,
             WRITE_BLOOM_FILTER TRUE
         );

-- we should access none row group, but actually all row groups are accessed.
memory D EXPLAIN ANALYZE
         SELECT m, payload FROM read_parquet('/tmp/map_extract_bloom_pruning.parquet')
         WHERE m['k'] = 101;
╭─ Summary ───────────╮
│ Total Time: 0.0033s │
│ Data Read: 107.5 kB │
╰─────────────────────╯
╭─ Table Scan ─────────────────────────────╮
│ Function: READ_PARQUET                   │
│ Projections: m, payload                  │
│ Filters: map_extract_value(m, 'k') = 101 │
│ Total Files Read: 1                      │
│ Filename(s):                             │
│ /tmp/map_extract_bloom_pruning.parquet   │
│ Row Groups Scanned: 10 / 10              │
│ 0 rows                            10.0ms │
╰──────────────────────────────────────────╯
```