### PR TITLE
Set nullability for a few functions

### DIFF
--- a/extension/core_functions/scalar/array/array_functions.cpp
+++ b/extension/core_functions/scalar/array/array_functions.cpp
@@ -213,6 +213,10 @@ static auto ArrayGenericFoldStats(ClientContext &context, FunctionStatisticsInpu
 	const auto &lhs_stats = input.child_stats[0];
 	const auto &rhs_stats = input.child_stats[1];
 	auto new_stats = NumericStats::CreateUnknown(input.expr.GetReturnType());
+	new_stats.CombineValidity(lhs_stats, rhs_stats);
+	if (!lhs_stats.CanHaveNoNull() || !rhs_stats.CanHaveNoNull()) {
+		new_stats.Set(StatsInfo::CANNOT_HAVE_VALID_VALUES);
+	}
 
 	auto &lhs_child_stats = ArrayStats::GetChildStats(lhs_stats);
 	auto &rhs_child_stats = ArrayStats::GetChildStats(rhs_stats);
@@ -226,9 +230,6 @@ static auto ArrayGenericFoldStats(ClientContext &context, FunctionStatisticsInpu
 
 	// If the child has no nulls, we won't throw.
 	input.expr.FunctionMutable().GetProperties().SetErrorMode(FunctionErrors::CANNOT_ERROR);
-
-	// Forward the validity
-	new_stats.CombineValidity(lhs_stats, rhs_stats);
 
 	return new_stats.ToUnique();
 }

--- a/extension/core_functions/scalar/map/map_extract.cpp
+++ b/extension/core_functions/scalar/map/map_extract.cpp
@@ -102,6 +102,9 @@ static unique_ptr<BaseStatistics> MapExtractValueStats(ClientContext &, Function
 	auto value_copy = StructStats::GetChildStats(entry_stats, 1).Copy();
 	// missing keys return NULL
 	value_copy.Set(StatsInfo::CAN_HAVE_NULL_VALUES);
+	if (!input.child_stats[0].CanHaveNoNull() || !input.child_stats[1].CanHaveNoNull()) {
+		value_copy.Set(StatsInfo::CANNOT_HAVE_VALID_VALUES);
+	}
 	return value_copy.ToUnique();
 }
 

--- a/extension/core_functions/scalar/struct/struct_insert.cpp
+++ b/extension/core_functions/scalar/struct/struct_insert.cpp
@@ -73,6 +73,7 @@ static unique_ptr<BaseStatistics> StructInsertStats(ClientContext &context, Func
 	auto &child_stats = input.child_stats;
 	auto &expr = input.expr;
 	auto new_stats = StructStats::CreateUnknown(expr.GetReturnType());
+	new_stats.Set(StatsInfo::CANNOT_HAVE_NULL_VALUES);
 
 	auto existing_count = StructType::GetChildCount(child_stats[0].GetType());
 	auto existing_stats = StructStats::GetChildStats(child_stats[0]);

--- a/extension/core_functions/scalar/struct/struct_update.cpp
+++ b/extension/core_functions/scalar/struct/struct_update.cpp
@@ -116,6 +116,7 @@ static unique_ptr<BaseStatistics> StructUpdateStats(ClientContext &context, Func
 	auto incoming_children = identifier_tree_t<idx_t>();
 	auto is_new_field = vector<bool>(expr.GetChildren().size(), true);
 	auto new_stats = StructStats::CreateUnknown(expr.GetReturnType());
+	new_stats.Set(StatsInfo::CANNOT_HAVE_NULL_VALUES);
 
 	for (idx_t arg_idx = 1; arg_idx < expr.GetChildren().size(); arg_idx++) {
 		auto &new_child = expr.GetChildren()[arg_idx];

--- a/src/function/scalar/list/list_extract.cpp
+++ b/src/function/scalar/list/list_extract.cpp
@@ -159,6 +159,9 @@ static unique_ptr<BaseStatistics> ListExtractStats(ClientContext &context, Funct
 	auto child_copy = list_child_stats.Copy();
 	// list_extract always pushes a NULL, since if the offset is out of range for a list it inserts a null
 	child_copy.Set(StatsInfo::CAN_HAVE_NULL_VALUES);
+	if (!child_stats[0].CanHaveNoNull() || !child_stats[1].CanHaveNoNull()) {
+		child_copy.Set(StatsInfo::CANNOT_HAVE_VALID_VALUES);
+	}
 	return child_copy.ToUnique();
 }
 

--- a/src/function/scalar/struct/struct_concat.cpp
+++ b/src/function/scalar/struct/struct_concat.cpp
@@ -86,6 +86,7 @@ static unique_ptr<BaseStatistics> StructConcatStats(ClientContext &context, Func
 	auto &arg_exprs = input.expr.GetChildren();
 
 	auto struct_stats = StructStats::CreateUnknown(expr.GetReturnType());
+	struct_stats.Set(StatsInfo::CANNOT_HAVE_NULL_VALUES);
 	idx_t struct_index = 0;
 
 	for (idx_t arg_idx = 0; arg_idx < arg_exprs.size(); arg_idx++) {

--- a/src/function/scalar/struct/struct_pack.cpp
+++ b/src/function/scalar/struct/struct_pack.cpp
@@ -82,6 +82,7 @@ static unique_ptr<BaseStatistics> StructPackStats(ClientContext &context, Functi
 	auto &child_stats = input.child_stats;
 	auto &expr = input.expr;
 	auto struct_stats = StructStats::CreateUnknown(expr.GetReturnType());
+	struct_stats.Set(StatsInfo::CANNOT_HAVE_NULL_VALUES);
 	for (idx_t i = 0; i < child_stats.size(); i++) {
 		StructStats::SetChildStats(struct_stats, i, child_stats[i]);
 	}

--- a/test/optimizer/statistics/statistics_filter_pruning.test
+++ b/test/optimizer/statistics/statistics_filter_pruning.test
@@ -353,3 +353,26 @@ query I
 SELECT count(*) FROM stats_filter_nullable WHERE (i * 0 = 0) OR ((i + 1) > 1000000);
 ----
 9000
+
+# struct_pack always constructs a non-NULL parent, even when a child is NULL.
+statement ok
+ATTACH '{TEST_DIR}/struct_pack_pruning.duckdb' AS struct_pack_db (ROW_GROUP_SIZE 2048)
+
+statement ok
+CREATE TABLE struct_pack_db.inputs AS
+SELECT CASE WHEN i % 2 = 0 THEN i ELSE NULL END AS i
+FROM range(6144) tbl(i)
+
+query I
+SELECT count(*) FROM struct_pack_db.inputs WHERE struct_pack(x := i) IS NULL;
+----
+0
+
+statement ok
+RESET enable_profiling;
+
+query II
+EXPLAIN ANALYZE
+SELECT count(*) FROM struct_pack_db.inputs WHERE struct_pack(x := i) IS NULL;
+----
+analyzed_plan	<REGEX>:.*EMPTY_RESULT.*

--- a/test/optimizer/statistics/statistics_filter_pruning.test
+++ b/test/optimizer/statistics/statistics_filter_pruning.test
@@ -360,7 +360,8 @@ ATTACH '{TEST_DIR}/struct_pack_pruning.duckdb' AS struct_pack_db (ROW_GROUP_SIZE
 
 statement ok
 CREATE TABLE struct_pack_db.inputs AS
-SELECT CASE WHEN i % 2 = 0 THEN i ELSE NULL END AS i
+SELECT CASE WHEN i % 2 = 0 THEN i ELSE NULL END AS i,
+       CASE WHEN i % 2 = 0 THEN {'a': i} ELSE NULL END AS s
 FROM range(6144) tbl(i)
 
 query I
@@ -374,5 +375,23 @@ RESET enable_profiling;
 query II
 EXPLAIN ANALYZE
 SELECT count(*) FROM struct_pack_db.inputs WHERE struct_pack(x := i) IS NULL;
+----
+analyzed_plan	<REGEX>:.*EMPTY_RESULT.*
+
+query II
+EXPLAIN ANALYZE
+SELECT count(*) FROM struct_pack_db.inputs WHERE struct_concat(s, {'b': 1}) IS NULL;
+----
+analyzed_plan	<REGEX>:.*EMPTY_RESULT.*
+
+query II
+EXPLAIN ANALYZE
+SELECT count(*) FROM struct_pack_db.inputs WHERE struct_insert(s, b := 1) IS NULL;
+----
+analyzed_plan	<REGEX>:.*EMPTY_RESULT.*
+
+query II
+EXPLAIN ANALYZE
+SELECT count(*) FROM struct_pack_db.inputs WHERE struct_update(s, b := 1) IS NULL;
 ----
 analyzed_plan	<REGEX>:.*EMPTY_RESULT.*

--- a/test/sql/function/array/array_inner_product.test
+++ b/test/sql/function/array/array_inner_product.test
@@ -58,3 +58,23 @@ array_inner_product: Array arguments must be of the same size
 
 
 endloop
+
+# Strict binary array functions are NULL when either parent array is NULL.
+statement ok
+ATTACH '{TEST_DIR}/array_fold_validity.duckdb' AS array_fold_db (ROW_GROUP_SIZE 2048)
+
+statement ok
+CREATE TABLE array_fold_db.inputs AS
+SELECT NULL::DOUBLE[2] AS a, [1::DOUBLE, 1]::DOUBLE[2] AS b
+FROM range(6144) tbl(i)
+
+query I
+SELECT count(*) FROM array_fold_db.inputs WHERE array_inner_product(a, b) IS NOT NULL;
+----
+0
+
+query II
+EXPLAIN ANALYZE
+SELECT count(*) FROM array_fold_db.inputs WHERE array_inner_product(a, b) IS NOT NULL;
+----
+analyzed_plan	<REGEX>:.*Empty Result.*

--- a/test/sql/optimizer/array_extract_row_group_pruning.test
+++ b/test/sql/optimizer/array_extract_row_group_pruning.test
@@ -59,3 +59,24 @@ query I
 SELECT count(*) FROM nullable_arrays WHERE a[4] IS NULL;
 ----
 3
+
+# An all-NULL list or index makes extraction NULL for the entire row group.
+statement ok
+CREATE TABLE nullable_list_extract AS
+SELECT CASE WHEN i < 2048 THEN NULL ELSE [i] END AS nullable_l
+FROM range(6144) tbl(i)
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM nullable_list_extract WHERE list_extract(nullable_l, 1) IS NOT NULL;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 2 / 3.*
+
+statement ok
+CREATE TABLE all_null_list_index AS
+SELECT [i] AS l, NULL::BIGINT AS idx
+FROM range(6144) tbl(i)
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM all_null_list_index WHERE list_extract(l, idx) IS NOT NULL;
+----
+analyzed_plan	<REGEX>:.*Empty Result.*

--- a/test/sql/optimizer/map_extract_row_group_pruning.test
+++ b/test/sql/optimizer/map_extract_row_group_pruning.test
@@ -27,3 +27,24 @@ query II
 EXPLAIN ANALYZE SELECT count(*) FROM maps WHERE map_extract_value(m, 'k') BETWEEN 2900 AND 3100;
 ----
 analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
+
+# An all-NULL map or key makes extraction NULL for the entire row group.
+statement ok
+CREATE TABLE nullable_map_extract AS
+SELECT CASE WHEN i < 2048 THEN NULL ELSE MAP {'k': i} END AS nullable_m
+FROM range(6144) tbl(i)
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM nullable_map_extract WHERE map_extract_value(nullable_m, 'k') IS NOT NULL;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 2 / 3.*
+
+statement ok
+CREATE TABLE all_null_map_key AS
+SELECT MAP {'k': i} AS m, NULL::VARCHAR AS key
+FROM range(6144) tbl(i)
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM all_null_map_key WHERE map_extract_value(m, key) IS NOT NULL;
+----
+analyzed_plan	<REGEX>:.*Empty Result.*


### PR DESCRIPTION
Hi team, I found there're a few functions which set stats nullability conservatively, which leads to more row groups to be accessed on query; for example,
```sql
memory D ATTACH '/TMP/struct_pack_pruning.duckdb' AS struct_pack_db (ROW_GROUP_SIZE 2048);
memory D CREATE TABLE struct_pack_db.inputs AS
         SELECT CASE WHEN i % 2 = 0 THEN i ELSE NULL END AS i
         FROM range(6144) tbl(i);

-- for this query, we shouldn't access any row groups
memory D EXPLAIN ANALYZE
         SELECT count(*) FROM struct_pack_db.inputs WHERE struct_pack(x := i) IS NULL;
╭─ Summary ───────────╮
│ Total Time: 0.0046s │
╰─────────────────────╯
╭─ Ungrouped Aggregate ─────────────╮
│ Aggregates: count_star()          │
│ 1 row                         0µs │
╰─────────────────┬─────────────────╯
╭─ Table Scan ────┴─────────────────╮
│ Table: struct_pack_db.main.inputs │
│ Type: Sequential Scan             │
│ Filters: struct_pack(i) IS NULL   │
│ Row Groups Scanned: 3 / 3         │
│ 0 rows                        0µs │
╰───────────────────────────────────╯
```