### PR TITLE
Fix `flatten` function validity

### DIFF
--- a/extension/core_functions/scalar/list/flatten.cpp
+++ b/extension/core_functions/scalar/list/flatten.cpp
@@ -134,7 +134,7 @@ unique_ptr<BaseStatistics> ListFlattenStats(ClientContext &context, FunctionStat
 	auto &child_stats = input.child_stats;
 	auto &list_child_stats = ListStats::GetChildStats(child_stats[0]);
 	auto child_copy = list_child_stats.Copy();
-	child_copy.Set(StatsInfo::CAN_HAVE_NULL_VALUES);
+	child_copy.CopyValidity(child_stats[0]);
 	return child_copy.ToUnique();
 }
 

--- a/test/sql/function/list/flatten.test
+++ b/test/sql/function/list/flatten.test
@@ -156,3 +156,29 @@ select v.*, flatten(v.list_of_lists) from v_list_of_lists v;
 a	[1, 2, 3]	[[1, 2, 3]]	[1, 2, 3]
 a	[2, 6]	[[1, 2, 3], [2, 6]]	[1, 2, 3, 2, 6]
 b	[4, 5]	[[4, 5]]	[4, 5]
+
+# Output validity follows the outer list, not its inner lists.
+statement ok
+ATTACH '{TEST_DIR}/flatten_validity.duckdb' AS flatten_db (ROW_GROUP_SIZE 2048)
+
+statement ok
+CREATE TABLE flatten_db.inputs AS
+SELECT CASE
+           WHEN i < 2048 THEN NULL::INTEGER[][]
+           WHEN i < 4096 THEN [NULL::INTEGER[]]
+           ELSE [[i::INTEGER]]
+       END AS nested
+FROM range(6144) tbl(i)
+
+query I
+SELECT count(*) FROM flatten_db.inputs WHERE flatten(nested) IS NOT NULL;
+----
+4096
+
+query II
+EXPLAIN ANALYZE
+SELECT sum(array_length(flatten(nested)))
+FROM flatten_db.inputs
+WHERE flatten(nested) IS NOT NULL;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 2 / 3.*


### PR DESCRIPTION
Closes https://github.com/duckdb/duckdb/issues/25241

In the current implementation, statistics propagation copied the inner-list validity and only marked the result as nullable. This could leave the result marked as having no valid values, causing incorrect row-group pruning for
`flatten(...) IS NOT NULL`.