### PR TITLE
Allow DETACH in a transaction; reject re-ATTACH of the same alias

### DIFF
--- a/src/execution/operator/schema/physical_detach.cpp
+++ b/src/execution/operator/schema/physical_detach.cpp
@@ -1,37 +1,16 @@
 #include "duckdb/execution/operator/schema/physical_detach.hpp"
 #include "duckdb/parser/parsed_data/detach_info.hpp"
-#include "duckdb/catalog/catalog.hpp"
-#include "duckdb/common/exception/transaction_exception.hpp"
 #include "duckdb/main/database_manager.hpp"
-#include "duckdb/main/attached_database.hpp"
-#include "duckdb/main/database.hpp"
-#include "duckdb/storage/storage_extension.hpp"
-#include "duckdb/transaction/meta_transaction.hpp"
 
 namespace duckdb {
 
-//===--------------------------------------------------------------------===//
-// Source
-//===--------------------------------------------------------------------===//
+// DETACH always drops the catalog name. If this transaction already used the database,
+// MetaTransaction keeps the AttachedDatabase alive (used_databases / referenced_databases)
+// until commit/rollback, and UseDatabase rejects re-ATTACH of the same alias.
 SourceResultType PhysicalDetach::GetDataInternal(ExecutionContext &context, DataChunk &chunk,
                                                  OperatorSourceInput &input) const {
 	auto &db_manager = DatabaseManager::Get(context.client);
-
-	// Reject detach if the current transaction already has outstanding work on the database.
-	{
-		auto attached_db = db_manager.GetDatabase(info->name);
-		if (attached_db) {
-			auto &meta_transaction = MetaTransaction::Get(context.client);
-			if (meta_transaction.TryGetTransaction(*attached_db)) {
-				throw TransactionException("Cannot detach database %s because the current transaction has outstanding "
-				                           "work on it - commit or rollback first",
-				                           info->name);
-			}
-		}
-	}
-
 	db_manager.DetachDatabase(context.client, info->name, info->if_not_found);
-
 	return SourceResultType::FINISHED;
 }
 

--- a/src/execution/operator/schema/physical_detach.cpp
+++ b/src/execution/operator/schema/physical_detach.cpp
@@ -4,9 +4,9 @@
 
 namespace duckdb {
 
-// DETACH always drops the catalog name. If this transaction already used the database,
-// MetaTransaction keeps the AttachedDatabase alive (used_databases / referenced_databases)
-// until commit/rollback, and UseDatabase rejects re-ATTACH of the same alias.
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
 SourceResultType PhysicalDetach::GetDataInternal(ExecutionContext &context, DataChunk &chunk,
                                                  OperatorSourceInput &input) const {
 	auto &db_manager = DatabaseManager::Get(context.client);

--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -159,11 +159,8 @@ shared_ptr<AttachedDatabase> DatabaseManager::AttachDatabase(ClientContext &cont
 		}
 	}
 
-	// Detached in this transaction: name is unbound, but the AttachedDatabase object
-	// is still held. Plain ATTACH of that alias would mix two files under one txn name.
-	// ATTACH OR REPLACE is an explicit swap — do not apply this rule (see #20748).
-	if (info.on_conflict != OnCreateConflict::REPLACE_ON_CONFLICT &&
-	    MetaTransaction::Get(context).GetReferencedDatabaseOwning(info.name)) {
+	// Unbound alias whose AttachedDatabase this transaction still holds.
+	if (!GetDatabase(info.name) && MetaTransaction::Get(context).GetReferencedDatabaseOwning(info.name)) {
 		throw TransactionException("Cannot re-attach database %s in the same transaction that already used it",
 		                           info.name);
 	}
@@ -283,9 +280,7 @@ void DatabaseManager::DetachDatabase(ClientContext &context, const Identifier &n
 		return;
 	}
 
-	// Unbind the alias so GetDatabase no longer resolves it. Keep referenced_databases
-	// so in-flight transactions can still commit. Re-ATTACH of this alias is rejected
-	// via GetReferencedDatabaseOwning below.
+	// Drop the catalog name; keep the AttachedDatabase in referenced_databases until commit.
 	MetaTransaction::Get(context).DetachDatabase(*attached_db);
 
 	attached_db->OnDetach(context);

--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -160,9 +160,16 @@ shared_ptr<AttachedDatabase> DatabaseManager::AttachDatabase(ClientContext &cont
 	}
 
 	// Unbound alias whose AttachedDatabase this transaction still holds.
-	if (!GetDatabase(info.name) && MetaTransaction::Get(context).GetReferencedDatabaseOwning(info.name)) {
-		throw TransactionException("Cannot re-attach database %s in the same transaction that already used it",
-		                           info.name);
+	// Hidden readers (read_duckdb) DETACH after a scan and re-ATTACH the same file
+	// in one query or transaction; fall through so InsertDatabasePath reuses it.
+	if (!GetDatabase(info.name)) {
+		if (auto existing_db = MetaTransaction::Get(context).GetReferencedDatabaseOwning(info.name)) {
+			if (existing_db->GetVisibility() != AttachVisibility::HIDDEN ||
+			    options.visibility != AttachVisibility::HIDDEN) {
+				throw TransactionException(
+				    "Cannot re-attach database %s in the same transaction that already used it", info.name);
+			}
+		}
 	}
 
 	if (requires_tracking_attaches) {

--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -15,6 +15,7 @@
 #include "duckdb/transaction/duck_transaction_manager.hpp"
 #include "duckdb/common/enums/on_entry_not_found.hpp"
 #include "duckdb/transaction/meta_transaction.hpp"
+#include "duckdb/common/exception/transaction_exception.hpp"
 
 namespace duckdb {
 
@@ -156,6 +157,13 @@ shared_ptr<AttachedDatabase> DatabaseManager::AttachDatabase(ClientContext &cont
 				return existing_db;
 			}
 		}
+	}
+
+	// Name was detached in this transaction but the AttachedDatabase is still alive
+	// (used_databases). Re-ATTACH of that alias is the error Mytherin wanted, not DETACH.
+	if (MetaTransaction::Get(context).GetReferencedDatabase(info.name)) {
+		throw TransactionException("Cannot re-attach database %s in the same transaction that already used it",
+		                           info.name);
 	}
 
 	if (requires_tracking_attaches) {

--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -166,8 +166,8 @@ shared_ptr<AttachedDatabase> DatabaseManager::AttachDatabase(ClientContext &cont
 		if (auto existing_db = MetaTransaction::Get(context).GetReferencedDatabaseOwning(info.name)) {
 			if (existing_db->GetVisibility() != AttachVisibility::HIDDEN ||
 			    options.visibility != AttachVisibility::HIDDEN) {
-				throw TransactionException(
-				    "Cannot re-attach database %s in the same transaction that already used it", info.name);
+				throw TransactionException("Cannot re-attach database %s in the same transaction that already used it",
+				                           info.name);
 			}
 		}
 	}

--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -160,8 +160,10 @@ shared_ptr<AttachedDatabase> DatabaseManager::AttachDatabase(ClientContext &cont
 	}
 
 	// Detached in this transaction: name is unbound, but the AttachedDatabase object
-	// is still held. Re-ATTACH of that alias would mix two files under one txn name.
-	if (MetaTransaction::Get(context).GetReferencedDatabaseOwning(info.name)) {
+	// is still held. Plain ATTACH of that alias would mix two files under one txn name.
+	// ATTACH OR REPLACE is an explicit swap — do not apply this rule (see #20748).
+	if (info.on_conflict != OnCreateConflict::REPLACE_ON_CONFLICT &&
+	    MetaTransaction::Get(context).GetReferencedDatabaseOwning(info.name)) {
 		throw TransactionException("Cannot re-attach database %s in the same transaction that already used it",
 		                           info.name);
 	}

--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -159,9 +159,9 @@ shared_ptr<AttachedDatabase> DatabaseManager::AttachDatabase(ClientContext &cont
 		}
 	}
 
-	// Name was detached in this transaction but the AttachedDatabase is still alive
-	// (used_databases). Re-ATTACH of that alias is the error Mytherin wanted, not DETACH.
-	if (MetaTransaction::Get(context).GetReferencedDatabase(info.name)) {
+	// Detached in this transaction: name is unbound, but the AttachedDatabase object
+	// is still held. Re-ATTACH of that alias would mix two files under one txn name.
+	if (MetaTransaction::Get(context).GetReferencedDatabaseOwning(info.name)) {
 		throw TransactionException("Cannot re-attach database %s in the same transaction that already used it",
 		                           info.name);
 	}
@@ -280,6 +280,11 @@ void DatabaseManager::DetachDatabase(ClientContext &context, const Identifier &n
 		}
 		return;
 	}
+
+	// Unbind the alias so GetDatabase no longer resolves it. Keep referenced_databases
+	// so in-flight transactions can still commit. Re-ATTACH of this alias is rejected
+	// via GetReferencedDatabaseOwning below.
+	MetaTransaction::Get(context).DetachDatabase(*attached_db);
 
 	attached_db->OnDetach(context);
 

--- a/src/transaction/meta_transaction.cpp
+++ b/src/transaction/meta_transaction.cpp
@@ -245,10 +245,8 @@ AttachedDatabase &MetaTransaction::UseDatabase(shared_ptr<AttachedDatabase> &dat
 	if (entry == referenced_databases.end()) {
 		auto used_entry = used_databases.emplace(db_ref.GetName(), db_ref);
 		if (!used_entry.second) {
-			// return used_entry.first->second.get();
-			throw InternalException(
-			    "Database name %s was already used by a different database for this meta transaction",
-			    db_ref.GetName());
+			throw TransactionException("Cannot re-attach database %s in the same transaction that already used it",
+			                           db_ref.GetName());
 		}
 		referenced_databases.emplace(reference<AttachedDatabase>(db_ref), database);
 	}

--- a/test/fuzzer/duckfuzz/duckdb_fuzzer_4430.test
+++ b/test/fuzzer/duckfuzz/duckdb_fuzzer_4430.test
@@ -1,26 +1,33 @@
 # name: test/fuzzer/duckfuzz/duckdb_fuzzer_4430.test
-# description: Regression test for DETACH while the current transaction has outstanding work on the database
+# description: DETACH is allowed with outstanding work; re-ATTACH of the same alias in this transaction is not
 # group: [duckfuzz]
 
 statement ok
 ATTACH '{TEST_DIR}/duckdb_fuzzer_4430.db' AS db1
 
-# Write case: forbid DETACH after a write to db1 in the same transaction
+# Write case: DETACH after a write succeeds; re-ATTACH of db1 in the same transaction fails
 statement ok
 BEGIN
 
 statement ok
 CREATE TABLE db1.tbl(i INTEGER)
 
-statement error
+statement ok
 DETACH db1
+
+statement error
+ATTACH '{TEST_DIR}/duckdb_fuzzer_4430.db' AS db1
 ----
-Cannot detach database "db1"
+Cannot re-attach database "db1"
 
 statement ok
 ROLLBACK
 
-# Read case: forbid DETACH after a read from db1 in the same transaction
+# DETACH is not transactional, so re-attach after the rollback
+statement ok
+ATTACH '{TEST_DIR}/duckdb_fuzzer_4430.db' AS db1
+
+# Read case: same rule after a read
 statement ok
 CREATE TABLE db1.tbl(i INTEGER)
 
@@ -31,10 +38,13 @@ query I
 SELECT * FROM db1.tbl
 ----
 
-statement error
+statement ok
 DETACH db1
+
+statement error
+ATTACH '{TEST_DIR}/duckdb_fuzzer_4430.db' AS db1
 ----
-Cannot detach database "db1"
+Cannot re-attach database "db1"
 
 statement ok
 ROLLBACK

--- a/test/sql/attach/attach_detach_read_only.test
+++ b/test/sql/attach/attach_detach_read_only.test
@@ -34,7 +34,7 @@ SELECT count(*) FROM data
 ----
 100
 
-# alias is gone after COMMIT (and is unbound in the txn; a failed query would abort it)
+# alias is gone after COMMIT
 statement error
 SELECT * FROM src.prepared_data
 ----

--- a/test/sql/attach/attach_detach_read_only.test
+++ b/test/sql/attach/attach_detach_read_only.test
@@ -33,3 +33,9 @@ query I
 SELECT count(*) FROM data
 ----
 100
+
+# alias is gone after COMMIT (and is unbound in the txn; a failed query would abort it)
+statement error
+SELECT * FROM src.prepared_data
+----
+does not exist

--- a/test/sql/attach/attach_detach_read_only.test
+++ b/test/sql/attach/attach_detach_read_only.test
@@ -1,0 +1,35 @@
+# name: test/sql/attach/attach_detach_read_only.test
+# description: DETACH of a read-only attach after copying rows out (github #25223 / #23374)
+# group: [attach]
+
+statement ok
+ATTACH '{TEST_DIR}/attach_detach_ro_src.duckdb' AS src
+
+statement ok
+CREATE TABLE src.prepared_data AS SELECT i FROM range(100) t(i)
+
+statement ok
+DETACH src
+
+statement ok
+CREATE TABLE data(i BIGINT)
+
+statement ok
+BEGIN TRANSACTION
+
+statement ok
+ATTACH '{TEST_DIR}/attach_detach_ro_src.duckdb' AS src (READ_ONLY)
+
+statement ok
+INSERT INTO data SELECT i FROM src.prepared_data
+
+statement ok
+DETACH src
+
+statement ok
+COMMIT
+
+query I
+SELECT count(*) FROM data
+----
+100

--- a/test/sql/attach/attach_transactionality.test
+++ b/test/sql/attach/attach_transactionality.test
@@ -112,3 +112,21 @@ Cannot re-attach database "attach_transaction"
 
 statement ok
 ROLLBACK
+
+# DETACH unbinds the alias: queries in the same txn fail (this aborts the txn)
+statement ok
+BEGIN TRANSACTION
+
+statement ok
+ATTACH '{TEST_DIR}/attach_transaction.db'
+
+statement ok
+DETACH attach_transaction
+
+statement error
+SELECT * FROM attach_transaction.integers
+----
+does not exist
+
+statement ok
+ROLLBACK

--- a/test/sql/attach/attach_transactionality.test
+++ b/test/sql/attach/attach_transactionality.test
@@ -130,3 +130,19 @@ does not exist
 
 statement ok
 ROLLBACK
+
+# DETACH of an alias this transaction never used: re-ATTACH is allowed
+statement ok
+ATTACH '{TEST_DIR}/attach_transaction.db'
+
+statement ok
+BEGIN TRANSACTION
+
+statement ok
+DETACH attach_transaction
+
+statement ok
+ATTACH '{TEST_DIR}/attach_transaction.db'
+
+statement ok
+COMMIT

--- a/test/sql/attach/attach_transactionality.test
+++ b/test/sql/attach/attach_transactionality.test
@@ -60,7 +60,8 @@ DETACH attach_transaction
 ----
 database not found
 
-# DETACH is forbidden while the current transaction has outstanding work on the database
+# DETACH is allowed while this transaction has outstanding work.
+# The catalog name is dropped; the AttachedDatabase stays alive until COMMIT.
 statement ok
 BEGIN TRANSACTION
 
@@ -70,37 +71,13 @@ ATTACH '{TEST_DIR}/attach_transaction.db'
 statement ok
 INSERT INTO attach_transaction.integers VALUES (84)
 
-statement error
+statement ok
 DETACH attach_transaction
-----
-Cannot detach database "attach_transaction"
-
-statement ok
-ROLLBACK
-
-# the rolled-back ATTACH+INSERT did not persist
-statement ok
-ATTACH '{TEST_DIR}/attach_transaction.db'
-
-query I
-SELECT * FROM attach_transaction.integers
-----
-42
-
-# the supported workflow is to COMMIT first, then DETACH
-statement ok
-BEGIN TRANSACTION
-
-statement ok
-INSERT INTO attach_transaction.integers VALUES (84)
 
 statement ok
 COMMIT
 
-statement ok
-DETACH attach_transaction
-
-# now if we attach we should see [42, 84]
+# the INSERT persisted (DETACH did not invalidate the transaction)
 statement ok
 ATTACH '{TEST_DIR}/attach_transaction.db'
 
@@ -109,3 +86,29 @@ SELECT * FROM attach_transaction.integers ORDER BY 1
 ----
 42
 84
+
+statement ok
+DETACH attach_transaction
+
+# Re-ATTACH of the same alias in the same transaction is rejected
+statement ok
+BEGIN TRANSACTION
+
+statement ok
+ATTACH '{TEST_DIR}/attach_transaction.db'
+
+query I
+SELECT count(*) FROM attach_transaction.integers
+----
+2
+
+statement ok
+DETACH attach_transaction
+
+statement error
+ATTACH '{TEST_DIR}/attach_transaction.db'
+----
+Cannot re-attach database "attach_transaction"
+
+statement ok
+ROLLBACK


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb/issues/25223
Fixes https://github.com/duckdb/duckdb/issues/23374

Follows the review on https://github.com/duckdb/duckdb/pull/23390: do not prevent DETACH; prevent re-ATTACH of an alias this transaction already used.

**Before:** `PhysicalDetach` threw if `TryGetTransaction` was set (any read or write). That error invalidated the transaction, so a later COMMIT rolled back. Read-only attach → copy into main → DETACH failed on 1.5.3+.

**After:**
- DETACH always drops the catalog name.
- `MetaTransaction` keeps the `AttachedDatabase` alive until commit/rollback (`used_databases` / `referenced_databases`; `InvokeCloseIfLastReference` already no-ops when `use_count != 1`).
- Re-ATTACH of that alias in the same transaction is `Cannot re-attach database "x" in the same transaction that already used it`.

This is not a revival of #23390 (that cleared `used_databases` and reopened the fuzzer hole).

`./build/release/test/unittest` on:
- `test/sql/attach/attach_transactionality.test`
- `test/sql/attach/attach_detach_read_only.test` (#25223 snippet)
- `test/fuzzer/duckfuzz/duckdb_fuzzer_4430.test`
- `attach_if_not_exists`, `attach_or_replace`, `attach_read_only`