### PR TITLE
ATTACH OR REPLACE reopens the same path instead of reusing the handle

### DIFF
--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -153,8 +153,12 @@ shared_ptr<AttachedDatabase> DatabaseManager::AttachDatabase(ClientContext &cont
 		// Start trying to attach.
 		while (InsertDatabasePath(info, options) == InsertDatabasePathResult::ALREADY_EXISTS) {
 			// database with this name and path already exists
-			// first check if it exists within this transaction
 			auto &meta_transaction = MetaTransaction::Get(context);
+			if (info.on_conflict == OnCreateConflict::REPLACE_ON_CONFLICT) {
+				// We just detached this alias. Returning the still-held object is the stale-handle
+				// bug. Break and try a new attach; the file lock will error if the txn still has it.
+				break;
+			}
 			if (auto existing_db = meta_transaction.GetReferencedDatabaseOwning(info.name)) {
 				// it does! return it
 				return existing_db;

--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -134,16 +134,20 @@ shared_ptr<AttachedDatabase> DatabaseManager::AttachDatabase(ClientContext &cont
 				throw BinderException("Database \"%s\" is already attached in %s mode, cannot re-attach in %s mode",
 				                      info.name, existing_mode_str, attached_mode);
 			}
-			if (info.on_conflict == OnCreateConflict::IGNORE_ON_CONFLICT) {
+			const bool same_attach = !existing_db->GetCatalog().HasConflictingAttachOptions(info.path, options);
+			if (info.on_conflict == OnCreateConflict::IGNORE_ON_CONFLICT ||
+			    (same_attach && !requires_tracking_attaches)) {
 				if (!options.default_table.Name().empty()) {
 					existing_db->GetCatalog().SetDefaultTable(options.default_table.Schema(),
 					                                          options.default_table.Name());
 				}
 				return existing_db;
 			}
-			// REPLACE: always drop the current attach so the same path is reopened (github #20748).
-			// Skipping on "same path, same options" left a stale handle when the file changed on disk.
-			DetachDatabase(context, info.name, OnEntryNotFound::RETURN_NULL);
+			if (same_attach) {
+				// Reopen file-based DuckDB so a replaced file is not served from a stale handle.
+				existing_db.reset();
+				DetachDatabase(context, info.name, OnEntryNotFound::RETURN_NULL);
+			}
 		}
 	}
 
@@ -153,12 +157,8 @@ shared_ptr<AttachedDatabase> DatabaseManager::AttachDatabase(ClientContext &cont
 		// Start trying to attach.
 		while (InsertDatabasePath(info, options) == InsertDatabasePathResult::ALREADY_EXISTS) {
 			// database with this name and path already exists
+			// first check if it exists within this transaction
 			auto &meta_transaction = MetaTransaction::Get(context);
-			if (info.on_conflict == OnCreateConflict::REPLACE_ON_CONFLICT) {
-				// We just detached this alias. Returning the still-held object is the stale-handle
-				// bug. Break and try a new attach; the file lock will error if the txn still has it.
-				break;
-			}
 			if (auto existing_db = meta_transaction.GetReferencedDatabaseOwning(info.name)) {
 				// it does! return it
 				return existing_db;

--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -134,6 +134,16 @@ shared_ptr<AttachedDatabase> DatabaseManager::AttachDatabase(ClientContext &cont
 				throw BinderException("Database \"%s\" is already attached in %s mode, cannot re-attach in %s mode",
 				                      info.name, existing_mode_str, attached_mode);
 			}
+			if (info.on_conflict == OnCreateConflict::REPLACE_ON_CONFLICT &&
+			    options.vacuum_rebuild_indexes_threshold.IsValid()) {
+				auto previous_setting = existing_db->GetVacuumRebuildIndexThreshold();
+				auto new_setting = options.vacuum_rebuild_indexes_threshold.GetIndex();
+				if (previous_setting != new_setting) {
+					throw BinderException("Cannot re-attach with a different vacuum_rebuild_indexes setting "
+					                      "(previous: %d, new: %d)",
+					                      previous_setting, new_setting);
+				}
+			}
 			const bool same_attach = !existing_db->GetCatalog().HasConflictingAttachOptions(info.path, options);
 			if (info.on_conflict == OnCreateConflict::IGNORE_ON_CONFLICT ||
 			    (same_attach && !requires_tracking_attaches)) {

--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -134,27 +134,16 @@ shared_ptr<AttachedDatabase> DatabaseManager::AttachDatabase(ClientContext &cont
 				throw BinderException("Database \"%s\" is already attached in %s mode, cannot re-attach in %s mode",
 				                      info.name, existing_mode_str, attached_mode);
 			}
-			if (!options.default_table.Name().empty()) {
-				existing_db->GetCatalog().SetDefaultTable(options.default_table.Schema(), options.default_table.Name());
-			}
-			if (info.on_conflict == OnCreateConflict::REPLACE_ON_CONFLICT) {
-				// we require the vacuuming threshold for indexed tables to be the same as the already attached db
-				if (options.vacuum_rebuild_indexes_threshold.IsValid()) {
-					auto previous_setting = existing_db->GetVacuumRebuildIndexThreshold();
-					auto new_setting = options.vacuum_rebuild_indexes_threshold.GetIndex();
-					if (previous_setting != new_setting) {
-						throw BinderException("Cannot re-attach with a different vacuum_rebuild_indexes setting "
-						                      "(previous: %d, new: %d)",
-						                      previous_setting, new_setting);
-					}
+			if (info.on_conflict == OnCreateConflict::IGNORE_ON_CONFLICT) {
+				if (!options.default_table.Name().empty()) {
+					existing_db->GetCatalog().SetDefaultTable(options.default_table.Schema(),
+					                                          options.default_table.Name());
 				}
-				// allow custom catalogs to override this behavior
-				if (!existing_db->GetCatalog().HasConflictingAttachOptions(info.path, options)) {
-					return existing_db;
-				}
-			} else {
 				return existing_db;
 			}
+			// REPLACE: always drop the current attach so the same path is reopened (github #20748).
+			// Skipping on "same path, same options" left a stale handle when the file changed on disk.
+			DetachDatabase(context, info.name, OnEntryNotFound::RETURN_NULL);
 		}
 	}
 

--- a/test/sql/attach/attach_or_replace.test
+++ b/test/sql/attach/attach_or_replace.test
@@ -17,12 +17,24 @@ CREATE TABLE db2.all_types_new AS SELECT * FROM test_all_types();
 statement ok
 DETACH db2;
 
-# ATTACH OR REPLACE same path to same alias should work
+# ATTACH OR REPLACE same path to same alias should reopen, not reuse the handle (#20748)
+statement ok
+CREATE TABLE db1_oid AS SELECT database_oid FROM duckdb_databases() WHERE database_name = 'db1'
+
 statement ok
 ATTACH OR REPLACE '{TEST_DIR}/attach_or_replace.db' AS db1;
 
+query I
+SELECT (SELECT database_oid FROM duckdb_databases() WHERE database_name = 'db1') !=
+       (SELECT database_oid FROM db1_oid)
+----
+true
+
 statement ok
 SELECT * FROM db1.all_types;
+
+statement ok
+DROP TABLE db1_oid
 
 # ATTACHing the same path to a different alias is an error
 statement error

--- a/test/sql/attach/attach_or_replace.test
+++ b/test/sql/attach/attach_or_replace.test
@@ -19,7 +19,7 @@ DETACH db2;
 
 # ATTACH OR REPLACE same path to same alias should reopen, not reuse the handle (#20748)
 statement ok
-CREATE TABLE db1_oid AS SELECT database_oid FROM duckdb_databases() WHERE database_name = 'db1'
+CREATE TABLE db1_oid AS SELECT database_oid FROM duckdb_databases() WHERE database_name = 'db1';
 
 statement ok
 ATTACH OR REPLACE '{TEST_DIR}/attach_or_replace.db' AS db1;
@@ -33,8 +33,24 @@ true
 statement ok
 SELECT * FROM db1.all_types;
 
+# ATTACH IF NOT EXISTS on the same alias is still a no-op
 statement ok
-DROP TABLE db1_oid
+CREATE TABLE db1_oid_keep AS SELECT database_oid FROM duckdb_databases() WHERE database_name = 'db1';
+
+statement ok
+ATTACH IF NOT EXISTS '{TEST_DIR}/attach_or_replace.db' AS db1;
+
+query I
+SELECT (SELECT database_oid FROM duckdb_databases() WHERE database_name = 'db1') =
+       (SELECT database_oid FROM db1_oid_keep)
+----
+true
+
+statement ok
+DROP TABLE db1_oid;
+
+statement ok
+DROP TABLE db1_oid_keep;
 
 # ATTACHing the same path to a different alias is an error
 statement error


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb/issues/20748

`ATTACH OR REPLACE` of a file-based DuckDB with the same path used to return the existing attach (`HasConflictingAttachOptions` false). That left a stale handle when the file was replaced on disk (Azure blob, `mv -f`, etc.).

Same-path DuckDB REPLACE now DETACHes first, then attaches, so `database_oid` changes. Custom catalogs still reuse the handle when path/type match (e.g. `TYPE sqlite` vs `TYPE sqlite3` under an open transaction). `IF NOT EXISTS` is unchanged.

Test: `database_oid` changes across same-path `ATTACH OR REPLACE` and is stable across `ATTACH IF NOT EXISTS`.