### PR TITLE
Do not push throwing CAST out from under TRY

### DIFF
--- a/src/include/duckdb/optimizer/remove_unused_columns.hpp
+++ b/src/include/duckdb/optimizer/remove_unused_columns.hpp
@@ -128,6 +128,8 @@ protected:
 private:
 	//! The current mode of the pruner, enables/disables certain behaviors
 	BaseColumnPrunerMode mode = BaseColumnPrunerMode::DEFAULT;
+	//! True while visiting the child of OPERATOR_TRY. Do not push throwing CASTs (#25236).
+	bool inside_try = false;
 };
 
 //! The RemoveUnusedColumns optimizer traverses the logical operator tree and removes any columns that are not required

--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -1610,9 +1610,20 @@ static bool TryGetCastChild(unique_ptr<Expression> &expr, optional_ptr<unique_pt
 }
 
 void BaseColumnPruner::VisitExpression(unique_ptr<Expression> *expression) {
-	//! Check if this is a struct extract wrapped in a cast
+	if ((*expression)->GetExpressionType() == ExpressionType::OPERATOR_TRY) {
+		const auto was_inside_try = inside_try;
+		inside_try = true;
+		LogicalOperatorVisitor::VisitExpression(expression);
+		inside_try = was_inside_try;
+		return;
+	}
+
+	//! Check if this is a struct extract wrapped in a cast. TRY_CAST is already
+	//! skipped by TryGetCastChild. A throwing CAST under TRY must also stay put:
+	//! unused-columns would otherwise emit CAST(struct_extract) in a child
+	//! projection and leave TRY wrapping only the already-cast column (#25236).
 	optional_ptr<unique_ptr<Expression>> cast_child;
-	if (TryGetCastChild(*expression, cast_child)) {
+	if (!inside_try && TryGetCastChild(*expression, cast_child)) {
 		if (HandleExtractExpression(cast_child.get(), expression)) {
 			// already handled
 			return;

--- a/test/sql/optimizer/try_struct_extract_cast.test
+++ b/test/sql/optimizer/try_struct_extract_cast.test
@@ -1,0 +1,61 @@
+# name: test/sql/optimizer/try_struct_extract_cast.test
+# description: unused-columns must not push a throwing CAST out from under TRY (#25236)
+# group: [optimizer]
+
+# unused-columns pushdown-extract rewrites CAST(struct_extract(s, 'bar')) into a
+# child projection and replaces the CAST with a column ref. If that CAST sat
+# inside TRY, the conversion error is then thrown by the child and TRY never
+# sees it. TRY_CAST already refused this rewrite; OPERATOR_TRY must too.
+
+statement ok
+CREATE TABLE foo AS SELECT 'x' AS t, {'bar': 'x'} AS t2;
+
+# column CAST inside TRY
+query I
+SELECT TRY(t::INTEGER) FROM foo
+----
+NULL
+
+# struct-field CAST inside TRY (the failing case)
+query I
+SELECT TRY(t2.bar::INTEGER) FROM foo
+----
+NULL
+
+# both in one projection — unused-columns still has the extra VARCHAR column
+query II
+SELECT TRY(t::INTEGER), TRY(t2.bar::INTEGER) FROM foo
+----
+NULL	NULL
+
+# TRY_CAST on the struct field already worked
+query I
+SELECT TRY_CAST(t2.bar AS INTEGER) FROM foo
+----
+NULL
+
+# bare CAST of the struct field still throws
+statement error
+SELECT t2.bar::INTEGER FROM foo
+----
+Conversion Error
+
+# CTE with an unused sibling column (original #25236 shape, TIMESTAMPTZ)
+query II
+WITH src AS (SELECT '2026-05-02, 00:00:00' AS t, {'bar': '2026-05-02, 00:00:00'} AS t2)
+SELECT TRY(t::TIMESTAMPTZ), TRY(t2.bar::TIMESTAMPTZ) FROM src
+----
+NULL	NULL
+
+# valid struct-field CAST is unchanged
+query I
+SELECT TRY(t2.bar::INTEGER)
+FROM (SELECT {'bar': '7'} AS t2)
+----
+7
+
+# CAST nested under arithmetic still inside TRY
+query I
+SELECT TRY(t2.bar::INTEGER + 1) FROM foo
+----
+NULL


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb/issues/25236

`TRY(col::T)` returned NULL, and `TRY_CAST(struct.field AS T)` returned NULL, but `TRY(struct.field::T)` threw. `PRAGMA disable_optimizer` made it work.

unused-columns pushdown-extract rewrote `CAST(struct_extract(s, 'bar'))` into a child projection and replaced the CAST with a column ref. TRY then wrapped an already-cast column, so the conversion error was thrown below TRY. The plan was:

```
PROJECTION TRY(t2)
  PROJECTION CAST(struct_extract(#0, 'bar') AS TIMESTAMPTZ)
```

`TRY_CAST` already skipped this rewrite (`TryGetCastChild` returns false for try-cast). `OPERATOR_TRY` did not.

Keep the throwing CAST inside TRY. Extract pushdown still happens:

```
PROJECTION TRY(CAST(t2 AS TIMESTAMPTZ))
  PROJECTION struct_extract(#0, 'bar')
```

`./build/release/test/unittest test/sql/optimizer/try_struct_extract_cast.test` — 11 assertions.