### PR TITLE
enable auto-loading of extensions via their log types/messages

### DIFF
--- a/scripts/generate_extensions_function.py
+++ b/scripts/generate_extensions_function.py
@@ -898,6 +898,13 @@ static constexpr ExtensionEntry EXTENSION_SECRET_PROVIDERS[] = {{"s3/config", "h
                                                                 {"postgres/config", "postgres_scanner"}
 }; // EXTENSION_SECRET_PROVIDERS
 
+// Note: these are currently hardcoded in scripts/generate_extensions_function.py
+// TODO: automate by passing though to script via duckdb
+static constexpr ExtensionEntry EXTENSION_LOG_TYPES[] = {
+    {"DuckLakeMetadata", "ducklake"},
+    {"Iceberg", "iceberg"},
+}; // END_OF_EXTENSION_LOG_TYPES
+
 static constexpr const char *AUTOLOADABLE_EXTENSIONS[] = {
     "autocomplete",
     "avro",

--- a/src/function/table/system/logging_utils.cpp
+++ b/src/function/table/system/logging_utils.cpp
@@ -7,6 +7,8 @@
 #include "duckdb/logging/logging.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/database.hpp"
+#include "duckdb/main/extension_entries.hpp"
+#include "duckdb/main/extension_helper.hpp"
 
 namespace duckdb {
 
@@ -42,6 +44,16 @@ static void EnableLogging(ClientContext &context, TableFunctionInput &data, Data
 	if (!bind_data.storage_config.empty()) {
 		log_manager.UpdateLogStorageConfig(*context.db, bind_data.storage_config);
 	}
+}
+
+//! Log types are registered by extensions when they are loaded, so an unknown type may just belong to an extension
+//! that is not loaded yet
+static void TryAutoloadLogTypeExtension(ClientContext &context, const string &log_type) {
+	auto &db = *context.db;
+	if (db.GetLogManager().LookupLogType(log_type)) {
+		return;
+	}
+	ExtensionHelper::TryAutoloadFromEntry(db, Identifier(log_type), EXTENSION_LOG_TYPES);
 }
 
 static unique_ptr<FunctionData> BindEnableLogging(ClientContext &context, TableFunctionBindInput &input,
@@ -121,6 +133,10 @@ static unique_ptr<FunctionData> BindEnableLogging(ClientContext &context, TableF
 		} else {
 			throw BinderException("Unexpected type positional parameter to enable_logging");
 		}
+	}
+
+	for (const auto &log_type : result->log_types_to_set) {
+		TryAutoloadLogTypeExtension(context, log_type);
 	}
 
 	return_types.emplace_back(LogicalType::BOOLEAN);

--- a/src/include/duckdb/main/extension_entries.hpp
+++ b/src/include/duckdb/main/extension_entries.hpp
@@ -1521,6 +1521,13 @@ static constexpr ExtensionEntry EXTENSION_SECRET_PROVIDERS[] = {
     {"mysql/config", "mysql_scanner"},
     {"postgres/config", "postgres_scanner"}}; // EXTENSION_SECRET_PROVIDERS
 
+// Note: these are currently hardcoded in scripts/generate_extensions_function.py
+// TODO: automate by passing though to script via duckdb
+static constexpr ExtensionEntry EXTENSION_LOG_TYPES[] = {
+    {"DuckLakeMetadata", "ducklake"},
+    {"Iceberg", "iceberg"},
+}; // END_OF_EXTENSION_LOG_TYPES
+
 static constexpr const char *AUTOLOADABLE_EXTENSIONS[] = {
     "autocomplete", "avro",       "aws",           "azure",   "core_functions",   "delta", "ducklake",
     "encodings",    "excel",      "fts",           "httpfs",  "iceberg",          "icu",   "inet",

--- a/test/extension/autoloading_log_types.test
+++ b/test/extension/autoloading_log_types.test
@@ -1,0 +1,52 @@
+# name: test/extension/autoloading_log_types.test
+# description: Tests for autoloading extensions that register log types
+# group: [extension]
+
+# This test assumes iceberg to be available in the LOCAL_EXTENSION_REPO and NOT linked into duckdb statically
+# -> this should be the case for our autoloading tests where we have the local_extension_repo variable set
+require-env LOCAL_EXTENSION_REPO
+
+require iceberg
+
+# Ensure we have a clean extension directory without any preinstalled extensions
+statement ok
+set extension_directory='{TEST_DIR}/autoloading_log_types'
+
+### Without autoloading the log type of an unloaded extension is unknown
+statement ok
+set autoload_known_extensions=false
+
+statement ok
+set autoinstall_known_extensions=false
+
+statement maybe
+CALL enable_logging('Iceberg')
+----
+Unknown log type: 'Iceberg'
+
+### With autoloading, the extension registering the log type is loaded
+statement ok
+set autoload_known_extensions=true
+
+statement ok
+set autoinstall_known_extensions=true
+
+statement ok
+set autoinstall_extension_repository='{LOCAL_EXTENSION_REPO}';
+
+statement ok
+CALL enable_logging('Iceberg')
+
+query I
+SELECT loaded FROM duckdb_extensions() WHERE extension_name='iceberg'
+----
+true
+
+statement ok
+CALL disable_logging()
+
+# log types that no extension registers are still rejected
+statement error
+CALL enable_logging('ThisLogTypeDoesNotExist')
+----
+Unknown log type: 'ThisLogTypeDoesNotExist'


### PR DESCRIPTION
fixes https://github.com/duckdblabs/duckdb-internal/issues/10398

In previous versions of DuckDB, when you enabled logging on core extensions that were not loaded, you would get the following,
```
memory D call enable_logging(['Iceberg', 'HTTP']);
Invalid Input Error:
Unknown log type: 'Iceberg'
memory D load iceberg;
memory D call enable_logging(['Iceberg', 'HTTP']);
```

This PR will auto load the extension if you enable logging for a core extension.
Currently only enabled for Iceberg and DuckLake. 

`call enable_logging('HTTP')` works because `HTTP` is a core log type since logging happens in src/main/http/http_util.cpp

