### PR TITLE
Don't let terminal matchers have a separate frame

### DIFF
--- a/src/include/duckdb/parser/peg/matcher_stack.hpp
+++ b/src/include/duckdb/parser/peg/matcher_stack.hpp
@@ -22,7 +22,7 @@ struct MatchStackFrame {
 	MatchStackFrame(match_frame_index_t frame_index, const Matcher &matcher, MatchState &state);
 	virtual ~MatchStackFrame() = default;
 
-	virtual void Execute(MatchStack &stack);
+	virtual void Execute(MatchStack &stack) = 0;
 	void SetResult(const MatcherResult &result);
 	bool HasResult() const;
 	MatcherResult GetResult() const;
@@ -49,6 +49,8 @@ public:
 	void PushChildFrame(MatchStackFrame &parent, const Matcher &matcher, MatchState &state);
 
 private:
+	static bool IsTerminalMatcher(const Matcher &matcher);
+	MatcherResult ExecuteTerminalMatcher(const Matcher &matcher, MatchState &state);
 	void PushFrame(const Matcher &matcher, MatchState &state);
 	void InitializeFrame(MatchStackFrame &frame);
 	void ExecuteFrame(MatchStackFrame &frame);

--- a/src/include/duckdb/parser/peg/matcher_stack.hpp
+++ b/src/include/duckdb/parser/peg/matcher_stack.hpp
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include "duckdb/common/optional.hpp"
+#include "duckdb/common/optional_idx.hpp"
 #include "duckdb/parser/peg/matcher.hpp"
 
 namespace duckdb {
@@ -17,6 +19,19 @@ class MatchStack;
 
 enum class MatchFrameState : uint8_t { INITIALIZE, EXECUTE };
 enum class MatchResultState : uint8_t { NONE, FAILURE, SUCCESS };
+
+struct PackratMatchState {
+	static bool IsEnabled(const Matcher &matcher, const MatchState &state) {
+		return state.packrat_cache && matcher.IsPackratMemoized() && matcher.GetPackratId().IsValid();
+	}
+
+	optional<MatcherResult> TryLoadCachedResult(const Matcher &matcher, MatchState &state);
+	void StoreResult(const Matcher &matcher, MatchState &state, const MatcherResult &result) const;
+
+private:
+	optional_idx token_index_before;
+	idx_t max_token_index_before = 0;
+};
 
 struct MatchStackFrame {
 	MatchStackFrame(match_frame_index_t frame_index, const Matcher &matcher, MatchState &state);
@@ -38,9 +53,7 @@ struct MatchStackFrame {
 	optional_ptr<ParseResult> parse_result;
 	MatchResultState child_result_state = MatchResultState::NONE;
 	optional_ptr<ParseResult> child_parse_result;
-	bool store_packrat_result = false;
-	idx_t token_index_before = 0;
-	idx_t max_token_index_before = 0;
+	PackratMatchState packrat_state;
 };
 
 class MatchStack {

--- a/src/parser/peg/matcher_stack.cpp
+++ b/src/parser/peg/matcher_stack.cpp
@@ -10,10 +10,6 @@ MatchStackFrame::MatchStackFrame(match_frame_index_t frame_index_p, const Matche
     : frame_index(frame_index_p), matcher(matcher_p), match_state(state_p) {
 }
 
-void MatchStackFrame::Execute(MatchStack &) {
-	SetResult(matcher.MatchParseResultInternal(match_state));
-}
-
 void MatchStackFrame::SetResult(const MatcherResult &result) {
 	D_ASSERT(result_state == MatchResultState::NONE);
 	result_state = result.IsSuccess() ? MatchResultState::SUCCESS : MatchResultState::FAILURE;
@@ -54,6 +50,54 @@ MatcherResult MatchStackFrame::TakeChildResult() {
 	return MatcherResult::Success(parse_result);
 }
 
+bool MatchStack::IsTerminalMatcher(const Matcher &matcher) {
+	switch (matcher.Type()) {
+	case MatcherType::KEYWORD:
+	case MatcherType::VARIABLE:
+	case MatcherType::STRING_LITERAL:
+	case MatcherType::NUMBER_LITERAL:
+	case MatcherType::OPERATOR:
+	case MatcherType::END_OF_INPUT:
+		return true;
+	case MatcherType::OPTIONAL:
+	case MatcherType::CHOICE:
+	case MatcherType::LIST:
+	case MatcherType::REPEAT:
+		return false;
+	default:
+		throw InternalException("Unsupported matcher type in heap-based parser");
+	}
+}
+
+MatcherResult MatchStack::ExecuteTerminalMatcher(const Matcher &matcher, MatchState &state) {
+	D_ASSERT(IsTerminalMatcher(matcher));
+	state.rule = matcher.GetRule();
+	if (!state.packrat_cache || !matcher.IsPackratMemoized() || !matcher.GetPackratId().IsValid()) {
+		return matcher.MatchParseResultInternal(state);
+	}
+
+	auto token_index_before = state.token_iterator.Position();
+	auto cached_result = state.packrat_cache->Lookup(matcher, token_index_before);
+	if (cached_result) {
+		state.token_iterator.SetPosition(cached_result->token_index_after);
+		state.max_token_index = MaxValue(state.max_token_index, cached_result->max_token_index_seen);
+		if (cached_result->success) {
+			return MatcherResult::Success(cached_result->result);
+		}
+		return MatcherResult::Failure();
+	}
+
+	auto max_token_index_before = state.GetMaxTokenIndex();
+	auto result = matcher.MatchParseResultInternal(state);
+	ParserPackratEntry cache_entry;
+	cache_entry.success = result.IsSuccess();
+	cache_entry.token_index_after = state.token_iterator.Position();
+	cache_entry.max_token_index_seen = MaxValue(max_token_index_before, state.GetMaxTokenIndex());
+	cache_entry.result = result.GetParseResult();
+	state.packrat_cache->Store(matcher, token_index_before, cache_entry);
+	return result;
+}
+
 void MatchStack::PushFrame(const Matcher &matcher, MatchState &state) {
 	state.rule = matcher.GetRule();
 	auto frame_index = frames.size();
@@ -76,8 +120,7 @@ void MatchStack::PushFrame(const Matcher &matcher, MatchState &state) {
 	case MatcherType::NUMBER_LITERAL:
 	case MatcherType::OPERATOR:
 	case MatcherType::END_OF_INPUT:
-		frames.push_back(make_uniq<MatchStackFrame>(frame_index, matcher, state));
-		break;
+		throw InternalException("Terminal matcher cannot create a heap-based parser frame");
 	default:
 		throw InternalException("Unsupported matcher type in heap-based parser");
 	}
@@ -87,6 +130,10 @@ void MatchStack::PushChildFrame(MatchStackFrame &parent, const Matcher &matcher,
 	D_ASSERT(!frames.empty());
 	D_ASSERT(frames.back()->frame_index == parent.frame_index);
 	D_ASSERT(!parent.HasChildResult());
+	if (IsTerminalMatcher(matcher)) {
+		parent.SetChildResult(ExecuteTerminalMatcher(matcher, state));
+		return;
+	}
 	PushFrame(matcher, state);
 }
 
@@ -138,13 +185,16 @@ MatcherResult MatchStack::FinalizeFrame(MatchStackFrame &frame) {
 
 MatcherResult MatchStack::ExecuteInternal(const Matcher &matcher, MatchState &state) {
 	D_ASSERT(frames.empty());
+	if (IsTerminalMatcher(matcher)) {
+		return ExecuteTerminalMatcher(matcher, state);
+	}
 	PushFrame(matcher, state);
 	while (!frames.empty()) {
 		auto &frame = *frames.back();
 		auto frame_count = frames.size();
 		ExecuteFrame(frame);
 		if (!frame.HasResult()) {
-			D_ASSERT(frames.size() > frame_count);
+			D_ASSERT(frames.size() > frame_count || frame.HasChildResult());
 			continue;
 		}
 		auto result = FinalizeFrame(frame);

--- a/src/parser/peg/matcher_stack.cpp
+++ b/src/parser/peg/matcher_stack.cpp
@@ -6,6 +6,36 @@
 
 namespace duckdb {
 
+optional<MatcherResult> PackratMatchState::TryLoadCachedResult(const Matcher &matcher, MatchState &state) {
+	D_ASSERT(IsEnabled(matcher, state));
+	auto token_index = state.token_iterator.Position();
+	auto cached_result = state.packrat_cache->Lookup(matcher, token_index);
+	if (!cached_result) {
+		token_index_before = token_index;
+		max_token_index_before = state.GetMaxTokenIndex();
+		return nullopt;
+	}
+
+	state.token_iterator.SetPosition(cached_result->token_index_after);
+	state.max_token_index = MaxValue(state.max_token_index, cached_result->max_token_index_seen);
+	if (cached_result->success) {
+		return MatcherResult::Success(cached_result->result);
+	}
+	return MatcherResult::Failure();
+}
+
+void PackratMatchState::StoreResult(const Matcher &matcher, MatchState &state, const MatcherResult &result) const {
+	if (!token_index_before.IsValid()) {
+		return;
+	}
+	ParserPackratEntry cache_entry;
+	cache_entry.success = result.IsSuccess();
+	cache_entry.token_index_after = state.token_iterator.Position();
+	cache_entry.max_token_index_seen = MaxValue(max_token_index_before, state.GetMaxTokenIndex());
+	cache_entry.result = result.GetParseResult();
+	state.packrat_cache->Store(matcher, token_index_before.GetIndex(), cache_entry);
+}
+
 MatchStackFrame::MatchStackFrame(match_frame_index_t frame_index_p, const Matcher &matcher_p, MatchState &state_p)
     : frame_index(frame_index_p), matcher(matcher_p), match_state(state_p) {
 }
@@ -72,29 +102,18 @@ bool MatchStack::IsTerminalMatcher(const Matcher &matcher) {
 MatcherResult MatchStack::ExecuteTerminalMatcher(const Matcher &matcher, MatchState &state) {
 	D_ASSERT(IsTerminalMatcher(matcher));
 	state.rule = matcher.GetRule();
-	if (!state.packrat_cache || !matcher.IsPackratMemoized() || !matcher.GetPackratId().IsValid()) {
+	if (!PackratMatchState::IsEnabled(matcher, state)) {
 		return matcher.MatchParseResultInternal(state);
 	}
 
-	auto token_index_before = state.token_iterator.Position();
-	auto cached_result = state.packrat_cache->Lookup(matcher, token_index_before);
+	PackratMatchState packrat_state;
+	auto cached_result = packrat_state.TryLoadCachedResult(matcher, state);
 	if (cached_result) {
-		state.token_iterator.SetPosition(cached_result->token_index_after);
-		state.max_token_index = MaxValue(state.max_token_index, cached_result->max_token_index_seen);
-		if (cached_result->success) {
-			return MatcherResult::Success(cached_result->result);
-		}
-		return MatcherResult::Failure();
+		return *cached_result;
 	}
 
-	auto max_token_index_before = state.GetMaxTokenIndex();
 	auto result = matcher.MatchParseResultInternal(state);
-	ParserPackratEntry cache_entry;
-	cache_entry.success = result.IsSuccess();
-	cache_entry.token_index_after = state.token_iterator.Position();
-	cache_entry.max_token_index_seen = MaxValue(max_token_index_before, state.GetMaxTokenIndex());
-	cache_entry.result = result.GetParseResult();
-	state.packrat_cache->Store(matcher, token_index_before, cache_entry);
+	packrat_state.StoreResult(matcher, state, result);
 	return result;
 }
 
@@ -140,21 +159,12 @@ void MatchStack::PushChildFrame(MatchStackFrame &parent, const Matcher &matcher,
 void MatchStack::InitializeFrame(MatchStackFrame &frame) {
 	auto &matcher = frame.matcher;
 	auto &state = frame.match_state;
-	if (state.packrat_cache && matcher.IsPackratMemoized() && matcher.GetPackratId().IsValid()) {
-		frame.token_index_before = state.token_iterator.Position();
-		auto cached_result = state.packrat_cache->Lookup(matcher, frame.token_index_before);
-		if (cached_result) {
-			state.token_iterator.SetPosition(cached_result->token_index_after);
-			state.max_token_index = MaxValue(state.max_token_index, cached_result->max_token_index_seen);
-			if (cached_result->success) {
-				frame.SetResult(MatcherResult::Success(cached_result->result));
-			} else {
-				frame.SetResult(MatcherResult::Failure());
-			}
-			return;
-		}
-		frame.store_packrat_result = true;
-		frame.max_token_index_before = state.GetMaxTokenIndex();
+	if (!PackratMatchState::IsEnabled(matcher, state)) {
+		return;
+	}
+	auto cached_result = frame.packrat_state.TryLoadCachedResult(matcher, state);
+	if (cached_result) {
+		frame.SetResult(*cached_result);
 	}
 }
 
@@ -172,14 +182,7 @@ MatcherResult MatchStack::FinalizeFrame(MatchStackFrame &frame) {
 	auto result = frame.GetResult();
 	auto &matcher = frame.matcher;
 	auto &state = frame.match_state;
-	if (frame.store_packrat_result) {
-		ParserPackratEntry cache_entry;
-		cache_entry.success = result.IsSuccess();
-		cache_entry.token_index_after = state.token_iterator.Position();
-		cache_entry.max_token_index_seen = MaxValue(frame.max_token_index_before, state.GetMaxTokenIndex());
-		cache_entry.result = result.GetParseResult();
-		state.packrat_cache->Store(matcher, frame.token_index_before, cache_entry);
-	}
+	frame.packrat_state.StoreResult(matcher, state, result);
 	return result;
 }
 


### PR DESCRIPTION
A first optimization for the heap based matcher; don't let terminal matchers create new frames, but instead resolve them directly, reducing allocation overhead. 

This improves performance by about 25% compared to the previous PR for TPC-H and TPC-DS queries. The overhead for the heap based matcher compared to stack is 2.65x. More optimizations to come. 